### PR TITLE
Add a test locking in that catching unstable Errors only warns once

### DIFF
--- a/test/unstable-keyword/catchUnstableError.chpl
+++ b/test/unstable-keyword/catchUnstableError.chpl
@@ -1,0 +1,17 @@
+@unstable
+class MyUnstableErr : Error {
+}
+
+proc throwsUnstableErr() throws {
+  throw new MyUnstableErr();
+}
+
+proc main() {
+  try {
+    throwsUnstableErr();
+  } catch (e: MyUnstableErr) {
+    writeln(e.type: string);
+  } catch {
+    writeln("whatever");
+  }
+}

--- a/test/unstable-keyword/catchUnstableError.compopts
+++ b/test/unstable-keyword/catchUnstableError.compopts
@@ -1,0 +1,1 @@
+--warn-unstable

--- a/test/unstable-keyword/catchUnstableError.good
+++ b/test/unstable-keyword/catchUnstableError.good
@@ -1,0 +1,5 @@
+catchUnstableError.chpl:5: In function 'throwsUnstableErr':
+catchUnstableError.chpl:6: warning: MyUnstableErr is unstable
+catchUnstableError.chpl:9: In function 'main':
+catchUnstableError.chpl:12: warning: MyUnstableErr is unstable
+owned MyUnstableErr


### PR DESCRIPTION
There was a point where deprecated Error subclasses would trigger their deprecation warning twice when caught.  That has since been resolved, but figured it would be good to also lock in that unstable warnings also behave appropriately

Checked a fresh checkout of the test