### PR TITLE
Get `chapel-py` building on chapdl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,12 @@ frontend: FORCE
 	@cd third-party && $(MAKE) CHPL_MAKE_HOST_TARGET=--host jemalloc
 	@cd compiler && $(MAKE) frontend
 
+frontend-shared: FORCE
+	@echo "Making the frontend compiler library (always shared)..."
+	@cd third-party && $(MAKE) llvm
+	@cd third-party && $(MAKE) CHPL_MAKE_HOST_TARGET=--host jemalloc
+	@cd compiler && $(MAKE) frontend-shared
+
 compiler: FORCE
 	@echo "Making the compiler..."
 	@cd third-party && $(MAKE) llvm
@@ -116,7 +122,7 @@ third-party-c2chapel-venv: FORCE
 	cd third-party && $(MAKE) c2chapel-venv; \
 	fi
 
-third-party-chapel-py-venv: frontend FORCE
+third-party-chapel-py-venv: frontend-shared FORCE
 	cd third-party && $(MAKE) chapel-py-venv;
 
 test-venv: third-party-test-venv

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -164,6 +164,9 @@ CMAKE_FLAGS_NO_NDEBUG=$(subst -DNDEBUG,,$(CMAKE_FLAGS))
 frontend: FORCE $(CHPL_CONFIG_CHECK) $(COMPILER_BUILD)
 	@cd $(COMPILER_BUILD) && $(CMAKE) $(CHPL_MAKE_HOME) $(CMAKE_FLAGS) && $(MAKE) ChplFrontend
 
+frontend-shared: FORCE $(CHPL_CONFIG_CHECK) $(COMPILER_BUILD)
+	@cd $(COMPILER_BUILD) && $(CMAKE) $(CHPL_MAKE_HOME) $(CMAKE_FLAGS) && $(MAKE) ChplFrontendShared
+
 test-frontend: FORCE $(CHPL_CONFIG_CHECK) $(COMPILER_BUILD)
 	@echo "Making and running the frontend tests..."
 	@cd $(COMPILER_BUILD) && $(CMAKE) $(CHPL_MAKE_HOME) $(CMAKE_FLAGS_NO_NDEBUG) && $(MAKE) tests

--- a/frontend/lib/CMakeLists.txt
+++ b/frontend/lib/CMakeLists.txt
@@ -90,6 +90,11 @@ else()
               $<TARGET_OBJECTS:git-sha-obj>)
 endif()
 
+add_library(ChplFrontendShared SHARED
+            $<TARGET_OBJECTS:ChplFrontend-obj>
+            $<TARGET_OBJECTS:git-sha-obj>)
+target_link_libraries(ChplFrontendShared ChplFrontend)
+
 target_include_directories(ChplFrontend PUBLIC
                            ${CHPL_MAIN_INCLUDE_DIR}
                            ${CHPL_INCLUDE_DIR})
@@ -132,7 +137,7 @@ target_compile_options(ChplFrontend PUBLIC
 
 # TODO: ADDITIONAL_CLEAN_FILES requires cmake v3.15 ...
 #       Can we find another way to mark these files for cleanup?
-set_target_properties(ChplFrontend PROPERTIES
+set_target_properties(ChplFrontend ChplFrontendShared PROPERTIES
                       ADDITIONAL_CLEAN_FILES
                       ${CMAKE_CURRENT_SOURCE_DIR}/util/git-version.cpp)
 
@@ -140,13 +145,13 @@ set_target_properties(ChplFrontend PROPERTIES
 # install ChplFrontend
 # TODO: also install headers with PUBLIC_HEADER DESTINATION <dir>
 if (INSTALLATION_MODE STREQUAL "prefix")
-  install(TARGETS ChplFrontend
+  install(TARGETS ChplFrontend ChplFrontendShared
           LIBRARY DESTINATION
           "lib/chapel/${CHPL_MAJOR_VERSION}.${CHPL_MINOR_VERSION}/compiler"
           ARCHIVE DESTINATION
           "lib/chapel/${CHPL_MAJOR_VERSION}.${CHPL_MINOR_VERSION}/compiler")
 else()
-  install(TARGETS ChplFrontend
+  install(TARGETS ChplFrontend ChplFrontendShared
           LIBRARY DESTINATION
           "lib/compiler/${CHPL_HOST_BIN_SUBDIR}"
           ARCHIVE DESTINATION

--- a/tools/chapel-py/setup.py
+++ b/tools/chapel-py/setup.py
@@ -27,10 +27,10 @@ import glob
 
 chpl_home = os.getenv('CHPL_HOME')
 chpl_printchplenv = os.path.join(chpl_home, "util", "printchplenv")
-chpl_variables_lines = subprocess.check_output([chpl_printchplenv, "--internal", "--all", " --anonymize"]).decode(sys.stdout.encoding).strip().splitlines()
+chpl_variables_lines = subprocess.check_output([chpl_printchplenv, "--internal", "--all", " --anonymize", "--simple"]).decode(sys.stdout.encoding).strip().splitlines()
 chpl_variables = dict()
 for line in chpl_variables_lines:
-    elms = line.split(":", maxsplit=1)
+    elms = line.split("=", maxsplit=1)
     if len(elms) == 2:
         chpl_variables[elms[0].strip()] = elms[1].strip()
 
@@ -40,7 +40,7 @@ chpl_lib_path = os.path.join(chpl_home, "lib", "compiler", chpl_variables.get("C
 
 CXXFLAGS = []
 CXXFLAGS += ["-Wno-c99-designator"]
-CXXFLAGS += subprocess.check_output([llvm_config, "--cxxflags"]).decode(sys.stdout.encoding).strip().split(" ")
+CXXFLAGS += subprocess.check_output([llvm_config, "--cxxflags"]).decode(sys.stdout.encoding).strip().split()
 CXXFLAGS += ["-std=c++17", "-I{}/frontend/include".format(chpl_home)]
 
 LDFLAGS = []

--- a/tools/chapel-py/setup.py
+++ b/tools/chapel-py/setup.py
@@ -44,7 +44,7 @@ CXXFLAGS += subprocess.check_output([llvm_config, "--cxxflags"]).decode(sys.stdo
 CXXFLAGS += ["-std=c++17", "-I{}/frontend/include".format(chpl_home)]
 
 LDFLAGS = []
-LDFLAGS += ["-L{}".format(chpl_lib_path), "-lChplFrontend", "-Wl,-rpath", chpl_lib_path]
+LDFLAGS += ["-L{}".format(chpl_lib_path), "-lChplFrontendShared", "-Wl,-rpath", chpl_lib_path]
 
 setup(name = "chapel",
       version = "0.1",

--- a/tools/chapel-py/src/chapel.cpp
+++ b/tools/chapel-py/src/chapel.cpp
@@ -43,6 +43,15 @@ extern "C" {
 PyMODINIT_FUNC PyInit_core() {
   PyObject* chapelModule = nullptr;
 
+  setupContextType();
+  setupErrorType();
+  setupErrorManagerType();
+  setupLocationType();
+  setupAstIterType();
+  setupAstCallIterType();
+  setupAstNodeType();
+  setupPerNodeTypes();
+
   if (PyType_Ready(&ContextType) < 0) return nullptr;
   if (PyType_Ready(&ErrorType) < 0) return nullptr;
   if (PyType_Ready(&ErrorManagerType) < 0) return nullptr;

--- a/tools/chapel-py/src/core-types-pernode.cpp
+++ b/tools/chapel-py/src/core-types-pernode.cpp
@@ -194,15 +194,6 @@ struct PerNodeInfo {
 #define DEFINE_PY_TYPE_FOR(NAME, TAG, FLAGS)\
   PyTypeObject NAME##Type = { \
     PyVarObject_HEAD_INIT(NULL, 0) \
-    .tp_name = #NAME, \
-    .tp_basicsize = sizeof(NAME##Object), \
-    .tp_itemsize = 0, \
-    .tp_flags = FLAGS, \
-    .tp_doc = PyDoc_STR("A Chapel " #NAME " AST node"), \
-    .tp_methods = (PyMethodDef*) PerNodeInfo<TAG>::methods, \
-    .tp_base = parentTypeFor(TAG), \
-    .tp_init = (initproc) NAME##Object_init, \
-    .tp_new = PyType_GenericNew, \
   }; \
 
 /* Now, invoke DEFINE_PY_TYPE_FOR for each AST node to get our type objects. */
@@ -215,3 +206,26 @@ struct PerNodeInfo {
 #undef AST_LEAF
 #undef AST_BEGIN_SUBCLASSES
 #undef AST_END_SUBCLASSES
+
+#define INITIALIZE_PY_TYPE_FOR(NAME, TYPE, TAG, FLAGS)\
+  TYPE.tp_name = #NAME; \
+  TYPE.tp_basicsize = sizeof(NAME##Object); \
+  TYPE.tp_itemsize = 0; \
+  TYPE.tp_flags = FLAGS; \
+  TYPE.tp_doc = PyDoc_STR("A Chapel " #NAME " AST node"); \
+  TYPE.tp_methods = (PyMethodDef*) PerNodeInfo<TAG>::methods; \
+  TYPE.tp_base = parentTypeFor(TAG); \
+  TYPE.tp_init = (initproc) NAME##Object_init; \
+  TYPE.tp_new = PyType_GenericNew; \
+
+void setupPerNodeTypes() {
+#define AST_NODE(NAME) INITIALIZE_PY_TYPE_FOR(NAME, NAME##Type, asttags::NAME, Py_TPFLAGS_DEFAULT)
+#define AST_LEAF(NAME) INITIALIZE_PY_TYPE_FOR(NAME, NAME##Type, asttags::NAME, Py_TPFLAGS_DEFAULT)
+#define AST_BEGIN_SUBCLASSES(NAME) INITIALIZE_PY_TYPE_FOR(NAME, NAME##Type, asttags::START_##NAME, Py_TPFLAGS_BASETYPE)
+#define AST_END_SUBCLASSES(NAME)
+#include "chpl/uast/uast-classes-list.h"
+#undef AST_NODE
+#undef AST_LEAF
+#undef AST_BEGIN_SUBCLASSES
+#undef AST_END_SUBCLASSES
+}

--- a/tools/chapel-py/src/core-types.cpp
+++ b/tools/chapel-py/src/core-types.cpp
@@ -37,16 +37,19 @@ static PyMethodDef ContextObject_methods[] = {
 
 PyTypeObject ContextType = {
   PyVarObject_HEAD_INIT(NULL, 0)
-  .tp_name = "Context",
-  .tp_basicsize = sizeof(ContextObject),
-  .tp_itemsize = 0,
-  .tp_dealloc = (destructor) ContextObject_dealloc,
-  .tp_flags = Py_TPFLAGS_DEFAULT,
-  .tp_doc = PyDoc_STR("The Chapel context object that tracks various frontend state"),
-  .tp_methods = ContextObject_methods,
-  .tp_init = (initproc) ContextObject_init,
-  .tp_new = PyType_GenericNew,
 };
+
+void setupContextType() {
+  ContextType.tp_name = "Context";
+  ContextType.tp_basicsize = sizeof(ContextObject);
+  ContextType.tp_itemsize = 0;
+  ContextType.tp_dealloc = (destructor) ContextObject_dealloc;
+  ContextType.tp_flags = Py_TPFLAGS_DEFAULT;
+  ContextType.tp_doc = PyDoc_STR("The Chapel context object that tracks various frontend state");
+  ContextType.tp_methods = ContextObject_methods;
+  ContextType.tp_init = (initproc) ContextObject_init;
+  ContextType.tp_new = PyType_GenericNew;
+}
 
 int ContextObject_init(ContextObject* self, PyObject* args, PyObject* kwargs) {
   Context::Configuration config;
@@ -213,16 +216,19 @@ static PyMethodDef LocationObject_methods[] = {
 
 PyTypeObject LocationType = {
   PyVarObject_HEAD_INIT(NULL, 0)
-  .tp_name = "Location",
-  .tp_basicsize = sizeof(LocationObject),
-  .tp_itemsize = 0,
-  .tp_dealloc = (destructor) LocationObject_dealloc,
-  .tp_flags = Py_TPFLAGS_DEFAULT,
-  .tp_doc = PyDoc_STR("The Chapel context object that tracks various frontend state"),
-  .tp_methods = LocationObject_methods,
-  .tp_init = (initproc) LocationObject_init,
-  .tp_new = PyType_GenericNew,
 };
+
+void setupLocationType() {
+  LocationType.tp_name = "Location";
+  LocationType.tp_basicsize = sizeof(LocationObject);
+  LocationType.tp_itemsize = 0;
+  LocationType.tp_dealloc = (destructor) LocationObject_dealloc;
+  LocationType.tp_flags = Py_TPFLAGS_DEFAULT;
+  LocationType.tp_doc = PyDoc_STR("The Chapel context object that tracks various frontend state");
+  LocationType.tp_methods = LocationObject_methods;
+  LocationType.tp_init = (initproc) LocationObject_init;
+  LocationType.tp_new = PyType_GenericNew;
+}
 
 int LocationObject_init(LocationObject* self, PyObject* args, PyObject* kwargs) {
   new (&self->location) Location();
@@ -261,17 +267,20 @@ static PyMethodDef AstNodeObject_methods[] = {
 
 PyTypeObject AstNodeType = {
   PyVarObject_HEAD_INIT(NULL, 0)
-  .tp_name = "AstNode",
-  .tp_basicsize = sizeof(AstNodeObject),
-  .tp_itemsize = 0,
-  .tp_dealloc = (destructor) AstNodeObject_dealloc,
-  .tp_flags = Py_TPFLAGS_BASETYPE,
-  .tp_doc = PyDoc_STR("The base type of Chapel AST nodes"),
-  .tp_iter = (getiterfunc) AstNodeObject_iter,
-  .tp_methods = AstNodeObject_methods,
-  .tp_init = (initproc) AstNodeObject_init,
-  .tp_new = PyType_GenericNew,
 };
+
+void setupAstNodeType() {
+  AstNodeType.tp_name = "AstNode";
+  AstNodeType.tp_basicsize = sizeof(AstNodeObject);
+  AstNodeType.tp_itemsize = 0;
+  AstNodeType.tp_dealloc = (destructor) AstNodeObject_dealloc;
+  AstNodeType.tp_flags = Py_TPFLAGS_BASETYPE;
+  AstNodeType.tp_doc = PyDoc_STR("The base type of Chapel AST nodes");
+  AstNodeType.tp_iter = (getiterfunc) AstNodeObject_iter;
+  AstNodeType.tp_methods = AstNodeObject_methods;
+  AstNodeType.tp_init = (initproc) AstNodeObject_init;
+  AstNodeType.tp_new = PyType_GenericNew;
+}
 
 int AstNodeObject_init(AstNodeObject* self, PyObject* args, PyObject* kwargs) {
   PyObject* contextObjectPy;

--- a/tools/chapel-py/src/core-types.h
+++ b/tools/chapel-py/src/core-types.h
@@ -34,6 +34,7 @@ typedef struct {
   /* Type-specific fields go here. */
 } ContextObject;
 extern PyTypeObject ContextType;
+void setupContextType();
 
 int ContextObject_init(ContextObject* self, PyObject* args, PyObject* kwargs);
 void ContextObject_dealloc(ContextObject* self);
@@ -48,6 +49,7 @@ typedef struct {
   chpl::Location location;
 } LocationObject;
 extern PyTypeObject LocationType;
+void setupLocationType();
 
 int LocationObject_init(LocationObject* self, PyObject* args, PyObject* kwargs);
 void LocationObject_dealloc(LocationObject* self);
@@ -61,6 +63,7 @@ typedef struct {
   const chpl::uast::AstNode* astNode;
 } AstNodeObject;
 extern PyTypeObject AstNodeType;
+void setupAstNodeType();
 
 int AstNodeObject_init(AstNodeObject* self, PyObject* args, PyObject* kwargs);
 void AstNodeObject_dealloc(AstNodeObject* self);
@@ -97,6 +100,8 @@ PyObject* AstNodeObject_location(AstNodeObject *self);
 #undef AST_BEGIN_SUBCLASSES
 #undef AST_END_SUBCLASSES
 #undef DECLARE_PY_OBJECT_FOR
+
+void setupPerNodeTypes();
 
 
 /**

--- a/tools/chapel-py/src/error-tracker.cpp
+++ b/tools/chapel-py/src/error-tracker.cpp
@@ -31,16 +31,19 @@ static PyMethodDef ErrorObject_methods[] = {
 
 PyTypeObject ErrorType = {
   PyVarObject_HEAD_INIT(NULL, 0)
-  .tp_name = "Error",
-  .tp_basicsize = sizeof(ErrorObject),
-  .tp_itemsize = 0,
-  .tp_dealloc = (destructor) ErrorObject_dealloc,
-  .tp_flags = Py_TPFLAGS_DEFAULT,
-  .tp_doc = PyDoc_STR("An error that occurred as part of processing a file with the Chapel compiler frontend"),
-  .tp_methods = ErrorObject_methods,
-  .tp_init = (initproc) ErrorObject_init,
-  .tp_new = PyType_GenericNew,
 };
+
+void setupErrorType() {
+  ErrorType.tp_name = "Error";
+  ErrorType.tp_basicsize = sizeof(ErrorObject);
+  ErrorType.tp_itemsize = 0;
+  ErrorType.tp_dealloc = (destructor) ErrorObject_dealloc;
+  ErrorType.tp_flags = Py_TPFLAGS_DEFAULT;
+  ErrorType.tp_doc = PyDoc_STR("An error that occurred as part of processing a file with the Chapel compiler frontend");
+  ErrorType.tp_methods = ErrorObject_methods;
+  ErrorType.tp_init = (initproc) ErrorObject_init;
+  ErrorType.tp_new = PyType_GenericNew;
+}
 
 int ErrorObject_init(ErrorObject* self, PyObject* args, PyObject* kwargs) {
   new (&self->error) chpl::owned<chpl::ErrorBase>();
@@ -83,16 +86,19 @@ static PyMethodDef ErrorManagerObject_methods[] = {
 
 PyTypeObject ErrorManagerType = {
   PyVarObject_HEAD_INIT(NULL, 0)
-  .tp_name = "ErrorManager",
-  .tp_basicsize = sizeof(ErrorManagerObject),
-  .tp_itemsize = 0,
-  .tp_dealloc = (destructor) ErrorManagerObject_dealloc,
-  .tp_flags = Py_TPFLAGS_DEFAULT,
-  .tp_doc = PyDoc_STR("A wrapper container to help track the errors from a Context."),
-  .tp_methods = ErrorManagerObject_methods,
-  .tp_init = (initproc) ErrorManagerObject_init,
-  .tp_new = PyType_GenericNew,
 };
+
+void setupErrorManagerType() {
+  ErrorManagerType.tp_name = "ErrorManager";
+  ErrorManagerType.tp_basicsize = sizeof(ErrorManagerObject);
+  ErrorManagerType.tp_itemsize = 0;
+  ErrorManagerType.tp_dealloc = (destructor) ErrorManagerObject_dealloc;
+  ErrorManagerType.tp_flags = Py_TPFLAGS_DEFAULT;
+  ErrorManagerType.tp_doc = PyDoc_STR("A wrapper container to help track the errors from a Context.");
+  ErrorManagerType.tp_methods = ErrorManagerObject_methods;
+  ErrorManagerType.tp_init = (initproc) ErrorManagerObject_init;
+  ErrorManagerType.tp_new = PyType_GenericNew;
+}
 
 int ErrorManagerObject_init(ErrorManagerObject* self, PyObject* args, PyObject* kwargs) {
   self->contextObject = nullptr;

--- a/tools/chapel-py/src/error-tracker.h
+++ b/tools/chapel-py/src/error-tracker.h
@@ -31,6 +31,8 @@ typedef struct {
 } ErrorObject;
 extern PyTypeObject ErrorType;
 
+void setupErrorType();
+
 int ErrorObject_init(ErrorObject* self, PyObject* args, PyObject* kwargs);
 void ErrorObject_dealloc(ErrorObject* self);
 PyObject* ErrorObject_location(ErrorObject* self, PyObject* args);
@@ -43,6 +45,8 @@ typedef struct {
   PyObject* contextObject;
 } ErrorManagerObject;
 extern PyTypeObject ErrorManagerType;
+
+void setupErrorManagerType();
 
 int ErrorManagerObject_init(ErrorManagerObject* self, PyObject* args, PyObject* kwargs);
 void ErrorManagerObject_dealloc(ErrorManagerObject* self);

--- a/tools/chapel-py/src/iterator-support.cpp
+++ b/tools/chapel-py/src/iterator-support.cpp
@@ -22,17 +22,20 @@
 
 PyTypeObject AstIterType = {
   PyVarObject_HEAD_INIT(NULL, 0)
-  .tp_name = "AstIter",
-  .tp_basicsize = sizeof(AstIterObject),
-  .tp_itemsize = 0,
-  .tp_dealloc = (destructor) AstIterObject_dealloc,
-  .tp_flags = Py_TPFLAGS_DEFAULT,
-  .tp_doc = PyDoc_STR("An iterator over Chapel AST nodes"),
-  .tp_iter = (getiterfunc) AstIterObject_iter,
-  .tp_iternext = (iternextfunc) AstIterObject_next,
-  .tp_init = (initproc) AstIterObject_init,
-  .tp_new = PyType_GenericNew,
 };
+
+void setupAstIterType() {
+  AstIterType.tp_name = "AstIter";
+  AstIterType.tp_basicsize = sizeof(AstIterObject);
+  AstIterType.tp_itemsize = 0;
+  AstIterType.tp_dealloc = (destructor) AstIterObject_dealloc;
+  AstIterType.tp_flags = Py_TPFLAGS_DEFAULT;
+  AstIterType.tp_doc = PyDoc_STR("An iterator over Chapel AST nodes");
+  AstIterType.tp_iter = (getiterfunc) AstIterObject_iter;
+  AstIterType.tp_iternext = (iternextfunc) AstIterObject_next;
+  AstIterType.tp_init = (initproc) AstIterObject_init;
+  AstIterType.tp_new = PyType_GenericNew;
+}
 
 int AstIterObject_init(AstIterObject* self, PyObject* args, PyObject* kwargs) {
   PyObject* astObjectPy;
@@ -71,17 +74,20 @@ PyObject* AstIterObject_next(AstIterObject *self) {
 
 PyTypeObject AstCallIterType = {
   PyVarObject_HEAD_INIT(NULL, 0)
-  .tp_name = "AstCallIter",
-  .tp_basicsize = sizeof(AstCallIterObject),
-  .tp_itemsize = 0,
-  .tp_dealloc = (destructor) AstCallIterObject_dealloc,
-  .tp_flags = Py_TPFLAGS_DEFAULT,
-  .tp_doc = PyDoc_STR("An iterator over Chapel function call actuals"),
-  .tp_iter = (getiterfunc) AstCallIterObject_iter,
-  .tp_iternext = (iternextfunc) AstCallIterObject_next,
-  .tp_init = (initproc) AstCallIterObject_init,
-  .tp_new = PyType_GenericNew,
 };
+
+void setupAstCallIterType() {
+  AstCallIterType.tp_name = "AstCallIter";
+  AstCallIterType.tp_basicsize = sizeof(AstCallIterObject);
+  AstCallIterType.tp_itemsize = 0;
+  AstCallIterType.tp_dealloc = (destructor) AstCallIterObject_dealloc;
+  AstCallIterType.tp_flags = Py_TPFLAGS_DEFAULT;
+  AstCallIterType.tp_doc = PyDoc_STR("An iterator over Chapel function call actuals");
+  AstCallIterType.tp_iter = (getiterfunc) AstCallIterObject_iter;
+  AstCallIterType.tp_iternext = (iternextfunc) AstCallIterObject_next;
+  AstCallIterType.tp_init = (initproc) AstCallIterObject_init;
+  AstCallIterType.tp_new = PyType_GenericNew;
+}
 
 int AstCallIterObject_init(AstCallIterObject* self, PyObject* args, PyObject* kwargs) {
   PyObject* astObjectPy;

--- a/tools/chapel-py/src/iterator-support.h
+++ b/tools/chapel-py/src/iterator-support.h
@@ -53,6 +53,8 @@ typedef struct {
 } AstIterObject;
 extern PyTypeObject AstIterType;
 
+void setupAstIterType();
+
 int AstIterObject_init(AstIterObject* self, PyObject* args, PyObject* kwargs);
 void AstIterObject_dealloc(AstIterObject* self);
 PyObject* AstIterObject_iter(AstIterObject *self);
@@ -68,6 +70,8 @@ typedef struct {
   PyObject* contextObject;
 } AstCallIterObject;
 extern PyTypeObject AstCallIterType;
+
+void setupAstCallIterType();
 
 int AstCallIterObject_init(AstCallIterObject* self, PyObject* args, PyObject* kwargs);
 void AstCallIterObject_dealloc(AstCallIterObject* self);


### PR DESCRIPTION
This includes three separate fixes:

* Fixing the string processing in `setup.py` to split on multiple whitespace characters (`a   b => [a, b]`) and to ignore `*` for "variable changed" modifiers from `chplenv`.
* Removing designated initializers `{ .tp_xyz = ... }` because they are not supported by older GCCs. I've replaced these with a global function that updates the object's non-default fields. This does introduce an extra call to `setupPythonObjectX` for each python type `X` we provide, but it seemed like a pretty small price to pay for more portability. Designated initializers may or may not be a C++20 extension.
* Adds an always-on `ChplFrontendShared` library that is _always_ built as a shared object (as opposed to a `ChplFrontend`, which is sometimes built as a static library depending on the LLVM configuration). 

I'm not particularly sure about that last one -- perhaps someone more knowledgeable with the deets of the build system and how it got into its current state should review.

Reviewed by @jabraham17 (Python/C++) and @arezaii (build system) -- thanks!