### PR TITLE
Dyno: implement 'transmute' primitives between reals and uints.

### DIFF
--- a/frontend/include/chpl/types/Param.h
+++ b/frontend/include/chpl/types/Param.h
@@ -214,6 +214,8 @@ class Param {
 /// \cond DO_NOT_DOCUMENT
 #define PARAM_NODE(NAME, VALTYPE) \
   class NAME : public Param { \
+   public: \
+    using ValueType = VALTYPE; \
    private: \
     VALTYPE value_; \
     explicit NAME(VALTYPE value) : Param(paramtags::NAME), value_(value) { } \


### PR DESCRIPTION
'transmutation' in this case means literally taking the bits of a real number and interpreting them as bits of an unsigned integer, and vise versa. Because there are four related primitives that do this, I implemented them all using a templated function that accepts the `Param` containers and the (C++) types to be converted.

I didn't find a way to generate params of types other than `real(64)` without modifying compiler code, so I am only testing that case. However, since the same code is used for all four primitives, I have a high confidence that it works.

Reviewed by @dlongnecke-cray -- thanks!

## Testing
- [x] dyno tests
- [x] paratest