### PR TITLE
Deprecate `ioendian`

### DIFF
--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1705,6 +1705,7 @@ static void resolveEnumeratedTypes() {
         // Go through chains like:
         // enum color = { ... }
         // type col = color;
+        // var a = col.red;
         SymExpr* firstDeAliased = first;
         while (auto varSym = toVarSymbol(firstDeAliased->symbol())) {
           if (!varSym->hasFlag(FLAG_TYPE_VARIABLE)) break;

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1702,7 +1702,18 @@ static void resolveEnumeratedTypes() {
       SET_LINENO(call);
 
       if (SymExpr* first = toSymExpr(call->get(1))) {
-        if (EnumType* type = toEnumType(first->symbol()->type)) {
+        // Go through chains like:
+        // enum color = { ... }
+        // type col = color;
+        SymExpr* firstDeAliased = first;
+        while (auto varSym = toVarSymbol(firstDeAliased->symbol())) {
+          if (!varSym->hasFlag(FLAG_TYPE_VARIABLE)) break;
+          if (!toSymExpr(varSym->defPoint->init)) break;
+
+          firstDeAliased = toSymExpr(varSym->defPoint->init);
+        }
+
+        if (EnumType* type = toEnumType(firstDeAliased->symbol()->type)) {
           if (SymExpr* second = toSymExpr(call->get(2))) {
             const char* name;
 

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1705,7 +1705,7 @@ static void resolveEnumeratedTypes() {
         // Go through chains like:
         // enum color = { ... }
         // type col = color;
-        // var a = col.red;
+        // which is needed to support e.g. 'col.red'
         SymExpr* firstDeAliased = first;
         while (auto varSym = toVarSymbol(firstDeAliased->symbol())) {
           if (!varSym->hasFlag(FLAG_TYPE_VARIABLE)) break;

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -835,6 +835,8 @@ enum endianness {
   little = 2
 }
 
+@deprecated(":enum: ioendian is dprecated - please use :enum: endianness instead")
+type ioendian = endianness;
 
 /*
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -835,7 +835,7 @@ enum endianness {
   little = 2
 }
 
-@deprecated(":enum: ioendian is dprecated - please use :enum: endianness instead")
+@deprecated(":enum: ioendian is deprecated; please use :enum: endianness instead")
 type ioendian = endianness;
 
 /*

--- a/test/deprecated/IO/ioendian/ioendianUse.chpl
+++ b/test/deprecated/IO/ioendian/ioendianUse.chpl
@@ -1,0 +1,19 @@
+use IO;
+
+var k : ioendian;
+
+var a = ioendian.big;
+var b = ioendian.native;
+var c = ioendian.little;
+
+var f = openMemFile();
+var reader = f.reader(deserializer=new binaryDeserializer(ioendian.big));
+var writer = f.writer(serializer=new binarySerializer(ioendian.big));
+
+var ds = new binaryDeserializer(ioendian.little);
+var s = new binarySerializer(ioendian.little);
+var r2 = f.reader(deserializer=ds);
+var w2 = f.writer(serializer=s);
+
+writeln(ds.endian);
+writeln(s.endian);

--- a/test/deprecated/IO/ioendian/ioendianUse.good
+++ b/test/deprecated/IO/ioendian/ioendianUse.good
@@ -1,0 +1,10 @@
+ioendianUse.chpl:3: warning: :enum: ioendian is deprecated; please use :enum: endianness instead
+ioendianUse.chpl:5: warning: :enum: ioendian is deprecated; please use :enum: endianness instead
+ioendianUse.chpl:6: warning: :enum: ioendian is deprecated; please use :enum: endianness instead
+ioendianUse.chpl:7: warning: :enum: ioendian is deprecated; please use :enum: endianness instead
+ioendianUse.chpl:10: warning: :enum: ioendian is deprecated; please use :enum: endianness instead
+ioendianUse.chpl:11: warning: :enum: ioendian is deprecated; please use :enum: endianness instead
+ioendianUse.chpl:13: warning: :enum: ioendian is deprecated; please use :enum: endianness instead
+ioendianUse.chpl:14: warning: :enum: ioendian is deprecated; please use :enum: endianness instead
+little
+little

--- a/test/deprecated/IO/ioendian/readWriteBinary.chpl
+++ b/test/deprecated/IO/ioendian/readWriteBinary.chpl
@@ -1,0 +1,26 @@
+use IO;
+
+var f = openMemFile();
+
+
+proc writeout(arg:numeric) {
+    f.writer().writeBinary(arg, ioendian.little);
+    f.writer().writeBinary(arg, ioendian.big);
+    f.writer().writeBinary(arg, ioendian.native);
+}
+
+proc readin(ref arg:int) {
+  f.reader().readBinary(arg, ioendian.little);
+  f.reader().readBinary(arg, ioendian.big);
+  f.reader().readBinary(arg, ioendian.native);
+
+}
+
+
+writeout(0x15678);
+writeout(0x12345678);
+writeout(0x31);
+var x : int;
+readin(x);
+readin(x);
+readin(x);

--- a/test/deprecated/IO/ioendian/readWriteBinary.good
+++ b/test/deprecated/IO/ioendian/readWriteBinary.good
@@ -1,0 +1,8 @@
+readWriteBinary.chpl:6: In function 'writeout':
+readWriteBinary.chpl:7: warning: :enum: ioendian is deprecated; please use :enum: endianness instead
+readWriteBinary.chpl:8: warning: :enum: ioendian is deprecated; please use :enum: endianness instead
+readWriteBinary.chpl:9: warning: :enum: ioendian is deprecated; please use :enum: endianness instead
+readWriteBinary.chpl:12: In function 'readin':
+readWriteBinary.chpl:13: warning: :enum: ioendian is deprecated; please use :enum: endianness instead
+readWriteBinary.chpl:14: warning: :enum: ioendian is deprecated; please use :enum: endianness instead
+readWriteBinary.chpl:15: warning: :enum: ioendian is deprecated; please use :enum: endianness instead


### PR DESCRIPTION
Using @DanilaFe 's (thanks!) strategy to have `ioendian` be a type alias to the new `endianness` enum.
This didn't work at first because the alias was a reference to a type variable instead of a type itself, so we dereference hoping that there's a type declaration at the end.

Added testing for deprecated `ioendian`

- [x] paratest
- [x] gasnet paratest
- [x] c backend paratest
