### PR TITLE
Turn chplcheck unused formal rule off by default

### DIFF
--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -157,7 +157,7 @@ def register_rules(driver):
                     prev = blockchild
                     break
 
-    @driver.advanced_rule
+    @driver.advanced_rule(default=False)
     def UnusedFormal(context, root):
         formals = dict()
         uses = set()


### PR DESCRIPTION
Turns the `UnusedFormal` rule to be off by default due to its experimental nature.

Tested locally

[Reviewed by @DanilaFe]