### PR TITLE
Fix `MisleadingIndentation` in chplcheck for comments

### DIFF
--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -128,6 +128,10 @@ def register_rules(driver):
         for child in root:
             yield from MisleadingIndentation(context, child)
 
+            # dont call `.location` on comments
+            if isinstance(child, Comment) or isinstance(prev, Comment):
+                continue
+
             if prev is not None:
                 if child.location().start()[1] == prev.location().start()[1]:
                     yield child

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -136,7 +136,7 @@ def register_rules(driver):
             prev = None
             if isinstance(child, Loop) and child.block_style() == "implicit":
                 grandchildren = list(child)
-                # safe to access [-1], implicit loops must have at least 1 child
+                # safe to access [-1], loops must have at least 1 child
                 for blockchild in reversed(list(grandchildren[-1])):
                     if isinstance(blockchild, Comment): continue
                     prev = blockchild

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -138,7 +138,6 @@ def register_rules(driver):
                 grandchildren = list(child)
                 # safe to access [-1], implicit loops must have at least 1 child
                 for blockchild in reversed(list(grandchildren[-1])):
-                    if isinstance(blockchild, Comment):
-                        continue
+                    if isinstance(blockchild, Comment): continue
                     prev = blockchild
                     break


### PR DESCRIPTION
Running `./tools/chapel-py/runChplcheck` on the following problem used trigger an assert in the frontend library.

```chapel
for i in 1..10 do
  writeln("hello");
  // misleading
  foo();
```

This is because you cannot get the location of a Comment. This PR sidesteps the issue by skipping over comments in the relevant rule.

[Reveiwed by @DanilaFe]