### PR TITLE
Fixes nightly test issue with `--no-local`

### DIFF
--- a/test/library/standard/CommDiagnostics/commDiagnosticsWarnings.chpl
+++ b/test/library/standard/CommDiagnostics/commDiagnosticsWarnings.chpl
@@ -25,9 +25,9 @@ if compiledForSingleLocale() {
   startCommDiagnosticsHere(); // triggers warning
   stopCommDiagnosticsHere();
   stopCommDiagnosticsHere(); // trigers warning
-} else {
+
+} else if (numLocales == 4) {
   // test is built for 4 locales
-  assert(numLocales == 4);
 
   //
   // test starting and stopping in order on all locales

--- a/test/library/standard/CommDiagnostics/commDiagnosticsWarnings.chpl
+++ b/test/library/standard/CommDiagnostics/commDiagnosticsWarnings.chpl
@@ -14,7 +14,7 @@ startCommDiagnostics(); // triggers warning
 stopCommDiagnostics();
 stopCommDiagnostics(); // trigers warning
 
-if compiledForSingleLocale() {
+if compiledForSingleLocale() || numLocales == 1 {
   stderr.writeln("here start/stop");
   startVerboseCommHere();
   startVerboseCommHere(); // triggers warning

--- a/test/library/standard/CommDiagnostics/commDiagnosticsWarnings.no-local.good
+++ b/test/library/standard/CommDiagnostics/commDiagnosticsWarnings.no-local.good
@@ -1,0 +1,5 @@
+global start/stop
+commDiagnosticsWarnings.chpl:8: warning: verbose comm was already started
+commDiagnosticsWarnings.chpl:10: warning: verbose comm was never started
+commDiagnosticsWarnings.chpl:13: warning: comm diagnostics was already started
+commDiagnosticsWarnings.chpl:15: warning: comm diagnostics was never started

--- a/test/library/standard/CommDiagnostics/commDiagnosticsWarnings.no-local.good
+++ b/test/library/standard/CommDiagnostics/commDiagnosticsWarnings.no-local.good
@@ -1,5 +1,0 @@
-global start/stop
-commDiagnosticsWarnings.chpl:8: warning: verbose comm was already started
-commDiagnosticsWarnings.chpl:10: warning: verbose comm was never started
-commDiagnosticsWarnings.chpl:13: warning: comm diagnostics was already started
-commDiagnosticsWarnings.chpl:15: warning: comm diagnostics was never started


### PR DESCRIPTION
Fixes a test failing in our nightly tests with `--no-local`.

Tested locally with and without `--no-local` and comm.

[Not reviewed - trivial]