### PR TITLE
Fix nested type indentation in chpldoc

### DIFF
--- a/test/chpldoc/nested.doc.catfiles
+++ b/test/chpldoc/nested.doc.catfiles
@@ -1,0 +1,1 @@
+docs/source/modules/nested.doc.rst

--- a/test/chpldoc/nested.doc.chpl
+++ b/test/chpldoc/nested.doc.chpl
@@ -1,0 +1,39 @@
+
+//
+// This test exists to guard against errors in the case that the documentation
+// for a nested type (e.g. 'Inner') contains a code-block as the final
+// element of the doc-comment. At one point in history, the documentation for
+// 'Inner' was incorrectly indented such that it was aligned with the
+// '.. record:: Inner' line in the output file. The result was that the
+// 'innerMethod' indentation was then incorrectly aligned with the code-block,
+// and appeared as literal rst in the rendered HTML.
+//
+
+/*
+  Documentation for record R.
+
+  .. code-block:: text
+
+    a code block!
+*/
+record R {
+  var x : int;
+
+  /* Document 'foo' */
+  proc foo() {
+  }
+
+  /*
+    Documentation for ``Inner``
+
+    .. code-block:: text
+
+      This code-block should not overflow to 'innerMethod'!
+
+  */
+  record Inner {
+    /* Inner Method. */
+    proc innerMethod() {
+    }
+  }
+}

--- a/test/chpldoc/nested.doc.good
+++ b/test/chpldoc/nested.doc.good
@@ -1,0 +1,51 @@
+.. default-domain:: chpl
+
+.. module:: nested.doc
+
+nested.doc
+==========
+**Usage**
+
+.. code-block:: chapel
+
+   use nested.doc;
+
+
+or
+
+.. code-block:: chapel
+
+   import nested.doc;
+
+.. record:: R
+
+   
+   Documentation for record R.
+   
+   .. code-block:: text
+   
+     a code block!
+
+
+   .. attribute:: var x: int
+
+   .. method:: proc foo()
+
+      Document 'foo' 
+
+   .. record:: Inner
+
+      
+      Documentation for ``Inner``
+      
+      .. code-block:: text
+      
+        This code-block should not overflow to 'innerMethod'!
+      
+      
+
+
+      .. method:: proc innerMethod()
+
+      Inner Method. 
+

--- a/tools/chpldoc/chpldoc.cpp
+++ b/tools/chpldoc/chpldoc.cpp
@@ -1416,7 +1416,17 @@ struct RstResultBuilder {
   bool showComment(const AstNode* node, bool indent=true) {
     std::string errMsg;
     auto lastComment = previousComment(context_, node->id());
+
+    bool isNested = false;
+    if (node->isRecord() || node->isClass()) {
+      auto parent = parentAst(context_, node);
+      isNested = parent->isRecord() || parent->isClass();
+    }
+
+    if (isNested) indentDepth_ += 1;
     bool commentShown = showComment(lastComment, errMsg, indent);
+    if (isNested) indentDepth_ -= 1;
+
     if (!errMsg.empty()) {
       // process the warning about comments
       auto br = parseFileContainingIdToBuilderResult(context_, node->id());


### PR DESCRIPTION
This PR fixes the indentation of nested types in ``chpldoc``. Prior to this PR, if a nested type's documentation ended in a ``.. code-block::``, then the nested type's methods would be "absorbed" into that code-block:

For example, consider the following program:

```chpl
/*
  Documentation for record R.

  .. code-block:: text

    a code block!
*/
record R {
  var x : int;

  /* Document 'foo' */
  proc foo() {
  }

  /*
    Documentation for ``Inner``

    .. code-block:: text

      This code-block should not overflow to 'innerMethod'!

  */
  record Inner {
    /* Inner Method. */
    proc innerMethod() {
    }
  }
}
```

The ``rst`` chpldoc output for ``Inner`` would previously have indented the ".. method::" section under the code-block section:

```
   .. record:: Inner

   
   Documentation for ``Inner``
   
   .. code-block:: text
   
     This code-block should not overflow to 'innerMethod'!
   
   


      .. method:: proc innerMethod()

      Inner Method. 
```

With this PR, the documentation for "Inner" is correctly indented:
```
   .. record:: Inner


      Documentation for ``Inner``

      .. code-block:: text

        This code-block should not overflow to 'innerMethod'!




      .. method:: proc innerMethod()

      Inner Method. 
```

Testing:
- [x] local paratest