### PR TITLE
Add missing `hash` specialization for new enums and avoid using non-portable `hasValue` on `optional`.

### DIFF
--- a/frontend/include/chpl/resolution/can-pass.h
+++ b/frontend/include/chpl/resolution/can-pass.h
@@ -142,7 +142,7 @@ class CanPassResult {
   bool passes() { return !failReason_; }
 
   PassingFailureReason reason() {
-    CHPL_ASSERT(failReason_.hasValue());
+    CHPL_ASSERT((bool) failReason_);
     return *failReason_;
   }
 

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -2080,6 +2080,19 @@ template<> struct hash<chpl::resolution::TypedFnSignature::WhereClauseResult>
   }
 };
 
+template<> struct hash<chpl::resolution::CandidateFailureReason>
+{
+  size_t operator()(const chpl::resolution::CandidateFailureReason& key) const {
+    return (size_t) key;
+  }
+};
+
+template<> struct hash<chpl::resolution::PassingFailureReason>
+{
+  size_t operator()(const chpl::resolution::PassingFailureReason& key) const {
+    return (size_t) key;
+  }
+};
 
 
 } // end namespace std


### PR DESCRIPTION
Tests under GCC 5.4 failed because that version of GCC doesn't auto-specialize hash for enums, and I added two enums in my `canPass` PR (#23709). This PR adds the missing specializations. It also replaces a call to `hasValue` (which doesn't work in all compile-time configs since Chapel's optionals are either `std::optional` or `llvm::Optional`) with a cast to bool, which works with both.

Reviewed by @riftEmber -- thanks!

## Testing
- [x] compiles with GCC 5.4
- [x] paratest