### PR TITLE
Fix the runtime reduction interface for cpu-as-device

### DIFF
--- a/runtime/src/gpu/cpu/gpu-cpu.c
+++ b/runtime/src/gpu/cpu/gpu-cpu.c
@@ -159,7 +159,7 @@ void chpl_gpu_impl_stream_synchronize(void* stream) {
 
 #define DEF_ONE_REDUCE_RET_VAL(impl_kind, chpl_kind, data_type) \
 void chpl_gpu_impl_##chpl_kind##_reduce_##data_type(data_type* data, int n,\
-                                                    data_type* val,\
+                                                    data_type* val, int* idx,\
                                                     void* stream) {\
   chpl_internal_error("This function shouldn't have been called. "\
                       "cpu-as-device mode should handle reductions in "\


### PR DESCRIPTION
I updated the reduction interface in the runtime a little late in the PR process and forgot to update the cpu-as-device implementation for it. This PR adjusts that.