### PR TITLE
Add a chpldoc.hideType attribute to hide implementation type

### DIFF
--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -150,6 +150,7 @@ module CTypes {
   pragma "no default functions"
   pragma "no wide class"
   pragma "c_ptr class"
+  @chpldoc.hideType
   class c_ptr : writeSerializable {
     //   Similar to _ddata from ChapelBase, but differs
     //   from _ddata because it can never be wide.


### PR DESCRIPTION
Prototype of what a `chpldoc` attribute that hides the implementation type of a symbol might look like.

Just PR'ing so I don't lose the branch while cleaning up my fork.

See https://github.com/chapel-lang/chapel/issues/22461 for proposal.