### PR TITLE
update line numbers for validation of knucleotide perf tests

### DIFF
--- a/test/studies/shootout/submitted/knucleotide3.perfkeys
+++ b/test/studies/shootout/submitted/knucleotide3.perfkeys
@@ -1,3 +1,3 @@
 real
-verify:65:GG 3.902
-verify:71:893	GGTATTTTAATTTATAGT
+verify:-10:GG 3.902
+verify:-4:893	GGTATTTTAATTTATAGT

--- a/test/studies/shootout/submitted/knucleotide4.perfkeys
+++ b/test/studies/shootout/submitted/knucleotide4.perfkeys
@@ -1,3 +1,3 @@
 real
-verify:71:GG 3.902
-verify:77:893	GGTATTTTAATTTATAGT
+verify:-10:GG 3.902
+verify:-4:893	GGTATTTTAATTTATAGT


### PR DESCRIPTION
https://github.com/chapel-lang/chapel/pull/23957 removed a deprecation warning from our implementation of the knucleotide computer language benchmark game test.

This shifts line numbers in the output and so we need to update what line numbers we specify for validation during our perf tests. I failed to do that in the previously mentioned PR but now this PR fixes it.