### PR TITLE
Improve documentation of AutoMath/Math and ChapelIO/IO pairs

### DIFF
--- a/doc/rst/meta/modules/standard.rst
+++ b/doc/rst/meta/modules/standard.rst
@@ -74,11 +74,11 @@ Math/Numerical
 .. toctree::
    :maxdepth: 1
 
-   AutoMath <standard/AutoMath>
    BigInteger <standard/BigInteger>
    BitOps <standard/BitOps>
    GMP <standard/GMP>
    Math <standard/Math>
+   Automatically-included Math symbols <standard/AutoMath>
    Random <standard/Random>
 
 

--- a/doc/rst/meta/modules/standard.rst
+++ b/doc/rst/meta/modules/standard.rst
@@ -16,10 +16,10 @@ default:
 .. toctree::
    :maxdepth: 1
 
-   AutoMath <standard/AutoMath>
    Errors <standard/Errors>
-   IO Support <standard/ChapelIO>
    Types <standard/Types>
+   A subset of the IO symbols <standard/ChapelIO>
+   A subset of the Math symbols <standard/AutoMath>
 
 
 Data Structures

--- a/modules/standard/AutoMath.chpl
+++ b/modules/standard/AutoMath.chpl
@@ -21,6 +21,12 @@
 /*
 This module provides mathematical constants and functions.
 
+.. warning::
+
+   The module name 'AutoMath' is unstable.  If you want to use qualified naming
+   on the symbols within it, please ``use`` or ``import`` the :mod:`Math`
+   module.
+
 It includes wrappers for many of the constants and functions in
 the C Math library, which is part of the C Language Standard (ISO/IEC 9899)
 as described in Section 7.12.  Please consult that standard for an

--- a/modules/standard/ChapelIO.chpl
+++ b/modules/standard/ChapelIO.chpl
@@ -22,6 +22,11 @@
 
 Basic types and utilities in support of I/O operation.
 
+.. warning::
+
+   The module name 'ChapelIO' is unstable.  If you want to use qualified naming
+   on the symbols within it, please ``use`` or ``import`` the :mod:`IO` module.
+
 Most of Chapel's I/O support is within the :mod:`IO` module.  This section
 describes automatically included basic types and routines that support the
 :mod:`IO` module.

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -24,7 +24,8 @@
 Support for a variety of kinds of input and output.
 
 .. note:: All Chapel programs automatically include :proc:`~ChapelIO.write`,
-          :proc:`~ChapelIO.writeln` and :proc:`~ChapelIO.writef`.
+          :proc:`~ChapelIO.writeln` and :proc:`~ChapelIO.writef`.  These symbols
+          can also be accessed using ``IO.`` as their qualified access prefix.
 
 Input/output (I/O) facilities in Chapel include the types :record:`file`,
 :record:`fileReader` and :record:`fileWriter`; the constants :record:`stdin`,

--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -22,6 +22,12 @@
 
 This module provides less frequently used mathematical constants and functions.
 
+.. note::
+
+   Automatically-included Math symbols can be found :doc:`here <AutoMath>`.
+   These symbols can also be accessed using ``Math.`` as their qualified access
+   prefix.
+
 It includes wrappers for many of the constants and functions in
 the C Math library, which is part of the C Language Standard (ISO/IEC 9899)
 as described in Section 7.12.  Please consult that standard for an


### PR DESCRIPTION
Does a number of things (some of which were suggested by Brad):
- Hides the AutoMath name from the standard module index page
- Unifies how AutoMath and ChapelIO are displayed on the standard
module index page
- Rearranges the standard module index so that Errors and Types
come first, then the subsections of IO and Math symbols
- Rearranges AutoMath and Math's order in the Math/Numerical section
of the standard module index
- Moves the unstable warning for the module names AutoMath and ChapelIO higher
in their docs (by explicitly chosing where to include it)
- Insert a reference in Math back to AutoMath and its symbols
- Mentions in IO and Math that the automatically included symbols can also use
  those module names for qualified access

Double checked that the built docs looked as expected and that the
links work.