### PR TITLE
Add extra warnings for resolved functions

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -545,7 +545,8 @@ void Symbol::maybeGenerateUnstableWarning(Expr* context) {
   Symbol* contextParent = context->parentSymbol;
   bool parentUnstable = isUnstableContext(contextParent);
   bool parentDeprecated = contextParent->hasFlag(FLAG_DEPRECATED);
-  bool compilerGenerated = contextParent->hasFlag(FLAG_COMPILER_GENERATED);
+  bool compilerGenerated = contextParent->hasFlag(FLAG_COMPILER_GENERATED) &&
+                          !contextParent->hasFlag(FLAG_DEFAULT_ACTUAL_FUNCTION);
 
   // Traverse until we find an unstable parent symbol, a deprecated parent
   // symbol, a compiler generated parent symbol, or until we reach the highest
@@ -558,7 +559,8 @@ void Symbol::maybeGenerateUnstableWarning(Expr* context) {
     contextParent = contextParent->defPoint->parentSymbol;
     parentUnstable = isUnstableContext(contextParent);
     parentDeprecated = contextParent->hasFlag(FLAG_DEPRECATED);
-    compilerGenerated = contextParent->hasFlag(FLAG_COMPILER_GENERATED);
+    compilerGenerated = contextParent->hasFlag(FLAG_COMPILER_GENERATED) &&
+                       !contextParent->hasFlag(FLAG_DEFAULT_ACTUAL_FUNCTION);
   }
 
   // Only generate the warning if the location with the reference is not

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -501,6 +501,7 @@ void Symbol::maybeGenerateDeprecationWarning(Expr* context) {
 
   // Only generate the warning if the location with the reference is not
   // created by the compiler or also deprecated.
+  if (!compilerGenerated && !parentDeprecated && !ignoreUsage) {
     auto key = std::make_pair(this, context);
     if (dedupDeprecationWarnings.find(key) == dedupDeprecationWarnings.end()) {
       USR_WARN(context, "%s", getSanitizedMsg(getDeprecationMsg()));
@@ -560,6 +561,7 @@ void Symbol::maybeGenerateUnstableWarning(Expr* context) {
 
   // Only generate the warning if the location with the reference is not
   // created by the compiler, is not unstable, and is not deprecated.
+  if (!compilerGenerated && !parentUnstable && !parentDeprecated) {
     auto key = std::make_pair(this, context);
     if (dedupUnstableWarnings.find(key) == dedupUnstableWarnings.end()) {
       USR_WARN(context, "%s", getSanitizedMsg(getUnstableMsg()));

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -474,7 +474,8 @@ void Symbol::maybeGenerateDeprecationWarning(Expr* context) {
 
   Symbol* contextParent = context->parentSymbol;
   bool parentDeprecated = contextParent->hasFlag(FLAG_DEPRECATED);
-  bool compilerGenerated = contextParent->hasFlag(FLAG_COMPILER_GENERATED);
+  bool compilerGenerated = contextParent->hasFlag(FLAG_COMPILER_GENERATED) &&
+                          !contextParent->hasFlag(FLAG_DEFAULT_ACTUAL_FUNCTION);
   bool ignoreUsage = contextParent->hasFlag(FLAG_IGNORE_DEPRECATED_USE);
 
   // Ignore initialization of deprecated fields in initializers.
@@ -495,7 +496,8 @@ void Symbol::maybeGenerateDeprecationWarning(Expr* context) {
          ignoreUsage != true) {
     contextParent = contextParent->defPoint->parentSymbol;
     parentDeprecated = contextParent->hasFlag(FLAG_DEPRECATED);
-    compilerGenerated = contextParent->hasFlag(FLAG_COMPILER_GENERATED);
+    compilerGenerated = contextParent->hasFlag(FLAG_COMPILER_GENERATED) &&
+                       !contextParent->hasFlag(FLAG_DEFAULT_ACTUAL_FUNCTION);
     ignoreUsage = contextParent->hasFlag(FLAG_IGNORE_DEPRECATED_USE);
   }
 

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -597,6 +597,10 @@ void resolveFunction(FnSymbol* fn, CallExpr* forCall) {
     popInstantiationLimit(fn);
     clearCacheInfoIfEmpty(fn);
   }
+  if(fn && forCall) {
+    fn->maybeGenerateDeprecationWarning(forCall);
+    fn->maybeGenerateUnstableWarning(forCall);
+  }
 }
 
 static void markTypesWithDefaultInitEqOrAssign(FnSymbol* fn) {

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -981,6 +981,11 @@ proc stringStyleExactLen(len:int(64)) {
 @deprecated
 ("stringStyleWithVariableLength is deprecated following the deprecation of 'iostyle', please use Serializers or Deserializers instead")
 proc stringStyleWithVariableLength() {
+  return stringStyleWithVariableLengthInternal();
+}
+
+@chpldoc.nodoc
+proc stringStyleWithVariableLengthInternal() {
   return iostringstyleInternal.lenVb_data: int(64);
 }
 
@@ -1651,7 +1656,7 @@ proc defaultIOStyleInternal(): iostyleInternal {
 
 /* Get an iostyleInternal indicating binary I/O in native byte order. */
 @chpldoc.nodoc
-proc iostyleInternal.native(str_style:int(64)=stringStyleWithVariableLength()):iostyleInternal {
+proc iostyleInternal.native(str_style:int(64)=stringStyleWithVariableLengthInternal()):iostyleInternal {
   var ret = this;
   ret.binary = 1;
   ret.byteorder = _iokind.native:uint(8);
@@ -1661,7 +1666,7 @@ proc iostyleInternal.native(str_style:int(64)=stringStyleWithVariableLength()):i
 
 /* Get an iostyleInternal indicating binary I/O in big-endian byte order.*/
 @chpldoc.nodoc
-proc iostyleInternal.big(str_style:int(64)=stringStyleWithVariableLength()):iostyleInternal {
+proc iostyleInternal.big(str_style:int(64)=stringStyleWithVariableLengthInternal()):iostyleInternal {
   var ret = this;
   ret.binary = 1;
   ret.byteorder = _iokind.big:uint(8);
@@ -1671,7 +1676,7 @@ proc iostyleInternal.big(str_style:int(64)=stringStyleWithVariableLength()):iost
 
 /* Get an iostyleInternal indicating binary I/O in little-endian byte order. */
 @chpldoc.nodoc
-proc iostyleInternal.little(str_style:int(64)=stringStyleWithVariableLength()):iostyleInternal {
+proc iostyleInternal.little(str_style:int(64)=stringStyleWithVariableLengthInternal()):iostyleInternal {
   var ret = this;
   ret.binary = 1;
   ret.byteorder = _iokind.little:uint(8);

--- a/test/classes/delete-free/shared/coerce-owned-to-shared.good
+++ b/test/classes/delete-free/shared/coerce-owned-to-shared.good
@@ -1,1 +1,3 @@
+coerce-owned-to-shared.chpl:6: In function 'test':
+coerce-owned-to-shared.chpl:9: warning: assigning owned class to shared class is deprecated.
 {x = 4} nil

--- a/test/classes/errors/nilability-init-field-dflt/init-field-dflt-nonnil-shared-from-nonnil-owned.good
+++ b/test/classes/errors/nilability-init-field-dflt/init-field-dflt-nonnil-shared-from-nonnil-owned.good
@@ -1,1 +1,2 @@
+init-field-dflt-nonnil-shared-from-nonnil-owned.chpl:8: warning: assigning owned class to shared class is deprecated.
 init-field-dflt-nonnil-shared-from-nonnil-owned.chpl:13: error: done

--- a/test/classes/errors/nilability-init-field-dflt/init-field-dflt-nonnil-shared-from-oknil-owned.good
+++ b/test/classes/errors/nilability-init-field-dflt/init-field-dflt-nonnil-shared-from-oknil-owned.good
@@ -1,1 +1,2 @@
+init-field-dflt-nonnil-shared-from-oknil-owned.chpl:8: warning: assigning owned class to shared class is deprecated.
 init-field-dflt-nonnil-shared-from-oknil-owned.chpl:11: error: cannot initialize 'shared MyClass' from a 'owned MyClass?'

--- a/test/classes/errors/nilability-init-field-dflt/init-field-dflt-oknil-shared-from-nonnil-owned.good
+++ b/test/classes/errors/nilability-init-field-dflt/init-field-dflt-oknil-shared-from-nonnil-owned.good
@@ -1,1 +1,2 @@
+init-field-dflt-oknil-shared-from-nonnil-owned.chpl:8: warning: assigning owned class to shared class is deprecated.
 init-field-dflt-oknil-shared-from-nonnil-owned.chpl:13: error: done

--- a/test/classes/errors/nilability-init-field-dflt/init-field-dflt-oknil-shared-from-oknil-owned.good
+++ b/test/classes/errors/nilability-init-field-dflt/init-field-dflt-oknil-shared-from-oknil-owned.good
@@ -1,0 +1,1 @@
+init-field-dflt-oknil-shared-from-oknil-owned.chpl:8: warning: assigning owned class to shared class is deprecated.

--- a/test/deprecated-keyword/warn-in-init.chpl
+++ b/test/deprecated-keyword/warn-in-init.chpl
@@ -1,0 +1,21 @@
+record myShared {
+  proc init() {}
+  proc init=(s: myShared) {}
+  @deprecated("converting myOwned to myShared is deprecated")
+  proc init=(o: myOwned) {}
+  operator :(x: myOwned, type t: myShared) {
+    return new myShared();
+  }
+}
+record myOwned {
+  proc init() {}
+}
+
+var o = new myOwned();
+record R {
+  var s: myShared = o;
+}
+
+proc main() {
+  var r = new R();
+}

--- a/test/deprecated-keyword/warn-in-init.future
+++ b/test/deprecated-keyword/warn-in-init.future
@@ -1,2 +1,0 @@
-bug: deprecated functions should still warn when used in a default init function
-#23787

--- a/test/deprecated-keyword/warn-in-init.future
+++ b/test/deprecated-keyword/warn-in-init.future
@@ -1,0 +1,2 @@
+bug: deprecated functions should still warn when used in a default init function
+#23787

--- a/test/deprecated-keyword/warn-in-init.good
+++ b/test/deprecated-keyword/warn-in-init.good
@@ -1,0 +1,1 @@
+warn-in-init.chpl:16: warning: converting myOwned to myShared is deprecated

--- a/test/deprecated/CyclicTest.comm-none.good
+++ b/test/deprecated/CyclicTest.comm-none.good
@@ -5,6 +5,7 @@ CyclicStridable.chpl:465: warning: domain.stridable is deprecated; use domain.st
 CyclicTest.chpl:8: warning: the domain map 'unmanaged Cyclic(1,int(64))' needs to be updated from 'stridable: bool' to 'strides: strideKind' because 'stridable' is deprecated
 $CHPL_HOME/modules/dists/DSIUtil.chpl:560: warning: domain.stridable is deprecated; use domain.strides instead
 CyclicStridable.chpl:729: warning: domain.stridable is deprecated; use domain.strides instead
+CyclicStridable.chpl:729: warning: domain.stridable is deprecated; use domain.strides instead
 CyclicStridable.chpl:375: warning: casting from a managed class to an 'unmanaged' is deprecated
 CyclicStridable.chpl:500: warning: domain.stridable is deprecated; use domain.strides instead
 CyclicTest.chpl:9: warning: the domain map 'unmanaged Cyclic(1,int(64))' needs to be updated from 'stridable: bool' to 'strides: strideKind' because 'stridable' is deprecated

--- a/test/deprecated/CyclicTest.good
+++ b/test/deprecated/CyclicTest.good
@@ -5,6 +5,7 @@ CyclicStridable.chpl:465: warning: domain.stridable is deprecated; use domain.st
 CyclicTest.chpl:8: warning: the domain map 'unmanaged Cyclic(1,int(64))' needs to be updated from 'stridable: bool' to 'strides: strideKind' because 'stridable' is deprecated
 $CHPL_HOME/modules/dists/DSIUtil.chpl:560: warning: domain.stridable is deprecated; use domain.strides instead
 CyclicStridable.chpl:729: warning: domain.stridable is deprecated; use domain.strides instead
+CyclicStridable.chpl:729: warning: domain.stridable is deprecated; use domain.strides instead
 CyclicStridable.chpl:375: warning: casting from a managed class to an 'unmanaged' is deprecated
 CyclicStridable.chpl:500: warning: domain.stridable is deprecated; use domain.strides instead
 CyclicStridable.chpl:711: warning: domain.stridable is deprecated; use domain.strides instead

--- a/test/deprecated/rangeStridable.good
+++ b/test/deprecated/rangeStridable.good
@@ -15,6 +15,7 @@ rangeStridable.chpl:25: warning: domain.stridable is deprecated; use domain.stri
 rangeStridable.chpl:26: warning: range.stridable is deprecated; please use '.strides' instead
 rangeStridable.chpl:27: warning: domain.stridable is deprecated; use domain.strides instead
 rangeStridable.chpl:28: warning: [array].stridable is deprecated; use [array].strides instead
+rangeStridable.chpl:28: warning: [array].stridable is deprecated; use [array].strides instead
 rangeStridable.chpl:29: warning: range.stridable is deprecated; please use '.strides' instead
 % pd: unit stride range(int(64),both,one)
 % pd: stridable range(int(64),both,any)

--- a/test/distributions/block/redistBlock.comm-none.good
+++ b/test/distributions/block/redistBlock.comm-none.good
@@ -1,5 +1,7 @@
 redistBlock.chpl:5: warning: 'dmapped' keyword is unstable, instead please use factory functions when available
 redistBlock.chpl:15: warning: 'blockDist.redistribute()' is currently unstable due to lack of design review and is being made available as a prototype
+redistBlock.chpl:15: warning: 'blockDist.redistribute()' is currently unstable due to lack of design review and is being made available as a prototype
+redistBlock.chpl:34: warning: 'blockDist.redistribute()' is currently unstable due to lack of design review and is being made available as a prototype
 redistBlock.chpl:34: warning: 'blockDist.redistribute()' is currently unstable due to lack of design review and is being made available as a prototype
 redistBlock.chpl:41: warning: assignment between distributions is currently unstable due to lack of testing
 -------------

--- a/test/distributions/block/redistBlock.good
+++ b/test/distributions/block/redistBlock.good
@@ -1,5 +1,7 @@
 redistBlock.chpl:5: warning: 'dmapped' keyword is unstable, instead please use factory functions when available
 redistBlock.chpl:15: warning: 'blockDist.redistribute()' is currently unstable due to lack of design review and is being made available as a prototype
+redistBlock.chpl:15: warning: 'blockDist.redistribute()' is currently unstable due to lack of design review and is being made available as a prototype
+redistBlock.chpl:34: warning: 'blockDist.redistribute()' is currently unstable due to lack of design review and is being made available as a prototype
 redistBlock.chpl:34: warning: 'blockDist.redistribute()' is currently unstable due to lack of design review and is being made available as a prototype
 redistBlock.chpl:41: warning: assignment between distributions is currently unstable due to lack of testing
 -------------


### PR DESCRIPTION
Adds calls to `maybeGenerate[Deprecation|Unstable]Warning` in `resolveFunction` to catch more cases of deprecated functions not being warned for. This is a relatively lazy fix in that it is prone to generate duplicate warnings, so dedup code has been added to `maybeGenerate[Deprecation|Unstable]Warning`.

This resolves #23787, where some resolved functions would not warn. It handles the initializer problem by adding an exception for `"default actual functions"` for what is considered 'compiler-generated' code, since the user wrote it and is able to change and get rid of the deprecation warning.

This PR takes the approach that multiple warnings is better than no warning at all, which requires updates to a few test's .good files
- test/deprecated/rangeStridable
- test/distributions/block/redistBlock
- test/deprecated/CyclicTest

## Testing
- [x] paratest with comm=none
- [x] paratest with comm=gasnet

[Reviewed by @lydia-duncan]