### PR TITLE
Drop explicit formal type in GPU.setBlockSize

### DIFF
--- a/modules/standard/GPU.chpl
+++ b/modules/standard/GPU.chpl
@@ -209,7 +209,7 @@ module GPU
   /*
     Set the block size for kernels launched on the GPU.
    */
-  inline proc setBlockSize(blockSize: int) {
+  inline proc setBlockSize(blockSize) {
     __primitive("gpu set blockSize", blockSize);
   }
 

--- a/modules/standard/GPU.chpl
+++ b/modules/standard/GPU.chpl
@@ -209,7 +209,7 @@ module GPU
   /*
     Set the block size for kernels launched on the GPU.
    */
-  inline proc setBlockSize(blockSize) {
+  inline proc setBlockSize(blockSize: integral) {
     __primitive("gpu set blockSize", blockSize);
   }
 

--- a/test/gpu/native/basics/blockSize-int32.chpl
+++ b/test/gpu/native/basics/blockSize-int32.chpl
@@ -1,0 +1,16 @@
+use GPU;
+
+on here.gpus[0] {
+  foo(128);
+}
+
+proc foo(blockSize: int(32)) {
+  var A: [1..10] int;
+  @assertOnGpu
+  foreach a in A {
+    setBlockSize(blockSize);
+    a = 1;
+  }
+
+  writeln(A);
+}

--- a/test/gpu/native/basics/blockSize-int32.good
+++ b/test/gpu/native/basics/blockSize-int32.good
@@ -1,0 +1,2 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
+1 1 1 1 1 1 1 1 1 1

--- a/test/gpu/native/basics/intCoercion.chpl
+++ b/test/gpu/native/basics/intCoercion.chpl
@@ -1,0 +1,24 @@
+// this test is similar to blockSize-int32: setBlockSize was failing because of
+// a type coercion issue. This is trying type coercion in a more general sense.
+// It looks like the original bug was about the primitive that setBlockSize
+// uses, and we can do type coercion in general. This test locks in the basic
+// behavior nonetheless
+use GPU;
+
+on here.gpus[0] {
+  foo(128);
+}
+
+proc bar(x: int) {
+  return x+2;
+}
+
+proc foo(arg: int(32)) {
+  var A: [1..10] int;
+  @assertOnGpu
+  foreach a in A {
+    a = bar(arg);
+  }
+
+  writeln(A);
+}

--- a/test/gpu/native/basics/intCoercion.good
+++ b/test/gpu/native/basics/intCoercion.good
@@ -1,0 +1,2 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
+130 130 130 130 130 130 130 130 130 130


### PR DESCRIPTION
The compiler primitive `setBlockSize` used was causing issues when the function was called with 32-bit integers. This PR drops the formal type and makes the function completely generic. Probably I should test making the type `integral` and merge that if it works.

Test:
- [x] nvidia