### PR TITLE
Add a Makefile target for `chplcheck` and install it to `bin` for in-source builds.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,12 @@ c2chapel: third-party-c2chapel-venv FORCE
 	cd tools/c2chapel && $(MAKE)
 	cd tools/c2chapel && $(MAKE) install
 
+chplcheck: FORCE
+	@# chplcheck's build files take care of ensuring the virtual env is built.
+	@# Best not to depend on chapel-py-venv here, because at the time of
+	@# writing this target is always FORCEd (so we'd end up building it twice).
+	cd tools/chplcheck && $(MAKE) all install
+
 compile-util-python: FORCE
 	@if $(CHPL_MAKE_PYTHON) -m compileall -h > /dev/null 2>&1 ; then \
 	  echo "Compiling Python scripts in util/" ; \

--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,7 @@ c2chapel: third-party-c2chapel-venv FORCE
 	cd tools/c2chapel && $(MAKE)
 	cd tools/c2chapel && $(MAKE) install
 
-chplcheck: FORCE
+chplcheck: frontend-shared FORCE
 	@# chplcheck's build files take care of ensuring the virtual env is built.
 	@# Best not to depend on chapel-py-venv here, because at the time of
 	@# writing this target is always FORCEd (so we'd end up building it twice).

--- a/Makefile
+++ b/Makefile
@@ -122,12 +122,13 @@ third-party-c2chapel-venv: FORCE
 	cd third-party && $(MAKE) c2chapel-venv; \
 	fi
 
-third-party-chapel-py-venv: frontend-shared FORCE
+third-party-chapel-py-venv: FORCE
 	cd third-party && $(MAKE) chapel-py-venv;
 
 test-venv: third-party-test-venv
 
-chapel-py-venv: third-party-chapel-py-venv
+chapel-py-venv: frontend-shared
+	$(MAKE) third-party-chapel-py-venv
 
 chpldoc: third-party-chpldoc-venv
 	@cd third-party && $(MAKE) llvm

--- a/third-party/Makefile
+++ b/third-party/Makefile
@@ -93,6 +93,9 @@ c2chapel-venv: FORCE
 chapel-py-venv: FORCE
 	cd chpl-venv && $(MAKE) chapel-py-venv
 
+chplcheck-venv: FORCE
+	cd chpl-venv && $(MAKE) chplcheck-venv
+
 # See gasnet/Makefile for explanation of the post-install step
 gasnet: $(GASNET_INSTALL_DIR)
 $(GASNET_INSTALL_DIR): $(GASNET_DEPEND)

--- a/third-party/chpl-venv/Makefile
+++ b/third-party/chpl-venv/Makefile
@@ -107,6 +107,8 @@ chapel-py-venv: FORCE $(CHPL_VENV_VIRTUALENV_DIR_OK)
 	  $(CHPL_MAKE_HOME)/tools/chapel-py \
 	  -r $(CHPL_VENV_CHPLCHECK_REQUIREMENTS_FILE)
 
+chplcheck-venv: chapel-py-venv
+
 install-requirements: install-chpldeps
 
 $(CHPL_VENV_CHPLSPELL_REQS): $(CHPL_VENV_VIRTUALENV_DIR_OK) $(CHPL_VENV_CHPLSPELL_REQUIREMENTS_FILE)

--- a/third-party/chpl-venv/Makefile
+++ b/third-party/chpl-venv/Makefile
@@ -92,11 +92,16 @@ chpldoc-venv: install-chpldeps
 
 c2chapel-venv: install-chpldeps
 
-# the Python bindings depend on libChplFrontendShared.so, which we probably
-# shouldn't explicitly list here. So, make this target FORCE to always
-# perform a rebuild. Parent makefiles can intelligently re-build the bindings
-# as needed. Since the target is always forced, no reason to keep
-# around a sentinel file like ok1/ok2.
+# the Python bindings depend on libChplFrontendShared.so and some additional
+# files listed in setup.py. The former is not consistently named (.so on UNIX,
+# .dylib on macOS), making it harder to list as a dependency. The latter we
+# could duplicate in the Makefile here, but that would be a possible 'gotcha':
+# adding to setup.py but not here would break the build system. Thus, take
+# the easy way out and mark this target as FORCE. This isn't too bad since setup.py
+# generally skips re-compiling files that haven't changed.
+#
+# Since the target is always forced, no reason to keep around a sentinel file
+# like ok1/ok2.
 chapel-py-venv: FORCE $(CHPL_VENV_VIRTUALENV_DIR_OK)
 	@# Install chapel-py's Python package into the Python Application
 	@# directory structure at $(CHPL_VENV_CHPLDEPS)

--- a/third-party/chpl-venv/Makefile
+++ b/third-party/chpl-venv/Makefile
@@ -92,7 +92,12 @@ chpldoc-venv: install-chpldeps
 
 c2chapel-venv: install-chpldeps
 
-chapel-py-venv: install-chpldeps
+# the Python bindings depend on libChplFrontendShared.so, which we probably
+# shouldn't explicitly list here. So, make this target FORCE to always
+# perform a rebuild. Parent makefiles can intelligently re-build the bindings
+# as needed. Since the target is always forced, no reason to keep
+# around a sentinel file like ok1/ok2.
+chapel-py-venv: FORCE $(CHPL_VENV_VIRTUALENV_DIR_OK)
 	@# Install chapel-py's Python package into the Python Application
 	@# directory structure at $(CHPL_VENV_CHPLDEPS)
 	export PATH="$(CHPL_VENV_VIRTUALENV_BIN):$$PATH" && \

--- a/tools/chplcheck/Makefile
+++ b/tools/chplcheck/Makefile
@@ -1,0 +1,56 @@
+#
+# Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+# Copyright 2004-2019 Cray Inc.
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+# chplcheck - a Python-based Chapel linter.
+
+ifndef CHPL_MAKE_HOME
+export CHPL_MAKE_HOME=$(realpath $(shell pwd)/../..)
+endif
+
+include $(CHPL_MAKE_HOME)/make/Makefile.base
+include $(CHPL_MAKE_HOME)/third-party/chpl-venv/Makefile.include
+
+bdir=$(CHPL_BIN_DIR)
+link=$(bdir)/chplcheck
+
+all: chplcheck install
+
+chplcheck-venv:
+	cd ../../third-party && $(MAKE) chplcheck-venv
+
+chplcheck: chplcheck-venv
+
+clean:
+ifneq ($(wildcard $(link)),)
+	@echo "Removing old symbolic link..."
+	rm -f $(link)
+	@echo
+endif
+
+cleanall: clean
+
+clobber: clean
+
+$(link): clean
+	@echo "Installing chplcheck symbolic link..."
+	mkdir -p $(bdir)
+	ln -s $(shell pwd)/chplcheck $(link)
+
+install: chplcheck $(link)

--- a/util/config/run-in-venv-common.bash
+++ b/util/config/run-in-venv-common.bash
@@ -11,12 +11,7 @@ python=$($CHPL_HOME/util/config/find-python.sh)
 chpldeps=$("$python" "$CHPL_HOME/util/chplenv/chpl_home_utils.py" --chpldeps)
 
 if [ ! -e "$chpldeps" ]; then
-  echo "chpl dependencies are missing - try make test-venv" 1>&2
-  exit 1
-fi
-
-if [ ! -f "$chpldeps/__main__.py" ]; then
-  echo "chpl dependencies are missing - try make test-venv" 1>&2
+  echo "chpl dependencies are missing - try make test-venv or make chapel-py-venv" 1>&2
   exit 1
 fi
 

--- a/util/config/run-in-venv.bash
+++ b/util/config/run-in-venv.bash
@@ -7,4 +7,10 @@ CWD=$(cd $(dirname $0) ; pwd)
 # Perform checks and set up environment variables for virtual env.
 source $CWD/run-in-venv-common.bash
 
+# Make sure that chpldeps (via its __main__.py) is installed.
+if [ ! -f "$chpldeps/__main__.py" ]; then
+  echo "chpl dependencies are missing - try make test-venv" 1>&2
+  exit 1
+fi
+
 exec "$1" "${@:2}"


### PR DESCRIPTION
This PR adds a `chplcheck` target to our Makefile, which serves to build the Chapel Python bindings if necessary, as well as to install `chplcheck` into `bin`, making it accessible without specifying the path to the `tools` directory. While there, this PR also cleans up some of the Makefiles, slightly untangling the dependencies between the various `third-party/chpl-venv` targets and `chapel-py` (changing the `run-in-venv-*` scripts in the process).

Reviewed by @mppf -- thanks!