### PR TITLE
Do not gpuize forall loop that has a reduction intent

### DIFF
--- a/compiler/resolution/lowerForalls.cpp
+++ b/compiler/resolution/lowerForalls.cpp
@@ -487,6 +487,7 @@ static VarSymbol* createCurrRP(ShadowVarSymbol* RP) {
 static VarSymbol* createCurrAS(ShadowVarSymbol* AS) {
   VarSymbol* currAS = new VarSymbol(astr("AS_", AS->name), AS->type);
   currAS->qual = QUAL_VAL;
+  currAS->addFlag(FLAG_REDUCTION_TEMP);
   return currAS;
  }
 

--- a/frontend/include/chpl/uast/PragmaList.h
+++ b/frontend/include/chpl/uast/PragmaList.h
@@ -286,6 +286,7 @@ PRAGMA(GPU_CODEGEN, ypr, "codegen for GPU", "generate GPU code and set function 
 PRAGMA(GPU_AND_CPU_CODEGEN, ypr, "codegen for CPU and GPU", "generate both GPU and CPU code")
 PRAGMA(ASSERT_ON_GPU, ypr, "assert on gpu", "triggers runtime assertion if not running on device")
 PRAGMA(GPU_SPECIALIZATION, npr, "gpu specialization", ncm)
+PRAGMA(REDUCTION_TEMP, npr, "reduction temp variable", ncm)
 
 PRAGMA(HAS_POSTINIT, ypr, "has postinit", "type that has a postinit method")
 PRAGMA(HAS_RUNTIME_TYPE, ypr, "has runtime type", "type that has an associated runtime type")

--- a/test/gpu/native/basics/reductionNoGpuize.chpl
+++ b/test/gpu/native/basics/reductionNoGpuize.chpl
@@ -1,0 +1,7 @@
+on here.gpus[0] {
+  var x = 0;
+  forall i in 0..10 with (+ reduce x) {
+    x += i;
+  }
+  writeln(x);
+}

--- a/test/gpu/native/basics/reductionNoGpuize.good
+++ b/test/gpu/native/basics/reductionNoGpuize.good
@@ -1,0 +1,2 @@
+warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
+55


### PR DESCRIPTION
Currently if a gpuizable forall loop has a reduction intent it will produce
a wrong answer.

Long term we'd like to support this but in the meantime this PR changes
things so these loops will not gpuize (and will run on the cpu instead).

Specifically, this PR flags a temporary var introduced by reduce intents
and then detects the presence of a variable with this flag during gpuTransforms
to determine that the loop is ineligible.
Resolves #23827

TODO:
* [x] paratests nvidia
* [x] paratests (non gpu)