### PR TITLE
Deprecate 'require' on chpl files at non-module scope

### DIFF
--- a/compiler/include/build.h
+++ b/compiler/include/build.h
@@ -95,9 +95,12 @@ ImportStmt* buildImportStmt(Expr* mod);
 ImportStmt* buildImportStmt(Expr* mod, const char* rename);
 ImportStmt* buildImportStmt(Expr* mod, std::vector<PotentialRename*>* names);
 void setImportPrivacy(BlockStmt* list, bool isPrivate);
-bool processStringInRequireStmt(const char* str, bool parseTime,
+bool processStringInRequireStmt(Expr* expr,
+                                bool atModuleScope,
+                                const char* str,
+                                bool parseTime,
                                 const char* modFilename);
-BlockStmt* buildRequireStmt(CallExpr* args);
+BlockStmt* buildRequireStmt(CallExpr* args, bool atModuleScope);
 DefExpr* buildQueriedExpr(const char *expr);
 BlockStmt* buildTupleVarDeclStmt(BlockStmt* tupleBlock, Expr* type, Expr* init);
 BlockStmt* buildLabelStmt(const char* name, Expr* stmt);

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -1063,7 +1063,11 @@ struct Converter {
       actuals->insertAtTail(conv);
     }
 
-    return buildRequireStmt(actuals);
+    auto parentId = parsing::idToParentId(context, node->id());
+    auto parentAst = parsing::idToAst(context, parentId);
+    bool atModuleScope = parentAst->isModule();
+
+    return buildRequireStmt(actuals, atModuleScope);
   }
 
   Expr* visit(const uast::Include* node) {

--- a/compiler/resolution/postFold.cpp
+++ b/compiler/resolution/postFold.cpp
@@ -662,7 +662,16 @@ static Expr* postFoldPrimop(CallExpr* call) {
     const char* str = NULL;
 
     if (get_string(arg, &str)) {
-      processStringInRequireStmt(str, false, call->astloc.filename());
+      // call is at the module scope if inside the module init
+      // and directly inside the module (ie no intervening blocks)
+      bool insideModuleInit =
+        call->parentSymbol && call->parentSymbol->hasFlag(FLAG_MODULE_INIT);
+      FnSymbol* moduleInit =
+        insideModuleInit ? toFnSymbol(call->parentSymbol) : nullptr;
+      BlockStmt* parentBlock = toBlockStmt(call->parentExpr);
+      bool atModuleScope = parentBlock && moduleInit && moduleInit->body == parentBlock;
+
+      processStringInRequireStmt(arg, atModuleScope, str, false, call->astloc.filename());
 
     } else {
       USR_FATAL(call, "'require' statements require string arguments");

--- a/test/deprecated/dummyFile.chpl
+++ b/test/deprecated/dummyFile.chpl
@@ -1,0 +1,3 @@
+module dummyFile {
+  // empty file used by requireNotAtModuleScope.chpl
+}

--- a/test/deprecated/requireNotAtModuleScope.chpl
+++ b/test/deprecated/requireNotAtModuleScope.chpl
@@ -1,0 +1,18 @@
+
+require "dummyFile.chpl";
+class C {
+  proc foo() {
+    require "dummyFile.chpl"; // should warn
+  }
+}
+record R {
+  proc foo() {
+    require "dummyFile.chpl"; // should warn
+  }
+}
+proc foo() {
+  require "dummyFile.chpl"; // should warn
+}
+if false then require "dummyFile.chpl"; // should warn
+config const unknownAtCompileTime = true;
+if unknownAtCompileTime then require "dummyFile.chpl"; // should warn

--- a/test/deprecated/requireNotAtModuleScope.compopts
+++ b/test/deprecated/requireNotAtModuleScope.compopts
@@ -1,0 +1,1 @@
+--main-module requireNotAtModuleScope

--- a/test/deprecated/requireNotAtModuleScope.good
+++ b/test/deprecated/requireNotAtModuleScope.good
@@ -1,0 +1,5 @@
+requireNotAtModuleScope.chpl:5: warning: using 'require' on a Chapel source file not at module scope is deprecated
+requireNotAtModuleScope.chpl:10: warning: using 'require' on a Chapel source file not at module scope is deprecated
+requireNotAtModuleScope.chpl:14: warning: using 'require' on a Chapel source file not at module scope is deprecated
+requireNotAtModuleScope.chpl:16: warning: using 'require' on a Chapel source file not at module scope is deprecated
+requireNotAtModuleScope.chpl:18: warning: using 'require' on a Chapel source file not at module scope is deprecated


### PR DESCRIPTION
Deprecates the 'require' statement used on chpl files at non-module scope.

Based on discussion in https://github.com/chapel-lang/chapel/issues/23418#issuecomment-1725825232

## Summary of changes
- add check to `processStringInRequireStmt` for chpl files if the statement is at module scope
  - this check is against a boolean passed in, since this function can be called when `expr` is not yet in the tree (and thus has no parent information)
- add test `test/deprecated/requireNotAtModuleScope.chpl`

## Testing
- paratest with futures
- paratest with gasnet

[Reviewed by @vasslitvinov]