### PR TITLE
Refactor driver mode tmp file save/restore code to use a helper

### DIFF
--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -242,9 +242,9 @@ void preparePrintLlvmIrForCodegen() {
   // This is so that handlePrintAsm can access them later from phase two, when
   // we don't have a way to determine name->cname correspondence.
   if (fDriverPhaseOne) {
-    for (const auto& cname : llvmPrintIrCNames) {
-      saveDriverTmp(cnamesToPrintFilename, cname);
-    }
+    saveDriverTmpMultiple(cnamesToPrintFilename,
+                          std::vector<const char*>(llvmPrintIrCNames.begin(),
+                                                   llvmPrintIrCNames.end()));
   }
 }
 

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1177,14 +1177,6 @@ static void codegen_aggregate_def(AggregateType* ct) {
   ct->symbol->codegenDef();
 }
 
-static void retrieveCompileCommand() {
-  fileinfo* file = openTmpFile(compileCommandFilename, "r");
-  char buf[4096];
-  INT_ASSERT(fgets(buf, sizeof(buf), file->fptr));
-  compileCommand = astr(buf);
-  closefile(file);
-}
-
 static void genConfigGlobalsAndAbout() {
   GenInfo* info = gGenInfo;
 
@@ -1196,7 +1188,9 @@ static void genConfigGlobalsAndAbout() {
 
   // if we are running as compiler-driver, retrieve compile command saved to tmp
   if (!fDriverDoMonolithic) {
-    retrieveCompileCommand();
+    restoreDriverTmp(compileCommandFilename, [](const char* restoredCommand) {
+      compileCommand = astr(restoredCommand);
+    });
   }
 
   genGlobalString("chpl_compileCommand", compileCommand);

--- a/compiler/include/files.h
+++ b/compiler/include/files.h
@@ -25,6 +25,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <functional>
 #include "vec.h"
 
 extern char executableFilename[FILENAME_MAX+1];
@@ -101,7 +102,7 @@ void saveDriverTmp(const char* tmpFilePath, const char* stringToSave);
 // restoring function.
 // For accessing information saved between driver phases with saveDriverTmp.
 void restoreDriverTmp(const char* tmpFilePath,
-                          void (*restoreSavedString)(const char*));
+                      std::function<void(const char*)> restoreSavedString);
 
 // Restore lib dir, lib name, and inc dir info that was saved to disk, for
 // compiler-driver use.

--- a/compiler/include/files.h
+++ b/compiler/include/files.h
@@ -98,8 +98,10 @@ void addIncInfo(const char* incDir);
 // assumed to not contain newlines.
 // For storing information that needs to be saved between driver phases.
 void saveDriverTmp(const char* tmpFilePath, const char* stringToSave);
+void saveDriverTmpMultiple(const char* tmpFilePath,
+                           std::vector<const char*> stringsToSave);
 // Feed strings from the specified tmp file (one per line) into the given
-// restoring function.
+// restoring function, which should copy any it needs to keep.
 // For accessing information saved between driver phases with saveDriverTmp.
 void restoreDriverTmp(const char* tmpFilePath,
                       std::function<void(const char*)> restoreSavedString);

--- a/compiler/include/files.h
+++ b/compiler/include/files.h
@@ -92,6 +92,17 @@ void addLibPath(const char* filename);
 void addLibFile(const char* filename);
 void addIncInfo(const char* incDir);
 
+// Save provided string into the given tmp file.
+// Appends the given string as a new line in the file. Provided string is
+// assumed to not contain newlines.
+// For storing information that needs to be saved between driver phases.
+void saveDriverTmp(const char* tmpFilePath, const char* stringToSave);
+// Feed strings from the specified tmp file (one per line) into the given
+// restoring function.
+// For accessing information saved between driver phases with saveDriverTmp.
+void restoreDriverTmp(const char* tmpFilePath,
+                          void (*restoreSavedString)(const char*));
+
 // Restore lib dir, lib name, and inc dir info that was saved to disk, for
 // compiler-driver use.
 void restoreLibraryAndIncludeInfo();

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -5310,7 +5310,9 @@ static void handlePrintAsm(std::string dotOFile) {
       disSymArg += "_";
     }
 
+    // If in driver mode, restore list of C symbols to print from disk.
     if (fDriverPhaseTwo) restorePrintIrCNames();
+
     // TODO: skip calling this (and remove the function) as the set should
     // already have deterministic ordering and be fine to iterate through
     std::vector<std::string> names = gatherPrintLlvmIrCNames();

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -610,13 +610,6 @@ static void setupChplLLVM(void) {
 #endif
 }
 
-static void saveCompileCommand() {
-  // save compile command to file for later use in codegen
-  fileinfo* file = openTmpFile(compileCommandFilename, "w");
-  fprintf(file->fptr, "%s", compileCommand);
-  closefile(file);
-}
-
 static void recordCodeGenStrings(int argc, char* argv[]) {
   compileCommand = astr("chpl ");
   // WARNING: This does not handle arbitrary sequences of escaped characters
@@ -815,8 +808,8 @@ static int runDriverPhaseTwo(int argc, char* argv[]);
 static void runAsCompilerDriver(int argc, char* argv[]) {
   int status = 0;
 
-  // initialize resources that need to be carried over between invocations
-  saveCompileCommand();
+  // Save initial compilation command before re-invocations.
+  saveDriverTmp(compileCommandFilename, compileCommand);
 
   // invoke phase one
   if ((status = runDriverPhaseOne(argc, argv)) != 0) {

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -435,10 +435,8 @@ void addSourceFiles(int numNewFilenames, const char* filename[]) {
       numInputFiles--;
     } else {
       // add file
+      if (firstAddedIdx < 0) firstAddedIdx = cursor;
       inputFilenames[cursor++] = newFilename;
-      if (firstAddedIdx < 0) {
-        firstAddedIdx = cursor;
-      }
     }
   }
   inputFilenames[cursor] = NULL;

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -129,7 +129,7 @@ void saveDriverTmp(const char* tmpFilePath, const char* stringToSave) {
 }
 
 void restoreDriverTmp(const char* tmpFilePath,
-                               void (*restoreSavedString)(const char*)) {
+                      std::function<void(const char*)> restoreSavedString) {
   assert(!fDriverDoMonolithic && "meant for use in driver mode only");
 
   // Create file iff it did not already exist, for simpler reading logic in the
@@ -144,11 +144,11 @@ void restoreDriverTmp(const char* tmpFilePath,
     // remove trailing newline from fgets
     // using strlen here is fine because fgets guarantees null termination
     size_t len = strlen(strBuf);
-    assert(strBuf[len-1] == '\n' && "stored line exceeds maximum length");
+    assert(strBuf[len - 1] == '\n' && "stored line exceeds maximum length");
     strBuf[--len] = '\0';
 
     // invoke restoring function
-    (*restoreSavedString)(strBuf);
+    restoreSavedString(strBuf);
   }
 
   closefile(tmpFile);


### PR DESCRIPTION
Refactors the many instances of ad-hoc saving to/restoring from tmp files on disk for driver mode to all use helper functions in `files.h`.

Previously the same logic was written slightly differently many times. The symbols needing save/restore, which now all go through the helpers, are: `incDirs`, `libDirs`, `libFiles`, `llvmPrintIrCNames`, `compileCommand`, `getMainModuleFilename`, `restoreAdditionalSourceFiles`. Note `incDirs`, `libDirs`, and `libFiles` were already being done in a uniform way through the functions that were adapted to become the helpers. Also, `loadModuleFromBitcode` is not included as it is a more complicated save/restore (of the entire LLVM Module) than the others which are just strings.

Follow up to https://github.com/chapel-lang/chapel/pull/21063.

Completes a component of https://github.com/Cray/chapel-private/issues/5373.

[reviewer info placeholder]

Testing:
- [x] paratest
- [x] paratest with `--compiler-driver`
- [x] C backend paratest with `--compiler-driver`