### PR TITLE
Rename some GPU pref test configs and descriptions

### DIFF
--- a/util/cron/common-native-gpu-perf.bash
+++ b/util/cron/common-native-gpu-perf.bash
@@ -2,9 +2,7 @@
 #
 # Common GPU performance testing configs
 
-source $CWD/common-perf.bash
-
+# set this before sourcing common-perf
+export CHPL_TEST_PERF_SUBDIR='gpu'
 
 nightly_args="${nightly_args} -performance -perflabel gpu- -numtrials 5"
-export CHPL_TEST_PERF_SUBDIR='gpu'
-export CHPL_TEST_PERF_CONFIGS="aod:v,um"  # v: visible by def

--- a/util/cron/common-native-gpu-perf.bash
+++ b/util/cron/common-native-gpu-perf.bash
@@ -2,8 +2,9 @@
 #
 # Common GPU performance testing configs
 
-export CHPL_TEST_PERF_CONFIG_NAME='gpu'
 source $CWD/common-perf.bash
 
 
-export CHPL_TEST_PERF_CONFIGS="gpu-cuda:v,gpu-cuda.um"  # v: visible by def
+nightly_args="${nightly_args} -performance -perflabel gpu- -numtrials 5"
+export CHPL_TEST_PERF_SUBDIR='gpu'
+export CHPL_TEST_PERF_CONFIGS="aod:v,um"  # v: visible by def

--- a/util/cron/test-perf.gpu-cuda.bash
+++ b/util/cron/test-perf.gpu-cuda.bash
@@ -15,8 +15,9 @@ export CHPL_COMM=none
 
 
 source $CWD/common-native-gpu-perf.bash
+export CHPL_TEST_PERF_CONFIG_NAME="1-node-p100"
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.gpu-cuda"
-export CHPL_TEST_PERF_DESCRIPTION='gpu-cuda'
+export CHPL_TEST_PERF_DESCRIPTION='aod'
 
-nightly_args="${nightly_args} -performance -perflabel gpu- -numtrials 5 -startdate 07/15/22"
+nightly_args="${nightly_args} -startdate 07/15/22"
 $CWD/nightly -cron ${nightly_args}

--- a/util/cron/test-perf.gpu-cuda.bash
+++ b/util/cron/test-perf.gpu-cuda.bash
@@ -13,11 +13,15 @@ export CHPL_LAUNCHER_PARTITION=stormP100
 
 export CHPL_COMM=none
 
-
-source $CWD/common-native-gpu-perf.bash
-export CHPL_TEST_PERF_CONFIG_NAME="1-node-p100"
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.gpu-cuda"
-export CHPL_TEST_PERF_DESCRIPTION='aod'
+
+export CHPL_TEST_PERF_CONFIG_NAME="1-node-p100"
+source $CWD/common-native-gpu-perf.bash
+# make sure this comes after setting SUBDIR (set by native-gpu-perf) and
+# CONFIG_NAME
+source $CWD/common-perf.bash
+
 
 nightly_args="${nightly_args} -startdate 07/15/22"
+
 $CWD/nightly -cron ${nightly_args}

--- a/util/cron/test-perf.gpu-cuda.um.bash
+++ b/util/cron/test-perf.gpu-cuda.um.bash
@@ -15,8 +15,9 @@ export CHPL_COMM=none
 export CHPL_GPU_MEM_STRATEGY=unified_memory
 
 source $CWD/common-native-gpu-perf.bash
+export CHPL_TEST_PERF_CONFIG_NAME="1-node-p100"
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.gpu-cuda.um"
-export CHPL_TEST_PERF_DESCRIPTION='gpu-cuda.um'
+export CHPL_TEST_PERF_DESCRIPTION='um'
 
-nightly_args="${nightly_args} -performance -perflabel gpu- -numtrials 5 -startdate 07/15/22"
+nightly_args="${nightly_args} -startdate 07/15/22"
 $CWD/nightly -cron ${nightly_args}

--- a/util/cron/test-perf.gpu-cuda.um.bash
+++ b/util/cron/test-perf.gpu-cuda.um.bash
@@ -14,10 +14,15 @@ export CHPL_LAUNCHER_PARTITION=stormP100
 export CHPL_COMM=none
 export CHPL_GPU_MEM_STRATEGY=unified_memory
 
-source $CWD/common-native-gpu-perf.bash
-export CHPL_TEST_PERF_CONFIG_NAME="1-node-p100"
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.gpu-cuda.um"
-export CHPL_TEST_PERF_DESCRIPTION='um'
 
+export CHPL_TEST_PERF_CONFIG_NAME="1-node-p100"
+source $CWD/common-native-gpu-perf.bash
+# make sure this comes after setting SUBDIR (set by native-gpu-perf) and
+# CONFIG_NAME
+source $CWD/common-perf.bash
+
+SHORT_NAME=um
+nightly_args="${nightly_args} -performance-description $SHORT_NAME -performance-configs default:v,$SHORT_NAME:v -sync-dir-suffix $SHORT_NAME"
 nightly_args="${nightly_args} -startdate 07/15/22"
 $CWD/nightly -cron ${nightly_args}

--- a/util/cron/test-perf.gpu-rocm.bash
+++ b/util/cron/test-perf.gpu-rocm.bash
@@ -6,18 +6,22 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-slurm-gasnet-cray-cs.bash
 source $CWD/common-native-gpu.bash
 
-export CHPL_GPU=amd
-export CHPL_GPU_ARCH=gfx906
-export CHPL_LLVM=bundled
-export CHPL_COMM=none
-export CHPL_LAUNCHER_PARTITION=amdMI60
 module load rocm
 
-
-source $CWD/common-native-gpu-perf.bash
-export CHPL_TEST_PERF_CONFIG_NAME="1-node-mi60"
+export CHPL_GPU=amd
+export CHPL_LAUNCHER_PARTITION=amdMI60
+export CHPL_GPU_ARCH=gfx906
+export CHPL_COMM=none
+export CHPL_LLVM=bundled
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.gpu-rocm"
-unset CHPL_TEST_PERF_CONFIGS      # not applicable for this config
+
+export CHPL_TEST_PERF_CONFIG_NAME="1-node-mi60"
+source $CWD/common-native-gpu-perf.bash
+# make sure this comes after setting SUBDIR (set by native-gpu-perf) and
+# CONFIG_NAME
+source $CWD/common-perf.bash
+
 
 nightly_args="${nightly_args} -startdate 07/20/23"
+
 $CWD/nightly -cron ${nightly_args}

--- a/util/cron/test-perf.gpu-rocm.bash
+++ b/util/cron/test-perf.gpu-rocm.bash
@@ -14,9 +14,10 @@ export CHPL_LAUNCHER_PARTITION=amdMI60
 module load rocm
 
 
-export CHPL_TEST_PERF_CONFIG_NAME='gpu-rocm'
-source $CWD/common-perf.bash
+source $CWD/common-native-gpu-perf.bash
+export CHPL_TEST_PERF_CONFIG_NAME="1-node-mi60"
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.gpu-rocm"
+unset CHPL_TEST_PERF_CONFIGS      # not applicable for this config
 
-nightly_args="${nightly_args} -performance -perflabel gpu- -numtrials 5 -startdate 07/20/23"
+nightly_args="${nightly_args} -startdate 07/20/23"
 $CWD/nightly -cron ${nightly_args}


### PR DESCRIPTION
Part of https://github.com/Cray/chapel-private/issues/5399

Recently, I have broken GPU performance plots while fiddling with array_on_device testing. Currently, we run performance testing, but data goes to the wrong place and end up being not plotted, whereas our plots are missing that recent data.

This PR will not fix the problem, but will adjust names of configs so that there's a better structure in the generated dat files. I'll manually splice data when the new directories are online.

The structure I am hoping to achieve with this PR is

```
| gpu
|-- 1-node-p100
|---- aod
|---- um
|-- 1-node-mi60
```