### PR TITLE
Fix name of .good file in execopts for bigint test

### DIFF
--- a/test/studies/shootout/pidigits/thomasvandoren/pidigits-ledrug-BigInt.execopts
+++ b/test/studies/shootout/pidigits/thomasvandoren/pidigits-ledrug-BigInt.execopts
@@ -1,2 +1,2 @@
 --n=50
---n=27 # pidigits-27-ledrug.good
+--n=27 # pidigits-27.good


### PR DESCRIPTION
Fixes name of .good file changed in #23755

Tested locally

[Not Reviewed - trivial]