### PR TITLE
[dyno] implement compiler generated record comparison and assignment

### DIFF
--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -83,18 +83,23 @@ areOverloadsPresentInDefiningScope(Context* context, const Type* type,
       CHPL_ASSERT(node);
 
       if (auto fn = node->toFunction()) {
-        if (!fn->isMethod()) continue;
+        if (fn->isMethod()) {
+          ResolutionResultByPostorderID r;
+          auto vis = Resolver::createForInitialSignature(context, fn, r);
+          fn->thisFormal()->traverse(vis);
+          auto receiverQualType = vis.byPostorder.byAst(fn->thisFormal()).type();
 
-        ResolutionResultByPostorderID r;
-        auto vis = Resolver::createForInitialSignature(context, fn, r);
-        fn->thisFormal()->traverse(vis);
-        auto receiverQualType = vis.byPostorder.byAst(fn->thisFormal()).type();
-
-        // return true if the receiver type matches or
-        // if the receiver type is a generic type and we have
-        // an instantiation.
-        auto result = canPass(context, haveQt, receiverQualType);
-        if (result.passes() && !result.converts() && !result.promotes()) {
+          // return true if the receiver type matches or
+          // if the receiver type is a generic type and we have
+          // an instantiation.
+          auto result = canPass(context, haveQt, receiverQualType);
+          if (result.passes() && !result.converts() && !result.promotes()) {
+            return true;
+          }
+        } else if (fn->kind()==Function::Kind::OPERATOR) {
+          // TODO: There should probably be some more checks happening in here,
+          // but unsure of what they should be currently and this seems to work
+          // in basic testing.
           return true;
         }
       }
@@ -104,10 +109,19 @@ areOverloadsPresentInDefiningScope(Context* context, const Type* type,
   return false;
 }
 
+// non-record types have == and = implemented in the modules so we don't
+// want to generate them
+static bool isBuiltinTypeOperator(UniqueString name) {
+  // adding "==" and "=" to list of compiler generated method names was
+  // problematic for other types, like int
+  return !(name == USTR("==") || name == USTR("="));
+}
+
 bool
 needCompilerGeneratedMethod(Context* context, const Type* type,
                             UniqueString name, bool parenless) {
-  if (isNameOfCompilerGeneratedMethod(name)) {
+  if (isNameOfCompilerGeneratedMethod(name) ||
+      (type->isRecordType() && !isBuiltinTypeOperator(name))) {
     if (!areOverloadsPresentInDefiningScope(context, type, name)) {
       return true;
     }
@@ -488,6 +502,141 @@ const TypedFnSignature* fieldAccessor(Context* context,
   return fieldAccessorQuery(context, compType, fieldName);
 }
 
+// generate formal detail and formal type
+static void
+generateOperatorFormalDetail(const UniqueString name,
+                             const CompositeType*& compType,
+                             std::vector<UntypedFnSignature::FormalDetail>& ufsFormals,
+                             std::vector<QualifiedType>& formalTypes,
+                             QualifiedType::Kind qtKind,
+                             bool hasDefault = false,
+                             const uast::Decl* decl = nullptr) {
+  auto fd = UntypedFnSignature::FormalDetail(name, hasDefault, decl);
+  ufsFormals.push_back(std::move(fd));
+
+  auto qtFd = QualifiedType(qtKind, compType);
+  formalTypes.push_back(std::move(qtFd));
+}
+
+
+// builds the formal entries for the operator methods, including the 'this'
+// method receiver and the lhs argument. Specify the
+// QualifiedType::Kind for each of these.
+static void
+generateUnaryOperatorMethodParts(Context* context,
+                                  const CompositeType* inCompType,
+                                  const CompositeType*& compType,
+                                  std::vector<UntypedFnSignature::FormalDetail>& ufsFormals,
+                                  std::vector<QualifiedType>& formalTypes,
+                                  QualifiedType::Kind thisKind,
+                                  QualifiedType::Kind lhsKind) {
+  // adjust to refer to fully generic signature if needed
+  auto genericCompType = inCompType->instantiatedFromCompositeType();
+  compType = genericCompType ? genericCompType : inCompType;
+
+  // make sure the receiver is a record type
+  CHPL_ASSERT(compType->isRecordType() && "Only RecordType supported for now");
+
+  // start by adding a formal for the receiver, 'this'
+  generateOperatorFormalDetail(USTR("this"), compType, ufsFormals, formalTypes,
+                               thisKind);
+
+  // add a formal for the 'lhs' argument
+  generateOperatorFormalDetail(UniqueString::get(context,"lhs"),
+                               compType, ufsFormals, formalTypes,
+                               lhsKind);
+  CHPL_ASSERT(formalTypes.size() == 2);
+  CHPL_ASSERT(ufsFormals.size() == 2);
+}
+
+// builds the formal entries for the operator methods, including the 'this'
+// method receiver and the lhs and rhs arguments. Specify the
+// QualifiedType::Kind for each of these.
+static void
+generateBinaryOperatorMethodParts(Context* context,
+                                  const CompositeType* inCompType,
+                                  const CompositeType*& compType,
+                                  std::vector<UntypedFnSignature::FormalDetail>& ufsFormals,
+                                  std::vector<QualifiedType>& formalTypes,
+                                  QualifiedType::Kind thisKind,
+                                  QualifiedType::Kind lhsKind,
+                                  QualifiedType::Kind rhsKind) {
+  // add formals for the 'this' receiver and 'lhs' argument
+  generateUnaryOperatorMethodParts(context, inCompType, compType, ufsFormals,
+                                   formalTypes, thisKind, lhsKind);
+
+  // add a formal for the 'rhs' argument
+  generateOperatorFormalDetail(UniqueString::get(context,"rhs"),
+                               compType, ufsFormals, formalTypes,
+                               rhsKind);
+
+  CHPL_ASSERT(formalTypes.size() == 3);
+  CHPL_ASSERT(ufsFormals.size() == 3);
+}
+
+/*
+generate a TypedFnSignature and UntypedFnSignature with formal details for a
+record operator method. The operator is specified by the UniqueString op.
+*/
+static const TypedFnSignature*
+generateRecordBinaryOperator(Context* context, UniqueString op,
+                             const CompositeType* lhsType,
+                             QualifiedType::Kind thisKind,
+                             QualifiedType::Kind lhsKind,
+                             QualifiedType::Kind rhsKind) {
+  const CompositeType* compType = nullptr;
+  std::vector<UntypedFnSignature::FormalDetail> ufsFormals;
+  std::vector<QualifiedType> formalTypes;
+
+  // build the formal details
+  generateBinaryOperatorMethodParts(context, lhsType, compType, ufsFormals,
+                                  formalTypes, thisKind, lhsKind, rhsKind);
+  // build the untyped signature
+  auto ufs = UntypedFnSignature::get(context,
+                        /*id*/ compType->id(),
+                        /*name*/ op,
+                        /*isMethod*/ true,
+                        /*isTypeConstructor*/ false,
+                        /*isCompilerGenerated*/ true,
+                        /*throws*/ false,
+                        /*idTag*/ parsing::idToTag(context, compType->id()),
+                        /*kind*/ uast::Function::Kind::OPERATOR,
+                        /*formals*/ std::move(ufsFormals),
+                        /*whereClause*/ nullptr);
+
+  // now build the other pieces of the typed signature
+  auto g = getTypeGenericity(context, lhsType);
+  bool needsInstantiation = (g == Type::GENERIC ||
+                             g == Type::GENERIC_WITH_DEFAULTS);
+
+  auto ret = TypedFnSignature::get(context,
+                                   ufs,
+                                   std::move(formalTypes),
+                                   TypedFnSignature::WHERE_NONE,
+                                   needsInstantiation,
+                                   /* instantiatedFrom */ nullptr,
+                                   /* parentFn */ nullptr,
+                                   /* formalsInstantiated */ Bitmap());
+
+  return ret;
+}
+
+static const TypedFnSignature*
+generateRecordAssignment(Context* context, const CompositeType* lhsType) {
+  return generateRecordBinaryOperator(context, USTR("="), lhsType,
+                                      /*this*/ QualifiedType::CONST_REF,
+                                      /*lhs*/  QualifiedType::CONST_REF,
+                                      /*rhs*/  QualifiedType::CONST_REF);
+}
+
+static const TypedFnSignature*
+generateRecordComparison(Context* context, const CompositeType* lhsType) {
+  return generateRecordBinaryOperator(context, USTR("=="), lhsType,
+                                      /*this*/ QualifiedType::REF,
+                                      /*lhs*/  QualifiedType::REF,
+                                      /*rhs*/  QualifiedType::CONST_REF);
+}
+
 static const TypedFnSignature* const&
 getCompilerGeneratedMethodQuery(Context* context, const Type* type,
                                 UniqueString name, bool parenless) {
@@ -509,6 +658,14 @@ getCompilerGeneratedMethodQuery(Context* context, const Type* type,
       result = generateDomainMethod(context, domainType, name);
     } else if (auto arrayType = type->toArrayType()) {
       result = generateArrayMethod(context, arrayType, name);
+    } else if (auto recordType = type->toRecordType()) {
+      if (name == USTR("==")) {
+        result = generateRecordComparison(context, recordType);
+      } else if (name == USTR("=")) {
+        result = generateRecordAssignment(context, recordType);
+      } else {
+        CHPL_ASSERT(false && "record method not implemented yet!");
+      }
     } else {
       CHPL_ASSERT(false && "Not implemented yet!");
     }

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2915,8 +2915,8 @@ considerCompilerGeneratedCandidates(Context* context,
                                    const PoiScope* inPoiScope,
                                    CandidatesVec& candidates) {
 
-  // only consider compiler-generated methods, for now
-  if (!ci.isMethodCall()) return;
+  // only consider compiler-generated methods and opcalls, for now
+  if (!ci.isMethodCall() && !ci.isOpCall()) return;
 
   // fetch the receiver type info
   CHPL_ASSERT(ci.numActuals() >= 1);

--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -848,6 +848,83 @@ static const bool& fnAstReturnsNonVoid(Context* context, ID fnId) {
   return QUERY_END(result);
 }
 
+static bool helpComputeCompilerGeneratedReturnType(Context* context,
+                                                   const TypedFnSignature* sig,
+                                                   const PoiScope* poiScope,
+                                                   QualifiedType& result,
+                                                   const UntypedFnSignature* untyped) {
+  if (untyped->name() == USTR("init") ||
+      untyped->name() == USTR("init=") ||
+      untyped->name() == USTR("deinit") ||
+      untyped->name() == USTR("=")) {
+      result = QualifiedType(QualifiedType::CONST_VAR,
+                             VoidType::get(context));
+      return true;
+  } else if (untyped->name() == USTR("==")) {
+      result = QualifiedType(QualifiedType::CONST_VAR, BoolType::get(context));
+      return true;
+  } else if (untyped->idIsField() && untyped->isMethod()) {
+      // method accessor - compute the type of the field
+      QualifiedType ft = computeTypeOfField(context,
+                                            sig->formalType(0).type(),
+                                            untyped->id());
+      if (ft.isType() || ft.isParam()) {
+        // return the type as-is (preserving param/type-ness)
+        result = ft;
+      } else if (ft.isConst()) {
+        // return a const ref
+        result = QualifiedType(QualifiedType::CONST_REF, ft.type());
+      } else {
+        // return a ref
+        result = QualifiedType(QualifiedType::REF, ft.type());
+      }
+      return true;
+    } else if (untyped->isMethod() && sig->formalType(0).type()->isDomainType()) {
+      auto dt = sig->formalType(0).type()->toDomainType();
+
+      if (untyped->name() == "idxType") {
+        result = dt->idxType();
+      } else if (untyped->name() == "rank") {
+        // Can't use `RankType::rank` because `D.rank` is defined for associative
+        // domains, even though they don't have a matching substitution.
+        result = QualifiedType(QualifiedType::PARAM,
+                               IntType::get(context, 64),
+                               IntParam::get(context, dt->rankInt()));
+      } else if (untyped->name() == "stridable") {
+        result = dt->stridable();
+      } else if (untyped->name() == "parSafe") {
+        result = dt->parSafe();
+      } else if (untyped->name() == "isRectangular") {
+        auto val = BoolParam::get(context, dt->kind() == DomainType::Kind::Rectangular);
+        auto type = BoolType::get(context);
+        result = QualifiedType(QualifiedType::PARAM, type, val);
+      } else if (untyped->name() == "isAssociative") {
+        auto val = BoolParam::get(context, dt->kind() == DomainType::Kind::Associative);
+        auto type = BoolType::get(context);
+        result = QualifiedType(QualifiedType::PARAM, type, val);
+      } else {
+        CHPL_ASSERT(false && "unhandled compiler-generated domain method");
+        return true;
+      }
+      return true;
+    } else if (untyped->isMethod() && sig->formalType(0).type()->isArrayType()) {
+      auto at = sig->formalType(0).type()->toArrayType();
+
+      if (untyped->name() == "domain") {
+        result = QualifiedType(QualifiedType::CONST_REF, at->domainType().type());
+      } else if (untyped->name() == "eltType") {
+        result = at->eltType();
+      } else {
+        CHPL_ASSERT(false && "unhandled compiler-generated array method");
+      }
+
+      return true;
+    } else {
+      CHPL_ASSERT(false && "unhandled compiler-generated record method");
+      return true;
+    }
+}
+
 // returns 'true' if it was a case handled here & sets 'result' in that case
 // returns 'false' if it needs to be computed with a ResolvedVisitor traversal
 static bool helpComputeReturnType(Context* context,
@@ -856,6 +933,10 @@ static bool helpComputeReturnType(Context* context,
                                   QualifiedType& result) {
   const UntypedFnSignature* untyped = sig->untyped();
 
+  // TODO: Optimize the order of this case and the isCompilerGenerated case
+  // such that we don't worry about instantiating the signature if we it's
+  // compiler generated and one of the ops we know the return type for, e.g.
+  // `==`, `init`, `init=`, `deinit`, and `=`.
   if (untyped->idIsFunction() && sig->needsInstantiation()) {
     // if it needs instantiation, we don't know the return type yet.
     result = QualifiedType(QualifiedType::UNKNOWN, UnknownType::get(context));
@@ -914,72 +995,8 @@ static bool helpComputeReturnType(Context* context,
   // if method call and the receiver points to a composite type definition,
   // then it's some sort of compiler-generated method
   } else if (untyped->isCompilerGenerated()) {
-    if (untyped->name() == USTR("init") ||
-        untyped->name() == USTR("init=") ||
-        untyped->name() == USTR("deinit")) {
-      result = QualifiedType(QualifiedType::CONST_VAR,
-                             VoidType::get(context));
-      return true;
-    } else if (untyped->idIsField() && untyped->isMethod()) {
-      // method accessor - compute the type of the field
-      QualifiedType ft = computeTypeOfField(context,
-                                            sig->formalType(0).type(),
-                                            untyped->id());
-      if (ft.isType() || ft.isParam()) {
-        // return the type as-is (preserving param/type-ness)
-        result = ft;
-      } else if (ft.isConst()) {
-        // return a const ref
-        result = QualifiedType(QualifiedType::CONST_REF, ft.type());
-      } else {
-        // return a ref
-        result = QualifiedType(QualifiedType::REF, ft.type());
-      }
-      return true;
-    } else if (untyped->isMethod() && sig->formalType(0).type()->isDomainType()) {
-      auto dt = sig->formalType(0).type()->toDomainType();
-
-      if (untyped->name() == "idxType") {
-        result = dt->idxType();
-      } else if (untyped->name() == "rank") {
-        // Can't use `RankType::rank` because `D.rank` is defined for associative
-        // domains, even though they don't have a matching substitution.
-        result = QualifiedType(QualifiedType::PARAM,
-                               IntType::get(context, 64),
-                               IntParam::get(context, dt->rankInt()));
-      } else if (untyped->name() == "stridable") {
-        result = dt->stridable();
-      } else if (untyped->name() == "parSafe") {
-        result = dt->parSafe();
-      } else if (untyped->name() == "isRectangular") {
-        auto val = BoolParam::get(context, dt->kind() == DomainType::Kind::Rectangular);
-        auto type = BoolType::get(context);
-        result = QualifiedType(QualifiedType::PARAM, type, val);
-      } else if (untyped->name() == "isAssociative") {
-        auto val = BoolParam::get(context, dt->kind() == DomainType::Kind::Associative);
-        auto type = BoolType::get(context);
-        result = QualifiedType(QualifiedType::PARAM, type, val);
-      } else {
-        CHPL_ASSERT(false && "unhandled compiler-generated domain method");
-        return true;
-      }
-      return true;
-    } else if (untyped->isMethod() && sig->formalType(0).type()->isArrayType()) {
-      auto at = sig->formalType(0).type()->toArrayType();
-
-      if (untyped->name() == "domain") {
-        result = QualifiedType(QualifiedType::CONST_REF, at->domainType().type());
-      } else if (untyped->name() == "eltType") {
-        result = at->eltType();
-      } else {
-        CHPL_ASSERT(false && "unhandled compiler-generated array method");
-      }
-
-      return true;
-    } else {
-      CHPL_ASSERT(false && "unhandled compiler-generated method");
-      return true;
-    }
+    return helpComputeCompilerGeneratedReturnType(context, sig, poiScope,
+                                                  result, untyped);
   } else {
     CHPL_ASSERT(false && "case not handled");
     return true;

--- a/frontend/test/resolution/testOperatorOverloads.cpp
+++ b/frontend/test/resolution/testOperatorOverloads.cpp
@@ -218,11 +218,153 @@ static void test3() {
   ctx.advanceToNextRevision(false);
 }
 
+// test that we get a compiler generated record method for `==` when none exist
+static void test4() {
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  std::string program =
+    R""""(
+      record R {
+        var x : int;
+      }
+
+      var a : R;
+      var b : R;
+
+      var x = a == b;
+    )"""";
+
+  QualifiedType initType = resolveTypeOfXInit(context, program);
+  assert(initType.type()->isBoolType());
+  assert(initType.kind() == QualifiedType::CONST_VAR);
+}
+
+// test that we don't get a compiler generated record method for `==`
+// when one exists as a method
+static void test5() {
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  std::string program =
+    R""""(
+      record R {
+        var x : int;
+      }
+      operator R.==(a: R, b: R) { return "true"; }
+
+      var a : R;
+      var b : R;
+
+      var x = a == b;
+    )"""";
+
+  QualifiedType initType = resolveTypeOfXInit(context, program);
+  assert(initType.type()->isStringType());
+  assert(initType.kind() == QualifiedType::CONST_VAR);
+}
+
+// test that we don't get a compiler generated record method for `==`
+// when one exists as a standalone procedure
+static void test6() {
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  std::string program =
+    R""""(
+      record R {
+        var x : int;
+      }
+      operator ==(a: R, b: R) { return 1; }
+
+      var a : R;
+      var b : R;
+
+      var x = a == b;
+    )"""";
+
+  QualifiedType initType = resolveTypeOfXInit(context, program);
+  assert(initType.type()->isIntType());
+  assert(initType.kind() == QualifiedType::CONST_VAR);
+}
+
+// test that we do get a compiler generated record method for `==`
+// when other operators exist
+static void test7() {
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  std::string program =
+    R""""(
+      record R {
+        var x : int;
+      }
+      operator +=(a: R, b: R) { return 1; }
+      operator R.-(a:R,b:R) { return 2; }
+
+      var a : R;
+      var b : R;
+
+      var x = a == b;
+    )"""";
+
+  QualifiedType initType = resolveTypeOfXInit(context, program);
+  assert(initType.type()->isBoolType());
+  assert(initType.kind() == QualifiedType::CONST_VAR);
+}
+
+// test that we get compiler generated methods for = and == when inside a proc
+static void test8() {
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  std::string program =
+    R""""(
+
+      record T {
+        var y: string;
+      }
+
+      // make sure these don't prevent us generating R.== and R.=
+      operator ==(v:T, w:T) { return false; }
+      operator =(v:T, w:T) { }
+
+      record R {
+        var x:int;
+      }
+
+      var r = new R(9);
+      var q = new R(10);
+      proc assign(ref a:R, b:R) {
+        var p = new R(0);
+        if (a == b) {
+          a = p;
+        }
+      }
+      assign(r, q);
+      var x = r;
+    )"""";
+
+  QualifiedType initType = resolveTypeOfXInit(context, program);
+  assert(initType.type()->isRecordType());
+  assert(initType.kind() == QualifiedType::VAR);
+}
+
 
 int main() {
   test1();
   test2();
   test3();
+  test4();
+  test5();
+  test6();
+  test7();
+  test8();
 
   return 0;
 }


### PR DESCRIPTION
This PR adds compiler generated signatures for record assignment and record comparison to dyno. 

If we detect a matching operator already defined, we will skip generating the signature. 

Adds some minimal testing for generating signatures of `==` and `=` with and without `R.==` or `==` defined.

[reviewed by @mppf - thank you!]