### PR TITLE
[LSP] Improve the accuracy and coverage of the 'Declaration' message

### DIFF
--- a/frontend/include/chpl/framework/Location.h
+++ b/frontend/include/chpl/framework/Location.h
@@ -56,6 +56,11 @@ public:
     return !isEmpty();
   }
 
+  inline bool isValid() const {
+    return !isEmpty() && firstLine_ >= 1 && firstColumn_ >= 1 &&
+           lastLine_ >= 1 && lastColumn_ >= 1;
+  }
+
   UniqueString path() const { return path_; }
   int firstLine() const { return firstLine_; }
   int firstColumn() const { return firstColumn_; }
@@ -74,6 +79,7 @@ public:
   inline bool operator!=(const Location& other) const {
     return !(*this == other);
   }
+
   void swap(Location& other) {
     path_.swap(other.path_);
     std::swap(firstLine_, other.firstLine_);
@@ -90,18 +96,16 @@ public:
     return chpl::hash(path_, firstLine_, firstColumn_, lastLine_, lastColumn_);
   }
 
-  /** True if this contains 'loc' or if this and 'loc' are equal. */
-  bool contains(const Location& loc) {
+  /** Returns 'true' if this contains 'loc' or if this and 'loc' are equal.
+      Returns 'false' if either this or 'loc' are empty, or if paths do
+      not match. */
+  inline bool contains(const Location& loc) {
+    if (this->isEmpty() || loc.isEmpty()) return false;
+    if (this->path() != loc.path()) return false;
     return firstLine() <= loc.firstLine() &&
            firstColumn() <= loc.firstColumn() &&
            lastLine() >= loc.lastLine() &&
            lastColumn() >= loc.lastColumn();
-  }
-
-  inline bool operator>(const Location& rhs) {
-    if (firstLine() > rhs.firstLine()) return true;
-    return firstLine() == rhs.firstLine() &&
-           firstColumn() > rhs.firstColumn();
   }
 
   void stringify(std::ostream& os, StringifyKind stringifyKind) const;

--- a/frontend/include/chpl/framework/Location.h
+++ b/frontend/include/chpl/framework/Location.h
@@ -108,6 +108,13 @@ public:
            lastColumn() >= loc.lastColumn();
   }
 
+  /** Determine if this location is greater than the location 'rhs' without
+      considering paths. */
+  inline bool operator>(const Location& rhs) {
+    if (firstLine() > rhs.firstLine()) return true;
+    return firstLine() == rhs.firstLine() && firstColumn() > rhs.firstColumn();
+  }
+
   void stringify(std::ostream& os, StringifyKind stringifyKind) const;
 
   // TODO: We could probably save some space by using a variable byte

--- a/tools/chpldef/compute-goto-declaration.cpp
+++ b/tools/chpldef/compute-goto-declaration.cpp
@@ -19,8 +19,8 @@
  */
 
 #include "compiler-gadgets.h"
-#include "./Message.h"
-#include "./Server.h"
+#include "Message.h"
+#include "Server.h"
 
 namespace chpldef {
 
@@ -33,16 +33,41 @@ chooseAstClosestToLocation(chpl::Context* chapel,
   CHPL_ASSERT(astNew);
   CHPL_ASSERT(astOld != astNew);
 
+  // If there is no new candidate then bail early.
+  if (!astNew) return astOld;
+
   // TODO: This can run 'locateAst' on the same AST node O(n) times.
   auto locOld = astOld ? locateAst(chapel, astOld) : chpl::Location();
   auto locNew = locateAst(chapel, astNew);
 
+  // If the new candidate has an empty location, bail early (and if the
+  // old candidate's location is empty, clear it as well).
+  if (!locNew) return !locOld ? nullptr : astOld;
+
+  // A valid candidate must contain the range of interest (note that 'astOld'
+  // can stay 'nullptr' along this path as long as no new AST's location
+  // range contains 'loc').
   if (!locNew.contains(loc)) return astOld;
+
+  // If there is no old candidate, the new one trivially wins because it
+  // contains the range of interest.
   if (!astOld) return astNew;
 
-  // Prefer the location furthest towards the end of the range.
-  // TODO: Need to compute distance.
-  auto ret = (locNew > locOld) ? astNew : astOld;
+  // We know that both candidates contain the range of interest. If either
+  // candidate is a tighter range than the other, then it trivially wins
+  // (because it must be closer to the range of interest).
+  if (locNew.contains(locOld)) return astOld;
+  if (locOld.contains(locNew)) return astNew;
+
+  // Construct two LSP ranges to use for comparison.
+  Range rangeOld(std::move(locOld));
+  Range rangeNew(std::move(locNew));
+
+  // At this point, candidates only partially overlap, so we have to
+  // determine distance another way. Since AST are pretty granular,
+  // try just preferring the lesser location (the one earlier in the
+  // source code).
+  auto ret = (rangeNew < rangeOld) ? astNew : astOld;
 
   return ret;
 }
@@ -81,79 +106,94 @@ astAtLocation(Server* ctx, chpl::Location loc) {
     if (ret && ret == last) break;
   }
 
+  // Do final filtering. E.g., for 'x.   foo', was the cursor on 'foo'?
+  ctx->withChapel([&](auto chapel) {
+    if (auto dot = ret->toDot()) {
+      auto locField = chpl::parsing::locateDotFieldWithAst(chapel, dot);
+      if (!locField.contains(loc)) ret = nullptr;
+    }
+  });
+
   return ret;
 }
 
-static const chpl::uast::Module*
-closestModule(chpl::Context* chapel, const chpl::uast::AstNode* ast) {
-  if (auto mod = ast->toModule()) return mod;
-  if (auto id = chpl::parsing::idToParentModule(chapel, ast->id())) {
-    auto mod = chpl::parsing::idToAst(chapel, id);
-    return mod->toModule();
-  }
-  return nullptr;
-}
-
-static const chpl::resolution::ResolutionResultByPostorderID&
-resolveModule(Server* ctx, chpl::ID idMod) {
-  return ctx->withChapel(chpl::resolution::resolveModule, idMod);
+static bool isAstForAggregate(const chpl::uast::AstNode* ast) {
+  return ast->isClass() || ast->isRecord() || ast->isUnion();
 }
 
 static std::vector<chpl::ID>
 sourceAstToIds(Server* ctx, const chpl::uast::AstNode* ast) {
+  using namespace chpl::resolution;
+
+  if (!ast) return {};
+
+  const ResolvedFunction* rf = nullptr;
+  const ResolutionResultByPostorderID* rr = nullptr;
+  auto parentCall = ctx->withChapel(parentCallIfBaseExpression, ast);
+  const bool isCallBaseExpr = (parentCall != nullptr);
+  const chpl::uast::AstNode* sym = nullptr;
+  bool canScopeResolveFunction = false;
   std::vector<chpl::ID> ret;
 
-  if (!ast) return ret;
+  // We need to look at the ID in order to determine the closest entity to
+  // resolve, and then we need to fetch some sort of 'ResolutionResult'.
+  ctx->withChapel([&](auto chapel) {
+    if (auto id = ast->id().parentSymbolId(chapel)) {
+      auto ast = chpl::parsing::idToAst(chapel, id);
+      CHPL_ASSERT(ast);
 
-  auto mod = ctx->withChapel(closestModule, ast);
-  CHPL_ASSERT(mod);
+      if (chpl::parsing::idIsFunction(chapel, id)) {
+        rf = resolveConcreteFunction(chapel, id);
+        // TODO: What do we do if the symbol is a generic function?
+        if (rf == nullptr) CHPLDEF_TODO();
+        canScopeResolveFunction = true;
+        rr = &rf->resolutionById();
+        sym = ast;
 
-  if (mod == ast) CHPLDEF_TODO();
+      } else if (ast->isModule()) {
+        rr = &resolveModule(chapel, id);
+        sym = ast;
 
-  ctx->trace("Target '%s' in containing module '%s'\n",
-             ctx->fmt(ast).c_str(),
-             ctx->fmt(mod).c_str());
-
-  auto& rr = resolveModule(ctx, mod->id());
-  auto& re = rr.byAst(ast);
-  auto parentCall = ctx->withChapel(parentCallIfBaseExpression, ast);
-
-  if (re.isBuiltin()) CHPLDEF_TODO();
-
-  ctx->trace("Encountered '%zu' errors resolving\n",
-             ctx->errorHandler()->numErrors());
-
-  // First do a simple check for target location.
-  if (auto idTarget = re.toId()) {
-    ret.push_back(idTarget);
-
-  // It's a call base expression, so we need to pick apart the call.
-  } else if (parentCall) {
-    auto& reCall = rr.byAst(parentCall);
-
-    if (auto idTarget = re.toId()) {
-      ret.push_back(idTarget);
-    } else {
-      if (auto tfs = reCall.mostSpecific().only()) {
-        ret.push_back(tfs->id());
-      } else {
+      } else if (isAstForAggregate(ast)) {
         CHPLDEF_TODO();
       }
     }
+  });
 
-  // Else, more work is required...
-  } else {
-    CHPLDEF_TODO();
+  if (!sym || sym == ast) CHPLDEF_TODO();
+
+  // If we are a call base expression, inspect the parent call.
+  const auto node = isCallBaseExpr ? parentCall : ast;
+
+  // In most cases, just inspect the resolution results we were given.
+  if (auto re = rr->byAstOrNull(node)) {
+    auto& ms = re->mostSpecific();
+
+    if (re->isBuiltin()) CHPLDEF_TODO();
+
+    if (auto id = re->toId()) {
+      ret.push_back(std::move(id));
+    } else if (auto tfs = ms.only()) {
+      ret.push_back(tfs->id());
+    } else {
+      CHPLDEF_TODO();
+    }
+
+  // If we failed to find something and our symbol is a function, try again
+  // with just scope resolving since the info for this AST may have been
+  // discarded if it is e.g., a formal's type.
+  // TODO: This branch is not sufficient to cover all cases and should be
+  // replaced with a new dyno query that populates the ResolutionResult
+  // for formal components.
+  } else if (canScopeResolveFunction) {
+    auto rf = ctx->withChapel(scopeResolveFunction, sym->id());
+    auto& rr = rf->resolutionById();
+    if (auto re = rr.byAstOrNull(node)) {
+      if (auto id = re->toId()) ret.push_back(std::move(id));
+    }
   }
 
   return ret;
-}
-
-static bool chplLocIsValid(const chpl::Location& loc) {
-  return !loc.isEmpty() && loc.firstLine() >= 1 &&
-        loc.firstColumn() >= 1 &&
-        loc.lastLine() >= 1 &&
-        loc.lastColumn() >= 1;
 }
 
 static std::variant<LocationArray, LocationLinkArray>
@@ -176,12 +216,8 @@ computeDeclarationPoints(Server* ctx, const TextDocumentPositionParams& p) {
 
     ctx->trace("Found entity at '%s'\n", ctx->fmt(loc).c_str());
 
-    if (chplLocIsValid(loc)) {
-      Position start = { static_cast<uint64_t>(loc.firstLine()-1),
-                         static_cast<uint64_t>(loc.firstColumn()-1) };
-      Position end = { static_cast<uint64_t>(loc.lastLine()-1),
-                       static_cast<uint64_t>(loc.lastColumn()-1) };
-      Location out(loc.path().str(), { start, end });
+    if (loc.isValid()) {
+      Location out(loc);
       ret.push_back(std::move(out));
     }
   }

--- a/tools/chpldef/protocol-types.cpp
+++ b/tools/chpldef/protocol-types.cpp
@@ -236,6 +236,26 @@ bool Position::operator==(const Position& rhs) const {
   return line == rhs.line && character == rhs.character;
 }
 
+bool Position::operator!=(const Position& rhs) const {
+  return !(*this == rhs);
+}
+
+bool Position::operator<(const Position& rhs) const {
+  return line < rhs.line || (line == rhs.line && character < rhs.character);
+}
+
+bool Position::operator<=(const Position& rhs) const {
+  return (*this < rhs) || (*this == rhs);
+}
+
+bool Position::operator>(const Position& rhs) const {
+  return !(*this <= rhs);
+}
+
+bool Position::operator>=(const Position& rhs) const {
+  return (*this > rhs) || (*this == rhs);
+}
+
 bool TextDocumentPositionParams::fromJson(const JsonValue& j, JsonPath p) {
   JsonMapper m(j, p);
   return m && MAP_(m, textDocument) && MAP_(m, position);
@@ -311,6 +331,42 @@ JsonValue Range::toJson() const {
 
 bool Range::operator==(const Range& rhs) const {
   return start == rhs.start && end == rhs.end;
+}
+
+bool Range::operator!=(const Range& rhs) const {
+  return !(*this == rhs);
+}
+
+bool Range::operator<(const Range& rhs) const {
+  return start < rhs.start;
+}
+
+bool Range::operator<=(const Range& rhs) const {
+  return (*this < rhs) || (*this == rhs);
+}
+
+bool Range::operator>(const Range& rhs) const {
+  return end > rhs.end;
+}
+
+bool Range::operator>=(const Range& rhs) const {
+  return (*this > rhs) || (*this == rhs);
+}
+
+bool Range::contains(const Range& r) const {
+  return start <= r.start && end >= r.end;
+}
+
+bool Range::contains(const Position& p) const {
+  return start <= p && end >= p;
+}
+
+bool Range::overlaps(const Range& r) const {
+  return contains(r.start) || contains(r.end);
+}
+
+bool Range::isNegative() const {
+  return end < start;
 }
 
 JsonValue DeclarationResult::toJson() const {

--- a/tools/chpldef/protocol-types.h
+++ b/tools/chpldef/protocol-types.h
@@ -276,8 +276,8 @@ struct Position : ProtocolType {
   bool operator==(const Position& rhs) const;
   bool operator!=(const Position& rhs) const;
   bool operator<(const Position& rhs) const;
-  bool operator>(const Position& rhs) const;
   bool operator<=(const Position& rhs) const;
+  bool operator>(const Position& rhs) const;
   bool operator>=(const Position& rhs) const;
 };
 
@@ -293,6 +293,27 @@ struct Range : ProtocolType {
   virtual bool fromJson(const JsonValue& j, JsonPath p) override;
   virtual JsonValue toJson() const override;
   bool operator==(const Range& rhs) const;
+  bool operator!=(const Range& rhs) const;
+
+  /** Determine if the start position of this is less than that of 'rhs'. */
+  bool operator<(const Range& rhs) const;
+  bool operator<=(const Range& rhs) const;
+
+  /** Determine if the end position of this is greater than that of 'rhs'. */
+  bool operator>(const Range& rhs) const;
+  bool operator>=(const Range& rhs) const;
+
+  /** Determine if this contains 'r'. Equal ranges contain each other. */
+  bool contains(const Range& r) const;
+
+  /** Determine if this contains the position 'p'. */
+  bool contains(const Position& p) const;
+
+  /** Determine if one range overlaps another. */
+  bool overlaps(const Range& r) const;
+
+  /** Determine if the end position is less than the start position. */
+  bool isNegative() const;
 };
 
 struct TextDocumentPositionParams : ProtocolTypeRecv {

--- a/tools/chpldef/test/TestClient.cpp
+++ b/tools/chpldef/test/TestClient.cpp
@@ -96,7 +96,7 @@ static std::string mentionSymbol(const chpl::uast::AstNode* ast) {
 }
 
 static Location
-sourceLocationFromAst(chpl::Context* chapel, const chpl::uast::AstNode* ast) {
+mentionSourceLocation(chpl::Context* chapel, const chpl::uast::AstNode* ast) {
   assert(ast);
   if (auto ident = ast->toIdentifier()) {
     auto loc = chpl::parsing::locateAst(chapel, ast);
@@ -112,7 +112,7 @@ sourceLocationFromAst(chpl::Context* chapel, const chpl::uast::AstNode* ast) {
 }
 
 static Location
-targetLocationFromAst(chpl::Context* chapel, const chpl::uast::AstNode* ast) {
+mentionTargetLocation(chpl::Context* chapel, const chpl::uast::AstNode* ast) {
   assert(ast);
   auto loc = chpl::parsing::locateAst(chapel, ast);
   return Location(std::move(loc));
@@ -131,7 +131,7 @@ doCollectMentions(chpl::Context* chapel,
     m.symbol = mentionSymbol(ast);
     bool isBaseExpr = parentCallIfBaseExpression(chapel, ast) != nullptr;
     m.isCallBaseExpression = isBaseExpr;
-    m.source = sourceLocationFromAst(chapel, ast);
+    m.source = mentionSourceLocation(chapel, ast);
     mentions.push_back(std::move(m));
   }
 
@@ -182,7 +182,7 @@ doFixupMentionTargets(chpl::Context* chapel,
     }
 
     assert(nd);
-    m.target = targetLocationFromAst(chapel, nd);
+    m.target = mentionTargetLocation(chapel, nd);
   }
 }
 

--- a/tools/chpldef/test/TestClient.cpp
+++ b/tools/chpldef/test/TestClient.cpp
@@ -99,7 +99,7 @@ static Location
 mentionSourceLocation(chpl::Context* chapel, const chpl::uast::AstNode* ast) {
   assert(ast);
   if (auto ident = ast->toIdentifier()) {
-    auto loc = chpl::parsing::locateAst(chapel, ast);
+    auto loc = chpl::parsing::locateAst(chapel, ident);
     return Location(std::move(loc));
   } else if (auto dot = ast->toDot()) {
     auto loc = chpl::parsing::locateDotFieldWithAst(chapel, dot);

--- a/tools/chpldef/test/TestClient.cpp
+++ b/tools/chpldef/test/TestClient.cpp
@@ -70,12 +70,12 @@ void TestClient::sendShutdown() {
 void TestClient::advanceServerToReady() {
   if (ctx_->state() == Server::UNINITIALIZED) {
     std::ignore = sendInitialize();
-    CHPL_ASSERT(ctx_->state() == Server::SETUP);
+    assert(ctx_->state() == Server::SETUP);
   }
 
   if (ctx_->state() == Server::SETUP) {
     sendInitialized();
-    CHPL_ASSERT(ctx_->state() == Server::READY);
+    assert(ctx_->state() == Server::READY);
   }
 }
 
@@ -96,8 +96,24 @@ static std::string mentionSymbol(const chpl::uast::AstNode* ast) {
 }
 
 static Location
-locationFromAst(chpl::Context* chapel, const chpl::uast::AstNode* ast) {
-  CHPL_ASSERT(ast);
+sourceLocationFromAst(chpl::Context* chapel, const chpl::uast::AstNode* ast) {
+  assert(ast);
+  if (auto ident = ast->toIdentifier()) {
+    auto loc = chpl::parsing::locateAst(chapel, ast);
+    return Location(std::move(loc));
+  } else if (auto dot = ast->toDot()) {
+    auto loc = chpl::parsing::locateDotFieldWithAst(chapel, dot);
+    assert(loc);
+    return Location(std::move(loc));
+  } else {
+    CHPLDEF_TODO();
+  }
+  return {};
+}
+
+static Location
+targetLocationFromAst(chpl::Context* chapel, const chpl::uast::AstNode* ast) {
+  assert(ast);
   auto loc = chpl::parsing::locateAst(chapel, ast);
   return Location(std::move(loc));
 }
@@ -115,12 +131,9 @@ doCollectMentions(chpl::Context* chapel,
     m.symbol = mentionSymbol(ast);
     bool isBaseExpr = parentCallIfBaseExpression(chapel, ast) != nullptr;
     m.isCallBaseExpression = isBaseExpr;
-    m.source = locationFromAst(chapel, ast);
+    m.source = sourceLocationFromAst(chapel, ast);
     mentions.push_back(std::move(m));
   }
-
-  const bool canRecurse = !ast->isFunction();
-  if (!canRecurse) return;
 
   for (auto child : ast->children()) {
     doCollectMentions(chapel, child, decls, mentions);
@@ -138,7 +151,7 @@ doFixupMentionTargets(chpl::Context* chapel,
     auto name = nd->name().c_str();
     auto& v = nameToDecls[name];
     v.push_back(nd);
-    if (!nd->isFunction()) CHPL_ASSERT(v.size() == 1);
+    if (!nd->isFunction()) assert(v.size() == 1);
   }
 
   for (size_t i = 0; i < mentions.size(); i++) {
@@ -147,26 +160,29 @@ doFixupMentionTargets(chpl::Context* chapel,
 
     // Get the declaration(s) with the name 'name'.
     auto it = nameToDecls.find(name);
-    CHPL_ASSERT(it != nameToDecls.end());
-    auto& v = it->second;
+    if (it == nameToDecls.end()) {
+      m.isValid = false;
+      continue;
+    }
 
+    auto& v = it->second;
     const chpl::uast::NamedDecl* nd = nullptr;
 
     // Calls map linearly in order to simulate overloading.
     if (m.isCallBaseExpression) {
       auto& idx = functionMentionIdx[name];
-      CHPL_ASSERT(v.size() >= 1);
-      CHPL_ASSERT(idx < v.size());
+      assert(v.size() >= 1);
+      assert(idx < v.size());
       nd = v[idx++];
 
     // Everything else just maps by name.
     } else {
-      CHPL_ASSERT(v.size() == 1);
+      assert(v.size() == 1);
       nd = v[0];
     }
 
-    CHPL_ASSERT(nd);
-    m.target = locationFromAst(chapel, nd);
+    assert(nd);
+    m.target = targetLocationFromAst(chapel, nd);
   }
 }
 
@@ -225,7 +241,7 @@ TestClient::sendDeclaration(const std::string& uri, Position cursor) {
     if (auto& res = r->result) {
       if (auto p = std::get_if<LocationArray>(&(*res))) {
         auto& arr = *p;
-        CHPL_ASSERT(arr.size() <= 1);
+        assert(arr.size() <= 1);
         if (arr.size() == 1) return arr[0];
         return {};
       }

--- a/tools/chpldef/test/TestClient.h
+++ b/tools/chpldef/test/TestClient.h
@@ -81,23 +81,27 @@ public:
   /** Send a 'DidOpen' notification. */
   void sendDidOpen(const std::string& uri, const std::string& text);
 
-  /** A mention represents a text range the client is interested in. */
+  /** A mention represents a text range the client is interested in.
+      Mentions cannot actually store AST because they were computed
+      with a separate instance of the Chapel compiler that has a short
+      lifetime. */
   struct Mention {
     using AstTag = chpl::uast::asttags::AstTag;
     AstTag tag;
     bool isCallBaseExpression = false;
     std::string symbol;
-    Location source;
-    Location target;
+    Location source;        /** This is a LSP location, not Chapel's! */
+    Location target;        /** Which means it is 0-based! */
+    bool isValid = true;    /** If there is no target, this is false. */
 
     std::string toString() const;
   };
 
-  /** Collect locations the client is interested in using a separate
-      instance of the Chapel compiler. The way mentions are mapped to
-      target locations depends on the target. Calls are mapped linearly
-      (where call N of 'foo' maps to overload N of 'foo') in order to
-      simulate overloading. Every other declaration is mapped by name.
+  /** Collect mention the client is interested in using a separate instance
+      of the Chapel compiler. The way mentions are mapped to target
+      locations depends on the target. Calls are mapped linearly (where call
+      N of 'foo' maps to overload N of 'foo') in order to simulate
+      overloading. Every other declaration is mapped by name.
   */
   static std::vector<Mention>
   collectMentions(const std::string& uri, const std::string& text);

--- a/tools/chpldef/test/test-declaration.cpp
+++ b/tools/chpldef/test/test-declaration.cpp
@@ -32,23 +32,38 @@ static void testDeclaration(const std::string& uri, const std::string& text) {
   auto lineLengths = TestClient::collectLineLengthsInSource(text);
   auto mentions = TestClient::collectMentions(uri, text);
 
+  /** Loop through each mention and convert the location range into a series
+      of mouse clicks spanning the entire range. A mouse click is represented
+      as a 'Position' in a range. Send that position to the server as the
+      argument for a 'Declaration' request. */
   for (auto& m : mentions) {
+    if (!m.isValid) continue;
+
     auto& range = m.source.range;
     auto& start = range.start;
     auto& end = range.end;
 
-    // TODO: Fuzz characters to the left and the right of the identifier.
-    if (m.tag == chpl::uast::asttags::Identifier) {
-      CHPL_ASSERT(start.line == end.line);
-      const auto line = start.line;
-      for (uint64_t c = start.character; c <= end.character; c++) {
-        Position cursor(line, c);
-        client.dbg() << m.toString();
-        client.dbg() << " w/ cursor (" << cursor.line << ":";
-        client.dbg() << cursor.character << ")" << std::endl;
+    if (m.tag == chpl::uast::asttags::Identifier ||
+        m.tag == chpl::uast::asttags::Dot) {
 
-        auto targetLoc = client.sendDeclaration(uri, cursor);
-        CHPL_ASSERT(targetLoc == m.target);
+      for (auto line = start.line; line <= end.line; line++) {
+        CHPL_ASSERT(line >= 0 && line < lineLengths.size());
+
+        auto lineLength = lineLengths[line];
+        auto startChar = line == start.line ? start.character : 0;
+        auto endChar = line == end.line ? end.character : lineLength;
+
+        for (auto c = startChar; c <= endChar; c++) {
+          Position cursor(line, c);
+
+          client.dbg() << m.toString();
+          client.dbg() << " w/ cursor (" << cursor.line << ":";
+          client.dbg() << cursor.character << ")" << std::endl;
+
+          auto targetLoc = client.sendDeclaration(uri, cursor);
+          assert(targetLoc);
+          assert(targetLoc == m.target);
+        }
       }
     } else {
       CHPLDEF_TODO();
@@ -69,12 +84,16 @@ static void test0(void) {
 
   x1;
   x2;
-  // x3.f; TODO: Dot targets. // BUG: Dot hugs right.
+  x3.f;
+  x3.
+     f;
 
   x1 = 8;
-  x2 = x1 * 2; // BUG: Assigned expression not considered.
+  x2 = x1 * 2;
 
   proc foo() {}
+
+  // TODO: 'C' does not have an entry in the ResolutionResult for 'bar'.
   proc bar(a: owned C?, b: int=0) { a; b; }
 
   foo();


### PR DESCRIPTION
Improve the accuracy of the `Declaration` message by fixing bugs, and allow it to connect more symbols to their definitions such as dot fields or the operands of binary expressions.

Reviewed by @DanilaFe. Thanks!