### PR TITLE
Fix sporadic Oct23Tutorial failures

### DIFF
--- a/test/exercises/Oct2023tutorial/04-atomic-type.chpl
+++ b/test/exercises/Oct2023tutorial/04-atomic-type.chpl
@@ -22,16 +22,16 @@ proc barrier(numTasks) {
 // the shortest, will not be past the barrier until all other tasks are done.
 const numTasks = 10;
 coforall i in 1..numTasks {
-  sleep(i);
+  sleep(i/100.0);
   barrier(numTasks);
 
 
   if i==1 {
     writeln("All tasks done sleeping");
     // reset the barrier
-    count.write(0); done.write(false);
+    count.write(0);
   }
-  
+
   // all tasks waiting for task 1 to finish resetting the barrier count
   count.waitFor(0);
 
@@ -55,4 +55,3 @@ writeln();
     bucketCount[i % m].add(1);
   writeln("bucketCount = ", bucketCount, ", 'ref' intent is also the default for atomic");
 }
-

--- a/test/exercises/Oct2023tutorial/parfilekmer.good
+++ b/test/exercises/Oct2023tutorial/parfilekmer.good
@@ -1,4 +1,4 @@
-Number of unique k-mers in DataDir/kmer_large_input_half.txt is 252
+
 
 Number of unique k-mers in DataDir/kmer_large_input.txt is 255
-
+Number of unique k-mers in DataDir/kmer_large_input_half.txt is 252

--- a/test/exercises/Oct2023tutorial/parfilekmer.prediff
+++ b/test/exercises/Oct2023tutorial/parfilekmer.prediff
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# sort output to ensure task IDs are listed in a deterministic order
+outfile=$2
+
+sort $outfile > $outfile.2
+mv $outfile.2 $outfile


### PR DESCRIPTION
Fix a couple of sporadic failures on Oct23tutorial tests:

* Fix a sporadic failure in `exercises/Oct2023tutorial/parfilekmer.chpl` due to output order being non-deterministic. A prediff is added to sort the output.
* Fix a sporadic timeout in `exercises/Oct2023tutorial/04-atomic-type.chpl`. With the original implementation, task 1 reset the barrier before other tasks finished waiting causing them to wait indefinitely. (Also lowers the amount of time spent sleeping to speed up test.) The test is no longer timing out - testing with 1000 trials.