### PR TITLE
Improve chplcheck rule default specification

### DIFF
--- a/tools/chplcheck/src/chplcheck.py
+++ b/tools/chplcheck/src/chplcheck.py
@@ -43,10 +43,10 @@ def main():
     args = parser.parse_args()
 
     driver = LintDriver()
-    driver.disable_rules("CamelCaseVariables", "ConsecutiveDecls", "UseExplicitModules")
+    # register rules before enabling/disabling
+    register_rules(driver)
     driver.disable_rules(*args.disabled_rules)
     driver.enable_rules(*args.enabled_rules)
-    register_rules(driver)
 
     if args.lsp:
         run_lsp(driver)

--- a/tools/chplcheck/src/driver.py
+++ b/tools/chplcheck/src/driver.py
@@ -151,6 +151,8 @@ class LintDriver:
             def wrapper_advanced_rule(*args, **kwargs):
                 return func(*args, **kwargs)
             return wrapper_advanced_rule
+
+        # this allows the usage of either `@advanced_rule` or `@advanced_rule()`
         if _func is None:
             return decorator_advanced_rule
         else:

--- a/tools/chplcheck/src/driver.py
+++ b/tools/chplcheck/src/driver.py
@@ -133,7 +133,7 @@ class LintDriver:
         return decorator_basic_rule
 
 
-    def advanced_rule(self, default=True):
+    def advanced_rule(self, _func=None, *, default=True):
         """
         This method is a decorator for adding 'advanced' rules to the driver.
         An advanced rule is a function that gets called on a root AST node,
@@ -151,7 +151,10 @@ class LintDriver:
             def wrapper_advanced_rule(*args, **kwargs):
                 return func(*args, **kwargs)
             return wrapper_advanced_rule
-        return decorator_advanced_rule
+        if _func is None:
+            return decorator_advanced_rule
+        else:
+            return decorator_advanced_rule(_func)
 
     def run_checks(self, context, asts):
         """

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -126,7 +126,7 @@ def register_rules(driver):
 
         yield from recurse(root)
 
-    @driver.advanced_rule()
+    @driver.advanced_rule
     def MisleadingIndentation(context, root):
         prev = None
         for child in root:

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -39,7 +39,7 @@ def check_pascal_case(node):
     return re.fullmatch(r'_?(([A-Z][a-z]+|\d+)+|[A-Z]+)?', name_for_linting(node))
 
 def register_rules(driver):
-    @driver.basic_rule(VarLikeDecl)
+    @driver.basic_rule(VarLikeDecl, default=False)
     def CamelCaseVariables(context, node):
         if node.name() == "_": return True
         return check_camel_case(node)
@@ -56,7 +56,7 @@ def register_rules(driver):
     def PascalCaseModules(context, node):
         return node.kind() == "implicit" or check_pascal_case(node)
 
-    @driver.basic_rule(Module)
+    @driver.basic_rule(Module, default=False)
     def UseExplicitModules(context, node):
         return node.kind() != "implicit"
 
@@ -84,7 +84,7 @@ def register_rules(driver):
             return context.is_bundled_path(path)
         return True
 
-    @driver.advanced_rule
+    @driver.advanced_rule(default=False)
     def ConsecutiveDecls(context, root):
         def is_relevant_decl(node):
             if isinstance(node, MultiDecl):
@@ -126,7 +126,7 @@ def register_rules(driver):
 
         yield from recurse(root)
 
-    @driver.advanced_rule
+    @driver.advanced_rule()
     def MisleadingIndentation(context, root):
         prev = None
         for child in root:


### PR DESCRIPTION
Improves how we specify that a given `chplcheck` rule is default or not, by enabling a non-required argument on the decorator.

Tested locally

[Reviewed by @DanilaFe]