### PR TITLE
Fix runtime build issues with CUB wrappers when CUDA 12 used

### DIFF
--- a/runtime/src/gpu/nvidia/Makefile.share
+++ b/runtime/src/gpu/nvidia/Makefile.share
@@ -21,7 +21,17 @@ SRCS = $(GPU_SRCS)
 
 GPU_OBJS = $(addprefix $(GPU_OBJDIR)/,$(addsuffix .o,$(basename $(GPU_SRCS))))
 
-RUNTIME_CXXFLAGS += -x cuda -Wno-unknown-cuda-version
+# 1. our bundled clang (15 as of today) doesn't support warp-reductions which
+# came in with 8.x. So, we are limiting our runtime binary to 7.5. This seems to
+# work fine even if the user code is compiled with >7.5.
+# 2. clang-14 wants offload-arch to be passed multiple times and doesn't accept
+# a comma-separated list.
+RUNTIME_CXXFLAGS += -x cuda -Wno-unknown-cuda-version \
+                    -Xclang -fcuda-allow-variadic-functions \
+                    --offload-arch=sm_60 \
+                    --offload-arch=sm_61 \
+                    --offload-arch=sm_70 \
+                    --offload-arch=sm_75
 
 $(RUNTIME_OBJ_DIR)/gpu-nvidia-reduce.o: gpu-nvidia-reduce.cc \
                                          $(RUNTIME_OBJ_DIR_STAMP)


### PR DESCRIPTION
This is a draft PR to attempt fixing runtime builds with the newly added CUB wrappers. As-is, this takes us further and keeps things compiling with `sm_60`. But with newer architectures, I see failures. Some may be due to us using LLVM 15 with a patch.