### PR TITLE
Make 'grep' command in GDB test case-insensitive

### DIFF
--- a/test/compflags/bradc/gdbddash/declint.prediff
+++ b/test/compflags/bradc/gdbddash/declint.prediff
@@ -8,7 +8,7 @@ set tmpfile = $outfile.raw.tmp
 # some gdbs print out extra stuff.  This filters it out
 #
 mv $outfile $tmpfile
-cat $tmpfile | grep -vE "Using host libthread_db library|Breakpoint 1 at|no debugging symbols found|Reading symbols|'tmpdirname' has unknown type" | sed 's@(gdb) quit@(gdb) @' > $outfile
+cat $tmpfile | grep -ivE "Using host libthread_db library|Breakpoint 1 at|no debugging symbols found|Reading symbols|'tmpdirname' has unknown type" | sed 's@(gdb) quit@(gdb) @' > $outfile
 rm $tmpfile
 
 #


### PR DESCRIPTION
Add a `-i` to a `grep` command in a test `.prediff` to make it case-insensitive.

It seems like in newer versions of `GDB` a loaded program without debuginfos will display "(No debugging symbols...)" instead of "no debugging symbols". The `grep` command in a test `.prediff` is not case-insensitive and so fails to filter out the warning from the newer `GDB`.

Reviewed by @bradcray. Thanks!