### PR TITLE
Fix LLVM 16 issues

### DIFF
--- a/frontend/include/chpl/util/memory.h
+++ b/frontend/include/chpl/util/memory.h
@@ -20,8 +20,10 @@
 #ifndef CHPL_UTIL_MEMORY_H
 #define CHPL_UTIL_MEMORY_H
 
+#include "llvm/Config/llvm-config.h"
+
 #include <memory>
-#if HAVE_LLVM_VER >= 160
+#if LLVM_VERSION_MAJOR >= 16
 #include <optional>
 #else
 #include "llvm/ADT/Optional.h"
@@ -36,7 +38,7 @@ namespace chpl {
  underlying optional types.
  */
 template<typename T>
-#if HAVE_LLVM_VER >= 160
+#if LLVM_VERSION_MAJOR >= 16
 using optional = std::optional<T>;
 #else
 using optional = llvm::Optional<T>;
@@ -46,7 +48,7 @@ using optional = llvm::Optional<T>;
 /**
   This is the "empty" value for the above optional<T> type.
  */
-#if HAVE_LLVM_VER >= 160
+#if LLVM_VERSION_MAJOR >= 16
 static const auto empty = std::nullopt;
 #else
 static const auto empty = llvm::None;

--- a/test/llvm/parallel_loop_access/different_numbers.chpl
+++ b/test/llvm/parallel_loop_access/different_numbers.chpl
@@ -18,7 +18,7 @@ proc loop (A, B, n) {
     //CHECK-SAME: !llvm.access.group ![[GROUP1:[0-9]+]]
 
     //CHECK: %[[MUL_DEST1:[0-9]+]] = mul
-    //CHECK-SAME: i32 %[[LOAD_DEST1]]
+    //CHECK-SAME: %[[LOAD_DEST1]]
     A[i] = 3*B[i];
     //CHECK: store i32 %[[MUL_DEST1]]
     //CHECK-SAME: !llvm.access.group ![[GROUP1]]
@@ -39,7 +39,7 @@ proc loop (A, B, n) {
     //CHECK-NOT: !llvm.access.group ![[GROUP1]]
 
     //CHECK: %[[MUL_DEST2:[0-9]+]] = mul
-    //CHECK-SAME: i32 %[[LOAD_DEST2]]
+    //CHECK-SAME: %[[LOAD_DEST2]]
     A[i] = 5*B[i];
     //CHECK: store i32 %[[MUL_DEST2]]
     //CHECK-SAME: !llvm.access.group ![[GROUP2]]
@@ -55,7 +55,7 @@ proc loop (A, B, n) {
       //CHECK-NOT: !llvm.access.group ![[GROUP1]]
 
       //CHECK: %[[MUL_DEST3:[0-9]+]] = mul
-      //CHECK-SAME: i32 %[[LOAD_DEST3]]
+      //CHECK-SAME: %[[LOAD_DEST3]]
       A[j] = 7*B[j];
       //CHECK: store i32 %[[MUL_DEST3]]
       //CHECK-SAME: !llvm.access.group ![[GROUP3]]


### PR DESCRIPTION
Fixes two issues after merging LLVM 16 fixes. 

- `test/llvm/parallel_loop_access/different_numbers.chpl` was checking the ir too strictly, and didn't work with LLVM versions prior to 16
- `frontend/include/chpl/util/memory.h` was using `HAVE_LLVM_VER`, which is not defined in the frontend

Tested locally with llvm version 15 and 16

[reviewed by @benharsh]