### PR TITLE
Fix typos

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -79,7 +79,7 @@ Syntactic / Naming Changes
 * added a warning for fields with generic class management to avoid confusion
 * renamed context manager `[enter|leave]This()` to `[enter|exit]Context()`  
   (see https://chapel-lang.org/docs/1.32/language/spec/statements.html#the-manage-statement)
-* renamed `sync` formals from `x: valtype` to `val: valType`
+* renamed `sync` formals from `x: valType` to `val: valType`
 * renamed `atomic` formals and formal types from `value: T` to `val: valType`
 
 Semantic Changes / Changes to the Chapel Language
@@ -171,7 +171,7 @@ Deprecated / Removed Language Features
 * deprecated relying on default initializers for `sync`, `single`, and `atomic`
 * deprecated the `owned.borrow()` type method  
   (see https://chapel-lang.org/docs/1.32/language/spec/classes.html#OwnedObject.owned.borrow)
-* deprecated assignment between unbounded ranges of incompatible `idxtype`
+* deprecated assignment between unbounded ranges of incompatible `idxType`
 * deprecated `range.isAmbiguous()` in favor of `!range.isAligned()`
 * deprecated `range.isNaturallyAligned()` and `range.boundsCheck()`
 * deprecated the `.intIdxType` query on ranges, domains, and arrays  

--- a/compiler/AST/AstDump.cpp
+++ b/compiler/AST/AstDump.cpp
@@ -89,7 +89,7 @@ void AstDump::view(const char* passName, int passNum) {
           // update it to take a file pointer use it and pass it along as needed. But rather
           // than update all the code I instead redirect stdout to the file (and then restore it
           // after the dump is done).  This makes debugging pain and folks can really get caught
-          // off-gaurd when stdout is no longer really stdout.
+          // off-guard when stdout is no longer really stdout.
           int oldStdout = dup(1);
           dup2(fileno(logger.mFP), 1);
 

--- a/compiler/include/LoopWithShadowVarsInterface.h
+++ b/compiler/include/LoopWithShadowVarsInterface.h
@@ -24,8 +24,8 @@
 #include "stmt.h"
 
 // Both 'forall' and 'foreach' loops have shadow variables. We have code that we want to be able
-// to process either but the nearest common ancenstor to these two classes is 'Expr'.
-// In the long run it might be beneficial to rearrange our class heirarchy so these two share
+// to process either but the nearest common ancestor to these two classes is 'Expr'.
+// In the long run it might be beneficial to rearrange our class hierarchy so these two share
 // a closer ancestor but for the time being I use the following interface for the shared
 // behavior between the two that's used when processing shadow variables.
 struct LoopWithShadowVarsInterface {

--- a/compiler/main/PhaseTracker.cpp
+++ b/compiler/main/PhaseTracker.cpp
@@ -174,7 +174,7 @@ void PhaseTracker::ReportPassGroupTotals(
     if (saveToList) {
       groupTimes->emplace_back(passTime);
     } else {
-      // No out-paremeter to save into, report time normally
+      // No out-parameter to save into, report time normally
       // (whether it was calculated or retrieved from list).
 
       const char* groupName = passGroups[i][0];

--- a/compiler/main/PhaseTracker.h
+++ b/compiler/main/PhaseTracker.h
@@ -85,7 +85,7 @@ public:
   // Report out total times by pass group, with differing behavior based on the
   // provided argument:
   // - nullptr: Ignore it and report as normal.
-  // - empty list: Instead insert times into it and skip outputing.
+  // - empty list: Instead insert times into it and skip outputting.
   // - non-empty list: Take the values as already-recorded times and report
   // them out. They are assumed to represent pass group times in order, with
   // missing values meaning that pass group did not occur (early exit).

--- a/doc/rst/developer/bestPractices/GeneratedCode.rst
+++ b/doc/rst/developer/bestPractices/GeneratedCode.rst
@@ -200,7 +200,7 @@ To use ``gprof``:
   This produces a `gprof-enabled` executable.
 
   The use of ``--fast`` and ``--savec`` are not strictly necessary,
-  but will improve exeution time and give you access to the generated
+  but will improve execution time and give you access to the generated
   C code (in the named directory), respectively.
 
 

--- a/frontend/doc/file-format.rst
+++ b/frontend/doc/file-format.rst
@@ -48,7 +48,7 @@ bytes for smaller numbers. Portions of the number are stored in a
 variable number of component bytes. Each component byte has part of the
 number stored in the bottom 7 bits and uses the top bit to indicate if
 there are more components. The components store portions of the original
-number in a little-endian way (i.e., starting with the least-siginificant
+number in a little-endian way (i.e., starting with the least-significant
 group of 7 bits).
 
 For example, the variable byte encoding of 0b110110 is just 0b00110110

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -1233,7 +1233,7 @@ class MostSpecificCandidates {
 
   /**
     If there is exactly one candidate, return that candidate.
-    Otherwise, return an empty candiate.
+    Otherwise, return an empty candidate.
    */
   MostSpecificCandidate only() const {
     const MostSpecificCandidate* ret = nullptr;

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -307,7 +307,7 @@ static QualifiedType primCast(Context* context,
 
   // Note: the production compiler also handles wide classes here (if
   // cast-from is a wide class, turn cast-to into a wide class). We don't
-  // currently track wide classs in Dyno so this logic is omitted here.
+  // currently track wide classes in Dyno so this logic is omitted here.
 
   return QualifiedType(castFrom.kind(), castTo.type(), castFrom.param());
 }

--- a/modules/standard/GPU.chpl
+++ b/modules/standard/GPU.chpl
@@ -758,7 +758,7 @@ module GPU
     // Not a power of two, so we pad it out
     // To the next nearest power of two
     const log_2_x = numBytes(uint)*8 - BitOps.clz(x); // get quick log for uint
-    // Next highest nerest power of two is
+    // Next highest power of two is
     return 1 << log_2_x;
   }
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -8722,12 +8722,12 @@ proc fileReader.readByte(ref byte: uint(8)): bool throws {
   buffering mechanism.
 
   This optimization is on by default as it can improve performance for large
-  operations where buffering doesn't segnificantly reduce the number of system
+  operations where buffering doesn't significantly reduce the number of system
   I/O calls and thus adds unnecessary overhead.
 
   To disable the optimization, compile with ``-sIOSkipBufferingForLargeOps=false``.
 
-  Note that this is flag controlls an implementation-specific feature and
+  Note that this flag controls an implementation-specific feature and
   thus is not part of the Chapel language specification.
 */
 @unstable("IOSkipBufferingForLargeOps is unstable and could change or be removed in the future")

--- a/modules/standard/OS.chpl
+++ b/modules/standard/OS.chpl
@@ -790,7 +790,7 @@ module OS {
     //
     // stdlib.h
     //
-    /* Get the value of an enviroment variable. */
+    /* Get the value of an environment variable. */
     extern proc getenv(name:c_ptrConst(c_char)):c_ptr(c_char);
 
     //
@@ -836,7 +836,7 @@ module OS {
 
     // No way around this -- 'select' is a keyword in Chapel.
     /*
-      Indicates which of the specificed file descriptors is ready for reading
+      Indicates which of the specified file descriptors is ready for reading
       or writing, or has an error condition pending. If no file descriptors are
       ready, the procedure blocks until the ``timeout``.
     */
@@ -929,7 +929,7 @@ module OS {
     }
 
     /* A Chapel version of the POSIX structure ``stat``, which contains common
-    fields. This should be useed with :proc:`stat`.
+    fields. This should be used with :proc:`stat`.
     */
     extern 'struct chpl_os_posix_struct_stat' record struct_stat {
       /* Device. */
@@ -1240,7 +1240,7 @@ module OS {
 
     /*
       Construct a :class:`SystemError` with a specific error code and optional
-      extra detais.
+      extra details.
     */
     proc init(err: errorCode, details: string = "") {
       this.err     = err;

--- a/modules/standard/Regex.chpl
+++ b/modules/standard/Regex.chpl
@@ -633,7 +633,7 @@ record regex : serializable {
     :param:`~ChplConfig.CHPL_COMM`.
 
     .. note::
-       If you are looking to default intialize a :type:`regex`, you might be
+       If you are looking to default initialize a :type:`regex`, you might be
        looking for ``new regex("")``, which will create a regular expression
        matching the empty string.
   */

--- a/runtime/src/comm/gasnet/comm-gasnet-ex.c
+++ b/runtime/src/comm/gasnet/comm-gasnet-ex.c
@@ -1302,7 +1302,7 @@ void  chpl_comm_get_strd(void* dstaddr, size_t* dststrides, c_nodeid_t srcnode_i
                          int ln, int32_t fn) {
   int i;
   const size_t strlvls = (size_t)stridelevels;
-  // Avoid 0-lengh VLA when stridelevels is 0 (contiguous transfer), gasnet
+  // Avoid 0-length VLA when stridelevels is 0 (contiguous transfer), gasnet
   // will ignore arrays in this case
   const size_t strlvls_nz = strlvls == 0 ? 1 : strlvls;
   const gasnet_node_t srcnode = (gasnet_node_t)srcnode_id;
@@ -1345,7 +1345,7 @@ void  chpl_comm_put_strd(void* dstaddr, size_t* dststrides, c_nodeid_t dstnode_i
                          int ln, int32_t fn) {
   int i;
   const size_t strlvls = (size_t)stridelevels;
-  // Avoid 0-lengh VLA when stridelevels is 0 (contiguous transfer), gasnet
+  // Avoid 0-length VLA when stridelevels is 0 (contiguous transfer), gasnet
   // will ignore arrays in this case
   const size_t strlvls_nz = strlvls == 0 ? 1 : strlvls;
   const gasnet_node_t dstnode = (gasnet_node_t)dstnode_id;


### PR DESCRIPTION
Fix typos in CHANGES.md,
AstDump.cpp, loopWithShadowVarsInterface.h,
PhaseTracker.cpp, PhaseTracker.h,
GeneratedCode.rst, file-format.rst,
resolution-types.h, prims.cpp,
GPU.chpl, IO.chpl, OS.chpl, Regex.chpl,
comm-gasnet-ex.c
