### PR TITLE
Move existing GPU annotations to new plots, add new ones

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -556,7 +556,7 @@ all:
     - text: Deprecate c_string in user facing modules (#22622)
       config: chapcs
   08/31/23:
-    - text: GPU: Relax LICM aliasing rules for GPU kernels to try benefit performance (#22664)
+    - text: Relax LICM aliasing rules for GPU kernels to try benefit performance (#22664)
       config: 1-node-p100, 1-node-mi60
   09/01/23:
     - text: Switch the default GPU memory strategy to `array_on_device` (#23138)

--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -555,7 +555,7 @@ all:
   08/09/23:
     - text: Deprecate c_string in user facing modules (#22622)
       config: chapcs
-  09/01/23:
+  08/31/23:
     - text: GPU: Relax LICM aliasing rules for GPU kernels to try benefit performance (#22664)
       config: 1-node-p100, 1-node-mi60
   09/01/23:
@@ -2472,6 +2472,8 @@ chplGPU:
     - Upstream changes
 
 coral:
+  09/20/23:
+    - Can't repro on RTX A2000
   11/21/23:
     - text: Pin CUDA 11.3 on a test system that was defaulting to 11.0 (#23894)
       config: 1-node-p100

--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -555,6 +555,15 @@ all:
   08/09/23:
     - text: Deprecate c_string in user facing modules (#22622)
       config: chapcs
+  09/01/23:
+    - text: GPU: Relax LICM aliasing rules for GPU kernels to try benefit performance (#22664)
+      config: 1-node-p100, 1-node-mi60
+  09/01/23:
+    - text: Switch the default GPU memory strategy to `array_on_device` (#23138)
+      config: 1-node-p100, 1-node-mi60
+  09/15/23:
+    - text: Use per-task, per-device GPU streams for asynchronous execution (#23307)
+      config: 1-node-p100, 1-node-mi60
 
 # End all
 
@@ -2459,3 +2468,10 @@ shoc-sort:
 chplGPU:
   03/25/23:
     - Upstream changes
+  09/18/23:
+    - Upstream changes
+
+coral:
+  11/21/23:
+    - text: Pin CUDA 11.3 on a test system that was defaulting to 11.0 (#23894)
+      config: 1-node-p100

--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -2477,3 +2477,7 @@ coral:
   11/21/23:
     - text: Pin CUDA 11.3 on a test system that was defaulting to 11.0 (#23894)
       config: 1-node-p100
+
+transpose-time:
+  09/01/23:
+    - Can only repro on nightly testing system

--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -522,7 +522,7 @@ all:
     - text: Improvements for iterating over unbounded enum/bool ranges (#21332)
       config: chapcs
     - text: Avoid loading CUDA module at each kernel launch (#21346)
-      config: gpu
+      config: 1-node-p100
   01/19/23:
     - text: Support for one locale per socket (#21057)
       config: 16-node-xc, 16-node-cs-hdr
@@ -533,7 +533,7 @@ all:
     - text: Fix default and const argument intents on tuples (#21665)
       config: chapcs, 1-node-xc
     - text: Do less normalization in gpuTransforms and do gpuTransforms after loop invariant code motion (#21673)
-      config: gpu
+      config: 1-node-p100
   03/07/23:
     - text: Switch DR.dsiAccess tuple arg to const ref (#21777)
       config: chapcs, 1-node-xc
@@ -542,7 +542,7 @@ all:
       config: chapcs
   03/16/23:
     - text: Update GPU performance tests to not count launches in perf mode (#21891)
-      config: gpu
+      config: 1-node-p100
   04/06/23:
     - text: Make Dyno scope resolution default (#21983)
       config: chapcs

--- a/util/test/check_annotations.py
+++ b/util/test/check_annotations.py
@@ -92,7 +92,7 @@ def check_configs(ann_data):
     """Check that all the configs used in the annotation file are 'known'"""
     known_configs = {'shootout', 'chap03', 'chap04', 'bradc-lnx', 'chapcs',
                      '16-node-xc', '1-node-xc', '16-node-cs', '16-node-cs-hdr',
-                     'chapcs.comm-counts', 'gpu'}
+                     'chapcs.comm-counts', '1-node-p100', '1-node-mi60'}
     for graph in ann_data:
         for _, annotations in ann_data[graph].items():
             for ann in annotations:


### PR DESCRIPTION
Adds annotation for every change I can catch and notes for things that I can't repro easily or looked but chose to ignore.

Also adjusts `check_annotations.py` to have the new config names (`1-node-p100` etc)