### PR TITLE
Simplify documentation of `c_ptrTo` and related procedures' overloads

### DIFF
--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -791,7 +791,8 @@ module CTypes {
   /*
     Toggles whether the new or deprecated behavior of :proc:`c_ptrTo` and
     :proc:`c_ptrToConst` is used for :type:`~String.string`,
-    :type:`~Bytes.bytes`, and class type arguments.
+    :type:`~Bytes.bytes`, and class type arguments. (The behavior of
+    :proc:`c_ptrTo` with array type arguments is unaffected.)
 
     The new behavior is to return a :type:`c_ptr`/:type:`c_ptrConst` to the
     underlying buffer of the ``string`` or ``bytes``, or to the heap instance of

--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -799,6 +799,7 @@ module CTypes {
     :arg arr: the array for which a pointer should be returned
     :returns: a pointer to the array's elements
   */
+  @chpldoc.nodoc
   inline proc c_ptrTo(ref arr: []): c_ptr(arr.eltType) {
     if (!arr.isRectangular() || !arr.domain.distribution._value.dsiIsLayout()) then
       compilerError("Only single-locale rectangular arrays support c_ptrTo() at present");
@@ -820,6 +821,7 @@ module CTypes {
    Like :proc:`c_ptrTo` for arrays, but returns a :type:`c_ptrConst` which
    disallows direct modification of the pointee.
    */
+  @chpldoc.nodoc
   inline proc c_ptrToConst(const arr: []): c_ptrConst(arr.eltType) {
     if (!arr.isRectangular() || !arr.domain.distribution._value.dsiIsLayout()) then
       compilerError("Only single-locale rectangular arrays support c_ptrToConst() at present");
@@ -865,6 +867,7 @@ module CTypes {
 
     Halts if the ``string`` is empty and bounds checking is enabled.
   */
+  @chpldoc.nodoc
   inline proc c_ptrTo(ref s: string): c_ptr(c_uchar)
     where cPtrToLogicalValue == true
   {
@@ -886,6 +889,7 @@ module CTypes {
    Like :proc:`c_ptrTo` for :type:`~String.string`, but returns a
    :type:`c_ptrConst` which disallows direct modification of the pointee.
    */
+  @chpldoc.nodoc
   inline proc c_ptrToConst(const ref s: string): c_ptrConst(c_uchar)
     where cPtrToLogicalValue == true
   {
@@ -991,6 +995,7 @@ module CTypes {
 
     Halts if the ``bytes`` is empty and bounds checking is enabled.
   */
+  @chpldoc.nodoc
   inline proc c_ptrTo(ref b: bytes): c_ptr(c_uchar)
     where cPtrToLogicalValue == true
   {
@@ -1012,6 +1017,7 @@ module CTypes {
    Like :proc:`c_ptrTo` for :type:`~Bytes.bytes`, but returns a
    :type:`c_ptrConst` which disallows direct modification of the pointee.
    */
+  @chpldoc.nodoc
   inline proc c_ptrToConst(const ref b: bytes): c_ptrConst(c_uchar)
     where cPtrToLogicalValue == true
   {
@@ -1042,6 +1048,7 @@ module CTypes {
     lifetime of the instance.  The returned pointer will be invalid if the
     instance is freed or even reallocated.
   */
+  @chpldoc.nodoc
   inline proc c_ptrTo(c: class?): c_ptr(void)
     where cPtrToLogicalValue == true
   {
@@ -1071,6 +1078,7 @@ module CTypes {
   /*
    Like :proc:`c_ptrTo` for class types, but also accepts ``const`` data.
    */
+  @chpldoc.nodoc
   inline proc c_ptrToConst(const c: class?): c_ptrConst(void)
     where cPtrToLogicalValue == true
   {
@@ -1136,6 +1144,7 @@ module CTypes {
     Note that the existence of this :type:`c_ptr` has no impact on the lifetime
     of the array. The returned pointer will be invalid if the array is freed.
   */
+  @chpldoc.nodoc
   inline proc c_addrOf(ref arr: []) {
     if (!arr.isRectangular() || !arr.domain.distribution._value.dsiIsLayout()) then
       compilerError("Only single-locale rectangular arrays support c_addrOf() at present");
@@ -1153,6 +1162,7 @@ module CTypes {
    Like :proc:`c_addrOf` for arrays, but returns a :type:`c_ptrConst` which
    disallows direct modification of the pointee.
   */
+  @chpldoc.nodoc
   inline proc c_addrOfConst(const arr: []) {
     if (!arr.isRectangular() || !arr.domain.distribution._value.dsiIsLayout()) then
       compilerError("Only single-locale rectangular arrays support c_addrOfConst() at present");

--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -801,7 +801,7 @@ module CTypes {
     the stack representation of the class — this matches the behavior of
     :proc:`c_addrOf`/:proc:`c_addrOfConst`.
 
-    The deprecated behavior is on by default. To opt in to the new behavior,
+    The deprecated behavior is on by default. To opt-in to the new behavior,
     compile your program with the following argument:
     ``-s cPtrToLogicalValue=true``.
   */
@@ -832,9 +832,11 @@ module CTypes {
     behavior to ``c_addrOf`` on types other than those with special behavior
     listed above.
 
-    Note that the existence of the ``c_ptr`` has no impact of the lifetime
-    of the object. In many cases the object will be stack allocated and
-    could go out of scope even if this ``c_ptr`` remains.
+    .. note::
+
+      The existence of the ``c_ptr`` has no impact on the lifetime
+      of the object it points to. In many cases the object will be stack
+      allocated and could go out of scope even if this ``c_ptr`` remains.
 
     :arg x:   The by-reference argument to get a pointer to. Domains are not
               supported, and will cause a compiler error.

--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -789,6 +789,12 @@ module CTypes {
                              eltSize:c_ptrdiff):c_ptrdiff;
 
   /*
+   ********************************
+   Begin c_ptrTo[Const], c_addrOf[Const] definitions
+   ********************************
+  */
+
+  /*
     Returns a :type:`c_ptr` to the elements of a non-distributed
     Chapel rectangular array.  Note that the existence of this
     :type:`c_ptr` has no impact on the lifetime of the array.  The
@@ -1203,6 +1209,13 @@ module CTypes {
   inline proc c_addrOf(x: c_fn_ptr) {
     return x;
   }
+
+  /*
+   ********************************
+   End c_ptrTo[Const], c_addrOf[Const] definitions
+   ********************************
+  */
+
 
   // Offset the CHPL_RT_MD constant in order to preserve the value through
   // calls to chpl_here_alloc. See comments on offset_STR_* in String.chpl

--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -1024,6 +1024,7 @@ module CTypes {
   }
 
   @deprecated(notes="The c_ptrToConst(string) overload that returns a c_ptrConst(string) is deprecated. Please use 'c_addrOfConst' instead, or recompile with '-s cPtrToLogicalValue=true' to opt-in to the new behavior.")
+  @chpldoc.nodoc
   inline proc c_ptrToConst(const ref s: string): c_ptrConst(string)
     where cPtrToLogicalValue == false
   {
@@ -1046,6 +1047,7 @@ module CTypes {
   }
 
   @deprecated(notes="The c_ptrToConst(bytes) overload that returns a c_ptrConst(bytes) is deprecated. Please use 'c_addrOfConst' instead, or recompile with '-s cPtrToLogicalValue=true' to opt-in to the new behavior.")
+  @chpldoc.nodoc
   inline proc c_ptrToConst(const ref b: bytes): c_ptrConst(bytes)
     where cPtrToLogicalValue == false
   {
@@ -1076,6 +1078,7 @@ module CTypes {
     return c_addrOfConst(c);
   }
   @deprecated(notes="The c_ptrToConst(class) overload that returns a pointer to the class representation on the stack is deprecated. Default behavior will soon change to return a pointer to the heap instance. Please use 'c_addrOfConst' instead, or recompile with '-s cPtrToLogicalValue=true' to opt-in to the new behavior.")
+  @chpldoc.nodoc
   inline proc c_ptrToConst(const ref c: class?): c_ptrConst(c.type)
     where cPtrToLogicalValue == false
   {


### PR DESCRIPTION
Simplify the documentation of `c_ptrTo`, `c_ptrToConst`, `c_addrOf`, and `c_addrOfConst` by documenting just the catch-all overload for each, hiding the fact they are implemented via numerous overloads taking specific argument types.

This includes the following changes:
- No-doc all overloads of these procedures except for the "catch-all" overload that takes any type, and some deprecated overloads so they still show up in docs during the deprecation period.
- Expand the documentation of the remaining documented `c_ptrTo` overload to describe all its special behavior cases, and refer users to `c_addrOf` for a non-special behavior version.
- Reorganize the order of the various definitions, to make the code a little easier to follow (imo) and to display deprecated overloads after the primary overloads. It is now grouped as follows, with each group getting bookending "begin" and "end" comments in code:
  - `c_ptrTo` definitions
  - `c_ptrToConst` definitions
  - definitions of deprecation transition helpers (which were all no-doc already)
  - `c_addrOf` and `c_addrOfConst` definitions
- No-doc deprecated `c_ptrToConst` overloads that have a 1:1 corresponding deprecated `c_ptrTo` overload that _is_ documented, to avoid redundant information on the doc page.
- Add docs mention that `c_ptrTo` on arrays is unaffected by `cPtrToLogicalValue`.

Likely best reviewed commit-by-commit or by looking at the rendered `CTypes` docs page, as moving around chunks of code makes a confusing diff. For convenient comparison, here is the start of the documentation of `c_ptrTo` and friends on the current version of docs: [link](https://chapel-lang.org/docs/main/modules/standard/CTypes.html#CTypes.c_ptrTo)

Resolves https://github.com/Cray/chapel-private/issues/5386.

[reviewer info placeholder]

Testing:
- [x] locally generated docs look right
- [x] local paratest (ensuring I didn't drop an overload on the floor)