### PR TITLE
Pin CUDA 11.3 on a test system that was defaulting to 11.0

### DIFF
--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -520,7 +520,7 @@ marked with * are covered in our nightly testing configuration.
 
   * Hardware: RTX A2000, P100*, V100*, A100* and H100
 
-  * Software: CUDA 11.0*, 11.6, 11.8*, 12.0*
+  * Software: CUDA 11.3*, 11.6, 11.8*, 12.0*
 
 * AMD
 

--- a/util/cron/test-gpu-cuda.bash
+++ b/util/cron/test-gpu-cuda.bash
@@ -6,7 +6,7 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-slurm-gasnet-cray-cs.bash
 source $CWD/common-native-gpu.bash
 
-module load cudatoolkit
+module load cudatoolkit/11.3
 
 export CHPL_GPU=nvidia
 export CHPL_COMM=none

--- a/util/cron/test-gpu-cuda.gasnet.bash
+++ b/util/cron/test-gpu-cuda.gasnet.bash
@@ -6,7 +6,7 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-slurm-gasnet-cray-cs.bash
 source $CWD/common-native-gpu.bash
 
-module load cudatoolkit
+module load cudatoolkit/11.3
 
 export CHPL_GPU=nvidia
 export CHPL_COMM=gasnet

--- a/util/cron/test-gpu-cuda.specialization.bash
+++ b/util/cron/test-gpu-cuda.specialization.bash
@@ -6,7 +6,7 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-slurm-gasnet-cray-cs.bash
 source $CWD/common-native-gpu.bash
 
-module load cudatoolkit
+module load cudatoolkit/11.3
 
 export CHPL_GPU=nvidia
 export CHPL_COMM=none

--- a/util/cron/test-gpu-cuda.um.bash
+++ b/util/cron/test-gpu-cuda.um.bash
@@ -6,7 +6,7 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-slurm-gasnet-cray-cs.bash
 source $CWD/common-native-gpu.bash
 
-module load cudatoolkit
+module load cudatoolkit/11.3
 
 export CHPL_GPU=nvidia
 export CHPL_COMM=none

--- a/util/cron/test-gpu-cuda.um.gasnet.bash
+++ b/util/cron/test-gpu-cuda.um.gasnet.bash
@@ -6,7 +6,7 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-slurm-gasnet-cray-cs.bash
 source $CWD/common-native-gpu.bash
 
-module load cudatoolkit
+module load cudatoolkit/11.3
 
 export CHPL_GPU=nvidia
 export CHPL_COMM=gasnet

--- a/util/cron/test-perf.gpu-cuda.bash
+++ b/util/cron/test-perf.gpu-cuda.bash
@@ -6,7 +6,7 @@ CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common-slurm-gasnet-cray-cs.bash
 source $CWD/common-native-gpu.bash
 
-module load cudatoolkit
+module load cudatoolkit/11.3
 
 export CHPL_GPU=nvidia
 export CHPL_LAUNCHER_PARTITION=stormP100

--- a/util/cron/test-perf.gpu-cuda.um.bash
+++ b/util/cron/test-perf.gpu-cuda.um.bash
@@ -6,7 +6,7 @@ CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common-slurm-gasnet-cray-cs.bash
 source $CWD/common-native-gpu.bash
 
-module load cudatoolkit
+module load cudatoolkit/11.3
 
 export CHPL_GPU=nvidia
 export CHPL_LAUNCHER_PARTITION=stormP100


### PR DESCRIPTION
The nightly testing system was using 11.0 by default that wasn't getting along well with some of the recent changes for reduction support. 11.0 is too old, and we're fine not supporting it. This PR pins to newer CUDA version (still old, 11.3) to keep nightly testing going.

Also updates the GPU technote's "Tested Configurations" part. 