### PR TITLE
Prevent driver debug phase warning in sub-invocations

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1906,7 +1906,7 @@ static void checkCompilerDriverFlags() {
       USR_WARN(
           "Driver debug phase has no effect for monolithic compilation");
     }
-    if (!(fRungdb || fRunlldb)) {
+    if (!(fRungdb || fRunlldb) && !driverInSubInvocation) {
       USR_WARN(
           "Driver debug phase has no effect when not running with debugger");
     }


### PR DESCRIPTION
Prevent generating extraneous warnings about unused `--driver-debug-phase`, some of which were incorrect.

This warning message is intended to be displayed only for an initial invocation of the driver with an unused --driver-debug-phase flag. Previously it was also emitted by sub-invocations, even if the sub-invocation is inside the debugger (meaning the user didn't specify anything incorrect).

[reviewer info placeholder]

Testing:
- [x] paratest (with and without `--compiler-driver`)