### PR TITLE
Use https link while cloning champs-nightly repo in CHAMPS testing

### DIFF
--- a/test/studies/champs/sub_test
+++ b/test/studies/champs/sub_test
@@ -20,7 +20,7 @@ if [ ! -z "$CHAMPS_QUICKSTART" ]; then
   else 
     echo "Creating $CHAMPS_COMMON_DIR"
     pushd $(dirname $CHAMPS_COMMON_DIR)
-    git clone git@github.com:chapelu-champs/champs-nightly.git
+    git clone https://github.com/chapelu-champs/champs-nightly.git
     popd
   fi
 else


### PR DESCRIPTION
@mppf mentioned that he needed to use HTTPS to clone the champs-nightly repo while triaging CHAMPS warnings locally. This PR changes the link to use HTTPS in `sub_test` as well. This should be more portable in general.