### PR TITLE
Prevent auto local access from optimizing loops with semantic errors

### DIFF
--- a/compiler/optimizations/forallOptimizations.cpp
+++ b/compiler/optimizations/forallOptimizations.cpp
@@ -1433,7 +1433,7 @@ static void autoLocalAccess(ForallStmt *forall) {
   }
 
   if (!loopHasValidOptInfo(forall)) {
-    LOG_ALA(1, "Can't optimize this forall: invalid opt info", forall);
+    LOG_ALA(1, "Can't optimize this forall: invalid loop", forall);
     return;
   }
 

--- a/compiler/optimizations/forallOptimizations.cpp
+++ b/compiler/optimizations/forallOptimizations.cpp
@@ -92,6 +92,7 @@ static std::vector<Symbol *> getLoopIndexSymbols(ForallStmt *forall,
                                                  Symbol *baseSym);
 static void gatherForallInfo(ForallStmt *forall);
 static bool loopHasValidInductionVariables(ForallStmt *forall);
+static bool loopHasValidOptInfo(ForallStmt *forall);
 static Symbol *canDetermineLoopDomainStatically(ForallStmt *forall);
 static Symbol *getCallBaseSymIfSuitable(CallExpr *call, ForallStmt *forall,
                                         bool checkArgs, int *argIdx,
@@ -931,18 +932,17 @@ static void gatherForallInfo(ForallStmt *forall) {
 static bool loopHasValidInductionVariables(ForallStmt *forall) {
   // if we understand the induction variables, then we can still take a look at
   // the loop body for some calls that we can optimize dynamically
+  return forall->optInfo.multiDIndices.size() > 0;
+}
+
+static bool loopHasValidOptInfo(ForallStmt *forall) {
   // if multiDIndicesSize is a different length than the other sym lists,
   // its likely we didn't understand one of the calls (possible use-before-def)
-
+  // we only need to check one of the sym lists, since they are all appended to
+  // together
   auto multiDIndicesSize = forall->optInfo.multiDIndices.size();
   auto iterSymSize = forall->optInfo.iterSym.size();
-  auto dotDomIterSymSize = forall->optInfo.dotDomIterSym.size();
-  auto iterCallTmpSize = forall->optInfo.iterCallTmp.size();
-
-  return multiDIndicesSize > 0 &&
-         multiDIndicesSize == iterSymSize &&
-         multiDIndicesSize == dotDomIterSymSize &&
-         iterCallTmpSize == multiDIndicesSize;
+  return multiDIndicesSize == iterSymSize;
 }
 
 static Symbol *canDetermineLoopDomainStatically(ForallStmt *forall) {
@@ -1432,6 +1432,11 @@ static void autoLocalAccess(ForallStmt *forall) {
     return;
   }
 
+  if (!loopHasValidOptInfo(forall)) {
+    LOG_ALA(1, "Can't optimize this forall: invalid opt info", forall);
+    return;
+  }
+
   Symbol *loopDomain = canDetermineLoopDomainStatically(forall);
   bool staticLoopDomain = loopDomain != NULL;
   if (staticLoopDomain) {
@@ -1678,7 +1683,7 @@ static void autoAggregation(ForallStmt *forall) {
 
   LOG_AA(0, "Start analyzing forall for automatic aggregation", forall);
 
-  if (loopHasValidInductionVariables(forall)) {
+  if (loopHasValidInductionVariables(forall) && loopHasValidOptInfo(forall)) {
     std::vector<Expr *> lastStmts = getLastStmtsForForallUnorderedOps(forall);
 
     for_vector(Expr, lastStmt, lastStmts) {

--- a/compiler/optimizations/forallOptimizations.cpp
+++ b/compiler/optimizations/forallOptimizations.cpp
@@ -931,7 +931,18 @@ static void gatherForallInfo(ForallStmt *forall) {
 static bool loopHasValidInductionVariables(ForallStmt *forall) {
   // if we understand the induction variables, then we can still take a look at
   // the loop body for some calls that we can optimize dynamically
-  return forall->optInfo.multiDIndices.size() > 0;
+  // if multiDIndicesSize is a different length than the other sym lists,
+  // its likely we didn't understand one of the calls (possible use-before-def)
+
+  auto multiDIndicesSize = forall->optInfo.multiDIndices.size();
+  auto iterSymSize = forall->optInfo.iterSym.size();
+  auto dotDomIterSymSize = forall->optInfo.dotDomIterSym.size();
+  auto iterCallTmpSize = forall->optInfo.iterCallTmp.size();
+
+  return multiDIndicesSize > 0 &&
+         multiDIndicesSize == iterSymSize &&
+         multiDIndicesSize == dotDomIterSymSize &&
+         iterCallTmpSize == multiDIndicesSize;
 }
 
 static Symbol *canDetermineLoopDomainStatically(ForallStmt *forall) {

--- a/test/optimizations/autoLocalAccess/use-before-def-bug.chpl
+++ b/test/optimizations/autoLocalAccess/use-before-def-bug.chpl
@@ -1,4 +1,4 @@
-// from issue #23653
+// from issue #23653, where a use-before-def caused an internal error from auto-aggregation optimizations
 const D = {1..3};
 var Src = [1, 2, 3, 4, 5];
 var Inds: [D] int;

--- a/test/optimizations/autoLocalAccess/use-before-def-bug.chpl
+++ b/test/optimizations/autoLocalAccess/use-before-def-bug.chpl
@@ -1,0 +1,6 @@
+// from issue #23653
+const D = {1..3};
+var Src = [1, 2, 3, 4, 5];
+var Inds: [D] int;
+// order matters, `zip(Inds, Dst)` does not trigger the bug
+forall (d, i) in zip(Dst, Inds) do d = Src[i];

--- a/test/optimizations/autoLocalAccess/use-before-def-bug.good
+++ b/test/optimizations/autoLocalAccess/use-before-def-bug.good
@@ -1,4 +1,4 @@
 
 Start analyzing forall (use-before-def-bug.chpl:6)
-| Can't optimize this forall: invalid opt info (use-before-def-bug.chpl:6)
+| Can't optimize this forall: invalid loop (use-before-def-bug.chpl:6)
 use-before-def-bug.chpl:6: error: 'Dst' undeclared (first use this function)

--- a/test/optimizations/autoLocalAccess/use-before-def-bug.good
+++ b/test/optimizations/autoLocalAccess/use-before-def-bug.good
@@ -1,4 +1,4 @@
 
 Start analyzing forall (use-before-def-bug.chpl:6)
-| Can't optimize this forall: invalid induction variables (use-before-def-bug.chpl:6)
+| Can't optimize this forall: invalid opt info (use-before-def-bug.chpl:6)
 use-before-def-bug.chpl:6: error: 'Dst' undeclared (first use this function)

--- a/test/optimizations/autoLocalAccess/use-before-def-bug.good
+++ b/test/optimizations/autoLocalAccess/use-before-def-bug.good
@@ -1,0 +1,4 @@
+
+Start analyzing forall (use-before-def-bug.chpl:6)
+| Can't optimize this forall: invalid induction variables (use-before-def-bug.chpl:6)
+use-before-def-bug.chpl:6: error: 'Dst' undeclared (first use this function)


### PR DESCRIPTION
Adds new check `loopHasValidOptInfo` to prevent the compiler trying to optimize loops with semantic errors.

This resolves #23653, where the compiler would try to optimize the loop, but because the variable did not exist the optimization would fail. Sadly, this couldn't be handled by the existing use-before-def check because it occurs after the optimization.

Testing: paratest and paratest with gasnet

[Reviewed by @e-kayrakli]