### PR TITLE
Rename driver mode phase names to `compilation` and `makeBinary`

### DIFF
--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -271,7 +271,7 @@ void preparePrintLlvmIrForCodegen() {
   // If running in compiler-driver mode, save cnames to print IR for to disk.
   // This is so that handlePrintAsm can access them later from phase two, when
   // we don't have a way to determine name->cname correspondence.
-  if (fDriverPhaseOne) {
+  if (fDriverCompilationPhase) {
     saveDriverTmpMultiple(cnamesToPrintFilename,
                           std::vector<const char*>(llvmPrintIrCNames.begin(),
                                                    llvmPrintIrCNames.end()));

--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -269,8 +269,8 @@ void preparePrintLlvmIrForCodegen() {
   } while (changed);
 
   // If running in compiler-driver mode, save cnames to print IR for to disk.
-  // This is so that handlePrintAsm can access them later from phase two, when
-  // we don't have a way to determine name->cname correspondence.
+  // This is so that handlePrintAsm can access them later from the makeBinary
+  // phase, when we don't have a way to determine name->cname correspondence.
   if (fDriverCompilationPhase) {
     saveDriverTmpMultiple(cnamesToPrintFilename,
                           std::vector<const char*>(llvmPrintIrCNames.begin(),

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2336,7 +2336,7 @@ static const char* getMainModuleFilename() {
   static const char* mainModTmpFilename = "mainmodpath.tmp";
 
   const char* filename;
-  if (fDriverPhaseTwo) {
+  if (fDriverMakeBinaryPhase) {
     // Retrieve saved main module filename
     restoreDriverTmp(mainModTmpFilename, [&filename](const char* mainModName) {
       filename = astr(mainModName);
@@ -2351,7 +2351,7 @@ static const char* getMainModuleFilename() {
 
     // Save result in tmp file for future usage if in driver mode
     if (!fDriverDoMonolithic) {
-      assert(fDriverPhaseOne &&
+      assert(fDriverCompilationPhase &&
              "should not be reachable outside of driver "
              "phase one");
       saveDriverTmp(mainModTmpFilename, filename);
@@ -2371,7 +2371,7 @@ void setupDefaultFilenames() {
     // phase two, but that's not a problem because the errors would have already
     // been hit (and are fatal) in phase one.
     ModuleSymbol* mainMod =
-        (fDriverPhaseTwo ? nullptr : ModuleSymbol::mainModule());
+        (fDriverMakeBinaryPhase ? nullptr : ModuleSymbol::mainModule());
     const char* filename = getMainModuleFilename();
 
     // "Executable" name should be given a "lib" prefix in library compilation,
@@ -2389,7 +2389,7 @@ void setupDefaultFilenames() {
         // remove the filename extension from the library header name.
         char* lastDot = strrchr(libmodeHeadername, '.');
         if (lastDot == NULL) {
-          INT_ASSERT(!fDriverPhaseTwo &&
+          INT_ASSERT(!fDriverMakeBinaryPhase &&
                      "encountered error in phase two that should only be "
                      "reachable in phase one");
           INT_FATAL(mainMod,
@@ -2409,7 +2409,7 @@ void setupDefaultFilenames() {
         pythonModulename[sizeof(pythonModulename)-1] = '\0';
         char* lastDot = strrchr(pythonModulename, '.');
         if (lastDot == NULL) {
-          INT_ASSERT(!fDriverPhaseTwo &&
+          INT_ASSERT(!fDriverMakeBinaryPhase &&
                      "encountered error in phase two that should only be "
                      "reachable in phase one");
           INT_FATAL(mainMod,
@@ -2432,7 +2432,7 @@ void setupDefaultFilenames() {
     // remove the filename extension from the executable filename
     char* lastDot = strrchr(executableFilename, '.');
     if (lastDot == NULL) {
-      INT_ASSERT(!fDriverPhaseTwo &&
+      INT_ASSERT(!fDriverMakeBinaryPhase &&
                  "encountered error in phase two that should only be "
                  "reachable in phase one");
       INT_FATAL(mainMod, "main module filename is missing its extension: %s\n",
@@ -3049,7 +3049,7 @@ void makeBinary(void) {
 
   // makeBinary shouldn't run in a phase-one invocation.
   // (Unless we're doing GPU codegen, which currently happens in phase one.)
-  INT_ASSERT(!fDriverPhaseOne || gCodegenGPU);
+  INT_ASSERT(!fDriverCompilationPhase || gCodegenGPU);
 
   if(fLlvmCodegen) {
 #ifdef HAVE_LLVM

--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -164,8 +164,8 @@ extern bool fExplainVerbose;
 extern bool fParseOnly;
 // begin compiler driver control flags
 extern bool fDriverDoMonolithic;
-extern bool fDriverPhaseOne;
-extern bool fDriverPhaseTwo;
+extern bool fDriverCompilationPhase;
+extern bool fDriverMakeBinaryPhase;
 extern char driverTmpDir[FILENAME_MAX];
 // end compiler driver control flags
 extern bool fPrintAllCandidates;

--- a/compiler/include/files.h
+++ b/compiler/include/files.h
@@ -90,8 +90,8 @@ void addSourceFile(const char* filename, const char* modFilename);
 void assertSourceFilesFound();
 const char* nthFilename(int i);
 // Functions to add C library or include dir information.
-// If running in driver phase one and the information is not from parsing the
-// command line, these will also save to a tmp dir for later use.
+// If running in driver compilation phase and the information is not from
+// parsing the command line, these will also save to a tmp dir for later use.
 void addLibPath(const char* filename, bool fromCmdLine = false);
 void addLibFile(const char* filename, bool fromCmdLine = false);
 void addIncInfo(const char* incDir, bool fromCmdLine = false);

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -3038,10 +3038,10 @@ void runClang(const char* just_parse_filename) {
   setupClang(gGenInfo, rtmain);
 
 
-  // If running in driver phase two, we only need the Clang setup work, so stop
-  // before code generation.
+  // If running in makeBinary phase, we only need the Clang setup work,
+  // so stop before code generation.
   if (fDriverMakeBinaryPhase) {
-    // Needed for phase two but is only otherwise run by the skipped
+    // Needed for makeBinary but is only otherwise run by the skipped
     // ExecuteAction below.
 #if HAVE_LLVM_VER >= 130
     clangInfo->Clang->createTarget();

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2008,7 +2008,7 @@ static llvm::TargetOptions getTargetOptions(
 // deserialize the module from previously-outputted LLVM bitcode file
 static void loadModuleFromBitcode() {
   // should only be used for the backend to retrieve codegen results
-  INT_ASSERT(fDriverPhaseTwo);
+  INT_ASSERT(fDriverMakeBinaryPhase);
 
   GenInfo* info = gGenInfo;
   INT_ASSERT(info);
@@ -3040,7 +3040,7 @@ void runClang(const char* just_parse_filename) {
 
   // If running in driver phase two, we only need the Clang setup work, so stop
   // before code generation.
-  if (fDriverPhaseTwo) {
+  if (fDriverMakeBinaryPhase) {
     // Needed for phase two but is only otherwise run by the skipped
     // ExecuteAction below.
 #if HAVE_LLVM_VER >= 130
@@ -4832,7 +4832,7 @@ static void checkLoopsAssertVectorize(void) {
 #endif
 
 void makeBinaryLLVM(void) {
-  if (fDriverPhaseTwo) {
+  if (fDriverMakeBinaryPhase) {
     // Set up necessary resources for a driver makeBinary phase invocation.
 
     initializeGenInfo();
@@ -5328,7 +5328,7 @@ static void handlePrintAsm(std::string dotOFile) {
     }
 
     // If in driver mode, restore list of C symbols to print from disk.
-    if (fDriverPhaseTwo) restorePrintIrCNames();
+    if (fDriverMakeBinaryPhase) restorePrintIrCNames();
     const auto& names = gatherPrintLlvmIrCNames();
     printf("%lu symbol names to disassemble\n", names.size());
     for (const auto& name : names) {

--- a/compiler/main/PhaseTracker.cpp
+++ b/compiler/main/PhaseTracker.cpp
@@ -141,7 +141,7 @@ void PhaseTracker::ReportPassGroupTotals(
 
       // No such pass, we might've exited early, or begun late from driver mode.
       if (currentPass == mPhases.end()) {
-        if (fDriverPhaseTwo) {
+        if (fDriverMakeBinaryPhase) {
           // We began after the current pass group, check the next.
           continue;
         } else {
@@ -207,7 +207,7 @@ void PhaseTracker::ReportRollup() const
   // phase one.
   // Skipped for driver overhead time or driver phase two as they contain very
   // little information and the sort isn't that informative.
-  if (fDriverDoMonolithic || fDriverPhaseOne) {
+  if (fDriverDoMonolithic || fDriverCompilationPhase) {
     Phase::ReportText("\n\n\n");
 
     PassesSortByTime(passes);

--- a/compiler/main/PhaseTracker.cpp
+++ b/compiler/main/PhaseTracker.cpp
@@ -204,9 +204,9 @@ void PhaseTracker::ReportRollup() const
   PassesReport(passes, totalTime);
 
   // Repeat the information but sorted by time, for monolithic mode or driver
-  // phase one.
-  // Skipped for driver overhead time or driver phase two as they contain very
-  // little information and the sort isn't that informative.
+  // compilation phase.
+  // Skipped for driver overhead time or makeBinary phase as they contain
+  // very little information and the sort isn't that informative.
   if (fDriverDoMonolithic || fDriverCompilationPhase) {
     Phase::ReportText("\n\n\n");
 

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -806,8 +806,8 @@ static bool shouldSkipMakeBinary(bool warnIfSkipping = true) {
       (fRungdb || fRunlldb) && (driverDebugCompilation && !driverDebugMakeBinary);
   if (debugCompilationPhaseOnly && warnIfSkipping) {
     USR_WARN(
-        "Skipping makeBinary phase due to running only compilation phase "
-        "in debugger; change this with --driver-debug-phase if desired");
+        "Skipping makeBinary driver phase due to running only compilation "
+        "phase in debugger; change this with --driver-debug-phase if desired");
   }
 
   // Check if skipping for the above reason or any other early stop.

--- a/compiler/main/runpasses.cpp
+++ b/compiler/main/runpasses.cpp
@@ -187,9 +187,11 @@ void runPasses(PhaseTracker& tracker) {
 
   if (printPasses == true || printPassesFile != 0) {
     if (fDriverCompilationPhase) {
-      Phase::ReportText("Timing for driver phase one\n--------------\n");
+      Phase::ReportText(
+          "Timing for driver compilation phase\n--------------\n");
     } else if (fDriverMakeBinaryPhase) {
-      Phase::ReportText("\n\nTiming for driver phase two\n--------------\n");
+      Phase::ReportText(
+          "\n\nTiming for driver makeBinary phase\n--------------\n");
     }
     tracker.ReportPass();
   }
@@ -197,7 +199,7 @@ void runPasses(PhaseTracker& tracker) {
   setupStopAfterPass();
 
   for (size_t i = 0; i < passListSize; i++) {
-    // skip until makeBinary if in phase-two invocation
+    // skip until makeBinary if in makeBinary phase invocation
     if (fDriverMakeBinaryPhase && strcmp(sPassList[i].name, "makeBinary") != 0) {
       continue;
     }
@@ -208,7 +210,7 @@ void runPasses(PhaseTracker& tracker) {
 
     currentPassNo++;
 
-    // quit before makeBinary in phase-one invocation
+    // quit before makeBinary in compilation phase invocation
     if (fDriverCompilationPhase && strcmp(sPassList[i].name, "codegen") == 0) {
       break;
     }

--- a/compiler/main/runpasses.cpp
+++ b/compiler/main/runpasses.cpp
@@ -186,9 +186,9 @@ void runPasses(PhaseTracker& tracker) {
   setupLogfiles();
 
   if (printPasses == true || printPassesFile != 0) {
-    if (fDriverPhaseOne) {
+    if (fDriverCompilationPhase) {
       Phase::ReportText("Timing for driver phase one\n--------------\n");
-    } else if (fDriverPhaseTwo) {
+    } else if (fDriverMakeBinaryPhase) {
       Phase::ReportText("\n\nTiming for driver phase two\n--------------\n");
     }
     tracker.ReportPass();
@@ -198,7 +198,7 @@ void runPasses(PhaseTracker& tracker) {
 
   for (size_t i = 0; i < passListSize; i++) {
     // skip until makeBinary if in phase-two invocation
-    if (fDriverPhaseTwo && strcmp(sPassList[i].name, "makeBinary") != 0) {
+    if (fDriverMakeBinaryPhase && strcmp(sPassList[i].name, "makeBinary") != 0) {
       continue;
     }
 
@@ -209,7 +209,7 @@ void runPasses(PhaseTracker& tracker) {
     currentPassNo++;
 
     // quit before makeBinary in phase-one invocation
-    if (fDriverPhaseOne && strcmp(sPassList[i].name, "codegen") == 0) {
+    if (fDriverCompilationPhase && strcmp(sPassList[i].name, "codegen") == 0) {
       break;
     }
 
@@ -265,7 +265,7 @@ static void runPass(PhaseTracker& tracker, size_t passIndex) {
   // Skip if we're on the backend invocation of the compiler, in which case
   // there is no AST.
   //
-  if (!fDriverPhaseTwo) {
+  if (!fDriverMakeBinaryPhase) {
     tracker.StartPhase(info->name, PhaseTracker::kCleanAst);
     cleanAst();
   }

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -103,7 +103,7 @@ static void addPath(const char* pathVar, std::vector<const char*>* pathvec) {
 void addLibPath(const char* libString, bool fromCmdLine) {
   addPath(libString, &libDirs);
 
-  if (fDriverPhaseOne && !fromCmdLine) {
+  if (fDriverCompilationPhase && !fromCmdLine) {
     saveDriverTmp(libDirsFilename, libString);
   }
 }
@@ -112,7 +112,7 @@ void addLibFile(const char* libFile, bool fromCmdLine) {
   // use astr() to get a copy of the string that this vector can own
   libFiles.push_back(astr(libFile));
 
-  if (fDriverPhaseOne && !fromCmdLine) {
+  if (fDriverCompilationPhase && !fromCmdLine) {
     saveDriverTmp(libFilesFilename, libFile);
   }
 }
@@ -120,7 +120,7 @@ void addLibFile(const char* libFile, bool fromCmdLine) {
 void addIncInfo(const char* incDir, bool fromCmdLine) {
   addPath(incDir, &incDirs);
 
-  if (fDriverPhaseOne && !fromCmdLine) {
+  if (fDriverCompilationPhase && !fromCmdLine) {
     saveDriverTmp(incDirsFilename, incDir);
   }
 }
@@ -168,7 +168,7 @@ void saveDriverTmpMultiple(const char* tmpFilePath,
 
   // Overwrite on first use in phase one or driver init, append after.
   const char* fileOpenMode;
-  if (seen.emplace(pathAsAstr).second && !fDriverPhaseTwo) {
+  if (seen.emplace(pathAsAstr).second && !fDriverMakeBinaryPhase) {
     fileOpenMode = "w";
   } else {
     // Already seen
@@ -225,7 +225,7 @@ void restoreDriverTmpMultiline(
 
 void restoreLibraryAndIncludeInfo() {
   INT_ASSERT(
-      fDriverPhaseTwo &&
+      fDriverMakeBinaryPhase &&
       "should only be restoring library and include info in driver phase two");
 
   restoreDriverTmp(libDirsFilename, [](const char* filename) {
@@ -240,7 +240,7 @@ void restoreLibraryAndIncludeInfo() {
 }
 
 void restoreAdditionalSourceFiles() {
-  INT_ASSERT(fDriverPhaseTwo &&
+  INT_ASSERT(fDriverMakeBinaryPhase &&
              "should only be restoring filenames in driver phase two");
 
   std::vector<const char*> additionalFilenames;
@@ -504,7 +504,7 @@ void addSourceFiles(int numNewFilenames, const char* filename[]) {
   // driver phase two.
   // Note: Need to check both driver mode and phase here. The two could conflict
   // since files can be added before driver flags are validated.
-  if (!fDriverDoMonolithic && fDriverPhaseOne && firstAddedIdx >= 0) {
+  if (!fDriverDoMonolithic && fDriverCompilationPhase && firstAddedIdx >= 0) {
     saveDriverTmpMultiple(
         additionalFilenamesListFilename,
         std::vector<const char*>(inputFilenames + firstAddedIdx,

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -166,7 +166,8 @@ void saveDriverTmpMultiple(const char* tmpFilePath,
   // Contents expected to be astrs so it's safe to use a set.
   static std::unordered_set<const char*> seen;
 
-  // Overwrite on first use in phase one or driver init, append after.
+  // Overwrite on first use in driver compilation phase or init process, append
+  // after.
   const char* fileOpenMode;
   if (seen.emplace(pathAsAstr).second && !fDriverMakeBinaryPhase) {
     fileOpenMode = "w";
@@ -224,9 +225,9 @@ void restoreDriverTmpMultiline(
 }
 
 void restoreLibraryAndIncludeInfo() {
-  INT_ASSERT(
-      fDriverMakeBinaryPhase &&
-      "should only be restoring library and include info in driver phase two");
+  INT_ASSERT(fDriverMakeBinaryPhase &&
+             "should only be restoring library and include info in driver "
+             "makeBinary phase");
 
   restoreDriverTmp(libDirsFilename, [](const char* filename) {
     addLibPath(filename, /* fromCmdLine */ false);
@@ -241,7 +242,7 @@ void restoreLibraryAndIncludeInfo() {
 
 void restoreAdditionalSourceFiles() {
   INT_ASSERT(fDriverMakeBinaryPhase &&
-             "should only be restoring filenames in driver phase two");
+             "should only be restoring filenames in driver makeBinary phase");
 
   std::vector<const char*> additionalFilenames;
   restoreDriverTmp(additionalFilenamesListFilename,
@@ -501,7 +502,7 @@ void addSourceFiles(int numNewFilenames, const char* filename[]) {
   inputFilenames[cursor] = NULL;
 
   // If in driver mode, and filenames were added, also save added filenames for
-  // driver phase two.
+  // makeBinary phase.
   // Note: Need to check both driver mode and phase here. The two could conflict
   // since files can be added before driver flags are validated.
   if (!fDriverDoMonolithic && fDriverCompilationPhase && firstAddedIdx >= 0) {

--- a/doc/rst/technotes/driver.rst
+++ b/doc/rst/technotes/driver.rst
@@ -22,9 +22,9 @@ invoking separate processes for the different stages of compilation required.
 With release 1.32, the Chapel compiler provides an opt-in compiler driver mode
 that can be used via the ``--compiler-driver`` flag. This mode will become the
 default at some point in the future. The driver currently splits work into two
-phases: phase one, which is responsible for everything through code generation
-(C code or LLVM bitcode), and phase two, which is responsible for binary
-generation (including linking).
+phases: `compilation`, which is responsible for everything through code
+generation (C code or LLVM bitcode), and `makeBinary`, which is responsible for
+binary generation (including linking).
 
 ---------------------
 Motivation for Driver
@@ -56,12 +56,13 @@ to be useful to compiler developers. Both are documented here.
   to set any other driver flags. Without this flag, the compiler will run
   monolithically as usual.
 - ``--driver-debug-phase``: Set which phase of compilation to run in the
-  debugger: '1', '2', or 'all'. If debugging just phase one, phase two will be
-  skipped entirely as it is unlikely to be useful.
-- ``--driver-phase-one``: Internal flag. Causes the execution of phase one.
-  The driver re-invokes itself with this flag to run phase one.
-- ``--driver-phase-two``: Internal flag. Causes the execution of phase two.
-  The driver re-invokes itself with this flag to run phase two.
+  debugger: 'compilation', 'makeBinary', or 'all'. If debugging just
+  compilation, makeBinary will be skipped entirely as it is unlikely to be
+  useful.
+- ``--driver-compilation-phase``: Internal flag. The driver re-invokes itself
+  with this flag to to trigger execution of the compilation phase.
+- ``--driver-makebinary-phase``: Internal flag. The driver re-invokes itself
+  with this flag to to trigger execution of the makeBinary phase.
 - ``--driver-tmp-dir``: Internal flag, specifying where the current phase will
   look for temporary files that must be carried between phases. The driver sets
   this flag during re-invocations for the different phases, and will provide the
@@ -72,7 +73,7 @@ Future Work
 -----------
 
 - Fix driver behavior for GPU compilation, which currently performs all work
-  in phase one and skips phase two.
+  in compilation and skips makeBinary.
 - Reduce work re-done between driver and phase invocations.
 - Enable our usual performance and correctness testing for driver mode, and
   reach parity with monolithic mode.

--- a/test/compflags/driver/debugger/declint-lldb.good
+++ b/test/compflags/driver/debugger/declint-lldb.good
@@ -1,2 +1,2 @@
 (lldb) quit
-warning: Skipping makeBinary phase due to running only compilation phase in debugger; change this with --driver-debug-phase if desired
+warning: Skipping makeBinary driver phase due to running only compilation phase in debugger; change this with --driver-debug-phase if desired

--- a/test/compflags/driver/debugger/declint-lldb.good
+++ b/test/compflags/driver/debugger/declint-lldb.good
@@ -1,2 +1,2 @@
 (lldb) quit
-warning: Skipping phase two due to running only phase one in debugger; change this with --driver-debug-phase if desired
+warning: Skipping makeBinary phase due to running only compilation phase in debugger; change this with --driver-debug-phase if desired

--- a/test/compflags/driver/debugger/declint.good
+++ b/test/compflags/driver/debugger/declint.good
@@ -1,2 +1,2 @@
 (gdb) 
-warning: Skipping makeBinary phase due to running only compilation phase in debugger; change this with --driver-debug-phase if desired
+warning: Skipping makeBinary driver phase due to running only compilation phase in debugger; change this with --driver-debug-phase if desired

--- a/test/compflags/driver/debugger/declint.good
+++ b/test/compflags/driver/debugger/declint.good
@@ -1,2 +1,2 @@
 (gdb) 
-warning: Skipping phase two due to running only phase one in debugger; change this with --driver-debug-phase if desired
+warning: Skipping makeBinary phase due to running only compilation phase in debugger; change this with --driver-debug-phase if desired

--- a/test/compflags/driver/driver-multiple-phases.compopts
+++ b/test/compflags/driver/driver-multiple-phases.compopts
@@ -1,1 +1,1 @@
---compiler-driver --driver-tmp-dir=./tmp --driver-phase-one --driver-phase-two
+--compiler-driver --driver-tmp-dir=./tmp --driver-compilation-phase --driver-makebinary-phase

--- a/test/compflags/driver/driver-subinvocation-commands.good
+++ b/test/compflags/driver/driver-subinvocation-commands.good
@@ -1,2 +1,2 @@
-# invoking driver phase one
-# invoking driver phase two
+# invoking driver compilation phase
+# invoking driver makeBinary phase

--- a/test/compflags/driver/monolithic/monolithic-debug-phase.compopts
+++ b/test/compflags/driver/monolithic/monolithic-debug-phase.compopts
@@ -1,1 +1,1 @@
---driver-debug-phase=1
+--driver-debug-phase=compilation

--- a/test/compflags/driver/monolithic/monolithic-subinvocation-no-tmp.compopts
+++ b/test/compflags/driver/monolithic/monolithic-subinvocation-no-tmp.compopts
@@ -1,2 +1,2 @@
---driver-phase-one
---driver-phase-two
+--driver-compilation-phase
+--driver-makebinary-phase

--- a/test/compflags/driver/monolithic/monolithic-subinvocation.compopts
+++ b/test/compflags/driver/monolithic/monolithic-subinvocation.compopts
@@ -1,2 +1,2 @@
---driver-phase-one --driver-tmp-dir=./tmp
---driver-phase-two --driver-tmp-dir=./tmp
+--driver-compilation-phase --driver-tmp-dir=./tmp
+--driver-makebinary-phase --driver-tmp-dir=./tmp

--- a/util/chpl-completion.bash
+++ b/util/chpl-completion.bash
@@ -57,9 +57,9 @@ _chpl ()
 --detailed-errors \
 --devel \
 --div-by-zero-checks \
+--driver-compilation-phase \
 --driver-debug-phase \
---driver-phase-one \
---driver-phase-two \
+--driver-makebinary-phase \
 --driver-tmp-dir \
 --dynamic \
 --dynamic-auto-local-access \


### PR DESCRIPTION
Change names of driver phases to `compilation` and `makeBinary` (previously just "phase one" and "phase two", respectively).

Includes flags, references in source code and comments, and docs.

Resolves https://github.com/Cray/chapel-private/issues/5643.

[reviewer info placeholder]

Testing:
- [x] paratest (with and without `--compiler-driver`)
- [x] manually checked all docs references updated