### PR TITLE
Remove deprecated c_FILE pointer behavior

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -64,10 +64,6 @@ module ChapelBase {
   use CTypes;
   use ChplConfig;
 
-  @chpldoc.nodoc
-  @deprecated(notes="the '_file' type is deprecated; please use 'CTypes.c_FILE' instead")
-  type _file = c_FILE_internal;
-
   config param enablePostfixBangChecks = false;
 
   // These two are called by compiler-generated code.

--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -52,36 +52,16 @@ module CTypes {
   extern "_cfiletype" type chpl_cFile; // direct uses of this type in the IO module
                                       // can be replaced with c_FILE when deprecation is complete
 
-  /* Controls whether :type:`c_FILE` represents a ``FILE*`` or a ``FILE``.
-
-    - If true, ``c_FILE`` represents a ``FILE*``. This behavior is deprecated
-      and will be removed in an upcoming release.
-    - If false, ``c_FILE`` represents a ``FILE``. A ``FILE*`` can still be
-      represented with ``c_ptr(c_FILE)``.
-
-    The deprecated behavior is on by default. To opt-in to the new behavior,
-    recompile your program with ``-scFileTypeHasPointer=false``.
-
-  */
-  config param cFileTypeHasPointer = true;
-
-  /* Chapel type alias for a C ``FILE`` */
-  proc c_FILE type {
-    if cFileTypeHasPointer {
-      compilerWarning("in an upcoming release 'c_FILE' will represent a 'FILE' rather than a 'FILE*'. Wrap instances of 'c_FILE' with 'c_ptr()' and recompile with '-scFileTypeHasPointer=false' to opt-in to the new behavior.");
-      return chpl_cFilePtr;
-    } else {
-      return chpl_cFile;
-    }
-  }
-  // post deprecation, all the above type-proc can be replaced with the following:
-  // extern "_cfiletype" type c_FILE;
-
-  // type c_FILE = if cFileTypeHasPointer then chpl_cFilePtr else chpl_cFile;
-
-  // all uses of this type should be replaced with c_FILE when deprecation is complete
   @chpldoc.nodoc
-  type c_FILE_internal = if cFileTypeHasPointer then chpl_cFilePtr else chpl_cFile;
+  @deprecated("'cFileTypeHasPointer' is deprecated and no longer affects the behavior of the 'c_FILE' type. A 'FILE*' should be represented by 'c_ptr(c_FILE)'")
+  config param cFileTypeHasPointer = false;
+
+  /*
+    Chapel type alias for a C ``FILE``
+
+    A ``FILE*`` can be represented with ``c_ptr(c_FILE)``
+  */
+  extern "_cfiletype" type c_FILE;
 
   /*
     A Chapel type alias for ``void*`` in C. Casts from integral types to

--- a/test/deprecated/IO/cFileWithPtr.chpl
+++ b/test/deprecated/IO/cFileWithPtr.chpl
@@ -1,8 +1,8 @@
 use CTypes;
 
-extern proc fopen(filename: c_ptrConst(c_uchar), mode: c_ptrConst(c_uchar)): c_FILE;
-extern proc fwrite(ptr: c_ptrConst(c_uchar), size: c_size_t, count: c_size_t, stream: c_FILE): c_size_t;
-extern proc fclose(stream: c_FILE): c_int;
+extern proc fopen(filename: c_ptrConst(c_uchar), mode: c_ptrConst(c_uchar)): c_ptr(c_FILE);
+extern proc fwrite(ptr: c_ptrConst(c_uchar), size: c_size_t, count: c_size_t, stream: c_ptr(c_FILE)): c_size_t;
+extern proc fclose(stream: c_ptr(c_FILE)): c_int;
 
 var f = fopen(c_ptrToConst("./filePtrTest.txt"), c_ptrToConst("w+"));
 var s = "Hello, World!\n";

--- a/test/deprecated/IO/cFileWithPtr.compopts
+++ b/test/deprecated/IO/cFileWithPtr.compopts
@@ -1,1 +1,1 @@
--scPtrToLogicalValue=true
+-scPtrToLogicalValue=true -scFileTypeHasPointer=true

--- a/test/deprecated/IO/cFileWithPtr.good
+++ b/test/deprecated/IO/cFileWithPtr.good
@@ -1,7 +1,3 @@
-cFileWithPtr.chpl:3: In function 'fopen':
-cFileWithPtr.chpl:3: warning: in an upcoming release 'c_FILE' will represent a 'FILE' rather than a 'FILE*'. Wrap instances of 'c_FILE' with 'c_ptr()' and recompile with '-scFileTypeHasPointer=false' to opt-in to the new behavior.
-cFileWithPtr.chpl:4: In function 'fwrite':
-cFileWithPtr.chpl:4: warning: in an upcoming release 'c_FILE' will represent a 'FILE' rather than a 'FILE*'. Wrap instances of 'c_FILE' with 'c_ptr()' and recompile with '-scFileTypeHasPointer=false' to opt-in to the new behavior.
-cFileWithPtr.chpl:5: In function 'fclose':
-cFileWithPtr.chpl:5: warning: in an upcoming release 'c_FILE' will represent a 'FILE' rather than a 'FILE*'. Wrap instances of 'c_FILE' with 'c_ptr()' and recompile with '-scFileTypeHasPointer=false' to opt-in to the new behavior.
+warning: 'cFileTypeHasPointer' is deprecated and no longer affects the behavior of the 'c_FILE' type. A 'FILE*' should be represented by 'c_ptr(c_FILE)'
+note: 'cFileTypeHasPointer' was set via a compiler flag
 Hello, World!

--- a/test/extern/deitz/COMPOPTS
+++ b/test/extern/deitz/COMPOPTS
@@ -1,1 +1,0 @@
--scFileTypeHasPointer=false

--- a/test/interop/C/cFileType.compopts
+++ b/test/interop/C/cFileType.compopts
@@ -1,1 +1,1 @@
--scPtrToLogicalValue=true -scFileTypeHasPointer=false
+-scPtrToLogicalValue=true

--- a/test/library/packages/Yaml/COMPOPTS
+++ b/test/library/packages/Yaml/COMPOPTS
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-normal_args="-scPtrToLogicalValue=true -scFileTypeHasPointer=false"
+normal_args="-scPtrToLogicalValue=true"
 
 ccflags=$(pkg-config --cflags yaml-0.1)
 ldflags=$(pkg-config --libs yaml-0.1)

--- a/test/library/standard/IO/initWithCFile/COMPOPTS
+++ b/test/library/standard/IO/initWithCFile/COMPOPTS
@@ -1,1 +1,0 @@
--scFileTypeHasPointer=false


### PR DESCRIPTION
In https://github.com/chapel-lang/chapel/pull/22435, the `c_FILE` type was adjusted to represent a `FILE` rather than a `FILE*`, where the deprecated/new behavior could be selected by `cFileTypeHasPointer`.

This PR removes the deprecated behavior and deprecates the `cFileTypeHasPointer` flag. A `c_FILE` now represents a `FILE` without the pointer.

- [x] local paratest
- [x] gasnet paratest