### PR TITLE
Use backend's `clang-offload-bundler` instead of ROCm's

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -4712,11 +4712,13 @@ static void makeBinaryLLVMForHIP(const std::string& artifactFilename,
   // So this loop should run exactly one iteration.
   INT_ASSERT(gpuArches.size() == 1);
 
-  std::string targets;
+  std::string targets = "-targets=host-x86_64-unknown-linux";
 #if HAVE_LLVM_VER >= 150
   std::string inputs = "-input=/dev/null ";
+  std::string outputs = "-output=" + fatbinFilename;
 #else
   std::string inputs = "-inputs=/dev/null";
+  std::string outputs = "-outputs=" + fatbinFilename;
 #endif
   for (auto& gpuArch : gpuArches) {
     std::string gpuObject = gpuObjFilename + "_" + gpuArch + ".o";
@@ -4748,11 +4750,10 @@ static void makeBinaryLLVMForHIP(const std::string& artifactFilename,
 
   }
   std::string bundlerCmd = findSiblingClangToolPath("clang-offload-bundler") +
-                           " -type=o -bundle-align=4096" +
-                           " -targets=host-x86_64-unknown-linux" +
+                           " -type=o -bundle-align=4096 " +
                            targets + " " +
-                           inputs +
-                           " -output=" + fatbinFilename;
+                           inputs + " " +
+                           outputs;
 
   mysystem(bundlerCmd.c_str(), ".out file to fatbin file");
 }

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -4713,7 +4713,11 @@ static void makeBinaryLLVMForHIP(const std::string& artifactFilename,
   INT_ASSERT(gpuArches.size() == 1);
 
   std::string targets;
+#if HAVE_LLVM_VER >= 150
   std::string inputs = "-input=/dev/null ";
+#else
+  std::string inputs = "-inputs=/dev/null";
+#endif
   for (auto& gpuArch : gpuArches) {
     std::string gpuObject = gpuObjFilename + "_" + gpuArch + ".o";
     std::string gpuOut = outFilenamePrefix + "_" + gpuArch + ".out";
@@ -4736,7 +4740,11 @@ static void makeBinaryLLVMForHIP(const std::string& artifactFilename,
     mysystem(lldCmd.c_str(), "Device .o file to .out file");
 
     targets += std::string(",hipv4-amdgcn-amd-amdhsa--") + gpuArch;
+#if HAVE_LLVM_VER >= 150
     inputs += "-input=" + gpuOut + " ";
+#else
+    inputs += "," + gpuOut;
+#endif
 
   }
   std::string bundlerCmd = findSiblingClangToolPath("clang-offload-bundler") +

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -4713,7 +4713,7 @@ static void makeBinaryLLVMForHIP(const std::string& artifactFilename,
   INT_ASSERT(gpuArches.size() == 1);
 
   std::string targets;
-  std::string inputs;
+  std::string inputs = "-input=/dev/null ";
   for (auto& gpuArch : gpuArches) {
     std::string gpuObject = gpuObjFilename + "_" + gpuArch + ".o";
     std::string gpuOut = outFilenamePrefix + "_" + gpuArch + ".out";
@@ -4736,17 +4736,15 @@ static void makeBinaryLLVMForHIP(const std::string& artifactFilename,
     mysystem(lldCmd.c_str(), "Device .o file to .out file");
 
     targets += std::string(",hipv4-amdgcn-amd-amdhsa--") + gpuArch;
-    inputs += std::string(",") + gpuOut;
+    inputs += "-input=" + gpuOut + " ";
 
   }
-  std::string bundlerCmd = std::string(gGpuSdkPath) +
-                          "/llvm/bin/clang-offload-bundler" +
+  std::string bundlerCmd = findSiblingClangToolPath("clang-offload-bundler") +
                            " -type=o -bundle-align=4096" +
                            " -targets=host-x86_64-unknown-linux" +
-                           targets +
-                           " -inputs=/dev/null" +
+                           targets + " " +
                            inputs +
-                           " -outputs=" + fatbinFilename;
+                           " -output=" + fatbinFilename;
 
   mysystem(bundlerCmd.c_str(), ".out file to fatbin file");
 }


### PR DESCRIPTION
Resolves https://github.com/Cray/chapel-private/issues/5509

Since the beginning of AMD support, we have been using `clang-offload-bundler` from the ROCm installation instead of from our backend. This is probably based on a decision in the prototyping phase that we haven't revisited or didn't feel the need to.

Recently, we've observed that this resulted in some deprecation warnings because the flags we use while launching `clang-offload-bundler`: https://github.com/chapel-lang/chapel/issues/23480. Sticking to ROCm's bundler, we'd have to do some wiring to be able to determine the version so that we can use the right arguments. We already have that wiring laid out for the backend's clang version. So, with this PR, we'll start using backend's bundler. On a more abstract level, it also makes sense to prefer that one as we're generating the binary that the bundler works with using our backend and not ROCm's clang.

This allows choosing the right arguments for passing inputs and outputs to and from `clang-offload-bundler`.

While there, this PR also adjusts how we generate the `targets` argument to make the implementation more consistent.

Test:
- [x] amd with rocm 4.4
- [x] spot-check amd with rocm 5.2, 5.3, 5.4
- [x] spot-check nvidia