### PR TITLE
Dyno: add version primitives

### DIFF
--- a/frontend/lib/resolution/Resolver.h
+++ b/frontend/lib/resolution/Resolver.h
@@ -415,6 +415,10 @@ struct Resolver {
   // resolve a special op call such as tuple unpack assign
   bool resolveSpecialOpCall(const uast::Call* call);
 
+  // resolve a special primitive call such as 'resolves', which has its
+  // own logic for traversing actuals etc.
+  bool resolveSpecialPrimitiveCall(const uast::Call* call);
+
   // resolve a keyword call like index(D)
   bool resolveSpecialKeywordCall(const uast::Call* call);
 

--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -991,95 +991,70 @@ CanPassResult CanPassResult::canPass(Context* context,
   return fail(FAIL_FORMAL_OTHER);
 }
 
-// When trying to combine two kinds, you can't just pick one.
-// For instance, if any type in the list is a value, the result
-// should be a value, and if any type in the list is const, the
-// result should be const. Thus, combining `const ref` and `var`
-// should result in `const var`.
-//
-// This class is used to describe the "mixing rules" of various kinds.
-// To this end, it breaks them down into their properties (const-ness,
-// ref-ness, etc) each of which are processed independently from
-// the others.
-class KindProperties {
- private:
-  bool isConst = false;
-  bool isRef = false;
-  bool isType = false;
-  bool isParam = false;
-  bool isValid = false;
+void KindProperties::invalidate() {
+  isRef = isConst = isType = isParam = isValid = false;
+}
 
-  KindProperties() {}
+KindProperties KindProperties::fromKind(QualifiedType::Kind kind) {
+  if (kind == QualifiedType::TYPE)
+    return KindProperties(false, false, true, false);
+  if (kind == QualifiedType::PARAM)
+    // Mark params as const to cover the case in which a
+    // param decays to a const var.
+    return KindProperties(true, false, false, true);
+  auto isConst = isConstQualifier(kind);
+  auto isRef = isRefQualifier(kind);
+  return KindProperties(isConst, isRef, false, false);
+}
 
-  KindProperties(bool isConst, bool isRef, bool isType,
-                 bool isParam)
-    : isConst(isConst), isRef(isRef), isType(isType),
-      isParam(isParam), isValid(true) {}
+void KindProperties::setRef(bool isRef) {
+  this->isRef = isRef;
+}
 
- public:
-  static KindProperties fromKind(QualifiedType::Kind kind) {
-    if (kind == QualifiedType::TYPE)
-      return KindProperties(false, false, true, false);
-    if (kind == QualifiedType::PARAM)
-      // Mark params as const to cover the case in which a
-      // param decays to a const var.
-      return KindProperties(true, false, false, true);
-    auto isConst = isConstQualifier(kind);
-    auto isRef = isRefQualifier(kind);
-    return KindProperties(isConst, isRef, false, false);
+void KindProperties::setParam(bool isParam) {
+  this->isParam = isParam;
+}
+
+void KindProperties::combineWith(const KindProperties& other) {
+  if (!isValid) return;
+  if (!other.isValid || isType != other.isType) {
+    // Can't mix types and non-types.
+    invalidate();
+    return;
   }
+  isConst = isConst || other.isConst;
+  isRef = isRef && other.isRef;
+  isParam = isParam && other.isParam;
+}
 
-  void invalidate() {
-    isRef = isConst = isType = isParam = isValid = false;
+void KindProperties::strictCombineWith(const KindProperties& other) {
+  if (!isValid) return;
+  if (!other.isValid || isType != other.isType) {
+    // Can't mix types and non-types.
+    invalidate();
+    return;
   }
-
-  void setParam(bool isParam) {
-    this->isParam = isParam;
+  if (isParam && !other.isParam) {
+    // If a param is required, can't return a non-param.
+    invalidate();
+    return;
   }
+  // Ensuring that everything can actually be made
+  // into a reference and const will happen later.
+  // leave isRef and isConst as specified.
+  // We could do some checking now, but that might be a bit premature.
+}
 
-  void combineWith(const KindProperties& other) {
-    if (!isValid) return;
-    if (!other.isValid || isType != other.isType) {
-      // Can't mix types and non-types.
-      invalidate();
-      return;
-    }
-    isConst = isConst || other.isConst;
-    isRef = isRef && other.isRef;
-    isParam = isParam && other.isParam;
+QualifiedType::Kind KindProperties::toKind() const {
+  if (!isValid) return QualifiedType::UNKNOWN;
+  if (isType) return QualifiedType::TYPE;
+  if (isParam) return QualifiedType::PARAM;
+  if (isConst) {
+    return isRef ? QualifiedType::CONST_REF : QualifiedType::CONST_VAR ;
+  } else {
+    return isRef ? QualifiedType::REF : QualifiedType::VAR ;
   }
-
-  void strictCombineWith(const KindProperties& other) {
-    if (!isValid) return;
-    if (!other.isValid || isType != other.isType) {
-      // Can't mix types and non-types.
-      invalidate();
-      return;
-    }
-    if (isParam && !other.isParam) {
-      // If a param is required, can't return a non-param.
-      invalidate();
-      return;
-    }
-    // Ensuring that everything can actually be made
-    // into a reference and const will happen later.
-    // leave isRef and isConst as specified.
-    // We could do some checking now, but that might be a bit premature.
-  }
-
-  QualifiedType::Kind toKind() const {
-    if (!isValid) return QualifiedType::UNKNOWN;
-    if (isType) return QualifiedType::TYPE;
-    if (isParam) return QualifiedType::PARAM;
-    if (isConst) {
-      return isRef ? QualifiedType::CONST_REF : QualifiedType::CONST_VAR ;
-    } else {
-      return isRef ? QualifiedType::REF : QualifiedType::VAR ;
-    }
-  }
-
-  bool valid() const { return isValid; }
-};
+}
 
 static optional<QualifiedType>
 findByPassing(Context* context,

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -24,6 +24,7 @@
 #include "chpl/uast/all-uast.h"
 #include "chpl/framework/ErrorBase.h"
 #include "chpl/resolution/can-pass.h"
+#include "chpl/util/version-info.h"
 
 namespace chpl {
 namespace resolution {
@@ -1115,10 +1116,26 @@ CallResolutionResult resolvePrimCall(Context* context,
     case PRIM_COPIES_NO_ALIAS_SET:
     case PRIM_OPTIMIZATION_INFO:
     case PRIM_GATHER_TESTS:
+      CHPL_UNIMPL("misc primitives");
+      break;
+
     case PRIM_VERSION_MAJOR:
+      type = QualifiedType(QualifiedType::PARAM, IntType::get(context, 0),
+                           IntParam::get(context, getMajorVersion()));
+      break;
     case PRIM_VERSION_MINOR:
+      type = QualifiedType(QualifiedType::PARAM, IntType::get(context, 0),
+                           IntParam::get(context, getMinorVersion()));
+      break;
     case PRIM_VERSION_UPDATE:
+      type = QualifiedType(QualifiedType::PARAM, IntType::get(context, 0),
+                           IntParam::get(context, getUpdateVersion()));
+      break;
     case PRIM_VERSION_SHA:
+      type = QualifiedType(QualifiedType::PARAM, RecordType::getStringType(context),
+                           StringParam::get(context, UniqueString::get(context, getCommitHash())));
+      break;
+
     case PRIM_REF_DESERIALIZE:
     case PRIM_UNKNOWN:
     case NUM_KNOWN_PRIMS:

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -1123,18 +1123,27 @@ CallResolutionResult resolvePrimCall(Context* context,
       type = QualifiedType(QualifiedType::PARAM, IntType::get(context, 0),
                            IntParam::get(context, getMajorVersion()));
       break;
+
     case PRIM_VERSION_MINOR:
       type = QualifiedType(QualifiedType::PARAM, IntType::get(context, 0),
                            IntParam::get(context, getMinorVersion()));
       break;
+
     case PRIM_VERSION_UPDATE:
       type = QualifiedType(QualifiedType::PARAM, IntType::get(context, 0),
                            IntParam::get(context, getUpdateVersion()));
       break;
-    case PRIM_VERSION_SHA:
+
+    case PRIM_VERSION_SHA: {
+      UniqueString versionHash;
+      if (!getIsOfficialRelease()) {
+        versionHash = UniqueString::get(context, getCommitHash());
+      }
+
       type = QualifiedType(QualifiedType::PARAM, RecordType::getStringType(context),
-                           StringParam::get(context, UniqueString::get(context, getCommitHash())));
+                           StringParam::get(context, versionHash));
       break;
+    }
 
     case PRIM_REF_DESERIALIZE:
     case PRIM_UNKNOWN:

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -325,6 +325,11 @@ static QualifiedType primTypeof(Context* context, PrimitiveTag prim, const CallI
 }
 
 static QualifiedType staticFieldType(Context* context, const CallInfo& ci) {
+  // Note: this is slightly different semantically from the primitive in
+  // production. In production owned(X) is a type of its own (aliasing _owned(X)),
+  // so it would have the fields of _owned accessed by the primitive. Meanwhile,
+  // in Dyno, an owned(X) will have the fields of X accessed by this primitive.
+
   if (ci.numActuals() != 2) return QualifiedType();
 
   auto typeActualQt = ci.actual(0).type();

--- a/frontend/lib/types/TupleType.cpp
+++ b/frontend/lib/types/TupleType.cpp
@@ -223,9 +223,16 @@ const TupleType* TupleType::toValueTuple(Context* context) const {
   bool allValue = true;
   int n = numElements();
   for (int i = 0; i < n; i++) {
-    auto kind = elementType(i).kind();
+    const auto& eltType = elementType(i);
+    auto kind = eltType.kind();
     if (kind != QualifiedType::VAR)
       allValue = false;
+
+    if (eltType.type() && eltType.type()->isTupleType()) {
+      // Conservatively throw off 'allValue' because the nested tuple might
+      // have a reference inside it.
+      allValue = false;
+    }
   }
 
   if (numElements() == 0 || allValue)
@@ -234,7 +241,11 @@ const TupleType* TupleType::toValueTuple(Context* context) const {
   // Otherwise, compute a new value tuple
   std::vector<const Type*> eltTypes;
   for (int i = 0; i < n; i++) {
-    eltTypes.push_back(elementType(i).type());
+    auto eltType = elementType(i).type();
+    if (auto eltTup = eltType->toTupleType()) {
+      eltType = eltTup->toValueTuple(context);
+    }
+    eltTypes.push_back(eltType);
   }
 
   return getValueTuple(context, std::move(eltTypes));
@@ -246,10 +257,17 @@ const TupleType* TupleType::toReferentialTuple(Context* context) const {
   bool allRef = true;
   int n = numElements();
   for (int i = 0; i < n; i++) {
-    auto kind = elementType(i).kind();
+    const auto& eltType = elementType(i);
+    auto kind = eltType.kind();
     if (kind != QualifiedType::CONST_REF &&
         kind != QualifiedType::REF)
       allRef = false;
+
+    if (eltType.type() && eltType.type()->isTupleType()) {
+      // Conservatively throw off 'allRef' because the nested tuple might
+      // have a reference inside it.
+      allRef = false;
+    }
   }
 
   if (numElements() == 0 || allRef)
@@ -258,7 +276,11 @@ const TupleType* TupleType::toReferentialTuple(Context* context) const {
   // Otherwise, compute a new referential tuple
   std::vector<const Type*> eltTypes;
   for (int i = 0; i < n; i++) {
-    eltTypes.push_back(elementType(i).type());
+    auto eltType = elementType(i).type();
+    if (auto eltTup = eltType->toTupleType()) {
+      eltType = eltTup->toReferentialTuple(context);
+    }
+    eltTypes.push_back(eltType);
   }
 
   return getReferentialTuple(context, std::move(eltTypes));

--- a/frontend/test/resolution/testReflection.cpp
+++ b/frontend/test/resolution/testReflection.cpp
@@ -28,38 +28,6 @@
 #include "chpl/uast/Record.h"
 #include "chpl/uast/Variable.h"
 
-static void ensureParamInt(const QualifiedType& type, int64_t expectedValue) {
-  assert(type.kind() == QualifiedType::PARAM);
-  assert(type.type() != nullptr);
-  assert(type.type()->isIntType());
-  assert(type.param() != nullptr);
-  assert(type.param()->isIntParam());
-  assert(type.param()->toIntParam()->value() == expectedValue);
-}
-
-static void ensureParamBool(const QualifiedType& type, bool expectedValue) {
-  assert(type.kind() == QualifiedType::PARAM);
-  assert(type.type() != nullptr);
-  assert(type.type()->isBoolType());
-  assert(type.param() != nullptr);
-  assert(type.param()->isBoolParam());
-  assert(type.param()->toBoolParam()->value() == expectedValue);
-}
-
-static void ensureParamString(const QualifiedType& type, const std::string& expectedValue) {
-  assert(type.kind() == QualifiedType::PARAM);
-  assert(type.type() != nullptr);
-  assert(type.type()->isStringType());
-  assert(type.param() != nullptr);
-  assert(type.param()->isStringParam());
-  assert(type.param()->toStringParam()->value() == expectedValue);
-}
-
-static void ensureErroneousType(const QualifiedType& type) {
-  assert(type.type() != nullptr);
-  assert(type.type()->isErroneousType());
-}
-
 // test num fields and field num to name
 static void test1() {
   Context context;

--- a/frontend/test/resolution/testReflection.cpp
+++ b/frontend/test/resolution/testReflection.cpp
@@ -310,6 +310,40 @@ static void test8() {
   ensureParamBool(variables.at("r8"), false);
 }
 
+static void test9() {
+  Context context;
+  // Make sure no errors make it to the user, even though we will get errors.
+  ErrorGuard guard(&context);
+  auto variables = resolveTypesOfVariables(&context,
+      R"""(
+      record R {
+          proc f() {}
+          proc g(x: int) {}
+      }
+
+      proc h(x: string) {}
+
+      operator +(lhs: int, rhs: int) do return __primitive("+", lhs, rhs);
+
+      var r: R;
+
+      param r1 = __primitive("resolves", r.f());
+      param r2 = __primitive("resolves", r.g(42));
+      param r3 = __primitive("resolves", r.g("hello"));
+      param r4 = __primitive("resolves", h(42));
+      param r5 = __primitive("resolves", h("hello"));
+      param r6 = __primitive("resolves", 1+1);
+      param r7 = __primitive("resolves", 1+"hello");
+      )""", { "r1", "r2", "r3", "r4", "r5", "r6", "r7" });
+  ensureParamBool(variables.at("r1"), true);
+  ensureParamBool(variables.at("r2"), true);
+  ensureParamBool(variables.at("r3"), false);
+  ensureParamBool(variables.at("r4"), false);
+  ensureParamBool(variables.at("r5"), true);
+  ensureParamBool(variables.at("r6"), true);
+  ensureParamBool(variables.at("r7"), false);
+}
+
 int main() {
   test1();
   test2();
@@ -319,5 +353,6 @@ int main() {
   test6();
   test7();
   test8();
+  test9();
   return 0;
 }

--- a/frontend/test/resolution/testResolve.cpp
+++ b/frontend/test/resolution/testResolve.cpp
@@ -671,6 +671,41 @@ static void test15() {
   assert(guard.realizeErrors() == 1);
 }
 
+static void test16() {
+  Context context;
+  // Make sure no errors make it to the user, even though we will get errors.
+  ErrorGuard guard(&context);
+  auto variables = resolveTypesOfVariablesInit(&context,
+      R"""(
+      record Concrete {
+          var x: int;
+          var y: string;
+          var z: (int, string);
+      };
+
+      record Generic {
+          var x;
+          var y;
+          var z;
+      }
+
+      var conc: Concrete;
+      var inst: Generic(int, string, (int, string));
+
+      param r1 = __primitive("static field type", conc, "x") == int;
+      param r2 = __primitive("static field type", conc, "y") == string;
+      param r3 = __primitive("static field type", conc, "z") == (int, string);
+      param r4 = __primitive("static field type", inst, "x") == int;
+      param r5 = __primitive("static field type", inst, "y") == string;
+      param r6 = __primitive("static field type", inst, "z") == (int, string);
+      )""", { "r1", "r2", "r3", "r4", "r5", "r6"});
+
+  for (auto& pair : variables) {
+    pair.second.isParamTrue();
+  }
+
+}
+
 int main() {
   test1();
   test2();
@@ -686,6 +721,7 @@ int main() {
   test12();
   test14();
   test15();
+  test16();
 
   return 0;
 }

--- a/frontend/test/resolution/testResolve.cpp
+++ b/frontend/test/resolution/testResolve.cpp
@@ -586,7 +586,7 @@ static void test13() {
   ensureParamInt(variables.at("r1"), getMajorVersion());
   ensureParamInt(variables.at("r2"), getMinorVersion());
   ensureParamInt(variables.at("r3"), getUpdateVersion());
-  ensureParamString(variables.at("r4"), getCommitHash());
+  ensureParamString(variables.at("r4"), getIsOfficialRelease() ? "" : getCommitHash());
 }
 
 static void test14() {

--- a/frontend/test/resolution/testResolve.cpp
+++ b/frontend/test/resolution/testResolve.cpp
@@ -29,6 +29,7 @@
 #include "chpl/uast/Identifier.h"
 #include "chpl/uast/Module.h"
 #include "chpl/uast/Variable.h"
+#include "chpl/util/version-info.h"
 
 // test resolving a very simple module
 static void test1() {
@@ -571,6 +572,23 @@ static void test12() {
   assert(type.param()->toUintParam()->value() == 4607182418800017408);
 }
 
+static void test13() {
+  Context context;
+  // Make sure no errors make it to the user, even though we will get errors.
+  ErrorGuard guard(&context);
+  auto variables = resolveTypesOfVariables(&context,
+      R"""(
+      param r1 = __primitive("version major");
+      param r2 = __primitive("version minor");
+      param r3 = __primitive("version update");
+      param r4 = __primitive("version sha");
+      )""", { "r1", "r2", "r3", "r4" });
+  ensureParamInt(variables.at("r1"), getMajorVersion());
+  ensureParamInt(variables.at("r2"), getMinorVersion());
+  ensureParamInt(variables.at("r3"), getUpdateVersion());
+  ensureParamString(variables.at("r4"), getCommitHash());
+}
+
 static void test14() {
   Context context;
   // Make sure no errors make it to the user, even though we will get errors.
@@ -703,7 +721,6 @@ static void test16() {
   for (auto& pair : variables) {
     pair.second.isParamTrue();
   }
-
 }
 
 int main() {
@@ -719,6 +736,7 @@ int main() {
   test10();
   test11();
   test12();
+  test13();
   test14();
   test15();
   test16();

--- a/frontend/test/test-resolution.cpp
+++ b/frontend/test/test-resolution.cpp
@@ -218,3 +218,20 @@ resolveTypesOfVariables(Context* context,
   }
   return toReturn;
 }
+
+std::unordered_map<std::string, QualifiedType>
+resolveTypesOfVariablesInit(Context* context,
+                        std::string program,
+                        const std::vector<std::string>& variables) {
+  auto m = parseModule(context, std::move(program));
+  auto& rr = resolveModule(context, m->id());
+
+  std::unordered_map<std::string, QualifiedType> toReturn;
+  for (auto& variable : variables) {
+    auto varAst = findVariable(m, variable.c_str());
+    assert(varAst != nullptr);
+    assert(varAst->initExpression());
+    toReturn[variable] = rr.byAst(varAst->initExpression()).type();
+  }
+  return toReturn;
+}

--- a/frontend/test/test-resolution.cpp
+++ b/frontend/test/test-resolution.cpp
@@ -235,3 +235,35 @@ resolveTypesOfVariablesInit(Context* context,
   }
   return toReturn;
 }
+
+void ensureParamInt(const QualifiedType& type, int64_t expectedValue) {
+  assert(type.kind() == QualifiedType::PARAM);
+  assert(type.type() != nullptr);
+  assert(type.type()->isIntType());
+  assert(type.param() != nullptr);
+  assert(type.param()->isIntParam());
+  assert(type.param()->toIntParam()->value() == expectedValue);
+}
+
+void ensureParamBool(const QualifiedType& type, bool expectedValue) {
+  assert(type.kind() == QualifiedType::PARAM);
+  assert(type.type() != nullptr);
+  assert(type.type()->isBoolType());
+  assert(type.param() != nullptr);
+  assert(type.param()->isBoolParam());
+  assert(type.param()->toBoolParam()->value() == expectedValue);
+}
+
+void ensureParamString(const QualifiedType& type, const std::string& expectedValue) {
+  assert(type.kind() == QualifiedType::PARAM);
+  assert(type.type() != nullptr);
+  assert(type.type()->isStringType());
+  assert(type.param() != nullptr);
+  assert(type.param()->isStringParam());
+  assert(type.param()->toStringParam()->value() == expectedValue);
+}
+
+void ensureErroneousType(const QualifiedType& type) {
+  assert(type.type() != nullptr);
+  assert(type.type()->isErroneousType());
+}

--- a/frontend/test/test-resolution.h
+++ b/frontend/test/test-resolution.h
@@ -67,4 +67,7 @@ const Variable* findVariable(const ModuleVec& vec, const char* name);
 std::unordered_map<std::string, QualifiedType>
 resolveTypesOfVariables(Context* context, std::string program, const std::vector<std::string>& variables);
 
+std::unordered_map<std::string, QualifiedType>
+resolveTypesOfVariablesInit(Context* context, std::string program, const std::vector<std::string>& variables);
+
 #endif

--- a/frontend/test/test-resolution.h
+++ b/frontend/test/test-resolution.h
@@ -70,4 +70,9 @@ resolveTypesOfVariables(Context* context, std::string program, const std::vector
 std::unordered_map<std::string, QualifiedType>
 resolveTypesOfVariablesInit(Context* context, std::string program, const std::vector<std::string>& variables);
 
+void ensureParamInt(const QualifiedType& type, int64_t expectedValue);
+void ensureParamBool(const QualifiedType& type, bool expectedValue);
+void ensureParamString(const QualifiedType& type, const std::string& expectedValue);
+void ensureErroneousType(const QualifiedType& type);
+
 #endif


### PR DESCRIPTION
This PR adds the version primitives (major, minor, update, hash) that return this values as params.

Reviewed by @arezaii and @dlongnecke-cray -- thanks!

## Testing
- [x] paratest
- [x] dyno tests