### PR TITLE
Fix driver compilation with command-line library info

### DIFF
--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -164,6 +164,7 @@ extern bool fParseOnly;
 extern bool fDriverDoMonolithic;
 extern bool fDriverPhaseOne;
 extern bool fDriverPhaseTwo;
+extern char driverTmpDir[FILENAME_MAX];
 // end compiler driver control flags
 extern bool fPrintAllCandidates;
 extern bool fPrintCallGraph;

--- a/compiler/include/files.h
+++ b/compiler/include/files.h
@@ -106,6 +106,8 @@ void saveDriverTmpMultiple(const char* tmpFilePath,
 void restoreDriverTmp(const char* tmpFilePath,
                       std::function<void(const char*)> restoreSavedString);
 
+// Save lib dir, lib name, and inc dir info to disk, for compiler-driver use.
+void saveLibraryAndIncludeInfo();
 // Restore lib dir, lib name, and inc dir info that was saved to disk, for
 // compiler-driver use.
 void restoreLibraryAndIncludeInfo();

--- a/compiler/include/files.h
+++ b/compiler/include/files.h
@@ -89,10 +89,16 @@ void addSourceFiles(int numFilenames, const char* filename[]);
 void addSourceFile(const char* filename, const char* modFilename);
 void assertSourceFilesFound();
 const char* nthFilename(int i);
-void addLibPath(const char* filename);
-void addLibFile(const char* filename);
-void addIncInfo(const char* incDir);
+// Functions to add C library or include dir information.
+// If running in driver phase one and the information is not from parsing the
+// command line, these will also save to a tmp dir for later use.
+void addLibPath(const char* filename, bool fromCmdLine = false);
+void addLibFile(const char* filename, bool fromCmdLine = false);
+void addIncInfo(const char* incDir, bool fromCmdLine = false);
 
+// Ensure the tmp dir is set up for use by the driver (i.e., isn't about to be
+// replaced).
+void checkDriverTmp();
 // Save provided string into the given tmp file.
 // Appends the given string as a new line in the file. Provided string is
 // assumed to not contain newlines.
@@ -106,8 +112,6 @@ void saveDriverTmpMultiple(const char* tmpFilePath,
 void restoreDriverTmp(const char* tmpFilePath,
                       std::function<void(const char*)> restoreSavedString);
 
-// Save lib dir, lib name, and inc dir info to disk, for compiler-driver use.
-void saveLibraryAndIncludeInfo();
 // Restore lib dir, lib name, and inc dir info that was saved to disk, for
 // compiler-driver use.
 void restoreLibraryAndIncludeInfo();

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -2100,6 +2100,10 @@ static void postprocess_args() {
 
   setGPUFlags();
 
+  if (fDriverPhaseOne) {
+    saveLibraryAndIncludeInfo();
+  }
+
   // restore warnings to previous state
   ignore_warnings = ignore_warnings_previous;
 }

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -133,9 +133,6 @@ static char libraryFilename[FILENAME_MAX] = "";
 static char incFilename[FILENAME_MAX] = "";
 static bool fBaseline = false;
 
-// Tmp dir path managed by compiler driver
-static char driverTmpDir[FILENAME_MAX] = "";
-
 // Flags that were in commonFlags.h/cpp for awhile
 
 // TODO: Should --library automatically generate all supported
@@ -148,6 +145,8 @@ bool fDriverDoMonolithic = true;
 bool fDriverPhaseOne = false;
 bool fDriverPhaseTwo = false;
 bool driverDebugPhaseSpecified = false;
+// Tmp dir path managed by compiler driver
+char driverTmpDir[FILENAME_MAX] = "";
 bool fLibraryCompile = false;
 bool fLibraryFortran = false;
 bool fLibraryMakefile = false;
@@ -766,15 +765,15 @@ static void setLLVMRemarksFunctions(const ArgumentDescription* desc, const char*
 }
 
 static void handleLibrary(const ArgumentDescription* desc, const char* arg_unused) {
- addLibFile(libraryFilename);
+ addLibFile(libraryFilename, /* fromCmdLine */ true);
 }
 
 static void handleLibPath(const ArgumentDescription* desc, const char* arg_unused) {
-  addLibPath(libraryFilename);
+  addLibPath(libraryFilename, /* fromCmdLine */ true);
 }
 
 static void handleIncDir(const ArgumentDescription* desc, const char* arg_unused) {
-  addIncInfo(incFilename);
+  addIncInfo(incFilename, /* fromCmdLine */ true);
 }
 
 static int invokeChplWithArgs(int argc, char* argv[],
@@ -2099,10 +2098,6 @@ static void postprocess_args() {
   setPrintCppLineno();
 
   setGPUFlags();
-
-  if (fDriverPhaseOne) {
-    saveLibraryAndIncludeInfo();
-  }
 
   // restore warnings to previous state
   ignore_warnings = ignore_warnings_previous;

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -134,6 +134,9 @@ void checkDriverTmp() {
     // specification, all good.
     valid = true;
   }
+
+  // Reassure some compilers that this variable is not unused.
+  std::ignore = valid;
   assert(
       valid &&
       "attempted to save info to tmp dir before it is set up for driver use");

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -171,9 +171,13 @@ void restoreLibraryAndIncludeInfo() {
   INT_ASSERT(
       fDriverPhaseTwo &&
       "should only be restoring library and include info in driver phase two");
-  assert(libDirs.empty() && libFiles.empty() && incDirs.empty() &&
-         "tried to restore library and include info from disk, but it was "
-         "already present in memory");
+
+  // Phase two has access to the command line but not any info added from
+  // 'require' statements, so these contents are incomplete. Just clear any
+  // partial info and re-load it all.
+  libDirs.clear();
+  libFiles.clear();
+  incDirs.clear();
 
   restoreDriverTmp(libDirsFilename, &addLibPath);
   restoreDriverTmp(libFilesFilename, &addLibFile);

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -167,6 +167,16 @@ void restoreDriverTmp(const char* tmpFilePath,
   closefile(tmpFile);
 }
 
+void saveLibraryAndIncludeInfo() {
+  INT_ASSERT(
+      fDriverPhaseOne &&
+      "should only be saving library and include info in driver phase one");
+
+  saveDriverTmpMultiple(libDirsFilename, libDirs);
+  saveDriverTmpMultiple(libFilesFilename, libFiles);
+  saveDriverTmpMultiple(incDirsFilename, incDirs);
+}
+
 void restoreLibraryAndIncludeInfo() {
   INT_ASSERT(
       fDriverPhaseTwo &&


### PR DESCRIPTION
Fix two bugs relating to driver save/restore of command-line library and include info, which could cause an assertion failure in developer mode.

1. Library and include info can come from either the command-line or `require` statements. The driver needs to save and restore this info from disk, as phase two has no access to the AST including `require` statements. However, phase two does have access to the command-line, so by the restore point it can already have some library/include info, tripping an assertion that it has none. Solved by removing the assertion.
2. It was intended for phase one to also save info gathered from the command-line, but it was getting saved before the driver-specified tmp dir was set up, so it was thrown away. However, this info isn't needed anyways -- if it had been working properly, phase two would end up with two copies of the command-line info. Solved by avoiding saving command-line library/include info to disk in phase one.

Discovered while trying to compile Arkouda with `--compiler-driver` in developer mode for https://github.com/Cray/chapel-private/issues/5497.

[reviewer info placeholder]

Testing:
- [x] paratest
- [x] paratest with `--compiler-driver`
- [x] C backend paratest
- [x] C backend paratest with `--compiler-driver`
- [x] can compile Arkouda with `--compiler-driver`