### PR TITLE
Fix error message with chpl_ioLiteral

### DIFF
--- a/test/io/serializers/inflexible-types.bad
+++ b/test/io/serializers/inflexible-types.bad
@@ -21,4 +21,4 @@ SUCCESS: date
 --------------------
 "2002-03-01T00:00:00"
 ====================
-ERROR: BadFormatError: bad format: missing expected literal (while reading chpl_ioLiteral "." with path "unknown" offset 20)
+ERROR: BadFormatError: bad format: missing expected literal (while reading string literal "." with path "unknown" offset 20)


### PR DESCRIPTION
PR #23585 replaced the ``_readLiteral`` and ``_writeLiteral`` helper methods with calls to ``readLiteral`` and ``writeLiteral``. The non-underscore methods have nicer error message text that says "string literal" instead of "chpl_ioLiteral". This PR fixes a stray .bad file that checked the "chpl_ioLiteral" output.