### PR TITLE
Route all setToId calls through validation

### DIFF
--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2659,7 +2659,7 @@ void Resolver::resolveIdentifier(const Identifier* ident,
           builtinId = ct->id();
         }
       }
-      result.setToId(builtinId);
+      validateAndSetToId(result, ident, builtinId);
 
       result.setType(type);
       return;


### PR DESCRIPTION
The 'validateAndSetToId' function is meant to always wrap calls to 'setToId', providing additional checking to make sure that they're valid. There's one call in `Resolver.cpp` that invokes `setToId` without `validateAndSetToId`. This PR corrects the call.

Reviewed by @benharsh -- thanks!

## Testing
- [x] paratest