### PR TITLE
Adjust uAST serializer to store children after subclass fields

### DIFF
--- a/frontend/include/chpl/uast/AggregateDecl.h
+++ b/frontend/include/chpl/uast/AggregateDecl.h
@@ -42,6 +42,8 @@ namespace uast {
 
  */
 class AggregateDecl : public TypeDecl {
+ friend class AstNode;
+
  private:
   int inheritExprChildNum_;
   int numInheritExprs_;
@@ -67,7 +69,6 @@ class AggregateDecl : public TypeDecl {
 
   std::string aggregateDeclDumpChildLabelInner(int i) const;
 
- public:
   AggregateDecl(AstTag tag, AstList children, int attributeGroupChildNum,
                 Decl::Visibility vis,
                 Decl::Linkage linkage,
@@ -99,8 +100,8 @@ class AggregateDecl : public TypeDecl {
     CHPL_ASSERT(validAggregateChildren(declOrComments()));
   }
 
-  void serialize(Serializer& ser) const override {
-    TypeDecl::serialize(ser);
+  void aggregateDeclSerializeInner(Serializer& ser) const {
+    typeDeclSerializeInner(ser);
     ser.writeVInt(inheritExprChildNum_);
     ser.writeVInt(numInheritExprs_);
     ser.writeVInt(elementsChildNum_);
@@ -117,6 +118,7 @@ class AggregateDecl : public TypeDecl {
 
   ~AggregateDecl() = 0; // this is an abstract base class
 
+ public:
   /**
     Return a way to iterate over the contained Decls and Comments.
    */

--- a/frontend/include/chpl/uast/AnonFormal.h
+++ b/frontend/include/chpl/uast/AnonFormal.h
@@ -63,6 +63,8 @@ namespace uast {
   They also do not carry an initialization expression.
 */
 class AnonFormal final : public AstNode {
+ friend class AstNode;
+
  public:
   using Intent = Formal::Intent;
 
@@ -77,21 +79,16 @@ class AnonFormal final : public AstNode {
       typeExpressionChildNum_(typeExpressionChildNum) {
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
     ser.write(intent_);
     ser.write(typeExpressionChildNum_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(AnonFormal);
-
- private:
-  AnonFormal(Deserializer& des)
+  explicit AnonFormal(Deserializer& des)
     : AstNode(asttags::AnonFormal, des) {
-      intent_ = des.read<Formal::Intent>();
-      typeExpressionChildNum_ = des.read<int8_t>();
-    }
+    intent_ = des.read<Formal::Intent>();
+    typeExpressionChildNum_ = des.read<int8_t>();
+  }
 
   bool contentsMatchInner(const AstNode* other) const override {
     const AnonFormal* lhs = this;
@@ -100,7 +97,7 @@ class AnonFormal final : public AstNode {
            lhs->typeExpressionChildNum_ == rhs->typeExpressionChildNum_;
   }
 
-  void markUniqueStringsInner(Context* context) const override {}
+  void markUniqueStringsInner(Context* context) const override { }
 
   void dumpInner(const DumpSettings& s) const;
 

--- a/frontend/include/chpl/uast/Array.h
+++ b/frontend/include/chpl/uast/Array.h
@@ -41,8 +41,9 @@ namespace uast {
   An array expression will never contain comments.
  */
 class Array final : public AstNode {
- private:
+ friend class AstNode;
 
+ private:
   bool trailingComma_,
        associative_;
   
@@ -52,17 +53,12 @@ class Array final : public AstNode {
     associative_ = associative;
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
     ser.write(trailingComma_);
     ser.write(associative_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Array);
-
- private:
-  Array(Deserializer& des)
+  explicit Array(Deserializer& des)
     : AstNode(asttags::Array, des) {
     trailingComma_ = des.read<bool>();
     associative_ = des.read<bool>();

--- a/frontend/include/chpl/uast/As.h
+++ b/frontend/include/chpl/uast/As.h
@@ -41,25 +41,21 @@ namespace uast {
   \endrst
  */
 class As final : public AstNode {
+ friend class AstNode;
+
  private:
   As(AstList children) : AstNode(asttags::As, std::move(children)) { }
 
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-  }
-  DECLARE_STATIC_DESERIALIZE(As);
+  void serializeInner(Serializer& ser) const override { }
 
- private:
-  As(Deserializer& des) : AstNode(asttags::As, des) { }
+  explicit As(Deserializer& des) : AstNode(asttags::As, des) { }
 
   // No need to match 'symbolChildNum_' or 'renameChildNum_', they are const.
   bool contentsMatchInner(const AstNode* other) const override {
     return true;
   }
 
-  void markUniqueStringsInner(Context* context) const override {
-  }
+  void markUniqueStringsInner(Context* context) const override { }
 
   std::string dumpChildLabelInner(int i) const override;
 

--- a/frontend/include/chpl/uast/AstNode.h
+++ b/frontend/include/chpl/uast/AstNode.h
@@ -79,6 +79,15 @@ class AstNode {
    */
   virtual void markUniqueStringsInner(Context* context) const = 0;
 
+  /**
+   This function needs to be defined by subclasses.
+   It should serialize any fields in the subclasses.
+   It need not concern itself with AstNode's fields, including the children.
+   Note that subclasses also need to provide a constructor
+   accepting AstTag, Deserializer.
+   */
+  virtual void serializeInner(Serializer& os) const = 0;
+
   struct DumpSettings {
     chpl::StringifyKind kind = StringifyKind::DEBUG_DETAIL;
     bool printId = true;
@@ -125,7 +134,13 @@ class AstNode {
     }
   }
 
+  /** To be called by subclasses to set the tag and
+      deserialize the AstNode fields other than the children */
   AstNode(AstTag tag, Deserializer& des);
+
+  /** Completes the deserialization process for an AstNode
+      by deserializing the children. */
+  void deserializeChildren(Deserializer& des);
 
   // Quick way to return an already exhausted iterator.
   template <typename T>
@@ -277,8 +292,7 @@ class AstNode {
   // compute the maximum width of all of the IDs
   int computeMaxIdStringWidth() const;
 
-  virtual void serialize(Serializer& os) const;
-
+  void serialize(Serializer& ser) const;
   static owned<AstNode> deserialize(Deserializer& des);
 
   /// \cond DO_NOT_DOCUMENT
@@ -533,7 +547,7 @@ class AstNode {
 
 template<> struct serialize<uast::AstList> {
   void operator()(Serializer& ser, const uast::AstList& list) {
-    ser.write((uint64_t)list.size());
+    ser.writeVU64(list.size());
     for (const auto& node : list) {
       node->serialize(ser);
     }
@@ -543,7 +557,7 @@ template<> struct serialize<uast::AstList> {
 template<> struct deserialize<uast::AstList> {
   uast::AstList operator()(Deserializer& des) {
     uast::AstList ret;
-    auto len = des.read<uint64_t>();
+    uint64_t len = des.readVU64();
     for (uint64_t i = 0; i < len; i++) {
       ret.push_back(uast::AstNode::deserialize(des));
     }
@@ -586,11 +600,6 @@ AST_LESS(AstNode)
 #undef AST_END_SUBCLASSES
 #undef AST_LESS
 /// \endcond
-
-#define DECLARE_STATIC_DESERIALIZE(NAME) \
-static owned<NAME> deserialize(Deserializer& des) { \
-  return owned<NAME>(new NAME(des)); \
-}
 
 } // end namespace std
 

--- a/frontend/include/chpl/uast/Attribute.h
+++ b/frontend/include/chpl/uast/Attribute.h
@@ -28,6 +28,7 @@ namespace chpl {
 namespace uast {
 
 class Attribute final: public AstNode {
+ friend class AstNode;
 
  private:
   // the attribute name - deprecated or unstable or chpldoc.nodoc, for example
@@ -43,19 +44,13 @@ class Attribute final: public AstNode {
       actualNames_(std::move(actualNames)) {
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-
+  void serializeInner(Serializer& ser) const override {
     ser.write(name_);
     ser.writeVInt(numActuals_);
     ser.write(actualNames_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Attribute);
-
- private:
-  Attribute(Deserializer& des) : AstNode(asttags::Attribute, des) {
+  explicit Attribute(Deserializer& des) : AstNode(asttags::Attribute, des) {
     name_ = des.read<UniqueString>();
     numActuals_ = des.readVInt();
     actualNames_ = des.read<std::vector<UniqueString>>();

--- a/frontend/include/chpl/uast/AttributeGroup.h
+++ b/frontend/include/chpl/uast/AttributeGroup.h
@@ -38,6 +38,8 @@ namespace uast {
   use only) are both examples of attributes.
 */
 class AttributeGroup final : public AstNode {
+ friend class AstNode;
+
  private:
   std::set<PragmaTag> pragmas_;
   bool isDeprecated_;
@@ -108,10 +110,7 @@ class AttributeGroup final : public AstNode {
     CHPL_ASSERT(pragmas_.size() <= NUM_KNOWN_PRAGMAS);
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-
+  void serializeInner(Serializer& ser) const override {
     ser.write(pragmas_);
     ser.write(isDeprecated_);
     ser.write(isUnstable_);
@@ -121,20 +120,16 @@ class AttributeGroup final : public AstNode {
     ser.write(parenfulDeprecationMessage_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(AttributeGroup);
-
- private:
-  AttributeGroup(Deserializer& des)
+  explicit AttributeGroup(Deserializer& des)
     : AstNode(asttags::AttributeGroup, des) {
-      pragmas_ = des.read<std::set<PragmaTag>>();
-      isDeprecated_ = des.read<bool>();
-      isUnstable_ = des.read<bool>();
-      isParenfulDeprecated_ = des.read<bool>();
-      deprecationMessage_ = des.read<UniqueString>();
-      unstableMessage_ = des.read<UniqueString>();
-      parenfulDeprecationMessage_ = des.read<UniqueString>();
-    }
-
+    pragmas_ = des.read<std::set<PragmaTag>>();
+    isDeprecated_ = des.read<bool>();
+    isUnstable_ = des.read<bool>();
+    isParenfulDeprecated_ = des.read<bool>();
+    deprecationMessage_ = des.read<UniqueString>();
+    unstableMessage_ = des.read<UniqueString>();
+    parenfulDeprecationMessage_ = des.read<UniqueString>();
+  }
 
   bool contentsMatchInner(const AstNode* other) const override {
     const AttributeGroup* rhs = (const AttributeGroup*)other;

--- a/frontend/include/chpl/uast/Begin.h
+++ b/frontend/include/chpl/uast/Begin.h
@@ -46,6 +46,8 @@ namespace uast {
 
  */
 class Begin final : public SimpleBlockLike {
+ friend class AstNode;
+
  private:
   int8_t withClauseChildNum_;
 
@@ -58,17 +60,12 @@ class Begin final : public SimpleBlockLike {
       withClauseChildNum_(withClauseChildNum) {
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    SimpleBlockLike::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
     ser.write(withClauseChildNum_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Begin);
-
- private:
-  Begin(Deserializer& des)
-  : SimpleBlockLike(asttags::Begin, des) {
+  explicit Begin(Deserializer& des)
+    : SimpleBlockLike(asttags::Begin, des) {
     withClauseChildNum_ = des.read<int8_t>();
   }
 

--- a/frontend/include/chpl/uast/Block.h
+++ b/frontend/include/chpl/uast/Block.h
@@ -32,6 +32,8 @@ namespace uast {
   This class represents a { } block.
  */
 class Block final : public SimpleBlockLike {
+ friend class AstNode;
+
  private:
   Block(AstList stmts, int bodyChildNum, int numBodyStmts)
     : SimpleBlockLike(asttags::Block, std::move(stmts),
@@ -42,16 +44,11 @@ class Block final : public SimpleBlockLike {
     CHPL_ASSERT(bodyChildNum_ >= 0);
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    SimpleBlockLike::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    simpleBlockLikeSerializeInner(ser);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Block);
-
- private:
-  Block(Deserializer& des)
-    : SimpleBlockLike(asttags::Block, des) { }
+  explicit Block(Deserializer& des) : SimpleBlockLike(asttags::Block, des) { }
 
   bool contentsMatchInner(const AstNode* other) const override {
     return simpleBlockLikeContentsMatchInner(other);

--- a/frontend/include/chpl/uast/BoolLiteral.h
+++ b/frontend/include/chpl/uast/BoolLiteral.h
@@ -32,20 +32,18 @@ namespace uast {
   This class represents a boolean literal.
  */
 class BoolLiteral final : public Literal {
+ friend class AstNode;
+
  private:
   explicit BoolLiteral(const types::BoolParam* value)
     : Literal(asttags::BoolLiteral, value) {
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    Literal::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    literalSerializeInner(ser);
   }
 
-  DECLARE_STATIC_DESERIALIZE(BoolLiteral);
-
- private:
-  BoolLiteral(Deserializer& des)
+  explicit BoolLiteral(Deserializer& des)
     : Literal(asttags::BoolLiteral, des) {
     assert(value_->isBoolParam());
   }

--- a/frontend/include/chpl/uast/BracketLoop.h
+++ b/frontend/include/chpl/uast/BracketLoop.h
@@ -42,6 +42,8 @@ namespace uast {
 
  */
 class BracketLoop final : public IndexableLoop {
+ friend class AstNode;
+
  private:
   BracketLoop(AstList children, int8_t indexChildNum,
               int8_t iterandChildNum,
@@ -60,15 +62,11 @@ class BracketLoop final : public IndexableLoop {
                     attributeGroupChildNum) {
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    IndexableLoop::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    indexableLoopSerializeInner(ser);
   }
 
-  DECLARE_STATIC_DESERIALIZE(BracketLoop);
-
- private:
-  BracketLoop(Deserializer& des)
+  explicit BracketLoop(Deserializer& des)
     : IndexableLoop(asttags::BracketLoop, des) { }
 
   bool contentsMatchInner(const AstNode* other) const override {

--- a/frontend/include/chpl/uast/Break.h
+++ b/frontend/include/chpl/uast/Break.h
@@ -41,6 +41,8 @@ namespace uast {
   \endrst
 */
 class Break : public AstNode {
+ friend class AstNode;
+
  private:
   int8_t targetChildNum_;
 
@@ -50,16 +52,11 @@ class Break : public AstNode {
     CHPL_ASSERT(numChildren() <= 1);
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
     ser.write(targetChildNum_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Break);
-
- private:
-  Break(Deserializer& des)
+  explicit Break(Deserializer& des)
    : AstNode(asttags::Break, des) {
     targetChildNum_ = des.read<int8_t>();
   }

--- a/frontend/include/chpl/uast/BytesLiteral.h
+++ b/frontend/include/chpl/uast/BytesLiteral.h
@@ -33,21 +33,19 @@ namespace uast {
   and `b''' bytes contents here '''`.
  */
 class BytesLiteral final : public StringLikeLiteral {
+ friend class AstNode;
+
  private:
   BytesLiteral(const types::StringParam* value,
                StringLikeLiteral::QuoteStyle quotes)
     : StringLikeLiteral(asttags::BytesLiteral, value, quotes)
   { }
 
- public:
-  void serialize(Serializer& ser) const override {
-    StringLikeLiteral::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    stringLikeLiteralSerializeInner(ser);
   }
 
-  DECLARE_STATIC_DESERIALIZE(BytesLiteral);
-
- private:
-  BytesLiteral(Deserializer& des)
+  explicit BytesLiteral(Deserializer& des)
     : StringLikeLiteral(asttags::BytesLiteral, des)
   { }
 

--- a/frontend/include/chpl/uast/CStringLiteral.h
+++ b/frontend/include/chpl/uast/CStringLiteral.h
@@ -32,19 +32,19 @@ namespace uast {
   This class represents a C string literal, for example `c"hello"`.
  */
 class CStringLiteral final : public StringLikeLiteral {
+ friend class AstNode;
+
  private:
   CStringLiteral(const types::StringParam* value,
                  StringLikeLiteral::QuoteStyle quotes)
     : StringLikeLiteral(asttags::CStringLiteral, value, quotes)
   { }
- public:
-  void serialize(Serializer& ser) const override {
-    StringLikeLiteral::serialize(ser);
+
+  void serializeInner(Serializer& ser) const override {
+    stringLikeLiteralSerializeInner(ser);
   }
 
-  DECLARE_STATIC_DESERIALIZE(CStringLiteral);
- private:
-  CStringLiteral(Deserializer& des)
+  explicit CStringLiteral(Deserializer& des)
     : StringLikeLiteral(asttags::CStringLiteral, des)
   { }
 

--- a/frontend/include/chpl/uast/Call.h
+++ b/frontend/include/chpl/uast/Call.h
@@ -34,8 +34,11 @@ namespace uast {
   are the actuals.
  */
 class Call : public AstNode {
+ friend class AstNode;
+
  protected:
   bool hasCalledExpression_;
+
   Call(AstTag tag)
     : AstNode(tag), hasCalledExpression_(false) {
   }
@@ -43,13 +46,12 @@ class Call : public AstNode {
     : AstNode(tag, std::move(children)),
       hasCalledExpression_(hasCalledExpression) {
   }
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
+
+  void callSerializeInner(Serializer& ser) const {
     ser.write(hasCalledExpression_);
   }
- protected:
-  Call(AstTag tag, Deserializer& des)
+
+  explicit Call(AstTag tag, Deserializer& des)
     : AstNode(tag, des) {
     hasCalledExpression_ = des.read<bool>();
   }

--- a/frontend/include/chpl/uast/Catch.h
+++ b/frontend/include/chpl/uast/Catch.h
@@ -45,6 +45,8 @@ namespace uast {
 
  */
 class Catch final : public AstNode {
+ friend class AstNode;
+
  private:
   int8_t errorChildNum_;
   int8_t bodyChildNum_;
@@ -57,21 +59,18 @@ class Catch final : public AstNode {
       bodyChildNum_(bodyChildNum),
       hasParensAroundError_(hasParensAroundError) {
   }
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
+
+  void serializeInner(Serializer& ser) const override {
     ser.write(errorChildNum_);
     ser.write(bodyChildNum_);
     ser.write(hasParensAroundError_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Catch);
- private:
-  Catch(Deserializer& des)
+  explicit Catch(Deserializer& des)
     : AstNode(asttags::Catch, des) {
-      errorChildNum_ = des.read<int8_t>();
-      bodyChildNum_ = des.read<int8_t>();
-      hasParensAroundError_ = des.read<bool>();
+    errorChildNum_ = des.read<int8_t>();
+    bodyChildNum_ = des.read<int8_t>();
+    hasParensAroundError_ = des.read<bool>();
   }
 
   bool contentsMatchInner(const AstNode* other) const override {

--- a/frontend/include/chpl/uast/Class.h
+++ b/frontend/include/chpl/uast/Class.h
@@ -43,6 +43,8 @@ namespace uast {
   The class itself (MyClass) is represented by a Class AST node.
  */
 class Class final : public AggregateDecl {
+ friend class AstNode;
+
  private:
   Class(AstList children, int attributeGroupChildNum, Decl::Visibility vis,
         UniqueString name,
@@ -61,14 +63,11 @@ class Class final : public AggregateDecl {
                     elementsChildNum,
                     numElements) {}
 
- public:
-  void serialize(Serializer& ser) const override {
-    AggregateDecl::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    aggregateDeclSerializeInner(ser);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Class);
- private:
-  Class(Deserializer& des)
+  explicit Class(Deserializer& des)
     : AggregateDecl(asttags::Class, des) { }
 
   bool contentsMatchInner(const AstNode* other) const override {

--- a/frontend/include/chpl/uast/Cobegin.h
+++ b/frontend/include/chpl/uast/Cobegin.h
@@ -46,6 +46,8 @@ namespace uast {
 
  */
 class Cobegin final : public AstNode {
+ friend class AstNode;
+
  private:
   int8_t withClauseChildNum_;
   int bodyChildNum_;
@@ -59,17 +61,13 @@ class Cobegin final : public AstNode {
       numTaskBodies_(numTaskBodies) {
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
     ser.write(withClauseChildNum_ );
     ser.writeVInt(bodyChildNum_);
     ser.writeVInt(numTaskBodies_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Cobegin);
- private:
-  Cobegin(Deserializer& des) : AstNode(asttags::Cobegin, des) {
+  explicit Cobegin(Deserializer& des) : AstNode(asttags::Cobegin, des) {
     withClauseChildNum_ = des.read<int8_t>();
     bodyChildNum_ = des.readVInt();
     numTaskBodies_ = des.readVInt();

--- a/frontend/include/chpl/uast/Coforall.h
+++ b/frontend/include/chpl/uast/Coforall.h
@@ -44,6 +44,8 @@ namespace uast {
 
  */
 class Coforall final : public IndexableLoop {
+ friend class AstNode;
+
  private:
   Coforall(AstList children, int8_t indexChildNum,
            int8_t iterandChildNum,
@@ -61,14 +63,12 @@ class Coforall final : public IndexableLoop {
                     attributeGroupChildNum) {
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    IndexableLoop::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    indexableLoopSerializeInner(ser);
   }
-  DECLARE_STATIC_DESERIALIZE(Coforall);
 
- private:
-  Coforall(Deserializer& des) : IndexableLoop(asttags::Coforall, des) { }
+  explicit Coforall(Deserializer& des)
+    : IndexableLoop(asttags::Coforall, des) { }
 
   bool contentsMatchInner(const AstNode* other) const override {
     return indexableLoopContentsMatchInner(other->toIndexableLoop());

--- a/frontend/include/chpl/uast/Comment.h
+++ b/frontend/include/chpl/uast/Comment.h
@@ -39,7 +39,8 @@ class Builder;
   are at a statement level will be represented with this type.
  */
 class Comment final : public AstNode {
-  friend Builder;
+ friend class AstNode;
+ friend class Builder;
 
  private:
   std::string comment_;
@@ -48,16 +49,13 @@ class Comment final : public AstNode {
   Comment(std::string s)
     : AstNode(asttags::Comment), comment_(std::move(s)) {
   }
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
+
+  void serializeInner(Serializer& ser) const override {
     ser.write(comment_);
-    ser.write(commentId_);
+    ser.write(commentId_); // TODO: don't serialize comment IDs
   }
 
-  DECLARE_STATIC_DESERIALIZE(Comment);
- private:
-  Comment(Deserializer& des)
+  explicit Comment(Deserializer& des)
     : AstNode(asttags::Comment, des) {
     comment_ = des.read<std::string>();
     commentId_ = des.read<CommentID>();

--- a/frontend/include/chpl/uast/Conditional.h
+++ b/frontend/include/chpl/uast/Conditional.h
@@ -43,6 +43,9 @@ namespace uast {
 
  */
 class Conditional final : public AstNode {
+ friend class AstNode;
+
+ private:
   // Condition always exists, and its position is always the same.
   static const int8_t conditionChildNum_ = 0;
   // Ditto then
@@ -54,7 +57,6 @@ class Conditional final : public AstNode {
   BlockStyle elseBlockStyle_;
   bool isExpressionLevel_;
 
- private:
   Conditional(AstList children,
               BlockStyle thenBlockStyle,
               BlockStyle elseBlockStyle,
@@ -91,17 +93,13 @@ class Conditional final : public AstNode {
     CHPL_ASSERT(thenBodyChildNum_ < (int) children_.size());
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
     ser.write(thenBlockStyle_);
     ser.write(elseBlockStyle_);
     ser.write(isExpressionLevel_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Conditional);
- private:
-  Conditional(Deserializer& des)
+  explicit Conditional(Deserializer& des)
     : AstNode(asttags::Conditional, des) {
     thenBlockStyle_ = des.read<BlockStyle>();
     elseBlockStyle_ = des.read<BlockStyle>();

--- a/frontend/include/chpl/uast/Continue.h
+++ b/frontend/include/chpl/uast/Continue.h
@@ -40,6 +40,8 @@ namespace uast {
   \endrst
 */
 class Continue : public AstNode {
+ friend class AstNode;
+
  private:
   int8_t targetChildNum_;
 
@@ -48,15 +50,12 @@ class Continue : public AstNode {
       targetChildNum_(targetChildNum) {
     CHPL_ASSERT(numChildren() <= 1);
   }
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
+
+  void serializeInner(Serializer& ser) const override {
     ser.write(targetChildNum_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Continue);
- private:
-  Continue(Deserializer& des)
+  explicit Continue(Deserializer& des)
     : AstNode(asttags::Continue, des) {
     targetChildNum_ = des.read<int8_t>();
   }

--- a/frontend/include/chpl/uast/Decl.h
+++ b/frontend/include/chpl/uast/Decl.h
@@ -33,6 +33,8 @@ namespace uast {
   however these declarations might be contained in MultiDecl or TupleDecl.
  */
 class Decl : public AstNode {
+ friend class AstNode;
+
  public:
   enum Visibility {
     DEFAULT_VISIBILITY,
@@ -78,15 +80,12 @@ class Decl : public AstNode {
                  linkageNameChildNum_ < (ssize_t)children_.size());
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-
+  void declSerializeInner(Serializer& ser) const {
     ser.write(visibility_);
     ser.write(linkage_);
     ser.writeVInt(linkageNameChildNum_);
   }
- protected:
+
   Decl(AstTag tag, Deserializer& des)
     : AstNode(tag, des) {
       visibility_ = des.read<Decl::Visibility>();

--- a/frontend/include/chpl/uast/Defer.h
+++ b/frontend/include/chpl/uast/Defer.h
@@ -48,6 +48,8 @@ namespace uast {
   This code will write 'bar' after 'foo' due to use of the defer block.
  */
 class Defer final : public SimpleBlockLike {
+ friend class AstNode;
+
  private:
   Defer(AstList stmts, BlockStyle blockStyle, int bodyChildNum,
         int numBodyStmts)
@@ -57,13 +59,11 @@ class Defer final : public SimpleBlockLike {
     CHPL_ASSERT(bodyChildNum_ >= 0);
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    SimpleBlockLike::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    simpleBlockLikeSerializeInner(ser);
   }
-  DECLARE_STATIC_DESERIALIZE(Defer);
- private:
-  Defer(Deserializer& des) : SimpleBlockLike(asttags::Defer, des) { }
+
+  explicit Defer(Deserializer& des) : SimpleBlockLike(asttags::Defer, des) { }
 
   bool contentsMatchInner(const AstNode* other) const override {
     return simpleBlockLikeContentsMatchInner(other);

--- a/frontend/include/chpl/uast/Delete.h
+++ b/frontend/include/chpl/uast/Delete.h
@@ -40,18 +40,16 @@ namespace uast {
   \endrst
 */
 class Delete final : public AstNode {
+ friend class AstNode;
+
  private:
   Delete(AstList children)
     : AstNode(asttags::Delete, std::move(children)) {
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-  }
-  DECLARE_STATIC_DESERIALIZE(Delete);
- private:
-  Delete(Deserializer& des) : AstNode(asttags::Delete, des) { }
+  void serializeInner(Serializer& ser) const override { }
+
+  explicit Delete(Deserializer& des) : AstNode(asttags::Delete, des) { }
 
   bool contentsMatchInner(const AstNode* other) const override {
     return true;

--- a/frontend/include/chpl/uast/DoWhile.h
+++ b/frontend/include/chpl/uast/DoWhile.h
@@ -45,6 +45,8 @@ namespace uast {
 
  */
 class DoWhile final : public Loop {
+ friend class AstNode;
+
  private:
   int conditionChildNum_;
 
@@ -59,14 +61,13 @@ class DoWhile final : public Loop {
       conditionChildNum_(conditionChildNum) {
     CHPL_ASSERT(condition());
   }
- public:
-  void serialize(Serializer& ser) const override {
-    Loop::serialize(ser);
+
+  void serializeInner(Serializer& ser) const override {
+    loopSerializeInner(ser);
     ser.writeVInt(conditionChildNum_);
   }
-  DECLARE_STATIC_DESERIALIZE(DoWhile);
- private:
-  DoWhile(Deserializer& des)
+
+  explicit DoWhile(Deserializer& des)
     : Loop(asttags::DoWhile, des) {
       conditionChildNum_ = des.readVInt();
   }

--- a/frontend/include/chpl/uast/Domain.h
+++ b/frontend/include/chpl/uast/Domain.h
@@ -41,6 +41,8 @@ namespace uast {
   A domain expression will never contain comments.
  */
 class Domain final : public AstNode {
+ friend class AstNode;
+
  private:
   bool usedCurlyBraces_;
 
@@ -49,14 +51,12 @@ class Domain final : public AstNode {
     : AstNode(asttags::Domain, std::move(children)),
       usedCurlyBraces_(usedCurlyBraces) {
   }
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
+
+  void serializeInner(Serializer& ser) const override {
     ser.write(usedCurlyBraces_);
   }
-  DECLARE_STATIC_DESERIALIZE(Domain);
- private:
-  Domain(Deserializer& des)
+
+  explicit Domain(Deserializer& des)
     : AstNode(asttags::Domain, des) {
     usedCurlyBraces_ = des.read<bool>();
   }

--- a/frontend/include/chpl/uast/Dot.h
+++ b/frontend/include/chpl/uast/Dot.h
@@ -46,23 +46,23 @@ namespace uast {
 
  */
 class Dot final : public AstNode {
+ friend class AstNode;
+
  private:
   // which field
- UniqueString fieldName_;
+  UniqueString fieldName_;
 
   Dot(AstList children, UniqueString fieldName)
     : AstNode(asttags::Dot, std::move(children)),
       fieldName_(fieldName) {
     CHPL_ASSERT(children_.size() == 1);
   }
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
+
+  void serializeInner(Serializer& ser) const override {
     ser.write(fieldName_);
   }
-  DECLARE_STATIC_DESERIALIZE(Dot);
- private:
-  Dot(Deserializer& des)
+
+  explicit Dot(Deserializer& des)
     : AstNode(asttags::Dot, des) {
     fieldName_ = des.read<UniqueString>();
   }

--- a/frontend/include/chpl/uast/EmptyStmt.h
+++ b/frontend/include/chpl/uast/EmptyStmt.h
@@ -42,18 +42,17 @@ namespace uast {
  */
 
 class EmptyStmt final : public AstNode {
+ friend class AstNode;
+
  private:
   EmptyStmt()
     : AstNode(asttags::EmptyStmt) {
     CHPL_ASSERT(numChildren() == 0);
   }
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-  }
-  DECLARE_STATIC_DESERIALIZE(EmptyStmt);
- private:
-  EmptyStmt(Deserializer& des)
+
+  void serializeInner(Serializer& ser) const override { }
+
+  explicit EmptyStmt(Deserializer& des)
     : AstNode(asttags::EmptyStmt, des) { }
 
   bool contentsMatchInner(const AstNode* other) const override {

--- a/frontend/include/chpl/uast/Enum.h
+++ b/frontend/include/chpl/uast/Enum.h
@@ -43,6 +43,8 @@ namespace uast {
   (for a, b, c in the example).
  */
 class Enum final : public TypeDecl {
+ friend class AstNode;
+
  private:
   Enum(AstList children, int attributeGroupChildNum, Decl::Visibility vis,
        UniqueString name)
@@ -63,16 +65,11 @@ class Enum final : public TypeDecl {
     #endif
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    TypeDecl::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    typeDeclSerializeInner(ser);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Enum);
-
- private:
-  Enum(Deserializer& des)
-    : TypeDecl(asttags::Enum, des) {}
+  explicit Enum(Deserializer& des) : TypeDecl(asttags::Enum, des) { }
 
   int declOrCommentChildNum() const {
     return attributeGroup() ? 1 : 0;

--- a/frontend/include/chpl/uast/EnumElement.h
+++ b/frontend/include/chpl/uast/EnumElement.h
@@ -40,6 +40,8 @@ namespace uast {
 
  */
 class EnumElement final : public NamedDecl {
+ friend class AstNode;
+
  private:
   EnumElement(AstList children, int attributeGroupChildNum,
               UniqueString name)
@@ -53,14 +55,11 @@ class EnumElement final : public NamedDecl {
     CHPL_ASSERT(children_.size() <= 2);
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    NamedDecl::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    namedDeclSerializeInner(ser);
   }
 
-  DECLARE_STATIC_DESERIALIZE(EnumElement);
- private:
-  EnumElement(Deserializer& des)
+  explicit EnumElement(Deserializer& des)
     : NamedDecl(asttags::EnumElement, des) { }
 
   bool contentsMatchInner(const AstNode* other) const override {

--- a/frontend/include/chpl/uast/ErroneousExpression.h
+++ b/frontend/include/chpl/uast/ErroneousExpression.h
@@ -31,18 +31,16 @@ namespace uast {
   This class represents some missing AST due to an error.
  */
 class ErroneousExpression final : public AstNode {
+ friend class AstNode;
+
  private:
   ErroneousExpression()
     : AstNode(asttags::ErroneousExpression) {
   }
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-  }
 
-  DECLARE_STATIC_DESERIALIZE(ErroneousExpression);
+  void serializeInner(Serializer& ser) const override { }
 
-  ErroneousExpression(Deserializer& des)
+  explicit ErroneousExpression(Deserializer& des)
     : AstNode(asttags::ErroneousExpression, des) { }
 
  private:

--- a/frontend/include/chpl/uast/ExternBlock.h
+++ b/frontend/include/chpl/uast/ExternBlock.h
@@ -46,6 +46,8 @@ namespace uast {
 
  */
 class ExternBlock final : public AstNode {
+ friend class AstNode;
+
  private:
   std::string code_;
 
@@ -55,19 +57,14 @@ class ExternBlock final : public AstNode {
     CHPL_ASSERT(numChildren() == 0);
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
     ser.write(code_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(ExternBlock);
-
- private:
-  ExternBlock(Deserializer& des)
+  explicit ExternBlock(Deserializer& des)
     : AstNode(asttags::ExternBlock, des) {
-      code_ = des.read<std::string>();
-    }
+    code_ = des.read<std::string>();
+  }
 
   bool contentsMatchInner(const AstNode* other) const override {
     const ExternBlock* rhs = (const ExternBlock*)other;

--- a/frontend/include/chpl/uast/FnCall.h
+++ b/frontend/include/chpl/uast/FnCall.h
@@ -49,6 +49,8 @@ namespace uast {
 
  */
 class FnCall : public Call {
+ friend class AstNode;
+
  private:
   // For each actual (matching Call's actuals), what are the names?
   // if the actual is unnamed, it is the empty string.
@@ -62,21 +64,19 @@ class FnCall : public Call {
       actualNames_(std::move(actualNames)),
       callUsedSquareBrackets_(callUsedSquareBrackets) {
   }
- public:
-  void serialize(Serializer& ser) const override {
-    Call::serialize(ser);
+
+  void serializeInner(Serializer& ser) const override {
+    callSerializeInner(ser);
     ser.write(actualNames_);
     ser.write(callUsedSquareBrackets_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(FnCall);
-
- private:
-  FnCall(Deserializer& des)
+  explicit FnCall(Deserializer& des)
     : Call(asttags::FnCall, des) {
     actualNames_ = des.read<std::vector<UniqueString>>();
     callUsedSquareBrackets_ = des.read<bool>();
   }
+
   bool contentsMatchInner(const AstNode* other) const override {
     const FnCall* lhs = this;
     const FnCall* rhs = (const FnCall*) other;

--- a/frontend/include/chpl/uast/For.h
+++ b/frontend/include/chpl/uast/For.h
@@ -43,6 +43,8 @@ namespace uast {
 
  */
 class For final : public IndexableLoop {
+ friend class AstNode;
+
  private:
   For(AstList children,  int8_t indexChildNum,
       int8_t iterandChildNum,
@@ -64,16 +66,12 @@ class For final : public IndexableLoop {
     CHPL_ASSERT(withClause() == nullptr);
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    IndexableLoop::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    indexableLoopSerializeInner(ser);
     ser.write(isParam_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(For);
-
- private:
-  For(Deserializer& des)
+  explicit For(Deserializer& des)
     : IndexableLoop(asttags::For, des) {
     isParam_ = des.read<bool>();
   }

--- a/frontend/include/chpl/uast/Forall.h
+++ b/frontend/include/chpl/uast/Forall.h
@@ -45,6 +45,8 @@ namespace uast {
 
  */
 class Forall final : public IndexableLoop {
+ friend class AstNode;
+
  private:
   Forall(AstList children, int8_t indexChildNum,
          int8_t iterandChildNum,
@@ -63,17 +65,11 @@ class Forall final : public IndexableLoop {
                     attributeGroupChildNum) {
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    IndexableLoop::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    indexableLoopSerializeInner(ser);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Forall);
-
- private:
-  Forall(Deserializer& des)
-    : IndexableLoop(asttags::Forall, des) {
-  }
+  explicit Forall(Deserializer& des) : IndexableLoop(asttags::Forall, des) { }
 
   bool contentsMatchInner(const AstNode* other) const override {
     return indexableLoopContentsMatchInner(other->toIndexableLoop());

--- a/frontend/include/chpl/uast/Foreach.h
+++ b/frontend/include/chpl/uast/Foreach.h
@@ -45,6 +45,8 @@ namespace uast {
 
  */
 class Foreach final : public IndexableLoop {
+ friend class AstNode;
+
  private:
   Foreach(AstList children, int8_t indexChildNum,
           int8_t iterandChildNum,
@@ -63,16 +65,11 @@ class Foreach final : public IndexableLoop {
 
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    IndexableLoop::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    indexableLoopSerializeInner(ser);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Foreach);
-
- private:
-  Foreach(Deserializer& des)
-    : IndexableLoop(asttags::Foreach, des) {}
+  explicit Foreach(Deserializer& des) : IndexableLoop(asttags::Foreach, des) { }
 
   bool contentsMatchInner(const AstNode* other) const override {
     return indexableLoopContentsMatchInner(other->toIndexableLoop());

--- a/frontend/include/chpl/uast/Formal.h
+++ b/frontend/include/chpl/uast/Formal.h
@@ -42,6 +42,8 @@ namespace uast {
   The Formals are stored inside of a Function.
  */
 class Formal final : public VarLikeDecl {
+ friend class AstNode;
+
  public:
   enum Intent {
     // Use Qualifier here for consistent enum values.
@@ -73,15 +75,11 @@ class Formal final : public VarLikeDecl {
                   initExpressionChildNum) {
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    VarLikeDecl::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    varLikeDeclSerializeInner(ser);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Formal);
-
- private:
-  Formal(Deserializer& des)
+  explicit Formal(Deserializer& des)
     : VarLikeDecl(asttags::Formal, des) {
   }
 

--- a/frontend/include/chpl/uast/ForwardingDecl.h
+++ b/frontend/include/chpl/uast/ForwardingDecl.h
@@ -55,6 +55,7 @@ namespace uast {
 */
 
 class ForwardingDecl final : public Decl {
+ friend class AstNode;
 
  private:
   ForwardingDecl(AstList children, Decl::Visibility visibility,
@@ -68,16 +69,13 @@ class ForwardingDecl final : public Decl {
     CHPL_ASSERT(children_.size() >= 0 && children_.size() <= 2);
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    Decl::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    declSerializeInner(ser);
   }
 
-  DECLARE_STATIC_DESERIALIZE(ForwardingDecl);
-
- private:
-  ForwardingDecl(Deserializer& des)
-    : Decl(asttags::ForwardingDecl, des) { }
+  explicit ForwardingDecl(Deserializer& des)
+    : Decl(asttags::ForwardingDecl, des) {
+  }
 
   bool contentsMatchInner(const AstNode* other) const override {
     const ForwardingDecl* lhs = (const ForwardingDecl*) this;

--- a/frontend/include/chpl/uast/Function.h
+++ b/frontend/include/chpl/uast/Function.h
@@ -48,6 +48,8 @@ namespace uast {
   each of these is a Function.
  */
 class Function final : public NamedDecl {
+ friend class AstNode;
+
  public:
   enum Kind {
     PROC,
@@ -166,9 +168,8 @@ class Function final : public NamedDecl {
     #endif
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    NamedDecl::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    namedDeclSerializeInner(ser);
     ser.write(inline_);
     ser.write(override_);
     ser.write(kind_);
@@ -187,10 +188,7 @@ class Function final : public NamedDecl {
     ser.writeVInt(bodyChildNum_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Function);
-
- private:
-  Function(Deserializer& des)
+  explicit Function(Deserializer& des)
     : NamedDecl(asttags::Function, des) {
     inline_        = des.read<bool>();
     override_      = des.read<bool>();

--- a/frontend/include/chpl/uast/FunctionSignature.h
+++ b/frontend/include/chpl/uast/FunctionSignature.h
@@ -44,6 +44,8 @@ namespace uast {
   that takes two ints and returns an int.
 */
 class FunctionSignature final : public AstNode {
+ friend class AstNode;
+
  public:
   using ReturnIntent = Function::ReturnIntent;
   using Kind = Function::Kind;
@@ -86,9 +88,7 @@ class FunctionSignature final : public AstNode {
                  returnTypeChildNum_ < (ssize_t)children_.size());
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
     ser.write(kind_);
     ser.write(returnIntent_);
     ser.writeVInt(formalsChildNum_);
@@ -99,10 +99,7 @@ class FunctionSignature final : public AstNode {
     ser.write(isParenless_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(FunctionSignature);
-
- private:
-  FunctionSignature(Deserializer& des)
+  explicit FunctionSignature(Deserializer& des)
     : AstNode(asttags::FunctionSignature, des) {
       kind_ = des.read<Kind>();
       returnIntent_ = des.read<ReturnIntent>();

--- a/frontend/include/chpl/uast/Identifier.h
+++ b/frontend/include/chpl/uast/Identifier.h
@@ -40,6 +40,7 @@ namespace uast {
   \endrst
  */
 class Identifier final : public AstNode {
+ friend class AstNode;
 
  private:
   UniqueString name_;
@@ -50,16 +51,11 @@ class Identifier final : public AstNode {
     CHPL_ASSERT(!name.isEmpty());
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
     ser.write(name_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Identifier);
-
- private:
-  Identifier(Deserializer& des)
+  explicit Identifier(Deserializer& des)
     : AstNode(asttags::Identifier, des) {
     name_ = des.read<UniqueString>();
   }

--- a/frontend/include/chpl/uast/ImagLiteral.h
+++ b/frontend/include/chpl/uast/ImagLiteral.h
@@ -31,20 +31,18 @@ namespace uast {
   This class represents an imaginary floating point literal, e.g. ``10.4i``.
  */
 class ImagLiteral final : public NumericLiteral<double, types::RealParam> {
+ friend class AstNode;
+
  private:
   ImagLiteral(const types::RealParam* value, UniqueString text)
     : NumericLiteral(asttags::ImagLiteral, value, text)
   { }
 
- public:
-  void serialize(Serializer& ser) const override {
-    NumericLiteral::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    numericLiteralSerializeInner(ser);
   }
 
-  DECLARE_STATIC_DESERIALIZE(ImagLiteral);
-
- private:
-  ImagLiteral(Deserializer& des)
+  explicit ImagLiteral(Deserializer& des)
     : NumericLiteral(asttags::ImagLiteral, des)
   { }
 

--- a/frontend/include/chpl/uast/Implements.h
+++ b/frontend/include/chpl/uast/Implements.h
@@ -46,6 +46,8 @@ namespace uast {
   interface 'Foo(A, B)'.
 */
 class Implements final : public AstNode {
+ friend class AstNode;
+
  private:
   int8_t typeIdentChildNum_;
   bool isExpressionLevel_;
@@ -78,17 +80,12 @@ class Implements final : public AstNode {
            interfaceExpr()->isFnCall());
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
     ser.write(typeIdentChildNum_);
     ser.write(isExpressionLevel_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Implements);
-
- private:
-  Implements(Deserializer& des)
+  explicit Implements(Deserializer& des)
     : AstNode(asttags::Implements, des) {
       typeIdentChildNum_ = des.read<int8_t>();
       isExpressionLevel_ = des.read<bool>();

--- a/frontend/include/chpl/uast/Import.h
+++ b/frontend/include/chpl/uast/Import.h
@@ -44,6 +44,8 @@ namespace uast {
   and 'Bar as A'.
 */
 class Import final : public AstNode {
+ friend class AstNode;
+
  private:
   Decl::Visibility visibility_;
 
@@ -61,16 +63,11 @@ class Import final : public AstNode {
     #endif
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
     ser.write(visibility_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Import);
-
- private:
-  Import(Deserializer& des)
+  explicit Import(Deserializer& des)
     : AstNode(asttags::Import, des) {
     visibility_ = des.read<Decl::Visibility>();
   }

--- a/frontend/include/chpl/uast/Include.h
+++ b/frontend/include/chpl/uast/Include.h
@@ -45,6 +45,8 @@ namespace uast {
   visible within the module Foo.
 */
 class Include final : public AstNode {
+ friend class AstNode;
+
  private:
   Decl::Visibility visibility_;
   bool isPrototype_;
@@ -58,18 +60,13 @@ class Include final : public AstNode {
     CHPL_ASSERT(!name_.isEmpty());
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
     ser.write(visibility_);
     ser.write(isPrototype_);
     ser.write(name_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Include);
-
- private:
-  Include(Deserializer& des)
+  explicit Include(Deserializer& des)
     : AstNode(asttags::Include, des) {
     visibility_ = des.read<Decl::Visibility>();
     isPrototype_ = des.read<bool>();

--- a/frontend/include/chpl/uast/IndexableLoop.h
+++ b/frontend/include/chpl/uast/IndexableLoop.h
@@ -33,6 +33,8 @@ namespace uast {
   This abstract class represents an indexable loop.
  */
 class IndexableLoop : public Loop {
+ friend class AstNode;
+
  protected:
   int8_t indexChildNum_;
   int8_t iterandChildNum_;
@@ -57,17 +59,15 @@ class IndexableLoop : public Loop {
     CHPL_ASSERT(iterandChildNum >= 0);
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    Loop::serialize(ser);
+  void indexableLoopSerializeInner(Serializer& ser) const {
+    loopSerializeInner(ser);
     ser.write(indexChildNum_);
     ser.write(iterandChildNum_);
     ser.write(withClauseChildNum_);
     ser.write(isExpressionLevel_);
   }
 
- protected:
-  IndexableLoop(AstTag tag, Deserializer& des)
+  explicit IndexableLoop(AstTag tag, Deserializer& des)
     : Loop(tag, des) {
     indexChildNum_ = des.read<int8_t>();
     iterandChildNum_ = des.read<int8_t>();

--- a/frontend/include/chpl/uast/Init.h
+++ b/frontend/include/chpl/uast/Init.h
@@ -40,6 +40,8 @@ namespace uast {
   \endrst
 */
 class Init : public AstNode {
+ friend class AstNode;
+
  private:
   int8_t targetChildNum_;
 
@@ -49,16 +51,11 @@ class Init : public AstNode {
     CHPL_ASSERT(numChildren() == 1);
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
     ser.write(targetChildNum_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Init);
-
- private:
-  Init(Deserializer& des)
+  explicit Init(Deserializer& des)
    : AstNode(asttags::Init, des) {
     targetChildNum_ = des.read<int8_t>();
   }

--- a/frontend/include/chpl/uast/IntLiteral.h
+++ b/frontend/include/chpl/uast/IntLiteral.h
@@ -35,20 +35,18 @@ namespace uast {
   by applying the unary `-` operator.
  */
 class IntLiteral final : public NumericLiteral<int64_t, types::IntParam> {
+ friend class AstNode;
+
  private:
   IntLiteral(const types::IntParam* value, UniqueString text)
     : NumericLiteral(asttags::IntLiteral, value, text)
   { }
 
- public:
-  void serialize(Serializer& ser) const override {
-    NumericLiteral::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    numericLiteralSerializeInner(ser);
   }
 
-  DECLARE_STATIC_DESERIALIZE(IntLiteral);
-
- private:
-  IntLiteral(Deserializer& des)
+  explicit IntLiteral(Deserializer& des)
     : NumericLiteral(asttags::IntLiteral, des)
   { }
 

--- a/frontend/include/chpl/uast/Interface.h
+++ b/frontend/include/chpl/uast/Interface.h
@@ -46,6 +46,8 @@ namespace uast {
   The interface body contains one required function named '=='.
 */
 class Interface final : public NamedDecl {
+ friend class AstNode;
+
  private:
   int interfaceFormalsChildNum_;
   int numInterfaceFormals_;
@@ -76,9 +78,8 @@ class Interface final : public NamedDecl {
     // TODO: Some assertions here...
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    NamedDecl::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    namedDeclSerializeInner(ser);
     ser.writeVInt(interfaceFormalsChildNum_);
     ser.writeVInt(numInterfaceFormals_);
     ser.writeVInt(bodyChildNum_);
@@ -86,10 +87,7 @@ class Interface final : public NamedDecl {
     ser.write(isFormalListExplicit_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Interface);
-
- private:
-  Interface(Deserializer& des)
+  explicit Interface(Deserializer& des)
     : NamedDecl(asttags::Interface, des) {
       interfaceFormalsChildNum_ = des.readVInt();
       numInterfaceFormals_ = des.readVInt();

--- a/frontend/include/chpl/uast/Label.h
+++ b/frontend/include/chpl/uast/Label.h
@@ -43,6 +43,8 @@ namespace uast {
 
 */
 class Label final : public AstNode {
+ friend class AstNode;
+
  private:
   Label(AstList children, UniqueString name)
     : AstNode(asttags::Label, std::move(children)),
@@ -50,16 +52,11 @@ class Label final : public AstNode {
     CHPL_ASSERT(numChildren() == 1);
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
     ser.write(name_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Label);
-
- private:
-  Label(Deserializer& des)
+  explicit Label(Deserializer& des)
     : AstNode(asttags::Label, des) {
     name_ = des.read<UniqueString>();
   }

--- a/frontend/include/chpl/uast/Let.h
+++ b/frontend/include/chpl/uast/Let.h
@@ -41,6 +41,8 @@ namespace uast {
 
  */
 class Let final : public AstNode {
+ friend class AstNode;
+
  private:
   int numDecls_;
 
@@ -51,16 +53,11 @@ class Let final : public AstNode {
     CHPL_ASSERT(1 <= numDecls && (numDecls == numChildren() - 1));
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
     ser.writeVInt(numDecls_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Let);
-
- private:
-  Let(Deserializer& des)
+  explicit Let(Deserializer& des)
     : AstNode(asttags::Let, des) {
     numDecls_ = des.readVInt();
   }

--- a/frontend/include/chpl/uast/Literal.h
+++ b/frontend/include/chpl/uast/Literal.h
@@ -32,6 +32,8 @@ namespace uast {
   Literals are fixed values in the source code, like 1, 30.24, and "x".
  */
 class Literal : public AstNode {
+ friend class AstNode;
+
  protected:
   const types::Param* value_ = nullptr;
 
@@ -41,13 +43,10 @@ class Literal : public AstNode {
     CHPL_ASSERT(value_ != nullptr);
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
+  void literalSerializeInner(Serializer& ser) const {
     value_->serialize(ser);
   }
 
- protected:
   Literal(AstTag tag, Deserializer& des)
     : AstNode(tag, des), value_(types::Param::deserialize(des)) {
     assert(value_ != nullptr);

--- a/frontend/include/chpl/uast/Local.h
+++ b/frontend/include/chpl/uast/Local.h
@@ -49,6 +49,8 @@ namespace uast {
 
  */
 class Local final : public SimpleBlockLike {
+ friend class AstNode;
+
  private:
   int8_t condChildNum_;
 
@@ -61,16 +63,12 @@ class Local final : public SimpleBlockLike {
       condChildNum_(condChildNum) {
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    SimpleBlockLike::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    simpleBlockLikeSerializeInner(ser);
     ser.write(condChildNum_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Local);
-
- private:
-  Local(Deserializer& des)
+  explicit Local(Deserializer& des)
     : SimpleBlockLike(asttags::Local, des) {
     condChildNum_ = des.read<int8_t>();
   }

--- a/frontend/include/chpl/uast/Loop.h
+++ b/frontend/include/chpl/uast/Loop.h
@@ -33,6 +33,8 @@ namespace uast {
   This abstract class represents some sort of loop.
  */
 class Loop: public AstNode {
+ friend class AstNode;
+
  protected:
   BlockStyle blockStyle_;
   int loopBodyChildNum_;
@@ -48,14 +50,11 @@ class Loop: public AstNode {
     CHPL_ASSERT(children_[loopBodyChildNum_]->isBlock());
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
+  void loopSerializeInner(Serializer& ser) const {
     ser.write(blockStyle_);
     ser.writeVInt(loopBodyChildNum_);
   }
 
- protected:
   Loop(AstTag tag, Deserializer& des)
     : AstNode(tag, des) {
     blockStyle_ = des.read<BlockStyle>();

--- a/frontend/include/chpl/uast/Manage.h
+++ b/frontend/include/chpl/uast/Manage.h
@@ -44,6 +44,8 @@ namespace uast {
   that can be referred to as 'res'.
  */
 class Manage final : public SimpleBlockLike {
+ friend class AstNode;
+
  private:
   int managerExprChildNum_;
   int numManagerExprs_;
@@ -67,17 +69,13 @@ class Manage final : public SimpleBlockLike {
     #endif
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    SimpleBlockLike::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    simpleBlockLikeSerializeInner(ser);
     ser.writeVInt(managerExprChildNum_);
     ser.writeVInt(numManagerExprs_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Manage);
-
- private:
-  Manage(Deserializer& des)
+  explicit Manage(Deserializer& des)
     : SimpleBlockLike(asttags::Manage, des) {
     managerExprChildNum_ = des.readVInt();
     numManagerExprs_ = des.readVInt();

--- a/frontend/include/chpl/uast/Module.h
+++ b/frontend/include/chpl/uast/Module.h
@@ -39,6 +39,8 @@ namespace uast {
   is a declaration for a module named M.
  */
 class Module final : public NamedDecl {
+ friend class AstNode;
+
  public:
   enum Kind {
     DEFAULT_MODULE_KIND,
@@ -61,16 +63,12 @@ class Module final : public NamedDecl {
 
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    NamedDecl::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    namedDeclSerializeInner(ser);
     ser.write(kind_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Module);
-
- private:
-  Module(Deserializer& des)
+  explicit Module(Deserializer& des)
     : NamedDecl(asttags::Module, des) {
     kind_ = des.read<Kind>();
   }

--- a/frontend/include/chpl/uast/MultiDecl.h
+++ b/frontend/include/chpl/uast/MultiDecl.h
@@ -51,6 +51,8 @@ namespace uast {
 
  */
 class MultiDecl final : public Decl {
+ friend class AstNode;
+
  private:
   MultiDecl(AstList children, int attributeGroupChildNum, Decl::Visibility vis,
             Decl::Linkage linkage)
@@ -62,15 +64,11 @@ class MultiDecl final : public Decl {
     CHPL_ASSERT(isAcceptableMultiDecl());
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    Decl::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    declSerializeInner(ser);
   }
 
-  DECLARE_STATIC_DESERIALIZE(MultiDecl);
-
- private:
-  MultiDecl(Deserializer& des)
+  explicit MultiDecl(Deserializer& des)
     : Decl(asttags::MultiDecl, des) { }
 
   bool isAcceptableMultiDecl();

--- a/frontend/include/chpl/uast/NamedDecl.h
+++ b/frontend/include/chpl/uast/NamedDecl.h
@@ -31,6 +31,7 @@ namespace uast {
   This is an abstract base class for declarations that carry a name.
  */
 class NamedDecl : public Decl {
+ friend class AstNode;
 
  private:
   UniqueString name_;
@@ -53,13 +54,11 @@ class NamedDecl : public Decl {
       name_(name) {
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    Decl::serialize(ser);
+  void namedDeclSerializeInner(Serializer& ser) const {
+    declSerializeInner(ser);
     ser.write(name_);
   }
 
- protected:
   NamedDecl(AstTag tag, Deserializer& des)
     : Decl(tag, des) {
     name_ = des.read<UniqueString>();

--- a/frontend/include/chpl/uast/New.h
+++ b/frontend/include/chpl/uast/New.h
@@ -39,8 +39,9 @@ namespace uast {
   is a New node (representing 'new bar').
 */
 class New : public AstNode {
- public:
+ friend class AstNode;
 
+ public:
   /**
     Possible management flavors for a new expression.
   */
@@ -59,16 +60,11 @@ class New : public AstNode {
     : AstNode(asttags::New, std::move(children)),
       management_(management) {}
 
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
     ser.write(management_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(New);
-
- private:
-  New(Deserializer& des)
+  explicit New(Deserializer& des)
     : AstNode(asttags::New, des) {
     management_ = des.read<Management>();
   }

--- a/frontend/include/chpl/uast/NumericLiteral.h
+++ b/frontend/include/chpl/uast/NumericLiteral.h
@@ -33,6 +33,8 @@ namespace uast {
  */
 template <typename ValueT, typename ParamT>
 class NumericLiteral : public Literal {
+ friend class AstNode;
+
  protected:
   UniqueString text_;
 
@@ -41,13 +43,11 @@ class NumericLiteral : public Literal {
       text_(text)
   { }
 
- public:
-  void serialize(Serializer& ser) const override {
-    Literal::serialize(ser);
+  void numericLiteralSerializeInner(Serializer& ser) const {
+    literalSerializeInner(ser);
     ser.write(text_);
   }
 
- protected:
   NumericLiteral(AstTag tag, Deserializer& des)
     : Literal(tag, des) {
     text_ = des.read<UniqueString>();

--- a/frontend/include/chpl/uast/On.h
+++ b/frontend/include/chpl/uast/On.h
@@ -43,6 +43,8 @@ namespace uast {
 
  */
 class On final : public SimpleBlockLike {
+ friend class AstNode;
+
  private:
   static const int8_t destChildNum_ = 0;
 
@@ -53,15 +55,11 @@ class On final : public SimpleBlockLike {
                       numBodyStmts) {
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    SimpleBlockLike::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    simpleBlockLikeSerializeInner(ser);
   }
 
-  DECLARE_STATIC_DESERIALIZE(On);
-
- private:
-  On(Deserializer& des)
+  explicit On(Deserializer& des)
     : SimpleBlockLike(asttags::On, des) { }
 
   bool contentsMatchInner(const AstNode* other) const override {

--- a/frontend/include/chpl/uast/OpCall.h
+++ b/frontend/include/chpl/uast/OpCall.h
@@ -36,6 +36,8 @@ namespace uast {
 
  */
 class OpCall final : public Call {
+ friend class AstNode;
+
  private:
   // which operator
   UniqueString op_;
@@ -46,16 +48,12 @@ class OpCall final : public Call {
       op_(op) {
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    Call::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    callSerializeInner(ser);
     ser.write(op_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(OpCall);
-
- private:
-  OpCall(Deserializer& des)
+  explicit OpCall(Deserializer& des)
     : Call(asttags::OpCall, des) {
     op_ = des.read<UniqueString>();
   }

--- a/frontend/include/chpl/uast/PrimCall.h
+++ b/frontend/include/chpl/uast/PrimCall.h
@@ -43,6 +43,8 @@ namespace uast {
 
  */
 class PrimCall final : public Call {
+ friend class AstNode;
+
  private:
   // which primitive
   PrimitiveTag prim_;
@@ -53,16 +55,12 @@ class PrimCall final : public Call {
       prim_(prim) {
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    Call::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    callSerializeInner(ser);
     ser.write(prim_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(PrimCall);
-
- private:
-  PrimCall(Deserializer& des)
+  explicit PrimCall(Deserializer& des)
     : Call(asttags::PrimCall, des) {
     prim_ = des.read<PrimitiveTag>();
   }

--- a/frontend/include/chpl/uast/Range.h
+++ b/frontend/include/chpl/uast/Range.h
@@ -40,6 +40,8 @@ namespace uast {
 
  */
 class Range final : public AstNode {
+ friend class AstNode;
+
  public:
   enum OpKind {
     DEFAULT,
@@ -63,18 +65,13 @@ class Range final : public AstNode {
     }
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
     ser.write(opKind_);
     ser.write(lowerBoundChildNum_);
     ser.write(upperBoundChildNum_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Range);
-
- private:
-  Range(Deserializer& des)
+  explicit Range(Deserializer& des)
     : AstNode(asttags::Range, des) {
     opKind_ = des.read<OpKind>();
     lowerBoundChildNum_ = des.read<int8_t>();

--- a/frontend/include/chpl/uast/RealLiteral.h
+++ b/frontend/include/chpl/uast/RealLiteral.h
@@ -32,20 +32,18 @@ namespace uast {
   That is, it is a "real" number. Examples include ``0.0``, and `3e24`.
  */
 class RealLiteral final : public NumericLiteral<double, types::RealParam> {
+ friend class AstNode;
+
  private:
   RealLiteral(const types::RealParam* value, UniqueString text)
     : NumericLiteral(asttags::RealLiteral, value, text)
   { }
 
- public:
-  void serialize(Serializer& ser) const override {
-    NumericLiteral::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    numericLiteralSerializeInner(ser);
   }
 
-  DECLARE_STATIC_DESERIALIZE(RealLiteral);
-
- private:
-  RealLiteral(Deserializer& des)
+  explicit RealLiteral(Deserializer& des)
     : NumericLiteral(asttags::RealLiteral, des)
   { }
 

--- a/frontend/include/chpl/uast/Record.h
+++ b/frontend/include/chpl/uast/Record.h
@@ -43,6 +43,8 @@ namespace uast {
   The record itself (myRecord) is represented by a Record AST node.
  */
 class Record final : public AggregateDecl {
+ friend class AstNode;
+
  private:
   Record(AstList children, int attributeGroupChildNum, Decl::Visibility vis,
          Decl::Linkage linkage,
@@ -63,16 +65,11 @@ class Record final : public AggregateDecl {
                     elementsChildNum,
                     numElements) {}
 
- public:
-  void serialize(Serializer& ser) const override {
-    AggregateDecl::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    aggregateDeclSerializeInner(ser);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Record);
-
- private:
-  Record(Deserializer& des)
-    : AggregateDecl(asttags::Record, des) {}
+  explicit Record(Deserializer& des) : AggregateDecl(asttags::Record, des) { }
 
   bool contentsMatchInner(const AstNode* other) const override {
     const Record* lhs = this;

--- a/frontend/include/chpl/uast/Reduce.h
+++ b/frontend/include/chpl/uast/Reduce.h
@@ -63,6 +63,8 @@ namespace uast {
 
 */
 class Reduce final : public Call {
+ friend class AstNode;
+
  private:
   static const int opChildNum_ = 0;
   static const int iterandExprChildNum_ = 1;
@@ -73,16 +75,11 @@ class Reduce final : public Call {
     CHPL_ASSERT(numChildren() == 2);
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    Call::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    callSerializeInner(ser);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Reduce);
-
- private:
-  Reduce(Deserializer& des)
-      : Call(asttags::Reduce, des) { }
+  explicit Reduce(Deserializer& des) : Call(asttags::Reduce, des) { }
 
   bool contentsMatchInner(const AstNode* other) const override {
     const Reduce* rhs = other->toReduce();

--- a/frontend/include/chpl/uast/ReduceIntent.h
+++ b/frontend/include/chpl/uast/ReduceIntent.h
@@ -50,6 +50,8 @@ namespace uast {
 
 */
 class ReduceIntent final : public NamedDecl {
+ friend class AstNode;
+
  private:
   static const int opChildNum_ = 0;
 
@@ -63,16 +65,13 @@ class ReduceIntent final : public NamedDecl {
     CHPL_ASSERT(numChildren() == 1);
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    NamedDecl::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    namedDeclSerializeInner(ser);
   }
 
-  DECLARE_STATIC_DESERIALIZE(ReduceIntent);
-
- private:
-  ReduceIntent(Deserializer& des)
-    : NamedDecl(asttags::ReduceIntent, des) { }
+  explicit ReduceIntent(Deserializer& des)
+    : NamedDecl(asttags::ReduceIntent, des) {
+  }
 
   bool contentsMatchInner(const AstNode* other) const override {
     const ReduceIntent* rhs = other->toReduceIntent();

--- a/frontend/include/chpl/uast/Require.h
+++ b/frontend/include/chpl/uast/Require.h
@@ -39,21 +39,16 @@ namespace uast {
   \endrst
 */
 class Require final : public AstNode {
+ friend class AstNode;
+
  private:
   Require(AstList children)
     : AstNode(asttags::Require, std::move(children)) {
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-  }
+  void serializeInner(Serializer& ser) const override { }
 
-  DECLARE_STATIC_DESERIALIZE(Require);
-
- private:
-  Require(Deserializer& des)
-    : AstNode(asttags::Require, des) { }
+  explicit Require(Deserializer& des) : AstNode(asttags::Require, des) { }
 
   bool contentsMatchInner(const AstNode* other) const override {
     return true;

--- a/frontend/include/chpl/uast/Return.h
+++ b/frontend/include/chpl/uast/Return.h
@@ -42,6 +42,8 @@ namespace uast {
 
  */
 class Return final : public AstNode {
+ friend class AstNode;
+
  private:
   int8_t valueChildNum_;
 
@@ -51,16 +53,11 @@ class Return final : public AstNode {
     CHPL_ASSERT(valueChildNum_ <= 0);
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
     ser.write(valueChildNum_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Return);
-
- private:
-  Return(Deserializer& des)
+  explicit Return(Deserializer& des)
     : AstNode(asttags::Return, des) {
     valueChildNum_ = des.read<int8_t>();
   }

--- a/frontend/include/chpl/uast/Scan.h
+++ b/frontend/include/chpl/uast/Scan.h
@@ -41,6 +41,8 @@ namespace uast {
   The scan expression is '+ scan A'.
 */
 class Scan final : public Call {
+ friend class AstNode;
+
  private:
   static const int opChildNum_ = 0;
   static const int iterandChildNum_ = 1;
@@ -50,15 +52,11 @@ class Scan final : public Call {
     CHPL_ASSERT(numChildren() == 2);
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    Call::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    callSerializeInner(ser);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Scan);
-
- private:
-  Scan(Deserializer& des)
+  explicit Scan(Deserializer& des)
     : Call(asttags::Scan, des) { }
 
   bool contentsMatchInner(const AstNode* other) const override {

--- a/frontend/include/chpl/uast/Select.h
+++ b/frontend/include/chpl/uast/Select.h
@@ -45,6 +45,8 @@ namespace uast {
 
  */
 class Select final : public AstNode {
+ friend class AstNode;
+
  private:
   // The position of these never change.
   static const int8_t exprChildNum_ = 0;
@@ -57,16 +59,11 @@ class Select final : public AstNode {
       numWhenStmts_(numWhenStmts) {
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
     ser.writeVInt(numWhenStmts_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Select);
-
- private:
-  Select(Deserializer& des) : AstNode(asttags::Select, des) {
+  explicit Select(Deserializer& des) : AstNode(asttags::Select, des) {
     numWhenStmts_ = des.readVInt();
   }
 

--- a/frontend/include/chpl/uast/Serial.h
+++ b/frontend/include/chpl/uast/Serial.h
@@ -49,6 +49,8 @@ namespace uast {
 
  */
 class Serial final : public SimpleBlockLike {
+ friend class AstNode;
+
  private:
   int8_t condChildNum_;
 
@@ -61,19 +63,15 @@ class Serial final : public SimpleBlockLike {
       condChildNum_(condChildNum) {
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    SimpleBlockLike::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    simpleBlockLikeSerializeInner(ser);
     ser.write(condChildNum_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Serial);
-
- private:
-  Serial(Deserializer& des)
+  explicit Serial(Deserializer& des)
     : SimpleBlockLike(asttags::Serial, des) {
-      condChildNum_ = des.read<int8_t>();
-    }
+    condChildNum_ = des.read<int8_t>();
+  }
 
   bool contentsMatchInner(const AstNode* other) const override {
     const Serial* lhs = this;

--- a/frontend/include/chpl/uast/SimpleBlockLike.h
+++ b/frontend/include/chpl/uast/SimpleBlockLike.h
@@ -46,6 +46,8 @@ namespace uast {
   This is because the conditional may have an else block.
  */
 class SimpleBlockLike : public AstNode {
+ friend class AstNode;
+
  protected:
   BlockStyle blockStyle_;
   int bodyChildNum_;
@@ -61,15 +63,12 @@ class SimpleBlockLike : public AstNode {
 
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
+  void simpleBlockLikeSerializeInner(Serializer& ser) const {
     ser.write(blockStyle_);
     ser.writeVInt(bodyChildNum_);
     ser.writeVInt(numBodyStmts_);
   }
 
- protected:
   SimpleBlockLike(AstTag tag, Deserializer& des)
     : AstNode(tag, des) {
     blockStyle_ = des.read<BlockStyle>();

--- a/frontend/include/chpl/uast/StringLikeLiteral.h
+++ b/frontend/include/chpl/uast/StringLikeLiteral.h
@@ -31,6 +31,8 @@ namespace uast {
   This is an abstract parent class for string/bytes/c-string literals.
  */
 class StringLikeLiteral : public Literal {
+ friend class AstNode;
+
  public:
   enum QuoteStyle {
     SINGLE,
@@ -47,13 +49,11 @@ class StringLikeLiteral : public Literal {
       quotes_(quotes)
   { }
 
- public:
-  void serialize(Serializer& ser) const override {
-    Literal::serialize(ser);
+  void stringLikeLiteralSerializeInner(Serializer& ser) const {
+    literalSerializeInner(ser);
     ser.write(quotes_);
   }
 
- protected:
   StringLikeLiteral(AstTag tag, Deserializer& des)
     : Literal(tag, des) {
     quotes_ = des.read<QuoteStyle>();

--- a/frontend/include/chpl/uast/StringLiteral.h
+++ b/frontend/include/chpl/uast/StringLiteral.h
@@ -32,13 +32,19 @@ namespace uast {
   and `''' string contents here '''`.
  */
 class StringLiteral final : public StringLikeLiteral {
+ friend class AstNode;
+
  private:
   StringLiteral(const types::StringParam* value,
                 StringLikeLiteral::QuoteStyle quotes)
     : StringLikeLiteral(asttags::StringLiteral, value, quotes)
   { }
 
-  StringLiteral(Deserializer& des)
+  void serializeInner(Serializer& ser) const override {
+    stringLikeLiteralSerializeInner(ser);
+  }
+
+  explicit StringLiteral(Deserializer& des)
     : StringLikeLiteral(asttags::StringLiteral, des)
   { }
 
@@ -51,12 +57,6 @@ class StringLiteral final : public StringLikeLiteral {
   static owned<StringLiteral> build(Builder* builder, Location loc,
                                     const std::string& value,
                                     StringLikeLiteral::QuoteStyle quotes);
-
-  void serialize(Serializer& ser) const override {
-    StringLikeLiteral::serialize(ser);
-  }
-
-  DECLARE_STATIC_DESERIALIZE(StringLiteral);
 };
 
 

--- a/frontend/include/chpl/uast/Sync.h
+++ b/frontend/include/chpl/uast/Sync.h
@@ -51,6 +51,8 @@ namespace uast {
  */
 
 class Sync final : public SimpleBlockLike {
+ friend class AstNode;
+
  private:
   Sync(AstList stmts, BlockStyle blockStyle, int bodyChildNum,
        int numBodyStmts)
@@ -60,16 +62,11 @@ class Sync final : public SimpleBlockLike {
     CHPL_ASSERT(bodyChildNum_ >= 0);
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    SimpleBlockLike::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    simpleBlockLikeSerializeInner(ser);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Sync);
-
- private:
-  Sync(Deserializer& des)
-    : SimpleBlockLike(asttags::Sync, des) { }
+  explicit Sync(Deserializer& des) : SimpleBlockLike(asttags::Sync, des) { }
 
   bool contentsMatchInner(const AstNode* other) const override {
     return simpleBlockLikeContentsMatchInner(other);

--- a/frontend/include/chpl/uast/TaskVar.h
+++ b/frontend/include/chpl/uast/TaskVar.h
@@ -46,6 +46,8 @@ namespace uast {
   ref intent.
  */
 class TaskVar final : public VarLikeDecl {
+ friend class AstNode;
+
  public:
   enum Intent {
     // Use Qualifier here for consistent enum values.
@@ -73,17 +75,11 @@ class TaskVar final : public VarLikeDecl {
                     initExpressionChildNum) {
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    VarLikeDecl::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    varLikeDeclSerializeInner(ser);
   }
 
-  DECLARE_STATIC_DESERIALIZE(TaskVar);
-
- private:
-  TaskVar(Deserializer& des)
-      : VarLikeDecl(asttags::TaskVar, des) {
-  }
+  explicit TaskVar(Deserializer& des) : VarLikeDecl(asttags::TaskVar, des) { }
 
   bool contentsMatchInner(const AstNode* other) const override {
     const TaskVar* lhs = this;

--- a/frontend/include/chpl/uast/Throw.h
+++ b/frontend/include/chpl/uast/Throw.h
@@ -41,22 +41,17 @@ namespace uast {
   \endrst
 */
 class Throw final : public AstNode {
+ friend class AstNode;
+
  private:
   Throw(AstList children)
       : AstNode(asttags::Throw, std::move(children)) {
     CHPL_ASSERT(numChildren() == 1);
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-  }
+  void serializeInner(Serializer& ser) const override { }
 
-  DECLARE_STATIC_DESERIALIZE(Throw);
-
- private:
-  Throw(Deserializer& des)
-    : AstNode(asttags::Throw, des) { }
+  explicit Throw(Deserializer& des) : AstNode(asttags::Throw, des) { }
 
   bool contentsMatchInner(const AstNode* other) const override {
     return true;

--- a/frontend/include/chpl/uast/Try.h
+++ b/frontend/include/chpl/uast/Try.h
@@ -53,6 +53,8 @@ namespace uast {
   block.
  */
 class Try final : public AstNode {
+ friend class AstNode;
+
  private:
   // body position is always the same
   static const int8_t bodyChildNum_ = 0;
@@ -85,19 +87,14 @@ class Try final : public AstNode {
     }
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
     ser.writeVInt(numHandlers_);
     ser.write(containsBlock_);
     ser.write(isExpressionLevel_);
     ser.write(isTryBang_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Try);
-
- private:
-  Try(Deserializer& des)
+  explicit Try(Deserializer& des)
     : AstNode(asttags::Try, des) {
       numHandlers_ = des.readVInt();
       containsBlock_ = des.read<bool>();

--- a/frontend/include/chpl/uast/Tuple.h
+++ b/frontend/include/chpl/uast/Tuple.h
@@ -40,6 +40,8 @@ namespace uast {
   \endrst
 */
 class Tuple final : public Call {
+ friend class AstNode;
+
  private:
   // TODO: Record trailing comma?
   Tuple(AstList children)
@@ -48,16 +50,11 @@ class Tuple final : public Call {
     CHPL_ASSERT(numChildren() >= 1);
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    Call::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    callSerializeInner(ser);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Tuple);
-
- private:
-  Tuple(Deserializer& des)
-    : Call(asttags::Tuple, des) { }
+  explicit Tuple(Deserializer& des) : Call(asttags::Tuple, des) { }
 
   bool contentsMatchInner(const AstNode* other) const override {
     return this->callContentsMatchInner(other->toCall());

--- a/frontend/include/chpl/uast/TupleDecl.h
+++ b/frontend/include/chpl/uast/TupleDecl.h
@@ -52,6 +52,8 @@ namespace uast {
 
  */
 class TupleDecl final : public Decl {
+ friend class AstNode;
+
  public:
   enum IntentOrKind {
     DEFAULT_INTENT = (int) Qualifier::DEFAULT_INTENT,
@@ -93,19 +95,15 @@ class TupleDecl final : public Decl {
     CHPL_ASSERT(assertAcceptableTupleDecl());
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    Decl::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    declSerializeInner(ser);
     ser.write(intentOrKind_);
     ser.writeVInt(numElements_);
     ser.writeVInt(typeExpressionChildNum_);
     ser.writeVInt(initExpressionChildNum_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(TupleDecl);
-
- private:
-  TupleDecl(Deserializer& des)
+  explicit TupleDecl(Deserializer& des)
     : Decl(asttags::TupleDecl, des) {
     intentOrKind_ = des.read<IntentOrKind>();
     numElements_ = des.readVInt();

--- a/frontend/include/chpl/uast/TypeDecl.h
+++ b/frontend/include/chpl/uast/TypeDecl.h
@@ -31,6 +31,8 @@ namespace uast {
   (e.g. classes, records, enums).
  */
 class TypeDecl : public NamedDecl {
+ friend class AstNode;
+
  protected:
   TypeDecl(asttags::AstTag tag, AstList children, int attributeGroupChildNum,
            Decl::Visibility vis,
@@ -44,14 +46,11 @@ class TypeDecl : public NamedDecl {
 
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    NamedDecl::serialize(ser);
+  void typeDeclSerializeInner(Serializer& ser) const {
+    namedDeclSerializeInner(ser);
   }
 
- protected:
-  TypeDecl(AstTag tag, Deserializer& des)
-    : NamedDecl(tag, des) { }
+  TypeDecl(AstTag tag, Deserializer& des) : NamedDecl(tag, des) { }
 
   bool typeDeclContentsMatchInner(const TypeDecl* other) const {
     return namedDeclContentsMatchInner(other);

--- a/frontend/include/chpl/uast/TypeQuery.h
+++ b/frontend/include/chpl/uast/TypeQuery.h
@@ -49,6 +49,7 @@ namespace uast {
   rather than a TypeQuery.
  */
 class TypeQuery final : public NamedDecl {
+ friend class AstNode;
 
  private:
   TypeQuery(UniqueString name)
@@ -56,16 +57,11 @@ class TypeQuery final : public NamedDecl {
     CHPL_ASSERT(!name.isEmpty() && name.c_str()[0] != '?');
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    NamedDecl::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    namedDeclSerializeInner(ser);
   }
 
-  DECLARE_STATIC_DESERIALIZE(TypeQuery);
-
- private:
-  TypeQuery(Deserializer& des)
-    : NamedDecl(asttags::TypeQuery, des) { }
+  explicit TypeQuery(Deserializer& des) : NamedDecl(asttags::TypeQuery, des) { }
 
   bool contentsMatchInner(const AstNode* other) const override {
     const TypeQuery* lhs = this;

--- a/frontend/include/chpl/uast/UintLiteral.h
+++ b/frontend/include/chpl/uast/UintLiteral.h
@@ -33,20 +33,18 @@ namespace uast {
   Such integer literals have type `uint`.
  */
 class UintLiteral final : public NumericLiteral<uint64_t, types::UintParam> {
+ friend class AstNode;
+
  private:
   UintLiteral(const types::UintParam* value, UniqueString text)
     : NumericLiteral(asttags::UintLiteral, value, text)
   { }
 
- public:
-  void serialize(Serializer& ser) const override {
-    NumericLiteral::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    numericLiteralSerializeInner(ser);
   }
 
-  DECLARE_STATIC_DESERIALIZE(UintLiteral);
-
- private:
-  UintLiteral(Deserializer& des)
+  explicit UintLiteral(Deserializer& des)
     : NumericLiteral(asttags::UintLiteral, des)
   { }
 

--- a/frontend/include/chpl/uast/Union.h
+++ b/frontend/include/chpl/uast/Union.h
@@ -43,6 +43,8 @@ namespace uast {
   The union itself (myUnion) is represented by a Union AST node.
  */
 class Union final : public AggregateDecl {
+ friend class AstNode;
+
  private:
   Union(AstList children, int attributeGroupChildNum, Decl::Visibility vis,
         Decl::Linkage linkage,
@@ -67,17 +69,11 @@ class Union final : public AggregateDecl {
     CHPL_ASSERT(linkage != Decl::EXPORT);
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    AggregateDecl::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    aggregateDeclSerializeInner(ser);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Union);
-
- private:
-  Union(Deserializer& des)
-    : AggregateDecl(asttags::Union, des) { }
-
+  explicit Union(Deserializer& des) : AggregateDecl(asttags::Union, des) { }
 
   bool contentsMatchInner(const AstNode* other) const override {
     const Union* lhs = this;

--- a/frontend/include/chpl/uast/Use.h
+++ b/frontend/include/chpl/uast/Use.h
@@ -44,6 +44,8 @@ namespace uast {
   'Bar as A'.
 */
 class Use final : public AstNode {
+ friend class AstNode;
+
  private:
   Decl::Visibility visibility_;
 
@@ -67,16 +69,11 @@ class Use final : public AstNode {
     #endif
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
     ser.write(visibility_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Use);
-
- private:
-  Use(Deserializer& des) : AstNode(asttags::Use, des) {
+  explicit Use(Deserializer& des) : AstNode(asttags::Use, des) {
     visibility_ = des.read<Decl::Visibility>();
   }
 

--- a/frontend/include/chpl/uast/VarArgFormal.h
+++ b/frontend/include/chpl/uast/VarArgFormal.h
@@ -44,6 +44,8 @@ namespace uast {
   the number of which is denoted by the TypeQuery `?k`.
 */
 class VarArgFormal final : public VarLikeDecl {
+ friend class AstNode;
+
  private:
   int countChildNum_;
 
@@ -64,16 +66,12 @@ class VarArgFormal final : public VarLikeDecl {
       countChildNum_(countChildNum) {
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    VarLikeDecl::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    varLikeDeclSerializeInner(ser);
     ser.writeVInt(countChildNum_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(VarArgFormal);
-
- private:
-  VarArgFormal(Deserializer& des)
+  explicit VarArgFormal(Deserializer& des)
     : VarLikeDecl(asttags::VarArgFormal, des) {
     countChildNum_ = des.readVInt();
   }

--- a/frontend/include/chpl/uast/VarLikeDecl.h
+++ b/frontend/include/chpl/uast/VarLikeDecl.h
@@ -33,6 +33,8 @@ namespace uast {
   This includes things like fields, formals, or variables.
  */
 class VarLikeDecl : public NamedDecl {
+ friend class AstNode;
+
  protected:
   Qualifier storageKind_;
   int8_t typeExpressionChildNum_;
@@ -64,15 +66,13 @@ class VarLikeDecl : public NamedDecl {
     }
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    NamedDecl::serialize(ser);
+  void varLikeDeclSerializeInner(Serializer& ser) const {
+    namedDeclSerializeInner(ser);
     ser.write(storageKind_);
     ser.write(typeExpressionChildNum_);
     ser.write(initExpressionChildNum_);
   }
 
- protected:
   VarLikeDecl(AstTag tag, Deserializer& des)
     : NamedDecl(tag, des) {
     storageKind_ = des.read<Qualifier>();

--- a/frontend/include/chpl/uast/Variable.h
+++ b/frontend/include/chpl/uast/Variable.h
@@ -49,7 +49,9 @@ namespace uast {
   each of a-f are Variables.
  */
 class Variable final : public VarLikeDecl {
+ friend class AstNode;
  friend class Builder;
+
  public:
   enum Kind {
     // Use Qualifier here for consistent enum values.
@@ -88,17 +90,13 @@ class Variable final : public VarLikeDecl {
         isField_(isField) {
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    VarLikeDecl::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    varLikeDeclSerializeInner(ser);
     ser.write(isConfig_);
     ser.write(isField_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Variable);
-
- private:
-  Variable(Deserializer& des)
+  explicit Variable(Deserializer& des)
     : VarLikeDecl(asttags::Variable, des) {
     isConfig_ = des.read<bool>();
     isField_ = des.read<bool>();

--- a/frontend/include/chpl/uast/VisibilityClause.h
+++ b/frontend/include/chpl/uast/VisibilityClause.h
@@ -44,6 +44,8 @@ namespace uast {
   \endrst
  */
 class VisibilityClause final : public AstNode {
+ friend class AstNode;
+
  public:
 
   /**
@@ -86,17 +88,12 @@ class VisibilityClause final : public AstNode {
     }
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
     ser.write(limitationKind_);
     ser.writeVInt(numLimitations_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(VisibilityClause);
-
- private:
-  VisibilityClause(Deserializer& des)
+  explicit VisibilityClause(Deserializer& des)
     : AstNode(asttags::VisibilityClause, des) {
     limitationKind_ = des.read<LimitationKind>();
     numLimitations_ = des.readVInt();

--- a/frontend/include/chpl/uast/When.h
+++ b/frontend/include/chpl/uast/When.h
@@ -34,6 +34,8 @@ namespace uast {
   of the select statement.
  */
 class When final : public SimpleBlockLike {
+ friend class AstNode;
+
  private:
   // The position of this never changes.
   static const int8_t caseExprChildNum_ = 0;
@@ -49,19 +51,15 @@ class When final : public SimpleBlockLike {
       numCaseExprs_(numCaseExprs) {
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    SimpleBlockLike::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    simpleBlockLikeSerializeInner(ser);
     ser.writeVInt(numCaseExprs_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(When);
-
- private:
-  When(Deserializer& des)
+  explicit When(Deserializer& des)
     : SimpleBlockLike(asttags::When, des) {
-      numCaseExprs_ = des.readVInt();
-    }
+    numCaseExprs_ = des.readVInt();
+  }
 
   bool contentsMatchInner(const AstNode* other) const override {
     const When* rhs = other->toWhen();

--- a/frontend/include/chpl/uast/While.h
+++ b/frontend/include/chpl/uast/While.h
@@ -45,6 +45,8 @@ namespace uast {
 
  */
 class While final : public Loop {
+ friend class AstNode;
+
  private:
   int8_t conditionChildNum_;
 
@@ -58,16 +60,12 @@ class While final : public Loop {
     CHPL_ASSERT(condition());
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    Loop::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    loopSerializeInner(ser);
     ser.write(conditionChildNum_);
   }
 
-  DECLARE_STATIC_DESERIALIZE(While);
-
- private:
-  While(Deserializer& des)
+  explicit While(Deserializer& des)
     : Loop(asttags::While, des) {
     conditionChildNum_ = des.read<int8_t>();
   }

--- a/frontend/include/chpl/uast/WithClause.h
+++ b/frontend/include/chpl/uast/WithClause.h
@@ -44,21 +44,16 @@ namespace uast {
   task variable named 'x'.
 */
 class WithClause final : public AstNode {
+ friend class AstNode;
+
  private:
   WithClause(AstList exprs)
     : AstNode(asttags::WithClause, std::move(exprs)) {
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-  }
+  void serializeInner(Serializer& ser) const override { }
 
-  DECLARE_STATIC_DESERIALIZE(WithClause);
-
- private:
-  WithClause(Deserializer& des)
-    : AstNode(asttags::WithClause, des) { }
+  explicit WithClause(Deserializer& des) : AstNode(asttags::WithClause, des) { }
 
   bool contentsMatchInner(const AstNode* other) const override {
     return true;

--- a/frontend/include/chpl/uast/Yield.h
+++ b/frontend/include/chpl/uast/Yield.h
@@ -42,23 +42,17 @@ namespace uast {
 
  */
 class Yield final : public AstNode {
+ friend class AstNode;
+
  private:
   Yield(AstList children)
     : AstNode(asttags::Yield, std::move(children)) {
     CHPL_ASSERT(children_.size() == 1);
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    AstNode::serialize(ser);
-  }
+  void serializeInner(Serializer& ser) const override { }
 
-  DECLARE_STATIC_DESERIALIZE(Yield);
-
- private:
-  Yield(Deserializer& des)
-    : AstNode(asttags::Yield, des) {
-  }
+  explicit Yield(Deserializer& des) : AstNode(asttags::Yield, des) { }
 
   bool contentsMatchInner(const AstNode* other) const override {
     // The 'valueChildNum_' is const and does not need to be compared.

--- a/frontend/include/chpl/uast/Zip.h
+++ b/frontend/include/chpl/uast/Zip.h
@@ -31,22 +31,19 @@ namespace uast {
   This class represents a zip expression.
 */
 class Zip final : public Call {
+ friend class AstNode;
+
  private:
   Zip(AstList children)
     : Call(asttags::Zip, std::move(children),
            /*hasCalledExpression*/ false) {
   }
 
- public:
-  void serialize(Serializer& ser) const override {
-    Call::serialize(ser);
+  void serializeInner(Serializer& ser) const override {
+    callSerializeInner(ser);
   }
 
-  DECLARE_STATIC_DESERIALIZE(Zip);
-
- private:
-  Zip(Deserializer& des)
-    : Call(asttags::Zip, des) { }
+  explicit Zip(Deserializer& des) : Call(asttags::Zip, des) { }
 
   bool contentsMatchInner(const AstNode* other) const override {
     return callContentsMatchInner(other->toCall());

--- a/frontend/test/uast/CMakeLists.txt
+++ b/frontend/test/uast/CMakeLists.txt
@@ -17,5 +17,6 @@
 
 comp_unit_test(testBuildIDs)
 comp_unit_test(testConsistentEnums)
-comp_unit_test(testVisit)
+comp_unit_test(testSerialize)
 comp_unit_test(testStringify)
+comp_unit_test(testVisit)

--- a/frontend/test/uast/testSerialize.cpp
+++ b/frontend/test/uast/testSerialize.cpp
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "test-common.h"
+
+#include "chpl/framework/Context.h"
+#include "chpl/framework/Location.h"
+#include "chpl/framework/UniqueString.h"
+#include "chpl/uast/all-uast.h"
+
+#include <fstream>
+#include <sstream>
+
+using namespace chpl;
+using namespace uast;
+
+const char* output = "";
+const bool verbose = true;
+
+static void testSerializeDeserialize(const char* test, const char* program) {
+  printf("%s\n", test);
+
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  std::string filename = std::string(test) + ".chpl";
+
+  owned<std::ofstream> outFile;
+  owned<std::ifstream> inFile;
+  owned<std::stringstream> ss;
+
+  std::ostream* out = nullptr;
+  std::istream* in = nullptr;
+
+  if (output[0] != '\0') {
+    // if 'output' is set, work with that file.
+    outFile = toOwned(new std::ofstream(filename,
+                                        std::ios::out | std::ios::binary));
+    out = outFile.get();
+  } else {
+    // otherwise, work with a string stream
+    ss = toOwned(new std::stringstream());
+    out = ss.get();
+  }
+
+  auto path = UniqueString::get(context, filename);
+  parsing::setFileText(context, path, program);
+
+  const parsing::ModuleVec& vec = parsing::parseToplevel(context, path);
+  assert(guard.realizeErrors() == 0);
+  size_t nToplevelModules = vec.size();
+
+  Serializer::stringCacheType stringCache;
+
+  {
+    auto ser = Serializer(*out);
+    for (size_t i = 0; i < nToplevelModules; i++) {
+      if (verbose) {
+        printf("Serializing %s %s\n", test, vec[i]->name().c_str());
+        vec[i]->dump();
+      }
+
+      vec[i]->serialize(ser);
+    }
+    out->flush();
+
+    stringCache = ser.stringCache();
+  }
+
+  // Now deserialize!
+  if (output[0] != '\0') {
+    // if 'output' is set, work with that file.
+    inFile = toOwned(new std::ifstream(filename,
+                                        std::ios::in | std::ios::binary));
+    in = inFile.get();
+  } else {
+    // get an istream for the string stream
+    in = ss.get();
+  }
+
+  {
+    auto des = Deserializer(context, *in, stringCache);
+
+    for (size_t i = 0; i < nToplevelModules; i++) {
+      if (verbose) {
+        printf("Deserializing %s %s\n", test, vec[i]->name().c_str());
+      }
+
+      owned<AstNode> mod = AstNode::deserialize(des);
+      assert(mod->completeMatch(vec[i]));
+
+      if (verbose) {
+        mod->dump();
+      }
+    }
+  }
+}
+
+int main(int argc, char** argv) {
+  // use the passed file if provided
+  if (argc > 1) output = argv[1];
+
+  // TODO: these programs are relying on the short string behavior,
+  // but we need to test the long strings too.
+
+  testSerializeDeserialize("test1", "var i: int;");
+  testSerializeDeserialize("test2", "module X { var i: int; }");
+  testSerializeDeserialize("test3",
+                           R""""(
+                              module A {
+                                module B {
+                                  proc main() {
+                                    writeln("hello world");
+                                  }
+                                }
+                              }
+                           )"""");
+  testSerializeDeserialize("test4",
+                           R""""(
+                              class C { var x: int; }
+                              record R { var y: int; }
+                              proc R.secondary(arg: string) { return 1; }
+                              var cc = new C(1);
+                              var rr = new R(2);
+                              var zz = rr.secondary("actual");
+                           )"""");
+  testSerializeDeserialize("test5",
+                           R""""(
+                              module SomeVeryLongIdentifierName {
+                                var anEvenLongerIntegerVariableName: int;
+                              }
+                           )"""");
+
+  return 0;
+}


### PR DESCRIPTION
Continuation of PR ##23697.

This PR adjusts the uAST serializer/deserializers to store the children after the subclass fields implementing a uAST node. Storing the children after the subclass fields is important to preserve the property that each uAST node is contiguous (other than its children). In my view, that is important for the file format to be possible for a person to debug.

However, the way that the `serialize` functions were implemented prevented this reordering because 1) `serialize` was the public interface into these and 2) the only chance `AstNode` has to serialize the children is in `AstNode::serialize` and that's necessarily called before serializing the fields of a subclass.

To address that, this PR changes the strategy to differentiate between methods a subclass must provide and the methods for the public interface:
 * `AstNode::serialize` and `AstNode::deserialize` form the public interface
 * subclasses need to override `serializeInner(Serializer& ser)` and implement a constructor like `SubClass(Deserializer& des)`
 * `AstNode::serialize` calls `serializeInner` at the appropriate time. Similarly, `AstNode::deserialize` calls the constructor and deserializes the children at an appropriate time.

While there, I noticed that we can remove `DECLARE_STATIC_DESERIALIZE` by having `AstNode::deserialize` simply call `new NAME(des)` for each subclass (according to the tag). Also, since this constructor should not be part of the public API, I enabled it to be `private` / `protected` by making each uAST subclass include `friend class AstNode`. That reduces some of the switching between `public:` and `private:` in these uAST class definitions which appeared in PR #23697.

This PR also changes the abstract uAST types to include their name in the method to be called by subclasses in `serializeInner`: e.g., `declSerializeInner`. This matches the pattern already used in `contentsMatchInner` / `markUniqueStringsInner` with e.g. `declContentsMatchInner` / `declMarkUniqueStringsInner`. While I think it's important that these 3 use a consistent style, an alternative would be to use the `::` form in all 3: e.g., `Decl::serializeInner` / `Decl::contentsMatchInner` / `Decl::markUniqueStringsInner`.

Additionally, this PR updates the deserializing constructors to use `explicit` to avoid implicit conversion from a deserializer.

Lastly, this PR adds a C++ test of the uAST serialization and deserialization. This adds to the existing testing in `test/separate_compilation/serialization`.

Reviewed by @benharsh - thanks!

- [x] full comm=none testing