### PR TITLE
Add a warning to chplcheck for confusing indentation

### DIFF
--- a/tools/chapel-py/chplcheck.py
+++ b/tools/chapel-py/chplcheck.py
@@ -141,7 +141,7 @@ def check_misleading_indentation(node):
         yield from check_misleading_indentation(child)
 
         if prev is not None:
-            if rc.node_indent(child) == rc.node_indent(prev):
+            if child.location().start()[1] == prev.location().start()[1]:
                 yield child
 
         if isinstance(child, chapel.core.Loop) and child.block_style() == "implicit":
@@ -161,7 +161,7 @@ Rules = [
 ]
 
 def main():
-    global args, rc
+    global args
 
     parser = argparse.ArgumentParser( prog='chplcheck', description='A linter for the Chapel language')
     parser.add_argument('filename')
@@ -170,7 +170,6 @@ def main():
 
     ctx = chapel.core.Context()
     ast = ctx.parse(args.filename)
-    rc = chapel.replace.ReplacementContext(args.filename)
 
     for rule in Rules:
         check_basic_rule(ast, rule)


### PR DESCRIPTION
This PR adds a warning to the Chapel linter for "misleading indentation". Misleading indentation occurs when a non-curly-brace block is used in a for loop or if-else statement, but a line of code underneath is indented to the same extent. For example:

```Chapel
for i in 1..10 do
  writeln("Hello, ");
  writeln("World!");
```

The issue with the above code is that it _looks_ like both statements are a part of the loop; the user might have even intended that. However, the syntax of the `do` keyword is that only the statement following it is part of the block; thus, the code printing `World` is not run in a loop. Thus, the way the code _looks_ (and might be written in an indentation-sensitive language like Python) is not how it actually behaves.

```
➜  chapel git:(confusing-indentation) cat good.chpl
for i in 1..10 do
    writeln("Hello!");
writeln("World!");
➜  chapel git:(confusing-indentation) python3 tools/chapel-py/chplcheck.py good.chpl
➜  chapel git:(confusing-indentation) cat bad.chpl
for i in 1..10 do
    writeln("Hello!");
    writeln("World!");
➜  chapel git:(confusing-indentation) python3 tools/chapel-py/chplcheck.py bad.chpl
bad.chpl:3: node violates rule MisleadingIndentation
```

Reviewed by @jabraham17 -- thanks!