### PR TITLE
Bug fix in QIO buffering optimization

### DIFF
--- a/runtime/include/qio/qio.h
+++ b/runtime/include/qio/qio.h
@@ -843,6 +843,9 @@ qioerr qio_channel_read(const int threadsafe, qio_channel_t* restrict ch, void* 
 
   // Is there room in our fast path buffer?
   if( qio_space_in_ptr_diff(len, ch->cached_end, ch->cached_cur) ) {
+    // printf("\t-fast read: len=%zi, cached-cur=%p, rms=%lli\n", len, ch->cached_cur, ch->mark_stack[ch->mark_cur]);
+    // fflush(stdout);
+
     qio_memcpy( ptr, ch->cached_cur, len );
     ch->cached_cur = qio_ptr_add(ch->cached_cur, len);
     *amt_read = len;
@@ -850,6 +853,9 @@ qioerr qio_channel_read(const int threadsafe, qio_channel_t* restrict ch, void* 
   } else {
     err = _qio_slow_read(ch, ptr, len, amt_read);
     _qio_channel_set_error_unlocked(ch, err);
+
+    // printf("\t-slow read: len=%zi, cached-cur=%p, amt_read=%zi, rms=%lli\n", len, ch->cached_cur, *amt_read, ch->mark_stack[ch->mark_cur]);
+    // fflush(stdout);
   }
 
   if( threadsafe ) {

--- a/runtime/include/qio/qio.h
+++ b/runtime/include/qio/qio.h
@@ -843,9 +843,6 @@ qioerr qio_channel_read(const int threadsafe, qio_channel_t* restrict ch, void* 
 
   // Is there room in our fast path buffer?
   if( qio_space_in_ptr_diff(len, ch->cached_end, ch->cached_cur) ) {
-    // printf("\t-fast read: len=%zi, cached-cur=%p, rms=%lli\n", len, ch->cached_cur, ch->mark_stack[ch->mark_cur]);
-    // fflush(stdout);
-
     qio_memcpy( ptr, ch->cached_cur, len );
     ch->cached_cur = qio_ptr_add(ch->cached_cur, len);
     *amt_read = len;
@@ -853,9 +850,6 @@ qioerr qio_channel_read(const int threadsafe, qio_channel_t* restrict ch, void* 
   } else {
     err = _qio_slow_read(ch, ptr, len, amt_read);
     _qio_channel_set_error_unlocked(ch, err);
-
-    // printf("\t-slow read: len=%zi, cached-cur=%p, amt_read=%zi, rms=%lli\n", len, ch->cached_cur, *amt_read, ch->mark_stack[ch->mark_cur]);
-    // fflush(stdout);
   }
 
   if( threadsafe ) {

--- a/runtime/src/qio/qio.c
+++ b/runtime/src/qio/qio.c
@@ -2848,7 +2848,6 @@ qioerr _qio_buffered_read(qio_channel_t* ch, void* ptr, ssize_t len, ssize_t* am
     // advance the ptr, start of available data, etc.
     ptr = qio_ptr_add(ptr, gotlen);
     _set_right_mark_start(ch, end.offset);
-    ch->cached_cur = qio_ptr_add(ch->cached_cur, gotlen);
     remaining -= gotlen;
     *amt_read = gotlen;
 
@@ -2926,7 +2925,6 @@ qioerr _qio_buffered_read(qio_channel_t* ch, void* ptr, ssize_t len, ssize_t* am
 
       // figure out the end of the data to copy
       gotlen = ch->av_end - _right_mark_start(ch);
-      // printf("\t\tfull gotlen: %lli\n", gotlen);
       start = _right_mark_start_iter(ch);
       if( toRead < gotlen ) {
         gotlen = toRead;

--- a/runtime/src/qio/qio.c
+++ b/runtime/src/qio/qio.c
@@ -2890,6 +2890,7 @@ qioerr _qio_buffered_read(qio_channel_t* ch, void* ptr, ssize_t len, ssize_t* am
       }
       // Return early on an error or on EOF.
       if( err ) {
+        // do not update 'amt_read' because zero bytes were read on EOF
         return err;
       }
       ptr = qio_ptr_add(ptr, num_read);

--- a/runtime/src/qio/qio.c
+++ b/runtime/src/qio/qio.c
@@ -2827,42 +2827,57 @@ qioerr _qio_buffered_read(qio_channel_t* ch, void* ptr, ssize_t len, ssize_t* am
     ch->mark_cur == 0 &&                     // not waiting for a commit/revert
     ch->chan_info == NULL                    // there is no IO plugin
   ) {
+    // printf("\tdirect read: %zi, rms=%lli\n", len, _right_mark_start(ch));
+    // fflush(stdout);
+
     // copy out what remains in the buffer before making a system call
     gotlen = qio_ptr_diff(ch->cached_end, ch->cached_cur);
-    if ( gotlen > 0 ) {
-      start = qbuffer_iter_at(&ch->buf, qio_channel_offset_unlocked(ch));
-      // start = qbuffer_iter_at(&ch->buf, ch->cached_start_pos + qio_ptr_diff(ch->cached_cur, ch->cached_start));
-      end = start;
-      qbuffer_iter_advance(&ch->buf, &end, gotlen);  // end of available data
+    // printf("\t\tremaining in buffer: %lli\n", gotlen);
+    // fflush(stdout);
 
+    if ( ch->cached_start == NULL ) {
+      start = qbuffer_iter_at(&ch->buf, qio_channel_offset_unlocked(ch));
+    } else {
+      start = qbuffer_iter_at(&ch->buf, ch->cached_start_pos + qio_ptr_diff(ch->cached_cur, ch->cached_start));
+    }
+    end = start;
+    qbuffer_iter_advance(&ch->buf, &end, gotlen);  // end of available data
+
+    if ( gotlen > 0 ) {
       // copy 'gotlen' bytes into the ptr
       err = qbuffer_copyout(&ch->buf, start, end, ptr, gotlen);
       if( err ) return err;
-
-      // advance the ptr, start of available data, etc.
-      ptr = qio_ptr_add(ptr, gotlen);
-      _set_right_mark_start(ch, end.offset);
-      ch->cached_cur = qio_ptr_add(ch->cached_cur, gotlen);
-      remaining -= gotlen;
-      *amt_read = gotlen;
-
-      // clean up the now unused portion of the buffer
-      qbuffer_trim_front(&ch->buf, gotlen);
     }
+
+    // advance the ptr, start of available data, etc.
+    ptr = qio_ptr_add(ptr, gotlen);
+    _set_right_mark_start(ch, end.offset);
+    ch->cached_cur = qio_ptr_add(ch->cached_cur, gotlen);
+    remaining -= gotlen;
+    *amt_read = gotlen;
+
+    // clean up the now unused portion of the buffer
+    qbuffer_trim_front(&ch->buf, gotlen);
+    ch->cached_cur = NULL;
+    ch->cached_end = NULL;
+    ch->cached_start = NULL;
 
     // make a direct system call to read the rest
     while( remaining > 0 ) {
       num_read = 0;
       switch (method) {
         case QIO_METHOD_READWRITE:
+          // printf("\t\t\t readwrite\n");
           err = qio_int_to_err(sys_read(ch->file->fd, ptr, remaining,
                                &num_read));
           break;
         case QIO_METHOD_PREADPWRITE:
+          // printf("\t\t\t preadpwrite: %lli\n", _right_mark_start(ch));
           err = qio_int_to_err(sys_pread(ch->file->fd, ptr, remaining,
                                _right_mark_start(ch), &num_read));
           break;
         case QIO_METHOD_FREADFWRITE:
+          // printf("\t\t\t freadfwrite\n");
           if( ch->file->fp ) {
             num_read_u = fread(ptr, 1, remaining, ch->file->fp);
             err = 0;
@@ -2883,13 +2898,15 @@ qioerr _qio_buffered_read(qio_channel_t* ch, void* ptr, ssize_t len, ssize_t* am
       }
       // Return early on an error or on EOF.
       if( err ) {
-        *amt_read = len - remaining;
+        // *amt_read = num_read;
         return err;
       }
       ptr = qio_ptr_add(ptr, num_read);
       _add_right_mark_start(ch, num_read);
       remaining -= num_read;
       *amt_read += num_read;
+      // printf("\t\tdid read: %zi remaining=%lli, ptr=%p\n", num_read, remaining, ptr);
+      // fflush(stdout);
     }
 
     // reposition the existing buffer space (and 'av_end') by the size of the direct read
@@ -2903,6 +2920,8 @@ qioerr _qio_buffered_read(qio_channel_t* ch, void* ptr, ssize_t len, ssize_t* am
     ch->cached_end = NULL;
     ch->cached_start = NULL;
   } else {
+    // printf("\tbuffered read: %zi, rms=%lli\n", len, _right_mark_start(ch));
+    // fflush(stdout);
     // otherwise, read from the buffer
     while ((remaining > 0) && !eof) {
       if ((ch->bufIoMax > 0) && (remaining > ch->bufIoMax)) {
@@ -2919,6 +2938,7 @@ qioerr _qio_buffered_read(qio_channel_t* ch, void* ptr, ssize_t len, ssize_t* am
 
       // figure out the end of the data to copy
       gotlen = ch->av_end - _right_mark_start(ch);
+      // printf("\t\tfull gotlen: %lli\n", gotlen);
       start = _right_mark_start_iter(ch);
       if( toRead < gotlen ) {
         gotlen = toRead;

--- a/test/io/corrado/buffering_optimization/growing_buff_read_write.chpl
+++ b/test/io/corrado/buffering_optimization/growing_buff_read_write.chpl
@@ -6,6 +6,9 @@ qbytes_iobuf_size = 1024:c_size_t;
 extern var qio_write_unbuffered_threshold:c_ssize_t;
 qio_write_unbuffered_threshold = 2048:c_ssize_t;
 
+extern var qio_read_unbuffered_threshold:c_ssize_t;
+qio_read_unbuffered_threshold = 2048:c_ssize_t;
+
 config const maxBufSize = 16384;
 
 var bufSize = 128,


### PR DESCRIPTION
Fixes a bug in the IO runtime where a `fileReader` could read from the incorrect file offset when the runtime transitioned from buffered reading to non-buffered reading.

The bug was somewhat unlikely to come up in practice, as the total size of the buffered reads needed to add up to exactly the size of one qio buffer chunk (2**16 bytes).

Resolves: https://github.com/chapel-lang/chapel/issues/23800

- [x] local paratest
- [x] gasnet paratest
- [x] test referenced in [#23800](https://github.com/chapel-lang/chapel/issues/23800) is passing

