### PR TITLE
Fix broken links in `GPU` technote and `Socket` doc

### DIFF
--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -88,9 +88,9 @@ Benchmark examples
 ~~~~~~~~~~~~~~~~~~
 * `Jacobi <https://github.com/chapel-lang/chapel/blob/main/test/gpu/native/jacobi/jacobi.chpl>`_ -- Jacobi example (shown above)
 * `Stream <https://github.com/chapel-lang/chapel/blob/main/test/gpu/native/streamPrototype/stream.chpl>`_ -- GPU enabled version of Stream benchmark
-* `SHOC Triad (Direct) <https://github.com/chapel-lang/chapel/blob/main/test/gpu/native/studies/shoc/triad.chpl>`_ -- a transliterated version of the SHOC Triad benchmark 
+* `SHOC Triad (Direct) <https://github.com/chapel-lang/chapel/blob/main/test/gpu/native/studies/shoc/triad.chpl>`_ -- a transliterated version of the SHOC Triad benchmark
 * `SHOC Triad (Chapeltastic) <https://github.com/chapel-lang/chapel/blob/main/test/gpu/native/studies/shoc/triadchpl.chpl>`_ -- a version of the SHOC benchmark simplified to use Chapel language features (such as promotion)
-* `SHOC Sort <https://github.com/chapel-lang/chapel/blob/main/test/gpu/native/studies/shoc/shocsort.chpl>`_ -- SHOC radix sort benchmark
+* `SHOC Sort <https://github.com/chapel-lang/chapel/blob/main/test/gpu/native/studies/shoc/shoc-sort.chpl>`_ -- SHOC radix sort benchmark
 * `asyncTaskComm <https://github.com/chapel-lang/chapel/blob/main/test/gpu/native/asynchrony/asyncTaskComm.chpl>`_ -- a synthetic benchmark to test overlap performance using multiple Chaple tasks.
 
 Test examples
@@ -543,4 +543,3 @@ Further Information
   slide decks from our `release notes
   <https://chapel-lang.org/releaseNotes.html>`_; however, be aware that
   information presented in release notes for prior releases may be out-of-date.
-

--- a/modules/packages/Socket.chpl
+++ b/modules/packages/Socket.chpl
@@ -1272,7 +1272,7 @@ proc setSockOpt(socketFd: c_int, level: c_int, optname: c_int, ref value: c_int)
 }
 
 /*
-  Set the value of the given socket option (see `setsockopt(2) </https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsockopt.html#>`_)
+  Set the value of the given socket option (see `setsockopt(2) <https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsockopt.html#>`_)
   on provided :type:`tcpConn`. The needed symbolic constants (SO_* etc.)
   are defined above.
 
@@ -1375,7 +1375,7 @@ proc getSockOpt(socketFd:c_int, level: c_int, optname: c_int) throws {
 }
 
 /*
-  Returns the value of the given socket option (see `getsockopt </https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockopt.html>`_)
+  Returns the value of the given socket option (see `getsockopt <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockopt.html>`_)
   on provided :type:`tcpConn`. The needed symbolic constants (SO_* etc.)
   are defined above.
 


### PR DESCRIPTION
Fix broken links.

I found the broken link in the `GPU` technote while browsing on the site, and I used a broken link detector for the two others (broken since 1.26.0). In addition, it detected some broken links in the Chapel website (ping @bradcray), e.g.:
- in https://chapel-lang.org/community.html: ... in real-time (also accessible via [IRC](https://irc.gitter.im/))
- in https://chapel-lang.org/whatsnew.html: April 16, 2020 - ...—[download](https://chapel-lang.org/downloads.html) your copy today!
- in https://chapel-lang.org/whatsnew.html: September 22, 2015 - Added talks from last week's [PGAS 2015](http://hpcl.seas.gwu.edu/pgas15/) conference to ...
- in https://chapel-lang.org/whatsnew.html: May 25, 2016 - ... from [Programming Models for Parallel Computing](https://mitpress.mit.edu/programming-models-parallel-computing) is now available and linked to from the ...

**Note:** Since broken link detectors exist, you could benefit from it by using periodic detection, e.g. one before each release. However, I have no idea how to do this.