### PR TITLE
Start using --dyno to trigger type resolution

### DIFF
--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -301,7 +301,7 @@ extern std::vector<std::string> llvmRemarksFunctionsToShow;
 
 extern bool fPrintAdditionalErrors;
 
-extern bool fDynoResolve;
+extern bool fDynoCompilerLibrary;
 extern bool fDynoScopeResolve;
 extern bool fDynoScopeProduction;
 extern bool fDynoScopeBundled;

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -278,7 +278,11 @@ struct Converter {
     return false;
   }
   bool shouldResolve(ID symbolId) {
-    return shouldResolve(symbolId.symbolPath());
+    if (fDynoCompilerLibrary) {
+      return !chpl::parsing::idIsInBundledModule(context, symbolId);
+    } else {
+      return shouldResolve(symbolId.symbolPath());
+    }
   }
   bool shouldResolve(const uast::AstNode* node) {
     return shouldResolve(node->id());
@@ -2959,7 +2963,6 @@ struct Converter {
 
     const resolution::ResolutionResultByPostorderID* resolved = nullptr;
     const resolution::ResolvedFunction* resolvedFn = nullptr;
-    const resolution::TypedFnSignature* initialSig = nullptr;
     const resolution::PoiScope* poiScope = nullptr;
 
     if (shouldResolveFunction || shouldScopeResolveFunction) {
@@ -3168,8 +3171,8 @@ struct Converter {
     }
 
     // Update the function symbol with any resolution results.
-    if (shouldResolveFunction) {
-      auto retType = resolution::returnType(context, initialSig, poiScope);
+    if (shouldResolveFunction && resolvedFn != nullptr) {
+      auto retType = resolution::returnType(context, resolvedFn->signature(), poiScope);
       fn->retType = convertType(retType);
     }
 

--- a/test/errors/parsing/COMPOPTS
+++ b/test/errors/parsing/COMPOPTS
@@ -1,2 +1,2 @@
---dyno --no-detailed-errors
---dyno --detailed-errors
+--no-detailed-errors
+--detailed-errors

--- a/test/errors/scope-resolution/COMPOPTS
+++ b/test/errors/scope-resolution/COMPOPTS
@@ -1,2 +1,2 @@
---dyno --no-detailed-errors
---dyno --detailed-errors
+--no-detailed-errors
+--detailed-errors

--- a/test/errors/scope-resolution/redefinition/COMPOPTS
+++ b/test/errors/scope-resolution/redefinition/COMPOPTS
@@ -1,2 +1,2 @@
---dyno --no-detailed-errors
---dyno --detailed-errors
+--no-detailed-errors
+--detailed-errors


### PR DESCRIPTION
This PR updates ``--dyno`` to trigger type resolution in the frontend during ``convert-uast``. This change is primarily for the benefit of developers working on the frontend so that we can start fully resolving programs with both the frontend and production compiler.

Testing:
- [x] local paratest