### PR TITLE
Make driver mode `--print-passes` output more accurate and useful

### DIFF
--- a/compiler/main/PhaseTracker.cpp
+++ b/compiler/main/PhaseTracker.cpp
@@ -177,6 +177,7 @@ static const char* passGroups[][2] = {
 
 void PhaseTracker::ReportTotal(std::vector<unsigned long>* groupTimes) const
 {
+  printf("entered reporttotal\n");
   // Capture total time up to this point
   const unsigned long measuredTotalTime = mTimer.elapsedUsecs();
   static const size_t numMetapasses =
@@ -191,7 +192,6 @@ void PhaseTracker::ReportTotal(std::vector<unsigned long>* groupTimes) const
                "expected one saved time value per pass group to report");
   }
 
-  auto currentPass = mPhases.begin();
   unsigned long lastStart = 0;
   unsigned long passTime;
   for (size_t i = 0; i < numMetapasses; i++) {
@@ -199,13 +199,22 @@ void PhaseTracker::ReportTotal(std::vector<unsigned long>* groupTimes) const
       // No times provided, so calculate them.
 
       const char* groupLastPhase = passGroups[i][1];
+      gdbShouldBreakHere();
+      auto currentPass = mPhases.begin();
+      /* while (currentPass != mPhases.end()) { */
+      /*   if ((*currentPass)->mName != nullptr) { */
+      /*     if (strcmp((*currentPass)->mName, groupLastPhase) == 0) break; */
+      /*   } */
+      /*   currentPass++; */
+      /* } */
+      /* gdbShouldBreakHere(); */
       currentPass = std::find_if(currentPass, mPhases.end(), [&](auto pass) {
         if (pass->mName == nullptr) return false;
         return strcmp(pass->mName, groupLastPhase) == 0;
       });
 
       // No such pass, we might've exited early.
-      if (currentPass == mPhases.end()) break;
+      if (currentPass == mPhases.end()) continue;
       auto nextPass = currentPass + 1;
 
       if (nextPass != mPhases.end()) {
@@ -220,6 +229,8 @@ void PhaseTracker::ReportTotal(std::vector<unsigned long>* groupTimes) const
 
       passTime = (*groupTimes)[i];
     }
+
+    printf("got time value %zu for pass %zu\n", passTime, i);
 
     if (saveToList) {
       // Save time to output list

--- a/compiler/main/PhaseTracker.cpp
+++ b/compiler/main/PhaseTracker.cpp
@@ -215,10 +215,16 @@ void PhaseTracker::ReportRollup() const
   PassesCollect(passes);
   PassesReport(passes, totalTime);
 
-  PhaseTracker::ReportText("\n\n\n");
+  // Repeat the information but sorted by time, for monolithic mode or driver
+  // phase one.
+  // Skipped for driver overhead time or driver phase two as they contain very
+  // little information and the sort isn't that informative.
+  if (fDriverDoMonolithic || fDriverPhaseOne) {
+    PhaseTracker::ReportText("\n\n\n");
 
-  PassesSortByTime(passes);
-  PassesReport(passes, totalTime);
+    PassesSortByTime(passes);
+    PassesReport(passes, totalTime);
+  }
 }
 
 void PhaseTracker::PassesCollect(std::vector<Pass>& passes) const

--- a/compiler/main/PhaseTracker.cpp
+++ b/compiler/main/PhaseTracker.cpp
@@ -174,15 +174,14 @@ void PhaseTracker::ReportPassGroupTotals(
 }
 
 void PhaseTracker::ReportOverallTotal(long long overheadTime) const {
+  // Measure time so far
   unsigned long totalTime = mTimer.elapsedUsecs();
-  std::string msg = "total time";
-
+  // Add overhead if used
   if (overheadTime >= 0) {
-    totalTime += (unsigned long) overheadTime;
-    msg += " (including overhead)";
+    totalTime += overheadTime;
   }
 
-  Phase::ReportTime(msg.c_str(), totalTime / 1e6);
+  Phase::ReportTime("total time", totalTime / 1e6);
   Phase::ReportText("\n\n\n\n");
 }
 

--- a/compiler/main/PhaseTracker.cpp
+++ b/compiler/main/PhaseTracker.cpp
@@ -27,65 +27,6 @@
 #include <cstring>
 #include <algorithm>
 
-// Used to collect the times as the program runs
-class Phase
-{
-public:
-                           Phase(const char*            name,
-                                 int                    passId,
-                                 PhaseTracker::SubPhase subPhase,
-                                 unsigned long          startTime);
-                          ~Phase();
-
-  bool                     IsStartOfPass()                            const;
-
-  void                     ReportPass (unsigned long now)   const;
-  static void              ReportTotal(unsigned long totalTime);
-  static void              ReportPassGroup(const char* text,
-                                           unsigned long totalTime);
-
-  static void              ReportTime(const char* name, double secs);
-
-  char*                    mName;       // Only set for kPrimary
-  int                      mPassId;
-  PhaseTracker::SubPhase   mSubPhase;
-  unsigned long            mStartTime;  // Elapsed time from main() usecs
-
-private:
-  Phase();
-};
-
-// Group the phases in to passes and report on passes
-class Pass
-{
-public:
-                 Pass();
-                ~Pass();
-
-  static void    Header(FILE* fp);
-  static void    Footer(FILE*         fp,
-                        unsigned long mainTime,
-                        unsigned long checkTime,
-                        unsigned long cleanTime,
-                        unsigned long totalTime);
-
-  bool           CompareByTime(Pass const& ref)      const;
-
-  void           Reset();
-  unsigned long  TotalTime()                         const;
-
-  void           Print(FILE*         fp,
-                       unsigned long accumTime,
-                       unsigned long totalTime)      const;
-
-  char*          mName;
-  int            mPassId;
-  int            mIndex;
-  unsigned long  mPrimary;          // usecs()
-  unsigned long  mVerify;           // usecs()
-  unsigned long  mCleanAst;         // usecs()
-};
-
 struct SortByTime
 {
   bool operator() (Pass const& a, Pass const& b) const
@@ -242,7 +183,7 @@ void PhaseTracker::ReportOverallTotal(long long overheadTime) const {
   }
 
   Phase::ReportTime(msg.c_str(), totalTime / 1e6);
-  PhaseTracker::ReportText("\n\n\n\n");
+  Phase::ReportText("\n\n\n\n");
 }
 
 void PhaseTracker::ReportRollup() const
@@ -258,7 +199,7 @@ void PhaseTracker::ReportRollup() const
   // Skipped for driver overhead time or driver phase two as they contain very
   // little information and the sort isn't that informative.
   if (fDriverDoMonolithic || fDriverPhaseOne) {
-    PhaseTracker::ReportText("\n\n\n");
+    Phase::ReportText("\n\n\n");
 
     PassesSortByTime(passes);
     PassesReport(passes, totalTime);
@@ -400,22 +341,22 @@ void Phase::ReportPass(unsigned long now) const
 
     snprintf(text, sizeof(text), "  [%9d]", lastNodeIDUsed());
 
-    PhaseTracker::ReportText(text);
+    ReportText(text);
   }
 
-  PhaseTracker::ReportText("\n");
+  ReportText("\n");
 }
 
 void Phase::ReportTotal(unsigned long totalTime)
 {
   ReportTime("total time", totalTime / 1e6);
-  PhaseTracker::ReportText("\n\n\n\n");
+  ReportText("\n\n\n\n");
 }
 
 void Phase::ReportPassGroup(const char* label, unsigned long totalTime)
 {
   ReportTime(label, totalTime / 1e6);
-  PhaseTracker::ReportText("\n");
+  ReportText("\n");
 }
 
 void Phase::ReportTime(const char* name, double secs)
@@ -427,7 +368,7 @@ void Phase::ReportTime(const char* name, double secs)
     fprintf(printPassesFile, "%32s :%8.3f seconds", name, secs);
 }
 
-void PhaseTracker::ReportText(const char* text)
+void Phase::ReportText(const char* text)
 {
   if (printPasses     == true)
     fputs(text, stderr);

--- a/compiler/main/PhaseTracker.cpp
+++ b/compiler/main/PhaseTracker.cpp
@@ -45,7 +45,6 @@ public:
                                            unsigned long totalTime);
 
   static void              ReportTime(const char* name, double secs);
-  static void              ReportText(const char* text);
 
   char*                    mName;       // Only set for kPrimary
   int                      mPassId;
@@ -153,6 +152,11 @@ void PhaseTracker::Stop()
   mTimer.stop();
 }
 
+void PhaseTracker::Resume()
+{
+  mTimer.start();
+}
+
 void PhaseTracker::ReportPass() const
 {
   int index = mPhases.size() - 1;
@@ -211,7 +215,7 @@ void PhaseTracker::ReportRollup() const
   PassesCollect(passes);
   PassesReport(passes, totalTime);
 
-  Phase::ReportText("\n\n\n");
+  PhaseTracker::ReportText("\n\n\n");
 
   PassesSortByTime(passes);
   PassesReport(passes, totalTime);
@@ -352,22 +356,22 @@ void Phase::ReportPass(unsigned long now) const
 
     snprintf(text, sizeof(text), "  [%9d]", lastNodeIDUsed());
 
-    ReportText(text);
+    PhaseTracker::ReportText(text);
   }
 
-  ReportText("\n");
+  PhaseTracker::ReportText("\n");
 }
 
 void Phase::ReportTotal(unsigned long totalTime)
 {
   ReportTime("total time", totalTime / 1e6);
-  ReportText("\n\n\n\n");
+  PhaseTracker::ReportText("\n\n\n\n");
 }
 
 void Phase::ReportPassGroup(const char* label, unsigned long totalTime)
 {
   ReportTime(label, totalTime / 1e6);
-  ReportText("\n");
+  PhaseTracker::ReportText("\n");
 }
 
 void Phase::ReportTime(const char* name, double secs)
@@ -379,7 +383,7 @@ void Phase::ReportTime(const char* name, double secs)
     fprintf(printPassesFile, "%32s :%8.3f seconds", name, secs);
 }
 
-void Phase::ReportText(const char* text)
+void PhaseTracker::ReportText(const char* text)
 {
   if (printPasses     == true)
     fputs(text, stderr);

--- a/compiler/main/PhaseTracker.h
+++ b/compiler/main/PhaseTracker.h
@@ -82,7 +82,12 @@ public:
   void                 Resume();
 
   void                 ReportPass  ()                                const;
-  void                 ReportTotal ()                                const;
+  // Report out total times, by pass group and total overall. If the parameter
+  // is an empty list, instead insert times into it and skip output. If it is
+  // a list with values, take these as already-recorded times and report them
+  // out. If it is nullptr, ignore it and report as normal.
+  void                 ReportTotal (std::vector<unsigned long>*
+                                             groupTimes = nullptr)   const;
 
   void                 ReportRollup()                                const;
 

--- a/compiler/main/PhaseTracker.h
+++ b/compiler/main/PhaseTracker.h
@@ -89,9 +89,8 @@ public:
   void                 ReportPassGroupTotals (std::vector<unsigned long>*
                                               groupTimes = nullptr)  const;
   // Report out total overall time for the compiler. If overheadTime is
-  // negative, it is unused, otherwise add it to the total time and note in
-  // report that it includes overhead. If positive it must fit in an unsigned
-  // long.
+  // negative, it is unused, otherwise add it to the total time.
+  // If positive it must fit in an unsigned long.
   void                 ReportOverallTotal (long long
                                            overheadTime = -1)        const;
 

--- a/compiler/main/PhaseTracker.h
+++ b/compiler/main/PhaseTracker.h
@@ -97,8 +97,6 @@ public:
 
   void                 ReportRollup()                                const;
 
-  static void          ReportText(const char* text);
-
 private:
   void                 PassesCollect(std::vector<Pass>& passes) const;
 
@@ -109,6 +107,66 @@ private:
   Timer                mTimer;
   int                  mPhaseId;
   std::vector<Phase*>  mPhases;
+};
+
+// Used to collect the times as the program runs
+class Phase
+{
+public:
+                           Phase(const char*            name,
+                                 int                    passId,
+                                 PhaseTracker::SubPhase subPhase,
+                                 unsigned long          startTime);
+                          ~Phase();
+
+  bool                     IsStartOfPass()                            const;
+
+  void                     ReportPass (unsigned long now)   const;
+  static void              ReportTotal(unsigned long totalTime);
+  static void              ReportPassGroup(const char* text,
+                                           unsigned long totalTime);
+
+  static void              ReportTime(const char* name, double secs);
+  static void              ReportText(const char* text);
+
+  char*                    mName;       // Only set for kPrimary
+  int                      mPassId;
+  PhaseTracker::SubPhase   mSubPhase;
+  unsigned long            mStartTime;  // Elapsed time from main() usecs
+
+private:
+  Phase();
+};
+
+// Group the phases in to passes and report on passes
+class Pass
+{
+public:
+                 Pass();
+                ~Pass();
+
+  static void    Header(FILE* fp);
+  static void    Footer(FILE*         fp,
+                        unsigned long mainTime,
+                        unsigned long checkTime,
+                        unsigned long cleanTime,
+                        unsigned long totalTime);
+
+  bool           CompareByTime(Pass const& ref)      const;
+
+  void           Reset();
+  unsigned long  TotalTime()                         const;
+
+  void           Print(FILE*         fp,
+                       unsigned long accumTime,
+                       unsigned long totalTime)      const;
+
+  char*          mName;
+  int            mPassId;
+  int            mIndex;
+  unsigned long  mPrimary;          // usecs()
+  unsigned long  mVerify;           // usecs()
+  unsigned long  mCleanAst;         // usecs()
 };
 
 #endif

--- a/compiler/main/PhaseTracker.h
+++ b/compiler/main/PhaseTracker.h
@@ -82,10 +82,13 @@ public:
   void                 Resume();
 
   void                 ReportPass  ()                                const;
-  // Report out total times by pass group. If the parameter
-  // is an empty list, instead insert times into it and skip output. If it is
-  // a list with values, take these as already-recorded times and report them
-  // out. If it is nullptr, ignore it and report as normal.
+  // Report out total times by pass group, with differing behavior based on the
+  // provided argument:
+  // - nullptr: Ignore it and report as normal.
+  // - empty list: Instead insert times into it and skip outputing.
+  // - non-empty list: Take the values as already-recorded times and report
+  // them out. They are assumed to represent pass group times in order, with
+  // missing values meaning that pass group did not occur (early exit).
   void                 ReportPassGroupTotals (std::vector<unsigned long>*
                                               groupTimes = nullptr)  const;
   // Report out total overall time for the compiler. If overheadTime is

--- a/compiler/main/PhaseTracker.h
+++ b/compiler/main/PhaseTracker.h
@@ -47,7 +47,7 @@
 * Every phase has a descriptive name that will be used by the reports.        *
 *                                                                             *
 * The main loop for the compiler, in runpasses.cpp, has a notion of a "pass"  *
-* consists of three phases;                                                   *
+* which consists of three phases;                                             *
 *                                                                             *
 *    1) The primary computation                                               *
 *    2) An optional verify / check phase                                      *

--- a/compiler/main/PhaseTracker.h
+++ b/compiler/main/PhaseTracker.h
@@ -82,12 +82,18 @@ public:
   void                 Resume();
 
   void                 ReportPass  ()                                const;
-  // Report out total times, by pass group and total overall. If the parameter
+  // Report out total times by pass group. If the parameter
   // is an empty list, instead insert times into it and skip output. If it is
   // a list with values, take these as already-recorded times and report them
   // out. If it is nullptr, ignore it and report as normal.
-  void                 ReportTotal (std::vector<unsigned long>*
-                                             groupTimes = nullptr)   const;
+  void                 ReportPassGroupTotals (std::vector<unsigned long>*
+                                              groupTimes = nullptr)  const;
+  // Report out total overall time for the compiler. If overheadTime is
+  // negative, it is unused, otherwise add it to the total time and note in
+  // report that it includes overhead. If positive it must fit in an unsigned
+  // long.
+  void                 ReportOverallTotal (long long
+                                           overheadTime = -1)        const;
 
   void                 ReportRollup()                                const;
 

--- a/compiler/main/PhaseTracker.h
+++ b/compiler/main/PhaseTracker.h
@@ -79,11 +79,14 @@ public:
   void                 StartPhase(const char* passName, SubPhase subPhase);
 
   void                 Stop();
+  void                 Resume();
 
   void                 ReportPass  ()                                const;
   void                 ReportTotal ()                                const;
 
   void                 ReportRollup()                                const;
+
+  static void          ReportText(const char* text);
 
 private:
   void                 PassesCollect(std::vector<Pass>& passes) const;

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -2422,7 +2422,7 @@ int main(int argc, char* argv[]) {
 
   if (!fDriverDoMonolithic && !driverInSubInvocation) {
     // Begin reporting driver init process timing
-    PhaseTracker::ReportText(
+    Phase::ReportText(
         "\n\nTiming for driver mode overhead\n--------------\n");
     tracker.ReportPass();
   }

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -2422,7 +2422,7 @@ int main(int argc, char* argv[]) {
   if (!fDriverDoMonolithic && !driverInSubInvocation) {
     // Begin reporting driver init process timing
     PhaseTracker::ReportText(
-        "Timing for driver mode overhead\n--------------\n");
+        "\n\nTiming for driver mode overhead\n--------------\n");
     tracker.ReportPass();
   }
 

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -2476,7 +2476,9 @@ int main(int argc, char* argv[]) {
         // We expect frontend, middle-end, and backend results from phase one,
         // plus the other half of backend results from phase two.
         static const size_t numPassGroups = 3;
-        INT_ASSERT(groupTimes.size() == (numPassGroups + 1));
+        INT_ASSERT(
+            groupTimes.size() == (numPassGroups + 1) &&
+            "unexpected number of saved timing results from driver phases");
         // Combine the two halves of the backend total time into one value.
         groupTimes[numPassGroups - 1] += groupTimes[numPassGroups];
         groupTimes.pop_back();

--- a/compiler/main/runpasses.cpp
+++ b/compiler/main/runpasses.cpp
@@ -189,7 +189,8 @@ void runPasses(PhaseTracker& tracker) {
     if (fDriverPhaseOne) {
       PhaseTracker::ReportText("Timing for driver phase one\n--------------\n");
     } else if (fDriverPhaseTwo) {
-      PhaseTracker::ReportText("Timing for driver phase two\n--------------\n");
+      PhaseTracker::ReportText(
+          "\n\nTiming for driver phase two\n--------------\n");
     }
     tracker.ReportPass();
   }

--- a/compiler/main/runpasses.cpp
+++ b/compiler/main/runpasses.cpp
@@ -187,10 +187,9 @@ void runPasses(PhaseTracker& tracker) {
 
   if (printPasses == true || printPassesFile != 0) {
     if (fDriverPhaseOne) {
-      PhaseTracker::ReportText("Timing for driver phase one\n--------------\n");
+      Phase::ReportText("Timing for driver phase one\n--------------\n");
     } else if (fDriverPhaseTwo) {
-      PhaseTracker::ReportText(
-          "\n\nTiming for driver phase two\n--------------\n");
+      Phase::ReportText("\n\nTiming for driver phase two\n--------------\n");
     }
     tracker.ReportPass();
   }

--- a/compiler/main/runpasses.cpp
+++ b/compiler/main/runpasses.cpp
@@ -186,6 +186,11 @@ void runPasses(PhaseTracker& tracker) {
   setupLogfiles();
 
   if (printPasses == true || printPassesFile != 0) {
+    if (fDriverPhaseOne) {
+      PhaseTracker::ReportText("Timing for driver phase one\n--------------\n");
+    } else if (fDriverPhaseTwo) {
+      PhaseTracker::ReportText("Timing for driver phase two\n--------------\n");
+    }
     tracker.ReportPass();
   }
 

--- a/test/compflags/stopEarly/parseOnly.prediff
+++ b/test/compflags/stopEarly/parseOnly.prediff
@@ -6,8 +6,14 @@ tmpfile=$2
 tmptmp=`mktemp "tmp.XXXXXX"`
 cp $tmpfile $tmptmp
 
-# extract just names of passes run
+# exclude lines that don't start with whitespace since they are headers, not
+# pass names
+grep '^\s.*' $tmptmp > $tmpfile
+
+# extract lines with pass names
 sed '5,$ d' $tmpfile > $tmptmp
+
+# extract pass names from lines
 awk '{print $1}' $tmptmp > $tmpfile
 
 rm $tmptmp

--- a/test/performance/compiler/elliot/passCheck.prediff
+++ b/test/performance/compiler/elliot/passCheck.prediff
@@ -32,8 +32,10 @@ with open(logfile, 'r') as f:
 with open(logfile, 'w') as f:
     for line in loglines:
       splitline = line.split(':')[0].strip() + ' :'
-      # Only look at the pass groups (front-end, middle-end, back-end)
-      if line.strip().startswith('total time'):
+      # Only look at the pass groups (front-end, middle-end, back-end) and
+      # overall total time. Skip lines without ':' to exclude the 'total time'
+      # line at the bottom of pass timing tables, which isn't in the perfkeys.
+      if line.strip().startswith('total time') and ':' in line.strip():
           f.write(splitline + '\n')
       # --print-passes prints detailed output after printing the total
       # time for each pass. This just strips all that output which


### PR DESCRIPTION
Make significant changes to the output of `--print-passes` in driver mode so it accurately times each pass group as well as the overall time, displays this information more clearly, and is compatible with our performance testing.

Changes to `--print-passes` output (in driver mode only unless otherwise specified):
- In both monolithic and driver mode, the total times per pass group and overall total time are now displayed at the end of all output. Previously in monolithic mode this information was displayed immediately after individual pass timings.
- Besides these sweeping totals, normal `--print-passes` output is now displayed three times: for phase one, phase two, then for driver overhead. Each section begins with a header, contains only the passes that run in that process; driver overhead does not contain any "real" compiler passes, only initialization and teardown. The section for phase one includes the pass table followed by the pass table again but sorted, as before; the other sections skip the sorted table version.
  - Driver overhead is measured by starting the timer at the beginning of `main` (as before), pausing it before invoking sub-processes, resuming it after, then finally stopping it as immediately before reporting out as possible.
- The overall "total time" field displayed at the end now contains the driver overhead time, so it is consistently larger (by ~0.25s) than the sum of the front-end, middle-end, and back-end times. Almost all of the driver overhead footprint is work that monolithic mode accounts for as front-end time.

Reviewer notes:
- This work is affected by the bug resolved in https://github.com/chapel-lang/chapel/pull/23856, so that PR should be merged first, but it doesn't affect testing or reviewing _this_ PR except with `--savec`.
- This PR updates `passCheck.prediff` against the advice of the comment in that file, however I believe it's correct as I think the `--print-passes` output order change affects how that `prediff` filters lines but not what the `perfkeys` will pick up on.
- Example output of `--print-passes` in driver mode is included below for the record, but it's likely easier to just run it yourself.

<details>
<summary>Example `--print-passes` output in driver mode</summary>

Timing for driver phase one
--------------
                            init :   0.001 seconds  [      285]
             parseAndConvertUast :   1.620 seconds  [   409577]
                       checkUast :   0.077 seconds  [   409577]
                     readExternC :   0.006 seconds  [   409577]
          expandExternArrayCalls :   0.007 seconds  [   409577]
                         cleanup :   0.087 seconds  [   410945]
                    scopeResolve :   0.881 seconds  [   494007]
                  flattenClasses :   0.006 seconds  [   494007]
                       normalize :   0.676 seconds  [   920518]
                 checkNormalized :   0.015 seconds  [   920518]
           buildDefaultFunctions :   0.194 seconds  [  1217758]
             createTaskFunctions :   0.026 seconds  [  1219086]
                         resolve :   3.367 seconds  [  2019535]
                  resolveIntents :   0.012 seconds  [  2019535]
                   checkResolved :   0.015 seconds  [  2019535]
replaceArrayAccessesWithRefTemps :   0.006 seconds  [  2019535]
                flattenFunctions :   0.009 seconds  [  2019878]
              cullOverReferences :   0.028 seconds  [  2019998]
              lowerErrorHandling :   0.022 seconds  [  2024771]
                 callDestructors :   0.579 seconds  [  2047007]
                  lowerIterators :   0.116 seconds  [  2185830]
                        parallel :   0.131 seconds  [  2193901]
                           prune :   0.041 seconds  [  2193901]
                 bulkCopyRecords :   0.006 seconds  [  2194105]
  removeUnnecessaryAutoCopyCalls :   0.005 seconds  [  2194105]
                 inlineFunctions :   0.245 seconds  [  2368027]
                   scalarReplace :   0.019 seconds  [  2380952]
                  refPropagation :   0.069 seconds  [  2388684]
                 copyPropagation :   0.422 seconds  [  2388684]
             deadCodeElimination :   0.086 seconds  [  2391937]
              removeEmptyRecords :   0.003 seconds  [  2391937]
                 localizeGlobals :   0.010 seconds  [  2392250]
         loopInvariantCodeMotion :   0.176 seconds  [  2392250]
                          prune2 :   0.015 seconds  [  2392250]
       returnStarTuplesByRefArgs :   0.005 seconds  [  2392377]
            insertWideReferences :   0.006 seconds  [  2392382]
               optimizeOnClauses :   0.022 seconds  [  2392382]
                    addInitCalls :   0.004 seconds  [  2396430]
               insertLineNumbers :   0.037 seconds  [  2411218]
                     denormalize :   0.083 seconds  [  2411624]
                         codegen :   0.440 seconds  [  2413207]
                   driverCleanup :   0.000 seconds  [  2413207]
Pass               Name                   Main    Check    Clean     Time    %     Accum    %
---- ---------------------------------  -------  -------  -------  ------- -----  ------- -----
     startup                              0.000    0.000    0.000    0.000   0.0    0.000   0.0
     init                                 0.001    0.000    0.000    0.001   0.0    0.002   0.0
   1 parseAndConvertUast                  1.613    0.000    0.008    1.620  16.9    1.622  16.9
   2 checkUast                            0.069    0.001    0.006    0.077   0.8    1.698  17.7
   3 readExternC                          0.000    0.000    0.006    0.006   0.1    1.704  17.8
   4 expandExternArrayCalls               0.001    0.000    0.006    0.007   0.1    1.711  17.8
   5 cleanup                              0.080    0.000    0.007    0.087   0.9    1.798  18.7
   6 scopeResolve                         0.870    0.001    0.010    0.881   9.2    2.680  27.9
   7 flattenClasses                       0.000    0.000    0.006    0.006   0.1    2.685  28.0
   8 normalize                            0.661    0.000    0.014    0.676   7.0    3.361  35.0
   9 checkNormalized                      0.002    0.000    0.013    0.015   0.2    3.376  35.2
  10 buildDefaultFunctions                0.174    0.000    0.020    0.194   2.0    3.570  37.2
  11 createTaskFunctions                  0.004    0.002    0.019    0.026   0.3    3.596  37.5
  12 resolve                              3.286    0.007    0.074    3.367  35.1    6.963  72.6
  13 resolveIntents                       0.005    0.000    0.006    0.012   0.1    6.975  72.7
  14 checkResolved                        0.008    0.000    0.007    0.015   0.2    6.991  72.9
  15 replaceArrayAccessesWithRefTemps     0.000    0.000    0.006    0.006   0.1    6.997  73.0
  16 flattenFunctions                     0.003    0.000    0.007    0.009   0.1    7.006  73.1
  17 cullOverReferences                   0.018    0.002    0.007    0.028   0.3    7.034  73.3
  18 lowerErrorHandling                   0.016    0.000    0.007    0.022   0.2    7.056  73.6
  19 callDestructors                      0.571    0.000    0.008    0.579   6.0    7.635  79.6
  20 lowerIterators                       0.104    0.001    0.011    0.116   1.2    7.751  80.8
  21 parallel                             0.121    0.001    0.009    0.131   1.4    7.883  82.2
  22 prune                                0.023    0.001    0.017    0.041   0.4    7.924  82.6
  23 bulkCopyRecords                      0.000    0.001    0.005    0.006   0.1    7.930  82.7
  24 removeUnnecessaryAutoCopyCalls       0.001    0.000    0.004    0.005   0.1    7.935  82.7
  25 inlineFunctions                      0.228    0.001    0.015    0.245   2.6    8.180  85.3
  26 scalarReplace                        0.012    0.001    0.006    0.019   0.2    8.198  85.5
  27 refPropagation                       0.061    0.001    0.007    0.069   0.7    8.267  86.2
  28 copyPropagation                      0.415    0.001    0.007    0.422   4.4    8.689  90.6
  29 deadCodeElimination                  0.081    0.001    0.004    0.086   0.9    8.775  91.5
  30 removeEmptyRecords                   0.000    0.000    0.003    0.003   0.0    8.778  91.5
  31 localizeGlobals                      0.007    0.000    0.003    0.010   0.1    8.788  91.6
  32 loopInvariantCodeMotion              0.171    0.001    0.004    0.176   1.8    8.963  93.5
  33 prune2                               0.011    0.000    0.003    0.015   0.2    8.978  93.6
  34 returnStarTuplesByRefArgs            0.002    0.000    0.003    0.005   0.0    8.983  93.7
  35 insertWideReferences                 0.002    0.000    0.003    0.006   0.1    8.989  93.7
  36 optimizeOnClauses                    0.019    0.000    0.003    0.022   0.2    9.011  94.0
  37 addInitCalls                         0.001    0.000    0.003    0.004   0.0    9.015  94.0
  38 insertLineNumbers                    0.032    0.001    0.004    0.037   0.4    9.052  94.4
  39 denormalize                          0.078    0.000    0.005    0.083   0.9    9.134  95.2
  40 codegen                              0.435    0.000    0.021    0.456   4.8    9.591 100.0
     driverCleanup                        0.000    0.000    0.000    0.000   0.0    9.591 100.0

     total time                           9.189    0.027    0.375    9.591



Pass               Name                   Main    Check    Clean     Time    %     Accum    %
---- ---------------------------------  -------  -------  -------  ------- -----  ------- -----
  12 resolve                              3.286    0.007    0.074    3.367  35.1    3.367  35.1
   1 parseAndConvertUast                  1.613    0.000    0.008    1.620  16.9    4.988  52.0
   6 scopeResolve                         0.870    0.001    0.010    0.881   9.2    5.869  61.2
   8 normalize                            0.661    0.000    0.014    0.676   7.0    6.544  68.2
  19 callDestructors                      0.571    0.000    0.008    0.579   6.0    7.123  74.3
  40 codegen                              0.435    0.000    0.021    0.456   4.8    7.580  79.0
  28 copyPropagation                      0.415    0.001    0.007    0.422   4.4    8.002  83.4
  25 inlineFunctions                      0.228    0.001    0.015    0.245   2.6    8.247  86.0
  10 buildDefaultFunctions                0.174    0.000    0.020    0.194   2.0    8.441  88.0
  32 loopInvariantCodeMotion              0.171    0.001    0.004    0.176   1.8    8.617  89.8
  21 parallel                             0.121    0.001    0.009    0.131   1.4    8.748  91.2
  20 lowerIterators                       0.104    0.001    0.011    0.116   1.2    8.864  92.4
   5 cleanup                              0.080    0.000    0.007    0.087   0.9    8.951  93.3
  29 deadCodeElimination                  0.081    0.001    0.004    0.086   0.9    9.037  94.2
  39 denormalize                          0.078    0.000    0.005    0.083   0.9    9.119  95.1
   2 checkUast                            0.069    0.001    0.006    0.077   0.8    9.196  95.9
  27 refPropagation                       0.061    0.001    0.007    0.069   0.7    9.265  96.6
  22 prune                                0.023    0.001    0.017    0.041   0.4    9.306  97.0
  38 insertLineNumbers                    0.032    0.001    0.004    0.037   0.4    9.343  97.4
  17 cullOverReferences                   0.018    0.002    0.007    0.028   0.3    9.370  97.7
  11 createTaskFunctions                  0.004    0.002    0.019    0.026   0.3    9.396  98.0
  18 lowerErrorHandling                   0.016    0.000    0.007    0.022   0.2    9.418  98.2
  36 optimizeOnClauses                    0.019    0.000    0.003    0.022   0.2    9.441  98.4
  26 scalarReplace                        0.012    0.001    0.006    0.019   0.2    9.459  98.6
  14 checkResolved                        0.008    0.000    0.007    0.015   0.2    9.475  98.8
  33 prune2                               0.011    0.000    0.003    0.015   0.2    9.490  98.9
   9 checkNormalized                      0.002    0.000    0.013    0.015   0.2    9.504  99.1
  13 resolveIntents                       0.005    0.000    0.006    0.012   0.1    9.517  99.2
  31 localizeGlobals                      0.007    0.000    0.003    0.010   0.1    9.527  99.3
  16 flattenFunctions                     0.003    0.000    0.007    0.009   0.1    9.536  99.4
   4 expandExternArrayCalls               0.001    0.000    0.006    0.007   0.1    9.543  99.5
   3 readExternC                          0.000    0.000    0.006    0.006   0.1    9.549  99.6
  15 replaceArrayAccessesWithRefTemps     0.000    0.000    0.006    0.006   0.1    9.555  99.6
   7 flattenClasses                       0.000    0.000    0.006    0.006   0.1    9.561  99.7
  35 insertWideReferences                 0.002    0.000    0.003    0.006   0.1    9.566  99.7
  23 bulkCopyRecords                      0.000    0.001    0.005    0.006   0.1    9.572  99.8
  24 removeUnnecessaryAutoCopyCalls       0.001    0.000    0.004    0.005   0.1    9.577  99.9
  34 returnStarTuplesByRefArgs            0.002    0.000    0.003    0.005   0.0    9.582  99.9
  37 addInitCalls                         0.001    0.000    0.003    0.004   0.0    9.586 100.0
  30 removeEmptyRecords                   0.000    0.000    0.003    0.003   0.0    9.589 100.0
     init                                 0.001    0.000    0.000    0.001   0.0    9.590 100.0
     startup                              0.000    0.000    0.000    0.000   0.0    9.591 100.0
     driverCleanup                        0.000    0.000    0.000    0.000   0.0    9.591 100.0

     total time                           9.189    0.027    0.375    9.591


Timing for driver phase two
--------------
                            init :   0.001 seconds  [      285]
                      makeBinary :   0.671 seconds  [      285]
                   driverCleanup :   0.000 seconds  [      285]
Pass               Name                   Main    Check    Clean     Time    %     Accum    %
---- ---------------------------------  -------  -------  -------  ------- -----  ------- -----
     startup                              0.000    0.000    0.000    0.000   0.0    0.000   0.0
     init                                 0.001    0.000    0.000    0.001   0.2    0.001   0.2
   1 makeBinary                           0.671    0.000    0.000    0.671  99.8    0.672 100.0
     driverCleanup                        0.000    0.000    0.000    0.000   0.0    0.672 100.0

     total time                           0.672    0.000    0.000    0.672


Timing for driver mode overhead
--------------
                            init :   0.230 seconds  [      285]
                   driverCleanup :   0.000 seconds  [      285]
Pass               Name                   Main    Check    Clean     Time    %     Accum    %
---- ---------------------------------  -------  -------  -------  ------- -----  ------- -----
     startup                              0.000    0.000    0.000    0.000   0.0    0.000   0.0
     init                                 0.230    0.000    0.000    0.230 100.0    0.230 100.0
     driverCleanup                        0.000    0.000    0.000    0.000   0.0    0.230 100.0

     total time                           0.230    0.000    0.000    0.230
          total time (front end) :   7.873 seconds
         total time (middle end) :   1.256 seconds
           total time (back end) :   1.134 seconds
                      total time :  10.493 seconds

</details>

Resolves https://github.com/Cray/chapel-private/issues/5593.

[reviewer info placeholder]

Testing:
- [x] paratest with and without `--compiler-driver`
- [x] manually checked behavior for early-exits (`--parse-only` etc) is analogous between pre-PR monolithic, post-PR monolithic, and post-PR driver modes