### PR TITLE
Skip saving added source files to driver tmp with inconsistent flags

### DIFF
--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -443,7 +443,9 @@ void addSourceFiles(int numNewFilenames, const char* filename[]) {
 
   // If in driver mode, and filenames were added, also save added filenames for
   // driver phase two.
-  if (fDriverPhaseOne && firstAddedIdx >= 0) {
+  // Note: Need to check both driver mode and phase here. The two could conflict
+  // since files can be added before driver flags are validated.
+  if (!fDriverDoMonolithic && fDriverPhaseOne && firstAddedIdx >= 0) {
     saveDriverTmpMultiple(
         additionalFilenamesListFilename,
         std::vector<const char*>(inputFilenames + firstAddedIdx,


### PR DESCRIPTION
We intend to only save the list of additional source files to a tmp file when running in driver phase one. However, it is possible to add source files for compilation before the point driver flags are validated for consistency, meaning we could have the phase one flag specified for an actually monolithic compilation. Before this PR this leads to an assertion failure via calling a driver save-to-disk helper while actually in monolithic mode, instead of a correct error for conflicting flags. To fix this, check that we are not in a monolithic compilation before attempting to save added source files list.

Fixes nightly failure with `test/compflags/driver/monolithic/monolithic-subinvocation.chpl`.

Follow up to https://github.com/chapel-lang/chapel/pull/23606.

[trivial fix, not reviewed]

Testing:
- [x] paratest
- [x] paratest with `--compiler-driver`
- [x] C backend paratest
- [x] C backend paratest with `--compiler-driver`