### PR TITLE
Optimizations and fixes to write/readBinary()

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -8796,7 +8796,7 @@ proc fileWriter.writeBinary(ptr: c_ptr(void), numBytes: int) throws {
 proc fileWriter.writeBinary(arg:numeric,
                             param endian:ioendian = ioendian.native) throws {
   const e: errorCode = try _write_binary_internal(_channel_internal,
-                                                  endianToIOKind(endian),
+                                                  endianToIoKind(endian),
                                                   arg);
   if (e != 0) {
     throw createSystemOrChplError(e);


### PR DESCRIPTION
This optimizes write/readBinary() to use the fast-path "native" code whenever the endianness requested explicitly matches the current architecture's endianness.  Previously, we fell into the slow path for both big/little choices whether or not our architecture is big/little.  Also applied this optimization to readBulkElements() and writeBulkElements().

While testing, I noticed and fixed a bug in which readBinary() was returning the number of bytes read rather than the number of array elements read when using the fast path.  Our only tests of the fast path were testing 8-bit values which is why this was not noticed previously.

While here, I also refactored some logic to exchange multi-case select statements for a singleton call that makes use of a new param->param helper procedure for converting from an endianness enum to an ioKind value.