### PR TITLE
[LSP] Adjust language server code to fix bugs when compiling with GCC

### DIFF
--- a/tools/chpldef/Message.h
+++ b/tools/chpldef/Message.h
@@ -413,7 +413,8 @@ protected:
   }
 
 public:
-  virtual ~TemplatedMessage() = default;
+  // Cannot use 'default' because of a conflict with specialization on GCC.
+  virtual ~TemplatedMessage() override {}
 
   /** Create a message using a JSON id and parameters. */
   static chpl::owned<Self> create(JsonValue id, Params p);
@@ -440,13 +441,13 @@ public:
       For incoming notifications, a JSON 'null' value is returned, as there
       is nothing to pack.
   */
-  virtual opt<JsonValue> pack() const final;
+  virtual opt<JsonValue> pack() const final override;
 
   /** For incoming messages, compute a result using the input parameters. */
-  virtual void handle(Server* ctx) final;
+  virtual void handle(Server* ctx) final override;
 
   /** For outbound messages, compute using a response sent by the client. */
-  virtual void handle(Server* ctx, Response* r) final;
+  virtual void handle(Server* ctx, Response* r) final override;
 
   /** For outbound messages, compute using results sent by the client. */
   void handle(Server* ctx, Result r);
@@ -469,8 +470,7 @@ public:
 
 /** Create aliases for each specialization over a message tag. */
 #define CHPLDEF_MESSAGE(name__, x1__, x2__, x3__) \
-  template <> class TemplatedMessage<MessageTag::name__>; \
-  using name__ = TemplatedMessage<MessageTag::name__>;
+  using name__ = class TemplatedMessage<MessageTag::name__>;
 #include "message-macro-list.h"
 #undef CHPLDEF_MESSAGE
 

--- a/tools/chpldef/Transport.cpp
+++ b/tools/chpldef/Transport.cpp
@@ -22,9 +22,9 @@
 #include "Server.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/JSON.h"
+#include <cinttypes>
 #include <iostream>
 #include <fstream>
-#include <inttypes.h>
 
 namespace chpldef {
 

--- a/tools/chpldef/Transport.cpp
+++ b/tools/chpldef/Transport.cpp
@@ -24,6 +24,7 @@
 #include "llvm/Support/JSON.h"
 #include <iostream>
 #include <fstream>
+#include <inttypes.h>
 
 namespace chpldef {
 
@@ -89,7 +90,7 @@ Transport::Status Transport::readJson(Server* ctx, JsonValue& j) {
   }
 
   // Failed to parse.
-  ctx->verbose("Failed to parse JSON object of length: %lld\n", length);
+  ctx->verbose("Failed to parse JSON object of size: %" PRId64 "\n", length);
   ctx->trace("String is: %s\n", line.c_str());
   return ERROR_JSON_PARSE_FAILED;
 }


### PR DESCRIPTION
This PR fixes several compiler errors that only appear when compiling
the language server with GCC. Shamefully, I forgot to test my build of
#22861 w/ GCC, and let in some bugs as I only develop with Clang.

The most frustrating bug here by far was "full specialization in
non-namespace scope", which I finally tracked down to the following
defect report: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85282

This is still not fixed yet as of GCC 12 as far as I know (haven't
used 12, so don't quote me on it), so it certainly isn't a feature
we can rely on.

I worked around the bug by using `constexpr` folding instead of
specialization, but it's a solution I'm still not quite happy with.

Another frustrating bug involved parameter-packing and recursive
template instantiation. While Clang knew to terminate recursive
instantiation of `withChapel` early and eagerly, GCC opted to blow
out its instantiation stack instead. The only solution was to
rewrite the problematic overload to avoid a recursive call. I'm not
sure which of GCC or Clang is in the right, here.

I've left comments in the code indicating why certain patterns exist.

This PR marks the first time I've opted to use [LSP] as a tag to
indicate that this effort is for the "Language Server (Protocol)".
I'm preferring this tag over "chpldef" as the team has indicated
they'd like a different name for the server in the future. While
I haven't changed the server name yet, it's on the agenda.

TESTING

- [x] LSP/tests on `linux64`
- [x] LSP/tests on `osx`

Reviewed by @DanilaFe. Thanks!