### PR TITLE
Linter rule enforcing methods come after all fields

### DIFF
--- a/test/chplcheck/MethodsAfterFields.chpl
+++ b/test/chplcheck/MethodsAfterFields.chpl
@@ -1,0 +1,53 @@
+record emptyRecord {   
+}
+
+record methodField {
+    proc method1() {
+        return 12;
+    }
+    var field1: int;
+}
+
+record fieldMethodField {
+    var field1: int;
+    proc method1() {
+        return field1;
+    }
+    var field2: int;
+}
+
+record fieldFieldMethod {
+    var field1: int;
+    var field2: int;
+
+    proc method1() {
+        return field1;
+    }
+}
+
+class EmptyClass {   
+}
+
+class MethodField {
+    proc method1() {
+        return 12;
+    }
+    var field1: int;
+}
+
+class FieldMethodField {
+    var field1: int;
+    proc method1() {
+        return field1;
+    }
+    var field2: int;
+}
+
+class FieldFieldMethod {
+    var field1: int;
+    var field2: int;
+
+    proc method1() {
+        return field1;
+    }
+}

--- a/test/chplcheck/MethodsAfterFields.good
+++ b/test/chplcheck/MethodsAfterFields.good
@@ -1,0 +1,4 @@
+MethodsAfterFields.chpl:31: node violates rule MethodsAfterFields
+MethodsAfterFields.chpl:38: node violates rule MethodsAfterFields
+MethodsAfterFields.chpl:4: node violates rule MethodsAfterFields
+MethodsAfterFields.chpl:11: node violates rule MethodsAfterFields

--- a/test/chplcheck/PREDIFF
+++ b/test/chplcheck/PREDIFF
@@ -1,0 +1,3 @@
+#!/bin/bash
+$CHPL_HOME/tools/chplcheck/chplcheck $1.chpl >> $2
+sed -i .tmp "s#$(pwd)/##" $2 # strip the working directory from output

--- a/test/chplcheck/SKIPIF
+++ b/test/chplcheck/SKIPIF
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+source $CHPL_HOME/util/config/run-in-venv-common.bash
+
+if python3 -c "import chapel" 2> /dev/null; then
+    echo "False"
+else
+    echo "True"
+fi
+

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -39,7 +39,7 @@ def check_pascal_case(node):
     return re.fullmatch(r'_?(([A-Z][a-z]+|\d+)+|[A-Z]+)?', name_for_linting(node))
 
 def register_rules(driver):
-    @driver.basic_rule(VarLikeDecl, default=False)
+    @driver.basic_rule(VarLikeDecl)
     def CamelCaseVariables(context, node):
         if node.name() == "_": return True
         return check_camel_case(node)
@@ -56,7 +56,7 @@ def register_rules(driver):
     def PascalCaseModules(context, node):
         return node.kind() == "implicit" or check_pascal_case(node)
 
-    @driver.basic_rule(Module, default=False)
+    @driver.basic_rule(Module)
     def UseExplicitModules(context, node):
         return node.kind() != "implicit"
 
@@ -73,6 +73,17 @@ def register_rules(driver):
             parent = parent.parent()
         return True
 
+    @driver.basic_rule(Record)
+    @driver.basic_rule(Class)
+    def MethodsAfterFields(context, node):
+        method_seen = False
+        for child in node:
+            if isinstance(child, VarLikeDecl) and method_seen:
+                return False
+            if isinstance(child, Function):
+                method_seen = True
+        return True
+
     @driver.basic_rule([Conditional, BoolLiteral, chapel.rest])
     def BoolLitInCondStmt(context, node):
         return False
@@ -84,7 +95,7 @@ def register_rules(driver):
             return context.is_bundled_path(path)
         return True
 
-    @driver.advanced_rule(default=False)
+    @driver.advanced_rule
     def ConsecutiveDecls(context, root):
         def is_relevant_decl(node):
             if isinstance(node, MultiDecl):
@@ -145,53 +156,3 @@ def register_rules(driver):
                     if isinstance(blockchild, Comment): continue
                     prev = blockchild
                     break
-
-    @driver.advanced_rule
-    def UnusedFormal(context, root):
-        formals = dict()
-        uses = set()
-
-        for (formal, _) in chapel.each_matching(root, Formal):
-            # For now, it's harder to tell if we're ignoring 'this' formals
-            # (what about method calls with implicit receiver?). So skip
-            # 'this' formals.
-            if formal.name() == "this":
-                continue
-
-            # extern functions have no bodies that can use their formals.
-            if formal.parent().linkage() == "extern":
-                continue
-
-            formals[formal.unique_id()] = formal
-
-        for (use, _) in chapel.each_matching(root, Identifier):
-            if refersto := use.to_node():
-                uses.add(refersto.unique_id())
-
-        for unused in formals.keys() - uses:
-            yield formals[unused]
-
-    @driver.advanced_rule
-    def UnusedLoopIndex(context, root):
-        indices = dict()
-        uses = set()
-
-        def variables(node):
-            if isinstance(node, Variable):
-                yield node
-            elif isinstance(node, TupleDecl):
-                for child in node:
-                    yield from variables(child)
-
-        for (_, match) in chapel.each_matching(root, [IndexableLoop, ("?decl", Decl), chapel.rest]):
-            node = match["decl"]
-
-            for index in variables(node):
-                indices[index.unique_id()] = index
-
-        for (use, _) in chapel.each_matching(root, Identifier):
-            if refersto := use.to_node():
-                uses.add(refersto.unique_id())
-
-        for unused in indices.keys() - uses:
-            yield indices[unused]


### PR DESCRIPTION
This redoes yesterday's reverted changes with the fix to the SKIPIF. Flattening the directory structure ensures the SKIPIF applies to the test. Now, all the test files are present in the chplcheck directory and the prediff file is generalized to be used for future tests.