### PR TITLE
Add cast to tmpdirname in compiler/gdb.commands

### DIFF
--- a/compiler/etc/gdb.commands
+++ b/compiler/etc/gdb.commands
@@ -2,7 +2,7 @@ set $forcecmd = 0
 define hook-run
   if ($forcecmd != 1)
     set $forcecmd = 1
-    if (tmpdirname != 0)
+    if ((const char*)tmpdirname != 0)
       call cleanup_for_exit()
     end
   end
@@ -11,7 +11,7 @@ end
 define hook-quit
   if ($forcecmd != 1)
     set $forcecmd = 1
-    if (tmpdirname != 0)
+    if ((const char*)tmpdirname != 0)
       call cleanup_for_exit()
     end
   end


### PR DESCRIPTION
This adds a type cast to tmpdirname as a means of trying to make error messages go away when using the --gdb flag that complain that the type can't be determined, suggesting to apply a cast.  I got motivated to add it when a user ran into it today and I mistakenly thought it was the same thing that was breaking linux32 testing.

This change is a bit speculative because I haven't been able to reproduce the error, have just seen that it occurs in some configurations and that we have tests that try to grep the message away.  But I also don't think it's at all problematic.
