### PR TITLE
Fix and test error for `c_ptrTo[Const]` on `domain`s

### DIFF
--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -1107,7 +1107,7 @@ module CTypes {
   */
   inline proc c_ptrTo(ref x:?t):c_ptr(t) {
     if isDomainType(t) then
-      compilerError("c_ptrTo domain type not supported", 2);
+      compilerError("c_ptrTo domain type not supported");
     return c_addrOf(x);
   }
 
@@ -1117,7 +1117,7 @@ module CTypes {
   */
   inline proc c_ptrToConst(const ref x:?t): c_ptrConst(t) {
     if isDomainType(t) then
-      compilerError("c_ptrToConst domain type not supported", 2);
+      compilerError("c_ptrToConst domain type not supported");
     return c_addrOfConst(x);
   }
 
@@ -1175,7 +1175,7 @@ module CTypes {
   */
   inline proc c_addrOf(ref x: ?t): c_ptr(t) {
     if isDomainType(t) then
-      compilerError("c_addrOf domain type not supported", 2);
+      compilerError("c_addrOf domain type not supported");
     return c_pointer_return(x);
   }
 
@@ -1185,7 +1185,7 @@ module CTypes {
   */
   inline proc c_addrOfConst(const ref x: ?t): c_ptrConst(t) {
     if isDomainType(t) then
-      compilerError("c_addrOfConst domain type not supported", 2);
+      compilerError("c_addrOfConst domain type not supported");
     return c_pointer_return_const(x);
   }
 

--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -1106,6 +1106,8 @@ module CTypes {
 
   */
   inline proc c_ptrTo(ref x:?t):c_ptr(t) {
+    if isDomainType(t) then
+      compilerError("c_ptrTo domain type not supported", 2);
     return c_addrOf(x);
   }
 
@@ -1114,6 +1116,8 @@ module CTypes {
     modification of the pointee.
   */
   inline proc c_ptrToConst(const ref x:?t): c_ptrConst(t) {
+    if isDomainType(t) then
+      compilerError("c_ptrToConst domain type not supported", 2);
     return c_addrOfConst(x);
   }
 

--- a/test/types/cptr/c_ptrTo_domain.1.good
+++ b/test/types/cptr/c_ptrTo_domain.1.good
@@ -1,5 +1,1 @@
-$CHPL_HOME/modules/standard/Errors.chpl:nnnn: In function 'compilerError':
-$CHPL_HOME/modules/standard/Errors.chpl:nnnn: warning: compiler diagnostic depth value exceeds call stack depth
-  $CHPL_HOME/modules/standard/CTypes.chpl:nnnn: called as compilerError(param msg(0) = "c_ptrTo domain type not supported", param errorDepth = 2) from function 'c_ptrTo'
-  c_ptrTo_domain.chpl:8: called as c_ptrTo(x: domain(1,int(64),one))
 c_ptrTo_domain.chpl:8: error: c_ptrTo domain type not supported

--- a/test/types/cptr/c_ptrTo_domain.1.good
+++ b/test/types/cptr/c_ptrTo_domain.1.good
@@ -1,0 +1,5 @@
+$CHPL_HOME/modules/standard/Errors.chpl:647: In function 'compilerError':
+$CHPL_HOME/modules/standard/Errors.chpl:648: warning: compiler diagnostic depth value exceeds call stack depth
+  $CHPL_HOME/modules/standard/CTypes.chpl:1110: called as compilerError(param msg(0) = "c_ptrTo domain type not supported", param errorDepth = 2) from function 'c_ptrTo'
+  c_ptrTo_domain.chpl:8: called as c_ptrTo(x: domain(1,int(64),one))
+c_ptrTo_domain.chpl:8: error: c_ptrTo domain type not supported

--- a/test/types/cptr/c_ptrTo_domain.1.good
+++ b/test/types/cptr/c_ptrTo_domain.1.good
@@ -1,5 +1,5 @@
-$CHPL_HOME/modules/standard/Errors.chpl:647: In function 'compilerError':
-$CHPL_HOME/modules/standard/Errors.chpl:648: warning: compiler diagnostic depth value exceeds call stack depth
-  $CHPL_HOME/modules/standard/CTypes.chpl:1110: called as compilerError(param msg(0) = "c_ptrTo domain type not supported", param errorDepth = 2) from function 'c_ptrTo'
+$CHPL_HOME/modules/standard/Errors.chpl:nnnn: In function 'compilerError':
+$CHPL_HOME/modules/standard/Errors.chpl:nnnn: warning: compiler diagnostic depth value exceeds call stack depth
+  $CHPL_HOME/modules/standard/CTypes.chpl:nnnn: called as compilerError(param msg(0) = "c_ptrTo domain type not supported", param errorDepth = 2) from function 'c_ptrTo'
   c_ptrTo_domain.chpl:8: called as c_ptrTo(x: domain(1,int(64),one))
 c_ptrTo_domain.chpl:8: error: c_ptrTo domain type not supported

--- a/test/types/cptr/c_ptrTo_domain.2.good
+++ b/test/types/cptr/c_ptrTo_domain.2.good
@@ -1,5 +1,1 @@
-$CHPL_HOME/modules/standard/Errors.chpl:nnnn: In function 'compilerError':
-$CHPL_HOME/modules/standard/Errors.chpl:nnnn: warning: compiler diagnostic depth value exceeds call stack depth
-  $CHPL_HOME/modules/standard/CTypes.chpl:nnnn: called as compilerError(param msg(0) = "c_ptrToConst domain type not supported", param errorDepth = 2) from function 'c_ptrToConst'
-  c_ptrTo_domain.chpl:9: called as c_ptrToConst(x: domain(1,int(64),one))
 c_ptrTo_domain.chpl:9: error: c_ptrToConst domain type not supported

--- a/test/types/cptr/c_ptrTo_domain.2.good
+++ b/test/types/cptr/c_ptrTo_domain.2.good
@@ -1,0 +1,5 @@
+$CHPL_HOME/modules/standard/Errors.chpl:647: In function 'compilerError':
+$CHPL_HOME/modules/standard/Errors.chpl:648: warning: compiler diagnostic depth value exceeds call stack depth
+  $CHPL_HOME/modules/standard/CTypes.chpl:1120: called as compilerError(param msg(0) = "c_ptrToConst domain type not supported", param errorDepth = 2) from function 'c_ptrToConst'
+  c_ptrTo_domain.chpl:9: called as c_ptrToConst(x: domain(1,int(64),one))
+c_ptrTo_domain.chpl:9: error: c_ptrToConst domain type not supported

--- a/test/types/cptr/c_ptrTo_domain.2.good
+++ b/test/types/cptr/c_ptrTo_domain.2.good
@@ -1,5 +1,5 @@
-$CHPL_HOME/modules/standard/Errors.chpl:647: In function 'compilerError':
-$CHPL_HOME/modules/standard/Errors.chpl:648: warning: compiler diagnostic depth value exceeds call stack depth
-  $CHPL_HOME/modules/standard/CTypes.chpl:1120: called as compilerError(param msg(0) = "c_ptrToConst domain type not supported", param errorDepth = 2) from function 'c_ptrToConst'
+$CHPL_HOME/modules/standard/Errors.chpl:nnnn: In function 'compilerError':
+$CHPL_HOME/modules/standard/Errors.chpl:nnnn: warning: compiler diagnostic depth value exceeds call stack depth
+  $CHPL_HOME/modules/standard/CTypes.chpl:nnnn: called as compilerError(param msg(0) = "c_ptrToConst domain type not supported", param errorDepth = 2) from function 'c_ptrToConst'
   c_ptrTo_domain.chpl:9: called as c_ptrToConst(x: domain(1,int(64),one))
 c_ptrTo_domain.chpl:9: error: c_ptrToConst domain type not supported

--- a/test/types/cptr/c_ptrTo_domain.3.good
+++ b/test/types/cptr/c_ptrTo_domain.3.good
@@ -1,0 +1,5 @@
+$CHPL_HOME/modules/standard/Errors.chpl:647: In function 'compilerError':
+$CHPL_HOME/modules/standard/Errors.chpl:648: warning: compiler diagnostic depth value exceeds call stack depth
+  $CHPL_HOME/modules/standard/CTypes.chpl:1178: called as compilerError(param msg(0) = "c_addrOf domain type not supported", param errorDepth = 2) from function 'c_addrOf'
+  c_ptrTo_domain.chpl:10: called as c_addrOf(x: domain(1,int(64),one))
+c_ptrTo_domain.chpl:10: error: c_addrOf domain type not supported

--- a/test/types/cptr/c_ptrTo_domain.3.good
+++ b/test/types/cptr/c_ptrTo_domain.3.good
@@ -1,5 +1,5 @@
-$CHPL_HOME/modules/standard/Errors.chpl:647: In function 'compilerError':
-$CHPL_HOME/modules/standard/Errors.chpl:648: warning: compiler diagnostic depth value exceeds call stack depth
-  $CHPL_HOME/modules/standard/CTypes.chpl:1178: called as compilerError(param msg(0) = "c_addrOf domain type not supported", param errorDepth = 2) from function 'c_addrOf'
+$CHPL_HOME/modules/standard/Errors.chpl:nnnn: In function 'compilerError':
+$CHPL_HOME/modules/standard/Errors.chpl:nnnn: warning: compiler diagnostic depth value exceeds call stack depth
+  $CHPL_HOME/modules/standard/CTypes.chpl:nnnn: called as compilerError(param msg(0) = "c_addrOf domain type not supported", param errorDepth = 2) from function 'c_addrOf'
   c_ptrTo_domain.chpl:10: called as c_addrOf(x: domain(1,int(64),one))
 c_ptrTo_domain.chpl:10: error: c_addrOf domain type not supported

--- a/test/types/cptr/c_ptrTo_domain.3.good
+++ b/test/types/cptr/c_ptrTo_domain.3.good
@@ -1,5 +1,1 @@
-$CHPL_HOME/modules/standard/Errors.chpl:nnnn: In function 'compilerError':
-$CHPL_HOME/modules/standard/Errors.chpl:nnnn: warning: compiler diagnostic depth value exceeds call stack depth
-  $CHPL_HOME/modules/standard/CTypes.chpl:nnnn: called as compilerError(param msg(0) = "c_addrOf domain type not supported", param errorDepth = 2) from function 'c_addrOf'
-  c_ptrTo_domain.chpl:10: called as c_addrOf(x: domain(1,int(64),one))
 c_ptrTo_domain.chpl:10: error: c_addrOf domain type not supported

--- a/test/types/cptr/c_ptrTo_domain.4.good
+++ b/test/types/cptr/c_ptrTo_domain.4.good
@@ -1,5 +1,1 @@
-$CHPL_HOME/modules/standard/Errors.chpl:nnnn: In function 'compilerError':
-$CHPL_HOME/modules/standard/Errors.chpl:nnnn: warning: compiler diagnostic depth value exceeds call stack depth
-  $CHPL_HOME/modules/standard/CTypes.chpl:nnnn: called as compilerError(param msg(0) = "c_addrOfConst domain type not supported", param errorDepth = 2) from function 'c_addrOfConst'
-  c_ptrTo_domain.chpl:11: called as c_addrOfConst(x: domain(1,int(64),one))
 c_ptrTo_domain.chpl:11: error: c_addrOfConst domain type not supported

--- a/test/types/cptr/c_ptrTo_domain.4.good
+++ b/test/types/cptr/c_ptrTo_domain.4.good
@@ -1,5 +1,5 @@
-$CHPL_HOME/modules/standard/Errors.chpl:647: In function 'compilerError':
-$CHPL_HOME/modules/standard/Errors.chpl:648: warning: compiler diagnostic depth value exceeds call stack depth
-  $CHPL_HOME/modules/standard/CTypes.chpl:1188: called as compilerError(param msg(0) = "c_addrOfConst domain type not supported", param errorDepth = 2) from function 'c_addrOfConst'
+$CHPL_HOME/modules/standard/Errors.chpl:nnnn: In function 'compilerError':
+$CHPL_HOME/modules/standard/Errors.chpl:nnnn: warning: compiler diagnostic depth value exceeds call stack depth
+  $CHPL_HOME/modules/standard/CTypes.chpl:nnnn: called as compilerError(param msg(0) = "c_addrOfConst domain type not supported", param errorDepth = 2) from function 'c_addrOfConst'
   c_ptrTo_domain.chpl:11: called as c_addrOfConst(x: domain(1,int(64),one))
 c_ptrTo_domain.chpl:11: error: c_addrOfConst domain type not supported

--- a/test/types/cptr/c_ptrTo_domain.4.good
+++ b/test/types/cptr/c_ptrTo_domain.4.good
@@ -1,0 +1,5 @@
+$CHPL_HOME/modules/standard/Errors.chpl:647: In function 'compilerError':
+$CHPL_HOME/modules/standard/Errors.chpl:648: warning: compiler diagnostic depth value exceeds call stack depth
+  $CHPL_HOME/modules/standard/CTypes.chpl:1188: called as compilerError(param msg(0) = "c_addrOfConst domain type not supported", param errorDepth = 2) from function 'c_addrOfConst'
+  c_ptrTo_domain.chpl:11: called as c_addrOfConst(x: domain(1,int(64),one))
+c_ptrTo_domain.chpl:11: error: c_addrOfConst domain type not supported

--- a/test/types/cptr/c_ptrTo_domain.chpl
+++ b/test/types/cptr/c_ptrTo_domain.chpl
@@ -1,0 +1,13 @@
+use CTypes;
+
+config param funcToTest : string = "invalid";
+
+var myDom : domain(1);
+
+select funcToTest {
+  when "c_ptrTo" do c_ptrTo(myDom);
+  when "c_ptrToConst" do c_ptrToConst(myDom);
+  when "c_addrOf" do c_addrOf(myDom);
+  when "c_addrOfConst" do c_addrOfConst(myDom);
+  otherwise writeln("invalid function specified");
+}

--- a/test/types/cptr/c_ptrTo_domain.compopts
+++ b/test/types/cptr/c_ptrTo_domain.compopts
@@ -1,0 +1,4 @@
+-sfuncToTest='"c_ptrTo"' # c_ptrTo_domain.1.good
+-sfuncToTest='"c_ptrToConst"' # c_ptrTo_domain.2.good
+-sfuncToTest='"c_addrOf"' # c_ptrTo_domain.3.good
+-sfuncToTest='"c_addrOfConst"' # c_ptrTo_domain.4.good

--- a/test/types/cptr/c_ptrTo_domain.compopts
+++ b/test/types/cptr/c_ptrTo_domain.compopts
@@ -1,4 +1,4 @@
--sfuncToTest='"c_ptrTo"' # c_ptrTo_domain.1.good
--sfuncToTest='"c_ptrToConst"' # c_ptrTo_domain.2.good
--sfuncToTest='"c_addrOf"' # c_ptrTo_domain.3.good
+-sfuncToTest='"c_ptrTo"'       # c_ptrTo_domain.1.good
+-sfuncToTest='"c_ptrToConst"'  # c_ptrTo_domain.2.good
+-sfuncToTest='"c_addrOf"'      # c_ptrTo_domain.3.good
 -sfuncToTest='"c_addrOfConst"' # c_ptrTo_domain.4.good

--- a/test/types/cptr/c_ptrTo_domain.prediff
+++ b/test/types/cptr/c_ptrTo_domain.prediff
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# Designed to squash out line numbers from modules files to prevent
+# sensitivities to code locations.  Borrowed from
+# `test/functions/operatorOverloads/operatorMethods/nestedMethodBad.prediff`
+#
+
+tmpfile=$2
+
+tmptmp=`mktemp "tmp.XXXXXX"`
+
+regex='\|CHPL_HOME/modules|s/:[0-9:]*:/:nnnn:/'
+
+sed -e "$regex" $tmpfile > $tmptmp
+
+mv $tmptmp $tmpfile


### PR DESCRIPTION
Fix incorrect error text for `c_ptrTo`/`c_ptrToConst` on `domain` types, and add a test locking it in.

Before this PR, an error is emitted, but it mentions the corresponding `c_addrOf`/`c_addrOfConst` procedure instead of the called procedure. This bug appears to have been introduced in https://github.com/chapel-lang/chapel/pull/22165.

[reviewer info placeholder]

Testing:
- [x] local paratest