### PR TITLE
Add a missing `SET_LINENO` to resolve bug #21402.

### DIFF
--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -3005,6 +3005,7 @@ static void insertCasts(BaseAST* ast, FnSymbol* fn,
               from = rhsSe->symbol();
             } else {
               // Store the RHS into a temporary
+              SET_LINENO(rhs);
               Symbol* tmp = NULL;
               tmp = newTemp("_cast_tmp_", rhs->typeInfo());
               call->insertBefore(new DefExpr(tmp));

--- a/test/reductions/userdefined/bug21402.chpl
+++ b/test/reductions/userdefined/bug21402.chpl
@@ -1,0 +1,46 @@
+class AnyEvenReduceScanOp: ReduceScanOp {
+  type eltType;
+  var value: bool;
+
+  // Rely on the default value of the desired type.
+  // Todo: is this efficient when that is an array?
+  inline proc identity {
+    return false;
+  }
+  inline proc accumulate(x) {
+    value = value || (x % 2 == 0);
+  }
+  inline proc accumulateOntoState(ref state, x) {
+    state = state || (x % 2 == 0);
+  }
+  inline proc combine(x) {
+    value = value || x.value;
+  }
+  inline proc generate() do return value;
+  inline proc clone() do return new unmanaged AnyEvenReduceScanOp(eltType=eltType);
+}
+
+class WeirdReduceScanOp: ReduceScanOp {
+  type eltType;
+  var value: bool;
+
+  // Rely on the default value of the desired type.
+  // Todo: is this efficient when that is an array?
+  inline proc identity {
+    return false;
+  }
+  inline proc accumulate(x) {
+    value = value || (x % 2 == 0);
+  }
+  inline proc accumulateOntoState(ref state, x) {
+    state = state || (x % 2 == 0);
+  }
+  inline proc combine(x) {
+    value = value || x.value;
+  }
+  inline proc generate() do return value;
+  inline proc clone() do return new unmanaged AnyEvenReduceScanOp(eltType=eltType);
+}
+
+var result = WeirdReduceScanOp reduce [1,2,3];
+writeln(result);

--- a/test/reductions/userdefined/bug21402.good
+++ b/test/reductions/userdefined/bug21402.good
@@ -1,0 +1,1 @@
+bug21402.chpl:45: error: cannot initialize 'RP_chpl_redSVar' of type 'unmanaged WeirdReduceScanOp(int(64))' from a 'unmanaged AnyEvenReduceScanOp(int(64))'


### PR DESCRIPTION
Resolves #21402.

The internal error is due to the simple fact that we don't have an AST location marker when creating the copy temp. Adding the marker prevents the internal error, and we get a much more obvious error message from the case listed there.

Reviewed by @jabraham17 -- thanks!

## Testing
- [x] paratest