### PR TITLE
Check the declared types of 'ref' variables

### DIFF
--- a/compiler/AST/CallExpr.cpp
+++ b/compiler/AST/CallExpr.cpp
@@ -248,9 +248,10 @@ void CallExpr::verify() {
   } else if (CallExpr* subCall = toCallExpr(baseExpr)) {
     // Confirm that this is a partial call, but only if the call is not
     // within a DefExpr (indicated by not having a stmt-expr)
-    if (!partOfNonNormalizableExpr(this))
-      if (normalized && subCall->getStmtExpr() != NULL)
-        INT_ASSERT(subCall->partialTag == true);
+    if (normalized && subCall->getStmtExpr() != NULL)
+      INT_ASSERT(subCall->partialTag == true
+                 // non-normalizable expressions are also exempt
+                 || partOfNonNormalizableExpr(this));
   }
 
   verifyNotOnList(baseExpr);

--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -719,6 +719,8 @@ initPrimitive() {
   // if the optional type is provided, it should match PRIM_INIT_VAR_SPLIT_DECL.
   prim_def(PRIM_INIT_VAR_SPLIT_INIT, "init var split init",   returnInfoVoid);
 
+  prim_def(PRIM_INIT_REF_DECL, "init ref decl", returnInfoVoid);
+
   // indicates the body of the initializer is now in Phase 2
   prim_def(PRIM_INIT_DONE, "init done", returnInfoVoid);
 

--- a/compiler/resolution/cleanups.cpp
+++ b/compiler/resolution/cleanups.cpp
@@ -640,11 +640,6 @@ static void removeTypedefParts() {
       def->init = NULL;
     }
 
-    if (def->exprType) {
-      def->exprType->remove(); // it may reference a generic type
-      def->exprType = NULL;
-    }
-
     // Also remove DefExprs for generic type variables
     if (!isPrimitiveType(def->sym->type) &&
         def->sym->hasFlag(FLAG_TYPE_VARIABLE) &&

--- a/compiler/resolution/cleanups.cpp
+++ b/compiler/resolution/cleanups.cpp
@@ -640,6 +640,11 @@ static void removeTypedefParts() {
       def->init = NULL;
     }
 
+    if (def->exprType) {
+      def->exprType->remove(); // it may reference a generic type
+      def->exprType = NULL;
+    }
+
     // Also remove DefExprs for generic type variables
     if (!isPrimitiveType(def->sym->type) &&
         def->sym->hasFlag(FLAG_TYPE_VARIABLE) &&

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -2742,6 +2742,9 @@ static void insertInitConversion(Symbol* to, Symbol* toType, Symbol* from,
       INT_ASSERT(!toValType->symbol->hasFlag(FLAG_GENERIC));
       toType = toValType->symbol;
     }
+
+    // If there is a mismatch and we already have errors, leave it alone.
+    if (toValType != toType->type && fatalErrorsEncountered()) return;
     // Remainder of this code assumes that to and toType match.
     INT_ASSERT(toValType == toType->type);
 

--- a/frontend/include/chpl/uast/prim-ops-list.h
+++ b/frontend/include/chpl/uast/prim-ops-list.h
@@ -49,6 +49,7 @@ PRIMITIVE_R(INIT_FIELD, "init field")
 PRIMITIVE_R(INIT_VAR, "init var")
 PRIMITIVE_R(INIT_VAR_SPLIT_DECL, "init var split decl")
 PRIMITIVE_R(INIT_VAR_SPLIT_INIT, "init var split init")
+PRIMITIVE_R(INIT_REF_DECL, "init ref decl")
 PRIMITIVE_R(INIT_DONE, "init done")
 
 PRIMITIVE_G(REF_TO_STRING, "ref to string")

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -781,6 +781,7 @@ CallResolutionResult resolvePrimCall(Context* context,
     case PRIM_INIT_VAR:
     case PRIM_INIT_VAR_SPLIT_DECL:
     case PRIM_INIT_VAR_SPLIT_INIT:
+    case PRIM_INIT_REF_DECL:
     case PRIM_INIT_DONE:
     case PRIM_REDUCE:
     case PRIM_ASSIGN:

--- a/test/deprecated/atomic/return-by-ref-array.compopts
+++ b/test/deprecated/atomic/return-by-ref-array.compopts
@@ -1,2 +1,2 @@
--stestnum=3 -sretType='[0..2] atomic int' # return-by-ref.good
--stestnum=3 -sretType='[0..2] [0..2] atomic int' # return-by-ref.good
+-stestnum=3 -sretType='[0..2] atomic int'
+-stestnum=3 -sretType='[0..2] [0..2] atomic int'

--- a/test/deprecated/atomic/return-by-ref-array.good
+++ b/test/deprecated/atomic/return-by-ref-array.good
@@ -1,0 +1,2 @@
+return-by-ref-array.chpl:23: warning: there is no checking that the domain of the initialization expression matches the domain of the declared type of the reference 'a1'
+return-by-ref-array.chpl:27: warning: there is no checking that the domain of the initialization expression matches the domain of the declared type of the reference 'a2'

--- a/test/deprecated/sync/return-by-ref-array.compopts
+++ b/test/deprecated/sync/return-by-ref-array.compopts
@@ -1,2 +1,2 @@
--stestnum=3 -sretType='[0..2] sync int' # return-by-ref.good
--stestnum=3 -sretType='[0..2] [0..2] sync int' # return-by-ref.good
+-stestnum=3 -sretType='[0..2] sync int'
+-stestnum=3 -sretType='[0..2] [0..2] sync int'

--- a/test/deprecated/sync/return-by-ref-array.good
+++ b/test/deprecated/sync/return-by-ref-array.good
@@ -1,0 +1,2 @@
+return-by-ref-array.chpl:23: warning: there is no checking that the domain of the initialization expression matches the domain of the declared type of the reference 'a1'
+return-by-ref-array.chpl:27: warning: there is no checking that the domain of the initialization expression matches the domain of the declared type of the reference 'a2'

--- a/test/variables/ref/errors-type-mismatch-1.chpl
+++ b/test/variables/ref/errors-type-mismatch-1.chpl
@@ -1,0 +1,61 @@
+
+
+
+var globalVar: int;
+ref globalRef = globalVar;
+
+proc refFun(arg:int) ref do return globalVar;
+
+record RR { type t1, t2; }
+
+
+
+
+var v1 = 5;
+ref r1: real = v1;  // error
+
+var v2 = "hi";
+ref r2: int = v2;   // error
+
+ref r3: real;
+r3 = v1;            // error (this is a split init)
+r3 = v1;            // OK (this is an assignment)
+
+const c1 = true;
+const ref q1: int = c1;   // error
+
+const ref q2: real;
+q2 = v1;                  // error
+
+var v4: RR(int, string);
+ref r4: RR(?) = v4;      // OK
+compilerWarning("r4 has type ", r4.type:string, 0);  // RR(int, string)
+
+ref r5: RR(int,?);
+r5 = v4;                 // OK
+compilerWarning("r5 has type ", r5.type:string, 0);  // RR(int, string);
+
+ref r6: RR(real,?) = v4; // error
+
+const ref q3: RR(bool,string);
+q3 = v4;                 // error
+
+const ref q4: domain(?) = LocaleSpace;  // OK
+compilerWarning("q4 has type ", q4.type:string, 0);  // domain(1)
+
+const ref q5: domain(1,int(8));
+q5 = LocaleSpace;        // error
+
+var v6: [LocaleSpace.dim(0)] locale;
+const ref q6: Locales;   // error: not a type
+q6 = v6;                 // warning
+
+const ref q7: [LocaleSpace] int = Locales;  // error
+
+ref r71: real = globalRef;                  // error
+ref r72: real;
+r72 = globalRef;                            // error
+
+const ref q81: real = refFun(5);            // error
+const ref q82: real;
+q82 = refFun(6);                            // error 

--- a/test/variables/ref/errors-type-mismatch-1.good
+++ b/test/variables/ref/errors-type-mismatch-1.good
@@ -1,0 +1,43 @@
+errors-type-mismatch-1.chpl:15: error: Initializing a reference with another type
+errors-type-mismatch-1.chpl:15: note: Reference has type real(64)
+errors-type-mismatch-1.chpl:15: note: Initializing with type int(64)
+errors-type-mismatch-1.chpl:18: error: Initializing a reference with another type
+errors-type-mismatch-1.chpl:18: note: Reference has type int(64)
+errors-type-mismatch-1.chpl:18: note: Initializing with type string
+errors-type-mismatch-1.chpl:21: error: Initializing a reference with another type
+errors-type-mismatch-1.chpl:20: note: Reference has type real(64)
+errors-type-mismatch-1.chpl:21: note: Initializing with type int(64)
+errors-type-mismatch-1.chpl:25: error: Initializing a reference with another type
+errors-type-mismatch-1.chpl:25: note: Reference has type int(64)
+errors-type-mismatch-1.chpl:25: note: Initializing with type bool
+errors-type-mismatch-1.chpl:28: error: Initializing a reference with another type
+errors-type-mismatch-1.chpl:27: note: Reference has type real(64)
+errors-type-mismatch-1.chpl:28: note: Initializing with type int(64)
+errors-type-mismatch-1.chpl:32: warning: r4 has type RR(int(64),string)
+errors-type-mismatch-1.chpl:36: warning: r5 has type RR(int(64),string)
+errors-type-mismatch-1.chpl:38: error: initializing a reference using an expression whose type 'RR(int(64),string)' is not an instantiation of the declared type 'RR(real(64))'
+errors-type-mismatch-1.chpl:41: error: Initializing a reference with another type
+errors-type-mismatch-1.chpl:40: note: Reference has type RR(bool,string)
+errors-type-mismatch-1.chpl:41: note: Initializing with type RR(int(64),string)
+errors-type-mismatch-1.chpl:44: warning: q4 has type domain(1,int(64),one)
+errors-type-mismatch-1.chpl:47: error: Initializing a reference with another type
+errors-type-mismatch-1.chpl:46: note: Reference has type domain(1,int(8),one)
+errors-type-mismatch-1.chpl:47: note: Initializing with type domain(1,int(64),one)
+errors-type-mismatch-1.chpl:50: error: the type declaration of the reference q6 is not a type
+errors-type-mismatch-1.chpl:50: warning: there is no checking that the domain of the initialization expression matches the domain of the declared type of the reference 'q6'
+errors-type-mismatch-1.chpl:53: warning: there is no checking that the domain of the initialization expression matches the domain of the declared type of the reference 'q7'
+errors-type-mismatch-1.chpl:53: error: Initializing a reference with another type
+errors-type-mismatch-1.chpl:53: note: Reference has type [domain(1,int(64),one)] int(64)
+errors-type-mismatch-1.chpl:53: note: Initializing with type [domain(1,int(64),one)] locale
+errors-type-mismatch-1.chpl:55: error: Initializing a reference with another type
+errors-type-mismatch-1.chpl:55: note: Reference has type real(64)
+errors-type-mismatch-1.chpl:55: note: Initializing with type int(64)
+errors-type-mismatch-1.chpl:57: error: Initializing a reference with another type
+errors-type-mismatch-1.chpl:56: note: Reference has type real(64)
+errors-type-mismatch-1.chpl:57: note: Initializing with type int(64)
+errors-type-mismatch-1.chpl:59: error: Initializing a reference with another type
+errors-type-mismatch-1.chpl:59: note: Reference has type real(64)
+errors-type-mismatch-1.chpl:59: note: Initializing with type int(64)
+errors-type-mismatch-1.chpl:61: error: Initializing a reference with another type
+errors-type-mismatch-1.chpl:60: note: Reference has type real(64)
+errors-type-mismatch-1.chpl:61: note: Initializing with type int(64)

--- a/test/variables/ref/errors-type-mismatch-2.chpl
+++ b/test/variables/ref/errors-type-mismatch-2.chpl
@@ -1,0 +1,65 @@
+// This is a copy of errors-type-mismatch-1.chpl
+// with all ref decls wrapped in a function.
+
+var globalVar: int;
+ref globalRef = globalVar;
+
+proc refFun(arg:int) ref do return globalVar;
+
+record RR { type t1, t2; }
+
+
+proc test() {
+
+var v1 = 5;
+ref r1: real = v1;  // error
+
+var v2 = "hi";
+ref r2: int = v2;   // error
+
+ref r3: real;
+r3 = v1;            // error (this is a split init)
+r3 = v1;            // OK (this is an assignment)
+
+const c1 = true;
+const ref q1: int = c1;   // error
+
+const ref q2: real;
+q2 = v1;                  // error
+
+var v4: RR(int, string);
+ref r4: RR(?) = v4;      // OK
+compilerWarning("r4 has type ", r4.type:string, 0);  // RR(int, string)
+
+ref r5: RR(int,?);
+r5 = v4;                 // OK
+compilerWarning("r5 has type ", r5.type:string, 0);  // RR(int, string);
+
+ref r6: RR(real,?) = v4; // error
+
+const ref q3: RR(bool,string);
+q3 = v4;                 // error
+
+const ref q4: domain(?) = LocaleSpace;  // OK
+compilerWarning("q4 has type ", q4.type:string, 0);  // domain(1)
+
+const ref q5: domain(1,int(8));
+q5 = LocaleSpace;        // error
+
+var v6: [LocaleSpace.dim(0)] locale;
+const ref q6: Locales;   // error: not a type
+q6 = v6;                 // warning
+
+const ref q7: [LocaleSpace] int = Locales;  // error
+
+ref r71: real = globalRef;                  // error
+ref r72: real;
+r72 = globalRef;                            // error
+
+const ref q81: real = refFun(5);            // error
+const ref q82: real;
+q82 = refFun(6);                            // error 
+
+}
+
+test();

--- a/test/variables/ref/errors-type-mismatch-2.good
+++ b/test/variables/ref/errors-type-mismatch-2.good
@@ -1,0 +1,44 @@
+errors-type-mismatch-2.chpl:12: In function 'test':
+errors-type-mismatch-2.chpl:15: error: Initializing a reference with another type
+errors-type-mismatch-2.chpl:15: note: Reference has type real(64)
+errors-type-mismatch-2.chpl:15: note: Initializing with type int(64)
+errors-type-mismatch-2.chpl:18: error: Initializing a reference with another type
+errors-type-mismatch-2.chpl:18: note: Reference has type int(64)
+errors-type-mismatch-2.chpl:18: note: Initializing with type string
+errors-type-mismatch-2.chpl:21: error: Initializing a reference with another type
+errors-type-mismatch-2.chpl:20: note: Reference has type real(64)
+errors-type-mismatch-2.chpl:21: note: Initializing with type int(64)
+errors-type-mismatch-2.chpl:25: error: Initializing a reference with another type
+errors-type-mismatch-2.chpl:25: note: Reference has type int(64)
+errors-type-mismatch-2.chpl:25: note: Initializing with type bool
+errors-type-mismatch-2.chpl:28: error: Initializing a reference with another type
+errors-type-mismatch-2.chpl:27: note: Reference has type real(64)
+errors-type-mismatch-2.chpl:28: note: Initializing with type int(64)
+errors-type-mismatch-2.chpl:32: warning: r4 has type RR(int(64),string)
+errors-type-mismatch-2.chpl:36: warning: r5 has type RR(int(64),string)
+errors-type-mismatch-2.chpl:38: error: initializing a reference using an expression whose type 'RR(int(64),string)' is not an instantiation of the declared type 'RR(real(64))'
+errors-type-mismatch-2.chpl:41: error: Initializing a reference with another type
+errors-type-mismatch-2.chpl:40: note: Reference has type RR(bool,string)
+errors-type-mismatch-2.chpl:41: note: Initializing with type RR(int(64),string)
+errors-type-mismatch-2.chpl:44: warning: q4 has type domain(1,int(64),one)
+errors-type-mismatch-2.chpl:47: error: Initializing a reference with another type
+errors-type-mismatch-2.chpl:46: note: Reference has type domain(1,int(8),one)
+errors-type-mismatch-2.chpl:47: note: Initializing with type domain(1,int(64),one)
+errors-type-mismatch-2.chpl:50: error: the type declaration of the reference q6 is not a type
+errors-type-mismatch-2.chpl:50: warning: there is no checking that the domain of the initialization expression matches the domain of the declared type of the reference 'q6'
+errors-type-mismatch-2.chpl:53: warning: there is no checking that the domain of the initialization expression matches the domain of the declared type of the reference 'q7'
+errors-type-mismatch-2.chpl:53: error: Initializing a reference with another type
+errors-type-mismatch-2.chpl:53: note: Reference has type [domain(1,int(64),one)] int(64)
+errors-type-mismatch-2.chpl:53: note: Initializing with type [domain(1,int(64),one)] locale
+errors-type-mismatch-2.chpl:55: error: Initializing a reference with another type
+errors-type-mismatch-2.chpl:55: note: Reference has type real(64)
+errors-type-mismatch-2.chpl:55: note: Initializing with type int(64)
+errors-type-mismatch-2.chpl:57: error: Initializing a reference with another type
+errors-type-mismatch-2.chpl:56: note: Reference has type real(64)
+errors-type-mismatch-2.chpl:57: note: Initializing with type int(64)
+errors-type-mismatch-2.chpl:59: error: Initializing a reference with another type
+errors-type-mismatch-2.chpl:59: note: Reference has type real(64)
+errors-type-mismatch-2.chpl:59: note: Initializing with type int(64)
+errors-type-mismatch-2.chpl:61: error: Initializing a reference with another type
+errors-type-mismatch-2.chpl:60: note: Reference has type real(64)
+errors-type-mismatch-2.chpl:61: note: Initializing with type int(64)

--- a/test/variables/ref/type-decls-1.chpl
+++ b/test/variables/ref/type-decls-1.chpl
@@ -1,0 +1,42 @@
+
+var globalVar: int;
+ref globalRef = globalVar;
+
+proc refFun(arg:int) ref do return globalVar;
+
+record RR { type t1, t2; var x1: t1, x2: t2; }
+
+ref r1: int = globalRef;
+r1 = 23;
+writeln(globalVar);
+
+ref r2: int = refFun(0);
+r2 = 32;
+writeln(globalVar);
+
+var v3: RR(int, string);
+ref r3: RR(int, string) = v3;
+r3 = new RR(int, string, 33, "hi3");
+writeln(v3, "  ", r3.type:string);
+
+ref r4: RR(?) = v3;
+r4 = new RR(int, string, 44, "hi4");
+writeln(v3, "  ", r4.type:string);
+
+ref r5: RR(int,?);
+r5 = v3;
+r5 = new RR(int, string, 55, "hi5");
+writeln(v3, "  ", r5.type:string);
+
+var dom: domain(1);
+ref r6: domain(?) = dom;
+r6.setIndices((1..6,));
+writeln(dom, "  ", r6.type:string);
+
+ref r7: domain(1);
+r7 = dom;
+r7.setIndices((2..7,));
+writeln(dom, "  ", r7.type:string);
+
+const ref r8: [LocaleSpace] locale = Locales;
+writeln(r8[0], "  ", r8.type:string);

--- a/test/variables/ref/type-decls-1.good
+++ b/test/variables/ref/type-decls-1.good
@@ -1,0 +1,9 @@
+type-decls-1.chpl:41: warning: there is no checking that the domain of the initialization expression matches the domain of the declared type of the reference 'r8'
+23
+32
+(x1 = 33, x2 = hi3)  RR(int(64),string)
+(x1 = 44, x2 = hi4)  RR(int(64),string)
+(x1 = 55, x2 = hi5)  RR(int(64),string)
+{1..6}  domain(1,int(64),one)
+{2..7}  domain(1,int(64),one)
+LOCALE0  [domain(1,int(64),one)] locale

--- a/test/variables/ref/type-decls-arrays-1.bad
+++ b/test/variables/ref/type-decls-arrays-1.bad
@@ -1,0 +1,2 @@
+type-decls-arrays-1.chpl:8: warning: there is no checking that the domain of the initialization expression matches the domain of the declared type of the reference 'r1'
+type-decls-arrays-1.chpl:9: warning: there is no checking that the domain of the initialization expression matches the domain of the declared type of the reference 'r2'

--- a/test/variables/ref/type-decls-arrays-1.chpl
+++ b/test/variables/ref/type-decls-arrays-1.chpl
@@ -1,0 +1,21 @@
+// When declaring the type of a 'ref' to an array, it should be an error if
+// the domain of that type differs from the domain of the referenced array.
+
+
+var d1, d2: domain(1);
+
+var a1: [d1] int;
+ref r1: [d1] int = a1; // OK
+ref r2: [d2] int = a1; // error: d2 has a different identity than a1.domain 
+
+// Analogously for domains.
+
+use BlockDist;
+const d3 = {1..3};
+var dist1 = new blockDist(d3);
+var dist2 = new blockDist(d3);
+var dom1 = dist1.createDomain(d3);
+var dom2 = dist2.createDomain(d3);
+ref br1: dom1.type = dom1;  // OK
+ref br2: dom2.type = dom1;  // error: dom2.distribution has a different identity
+                            //   than dom1.distribution

--- a/test/variables/ref/type-decls-arrays-1.future
+++ b/test/variables/ref/type-decls-arrays-1.future
@@ -1,0 +1,8 @@
+bug: missing checks that the runtime types match
+
+When declaring the type of a reference to a domain or array,
+the runtime types of the declared type and the referenced domain or array
+must match:
+
+ref r2: [d2] int = a1;      // require same domain identity d2 and a1.domain 
+ref br2: dom2.type = dom1;  // require same dist. identity of dom1 and dom2

--- a/test/variables/ref/type-decls-arrays-1.good
+++ b/test/variables/ref/type-decls-arrays-1.good
@@ -1,0 +1,1 @@
+type-decls-arrays.chpl-1:9: error: halt reached - the domain of the declared array type of the reference has a different identity than the domain of the referenced array

--- a/test/variables/ref/type-decls-arrays-2.bad
+++ b/test/variables/ref/type-decls-arrays-2.bad
@@ -1,0 +1,2 @@
+type-decls-arrays-2.chpl:8: warning: there is no checking that the domain of the initialization expression matches the domain of the declared type of the reference 'r1'
+0 0 0

--- a/test/variables/ref/type-decls-arrays-2.chpl
+++ b/test/variables/ref/type-decls-arrays-2.chpl
@@ -1,0 +1,9 @@
+// When declaring the type of a 'ref' to an array, it should be an error if
+// the domain of that type differs from the domain of the referenced array.
+
+// This is a lighter / more obvious variant of type-decls-arrays-1.future
+// Here not only the identities, but also the sizes of the two domains differ.
+
+var a1: [1..3] int;
+ref r1: [1..44] int = a1;  // error: domain mismatch between r1 and a1
+writeln(r1);

--- a/test/variables/ref/type-decls-arrays-2.future
+++ b/test/variables/ref/type-decls-arrays-2.future
@@ -1,0 +1,8 @@
+bug: missing checks that the runtime types match
+
+When declaring the type of a reference to a domain or array,
+the runtime types of the declared type and the referenced domain or array
+must match.
+
+This is a lighter / more obvious variant of type-decls-arrays-1.future
+Here not only the identities, but also the sizes of the two domains differ.

--- a/test/variables/ref/type-decls-arrays-2.good
+++ b/test/variables/ref/type-decls-arrays-2.good
@@ -1,0 +1,1 @@
+type-decls-arrays.chpl-2:8: error: halt reached - the domain of the declared array type of the reference differs from the domain of the referenced array


### PR DESCRIPTION
Given `ref r: t = rr;`, ensure that `t` is exactly the type of `rr`, see #8947.

When `rr` is an array or a domain, warn the user that there is no runtime checking that the runtime types of `t` and `rr` are identical. This PR adds a future requesting that such runtime types be identical, and another one requesting that they at least be equal.

When `t` is generic, the check requires that it be instantiatable with the type of `rr`.

When `t` and `rr` are classes and `r` is a `const` reference, we could potentiall allow `t` to be a superclass of `rr`. However this PR does not do this.

Implementation: I introduce `PRIM_INIT_REF_DECL` during normalization as an anchor for performing the type check during resolution. The first commit on this PR's branch performs the type check without introducing this primitive -- instead using the reference's DefExpr. However this version overlooks references declared at the module level, as their DefExprs do not undergo resolution. `PRIM_INIT_REF_DECL` currently has no effect for references declared without a type. However I add them to the IR anyway for uniformity.

While there, move the potentially-costly check `partOfNonNormalizableExpr()` so it is executed fewer times. Also, allow multiple type mismatches in ref declarations during single compilation. When there is a type mismatch, continue resolving assuming the reference has its declared type if possible, otherwise it has the type of the referenced variable.

Testing: standard and gasnet paratests.