### PR TITLE
Fixup deprecated readBinary overloads

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -8726,7 +8726,7 @@ proc fileReader.readBinary(ref data: [] ?t, param endian = ioendian.native): boo
   Binary values of the type ``data.eltType`` are consumed from the fileReader
   until ``data`` is full or EOF is reached.
 
-  Note that this routine currently requires a 1D rectangular non-strided array.
+  Note that this routine currently requires a local rectangular non-strided array.
 
   :arg data: an array to read into – existing values are overwritten.
   :arg endian: :type:`ioendian` compile-time argument that specifies the byte
@@ -8799,7 +8799,7 @@ proc fileReader.readBinary(ref data: [?d] ?t, param endian = ioendian.native): i
    until ``data`` is full or EOF is reached. An :class:`~OS.UnexpectedEofError`
    is thrown if EOF is reached before the array is filled.
 
-   Note that this routine currently requires a local rectangular non-strided array.
+   Note that this routine currently requires a 1D rectangular non-strided array.
 
    :arg data: an array to read into – existing values are overwritten.
    :arg endian: :type:`ioendian` specifies the byte order in which

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -8681,7 +8681,7 @@ config param ReadBinaryArrayReturnInt = false;
 @deprecated(notes="The variant of `readBinary(data: [])` that returns a `bool` is deprecated; please recompile with `-sReadBinaryArrayReturnInt=true` to use the new variant")
 proc fileReader.readBinary(ref data: [] ?t, param endian = ioendian.native): bool throws
   where ReadBinaryArrayReturnInt == false &&
-    isSuitableForBinaryReadWrite(data) && data.strides == strideKind.one && (
+    data.rank == 1 && data.isRectangular() && data.strides == strideKind.one && (
     isIntegralType(t) || isRealType(t) || isImagType(t) || isComplexType(t) )
 {
   var e : errorCode = 0,
@@ -8815,7 +8815,7 @@ proc fileReader.readBinary(ref data: [?d] ?t, param endian = ioendian.native): i
 @deprecated(notes="The variant of `readBinary(data: [])` that returns a `bool` is deprecated; please recompile with `-sReadBinaryArrayReturnInt=true` to use the new variant")
 proc fileReader.readBinary(ref data: [] ?t, endian: ioendian):bool throws
   where ReadBinaryArrayReturnInt == false &&
-    isSuitableForBinaryReadWrite(data) && data.strides == strideKind.one && (
+    data.rank == 1 && data.isRectangular() && data.strides == strideKind.one && (
     isIntegralType(t) || isRealType(t) || isImagType(t) || isComplexType(t) )
 {
   var rv: bool = false;

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -8445,7 +8445,7 @@ proc fileWriter.writeBinary(const ref data: [?d] ?t, param endian:ioendian = ioe
 
 @chpldoc.nodoc
 proc fileWriter.writeBinary(const ref data: [?d] ?t, param endian:ioendian = ioendian.native) throws {
-  compilerError("writeBinary() only supports local, rectangular, non-strided arrays");
+  compilerError("writeBinary() only supports local, rectangular, non-strided arrays or simple types");
 }
 
 
@@ -8484,7 +8484,7 @@ proc fileWriter.writeBinary(const ref data: [] ?t, endian:ioendian) throws
 @chpldoc.nodoc
 proc fileWriter.writeBinary(const ref data: [] ?t, endian:ioendian) throws
 {
-  compilerError("writeBinary() only supports local, rectangular, non-strided arrays");
+  compilerError("writeBinary() only supports local, rectangular, non-strided arrays of simple types");
 }
 
 /*
@@ -8878,13 +8878,25 @@ proc fileReader.readBinary(ref data: [] ?t, endian: ioendian):int throws
 @chpldoc.nodoc
 proc fileReader.readBinary(ref data: [] ?t, endian: ioendian):int throws
 {
-  compilerError("readBinary() only supports local, rectangular, non-strided arrays");
+  if ReadBinaryArrayReturnInt == true {
+    compilerError("readBinary() only supports local, rectangular, non-strided ",
+                  "arrays of simple types");
+  } else {
+    compilerError("readBinary() only supports 1-dimensional, rectangular, ",
+                  "non-strided arrays of simple types");
+  }
 }
 
 @chpldoc.nodoc
 proc fileReader.readBinary(ref data: [] ?t, param endian = ioendian.native): bool throws
 {
-  compilerError("readBinary() only supports local, rectangular, non-strided arrays");
+  if ReadBinaryArrayReturnInt == true {
+    compilerError("readBinary() only supports local, rectangular, non-strided ",
+                  "arrays of simple types");
+  } else {
+    compilerError("readBinary() only supports 1-dimensional, rectangular, ",
+                  "non-strided arrays of simple types");
+  }
 }
 
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -8445,7 +8445,7 @@ proc fileWriter.writeBinary(const ref data: [?d] ?t, param endian:ioendian = ioe
 
 @chpldoc.nodoc
 proc fileWriter.writeBinary(const ref data: [?d] ?t, param endian:ioendian = ioendian.native) throws {
-  compilerError("writeBinary() only supports local, rectangular, non-strided arrays or simple types");
+  compilerError("writeBinary() only supports local, rectangular, non-strided arrays of simple types");
 }
 
 

--- a/test/library/standard/IO/writeBinary/multiDimArraySlices-block.good
+++ b/test/library/standard/IO/writeBinary/multiDimArraySlices-block.good
@@ -1,1 +1,1 @@
-multiDimArraySlices.chpl:15: error: writeBinary() only supports local, rectangular, non-strided arrays
+multiDimArraySlices.chpl:15: error: writeBinary() only supports local, rectangular, non-strided arrays of simple types

--- a/test/library/standard/IO/writeBinary/multiDimArraySlices-old.chpl
+++ b/test/library/standard/IO/writeBinary/multiDimArraySlices-old.chpl
@@ -1,0 +1,32 @@
+use IO, BlockDist;
+
+config const useCol = false;
+config param useBlock = false;
+
+var Dom = if useBlock then blockDist.createDomain({1..10, 1..10})
+                      else {1..10, 1..10};
+var Slice = if useCol then {1..10, 2..2} else {2..2, 1..10};
+
+var A: [Dom] real = [(i,j) in Dom] i * 100 + j/100.0;
+
+writeln(A);
+
+var outfile = open("out.bin", ioMode.cw);
+outfile.writer().writeBinary(A[Slice]);
+outfile.close();
+
+var B: [Dom] real;
+
+var infile = open("out.bin", ioMode.r);
+infile.reader().readBinary(B[Slice]);
+infile.close();
+
+writeln(B);
+
+const equalIn = + reduce (A[Slice] == B[Slice]);
+const equalZero = + reduce (B == 0);
+
+if equalIn + equalZero != Dom.size then
+  halt("Mismatch between A and B");
+else
+  writeln("Matched!");

--- a/test/library/standard/IO/writeBinary/multiDimArraySlices-old.compopts
+++ b/test/library/standard/IO/writeBinary/multiDimArraySlices-old.compopts
@@ -1,0 +1,1 @@
+-sReadBinaryArrayReturnInt=false

--- a/test/library/standard/IO/writeBinary/multiDimArraySlices-old.good
+++ b/test/library/standard/IO/writeBinary/multiDimArraySlices-old.good
@@ -1,0 +1,1 @@
+multiDimArraySlices-old.chpl:21: error: readBinary() only supports 1-dimensional, rectangular, non-strided arrays of simple types

--- a/test/library/standard/IO/writeBinary/readBlockArray-old.chpl
+++ b/test/library/standard/IO/writeBinary/readBlockArray-old.chpl
@@ -1,0 +1,18 @@
+// There's no 'new' version of this test because the updated behavior of
+// read/writeBinary is to disallow non-DR arrays.
+//
+// This test just serves to preserve the "normal" behavior of the deprecated
+// readBinary for arrays. Once the deprecated method is no longer present,
+// this test can be removed.
+
+use IO, BlockDist;
+
+var Dom = blockDist.createDomain({1..10});
+
+var A: [Dom] real = [i in Dom] i;
+
+var infile = open("out.bin", ioMode.r);
+infile.reader().readBinary(A);
+infile.close();
+
+writeln(A);

--- a/test/library/standard/IO/writeBinary/readBlockArray-old.compopts
+++ b/test/library/standard/IO/writeBinary/readBlockArray-old.compopts
@@ -1,0 +1,1 @@
+-sReadBinaryArrayReturnInt=false

--- a/test/library/standard/IO/writeBinary/readBlockArray-old.good
+++ b/test/library/standard/IO/writeBinary/readBlockArray-old.good
@@ -1,0 +1,1 @@
+readBlockArray-old.chpl:15: warning: The variant of `readBinary(data: [])` that returns a `bool` is deprecated; please recompile with `-sReadBinaryArrayReturnInt=true` to use the new variant

--- a/test/library/standard/IO/writeBinary/readWriteMultidimArray-block.good
+++ b/test/library/standard/IO/writeBinary/readWriteMultidimArray-block.good
@@ -1,1 +1,1 @@
-readWriteMultidimArray.chpl:13: error: writeBinary() only supports local, rectangular, non-strided arrays
+readWriteMultidimArray.chpl:13: error: writeBinary() only supports local, rectangular, non-strided arrays of simple types

--- a/test/library/standard/IO/writeBinary/readWriteMultidimArray-old-block.good
+++ b/test/library/standard/IO/writeBinary/readWriteMultidimArray-old-block.good
@@ -1,0 +1,1 @@
+readWriteMultidimArray-old.chpl:13: error: writeBinary() only supports local, rectangular, non-strided arrays or simple types

--- a/test/library/standard/IO/writeBinary/readWriteMultidimArray-old-block.good
+++ b/test/library/standard/IO/writeBinary/readWriteMultidimArray-old-block.good
@@ -1,1 +1,1 @@
-readWriteMultidimArray-old.chpl:13: error: writeBinary() only supports local, rectangular, non-strided arrays or simple types
+readWriteMultidimArray-old.chpl:13: error: writeBinary() only supports local, rectangular, non-strided arrays of simple types

--- a/test/library/standard/IO/writeBinary/readWriteMultidimArray-old-dr.good
+++ b/test/library/standard/IO/writeBinary/readWriteMultidimArray-old-dr.good
@@ -1,0 +1,1 @@
+readWriteMultidimArray-old.chpl:19: error: readBinary() only supports 1-dimensional, rectangular, non-strided arrays of simple types

--- a/test/library/standard/IO/writeBinary/readWriteMultidimArray-old.chpl
+++ b/test/library/standard/IO/writeBinary/readWriteMultidimArray-old.chpl
@@ -1,0 +1,27 @@
+use IO, BlockDist;
+
+config param useBlock = false;
+
+var Dom = if useBlock then blockDist.createDomain({1..10, 1..10})
+                      else {1..10, 1..10};
+
+var A: [Dom] real = [(i,j) in Dom] i * 100 + j/100.0;
+
+writeln(A);
+
+var outfile = open("out.bin", ioMode.cw);
+outfile.writer().writeBinary(A);
+outfile.close();
+
+var B: [Dom] real;
+
+var infile = open("out.bin", ioMode.r);
+infile.reader().readBinary(B);
+infile.close();
+
+writeln(B);
+
+if + reduce (A == B) != Dom.size then
+  halt("Mismatch between A and B");
+else
+  writeln("Matched!");

--- a/test/library/standard/IO/writeBinary/readWriteMultidimArray-old.compopts
+++ b/test/library/standard/IO/writeBinary/readWriteMultidimArray-old.compopts
@@ -1,0 +1,2 @@
+-sReadBinaryArrayReturnInt=false                  # readWriteMultidimArray-old-dr.good
+-sReadBinaryArrayReturnInt=false -suseBlock=true  # readWriteMultidimArray-old-block.good


### PR DESCRIPTION
PR #23396 modified the `where` clauses of deprecated overloads, but didn't change their implementations (since they were deprecated, and shouldn't be updated). This was effectively a change in behavior for these routines, since they would now accept multi-dimensional arrays (but not have any logic to throw etc.). This PR restores the old `where` to limit arguments to the _old_ `readBinary` to 1-dimensional, rectangular arrays (as opposed to the new implementation's N-dimensional _local_ rectangular arrays). 

Since the new no-`where` overload introduced by Brad serves to prevent accidental promotion for arrays of unsupported types, I've kept it. However, I've specialized the message to be consistent with the `where` clause of the current `readBinary` overload, be it the "old" or the "new" one. 

I've also updated the error message slightly to be more helpful in the case the user tries to use `readBinary`/`writeBinary` to write out an array of non-numbers (e.g. records). That array might be local and rectangular (so the error message about only supporting "local, rectangular" arrays is quite confusing), but it isn't made up of the allowed types.

Reviewed by @benharsh -- thanks!

## Testing
- [x] gasnet paratest