### PR TITLE
Restore deprecated `c_nil` and `is_c_nil`

### DIFF
--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -69,6 +69,21 @@ module CTypes {
   @deprecated(notes="c_void_ptr is deprecated, use 'c_ptr(void)' instead.")
   type c_void_ptr = c_ptr(void);
 
+
+  /* A Chapel version of a C NULL pointer. */
+  @deprecated(notes="c_nil is deprecated, use just 'nil' instead.")
+  inline proc c_nil {
+    return nil;
+  }
+
+  /*
+     :returns: true if the passed value is a NULL pointer (ie 0).
+   */
+  @deprecated(notes="is_c_nil is deprecated without replacement, as 'c_nil' is deprecated in favor of 'nil'; compare argument to 'nil' directly with ==, casting to c_ptr(void) first if needed.")
+  inline proc is_c_nil(x):bool {
+    return __primitive("cast", c_ptr(void), x) == c_nil;
+  }
+
   /*
 
     Represents a local C pointer for the purpose of C integration. This type

--- a/test/deprecated/CTypes/c_nil.chpl
+++ b/test/deprecated/CTypes/c_nil.chpl
@@ -1,0 +1,4 @@
+use CTypes;
+
+var x : c_ptr(c_int) = c_nil;
+writeln(is_c_nil(x));

--- a/test/deprecated/CTypes/c_nil.good
+++ b/test/deprecated/CTypes/c_nil.good
@@ -1,0 +1,3 @@
+c_nil.chpl:3: warning: c_nil is deprecated, use just 'nil' instead.
+c_nil.chpl:4: warning: is_c_nil is deprecated without replacement, as 'c_nil' is deprecated in favor of 'nil'; compare argument to 'nil' directly with ==, casting to c_ptr(void) first if needed.
+true


### PR DESCRIPTION
Restore these removed deprecated symbols, due to a compiler bug (https://github.com/Cray/chapel-private/issues/5536) preventing deprecation warnings from being generated for them.

Reverts part of https://github.com/chapel-lang/chapel/pull/23580.

[reviewer info placeholder]

Testing:
- [ ] paratest