### PR TITLE
Dyno: Miscellaneous fixes to simple resolution errors

### DIFF
--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -431,6 +431,9 @@ class CallInfo {
                                      types::QualifiedType receiverType,
                                      UniqueString rename=UniqueString());
 
+  /** Copy and rename a CallInfo. */
+  static CallInfo copyAndRename(const CallInfo& ci, UniqueString rename);
+
   /** Prepare actuals for a call for later use in creating a CallInfo.
       This is a helper function for CallInfo::create that is sometimes
       useful to call separately.

--- a/frontend/include/chpl/types/Type.h
+++ b/frontend/include/chpl/types/Type.h
@@ -180,6 +180,9 @@ class Type {
   /** returns true if this represents the bytes type */
   bool isBytesType() const;
 
+  /** returns true if this represents the locale type */
+  bool isLocaleType() const;
+
   /** returns true if it's string, bytes, or c_string type */
   bool isStringLikeType() const {
     return isStringType() || isBytesType() || isCStringType();

--- a/frontend/lib/resolution/InitResolver.cpp
+++ b/frontend/lib/resolution/InitResolver.cpp
@@ -55,7 +55,7 @@ static const Type* receiverTypeFromTfs(const TypedFnSignature* tfs) {
 
 static const CompositeType* typeToCompType(const Type* type) {
   if (auto cls = type->toClassType()) {
-    return cls->toManageableType();
+    return cls->manageableType()->toCompositeType();
   } else {
     auto ret = type->toCompositeType();
     return ret;

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -945,7 +945,7 @@ const Type* Resolver::tryResolveCrossTypeInitEq(const AstNode* ast,
     actuals.push_back(CallInfoActual(lhsType, USTR("this")));
     actuals.push_back(CallInfoActual(rhsType, UniqueString()));
     auto ci = CallInfo (/* name */ USTR("init="),
-                        /* calledType */ QualifiedType(),
+                        /* calledType */ lhsType,
                         /* isMethodCall */ true,
                         /* hasQuestionArg */ false,
                         /* isParenless */ false,

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -543,7 +543,7 @@ void CallInitDeinit::resolveCopyInit(const AstNode* ast,
   actuals.push_back(CallInfoActual(lhsType, USTR("this")));
   actuals.push_back(CallInfoActual(rhsType, UniqueString()));
   auto ci = CallInfo (/* name */ USTR("init="),
-                      /* calledType */ QualifiedType(),
+                      /* calledType */ lhsType,
                       /* isMethodCall */ true,
                       /* hasQuestionArg */ false,
                       /* isParenless */ false,

--- a/frontend/lib/resolution/copy-elision.cpp
+++ b/frontend/lib/resolution/copy-elision.cpp
@@ -125,7 +125,7 @@ bool FindElidedCopies::hasCrossTypeInitAssignWithIn(
   actuals.push_back(CallInfoActual(lhsType, USTR("this")));
   actuals.push_back(CallInfoActual(rhsType, UniqueString()));
   auto ci = CallInfo (/* name */ USTR("init="),
-                      /* calledType */ QualifiedType(),
+                      /* calledType */ lhsType,
                       /* isMethodCall */ true,
                       /* hasQuestionArg */ false,
                       /* isParenless */ false,

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -862,6 +862,17 @@ CallResolutionResult resolvePrimCall(Context* context,
       type = computeDomainType(context, ci);
       break;
 
+    case PRIM_GET_COMPILER_VAR: {
+        auto chplenv = context->getChplEnv();
+        auto varName = ci.actual(0).type().param()->toStringParam()->value().str();
+        auto it = chplenv->find(varName);
+        auto ret = (it != chplenv->end()) ? it->second : "";
+
+        auto st = CompositeType::getStringType(context);
+        auto sp = StringParam::get(context, UniqueString::get(context, ret));
+        type = QualifiedType(QualifiedType::PARAM, st, sp);
+      }
+      break;
 
     /* primitives that are not yet handled in dyno */
     case PRIM_ACTUALS_LIST:
@@ -966,7 +977,6 @@ CallResolutionResult resolvePrimCall(Context* context,
     case PRIM_AUTO_DESTROY_RUNTIME_TYPE:
     case PRIM_GET_RUNTIME_TYPE_FIELD:
     case PRIM_LOOKUP_FILENAME:
-    case PRIM_GET_COMPILER_VAR:
     case PRIM_GET_VISIBLE_SYMBOLS:
     case PRIM_STACK_ALLOCATE_CLASS:
     case PRIM_ZIP:

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -3690,7 +3690,12 @@ static bool shouldAttemptImplicitReceiver(const CallInfo& ci,
          implicitReceiver.type() != nullptr &&
          // Assuming ci.name().isEmpty()==true implies a primitive call.
          // TODO: Add some kind of 'isPrimitive()' to CallInfo
-         !ci.name().isEmpty();
+         !ci.name().isEmpty() &&
+         ci.name() != "?" &&
+         ci.name() != "owned" &&
+         ci.name() != "shared" &&
+         ci.name() != "borrowed" &&
+         ci.name() != "unmanaged";
 }
 
 CallResolutionResult resolveCall(Context* context,

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2844,12 +2844,12 @@ static bool resolveFnCallSpecial(Context* context,
   return false;
 }
 
-static bool isKeywordTypeCtor(Context* context,
-                              const Call* call,
-                              const CallInfo& ci,
-                              const Scope* inScope,
-                              const PoiScope* inPoiScope,
-                              CallResolutionResult& result) {
+static bool resolveFnCallSpecialType(Context* context,
+                                     const Call* call,
+                                     const CallInfo& ci,
+                                     const Scope* inScope,
+                                     const PoiScope* inPoiScope,
+                                     CallResolutionResult& result) {
   if (ci.isMethodCall()) {
     return false;
   }
@@ -3694,11 +3694,11 @@ static bool shouldAttemptImplicitReceiver(const CallInfo& ci,
          // Assuming ci.name().isEmpty()==true implies a primitive call.
          // TODO: Add some kind of 'isPrimitive()' to CallInfo
          !ci.name().isEmpty() &&
-         ci.name() != "?" &&
-         ci.name() != "owned" &&
-         ci.name() != "shared" &&
-         ci.name() != "borrowed" &&
-         ci.name() != "unmanaged";
+         ci.name() != USTR("?") &&
+         ci.name() != USTR("owned") &&
+         ci.name() != USTR("shared") &&
+         ci.name() != USTR("borrowed") &&
+         ci.name() != USTR("unmanaged");
 }
 
 CallResolutionResult resolveCall(Context* context,
@@ -3718,7 +3718,8 @@ CallResolutionResult resolveCall(Context* context,
     }
 
     CallResolutionResult keywordRes;
-    if (isKeywordTypeCtor(context, call, ci, inScope, inPoiScope, keywordRes)) {
+    if (resolveFnCallSpecialType(context, call, ci,
+                                 inScope, inPoiScope, keywordRes)) {
       return keywordRes;
     }
 

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2889,6 +2889,54 @@ static bool isKeywordTypeCtor(Context* context,
   return false;
 }
 
+static void buildReaderWriterTypeCtor(Context* context,
+                                      const CallInfo& ci,
+                                      const TypedFnSignature* initial,
+                                      CandidatesVec& initialCandidates) {
+  std::vector<UntypedFnSignature::FormalDetail> formals;
+  // Move 'kind' to the end and allow the first two args to just be
+  // 'locking' and  '(de)serializerType'
+  //
+  // TODO: The '_serializerWrapper' arg should _not_ be considered
+  // part of the type constructor...
+  std::vector<int> order = {1, 2, 3, 0};
+  for (auto i : order) {
+    auto un = initial->untyped();
+    auto d = UntypedFnSignature::FormalDetail(un->formalName(i),
+                                              un->formalHasDefault(i),
+                                              un->formalDecl(i),
+                                              un->formalIsVarArgs(i));
+    formals.push_back(d);
+  }
+
+  std::vector<types::QualifiedType> formalTypes;
+  for (auto i : order) {
+    formalTypes.push_back(initial->formalType(i));
+  }
+
+  auto untyped = UntypedFnSignature::get(context,
+                                         initial->id(), ci.name(),
+                                         /* isMethod */ false,
+                                         /* isTypeConstructor */ true,
+                                         /* isCompilerGenerated */ true,
+                                         /* throws */ false,
+                                         uast::asttags::Record,
+                                         Function::PROC,
+                                         std::move(formals),
+                                         /* whereClause */ nullptr);
+
+  auto result = TypedFnSignature::get(context,
+                                      untyped,
+                                      std::move(formalTypes),
+                                      TypedFnSignature::WHERE_NONE,
+                                      /* needsInstantiation */ true,
+                                      /* instantiatedFrom */ nullptr,
+                                      /* parentFn */ nullptr,
+                                      /* formalsInstantiated */ Bitmap());
+
+  initialCandidates.push_back(result);
+}
+
 static MostSpecificCandidates
 resolveFnCallForTypeCtor(Context* context,
                          const CallInfo& ci,
@@ -2904,6 +2952,20 @@ resolveFnCallForTypeCtor(Context* context,
 
   auto initial = typeConstructorInitial(context, ci.calledType().type());
   initialCandidates.push_back(initial);
+
+  //
+  // Adds an alternative type constructor for fileReader/Writer to support
+  // the deprecated 'kind' field, as in PR #23007.
+  //
+  // TODO: Remove this code when the 'kind' field is finally removed.
+  //
+  if (auto rt = ci.calledType().type()->toRecordType()) {
+    if (parsing::idIsInBundledModule(context, rt->id())) {
+      if (ci.name() == "fileWriter" || ci.name() == "fileReader") {
+        buildReaderWriterTypeCtor(context, ci, initial, initialCandidates);
+      }
+    }
+  }
 
   // TODO: do something for partial instantiation
 

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2516,7 +2516,9 @@ static const Type* getManagedClassType(Context* context,
     t = ci.actual(0).type().type();
 
   if (t == nullptr || !(t->isManageableType() || t->isClassType())) {
-    context->error(astForErr, "invalid class type construction");
+    if (t != nullptr && !t->isUnknownType()) {
+      context->error(astForErr, "invalid class type construction");
+    }
     return ErroneousType::get(context);
   }
 

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -1405,7 +1405,7 @@ static QualifiedType getProperFormalType(const ResolutionResultByPostorderID& r,
 }
 
 static bool isCallInfoForInitializer(const CallInfo& ci) {
-  if (ci.name() == USTR("init"))
+  if (ci.name() == USTR("init") || ci.name() == USTR("init="))
     if (ci.isMethodCall())
       return true;
   return false;
@@ -1413,7 +1413,8 @@ static bool isCallInfoForInitializer(const CallInfo& ci) {
 
 // TODO: Move these to the 'InitResolver' visitor.
 static bool isTfsForInitializer(const TypedFnSignature* tfs) {
-  if (tfs->untyped()->name() == USTR("init"))
+  if (tfs->untyped()->name() == USTR("init") ||
+      tfs->untyped()->name() == USTR("init="))
     if (tfs->untyped()->isMethod())
       return true;
   return false;
@@ -2301,7 +2302,7 @@ doIsCandidateApplicableInitial(Context* context,
 
   CHPL_ASSERT(isFunction(tag) && "expected fn case only by this point");
 
-  if (ci.isMethodCall() && ci.name() == "init") {
+  if (ci.isMethodCall() && (ci.name() == "init" || ci.name() == "init=")) {
     // TODO: test when record has defaults for type/param fields
     auto recv = ci.calledType();
     auto fn = parsing::idToAst(context, candidateId)->toFunction();

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -408,6 +408,11 @@ CallInfo CallInfo::createWithReceiver(const CallInfo& ci,
                   std::move(newActuals));
 }
 
+CallInfo CallInfo::copyAndRename(const CallInfo &ci, UniqueString rename) {
+  return CallInfo(rename, ci.calledType(), ci.isMethodCall(),
+                  ci.hasQuestionArg_, ci.isParenless_, ci.actuals_);
+}
+
 void ResolutionResultByPostorderID::setupForSymbol(const AstNode* ast) {
   CHPL_ASSERT(Builder::astTagIndicatesNewIdScope(ast->tag()));
 

--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -889,7 +889,8 @@ static bool helpComputeReturnType(Context* context,
     }
 
     // if there are no returns with a value, use void return type
-    if (fnAstReturnsNonVoid(context, ast->id()) == false) {
+    if (fn->linkage() != Decl::EXTERN &&
+        fnAstReturnsNonVoid(context, ast->id()) == false) {
       result = QualifiedType(QualifiedType::CONST_VAR, VoidType::get(context));
       return true;
     }
@@ -1096,9 +1097,11 @@ void computeReturnType(Resolver& resolver) {
     }
 
     // infer the return type
-    auto v = ReturnTypeInferrer(resolver.context, fn, declaredReturnType);
-    v.process(fn->body(), resolver.byPostorder);
-    resolver.returnType = v.returnedType();
+    if (fn->linkage() != Decl::EXTERN) {
+      auto v = ReturnTypeInferrer(resolver.context, fn, declaredReturnType);
+      v.process(fn->body(), resolver.byPostorder);
+      resolver.returnType = v.returnedType();
+    }
   }
 }
 

--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -166,6 +166,8 @@ const CompositeType* helpGetTypeForDecl(Context* context,
       // TODO: update this to call a method on ArrayType to get the id or path
     } else if (r->id().symbolPath() == "ChapelArray._array") {
       ret = ArrayType::getGenericArrayType(context);
+    } else if (r->id().symbolPath() == "ChapelLocale._locale") {
+      ret = CompositeType::getLocaleType(context);
     } else {
       const RecordType* insnFromRec = nullptr;
       if (instantiatedFrom != nullptr) {

--- a/frontend/lib/types/Type.cpp
+++ b/frontend/lib/types/Type.cpp
@@ -171,6 +171,14 @@ bool Type::isBytesType() const {
   return false;
 }
 
+bool Type::isLocaleType() const {
+  if (auto rec = toRecordType()) {
+    if (rec->name() == USTR("locale"))
+      return true;
+  }
+  return false;
+}
+
 bool Type::isNilablePtrType() const {
   if (isPtrType()) {
 


### PR DESCRIPTION
This PR fixes a variety of type resolution errors in the interest of unblocking progress towards resolving "hello world":
- introduces the ``locale`` type in the frontend
- works around some deprecation issues with the ``kind`` field in fileReader/Writer
- avoids some issues when resolving the return type of extern procs
- adds some basic support for atomic type construction (though this is still blocked by an issue with ChplConfig)
- implements PRIM_GET_COMPILER_VAR

Testing:
- [x] local paratest