### PR TITLE
Disable where-clauses in chpldoc with a pragma

### DIFF
--- a/frontend/include/chpl/uast/PragmaList.h
+++ b/frontend/include/chpl/uast/PragmaList.h
@@ -415,6 +415,7 @@ PRAGMA(NO_COPY_RETURN, ypr, "no copy return", ncm)
 PRAGMA(NO_COPY_RETURNS_OWNED, ypr, "no copy returns owned", ncm)
 PRAGMA(NO_DEFAULT_FUNCTIONS, ypr, "no default functions", ncm)
 PRAGMA(NO_DOC, ypr, "no doc", "do not generate chpldoc documentation for this symbol")
+PRAGMA(NO_WHERE_DOC, ypr, "no where doc", "do not include the where clause in chpldoc documentation for this symbol")
 PRAGMA(NO_IMPLICIT_COPY, ypr, "no implicit copy", "function does not require autoCopy/autoDestroy")
 
 // This flag disables initialization entirely. In contrast, `= noinit`

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -1764,6 +1764,7 @@ proc range.safeCast(type t: range(?)) {
    the original bounds and/or stride do not fit in the new idxType
    or when the original stride is not legal for the new `strides` parameter.
  */
+pragma "no where doc"
 proc range.tryCast(type t: range(?)) where chpl_tryCastIsSafe(this, t) {
   const r = this;
   checkBounds(t, r);

--- a/test/chpldoc/functions/WhereClause.doc.chpl
+++ b/test/chpldoc/functions/WhereClause.doc.chpl
@@ -30,6 +30,11 @@ module M {
         writeln("processRange 2");
     }
 
+    pragma "no where doc"
+    proc processRangeNW(r: range) where r.low > 1 {
+        writeln("processRange no where");
+    }
+
     // From borrowed-in-where.chpl
     proc foo(type t) where isSubtype(t, int) {
         writeln("In foo where");

--- a/test/chpldoc/functions/WhereClause.doc.good
+++ b/test/chpldoc/functions/WhereClause.doc.good
@@ -33,6 +33,8 @@ or
 
 .. function:: proc processRange(r: range) where r.low > 1
 
+.. function:: proc processRangeNW(r: range)
+
 .. function:: proc foo(type t) where isSubtype(t, int)
 
 .. function:: operator +(a: int, b: int) where a > 0

--- a/tools/chpldoc/chpldoc.cpp
+++ b/tools/chpldoc/chpldoc.cpp
@@ -339,6 +339,13 @@ static bool isNoDoc(const Decl* e) {
   return false;
 }
 
+static bool isNoWhereDoc(const Function* f) {
+  if (auto attrs = f->attributeGroup())
+    if (attrs->hasPragma(pragmatags::PRAGMA_NO_WHERE_DOC))
+      return true;
+  return false;
+}
+
 static std::vector<std::string> splitLines(const std::string& s) {
   std::stringstream ss(s);
   std::string line;
@@ -1145,8 +1152,10 @@ struct RstSignatureVisitor {
 
     // Where Clause
     if (const AstNode* wc = f->whereClause()) {
+     if (isNoWhereDoc(f)) {
       os_ << " where ";
       wc->traverse(*this);
+     }
     }
 
     return false;

--- a/tools/chpldoc/chpldoc.cpp
+++ b/tools/chpldoc/chpldoc.cpp
@@ -1152,7 +1152,7 @@ struct RstSignatureVisitor {
 
     // Where Clause
     if (const AstNode* wc = f->whereClause()) {
-     if (isNoWhereDoc(f)) {
+     if (!isNoWhereDoc(f)) {
       os_ << " where ";
       wc->traverse(*this);
      }


### PR DESCRIPTION
This PR enables hiding the where-clause from the chpldoc of a function by annotating the function with a pragma `"no where doc"` . It applies this pragma to `range.tryCast`, whose where-clause is not intended for user-facing documentation.

The same result could be achieved as easily with `@chpldoc.noWhere`, however that would be a "feature" and we are past feature freeze for the release.

Testing: standard paratest.

Here are two overloads of `range.tryCast` (with @chpldoc.nodoc removed) before the pragma:
<img width="714" src="https://github.com/chapel-lang/chapel/assets/8039635/0bec0a1a-6b9d-4da5-b648-74a21e1ae250">
Here are the same overloads with the pragma implemented and added to the first overload:
<img width="725" src="https://github.com/chapel-lang/chapel/assets/8039635/ac8e7684-99ee-483f-95ff-d29a9301a0d7">

I anticipate this pragma to be used in the Reflection module, which has a couple of non-user-facing where clauses, ex. https://chapel-lang.org/docs/main/modules/standard/Reflection.html#Reflection.getField