### PR TITLE
Set `-Wl,-rpath` in Socket tests' COMPOPTS

### DIFF
--- a/test/library/packages/Socket/COMPOPTS
+++ b/test/library/packages/Socket/COMPOPTS
@@ -2,5 +2,6 @@
 
 ccflags=$(pkg-config --cflags libevent)
 ldflags=$(pkg-config --libs libevent)
+libdir=$(pkg-config --variable=libdir libevent)
 
-echo "${ccflags:+--ccflags '$ccflags'} ${ldflags:+--ldflags '$ldflags'}"
+echo "${ccflags:+--ccflags \"$ccflags\"} ${ldflags:+--ldflags \"$ldflags -Wl,-rpath,$libdir\"}"


### PR DESCRIPTION
Adds missing `libevent` `-rpath` linker argument to enable running Socket package tests on chapdl.

Resolves https://github.com/Cray/chapel-private/issues/5016.

[reviewer info placeholder]

Testing:
- [x] tests in `test/library/packages/Socket` pass on chapdl