### PR TITLE
Avoid re-calculating `printchplenv` output in driver mode

### DIFF
--- a/compiler/include/files.h
+++ b/compiler/include/files.h
@@ -99,11 +99,12 @@ void addIncInfo(const char* incDir, bool fromCmdLine = false);
 // Ensure the tmp dir is set up for use by the driver (i.e., isn't about to be
 // replaced).
 void checkDriverTmp();
-// Save provided string into the given tmp file.
-// Appends the given string as a new line in the file. Provided string is
-// assumed to not contain newlines.
+// Save (append) provided string into the given tmp file.
 // For storing information that needs to be saved between driver phases.
-void saveDriverTmp(const char* tmpFilePath, const char* stringToSave);
+void saveDriverTmp(const char* tmpFilePath, const char* stringToSave,
+                   bool appendNewline = true);
+// Like saveDriverTmp, but accepts a vector of strings to save in one go without
+// repeatedly opening/closing file.
 void saveDriverTmpMultiple(const char* tmpFilePath,
                            std::vector<const char*> stringsToSave);
 // Feed strings from the specified tmp file (one per line) into the given
@@ -111,6 +112,11 @@ void saveDriverTmpMultiple(const char* tmpFilePath,
 // For accessing information saved between driver phases with saveDriverTmp.
 void restoreDriverTmp(const char* tmpFilePath,
                       std::function<void(const char*)> restoreSavedString);
+// Like restoreDriverTmp, but just saves the entire contents of the file into
+// the given string including newlines.
+void restoreDriverTmpMultiline(
+    const char* tmpFilePath,
+    std::function<void(const char*)> restoreSavedString);
 
 // Restore lib dir, lib name, and inc dir info that was saved to disk, for
 // compiler-driver use.

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -2313,8 +2313,6 @@ int main(int argc, char* argv[]) {
 
     process_args(&sArgState, argc, argv);
 
-    setupChplGlobals(argv[0]);
-
     // set up the module paths
     std::string chpl_module_path;
     if (const char* envvarpath  = getenv("CHPL_MODULE_PATH")) {
@@ -2322,6 +2320,8 @@ int main(int argc, char* argv[]) {
     }
 
     bootstrapTmpDir();
+
+    setupChplGlobals(argv[0]);
 
     addSourceFiles(sArgState.nfile_arguments, sArgState.file_argument);
 

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -196,7 +196,8 @@ void restoreDriverTmpMultiline(
 
   std::string restoredString;
   std::string errorOutString;
-  if (!chpl::readfile(tmpFilePath, restoredString, errorOutString)) {
+  if (!chpl::readfile(genIntermediateFilename(tmpFilePath), restoredString,
+                      errorOutString)) {
     INT_FATAL("Error restoring from tmp file: %s", errorOutString.c_str());
   }
 

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -47,6 +47,8 @@
 #include <unistd.h>
 
 #include <cstring>
+#include <sstream>
+#include <iostream>
 #include <cstdlib>
 #include <cerrno>
 #include <string>
@@ -192,16 +194,13 @@ void restoreDriverTmp(const char* tmpFilePath,
 void restoreDriverTmpMultiline(
     const char* tmpFilePath,
     std::function<void(const char*)> restoreSavedString) {
-  assert(!fDriverDoMonolithic && "meant for use in driver mode only");
+  std::ostringstream os;
 
-  std::string restoredString;
-  std::string errorOutString;
-  if (!chpl::readfile(genIntermediateFilename(tmpFilePath), restoredString,
-                      errorOutString)) {
-    INT_FATAL("Error restoring from tmp file: %s", errorOutString.c_str());
-  }
+  // Just call line-by-line restore for simplicity, adding newlines back in.
+  restoreDriverTmp(tmpFilePath,
+                   [&os](const char* line) { os << line << "\n"; });
 
-  // invoke restoring function
+  std::string restoredString = os.str();
   restoreSavedString(restoredString.c_str());
 }
 

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -142,11 +142,12 @@ void checkDriverTmp() {
       "attempted to save info to tmp dir before it is set up for driver use");
 }
 
-void saveDriverTmp(const char* tmpFilePath, const char* stringToSave) {
+void saveDriverTmp(const char* tmpFilePath, const char* stringToSave,
+                   bool appendNewline) {
   checkDriverTmp();
 
   fileinfo* file = openTmpFile(tmpFilePath, "a");
-  fprintf(file->fptr, "%s\n", stringToSave);
+  fprintf(file->fptr, "%s%s", stringToSave, (appendNewline ? "\n" : ""));
   closefile(file);
 }
 

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -189,6 +189,21 @@ void restoreDriverTmp(const char* tmpFilePath,
   closefile(tmpFile);
 }
 
+void restoreDriverTmpMultiline(
+    const char* tmpFilePath,
+    std::function<void(const char*)> restoreSavedString) {
+  assert(!fDriverDoMonolithic && "meant for use in driver mode only");
+
+  std::string restoredString;
+  std::string errorOutString;
+  if (!chpl::readfile(tmpFilePath, restoredString, errorOutString)) {
+    INT_FATAL("Error restoring from tmp file: %s", errorOutString.c_str());
+  }
+
+  // invoke restoring function
+  restoreSavedString(restoredString.c_str());
+}
+
 void restoreLibraryAndIncludeInfo() {
   INT_ASSERT(
       fDriverPhaseTwo &&

--- a/frontend/include/chpl/util/chplenv.h
+++ b/frontend/include/chpl/util/chplenv.h
@@ -40,6 +40,12 @@ using ChplEnvMap = std::unordered_map<std::string, std::string>;
   chplHome
     the CHPL_HOME environment variable, to locate printchplenv
 
+  printchplenvOutput
+    output from printchplenv invocation. Treated as an input parameter if
+    non-empty, to be re-used instead of calling printchplenv. Treated as an
+    output parameter if empty, and will be set from this call of printchplenv.
+    Ignored if null.
+
   returns
     an error code if something went wrong while running printchplenv,
     or a map containing key-value pairs for each variable in
@@ -47,10 +53,10 @@ using ChplEnvMap = std::unordered_map<std::string, std::string>;
  */
 llvm::ErrorOr<ChplEnvMap>
 getChplEnv(const std::map<std::string, const char*>& varMap,
-           const char* chplHome);
+           const char* chplHome, std::string* printchplenvOutput = nullptr);
 llvm::ErrorOr<ChplEnvMap>
 getChplEnv(const std::unordered_map<std::string, std::string>& varMap,
-           const char* chplHome);
+           const char* chplHome, std::string* printchplenvOutput = nullptr);
 
 /*
   Check if a given path might be CHPL_HOME based on it containing

--- a/frontend/lib/util/chplenv.cpp
+++ b/frontend/lib/util/chplenv.cpp
@@ -64,11 +64,11 @@ template <typename InputMap>
 llvm::ErrorOr<ChplEnvMap> getChplEnvImpl(
     const InputMap& varMap, const char* chplHome,
     std::string* printchplenvOutput) {
-  std::string* usablePrintchplenvOutput;
+  std::string usablePrintchplenvOutput;
 
   if (printchplenvOutput && !printchplenvOutput->empty()) {
     // Just re-use passed-in command output
-    usablePrintchplenvOutput = printchplenvOutput;
+    usablePrintchplenvOutput = *printchplenvOutput;
   } else {
     // Construct and run printchplenv command
     std::string command;
@@ -88,19 +88,19 @@ llvm::ErrorOr<ChplEnvMap> getChplEnvImpl(
       return commandOutput.getError();
     }
 
-    usablePrintchplenvOutput = &commandOutput.get();
+    usablePrintchplenvOutput = commandOutput.get();
 
     // Save copy of command output if out-parameter was supplied
     if (printchplenvOutput) {
       assert(printchplenvOutput->empty());
       // This is intentionally copied since parseChplEnv destroys the input
-      *printchplenvOutput = *usablePrintchplenvOutput;
+      *printchplenvOutput = usablePrintchplenvOutput;
     }
   }
 
   // parse command output into map
   ChplEnvMap result;
-  parseChplEnv(*usablePrintchplenvOutput, result);
+  parseChplEnv(usablePrintchplenvOutput, result);
   return result;
 }
 


### PR DESCRIPTION
Save the output of calling `printchplenv` in the driver initial invocation and restore it in sub-invocations, to avoid redundant work.

On my machine this reduces the compilation time in driver mode by about 0.5s, bringing it almost on par with monolithic.

This is one component of https://github.com/Cray/chapel-private/issues/5373.

[reviewer info placeholder]

Testing:
- [x] paratest
- [x] paratest with `--compiler-driver`
- [x] C backend paratest with `--compiler-driver`