### PR TITLE
[dyno] implement discardWorseWhereClauses disambiguation stub

### DIFF
--- a/frontend/lib/resolution/disambiguation.cpp
+++ b/frontend/lib/resolution/disambiguation.cpp
@@ -1028,7 +1028,40 @@ static void discardWorseArgs(const DisambiguationContext& dctx,
 static void discardWorseWhereClauses(const DisambiguationContext& dctx,
                                      const CandidatesVec& candidates,
                                      std::vector<bool>& discarded) {
-  // TODO: fill me in
+  int nWhere = 0;
+  int nNoWhere = 0;
+  for (size_t i = 0; i < candidates.size(); ++i) {
+    if (discarded[i]) {
+      continue;
+    }
+
+    const DisambiguationCandidate* candidate = candidates[i];
+    bool where = candidate->fn->whereClauseResult() != TypedFnSignature::WHERE_NONE;
+                // TODO: is there a dyno equivalent of this flag?
+                //  !candidate->fn->hasFlag(FLAG_COMPILER_ADDED_WHERE);
+    if (where) {
+      nWhere++;
+    } else {
+      nNoWhere++;
+    }
+  }
+
+  if (nWhere > 0 && nNoWhere > 0) {
+    for (size_t i = 0; i < candidates.size(); ++i) {
+      if (discarded[i]) {
+        continue;
+      }
+
+      const DisambiguationCandidate* candidate = candidates[i];
+      bool where = candidate->fn->whereClauseResult() != TypedFnSignature::WHERE_NONE;
+                  // TODO: is there a dyno equivalent of this flag?
+                  //  !candidate->fn->hasFlag(FLAG_COMPILER_ADDED_WHERE);
+      if (!where) {
+        EXPLAIN("X: Fn %d does not have 'where' but others do\n", i);
+        discarded[i] = true;
+      }
+    }
+  }
 }
 
 static void discardWorseConversions(const DisambiguationContext& dctx,

--- a/frontend/lib/resolution/disambiguation.cpp
+++ b/frontend/lib/resolution/disambiguation.cpp
@@ -1036,9 +1036,9 @@ static void discardWorseWhereClauses(const DisambiguationContext& dctx,
     }
 
     const DisambiguationCandidate* candidate = candidates[i];
-    bool where = candidate->fn->whereClauseResult() != TypedFnSignature::WHERE_NONE;
-                // TODO: is there a dyno equivalent of this flag?
-                //  !candidate->fn->hasFlag(FLAG_COMPILER_ADDED_WHERE);
+    auto whereClause = candidate->fn->whereClauseResult();
+    bool where = whereClause != TypedFnSignature::WHERE_NONE;
+
     if (where) {
       nWhere++;
     } else {
@@ -1053,9 +1053,9 @@ static void discardWorseWhereClauses(const DisambiguationContext& dctx,
       }
 
       const DisambiguationCandidate* candidate = candidates[i];
-      bool where = candidate->fn->whereClauseResult() != TypedFnSignature::WHERE_NONE;
-                  // TODO: is there a dyno equivalent of this flag?
-                  //  !candidate->fn->hasFlag(FLAG_COMPILER_ADDED_WHERE);
+      auto whereClause = candidate->fn->whereClauseResult();
+      bool where = whereClause != TypedFnSignature::WHERE_NONE;
+
       if (!where) {
         EXPLAIN("X: Fn %d does not have 'where' but others do\n", i);
         discarded[i] = true;


### PR DESCRIPTION
This PR implements the `discardWorseWhereClauses` function for Dyno disambiguation. This PR is part 6 of a series of PRs that implement disambiguation changes already in production from https://github.com/chapel-lang/chapel/pull/20528.