### PR TITLE
Implement some more primitives from the 'cast' family.

### DIFF
--- a/frontend/include/chpl/types/CPtrType.h
+++ b/frontend/include/chpl/types/CPtrType.h
@@ -70,6 +70,7 @@ class CPtrType final : public Type {
 
   static const CPtrType* get(Context* context);
   static const CPtrType* get(Context* context, const Type* eltType);
+  static const CPtrType* getCVoidPtrType(Context* context);
 
   static const ID& getId(Context* context);
 

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -404,7 +404,7 @@ static QualifiedType setClassNilability(Context* context,
 
   if (cde) {
     auto decorator = ClassTypeDecorator(*cde);
-    auto newDecorator = nilability ? decorator.addNilable() : decorator.removeNilable();
+    auto newDecorator = nilability ? decorator.addNilable() : decorator.addNonNil();
     const Type* newType = ClassType::get(context, manageableType, manager, newDecorator);
     return QualifiedType(actualType.kind(), newType);
   } else if (checked) {

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -296,6 +296,10 @@ static QualifiedType primCast(Context* context,
 
   if (!castTo.isType()) return QualifiedType();
 
+  // Note: the production compiler also handles wide classes here (if
+  // cast-from is a wide class, turn cast-to into a wide class). We don't
+  // currently track wide classs in Dyno so this logic is omitted here.
+
   return QualifiedType(castFrom.kind(), castTo.type(), castFrom.param());
 }
 
@@ -364,9 +368,10 @@ static QualifiedType primToBorrowedClass(Context* context,
                                  ClassTypeDecorator::BORROWED, checked);
 }
 
-static QualifiedType primToNilableClass(Context* context,
+static QualifiedType setClassNilability(Context* context,
                                         const PrimCall* call,
                                         const CallInfo& ci,
+                                        bool nilability,
                                         bool checked) {
   if (ci.numActuals() != 1) return QualifiedType();
 
@@ -399,7 +404,7 @@ static QualifiedType primToNilableClass(Context* context,
 
   if (cde) {
     auto decorator = ClassTypeDecorator(*cde);
-    auto newDecorator = decorator.addNilable();
+    auto newDecorator = nilability ? decorator.addNilable() : decorator.removeNilable();
     const Type* newType = ClassType::get(context, manageableType, manager, newDecorator);
     return QualifiedType(actualType.kind(), newType);
   } else if (checked) {
@@ -458,6 +463,43 @@ static QualifiedType primFamilyIsSubtype(Context* context,
 
   return QualifiedType(QualifiedType::PARAM, BoolType::get(context),
                        BoolParam::get(context, result));
+}
+
+static QualifiedType primToNilableClass(Context* context,
+                                        const PrimCall* call,
+                                        const CallInfo& ci,
+                                        bool checked) {
+  return setClassNilability(context, call, ci, /* nilability */ true, checked);
+}
+
+static QualifiedType primToNonNilableClass(Context* context,
+                                           const PrimCall* call,
+                                           const CallInfo& ci,
+                                           bool checked) {
+  return setClassNilability(context, call, ci, /* nilability */ false, checked);
+}
+
+static QualifiedType primRealToInt(Context* context, const CallInfo& ci) {
+  if (ci.numActuals() != 1) return QualifiedType();
+
+  auto argType = ci.actual(0).type();
+  auto argTypePtr = argType.type();
+
+  if (!argTypePtr->isRealType()) return QualifiedType();
+
+  return QualifiedType(argType.kind(), IntType::get(context, 64));
+}
+
+static QualifiedType primObjectToInt(Context* context, const CallInfo& ci) {
+  if (ci.numActuals() != 1) return QualifiedType();
+
+  auto argType = ci.actual(0).type();
+  auto argTypePtr = argType.type();
+
+  if (!argTypePtr->isClassType() && !argTypePtr->isBasicClassType())
+    return QualifiedType();
+
+  return QualifiedType(argType.kind(), IntType::get(context, 64));
 }
 
 CallResolutionResult resolvePrimCall(Context* context,
@@ -591,17 +633,38 @@ CallResolutionResult resolvePrimCall(Context* context,
 
     /* cast-like things */
     case PRIM_CAST:
+    case PRIM_DYNAMIC_CAST:
       type = primCast(context, ci);
       break;
 
-    case PRIM_DYNAMIC_CAST:
     case PRIM_TO_LEADER:
     case PRIM_TO_FOLLOWER:
     case PRIM_TO_STANDALONE:
+      if (ci.numActuals() == 1) {
+        type = QualifiedType(QualifiedType::CONST_IN, VoidType::get(context));
+      }
+      break;
+
     case PRIM_CAST_TO_VOID_STAR:
+      if (ci.numActuals() == 1) {
+        type = QualifiedType(ci.actual(0).type().kind(),
+                             CPtrType::getCVoidPtrType(context));
+      }
+      break;
+
     case PRIM_CAST_TO_TYPE:
+      // Note: the implementation isn't the same in production, but seems to
+      // match what we do in Dyno for primCast.
+      type = primCast(context, ci);
+      break;
+
     case PRIM_REAL_TO_INT:
+      type = primRealToInt(context, ci);
+      break;
+
     case PRIM_OBJECT_TO_INT:
+      type = primObjectToInt(context, ci);
+
     case PRIM_COERCE:
       assert(false && "not implemented yet");
       break;
@@ -629,6 +692,9 @@ CallResolutionResult resolvePrimCall(Context* context,
       break;
 
     case PRIM_TO_NON_NILABLE_CLASS:
+      type = primToNonNilableClass(context, call, ci, /* checked */ false);
+      break;
+
     case PRIM_UINT32_AS_REAL32:
     case PRIM_UINT64_AS_REAL64:
     case PRIM_REAL32_AS_UINT32:

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -640,9 +640,7 @@ CallResolutionResult resolvePrimCall(Context* context,
     case PRIM_TO_LEADER:
     case PRIM_TO_FOLLOWER:
     case PRIM_TO_STANDALONE:
-      if (ci.numActuals() == 1) {
-        type = QualifiedType(QualifiedType::CONST_IN, VoidType::get(context));
-      }
+      assert(false && "not implemented yet");
       break;
 
     case PRIM_CAST_TO_VOID_STAR:

--- a/frontend/lib/types/CPtrType.cpp
+++ b/frontend/lib/types/CPtrType.cpp
@@ -22,6 +22,7 @@
 #include "chpl/framework/query-impl.h"
 #include "chpl/resolution/intents.h"
 #include "chpl/types/Param.h"
+#include "chpl/types/VoidType.h"
 #include "chpl/resolution/can-pass.h"
 
 namespace chpl {
@@ -53,6 +54,10 @@ const CPtrType* CPtrType::get(Context* context, const Type* eltType) {
   return CPtrType::getCPtrType(context,
                                /* instantiatedFrom */ CPtrType::get(context),
                                eltType).get();
+}
+
+const CPtrType* CPtrType::getCVoidPtrType(Context* context) {
+  return CPtrType::get(context, VoidType::get(context));
 }
 
 const ID& CPtrType::getId(Context* context) {

--- a/frontend/test/resolution/testClassPrimitives.cpp
+++ b/frontend/test/resolution/testClassPrimitives.cpp
@@ -267,6 +267,36 @@ static void test6() {
   });
 }
 
+static void test7() {
+  testPrimitive("to non nilable class", {
+    { "new owned C()", "owned C", testType },
+    { "new owned C?()", "owned C", testType },
+    { "new shared C()", "shared C", testType },
+    { "new shared C?()", "shared C", testType },
+    { "new unmanaged C()", "unmanaged C", testType },
+    { "new unmanaged C?()", "unmanaged C", testType },
+
+    { "owned C", "owned C", testExact },
+    { "owned C?", "owned C", testExact },
+    { "shared C", "shared C", testExact },
+    { "shared C?", "shared C", testExact },
+    { "unmanaged C", "unmanaged C", testExact },
+    { "unmanaged C?", "unmanaged C", testExact },
+
+    { "owned class", "owned class", testExact },
+    { "owned class", "owned class", testExact },
+    { "shared class", "shared class", testExact },
+    { "shared class", "shared class", testExact },
+    { "unmanaged class", "unmanaged class", testExact },
+    { "unmanaged class", "unmanaged class", testExact },
+
+    { "42", "int(64)", testType },
+    { "int(64)", "int(64)", testExact },
+    { "\"hello\"", "string", testType },
+    { "string", "string", testExact },
+  });
+}
+
 int main() {
   test1();
   test2();
@@ -274,4 +304,5 @@ int main() {
   test4();
   test5();
   test6();
+  test7();
 }


### PR DESCRIPTION
I'm leaving alone `TO_LEADER` and `TO_FOLLOWER` because they seem to involve call wrangling to insert the iterator tag -- I don't know how to approach this right now, and hope that this isn't what's blocking the `writeln` efforts.

Reviewed by @benharsh -- thanks!

## Testing
- [x] paratest