### PR TITLE
Update test scripts to not run local 'sub_test' scripts for performance runs

### DIFF
--- a/util/test/start_test.py
+++ b/util/test/start_test.py
@@ -327,9 +327,10 @@ def test_directory(test, test_type):
                         are_tests = True
                         break
 
-            run_local_sub_test = os.access(os.path.join(dir, "sub_test"), os.X_OK)
-            if args.performance:
-                run_local_sub_test = False
+            # don't run local 'sub_test's on --performance or --gen-graphs runs
+            run_local_sub_test = False
+            if test_type == "run":
+                run_local_sub_test = os.access(os.path.join(dir, "sub_test"), os.X_OK)
 
             # check a lot of stuff before continuing
             if are_tests or run_local_sub_test:

--- a/util/test/start_test.py
+++ b/util/test/start_test.py
@@ -327,8 +327,12 @@ def test_directory(test, test_type):
                         are_tests = True
                         break
 
+            run_local_sub_test = os.access(os.path.join(dir, "sub_test"), os.X_OK)
+            if args.performance:
+                run_local_sub_test = False
+
             # check a lot of stuff before continuing
-            if are_tests or os.access(os.path.join(dir, "sub_test"), os.X_OK):
+            if are_tests or run_local_sub_test:
                 # cd to dir for clean and run, saving current location
                 with cd(dir):
                     # clean dir


### PR DESCRIPTION
This updates our test scripts to not run local `sub_test` scripts when we're in `-performance` or `--gen-graphs` modes.  The motivations for this are that none of our current `sub_test` scripts are used for performance runs, so we're effectively doing bonus correctness runs while doing performance testing (or generating graphs) that are not necessary and may introduce failures that we don't care about / shouldn't be testing in those configuration to begin with.

I reviewed the existing `sub_test` scripts and didn't find any whose directories seemed to be involved in performance testing.  I'm also polling the performance team to make sure nobody's aware of any cases that are subtly disguised.

If, in some future, we want a way to run a custom `sub_test` for a performance run, we'll need to think about how to do that.  But given how averse we generally are to custom `sub_test` scripts and that we haven't found ourselves wanting them for performance testing before now, I'm hoping that won't happen.

Resolves https://github.com/Cray/chapel-private/issues/5490