### PR TITLE
Move generated warnings in documentation and fix some spacing

### DIFF
--- a/modules/standard/ChapelIO.chpl
+++ b/modules/standard/ChapelIO.chpl
@@ -22,11 +22,6 @@
 
 Basic types and utilities in support of I/O operation.
 
-.. warning::
-
-   The module name 'ChapelIO' is unstable.  If you want to use qualified naming
-   on the symbols within it, please ``use`` or ``import`` the :mod:`IO` module.
-
 Most of Chapel's I/O support is within the :mod:`IO` module.  This section
 describes automatically included basic types and routines that support the
 :mod:`IO` module.

--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -52,7 +52,7 @@ Automatically Available Symbols
 .. include:: AutoMath.rst
   :start-line: 7
   :start-after: Automatically included Math symbols
-  :end-before: .. warning::
+  :end-before: .. function::
 
 Non-Automatically Available Symbols
 -----------------------------------
@@ -167,7 +167,7 @@ Automatically Included Constant and Function Definitions
 --------------------------------------------------------
 
 .. include:: AutoMath.rst
-  :start-after: The module name 'AutoMath' is unstable.  If you want to use qualified naming on the symbols within it, please 'use' or 'import' the :mod:`Math` module
+  :start-after: :proc:`~Math.mod`
 
 .. _math-constant-and-function-definitions:
 

--- a/test/chpldoc/classes/basic.doc.good
+++ b/test/chpldoc/classes/basic.doc.good
@@ -69,7 +69,6 @@ that lies in the module that Lydia built
    sad and alone, listed behind the proc that lies in the module
    that Lydia built 
 
-
 .. default-domain:: chpl
 
 .. module:: classesAreGrown
@@ -102,7 +101,6 @@ Lydia built
    classes are grown, sister of the class with nary a tone,
    declared in the module all sad and alone, listed behind 
    the proc that lies in the module that Lydia built. 
-
 
 .. function:: proc thoroughlyMiffed()
 

--- a/test/chpldoc/classes/deprecatedClasses.doc.good
+++ b/test/chpldoc/classes/deprecatedClasses.doc.good
@@ -87,100 +87,97 @@ or
 
 .. class:: A
 
-   There was documentation of this symbol 
-
-
    .. warning::
 
       A is deprecated
 
-   .. attribute:: var a: int
+   There was documentation of this symbol 
 
-      There was documentation of this field 
+   .. attribute:: var a: int
 
       .. warning::
 
          a is deprecated
 
-   .. method:: proc foo()
+      There was documentation of this field 
 
-      There was documentation of this method 
+   .. method:: proc foo()
 
       .. warning::
 
          foo is deprecated
 
-   .. method:: proc type bar()
+      There was documentation of this method 
 
-      There was documentation of this type method 
+   .. method:: proc type bar()
 
       .. warning::
 
          bar is deprecated
 
+      There was documentation of this type method 
+
 .. class:: B
-
-   This symbol also was documented 
-
 
    .. warning::
 
       B is deprecated, use C instead
 
-   .. attribute:: var a: int
+   This symbol also was documented 
 
-      There was documentation of this field 
+   .. attribute:: var a: int
 
       .. warning::
 
          field a is deprecated
 
-   .. method:: proc foo()
+      There was documentation of this field 
 
-      There was documentation of this method 
+   .. method:: proc foo()
 
       .. warning::
 
          method foo is deprecated
 
-   .. method:: proc type bar()
+      There was documentation of this method 
 
-      There was documentation of this type method 
+   .. method:: proc type bar()
 
       .. warning::
 
          type method bar is deprecated
 
+      There was documentation of this type method 
+
 .. class:: C
 
    .. attribute:: var a: int
-
-      There was documentation of this field 
 
       .. warning::
 
          a is deprecated
 
-   .. method:: proc foo()
+      There was documentation of this field 
 
-      There was documentation of this method 
+   .. method:: proc foo()
 
       .. warning::
 
          method foo is deprecated
 
-   .. method:: proc type bar()
+      There was documentation of this method 
 
-      There was documentation of this type method 
+   .. method:: proc type bar()
 
       .. warning::
 
          bar is deprecated
 
+      There was documentation of this type method 
+
 .. class:: D
 
    This symbol is deprecated 
-
 
    .. attribute:: var a: int
 
@@ -197,7 +194,6 @@ or
 .. class:: E
 
    This symbol is also deprecated, please use F instead 
-
 
    .. attribute:: var a: int
 

--- a/test/chpldoc/classes/fieldInheritance.doc.good
+++ b/test/chpldoc/classes/fieldInheritance.doc.good
@@ -21,7 +21,6 @@ or
 
    This class has two fields 
 
-
    .. attribute:: var rod: string
 
    .. attribute:: var staff: bool
@@ -29,7 +28,6 @@ or
 .. class:: Younger : Elder
 
    This class should inherit its Elder's fields 
-
 
    .. attribute:: var key: int
 

--- a/test/chpldoc/classes/forwards-generic.doc.good
+++ b/test/chpldoc/classes/forwards-generic.doc.good
@@ -21,7 +21,6 @@ or
 
    This class should not get the forwarded methods from B 
 
-
    .. attribute:: var f
 
 .. class:: B

--- a/test/chpldoc/classes/forwards.doc.bad
+++ b/test/chpldoc/classes/forwards.doc.bad
@@ -21,7 +21,6 @@ or
 
    This class should get the forwarded methods from B 
 
-
    .. attribute:: var f: B
 
 .. class:: B

--- a/test/chpldoc/classes/forwards.doc.good
+++ b/test/chpldoc/classes/forwards.doc.good
@@ -21,7 +21,6 @@ or
 
    This class should get the forwarded methods from B 
 
-
    .. attribute:: var f: B
 
    .. method:: proc someProc()

--- a/test/chpldoc/classes/inheritance.doc.good
+++ b/test/chpldoc/classes/inheritance.doc.good
@@ -21,7 +21,6 @@ or
 
    The eldest 
 
-
    .. method:: proc getOffMyLawn()
 
       You durn kids! 
@@ -32,7 +31,6 @@ or
 
    Second generation 
 
-
    .. method:: proc goToYourRoom()
 
       Grounded! 
@@ -42,7 +40,6 @@ or
 .. class:: Child : Parent
 
    Reaping the benefits of third generation status 
-
 
    .. method:: proc whine()
 

--- a/test/chpldoc/classes/lifetimeChecking-generic.doc.good
+++ b/test/chpldoc/classes/lifetimeChecking-generic.doc.good
@@ -21,13 +21,11 @@ or
 
    Generic type for use with all the lifetime checking styles 
 
-
    .. attribute:: type t
 
 .. class:: Foo
 
    Used to demonstrate the behavior of lifetime checking and documentation 
-
 
    .. attribute:: var a: unmanaged MyGeneric(int)
 

--- a/test/chpldoc/classes/lifetimeChecking-notype.doc.good
+++ b/test/chpldoc/classes/lifetimeChecking-notype.doc.good
@@ -21,7 +21,6 @@ or
 
    Used to demonstrate the behavior of lifetime checking and documentation 
 
-
    .. attribute:: var a: unmanaged
 
    .. attribute:: var b: shared

--- a/test/chpldoc/classes/lifetimeChecking.doc.good
+++ b/test/chpldoc/classes/lifetimeChecking.doc.good
@@ -21,7 +21,6 @@ or
 
    Used to demonstrate the behavior of lifetime checking and documentation 
 
-
    .. attribute:: var a: unmanaged Foo
 
    .. attribute:: var b: shared Foo

--- a/test/chpldoc/classes/methodOutsideClassDef.doc.good
+++ b/test/chpldoc/classes/methodOutsideClassDef.doc.good
@@ -22,7 +22,6 @@ or
    This class will declare a method inside itself, but will have a
    method declared outside it as well 
 
-
    .. method:: proc internalMeth()
 
 .. method:: proc Foo.externalMeth1()
@@ -34,7 +33,6 @@ or
 .. record:: Bar
 
    Declares one primary and one secondary method... 
-
 
    .. method:: proc internal()
 

--- a/test/chpldoc/classes/unstableClasses.doc.catfiles
+++ b/test/chpldoc/classes/unstableClasses.doc.catfiles
@@ -1,0 +1,1 @@
+docs/source/modules/unstableClasses.doc.rst

--- a/test/chpldoc/classes/unstableClasses.doc.chpl
+++ b/test/chpldoc/classes/unstableClasses.doc.chpl
@@ -1,0 +1,130 @@
+// Checks basic unstable declarations of classes
+@unstable class X {
+  // Also fields, methods, and type methods
+  @unstable var a: int;
+  @unstable proc foo() { }
+  @unstable proc type bar() {}
+}
+
+@unstable(reason="Y is unstable, use Z instead") class Y {
+  // Also fields, methods, and type methods
+  @unstable(reason="field a is unstable") var a: int;
+  @unstable(reason="method foo is unstable") proc foo() { }
+  @unstable(reason="type method bar is unstable") proc type bar() {}
+}
+
+class Z {
+  // Checks unstable fields, methods and type methods in an ununstable class
+  @unstable var a: int;
+  @unstable(reason="method foo is unstable") proc foo() { }
+  @unstable proc type bar() { }
+}
+
+// Checks interaction with documentation
+/* There was documentation of this symbol */
+@unstable class A {
+  // Also fields, methods, and type methods
+
+  /* There was documentation of this field */
+  @unstable var a: int;
+  /* There was documentation of this method */
+  @unstable proc foo() { }
+  /* There was documentation of this type method */
+  @unstable proc type bar() {}
+}
+
+/* This symbol also was documented */
+@unstable(reason="B is unstable, use C instead") class B {
+  // Also fields, methods, and type methods
+
+  /* There was documentation of this field */
+  @unstable(reason="field a is unstable") var a: int;
+  /* There was documentation of this method */
+  @unstable(reason="method foo is unstable") proc foo() { }
+  /* There was documentation of this type method */
+  @unstable(reason="type method bar is unstable") proc type bar() {}
+}
+
+class C {
+  // Checks unstable fields, methods and type methods in an ununstable class
+  // when the unstable symbols are also documented
+
+  /* There was documentation of this field */
+  @unstable var a: int;
+  /* There was documentation of this method */
+  @unstable(reason="method foo is unstable") proc foo() { }
+  /* There was documentation of this type method */
+  @unstable proc type bar() { }
+}
+
+// Checks interaction when documentation mentions deprecation in some form
+/* This symbol is unstable */
+@unstable class D {
+  // Also fields, methods, and type methods
+
+  /* This symbol is unstable */
+  @unstable var a: int;
+  /* This symbol is unstable */
+  @unstable proc foo() { }
+  /* This symbol is unstable */
+  @unstable proc type bar() {}
+}
+
+/* This symbol is also unstable, please use F instead */
+@unstable(reason="E is unstable, use F instead") class E {
+  // Also fields, methods, and type methods
+
+  /* This symbol is also unstable, unfortunately */
+  @unstable(reason="field a is unstable") var a: int;
+  /* This symbol is also unstable, unfortunately */
+  @unstable(reason="method foo is unstable") proc foo() { }
+  /* This symbol is also unstable, unfortunately */
+  @unstable(reason="type method bar is unstable") proc type bar() {}
+}
+
+class F {
+  // Checks unstable fields, methods and type methods in an ununstable class
+  // when the unstable symbols are also documented and the documentation
+  // mentions deprecation
+
+  /* This symbol is also unstable, unfortunately */
+  @unstable var a: int;
+  /* This symbol is unstable */
+  @unstable(reason="method foo is unstable") proc foo() { }
+  /* This symbol is unstable */
+  @unstable proc type bar() { }
+}
+
+// Ensures deprecation doesn't cause "no doc" symbols to turn up in
+// documentation
+@chpldoc.nodoc
+@unstable class G {
+  // Also fields, methods, and type methods
+  @chpldoc.nodoc
+  @unstable var a: int;
+  @chpldoc.nodoc
+  @unstable proc foo() { }
+  @chpldoc.nodoc
+  @unstable proc type bar() {}
+}
+
+@chpldoc.nodoc
+@unstable(reason="H is unstable, use I instead") class H {
+  // Also fields, methods, and type methods
+  @chpldoc.nodoc
+  @unstable(reason="field a is unstable") var a: int;
+  @chpldoc.nodoc
+  @unstable(reason="method foo is unstable") proc foo() { }
+  @chpldoc.nodoc
+  @unstable(reason="type method bar is unstable") proc type bar() {}
+}
+
+class I {
+  // Checks unstable fields, methods and type methods in an ununstable class
+  @chpldoc.nodoc
+  @unstable var a: int;
+  @chpldoc.nodoc
+  @unstable(reason="method foo is unstable") proc foo() { }
+  @chpldoc.nodoc
+  @unstable proc type bar() { }
+}

--- a/test/chpldoc/classes/unstableClasses.doc.good
+++ b/test/chpldoc/classes/unstableClasses.doc.good
@@ -1,0 +1,225 @@
+.. default-domain:: chpl
+
+.. module:: unstableClasses.doc
+
+unstableClasses.doc
+===================
+**Usage**
+
+.. code-block:: chapel
+
+   use unstableClasses.doc;
+
+
+or
+
+.. code-block:: chapel
+
+   import unstableClasses.doc;
+
+.. class:: X
+
+   .. warning::
+
+      X is unstable
+
+   .. attribute:: var a: int
+
+      .. warning::
+
+         a is unstable
+
+   .. method:: proc foo()
+
+      .. warning::
+
+         foo is unstable
+
+   .. method:: proc type bar()
+
+      .. warning::
+
+         bar is unstable
+
+.. class:: Y
+
+   .. warning::
+
+      Y is unstable, use Z instead
+
+   .. attribute:: var a: int
+
+      .. warning::
+
+         field a is unstable
+
+   .. method:: proc foo()
+
+      .. warning::
+
+         method foo is unstable
+
+   .. method:: proc type bar()
+
+      .. warning::
+
+         type method bar is unstable
+
+.. class:: Z
+
+   .. attribute:: var a: int
+
+      .. warning::
+
+         a is unstable
+
+   .. method:: proc foo()
+
+      .. warning::
+
+         method foo is unstable
+
+   .. method:: proc type bar()
+
+      .. warning::
+
+         bar is unstable
+
+.. class:: A
+
+   .. warning::
+
+      A is unstable
+
+   There was documentation of this symbol 
+
+   .. attribute:: var a: int
+
+      .. warning::
+
+         a is unstable
+
+      There was documentation of this field 
+
+   .. method:: proc foo()
+
+      .. warning::
+
+         foo is unstable
+
+      There was documentation of this method 
+
+   .. method:: proc type bar()
+
+      .. warning::
+
+         bar is unstable
+
+      There was documentation of this type method 
+
+.. class:: B
+
+   .. warning::
+
+      B is unstable, use C instead
+
+   This symbol also was documented 
+
+   .. attribute:: var a: int
+
+      .. warning::
+
+         field a is unstable
+
+      There was documentation of this field 
+
+   .. method:: proc foo()
+
+      .. warning::
+
+         method foo is unstable
+
+      There was documentation of this method 
+
+   .. method:: proc type bar()
+
+      .. warning::
+
+         type method bar is unstable
+
+      There was documentation of this type method 
+
+.. class:: C
+
+   .. attribute:: var a: int
+
+      .. warning::
+
+         a is unstable
+
+      There was documentation of this field 
+
+   .. method:: proc foo()
+
+      .. warning::
+
+         method foo is unstable
+
+      There was documentation of this method 
+
+   .. method:: proc type bar()
+
+      .. warning::
+
+         bar is unstable
+
+      There was documentation of this type method 
+
+.. class:: D
+
+   This symbol is unstable 
+
+   .. attribute:: var a: int
+
+      This symbol is unstable 
+
+   .. method:: proc foo()
+
+      This symbol is unstable 
+
+   .. method:: proc type bar()
+
+      This symbol is unstable 
+
+.. class:: E
+
+   This symbol is also unstable, please use F instead 
+
+   .. attribute:: var a: int
+
+      This symbol is also unstable, unfortunately 
+
+   .. method:: proc foo()
+
+      This symbol is also unstable, unfortunately 
+
+   .. method:: proc type bar()
+
+      This symbol is also unstable, unfortunately 
+
+.. class:: F
+
+   .. attribute:: var a: int
+
+      This symbol is also unstable, unfortunately 
+
+   .. method:: proc foo()
+
+      This symbol is unstable 
+
+   .. method:: proc type bar()
+
+      This symbol is unstable 
+
+.. class:: I
+

--- a/test/chpldoc/deprecatedSymbols.doc.catfiles
+++ b/test/chpldoc/deprecatedSymbols.doc.catfiles
@@ -1,1 +1,4 @@
 docs/source/modules/deprecatedSymbols.doc.rst
+docs/source/modules/deprecatedSymbols.doc/DeprecatedMod1.rst
+docs/source/modules/deprecatedSymbols.doc/DeprecatedMod2.rst
+docs/source/modules/deprecatedSymbols.doc/DeprecatedMod3.rst

--- a/test/chpldoc/deprecatedSymbols.doc.chpl
+++ b/test/chpldoc/deprecatedSymbols.doc.chpl
@@ -23,3 +23,20 @@ var f: real;
 @deprecated var g: int;
 @chpldoc.nodoc
 @deprecated(notes="h is deprecated, use z instead") var h: int;
+
+
+// Ensures that modules respond appropriately to deprecated
+@deprecated
+module DeprecatedMod1 {
+}
+
+@deprecated("This module is deprecated")
+module DeprecatedMod2 {
+}
+
+/* Including modules with documentation */
+@deprecated("This module is deprecated")
+module DeprecatedMod3 {
+  /* Just a regular symbol to show how it interacts */
+  var x: int;
+}

--- a/test/chpldoc/deprecatedSymbols.doc.good
+++ b/test/chpldoc/deprecatedSymbols.doc.good
@@ -33,19 +33,19 @@ or
 
 .. data:: var a: string
 
-   There was documentation of this symbol 
-
    .. warning::
 
       a is deprecated
 
-.. data:: var b: string
+   There was documentation of this symbol 
 
-   This symbol also was documented 
+.. data:: var b: string
 
    .. warning::
 
       b is deprecated, use c instead
+
+   This symbol also was documented 
 
 .. data:: var c: string
 

--- a/test/chpldoc/deprecatedSymbols.doc.good
+++ b/test/chpldoc/deprecatedSymbols.doc.good
@@ -1,3 +1,4 @@
+warning in deprecatedSymbols.doc.chpl:2: an implicit module named 'deprecatedSymbols.doc' is being introduced to contain file-scope code
 .. default-domain:: chpl
 
 .. module:: deprecatedSymbols.doc
@@ -16,6 +17,14 @@ or
 .. code-block:: chapel
 
    import deprecatedSymbols.doc;
+
+**Submodules**
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   deprecatedSymbols.doc/*
 
 .. data:: var x: int
 
@@ -58,4 +67,80 @@ or
    This symbol is also deprecated, please use f instead 
 
 .. data:: var f: real
+
+.. default-domain:: chpl
+
+.. module:: DeprecatedMod1
+
+DeprecatedMod1
+==============
+**Usage**
+
+.. code-block:: chapel
+
+   use deprecatedSymbols.doc.DeprecatedMod1;
+
+
+or
+
+.. code-block:: chapel
+
+   import deprecatedSymbols.doc.DeprecatedMod1;
+
+.. warning::
+
+   DeprecatedMod1 is deprecated
+
+.. default-domain:: chpl
+
+.. module:: DeprecatedMod2
+
+DeprecatedMod2
+==============
+**Usage**
+
+.. code-block:: chapel
+
+   use deprecatedSymbols.doc.DeprecatedMod2;
+
+
+or
+
+.. code-block:: chapel
+
+   import deprecatedSymbols.doc.DeprecatedMod2;
+
+.. warning::
+
+   This module is deprecated
+
+.. default-domain:: chpl
+
+.. module:: DeprecatedMod3
+   :synopsis: Including modules with documentation 
+
+DeprecatedMod3
+==============
+**Usage**
+
+.. code-block:: chapel
+
+   use deprecatedSymbols.doc.DeprecatedMod3;
+
+
+or
+
+.. code-block:: chapel
+
+   import deprecatedSymbols.doc.DeprecatedMod3;
+
+.. warning::
+
+   This module is deprecated
+
+Including modules with documentation 
+
+.. data:: var x: int
+
+   Just a regular symbol to show how it interacts 
 

--- a/test/chpldoc/enum/deprecatedEnum.doc.good
+++ b/test/chpldoc/enum/deprecatedEnum.doc.good
@@ -53,11 +53,11 @@ or
 
 .. enum:: enum atomicSymbols { proton, electron, neutron }
 
-   There was documentation of this symbol 
-
    .. warning::
 
       atomicSymbols is deprecated
+
+   There was documentation of this symbol 
 
    .. enumconstant:: enum constant proton
 
@@ -67,11 +67,11 @@ or
 
 .. enum:: enum monsters { vampire, werewolf, ghost }
 
-   This symbol also was documented 
-
    .. warning::
 
       monsters is deprecated, use monsterMash instead
+
+   This symbol also was documented 
 
    .. enumconstant:: enum constant vampire
 

--- a/test/chpldoc/functions/deprecatedFunctions.doc.good
+++ b/test/chpldoc/functions/deprecatedFunctions.doc.good
@@ -33,19 +33,19 @@ or
 
 .. function:: proc alpha()
 
-   There was documentation of this symbol 
-
    .. warning::
 
       alpha is deprecated
 
-.. function:: proc beta()
-
    There was documentation of this symbol 
+
+.. function:: proc beta()
 
    .. warning::
 
       beta is deprecated, use gamma instead
+
+   There was documentation of this symbol 
 
 .. function:: proc gamma()
 

--- a/test/chpldoc/globals/deprecateExternTypeVars.doc.good
+++ b/test/chpldoc/globals/deprecateExternTypeVars.doc.good
@@ -33,19 +33,19 @@ or
 
 .. type:: type Blah4
 
-   There was documentation of this symbol 
-
    .. warning::
 
       Blah4 is deprecated
 
-.. type:: type Blah5
+   There was documentation of this symbol 
 
-   This symbol also was documented 
+.. type:: type Blah5
 
    .. warning::
 
       Blah5 is deprecated, use Blah6 instead
+
+   This symbol also was documented 
 
 .. type:: type Blah6
 

--- a/test/chpldoc/linkage-spec/exportTest.doc.good
+++ b/test/chpldoc/linkage-spec/exportTest.doc.good
@@ -98,7 +98,6 @@ or
 
    Commenting exportRecordComment 
 
-
    .. attribute:: var field: int
 
       Commenting a field 
@@ -108,7 +107,6 @@ or
 .. record:: exportRecordRenamedComment
 
    Commenting exportRecordRenamedComment 
-
 
    .. attribute:: var field: int
 

--- a/test/chpldoc/linkage-spec/externTest.doc.good
+++ b/test/chpldoc/linkage-spec/externTest.doc.good
@@ -74,7 +74,6 @@ or
 
    Commenting externRecordComment 
 
-
    .. attribute:: var field: int
 
       Commenting a field 
@@ -84,7 +83,6 @@ or
 .. record:: externRecordRenamedComment
 
    Commenting externRecordRenamedComment 
-
 
    .. attribute:: var field: int
 

--- a/test/chpldoc/nested.doc.good
+++ b/test/chpldoc/nested.doc.good
@@ -26,7 +26,6 @@ or
    
      a code block!
 
-
    .. attribute:: var x: int
 
    .. method:: proc foo()
@@ -43,7 +42,6 @@ or
         This code-block should not overflow to 'innerMethod'!
       
       
-
 
       .. method:: proc innerMethod()
 

--- a/test/chpldoc/types/fields/enums.doc.good
+++ b/test/chpldoc/types/fields/enums.doc.good
@@ -31,7 +31,6 @@ or
 
    This class holds many different colors 
 
-
    .. attribute:: var defOnly = Color.Yellow
 
       Field has only enum as a default value 

--- a/test/chpldoc/types/fields/typevar.doc.good
+++ b/test/chpldoc/types/fields/typevar.doc.good
@@ -21,7 +21,6 @@ or
 
    This class has type fields 
 
-
    .. attribute:: type t1
 
    .. attribute:: type t2

--- a/test/chpldoc/types/fields/usesTypeVar.doc.good
+++ b/test/chpldoc/types/fields/usesTypeVar.doc.good
@@ -21,7 +21,6 @@ or
 
    This class uses the type field as the type of another field 
 
-
    .. attribute:: type t
 
       To be used 

--- a/test/chpldoc/unstableSymbols.doc.catfiles
+++ b/test/chpldoc/unstableSymbols.doc.catfiles
@@ -1,3 +1,4 @@
 docs/source/modules/unstableSymbols.doc.rst
 docs/source/modules/unstableSymbols.doc/UnstableMod1.rst
 docs/source/modules/unstableSymbols.doc/UnstableMod2.rst
+docs/source/modules/unstableSymbols.doc/UnstableMod3.rst

--- a/test/chpldoc/unstableSymbols.doc.chpl
+++ b/test/chpldoc/unstableSymbols.doc.chpl
@@ -25,10 +25,18 @@
 @chpldoc.nodoc
 @unstable("j is unstable, don't use it") var j: int;
 
+// Ensures that modules respond appropriately to unstable
 @unstable
 module UnstableMod1 {
 }
 
 @unstable("This module is unstable")
 module UnstableMod2 {
+}
+
+/* Including modules with documentation */
+@unstable("This module is unstable")
+module UnstableMod3 {
+  /* Just a regular symbol to show how it interacts */
+  var x: int;
 }

--- a/test/chpldoc/unstableSymbols.doc.good
+++ b/test/chpldoc/unstableSymbols.doc.good
@@ -124,3 +124,33 @@ or
 
    This module is unstable
 
+.. default-domain:: chpl
+
+.. module:: UnstableMod3
+   :synopsis: Including modules with documentation 
+
+UnstableMod3
+============
+**Usage**
+
+.. code-block:: chapel
+
+   use unstableSymbols.doc.UnstableMod3;
+
+
+or
+
+.. code-block:: chapel
+
+   import unstableSymbols.doc.UnstableMod3;
+
+.. warning::
+
+   This module is unstable
+
+Including modules with documentation 
+
+.. data:: var x: int
+
+   Just a regular symbol to show how it interacts 
+

--- a/test/chpldoc/unstableSymbols.doc.good
+++ b/test/chpldoc/unstableSymbols.doc.good
@@ -40,19 +40,19 @@ or
 
 .. data:: var c: string
 
-   There was documentation of this symbol 
-
    .. warning::
 
       c is unstable
 
-.. data:: var d: string
+   There was documentation of this symbol 
 
-   This symbol was also documented 
+.. data:: var d: string
 
    .. warning::
 
       d is unstable, don't use it
+
+   This symbol was also documented 
 
 .. data:: var e: real
 
@@ -64,19 +64,19 @@ or
 
 .. data:: var g: bool
 
-   This symbol is not considered stable 
-
    .. warning::
 
       g is unstable
 
-.. data:: var h: bool
+   This symbol is not considered stable 
 
-   This symbol is also not considered stable 
+.. data:: var h: bool
 
    .. warning::
 
       h is unstable, don't use it
+
+   This symbol is also not considered stable 
 
 .. default-domain:: chpl
 

--- a/tools/chpldoc/chpldoc.cpp
+++ b/tools/chpldoc/chpldoc.cpp
@@ -1457,18 +1457,17 @@ struct RstResultBuilder {
     node->traverse(ppv);
     if (!textOnly_) os_ << "\n";
 
-    bool commentShown = showComment(node, indentComment);
-    // TODO: Fix all this because why are we checking for specific node types
-    //  just to add a newline?
-    if (commentShown && !textOnly_ && (node->isClass() ||
-                                       node->isRecord() ||
-                                       node->isModule())) {
-      os_ << "\n";
-    }
-
     showDeprecationMessage(node, indentComment);
     // TODO: how do deprecation and unstable messages interplay?
     showUnstableWarning(node, indentComment);
+
+    bool commentShown = showComment(node, indentComment);
+    // TODO: Fix all this because why are we checking for specific node types
+    //  just to add a newline?
+    if (commentShown && !textOnly_ && node->isModule()) {
+      os_ << "\n";
+    }
+
     return commentShown;
   }
 
@@ -1482,6 +1481,12 @@ struct RstResultBuilder {
           // do nothing because unstable was mentioned in doc comment
         } else {
           // write the unstable warning and message
+          // TODO: Fix all this because why are we checking for specific node
+          // types just to add a newline?
+          if (!textOnly_ && !node->isModule()) {
+            os_ << "\n";
+          }
+
           int commentShift = 0;
           if (indentComment) {
             indentStream(os_, indentDepth_ * indentPerDepth);
@@ -1496,7 +1501,13 @@ struct RstResultBuilder {
             // use the specific unstable message
             os_ << strip(attrs->unstableMessage().c_str());
           }
-          os_ << "\n\n";
+          os_ << "\n";
+          // TODO: Fix all this because why are we checking for specific node
+          // types just to add a newline?
+          if (!textOnly_ && (node->isClass() || node->isRecord() ||
+                             node->isModule())) {
+            os_ << "\n";
+          }
         }
       }
     }
@@ -1512,6 +1523,12 @@ struct RstResultBuilder {
             // do nothing because deprecation was mentioned in doc comment
         } else {
           // write the deprecation warning and message
+          // TODO: Fix all this because why are we checking for specific node
+          // types just to add a newline?
+          if (!textOnly_ && !node->isModule()) {
+            os_ << "\n";
+          }
+
           int commentShift = 0;
           if (indentComment) {
             indentStream(os_, indentDepth_ * indentPerDepth);
@@ -1526,7 +1543,12 @@ struct RstResultBuilder {
             // use the specific deprecation message
             os_ << strip(attrs->deprecationMessage().c_str());
           }
-          os_ << "\n\n";
+          os_ << "\n";
+          // TODO: Fix all this because why are we checking for specific node
+          // types just to add a newline?
+          if (!textOnly_ && (node->isModule())) {
+            os_ << "\n";
+          }
         }
       }
     }

--- a/tools/chpldoc/chpldoc.cpp
+++ b/tools/chpldoc/chpldoc.cpp
@@ -1504,8 +1504,7 @@ struct RstResultBuilder {
           os_ << "\n";
           // TODO: Fix all this because why are we checking for specific node
           // types just to add a newline?
-          if (!textOnly_ && (node->isClass() || node->isRecord() ||
-                             node->isModule())) {
+          if (!textOnly_ && node->isModule()) {
             os_ << "\n";
           }
         }

--- a/tools/chpldoc/chpldoc.cpp
+++ b/tools/chpldoc/chpldoc.cpp
@@ -1481,11 +1481,7 @@ struct RstResultBuilder {
           // do nothing because unstable was mentioned in doc comment
         } else {
           // write the unstable warning and message
-          // TODO: Fix all this because why are we checking for specific node
-          // types just to add a newline?
-          if (!textOnly_ && !node->isModule()) {
-            os_ << "\n";
-          }
+          os_ << "\n";
 
           int commentShift = 0;
           if (indentComment) {
@@ -1502,11 +1498,6 @@ struct RstResultBuilder {
             os_ << strip(attrs->unstableMessage().c_str());
           }
           os_ << "\n";
-          // TODO: Fix all this because why are we checking for specific node
-          // types just to add a newline?
-          if (!textOnly_ && node->isModule()) {
-            os_ << "\n";
-          }
         }
       }
     }
@@ -1732,9 +1723,9 @@ struct RstResultBuilder {
       }
     }
     if (textOnly_) indentDepth_ --;
-    showComment(m, textOnly_);
     showDeprecationMessage(m, false);
     showUnstableWarning(m, false);
+    showComment(m, textOnly_);
     if (textOnly_) indentDepth_ ++;
 
     visitChildren(m);

--- a/tools/chpldoc/chpldoc.cpp
+++ b/tools/chpldoc/chpldoc.cpp
@@ -1513,11 +1513,7 @@ struct RstResultBuilder {
             // do nothing because deprecation was mentioned in doc comment
         } else {
           // write the deprecation warning and message
-          // TODO: Fix all this because why are we checking for specific node
-          // types just to add a newline?
-          if (!textOnly_ && !node->isModule()) {
-            os_ << "\n";
-          }
+          os_ << "\n";
 
           int commentShift = 0;
           if (indentComment) {
@@ -1534,11 +1530,6 @@ struct RstResultBuilder {
             os_ << strip(attrs->deprecationMessage().c_str());
           }
           os_ << "\n";
-          // TODO: Fix all this because why are we checking for specific node
-          // types just to add a newline?
-          if (!textOnly_ && (node->isModule())) {
-            os_ << "\n";
-          }
         }
       }
     }


### PR DESCRIPTION
Resolves #23018 

We want deprecation and unstable documentation notes to be generated before the
documentation comment.  When it was at the end of the documentation comment, it
could confuse users into thinking that it was associated with the later symbol
instead of the preceding one.  By placing it between the symbol header and its
documentation comment, it's more clear what it is associated with.

While here, ended up mucking about a bit with the spacing after class, record, and
module comments in general.  I think the situation is improved now, but it did
require updating some test files.

Updated ChapelIO and AutoMath's handling in our generated online documentation:
- ChapelIO no longer needs an explicit warning and can now rely on the generated
  one ending up in the right place
- Math's indicators of when to start and stop including information from
  AutoMath needed to adjust for the new generated location of the unstable
  warning

Updated the unstable and deprecated chpldoc tests for the new expected
behavior.  Added a test of unstable and classes, since there wasn't coverage
of that before, as well as extended/added tests of unstable/deprecated and
modules.

Passed a full paratest with futures, checked generated online documentation
for the case mentioned in #23018, for IO.file (since that is a record and would
be impacted by the comment changes), as well as ChapelIO and AutoMath.