### PR TITLE
Fix uninitialized variable warning in LibraryFileWriter.cpp

### DIFF
--- a/frontend/lib/libraries/LibraryFileWriter.cpp
+++ b/frontend/lib/libraries/LibraryFileWriter.cpp
@@ -755,6 +755,7 @@ bool LibraryFileWriter::writeAllSections() {
 
   std::vector<uint64_t> moduleSectionOffsets;
   Region moduleRegion;
+  memset(&moduleRegion, 0, sizeof(moduleRegion));
 
   for (auto& info : modules) {
     // write the module section & update the header's table


### PR DESCRIPTION
Follow-up to PR #23862.

Trivial and not reviewed.

- [x] full comm=none testing