### PR TITLE
Add no-local.good file for regex test

### DIFF
--- a/test/regex/defaultInitializer.no-local.good
+++ b/test/regex/defaultInitializer.no-local.good
@@ -1,0 +1,7 @@
+new regex("")
+find: '0'
+y: 'new regex("")'
+x: 'new regex("")'
+'hello'
+replaced: ''
+(matched = true, byteOffset = 0, numBytes = 0)


### PR DESCRIPTION
Add `no-local.good` file for regex test which has different behavior with and without comm

Address an issue with nightly testing

Tested locally with `comm=none`, `comm=gasnet`, and `--no-local`

[not reviewed - trivial]