### PR TITLE
Skip over functions that may no longer be in tree during normalize

### DIFF
--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -151,6 +151,12 @@ void normalize() {
   }
 
   forv_expanding_Vec(FnSymbol, fn, gFnSymbols) {
+
+    // Some functions can get removed by code in the loop - and if they
+    // contain nested functions, then those functions will get removed
+    // as well (as flattening does not happen until after resolution).
+    if (!fn->inTree()) continue;
+
     SET_LINENO(fn);
 
     if (fn->hasFlag(FLAG_EXPORT) &&

--- a/test/functions/NestedFunctionBug.chpl
+++ b/test/functions/NestedFunctionBug.chpl
@@ -1,0 +1,9 @@
+proc foo(n: int(?w)) {
+	proc helper(a : [?D] int) {}
+  helper([0,1]);
+}
+
+proc main() {
+ foo(1);
+}
+


### PR DESCRIPTION
Resolves #23560.

Fix an internal error by skipping functions that are no longer in the tree during normalize.

There are times during normalize where a function may be cloned and then removed from the tree. If this happens then any nested functions are also effectively cloned and pruned as well. Add a simple check that skips a function in normalize if it is no longer in the tree.

TESTING

- [x] `linux64`, `standard`

Reviewed by @riftEmber. Thanks!