### PR TITLE
Fix the load scripts to use the default cce compiler

### DIFF
--- a/util/build_configs/cray-internal/setenv-hpe-cray-ex-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-hpe-cray-ex-x86_64.bash
@@ -345,14 +345,14 @@ else
 
         local target_prgenv="PrgEnv-cray"
         local target_compiler="cce"
-        local target_version=$gen_version_cce
+        #local target_version=$gen_version_cce
 
         # unload any existing PrgEnv
         unload_module_re PrgEnv-
 
         # load target PrgEnv with compiler version
         load_module $target_prgenv
-        load_module_version $target_compiler $target_version
+        #load_module_version $target_compiler $target_version
     }
 
     function load_target_cpu() {


### PR DESCRIPTION
The previous change removed the pin, but a change is needed to the load_prgenv_cray function to not attempt to load a module and accept the default module.