### PR TITLE
Fix an include in the runtime causing failures while building with ROCm 4

### DIFF
--- a/runtime/src/gpu/amd/gpu-amd-reduce.cc
+++ b/runtime/src/gpu/amd/gpu-amd-reduce.cc
@@ -19,11 +19,12 @@
 
 #ifdef HAS_GPU_LOCALE
 
-#include "../common/rocm-utils.h"
 
 #include <hip/hip_common.h>
 
 #if ROCM_VERSION_MAJOR >= 5
+// if we include this all the time, we get unused function errors
+#include "../common/rocm-utils.h"
 #include <hipcub/hipcub.hpp>
 #endif
 


### PR DESCRIPTION
With ROCm 4, some runtime functions for reduction are just empty stubs (they actually error out). In that world, one of the includes is not necessary and causing unused function errors. This PR adjust the reduction support in the runtime for AMD GPUs.