### PR TITLE
Fix forward declaration in LibraryFileWriter.h

### DIFF
--- a/frontend/include/chpl/libraries/LibraryFile.h
+++ b/frontend/include/chpl/libraries/LibraryFile.h
@@ -47,7 +47,6 @@ namespace uast {
 }
 namespace libraries {
 class LibraryFile;
-struct LocationsMap;
 
 /** Helper object to interact with the Deserializer to:
       * read long strings from a LibraryFile strings table

--- a/frontend/include/chpl/libraries/LibraryFileWriter.h
+++ b/frontend/include/chpl/libraries/LibraryFileWriter.h
@@ -42,7 +42,7 @@ class LibraryFileWriter;
 /**
   Helper object for registering serialized uAST positions during serialization
  */
-struct LibraryFileSerializationHelper {
+class LibraryFileSerializationHelper {
  friend class LibraryFileWriter;
 
  private:


### PR DESCRIPTION
Follow-up to PR #23862 to fix a `clang` error/warning when building with `clang` on Mac OS X about mixing `struct` and `class` in forward declarations. Also removes an unused forward declaration.

Trivial and not reviewed.

- [x] full comm=none testing