### PR TITLE
Update driver technote Future Work to reflect current status

### DIFF
--- a/doc/rst/technotes/driver.rst
+++ b/doc/rst/technotes/driver.rst
@@ -72,11 +72,5 @@ to be useful to compiler developers. Both are documented here.
 Future Work
 -----------
 
-- Fix driver behavior for GPU compilation, which currently performs all work
-  in compilation and skips makeBinary.
-- Reduce work re-done between driver and phase invocations.
-- Enable our usual performance and correctness testing for driver mode, and
-  reach parity with monolithic mode.
-- Measure performance of compiler itself in driver mode, including change in
-  memory pressure.
-- Eventually, make compiler driver mode the default, with an opt-out flag.
+- Fix driver mode bugs encountered in testing.
+- Make compiler driver mode the default, with an opt-out flag.


### PR DESCRIPTION
Update Future Work bullets in the driver technote to reflect the current status of the work.

I left the issues to be resolved vague since we don't know enough about their cause yet to provide any useful information.

[minor dev-oriented docs change, not reviewed]