### PR TITLE
Modify homebrew testing to use new CI settings

### DIFF
--- a/util/packaging/docker/test/Dockerfile
+++ b/util/packaging/docker/test/Dockerfile
@@ -1,12 +1,10 @@
 # This is a container used to run homebrew-ci 
 
-# Get the ubuntu container
-FROM homebrew/ubuntu20.04:latest
+# Get the homebrew ubuntu container
+FROM FROM ghcr.io/homebrew/ubuntu22.04:master
 
 RUN mkdir -p /home/linuxbrew
 
 # COPY chapel.rb and chapel*.tar.gz inside the container to run homebrew install 
 COPY chapel.rb /home/linuxbrew/
 COPY chapel*.tar.gz /home/linuxbrew/
-
-

--- a/util/packaging/docker/test/brew_install.bash
+++ b/util/packaging/docker/test/brew_install.bash
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+export HOMEBREW_SIMULATE_MACOS_ON_LINUX=1
+#Update homebrew
+brew update 
 
 #Script used in docker exec command to test homebrew formula
 brew test-bot --only-tap-syntax


### PR DESCRIPTION
Homebrew moved their CI to use Ubuntu 22.04 and added a flag to allow Linux testing to impersonate a Mac.