### PR TITLE
Skip a test with cpu-as-device mode

### DIFF
--- a/test/gpu/native/basics/bug23045.skipif
+++ b/test/gpu/native/basics/bug23045.skipif
@@ -1,0 +1,4 @@
+# This test is verbatim from an issue and uses extern `__device__` functions
+# that doesn't compile with the cpu backend. The addressed issue is covered in
+# other unit tests in this directory.
+CHPL_GPU==cpu


### PR DESCRIPTION
The test in question is the code from https://github.com/chapel-lang/chapel/issues/23045 which has `__device__` functions in an extern block. That doesn't compile in cpu-as-device mode. This PR adds a skipif for that. 