### PR TITLE
Improve the copyright checking script

### DIFF
--- a/compiler/llvm/llvm-global-to-wide/CMakeLists.txt
+++ b/compiler/llvm/llvm-global-to-wide/CMakeLists.txt
@@ -1,3 +1,20 @@
+# Copyright 2023 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 cmake_minimum_required(VERSION 3.20.0)
 project(llvm-pgas)
 

--- a/frontend/include/chpl/framework/serialize-functions.h
+++ b/frontend/include/chpl/framework/serialize-functions.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+ * Copyright 2021-2023 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,

--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+ * Copyright 2021-2023 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,

--- a/frontend/lib/resolution/return-type-inference.h
+++ b/frontend/lib/resolution/return-type-inference.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+ * Copyright 2021-2023 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,

--- a/frontend/lib/resolution/signature-checks.cpp
+++ b/frontend/lib/resolution/signature-checks.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+ * Copyright 2021-2023 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,

--- a/frontend/lib/resolution/signature-checks.h
+++ b/frontend/lib/resolution/signature-checks.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+ * Copyright 2021-2023 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,

--- a/frontend/lib/types/ExternType.cpp
+++ b/frontend/lib/types/ExternType.cpp
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2023 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "chpl/types/ExternType.h"
 #include "chpl/framework/query-impl.h"
 

--- a/frontend/test/resolution/testDeprecationUnstable.cpp
+++ b/frontend/test/resolution/testDeprecationUnstable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+ * Copyright 2021-2023 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,

--- a/frontend/test/resolution/testModuleInitOrder.cpp
+++ b/frontend/test/resolution/testModuleInitOrder.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+ * Copyright 2021-2023 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,

--- a/frontend/test/resolution/testSuper.cpp
+++ b/frontend/test/resolution/testSuper.cpp
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2023 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 
 #include "test-resolution.h"
 

--- a/util/test/checkCopyrights.bash
+++ b/util/test/checkCopyrights.bash
@@ -4,7 +4,7 @@
 #
 # Check that files matching the following patterns have copyright in their
 # sources. This check does not necessary ensure these are comments within the
-# first few lines of the file, but that seems excessive.
+# first few lines of the file.
 #
 #  *.c
 #  *.cc
@@ -19,7 +19,8 @@
 #
 
 todate=`date "+%m%d"`
-#This hardcoding is intentional. Date accepts a full date like this, but %m%d cuts off the year so it only compares 0107 to the current date
+# This hardcoding is intentional. Date accepts a full date like this,
+# but %m%d cuts off the year so it only compares 0107 to the current date
 cond=`date -d 2023-01-07 "+%m%d"`
 
 if [ $todate -le $cond ];
@@ -32,7 +33,9 @@ CHPL_HOME=${CHPL_HOME:-$CWD/../..}
 
 this_year=$(date '+%Y')
 copyright_pattern="Copyright .*${this_year}[^0-9]* Hewlett Packard Enterprise Development LP"
-source_dirs="compiler runtime make modules*"
+outdated_copyright_pattern="Copyright .* Hewlett Packard Enterprise Development LP"
+
+source_dirs="compiler frontend runtime make modules*"
 
 echo "[INFO] Moving to CHPL_HOME: ${CHPL_HOME}"
 cd $CHPL_HOME
@@ -48,6 +51,7 @@ echo "[INFO] Checking for copyrights in source files: ${copyright_pattern}"
 
 files_wo_copy=$(find $source_dirs -type f \( \
     -name Make\* -o \
+    -name CMakeLists.txt -o \
     -name \*.c -o \
     -name \*.cc -o \
     -name \*.chpl -o \
@@ -60,16 +64,17 @@ files_wo_copy=$(find $source_dirs -type f \( \
     grep -v compiler/include/bison-chapel.h        | \
     grep -v compiler/include/flex-chapel.h         | \
     grep -v compiler/parser/bison-chapel.cpp       | \
-    grep -v compiler/dyno/lib/parsing/bison-chpl-lib.h | \
-    grep -v compiler/dyno/lib/parsing/bison-chpl-lib.cpp | \
-    grep -v compiler/dyno/lib/parsing/flex-chpl-lib.h | \
-    grep -v compiler/dyno/lib/parsing/flex-chpl-lib.cpp | \
+    grep -v frontend/lib/parsing/bison-chpl-lib.h | \
+    grep -v frontend/lib/parsing/bison-chpl-lib.cpp | \
+    grep -v frontend/lib/parsing/flex-chpl-lib.h | \
+    grep -v frontend/lib/parsing/flex-chpl-lib.cpp | \
+    grep -v frontend/lib/util/git-version.cpp | \
     grep -v 'modules/standard/gen/.*/ChapelSysCTypes.chpl' | \
     xargs grep -i -L "${copyright_pattern}")
 
 
 # Check the top-level Makefiles in CHPL_HOME
-root_files_wo_copy=$(find . -maxdepth 1 -name Make\* | xargs grep -i -L "${copyright_pattern}")
+root_files_wo_copy=$(find . -maxdepth 1 -name Make\* -o -name CMakeLists.txt | xargs grep -i -L "${copyright_pattern}")
 
 
 # Check CHPL_HOME/tools. Filename suffixes actually used, by subdir:
@@ -79,6 +84,7 @@ root_files_wo_copy=$(find . -maxdepth 1 -name Make\* | xargs grep -i -L "${copyr
 
 tools_wo_copy=$(find tools \( -type d \( -name test -o -name utils \) -prune \) -o \( -type f \( \
     -name Make\* -o \
+    -name CMakeLists.txt -o \
     -name \*.c -o \
     -name \*.cc -o \
     -name \*.chpl -o \
@@ -92,10 +98,24 @@ tools_wo_copy=$(find tools \( -type d \( -name test -o -name utils \) -prune \) 
     xargs grep -i -L "${copyright_pattern}")
 
 if [ -n "${files_wo_copy}" -o -n "${root_files_wo_copy}" -o -n "${tools_wo_copy}" ] ; then
-    echo "[ERROR] The following files have missing or incorrect copyrights:"
-    echo "${files_wo_copy}"
-    echo "${root_files_wo_copy}"
-    echo "${tools_wo_copy}"
-    echo "Add the copyright with: \$CHPL_HOME/util/buildRelease/add_license_to_sources.py <files>"
+    echo "[ERROR] Missing or incorrect copyrights"
+    echo
+
+    files="${files_wo_copy} ${root_files_wo_copy} ${tools_wo_copy}"
+    incorrect=$(echo "${files}" | xargs grep -i -l "${outdated_copyright_pattern}")
+    missing=$(echo "${files}" | xargs grep -i -L "${outdated_copyright_pattern}")
+    if [ -n "${incorrect}" ] ; then
+      echo "[ERROR] The following files have incorrect copyrights:"
+      echo "${incorrect}"
+      echo
+      echo " Please correct these by updating the copyright date"
+      echo
+    fi
+    if [ -n "${missing}" ] ; then
+      echo "[ERROR] The following files have missing copyrights:"
+      echo "${missing}"
+      echo
+      echo "${missing}" | xargs echo " Add the copyright to these files with \$CHPL_HOME/util/buildRelease/add_license_to_sources.py "
+    fi
     exit 1
 fi


### PR DESCRIPTION
Improve the copyright checking script
    
* check `frontend/`
* check `CMakeLists.txt` files
* show the full command to add copyright when missing
* separately output files that need a copyright date update. Previously, the script misleadingly suggested adding a copyright to the listed files with `add_license_to_sources.py`, but that script does not update an existing copyright; it just adds a new one. Now, the script only makes this suggestion for files that do not appear to contain an old copyright.

Updates a few files that had old or missing copyrights.

Reviewed by @arezaii - thanks!

- [x] full comm=none testing