### PR TITLE
Fix memory leak with const check warning message

### DIFF
--- a/runtime/src/chpl-const-arg-check.c
+++ b/runtime/src/chpl-const-arg-check.c
@@ -21,6 +21,7 @@
 
 #include "chplrt.h"
 #include "chpl-linefile-support.h"
+#include "chpl-mem.h"
 #include "error.h"
 
 // FNV-1a hash function, a "string hash"
@@ -41,7 +42,7 @@ void check_const_hash_matches(uint64_t start_val, uint64_t end_val,
                               const char* arg_name, int32_t lineno,
                               int32_t filenameIdx) {
   if (start_val != end_val) {
-    const char* warning_msg = chpl_glom_strings(8, "The argument '", arg_name,
+    char* warning_msg = chpl_glom_strings(8, "The argument '", arg_name,
                       "' was modified indirectly during this function, this ",
                       "behavior is unstable and may change in the future.\n",
                       "If this behavior is intentional, declaring the argument",
@@ -49,5 +50,6 @@ void check_const_hash_matches(uint64_t start_val, uint64_t end_val,
                       "declaring the argument as 'const in' will prevent ",
                       "indirect modifications");
     chpl_warning(warning_msg, lineno, filenameIdx);
+    chpl_mem_free(warning_msg, 0, 0);
   }
 }


### PR DESCRIPTION
chpl_glom_strings allocates memory for the message, so we need to clean it up when we are done with it.

Checked the new tests with `-memLeaks` and the remote test with CHPL_COMM=gasnet and `-memLeaks`