### PR TITLE
Add missing documentation for standard modules

### DIFF
--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -20,14 +20,13 @@
 
 /* Provides a 'bigint' type and supporting math operations.
 
-The ``bigint`` record supports arithmetic operations on arbitrary
+The ``bigint`` type supports arithmetic operations on arbitrary
 precision integers in a manner that is broadly consistent with
 the conventional operations on primitive fixed length integers.
 
 The current implementation is based on the low-level types and
 functions defined in the GMP module i.e. it is implemented using the
-GNU Multiple Precision Integer Arithmetic library (GMP). More specifically
-the record :record:`bigint` wraps the GMP type :type:`~GMP.mpz_t`.
+GNU Multiple Precision Integer Arithmetic library (GMP). More specifically, :type:`bigint` wraps the GMP type :type:`~GMP.mpz_t`.
 
 The primary benefits of ``bigint`` over ``mpz_t`` are
 
@@ -170,6 +169,10 @@ module BigInteger {
     throw new BadFormatError("Error initializing big integer");
   }
 
+  /*
+    The `bigint` type supports arithmetic operations on arbitrary
+    precision integers across multiple locales.
+  */
   pragma "ignore noinit"
   record bigint : writeSerializable {
     // The underlying GMP C structure
@@ -704,6 +707,8 @@ module BigInteger {
     BigInteger.add(c, b, a);
     return c;
   }
+
+  /* See :proc:`~BigInteger.add` */
   operator bigint.+(a: uint, const ref b: bigint): bigint {
     var c = new bigint();
     BigInteger.add(c, b, a);

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -26,7 +26,8 @@ the conventional operations on primitive fixed length integers.
 
 The current implementation is based on the low-level types and
 functions defined in the GMP module i.e. it is implemented using the
-GNU Multiple Precision Integer Arithmetic library (GMP). More specifically, :type:`bigint` wraps the GMP type :type:`~GMP.mpz_t`.
+GNU Multiple Precision Integer Arithmetic library (GMP). More specifically,
+:type:`bigint` wraps the GMP type :type:`~GMP.mpz_t`.
 
 The primary benefits of ``bigint`` over ``mpz_t`` are
 

--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -242,7 +242,7 @@ module CTypes {
     param size;
 
     /*
-      Default-initializes a :type:`c_array`, where each element gets the default value of ` eltType``.
+      Default-initializes a :type:`c_array`, where each element gets the default value of ``eltType``.
     */
     proc init(type eltType, param size) {
       this.eltType = eltType;
@@ -360,6 +360,7 @@ module CTypes {
       lhs[i] = rhs[i];
     }
   }
+
   /*
     Get a pointer to the first element in ``rhs``, essentially decaying the :type:`c_array` to a :type:`c_ptr`.
   */

--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -241,6 +241,9 @@ module CTypes {
     */
     param size;
 
+    /*
+      Default-initializes a :type:`c_array`, where each element gets the default value of ` eltType``.
+    */
     proc init(type eltType, param size) {
       this.eltType = eltType;
       this.size = size;
@@ -258,6 +261,7 @@ module CTypes {
       }
     }
 
+    @chpldoc.nodoc
     proc deinit() {
       var i = 0;
       while i < size {
@@ -327,6 +331,9 @@ module CTypes {
       writeThis(writer);
     }
 
+    /*
+      Moves the elements from ``other`` to ``this``.
+    */
     proc init=(other: c_array) {
       this.eltType = other.eltType;
       this.size = other.size;
@@ -353,6 +360,9 @@ module CTypes {
       lhs[i] = rhs[i];
     }
   }
+  /*
+    Get a pointer to the first element in ``rhs``, essentially decaying the :type:`c_array` to a :type:`c_ptr`.
+  */
   operator =(ref lhs:c_ptr, ref rhs:c_array) {
     if lhs.eltType != rhs.eltType && lhs.eltType != void then
       compilerError("element type mismatch in c_array assignment");

--- a/modules/standard/Errors.chpl
+++ b/modules/standard/Errors.chpl
@@ -86,6 +86,9 @@ module Errors {
     }
   }
 
+  /*
+    A `NilClassError` is thrown if a cast from a `nil` class is made.
+  */
   class NilClassError : Error {
     @chpldoc.nodoc
     override proc message() {
@@ -93,6 +96,10 @@ module Errors {
     }
   }
 
+  /*
+    A `ClassCastError` is thrown if a cast between class types fails and the
+    destination is not nilable.
+  */
   class ClassCastError : Error {
     @chpldoc.nodoc
     override proc message() {
@@ -102,8 +109,8 @@ module Errors {
 
   /*
    A `DecodeError` is thrown if an attempt to create a string with non-UTF8 byte
-   sequences are made at runtime. This includes calling the
-   `bytes.decode(decodePolicy.strict)` method on a bytes with non-UTF8 byte
+   sequences is made at runtime. This includes calling the
+   `bytes.decode(decodePolicy.strict)` method on a ``bytes`` with non-UTF8 byte
    sequences.
    */
   class DecodeError: Error {
@@ -114,9 +121,15 @@ module Errors {
     }
   }
 
+  /*
+    An `IllegalArgumentError` is thrown if bad arguments are passed as arguments
+    to procedures.
+  */
   class IllegalArgumentError : Error {
+    @chpldoc.nodoc
     proc init() {}
 
+    @chpldoc.nodoc
     proc init(msg: string) {
       super.init(msg);
     }
@@ -149,10 +162,12 @@ module Errors {
     with codepoint boundaries.
   */
   class CodepointSplitError: Error {
+    @chpldoc.nodoc
     proc init(info: string) {
       super.init(info);
     }
 
+    @chpldoc.nodoc
     override proc message() {
       return "Attempting to split a multi-byte codepoint. " + _msg;
     }
@@ -291,6 +306,7 @@ module Errors {
       errorsArray = nil;
     }
 
+    @chpldoc.nodoc
     proc deinit() {
       if errorsArray {
         for i in 0..#nErrors {

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -2435,6 +2435,8 @@ proc openMemFileHelper(style:iostyleInternal = defaultIOStyleInternal()):file th
   return ret;
 }
 
+// temporary config documented elsewhere
+@chpldoc.nodoc
 config param useIOSerializers = true;
 
 private proc defaultSerializeType(param writing : bool,
@@ -11835,6 +11837,7 @@ proc fileWriter.writef(fmtStr: ?t, const args ...?k) throws
 }
 
 // documented in varargs version
+@chpldoc.nodoc
 proc fileWriter.writef(fmtStr:?t) throws
   where isStringType(t) || isBytesType(t)
 {

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3389,7 +3389,9 @@ record defaultDeserializer {
     for lists.
   */
   record ListDeserializer {
+    @chpldoc.nodoc
     var reader;
+    @chpldoc.nodoc
     var _first : bool = true;
 
     /*

--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -2140,7 +2140,7 @@ module List {
     Initializes a list containing elements that are copy initialized from
     the elements contained in another list.
 
-    See :proc:`~List.init=`
+    See :proc:`~list.init=`
   */
   operator :(rhs:list, type t:list) {
     var lst: list = rhs; // use init=
@@ -2151,7 +2151,7 @@ module List {
     Initializes a list containing elements that are copy initialized from
     the elements contained in an array.
 
-    See :proc:`~List.init=`
+    See :proc:`~list.init=`
   */
   operator :(rhs:[], type t:list) {
     var lst: list = rhs; // use init=
@@ -2162,7 +2162,7 @@ module List {
     Initializes a list containing elements that are copy initialized from
     the elements yielded by a range.
 
-    See :proc:`~List.init=`
+    See :proc:`~list.init=`
   */
   operator :(rhs:range(?), type t:list) {
     var lst: list = rhs; // use init=
@@ -2173,7 +2173,7 @@ module List {
     Initializes a list containing elements that are copy initialized from
     the elements yielded by an iterator expression.
 
-    See :proc:`~List.init=`
+    See :proc:`~list.init=`
   */
   operator :(rhs:_iteratorRecord, type t:list) {
     var lst: list = rhs; // use init=

--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -2136,18 +2136,45 @@ module List {
     return !(a == b);
   }
 
+  /*
+    Initializes a list containing elements that are copy initialized from
+    the elements contained in another list.
+
+    See `~List.init=`
+  */
   operator :(rhs:list, type t:list) {
     var lst: list = rhs; // use init=
     return lst;
   }
+
+  /*
+    Initializes a list containing elements that are copy initialized from
+    the elements contained in an array.
+
+    See `~List.init=`
+  */
   operator :(rhs:[], type t:list) {
     var lst: list = rhs; // use init=
     return lst;
   }
+
+  /*
+    Initializes a list containing elements that are copy initialized from
+    the elements yielded by a range.
+
+    See `~List.init=`
+  */
   operator :(rhs:range(?), type t:list) {
     var lst: list = rhs; // use init=
     return lst;
   }
+
+  /*
+    Initializes a list containing elements that are copy initialized from
+    the elements yielded by an iterator expression.
+
+    See `~List.init=`
+  */
   operator :(rhs:_iteratorRecord, type t:list) {
     var lst: list = rhs; // use init=
     return lst;

--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -363,6 +363,7 @@ module List {
 
       :arg other: The iterator expression to initialize from.
     */
+    @chpldoc.nodoc
     proc init(other: _iteratorRecord) {
       // get the type yielded by the iterator
       type t = __primitive("scalar promotion type", other.type);
@@ -388,6 +389,7 @@ module List {
     */
     pragma "last resort"
     @unstable("'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future")
+    @chpldoc.nodoc
     proc init(other: _iteratorRecord, param parSafe=false) {
       // get the type yielded by the iterator
       type t = __primitive("scalar promotion type", other.type);
@@ -495,6 +497,7 @@ module List {
 
       :arg other: The iterator expression to initialize from.
     */
+    @chpldoc.nodoc
     proc init=(other: _iteratorRecord) {
       // get the type yielded by the iterator
       type t = __primitive("scalar promotion type", other.type);
@@ -2175,6 +2178,7 @@ module List {
 
     See :proc:`~list.init=`
   */
+  @chpldoc.nodoc
   operator :(rhs:_iteratorRecord, type t:list) {
     var lst: list = rhs; // use init=
     return lst;

--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -2140,7 +2140,7 @@ module List {
     Initializes a list containing elements that are copy initialized from
     the elements contained in another list.
 
-    See `~List.init=`
+    See :proc:`~List.init=`
   */
   operator :(rhs:list, type t:list) {
     var lst: list = rhs; // use init=
@@ -2151,7 +2151,7 @@ module List {
     Initializes a list containing elements that are copy initialized from
     the elements contained in an array.
 
-    See `~List.init=`
+    See :proc:`~List.init=`
   */
   operator :(rhs:[], type t:list) {
     var lst: list = rhs; // use init=
@@ -2162,7 +2162,7 @@ module List {
     Initializes a list containing elements that are copy initialized from
     the elements yielded by a range.
 
-    See `~List.init=`
+    See :proc:`~List.init=`
   */
   operator :(rhs:range(?), type t:list) {
     var lst: list = rhs; // use init=
@@ -2173,7 +2173,7 @@ module List {
     Initializes a list containing elements that are copy initialized from
     the elements yielded by an iterator expression.
 
-    See `~List.init=`
+    See :proc:`~List.init=`
   */
   operator :(rhs:_iteratorRecord, type t:list) {
     var lst: list = rhs; // use init=

--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -362,21 +362,10 @@ module Map {
                       '`parSafe=true`', 2);
     }
 
-    @chpldoc.nodoc
-    proc ref this(k: keyType) ref
-      where isDefaultInitializable(valType) {
-      _warnForParSafeIndexing();
 
-      _enter(); defer _leave();
-
-      var (_, slot) = table.findAvailableSlot(k);
-      if !table.isSlotFull(slot) {
-        var val: valType;
-        table.fillSlot(slot, k, val);
-      }
-      return table.table[slot].val;
-    }
-
+    // TODO (Jade 11/6/23): This doc comment should go on the `this` overload
+    // without `where` that is marked `throws`. However, there is a current
+    // limitation in chpldoc with return intents and `throws` (#23776)
     /*
       If the key exists in the map, get a reference to the value mapped
       to the given key. If the key does not exist in the map, the value
@@ -396,6 +385,21 @@ module Map {
 
       :returns: Reference to the value mapped to the given key.
     */
+    proc ref this(k: keyType) ref
+      where isDefaultInitializable(valType) {
+      _warnForParSafeIndexing();
+
+      _enter(); defer _leave();
+
+      var (_, slot) = table.findAvailableSlot(k);
+      if !table.isSlotFull(slot) {
+        var val: valType;
+        table.fillSlot(slot, k, val);
+      }
+      return table.table[slot].val;
+    }
+
+    @chpldoc.nodoc
     proc ref this(k: keyType) ref throws {
       _warnForParSafeIndexing();
 

--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -18,8 +18,10 @@
  * limitations under the License.
  */
 
-/* This module contains the implementation of the ``map`` type which is a
-   container that stores key-value associations.
+/* Provides Chapel's standard ``map`` type for key-value storage.
+
+  This module contains the implementation of the ``map`` type which is a
+  container that stores key-value associations.
 */
 module Map {
   import ChapelLocks;
@@ -64,7 +66,6 @@ module Map {
     }
   }
 
-  // empty doc, the module docstring serves for this
   /*
     Chapel's standard ``map`` type for key-value storage.
 

--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -73,6 +73,8 @@ module Map {
     }
   }
 
+  // empty doc, the module docstring serves for this
+  /**/
   record map : serializable {
     /* Type of map keys. */
     type keyType;
@@ -392,6 +394,7 @@ module Map {
       return table.table[slot].val;
     }
 
+    @chpldoc.nodoc
     proc ref this(k: keyType) ref throws {
       _warnForParSafeIndexing();
 

--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -18,17 +18,8 @@
  * limitations under the License.
  */
 
-/* Chapel's standard 'map' type for key-value storage.
-
-  This module contains the implementation of the map type which is a container
-  that stores key-value associations.
-
-  Maps are not parallel safe by default, but can be made parallel safe by
-  setting the param formal `parSafe` to true in any map constructor. When
-  constructed from another map, the new map will inherit the parallel safety
-  mode of its originating map. Note that the ``parSafe`` mode is currently
-  unstable and will eventually be replaced by a standalone parallel-safe map
-  type.
+/* This module contains the implementation of the ``map`` type which is a
+   container that stores key-value associations.
 */
 module Map {
   import ChapelLocks;
@@ -74,7 +65,16 @@ module Map {
   }
 
   // empty doc, the module docstring serves for this
-  /**/
+  /*
+    Chapel's standard ``map`` type for key-value storage.
+
+    Maps are not parallel safe by default, but can be made parallel safe by
+    setting the param formal ``parSafe`` to true in any ``map`` constructor. When
+    constructed from another ``map``, the new ``map`` will inherit the parallel safety
+    mode of its originating map. Note that the ``parSafe`` mode is currently
+    unstable and will eventually be replaced by a standalone parallel-safe map
+    type.
+  */
   record map : serializable {
     /* Type of map keys. */
     type keyType;

--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -1019,8 +1019,10 @@ module Map {
    state of the `map`. An example of this is calling `map.getValue()`.
    */
   class KeyNotFoundError : Error {
+    @chpldoc.nodoc
     proc init() {}
 
+    @chpldoc.nodoc
     proc init(k) {
       super.init(try! "key '%?' not found".format(k));
     }

--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -361,6 +361,21 @@ module Map {
                       '`parSafe=true`', 2);
     }
 
+    @chpldoc.nodoc
+    proc ref this(k: keyType) ref
+      where isDefaultInitializable(valType) {
+      _warnForParSafeIndexing();
+
+      _enter(); defer _leave();
+
+      var (_, slot) = table.findAvailableSlot(k);
+      if !table.isSlotFull(slot) {
+        var val: valType;
+        table.fillSlot(slot, k, val);
+      }
+      return table.table[slot].val;
+    }
+
     /*
       If the key exists in the map, get a reference to the value mapped
       to the given key. If the key does not exist in the map, the value
@@ -380,21 +395,6 @@ module Map {
 
       :returns: Reference to the value mapped to the given key.
     */
-    proc ref this(k: keyType) ref
-      where isDefaultInitializable(valType) {
-      _warnForParSafeIndexing();
-
-      _enter(); defer _leave();
-
-      var (_, slot) = table.findAvailableSlot(k);
-      if !table.isSlotFull(slot) {
-        var val: valType;
-        table.fillSlot(slot, k, val);
-      }
-      return table.table[slot].val;
-    }
-
-    @chpldoc.nodoc
     proc ref this(k: keyType) ref throws {
       _warnForParSafeIndexing();
 

--- a/modules/standard/OS.chpl
+++ b/modules/standard/OS.chpl
@@ -838,7 +838,7 @@ module OS {
     /*
       Indicates which of the specificed file descriptors is ready for reading
       or writing, or has an error condition pending. If no file descriptors are
-      ready, the procoedure blocks until the ``timeout``.
+      ready, the procedure blocks until the ``timeout``.
     */
     extern 'select' proc select_posix(nfds:c_int,
                                       readfds:c_ptr(fd_set),

--- a/modules/standard/OS.chpl
+++ b/modules/standard/OS.chpl
@@ -199,9 +199,12 @@ module OS {
     //
     // time.h (pre-decl for struct_timespec, needed in sys/stat.h)
     //
+    /* The structure ``timespec`` from ``time.h``. */
     extern "struct timespec" record struct_timespec {
-      var tv_sec:time_t;  // seconds since Jan. 1, 1970
-      var tv_nsec:c_long; // and nanoseconds
+      /* Seconds since the epoch, Jan. 1, 1970 */
+      var tv_sec:time_t;
+      /* Nanoseconds */
+      var tv_nsec:c_long;
     }
 
     //
@@ -521,6 +524,7 @@ module OS {
      */
     extern const ENOTEMPTY:c_int;
 
+    /* State not recoverable. */
     extern const ENOTRECOVERABLE:c_int;
 
     /* Socket operation on non-socket. */
@@ -560,6 +564,7 @@ module OS {
      */
     extern const EOVERFLOW:c_int;
 
+    /* Owner died. */
     extern const EOWNERDEAD:c_int;
 
     /* Operation not permitted. An attempt was made to perform an operation
@@ -734,27 +739,47 @@ module OS {
     //
     // fcntl.h
     //
+    /* Mask for file access modes. */
     extern const O_ACCMODE:c_int;
+    /* Set append mode. */
     extern const O_APPEND:c_int;
+    /*
+      Sets the ``FD_CLOEXEC`` flag of new descriptor to close it after
+      execution of an ``exec` function.
+    */
     extern const O_CLOEXEC:c_int;
+    /* Create file if it does not exist. */
     extern const O_CREAT:c_int;
+    /* Fail if file is a non-directory file. */
     extern const O_DIRECTORY:c_int;
+    /* Write according to synchronized I/O data integrity completion. */
     extern const O_DSYNC:c_int;
+    /* Exclusive use flag. */
     extern const O_EXCL:c_int;
+    /* Do not assign controlling terminal. */
     extern const O_NOCTTY:c_int;
+    /* Do not follow symbolic links. */
     extern const O_NOFOLLOW:c_int;
+    /* Non-blocking mode. */
     extern const O_NONBLOCK:c_int;
+    /* Open for reading only. */
     extern const O_RDONLY:c_int;
+    /* Open for reading and writing */
     extern const O_RDWR:c_int;
+    /* Write according to synchronized I/O file integrity completion. */
     extern const O_SYNC:c_int;
+    /* Truncate flag. */
     extern const O_TRUNC:c_int;
+    /* Open for writing only. */
     extern const O_WRONLY:c_int;
     // Note: O_EXEC, O_SEARCH, O_TTY_INIT
     // are documented in POSIX but don't seem to exist on linux
     // Note: O_RSYNC
     // is documented in POSIX but doesn't seem to exist on Mac OS
 
+    /* Create a new file or rewrite an existing file. */
     extern proc creat(path:c_ptrConst(c_char), mode:mode_t = 0):c_int;
+    /* Open a file. */
     inline proc open(path:c_ptrConst(c_char), oflag:c_int, mode:mode_t = 0:mode_t)
                   :c_int {
       extern proc chpl_os_posix_open(path:c_ptrConst(c_char), oflag:c_int, mode:mode_t)
@@ -765,42 +790,56 @@ module OS {
     //
     // stdlib.h
     //
+    /* Get the value of an enviroment variable. */
     extern proc getenv(name:c_ptrConst(c_char)):c_ptr(c_char);
 
     //
     // string.h
     //
+    /* Get the error message string for ``errnum`` */
     extern proc strerror(errnum:c_int):c_ptrConst(c_char);
+    /* Get the length of the null-terminated string. */
     extern proc strlen(s:c_ptrConst(c_char)):c_size_t;
 
     //
     // sys/select.h
     //
+    /* Maximum number of file descriptors that :type:`fd_set` can hold. */
     extern const FD_SETSIZE:c_int;
 
+    /* Contains a fixed amount of file descriptors. */
     extern record fd_set {};
 
+    /* Clears the bit for the file descriptor ``fd`` in ``fdset``. */
     proc FD_CLR(fd:c_int, fdset:c_ptr(fd_set)) {
       extern proc chpl_os_posix_FD_CLR(fd:c_int, fdset:c_ptr(fd_set));
       chpl_os_posix_FD_CLR(fd, fdset);
     }
 
+    /* Checks if the bit for the file descriptor ``fd`` is set in ``fdset``. */
     proc FD_ISSET(fd:c_int, fdset:c_ptr(fd_set)):c_int {
       extern proc chpl_os_posix_FD_ISSET(fd:c_int, fdset:c_ptr(fd_set)):c_int;
       return chpl_os_posix_FD_ISSET(fd, fdset);
     }
 
+    /* Sets the bit for the file descriptor ``fd`` in ``fdset``. */
     proc FD_SET(fd:c_int, fdset:c_ptr(fd_set)) {
       extern proc chpl_os_posix_FD_SET(fd:c_int, fdset:c_ptr(fd_set));
       chpl_os_posix_FD_SET(fd, fdset);
     }
 
+    /* Initializes all file descriptors in ``fdset`` to zero. */
     proc FD_ZERO(fdset:c_ptr(fd_set)) {
       extern proc chpl_os_posix_FD_ZERO(fdset:c_ptr(fd_set));
       chpl_os_posix_FD_ZERO(fdset);
     }
 
     // No way around this -- 'select' is a keyword in Chapel.
+    /*
+      Indicates which of the specificed file descriptors is ready for reading
+      or writing, or has an error condition pending. If no file descriptors are
+      ready, the procoedure blocks until the ``timeout``.
+    */
     extern 'select' proc select_posix(nfds:c_int,
                                       readfds:c_ptr(fd_set),
                                       writefds:c_ptr(fd_set),
@@ -810,147 +849,212 @@ module OS {
     //
     // sys/stat.h
     //
+    /* Shorthand for (:proc:`S_IRUSR` | :proc:`S_IWUSR` | :proc:`S_IXUSR`). */
     inline proc S_IRWXU:mode_t {
       extern proc chpl_os_posix_S_IRWXU():mode_t;
       return chpl_os_posix_S_IRWXU();
     }
+    /* Read permission bit for the file's owner. */
     inline proc S_IRUSR:mode_t {
       extern proc chpl_os_posix_S_IRUSR():mode_t;
       return chpl_os_posix_S_IRUSR();
     }
+    /* Write permission bit for the file's owner. */
     inline proc S_IWUSR:mode_t {
       extern proc chpl_os_posix_S_IWUSR():mode_t;
       return chpl_os_posix_S_IWUSR();
     }
+    /* Execute permission bit for the file's owner. */
     inline proc S_IXUSR:mode_t {
       extern proc chpl_os_posix_S_IXUSR():mode_t;
       return chpl_os_posix_S_IXUSR();
     }
 
+    /* Shorthand for (:proc:`S_IRGRP` | :proc:`S_IWGRP` | :proc:`S_IXGRP`). */
     inline proc S_IRWXG:mode_t {
       extern proc chpl_os_posix_S_IRWXG():mode_t;
       return chpl_os_posix_S_IRWXG();
     }
+    /* Read permission bit for the file's group. */
     inline proc S_IRGRP:mode_t {
       extern proc chpl_os_posix_S_IRGRP():mode_t;
       return chpl_os_posix_S_IRGRP();
     }
+    /* Write permission bit for the file's group. */
     inline proc S_IWGRP:mode_t {
       extern proc chpl_os_posix_S_IWGRP():mode_t;
       return chpl_os_posix_S_IWGRP();
     }
+    /* Execute permission bit for the file's group. */
     inline proc S_IXGRP:mode_t {
       extern proc chpl_os_posix_S_IXGRP():mode_t;
       return chpl_os_posix_S_IXGRP();
     }
 
+     /* Shorthand for (:proc:`S_IROTH` | :proc:`S_IWOTH` | :proc:`S_IXOTH`). */
     inline proc S_IRWXO:mode_t {
       extern proc chpl_os_posix_S_IRWXO():mode_t;
       return chpl_os_posix_S_IRWXO();
     }
+    /* Read permission bit for others. */
     inline proc S_IROTH:mode_t {
       extern proc chpl_os_posix_S_IROTH():mode_t;
       return chpl_os_posix_S_IROTH();
     }
+    /* Write permission bit for others. */
     inline proc S_IWOTH:mode_t {
       extern proc chpl_os_posix_S_IWOTH():mode_t;
       return chpl_os_posix_S_IWOTH();
     }
+    /* Execute permission bit for others. */
     inline proc S_IXOTH:mode_t {
       extern proc chpl_os_posix_S_IXOTH():mode_t;
       return chpl_os_posix_S_IXOTH();
     }
 
+    /* Set user ID on execute bit. */
     inline proc S_ISUID:mode_t {
       extern proc chpl_os_posix_S_ISUID():mode_t;
       return chpl_os_posix_S_ISUID();
     }
+    /* Set group ID on execute bit. */
     inline proc S_ISGID:mode_t {
       extern proc chpl_os_posix_S_ISGID():mode_t;
       return chpl_os_posix_S_ISGID();
     }
+    /* Sticky bit */
     inline proc S_ISVTX:mode_t {
       extern proc chpl_os_posix_S_ISVTX():mode_t;
       return chpl_os_posix_S_ISVTX();
     }
 
+    /* A Chapel version of the POSIX structure ``stat``, which contains common
+    fields. This should be useed with :proc:`stat`.
+    */
     extern 'struct chpl_os_posix_struct_stat' record struct_stat {
-      var st_dev:dev_t;            // Device.
-      var st_ino:ino_t;            // File serial number.
-      var st_mode:mode_t;          // File mode.
-      var st_nlink:nlink_t;        // Link count.
-      var st_uid:uid_t;            // User ID of the file's owner.
-      var st_gid:gid_t;            // Group ID of the file's group.
-      var st_rdev:dev_t;           // Device number, if device.
-      var st_size:off_t;           // Size of file, in bytes.
-      var st_atim:struct_timespec; // Last data access timestamp.
-      var st_mtim:struct_timespec; // Last data modification timestamp.
-      var st_ctim:struct_timespec; // Last file status change timestamp.
-      var st_blksize:blksize_t;    // Optimal block size for I/O.
-      var st_blocks:blkcnt_t;      // Number 512-byte blocks allocated.
+      /* Device. */
+      var st_dev:dev_t;
+      /* File serial number. */
+      var st_ino:ino_t;            
+      /* File mode. */
+      var st_mode:mode_t;          
+      /* Link count. */
+      var st_nlink:nlink_t;        
+      /* User ID of the file's owner. */
+      var st_uid:uid_t;            
+      /* Group ID of the file's group. */
+      var st_gid:gid_t;            
+      /* Device number, if device. */
+      var st_rdev:dev_t;           
+      /* Size of file, in bytes. */
+      var st_size:off_t;
+      /* Last data access timestamp. */
+      var st_atim:struct_timespec; 
+      /* Last data modification timestamp. */
+      var st_mtim:struct_timespec; 
+      /* Last file status change timestamp. */
+      var st_ctim:struct_timespec;
+      /* Optimal block size for I/O. */
+      var st_blksize:blksize_t;
+      /* Number 512-byte blocks allocated. */
+      var st_blocks:blkcnt_t;      
     }
 
+    /* Changes the mode of a file. */
     extern proc chmod(path:c_ptrConst(c_char), mode:mode_t):c_int;
+    /* Get the status of a file, should be used with :record:`struct_stat`. */
     extern 'chpl_os_posix_stat' proc stat(path:c_ptrConst(c_char),
                                           buf:c_ptr(struct_stat)):c_int;
 
     //
     // sys/time.h
     //
+    /* The structure ``timeval`` from ``sys/time.h``. */
     extern "struct timeval" record struct_timeval {
-      var tv_sec:time_t;       // seconds since Jan. 1, 1970
-      var tv_usec:suseconds_t; // and microseconds
+      /* Seconds since the epoch, Jan. 1, 1970 */
+      var tv_sec:time_t;
+      /* Nanoseconds */
+      var tv_usec:suseconds_t;
     }
 
+    @chpldoc.nodoc
     proc struct_timeval.init() {}
 
+    @chpldoc.nodoc
     proc struct_timeval.init(tv_sec: integral, tv_usec: integral) {
       this.tv_sec = tv_sec:time_t;
       this.tv_usec = tv_usec:suseconds_t;
     }
 
+    @chpldoc.nodoc
     proc struct_timeval.init(tv_sec: time_t, tv_usec: suseconds_t) {
       this.tv_sec = tv_sec;
       this.tv_usec = tv_usec;
     }
 
+    /* The structure ``timezone`` from ``time.h``. */
     extern "struct timezone" record struct_timezone {
-      var tz_minuteswest:c_int; // of Greenwich
-      var tz_dsttime:c_int;     // type of dst correction to apply
+      /* Minutes west of Greenwich */
+      var tz_minuteswest:c_int;
+      /* Type of DST correction */
+      var tz_dsttime:c_int;
     };
 
+    /*
+      Get the date and time, based on the timezone in ``tzp``.
+      The result is stored in ``tp``.
+    */
     extern proc gettimeofday(tp:c_ptr(struct_timeval),
                              tzp:c_ptr(struct_timezone)):c_int;
 
     //
     // time.h
     //
+    /* The structure ``tm`` from ``time.h``. */
     extern "struct tm" record struct_tm {
-      var tm_sec:c_int;   // Seconds [0,60] (60 allows for leap seconds)
-      var tm_min:c_int;   // Minutes [0,59]
-      var tm_hour:c_int;  // Hour [0,23]
-      var tm_mday:c_int;  // Day of month [1,31]
-      var tm_mon:c_int;   // Month of year [0,11]
-      var tm_year:c_int;  // Years since 1900
-      var tm_wday:c_int;  // Day of week [0,6] (Sunday =0)
-      var tm_yday:c_int;  // Day of year [0,365]
-      var tm_isdst:c_int; // Daylight Savings flag
+      /* Seconds [0,60] (60 allows for leap seconds) */
+      var tm_sec:c_int;
+      /* Minutes [0,59] */
+      var tm_min:c_int;   
+      /* Hour [0,23] */
+      var tm_hour:c_int;  
+      /* Day of month [1,31] */
+      var tm_mday:c_int;  
+      /* Month of year [0,11] */
+      var tm_mon:c_int;   
+      /* Years since 1900 */
+      var tm_year:c_int;  
+      /* Day of week [0,6] (Sunday =0) */
+      var tm_wday:c_int;
+      /* Day of year [0,365] */
+      var tm_yday:c_int;  
+      /* Daylight Savings flag */
+      var tm_isdst:c_int;
     };
 
+    /* Get the date and time as a string. */
     extern proc asctime(timeptr:c_ptr(struct_tm)):c_ptr(c_char);
+    /* Get the date and time as a string, using the given buffer. */
     extern proc asctime_r(timeptr:c_ptr(struct_tm), buf:c_ptr(c_char))
                   :c_ptr(c_char);
+    /* Convert the time to a local time. */
     extern proc localtime(timer:c_ptr(time_t)):c_ptr(struct_tm);
+    /* Convert the time to a local time, storing the result in the given struct. */
     extern proc localtime_r(timer:c_ptr(time_t), result:c_ptr(struct_tm))
                   :c_ptr(struct_tm);
+    /* Get the time. */
     extern proc time(tloc:c_ptr(time_t)):time_t;
 
     //
     // unistd.h
     //
+    /* Close a file descriptor. */
     extern proc close(fildes:c_int):c_int;
+    /* Create a pipe. */
     extern proc pipe(fildes:c_ptr(c_array(c_int, 2))):c_int;
+    /* Read ``size`` bytes from a file descriptor into ``buf``. */
     extern proc read(fildes:c_int, buf:c_ptr(void), size:c_size_t):c_ssize_t;
+    /* Write ``size`` bytes to file descriptor from ``buf``. */
     extern proc write(fildes:c_int, buf:c_ptr(void), size:c_size_t):c_ssize_t;
 
     /*

--- a/modules/standard/OS.chpl
+++ b/modules/standard/OS.chpl
@@ -745,7 +745,7 @@ module OS {
     extern const O_APPEND:c_int;
     /*
       Sets the ``FD_CLOEXEC`` flag of new descriptor to close it after
-      execution of an ``exec` function.
+      execution of an ``exec`` function.
     */
     extern const O_CLOEXEC:c_int;
     /* Create file if it does not exist. */
@@ -1034,12 +1034,20 @@ module OS {
 
     /* Get the date and time as a string. */
     extern proc asctime(timeptr:c_ptr(struct_tm)):c_ptr(c_char);
-    /* Get the date and time as a string, using the given buffer. */
+    /*
+      Get the date and time as a string, using the given buffer.
+
+      :returns: ``buf``
+    */
     extern proc asctime_r(timeptr:c_ptr(struct_tm), buf:c_ptr(c_char))
                   :c_ptr(c_char);
     /* Convert the time to a local time. */
     extern proc localtime(timer:c_ptr(time_t)):c_ptr(struct_tm);
-    /* Convert the time to a local time, storing the result in the given struct. */
+    /*
+      Convert the time to a local time, storing the result in the given struct.
+
+      :returns: ``result``
+    */
     extern proc localtime_r(timer:c_ptr(time_t), result:c_ptr(struct_tm))
                   :c_ptr(struct_tm);
     /* Get the time. */
@@ -1116,7 +1124,7 @@ module OS {
       :arg c: the byte value to use
       :arg n: the number of bytes of s to fill
 
-      :returns: s
+      :returns: ``s``
     */
     pragma "fn synchronization free"
     inline proc memset(s:c_ptr(void), c:integral, n: c_size_t) {

--- a/modules/standard/OS.chpl
+++ b/modules/standard/OS.chpl
@@ -1122,9 +1122,12 @@ module OS {
 
   */
   class SystemError : Error {
+    /**/
     var err:     errorCode;
+    /**/
     var details: string;
 
+    /**/
     proc init(err: errorCode, details: string = "") {
       this.err     = err;
       this.details = details;
@@ -1250,6 +1253,7 @@ module OS {
      :const:`~POSIX.EWOULDBLOCK`, and :const:`~POSIX.EINPROGRESS`.
   */
   class BlockingIoError : SystemError {
+    @chpldoc.nodoc
     proc init(details: string = "", err: errorCode = EWOULDBLOCK:errorCode) {
       super.init(err, details);
     }
@@ -1260,6 +1264,7 @@ module OS {
      corresponding to :const:`~POSIX.ECHILD`.
   */
   class ChildProcessError : SystemError {
+    @chpldoc.nodoc
     proc init(details: string = "", err: errorCode = ECHILD:errorCode) {
       super.init(err, details);
     }
@@ -1270,6 +1275,7 @@ module OS {
      serves as the base class for all system errors regarding connections.
   */
   class ConnectionError : SystemError {
+    @chpldoc.nodoc
     proc init(err: errorCode, details: string = "") {
       super.init(err, details);
     }
@@ -1280,6 +1286,7 @@ module OS {
      corresponding to :const:`~POSIX.EPIPE`
   */
   class BrokenPipeError : ConnectionError {
+    @chpldoc.nodoc
     proc init(details: string = "", err: errorCode = EPIPE:errorCode) {
       super.init(err, details);
     }
@@ -1290,6 +1297,7 @@ module OS {
      corresponding to :const:`~POSIX.ECONNABORTED`.
   */
   class ConnectionAbortedError : ConnectionError {
+    @chpldoc.nodoc
     proc init(details: string = "", err: errorCode = ECONNABORTED:errorCode) {
       super.init(err, details);
     }
@@ -1300,6 +1308,7 @@ module OS {
      corresponding to :const:`~POSIX.ECONNREFUSED`.
   */
   class ConnectionRefusedError : ConnectionError {
+    @chpldoc.nodoc
     proc init(details: string = "", err: errorCode = ECONNREFUSED:errorCode) {
       super.init(err, details);
     }
@@ -1310,6 +1319,7 @@ module OS {
      corresponding to :const:`~POSIX.ECONNRESET`.
   */
   class ConnectionResetError : ConnectionError {
+    @chpldoc.nodoc
     proc init(details: string = "", err: errorCode = ECONNRESET:errorCode) {
       super.init(err, details);
     }
@@ -1320,6 +1330,7 @@ module OS {
      corresponding to :const:`~POSIX.EEXIST`.
   */
   class FileExistsError : SystemError {
+    @chpldoc.nodoc
     proc init(details: string = "", err: errorCode = EEXIST:errorCode) {
       super.init(err, details);
     }
@@ -1330,6 +1341,7 @@ module OS {
      corresponding to :const:`~POSIX.ENOENT`.
   */
   class FileNotFoundError : SystemError {
+    @chpldoc.nodoc
     proc init(details: string = "", err: errorCode = ENOENT:errorCode) {
       super.init(err, details);
     }
@@ -1340,6 +1352,7 @@ module OS {
      corresponding to :const:`~POSIX.EINTR`.
   */
   class InterruptedError : SystemError {
+    @chpldoc.nodoc
     proc init(details: string = "", err: errorCode = EINTR:errorCode) {
       super.init(err, details);
     }
@@ -1350,6 +1363,7 @@ module OS {
      corresponding to :const:`~POSIX.EISDIR`.
   */
   class IsADirectoryError : SystemError {
+    @chpldoc.nodoc
     proc init(details: string = "", err: errorCode = EISDIR:errorCode) {
       super.init(err, details);
     }
@@ -1360,6 +1374,7 @@ module OS {
      corresponding to :const:`~POSIX.ENOTDIR`.
   */
   class NotADirectoryError : SystemError {
+    @chpldoc.nodoc
     proc init(details: string = "", err: errorCode = ENOTDIR:errorCode) {
       super.init(err, details);
     }
@@ -1370,6 +1385,7 @@ module OS {
      corresponding to :const:`~POSIX.EACCES` and :const:`~POSIX.EPERM`.
   */
   class PermissionError : SystemError {
+    @chpldoc.nodoc
     proc init(details: string = "", err: errorCode = EPERM:errorCode) {
       super.init(err, details);
     }
@@ -1380,6 +1396,7 @@ module OS {
      corresponding to :const:`~POSIX.ESRCH`.
   */
   class ProcessLookupError : SystemError {
+    @chpldoc.nodoc
     proc init(details: string = "", err: errorCode = ESRCH:errorCode) {
       super.init(err, details);
     }
@@ -1390,6 +1407,7 @@ module OS {
      to :const:`~POSIX.ETIMEDOUT`.
   */
   class TimeoutError : SystemError {
+    @chpldoc.nodoc
     proc init(details: string = "", err: errorCode = ETIMEDOUT:errorCode) {
       super.init(err, details);
     }
@@ -1400,6 +1418,7 @@ module OS {
      EIO.
   */
   class IoError : SystemError {
+    @chpldoc.nodoc
     proc init(err: errorCode = EIO, details: string = "") {
       super.init(err, details);
     }
@@ -1410,13 +1429,16 @@ module OS {
      encountering end-of-file.
   */
   class EofError : Error {
+    @chpldoc.nodoc
     var details: string;
 
+    @chpldoc.nodoc
     proc init(details: string = "", err_msg: string = "") {
       this.details = details;
       this._msg = err_msg;
     }
 
+    @chpldoc.nodoc
     override proc message() {
       var generatedMsg: string;
 
@@ -1452,13 +1474,16 @@ module OS {
      the valid range.
   */
   class UnexpectedEofError : Error {
+    @chpldoc.nodoc
     var details: string;
 
+    @chpldoc.nodoc
     proc init(details: string = "", err_msg: string = "") {
       this.details = details;
       this._msg = err_msg;
     }
 
+    @chpldoc.nodoc
     override proc message() {
       var generatedMsg: string;
 
@@ -1489,13 +1514,16 @@ module OS {
      to incorrectly-formatted input.
   */
   class BadFormatError : Error {
+    @chpldoc.nodoc
     var details: string;
 
+    @chpldoc.nodoc
     proc init(details: string = "", err_msg: string = "") {
       this.details = details;
       this._msg = err_msg;
     }
 
+    @chpldoc.nodoc
     override proc message() {
       var generatedMsg: string;
 
@@ -1526,10 +1554,12 @@ module OS {
     indicating that an IO operation required more storage than was provided
   */
   class InsufficientCapacityError : IoError {
+    @chpldoc.nodoc
     proc init(details: string = "") {
       super.init(ERANGE: errorCode, details);
     }
 
+    @chpldoc.nodoc
     override proc message() {
       return
         if details.isEmpty() then

--- a/modules/standard/OS.chpl
+++ b/modules/standard/OS.chpl
@@ -1448,7 +1448,7 @@ module OS {
      input could be read.
 
      This error can also occur on some writing operations when a
-     :record:~IO.fileWriter's range has been specified, and the write exceeds
+     :record:`~IO.fileWriter`'s range has been specified, and the write exceeds
      the valid range.
   */
   class UnexpectedEofError : Error {

--- a/modules/standard/OS.chpl
+++ b/modules/standard/OS.chpl
@@ -1231,15 +1231,17 @@ module OS {
      :class:`SystemError` is a base class for :class:`Errors.Error` s
      generated from ``errorCode``. It provides factory methods to create
      different subtypes based on the ``errorCode`` that is passed.
-
   */
   class SystemError : Error {
-    /**/
+    @chpldoc.nodoc
     var err:     errorCode;
-    /**/
+    @chpldoc.nodoc
     var details: string;
 
-    /**/
+    /*
+      Construct a :class:`SystemError` with a specific error code and optional
+      extra detais.
+    */
     proc init(err: errorCode, details: string = "") {
       this.err     = err;
       this.details = details;

--- a/modules/standard/OS.chpl
+++ b/modules/standard/OS.chpl
@@ -935,29 +935,29 @@ module OS {
       /* Device. */
       var st_dev:dev_t;
       /* File serial number. */
-      var st_ino:ino_t;            
+      var st_ino:ino_t;
       /* File mode. */
-      var st_mode:mode_t;          
+      var st_mode:mode_t;
       /* Link count. */
-      var st_nlink:nlink_t;        
+      var st_nlink:nlink_t;
       /* User ID of the file's owner. */
-      var st_uid:uid_t;            
+      var st_uid:uid_t;
       /* Group ID of the file's group. */
-      var st_gid:gid_t;            
+      var st_gid:gid_t;
       /* Device number, if device. */
-      var st_rdev:dev_t;           
+      var st_rdev:dev_t;
       /* Size of file, in bytes. */
       var st_size:off_t;
       /* Last data access timestamp. */
-      var st_atim:struct_timespec; 
+      var st_atim:struct_timespec;
       /* Last data modification timestamp. */
-      var st_mtim:struct_timespec; 
+      var st_mtim:struct_timespec;
       /* Last file status change timestamp. */
       var st_ctim:struct_timespec;
       /* Optimal block size for I/O. */
       var st_blksize:blksize_t;
       /* Number 512-byte blocks allocated. */
-      var st_blocks:blkcnt_t;      
+      var st_blocks:blkcnt_t;
     }
 
     /* Changes the mode of a file. */
@@ -1015,19 +1015,19 @@ module OS {
       /* Seconds [0,60] (60 allows for leap seconds) */
       var tm_sec:c_int;
       /* Minutes [0,59] */
-      var tm_min:c_int;   
+      var tm_min:c_int;
       /* Hour [0,23] */
-      var tm_hour:c_int;  
+      var tm_hour:c_int;
       /* Day of month [1,31] */
-      var tm_mday:c_int;  
+      var tm_mday:c_int;
       /* Month of year [0,11] */
-      var tm_mon:c_int;   
+      var tm_mon:c_int;
       /* Years since 1900 */
-      var tm_year:c_int;  
+      var tm_year:c_int;
       /* Day of week [0,6] (Sunday =0) */
       var tm_wday:c_int;
       /* Day of year [0,365] */
-      var tm_yday:c_int;  
+      var tm_yday:c_int;
       /* Daylight Savings flag */
       var tm_isdst:c_int;
     };

--- a/modules/standard/Regex.chpl
+++ b/modules/standard/Regex.chpl
@@ -402,11 +402,15 @@ private extern proc qio_regex_replace(const ref re:qio_regex_t, repl:c_ptrConst(
 // (or any way to use 'nil' in pass-by-ref)
 // This one is documented below.
 
+/* Error thrown if a regular expression fails to compile */
 class BadRegexError : Error {
+  @chpldoc.nodoc
   var msg:string;
+  @chpldoc.nodoc
   proc init(msg: string) {
     this.msg = msg;
   }
+  @chpldoc.nodoc
   override proc message() {
     return msg;
   }
@@ -608,6 +612,7 @@ record regex : serializable {
     }
   }
 
+  /* Creates a new :type:`regex` with the same pattern as ``x``. */
   proc init=(x: regex(?)) {
     this.exprType = x.exprType;
     /* always bring the regex local */
@@ -1010,6 +1015,7 @@ operator regex.=(ref ret:regex(?t), x:regex(t))
   }
 }
 
+/* Returns the pattern of the :type:`regex`. */
 inline operator :(x: regex(?exprType), type t: exprType) {
   var pattern: t;
   on x.home {

--- a/modules/standard/Subprocess.chpl
+++ b/modules/standard/Subprocess.chpl
@@ -755,7 +755,7 @@ module Subprocess {
     return spawnshellHelper(command, env, stdin, stdout, stderr, executable, shellarg, _iokind.dynamic, locking);
   }
 
-  proc spawnshellHelper(command:string, env:[] string=Subprocess.empty_env,
+  private proc spawnshellHelper(command:string, env:[] string=Subprocess.empty_env,
                   stdin:?t = pipeStyle.forward, stdout:?u = pipeStyle.forward,
                   stderr:?v = pipeStyle.forward,
                   executable="/bin/sh", shellarg="-c",

--- a/modules/standard/Time.chpl
+++ b/modules/standard/Time.chpl
@@ -107,12 +107,19 @@ module Time {
       controlled with :var:`cIsoDayOfWeek`.
    */
   enum dayOfWeek {
+    /**/
     Monday = firstDayOfWeekNum,
+    /**/
     Tuesday,
+    /**/
     Wednesday,
+    /**/
     Thursday,
+    /**/
     Friday,
+    /**/
     Saturday,
+    /**/
     Sunday
   }
   @chpldoc.nodoc

--- a/modules/standard/Version.chpl
+++ b/modules/standard/Version.chpl
@@ -674,14 +674,21 @@ module Version {
   }
 
 
+  /*
+    Error class thrown when two versions are compared that cannot be compared.
 
+    For example, two versions differing only in commit IDs cannot be compared.
+  */
   class VersionComparisonError : Error {
+    @chpldoc.nodoc
     var msg:string;
 
+    @chpldoc.nodoc
     proc init(msg:string) {
       this.msg = msg;
     }
 
+    @chpldoc.nodoc
     override proc message() {
       return msg;
     }


### PR DESCRIPTION
Adds documentation based on warnings from `$CHPL_HOME/tools/chpldoc/findUndocumentedSymbols $CHPL_HOME/modules/standard/ --ignore-deprecated --ignore-unstable`. After this PR, this command should return clean except for one `init` in `Regex`.

Summary of changes
- fix inline rst in `OS`
- hide internal `Subprocess.spwanshellHelper` method from docs
- add docs to `List`, `BigInteger`, `Map`, `Version`, `Regex`, and CTypes
- cleanup docs in `IO`
- nodoc overridden `init` and `message` procs in `Error` subclasses since these don't really add to the docs
- add POSIX docs

Tested locally by building docs and checking the formatting after each commit.

[Reviewed by @lydia-duncan]