### PR TITLE
Use correct specifier for `printf`-like function

### DIFF
--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -45,6 +45,8 @@ bool chpl_gpu_use_stream_per_task = true;
 
 #include "gpu/chpl-gpu-reduce-util.h"
 
+#include <inttypes.h>
+
 void chpl_gpu_init(void) {
   chpl_gpu_impl_init(&chpl_gpu_num_devices);
 
@@ -275,7 +277,7 @@ inline void chpl_gpu_launch_kernel_flat(int ln, int32_t fn,
                  "\tKernel: %s\n"
                  "\tStream: %p\n"
                  "\tNumArgs: %d\n"
-                 "\tNumThreads: %ld\n",
+                 "\tNumThreads: %"PRId64"\n",
                  chpl_task_getRequestedSubloc(),
                  chpl_lookupFilename(fn),
                  ln,


### PR DESCRIPTION
Fixes an issue in `chpl-gpu.c` where an `int64_t` was passed to the format specifer `%ld`. 

On some systems/compilers, we could get away with this. But after [23901](https://github.com/chapel-lang/chapel/pull/23901) some compilers will do more stringent checking and complain. The solution is to just use the right format specifier for `int64_t`.

Built locally

[Reviewed by @e-kayrakli]