### PR TITLE
Unset CHPL_LLVM_CONFIG to prevent warning in perf playground

### DIFF
--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -32,6 +32,7 @@ SHORT_NAME=llvm-16
 START_DATE=10/05/23
 # this is just for testing LLVM 16
 export CHPL_LLVM=bundled
+unset CHPL_LLVM_CONFIG
 
 git branch -D $GITHUB_USER-$GITHUB_BRANCH
 git checkout -b $GITHUB_USER-$GITHUB_BRANCH


### PR DESCRIPTION
adds `unset CHPL_LLVM_CONFIG` to prevent the warning `Warning: CHPL_LLVM_CONFIG is ignored for CHPL_LLVM=bundled` in the perf playground

[Reviewed by @mppf]
