### PR TITLE
Add flag to control IO dynamic buffering optimizaiton

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1616,6 +1616,21 @@ private extern proc qio_format_error_arg_mismatch(arg:int):errorCode;
 extern proc qio_format_error_bad_regex():errorCode;
 private extern proc qio_format_error_write_regex():errorCode;
 
+@chpldoc.nodoc
+// flag to controll whether the dynamic buffering optimization is active
+//  * when 'true', read and write ops above a certain size can bypass the IO
+//      rutime's buffering mechanism in some cases
+//      (see `_qio_buffered_write` and `_qio_buffered_read` in `qio.c` for more)
+//  * when 'false', buffering is always used
+config param IOSkipBufferingForLargeOps = true;
+private extern var qio_write_unbuffered_threshold: c_ssize_t;
+private extern var qio_read_unbuffered_threshold: c_ssize_t;
+
+if !IOSkipBufferingForLargeOps {
+  qio_write_unbuffered_threshold = max(c_ssize_t);
+  qio_read_unbuffered_threshold = max(c_ssize_t);
+}
+
 /*
    :returns: the default I/O style. See :record:`iostyle`
              and :ref:`about-io-styles`

--- a/test/io/corrado/buffering_optimization/optimization_flag.chpl
+++ b/test/io/corrado/buffering_optimization/optimization_flag.chpl
@@ -1,0 +1,9 @@
+use CTypes;
+
+extern var qio_write_unbuffered_threshold:c_ssize_t;
+extern var qio_read_unbuffered_threshold:c_ssize_t;
+
+// setting `IOSkipBufferingForLargeOps=false` should set these thresholds
+//  to their maximum value, deactivating the optimization
+writeln(qio_write_unbuffered_threshold == max(c_ssize_t));
+writeln(qio_write_unbuffered_threshold == max(c_ssize_t));

--- a/test/io/corrado/buffering_optimization/optimization_flag.compopts
+++ b/test/io/corrado/buffering_optimization/optimization_flag.compopts
@@ -1,0 +1,2 @@
+ # optimization_flag.opt-on.good
+-sIOSkipBufferingForLargeOps=false # optimization_flag.opt-off.good

--- a/test/io/corrado/buffering_optimization/optimization_flag.opt-off.good
+++ b/test/io/corrado/buffering_optimization/optimization_flag.opt-off.good
@@ -1,0 +1,2 @@
+true
+true

--- a/test/io/corrado/buffering_optimization/optimization_flag.opt-on.good
+++ b/test/io/corrado/buffering_optimization/optimization_flag.opt-on.good
@@ -1,0 +1,2 @@
+false
+false


### PR DESCRIPTION
Recently, it was pointed out that there is no easy way to disable the IO optimization added in https://github.com/chapel-lang/chapel/pull/22031 and https://github.com/chapel-lang/chapel/pull/21786.

This PR adds a config param `IOSkipBufferingForLargeOps` that disables the optimization when set to `false`.

- [x] paratest