### PR TITLE
Overwrite driver tmp files on first use

### DIFF
--- a/compiler/include/files.h
+++ b/compiler/include/files.h
@@ -96,17 +96,16 @@ void addLibPath(const char* filename, bool fromCmdLine = false);
 void addLibFile(const char* filename, bool fromCmdLine = false);
 void addIncInfo(const char* incDir, bool fromCmdLine = false);
 
-// Ensure the tmp dir is set up for use by the driver (i.e., isn't about to be
-// replaced).
-void checkDriverTmp();
 // Save (append) provided string into the given tmp file.
 // For storing information that needs to be saved between driver phases.
 void saveDriverTmp(const char* tmpFilePath, const char* stringToSave,
                    bool appendNewline = true);
 // Like saveDriverTmp, but accepts a vector of strings to save in one go without
-// repeatedly opening/closing file.
+// repeatedly opening/closing file. Newline separated by default unless
+// noNewlines is true.
 void saveDriverTmpMultiple(const char* tmpFilePath,
-                           std::vector<const char*> stringsToSave);
+                           std::vector<const char*> stringsToSave,
+                           bool noNewlines = false);
 // Feed strings from the specified tmp file (one per line) into the given
 // restoring function, which should copy any it needs to keep.
 // For accessing information saved between driver phases with saveDriverTmp.

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -166,9 +166,11 @@ void saveDriverTmpMultiple(const char* tmpFilePath,
   // Contents expected to be astrs so it's safe to use a set.
   static std::unordered_set<const char*> seen;
 
-  // Overwrite on first use, append after.
-  const char* fileOpenMode = "w";
-  if (!seen.emplace(pathAsAstr).second) {
+  // Overwrite on first use in phase one or driver init, append after.
+  const char* fileOpenMode;
+  if (seen.emplace(pathAsAstr).second && !fDriverPhaseTwo) {
+    fileOpenMode = "w";
+  } else {
     // Already seen
     fileOpenMode = "a";
   }

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -168,7 +168,7 @@ void saveDriverTmpMultiple(const char* tmpFilePath,
 
   // Overwrite on first use, append after.
   const char* fileOpenMode = "w";
-  if (seen.emplace(pathAsAstr).second) {
+  if (!seen.emplace(pathAsAstr).second) {
     // Already seen
     fileOpenMode = "a";
   }

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -123,7 +123,9 @@ void addIncInfo(const char* incDir, bool fromCmdLine) {
   }
 }
 
-void checkDriverTmp() {
+// Ensure the tmp dir is set up for use by the driver (i.e., isn't about to be
+// replaced).
+static void checkDriverTmp() {
   assert(!fDriverDoMonolithic && "meant for use in driver mode only");
 
   bool valid = false;
@@ -146,20 +148,20 @@ void checkDriverTmp() {
 
 void saveDriverTmp(const char* tmpFilePath, const char* stringToSave,
                    bool appendNewline) {
-  checkDriverTmp();
-
-  fileinfo* file = openTmpFile(tmpFilePath, "a");
-  fprintf(file->fptr, "%s%s", stringToSave, (appendNewline ? "\n" : ""));
-  closefile(file);
+  saveDriverTmpMultiple(tmpFilePath, {stringToSave}, !appendNewline);
 }
 
 void saveDriverTmpMultiple(const char* tmpFilePath,
-                           std::vector<const char*> stringsToSave) {
+                           std::vector<const char*> stringsToSave,
+                           bool noNewlines) {
   checkDriverTmp();
 
-  fileinfo* file = openTmpFile(tmpFilePath, "a");
+  const char* pathAsAstr = astr(tmpFilePath);
+
+  // Write into tmp file
+  fileinfo* file = openTmpFile(pathAsAstr, "a");
   for (const auto stringToSave : stringsToSave) {
-    fprintf(file->fptr, "%s\n", stringToSave);
+    fprintf(file->fptr, "%s%s", stringToSave, (noNewlines ? "" : "\n"));
   }
   closefile(file);
 }


### PR DESCRIPTION
Overwrite driver tmp files the first time they are written to, so stored results from previous compilations are not saved.

Along the way, simplify the implementation of `saveDriverTmp` to just call its sibling `saveDriverTmpMultiple` and avoid duplicated code.

Resolves https://github.com/Cray/chapel-private/issues/5642.

[reviewer info placeholder]

Testing:
- [x] fixes bug as observed in https://github.com/chapel-lang/chapel/pull/23818
- [x] paratest with and without `--compiler-driver`
- [x] C backend paratest with and without `--compiler-driver`