### PR TITLE
Change flag for failing test with `--fast`

### DIFF
--- a/test/llvm/ccflags/llvmBackendCCflagsSplitBySpaces.compopts
+++ b/test/llvm/ccflags/llvmBackendCCflagsSplitBySpaces.compopts
@@ -1,1 +1,1 @@
---ccflags -mllvm --ccflags -force-vector-width=8
+--ccflags -mllvm --ccflags -force-vector-width=0


### PR DESCRIPTION
Changes the value of a flag to force vector optimization widths to 0. Under llvm optimization (`--fast`), llvm complains about missed optimizations. This is outside our control, but since the test is just that flags can be passed with a space, it does not matter the value of the flag.

[Not reviewed - trivial]
