### PR TITLE
Adjust documentation for some standard writeThis/serialize methods

### DIFF
--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -183,10 +183,11 @@ module CTypes {
       }
       return __primitive("array_get", this, 0);
     }
-    /* Print this pointer */
+    @chpldoc.nodoc
     inline proc writeThis(ch) throws {
       (this:c_ptr(void)).writeThis(ch);
     }
+    /* Print this pointer */
     inline proc serialize(writer, ref serializer) throws {
       (this:c_ptr(void)).writeThis(writer);
     }
@@ -235,10 +236,11 @@ module CTypes {
       }
       return __primitive("array_get", this, 0);
     }
-    /* Print this pointer */
+    @chpldoc.nodoc
     inline proc writeThis(ch) throws {
       (this:c_ptr(void)).writeThis(ch);
     }
+    /* Print this pointer */
     inline proc serialize(writer, ref serializer) throws {
       (this:c_ptr(void)).writeThis(writer);
     }
@@ -345,8 +347,7 @@ module CTypes {
       return __primitive("array_get", this, i);
     }
 
-
-    /* Print the elements */
+    @chpldoc.nodoc
     proc writeThis(ch) throws {
       ch.writeLiteral("[");
       var first = true;
@@ -360,6 +361,7 @@ module CTypes {
       ch.writeLiteral("]");
     }
 
+    /* Print the elements */
     proc const serialize(writer, ref serializer) throws {
       writeThis(writer);
     }

--- a/modules/standard/CommDiagnostics.chpl
+++ b/modules/standard/CommDiagnostics.chpl
@@ -315,6 +315,7 @@ module CommDiagnostics
     */
     var cache_readahead_waited : uint(64);
 
+    @chpldoc.nodoc
     proc writeThis(c) throws {
       use Reflection;
 
@@ -334,6 +335,7 @@ module CommDiagnostics
       c.write(")");
     }
 
+    @chpldoc.nodoc
     proc serialize(writer, ref serializer) throws {
       writeThis(writer);
     }


### PR DESCRIPTION
This PR either adds a nodoc to ``writeThis`` and ``serialize`` methods, or shifts documentation from ``writeThis`` to ``serialize``.