### PR TITLE
Add off-by-default rule UseExplicitModules

### DIFF
--- a/tools/chplcheck/src/chplcheck.py
+++ b/tools/chplcheck/src/chplcheck.py
@@ -43,7 +43,7 @@ def main():
     args = parser.parse_args()
 
     driver = LintDriver()
-    driver.disable_rules("CamelCaseVariables", "ConsecutiveDecls")
+    driver.disable_rules("CamelCaseVariables", "ConsecutiveDecls", "UseExplicitModules")
     driver.disable_rules(*args.disabled_rules)
     driver.enable_rules(*args.enabled_rules)
     register_rules(driver)

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -54,7 +54,11 @@ def register_rules(driver):
 
     @driver.basic_rule(Module)
     def PascalCaseModules(context, node):
-        return check_pascal_case(node)
+        return node.kind() == "implicit" or check_pascal_case(node)
+
+    @driver.basic_rule(Module)
+    def UseExplicitModules(context, node):
+        return node.kind() != "implicit"
 
     @driver.basic_rule(Loop)
     def DoKeywordAndBlock(context, node):


### PR DESCRIPTION
Adds an off-by-default rule UseExplicitModules which warns for code relying on implicit modules.

This also improves the normal module name check to not fire when there are implicit modules

[Reviewed by @]