### PR TITLE
Add ref-maybe-const changes to evolution.rst

### DIFF
--- a/doc/rst/language/evolution.rst
+++ b/doc/rst/language/evolution.rst
@@ -19,6 +19,9 @@ version 1.32, September 2023
 
 .. _readme-evolution.c_string-deprecation:
 
+``c_string`` deprecation
+************************
+
 Version 1.32 deprecates the ``c_string`` type in user interfaces. Please
 replace occurrences of ``c_string`` with ``c_ptrConst(c_char)``. Note that you
 need to ``use`` or ``import`` the ``CTypes`` module to have access to
@@ -52,6 +55,9 @@ An equivalent for ``.size`` is the unstable procedure ``strLen(x)`` in the
 ``CTypes`` module.
 
 .. _readme-evolution.ref-if-modified-deprecation:
+
+The default intent for arrays and records
+*****************************************
 
 In version 1.32, arrays and records now always have a default intent of
 ``const``. Previously, these types would be passed by ``const ref`` intent,
@@ -123,9 +129,9 @@ definition:
      }
    }
 
-  Without knowing what the body of ``doSomething`` does, it is not clear
-  whether ``x`` may be modified. In version 1.32, if ``x`` is modified the
-  method must be marked as a modifying record using a this-intent.
+Without knowing what the body of ``doSomething`` does, it is not clear
+whether ``x`` may be modified. In version 1.32, if ``x`` is modified the
+method must be marked as a modifying record using a this-intent.
 
 .. code-block:: chapel
 
@@ -136,7 +142,7 @@ definition:
      }
    }
 
-   Now it is clear that the method may modify ``x``.
+Now it is clear that the method may modify ``x``.
 
 version 1.31, June 2023
 -----------------------

--- a/doc/rst/language/evolution.rst
+++ b/doc/rst/language/evolution.rst
@@ -60,10 +60,13 @@ The default intent for arrays and records
 *****************************************
 
 In version 1.32, arrays and records now always have a default intent of
-``const``. Previously, these types would be passed by ``const ref`` intent,
-unless they were modified and then they were passed by ``ref`` intent. This
-change was motivated by improving the consistency across types and making
-potential problems more apparent.
+``const``. This means that if arrays and records are modified inside of a loop
+body, a function, or a task body they must use a ``ref`` intent. This also
+means that record methods which modify their implicit ``this`` argument must
+also use a ``ref`` intent. Previously, the compiler would treat these types as
+either ``const ref`` intent or ``ref`` intent, depending on if they were
+modified. This change was motivated by improving the consistency across types
+and making potential problems more apparent.
 
 Consider the following code segment, which contains a ``forall`` statement
 which modifies local variables. Prior to version 1.32, this code compiled and
@@ -101,7 +104,8 @@ which can be a source of subtle bugs. In 1.32, the loop is written as:
      myArray[i] = myArray[i-1] + 1;
    }
 
-This removes the inconsistency and makes the potential issues much more clear.
+This removes the inconsistency and calls greater attention to potential race
+conditions.
 
 This change also applies to procedures. Consider the following procedure:
 


### PR DESCRIPTION
Adds a section about ref-maybe-const (also called ref-if-modified) to the language evolution document

[Reviewed by @bmcdonald3]