### PR TITLE
test fixes for 23931 (don't gpuize + reduce loops)

### DIFF
--- a/test/gpu/native/basics/reductionNoGpuize.good
+++ b/test/gpu/native/basics/reductionNoGpuize.good
@@ -1,2 +1,1 @@
-warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
 55

--- a/test/gpu/native/loopNaming.chpl
+++ b/test/gpu/native/loopNaming.chpl
@@ -1,5 +1,5 @@
 on here.gpus[0] {
-    writeln(+ reduce (1..100));
+    [i in 1..100];
     f();
     g();
     h();
@@ -7,12 +7,12 @@ on here.gpus[0] {
 }
 
 proc f() {
-    writeln(+ reduce (1..100));
-    writeln(+ reduce (1..100));
+    [i in 1..100];
+    [i in 1..100];
 }
 
 proc g() {
-    writeln(+ reduce (1..100));
+    [i in 1..100];
     var A: [0..#100] int;
     foreach a in A {
         a += 1;
@@ -21,8 +21,8 @@ proc g() {
 }
 
 inline proc h() {
-    writeln(+ reduce (1..100));
-    writeln(+ reduce (1..100));
+    [i in 1..100];
+    [i in 1..100];
 }
 
 proc i() {


### PR DESCRIPTION
Looks like I accidentally introduced some test failures after merging #23931.

- One involves a warning that gets filtered out by default during our test runs that I was erroneously locking down,
- another involves a test that previously assumed we gpuized (+ reduce) operations to gpu kernels.