### PR TITLE
Fix `postorder` in chapel-py bindings

### DIFF
--- a/tools/chapel-py/chapel/__init__.py
+++ b/tools/chapel-py/chapel/__init__.py
@@ -33,7 +33,7 @@ def postorder(node):
     Recursively visit the given AST node, going in post-order (children-then-parent)
     """
     for child in node:
-        yield from preorder(child)
+        yield from postorder(child)
     yield node
 
 def parse_attribute(attr, attribute):


### PR DESCRIPTION
Fixes recursive call to `postorder` 

Tested locally

[Reviewed by @]