### PR TITLE
Add user-facing error when multiple files define the same module

### DIFF
--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -3423,9 +3423,6 @@ struct Converter {
     CHPL_ASSERT(foundPath);
     const char* path = astr(pathUstr);
 
-    // TODO (dlongnecke): For now, the tag is overridden by the caller.
-    // See 'uASTAttemptToParseMod'. Eventually, it would be great if dyno
-    // could note if a module is standard/internal/user.
     const ModTag tag = this->topLevelModTag;
     bool priv = (node->visibility() == uast::Decl::PRIVATE);
     bool prototype = (node->kind() == uast::Module::PROTOTYPE ||

--- a/frontend/lib/framework/Context.cpp
+++ b/frontend/lib/framework/Context.cpp
@@ -644,31 +644,31 @@ void Context::setFilePathForModuleId(ID moduleID, UniqueString path) {
     UniqueString gotPath;
     bool ok = filePathForId(moduleID, gotPath);
     CHPL_ASSERT(ok);
+  #endif
 
-    // ... and gives the same path
+  // ... and gives the same path
 
-    // Note: if this check causes problems in the future, it could
-    // be removed, or we could wire up setFileText used in tests
-    // to work with the LLVM VirtualFilesystem
+  // Note: if this check causes problems in the future, it could
+  // be removed, or we could wire up setFileText used in tests
+  // to work with the LLVM VirtualFilesystem
 #if LLVM_VERSION_MAJOR <= 11
     llvm::SmallVector<char, 64> realPath, realGotPath;
 #else
     llvm::SmallVector<char> realPath, realGotPath;
 #endif
-    std::error_code errPath;
-    std::error_code errGotPath;
-    errPath = llvm::sys::fs::real_path(path.str(), realPath);
-    errGotPath = llvm::sys::fs::real_path(gotPath.str(), realGotPath);
-    if (errPath || errGotPath) {
-      // ignore the check if there were errors
-    } else {
-      if (realPath != realGotPath) {
-        error(moduleID,
-              "Redefinition of module '%s' (the original was defined in '%s')",
-              moduleIdSymbolPath.c_str(), path.c_str());
-      }
+  std::error_code errPath;
+  std::error_code errGotPath;
+  errPath = llvm::sys::fs::real_path(path.str(), realPath);
+  errGotPath = llvm::sys::fs::real_path(gotPath.str(), realGotPath);
+  if (errPath || errGotPath) {
+    // ignore the check if there were errors
+  } else {
+    if (realPath != realGotPath) {
+      error(moduleID,
+            "Redefinition of module '%s' (the original was defined in '%s')",
+            moduleIdSymbolPath.c_str(), path.c_str());
     }
-  #endif
+  }
 }
 
 static

--- a/frontend/lib/framework/Context.cpp
+++ b/frontend/lib/framework/Context.cpp
@@ -660,7 +660,7 @@ void Context::setFilePathForModuleId(ID moduleID, UniqueString path) {
   std::error_code errGotPath;
   errPath = llvm::sys::fs::real_path(path.str(), realPath);
   errGotPath = llvm::sys::fs::real_path(gotPath.str(), realGotPath);
-  if (errPath || errGotPath) {
+  if (!ok || errPath || errGotPath) {
     // ignore the check if there were errors
   } else {
     if (realPath != realGotPath) {

--- a/frontend/lib/framework/Context.cpp
+++ b/frontend/lib/framework/Context.cpp
@@ -639,8 +639,8 @@ void Context::setFilePathForModuleId(ID moduleID, UniqueString path) {
     printf("%i SETTING FILE PATH FOR MODULE %s -> %s\n", queryTraceDepth,
            moduleIdSymbolPath.c_str(), path.c_str());
   }
-  UniqueString gotPath;
   // check that querying the module ID works...
+  UniqueString gotPath;
   bool ok = filePathForId(moduleID, gotPath);
   #ifndef NDEBUG
     CHPL_ASSERT(ok);
@@ -662,15 +662,15 @@ void Context::setFilePathForModuleId(ID moduleID, UniqueString path) {
   errGotPath = llvm::sys::fs::real_path(gotPath.str(), realGotPath);
   if (!ok || errPath || errGotPath) {
     // ignore the check if there were errors
-  } else {
+  } else
     // Check for duplicate modules names, but skip over bundled modules
     // since we don't necessarily want to preclude the user from using
     // the same names that we happen to have chosen.
-    if (realPath != realGotPath && !parsing::idIsInBundledModule(this, moduleID)) {
+    if (realPath != realGotPath &&
+        !parsing::idIsInBundledModule(this, moduleID)) {
       error(moduleID,
             "Redefinition of module '%s' (the original was defined in '%s')",
             moduleIdSymbolPath.c_str(), path.c_str());
-    }
   }
 }
 

--- a/frontend/lib/framework/Context.cpp
+++ b/frontend/lib/framework/Context.cpp
@@ -663,7 +663,10 @@ void Context::setFilePathForModuleId(ID moduleID, UniqueString path) {
   if (!ok || errPath || errGotPath) {
     // ignore the check if there were errors
   } else {
-    if (realPath != realGotPath) {
+    // Check for duplicate modules names, but skip over bundled modules
+    // since we don't necessarily want to preclude the user from using
+    // the same names that we happen to have chosen.
+    if (realPath != realGotPath && !parsing::idIsInBundledModule(this, moduleID)) {
       error(moduleID,
             "Redefinition of module '%s' (the original was defined in '%s')",
             moduleIdSymbolPath.c_str(), path.c_str());

--- a/frontend/lib/framework/Context.cpp
+++ b/frontend/lib/framework/Context.cpp
@@ -662,7 +662,11 @@ void Context::setFilePathForModuleId(ID moduleID, UniqueString path) {
     if (errPath || errGotPath) {
       // ignore the check if there were errors
     } else {
-      CHPL_ASSERT(realPath == realGotPath);
+      if (realPath != realGotPath) {
+        error(moduleID,
+              "Redefinition of module '%s' (the original was defined in '%s')",
+              moduleIdSymbolPath.c_str(), path.c_str());
+      }
     }
   #endif
 }

--- a/frontend/lib/framework/Context.cpp
+++ b/frontend/lib/framework/Context.cpp
@@ -639,10 +639,10 @@ void Context::setFilePathForModuleId(ID moduleID, UniqueString path) {
     printf("%i SETTING FILE PATH FOR MODULE %s -> %s\n", queryTraceDepth,
            moduleIdSymbolPath.c_str(), path.c_str());
   }
+  UniqueString gotPath;
+  // check that querying the module ID works...
+  bool ok = filePathForId(moduleID, gotPath);
   #ifndef NDEBUG
-    // check that querying the module ID works...
-    UniqueString gotPath;
-    bool ok = filePathForId(moduleID, gotPath);
     CHPL_ASSERT(ok);
   #endif
 

--- a/test/modules/errors/duplicateModules.chpl
+++ b/test/modules/errors/duplicateModules.chpl
@@ -1,0 +1,3 @@
+module M {
+  writeln("In M.init()");
+}

--- a/test/modules/errors/duplicateModules.compopts
+++ b/test/modules/errors/duplicateModules.compopts
@@ -1,0 +1,1 @@
+duplicateModules2.chpl

--- a/test/modules/errors/duplicateModules.good
+++ b/test/modules/errors/duplicateModules.good
@@ -1,0 +1,1 @@
+duplicateModules2.chpl:1: error: Redefinition of module 'M' (the original was defined in 'duplicateModules.chpl')

--- a/test/modules/errors/duplicateModules2.chpl
+++ b/test/modules/errors/duplicateModules2.chpl
@@ -1,0 +1,3 @@
+module M {
+  writeln("In another M.init()");
+}

--- a/test/modules/errors/duplicateModules2.compopts
+++ b/test/modules/errors/duplicateModules2.compopts
@@ -1,0 +1,1 @@
+duplicateModules.chpl

--- a/test/modules/errors/duplicateModules2.good
+++ b/test/modules/errors/duplicateModules2.good
@@ -1,0 +1,1 @@
+duplicateModules.chpl:1: error: Redefinition of module 'M' (the original was defined in 'duplicateModules2.chpl')


### PR DESCRIPTION
This adds an error message when two files define the same module name, replacing an assertion / internal error as reported in #23775 (though that only occurred for a compiler built with NDEBUG left unset).  It also adds new tests of this error.

The approach I took here was to essentially move the assertion that used to take place into code that's always executed and to replace it with a user-facing error message when it fails.  That said, I also squashed the error for bundled modules (as defined by the Dyno front-end) because failing to do so caused tests in which the user re-used module names to fail, like `test/modules/bradc/overrideStd/foo.chpl` and `test/modules/bradc/userInsteadOfStandard/foo2.chpl`.

While here, I also "fixed" the indentation of the code (making the diff look worse than ideal unless ignoring whitespace) and removed a comment that DavidL said was outdated and that I should remove after I got confused by it.

Interestingly, if we just skip past this assertion check in Context.cpp the normal code that complains about re-duplication of a symbol _almost_ catches this case and warns about it properly, suggesting maybe we should just remove this early check.  However, strangely, it complains about the same module name and location twice rather than pointing to two.  Worse, the implication I seemed to be getting from the generated `--log=` files suggested that one of the modules had completely overwritten and subsumed the other, possibly when Dyno was lowering to the production compiler (?).  So that suggested to me that catching it early was probably the right thing to do, at least for now, particularly if we want to generate a clear error message that points to both locations.