### PR TITLE
Second attempt at skipping this test under valgrind

### DIFF
--- a/test/compflags/testPgWithLlvm.skipif
+++ b/test/compflags/testPgWithLlvm.skipif
@@ -1,2 +1,3 @@
 CHPL_TARGET_COMPILER!=llvm
-CHPL_TEST_VGRND_EXE == on  # something about -ldflags=-pg causes segfaults?
+# something about -ldflags=-pg causes segfaults when compiled with valgrind?
+CHPL_TEST_VGRND_EXE == on


### PR DESCRIPTION
Though the skipif I committed yesterday worked as expected when running 'start_test -valgrindexe' locally, it did not get skipped in nightly testing as expected.  Jade and I guessed it could have something to do with the end-of-line comment (and Jade successfully proved it where I floundered :D ). so here, I'm hoisting the comment onto a line of its own.