### PR TITLE
Simple summary of ctest failures with path to filename

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -173,7 +173,7 @@ test-frontend: FORCE $(CHPL_CONFIG_CHECK) $(COMPILER_BUILD)
 	@echo "Making symbolic link to frontend tests in build/frontend-test"
 	@cd ../build && rm -f frontend-test && ln -s $(COMPILER_BUILD)/frontend/test frontend-test
 	JOBSFLAG=`echo "$$MAKEFLAGS" | sed -n 's/.*\(-j\|--jobs=\) *\([0-9][0-9]*\).*/-j\2/p'` ; \
-	  cd $(COMPILER_BUILD)/frontend/test && ctest $$JOBSFLAG . ;
+	  cd $(COMPILER_BUILD)/frontend/test && ctest $$JOBSFLAG . || $(CHPL_MAKE_HOME)/frontend/util/ctestSummary.sh $(CHPL_MAKE_HOME) $$?;
 	@echo "frontend tests are available in build/frontend-test"
 
 COPY_IF_DIFFERENT = $(CHPL_MAKE_PYTHON) $(CHPL_MAKE_HOME)/util/config/update-if-different --quiet --copy

--- a/frontend/util/ctestSummary.sh
+++ b/frontend/util/ctestSummary.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+CHPL_MAKE_HOME=$1
+ctest_exit_code=$2
+
+log=${CHPL_MAKE_HOME}/build/frontend-test/Testing/Temporary/LastTestsFailed.log
+numFailures=$(wc -l < $log)
+
+echo ""
+echo "Testing summary: $numFailures Failures:"
+
+for line in $(cat $log); do
+  testName=$(cut -d ':' -f 2 <<< $line)
+  fname=$(find ${CHPL_MAKE_HOME}/frontend/test -name "$testName.cpp" | head -n 1)
+  echo $fname
+done
+
+echo
+
+exit $ctest_exit_code


### PR DESCRIPTION
This PR adds some additional output to the ``test-frontend`` make target that lists the failed tests as a full path to the appropriate file. This may be beneficial to users who do not work in the frontend regularly.