### PR TITLE
Dyno: Introduce and use CHPL_UNIMPL instead of halting assertions

### DIFF
--- a/frontend/include/chpl/util/assertions.h
+++ b/frontend/include/chpl/util/assertions.h
@@ -31,6 +31,11 @@ namespace chpl {
 void assertion(bool expr, const char* filename, const char* func, int lineno,
                const char* exprText);
 
+/// \cond DO_NOT_DOCUMENT
+void chpl_unimpl(const char* filename, const char* func, int lineno,
+                 const char* msg);
+/// \endcond DO_NOT_DOCUMENT
+
 /*
   Macro for our custom assertion mechanism - folded out if NDEBUG is defined
 */
@@ -41,13 +46,24 @@ void assertion(bool expr, const char* filename, const char* func, int lineno,
     bool ignore = expr__; \
     (void) ignore; \
    } while (0)
+
 #else
 // debug mode
 #define CHPL_ASSERT(expr__) \
   do { \
     chpl::assertion(expr__, __FILE__, __FUNCTION__, __LINE__, #expr__); \
   } while (0)
+
 #endif
+
+/// \cond DO_NOT_DOCUMENT
+
+#define CHPL_UNIMPL(msg__) \
+  do { \
+    chpl::chpl_unimpl(__FILE__, __FUNCTION__, __LINE__, msg__); \
+  } while (0)
+
+/// \endcond DO_NOT_DOCUMENT
 
 /*
   Set whether or not assertions in dyno are enabled

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -626,7 +626,7 @@ void CallInitDeinit::resolveMoveInit(const AstNode* ast,
       }
     }
   } else {
-    CHPL_ASSERT(false && "TODO"); // e.g. value = copy init from ref
+    CHPL_UNIMPL("value = copy init from ref");
   }
 }
 

--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -734,11 +734,15 @@ bool CanPassResult::canInstantiateBuiltin(Context* context,
   if (formalT->isAnyIntegralType() && actualT->isIntegralType())
     return true;
 
-  if (formalT->isAnyIteratorClassType())
-    CHPL_ASSERT(false && "Not implemented yet"); // TODO: represent iterators
+  if (formalT->isAnyIteratorClassType()) {
+    CHPL_UNIMPL("iterator classes"); // TODO: represent iterators
+    return false;
+  }
 
-  if (formalT->isAnyIteratorRecordType())
-    CHPL_ASSERT(false && "Not implemented yet"); // TODO: represent iterators
+  if (formalT->isAnyIteratorRecordType()) {
+    CHPL_UNIMPL("iterator records"); // TODO: represent iterators
+    return false;
+  }
 
   if (formalT->isAnyNumericType() && actualT->isNumericType())
     return true;

--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -754,8 +754,10 @@ bool CanPassResult::canInstantiateBuiltin(Context* context,
           if (manager->isAnyOwnedType())
             return true;
 
-  if (formalT->isAnyPodType())
-    CHPL_ASSERT(false && "Not implemented yet"); // TODO: compute POD-ness
+  if (formalT->isAnyPodType()) {
+    CHPL_UNIMPL("POD types"); // TODO: compute POD-ness
+    return false;
+  }
 
   if (formalT->isAnyRealType() && actualT->isRealType())
     return true;

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -210,7 +210,7 @@ generateInitSignature(Context* context, const CompositeType* inCompType) {
   if (auto basic = compType->toBasicClassType()) {
     if (auto parent = basic->parentClassType()) {
       if (!parent->isObjectType()) {
-        CHPL_ASSERT(false && "Not handled yet!");
+        CHPL_UNIMPL("initializers on inheriting classes");
       }
     }
   }

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -510,7 +510,7 @@ getCompilerGeneratedMethodQuery(Context* context, const Type* type,
     } else if (auto arrayType = type->toArrayType()) {
       result = generateArrayMethod(context, arrayType, name);
     } else {
-      CHPL_ASSERT(false && "Not implemented yet!");
+      CHPL_ASSERT(false && "should not be reachable");
     }
   }
 

--- a/frontend/lib/resolution/disambiguation.cpp
+++ b/frontend/lib/resolution/disambiguation.cpp
@@ -1293,7 +1293,7 @@ static bool prefersConvToOtherNumeric(const DisambiguationContext& dctx,
 static QualifiedType computeActualScalarType(Context* context,
                                              QualifiedType actualType) {
   // TODO: fill this in
-  CHPL_ASSERT(false && "not implemented yet");
+  CHPL_UNIMPL("scalar type matching");
   return actualType;
 }
 

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -558,13 +558,13 @@ CallResolutionResult resolvePrimCall(Context* context,
     case PRIM_IS_COERCIBLE:
     case PRIM_TYPE_TO_STRING:
     case PRIM_HAS_LEADER:
-      CHPL_ASSERT(false && "not implemented yet");
+      CHPL_UNIMPL("misc primitives");
       break;
     case PRIM_IS_TUPLE_TYPE:
       type = primIsTuple(context, ci);
       break;
     case PRIM_SIMPLE_TYPE_NAME:
-      CHPL_ASSERT(false && "not implemented yet");
+      CHPL_UNIMPL("misc primitives");
       break;
 
     case PRIM_NUM_FIELDS:
@@ -673,7 +673,7 @@ CallResolutionResult resolvePrimCall(Context* context,
       type = primObjectToInt(context, ci);
 
     case PRIM_COERCE:
-      assert(false && "not implemented yet");
+      CHPL_UNIMPL("coerce primitive");
       break;
 
     case PRIM_TO_UNMANAGED_CLASS_CHECKED:
@@ -706,7 +706,7 @@ CallResolutionResult resolvePrimCall(Context* context,
     case PRIM_UINT64_AS_REAL64:
     case PRIM_REAL32_AS_UINT32:
     case PRIM_REAL64_AS_UINT64:
-      assert(false && "not implemented yet");
+      CHPL_UNIMPL("uint <-> real primitives");
       break;
 
     /* string operations */
@@ -982,7 +982,7 @@ CallResolutionResult resolvePrimCall(Context* context,
     case PRIM_UNKNOWN:
     case NUM_KNOWN_PRIMS:
     case PRIM_BREAKPOINT:
-      CHPL_ASSERT(false && "not implemented yet");
+      CHPL_UNIMPL("misc primitives");
 
     // no default to get a warning when new primitives are added
   }

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -605,7 +605,7 @@ CallResolutionResult resolvePrimCall(Context* context,
     case PRIM_IS_CONST_ASSIGNABLE:
     case PRIM_HAS_DEFAULT_VALUE:
     case PRIM_NEEDS_AUTO_DESTROY:
-      CHPL_ASSERT(false && "not implemented yet");
+      CHPL_UNIMPL("various primitives");
       break;
 
     case PRIM_CALL_RESOLVES:
@@ -624,7 +624,7 @@ CallResolutionResult resolvePrimCall(Context* context,
 
     case PRIM_RESOLVES:
     case PRIM_IMPLEMENTS_INTERFACE:
-      CHPL_ASSERT(false && "not implemented yet");
+      CHPL_UNIMPL("various primitives");
       break;
 
     case PRIM_IS_STAR_TUPLE_TYPE:
@@ -649,7 +649,7 @@ CallResolutionResult resolvePrimCall(Context* context,
     case PRIM_TO_LEADER:
     case PRIM_TO_FOLLOWER:
     case PRIM_TO_STANDALONE:
-      assert(false && "not implemented yet");
+      CHPL_UNIMPL("iterator casting  primitives");
       break;
 
     case PRIM_CAST_TO_VOID_STAR:

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -1286,7 +1286,7 @@ QualifiedType getInstantiationType(Context* context,
       }
       auto g = getTypeGenericity(context, bct);
       if (g != Type::CONCRETE) {
-        CHPL_ASSERT(false && "not implemented yet");
+        CHPL_UNIMPL("instantiate generic class formal");
       }
 
       // now construct the ClassType

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -249,6 +249,9 @@ const QualifiedType& typeForModuleLevelSymbol(Context* context, ID id) {
         } else {
           kind = QualifiedType::FUNCTION;
         }
+      } else if (asttags::isInterface(tag)) {
+        //TODO: kind = QualifiedType::INTERFACE;
+        CHPL_UNIMPL("interfaces");
       } else {
         CHPL_ASSERT(false && "case not handled");
       }

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -318,7 +318,7 @@ CallInfo CallInfo::create(Context* context,
     } else if (auto calledDot = called->toDot()) {
       name = calledDot->field();
     } else {
-      CHPL_ASSERT(false && "Unexpected called expression");
+      CHPL_UNIMPL("CallInfo without a name");
     }
   }
 

--- a/frontend/lib/util/assertions.cpp
+++ b/frontend/lib/util/assertions.cpp
@@ -63,5 +63,13 @@ void assertion(bool expr, const char* filename, const char* func,
   // assertions active and passed
 }
 
+void chpl_unimpl(const char* filename, const char* func, int lineno,
+                 const char* msg) {
+  std::string fname(filename);
+  auto front = fname.substr(fname.find("frontend"), std::string::npos);
+  printf("[%s:%d in %s] Unimplemented: %s\n", front.c_str(), lineno,
+         func, msg);
+};
+
 
 } // end namespace chpl


### PR DESCRIPTION
This PR introduces an alternative to the frontend's usage of ``CHPL_ASSERT`` to indicate unimplemented parts of resolution. These assertions can hinder the progress of resolution by stopping earlier than is strictly required. The frontend is intended to be resilient against resolution failures, so generally speaking resolving something as an "unknown type" should be fine.

Instead of using ``CHPL_ASSERT``, we can now use ``CHPL_UNIMPL``. ``CHPL_UNIMPL`` prints a message provided by the caller. Developers wishing to break on these calls can do so using the ``chpl_unimpl`` helper function. Eventually I expect this macro to go away once the frontend becomes sufficiently capable of performing full type resolution.