### PR TITLE
Fix try! usage in initializers

### DIFF
--- a/compiler/passes/InitNormalize.cpp
+++ b/compiler/passes/InitNormalize.cpp
@@ -26,6 +26,7 @@
 #include "IfExpr.h"
 #include "initializerRules.h"
 #include "LoopExpr.h"
+#include "TryStmt.h"
 #include "stmt.h"
 #include "astutil.h"
 
@@ -758,6 +759,14 @@ InitNormalize::InitPhase InitNormalize::startPhase(BlockStmt* block) const {
       INT_ASSERT(forall->fRecIterIRdef == NULL);
 
       InitPhase phase = startPhase(forall->loopBody());
+
+      if (phase != defaultPhase) {
+        retval = phase;
+      } else {
+        stmt   = stmt->next;
+      }
+    } else if (TryStmt* tryStmt = toTryStmt(stmt)) {
+      InitPhase phase = startPhase(tryStmt->body());
 
       if (phase != defaultPhase) {
         retval = phase;

--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -901,7 +901,14 @@ static bool isUnacceptableTry(Expr* stmt) {
   bool retval = false;
 
   if (TryStmt* ts = toTryStmt(stmt)) {
-    if (ts->tryBang() == false) {
+    if (ts->isSyncTry()) {
+      // Ignore compiler-inserted sync-try statements for now since they
+      // are invisible to the user and sync statements on their own seem to
+      // be fine.
+      //
+      // TODO: What *should* we be doing here?
+      retval = false;
+    } else if (ts->tryBang() == false) {
       // Only allow try! statements in initializers at the moment
       retval = true;
 

--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -710,6 +710,9 @@ static InitNormalize preNormalize(AggregateType* at,
                                block,
                                InitNormalize(block, state)));
       stmt = stmt->next;
+    } else if (TryStmt* tryStmt = toTryStmt(stmt)) {
+      state.merge(preNormalize(at, tryStmt->body(), InitNormalize(tryStmt->body(), state)));
+      stmt = stmt->next;
 
     } else {
       stmt = stmt->next;

--- a/test/classes/initializers/errors/errHandling/initInsideTryBang.chpl
+++ b/test/classes/initializers/errors/errHandling/initInsideTryBang.chpl
@@ -1,0 +1,46 @@
+
+record Signal {
+  var x : int;
+
+  proc init(x: int = 0) {
+    writeln("Signal.init");
+    this.x = x;
+  }
+
+  proc init=(other: Signal) {
+    writeln("Signal.init=");
+    this.x = other.x;
+  }
+
+  operator =(ref lhs: Signal, const rhs: Signal) {
+    writeln("Signal.=");
+    lhs.x = rhs.x;
+  }
+}
+
+proc makeSignal(x: int) throws {
+  if x < 0 then throw new Error("negative int!");
+
+  return new Signal(x);
+}
+
+//
+// This test exists to ensure that initializer normalization occurs within
+// try! statements. Without such normalization, we'd see an assignment into
+// an uninitialized 'sig' field, then see the field initialized such that
+// 'x == 0'.
+//
+record Wrapper {
+  var sig : Signal;
+
+  proc init() throws {
+    try! {
+      this.sig = makeSignal(999);
+    }
+  }
+}
+
+proc main() {
+  var w : Wrapper;
+  writeln(w);
+}

--- a/test/classes/initializers/errors/errHandling/initInsideTryBang.good
+++ b/test/classes/initializers/errors/errHandling/initInsideTryBang.good
@@ -1,0 +1,2 @@
+Signal.init
+(sig = (x = 999))

--- a/test/classes/initializers/parentCall/syncStatements.bad
+++ b/test/classes/initializers/parentCall/syncStatements.bad
@@ -1,2 +1,0 @@
-syncStatements.chpl:7: In initializer:
-syncStatements.chpl:9: error: Only catch-less try! statements are allowed in initializers for now

--- a/test/classes/initializers/parentCall/syncStatements.chpl
+++ b/test/classes/initializers/parentCall/syncStatements.chpl
@@ -5,13 +5,12 @@ class Foo {
   var x: real;
 
   proc init(xVal) {
-    x = xVal;
     sync {
       super.init();
     }
+    x = xVal;
   }
 }
 
 var foo = new Foo(4.3);
 writeln(foo);
-delete foo;

--- a/test/classes/initializers/parentCall/syncStatements.future
+++ b/test/classes/initializers/parentCall/syncStatements.future
@@ -1,4 +1,0 @@
-feature request: support sync statements in initializers
-
-Due to their implicit try wrapping, we cannot support sync statements in
-initializers today (see #7098 and #6145)

--- a/test/classes/initializers/phase1/syncStatements.bad
+++ b/test/classes/initializers/phase1/syncStatements.bad
@@ -1,2 +1,0 @@
-syncStatements.chpl:7: In initializer:
-syncStatements.chpl:8: error: Only catch-less try! statements are allowed in initializers for now

--- a/test/classes/initializers/phase1/syncStatements.chpl
+++ b/test/classes/initializers/phase1/syncStatements.chpl
@@ -13,4 +13,3 @@ class Foo {
 
 var foo = new Foo(13);
 writeln(foo);
-delete foo;

--- a/test/classes/initializers/phase1/syncStatements.future
+++ b/test/classes/initializers/phase1/syncStatements.future
@@ -1,9 +1,0 @@
-feature request: sync statements in phase 1
-
-Philosophically, it should not be a big deal for phase 1 initializers to
-include a sync statement. However, because of error-handling changes to
-do with sync statements, the matching for phase 1 initializers can no
-longer allow this pattern without also allowing try/catch. This issue
-should be revisited after error handling and initializers have both
-stabilized more.
-

--- a/test/classes/initializers/siblingCall/syncStatements.bad
+++ b/test/classes/initializers/siblingCall/syncStatements.bad
@@ -1,2 +1,0 @@
-syncStatements.chpl:8: In initializer:
-syncStatements.chpl:9: error: Only catch-less try! statements are allowed in initializers for now

--- a/test/classes/initializers/siblingCall/syncStatements.chpl
+++ b/test/classes/initializers/siblingCall/syncStatements.chpl
@@ -19,4 +19,3 @@ class Foo {
 
 var foo = new Foo();
 writeln(foo);
-delete foo;

--- a/test/classes/initializers/siblingCall/syncStatements.future
+++ b/test/classes/initializers/siblingCall/syncStatements.future
@@ -1,4 +1,0 @@
-feature request: support sync statements in initializers
-
-Due to their implicit try wrapping, we cannot support sync statements in
-initializers today (see #7098 and #6145)


### PR DESCRIPTION
This PR fixes a bug in the compiler where we would not apply initializer semantics to field initialization inside a ``try!`` block. This PR also updates some tests and fixes several outdated futures. A new test is added to demonstrate that fields are being initialized as expected.

Testing:
- [x] local
- [x] gasnet