### PR TITLE
Add quickstart compilation mode for CHAMPS

### DIFF
--- a/test/studies/champs/functions.bash
+++ b/test/studies/champs/functions.bash
@@ -46,6 +46,12 @@ function log_success() {
   echo "[Success matching ${msg}]"
 }
 
+function update_nightly_repo() {
+  pushd $CHAMPS_COMMON_DIR
+  git pull
+  popd
+}
+
 function apply_patch() {
   local patch_file=$@
   echo "[Applying patch ${patch_file}]"
@@ -78,6 +84,11 @@ function test_compile() {
     log_success "make output"
   fi
   test_end
+
+  # don't leave this environment set
+  if [ ! -z "$CHAMPS_QUICKSTART" ]; then
+    unset CHPL_STOP_AFTER_PASS
+  fi
 
   if [ -z "$CHAMPS_QUICKSTART" ]; then
     $CHPL_HOME/util/test/computePerfStats comp-time-$kind $CHPL_TEST_PERF_DIR/$CHPL_TEST_PERF_DESCRIPTION $CHAMPS_GRAPH_PATH/comp-time.perfkeys $kind.comp.out.tmp

--- a/test/studies/champs/functions.bash
+++ b/test/studies/champs/functions.bash
@@ -65,10 +65,14 @@ function apply_patch() {
 function test_compile() {
   local kind=$@
   local make_vars="MOD=$kind NPROCS=0"
+  local reset_chpl_stop_after_pass=false
 
   if [ ! -z "$CHAMPS_QUICKSTART" ]; then
     local version=quick-shared
-    export CHPL_STOP_AFTER_PASS=${CHPL_STOP_AFTER_PASS:-denormalize}
+    if [ -z "$CHPL_STOP_AFTER_PASS" ]; then
+      reset_chpl_stop_after_pass=true
+      export CHPL_STOP_AFTER_PASS=denormalize
+    fi
 
     # CHAMPS' Makefile runs `time` in an unportable way causing failures on
     # darwin. Measuring time and memory in this setting is probably useless
@@ -95,7 +99,7 @@ function test_compile() {
   test_end
 
   # don't leave this environment set
-  if [ ! -z "$CHAMPS_QUICKSTART" ]; then
+  if [ "$reset_chpl_stop_after_pass" = true ]; then
     unset CHPL_STOP_AFTER_PASS
   fi
 

--- a/test/studies/champs/functions.bash
+++ b/test/studies/champs/functions.bash
@@ -64,17 +64,26 @@ function apply_patch() {
 
 function test_compile() {
   local kind=$@
+  local make_vars="MOD=$kind NPROCS=0"
+
   if [ ! -z "$CHAMPS_QUICKSTART" ]; then
     local version=quick-shared
     export CHPL_STOP_AFTER_PASS=${CHPL_STOP_AFTER_PASS:-denormalize}
+
+    # CHAMPS' Makefile runs `time` in an unportable way causing failures on
+    # darwin. Measuring time and memory in this setting is probably useless
+    # anyway. So, disable that for quickstart.
+    make_vars+=" MONITOR_MAKE=false"
+
     echo "[Building $kind in quickstart mode. Will stop after the $CHPL_STOP_AFTER_PASS pass]"
   else
     local version=release
+
     echo "[Building $kind in normal mode]"
   fi
 
   test_start "make $kind"
-  make $version MOD=$kind NPROCS=0 2> $kind.comp.out.tmp
+  make $version $make_vars 2> $kind.comp.out.tmp
   local status=$?
   cat $kind.comp.out.tmp
 

--- a/test/studies/champs/sub_test
+++ b/test/studies/champs/sub_test
@@ -32,7 +32,12 @@ else
 fi
 cd ${CHAMPS_HOME}
 
-CHAMPS_VERSION=$(git describe --tags --abbrev=0)
+# CHAMPS versions are tagged. Not all commits have tags, in which case this
+# command fails. Note that this is exactly as what CHAMPS Makefile does. IOW,
+# they must be seeing and ignoring the same error. To avoid triage confusion, I
+# am redirecting stderr to dev/null. (I think they should use --always
+# --abbrev=10 or something)
+CHAMPS_VERSION=$(git describe --tags --abbrev=0 2>/dev/null)
 
 # Apply patches
 for p in $CHAMPS_PATCH_PATH/*patch; do
@@ -63,33 +68,40 @@ ls $CHAMPS_HOME
 echo LD_LIBRARY_PATH=$LD_LIBRARY_PATH
 
 # Compile CHAMPS executables
-test_compile prep
-test_compile flow
 test_compile icing
-test_compile drop
-test_compile potential
-test_compile potentialPrep
-test_compile geo
-test_compile thermo
-test_compile postLink
-test_compile post
-test_compile stochasticIcing
-test_compile octree
-test_compile eigenSolvePost
-test_compile externalSolverPost
-test_compile meshDeformation
-test_compile continuation
-test_compile stability
-test_compile coloring
 
-# copy the input data to the filesystem we're running on
+if [ -z "$CHAMPS_QUICKSTART" ] || [ ! -z "$CHAMPS_COMPILE_ALL_EXECS" ] ; then
+  test_compile prep
+  test_compile flow
+  test_compile drop
+  test_compile potential
+  test_compile potentialPrep
+  test_compile geo
+  test_compile thermo
+  test_compile postLink
+  test_compile post
+  test_compile stochasticIcing
+  test_compile octree
+  test_compile eigenSolvePost
+  test_compile externalSolverPost
+  test_compile meshDeformation
+  test_compile continuation
+  test_compile stability
+  test_compile coloring
+fi
 
-# I can't tell whether prep is running too slow or just freezing, for now don't run it
-# cp $CHAMPS_DATA_PATH/CRMHL_coarse.cgns $CHAMPS_HOME/
-# test_run prep 1
 
-test_run flow 16
+if [ -z "$CHAMPS_QUICKSTART" ] ; then
+  # copy the input data to the filesystem we're running on
+  # I can't tell whether prep is running too slow or just freezing, for now don't run it
+  # cp $CHAMPS_DATA_PATH/CRMHL_coarse.cgns $CHAMPS_HOME/
+  # test_run prep 1
 
-$CHPL_HOME/util/test/genGraphs --configs $CHPL_TEST_PERF_CONFIGS --annotate $CHPL_HOME/test/ANNOTATIONS.yaml --name $CHPL_TEST_PERF_CONFIG_NAME --perfdir $CHPL_TEST_PERF_DIR --outdir $CHPL_TEST_PERF_DIR/html --graphlist $CHAMPS_GRAPH_PATH/GRAPHLIST --testdir $CHAMPS_GRAPH_PATH --alttitle "CHAMPS Performance Graphs"
+  # copy the prepartitoned grid for 16 locales into scratch space
+  cp $CHAMPS_DATA_PATH/CRMHL_coarse_1152B.cgns $CHAMPS_HOME/
+  test_run flow 16
+
+  $CHPL_HOME/util/test/genGraphs --configs $CHPL_TEST_PERF_CONFIGS --annotate $CHPL_HOME/test/ANNOTATIONS.yaml --name $CHPL_TEST_PERF_CONFIG_NAME --perfdir $CHPL_TEST_PERF_DIR --outdir $CHPL_TEST_PERF_DIR/html --graphlist $CHAMPS_GRAPH_PATH/GRAPHLIST --testdir $CHAMPS_GRAPH_PATH --alttitle "CHAMPS Performance Graphs"
+fi
 
 subtest_end

--- a/test/studies/champs/sub_test
+++ b/test/studies/champs/sub_test
@@ -74,24 +74,9 @@ if [ ! -z "$CHAMPS_QUICKSTART" ]; then
   git status
 fi
 
-# copy the prepartitoned grid for 16 locales into scratch space for better IO
-# performance
-cp $CHAMPS_DATA_PATH/CRMHL_coarse_1152B.cgns $CHAMPS_HOME/
-
-# in the system where we run this, compute nodes don't have access to our shared
-# non-scratch space. I do not want to store those in the scratch space for good.
-# So, what we are doing here is to copy the stuff from CHAMPS_CFG_PATH and
-# CHAMPS_DEP_PATH to the scratch space for running the code.
-cp $CHAMPS_CFG_PATH/flow.in $CHAMPS_HOME/
-
-# ... and this is where it really gets unfortunate.
-cp -r $CHAMPS_DEP_PATH $CHAMPS_HOME/
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CHAMPS_HOME/deps-manual/lib
-
 # some debugging output before starting the run
 echo "contents of $CHAMPS_HOME"
 ls $CHAMPS_HOME
-echo LD_LIBRARY_PATH=$LD_LIBRARY_PATH
 
 # Compile CHAMPS executables
 test_compile icing
@@ -125,6 +110,18 @@ if [ -z "$CHAMPS_QUICKSTART" ] ; then
 
   # copy the prepartitoned grid for 16 locales into scratch space
   cp $CHAMPS_DATA_PATH/CRMHL_coarse_1152B.cgns $CHAMPS_HOME/
+
+  # in the system where we run this, compute nodes don't have access to our shared
+  # non-scratch space. I do not want to store those in the scratch space for good.
+  # So, what we are doing here is to copy the stuff from CHAMPS_CFG_PATH and
+  # CHAMPS_DEP_PATH to the scratch space for running the code.
+  cp $CHAMPS_CFG_PATH/flow.in $CHAMPS_HOME/
+
+  # ... and this is where it really gets unfortunate.
+  cp -r $CHAMPS_DEP_PATH $CHAMPS_HOME/
+  export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CHAMPS_HOME/deps-manual/lib
+  echo LD_LIBRARY_PATH=$LD_LIBRARY_PATH
+
   test_run flow 16
 
   $CHPL_HOME/util/test/genGraphs --configs $CHPL_TEST_PERF_CONFIGS --annotate $CHPL_HOME/test/ANNOTATIONS.yaml --name $CHPL_TEST_PERF_CONFIG_NAME --perfdir $CHPL_TEST_PERF_DIR --outdir $CHPL_TEST_PERF_DIR/html --graphlist $CHAMPS_GRAPH_PATH/GRAPHLIST --testdir $CHAMPS_GRAPH_PATH --alttitle "CHAMPS Performance Graphs"

--- a/test/studies/champs/sub_test
+++ b/test/studies/champs/sub_test
@@ -10,6 +10,7 @@ source $CWD/functions.bash
 if [ ! -z "$CHAMPS_QUICKSTART" ]; then
   if [ -z "$CHPL_HOME" ]; then
     echo "[Error: \$CHPL_HOME is unset]"
+    exit 1
   fi
   export CHAMPS_COMMON_DIR=$CWD/champs-nightly
 

--- a/test/studies/champs/sub_test
+++ b/test/studies/champs/sub_test
@@ -69,8 +69,10 @@ if [ "${CHPL_LLVM}" != "none" ] ; then
 fi
 
 if [ ! -z "$CHAMPS_QUICKSTART" ]; then
+  git checkout -b quickstart-triage
+  echo "[New branch (quickstart-triage) created]"
+  git commit -am "Snapshot after applying patches (by sub_test)" >/dev/null
   echo "[Patch commit created]"
-  git commit -am "Snapshot after applying patches" >/dev/null
   git clean -df >/dev/null
   git status
 fi

--- a/test/studies/champs/sub_test
+++ b/test/studies/champs/sub_test
@@ -67,6 +67,13 @@ if [ "${CHPL_LLVM}" != "none" ] ; then
   apply_patch $CHAMPS_PATCH_PATH/optional/llvm.patch
 fi
 
+if [ ! -z "$CHAMPS_QUICKSTART" ]; then
+  echo "[Patch commit created]"
+  git commit -am "Snapshot after applying patches" >/dev/null
+  git clean -df >/dev/null
+  git status
+fi
+
 # copy the prepartitoned grid for 16 locales into scratch space for better IO
 # performance
 cp $CHAMPS_DATA_PATH/CRMHL_coarse_1152B.cgns $CHAMPS_HOME/

--- a/test/studies/champs/sub_test
+++ b/test/studies/champs/sub_test
@@ -4,14 +4,33 @@
 
 CHAMPS_BRANCH=${CHAMPS_BRANCH:-development}
 
+CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+source $CWD/functions.bash
+
+if [ ! -z "$CHAMPS_QUICKSTART" ]; then
+  if [ -z "$CHPL_HOME" ]; then
+    echo "[Error: \$CHPL_HOME is unset]"
+  fi
+  export CHAMPS_COMMON_DIR=$CWD/champs-nightly
+
+  if [ -d "$CHAMPS_COMMON_DIR" ]; then
+    echo "[Warning: $CHAMPS_COMMON_DIR exists, will try to git pull]"
+    update_nightly_repo
+  else 
+    echo "Creating $CHAMPS_COMMON_DIR"
+    pushd $(dirname $CHAMPS_COMMON_DIR)
+    git clone git@github.com:chapelu-champs/champs-nightly.git
+    popd
+  fi
+else
+  update_nightly_repo
+fi
+
 CHAMPS_PATCH_PATH=$CHAMPS_COMMON_DIR/patches
 CHAMPS_GRAPH_PATH=$CHAMPS_COMMON_DIR/graph-infra
 CHAMPS_DATA_PATH=$CHAMPS_COMMON_DIR/data
 CHAMPS_CFG_PATH=$CHAMPS_COMMON_DIR/configs
 CHAMPS_DEP_PATH=$CHAMPS_COMMON_DIR/deps-manual
-
-CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
-source $CWD/functions.bash
 
 subtest_start
 

--- a/util/cron/common-champs.bash
+++ b/util/cron/common-champs.bash
@@ -3,35 +3,13 @@
 # Configure environment for CHAMPS testing
 
 
-# CHAMPS_QUICKSTART implies someone trying to source this directly, so no
-# BASH_SOURCE
-if [ ! -z "$CHAMPS_QUICKSTART" ]; then
-  CWD=$(pwd)
-  COMMON_DIR=$CWD
-else
-  CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
-  COMMON_DIR=/cy/users/chapelu
-fi
+CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+COMMON_DIR=/cy/users/chapelu
 
 export CHAMPS_COMMON_DIR=$COMMON_DIR/champs-nightly
 
 if [ ! -d "$CHAMPS_COMMON_DIR" ]; then
-  if [ ! -z "$CHAMPS_QUICKSTART" ]; then
-    echo "Creating $CWD/$CHAMPS_COMMON_DIR"
-    git clone git@github.com:chapelu-champs/champs-nightly.git
-  else
-    echo "Error: $CHAMPS_COMMON_DIR doesn't exist. If you are trying to build locally, set 'CHAMPS_QUICKSTART'"
-    return
-  fi
-
-fi
-
-
-pushd $CHAMPS_COMMON_DIR
-git pull
-popd
-
-if [ ! -z "$CHAMPS_QUICKSTART" ]; then
+  echo "Error: $CHAMPS_COMMON_DIR doesn't exist. If you are trying to build locally, set 'CHAMPS_QUICKSTART'"
   return
 fi
 

--- a/util/cron/common-champs.bash
+++ b/util/cron/common-champs.bash
@@ -2,15 +2,38 @@
 #
 # Configure environment for CHAMPS testing
 
-CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 
-COMMON_DIR=/cy/users/chapelu
+# CHAMPS_QUICKSTART implies someone trying to source this directly, so no
+# BASH_SOURCE
+if [ ! -z "$CHAMPS_QUICKSTART" ]; then
+  CWD=$(pwd)
+  COMMON_DIR=$CWD
+else
+  CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+  COMMON_DIR=/cy/users/chapelu
+fi
 
 export CHAMPS_COMMON_DIR=$COMMON_DIR/champs-nightly
+
+if [ ! -d "$CHAMPS_COMMON_DIR" ]; then
+  if [ ! -z "$CHAMPS_QUICKSTART" ]; then
+    echo "Creating $CWD/$CHAMPS_COMMON_DIR"
+    git clone git@github.com:chapelu-champs/champs-nightly.git
+  else
+    echo "Error: $CHAMPS_COMMON_DIR doesn't exist. If you are trying to build locally, set 'CHAMPS_QUICKSTART'"
+    return
+  fi
+
+fi
+
 
 pushd $CHAMPS_COMMON_DIR
 git pull
 popd
+
+if [ ! -z "$CHAMPS_QUICKSTART" ]; then
+  return
+fi
 
 echo Enabling Cray PE
 source $CRAY_ENABLE_PE


### PR DESCRIPTION
This PR adds a mode to our CHAMPS testing infrastructure to be able to compile CHAMPS locally.

- This mode is enabled by `export CHAMPS_QUICKSTART=1`
- With that, the custom `sub_test` will skip over some steps, but most importantly will use `CHPL_STOP_AFTER_PASS=denormalize` as starting with `codegen` we'll need dependencies.
- The rest of the build/triage should be pretty similar to how CHAMPS is triaged normally on DC machines.
- By default, only `icing` is built. `export CHAMPS_COMPILE_ALL_EXECS=1` will make `sub_test` build all the executables.

Note: with this mode issues with codegen/linkage/correctness will not be captured.

I (and some others in the recent past) tested the branch locally.