### PR TITLE
Store LLVM IR in .dyno files

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2943,14 +2943,18 @@ static void codegenPartTwo() {
       }
 
       for (FnSymbol* fn : fns) {
-        if (llvm::Function* g = llvmModule->getFunction(fn->cname)) {
-          chpl::ID fnId = fn->astloc.id();
-          if (!fnId.isEmpty()) {
-            LibraryFileWriter::GenInfo info;
-            info.cname = UniqueString::get(gContext, fn->cname);
-            info.isInstantiation = fn->hasFlag(FLAG_INSTANTIATED_GENERIC);
-            genMap[fnId].push_back(info);
-            filterGvs.insert(g);
+        if (fn->hasFlag(FLAG_GEN_MAIN_FUNC)) {
+          // skip chpl_gen_main
+        } else {
+          if (llvm::Function* g = llvmModule->getFunction(fn->cname)) {
+            chpl::ID fnId = fn->astloc.id();
+            if (!fnId.isEmpty()) {
+              LibraryFileWriter::GenInfo info;
+              info.cname = UniqueString::get(gContext, fn->cname);
+              info.isInstantiation = fn->hasFlag(FLAG_INSTANTIATED_GENERIC);
+              genMap[fnId].push_back(info);
+              filterGvs.insert(g);
+            }
           }
         }
       }

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1902,8 +1902,8 @@ static void codegen_header(std::set<const char*> & cnames,
     if (fn2->hasFlag(FLAG_BEGIN_BLOCK) ||
         fn2->hasFlag(FLAG_COBEGIN_OR_COFORALL_BLOCK) ||
         fn2->hasFlag(FLAG_ON_BLOCK)) {
-    ftableVec.push_back(fn2);
-    ftableMap[fn2] = ftableVec.size()-1;
+      ftableVec.push_back(fn2);
+      ftableMap[fn2] = ftableVec.size()-1;
     }
   }
 
@@ -2814,7 +2814,7 @@ static void codegenPartTwo() {
 
   // Prepare the LLVM IR dumper for code generation
   // This needs to happen after protectNameFromC which happens
-  // currently in codegen_header.
+  // currently in codegenPartOne.
   preparePrintLlvmIrForCodegen();
 
   info->cfile = defnfile.fptr;
@@ -2893,6 +2893,7 @@ void codegen() {
   if (isFullGpuCodegen()) {
     // flush stdout before forking process so buffered output doesn't get copied over
     fflush(stdout);
+    fflush(stderr);
 
     pid_t pid = fork();
 

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2958,6 +2958,7 @@ static void codegenPartTwo() {
       {
         llvm::raw_string_ostream OS(generatedCodeBuffer);
         llvm::WriteBitcodeToFile(*M.get(), OS);
+        //M.get()->dump();
       }
 
       auto modName = UniqueString::get(gContext, genMod->name);

--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -27,7 +27,9 @@
 
 #include <cstdio>
 #include <map>
+#include <set>
 #include <string>
+#include <unordered_set>
 
 class Timer;
 
@@ -324,6 +326,9 @@ extern std::vector<std::pair<std::string, std::string>> gDynoParams;
 
 extern std::vector<std::string> gDynoPrependInternalModulePaths;
 extern std::vector<std::string> gDynoPrependStandardModulePaths;
+
+extern std::vector<UniqueString> gDynoGenLibSourcePaths;
+extern std::unordered_set<const char*> gDynoGenLibModuleNameAstrs;
 
 extern bool fForeachIntents;
 

--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -327,6 +327,7 @@ extern std::vector<std::pair<std::string, std::string>> gDynoParams;
 extern std::vector<std::string> gDynoPrependInternalModulePaths;
 extern std::vector<std::string> gDynoPrependStandardModulePaths;
 
+extern std::string gDynoGenLibOutput;
 extern std::vector<UniqueString> gDynoGenLibSourcePaths;
 extern std::unordered_set<const char*> gDynoGenLibModuleNameAstrs;
 

--- a/compiler/include/llvmExtractIR.h
+++ b/compiler/include/llvmExtractIR.h
@@ -22,14 +22,23 @@
 #define _LLVM_EXTRACT_IR_
 
 #include <set>
+#include <memory>
 
 #ifdef HAVE_LLVM
 namespace llvm
 {
   class Function;
   class GlobalValue;
+  class Module;
 }
 
+// creates a new module by extracting just the 'gvs' passed
+// and creating prototypes for other things.
+std::unique_ptr<llvm::Module>
+extractLLVM(const llvm::Module* fromModule,
+            std::set<const llvm::GlobalValue*> &gvs);
+
+// extracts only the functions in 'gvs' and prints those
 void extractAndPrintFunctionsLLVM(std::set<const llvm::GlobalValue*> *gvs);
 
 #endif // end HAVE_LLVM

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -131,6 +131,7 @@ public:
   // const ref. It can depend on the variable for ref to arrays.
   Qualifier*         fieldQualifiers;
 
+  // these two must be astrs
   const char*        name;
   const char*        cname;    // Name of symbol for C code
 

--- a/compiler/llvm/llvmExtractIR.cpp
+++ b/compiler/llvm/llvmExtractIR.cpp
@@ -36,6 +36,53 @@
 
 using namespace llvm;
 
+std::unique_ptr<Module> extractLLVM(const llvm::Module* fromModule,
+                                    std::set<const GlobalValue*> &gvs) {
+  ValueToValueMapTy VMap;
+  // Create a new module containing only the definition of the function
+  // and using external declarations for everything else
+#if HAVE_LLVM_VER < 70
+  auto ownedM = CloneModule(fromModule, VMap,
+                            [&](const GlobalValue *GV) {
+                                       return gvs.count(GV) > 0; });
+#else
+  auto ownedM = CloneModule(*fromModule, VMap,
+                            [&](const GlobalValue *GV) {
+                                       return gvs.count(GV) > 0; });
+#endif
+  Module& M = *ownedM.get();
+
+  // collect names for the next step
+  // TODO: could the next step just check to see if it's in gvs?
+  std::set<std::string> names;
+  for (auto V : gvs) {
+    names.insert(V->getName().str());
+  }
+
+  // Make sure the function in the module is externally visible
+  // (so the below cleanups don't remove it)
+  for (Function &F : M) {
+    std::string name = F.getName().str();
+    if (names.count(name) > 0) {
+      F.setLinkage(GlobalValue::WeakAnyLinkage);
+    }
+  }
+
+  // TODO: update per LLVM 16's version of llvm-extract
+  // which uses the newer PassManager and the new in 16 ExtractGV pass.
+
+  // cleanup a-la llvm-extract
+  legacy::PassManager Passes;
+
+  Passes.add(createGlobalDCEPass());           // Delete unreachable globals
+  Passes.add(createStripDeadDebugInfoPass());  // Remove dead debug info
+  Passes.add(createStripDeadPrototypesPass()); // Remove dead func decls
+
+  Passes.run(M);
+
+  return ownedM;
+}
+
 void extractAndPrintFunctionsLLVM(std::set<const GlobalValue*> *gvs) {
 
   if (gvs == NULL || gvs->size() == 0)
@@ -54,35 +101,8 @@ void extractAndPrintFunctionsLLVM(std::set<const GlobalValue*> *gvs) {
   }
   assert(funcModule != NULL);
 
-  ValueToValueMapTy VMap;
-  // Create a new module containing only the definition of the function
-  // and using external declarations for everything else
-#if HAVE_LLVM_VER < 70
-  auto ownedM = CloneModule(funcModule, VMap,
-                            [=](const GlobalValue *GV) {
-                                       return gvs->count(GV) > 0; });
-#else
-  auto ownedM = CloneModule(*funcModule, VMap,
-                            [=](const GlobalValue *GV) {
-                                       return gvs->count(GV) > 0; });
-#endif
+  std::unique_ptr<Module> ownedM = extractLLVM(funcModule, *gvs);
   Module& M = *ownedM.get();
-
-  // Make sure the function in the module is externally visible
-  // (so the below cleanups don't remove it)
-  for (Function &F : M) {
-    std::string name = F.getName().str();
-    if (names.count(name) > 0) {
-      F.setLinkage(GlobalValue::WeakAnyLinkage);
-    }
-  }
-
-  // cleanup a-la llvm-extract
-  legacy::PassManager Passes;
-
-  Passes.add(createGlobalDCEPass());           // Delete unreachable globals
-  Passes.add(createStripDeadDebugInfoPass());  // Remove dead debug info
-  Passes.add(createStripDeadPrototypesPass()); // Remove dead func decls
 
   std::error_code EC;
   // note: could output to a file if we replace "-" with a filename
@@ -96,6 +116,8 @@ void extractAndPrintFunctionsLLVM(std::set<const GlobalValue*> *gvs) {
     return;
   }
 
+  // TODO: use the new PassManager
+  legacy::PassManager Passes;
   Passes.add( createPrintModulePass(Out.os(), "", false));
   // note: could output bit code this way:
   //Passes.add(createBitcodeWriterPass(Out.os(), true));

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -389,21 +389,11 @@ static bool compilerSetChplLLVM = false;
 
 static std::vector<std::string> cmdLineModPaths;
 
-// TODO: with the updates to filesystem that utilize GetExecutablePath,
-// do we still need this block comment?
-/* Note -- LLVM provides a way to get the path to the executable...
-// This function isn't referenced outside its translation unit, but it
-// can't use the "static" keyword because its address is used for
-// GetMainExecutable (since some platforms don't support taking the
-// address of main, and some platforms can't implement GetMainExecutable
-// without being given the address of a function in the main executable).
-llvm::sys::Path GetExecutablePath(const char *Argv0) {
-  // This just needs to be some symbol in the binary; C++ doesn't
-  // allow taking the address of ::main however.
-  void *MainAddr = (void*) (intptr_t) GetExecutablePath;
-  return llvm::sys::Path::GetMainExecutable(Argv0, MainAddr);
-}
-*/
+// support for separate compilation
+// what source code paths were requested to be compiled into the lib?
+std::vector<UniqueString> gDynoGenLibSourcePaths;
+// what top-level module names as astrs were requested to be stored in the lib?
+std::unordered_set<const char*> gDynoGenLibModuleNameAstrs;
 
 static bool isMaybeChplHome(const char* path)
 {
@@ -1180,6 +1170,10 @@ static void driverSetDevelSettings(const ArgumentDescription* desc, const char* 
   } else {
     ccwarnings = false;
   }
+}
+
+void addDynoGenLib(const ArgumentDescription* desc, const char* newpath) {
+  gDynoGenLibSourcePaths.push_back(UniqueString::get(gContext, newpath));
 }
 
 /*

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -390,6 +390,8 @@ static bool compilerSetChplLLVM = false;
 static std::vector<std::string> cmdLineModPaths;
 
 // support for separate compilation
+// what is the name of the output library file e.g. MyModule.dyno
+std::string gDynoGenLibOutput;
 // what source code paths were requested to be compiled into the lib?
 std::vector<UniqueString> gDynoGenLibSourcePaths;
 // what top-level module names as astrs were requested to be stored in the lib?
@@ -1173,7 +1175,17 @@ static void driverSetDevelSettings(const ArgumentDescription* desc, const char* 
 }
 
 void addDynoGenLib(const ArgumentDescription* desc, const char* newpath) {
-  gDynoGenLibSourcePaths.push_back(UniqueString::get(gContext, newpath));
+  std::string path = std::string(newpath);
+  auto dot = path.find_last_of(".");
+  std::string noExt = path.substr(0, dot);
+  std::string usePath = noExt + ".dyno";
+  if (usePath != path) {
+    USR_FATAL("--dyno-gen-lib accepts the output file as an argument." \
+              "Please use the .dyno suffix for the output file");
+  }
+
+  // other variables will be set later
+  gDynoGenLibOutput = usePath;
 }
 
 /*
@@ -1470,7 +1482,7 @@ static ArgumentDescription arg_desc[] = {
  {"dyno-scope-bundled", ' ', NULL, "Enable [disable] using dyno to scope resolve bundled modules", "N", &fDynoScopeBundled, "CHPL_DYNO_SCOPE_BUNDLED", NULL},
  {"dyno-debug-trace", ' ', NULL, "Enable [disable] debug-trace output when using dyno compiler library", "N", &fDynoDebugTrace, "CHPL_DYNO_DEBUG_TRACE", NULL},
  {"dyno-break-on-hash", ' ' , NULL, "Break when query with given hash value is executed when using dyno compiler library", "X", &fDynoBreakOnHash, "CHPL_DYNO_BREAK_ON_HASH", NULL},
- {"dyno-gen-lib", ' ', "<path>", "Specify file to be generated as a .dyno library", "P", NULL, NULL, addDynoGenLib},
+ {"dyno-gen-lib", ' ', "<path>", "Specify files named on the command line should be saved into a .dyno library", "P", NULL, NULL, addDynoGenLib},
  {"dyno-verify-serialization", ' ', NULL, "Enable [disable] verification of serialization", "N", &fDynoVerifySerialization, NULL, NULL},
  {"foreach-intents", ' ', NULL, "Enable [disable] (current, experimental, support for) foreach intents.", "N", &fForeachIntents, "CHPL_FOREACH_INTENTS", NULL},
 

--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -179,8 +179,6 @@ static Vec<const char*> sModNameList;
 static Vec<const char*> sModDoneSet;
 static Vec<VisibilityStmt*> sModReqdByInt;
 
-static std::set<std::string> gDynoGenLibPaths;
-
 void addInternalModulePath(const ArgumentDescription* desc, const char* newpath) {
   sIntModPath.add(astr(newpath));
   gDynoPrependInternalModulePaths.push_back(newpath);
@@ -189,10 +187,6 @@ void addInternalModulePath(const ArgumentDescription* desc, const char* newpath)
 void addStandardModulePath(const ArgumentDescription* desc, const char* newpath) {
   sStdModPath.add(astr(newpath));
   gDynoPrependInternalModulePaths.push_back(newpath);
-}
-
-void addDynoGenLib(const ArgumentDescription* desc, const char* newpath) {
-  gDynoGenLibPaths.insert(std::string(newpath));
 }
 
 void setupModulePaths() {
@@ -484,8 +478,8 @@ static void parseCommandLineFiles() {
     mod->addDefaultUses();
   }
 
-  if (gDynoGenLibPaths.size() > 0) {
-    for (std::string path : gDynoGenLibPaths) {
+  if (gDynoGenLibSourcePaths.size() > 0) {
+    for (UniqueString path : gDynoGenLibSourcePaths) {
       if (path == "<standard>") {
         std::vector<UniqueString> todo;
         for (auto& path : parsedPaths) {
@@ -499,12 +493,12 @@ static void parseCommandLineFiles() {
                                              "chpl_standard.dyno");
         libWriter.writeAllSections();
       } else {
-        std::string justFile = path.substr(path.find_last_of("/") + 1);
+        std::string pathS = path.str();
+        std::string justFile = pathS.substr(pathS.find_last_of("/") + 1);
         auto dot = justFile.find_last_of(".");
         std::string noExt = justFile.substr(0, dot);
-        auto ustr = chpl::UniqueString::get(gContext, path);
         auto libWriter =
-          chpl::libraries::LibraryFileWriter(gContext, {ustr}, noExt + ".dyno");
+          chpl::libraries::LibraryFileWriter(gContext, {path}, noExt + ".dyno");
         libWriter.writeAllSections();
       }
     }

--- a/frontend/doc/file-format.rst
+++ b/frontend/doc/file-format.rst
@@ -182,15 +182,37 @@ This section consists of:
 
    * a byte storing flags / kind information
 
-   * unsigned variable-byte encoded, prefix A to copy from the
-     previous symbol table ID
+   * the symbol table ID, stored in a compressed form. It is formed by
+     concatenating the first A bytes of the previous symbol table ID with
+     the B bytes of suffix:
 
-   * unsigned variable-byte encoded, suffix size B stored here
+     * unsigned variable-byte encoded, prefix A to copy from the
+       previous symbol table ID
 
-   * B bytes of suffix
+     * unsigned variable-byte encoded, suffix size B stored here
 
-     * the symbol table ID string is formed by concatenating
-       first A bytes of the previous string with the B bytes of suffix
+     * B bytes of suffix
+
+  * unsigned variable-byte encoded number, G, of code-generated versions
+
+  * for each of the G code-generated versions
+
+    * byte indicating 0 if it is concrete and nonzero for an
+      instantiation
+
+    * additional information TBD for instantiations
+
+    * the name of the symbol in the generated code, also called a "cname",
+      stored in a compressed form. It is formed by concatenating the first
+      A bytes of the previous cname with the B bytes of suffix:
+
+       * unsigned variable-byte encoded, prefix A to copy from the
+         previous symbol's cname
+
+       * unsigned variable-byte encoded, suffix size B stored here
+
+       * B bytes of suffix
+
 
 uAST Section
 ------------

--- a/frontend/doc/file-format.rst
+++ b/frontend/doc/file-format.rst
@@ -335,6 +335,22 @@ The Location section consists of:
        * unsigned variable-byte encoded first last column
 
 
+Generated Code Section
+----------------------
+
+The generated code contains serialized LLVM IR for the result of
+compilation for the module (with the exception of generic functions that
+are not yet instantiated).
+
+The generated code section consists of:
+
+ * 8 bytes of magic number 0x4e4547075ec110e0
+
+ * 8 bytes, M, the size of the serialized LLVM IR bytecode
+
+ * M bytes of serialized LLVM IR bytecode
+
+
 Types Section
 -------------
 

--- a/frontend/include/chpl/libraries/LibraryFile.h
+++ b/frontend/include/chpl/libraries/LibraryFile.h
@@ -370,6 +370,8 @@ class LibraryFile {
                 int moduleIndex,
                 int symbolTableEntryIndex,
                 const uast::AstNode* symbolTableEntryAst) const;
+
+  // TODO: reading LLVM IR, getLazyIRModule con work with a MemoryBuffer
 };
 
 

--- a/frontend/include/chpl/libraries/LibraryFileFormat.h
+++ b/frontend/include/chpl/libraries/LibraryFileFormat.h
@@ -40,6 +40,7 @@ static const uint64_t SYMBOL_TABLE_MAGIC =     0x4d59531e5ec110e0;
 static const uint64_t UAST_SECTION_MAGIC =     0x5453411e5ec110e0;
 static const uint32_t LONG_STRINGS_TABLE_MAGIC =       0x52545301;
 static const uint64_t LOCATION_SECTION_MAGIC = 0x434F4C075ec110e0;
+static const uint64_t GEN_CODE_SECTION_MAGIC = 0x4e4547075ec110e0;
 
 // current file format version numbers
 static const uint32_t FORMAT_VERSION_MAJOR =  0;
@@ -89,6 +90,7 @@ struct ModuleHeader {
   Region astSection;
   Region longStringsTable;
   Region locationSection;
+  Region genCodeSection;
   // TODO: add other sections
 
   // followed by a variable-byte length & string storing the module ID
@@ -131,6 +133,13 @@ struct LocationSectionHeader {
   // followed by file path strings
   // then followed serialized location groups
 };
+
+struct GenCodeSectionHeader {
+  uint64_t magic;
+  uint64_t len;
+  // followed by the LLVM IR bc data
+};
+
 
 
 } // end namespace libraries

--- a/frontend/include/chpl/libraries/LibraryFileWriter.h
+++ b/frontend/include/chpl/libraries/LibraryFileWriter.h
@@ -98,8 +98,9 @@ class LibraryFileWriter {
       set 'ok' to 'false' */
   void fail(const char* msg);
 
-  /** Gather the top-level modules */
-  void gatherTopLevelModules();
+  /** Gather the top-level modules and the paths they came from */
+  static std::vector<std::pair<const uast::Module*, UniqueString>>
+  gatherTopLevelModules(Context* context, std::vector<UniqueString> paths);
 
   /** Open the file */
   void openFile();
@@ -177,6 +178,11 @@ class LibraryFileWriter {
     error in the process.
     */
   bool writeAllSections();
+
+  /** Gather the names of the top-level modules in the source
+      code files from 'paths' */
+  static std::vector<UniqueString>
+  gatherTopLevelModuleNames(Context* context, std::vector<UniqueString> paths);
 };
 
 

--- a/frontend/include/chpl/libraries/LibraryFileWriter.h
+++ b/frontend/include/chpl/libraries/LibraryFileWriter.h
@@ -86,7 +86,7 @@ class LibraryFileWriter {
  public:
   struct GenInfo {
     UniqueString cname;
-    bool isInstantiation;
+    bool isInstantiation = false;
     // TODO: other information about instantiations
   };
 
@@ -136,7 +136,7 @@ class LibraryFileWriter {
 
   /** Write the symbol table for a given module. Returns the
       module-relative offset to the symbol table. */
-  Region writeSymbolTable(const uast::Module* mod,
+  Region writeSymbolTable(const ModInfo& info,
                           Serializer& ser,
                           LibraryFileSerializationHelper& reg);
 

--- a/frontend/test/libraries/testLibraryFile.cpp
+++ b/frontend/test/libraries/testLibraryFile.cpp
@@ -109,7 +109,8 @@ static void testStoreLoadAst(const char* test,
   parsedMod->dump();
 
   // Use a LibraryWriter to create a library file
-  LibraryFileWriter writer(context, paths, libpath.str());
+  LibraryFileWriter writer(context, libpath.str());
+  writer.setSourcePaths(paths);
   writer.writeAllSections();
 
   // use a LibraryFile to read the serialized uAST


### PR DESCRIPTION
Continuation of the .dyno file separate compilation effort after PR #23862.

This PR moves the .dyno file generation to `codegen` and adds generated LLVM IR to the library file. So far, nothing is using this LLVM IR saved in the library file.

At present, the code generator is compiling everything and then filtering those things that need to go into the .dyno file module sections & copying these to a different module for storage there. This strategy is just for getting started here and in the longer term, it'd be better to adjust the code generator to use a more demand-driven approach, so that the prototypes for functions that are called in definitions we need will be generated, but prototypes for functions that aren't called won't end up in the module.

Likewise, it will require some adjustment to the code generator to reuse the generated LLVM IR for specific functions.

There are a number of other challenges we are facing with separate compilation that we will need to address. I am keeping a list of these in https://github.com/Cray/chapel-private/issues/5635 .

