### PR TITLE
Fix duplicate error messages from `sub_test` for known issues

### DIFF
--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -2453,7 +2453,7 @@ def main():
                                     printTestVariation(compoptsnum, compoptslist,
                                                     execoptsnum, execoptslist);
                                 sys.stdout.write(']\n')
-                        else:
+                        elif (not launcher_error):
                             sys.stdout.write('[Error execution failed for %s]\n'%(test_name))
 
                         if exectimeout or status != 0 or exec_status != 0:


### PR DESCRIPTION
When `sub_test` encounters a well-known error caused by a launcher failure, etc., it emits a modified error message instead of the original. This is intended to notify us that something went wrong before the test could be executed. 

We recently observed `sub_test` emitting the modified message in addition to an `[Execution failed for ...]` error message for performance tests that fail during/before launch. 

This PR corrects the duplication, such that only the modified message is emitted in these cases. 

Resolves: https://github.com/Cray/chapel-private/issues/5491