### PR TITLE
Adjust Builder to store a BuilderResult instead of its fields

### DIFF
--- a/frontend/include/chpl/uast/Builder.h
+++ b/frontend/include/chpl/uast/Builder.h
@@ -50,13 +50,12 @@ class Builder final {
   using pathVecT = std::vector<std::pair<UniqueString,int>>;
   // maps the name to the repeat number
   using declaredHereT = std::unordered_map<UniqueString,int>;
+  // maps from a uAST pointer to a location
+  using AstLocMap = std::unordered_map<const AstNode*, Location>;
 
   Context* context_;
-  UniqueString filepath_;
   UniqueString startingSymbolPath_;
-  AstList topLevelExpressions_;
-
-  using AstLocMap = std::unordered_map<const AstNode*, Location>;
+  BuilderResult br;
 
   // note: notedLocations_ might have keys pointing to deleted uAST
   // nodes in the event one is created temporarily during parsing.
@@ -64,28 +63,18 @@ class Builder final {
   AstLocMap notedLocations_;
 
   // These map AST to additional locations while the builder is building.
+  // This is an equivalent to notedLocations for the additional locations.
   // The key type is just 'AstNode' so that we can use generic functions.
   #define LOCATION_MAP(ast__, location__) \
     AstLocMap CHPL_AST_LOC_MAP(ast__, location__);
   #include "all-location-maps.h"
   #undef LOCATION_MAP
 
-  // The following maps are computed during 'assignIDs'.
-  llvm::DenseMap<ID, Location> idToLocation_;
-  std::vector<Location> commentToLocation_;
-  llvm::DenseMap<ID, const AstNode*> idToAst_;
-  llvm::DenseMap<ID, ID> idToParent_;
-
-  // Maps for additional locations are also computed during 'assignIDs'.
-  #define LOCATION_MAP(ast__, location__) \
-    llvm::DenseMap<ID, Location> CHPL_ID_LOC_MAP(ast__, location__);
-  #include "all-location-maps.h"
-  #undef LOCATION_MAP
-
-  Builder(Context* context, UniqueString filepath,
+  Builder(Context* context, UniqueString filePath,
           UniqueString startingSymbolPath)
-    : context_(context), filepath_(filepath),
-      startingSymbolPath_(startingSymbolPath)
+    : context_(context),
+      startingSymbolPath_(startingSymbolPath),
+      br(filePath)
   {
   }
 

--- a/frontend/lib/uast/BuilderResult.cpp
+++ b/frontend/lib/uast/BuilderResult.cpp
@@ -76,10 +76,8 @@ void BuilderResult::swap(BuilderResult& other) {
   filePath_.swap(other.filePath_);
   topLevelExpressions_.swap(other.topLevelExpressions_);
   idToAst_.swap(other.idToAst_);
-  idToLocation_.swap(other.idToLocation_);
-  commentIdToLocation_.swap(other.commentIdToLocation_);
   idToParentId_.swap(other.idToParentId_);
-  idToAst_.swap(other.idToAst_);
+  idToLocation_.swap(other.idToLocation_);
 
   // Swap additional location maps.
   #define LOCATION_MAP(ast__, location__) { \
@@ -89,6 +87,8 @@ void BuilderResult::swap(BuilderResult& other) {
   }
   #include "chpl/uast/all-location-maps.h"
   #undef LOCATION_MAP
+
+  commentIdToLocation_.swap(other.commentIdToLocation_);
 }
 
 bool BuilderResult::update(BuilderResult& keep, BuilderResult& addin) {


### PR DESCRIPTION
Historically, `uast::Builder` is a class that contains as fields all of the fields of `uast::BuilderResult`. However, that adds unnecessary maintenance burden. This PR adjusts `Builder` to store a `BuilderResult` as a field. It can update the same elements (even though they are private in `BuilderResult`) because `BuilderResult` declares `Builder` as a friend.

Reviewed by @DanilaFe - thanks!

- [x] full comm=none testing