### PR TITLE
Add support ROCm versions through 5.4

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -4352,6 +4352,11 @@ static void linkGpuDeviceLibraries() {
       linkBitCodeFile(determineOclcVersionLib(libPath, gpuArch).c_str());
     }
 
+    // here, we are hard coding _400.bc. In all systems where we see the need
+    // for this, there's also _500.bc. We need to investigate the difference
+    // between the two (version 4.0.0 vs 5.0.0 of something?) and understand
+    // what this library does (is oclc short for OpenCL something?). 400 seems
+    // to work for now and I haven't tried what happens with 500.
     std::string oclcAbiVersionLibPath = libPath + "/oclc_abi_version_400.bc";
     std::ifstream file(oclcAbiVersionLibPath);
     if(file.good()) {

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -4347,9 +4347,17 @@ static void linkGpuDeviceLibraries() {
     linkBitCodeFile((libPath + "/oclc_finite_only_off.bc").c_str());
     linkBitCodeFile((libPath + "/oclc_correctly_rounded_sqrt_on.bc").c_str());
     linkBitCodeFile((libPath + "/oclc_wavefrontsize64_on.bc").c_str());
+
     for (auto gpuArch : gpuArches) {
       linkBitCodeFile(determineOclcVersionLib(libPath, gpuArch).c_str());
     }
+
+    std::string oclcAbiVersionLibPath = libPath + "/oclc_abi_version_400.bc";
+    std::ifstream file(oclcAbiVersionLibPath);
+    if(file.good()) {
+      linkBitCodeFile(oclcAbiVersionLibPath.c_str());
+    }
+
   }
 
   // internalize all functions that are not in `externals`

--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -131,8 +131,8 @@ Requirements
     ``CHPL_RT_NUM_THREADS_PER_LOCALE=1``. Versions as early as 7.x may work,
     although we have not tested this.
 
-  * If targeting AMD GPUs, we require ROCm version 4.x; we suspect version 5.x
-    will work as well although we have not tested so.
+  * If targeting AMD GPUs, we require ROCm version 4.x or <5.4. ROCm versions
+    greater than 5.4 are not supported, yet.
 
 
 GPU-Related Environment Variables

--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -131,7 +131,7 @@ Requirements
     ``CHPL_RT_NUM_THREADS_PER_LOCALE=1``. Versions as early as 7.x may work,
     although we have not tested this.
 
-  * If targeting AMD GPUs, we require ROCm version 4.x or <5.4. ROCm versions
+  * If targeting AMD GPUs, we require ROCm version 4.x or <5.5. ROCm versions
     greater than 5.4 are not supported, yet.
 
 

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -142,7 +142,17 @@ def get_sdk_path(for_gpu):
 
     if exists and returncode == 0:
         real_path = os.path.realpath(my_stdout.strip()).strip()
-        chpl_sdk_path = "/".join(real_path.split("/")[:-gpu.bin_depth])
+        path_parts = real_path.split("/")
+        # chpl_sdk_path = "/".join(real_path.split("/")[:-gpu.bin_depth])
+        chpl_sdk_path = "/"
+        for part in path_parts:
+            if len(part) == 0: continue
+            chpl_sdk_path += part
+            if not part.startswith(gpu.runtime_impl):
+                chpl_sdk_path += "/"
+            else:
+                break
+
         return chpl_sdk_path
     elif gpu_type == for_gpu:
         _reportMissingGpuReq("Can't find {} toolkit.".format(get()))

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -16,11 +16,10 @@ def _validate_rocm_version():
     return _validate_rocm_version_impl()
 
 class gpu_type:
-    def __init__(self, sdk_path_env, compiler, bin_depth, default_arch,
-                 llvm_target, runtime_impl, version_validator):
+    def __init__(self, sdk_path_env, compiler, default_arch, llvm_target,
+                 runtime_impl, version_validator):
         self.sdk_path_env = sdk_path_env
         self.compiler = compiler
-        self.bin_depth = bin_depth
         self.default_arch = default_arch
         self.llvm_target = llvm_target
         self.runtime_impl = runtime_impl
@@ -33,21 +32,18 @@ class gpu_type:
 GPU_TYPES = {
     "nvidia": gpu_type(sdk_path_env="CHPL_CUDA_PATH",
                        compiler="nvcc",
-                       bin_depth=2,
                        default_arch="sm_60",
                        llvm_target="NVPTX",
                        runtime_impl="cuda",
                        version_validator=_validate_cuda_version),
     "amd": gpu_type(sdk_path_env="CHPL_ROCM_PATH",
                     compiler="hipcc",
-                    bin_depth=3,
                     default_arch="",
                     llvm_target="AMDGPU",
                     runtime_impl="rocm",
                     version_validator=_validate_rocm_version),
     "cpu": gpu_type(sdk_path_env="",
                     compiler="",
-                    bin_depth=-1,
                     default_arch="",
                     llvm_target="",
                     runtime_impl="cpu",
@@ -141,9 +137,11 @@ def get_sdk_path(for_gpu):
                                                                       gpu.compiler])
 
     if exists and returncode == 0:
+        # Walk up from directories from the one containing the gpu compiler
+        # (e.g.  `nvcc` or `hipcc`) until we find a directory that starts with
+        # `runtime_impl` (e.g `cuda` or `rocm`)
         real_path = os.path.realpath(my_stdout.strip()).strip()
         path_parts = real_path.split("/")
-        # chpl_sdk_path = "/".join(real_path.split("/")[:-gpu.bin_depth])
         chpl_sdk_path = "/"
         for part in path_parts:
             if len(part) == 0: continue

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -268,7 +268,7 @@ def _validate_rocm_version_impl():
     """Check that the installed ROCM version is >= MIN_REQ_VERSION and <
        MAX_REQ_VERSION"""
     MIN_REQ_VERSION = "4"
-    MAX_REQ_VERSION = "6"
+    MAX_REQ_VERSION = "5.5"
 
     chpl_rocm_path = get_sdk_path('amd')
     files_to_try = ['%s/.info/version-hiprt' % chpl_rocm_path,


### PR DESCRIPTION
This PR:

- improves the GPU SDK path finding heuristic (resolves https://github.com/chapel-lang/chapel/issues/22780)
- links `oclc_abi_version_400.bc` file (resolves https://github.com/chapel-lang/chapel/issues/22781)
- updates the GPU technote w.r.t. supported ROCm versions

Test:
- [x] jacobi on amd with rocm versions 4.2, 4.4, 5.1, 5.2, 5.3, 5.4
- [x] nvidia
- [x] amd