### PR TITLE
Add missign arguments to kernel launch calls

### DIFF
--- a/runtime/src/gpu/amd/gpu-amd.c
+++ b/runtime/src/gpu/amd/gpu-amd.c
@@ -207,7 +207,8 @@ static void chpl_gpu_launch_kernel_help(int ln,
   CHPL_GPU_START_TIMER(prep_time);
 
   void ***kernel_params = chpl_mem_alloc(
-      nargs * sizeof(void **), CHPL_RT_MD_GPU_KERNEL_PARAM_BUFF, ln, fn);
+     (nargs+2) * sizeof(void **), CHPL_RT_MD_GPU_KERNEL_PARAM_BUFF, ln, fn);
+  //         ^ +2 for the ln and fn arguments that we add to the end of the array
 
   assert(function);
   assert(kernel_params);
@@ -249,6 +250,14 @@ static void chpl_gpu_launch_kernel_help(int ln,
                    i, kernel_params[i]);
     }
   }
+
+  // add the ln and fn arguments to the end of the array
+  // These arguments only make sense when the kernel lives inside of standard
+  // module code and CHPL_DEVELOPER is not set since the generated kernel function
+  // will have two extra formals to account for the line and file num.
+  // If CHPL_DEVELOPER is set, these arguments are dropped on the floor
+  kernel_params[nargs] = (void**)(&ln);
+  kernel_params[nargs+1] = (void**)(&fn);
 
   CHPL_GPU_STOP_TIMER(prep_time);
   CHPL_GPU_START_TIMER(kernel_time);

--- a/runtime/src/gpu/nvidia/gpu-nvidia.c
+++ b/runtime/src/gpu/nvidia/gpu-nvidia.c
@@ -190,7 +190,8 @@ static void chpl_gpu_launch_kernel_help(int ln,
   CHPL_GPU_START_TIMER(prep_time);
 
   void ***kernel_params = chpl_mem_alloc(
-      nargs * sizeof(void **), CHPL_RT_MD_GPU_KERNEL_PARAM_BUFF, ln, fn);
+      (nargs+2) * sizeof(void **), CHPL_RT_MD_GPU_KERNEL_PARAM_BUFF, ln, fn);
+  //         ^ +2 for the ln and fn arguments that we add to the end of the array
 
   assert(function);
   assert(kernel_params);
@@ -234,6 +235,14 @@ static void chpl_gpu_launch_kernel_help(int ln,
                    i, kernel_params[i]);
     }
   }
+
+  // add the ln and fn arguments to the end of the array
+  // These arguments only make sense when the kernel lives inside of standard
+  // module code and CHPL_DEVELOPER is not set since the generated kernel function
+  // will have two extra formals to account for the line and file num.
+  // If CHPL_DEVELOPER is set, these arguments are dropped on the floor
+  kernel_params[nargs] = (void**)(&ln);
+  kernel_params[nargs+1] = (void**)(&fn);
 
   CHPL_GPU_STOP_TIMER(prep_time);
   CHPL_GPU_START_TIMER(kernel_time);


### PR DESCRIPTION
When calling a kernel that lives inside a standard module, we propagate line numbers and file names for memory tracking and error reporting in a way that these arguments are added as formals to the kernel funciton generated by our compiler. The ln and fn arguments are already passed to the kernel launch functions in our runtime, but they were not being passed on the to the respective Nvidia and AMD kernel launch calls. 
This meant that the number of formals was more than the actuals and caused an error/segfault. 

By adding these arguments we fix the issue with the caveat that when in developer mode (CHPL_DEVELOPER) we don't need to pass these arguments since the line number is that of the Standard module. In this case the extra arguments are dropped on the floor. If there is an easy way to query if we are running with CHPL_DEVELOPER set, we should use it here to avoid doing the above.

Fixes #23823

- [x] GPU AOD (Nvida+AMD)
- [X] GPU UM (Nvidia+AMD)
- [X] GPU CPU-as-device