### PR TITLE
[tests] fix some dyno tests comparing int to size_t

### DIFF
--- a/frontend/test/parsing/testParseAdditionalLocations.cpp
+++ b/frontend/test/parsing/testParseAdditionalLocations.cpp
@@ -116,19 +116,19 @@ static void test1() {
     "union foo {}\n"            // 14:7
     // enum
     "enum foo { bar }\n";       // 15:6
-    
+
   setFileText(ctx, path, contents);
   auto& br = parseAndReportErrors(ctx, path);
   assert(!guard.realizeErrors());
 
-  static const std::array<pos, 13> positions = {
+  static const std::array<pos, 13> positions = {{
     pos(1,6), pos(2,9), pos(3,6), pos(5,5), pos(6,8), pos(7,6), pos(8,9),
     pos(9,6), pos(11,5), pos(12,7), pos(13,8), pos(14,7), pos(15,6)
-  };
+  }};
 
   auto mod = br.singleModule();
   assert(mod && mod->numStmts() == 13);
-  assert(positions.size() == mod->numStmts());
+  assert(positions.size() == (size_t) mod->numStmts());
 
   for (int i = 0; i < mod->numStmts(); i++) {
     auto nd = mod->stmt(i)->toNamedDecl();

--- a/frontend/test/resolution/testClassPrimitives.cpp
+++ b/frontend/test/resolution/testClassPrimitives.cpp
@@ -72,7 +72,7 @@ static void testPrimitive(std::string primitive, std::vector<std::tuple<const ch
 
   auto varTypes = resolveTypesOfVariables(context, ps.str(), variables);
 
-  for (int i = 0; i < varTypes.size(); i++) {
+  for (size_t i = 0; i < varTypes.size(); i++) {
     if (expectedValidities[i]) {
       assert(varTypes.at(variables[i]).isParamTrue());
     } else {

--- a/frontend/test/resolution/testSubtypePrimitives.cpp
+++ b/frontend/test/resolution/testSubtypePrimitives.cpp
@@ -68,7 +68,7 @@ static void testPrimitive(std::string primitive,
 
   auto varTypes = resolveTypesOfVariables(context, ps.str(), variables);
 
-  for (int i = 0; i < varTypes.size(); i++) {
+  for (size_t i = 0; i < varTypes.size(); i++) {
     std::cout << "Checking " << variables[i] << std::endl;
 
     if (expectedResults[i] == shouldReturnTrue) {


### PR DESCRIPTION
This PR just updates some dyno-tests that were making comparisons between `int` and `size_t` types, which caused a warning that gets promoted to an error on some systems (Ubuntu, for example).

It also addresses a warning about missing curly braces in an array initializer in one test.

[reviewed by @dlongnecke-cray]