### PR TITLE
Fix `extern record` locations to be consistent with `records`

### DIFF
--- a/frontend/lib/parsing/bison-chpl-lib.cpp
+++ b/frontend/lib/parsing/bison-chpl-lib.cpp
@@ -7760,7 +7760,7 @@ yyreduce:
   case 207: /* extern_export_decl_stmt: extern_export_decl_stmt_start class_start opt_inherit TLCBR class_level_stmt_ls TRCBR  */
 #line 1514 "chpl.ypp"
   {
-    (yyval.commentsAndStmt) = context->buildAggregateTypeDecl((yylsp[-5]), (yyvsp[-4].typeDeclParts), (yylsp[-3]), (yyvsp[-3].exprList), (yylsp[-2]), (yyvsp[-1].exprList), (yylsp[0]));
+    (yyval.commentsAndStmt) = context->buildAggregateTypeDecl((yyloc), (yyvsp[-4].typeDeclParts), (yylsp[-3]), (yyvsp[-3].exprList), (yylsp[-2]), (yyvsp[-1].exprList), (yylsp[0]));
     context->exitScope((yyvsp[-4].typeDeclParts).tag, (yyvsp[-4].typeDeclParts).name);
   }
 #line 7767 "bison-chpl-lib.cpp"
@@ -7771,7 +7771,7 @@ yyreduce:
   {
     // Set the linkage name since it will be nullptr otherwise.
     (yyvsp[-4].typeDeclParts).linkageName = (yyvsp[-5].expr);
-    (yyval.commentsAndStmt) = context->buildAggregateTypeDecl((yylsp[-6]), (yyvsp[-4].typeDeclParts), (yylsp[-3]), (yyvsp[-3].exprList), (yylsp[-2]), (yyvsp[-1].exprList), (yylsp[0]));
+    (yyval.commentsAndStmt) = context->buildAggregateTypeDecl((yyloc), (yyvsp[-4].typeDeclParts), (yylsp[-3]), (yyvsp[-3].exprList), (yylsp[-2]), (yyvsp[-1].exprList), (yylsp[0]));
     context->exitScope((yyvsp[-4].typeDeclParts).tag, (yyvsp[-4].typeDeclParts).name);
   }
 #line 7778 "bison-chpl-lib.cpp"

--- a/frontend/lib/parsing/chpl.ypp
+++ b/frontend/lib/parsing/chpl.ypp
@@ -1512,7 +1512,7 @@ extern_export_decl_stmt:
   extern_export_decl_stmt_start class_start opt_inherit
   TLCBR class_level_stmt_ls TRCBR
   {
-    $$ = context->buildAggregateTypeDecl(@1, $2, @3, $3, @4, $5, @6);
+    $$ = context->buildAggregateTypeDecl(@$, $2, @3, $3, @4, $5, @6);
     context->exitScope($2.tag, $2.name);
   }
 | extern_export_decl_stmt_start STRINGLITERAL class_start opt_inherit
@@ -1520,7 +1520,7 @@ extern_export_decl_stmt:
   {
     // Set the linkage name since it will be nullptr otherwise.
     $3.linkageName = $2;
-    $$ = context->buildAggregateTypeDecl(@1, $3, @4, $4, @5, $6, @7);
+    $$ = context->buildAggregateTypeDecl(@$, $3, @4, $4, @5, $6, @7);
     context->exitScope($3.tag, $3.name);
   }
 | extern_export_decl_stmt_start opt_expr fn_decl_stmt

--- a/frontend/lib/parsing/flex-chpl-lib.cpp
+++ b/frontend/lib/parsing/flex-chpl-lib.cpp
@@ -1,6 +1,6 @@
-#line 2 "flex-chpl-lib.cpp"
+#line 1 "flex-chpl-lib.cpp"
 
-#line 4 "flex-chpl-lib.cpp"
+#line 3 "flex-chpl-lib.cpp"
 
 #define  YY_INT_ALIGNED short int
 
@@ -1079,10 +1079,10 @@ static void processInvalidToken(yyscan_t scanner);
 static bool yy_has_state(yyscan_t scanner);
 }
 
-#line 1083 "flex-chpl-lib.cpp"
+#line 1082 "flex-chpl-lib.cpp"
 /* hex float literals, have decimal exponents indicating the power of 2 */
 
-#line 1086 "flex-chpl-lib.cpp"
+#line 1085 "flex-chpl-lib.cpp"
 
 #define INITIAL 0
 #define externmode 1
@@ -1372,7 +1372,7 @@ YY_DECL
 #line 113 "chpl.lex"
 
 
-#line 1376 "flex-chpl-lib.cpp"
+#line 1375 "flex-chpl-lib.cpp"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -2382,7 +2382,7 @@ YY_RULE_SETUP
 #line 330 "chpl.lex"
 ECHO;
 	YY_BREAK
-#line 2386 "flex-chpl-lib.cpp"
+#line 2385 "flex-chpl-lib.cpp"
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(externmode):
 	yyterminate();

--- a/frontend/lib/parsing/flex-chpl-lib.h
+++ b/frontend/lib/parsing/flex-chpl-lib.h
@@ -2,9 +2,9 @@
 #define yychpl_HEADER_H 1
 #define yychpl_IN_HEADER 1
 
-#line 6 "flex-chpl-lib.h"
+#line 5 "flex-chpl-lib.h"
 
-#line 8 "flex-chpl-lib.h"
+#line 7 "flex-chpl-lib.h"
 
 #define  YY_INT_ALIGNED short int
 
@@ -730,6 +730,6 @@ extern int yylex \
 #line 330 "chpl.lex"
 
 
-#line 734 "flex-chpl-lib.h"
+#line 733 "flex-chpl-lib.h"
 #undef yychpl_IN_HEADER
 #endif /* yychpl_HEADER_H */


### PR DESCRIPTION
Fixes an issue with the locations reported by Chapel for an `extern record` being different than a `record`.

For example, the location for this record includes everything from `record` to the closing curly brace.
```chapel
record foo {
  var x: int;
  var y: int;
}
```

The location for this record was only for `extern`, now it is everything from `extern` to the closing curly brace.
```chapel
extern record bar {
  var x: int;
  var y: int;
}
```

## Testing
- local testing with `chplcheck` to view locations
- paratest with comm=none
- paratest with comm=gasnet

[Reviewed by @lydia-duncan]