### PR TITLE
Fix sporadic failures with heat-1d example

### DIFF
--- a/test/exercises/diffusion-1D/heat_1d_tasks.chpl
+++ b/test/exercises/diffusion-1D/heat_1d_tasks.chpl
@@ -55,12 +55,10 @@ proc taskSimulate(tid) {
     uLocal1[omegaLocal] = u[omegaLocal];
     uLocal2 = uLocal1;
 
-    // synchronize with other tasks
-    b.barrier();
-
     // iterate for 'nt' time steps
     for 1..nt {
       // copy results from previous iteration into neighbors' halo cells
+      b.barrier();
       if tid != 0        then halos[tid-1][RIGHT] = uLocal2[omegaLocal.low];
       if tid != nTasks-1 then halos[tid+1][LEFT] = uLocal2[omegaLocal.high];
 


### PR DESCRIPTION
One of the tests introduced in https://github.com/chapel-lang/chapel/pull/23583 (`exercises/diffusion-1D/heat_1d_tasks.chpl`) was failing sporadically due to slight numerical inaccuracies. This PR adds a missing barrier to correct the issue.

- [x] passing w/ `CHPL_COMM=none`, `CHPL_TASKS=fifo`, numtrials=1000
- [x] passing w/ `CHPL_COMM=gasnet`, `CHPL_TASKS=qthreads`, numtrials=250