### PR TITLE
Improve index-neutrality of `LinearAlgebra`

### DIFF
--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -1630,6 +1630,10 @@ private proc _lu(in A: [?Adom] ?eltType) {
 
   `ipiv` contains the pivot indices such that row i of `A`
   was interchanged with row `ipiv(i)`.
+
+  .. note::
+
+    Arrays with any offset are supported, and `LU` and `ipiv` inherit the indexing.
 */
 proc lu(A: [?Adom] ?eltType) {
   if Adom.rank != 2 then
@@ -1786,6 +1790,10 @@ proc _norm(x: [?D], param p: normType) where x.rank == 2 {
     where ``L`` is a lower triangular matrix. Setting `unit_diag` to true
     will assume the diagonal elements as `1` and will not be referenced
     within this procedure.
+
+   .. note::
+
+     Arrays with any offset are supported, and ``x`` inherits the indexing.
 */
 proc solve_tril(const ref L: [?Ldom] ?eltType, const ref b: [?bdom] eltType,
                   unit_diag = true)
@@ -1810,6 +1818,10 @@ proc solve_tril(const ref L: [?Ldom] ?eltType, const ref b: [?bdom] eltType,
 
 /* Return the solution ``x`` to the linear system `` U * x = b ``
     where ``U`` is an upper triangular matrix.
+
+   .. note::
+
+     Arrays with any offset are supported, and ``x`` inherits the indexing.
 */
 proc solve_triu(const ref U: [?Udom] ?eltType, const ref b: [?bdom] eltType) {
   const first = Udom.dim(0).first;
@@ -1831,6 +1843,10 @@ proc solve_triu(const ref U: [?Udom] ?eltType, const ref b: [?bdom] eltType) {
 }
 
 /* Return the solution ``x`` to the linear system ``A * x = b``.
+
+   .. note::
+
+     Arrays with any offset are supported, and ``x`` inherits the indexing.
 */
 proc solve(A: [?Adom] ?eltType, ref b: [?bdom] eltType) {
   var (LU, ipiv) = lu(A);

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -1646,36 +1646,26 @@ proc lu(A: [?Adom] ?eltType) {
   return (LU,ipiv);
 }
 
-/* Return a new array as the permuted form of `A` according to
-    permutation array `ipiv`.*/
+/*
+  Return a new array as the permuted form of `A` according to
+  permutation array `ipiv`. Only 1D input arrays are supported, since there is
+  no need for multi-dimensional arrays for now.
+*/
 private proc permute(ipiv: [] int, A: [?Adom] ?eltType, transpose=false) {
-  const dim = Adom;
-  var B: [dim] eltType;
+  const dim = Adom.dim(0);
+  var B: [Adom] eltType;
 
-  if Adom.rank == 1 {
-    if transpose {
-      forall (i,pi) in zip(dim, ipiv) with (ref B) {
-        B[i] = A[pi];
-      }
-    }
-    else {
-      forall (i,pi) in zip(dim, ipiv) with (ref B) {
-        B[pi] = A[i];
-      }
+  if transpose {
+    forall (i,pi) in zip(dim, ipiv) with (ref B) {
+      B[i] = A[pi];
     }
   }
-  else if Adom.rank == 2 {
-    if transpose {
-      forall (i,pi) in zip(dim, ipiv) {
-        B[i, ..] = A[pi, ..];
-      }
-    }
-    else {
-      forall (i,pi) in zip(dim, ipiv) {
-        B[pi, ..] = A[i, ..];
-      }
+  else {
+    forall (i,pi) in zip(dim, ipiv) with (ref B) {
+      B[pi] = A[i];
     }
   }
+
   return B;
 }
 

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -1813,15 +1813,16 @@ proc solve_tril(const ref L: [?Ldom] ?eltType, const ref b: [?bdom] eltType,
     where ``U`` is an upper triangular matrix.
 */
 proc solve_triu(const ref U: [?Udom] ?eltType, const ref b: [?bdom] eltType) {
-  const n = Udom.shape(0);
+  const first = Udom.dim(0).first;
+  const last = Udom.dim(0).last;
   var y = b;
 
-  for i in 0..<n by -1 {
+  for i in first..last by -1 {
     const sol = y(i) / U(i,i);
     y(i) = sol;
 
-    if (i > 0) {
-      forall j in 0..<i by -1 with (ref y) {
+    if (i > first) {
+      forall j in first..<i by -1 with (ref y) {
         y(j) -= U(j,i) * sol;
       }
     }

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -1791,15 +1791,16 @@ proc _norm(x: [?D], param p: normType) where x.rank == 2 {
 proc solve_tril(const ref L: [?Ldom] ?eltType, const ref b: [?bdom] eltType,
                   unit_diag = true)
 {
-  const n = Ldom.shape(0);
+  const first = Ldom.dim(0).first;
+  const last = Ldom.dim(0).last;
   var y = b;
 
-  for i in 0..<n {
+  for i in first..last {
     const sol = if unit_diag then y(i) else y(i) / L(i,i);
     y(i) = sol;
 
-    if (i < n - 1) {
-      forall j in (i+1)..<n with (ref y) {
+    if (i < last) {
+      forall j in (i+1)..last with (ref y) {
         y(j) -= L(j,i) * sol;
       }
     }

--- a/test/library/packages/LinearAlgebra/correctness/no-dependencies/solveLU.chpl
+++ b/test/library/packages/LinearAlgebra/correctness/no-dependencies/solveLU.chpl
@@ -1,0 +1,60 @@
+use LinearAlgebra;
+
+const eps = 1e-7;
+
+proc checkResults(A, x, b) {
+  var v = dot(A, x);
+  for (vv, bb) in zip(v, b) {
+    if (abs(vv - bb) > eps) then return false;
+  }
+  return true;
+}
+
+/*
+  Check correctness of `solve` (calling `lu`).
+
+  Expected results (manually computed): 5.0 -2.0 3.0
+*/
+
+var res = true;
+
+// 0-based domain (default)
+var A: [0..#3, 0..#3] real;
+var b: [0..#3] real;
+
+A[0, ..] = [ 2.0,  1.0, 3.0];
+A[1, ..] = [ 4.0, -1.0, 3.0];
+A[2, ..] = [-2.0,  5.0, 5.0];
+
+b = [17.0, 31.0, -5.0];
+
+const x = solve(A, b);
+b = [17.0, 31.0, -5.0]; // `solve` overrites b
+if !checkResults(A, x, b) {
+  res = false;
+  writeln("test 1 failed");
+}
+
+// 11-based domain
+var A2 = A.reindex(11..#3, 11..#3);
+var b2 = b.reindex(11..#3);
+
+const x2 = solve(A2, b2); // `solve` overrites b2
+b2 = [17.0, 31.0, -5.0];
+if !checkResults(A2, x2, b2) {
+  res = false;
+  writeln("test 2 failed");
+}
+
+// -7-based domain
+var A3 = A.reindex(-7..#3, -7..#3);
+var b3 = b.reindex(-7..#3);
+
+const x3 = solve(A3, b3); // `solve` overrites b3
+b3 = [17.0, 31.0, -5.0];
+if !checkResults(A3, x3, b3) {
+  res = false;
+  writeln("test 3 failed");
+}
+
+if res then writeln("All tests passed");

--- a/test/library/packages/LinearAlgebra/correctness/no-dependencies/solveLU.good
+++ b/test/library/packages/LinearAlgebra/correctness/no-dependencies/solveLU.good
@@ -1,0 +1,1 @@
+All tests passed

--- a/test/library/packages/LinearAlgebra/correctness/no-dependencies/solveTriangular.chpl
+++ b/test/library/packages/LinearAlgebra/correctness/no-dependencies/solveTriangular.chpl
@@ -1,0 +1,54 @@
+use LinearAlgebra;
+
+proc checkResults(A, x, b) {
+  var v = dot(A, x);
+  for (vv, bb) in zip(v, b) {
+    if (vv != bb) then return false;
+  }
+  return true;
+}
+
+/*
+  Check correctness of `solve_tril`.
+  Expected result: 0.5 5.5 5.5 (manually verified)
+*/
+
+var res = true;
+
+// 0-based domain (default)
+var A: [0..#3, 0..#3] real;
+var b: [0..#3] real;
+
+A[0, ..] = [ 2.0,  0.0, 0.0];
+A[1, ..] = [-7.0,  1.0, 0.0];
+A[2, ..] = [ 0.5, -2.0, 2.5];
+
+b = [1.0, 2.0, 3.0];
+
+const x = solve_tril(A, b, false);
+if !checkResults(A, x, b) {
+  res = false;
+  writeln("test 1 failed");
+}
+
+// 11-based domain
+var A2 = A.reindex(11..#3, 11..#3);
+var b2 = b.reindex(11..#3);
+
+const x2 = solve_tril(A2, b2, false);
+if !checkResults(A2, x2, b2) {
+  res = false;
+  writeln("test 2 failed");
+}
+
+// -7-based domain
+var A3 = A.reindex(-7..#3, -7..#3);
+var b3 = b.reindex(-7..#3);
+
+const x3 = solve_tril(A3, b3, false);
+if !checkResults(A3, x3, b3) {
+  res = false;
+  writeln("test 3 failed");
+}
+
+if res then writeln("All tests passed");

--- a/test/library/packages/LinearAlgebra/correctness/no-dependencies/solveTriangular.chpl
+++ b/test/library/packages/LinearAlgebra/correctness/no-dependencies/solveTriangular.chpl
@@ -1,52 +1,65 @@
 use LinearAlgebra;
 
+const eps = 1e-7;
+
 proc checkResults(A, x, b) {
   var v = dot(A, x);
   for (vv, bb) in zip(v, b) {
-    if (vv != bb) then return false;
+    if (abs(vv - bb) > eps) then return false;
   }
   return true;
 }
 
 /*
-  Check correctness of `solve_tril`.
-  Expected result: 0.5 5.5 5.5 (manually verified)
+  Check correctness of `solve_[tril/triu]`.
+
+  Expected results (manually computed):
+      solve_tril(A,            b) =  0.5 5.5 5.5
+      solve_triu(transpose(A), b) = 15.6 4.4 1.2
 */
 
 var res = true;
 
 // 0-based domain (default)
 var A: [0..#3, 0..#3] real;
+var At: [0..#3, 0..#3] real;
 var b: [0..#3] real;
 
 A[0, ..] = [ 2.0,  0.0, 0.0];
 A[1, ..] = [-7.0,  1.0, 0.0];
 A[2, ..] = [ 0.5, -2.0, 2.5];
 
+At = transpose(A);
+
 b = [1.0, 2.0, 3.0];
 
-const x = solve_tril(A, b, false);
-if !checkResults(A, x, b) {
+const xl = solve_tril(A, b, false);
+const xu = solve_triu(At, b);
+if !checkResults(A, xl, b) || !checkResults(At, xu, b) {
   res = false;
   writeln("test 1 failed");
 }
 
 // 11-based domain
 var A2 = A.reindex(11..#3, 11..#3);
+var At2 = At.reindex(11..#3, 11..#3);
 var b2 = b.reindex(11..#3);
 
-const x2 = solve_tril(A2, b2, false);
-if !checkResults(A2, x2, b2) {
+const xl2 = solve_tril(A2, b2, false);
+const xu2 = solve_triu(At2, b2);
+if !checkResults(A2, xl2, b2) || !checkResults(At2, xu2, b2) {
   res = false;
   writeln("test 2 failed");
 }
 
 // -7-based domain
 var A3 = A.reindex(-7..#3, -7..#3);
+var At3 = At.reindex(-7..#3, -7..#3);
 var b3 = b.reindex(-7..#3);
 
-const x3 = solve_tril(A3, b3, false);
-if !checkResults(A3, x3, b3) {
+const xl3 = solve_tril(A3, b3, false);
+const xu3 = solve_triu(At3, b3);
+if !checkResults(A3, xl3, b3) || !checkResults(At3, xu3, b3) {
   res = false;
   writeln("test 3 failed");
 }

--- a/test/library/packages/LinearAlgebra/correctness/no-dependencies/solveTriangular.chpl
+++ b/test/library/packages/LinearAlgebra/correctness/no-dependencies/solveTriangular.chpl
@@ -1,67 +1,133 @@
-use LinearAlgebra;
-
-const eps = 1e-7;
-
-proc checkResults(A, x, b) {
-  var v = dot(A, x);
-  for (vv, bb) in zip(v, b) {
-    if (abs(vv - bb) > eps) then return false;
-  }
-  return true;
-}
+use LinearAlgebra, Random, TestUtils;
 
 /*
-  Check correctness of `solve_[tril/triu]`.
-
-  Expected results (manually computed):
-      solve_tril(A,            b) =  0.5 5.5 5.5
-      solve_triu(transpose(A), b) = 15.6 4.4 1.2
+  This test checks the correctness of the `solve_[tril/triu]` methods.
+  Different offsets and array initializations/sizes are considered for robustness.
 */
+
+const offsets = [0, 11, -7]; // tested offsets
+const eps = 1e-7; // error tolerance
 
 var res = true;
 
-// 0-based domain (default)
-var A: [0..#3, 0..#3] real;
-var At: [0..#3, 0..#3] real;
-var b: [0..#3] real;
+/*
+  Series 1: explicit initialization, with non-unitary diagonal, of size 3 x 3.
 
-A[0, ..] = [ 2.0,  0.0, 0.0];
-A[1, ..] = [-7.0,  1.0, 0.0];
-A[2, ..] = [ 0.5, -2.0, 2.5];
+  Expected results (manually computed):
+    solve_tril(A,            b) =  0.5 5.5 5.5
+    solve_triu(transpose(A), b) = 15.6 4.4 1.2
+*/
+{
+  const n = 3;
 
-At = transpose(A);
+  var A:  [0..#n, 0..#n] real;
+  var At: [0..#n, 0..#n] real;
+  var b:  [0..#n] real;
 
-b = [1.0, 2.0, 3.0];
+  A[0, ..] = [ 2.0, 0.0, 0.0];
+  A[1, ..] = [-7.0, 1.0, 0.0];
+  A[2, ..] = [ 0.5,-2.0, 2.5];
 
-const xl = solve_tril(A, b, false);
-const xu = solve_triu(At, b);
-if !checkResults(A, xl, b) || !checkResults(At, xu, b) {
-  res = false;
-  writeln("test 1 failed");
+  At = transpose(A);
+
+  b = [1.0, 2.0, 3.0];
+
+  for offset in offsets {
+    // reindex
+    const Ao  = A.reindex(offset..#n, offset..#n);
+    const Ato = At.reindex(offset..#n, offset..#n);
+    const bo  = b.reindex(offset..#n);
+
+    // solve
+    const xl = solve_tril(Ao, bo, false);
+    const xu = solve_triu(Ato, bo);
+
+    // check result
+    if !almostEquals(dot(Ao, xl), bo) || !almostEquals(dot(Ato, xu), bo) {
+      res = false;
+      writeln("test with offset ", offset, " in serie 1 failed");
+    }
+  }
 }
 
-// 11-based domain
-var A2 = A.reindex(11..#3, 11..#3);
-var At2 = At.reindex(11..#3, 11..#3);
-var b2 = b.reindex(11..#3);
+/*
+  Series 2: explicit initialization, with unitary diagonal, of size 5 x 5.
 
-const xl2 = solve_tril(A2, b2, false);
-const xu2 = solve_triu(At2, b2);
-if !checkResults(A2, xl2, b2) || !checkResults(At2, xu2, b2) {
-  res = false;
-  writeln("test 2 failed");
+  Expected results (manually computed):
+    solve_tril(A,            b) = 1.0    0.0  -0.5 -0.75 0.625
+    solve_triu(transpose(A), b) = 0.625 -0.75 -0.5  0.0  1.0
+*/
+{
+  const n = 5;
+
+  var A:  [0..#n, 0..#n] real;
+  var At: [0..#n, 0..#n] real;
+  var b:  [0..#n] real;
+
+  A[0,..] = [ 1.0, 0.0, 0.0, 0.0, 0.0];
+  A[1,..] = [-0.5, 1.0, 0.0, 0.0, 0.0];
+  A[2,..] = [ 0.0,-0.5, 1.0, 0.0, 0.0];
+  A[3,..] = [ 0.0, 0.0,-0.5, 1.0, 0.0];
+  A[4,..] = [ 0.0, 0.0, 0.0,-0.5, 1.0];
+
+  At = transpose(A);
+
+  b = [1.0, -0.5, -0.5, -0.5, 1.0];
+
+  for offset in offsets {
+    // reindex
+    const Ao  = A.reindex(offset..#n, offset..#n);
+    const Ato = At.reindex(offset..#n, offset..#n);
+    const bo  = b.reindex(offset..#n);
+
+    // solve
+    const xl = solve_tril(Ao, bo, true);
+    const xu = solve_triu(Ato, bo);
+
+    // check result
+    if !almostEquals(dot(Ao, xl), bo) || !almostEquals(dot(Ato, xu), bo) {
+      res = false;
+      writeln("test with offset ", offset, " in serie 2 failed");
+    }
+  }
 }
 
-// -7-based domain
-var A3 = A.reindex(-7..#3, -7..#3);
-var At3 = At.reindex(-7..#3, -7..#3);
-var b3 = b.reindex(-7..#3);
+/*
+  Series 3: random initialization of size 20 x 20.
+*/
+{
+  const n = 20;
 
-const xl3 = solve_tril(A3, b3, false);
-const xu3 = solve_triu(At3, b3);
-if !checkResults(A3, xl3, b3) || !checkResults(At3, xu3, b3) {
-  res = false;
-  writeln("test 3 failed");
+  var A:  [0..#n, 0..#n] real;
+  var At: [0..#n, 0..#n] real;
+  var b:  [0..#n] real;
+
+  fillRandom(A, min=-100.0, max=100.0);
+  for i in 0..#n {
+    for j in i+1..<n {
+      A(i,j) = 0.0;
+    }
+  }
+  At = transpose(A);
+  fillRandom(b, min=-100.0, max=100.0);
+
+  for offset in offsets {
+    // reindex
+    const Ao  = A.reindex(offset..#n, offset..#n);
+    const Ato = At.reindex(offset..#n, offset..#n);
+    const bo  = b.reindex(offset..#n);
+
+    // solve
+    const xl = solve_tril(Ao, bo, false);
+    const xu = solve_triu(Ato, bo);
+
+    // check result
+    if !almostEquals(dot(Ao, xl), bo) || !almostEquals(dot(Ato, xu), bo) {
+      res = false;
+      writeln("test with offset ", offset, " in serie 3 failed");
+    }
+  }
 }
 
 if res then writeln("All tests passed");
+else writeln("Some tests failed");

--- a/test/library/packages/LinearAlgebra/correctness/no-dependencies/solveTriangular.good
+++ b/test/library/packages/LinearAlgebra/correctness/no-dependencies/solveTriangular.good
@@ -1,0 +1,1 @@
+All tests passed


### PR DESCRIPTION
This PR is part of #17624 and improves the index-neutrality (any offset) of the following procedures:
- `solve_tril`
- `solve_triu`
- `solve`
    - private `_lu`
    - private `permute`
- `lu` (implicitly)
- `det` (implicitly)

It also adds several correctness tests.

Resolves #17513