### PR TITLE
update mason large package docs to show use of `--` before `-M`

### DIFF
--- a/doc/rst/tools/mason/guide/buildinglargerpackages.rst
+++ b/doc/rst/tools/mason/guide/buildinglargerpackages.rst
@@ -4,15 +4,16 @@ Building Larger Packages
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 For packages that span multiple files, the main module is designated by the module that
-shares the name with the package directory and the name field in the ``Mason.toml``.
+shares the name with the package directory and the name field in the ``Mason.toml`` file.
 
 While not recommended with mason libraries that are going to be added to the mason registry,
-passing a ``-M`` as outlined below can make building your mason application easier, but,
+passing a ``-- -M`` as outlined below can make building your mason application easier, but,
 for mason libraries, submodules should be used to avoid conflicting namespaces for users
 of your library (see :ref:`readme-module_include`).
 
 For packages that span multiple sub-directories within ``src``, sub-directories must be passed
-to Mason with the ``-M  <src/subdirectory>`` flag which is forwarded to the chapel compiler. For example, lets say
+to mason with the ``-- -M  <src/subdirectory>`` flag. Note the ``--`` which tells mason to
+forward all remaining flags directly to the chapel compiler. For example, lets say
 MyPackage's structure is as follows::
 
   MyPackage/
@@ -33,8 +34,8 @@ MyPackage's structure is as follows::
 
 
 If MyPackage needs multiple files in different directories like the example above,
-then call ``mason build`` with the ``-M`` flag followed by the local dependencies.
+then call ``mason build`` with the ``-- -M`` flag followed by the local dependencies.
 A full command of this example would be::
 
-  mason build -M src/util/MyPackageUtils.chpl
+  mason build -- -M src/util/MyPackageUtils.chpl
 


### PR DESCRIPTION
This PR updates the docs for building large packages with mason to indicate that `--` is needed prior to compiler flags, such as `-M`. This is in response to a user reporting trouble on discourse with trying to use `mason build -M src/subdir/myfile.chpl`. 

TESTING:

- [x] built docs and manually reviewed `tools/mason/guide/buildinglargerpackages.html`

[reviewed by @bmcdonald3 - thanks!]