### PR TITLE
Have make install rather than configure create the installation directory

### DIFF
--- a/configure
+++ b/configure
@@ -76,56 +76,16 @@ then
   fi
 fi
 
-NORMALIZED=""
-mynormalizepath () {
-  # Normalize PREFIX e.g.
-  P="$1"
-  case "$P" in
-    *~*)
-      # Replace ~ with home directory
-      P="${P/#\~/$HOME}"
-      ;;
-    *)
-      ;;
-  esac
-
-  if [ ! -d $P ]
-  then
-    echo "Prefix directory does not exist, creating directory."
-    mkdir -p $P
-  fi
-
-  # Normalize $P more - normalize path
-  P=`(unset CDPATH && cd "$P" && pwd)`
-
-  # Make sure we can cd into $P
-  if [ $? -ne 0 ]
-  then
-    echo "Error: Could not cd into prefix directory '$P'"
-    echo "       ... perhaps it does not exist?"
-    exit -1
-  fi
-
-  NORMALIZED="$P"
-  return 0
-}
-
 # Save configured installation prefix/dir
 rm -f configured-chpl-home
 rm -f configured-prefix
 CONFIGURED=""
 if [ "$DEST_DIR_SET" -ne 0 ]
 then
-  # Normalize DEST_DIR
-  mynormalizepath "$DEST_DIR"
-  DEST_DIR="$NORMALIZED"
   # Save target installation directory for 'make install' / install.sh
   echo "$DEST_DIR" > configured-chpl-home
   CONFIGURED=configured-chpl-home
 else
-  # Normalize PREFIX
-  mynormalizepath "$PREFIX"
-  PREFIX="$NORMALIZED"
   # Save prefix for building the compiler
   echo "$PREFIX" > configured-prefix
   CONFIGURED=configured-prefix

--- a/configure
+++ b/configure
@@ -82,10 +82,24 @@ rm -f configured-prefix
 CONFIGURED=""
 if [ "$DEST_DIR_SET" -ne 0 ]
 then
+  case $DEST_DIR in 
+    (/*) pathchk -- "$1";; 
+    (*) 
+    echo "error: expected an absolute directory name for --chpl-home: $DEST_DIR"
+    exit -1
+    ;; 
+  esac
   # Save target installation directory for 'make install' / install.sh
   echo "$DEST_DIR" > configured-chpl-home
   CONFIGURED=configured-chpl-home
 else
+  case $PREFIX in 
+    (/*) pathchk -- "$1";; 
+    (*) 
+    echo "error: expected an absolute directory name for --prefix: $PREFIX"
+    exit -1
+    ;; 
+  esac
   # Save prefix for building the compiler
   echo "$PREFIX" > configured-prefix
   CONFIGURED=configured-prefix

--- a/util/buildRelease/install.sh
+++ b/util/buildRelease/install.sh
@@ -59,10 +59,7 @@ fi
 if [ ! -z "$PREFIX" ]
 then
   PREFIX="${STAGE}${PREFIX}"
-  if [ "$STAGE_SET" -ne 0 ]
-  then
-    mkdir -p "$PREFIX"
-  fi
+  mkdir -p "$PREFIX"
   if [ ! -d "$PREFIX" ]
   then
     echo "Exiting: Installation prefix path '$PREFIX' does not exist"
@@ -73,10 +70,8 @@ else
   then
     read -r DEST_DIR < "$CHPL_HOME/configured-chpl-home"
     DEST_DIR="${STAGE}${DEST_DIR}"
-    if [ "$STAGE_SET" -ne 0 ]
-    then
-      mkdir -p "$DEST_DIR"
-    fi
+    mkdir -p "$DEST_DIR"
+    
     if [ ! -d "$DEST_DIR" ]
     then
       echo "Exiting: Installation dest path '$DEST_DIR' does not exist"


### PR DESCRIPTION
In an effort to copy the behavior of autoconf (which is what users expect our configure script to do), we delay the creation of installation directories till the `make install` step instead of in the `./configure` script. 

We also don't normalize the path anymore since `autoconf` doesn't do it either based on.

Resolves https://github.com/chapel-lang/chapel/issues/23271