### PR TITLE
Use variable-length byte encoding in the uAST serializers

### DIFF
--- a/frontend/include/chpl/framework/CommentID.h
+++ b/frontend/include/chpl/framework/CommentID.h
@@ -44,11 +44,11 @@ class CommentID {
   int index() const { return index_; }
 
   void serialize(Serializer& ser) const {
-    ser.write<int32_t>(index_);
+    ser.writeVInt(index_);
   }
 
   static CommentID deserialize(Deserializer& des) {
-    int val = (int)des.read<int32_t>();
+    int val = des.readVInt();
     return CommentID(val);
   }
 };

--- a/frontend/include/chpl/framework/ID.h
+++ b/frontend/include/chpl/framework/ID.h
@@ -251,13 +251,13 @@ class ID final {
 
   void serialize(Serializer& ser) const {
     ser.write(symbolPath_);
-    ser.write(postOrderId_);
-    ser.write(numChildIds_);
+    ser.writeVInt(postOrderId_);
+    ser.writeVInt(numChildIds_);
   }
   static ID deserialize(Deserializer& des) {
     auto path = des.read<UniqueString>();
-    auto poi = des.read<int>();
-    auto nci = des.read<int>();
+    auto poi = des.readVInt();
+    auto nci = des.readVInt();
     return ID(path, poi, nci);
   }
 };

--- a/frontend/include/chpl/uast/AggregateDecl.h
+++ b/frontend/include/chpl/uast/AggregateDecl.h
@@ -99,12 +99,20 @@ class AggregateDecl : public TypeDecl {
     CHPL_ASSERT(validAggregateChildren(declOrComments()));
   }
 
+  void serialize(Serializer& ser) const override {
+    TypeDecl::serialize(ser);
+    ser.writeVInt(inheritExprChildNum_);
+    ser.writeVInt(numInheritExprs_);
+    ser.writeVInt(elementsChildNum_);
+    ser.writeVInt(numElements_);
+  }
+
   AggregateDecl(AstTag tag, Deserializer& des)
     : TypeDecl(tag, des) {
-    inheritExprChildNum_ = des.read<int>();
-    numInheritExprs_ = des.read<int>();
-    elementsChildNum_ = des.read<int>();
-    numElements_ = des.read<int>();
+    inheritExprChildNum_ = des.readVInt();
+    numInheritExprs_ = des.readVInt();
+    elementsChildNum_ = des.readVInt();
+    numElements_ = des.readVInt();
   }
 
   ~AggregateDecl() = 0; // this is an abstract base class
@@ -179,15 +187,6 @@ class AggregateDecl : public TypeDecl {
     return AstListNoCommentsIteratorPair<AstNode>(
               children_.begin() + inheritExprChildNum_,
               children_.begin() + inheritExprChildNum_ + numInheritExprs_);
-  }
-
-
-  void serialize(Serializer& ser) const override {
-    TypeDecl::serialize(ser);
-    ser.write(inheritExprChildNum_);
-    ser.write(numInheritExprs_);
-    ser.write(elementsChildNum_);
-    ser.write(numElements_);
   }
 
   /** Returns the inherited Identifier, including considering

--- a/frontend/include/chpl/uast/AnonFormal.h
+++ b/frontend/include/chpl/uast/AnonFormal.h
@@ -77,9 +77,20 @@ class AnonFormal final : public AstNode {
       typeExpressionChildNum_(typeExpressionChildNum) {
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+    ser.write(intent_);
+    ser.write(typeExpressionChildNum_);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(AnonFormal);
+
+ private:
   AnonFormal(Deserializer& des)
     : AstNode(asttags::AnonFormal, des) {
       intent_ = des.read<Formal::Intent>();
+      typeExpressionChildNum_ = des.read<int8_t>();
     }
 
   bool contentsMatchInner(const AstNode* other) const override {
@@ -120,14 +131,6 @@ class AnonFormal final : public AstNode {
   static std::string intentToString(Intent intent) {
     return Formal::intentToString(intent);
   }
-
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-    ser.write(intent_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(AnonFormal);
-
 };
 
 

--- a/frontend/include/chpl/uast/Array.h
+++ b/frontend/include/chpl/uast/Array.h
@@ -52,8 +52,20 @@ class Array final : public AstNode {
     associative_ = associative;
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+    ser.write(trailingComma_);
+    ser.write(associative_);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Array);
+
+ private:
   Array(Deserializer& des)
     : AstNode(asttags::Array, des) {
+    trailingComma_ = des.read<bool>();
+    associative_ = des.read<bool>();
   }
 
   bool contentsMatchInner(const AstNode* other) const override {
@@ -100,13 +112,6 @@ class Array final : public AstNode {
     const AstNode* ast = this->child(i);
     return ast;
   }
-
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Array);
-
 };
 
 

--- a/frontend/include/chpl/uast/Array.h
+++ b/frontend/include/chpl/uast/Array.h
@@ -69,7 +69,9 @@ class Array final : public AstNode {
   }
 
   bool contentsMatchInner(const AstNode* other) const override {
-    return true;
+    const Array* rhs = other->toArray();
+    return this->trailingComma_ == rhs->trailingComma_ &&
+           this->associative_ == rhs->associative_;
   }
 
   void markUniqueStringsInner(Context* context) const override {

--- a/frontend/include/chpl/uast/As.h
+++ b/frontend/include/chpl/uast/As.h
@@ -42,8 +42,16 @@ namespace uast {
  */
 class As final : public AstNode {
  private:
-  As(AstList children) : AstNode(asttags::As, std::move(children)) {}
-  As(Deserializer& des) : AstNode(asttags::As, des) {}
+  As(AstList children) : AstNode(asttags::As, std::move(children)) { }
+
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+  }
+  DECLARE_STATIC_DESERIALIZE(As);
+
+ private:
+  As(Deserializer& des) : AstNode(asttags::As, des) { }
 
   // No need to match 'symbolChildNum_' or 'renameChildNum_', they are const.
   bool contentsMatchInner(const AstNode* other) const override {
@@ -84,13 +92,6 @@ class As final : public AstNode {
     auto ret = child(renameChildNum_);
     return ret;
   }
-
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(As);
-
 };
 
 

--- a/frontend/include/chpl/uast/Attribute.h
+++ b/frontend/include/chpl/uast/Attribute.h
@@ -29,7 +29,7 @@ namespace uast {
 
 class Attribute final: public AstNode {
 
-private:
+ private:
   // the attribute name - deprecated or unstable or chpldoc.nodoc, for example
   UniqueString name_;
   int numActuals_; // number of child actuals
@@ -43,11 +43,22 @@ private:
       actualNames_(std::move(actualNames)) {
   }
 
-  Attribute(Deserializer& des)
-    : AstNode(asttags::Attribute, des) {
-      name_ = des.read<UniqueString>();
-      numActuals_ = des.read<int>();
-      actualNames_ = des.read<std::vector<UniqueString>>();
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+
+    ser.write(name_);
+    ser.writeVInt(numActuals_);
+    ser.write(actualNames_);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Attribute);
+
+ private:
+  Attribute(Deserializer& des) : AstNode(asttags::Attribute, des) {
+    name_ = des.read<UniqueString>();
+    numActuals_ = des.readVInt();
+    actualNames_ = des.read<std::vector<UniqueString>>();
   }
 
   bool contentsMatchInner(const AstNode* other) const override {
@@ -156,18 +167,6 @@ public:
   const std::string fullyQualifiedAttributeName() const {
     return name_.str();
   }
-
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-
-    ser.write(name_);
-    ser.write(numActuals_);
-    ser.write(actualNames_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Attribute);
-
-
 }; // end Attribute
 
 

--- a/frontend/include/chpl/uast/AttributeGroup.h
+++ b/frontend/include/chpl/uast/AttributeGroup.h
@@ -78,17 +78,6 @@ class AttributeGroup final : public AstNode {
     CHPL_ASSERT(pragmas_.size() <= NUM_KNOWN_PRAGMAS);
   }
 
-  AttributeGroup(Deserializer& des)
-    : AstNode(asttags::AttributeGroup, des) {
-      pragmas_ = des.read<std::set<PragmaTag>>();
-      isDeprecated_ = des.read<bool>();
-      isUnstable_ = des.read<bool>();
-      isParenfulDeprecated_ = des.read<bool>();
-      deprecationMessage_ = des.read<UniqueString>();
-      unstableMessage_ = des.read<UniqueString>();
-      parenfulDeprecationMessage_ = des.read<UniqueString>();
-    }
-
   AttributeGroup(std::set<PragmaTag> pragmas,
                  bool isDeprecated,
                  bool isUnstable,
@@ -118,6 +107,34 @@ class AttributeGroup final : public AstNode {
     // This might already be a compile-time invariant? Not sure...
     CHPL_ASSERT(pragmas_.size() <= NUM_KNOWN_PRAGMAS);
   }
+
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+
+    ser.write(pragmas_);
+    ser.write(isDeprecated_);
+    ser.write(isUnstable_);
+    ser.write(isParenfulDeprecated_);
+    ser.write(deprecationMessage_);
+    ser.write(unstableMessage_);
+    ser.write(parenfulDeprecationMessage_);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(AttributeGroup);
+
+ private:
+  AttributeGroup(Deserializer& des)
+    : AstNode(asttags::AttributeGroup, des) {
+      pragmas_ = des.read<std::set<PragmaTag>>();
+      isDeprecated_ = des.read<bool>();
+      isUnstable_ = des.read<bool>();
+      isParenfulDeprecated_ = des.read<bool>();
+      deprecationMessage_ = des.read<UniqueString>();
+      unstableMessage_ = des.read<UniqueString>();
+      parenfulDeprecationMessage_ = des.read<UniqueString>();
+    }
+
 
   bool contentsMatchInner(const AstNode* other) const override {
     const AttributeGroup* rhs = (const AttributeGroup*)other;
@@ -240,20 +257,6 @@ class AttributeGroup final : public AstNode {
   UniqueString parenfulDeprecationMessage() const {
     return parenfulDeprecationMessage_;
   }
-
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-
-    ser.write(pragmas_);
-    ser.write(isDeprecated_);
-    ser.write(isUnstable_);
-    ser.write(isParenfulDeprecated_);
-    ser.write(deprecationMessage_);
-    ser.write(unstableMessage_);
-    ser.write(parenfulDeprecationMessage_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(AttributeGroup);
 
   /**
     Returns the number of attributes in this group.

--- a/frontend/include/chpl/uast/Begin.h
+++ b/frontend/include/chpl/uast/Begin.h
@@ -47,6 +47,8 @@ namespace uast {
  */
 class Begin final : public SimpleBlockLike {
  private:
+  int8_t withClauseChildNum_;
+
   Begin(AstList children, int8_t withClauseChildNum, BlockStyle blockStyle,
         int bodyChildNum,
         int numBodyStmts)
@@ -56,10 +58,19 @@ class Begin final : public SimpleBlockLike {
       withClauseChildNum_(withClauseChildNum) {
   }
 
-    Begin(Deserializer& des)
-    : SimpleBlockLike(asttags::Begin, des) {
-      withClauseChildNum_ = des.read<int8_t>();
-    }
+ public:
+  void serialize(Serializer& ser) const override {
+    SimpleBlockLike::serialize(ser);
+    ser.write(withClauseChildNum_);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Begin);
+
+ private:
+  Begin(Deserializer& des)
+  : SimpleBlockLike(asttags::Begin, des) {
+    withClauseChildNum_ = des.read<int8_t>();
+  }
 
   bool contentsMatchInner(const AstNode* other) const override {
     const Begin* lhs = this;
@@ -79,8 +90,6 @@ class Begin final : public SimpleBlockLike {
   }
 
   std::string dumpChildLabelInner(int i) const override;
-
-  int8_t withClauseChildNum_;
 
  public:
 
@@ -102,14 +111,6 @@ class Begin final : public SimpleBlockLike {
     CHPL_ASSERT(ret->isWithClause());
     return (const WithClause*)ret;
   }
-
-  void serialize(Serializer& ser) const override {
-    SimpleBlockLike::serialize(ser);
-    ser.write(withClauseChildNum_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Begin);
-
 };
 
 

--- a/frontend/include/chpl/uast/Block.h
+++ b/frontend/include/chpl/uast/Block.h
@@ -42,6 +42,14 @@ class Block final : public SimpleBlockLike {
     CHPL_ASSERT(bodyChildNum_ >= 0);
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    SimpleBlockLike::serialize(ser);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Block);
+
+ private:
   Block(Deserializer& des)
     : SimpleBlockLike(asttags::Block, des) { }
 
@@ -60,13 +68,6 @@ class Block final : public SimpleBlockLike {
    Create and return a Block containing the passed stmts.
    */
   static owned<Block> build(Builder* builder, Location loc, AstList stmts);
-
-  void serialize(Serializer& ser) const override {
-    SimpleBlockLike::serialize(ser);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Block);
-
 };
 
 

--- a/frontend/include/chpl/uast/BoolLiteral.h
+++ b/frontend/include/chpl/uast/BoolLiteral.h
@@ -37,6 +37,14 @@ class BoolLiteral final : public Literal {
     : Literal(asttags::BoolLiteral, value) {
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    Literal::serialize(ser);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(BoolLiteral);
+
+ private:
   BoolLiteral(Deserializer& des)
     : Literal(asttags::BoolLiteral, des) {
     assert(value_->isBoolParam());
@@ -69,13 +77,6 @@ class BoolLiteral final : public Literal {
     auto p = (const types::BoolParam*) value_;
     return p->value() != 0;
   }
-
-  void serialize(Serializer& ser) const override {
-    Literal::serialize(ser);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(BoolLiteral);
-
 };
 
 

--- a/frontend/include/chpl/uast/BracketLoop.h
+++ b/frontend/include/chpl/uast/BracketLoop.h
@@ -60,6 +60,14 @@ class BracketLoop final : public IndexableLoop {
                     attributeGroupChildNum) {
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    IndexableLoop::serialize(ser);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(BracketLoop);
+
+ private:
   BracketLoop(Deserializer& des)
     : IndexableLoop(asttags::BracketLoop, des) { }
 
@@ -90,13 +98,6 @@ class BracketLoop final : public IndexableLoop {
    * Check if this bracket loop is actually an array type
    */
   bool isMaybeArrayType() const;
-
-  void serialize(Serializer& ser) const override {
-    IndexableLoop::serialize(ser);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(BracketLoop);
-
 };
 
 

--- a/frontend/include/chpl/uast/Break.h
+++ b/frontend/include/chpl/uast/Break.h
@@ -42,16 +42,27 @@ namespace uast {
 */
 class Break : public AstNode {
  private:
+  int8_t targetChildNum_;
+
   Break(AstList children, int8_t targetChildNum)
     : AstNode(asttags::Break, std::move(children)),
       targetChildNum_(targetChildNum) {
     CHPL_ASSERT(numChildren() <= 1);
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+    ser.write(targetChildNum_);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Break);
+
+ private:
   Break(Deserializer& des)
    : AstNode(asttags::Break, des) {
     targetChildNum_ = des.read<int8_t>();
-    }
+  }
 
   bool contentsMatchInner(const AstNode* other) const override {
     const Break* lhs = this;
@@ -67,8 +78,6 @@ class Break : public AstNode {
   }
 
   std::string dumpChildLabelInner(int i) const override;
-
-  int8_t targetChildNum_;
 
  public:
 
@@ -88,14 +97,6 @@ class Break : public AstNode {
     CHPL_ASSERT(ret->isIdentifier());
     return (const Identifier*)ret;
   }
-
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-    ser.write(targetChildNum_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Break);
-
 };
 
 

--- a/frontend/include/chpl/uast/BuilderResult.h
+++ b/frontend/include/chpl/uast/BuilderResult.h
@@ -119,7 +119,7 @@ class BuilderResult final {
   #include "all-location-maps.h"
   #undef LOCATION_MAP
 
-  // Goes from Comment ID to Location, applies to all AST nodes except Comment
+  // Goes from Comment ID to Location (for comments, specifically)
   std::vector<Location> commentIdToLocation_;
 
  public:

--- a/frontend/include/chpl/uast/BytesLiteral.h
+++ b/frontend/include/chpl/uast/BytesLiteral.h
@@ -39,6 +39,14 @@ class BytesLiteral final : public StringLikeLiteral {
     : StringLikeLiteral(asttags::BytesLiteral, value, quotes)
   { }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    StringLikeLiteral::serialize(ser);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(BytesLiteral);
+
+ private:
   BytesLiteral(Deserializer& des)
     : StringLikeLiteral(asttags::BytesLiteral, des)
   { }
@@ -52,13 +60,6 @@ class BytesLiteral final : public StringLikeLiteral {
   static owned<BytesLiteral> build(Builder* builder, Location loc,
                                    const std::string& value,
                                    StringLikeLiteral::QuoteStyle quotes);
-
-  void serialize(Serializer& ser) const override {
-    StringLikeLiteral::serialize(ser);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(BytesLiteral);
-
 };
 
 

--- a/frontend/include/chpl/uast/CStringLiteral.h
+++ b/frontend/include/chpl/uast/CStringLiteral.h
@@ -37,7 +37,13 @@ class CStringLiteral final : public StringLikeLiteral {
                  StringLikeLiteral::QuoteStyle quotes)
     : StringLikeLiteral(asttags::CStringLiteral, value, quotes)
   { }
+ public:
+  void serialize(Serializer& ser) const override {
+    StringLikeLiteral::serialize(ser);
+  }
 
+  DECLARE_STATIC_DESERIALIZE(CStringLiteral);
+ private:
   CStringLiteral(Deserializer& des)
     : StringLikeLiteral(asttags::CStringLiteral, des)
   { }
@@ -51,13 +57,6 @@ class CStringLiteral final : public StringLikeLiteral {
   static owned<CStringLiteral> build(Builder* builder, Location loc,
                                      const std::string& value,
                                      StringLikeLiteral::QuoteStyle quotes);
-
-  void serialize(Serializer& ser) const override {
-    StringLikeLiteral::serialize(ser);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(CStringLiteral);
-
 };
 
 

--- a/frontend/include/chpl/uast/Call.h
+++ b/frontend/include/chpl/uast/Call.h
@@ -43,6 +43,12 @@ class Call : public AstNode {
     : AstNode(tag, std::move(children)),
       hasCalledExpression_(hasCalledExpression) {
   }
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+    ser.write(hasCalledExpression_);
+  }
+ protected:
   Call(AstTag tag, Deserializer& des)
     : AstNode(tag, des) {
     hasCalledExpression_ = des.read<bool>();
@@ -93,11 +99,6 @@ class Call : public AstNode {
       const AstNode* ast = this->child(0);
       return ast;
     }
-  }
-
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-    ser.write(hasCalledExpression_);
   }
 };
 

--- a/frontend/include/chpl/uast/Catch.h
+++ b/frontend/include/chpl/uast/Catch.h
@@ -46,6 +46,10 @@ namespace uast {
  */
 class Catch final : public AstNode {
  private:
+  int8_t errorChildNum_;
+  int8_t bodyChildNum_;
+  bool hasParensAroundError_;
+
   Catch(AstList children, int8_t errorChildNum, int8_t bodyChildNum,
         bool hasParensAroundError)
     : AstNode(asttags::Catch, std::move(children)),
@@ -53,13 +57,22 @@ class Catch final : public AstNode {
       bodyChildNum_(bodyChildNum),
       hasParensAroundError_(hasParensAroundError) {
   }
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+    ser.write(errorChildNum_);
+    ser.write(bodyChildNum_);
+    ser.write(hasParensAroundError_);
+  }
 
+  DECLARE_STATIC_DESERIALIZE(Catch);
+ private:
   Catch(Deserializer& des)
     : AstNode(asttags::Catch, des) {
-        errorChildNum_ = des.read<int8_t>();
-        bodyChildNum_ = des.read<int8_t>();
-        hasParensAroundError_ = des.read<bool>();
-      }
+      errorChildNum_ = des.read<int8_t>();
+      bodyChildNum_ = des.read<int8_t>();
+      hasParensAroundError_ = des.read<bool>();
+  }
 
   bool contentsMatchInner(const AstNode* other) const override {
     const Catch* rhs = other->toCatch();
@@ -72,10 +85,6 @@ class Catch final : public AstNode {
   }
 
   std::string dumpChildLabelInner(int i) const override;
-
-  int8_t errorChildNum_;
-  int8_t bodyChildNum_;
-  bool hasParensAroundError_;
 
  public:
   ~Catch() override = default;
@@ -135,16 +144,6 @@ class Catch final : public AstNode {
   bool hasParensAroundError() const {
     return hasParensAroundError_;
   }
-
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-    ser.write(errorChildNum_);
-    ser.write(bodyChildNum_);
-    ser.write(hasParensAroundError_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Catch);
-
 };
 
 

--- a/frontend/include/chpl/uast/Class.h
+++ b/frontend/include/chpl/uast/Class.h
@@ -61,8 +61,15 @@ class Class final : public AggregateDecl {
                     elementsChildNum,
                     numElements) {}
 
+ public:
+  void serialize(Serializer& ser) const override {
+    AggregateDecl::serialize(ser);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Class);
+ private:
   Class(Deserializer& des)
-    : AggregateDecl(asttags::Class, des) {}
+    : AggregateDecl(asttags::Class, des) { }
 
   bool contentsMatchInner(const AstNode* other) const override {
     const Class* lhs = this;
@@ -85,12 +92,6 @@ class Class final : public AggregateDecl {
                             UniqueString name,
                             AstList inheritExprs,
                             AstList contents);
-
-  void serialize(Serializer& ser) const override {
-    AggregateDecl::serialize(ser);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Class);
 };
 
 

--- a/frontend/include/chpl/uast/Cobegin.h
+++ b/frontend/include/chpl/uast/Cobegin.h
@@ -47,6 +47,10 @@ namespace uast {
  */
 class Cobegin final : public AstNode {
  private:
+  int8_t withClauseChildNum_;
+  int bodyChildNum_;
+  int numTaskBodies_;
+
   Cobegin(AstList children, int8_t withClauseChildNum, int bodyChildNum,
           int numTaskBodies)
     : AstNode(asttags::Cobegin, std::move(children)),
@@ -55,10 +59,20 @@ class Cobegin final : public AstNode {
       numTaskBodies_(numTaskBodies) {
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+    ser.write(withClauseChildNum_ );
+    ser.writeVInt(bodyChildNum_);
+    ser.writeVInt(numTaskBodies_);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Cobegin);
+ private:
   Cobegin(Deserializer& des) : AstNode(asttags::Cobegin, des) {
     withClauseChildNum_ = des.read<int8_t>();
-    bodyChildNum_ = des.read<int>();
-    numTaskBodies_ = des.read<int>();
+    bodyChildNum_ = des.readVInt();
+    numTaskBodies_ = des.readVInt();
   }
 
   bool contentsMatchInner(const AstNode* other) const override {
@@ -81,10 +95,6 @@ class Cobegin final : public AstNode {
   }
 
   std::string dumpChildLabelInner(int i) const override;
-
-  int8_t withClauseChildNum_;
-  int bodyChildNum_;
-  int numTaskBodies_;
 
  public:
 
@@ -130,16 +140,6 @@ class Cobegin final : public AstNode {
     const AstNode* ast = this->child(i + bodyChildNum_);
     return ast;
   }
-
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-    ser.write(withClauseChildNum_ );
-    ser.write(bodyChildNum_);
-    ser.write(numTaskBodies_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Cobegin);
-
 };
 
 

--- a/frontend/include/chpl/uast/Coforall.h
+++ b/frontend/include/chpl/uast/Coforall.h
@@ -61,6 +61,13 @@ class Coforall final : public IndexableLoop {
                     attributeGroupChildNum) {
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    IndexableLoop::serialize(ser);
+  }
+  DECLARE_STATIC_DESERIALIZE(Coforall);
+
+ private:
   Coforall(Deserializer& des) : IndexableLoop(asttags::Coforall, des) { }
 
   bool contentsMatchInner(const AstNode* other) const override {
@@ -84,13 +91,6 @@ class Coforall final : public IndexableLoop {
                                BlockStyle blockStyle,
                                owned<Block> body,
                                owned<AttributeGroup> attributeGroup = nullptr);
-
-  void serialize(Serializer& ser) const override {
-    IndexableLoop::serialize(ser);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Coforall);
-
 };
 
 

--- a/frontend/include/chpl/uast/Comment.h
+++ b/frontend/include/chpl/uast/Comment.h
@@ -48,7 +48,15 @@ class Comment final : public AstNode {
   Comment(std::string s)
     : AstNode(asttags::Comment), comment_(std::move(s)) {
   }
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+    ser.write(comment_);
+    ser.write(commentId_);
+  }
 
+  DECLARE_STATIC_DESERIALIZE(Comment);
+ private:
   Comment(Deserializer& des)
     : AstNode(asttags::Comment, des) {
     comment_ = des.read<std::string>();
@@ -85,14 +93,6 @@ class Comment final : public AstNode {
      its BuilderResult
   */
   CommentID commentId() const { return commentId_; }
-
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-    ser.write(comment_);
-    ser.write(commentId_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Comment);
 
  protected:
   /**

--- a/frontend/include/chpl/uast/Conditional.h
+++ b/frontend/include/chpl/uast/Conditional.h
@@ -43,6 +43,17 @@ namespace uast {
 
  */
 class Conditional final : public AstNode {
+  // Condition always exists, and its position is always the same.
+  static const int8_t conditionChildNum_ = 0;
+  // Ditto then
+  static const int8_t thenBodyChildNum_ = 1;
+  // Ditto else (if this > children_.size(), there is no else clause)
+  static const int8_t elseBodyChildNum_ = 2;
+
+  BlockStyle thenBlockStyle_;
+  BlockStyle elseBlockStyle_;
+  bool isExpressionLevel_;
+
  private:
   Conditional(AstList children,
               BlockStyle thenBlockStyle,
@@ -80,6 +91,16 @@ class Conditional final : public AstNode {
     CHPL_ASSERT(thenBodyChildNum_ < (int) children_.size());
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+    ser.write(thenBlockStyle_);
+    ser.write(elseBlockStyle_);
+    ser.write(isExpressionLevel_);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Conditional);
+ private:
   Conditional(Deserializer& des)
     : AstNode(asttags::Conditional, des) {
     thenBlockStyle_ = des.read<BlockStyle>();
@@ -108,17 +129,6 @@ class Conditional final : public AstNode {
 
   void dumpFieldsInner(const DumpSettings& s) const override;
   std::string dumpChildLabelInner(int i) const override;
-
-  // Condition always exists, and its position is always the same.
-  static const int8_t conditionChildNum_ = 0;
-  // Ditto then
-  static const int8_t thenBodyChildNum_ = 1;
-  // Ditto else (if this > children_.size(), there is no else clause)
-  static const int8_t elseBodyChildNum_ = 2;
-
-  BlockStyle thenBlockStyle_;
-  BlockStyle elseBlockStyle_;
-  bool isExpressionLevel_;
 
  public:
   ~Conditional() override = default;
@@ -260,16 +270,6 @@ class Conditional final : public AstNode {
   bool isExpressionLevel() const {
     return isExpressionLevel_;
   }
-
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-    ser.write(thenBlockStyle_);
-    ser.write(elseBlockStyle_);
-    ser.write(isExpressionLevel_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Conditional);
-
 };
 
 

--- a/frontend/include/chpl/uast/Continue.h
+++ b/frontend/include/chpl/uast/Continue.h
@@ -41,12 +41,21 @@ namespace uast {
 */
 class Continue : public AstNode {
  private:
+  int8_t targetChildNum_;
+
   Continue(AstList children, int8_t targetChildNum)
     : AstNode(asttags::Continue, std::move(children)),
       targetChildNum_(targetChildNum) {
     CHPL_ASSERT(numChildren() <= 1);
   }
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+    ser.write(targetChildNum_);
+  }
 
+  DECLARE_STATIC_DESERIALIZE(Continue);
+ private:
   Continue(Deserializer& des)
     : AstNode(asttags::Continue, des) {
     targetChildNum_ = des.read<int8_t>();
@@ -67,8 +76,6 @@ class Continue : public AstNode {
 
   std::string dumpChildLabelInner(int i) const override;
 
-  int8_t targetChildNum_;
-
  public:
 
   /**
@@ -87,14 +94,6 @@ class Continue : public AstNode {
     CHPL_ASSERT(ret->isIdentifier());
     return (const Identifier*)ret;
   }
-
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-    ser.write(targetChildNum_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Continue);
-
 };
 
 

--- a/frontend/include/chpl/uast/Decl.h
+++ b/frontend/include/chpl/uast/Decl.h
@@ -47,7 +47,6 @@ class Decl : public AstNode {
   };
 
  private:
-
   Visibility visibility_;
   Linkage linkage_;
   int linkageNameChildNum_;
@@ -79,11 +78,20 @@ class Decl : public AstNode {
                  linkageNameChildNum_ < (ssize_t)children_.size());
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+
+    ser.write(visibility_);
+    ser.write(linkage_);
+    ser.writeVInt(linkageNameChildNum_);
+  }
+ protected:
   Decl(AstTag tag, Deserializer& des)
     : AstNode(tag, des) {
       visibility_ = des.read<Decl::Visibility>();
       linkage_ = des.read<Decl::Linkage>();
-      linkageNameChildNum_ = (int)des.read<int32_t>();
+      linkageNameChildNum_ = des.readVInt();
   }
 
   bool declContentsMatchInner(const Decl* other) const {
@@ -92,8 +100,7 @@ class Decl : public AstNode {
            this->linkageNameChildNum_ == other->linkageNameChildNum_;
   }
 
-  void declMarkUniqueStringsInner(Context* context) const {
-  }
+  void declMarkUniqueStringsInner(Context* context) const { }
 
   void dumpFieldsInner(const DumpSettings& s) const override;
   std::string dumpChildLabelInner(int i) const override;
@@ -140,15 +147,6 @@ class Decl : public AstNode {
     Convert Decl::Linkage to a string
     */
   static const char* linkageToString(Linkage x);
-
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-
-    ser.write(visibility_);
-    ser.write(linkage_);
-    ser.write((int32_t)linkageNameChildNum_);
-  }
-
 };
 
 

--- a/frontend/include/chpl/uast/Defer.h
+++ b/frontend/include/chpl/uast/Defer.h
@@ -57,8 +57,13 @@ class Defer final : public SimpleBlockLike {
     CHPL_ASSERT(bodyChildNum_ >= 0);
   }
 
-  Defer(Deserializer& des)
-  : SimpleBlockLike(asttags::Defer, des) {}
+ public:
+  void serialize(Serializer& ser) const override {
+    SimpleBlockLike::serialize(ser);
+  }
+  DECLARE_STATIC_DESERIALIZE(Defer);
+ private:
+  Defer(Deserializer& des) : SimpleBlockLike(asttags::Defer, des) { }
 
   bool contentsMatchInner(const AstNode* other) const override {
     return simpleBlockLikeContentsMatchInner(other);
@@ -77,13 +82,6 @@ class Defer final : public SimpleBlockLike {
   static owned<Defer> build(Builder* builder, Location loc,
                             BlockStyle blockStyle,
                             AstList stmts);
-
-  void serialize(Serializer& ser) const override {
-    SimpleBlockLike::serialize(ser);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Defer);
-
 };
 
 

--- a/frontend/include/chpl/uast/Delete.h
+++ b/frontend/include/chpl/uast/Delete.h
@@ -45,8 +45,13 @@ class Delete final : public AstNode {
     : AstNode(asttags::Delete, std::move(children)) {
   }
 
-  Delete(Deserializer& des)
-    : AstNode(asttags::Delete, des) {}
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+  }
+  DECLARE_STATIC_DESERIALIZE(Delete);
+ private:
+  Delete(Deserializer& des) : AstNode(asttags::Delete, des) { }
 
   bool contentsMatchInner(const AstNode* other) const override {
     return true;
@@ -85,14 +90,6 @@ class Delete final : public AstNode {
     const AstNode* ast = this->child(i);
     return ast;
   }
-
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Delete);
-
-
 };
 
 

--- a/frontend/include/chpl/uast/DoWhile.h
+++ b/frontend/include/chpl/uast/DoWhile.h
@@ -46,6 +46,8 @@ namespace uast {
  */
 class DoWhile final : public Loop {
  private:
+  int conditionChildNum_;
+
   DoWhile(AstList children, BlockStyle blockStyle,
           int loopBodyChildNum,
           int conditionChildNum,
@@ -57,11 +59,17 @@ class DoWhile final : public Loop {
       conditionChildNum_(conditionChildNum) {
     CHPL_ASSERT(condition());
   }
-
+ public:
+  void serialize(Serializer& ser) const override {
+    Loop::serialize(ser);
+    ser.writeVInt(conditionChildNum_);
+  }
+  DECLARE_STATIC_DESERIALIZE(DoWhile);
+ private:
   DoWhile(Deserializer& des)
     : Loop(asttags::DoWhile, des) {
-      conditionChildNum_ = des.read<int>();
-    }
+      conditionChildNum_ = des.readVInt();
+  }
 
   bool contentsMatchInner(const AstNode* other) const override {
     const DoWhile* lhs = this;
@@ -81,8 +89,6 @@ class DoWhile final : public Loop {
   }
 
   std::string dumpChildLabelInner(int i) const override;
-
-  int conditionChildNum_;
 
  public:
   ~DoWhile() override = default;
@@ -104,14 +110,6 @@ class DoWhile final : public Loop {
     auto ret = child(conditionChildNum_);
     return ret;
   }
-
-  void serialize(Serializer& ser) const override {
-    Loop::serialize(ser);
-    ser.write(conditionChildNum_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(DoWhile);
-
 };
 
 

--- a/frontend/include/chpl/uast/Domain.h
+++ b/frontend/include/chpl/uast/Domain.h
@@ -49,6 +49,13 @@ class Domain final : public AstNode {
     : AstNode(asttags::Domain, std::move(children)),
       usedCurlyBraces_(usedCurlyBraces) {
   }
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+    ser.write(usedCurlyBraces_);
+  }
+  DECLARE_STATIC_DESERIALIZE(Domain);
+ private:
   Domain(Deserializer& des)
     : AstNode(asttags::Domain, des) {
     usedCurlyBraces_ = des.read<bool>();
@@ -101,14 +108,6 @@ class Domain final : public AstNode {
   bool usedCurlyBraces() const {
     return usedCurlyBraces_;
   }
-
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-    ser.write(usedCurlyBraces_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Domain);
-
 };
 
 

--- a/frontend/include/chpl/uast/Dot.h
+++ b/frontend/include/chpl/uast/Dot.h
@@ -55,10 +55,18 @@ class Dot final : public AstNode {
       fieldName_(fieldName) {
     CHPL_ASSERT(children_.size() == 1);
   }
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+    ser.write(fieldName_);
+  }
+  DECLARE_STATIC_DESERIALIZE(Dot);
+ private:
   Dot(Deserializer& des)
     : AstNode(asttags::Dot, des) {
     fieldName_ = des.read<UniqueString>();
   }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Dot* lhs = this;
     const Dot* rhs = (const Dot*) other;
@@ -90,13 +98,6 @@ class Dot final : public AstNode {
   UniqueString field() const {
     return fieldName_;
   }
-
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-    ser.write(fieldName_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Dot);
 };
 
 

--- a/frontend/include/chpl/uast/EmptyStmt.h
+++ b/frontend/include/chpl/uast/EmptyStmt.h
@@ -42,21 +42,26 @@ namespace uast {
  */
 
 class EmptyStmt final : public AstNode {
-private:
+ private:
   EmptyStmt()
     : AstNode(asttags::EmptyStmt) {
     CHPL_ASSERT(numChildren() == 0);
   }
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+  }
+  DECLARE_STATIC_DESERIALIZE(EmptyStmt);
+ private:
   EmptyStmt(Deserializer& des)
     : AstNode(asttags::EmptyStmt, des) { }
 
-    bool contentsMatchInner(const AstNode* other) const override {
+  bool contentsMatchInner(const AstNode* other) const override {
     const EmptyStmt* rhs = other->toEmptyStmt();
     return rhs != nullptr;
   }
 
-  void markUniqueStringsInner(Context* context) const override {
-  }
+  void markUniqueStringsInner(Context* context) const override { }
 
 public:
   ~EmptyStmt() override = default;
@@ -65,13 +70,6 @@ public:
    Create an EmptyStmt at this location.
   */
   static owned<EmptyStmt> build(Builder* builder, Location loc);
-
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(EmptyStmt);
-
 }; // end EmptyStmt
 
 

--- a/frontend/include/chpl/uast/Enum.h
+++ b/frontend/include/chpl/uast/Enum.h
@@ -63,6 +63,14 @@ class Enum final : public TypeDecl {
     #endif
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    TypeDecl::serialize(ser);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Enum);
+
+ private:
   Enum(Deserializer& des)
     : TypeDecl(asttags::Enum, des) {}
 
@@ -126,13 +134,6 @@ class Enum final : public TypeDecl {
     auto end = begin + numDeclOrComments();
     return AstListNoCommentsIteratorPair<EnumElement>(begin, end);
   }
-
-  void serialize(Serializer& ser) const override {
-    TypeDecl::serialize(ser);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Enum);
-
 };
 
 

--- a/frontend/include/chpl/uast/EnumElement.h
+++ b/frontend/include/chpl/uast/EnumElement.h
@@ -53,8 +53,15 @@ class EnumElement final : public NamedDecl {
     CHPL_ASSERT(children_.size() <= 2);
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    NamedDecl::serialize(ser);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(EnumElement);
+ private:
   EnumElement(Deserializer& des)
-    : NamedDecl(asttags::EnumElement, des) {}
+    : NamedDecl(asttags::EnumElement, des) { }
 
   bool contentsMatchInner(const AstNode* other) const override {
     const EnumElement* lhs = (const EnumElement*) this;
@@ -105,13 +112,6 @@ class EnumElement final : public NamedDecl {
       return nullptr;
     }
   }
-
-  void serialize(Serializer& ser) const override {
-    NamedDecl::serialize(ser);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(EnumElement);
-
 };
 
 

--- a/frontend/include/chpl/uast/ErroneousExpression.h
+++ b/frontend/include/chpl/uast/ErroneousExpression.h
@@ -35,11 +35,17 @@ class ErroneousExpression final : public AstNode {
   ErroneousExpression()
     : AstNode(asttags::ErroneousExpression) {
   }
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(ErroneousExpression);
 
   ErroneousExpression(Deserializer& des)
-    : AstNode(asttags::ErroneousExpression, des) {}
+    : AstNode(asttags::ErroneousExpression, des) { }
 
-
+ private:
   bool contentsMatchInner(const AstNode* other) const override {
     return true;
   }
@@ -49,13 +55,6 @@ class ErroneousExpression final : public AstNode {
  public:
   ~ErroneousExpression() = default;
   static owned<ErroneousExpression> build(Builder* builder, Location loc);
-
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(ErroneousExpression);
-
 };
 
 

--- a/frontend/include/chpl/uast/ExternBlock.h
+++ b/frontend/include/chpl/uast/ExternBlock.h
@@ -55,6 +55,15 @@ class ExternBlock final : public AstNode {
     CHPL_ASSERT(numChildren() == 0);
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+    ser.write(code_);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(ExternBlock);
+
+ private:
   ExternBlock(Deserializer& des)
     : AstNode(asttags::ExternBlock, des) {
       code_ = des.read<std::string>();
@@ -80,14 +89,6 @@ class ExternBlock final : public AstNode {
   const std::string& code() const {
     return code_;
   }
-
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-    ser.write(code_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(ExternBlock);
-
 };
 
 

--- a/frontend/include/chpl/uast/FnCall.h
+++ b/frontend/include/chpl/uast/FnCall.h
@@ -62,6 +62,16 @@ class FnCall : public Call {
       actualNames_(std::move(actualNames)),
       callUsedSquareBrackets_(callUsedSquareBrackets) {
   }
+ public:
+  void serialize(Serializer& ser) const override {
+    Call::serialize(ser);
+    ser.write(actualNames_);
+    ser.write(callUsedSquareBrackets_);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(FnCall);
+
+ private:
   FnCall(Deserializer& des)
     : Call(asttags::FnCall, des) {
     actualNames_ = des.read<std::vector<UniqueString>>();
@@ -134,14 +144,6 @@ class FnCall : public Call {
   bool callUsedSquareBrackets() const {
     return callUsedSquareBrackets_;
   }
-
-  void serialize(Serializer& ser) const override {
-    Call::serialize(ser);
-    ser.write(actualNames_);
-    ser.write(callUsedSquareBrackets_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(FnCall);
 };
 
 

--- a/frontend/include/chpl/uast/For.h
+++ b/frontend/include/chpl/uast/For.h
@@ -64,6 +64,15 @@ class For final : public IndexableLoop {
     CHPL_ASSERT(withClause() == nullptr);
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    IndexableLoop::serialize(ser);
+    ser.write(isParam_);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(For);
+
+ private:
   For(Deserializer& des)
     : IndexableLoop(asttags::For, des) {
     isParam_ = des.read<bool>();
@@ -111,14 +120,6 @@ class For final : public IndexableLoop {
   bool isParam() const {
     return isParam_;
   }
-
-  void serialize(Serializer& ser) const override {
-    IndexableLoop::serialize(ser);
-    ser.write(isParam_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(For);
-
 };
 
 

--- a/frontend/include/chpl/uast/Forall.h
+++ b/frontend/include/chpl/uast/Forall.h
@@ -63,6 +63,14 @@ class Forall final : public IndexableLoop {
                     attributeGroupChildNum) {
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    IndexableLoop::serialize(ser);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Forall);
+
+ private:
   Forall(Deserializer& des)
     : IndexableLoop(asttags::Forall, des) {
   }
@@ -89,13 +97,6 @@ class Forall final : public IndexableLoop {
                              owned<Block> body,
                              bool isExpressionLevel,
                              owned<AttributeGroup> attributeGroup = nullptr);
-
-  void serialize(Serializer& ser) const override {
-    IndexableLoop::serialize(ser);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Forall);
-
 };
 
 

--- a/frontend/include/chpl/uast/Foreach.h
+++ b/frontend/include/chpl/uast/Foreach.h
@@ -63,6 +63,14 @@ class Foreach final : public IndexableLoop {
 
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    IndexableLoop::serialize(ser);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Foreach);
+
+ private:
   Foreach(Deserializer& des)
     : IndexableLoop(asttags::Foreach, des) {}
 
@@ -87,14 +95,6 @@ class Foreach final : public IndexableLoop {
                               BlockStyle blockStyle,
                               owned<Block> body,
                               owned<AttributeGroup> attributeGroup = nullptr);
-
-
-  void serialize(Serializer& ser) const override {
-    IndexableLoop::serialize(ser);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Foreach);
-
 };
 
 

--- a/frontend/include/chpl/uast/Formal.h
+++ b/frontend/include/chpl/uast/Formal.h
@@ -72,6 +72,15 @@ class Formal final : public VarLikeDecl {
                   typeExpressionChildNum,
                   initExpressionChildNum) {
   }
+
+ public:
+  void serialize(Serializer& ser) const override {
+    VarLikeDecl::serialize(ser);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Formal);
+
+ private:
   Formal(Deserializer& des)
     : VarLikeDecl(asttags::Formal, des) {
   }
@@ -113,13 +122,6 @@ class Formal final : public VarLikeDecl {
   inline bool isExplicitlyAnonymous() const {
     return name() == USTR("_");
   }
-
-  void serialize(Serializer& ser) const override {
-    VarLikeDecl::serialize(ser);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Formal);
-
 };
 
 

--- a/frontend/include/chpl/uast/ForwardingDecl.h
+++ b/frontend/include/chpl/uast/ForwardingDecl.h
@@ -56,8 +56,7 @@ namespace uast {
 
 class ForwardingDecl final : public Decl {
 
-
-private:
+ private:
   ForwardingDecl(AstList children, Decl::Visibility visibility,
                  int attributeGroupChildNum)
     : Decl(asttags::ForwardingDecl, std::move(children), attributeGroupChildNum,
@@ -69,6 +68,14 @@ private:
     CHPL_ASSERT(children_.size() >= 0 && children_.size() <= 2);
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    Decl::serialize(ser);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(ForwardingDecl);
+
+ private:
   ForwardingDecl(Deserializer& des)
     : Decl(asttags::ForwardingDecl, des) { }
 
@@ -110,13 +117,6 @@ private:
       return nullptr;
     }
   }
-
-  void serialize(Serializer& ser) const override {
-    Decl::serialize(ser);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(ForwardingDecl);
-
 };
 
 

--- a/frontend/include/chpl/uast/Function.h
+++ b/frontend/include/chpl/uast/Function.h
@@ -166,6 +166,30 @@ class Function final : public NamedDecl {
     #endif
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    NamedDecl::serialize(ser);
+    ser.write(inline_);
+    ser.write(override_);
+    ser.write(kind_);
+    ser.write(returnIntent_);
+    ser.write(throws_);
+    ser.write(primaryMethod_);
+    ser.write(parenless_);
+
+    ser.writeVInt(formalsChildNum_);
+    ser.writeVInt(thisFormalChildNum_);
+    ser.writeVInt(numFormals_);
+    ser.writeVInt(returnTypeChildNum_);
+    ser.writeVInt(whereChildNum_);
+    ser.writeVInt(lifetimeChildNum_);
+    ser.writeVInt(numLifetimeParts_);
+    ser.writeVInt(bodyChildNum_);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Function);
+
+ private:
   Function(Deserializer& des)
     : NamedDecl(asttags::Function, des) {
     inline_        = des.read<bool>();
@@ -176,16 +200,15 @@ class Function final : public NamedDecl {
     primaryMethod_ = des.read<bool>();
     parenless_     = des.read<bool>();
 
-    formalsChildNum_    = (int)des.read<int32_t>();
-    thisFormalChildNum_ = (int)des.read<int32_t>();
-    numFormals_         = (int)des.read<int32_t>();
-    returnTypeChildNum_ = (int)des.read<int32_t>();
-    whereChildNum_      = (int)des.read<int32_t>();
-    lifetimeChildNum_   = (int)des.read<int32_t>();
-    numLifetimeParts_   = (int)des.read<int32_t>();
-    bodyChildNum_       = (int)des.read<int32_t>();
+    formalsChildNum_    = des.readVInt();
+    thisFormalChildNum_ = des.readVInt();
+    numFormals_         = des.readVInt();
+    returnTypeChildNum_ = des.readVInt();
+    whereChildNum_      = des.readVInt();
+    lifetimeChildNum_   = des.readVInt();
+    numLifetimeParts_   = des.readVInt();
+    bodyChildNum_       = des.readVInt();
   }
-
 
   bool contentsMatchInner(const AstNode* other) const override {
     const Function* lhs = this;
@@ -407,28 +430,6 @@ class Function final : public NamedDecl {
   static const char* returnIntentToString(ReturnIntent intent);
 
   static const char* kindToString(Kind kind);
-
-  void serialize(Serializer& ser) const override {
-    NamedDecl::serialize(ser);
-    ser.write(inline_);
-    ser.write(override_);
-    ser.write(kind_);
-    ser.write(returnIntent_);
-    ser.write(throws_);
-    ser.write(primaryMethod_);
-    ser.write(parenless_);
-
-    ser.write<int32_t>(formalsChildNum_);
-    ser.write<int32_t>(thisFormalChildNum_);
-    ser.write<int32_t>(numFormals_);
-    ser.write<int32_t>(returnTypeChildNum_);
-    ser.write<int32_t>(whereChildNum_);
-    ser.write<int32_t>(lifetimeChildNum_);
-    ser.write<int32_t>(numLifetimeParts_);
-    ser.write<int32_t>(bodyChildNum_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Function);
 };
 
 } // end namespace uast

--- a/frontend/include/chpl/uast/FunctionSignature.h
+++ b/frontend/include/chpl/uast/FunctionSignature.h
@@ -86,14 +86,30 @@ class FunctionSignature final : public AstNode {
                  returnTypeChildNum_ < (ssize_t)children_.size());
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+    ser.write(kind_);
+    ser.write(returnIntent_);
+    ser.writeVInt(formalsChildNum_);
+    ser.writeVInt(thisFormalChildNum_);
+    ser.writeVInt(numFormals_);
+    ser.writeVInt(returnTypeChildNum_);
+    ser.write(throws_);
+    ser.write(isParenless_);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(FunctionSignature);
+
+ private:
   FunctionSignature(Deserializer& des)
     : AstNode(asttags::FunctionSignature, des) {
       kind_ = des.read<Kind>();
       returnIntent_ = des.read<ReturnIntent>();
-      formalsChildNum_ = des.read<int>();
-      thisFormalChildNum_ = des.read<int>();
-      numFormals_= des.read<int>();
-      returnTypeChildNum_ = des.read<int>();
+      formalsChildNum_ = des.readVInt();
+      thisFormalChildNum_ = des.readVInt();
+      numFormals_= des.readVInt();
+      returnTypeChildNum_ = des.readVInt();
       throws_ = des.read<bool>();
       isParenless_ = des.read<bool>();
     }
@@ -174,22 +190,8 @@ class FunctionSignature final : public AstNode {
     const AstNode* ret = this->child(returnTypeChildNum_);
     return ret;
   }
-
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-    ser.write(kind_);
-    ser.write(returnIntent_);
-    ser.write(formalsChildNum_);
-    ser.write(thisFormalChildNum_);
-    ser.write(numFormals_);
-    ser.write(returnTypeChildNum_);
-    ser.write(throws_);
-    ser.write(isParenless_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(FunctionSignature);
-
 };
+
 
 } // end namespace uast
 } // end namespace chpl

--- a/frontend/include/chpl/uast/Identifier.h
+++ b/frontend/include/chpl/uast/Identifier.h
@@ -50,11 +50,19 @@ class Identifier final : public AstNode {
     CHPL_ASSERT(!name.isEmpty());
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+    ser.write(name_);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Identifier);
+
+ private:
   Identifier(Deserializer& des)
     : AstNode(asttags::Identifier, des) {
     name_ = des.read<UniqueString>();
   }
-
 
   bool contentsMatchInner(const AstNode* other) const override {
     const Identifier* lhs = this;
@@ -71,13 +79,6 @@ class Identifier final : public AstNode {
   ~Identifier() override = default;
   static owned<Identifier> build(Builder* builder, Location loc, UniqueString name);
   UniqueString name() const { return name_; }
-
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-    ser.write(name_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Identifier);
 };
 
 /*

--- a/frontend/include/chpl/uast/ImagLiteral.h
+++ b/frontend/include/chpl/uast/ImagLiteral.h
@@ -36,6 +36,14 @@ class ImagLiteral final : public NumericLiteral<double, types::RealParam> {
     : NumericLiteral(asttags::ImagLiteral, value, text)
   { }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    NumericLiteral::serialize(ser);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(ImagLiteral);
+
+ private:
   ImagLiteral(Deserializer& des)
     : NumericLiteral(asttags::ImagLiteral, des)
   { }
@@ -48,12 +56,6 @@ class ImagLiteral final : public NumericLiteral<double, types::RealParam> {
 
   static owned<ImagLiteral> build(Builder* builder, Location loc,
                                   double value, UniqueString text);
-
-  void serialize(Serializer& ser) const override {
-    NumericLiteral::serialize(ser);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(ImagLiteral);
 };
 
 

--- a/frontend/include/chpl/uast/Implements.h
+++ b/frontend/include/chpl/uast/Implements.h
@@ -78,11 +78,22 @@ class Implements final : public AstNode {
            interfaceExpr()->isFnCall());
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+    ser.write(typeIdentChildNum_);
+    ser.write(isExpressionLevel_);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Implements);
+
+ private:
   Implements(Deserializer& des)
     : AstNode(asttags::Implements, des) {
       typeIdentChildNum_ = des.read<int8_t>();
       isExpressionLevel_ = des.read<bool>();
-    }
+  }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const Implements* lhs = this;
     const Implements* rhs = (const Implements*) other;
@@ -172,15 +183,6 @@ class Implements final : public AstNode {
                                  owned<Identifier> typeIdent,
                                  owned<AstNode> interfaceExpr,
                                  bool isExpressionLevel);
-
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-    ser.write(typeIdentChildNum_);
-    ser.write(isExpressionLevel_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Implements);
-
 };
 
 

--- a/frontend/include/chpl/uast/Import.h
+++ b/frontend/include/chpl/uast/Import.h
@@ -45,6 +45,8 @@ namespace uast {
 */
 class Import final : public AstNode {
  private:
+  Decl::Visibility visibility_;
+
   Import(AstList children, Decl::Visibility visibility)
     : AstNode(asttags::Import, std::move(children)),
       visibility_(visibility) {
@@ -59,9 +61,19 @@ class Import final : public AstNode {
     #endif
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+    ser.write(visibility_);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Import);
+
+ private:
   Import(Deserializer& des)
-    : AstNode(asttags::Import, des)
-      {visibility_=des.read<Decl::Visibility>();}
+    : AstNode(asttags::Import, des) {
+    visibility_ = des.read<Decl::Visibility>();
+  }
 
   bool contentsMatchInner(const AstNode* other) const override {
     const Import* rhs = other->toImport();
@@ -70,8 +82,6 @@ class Import final : public AstNode {
 
   void markUniqueStringsInner(Context* context) const override {
   }
-
-  Decl::Visibility visibility_;
 
  public:
 
@@ -112,14 +122,6 @@ class Import final : public AstNode {
     CHPL_ASSERT(ret->isVisibilityClause());
     return (const VisibilityClause*)ret;
   }
-
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-    ser.write(visibility_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Import);
-
 };
 
 

--- a/frontend/include/chpl/uast/Include.h
+++ b/frontend/include/chpl/uast/Include.h
@@ -58,13 +58,23 @@ class Include final : public AstNode {
     CHPL_ASSERT(!name_.isEmpty());
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+    ser.write(visibility_);
+    ser.write(isPrototype_);
+    ser.write(name_);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Include);
+
+ private:
   Include(Deserializer& des)
     : AstNode(asttags::Include, des) {
-      visibility_ = des.read<Decl::Visibility>();
-      isPrototype_ = des.read<bool>();
-      name_ = des.read<UniqueString>();
-    }
-
+    visibility_ = des.read<Decl::Visibility>();
+    isPrototype_ = des.read<bool>();
+    name_ = des.read<UniqueString>();
+  }
 
   bool contentsMatchInner(const AstNode* other) const override {
     const Include* lhs = this;
@@ -110,16 +120,6 @@ class Include final : public AstNode {
   UniqueString name() const {
     return name_;
   }
-
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-    ser.write(visibility_);
-    ser.write(isPrototype_);
-    ser.write(name_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Include);
-
 };
 
 

--- a/frontend/include/chpl/uast/IndexableLoop.h
+++ b/frontend/include/chpl/uast/IndexableLoop.h
@@ -34,6 +34,11 @@ namespace uast {
  */
 class IndexableLoop : public Loop {
  protected:
+  int8_t indexChildNum_;
+  int8_t iterandChildNum_;
+  int8_t withClauseChildNum_;
+  bool isExpressionLevel_;
+
   IndexableLoop(AstTag tag, AstList children,
                 int8_t indexChildNum,
                 int8_t iterandChildNum,
@@ -52,6 +57,16 @@ class IndexableLoop : public Loop {
     CHPL_ASSERT(iterandChildNum >= 0);
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    Loop::serialize(ser);
+    ser.write(indexChildNum_);
+    ser.write(iterandChildNum_);
+    ser.write(withClauseChildNum_);
+    ser.write(isExpressionLevel_);
+  }
+
+ protected:
   IndexableLoop(AstTag tag, Deserializer& des)
     : Loop(tag, des) {
     indexChildNum_ = des.read<int8_t>();
@@ -88,11 +103,6 @@ class IndexableLoop : public Loop {
 
   virtual void dumpFieldsInner(const DumpSettings& s) const override;
   virtual std::string dumpChildLabelInner(int i) const override;
-
-  int8_t indexChildNum_;
-  int8_t iterandChildNum_;
-  int8_t withClauseChildNum_;
-  bool isExpressionLevel_;
 
  public:
   virtual ~IndexableLoop() override = 0; // this is an abstract base class
@@ -134,15 +144,6 @@ class IndexableLoop : public Loop {
   bool isExpressionLevel() const {
     return isExpressionLevel_;
   }
-
-  void serialize(Serializer& ser) const override {
-    Loop::serialize(ser);
-    ser.write(indexChildNum_);
-    ser.write(iterandChildNum_);
-    ser.write(withClauseChildNum_);
-    ser.write(isExpressionLevel_);
-  }
-
 };
 
 

--- a/frontend/include/chpl/uast/Init.h
+++ b/frontend/include/chpl/uast/Init.h
@@ -41,12 +41,23 @@ namespace uast {
 */
 class Init : public AstNode {
  private:
+  int8_t targetChildNum_;
+
   Init(AstList children, int8_t targetChildNum)
     : AstNode(asttags::Init, std::move(children)),
       targetChildNum_(targetChildNum) {
     CHPL_ASSERT(numChildren() == 1);
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+    ser.write(targetChildNum_);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Init);
+
+ private:
   Init(Deserializer& des)
    : AstNode(asttags::Init, des) {
     targetChildNum_ = des.read<int8_t>();
@@ -67,8 +78,6 @@ class Init : public AstNode {
 
   std::string dumpChildLabelInner(int i) const override;
 
-  int8_t targetChildNum_;
-
  public:
 
   /**
@@ -87,15 +96,8 @@ class Init : public AstNode {
     CHPL_ASSERT(ret->isIdentifier());
     return (const Identifier*)ret;
   }
-
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-    ser.write(targetChildNum_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Init);
-
 };
+
 
 } // end namespace uast
 } // end namespace chpl

--- a/frontend/include/chpl/uast/IntLiteral.h
+++ b/frontend/include/chpl/uast/IntLiteral.h
@@ -40,6 +40,14 @@ class IntLiteral final : public NumericLiteral<int64_t, types::IntParam> {
     : NumericLiteral(asttags::IntLiteral, value, text)
   { }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    NumericLiteral::serialize(ser);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(IntLiteral);
+
+ private:
   IntLiteral(Deserializer& des)
     : NumericLiteral(asttags::IntLiteral, des)
   { }
@@ -52,12 +60,6 @@ class IntLiteral final : public NumericLiteral<int64_t, types::IntParam> {
 
   static owned<IntLiteral> build(Builder* builder, Location loc,
                                  int64_t value, UniqueString text);
-
-  void serialize(Serializer& ser) const override {
-    NumericLiteral::serialize(ser);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(IntLiteral);
 };
 
 

--- a/frontend/include/chpl/uast/Interface.h
+++ b/frontend/include/chpl/uast/Interface.h
@@ -76,12 +76,25 @@ class Interface final : public NamedDecl {
     // TODO: Some assertions here...
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    NamedDecl::serialize(ser);
+    ser.writeVInt(interfaceFormalsChildNum_);
+    ser.writeVInt(numInterfaceFormals_);
+    ser.writeVInt(bodyChildNum_);
+    ser.writeVInt(numBodyStmts_);
+    ser.write(isFormalListExplicit_);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Interface);
+
+ private:
   Interface(Deserializer& des)
     : NamedDecl(asttags::Interface, des) {
-      interfaceFormalsChildNum_ = des.read<int>();
-      numInterfaceFormals_ = des.read<int>();
-      bodyChildNum_ = des.read<int>();
-      numBodyStmts_ = des.read<int>();
+      interfaceFormalsChildNum_ = des.readVInt();
+      numInterfaceFormals_ = des.readVInt();
+      bodyChildNum_ = des.readVInt();
+      numBodyStmts_ = des.readVInt();
       isFormalListExplicit_ = des.read<bool>();
     }
 
@@ -196,18 +209,6 @@ class Interface final : public NamedDecl {
                                 bool isFormalListExplicit,
                                 AstList formals,
                                 AstList body);
-
-  void serialize(Serializer& ser) const override {
-    NamedDecl::serialize(ser);
-    ser.write(interfaceFormalsChildNum_);
-    ser.write(numInterfaceFormals_);
-    ser.write(bodyChildNum_);
-    ser.write(numBodyStmts_);
-    ser.write(isFormalListExplicit_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Interface);
-
 };
 
 

--- a/frontend/include/chpl/uast/Label.h
+++ b/frontend/include/chpl/uast/Label.h
@@ -50,10 +50,19 @@ class Label final : public AstNode {
     CHPL_ASSERT(numChildren() == 1);
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+    ser.write(name_);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Label);
+
+ private:
   Label(Deserializer& des)
     : AstNode(asttags::Label, des) {
-      name_ = des.read<UniqueString>();
-    }
+    name_ = des.read<UniqueString>();
+  }
 
   bool contentsMatchInner(const AstNode* other) const override {
     const Label* lhs = this;
@@ -101,15 +110,6 @@ class Label final : public AstNode {
   UniqueString name() const {
     return name_;
   }
-
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-    ser.write(name_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Label);
-
-
 };
 
 

--- a/frontend/include/chpl/uast/Let.h
+++ b/frontend/include/chpl/uast/Let.h
@@ -51,10 +51,19 @@ class Let final : public AstNode {
     CHPL_ASSERT(1 <= numDecls && (numDecls == numChildren() - 1));
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+    ser.writeVInt(numDecls_);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Let);
+
+ private:
   Let(Deserializer& des)
     : AstNode(asttags::Let, des) {
-      numDecls_ = des.read<int>();
-    }
+    numDecls_ = des.readVInt();
+  }
 
   bool contentsMatchInner(const AstNode* other) const override {
     const Let* lhs = this;
@@ -111,14 +120,6 @@ class Let final : public AstNode {
     CHPL_ASSERT(ret);
     return ret;
   }
-
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-    ser.write(numDecls_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Let);
-
 };
 
 

--- a/frontend/include/chpl/uast/Literal.h
+++ b/frontend/include/chpl/uast/Literal.h
@@ -41,6 +41,13 @@ class Literal : public AstNode {
     CHPL_ASSERT(value_ != nullptr);
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+    value_->serialize(ser);
+  }
+
+ protected:
   Literal(AstTag tag, Deserializer& des)
     : AstNode(tag, des), value_(types::Param::deserialize(des)) {
     assert(value_ != nullptr);
@@ -61,11 +68,6 @@ class Literal : public AstNode {
    */
   const types::Param* param() const {
     return value_;
-  }
-
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-    value_->serialize(ser);
   }
 };
 

--- a/frontend/include/chpl/uast/Local.h
+++ b/frontend/include/chpl/uast/Local.h
@@ -50,6 +50,8 @@ namespace uast {
  */
 class Local final : public SimpleBlockLike {
  private:
+  int8_t condChildNum_;
+
   Local(AstList children, int8_t condChildNum, BlockStyle blockStyle,
         int bodyChildNum,
         int numBodyStmts)
@@ -59,6 +61,15 @@ class Local final : public SimpleBlockLike {
       condChildNum_(condChildNum) {
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    SimpleBlockLike::serialize(ser);
+    ser.write(condChildNum_);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Local);
+
+ private:
   Local(Deserializer& des)
     : SimpleBlockLike(asttags::Local, des) {
     condChildNum_ = des.read<int8_t>();
@@ -82,8 +93,6 @@ class Local final : public SimpleBlockLike {
   }
 
   std::string dumpChildLabelInner(int i) const override;
-
-  int8_t condChildNum_;
 
  public:
 
@@ -111,14 +120,6 @@ class Local final : public SimpleBlockLike {
   const AstNode* condition() const {
     return condChildNum_ < 0 ? nullptr : child(condChildNum_);
   }
-
-  void serialize(Serializer& ser) const override {
-    SimpleBlockLike::serialize(ser);
-    ser.write(condChildNum_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Local);
-
 };
 
 

--- a/frontend/include/chpl/uast/Loop.h
+++ b/frontend/include/chpl/uast/Loop.h
@@ -34,6 +34,9 @@ namespace uast {
  */
 class Loop: public AstNode {
  protected:
+  BlockStyle blockStyle_;
+  int loopBodyChildNum_;
+
   Loop(asttags::AstTag tag, AstList children, BlockStyle blockStyle,
        int loopBodyChildNum, int attributeGroupChildNum)
     : AstNode(tag, std::move(children), attributeGroupChildNum),
@@ -45,10 +48,18 @@ class Loop: public AstNode {
     CHPL_ASSERT(children_[loopBodyChildNum_]->isBlock());
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+    ser.write(blockStyle_);
+    ser.writeVInt(loopBodyChildNum_);
+  }
+
+ protected:
   Loop(AstTag tag, Deserializer& des)
     : AstNode(tag, des) {
     blockStyle_ = des.read<BlockStyle>();
-    loopBodyChildNum_ = des.read<int>();
+    loopBodyChildNum_ = des.readVInt();
   }
 
   bool loopContentsMatchInner(const Loop* other) const {
@@ -68,9 +79,6 @@ class Loop: public AstNode {
   }
 
   virtual std::string dumpChildLabelInner(int i) const override;
-
-  BlockStyle blockStyle_;
-  int loopBodyChildNum_;
 
  public:
   virtual ~Loop() override = 0; // this is an abstract base class
@@ -109,12 +117,6 @@ class Loop: public AstNode {
   */
   BlockStyle blockStyle() const {
     return blockStyle_;
-  }
-
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-    ser.write(blockStyle_);
-    ser.write(loopBodyChildNum_);
   }
 };
 

--- a/frontend/include/chpl/uast/Manage.h
+++ b/frontend/include/chpl/uast/Manage.h
@@ -67,12 +67,21 @@ class Manage final : public SimpleBlockLike {
     #endif
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    SimpleBlockLike::serialize(ser);
+    ser.writeVInt(managerExprChildNum_);
+    ser.writeVInt(numManagerExprs_);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Manage);
+
+ private:
   Manage(Deserializer& des)
     : SimpleBlockLike(asttags::Manage, des) {
-      managerExprChildNum_ = des.read<int>();
-      numManagerExprs_ = des.read<int>();
-    }
-
+    managerExprChildNum_ = des.readVInt();
+    numManagerExprs_ = des.readVInt();
+  }
 
   bool contentsMatchInner(const AstNode* other) const override {
     const Manage* lhs = this;
@@ -126,15 +135,6 @@ class Manage final : public SimpleBlockLike {
     auto ret = child(managerExprChildNum_ + i);
     return ret;
   }
-
-  void serialize(Serializer& ser) const override {
-    SimpleBlockLike::serialize(ser);
-    ser.write(managerExprChildNum_);
-    ser.write(numManagerExprs_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Manage);
-
 };
 
 

--- a/frontend/include/chpl/uast/Module.h
+++ b/frontend/include/chpl/uast/Module.h
@@ -61,6 +61,15 @@ class Module final : public NamedDecl {
 
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    NamedDecl::serialize(ser);
+    ser.write(kind_);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Module);
+
+ private:
   Module(Deserializer& des)
     : NamedDecl(asttags::Module, des) {
     kind_ = des.read<Kind>();
@@ -130,13 +139,6 @@ class Module final : public NamedDecl {
     Return a string describing a Module::Kind
    */
   static const char* moduleKindToString(Kind kind);
-
-  void serialize(Serializer& ser) const override {
-    NamedDecl::serialize(ser);
-    ser.write(kind_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Module);
 };
 
 

--- a/frontend/include/chpl/uast/MultiDecl.h
+++ b/frontend/include/chpl/uast/MultiDecl.h
@@ -62,6 +62,14 @@ class MultiDecl final : public Decl {
     CHPL_ASSERT(isAcceptableMultiDecl());
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    Decl::serialize(ser);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(MultiDecl);
+
+ private:
   MultiDecl(Deserializer& des)
     : Decl(asttags::MultiDecl, des) { }
 
@@ -128,13 +136,6 @@ class MultiDecl final : public Decl {
     auto end = begin + numDeclOrComments();
     return AstListNoCommentsIteratorPair<Decl>(begin, end);
   }
-
-  void serialize(Serializer& ser) const override {
-    Decl::serialize(ser);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(MultiDecl);
-
 };
 
 

--- a/frontend/include/chpl/uast/NamedDecl.h
+++ b/frontend/include/chpl/uast/NamedDecl.h
@@ -53,11 +53,17 @@ class NamedDecl : public Decl {
       name_(name) {
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    Decl::serialize(ser);
+    ser.write(name_);
+  }
+
+ protected:
   NamedDecl(AstTag tag, Deserializer& des)
     : Decl(tag, des) {
     name_ = des.read<UniqueString>();
   }
-
 
   bool namedDeclContentsMatchInner(const NamedDecl* other) const {
     return this->name_ == other->name_ &&
@@ -72,11 +78,6 @@ class NamedDecl : public Decl {
 
  public:
   virtual ~NamedDecl() = 0; // this is an abstract base class
-
-  void serialize(Serializer& ser) const override {
-    Decl::serialize(ser);
-    ser.write(name_);
-  }
 
   UniqueString name() const { return name_; }
 };

--- a/frontend/include/chpl/uast/New.h
+++ b/frontend/include/chpl/uast/New.h
@@ -52,26 +52,26 @@ class New : public AstNode {
     UNMANAGED
   };
 
-  /**
-    Given a management style, return the Chapel keyword representing it.
-  */
-  static const char* managementToString(Management management);
-
-  /**
-    Given a string, return a management style, or 'DEFAULT_MANAGEMENT' if
-    there was not a match.
-  */
-  static Management stringToManagement(UniqueString ustr);
-
  private:
+  Management management_;
+
   New(AstList children, New::Management management)
     : AstNode(asttags::New, std::move(children)),
       management_(management) {}
 
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+    ser.write(management_);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(New);
+
+ private:
   New(Deserializer& des)
     : AstNode(asttags::New, des) {
-        management_ = des.read<Management>();
-      }
+    management_ = des.read<Management>();
+  }
 
   bool contentsMatchInner(const AstNode* other) const override {
     const New* lhs = this;
@@ -86,8 +86,6 @@ class New : public AstNode {
   }
 
   void dumpFieldsInner(const DumpSettings& s) const override;
-
-  Management management_;
 
  public:
 
@@ -114,13 +112,16 @@ class New : public AstNode {
     return management_;
   }
 
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-    ser.write(management_);
-  }
+  /**
+    Given a management style, return the Chapel keyword representing it.
+  */
+  static const char* managementToString(Management management);
 
-  DECLARE_STATIC_DESERIALIZE(New);
-
+  /**
+    Given a string, return a management style, or 'DEFAULT_MANAGEMENT' if
+    there was not a match.
+  */
+  static Management stringToManagement(UniqueString ustr);
 };
 
 

--- a/frontend/include/chpl/uast/NumericLiteral.h
+++ b/frontend/include/chpl/uast/NumericLiteral.h
@@ -41,6 +41,13 @@ class NumericLiteral : public Literal {
       text_(text)
   { }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    Literal::serialize(ser);
+    ser.write(text_);
+  }
+
+ protected:
   NumericLiteral(AstTag tag, Deserializer& des)
     : Literal(tag, des) {
     text_ = des.read<UniqueString>();
@@ -70,12 +77,6 @@ class NumericLiteral : public Literal {
     const ParamT* p = (const ParamT*) value_;
     return p->value();
   }
-
-  void serialize(Serializer& ser) const override {
-    Literal::serialize(ser);
-    ser.write(text_);
-  }
-
   /**
    Returns the number as it was written in the source code (as a string)
    */
@@ -83,8 +84,8 @@ class NumericLiteral : public Literal {
 };
 
 template <typename ValueT, typename ParamT>
-NumericLiteral<ValueT, ParamT>::~NumericLiteral() {
-}
+NumericLiteral<ValueT, ParamT>::~NumericLiteral() { }
+
 
 } // end namespace uast
 } // end namespace chpl

--- a/frontend/include/chpl/uast/On.h
+++ b/frontend/include/chpl/uast/On.h
@@ -44,6 +44,8 @@ namespace uast {
  */
 class On final : public SimpleBlockLike {
  private:
+  static const int8_t destChildNum_ = 0;
+
   On(AstList children, BlockStyle blockStyle, int bodyChildNum,
      int numBodyStmts)
     : SimpleBlockLike(asttags::On, std::move(children), blockStyle,
@@ -51,6 +53,14 @@ class On final : public SimpleBlockLike {
                       numBodyStmts) {
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    SimpleBlockLike::serialize(ser);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(On);
+
+ private:
   On(Deserializer& des)
     : SimpleBlockLike(asttags::On, des) { }
 
@@ -63,8 +73,6 @@ class On final : public SimpleBlockLike {
   }
 
   std::string dumpChildLabelInner(int i) const override;
-
-  static const int8_t destChildNum_ = 0;
 
  public:
 
@@ -83,13 +91,6 @@ class On final : public SimpleBlockLike {
     auto ret = child(destChildNum_);
     return ret;
   }
-
-  void serialize(Serializer& ser) const override {
-    SimpleBlockLike::serialize(ser);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(On);
-
 };
 
 

--- a/frontend/include/chpl/uast/OpCall.h
+++ b/frontend/include/chpl/uast/OpCall.h
@@ -45,6 +45,16 @@ class OpCall final : public Call {
            /* hasCalledExpression */ false),
       op_(op) {
   }
+
+ public:
+  void serialize(Serializer& ser) const override {
+    Call::serialize(ser);
+    ser.write(op_);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(OpCall);
+
+ private:
   OpCall(Deserializer& des)
     : Call(asttags::OpCall, des) {
     op_ = des.read<UniqueString>();
@@ -87,13 +97,6 @@ class OpCall final : public Call {
   bool isBinaryOp() const { return children_.size() == 2; }
   /** Returns true if this is a unary operator */
   bool isUnaryOp() const { return children_.size() == 1; }
-
-  void serialize(Serializer& ser) const override {
-    Call::serialize(ser);
-    ser.write(op_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(OpCall);
 };
 
 // Returns true if the given string is an operator name

--- a/frontend/include/chpl/uast/PrimCall.h
+++ b/frontend/include/chpl/uast/PrimCall.h
@@ -52,6 +52,16 @@ class PrimCall final : public Call {
            /* hasCalledExpression */ false),
       prim_(prim) {
   }
+
+ public:
+  void serialize(Serializer& ser) const override {
+    Call::serialize(ser);
+    ser.write(prim_);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(PrimCall);
+
+ private:
   PrimCall(Deserializer& des)
     : Call(asttags::PrimCall, des) {
     prim_ = des.read<PrimitiveTag>();
@@ -84,13 +94,6 @@ class PrimCall final : public Call {
 
   /** Returns the enum value of the primitive called */
   PrimitiveTag prim() const { return prim_; }
-
-  void serialize(Serializer& ser) const override {
-    Call::serialize(ser);
-    ser.write(prim_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(PrimCall);
 };
 
 

--- a/frontend/include/chpl/uast/Range.h
+++ b/frontend/include/chpl/uast/Range.h
@@ -47,6 +47,10 @@ class Range final : public AstNode {
   };
 
  private:
+  OpKind opKind_;
+  int8_t lowerBoundChildNum_;
+  int8_t upperBoundChildNum_;
+
   Range(AstList children, OpKind opKind,
         int8_t lowerBoundChildNum,
         int8_t upperBoundChildNum)
@@ -59,6 +63,17 @@ class Range final : public AstNode {
     }
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+    ser.write(opKind_);
+    ser.write(lowerBoundChildNum_);
+    ser.write(upperBoundChildNum_);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Range);
+
+ private:
   Range(Deserializer& des)
     : AstNode(asttags::Range, des) {
     opKind_ = des.read<OpKind>();
@@ -78,10 +93,6 @@ class Range final : public AstNode {
 
   void dumpFieldsInner(const DumpSettings& s) const override;
   std::string dumpChildLabelInner(int i) const override;
-
-  OpKind opKind_;
-  int8_t lowerBoundChildNum_;
-  int8_t upperBoundChildNum_;
 
  public:
   ~Range() override = default;
@@ -123,16 +134,6 @@ class Range final : public AstNode {
     Returns a string describing the passed OpKind
     */
   static const char* opKindToString(OpKind kind);
-
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-    ser.write(opKind_);
-    ser.write(lowerBoundChildNum_);
-    ser.write(upperBoundChildNum_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Range);
-
 };
 
 

--- a/frontend/include/chpl/uast/RealLiteral.h
+++ b/frontend/include/chpl/uast/RealLiteral.h
@@ -37,6 +37,14 @@ class RealLiteral final : public NumericLiteral<double, types::RealParam> {
     : NumericLiteral(asttags::RealLiteral, value, text)
   { }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    NumericLiteral::serialize(ser);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(RealLiteral);
+
+ private:
   RealLiteral(Deserializer& des)
     : NumericLiteral(asttags::RealLiteral, des)
   { }
@@ -49,12 +57,6 @@ class RealLiteral final : public NumericLiteral<double, types::RealParam> {
 
   static owned<RealLiteral> build(Builder* builder, Location loc,
                                   double value, UniqueString text);
-
-  void serialize(Serializer& ser) const override {
-    NumericLiteral::serialize(ser);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(RealLiteral);
 };
 
 

--- a/frontend/include/chpl/uast/Record.h
+++ b/frontend/include/chpl/uast/Record.h
@@ -44,7 +44,6 @@ namespace uast {
  */
 class Record final : public AggregateDecl {
  private:
-
   Record(AstList children, int attributeGroupChildNum, Decl::Visibility vis,
          Decl::Linkage linkage,
          int linkageNameChildNum,
@@ -64,6 +63,14 @@ class Record final : public AggregateDecl {
                     elementsChildNum,
                     numElements) {}
 
+ public:
+  void serialize(Serializer& ser) const override {
+    AggregateDecl::serialize(ser);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Record);
+
+ private:
   Record(Deserializer& des)
     : AggregateDecl(asttags::Record, des) {}
 
@@ -90,11 +97,6 @@ class Record final : public AggregateDecl {
                              UniqueString name,
                              AstList inheritExprs,
                              AstList contents);
-  void serialize(Serializer& ser) const override {
-    AggregateDecl::serialize(ser);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Record);
 };
 
 

--- a/frontend/include/chpl/uast/Reduce.h
+++ b/frontend/include/chpl/uast/Reduce.h
@@ -73,6 +73,14 @@ class Reduce final : public Call {
     CHPL_ASSERT(numChildren() == 2);
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    Call::serialize(ser);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Reduce);
+
+ private:
   Reduce(Deserializer& des)
       : Call(asttags::Reduce, des) { }
 
@@ -113,13 +121,6 @@ class Reduce final : public Call {
   const AstNode* iterand() const {
     return this->child(iterandExprChildNum_);
   }
-
-  void serialize(Serializer& ser) const override {
-    Call::serialize(ser);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Reduce);
-
 };
 
 

--- a/frontend/include/chpl/uast/ReduceIntent.h
+++ b/frontend/include/chpl/uast/ReduceIntent.h
@@ -63,6 +63,14 @@ class ReduceIntent final : public NamedDecl {
     CHPL_ASSERT(numChildren() == 1);
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    NamedDecl::serialize(ser);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(ReduceIntent);
+
+ private:
   ReduceIntent(Deserializer& des)
     : NamedDecl(asttags::ReduceIntent, des) { }
 
@@ -95,13 +103,6 @@ class ReduceIntent final : public NamedDecl {
   const AstNode* op() const {
     return this->child(opChildNum_);
   }
-
-  void serialize(Serializer& ser) const override {
-    NamedDecl::serialize(ser);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(ReduceIntent);
-
 };
 
 

--- a/frontend/include/chpl/uast/Require.h
+++ b/frontend/include/chpl/uast/Require.h
@@ -44,6 +44,14 @@ class Require final : public AstNode {
     : AstNode(asttags::Require, std::move(children)) {
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Require);
+
+ private:
   Require(Deserializer& des)
     : AstNode(asttags::Require, des) { }
 
@@ -85,13 +93,6 @@ class Require final : public AstNode {
     const AstNode* ast = this->child(i);
     return ast;
   }
-
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Require);
-
 };
 
 

--- a/frontend/include/chpl/uast/Return.h
+++ b/frontend/include/chpl/uast/Return.h
@@ -43,11 +43,23 @@ namespace uast {
  */
 class Return final : public AstNode {
  private:
+  int8_t valueChildNum_;
+
   Return(AstList children,  int8_t valueChildNum)
     : AstNode(asttags::Return, std::move(children)),
       valueChildNum_(valueChildNum) {
     CHPL_ASSERT(valueChildNum_ <= 0);
   }
+
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+    ser.write(valueChildNum_);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Return);
+
+ private:
   Return(Deserializer& des)
     : AstNode(asttags::Return, des) {
     valueChildNum_ = des.read<int8_t>();
@@ -65,8 +77,6 @@ class Return final : public AstNode {
 
   void markUniqueStringsInner(Context* context) const override {
   }
-
-  int8_t valueChildNum_;
 
  public:
   ~Return() override = default;
@@ -87,14 +97,6 @@ class Return final : public AstNode {
     auto ret = child(valueChildNum_);
     return ret;
   }
-
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-    ser.write(valueChildNum_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Return);
-
 };
 
 

--- a/frontend/include/chpl/uast/Scan.h
+++ b/frontend/include/chpl/uast/Scan.h
@@ -50,6 +50,14 @@ class Scan final : public Call {
     CHPL_ASSERT(numChildren() == 2);
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    Call::serialize(ser);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Scan);
+
+ private:
   Scan(Deserializer& des)
     : Call(asttags::Scan, des) { }
 
@@ -87,13 +95,6 @@ class Scan final : public Call {
   const AstNode* iterand() const {
     return this->child(iterandChildNum_);
   }
-
-  void serialize(Serializer& ser) const override {
-    Call::serialize(ser);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Scan);
-
 };
 
 

--- a/frontend/include/chpl/uast/Select.h
+++ b/frontend/include/chpl/uast/Select.h
@@ -46,13 +46,28 @@ namespace uast {
  */
 class Select final : public AstNode {
  private:
+  // The position of these never change.
+  static const int8_t exprChildNum_ = 0;
+  static const int8_t whenStmtStartChildNum_ = 1;
+
+  int numWhenStmts_;
+
   Select(AstList children, int numWhenStmts)
     : AstNode(asttags::Select, std::move(children)),
       numWhenStmts_(numWhenStmts) {
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+    ser.writeVInt(numWhenStmts_);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Select);
+
+ private:
   Select(Deserializer& des) : AstNode(asttags::Select, des) {
-    numWhenStmts_ = des.read<int>();
+    numWhenStmts_ = des.readVInt();
   }
 
   bool contentsMatchInner(const AstNode* other) const override {
@@ -64,12 +79,6 @@ class Select final : public AstNode {
   }
 
   std::string dumpChildLabelInner(int i) const override;
-
-  // The position of these never change.
-  static const int8_t exprChildNum_ = 0;
-  static const int8_t whenStmtStartChildNum_ = 1;
-
-  int numWhenStmts_;
 
  public:
 
@@ -115,14 +124,6 @@ class Select final : public AstNode {
     auto end = begin + numWhenStmts_;
     return AstListIteratorPair<When>(begin, end);
   }
-
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-    ser.write(numWhenStmts_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Select);
-
 };
 
 

--- a/frontend/include/chpl/uast/Serial.h
+++ b/frontend/include/chpl/uast/Serial.h
@@ -50,6 +50,8 @@ namespace uast {
  */
 class Serial final : public SimpleBlockLike {
  private:
+  int8_t condChildNum_;
+
   Serial(AstList children, int8_t condChildNum, BlockStyle blockStyle,
          int bodyChildNum,
          int numBodyStmts)
@@ -59,6 +61,15 @@ class Serial final : public SimpleBlockLike {
       condChildNum_(condChildNum) {
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    SimpleBlockLike::serialize(ser);
+    ser.write(condChildNum_);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Serial);
+
+ private:
   Serial(Deserializer& des)
     : SimpleBlockLike(asttags::Serial, des) {
       condChildNum_ = des.read<int8_t>();
@@ -82,8 +93,6 @@ class Serial final : public SimpleBlockLike {
   }
 
   std::string dumpChildLabelInner(int i) const override;
-
-  int8_t condChildNum_;
 
  public:
 
@@ -111,14 +120,6 @@ class Serial final : public SimpleBlockLike {
   const AstNode* condition() const {
     return condChildNum_ < 0 ? nullptr : child(condChildNum_);
   }
-
-  void serialize(Serializer& ser) const override {
-    SimpleBlockLike::serialize(ser);
-    ser.write(condChildNum_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Serial);
-
 };
 
 

--- a/frontend/include/chpl/uast/SimpleBlockLike.h
+++ b/frontend/include/chpl/uast/SimpleBlockLike.h
@@ -47,6 +47,10 @@ namespace uast {
  */
 class SimpleBlockLike : public AstNode {
  protected:
+  BlockStyle blockStyle_;
+  int bodyChildNum_;
+  int numBodyStmts_;
+
   SimpleBlockLike(AstTag tag, AstList children, BlockStyle blockStyle,
                   int bodyChildNum,
                   int numBodyStmts)
@@ -57,13 +61,21 @@ class SimpleBlockLike : public AstNode {
 
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+    ser.write(blockStyle_);
+    ser.writeVInt(bodyChildNum_);
+    ser.writeVInt(numBodyStmts_);
+  }
+
+ protected:
   SimpleBlockLike(AstTag tag, Deserializer& des)
     : AstNode(tag, des) {
     blockStyle_ = des.read<BlockStyle>();
-    bodyChildNum_ = (int)des.read<int32_t>();
-    numBodyStmts_ = (int)des.read<int32_t>();
+    bodyChildNum_ = des.readVInt();
+    numBodyStmts_ = des.readVInt();
   }
-
 
   bool simpleBlockLikeContentsMatchInner(const AstNode* other) const {
     const SimpleBlockLike* lhs = this;
@@ -83,10 +95,6 @@ class SimpleBlockLike : public AstNode {
 
   void simpleBlockLikeMarkUniqueStringsInner(Context* context) const {
   }
-
-  BlockStyle blockStyle_;
-  int bodyChildNum_;
-  int numBodyStmts_;
 
  public:
   virtual ~SimpleBlockLike() override = 0; // this is an abstract base class
@@ -122,14 +130,6 @@ class SimpleBlockLike : public AstNode {
   BlockStyle blockStyle() const {
     return blockStyle_;
   }
-
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-    ser.write(blockStyle_);
-    ser.write<int32_t>(bodyChildNum_);
-    ser.write<int32_t>(numBodyStmts_);
-  }
-
 };
 
 

--- a/frontend/include/chpl/uast/StringLikeLiteral.h
+++ b/frontend/include/chpl/uast/StringLikeLiteral.h
@@ -47,6 +47,13 @@ class StringLikeLiteral : public Literal {
       quotes_(quotes)
   { }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    Literal::serialize(ser);
+    ser.write(quotes_);
+  }
+
+ protected:
   StringLikeLiteral(AstTag tag, Deserializer& des)
     : Literal(tag, des) {
     quotes_ = des.read<QuoteStyle>();
@@ -87,11 +94,6 @@ class StringLikeLiteral : public Literal {
     passed quote style
    */
   static const char* quoteStyleToString(QuoteStyle q);
-
-  void serialize(Serializer& ser) const override {
-    Literal::serialize(ser);
-    ser.write(quotes_);
-  }
 };
 
 

--- a/frontend/include/chpl/uast/Sync.h
+++ b/frontend/include/chpl/uast/Sync.h
@@ -60,6 +60,14 @@ class Sync final : public SimpleBlockLike {
     CHPL_ASSERT(bodyChildNum_ >= 0);
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    SimpleBlockLike::serialize(ser);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Sync);
+
+ private:
   Sync(Deserializer& des)
     : SimpleBlockLike(asttags::Sync, des) { }
 
@@ -80,13 +88,6 @@ class Sync final : public SimpleBlockLike {
   static owned<Sync> build(Builder* builder, Location loc,
                            BlockStyle blockStyle,
                            AstList stmts);
-
-  void serialize(Serializer& ser) const override {
-    SimpleBlockLike::serialize(ser);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Sync);
-
 };
 
 

--- a/frontend/include/chpl/uast/TaskVar.h
+++ b/frontend/include/chpl/uast/TaskVar.h
@@ -73,9 +73,16 @@ class TaskVar final : public VarLikeDecl {
                     initExpressionChildNum) {
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    VarLikeDecl::serialize(ser);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(TaskVar);
+
+ private:
   TaskVar(Deserializer& des)
       : VarLikeDecl(asttags::TaskVar, des) {
-
   }
 
   bool contentsMatchInner(const AstNode* other) const override {
@@ -103,13 +110,6 @@ class TaskVar final : public VarLikeDecl {
     Returns the intent of this task variable.
   */
   Intent intent() const { return (Intent)((int)storageKind()); }
-
-  void serialize(Serializer& ser) const override {
-    VarLikeDecl::serialize(ser);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(TaskVar);
-
 };
 
 // DECLARE_SERDE_ENUM(uast::TaskVar::Intent, uint8_t);

--- a/frontend/include/chpl/uast/Throw.h
+++ b/frontend/include/chpl/uast/Throw.h
@@ -47,6 +47,14 @@ class Throw final : public AstNode {
     CHPL_ASSERT(numChildren() == 1);
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Throw);
+
+ private:
   Throw(Deserializer& des)
     : AstNode(asttags::Throw, des) { }
 
@@ -75,13 +83,6 @@ class Throw final : public AstNode {
     const AstNode* ast = this->child(errorExprChildNum_);
     return ast;
   }
-
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Throw);
-
 };
 
 

--- a/frontend/include/chpl/uast/Try.h
+++ b/frontend/include/chpl/uast/Try.h
@@ -54,6 +54,17 @@ namespace uast {
  */
 class Try final : public AstNode {
  private:
+  // body position is always the same
+  static const int8_t bodyChildNum_ = 0;
+  // try expressions always contain a body expression
+  // try statements always contain a body block
+  static const int8_t numBodyStmts_ = 1;
+
+  int numHandlers_;
+  bool containsBlock_;
+  bool isExpressionLevel_;
+  bool isTryBang_;
+
   Try(AstList children,
       int numHandlers,
       bool containsBlock,
@@ -74,9 +85,21 @@ class Try final : public AstNode {
     }
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+    ser.writeVInt(numHandlers_);
+    ser.write(containsBlock_);
+    ser.write(isExpressionLevel_);
+    ser.write(isTryBang_);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Try);
+
+ private:
   Try(Deserializer& des)
     : AstNode(asttags::Try, des) {
-      numHandlers_ = des.read<int>();
+      numHandlers_ = des.readVInt();
       containsBlock_ = des.read<bool>();
       isExpressionLevel_ = des.read<bool>();
       isTryBang_ = des.read<bool>();
@@ -95,17 +118,6 @@ class Try final : public AstNode {
 
   void dumpFieldsInner(const DumpSettings& s) const override;
   std::string dumpChildLabelInner(int i) const override;
-
-  // body position is always the same
-  static const int8_t bodyChildNum_ = 0;
-  // try expressions always contain a body expression
-  // try statements always contain a body block
-  static const int8_t numBodyStmts_ = 1;
-
-  int numHandlers_;
-  bool containsBlock_;
-  bool isExpressionLevel_;
-  bool isTryBang_;
 
  public:
   ~Try() override = default;
@@ -217,17 +229,6 @@ class Try final : public AstNode {
   bool isTryBang() const {
     return isTryBang_;
   }
-
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-    ser.write(numHandlers_);
-    ser.write(containsBlock_);
-    ser.write(isExpressionLevel_);
-    ser.write(isTryBang_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Try);
-
 };
 
 

--- a/frontend/include/chpl/uast/Tuple.h
+++ b/frontend/include/chpl/uast/Tuple.h
@@ -48,6 +48,14 @@ class Tuple final : public Call {
     CHPL_ASSERT(numChildren() >= 1);
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    Call::serialize(ser);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Tuple);
+
+ private:
   Tuple(Deserializer& des)
     : Call(asttags::Tuple, des) { }
 
@@ -68,13 +76,6 @@ class Tuple final : public Call {
   static owned<Tuple> build(Builder* builder,
                             Location loc,
                             AstList exprs);
-
-  void serialize(Serializer& ser) const override {
-    Call::serialize(ser);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Tuple);
-
 };
 
 

--- a/frontend/include/chpl/uast/TupleDecl.h
+++ b/frontend/include/chpl/uast/TupleDecl.h
@@ -93,13 +93,25 @@ class TupleDecl final : public Decl {
     CHPL_ASSERT(assertAcceptableTupleDecl());
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    Decl::serialize(ser);
+    ser.write(intentOrKind_);
+    ser.writeVInt(numElements_);
+    ser.writeVInt(typeExpressionChildNum_);
+    ser.writeVInt(initExpressionChildNum_);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(TupleDecl);
+
+ private:
   TupleDecl(Deserializer& des)
     : Decl(asttags::TupleDecl, des) {
-      intentOrKind_ = des.read<IntentOrKind>();
-      numElements_ = des.read<int>();
-      typeExpressionChildNum_ = des.read<int>();
-      initExpressionChildNum_ = des.read<int>();
-    }
+    intentOrKind_ = des.read<IntentOrKind>();
+    numElements_ = des.readVInt();
+    typeExpressionChildNum_ = des.readVInt();
+    initExpressionChildNum_ = des.readVInt();
+  }
 
   bool assertAcceptableTupleDecl();
 
@@ -200,17 +212,6 @@ class TupleDecl final : public Decl {
     Returns a string describing the passed intentOrKind.
    */
   static const char* intentOrKindToString(IntentOrKind kind);
-
-  void serialize(Serializer& ser) const override {
-    Decl::serialize(ser);
-    ser.write(intentOrKind_);
-    ser.write(numElements_);
-    ser.write(typeExpressionChildNum_);
-    ser.write(initExpressionChildNum_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(TupleDecl);
-
 };
 
 

--- a/frontend/include/chpl/uast/TypeDecl.h
+++ b/frontend/include/chpl/uast/TypeDecl.h
@@ -43,6 +43,13 @@ class TypeDecl : public NamedDecl {
                 name) {
 
   }
+
+ public:
+  void serialize(Serializer& ser) const override {
+    NamedDecl::serialize(ser);
+  }
+
+ protected:
   TypeDecl(AstTag tag, Deserializer& des)
     : NamedDecl(tag, des) { }
 
@@ -56,10 +63,6 @@ class TypeDecl : public NamedDecl {
 
  public:
   virtual ~TypeDecl() = 0; // this is an abstract base class
-
-  void serialize(Serializer& ser) const override {
-    NamedDecl::serialize(ser);
-  }
 };
 
 

--- a/frontend/include/chpl/uast/TypeQuery.h
+++ b/frontend/include/chpl/uast/TypeQuery.h
@@ -56,6 +56,14 @@ class TypeQuery final : public NamedDecl {
     CHPL_ASSERT(!name.isEmpty() && name.c_str()[0] != '?');
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    NamedDecl::serialize(ser);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(TypeQuery);
+
+ private:
   TypeQuery(Deserializer& des)
     : NamedDecl(asttags::TypeQuery, des) { }
 
@@ -74,12 +82,6 @@ class TypeQuery final : public NamedDecl {
 
   static owned<TypeQuery> build(Builder* builder, Location loc,
                                 UniqueString name);
-
-  void serialize(Serializer& ser) const override {
-    NamedDecl::serialize(ser);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(TypeQuery);
 };
 
 

--- a/frontend/include/chpl/uast/UintLiteral.h
+++ b/frontend/include/chpl/uast/UintLiteral.h
@@ -38,6 +38,14 @@ class UintLiteral final : public NumericLiteral<uint64_t, types::UintParam> {
     : NumericLiteral(asttags::UintLiteral, value, text)
   { }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    NumericLiteral::serialize(ser);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(UintLiteral);
+
+ private:
   UintLiteral(Deserializer& des)
     : NumericLiteral(asttags::UintLiteral, des)
   { }
@@ -50,12 +58,6 @@ class UintLiteral final : public NumericLiteral<uint64_t, types::UintParam> {
 
   static owned<UintLiteral> build(Builder* builder, Location loc,
                                   uint64_t value, UniqueString text);
-
-  void serialize(Serializer& ser) const override {
-    NumericLiteral::serialize(ser);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(UintLiteral);
 };
 
 

--- a/frontend/include/chpl/uast/Union.h
+++ b/frontend/include/chpl/uast/Union.h
@@ -67,6 +67,14 @@ class Union final : public AggregateDecl {
     CHPL_ASSERT(linkage != Decl::EXPORT);
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    AggregateDecl::serialize(ser);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Union);
+
+ private:
   Union(Deserializer& des)
     : AggregateDecl(asttags::Union, des) { }
 
@@ -92,13 +100,6 @@ class Union final : public AggregateDecl {
                             UniqueString name,
                             AstList interfaceExprs,
                             AstList contents);
-
-  void serialize(Serializer& ser) const override {
-    AggregateDecl::serialize(ser);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Union);
-
 };
 
 

--- a/frontend/include/chpl/uast/Use.h
+++ b/frontend/include/chpl/uast/Use.h
@@ -45,6 +45,8 @@ namespace uast {
 */
 class Use final : public AstNode {
  private:
+  Decl::Visibility visibility_;
+
   Use(AstList children, Decl::Visibility visibility)
     : AstNode(asttags::Use, std::move(children)),
       visibility_(visibility) {
@@ -65,6 +67,15 @@ class Use final : public AstNode {
     #endif
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+    ser.write(visibility_);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Use);
+
+ private:
   Use(Deserializer& des) : AstNode(asttags::Use, des) {
     visibility_ = des.read<Decl::Visibility>();
   }
@@ -78,8 +89,6 @@ class Use final : public AstNode {
   }
 
   void dumpFieldsInner(const DumpSettings& s) const override;
-
-  Decl::Visibility visibility_;
 
  public:
 
@@ -120,14 +129,6 @@ class Use final : public AstNode {
     CHPL_ASSERT(ret->isVisibilityClause());
     return (const VisibilityClause*)ret;
   }
-
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-    ser.write(visibility_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Use);
-
 };
 
 

--- a/frontend/include/chpl/uast/VarArgFormal.h
+++ b/frontend/include/chpl/uast/VarArgFormal.h
@@ -64,10 +64,19 @@ class VarArgFormal final : public VarLikeDecl {
       countChildNum_(countChildNum) {
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    VarLikeDecl::serialize(ser);
+    ser.writeVInt(countChildNum_);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(VarArgFormal);
+
+ private:
   VarArgFormal(Deserializer& des)
     : VarLikeDecl(asttags::VarArgFormal, des) {
-      countChildNum_ = des.read<int>();
-    }
+    countChildNum_ = des.readVInt();
+  }
 
   bool contentsMatchInner(const AstNode* other) const override {
     const VarArgFormal* lhs = this;
@@ -112,14 +121,6 @@ class VarArgFormal final : public VarLikeDecl {
     auto ret = child(countChildNum_);
     return ret;
   }
-
-  void serialize(Serializer& ser) const override {
-    VarLikeDecl::serialize(ser);
-    ser.write(countChildNum_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(VarArgFormal);
-
 };
 
 

--- a/frontend/include/chpl/uast/VarLikeDecl.h
+++ b/frontend/include/chpl/uast/VarLikeDecl.h
@@ -64,13 +64,21 @@ class VarLikeDecl : public NamedDecl {
     }
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    NamedDecl::serialize(ser);
+    ser.write(storageKind_);
+    ser.write(typeExpressionChildNum_);
+    ser.write(initExpressionChildNum_);
+  }
+
+ protected:
   VarLikeDecl(AstTag tag, Deserializer& des)
     : NamedDecl(tag, des) {
     storageKind_ = des.read<Qualifier>();
     typeExpressionChildNum_ = des.read<int8_t>();
     initExpressionChildNum_ = des.read<int8_t>();
   }
-
 
   bool varLikeDeclContentsMatchInner(const AstNode* other) const {
     const VarLikeDecl* lhs = this;
@@ -124,13 +132,6 @@ class VarLikeDecl : public NamedDecl {
     } else {
       return nullptr;
     }
-  }
-
-  void serialize(Serializer& ser) const override {
-    NamedDecl::serialize(ser);
-    ser.write(storageKind_);
-    ser.write(typeExpressionChildNum_);
-    ser.write(initExpressionChildNum_);
   }
 };
 

--- a/frontend/include/chpl/uast/Variable.h
+++ b/frontend/include/chpl/uast/Variable.h
@@ -63,6 +63,9 @@ class Variable final : public VarLikeDecl {
   };
 
  private:
+  bool isConfig_;
+  bool isField_;
+
   Variable(AstList children, int attributeGroupChildNum, Decl::Visibility vis,
            Decl::Linkage linkage,
            int linkageNameChildNum,
@@ -85,6 +88,16 @@ class Variable final : public VarLikeDecl {
         isField_(isField) {
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    VarLikeDecl::serialize(ser);
+    ser.write(isConfig_);
+    ser.write(isField_);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Variable);
+
+ private:
   Variable(Deserializer& des)
     : VarLikeDecl(asttags::Variable, des) {
     isConfig_ = des.read<bool>();
@@ -103,9 +116,6 @@ class Variable final : public VarLikeDecl {
   }
 
   void dumpFieldsInner(const DumpSettings& s) const override;
-
-  bool isConfig_;
-  bool isField_;
 
   /**
    * Allows for setting a new initExpr when this Variable is a config
@@ -143,15 +153,6 @@ class Variable final : public VarLikeDecl {
     Returns true if this Variable represents a field.
   */
   bool isField() const { return this->isField_; }
-
-  void serialize(Serializer& ser) const override {
-    VarLikeDecl::serialize(ser);
-    ser.write(isConfig_);
-    ser.write(isField_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Variable);
-
 };
 
 

--- a/frontend/include/chpl/uast/VisibilityClause.h
+++ b/frontend/include/chpl/uast/VisibilityClause.h
@@ -65,6 +65,13 @@ class VisibilityClause final : public AstNode {
   };
 
  private:
+  // These always exist and their position never changes.
+  static const int8_t symbolChildNum_ = 0;
+  static const int8_t limitationChildNum_ = 1;
+
+  LimitationKind limitationKind_;
+  int numLimitations_;
+
   VisibilityClause(AstList children,  LimitationKind limitationKind,
                    int numLimitations)
     : AstNode(asttags::VisibilityClause, std::move(children)),
@@ -79,10 +86,20 @@ class VisibilityClause final : public AstNode {
     }
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+    ser.write(limitationKind_);
+    ser.writeVInt(numLimitations_);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(VisibilityClause);
+
+ private:
   VisibilityClause(Deserializer& des)
     : AstNode(asttags::VisibilityClause, des) {
     limitationKind_ = des.read<LimitationKind>();
-    numLimitations_ = (int)des.read<int32_t>();
+    numLimitations_ = des.readVInt();
   }
 
   // No need to check 'symbolChildNum_' or 'limitationChildNum_'.
@@ -97,13 +114,6 @@ class VisibilityClause final : public AstNode {
 
   void dumpFieldsInner(const DumpSettings& s) const override;
   std::string dumpChildLabelInner(int i) const override;
-
-  // These always exist and their position never changes.
-  static const int8_t symbolChildNum_ = 0;
-  static const int8_t limitationChildNum_ = 1;
-
-  LimitationKind limitationKind_;
-  int numLimitations_;
 
  public:
   ~VisibilityClause() override = default;
@@ -173,15 +183,6 @@ class VisibilityClause final : public AstNode {
     Return a string describing the passed LimitationKind.
    */
   static const char* limitationKindToString(LimitationKind kind);
-
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-    ser.write(limitationKind_);
-    ser.write<int32_t>(numLimitations_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(VisibilityClause);
-
 };
 
 

--- a/frontend/include/chpl/uast/When.h
+++ b/frontend/include/chpl/uast/When.h
@@ -35,6 +35,11 @@ namespace uast {
  */
 class When final : public SimpleBlockLike {
  private:
+  // The position of this never changes.
+  static const int8_t caseExprChildNum_ = 0;
+
+  int numCaseExprs_;
+
   When(AstList children, int numCaseExprs, BlockStyle blockStyle,
        int bodyChildNum,
        int numBodyStmts)
@@ -44,9 +49,18 @@ class When final : public SimpleBlockLike {
       numCaseExprs_(numCaseExprs) {
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    SimpleBlockLike::serialize(ser);
+    ser.writeVInt(numCaseExprs_);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(When);
+
+ private:
   When(Deserializer& des)
     : SimpleBlockLike(asttags::When, des) {
-      numCaseExprs_ = des.read<int>();
+      numCaseExprs_ = des.readVInt();
     }
 
   bool contentsMatchInner(const AstNode* other) const override {
@@ -60,11 +74,6 @@ class When final : public SimpleBlockLike {
   }
   
   void dumpFieldsInner(const DumpSettings& s) const override;
-
-  // The position of this never changes.
-  static const int8_t caseExprChildNum_ = 0;
-
-  int numCaseExprs_;
 
  public:
 
@@ -109,14 +118,6 @@ class When final : public SimpleBlockLike {
   bool isOtherwise() const {
     return numCaseExprs_ == 0;
   }
-
-  void serialize(Serializer& ser) const override {
-    SimpleBlockLike::serialize(ser);
-    ser.write(numCaseExprs_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(When);
-
 };
 
 

--- a/frontend/include/chpl/uast/While.h
+++ b/frontend/include/chpl/uast/While.h
@@ -46,6 +46,8 @@ namespace uast {
  */
 class While final : public Loop {
  private:
+  int8_t conditionChildNum_;
+
   While(AstList children, int8_t conditionChildNum,
         BlockStyle blockStyle,
         int loopBodyChildNum,
@@ -56,6 +58,15 @@ class While final : public Loop {
     CHPL_ASSERT(condition());
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    Loop::serialize(ser);
+    ser.write(conditionChildNum_);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(While);
+
+ private:
   While(Deserializer& des)
     : Loop(asttags::While, des) {
     conditionChildNum_ = des.read<int8_t>();
@@ -80,8 +91,6 @@ class While final : public Loop {
 
   std::string dumpChildLabelInner(int i) const override;
 
-  int8_t conditionChildNum_;
-
  public:
   ~While() override = default;
 
@@ -102,14 +111,6 @@ class While final : public Loop {
     auto ret = child(conditionChildNum_);
     return ret;
   }
-
-  void serialize(Serializer& ser) const override {
-    Loop::serialize(ser);
-    ser.write(conditionChildNum_);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(While);
-
 };
 
 

--- a/frontend/include/chpl/uast/WithClause.h
+++ b/frontend/include/chpl/uast/WithClause.h
@@ -49,6 +49,14 @@ class WithClause final : public AstNode {
     : AstNode(asttags::WithClause, std::move(exprs)) {
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(WithClause);
+
+ private:
   WithClause(Deserializer& des)
     : AstNode(asttags::WithClause, des) { }
 
@@ -89,13 +97,6 @@ class WithClause final : public AstNode {
     const AstNode* ast = this->child(i);
     return ast;
   }
-
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(WithClause);
-
 };
 
 

--- a/frontend/include/chpl/uast/Yield.h
+++ b/frontend/include/chpl/uast/Yield.h
@@ -48,6 +48,14 @@ class Yield final : public AstNode {
     CHPL_ASSERT(children_.size() == 1);
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    AstNode::serialize(ser);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Yield);
+
+ private:
   Yield(Deserializer& des)
     : AstNode(asttags::Yield, des) {
   }
@@ -80,13 +88,6 @@ class Yield final : public AstNode {
     CHPL_ASSERT(ret);
     return ret;
   }
-
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Yield);
-
 };
 
 

--- a/frontend/include/chpl/uast/Zip.h
+++ b/frontend/include/chpl/uast/Zip.h
@@ -37,6 +37,14 @@ class Zip final : public Call {
            /*hasCalledExpression*/ false) {
   }
 
+ public:
+  void serialize(Serializer& ser) const override {
+    Call::serialize(ser);
+  }
+
+  DECLARE_STATIC_DESERIALIZE(Zip);
+
+ private:
   Zip(Deserializer& des)
     : Call(asttags::Zip, des) { }
 
@@ -55,13 +63,6 @@ class Zip final : public Call {
     Create and return a zip expression.
   */
   static owned<Zip> build(Builder* builder, Location loc, AstList actuals);
-
-  void serialize(Serializer& ser) const override {
-    Call::serialize(ser);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(Zip);
-
 };
 
 

--- a/frontend/lib/uast/AstNode.cpp
+++ b/frontend/lib/uast/AstNode.cpp
@@ -546,7 +546,7 @@ void AstNode::stringify(std::ostream& ss,
 
 void AstNode::serialize(Serializer& ser) const {
   ser.write(tag_);
-  ser.write(attributeGroupChildNum_);
+  ser.writeVInt(attributeGroupChildNum_);
   ser.write(id_);
   ser.write(children_);
 }
@@ -555,7 +555,7 @@ AstNode::AstNode(AstTag tag, Deserializer& des)
   : tag_(tag) {
   // Note: Assumes that the tag was already serialized in order to invoke
   // the correct class' deserializer.
-  attributeGroupChildNum_ = (int)des.read<int32_t>();
+  attributeGroupChildNum_ = des.readVInt();
   id_ = des.read<ID>();
   children_ = des.read<AstList>();
 }


### PR DESCRIPTION
Following PR #23696, this PR adjusts the uAST header files to:
 * more consistently store fields first (only after nested type declarations necessary for the fields)
 * include the serializer just after the constructor and just before the deserializing constructor
 * use the new variable-byte encoding / decoding routines to better optimize space

Reviewed by @benharsh - thanks!

- [x] full comm=none testing