### PR TITLE
Load PrgEnv-gnu/8.4.0

### DIFF
--- a/util/cron/common-hpe-cray-ex.bash
+++ b/util/cron/common-hpe-cray-ex.bash
@@ -3,7 +3,9 @@
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 
 module unload $(module --terse list 2>&1 | grep PrgEnv-)
-module load PrgEnv-gnu
+
+# PrgEnv-gnu/8.5.0 currently has a problem on pinoak
+module load PrgEnv-gnu/8.4.0
 module load cray-pmi
 
 export CHPL_HOST_PLATFORM=hpe-cray-ex


### PR DESCRIPTION
Loading PrgEnv/8.5.0 currently causes an error on pinoak.