### PR TITLE
Foreach intents first steps

### DIFF
--- a/compiler/AST/ForLoop.cpp
+++ b/compiler/AST/ForLoop.cpp
@@ -172,6 +172,7 @@ static void tryToReplaceWithDirectRangeIterator(Expr* iteratorExpr)
 
 BlockStmt* ForLoop::doBuildForLoop(Expr*      indices,
                           Expr*      iteratorExpr,
+                          CallExpr*  intents,
                           BlockStmt* body,
                           LLVMMetadataList attrs,
                           bool       coforall,
@@ -297,6 +298,15 @@ BlockStmt* ForLoop::doBuildForLoop(Expr*      indices,
   loop->mContinueLabel = continueLabel;
   loop->mBreakLabel    = breakLabel;
 
+  // Transfer the DefExprs of the intent variables (ShadowVarSymbols).
+  if (isForeach && intents) {
+    while (Expr* src = intents->argList.head)
+      loop->shadowVariables().insertAtTail(src->remove());
+  }
+  /*if(isForeach) {
+    loop->byrefVars = intents;
+  }*/
+
   loop->insertAtTail(new DefExpr(continueLabel));
 
   retval->insertAtTail(new DefExpr(index));
@@ -320,7 +330,10 @@ BlockStmt* ForLoop::buildForLoop(Expr*      indices,
                                  bool       isForExpr,
                                  LLVMMetadataList attrs)
 {
-  return doBuildForLoop(indices, iteratorExpr, body, attrs,
+  return doBuildForLoop(indices, iteratorExpr, 
+                        /* intents */ nullptr,
+                        body,
+                        attrs,
                         /* coforall */ false,
                         zippered,
                         /* isLoweredForall */ false,
@@ -330,13 +343,15 @@ BlockStmt* ForLoop::buildForLoop(Expr*      indices,
 
 BlockStmt* ForLoop::buildForeachLoop(Expr*      indices,
                                      Expr*      iteratorExpr,
+                                     CallExpr*  intents,
                                      BlockStmt* body,
                                      bool       zippered,
                                      bool       isForExpr,
                                      LLVMMetadataList attrs)
 
 {
-  return doBuildForLoop(indices, iteratorExpr, body, attrs,
+  return doBuildForLoop(indices, iteratorExpr, intents, body,
+                        attrs,
                         /* coforall */ false,
                         zippered,
                         /* isLoweredForall */ false,
@@ -350,7 +365,10 @@ BlockStmt* ForLoop::buildCoforallLoop(Expr*      indices,
                                       bool       zippered,
                                       LLVMMetadataList attrs)
 {
-  return doBuildForLoop(indices, iteratorExpr, body, attrs,
+  return doBuildForLoop(indices, iteratorExpr, 
+                        /* intents */ nullptr,
+                        body,
+                        attrs,
                         /* coforall */ true,
                         zippered,
                         /* isLoweredForall */ false,
@@ -366,7 +384,10 @@ BlockStmt* ForLoop::buildLoweredForallLoop(Expr*      indices,
                                            bool       isForExpr,
                                            LLVMMetadataList attrs)
 {
-  return doBuildForLoop(indices, iteratorExpr, body, attrs,
+  return doBuildForLoop(indices, iteratorExpr,
+                        /* intents */ nullptr,
+                        body,
+                        attrs,
                         /* coforall */ false,
                         zippered,
                         /* isLoweredForall */ true,
@@ -402,6 +423,7 @@ ForLoop::ForLoop(VarSymbol* index,
   mZippered = zippered;
   mLoweredForall = isLoweredForall;
   mIsForExpr = isForExpr;
+  fShadowVars.parent = this;
 }
 
 ForLoop* ForLoop::copyInner(SymbolMap* map)
@@ -634,4 +656,8 @@ Expr* ForLoop::getNextExpr(Expr* expr)
     retval = body.head->getFirstExpr();
 
   return retval;
+}
+
+bool ForLoop::isInductionVar(Symbol* sym) {
+  return sym == mIndex->symbol();
 }

--- a/compiler/AST/ForLoop.cpp
+++ b/compiler/AST/ForLoop.cpp
@@ -303,9 +303,6 @@ BlockStmt* ForLoop::doBuildForLoop(Expr*      indices,
     while (Expr* src = intents->argList.head)
       loop->shadowVariables().insertAtTail(src->remove());
   }
-  /*if(isForeach) {
-    loop->byrefVars = intents;
-  }*/
 
   loop->insertAtTail(new DefExpr(continueLabel));
 

--- a/compiler/AST/ForLoop.cpp
+++ b/compiler/AST/ForLoop.cpp
@@ -299,7 +299,7 @@ BlockStmt* ForLoop::doBuildForLoop(Expr*      indices,
   loop->mBreakLabel    = breakLabel;
 
   // Transfer the DefExprs of the intent variables (ShadowVarSymbols).
-  if (isForeach && intents) {
+  if (intents) {
     while (Expr* src = intents->argList.head)
       loop->shadowVariables().insertAtTail(src->remove());
   }

--- a/compiler/AST/ForLoop.cpp
+++ b/compiler/AST/ForLoop.cpp
@@ -327,7 +327,7 @@ BlockStmt* ForLoop::buildForLoop(Expr*      indices,
                                  bool       isForExpr,
                                  LLVMMetadataList attrs)
 {
-  return doBuildForLoop(indices, iteratorExpr, 
+  return doBuildForLoop(indices, iteratorExpr,
                         /* intents */ nullptr,
                         body,
                         attrs,
@@ -362,7 +362,7 @@ BlockStmt* ForLoop::buildCoforallLoop(Expr*      indices,
                                       bool       zippered,
                                       LLVMMetadataList attrs)
 {
-  return doBuildForLoop(indices, iteratorExpr, 
+  return doBuildForLoop(indices, iteratorExpr,
                         /* intents */ nullptr,
                         body,
                         attrs,

--- a/compiler/AST/ForallStmt.cpp
+++ b/compiler/AST/ForallStmt.cpp
@@ -758,3 +758,7 @@ std::vector<BlockStmt*> ForallStmt::loopBodies() const {
   }
   return bodies;
 }
+
+bool ForallStmt::isInductionVar(Symbol* sym) {
+  return sym->defPoint->list == &inductionVariables();
+}

--- a/compiler/AST/LoopExpr.cpp
+++ b/compiler/AST/LoopExpr.cpp
@@ -427,6 +427,7 @@ static FnSymbol* buildSerialIteratorFn(const char* iteratorName,
   else {
     loop = ForLoop::buildForeachLoop(indices,
                                      new SymExpr(sifnIterator),
+                                     /* intents */ nullptr,
                                      new BlockStmt(stmt),
                                      zippered,
                                      /*isForExpr*/ true);

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -30,6 +30,7 @@
 #include "astutil.h"
 #include "driver.h"
 #include "ForallStmt.h"
+#include "ForLoop.h"
 #include "passes.h"
 #include "resolveIntents.h"
 #include "resolution.h"
@@ -1032,8 +1033,14 @@ void ShadowVarSymbol::verify() {
   if (!resolved) {
     // Verify that this symbol is on a ForallStmt::shadowVariables() list.
     ForallStmt* pfs = toForallStmt(defPoint->parentExpr);
-    INT_ASSERT(pfs);
-    INT_ASSERT(defPoint->list == &(pfs->shadowVariables()));
+    ForLoop *pfl = toForLoop(defPoint->parentExpr);
+    if(pfs) {
+      INT_ASSERT(defPoint->list == &(pfs->shadowVariables()));
+    } else {
+      INT_ASSERT(pfl);
+      INT_ASSERT(pfl->isOrderIndependent());
+      INT_ASSERT(defPoint->list == &(pfl->shadowVariables()));
+    }
   }
   if (specBlock != NULL)
     INT_ASSERT(intent == TFI_REDUCE || intent == TFI_REDUCE_OP);

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -1032,14 +1032,14 @@ void ShadowVarSymbol::verify() {
   verifyNotOnList(specBlock);
   if (!resolved) {
     // Verify that this symbol is on a ForallStmt::shadowVariables() list.
-    ForallStmt* pfs = toForallStmt(defPoint->parentExpr);
-    ForLoop *pfl = toForLoop(defPoint->parentExpr);
-    if(pfs) {
+    if(ForallStmt* pfs = toForallStmt(defPoint->parentExpr)) {
       INT_ASSERT(defPoint->list == &(pfs->shadowVariables()));
-    } else {
+    } else if(ForLoop *pfl = toForLoop(defPoint->parentExpr)) {
       INT_ASSERT(pfl);
       INT_ASSERT(pfl->isOrderIndependent());
       INT_ASSERT(defPoint->list == &(pfl->shadowVariables()));
+    } else {
+      INT_FATAL(defPoint, "Shadow variable on an unexpected expression");
     }
   }
   if (specBlock != NULL)

--- a/compiler/include/ForLoop.h
+++ b/compiler/include/ForLoop.h
@@ -22,7 +22,7 @@
 #define _FOR_LOOP_H_
 
 #include "LoopStmt.h"
-#include "ForallStmt.h"
+#include "LoopWithShadowVarsInterface.h"
 
 // A ForLoop represents the for-statement language construct as described in
 // the specification (see "The For Loop" section in the chapter on "Statements").

--- a/compiler/include/ForLoop.h
+++ b/compiler/include/ForLoop.h
@@ -22,6 +22,7 @@
 #define _FOR_LOOP_H_
 
 #include "LoopStmt.h"
+#include "ForallStmt.h" // TODO **AIS** CRUFT: Put ShadowVarLoopInterface in a better shared header
 
 // A ForLoop represents the for-statement language construct as described in
 // the specification (see "The For Loop" section in the chapter on "Statements").
@@ -29,7 +30,7 @@
 // parser production into its internal representation.
 // ForLoop objects are also used to represent coforall-statements and zippered
 // iteration.
-class ForLoop final : public LoopStmt
+class ForLoop final : public LoopStmt, public ShadowVarLoopInterface 
 {
   //
   // Class interface
@@ -44,6 +45,7 @@ public:
 
   static BlockStmt*      buildForeachLoop (Expr*      indices,
                                            Expr*      iteratorExpr,
+                                           CallExpr*  intents,
                                            BlockStmt* body,
                                            bool       zippered,
                                            bool       isForExpr,
@@ -66,6 +68,7 @@ public:
 private:
   static BlockStmt*      doBuildForLoop (Expr*      indices,
                                          Expr*      iteratorExpr,
+                                         CallExpr*  intents,
                                          BlockStmt* body,
                                          LLVMMetadataList attrs,
                                          bool       coforall,
@@ -132,6 +135,19 @@ public:
   CallExpr*              blockInfoGet()                      const override;
   CallExpr*              blockInfoSet(CallExpr* expr)              override;
 
+  AList&                 shadowVariables() override;
+
+  bool needToHandleOuterVars() const override { return true; }
+  BlockStmt* loopBody() const override {
+    return const_cast<ForLoop*>(this);
+  }
+  bool needsInitialAccumulate() const override { return false; }
+  Expr* asExpr() override { return this; }
+  bool isInductionVar(Symbol* sym) override;
+
+  virtual bool isForallStmt() override { return false; }
+  virtual ForallStmt *forallStmt() override { INT_ASSERT(false); return nullptr; }
+
 private:
                          ForLoop();
 
@@ -140,6 +156,10 @@ private:
   bool                   mZippered;
   bool                   mLoweredForall;
   bool                   mIsForExpr;
+
+  AList                  fShadowVars;  // may be empty
 };
+
+inline AList& ForLoop::shadowVariables() { return fShadowVars; }
 
 #endif

--- a/compiler/include/ForLoop.h
+++ b/compiler/include/ForLoop.h
@@ -30,7 +30,7 @@
 // parser production into its internal representation.
 // ForLoop objects are also used to represent coforall-statements and zippered
 // iteration.
-class ForLoop final : public LoopStmt, public ShadowVarLoopInterface 
+class ForLoop final : public LoopStmt, public LoopWithShadowVarsInterface
 {
   //
   // Class interface
@@ -145,8 +145,8 @@ public:
   Expr* asExpr() override { return this; }
   bool isInductionVar(Symbol* sym) override;
 
-  virtual bool isForallStmt() override { return false; }
-  virtual ForallStmt *forallStmt() override { INT_ASSERT(false); return nullptr; }
+  bool isForallStmt() final override { return false; }
+  ForallStmt *forallStmt() final override { return nullptr; }
 
 private:
                          ForLoop();

--- a/compiler/include/ForLoop.h
+++ b/compiler/include/ForLoop.h
@@ -22,7 +22,7 @@
 #define _FOR_LOOP_H_
 
 #include "LoopStmt.h"
-#include "ForallStmt.h" // TODO **AIS** CRUFT: Put ShadowVarLoopInterface in a better shared header
+#include "ForallStmt.h"
 
 // A ForLoop represents the for-statement language construct as described in
 // the specification (see "The For Loop" section in the chapter on "Statements").

--- a/compiler/include/ForallStmt.h
+++ b/compiler/include/ForallStmt.h
@@ -22,6 +22,7 @@
 #define _FORALL_STMT_H_
 
 #include "stmt.h"
+#include "LoopWithShadowVarsInterface.h"
 
 enum ForallAutoLocalAccessCloneType {
   NOT_CLONE,
@@ -68,23 +69,6 @@ class ForallOptimizationInfo {
 ///////////////////////////////////
 // forall loop statement         //
 ///////////////////////////////////
-
-// Both 'forall' and 'foreach' loops have shadow variables. We have code that we want to be able
-// to process either but the nearest common ancenstor to these two classes is 'Expr'.
-// In the long run it might be beneficial to rearrange our class heirarchy so these two share
-// a closer ancestor but for the time being I use the following interface for the shared
-// behavior between the two that's used when processing shadow variables.
-struct LoopWithShadowVarsInterface {
-  virtual AList& shadowVariables() = 0;
-  virtual bool needToHandleOuterVars() const = 0;
-  virtual BlockStmt* loopBody() const = 0;
-  virtual bool needsInitialAccumulate() const = 0;
-  virtual Expr* asExpr() = 0;
-  virtual bool isInductionVar(Symbol* sym) = 0;
-
-  virtual bool isForallStmt() = 0;
-  virtual ForallStmt *forallStmt() = 0;
-};
 
 class ForallStmt final : public Stmt, public LoopWithShadowVarsInterface
 {

--- a/compiler/include/ForallStmt.h
+++ b/compiler/include/ForallStmt.h
@@ -66,10 +66,15 @@ class ForallOptimizationInfo {
 };
 
 ///////////////////////////////////
-    // forall loop statement //
+// forall loop statement         //
 ///////////////////////////////////
 
-struct ShadowVarLoopInterface {
+// Both 'forall' and 'foreach' loops have shadow variables. We have code that we want to be able
+// to process either but the nearest common ancenstor to these two classes is 'Expr'.
+// In the long run it might be beneficial to rearrange our class heirarchy so these two share
+// a closer ancestor but for the time being I use the following interface for the shared
+// behavior between the two that's used when processing shadow variables.
+struct LoopWithShadowVarsInterface {
   virtual AList& shadowVariables() = 0;
   virtual bool needToHandleOuterVars() const = 0;
   virtual BlockStmt* loopBody() const = 0;
@@ -81,7 +86,7 @@ struct ShadowVarLoopInterface {
   virtual ForallStmt *forallStmt() = 0;
 };
 
-class ForallStmt final : public Stmt, public ShadowVarLoopInterface
+class ForallStmt final : public Stmt, public LoopWithShadowVarsInterface
 {
 public:
   Expr* asExpr() override { return this; }
@@ -154,8 +159,8 @@ public:
 
   bool isInductionVar(Symbol* sym) override;
 
-  virtual bool isForallStmt() override { return true; }
-  virtual ForallStmt *forallStmt() override { return this; }
+  bool isForallStmt() final override { return true; }
+  ForallStmt *forallStmt() final override { return this; }
 
 private:
   AList          fIterVars;    // DefExprs of the induction vars

--- a/compiler/include/LoopWithShadowVarsInterface.h
+++ b/compiler/include/LoopWithShadowVarsInterface.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _LOOP_WITH_SHADOW_VARS_INTERFACE_STMT_H_
+#define _LOOP_WITH_SHADOW_VARS_INTERFACE_STMT_H_
+
+#include "stmt.h"
+
+// Both 'forall' and 'foreach' loops have shadow variables. We have code that we want to be able
+// to process either but the nearest common ancenstor to these two classes is 'Expr'.
+// In the long run it might be beneficial to rearrange our class heirarchy so these two share
+// a closer ancestor but for the time being I use the following interface for the shared
+// behavior between the two that's used when processing shadow variables.
+struct LoopWithShadowVarsInterface {
+  virtual AList& shadowVariables() = 0;
+  virtual bool needToHandleOuterVars() const = 0;
+  virtual BlockStmt* loopBody() const = 0;
+  virtual bool needsInitialAccumulate() const = 0;
+  virtual Expr* asExpr() = 0;
+  virtual bool isInductionVar(Symbol* sym) = 0;
+
+  virtual bool isForallStmt() = 0;
+  virtual ForallStmt *forallStmt() = 0;
+};
+
+#endif

--- a/compiler/include/baseAST.h
+++ b/compiler/include/baseAST.h
@@ -599,6 +599,7 @@ static inline const CallExpr* toConstCallExpr(const BaseAST* a)
       AST_CALL_CHILD(_a, WhileStmt,    condExprGet(),  call, __VA_ARGS__); \
                                                                            \
     } else if (isForLoop(_a)      == true) {                               \
+      AST_CALL_LIST (_a, ForLoop,      shadowVariables(), call, __VA_ARGS__); \
       AST_CALL_LIST (_a, ForLoop,      body,           call, __VA_ARGS__); \
       AST_CALL_CHILD(_a, ForLoop,      indexGet(),     call, __VA_ARGS__); \
       AST_CALL_CHILD(_a, ForLoop,      iteratorGet(),  call, __VA_ARGS__); \

--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -324,4 +324,6 @@ extern std::vector<std::pair<std::string, std::string>> gDynoParams;
 extern std::vector<std::string> gDynoPrependInternalModulePaths;
 extern std::vector<std::string> gDynoPrependStandardModulePaths;
 
+extern bool fForeachIntents;
+
 #endif

--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -24,6 +24,7 @@
 #include "baseAST.h"
 #include "symbol.h"
 #include "expr.h"
+#include "ForallStmt.h"
 
 #include <map>
 #include <vector>
@@ -169,7 +170,7 @@ void  resolveForallStmts2();
 Expr* replaceForWithForallIfNeeded(ForLoop* forLoop);
 void  setReduceSVars(ShadowVarSymbol*& PRP, ShadowVarSymbol*& PAS,
                      ShadowVarSymbol*& RP, ShadowVarSymbol* AS);
-void setupAndResolveShadowVars(ForallStmt* fs);
+void setupAndResolveShadowVars(ShadowVarLoopInterface *fs);
 bool preserveShadowVar(Symbol* var);
 void adjustNothingShadowVariables();
 Expr* lowerPrimReduce(CallExpr* call);

--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -170,7 +170,7 @@ void  resolveForallStmts2();
 Expr* replaceForWithForallIfNeeded(ForLoop* forLoop);
 void  setReduceSVars(ShadowVarSymbol*& PRP, ShadowVarSymbol*& PAS,
                      ShadowVarSymbol*& RP, ShadowVarSymbol* AS);
-void setupAndResolveShadowVars(ShadowVarLoopInterface *fs);
+void setupAndResolveShadowVars(LoopWithShadowVarsInterface *fs);
 bool preserveShadowVar(Symbol* var);
 void adjustNothingShadowVariables();
 Expr* lowerPrimReduce(CallExpr* call);

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -379,6 +379,8 @@ bool fGpuSpecialization = false;
 const char* gGpuSdkPath = NULL;
 std::set<std::string> gpuArches;
 
+bool fForeachIntents = true;
+
 chpl::Context* gContext = nullptr;
 std::vector<std::pair<std::string, std::string>> gDynoParams;
 
@@ -1466,6 +1468,7 @@ static ArgumentDescription arg_desc[] = {
  {"dyno-break-on-hash", ' ' , NULL, "Break when query with given hash value is executed when using dyno compiler library", "X", &fDynoBreakOnHash, "CHPL_DYNO_BREAK_ON_HASH", NULL},
  {"dyno-gen-lib", ' ', "<path>", "Specify file to be generated as a .dyno library", "P", NULL, NULL, addDynoGenLib},
  {"dyno-verify-serialization", ' ', NULL, "Enable [disable] verification of serialization", "N", &fDynoVerifySerialization, NULL, NULL},
+ {"foreach-intents", ' ', NULL, "Enable [disable] (current, experimental, support for) foreach intents.", "N", &fForeachIntents, "CHPL_FOREACH_INTENTS", NULL},
 
  {"io-gen-serialization", ' ', NULL, "Enable [disable] generation of IO serialization methods", "n", &fNoIOGenSerialization, "CHPL_IO_GEN_SERIALIZATION", NULL},
  {"io-serialize-writeThis", ' ', NULL, "Enable [disable] use of 'writeThis' as default for 'serialize' methods", "n", &fNoIOSerializeWriteThis, "CHPL_IO_SERIALIZE_WRITETHIS", NULL},

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -379,7 +379,7 @@ bool fGpuSpecialization = false;
 const char* gGpuSdkPath = NULL;
 std::set<std::string> gpuArches;
 
-bool fForeachIntents = true;
+bool fForeachIntents = false;
 
 chpl::Context* gContext = nullptr;
 std::vector<std::pair<std::string, std::string>> gDynoParams;

--- a/compiler/passes/cleanup.cpp
+++ b/compiler/passes/cleanup.cpp
@@ -182,13 +182,19 @@ static void backPropagate(BaseAST* ast) {
 }
 
 static void handleNonTypedAndNonInitedVar(DefExpr* def) {
-  if (toVarSymbol(def->sym)) {
+  if (Symbol *sym = toVarSymbol(def->sym)) {
+    if(toShadowVarSymbol(sym)) {
+      return;
+    }
+
+
     bool needsInit = false;
     // The test for FLAG_TEMP allows compiler-generated (temporary) variables
     // to be declared without an explicit type or initializer expression.
     if ((!def->init || def->init->isNoInitExpr())
         && !def->exprType && !def->sym->hasFlag(FLAG_TEMP))
-      if (isBlockStmt(def->parentExpr) && !isArgSymbol(def->parentSymbol))
+      if (isBlockStmt(def->parentExpr) && !isArgSymbol(def->parentSymbol) &&
+          !isShadowVarSymbol(def->sym))
         if (def->parentExpr != rootModule->block && def->parentExpr != stringLiteralModule->block)
           if (!def->sym->hasFlag(FLAG_INDEX_VAR))
             needsInit = true;

--- a/compiler/passes/cleanup.cpp
+++ b/compiler/passes/cleanup.cpp
@@ -182,12 +182,7 @@ static void backPropagate(BaseAST* ast) {
 }
 
 static void handleNonTypedAndNonInitedVar(DefExpr* def) {
-  if (Symbol *sym = toVarSymbol(def->sym)) {
-    if(toShadowVarSymbol(sym)) {
-      return;
-    }
-
-
+  if (isVarSymbol(def->sym) && !isShadowVarSymbol(def->sym)) {
     bool needsInit = false;
     // The test for FLAG_TEMP allows compiler-generated (temporary) variables
     // to be declared without an explicit type or initializer expression.

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -1401,7 +1401,8 @@ struct Converter {
       } else if (const uast::ReduceIntent* rd = expr->toReduceIntent()) {
         astlocMarker markAstLoc(rd->id());
 
-        if(fForeachIntents && parent->toForeach()) {
+        //if(fForeachIntents && parent->toForeach()) {
+        if(parent->toForeach()) {
           USR_FATAL(node->id(), "reduce intents can not be used in foreach loops");
         }
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -7661,7 +7661,7 @@ void printTaskOrForallConstErrorNote(Symbol* aVar) {
     Expr* enclLoop = aVar->defPoint->parentExpr;
 
     USR_PRINT(enclLoop,
-              "The shadow variable '%s' is constant due to intents "
+              "The shadow variable '%s' is constant due to task intents "
               "in this loop",
               varname);
   }
@@ -10559,6 +10559,25 @@ static void        resolveExprMaybeIssueError(CallExpr* call);
 
 static bool        isMentionOfFnTriggeringCapture(SymExpr* se);
 
+static LoopWithShadowVarsInterface*
+  isForeachWhoseShadowVarsShouldBeResolved(SymExpr *se)
+{
+  ForLoop* pfl = toForLoop(se->parentExpr);
+
+  // The pfl->shadowVariables().length > 0 part of the above condition is a
+  // bit of a hack to ensure we don't apply implicit intents on a loop where
+  // we haven't added an explicit intent (via a 'with' clause). Getting
+  // intents to work for 'foreach' loops is a bit of a work in progress and
+  // for the time being I would like to keep the behavior of loops that
+  // don't have a 'with' clause unchanged.
+  if(pfl && pfl->isOrderIndependent() && se == pfl->indexGet() &&
+     (pfl->shadowVariables().length > 0))
+  {
+    return pfl;
+  }
+  return nullptr;
+}
+
 Expr* resolveExpr(Expr* expr) {
   FnSymbol* fn     = toFnSymbol(expr->parentSymbol);
   Expr*     retval = NULL;
@@ -10596,22 +10615,14 @@ Expr* resolveExpr(Expr* expr) {
   } else if (SymExpr* se = toSymExpr(expr)) {
     makeRefType(se->symbol()->type);
 
-    ForallStmt* pfs = isForallIterExpr(se);
-    ForLoop* pfl = toForLoop(se->parentExpr);
-    if (pfs) {
+    if (ForallStmt* pfs = isForallIterExpr(se)) {
       CallExpr* call = resolveForallHeader(pfs, se);
       retval = resolveExprPhase2(expr, fn, preFold(call));
-    } 
-    else if(pfl && pfl->isOrderIndependent() && se == pfl->indexGet() &&
-        (pfl->shadowVariables().length > 0))
+    }
+    else if(LoopWithShadowVarsInterface *loop =
+      isForeachWhoseShadowVarsShouldBeResolved(se))
     {
-      // The pfl->shadowVariables().length > 0 part of the above condition is a
-      // bit of a hack to ensure we don't apply implicit intents on a loop where
-      // we haven't added an explicit intent (via a 'with' clause). Getting
-      // intents to work for 'foreach' loops is a bit of a work in progress and
-      // for the time being I would like to keep the behavior of loops that
-      // don't have a 'with' clause unchanged.
-      setupAndResolveShadowVars(pfl);
+      setupAndResolveShadowVars(loop);
       retval = resolveExprPhase2(expr, fn, expr);
     } else if (isMentionOfFnTriggeringCapture(se)) {
       auto fn = toFnSymbol(se->symbol());

--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -34,15 +34,15 @@
 //
 
 // Is 'sym' an index variable of 'fs' ?
-static bool isFsIndexVar(ForallStmt* fs, Symbol* sym)
+static bool isFsIndexVar(ShadowVarLoopInterface* fs, Symbol* sym)
 {
   if (!sym->hasFlag(FLAG_INDEX_VAR))
     return false;
 
-  return sym->defPoint->list == &fs->inductionVariables();
+  return fs->isInductionVar(sym);
 }
 
-static bool isFsShadowVar(ForallStmt* fs, Symbol* sym)
+static bool isFsShadowVar(ShadowVarLoopInterface* fs, Symbol* sym)
 {
   if (!isShadowVarSymbol(sym))
     return false;
@@ -50,7 +50,7 @@ static bool isFsShadowVar(ForallStmt* fs, Symbol* sym)
   return sym->defPoint->list == &fs->shadowVariables();
 }
 
-static bool needsShadowVar(ForallStmt* fs, BlockStmt* block, Symbol* sym) {
+static bool needsShadowVar(ShadowVarLoopInterface* fs, BlockStmt* block, Symbol* sym) {
   return
     isLcnSymbol(sym)             && // include only variable-like things
     sym->type != dtMethodToken   && // not a method token
@@ -142,7 +142,7 @@ static void insertDeinitialization(ShadowVarSymbol* destVar) {
   insertDeinitialization(destVar->deinitBlock(), destVar);
 }
 
-static void resolveOneShadowVar(ForallStmt* fs, ShadowVarSymbol* svar) {
+static void resolveOneShadowVar(ShadowVarLoopInterface* fs, ShadowVarSymbol* svar) {
   resolveBlockStmt(svar->initBlock());
   resolveBlockStmt(svar->deinitBlock());
 }
@@ -157,7 +157,7 @@ static void resolveOneShadowVar(ForallStmt* fs, ShadowVarSymbol* svar) {
 // If this does not resolve, instead call:
 //   globalOp.accumulate(outerVar)
 //
-static void insertAndResolveInitialAccumulate(ForallStmt* fs, BlockStmt* hld,
+static void insertAndResolveInitialAccumulate(ShadowVarLoopInterface* fs, BlockStmt* hld,
                                             Symbol* globalOp, Symbol* outerVar)
 {
   CallExpr* initAccum = new CallExpr("initialAccumulate", gMethodToken,
@@ -165,7 +165,7 @@ static void insertAndResolveInitialAccumulate(ForallStmt* fs, BlockStmt* hld,
   if (hld)
     hld->insertAtTail(initAccum);
   else
-    fs->insertBefore(initAccum);
+    fs->asExpr()->insertBefore(initAccum);
 
   FnSymbol* initAccumOutcome = tryResolveCall(initAccum);
 
@@ -208,9 +208,9 @@ static void insertAndResolveInitialAccumulate(ForallStmt* fs, BlockStmt* hld,
 //   studies/kmeans/kmeans-blc
 //   studies/kmeans/kmeansonepassreduction-minchange
 //
-// This is invoked only for ForallStmts representing reduce expressions.
+// This is invoked only for ShadowVarLoopInterfaces representing reduce expressions.
 //
-static void workaroundForReduceIntoDetupleDecl(ForallStmt* fs, Symbol* svar) {
+static void workaroundForReduceIntoDetupleDecl(ShadowVarLoopInterface* fs, Symbol* svar) {
   //
   // The pattern we are looking for is when 'svar' is used twice:
   // * as an outer variable of one of fs's shadow variables, and
@@ -249,22 +249,22 @@ static void workaroundForReduceIntoDetupleDecl(ForallStmt* fs, Symbol* svar) {
 }
 
 // Finalize the reduction:  outerVar = globalOp.generate()
-static void insertFinalGenerate(ForallStmt* fs,
+static void insertFinalGenerate(ShadowVarLoopInterface* fs,
                                 Symbol* fiVarSym, Symbol* globalOp)
 {
   if (fs->needsInitialAccumulate()) {
     VarSymbol* genTemp = newTemp("chpl_gentemp");
-    fs->insertAfter(new CallExpr("=", fiVarSym, genTemp));
-    fs->insertAfter("'move'(%S, generate(%S,%S))",
+    fs->asExpr()->insertAfter(new CallExpr("=", fiVarSym, genTemp));
+    fs->asExpr()->insertAfter("'move'(%S, generate(%S,%S))",
                     genTemp, gMethodToken, globalOp);
-    fs->insertAfter(new DefExpr(genTemp));
+    fs->asExpr()->insertAfter(new DefExpr(genTemp));
     // TODO: Should we try to free chpl_gentemp right after the assignment?
     genTemp->addFlag(FLAG_INSERT_AUTO_DESTROY);
   } else {
     // Initialize, not assign. Do everything *after* 'fs'.
-    fs->insertAfter("'move'(%S, generate(%S,%S))",
+    fs->asExpr()->insertAfter("'move'(%S, generate(%S,%S))",
                     fiVarSym, gMethodToken, globalOp);
-    fs->insertAfter(fiVarSym->defPoint->remove());
+    fs->asExpr()->insertAfter(fiVarSym->defPoint->remove());
     fiVarSym->addFlag(FLAG_EXPR_TEMP);
     workaroundForReduceIntoDetupleDecl(fs, fiVarSym);
   }
@@ -295,12 +295,12 @@ static void moveInstantiationPoint(BlockStmt* to, BlockStmt* from, Type* type) {
   }
 }
 
-static Symbol* setupRiGlobalOp(ForallStmt* fs, Symbol* fiVarSym,
+static Symbol* setupRiGlobalOp(ShadowVarLoopInterface* fs, Symbol* fiVarSym,
                                Expr* origRiSpec, TypeSymbol* riTypeSym,
                                Expr* eltTypeArg)
 {
   BlockStmt* hld = new BlockStmt(); // "holder"
-  fs->insertBefore(hld);
+  fs->asExpr()->insertBefore(hld);
 
   VarSymbol* globalOp = newTemp(astr("globalRP_", fiVarSym->name));
   hld->insertAtTail(new DefExpr(globalOp));
@@ -332,7 +332,7 @@ static Symbol* setupRiGlobalOp(ForallStmt* fs, Symbol* fiVarSym,
     hld->insertAtTail(new CallExpr(PRIM_MOVE, globalOp, newCall));
   }
 
-  fs->insertAfter("chpl__delete(%S)", globalOp);
+  fs->asExpr()->insertAfter("chpl__delete(%S)", globalOp);
   insertFinalGenerate(fs, fiVarSym, globalOp);
 
   resolveBlockStmt(hld);
@@ -349,7 +349,7 @@ static Symbol* setupRiGlobalOp(ForallStmt* fs, Symbol* fiVarSym,
   return globalOp;
 }
 
-static void handleRISpec(ForallStmt* fs, ShadowVarSymbol* svar)
+static void handleRISpec(ShadowVarLoopInterface* fs, ShadowVarSymbol* svar)
 {
   Symbol* globalOp = NULL;
   Symbol* fiVarSym = svar->outerVarSym();
@@ -389,7 +389,7 @@ static void handleRISpec(ForallStmt* fs, ShadowVarSymbol* svar)
 
   } else {
     // What else can this be?
-    INT_FATAL(fs, "not implemented");
+    INT_FATAL(fs->asExpr(), "not implemented");
   }
   // Removing 'globalOp' is left as future work.
   if (globalOp) INT_ASSERT(globalOp); // dummy use of 'globalOp'
@@ -412,7 +412,7 @@ void  setReduceSVars(ShadowVarSymbol*& PRP, ShadowVarSymbol*& PAS,
   INT_ASSERT(PRP->intent == TFI_REDUCE_PARENT_OP);
 }
 
-static ShadowVarSymbol* create_REDUCE_PRP(ForallStmt* fs, ShadowVarSymbol* AS)
+static ShadowVarSymbol* create_REDUCE_PRP(ShadowVarLoopInterface* fs, ShadowVarSymbol* AS)
 {
   // This is the global reduce op, either provided by user or set up by us.
   // PRP->outerVarSE will point to it.
@@ -435,7 +435,7 @@ static ShadowVarSymbol* create_REDUCE_PRP(ForallStmt* fs, ShadowVarSymbol* AS)
   return PRP;
 }
 
-static ShadowVarSymbol* create_REDUCE_PAS(ForallStmt* fs, ShadowVarSymbol* AS)
+static ShadowVarSymbol* create_REDUCE_PAS(ShadowVarLoopInterface* fs, ShadowVarSymbol* AS)
 {
   ShadowVarSymbol* PAS = new ShadowVarSymbol(TFI_REDUCE_PARENT_AS,
                                              astr("PAS_", AS->name), NULL);
@@ -448,7 +448,7 @@ static ShadowVarSymbol* create_REDUCE_PAS(ForallStmt* fs, ShadowVarSymbol* AS)
   return PAS;
 }
 
-static ShadowVarSymbol* create_REDUCE_RP(ForallStmt* fs, ShadowVarSymbol* PRP,
+static ShadowVarSymbol* create_REDUCE_RP(ShadowVarLoopInterface* fs, ShadowVarSymbol* PRP,
                                          ShadowVarSymbol* AS)
 {
   ShadowVarSymbol* RP = new ShadowVarSymbol(TFI_REDUCE_OP,
@@ -466,7 +466,7 @@ static ShadowVarSymbol* create_REDUCE_RP(ForallStmt* fs, ShadowVarSymbol* PRP,
   return RP;
 }
 
-static void setupForReduce(ForallStmt* fs,
+static void setupForReduce(ShadowVarLoopInterface* fs,
                            ShadowVarSymbol* PRP, ShadowVarSymbol* PAS,
                            ShadowVarSymbol* RP,  ShadowVarSymbol* AS)
 {
@@ -495,7 +495,7 @@ static void setupForReduce(ForallStmt* fs,
 
   /// before the forall ///
   BlockStmt* holder1 = new BlockStmt();
-  fs->insertBefore(holder1);
+  fs->asExpr()->insertBefore(holder1);
   holder1->insertAtTail(new DefExpr(globalAS));
   insertInitialization(holder1, globalAS,
                        new_Expr("identity(%S,%S)", gMethodToken, globalRP));
@@ -505,7 +505,7 @@ static void setupForReduce(ForallStmt* fs,
 
   /// after the forall ///
   BlockStmt* holder2 = new BlockStmt();
-  fs->insertAfter(holder2);
+  fs->asExpr()->insertAfter(holder2);
   holder2->insertAtTail("accumulate(%S,%S,%S)",
                         gMethodToken, globalRP, globalAS);
   insertDeinitialization(holder2, globalAS);
@@ -513,12 +513,12 @@ static void setupForReduce(ForallStmt* fs,
   holder2->flattenAndRemove();
 }
 
-static void handleReduce(ForallStmt* fs, ShadowVarSymbol* AS) {
+static void handleReduce(ShadowVarLoopInterface* fs, ShadowVarSymbol* AS) {
   handleRISpec(fs, AS);
 
   Symbol* ASovar = AS->outerVarSym();
   if (ASovar && ASovar->hasFlag(FLAG_CONST)) {
-    USR_FATAL_CONT(fs,
+    USR_FATAL_CONT(fs->asExpr(),
       "reduce intent is applied to a 'const' variable %s", ASovar->name);
   }
 
@@ -546,7 +546,7 @@ static void handleReduce(ForallStmt* fs, ShadowVarSymbol* AS) {
 // handleOneShadowVar()
 //
 
-static ShadowVarSymbol* create_IN_Parentvar(ForallStmt* fs,
+static ShadowVarSymbol* create_IN_Parentvar(ShadowVarLoopInterface* fs,
                                             ShadowVarSymbol* SI,
                                             Symbol* userOuterVar)
 {
@@ -569,7 +569,7 @@ static ShadowVarSymbol* create_IN_Parentvar(ForallStmt* fs,
     VarSymbol* inptemp = newTempConst("INPtemp", SI->type);
     inptemp->qual      = QUAL_CONST_VAL;
 
-    fs->insertBefore(holder);
+    fs->asExpr()->insertBefore(holder);
     holder->insertAtTail(new DefExpr(inptemp));
     insertInitialization(holder, inptemp, cast);
     resolveBlockStmt(holder);
@@ -595,7 +595,7 @@ static void constDueToTFI(ShadowVarSymbol* svar, Symbol* ovar) {
     svar->addFlag(FLAG_CONST_DUE_TO_TASK_FORALL_INTENT);
 }
 
-static void handleIn(ForallStmt* fs, ShadowVarSymbol* SI, bool isConst) {
+static void handleIn(ShadowVarLoopInterface* fs, ShadowVarSymbol* SI, bool isConst) {
   Symbol* ovar = SI->outerVarSym();
 
   if (isConst) {
@@ -614,7 +614,7 @@ static void handleIn(ForallStmt* fs, ShadowVarSymbol* SI, bool isConst) {
   resolveOneShadowVar(fs, INP);
 }
 
-static void handleRef(ForallStmt* fs, ShadowVarSymbol* SR, bool isConst) {
+static void handleRef(ShadowVarLoopInterface* fs, ShadowVarSymbol* SR, bool isConst) {
   Symbol* ovar = SR->outerVarSym();
   if (isConst) {
     SR->addFlag(FLAG_CONST);
@@ -628,7 +628,7 @@ static void handleRef(ForallStmt* fs, ShadowVarSymbol* SR, bool isConst) {
     SR->addFlag(FLAG_REF_TO_IMMUTABLE);
 }
 
-static void handleTaskPrivate(ForallStmt* fs, ShadowVarSymbol* TPV) {
+static void handleTaskPrivate(ShadowVarLoopInterface* fs, ShadowVarSymbol* TPV) {
   // initBlock() already comes from TPV's declaration in the with-clause,
   // so nothing to do with it.
 
@@ -637,7 +637,7 @@ static void handleTaskPrivate(ForallStmt* fs, ShadowVarSymbol* TPV) {
     insertDeinitialization(TPV);
 }
 
-static void handleOneShadowVar(ForallStmt* fs, ShadowVarSymbol* svar)
+static void handleOneShadowVar(ShadowVarLoopInterface* fs, ShadowVarSymbol* svar)
 {
   if (svar->id == breakOnResolveID) gdbShouldBreakHere();
 
@@ -717,7 +717,7 @@ std::map<ForallStmt*, std::set<Symbol*>> refMaybeConstForallPairs;
 // It is done on an already-existing, explicit shadow variable
 // or before an implicit shadow variable is to be created.
 //
-static void resolveShadowVarTypeIntent(ForallStmt* fs,
+static void resolveShadowVarTypeIntent(ShadowVarLoopInterface* fs,
                                        Symbol* sym,
                                        Type*& type,
                                        ForallIntentTag& intent,
@@ -743,13 +743,18 @@ static void resolveShadowVarTypeIntent(ForallStmt* fs,
       argInt = concreteIntent(argInt, valType);
       intent = forallIntentForArgIntent(argInt);
 
-      // mark all ref-maybe-const shadow variables
-      if (argInt == INTENT_REF_MAYBE_CONST && intent == TFI_REF) {
-        auto it = refMaybeConstForallPairs.find(fs);
-        if (it == refMaybeConstForallPairs.end())
-          it = refMaybeConstForallPairs.insert(it, {fs, {}});
-        it->second.insert(sym);
-        implicitRefMaybeConst = true;
+      // We gather ref maybe const symbols for 'forall' loops for a later
+      // check that. This is not necessary on 'foreach' loops since (as of the
+      // time of this comment) 'foreach' is itself considered unstable.
+      if (fs->isForallStmt()) {
+        // mark all ref-maybe-const shadow variables
+        if (argInt == INTENT_REF_MAYBE_CONST && intent == TFI_REF) {
+          auto it = refMaybeConstForallPairs.find(fs->forallStmt());
+          if (it == refMaybeConstForallPairs.end())
+            it = refMaybeConstForallPairs.insert(it, {fs->forallStmt(), {}});
+          it->second.insert(sym);
+          implicitRefMaybeConst = true;
+        }
       }
 
       break;
@@ -764,13 +769,16 @@ static void resolveShadowVarTypeIntent(ForallStmt* fs,
     case TFI_REF: {
       // if there is an explicit ref shadow variable
       // we need to remove the symbol from the list
-      auto it = refMaybeConstForallPairs.find(fs);
-      if (it != refMaybeConstForallPairs.end()) {
-        auto& listOfSyms = it->second;
-        listOfSyms.erase(sym);
-        if (ShadowVarSymbol* svar = toShadowVarSymbol(sym)) {
-          if(Symbol* outerSym = svar->outerVarSym()) {
-            listOfSyms.erase(outerSym);
+      // this list is used for an unstable warning that's only applicable to 'forall' loops
+      if(fs->isForallStmt()) {
+        auto it = refMaybeConstForallPairs.find(fs->forallStmt());
+        if (it != refMaybeConstForallPairs.end()) {
+          auto& listOfSyms = it->second;
+          listOfSyms.erase(sym);
+          if (ShadowVarSymbol* svar = toShadowVarSymbol(sym)) {
+            if(Symbol* outerSym = svar->outerVarSym()) {
+              listOfSyms.erase(outerSym);
+            }
           }
         }
       }
@@ -813,7 +821,7 @@ static void resolveShadowVarTypeIntent(ForallStmt* fs,
 
 // If 'sym' is the receiver and 'fs' has a shadow var for the receiver,
 // return that shadow var.
-static ShadowVarSymbol* svarForReceiver(ForallStmt* fs, Symbol* sym) {
+static ShadowVarSymbol* svarForReceiver(ShadowVarLoopInterface* fs, Symbol* sym) {
   if (sym->name == astrThis)
     for_shadow_vars(SV, TEMP, fs)
       if (SV->name == astrThis)
@@ -850,11 +858,12 @@ static void assertNotRecordReceiver(Symbol* ovar, Expr* ref) {
 // At the same time, perform the substitutions already in 'outer2shadow'
 // except markPruned.
 //
-static void doImplicitShadowVars(ForallStmt* fs, BlockStmt* block,
+static void doImplicitShadowVars(ShadowVarLoopInterface* fs, BlockStmt* block,
                                  SymbolMap& outer2shadow)
 {
   std::vector<SymExpr*> symExprs;
-  collectLcnSymExprs(block, symExprs);
+  for_alist(next_ast, block->body)
+    collectLcnSymExprs(next_ast, symExprs);
 
   for_vector(SymExpr, se, symExprs) {
     Symbol* sym = se->symbol();
@@ -904,16 +913,16 @@ static void doImplicitShadowVars(ForallStmt* fs, BlockStmt* block,
   }
 }
 
-static void collectAndResolveImplicitShadowVars(ForallStmt* fs)
+static void collectAndResolveImplicitShadowVars(ShadowVarLoopInterface* fs)
 {
   if (!fs->needToHandleOuterVars())  // no shadow vars, please
     return;
 
-  SET_LINENO(fs);
+  SET_LINENO(fs->asExpr());
   SymbolMap outer2shadow;
 
   // These are the additional blocks to look into for outer/shadow variables.
-  // This is specific to the start-of-resolution-of-ForallStmt point,
+  // This is specific to the start-of-resolution-of-ShadowVarLoopInterface point,
   // where most initBlock() and deinitBlock() are irrelevant/empty.
   for_shadow_vars(svar, temp, fs)
     if (svar->isTaskPrivate())
@@ -942,7 +951,7 @@ static void removeUsesOfShadowVar(ShadowVarSymbol* svar) {
   svar->defPoint->remove();
 }
 
-static void resolveAndPruneExplicitShadowVars(ForallStmt* fs,
+static void resolveAndPruneExplicitShadowVars(ShadowVarLoopInterface* fs,
                                               Expr* lastExplicitSVarDef)
 {
   if (lastExplicitSVarDef == NULL)
@@ -1018,11 +1027,11 @@ static VarSymbol* createFieldRef(Expr* anchor, Symbol* thisSym,
 // Given a field "myField", create a shadow variable myField_SV
 // whose outer variable "myField_ref" is set up prior to 'fs':
 //   ref myField_ref = ovar.myField;
-static ShadowVarSymbol* createSVforFieldAccess(ForallStmt* fs, Symbol* ovar,
+static ShadowVarSymbol* createSVforFieldAccess(ShadowVarLoopInterface* fs, Symbol* ovar,
                                                Symbol* field)
 {
   bool isConst = ovar->isConstant() || field->isConstant();
-  VarSymbol* fieldRef = createFieldRef(fs, ovar, field, isConst);
+  VarSymbol* fieldRef = createFieldRef(fs->asExpr(), ovar, field, isConst);
 
   // Now create the shadow variable.
   Type*           svarType   = field->type;
@@ -1042,15 +1051,17 @@ static ShadowVarSymbol* createSVforFieldAccess(ForallStmt* fs, Symbol* ovar,
   // implicit ref intents, this check ensures that later on
   // refMaybeConstForallPairs checks the right symbols
   if (wasImplicitRef) {
-    auto fsIt = refMaybeConstForallPairs.find(fs);
-    CHPL_ASSERT(fsIt != refMaybeConstForallPairs.end());
-    fsIt->second.insert(svar);
+    if(fs->isForallStmt()) {
+      auto fsIt = refMaybeConstForallPairs.find(fs->forallStmt());
+      CHPL_ASSERT(fsIt != refMaybeConstForallPairs.end());
+      fsIt->second.insert(svar);
+    }
   }
 
   return svar;
 }
 
-static void doConvertFieldsOfThis(ForallStmt* fs, AggregateType* recType,
+static void doConvertFieldsOfThis(ShadowVarLoopInterface* fs, AggregateType* recType,
                                   ShadowVarSymbol* svar, Symbol* ovar)
 {
   std::map<Symbol*, ShadowVarSymbol*> fieldVars;
@@ -1072,7 +1083,7 @@ static void doConvertFieldsOfThis(ForallStmt* fs, AggregateType* recType,
 
 // This handles forall loops.
 // See also convertFieldsOfRecordThis().
-static void convertFieldsOfRecordReceiver(ForallStmt* fs) {
+static void convertFieldsOfRecordReceiver(ShadowVarLoopInterface* fs) {
   // Each access to the receiver's field will reference the ArgSymbol
   // for 'this'. Which will force us to have a shadow variable for 'this'
   // and replace those ArgSymbol references with the shadow variable.
@@ -1180,7 +1191,7 @@ void convertFieldsOfRecordThis(FnSymbol* fn) {
 // setupAndResolveShadowVars() - the driver
 //
 
-void setupAndResolveShadowVars(ForallStmt* fs)
+void setupAndResolveShadowVars(ShadowVarLoopInterface* fs)
 {
   // Remember the last explicit shadow variable on the list, so that
   // resolveAndPruneExplicitShadowVars() stops there and does not deal

--- a/test/domains/compilerErrors/constDomain11.good
+++ b/test/domains/compilerErrors/constDomain11.good
@@ -1,3 +1,3 @@
 constDomain11.chpl:3: error: const actual is passed to 'ref' formal 'this' of requestCapacity()
 note: to formal of type DefaultAssociativeDom(int(64),true)
-constDomain11.chpl:2: note: The shadow variable 'd' is constant due to intents in this loop
+constDomain11.chpl:2: note: The shadow variable 'd' is constant due to task intents in this loop

--- a/test/domains/compilerErrors/constDomain11.good
+++ b/test/domains/compilerErrors/constDomain11.good
@@ -1,3 +1,3 @@
 constDomain11.chpl:3: error: const actual is passed to 'ref' formal 'this' of requestCapacity()
 note: to formal of type DefaultAssociativeDom(int(64),true)
-constDomain11.chpl:2: note: The shadow variable 'd' is constant due to forall intents in this loop
+constDomain11.chpl:2: note: The shadow variable 'd' is constant due to intents in this loop

--- a/test/domains/compilerErrors/constDomain3.good
+++ b/test/domains/compilerErrors/constDomain3.good
@@ -1,3 +1,3 @@
 constDomain3.chpl:3: error: const actual is passed to 'ref' formal 'this' of add()
 note: to formal of type DefaultAssociativeDom(int(64),true)
-constDomain3.chpl:2: note: The shadow variable 'd' is constant due to forall intents in this loop
+constDomain3.chpl:2: note: The shadow variable 'd' is constant due to intents in this loop

--- a/test/domains/compilerErrors/constDomain3.good
+++ b/test/domains/compilerErrors/constDomain3.good
@@ -1,3 +1,3 @@
 constDomain3.chpl:3: error: const actual is passed to 'ref' formal 'this' of add()
 note: to formal of type DefaultAssociativeDom(int(64),true)
-constDomain3.chpl:2: note: The shadow variable 'd' is constant due to intents in this loop
+constDomain3.chpl:2: note: The shadow variable 'd' is constant due to task intents in this loop

--- a/test/domains/compilerErrors/constDomain8.good
+++ b/test/domains/compilerErrors/constDomain8.good
@@ -1,3 +1,3 @@
 constDomain8.chpl:3: error: const actual is passed to 'ref' formal 'this' of remove()
 note: to formal of type DefaultAssociativeDom(int(64),true)
-constDomain8.chpl:2: note: The shadow variable 'd' is constant due to forall intents in this loop
+constDomain8.chpl:2: note: The shadow variable 'd' is constant due to intents in this loop

--- a/test/domains/compilerErrors/constDomain8.good
+++ b/test/domains/compilerErrors/constDomain8.good
@@ -1,3 +1,3 @@
 constDomain8.chpl:3: error: const actual is passed to 'ref' formal 'this' of remove()
 note: to formal of type DefaultAssociativeDom(int(64),true)
-constDomain8.chpl:2: note: The shadow variable 'd' is constant due to intents in this loop
+constDomain8.chpl:2: note: The shadow variable 'd' is constant due to task intents in this loop

--- a/test/functions/ferguson/ref-pair/array-tasks-const1.good
+++ b/test/functions/ferguson/ref-pair/array-tasks-const1.good
@@ -1,6 +1,6 @@
 array-tasks-const1.chpl:56: In function 'writeCaptureForall':
 array-tasks-const1.chpl:58: error: const actual is passed to 'ref' formal 'x' of writeit()
-array-tasks-const1.chpl:57: note: The shadow variable 'A' is constant due to intents in this loop
+array-tasks-const1.chpl:57: note: The shadow variable 'A' is constant due to task intents in this loop
   array-tasks-const1.chpl:84: called as writeCaptureForall(A: [domain(1,int(64),one)] int(64))
 array-tasks-const1.chpl:62: In function 'writeCaptureCoforall':
 array-tasks-const1.chpl:64: error: const actual is passed to 'ref' formal 'x' of writeit()

--- a/test/functions/ferguson/ref-pair/array-tasks-const1.good
+++ b/test/functions/ferguson/ref-pair/array-tasks-const1.good
@@ -1,6 +1,6 @@
 array-tasks-const1.chpl:56: In function 'writeCaptureForall':
 array-tasks-const1.chpl:58: error: const actual is passed to 'ref' formal 'x' of writeit()
-array-tasks-const1.chpl:57: note: The shadow variable 'A' is constant due to forall intents in this loop
+array-tasks-const1.chpl:57: note: The shadow variable 'A' is constant due to intents in this loop
   array-tasks-const1.chpl:84: called as writeCaptureForall(A: [domain(1,int(64),one)] int(64))
 array-tasks-const1.chpl:62: In function 'writeCaptureCoforall':
 array-tasks-const1.chpl:64: error: const actual is passed to 'ref' formal 'x' of writeit()

--- a/test/parallel/forall/checks/forall-inout-domain-bug-16301.good
+++ b/test/parallel/forall/checks/forall-inout-domain-bug-16301.good
@@ -1,3 +1,3 @@
 forall-inout-domain-bug-16301.chpl:9: In function 'foo':
 forall-inout-domain-bug-16301.chpl:12: error: cannot assign to const variable
-forall-inout-domain-bug-16301.chpl:11: note: The shadow variable 'D' is constant due to forall intents in this loop
+forall-inout-domain-bug-16301.chpl:11: note: The shadow variable 'D' is constant due to intents in this loop

--- a/test/parallel/forall/checks/forall-inout-domain-bug-16301.good
+++ b/test/parallel/forall/checks/forall-inout-domain-bug-16301.good
@@ -1,3 +1,3 @@
 forall-inout-domain-bug-16301.chpl:9: In function 'foo':
 forall-inout-domain-bug-16301.chpl:12: error: cannot assign to const variable
-forall-inout-domain-bug-16301.chpl:11: note: The shadow variable 'D' is constant due to intents in this loop
+forall-inout-domain-bug-16301.chpl:11: note: The shadow variable 'D' is constant due to task intents in this loop

--- a/test/parallel/forall/vass/other/const-errors-due-to-intents.good
+++ b/test/parallel/forall/vass/other/const-errors-due-to-intents.good
@@ -1,16 +1,16 @@
 const-errors-due-to-intents.chpl:10: error: cannot assign to const variable
-const-errors-due-to-intents.chpl:9: note: The shadow variable 'i1' is constant due to forall intents in this loop
+const-errors-due-to-intents.chpl:9: note: The shadow variable 'i1' is constant due to intents in this loop
 const-errors-due-to-intents.chpl:11: error: cannot assign to const variable
-const-errors-due-to-intents.chpl:9: note: The shadow variable 'i2' is constant due to forall intents in this loop
+const-errors-due-to-intents.chpl:9: note: The shadow variable 'i2' is constant due to intents in this loop
 const-errors-due-to-intents.chpl:12: error: cannot assign to const variable
-const-errors-due-to-intents.chpl:9: note: The shadow variable 'i3' is constant due to forall intents in this loop
+const-errors-due-to-intents.chpl:9: note: The shadow variable 'i3' is constant due to intents in this loop
 const-errors-due-to-intents.chpl:13: error: cannot assign to const variable
-const-errors-due-to-intents.chpl:9: note: The shadow variable 'i4' is constant due to forall intents in this loop
+const-errors-due-to-intents.chpl:9: note: The shadow variable 'i4' is constant due to intents in this loop
 const-errors-due-to-intents.chpl:14: error: const actual is passed to 'ref' formal 'arg' of useit()
-const-errors-due-to-intents.chpl:9: note: The shadow variable 'i1' is constant due to forall intents in this loop
+const-errors-due-to-intents.chpl:9: note: The shadow variable 'i1' is constant due to intents in this loop
 const-errors-due-to-intents.chpl:15: error: const actual is passed to 'ref' formal 'arg' of useit()
-const-errors-due-to-intents.chpl:9: note: The shadow variable 'i2' is constant due to forall intents in this loop
+const-errors-due-to-intents.chpl:9: note: The shadow variable 'i2' is constant due to intents in this loop
 const-errors-due-to-intents.chpl:16: error: const actual is passed to 'ref' formal 'arg' of useit()
-const-errors-due-to-intents.chpl:9: note: The shadow variable 'i3' is constant due to forall intents in this loop
+const-errors-due-to-intents.chpl:9: note: The shadow variable 'i3' is constant due to intents in this loop
 const-errors-due-to-intents.chpl:17: error: const actual is passed to 'ref' formal 'arg' of useit()
-const-errors-due-to-intents.chpl:9: note: The shadow variable 'i4' is constant due to forall intents in this loop
+const-errors-due-to-intents.chpl:9: note: The shadow variable 'i4' is constant due to intents in this loop

--- a/test/parallel/forall/vass/other/const-errors-due-to-intents.good
+++ b/test/parallel/forall/vass/other/const-errors-due-to-intents.good
@@ -1,16 +1,16 @@
 const-errors-due-to-intents.chpl:10: error: cannot assign to const variable
-const-errors-due-to-intents.chpl:9: note: The shadow variable 'i1' is constant due to intents in this loop
+const-errors-due-to-intents.chpl:9: note: The shadow variable 'i1' is constant due to task intents in this loop
 const-errors-due-to-intents.chpl:11: error: cannot assign to const variable
-const-errors-due-to-intents.chpl:9: note: The shadow variable 'i2' is constant due to intents in this loop
+const-errors-due-to-intents.chpl:9: note: The shadow variable 'i2' is constant due to task intents in this loop
 const-errors-due-to-intents.chpl:12: error: cannot assign to const variable
-const-errors-due-to-intents.chpl:9: note: The shadow variable 'i3' is constant due to intents in this loop
+const-errors-due-to-intents.chpl:9: note: The shadow variable 'i3' is constant due to task intents in this loop
 const-errors-due-to-intents.chpl:13: error: cannot assign to const variable
-const-errors-due-to-intents.chpl:9: note: The shadow variable 'i4' is constant due to intents in this loop
+const-errors-due-to-intents.chpl:9: note: The shadow variable 'i4' is constant due to task intents in this loop
 const-errors-due-to-intents.chpl:14: error: const actual is passed to 'ref' formal 'arg' of useit()
-const-errors-due-to-intents.chpl:9: note: The shadow variable 'i1' is constant due to intents in this loop
+const-errors-due-to-intents.chpl:9: note: The shadow variable 'i1' is constant due to task intents in this loop
 const-errors-due-to-intents.chpl:15: error: const actual is passed to 'ref' formal 'arg' of useit()
-const-errors-due-to-intents.chpl:9: note: The shadow variable 'i2' is constant due to intents in this loop
+const-errors-due-to-intents.chpl:9: note: The shadow variable 'i2' is constant due to task intents in this loop
 const-errors-due-to-intents.chpl:16: error: const actual is passed to 'ref' formal 'arg' of useit()
-const-errors-due-to-intents.chpl:9: note: The shadow variable 'i3' is constant due to intents in this loop
+const-errors-due-to-intents.chpl:9: note: The shadow variable 'i3' is constant due to task intents in this loop
 const-errors-due-to-intents.chpl:17: error: const actual is passed to 'ref' formal 'arg' of useit()
-const-errors-due-to-intents.chpl:9: note: The shadow variable 'i4' is constant due to intents in this loop
+const-errors-due-to-intents.chpl:9: note: The shadow variable 'i4' is constant due to task intents in this loop

--- a/test/release/examples/users-guide/datapar/promotion.error2.good
+++ b/test/release/examples/users-guide/datapar/promotion.error2.good
@@ -1,2 +1,2 @@
 promotion.chpl:109: error: const actual is passed to 'ref' formal 'x' of maybeCopy()
-promotion.chpl:108: note: The shadow variable 'r' is constant due to forall intents in this loop
+promotion.chpl:108: note: The shadow variable 'r' is constant due to intents in this loop

--- a/test/release/examples/users-guide/datapar/promotion.error2.good
+++ b/test/release/examples/users-guide/datapar/promotion.error2.good
@@ -1,2 +1,2 @@
 promotion.chpl:109: error: const actual is passed to 'ref' formal 'x' of maybeCopy()
-promotion.chpl:108: note: The shadow variable 'r' is constant due to intents in this loop
+promotion.chpl:108: note: The shadow variable 'r' is constant due to task intents in this loop

--- a/test/statements/foreach/COMPOPTS
+++ b/test/statements/foreach/COMPOPTS
@@ -1,0 +1,1 @@
+--foreach-intents

--- a/test/statements/foreach/constIntent.chpl
+++ b/test/statements/foreach/constIntent.chpl
@@ -1,0 +1,4 @@
+var c = 42; 
+
+foreach i in 0..0 with (const c) do writeln(c);
+foreach i in 0..0 with (const c) do c = 1;

--- a/test/statements/foreach/constIntent.good
+++ b/test/statements/foreach/constIntent.good
@@ -1,0 +1,2 @@
+constIntent.chpl:4: error: cannot assign to const variable
+constIntent.chpl:4: note: The shadow variable 'c' is constant due to intents in this loop

--- a/test/statements/foreach/constIntent.good
+++ b/test/statements/foreach/constIntent.good
@@ -1,2 +1,2 @@
 constIntent.chpl:4: error: cannot assign to const variable
-constIntent.chpl:4: note: The shadow variable 'c' is constant due to intents in this loop
+constIntent.chpl:4: note: The shadow variable 'c' is constant due to task intents in this loop

--- a/test/statements/foreach/refIntent.chpl
+++ b/test/statements/foreach/refIntent.chpl
@@ -1,0 +1,5 @@
+var x = 42; 
+
+writeln("before loop: ", x);
+foreach i in 0..0 with (ref x) do x = 52;
+writeln("after loop: ", x);

--- a/test/statements/foreach/refIntent.good
+++ b/test/statements/foreach/refIntent.good
@@ -1,0 +1,2 @@
+before loop: 42
+after loop: 52

--- a/util/chpl-completion.bash
+++ b/util/chpl-completion.bash
@@ -79,6 +79,7 @@ _chpl ()
 --fast \
 --fast-followers \
 --force-vectorize \
+--foreach-intents \
 --formal-domain-checks \
 --gasnet-segment \
 --gdb \
@@ -197,6 +198,7 @@ _chpl ()
 --no-explain-verbose \
 --no-fast-followers \
 --no-force-vectorize \
+--no-foreach-intents \
 --no-formal-domain-checks \
 --no-gen-ids \
 --no-gpu-specialization \


### PR DESCRIPTION
This PR begins work on enabling intents on `foreach` loops.  Specifically, it changes things so that this example now properly errors out (saying you can't assign to the constant 'c'):

```chpl
var c = 42; 
foreach i in 0..0 with (const c) do c = 1;
```

While ensuring that an example that doesn't modify 'c' still works fine. It also allows `ref` intents syntactically, so this will work:

```chpl
foreach i in 0..0 with (ref x) do x = 52;
```

Although at this point the `ref` intent itself won't change any existing behavior (so for example if this loop is gpuized and run on the gpu it will keep the existing behavior where `x` is passed to the kernel by-value effectively treating like an `in` intent).

Anyway, this is all a work in progress but I would like to get code merged early and often as I make progress on it.  With this in mind I introduce a new feature controlling global `fForeachIntents` in `driver.h` that can be turned on/off by passing `chpl` `--foreach-intents`.  For the time being I'm leavning this default "off".

When this feature is off foreach loops that have explicit intents will error with a syntax error early on (during `convertuast`) and at the moment we don't apply implicit intents to `foreach` loops that don't have any other explicit intents.

**Implementation Notes**:

- Before being lowered, `foreach` loops are modeled in the production compiler's AST using the `ForLoop` node. `forall` loops use the `ForallStmt`.
  - Unfortunately, the nearest common ancestor of these nodes is `Expr` so there isn't really a nice place to put common methods or data members.  I spent some time trying to see if could mock up a way to refactor things so they could be (see the "Exploring if we could rearrange the class hierarchy" comments here https://github.com/Cray/chapel-private/issues/5092#issuecomment-1648278779) and I don't think it's really feasible without major engineering efforts. To avoid duplicating code as much as I can I create a class `ShadowVarLoopInterface` that I have both `ForLoop` and `ForallStmt` derive from.
- There are several places where I either copy or reuse code to get `foreach` loops to behave similarly to forall loops:
  - **Convert uast**: if the user opts into `foreach` intents then I skip a check that would previously error out. I then pass along intents to a `ForLoop::buildForeachLoop` function and process it there similarly to what we do for ForAll loops.
  - **Scope resolve**: there's a loop that iterates over all forall loops and processes their shadow variables, it's just a matter of copying this loop and doing the same for foreach (thankfully the bulk of the work done by the loop is already factored out into functions that are written generically enough to work for both kinds of loops). 
  - **Function resolution**: during resolveExpr when we encounter a forall loop we call call `setupAndResolveShadowVars` in `implementForallIntents.cpp`. I've expanded this to also call `setupAndResolveShadowVars` for foreach loops when they have a shadow variable (which happens if the user explicitly used a `with` clause to add intents).
    - Eventually I'd like to modify things so this is always called (so that we set implicit shadow variables for loops the user didn't explicitly imply intents on) but I'm leaving this as future work.
    - I've modified the various functions in this file to operate on my new `ShadowVarLoopInterface` interface instead of on `ForallStmt` directly.
      - There is some code that I think really is `ForallStmt` specific, in which case I have an "escape hatch" in `ShadwoVarLoopInterface` to see if the loop really is a forall loop and if so get a pointer back to it (see uses of `isForallStmt`).

**Testing**:

I have run this through (non gasnet non gpu related) paratest and it seems to pass fine without breaking anything regardless of whether the feature is enabled or disabled.

