### PR TITLE
Add warning for non-existent symbols to disassemble

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -5312,30 +5312,21 @@ static void handlePrintAsm(std::string dotOFile) {
 
     // If in driver mode, restore list of C symbols to print from disk.
     if (fDriverPhaseTwo) restorePrintIrCNames();
-
-    // TODO: skip calling this (and remove the function) as the set should
-    // already have deterministic ordering and be fine to iterate through
-    std::vector<std::string> names = gatherPrintLlvmIrCNames();
+    const auto& names = gatherPrintLlvmIrCNames();
     printf("%lu symbol names to disassemble\n", names.size());
-    if (names.empty()) {
-      USR_WARN(
-          "requested assembly dump, but none of the symbols requested to be "
-          "disassembled could be found in the object file");
-    } else {
-      for (const auto& name : names) {
-        printf("\n\n# Disassembling symbol %s\n\n", name.c_str());
-        fflush(stdout);
-        std::vector<std::string> cmd;
-        cmd.push_back(llvmObjDump);
-        std::string arg = disSymArg; // e.g. --disassemble=
-        arg += name;
-        cmd.push_back(arg);
-        cmd.push_back(dotOFile);
+    for (const auto& name : names) {
+      printf("\n\n# Disassembling symbol %s\n\n", name.c_str());
+      fflush(stdout);
+      std::vector<std::string> cmd;
+      cmd.push_back(llvmObjDump);
+      std::string arg = disSymArg; // e.g. --disassemble=
+      arg += name;
+      cmd.push_back(arg);
+      cmd.push_back(dotOFile);
 
-        mysystem(cmd, "disassemble a symbol",
-                 /* ignoreStatus */ true,
-                 /* quiet */ false);
-      }
+      mysystem(cmd, "disassemble a symbol",
+               /* ignoreStatus */ true,
+               /* quiet */ false);
     }
   }
 }

--- a/test/compflags/ferguson/print-asm-nonexistent.chpl
+++ b/test/compflags/ferguson/print-asm-nonexistent.chpl
@@ -1,1 +1,0 @@
-writeln("hi");

--- a/test/compflags/ferguson/print-asm-nonexistent.compopts
+++ b/test/compflags/ferguson/print-asm-nonexistent.compopts
@@ -1,1 +1,0 @@
---llvm-print-ir foo --llvm-print-ir-stage asm

--- a/test/compflags/ferguson/print-asm-nonexistent.good
+++ b/test/compflags/ferguson/print-asm-nonexistent.good
@@ -1,3 +1,0 @@
-warning: requested assembly dump, but none of the symbols requested to be disassembled could be found in the object file
-0 symbol names to disassemble
-hi

--- a/test/compflags/ferguson/print-asm-nonexistent.skipif
+++ b/test/compflags/ferguson/print-asm-nonexistent.skipif
@@ -1,2 +1,0 @@
-# Asm printing currently only works with LLVM backend
-CHPL_TARGET_COMPILER != llvm

--- a/test/compflags/ferguson/print-asm.1.good
+++ b/test/compflags/ferguson/print-asm.1.good
@@ -1,3 +1,4 @@
+2 symbol names to disassemble
 # Disassembling symbol bar_chpl
 ADDR <bar_chpl>:
 # Disassembling symbol foo_chpl

--- a/test/compflags/ferguson/print-asm.2.good
+++ b/test/compflags/ferguson/print-asm.2.good
@@ -1,0 +1,6 @@
+warning: Could not find requested symbol for disassembly: baz
+2 symbol names to disassemble
+# Disassembling symbol bar_chpl
+ADDR <bar_chpl>:
+# Disassembling symbol foo_chpl
+ADDR <foo_chpl>:

--- a/test/compflags/ferguson/print-asm.3.good
+++ b/test/compflags/ferguson/print-asm.3.good
@@ -1,0 +1,2 @@
+warning: Could not find requested symbol for disassembly: baz
+0 symbol names to disassemble

--- a/test/compflags/ferguson/print-asm.compopts
+++ b/test/compflags/ferguson/print-asm.compopts
@@ -1,1 +1,3 @@
---llvm-print-ir foo,bar --llvm-print-ir-stage asm
+--llvm-print-ir foo,bar --llvm-print-ir-stage asm     # print-asm.1.good
+--llvm-print-ir foo,bar,baz --llvm-print-ir-stage asm # print-asm.2.good
+--llvm-print-ir baz --llvm-print-ir-stage asm         # print-asm.3.good

--- a/test/compflags/ferguson/print-asm.prediff
+++ b/test/compflags/ferguson/print-asm.prediff
@@ -5,8 +5,8 @@ LOG=$2
 # PREDIFF: Script to execute before diff'ing output (arguments: <test
 #    executable>, <log>, <compiler executable>)
 
-# Include only Disassembling output and the symbol label
+# Include only disassembling output, symbol label, and diagnostic messages
 # Hide addresses
 # Remove leading _ from symbol if it is present
-cat $LOG | grep -e 'Disassembling\|foo_chpl>:\|bar_chpl>:' | sed 's/^[0-9a-fA-F][0-9a-fA-F]*/ADDR/' | sed 's/<_/</' > $LOG.tmp
+cat $LOG | grep -e 'error\|warning\|symbol names to disassemble\|Disassembling\|foo_chpl>:\|bar_chpl>:' | sed 's/^[0-9a-fA-F][0-9a-fA-F]* </ADDR </' | sed 's/<_/</' > $LOG.tmp
 mv $LOG.tmp $LOG


### PR DESCRIPTION
Add a warning for non-existent symbols requested to be disassembled with `--llvm-print-ir`.

Also removes the separate warning for when no symbols to disassemble are found, as it's covered by this new one. Includes testing for the case in which some but not all specified symbols are not found, as well as the case where no specified symbols are found.

Resolves https://github.com/Cray/chapel-private/issues/5387.

Contributes to a component of https://github.com/Cray/chapel-private/issues/5373.

[reviewer info placeholder]

Testing:
- [x] paratest