### PR TITLE
Cleanups to docs and compiler w.r.t. `-pg` and particularly the LLVM back-end

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1974,6 +1974,12 @@ static void checkLLVMCodeGen() {
               "       'chpl' was built without LLVM support.  Either select a different\n"
               "       target compiler or re-build your compiler with LLVM enabled.");
 #endif
+  if (fLlvmCodegen) {
+    if ((ccflags.find("-pg") != std::string::npos) ||
+        (ldflags.find("-pg") != std::string::npos)) {
+      USR_WARN("The LLVM target compiler does not currently support '-pg'");
+    }
+  }
 }
 
 static void checkTargetCpu() {

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -54,6 +54,7 @@
 
 #include <string>
 #include <map>
+#include <regex>
 
 #ifdef HAVE_LLVM
 #include "llvm/Config/llvm-config.h"
@@ -1975,8 +1976,8 @@ static void checkLLVMCodeGen() {
               "       target compiler or re-build your compiler with LLVM enabled.");
 #endif
   if (fLlvmCodegen) {
-    if ((ccflags.find("-pg") != std::string::npos) ||
-        (ldflags.find("-pg") != std::string::npos)) {
+    auto re = std::regex("(^|\\s)-pg($|\\s)");
+    if (std::regex_search(ccflags, re) || std::regex_search(ldflags, re)) {
       USR_WARN("The LLVM target compiler does not currently support '-pg'");
     }
   }

--- a/doc/rst/developer/bestPractices/GeneratedCode.rst
+++ b/doc/rst/developer/bestPractices/GeneratedCode.rst
@@ -176,127 +176,33 @@ then call ``sdirs`` from the gdb prompt (do not use `~` or `$CHPL_HOME`), e.g.:
 Profiling the generated code
 ----------------------------
 
-We basically use ``gprof`` for profiling. (There is also ``gcov``.)
+Some Chapel programmers have had success profiling Chapel's generated
+code using ``gprof`` using the instructions given below.  Others have
+had successes with the Linux-based ``perf record``/``perf report``
+commands, HPCToolkit, or other performance analysis tools (not covered
+here).
 
+To use ``gprof``:
 
-* Be sure your runtime is compiled with optimization (see above).
+* Note that, at present, this is only supported when using the C
+  back-end, not the LLVM back-end.  As a result,
+  ``CHPL_TARGET_COMPILER`` must be set or inferred to something other
+  than ``llvm``.
 
+* For best results, be sure your runtime is compiled with
+  ``OPTIMIZE=1`` to reduce the time spent in runtime code.  You may
+  also want to build it with ``PROFILE=1`` in order to have it
+  included in your profiling report.
 
 * When compiling, use:
 
       ``--ccflags -pg --ldflags -pg --fast --savec DIRECTORY``
 
-  This produces `gprof-enabled` executable. (See `gprof` docs if unfamiliar.)
+  This produces a `gprof-enabled` executable.
 
-  You probably want ``--fast`` ``--savec``, but they do not affect profilability.
-
-
-* If you want to profile the runtime as well, build it so:
-
- ::
-      
-      cd $CHPL_HOME/runtime
-      make clean
-      make DEBUG=0 OPTIMIZE=1 PROFILE=1
-
-Note: currently you can have only one compilation of the runtime (see above).
-
-
-Debugging/profiling the generated code, alternative approach
-------------------------------------------------------------
-
-You might find it more convenient to debug and profile (``gprof``/``gcov``)
-*the same* version of the generated code.
-
-
-* Keep track of how your runtime is presently built (see above).
-
-
-* When compiling, use ``--savec`` but not ``-g`` (I think), ``--ccflags``, or ``--ldflags``,
-  for example:
-
-      ``--fast --savec DIR --c-line-numbers``
-
-* Option A: run ``make -f DIR/Makefile`` then adjust the compilation
-  commands being issued. (You might even be able to redirect the
-  compilation to different runtime/lib directories.)
-
-
-* Option B is to replace `DIR/Makefile`
-  with the following (change ``a.out`` to your preferred executable name):
-
-.. code-block :: bash
-
-
-  ifneq ($(DB),)
-  EXTR_FLAGS += -g
-  EXTR_sfx += .db
-  endif
-
-  ifneq ($(GP),)
-  EXTR_FLAGS += -pg
-  EXTR_sfx += .gp
-  endif
-
-  ifneq ($(GC),)
-  EXTR_FLAGS += -fprofile-arcs -ftest-coverage
-  EXTR_sfx += .gc
-  endif
-
-  ifneq ($(DB),)
-  # don't want OPT_CFLAGS
-  COMP_GEN_CFLAGS = $(EXTR_FLAGS) $(WARN_GEN_CFLAGS)               $(NO_IEEE_FLOAT_GEN_CFLAGS)
-  else
-  COMP_GEN_CFLAGS = $(EXTR_FLAGS) $(WARN_GEN_CFLAGS) $(OPT_CFLAGS) $(NO_IEEE_FLOAT_GEN_CFLAGS)
-  endif
-
-  COMP_GEN_LFLAGS = $(EXTR_FLAGS) 
-  BINNAME = a.out$(EXTR_sfx)
-  TMPDIRNAME := $(dir $(lastword $(MAKEFILE_LIST)))
-  TMPBINNAME = $(TMPDIRNAME)a.out.tmp
-  CHAPEL_ROOT = $(CHPL_HOME)
-  TAGS_COMMAND = -@which $(CHPL_TAGS_UTIL) > /dev/null 2>&1 && test -f $(CHAPEL_ROOT)/runtime/$(CHPL_TAGS_FILE) && cd $(TMPDIRNAME) && cp $(CHAPEL_ROOT)/runtime/$(CHPL_TAGS_FILE) . && $(CHPL_TAGS_UTIL) $(CHPL_TAGS_FLAGS) $(CHPL_TAGS_APPEND_FLAG) *.c *.h
-
-  CHPLSRC = $(TMPDIRNAME)_main.c 
-  LIBS =
-
-  include $(CHAPEL_ROOT)/runtime/etc/Makefile.include
-
-
-Do all compilations in DIR (e.g. the directory with the generated code).
-
-::
-
-      make DB=1   # generates 'a.out.db' for debugging
-      make GP=1   # generates 'a.out.gp' for gprof
-      make GC=1   # generates 'a.out.gc' for gcov
-
-For ``gcov``, you may need to rename a couple of files by hand:
-
-::
-
-      rm *.c.gcov *.gcda *.gcno
-      make GC=1
-      ./a.out.gc <whatever options you have for a.out>
-      mv a.out{.tmp,}.gcda
-      mv a.out{.tmp,}.gcno
-      gcov a.out.gc
-
-
-Profiling only parts of the runtime
------------------------------------
-
-Do you want ``gprof/gcov/...`` to look only at certain parts of the runtime,
-to reduce profiling overhead, making the results more true to reality?
-
-One way to do so is to transplant those parts from the runtime into
-the generated code, patching everything involved to satisfaction
-(e.g. so that those parts compile and the generated code refers to
-them instead of the original runtime). This can easily be laborious,
-but you get good control over what's going on.
-
-Be sure NOT to re-run the Chapel compiler.
-
+  The use of ``--fast`` and ``--savec`` are not strictly necessary,
+  but will improve exeution time and give you access to the generated
+  C code (in the named directory), respectively.
 
 
 Miscellanea

--- a/doc/rst/developer/bestPractices/GeneratedCode.rst
+++ b/doc/rst/developer/bestPractices/GeneratedCode.rst
@@ -178,9 +178,8 @@ Profiling the generated code
 
 Some Chapel programmers have had success profiling Chapel's generated
 code using ``gprof`` using the instructions given below.  Others have
-had successes with the Linux-based ``perf record``/``perf report``
-commands, HPCToolkit, or other performance analysis tools (not covered
-here).
+had successes with the Linux-based ``perf`` command, HPCToolkit, or
+other performance analysis tools (not covered here).
 
 To use ``gprof``:
 

--- a/doc/rst/usingchapel/building.rst
+++ b/doc/rst/usingchapel/building.rst
@@ -208,12 +208,19 @@ WARNINGS=0``).
   ========  ================================================================
   Option    Effect
   ========  ================================================================
+  ASSERTS   Enables correctness assertions in the compiler and runtime
   DEBUG     Generate debug information (e.g., pass ``-g`` to the C compiler)
   OPTIMIZE  Enable optimizations (e.g., pass ``-O3`` to the C compiler)
   PROFILE   Enable profiling support (e.g., pass ``-pg`` to C compiler)
   WARNINGS  Enable more warnings and treat them as errors
-  ASSERTS   Enables correctness assertions in the compiler and runtime
   ========  ================================================================
+
+Note that these settings only affect how the ``chpl`` compiler and its
+runtime libraries are built, as well as the third-party packages that
+they rely upon.  In particular, building Chapel with ``DEBUG`` or
+``OPTIMIZE`` set will not cause invocations of the 'chpl' compiler to
+automatically generate an executable with debugging or optimizations
+on.
 
 
 ------------------------

--- a/doc/rst/usingchapel/building.rst
+++ b/doc/rst/usingchapel/building.rst
@@ -218,9 +218,9 @@ WARNINGS=0``).
 Note that these settings only affect how the ``chpl`` compiler and its
 runtime libraries are built, as well as the third-party packages that
 they rely upon.  In particular, building Chapel with ``DEBUG`` or
-``OPTIMIZE`` set will not cause invocations of the 'chpl' compiler to
-automatically generate an executable with debugging or optimizations
-on.
+``OPTIMIZE`` set will not cause invocations of the resulting ``chpl``
+compiler to automatically generate executables with debugging or
+optimizations enabled.
 
 
 ------------------------

--- a/test/compflags/testPgWithLlvm.chpl
+++ b/test/compflags/testPgWithLlvm.chpl
@@ -1,0 +1,1 @@
+writeln("Hello!");

--- a/test/compflags/testPgWithLlvm.compopts
+++ b/test/compflags/testPgWithLlvm.compopts
@@ -1,0 +1,4 @@
+--ccflags=-pg
+--ldflags=-pg
+--ccflags="-O3 -pg -O3"
+--ccflags=-pg --ldflags=-pg

--- a/test/compflags/testPgWithLlvm.compopts
+++ b/test/compflags/testPgWithLlvm.compopts
@@ -2,3 +2,4 @@
 --ldflags=-pg
 --ccflags="-O3 -pg -O3"
 --ccflags=-pg --ldflags=-pg
+--ccflags=-Iprk-iz-pgs         # testPgWithLlvm-ok.good

--- a/test/compflags/testPgWithLlvm.good
+++ b/test/compflags/testPgWithLlvm.good
@@ -1,0 +1,2 @@
+warning: The LLVM target compiler does not currently support '-pg'
+Hello!

--- a/test/compflags/testPgWithLlvm.skipif
+++ b/test/compflags/testPgWithLlvm.skipif
@@ -1,0 +1,1 @@
+CHPL_TARGET_COMPILER!=llvm


### PR DESCRIPTION
Based on user interactions this week, this refreshes some documentation w.r.t. profiling and also adds a warning to the compiler if trying to use the `-pg` flag with the LLVM back-end to indicate that it is not supported.  Specifically it:

* adds a warning to the compiler when the target compiler is LLVM and ccflags or ldflags contains the string `-pg`
* adds a test for this warning
* adds a caveat to the documentation about profiling generated code using `gprof` not being supported by the LLVM back-end
* adds an indication that other performance analysis tools may be used with Chapel without providing instructions
* refreshes the profiling-related text now that this developer-oriented document is available on the web docs and readily findable by searching.  Specifically, it:
  * fixed grammatical errors (hopefully without introducing new ones)
  * tries to linearize and tighten up the descriptions
  * removes a bunch of stuff that feels very advanced developer-oriented and potentially outdated
* clarifies that settings made at `make` time only affect the compiler, runtime, and third-parties, not the compiler's behavior
* re-alphabetizes the table of major build options available in the Makefiles

Resolves https://github.com/chapel-lang/chapel/issues/23858