### PR TITLE
Fix over-eager ref-maybe-const unstable warning

### DIFF
--- a/compiler/main/checks.cpp
+++ b/compiler/main/checks.cpp
@@ -324,10 +324,15 @@ void maybeIssueRefMaybeConstWarning(ForallStmt* fs, Symbol* sym, std::vector<Cal
     // if a call sets the symbol, warn
     if (callSetsSymbol(sym, ce)) {
       // checking for --warn-unstable done in checkForallRefMaybeConst
+
+      const char* argName = sym->name;
+      if (fs->getFunction() && fs->getFunction()->isMethodOnRecord())
+        argName = "this";
+
       USR_WARN(fs,
                 "inferring a 'ref' intent on an array in a forall is unstable"
                 " - in the future this may require an explicit 'ref' forall intent for '%s'",
-                sym->name);
+                argName);
       break;
     }
   }

--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -717,15 +717,14 @@ std::map<ForallStmt*, std::set<Symbol*>> refMaybeConstForallPairs;
 // It is done on an already-existing, explicit shadow variable
 // or before an implicit shadow variable is to be created.
 //
-// Returns true if the resolved shadow var intent was an implicit ref-maybe-const
-//
-static bool resolveShadowVarTypeIntent(ForallStmt* fs,
+static void resolveShadowVarTypeIntent(ForallStmt* fs,
                                        Symbol* sym,
                                        Type*& type,
                                        ForallIntentTag& intent,
-                                       bool& prune)
+                                       bool& prune,
+                                       bool& implicitRefMaybeConst)
 {
-  bool ret = false;
+  implicitRefMaybeConst = false;
   switch (intent) {
     case TFI_DEFAULT:
     case TFI_CONST:
@@ -750,7 +749,7 @@ static bool resolveShadowVarTypeIntent(ForallStmt* fs,
         if (it == refMaybeConstForallPairs.end())
           it = refMaybeConstForallPairs.insert(it, {fs, {}});
         it->second.insert(sym);
-        ret = true;
+        implicitRefMaybeConst = true;
       }
 
       break;
@@ -806,8 +805,6 @@ static bool resolveShadowVarTypeIntent(ForallStmt* fs,
   // Prune, as discussed in the above comment.
   if (intent == TFI_REF)
     prune = true;
-
-  return ret;
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -883,9 +880,10 @@ static void doImplicitShadowVars(ForallStmt* fs, BlockStmt* block,
     ForallIntentTag intent = TFI_DEFAULT;
     Type* type  = sym->type;
     bool  prune = false;
+    bool  implicitRMC = false;
     if (sym->type == dtUnknown)
       USR_FATAL(se, "'%s' appears to be used before it is defined", sym->name);
-    resolveShadowVarTypeIntent(fs, sym, type, intent, prune); // updates the args
+    resolveShadowVarTypeIntent(fs, sym, type, intent, prune, implicitRMC); // updates the args
 
     if (prune) {                      // do not convert to shadow var
       assertNotRecordReceiver(sym, se);
@@ -954,7 +952,8 @@ static void resolveAndPruneExplicitShadowVars(ForallStmt* fs,
   {
     Type* type  = ovarOrSvarType(svar);
     bool  prune = false;
-    resolveShadowVarTypeIntent(fs, svar, type, svar->intent, prune); // updates the args
+    bool  implicitRMC = false;
+    resolveShadowVarTypeIntent(fs, svar, type, svar->intent, prune, implicitRMC); // updates the args
 
     // Ensure the svar is retained for a `this` with an explicit intent,
     // see convertFieldsOfRecordThis().
@@ -1029,7 +1028,8 @@ static ShadowVarSymbol* createSVforFieldAccess(ForallStmt* fs, Symbol* ovar,
   Type*           svarType   = field->type;
   ForallIntentTag svarIntent = isConst ? TFI_CONST : TFI_DEFAULT;
   bool            pruneDummy = false;
-  bool wasImplicitRef = resolveShadowVarTypeIntent(fs, field, svarType, svarIntent, pruneDummy);
+  bool            wasImplicitRef = false;
+  resolveShadowVarTypeIntent(fs, field, svarType, svarIntent, pruneDummy, wasImplicitRef);
 
   ShadowVarSymbol* svar = new ShadowVarSymbol(svarIntent,
                                               astr(field->name, "_svar"),

--- a/test/unstable/ref-maybe-const-forall-intent.chpl
+++ b/test/unstable/ref-maybe-const-forall-intent.chpl
@@ -118,3 +118,11 @@ forall i in 1..10 with (ref myArrayD) do myArrayD(i) = i;
     f(Counts[key]);
   }
 }
+
+{
+  var A: [1..10] int;
+  var B: [1..10] int;
+  forall i in A.domain with (ref B) { // should not warn for A or B
+    B[i] = A[i] * 10 + A.localAccess[i];
+  }
+}

--- a/test/unstable/ref-maybe-const-forall-intent.good
+++ b/test/unstable/ref-maybe-const-forall-intent.good
@@ -7,7 +7,7 @@ ref-maybe-const-forall-intent.chpl:87: warning: inferring a 'ref' intent on an a
 ref-maybe-const-forall-intent.chpl:89: warning: inferring a 'ref' intent on an array in a forall is unstable - in the future this may require an explicit 'ref' forall intent for 'myArray1'
 ref-maybe-const-forall-intent.chpl:92: warning: inferring a 'ref' intent on an array in a forall is unstable - in the future this may require an explicit 'ref' forall intent for 'myArray1'
 ref-maybe-const-forall-intent.chpl:98: In method 'foo':
-ref-maybe-const-forall-intent.chpl:99: warning: inferring a 'ref' intent on an array in a forall is unstable - in the future this may require an explicit 'ref' forall intent for 'A'
+ref-maybe-const-forall-intent.chpl:99: warning: inferring a 'ref' intent on an array in a forall is unstable - in the future this may require an explicit 'ref' forall intent for 'this'
 ref-maybe-const-forall-intent.chpl:2: warning: inferring a 'ref' intent on an array in a forall is unstable - in the future this may require an explicit 'ref' forall intent for 'myArray1'
 ref-maybe-const-forall-intent.chpl:31: warning: inferring a 'ref' intent on an array in a forall is unstable - in the future this may require an explicit 'ref' forall intent for 'B'
 ref-maybe-const-forall-intent.chpl:50: warning: inferring a 'ref' intent on an array in a forall is unstable - in the future this may require an explicit 'ref' forall intent for 'myArrayD'


### PR DESCRIPTION
Resolves an issue were the ref-maybe-const unstable warning on foralls was over-eager and warning for incorrect cases. 

The warning was made extra eager in https://github.com/chapel-lang/chapel/pull/23518, but it is too eager and would warn for `B` incorrectly for something like
```
forall i in 1..10 with (ref A) do A[i] = B[i];
```

The fix to make this less eager caused the warning for foralls inside of record methods to no longer work, requiring a fix for that as well. While there, I improved the warning to tell users to use a ref intent for 'this'.

## Testing
- [x] paratest
- [x] paratest with gasnet
- [x] paratest with CHPL_GPU=nvidia

[Reviewed by @e-kayrakli]