### PR TITLE
Update type comparison implementation in dyno

### DIFF
--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -3152,19 +3152,6 @@ void Resolver::prepareCallInfoActuals(const Call* call,
                            /* actualAsts */ nullptr);
 }
 
-QualifiedType Resolver::typeForTypeOperator(const OpCall* op,
-    const QualifiedType& lt, const QualifiedType& rt) {
-  if (op->op() == USTR("==") || op->op() == USTR("!=")) {
-    bool opNotEqual = op->op() == USTR("!=");
-    bool compareResult = lt == rt;
-    return QualifiedType(QualifiedType::PARAM,
-                         BoolType::get(context),
-                         BoolParam::get(context, opNotEqual ^ compareResult));
-  }
-  CHPL_ASSERT(false && "not implemented!");
-  return QualifiedType();
-}
-
 void Resolver::exit(const Call* call) {
   if (scopeResolveOnly)
     return;
@@ -3176,22 +3163,6 @@ void Resolver::exit(const Call* call) {
   if (op && (op->op() == USTR("&&") || op->op() == USTR("||"))) {
     if (!scopeResolveOnly) {
       // these are handled in 'enter' to do param folding
-      return;
-    }
-  }
-
-  if (op && (op->op() == USTR("==") || op->op() == USTR("!=") ||
-        op->op() == USTR("<") || op->op() == USTR("<="))) {
-    if (op->numActuals() != 2) {
-      byPostorder.byAst(op).setType(typeErr(op, "invalid op call"));
-      return;
-    }
-    ResolvedExpression& leftR = byPostorder.byAst(op->child(0));
-    ResolvedExpression& rightR = byPostorder.byAst(op->child(1));
-    if ((leftR.type().isType() && rightR.type().isType()) ||
-        (leftR.type().isParam() && rightR.type().isParam())) {
-      auto resultType = typeForTypeOperator(op, leftR.type(), rightR.type());
-      byPostorder.byAst(op).setType(std::move(resultType));
       return;
     }
   }

--- a/frontend/lib/resolution/Resolver.h
+++ b/frontend/lib/resolution/Resolver.h
@@ -404,11 +404,6 @@ struct Resolver {
   // Resolve a || or && operation.
   types::QualifiedType typeForBooleanOp(const uast::OpCall* op);
 
-  // Handle ==, !=, and other operators as defined on types.
-  types::QualifiedType typeForTypeOperator(const uast::OpCall* op,
-                                           const types::QualifiedType& left,
-                                           const types::QualifiedType& right);
-
   // find the element, if any, that a name refers to.
   // Sets outAmbiguous to true if multiple elements of the same name are found,
   // and to false otherwise.

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2789,7 +2789,6 @@ static bool resolveFnCallSpecial(Context* context,
                                  const AstNode* astForErr,
                                  const CallInfo& ci,
                                  QualifiedType& exprTypeOut) {
-  // TODO: type comparisons
   // TODO: cast
   // TODO: .borrow()
   // TODO: chpl__coerceCopy
@@ -2799,12 +2798,18 @@ static bool resolveFnCallSpecial(Context* context,
     return true;
   }
 
-  if (ci.name() == USTR("==") && ci.numActuals() == 2) {
+  if ((ci.name() == USTR("==") || ci.name() == USTR("!=")) &&
+      ci.numActuals() == 2) {
     auto lhs = ci.actual(0).type();
     auto rhs = ci.actual(1).type();
-    if (lhs.kind() == QualifiedType::TYPE &&
-        rhs.kind() == QualifiedType::TYPE) {
-      bool result = lhs.type() == rhs.type();
+
+    bool bothType = lhs.kind() == QualifiedType::TYPE &&
+                    rhs.kind() == QualifiedType::TYPE;
+    bool bothParam = lhs.kind() == QualifiedType::PARAM &&
+                     rhs.kind() == QualifiedType::PARAM;
+    if (bothType || bothParam) {
+      bool result = lhs == rhs;
+      result = ci.name() == USTR("==") ? result : !result;
       exprTypeOut = QualifiedType(QualifiedType::PARAM, BoolType::get(context),
                                   BoolParam::get(context, result));
       return true;

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2799,6 +2799,18 @@ static bool resolveFnCallSpecial(Context* context,
     return true;
   }
 
+  if (ci.name() == USTR("==") && ci.numActuals() == 2) {
+    auto lhs = ci.actual(0).type();
+    auto rhs = ci.actual(1).type();
+    if (lhs.kind() == QualifiedType::TYPE &&
+        rhs.kind() == QualifiedType::TYPE) {
+      bool result = lhs.type() == rhs.type();
+      exprTypeOut = QualifiedType(QualifiedType::PARAM, BoolType::get(context),
+                                  BoolParam::get(context, result));
+      return true;
+    }
+  }
+
   if (ci.name() == USTR("isCoercible")) {
     if (ci.numActuals() != 2) {
       context->error(astForErr, "bad call to %s", ci.name().c_str());

--- a/frontend/test/resolution/testReturnTypes.cpp
+++ b/frontend/test/resolution/testReturnTypes.cpp
@@ -718,7 +718,6 @@ static void testControlFlowYield4() {
 std::string ops = R"""(
   operator ==(x:int, y:int) { return __primitive("==", x, y); }
   operator ==(param x:int, param y:int) param { return __primitive("==", x, y); }
-  operator ==(type A, type B) param : bool { return __primitive("==", A, B); }
 )""";
 
 static void testSelectVals() {
@@ -824,9 +823,11 @@ static void testSelectVals() {
 using stringMap = std::map<std::string, std::string>;
 
 static void testSelectCases(std::string base,
-                            stringMap vals) {
+                            stringMap vals,
+                            bool isType = true) {
   for (auto pair : vals) {
-    std::string program = base + "type x = foo(" + pair.first + ");";
+    std::string kind = isType ? "type" : "var";
+    std::string program = base + kind + " x = foo(" + pair.first + ");";
 
     Context ctx;
     Context* context = &ctx;
@@ -927,6 +928,27 @@ static void testSelectTypes() {
     ErrorGuard guard(context);
     auto qt = resolveTypeOfXInit(context, program);
     assert(qt.type()->isIntType());
+  }
+  {
+    std::string fooFunc = ops + R"""(
+    proc foo(type T) {
+      select T {
+        when int do return 5;
+        when real do return 42.0;
+        when string do return "hello";
+      }
+
+      var x : T;
+      return x;
+    }
+    )""";
+
+    stringMap vals = {{"int", "int(64)"},
+                      {"real", "real(64)"},
+                      {"string", "string"},
+                      {"uint", "uint(64)"}};
+
+    testSelectCases(fooFunc, vals, /*isType=*/false);
   }
 }
 


### PR DESCRIPTION
This PR updates support for comparisons between type variables in dyno for both user-written comparisons and compiler-generated comparison resolution. With this change, ``Resolver::typeForTypeOperator`` is obsolete and can be removed. To be exact, this PR is updating the implementation for comparing two types, and not two values.

A new test is also added to ``testSelectTypes``, which captures a previously untested case that was unaffected by this PR. The artificial comparison operator in the test file itself can now be removed, though.

Testing:
- [x] local paratest