### PR TITLE
Fix diags.chpl gpu test (add separate good file for cpu-as-device)

### DIFF
--- a/test/gpu/native/diags.cpu.good
+++ b/test/gpu/native/diags.cpu.good
@@ -1,0 +1,13 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
+Start
+0 (cpu): diags.chpl:nn: allocate xxB of domain(1,int(64),one) at 0xPREDIFFED
+0 (cpu): diags.chpl:nn: allocate xxB of [domain(1,int(64),one)] int(64) at 0xPREDIFFED
+0 (cpu): diags.chpl:nn: allocate xxB of array elements at 0xPREDIFFED
+0 (cpu): diags.chpl:nn: allocate xxB of _EndCount(atomic int(64),int(64)) at 0xPREDIFFED
+0 (cpu): diags.chpl:nn: free xxB of _EndCount(atomic int(64),int(64)) at 0xPREDIFFED
+0 (gpu 0): diags.chpl:nn: allocate xxB of [domain(1,int(64),one)] int(64) at 0xPREDIFFED
+0 (gpu 0): diags.chpl:nn: allocate xxB of array elements at 0xPREDIFFED
+0 (gpu 0): diags.chpl:nn: free xxB of array elements at 0xPREDIFFED
+0 (gpu 0): diags.chpl:nn: free xxB of [domain(1,int(64),one)] int(64) at 0xPREDIFFED
+2 2 2 2 2 2 2 2 2 2
+End

--- a/test/gpu/native/diags.execopts
+++ b/test/gpu/native/diags.execopts
@@ -1,1 +1,7 @@
---memTrack
+#!/usr/bin/env bash
+
+if [[ "$CHPL_GPU" == "cpu" ]]; then
+  echo "--memTrack # diags.cpu.good"
+else
+  echo "--memTrack"
+fi


### PR DESCRIPTION
In a prior PR (https://github.com/chapel-lang/chapel/pull/22592) I, among other things, changed some allocations during kernel launch to use `chpl_mem_alloc` instead of `chpl_malloc`. The effect of this is these allocations are now being reported in our memory diagonstics log when previously they weren't. I updated the `.good` file associated with the `diags.chpl` to account for this but didn't account for the fact that these newly reported allocations won't happen when using cpu-as-device.

In this PR I add a new `.cpu.good` file for when we do cpu-as-device testing and update the `.execopts` file to be a script that will tell start_test to use this new good file when appropriate.