### PR TITLE
Avoid zero length VLA in strided comm interface

### DIFF
--- a/runtime/include/chpl-comm-strd-xfer.h
+++ b/runtime/include/chpl-comm-strd-xfer.h
@@ -113,6 +113,9 @@ void put_strd_common(void* dstaddr_arg, size_t* dststrides, int32_t dstlocale,
                      size_t maxOutstandingXfers, void (yieldFn)(void),
                      int32_t commID, int ln, int32_t fn) {
   const size_t strlvls=(size_t)stridelevels;
+  // Avoid 0-lengh VLA when stridelevels is 0 (contiguous transfer), arrays are
+  // not used in this case anyways
+  const size_t strlvls_nz = strlvls == 0 ? 1 : strlvls;
   size_t i,j,k,t,total,off,x,carry;
 
   int8_t* dstaddr,*dstaddr1;
@@ -120,8 +123,8 @@ void put_strd_common(void* dstaddr_arg, size_t* dststrides, int32_t dstlocale,
 
   int *srcdisp, *dstdisp;
 
-  size_t dststr[strlvls];
-  size_t srcstr[strlvls];
+  size_t dststr[strlvls_nz];
+  size_t srcstr[strlvls_nz];
   size_t cnt[strlvls+1];
 
   chpl_comm_nb_handle_t handles[maxOutstandingXfers];
@@ -414,14 +417,17 @@ void strd_common_call(void* dstaddr_arg, size_t* dststrides, int32_t srclocale,
                                       /* ln */ int, /* fn */ int32_t),
                       int32_t commID, int ln, int32_t fn) {
   const size_t strlvls=(size_t)stridelevels;
+  // Avoid 0-lengh VLA when stridelevels is 0 (contiguous transfer), arrays are
+  // not used in this case anyways
+  const size_t strlvls_nz = strlvls == 0 ? 1 : strlvls;
   size_t i,j,k,t,total,off,x,carry;
 
   int8_t* dstaddr,*dstaddr1;
   int8_t* srcaddr,*srcaddr1;
 
   int *srcdisp, *dstdisp;
-  size_t dststr[strlvls];
-  size_t srcstr[strlvls];
+  size_t dststr[strlvls_nz];
+  size_t srcstr[strlvls_nz];
   size_t cnt[strlvls+1];
 
   //Only count[0] and strides are measured in number of bytes.

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -1330,10 +1330,13 @@ void  chpl_comm_get_strd(void* dstaddr, size_t* dststrides, c_nodeid_t srcnode_i
                          int ln, int32_t fn) {
   int i;
   const size_t strlvls = (size_t)stridelevels;
+  // Avoid 0-lengh VLA when stridelevels is 0 (contiguous transfer), gasnet
+  // will ignore arrays in this case
+  const size_t strlvls_nz = strlvls == 0 ? 1 : strlvls;
   const gasnet_node_t srcnode = (gasnet_node_t)srcnode_id;
 
-  size_t dststr[strlvls];
-  size_t srcstr[strlvls];
+  size_t dststr[strlvls_nz];
+  size_t srcstr[strlvls_nz];
   size_t cnt[strlvls+1];
 
   // Only count[0] and strides are measured in number of bytes.
@@ -1376,10 +1379,13 @@ void  chpl_comm_put_strd(void* dstaddr, size_t* dststrides, c_nodeid_t dstnode_i
                          int ln, int32_t fn) {
   int i;
   const size_t strlvls = (size_t)stridelevels;
+  // Avoid 0-lengh VLA when stridelevels is 0 (contiguous transfer), gasnet
+  // will ignore arrays in this case
+  const size_t strlvls_nz = strlvls == 0 ? 1 : strlvls;
   const gasnet_node_t dstnode = (gasnet_node_t)dstnode_id;
 
-  size_t dststr[strlvls];
-  size_t srcstr[strlvls];
+  size_t dststr[strlvls_nz];
+  size_t srcstr[strlvls_nz];
   size_t cnt[strlvls+1];
 
   // Only count[0] and strides are measured in number of bytes.


### PR DESCRIPTION
Zero-length VLAs are undefined behavior (though supported by clang/gnu extensions) so avoid using them in the strided interface when `stridelevels==0`. In this case just use lengh-1 VLAs that don't get used by gasnet or our common shims.