### PR TITLE
Add .skipifs for a couple tests if using the GPU locale model

### DIFF
--- a/test/release/examples/primers/cClient.skipif
+++ b/test/release/examples/primers/cClient.skipif
@@ -1,4 +1,4 @@
 #!/usr/bin/env python3
 
 import os
-print(os.getenv('CHPL_TARGET_COMPILER') != 'llvm')
+print(os.getenv('CHPL_TARGET_COMPILER') != 'llvm' or os.getenv('CHPL_LOCALE_MODEL') == 'gpu')

--- a/test/release/examples/primers/distributions.skipif
+++ b/test/release/examples/primers/distributions.skipif
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+
+import os
+print(os.getenv('CHPL_LOCALE_MODEL') == 'gpu')


### PR DESCRIPTION
These are the only two tests in release/examples that currently fail for the GPU locale model when using `CHPL_GPU=cpu`. Skip them for now so we can run the CHPL_GPU=cpu testing configuration on the examples directory.

Closes https://github.com/Cray/chapel-private/issues/5447