### PR TITLE
Add developer oriented flags to help LLVM debug

### DIFF
--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -104,9 +104,13 @@ const char* llvmStageName[llvmStageNum::LAST] = {
   "every", //llvmStageNum::EVERY
   "early-as-possible",
   "module-optimizer-early",
+  "late-loop-optimizer",
   "loop-optimizer-end",
   "scalar-optimizer-late",
+  "early-simplification",
+  "optimizer-early",
   "optimizer-last",
+  "cgscc-optimizer-late",
   "vectorizer-start",
   "enabled-on-opt-level0",
   "peephole",

--- a/compiler/include/codegen.h
+++ b/compiler/include/codegen.h
@@ -51,6 +51,7 @@ namespace clang {
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/MDBuilder.h"
 #include "llvm/IR/PassManager.h"
+#include "llvm/Passes/StandardInstrumentations.h"
 #include "llvm/Target/TargetMachine.h"
 
 struct ClangInfo;
@@ -163,6 +164,8 @@ struct GenInfo {
   llvm::CGSCCAnalysisManager* CGAM = nullptr;
   llvm::ModuleAnalysisManager* MAM = nullptr;
   llvm::FunctionPassManager* FunctionSimplificationPM = nullptr;
+  llvm::PassInstrumentationCallbacks* PIC = nullptr;
+  llvm::StandardInstrumentations* SI = nullptr;
 
   // pointer to clang support info
   ClangInfo* clangInfo = nullptr;

--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -301,6 +301,7 @@ extern bool fIncrementalCompilation;
 extern std::string llvmFlags;
 extern std::string llvmRemarksFilters;
 extern std::vector<std::string> llvmRemarksFunctionsToShow;
+extern bool fLlvmPrintPasses;
 
 extern bool fPrintAdditionalErrors;
 

--- a/compiler/include/llvmDumpIR.h
+++ b/compiler/include/llvmDumpIR.h
@@ -32,6 +32,7 @@ namespace llvm {
 }
 
 #include "llvm/Analysis/LoopAnalysisManager.h"
+#include "llvm/Analysis/CGSCCPassManager.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/Pass.h"
 
@@ -59,6 +60,10 @@ struct DumpIRPass : public llvm::PassInfoMixin<DumpIRPass> {
                               llvm::LoopAnalysisManager& AM,
                               llvm::LoopStandardAnalysisResults& AR,
                               llvm::LPMUpdater& U);
+  llvm::PreservedAnalyses run(llvm::LazyCallGraph::SCC &C,
+                              llvm::CGSCCAnalysisManager &AM,
+                              llvm::LazyCallGraph &CG,
+                              llvm::CGSCCUpdateResult &);
 };
 // old pass manager version
 struct LegacyDumpIRPass : public llvm::FunctionPass {

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -922,9 +922,13 @@ typedef enum {
        // and match ExtensionPointTy in PassManagerBuilder
        EarlyAsPossible,
        ModuleOptimizerEarly,
+       LateLoopOptimizer,
        LoopOptimizerEnd,
        ScalarOptimizerLate,
+       EarlySimplification,
+       OptimizerEarly,
        OptimizerLast,
+       CGSCCOptimizerLate,
        VectorizerStart,
        EnabledOnOptLevel0,
        Peephole,

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2468,7 +2468,10 @@ static void registerDumpIrExtensions(PassBuilder& PB);
 namespace llvm {
 extern cl::opt<bool> PrintPipelinePasses;
 }
-static PassBuilder constructPassBuilder(llvm::TargetMachine* targetMachine, PassInstrumentationCallbacks* PIC, bool forFunction) {
+static PassBuilder constructPassBuilder(
+  llvm::TargetMachine* targetMachine,
+  PassInstrumentationCallbacks* PIC,
+  bool forFunction) {
   // this is required to be set, or LLVM will not properly populate the pass
   // names. technically this flag enables extra printing to the dbg() output,
   // but we only keep the flag long enough to populate the pass names.

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -4375,8 +4375,9 @@ bool getIrDumpExtensionPoint(llvmStageNum_t s,
       dumpIrPoint = PassManagerBuilder::EP_ModuleOptimizerEarly;
       return true;
     case llvmStageNum::LateLoopOptimizer:
-      dumpIrPoint = PassManagerBuilder::EP_LateLoopOptimizer;
-      return true;
+      USR_FATAL("Cannot use llvm-print-ir-stage late-loop-optimizer "
+                      "with the old pass manager\n");
+      return false;
     case llvmStageNum::LoopOptimizerEnd:
       dumpIrPoint = PassManagerBuilder::EP_LoopOptimizerEnd;
       return true;
@@ -4384,11 +4385,13 @@ bool getIrDumpExtensionPoint(llvmStageNum_t s,
       dumpIrPoint = PassManagerBuilder::EP_ScalarOptimizerLate;
       return true;
     case llvmStageNum::EarlySimplification:
-      dumpIrPoint = PassManagerBuilder::EP_EarlySimplification;
-      return true;,
+      USR_FATAL("Cannot use llvm-print-ir-stage early-simplification "
+                      "with the old pass manager\n");
+      return false;
     case llvmStageNum::OptimizerEarly:
-      dumpIrPoint = PassManagerBuilder::EP_OptimizerEarly;
-      return true;,
+      USR_FATAL("Cannot use llvm-print-ir-stage optimizer-early "
+                      "with the old pass manager\n");
+      return false;
     case llvmStageNum::OptimizerLast:
       dumpIrPoint = PassManagerBuilder::EP_OptimizerLast;
       return true;

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2496,11 +2496,11 @@ static void runModuleOptPipeline(bool addWideOpts) {
                               info->llvmContext,
 #endif
                               /* DebugLogging */ false);
-#if HAVE_LLVM_VER >= 170
+  #if HAVE_LLVM_VER >= 170
   SI.registerCallbacks(PIC, &MAM);
-#else
+  #else
   SI.registerCallbacks(PIC, &FAM);
-#endif
+  #endif
 
   PassBuilder PB = constructPassBuilder(info->targetMachine, &PIC, false);
 
@@ -2640,7 +2640,11 @@ void prepareCodegenLLVM()
                               info->llvmContext,
   #endif
                               /* DebugLogging */ false);
+  #if HAVE_LLVM_VER >= 170
+  info->SI->registerCallbacks(*info->PIC, info->MAM);
+  #else
   info->SI->registerCallbacks(*info->PIC, info->FAM);
+  #endif
 
   // Construct a function simplification pass manager
   PassBuilder PB = constructPassBuilder(info->targetMachine, info->PIC, true);

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -4376,14 +4376,26 @@ bool getIrDumpExtensionPoint(llvmStageNum_t s,
     case llvmStageNum::ModuleOptimizerEarly:
       dumpIrPoint = PassManagerBuilder::EP_ModuleOptimizerEarly;
       return true;
+    case llvmStageNum::LateLoopOptimizer:
+      dumpIrPoint = PassManagerBuilder::EP_LateLoopOptimizer;
+      return true;
     case llvmStageNum::LoopOptimizerEnd:
       dumpIrPoint = PassManagerBuilder::EP_LoopOptimizerEnd;
       return true;
     case llvmStageNum::ScalarOptimizerLate:
       dumpIrPoint = PassManagerBuilder::EP_ScalarOptimizerLate;
       return true;
+    case llvmStageNum::EarlySimplification:
+      dumpIrPoint = PassManagerBuilder::EP_EarlySimplification;
+      return true;,
+    case llvmStageNum::OptimizerEarly:
+      dumpIrPoint = PassManagerBuilder::EP_OptimizerEarly;
+      return true;,
     case llvmStageNum::OptimizerLast:
       dumpIrPoint = PassManagerBuilder::EP_OptimizerLast;
+      return true;
+    case llvmStageNum::CGSCCOptimizerLate:
+      dumpIrPoint = PassManagerBuilder::EP_CGSCCOptimizerLate;
       return true;
     case llvmStageNum::VectorizerStart:
       dumpIrPoint = PassManagerBuilder::EP_VectorizerStart;

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2496,11 +2496,11 @@ static void runModuleOptPipeline(bool addWideOpts) {
                               info->llvmContext,
 #endif
                               /* DebugLogging */ false);
-  #if HAVE_LLVM_VER >= 170
+#if HAVE_LLVM_VER >= 170
   SI.registerCallbacks(PIC, &MAM);
-  #else
+#else
   SI.registerCallbacks(PIC, &FAM);
-  #endif
+#endif
 
   PassBuilder PB = constructPassBuilder(info->targetMachine, &PIC, false);
 
@@ -2636,15 +2636,15 @@ void prepareCodegenLLVM()
 
   info->PIC = new PassInstrumentationCallbacks();
   info->SI = new StandardInstrumentations(
-  #if HAVE_LLVM_VER >= 160
+#if HAVE_LLVM_VER >= 160
                               info->llvmContext,
-  #endif
+#endif
                               /* DebugLogging */ false);
-  #if HAVE_LLVM_VER >= 170
+#if HAVE_LLVM_VER >= 170
   info->SI->registerCallbacks(*info->PIC, info->MAM);
-  #else
+#else
   info->SI->registerCallbacks(*info->PIC, info->FAM);
-  #endif
+#endif
 
   // Construct a function simplification pass manager
   PassBuilder PB = constructPassBuilder(info->targetMachine, info->PIC, true);

--- a/compiler/llvm/llvmDumpIR.cpp
+++ b/compiler/llvm/llvmDumpIR.cpp
@@ -63,6 +63,18 @@ PreservedAnalyses DumpIRPass::run(Loop& L,
   return llvm::PreservedAnalyses::all();
 }
 
+PreservedAnalyses DumpIRPass::run(LazyCallGraph::SCC &C,
+                                  CGSCCAnalysisManager &AM,
+                                  LazyCallGraph &CG,
+                                  CGSCCUpdateResult &) {
+  for (auto node: C) {
+    Function* F = &node.getFunction();
+    pass.run(*F);
+  }
+  // We don't modify the program, so we preserve all analyses.
+  return llvm::PreservedAnalyses::all();
+}
+
 bool LegacyDumpIRPass::runOnFunction(llvm::Function& function) {
   pass.run(function);
   return false;

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -345,6 +345,7 @@ static bool fPrintChplHome = false;
 std::string llvmFlags;
 std::string llvmRemarksFilters;
 std::vector<std::string> llvmRemarksFunctionsToShow;
+bool fLlvmPrintPasses = false;
 
 bool fPrintAdditionalErrors;
 
@@ -763,6 +764,13 @@ static void setLLVMRemarksFunctions(const ArgumentDescription* desc, const char*
   for(auto n: fNames) {
     llvmRemarksFunctionsToShow.push_back(n);
   }
+}
+
+static void setLLVMPrintPasses(const ArgumentDescription* desc, const char* arg) {
+#ifdef LLVM_USE_OLD_PASSES
+  printf("Cannot use '--llvm-print-passes' with this version of LLVM");
+  clean_exit(1);
+#endif
 }
 
 static void handleLibrary(const ArgumentDescription* desc, const char* arg_unused) {
@@ -1390,6 +1398,7 @@ static ArgumentDescription arg_desc[] = {
  {"llvm-print-ir-stage", ' ', "<stage>", "Specifies from which LLVM optimization stage to print function: none, basic, full", "S", NULL, "CHPL_LLVM_PRINT_IR_STAGE", &verifyStageAndSetStageNum},
  {"llvm-remarks", ' ', "<regex>", "Print LLVM optimization remarks", "S", NULL, NULL, &setLLVMRemarksFilters},
  {"llvm-remarks-function", ' ', "<name>", "Print LLVM optimization remarks only for these functions", "S", NULL, NULL, &setLLVMRemarksFunctions},
+ {"llvm-print-passes", ' ', NULL, "Print the LLVM optimizations to be run", "F", &fLlvmPrintPasses, NULL, &setLLVMPrintPasses},
  {"verify", ' ', NULL, "Run consistency checks during compilation", "N", &fVerify, "CHPL_VERIFY", NULL},
  {"parse-only", ' ', NULL, "Stop compiling after 'parse' pass for syntax checking", "N", &fParseOnly, NULL, NULL},
  {"parser-debug", ' ', NULL, "Set parser debug level", "+", &debugParserLevel, "CHPL_PARSER_DEBUG", NULL},

--- a/doc/rst/technotes/llvm.rst
+++ b/doc/rst/technotes/llvm.rst
@@ -73,7 +73,9 @@ something like ``opt --passes='...'``.
 
 This information can be combined with dumping LLVM IR, so that developers can
 focus on the LLVM IR level transformations without needing to worry about the
-frontend. The following flags are very useful for printing and maniupltaing LLVM IR. All should be passed as ``--mllvm <flag>``, for example ``--mllvm --print-after-all``
+frontend. The following flags are very useful for printing and manipulating
+LLVM IR. All should be passed as ``--mllvm <flag>``, for example
+``--mllvm --print-after-all``.
 
  * ``--print-before=<PASSES>``
     * Enables printing the LLVM IR before each pass.

--- a/doc/rst/technotes/llvm.rst
+++ b/doc/rst/technotes/llvm.rst
@@ -62,6 +62,37 @@ files:
  * ``chpl__module.bc`` is the version that will be linked
  * ``chpl__module-nopt.bc`` is the generated code without optimizations applied.
 
+Inspecting Individual LLVM Passes
+---------------------------------
+
+When debugging LLVM optimizations, it can be useful to inspect what passes have
+run and what they changed. The Chapel compiler supports the flag
+``--llvm-print-passes``, which will print all the LLVM passes that will be run.
+These pass names are printed as a pipeline, so the output can be fed into
+something like ``opt --passes='...'``.
+
+This information can be combined with dumping LLVM IR, so that developers can
+focus on the LLVM IR level transformations without needing to worry about the
+frontend. The following flags are very useful for printing and maniupltaing LLVM IR. All should be passed as ``--mllvm <flag>``, for example ``--mllvm --print-after-all``
+
+ * ``--print-before=<PASSES>``
+    * Enables printing the LLVM IR before each pass.
+    * Takes a comma separated list of LLVM passes.
+ * ``--print-before-all``
+    * Enables printing the LLVM IR before every pass.
+ * ``--print-after=<PASSES>``
+    * Enables printing the LLVM IR after each pass.
+    * Takes a comma separated list of LLVM passes.
+ * ``--print-after-all``
+    * Enables printing the LLVM IR after every pass.
+ * ``--print-module-scope``
+    * When printing LLVM IR, always print the module level scope.
+    * This flag generally allows the output to be passed to ``opt`` separately
+      from Chapel.
+ * ``--filter-print-funcs=<FUNCTIONS>``
+    * When printing LLVM IR, only print the IR for the listed functions
+    * Takes a comma separated list of LLVM IR function names.
+
 --------------------
 Optimization Options
 --------------------

--- a/util/chpl-completion.bash
+++ b/util/chpl-completion.bash
@@ -142,6 +142,7 @@ _chpl ()
 --llvm \
 --llvm-print-ir \
 --llvm-print-ir-stage \
+--llvm-print-passes \
 --llvm-remarks \
 --llvm-remarks-function \
 --llvm-wide-opt \


### PR DESCRIPTION
This PR adds a number of useful developer features for debugging LLVM backend issues.

Namely:
- Adds more stages to the existing `--llvm-print-ir-stage`
- Adds `--llvm-print-passes`
  - when using the new pass manager (enabled in Chapel with LLVM 16+), allows dumping of the optimization pipeline used by the compiler
- Adds docs on printing and inspecting llvm passes using the new pass manager (enabled in Chapel with LLVM 16+)

Testing:
- [x] `make check` passes with LLVM 16
- [x] standard paratest w/wo comm with LLVM 16
- [x] standard paratest w/wo comm with LLVM 15


[Reviewed by @mppf]