### PR TITLE
[dyno] implement discardWorseArgs disambiguation stub

### DIFF
--- a/frontend/lib/resolution/disambiguation.cpp
+++ b/frontend/lib/resolution/disambiguation.cpp
@@ -693,8 +693,8 @@ static int compareSpecificity(const DisambiguationContext& dctx,
   std::string reason;
   DisambiguationState ds;
 
-  // Initializer work-around: Skip _mt/_this for generic initializers
-  int start = (forGenericInit == false) ? 0 : 2;
+  // Initializer work-around: Skip 'this' for generic initializers
+  int start = (forGenericInit == false) ? 0 : 1;
 
   for (int k = start; k < n; k++) {
 
@@ -1375,8 +1375,7 @@ moreVisible(const DisambiguationContext& dctx,
   disambiguation state appropriately.
 
   This function implements the argument mapping comparison component of the
-  disambiguation procedure as detailed in section 13.14.3 of the Chapel
-  language specification (page 107).
+  disambiguation procedure as detailed in the language specification.
 
   actualIdx is the index within the call of the argument to be compared.
 
@@ -1415,10 +1414,6 @@ static int testArgMapping(const DisambiguationContext& dctx,
       f2Type.kind() == QualifiedType::OUT) {
     return -1;
   }
-
-  // We only want to deal with the value types here, avoiding odd overloads
-  // working (or not) due to _ref.
-  // TODO: not sure how to reproduce this code in Dyno
 
   // Additionally, ignore the difference between referential tuples
   // and value tuples.
@@ -1485,11 +1480,9 @@ static int testArgMapping(const DisambiguationContext& dctx,
     actualScalarT = computeActualScalarType(dctx.context, actualType);
   }
 
-  // TODO: for sync/single use the valType
-
   // consider promotion
   if (!formal1Promotes && formal2Promotes) {
-    reason = "no promotin vs promotes";
+    reason = "no promotion vs promotes";
     return 1;
   }
 
@@ -2098,7 +2091,8 @@ static int prefersNumericCoercion(const DisambiguationContext& dctx,
     reason = "same numeric kind";
     return 2;
   }
-// Otherwise, prefer the function with the same numeric width
+
+  // Otherwise, prefer the function with the same numeric width
   // as the actual. This rule helps this case:
   //
   //  proc f(arg: real(32))

--- a/frontend/lib/resolution/disambiguation.cpp
+++ b/frontend/lib/resolution/disambiguation.cpp
@@ -156,11 +156,25 @@ findMostSpecificIgnoringReturn(const DisambiguationContext& dctx,
 static int compareSpecificity(const DisambiguationContext& dctx,
                               const DisambiguationCandidate& candidate1,
                               const DisambiguationCandidate& candidate2,
+                              int i,
+                              int j,
+                              bool forGenericInit);
+
+static int compareSpecificity(const DisambiguationContext& dctx,
+                              const DisambiguationCandidate& candidate1,
+                              const DisambiguationCandidate& candidate2,
                               bool ignoreWhere);
 
 static MoreVisibleResult moreVisible(const DisambiguationContext& dctx,
                                      const DisambiguationCandidate& candidate1,
                                      const DisambiguationCandidate& candidate2);
+
+static int testArgMapping(const DisambiguationContext& dctx,
+                          const DisambiguationCandidate& candidate1,
+                          const DisambiguationCandidate& candidate2,
+                          int actualIdx,
+                          DisambiguationState& ds,
+                          std::string& reason);
 
 static void testArgMapping(const DisambiguationContext& dctx,
                            const DisambiguationCandidate& candidate1,
@@ -174,6 +188,13 @@ static void testArgMapHelper(const DisambiguationContext& dctx,
                              bool* formalPromotes, bool* formalNarrows,
                              DisambiguationState& ds,
                              int fnNum);
+
+static int testOpArgMapping(const DisambiguationContext& dctx,
+                            const DisambiguationCandidate& candidate1,
+                            const DisambiguationCandidate& candidate2,
+                            int actualIdx,
+                            DisambiguationState& ds,
+                            std::string& reason);
 
 static bool isFormalInstantiatedAny(const DisambiguationCandidate& candidate,
                                     const FormalActual* fa);
@@ -191,8 +212,9 @@ static QualifiedType computeActualScalarType(Context* context,
 
 static bool isNumericParamDefaultType(QualifiedType type);
 
-static bool moreSpecific(const DisambiguationContext& dctx,
-                         QualifiedType actualType, QualifiedType formalType);
+static bool moreSpecificCanDispatch(const DisambiguationContext& dctx,
+                                    QualifiedType actualType,
+                                    QualifiedType formalType);
 
 static MostSpecificCandidates
 computeMostSpecificCandidatesWithVecs(Context* context,
@@ -223,6 +245,12 @@ static void disambiguateDiscarding(const DisambiguationContext&   dctx,
                                    const CandidatesVec& candidates,
                                    bool ignoreWhere,
                                    std::vector<bool>&   discarded);
+
+static int prefersNumericCoercion(const DisambiguationContext& dctx,
+                                  QualifiedType f1Qt,
+                                  QualifiedType f2Qt,
+                                  QualifiedType actualQt,
+                                  std::string &reason);
 
 // count the number of candidates with each return intent
 static void countByReturnIntent(const DisambiguationContext& dctx,
@@ -644,6 +672,128 @@ findMostSpecificIgnoringReturn(const DisambiguationContext& dctx,
 
   \param candidate1 The function on the left-hand side of the comparison.
   \param candidate2 The function on the right-hand side of the comparison.
+
+
+  \return -1 if the two functions are incomparable
+  \return 0 if the two functions are equally specific
+  \return 1 if fn1 is a more specific function than f2
+  \return 2 if fn2 is a more specific function than f1
+ */
+static int compareSpecificity(const DisambiguationContext& dctx,
+                              const DisambiguationCandidate& candidate1,
+                              const DisambiguationCandidate& candidate2,
+                              int i,
+                              int j,
+                              bool forGenericInit) {
+
+  bool prefer1 = false;
+  bool prefer2 = false;
+  int n = dctx.call->numActuals();
+  int nArgsIncomparable = 0;
+  std::string reason;
+  DisambiguationState ds;
+
+  // Initializer work-around: Skip _mt/_this for generic initializers
+  int start = (forGenericInit == false) ? 0 : 2;
+
+  for (int k = start; k < n; k++) {
+
+    EXPLAIN("\nLooking at argument %d\n", k);
+    const FormalActual* fa1 = candidate1.formalActualMap.byActualIdx(k);
+    const FormalActual* fa2 = candidate2.formalActualMap.byActualIdx(k);
+
+    if (fa1 == nullptr || fa2 == nullptr) {
+      if (candidate1.fn->untyped()->kind()==Function::Kind::OPERATOR &&
+          candidate2.fn->untyped()->kind()==Function::Kind::OPERATOR) {
+        EXPLAIN("\nSkipping argument %d because could be in an operator call\n", k);
+        continue;
+      } else {
+        // One of the two candidate functions was not an operator, but one
+        // was so we need to do something special here.
+        int p = testOpArgMapping(dctx, candidate1, candidate2, k, ds, reason);
+        std::string reason = "operator method vs function";
+        if (p == 1) {
+          ds.fn1NonParamArgsPreferred = true;
+          EXPLAIN("%s: Fn %d is non-param preferred\n", reason, i);
+        } else if (p == 2) {
+          ds.fn2NonParamArgsPreferred = true;
+            EXPLAIN("%s: Fn %d is non-param preferred\n", reason, j);
+        }
+        continue;
+      }
+    }
+
+    bool actualParam = fa1->actualType().isParam();
+
+
+    int p = testArgMapping(dctx, candidate1, candidate2, k, ds, reason);
+    if (p == -1) {
+      nArgsIncomparable++;
+    }
+
+    if (actualParam) {
+      if (p == 1) {
+        ds.fn1ParamArgsPreferred = true;
+        EXPLAIN("%s: Fn %d is param preferred\n", reason, i);
+      } else if (p == 2) {
+        ds.fn2ParamArgsPreferred = true;
+        EXPLAIN("%s: Fn %d is param preferred\n", reason, j);
+      }
+    } else {
+      if (p == 1) {
+        ds.fn1NonParamArgsPreferred = true;
+        EXPLAIN("%s: Fn %d is non-param preferred\n", reason, i);
+      } else if (p == 2) {
+        ds.fn2NonParamArgsPreferred = true;
+        EXPLAIN("%s: Fn %d is non-param preferred\n", reason, j);
+      }
+    }
+  }
+  if (ds.fn1NonParamArgsPreferred != ds.fn2NonParamArgsPreferred) {
+    EXPLAIN("\nP: only one function has preferred non-param args\n");
+
+    prefer1 = ds.fn1NonParamArgsPreferred;
+    prefer2 = ds.fn2NonParamArgsPreferred;
+
+  } else if (ds.fn1ParamArgsPreferred != ds.fn2ParamArgsPreferred) {
+    EXPLAIN("\nP1: only one function has preferred param args\n");
+
+    prefer1 = ds.fn1ParamArgsPreferred;
+    prefer2 = ds.fn2ParamArgsPreferred;
+
+  }
+
+  if (prefer1) {
+    EXPLAIN("\nW: Fn %d is more specific than Fn %d\n", i, j);
+    return 1;
+
+  } else if (prefer2) {
+    EXPLAIN("\nW: Fn %d is less specific than Fn %d\n", i, j);
+    return 2;
+
+  } else {
+    if (nArgsIncomparable > 0 ||
+        (ds.fn1NonParamArgsPreferred && ds.fn2NonParamArgsPreferred) ||
+        (ds.fn1ParamArgsPreferred && ds.fn2ParamArgsPreferred)) {
+      EXPLAIN("\nW: Fn %d and Fn %d are incomparable\n", i, j);
+      return -1;
+    }
+
+    EXPLAIN("\nW: Fn %d and Fn %d are equally specific\n", i, j);
+    return 0;
+  }
+}
+
+/**
+
+  Determines if fn1 is a better match than fn2.
+
+  This function implements the function comparison component of the
+  disambiguation procedure as detailed in section 13.13 of the Chapel
+  language specification.
+
+  \param candidate1 The function on the left-hand side of the comparison.
+  \param candidate2 The function on the right-hand side of the comparison.
   \param ignoreWhere Set to `true` to ignore `where` clauses when
                      deciding if one match is better than another.
                      This is important for resolving return intent
@@ -751,6 +901,56 @@ static int compareSpecificity(const DisambiguationContext& dctx,
     return 0;
   }
 }
+
+/*
+ * Returns:
+ *   0 if there is no preference between them
+ *   1 if fn1 is preferred
+ *   2 if fn2 is preferred
+*/
+static int testOpArgMapping(const DisambiguationContext& dctx,
+                           const DisambiguationCandidate& candidate1,
+                           const DisambiguationCandidate& candidate2,
+                           int actualIdx,
+                           DisambiguationState& ds,
+                           std::string& reason) {
+  // Validate our assumptions in this function - only operator functions should
+  // return a NULL for the formal and they should only do so for method token
+  // and "this" actuals.
+
+  const FormalActual* fa1 = candidate1.formalActualMap.byActualIdx(actualIdx);
+  const FormalActual* fa2 = candidate2.formalActualMap.byActualIdx(actualIdx);
+
+  CHPL_ASSERT((candidate1.fn->untyped()->kind()==Function::Kind::OPERATOR) == (fa1 == nullptr));
+  CHPL_ASSERT((candidate2.fn->untyped()->kind()==Function::Kind::OPERATOR) == (fa2 == nullptr));
+  CHPL_ASSERT(fa1->actualType() == fa2->actualType());
+
+  if (fa1 == nullptr) {
+    CHPL_ASSERT(fa2 != nullptr);
+
+    bool formal2Promotes = false;
+    bool formal2Narrows = false;
+
+    testArgMapHelper(dctx, *fa2, candidate2.forwardingTo,
+                     &formal2Promotes, &formal2Narrows, ds, 2);
+    return 2;
+
+  } else {
+    CHPL_ASSERT(fa2 == nullptr);
+
+    bool formal1Promotes = false;
+    bool formal1Narrows = false;
+
+    testArgMapHelper(dctx, *fa1, candidate1.forwardingTo,
+                     &formal1Promotes, &formal1Narrows, ds, 1);
+
+    return 1;
+  }
+
+  return 0;
+
+}
+
 
 static MoreVisibleResult
 checkVisibilityInVec(Context* context,
@@ -1014,15 +1214,89 @@ computeIsMoreVisible(Context* context,
   return MoreVisibleResult::FOUND_NEITHER;
 }
 
-// body should be updated similar to match disambiguateDiscarding
-// current body gets into discardWorseArgs (new)
 
 // Discard any candidate that has a worse argument mapping than another
 // candidate.
 static void discardWorseArgs(const DisambiguationContext& dctx,
-                               const CandidatesVec& candidates,
-                               std::vector<bool>& discarded) {
-  // TODO: fill me in
+                             const CandidatesVec& candidates,
+                             std::vector<bool>& discarded) {
+  int n = candidates.size();
+
+  // If index i is set then we can skip testing function F_i because
+  // we already know it can not be the best match.
+  std::vector<bool> notBest(n, false);
+
+  for (int i = 0; i < n; i++) {
+    if (discarded[i]) {
+      continue;
+    }
+
+    EXPLAIN("##########################\n");
+    EXPLAIN("# Considering function %d #\n", i);
+    EXPLAIN("##########################\n\n");
+
+    const DisambiguationCandidate* candidate1 = candidates[i];
+
+    bool forGenericInit = candidate1->fn->untyped()->isMethod() &&
+                          (candidate1->fn->untyped()->name() == USTR("init") ||
+                           candidate1->fn->untyped()->name() == USTR("init="))
+
+    EXPLAIN_DUMP(candidate1->fn);
+
+    if (notBest[i]) {
+      EXPLAIN("Already known to not be best match.  Skipping.\n\n");
+      continue;
+    }
+
+    for (int j = 0; j < n; j++) {
+      if (i == j) {
+        continue;
+      }
+      if (discarded[j]) {
+        continue;
+      }
+
+      EXPLAIN("Comparing to function %d\n", j);
+      EXPLAIN("-----------------------\n");
+
+      const DisambiguationCandidate* candidate2 = candidates[j];
+
+      EXPLAIN_DUMP(candidate2->fn);
+
+      // Consider the relationship among the arguments
+      // Note that this part is a partial order;
+      // in other words, "incomparable" is an option when comparing
+      // two candidates.
+      int cmp = compareSpecificity(dctx, *candidate1, *candidate2, i, j, forGenericInit);
+
+      if (cmp == 1) {
+        EXPLAIN("X: Fn %d is a better match than Fn %d\n\n\n", i, j);
+        notBest[j] = true;
+
+      } else if (cmp == 2) {
+        EXPLAIN("X: Fn %d is a worse match than Fn %d\n\n\n", i, j);
+        notBest[i] = true;
+        break;
+      } else {
+        if (cmp == -1) {
+          EXPLAIN("X: Fn %d is incomparable with Fn %d\n\n\n", i, j);
+        } else if (cmp == 0) {
+          EXPLAIN("X: Fn %d is as good a match as Fn %d\n\n\n", i, j);
+          if (notBest[j]) {
+            notBest[i] = true;
+            break;
+          }
+        }
+      }
+    }
+  }
+
+  // Now, discard any candidates that were worse than another candidate
+  for (size_t i = 0; i < candidates.size(); ++i) {
+    if (notBest[i]) {
+      discarded[i] = true;
+    }
+  }
 }
 
 static void discardWorseWhereClauses(const DisambiguationContext& dctx,
@@ -1096,6 +1370,255 @@ moreVisible(const DisambiguationContext& dctx,
                           fn1Id, fn2Id);
 }
 
+/**
+  Compare two argument mappings, given a set of actual arguments, and set the
+  disambiguation state appropriately.
+
+  This function implements the argument mapping comparison component of the
+  disambiguation procedure as detailed in section 13.14.3 of the Chapel
+  language specification (page 107).
+
+  actualIdx is the index within the call of the argument to be compared.
+
+  Sets bits in DisambiguationState ds according to whether argument actualIdx
+  in candidate1 vs candidate2 is a better match.
+
+  Returns:
+   -1 if the two formals are incomparable
+    0 if the two formals have the same level of preference
+    1 if fn1 is preferred
+    2 if fn2 is preferred
+ */
+static int testArgMapping(const DisambiguationContext& dctx,
+                          const DisambiguationCandidate& candidate1,
+                          const DisambiguationCandidate& candidate2,
+                          int actualIdx,
+                          DisambiguationState& ds,
+                          std::string& reason) {
+
+  const FormalActual* fa1 = candidate1.formalActualMap.byActualIdx(actualIdx);
+  const FormalActual* fa2 = candidate2.formalActualMap.byActualIdx(actualIdx);
+
+  if (fa1 == nullptr || fa2 == nullptr) {
+
+    return testOpArgMapping(dctx, candidate1, candidate2, actualIdx, ds, reason);
+  }
+
+  QualifiedType f1Type = fa1->formalType();
+  QualifiedType f2Type = fa2->formalType();
+  QualifiedType actualType = fa1->actualType();
+  CHPL_ASSERT(actualType == fa2->actualType());
+
+  // Give up early for out intent arguments
+  // (these don't impact candidate selection)
+  if (f1Type.kind() == QualifiedType::OUT ||
+      f2Type.kind() == QualifiedType::OUT) {
+    return -1;
+  }
+
+  // We only want to deal with the value types here, avoiding odd overloads
+  // working (or not) due to _ref.
+  // TODO: not sure how to reproduce this code in Dyno
+
+  // Additionally, ignore the difference between referential tuples
+  // and value tuples.
+  // TODO: not sure how to reproduce this code in Dyno
+
+  // TODO: Not sure we still need this here, based on production
+  // Initializer work-around: Skip 'this' for generic initializers
+  // if (dctx.call->name() == USTR("init") || dctx.call->name() == USTR("init=")) {
+  //   auto nd1 = fa1->formal()->toNamedDecl();
+  //   auto nd2 = fa2->formal()->toNamedDecl();
+  //   if (nd1 != nullptr && nd2 != nullptr &&
+  //       nd1->name() == USTR("this") && nd2->name() == USTR("this")) {
+  //     if (getTypeGenericity(dctx.context, f1Type) != Type::CONCRETE &&
+  //         getTypeGenericity(dctx.context, f2Type) != Type::CONCRETE) {
+  //       return;
+  //     }
+  //   }
+  // }
+
+  bool formal1Promotes = false;
+  bool formal2Promotes = false;
+  bool formal1Narrows = false;
+  bool formal2Narrows = false;
+
+  QualifiedType actualScalarT = actualType;
+
+  bool f1Param = f1Type.hasParamPtr();
+  bool f2Param = f2Type.hasParamPtr();
+
+  bool f1Instantiated = fa1->formalInstantiated();
+  bool f2Instantiated = fa2->formalInstantiated();
+
+  bool f1InstantiatedFromAny = false;
+  bool f2InstantiatedFromAny = false;
+
+  bool f1PartiallyGeneric = false;
+  bool f2PartiallyGeneric = false;
+
+  if (f1Instantiated) {
+    f1InstantiatedFromAny = isFormalInstantiatedAny(candidate1, fa1);
+    f1PartiallyGeneric = isFormalPartiallyGeneric(candidate1, fa1);
+  }
+  if (f2Instantiated) {
+    f2InstantiatedFromAny = isFormalInstantiatedAny(candidate2, fa2);
+    f2PartiallyGeneric = isFormalPartiallyGeneric(candidate2, fa2);
+  }
+
+  bool actualParam = actualType.isParam();
+  EXPLAIN("Actual's type: ");
+  EXPLAIN_DUMP(&actualType);
+  if (actualParam)
+    EXPLAIN(" (param)");
+  EXPLAIN("\n");
+
+  // do some EXPLAIN calls
+  testArgMapHelper(dctx, *fa1, candidate1.forwardingTo,
+                   &formal1Promotes, &formal1Narrows, ds, 1);
+
+  testArgMapHelper(dctx, *fa2, candidate2.forwardingTo,
+                   &formal2Promotes, &formal2Narrows, ds, 2);
+
+  // Figure out scalar type for candidate matching
+  if (formal1Promotes || formal2Promotes) {
+    actualScalarT = computeActualScalarType(dctx.context, actualType);
+  }
+
+  // TODO: for sync/single use the valType
+
+  // consider promotion
+  if (!formal1Promotes && formal2Promotes) {
+    reason = "no promotin vs promotes";
+    return 1;
+  }
+
+  if (formal1Promotes && !formal2Promotes) {
+    reason = "no promotion vs promotes";
+    return 2;
+  }
+
+  // consider concrete vs generic functions
+  // note: the f1Type == f2Type part here is important
+  // and it prevents moving this logic out of the pairwise comparison.
+  // It is important e.g. for:
+  //   class Parent { }
+  //   class GenericChild : Parent { type t; }
+  // Here a GenericChild argument should be preferred to a Parent one
+  if (f1Type == f2Type) {
+    if (!f1Instantiated && f2Instantiated) {
+      reason = "concrete vs generic";
+      return 1;
+    }
+
+    if (f1Instantiated && !f2Instantiated) {
+      reason = "concrete vs generic";
+      return 2;
+    }
+
+    if (!f1InstantiatedFromAny && f2InstantiatedFromAny) {
+      reason = "generic any vs partially generic/concrete";
+      return 1;
+    }
+
+    if (f1InstantiatedFromAny && !f2InstantiatedFromAny) {
+      reason = "generic any vs partially generic/concrete";
+      return 2;
+    }
+
+    if (f1PartiallyGeneric && f2Instantiated && !f2PartiallyGeneric) {
+      reason = "partially generic vs generic";
+      return 1;
+    }
+
+    if (f1Instantiated && !f1PartiallyGeneric && f2PartiallyGeneric) {
+      reason = "partially generic vs generic";
+      return 2;
+    }
+  }
+
+  if (f1Param && !f2Param) {
+    reason = "param vs not";
+    return 1;
+  }
+
+  if (!f1Param && f2Param) {
+    reason = "param vs not";
+    return 2;
+  }
+
+  if (f1Type != f2Type) {
+    // to help with
+    // proc f(x: int(8))
+    // proc f(x: int(64))
+    // f(myInt32) vs. f(1: int(32)) should behave the same
+    if (actualParam) {
+      if (!formal1Narrows && formal2Narrows) {
+        reason = "param narrows vs not";
+        return 1;
+      }
+      if (formal1Narrows && !formal2Narrows) {
+        reason = "param narrows vs not";
+        return 2;
+      }
+    }
+    // e.g. to help with
+    //   sin(1) calling the real(64) version (vs real(32) version)
+    //
+    //   proc f(complex(64), complex(64))
+    //   proc f(complex(128), complex(128))
+    //   f(1.0, 1.0i) calling the complex(128) version
+
+    int p = prefersNumericCoercion(dctx, f1Type, f2Type, actualScalarT, reason);
+
+    if (p == 1) {
+      return 1;
+    }
+    if (p == 2) {
+      return 2;
+    }
+
+    if (actualType == f1Type && actualType != f2Type) {
+      reason = "actual type vs not";
+      return 1;
+    }
+
+    if (actualType == f2Type && actualType != f1Type) {
+      reason = "actual type vs not";
+      return 2;
+    }
+
+    if (actualScalarT == f1Type && actualScalarT != f2Type) {
+      reason = "scalar type vs not";
+      return 1;
+    }
+
+    if (actualScalarT == f2Type && actualScalarT != f1Type) {
+      reason = "scalar type vs not";
+      return 2;
+    }
+
+
+    bool fn1Dispatches = moreSpecificCanDispatch(dctx, f1Type, f2Type);
+    bool fn2Dispatches = moreSpecificCanDispatch(dctx, f2Type, f1Type);
+    if (fn1Dispatches && !fn2Dispatches) {
+      reason = "can dispatch";
+      return 1;
+    }
+    if (!fn1Dispatches && fn2Dispatches) {
+      reason = "can dispatch";
+      return 2;
+    }
+  }
+
+  if (f1Type == f2Type) {
+    // the formals are the same in terms of preference
+    return 0;
+  }
+
+  // the formals are incomparable
+  return -1;
+}
 
 /**
   Compare two argument mappings, given a set of actual arguments, and set the
@@ -1317,11 +1840,11 @@ static void testArgMapping(const DisambiguationContext& dctx,
 
     reason = "preferred coercion to other";
 
-  } else if (f1Type != f2Type && moreSpecific(dctx, f1Type, f2Type)) {
+  } else if (f1Type != f2Type && moreSpecificCanDispatch(dctx, f1Type, f2Type)) {
     prefer1 = actualParam ? WEAKEST : STRONG;
     reason = "can dispatch";
 
-  } else if (f1Type != f2Type && moreSpecific(dctx, f2Type, f1Type)) {
+  } else if (f1Type != f2Type && moreSpecificCanDispatch(dctx, f2Type, f1Type)) {
     prefer2 = actualParam ? WEAKEST : STRONG;
     reason = "can dispatch";
 
@@ -1379,14 +1902,6 @@ static void testArgMapHelper(const DisambiguationContext& dctx,
   CHPL_ASSERT(result.passes());
   *formalPromotes = result.promotes();
   *formalNarrows = result.convertsWithParamNarrowing();
-
-  if (fnNum == 1) {
-    ds.fn1Promotes |= *formalPromotes;
-  } else if (fnNum == 2) {
-    ds.fn2Promotes |= *formalPromotes;
-  } else {
-    CHPL_ASSERT(false && "fnNum should be either 1 or 2");
-  }
 
   EXPLAIN("Formal %d's type: ", fnNum);
   EXPLAIN_DUMP(&formalType);
@@ -1485,6 +2000,13 @@ static bool isDefaultUint(const Type* t) {
   return false;
 }
 
+static bool isDefaultImag(const Type* t) {
+  if (auto tt = t->toImagType())
+    return tt->isDefaultWidth();
+
+  return false;
+}
+
 static bool isDefaultReal(const Type* t) {
   if (auto tt = t->toRealType())
     return tt->isDefaultWidth();
@@ -1502,6 +2024,112 @@ static bool isDefaultComplex(const Type* t) {
 static int bitwidth(const Type* t) {
   if (auto tt = t->toPrimitiveType())
     return tt->bitwidth();
+
+  return 0;
+}
+
+// Returns:
+//   -1 if 't' is not a numeric type
+//   0 if 't' is a default numeric type ('int' 'bool' etc)
+//   n a positive integer width if 't' is a non-default numeric type
+static int classifyNumericWidth(QualifiedType* qt)
+{
+  const Type* t = qt->type();
+  // The default size counts as 0
+  if (isDefaultInt(t)     ||
+      isDefaultUint(t)    ||
+      isDefaultReal(t)    ||
+      isDefaultImag(t)    ||
+      isDefaultComplex(t))
+    return 0;
+
+  // Bool size 64 should be considered the same as int 64
+  // and just treat all bools the same
+  // to prefer the default size (i.e. int)
+  if (t->isBoolType())
+    return 0;
+
+  if (t->isIntType()  ||
+      t->isUintType() ||
+      t->isRealType() ||
+      t->isImagType() )
+    return bitwidth(t);
+
+  if (t->isComplexType())
+    return bitwidth(t) / 2;
+
+  return -1;
+}
+
+// This method implements rules such as that a bool would prefer to
+// coerce to 'int' over 'int(8)'.
+// Returns
+//  0 if there is no preference
+//  1 if f1Type is better
+//  2 if f2Type is better
+static int prefersNumericCoercion(const DisambiguationContext& dctx,
+                                  QualifiedType f1Qt,
+                                  QualifiedType f2Qt,
+                                  QualifiedType actualQt,
+                                  std::string &reason) {
+
+  const Type* actualType = actualQt.type();
+  const Type* f1Type = f1Qt.type();
+  const Type* f2Type = f2Qt.type();
+
+  int acWidth = classifyNumericWidth(&actualQt);
+  int f1Width = classifyNumericWidth(&f1Qt);
+  int f2Width = classifyNumericWidth(&f2Qt);
+
+  if (acWidth < 0 || f1Width < 0 || f2Width < 0) {
+    // something is not a numeric type
+    return 0;
+  }
+
+  numeric_type_t acKind = classifyNumericType(actualType);
+  numeric_type_t f1Kind = classifyNumericType(f1Type);
+  numeric_type_t f2Kind = classifyNumericType(f2Type);
+
+  if (acKind == f1Kind && acKind != f2Kind) {
+    reason = "same numeric kind";
+    return 1;
+  }
+  if (acKind != f1Kind && acKind == f2Kind) {
+    reason = "same numeric kind";
+    return 2;
+  }
+// Otherwise, prefer the function with the same numeric width
+  // as the actual. This rule helps this case:
+  //
+  //  proc f(arg: real(32))
+  //  proc f(arg: real(64))
+  //  f(myInt64)
+  //
+  // here we desire to call f(real(64)) e.g. for sin(1)
+  //
+  // Additionally, it impacts this case:
+  //  proc f(a: real(32), b: real(32))
+  //  proc f(a: real(64), b: real(64))
+  //  f(myInt64, 1.0)
+  // (it arranges for it to call the real(64) version vs the real(32) one)
+  if (acWidth == f1Width && acWidth != f2Width) {
+    reason = "same numeric width";
+    return 1;
+  }
+
+  if (acWidth != f1Width && acWidth == f2Width) {
+    reason = "same numeric width";
+    return 2;
+  }
+
+  // note that if in the future we allow more numeric coercions,
+  // we might need to make this function complete
+  // (where currently it falls back on the "can dispatch" check
+  //  in some cases). E.g. it could finish up by comparing
+  // the two formal types in terms of their index in this list:
+  //
+  //  int(8) uint(8) int(16) uint(16) int(32) uint(32) int(64) uint(64)
+  //  real(32) real(64) imag(32) real(64) complex(64) complex(128)
 
   return 0;
 }
@@ -1588,7 +2216,7 @@ static bool isNumericParamDefaultType(QualifiedType type) {
   return false;
 }
 
-static bool moreSpecific(const DisambiguationContext& dctx,
+static bool moreSpecificCanDispatch(const DisambiguationContext& dctx,
                          QualifiedType actualType, QualifiedType formalType) {
   CanPassResult result = canPass(dctx.context, actualType, formalType);
 


### PR DESCRIPTION
This PR implements the `discardWorseArgs` function for Dyno disambiguation. This PR is part 7 of a series of PRs that implement disambiguation changes already in production from https://github.com/chapel-lang/chapel/pull/20528.

Also implemented in this PR are several supporting helper functions for `discardWorseArgs`.

There is future work to implement rules ignoring the differences between ref and value tuples.

[reviewed by @mppf - thanks!]