### PR TITLE
Print file path in detailed errors when jumping files

### DIFF
--- a/frontend/include/chpl/framework/ErrorWriter.h
+++ b/frontend/include/chpl/framework/ErrorWriter.h
@@ -393,6 +393,9 @@ class ErrorWriter : public ErrorWriterBase {
   std::ostream& oss_;
   ErrorWriterBase::OutputFormat outputFormat_;
   bool useColor_;
+  std::string lastFilePath_;
+
+  bool noteLastFilePath(std::string newPath);
 
   void setColor(TermColorName color);
 

--- a/frontend/include/chpl/framework/ErrorWriter.h
+++ b/frontend/include/chpl/framework/ErrorWriter.h
@@ -395,7 +395,13 @@ class ErrorWriter : public ErrorWriterBase {
   bool useColor_;
   std::string lastFilePath_;
 
-  bool noteLastFilePath(std::string newPath);
+  /* Called when the error tries to print a particular file path to indicate
+     the location of an error. Returns true if this is needed, which happens
+     when the previously-printed file path was different. Otherwise,
+     the error message can skip printing file path information, since
+     it has not changed.
+   */
+  bool noteFilePath(std::string newPath);
 
   void setColor(TermColorName color);
 

--- a/frontend/lib/framework/ErrorWriter.cpp
+++ b/frontend/lib/framework/ErrorWriter.cpp
@@ -78,7 +78,7 @@ static std::string fileText(Context* context, const Location& loc) {
   return fileText.text();
 }
 
-bool ErrorWriter::noteLastFilePath(std::string newPath) {
+bool ErrorWriter::noteFilePath(std::string newPath) {
   bool toReturn = lastFilePath_ != newPath;
   lastFilePath_ = std::move(newPath);
   return toReturn;
@@ -151,7 +151,7 @@ void ErrorWriter::writeHeading(ErrorBase::Kind kind, ErrorType type,
   // 'lastFilePath_' field.
   std::string printedPath;
   writeFile(context, oss_, errordetail::locate(context, loc), &printedPath);
-  noteLastFilePath(std::move(printedPath));
+  noteFilePath(std::move(printedPath));
 
   if (outputFormat_ == DETAILED) {
     // Second part of the error decoration
@@ -233,7 +233,7 @@ void ErrorWriter::writeCode(const Location& location,
   // Print the file path if it's changed since the last code block. Printing
   // a code block will display the file path if needed, so lastFilePath_ needs
   // to be updated.
-  if (noteLastFilePath(locToPath(context, location))) {
+  if (noteFilePath(locToPath(context, location))) {
     printBlank(oss_, codeIndent - 1);
     oss_ << "--> " << lastFilePath_ << std::endl;
   }


### PR DESCRIPTION
This aims to resolve https://github.com/chapel-lang/chapel/issues/21656.

Though I've read Brad's opinion on the various sketches, I am not inclined to put the filename on the same line as the previous error message. The reason for this is that it doesn't mesh well with the current approach we take (each piece of the error message is a distinct call that writes text to a stream). To be able to splice the file from code output back into the line before it, we'd need the code that prints the error message to be coupled with the code that prints the lines of Chapel. Furthermore, the approach is not resilient to non-standard phrasing of the message above (it modifies them grammatically!).

Thus, I've taken the approach of Rust error messages, and print the filename with an `-->` character. I think using delimiters makes the filename less likely to blend in with the sentence above (and, like I described above, actually making it blend in properly is hard).

The error message from the issue now looks as follows:

<img width="368" alt="Screen Shot 2023-09-21 at 5 08 18 PM" src="https://github.com/chapel-lang/chapel/assets/4361282/4ba23642-0453-4807-b928-43916ca4c569">

Reviewed by @mppf -- thanks!

## Testing
- [x] paratest