### PR TITLE
Skip serialization tests when not using LLVM

### DIFF
--- a/test/separate_compilation/serialization/SKIPIF
+++ b/test/separate_compilation/serialization/SKIPIF
@@ -1,0 +1,1 @@
+CHPL_TARGET_COMPILER!=llvm

--- a/test/separate_compilation/serialization/bug/SKIPIF
+++ b/test/separate_compilation/serialization/bug/SKIPIF
@@ -1,0 +1,1 @@
+CHPL_TARGET_COMPILER!=llvm

--- a/test/separate_compilation/serialization/bug/testGenLib.precomp
+++ b/test/separate_compilation/serialization/bug/testGenLib.precomp
@@ -12,7 +12,9 @@ def genDyno(val):
         stem = Path(val).stem
         dyno = stem + ".dyno"
     if not os.path.exists(dyno):
-        subprocess.run([sys.argv[3], "--dyno-gen-lib", dyno, val])
+        cmd = [sys.argv[3], "--dyno-gen-lib", dyno, val]
+        print("Creating lib with", " ".join(cmd))
+        subprocess.run(cmd, check=True)
 
 def genAndMod(name):
     dotChpl = name + ".chpl"

--- a/test/separate_compilation/serialization/testGenLib.precomp
+++ b/test/separate_compilation/serialization/testGenLib.precomp
@@ -12,7 +12,9 @@ def genDyno(val):
         stem = Path(val).stem
         dyno = stem + ".dyno"
     if not os.path.exists(dyno):
-        subprocess.run([sys.argv[3], "--dyno-gen-lib", dyno, val])
+        cmd = [sys.argv[3], "--dyno-gen-lib", dyno, val]
+        print("Creating lib with", " ".join(cmd))
+        subprocess.run(cmd, check=True)
 
 def genAndMod(name):
     dotChpl = name + ".chpl"


### PR DESCRIPTION
Follow-up to PR #23906

This PR skips the `--dyno-gen-lib` tests when not using LLVM, since the generated `.dyno` files now store LLVM IR. While there, it improves the error handling in the `.precomp` files to make the issue easier to see in the future.

Test change only - not reviewed.

- [x] full comm=none testing