### PR TITLE
Load a newer GCC in EX testing to avoid LLVM build issues

### DIFF
--- a/util/cron/common-hpe-cray-ex.bash
+++ b/util/cron/common-hpe-cray-ex.bash
@@ -6,6 +6,9 @@ module unload $(module --terse list 2>&1 | grep PrgEnv-)
 
 # PrgEnv-gnu/8.5.0 currently has a problem on the Cray EX we run on
 module load PrgEnv-gnu/8.4.0
+
+# Load a newer gcc to avoid LLVM build errors
+module swap gcc gcc/12.2.0
 module load cray-pmi
 
 # cray-libsci currently has a problem on the Cray EX we run on


### PR DESCRIPTION
We are seeing some failures while building the bundled LLVM with GCC 10 and 11 on our nightly EX testing system. This PR adjusts those configs to use GCC 12.