### PR TITLE
Change the regionArgReader test to be more reliable

### DIFF
--- a/test/library/packages/URL/RunServer.chpl
+++ b/test/library/packages/URL/RunServer.chpl
@@ -1,0 +1,64 @@
+use Subprocess;
+use OS.POSIX;
+use URL;
+use Time;
+use FileSystem;
+
+config const host = "127.0.0.1";
+config const port = "8000";
+
+var server:subprocess(locking=true);
+
+proc startServer() {
+  // Run a curl command to check if the server is already up
+  var check = spawn(["curl", "http://" + host + ":" + port + "/test.txt"],
+                     stdin=pipeStyle.close, stdout=pipeStyle.pipe, stderr=pipeStyle.pipe);
+  check.communicate();
+
+  if check.exitCode == 0 {
+    // Server already running, so nothing to do.
+    return;
+  }
+
+  // Start a little HTTP server
+  server = spawn(["python3", "-m", "http.server", port, "--bind", host],
+                 stdin=pipeStyle.close, stdout=pipeStyle.pipe, stderr=pipeStyle.pipe);
+
+  var ok = false;
+
+  for tries in 1..10 {
+    // Run curl command to make sure server is up
+    // We could use curl to do the retries, but not all curl versions
+    // have the relevant options.
+    var check = spawn(["curl", "http://" + host + ":" + port + "/test.txt"],
+                       stdin=pipeStyle.close, stdout=pipeStyle.pipe, stderr=pipeStyle.pipe);
+    check.communicate();
+
+    if check.exitCode == 0 {
+      ok = true;
+      break;
+    }
+
+    sleep(1);
+  }
+
+  if ok == false {
+    halt("Unable to bring up http server");
+  }
+
+  // Wait on it in a task (to make sure to consume any output)
+  begin with (ref server) {
+    server.communicate();
+  }
+}
+
+proc stopServer() {
+  if server.running {
+    // Kill the little HTTP server
+    try! {
+      server.sendPosixSignal(SIGINT);
+    } catch e:ProcessLookupError {
+      // Ignore it already being dead
+    }
+  }
+}

--- a/test/library/packages/URL/RunServer.chpl
+++ b/test/library/packages/URL/RunServer.chpl
@@ -4,12 +4,9 @@ use URL;
 use Time;
 use FileSystem;
 
-config const host = "127.0.0.1";
-config const port = "8000";
-
 var server:subprocess(locking=true);
 
-proc startServer() {
+proc startServer(host, port) {
   // Run a curl command to check if the server is already up
   var check = spawn(["curl", "http://" + host + ":" + port + "/test.txt"],
                      stdin=pipeStyle.close, stdout=pipeStyle.pipe, stderr=pipeStyle.pipe);

--- a/test/library/packages/URL/regionArgReader.chpl
+++ b/test/library/packages/URL/regionArgReader.chpl
@@ -1,19 +1,29 @@
+use RunServer;
 use URL;
 
-var url = "https://chapel-lang.org";
+proc main() throws {
+  startServer();
+  defer stopServer();
 
-var urlreaderCheck1 = openUrlReader(url, region=..8);
-var str:string;
-urlreaderCheck1.readLine(str);
-urlreaderCheck1.close();
-writeln(str);
+  var url = "http://" + host + ":" + port + "/test.txt";
 
-var urlreaderCheck2 = openUrlReader(url, region=2..);
-urlreaderCheck2.readLine(str);
-urlreaderCheck2.close();
-writeln(str);
+  var urlreaderCheck1 = openUrlReader(url, region=..2);
+  var str:string;
+  urlreaderCheck1.readLine(str);
+  urlreaderCheck1.close();
+  writeln(str);
 
-var urlreaderCheck3 = openUrlReader(url, region=2..8);
-urlreaderCheck3.readLine(str);
-urlreaderCheck3.close();
-writeln(str);
+  // Note: ideally want to test setting a different starting location, but
+  // that requires having an http server that is reliably seekable and I'm not
+  // sure how to do that right now.  So for now, explicitly specify what it
+  // should already be using
+  var urlreaderCheck2 = openUrlReader(url, region=0..);
+  urlreaderCheck2.readLine(str);
+  urlreaderCheck2.close();
+  writeln(str);
+
+  var urlreaderCheck3 = openUrlReader(url, region=0..2);
+  urlreaderCheck3.readLine(str);
+  urlreaderCheck3.close();
+  writeln(str);
+}

--- a/test/library/packages/URL/regionArgReader.chpl
+++ b/test/library/packages/URL/regionArgReader.chpl
@@ -1,8 +1,11 @@
 use RunServer;
 use URL;
 
+config const host = "127.0.0.1";
+config const port = "8000";
+
 proc main() throws {
-  startServer();
+  startServer(host, port);
   defer stopServer();
 
   var url = "http://" + host + ":" + port + "/test.txt";

--- a/test/library/packages/URL/regionArgReader.chpl
+++ b/test/library/packages/URL/regionArgReader.chpl
@@ -1,6 +1,6 @@
 use URL;
 
-var url = "http://example.com";
+var url = "https://chapel-lang.org";
 
 var urlreaderCheck1 = openUrlReader(url, region=..8);
 var str:string;

--- a/test/library/packages/URL/regionArgReader.good
+++ b/test/library/packages/URL/regionArgReader.good
@@ -1,4 +1,4 @@
-<!doctype
-doctype html>
+thi
+this
 
-doctype
+thi

--- a/test/library/packages/URL/test.txt
+++ b/test/library/packages/URL/test.txt
@@ -1,1 +1,2 @@
-/Users/lydia/Documents/Repositories/chapel/test/library/packages/Curl/test.txt
+this
+is a test

--- a/test/library/packages/URL/test.txt
+++ b/test/library/packages/URL/test.txt
@@ -1,0 +1,1 @@
+/Users/lydia/Documents/Repositories/chapel/test/library/packages/Curl/test.txt


### PR DESCRIPTION
Uses a local http server we set up ourselves locally instead of one hosted on
the web.  The server code was copied from the `test/library/packages/Curl`
directory, as was the .txt file

As a result of making this change, I had to change the starting location to look
at, since I wasn't sure how to make the file we're getting seekable (so we can't
start at anywhere other than the first point in the file).

Worked locally and on a fresh checkout with 200+ trials (though I haven't been
able to reproduce the timeout that has plagued nightly testing, so I can't
guarantee this will fix things)