### PR TITLE
Fix GPU-based reductions for cpu-as-device mode

### DIFF
--- a/modules/standard/GPU.chpl
+++ b/modules/standard/GPU.chpl
@@ -440,7 +440,7 @@ module GPU
 
 
     proc getExternFuncName(param op: string, type t) param: string {
-      return "chpl_gpu_"+op+"_reduce_"+chplTypeToCTypeName(t);
+      return "chpl_gpu_"+op+"_reduce_"+cTypeName;
     }
 
     proc isValReduce(param op) param {

--- a/modules/standard/GPU.chpl
+++ b/modules/standard/GPU.chpl
@@ -593,7 +593,7 @@ module GPU
   inline proc gpuMaxReduce(const ref A: [] ?t) do return doGpuReduce("max", A);
 
   /*
-    For an array on the GPU, return a tuple with the index and the value of the
+    For an array on the GPU, return a tuple with the value and the index of the
     minimum element (that is, perform a minloc-reduction). If there are multiple
     elements with the same minimum value, the index of the first one is
     returned. The array must be in GPU-accessible memory and the function must
@@ -604,13 +604,13 @@ module GPU
 
        on here.gpus[0] {
          var Arr = [3, 2, 1, 5, 4]; // will be GPU-accessible
-         writeln(gpuMinLocReduce(Arr)); // (2, 1). Note that Arr[2]==1.
+         writeln(gpuMinLocReduce(Arr)); // (1, 2). Note that Arr[2]==1.
        }
   */
   inline proc gpuMinLocReduce(const ref A: [] ?t) do return doGpuReduce("minloc", A);
 
   /*
-    For an array on the GPU, return a tuple with the index and the value of the
+    For an array on the GPU, return a tuple with the value and the index of the
     maximum element (that is, perform a maxloc-reduction). If there are multiple
     elements with the same maximum value, the index of the first one is
     returned. The array must be in GPU-accessible memory and the function must
@@ -621,7 +621,7 @@ module GPU
 
        on here.gpus[0] {
          var Arr = [3, 2, 1, 5, 4]; // will be GPU-accessible
-         writeln(gpuMaxLocReduce(Arr)); // (3, 5). Note that Arr[3]==5.
+         writeln(gpuMaxLocReduce(Arr)); // (5, 3). Note that Arr[3]==5.
        }
   */
   inline proc gpuMaxLocReduce(const ref A: [] ?t) do return doGpuReduce("maxloc", A);

--- a/modules/standard/GPU.chpl
+++ b/modules/standard/GPU.chpl
@@ -404,6 +404,22 @@ module GPU
       compilerError("Unexpected reduction kind in doGpuReduce: ", op);
     }
 
+    param cTypeName = if      t==int(8)   then "int8_t"
+                      else if t==int(16)  then "int16_t"
+                      else if t==int(32)  then "int32_t"
+                      else if t==int(64)  then "int64_t"
+                      else if t==uint(8)  then "uint8_t"
+                      else if t==uint(16) then "uint16_t"
+                      else if t==uint(32) then "uint32_t"
+                      else if t==uint(64) then "uint64_t"
+                      else if t==real(32) then "float"
+                      else if t==real(64) then "double"
+                      else                     "unknown";
+
+    if cTypeName == "unknown" {
+      compilerError("Arrays with ", t:string,
+                    " elements cannot be reduced with gpu*Reduce functions");
+    }
 
     if CHPL_GPU == "amd" {
       compilerError("gpu*Reduce functions are not supported on AMD GPUs");
@@ -422,24 +438,6 @@ module GPU
       compilerAssert(CHPL_GPU=="nvidia");
     }
 
-
-    proc chplTypeToCTypeName(type t) param {
-      select t {
-        when int(8)   do return "int8_t";
-        when int(16)  do return "int16_t";
-        when int(32)  do return "int32_t";
-        when int(64)  do return "int64_t";
-        when uint(8)  do return "uint8_t";
-        when uint(16) do return "uint16_t";
-        when uint(32) do return "uint32_t";
-        when uint(64) do return "uint64_t";
-        when real(32) do return "float";
-        when real(64) do return "double";
-        otherwise do
-          compilerError("Arrays with ", t:string, " elements cannot be reduced");
-      }
-      return "unknown";
-    }
 
     proc getExternFuncName(param op: string, type t) param: string {
       return "chpl_gpu_"+op+"_reduce_"+chplTypeToCTypeName(t);

--- a/test/gpu/native/noAmd/reduction/basic.good
+++ b/test/gpu/native/noAmd/reduction/basic.good
@@ -59,13 +59,13 @@ Testing type real(32)
 sum: 4950.0
 min: 0.0
 max: 99.0
-minloc: (0, 0.0)
-maxloc: (99, 99.0)
+minloc: (0.0, 0)
+maxloc: (99.0, 99)
 
 Testing type real(64)
 sum: 4950.0
 min: 0.0
 max: 99.0
-minloc: (0, 0.0)
-maxloc: (99, 99.0)
+minloc: (0.0, 0)
+maxloc: (99.0, 99)
 

--- a/test/gpu/native/noAmd/reduction/largeArraysMinMax.chpl
+++ b/test/gpu/native/noAmd/reduction/largeArraysMinMax.chpl
@@ -13,7 +13,7 @@ assert(n>setIdx);
 config const printResult = false;
 
 const expectedVal = if isMin then 7:uint(8) else 13:uint(8);
-const expected = if withLoc then (setIdx, expectedVal) else expectedVal;
+const expected = if withLoc then (expectedVal, setIdx) else expectedVal;
 
 inline proc doReduce(Arr) {
   if withLoc then
@@ -22,7 +22,7 @@ inline proc doReduce(Arr) {
     return if isMin then gpuMinReduce(Arr) else gpuMaxReduce(Arr);
 }
 
-var result: if withLoc then (int, uint(8)) else uint(8);
+var result: if withLoc then (uint(8), int) else uint(8);
 on here.gpus[0] {
   var Arr: [0..#n] uint(8) = 10;
   Arr[setIdx] = expectedVal;

--- a/test/gpu/native/noAmd/reduction/nonZeroBased.good
+++ b/test/gpu/native/noAmd/reduction/nonZeroBased.good
@@ -1,10 +1,10 @@
 warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
 64 6 5 12 14 91 11 91 11 58
-(-18, 5)
-(-15, 91)
+(5, -18)
+(91, -15)
 64 6 5 12 14 91 11 91 11 58
-(2, 5)
-(5, 91)
+(5, 2)
+(91, 5)
 64 6 5 12 14 91 11 91 11 58
-(12, 5)
-(15, 91)
+(5, 12)
+(91, 15)

--- a/test/gpu/native/noAmd/reduction/stringError.good
+++ b/test/gpu/native/noAmd/reduction/stringError.good
@@ -1,5 +1,4 @@
 warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
-$CHPL_HOME/modules/standard/GPU.chpl:prediffed: In function 'doGpuReduce':
-$CHPL_HOME/modules/standard/GPU.chpl:prediffed: error: Arrays with string elements cannot be reduced
-  $CHPL_HOME/modules/standard/GPU.chpl:prediffed: called as doGpuReduce(param op = "sum", A: [domain(1,int(64),one)] string) from function 'gpuSumReduce'
+$CHPL_HOME/modules/standard/GPU.chpl:prediffed: In function 'gpuSumReduce':
+$CHPL_HOME/modules/standard/GPU.chpl:prediffed: error: Arrays with string elements cannot be reduced with gpu*Reduce functions
   stringError.chpl:prediffed: called as gpuSumReduce(A: [domain(1,int(64),one)] string)


### PR DESCRIPTION
Fixes two issues with the gpu*Reduce functions:

- I've made a mistake in `gpuMinLocReduce` and `gpuMaxLocReduce` where I made them return `(idx, val)` (a la CUB), whereas they should return `(val, idx)` (a la Chapel). 
- `stringError` test checks an error message for unsupported types. However, cpu-as-device branch of the code was before that check, so it was not exercising the check.

Both issues are fixed with this PR.
