### PR TITLE
Update language specification to describe T(?)

### DIFF
--- a/doc/rst/language/spec/classes.rst
+++ b/doc/rst/language/spec/classes.rst
@@ -570,9 +570,10 @@ Otherwise the class inherits from the predefined ``RootClass`` class
 parent class.
 
 It is possible for a class to inherit from a generic class. Suppose for
-example that a class ``C`` inherits from class ``ParentC``. In this
-situation, ``C`` will have type constructor arguments based upon generic
-fields in the ``ParentC`` as described
+example that ``ParentC`` is a generic class. A class ``C`` can inherits
+from it by writing ``class C : ParentC(?)``.
+In this situation, ``C`` will have type constructor arguments based upon
+generic fields in the ``ParentC`` as described
 in :ref:`Type_Constructors`. Furthermore, a fully specified ``C``
 will be a subclass of a corresponding fully specified ``ParentC``.
 

--- a/doc/rst/language/spec/classes.rst
+++ b/doc/rst/language/spec/classes.rst
@@ -571,11 +571,11 @@ parent class.
 
 It is possible for a class to inherit from a generic class. Suppose for
 example that ``ParentC`` is a generic class. A class ``C`` can inherits
-from it by writing ``class C : ParentC(?)``.
-In this situation, ``C`` will have type constructor arguments based upon
-generic fields in the ``ParentC`` as described
-in :ref:`Type_Constructors`. Furthermore, a fully specified ``C``
-will be a subclass of a corresponding fully specified ``ParentC``.
+from it by writing ``class C : ParentC(?)``. In this situation, ``C``
+will have type constructor arguments based upon generic fields in the
+``ParentC`` as described in :ref:`Type_Constructors`. Furthermore, a
+fully specified ``C`` will be a subclass of a corresponding fully
+specified ``ParentC``.
 
 .. _The_Root_Class:
 

--- a/doc/rst/language/spec/conversions.rst
+++ b/doc/rst/language/spec/conversions.rst
@@ -261,7 +261,7 @@ when one type is a subtype of another.
    *Example (subtype-int8-integral.chpl)*
 
    However, ``int(8)`` is a subtype of the generic type ``integral``
-   according to the first rule above (:ref:`Built_in_Generic_types`).
+   according to the first rule above (:ref:`Built_in_Generic_Types`).
 
    .. BLOCK-test-chapelpre
 

--- a/doc/rst/language/spec/generics.rst
+++ b/doc/rst/language/spec/generics.rst
@@ -741,10 +741,10 @@ Parameters in Generic Types
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If a class or record defines a parameter field, the class or record is
-generic over the value that is bound to that field.  Similarly to
-``type`` fields, a ``param`` field is always generic, whether or not it
-includes a default.  The field can be accessed from a class or record
-instance or from the instantiated class or record type itself.
+generic over the value that is bound to that field. A parameter field is
+always generic, whether or not includes a default. The field can be
+accessed from a class or record instance or from the instantiated class
+or record type itself.
 
 The parameter becomes an argument with intent ``param`` to the
 compiler-generated initializer
@@ -922,7 +922,7 @@ The types for such fields must either be a built-in generic type (see
    *Example (fieldWithGenericType.chpl)*.
 
    This code defines a generic record ``queue`` and then a generic record
-   ``wrapper`` that uses a field to hold a.
+   ``wrapper`` that uses a field to hold a ``queue``.
 
    .. code-block:: chapel
 
@@ -947,20 +947,19 @@ The Type Constructor
 ~~~~~~~~~~~~~~~~~~~~
 
 A type constructor is automatically created for each class or record. A
-type constructor is a type function (:ref:`Type_Return_Intent`)
-that has the same name as the class or record. It takes one argument per
-the class’s or record’s generic field, including fields inherited from
-the superclasses, if any. The formal argument has intent ``type`` for a
-type alias field and is a parameter for a parameter field. It accepts
-the type to be bound to the type alias and the value to be bound to the
-parameter, respectively. For a generic ``var`` or ``const`` field, the
-corresponding formal argument also has intent ``type``. It accepts the
-type of the field, as opposed to a value as is the case for a parameter
-field. The formal arguments occur in the same order as the fields are
-declared and formals for ``type``/``param`` fields have the same names
-as the corresponding fields. Unlike the
-compiler-generated initializer, the type constructor only has arguments
-that correspond to generic fields.
+type constructor is a type function (:ref:`Type_Return_Intent`) that has
+the same name as the class or record. It takes one argument per the
+class’s or record’s generic field, including fields inherited from the
+superclasses, if any. The formal argument has intent ``type`` for a type
+alias field and is a parameter for a parameter field. It accepts the type
+to be bound to the type alias and the value to be bound to the parameter,
+respectively. For a generic ``var`` or ``const`` field, the corresponding
+formal argument also has intent ``type``. It accepts the type of the
+field, as opposed to a value as is the case for a parameter field. The
+formal arguments occur in the same order as the fields are declared and
+formals for ``type``/``param`` fields have the same names as the
+corresponding fields. Unlike the compiler-generated initializer, the type
+constructor only has arguments that correspond to generic fields.
 
 A call to a type constructor accepts actual types and parameter values
 and returns the type of the class or record that is instantiated

--- a/doc/rst/language/spec/generics.rst
+++ b/doc/rst/language/spec/generics.rst
@@ -299,7 +299,7 @@ type.
 
    .. code-block:: chapel
 
-      proc writeTop(s: Stack) {
+      proc writeTop(s: Stack(?)) {
         write(s.top.item);
       }
 
@@ -310,8 +310,8 @@ to ``s.itemType``.
 
 Note that generic types which have default values for all of their
 generic fields, *e.g. range*, are not generic when simply specified and
-require a query to mark the argument as generic. For simplicity, the
-identifier may be omitted.
+require a query to mark the argument as generic. See also
+:ref:`Marking_Generic_Types`.
 
    *Example*.
 
@@ -586,7 +586,7 @@ Generic Types
 Generic types comprise built-in generic types, generic classes, and
 generic records.
 
-.. _Built_in_Generic_types:
+.. _Built_in_Generic_Types:
 
 Built-in Generic Types
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -640,17 +640,21 @@ Generic Classes and Records
 
 The remainder of this section :ref:`Generic_Types` specifies
 generic class and record types that are not built-in types
-(:ref:`Built_in_Generic_types`).
+(:ref:`Built_in_Generic_Types`).
 
 A class or record is generic if it contains one or more generic fields.
 A generic field is one of:
 
--  a specified or unspecified type alias,
+-  a specified or unspecified type alias (that is, both ``type t=int;`` and
+   ``type u;``)
 
 -  a parameter field, or
 
 -  a ``var`` or ``const`` field that has no type and no initialization
    expression.
+
+-  a ``var`` or ``const`` field with a generic type marked with ``(?)``
+   and no initialization expression.
 
 For each generic field, the class or record is parameterized over:
 
@@ -737,9 +741,10 @@ Parameters in Generic Types
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If a class or record defines a parameter field, the class or record is
-generic over the value that is bound to that field. The field can be
-accessed from a class or record instance or from the instantiated class
-or record type itself.
+generic over the value that is bound to that field.  Similarly to
+``type`` fields, a ``param`` field is always generic, whether or not it
+includes a default.  The field can be accessed from a class or record
+instance or from the instantiated class or record type itself.
 
 The parameter becomes an argument with intent ``param`` to the
 compiler-generated initializer
@@ -854,6 +859,11 @@ constructor is invoked, the class or record is instantiated by binding
 the type of the field to the actual type passed to the corresponding
 argument.
 
+Note that records containing fields without types or fields with generic
+types (see :ref:`Fields_with_Generic_Types`) cannot be
+default-initialized.
+
+
    *Example (fieldWithoutType.chpl)*.
 
    The following code defines another class called ``Node`` that
@@ -897,6 +907,40 @@ argument.
    defines a two-element list with nodes containing the values ``1`` and
    ``2``. The type of each object could be specified as ``Node(int)``.
 
+ .. _Fields_with_Generic_Types:
+
+Fields with Generic Types
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A field declared with a generic type is similar to a field declared
+without any type (:ref:`Fields_without_Types`); however, the generic type
+constrains the possible field types to instantiations of the generic.
+The types for such fields must either be a built-in generic type (see
+:ref:`Built_in_Generic_Types`) or include a ``?`` to mark them as generic
+(see :ref:`Marking_Generic_Types`).
+
+   *Example (fieldWithGenericType.chpl)*.
+
+   This code defines a generic record ``queue`` and then a generic record
+   ``wrapper`` that uses a field to hold a.
+
+   .. code-block:: chapel
+
+      record queue {
+        type eltType;
+      }
+
+      record wrapper {
+        var q: queue(?); // indicates 'q' is generic but is an instantiation
+                         // of 'queue'
+      }
+
+   .. BLOCK-test-chapelpost
+
+      var x = new wrapper(new queue(int));
+
+
+
 .. _Type_Constructors:
 
 The Type Constructor
@@ -913,19 +957,22 @@ parameter, respectively. For a generic ``var`` or ``const`` field, the
 corresponding formal argument also has intent ``type``. It accepts the
 type of the field, as opposed to a value as is the case for a parameter
 field. The formal arguments occur in the same order as the fields are
-declared and have the same names as the corresponding fields. Unlike the
-compiler-generated initializer, the type constructor has only those
-arguments that correspond to generic fields.
+declared and formals for ``type``/``param`` fields have the same names
+as the corresponding fields. Unlike the
+compiler-generated initializer, the type constructor only has arguments
+that correspond to generic fields.
 
 A call to a type constructor accepts actual types and parameter values
 and returns the type of the class or record that is instantiated
 appropriately for each field
 (:ref:`Type_Aliases_in_Generic_Types`,
 :ref:`Parameters_in_Generic_Types`,
-:ref:`Fields_without_Types`). Such an instantiated type must
-be used as the type of a variable, array element, non-generic formal
-argument, and in other cases where uninstantiated generic class or
-record types are not allowed.
+:ref:`Fields_without_Types`).
+A call to a type constructor need not include actual arguments for each
+generic field if it ends with a ``?`` argument. This argument indicates
+that the remaining arguments should remain generic. Additionally, for a
+generic type ``T``, in some cases it is necessary to mark the type as
+generic, and that can be done by writing ``T(?)``.
 
 When a generic field declaration has an initialization expression or a
 type alias is specified, that initializer becomes the default value for
@@ -934,6 +981,73 @@ including all generic ``var`` and ``const`` fields, and unspecified type
 aliases result in arguments with no defaults; actual types or values for
 these arguments must always be provided when invoking the type
 constructor.
+
+.. _Fully_Defaulted_Generic_Types:
+
+Fully Defaulted Generic Types
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A generic record can be written that includes defaults for all ``type``
+and ``param`` fields and does not use any other generic fields. Such a
+generic record type is called a *fully defaulted generic* type.
+
+For a fully defaulted generic type ``T``, the type expression ``T``
+refers to the instantiation with defaults. This allows the type to be
+used in a manner similar to a concrete type. In contrast, ``T(?)``
+indicates the fully generic type and ignores the defaults.
+
+   *Example (fully-defaulted.chpl)*.
+
+   The type ``fullyDefaulted`` below is an example of a fully-defaulted
+   type because the ``type`` and ``param`` fields have defaults. It can
+   be used in a manner similar to a non-generic type, and in that case,
+   the default values for the ``type`` and ``param`` fields will apply.
+
+   .. code-block:: chapel
+
+      record fullyDefaulted {
+        type t = int;
+        param p = 2;
+      }
+      var x:fullyDefaulted; // here, 'fullyDefaulted' uses the defaults
+      writeln(x.t:string); // 'int'
+      writeln(x.p:string); // '2'
+      var y: fullyDefaulted(real, 0); // but, other instantiations are possible
+      writeln(y.t:string); // 'real'
+      writeln(y.p:string); // '0'
+
+   .. BLOCK-test-chapeloutput
+
+      int
+      2
+      real
+      0
+
+
+.. _Marking_Generic_Types:
+
+Marking Generic Types
+~~~~~~~~~~~~~~~~~~~~~
+
+In order to make it clearer when a type expression ``T`` refers to a
+generic type, the syntax ``T(?)`` can be used. This syntax will generate
+an error if ``T`` is not a generic type. As a result, writing ``T(?)``
+communicates to a reader of the code that ``T`` is a generic type.
+
+When generic types other than those listed in
+:ref:`Built_in_Generic_Types` are used in the following situations, they
+should be marked with ``(?)``:
+
+ * fields declared with generic type (see :ref:`Fields_with_Generic_Types`)
+
+ * variables declared with generic type (see
+   :ref:`Variable_Declarations`)
+
+ * formal argument type expressions  (see
+   :ref:`Formal_Arguments_of_Generic_Type`)
+
+ * ``class-inherit`` expressions (see :ref:`Inheritance`)
+
 
 .. _Generic_Methods:
 

--- a/doc/rst/language/spec/generics.rst
+++ b/doc/rst/language/spec/generics.rst
@@ -1034,9 +1034,13 @@ generic type, the syntax ``T(?)`` can be used. This syntax will generate
 an error if ``T`` is not a generic type. As a result, writing ``T(?)``
 communicates to a reader of the code that ``T`` is a generic type.
 
-When generic types other than those listed in
-:ref:`Built_in_Generic_Types` are used in the following situations, they
-should be marked with ``(?)``:
+Marking is not necessary for the built-in generic types listed in
+:ref:`Built_in_Generic_Types`. For fully defaulted generic types
+(:ref:`_Fully_Defaulted_Generic_Types`), marking indicates the generic
+type rather than the instantiation with the defaults.
+
+Otherwise, generic types used in the following situations should be
+marked with ``(?)``:
 
  * fields declared with generic type (see :ref:`Fields_with_Generic_Types`)
 
@@ -1045,6 +1049,8 @@ should be marked with ``(?)``:
 
  * formal argument type expressions  (see
    :ref:`Formal_Arguments_of_Generic_Type`)
+
+ * declared return or yield types (see :ref:`Return_Types`)
 
  * ``class-inherit`` expressions (see :ref:`Inheritance`)
 

--- a/doc/rst/language/spec/generics.rst
+++ b/doc/rst/language/spec/generics.rst
@@ -1036,7 +1036,7 @@ communicates to a reader of the code that ``T`` is a generic type.
 
 Marking is not necessary for the built-in generic types listed in
 :ref:`Built_in_Generic_Types`. For fully defaulted generic types
-(:ref:`_Fully_Defaulted_Generic_Types`), marking indicates the generic
+(:ref:`Fully_Defaulted_Generic_Types`), marking indicates the generic
 type rather than the instantiation with the defaults.
 
 Otherwise, generic types used in the following situations should be

--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -287,6 +287,9 @@ how the actual argument is passed to the function. If no intent is
 specified, the default intent (:ref:`The_Default_Intent`) is
 applied, resulting in type-dependent behavior.
 
+A formal argument can include a type (e.g. ``arg: int``) and possibly a
+default value (e.g. ``arg = ""``).
+
 .. _Named_Arguments:
 
 Named Arguments

--- a/doc/rst/language/spec/records.rst
+++ b/doc/rst/language/spec/records.rst
@@ -208,6 +208,10 @@ The compiler-generated default initializer for a record is defined in the
 same way as the default initializer for a class
 (:ref:`The_Compiler_Generated_Initializer`).
 
+Records containing fields without types or fields with generic types (see
+:ref:`Fields_without_Types` and :ref:`Fields_with_Generic_Types`) cannot
+be default-initialized.
+
 To create a record as an expression, i.e. without binding it to a
 variable, the ``new`` operator is required. In this case, storage is
 allocated and reclaimed as for a record variable declaration

--- a/doc/rst/language/spec/types.rst
+++ b/doc/rst/language/spec/types.rst
@@ -64,7 +64,7 @@ The concrete primitive types are: ``void``, ``nothing``, ``bool``,
 ``bytes``. They are defined in this section.
 
 In addition, there are several generic primitive types that are
-described in :ref:`Built_in_Generic_types`.
+described in :ref:`Built_in_Generic_Types`.
 
 The primitive types are summarized by the following syntax:
 


### PR DESCRIPTION
This PR updates the language specification to cover the changes in PRs #23291 #22784 #22745 #23356 where marking a generic type with `(?)` is now needed.

This PR adds several new spec sections:
 * Fields with Generic Types
 * Fully Defaulted Generic Types
 * Marking Generic Types

Reviewed by @lydia-duncan - thanks!