### PR TITLE
Add fma to Math docs index

### DIFF
--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -155,6 +155,12 @@ Bessel Functions
 :proc:`~Math.y1`
 :proc:`~Math.yn`
 
+.. _math-other:
+
+Remaining Functions
+^^^^^^^^^^^^^^^^^^^
+:proc:`~Math.fma`
+
 .. _automath-constant-and-function-definitions:
 
 Automatically Included Constant and Function Definitions

--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -155,10 +155,10 @@ Bessel Functions
 :proc:`~Math.y1`
 :proc:`~Math.yn`
 
-.. _math-other:
+.. _math-optimization:
 
-Remaining Functions
-^^^^^^^^^^^^^^^^^^^
+Optimization Functions
+^^^^^^^^^^^^^^^^^^^^^^
 :proc:`~Math.fma`
 
 .. _automath-constant-and-function-definitions:


### PR DESCRIPTION
Adds the newly added `fma` function to the list of Math functions at the top of the Math module.

Tested `test/library/standard/Math/docs` locally

[Reviewed by @lydia-duncan]