### PR TITLE
Avoid kernel launch when number of threads is 0

### DIFF
--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -289,21 +289,22 @@ inline void chpl_gpu_launch_kernel_flat(int ln, int32_t fn,
       blk_dim, 1, 1);
   chpl_gpu_diags_incr(kernel_launch);
 
-  chpl_gpu_impl_launch_kernel_flat(ln, fn,
-                                   name,
-                                   num_threads, blk_dim,
-                                   stream,
-                                   nargs, args);
+  if (num_threads > 0){
+    chpl_gpu_impl_launch_kernel_flat(ln, fn,
+                                    name,
+                                    num_threads, blk_dim,
+                                    stream,
+                                    nargs, args);
 
 #ifdef CHPL_GPU_MEM_STRATEGY_ARRAY_ON_DEVICE
-  if (chpl_gpu_sync_with_host) {
-    CHPL_GPU_DEBUG("Eagerly synchronizing stream %p\n", stream);
-    wait_stream(stream);
-  }
+    if (chpl_gpu_sync_with_host) {
+      CHPL_GPU_DEBUG("Eagerly synchronizing stream %p\n", stream);
+      wait_stream(stream);
+    }
 #else
-  chpl_gpu_impl_synchronize();
+    chpl_gpu_impl_synchronize();
 #endif
-
+  }
   va_end(args);
 
   CHPL_GPU_DEBUG("Kernel launcher returning. (subloc %d)\n"

--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -286,17 +286,15 @@ inline void chpl_gpu_launch_kernel_flat(int ln, int32_t fn,
   va_start(args, nargs);
 
   if (num_threads > 0){
-    CHPL_GPU_DEBUG("No kernel launched since num_threads is 0\n");    )
-
     chpl_gpu_diags_verbose_launch(ln, fn, chpl_task_getRequestedSubloc(),
         blk_dim, 1, 1);
     chpl_gpu_diags_incr(kernel_launch);
 
     chpl_gpu_impl_launch_kernel_flat(ln, fn,
-                                    name,
-                                    num_threads, blk_dim,
-                                    stream,
-                                    nargs, args);
+                                     name,
+                                     num_threads, blk_dim,
+                                     stream,
+                                     nargs, args);
 
 #ifdef CHPL_GPU_MEM_STRATEGY_ARRAY_ON_DEVICE
     if (chpl_gpu_sync_with_host) {
@@ -306,6 +304,8 @@ inline void chpl_gpu_launch_kernel_flat(int ln, int32_t fn,
 #else
     chpl_gpu_impl_synchronize();
 #endif
+  } else {
+  CHPL_GPU_DEBUG("No kernel launched since num_threads is <=0\n");
   }
   va_end(args);
 

--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -285,11 +285,13 @@ inline void chpl_gpu_launch_kernel_flat(int ln, int32_t fn,
   va_list args;
   va_start(args, nargs);
 
-  chpl_gpu_diags_verbose_launch(ln, fn, chpl_task_getRequestedSubloc(),
-      blk_dim, 1, 1);
-  chpl_gpu_diags_incr(kernel_launch);
-
   if (num_threads > 0){
+    CHPL_GPU_DEBUG("No kernel launched since num_threads is 0\n");    )
+
+    chpl_gpu_diags_verbose_launch(ln, fn, chpl_task_getRequestedSubloc(),
+        blk_dim, 1, 1);
+    chpl_gpu_diags_incr(kernel_launch);
+
     chpl_gpu_impl_launch_kernel_flat(ln, fn,
                                     name,
                                     num_threads, blk_dim,

--- a/test/gpu/native/basics/bug23658.chpl
+++ b/test/gpu/native/basics/bug23658.chpl
@@ -9,7 +9,8 @@ const sz = 10;
 if gpuDiags then startGpuDiagnostics();
 
 on here.gpus[0] {
-  var Arr: [0..<sz] int;
+  const s = sz;
+  var Arr: [0..<s] int;
   foreach i in 1..0 do {
     Arr[i] = i;
   }
@@ -18,6 +19,6 @@ on here.gpus[0] {
 
 if gpuDiags {
   stopGpuDiagnostics();
-  assertGpuDiags(kernel_launch=2, host_to_device=0, device_to_host=sz,
+  assertGpuDiags(kernel_launch=1, host_to_device=0, device_to_host=sz,
                  device_to_device=0);
 }

--- a/test/gpu/native/basics/bug23658.chpl
+++ b/test/gpu/native/basics/bug23658.chpl
@@ -1,0 +1,23 @@
+// this code is from https://github.com/chapel-lang/chapel/issues/23658 verbatim
+// the bug reported will be resolved via
+// TBD
+use GpuDiagnostics;
+
+config const gpuDiags = true;
+const sz = 10;
+
+if gpuDiags then startGpuDiagnostics();
+
+on here.gpus[0] {
+  var Arr: [0..<sz] int;
+  foreach i in 1..0 do {
+    Arr[i] = i;
+  }
+  writeln(Arr);
+}
+
+if gpuDiags {
+  stopGpuDiagnostics();
+  assertGpuDiags(kernel_launch=2, host_to_device=0, device_to_host=sz,
+                 device_to_device=0);
+}

--- a/test/gpu/native/basics/bug23658.chpl
+++ b/test/gpu/native/basics/bug23658.chpl
@@ -1,6 +1,5 @@
-// this code is from https://github.com/chapel-lang/chapel/issues/23658 verbatim
-// the bug reported will be resolved via
-// TBD
+// this code is from https://github.com/chapel-lang/chapel/issues/23658
+// the bug will be resolved via https://github.com/chapel-lang/chapel/pull/23674
 use GpuDiagnostics;
 
 config const gpuDiags = true;
@@ -9,8 +8,7 @@ const sz = 10;
 if gpuDiags then startGpuDiagnostics();
 
 on here.gpus[0] {
-  const s = sz;
-  var Arr: [0..<s] int;
+  var Arr: [0..<sz] int;
   foreach i in 1..0 do {
     Arr[i] = i;
   }
@@ -19,6 +17,6 @@ on here.gpus[0] {
 
 if gpuDiags {
   stopGpuDiagnostics();
-  assertGpuDiags(kernel_launch=1, host_to_device=0, device_to_host=sz,
-                 device_to_device=0);
+  assertGpuDiags(kernel_launch_aod=1, kernel_launch_um=0, host_to_device=0,
+                 device_to_host=sz, device_to_device=0);
 }

--- a/test/gpu/native/basics/bug23658.execopts
+++ b/test/gpu/native/basics/bug23658.execopts
@@ -1,0 +1,1 @@
+--debugGpu

--- a/test/gpu/native/basics/bug23658.good
+++ b/test/gpu/native/basics/bug23658.good
@@ -1,2 +1,1 @@
-warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
-0 0 0 0 0 0 0 0 0 0
+No kernel launched since num_threads is <=0

--- a/test/gpu/native/basics/bug23658.good
+++ b/test/gpu/native/basics/bug23658.good
@@ -1,0 +1,2 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
+0 0 0 0 0 0 0 0 0 0

--- a/test/gpu/native/basics/bug23658.prediff
+++ b/test/gpu/native/basics/bug23658.prediff
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+grep "No kernel launched since num_threads is <=0" $2 > $2.tmp
+
+mv $2.tmp $2

--- a/test/gpu/native/nestedForeach.chpl
+++ b/test/gpu/native/nestedForeach.chpl
@@ -18,10 +18,10 @@ on here.gpus[0] {
     B(i,j) = i + j;
   }
   writeln(B);
-  // @assertOnGpu
-  // foreach (i,j) in {1..-1, 1..-1} {}
-  // @assertOnGpu
-  // foreach (i,j) in {low..high, low..high} {}
+  @assertOnGpu
+  foreach (i,j) in {1..-1, 1..-1} {}
+  @assertOnGpu
+  foreach (i,j) in {low..high, low..high} {}
 }
 stopGpuDiagnostics();
 assertGpuDiags(kernel_launch_um=2, kernel_launch_aod=4);


### PR DESCRIPTION
Resolves https://github.com/chapel-lang/chapel/issues/23658 and adds a test for it
Resolves https://github.com/chapel-lang/chapel/issues/20635 and updates the associated test
Resolves https://github.com/chapel-lang/chapel/issues/23095

This changes the behavior of GPU diagnostics as well to not register this as a kernel launch.
We also print a message informing the developer that a kernel was not launched when using `--debugGpu`.

Pending Nvidia and AMD testing for latest commit.