### PR TITLE
Make the unstable warning give the correct name for this GPU config

### DIFF
--- a/modules/internal/ChapelGpuSupport.chpl
+++ b/modules/internal/ChapelGpuSupport.chpl
@@ -35,7 +35,7 @@ module ChapelGpuSupport {
   config const gpuSyncWithHostAfterGpuOp = true;
 
   extern var chpl_gpu_use_stream_per_task : bool;
-  @unstable("The variable 'gpuUseDefaultStream' is unstable and its interface is subject to change in the future")
+  @unstable("The variable 'gpuUseStreamPerTask' is unstable and its interface is subject to change in the future")
   config var gpuUseStreamPerTask = CHPL_GPU_MEM_STRATEGY!="unified_memory";
 
   /* If true, upon startup, enables peer-to-peer access between all pairs of


### PR DESCRIPTION
I suspect what happened is that the config's name was changed but we didn't change the unstable warning at the same time.  Regardless of how they got out of sync, they shouldn't be, so unify them again (using the name of the config, since that seems more likely to be right imo)

I didn't see any tests that relied on this unstable output.  Given that the GPU implementation is still evolving, I suspect it doesn't make sense to add a test of it, but I'm happy to try to make one (I just don't necessary know what this config is actually for)