### PR TITLE
Fix bugs with generic class downcast error message

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3138,8 +3138,9 @@ static bool isGenericSubclass(Type* targetType, Type* valueType) {
 
   const bool isDowncast = isSubType(atTarget, atValue);
   const bool isTargetTypeGeneric = atTarget->isGeneric();
+  const bool targetTypeHasDefaults = atTarget->isGenericWithDefaults();
+  bool ret = isDowncast && isTargetTypeGeneric && !targetTypeHasDefaults;
 
-  bool ret = isDowncast && isTargetTypeGeneric;
   return ret;
 }
 
@@ -3264,7 +3265,7 @@ static bool resolveBuiltinCastCall(CallExpr* call)
     // here to make sure we don't emit a nonsensical error from later in the
     // pass (e.g., in the module code for the owned manager).
     if (isGenericSubclass(targetType, valueType)) {
-      USR_FATAL(call, "illegal downcast to generic superclass type '%s'",
+      USR_FATAL(call, "illegal downcast to generic subclass type '%s'",
                       toString(targetType));
     }
   }

--- a/test/classes/casts/GenericDowncast.1.good
+++ b/test/classes/casts/GenericDowncast.1.good
@@ -1,2 +1,2 @@
 GenericDowncast.chpl:6: In function 'main':
-GenericDowncast.chpl:10: error: illegal downcast to generic superclass type 'owned D'
+GenericDowncast.chpl:10: error: illegal downcast to generic subclass type 'owned D'

--- a/test/classes/casts/GenericDowncast.2.good
+++ b/test/classes/casts/GenericDowncast.2.good
@@ -1,2 +1,2 @@
 GenericDowncast.chpl:6: In function 'main':
-GenericDowncast.chpl:15: error: illegal downcast to generic superclass type 'shared D'
+GenericDowncast.chpl:15: error: illegal downcast to generic subclass type 'shared D'

--- a/test/classes/casts/GenericDowncast.3.good
+++ b/test/classes/casts/GenericDowncast.3.good
@@ -1,2 +1,2 @@
 GenericDowncast.chpl:6: In function 'main':
-GenericDowncast.chpl:20: error: illegal downcast to generic superclass type 'unmanaged D'
+GenericDowncast.chpl:20: error: illegal downcast to generic subclass type 'unmanaged D'


### PR DESCRIPTION
Fix bugs in #23799 that were breaking Arkouda.

The "downcast to generic subclass" error message I added was firing even when the target type `T` was generic with defaults. Adjust the code to skip emitting the error in that case. While here, fix a silly mistake with the error message wording. We're downcasting to a _subclass_ not a superclass.

TESTING

- [x] `arkouda`
- [x] `linux64`, `standard`

Reviewed by @riftEmber. Thanks!