### PR TITLE
implement prim string_length_bytes in dyno, add param tests

### DIFF
--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -75,7 +75,8 @@ static bool toParamIntActual(const QualifiedType& type, int64_t& into) {
 static bool paramStringBytesHelper(const QualifiedType& type, UniqueString& into, bool isString) {
   if (type.kind() == QualifiedType::PARAM) {
     if (auto t = type.type()) {
-      if (t->isBytesType() || (t->isStringType() && isString)) {
+      if ((t->isBytesType() && !isString) ||
+          (t->isStringType() && isString)) {
         if (auto p = type.param()) {
           if (auto sp = p->toStringParam()) {
             into = sp->value();

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -720,7 +720,7 @@ CallResolutionResult resolvePrimCall(Context* context,
           toParamBytesActual(actualType, sParam)) {
         const size_t s = sParam.length();
         type = QualifiedType(QualifiedType::PARAM,
-                      IntType::get(context, 64),
+                      IntType::get(context, 0),
                       IntParam::get(context, s));
         break;
       } else if (type.kind() != QualifiedType::PARAM) {

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -72,10 +72,10 @@ static bool toParamIntActual(const QualifiedType& type, int64_t& into) {
   return false;
 }
 
-static bool toParamStringActual(const QualifiedType& type, UniqueString& into) {
+static bool paramStringBytesHelper(const QualifiedType& type, UniqueString& into, bool isString) {
   if (type.kind() == QualifiedType::PARAM) {
     if (auto t = type.type()) {
-      if (t->isStringType()) {
+      if (t->isBytesType() || (t->isStringType() && isString)) {
         if (auto p = type.param()) {
           if (auto sp = p->toStringParam()) {
             into = sp->value();
@@ -86,6 +86,14 @@ static bool toParamStringActual(const QualifiedType& type, UniqueString& into) {
     }
   }
   return false;
+}
+
+static bool toParamBytesActual(const QualifiedType& type, UniqueString& into) {
+ return paramStringBytesHelper(type, into, false);
+}
+
+static bool toParamStringActual(const QualifiedType& type, UniqueString& into) {
+  return paramStringBytesHelper(type, into, true);
 }
 
 static QualifiedType primIsBound(Context* context, const CallInfo& ci) {
@@ -705,6 +713,23 @@ CallResolutionResult resolvePrimCall(Context* context,
     case PRIM_STRING_CONTAINS:
     case PRIM_STRING_CONCAT:
     case PRIM_STRING_LENGTH_BYTES:
+    {
+      UniqueString sParam;
+      auto& actualType = ci.actual(0).type();
+      if (toParamStringActual(actualType, sParam)||
+          toParamBytesActual(actualType, sParam)) {
+        const size_t s = sParam.length();
+        type = QualifiedType(QualifiedType::PARAM,
+                      IntType::get(context, 64),
+                      IntParam::get(context, s));
+        break;
+      } else if (type.kind() != QualifiedType::PARAM) {
+        // error - cannot call PRIM_STRING_LENGTH_BYTES on something that isn't
+        // a param
+        type = CHPL_TYPE_ERROR(context, IncompatibleKinds, QualifiedType::Kind::PARAM,
+                               call, actualType);
+      }
+    }
     case PRIM_STRING_LENGTH_CODEPOINTS:
     case PRIM_ASCII:
     case PRIM_STRING_ITEM:

--- a/frontend/test/resolution/testParams.cpp
+++ b/frontend/test/resolution/testParams.cpp
@@ -124,12 +124,8 @@ static void test4() {
   const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
   const auto& resolvedXExpr = rr.byAst(xStmt);
   const auto& resolvedYExpr = rr.byAst(yStmt);
-  assert(resolvedXExpr.type().kind() == QualifiedType::Kind::PARAM);
-  assert(resolvedYExpr.type().kind() == QualifiedType::Kind::PARAM);
-  assert(resolvedXExpr.type().param()->isBoolParam());
-  assert(resolvedYExpr.type().param()->isBoolParam());
-  assert(!resolvedXExpr.type().param()->toBoolParam()->value());
-  assert(resolvedYExpr.type().param()->toBoolParam()->value());
+  assert(resolvedXExpr.type().isParamFalse());
+  assert(resolvedYExpr.type().isParamTrue());
   auto isBlueXCall = xStmt->child(0);
   assert(isBlueXCall);
   auto isBlueProc = m->stmt(1);

--- a/frontend/test/resolution/testParams.cpp
+++ b/frontend/test/resolution/testParams.cpp
@@ -113,6 +113,10 @@ static void test4() {
   assert(m->numStmts() == 4);
   auto enumDecl = m->stmt(0);
   assert(enumDecl);
+  auto blueEnum = enumDecl->child(0);
+  auto greenEnum = enumDecl->child(2);
+  assert(blueEnum);
+  assert(greenEnum);
   auto xStmt = m->stmt(2);
   auto yStmt = m->stmt(3);
   assert(xStmt);
@@ -126,6 +130,24 @@ static void test4() {
   assert(resolvedYExpr.type().param()->isBoolParam());
   assert(!resolvedXExpr.type().param()->toBoolParam()->value());
   assert(resolvedYExpr.type().param()->toBoolParam()->value());
+  auto isBlueXCall = xStmt->child(0);
+  assert(isBlueXCall);
+  auto isBlueProc = m->stmt(1);
+  assert(isBlueProc);
+  auto isBlueFn = isBlueProc->toFunction();
+  assert(isBlueFn);
+  const auto rrIsBlueCall = rr.byAst(isBlueXCall);
+  assert(rrIsBlueCall.type().kind() == QualifiedType::Kind::PARAM);
+  auto bestFn = rrIsBlueCall.mostSpecific().only();
+  assert(bestFn);
+  assert(bestFn->id() == isBlueFn->id());
+  assert(bestFn->formalType(0).isParam());
+  assert(bestFn->formalName(0) == UniqueString::get(context, "this"));
+  assert(bestFn->formalType(0).param()->isEnumParam());
+  assert(bestFn->formalType(0).param()->toEnumParam()->value() == greenEnum->id());
+  const ResolvedFunction* rfn = scopeResolveFunction(context, isBlueFn->id());
+  const auto tsi = typedSignatureInitial(context, rfn->signature()->untyped());
+  assert(tsi->formalType(0).isParam());
 }
 
 static void test5() {


### PR DESCRIPTION
This PR adds an implementation for the primitive `string_length_bytes` for `param string` and `param bytes` arguments. It also adds a test to demonstrate correct behavior for `param this` intent with an `enum`. 

TESTING:

- [x] paratest `[Summary: #Successes = 17029 | #Failures = 0 | #Futures = 917]`
- [x] gasnet paratest `[Summary: #Successes = 17209 | #Failures = 0 | #Futures = 926]`