### PR TITLE
Fix more fallouts from #23992

### DIFF
--- a/modules/standard/Errors.chpl
+++ b/modules/standard/Errors.chpl
@@ -330,8 +330,8 @@ module Errors {
      */
     iter these() ref : owned Error? {
       if boundsChecking then assert(this.locale.id == here.id,
-        "iterating over a TaskErrors object allocated on ", this.locale,
-        " while being on ", here);
+        "iterating over a TaskErrors object allocated on locale ",
+        this.locale.id, " while being on locale ", here.id);
       foreach i in 0..#nErrors {
         if errorsArray[i] != nil {
           yield errorsArray[i];
@@ -343,8 +343,8 @@ module Errors {
     @unstable("`TaskErrors.first` is unstable; expect this method to change in the future.")
     proc first() ref : owned Error? {
       if boundsChecking then assert(this.locale.id == here.id,
-        "querying first() of a TaskErrors object allocated on ", this.locale,
-        " while being on ", here);
+        "querying first() of a TaskErrors object allocated on locale ",
+        this.locale.id, " while being on locale ", here.id);
       var first = 0;
       for i in 0..#nErrors {
         if errorsArray[i] != nil {

--- a/test/errhandling/errorMessages/taskerrors-remote-1.good
+++ b/test/errhandling/errorMessages/taskerrors-remote-1.good
@@ -1,1 +1,1 @@
-taskerrors-remote-1.chpl:6: error: assert failed - iterating over a TaskErrors object allocated on LOCALE1 while being on LOCALE0
+taskerrors-remote-1.chpl:6: error: assert failed - iterating over a TaskErrors object allocated on locale 1 while being on locale 0

--- a/test/errhandling/errorMessages/taskerrors-remote-2.good
+++ b/test/errhandling/errorMessages/taskerrors-remote-2.good
@@ -1,1 +1,1 @@
-taskerrors-remote-2.chpl:6: error: assert failed - querying first() of a TaskErrors object allocated on LOCALE1 while being on LOCALE0
+taskerrors-remote-2.chpl:6: error: assert failed - querying first() of a TaskErrors object allocated on locale 1 while being on locale 0

--- a/test/modules/bradc/userInsteadOfStandard/ChapelIO.chpl
+++ b/test/modules/bradc/userInsteadOfStandard/ChapelIO.chpl
@@ -3,14 +3,6 @@
 
 use IO;
 
-    // This works around "unresolved call serializeDefaultImpl(..., locale)"
-    // due to passing a 'locale' to assert() in TaskErrors.these().
-    @chpldoc.nodoc
-    proc serializeDefaultImpl(writer:fileWriter(?), ref serializer,
-                              const x:?t) throws {
-      writer.writeLiteral("(dummy serializeDefaultImpl)");
-    }
-
   proc chpl_stringify_wrapper(const args ...):string {
     use IO only chpl_stringify;
     return chpl_stringify((...args));


### PR DESCRIPTION
This reverts the change to Errors.chpl made in #23992's commit cfebf149d2. That change switched two asserts from displaying `someLocale.id` to displaying `someLocale`, which threw off a lot of tests due to problems with resolution order. For example, the test `errhandling/parallel/forall-wrap-first-error` started reporting "error: module-scope variable 'count' may be used before it is initialized". Using `someLocale.id` in the assertions avoids these problems. Correspondingly, this reverts the change to `test/modules/bradc/userInsteadOfStandard/ChapelIO.chpl` as no longer needed.

Merging without a review for expediency.