### PR TITLE
Warn for deprecated generated compiler code when using `--devel`

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -488,8 +488,8 @@ void Symbol::maybeGenerateDeprecationWarning(Expr* context) {
   // parent symbol, or until we reach the highest outer scope
   while (contextParent != NULL && contextParent->defPoint != NULL &&
          contextParent->defPoint->parentSymbol != NULL &&
-         parentDeprecated != true && compilerGenerated != true &&
-         ignoreUsage != true) {
+         parentDeprecated != true && ignoreUsage != true &&
+         (developer || compilerGenerated != true)) {
     contextParent = contextParent->defPoint->parentSymbol;
     parentDeprecated = contextParent->hasFlag(FLAG_DEPRECATED);
     compilerGenerated = contextParent->hasFlag(FLAG_COMPILER_GENERATED);
@@ -498,7 +498,7 @@ void Symbol::maybeGenerateDeprecationWarning(Expr* context) {
 
   // Only generate the warning if the location with the reference is not
   // created by the compiler or also deprecated.
-  if (!compilerGenerated && !parentDeprecated && !ignoreUsage) {
+  if ((developer || !compilerGenerated) && !parentDeprecated && !ignoreUsage) {
     USR_WARN(context, "%s", getSanitizedMsg(getDeprecationMsg()));
   }
 }
@@ -542,8 +542,8 @@ void Symbol::maybeGenerateUnstableWarning(Expr* context) {
   while (contextParent != NULL && contextParent->defPoint != NULL &&
          contextParent->defPoint->parentSymbol != NULL &&
          !isInvisibleModule(contextParent) &&
-         parentUnstable != true && compilerGenerated != true &&
-         parentDeprecated != true) {
+         parentUnstable != true && parentDeprecated != true &&
+         (developer || compilerGenerated != true)) {
     contextParent = contextParent->defPoint->parentSymbol;
     parentUnstable = isUnstableContext(contextParent);
     parentDeprecated = contextParent->hasFlag(FLAG_DEPRECATED);
@@ -552,7 +552,7 @@ void Symbol::maybeGenerateUnstableWarning(Expr* context) {
 
   // Only generate the warning if the location with the reference is not
   // created by the compiler, is not unstable, and is not deprecated.
-  if (!compilerGenerated && !parentUnstable && !parentDeprecated) {
+  if ((developer || !compilerGenerated) && !parentUnstable && !parentDeprecated) {
     USR_WARN(context, "%s", getSanitizedMsg(getUnstableMsg()));
   }
 }

--- a/test/deprecated-keyword/warn-in-init.chpl
+++ b/test/deprecated-keyword/warn-in-init.chpl
@@ -1,0 +1,21 @@
+record myShared {
+  proc init() {}
+  proc init=(s: myShared) {}
+  @deprecated("converting myOwned to myShared is deprecated")
+  proc init=(o: myOwned) {}
+  operator :(x: myOwned, type t: myShared) {
+    return new myShared();
+  }
+}
+record myOwned {
+  proc init() {}
+}
+
+var o = new myOwned();
+record R {
+  var s: myShared = o;
+}
+
+proc main() {
+  var r = new R();
+}

--- a/test/deprecated-keyword/warn-in-init.future
+++ b/test/deprecated-keyword/warn-in-init.future
@@ -1,0 +1,2 @@
+bug: deprecated functions should still warn when used in a default init function
+#23787

--- a/test/deprecated-keyword/warn-in-init.good
+++ b/test/deprecated-keyword/warn-in-init.good
@@ -1,0 +1,1 @@
+warn-in-init.chpl:16: warning: converting myOwned to myShared is deprecated


### PR DESCRIPTION
To help developers start to alleviate the other issue in #23787, where code in compiler generated code fails to warn for deprecations (intentionally). This PR also turns that off in the presence of `--devel`, to help developers find deprecated features being used.

This PR also adds a standalone future for one of the bugs in #23787

## Testing
- [ ] paratest with comm=none
- [ ] paratest with comm=gasnet

[Reviewed by @]