### PR TITLE
Dyno: Add the "resolves" primitive

### DIFF
--- a/frontend/lib/resolution/Resolver.h
+++ b/frontend/lib/resolution/Resolver.h
@@ -415,6 +415,10 @@ struct Resolver {
   // resolve a special op call such as tuple unpack assign
   bool resolveSpecialOpCall(const uast::Call* call);
 
+  // resolve a special primitive call such as 'resolves', which has its
+  // own logic for traversing actuals etc.
+  bool resolveSpecialPrimitiveCall(const uast::Call* call);
+
   // resolve a keyword call like index(D)
   bool resolveSpecialKeywordCall(const uast::Call* call);
 

--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -991,95 +991,70 @@ CanPassResult CanPassResult::canPass(Context* context,
   return fail(FAIL_FORMAL_OTHER);
 }
 
-// When trying to combine two kinds, you can't just pick one.
-// For instance, if any type in the list is a value, the result
-// should be a value, and if any type in the list is const, the
-// result should be const. Thus, combining `const ref` and `var`
-// should result in `const var`.
-//
-// This class is used to describe the "mixing rules" of various kinds.
-// To this end, it breaks them down into their properties (const-ness,
-// ref-ness, etc) each of which are processed independently from
-// the others.
-class KindProperties {
- private:
-  bool isConst = false;
-  bool isRef = false;
-  bool isType = false;
-  bool isParam = false;
-  bool isValid = false;
+void KindProperties::invalidate() {
+  isRef = isConst = isType = isParam = isValid = false;
+}
 
-  KindProperties() {}
+KindProperties KindProperties::fromKind(QualifiedType::Kind kind) {
+  if (kind == QualifiedType::TYPE)
+    return KindProperties(false, false, true, false);
+  if (kind == QualifiedType::PARAM)
+    // Mark params as const to cover the case in which a
+    // param decays to a const var.
+    return KindProperties(true, false, false, true);
+  auto isConst = isConstQualifier(kind);
+  auto isRef = isRefQualifier(kind);
+  return KindProperties(isConst, isRef, false, false);
+}
 
-  KindProperties(bool isConst, bool isRef, bool isType,
-                 bool isParam)
-    : isConst(isConst), isRef(isRef), isType(isType),
-      isParam(isParam), isValid(true) {}
+void KindProperties::setRef(bool isRef) {
+  this->isRef = isRef;
+}
 
- public:
-  static KindProperties fromKind(QualifiedType::Kind kind) {
-    if (kind == QualifiedType::TYPE)
-      return KindProperties(false, false, true, false);
-    if (kind == QualifiedType::PARAM)
-      // Mark params as const to cover the case in which a
-      // param decays to a const var.
-      return KindProperties(true, false, false, true);
-    auto isConst = isConstQualifier(kind);
-    auto isRef = isRefQualifier(kind);
-    return KindProperties(isConst, isRef, false, false);
+void KindProperties::setParam(bool isParam) {
+  this->isParam = isParam;
+}
+
+void KindProperties::combineWith(const KindProperties& other) {
+  if (!isValid) return;
+  if (!other.isValid || isType != other.isType) {
+    // Can't mix types and non-types.
+    invalidate();
+    return;
   }
+  isConst = isConst || other.isConst;
+  isRef = isRef && other.isRef;
+  isParam = isParam && other.isParam;
+}
 
-  void invalidate() {
-    isRef = isConst = isType = isParam = isValid = false;
+void KindProperties::strictCombineWith(const KindProperties& other) {
+  if (!isValid) return;
+  if (!other.isValid || isType != other.isType) {
+    // Can't mix types and non-types.
+    invalidate();
+    return;
   }
-
-  void setParam(bool isParam) {
-    this->isParam = isParam;
+  if (isParam && !other.isParam) {
+    // If a param is required, can't return a non-param.
+    invalidate();
+    return;
   }
+  // Ensuring that everything can actually be made
+  // into a reference and const will happen later.
+  // leave isRef and isConst as specified.
+  // We could do some checking now, but that might be a bit premature.
+}
 
-  void combineWith(const KindProperties& other) {
-    if (!isValid) return;
-    if (!other.isValid || isType != other.isType) {
-      // Can't mix types and non-types.
-      invalidate();
-      return;
-    }
-    isConst = isConst || other.isConst;
-    isRef = isRef && other.isRef;
-    isParam = isParam && other.isParam;
+QualifiedType::Kind KindProperties::toKind() const {
+  if (!isValid) return QualifiedType::UNKNOWN;
+  if (isType) return QualifiedType::TYPE;
+  if (isParam) return QualifiedType::PARAM;
+  if (isConst) {
+    return isRef ? QualifiedType::CONST_REF : QualifiedType::CONST_VAR ;
+  } else {
+    return isRef ? QualifiedType::REF : QualifiedType::VAR ;
   }
-
-  void strictCombineWith(const KindProperties& other) {
-    if (!isValid) return;
-    if (!other.isValid || isType != other.isType) {
-      // Can't mix types and non-types.
-      invalidate();
-      return;
-    }
-    if (isParam && !other.isParam) {
-      // If a param is required, can't return a non-param.
-      invalidate();
-      return;
-    }
-    // Ensuring that everything can actually be made
-    // into a reference and const will happen later.
-    // leave isRef and isConst as specified.
-    // We could do some checking now, but that might be a bit premature.
-  }
-
-  QualifiedType::Kind toKind() const {
-    if (!isValid) return QualifiedType::UNKNOWN;
-    if (isType) return QualifiedType::TYPE;
-    if (isParam) return QualifiedType::PARAM;
-    if (isConst) {
-      return isRef ? QualifiedType::CONST_REF : QualifiedType::CONST_VAR ;
-    } else {
-      return isRef ? QualifiedType::REF : QualifiedType::VAR ;
-    }
-  }
-
-  bool valid() const { return isValid; }
-};
+}
 
 static optional<QualifiedType>
 findByPassing(Context* context,

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -325,6 +325,11 @@ static QualifiedType primTypeof(Context* context, PrimitiveTag prim, const CallI
 }
 
 static QualifiedType staticFieldType(Context* context, const CallInfo& ci) {
+  // Note: this is slightly different semantically from the primitive in
+  // production. In production owned(X) is a type of its own (aliasing _owned(X)),
+  // so it would have the fields of _owned accessed by the primitive. Meanwhile,
+  // in Dyno, an owned(X) will have the fields of X accessed by this primitive.
+
   if (ci.numActuals() != 2) return QualifiedType();
 
   auto typeActualQt = ci.actual(0).type();

--- a/frontend/lib/types/TupleType.cpp
+++ b/frontend/lib/types/TupleType.cpp
@@ -223,9 +223,16 @@ const TupleType* TupleType::toValueTuple(Context* context) const {
   bool allValue = true;
   int n = numElements();
   for (int i = 0; i < n; i++) {
-    auto kind = elementType(i).kind();
+    const auto& eltType = elementType(i);
+    auto kind = eltType.kind();
     if (kind != QualifiedType::VAR)
       allValue = false;
+
+    if (eltType.type() && eltType.type()->isTupleType()) {
+      // Conservatively throw off 'allValue' because the nested tuple might
+      // have a reference inside it.
+      allValue = false;
+    }
   }
 
   if (numElements() == 0 || allValue)
@@ -234,7 +241,11 @@ const TupleType* TupleType::toValueTuple(Context* context) const {
   // Otherwise, compute a new value tuple
   std::vector<const Type*> eltTypes;
   for (int i = 0; i < n; i++) {
-    eltTypes.push_back(elementType(i).type());
+    auto eltType = elementType(i).type();
+    if (auto eltTup = eltType->toTupleType()) {
+      eltType = eltTup->toValueTuple(context);
+    }
+    eltTypes.push_back(eltType);
   }
 
   return getValueTuple(context, std::move(eltTypes));
@@ -246,10 +257,17 @@ const TupleType* TupleType::toReferentialTuple(Context* context) const {
   bool allRef = true;
   int n = numElements();
   for (int i = 0; i < n; i++) {
-    auto kind = elementType(i).kind();
+    const auto& eltType = elementType(i);
+    auto kind = eltType.kind();
     if (kind != QualifiedType::CONST_REF &&
         kind != QualifiedType::REF)
       allRef = false;
+
+    if (eltType.type() && eltType.type()->isTupleType()) {
+      // Conservatively throw off 'allRef' because the nested tuple might
+      // have a reference inside it.
+      allRef = false;
+    }
   }
 
   if (numElements() == 0 || allRef)
@@ -258,7 +276,11 @@ const TupleType* TupleType::toReferentialTuple(Context* context) const {
   // Otherwise, compute a new referential tuple
   std::vector<const Type*> eltTypes;
   for (int i = 0; i < n; i++) {
-    eltTypes.push_back(elementType(i).type());
+    auto eltType = elementType(i).type();
+    if (auto eltTup = eltType->toTupleType()) {
+      eltType = eltTup->toReferentialTuple(context);
+    }
+    eltTypes.push_back(eltType);
   }
 
   return getReferentialTuple(context, std::move(eltTypes));

--- a/frontend/test/resolution/testReflection.cpp
+++ b/frontend/test/resolution/testReflection.cpp
@@ -310,6 +310,40 @@ static void test8() {
   ensureParamBool(variables.at("r8"), false);
 }
 
+static void test9() {
+  Context context;
+  // Make sure no errors make it to the user, even though we will get errors.
+  ErrorGuard guard(&context);
+  auto variables = resolveTypesOfVariables(&context,
+      R"""(
+      record R {
+          proc f() {}
+          proc g(x: int) {}
+      }
+
+      proc h(x: string) {}
+
+      operator +(lhs: int, rhs: int) do return __primitive("+", lhs, rhs);
+
+      var r: R;
+
+      param r1 = __primitive("resolves", r.f());
+      param r2 = __primitive("resolves", r.g(42));
+      param r3 = __primitive("resolves", r.g("hello"));
+      param r4 = __primitive("resolves", h(42));
+      param r5 = __primitive("resolves", h("hello"));
+      param r6 = __primitive("resolves", 1+1);
+      param r7 = __primitive("resolves", 1+"hello");
+      )""", { "r1", "r2", "r3", "r4", "r5", "r6", "r7" });
+  ensureParamBool(variables.at("r1"), true);
+  ensureParamBool(variables.at("r2"), true);
+  ensureParamBool(variables.at("r3"), false);
+  ensureParamBool(variables.at("r4"), false);
+  ensureParamBool(variables.at("r5"), true);
+  ensureParamBool(variables.at("r6"), true);
+  ensureParamBool(variables.at("r7"), false);
+}
+
 int main() {
   test1();
   test2();
@@ -319,5 +353,6 @@ int main() {
   test6();
   test7();
   test8();
+  test9();
   return 0;
 }

--- a/frontend/test/resolution/testResolve.cpp
+++ b/frontend/test/resolution/testResolve.cpp
@@ -671,6 +671,41 @@ static void test15() {
   assert(guard.realizeErrors() == 1);
 }
 
+static void test16() {
+  Context context;
+  // Make sure no errors make it to the user, even though we will get errors.
+  ErrorGuard guard(&context);
+  auto variables = resolveTypesOfVariablesInit(&context,
+      R"""(
+      record Concrete {
+          var x: int;
+          var y: string;
+          var z: (int, string);
+      };
+
+      record Generic {
+          var x;
+          var y;
+          var z;
+      }
+
+      var conc: Concrete;
+      var inst: Generic(int, string, (int, string));
+
+      param r1 = __primitive("static field type", conc, "x") == int;
+      param r2 = __primitive("static field type", conc, "y") == string;
+      param r3 = __primitive("static field type", conc, "z") == (int, string);
+      param r4 = __primitive("static field type", inst, "x") == int;
+      param r5 = __primitive("static field type", inst, "y") == string;
+      param r6 = __primitive("static field type", inst, "z") == (int, string);
+      )""", { "r1", "r2", "r3", "r4", "r5", "r6"});
+
+  for (auto& pair : variables) {
+    pair.second.isParamTrue();
+  }
+
+}
+
 int main() {
   test1();
   test2();
@@ -686,6 +721,7 @@ int main() {
   test12();
   test14();
   test15();
+  test16();
 
   return 0;
 }

--- a/frontend/test/test-resolution.cpp
+++ b/frontend/test/test-resolution.cpp
@@ -218,3 +218,20 @@ resolveTypesOfVariables(Context* context,
   }
   return toReturn;
 }
+
+std::unordered_map<std::string, QualifiedType>
+resolveTypesOfVariablesInit(Context* context,
+                        std::string program,
+                        const std::vector<std::string>& variables) {
+  auto m = parseModule(context, std::move(program));
+  auto& rr = resolveModule(context, m->id());
+
+  std::unordered_map<std::string, QualifiedType> toReturn;
+  for (auto& variable : variables) {
+    auto varAst = findVariable(m, variable.c_str());
+    assert(varAst != nullptr);
+    assert(varAst->initExpression());
+    toReturn[variable] = rr.byAst(varAst->initExpression()).type();
+  }
+  return toReturn;
+}

--- a/frontend/test/test-resolution.h
+++ b/frontend/test/test-resolution.h
@@ -67,4 +67,7 @@ const Variable* findVariable(const ModuleVec& vec, const char* name);
 std::unordered_map<std::string, QualifiedType>
 resolveTypesOfVariables(Context* context, std::string program, const std::vector<std::string>& variables);
 
+std::unordered_map<std::string, QualifiedType>
+resolveTypesOfVariablesInit(Context* context, std::string program, const std::vector<std::string>& variables);
+
 #endif


### PR DESCRIPTION
The `resolves` primitive accepts an arbitrary expression and attempts to resolve it. If it resolves, the primitive returns `true`; if it does not resolve the primitive returns `false`. 

This PR adds special treatment for `resolves` because unlike most other primitives, its behavior cant' be described in terms of already-resolved actual types: in fact, the way that it resolves actuals is unusual (it hides and ignores errors). Thus, this PR adds a new `resolveSpecialPrimCall` method to the `Resolver`, and skips "usual" actual handling for `PRIM_RESOLVES`. 

Reviewed by @dlongnecke-cray -- thanks!

## Testing
- [x] paratest
- [x] dyno tests