### PR TITLE
Update test to lock in bug fix from #23805

### DIFF
--- a/test/io/corrado/buffering_optimization/growing_buff_read_write.chpl
+++ b/test/io/corrado/buffering_optimization/growing_buff_read_write.chpl
@@ -21,7 +21,7 @@ var i : uint(8) = 1;
 while bufSize < maxBufSize {
   buf = i;
   fw.writeBinary(buf);
-  bufSize *= 2;
+  if i > 1 then bufSize *= 2;
   bufDom = {0..<bufSize};
   i += 1;
 }
@@ -42,7 +42,7 @@ while bufSize < maxBufSize {
     writeln(buf);
   }
 
-  bufSize *= 2;
+  if i > 1 then bufSize *= 2;
   bufDom = {0..<bufSize};
   i += 1;
 }

--- a/test/io/corrado/buffering_optimization/growing_buff_read_write.chpl
+++ b/test/io/corrado/buffering_optimization/growing_buff_read_write.chpl
@@ -1,13 +1,13 @@
 use IO, CTypes, FileSystem;
 
 extern var qbytes_iobuf_size:c_size_t;
-qbytes_iobuf_size = 1024:c_size_t;
+qbytes_iobuf_size = 2048:c_size_t;
 
 extern var qio_write_unbuffered_threshold:c_ssize_t;
-qio_write_unbuffered_threshold = 2048:c_ssize_t;
+qio_write_unbuffered_threshold = 1024:c_ssize_t;
 
 extern var qio_read_unbuffered_threshold:c_ssize_t;
-qio_read_unbuffered_threshold = 2048:c_ssize_t;
+qio_read_unbuffered_threshold = 1024:c_ssize_t;
 
 config const maxBufSize = 16384;
 


### PR DESCRIPTION
https://github.com/chapel-lang/chapel/pull/23805 fixed a bug in the IO runtime related to the non-buffered read optimization.

This PR updates a test related to the optimization to ensure that a bug of a similar nature isn't introduced in the future (per the recommendation in [this comment](https://github.com/chapel-lang/chapel/pull/23805#issuecomment-1813182936)). The bug only occured when a series of reads added up exactly to the size of one QIO buffer chunk, so the test is updated to meet that condition.