### PR TITLE
Renaming `ioendian` to `endianness`

### DIFF
--- a/modules/packages/ProtobufProtocolSupport.chpl
+++ b/modules/packages/ProtobufProtocolSupport.chpl
@@ -193,22 +193,22 @@ module ProtobufProtocolSupport {
     }
 
     proc fixed32AppendBase(val: uint(32), ch: writingChannel) throws {
-      ch.writeBinary(val, ioendian.little);
+      ch.writeBinary(val, endianness.little);
     }
 
     proc fixed32ConsumeBase(ch: readingChannel): uint(32) throws {
       var val: uint(32);
-      ch.readBinary(val, ioendian.little);
+      ch.readBinary(val, endianness.little);
       return val;
     }
 
     proc fixed64AppendBase(val: uint(64), ch: writingChannel) throws {
-      ch.writeBinary(val, ioendian.little);
+      ch.writeBinary(val, endianness.little);
     }
 
     proc fixed64ConsumeBase(ch: readingChannel): uint(64) throws {
       var val: uint(64);
-      ch.readBinary(val, ioendian.little);
+      ch.readBinary(val, endianness.little);
       return val;
     }
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -821,11 +821,11 @@ param iobig = _iokind.big;
 param iolittle = _iokind.little;
 
 /*
-The :type:`ioendian` type is an enum. When used as an argument to the
+The :type:`endianness` type is an enum. When used as an argument to the
 :record:`fileReader` or :record:`fileWriter` methods, its constants have the
 following meanings:
 */
-enum ioendian {
+enum endianness {
   /* ``native`` means binary I/O is performed in the byte order that is native
   to the target platform. */
   native = 0,
@@ -2463,9 +2463,9 @@ private proc defaultSerializeVal(param writing : bool,
   if !useIOSerializers then return none;
 
   if kind != _iokind.dynamic {
-    var endian = if kind == _iokind.native then ioendian.native
-                 else if kind == _iokind.big then ioendian.big
-                 else ioendian.little;
+    var endian = if kind == _iokind.native then endianness.native
+                 else if kind == _iokind.big then endianness.big
+                 else endianness.little;
     if writing then return new binarySerializer(endian, _structured=false);
     else return new binaryDeserializer(endian, _structured=false);
   }
@@ -3622,7 +3622,7 @@ record binarySerializer {
     'endian' represents the endianness of the binary output produced by this
     Serializer.
   */
-  const endian : ioendian = ioendian.native;
+  const endian : endianness = endianness.native;
 
   @chpldoc.nodoc
   const _structured = true;
@@ -3691,9 +3691,9 @@ record binarySerializer {
                       const val:?t) throws {
     if isNumericType(t) {
       select endian {
-        when ioendian.native do writer.writeBinary(val, ioendian.native);
-        when ioendian.little do writer.writeBinary(val, ioendian.little);
-        when ioendian.big do writer.writeBinary(val, ioendian.big);
+        when endianness.native do writer.writeBinary(val, endianness.native);
+        when endianness.little do writer.writeBinary(val, endianness.little);
+        when endianness.big do writer.writeBinary(val, endianness.big);
       }
     } else if t == string  || isEnumType(t) || t == bytes ||
               isBoolType(t) {
@@ -3884,7 +3884,7 @@ record binarySerializer {
     @chpldoc.nodoc
     var writer : fileWriter(false, binarySerializer);
     @chpldoc.nodoc
-    const endian : ioendian;
+    const endian : endianness;
 
     /*
       Start serializing a new dimension of the array.
@@ -4004,13 +4004,13 @@ record binaryDeserializer {
     'endian' represents the endianness that this Deserializer should use when
     deserializing input.
   */
-  const endian : IO.ioendian = IO.ioendian.native;
+  const endian : IO.endianness = IO.endianness.native;
 
   @chpldoc.nodoc
   var _structured = true;
 
   @chpldoc.nodoc
-  proc init(endian: IO.ioendian = IO.ioendian.native, _structured : bool = true) {
+  proc init(endian: IO.endianness = IO.endianness.native, _structured : bool = true) {
     this.endian = endian;
     this._structured = _structured;
     init this;
@@ -4079,9 +4079,9 @@ record binaryDeserializer {
       var x : readType;
       var ret : bool;
       select endian {
-        when ioendian.native do ret = reader.readBinary(x, ioendian.native);
-        when ioendian.little do ret = reader.readBinary(x, ioendian.little);
-        when ioendian.big    do ret = reader.readBinary(x, ioendian.big);
+        when endianness.native do ret = reader.readBinary(x, endianness.native);
+        when endianness.little do ret = reader.readBinary(x, endianness.little);
+        when endianness.big    do ret = reader.readBinary(x, endianness.big);
       }
       if !ret then
         throw new EofError();
@@ -4340,7 +4340,7 @@ record binaryDeserializer {
     @chpldoc.nodoc
     var reader : fileReader(false, binaryDeserializer);
     @chpldoc.nodoc
-    const endian : ioendian;
+    const endian : endianness;
 
     /*
       Inform the ``ArrayDeserializer`` to start deserializing a new dimension.
@@ -8702,21 +8702,21 @@ private proc sysEndianness() {
   var x: int(16) = 1;
   // if the initial byte is 0, this is a big-endian system
   if (c_addrOf(x): c_ptr(void): c_ptr(uint(8))).deref() == 0 then
-    return ioendian.big;
+    return endianness.big;
   else
-    return ioendian.little;
+    return endianness.little;
 }
 
 private proc isNativeEndianness(endian) {
-  return endian == ioendian.native || endian == sysEndianness();
+  return endian == endianness.native || endian == sysEndianness();
 }
 
-private proc endianToIoKind(param e: ioendian) param {
-  if e == ioendian.native then
+private proc endianToIoKind(param e: endianness) param {
+  if e == endianness.native then
     return _iokind.native;
-  else if e == ioendian.big then
+  else if e == endianness.big then
     return _iokind.big;
-  else if e == ioendian.little then
+  else if e == endianness.little then
     return _iokind.little;
   else
     compilerError("Unexpected value in chpl_endianToIoKind(): ", e);
@@ -8788,9 +8788,9 @@ proc fileWriter.writeBinary(ptr: c_ptr(void), numBytes: int) throws {
   Write a binary number to the ``fileWriter``
 
   :arg arg: number to be written
-  :arg endian: :type:`ioendian` compile-time argument that specifies the byte
+  :arg endian: :type:`endianness` compile-time argument that specifies the byte
                order in which to write the number. Defaults to
-               :enumconstant:`ioendian.native`.
+               :enumconstant:`endianness.native`.
 
   :throws EofError: Thrown if the ``fileWriter`` offset was already at EOF.
   :throws UnexpectedEofError: Thrown if the write operation exceeds the
@@ -8799,7 +8799,7 @@ proc fileWriter.writeBinary(ptr: c_ptr(void), numBytes: int) throws {
                        due to a :ref:`system error<io-general-sys-error>`.
  */
 proc fileWriter.writeBinary(arg:numeric,
-                            param endian:ioendian = ioendian.native) throws {
+                            param endian:endianness = endianness.native) throws {
   const e: errorCode = try _write_binary_internal(_channel_internal,
                                                   endianToIoKind(endian),
                                                   arg);
@@ -8812,7 +8812,7 @@ proc fileWriter.writeBinary(arg:numeric,
   Write a binary number to the ``fileWriter``
 
   :arg arg: number to be written
-  :arg endian: :type:`ioendian` specifies the byte order in which
+  :arg endian: :type:`endianness` specifies the byte order in which
                to write the number.
 
   :throws EofError: Thrown if the ``fileWriter`` offset was already at EOF.
@@ -8821,16 +8821,16 @@ proc fileWriter.writeBinary(arg:numeric,
   :throws SystemError: Thrown if data could not be written to the ``fileWriter``
                        due to a :ref:`system error<io-general-sys-error>`.
 */
-proc fileWriter.writeBinary(arg:numeric, endian:ioendian) throws {
+proc fileWriter.writeBinary(arg:numeric, endian:endianness) throws {
   select (endian) {
-    when ioendian.native {
-      this.writeBinary(arg, ioendian.native);
+    when endianness.native {
+      this.writeBinary(arg, endianness.native);
     }
-    when ioendian.big {
-      this.writeBinary(arg, ioendian.big);
+    when endiannessssss.big {
+      this.writeBinary(arg, endianness.big);
     }
-    when ioendian.little {
-      this.writeBinary(arg, ioendian.little);
+    when endianness.little {
+      this.writeBinary(arg, endianness.little);
     }
   }
 }
@@ -8929,9 +8929,9 @@ private proc isSuitableForBinaryReadWrite(arr: _array) param {
   Note that this routine currently requires a local rectangular non-strided array.
 
   :arg data: an array of numbers to write to the fileWriter
-  :arg endian: :type:`ioendian` compile-time argument that specifies the byte
+  :arg endian: :type:`endianness` compile-time argument that specifies the byte
                order in which to read the numbers. Defaults to
-               :enumconstant:`ioendian.native`.
+               :enumconstant:`endianness.native`.
 
   :throws EofError: Thrown if the ``fileWriter`` offset was already at EOF.
   :throws UnexpectedEofError: Thrown if the write operation exceeds the
@@ -8939,7 +8939,7 @@ private proc isSuitableForBinaryReadWrite(arr: _array) param {
   :throws SystemError: Thrown if data could not be written to the ``fileWriter``
                        due to a :ref:`system error<io-general-sys-error>`.
 */
-proc fileWriter.writeBinary(const ref data: [?d] ?t, param endian:ioendian = ioendian.native) throws
+proc fileWriter.writeBinary(const ref data: [?d] ?t, param endian:endianness = endianness.native) throws
   where isSuitableForBinaryReadWrite(data) && data.strides == strideKind.one && (
     isIntegralType(t) || isRealType(t) || isImagType(t) || isComplexType(t) )
 {
@@ -8978,7 +8978,7 @@ proc fileWriter.writeBinary(const ref data: [?d] ?t, param endian:ioendian = ioe
 
 
 @chpldoc.nodoc
-proc fileWriter.writeBinary(const ref data: [?d] ?t, param endian:ioendian = ioendian.native) throws {
+proc fileWriter.writeBinary(const ref data: [?d] ?t, param endian:endianness = endianness.native) throws {
   compilerError("writeBinary() only supports local, rectangular, non-strided arrays of simple types");
 }
 
@@ -8989,7 +8989,7 @@ proc fileWriter.writeBinary(const ref data: [?d] ?t, param endian:ioendian = ioe
   Note that this routine currently requires a local rectangular non-strided array.
 
   :arg data: an array of numbers to write to the fileWriter
-  :arg endian: :type:`ioendian` specifies the byte order in which
+  :arg endian: :type:`endianness` specifies the byte order in which
                to write the number.
 
   :throws EofError: Thrown if the ``fileWriter`` offset was already at EOF.
@@ -8998,25 +8998,25 @@ proc fileWriter.writeBinary(const ref data: [?d] ?t, param endian:ioendian = ioe
   :throws SystemError: Thrown if data could not be written to the ``fileWriter``
                        due to a :ref:`system error<io-general-sys-error>`.
 */
-proc fileWriter.writeBinary(const ref data: [] ?t, endian:ioendian) throws
+proc fileWriter.writeBinary(const ref data: [] ?t, endian:endianness) throws
   where isSuitableForBinaryReadWrite(data) && data.strides == strideKind.one && (
     isIntegralType(t) || isRealType(t) || isImagType(t) || isComplexType(t) )
 {
   select (endian) {
-    when ioendian.native {
-      this.writeBinary(data, ioendian.native);
+    when endianness.native {
+      this.writeBinary(data, endianness.native);
     }
-    when ioendian.big {
-      this.writeBinary(data, ioendian.big);
+    when endianness.big {
+      this.writeBinary(data, endianness.big);
     }
-    when ioendian.little {
-      this.writeBinary(data, ioendian.little);
+    when endianness.little {
+      this.writeBinary(data, endianness.little);
     }
   }
 }
 
 @chpldoc.nodoc
-proc fileWriter.writeBinary(const ref data: [] ?t, endian:ioendian) throws
+proc fileWriter.writeBinary(const ref data: [] ?t, endian:endianness) throws
 {
   compilerError("writeBinary() only supports local, rectangular, non-strided arrays of simple types");
 }
@@ -9025,9 +9025,9 @@ proc fileWriter.writeBinary(const ref data: [] ?t, endian:ioendian) throws
   Read a binary number from the ``fileReader``
 
   :arg arg: number to be read
-  :arg endian: :type:`ioendian` compile-time argument that specifies the byte
+  :arg endian: :type:`endianness` compile-time argument that specifies the byte
                order in which to read the number. Defaults to
-               :enumconstant:`ioendian.native`.
+               :enumconstant:`endianness.native`.
   :returns: ``true`` if the number was read, and ``false`` otherwise (i.e.,
             the ``fileReader`` was already at EOF).
 
@@ -9036,7 +9036,7 @@ proc fileWriter.writeBinary(const ref data: [] ?t, endian:ioendian) throws
   :throws SystemError: Thrown if data could not be read from the ``fileReader``
                        due to a :ref:`system error<io-general-sys-error>`.
  */
-proc fileReader.readBinary(ref arg:numeric, param endian:ioendian = ioendian.native):bool throws {
+proc fileReader.readBinary(ref arg:numeric, param endian:endianness = endianness.native):bool throws {
   const e:errorCode = try _read_binary_internal(_channel_internal,
                                                 endianToIoKind(endian),
                                                 arg);
@@ -9053,7 +9053,7 @@ proc fileReader.readBinary(ref arg:numeric, param endian:ioendian = ioendian.nat
    Read a binary number from the ``fileReader``
 
    :arg arg: number to be read
-   :arg endian: :type:`ioendian` specifies the byte order in which
+   :arg endian: :type:`endianness` specifies the byte order in which
                 to read the number.
    :returns: ``true`` if the number was read, and ``false`` otherwise (i.e.,
              the ``fileReader`` was already at EOF).
@@ -9063,18 +9063,18 @@ proc fileReader.readBinary(ref arg:numeric, param endian:ioendian = ioendian.nat
   :throws SystemError: Thrown if data could not be read from the ``fileReader``
                        due to a :ref:`system error<io-general-sys-error>`.
  */
-proc fileReader.readBinary(ref arg:numeric, endian: ioendian):bool throws {
+proc fileReader.readBinary(ref arg:numeric, endian: endianness):bool throws {
   var rv: bool = false;
 
   select (endian) {
-    when ioendian.native {
-      rv = this.readBinary(arg, ioendian.native);
+    when endianness.native {
+      rv = this.readBinary(arg, endianness.native);
     }
-    when ioendian.big {
-      rv = this.readBinary(arg, ioendian.big);
+    when endianness.big {
+      rv = this.readBinary(arg, endianness.big);
     }
-    when ioendian.little {
-      rv = this.readBinary(arg, ioendian.little);
+    when endianness.little {
+      rv = this.readBinary(arg, endianness.little);
     }
   }
   return rv;
@@ -9108,7 +9108,7 @@ proc fileReader.readBinary(ref s: string, maxSize: int): bool throws {
     var len: int(64),
         tx: c_ptrConst(c_char);
 
-    e = qio_channel_read_string(false, ioendian.native: c_int,
+    e = qio_channel_read_string(false, endianness.native: c_int,
                                 qio_channel_str_style(this._channel_internal),
                                 this._channel_internal, tx, len, maxSize:c_ssize_t);
 
@@ -9147,7 +9147,7 @@ proc fileReader.readBinary(ref b: bytes, maxSize: int): bool throws {
     var len: int(64),
         tx: c_ptrConst(c_char);
 
-    e = qio_channel_read_string(false, ioendian.native: c_int,
+    e = qio_channel_read_string(false, endianness.native: c_int,
                                 qio_channel_str_style(this._channel_internal),
                                 this._channel_internal, tx, len, maxSize:c_ssize_t);
 
@@ -9177,9 +9177,9 @@ config param ReadBinaryArrayReturnInt = true;
   Note that this routine currently requires a local rectangular non-strided array.
 
   :arg data: an array to read into – existing values are overwritten.
-  :arg endian: :type:`ioendian` compile-time argument that specifies the byte
+  :arg endian: :type:`endianness` compile-time argument that specifies the byte
                order in which to read the numbers in. Defaults to
-               :enumconstant:`ioendian.native`.
+               :enumconstant:`endianness.native`.
   :returns: the number of values that were read into the array. This can be
             less than ``data.size`` if EOF was reached, or an error occurred,
             before filling the array.
@@ -9187,7 +9187,7 @@ config param ReadBinaryArrayReturnInt = true;
   :throws SystemError: Thrown if data could not be read from the ``fileReader``
                        due to a :ref:`system error<io-general-sys-error>`.
 */
-proc fileReader.readBinary(ref data: [?d] ?t, param endian = ioendian.native): int throws
+proc fileReader.readBinary(ref data: [?d] ?t, param endian = endianness.native): int throws
   where isSuitableForBinaryReadWrite(data) && data.strides == strideKind.one && (
         isIntegralType(t) || isRealType(t) || isImagType(t) || isComplexType(t) )
 {
@@ -9242,7 +9242,7 @@ proc fileReader.readBinary(ref data: [?d] ?t, param endian = ioendian.native): i
    Note that this routine currently requires a local rectangular non-strided array.
 
    :arg data: an array to read into – existing values are overwritten.
-   :arg endian: :type:`ioendian` specifies the byte order in which
+   :arg endian: :type:`endianness` specifies the byte order in which
                 to read the number.
    :returns: the number of values that were read into the array. This can be
              less than ``data.size`` if EOF was reached, or an error occurred,
@@ -9251,21 +9251,21 @@ proc fileReader.readBinary(ref data: [?d] ?t, param endian = ioendian.native): i
    :throws SystemError: Thrown if data could not be read from the ``fileReader``
                         due to a :ref:`system error<io-general-sys-error>`.
 */
-proc fileReader.readBinary(ref data: [] ?t, endian: ioendian):int throws
+proc fileReader.readBinary(ref data: [] ?t, endian: endianness):int throws
   where isSuitableForBinaryReadWrite(data) && data.strides == strideKind.one && (
         isIntegralType(t) || isRealType(t) || isImagType(t) || isComplexType(t) )
 {
   var nr: int = 0;
 
   select (endian) {
-    when ioendian.native {
-      nr = this.readBinary(data, ioendian.native);
+    when endianness.native {
+      nr = this.readBinary(data, endianness.native);
     }
-    when ioendian.big {
-      nr = this.readBinary(data, ioendian.big);
+    when endianness.big {
+      nr = this.readBinary(data, endianness.big);
     }
-    when ioendian.little {
-      nr = this.readBinary(data, ioendian.little);
+    when endianness.little {
+      nr = this.readBinary(data, endianness.little);
     }
   }
 
@@ -9273,14 +9273,14 @@ proc fileReader.readBinary(ref data: [] ?t, endian: ioendian):int throws
 }
 
 @chpldoc.nodoc
-proc fileReader.readBinary(ref data: [] ?t, endian: ioendian):int throws
+proc fileReader.readBinary(ref data: [] ?t, endian: endianness):int throws
 {
   compilerError("readBinary() only supports local, rectangular, non-strided ",
                   "arrays of simple types");
 }
 
 @chpldoc.nodoc
-proc fileReader.readBinary(ref data: [] ?t, param endian = ioendian.native): bool throws
+proc fileReader.readBinary(ref data: [] ?t, param endian = endianness.native): bool throws
 {
   compilerError("readBinary() only supports local, rectangular, non-strided ",
                   "arrays of simple types");

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -8826,7 +8826,7 @@ proc fileWriter.writeBinary(arg:numeric, endian:endianness) throws {
     when endianness.native {
       this.writeBinary(arg, endianness.native);
     }
-    when endiannessssss.big {
+    when endianness.big {
       this.writeBinary(arg, endianness.big);
     }
     when endianness.little {

--- a/test/exercises/Mandelbrot/MPlot.chpl
+++ b/test/exercises/Mandelbrot/MPlot.chpl
@@ -162,23 +162,23 @@ const header_size = 14;
 
   // Write the BMP image header
   outfile.writef("BM");
-  outfile.writeBinary(size:uint(32), ioendian.little);
-  outfile.writeBinary(0:uint(16), ioendian.little); /* reserved1 */
-  outfile.writeBinary(0:uint(16), ioendian.little); /* reserved2 */
-  outfile.writeBinary(offset_to_pixel_data:uint(32), ioendian.little);
+  outfile.writeBinary(size:uint(32), endianness.little);
+  outfile.writeBinary(0:uint(16), endianness.little); /* reserved1 */
+  outfile.writeBinary(0:uint(16), endianness.little); /* reserved2 */
+  outfile.writeBinary(offset_to_pixel_data:uint(32), endianness.little);
 
   // Write the DIB header BITMAPINFOHEADER
-  outfile.writeBinary(dib_header_size:uint(32), ioendian.little);
-  outfile.writeBinary(cols:int(32), ioendian.little);
-  outfile.writeBinary(-rows:int(32), ioendian.little); /*neg for swap*/
-  outfile.writeBinary(1:uint(16), ioendian.little); /* 1 color plane */
-  outfile.writeBinary(bits_per_pixel:uint(16), ioendian.little);
-  outfile.writeBinary(0:uint(32), ioendian.little); /* no compression */
-  outfile.writeBinary(pixels_size:uint(32), ioendian.little);
-  outfile.writeBinary(2835:uint(32), ioendian.little); /*pixels/meter print resolution=72dpi*/
-  outfile.writeBinary(2835:uint(32), ioendian.little); /*pixels/meter print resolution=72dpi*/
-  outfile.writeBinary(0:uint(32), ioendian.little); /* colors in palette */
-  outfile.writeBinary(0:uint(32), ioendian.little); /* "important" colors */
+  outfile.writeBinary(dib_header_size:uint(32), endianness.little);
+  outfile.writeBinary(cols:int(32), endianness.little);
+  outfile.writeBinary(-rows:int(32), endianness.little); /*neg for swap*/
+  outfile.writeBinary(1:uint(16), endianness.little); /* 1 color plane */
+  outfile.writeBinary(bits_per_pixel:uint(16), endianness.little);
+  outfile.writeBinary(0:uint(32), endianness.little); /* no compression */
+  outfile.writeBinary(pixels_size:uint(32), endianness.little);
+  outfile.writeBinary(2835:uint(32), endianness.little); /*pixels/meter print resolution=72dpi*/
+  outfile.writeBinary(2835:uint(32), endianness.little); /*pixels/meter print resolution=72dpi*/
+  outfile.writeBinary(0:uint(32), endianness.little); /* colors in palette */
+  outfile.writeBinary(0:uint(32), endianness.little); /* "important" colors */
 
   //
   // compute the maximum number of steps that were taken, just in case

--- a/test/exercises/c-ray/Image.chpl
+++ b/test/exercises/c-ray/Image.chpl
@@ -122,23 +122,23 @@ proc writeImageBMP(outfile, pixels) {
 
   // Write the BMP image header
   outfile.writef("BM");
-  outfile.writeBinary(size:uint(32), ioendian.little);
-  outfile.writeBinary(0:uint(16), ioendian.little); /* reserved1 */
-  outfile.writeBinary(0:uint(16), ioendian.little); /* reserved2 */
-  outfile.writeBinary(offsetToPixelData:uint(32), ioendian.little);
+  outfile.writeBinary(size:uint(32), endianness.little);
+  outfile.writeBinary(0:uint(16), endianness.little); /* reserved1 */
+  outfile.writeBinary(0:uint(16), endianness.little); /* reserved2 */
+  outfile.writeBinary(offsetToPixelData:uint(32), endianness.little);
 
   // Write the DIB header BITMAPINFOHEADER
-  outfile.writeBinary(dibHeaderSize:uint(32), ioendian.little);
-  outfile.writeBinary(cols:int(32), ioendian.little);
-  outfile.writeBinary(-rows:int(32), ioendian.little); /*neg for swap*/
-  outfile.writeBinary(1:uint(16), ioendian.little); /* 1 color plane */
-  outfile.writeBinary(bitsPerPixel:uint(16), ioendian.little);
-  outfile.writeBinary(0:uint(32), ioendian.little); /* no compression */
-  outfile.writeBinary(pixelsSize:uint(32), ioendian.little);
-  outfile.writeBinary(2835:uint(32), ioendian.little); /*pixels/meter print resolution=72dpi*/
-  outfile.writeBinary(2835:uint(32), ioendian.little); /*pixels/meter print resolution=72dpi*/
-  outfile.writeBinary(0:uint(32), ioendian.little); /* colors in palette */
-  outfile.writeBinary(0:uint(32), ioendian.little); /* "important" colors */
+  outfile.writeBinary(dibHeaderSize:uint(32), endianness.little);
+  outfile.writeBinary(cols:int(32), endianness.little);
+  outfile.writeBinary(-rows:int(32), endianness.little); /*neg for swap*/
+  outfile.writeBinary(1:uint(16), endianness.little); /* 1 color plane */
+  outfile.writeBinary(bitsPerPixel:uint(16), endianness.little);
+  outfile.writeBinary(0:uint(32), endianness.little); /* no compression */
+  outfile.writeBinary(pixelsSize:uint(32), endianness.little);
+  outfile.writeBinary(2835:uint(32), endianness.little); /*pixels/meter print resolution=72dpi*/
+  outfile.writeBinary(2835:uint(32), endianness.little); /*pixels/meter print resolution=72dpi*/
+  outfile.writeBinary(0:uint(32), endianness.little); /* colors in palette */
+  outfile.writeBinary(0:uint(32), endianness.little); /* "important" colors */
 
   for i in pixels.domain.dim(0) {
     var nbits = 0;

--- a/test/exercises/duplicates/forStudents/FileHashing.chpl
+++ b/test/exercises/duplicates/forStudents/FileHashing.chpl
@@ -90,7 +90,7 @@ module FileHashing {
 
     var f = open(path, ioMode.r);
     var len = f.size;
-    var r = f.reader(deserializer=new binaryDeserializer(ioendian.big), locking=false,
+    var r = f.reader(deserializer=new binaryDeserializer(endianness.big), locking=false,
                      region=0..#len);
 
 

--- a/test/io/diten/checkpoint.chpl
+++ b/test/io/diten/checkpoint.chpl
@@ -16,10 +16,9 @@ proc readArrayCheckpoint(filename: string, A:[] ?t, nTasks: int = dataParTasksPe
     const eltSize = numBytes(A.eltType);
     const start = eltSize * if idx == offsetDom.low then 0 else cumulativeOffsets[idx-1];
     const end = eltSize * cumulativeOffsets[idx];
-    var ch = f.reader(region = start..#end, deserializer=new binaryDeserializer(ioendian.native));
+    var ch = f.reader(region = start..#end, deserializer=new binaryDeserializer(endianness.native));
 
     for sub in A.localSubdomains(targetLocs(idx)) {
-     
       ch.read(A[sub]);
     }
   }
@@ -43,7 +42,7 @@ proc checkpointArray(filename: string, A:[] ?t, nTasks: int = dataParTasksPerLoc
     const start = eltSize * if idx == offsetDom.low then 0 else cumulativeOffsets[idx-1];
     const end = eltSize * cumulativeOffsets[idx];
     var ch = f.writer(region = start..#end,
-                      serializer=new binarySerializer(ioendian.native));
+                      serializer=new binarySerializer(endianness.native));
     for sub in A.localSubdomains(targetLocs(idx)) {
       ch.write(A[sub]);
     }

--- a/test/io/ferguson/channel-changing-type.chpl
+++ b/test/io/ferguson/channel-changing-type.chpl
@@ -6,14 +6,14 @@ proc test1() {
   {
     var ch = f.writer(); // defaults to dynamic, text, locking
     // make a binary, unlocked channel using same buffer as ch
-    var cha = ch.withSerializer(new binarySerializer(ioendian.big));
+    var cha = ch.withSerializer(new binarySerializer(endianness.big));
     cha.write(1);
   }
 
   // check the output
   {
     var i: int;
-    f.reader().readBinary(i, ioendian.big);
+    f.reader().readBinary(i, endianness.big);
     assert(i == 1);
   }
 }
@@ -25,14 +25,14 @@ proc test2() {
   {
     var ch = f.writer(); // defaults to dynamic, text, locking
     // make a binary, unlocked channel using same buffer as ch
-    var cha = ch.withSerializer(new binarySerializer(ioendian.big));
+    var cha = ch.withSerializer(new binarySerializer(endianness.big));
     cha.write(1);
   }
 
   // check the output
   {
     var i: int;
-    f.reader().readBinary(i, ioendian.big);
+    f.reader().readBinary(i, endianness.big);
     assert(i == 1);
   }
 }

--- a/test/io/ferguson/writebinaryarray.chpl
+++ b/test/io/ferguson/writebinaryarray.chpl
@@ -4,14 +4,14 @@ var f = open("binary-output.bin", ioMode.cwr);
 
 var A = [1,2,3,4,5];
 {
-  var w = f.writer(serializer=new binarySerializer(ioendian.big));
+  var w = f.writer(serializer=new binarySerializer(endianness.big));
   writeln("Writing ", A);
   w.write(A);
   w.close();
 }
 
 {
-  var r = f.reader(deserializer=new binaryDeserializer(ioendian.big));
+  var r = f.reader(deserializer=new binaryDeserializer(endianness.big));
   var B = [0,0,0,0,0];
   r.read(B);
   writeln("Read ", B);
@@ -20,7 +20,7 @@ var A = [1,2,3,4,5];
 
 
 {
-  var r = f.reader(deserializer=new binaryDeserializer(ioendian.big));
+  var r = f.reader(deserializer=new binaryDeserializer(endianness.big));
   var num:int;
   var B = [0,0,0,0,0];
   var i=0;

--- a/test/io/ferguson/writebinaryclass.chpl
+++ b/test/io/ferguson/writebinaryclass.chpl
@@ -17,14 +17,14 @@ var ownA = new owned R(1,2,3,4,5);
 var A = ownA.borrow();
 
 {
-  var w = f.writer(serializer=new binarySerializer(ioendian.big));
+  var w = f.writer(serializer=new binarySerializer(endianness.big));
   writeln("Writing ", A);
   w.write(A);
   w.close();
 }
 
 {
-  var r = f.reader(deserializer=new binaryDeserializer(ioendian.big));
+  var r = f.reader(deserializer=new binaryDeserializer(endianness.big));
   var ownB = new owned R(0,0,0,0,0);
   var B = ownB.borrow();
 
@@ -36,7 +36,7 @@ var A = ownA.borrow();
 
 
 {
-  var r = f.reader(deserializer=new binaryDeserializer(ioendian.big));
+  var r = f.reader(deserializer=new binaryDeserializer(endianness.big));
   var ownB = new owned R(0,0,0,0,0);
   var B = ownB.borrow();
 

--- a/test/io/ferguson/writebinaryrecord.chpl
+++ b/test/io/ferguson/writebinaryrecord.chpl
@@ -12,14 +12,14 @@ var f = open("binary-output.bin", ioMode.cwr);
 
 var A = new R(1,2,3,4,5);
 {
-  var w = f.writer(serializer=new binarySerializer(ioendian.big));
+  var w = f.writer(serializer=new binarySerializer(endianness.big));
   writeln("Writing ", A);
   w.write(A);
   w.close();
 }
 
 {
-  var r = f.reader(deserializer=new binaryDeserializer(ioendian.big));
+  var r = f.reader(deserializer=new binaryDeserializer(endianness.big));
   var B = new R(0,0,0,0,0);
   r.read(B);
   writeln("Read ", B);
@@ -28,7 +28,7 @@ var A = new R(1,2,3,4,5);
 
 
 {
-  var r = f.reader(deserializer=new binaryDeserializer(ioendian.big));
+  var r = f.reader(deserializer=new binaryDeserializer(endianness.big));
   var B = new R(0,0,0,0,0);
   assert(r.read(B.a));
   assert(r.read(B.b));

--- a/test/io/ferguson/writebinarytuple.chpl
+++ b/test/io/ferguson/writebinarytuple.chpl
@@ -4,14 +4,14 @@ var f = open("binary-output.bin", ioMode.cwr);
 
 var A = (1,2,3,4,5);
 {
-  var w = f.writer(serializer=new binarySerializer(ioendian.big));
+  var w = f.writer(serializer=new binarySerializer(endianness.big));
   writeln("Writing ", A);
   w.write(A);
   w.close();
 }
 
 {
-  var r = f.reader(deserializer=new binaryDeserializer(ioendian.big));
+  var r = f.reader(deserializer=new binaryDeserializer(endianness.big));
   var B = (0,0,0,0,0);
   r.read(B);
   writeln("Read ", B);
@@ -20,7 +20,7 @@ var A = (1,2,3,4,5);
 
 
 {
-  var r = f.reader(deserializer=new binaryDeserializer(ioendian.big));
+  var r = f.reader(deserializer=new binaryDeserializer(endianness.big));
   var num:int;
   var B = (0,0,0,0,0);
   var i=0;

--- a/test/io/ferguson/zerosatend.chpl
+++ b/test/io/ferguson/zerosatend.chpl
@@ -10,7 +10,7 @@ var n = sz / 8;
 {
   var tmp = open(testfile, ioMode.cwr);
 
-  var och = tmp.writer(serializer=new binarySerializer(ioendian.big));
+  var och = tmp.writer(serializer=new binarySerializer(endianness.big));
   for i in 0..#n {
     var x:uint(64) = i:uint(64);
     och.write(x);
@@ -24,7 +24,7 @@ var n = sz / 8;
 {
   var tmp = open(testfile, ioMode.r);
 
-  var ich = tmp.reader(deserializer=new binaryDeserializer(ioendian.big));
+  var ich = tmp.reader(deserializer=new binaryDeserializer(endianness.big));
   for i in 0..#n {
     var x:uint(64);
     var got = ich.read(x);

--- a/test/io/jhh/readbinary.chpl
+++ b/test/io/jhh/readbinary.chpl
@@ -20,9 +20,9 @@ var x64:complex(64) = 3.14159 + 2.718i;
 var x128:complex(128) = 3.14159 + 2.718i;
 
 
-var endians = [ioendian.native, ioendian.little, ioendian.big];
- 
-proc readone(expected:numeric, endian:ioendian=ioendian.native) {
+var endians = [endianness.native, endianness.little, endianness.big];
+
+proc readone(expected:numeric, endian:endianness=endianness.native) {
     var inp: expected.type;
     stdin.readBinary(inp, endian);
     assert(inp == expected, inp.type:string, inp, expected);

--- a/test/io/jhh/writebinary.chpl
+++ b/test/io/jhh/writebinary.chpl
@@ -19,7 +19,7 @@ var im64:imag(64) = 3.14159i;
 var x64:complex(64) = 3.14159 + 2.718i;
 var x128:complex(128) = 3.14159 + 2.718i;
 
-var endians = [ioendian.native, ioendian.little, ioendian.big];
+var endians = [endianness.native, endianness.little, endianness.big];
 
 proc output(arg:numeric) {
     for endian in endians {

--- a/test/io/serializers/FormatHelper.chpl
+++ b/test/io/serializers/FormatHelper.chpl
@@ -26,12 +26,12 @@ module FormatHelper {
         else return new jsonDeserializer();
       }
       when FormatKind.little {
-        if writing then return new binarySerializer(endian=IO.ioendian.little);
-        else return new binaryDeserializer(endian=IO.ioendian.little);
+        if writing then return new binarySerializer(endian=IO.endianness.little);
+        else return new binaryDeserializer(endian=IO.endianness.little);
       }
       when FormatKind.big {
-        if writing then return new binarySerializer(endian=IO.ioendian.big);
-        else return new binaryDeserializer(endian=IO.ioendian.big);
+        if writing then return new binarySerializer(endian=IO.endianness.big);
+        else return new binaryDeserializer(endian=IO.endianness.big);
       }
       when FormatKind.syntax {
         if writing then return new chplSerializer();

--- a/test/library/standard/IO/readBinary/arrayOfValues.chpl
+++ b/test/library/standard/IO/readBinary/arrayOfValues.chpl
@@ -5,25 +5,25 @@ use IO;
 
 testBinaryRead("./input/tu8.bin", makeUnsignedArray(8));
 
-testBinaryRead("./input/tu16.bin", makeUnsignedArray(16), ioendian.big);
-testBinaryRead("./input/tu32.bin", makeUnsignedArray(32), ioendian.big);
-testBinaryRead("./input/tu64.bin", makeUnsignedArray(64), ioendian.big);
+testBinaryRead("./input/tu16.bin", makeUnsignedArray(16), endianness.big);
+testBinaryRead("./input/tu32.bin", makeUnsignedArray(32), endianness.big);
+testBinaryRead("./input/tu64.bin", makeUnsignedArray(64), endianness.big);
 
-testBinaryRead("./input/tu16le.bin", makeUnsignedArray(16), ioendian.little);
-testBinaryRead("./input/tu32le.bin", makeUnsignedArray(32), ioendian.little);
-testBinaryRead("./input/tu64le.bin", makeUnsignedArray(64), ioendian.little);
+testBinaryRead("./input/tu16le.bin", makeUnsignedArray(16), endianness.little);
+testBinaryRead("./input/tu32le.bin", makeUnsignedArray(32), endianness.little);
+testBinaryRead("./input/tu64le.bin", makeUnsignedArray(64), endianness.little);
 
 testBinaryRead("./input/ti8.bin", makeSignedArray(8));
 
-testBinaryRead("./input/ti16.bin", makeSignedArray(16), ioendian.big);
-testBinaryRead("./input/ti32.bin", makeSignedArray(32), ioendian.big);
-testBinaryRead("./input/ti64.bin", makeSignedArray(64), ioendian.big);
+testBinaryRead("./input/ti16.bin", makeSignedArray(16), endianness.big);
+testBinaryRead("./input/ti32.bin", makeSignedArray(32), endianness.big);
+testBinaryRead("./input/ti64.bin", makeSignedArray(64), endianness.big);
 
-testBinaryRead("./input/ti16le.bin", makeSignedArray(16), ioendian.little);
-testBinaryRead("./input/ti32le.bin", makeSignedArray(32), ioendian.little);
-testBinaryRead("./input/ti64le.bin", makeSignedArray(64), ioendian.little);
+testBinaryRead("./input/ti16le.bin", makeSignedArray(16), endianness.little);
+testBinaryRead("./input/ti32le.bin", makeSignedArray(32), endianness.little);
+testBinaryRead("./input/ti64le.bin", makeSignedArray(64), endianness.little);
 
-proc testBinaryRead(path: string, expected_values, endian: ioendian = ioendian.native) {
+proc testBinaryRead(path: string, expected_values, endian: endianness = endianness.native) {
     var reader = openReader(path);
     var values : expected_values.type;
 

--- a/test/library/standard/IO/readBinary/multiloc/binaryArray.chpl
+++ b/test/library/standard/IO/readBinary/multiloc/binaryArray.chpl
@@ -8,7 +8,7 @@ on Locales[0] {
         var a : [0..<8] uint(8);
 
         on Locales[2] {
-            const numRead = reader.readBinary(a, ioendian.native),
+            const numRead = reader.readBinary(a, endianness.native),
                   correct = && reduce (a == a_expected);
             writeln(numRead, " ", correct);
         }

--- a/test/library/standard/IO/writeBinary/writeArray.chpl
+++ b/test/library/standard/IO/writeBinary/writeArray.chpl
@@ -3,24 +3,24 @@ use IO;
 testBinaryWrite("U8", makeUnsignedArray(8));
 testBinaryWrite("I8", makeSignedArray(8));
 
-testBinaryWrite("U16_BE", makeUnsignedArray(16), ioendian.big);
-testBinaryWrite("U32_BE", makeUnsignedArray(32), ioendian.big);
-testBinaryWrite("U64_BE", makeUnsignedArray(64), ioendian.big);
+testBinaryWrite("U16_BE", makeUnsignedArray(16), endianness.big);
+testBinaryWrite("U32_BE", makeUnsignedArray(32), endianness.big);
+testBinaryWrite("U64_BE", makeUnsignedArray(64), endianness.big);
 
-testBinaryWrite("U16_LE", makeUnsignedArray(16), ioendian.little);
-testBinaryWrite("U32_LE", makeUnsignedArray(32), ioendian.little);
-testBinaryWrite("U64_LE", makeUnsignedArray(64), ioendian.little);
+testBinaryWrite("U16_LE", makeUnsignedArray(16), endianness.little);
+testBinaryWrite("U32_LE", makeUnsignedArray(32), endianness.little);
+testBinaryWrite("U64_LE", makeUnsignedArray(64), endianness.little);
 
-testBinaryWrite("I16_BE", makeSignedArray(16), ioendian.big);
-testBinaryWrite("I32_BE", makeSignedArray(32), ioendian.big);
-testBinaryWrite("I64_BE", makeSignedArray(64), ioendian.big);
+testBinaryWrite("I16_BE", makeSignedArray(16), endianness.big);
+testBinaryWrite("I32_BE", makeSignedArray(32), endianness.big);
+testBinaryWrite("I64_BE", makeSignedArray(64), endianness.big);
 
-testBinaryWrite("I16_LE", makeSignedArray(16), ioendian.little);
-testBinaryWrite("I32_LE", makeSignedArray(32), ioendian.little);
-testBinaryWrite("I64_LE", makeSignedArray(64), ioendian.little);
+testBinaryWrite("I16_LE", makeSignedArray(16), endianness.little);
+testBinaryWrite("I32_LE", makeSignedArray(32), endianness.little);
+testBinaryWrite("I64_LE", makeSignedArray(64), endianness.little);
 
 
-proc testBinaryWrite(testName, values, endian: ioendian = ioendian.native) {
+proc testBinaryWrite(testName, values, endian: endianness = endianness.native) {
     var w = openWriter(testName + ".bin");
     w.writeBinary(values, endian);
 }

--- a/test/release/examples/primers/FFTWlib.chpl
+++ b/test/release/examples/primers/FFTWlib.chpl
@@ -120,7 +120,7 @@ proc runtest(param ndim : int, fn : string) {
   var A,B,goodA,goodB : [D] complex(128);
   {
     use IO;
-    var f = open(fn,ioMode.r).reader(deserializer=new binaryDeserializer(endiannessss.little));
+    var f = open(fn,ioMode.r).reader(deserializer=new binaryDeserializer(endianness.little));
 
     // Read in dimensions
     for d in dims {

--- a/test/release/examples/primers/FFTWlib.chpl
+++ b/test/release/examples/primers/FFTWlib.chpl
@@ -120,7 +120,7 @@ proc runtest(param ndim : int, fn : string) {
   var A,B,goodA,goodB : [D] complex(128);
   {
     use IO;
-    var f = open(fn,ioMode.r).reader(deserializer=new binaryDeserializer(ioendian.little));
+    var f = open(fn,ioMode.r).reader(deserializer=new binaryDeserializer(endiannessss.little));
 
     // Read in dimensions
     for d in dims {

--- a/test/studies/ml/lib/Chai.chpl
+++ b/test/studies/ml/lib/Chai.chpl
@@ -16,7 +16,7 @@
         - Returns a string that uniquely identifies the layer and its hyperparameters parameters.
 */
 module Chai {
-    
+
     import Tensor as tn;
     use Tensor only Tensor;
 
@@ -671,7 +671,7 @@ module Chai {
 
         proc ref save(path: string) throws {
             var file = IO.open(path, IO.ioMode.cw);
-            var serializer = new IO.binarySerializer(IO.ioendian.big);
+            var serializer = new IO.binarySerializer(IO.endianness.big);
             var fw = file.writer(serializer=serializer);
             // fw.write("[network]");
             fw.write(layers.size);
@@ -683,7 +683,7 @@ module Chai {
 
         proc ref load(path: string) throws {
             var file = IO.open(path, IO.ioMode.rw);
-            var deserializer = new IO.binaryDeserializer(IO.ioendian.big);
+            var deserializer = new IO.binaryDeserializer(IO.endianness.big);
             var fr = file.reader(deserializer=deserializer);
             var size = fr.read(int);
             if size != layers.size then err("Network load: size mismatch");

--- a/test/studies/ml/lib/MNIST.chpl
+++ b/test/studies/ml/lib/MNIST.chpl
@@ -4,7 +4,7 @@ use IO;
 
 proc loadImages(num: int, fileName: string = "week2/emnist/data/train-images-idx3-ubyte") {
 
-    var deserializer = new binaryDeserializer(ioendian.big);
+    var deserializer = new binaryDeserializer(endianness.big);
 
     var fr = openReader(fileName, deserializer=deserializer);
 
@@ -43,7 +43,7 @@ proc loadImages(num: int, fileName: string = "week2/emnist/data/train-images-idx
 
 proc loadLabels(num: int, fileName: string = "week2/emnist/data/train-labels-idx1-ubyte") {
 
-    var deserializer = new binaryDeserializer(ioendian.big);
+    var deserializer = new binaryDeserializer(endianness.big);
 
     var fr = openReader(fileName, deserializer=deserializer);
 

--- a/test/studies/ssca2/graphio/SSCA2_RMAT_graph_generator.chpl
+++ b/test/studies/ssca2/graphio/SSCA2_RMAT_graph_generator.chpl
@@ -344,8 +344,8 @@ proc createGraphChannel(prefix:string, suffix:string, param forWriting:bool) {
                  if forWriting then ioMode.cw else ioMode.r,
                  ioHintSet.sequential);
   const chan = if forWriting
-    then f.writer(serializer=new binarySerializer(ioendian.big), false)
-    else f.reader(deserializer=new binaryDeserializer(ioendian.big), false);
+    then f.writer(serializer=new binarySerializer(endianness.big), false)
+    else f.reader(deserializer=new binaryDeserializer(endianness.big), false);
   return chan;
 }
 

--- a/test/studies/ssca2/main/SSCA2_Modules/io_RMAT_graph.chpl
+++ b/test/studies/ssca2/main/SSCA2_Modules/io_RMAT_graph.chpl
@@ -17,7 +17,7 @@ config const EV2_FILENAME    = "ev2_snapshot.data";
 config const START_FILENAME  = "start_snapshot.data";
 config const WEIGHT_FILENAME = "weight_snapshot.data";
 config type  IONumType       = int(64);
-config param IOendianness    = ioendian.big;
+config param IOendianness    = endianness.big;
 config const IOserial        = false;
 config const IOsingleTaskPerLocale = true;
 

--- a/test/users/npadmana/fftw/testFFTWsegfault.chpl
+++ b/test/users/npadmana/fftw/testFFTWsegfault.chpl
@@ -19,7 +19,7 @@ proc runtest(param ndim : int, fn : string) {
   var rD,cD,reD,imD : domain(ndim,int,strideKind.any); 
   var A,B,goodA,goodB : [D] fftw_complex;
   {
-    var f = open(fn,ioMode.r).reader(deserializer=new binaryDeserializer(ioendian.little));
+    var f = open(fn,ioMode.r).reader(deserializer=new binaryDeserializer(endianness.little));
     for ii in 1..ndim {
       f.read(dims(ii));
     }

--- a/util/devel/chplspell-dictionary
+++ b/util/devel/chplspell-dictionary
@@ -7908,7 +7908,7 @@ iobig
 ioctldata
 ioctlfunction
 iodynamic
-ioendian
+endianness
 ioerror
 iohint
 iohints
@@ -9833,4 +9833,3 @@ zypper
 øbenhavns
 ławski
 śniak
-


### PR DESCRIPTION
Based on the discussion about the name change for `ioendian`.

Resolves https://github.com/chapel-lang/chapel/issues/23868

- [X] paratest
- [X] gasnet paratest
- [X] c backent paratest