### PR TITLE
Unload cray-libsci on a system that has problems with it

### DIFF
--- a/util/cron/common-hpe-cray-ex.bash
+++ b/util/cron/common-hpe-cray-ex.bash
@@ -4,11 +4,11 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 
 module unload $(module --terse list 2>&1 | grep PrgEnv-)
 
-# PrgEnv-gnu/8.5.0 currently has a problem on pinoak
+# PrgEnv-gnu/8.5.0 currently has a problem on the Cray EX we run on
 module load PrgEnv-gnu/8.4.0
 module load cray-pmi
 
-# cray-libsci currently has a problem on pinoak
+# cray-libsci currently has a problem on the Cray EX we run on
 module unload cray-libsci
 
 export CHPL_HOST_PLATFORM=hpe-cray-ex

--- a/util/cron/common-hpe-cray-ex.bash
+++ b/util/cron/common-hpe-cray-ex.bash
@@ -8,6 +8,9 @@ module unload $(module --terse list 2>&1 | grep PrgEnv-)
 module load PrgEnv-gnu/8.4.0
 module load cray-pmi
 
+# cray-libsci currently has a problem on pinoak
+module unload cray-libsci
+
 export CHPL_HOST_PLATFORM=hpe-cray-ex
 
 # Work around cxi provider bugs that limit memory registration


### PR DESCRIPTION
The Cray EX we run some of our nightlies on has a problematic `cray-libsci` installation. We don't need it but it comes with the PrgEnv. This PR unloads `cray-libsci` explicitly to avoid issues with it.