### PR TITLE
remove extra whitespace in version.goodstart file

### DIFF
--- a/test/compflags/bradc/printstuff/version.goodstart
+++ b/test/compflags/bradc/printstuff/version.goodstart
@@ -1,1 +1,1 @@
- version 1.33.0 
+ version 1.33.0


### PR DESCRIPTION
This PR removes an extra whitespace character accidentally inserted a file we use to generate a .good file to check the output when running `chpl --version`.