### PR TITLE
Remove deprecated `readstring` and `readbytes` methods

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1964,7 +1964,7 @@ module DefaultRectangular {
         if f._writing {
           f._writeBytes(_ddata_shift(arr.eltType, src, idx), size);
         } else {
-          f._readBytes(_ddata_shift(arr.eltType, src, idx), size);
+          f.readBinary(c_ptrTo(_ddata_shift(arr.eltType, src, idx)[0]), size);`
         }
       } catch err {
         // Setting errors in channels has no effect, so just rethrow.

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1964,7 +1964,7 @@ module DefaultRectangular {
         if f._writing {
           f._writeBytes(_ddata_shift(arr.eltType, src, idx), size);
         } else {
-          f.readBinary(c_ptrTo(_ddata_shift(arr.eltType, src, idx)[0]), size);`
+          f.readBinary(c_ptrTo(_ddata_shift(arr.eltType, src, idx)[0]), size);
         }
       } catch err {
         // Setting errors in channels has no effect, so just rethrow.

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -9730,7 +9730,7 @@ proc fileReader.readBinary(ptr: c_ptr(?t), maxBytes: int): int throws {
   var e: errorCode = 0,
       numRead: c_ssize_t = 0;
   const t_size = c_sizeof(t),
-        numBytesToRead = (maxBytes / t_size) * t_size;
+        numBytesToRead = (maxBytes:uint / t_size) * t_size;
 
   e = qio_channel_read(false, this._channel_internal, ptr[0], numBytesToRead: c_ssize_t, numRead);
 

--- a/test/deprecated/IO/readbytes.chpl
+++ b/test/deprecated/IO/readbytes.chpl
@@ -1,6 +1,0 @@
-use IO;
-
-var r = openReader("f.txt");
-var b = b"";
-r.readbytes(b);
-write(b);

--- a/test/deprecated/IO/readbytes.good
+++ b/test/deprecated/IO/readbytes.good
@@ -1,2 +1,0 @@
-readbytes.chpl:5: warning: 'readbytes' is deprecated; please use 'readBytes' instead
-this is a file

--- a/test/deprecated/IO/readstring.chpl
+++ b/test/deprecated/IO/readstring.chpl
@@ -1,6 +1,0 @@
-use IO;
-
-var r = openReader("f.txt");
-var s = "";
-r.readstring(s);
-write(s);

--- a/test/deprecated/IO/readstring.good
+++ b/test/deprecated/IO/readstring.good
@@ -1,2 +1,0 @@
-readstring.chpl:5: warning: 'readstring' is deprecated; please use 'readString' instead
-this is a file

--- a/test/release/examples/benchmarks/shootout/regexdna-redux.chpl
+++ b/test/release/examples/benchmarks/shootout/regexdna-redux.chpl
@@ -29,7 +29,7 @@ proc main(args: [] string) {
   ];
 
   var data: string;
-  stdin.readstring(data); // read in the entire file
+  stdin.readAll(data); // read in the entire file
   const initLen = data.size;
 
   // remove newlines

--- a/test/release/examples/benchmarks/shootout/regexdna-redux.good
+++ b/test/release/examples/benchmarks/shootout/regexdna-redux.good
@@ -1,5 +1,3 @@
-regexdna-redux.chpl:13: In function 'main':
-regexdna-redux.chpl:32: warning: 'readstring' is deprecated; please use 'readString' instead
 agggtaaa|tttaccct 1
 [cgt]gggtaaa|tttaccc[acg] 0
 a[act]ggtaaa|tttacc[agt]t 0

--- a/test/release/examples/benchmarks/shootout/regexdna-redux.perfkeys
+++ b/test/release/examples/benchmarks/shootout/regexdna-redux.perfkeys
@@ -1,4 +1,4 @@
 # file: regexdnaredux-release.dat
 real
 verify:agggtaa\[cgt\]|\[acg\]ttaccct 2178
-verify:50833409
+verify:50833411

--- a/test/release/examples/benchmarks/shootout/regexdna-redux.perfkeys
+++ b/test/release/examples/benchmarks/shootout/regexdna-redux.perfkeys
@@ -1,4 +1,4 @@
 # file: regexdnaredux-release.dat
 real
 verify:agggtaa\[cgt\]|\[acg\]ttaccct 2178
-verify:50833411
+verify:50833409

--- a/test/studies/shootout/submitted/Compat.chpl
+++ b/test/studies/shootout/submitted/Compat.chpl
@@ -4,3 +4,9 @@ use IO;
 proc openfd(x) {
   return new file(x);
 }
+
+@deprecated(notes="'readstring' is deprecated; please use 'readString' instead")
+proc fileReader.readstring(ref s, len = -1) do return this.readString(s, len);
+
+@deprecated(notes="'readbytes' is deprecated; please use 'readBytes' instead")
+proc fileReader.readbytes(ref b, len = -1) do return this.readBytes(b, len);


### PR DESCRIPTION
Removes the `fileReader.readstring` and `fileReader.readbytes` methods deprecated in: https://github.com/chapel-lang/chapel/pull/21201.

Also replaces uses of the undocumented `_readbytes` helper with `readBinary`.

- [x] local paratest
- [x] gasnet paratest