### PR TITLE
update docs regarding c_string and c_ptrConst(c_char)

### DIFF
--- a/doc/rst/language/spec/interoperability.rst
+++ b/doc/rst/language/spec/interoperability.rst
@@ -18,7 +18,7 @@ overview of procedure importing and exporting is provided
 in :ref:`Interop_Overview`. Details on sharing types, variables
 and procedures are supplied in :ref:`Shared_Language_Elements`.
 
-   .. note:: 
+   .. note::
 
       *Future:*
 
@@ -58,7 +58,7 @@ function signature during function resolution. The user must also supply
 a definition for the referenced function by naming a C source file, an
 object file or an object library on the ``chpl`` command line.
 
-An external procedure declaration has the following syntax: 
+An external procedure declaration has the following syntax:
 
 .. code-block:: syntax
 
@@ -86,11 +86,11 @@ For example, the code below declares a function callable in Chapel as
 
 .. code-block:: chapel
 
-     extern "atoi" proc c_atoi(arg:c_string):c_int;
+     extern "atoi" proc c_atoi(arg:c_ptrConst(c_char)):c_int;
 
 At present, external iterators are not supported.
 
-   .. note::   
+   .. note::
 
       *Future:*
 
@@ -104,8 +104,8 @@ At present, external iterators are not supported.
 
 ..
 
-   .. note::  
-     
+   .. note::
+
       *Future:*
 
       Dynamic dispatch (polymorphism) is also unsupported in this version.
@@ -136,7 +136,7 @@ the ``export`` linkage specifier to the function definition. The
 resolved, even if it is not called within the Chapel program or library
 being compiled.
 
-An exported procedure declaration has the following syntax: 
+An exported procedure declaration has the following syntax:
 
 .. code-block:: syntax
 
@@ -227,7 +227,7 @@ Referring to External C Types
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 An externally-defined type can be referenced using a external type
-declaration with the following syntax. 
+declaration with the following syntax.
 
 .. code-block:: syntax
 
@@ -246,13 +246,13 @@ refer to them within Chapel code.
 
 Fixed-size C array types can be described within Chapel using the
 ``c_array`` type defined by the standard ``CTypes`` module.
-For example, the C typedef 
+For example, the C typedef
 
 .. code-block:: chapel
 
    typedef double vec[3];
 
-can be described in Chapel using 
+can be described in Chapel using
 
 .. code-block:: chapel
 
@@ -264,7 +264,7 @@ Referring to External C Structs and Unions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 External C struct and union types can be referred to within Chapel by prefixing a
-Chapel ``record`` definition with the ``extern`` keyword. 
+Chapel ``record`` definition with the ``extern`` keyword.
 
 .. code-block:: syntax
 
@@ -272,7 +272,7 @@ Chapel ``record`` definition with the ``extern`` keyword.
      'extern' external-name[OPT] simple-record-declaration-statement
 
 For example, consider an external C structure defined in ``foo.h``
-called ``fltdbl``. 
+called ``fltdbl``.
 
 .. code-block:: chapel
 
@@ -386,7 +386,7 @@ for operations other than argument passing and assignment.
 
 For example, Chapel could be used to call an external C function that
 returns a pointer to a structure (that can’t or won’t be described as a
-pointer to an external record) as follows: 
+pointer to an external record) as follows:
 
 .. code-block:: chapel
 
@@ -396,7 +396,7 @@ pointer to an external record) as follows:
 
 However, because the type of ``structPtr`` is opaque, it can be used
 only in assignments and the arguments of functions expecting the same
-underlying type. 
+underlying type.
 
 .. code-block:: chapel
 
@@ -418,14 +418,14 @@ This subsection discusses how to access external variables and
 constants.
 
 A C variable or constant can be referred to within Chapel by prefixing
-its declaration with the extern keyword. For example: 
+its declaration with the extern keyword. For example:
 
 .. code-block:: chapel
 
        extern var bar: foo;
 
 would tell the Chapel compiler about an external C variable named
-``bar`` of type ``foo``. Similarly, 
+``bar`` of type ``foo``. Similarly,
 
 .. code-block:: chapel
 
@@ -460,7 +460,7 @@ To call an external C function, a prototype of the routine must appear
 in the Chapel code. This is accomplished by providing the Chapel
 signature of the function preceded by the ``extern`` keyword. For
 example, for a C function foo() that takes no arguments and returns
-nothing, the prototype would be: 
+nothing, the prototype would be:
 
 .. code-block:: chapel
 
@@ -482,7 +482,7 @@ type specifiers.
 
 The types of function arguments may be omitted from the external
 procedure declaration, in which case they are inferred based on the
-Chapel callsite. For example, the Chapel code 
+Chapel callsite. For example, the Chapel code
 
 .. code-block:: chapel
 
@@ -497,7 +497,7 @@ omitted type arguments can also be used call external C macros.
 External function arguments can be declared using the
 ``default-expression`` syntax. In this case, the default argument will
 be supplied by the Chapel compiler if the corresponding actual argument
-is omitted at the callsite. For example: 
+is omitted at the callsite. For example:
 
 .. code-block:: chapel
 
@@ -509,11 +509,11 @@ and 1.2.
 
 C varargs functions can be declared using Chapel’s
 ``variable-argument-expression`` syntax (``...``). For example, the C
-``printf`` function can be declared in Chapel as 
+``printf`` function can be declared in Chapel as
 
 .. code-block:: chapel
 
-          extern proc printf(fmt: c_string, vals...?numvals): int;
+          extern proc printf(fmt: c_ptrConst(c_char), vals...?numvals): int;
 
 External C functions or macros that accept type arguments can also be
 prototyped in Chapel by declaring the argument as a type. For example:
@@ -541,7 +541,7 @@ no arguments and returning a 64-bit integer can be declared as:
    export proc foo(): int { ... }
 
 If the optional ``external-name`` is supplied, that is the name used in
-linking with external code. For example, if we declare 
+linking with external code. For example, if we declare
 
 .. code-block:: chapel
 
@@ -573,7 +573,7 @@ T           const T
 in T        T
 ref T       T\*
 const ref T const T\*
-param  
+param
 type        char\*
 =========== =========
 

--- a/doc/rst/technotes/extern.rst
+++ b/doc/rst/technotes/extern.rst
@@ -226,6 +226,13 @@ because c_string is a local-only type, the .c_str() method can only be
 called on Chapel strings that are stored on the same locale; calling
 .c_str() on a non-local string will result in a runtime error.
 
+.. note::
+
+  ``c_string`` is deprecated in favor of ``c_ptrConst(c_char)``.
+  See :ref:`c_string deprecation <readme-evolution.c_string-deprecation>`
+  for more information.
+
+
 c_fn_ptr
 ~~~~~~~~
 
@@ -1089,9 +1096,9 @@ myprint.chpl:
 
 .. code-block:: chapel
 
-  extern proc myprint(str:c_string);
+  extern proc myprint(str:c_ptrConst(c_char));
 
-  // string literal is automatically converted to a c_string
+  // string literal is automatically converted to a c_ptrConst(c_char)
   myprint("hello");
 
   // a string variable must be converted with .c_str()

--- a/doc/rst/technotes/extern.rst
+++ b/doc/rst/technotes/extern.rst
@@ -130,7 +130,7 @@ These types are the same as C types:
 
   c_ptr(T) is T*
   c_ptrConst(T) is const T*
-  c_string is const char*
+  c_string is const char* (c_string is deprecated in favor of c_ptrConst(c_char))
   c_fn_ptr represents a C function pointer (with unspecified arg and return types)
   c_array(T,n) is T[n]
 
@@ -220,17 +220,13 @@ c_string
 
 The c_string type maps to a constant C string (that is, const char*)
 that is intended for use locally. A c_string can be obtained from a
-Chapel string using the method :proc:`~String.string.c_str`. A Chapel string can be
-constructed from a C string using the cast operator. Note however that
-because c_string is a local-only type, the .c_str() method can only be
-called on Chapel strings that are stored on the same locale; calling
-.c_str() on a non-local string will result in a runtime error.
-
-.. note::
-
-  ``c_string`` is deprecated in favor of ``c_ptrConst(c_char)``.
-  See :ref:`c_string deprecation <readme-evolution.c_string-deprecation>`
-  for more information.
+Chapel string using the method :proc:`~String.string.c_str` and casting the
+result to c_string. A Chapel string can be constructed from a C string using
+:proc:`~String.string.createCopyingBuffer` or one of the other similarly named
+string creation methods. Note however, that because c_string is a local-only
+type, the .c_str() method can only be called on Chapel strings that are stored
+on the same locale; calling .c_str() on a non-local string will result in a
+runtime error.
 
 
 c_fn_ptr
@@ -493,7 +489,7 @@ function:
 
 .. code-block:: chapel
 
-       extern proc printf(fmt: c_string, vals...?numvals): int;
+       extern proc printf(fmt: c_ptrConst(c_char), vals...?numvals): int;
 
 Note that it can also be prototyped more trivially/less accurately
 as follows:
@@ -698,8 +694,8 @@ for the type is ``struct stat``:
     var st_size: off_t;
   }
 
-  proc getFileSize(path:c_string) : int {
-    extern proc stat(x: c_string, ref buf:chpl_stat_type): c_int;
+  proc getFileSize(path:c_ptrConst(c_char)) : int {
+    extern proc stat(x: c_ptrConst(c_char), ref buf:chpl_stat_type): c_int;
     var buf: chpl_stat_type;
 
     if (chpl_stat_function(path, buf) == 0) {
@@ -802,7 +798,7 @@ block will be usable.
 This feature strives to support C global variables, functions, structures,
 typedefs, enums, and some #defines. Structures always generate a Chapel record,
 and pointers to a structure are represented with c_ptr(struct type). Also,
-pointer arguments to functions are always represented with c_ptr or c_string
+pointer arguments to functions are always represented with c_ptr or c_ptrConst
 instead of the ref intent.
 
 Note that functions or variables declared within an extern block should either
@@ -865,8 +861,7 @@ Pointer Types
 See the section `Pointer and String Types`_ above for background on
 how the Chapel programs can work with C pointer types. Any pointer type used in
 an extern block will be made visible to the Chapel program as c_ptr(T),
-c_ptrConst(T) (for const pointer types besides char) or c_string
-(for const char* types).
+c_ptrConst(T).
 
 For example:
 
@@ -902,9 +897,9 @@ For example:
  var space:c_ptr(c_int);
  setSpace(c_ptrTo(space));
 
- var str:c_string;
+ var str:c_ptrConst(c_char);
  setString(c_ptrTo(str));
- writeln(toString(str));
+ writeln(string.createBorrowingBuffer(str));
 
 As you can see in this example, using the extern block might result in
 more calls to c_ptrTo() when using the generated extern declarations,

--- a/doc/rst/technotes/extern.rst
+++ b/doc/rst/technotes/extern.rst
@@ -877,7 +877,7 @@ For example:
    // will translate automatically into
    //  extern proc setItToOne(x:c_ptr(c_int));
 
-   static void getItPlusOne(const int* x) { return *x + 1; }
+   static int getItPlusOne(const int* x) { return *x + 1; }
    // will translate automatically into
    //  extern proc getItPlusOne(x:c_ptrConst(c_int));
 
@@ -896,7 +896,7 @@ For example:
  var x:c_int;
  setItToOne(c_ptrTo(x));
 
- var y:c_int = 5
+ var y:c_int = 5;
  writeln(getItPlusOne(c_ptrToConst(y))); // could also just use c_ptrTo(y)
 
  var space:c_ptr(c_int);

--- a/doc/rst/technotes/extern.rst
+++ b/doc/rst/technotes/extern.rst
@@ -220,7 +220,7 @@ c_string
 
 The c_string type maps to a constant C string (that is, const char*)
 that is intended for use locally. A c_string can be obtained from a
-Chapel string using the method :proc:`~String.string.c_str` and casting the
+Chapel string using the method :proc:`~CTypes.string.c_str` and casting the
 result to c_string. A Chapel string can be constructed from a C string using
 :proc:`~String.string.createCopyingBuffer` or one of the other similarly named
 string creation methods. Note however, that because c_string is a local-only
@@ -1068,10 +1068,10 @@ instance, it is possible to safely go back the other direction:
 Working with strings
 --------------------
 
-If you need to call a C function and provide a Chapel string, you may need to
-convert the Chapel string to a C string first.  Chapel string literals will
-automatically convert to C strings.  A Chapel string variable can be converted
-using the :proc:`~String.string.c_str` method.
+If you need to call a C function and provide a Chapel string, you will need to
+convert the Chapel string to a c_ptrConst(c_char) first.  Chapel string literals
+will automatically convert to c_ptrConst(c_char). A Chapel string variable can
+be converted using the :proc:`~CTypes.string.c_str` method.
 
 myprint.h:
 

--- a/doc/rst/technotes/libraries.rst
+++ b/doc/rst/technotes/libraries.rst
@@ -572,7 +572,7 @@ this function itself.  The following should work after replacing
     export proc chpl_library_init_ftn() {
       // Make the runtime/library initialization function visible
       extern proc chpl_library_init(argc: c_int, argv: c_ptr(c_ptr(c_char)));
-      var filename = "fake":chpl_c_string;
+      var filename = "fake":c_ptrConst(c_char);
       // Initialize the internal runtime/library
       chpl_library_init(1, c_ptrTo(filename): c_ptr(c_ptr(c_char)));
       // Initialize the main user module

--- a/doc/rst/tools/c2chapel/c2chapel.rst
+++ b/doc/rst/tools/c2chapel/c2chapel.rst
@@ -20,7 +20,7 @@ function declaration in a header file:
 
 .. code-block:: chapel
 
-  extern proc foo(str: c_string, n : c_int) : void;
+  extern proc foo(str: c_ptr(c_char), n : c_int) : void;
 
 
 Prerequisites


### PR DESCRIPTION
This PR updates the docs to indicate the deprecation of the `c_string` type, and replaces its use in example codes for C interop, Fortran libraries, `c2chapel` and the interop spec doc. 

TESTING (manually review changes in generated docs for):
- [x] extern technote
- [x] library spec doc
- [x] c2chapel doc
- [x] Fortran library doc

[reviewed by @jabraham17 - thank you!]