### PR TITLE
chpldoc: fix python dependencies failing to install

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -234,6 +234,11 @@ $(CHPL_BIN_DIR):
 	mkdir -p $@
 
 install-chpl-chpldoc: $(CHPL) $(CHPLDOC)
+# this target is called from the install.sh script, bypassing the normal
+# way of building chpldoc.  So we need to make sure the venv is built
+	@if [ -z "$$CHPL_DONT_BUILD_CHPLDOC_VENV" ]; then \
+	cd $(CHPL_MAKE_HOME)/third-party && $(MAKE) chpldoc-venv; \
+	fi
 	@cd $(COMPILER_BUILD) && $(CMAKE) $(CHPL_MAKE_HOME) $(CMAKE_FLAGS) && $(MAKE) install
 
 #

--- a/tools/chpldoc/chpldoc.cpp
+++ b/tools/chpldoc/chpldoc.cpp
@@ -74,6 +74,7 @@ bool fPrintSettingsHelp = false;
 bool fPrintChplHome = false;
 bool fPrintVersion = false;
 bool fWarnUnknownAttributeToolname = true;
+std::string CHPL_THIRD_PARTY;
 
 std::vector<UniqueString> usingAttributeToolNames;
 std::vector<std::string> usingAttributeToolNamesStr;
@@ -489,9 +490,11 @@ static int myshell(std::string command,
 
 static
 std::string getChplDepsApp() {
+  std::string thirdParty =
+        CHPL_THIRD_PARTY.empty() ? "" : " CHPL_THIRD_PARTY=" + CHPL_THIRD_PARTY;
   // Runs `util/chplenv/chpl_home_utils.py --chpldeps` and removes the newline
   std::string command = "CHPLENV_SUPPRESS_WARNINGS=true CHPL_HOME=" +
-                         CHPL_HOME + " python3 ";
+                         CHPL_HOME + thirdParty + " python3 ";
   command += CHPL_HOME + "/util/chplenv/chpl_home_utils.py --chpldeps";
 
   std::string venvDir = runCommand(command);
@@ -2226,6 +2229,8 @@ void generateSphinxOutput(std::string sphinxDir, std::string outputDir,
   }
   if (myshell(cmd, "building html output from chpldoc sphinx project") == 0) {
     printf("HTML files are at: %s\n", outputDir.c_str());
+  } else {
+    clean_exit(1);
   }
 }
 
@@ -2269,7 +2274,17 @@ int main(int argc, char** argv) {
   bool installed = false;
   // if user overrides CHPL_HOME from command line, don't go looking for trouble
   if (CHPL_HOME.empty()) {
-    std::error_code err = findChplHome(argv[0], (void*)main, CHPL_HOME, installed, foundEnv, warningMsg);
+    std::error_code err = findChplHome(argv[0], (void*)main, CHPL_HOME,
+                                       installed, foundEnv, warningMsg);
+    if (installed) {
+      // need to determine and update third-party location before calling
+      // getChplDepsApp to make sure we get an updated path in the case
+      // chpldoc was installed using --prefix mode
+      std::string CHPL_THIRD_PARTY = std::string(getConfiguredPrefix());
+      CHPL_THIRD_PARTY += "/lib/chapel/";
+      CHPL_THIRD_PARTY += getMajorMinorVersion();
+      CHPL_THIRD_PARTY += "/third-party";
+    }
     if (!warningMsg.empty()) {
       fprintf(stderr, "%s\n", warningMsg.c_str());
     }


### PR DESCRIPTION
There are several layers to this bug, I'll summarize up top and give more detail 
about each point later.

The reported error was a failure in `chpldoc` after running
```
./configure && make && make install
```

TL;DR there were three different reasons this was failing:

1. we didn't build the `chpldoc` dependencies during `make install`
2. `chpldoc` did not look in the right place for its dependencies if it was installed with `--prefix`
3. `chpldoc` did not return a non-zero exit code when it failed to locate dependencies

<details>
 <summary>The gory details</summary> 

#### Should the user expect `chpldoc` be installed at this point?

It wasn't asked for explicitly, but it was installed and if we are building it 
then we really should also build some python dependencies for `chpldoc`.
(*note, our tests for this explicitly call `make chpldoc` before `make install`)
The root of this failure is that `install.sh`, calls a special `Makefile` target
in `compiler/`, bypassing the `chpldoc venv` dependencies that would otherwise
be triggered from a root level `make chpldoc`. 

#### Well, wouldn't `chpldoc` completely fail to run without it's dependencies? 

We would like to believe so, but since these are runtime dependencies that are
really just for the end result of `chpldoc`'s work (using `sphinx` to convert the
 `rst` into `html`), simple things like `chpldoc -h` or `-v` worked. 
The missing dependencies would only become apparent if you used `chpldoc` on a file. 

#### Certainly we have a test for installing `chpldoc` and running it on a file?

I'm so glad you asked, yes we do have that test. There was another problem though,
when `chpldoc` failed to find the python dependencies, it also ignored the return
code of the subprocess call, so instead of exiting with a 1, it returned 0. This
meant that the `test_install.bash` script happily generated the failure, 
but didn't see it.

#### So how does this PR address these problems?

First, it adds exit code checking to the subprocess call in `chpldoc` and
exits with a non-zero return code if the subprocess fails.

Next, it adds the step to the makefile target that install `chpl` and `chpldoc`
to build the `chpldoc` dependencies so that the install script will be able 
to copy them to the install location. 

#### Glad to hear it all worked out at this point in the story

Well just a second there, professor. The dependencies do get built now, and the
install script will move them to the right location, but `chpldoc` still doesn't
see them...

#### Wait, why doesn't `chpldoc` see them at this point?

Join me on a journey through time, way back when `chpldoc` was really just `chpl`
with a switch. `chpl` has a way of determining its home at runtime and that 
was _mostly_ ported to the new `chpldoc`. 
However, there was a missing component that handled the case when 
`chpldoc` was _installed_. In that case `chpldoc` needs to set the `CHPL_THIRD_PARTY`
environment variable before it uses the utility script `chpl_home_utils.py`
to locate its python dependencies at runtime, or it might get the wrong answer, 
like in the case when it was installed with `--prefix` specifically.

To address this, `chpldoc` now follows similar logic to `chpl` now if it detects it
might be installed, and sets the `CHPL_THIRD_PARTY` variable in the environment
when calling the utility script.
</details>

TESTING:

- [ ] paratest ``
- [x] `chpldoc` returns 1 on exit if it fails to run the sphinx subprocess
- [x] `./configure && make && make install` installs a working `chpldoc`