### PR TITLE
Replace CompilerInstance::createTarget() for old LLVMs

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -3043,7 +3043,13 @@ void runClang(const char* just_parse_filename) {
   if (fDriverPhaseTwo) {
     // Needed for phase two but is only otherwise run by the skipped
     // ExecuteAction below.
+#if HAVE_LLVM_VER >= 130
     clangInfo->Clang->createTarget();
+#else
+    clangInfo->Clang->setTarget(TargetInfo::CreateTargetInfo(
+        clangInfo->Clang->getDiagnostics(),
+        clangInfo->Clang->getInvocation().TargetOpts));
+#endif
 
     return;
   }


### PR DESCRIPTION
Conditionally replace the call to `CompilerInstance::createTarget()` added in https://github.com/chapel-lang/chapel/pull/23795 with the equivalent code for Clang 11/12.

Determined the correct code by inspecting Clang 12 source code and seeing this is what `ExecuteAction` calls instead of the not-yet-existent `createTarget()` function.

Follow up to https://github.com/chapel-lang/chapel/pull/23795.

[trivial fix, not reviewed]

Testing:
- [x] paratest with `--compiler-driver`
- [x] helloworld on chapcs with LLVM 11 and `--compiler-driver`