### PR TITLE
Skip leading underscore warning for name "_"

### DIFF
--- a/frontend/lib/uast/post-parse-checks.cpp
+++ b/frontend/lib/uast/post-parse-checks.cpp
@@ -1253,7 +1253,8 @@ void Visitor::warnUnstableSymbolNames(const NamedDecl* node) {
 
   auto name = node->name();
 
-  if (name.startsWith("_")) {
+  // warn on names with leading underscore, except for just underscore itself
+  if (name.startsWith("_") && name.length() > 1) {
     warn(node,
          "symbol names with leading underscores (%s) are unstable.",
          name.c_str());

--- a/test/unstable/leadingUnderscore.chpl
+++ b/test/unstable/leadingUnderscore.chpl
@@ -10,4 +10,7 @@ module _MyHiddenModule {
 
   class _Underscore_ {
   }
+
+  // don't warn for use of special _ (as in dropping a value in de-tupling)
+  var (x, _) = (1, 2);
 }


### PR DESCRIPTION
Skip unstable warning for names with leading underscores for the special name that is _just_ `_`, as used in de-tupling, and test that the warning is not emitted.

Resolves https://github.com/chapel-lang/chapel/issues/23430.

[reviewer info placeholder]

Testing:
- [x] local paratest