### PR TITLE
Fix lint checks for CamelCaseFunctions on operators

### DIFF
--- a/test/chplcheck/CaseRules.chpl
+++ b/test/chplcheck/CaseRules.chpl
@@ -50,4 +50,6 @@ module CaseRules {
 
   var justOneCapitalLetterAtTheE: string;
   const justO: real;
+
+  operator +(a: int, b: string) {}
 }

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -52,6 +52,7 @@ def register_rules(driver):
     @driver.basic_rule(Function)
     def CamelCaseFunctions(context, node):
         if node.linkage() == 'extern': return True
+        if node.kind() == 'operator': return True
         return check_camel_case(node)
 
     @driver.basic_rule(Class)


### PR DESCRIPTION
The chplcheck warning to camel case functions was incorrectly firing for operators, since they use non-ascii charcters. This PR just skips checking operator function names.

Tested locally

[Reviewed by @brandon-neth]