### PR TITLE
Clarify that "stripped-down" does not mean "fast" in QUICKSTART instructions

### DIFF
--- a/doc/rst/usingchapel/QUICKSTART.rst
+++ b/doc/rst/usingchapel/QUICKSTART.rst
@@ -10,11 +10,11 @@ understand Chapel's configuration options, build process, and
 installation more thoroughly, please refer to :ref:`readme-chplenv`
 and :ref:`readme-building` instead.
 
-These instructions first have you build a minimal, stripped-down
-version of Chapel to reduce build times and the potential for
-third-party portability issues.  Once you are interested in a
-full-featured version of Chapel, refer to
-:ref:`using-a-more-full-featured-chapel` below.
+These instructions first have you build a minimal, low-performance
+configuration of Chapel to reduce build times and the potential for
+third-party portability issues.  Once you are interested in getting
+better performance or using a full-featured version of Chapel, refer
+to :ref:`using-a-more-full-featured-chapel` below.
 
 
 0) See :ref:`readme-prereqs` for information about system tools and


### PR DESCRIPTION
This PR touches up some wording in the quickstart instructions to try and drive home the point that the quickstart configuration is not ideal for performance-oriented programmers.  Specifically, the old use of the term "stripped down" could be viewed as "no frills == fast" when in fact it was just meant to mean "less capable".  So try to clarify that here and provide users with an indication that if they want performance they should make sure they get to the preferred configuration.