### PR TITLE
Replaced "heterogenous PU" with "hybrid PU"

### DIFF
--- a/doc/rst/usingchapel/executing.rst
+++ b/doc/rst/usingchapel/executing.rst
@@ -283,7 +283,7 @@ are as follows:
     number of threads used to execute tasks
 
   ``CHPL_RT_USE_PU_KIND``
-    which kind of processing units to use on CPUs with heterogeneous
+    which kind of processing units to use on CPUs with hybrid
     processing units. Values are "performance", "efficiency", or "all".
 
 There is a bit more information on ``CHPL_RT_CALL_STACK_SIZE``,
@@ -349,12 +349,12 @@ Controlling the Kind of Processing Units
 ----------------------------------------
 
 Some CPUs, such as Intel's "Alder Lake" family of processors, have
-heterogeneous processing units, some of which are "performance" and others
+hybrid processing units, some of which are "performance" and others
 of which are "efficiency". The following environment variable can be used
 to select the kind of processing units used by a program.
 
   ``CHPL_RT_USE_PU_KIND``
-    Specifies which kind of processing units to use on CPUs with heterogeneous
+    Specifies which kind of processing units to use on CPUs with hybrid
     processing units. Values are "performance", "efficiency", or "all".
 
 By default the Chapel runtime will only use "performance" processing units.
@@ -362,7 +362,7 @@ Note that if set to "all" the runtime will run tasks on all available
 cores/processing units indiscriminately ; it will not take the difference in
 performance into account when assigning tasks to processing units.
 
-This environment variable has no effect if the processor has homogeneous
+This environment variable has no effect if the processor does not have hybrid
 processing units.
 
 -----------------------------------------

--- a/runtime/src/topo/hwloc/topo-hwloc.c
+++ b/runtime/src/topo/hwloc/topo-hwloc.c
@@ -408,7 +408,7 @@ static void cpuInfoInit(void) {
       char buf[1024];
       hwloc_bitmap_list_snprintf(buf, sizeof(buf), cpuset);
       _DBG_P("core cpuset: %s", buf);
-    // filter the core's PUs in case they are heterogeneous
+    // filter the core's PUs in case they are hybrid
     _DBG_P("filtering core's cpuset");
     filterPUsByKind(numKinds, ignoreKinds, cpuset);
 


### PR DESCRIPTION
"Heterogeneous PU" could imply that the processing units on CPUs such as Intel's Alder Lake have different ISAs, which they do not. Intel uses the term "hybrid" so we should adopt that.