### PR TITLE
Reduce generated code for nil comparisons

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -173,6 +173,8 @@ module ChapelBase {
   inline operator ==(a: complex(64), b: complex(64)) do return a.re == b.re && a.im == b.im;
   inline operator ==(a: complex(128), b: complex(128)) do return a.re == b.re && a.im == b.im;
   inline operator ==(a: borrowed RootClass?, b: borrowed RootClass?) do return __primitive("ptr_eq", a, b);
+  inline operator ==(a: borrowed RootClass?, b: _nilType) do return __primitive("==", a, nil);
+  inline operator ==(a: _nilType, b: borrowed RootClass?) do return __primitive("==", b, nil);
   inline operator ==(a: enum, b: enum) where (a.type == b.type) {
     return __primitive("==", a, b);
   }
@@ -204,6 +206,8 @@ module ChapelBase {
   inline operator !=(a: complex(64), b: complex(64)) do return a.re != b.re || a.im != b.im;
   inline operator !=(a: complex(128), b: complex(128)) do return a.re != b.re || a.im != b.im;
   inline operator !=(a: borrowed RootClass?, b: borrowed RootClass?) do return __primitive("ptr_neq", a, b);
+  inline operator !=(a: borrowed RootClass?, b: _nilType) do return __primitive("!=", a, nil);
+  inline operator !=(a: _nilType, b: borrowed RootClass?) do return __primitive("!=", b, nil);
   inline operator !=(a: enum, b: enum) where (a.type == b.type) {
     return __primitive("!=", a, b);
   }


### PR DESCRIPTION
This change simplifies the generated code for the comparisons `c == nil` and `c != nil` in multilocale compilations, where `c` is a nilable class represented in the compiler as a wide pointer, as in:

```chpl
var c: unmanaged RootClass?;
proc main {
  if c != nil then writeln("hi");
}
```

Prior to this change this comparison looked like this:
```c
chpl_macro_tmp_3298.locale = chpl_gen_getLocaleID();
chpl_macro_tmp_3298.addr = NULL;
T2 = chpl_macro_tmp_3298;
... (((&T)->addr != (&T2)->addr) || ((!(! (&T)->addr)) && (chpl_nodeFromLocaleID((&T)->locale, [...]) != chpl_nodeFromLocaleID((&T2)->locale, [...])))) ...
```

With this change it looks like this:
```c
... ((&T)->addr != nil) ...
```

I expect no significant impact from this change on --local compilations.

A somewhat relevant tidbit: insertWideReferences expands some cases of `nil` to a wide pointer:
```c++
else if (call->isPrimitive(PRIM_PTR_EQUAL) || call->isPrimitive(PRIM_PTR_NOTEQUAL)) {
  SymExpr* lhs = toSymExpr(call->get(1));
  SymExpr* rhs = toSymExpr(call->get(2));
  makeMatch(lhs, rhs);
  makeMatch(rhs, lhs);
}
```

Testing: local and gasnet paratests.