### PR TITLE
Fix usages of single return statement procedures

### DIFF
--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -69,7 +69,7 @@ module LocaleModel {
           (parent._instance: borrowed LocaleModel?)!._node_id:chpl_nodeID_t,
           sid);
     }
-    override proc chpl_name() return ndName;
+    override proc chpl_name() do return ndName;
 
     proc init() {
     }
@@ -173,15 +173,15 @@ module LocaleModel {
       setup();
     }
 
-    override proc chpl_id() return _node_id;     // top-level locale (node) number
+    override proc chpl_id() do return _node_id;     // top-level locale (node) number
     override proc chpl_localeid() {
       return chpl_buildLocaleID(_node_id:chpl_nodeID_t, c_sublocid_any);
     }
-    override proc chpl_name() return local_name;
+    override proc chpl_name() do return local_name;
 
-    proc getChildSpace() return childSpace;
+    proc getChildSpace() do return childSpace;
 
-    override proc _getChildCount() return numSublocales;
+    override proc _getChildCount() do return numSublocales;
 
     iter getChildIndices() : int {
       for idx in childSpace do
@@ -251,12 +251,12 @@ module LocaleModel {
     // We return numLocales for now, since we expect nodes to be
     // numbered less than this.
     // -1 is used in the abstract locale class to specify an invalid node ID.
-    override proc chpl_id() return numLocales;
+    override proc chpl_id() do return numLocales;
     override proc chpl_localeid() {
       return chpl_buildLocaleID(numLocales:chpl_nodeID_t, c_sublocid_none);
     }
-    override proc chpl_name() return local_name();
-    proc local_name() return "rootLocale";
+    override proc chpl_name() do return local_name();
+    proc local_name() do return "rootLocale";
 
     override proc writeThis(f) throws {
       f.write(name);
@@ -266,24 +266,24 @@ module LocaleModel {
       writeThis(writer);
     }
 
-    override proc _getChildCount() return this.myLocaleSpace.size;
+    override proc _getChildCount() do return this.myLocaleSpace.size;
 
-    proc getChildSpace() return this.myLocaleSpace;
+    proc getChildSpace() do return this.myLocaleSpace;
 
     iter getChildIndices() : int {
       for idx in this.myLocaleSpace do
         yield idx;
     }
 
-    override proc _getChild(idx:int) return this.myLocales[idx];
+    override proc _getChild(idx:int) do return this.myLocales[idx];
 
     iter getChildren() : locale  {
       for loc in this.myLocales do
         yield loc;
     }
 
-    override proc getDefaultLocaleSpace() const ref return this.myLocaleSpace;
-    override proc getDefaultLocaleArray() const ref return myLocales;
+    override proc getDefaultLocaleSpace() const ref do return this.myLocaleSpace;
+    override proc getDefaultLocaleArray() const ref do return myLocales;
 
     override proc localeIDtoLocale(id : chpl_localeID_t) {
       const node = chpl_nodeFromLocaleID(id);


### PR DESCRIPTION
Fixes a few usages of the deprecated single statement procedures in an internal module, `modules/internal/localeModels/numa/LocaleModel.chpl`

This was missed in #21632

[Reviewed by @]