### PR TITLE
Remove -B flag while building the runtime for AMD GPUs

### DIFF
--- a/util/chplenv/compile_link_args_utils.py
+++ b/util/chplenv/compile_link_args_utils.py
@@ -69,14 +69,6 @@ def get_runtime_includes_and_defines():
             system.append("-isystem" + os.path.join(sdk_path, "hip", "include"))
             system.append("-isystem" + os.path.join(sdk_path, "hsa", "include"))
 
-
-            # We need runtime to use the lld that ships with the rocm
-            # installation so that we can properly link hipCUB. I believe this
-            # requirement is coming from using "-x hip" with clang
-            lld_path = os.path.join(sdk_path, "llvm/bin")
-            system.append("-B " + lld_path)
-            bundled.append("-B " + lld_path)
-
     if mem == "jemalloc":
         # set -DCHPL_JEMALLOC_PREFIX=chpl_je_
         # this is needed since it affects code inside of headers


### PR DESCRIPTION
As part of adding reduction support, I modified how we build the runtime by adding `-B` in the compilation command so that we can use the lld that comes with the ROCm installation. But the side effect of that is we ended up using `clang-offload-bundler` from the ROCm installation instead of the the target compiler. This causes issues with the flags we pass to the bundler, especially with older versions of ROCm, where the corresponding clang version is 12. We'll need a solution to the `lld` problem when we enable reduction support for AMD GPUs via hipCUB, but until then, this `-B` doesn't have any use.