### PR TITLE
add support for --log-fmt=nprint

### DIFF
--- a/compiler/include/log.h
+++ b/compiler/include/log.h
@@ -30,12 +30,17 @@ struct ArgumentDescription;
 #define LOG_NO_SHORT ' '
 #define LOG_NEVER    '\0'
 
+enum class LogFormat { DEFAULT, NPRINT };
+
 // runpasses uses this to configure the logger
 void logMakePassAvailable(const char* name, char shortname);
 
 // Driver uses this to configure the logger.
 // arg might be a pass name or a 1-character short name (e.g. 'R')
 void logSelectPass(const char* arg);
+
+// Also used by driver to configure the logger.
+void logSelectFormat(const char* arg);
 
 void  setupLogfiles();
 void  teardownLogfiles();
@@ -51,6 +56,7 @@ extern bool  fLogDir; // was --log-dir passed?
 
 extern bool  fLog;
 extern bool  fLogIds;
+extern LogFormat fLogFormat;
 
 extern int   fdump_html;
 extern char  fdump_html_chpl_home[FILENAME_MAX + 1];

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1113,6 +1113,10 @@ static void setLogPass(const ArgumentDescription* desc, const char* arg) {
   logSelectPass(arg);
 }
 
+static void setLogFormat(const ArgumentDescription* desc, const char* arg) {
+  logSelectFormat(arg);
+}
+
 static void setLogModule(const ArgumentDescription* desc, const char* arg) {
   log_modules.insert(std::string(arg));
 }
@@ -1350,6 +1354,7 @@ static ArgumentDescription arg_desc[] = {
  {"log-ids", ' ', NULL, "[Don't] include BaseAST::ids in log files", "N", &fLogIds, "CHPL_LOG_IDS", NULL},
  {"log-module", ' ', "<module-name>", "Restrict IR dump to the named module. Can be specified multiple times", "S", NULL, "CHPL_LOG_MODULE", setLogModule},
  {"log-pass", ' ', "<passname>", "Restrict IR dump to the named pass. Can be specified multiple times", "S", NULL, "CHPL_LOG_PASS", setLogPass},
+ {"log-fmt", ' ', "<format>", "May be set to 'default' or 'nprint' to specify format to use", "S", NULL, "CHPL_LOG_FORMAT", setLogFormat},
 // {"log-symbol", ' ', "<symbol-name>", "Restrict IR dump to the named symbol(s)", "S256", log_symbol, "CHPL_LOG_SYMBOL", NULL}, // This doesn't work yet.
  {"llvm-print-ir", ' ', "<name>", "Dump LLVM Intermediate Representation of given function to stdout", "S", NULL, "CHPL_LLVM_PRINT_IR", &setPrintIr},
  {"llvm-print-ir-stage", ' ', "<stage>", "Specifies from which LLVM optimization stage to print function: none, basic, full", "S", NULL, "CHPL_LLVM_PRINT_IR_STAGE", &verifyStageAndSetStageNum},

--- a/compiler/main/log.cpp
+++ b/compiler/main/log.cpp
@@ -39,6 +39,7 @@ std::set<std::string> log_modules;
 bool             fLog                                   =    false;
 bool             fLogDir                                =    false;
 bool             fLogIds                                =    true;
+LogFormat        fLogFormat                             =    LogFormat::DEFAULT;
 
 int              fdump_html                             =       0;
 char             fdump_html_chpl_home[FILENAME_MAX + 1] =      "";
@@ -100,6 +101,16 @@ void logSelectPass(const char* arg) {
   // Otherwise, we don't know what pass this is.
   fprintf(stderr, "Unrecognized log pass name: \"%s\"\n", arg);
   clean_exit(1);
+}
+
+void logSelectFormat(const char* arg) {
+  if(!strcmp(arg, "default")) {
+    fLogFormat = LogFormat::DEFAULT;
+  } else if(!strcmp(arg, "nprint")) {
+    fLogFormat = LogFormat::NPRINT;
+  } else {
+    USR_FATAL("Unrecognized log format: %s (may be set to 'default' or 'nprint')\n", arg);
+  }
 }
 
 void setupLogfiles() {

--- a/util/chpl-completion.bash
+++ b/util/chpl-completion.bash
@@ -150,6 +150,7 @@ _chpl ()
 --log \
 --log-deleted-ids-to \
 --log-dir \
+--log-fmt \
 --log-ids \
 --log-module \
 --log-pass \


### PR DESCRIPTION
Often times I want to use `--log` to get pretty prints of the AST after each pass but I want it in the same format used by `nprint_view` which I use when debugging.

This PR adds a new developer-oriented flag `--log-fmt <format>` where (for now) format can either be `default` or `nprint`. If left off, as one would expect, it defaults to `default` and we print logs the same as we always have.

In terms of implementation, to get this to work I ended up redirecting `stdout` to the log file we're generating.  This comment I added kind of explains it:

```C++
  // This is an absolute hack. nprint_view prints directly to stdout, we should
  // update it to take a file pointer use it and pass it along as needed. But rather
  // than update all the code I instead redirect stdout to the file (and then restore it
  // after the dump is done).  This makes debugging a pain and folks can really get caught
  // off-gaurd when stdout is no longer really stdout.
```

But I'm going to justify this as:
* This functionality is useful, and
* enabling it even in this hackish way is moving us in the right direction.