### PR TITLE
Allow installing Python bindings into our Python Application

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ third-party-c2chapel-venv: FORCE
 	fi
 
 third-party-chapel-py-venv: frontend FORCE
-	cd third-party && $(MAKE) chapel-py-venv; \
+	cd third-party && $(MAKE) chapel-py-venv;
 
 test-venv: third-party-test-venv
 

--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,12 @@ third-party-c2chapel-venv: FORCE
 	cd third-party && $(MAKE) c2chapel-venv; \
 	fi
 
+third-party-chapel-py-venv: frontend FORCE
+	cd third-party && $(MAKE) chapel-py-venv; \
+
 test-venv: third-party-test-venv
+
+chapel-py-venv: third-party-chapel-py-venv
 
 chpldoc: third-party-chpldoc-venv
 	@cd third-party && $(MAKE) llvm

--- a/third-party/Makefile
+++ b/third-party/Makefile
@@ -90,6 +90,9 @@ chpldoc-venv: FORCE
 c2chapel-venv: FORCE
 	cd chpl-venv && $(MAKE) c2chapel-venv
 
+chapel-py-venv: FORCE
+	cd chpl-venv && $(MAKE) chapel-py-venv
+
 # See gasnet/Makefile for explanation of the post-install step
 gasnet: $(GASNET_INSTALL_DIR)
 $(GASNET_INSTALL_DIR): $(GASNET_DEPEND)

--- a/third-party/chpl-venv/Makefile
+++ b/third-party/chpl-venv/Makefile
@@ -92,6 +92,14 @@ chpldoc-venv: install-chpldeps
 
 c2chapel-venv: install-chpldeps
 
+chapel-py-venv: install-chpldeps
+	@# Install chapel-py's Python package into the virtual environment.
+	export PATH="$(CHPL_VENV_VIRTUALENV_BIN):$$PATH" && \
+	export VIRTUAL_ENV=$(CHPL_VENV_VIRTUALENV_DIR) && \
+	$(PIP) install --upgrade $(CHPL_PIP_INSTALL_PARAMS) $(LOCAL_PIP_FLAGS) \
+	  --target $(CHPL_VENV_CHPLDEPS) \
+	  -e $(CHPL_MAKE_HOME)/tools/chapel-py
+
 install-requirements: install-chpldeps
 
 $(CHPL_VENV_CHPLSPELL_REQS): $(CHPL_VENV_VIRTUALENV_DIR_OK) $(CHPL_VENV_CHPLSPELL_REQUIREMENTS_FILE)

--- a/third-party/chpl-venv/Makefile
+++ b/third-party/chpl-venv/Makefile
@@ -93,7 +93,8 @@ chpldoc-venv: install-chpldeps
 c2chapel-venv: install-chpldeps
 
 chapel-py-venv: install-chpldeps
-	@# Install chapel-py's Python package into the virtual environment.
+	@# Install chapel-py's Python package into the Python Application
+	@# directory structure at $(CHPL_VENV_CHPLDEPS)
 	export PATH="$(CHPL_VENV_VIRTUALENV_BIN):$$PATH" && \
 	export VIRTUAL_ENV=$(CHPL_VENV_VIRTUALENV_DIR) && \
 	$(PIP) install --upgrade $(CHPL_PIP_INSTALL_PARAMS) $(LOCAL_PIP_FLAGS) \

--- a/tools/chapel-py/chplcheck
+++ b/tools/chapel-py/chplcheck
@@ -1,0 +1,30 @@
+#!/usr/bin/env sh
+
+#
+# Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+# Copyright 2004-2019 Cray Inc.
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if [ -z "$CHPL_HOME" ]; then
+  echo "Error: CHPL_HOME is not set"
+  exit 1
+fi
+
+exec $CHPL_HOME/util/config/run-in-venv-with-python-bindings.bash \
+     $CHPL_HOME/tools/chapel-py/chplcheck.py "$@"
+

--- a/tools/chapel-py/chplcheck.py
+++ b/tools/chapel-py/chplcheck.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 #
 # Copyright 2020-2023 Hewlett Packard Enterprise Development LP
 # Copyright 2004-2019 Cray Inc.

--- a/util/config/run-in-venv-common.bash
+++ b/util/config/run-in-venv-common.bash
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Common support code to run a command in the Python virtual environment.
+# Some scripts can use this as-is, others might want to perform other checks.
+
+if [ -z "$CHPL_HOME" ]; then
+  # compute the chpl home directory
+  export CHPL_HOME=$(cd $(dirname $0) ; cd ..; cd ..; pwd)
+fi
+
+python=$($CHPL_HOME/util/config/find-python.sh)
+chpldeps=$("$python" "$CHPL_HOME/util/chplenv/chpl_home_utils.py" --chpldeps)
+
+if [ ! -e "$chpldeps" ]; then
+  echo "chpl dependencies are missing - try make test-venv" 1>&2
+  exit 1
+fi
+
+if [ ! -f "$chpldeps/__main__.py" ]; then
+  echo "chpl dependencies are missing - try make test-venv" 1>&2
+  exit 1
+fi
+
+# include the dependencies
+export PYTHONPATH="$chpldeps":$PYTHONPATH

--- a/util/config/run-in-venv-with-python-bindings.bash
+++ b/util/config/run-in-venv-with-python-bindings.bash
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Active the virtual environment (including Python bindings) and run the command supplied
+# usage: ./run-in-venv-with-python-bindings prog [args]
+
+CWD=$(cd $(dirname $0) ; pwd)
+
+# Perform checks and set up environment variables for virtual env.
+source $CWD/run-in-venv-common.bash
+
+if [ ! -f "$chpldeps/chapel.egg-link" ]; then
+  echo "chapel python bindings not built - try make chapel-py-venv " 1>&2
+  exit 1
+fi
+
+exec "$1" "${@:2}"

--- a/util/config/run-in-venv.bash
+++ b/util/config/run-in-venv.bash
@@ -2,24 +2,9 @@
 # Active the virtual environment and run the command supplied
 # usage: ./run-in-venv prog [args]
 
-if [ -z "$CHPL_HOME" ]; then
-  # compute the chpl home directory
-  export CHPL_HOME=$(cd $(dirname $0) ; cd ..; cd ..; pwd)
-fi
+CWD=$(cd $(dirname $0) ; pwd)
 
-python=$($CHPL_HOME/util/config/find-python.sh)
-chpldeps=$("$python" "$CHPL_HOME/util/chplenv/chpl_home_utils.py" --chpldeps)
+# Perform checks and set up environment variables for virtual env.
+source $CWD/run-in-venv-common.bash
 
-if [ ! -e "$chpldeps" ]; then
-  echo "chpl dependencies are missing - try make test-venv" 1>&2
-  exit 1
-fi
-
-if [ ! -f "$chpldeps/__main__.py" ]; then
-  echo "chpl dependencies are missing - try make test-venv" 1>&2
-  exit 1
-fi
-
-# include the dependencies
-export PYTHONPATH="$chpldeps":$PYTHONPATH
 exec "$1" "${@:2}"


### PR DESCRIPTION
This PR adds a new target to our Makefile which builds on top of the `test-venv` and adds support for installing the Python bindings into the Python Application directory structure. This should make it possible to run scripts like `chplcheck` "out of the box", the same way we can run `chpldoc` (which requires Python for sphinx). The overarching goal is to be able to ship Python-based tools with Chapel, allowing our users to make use of `chplcheck` with no additional setup. It would also be nice if we could run the Python-based tools in CI jobs.

Reviewed by @jabraham17 and @mppf -- thanks!

## Testing

 - [x] c2chapel still works
 - [x] can invoke the linter from the command line without bindings installed