### PR TITLE
update dyno resolver to use new disambiguation rules

### DIFF
--- a/frontend/lib/resolution/disambiguation.cpp
+++ b/frontend/lib/resolution/disambiguation.cpp
@@ -140,19 +140,6 @@ disambiguateByMatch(const DisambiguationContext& dctx,
 static MostSpecificCandidates
 disambiguateByMatch(DisambiguationContext& dctx, CandidatesVec& candidates);
 
-// static int disambiguateByMatch(CallInfo&                 info,
-//                                Scope*                    searchScope,
-//                                CandidatesVec&            candidates,
-//                                DisambiguationCandidate*& bestRef,
-//                                DisambiguationCandidate*& bestConstRef,
-//                                DisambiguationCandidate*& bestValue);
-
-// static const DisambiguationCandidate*
-// findMostSpecificIgnoringReturn(const DisambiguationContext& dctx,
-//                                const CandidatesVec& candidates,
-//                                bool ignoreWhere,
-//                                CandidatesVec& ambiguousBest);
-
 static int compareSpecificity(const DisambiguationContext& dctx,
                               const DisambiguationCandidate& candidate1,
                               const DisambiguationCandidate& candidate2,
@@ -160,27 +147,12 @@ static int compareSpecificity(const DisambiguationContext& dctx,
                               int j,
                               bool forGenericInit);
 
-// static int compareSpecificity(const DisambiguationContext& dctx,
-//                               const DisambiguationCandidate& candidate1,
-//                               const DisambiguationCandidate& candidate2,
-//                               bool ignoreWhere);
-
-// static MoreVisibleResult moreVisible(const DisambiguationContext& dctx,
-//                                      const DisambiguationCandidate& candidate1,
-//                                      const DisambiguationCandidate& candidate2);
-
 static int testArgMapping(const DisambiguationContext& dctx,
                           const DisambiguationCandidate& candidate1,
                           const DisambiguationCandidate& candidate2,
                           int actualIdx,
                           DisambiguationState& ds,
                           std::string& reason);
-
-// static void testArgMapping(const DisambiguationContext& dctx,
-//                            const DisambiguationCandidate& candidate1,
-//                            const DisambiguationCandidate& candidate2,
-//                            int actualIdx,
-//                            DisambiguationState& ds);
 
 static void testArgMapHelper(const DisambiguationContext& dctx,
                              const FormalActual& fa,
@@ -202,24 +174,12 @@ static bool isFormalInstantiatedAny(const DisambiguationCandidate& candidate,
 static bool isFormalPartiallyGeneric(const DisambiguationCandidate& candidate,
                                      const FormalActual* fa);
 
-// static bool prefersConvToOtherNumeric(const DisambiguationContext& dctx,
-//                                       QualifiedType actualType,
-//                                       QualifiedType f1Type,
-//                                       QualifiedType f2Type);
-
 static QualifiedType computeActualScalarType(Context* context,
                                              QualifiedType actualType);
-
-// static bool isNumericParamDefaultType(QualifiedType type);
 
 static bool moreSpecificCanDispatch(const DisambiguationContext& dctx,
                                     QualifiedType actualType,
                                     QualifiedType formalType);
-
-// static MostSpecificCandidates
-// computeMostSpecificCandidatesWithVecs(Context* context,
-//                                       const DisambiguationContext& dctx,
-//                                       const CandidatesVec& vec);
 
 static void discardWorseVisibility(const DisambiguationContext& dctx,
                                    const CandidatesVec& candidates,
@@ -350,143 +310,6 @@ static void gatherVecsByReturnIntent(const DisambiguationContext& dctx,
   }
 }
 
-// TODO: this needs to become, or call? disambiguateByMatch
-// static MostSpecificCandidates
-// computeMostSpecificCandidates(Context* context,
-//                               const DisambiguationContext& dctx,
-//                               const CandidatesVec& candidates) {
-
-//   CandidatesVec ambiguousBest;
-
-//   // The common case is that there is no ambiguity because the
-//   // return intent overload feature is not used.
-//   auto best = findMostSpecificIgnoringReturn(dctx, candidates,
-//                                              /* ignoreWhere */ true,
-//                                              ambiguousBest);
-
-//   if (best != nullptr) {
-//     return MostSpecificCandidates::getOnly(best->toMostSpecificCandidate(context));
-//   }
-
-//   if (ambiguousBest.size() == 0) {
-//     // nothing to do, return no candidates
-//     return MostSpecificCandidates::getEmpty();
-//   }
-
-//   // Now, if there was ambiguity, try again while considering
-//   // separately each category of return intent.
-//   //
-//   // If there is only one most specific function in each category,
-//   // that is what we need to return.
-//   int nRef = 0;
-//   int nConstRef = 0;
-//   int nValue = 0;
-//   int nOther = 0;
-
-//   // Count number of candidates in each category.
-//   countByReturnIntent(dctx, ambiguousBest, nRef, nConstRef, nValue, nOther);
-
-//   if (nOther > 0) {
-//     // If there are *any* type/param candidates, we need to cause ambiguity
-//     // if they are not selected... including consideration of where clauses.
-//     ambiguousBest.clear();
-//     auto best = findMostSpecificIgnoringReturn(dctx, candidates,
-//                                                /* ignoreWhere */ false,
-//                                                ambiguousBest);
-
-//     if (ambiguousBest.size() > 1)
-//       return MostSpecificCandidates::getAmbiguous();
-
-//     return MostSpecificCandidates::getOnly(best->toMostSpecificCandidate(context));
-//   }
-
-//   if (nRef <= 1 && nConstRef <= 1 && nValue <= 1) {
-//     return gatherByReturnIntent(context, dctx, ambiguousBest);
-//   }
-
-//   // Otherwise, nRef > 1 || nConstRef > 1 || nValue > 1.
-
-//   // handle the more complex case where there is > 1 candidate
-//   // with a particular return intent by disambiguating each group
-//   // individually.
-//   return computeMostSpecificCandidatesWithVecs(context, dctx, ambiguousBest);
-// }
-
-// static MostSpecificCandidates
-// computeMostSpecificCandidatesWithVecs(Context* context,
-//                                       const DisambiguationContext& dctx,
-//                                       const CandidatesVec& vec) {
-//   CandidatesVec refCandidates;
-//   CandidatesVec constRefCandidates;
-//   CandidatesVec valueCandidates;
-//   CandidatesVec ambiguousBest;
-
-//   // Split candidates into ref, const ref, and value candidates
-//   gatherVecsByReturnIntent(dctx, vec,
-//                            refCandidates,
-//                            constRefCandidates,
-//                            valueCandidates);
-
-//   // Disambiguate each group and update the counts
-//   int nRef = 0;
-//   int nConstRef = 0;
-//   int nValue = 0;
-
-//   bool ignoreWhere = false;
-
-//   ambiguousBest.clear();
-//   auto bestRef = findMostSpecificIgnoringReturn(dctx, refCandidates,
-//                                                 ignoreWhere, ambiguousBest);
-//   if (bestRef != nullptr) {
-//     nRef = 1;
-//   } else {
-//     nRef = ambiguousBest.size();
-//   }
-
-//   ambiguousBest.clear();
-//   auto bestCRef = findMostSpecificIgnoringReturn(dctx, constRefCandidates,
-//                                                      ignoreWhere, ambiguousBest);
-//   if (bestCRef != nullptr) {
-//     nConstRef = 1;
-//   } else {
-//     nConstRef = ambiguousBest.size();
-//   }
-
-//   ambiguousBest.clear();
-//   auto bestValue = findMostSpecificIgnoringReturn(dctx, valueCandidates,
-//                                                   ignoreWhere, ambiguousBest);
-//   if (bestValue != nullptr) {
-//     nValue = 1;
-//   } else {
-//     nValue = ambiguousBest.size();
-//   }
-
-//   // if there is > 1 match in any category, fail to match due to ambiguity
-//   if (nRef > 1 || nConstRef > 1 || nValue > 1) {
-//     return MostSpecificCandidates::getAmbiguous();
-//   }
-
-//   // otherwise, there is 1 or fewer match in each category,
-//   // so there is no ambiguity.
-//   MostSpecificCandidates ret;
-//   if (bestRef != nullptr)
-//     ret.setBestRef(bestRef->toMostSpecificCandidate(context));
-//   if (bestCRef != nullptr)
-//     ret.setBestConstRef(bestCRef->toMostSpecificCandidate(context));
-//   if (bestValue != nullptr)
-//     ret.setBestValue(bestValue->toMostSpecificCandidate(context));
-
-//   return ret;
-// }
-
-// handle the more complex case where there is > 1 candidate
-// with a particular return intent by disambiguating each group
-// individually.
-// static MostSpecificCandidates
-// computeMostSpecificCandidatesWithVecs(Context* context,
-//                                       const DisambiguationContext& dctx,
-//                                       const CandidatesVec& vec);
-
 
 static const MostSpecificCandidates&
 findMostSpecificCandidatesQuery(Context* context,
@@ -557,108 +380,6 @@ findMostSpecificCandidates(Context* context,
                                          callInScope, callInPoiScope);
 }
 
-/*
-  Find the most specific candidate and returns it, ignoring
-  return intents.
-
-  If there is not a single most specific candidate, and ambiguousBest is not
-  nullptr, appends the possibly-best candidates to ambiguousBest.
-
-  Does not consider return intent overloading.
-  */
-// static const DisambiguationCandidate*
-// findMostSpecificIgnoringReturn(const DisambiguationContext& dctx,
-//                                const CandidatesVec& candidates,
-//                                bool ignoreWhere,
-//                                CandidatesVec& ambiguousBest) {
-//   int n = candidates.size();
-
-//   if (n == 0) {
-//     // nothing to do
-//     return nullptr;
-//   }
-
-//   if (n == 1) {
-//     // the only match is the best match
-//     return candidates[0];
-//   }
-
-//   // If index i is set then we can skip testing function F_i because
-//   // we already know it can not be the best match.
-//   std::vector<bool> notBest(n, false);
-
-//   for (int i = 0; i < n; i++) {
-//     EXPLAIN("##########################\n");
-//     EXPLAIN("# Considering function %d #\n", i);
-//     EXPLAIN("##########################\n\n");
-
-//     const DisambiguationCandidate* candidate1 = candidates[i];
-//     bool singleMostSpecific = true;
-
-//     EXPLAIN_DUMP(candidate1->fn);
-
-//     if (notBest[i]) {
-//       EXPLAIN("Already known to not be best match.  Skipping.\n\n");
-//       continue;
-//     }
-
-//     for (int j = 0; j < n; j++) {
-//       if (i == j) {
-//         continue;
-//       }
-
-//       EXPLAIN("Comparing to function %d\n", j);
-//       EXPLAIN("-----------------------\n");
-
-//       const DisambiguationCandidate* candidate2 = candidates[j];
-
-//       EXPLAIN_DUMP(candidate2->fn);
-
-//       int cmp = compareSpecificity(dctx, *candidate1, *candidate2, ignoreWhere);
-
-//       if (cmp < 0) {
-//         EXPLAIN("X: Fn %d is a better match than Fn %d\n\n\n", i, j);
-//         notBest[j] = true;
-
-//       } else if (cmp > 0) {
-//         EXPLAIN("X: Fn %d is a worse match than Fn %d\n\n\n", i, j);
-//         notBest[i] = true;
-//         singleMostSpecific = false;
-//         break;
-//       } else {
-//         EXPLAIN("X: Fn %d is a as good a match as Fn %d\n\n\n", i, j);
-//         singleMostSpecific = false;
-//         if (notBest[j]) {
-//           // Inherit the notBest status of what we are comparing against
-//           //
-//           // If this candidate is equally as good as something that wasn't
-//           // the best, then it is also not the best (or else there is something
-//           // terribly wrong with our compareSpecificity function).
-//           notBest[i] = true;
-//         }
-//         break;
-//       }
-//     }
-
-//     if (singleMostSpecific) {
-//       EXPLAIN("Y: Fn %d is the best match.\n\n\n", i);
-//       return candidates[i];
-
-//     } else {
-//       EXPLAIN("Y: Fn %d is NOT the best match.\n\n\n", i);
-//     }
-//   }
-
-//   EXPLAIN("Z: No non-ambiguous best match.\n\n");
-
-//   for (int i = 0; i < n; i++) {
-//     if (notBest[i] == false) {
-//       ambiguousBest.push_back(candidates[i]);
-//     }
-//   }
-
-//   return nullptr;
-// }
 
 /**
 
@@ -782,123 +503,6 @@ static int compareSpecificity(const DisambiguationContext& dctx,
   }
 }
 
-/**
-
-  Determines if fn1 is a better match than fn2.
-
-  This function implements the function comparison component of the
-  disambiguation procedure as detailed in section 13.13 of the Chapel
-  language specification.
-
-  \param candidate1 The function on the left-hand side of the comparison.
-  \param candidate2 The function on the right-hand side of the comparison.
-  \param ignoreWhere Set to `true` to ignore `where` clauses when
-                     deciding if one match is better than another.
-                     This is important for resolving return intent
-                     overloads.
-
-  \return -1 if fn1 is a more specific function than f2
-  \return 0 if fn1 and fn2 are equally specific
-  \return 1 if fn2 is a more specific function than f1
- */
-// static int compareSpecificity(const DisambiguationContext& dctx,
-//                               const DisambiguationCandidate& candidate1,
-//                               const DisambiguationCandidate& candidate2,
-//                               bool ignoreWhere) {
-
-  // bool prefer1 = false;
-  // bool prefer2 = false;
-  // int n = dctx.call->numActuals();
-  // DisambiguationState ds;
-
-  // for (int k = 0; k < n; k++) {
-  //   testArgMapping(dctx, candidate1, candidate2, k, ds);
-  // }
-
-  // if (ds.fn1Promotes != ds.fn2Promotes) {
-  //   EXPLAIN("\nP: only one of the functions requires argument promotion\n");
-
-  //   // Prefer the version that did not promote
-  //   prefer1 = !ds.fn1Promotes;
-  //   prefer2 = !ds.fn2Promotes;
-
-  // } else if (ds.fn1MoreSpecific != ds.fn2MoreSpecific) {
-  //   EXPLAIN("\nP1: only one more specific argument mapping\n");
-
-  //   prefer1 = ds.fn1MoreSpecific;
-  //   prefer2 = ds.fn2MoreSpecific;
-
-  // } else {
-  //   // If the decision hasn't been made based on the argument mappings...
-  //   auto moreVis = moreVisible(dctx, candidate1, candidate2);
-  //   if (moreVis == MoreVisibleResult::FOUND_F1_FIRST) {
-  //     EXPLAIN("\nQ: preferring more visible function\n");
-  //     prefer1 = true;
-
-  //   } else if (moreVis == MoreVisibleResult::FOUND_F2_FIRST) {
-  //     EXPLAIN("\nR: preferring more visible function\n");
-  //     prefer2 = true;
-
-  //   } else if (ds.fn1WeakPreferred != ds.fn2WeakPreferred) {
-  //     EXPLAIN("\nS: preferring based on weak preference\n");
-  //     prefer1 = ds.fn1WeakPreferred;
-  //     prefer2 = ds.fn2WeakPreferred;
-
-  //   } else if (ds.fn1WeakerPreferred != ds.fn2WeakerPreferred) {
-  //     EXPLAIN("\nS: preferring based on weaker preference\n");
-  //     prefer1 = ds.fn1WeakerPreferred;
-  //     prefer2 = ds.fn2WeakerPreferred;
-
-  //   } else if (ds.fn1WeakestPreferred != ds.fn2WeakestPreferred) {
-  //     EXPLAIN("\nS: preferring based on weakest preference\n");
-  //     prefer1 = ds.fn1WeakestPreferred;
-  //     prefer2 = ds.fn2WeakestPreferred;
-
-  //     /* A note about weak-prefers. Why are there 3 levels?
-
-  //        Something like 'param x:int(16) = 5' should be able to coerce to any
-  //        integral type. Meanwhile, 'param y = 5' should also be able to coerce
-  //        to any integral type. Now imagine we are resolving 'x+y'.  We
-  //        want it to resolve to the 'int(16)' version because 'x' has a type
-  //        specified, but 'y' is a default type. Before the 3 weak levels, this
-  //        version was chosen simply because non-default-sized ints didn't allow
-  //        param conversion.
-
-  //      */
-  //   } else if (!ignoreWhere) {
-  //     ID id1 = candidate1.fn->id();
-  //     ID id2 = candidate2.fn->id();
-  //     bool fn1where = parsing::idIsFunctionWithWhere(dctx.context, id1);
-  //     bool fn2where = parsing::idIsFunctionWithWhere(dctx.context, id2);
-
-  //     if (fn1where != fn2where) {
-  //       EXPLAIN("\nU: preferring function with where clause\n");
-
-  //       prefer1 = fn1where;
-  //       prefer2 = fn2where;
-  //     }
-  //   }
-  // }
-
-  // CHPL_ASSERT(!(prefer1 && prefer2));
-
-  // if (prefer1) {
-  //   EXPLAIN("\nW: Fn %d is more specific than Fn %d\n",
-  //           candidate1.idx, candidate2.idx);
-  //   return -1;
-
-  // } else if (prefer2) {
-  //   EXPLAIN("\nW: Fn %d is less specific than Fn %d\n",
-  //           candidate1.idx, candidate2.idx);
-  //   return 1;
-
-  // } else {
-  //   // Neither is more specific
-  //   EXPLAIN("\nW: Fn %d and Fn %d are equally specific\n",
-  //           candidate1.idx, candidate2.idx);
-  //   return 0;
-  // }
-// }
 
 /*
  * Returns:
@@ -1062,7 +666,8 @@ computeVisibilityDistanceInternal(Context* context, const Scope* scope,
 // of two functions.
 //
 // Returns -1 if the function is a method or if the function is not found
-static int computeVisibilityDistance(Context* context, const Scope* scope, const TypedFnSignature* fn) {
+static int computeVisibilityDistance(Context* context, const Scope* scope,
+                                     const TypedFnSignature* fn) {
   // is this a method?
   if (fn->untyped()->isMethod()) {
     return -1;
@@ -1319,28 +924,16 @@ static MostSpecificCandidates
 disambiguateByMatch(DisambiguationContext& dctx, CandidatesVec& candidates) {
   CandidatesVec ambiguous;
 
-  // DisambiguationCandidate* bestRef = nullptr;
-  // DisambiguationCandidate* bestConstRef = nullptr;
   DisambiguationCandidate* bestValue = nullptr;
 
   DisambiguationCandidate* best = (DisambiguationCandidate*)disambiguateByMatch(dctx, candidates, true,
                                                     ambiguous);
   MostSpecificCandidates ret = MostSpecificCandidates::getAmbiguous();
-  // int retval = 0;
 
   // The common case is that there is no ambiguity because the
   // return intent overload feature is not used.
   if (best != nullptr) {
     ret = MostSpecificCandidates::getOnly(best->toMostSpecificCandidate(dctx.context));
-    // auto returnIntent = parsing::idToFnReturnIntent(dctx.context, best->fn->id());
-    // if (returnIntent == Function::REF) {
-    //   bestRef = best;
-    // } else if(returnIntent == Function::CONST_REF) {
-    //   bestConstRef = best;
-    // } else {
-    //   bestValue = best;
-    // }
-    // retval = 1;
 
   } else {
     // Now, if there was ambiguity, find candidates with different
@@ -1861,28 +1454,6 @@ moreVisibleQuery(Context* context,
   return QUERY_END(result);
 }
 
-/**
-  Computes whether candidate1 or candidate2 is more visible/shadowing
-  the other.
- */
-// static MoreVisibleResult
-// moreVisible(const DisambiguationContext& dctx,
-//             const DisambiguationCandidate& candidate1,
-//             const DisambiguationCandidate& candidate2) {
-//   UniqueString callName = dctx.call->name();
-//   ID fn1Id = candidate1.fn->id();
-//   ID fn2Id = candidate2.fn->id();
-
-//   // ignore more-visible for methods
-//   if (candidate1.fn->untyped()->isMethod() &&
-//       candidate2.fn->untyped()->isMethod()) {
-//     return FOUND_BOTH;
-//   }
-
-//   return moreVisibleQuery(dctx.context, callName,
-//                           dctx.callInScope, dctx.callInPoiScope,
-//                           fn1Id, fn2Id);
-// }
 
 /**
   Compare two argument mappings, given a set of actual arguments, and set the
@@ -2131,264 +1702,6 @@ static int testArgMapping(const DisambiguationContext& dctx,
   return -1;
 }
 
-/**
-  Compare two argument mappings, given a set of actual arguments, and set the
-  disambiguation state appropriately.
-
-  This function implements the argument mapping comparison component of the
-  disambiguation procedure as detailed in section 13.14.3 of the Chapel
-  language specification (page 107).
-
-  actualIdx is the index within the call of the argument to be compared.
-
-  Sets bits in DisambiguationState ds according to whether argument actualIdx
-  in candidate1 vs candidate2 is a better match.
- */
-// static void testArgMapping(const DisambiguationContext& dctx,
-//                            const DisambiguationCandidate& candidate1,
-//                            const DisambiguationCandidate& candidate2,
-//                            int actualIdx,
-//                            DisambiguationState& ds) {
-
-//   EXPLAIN("\nLooking at argument %d\n", actualIdx);
-
-//   const FormalActual* fa1 = candidate1.formalActualMap.byActualIdx(actualIdx);
-//   const FormalActual* fa2 = candidate2.formalActualMap.byActualIdx(actualIdx);
-
-//   if (fa1 == nullptr || fa2 == nullptr) {
-//     // TODO: call testOpArgMapping if one was an operator but the
-//     // other is not
-//     CHPL_ASSERT(false && "TODO -- handle operator calls");
-//   }
-
-//   QualifiedType f1Type = fa1->formalType();
-//   QualifiedType f2Type = fa2->formalType();
-//   QualifiedType actualType = fa1->actualType();
-//   CHPL_ASSERT(actualType == fa2->actualType());
-
-//   // Give up early for out intent arguments
-//   // (these don't impact candidate selection)
-//   if (f1Type.kind() == QualifiedType::OUT ||
-//       f2Type.kind() == QualifiedType::OUT) {
-//     return;
-//   }
-
-//   // Initializer work-around: Skip 'this' for generic initializers
-//   if (dctx.call->name() == USTR("init") || dctx.call->name() == USTR("init=")) {
-//     auto nd1 = fa1->formal()->toNamedDecl();
-//     auto nd2 = fa2->formal()->toNamedDecl();
-//     if (nd1 != nullptr && nd2 != nullptr &&
-//         nd1->name() == USTR("this") && nd2->name() == USTR("this")) {
-//       if (getTypeGenericity(dctx.context, f1Type) != Type::CONCRETE &&
-//           getTypeGenericity(dctx.context, f2Type) != Type::CONCRETE) {
-//         return;
-//       }
-//     }
-//   }
-
-//   bool formal1Promotes = false;
-//   bool formal2Promotes = false;
-//   bool formal1Narrows = false;
-//   bool formal2Narrows = false;
-
-//   QualifiedType actualScalarT = actualType;
-
-//   bool f1Param = f1Type.hasParamPtr();
-//   bool f2Param = f2Type.hasParamPtr();
-
-//   bool f1Instantiated = fa1->formalInstantiated();
-//   bool f2Instantiated = fa2->formalInstantiated();
-
-//   bool f1InstantiatedFromAny = false;
-//   bool f2InstantiatedFromAny = false;
-
-//   bool f1PartiallyGeneric = false;
-//   bool f2PartiallyGeneric = false;
-
-//   if (f1Instantiated) {
-//     f1InstantiatedFromAny = isFormalInstantiatedAny(candidate1, fa1);
-//     f1PartiallyGeneric = isFormalPartiallyGeneric(candidate1, fa1);
-//   }
-//   if (f2Instantiated) {
-//     f2InstantiatedFromAny = isFormalInstantiatedAny(candidate2, fa2);
-//     f2PartiallyGeneric = isFormalPartiallyGeneric(candidate2, fa2);
-//   }
-
-//   bool actualParam = false;
-//   bool paramWithDefaultSize = false;
-
-//   // Don't enable param/ weak preferences for non-default sized param values.
-//   // If somebody bothered to type the param, they probably want it to stay that
-//   // way. This is a strategy to resolve ambiguity with e.g.
-//   //  +(param x:int(32), param y:int(32)
-//   //  +(param x:int(64), param y:int(64)
-//   // called with
-//   //  param x:int(32), param y:int(64)
-//   if (actualType.hasParamPtr()) {
-//     actualParam = true;
-//     paramWithDefaultSize = isNumericParamDefaultType(actualType);
-//   }
-
-//   EXPLAIN("Actual's type: ");
-//   EXPLAIN_DUMP(&actualType);
-//   if (actualParam)
-//     EXPLAIN(" (param)");
-//   if (paramWithDefaultSize)
-//     EXPLAIN(" (default)");
-//   EXPLAIN("\n");
-
-//   testArgMapHelper(dctx, *fa1, candidate1.forwardingTo,
-//                    &formal1Promotes, &formal1Narrows, ds, 1);
-
-//   testArgMapHelper(dctx, *fa2, candidate2.forwardingTo,
-//                    &formal2Promotes, &formal2Narrows, ds, 2);
-
-//   // Figure out scalar type for candidate matching
-//   if (formal1Promotes || formal2Promotes) {
-//     actualScalarT = computeActualScalarType(dctx.context, actualType);
-//   }
-
-//   // TODO: for sync/single use the valType
-
-//   const char* reason = "";
-//   (void) reason;
-//   typedef enum {
-//     NONE,
-//     WEAKEST,
-//     WEAKER,
-//     WEAK,
-//     STRONG
-//   } arg_preference_t;
-
-//   arg_preference_t prefer1 = NONE;
-//   arg_preference_t prefer2 = NONE;
-
-//   if (f1Type == f2Type && f1Param && !f2Param) {
-//     prefer1 = STRONG; reason = "same type, param vs not";
-
-//   } else if (f1Type == f2Type && !f1Param && f2Param) {
-//     prefer2 = STRONG; reason = "same type, param vs not";
-
-//   } else if (!formal1Promotes && formal2Promotes) {
-//     prefer1 = STRONG; reason = "no promotion vs promotes";
-
-//   } else if (formal1Promotes && !formal2Promotes) {
-//     prefer2 = STRONG; reason = "no promotion vs promotes";
-
-//   } else if (f1Type == f2Type           &&
-//              !f1Instantiated && f2Instantiated) {
-//     prefer1 = STRONG; reason = "concrete vs generic";
-
-//   } else if (f1Type == f2Type &&
-//              f1Instantiated && !f2Instantiated) {
-//     prefer2 = STRONG; reason = "concrete vs generic";
-
-//   } else if (!f1InstantiatedFromAny && f2InstantiatedFromAny) {
-//     prefer1 = STRONG; reason = "generic any vs partially generic/concrete";
-
-//   } else if (f1InstantiatedFromAny && !f2InstantiatedFromAny) {
-//     prefer2 = STRONG; reason = "generic any vs partially generic/concrete";
-
-//   } else if (f1Instantiated && f2Instantiated &&
-//              f1PartiallyGeneric && !f2PartiallyGeneric) {
-//     prefer1 = STRONG; reason = "partially generic vs generic";
-
-//   } else if (f1Instantiated && f2Instantiated &&
-//              !f1PartiallyGeneric && f2PartiallyGeneric) {
-//     prefer2 = STRONG; reason = "partially generic vs generic";
-
-//   } else if (f1Param != f2Param && f1Param) {
-//     prefer1 = WEAK; reason = "param vs not";
-
-//   } else if (f1Param != f2Param && f2Param) {
-//     prefer2 = WEAK; reason = "param vs not";
-
-//   } else if (!paramWithDefaultSize && formal2Narrows && !formal1Narrows) {
-//     prefer1 = WEAK; reason = "no narrows vs narrows";
-
-//   } else if (!paramWithDefaultSize && formal1Narrows && !formal2Narrows) {
-//     prefer2 = WEAK; reason = "no narrows vs narrows";
-
-//   } else if (!actualParam && actualType == f1Type && actualType != f2Type) {
-//     prefer1 = STRONG; reason = "actual type vs not";
-
-//   } else if (!actualParam && actualType == f2Type && actualType != f1Type) {
-//     prefer2 = STRONG; reason = "actual type vs not";
-
-//   } else if (actualScalarT == f1Type && actualScalarT != f2Type) {
-//     if (paramWithDefaultSize)
-//       prefer1 = WEAKEST;
-//     else if (actualParam)
-//       prefer1 = WEAKER;
-//     else
-//       prefer1 = STRONG;
-
-//     reason = "scalar type vs not";
-
-//   } else if (actualScalarT == f2Type && actualScalarT != f1Type) {
-//     if (paramWithDefaultSize)
-//       prefer2 = WEAKEST;
-//     else if (actualParam)
-//       prefer2 = WEAKER;
-//     else
-//       prefer2 = STRONG;
-
-//     reason = "scalar type vs not";
-
-//   } else if (prefersConvToOtherNumeric(dctx, actualScalarT, f1Type, f2Type)) {
-//     if (paramWithDefaultSize)
-//       prefer1 = WEAKEST;
-//     else
-//       prefer1 = WEAKER;
-
-//     reason = "preferred coercion to other";
-
-//   } else if (prefersConvToOtherNumeric(dctx, actualScalarT, f2Type, f1Type)) {
-//     if (paramWithDefaultSize)
-//       prefer2 = WEAKEST;
-//     else
-//       prefer2 = WEAKER;
-
-//     reason = "preferred coercion to other";
-
-//   } else if (f1Type != f2Type && moreSpecificCanDispatch(dctx, f1Type, f2Type)) {
-//     prefer1 = actualParam ? WEAKEST : STRONG;
-//     reason = "can dispatch";
-
-//   } else if (f1Type != f2Type && moreSpecificCanDispatch(dctx, f2Type, f1Type)) {
-//     prefer2 = actualParam ? WEAKEST : STRONG;
-//     reason = "can dispatch";
-
-//   } else if (f1Type.type()->isIntType() && f2Type.type()->isUintType()) {
-//     // This int/uint rule supports choosing between an 'int' and 'uint'
-//     // overload when passed say a uint(32).
-//     prefer1 = actualParam ? WEAKEST : STRONG;
-//     reason = "int vs uint";
-
-//   } else if (f2Type.type()->isIntType() && f1Type.type()->isUintType()) {
-//     prefer2 = actualParam ? WEAKEST : STRONG;
-//     reason = "int vs uint";
-
-//   }
-
-//   if (prefer1 != NONE) {
-//     const char* level = "";
-//     (void) level;
-//     if (prefer1 == STRONG)  { ds.fn1MoreSpecific = true;     level = "strong"; }
-//     if (prefer1 == WEAK)    { ds.fn1WeakPreferred = true;    level = "weak"; }
-//     if (prefer1 == WEAKER)  { ds.fn1WeakerPreferred = true;  level = "weaker"; }
-//     if (prefer1 == WEAKEST) { ds.fn1WeakestPreferred = true; level = "weakest"; }
-//     EXPLAIN("%s: Fn %d is %s preferred\n", reason, candidate1.idx, level);
-//   } else if (prefer2 != NONE) {
-//     const char* level = "";
-//     (void) level;
-//     if (prefer2 == STRONG)  { ds.fn2MoreSpecific = true;     level = "strong"; }
-//     if (prefer2 == WEAK)    { ds.fn2WeakPreferred = true;    level = "weak"; }
-//     if (prefer2 == WEAKER)  { ds.fn2WeakerPreferred = true;  level = "weaker"; }
-//     if (prefer2 == WEAKEST) { ds.fn2WeakestPreferred = true; level = "weakest"; }
-//     EXPLAIN("%s: Fn %d is %s preferred\n", reason, candidate2.idx, level);
-//   }
-// }
 
 static void testArgMapHelper(const DisambiguationContext& dctx,
                              const FormalActual& fa,
@@ -2646,71 +1959,6 @@ static int prefersNumericCoercion(const DisambiguationContext& dctx,
   return 0;
 }
 
-// Returns 'true' if we should prefer passing actual to f1Type
-// over f2Type.
-// This method implements rules such as that a bool would prefer to
-// coerce to 'int' over 'int(8)'.
-// static bool prefersConvToOtherNumeric(const DisambiguationContext& dctx,
-//                                       QualifiedType actualQt,
-//                                       QualifiedType f1Qt,
-//                                       QualifiedType f2Qt) {
-
-//   const Type* actualType = actualQt.type();
-//   const Type* f1Type = f1Qt.type();
-//   const Type* f2Type = f2Qt.type();
-
-//   if (actualType != f1Type && actualType != f2Type) {
-//     // Is there any preference among coercions of the built-in type?
-//     // E.g., would we rather convert 'false' to :int or to :uint(8) ?
-
-//     numeric_type_t aT = classifyNumericType(actualType);
-//     numeric_type_t f1T = classifyNumericType(f1Type);
-//     numeric_type_t f2T = classifyNumericType(f2Type);
-
-//     bool aBoolEnum = (aT == NUMERIC_TYPE_BOOL || aT == NUMERIC_TYPE_ENUM);
-
-//     // Prefer e.g. bool(w1) passed to bool(w2) over passing to int (say)
-//     // Prefer uint(8) passed to uint(16) over passing to a real
-//     if (aT == f1T && aT != f2T)
-//       return true;
-//     // Prefer bool/enum cast to int over uint
-//     if (aBoolEnum && f1Type->isIntType() && f2Type->isUintType())
-//       return true;
-//     // Prefer bool/enum cast to default-sized int/uint over another
-//     // size of int/uint
-//     if (aBoolEnum &&
-//         (isDefaultInt(f1Type) || isDefaultUint(f1Type)) &&
-//         f2T == NUMERIC_TYPE_INT_UINT &&
-//         !(isDefaultInt(f2Type) || isDefaultUint(f2Type)))
-//       return true;
-//     // Prefer bool/enum/int/uint cast to a default-sized real over another
-//     // size of real or complex.
-//     if ((aBoolEnum || aT == NUMERIC_TYPE_INT_UINT) &&
-//         isDefaultReal(f1Type) &&
-//         (f2T == NUMERIC_TYPE_REAL || f2T == NUMERIC_TYPE_COMPLEX) &&
-//         !isDefaultReal(f2Type))
-//       return true;
-//     // Prefer bool/enum/int/uint cast to a default-sized complex over another
-//     // size of complex.
-//     if ((aBoolEnum || aT == NUMERIC_TYPE_INT_UINT) &&
-//         isDefaultComplex(f1Type) &&
-//         f2T == NUMERIC_TYPE_COMPLEX &&
-//         !isDefaultComplex(f2Type))
-//       return true;
-//     // Prefer real/imag cast to a same-sized complex over another size of
-//     // complex.
-//     if ((aT == NUMERIC_TYPE_REAL || aT == NUMERIC_TYPE_IMAG) &&
-//         f1T == NUMERIC_TYPE_COMPLEX &&
-//         f2T == NUMERIC_TYPE_COMPLEX &&
-//         bitwidth(actualType)*2 == bitwidth(f1Type) &&
-//         bitwidth(actualType)*2 != bitwidth(f2Type))
-//       return true;
-//   }
-
-//   return false;
-// }
-
-
 static QualifiedType computeActualScalarType(Context* context,
                                              QualifiedType actualType) {
   // TODO: fill this in
@@ -2718,15 +1966,6 @@ static QualifiedType computeActualScalarType(Context* context,
   return actualType;
 }
 
-// static bool isNumericParamDefaultType(QualifiedType type) {
-//   if (auto typePtr = type.type()) {
-//     if (auto primType = typePtr->toPrimitiveType()) {
-//       return primType->isDefaultWidth();
-//     }
-//   }
-
-//   return false;
-// }
 
 static bool moreSpecificCanDispatch(const DisambiguationContext& dctx,
                          QualifiedType actualType, QualifiedType formalType) {

--- a/frontend/lib/resolution/disambiguation.cpp
+++ b/frontend/lib/resolution/disambiguation.cpp
@@ -102,22 +102,6 @@ struct DisambiguationState {
 
   bool fn1ParamArgsPreferred = false;
   bool fn2ParamArgsPreferred = false;
-
-  // TODO: Remove all these
-  bool  fn1MoreSpecific = false;
-  bool  fn2MoreSpecific = false;
-
-  bool  fn1Promotes = false;
-  bool  fn2Promotes = false;
-
-  bool fn1WeakPreferred = false;
-  bool fn2WeakPreferred = false;
-
-  bool fn1WeakerPreferred = false;
-  bool fn2WeakerPreferred = false;
-
-  bool fn1WeakestPreferred = false;
-  bool fn2WeakestPreferred = false;
 };
 
 using CandidatesVec = std::vector<const DisambiguationCandidate*>;
@@ -148,10 +132,26 @@ enum MoreVisibleResult {
 #endif
 
 static const DisambiguationCandidate*
-findMostSpecificIgnoringReturn(const DisambiguationContext& dctx,
-                               const CandidatesVec& candidates,
-                               bool ignoreWhere,
-                               CandidatesVec& ambiguousBest);
+disambiguateByMatch(const DisambiguationContext& dctx,
+                    const CandidatesVec& candidates,
+                    bool ignoreWhere,
+                    CandidatesVec& ambiguousBest);
+
+static MostSpecificCandidates
+disambiguateByMatch(DisambiguationContext& dctx, CandidatesVec& candidates);
+
+// static int disambiguateByMatch(CallInfo&                 info,
+//                                Scope*                    searchScope,
+//                                CandidatesVec&            candidates,
+//                                DisambiguationCandidate*& bestRef,
+//                                DisambiguationCandidate*& bestConstRef,
+//                                DisambiguationCandidate*& bestValue);
+
+// static const DisambiguationCandidate*
+// findMostSpecificIgnoringReturn(const DisambiguationContext& dctx,
+//                                const CandidatesVec& candidates,
+//                                bool ignoreWhere,
+//                                CandidatesVec& ambiguousBest);
 
 static int compareSpecificity(const DisambiguationContext& dctx,
                               const DisambiguationCandidate& candidate1,
@@ -160,14 +160,14 @@ static int compareSpecificity(const DisambiguationContext& dctx,
                               int j,
                               bool forGenericInit);
 
-static int compareSpecificity(const DisambiguationContext& dctx,
-                              const DisambiguationCandidate& candidate1,
-                              const DisambiguationCandidate& candidate2,
-                              bool ignoreWhere);
+// static int compareSpecificity(const DisambiguationContext& dctx,
+//                               const DisambiguationCandidate& candidate1,
+//                               const DisambiguationCandidate& candidate2,
+//                               bool ignoreWhere);
 
-static MoreVisibleResult moreVisible(const DisambiguationContext& dctx,
-                                     const DisambiguationCandidate& candidate1,
-                                     const DisambiguationCandidate& candidate2);
+// static MoreVisibleResult moreVisible(const DisambiguationContext& dctx,
+//                                      const DisambiguationCandidate& candidate1,
+//                                      const DisambiguationCandidate& candidate2);
 
 static int testArgMapping(const DisambiguationContext& dctx,
                           const DisambiguationCandidate& candidate1,
@@ -176,11 +176,11 @@ static int testArgMapping(const DisambiguationContext& dctx,
                           DisambiguationState& ds,
                           std::string& reason);
 
-static void testArgMapping(const DisambiguationContext& dctx,
-                           const DisambiguationCandidate& candidate1,
-                           const DisambiguationCandidate& candidate2,
-                           int actualIdx,
-                           DisambiguationState& ds);
+// static void testArgMapping(const DisambiguationContext& dctx,
+//                            const DisambiguationCandidate& candidate1,
+//                            const DisambiguationCandidate& candidate2,
+//                            int actualIdx,
+//                            DisambiguationState& ds);
 
 static void testArgMapHelper(const DisambiguationContext& dctx,
                              const FormalActual& fa,
@@ -202,24 +202,24 @@ static bool isFormalInstantiatedAny(const DisambiguationCandidate& candidate,
 static bool isFormalPartiallyGeneric(const DisambiguationCandidate& candidate,
                                      const FormalActual* fa);
 
-static bool prefersConvToOtherNumeric(const DisambiguationContext& dctx,
-                                      QualifiedType actualType,
-                                      QualifiedType f1Type,
-                                      QualifiedType f2Type);
+// static bool prefersConvToOtherNumeric(const DisambiguationContext& dctx,
+//                                       QualifiedType actualType,
+//                                       QualifiedType f1Type,
+//                                       QualifiedType f2Type);
 
 static QualifiedType computeActualScalarType(Context* context,
                                              QualifiedType actualType);
 
-static bool isNumericParamDefaultType(QualifiedType type);
+// static bool isNumericParamDefaultType(QualifiedType type);
 
 static bool moreSpecificCanDispatch(const DisambiguationContext& dctx,
                                     QualifiedType actualType,
                                     QualifiedType formalType);
 
-static MostSpecificCandidates
-computeMostSpecificCandidatesWithVecs(Context* context,
-                                      const DisambiguationContext& dctx,
-                                      const CandidatesVec& vec);
+// static MostSpecificCandidates
+// computeMostSpecificCandidatesWithVecs(Context* context,
+//                                       const DisambiguationContext& dctx,
+//                                       const CandidatesVec& vec);
 
 static void discardWorseVisibility(const DisambiguationContext& dctx,
                                    const CandidatesVec& candidates,
@@ -350,141 +350,142 @@ static void gatherVecsByReturnIntent(const DisambiguationContext& dctx,
   }
 }
 
-static MostSpecificCandidates
-computeMostSpecificCandidates(Context* context,
-                              const DisambiguationContext& dctx,
-                              const CandidatesVec& candidates) {
+// TODO: this needs to become, or call? disambiguateByMatch
+// static MostSpecificCandidates
+// computeMostSpecificCandidates(Context* context,
+//                               const DisambiguationContext& dctx,
+//                               const CandidatesVec& candidates) {
 
-  CandidatesVec ambiguousBest;
+//   CandidatesVec ambiguousBest;
 
-  // The common case is that there is no ambiguity because the
-  // return intent overload feature is not used.
-  auto best = findMostSpecificIgnoringReturn(dctx, candidates,
-                                             /* ignoreWhere */ true,
-                                             ambiguousBest);
+//   // The common case is that there is no ambiguity because the
+//   // return intent overload feature is not used.
+//   auto best = findMostSpecificIgnoringReturn(dctx, candidates,
+//                                              /* ignoreWhere */ true,
+//                                              ambiguousBest);
 
-  if (best != nullptr) {
-    return MostSpecificCandidates::getOnly(best->toMostSpecificCandidate(context));
-  }
+//   if (best != nullptr) {
+//     return MostSpecificCandidates::getOnly(best->toMostSpecificCandidate(context));
+//   }
 
-  if (ambiguousBest.size() == 0) {
-    // nothing to do, return no candidates
-    return MostSpecificCandidates::getEmpty();
-  }
+//   if (ambiguousBest.size() == 0) {
+//     // nothing to do, return no candidates
+//     return MostSpecificCandidates::getEmpty();
+//   }
 
-  // Now, if there was ambiguity, try again while considering
-  // separately each category of return intent.
-  //
-  // If there is only one most specific function in each category,
-  // that is what we need to return.
-  int nRef = 0;
-  int nConstRef = 0;
-  int nValue = 0;
-  int nOther = 0;
+//   // Now, if there was ambiguity, try again while considering
+//   // separately each category of return intent.
+//   //
+//   // If there is only one most specific function in each category,
+//   // that is what we need to return.
+//   int nRef = 0;
+//   int nConstRef = 0;
+//   int nValue = 0;
+//   int nOther = 0;
 
-  // Count number of candidates in each category.
-  countByReturnIntent(dctx, ambiguousBest, nRef, nConstRef, nValue, nOther);
+//   // Count number of candidates in each category.
+//   countByReturnIntent(dctx, ambiguousBest, nRef, nConstRef, nValue, nOther);
 
-  if (nOther > 0) {
-    // If there are *any* type/param candidates, we need to cause ambiguity
-    // if they are not selected... including consideration of where clauses.
-    ambiguousBest.clear();
-    auto best = findMostSpecificIgnoringReturn(dctx, candidates,
-                                               /* ignoreWhere */ false,
-                                               ambiguousBest);
+//   if (nOther > 0) {
+//     // If there are *any* type/param candidates, we need to cause ambiguity
+//     // if they are not selected... including consideration of where clauses.
+//     ambiguousBest.clear();
+//     auto best = findMostSpecificIgnoringReturn(dctx, candidates,
+//                                                /* ignoreWhere */ false,
+//                                                ambiguousBest);
 
-    if (ambiguousBest.size() > 1)
-      return MostSpecificCandidates::getAmbiguous();
+//     if (ambiguousBest.size() > 1)
+//       return MostSpecificCandidates::getAmbiguous();
 
-    return MostSpecificCandidates::getOnly(best->toMostSpecificCandidate(context));
-  }
+//     return MostSpecificCandidates::getOnly(best->toMostSpecificCandidate(context));
+//   }
 
-  if (nRef <= 1 && nConstRef <= 1 && nValue <= 1) {
-    return gatherByReturnIntent(context, dctx, ambiguousBest);
-  }
+//   if (nRef <= 1 && nConstRef <= 1 && nValue <= 1) {
+//     return gatherByReturnIntent(context, dctx, ambiguousBest);
+//   }
 
-  // Otherwise, nRef > 1 || nConstRef > 1 || nValue > 1.
+//   // Otherwise, nRef > 1 || nConstRef > 1 || nValue > 1.
 
-  // handle the more complex case where there is > 1 candidate
-  // with a particular return intent by disambiguating each group
-  // individually.
-  return computeMostSpecificCandidatesWithVecs(context, dctx, ambiguousBest);
-}
+//   // handle the more complex case where there is > 1 candidate
+//   // with a particular return intent by disambiguating each group
+//   // individually.
+//   return computeMostSpecificCandidatesWithVecs(context, dctx, ambiguousBest);
+// }
 
-static MostSpecificCandidates
-computeMostSpecificCandidatesWithVecs(Context* context,
-                                      const DisambiguationContext& dctx,
-                                      const CandidatesVec& vec) {
-  CandidatesVec refCandidates;
-  CandidatesVec constRefCandidates;
-  CandidatesVec valueCandidates;
-  CandidatesVec ambiguousBest;
+// static MostSpecificCandidates
+// computeMostSpecificCandidatesWithVecs(Context* context,
+//                                       const DisambiguationContext& dctx,
+//                                       const CandidatesVec& vec) {
+//   CandidatesVec refCandidates;
+//   CandidatesVec constRefCandidates;
+//   CandidatesVec valueCandidates;
+//   CandidatesVec ambiguousBest;
 
-  // Split candidates into ref, const ref, and value candidates
-  gatherVecsByReturnIntent(dctx, vec,
-                           refCandidates,
-                           constRefCandidates,
-                           valueCandidates);
+//   // Split candidates into ref, const ref, and value candidates
+//   gatherVecsByReturnIntent(dctx, vec,
+//                            refCandidates,
+//                            constRefCandidates,
+//                            valueCandidates);
 
-  // Disambiguate each group and update the counts
-  int nRef = 0;
-  int nConstRef = 0;
-  int nValue = 0;
+//   // Disambiguate each group and update the counts
+//   int nRef = 0;
+//   int nConstRef = 0;
+//   int nValue = 0;
 
-  bool ignoreWhere = false;
+//   bool ignoreWhere = false;
 
-  ambiguousBest.clear();
-  auto bestRef = findMostSpecificIgnoringReturn(dctx, refCandidates,
-                                                ignoreWhere, ambiguousBest);
-  if (bestRef != nullptr) {
-    nRef = 1;
-  } else {
-    nRef = ambiguousBest.size();
-  }
+//   ambiguousBest.clear();
+//   auto bestRef = findMostSpecificIgnoringReturn(dctx, refCandidates,
+//                                                 ignoreWhere, ambiguousBest);
+//   if (bestRef != nullptr) {
+//     nRef = 1;
+//   } else {
+//     nRef = ambiguousBest.size();
+//   }
 
-  ambiguousBest.clear();
-  auto bestCRef = findMostSpecificIgnoringReturn(dctx, constRefCandidates,
-                                                     ignoreWhere, ambiguousBest);
-  if (bestCRef != nullptr) {
-    nConstRef = 1;
-  } else {
-    nConstRef = ambiguousBest.size();
-  }
+//   ambiguousBest.clear();
+//   auto bestCRef = findMostSpecificIgnoringReturn(dctx, constRefCandidates,
+//                                                      ignoreWhere, ambiguousBest);
+//   if (bestCRef != nullptr) {
+//     nConstRef = 1;
+//   } else {
+//     nConstRef = ambiguousBest.size();
+//   }
 
-  ambiguousBest.clear();
-  auto bestValue = findMostSpecificIgnoringReturn(dctx, valueCandidates,
-                                                  ignoreWhere, ambiguousBest);
-  if (bestValue != nullptr) {
-    nValue = 1;
-  } else {
-    nValue = ambiguousBest.size();
-  }
+//   ambiguousBest.clear();
+//   auto bestValue = findMostSpecificIgnoringReturn(dctx, valueCandidates,
+//                                                   ignoreWhere, ambiguousBest);
+//   if (bestValue != nullptr) {
+//     nValue = 1;
+//   } else {
+//     nValue = ambiguousBest.size();
+//   }
 
-  // if there is > 1 match in any category, fail to match due to ambiguity
-  if (nRef > 1 || nConstRef > 1 || nValue > 1) {
-    return MostSpecificCandidates::getAmbiguous();
-  }
+//   // if there is > 1 match in any category, fail to match due to ambiguity
+//   if (nRef > 1 || nConstRef > 1 || nValue > 1) {
+//     return MostSpecificCandidates::getAmbiguous();
+//   }
 
-  // otherwise, there is 1 or fewer match in each category,
-  // so there is no ambiguity.
-  MostSpecificCandidates ret;
-  if (bestRef != nullptr)
-    ret.setBestRef(bestRef->toMostSpecificCandidate(context));
-  if (bestCRef != nullptr)
-    ret.setBestConstRef(bestCRef->toMostSpecificCandidate(context));
-  if (bestValue != nullptr)
-    ret.setBestValue(bestValue->toMostSpecificCandidate(context));
+//   // otherwise, there is 1 or fewer match in each category,
+//   // so there is no ambiguity.
+//   MostSpecificCandidates ret;
+//   if (bestRef != nullptr)
+//     ret.setBestRef(bestRef->toMostSpecificCandidate(context));
+//   if (bestCRef != nullptr)
+//     ret.setBestConstRef(bestCRef->toMostSpecificCandidate(context));
+//   if (bestValue != nullptr)
+//     ret.setBestValue(bestValue->toMostSpecificCandidate(context));
 
-  return ret;
-}
+//   return ret;
+// }
 
 // handle the more complex case where there is > 1 candidate
 // with a particular return intent by disambiguating each group
 // individually.
-static MostSpecificCandidates
-computeMostSpecificCandidatesWithVecs(Context* context,
-                                      const DisambiguationContext& dctx,
-                                      const CandidatesVec& vec);
+// static MostSpecificCandidates
+// computeMostSpecificCandidatesWithVecs(Context* context,
+//                                       const DisambiguationContext& dctx,
+//                                       const CandidatesVec& vec);
 
 
 static const MostSpecificCandidates&
@@ -517,12 +518,9 @@ findMostSpecificCandidatesQuery(Context* context,
     }
   }
 
-  // If index i is set we have ruled out that function
-  std::vector<bool> discarded(candidates.size(), false);
-  disambiguateDiscarding(dctx, candidates, true /*ignoreWhere*/, discarded);
-
   MostSpecificCandidates result =
-    computeMostSpecificCandidates(context, dctx, candidates);
+    disambiguateByMatch(dctx, candidates);
+    // computeMostSpecificCandidates(context, dctx, candidates);
 
   // Delete all of the FormalActualMaps
   for (auto elt : candidates) {
@@ -568,99 +566,99 @@ findMostSpecificCandidates(Context* context,
 
   Does not consider return intent overloading.
   */
-static const DisambiguationCandidate*
-findMostSpecificIgnoringReturn(const DisambiguationContext& dctx,
-                               const CandidatesVec& candidates,
-                               bool ignoreWhere,
-                               CandidatesVec& ambiguousBest) {
-  int n = candidates.size();
+// static const DisambiguationCandidate*
+// findMostSpecificIgnoringReturn(const DisambiguationContext& dctx,
+//                                const CandidatesVec& candidates,
+//                                bool ignoreWhere,
+//                                CandidatesVec& ambiguousBest) {
+//   int n = candidates.size();
 
-  if (n == 0) {
-    // nothing to do
-    return nullptr;
-  }
+//   if (n == 0) {
+//     // nothing to do
+//     return nullptr;
+//   }
 
-  if (n == 1) {
-    // the only match is the best match
-    return candidates[0];
-  }
+//   if (n == 1) {
+//     // the only match is the best match
+//     return candidates[0];
+//   }
 
-  // If index i is set then we can skip testing function F_i because
-  // we already know it can not be the best match.
-  std::vector<bool> notBest(n, false);
+//   // If index i is set then we can skip testing function F_i because
+//   // we already know it can not be the best match.
+//   std::vector<bool> notBest(n, false);
 
-  for (int i = 0; i < n; i++) {
-    EXPLAIN("##########################\n");
-    EXPLAIN("# Considering function %d #\n", i);
-    EXPLAIN("##########################\n\n");
+//   for (int i = 0; i < n; i++) {
+//     EXPLAIN("##########################\n");
+//     EXPLAIN("# Considering function %d #\n", i);
+//     EXPLAIN("##########################\n\n");
 
-    const DisambiguationCandidate* candidate1 = candidates[i];
-    bool singleMostSpecific = true;
+//     const DisambiguationCandidate* candidate1 = candidates[i];
+//     bool singleMostSpecific = true;
 
-    EXPLAIN_DUMP(candidate1->fn);
+//     EXPLAIN_DUMP(candidate1->fn);
 
-    if (notBest[i]) {
-      EXPLAIN("Already known to not be best match.  Skipping.\n\n");
-      continue;
-    }
+//     if (notBest[i]) {
+//       EXPLAIN("Already known to not be best match.  Skipping.\n\n");
+//       continue;
+//     }
 
-    for (int j = 0; j < n; j++) {
-      if (i == j) {
-        continue;
-      }
+//     for (int j = 0; j < n; j++) {
+//       if (i == j) {
+//         continue;
+//       }
 
-      EXPLAIN("Comparing to function %d\n", j);
-      EXPLAIN("-----------------------\n");
+//       EXPLAIN("Comparing to function %d\n", j);
+//       EXPLAIN("-----------------------\n");
 
-      const DisambiguationCandidate* candidate2 = candidates[j];
+//       const DisambiguationCandidate* candidate2 = candidates[j];
 
-      EXPLAIN_DUMP(candidate2->fn);
+//       EXPLAIN_DUMP(candidate2->fn);
 
-      int cmp = compareSpecificity(dctx, *candidate1, *candidate2, ignoreWhere);
+//       int cmp = compareSpecificity(dctx, *candidate1, *candidate2, ignoreWhere);
 
-      if (cmp < 0) {
-        EXPLAIN("X: Fn %d is a better match than Fn %d\n\n\n", i, j);
-        notBest[j] = true;
+//       if (cmp < 0) {
+//         EXPLAIN("X: Fn %d is a better match than Fn %d\n\n\n", i, j);
+//         notBest[j] = true;
 
-      } else if (cmp > 0) {
-        EXPLAIN("X: Fn %d is a worse match than Fn %d\n\n\n", i, j);
-        notBest[i] = true;
-        singleMostSpecific = false;
-        break;
-      } else {
-        EXPLAIN("X: Fn %d is a as good a match as Fn %d\n\n\n", i, j);
-        singleMostSpecific = false;
-        if (notBest[j]) {
-          // Inherit the notBest status of what we are comparing against
-          //
-          // If this candidate is equally as good as something that wasn't
-          // the best, then it is also not the best (or else there is something
-          // terribly wrong with our compareSpecificity function).
-          notBest[i] = true;
-        }
-        break;
-      }
-    }
+//       } else if (cmp > 0) {
+//         EXPLAIN("X: Fn %d is a worse match than Fn %d\n\n\n", i, j);
+//         notBest[i] = true;
+//         singleMostSpecific = false;
+//         break;
+//       } else {
+//         EXPLAIN("X: Fn %d is a as good a match as Fn %d\n\n\n", i, j);
+//         singleMostSpecific = false;
+//         if (notBest[j]) {
+//           // Inherit the notBest status of what we are comparing against
+//           //
+//           // If this candidate is equally as good as something that wasn't
+//           // the best, then it is also not the best (or else there is something
+//           // terribly wrong with our compareSpecificity function).
+//           notBest[i] = true;
+//         }
+//         break;
+//       }
+//     }
 
-    if (singleMostSpecific) {
-      EXPLAIN("Y: Fn %d is the best match.\n\n\n", i);
-      return candidates[i];
+//     if (singleMostSpecific) {
+//       EXPLAIN("Y: Fn %d is the best match.\n\n\n", i);
+//       return candidates[i];
 
-    } else {
-      EXPLAIN("Y: Fn %d is NOT the best match.\n\n\n", i);
-    }
-  }
+//     } else {
+//       EXPLAIN("Y: Fn %d is NOT the best match.\n\n\n", i);
+//     }
+//   }
 
-  EXPLAIN("Z: No non-ambiguous best match.\n\n");
+//   EXPLAIN("Z: No non-ambiguous best match.\n\n");
 
-  for (int i = 0; i < n; i++) {
-    if (notBest[i] == false) {
-      ambiguousBest.push_back(candidates[i]);
-    }
-  }
+//   for (int i = 0; i < n; i++) {
+//     if (notBest[i] == false) {
+//       ambiguousBest.push_back(candidates[i]);
+//     }
+//   }
 
-  return nullptr;
-}
+//   return nullptr;
+// }
 
 /**
 
@@ -714,10 +712,10 @@ static int compareSpecificity(const DisambiguationContext& dctx,
         std::string reason = "operator method vs function";
         if (p == 1) {
           ds.fn1NonParamArgsPreferred = true;
-          EXPLAIN("%s: Fn %d is non-param preferred\n", reason, i);
+          EXPLAIN("%s: Fn %d is non-param preferred\n", reason.c_str(), i);
         } else if (p == 2) {
           ds.fn2NonParamArgsPreferred = true;
-            EXPLAIN("%s: Fn %d is non-param preferred\n", reason, j);
+            EXPLAIN("%s: Fn %d is non-param preferred\n", reason.c_str(), j);
         }
         continue;
       }
@@ -734,18 +732,18 @@ static int compareSpecificity(const DisambiguationContext& dctx,
     if (actualParam) {
       if (p == 1) {
         ds.fn1ParamArgsPreferred = true;
-        EXPLAIN("%s: Fn %d is param preferred\n", reason, i);
+        EXPLAIN("%s: Fn %d is param preferred\n", reason.c_str(), i);
       } else if (p == 2) {
         ds.fn2ParamArgsPreferred = true;
-        EXPLAIN("%s: Fn %d is param preferred\n", reason, j);
+        EXPLAIN("%s: Fn %d is param preferred\n", reason.c_str(), j);
       }
     } else {
       if (p == 1) {
         ds.fn1NonParamArgsPreferred = true;
-        EXPLAIN("%s: Fn %d is non-param preferred\n", reason, i);
+        EXPLAIN("%s: Fn %d is non-param preferred\n", reason.c_str(), i);
       } else if (p == 2) {
         ds.fn2NonParamArgsPreferred = true;
-        EXPLAIN("%s: Fn %d is non-param preferred\n", reason, j);
+        EXPLAIN("%s: Fn %d is non-param preferred\n", reason.c_str(), j);
       }
     }
   }
@@ -803,104 +801,104 @@ static int compareSpecificity(const DisambiguationContext& dctx,
   \return 0 if fn1 and fn2 are equally specific
   \return 1 if fn2 is a more specific function than f1
  */
-static int compareSpecificity(const DisambiguationContext& dctx,
-                              const DisambiguationCandidate& candidate1,
-                              const DisambiguationCandidate& candidate2,
-                              bool ignoreWhere) {
+// static int compareSpecificity(const DisambiguationContext& dctx,
+//                               const DisambiguationCandidate& candidate1,
+//                               const DisambiguationCandidate& candidate2,
+//                               bool ignoreWhere) {
 
-  bool prefer1 = false;
-  bool prefer2 = false;
-  int n = dctx.call->numActuals();
-  DisambiguationState ds;
+  // bool prefer1 = false;
+  // bool prefer2 = false;
+  // int n = dctx.call->numActuals();
+  // DisambiguationState ds;
 
-  for (int k = 0; k < n; k++) {
-    testArgMapping(dctx, candidate1, candidate2, k, ds);
-  }
+  // for (int k = 0; k < n; k++) {
+  //   testArgMapping(dctx, candidate1, candidate2, k, ds);
+  // }
 
-  if (ds.fn1Promotes != ds.fn2Promotes) {
-    EXPLAIN("\nP: only one of the functions requires argument promotion\n");
+  // if (ds.fn1Promotes != ds.fn2Promotes) {
+  //   EXPLAIN("\nP: only one of the functions requires argument promotion\n");
 
-    // Prefer the version that did not promote
-    prefer1 = !ds.fn1Promotes;
-    prefer2 = !ds.fn2Promotes;
+  //   // Prefer the version that did not promote
+  //   prefer1 = !ds.fn1Promotes;
+  //   prefer2 = !ds.fn2Promotes;
 
-  } else if (ds.fn1MoreSpecific != ds.fn2MoreSpecific) {
-    EXPLAIN("\nP1: only one more specific argument mapping\n");
+  // } else if (ds.fn1MoreSpecific != ds.fn2MoreSpecific) {
+  //   EXPLAIN("\nP1: only one more specific argument mapping\n");
 
-    prefer1 = ds.fn1MoreSpecific;
-    prefer2 = ds.fn2MoreSpecific;
+  //   prefer1 = ds.fn1MoreSpecific;
+  //   prefer2 = ds.fn2MoreSpecific;
 
-  } else {
-    // If the decision hasn't been made based on the argument mappings...
-    auto moreVis = moreVisible(dctx, candidate1, candidate2);
-    if (moreVis == MoreVisibleResult::FOUND_F1_FIRST) {
-      EXPLAIN("\nQ: preferring more visible function\n");
-      prefer1 = true;
+  // } else {
+  //   // If the decision hasn't been made based on the argument mappings...
+  //   auto moreVis = moreVisible(dctx, candidate1, candidate2);
+  //   if (moreVis == MoreVisibleResult::FOUND_F1_FIRST) {
+  //     EXPLAIN("\nQ: preferring more visible function\n");
+  //     prefer1 = true;
 
-    } else if (moreVis == MoreVisibleResult::FOUND_F2_FIRST) {
-      EXPLAIN("\nR: preferring more visible function\n");
-      prefer2 = true;
+  //   } else if (moreVis == MoreVisibleResult::FOUND_F2_FIRST) {
+  //     EXPLAIN("\nR: preferring more visible function\n");
+  //     prefer2 = true;
 
-    } else if (ds.fn1WeakPreferred != ds.fn2WeakPreferred) {
-      EXPLAIN("\nS: preferring based on weak preference\n");
-      prefer1 = ds.fn1WeakPreferred;
-      prefer2 = ds.fn2WeakPreferred;
+  //   } else if (ds.fn1WeakPreferred != ds.fn2WeakPreferred) {
+  //     EXPLAIN("\nS: preferring based on weak preference\n");
+  //     prefer1 = ds.fn1WeakPreferred;
+  //     prefer2 = ds.fn2WeakPreferred;
 
-    } else if (ds.fn1WeakerPreferred != ds.fn2WeakerPreferred) {
-      EXPLAIN("\nS: preferring based on weaker preference\n");
-      prefer1 = ds.fn1WeakerPreferred;
-      prefer2 = ds.fn2WeakerPreferred;
+  //   } else if (ds.fn1WeakerPreferred != ds.fn2WeakerPreferred) {
+  //     EXPLAIN("\nS: preferring based on weaker preference\n");
+  //     prefer1 = ds.fn1WeakerPreferred;
+  //     prefer2 = ds.fn2WeakerPreferred;
 
-    } else if (ds.fn1WeakestPreferred != ds.fn2WeakestPreferred) {
-      EXPLAIN("\nS: preferring based on weakest preference\n");
-      prefer1 = ds.fn1WeakestPreferred;
-      prefer2 = ds.fn2WeakestPreferred;
+  //   } else if (ds.fn1WeakestPreferred != ds.fn2WeakestPreferred) {
+  //     EXPLAIN("\nS: preferring based on weakest preference\n");
+  //     prefer1 = ds.fn1WeakestPreferred;
+  //     prefer2 = ds.fn2WeakestPreferred;
 
-      /* A note about weak-prefers. Why are there 3 levels?
+  //     /* A note about weak-prefers. Why are there 3 levels?
 
-         Something like 'param x:int(16) = 5' should be able to coerce to any
-         integral type. Meanwhile, 'param y = 5' should also be able to coerce
-         to any integral type. Now imagine we are resolving 'x+y'.  We
-         want it to resolve to the 'int(16)' version because 'x' has a type
-         specified, but 'y' is a default type. Before the 3 weak levels, this
-         version was chosen simply because non-default-sized ints didn't allow
-         param conversion.
+  //        Something like 'param x:int(16) = 5' should be able to coerce to any
+  //        integral type. Meanwhile, 'param y = 5' should also be able to coerce
+  //        to any integral type. Now imagine we are resolving 'x+y'.  We
+  //        want it to resolve to the 'int(16)' version because 'x' has a type
+  //        specified, but 'y' is a default type. Before the 3 weak levels, this
+  //        version was chosen simply because non-default-sized ints didn't allow
+  //        param conversion.
 
-       */
-    } else if (!ignoreWhere) {
-      ID id1 = candidate1.fn->id();
-      ID id2 = candidate2.fn->id();
-      bool fn1where = parsing::idIsFunctionWithWhere(dctx.context, id1);
-      bool fn2where = parsing::idIsFunctionWithWhere(dctx.context, id2);
+  //      */
+  //   } else if (!ignoreWhere) {
+  //     ID id1 = candidate1.fn->id();
+  //     ID id2 = candidate2.fn->id();
+  //     bool fn1where = parsing::idIsFunctionWithWhere(dctx.context, id1);
+  //     bool fn2where = parsing::idIsFunctionWithWhere(dctx.context, id2);
 
-      if (fn1where != fn2where) {
-        EXPLAIN("\nU: preferring function with where clause\n");
+  //     if (fn1where != fn2where) {
+  //       EXPLAIN("\nU: preferring function with where clause\n");
 
-        prefer1 = fn1where;
-        prefer2 = fn2where;
-      }
-    }
-  }
+  //       prefer1 = fn1where;
+  //       prefer2 = fn2where;
+  //     }
+  //   }
+  // }
 
-  CHPL_ASSERT(!(prefer1 && prefer2));
+  // CHPL_ASSERT(!(prefer1 && prefer2));
 
-  if (prefer1) {
-    EXPLAIN("\nW: Fn %d is more specific than Fn %d\n",
-            candidate1.idx, candidate2.idx);
-    return -1;
+  // if (prefer1) {
+  //   EXPLAIN("\nW: Fn %d is more specific than Fn %d\n",
+  //           candidate1.idx, candidate2.idx);
+  //   return -1;
 
-  } else if (prefer2) {
-    EXPLAIN("\nW: Fn %d is less specific than Fn %d\n",
-            candidate1.idx, candidate2.idx);
-    return 1;
+  // } else if (prefer2) {
+  //   EXPLAIN("\nW: Fn %d is less specific than Fn %d\n",
+  //           candidate1.idx, candidate2.idx);
+  //   return 1;
 
-  } else {
-    // Neither is more specific
-    EXPLAIN("\nW: Fn %d and Fn %d are equally specific\n",
-            candidate1.idx, candidate2.idx);
-    return 0;
-  }
-}
+  // } else {
+  //   // Neither is more specific
+  //   EXPLAIN("\nW: Fn %d and Fn %d are equally specific\n",
+  //           candidate1.idx, candidate2.idx);
+  //   return 0;
+  // }
+// }
 
 /*
  * Returns:
@@ -1087,8 +1085,8 @@ static void discardWorseVisibility(const DisambiguationContext& dctx,
     }
 
     DisambiguationCandidate* candidate = (DisambiguationCandidate*)candidates[i];
-
-    int distance = computeVisibilityDistance(dctx.context, dctx.callInScope, candidate->fn);
+    auto scope = dctx.callInPoiScope == nullptr ? dctx.callInScope : dctx.callInPoiScope->inScope();
+    int distance = computeVisibilityDistance(dctx.context, scope, candidate->fn);
     candidate->visibilityDistance = distance;
 
     if (distance >= 0) {
@@ -1110,7 +1108,7 @@ static void discardWorseVisibility(const DisambiguationContext& dctx,
       const DisambiguationCandidate* candidate = candidates[i];
       int distance = candidate->visibilityDistance;
       if (distance > 0 && distance > minDistance) {
-        EXPLAIN("X: Fn %d has further visibility distance\n", i);
+        EXPLAIN("X: Fn %lu has further visibility distance\n", i);
         discarded[i] = true;
       }
     }
@@ -1213,7 +1211,226 @@ computeIsMoreVisible(Context* context,
 
   return MoreVisibleResult::FOUND_NEITHER;
 }
+static const DisambiguationCandidate*
+disambiguateByMatchInner(const DisambiguationContext& dctx,
+                        const CandidatesVec& candidates,
+                               bool ignoreWhere,
+                               CandidatesVec& ambiguous) {
 
+  // quick exit if there is nothing to do
+  if (candidates.size() == 0) {
+    return nullptr;
+  }
+  if (candidates.size() == 1) {
+    return candidates[0];
+  }
+
+  // Disable implicit conversion to remove nilability for disambiguation
+  // int saveGenerousResolutionForErrors = 0;
+  // if (generousResolutionForErrors > 0) {
+  //   saveGenerousResolutionForErrors = generousResolutionForErrors;
+  //   generousResolutionForErrors = 0;
+  // }
+
+  // If index i is set we have ruled out that function
+  std::vector<bool> discarded(candidates.size(), false);
+
+  // use new rules
+  disambiguateDiscarding(dctx, candidates, ignoreWhere, discarded);
+
+  // If there is just 1 candidate at this point, return it
+  {
+    int only = -1;
+    int currentCandidates = 0;
+    for (size_t i = 0; i < candidates.size(); ++i) {
+      if (discarded[i]) {
+        continue;
+      }
+      only = i;
+      currentCandidates++;
+    }
+
+    if (currentCandidates == 1) {
+      EXPLAIN("Y: Fn %d is the best match.\n\n\n", only);
+
+      // if (saveGenerousResolutionForErrors > 0)
+      //   generousResolutionForErrors = saveGenerousResolutionForErrors;
+
+      return candidates[only];
+    }
+  }
+
+  // There was more than one best candidate.
+  // So, add whatever is left to 'ambiguous'
+  // and return NULL.
+  for (size_t i = 0; i < candidates.size(); i++) {
+    if (discarded[i]) {
+      continue;
+    }
+
+    EXPLAIN("Z: Fn %lu is one of the best matches\n", i);
+    ambiguous.push_back(candidates[i]);
+  }
+
+  // if (saveGenerousResolutionForErrors > 0)
+  //   generousResolutionForErrors = saveGenerousResolutionForErrors;
+
+  return nullptr;
+}
+
+static const DisambiguationCandidate*
+disambiguateByMatch(const DisambiguationContext& dctx,
+                    const CandidatesVec& candidates,
+                    bool ignoreWhere,
+                    CandidatesVec& ambiguousBest) {
+
+  return disambiguateByMatchInner(dctx, candidates, ignoreWhere, ambiguousBest);
+
+  // TODO: maybe implement the verify procedure in dyno
+  // if (fVerify) {
+  //   // check that 'compareSpecificity' creates a partial order
+  //   PartialOrderChecker checker(candidates, DC);
+
+  //   for (int i = 0; i < candidates.n; ++i) {
+  //     ResolutionCandidate* candidate1         = candidates.v[i];
+  //     bool forGenericInit = candidate1->fn->isInitializer() || candidate1->fn->isCopyInit();
+
+  //     for (int j = i; j < candidates.n; ++j) {
+  //       ResolutionCandidate* candidate2 = candidates.v[j];
+
+  //       int cmp = compareSpecificity(candidate1,
+  //                                    candidate2,
+  //                                    DC,
+  //                                    i,
+  //                                    j,
+  //                                    forGenericInit);
+
+  //       checker.addResult(i, j, cmp);
+  //     }
+  //   }
+
+  //   checker.checkResults();
+  // }
+
+}
+
+
+static MostSpecificCandidates
+disambiguateByMatch(DisambiguationContext& dctx, CandidatesVec& candidates) {
+  CandidatesVec ambiguous;
+
+  // DisambiguationCandidate* bestRef = nullptr;
+  // DisambiguationCandidate* bestConstRef = nullptr;
+  DisambiguationCandidate* bestValue = nullptr;
+
+  DisambiguationCandidate* best = (DisambiguationCandidate*)disambiguateByMatch(dctx, candidates, true,
+                                                    ambiguous);
+  MostSpecificCandidates ret = MostSpecificCandidates::getAmbiguous();
+  // int retval = 0;
+
+  // The common case is that there is no ambiguity because the
+  // return intent overload feature is not used.
+  if (best != nullptr) {
+    ret = MostSpecificCandidates::getOnly(best->toMostSpecificCandidate(dctx.context));
+    // auto returnIntent = parsing::idToFnReturnIntent(dctx.context, best->fn->id());
+    // if (returnIntent == Function::REF) {
+    //   bestRef = best;
+    // } else if(returnIntent == Function::CONST_REF) {
+    //   bestConstRef = best;
+    // } else {
+    //   bestValue = best;
+    // }
+    // retval = 1;
+
+  } else {
+    // Now, if there was ambiguity, find candidates with different
+    // return intent in ambiguousCandidates.
+    // If there is only one of each, we are good to go.
+    int                  nRef              = 0;
+    int                  nConstRef         = 0;
+    int                  nValue            = 0;
+    int                  nOther            = 0;
+    int                  total             = 0;
+
+    DisambiguationCandidate* refCandidate      = NULL;
+    DisambiguationCandidate* constRefCandidate = NULL;
+    DisambiguationCandidate* valueCandidate    = NULL;
+
+    // Count number of candidates in each category.
+    countByReturnIntent(dctx, ambiguous, nRef, nConstRef, nValue, nOther);
+
+    total = nRef + nConstRef + nValue + nOther;
+
+    // 0 or 1 matches -> return now, not a ref pair.
+    if (total <= 1) {
+      ret = MostSpecificCandidates::getAmbiguous();
+
+      // 1 match is possible with best==NULL in cases
+      // where the 'more specific' relation is not transitive.
+
+    } else if (nOther > 0) {
+      ambiguous.clear();
+
+      // If there are *any* type/param candidates, we need to cause ambiguity
+      // if they are not selected... including consideration of where clauses.
+      bestValue  = (DisambiguationCandidate*)disambiguateByMatch(dctx, candidates, false, ambiguous);
+      if (bestValue)
+        ret = MostSpecificCandidates::getOnly(best->toMostSpecificCandidate(dctx.context));
+      else
+        ret = MostSpecificCandidates::getAmbiguous();
+
+    } else {
+      if (nRef > 1 || nConstRef > 1 || nValue > 1) {
+        // Split candidates into ref, const ref, and value candidates
+        CandidatesVec refCandidates;
+        CandidatesVec constRefCandidates;
+        CandidatesVec valueCandidates;
+        CandidatesVec tmpAmbiguous;
+
+        // Move candidates to above Vecs according to return intent
+        gatherVecsByReturnIntent(dctx,
+                                 candidates,
+                                 refCandidates,
+                                 constRefCandidates,
+                                 valueCandidates);
+
+        // Disambiguate each group
+        refCandidate      = (DisambiguationCandidate*)disambiguateByMatch(dctx, refCandidates,
+                                                false,
+                                                tmpAmbiguous);
+
+        constRefCandidate = (DisambiguationCandidate*)disambiguateByMatch(dctx, constRefCandidates,
+                                                false,
+                                                tmpAmbiguous);
+
+        valueCandidate    = (DisambiguationCandidate*)disambiguateByMatch(dctx, valueCandidates,
+                                                false,
+                                                tmpAmbiguous);
+        // update the counts
+        if (refCandidate      != NULL) nRef      = 1;
+        if (constRefCandidate != NULL) nConstRef = 1;
+        if (valueCandidate    != NULL) nValue    = 1;
+      }
+
+      // Now we know there are >= 2 matches.
+      // If there are more than 2 matches in any category, fail for ambiguity.
+      if (nRef > 1 || nConstRef > 1 || nValue > 1) {
+        return MostSpecificCandidates::getAmbiguous();
+      } else {
+        ret = gatherByReturnIntent(dctx.context, dctx, ambiguous);
+        // otherwise, there is 1 or fewer match in each category,
+        // so there is no ambiguity.
+        if (refCandidate != nullptr)
+          ret.setBestRef(refCandidate->toMostSpecificCandidate(dctx.context));
+        if (constRefCandidate != nullptr)
+          ret.setBestConstRef(constRefCandidate->toMostSpecificCandidate(dctx.context));
+        if (valueCandidate != nullptr)
+          ret.setBestValue(valueCandidate->toMostSpecificCandidate(dctx.context));
+      }
+    }
+  }
+  return ret;
+}
 
 // Discard any candidate that has a worse argument mapping than another
 // candidate.
@@ -1239,7 +1456,7 @@ static void discardWorseArgs(const DisambiguationContext& dctx,
 
     bool forGenericInit = candidate1->fn->untyped()->isMethod() &&
                           (candidate1->fn->untyped()->name() == USTR("init") ||
-                           candidate1->fn->untyped()->name() == USTR("init="))
+                           candidate1->fn->untyped()->name() == USTR("init="));
 
     EXPLAIN_DUMP(candidate1->fn);
 
@@ -1331,7 +1548,7 @@ static void discardWorseWhereClauses(const DisambiguationContext& dctx,
       bool where = whereClause != TypedFnSignature::WHERE_NONE;
 
       if (!where) {
-        EXPLAIN("X: Fn %d does not have 'where' but others do\n", i);
+        EXPLAIN("X: Fn %lu does not have 'where' but others do\n", i);
         discarded[i] = true;
       }
     }
@@ -1364,6 +1581,15 @@ static bool isMatchingImagComplex(Type* actualType, Type* formalType) {
     }
   }
   return false;
+}
+
+static const Type*
+normalizeTupleTypeToValueTuple(Context* context, const Type* t) {
+  if (auto tt = t->toTupleType()) {
+    return (const Type*)tt->toValueTuple(context);
+    // return do_computeTupleWithIntent(false, intent, t, NULL, NULL, false);
+  }
+  return t;
 }
 
 static void computeConversionInfo(const DisambiguationContext& dctx,
@@ -1450,15 +1676,14 @@ static void computeConversionInfo(const DisambiguationContext& dctx,
     // TODO: skipping for now b/c I think this is implemented in canPass
     //       otherwise need to implement something here still
     // Not counting tuple value vs referential tuple changes
-    // if (actualType->symbol->hasFlag(FLAG_TUPLE) &&
-    //     formalType->symbol->hasFlag(FLAG_TUPLE)) {
-    //   Type* actualNormTup = normalizeTupleTypeToValueTuple(actualType);
-    //   Type* formalNormTup = normalizeTupleTypeToValueTuple(formalType);
-    //   if (actualNormTup == formalNormTup) {
-    //     // it is only a change in the tuple ref-ness
-    //     continue;
-    //   }
-    // }
+    if (actualType->isTupleType() && formalType->isTupleType()) {
+      const Type* actualNormTup = normalizeTupleTypeToValueTuple(dctx.context, fa1->actualType().type());
+      const Type* formalNormTup = normalizeTupleTypeToValueTuple(dctx.context, fa1->formalType().type());
+      if (actualNormTup == formalNormTup) {
+        // it is only a change in the tuple ref-ness
+        continue;
+      }
+    }
 
     nImplicitConversions++;
   }
@@ -1501,7 +1726,7 @@ static void discardWorseConversions(const DisambiguationContext& dctx,
       const DisambiguationCandidate* candidate = candidates[i];
       int impConv = candidate->nImplicitConversions;
       if (impConv > minImpConv) {
-        EXPLAIN("X: Fn %d has more implicit conversions\n", i);
+        EXPLAIN("X: Fn %lu has more implicit conversions\n", i);
         discarded[i] = true;
       }
     }
@@ -1531,7 +1756,7 @@ static void discardWorseConversions(const DisambiguationContext& dctx,
 
       const DisambiguationCandidate* candidate = candidates[i];
       if (candidate->anyNegParamToUnsigned) {
-        EXPLAIN("X: Fn %d has negative param to signed and others do not\n", i);
+        EXPLAIN("X: Fn %lu has negative param to signed and others do not\n", i);
         discarded[i] = true;
       }
     }
@@ -1564,7 +1789,7 @@ static void discardWorseConversions(const DisambiguationContext& dctx,
       const DisambiguationCandidate* candidate = candidates[i];
       int narrowing = candidate->nParamNarrowingImplicitConversions;
       if (narrowing > minNarrowing) {
-        EXPLAIN("X: Fn %d has more param narrowing conversions\n", i);
+        EXPLAIN("X: Fn %lu has more param narrowing conversions\n", i);
         discarded[i] = true;
       }
     }
@@ -1599,9 +1824,9 @@ static void discardWorsePromoting(const DisambiguationContext& dctx,
 
       const DisambiguationCandidate* candidate = candidates[i];
       if (candidate->anyPromotes) {
-        EXPLAIN_DUMP(candidate1->fn);
+        EXPLAIN_DUMP(candidate->fn);
         EXPLAIN("\n\n");
-        EXPLAIN("X: Fn %d promotes but others do not\n", i);
+        EXPLAIN("X: Fn %lu promotes but others do not\n", i);
         discarded[i] = true;
       }
     }
@@ -1640,24 +1865,24 @@ moreVisibleQuery(Context* context,
   Computes whether candidate1 or candidate2 is more visible/shadowing
   the other.
  */
-static MoreVisibleResult
-moreVisible(const DisambiguationContext& dctx,
-            const DisambiguationCandidate& candidate1,
-            const DisambiguationCandidate& candidate2) {
-  UniqueString callName = dctx.call->name();
-  ID fn1Id = candidate1.fn->id();
-  ID fn2Id = candidate2.fn->id();
+// static MoreVisibleResult
+// moreVisible(const DisambiguationContext& dctx,
+//             const DisambiguationCandidate& candidate1,
+//             const DisambiguationCandidate& candidate2) {
+//   UniqueString callName = dctx.call->name();
+//   ID fn1Id = candidate1.fn->id();
+//   ID fn2Id = candidate2.fn->id();
 
-  // ignore more-visible for methods
-  if (candidate1.fn->untyped()->isMethod() &&
-      candidate2.fn->untyped()->isMethod()) {
-    return FOUND_BOTH;
-  }
+//   // ignore more-visible for methods
+//   if (candidate1.fn->untyped()->isMethod() &&
+//       candidate2.fn->untyped()->isMethod()) {
+//     return FOUND_BOTH;
+//   }
 
-  return moreVisibleQuery(dctx.context, callName,
-                          dctx.callInScope, dctx.callInPoiScope,
-                          fn1Id, fn2Id);
-}
+//   return moreVisibleQuery(dctx.context, callName,
+//                           dctx.callInScope, dctx.callInPoiScope,
+//                           fn1Id, fn2Id);
+// }
 
 /**
   Compare two argument mappings, given a set of actual arguments, and set the
@@ -1707,6 +1932,10 @@ static int testArgMapping(const DisambiguationContext& dctx,
   // Additionally, ignore the difference between referential tuples
   // and value tuples.
   // TODO: not sure how to reproduce this code in Dyno
+
+  f1Type = QualifiedType(QualifiedType::Kind::IN, normalizeTupleTypeToValueTuple(dctx.context, f1Type.type()));
+  f2Type = QualifiedType(QualifiedType::Kind::IN, normalizeTupleTypeToValueTuple(dctx.context, f2Type.type()));
+  actualType = QualifiedType(QualifiedType::Kind::IN, normalizeTupleTypeToValueTuple(dctx.context, actualType.type()));
 
   // TODO: Not sure we still need this here, based on production
   // Initializer work-around: Skip 'this' for generic initializers
@@ -1915,251 +2144,251 @@ static int testArgMapping(const DisambiguationContext& dctx,
   Sets bits in DisambiguationState ds according to whether argument actualIdx
   in candidate1 vs candidate2 is a better match.
  */
-static void testArgMapping(const DisambiguationContext& dctx,
-                           const DisambiguationCandidate& candidate1,
-                           const DisambiguationCandidate& candidate2,
-                           int actualIdx,
-                           DisambiguationState& ds) {
+// static void testArgMapping(const DisambiguationContext& dctx,
+//                            const DisambiguationCandidate& candidate1,
+//                            const DisambiguationCandidate& candidate2,
+//                            int actualIdx,
+//                            DisambiguationState& ds) {
 
-  EXPLAIN("\nLooking at argument %d\n", actualIdx);
+//   EXPLAIN("\nLooking at argument %d\n", actualIdx);
 
-  const FormalActual* fa1 = candidate1.formalActualMap.byActualIdx(actualIdx);
-  const FormalActual* fa2 = candidate2.formalActualMap.byActualIdx(actualIdx);
+//   const FormalActual* fa1 = candidate1.formalActualMap.byActualIdx(actualIdx);
+//   const FormalActual* fa2 = candidate2.formalActualMap.byActualIdx(actualIdx);
 
-  if (fa1 == nullptr || fa2 == nullptr) {
-    // TODO: call testOpArgMapping if one was an operator but the
-    // other is not
-    CHPL_ASSERT(false && "TODO -- handle operator calls");
-  }
+//   if (fa1 == nullptr || fa2 == nullptr) {
+//     // TODO: call testOpArgMapping if one was an operator but the
+//     // other is not
+//     CHPL_ASSERT(false && "TODO -- handle operator calls");
+//   }
 
-  QualifiedType f1Type = fa1->formalType();
-  QualifiedType f2Type = fa2->formalType();
-  QualifiedType actualType = fa1->actualType();
-  CHPL_ASSERT(actualType == fa2->actualType());
+//   QualifiedType f1Type = fa1->formalType();
+//   QualifiedType f2Type = fa2->formalType();
+//   QualifiedType actualType = fa1->actualType();
+//   CHPL_ASSERT(actualType == fa2->actualType());
 
-  // Give up early for out intent arguments
-  // (these don't impact candidate selection)
-  if (f1Type.kind() == QualifiedType::OUT ||
-      f2Type.kind() == QualifiedType::OUT) {
-    return;
-  }
+//   // Give up early for out intent arguments
+//   // (these don't impact candidate selection)
+//   if (f1Type.kind() == QualifiedType::OUT ||
+//       f2Type.kind() == QualifiedType::OUT) {
+//     return;
+//   }
 
-  // Initializer work-around: Skip 'this' for generic initializers
-  if (dctx.call->name() == USTR("init") || dctx.call->name() == USTR("init=")) {
-    auto nd1 = fa1->formal()->toNamedDecl();
-    auto nd2 = fa2->formal()->toNamedDecl();
-    if (nd1 != nullptr && nd2 != nullptr &&
-        nd1->name() == USTR("this") && nd2->name() == USTR("this")) {
-      if (getTypeGenericity(dctx.context, f1Type) != Type::CONCRETE &&
-          getTypeGenericity(dctx.context, f2Type) != Type::CONCRETE) {
-        return;
-      }
-    }
-  }
+//   // Initializer work-around: Skip 'this' for generic initializers
+//   if (dctx.call->name() == USTR("init") || dctx.call->name() == USTR("init=")) {
+//     auto nd1 = fa1->formal()->toNamedDecl();
+//     auto nd2 = fa2->formal()->toNamedDecl();
+//     if (nd1 != nullptr && nd2 != nullptr &&
+//         nd1->name() == USTR("this") && nd2->name() == USTR("this")) {
+//       if (getTypeGenericity(dctx.context, f1Type) != Type::CONCRETE &&
+//           getTypeGenericity(dctx.context, f2Type) != Type::CONCRETE) {
+//         return;
+//       }
+//     }
+//   }
 
-  bool formal1Promotes = false;
-  bool formal2Promotes = false;
-  bool formal1Narrows = false;
-  bool formal2Narrows = false;
+//   bool formal1Promotes = false;
+//   bool formal2Promotes = false;
+//   bool formal1Narrows = false;
+//   bool formal2Narrows = false;
 
-  QualifiedType actualScalarT = actualType;
+//   QualifiedType actualScalarT = actualType;
 
-  bool f1Param = f1Type.hasParamPtr();
-  bool f2Param = f2Type.hasParamPtr();
+//   bool f1Param = f1Type.hasParamPtr();
+//   bool f2Param = f2Type.hasParamPtr();
 
-  bool f1Instantiated = fa1->formalInstantiated();
-  bool f2Instantiated = fa2->formalInstantiated();
+//   bool f1Instantiated = fa1->formalInstantiated();
+//   bool f2Instantiated = fa2->formalInstantiated();
 
-  bool f1InstantiatedFromAny = false;
-  bool f2InstantiatedFromAny = false;
+//   bool f1InstantiatedFromAny = false;
+//   bool f2InstantiatedFromAny = false;
 
-  bool f1PartiallyGeneric = false;
-  bool f2PartiallyGeneric = false;
+//   bool f1PartiallyGeneric = false;
+//   bool f2PartiallyGeneric = false;
 
-  if (f1Instantiated) {
-    f1InstantiatedFromAny = isFormalInstantiatedAny(candidate1, fa1);
-    f1PartiallyGeneric = isFormalPartiallyGeneric(candidate1, fa1);
-  }
-  if (f2Instantiated) {
-    f2InstantiatedFromAny = isFormalInstantiatedAny(candidate2, fa2);
-    f2PartiallyGeneric = isFormalPartiallyGeneric(candidate2, fa2);
-  }
+//   if (f1Instantiated) {
+//     f1InstantiatedFromAny = isFormalInstantiatedAny(candidate1, fa1);
+//     f1PartiallyGeneric = isFormalPartiallyGeneric(candidate1, fa1);
+//   }
+//   if (f2Instantiated) {
+//     f2InstantiatedFromAny = isFormalInstantiatedAny(candidate2, fa2);
+//     f2PartiallyGeneric = isFormalPartiallyGeneric(candidate2, fa2);
+//   }
 
-  bool actualParam = false;
-  bool paramWithDefaultSize = false;
+//   bool actualParam = false;
+//   bool paramWithDefaultSize = false;
 
-  // Don't enable param/ weak preferences for non-default sized param values.
-  // If somebody bothered to type the param, they probably want it to stay that
-  // way. This is a strategy to resolve ambiguity with e.g.
-  //  +(param x:int(32), param y:int(32)
-  //  +(param x:int(64), param y:int(64)
-  // called with
-  //  param x:int(32), param y:int(64)
-  if (actualType.hasParamPtr()) {
-    actualParam = true;
-    paramWithDefaultSize = isNumericParamDefaultType(actualType);
-  }
+//   // Don't enable param/ weak preferences for non-default sized param values.
+//   // If somebody bothered to type the param, they probably want it to stay that
+//   // way. This is a strategy to resolve ambiguity with e.g.
+//   //  +(param x:int(32), param y:int(32)
+//   //  +(param x:int(64), param y:int(64)
+//   // called with
+//   //  param x:int(32), param y:int(64)
+//   if (actualType.hasParamPtr()) {
+//     actualParam = true;
+//     paramWithDefaultSize = isNumericParamDefaultType(actualType);
+//   }
 
-  EXPLAIN("Actual's type: ");
-  EXPLAIN_DUMP(&actualType);
-  if (actualParam)
-    EXPLAIN(" (param)");
-  if (paramWithDefaultSize)
-    EXPLAIN(" (default)");
-  EXPLAIN("\n");
+//   EXPLAIN("Actual's type: ");
+//   EXPLAIN_DUMP(&actualType);
+//   if (actualParam)
+//     EXPLAIN(" (param)");
+//   if (paramWithDefaultSize)
+//     EXPLAIN(" (default)");
+//   EXPLAIN("\n");
 
-  testArgMapHelper(dctx, *fa1, candidate1.forwardingTo,
-                   &formal1Promotes, &formal1Narrows, ds, 1);
+//   testArgMapHelper(dctx, *fa1, candidate1.forwardingTo,
+//                    &formal1Promotes, &formal1Narrows, ds, 1);
 
-  testArgMapHelper(dctx, *fa2, candidate2.forwardingTo,
-                   &formal2Promotes, &formal2Narrows, ds, 2);
+//   testArgMapHelper(dctx, *fa2, candidate2.forwardingTo,
+//                    &formal2Promotes, &formal2Narrows, ds, 2);
 
-  // Figure out scalar type for candidate matching
-  if (formal1Promotes || formal2Promotes) {
-    actualScalarT = computeActualScalarType(dctx.context, actualType);
-  }
+//   // Figure out scalar type for candidate matching
+//   if (formal1Promotes || formal2Promotes) {
+//     actualScalarT = computeActualScalarType(dctx.context, actualType);
+//   }
 
-  // TODO: for sync/single use the valType
+//   // TODO: for sync/single use the valType
 
-  const char* reason = "";
-  (void) reason;
-  typedef enum {
-    NONE,
-    WEAKEST,
-    WEAKER,
-    WEAK,
-    STRONG
-  } arg_preference_t;
+//   const char* reason = "";
+//   (void) reason;
+//   typedef enum {
+//     NONE,
+//     WEAKEST,
+//     WEAKER,
+//     WEAK,
+//     STRONG
+//   } arg_preference_t;
 
-  arg_preference_t prefer1 = NONE;
-  arg_preference_t prefer2 = NONE;
+//   arg_preference_t prefer1 = NONE;
+//   arg_preference_t prefer2 = NONE;
 
-  if (f1Type == f2Type && f1Param && !f2Param) {
-    prefer1 = STRONG; reason = "same type, param vs not";
+//   if (f1Type == f2Type && f1Param && !f2Param) {
+//     prefer1 = STRONG; reason = "same type, param vs not";
 
-  } else if (f1Type == f2Type && !f1Param && f2Param) {
-    prefer2 = STRONG; reason = "same type, param vs not";
+//   } else if (f1Type == f2Type && !f1Param && f2Param) {
+//     prefer2 = STRONG; reason = "same type, param vs not";
 
-  } else if (!formal1Promotes && formal2Promotes) {
-    prefer1 = STRONG; reason = "no promotion vs promotes";
+//   } else if (!formal1Promotes && formal2Promotes) {
+//     prefer1 = STRONG; reason = "no promotion vs promotes";
 
-  } else if (formal1Promotes && !formal2Promotes) {
-    prefer2 = STRONG; reason = "no promotion vs promotes";
+//   } else if (formal1Promotes && !formal2Promotes) {
+//     prefer2 = STRONG; reason = "no promotion vs promotes";
 
-  } else if (f1Type == f2Type           &&
-             !f1Instantiated && f2Instantiated) {
-    prefer1 = STRONG; reason = "concrete vs generic";
+//   } else if (f1Type == f2Type           &&
+//              !f1Instantiated && f2Instantiated) {
+//     prefer1 = STRONG; reason = "concrete vs generic";
 
-  } else if (f1Type == f2Type &&
-             f1Instantiated && !f2Instantiated) {
-    prefer2 = STRONG; reason = "concrete vs generic";
+//   } else if (f1Type == f2Type &&
+//              f1Instantiated && !f2Instantiated) {
+//     prefer2 = STRONG; reason = "concrete vs generic";
 
-  } else if (!f1InstantiatedFromAny && f2InstantiatedFromAny) {
-    prefer1 = STRONG; reason = "generic any vs partially generic/concrete";
+//   } else if (!f1InstantiatedFromAny && f2InstantiatedFromAny) {
+//     prefer1 = STRONG; reason = "generic any vs partially generic/concrete";
 
-  } else if (f1InstantiatedFromAny && !f2InstantiatedFromAny) {
-    prefer2 = STRONG; reason = "generic any vs partially generic/concrete";
+//   } else if (f1InstantiatedFromAny && !f2InstantiatedFromAny) {
+//     prefer2 = STRONG; reason = "generic any vs partially generic/concrete";
 
-  } else if (f1Instantiated && f2Instantiated &&
-             f1PartiallyGeneric && !f2PartiallyGeneric) {
-    prefer1 = STRONG; reason = "partially generic vs generic";
+//   } else if (f1Instantiated && f2Instantiated &&
+//              f1PartiallyGeneric && !f2PartiallyGeneric) {
+//     prefer1 = STRONG; reason = "partially generic vs generic";
 
-  } else if (f1Instantiated && f2Instantiated &&
-             !f1PartiallyGeneric && f2PartiallyGeneric) {
-    prefer2 = STRONG; reason = "partially generic vs generic";
+//   } else if (f1Instantiated && f2Instantiated &&
+//              !f1PartiallyGeneric && f2PartiallyGeneric) {
+//     prefer2 = STRONG; reason = "partially generic vs generic";
 
-  } else if (f1Param != f2Param && f1Param) {
-    prefer1 = WEAK; reason = "param vs not";
+//   } else if (f1Param != f2Param && f1Param) {
+//     prefer1 = WEAK; reason = "param vs not";
 
-  } else if (f1Param != f2Param && f2Param) {
-    prefer2 = WEAK; reason = "param vs not";
+//   } else if (f1Param != f2Param && f2Param) {
+//     prefer2 = WEAK; reason = "param vs not";
 
-  } else if (!paramWithDefaultSize && formal2Narrows && !formal1Narrows) {
-    prefer1 = WEAK; reason = "no narrows vs narrows";
+//   } else if (!paramWithDefaultSize && formal2Narrows && !formal1Narrows) {
+//     prefer1 = WEAK; reason = "no narrows vs narrows";
 
-  } else if (!paramWithDefaultSize && formal1Narrows && !formal2Narrows) {
-    prefer2 = WEAK; reason = "no narrows vs narrows";
+//   } else if (!paramWithDefaultSize && formal1Narrows && !formal2Narrows) {
+//     prefer2 = WEAK; reason = "no narrows vs narrows";
 
-  } else if (!actualParam && actualType == f1Type && actualType != f2Type) {
-    prefer1 = STRONG; reason = "actual type vs not";
+//   } else if (!actualParam && actualType == f1Type && actualType != f2Type) {
+//     prefer1 = STRONG; reason = "actual type vs not";
 
-  } else if (!actualParam && actualType == f2Type && actualType != f1Type) {
-    prefer2 = STRONG; reason = "actual type vs not";
+//   } else if (!actualParam && actualType == f2Type && actualType != f1Type) {
+//     prefer2 = STRONG; reason = "actual type vs not";
 
-  } else if (actualScalarT == f1Type && actualScalarT != f2Type) {
-    if (paramWithDefaultSize)
-      prefer1 = WEAKEST;
-    else if (actualParam)
-      prefer1 = WEAKER;
-    else
-      prefer1 = STRONG;
+//   } else if (actualScalarT == f1Type && actualScalarT != f2Type) {
+//     if (paramWithDefaultSize)
+//       prefer1 = WEAKEST;
+//     else if (actualParam)
+//       prefer1 = WEAKER;
+//     else
+//       prefer1 = STRONG;
 
-    reason = "scalar type vs not";
+//     reason = "scalar type vs not";
 
-  } else if (actualScalarT == f2Type && actualScalarT != f1Type) {
-    if (paramWithDefaultSize)
-      prefer2 = WEAKEST;
-    else if (actualParam)
-      prefer2 = WEAKER;
-    else
-      prefer2 = STRONG;
+//   } else if (actualScalarT == f2Type && actualScalarT != f1Type) {
+//     if (paramWithDefaultSize)
+//       prefer2 = WEAKEST;
+//     else if (actualParam)
+//       prefer2 = WEAKER;
+//     else
+//       prefer2 = STRONG;
 
-    reason = "scalar type vs not";
+//     reason = "scalar type vs not";
 
-  } else if (prefersConvToOtherNumeric(dctx, actualScalarT, f1Type, f2Type)) {
-    if (paramWithDefaultSize)
-      prefer1 = WEAKEST;
-    else
-      prefer1 = WEAKER;
+//   } else if (prefersConvToOtherNumeric(dctx, actualScalarT, f1Type, f2Type)) {
+//     if (paramWithDefaultSize)
+//       prefer1 = WEAKEST;
+//     else
+//       prefer1 = WEAKER;
 
-    reason = "preferred coercion to other";
+//     reason = "preferred coercion to other";
 
-  } else if (prefersConvToOtherNumeric(dctx, actualScalarT, f2Type, f1Type)) {
-    if (paramWithDefaultSize)
-      prefer2 = WEAKEST;
-    else
-      prefer2 = WEAKER;
+//   } else if (prefersConvToOtherNumeric(dctx, actualScalarT, f2Type, f1Type)) {
+//     if (paramWithDefaultSize)
+//       prefer2 = WEAKEST;
+//     else
+//       prefer2 = WEAKER;
 
-    reason = "preferred coercion to other";
+//     reason = "preferred coercion to other";
 
-  } else if (f1Type != f2Type && moreSpecificCanDispatch(dctx, f1Type, f2Type)) {
-    prefer1 = actualParam ? WEAKEST : STRONG;
-    reason = "can dispatch";
+//   } else if (f1Type != f2Type && moreSpecificCanDispatch(dctx, f1Type, f2Type)) {
+//     prefer1 = actualParam ? WEAKEST : STRONG;
+//     reason = "can dispatch";
 
-  } else if (f1Type != f2Type && moreSpecificCanDispatch(dctx, f2Type, f1Type)) {
-    prefer2 = actualParam ? WEAKEST : STRONG;
-    reason = "can dispatch";
+//   } else if (f1Type != f2Type && moreSpecificCanDispatch(dctx, f2Type, f1Type)) {
+//     prefer2 = actualParam ? WEAKEST : STRONG;
+//     reason = "can dispatch";
 
-  } else if (f1Type.type()->isIntType() && f2Type.type()->isUintType()) {
-    // This int/uint rule supports choosing between an 'int' and 'uint'
-    // overload when passed say a uint(32).
-    prefer1 = actualParam ? WEAKEST : STRONG;
-    reason = "int vs uint";
+//   } else if (f1Type.type()->isIntType() && f2Type.type()->isUintType()) {
+//     // This int/uint rule supports choosing between an 'int' and 'uint'
+//     // overload when passed say a uint(32).
+//     prefer1 = actualParam ? WEAKEST : STRONG;
+//     reason = "int vs uint";
 
-  } else if (f2Type.type()->isIntType() && f1Type.type()->isUintType()) {
-    prefer2 = actualParam ? WEAKEST : STRONG;
-    reason = "int vs uint";
+//   } else if (f2Type.type()->isIntType() && f1Type.type()->isUintType()) {
+//     prefer2 = actualParam ? WEAKEST : STRONG;
+//     reason = "int vs uint";
 
-  }
+//   }
 
-  if (prefer1 != NONE) {
-    const char* level = "";
-    (void) level;
-    if (prefer1 == STRONG)  { ds.fn1MoreSpecific = true;     level = "strong"; }
-    if (prefer1 == WEAK)    { ds.fn1WeakPreferred = true;    level = "weak"; }
-    if (prefer1 == WEAKER)  { ds.fn1WeakerPreferred = true;  level = "weaker"; }
-    if (prefer1 == WEAKEST) { ds.fn1WeakestPreferred = true; level = "weakest"; }
-    EXPLAIN("%s: Fn %d is %s preferred\n", reason, candidate1.idx, level);
-  } else if (prefer2 != NONE) {
-    const char* level = "";
-    (void) level;
-    if (prefer2 == STRONG)  { ds.fn2MoreSpecific = true;     level = "strong"; }
-    if (prefer2 == WEAK)    { ds.fn2WeakPreferred = true;    level = "weak"; }
-    if (prefer2 == WEAKER)  { ds.fn2WeakerPreferred = true;  level = "weaker"; }
-    if (prefer2 == WEAKEST) { ds.fn2WeakestPreferred = true; level = "weakest"; }
-    EXPLAIN("%s: Fn %d is %s preferred\n", reason, candidate2.idx, level);
-  }
-}
+//   if (prefer1 != NONE) {
+//     const char* level = "";
+//     (void) level;
+//     if (prefer1 == STRONG)  { ds.fn1MoreSpecific = true;     level = "strong"; }
+//     if (prefer1 == WEAK)    { ds.fn1WeakPreferred = true;    level = "weak"; }
+//     if (prefer1 == WEAKER)  { ds.fn1WeakerPreferred = true;  level = "weaker"; }
+//     if (prefer1 == WEAKEST) { ds.fn1WeakestPreferred = true; level = "weakest"; }
+//     EXPLAIN("%s: Fn %d is %s preferred\n", reason, candidate1.idx, level);
+//   } else if (prefer2 != NONE) {
+//     const char* level = "";
+//     (void) level;
+//     if (prefer2 == STRONG)  { ds.fn2MoreSpecific = true;     level = "strong"; }
+//     if (prefer2 == WEAK)    { ds.fn2WeakPreferred = true;    level = "weak"; }
+//     if (prefer2 == WEAKER)  { ds.fn2WeakerPreferred = true;  level = "weaker"; }
+//     if (prefer2 == WEAKEST) { ds.fn2WeakestPreferred = true; level = "weakest"; }
+//     EXPLAIN("%s: Fn %d is %s preferred\n", reason, candidate2.idx, level);
+//   }
+// }
 
 static void testArgMapHelper(const DisambiguationContext& dctx,
                              const FormalActual& fa,
@@ -2421,65 +2650,65 @@ static int prefersNumericCoercion(const DisambiguationContext& dctx,
 // over f2Type.
 // This method implements rules such as that a bool would prefer to
 // coerce to 'int' over 'int(8)'.
-static bool prefersConvToOtherNumeric(const DisambiguationContext& dctx,
-                                      QualifiedType actualQt,
-                                      QualifiedType f1Qt,
-                                      QualifiedType f2Qt) {
+// static bool prefersConvToOtherNumeric(const DisambiguationContext& dctx,
+//                                       QualifiedType actualQt,
+//                                       QualifiedType f1Qt,
+//                                       QualifiedType f2Qt) {
 
-  const Type* actualType = actualQt.type();
-  const Type* f1Type = f1Qt.type();
-  const Type* f2Type = f2Qt.type();
+//   const Type* actualType = actualQt.type();
+//   const Type* f1Type = f1Qt.type();
+//   const Type* f2Type = f2Qt.type();
 
-  if (actualType != f1Type && actualType != f2Type) {
-    // Is there any preference among coercions of the built-in type?
-    // E.g., would we rather convert 'false' to :int or to :uint(8) ?
+//   if (actualType != f1Type && actualType != f2Type) {
+//     // Is there any preference among coercions of the built-in type?
+//     // E.g., would we rather convert 'false' to :int or to :uint(8) ?
 
-    numeric_type_t aT = classifyNumericType(actualType);
-    numeric_type_t f1T = classifyNumericType(f1Type);
-    numeric_type_t f2T = classifyNumericType(f2Type);
+//     numeric_type_t aT = classifyNumericType(actualType);
+//     numeric_type_t f1T = classifyNumericType(f1Type);
+//     numeric_type_t f2T = classifyNumericType(f2Type);
 
-    bool aBoolEnum = (aT == NUMERIC_TYPE_BOOL || aT == NUMERIC_TYPE_ENUM);
+//     bool aBoolEnum = (aT == NUMERIC_TYPE_BOOL || aT == NUMERIC_TYPE_ENUM);
 
-    // Prefer e.g. bool(w1) passed to bool(w2) over passing to int (say)
-    // Prefer uint(8) passed to uint(16) over passing to a real
-    if (aT == f1T && aT != f2T)
-      return true;
-    // Prefer bool/enum cast to int over uint
-    if (aBoolEnum && f1Type->isIntType() && f2Type->isUintType())
-      return true;
-    // Prefer bool/enum cast to default-sized int/uint over another
-    // size of int/uint
-    if (aBoolEnum &&
-        (isDefaultInt(f1Type) || isDefaultUint(f1Type)) &&
-        f2T == NUMERIC_TYPE_INT_UINT &&
-        !(isDefaultInt(f2Type) || isDefaultUint(f2Type)))
-      return true;
-    // Prefer bool/enum/int/uint cast to a default-sized real over another
-    // size of real or complex.
-    if ((aBoolEnum || aT == NUMERIC_TYPE_INT_UINT) &&
-        isDefaultReal(f1Type) &&
-        (f2T == NUMERIC_TYPE_REAL || f2T == NUMERIC_TYPE_COMPLEX) &&
-        !isDefaultReal(f2Type))
-      return true;
-    // Prefer bool/enum/int/uint cast to a default-sized complex over another
-    // size of complex.
-    if ((aBoolEnum || aT == NUMERIC_TYPE_INT_UINT) &&
-        isDefaultComplex(f1Type) &&
-        f2T == NUMERIC_TYPE_COMPLEX &&
-        !isDefaultComplex(f2Type))
-      return true;
-    // Prefer real/imag cast to a same-sized complex over another size of
-    // complex.
-    if ((aT == NUMERIC_TYPE_REAL || aT == NUMERIC_TYPE_IMAG) &&
-        f1T == NUMERIC_TYPE_COMPLEX &&
-        f2T == NUMERIC_TYPE_COMPLEX &&
-        bitwidth(actualType)*2 == bitwidth(f1Type) &&
-        bitwidth(actualType)*2 != bitwidth(f2Type))
-      return true;
-  }
+//     // Prefer e.g. bool(w1) passed to bool(w2) over passing to int (say)
+//     // Prefer uint(8) passed to uint(16) over passing to a real
+//     if (aT == f1T && aT != f2T)
+//       return true;
+//     // Prefer bool/enum cast to int over uint
+//     if (aBoolEnum && f1Type->isIntType() && f2Type->isUintType())
+//       return true;
+//     // Prefer bool/enum cast to default-sized int/uint over another
+//     // size of int/uint
+//     if (aBoolEnum &&
+//         (isDefaultInt(f1Type) || isDefaultUint(f1Type)) &&
+//         f2T == NUMERIC_TYPE_INT_UINT &&
+//         !(isDefaultInt(f2Type) || isDefaultUint(f2Type)))
+//       return true;
+//     // Prefer bool/enum/int/uint cast to a default-sized real over another
+//     // size of real or complex.
+//     if ((aBoolEnum || aT == NUMERIC_TYPE_INT_UINT) &&
+//         isDefaultReal(f1Type) &&
+//         (f2T == NUMERIC_TYPE_REAL || f2T == NUMERIC_TYPE_COMPLEX) &&
+//         !isDefaultReal(f2Type))
+//       return true;
+//     // Prefer bool/enum/int/uint cast to a default-sized complex over another
+//     // size of complex.
+//     if ((aBoolEnum || aT == NUMERIC_TYPE_INT_UINT) &&
+//         isDefaultComplex(f1Type) &&
+//         f2T == NUMERIC_TYPE_COMPLEX &&
+//         !isDefaultComplex(f2Type))
+//       return true;
+//     // Prefer real/imag cast to a same-sized complex over another size of
+//     // complex.
+//     if ((aT == NUMERIC_TYPE_REAL || aT == NUMERIC_TYPE_IMAG) &&
+//         f1T == NUMERIC_TYPE_COMPLEX &&
+//         f2T == NUMERIC_TYPE_COMPLEX &&
+//         bitwidth(actualType)*2 == bitwidth(f1Type) &&
+//         bitwidth(actualType)*2 != bitwidth(f2Type))
+//       return true;
+//   }
 
-  return false;
-}
+//   return false;
+// }
 
 
 static QualifiedType computeActualScalarType(Context* context,
@@ -2489,15 +2718,15 @@ static QualifiedType computeActualScalarType(Context* context,
   return actualType;
 }
 
-static bool isNumericParamDefaultType(QualifiedType type) {
-  if (auto typePtr = type.type()) {
-    if (auto primType = typePtr->toPrimitiveType()) {
-      return primType->isDefaultWidth();
-    }
-  }
+// static bool isNumericParamDefaultType(QualifiedType type) {
+//   if (auto typePtr = type.type()) {
+//     if (auto primType = typePtr->toPrimitiveType()) {
+//       return primType->isDefaultWidth();
+//     }
+//   }
 
-  return false;
-}
+//   return false;
+// }
 
 static bool moreSpecificCanDispatch(const DisambiguationContext& dctx,
                          QualifiedType actualType, QualifiedType formalType) {

--- a/frontend/test/resolution/testDisambiguation.cpp
+++ b/frontend/test/resolution/testDisambiguation.cpp
@@ -265,6 +265,32 @@ static void test3() {
         f(x);
       )"""",
     1);
+
+  // updated disambiguation based on width of argument
+  // checkCalledIndex(context,
+  //     R""""(
+  //       proc f(arg: int(8)) { }                   // 1
+  //       proc f(arg: uint(64)) { }                 // 2
+  //       var x: int(64);
+  //       f(x);
+  //     )"""",
+  //   2); // The answer should be 2 once disambiguation changes are made to
+  //          // match prod, but today it doesn't run because the helper
+  //          // checkCalledIndex requires just one fnCall to disambiguate
+  //          // and this test has four
+
+  // updated disambiguation based on visibility of proc
+  checkCalledIndex(context,
+      R""""(
+        proc f(arg: int) { }                     // 1
+        {
+          proc f(arg) { }                        // 2
+
+          var x = 1;
+          f(x);
+        }
+      )"""",
+    2);
 }
 
 int main() {


### PR DESCRIPTION
This PR integrates changes from previous work to refactor the dyno resolver's disambiguation rules to more closely match production's following https://github.com/chapel-lang/chapel/pull/20528.

There remains a TODO to implement the warning when allowing `int`->`uint` conversion, captured in https://github.com/Cray/chapel-private/issues/5709

TESTING:

- [x] paratest `[Summary: #Successes = 17103 | #Failures = 1 | #Futures = 915]` (matches failure on main)
- [x] resolving example from og issue chooses correct function

```
proc f(arg: int(8)) { }                   // 1
proc f(arg: uint(64)) { }                 // 2
var x: int(64);
f(x);
```
using the new disambiguation rules, the resolver will pick the `uint` version of `f` (labeled 2) because of matching bit widths.

[reviewed by @mppf - thank you!]
