### PR TITLE
Rename domains in heat-2D tutorial examples

### DIFF
--- a/test/exercises/Oct2023tutorial/03-heat-2D-block.chpl
+++ b/test/exercises/Oct2023tutorial/03-heat-2D-block.chpl
@@ -23,14 +23,14 @@ config const nx = 256,      // number of grid points in x
              ny = 256,      // number of grid points in y
              nt = 50,       // number of time steps
              alpha = 0.25,  // diffusion constant
-             solutionStd = 0.221167; // known solution for the default parameters
+             solutionStd = 0.222751; // known solution for the default parameters
 
 // define a distributed 2D domain and subdomain to describe the grid and its interior
-const Indices = blockDist.createDomain(0..nx+1, 0..ny+1),
-      IndicesInner = Indices[1..nx, 1..ny];
+const Omega = blockDist.createDomain(0..<nx, 0..<ny),
+      OmegaHat = Omega.expand(-1);
 
 // define a distributed 2D array over the above domain
-var u: [Indices] real = 1.0;
+var u: [Omega] real = 1.0;
 
 // set up initial conditions
 u[nx/4..nx/2, ny/4..ny/2] = 2.0;
@@ -48,7 +48,7 @@ for 1..nt {
   u <=> un;
 
   // compute the FD kernel in parallel
-  forall (i, j) in IndicesInner with (ref u) do
+  forall (i, j) in OmegaHat with (ref u) do
     u[i, j] = un[i, j] + alpha *
       (un[i-1, j] + un[i, j-1] + un[i+1, j] + un[i, j+1] - 4 * un[i, j]);
 }

--- a/test/exercises/Oct2023tutorial/03-heat-2D-stencil.chpl
+++ b/test/exercises/Oct2023tutorial/03-heat-2D-stencil.chpl
@@ -24,15 +24,15 @@ config const nx = 256,      // number of grid points in x
              ny = 256,      // number of grid points in y
              nt = 50,       // number of time steps
              alpha = 0.25,  // diffusion constant
-             solutionStd = 0.221167; // known solution for the default parameters
+             solutionStd = 0.222751; // known solution for the default parameters
 
 // define a distributed 2D domain and subdomain to describe the grid and its interior
 
-const Indices = stencilDist.createDomain({0..nx+1, 0..ny+1}, fluff=(1,1)),
-      IndicesInner = Indices[1..nx, 1..ny];
+const Omega = stencilDist.createDomain({0..<nx, 0..<ny}, fluff=(1,1)),
+      OmegaHat = Omega.expand(-1);
 
 // define a distributed 2D array over the above domain
-var u: [Indices] real = 1.0;
+var u: [Omega] real = 1.0;
 
 // set up initial conditions
 u[nx/4..nx/2, ny/4..ny/2] = 2.0;
@@ -53,7 +53,7 @@ for 1..nt {
   un.updateFluff();
 
   // compute the FD kernel in parallel
-  forall (i, j) in IndicesInner with (ref u) do
+  forall (i, j) in OmegaHat with (ref u) do
     u[i, j] = un[i, j] + alpha *
       (un[i-1, j] + un[i, j-1] + un[i+1, j] + un[i, j+1] - 4 * un[i, j]);
 }

--- a/test/exercises/Oct2023tutorial/03-heat-2D.chpl
+++ b/test/exercises/Oct2023tutorial/03-heat-2D.chpl
@@ -19,14 +19,14 @@ config const nx = 256,      // number of grid points in x
              ny = 256,      // number of grid points in y
              nt = 50,       // number of time steps
              alpha = 0.25,  // diffusion constant
-             solutionStd = 0.221167; // known solution for the default parameters
+             solutionStd = 0.222751; // known solution for the default parameters
 
 // define a 2D domain and subdomain to describe the grid and its interior
-const indices = {0..nx+1, 0..ny+1},
-      indicesInner = {1..nx, 1..ny};
+const omega = {0..<nx, 0..<ny},
+      omegaHat = omega.expand(-1);
 
 // define a 2D array over the above domain
-var u: [indices] real = 1.0;
+var u: [omega] real = 1.0;
 
 // set up initial conditions
 u[nx/4..nx/2, ny/4..ny/2] = 2.0;
@@ -41,7 +41,7 @@ for 1..nt {
   u <=> un;
 
   // compute the FD kernel in parallel
-  forall (i, j) in indicesInner with (ref u) do
+  forall (i, j) in omegaHat with (ref u) do
     u[i, j] = un[i, j] + alpha *
       (un[i-1, j] + un[i, j-1] + un[i+1, j] + un[i, j+1] - 4 * un[i, j]);
 }


### PR DESCRIPTION
Make domain naming consistent across 1D and 2D heat examples.

- [x] tests passing
- [x] tests passing w/ `CHPL_COMM=gasnet`
