### PR TITLE
Remove Pre Release from chapel repo for 1.32 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ set(CHPL_BUILD_VERSION 0)
 
 # Flip this to 'true' when we're ready to roll out a release; then back
 # after branching
-set(CHPL_OFFICIAL_RELEASE false)
+set(CHPL_OFFICIAL_RELEASE true)
 
 ### END config.h version value setting - configured_prefix set below ###
 

--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -81,8 +81,8 @@ shortversion = chplversion.replace('-', '&#8209') # prevent line-break at hyphen
 html_context = {"chplversion":chplversion}
 
 # The full version, including alpha/beta/rc tags.
-release = '1.32.0 (pre-release)'
-#release = '1.31.0'
+#release = '1.32.0 (pre-release)'
+release = '1.32.0'
 
 # General information about the project.
 project = u'Chapel Documentation'

--- a/doc/rst/language/archivedSpecs.rst
+++ b/doc/rst/language/archivedSpecs.rst
@@ -5,6 +5,7 @@ Documentation Archives
 
 Online Documentation Archives
 -----------------------------
+* `Chapel 1.31 <https://chapel-lang.org/docs/1.31/index.html>`_
 * `Chapel 1.30 <https://chapel-lang.org/docs/1.30/index.html>`_
 * `Chapel 1.29 <https://chapel-lang.org/docs/1.29/index.html>`_
 * `Chapel 1.28 <https://chapel-lang.org/docs/1.28/index.html>`_

--- a/doc/rst/usingchapel/QUICKSTART.rst
+++ b/doc/rst/usingchapel/QUICKSTART.rst
@@ -21,7 +21,7 @@ full-featured version of Chapel, refer to
    packages you should have available to build and run Chapel.
 
 
-1) If you don't already have the Chapel 1.31 source release, see
+1) If you don't already have the Chapel 1.32 source release, see
    https://chapel-lang.org/download.html.
 
 
@@ -31,14 +31,14 @@ full-featured version of Chapel, refer to
 
       .. code-block:: bash
 
-         tar xzf chapel-1.31.0.tar.gz
+         tar xzf chapel-1.32.0.tar.gz
 
    b. Make sure that you are in the directory that was created when
       unpacking the source release, for example:
 
       .. code-block:: bash
 
-         cd chapel-1.31.0
+         cd chapel-1.32.0
 
    c. Set up your environment for Chapel's Quickstart mode.
       If you are using a shell other than ``bash`` or ``zsh``,

--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -37,7 +37,7 @@ CHPL_HOME
 
     .. code-block:: sh
 
-        export CHPL_HOME=~/chapel-1.31.0
+        export CHPL_HOME=~/chapel-1.32.0
 
    .. note::
      This, and all other examples in the Chapel documentation, assumes you're

--- a/man/confchpl.rst
+++ b/man/confchpl.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.32.0 pre-release
+:Version: 1.32.0 
 :Manual section: 1
 :Title: \\fBchpl\\fP
 :Subtitle: Compiler for the Chapel Programming Language

--- a/man/confchpldoc.rst
+++ b/man/confchpldoc.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.32.0 pre-release
+:Version: 1.32.0 
 :Manual section: 1
 :Title: \\fBchpldoc\\fP
 :Subtitle: the Chapel Documentation Tool

--- a/test/chpldoc/compflags/combinations/versionhelp-chpldoc.sh
+++ b/test/chpldoc/compflags/combinations/versionhelp-chpldoc.sh
@@ -5,7 +5,7 @@ compiler=$3
 echo -n `basename $compiler`
 cat $CWD/../../../compflags/bradc/printstuff/version.goodstart
 # During pre-release mode
-diff $CWD/../../../../compiler/main/BUILD_VERSION $CWD/zero.txt > /dev/null 2>&1 && echo "" || \
-{ echo -n " pre-release (" && cat $CWD/../../../../compiler/main/BUILD_VERSION | tr -d \"\\n && echo ")" ; }
+#diff $CWD/../../../../compiler/main/BUILD_VERSION $CWD/zero.txt > /dev/null 2>&1 && echo "" || \
+# { echo -n " pre-release (" && cat $CWD/../../../../compiler/main/BUILD_VERSION | tr -d \"\\n && echo ")" ; }
 # During release mode:
-# echo ""
+ echo ""

--- a/test/compflags/bradc/printstuff/versionhelp.sh
+++ b/test/compflags/bradc/printstuff/versionhelp.sh
@@ -5,10 +5,10 @@ compiler=$3
 echo -n `basename $compiler`
 cat $CWD/version.goodstart
 # During pre-release mode
-diff $CWD/../../../../compiler/main/BUILD_VERSION $CWD/zero.txt > /dev/null 2>&1 && echo "" || \
-{ echo -n " pre-release (" && cat $CWD/../../../../compiler/main/BUILD_VERSION | tr -d \"\\n && echo ")" ; }
+# diff $CWD/../../../../compiler/main/BUILD_VERSION $CWD/zero.txt > /dev/null 2>&1 && echo "" || \
+# { echo -n " pre-release (" && cat $CWD/../../../../compiler/main/BUILD_VERSION | tr -d \"\\n && echo ")" ; }
 # During release mode:
-#echo ""
+echo ""
 
 if [ "$CHPL_LLVM" != "none" ]
 then


### PR DESCRIPTION
As part of the release process for 1.32 Release, remove pre-release.