### PR TITLE
Add multiple GPU, multiple Locale support for the Coral code

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -1867,11 +1867,10 @@ proc BlockImpl.dsiTargetLocales() const ref {
 }
 
 proc BlockImpl.chpl__locToLocIdx(loc: locale) {
-  var ret = (false, targetLocDom.first);
   for locIdx in targetLocDom do
     if (targetLocales[locIdx] == loc) then
-      ret = (true, locIdx);
-  return ret;
+      return (true, locIdx);
+  return (false, targetLocDom.first);
 }
 
 // Block subdomains are continuous

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -1867,10 +1867,11 @@ proc BlockImpl.dsiTargetLocales() const ref {
 }
 
 proc BlockImpl.chpl__locToLocIdx(loc: locale) {
+  var ret = (false, targetLocDom.first);
   for locIdx in targetLocDom do
     if (targetLocales[locIdx] == loc) then
-      return (true, locIdx);
-  return (false, targetLocDom.first);
+      ret = (true, locIdx);
+  return ret;
 }
 
 // Block subdomains are continuous

--- a/runtime/include/chpl-gpu.h
+++ b/runtime/include/chpl-gpu.h
@@ -42,12 +42,17 @@ extern bool chpl_gpu_use_stream_per_task;
 
 #ifdef HAS_GPU_LOCALE
 
+extern int chpl_nodeID;
+
 __attribute__ ((format (printf, 1, 2)))
 static inline void CHPL_GPU_DEBUG(const char *str, ...) {
   if (chpl_gpu_debug) {
     va_list args;
     va_start(args, str);
-    vfprintf(stdout, str, args);
+    const char* base_fmt = "(%3d:%3d) %s";
+    char fmt[128];
+    snprintf(fmt, 128, base_fmt, chpl_nodeID, chpl_task_getRequestedSubloc(), str);
+    vfprintf(stdout, fmt, args);
     va_end(args);
     fflush(stdout);
   }

--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -684,7 +684,7 @@ inline void chpl_gpu_launch_kernel_flat(const char* name,
 
   CHPL_GPU_DEBUG("Kernel launcher returning. (subloc %d, %p)\n"
                  "\tKernel: %s\n",
-                 chpl_task_getRequestedSubloc(), stream,
+                 chpl_task_getRequestedSubloc(), cfg->stream,
                  name);
 }
 

--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -682,8 +682,10 @@ inline void chpl_gpu_launch_kernel_flat(const char* name,
     CHPL_GPU_DEBUG("No kernel launched since num_threads is <=0\n");
   }
 
-  CHPL_GPU_DEBUG("Kernel launcher returning. (subloc %d)\n"
-                 "\tKernel: %s\n", cfg->dev, name);
+  CHPL_GPU_DEBUG("Kernel launcher returning. (subloc %d, %p)\n"
+                 "\tKernel: %s\n",
+                 chpl_task_getRequestedSubloc(), stream,
+                 name);
 }
 
 extern void chpl_gpu_comm_on_put(c_sublocid_t dst_subloc, void *addr,

--- a/test/gpu/native/studies/coral/coral.chpl
+++ b/test/gpu/native/studies/coral/coral.chpl
@@ -10,6 +10,7 @@ use Time;
 use IO;
 use AutoMath;
 use LinearAlgebra;
+import DSIUtil._computeChunkStartEnd;
 
 /* Command line arguments. */
 config const in_array : string;               /* name of array to read in */
@@ -20,27 +21,30 @@ config const dx : real;                      /* the resolution of the raster ima
 config const bigInput = false;
 config const inputSize = -1;
 config const report_times = true;
+config const report_detail_times = false;
 config const report_checksum = false;
 config const write_data = false;
 config const verbose_gpu = false;
+config const numWorkers = 1;
+config const numChunksPerWorker = 1;
+
+extern proc printf(s...);
 
 //var bs = 1;
 //var be = 5;
 
 proc convolve_and_calculate(Array: [] real(32), const in centerPoints : ?, locL : ?, locC : ?, locR : ?, ref Output: [] real(64), t: stopwatch) : [] {
 
-  param bs = 1;
-  param be = 5;
+  param bs = 0;
+  param be = 4;
 
-  var first_point = centerPoints.first[1];
-  var last_point = centerPoints.last[1];
+  var first_point = centerPoints.first[0];
+  var last_point = centerPoints.last[0];
 
-  writeln("Before gpu ", centerPoints.dim(0));
   if verbose_gpu then startVerboseGpu();
 
-  
   @assertOnGpu
-  foreach i in centerPoints.dim(0) {
+  foreach i in centerPoints.dim(1) {
     // Only these need to be real(64) in order to guarantee non-negative outputs
     var tmpLL : real(64) = 0;
     var tmpLC : real(64) = 0;
@@ -101,99 +105,131 @@ proc main(args: [] string) {
 
   var (LeftMask, CenterMask, RightMask, Mask_Size) = create_distance_mask(radius, dx, nx);
 
+  var x, y: int;
+  if inputSize != -1 {
+    x = inputSize;
+    y = inputSize;
+  }
+  else if bigInput {
+    x = 15243;
+    y = 10073;
+  }
+  else {
+    x = 1000;
+    y = 1000;
+  }
+  const ImageSpace = {0..#y, 0..#x};
+
+  var Array : [0..#5,0..#y,0..#x] real(32);
+
+  // Read in array
+  if inputSize == -1 {
+    var f = open(in_array, ioMode.r);
+    var r = f.reader(deserializer=new binaryDeserializer());
+    for i in 0..#5 {
+      for j in 0..#x {
+        for k in 0..#y {
+          var tmp : real;
+          r.readBinary(tmp);
+          Array[i,k,j] = tmp : real(32);
+        }
+      }
+    }
+    r.close();
+  }
+  else {
+    use Random;
+    fillRandom(Array, seed=13);
+    if write_data then writeln(Array);
+  }
+
+  // Create Block distribution of interior of PNG
+  const offset = nx+1; // maybe needs to be +1 to account for truncation?
+
+  /*
+
+     The code below can be used to use multiple locales. It is something
+     that existed in the original implementation, so we are keeping it for
+     now.
+
+     const myTargetLocales = reshape(Locales, {1..Locales.size, 1..1});
+     const D = Inner dmapped blockDist(Inner, targetLocales=myTargetLocales);
+
+  */
+  const Inner = ImageSpace.expand(-offset);
+  const myTargetLocales = reshape(Locales, {1..Locales.size, 1..1});
+  const D = blockDist.createDomain(Inner, targetLocales=myTargetLocales);
+  var OutputHost : [D] real(64); // D
+
   if report_times then
     writeln("Elapsed time at start of coforall loop: ", t.elapsed(), " seconds.");
 
   writeln("Starting coforall loop.");
 
   coforall loc in Locales do on loc {
+    var locOutput = D.localSubdomain();
+    var locInput = locOutput.expand(offset);
+    var locImage: [0..#5, locInput.dim(0), locInput.dim(1)] real(32);
 
+    locImage = Array[locImage.domain];
 
-    const radius = (sqrt(window_size) / 2) : int;
-    const nx = (radius / dx) : int(16);
-    writeln("Distance circle has a radius of ", nx, " points.");
-
-    var x, y: int;
-    if inputSize != -1 {
-      x = inputSize;
-      y = inputSize;
-    }
-    else if bigInput {
-      x = 15243;
-      y = 10073;
-    }
-    else {
-      x = 1000;
-      y = 1000;
-    }
-    const ImageSpace = {0..#y, 0..#x};
-
-
-    var Array : [1..5,1..y,1..x] real(32);
-
-    // Read in array
-    if inputSize == -1 {
-      var f = open(in_array, ioMode.r);
-      var r = f.reader(deserializer=new binaryDeserializer(), locking=false);
-      for i in 1..5 {
-        for j in 1..x {
-          for k in 1..y {
-            var tmp : real;
-            r.readBinary(tmp);
-            Array[i,k,j] = tmp : real(32);
-          }
-        }
-      }
-      r.close();
-    }
-    else {
-      use Random;
-      fillRandom(Array, seed=13);
-      if write_data then writeln(Array);
-    }
-
-    // Create Block distribution of interior of PNG
-    const offset = nx+1; // maybe needs to be +1 to account for truncation?
-
-    /*
-
-    The code below can be used to use multiple locales. It is something
-    that existed in the original implementation, so we are keeping it for
-    now.
-     
-    const myTargetLocales = reshape(Locales, {1..Locales.size, 1..1});
-    const D = Inner dmapped blockDist(Inner, targetLocales=myTargetLocales);
-
-    */
-    const Inner = ImageSpace.expand(-offset);
-    var OutputHost : [Inner] real(64); // D
-
-    on here.gpus[0] {
-
-      var Output: [Inner] real(64); // D
-      const locArrayDomain = Array.domain;
-      const locArray : [locArrayDomain] Array.eltType = Array;
-
+    coforall (gpuId, gpu) in zip(here.gpus.domain, here.gpus) do on gpu {
       // Create distance mask
       const locLeftMaskDomain = LeftMask.domain;
       const locCenterMaskDomain = CenterMask.domain;
       const locRightMaskDomain = RightMask.domain;
 
-      if report_times then
-        writeln("Starting convolution at ", t.elapsed(), ".");
+      coforall taskId in 0..#numWorkers {
+        const workerId = gpuId*numWorkers + taskId;
 
-      var t2 : stopwatch;
-      t2.start();
-      convolve_and_calculate(locArray, Inner, locLeftMaskDomain, locCenterMaskDomain, locRightMaskDomain, Output, t);
-      t2.stop();
+        var commTimer : stopwatch;
+        var convolveTimer : stopwatch;
 
-      if report_times then writeln("Convolve time: ", t2.elapsed());
+        for chunkId in 0..#numChunksPerWorker {
+          const globalChunkId = workerId*numChunksPerWorker + chunkId;
 
-      if report_checksum {
-        on loc {
-          OutputHost = Output;
-          writeln("Checksum: ", + reduce OutputHost);
-          if write_data then writeln(OutputHost);
+          var (outRowStart, outRowEnd) =
+             _computeChunkStartEnd(locOutput.dim(0).size,
+                                   loc.gpus.size*numWorkers*numChunksPerWorker,
+                                   globalChunkId+1);
+          // offset for 1-based support function and start offset
+          outRowStart += locOutput.dim(0).low-1;
+          outRowEnd += locOutput.dim(0).low-1;
+
+          const MyInner = {outRowStart..outRowEnd, locOutput.dim(1)};
+
+          var OutputGpu: [MyInner] real(64) = noinit; // D
+
+
+          const MyInnerExpanded = MyInner.expand(offset);
+
+          const MyArrayDom = {0..#5, MyInnerExpanded.dim(0),
+                              MyInnerExpanded.dim(1)};
+
+          var locArray : [MyArrayDom] Array.eltType = noinit;
+
+          commTimer.start();
+          locArray = locImage[MyArrayDom];
+          commTimer.stop();
+          if write_data then writeln(locArray);
+
+          convolveTimer.start();
+          convolve_and_calculate(locArray, MyInner, locLeftMaskDomain,
+              locCenterMaskDomain, locRightMaskDomain,
+              OutputGpu, t);
+          convolveTimer.stop();
+
+
+          commTimer.start();
+          OutputHost[MyInner] = OutputGpu;
+          commTimer.stop();
+        }
+
+        if report_detail_times {
+          writef("(Locale %i, GPU %i, Task %i) Convolve time: %r\n", here.id,
+                 gpuId, taskId, convolveTimer.elapsed());
+          writef("(Locale %i, GPU %i, Task %i) Comm     time: %r\n", here.id,
+                 gpuId, taskId, commTimer.elapsed());
         }
       }
     }
@@ -201,5 +237,10 @@ proc main(args: [] string) {
 
   if report_times then
     writeln("Elapsed time to finish coforall loop: ", t.elapsed(), " seconds.");
+
+  if report_checksum {
+      writeln("Checksum: ", + reduce OutputHost);
+      if write_data then writeln(OutputHost);
+  }
 
 }

--- a/test/gpu/native/studies/coral/coral.good
+++ b/test/gpu/native/studies/coral/coral.good
@@ -1,6 +1,4 @@
 Distance circle has a radius of 2 points.
 inputSize = 200
 Starting coforall loop.
-Distance circle has a radius of 2 points.
-Before gpu 3..196
-Checksum: 2.38008e+06
+Checksum: 2.3798e+06


### PR DESCRIPTION
This PR modifies the `test/gpu/native/studies/coral.chpl` test to support multiple locales+GPUs+tasks.

The input is generated on `Locales[0]` and then chunked up to locales before GPU operation begins. Eventually we want to have each locale read their own portion of the input file and write their outputs. So, this is a temporary solution for having reproducible output.

This PR also changes the iteration order of the GPU kernel for better memory coalescing. This results in changes in the checksum. I am fairly confident that this is due to the order of floating point operations and the changes at individual elements are less than half a percent for cases that I tested.

TODO: this also has a workaround for https://github.com/chapel-lang/chapel/issues/23574 that ideally should be removed when the compiler issue is fixed.

Test:
- [x] multiple locales+gpu+tasks on nvidia
- [x] multiple locales+gpu+tasks on amd