### PR TITLE
Expand cpu-as-device testing to release/examples

### DIFF
--- a/util/cron/test-gpu-cpu.bash
+++ b/util/cron/test-gpu-cpu.bash
@@ -11,5 +11,8 @@ export CHPL_GPU=cpu
 export CHPL_COMM=none
 export CHPL_GPU_NO_CPU_MODE_WARNING=y
 
+# Now that we can run this config across release/examples, add it here
+export CHPL_NIGHTLY_TEST_DIRS="$CHPL_NIGHTLY_TEST_DIRS release/examples"
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-cpu"
 $CWD/nightly -cron ${nightly_args}


### PR DESCRIPTION
Part of https://github.com/Cray/chapel-private/issues/4625.

@daviditen has done a lot of work to test `release/examples` with cpu-as-device mode and added some skipif/suppressifs in that directory. This PR adjusts our nightly cpu-as-device testing to expand its coverage to `release/examples`.