### PR TITLE
Fix a test failure introduced in #23992

### DIFF
--- a/test/modules/vass/userInsteadOfStandard/ChapelIO.chpl
+++ b/test/modules/vass/userInsteadOfStandard/ChapelIO.chpl
@@ -5,8 +5,10 @@ use IO;
 
     // This works around "unresolved call serializeDefaultImpl(..., locale)"
     // due to passing a 'locale' to assert() in TaskErrors.these().
+    // It differs from test/modules/bradc/userInsteadOfStandard/ChapelIO.chpl
+    // by the lack of '(?)' after 'writer:fileWriter'.
     @chpldoc.nodoc
-    proc serializeDefaultImpl(writer:fileWriter(?), ref serializer,
+    proc serializeDefaultImpl(writer:fileWriter, ref serializer,
                               const x:?t) throws {
       writer.writeLiteral("(dummy serializeDefaultImpl)");
     }

--- a/test/modules/vass/userInsteadOfStandard/ChapelIO.notest
+++ b/test/modules/vass/userInsteadOfStandard/ChapelIO.notest
@@ -1,0 +1,2 @@
+This module isn't used -- it's just a trick to see if the wrong one gets
+included.

--- a/test/modules/vass/userInsteadOfStandard/foo2.bad
+++ b/test/modules/vass/userInsteadOfStandard/foo2.bad
@@ -1,0 +1,4 @@
+warning: Ambiguous module source file -- using ./ChapelIO.chpl over $CHPL_HOME/modules/standard/ChapelIO.chpl
+$CHPL_HOME/modules/standard/ChapelIO.chpl:477: In function 'serializeDefaultImpl':
+$CHPL_HOME/modules/standard/ChapelIO.chpl:477: warning: need '(?)' on the type 'fileWriter' of the formal 'writer' because this type is generic
+foo2.chpl:9: error: done

--- a/test/modules/vass/userInsteadOfStandard/foo2.chpl
+++ b/test/modules/vass/userInsteadOfStandard/foo2.chpl
@@ -1,0 +1,9 @@
+// This test and ./ChapelIO.chpl are copies of those in
+//   test/modules/bradc/userInsteadOfStandard/foo2.chpl
+// with a tweak to ./ChapelIO.chpl to illustrate a bug.
+
+use ChapelIO;
+
+testchapelio();
+writeln("In my foo2");
+compilerError("done");

--- a/test/modules/vass/userInsteadOfStandard/foo2.future
+++ b/test/modules/vass/userInsteadOfStandard/foo2.future
@@ -1,0 +1,9 @@
+bug: incorrect line number reported in a warning
+
+The compiler warns about a missing '(?)' in modules/standard/ChapelIO.chpl
+whereas it should about ./ChapelIO.chpl
+// in serializeDefaultImpl() in both cases
+
+Perhaps serializeDefaultImpl() in modules/standard/ChapelIO.chpl
+should indeed be updated, however in the absense of a custom ChapelIO.chpl
+such warning is currently not generated.

--- a/test/modules/vass/userInsteadOfStandard/foo2.good
+++ b/test/modules/vass/userInsteadOfStandard/foo2.good
@@ -1,0 +1,4 @@
+warning: Ambiguous module source file -- using ./ChapelIO.chpl over $CHPL_HOME/modules/standard/ChapelIO.chpl
+ChapelIO.chpl:11: In function 'serializeDefaultImpl':
+ChapelIO.chpl:11: warning: need '(?)' on the type 'fileWriter' of the formal 'writer' because this type is generic
+foo2.chpl:9: error: done


### PR DESCRIPTION
This adds a workaround for a test failure introduced in #23992.

It also adds a .future test for a minor weirdness with the compiler warning about a missing `(?)`.

Not reviewed.