### PR TITLE
Update serializers technote and ChapelIO

### DIFF
--- a/doc/rst/technotes/ioSerializers.rst
+++ b/doc/rst/technotes/ioSerializers.rst
@@ -11,18 +11,18 @@ Overview
 
 Historically, Chapel's IO module supported formatting options for reading and
 writing values in non-standard formats via the ``readf`` and ``writef`` methods
-(e.g., ``%jt`` for JSON). Chapel 1.31 introduces a new API that allows for
+(e.g., ``%jt`` for JSON). Chapel 1.32 introduced a new API that allows for
 user-defined formatting with ``fileReader`` and ``fileWriter``, rather than
 relying solely on built-in support in the standard library. This new API allows
 for the configuration of ``fileReader`` and ``fileWriter`` with user-defined
 types that can define the format used by methods like ``read`` and ``write``.
 
 For example, if a user wishes to write a record in JSON format they can now
-use the ``Json`` package module in Chapel 1.31:
+use the ``JSON`` standard module in Chapel 1.32:
 
 .. code-block:: chapel
 
-   use IO, Json;
+   use IO, JSON;
 
    record Person {
      var name : string;
@@ -32,7 +32,7 @@ use the ``Json`` package module in Chapel 1.31:
    var f = open("output.txt", ioMode.cw);
 
    // configure 'w' to always write in JSON format
-   var w = f.writer(serializer=new JsonSerializer());
+   var w = f.writer(serializer=new jsonSerializer());
 
    // writes:
    // {"name":"Sam", "age":20}
@@ -40,27 +40,17 @@ use the ``Json`` package module in Chapel 1.31:
    w.write(p);
 
 Serializers and Deserializers interact with user-defined types like ``Person``
-by invoking a particular set of methods which will be discussed in more detail
+by invoking particular methods whose API will be discussed in more detail
 later in this technote. By default, the compiler will generate methods on
 user-defined types capable of interacting with Serializers and Deserializers
 such that most types will simply work out of the box. For more complicated
 cases, users can implement their own methods on their types to customize
 serialization and deserialization.
 
-In the interest of supporting gradual updating of code, in Chapel 1.31 the
-standard IO library will *not* use Serializers or Deserializers by default.
-Users can opt-in to particular formats by creating ``fileReader`` and
-``fileWriter`` instances with new Serializer and Deserializer types. Users
-wishing to experiment with exclusively using this new feature can set the
-boolean config param ``useIOSerializers``:
-
-.. code-block:: sh
-
-   chpl foo.chpl -suseIOSerializers
-
-This config param configures ``fileReader`` and ``fileWriter`` to use the
-``DefaultDeserializer`` and ``DefaultSerializer`` types by default, which
-implement the exact same formatting as past releases.
+In Chapel 1.32, Serializers and Deserializers are enabled by default. Users
+wishing to opt-out of this capability can recompile their programs with
+the config param ``useIOSerializers`` set to ``false``. This config param
+will be available through the Chapel 1.34 release at minimum.
 
 API Changes to Standard IO
 --------------------------
@@ -112,11 +102,11 @@ particular serialization formats:
 .. code-block:: chapel
 
    proc readData(data: [],
-                 reader: fileReader(deserializerType=JsonDeserializer, ?)) {
+                 reader: fileReader(deserializerType=jsonDeserializer, ?)) {
    }
 
    proc readData(data: [],
-                 reader: fileReader(deserializerType=BinaryDeserializer, ?)) {
+                 reader: fileReader(deserializerType=binaryDeserializer, ?)) {
    }
 
 Accessing Serializers and Deserializers
@@ -170,7 +160,7 @@ a simple process:
 
      for d in data {
        log.write("[INFO] ");
-       log.withSerializer(new JsonSerializer()).writeln(d);
+       log.withSerializer(new jsonSerializer()).writeln(d);
 
        this.sendInfo(d);
      }
@@ -186,7 +176,7 @@ initialization without any arguments.
 .. code-block:: chapel
 
    // Replacing the line from the previous example
-   log.withSerializer(JsonSerializer).writeln(d);
+   log.withSerializer(jsonSerializer).writeln(d);
 
 Methods That Invoke Serializers and Deserializers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -202,12 +192,20 @@ Serializers or Deserializers are:
 Reading Generic Types and Borrowed Classes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In Chapel 1.31 generic types and borrowed classes are no longer valid arguments
-to the versions of ``read`` and ``readln`` that accept a ``type`` argument.
-Note that fully-instantiated generic types are still allowed.
+As of Chapel 1.31 generic types and borrowed classes are no longer valid
+arguments to the versions of ``read`` and ``readln`` that accept a ``type``
+argument. Note that fully-instantiated generic types are still allowed.
 
 Serializer API
 --------------
+
+The API for a Serializer can be split into a few parts:
+1. The part that ``fileWriter`` will invoke
+2. The user-defined ``serialize`` method that Serializers may invoke
+3. The part defined for user interaction inside a ``serialize`` method
+
+The fileWriter-Facing Serializer API
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A Serializer must implement the ``serializeValue`` method:
 
@@ -224,6 +222,19 @@ non-locking.
 By convention Serializers will invoke a ``serialize`` method on records and
 classes, but notably may choose not to do so if the class instance is ``nil``.
 
+The implementation of ``serializeValue`` is expected to handle primitive types
+directly. Those primitive types are:
+- ``numeric`` types (e.g., integers, reals, complex numbers)
+- ``bool`` types
+- ``string`` and ``bytes`` types
+- ``nil`` and ``none`` values
+- ``enum`` types
+
+The argument ``val`` is defined to be a "primitive" type or a type that
+implements either the ``writeSerializable`` or ``serializable`` interfaces,
+both of which define a ``serialize`` method that a Serializer may invoke to
+allow for user-defined serialization of a type.
+
 The 'serialize' Method
 ^^^^^^^^^^^^^^^^^^^^^^
 
@@ -232,30 +243,262 @@ named arguments "writer" and "serializer":
 
 .. code-block:: chapel
 
-   proc T.serialize(writer: fileWriter(?),
-                    ref serializer: writer.serializerType) throws
+   proc T.serialize(writer: fileWriter(?), ref serializer: ?st) throws
+
+For classes, the ``serialize`` method signature must include ``override`` to
+account for the ``serialize`` method on the ``RootClass`` type.
 
 The ``writer`` and ``serializer`` are passed separately to help distinguish the
 method signature from other possible implementations named "serialize", as well
-as to make it slightly more convenient to call methods on the Serializer. A
-future release will standardize other methods on a Serializer that provide ways
-to serialize into common types, like lists or maps.
+as to make it slightly more convenient to call methods on the Serializer.
 
-It is an error for ``writer.serializer`` to refer to a different Serializer
-instance than the ``serializer`` argument. The Serializer is responsible for
-either passing itself to the 'serializer' argument, or if applicable can create
-a new instance of itself to pass. The appropriate choice here depends on the
-degree to which the Serializer relies on internal state, and how that internal
-state must be managed. If a copy must be made, then the ``withSerializer``
-method may be used to provide an alias.
+The ``serializer`` argument does not necessarily need to be of the same type as
+``writer.serializerType``, and simply needs to implement the Serializer API
+and must serialize in a compatible format with ``writer.serializerType``. This
+constraint exists to allow for child classes to pass helper objects created by
+Serializers to parent class ``serialize`` methods. See the
+:ref:`serializer inheritance<serializerInheritance>` section for more
+information.
+
+The User-Facing Serializer API
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The user-facing part of the Serializer API is much larger, and is designed to
+support serializing various "kinds" of types. In particular, the API currently
+supports serializing Classes, Records, Tuples, Arrays, Lists, and Maps. A given
+implementation of a Serializer determines how to represent each kind of type
+in its format. For example, JSON lacks a native representation of tuples, and
+so the ``JSON`` Serializer represents both "list" and "tuple" type-kinds as
+JSON lists (e.g. ``[1, 2, 3]``).
+
+To begin serializing a kind of type, users will invoke one of six available
+"start" methods on a Serializer, each of which return a "helper" object that
+implements an API specific to that kind of type. Note that any of the "start"
+methods may return the same "helper" type as another method, in the case that
+it is useful for the helper to share logic among certain type kinds. For
+example, in the Chapel 1.32 release the ``defaultSerializer`` type returned
+the same helper object type for both Class and Record type kinds.
 
 .. note::
 
-   The set of standard builtin types (e.g. ranges and domains) on which this
-   method may be invoked is currently unstable.
+   In each of these methods, unless otherwise stated, it is entirely up to the
+   author of the Serializer to define their behavior. For example, ``name``
+   arguments for classes and records may not apply to a particular format, and
+   might be ignored.
+
+.. note::
+
+  In each of these groups of methods, it should be noted that the name of each
+  helper object is purely illustrative, and does not indicate the name of a
+  stable interface to be implemented in the future.
+
+The Record Helper
+~~~~~~~~~~~~~~~~~
+
+Users may begin serializing a Record type kind by invoking the ``startRecord``
+method on a Serializer. This method takes a ``name`` argument that represents
+the name of the record type, and a ``size`` argument that represents the
+number of fields to be serialized.
+
+.. code-block:: chapel
+
+  proc Serializer.startRecord(writer: fileWriter(false, this.type), name: string, size: int) : RecordHelper throws;
+
+The returned object must implement the following API:
+
+.. code-block:: chapel
+
+  // Serialize a field named 'name'
+  proc RecordHelper.writeField(name: string, const field: ?) throws;
+
+  // End the record according to the serialization format. 
+  proc RecordHelper.endRecord() throws;
+
+The Tuple Helper
+~~~~~~~~~~~~~~~~~
+
+Users may begin serializing a Tuple type kind by invoking the ``startTuple``
+method on a Serializer. This method takes a ``size`` argument that represents
+the number of elements to be serialized.
+
+.. code-block:: chapel
+
+  proc Serializer.startTuple(writer: fileWriter(false, this.type), size: int) : TupleHelper throws;
+
+The returned object must implement the following API:
+
+.. code-block:: chapel
+
+  // Serialize an element of the tuple.
+  proc TupleHelper.writeElement(const element: ?) throws;
+
+  // End the tuple according to the serialization format.
+  proc TupleHelper.endTuple() throws;
+
+The Array Helper
+~~~~~~~~~~~~~~~~
+
+Users may begin serializing an Array type kind by invoking the ``startArray``
+method on a Serializer. This method takes a ``size`` argument that represents
+the number of array elements to be serialized.
+
+.. code-block:: chapel
+
+  proc Serializer.startArray(writer: fileWriter(false, this.type), size: int) : ArrayHelper throws;
+
+The returned object must implement the following API:
+
+.. code-block:: chapel
+
+  // Serialize the start of a new dimension of size ``size``
+  proc ArrayHelper.startDim(size: int) throws;
+
+  // Serialize the end of the current dimension
+  proc ArrayHelper.endDim() throws;
+
+  // Serializer an element of the array.
+  proc ArrayHelper.writeElement(const element: ?) throws;
+
+  // End the array according to the serialization format.
+  proc ArrayHelper.endArray() throws;
+
+ArrayHelpers may also optionally implement a ``writeBulkElements`` method for
+performance:
+
+.. code-block:: chapel
+
+  // If the format permits, write 'numElements' of 'data' in bulk.
+  proc ArrayHelper.writeBulkElements(data: c_ptr(?eltType), numElements: int) throws;
+
+The List Helper
+~~~~~~~~~~~~~~~
+
+Users may begin serializing a List type kind by invoking the ``startList``
+method on a Serializer. This method takes a ``size`` argument that represents
+the number of list elements to be serialized.
+
+.. code-block:: chapel
+
+  proc Serializer.startList(writer: fileWriter(false, this.type), size: int) : ListHelper throws;
+
+The returned object must implement the following API:
+
+.. code-block:: chapel
+
+  // Serialize the list element.
+  proc ListHelper.writeElement(const element: ?) throws;
+
+  // End the list according to the serialization format.
+  proc ListHelper.endList() throws;
+
+The Map Helper
+~~~~~~~~~~~~~~
+
+Users may begin serializing a Map type kind by invoking the ``startMap``
+method on a Serializer. This method takes a ``size`` argument that represents
+the number of map entries to be serialized.
+
+.. code-block:: chapel
+
+  proc Serializer.startMap(writer: fileWriter(false, this.type), size: int) : MapHelper throws;
+
+The returned object must implement the following API:
+
+.. code-block:: chapel
+
+  // Serialize a map key.
+  proc MapHelper.writeKey(const key: ?) throws;
+
+  // Serialize a map value.
+  proc MapHelper.writeValue(const val: ?) throws;
+
+  // End the map according to the serialization format.
+  proc MapHelper.endMap() throws;
+
+.. _serializerInheritance:
+
+The Class Helper, Serializers, and Inheritance
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Users may begin serializing a Class type kind by invoking the ``startClass``
+method on a Serializer. The ``writer`` argument is passed in and will be used
+by the returned ClassHelper to write serialized output. The ``name`` argument
+is expected to be the name of the class type being serialized. The ``size``
+argument is the number of fields being serialized in the current class,
+excluding any parent fields. Parent fields are not included to preserve
+encapsulation of class implementations and to avoid the inextricable coupling
+of parent and child classes.
+
+.. code-block:: chapel
+
+  proc Serializer.startClass(writer: fileWriter(false, this.type), name: string, size: int) : ClassHelper throws;
+
+The returned object must implement the following API:
+
+.. code-block:: chapel
+
+  // Serialize a field named 'name'
+  proc ClassHelper.writeField(name: string, const field: ?) throws;
+
+  // End the class according to the serialization format
+  proc ClassHelper.endClass() throws;
+
+ClassHelpers are also required to implement *the rest* of the Serializer API
+since they may be passed to parent ``serialize`` methods in the
+compiler-generated default implementation of ``serialize`` methods on classes.
+
+This may be achieved without too much extra effort by using
+:ref:`forwarding<readme-forwarding>` on the stored ``fileWriter``'s
+``.serializer`` accessor. By allowing ClassHelpers to be passed to parent
+``serialize`` methods, formats may capture an inheritance hierarchy if such is
+relevant to their format.
+
+The following code snippet is an example of writing ``serialize`` methods for
+a parent and child class:
+
+.. code-block:: chapel
+
+  // When serializing an instance of 'Parent', 'serializer' could be the same
+  // type as 'writer.serializerType'.
+  //
+  // When serializing an instance of 'Child', 'serializer' could be a
+  // ClassHelper type, and so the ClassHelper must satisfy the Serializer API.
+  override proc Parent.serialize(writer: fileWriter(?), ref serializer) {
+    var ser = serializer.startClass(writer, "Parent", 1);
+    ser.writeField("x", x);
+    ser.endClass();
+  }
+
+  override proc Child.serialize(writer: fileWriter(?), ref serializer) {
+    var ser = serializer.startClass(writer, "Child", 1);
+
+    // pass the ClassHelper 'ser' to the parent 'serialize' method
+    super.serialize(writer, ser);
+
+    ser.writeField("y", y);
+    ser.endClass();
+  }
+
+User Facing API Notes
+~~~~~~~~~~~~~~~~~~~~~
+
+.. note::
+
+   This document does not define what errors these methods may or may not
+   throw.
 
 Deserializer API
 ----------------
+
+The API for a Deserializer can be split into a few parts:
+1. The part that ``fileReader`` will invoke
+2. The user-defined ``deserialize`` method and initializer that Deserializers
+   may invoke
+3. The part defined for user interaction inside a ``deserialize`` method or
+   intializer.
+
+The fileReader-Facing Serializer API
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A Deserializer must implement the following methods, corresponding to the
 versions of ``fileReader.read`` that accept either a type or a value:
@@ -283,6 +526,10 @@ method on records and classes. If a suitable ``deserialize`` method is not
 available, this method may attempt to invoke a suitable initializer and assign
 the result into the value.
 
+For classes, the ``deserializeValue`` method has the freedom to potentially
+free the given class and/or reassign it, depending on the needs of the
+Deserializer.
+
 In both methods, the given ``fileReader`` is guaranteed to have a
 ``deserializerType`` identical to the type whose method was called. The
 ``fileReader`` is also defined to be non-locking.
@@ -300,19 +547,20 @@ including the argument names "reader" and "deserializer":
 .. code-block:: chapel
 
    proc T.init(reader: fileReader(?),
-               ref deserializer: reader.deserializerType) throws
+               ref deserializer: ?dt) throws
 
 By default, the compiler will generate a suitable initializer with this
 signature provided that no other user-defined initializers exist.
 
 The ``reader`` and ``deserializer`` are passed separately to help distinguish
 the method signature from other possible initializers, as well as to make it
-slightly more convenient to call methods on the Deserializer. A future release
-will standardize other methods on a Deserializer that provide ways to
-deserialize into common types, like lists or maps.
+slightly more convenient to call methods on the Deserializer.
 
-As with the ``serialize`` method, it is an error for ``reader.deserializer`` to
-refer to a Deserializer other than the ``deserializer`` argument.
+The ``deserializer`` argument must implement the Deserializer API and must
+deserialize in a compatible format with ``reader.deserializerType``. This
+constraint exists to allow for child classes to pass helper objects created
+by Deserializers to parent initializers. See the previous section on
+:ref:`serializer inheritance<serializerInheritance>` for more information.
 
 Generic types have a slightly more complex initializer signature, in that there
 must be a ``type`` or ``param`` argument for each ``type`` or ``param`` field.
@@ -356,18 +604,214 @@ its arguments to have the names "reader" and "deserializer":
 .. code-block:: chapel
 
    proc ref T.deserialize(reader: fileReader(?),
-                          ref deserializer: reader.deserializerType) throws
+                          ref deserializer: ?dt) throws
+
+For classes, this signature must be slightly different:
+
+.. code-block:: chapel
+
+   override proc T.deserialize(reader: fileReader(?),
+                               ref deserializer: ?dt) throws
 
 By default, the compiler will generate a suitable ``deserialize`` method with
 this signature provided.
 
-As with the ``serialize`` method, it is an error for ``reader.deserializer`` to
-refer to a Deserializer other than the ``deserializer`` argument.
+The User-Facing Serializer API
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Like the Serializer API, the user-facing part of the Deserializer API is
+relatively large and supports the same set of type kinds as a Serializer. Also
+like the Serializer API, the Deserializer API works through the creation and
+use of helper objects returned by various "start" methods.
+
+The Deserializer API is also slightly larger due to the need for "type" and
+"by reference" versions of methods like ``readElement``, to match the desired
+behavior of the originating ``fileReader.read`` call. The List and Map type
+kinds also support a ``hasMore`` method to help users know when they can stop
+reading.
 
 .. note::
 
-   The set of standard builtin types (e.g. ranges and domains) on which this
-   method may be invoked is currently unstable.
+   In each of these methods, unless otherwise stated, it is entirely up to the
+   author of the Deserializer to define their behavior. For example, ``name``
+   arguments for classes and records may not apply to a particular format, and
+   might be ignored.
+
+.. note::
+
+  In each of these groups of methods, it should be noted that the name of each
+  helper object is purely illustrative, and does not indicate the name of a
+  stable interface to be implemented in the future.
+
+The Class Helper
+~~~~~~~~~~~~~~~~
+
+Users may begin deserializing a Class type kind by invoking the ``startClass``
+method on a Deserializer. This method takes a ``name`` argument that represents
+the name of the class type.
+
+.. code-block:: chapel
+
+  proc Deserializer.startClass(reader: fileReader(false, this.type), name: string) : ClassHelper throws;
+
+The returned object must implement the following API:
+
+.. code-block:: chapel
+
+  // Deserialize a field named 'name', returns a value of type ``fieldType``
+  proc ClassHelper.readField(name: string, type fieldType) : fieldType throws;
+
+  // Deserialize a field named 'name' in-place.
+  proc ClassHelper.readField(name: string, ref field :?) throws;
+
+  // End the class according to the deserialization format.
+  proc ClassHelper.endClass() throws;
+
+Like in the Serializer API, the ClassHelper must implement *the rest* of the
+Deserializer API to allow for the ClassHelper to be passed to parent
+initializers and parent ``deserialize`` methods.
+
+The Record Helper
+~~~~~~~~~~~~~~~~
+
+Users may begin deserializing a Record type kind by invoking the
+``startRecord`` method on a Deserializer. This method takes a ``name`` argument
+that represents the name of the record type.
+
+.. code-block:: chapel
+
+  proc Deserializer.startRecord(reader: fileReader(false, this.type), name: string) : RecordHelper throws;
+
+The returned object must implement the following API:
+
+.. code-block:: chapel
+
+  // Deserialize a field named 'name', returns a value of type ``fieldType``
+  proc RecordHelper.readField(name: string, type fieldType) : fieldType throws;
+
+  // Deserialize a field named 'name' in-place.
+  proc RecordHelper.readField(name: string, ref field :?) throws;
+
+  // End the record according to the deserialization format.
+  proc RecordHelper.endRecord() throws;
+
+The Tuple Helper
+~~~~~~~~~~~~~~~~
+
+Users may begin deserializing a Tuple type kind by invoking the ``startTuple``
+method on a Deserializer.
+
+.. code-block:: chapel
+
+  proc Deserializer.startTuple(reader: fileReader(false, this.type)) : TupleHelper throws;
+
+The returned object must implement the following API:
+
+.. code-block:: chapel
+
+  // Deserialize an element of the tuple, return a value of type ``eltType``
+  proc TupleHelper.readElement(type eltType) : eltType throws;
+
+  // Deserialize ``element`` as a tuple element in-place.
+  proc TupleHelper.readElement(ref element: ?) throws;
+
+  // End the tuple according to the deserialization format.
+  proc TupleHelper.endTuple() throws;
+
+The Array Helper
+~~~~~~~~~~~~~~~~
+
+Users may begin deserializing an Array type kind by invoking the ``startArray``
+method on a Deserializer.
+
+.. code-block:: chapel
+
+  proc Deserializer.startArray(reader: fileReader(false, this.type)) : ArrayHelper throws;
+
+The returned object must implement the following API:
+
+.. code-block:: chapel
+
+  // Deserialize an element of the array, return a value of type ``eltType``
+  proc ArrayHelper.readElement(type eltType) : eltType throws;
+
+  // Deserialize ``element`` as an array element in-place.
+  proc ArrayHelper.readElement(ref element: ?) throws;
+
+  // Start deserializing a new dimension
+  proc ArrayHelper.startDim() throws;
+
+  // End the array dimension according to the deserialization format.
+  proc ArrayHelper.endDim() throws;
+
+  // End the array according to the deserialization format.
+  proc ArrayHelper.endArray() throws;
+
+ArrayHelpers may also optionally implement a ``readBulkElements`` method for
+performance:
+
+.. code-block:: chapel
+
+  // If the format permits, write 'numElements' of 'data' in bulk.
+  proc ArrayHelper.readBulkElements(data: c_ptr(?eltType), n: int) throws;
+
+The List Helper
+~~~~~~~~~~~~~~~~
+
+Users may begin deserializing a List type kind by invoking the ``startList``
+method on a Deserializer.
+
+.. code-block:: chapel
+
+  proc Deserializer.startList(reader: fileReader(false, this.type)) : ListHelper throws;
+
+The returned object must implement the following API:
+
+.. code-block:: chapel
+
+  // Deserialize an element of the list, return a value of type ``eltType``
+  proc ListHelper.readElement(type eltType) : eltType throws;
+
+  // Deserialize ``element`` as a list element in-place.
+  proc ListHelper.readElement(ref element: ?) throws;
+
+  // Returns 'true' if there are more elements to deserialize
+  proc ListHelper.hasMore() : bool throws;
+
+  // End the list according to the deserialization format.
+  proc ListHelper.endList() throws;
+
+The Map Helper
+~~~~~~~~~~~~~~~~
+
+Users may begin deserializing a Map type kind by invoking the ``startMap``
+method on a Deserializer.
+
+.. code-block:: chapel
+
+  proc Deserializer.startMap(reader: fileReader(false, this.type)) : MapHelper throws;
+
+The returned object must implement the following API:
+
+.. code-block:: chapel
+
+  // Deserialize a key of the map, return a value of type ``keyType``
+  proc MapHelper.readKey(type keyType) : keyType throws;
+
+  // Deserialize ``key`` as a map key in-place.
+  proc MapHelper.readKey(ref key: ?) throws;
+
+  // Deserialize a value of the map, return a value of type ``valType``
+  proc MapHelper.readValue(type valType) : valType throws;
+
+  // Deserialize ``value`` as a map value in-place.
+  proc MapHelper.readValue(ref value: ?) throws;
+
+  // Returns 'true' if there are more map entries to deserialize
+  proc MapHelper.hasMore() : bool throws;
+
+  // End the map according to the deserialization format.
+  proc MapHelper.endMap() throws;
 
 Compiler-Generated Methods
 --------------------------
@@ -381,12 +825,3 @@ the ``deserialize`` method, or the deserializing initializer, then the compiler
 may choose to not automatically generate any of the other unimplemented
 methods. This is out of concern that the user has intentionally deviated from
 the compiler's default implementation of serialization and deserialization.
-
-Until it is determined that ``readThis`` and ``writeThis`` will be deprecated,
-the compiler-generated versions of ``serialize`` and ``deserialize`` methods
-will call any user-defined ``readThis`` or ``writeThis`` methods available on
-the same type. If this behavior is undesirable, users may implement their own
-``serialize`` and ``deserialize`` methods, or they may use the following
-compiler flags:
-- ``--no-io-serialize-writeThis``
-- ``--no-io-deserialize-readThis``

--- a/doc/rst/technotes/ioSerializers.rst
+++ b/doc/rst/technotes/ioSerializers.rst
@@ -196,6 +196,8 @@ As of Chapel 1.31 generic types and borrowed classes are no longer valid
 arguments to the versions of ``read`` and ``readln`` that accept a ``type``
 argument. Note that fully-instantiated generic types are still allowed.
 
+.. _io-serializer-API:
+
 Serializer API
 --------------
 
@@ -246,6 +248,9 @@ named arguments "writer" and "serializer":
 
    proc T.serialize(writer: fileWriter(?), ref serializer: ?st) throws
 
+Types implementing this method must also indicate that they satisfy the
+``writeSerializable`` interface.
+
 For classes, the ``serialize`` method signature must include ``override`` to
 account for the ``serialize`` method on the ``RootClass`` type.
 
@@ -260,6 +265,8 @@ constraint exists to allow for child classes to pass helper objects created by
 Serializers to parent class ``serialize`` methods. See the
 :ref:`serializer inheritance<serializerInheritance>` section for more
 information.
+
+.. _io-serializer-user-API:
 
 The User-Facing Serializer API
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -488,6 +495,8 @@ User Facing API Notes
    This document does not define what errors these methods may or may not
    throw.
 
+.. _io-deserializer-API:
+
 Deserializer API
 ----------------
 
@@ -530,6 +539,13 @@ For classes, the ``deserializeValue`` method has the freedom to potentially
 free the given class and/or reassign it, depending on the needs of the
 Deserializer.
 
+The arguments ``val`` or ``readType`` are defined to be a "primitive" type or a
+type that implements at least one of the following interfaces:
+
+- ``readDeserializable``
+- ``initDeserializable``
+- ``serializable``
+
 In both methods, the given ``fileReader`` is guaranteed to have a
 ``deserializerType`` identical to the type whose method was called. The
 ``fileReader`` is also defined to be non-locking.
@@ -548,6 +564,9 @@ including the argument names "reader" and "deserializer":
 
    proc T.init(reader: fileReader(?),
                ref deserializer: ?dt) throws
+
+Types implementing this method must also indicate that they satisfy the
+``initDeserializable`` interface.
 
 By default, the compiler will generate a suitable initializer with this
 signature provided that no other user-defined initializers exist.
@@ -616,8 +635,13 @@ For classes, this signature must be slightly different:
 By default, the compiler will generate a suitable ``deserialize`` method with
 this signature provided.
 
-The User-Facing Serializer API
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Types implementing this method must also indicate that they satisfy the
+``readDeserializable`` interface.
+
+.. _io-deserializer-user-API:
+
+The User-Facing Deserializer API
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Like the Serializer API, the user-facing part of the Deserializer API is
 relatively large and supports the same set of type kinds as a Serializer. Also
@@ -813,15 +837,13 @@ The returned object must implement the following API:
   // End the map according to the deserialization format.
   proc MapHelper.endMap() throws;
 
-Compiler-Generated Methods
---------------------------
+The 'serializable' Interface
+----------------------------
 
-Generation of the deserializing initializer, or the ``serialize`` and
-``deserialize`` methods can be disabled with the flag
-``--no-io-gen-serialization``.
+The ``serializable`` interface mentioned on this document is intended to be
+an interface that requires implementation of all three kinds of user-defined
+methods: ``serialize``, ``deserialize``, and a deserializing initializer.
 
-If the compiler sees a user-defined implementation of the ``serialize`` method,
-the ``deserialize`` method, or the deserializing initializer, then the compiler
-may choose to not automatically generate any of the other unimplemented
-methods. This is out of concern that the user has intentionally deviated from
-the compiler's default implementation of serialization and deserialization.
+A formal definition of this interface is pending, following the standardization
+of interfaces in the language.
+

--- a/doc/rst/technotes/ioSerializers.rst
+++ b/doc/rst/technotes/ioSerializers.rst
@@ -200,6 +200,7 @@ Serializer API
 --------------
 
 The API for a Serializer can be split into a few parts:
+
 1. The part that ``fileWriter`` will invoke
 2. The user-defined ``serialize`` method that Serializers may invoke
 3. The part defined for user interaction inside a ``serialize`` method
@@ -491,11 +492,10 @@ Deserializer API
 ----------------
 
 The API for a Deserializer can be split into a few parts:
+
 1. The part that ``fileReader`` will invoke
-2. The user-defined ``deserialize`` method and initializer that Deserializers
-   may invoke
-3. The part defined for user interaction inside a ``deserialize`` method or
-   intializer.
+2. The user-defined ``deserialize`` method and initializer that Deserializers may invoke
+3. The part defined for user interaction inside a ``deserialize`` method or intializer.
 
 The fileReader-Facing Serializer API
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -672,7 +672,7 @@ Deserializer API to allow for the ClassHelper to be passed to parent
 initializers and parent ``deserialize`` methods.
 
 The Record Helper
-~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
 
 Users may begin deserializing a Record type kind by invoking the
 ``startRecord`` method on a Deserializer. This method takes a ``name`` argument
@@ -756,7 +756,7 @@ performance:
   proc ArrayHelper.readBulkElements(data: c_ptr(?eltType), n: int) throws;
 
 The List Helper
-~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 
 Users may begin deserializing a List type kind by invoking the ``startList``
 method on a Deserializer.
@@ -782,7 +782,7 @@ The returned object must implement the following API:
   proc ListHelper.endList() throws;
 
 The Map Helper
-~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 
 Users may begin deserializing a Map type kind by invoking the ``startMap``
 method on a Deserializer.

--- a/modules/standard/ChapelIO.chpl
+++ b/modules/standard/ChapelIO.chpl
@@ -96,7 +96,7 @@ and ``fileWriter`` arguments. For example:
 Using Serializers and Deserializers
 -----------------------------------
 
-:ref:`Serializers<io-serializer-user-API>` and 
+:ref:`Serializers<io-serializer-user-API>` and
 :ref:`Deserializers<io-deserializer-user-API>` support a variety of methods
 to support serializing various kinds of types. These methods can be used
 to serialize or deserialize a type in a format-agnostic way. For example,
@@ -196,7 +196,7 @@ The readThis() and writeThis() Methods
 
 .. warning::
 
-  ``readThis`` and ``writeThis`` methods are deprecated. Please use 
+  ``readThis`` and ``writeThis`` methods are deprecated. Please use
   :ref:`serialize and deserialize<serialize-deserialize>` methods instead.
   Until ``readThis`` and ``writeThis`` methods are removed, any
   compiler-generated implementations of the 'serialize' and 'deserialize'

--- a/modules/standard/ChapelIO.chpl
+++ b/modules/standard/ChapelIO.chpl
@@ -38,10 +38,170 @@ of a Hello World program:
  // outputs
  // Hello, World!
 
+.. _serialize-deserialize:
+
+The 'serialize' and 'deserialize' Methods
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A Chapel program can implement ``serialize`` and ``deserialize`` methods
+on a custom data type to define how that type is deserialized from a
+``fileReader`` or serialized to a ``fileWriter``. The method signatures for
+non-class types are:
+
+.. code-block:: chapel
+
+   proc T.serialize(writer: fileWriter(locking=false, ?),
+                    ref serializer: ?st) throws
+
+   proc ref T.deserialize(reader: fileReader(locking=false, ?),
+                          ref deserializer: ?dt) throws
+
+The signatures for classes are slightly different:
+
+.. code-block:: chapel
+
+   override proc T.serialize(writer: fileWriter(locking=false, ?),
+                             ref serializer: ?st) throws
+
+   override proc T.deserialize(reader: fileReader(locking=false, ?),
+                               ref deserializer: ?dt) throws
+
+The ``serializer`` and ``deserializer`` arguments must satisfy the
+:ref:`Serializer API<io-serializer-API>` and the
+:ref:`Deserializer API<io-deserializer-API>`, respectively.
+
+Basic Usage
+-----------
+
+Implementations of ``serialize`` and ``deserialize`` methods are not
+necessarily required to utilize their ``serializer`` and ``deserializer``
+arguments, and can instead trivially read and write from their ``fileReader``
+and ``fileWriter`` arguments. For example:
+
+.. code-block:: chapel
+
+  // A record 'R' that serializes as an integer
+  record R : writeSerializable {
+    var x : int;
+
+    proc serialize(writer: fileWriter(locking=false, ?),
+                   ref serializer: ?st) {
+      writer.write(x);
+    }
+  }
+
+  var val = new R(5);
+  writeln(val); // prints '5'
+
+Using Serializers and Deserializers
+-----------------------------------
+
+:ref:`Serializers<io-serializer-user-API>` and 
+:ref:`Deserializers<io-deserializer-user-API>` support a variety of methods
+to support serializing various kinds of types. These methods can be used
+to serialize or deserialize a type in a format-agnostic way. For example,
+consider a simple 'Point' type:
+
+.. code-block:: chapel
+
+  record Point : writeSerializable {
+    var x : int;
+    var y : int;
+  }
+
+Serializers and Deserializers have "start" methods that begin serialization
+or deserialization of a type, and then return a helper object that implements
+methods to continue the process. To begin serializing ``Point`` as a tuple,
+a user may invoke the ``startTuple`` method on the ``serializer``, passing in
+the ``fileWriter`` to use when writing serialized output and the number of
+elements in the tuple. The returned value from ``startTuple`` is a helper
+object that implements ``writeElement`` and ``endTuple`` methods:
+
+.. code-block:: chapel
+
+    proc Point.serialize(writer: fileWriter(locking=false, ?),
+                         ref serializer: ?st) {
+      // Start serializing and get the helper object
+      // '2' represents the number of tuple elements to be serialized
+      var ser = serializer.startTuple(writer, 2);
+
+      ser.writeElement(x); // serialize 'x' as a tuple element
+      ser.writeElement(y); // serialize 'y' as a tuple element
+
+      // End serialization of the tuple
+      ser.endTuple();
+    }
+
+Now, when using different Serializers like the :type:`~IO.defaultSerializer` or
+the :type:`~JSON.jsonSerializer`, the ``Point`` type can be serialized without
+introducing special cases for each format:
+
+.. code-block:: chapel
+
+  use IO, JSON;
+
+  var p = new Point(4, 2);
+
+  // Prints '(4, 2)' in the default serialization format
+  stdout.writeln(p);
+
+  // Prints '[4, 2]' in the JSON serialization format
+  var jsonWriter = stdout.withSerializer(jsonSerializer);
+  jsonWriter.writeln(p);
+
+Please refer to the :ref:`IO Serializers<ioSerializers>` technote for more
+detail on the various kinds of types that can be serialized. As of Chapel 1.32
+the supported type kinds are Classes, Records, Tuples, Arrays, Lists, and Maps.
+
+Compiler-Generated Default Methods
+----------------------------------
+
+Default ``serialize`` methods are created for all types for which a
+user-defined ``serialize`` method is not provided.
+
+Classes will be serialized as a 'Class' type kind using the Serializer API,
+and will invoke their parent ``serialize`` method before serializing their
+own fields.
+
+Records will be serialized as a 'Record' type kind using the Serializer API,
+and will serialize each field in the record.
+
+Default ``deserialize`` methods are created for all types for which a
+user-defined ``deserialize`` method is not provided.  The default
+``deserialize`` methods will mirror the relevant API calls in the default
+``serialize`` methods.
+
+For more information on the default serialization format, please refer to the
+:type:`~IO.defaultSerializer` and :type:`~IO.defaultDeserializer` types.
+
+If the compiler sees a user-defined implementation of the ``serialize`` method,
+the ``deserialize`` method, or the deserializing initializer, then the compiler
+may choose to not automatically generate any of the other unimplemented
+methods. This is out of concern that the user has intentionally deviated from
+the default implementation of serialization and deserialization.
+
+Types with compiler-generated versions of these methods do not need to
+explicitly indicate that they satisfy any of the relevant serialization
+interfaces (such as ``writeSerializable``).
+
+.. note::
+
+  Note that it is not currently possible to read and write circular
+  data structures with these mechanisms.
+
 .. _readThis-writeThis:
 
 The readThis() and writeThis() Methods
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. warning::
+
+  ``readThis`` and ``writeThis`` methods are deprecated. Please use 
+  :ref:`serialize and deserialize<serialize-deserialize>` methods instead.
+  Until ``readThis`` and ``writeThis`` methods are removed, any
+  compiler-generated implementations of the 'serialize' and 'deserialize'
+  methods will attempt to invoke ``readThis`` and ``writeThis`` methods for
+  the sake of compatibility.
 
 A Chapel program can implement ``readThis`` and ``writeThis`` methods on a
 custom data type to define how that type is read from a fileReader or written to
@@ -129,14 +289,6 @@ appropriately before the elements can be read.
   Note that it is not currently possible to read and write circular
   data structures with these mechanisms.
 
-.. _serialize-deserialize:
-
-The `serialize` and `deserialize` Methods
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. warning::
-
-  This section is currently a placeholder for forthcoming documentation.
 
  */
 pragma "module included by default"
@@ -798,6 +950,7 @@ module ChapelIO {
   }
   implements writeSerializable(_tuple);
 
+  @chpldoc.nodoc
   proc _iteratorRecord.writeThis(f) throws {
     var first: bool = true;
     for e in this {


### PR DESCRIPTION
This PR updates the serializers technote to include the full Serializer and Deserializer API, as well as information concerning the relevant interfaces (e.g. ``writeSerializable``).