### PR TITLE
Remove _readLiteral and _writeLiteral methods

### DIFF
--- a/modules/dists/HashedDist.chpl
+++ b/modules/dists/HashedDist.chpl
@@ -1009,13 +1009,13 @@ class UserMapAssocArr: AbsBaseArr(?) {
 
     var printBraces = (isjson || ischpl);
 
-    if printBraces then f._writeLiteral("[");
+    if printBraces then f.writeLiteral("[");
 
     var first = true;
     for locArr in locArrs {
       locArr!.myElems._value.dsiSerialReadWrite(f, printBraces=false, first);
     }
-    if printBraces then f._writeLiteral("]");
+    if printBraces then f.writeLiteral("]");
 
   }
 

--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -145,15 +145,15 @@ module DefaultAssociative {
         }
       } else {
         var first = true;
-        f._writeLiteral("{");
+        f.writeLiteral("{");
         for idx in this {
           if first then
             first = false;
           else
-            f._writeLiteral(", ");
+            f.writeLiteral(", ");
           f.write(idx);
         }
-        f._writeLiteral("}");
+        f.writeLiteral("}");
       }
     }
     proc dsiSerialRead(f) throws {
@@ -168,7 +168,7 @@ module DefaultAssociative {
           dsiAdd(f.read(idxType));
         }
       } else {
-        f._readLiteral("{");
+        f.readLiteral("{");
 
         var first = true;
 
@@ -176,14 +176,14 @@ module DefaultAssociative {
 
           // Try reading an end curly. If we get it, then break.
           try {
-            f._readLiteral("}");
+            f.readLiteral("}");
             break;
           } catch err: BadFormatError {
             // We didn't read an end brace, so continue on.
           }
 
           // Try reading a comma.
-          if !first then f._readLiteral(",", true);
+          if !first then f.readLiteral(",", true);
           first = false;
 
           // Read an index.
@@ -738,7 +738,7 @@ module DefaultAssociative {
       printBraces &&= (isjson || ischpl);
 
       inline proc rwLiteral(lit:string) throws {
-        if f._writing then f._writeLiteral(lit); else f._readLiteral(lit);
+        if f._writing then f.writeLiteral(lit); else f.readLiteral(lit);
       }
 
       if printBraces then rwLiteral("[");
@@ -750,7 +750,7 @@ module DefaultAssociative {
 
         if f._writing && ischpl {
           f.write(key);
-          f._writeLiteral(" => ");
+          f.writeLiteral(" => ");
         }
 
         if f._writing then f.write(val);
@@ -766,7 +766,7 @@ module DefaultAssociative {
       var first = true;
       var readEnd = true;
 
-      f._readLiteral(openBracket);
+      f.readLiteral(openBracket);
 
       while true {
         if first {
@@ -774,7 +774,7 @@ module DefaultAssociative {
 
           // Break if we read an immediate closed bracket.
           try {
-            f._readLiteral(closedBracket);
+            f.readLiteral(closedBracket);
             readEnd = false;
             break;
           } catch err: BadFormatError {
@@ -784,7 +784,7 @@ module DefaultAssociative {
 
           // Try reading a comma. If we don't, then break.
           try {
-            f._readLiteral(",");
+            f.readLiteral(",");
           } catch err: BadFormatError {
             // Break out of the loop if we didn't read a comma.
             break;
@@ -793,13 +793,13 @@ module DefaultAssociative {
 
         // Read a key.
         var key: idxType = f.read(idxType);
-        f._readLiteral("=>");
+        f.readLiteral("=>");
 
         // Read the value.
         dsiAccess(key) = f.read(eltType);
       }
 
-      if readEnd then f._readLiteral(closedBracket);
+      if readEnd then f.readLiteral(closedBracket);
     }
 
     proc dsiSerialWrite(f) throws { this.dsiSerialReadWrite(f); }
@@ -969,7 +969,7 @@ module DefaultAssociative {
     }
 
     inline proc rwLiteral(lit:string) throws {
-      if f._writing then f._writeLiteral(lit); else f._readLiteral(lit);
+      if f._writing then f.writeLiteral(lit); else f.readLiteral(lit);
     }
 
     if isjson || ischpl then rwLiteral("[");
@@ -983,7 +983,7 @@ module DefaultAssociative {
 
       if f._writing && ischpl {
         f.write(key);
-        f._writeLiteral(" => ");
+        f.writeLiteral(" => ");
       }
 
       if f._writing then f.write(arr.dsiAccess(key));

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1702,7 +1702,7 @@ module DefaultRectangular {
 
   proc DefaultRectangularDom.dsiSerialReadWrite(f /*: Reader or Writer*/) throws {
     inline proc rwLiteral(lit:string) throws {
-      if f._writing then f._writeLiteral(lit); else f._readLiteral(lit);
+      if f._writing then f.writeLiteral(lit); else f.readLiteral(lit);
     }
 
     rwLiteral("{");
@@ -1872,7 +1872,7 @@ module DefaultRectangular {
     const isNative = f.styleElement(QIO_STYLE_ELEMENT_IS_NATIVE_BYTE_ORDER): bool;
 
     inline proc rwLiteral(lit:string) throws {
-      if f._writing then f._writeLiteral(lit); else f._readLiteral(lit);
+      if f._writing then f.writeLiteral(lit); else f.readLiteral(lit);
     }
 
     proc rwSpaces(dim:int) throws {

--- a/modules/packages/ChplFormat.chpl
+++ b/modules/packages/ChplFormat.chpl
@@ -61,7 +61,7 @@ module ChplFormat {
         _oldWrite(writer, val);
       } else if isClassType(t) {
         if val == nil {
-          writer._writeLiteral("nil");
+          writer.writeLiteral("nil");
         } else {
           val!.serialize(writer=writer, serializer=this);
         }
@@ -112,8 +112,8 @@ module ChplFormat {
     // - is the latter even possible?
     @chpldoc.nodoc
     proc startClass(writer: _writeType, name: string, size: int) throws {
-      writer._writeLiteral("new ");
-      writer._writeLiteral(name);
+      writer.writeLiteral("new ");
+      writer.writeLiteral(name);
       writer.writeLiteral("(");
 
       return new AggregateSerializer(writer);
@@ -121,8 +121,8 @@ module ChplFormat {
 
     @chpldoc.nodoc
     proc startRecord(writer: _writeType, name: string, size: int) throws {
-      writer._writeLiteral("new ");
-      writer._writeLiteral(name);
+      writer.writeLiteral("new ");
+      writer.writeLiteral(name);
       writer.writeLiteral("(");
 
       return new AggregateSerializer(writer);
@@ -159,7 +159,7 @@ module ChplFormat {
       var _first : bool = true;
 
       proc ref writeElement(const element: ?) throws {
-        if !_first then writer._writeLiteral(", ");
+        if !_first then writer.writeLiteral(", ");
         else _first = false;
 
         writer.write(element);
@@ -167,12 +167,12 @@ module ChplFormat {
 
       @chpldoc.nodoc
       proc endList() throws {
-        writer._writeLiteral("]");
+        writer.writeLiteral("]");
       }
     }
     @chpldoc.nodoc
     proc startList(writer: fileWriter, size: int) throws {
-      writer._writeLiteral("[");
+      writer.writeLiteral("[");
       return new ListSerializer(writer);
     }
 
@@ -186,19 +186,19 @@ module ChplFormat {
       }
 
       proc ref writeElement(const element: ?) throws {
-        if !_first then writer._writeLiteral(", ");
+        if !_first then writer.writeLiteral(", ");
         else _first = false;
 
         writer.write(element);
       }
       proc endArray() throws {
-        writer._writeLiteral("]");
+        writer.writeLiteral("]");
       }
     }
 
     @chpldoc.nodoc
     proc startArray(writer: _writeType, size: int) throws {
-      writer._writeLiteral("[");
+      writer.writeLiteral("[");
       return new ArraySerializer(writer);
     }
 
@@ -208,7 +208,7 @@ module ChplFormat {
 
       @chpldoc.nodoc
       proc ref writeKey(const key: ?) throws {
-        if !_first then writer._writeLiteral(", ");
+        if !_first then writer.writeLiteral(", ");
         else _first = false;
 
         writer.write(key);
@@ -216,19 +216,19 @@ module ChplFormat {
 
       @chpldoc.nodoc
       proc writeValue(const val: ?) throws {
-        writer._writeLiteral(" => ");
+        writer.writeLiteral(" => ");
         writer.write(val);
       }
 
       @chpldoc.nodoc
       proc endMap() throws {
-        writer._writeLiteral("]");
+        writer.writeLiteral("]");
       }
     }
 
     @chpldoc.nodoc
     proc startMap(writer: _writeType, size: int) throws {
-      writer._writeLiteral("[");
+      writer.writeLiteral("[");
       return new MapSerializer(writer);
     }
   }
@@ -372,21 +372,21 @@ module ChplFormat {
       var _first = true;
 
       proc ref readElement(type eltType) : eltType throws {
-        if !_first then reader._readLiteral(", ");
+        if !_first then reader.readLiteral(", ");
         else _first = false;
 
         return reader.read(eltType);
       }
 
       proc ref readElement(ref element) throws {
-        if !_first then reader._readLiteral(", ");
+        if !_first then reader.readLiteral(", ");
         else _first = false;
 
         reader.read(element);
       }
 
       proc endList() throws {
-        reader._readLiteral("]");
+        reader.readLiteral("]");
       }
 
       proc hasMore() : bool throws {
@@ -398,7 +398,7 @@ module ChplFormat {
 
     @chpldoc.nodoc
     proc startList(reader: _readerType) throws {
-      reader._readLiteral("[");
+      reader.readLiteral("[");
       return new ListDeserializer(reader);
     }
 
@@ -417,7 +417,7 @@ module ChplFormat {
 
     @chpldoc.nodoc
     proc startArray(reader: _readerType) throws {
-      reader._readLiteral("[");
+      reader.readLiteral("[");
       return new ArrayDeserializer(reader);
     }
 
@@ -427,7 +427,7 @@ module ChplFormat {
 
       @chpldoc.nodoc
       proc ref readKey(type keyType) : keyType throws {
-        if !_first then reader._readLiteral(",");
+        if !_first then reader.readLiteral(",");
         else _first = false;
 
         return reader.read(keyType);
@@ -435,7 +435,7 @@ module ChplFormat {
 
       @chpldoc.nodoc
       proc ref readKey(ref key) throws {
-        if !_first then reader._readLiteral(",");
+        if !_first then reader.readLiteral(",");
         else _first = false;
 
         reader.read(key);
@@ -443,19 +443,19 @@ module ChplFormat {
 
       @chpldoc.nodoc
       proc readValue(type valType) : valType throws {
-        reader._readLiteral("=>");
+        reader.readLiteral("=>");
         return reader.read(valType);
       }
 
       @chpldoc.nodoc
       proc readValue(ref value) throws {
-        reader._readLiteral("=>");
+        reader.readLiteral("=>");
         reader.read(value);
       }
 
       @chpldoc.nodoc
       proc endMap() throws {
-        reader._readLiteral("]");
+        reader.readLiteral("]");
       }
 
       proc hasMore() : bool throws {
@@ -467,7 +467,7 @@ module ChplFormat {
 
     @chpldoc.nodoc
     proc startMap(reader: _readerType) throws {
-      reader._readLiteral("[");
+      reader.readLiteral("[");
       return new MapDeserializer(reader);
     }
   }

--- a/modules/packages/LinkedLists.chpl
+++ b/modules/packages/LinkedLists.chpl
@@ -303,22 +303,22 @@ record LinkedList : serializable {
       f.write(size);
     }
     if isjson || ischpl {
-      f._writeLiteral("[");
+      f.writeLiteral("[");
     }
 
     var first = true;
     for e in this {
       if first then first = false;
       else {
-        if isspace then f._writeLiteral(" ");
-        else if isjson || ischpl then f._writeLiteral(", ");
+        if isspace then f.writeLiteral(" ");
+        else if isjson || ischpl then f.writeLiteral(", ");
       }
 
       f.write(e);
     }
 
     if isjson || ischpl {
-      f._writeLiteral("]");
+      f.writeLiteral("]");
     }
 
   }
@@ -351,7 +351,7 @@ record LinkedList : serializable {
     // How many elements should we read (for binary mode)?
     const num : int = if isBinary then f.read(int) else 0;
 
-    if isJson || isChpl then f._readLiteral("[");
+    if isJson || isChpl then f.readLiteral("[");
 
     // Clear out existing elements in the list.
     destroy();
@@ -372,7 +372,7 @@ record LinkedList : serializable {
         // Try reading an end bracket. If we don't, then continue on.
         try {
           if isJson || isChpl {
-            f._readLiteral("]");
+            f.readLiteral("]");
           } else if isSpace {
             f._readNewline();
           }
@@ -387,9 +387,9 @@ record LinkedList : serializable {
         // Try to read a space or a comma. Break if we don't.
         try {
           if isSpace {
-            f._readLiteral(" ");
+            f.readLiteral(" ");
           } else if isJson || isChpl {
-            f._readLiteral(",");
+            f.readLiteral(",");
           }
         } catch err: BadFormatError {
           break;
@@ -401,7 +401,7 @@ record LinkedList : serializable {
     }
 
     if !hasReadEnd then
-      if isJson || isChpl then f._readLiteral("]");
+      if isJson || isChpl then f.readLiteral("]");
   }
 
   proc ref deserialize(reader: fileReader, ref deserializer) throws

--- a/modules/standard/ChapelIO.chpl
+++ b/modules/standard/ChapelIO.chpl
@@ -392,10 +392,10 @@ module ChapelIO {
         for param i in 1..num_fields {
           if isIoField(x, i) {
             if !isBinary {
-              if !first then writer._writeLiteral(", ");
+              if !first then writer.writeLiteral(", ");
 
               const eq = ioFieldNameEqLiteral(writer, t, i);
-              writer._writeLiteral(eq);
+              writer.writeLiteral(eq);
             }
 
             writer.write(__primitive("field by num", x, i));
@@ -414,7 +414,7 @@ module ChapelIO {
               write(id);
             } else {
               const eq = ioFieldNameEqLiteral(writer, t, i);
-              writer._writeLiteral(eq);
+              writer.writeLiteral(eq);
             }
             writer.write(__primitive("field by num", x, i));
           }
@@ -443,7 +443,7 @@ module ChapelIO {
                       then "new " + t:string + "("
                       else if isClassType(t) then "{"
                       else "(";
-        writer._writeLiteral(start);
+        writer.writeLiteral(start);
       }
 
       var first = true;
@@ -455,7 +455,7 @@ module ChapelIO {
                     else if st == QIO_AGGREGATE_FORMAT_CHPL then ")"
                     else if isClassType(t) then "}"
                     else ")";
-        writer._writeLiteral(end);
+        writer.writeLiteral(end);
       }
     }
 
@@ -563,7 +563,7 @@ module ChapelIO {
 
           // Try reading a comma. If we don't, break out of the loop.
           try {
-            reader._readLiteral(",", true);
+            reader.readLiteral(",", true);
             needsComma = false;
           } catch err: BadFormatError {
             break;
@@ -633,7 +633,7 @@ module ChapelIO {
           // Try reading a comma. If we don't, then break.
           if needsComma then
             try {
-              reader._readLiteral(",", true);
+              reader.readLiteral(",", true);
               needsComma = false;
             } catch err: BadFormatError {
               // Break out of the loop if we didn't read a comma.
@@ -664,7 +664,7 @@ module ChapelIO {
 
             try {
               const fieldName = ioFieldNameLiteral(reader, t, i);
-              reader._readLiteral(fieldName);
+              reader.readLiteral(fieldName);
             } catch e : BadFormatError {
               // Try reading again with a different union element.
               continue;
@@ -678,7 +678,7 @@ module ChapelIO {
             const equalSign = if isJson then ":"
                               else "=";
 
-            try reader._readLiteral(equalSign, true);
+            try reader.readLiteral(equalSign, true);
 
             try reader.readIt(__primitive("field by num", x, i));
             readField[i-1] = true;
@@ -737,7 +737,7 @@ module ChapelIO {
 
           try {
             const fieldName = ioFieldNameLiteral(reader, t, i);
-            reader._readLiteral(fieldName);
+            reader.readLiteral(fieldName);
           } catch e : BadFormatError {
             // Try reading again with a different union element.
             continue;
@@ -752,7 +752,7 @@ module ChapelIO {
           const eq = if isJson then ":"
                      else "=";
 
-          try reader._readLiteral(eq, true);
+          try reader.readLiteral(eq, true);
 
           // We read the 'name = ', so now read the value!
           __primitive("set_union_id", x, i);
@@ -778,7 +778,7 @@ module ChapelIO {
                       then "new " + t:string + "("
                       else "{";
 
-        try reader._readLiteral(start);
+        try reader.readLiteral(start);
       }
 
       var needsComma = false;
@@ -793,7 +793,7 @@ module ChapelIO {
         const end = if st == QIO_AGGREGATE_FORMAT_CHPL then ")"
                     else "}";
 
-        try reader._readLiteral(end);
+        try reader.readLiteral(end);
       }
     }
 
@@ -808,7 +808,7 @@ module ChapelIO {
                       else if isJson then "{"
                       else "(";
 
-        try reader._readLiteral(start);
+        try reader.readLiteral(start);
       }
 
       var needsComma = false;
@@ -820,7 +820,7 @@ module ChapelIO {
         const end = if isJson then "}"
                     else ")";
 
-        try reader._readLiteral(end);
+        try reader.readLiteral(end);
       }
     }
 
@@ -907,7 +907,7 @@ module ChapelIO {
     proc helper(ref arg) throws where !f._writing { arg = f.read(arg.type); }
 
     proc rwLiteral(lit:string) throws {
-      if f._writing then f._writeLiteral(lit); else f._readLiteral(lit);
+      if f._writing then f.writeLiteral(lit); else f.readLiteral(lit);
     }
 
     if !binary {
@@ -998,11 +998,11 @@ module ChapelIO {
     if hasLowBound() then
       f.write(lowBound);
 
-    f._writeLiteral("..");
+    f.writeLiteral("..");
 
     if hasHighBound() {
       if (chpl__singleValIdxType(this.idxType) && this._low != this._high) {
-        f._writeLiteral("<");
+        f.writeLiteral("<");
         f.write(lowBound);
       } else {
         f.write(highBound);
@@ -1010,13 +1010,13 @@ module ChapelIO {
     }
 
     if stride != 1 {
-      f._writeLiteral(" by ");
+      f.writeLiteral(" by ");
       f.write(stride);
 
       if stride != -1 && isAligned() && ! chpl_isNaturallyAligned() {
     // Write out the alignment only if it differs from natural alignment.
     // We take alignment modulo the stride for consistency.
-      f._writeLiteral(" align ");
+      f.writeLiteral(" align ");
       f.write(alignment);
       }
     }
@@ -1038,7 +1038,7 @@ module ChapelIO {
   proc ref range.readThis(f) throws {
     if hasLowBound() then _low = f.read(_low.type);
 
-    f._readLiteral("..");
+    f.readLiteral("..");
 
     if hasHighBound() then _high = f.read(_high.type);
 
@@ -1101,7 +1101,7 @@ module ChapelIO {
 
   @chpldoc.nodoc
   override proc LocaleModel.writeThis(f) throws {
-    f._writeLiteral("LOCALE");
+    f.writeLiteral("LOCALE");
     f.write(chpl_id());
   }
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -2642,7 +2642,7 @@ record defaultSerializer {
   @chpldoc.nodoc
   proc ref _serializeClassOrPtr(writer:fileWriter, x: ?t) : void throws {
     if x == nil {
-      writer._writeLiteral("nil");
+      writer.writeLiteral("nil");
     } else if isClassType(t) {
       x!.serialize(writer=writer, serializer=this);
     } else {
@@ -2686,7 +2686,7 @@ record defaultSerializer {
        t == string || t == bytes {
       writer._writeOne(writer._kind, val, writer.getLocaleOfIoRequest());
     } else if t == _nilType {
-      writer._writeLiteral("nil");
+      writer.writeLiteral("nil");
     } else if isClassType(t) || chpl_isAnyCPtr(t) || chpl_isDdata(t) {
       _serializeClassOrPtr(writer, val);
     } else if isUnionType(t) {
@@ -2707,7 +2707,7 @@ record defaultSerializer {
     :returns: A new :type:`AggregateSerializer`
   */
   proc startClass(writer: fileWriter, name: string, size: int) throws {
-    writer._writeLiteral("{");
+    writer.writeLiteral("{");
     return new AggregateSerializer(writer, _ending="}");
   }
 
@@ -2721,7 +2721,7 @@ record defaultSerializer {
     :returns: A new AggregateSerializer
   */
   proc startRecord(writer: fileWriter, name: string, size: int) throws {
-    writer._writeLiteral("(");
+    writer.writeLiteral("(");
     return new AggregateSerializer(writer, _ending=")");
   }
 
@@ -2761,11 +2761,11 @@ record defaultSerializer {
       name if this is not the first field.
     */
     proc ref writeField(name: string, const field: ?) throws {
-      if !_first then writer._writeLiteral(", ");
+      if !_first then writer.writeLiteral(", ");
       else _first = false;
 
-      writer._writeLiteral(name);
-      writer._writeLiteral(" = ");
+      writer.writeLiteral(name);
+      writer.writeLiteral(" = ");
       writer.write(field);
     }
 
@@ -2813,7 +2813,7 @@ record defaultSerializer {
     */
     proc endClass() throws {
       if !_parent then
-        writer._writeLiteral(_ending);
+        writer.writeLiteral(_ending);
       else if _firstPtr != nil then
         _firstPtr.deref() = _first;
     }
@@ -2825,7 +2825,7 @@ record defaultSerializer {
                 invoking 'endRecord'.
     */
     proc endRecord() throws {
-      writer._writeLiteral(_ending);
+      writer.writeLiteral(_ending);
     }
   }
 
@@ -2838,7 +2838,7 @@ record defaultSerializer {
     :returns: A new TupleSerializer
   */
   proc startTuple(writer: fileWriter, size: int) throws {
-    writer._writeLiteral("(");
+    writer.writeLiteral("(");
     return new TupleSerializer(writer, size);
   }
 
@@ -2872,7 +2872,7 @@ record defaultSerializer {
       first element in the tuple.
     */
     proc ref writeElement(const element: ?) throws {
-      if !_first then writer._writeLiteral(", ");
+      if !_first then writer.writeLiteral(", ");
       else _first = false;
 
       writer.write(element);
@@ -2886,9 +2886,9 @@ record defaultSerializer {
     */
     proc endTuple() throws {
       if size == 1 then
-        writer._writeLiteral(",)");
+        writer.writeLiteral(",)");
       else
-        writer._writeLiteral(")");
+        writer.writeLiteral(")");
     }
   }
 
@@ -2901,7 +2901,7 @@ record defaultSerializer {
     :returns: A new ListSerializer
   */
   proc startList(writer: fileWriter, size: int) throws {
-    writer._writeLiteral("[");
+    writer.writeLiteral("[");
     return new ListSerializer(writer);
   }
 
@@ -2931,7 +2931,7 @@ record defaultSerializer {
       first element in the list.
     */
     proc ref writeElement(const element: ?) throws {
-      if !_first then writer._writeLiteral(", ");
+      if !_first then writer.writeLiteral(", ");
       else _first = false;
 
       writer.write(element);
@@ -2941,7 +2941,7 @@ record defaultSerializer {
       Ends serialization of the current list by writing the character ``]``.
     */
     proc endList() throws {
-      writer._writeLiteral("]");
+      writer.writeLiteral("]");
     }
   }
 
@@ -3034,7 +3034,7 @@ record defaultSerializer {
       Adds a space if this is not the first element in the row.
     */
     proc ref writeElement(const element: ?) throws {
-      if !_first then writer._writeLiteral(" ");
+      if !_first then writer.writeLiteral(" ");
       else _first = false;
 
       writer.write(element);
@@ -3055,7 +3055,7 @@ record defaultSerializer {
     :returns: A new MapSerializer
   */
   proc startMap(writer: fileWriter, size: int) throws {
-    writer._writeLiteral("{");
+    writer.writeLiteral("{");
     return new MapSerializer(writer);
   }
 
@@ -3085,7 +3085,7 @@ record defaultSerializer {
       Adds a leading comma if this is not the first pair in the map.
     */
     proc ref writeKey(const key: ?) throws {
-      if !_first then writer._writeLiteral(", ");
+      if !_first then writer.writeLiteral(", ");
       else _first = false;
 
       writer.write(key);
@@ -3095,7 +3095,7 @@ record defaultSerializer {
       Serialize ``val``, preceded by the character ``:``.
     */
     proc writeValue(const val: ?) throws {
-      writer._writeLiteral(": ");
+      writer.writeLiteral(": ");
       writer.write(val);
     }
 
@@ -3103,7 +3103,7 @@ record defaultSerializer {
       Ends serialization of the current map by writing the character ``}``
     */
     proc endMap() throws {
-      writer._writeLiteral("}");
+      writer.writeLiteral("}");
     }
   }
 }
@@ -3363,7 +3363,7 @@ record defaultDeserializer {
     :returns: A new :type:`ListDeserializer`
   */
   proc ref startList(reader: fileReader) throws {
-    reader._readLiteral("[");
+    reader.readLiteral("[");
     return new ListDeserializer(reader);
   }
 
@@ -3383,7 +3383,7 @@ record defaultDeserializer {
       :returns: A deserialized value of type ``eltType``.
     */
     proc ref readElement(type eltType) : eltType throws {
-      if !_first then reader._readLiteral(",");
+      if !_first then reader.readLiteral(",");
       else _first = false;
 
       return reader.read(eltType);
@@ -3393,7 +3393,7 @@ record defaultDeserializer {
       Deserialize ``element`` in-place as an element of the list.
     */
     proc ref readElement(ref element) throws {
-      if !_first then reader._readLiteral(",");
+      if !_first then reader.readLiteral(",");
       else _first = false;
 
       reader.read(element);
@@ -3403,7 +3403,7 @@ record defaultDeserializer {
       End deserialization of the current list by reading the character ``]``.
     */
     proc endList() throws {
-      reader._readLiteral("]");
+      reader.readLiteral("]");
     }
 
     /*
@@ -3473,7 +3473,7 @@ record defaultDeserializer {
       :returns: A deserialized value of type ``eltType``.
     */
     proc ref readElement(type eltType) : eltType throws {
-      if !_first then reader._readLiteral(" ");
+      if !_first then reader.readLiteral(" ");
       else _first = false;
 
       return reader.read(eltType);
@@ -3483,7 +3483,7 @@ record defaultDeserializer {
       Deserialize ``element`` in-place as an element of the array.
     */
     proc ref readElement(ref element) throws {
-      if !_first then reader._readLiteral(" ");
+      if !_first then reader.readLiteral(" ");
       else _first = false;
 
       reader.read(element);
@@ -3504,7 +3504,7 @@ record defaultDeserializer {
     :returns: A new :type:`MapDeserializer`
   */
   proc startMap(reader: fileReader) throws {
-    reader._readLiteral("{");
+    reader.readLiteral("{");
     return new MapDeserializer(reader);
   }
 
@@ -3524,7 +3524,7 @@ record defaultDeserializer {
       Deserialize and return a key of type ``keyType``.
     */
     proc ref readKey(type keyType) : keyType throws {
-      if !_first then reader._readLiteral(", ");
+      if !_first then reader.readLiteral(", ");
       else _first = false;
 
       return reader.read(keyType);
@@ -3534,7 +3534,7 @@ record defaultDeserializer {
       Deserialize ``key`` in-place as a key of the map.
     */
     proc ref readKey(ref key) throws {
-      if !_first then reader._readLiteral(", ");
+      if !_first then reader.readLiteral(", ");
       else _first = false;
 
       reader.read(key);
@@ -3544,7 +3544,7 @@ record defaultDeserializer {
       Deserialize and return a value of type ``valType``.
     */
     proc readValue(type valType) : valType throws {
-      reader._readLiteral(": ");
+      reader.readLiteral(": ");
 
       return reader.read(valType);
     }
@@ -3553,7 +3553,7 @@ record defaultDeserializer {
       Deserialize ``value`` in-place as a value of the map.
     */
     proc readValue(ref value) throws {
-      reader._readLiteral(": ");
+      reader.readLiteral(": ");
 
       reader.read(value);
     }
@@ -3562,7 +3562,7 @@ record defaultDeserializer {
       End deserialization of the current map by reading the character ``}``.
     */
     proc endMap() throws {
-      reader._readLiteral("}");
+      reader.readLiteral("}");
     }
 
     /*
@@ -6994,15 +6994,6 @@ inline proc fileReader._readLiteralCommon(x:?t, ignore:bool,
   }
 }
 
-// non-unstable version we can use internally
-@chpldoc.nodoc
-inline
-proc fileReader._readLiteral(literal:string,
-                             ignoreWhitespace=true) : void throws {
-  var iolit = new chpl_ioLiteral(literal, ignoreWhitespace);
-  this.readIt(iolit);
-}
-
 /*
   Advances the offset of a ``fileReader`` within the file by reading the exact
   text of the given string ``literal`` from the fileReader.
@@ -7205,13 +7196,6 @@ proc fileWriter._writeLiteralCommon(x:?t) : void throws {
                                           x.numBytes:c_ssize_t);
     try _checkLiteralError(x, err, "writing", isLiteral=true);
   }
-}
-
-@chpldoc.nodoc
-inline
-proc fileWriter._writeLiteral(literal:string) : void throws {
-  var iolit = new chpl_ioLiteral(literal);
-  this.writeIt(iolit);
 }
 
 /*

--- a/modules/standard/JSON.chpl
+++ b/modules/standard/JSON.chpl
@@ -104,7 +104,7 @@ module JSON {
         _oldWrite(writer, val);
       } else if isClassType(t) {
         if val == nil {
-          writer._writeLiteral("null");
+          writer.writeLiteral("null");
         } else {
           val!.serialize(writer=writer, serializer=this);
         }
@@ -169,11 +169,11 @@ module JSON {
         the name if this is not the first field.
       */
       proc ref writeField(name: string, const field: ?) throws {
-        if !_first then writer._writeLiteral(", ");
+        if !_first then writer.writeLiteral(", ");
         else _first = false;
 
         writer.write(name);
-        writer._writeLiteral(":");
+        writer.writeLiteral(":");
         writer.write(field);
       }
 
@@ -216,7 +216,7 @@ module JSON {
       */
       proc endClass() throws {
         if !_parent then
-          writer._writeLiteral(_ending);
+          writer.writeLiteral(_ending);
         else if _firstPtr != nil then
           _firstPtr.deref() = _first;
       }
@@ -226,7 +226,7 @@ module JSON {
         ``}``.
       */
       proc endRecord() throws {
-        writer._writeLiteral(_ending);
+        writer.writeLiteral(_ending);
       }
     }
 
@@ -286,7 +286,7 @@ module JSON {
         first element in the list.
       */
       proc ref writeElement(const element: ?) throws {
-        if !_first then writer._writeLiteral(", ");
+        if !_first then writer.writeLiteral(", ");
         else _first = false;
 
         writer.write(element);
@@ -377,7 +377,7 @@ module JSON {
         if _arrayFirst[_arrayDim-1] {
           _arrayFirst[_arrayDim-1] = false;
         } else {
-          writer._writeLiteral(",");
+          writer.writeLiteral(",");
         }
 
         _arrayMax = max(_arrayMax, _arrayDim);
@@ -389,7 +389,7 @@ module JSON {
         }
 
         // Actually start the JSON list format
-        writer._writeLiteral("[");
+        writer.writeLiteral("[");
       }
 
       /*
@@ -407,11 +407,11 @@ module JSON {
         */
         if _arrayDim < _arrayMax {
           writer.writeNewline();
-          writer._writeLiteral(" " * (_arrayDim-1));
+          writer.writeLiteral(" " * (_arrayDim-1));
         }
 
         // Actually close out the list
-        writer._writeLiteral("]");
+        writer.writeLiteral("]");
 
         // Reset the 'first' property so that a later 'pane' of this dimension
         // prints correctly. For example:
@@ -439,7 +439,7 @@ module JSON {
         Writes a leading comma if this is not the first element in the row.
       */
       proc ref writeElement(const element: ?) throws {
-        if !_first then writer._writeLiteral(", ");
+        if !_first then writer.writeLiteral(", ");
         else _first = false;
 
         writer.write(element);
@@ -461,7 +461,7 @@ module JSON {
       :returns: A new :type:`MapSerializer`
     */
     proc startMap(writer: jsonWriter, size: int) throws {
-      writer._writeLiteral("{");
+      writer.writeLiteral("{");
       return new MapSerializer(writer);
     }
 
@@ -508,12 +508,12 @@ module JSON {
       */
       proc ref writeKey(const key: ?) throws {
         if !_first {
-          writer._writeLiteral(", ");
+          writer.writeLiteral(", ");
           writer.writeNewline();
-          writer._writeLiteral("  ");
+          writer.writeLiteral("  ");
         } else {
           writer.writeNewline();
-          writer._writeLiteral("  ");
+          writer.writeLiteral("  ");
           _first = false;
         }
 
@@ -536,7 +536,7 @@ module JSON {
         Serialize ``val``, preceded by the character ``:``.
       */
       proc writeValue(const val: ?) throws {
-        writer._writeLiteral(": ");
+        writer.writeLiteral(": ");
         writer.write(val);
       }
 
@@ -545,7 +545,7 @@ module JSON {
       */
       proc endMap() throws {
         writer.writeNewline();
-        writer._writeLiteral("}");
+        writer.writeLiteral("}");
       }
     }
   }
@@ -756,10 +756,10 @@ module JSON {
       @chpldoc.nodoc
       proc _readFieldName(reader: jsonReader, key: string) throws {
         try {
-          reader._readLiteral('"');
-          reader._readLiteral(key);
-          reader._readLiteral('"');
-          reader._readLiteral(":");
+          reader.readLiteral('"');
+          reader.readLiteral(key);
+          reader.readLiteral('"');
+          reader.readLiteral(":");
         } catch e: BadFormatError {
           return false;
         }
@@ -891,7 +891,7 @@ module JSON {
       :returns: A new :type:`ListDeserializer`
     */
     proc startList(reader: jsonReader) throws {
-      reader._readLiteral("[");
+      reader.readLiteral("[");
       return new ListDeserializer(reader);
     }
 
@@ -914,7 +914,7 @@ module JSON {
         :returns: A deserialized value of type ``eltType``.
       */
       proc ref readElement(type eltType) : eltType throws {
-        if !_first then reader._readLiteral(",");
+        if !_first then reader.readLiteral(",");
         else _first = false;
 
         // preemptively check if a list will end with the next byte
@@ -929,7 +929,7 @@ module JSON {
         Deserialize ``element`` in-place.
       */
       proc ref readElement(ref element) throws {
-        if !_first then reader._readLiteral(",");
+        if !_first then reader.readLiteral(",");
         else _first = false;
 
         if !this.hasMore()
@@ -942,7 +942,7 @@ module JSON {
         ``]``.
       */
       proc endList() throws {
-        reader._readLiteral("]");
+        reader.readLiteral("]");
       }
 
       /*
@@ -1009,7 +1009,7 @@ module JSON {
         if _arrayFirst[_arrayDim-1] {
           _arrayFirst[_arrayDim-1] = false;
         } else {
-          reader._readLiteral(",");
+          reader.readLiteral(",");
         }
 
         _arrayMax = max(_arrayMax, _arrayDim);
@@ -1017,7 +1017,7 @@ module JSON {
         // Don't need to read the newline and pretty-printed spaces, as JSON
         // arrays can come in other forms. Relies on 'readLiteral' ignoring
         // whitespace by default.
-        reader._readLiteral("[");
+        reader.readLiteral("[");
       }
 
       /*
@@ -1026,13 +1026,13 @@ module JSON {
       proc ref endDim() throws {
         if _arrayDim < _arrayMax {
           reader.readNewline();
-          reader._readLiteral(" " * (_arrayDim-1));
+          reader.readLiteral(" " * (_arrayDim-1));
         }
 
         // Don't need to read the newline and pretty-printed spaces, as JSON
         // arrays can come in other forms. Relies on 'readLiteral' ignoring
         // whitespace by default.
-        reader._readLiteral("]");
+        reader.readLiteral("]");
 
         if _arrayDim < _arrayFirst.size then
           _arrayFirst[_arrayDim] = true;
@@ -1047,7 +1047,7 @@ module JSON {
         :returns: A deserialized value of type ``eltType``.
       */
       proc ref readElement(type eltType) : eltType throws {
-        if !_first then reader._readLiteral(", ");
+        if !_first then reader.readLiteral(", ");
         else _first = false;
 
         return reader.read(eltType);
@@ -1057,7 +1057,7 @@ module JSON {
         Deserialize ``element`` in-place as an element of the array.
       */
       proc ref readElement(ref element) throws {
-        if !_first then reader._readLiteral(", ");
+        if !_first then reader.readLiteral(", ");
         else _first = false;
 
         reader.read(element);
@@ -1078,7 +1078,7 @@ module JSON {
       :returns: A new :type:`MapDeserializer`
     */
     proc startMap(reader: jsonReader) throws {
-      reader._readLiteral("{");
+      reader.readLiteral("{");
       return new MapDeserializer(reader);
     }
 
@@ -1098,7 +1098,7 @@ module JSON {
         Deserialize and return a key of type ``keyType``.
       */
       proc ref readKey(type keyType) : keyType throws {
-        if !_first then reader._readLiteral(",");
+        if !_first then reader.readLiteral(",");
         else _first = false;
 
         if keyType == string {
@@ -1119,7 +1119,7 @@ module JSON {
         Deserialize ``key`` in-place as a key of the map.
       */
       proc ref readKey(ref key: ?t) throws {
-        if !_first then reader._readLiteral(",");
+        if !_first then reader.readLiteral(",");
         else _first = false;
 
         if t == string || t == bytes {
@@ -1140,7 +1140,7 @@ module JSON {
         Deserialize and return a value of type ``valType``.
       */
       proc readValue(type valType) : valType throws {
-        reader._readLiteral(":");
+        reader.readLiteral(":");
         return reader.read(valType);
       }
 
@@ -1148,7 +1148,7 @@ module JSON {
         Deserialize ``value`` in-place as a value of the map.
       */
       proc readValue(ref value) throws {
-        reader._readLiteral(":");
+        reader.readLiteral(":");
         reader.read(value);
       }
 
@@ -1156,7 +1156,7 @@ module JSON {
         End deserialization of the current map by reading the character ``}``.
       */
       proc endMap() throws {
-        reader._readLiteral("}");
+        reader.readLiteral("}");
       }
 
       /*

--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -1819,13 +1819,13 @@ module List {
         // Write the number of elements
         ch.write(_size);
       } else {
-        ch._writeLiteral("[");
+        ch.writeLiteral("[");
       }
 
       for i in 0..(_size - 2) {
         ch.write(_getRef(i));
         if !isBinary {
-          ch._writeLiteral(", ");
+          ch.writeLiteral(", ");
         }
       }
 
@@ -1833,7 +1833,7 @@ module List {
         ch.write(_getRef(_size-1));
 
       if !isBinary {
-        ch._writeLiteral("]");
+        ch.writeLiteral("]");
       }
 
       _leave();
@@ -1843,17 +1843,17 @@ module List {
     proc _writeJson(ch: fileWriter) throws {
       _enter();
 
-      ch._writeLiteral("[");
+      ch.writeLiteral("[");
 
       for i in 0..(_size - 2) {
         ch.writef("%jt", _getRef(i));
-        ch._writeLiteral(", ");
+        ch.writeLiteral(", ");
       }
 
       if _size > 0 then
         ch.writef("%jt", _getRef(_size-1));
 
-      ch._writeLiteral("]");
+      ch.writeLiteral("]");
 
       _leave();
     }
@@ -1903,7 +1903,7 @@ module List {
         var isFirst = true;
         var hasReadEnd = false;
 
-        ch._readLiteral("[");
+        ch.readLiteral("[");
 
         while !hasReadEnd {
           if isFirst {
@@ -1911,7 +1911,7 @@ module List {
 
             // Try reading an end bracket. If we don't, then continue on.
             try {
-              ch._readLiteral("]");
+              ch.readLiteral("]");
               hasReadEnd = true;
               break;
             } catch err: BadFormatError {
@@ -1921,7 +1921,7 @@ module List {
 
             // Try to read a comma. Break if we don't.
             try {
-              ch._readLiteral(",");
+              ch.readLiteral(",");
             } catch err: BadFormatError {
               break;
             }
@@ -1934,7 +1934,7 @@ module List {
         }
 
         if !hasReadEnd {
-          ch._readLiteral("]");
+          ch.readLiteral("]");
         }
       }
 
@@ -1949,13 +1949,13 @@ module List {
       _enter();
       _clearLocked();
 
-      ch._readLiteral("[");
+      ch.readLiteral("[");
 
       while !ch.matchLiteral("]") {
         if isFirst {
           isFirst = false;
         } else {
-          ch._readLiteral(",");
+          ch.readLiteral(",");
         }
 
         // read an element

--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -615,17 +615,17 @@ module Map {
       _enter(); defer _leave();
       var first = true;
 
-      ch._readLiteral("{");
+      ch.readLiteral("{");
 
       while !ch.matchLiteral("}") {
         if first {
           first = false;
         } else {
-          ch._readLiteral(",");
+          ch.readLiteral(",");
         }
         var k : keyType;
         ch.readf("%jt", k);
-        ch._readLiteral(":");
+        ch.readLiteral(":");
         var v : valType;
         ch.readf("%jt", v);
         add(k, v);
@@ -695,25 +695,25 @@ module Map {
       _enter(); defer _leave();
       var first = true;
 
-      ch._writeLiteral("{");
+      ch.writeLiteral("{");
 
       for slot in table.allSlots() {
         if table.isSlotFull(slot) {
           if first {
             first = false;
           } else {
-            ch._writeLiteral(", ");
+            ch.writeLiteral(", ");
           }
           ref tabEntry = table.table[slot];
           ref key = tabEntry.key;
           ref val = tabEntry.val;
           ch.writef("%jt", key);
-          ch._writeLiteral(": ");
+          ch.writeLiteral(": ");
           ch.writef("%jt", val);
         }
       }
 
-      ch._writeLiteral("}");
+      ch.writeLiteral("}");
     }
 
     @chpldoc.nodoc
@@ -738,7 +738,7 @@ module Map {
       _enter(); defer _leave();
       var first = true;
       proc rwLiteral(lit:string) throws {
-        if ch._writing then ch._writeLiteral(lit); else ch._readLiteral(lit);
+        if ch._writing then ch.writeLiteral(lit); else ch.readLiteral(lit);
       }
       rwLiteral("{");
       for slot in table.allSlots() {

--- a/modules/standard/Time.chpl
+++ b/modules/standard/Time.chpl
@@ -635,9 +635,9 @@ module Time {
     const dash = "-";
 
     chpl_year = f.read(int);
-    f._readLiteral(dash);
+    f.readLiteral(dash);
     chpl_month = f.read(int);
-    f._readLiteral(dash);
+    f.readLiteral(dash);
     chpl_day = f.read(int);
   }
 
@@ -651,12 +651,12 @@ module Time {
             isSubtype(f.deserializerType, jsonDeserializer);
 
     if isjson then
-      f._readLiteral('"');
+      f.readLiteral('"');
 
     this._readCore(f);
 
     if isjson then
-      f._readLiteral('"');
+      f.readLiteral('"');
   }
 
   /* Reads this `date` with the same format used by :proc:`date.serialize` */
@@ -969,11 +969,11 @@ module Time {
     const colon = ":";
 
     chpl_hour = f.read(int);
-    f._readLiteral(colon);
+    f.readLiteral(colon);
     chpl_minute = f.read(int);
-    f._readLiteral(colon);
+    f.readLiteral(colon);
     chpl_second = f.read(int);
-    f._readLiteral(".");
+    f.readLiteral(".");
     chpl_microsecond = f.read(int);
   }
 
@@ -987,12 +987,12 @@ module Time {
             isSubtype(f.deserializerType, jsonDeserializer);
 
     if isjson then
-      f._readLiteral('"');
+      f.readLiteral('"');
 
     this._readCore(f);
 
     if isjson then
-      f._readLiteral('"');
+      f.readLiteral('"');
   }
 
   /* Reads this `time` with the same format used by :proc:`time.serialize` */
@@ -1714,14 +1714,14 @@ module Time {
             isSubtype(f.deserializerType, jsonDeserializer);
 
     if isjson then
-      f._readLiteral('"');
+      f.readLiteral('"');
 
     chpl_date._readCore(f);
-    f._readLiteral("T");
+    f.readLiteral("T");
     chpl_time._readCore(f);
 
     if isjson then
-      f._readLiteral('"');
+      f.readLiteral('"');
   }
 
   /* Reads this `dateTime` with the same format used by

--- a/test/library/draft/DistributedMap/v2/DistributedMap.chpl
+++ b/test/library/draft/DistributedMap/v2/DistributedMap.chpl
@@ -424,14 +424,14 @@ module DistributedMap {
       }
 
       var first = true;
-      ch._readLiteral("{");
+      ch.readLiteral("{");
 
       while true {
         if first {
           first = false;
         } else {
           try {
-            ch._readLiteral(", ");
+            ch.readLiteral(", ");
           } catch {
             // If we can't find the `, ` then it's probably the end of the map
             break;
@@ -442,13 +442,13 @@ module DistributedMap {
         var val: valType;
 
         ch.read(key);
-        ch._readLiteral(": ");
+        ch.readLiteral(": ");
         ch.read(val);
 
         this.addOrReplaceUnlocked(key, val);
       }
 
-      ch._readLiteral("}");
+      ch.readLiteral("}");
 
       for i in locDom {
         locks[i].unlock();


### PR DESCRIPTION
The "_readLiteral" and "_writeLiteral" methods were created at a time when the "readLiteral" and "writeLiteral" methods were unstable, and could not be called from internal or standard modules. Now that the original methods are stable, we can remove these helpers.

Testing:
- [x] local paratest