### PR TITLE
Explicitly set PATH while building the AMD reduction support

### DIFF
--- a/runtime/src/gpu/amd/Makefile.share
+++ b/runtime/src/gpu/amd/Makefile.share
@@ -25,4 +25,4 @@ RUNTIME_CXXFLAGS += -x hip
 
 $(RUNTIME_OBJ_DIR)/gpu-amd-reduce.o: gpu-amd-reduce.cc \
                                          $(RUNTIME_OBJ_DIR_STAMP)
-	$(CXX) -c -std=c++14 $(RUNTIME_CXXFLAGS) $(RUNTIME_INCLS) -o $@ $<
+	PATH=$(PATH):$(CHPL_MAKE_ROCM_PATH)/llvm/bin $(CXX) -c -std=c++14 $(RUNTIME_CXXFLAGS) $(RUNTIME_INCLS) -o $@ $<


### PR DESCRIPTION
Clang needs `lld` and `clang-offload-bundler` while compiling with `-x hip`. We want clang to use its own `clang-offload-bundler` while using the ROCm install's `lld`. This is probably a short-term solution until we decide to either:

- use ROCm's LLVM as our system LLVM (so that we can use everything from ROCm)
- require our LLVM to be built with lld (so that we can use everything from our installation)

Luckily, clang finds these executables in different ways. I don't know why that's the case or whether there's a reasonable explanation for it, but it certainly helps us. So, this PR sets `PATH` explicitly while building AMD's reduction support code to make clang use ROCm's `lld` while still using our backend's `clang-offload-bundler`.

TODO
- [ ] check `CHPL_MAKE_ROCM_PATH` exists