### PR TITLE
Remove the dummy locale

### DIFF
--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -76,7 +76,8 @@ module ChapelLocale {
   // the first place, so it should stay in the locale that started the
   // execution.
   @chpldoc.nodoc
-  var dummyLocale = new locale(localeKind.dummy);
+  var locale0 = new locale(new unmanaged LocaleModel());
+
 
   // record locale - defines the locale record - called _locale to aid parsing
   pragma "always RVF"
@@ -112,7 +113,7 @@ module ChapelLocale {
         compilerError("locale.init(kind) can not be used to create ",
                       "a regular locale instance");
       else if kind == localeKind.dummy then
-        this._instance = new unmanaged DummyLocale();
+        compilerError("Should no longer get here");
       else if kind == localeKind.default then
         this._instance = nil;
     }
@@ -307,7 +308,7 @@ module ChapelLocale {
     // Every locale has a parent, except for the root locale.
     // The parent of the root locale is nil (by definition).
     @chpldoc.nodoc
-    const parent = nilLocale;
+    var parent = nilLocale;
 
     @chpldoc.nodoc var nPUsLogAcc: int;     // HW threads, accessible
     @chpldoc.nodoc var nPUsLogAll: int;     // HW threads, all
@@ -502,13 +503,15 @@ module ChapelLocale {
     if casted == nil then
       halt("cannot call chpl_getSingletonCurrentLocaleArray on nil or rootLocale");
 
-    return casted!.chpl_singletonThisLocaleArray;
+    // I think this is problematic...  We can't really return an array
+    // literal by 'const ref', can we?
+    return [casted!.chpl_singletonThisLocale, ];
   }
 
   @chpldoc.nodoc
   class AbstractLocaleModel : BaseLocale {
     // Used in chpl_getSingletonLocaleArray -- see the comment there
-    var chpl_singletonThisLocaleArray:[0..0] locale;
+    var chpl_singletonThisLocale: locale;
 
     // This will be used for interfaces that will be common to all
     // (non-RootLocale) locale models
@@ -545,6 +548,7 @@ module ChapelLocale {
   //
   @chpldoc.nodoc
   var origRootLocale = nilLocale;
+
 
   @chpldoc.nodoc
   class AbstractRootLocale : BaseLocale {
@@ -698,7 +702,7 @@ module ChapelLocale {
       if val == nil then
         halt("error in locale initialization");
 
-      val!.chpl_singletonThisLocaleArray[0]._instance = val;
+      val!.chpl_singletonThisLocale._instance = val;
 
       chpl_singletonCurrentLocaleInitPrivateSublocs(subloc);
     }
@@ -711,7 +715,7 @@ module ChapelLocale {
     if val == nil then
       halt("error in locale initialization");
 
-    val!.chpl_singletonThisLocaleArray[0]._instance = val;
+    val!.chpl_singletonThisLocale._instance = val;
     chpl_singletonCurrentLocaleInitPrivateSublocs(loc);
   }
 
@@ -745,10 +749,11 @@ module ChapelLocale {
       // changes in a way that IO is inited too early. In that scenario, we
       // somehow don't get dummyLocale set up correctly in this scheme
       // remove this check, and test/exits/albrecht/exitWithNoCall fails
-      if dummyLocale._instance == nil {
-        dummyLocale._instance = new unmanaged DummyLocale();
+      if locale0._instance == nil {
+        halt("locale0's instance was nil");
+//        dummyLocale._instance = new unmanaged DummyLocale();
       }
-      return dummyLocale;
+      return locale0;
     }
   }
 
@@ -788,6 +793,6 @@ module ChapelLocale {
   @chpldoc.nodoc
   proc deinit() {
     delete origRootLocale._instance;
-    delete dummyLocale._instance;
+//    delete dummyLocale._instance;
   }
 }

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -504,7 +504,7 @@ module ChapelLocale {
       halt("cannot call chpl_getSingletonCurrentLocaleArray on nil or rootLocale");
 
     // I think this is problematic...  We can't really return an array
-    // literal by 'const ref', can we?
+    // literal by 'const ref', can we?  (later: No, we can't)
     return [casted!.chpl_singletonThisLocale, ];
   }
 

--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -441,7 +441,7 @@ module DefaultAssociative {
     }
 
     proc dsiTargetLocales() const ref {
-      return EachLocSingletonArr[this.locale.id][0];
+      return EachLocSingletonArr[this.locale.id];
     }
 
     proc dsiHasSingleLocalSubdomain() param do return true;
@@ -881,7 +881,7 @@ module DefaultAssociative {
     }
 
     proc dsiTargetLocales() const ref {
-      return EachLocSingletonArr[this.locale.id][0];
+      return EachLocSingletonArr[this.locale.id];
     }
 
     proc dsiHasSingleLocalSubdomain() param do return true;

--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -441,7 +441,7 @@ module DefaultAssociative {
     }
 
     proc dsiTargetLocales() const ref {
-      return chpl_getSingletonLocaleArray(this.locale);
+      return EachLocSingletonArr[this.locale.id][0];
     }
 
     proc dsiHasSingleLocalSubdomain() param do return true;
@@ -881,7 +881,7 @@ module DefaultAssociative {
     }
 
     proc dsiTargetLocales() const ref {
-      return chpl_getSingletonLocaleArray(this.locale);
+      return EachLocSingletonArr[this.locale.id][0];
     }
 
     proc dsiHasSingleLocalSubdomain() param do return true;

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -114,7 +114,7 @@ module DefaultRectangular {
       return new unmanaged DefaultSparseDom(rank, idxType, _to_unmanaged(this), dom);
 
     proc dsiTargetLocales() const ref {
-      return EachLocSingletonArr[this.locale.id][0];
+      return EachLocSingletonArr[this.locale.id];
     }
 
     proc dsiIndexToLocale(ind) do return this.locale;
@@ -739,7 +739,7 @@ module DefaultRectangular {
     }
 
     proc dsiTargetLocales() const ref {
-      return EachLocSingletonArr[this.locale.id][0];
+      return EachLocSingletonArr[this.locale.id];
     }
 
     proc dsiHasSingleLocalSubdomain() param do return true;
@@ -1610,7 +1610,7 @@ module DefaultRectangular {
     }
 
     proc dsiTargetLocales() const ref {
-      return EachLocSingletonArr[this.locale.id][0];
+      return EachLocSingletonArr[this.locale.id];
     }
 
     proc dsiHasSingleLocalSubdomain() param do return true;

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -29,6 +29,12 @@ module DefaultRectangular {
   @unstable("The variable 'dataParMinGranularity' is unstable and its interface is subject to change in the future")
   config const dataParMinGranularity: int = 1;
 
+/*
+  pragma "locale private"
+  @chpldoc.nodoc
+  const targetLocaleArrayOfMe = [here, ];
+  */
+  
   if dataParTasksPerLocale<0 then halt("dataParTasksPerLocale must be >= 0");
   if dataParMinGranularity<=0 then halt("dataParMinGranularity must be > 0");
 
@@ -112,8 +118,9 @@ module DefaultRectangular {
     override proc dsiNewSparseDom(param rank: int, type idxType, dom: domain) do
       return new unmanaged DefaultSparseDom(rank, idxType, _to_unmanaged(this), dom);
 
-    proc dsiTargetLocales() const ref do
-      return chpl_getSingletonLocaleArray(this.locale);
+    proc dsiTargetLocales() const ref {
+      return Locales[this.locale.id..this.locale.id];
+    }
 
     proc dsiIndexToLocale(ind) do return this.locale;
 
@@ -737,7 +744,7 @@ module DefaultRectangular {
     }
 
     proc dsiTargetLocales() const ref {
-      return chpl_getSingletonLocaleArray(this.locale);
+      return Locales[this.locale.id..this.locale.id];
     }
 
     proc dsiHasSingleLocalSubdomain() param do return true;
@@ -1608,7 +1615,7 @@ module DefaultRectangular {
     }
 
     proc dsiTargetLocales() const ref {
-      return chpl_getSingletonLocaleArray(this.locale);
+      return Locales[this.locale.id..this.locale.id];
     }
 
     proc dsiHasSingleLocalSubdomain() param do return true;

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -96,6 +96,7 @@ module DefaultRectangular {
     return ret;
   }
 
+
   @unstable("DefaultDist is unstable and may change in the future")
   class DefaultDist: BaseDist {
     override proc dsiNewRectangularDom(param rank: int, type idxType,
@@ -112,8 +113,9 @@ module DefaultRectangular {
     override proc dsiNewSparseDom(param rank: int, type idxType, dom: domain) do
       return new unmanaged DefaultSparseDom(rank, idxType, _to_unmanaged(this), dom);
 
-    proc dsiTargetLocales() const ref do
-      return Locales[this.locale.id..this.locale.id];
+    proc dsiTargetLocales() const ref {
+      return EachLocSingletonArr[this.locale.id][0];
+    }
 
     proc dsiIndexToLocale(ind) do return this.locale;
 
@@ -737,7 +739,7 @@ module DefaultRectangular {
     }
 
     proc dsiTargetLocales() const ref {
-      return Locales[this.locale.id..this.locale.id];
+      return EachLocSingletonArr[this.locale.id][0];
     }
 
     proc dsiHasSingleLocalSubdomain() param do return true;
@@ -1608,7 +1610,7 @@ module DefaultRectangular {
     }
 
     proc dsiTargetLocales() const ref {
-      return Locales[this.locale.id..this.locale.id];
+      return EachLocSingletonArr[this.locale.id][0];
     }
 
     proc dsiHasSingleLocalSubdomain() param do return true;

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -29,12 +29,6 @@ module DefaultRectangular {
   @unstable("The variable 'dataParMinGranularity' is unstable and its interface is subject to change in the future")
   config const dataParMinGranularity: int = 1;
 
-/*
-  pragma "locale private"
-  @chpldoc.nodoc
-  const targetLocaleArrayOfMe = [here, ];
-  */
-  
   if dataParTasksPerLocale<0 then halt("dataParTasksPerLocale must be >= 0");
   if dataParMinGranularity<=0 then halt("dataParMinGranularity must be > 0");
 
@@ -118,9 +112,8 @@ module DefaultRectangular {
     override proc dsiNewSparseDom(param rank: int, type idxType, dom: domain) do
       return new unmanaged DefaultSparseDom(rank, idxType, _to_unmanaged(this), dom);
 
-    proc dsiTargetLocales() const ref {
+    proc dsiTargetLocales() const ref do
       return Locales[this.locale.id..this.locale.id];
-    }
 
     proc dsiIndexToLocale(ind) do return this.locale;
 

--- a/modules/internal/DefaultSparse.chpl
+++ b/modules/internal/DefaultSparse.chpl
@@ -393,7 +393,7 @@ module DefaultSparse {
     }
 
     proc dsiTargetLocales() const ref {
-      return chpl_getSingletonLocaleArray(this.locale);
+      return EachLocSingletonArr[this.locale.id][0];
     }
 
     proc dsiHasSingleLocalSubdomain() param do return true;
@@ -519,7 +519,7 @@ module DefaultSparse {
     }
 
     proc dsiTargetLocales() const ref {
-      return chpl_getSingletonLocaleArray(this.locale);
+      return EachLocSingletonArr[this.locale.id][0];
     }
 
     proc dsiHasSingleLocalSubdomain() param do return true;

--- a/modules/internal/DefaultSparse.chpl
+++ b/modules/internal/DefaultSparse.chpl
@@ -393,7 +393,7 @@ module DefaultSparse {
     }
 
     proc dsiTargetLocales() const ref {
-      return EachLocSingletonArr[this.locale.id][0];
+      return EachLocSingletonArr[this.locale.id];
     }
 
     proc dsiHasSingleLocalSubdomain() param do return true;
@@ -519,7 +519,7 @@ module DefaultSparse {
     }
 
     proc dsiTargetLocales() const ref {
-      return EachLocSingletonArr[this.locale.id][0];
+      return EachLocSingletonArr[this.locale.id];
     }
 
     proc dsiHasSingleLocalSubdomain() param do return true;

--- a/modules/internal/LocaleModelHelpSetup.chpl
+++ b/modules/internal/LocaleModelHelpSetup.chpl
@@ -82,8 +82,11 @@ module LocaleModelHelpSetup {
   proc helpSetupRootLocaleFlat(dst:borrowed RootLocale) {
     var root_accum:chpl_root_locale_accum;
 
+    // fill in missing aspects of locale 0
+    locale0._instance!.parent = new locale(dst);
+
+    // set up all other locales from scratch
     forall locIdx in dst.chpl_initOnLocales() with (ref root_accum) {
-      if locIdx == 0 then locale0._instance!.parent = new locale(dst);
       const node = if locIdx == 0 then locale0
                    else new locale(new unmanaged LocaleModel(new locale(dst)));
       dst.myLocales[locIdx] = node;
@@ -123,9 +126,14 @@ module LocaleModelHelpSetup {
   proc helpSetupRootLocaleGPU(dst:borrowed RootLocale) {
     var root_accum:chpl_root_locale_accum;
 
+    // fill in missing aspects of locale 0
+    locale0._instance!.parent = new locale(dst);
+
+    // set up all other locales from scratch
     forall locIdx in dst.chpl_initOnLocales() with (ref root_accum) {
       chpl_task_setSubloc(c_sublocid_none);
-      const node = new locale(new unmanaged LocaleModel(new locale (dst)));
+      const node = if locIdx == 0 then locale0
+                   else new locale(new unmanaged LocaleModel(new locale(dst)));
       dst.myLocales[locIdx] = node;
       root_accum.accum(node);
     }

--- a/modules/internal/LocaleModelHelpSetup.chpl
+++ b/modules/internal/LocaleModelHelpSetup.chpl
@@ -83,7 +83,9 @@ module LocaleModelHelpSetup {
     var root_accum:chpl_root_locale_accum;
 
     forall locIdx in dst.chpl_initOnLocales() with (ref root_accum) {
-      const node = new locale(new unmanaged LocaleModel(new locale(dst)));
+      if locIdx == 0 then locale0._instance!.parent = new locale(dst);
+      const node = if locIdx == 0 then locale0
+                   else new locale(new unmanaged LocaleModel(new locale(dst)));
       dst.myLocales[locIdx] = node;
       root_accum.accum(node);
     }

--- a/modules/internal/LocalesArray.chpl
+++ b/modules/internal/LocalesArray.chpl
@@ -56,5 +56,12 @@ module LocalesArray {
   // We don't use the same private "trick" as with Locales above with
   // LocaleSpace/ because it's small enough to not matter.
   const LocaleSpace = Locales.domain;
+
+  pragma "locale private"
+  var EachLocSingletonArr: [LocaleSpace] [0..0] locale;
+  coforall loc in Locales do
+    on loc do
+      forall locID in LocaleSpace do
+        EachLocSingletonArr[locID][0] = Locales[locID];
 }
 


### PR DESCRIPTION
For quite some time now, Chapel has supported a "dummy locale" used when bootstrapping the internal modules to serve as `here` until such time as the `Locales` array is created.  This has worked OK, but also led to some problematic effects.  One recent one that I hit was that the `stdin`/`stdout`/`stderr` variables (which capture a home locale) believed they lived on the dummy locale rather than locale 0, resulting in problems when trying to do things like readBinary()/writeBinary().

This PR takes a different tack, eliminating the dummy locale and instead setting up locale 0 in its place.  This is not a complete representation of locale 0, which can only occur when setting up the Locales array (or significantly refactoring how things are set up in general), but it establishes its identity such that it will be the same object as for the rest of the program's execution.  Thus, in the case of my `stdin`/`stdout`/`stderr` bug, those will now grab the incomplete locale 0 value, which will be complete by the time anyone needs it / we reach user code, resolving the bug.

When we are setting up the Locales array, I now finish setting up locale 0 and tuck it into position 0 in the locales array, whereas locales 1..numLocales-1 are still set up as ever.  One change I had to make in order to get this to work was to change the parentLocale field from `const` to `ref` since it is the main thing that has to be set up in locale 0 in this later phase.  That said, this doesn't seem like a huge deal since it's not a user-facing field and isn't used much in practice anyway.

This overall approach also has the effect of permitting us to remove a lot of dead / crufty code in support of the dummy locale.

The main challenge this refactoring led to is that the locale value stores a 1-array value of itself for use in implementing the `.targetLocales()` query for a DR domain or array.  Preserving that array field resulted in a classic "everything wants to be initialized first" problem at program startup where we couldn't create locale 0 as early as I wanted because we weren't in a position to create arrays yet (which is the reason we can't create the locales array until later on).  The fix I took here was to create a per-locale array of 1-element arrays for such queries to return.  While this feels a little strange, it also feels a bit more principled than the other approach and was one of the few approaches that I could get to work and that felt scalable (in the sense of not requiring communication).  Many of my attempts involved just trying to return the singleton array of locales on-demand, or returning a `Locales[id..id]` slice, but because the return intent of dsiTargetLocales/targetLocales is `const ref`, these would not get through the compiler (appropriately in the first case; I'm not confident the second shouldn't have made it through).