### PR TITLE
Minor doc touch-ups

### DIFF
--- a/doc/rst/language/spec/error-handling.rst
+++ b/doc/rst/language/spec/error-handling.rst
@@ -31,17 +31,6 @@ and before any ``where`` clauses.
 The statements following a throw statement in the same block
 are ignored by the compiler because they cannot be executed.
 
-..
-
-   *Open issue*.
-
-   The current implementation makes an exception to this rule: it does
-   consider the statements following a throw statement or a call to
-   `halt()` in the case these statements include a return
-   statement. This is done to support legacy codes that use return
-   statement(s) to establish the return type implicitly.
-   Should we remove this exception?
-
 Only ``owned`` instances of a type inheriting from ``Error`` can be
 thrown.
 

--- a/doc/rst/language/spec/statements.rst
+++ b/doc/rst/language/spec/statements.rst
@@ -745,8 +745,17 @@ string.  Only ``require`` statements in code that the compiler considers
 executable will be processed.  Thus, a ``require`` statement
 guarded by a ``param`` conditional that the compiler folds out, or
 in a module that does not appear in the program's ``use``
-statements will not be added to the program's requirements.  For
-example, the following code either requires ``foo.h`` or whatever
+statements will not be added to the program's requirements.  
+
+   *Rationale*.
+
+   Currently, the Chapel compiler parses all ``.chpl`` files early
+   in compilation, prior to resolving param strings, calls, or control flow.
+   This imposes more restrictions on ``.chpl``-requiring statements
+   than on other requirements that matter only during the backend compilation.
+   We may consider relaxing these restrictions in the future.
+
+For example, the following code either requires ``foo.h`` or whatever
 requirement is specified by *defaultHeader* (``bar.h`` by default)
 depending on the value of *requireFoo*:
 

--- a/test/release/examples/primers/distributions.chpl
+++ b/test/release/examples/primers/distributions.chpl
@@ -6,7 +6,7 @@
   distributions.
 
   Local vs. Distributed Domains and Arrays
-  ========================================
+  ----------------------------------------
 
   In Chapel, *distributions* are recipes for implementing arrays and
   their index sets (*domains*).  Each distribution indicates how a
@@ -39,7 +39,7 @@
   implementation.
 
   Properties of Typical Distributions
-  ===================================
+  -----------------------------------
 
   Distributions for rectangular arrays can be thought of as
   distributing a *d*-dimensional space of possible indices over a
@@ -69,7 +69,7 @@
   they all share the same distribution.
 
   Getting Started with Block and Cyclic Distributions
-  ===================================================
+  ---------------------------------------------------
 
   In this primer, we'll introduce two common distributions: the first
   maps indices to locales using contiguous rectilinear blocks; the
@@ -338,7 +338,7 @@ writeln("Locale 0 owns the following indices of CA: ", CA.localSubdomain());
 // compactly in a dense block of memory.
 
 // Conclusion
-// ==========
+// ----------
 
 // That wraps up this brief introduction to distributions in Chapel
 // and their use in declaring distributed domains and arrays.  Keep in

--- a/test/release/examples/primers/distributions.chpl
+++ b/test/release/examples/primers/distributions.chpl
@@ -162,7 +162,7 @@ var BA: [BlockSpace] int;
 */
 
 // Reasoning About Ownership
-// ~~~~~~~~~~~~~~~~~~~~~~~~~
+// -------------------------
 //
 // To illustrate how our block-distributed domain and array are mapped
 // to locales, let's use a forall loop that assigns each array element
@@ -209,7 +209,7 @@ coforall L in Locales {
 
 
 // Creating an Aligned Domain
-// ~~~~~~~~~~~~~~~~~~~~~~~~~~
+// --------------------------
 
 // Domains declared in terms of a ``blockDist`` distribution can also
 // include indices outside of the bounding box. That is, the bounding
@@ -232,7 +232,7 @@ const BigBlockSpace = blockDist.createDomain({0..n+1, 0..n+1});
 // are *aligned*.
 
 // Specifying Target Locales
-// ~~~~~~~~~~~~~~~~~~~~~~~~~
+// -------------------------
 
 //
 // As mentioned above, most Chapel distributions support an optional

--- a/test/release/examples/primers/replicated.chpl
+++ b/test/release/examples/primers/replicated.chpl
@@ -1,7 +1,13 @@
 // replicatedDist Distribution
 
 /*
-  This primer demonstrates uses of the replicatedDist Distribution.
+  This primer demonstrates uses of the Replicated Distribution.
+
+  .. warning::
+
+    The Replicated Distribution is currently unstable.
+    Its functionality is likely to change in the future.
+
   To use this distribution in a Chapel program, the following module must be
   used:
 */

--- a/test/release/examples/primers/replicated.chpl
+++ b/test/release/examples/primers/replicated.chpl
@@ -1,7 +1,8 @@
-// replicatedDist Distribution
+// Replicated Distribution
 
 /*
-  This primer demonstrates uses of the Replicated Distribution.
+  This primer demonstrates uses of replicatedDist,
+  the Replicated Distribution.
 
   .. warning::
 
@@ -23,7 +24,8 @@
 // locales does a nice job of illustrating the distribution
 // characteristics.
 //
-// Like other distributions, replicatedDist supports options to map to a different
+// Like other distributions, ``replicatedDist`` supports options
+// to map to a different
 // virtual locale grid than the one used by default (a multidimensional
 // factoring of the built-in ``Locales`` array), as well as
 // to control the amount of parallelism used in data parallel
@@ -43,8 +45,8 @@ config const n = 8;
 const Space = {1..n, 1..n};
 
 
-// replicatedDist
-// --------------
+// Replicated Distribution
+// -----------------------
 //
 // The ``replicatedDist`` distribution is different from other distributions:
 // each of the original domain's indices is replicated onto


### PR DESCRIPTION
This PR:

* Adds the rationale for the restrictions on the require statements, written by @bradcray.
* Adds an unstable warning to the Replicated Distribution primer. Refer to it as Replicated where appropriate.
* Adjusts the level of the headings in the Distribution primer.
  *  This removes the primer's top-level sections from the Primers index page where they used to appear.
  *  This adds the subsections "Reasoning About Ownership", "Creating an Aligned Domain", and "Specifying Target Locales" to the sidebar when viewing the primer.
* Removes the open issue about `return` statements following a `throw`, as that has been resolved in #23309.

Testing: built the docs and examined the modified areas.
