### PR TITLE
Source nightly dependencies in tarball scripts

### DIFF
--- a/util/cron/create_release_tarball.bash
+++ b/util/cron/create_release_tarball.bash
@@ -9,6 +9,7 @@
 # will be copied to that directory after it is built.
 
 CWD=$(cd $(dirname $0) ; pwd)
+source $CWD/common.bash
 source $CWD/functions.bash
 
 if [ "${CHPL_VERSION+x}" != "x" ] ; then

--- a/util/cron/create_tarball.bash
+++ b/util/cron/create_tarball.bash
@@ -6,6 +6,7 @@
 # The tarball is left in root of repo in tar/ directory.
 
 CWD=$(cd $(dirname $0) ; pwd)
+source $CWD/common.bash
 source $CWD/functions.bash
 
 # Tell gen_release to use existing repo instead of creating a new one with


### PR DESCRIPTION
Add sourcing of our nightly test dependencies (via `common.bash`) to `util/cron/create_[release_]tarball.bash` like we have for most of the scripts in that directory.

Part of [removing the need to load dependencies in the `chapelu` `.bashrc` on `chap*` systems](https://github.com/Cray/chapel-private/issues/5499#issuecomment-1789641313).

[reviewer info placeholder]