### PR TITLE
GPU technote updates for 1.32

### DIFF
--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -420,7 +420,7 @@ generate assemly). The Chapel compiler will emit a file ``chpl__gpu.s``, which
 contains AMD GCN or NVIDIA PTX instructions as appropriate.
 
 In the generated assembly, kernels are named
-q`chpl_gpu_kernel_<fileName>_line_<num>_`` (with ``filename`` replaced with the
+``chpl_gpu_kernel_<fileName>_line_<num>_`` (with ``filename`` replaced with the
 file containing the outlined loop and ``num`` as the line number of the loop
 header. For example, a kernel on line 3 of ``chpl.foo`` will be named
 ``chpl_gpu_kernel_foo_line_3_``).

--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -423,11 +423,6 @@ improvements in the future.
     * It's not currently possible to compile for multiple AMD GPU architectures
       at the same time.
 
-    * Certain 64-bit math functions are unsupported. To see what does
-      and doesn't work see `this test
-      <https://github.com/chapel-lang/chapel/blob/release/1.30/test/gpu/native/math.chpl>`_
-      and note which operations are executed when ``excludeForRocm == true``.
-
 * Distributed arrays cannot be used within GPU kernels.
 
 * PGAS style communication is not available within GPU kernels; that is:

--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -410,6 +410,21 @@ can reduce execution performance significantly, making profiling less valuable.
 To avoid this, please use ``--gpu-ptxas-enforce-optimization`` while compiling
 alongside ``-g``, and of course, ``--fast``.
 
+Examining Generated Assembly
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+While analyzing performance, users might also wish to look at the assembly
+``chpl`` generates for GPU kernels. To do this pass ``chpl`` ``--savec
+<dirName>`` (replacing ``<dirname>`` with a directory name to contain the
+generate assemly). The Chapel compiler will emit a file ``chpl__gpu.s``, which
+contains AMD GCN or NVIDIA PTX instructions as appropriate.
+
+In the generated assembly, kernels are be named
+`chpl_gpu_kernel_<fileName>_line_<num>_` (with `filename` replaced with the
+file containing the outlined loop and `num` as the line number of the loop
+header. For example, a kernel on line 3 of `chpl.foo` will be named
+`chpl_gpu_kernel_foo_line_3_`).
+
 Known Limitations
 -----------------
 

--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -419,11 +419,11 @@ While analyzing performance, users might also wish to look at the assembly
 generate assemly). The Chapel compiler will emit a file ``chpl__gpu.s``, which
 contains AMD GCN or NVIDIA PTX instructions as appropriate.
 
-In the generated assembly, kernels are be named
-`chpl_gpu_kernel_<fileName>_line_<num>_` (with `filename` replaced with the
-file containing the outlined loop and `num` as the line number of the loop
-header. For example, a kernel on line 3 of `chpl.foo` will be named
-`chpl_gpu_kernel_foo_line_3_`).
+In the generated assembly, kernels are named
+q`chpl_gpu_kernel_<fileName>_line_<num>_`` (with ``filename`` replaced with the
+file containing the outlined loop and ``num`` as the line number of the loop
+header. For example, a kernel on line 3 of ``chpl.foo`` will be named
+``chpl_gpu_kernel_foo_line_3_``).
 
 Known Limitations
 -----------------


### PR DESCRIPTION
Tech note updates for 1.32:

- We now have features parity for AMD in regards to math functions so remove the bullet saying we don't.
- Add a new small section: "Examining Generated Assembly"