### PR TITLE
Remove intDirName

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2895,11 +2895,6 @@ void codegen() {
   codegenPartOne();
 
   if (isFullGpuCodegen()) {
-    // We use the temp dir to output a fatbin file and read it between the forked and main process.
-    // We need to generate the name for the temp directory before we do the fork (since this
-    // name uses the PID).
-    ensureTmpDirExists();
-
     // flush stdout before forking process so buffered output doesn't get copied over
     fflush(stdout);
 

--- a/compiler/include/files.h
+++ b/compiler/include/files.h
@@ -39,10 +39,6 @@ extern std::vector<const char*> incDirs;
 extern std::vector<const char*> libDirs;
 extern std::vector<const char*> libFiles;
 
-// directory for intermediates; tmpdir or saveCDir
-// TODO: remove this as redundant with the Dyno Context's tmpdir
-extern const char* intDirName;
-
 struct fileinfo {
   FILE* fptr;
   const char* filename;
@@ -58,7 +54,6 @@ void codegen_makefile(fileinfo* mainfile, const char** tmpbinname=NULL,
 void ensureDirExists(const char* dirname, const char* explanation,
                      bool checkWriteable = true);
 const char* getCwd();
-void ensureTmpDirExists();
 void deleteDir(const char* dirname);
 const char* objectFileForCFile(const char* cfile);
 

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -816,7 +816,6 @@ static void runAsCompilerDriver(int argc, char* argv[]) {
   int status = 0;
 
   // initialize resources that need to be carried over between invocations
-  ensureTmpDirExists();
   saveCompileCommand();
 
   // invoke phase one
@@ -851,16 +850,16 @@ static void runAsCompilerDriver(int argc, char* argv[]) {
 
 // Run phase one of compiler-driver
 static int runDriverPhaseOne(int argc, char* argv[]) {
-  std::vector<std::string> additionalArgs = {"--driver-phase-one",
-                                             "--driver-tmp-dir", intDirName};
+  std::vector<std::string> additionalArgs = {
+      "--driver-phase-one", "--driver-tmp-dir", gContext->tmpDir()};
   return invokeChplWithArgs(argc, argv, additionalArgs,
                             "invoking driver phase one");
 }
 
 // Run phase two of compiler-driver
 static int runDriverPhaseTwo(int argc, char* argv[]) {
-  std::vector<std::string> additionalArgs = {"--driver-phase-two",
-                                             "--driver-tmp-dir", intDirName};
+  std::vector<std::string> additionalArgs = {
+      "--driver-phase-two", "--driver-tmp-dir", gContext->tmpDir()};
   return invokeChplWithArgs(argc, argv, additionalArgs,
                             "invoking driver phase two");
 }
@@ -2170,8 +2169,7 @@ static void bootstrapTmpDir() {
     if (!driverTmpDir[0]) {
       USR_FATAL("Driver sub-invocation was not supplied a tmp dir path");
     }
-    intDirName = driverTmpDir;
-    config.tmpDir = intDirName;
+    config.tmpDir = driverTmpDir;
     config.keepTmpDir = true;
   } else {
     // This is an initial invocation of the driver, or monolithic.


### PR DESCRIPTION
Remove `intDirName` as it is completely redundant with `gContext->tmpDir()`.

Also remove some supporting code that is not needed, such as `ensureTmpDirExists` which is covered by the `Context`.

The similar `tmpdirname` variable is also unused and could likely be removed, but as that interacts with the gdb tmp-dir cleanup hook (see https://github.com/chapel-lang/chapel/issues/23554) it is not removed in this PR.

Resolves https://github.com/Cray/chapel-private/issues/5390.

[reviewer info placeholder]

Testing:
- [x] local paratest
- [x] gasnet paratest
- [x] C backend paratest
- [x] GPU paratest