### PR TITLE
Improve macro check to be resilient to gcc versions

### DIFF
--- a/runtime/include/gdb.h
+++ b/runtime/include/gdb.h
@@ -30,11 +30,16 @@ extern "C" {
 void gdbShouldBreakHere(void);  // must be in separate file to avoid elimination
 
 inline static void chpl_debugtrap(void) {
-  #if defined(__has_builtin) && __has_builtin(__builtin_debugtrap)
-  __builtin_debugtrap();
-  #else
-  raise(SIGTRAP);
+  #ifdef __has_builtin
+    #if __has_builtin (__builtin_debugtrap)
+      #define call_debugtrap() __builtin_debugtrap()
+    #endif
   #endif
+  #ifndef call_debugtrap
+    #define call_debugtrap() raise(SIGTRAP)
+  #endif
+  call_debugtrap();
+  #undef call_debugtrap
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
Fixes the macro check added in #23678 to be portable across gcc versions

This failed in our nightly testing with gcc version 8.3.1, complaining about `__has_builtin(...)`. A simple solution would have been to just put a space before '(', but I just rewrote the check based on gcc docs: https://gcc.gnu.org/onlinedocs/gcc-10.1.0/cpp/_005f_005fhas_005fbuiltin.html

[Reviewed by @dlongnecke-cray]