### PR TITLE
Update docs to mention SSH_SERVERS

### DIFF
--- a/doc/rst/platforms/udp.rst
+++ b/doc/rst/platforms/udp.rst
@@ -59,7 +59,7 @@ Next, try running it across several machines.
    export GASNET_SSH_CMD=ssh
    # Disable X11 forwarding
    export GASNET_SSH_OPTIONS=-x
-   # Specify which hosts to spawn on.
+   # Specify which hosts to spawn on; SSH_SERVERS can be used equivalently
    export GASNET_SSH_SERVERS="host1 host2 host3 ..."
 
 where host1, host2, host3, ... are the names of the

--- a/doc/rst/usingchapel/launcher.rst
+++ b/doc/rst/usingchapel/launcher.rst
@@ -269,7 +269,7 @@ SSH can be configured analogously.
 
      # Specify that ssh should be used
      export GASNET_SPAWNFN=S
-     # Specify the list of nodes to use
+     # Specify the list of nodes to use; SSH_SERVERS can also be used
      export GASNET_SSH_SERVERS=`scontrol show hostnames | xargs echo`
      # Run the program on the 2 reserved nodes.
      ./hello6-taskpar-dist -nl 2

--- a/doc/rst/usingchapel/multilocale.rst
+++ b/doc/rst/usingchapel/multilocale.rst
@@ -64,7 +64,7 @@ compiling and running multilocale Chapel programs.
    .. code-block:: bash
 
      export GASNET_SPAWNFN=S
-     export GASNET_SSH_SERVERS="host1 host2 host3 ..."
+     export GASNET_SSH_SERVERS="host1 host2 host3 ..."  # or SSH_SERVERS
 
 #. Specify the number of locales on the command line. For example:
 


### PR DESCRIPTION
Sometimes, users will get a complaint when using GASNet about SSH_SERVERS not being set, but our documentation doesn't mention SSH_SERVERS at all, just the preferred GASNET_SSH_SERVERS, so it can be hard for them to figure out what they need to do.  This takes the simple approach of mentioning SSH_SERVERS in our docs so that a search will find it at least, and hopefully understand that they can set either of these two variables.