### PR TITLE
Return type resolution ignores dead branches in select statements

### DIFF
--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -955,7 +955,7 @@ struct Converter {
     }
 
     CallExpr* when = new CallExpr(PRIM_WHEN, args);
-    auto block = createBlockWithStmts(node->stmts(), node->blockStyle());
+    auto block = createBlockWithStmts(node->body()->stmts(), node->blockStyle());
 
     return new CondStmt(when, block);
   }

--- a/frontend/include/chpl/uast/When.h
+++ b/frontend/include/chpl/uast/When.h
@@ -24,6 +24,7 @@
 #include "chpl/uast/BlockStyle.h"
 #include "chpl/uast/AstNode.h"
 #include "chpl/uast/SimpleBlockLike.h"
+#include "chpl/uast/Block.h"
 
 namespace chpl {
 namespace uast {
@@ -33,42 +34,40 @@ namespace uast {
   This class represents a when statement. When statements make up the body
   of the select statement.
  */
-class When final : public SimpleBlockLike {
+class When final : public AstNode {
  friend class AstNode;
 
  private:
   // The position of this never changes.
   static const int8_t caseExprChildNum_ = 0;
-
-  int numCaseExprs_;
-
-  When(AstList children, int numCaseExprs, BlockStyle blockStyle,
-       int bodyChildNum,
-       int numBodyStmts)
-    : SimpleBlockLike(asttags::When, std::move(children), blockStyle,
-                      bodyChildNum,
-                      numBodyStmts),
-      numCaseExprs_(numCaseExprs) {
+  const int numCaseExprs_;
+  const BlockStyle blockStyle_;
+  
+  When(AstList children, int numCaseExprs, BlockStyle blockStyle)
+    : AstNode(asttags::When, std::move(children)),
+      numCaseExprs_(numCaseExprs),
+      blockStyle_(blockStyle) {
   }
 
   void serializeInner(Serializer& ser) const override {
-    simpleBlockLikeSerializeInner(ser);
+    serializeChildren(ser);
     ser.writeVInt(numCaseExprs_);
+    ser.write(blockStyle_);
   }
 
   explicit When(Deserializer& des)
-    : SimpleBlockLike(asttags::When, des) {
-    numCaseExprs_ = des.readVInt();
-  }
+    : AstNode(asttags::When, des),
+      numCaseExprs_(des.readVInt()),
+      blockStyle_(des.read<BlockStyle>()) {}
 
   bool contentsMatchInner(const AstNode* other) const override {
     const When* rhs = other->toWhen();
-    return this->numCaseExprs_ == rhs->numCaseExprs_ &&
-      this->simpleBlockLikeContentsMatchInner(rhs);
+    return this->numCaseExprs_ == rhs->numCaseExprs_ && 
+           this->blockStyle_ == rhs->blockStyle_;
   }
 
   void markUniqueStringsInner(Context* context) const override {
-    simpleBlockLikeMarkUniqueStringsInner(context);
+    
   }
   
   void dumpFieldsInner(const DumpSettings& s) const override;
@@ -85,12 +84,19 @@ class When final : public SimpleBlockLike {
                            AstList stmts);
 
   /**
-    Returns the number of case expressions for this when statement.
+    Returns the number of case expressions in this when statement.
   */
   int numCaseExprs() const {
     return numCaseExprs_;
   }
 
+  /**
+   Returns the block style of this when statement.
+  */
+  BlockStyle blockStyle() const {
+    return blockStyle_;
+  }
+  
   /**
     Returns the i'th case of this when statement.
   */
@@ -98,6 +104,14 @@ class When final : public SimpleBlockLike {
     if (numCaseExprs_ <= 0) return nullptr;
     CHPL_ASSERT(i >= 0 && i < numCaseExprs_);
     auto ret = child(i);
+    return ret;
+  }
+
+  /**
+    Returns the body node
+  */
+  const Block* body() const {
+    auto ret = child(numCaseExprs_)->toBlock();
     return ret;
   }
 

--- a/frontend/include/chpl/uast/When.h
+++ b/frontend/include/chpl/uast/When.h
@@ -50,7 +50,6 @@ class When final : public AstNode {
   }
 
   void serializeInner(Serializer& ser) const override {
-    serializeChildren(ser);
     ser.writeVInt(numCaseExprs_);
     ser.write(blockStyle_);
   }

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2372,9 +2372,9 @@ bool Resolver::enter(const uast::Select* sel) {
     if (!scopeResolveOnly && allParamFalse) {
       // case will never be true, so do not resolve the statement
       continue;
-    } else if (when->numStmts() > 0) {
+    } else if (when->body()->numChildren() > 0) {
       // Otherwise, resolve the body.
-      when->stmt(0)->traverse(*this);
+      when->body()->traverse(*this);
     }
 
     // Current behavior is to ignore when-stmts following a param-true
@@ -2392,8 +2392,8 @@ bool Resolver::enter(const uast::Select* sel) {
   // 'otherwise' statement, should one exist.
   if (foundParamTrue == false && otherwise != -1) {
     auto other = sel->whenStmt(otherwise);
-    if (other->numStmts() > 0) {
-      other->stmt(0)->traverse(*this);
+    if (other->body()->numChildren() > 0) {
+      other->body()->traverse(*this);
     }
   }
 

--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -566,6 +566,12 @@ bool ReturnTypeInferrer::enter(const Select* sel, RV& rv) {
     } else {
       sel->whenStmt(otherwise)->traverse(rv);
     }
+  } else {
+    //deal with the placeholder frame
+    if (foundParamTrue) {
+      auto& topFrame = returnFrames.back();
+      topFrame->subFrames.back().skip = true;
+    }
   }
 
   return false;

--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -553,7 +553,7 @@ bool ReturnTypeInferrer::enter(const Select* sel, RV& rv) {
   if (paramTrueIdx == -1) return false;
 
   auto& topFrame = returnFrames.back();
-  for (int i = paramTrueIdx+1; i < topFrame->subFrames.size(); i++) {
+  for (size_t i = paramTrueIdx+1; i < topFrame->subFrames.size(); i++) {
     topFrame->subFrames[i].skip = true;
   }
 

--- a/frontend/lib/uast/When.cpp
+++ b/frontend/lib/uast/When.cpp
@@ -29,7 +29,7 @@ void When::dumpFieldsInner(const DumpSettings& s) const {
   if (isOtherwise()) {
     s.out << " otherwise";
   }
-  return SimpleBlockLike::dumpFieldsInner(s);
+  return AstNode::dumpFieldsInner(s);
 }
 
 owned<When> When::build(Builder* builder, Location loc,
@@ -38,22 +38,15 @@ owned<When> When::build(Builder* builder, Location loc,
                         AstList stmts) {
   AstList lst;
   const int numCaseExprs = caseExprs.size();
-  const int numBodyStmts = stmts.size();
-  int bodyChildNum = NO_CHILD;
 
   for (auto& ast : caseExprs) {
     lst.push_back(std::move(ast));
   }
 
-  bodyChildNum = lst.size();
+  auto bodyBlock = Block::build(builder,loc,std::move(stmts));
+  lst.push_back(std::move(bodyBlock));
 
-  for (auto& ast : stmts) {
-    lst.push_back(std::move(ast));
-  }
-
-  When* ret = new When(std::move(lst), numCaseExprs, blockStyle,
-                       bodyChildNum,
-                       numBodyStmts);
+  When* ret = new When(std::move(lst), numCaseExprs, blockStyle);
   builder->noteLocation(ret, loc);
   return toOwned(ret);
 }

--- a/frontend/lib/uast/chpl-syntax-printer.cpp
+++ b/frontend/lib/uast/chpl-syntax-printer.cpp
@@ -1335,7 +1335,7 @@ struct ChplSyntaxVisitor {
       interpose(node->caseExprs(), ", ");
       ss_ << " ";
     }
-    printBlockWithStyle(node->blockStyle(), node->stmts(), "do ", ";", true);
+    printBlockWithStyle(node->blockStyle(), node->body()->stmts(), "do ", ";", true);
   }
 
   void visit(const While* node) {

--- a/frontend/test/parsing/testParseSelect.cpp
+++ b/frontend/test/parsing/testParseSelect.cpp
@@ -98,8 +98,8 @@ static void test0(Parser* parser) {
       assert(!when->isOtherwise());
     }
 
-    assert(when->numStmts() == 1);
-    assert(when->stmt(0)->isFnCall());
+    assert(when->body()->numStmts() == 1);
+    assert(when->body()->stmt(0)->isFnCall());
   }
 }
 
@@ -177,7 +177,7 @@ static void test3(Parser* parser) {
   assert(w0->isOtherwise());
   assert(w0->numCaseExprs() == 0);
   assert(w0->blockStyle() == BlockStyle::UNNECESSARY_KEYWORD_AND_BLOCK);
-  assert(w0->numStmts() == 1);
+  assert(w0->body()->numStmts() == 1);
 }
 
 int main() {

--- a/frontend/test/resolution/testReturnTypes.cpp
+++ b/frontend/test/resolution/testReturnTypes.cpp
@@ -958,7 +958,7 @@ static void testSelectTypes() {
       var x : int;
       select T {
         when int {
-          x = x + 2;
+          var x: int;
           return x;
         }
       }
@@ -981,7 +981,7 @@ static void testSelectTypes() {
       var x : int;
       select T {
         when int {
-          x = x + 2;
+          var x: int;
           return x;
         }
         otherwise {}

--- a/frontend/test/resolution/testReturnTypes.cpp
+++ b/frontend/test/resolution/testReturnTypes.cpp
@@ -950,6 +950,52 @@ static void testSelectTypes() {
 
     testSelectCases(fooFunc, vals, /*isType=*/false);
   }
+  {
+    // demonstrate that when blocks can have multiple 
+    // statements without otherwise
+    std::string fooFunc = ops + R"""(
+    proc foo(type T) {
+      var x : int;
+      select T {
+        when int {
+          x = x + 2;
+          return x;
+        }
+      }
+
+      var y : T;
+      return y;
+    }
+    )""";
+    stringMap vals = {{"int", "int(64)"},
+                      //{"string", "string"} //future test for init resolution DCE
+                      };
+
+    testSelectCases(fooFunc, vals, /*isType=*/false);
+  }
+  {
+    // demonstrate that when blocks can have multiple 
+    // statements with otherwise
+    std::string fooFunc = ops + R"""(
+    proc foo(type T) {
+      var x : int;
+      select T {
+        when int {
+          x = x + 2;
+          return x;
+        }
+        otherwise {}
+      }
+      var y : real;
+      return y;
+    }
+    )""";
+    stringMap vals = {{"int", "int(64)"},
+                      //{"string", "real(64)"} //future test for init resolution DCE
+                      };
+
+    testSelectCases(fooFunc, vals, /*isType=*/false);
+  }
 }
 
 static void testSelectParams() {


### PR DESCRIPTION
1. Updates the when node to store a child block node rather than storing the statements directly as children of the when node. 
2. Adds support for skipping select statement branches that are statically known not to run. For example, a branch with a param false or the branches after one with a param true. There was a bug caused by the internal data structures not being marked as skip for select statements without an otherwise clause. I went ahead and refactored the entire method for brevity.
3. Adds 2 return type inference tests.