### PR TITLE
Fix race in histogram test

### DIFF
--- a/test/puzzles/deitz/histogram.chpl
+++ b/test/puzzles/deitz/histogram.chpl
@@ -4,7 +4,7 @@ var A: [1..n] int = (1,7,2,9,6,7,1,3,7,5,7,9);
 var H: [0..9] int;
 
 // H(A) += 1;
-forall a in A with (ref H) do H(a) += 1;
+forall a in A with (+ reduce H) do H(a) += 1;
 
 for i in 0..9 {
   write(i, " ");


### PR DESCRIPTION
Fixes race introduced in #23208. The previous code was `H[A] += 1;`, which was likely serialized and so we did not see the race. The previous PR used an explicit parallel construct with a `ref` intent and was not serialized, causing the race.

Replaced the `ref` intent with a reduce intent.

[Reviewed by @jeremiah-corrado]