### PR TITLE
'Out' return/yield intent in the spec

### DIFF
--- a/doc/rst/language/spec/iterators.rst
+++ b/doc/rst/language/spec/iterators.rst
@@ -33,6 +33,7 @@ The syntax to declare an iterator is given by:
    yield-intent:
      'const'
      'const ref'
+     'out'
      'ref'
      'param'
      'type'

--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -162,6 +162,7 @@ Procedures are defined with the following syntax:
    return-intent:
      'const'
      'const ref'
+     'out'
      'ref'
      'param'
      'type'
@@ -927,6 +928,15 @@ The Default Return Intent
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When no ``return-intent`` is specified explicitly, the function returns
+a value in the same way as the ``out`` return intent,
+see :ref:`Out_Return_Intent`.
+
+.. _Out_Return_Intent:
+
+The Out Return Intent
+~~~~~~~~~~~~~~~~~~~~~
+
+A function with the ``out`` return intent returns
 a value that cannot be used as an lvalue. This value is obtained
 by copy-initialization from the returned expression,
 see :ref:`Copy_and_Move_Initialization`.

--- a/doc/rst/language/spec/tuples.rst
+++ b/doc/rst/language/spec/tuples.rst
@@ -961,7 +961,7 @@ tuple depending on its argument intent.
 Tuple Return Behavior
 ---------------------
 
-Procedures with the default return intent always return
+Procedures with the default and ``out`` return intent always return
 a value tuple. If an expression returned by such a procedure is
 a referential tuple, it will be implicitly converted to a value tuple.
 
@@ -1017,12 +1017,12 @@ the procedure's scope. Otherwise there is a compilation error.
 Tuple Yield Behavior
 --------------------
 
-Iterators with the default return intent always yield
+Iterators with the ``out`` yield intent always yield
 a value tuple. If an expression yielded by such an iterator is
 a referential tuple, it will be implicitly converted to a value tuple.
 
 A tuple yielded from an iterator with ``ref`` or ``const ref``
-return intent must be a value tuple.
+yield intent must be a value tuple.
 
    *Rationale*
 
@@ -1035,6 +1035,10 @@ return intent must be a value tuple.
    *Open issue*.
 
    We also need to provide a mechanism to yield referential tuples.
+
+An iterator with the default or ``const`` yield intent may yield
+using the semantics of either the ``out`` or ``const ref`` yield intent,
+in an implementation-defined manner.
 
 .. _Tuple_Operators:
 


### PR DESCRIPTION
This add the definitions of the `out` return/yield intent to the spec:
* for procedures
* for iterators
* for tuples

Testing: build and examine the docs