### PR TITLE
Add support for the `: interface` syntax for unions.

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -3138,6 +3138,8 @@ void AggregateType::addClassToHierarchy(std::set<AggregateType*>& localSeen) {
 
     if (this->isRecord()) {
       USR_FATAL(expr, "inheritance is not currently supported for records");
+    } else if (this->isUnion()) {
+      USR_FATAL(expr, "inheritance is not currently supported for unions");
     }
 
     if (firstParent) {

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -3966,10 +3966,8 @@ struct Converter {
     bool inheritMarkedGeneric = false;
 
     std::vector<Expr*> inherits;
-    if (auto cls = node->toClass()) {
-      convertInheritsExprs(cls->inheritExprs(), inherits, inheritMarkedGeneric);
-    } else if (auto rec = node->toRecord()) {
-      convertInheritsExprs(rec->inheritExprs(), inherits, inheritMarkedGeneric);
+    if (auto ad = node->toAggregateDecl()) {
+      convertInheritsExprs(ad->inheritExprs(), inherits, inheritMarkedGeneric);
     }
 
     if (node->linkageName()) {

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -3969,7 +3969,7 @@ struct Converter {
     if (auto cls = node->toClass()) {
       convertInheritsExprs(cls->inheritExprs(), inherits, inheritMarkedGeneric);
     } else if (auto rec = node->toRecord()) {
-      convertInheritsExprs(rec->interfaceExprs(), inherits, inheritMarkedGeneric);
+      convertInheritsExprs(rec->inheritExprs(), inherits, inheritMarkedGeneric);
     }
 
     if (node->linkageName()) {

--- a/frontend/include/chpl/uast/Record.h
+++ b/frontend/include/chpl/uast/Record.h
@@ -44,15 +44,15 @@ namespace uast {
  */
 class Record final : public AggregateDecl {
  private:
-  int interfaceExprChildNum_;
-  int numInterfaceExprs_;
+  int inheritExprChildNum_;
+  int numInheritExprs_;
 
   Record(AstList children, int attributeGroupChildNum, Decl::Visibility vis,
          Decl::Linkage linkage,
          int linkageNameChildNum,
          UniqueString name,
-         int interfaceExprChildNum,
-         int numInterfaceExprs,
+         int inheritExprChildNum,
+         int numInheritExprs,
          int elementsChildNum,
          int numElements)
     : AggregateDecl(asttags::Record, std::move(children),
@@ -63,32 +63,32 @@ class Record final : public AggregateDecl {
                     name,
                     elementsChildNum,
                     numElements),
-      interfaceExprChildNum_(interfaceExprChildNum),
-      numInterfaceExprs_(numInterfaceExprs) {
-    if (interfaceExprChildNum_ != NO_CHILD && elementsChildNum != NO_CHILD) {
-      CHPL_ASSERT(interfaceExprChildNum_ + numInterfaceExprs_ ==
+      inheritExprChildNum_(inheritExprChildNum),
+      numInheritExprs_(numInheritExprs) {
+    if (inheritExprChildNum_ != NO_CHILD && elementsChildNum != NO_CHILD) {
+      CHPL_ASSERT(inheritExprChildNum_ + numInheritExprs_ ==
                   elementsChildNum);
     }
 
-    if (interfaceExprChildNum_ != NO_CHILD) {
-      for (int i = 0; i < numInterfaceExprs_; i++) {
-        CHPL_ASSERT(isAcceptableInheritExpr(child(interfaceExprChildNum_ + i)));
+    if (inheritExprChildNum_ != NO_CHILD) {
+      for (int i = 0; i < numInheritExprs_; i++) {
+        CHPL_ASSERT(isAcceptableInheritExpr(child(inheritExprChildNum_ + i)));
       }
     }
   }
 
   Record(Deserializer& des)
     : AggregateDecl(asttags::Record, des) {
-    interfaceExprChildNum_ = des.read<int>();
-    numInterfaceExprs_ = des.read<int>();
+    inheritExprChildNum_ = des.read<int>();
+    numInheritExprs_ = des.read<int>();
   }
 
   bool contentsMatchInner(const AstNode* other) const override {
     const Record* lhs = this;
     const Record* rhs = (const Record*) other;
     return lhs->aggregateDeclContentsMatchInner(rhs) &&
-           lhs->interfaceExprChildNum_ == rhs->interfaceExprChildNum_ &&
-           lhs->numInterfaceExprs_ == rhs->numInterfaceExprs_;
+           lhs->inheritExprChildNum_ == rhs->inheritExprChildNum_ &&
+           lhs->numInheritExprs_ == rhs->numInheritExprs_;
   }
 
   void markUniqueStringsInner(Context* context) const override {
@@ -106,36 +106,36 @@ class Record final : public AggregateDecl {
                              Decl::Linkage linkage,
                              owned<AstNode> linkageName,
                              UniqueString name,
-                             AstList interfaceExprs,
+                             AstList inheritExprs,
                              AstList contents);
 
-  inline int numInterfaceExprs() const { return numInterfaceExprs_; }
+  inline int numInheritExprs() const { return numInheritExprs_; }
 
   /**
     Return the ith interface implemented as part of this record's declaration.
    */
-  const AstNode* interfaceExpr(int i) const {
-    if (interfaceExprChildNum_ < 0 || i >= numInterfaceExprs_)
+  const AstNode* inheritExpr(int i) const {
+    if (inheritExprChildNum_ < 0 || i >= numInheritExprs_)
       return nullptr;
 
-    auto ret = child(interfaceExprChildNum_ + i);
+    auto ret = child(inheritExprChildNum_ + i);
     return ret;
   }
 
-  AstListNoCommentsIteratorPair<AstNode> interfaceExprs() const {
-    if (interfaceExprChildNum_ < 0)
+  AstListNoCommentsIteratorPair<AstNode> inheritExprs() const {
+    if (inheritExprChildNum_ < 0)
       return AstListNoCommentsIteratorPair<AstNode>(
                 children_.end(), children_.end());
 
     return AstListNoCommentsIteratorPair<AstNode>(
-              children_.begin() + interfaceExprChildNum_,
-              children_.begin() + interfaceExprChildNum_ + numInterfaceExprs_);
+              children_.begin() + inheritExprChildNum_,
+              children_.begin() + inheritExprChildNum_ + numInheritExprs_);
   }
 
   void serialize(Serializer& ser) const override {
     AggregateDecl::serialize(ser);
-    ser.write(interfaceExprChildNum_);
-    ser.write(numInterfaceExprs_);
+    ser.write(inheritExprChildNum_);
+    ser.write(numInheritExprs_);
   }
 
   DECLARE_STATIC_DESERIALIZE(Record);

--- a/frontend/include/chpl/uast/Union.h
+++ b/frontend/include/chpl/uast/Union.h
@@ -48,6 +48,8 @@ class Union final : public AggregateDecl {
         Decl::Linkage linkage,
         int linkageNameChildNum,
         UniqueString name,
+        int inheritExprChildNum,
+        int numInheritExprs,
         int elementsChildNum,
         int numElements)
     : AggregateDecl(asttags::Union, std::move(children),
@@ -56,8 +58,8 @@ class Union final : public AggregateDecl {
                     linkage,
                     linkageNameChildNum,
                     name,
-                    /* inheritExprChildNum */ NO_CHILD,
-                    /* numInheritExprs */ 0,
+                    inheritExprChildNum,
+                    numInheritExprs,
                     elementsChildNum,
                     numElements) {
 
@@ -88,6 +90,7 @@ class Union final : public AggregateDecl {
                             Decl::Linkage linkage,
                             owned<AstNode> linkageName,
                             UniqueString name,
+                            AstList interfaceExprs,
                             AstList contents);
 
   void serialize(Serializer& ser) const override {

--- a/frontend/include/chpl/uast/Union.h
+++ b/frontend/include/chpl/uast/Union.h
@@ -56,6 +56,8 @@ class Union final : public AggregateDecl {
                     linkage,
                     linkageNameChildNum,
                     name,
+                    /* inheritExprChildNum */ NO_CHILD,
+                    /* numInheritExprs */ 0,
                     elementsChildNum,
                     numElements) {
 

--- a/frontend/lib/parsing/ParserContextImpl.h
+++ b/frontend/lib/parsing/ParserContextImpl.h
@@ -2614,23 +2614,17 @@ ParserContext::buildAggregateTypeDecl(YYLTYPE location,
   AstList inheritExprs;
   if (optInherit != nullptr) {
     if (optInherit->size() > 0) {
-      if (parts.tag == asttags::Union) {
-        // TODO union inheritance: unions should have support for inheriting
-        // from interfaces.
-        error(inheritLoc, "unions cannot inherit.");
-      } else {
-        for (size_t i = 0; i < optInherit->size(); i++) {
-          AstNode* ast = (*optInherit)[i];
-          bool inheritOk =
-            chpl::uast::AggregateDecl::isAcceptableInheritExpr(ast);
+      for (size_t i = 0; i < optInherit->size(); i++) {
+        AstNode* ast = (*optInherit)[i];
+        bool inheritOk =
+          chpl::uast::AggregateDecl::isAcceptableInheritExpr(ast);
 
-          if (inheritOk) {
-            inheritExprs.push_back(toOwned(ast));
-            (*optInherit)[i] = nullptr;
-          } else {
-            syntax(inheritLoc,
-                   "invalid parent class or interface; please specify a single class or interface name");
-          }
+        if (inheritOk) {
+          inheritExprs.push_back(toOwned(ast));
+          (*optInherit)[i] = nullptr;
+        } else {
+          syntax(inheritLoc,
+                 "invalid parent class or interface; please specify a single class or interface name");
         }
       }
     }
@@ -2672,6 +2666,7 @@ ParserContext::buildAggregateTypeDecl(YYLTYPE location,
                         parts.linkage,
                         toOwned(parts.linkageName),
                         parts.name,
+                        std::move(inheritExprs),
                         std::move(contentsList)).release();
   } else {
     CHPL_ASSERT(false && "case not handled");

--- a/frontend/lib/uast/AggregateDecl.cpp
+++ b/frontend/lib/uast/AggregateDecl.cpp
@@ -51,7 +51,7 @@ bool AggregateDecl::validAggregateChildren(AstListIteratorPair<AstNode> it) {
 
 std::string AggregateDecl::aggregateDeclDumpChildLabelInner(int i) const {
   if (i >= inheritExprChildNum_ && i  < inheritExprChildNum_ + numInheritExprs_) {
-    return "interface-expr";
+    return "inherit-expr";
   }
 
   return "";

--- a/frontend/lib/uast/AggregateDecl.cpp
+++ b/frontend/lib/uast/AggregateDecl.cpp
@@ -49,6 +49,14 @@ bool AggregateDecl::validAggregateChildren(AstListIteratorPair<AstNode> it) {
   return true;
 }
 
+std::string AggregateDecl::aggregateDeclDumpChildLabelInner(int i) const {
+  if (i >= inheritExprChildNum_ && i  < inheritExprChildNum_ + numInheritExprs_) {
+    return "interface-expr";
+  }
+
+  return "";
+}
+
 AggregateDecl::~AggregateDecl() {
 }
 

--- a/frontend/lib/uast/Class.cpp
+++ b/frontend/lib/uast/Class.cpp
@@ -26,11 +26,7 @@ namespace uast {
 
 
 std::string Class::dumpChildLabelInner(int i) const {
-  if (i >= inheritExprChildNum_ && i  < inheritExprChildNum_ + numInheritExprs_) {
-    return "inherit-expr";
-  }
-
-  return "";
+  return aggregateDeclDumpChildLabelInner(i);
 }
 
 owned<Class> Class::build(Builder* builder, Location loc,

--- a/frontend/lib/uast/Record.cpp
+++ b/frontend/lib/uast/Record.cpp
@@ -25,11 +25,7 @@ namespace chpl {
 namespace uast {
 
 std::string Record::dumpChildLabelInner(int i) const {
-  if (i >= inheritExprChildNum_ && i  < inheritExprChildNum_ + numInheritExprs_) {
-    return "interface-expr";
-  }
-
-  return "";
+  return aggregateDeclDumpChildLabelInner(i);
 }
 
 owned<Record> Record::build(Builder* builder, Location loc,

--- a/frontend/lib/uast/Record.cpp
+++ b/frontend/lib/uast/Record.cpp
@@ -25,7 +25,7 @@ namespace chpl {
 namespace uast {
 
 std::string Record::dumpChildLabelInner(int i) const {
-  if (i >= interfaceExprChildNum_ && i  < interfaceExprChildNum_ + numInterfaceExprs_) {
+  if (i >= inheritExprChildNum_ && i  < inheritExprChildNum_ + numInheritExprs_) {
     return "interface-expr";
   }
 

--- a/frontend/lib/uast/Union.cpp
+++ b/frontend/lib/uast/Union.cpp
@@ -31,10 +31,13 @@ owned<Union> Union::build(Builder* builder, Location loc,
                           Decl::Linkage linkage,
                           owned<AstNode> linkageName,
                           UniqueString name,
+                          AstList interfaceExprs,
                           AstList contents) {
   AstList lst;
   int attributeGroupChildNum = NO_CHILD;
   int elementsChildNum = NO_CHILD;
+  int interfaceExprChildNum = NO_CHILD;
+  int numInterfaceExprs = 0;
   int numElements = contents.size();
   int linkageNameChildNum = NO_CHILD;
 
@@ -48,6 +51,14 @@ owned<Union> Union::build(Builder* builder, Location loc,
     lst.push_back(std::move(linkageName));
   }
 
+  numInterfaceExprs = interfaceExprs.size();
+  if (numInterfaceExprs > 0) {
+    interfaceExprChildNum = lst.size();
+    for (auto& interfaceExpr : interfaceExprs) {
+      lst.push_back(std::move(interfaceExpr));
+    }
+  }
+
   elementsChildNum = lst.size();
   for (auto& ast : contents) {
     lst.push_back(std::move(ast));
@@ -57,6 +68,8 @@ owned<Union> Union::build(Builder* builder, Location loc,
                          linkage,
                          linkageNameChildNum,
                          name,
+                         interfaceExprChildNum,
+                         numInterfaceExprs,
                          elementsChildNum,
                          numElements);
   builder->noteLocation(ret, loc);

--- a/frontend/lib/uast/chpl-syntax-printer.cpp
+++ b/frontend/lib/uast/chpl-syntax-printer.cpp
@@ -1129,11 +1129,11 @@ struct ChplSyntaxVisitor {
     ss_ << "record ";
     ss_ << node->name() << " ";
 
-    if (node->numInterfaceExprs() > 0) {
+    if (node->numInheritExprs() > 0) {
       ss_ << ": ";
       bool printComma = false;
 
-      for (auto interfaceExpr : node->interfaceExprs()) {
+      for (auto interfaceExpr : node->inheritExprs()) {
         if (printComma) ss_ << ", ";
         printAst(interfaceExpr);
       }

--- a/test/constrained-generics/basic/withdecl/withdecl-union-notinterface.chpl
+++ b/test/constrained-generics/basic/withdecl/withdecl-union-notinterface.chpl
@@ -1,0 +1,22 @@
+use Set;
+
+class notAnInterface {}
+
+union myUnion : hashable, notAnInterface {
+    var x: int(64);
+    var y: int(64);
+
+    proc doSomething() {
+        writeln("Doing something!");
+    }
+
+    proc hash(): uint {
+        return 0;
+    }
+
+    // clearly a bad implementation, but the compiler (rightly) doesn't generate
+    // == for us.
+    operator ==(lhs: myUnion, rhs: myUnion) do return false;
+}
+
+var x: set(myUnion);

--- a/test/constrained-generics/basic/withdecl/withdecl-union-notinterface.good
+++ b/test/constrained-generics/basic/withdecl/withdecl-union-notinterface.good
@@ -1,1 +1,1 @@
-withdecl-union-notinterface.chpl:5: error: unions cannot inherit
+withdecl-union-notinterface.chpl:5: error: inheritance is not currently supported for unions

--- a/test/constrained-generics/basic/withdecl/withdecl-union-notinterface.good
+++ b/test/constrained-generics/basic/withdecl/withdecl-union-notinterface.good
@@ -1,0 +1,1 @@
+withdecl-union-notinterface.chpl:5: error: unions cannot inherit

--- a/test/constrained-generics/basic/withdecl/withdecl-union.chpl
+++ b/test/constrained-generics/basic/withdecl/withdecl-union.chpl
@@ -1,0 +1,31 @@
+use Set;
+
+interface myInterface {
+    proc Self.doSomething();
+}
+
+union myUnion : hashable, myInterface {
+    var x: int(64);
+    var y: int(64);
+
+    proc doSomething() {
+        writeln("Doing something!");
+    }
+
+    proc hash(): uint {
+        return 0;
+    }
+
+    // clearly a bad implementation, but the compiler (rightly) doesn't generate
+    // == for us.
+    operator ==(lhs: myUnion, rhs: myUnion) do return false;
+}
+
+
+proc f(x: myInterface) {
+    x.doSomething();
+}
+
+var x: set(myUnion);
+var u: myUnion;
+f(u);

--- a/test/constrained-generics/basic/withdecl/withdecl-union.good
+++ b/test/constrained-generics/basic/withdecl/withdecl-union.good
@@ -1,0 +1,1 @@
+Doing something!

--- a/tools/chpldoc/chpldoc.cpp
+++ b/tools/chpldoc/chpldoc.cpp
@@ -1214,14 +1214,14 @@ struct RstSignatureVisitor {
     if (textOnly_) os_ << "Record: ";
     os_ << r->name().c_str();
 
-    if (r->numInterfaceExprs() > 0) {
+    if (r->numInheritExprs() > 0) {
       os_ << " : ";
       bool printComma = false;
-      for (auto interfaceExpr : r->interfaceExprs()) {
+      for (auto inheritExpr : r->inheritExprs()) {
         if (printComma) os_ << ", ";
         printComma = true;
 
-        interfaceExpr->traverse(*this);
+        inheritExpr->traverse(*this);
       }
     }
     return false;


### PR DESCRIPTION
This turned out a lot simpler than I thought. All this does is:

* Lift the `inheritExprs` from `Class` to `AggregateDecl` (replacing `interfaceExprs` on `Record` with `inheritExprs` too, as a unified accessor). 
* Slightly tweak `Union` to allow it to accept a list of children and to set the `interfaceExprs` of the parent `AggregateDecl` class.
* Slightly tweak the parser to remove the "unions can't inherit" check and just give the union its inherit exprs.

Everything else seems to work as-is!

Reviewed by @mppf -- thanks!

## Testing
- [x] paratest