### PR TITLE
Remove previously deprecated BitOps.popcount

### DIFF
--- a/modules/standard/BitOps.chpl
+++ b/modules/standard/BitOps.chpl
@@ -50,17 +50,6 @@ module BitOps {
     :returns: the number of 1 bits set in `x` as `x.type`
     :rtype: `x.type`
    */
-  @deprecated(notes="popcount is deprecated - please use :proc:`popCount` instead")
-  inline proc popcount(x: integral) {
-    return popCount(x);
-  }
-
-  /*
-    Find the population count of `x`.
-
-    :returns: the number of 1 bits set in `x` as `x.type`
-    :rtype: `x.type`
-   */
   inline proc popCount(x: integral) {
     return BitOps_internal.popCount(x);
   }

--- a/test/deprecated/BitOps/popcount.chpl
+++ b/test/deprecated/BitOps/popcount.chpl
@@ -1,6 +1,0 @@
-// deprecated by jade in 1.31
-use BitOps;
-
-var x = 0x17171717;
-var p = popcount(x);
-writeln(x, " has ", p, " set bits");

--- a/test/deprecated/BitOps/popcount.good
+++ b/test/deprecated/BitOps/popcount.good
@@ -1,2 +1,0 @@
-popcount.chpl:5: warning: popcount is deprecated - please use popCount instead
-387389207 has 16 set bits


### PR DESCRIPTION
Remove previously deprecated `BitOps.popcount`, deprecated in 1.31 in this PR: https://github.com/chapel-lang/chapel/pull/22121

Tested with a full paratest using comm=none and comm=gasnet

[Reviewed by @jeremiah-corrado]