### PR TITLE
Make the `--detailed-errors` flag user-facing

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1290,6 +1290,7 @@ static ArgumentDescription arg_desc[] = {
  {"print-passes-file", ' ', "<filename>", "Print compiler passes to <filename>", "S", NULL, "CHPL_PRINT_PASSES_FILE", setPrintPassesFile},
 
  {"", ' ', NULL, "Miscellaneous Options", NULL, NULL, NULL, NULL},
+ {"detailed-errors", ' ', NULL, "Enable [disable] detailed error messages", "N", &fDetailedErrors, "CHPL_DETAILED_ERRORS", NULL},
  {"devel", ' ', NULL, "Compile as a developer [user]", "N", &developer, "CHPL_DEVELOPER", driverSetDevelSettings},
  {"explain-call", ' ', "<call>[:<module>][:<line>]", "Explain resolution of call", "S256", fExplainCall, NULL, NULL},
  {"explain-instantiation", ' ', "<function|type>[:<module>][:<line>]", "Explain instantiation of type", "S256", fExplainInstantiation, NULL, NULL},
@@ -1456,7 +1457,6 @@ static ArgumentDescription arg_desc[] = {
  {"warn-special", ' ', NULL, "Enable [disable] special warnings", "n", &fNoWarnSpecial, "CHPL_WARN_SPECIAL", setWarnSpecial},
  {"warn-unstable-internal", ' ', NULL, "Enable [disable] unstable warnings in internal modules", "N", &fWarnUnstableInternal, NULL, NULL},
  {"warn-unstable-standard", ' ', NULL, "Enable [disable] unstable warnings in standard modules", "N", &fWarnUnstableStandard, NULL, NULL},
- {"detailed-errors", ' ', NULL, "Enable [disable] detailed error messages", "N", &fDetailedErrors, NULL, NULL},
  {"dyno", ' ', NULL, "Enable [disable] using dyno compiler library", "N", &fDynoCompilerLibrary, "CHPL_DYNO_COMPILER_LIBRARY", NULL},
  {"dyno-scope-resolve", ' ', NULL, "Enable [disable] using dyno for scope resolution", "N", &fDynoScopeResolve, "CHPL_DYNO_SCOPE_RESOLVE", NULL},
  {"dyno-scope-production", ' ', NULL, "Enable [disable] using both dyno and production scope resolution", "N", &fDynoScopeProduction, "CHPL_DYNO_SCOPE_PRODUCTION", NULL},

--- a/man/chpl.rst
+++ b/man/chpl.rst
@@ -524,6 +524,13 @@ OPTIONS
 
 *Miscellaneous Options*
 
+**\--[no-]detailed-errors**
+
+    Enables [disables] the compiler's detailed error message mode. In this
+    mode, the compiler will print additional information about errors when
+    it is available. This could include printing and underlining relevant
+    segments of code, or providing suggestions for how to fix the error.
+
 **\--[no-]devel**
 
     Puts the compiler into [out of] developer mode, which takes off some of

--- a/test/compflags/bradc/help/userhelp.good
+++ b/test/compflags/bradc/help/userhelp.good
@@ -133,6 +133,7 @@ Compilation Trace Options:
       --print-passes-file <filename>  Print compiler passes to <filename>
 
 Miscellaneous Options:
+      --[no-]detailed-errors          Enable [disable] detailed error messages
       --[no-]devel                    Compile as a developer [user]
       --explain-call <call>[:<module>][:<line>]
                                       Explain resolution of call

--- a/util/chpl-completion.bash
+++ b/util/chpl-completion.bash
@@ -413,6 +413,7 @@ _chpl ()
 --cpp-lines \
 --dead-code-elimination \
 --debug \
+--detailed-errors \
 --devel \
 --div-by-zero-checks \
 --dynamic \
@@ -471,6 +472,7 @@ _chpl ()
 --no-cpp-lines \
 --no-dead-code-elimination \
 --no-debug \
+--no-detailed-errors \
 --no-devel \
 --no-div-by-zero-checks \
 --no-dynamic-auto-local-access \


### PR DESCRIPTION
As requested in #23706.

Reviewed by @mppf -- thanks!

## Testing
- [x] paratest