### PR TITLE
Add `--compiler-driver` nightly test script

### DIFF
--- a/util/cron/test-driver.bash
+++ b/util/cron/test-driver.bash
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#
+# Test --compiler-driver configuration on full suite on linux64.
+
+CWD=$(cd $(dirname $0) ; pwd)
+source $CWD/common.bash
+source $CWD/common-localnode-paratest.bash
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="driver"
+
+$CWD/nightly -cron -compopts --compiler-driver $(get_nightly_paratest_args)


### PR DESCRIPTION
Adds `util/cron/test-driver.bash` test script that runs our test suite with `--compiler-driver`.

[reviewer info placeholder]

Testing:
- [x] manual paratest with `--compiler-driver` passes on `main` at the moment