### PR TITLE
Fix uast list for TypeQuery

### DIFF
--- a/frontend/include/chpl/uast/uast-classes-list.h
+++ b/frontend/include/chpl/uast/uast-classes-list.h
@@ -76,7 +76,6 @@
   AST_NODE(Select)                     //
   AST_NODE(Throw)                      //
   AST_NODE(Try)                        // old AST: TryStmt
-  AST_NODE(TypeQuery)                  //
   AST_NODE(Use)                        // old AST: UseStmt
   AST_NODE(VisibilityClause)           //
   AST_NODE(WithClause)                 //
@@ -147,6 +146,7 @@
       AST_NODE(Function)                   // old AST: FnSymbol
       AST_NODE(Interface)                  // old AST: InterfaceSymbol
       AST_NODE(Module)                     // old AST: ModuleSymbol
+      AST_NODE(TypeQuery)
       AST_NODE(ReduceIntent)
 
       AST_BEGIN_SUBCLASSES(VarLikeDecl)


### PR DESCRIPTION
Fixes the uast list to correctly list `TypeQuery` as a `NamedDecl`

Tested with full paratest.

[Reviewed by @DanilaFe]