### PR TITLE
Convert gasnet-ex shim strided get/put over to GEX API

### DIFF
--- a/runtime/src/comm/gasnet/comm-gasnet-ex.c
+++ b/runtime/src/comm/gasnet/comm-gasnet-ex.c
@@ -1328,7 +1328,7 @@ void  chpl_comm_get(void* addr, c_nodeid_t node, void* raddr,
 }
 
 //
-// This is an adapter from Chapel code to GASNet's gasnet_gets_bulk. It does:
+// This is an adapter from Chapel code to GASNet's VIS interface. It does:
 // * convert count[0] and all of 'srcstr' and 'dststr' from counts of element
 //   to counts of bytes,
 //
@@ -1338,24 +1338,20 @@ void  chpl_comm_get_strd(void* dstaddr, size_t* dststrides, c_nodeid_t srcnode_i
                          int ln, int32_t fn) {
   int i;
   const size_t strlvls = (size_t)stridelevels;
+  // Avoid 0-lengh VLA when stridelevels is 0 (contiguous transfer), gasnet
+  // will ignore arrays in this case
+  const size_t strlvls_nz = strlvls == 0 ? 1 : strlvls;
   const gasnet_node_t srcnode = (gasnet_node_t)srcnode_id;
 
-  size_t dststr[strlvls];
-  size_t srcstr[strlvls];
-  size_t cnt[strlvls+1];
+  ptrdiff_t dststr[strlvls_nz];
+  ptrdiff_t srcstr[strlvls_nz];
+  size_t cnt[strlvls_nz];
+  size_t elemsz = count[0] * elemSize;
 
-  // Only count[0] and strides are measured in number of bytes.
-  cnt[0] = count[0] * elemSize;
-
-  if (strlvls>0) {
-    srcstr[0] = srcstrides[0] * elemSize;
-    dststr[0] = dststrides[0] * elemSize;
-    for (i=1; i<strlvls; i++) {
-      srcstr[i] = srcstrides[i] * elemSize;
-      dststr[i] = dststrides[i] * elemSize;
-      cnt[i] = count[i];
-    }
-    cnt[strlvls] = count[strlvls];
+  for (i=0; i<strlvls; i++) {
+    srcstr[i] = srcstrides[i] * elemSize;
+    dststr[i] = dststrides[i] * elemSize;
+    cnt[i] = count[i+1];
   }
 
   // Communications callback support
@@ -1374,33 +1370,31 @@ void  chpl_comm_get_strd(void* dstaddr, size_t* dststrides, c_nodeid_t srcnode_i
   }
 
   // TODO -- handle strided get for non-registered memory
-  gasnet_gets_bulk(dstaddr, dststr, srcnode, srcaddr, srcstr, cnt, strlvls);
+  // TODO GEX convert to NB with task-yield
+  gex_VIS_StridedGetBlocking(myteam, dstaddr, dststr, srcnode, srcaddr, srcstr, elemsz, cnt, strlvls, GEX_NO_FLAGS);
 }
 
-// See the comment for chpl_comm_gets().
+// See the comment for chpl_comm_get_strd().
 void  chpl_comm_put_strd(void* dstaddr, size_t* dststrides, c_nodeid_t dstnode_id,
                          void* srcaddr, size_t* srcstrides, size_t* count,
                          int32_t stridelevels, size_t elemSize, int32_t commID,
                          int ln, int32_t fn) {
   int i;
   const size_t strlvls = (size_t)stridelevels;
+  // Avoid 0-lengh VLA when stridelevels is 0 (contiguous transfer), gasnet
+  // will ignore arrays in this case
+  const size_t strlvls_nz = strlvls == 0 ? 1 : strlvls;
   const gasnet_node_t dstnode = (gasnet_node_t)dstnode_id;
 
-  size_t dststr[strlvls];
-  size_t srcstr[strlvls];
-  size_t cnt[strlvls+1];
+  ptrdiff_t dststr[strlvls_nz];
+  ptrdiff_t srcstr[strlvls_nz];
+  size_t cnt[strlvls_nz];
+  size_t elemsz = count[0] * elemSize;
 
-  // Only count[0] and strides are measured in number of bytes.
-  cnt[0] = count[0] * elemSize;
-  if (strlvls>0) {
-    srcstr[0] = srcstrides[0] * elemSize;
-    dststr[0] = dststrides[0] * elemSize;
-    for (i=1; i<strlvls; i++) {
-      srcstr[i] = srcstrides[i] * elemSize;
-      dststr[i] = dststrides[i] * elemSize;
-      cnt[i] = count[i];
-    }
-    cnt[strlvls] = count[strlvls];
+  for (i=0; i<strlvls; i++) {
+    srcstr[i] = srcstrides[i] * elemSize;
+    dststr[i] = dststrides[i] * elemSize;
+    cnt[i] = count[i+1];
   }
 
   // Communications callback support
@@ -1419,7 +1413,8 @@ void  chpl_comm_put_strd(void* dstaddr, size_t* dststrides, c_nodeid_t dstnode_i
   }
 
   // TODO -- handle strided put for non-registered memory
-  gasnet_puts_bulk(dstnode, dstaddr, dststr, srcaddr, srcstr, cnt, strlvls);
+  // TODO GEX convert to NB with task-yield
+  gex_VIS_StridedPutBlocking(myteam, dstnode, dstaddr, dststr, srcaddr, srcstr, elemsz, cnt, strlvls, GEX_NO_FLAGS);
 }
 
 #define MAX_UNORDERED_TRANS_SZ 1024


### PR DESCRIPTION
Convert strided RMA calls over to GEX API. The strided APIs were made a little more general in GEX, so adapt to the changes here. Specifically, `count[0]` is no longer special and was moved out into a separate `elemsz` variable so `count` is now of `stridelevels` size  instead of `stridelevels+1`.

Our strided interface was at least partially based on the gasnet-1 interface, so I think it could be worth revisiting the interface to see if it could be simplified now.

Note that during review we discovered a bug where we were using 0 length VLAs for `stridelevels == 0` (contiguous transfers). 0-size VLAs are undefined-behavior, so fix that here by ensuring the arrays are always at least of size 1 (they will be ignored by gasnet for stridelevels==0). I suspect in practice this didn't matter since clang and gcc have extensions for 0-length VLA, but it's still UB (and is caught by UBSan) so we should backport the fix to the gasnet-1 interface.

Testing:
 - [x] gex-udp-everything: full suite
 - [x] gex-ibv-large: `release/examples runtime/configMatters`
 - [x] manual test with UBSan

Part of #14443