### PR TITLE
Dyno: Fix resolution of methods on generic types with defaults

### DIFF
--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1239,7 +1239,7 @@ void Resolver::resolveNamedDecl(const NamedDecl* decl, const Type* useType) {
         auto functionId = parsing::idToParentId(context, decl->id());
         auto aggregateId = parsing::idToParentId(context, functionId);
         auto parentType = typeForId(aggregateId, /* localGenericToUnknown */ true);
-        typeExprT = computeTypeDefaults(*this, parentType);
+        typeExprT = parentType;
       }
 
       // for 'this' formals of class type, adjust them to be borrowed, so

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -716,7 +716,7 @@ void CallInitDeinit::resolveDeinit(const AstNode* ast,
   std::vector<CallInfoActual> actuals;
   actuals.push_back(CallInfoActual(type, USTR("this")));
   auto ci = CallInfo (/* name */ USTR("deinit"),
-                      /* calledType */ QualifiedType(),
+                      /* calledType */ type,
                       /* isMethodCall */ true,
                       /* hasQuestionArg */ false,
                       /* isParenless */ false,

--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -217,10 +217,8 @@ static bool fitsInMantissaExponent(int mantissaWidth,
 static bool isConsideredGeneric(Type::Genericity g) {
   switch (g) {
     case Type::CONCRETE:
-    case Type::GENERIC_WITH_DEFAULTS:
-      // argument passing calculations think of generic with defaults
-      // as the same as concrete.
       return false;
+    case Type::GENERIC_WITH_DEFAULTS:
     case Type::GENERIC:
       return true;
     case Type::MAYBE_GENERIC:

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -277,7 +277,7 @@ generateInitCopySignature(Context* context, const CompositeType* inCompType) {
   std::vector<QualifiedType> formalTypes;
 
   generateInitParts(context, inCompType, compType,
-                    ufsFormals, formalTypes, /*useGeneric*/ true);
+                    ufsFormals, formalTypes, /*useGeneric*/ false);
 
   // add a formal for the 'other' argument
   auto name = UniqueString::get(context, "other");
@@ -306,15 +306,11 @@ generateInitCopySignature(Context* context, const CompositeType* inCompType) {
                         /*whereClause*/ nullptr);
 
   // now build the other pieces of the typed signature
-  auto g = getTypeGenericity(context, formalTypes[1]);
-  bool needsInstantiation = (g == Type::GENERIC ||
-                             g == Type::GENERIC_WITH_DEFAULTS);
-
   auto ret = TypedFnSignature::get(context,
                                    ufs,
                                    std::move(formalTypes),
                                    TypedFnSignature::WHERE_NONE,
-                                   needsInstantiation,
+                                   /*needsInstantiation*/ false,
                                    /* instantiatedFrom */ nullptr,
                                    /* parentFn */ nullptr,
                                    /* formalsInstantiated */ Bitmap());

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -148,10 +148,15 @@ generateInitParts(Context* context,
                   const CompositeType* inCompType,
                   const CompositeType*& compType,
                   std::vector<UntypedFnSignature::FormalDetail>& ufsFormals,
-                  std::vector<QualifiedType>& formalTypes) {
+                  std::vector<QualifiedType>& formalTypes,
+                  bool useGeneric) {
   // adjust to refer to fully generic signature if needed
   auto genericCompType = inCompType->instantiatedFromCompositeType();
-  compType = genericCompType ? genericCompType : inCompType;
+  if (useGeneric && genericCompType != nullptr) {
+    compType = genericCompType;
+  } else {
+    compType = inCompType;
+  }
 
   // start by adding a formal for the receiver
   auto ufsReceiver = UntypedFnSignature::FormalDetail(USTR("this"),
@@ -189,7 +194,8 @@ generateInitSignature(Context* context, const CompositeType* inCompType) {
   std::vector<UntypedFnSignature::FormalDetail> ufsFormals;
   std::vector<QualifiedType> formalTypes;
 
-  generateInitParts(context, inCompType, compType, ufsFormals, formalTypes);
+  generateInitParts(context, inCompType, compType,
+                    ufsFormals, formalTypes, /*useGeneric*/ true);
 
   // consult the fields to build up the remaining untyped formals
   const DefaultsPolicy defaultsPolicy = DefaultsPolicy::IGNORE_DEFAULTS;
@@ -270,7 +276,8 @@ generateInitCopySignature(Context* context, const CompositeType* inCompType) {
   std::vector<UntypedFnSignature::FormalDetail> ufsFormals;
   std::vector<QualifiedType> formalTypes;
 
-  generateInitParts(context, inCompType, compType, ufsFormals, formalTypes);
+  generateInitParts(context, inCompType, compType,
+                    ufsFormals, formalTypes, /*useGeneric*/ true);
 
   // add a formal for the 'other' argument
   auto name = UniqueString::get(context, "other");
@@ -321,12 +328,13 @@ generateDeinitSignature(Context* context, const CompositeType* inCompType) {
   std::vector<UntypedFnSignature::FormalDetail> ufsFormals;
   std::vector<QualifiedType> formalTypes;
 
-  generateInitParts(context, inCompType, compType, ufsFormals, formalTypes);
+  generateInitParts(context, inCompType, compType,
+                    ufsFormals, formalTypes, /*useGeneric*/ false);
 
   // build the untyped signature
   auto ufs = UntypedFnSignature::get(context,
                         /*id*/ compType->id(),
-                        /*name*/ USTR("init"),
+                        /*name*/ USTR("deinit"),
                         /*isMethod*/ true,
                         /*isTypeConstructor*/ false,
                         /*isCompilerGenerated*/ true,
@@ -337,15 +345,11 @@ generateDeinitSignature(Context* context, const CompositeType* inCompType) {
                         /*whereClause*/ nullptr);
 
   // now build the other pieces of the typed signature
-  auto g = getTypeGenericity(context, formalTypes[0].type());
-  bool needsInstantiation = (g == Type::GENERIC ||
-                             g == Type::GENERIC_WITH_DEFAULTS);
-
   auto ret = TypedFnSignature::get(context,
                                    ufs,
                                    std::move(formalTypes),
                                    TypedFnSignature::WHERE_NONE,
-                                   needsInstantiation,
+                                   /*needsInstantiation*/ false,
                                    /* instantiatedFrom */ nullptr,
                                    /* parentFn */ nullptr,
                                    /* formalsInstantiated */ Bitmap());

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -295,7 +295,7 @@ generateInitCopySignature(Context* context, const CompositeType* inCompType) {
   // build the untyped signature
   auto ufs = UntypedFnSignature::get(context,
                         /*id*/ compType->id(),
-                        /*name*/ USTR("init"),
+                        /*name*/ USTR("init="),
                         /*isMethod*/ true,
                         /*isTypeConstructor*/ false,
                         /*isCompilerGenerated*/ true,
@@ -513,6 +513,8 @@ getCompilerGeneratedMethodQuery(Context* context, const Type* type,
       CHPL_ASSERT(false && "Not implemented yet!");
     }
   }
+
+  CHPL_ASSERT(result->untyped()->name() == name);
 
   return QUERY_END(result);
 }

--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -914,7 +914,8 @@ static bool helpComputeReturnType(Context* context,
   // if method call and the receiver points to a composite type definition,
   // then it's some sort of compiler-generated method
   } else if (untyped->isCompilerGenerated()) {
-    if (untyped->name() == USTR("init")) {
+    if (untyped->name() == USTR("init") ||
+        untyped->name() == USTR("deinit")) {
       result = QualifiedType(QualifiedType::CONST_VAR,
                              VoidType::get(context));
       return true;

--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -915,6 +915,7 @@ static bool helpComputeReturnType(Context* context,
   // then it's some sort of compiler-generated method
   } else if (untyped->isCompilerGenerated()) {
     if (untyped->name() == USTR("init") ||
+        untyped->name() == USTR("init=") ||
         untyped->name() == USTR("deinit")) {
       result = QualifiedType(QualifiedType::CONST_VAR,
                              VoidType::get(context));

--- a/frontend/test/resolution/testGenericDefaults.cpp
+++ b/frontend/test/resolution/testGenericDefaults.cpp
@@ -158,10 +158,48 @@ static void test4() {
   }
 }
 
+// Test methods on generics with defaults
+static void test5() {
+  Context ctx;
+  auto context = &ctx;
+  ErrorGuard guard(context);
+  std::string program = R"""(
+    operator =(ref lhs: int, rhs : int) {
+      __primitive("=", lhs, rhs);
+    }
+
+    record R {
+      type T = int;
+      var x : int;
+
+      proc init(type T) {
+        this.T = T;
+        this.x = 0;
+      }
+
+      proc foobar() {
+      }
+    }
+
+    proc blah(x: R(string)) {
+      x.foobar();
+    }
+
+    var r : R(string);
+    r.foobar();
+    blah(r);
+  )""";
+
+  auto m = parseModule(context, program);
+  resolveModule(context, m->id());
+}
+
 int main() {
   test1();
   test2();
   test3();
   test4();
+  test5();
+
   return 0;
 }


### PR DESCRIPTION
This PR fixes several cases of resolution bugs involving methods or method-like things called on generic-with-defaults types. The called type is instantiated, of course, but the receiver in a number of cases is often fully-generic. Prior to this PR the compiler was automatically resolving the types in such a way that used the defaults, rather than leaving the receiver as generic as possible.

As a bonus, this PR also fixes an issue in ``can-pass`` where a formal whose type was "generic-with-defaults" was considered concrete, when it should be considered generic for the purposes of instantiation and candidate selection.

Lastly, this PR fixes some bugs on generic-with-defaults types for compiler-generated copy initializers and deinit methods. The bugs involved these compiler-generated TypedFnSignatures making their way through to the ``instantiateSignature`` function, which expects to be working with "real" uAST nodes, and instead encountered a segfault when trying to fetch the uAST of the compiler-generated methods. The solution is to directly instantiate the compiler-generated TypedFnSignatures since we know everything about the arguments for these methods.

A few tests are also added to ``frontend/test/resolution/testGenericDefaults.cpp``.

Testing:
- [x] local paratest