### PR TITLE
Fix failing test from line changes in Map

### DIFF
--- a/test/studies/shootout/submitted/knucleotide4.good
+++ b/test/studies/shootout/submitted/knucleotide4.good
@@ -6,9 +6,9 @@ knucleotide4.chpl:24: warning: fileReader.readline is deprecated. Use fileReader
 knucleotide4.chpl:24: warning: fileReader.readline is deprecated. Use fileReader.readLine instead
 knucleotide4.chpl:32: warning: fileReader.readline is deprecated. Use fileReader.readLine instead
 knucleotide4.chpl:32: warning: fileReader.readline is deprecated. Use fileReader.readLine instead
-$CHPL_HOME/modules/standard/Map.chpl:409: In method 'this':
-$CHPL_HOME/modules/standard/Map.chpl:413: warning: 'hashVal' has a hash function that is being used by the standard library. However, 'hashVal' does not implement hashable. In the future, this will result in an error.
-$CHPL_HOME/modules/standard/Map.chpl:413: warning: to make 'hashVal' implement hashable, add the interface to its declaration: 'record hashVal : hashable'
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: In method 'this':
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: warning: 'hashVal' has a hash function that is being used by the standard library. However, 'hashVal' does not implement hashable. In the future, this will result in an error.
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: warning: to make 'hashVal' implement hashable, add the interface to its declaration: 'record hashVal : hashable'
   knucleotide4.chpl:84: called as (map(hashVal,int(64),false)).this(k: hashVal) from function 'calculate'
   knucleotide4.chpl:53: called as calculate(data: [domain(1,int(64),one)] uint(8), param nclSize = 1) from function 'writeFreqs'
   knucleotide4.chpl:42: called as writeFreqs(data: [domain(1,int(64),one)] uint(8), param nclSize = 1) from function 'main'

--- a/test/studies/shootout/submitted/knucleotide4.prediff
+++ b/test/studies/shootout/submitted/knucleotide4.prediff
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Ignore line numbers in modules.
+
+sed '\|CHPL_HOME/modules|s/:[0-9]*:/:nnnn:/' $2 > $2.tmp
+mv $2.tmp $2


### PR DESCRIPTION
Fixes `test/studies/shootout/submitted/knucleotide4.chpl`, which was failing after https://github.com/chapel-lang/chapel/pull/23672 changed the line numbers. This PR uses a prediff to resolve that error and future proof the test

Tested locally

[Reviewed by @benharsh]