### PR TITLE
Linter tests

### DIFF
--- a/test/chplcheck/BoolLitInCondStatement.chpl
+++ b/test/chplcheck/BoolLitInCondStatement.chpl
@@ -1,0 +1,20 @@
+module BoolLits {
+  proc myProc () {
+    if(true) then {
+      writeln("true");
+    } else {
+      writeln("false");
+    }
+
+    if (false) then {
+      writeln("false");
+    } else {
+      writeln("true");
+    }
+
+    while(true) {
+      writeln("and I loop!");
+      break;
+    }
+  }
+}

--- a/test/chplcheck/BoolLitInCondStatement.chpl
+++ b/test/chplcheck/BoolLitInCondStatement.chpl
@@ -1,18 +1,16 @@
 module BoolLits {
   proc myProc () {
-    if(true) then {
+    if true then
       writeln("true");
-    } else {
+    else
       writeln("false");
-    }
 
-    if (false) then {
+    if false then 
       writeln("false");
-    } else {
+    else 
       writeln("true");
-    }
 
-    while(true) {
+    while true {
       writeln("and I loop!");
       break;
     }

--- a/test/chplcheck/BoolLitInCondStatement.good
+++ b/test/chplcheck/BoolLitInCondStatement.good
@@ -1,2 +1,2 @@
 BoolLitInCondStatement.chpl:3: node violates rule BoolLitInCondStmt
-BoolLitInCondStatement.chpl:9: node violates rule BoolLitInCondStmt
+BoolLitInCondStatement.chpl:8: node violates rule BoolLitInCondStmt

--- a/test/chplcheck/BoolLitInCondStatement.good
+++ b/test/chplcheck/BoolLitInCondStatement.good
@@ -1,0 +1,2 @@
+BoolLitInCondStatement.chpl:3: node violates rule BoolLitInCondStmt
+BoolLitInCondStatement.chpl:9: node violates rule BoolLitInCondStmt

--- a/test/chplcheck/CaseRules.chpl
+++ b/test/chplcheck/CaseRules.chpl
@@ -49,5 +49,5 @@ module CaseRules {
   extern const c_const: int(32);
 
   var justOneCapitalLetterAtTheE: string;
-  var justO: real;
+  const justO: real;
 }

--- a/test/chplcheck/CaseRules.chpl
+++ b/test/chplcheck/CaseRules.chpl
@@ -1,7 +1,7 @@
 module CaseRules {
     var camelVar: int;
-    var PascalVar: int;
-    var snake_var: int;
+    const PascalVar: real;
+    var snake_var: string;
 
     record camelRecord {
         proc camelCaseMethod() {return 0;}
@@ -11,7 +11,7 @@ module CaseRules {
     record PascalRecord {}
     record snake_record {
         var camelField, anotherCamelField: int;
-        var camelField2, PascalField: real;
+        const camelField2, PascalField: real;
         var camelField3, snake_field: string;
     }
 
@@ -19,8 +19,8 @@ module CaseRules {
     proc PascalProc() {return 0;}
     proc snake_proc() {
         var camelVar: int;
-        var PascalVar: int;
-        var snake_var: int;
+        const PascalVar: real;
+        var snake_var: string;
         return 0;
     }
 
@@ -35,4 +35,7 @@ module CaseRules {
     class camelClass {}
     class PascalClass {}
     class snake_class {}
+
+    var snake_CapVar: real;
+    const snake_Var: string;
 }

--- a/test/chplcheck/CaseRules.chpl
+++ b/test/chplcheck/CaseRules.chpl
@@ -25,7 +25,7 @@ module CaseRules {
   }
 
   proc foo(camelArg: int, PascalArg: string, snake_arg: real) {
-    return camelArg + int(snake_arg) + PascalArg.size();
+    return camelArg + snake_arg : int + PascalArg.size();
   }
 
   module camelModule {}

--- a/test/chplcheck/CaseRules.chpl
+++ b/test/chplcheck/CaseRules.chpl
@@ -1,0 +1,38 @@
+module CaseRules {
+    var camelVar: int;
+    var PascalVar: int;
+    var snake_var: int;
+
+    record camelRecord {
+        proc camelCaseMethod() {return 0;}
+        proc PascalCaseMethod() {return 0;}
+        proc snake_case_method() {return 0;}
+    }
+    record PascalRecord {}
+    record snake_record {
+        var camelField, anotherCamelField: int;
+        var camelField2, PascalField: real;
+        var camelField3, snake_field: string;
+    }
+
+    proc camelProc() {return 0;}
+    proc PascalProc() {return 0;}
+    proc snake_proc() {
+        var camelVar: int;
+        var PascalVar: int;
+        var snake_var: int;
+        return 0;
+    }
+
+    proc foo(camelArg: int, PascalArg: string, snake_arg: real) {
+        return camelArg + int(snake_arg) + PascalArg.size();
+    }
+
+    module camelModule {}
+    module PascalModule {}
+    module snake_module {}
+    
+    class camelClass {}
+    class PascalClass {}
+    class snake_class {}
+}

--- a/test/chplcheck/CaseRules.chpl
+++ b/test/chplcheck/CaseRules.chpl
@@ -48,4 +48,6 @@ module CaseRules {
   extern var c_var: int(32);
   extern const c_const: int(32);
 
+  var justOneCapitalLetterAtTheE: string;
+  var justO: real;
 }

--- a/test/chplcheck/CaseRules.chpl
+++ b/test/chplcheck/CaseRules.chpl
@@ -1,41 +1,51 @@
 module CaseRules {
+  var camelVar: int;
+  const PascalVar: real;
+  var snake_var: string;
+
+  record camelRecord {
+    proc camelCaseMethod() {return 0;}
+    proc PascalCaseMethod() {return 0;}
+    proc snake_case_method() {return 0;}
+  }
+  record PascalRecord {}
+  record snake_record {
+    var camelField, anotherCamelField: int;
+    const camelField2, PascalField: real;
+    var camelField3, snake_field: string;
+  }
+
+  proc camelProc() {return 0;}
+  proc PascalProc() {return 0;}
+  proc snake_proc() {
     var camelVar: int;
     const PascalVar: real;
     var snake_var: string;
+    return 0;
+  }
 
-    record camelRecord {
-        proc camelCaseMethod() {return 0;}
-        proc PascalCaseMethod() {return 0;}
-        proc snake_case_method() {return 0;}
-    }
-    record PascalRecord {}
-    record snake_record {
-        var camelField, anotherCamelField: int;
-        const camelField2, PascalField: real;
-        var camelField3, snake_field: string;
-    }
+  proc foo(camelArg: int, PascalArg: string, snake_arg: real) {
+    return camelArg + int(snake_arg) + PascalArg.size();
+  }
 
-    proc camelProc() {return 0;}
-    proc PascalProc() {return 0;}
-    proc snake_proc() {
-        var camelVar: int;
-        const PascalVar: real;
-        var snake_var: string;
-        return 0;
-    }
+  module camelModule {}
+  module PascalModule {}
+  module snake_module {}
+  
+  class camelClass {}
+  class PascalClass {}
+  class snake_class {}
 
-    proc foo(camelArg: int, PascalArg: string, snake_arg: real) {
-        return camelArg + int(snake_arg) + PascalArg.size();
-    }
+  var snake_CapVar: real;
+  const snake_Var: string;
 
-    module camelModule {}
-    module PascalModule {}
-    module snake_module {}
-    
-    class camelClass {}
-    class PascalClass {}
-    class snake_class {}
+  record R {};
 
-    var snake_CapVar: real;
-    const snake_Var: string;
+  var _privateVar: int;
+
+  extern proc proc_from_another_lang();
+  extern proc Proc_with_Bad_consistenty();
+  extern var c_var: int(32);
+  extern const c_const: int(32);
+
 }

--- a/test/chplcheck/CaseRules.good
+++ b/test/chplcheck/CaseRules.good
@@ -12,3 +12,5 @@ CaseRules.chpl:31: node violates rule PascalCaseModules
 CaseRules.chpl:33: node violates rule PascalCaseModules
 CaseRules.chpl:35: node violates rule PascalCaseClasses
 CaseRules.chpl:37: node violates rule PascalCaseClasses
+CaseRules.chpl:39: node violates rule CamelOrPascalCaseVariables
+CaseRules.chpl:40: node violates rule CamelOrPascalCaseVariables

--- a/test/chplcheck/CaseRules.good
+++ b/test/chplcheck/CaseRules.good
@@ -1,0 +1,14 @@
+CaseRules.chpl:4: node violates rule CamelOrPascalCaseVariables
+CaseRules.chpl:8: node violates rule CamelCaseFunctions
+CaseRules.chpl:9: node violates rule CamelCaseFunctions
+CaseRules.chpl:11: node violates rule CamelCaseRecords
+CaseRules.chpl:12: node violates rule CamelCaseRecords
+CaseRules.chpl:15: node violates rule CamelOrPascalCaseVariables
+CaseRules.chpl:19: node violates rule CamelCaseFunctions
+CaseRules.chpl:20: node violates rule CamelCaseFunctions
+CaseRules.chpl:23: node violates rule CamelOrPascalCaseVariables
+CaseRules.chpl:27: node violates rule CamelOrPascalCaseVariables
+CaseRules.chpl:31: node violates rule PascalCaseModules
+CaseRules.chpl:33: node violates rule PascalCaseModules
+CaseRules.chpl:35: node violates rule PascalCaseClasses
+CaseRules.chpl:37: node violates rule PascalCaseClasses

--- a/test/chplcheck/ChplPrefixReserved.chpl
+++ b/test/chplcheck/ChplPrefixReserved.chpl
@@ -1,0 +1,5 @@
+module ChplModule{
+  var chpl_var: real;
+  proc chpl_proc() {}
+  record chpl_record {}
+}

--- a/test/chplcheck/ChplPrefixReserved.good
+++ b/test/chplcheck/ChplPrefixReserved.good
@@ -1,0 +1,3 @@
+ChplPrefixReserved.chpl:2: node violates rule ChplPrefixReserved
+ChplPrefixReserved.chpl:3: node violates rule ChplPrefixReserved
+ChplPrefixReserved.chpl:4: node violates rule ChplPrefixReserved

--- a/test/chplcheck/ConsecutiveDecls.chpl
+++ b/test/chplcheck/ConsecutiveDecls.chpl
@@ -1,0 +1,22 @@
+module ConsDecls {
+  var real1: real;
+  var real2: real;
+
+  const constReal1: real;
+  const constReal2: real;
+
+  const constReal3:  real;
+  const constIntBetween:  int;
+  const constReal4:  real;
+
+  const cr1: real;
+  var vr1: real;
+  const cr2: real;
+
+  const ref crr1: real = cr1;
+  const between: real;
+  const ref crr2: real = cr1;
+  const ref ref1: real = cr1;
+  const ref ref2: real = cr1;
+  const ref ref3: real = cr1;
+}

--- a/test/chplcheck/ConsecutiveDecls.chpl
+++ b/test/chplcheck/ConsecutiveDecls.chpl
@@ -67,5 +67,12 @@ module ConsDecls {
   extern var c_var: int(32); //its type is a function call
   extern var c_var2: int(32);
 
+  pragma "always RVF"
+  var q: real;
+  pragma "always RVF"
+  var r: real;
+  pragma "always RVF"
+  var s: int;
+  var t: int;
 
 }

--- a/test/chplcheck/ConsecutiveDecls.chpl
+++ b/test/chplcheck/ConsecutiveDecls.chpl
@@ -55,4 +55,17 @@ module ConsDecls {
   //should not warn
   var k: int;
   var l: string;
+
+  //should not warn
+  var m: int;
+  class MyClass {
+    var n: int;
+  }
+  var o: int;
+  //comment between should not interfere.
+  var p: int;
+  extern var c_var: int(32); //its type is a function call
+  extern var c_var2: int(32);
+
+
 }

--- a/test/chplcheck/ConsecutiveDecls.chpl
+++ b/test/chplcheck/ConsecutiveDecls.chpl
@@ -52,5 +52,7 @@ module ConsDecls {
   @chpldoc.nodoc
   extern var j: real;
 
-
+  //should not warn
+  var k: int;
+  var l: string;
 }

--- a/test/chplcheck/ConsecutiveDecls.chpl
+++ b/test/chplcheck/ConsecutiveDecls.chpl
@@ -19,4 +19,38 @@ module ConsDecls {
   const ref ref1: real = cr1;
   const ref ref2: real = cr1;
   const ref ref3: real = cr1;
+
+  //should not warn
+  @chpldoc.nodoc
+  var x, y = 42;
+
+  @chpldoc.nodoc
+  var x2 = 42;
+  var y2 = x2;
+
+  //should warn
+  @chpldoc.nodoc
+  var x3 = 42;
+  @chpldoc.nodoc
+  var y3 = x3;
+
+  var preAlphabet: string;
+  extern var a: string;
+  extern var b: string;
+  extern var c: real;
+  extern const d: real;
+  extern const e: real;
+  extern const f: int;
+  const f2: int;
+
+  @chpldoc.nodoc
+  var g: int;
+  @chpldoc.nodoc
+  var h: real;
+  @chpldoc.nodoc
+  extern var i: real;
+  @chpldoc.nodoc
+  extern var j: real;
+
+
 }

--- a/test/chplcheck/ConsecutiveDecls.good
+++ b/test/chplcheck/ConsecutiveDecls.good
@@ -1,3 +1,7 @@
 ConsecutiveDecls.chpl:3: node violates rule ConsecutiveDecls
 ConsecutiveDecls.chpl:6: node violates rule ConsecutiveDecls
 ConsecutiveDecls.chpl:19: node violates rule ConsecutiveDecls
+ConsecutiveDecls.chpl:34: node violates rule ConsecutiveDecls
+ConsecutiveDecls.chpl:39: node violates rule ConsecutiveDecls
+ConsecutiveDecls.chpl:42: node violates rule ConsecutiveDecls
+ConsecutiveDecls.chpl:52: node violates rule ConsecutiveDecls

--- a/test/chplcheck/ConsecutiveDecls.good
+++ b/test/chplcheck/ConsecutiveDecls.good
@@ -8,3 +8,4 @@ ConsecutiveDecls.chpl:42: node violates rule ConsecutiveDecls
 ConsecutiveDecls.chpl:53: node violates rule ConsecutiveDecls
 ConsecutiveDecls.chpl:66: node violates rule ConsecutiveDecls
 ConsecutiveDecls.chpl:68: node violates rule ConsecutiveDecls
+ConsecutiveDecls.chpl:73: node violates rule ConsecutiveDecls

--- a/test/chplcheck/ConsecutiveDecls.good
+++ b/test/chplcheck/ConsecutiveDecls.good
@@ -1,7 +1,10 @@
 ConsecutiveDecls.chpl:3: node violates rule ConsecutiveDecls
 ConsecutiveDecls.chpl:6: node violates rule ConsecutiveDecls
+ConsecutiveDecls.chpl:12: node violates rule ConsecutiveDecls
 ConsecutiveDecls.chpl:19: node violates rule ConsecutiveDecls
-ConsecutiveDecls.chpl:34: node violates rule ConsecutiveDecls
+ConsecutiveDecls.chpl:35: node violates rule ConsecutiveDecls
 ConsecutiveDecls.chpl:39: node violates rule ConsecutiveDecls
 ConsecutiveDecls.chpl:42: node violates rule ConsecutiveDecls
-ConsecutiveDecls.chpl:52: node violates rule ConsecutiveDecls
+ConsecutiveDecls.chpl:53: node violates rule ConsecutiveDecls
+ConsecutiveDecls.chpl:66: node violates rule ConsecutiveDecls
+ConsecutiveDecls.chpl:68: node violates rule ConsecutiveDecls

--- a/test/chplcheck/ConsecutiveDecls.good
+++ b/test/chplcheck/ConsecutiveDecls.good
@@ -1,0 +1,3 @@
+ConsecutiveDecls.chpl:3: node violates rule ConsecutiveDecls
+ConsecutiveDecls.chpl:6: node violates rule ConsecutiveDecls
+ConsecutiveDecls.chpl:19: node violates rule ConsecutiveDecls

--- a/test/chplcheck/DoKeywordAndBlock.chpl
+++ b/test/chplcheck/DoKeywordAndBlock.chpl
@@ -1,11 +1,11 @@
 module DoKeywordAndBlock {
-for i in 1..10 do {
-  writeln(i);
-}
+  for i in 1..10 do {
+    writeln(i);
+  }
 
-for i in 1..10 do writeln(i);
+  for i in 1..10 do writeln(i);
 
-for i in 1..10 {
-  writeln(i);
-}
+  for i in 1..10 {
+    writeln(i);
+  }
 }

--- a/test/chplcheck/DoKeywordAndBlock.chpl
+++ b/test/chplcheck/DoKeywordAndBlock.chpl
@@ -1,3 +1,4 @@
+module DoKeywordAndBlock {
 for i in 1..10 do {
   writeln(i);
 }
@@ -6,4 +7,5 @@ for i in 1..10 do writeln(i);
 
 for i in 1..10 {
   writeln(i);
+}
 }

--- a/test/chplcheck/DoKeywordAndBlock.chpl
+++ b/test/chplcheck/DoKeywordAndBlock.chpl
@@ -1,0 +1,9 @@
+for i in 1..10 do {
+  writeln(i);
+}
+
+for i in 1..10 do writeln(i);
+
+for i in 1..10 {
+  writeln(i);
+}

--- a/test/chplcheck/DoKeywordAndBlock.good
+++ b/test/chplcheck/DoKeywordAndBlock.good
@@ -1,1 +1,1 @@
-DoKeywordAndBlock.chpl:1: node violates rule DoKeywordAndBlock
+DoKeywordAndBlock.chpl:2: node violates rule DoKeywordAndBlock

--- a/test/chplcheck/DoKeywordAndBlock.good
+++ b/test/chplcheck/DoKeywordAndBlock.good
@@ -1,0 +1,1 @@
+DoKeywordAndBlock.chpl:1: node violates rule DoKeywordAndBlock

--- a/test/chplcheck/MethodsAfterFields.chpl
+++ b/test/chplcheck/MethodsAfterFields.chpl
@@ -1,53 +1,54 @@
-record emptyRecord {   
-}
+module MethodsAfterFields {
+    record emptyRecord {   }
 
-record methodField {
-    proc method1() {
-        return 12;
+    record methodField {
+        proc method1() {
+            return 12;
+        }
+        var field1: int;
     }
-    var field1: int;
-}
 
-record fieldMethodField {
-    var field1: int;
-    proc method1() {
-        return field1;
+    record fieldMethodField {
+        var field1: int;
+        proc method1() {
+            return field1;
+        }
+        var field2: int;
     }
-    var field2: int;
-}
 
-record fieldFieldMethod {
-    var field1: int;
-    var field2: int;
+    record fieldFieldMethod {
+        var field1: int;
+        const field2: real;
 
-    proc method1() {
-        return field1;
+        proc method1() {
+            return field1;
+        }
     }
-}
 
-class EmptyClass {   
-}
-
-class MethodField {
-    proc method1() {
-        return 12;
+    class EmptyClass {   
     }
-    var field1: int;
-}
 
-class FieldMethodField {
-    var field1: int;
-    proc method1() {
-        return field1;
+    class MethodField {
+        proc method1() {
+            return 12;
+        }
+        var field1: int;
     }
-    var field2: int;
-}
 
-class FieldFieldMethod {
-    var field1: int;
-    var field2: int;
+    class FieldMethodField {
+        var field1: int;
+        proc method1() {
+            return field1;
+        }
+        var field2: int;
+    }
 
-    proc method1() {
-        return field1;
+    class FieldFieldMethod {
+        var field1: int;
+        const field2: real;
+
+        proc method1() {
+            return field1;
+        }
     }
 }

--- a/test/chplcheck/MethodsAfterFields.chpl
+++ b/test/chplcheck/MethodsAfterFields.chpl
@@ -1,54 +1,54 @@
 module MethodsAfterFields {
-    record emptyRecord {   }
+  record emptyRecord {   }
 
-    record methodField {
-        proc method1() {
-            return 12;
-        }
-        var field1: int;
+  record methodField {
+    proc method1() {
+      return 12;
     }
+    var field1: int;
+  }
 
-    record fieldMethodField {
-        var field1: int;
-        proc method1() {
-            return field1;
-        }
-        var field2: int;
+  record fieldMethodField {
+    var field1: int;
+    proc method1() {
+      return field1;
     }
+    var field2: int;
+  }
 
-    record fieldFieldMethod {
-        var field1: int;
-        const field2: real;
+  record fieldFieldMethod {
+    var field1: int;
+    const field2: real;
 
-        proc method1() {
-            return field1;
-        }
+    proc method1() {
+      return field1;
     }
+  }
 
-    class EmptyClass {   
+  class EmptyClass {   
+  }
+
+  class MethodField {
+    proc method1() {
+      return 12;
     }
+    var field1: int;
+  }
 
-    class MethodField {
-        proc method1() {
-            return 12;
-        }
-        var field1: int;
+  class FieldMethodField {
+    var field1: int;
+    proc method1() {
+      return field1;
     }
+    var field2: int;
+  }
 
-    class FieldMethodField {
-        var field1: int;
-        proc method1() {
-            return field1;
-        }
-        var field2: int;
+  class FieldFieldMethod {
+    var field1: int;
+    const field2: real;
+
+    proc method1() {
+        return field1;
     }
-
-    class FieldFieldMethod {
-        var field1: int;
-        const field2: real;
-
-        proc method1() {
-            return field1;
-        }
-    }
+  }
 }

--- a/test/chplcheck/MethodsAfterFields.good
+++ b/test/chplcheck/MethodsAfterFields.good
@@ -1,4 +1,4 @@
-MethodsAfterFields.chpl:31: node violates rule MethodsAfterFields
-MethodsAfterFields.chpl:38: node violates rule MethodsAfterFields
 MethodsAfterFields.chpl:4: node violates rule MethodsAfterFields
 MethodsAfterFields.chpl:11: node violates rule MethodsAfterFields
+MethodsAfterFields.chpl:31: node violates rule MethodsAfterFields
+MethodsAfterFields.chpl:38: node violates rule MethodsAfterFields

--- a/test/chplcheck/MisleadingIndentation.chpl
+++ b/test/chplcheck/MisleadingIndentation.chpl
@@ -1,0 +1,5 @@
+module Indentation {
+  for i in 1..10 do
+    writeln(i);
+    writeln("second thing");
+}

--- a/test/chplcheck/MisleadingIndentation.good
+++ b/test/chplcheck/MisleadingIndentation.good
@@ -1,0 +1,1 @@
+MisleadingIndentation.chpl:4: node violates rule MisleadingIndentation

--- a/test/chplcheck/NestedCoforalls.chpl
+++ b/test/chplcheck/NestedCoforalls.chpl
@@ -1,0 +1,19 @@
+coforall tid in 1..8 {
+  coforall tid2 in 1..8 {
+    writeln(tid + tid2);
+  }
+}
+
+for i in 1..10 {
+  coforall tid in 1..8 {
+    writeln(i + tid);
+  }
+}
+
+coforall outer in 1..8 {
+  for i in 1..10 {
+    coforall tid in 1..8 {
+     writeln(outer + i + tid);
+    }
+  }
+}

--- a/test/chplcheck/NestedCoforalls.chpl
+++ b/test/chplcheck/NestedCoforalls.chpl
@@ -1,19 +1,23 @@
-coforall tid in 1..8 {
-  coforall tid2 in 1..8 {
-    writeln(tid + tid2);
-  }
-}
-
-for i in 1..10 {
-  coforall tid in 1..8 {
-    writeln(i + tid);
-  }
-}
-
-coforall outer in 1..8 {
-  for i in 1..10 {
+module Nested {
+  proc myProc() {
     coforall tid in 1..8 {
-     writeln(outer + i + tid);
+      coforall tid2 in 1..8 {
+        writeln(tid + tid2);
+      }
+    }
+
+    for i in 1..10 {
+      coforall tid in 1..8 {
+        writeln(i + tid);
+      }
+    }
+
+    coforall outer in 1..8 {
+      for i in 1..10 {
+        coforall tid in 1..8 {
+        writeln(outer + i + tid);
+        }
+      }
     }
   }
 }

--- a/test/chplcheck/NestedCoforalls.good
+++ b/test/chplcheck/NestedCoforalls.good
@@ -1,2 +1,2 @@
-NestedCoforalls.chpl:2: node violates rule NestedCoforalls
-NestedCoforalls.chpl:15: node violates rule NestedCoforalls
+NestedCoforalls.chpl:4: node violates rule NestedCoforalls
+NestedCoforalls.chpl:17: node violates rule NestedCoforalls

--- a/test/chplcheck/NestedCoforalls.good
+++ b/test/chplcheck/NestedCoforalls.good
@@ -1,0 +1,2 @@
+NestedCoforalls.chpl:2: node violates rule NestedCoforalls
+NestedCoforalls.chpl:15: node violates rule NestedCoforalls

--- a/test/chplcheck/PREDIFF
+++ b/test/chplcheck/PREDIFF
@@ -2,6 +2,7 @@
 $CHPL_HOME/tools/chplcheck/chplcheck --enable-rule ConsecutiveDecls \
   --enable-rule BoolLitInCondStatement \
   --enable-rule UseExplicitModules \
+  --enable-rule UnusedFormals \
   --enable-rule CamelOrPascalCaseVariables \
   $1.chpl >> $2
 sed -i .tmp "s#$(pwd)/##" $2 # strip the working directory from output

--- a/test/chplcheck/PREDIFF
+++ b/test/chplcheck/PREDIFF
@@ -1,3 +1,7 @@
 #!/bin/bash
-$CHPL_HOME/tools/chplcheck/chplcheck $1.chpl >> $2
+$CHPL_HOME/tools/chplcheck/chplcheck --enable-rule ConsecutiveDecls \
+  --enable-rule BoolLitInCondStatement \
+  --enable-rule UseExplicitModules \
+  $1.chpl >> $2
 sed -i .tmp "s#$(pwd)/##" $2 # strip the working directory from output
+rm $2.tmp

--- a/test/chplcheck/PREDIFF
+++ b/test/chplcheck/PREDIFF
@@ -2,6 +2,7 @@
 $CHPL_HOME/tools/chplcheck/chplcheck --enable-rule ConsecutiveDecls \
   --enable-rule BoolLitInCondStatement \
   --enable-rule UseExplicitModules \
+  --enable-rule CamelOrPascalCaseVariables \
   $1.chpl >> $2
 sed -i .tmp "s#$(pwd)/##" $2 # strip the working directory from output
 rm $2.tmp

--- a/test/chplcheck/Unused.chpl
+++ b/test/chplcheck/Unused.chpl
@@ -1,5 +1,15 @@
 module Unused {
   proc myProc(A, B) {
     for i in 1..10 do writeln(A);
+
+    for (i,j) in {1..10,1..10} do 
+      writeln(i);
+
+    for i in 1..10 {
+      for j in 1..10 {
+        writeln(i);
+      }
+    }
   }
+  myProc(1,2);
 }

--- a/test/chplcheck/Unused.chpl
+++ b/test/chplcheck/Unused.chpl
@@ -1,0 +1,5 @@
+module Unused {
+  proc myProc(A, B) {
+    for i in 1..10 do writeln(A);
+  }
+}

--- a/test/chplcheck/Unused.good
+++ b/test/chplcheck/Unused.good
@@ -1,0 +1,2 @@
+Unused.chpl:2: node violates rule UnusedFormal
+Unused.chpl:3: node violates rule UnusedLoopIndex

--- a/test/chplcheck/Unused.good
+++ b/test/chplcheck/Unused.good
@@ -1,2 +1,4 @@
 Unused.chpl:2: node violates rule UnusedFormal
 Unused.chpl:3: node violates rule UnusedLoopIndex
+Unused.chpl:5: node violates rule UnusedLoopIndex
+Unused.chpl:8: node violates rule UnusedLoopIndex

--- a/test/chplcheck/Unused.good
+++ b/test/chplcheck/Unused.good
@@ -1,4 +1,4 @@
 Unused.chpl:2: node violates rule UnusedFormal
 Unused.chpl:3: node violates rule UnusedLoopIndex
 Unused.chpl:5: node violates rule UnusedLoopIndex
-Unused.chpl:8: node violates rule UnusedLoopIndex
+Unused.chpl:9: node violates rule UnusedLoopIndex

--- a/test/chplcheck/UseExplicitModules.chpl
+++ b/test/chplcheck/UseExplicitModules.chpl
@@ -1,0 +1,1 @@
+var x: int;

--- a/test/chplcheck/UseExplicitModules.good
+++ b/test/chplcheck/UseExplicitModules.good
@@ -1,0 +1,1 @@
+UseExplicitModules.chpl:1: node violates rule UseExplicitModules

--- a/tools/chplcheck/src/chplcheck.py
+++ b/tools/chplcheck/src/chplcheck.py
@@ -56,7 +56,10 @@ def main():
         # Silence errors, warnings etc. -- we're just linting.
         with context.track_errors() as errors:
             asts = context.parse(filename)
-            for (node, rule) in driver.run_checks(context, asts):
+            violations = list(driver.run_checks(context, asts))
+            #sort the failures in order of appearance
+            violations.sort(key=lambda f : f[0].location().start()[0])
+            for (node, rule) in violations:
                 print_violation(node, rule)
 
 if __name__ == "__main__":

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -117,7 +117,11 @@ def register_rules(driver):
             last_has_attribute = False
 
             for child in node:
-                yield from recurse(child, skip_direct = isinstance(child, MultiDecl))
+                is_multi_or_tuple = isinstance(child, MultiDecl) \
+                    or isinstance(child, TupleDecl)
+                
+                yield from recurse(child, 
+                                   skip_direct = is_multi_or_tuple)
 
                 if skip_direct: continue
 
@@ -139,6 +143,10 @@ def register_rules(driver):
                     consecutive.append(child)
 
             if len(consecutive) > 1:
+                print(child)
+                print(type(child))
+                print(node)
+                print(type(node))
                 yield consecutive[1]
 
         yield from recurse(root)

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -116,10 +116,9 @@ def register_rules(driver):
                     if isinstance(child, Variable): var_node = child
             elif isinstance(node, Variable):
                 var_node = node
-            
-            if var_node is None:
+            else:
                 return None
-            
+
             var_type = None
             var_type_expr = var_node.type_expression()
 
@@ -135,21 +134,19 @@ def register_rules(driver):
                         var_type += child.text()
             elif isinstance(var_type_expr, Identifier):
                 var_type = var_type_expr.name()
-            
+
             var_kind = var_node.kind()
 
             var_attributes = ''
-            var_attribute_group = var_node.attribute_group()
-            if var_attribute_group is not None:
-                for attribute_node in var_attribute_group:
-                    if attribute_node is not None:
-                        var_attributes += attribute_node.name() + " "
-            
+            if var_attribute_group := var_node.attribute_group():
+                var_attributes = " ".join(
+                    [a.name() for a in var_attribute_group if a is not None])
+
             var_linkage = var_node.linkage()
 
             var_pragmas = ' '.join(var_node.pragmas())
             return (var_type, var_kind, var_attributes, var_linkage, var_pragmas)
-        
+
         def recurse(node):
             consecutive = []
             last_characteristics = None
@@ -158,18 +155,17 @@ def register_rules(driver):
                 #we want to skip Comments entirely
                 if isinstance(child,Comment):
                     continue
-                
+
                 #we want to do MultiDecls and TupleDecls, but not recurse
-                skip_children = isinstance(child, MultiDecl) \
-                    or isinstance(child, TupleDecl) \
-                
+                skip_children = isinstance(child, (MultiDecl, TupleDecl))
+
                 if not skip_children:
                     yield from recurse(child)
 
                 new_characteristics = is_relevant_decl(child)
                 compatible = new_characteristics is not None and \
                     new_characteristics == last_characteristics
-                
+
                 last_characteristics = new_characteristics
 
                 if compatible:

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -33,7 +33,7 @@ def name_for_linting(node):
     return name
 
 def check_camel_case(node):
-    return re.fullmatch(r'_?([a-z]+([A-Z][a-z]+|\d+)*|[A-Z]+)?', name_for_linting(node))
+    return re.fullmatch(r'_?([a-z]+([A-Z][a-z]*|\d+)*|[A-Z]+)?', name_for_linting(node))
 
 def check_pascal_case(node):
     return re.fullmatch(r'_?(([A-Z][a-z]+|\d+)+|[A-Z]+)?', name_for_linting(node))

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -42,6 +42,7 @@ def register_rules(driver):
     @driver.basic_rule(VarLikeDecl, default=False)
     def CamelOrPascalCaseVariables(context, node):
         if node.name() == "_": return True
+        if node.linkage() == 'extern': return True 
         return check_camel_case(node) or check_pascal_case(node)
 
     @driver.basic_rule(Record)
@@ -50,6 +51,7 @@ def register_rules(driver):
     
     @driver.basic_rule(Function)
     def CamelCaseFunctions(context, node):
+        if node.linkage() == 'extern': return True 
         return check_camel_case(node)
 
     @driver.basic_rule(Class)

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -39,7 +39,7 @@ def check_pascal_case(node):
     return re.fullmatch(r'_?(([A-Z][a-z]+|\d+)+|[A-Z]+)?', name_for_linting(node))
 
 def register_rules(driver):
-    @driver.basic_rule(VarLikeDecl, default=True)
+    @driver.basic_rule(VarLikeDecl, default=False)
     def CamelOrPascalCaseVariables(context, node):
         if node.name() == "_": return True
         return check_camel_case(node) or check_pascal_case(node)

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -39,13 +39,17 @@ def check_pascal_case(node):
     return re.fullmatch(r'_?(([A-Z][a-z]+|\d+)+|[A-Z]+)?', name_for_linting(node))
 
 def register_rules(driver):
-    @driver.basic_rule(VarLikeDecl, default=False)
-    def CamelCaseVariables(context, node):
+    @driver.basic_rule(VarLikeDecl, default=True)
+    def CamelOrPascalCaseVariables(context, node):
         if node.name() == "_": return True
-        return check_camel_case(node)
+        return check_camel_case(node) or check_pascal_case(node)
 
     @driver.basic_rule(Record)
     def CamelCaseRecords(context, node):
+        return check_camel_case(node)
+    
+    @driver.basic_rule(Function)
+    def CamelCaseFunctions(context, node):
         return check_camel_case(node)
 
     @driver.basic_rule(Class)

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -112,7 +112,6 @@ def register_rules(driver):
         def is_relevant_decl(node):
             var_node = None
             if isinstance(node, MultiDecl):
-                
                 for child in node:
                     if isinstance(child, Variable): var_node = child
             elif isinstance(node, Variable):
@@ -155,7 +154,6 @@ def register_rules(driver):
             consecutive = []
             last_characteristics = None
 
-            
             for child in node:
                 #we want to skip Comments entirely
                 if isinstance(child,Comment):
@@ -173,8 +171,7 @@ def register_rules(driver):
                     new_characteristics == last_characteristics
                 
                 last_characteristics = new_characteristics
-                
-                
+
                 if compatible:
                     consecutive.append(child)
                 else:

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -42,16 +42,16 @@ def register_rules(driver):
     @driver.basic_rule(VarLikeDecl, default=False)
     def CamelOrPascalCaseVariables(context, node):
         if node.name() == "_": return True
-        if node.linkage() == 'extern': return True 
+        if node.linkage() == 'extern': return True
         return check_camel_case(node) or check_pascal_case(node)
 
     @driver.basic_rule(Record)
     def CamelCaseRecords(context, node):
         return check_camel_case(node)
-    
+
     @driver.basic_rule(Function)
     def CamelCaseFunctions(context, node):
-        if node.linkage() == 'extern': return True 
+        if node.linkage() == 'extern': return True
         return check_camel_case(node)
 
     @driver.basic_rule(Class)
@@ -120,8 +120,7 @@ def register_rules(driver):
                 is_multi_or_tuple = isinstance(child, MultiDecl) \
                     or isinstance(child, TupleDecl)
                 
-                yield from recurse(child, 
-                                   skip_direct = is_multi_or_tuple)
+                yield from recurse(child, skip_direct = is_multi_or_tuple)
 
                 if skip_direct: continue
 
@@ -143,10 +142,6 @@ def register_rules(driver):
                     consecutive.append(child)
 
             if len(consecutive) > 1:
-                print(child)
-                print(type(child))
-                print(node)
-                print(type(node))
                 yield consecutive[1]
 
         yield from recurse(root)

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -101,11 +101,12 @@ def register_rules(driver):
                 method_seen = True
         return True
 
-    #Four things have to match between consecutive decls for this to warn:
-    # 1. same type (or lack thereof)
+    #Five things have to match between consecutive decls for this to warn:
+    # 1. same type
     # 2. same kind
     # 3. same attributes
     # 4. same linkage
+    # 5. same pragmas
     @driver.advanced_rule(default=False)
     def ConsecutiveDecls(context, root):
         def is_relevant_decl(node):
@@ -147,7 +148,8 @@ def register_rules(driver):
             
             var_linkage = var_node.linkage()
 
-            return (var_type, var_kind, var_attributes, var_linkage)
+            var_pragmas = ' '.join(var_node.pragmas())
+            return (var_type, var_kind, var_attributes, var_linkage, var_pragmas)
         
         def recurse(node):
             consecutive = []


### PR DESCRIPTION
Three changes:
1. Testing for the existing linter rules
2. Variable casing rule changed from camelCase only to camelCase or PascalCase to match [style guide](https://chapel-lang.org/docs/developer/bestPractices/StandardModuleStyle.html#other-identifiers).
3. Linter driver now sorts violations by line number.
