### PR TITLE
Explicitly set CHPL_CUDA_PATH in a nightly script as a workaround

### DIFF
--- a/util/cron/test-gpu-ex-cuda-11.bash
+++ b/util/cron/test-gpu-ex-cuda-11.bash
@@ -8,6 +8,10 @@ source $CWD/common-hpe-cray-ex.bash
 
 module load cudatoolkit/23.3_11.8 # pin to CUDA 11
 
+# the module loaded above doesn't wire symlinks correctly. I've created a ticket
+# for that, but until that's fixed, we are setting this environment explicitly
+export CHPL_CUDA_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/23.3/cuda/11.8
+
 export CHPL_COMM=none
 export CHPL_LOCALE_MODEL=gpu
 export CHPL_LAUNCHER_PARTITION=allgriz


### PR DESCRIPTION
Adds an `export CHPL_CUDA_PATH` to avoid a module setup complication on the nightly testing system. I think it is likely that the system issue will be resolved soon, and we'll take this out.