### PR TITLE
Skip this test with --fast

### DIFF
--- a/test/unstableAnonScript/specialCases/constArgs.skipif
+++ b/test/unstableAnonScript/specialCases/constArgs.skipif
@@ -1,0 +1,2 @@
+# This check is turned off by --fast, so don't run with it
+COMPOPTS <= --fast


### PR DESCRIPTION
The check this test validates doesn't run when --fast is used, so skip it

Verified the skipif worked in a fresh checkout