### PR TITLE
Use 'config const' to keep LLVM from statically optimizing FMA call

### DIFF
--- a/test/llvm/fma/FmaHardwareSpecialization.chpl
+++ b/test/llvm/fma/FmaHardwareSpecialization.chpl
@@ -1,12 +1,19 @@
 use Math;
 
-inline proc myfma(x: real(64), y: real(64), z: real(64)) {
-  return x*y+z;
-}
+// We use 'config const' as input so that the target compiler cannot
+// statically optimize away the hardware FMA instruction we're
+// looking for.
+config const x = 2;
+config const y = 2;
+config const z = 2;
+
+// Not used in the test proper, but upon inspection in the disassembly,
+// reveals x*y+z is not optimized into a single instruction.
+inline proc myfma(x, y, z) do return x*y+z;
 
 proc main() {
-  var n1 = fma(2, 2, 2);
-  var n2 = myfma(2, 2, 2);
+  var n1 = fma(x, y, z);
+  var n2 = myfma(x, y, z);
   assert(n1 == n2);
   writeln(n1);
 }


### PR DESCRIPTION
A new LLVM optimization test I added in #23572 failed when run with `--fast` because the LLVM compiler was statically optimizing away the call to the `fma()` intrinsic. This patch modifies the test to use `config const` as inputs to the `fma()` call so that it cannot be inlined away and the machine instruction persists.