### PR TITLE
Add experimental borrowed.release type method

### DIFF
--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -539,4 +539,17 @@ module OwnedObject {
     }
     return _to_nonnil(x.chpl_p);
   }
+
+  /*
+    Returns an ``unmanaged`` reference to the passed ``borrowed`` object.
+  */
+  @unstable("borrowed.release is currently unstable while we finalize the interface")
+  inline proc type (borrowed).release(x: borrowed class): unmanaged class {
+    return _to_unmanaged(x);
+  }
+  @chpldoc.nodoc
+  @unstable("borrowed.release is currently unstable while we finalize the interface")
+  inline proc type (borrowed).release(x: borrowed class?): unmanaged class? {
+    return _to_unmanaged(x);
+  }
 }

--- a/test/classes/delete-free/unmanaged/unmanaged-from-borrowed.chpl
+++ b/test/classes/delete-free/unmanaged/unmanaged-from-borrowed.chpl
@@ -1,0 +1,36 @@
+
+class C {
+  var x: int;
+}
+
+{
+  var c = new C();
+  var b = c.borrow();
+  writeln((b, b.type:string));
+
+  var u = borrowed.release(b);
+  writeln((u, u.type:string));
+
+  u.x = 10;
+
+  writeln((b, b.type:string));
+  writeln((u, u.type:string));
+
+  // no delete needed, u is just an unmanaged reference to the borrow
+}
+
+{
+  var c = new C?();
+  var b = c.borrow();
+  writeln((b, b.type:string));
+
+  var u = borrowed.release(b);
+  writeln((u, u.type:string));
+
+  u!.x = 10;
+
+  writeln((b, b.type:string));
+  writeln((u, u.type:string));
+
+  // no delete needed, u is just an unmanaged reference to the borrow
+}

--- a/test/classes/delete-free/unmanaged/unmanaged-from-borrowed.good
+++ b/test/classes/delete-free/unmanaged/unmanaged-from-borrowed.good
@@ -1,0 +1,8 @@
+({x = 0}, borrowed C)
+({x = 0}, unmanaged C)
+({x = 10}, borrowed C)
+({x = 10}, unmanaged C)
+({x = 0}, borrowed C?)
+({x = 0}, unmanaged C?)
+({x = 10}, borrowed C?)
+({x = 10}, unmanaged C?)

--- a/test/classes/delete-free/unmanaged/unmanaged-from-owned.chpl
+++ b/test/classes/delete-free/unmanaged/unmanaged-from-owned.chpl
@@ -1,0 +1,34 @@
+
+class C {
+  var x: int;
+}
+
+{
+  var c = new C();
+  writeln((c, c.type:string));
+
+  var u = borrowed.release(b);
+  writeln((u, u.type:string));
+
+  u.x = 10;
+
+  writeln((c, c.type:string));
+  writeln((u, u.type:string));
+
+  // no delete needed, u is just an unmanaged reference to the borrow
+}
+
+{
+  var c = new C?();
+  writeln((c, c.type:string));
+
+  var u = borrowed.release(b);
+  writeln((u, u.type:string));
+
+  u!.x = 10;
+
+  writeln((c, c.type:string));
+  writeln((u, u.type:string));
+
+  // no delete needed, u is just an unmanaged reference to the borrow
+}

--- a/test/classes/delete-free/unmanaged/unmanaged-from-owned.good
+++ b/test/classes/delete-free/unmanaged/unmanaged-from-owned.good
@@ -1,0 +1,8 @@
+({x = 0}, owned C)
+({x = 0}, unmanaged C)
+({x = 10}, owned C)
+({x = 10}, unmanaged C)
+({x = 0}, owned C?)
+({x = 0}, unmanaged C?)
+({x = 10}, owned C?)
+({x = 10}, unmanaged C?)

--- a/test/classes/delete-free/unmanaged/unmanaged-from-shared.chpl
+++ b/test/classes/delete-free/unmanaged/unmanaged-from-shared.chpl
@@ -1,0 +1,34 @@
+
+class C {
+  var x: int;
+}
+
+{
+  var c = new shared C();
+  writeln((c, c.type:string));
+
+  var u = borrowed.release(b);
+  writeln((u, u.type:string));
+
+  u.x = 10;
+
+  writeln((c, c.type:string));
+  writeln((u, u.type:string));
+
+  // no delete needed, u is just an unmanaged reference to the borrow
+}
+
+{
+  var c = new shared C?();
+  writeln((c, c.type:string));
+
+  var u = borrowed.release(b);
+  writeln((u, u.type:string));
+
+  u!.x = 10;
+
+  writeln((c, c.type:string));
+  writeln((u, u.type:string));
+
+  // no delete needed, u is just an unmanaged reference to the borrow
+}

--- a/test/classes/delete-free/unmanaged/unmanaged-from-shared.good
+++ b/test/classes/delete-free/unmanaged/unmanaged-from-shared.good
@@ -1,0 +1,8 @@
+({x = 0}, shared C)
+({x = 0}, unmanaged C)
+({x = 10}, shared C)
+({x = 10}, unmanaged C)
+({x = 0}, shared C?)
+({x = 0}, unmanaged C?)
+({x = 10}, shared C?)
+({x = 10}, unmanaged C?)

--- a/test/unstable/borrowed-release.chpl
+++ b/test/unstable/borrowed-release.chpl
@@ -1,0 +1,5 @@
+
+class C {}
+
+var c = new C();
+var u = borrowed.release(c); // warn

--- a/test/unstable/borrowed-release.good
+++ b/test/unstable/borrowed-release.good
@@ -1,0 +1,1 @@
+borrowed-release.chpl:5: warning: borrowed.release is currently unstable while we finalize the interface


### PR DESCRIPTION
Adds an experimental `borrowed.release` type method to get a `borrowed` as an `unmanaged`, without affecting the lifetime of the original object. This allows users to opt out of the lifetime checking for `borrowed`, similar to the previously deprecated cast to `unmanaged`.

As a side affect, users can pass an `owned` or `shared` to the method and implicit borrowed will insert a `.borrow()`.