### PR TITLE
Add a test showing for GPU arrays that are not bound to on lexical scope

### DIFF
--- a/test/gpu/native/basics/outOfOnArr.chpl
+++ b/test/gpu/native/basics/outOfOnArr.chpl
@@ -1,0 +1,34 @@
+use GpuDiagnostics;
+
+config const n = 10;
+
+class ArrWrapperClass {
+  const Dom: domain(?);
+  forwarding var Arr: [Dom] int;
+}
+
+type ArrWrapper = owned ArrWrapperClass?;
+
+startGpuDiagnostics();
+
+var HostArr = new ArrWrapper({1..n});
+var DevArr: HostArr.type; // make sure to not use a generic type
+
+on here.gpus[0] {
+  DevArr = new ArrWrapper({1..n}); // allocates the array on the GPU
+
+  foreach a in DevArr! do
+    a += 1;
+}
+
+on here.gpus[0] {
+  foreach a in DevArr! do
+    a += 1;
+}
+
+HostArr!.Arr = DevArr!.Arr;
+
+writeln(HostArr!.Arr);
+
+stopGpuDiagnostics();
+assertGpuDiags(kernel_launch_aod=3, kernel_launch_um=2, device_to_host=1);

--- a/test/gpu/native/basics/outOfOnArr.good
+++ b/test/gpu/native/basics/outOfOnArr.good
@@ -1,0 +1,2 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
+2 2 2 2 2 2 2 2 2 2


### PR DESCRIPTION
This came up in a meeting where arrays that outlive the scope of an `on` statement was requested. Today, you can achieve that with some class-wrapping. This PR adds a test for that.

An earlier version of this pattern was written by @mppf. However, it was not working at that time. The issue was resolved by @DanilaFe in https://github.com/chapel-lang/chapel/pull/22373.

Test:
- [x] nvidia