### PR TITLE
Add support for variable-length byte encoding for uAST serializers

### DIFF
--- a/frontend/include/chpl/framework/Context.h
+++ b/frontend/include/chpl/framework/Context.h
@@ -17,8 +17,8 @@
  * limitations under the License.
  */
 
-#ifndef CHPL_QUERIES_CONTEXT_H
-#define CHPL_QUERIES_CONTEXT_H
+#ifndef CHPL_FRAMEWORK_CONTEXT_H
+#define CHPL_FRAMEWORK_CONTEXT_H
 
 #include "chpl/framework/Context-detail.h"
 #include "chpl/framework/ID.h"

--- a/frontend/include/chpl/framework/UniqueString.h
+++ b/frontend/include/chpl/framework/UniqueString.h
@@ -26,8 +26,8 @@
 #define CHPL_QUERIES_UNIQUE_STRING_H
 
 #include "chpl/framework/UniqueString-detail.h"
-#include "chpl/framework/stringify-functions.h"
 #include "chpl/framework/serialize-functions.h"
+#include "chpl/framework/stringify-functions.h"
 #include "chpl/util/hash.h"
 
 #include <cstring>

--- a/frontend/include/chpl/framework/serialize-functions.h
+++ b/frontend/include/chpl/framework/serialize-functions.h
@@ -21,9 +21,8 @@
   This file implements the generic chpl::serialize and chpl::deserialize
   as well as specializations for some common types.
  */
-
-#ifndef CHPL_QUERIES_SERIALIZE_FUNCTIONS_H
-#define CHPL_QUERIES_SERIALIZE_FUNCTIONS_H
+#ifndef CHPL_FRAMEWORK_SERIALIZATION_H
+#define CHPL_FRAMEWORK_SERIALIZATION_H
 
 #include "chpl/util/memory.h"
 
@@ -42,13 +41,27 @@
 
 #include "llvm/ADT/DenseMap.h"
 
-
 namespace chpl {
-class Context;
 
+// forward declarations
+class Context;
 template<typename T> struct serialize;
 template<typename T> struct deserialize;
 
+
+/** write a variable-byte encoded unsigned integer */
+void writeUnsignedVarint(std::ostream& os, uint64_t num);
+/** write a variable-byte encoded signed integer */
+void writeSignedVarint(std::ostream& os, int64_t num);
+
+/** read a variable-byte encoded unsigned integer */
+uint64_t readUnsignedVarint(std::istream& is);
+/** read a variable-byte encoded signed integer */
+int64_t readSignedVarint(std::istream& is);
+
+
+/** this class is what is passed to serialize methods & helps
+    with the process */
 class Serializer {
 public:
   // Note: currently these char* entries are expected to support UniqueStrings,
@@ -62,9 +75,9 @@ private:
   stringCacheType stringCache_;
 
 public:
-  Serializer(std::ostream& os): os_(os) {
-  }
+  explicit Serializer(std::ostream& os) : os_(os) { }
 
+  /** Returns the output stream */
   std::ostream& os() const {
     return os_;
   }
@@ -89,60 +102,100 @@ public:
       return idx->second.first;
     }
   }
+
+  /* Write a variable-length byte-encoded 64-bit unsigned integer */
+  void writeVU64(uint64_t num) {
+    chpl::writeUnsignedVarint(os_, num);
+  }
+  /* Write a variable-length byte-encoded 64-bit signed integer */
+  void writeVI64(int64_t num) {
+    chpl::writeSignedVarint(os_, num);
+  }
+  /* Write a variable-length byte-encoded 'unsigned int' */
+  void writeVUint(unsigned int num) {
+    chpl::writeUnsignedVarint(os_, num);
+  }
+  /* Write a variable-length byte-encoded 'int' */
+  void writeVInt(int num) {
+    chpl::writeSignedVarint(os_, num);
+  }
 };
 
+
+/** this class is what is passed to deserialize methods & helps
+    with the process */
 class Deserializer {
-  public:
-    // Note: currently these char* entries are expected to support
-    // UniqueStrings, which are allocated from a Context and are
-    // null-terminated.
-    using stringCacheType = std::vector<std::pair<size_t, const char*>>;
-  private:
-    Context* context_;
-    std::istream& is_;
-    stringCacheType cache_;
+ public:
+  // Note: currently these char* entries are expected to support
+  // UniqueStrings, which are allocated from a Context and are
+  // null-terminated.
+  using stringCacheType = std::vector<std::pair<size_t, const char*>>;
+ private:
+  Context* context_;
+  std::istream& is_;
+  stringCacheType cache_;
 
-  public:
-    Deserializer(Context* context, std::istream& is)
-      : context_(context), is_(is) { }
+ public:
+  Deserializer(Context* context, std::istream& is)
+    : context_(context), is_(is) { }
 
-    Deserializer(Context* context, std::istream& is, const stringCacheType& cache)
-      : context_(context), is_(is), cache_(cache) { }
+  Deserializer(Context* context, std::istream& is, const stringCacheType& cache)
+    : context_(context), is_(is), cache_(cache) { }
 
-    //
-    // Convenience version to convert a Serializer's form of the string cache
-    //
-    Deserializer(Context* context, std::istream& is,
-                 Serializer::stringCacheType serCache)
-      : context_(context), is_(is) {
-      cache_.resize(serCache.size());
-      for (const auto& pair : serCache) {
-        cache_[pair.second.first] = {pair.second.second, pair.first};
-      }
+  //
+  // Convenience version to convert a Serializer's form of the string cache
+  //
+  Deserializer(Context* context, std::istream& is,
+               Serializer::stringCacheType serCache)
+    : context_(context), is_(is) {
+    cache_.resize(serCache.size());
+    for (const auto& pair : serCache) {
+      cache_[pair.second.first] = {pair.second.second, pair.first};
     }
+  }
 
-    Context* context() const {
-      return context_;
-    }
+  Context* context() const {
+    return context_;
+  }
 
-    std::istream& is() const {
-      return is_;
-    }
+  std::istream& is() const {
+    return is_;
+  }
 
-    std::pair<size_t, const char*>& getString(int id) {
-      return cache_[id];
-    }
+  std::pair<size_t, const char*>& getString(int id) {
+    return cache_[id];
+  }
 
-    template <typename T>
-    T operator()() {
-      return chpl::deserialize<T>{}(*this);
-    }
+  template <typename T>
+  T operator()() {
+    return chpl::deserialize<T>{}(*this);
+  }
 
-    template <typename T>
-    T read() {
-      return chpl::deserialize<T>{}(*this);
-    }
+  template <typename T>
+  T read() {
+    return chpl::deserialize<T>{}(*this);
+  }
+
+  /* Read a variable-length byte-encoded unsigned integer
+     and return a 'uint64_t'*/
+  uint64_t readVU64() {
+    return chpl::readUnsignedVarint(is_);
+  }
+  /* Read a variable-length byte-encoded signed integer & return an 'int64_t' */
+  int64_t readVI64() {
+    return chpl::readSignedVarint(is_);
+  }
+  /* Read a variable-length byte-encoded unsigned integer
+     and return an 'unsigned int'*/
+  unsigned int readVUint() {
+    return chpl::readUnsignedVarint(is_);
+  }
+  /* Read a variable-length byte-encoded signed integer & return an 'int'*/
+  int readVInt() {
+    return chpl::readSignedVarint(is_);
+  }
 };
+
 
 // define the generic serialize template
 template<typename T> struct serialize {
@@ -235,23 +288,20 @@ template<> struct deserialize<bool> {
  */
 template<> struct serialize<std::string> {
   void operator()(Serializer& ser, const std::string& val) const {
-    ser.write((uint64_t)val.size());
-    if (val.size() > 0) {
-      ser.os().write(val.c_str(), val.size());
+    uint64_t len = val.size();
+    ser.writeVU64(len);
+    if (len > 0) {
+      ser.os().write(val.c_str(), len);
     }
   }
 };
 
 template<> struct deserialize<std::string> {
   std::string operator()(Deserializer& des) {
-    size_t len = (size_t)des.read<uint64_t>();
-    char* buf = nullptr;
+    uint64_t len = des.readVU64();
     if (len > 0) {
-      buf = (char*)malloc(len+1);
-      des.is().read(buf, len);
-      buf[len] = '\0';
-      auto ret = std::string(buf, len);
-      free(buf);
+      std::string ret(len, 0);
+      des.is().read(&ret[0], len);
       return ret;
     } else {
       return std::string();
@@ -261,9 +311,9 @@ template<> struct deserialize<std::string> {
 
 template<typename T> struct serialize<std::vector<T>> {
  void operator()(Serializer& ser,
-                 const std::vector<T>& stringVec) const {
-   ser.write((uint64_t)stringVec.size());
-   for (const auto &elt : stringVec ) {
+                 const std::vector<T>& vec) const {
+   ser.writeVU64(vec.size());
+   for (const auto &elt : vec ) {
      ser.write(elt);
    }
  }
@@ -272,7 +322,7 @@ template<typename T> struct serialize<std::vector<T>> {
 template<typename T> struct deserialize<std::vector<T>> {
   std::vector<T> operator()(Deserializer& des) const {
     std::vector<T> ret;
-    auto n = des.read<uint64_t>();
+    uint64_t n = des.readVU64();
     for (uint64_t i = 0; i < n; i++) {
       ret.push_back(des.read<T>());
     }
@@ -283,7 +333,7 @@ template<typename T> struct deserialize<std::vector<T>> {
 template<typename T> struct serialize<std::set<T>> {
  void operator()(Serializer& ser,
                  const std::set<T>& val) const {
-   ser.write((uint64_t)val.size());
+   ser.writeVU64(val.size());
    for (const auto& elt : val) {
      ser.write(elt);
    }
@@ -293,7 +343,7 @@ template<typename T> struct serialize<std::set<T>> {
 template<typename T> struct deserialize<std::set<T>> {
   std::set<T> operator()(Deserializer& des) const {
     std::set<T> ret;
-    auto len = des.read<uint64_t>();
+    uint64_t len = des.readVU64();
     for (uint64_t i = 0; i < len; i++) {
       ret.insert(des.read<T>());
     }

--- a/frontend/lib/framework/CMakeLists.txt
+++ b/frontend/lib/framework/CMakeLists.txt
@@ -27,5 +27,6 @@ target_sources(ChplFrontend-obj
                TemporaryFileResult.cpp
                UniqueString.cpp
                compiler-configuration.cpp
+               serialize-functions.cpp
 
               )

--- a/frontend/lib/framework/serialize-functions.cpp
+++ b/frontend/lib/framework/serialize-functions.cpp
@@ -45,6 +45,9 @@ uint64_t readUnsignedVarint(std::istream& is) {
   uint64_t num = 0;
   for (int i = 0; i < 10; i++) {
     auto byte = is.get();
+    // TODO: what should this function do on EOF?
+    // What if it reads a byte that should be followed by another
+    // byte there is no other byte (due to EOF)?
     if (byte == is.eof()) break;
     uint64_t part = byte & 0x7f;
     num |= part << (7*i);

--- a/frontend/lib/framework/serialize-functions.cpp
+++ b/frontend/lib/framework/serialize-functions.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "chpl/framework/serialize-functions.h"
+
+namespace chpl {
+
+
+void writeUnsignedVarint(std::ostream& os, uint64_t num) {
+  for (int i = 0; i < 10; i++) {
+    uint8_t byte = num & 0x7f;
+    num >>= 7;
+    if (num != 0) byte |= 0x80;
+    os.put(byte);
+    if (byte & 0x80) {
+      // OK, continue
+    } else {
+      break;
+    }
+  }
+}
+
+void writeSignedVarint(std::ostream& os, int64_t num) {
+  uint64_t uNum = (num << 1) ^ (num >> 63);
+  writeUnsignedVarint(os, uNum);
+}
+
+uint64_t readUnsignedVarint(std::istream& is) {
+  uint64_t num = 0;
+  for (int i = 0; i < 10; i++) {
+    auto byte = is.get();
+    if (byte == is.eof()) break;
+    uint64_t part = byte & 0x7f;
+    num |= part << (7*i);
+    if (byte & 0x80) {
+      // continue
+    } else {
+      break; // all done
+    }
+  }
+  return num;
+}
+
+int64_t readSignedVarint(std::istream& is) {
+  uint64_t uNum = readUnsignedVarint(is);
+  return (uNum >> 1) ^ -((int64_t)(uNum & 1));
+}
+
+
+} // end namespace chpl

--- a/frontend/test/framework/CMakeLists.txt
+++ b/frontend/test/framework/CMakeLists.txt
@@ -22,6 +22,7 @@ comp_unit_test(testDependencies)
 comp_unit_test(testErrorTracking)
 comp_unit_test(testIds)
 comp_unit_test(testUniqueString)
+comp_unit_test(testVarint)
 
 # Copy the moby.txt to the binary dir for use by testUniqueString
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/../../../test/types/string/psahabu/perf/moby.txt

--- a/frontend/test/framework/testVarint.cpp
+++ b/frontend/test/framework/testVarint.cpp
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "test-common.h"
+
+#include "chpl/framework/Context.h"
+#include "chpl/framework/serialize-functions.h"
+
+#include <iostream>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+using namespace chpl;
+
+static void testMatchUnsigned(uint64_t i, std::string expect) {
+  std::ostringstream os;
+  writeUnsignedVarint(os, i);
+  std::string got = os.str();
+  assert(got.size() == expect.size());
+  for (size_t i = 0; i < expect.size(); i++) {
+    assert(got[i] == expect[i]);
+  }
+
+  // check also that we can read it
+  auto is = std::istringstream(got);
+  uint64_t val = readUnsignedVarint(is);
+  assert(val == i);
+}
+
+static void test1() {
+  testMatchUnsigned(0, std::string(1, '\x00'));
+  testMatchUnsigned(1, "\x01");
+  testMatchUnsigned(0x7e, "\x7e");
+  testMatchUnsigned(513, "\x81\x04");
+  testMatchUnsigned(514, "\x82\x04");
+  testMatchUnsigned(0x2bb, "\xbb\x05");
+  testMatchUnsigned(0xfedcba9876543210ull,
+                    "\x90\xe4\xd0\xb2\x87\xd3\xae\xee\xfe\x01");
+}
+
+static void testMatchSigned(int64_t i, std::string expect) {
+  std::ostringstream os;
+  writeSignedVarint(os, i);
+  std::string got = os.str();
+  assert(got.size() == expect.size());
+  for (size_t i = 0; i < expect.size(); i++) {
+    assert(got[i] == expect[i]);
+  }
+
+  // check also that we can read it
+  auto is = std::istringstream(got);
+  int64_t val = readSignedVarint(is);
+  assert(val == i);
+}
+
+static void test2() {
+  testMatchSigned(0, std::string(1, '\x00'));
+  testMatchSigned(1, "\x02");
+  testMatchSigned(2, "\x04");
+  testMatchSigned(257, "\x82\x04");
+  testMatchSigned(-257, "\x81\x04");
+  testMatchSigned(-1, "\x01");
+  testMatchSigned(-2, "\x03");
+}
+
+// testing unsigned writes and reads with a bunch of values
+static void test3() {
+  std::ostringstream os;
+  for (uint64_t i = 0; i < 1000000; i++) {
+    writeUnsignedVarint(os, i);
+  }
+  std::istringstream is(os.str());
+  for (uint64_t i = 0; i < 1000000; i++) {
+    uint64_t got = readUnsignedVarint(is);
+    assert(got == i);
+  }
+}
+
+// testing signed writes and reads with a bunch of values
+static void test4() {
+  std::ostringstream os;
+  for (int64_t i = -500000; i < 500000; i++) {
+    writeSignedVarint(os, i);
+  }
+  std::istringstream is(os.str());
+  for (int64_t i = -500000; i < 500000; i++) {
+    int64_t got = readSignedVarint(is);
+    assert(got == i);
+  }
+}
+
+int main(int argc, char** argv) {
+  test1();
+  test2();
+  test3();
+  test4();
+
+  return 0;
+}

--- a/runtime/include/qio/bswap.h
+++ b/runtime/include/qio/bswap.h
@@ -30,7 +30,7 @@
 #define _BSWAP_H_
 
 // On a BSD derived system (such as Mac OS X),
-// sys_basic will define _USE_BSD and include sys/types.h,
+// sys_basic will define _BSD_SOURCE and include sys/types.h,
 // and between that and sys/param.h, a BSD system should
 // give us these byte order functions.
 // (A BSD-derived system might define them in sys/endian.h,


### PR DESCRIPTION
This PR adds implementation of and testing for a variable-length byte encoding (aka "variable byte encoding") for signed and unsigned integers. The implementation is based upon the existing variable-byte encoding in the runtime and matches the wire format used in Protocol Buffers (see https://protobuf.dev/programming-guides/encoding/#varints ).

In addition, this PR includes a few trivial improvements:
 * a trivial comment correction in runtime/include/qio/bswap.h
 * fixing the header guard name in frontend/include/chpl/framework/Context.h
 * sorting the includes in frontend/include/chpl/framework/UniqueString.h

Future PRs will adjust the uAST serializes to use these new mechanisms.

Reviewed by @DanilaFe - thanks!

- [x] full comm=none testing