### PR TITLE
Build the runtime support for reductions on NVIDIA GPUs only for `CHPL_GPU_ARCH`

### DIFF
--- a/runtime/src/gpu/nvidia/Makefile.share
+++ b/runtime/src/gpu/nvidia/Makefile.share
@@ -28,10 +28,7 @@ GPU_OBJS = $(addprefix $(GPU_OBJDIR)/,$(addsuffix .o,$(basename $(GPU_SRCS))))
 # a comma-separated list.
 RUNTIME_CXXFLAGS += -x cuda -Wno-unknown-cuda-version \
                     -Xclang -fcuda-allow-variadic-functions \
-                    --offload-arch=sm_60 \
-                    --offload-arch=sm_61 \
-                    --offload-arch=sm_70 \
-                    --offload-arch=sm_75
+                    --offload-arch=$(CHPL_MAKE_GPU_ARCH)
 
 $(RUNTIME_OBJ_DIR)/gpu-nvidia-reduce.o: gpu-nvidia-reduce.cc \
                                          $(RUNTIME_OBJ_DIR_STAMP)

--- a/runtime/src/gpu/nvidia/gpu-nvidia-reduce.cc
+++ b/runtime/src/gpu/nvidia/gpu-nvidia-reduce.cc
@@ -31,6 +31,13 @@
 // the implementation in the rest of the runtime and the modules more
 // straightforward.
 #define DEF_ONE_REDUCE_RET_VAL(cub_kind, chpl_kind, data_type) \
+static void __cub_val_##cub_kind##_##data_type(void* temp, size_t temp_bytes, \
+                                           data_type* data, data_type* result, \
+                                           int n, CUstream stream) { \
+  cub::DeviceReduce::cub_kind(temp, temp_bytes, data, (data_type*)result, n,\
+                              (CUstream)stream); \
+}\
+\
 void chpl_gpu_impl_##chpl_kind##_reduce_##data_type(data_type* data, int n,\
                                                     data_type* val, int* idx,\
                                                     void* stream) {\
@@ -38,11 +45,10 @@ void chpl_gpu_impl_##chpl_kind##_reduce_##data_type(data_type* data, int n,\
   CUDA_CALL(cuMemAlloc(&result, sizeof(data_type))); \
   void* temp = NULL; \
   size_t temp_bytes = 0; \
-  cub::DeviceReduce::cub_kind(temp, temp_bytes, data, (data_type*)result, n,\
-                              (CUstream)stream); \
+  __cub_val_##cub_kind##_##data_type(temp, temp_bytes, data, (data_type*)result, n, \
+                           (CUstream)stream); \
   CUDA_CALL(cuMemAlloc(((CUdeviceptr*)&temp), temp_bytes)); \
-  cub::DeviceReduce::cub_kind(temp, temp_bytes, data, (data_type*)result, n,\
-                              (CUstream)stream); \
+  __cub_val_##cub_kind##_##data_type(temp, temp_bytes, data, (data_type*)result, n, (CUstream)stream); \
   CUDA_CALL(cuMemcpyDtoHAsync(val, result, sizeof(data_type),\
                               (CUstream)stream)); \
   CUDA_CALL(cuMemFree(result)); \
@@ -54,22 +60,29 @@ GPU_IMPL_REDUCE(DEF_ONE_REDUCE_RET_VAL, Max, max)
 
 #undef DEF_ONE_REDUCE_RET_VAL
 
+template <typename data_type>
+using kvp = cub::KeyValuePair<int, data_type>;
+
 #define DEF_ONE_REDUCE_RET_VAL_IDX(cub_kind, chpl_kind, data_type) \
+\
+static void __cub_val_idx_##cub_kind##_##data_type(void* temp, size_t temp_bytes, data_type* data, \
+                         kvp<data_type>* result, int n, CUstream stream) { \
+  cub::DeviceReduce::cub_kind(temp, temp_bytes, data, (kvp<data_type>*)result, n,\
+                              (CUstream)stream);\
+} \
+\
 void chpl_gpu_impl_##chpl_kind##_reduce_##data_type(data_type* data, int n,\
                                                     data_type* val, int* idx,\
                                                     void* stream) {\
-  using kvp = cub::KeyValuePair<int,data_type>; \
   CUdeviceptr result; \
-  CUDA_CALL(cuMemAlloc(&result, sizeof(kvp))); \
+  CUDA_CALL(cuMemAlloc(&result, sizeof(kvp<data_type>))); \
   void* temp = NULL; \
   size_t temp_bytes = 0; \
-  cub::DeviceReduce::cub_kind(temp, temp_bytes, data, (kvp*)result, n,\
-                              (CUstream)stream);\
+  __cub_val_idx_##cub_kind##_##data_type(temp, temp_bytes, data, (kvp<data_type>*)result, n, (CUstream)stream);\
   CUDA_CALL(cuMemAlloc(((CUdeviceptr*)&temp), temp_bytes)); \
-  cub::DeviceReduce::cub_kind(temp, temp_bytes, data, (kvp*)result, n,\
-                              (CUstream)stream);\
-  kvp result_host; \
-  CUDA_CALL(cuMemcpyDtoHAsync(&result_host, result, sizeof(kvp),\
+  __cub_val_idx_##cub_kind##_##data_type(temp, temp_bytes, data, (kvp<data_type>*)result, n, (CUstream)stream);\
+  kvp<data_type> result_host; \
+  CUDA_CALL(cuMemcpyDtoHAsync(&result_host, result, sizeof(kvp<data_type>),\
                               (CUstream)stream)); \
   *val = result_host.value; \
   *idx = result_host.key; \

--- a/runtime/src/gpu/nvidia/gpu-nvidia-reduce.cc
+++ b/runtime/src/gpu/nvidia/gpu-nvidia-reduce.cc
@@ -31,13 +31,6 @@
 // the implementation in the rest of the runtime and the modules more
 // straightforward.
 #define DEF_ONE_REDUCE_RET_VAL(cub_kind, chpl_kind, data_type) \
-static void __cub_val_##cub_kind##_##data_type(void* temp, size_t temp_bytes, \
-                                           data_type* data, data_type* result, \
-                                           int n, CUstream stream) { \
-  cub::DeviceReduce::cub_kind(temp, temp_bytes, data, (data_type*)result, n,\
-                              (CUstream)stream); \
-}\
-\
 void chpl_gpu_impl_##chpl_kind##_reduce_##data_type(data_type* data, int n,\
                                                     data_type* val, int* idx,\
                                                     void* stream) {\
@@ -45,10 +38,11 @@ void chpl_gpu_impl_##chpl_kind##_reduce_##data_type(data_type* data, int n,\
   CUDA_CALL(cuMemAlloc(&result, sizeof(data_type))); \
   void* temp = NULL; \
   size_t temp_bytes = 0; \
-  __cub_val_##cub_kind##_##data_type(temp, temp_bytes, data, (data_type*)result, n, \
-                           (CUstream)stream); \
+  cub::DeviceReduce::cub_kind(temp, temp_bytes, data, (data_type*)result, n,\
+                              (CUstream)stream); \
   CUDA_CALL(cuMemAlloc(((CUdeviceptr*)&temp), temp_bytes)); \
-  __cub_val_##cub_kind##_##data_type(temp, temp_bytes, data, (data_type*)result, n, (CUstream)stream); \
+  cub::DeviceReduce::cub_kind(temp, temp_bytes, data, (data_type*)result, n,\
+                              (CUstream)stream); \
   CUDA_CALL(cuMemcpyDtoHAsync(val, result, sizeof(data_type),\
                               (CUstream)stream)); \
   CUDA_CALL(cuMemFree(result)); \
@@ -60,29 +54,22 @@ GPU_IMPL_REDUCE(DEF_ONE_REDUCE_RET_VAL, Max, max)
 
 #undef DEF_ONE_REDUCE_RET_VAL
 
-template <typename data_type>
-using kvp = cub::KeyValuePair<int, data_type>;
-
 #define DEF_ONE_REDUCE_RET_VAL_IDX(cub_kind, chpl_kind, data_type) \
-\
-static void __cub_val_idx_##cub_kind##_##data_type(void* temp, size_t temp_bytes, data_type* data, \
-                         kvp<data_type>* result, int n, CUstream stream) { \
-  cub::DeviceReduce::cub_kind(temp, temp_bytes, data, (kvp<data_type>*)result, n,\
-                              (CUstream)stream);\
-} \
-\
 void chpl_gpu_impl_##chpl_kind##_reduce_##data_type(data_type* data, int n,\
                                                     data_type* val, int* idx,\
                                                     void* stream) {\
+  using kvp = cub::KeyValuePair<int,data_type>; \
   CUdeviceptr result; \
-  CUDA_CALL(cuMemAlloc(&result, sizeof(kvp<data_type>))); \
+  CUDA_CALL(cuMemAlloc(&result, sizeof(kvp))); \
   void* temp = NULL; \
   size_t temp_bytes = 0; \
-  __cub_val_idx_##cub_kind##_##data_type(temp, temp_bytes, data, (kvp<data_type>*)result, n, (CUstream)stream);\
+  cub::DeviceReduce::cub_kind(temp, temp_bytes, data, (kvp*)result, n,\
+                              (CUstream)stream);\
   CUDA_CALL(cuMemAlloc(((CUdeviceptr*)&temp), temp_bytes)); \
-  __cub_val_idx_##cub_kind##_##data_type(temp, temp_bytes, data, (kvp<data_type>*)result, n, (CUstream)stream);\
-  kvp<data_type> result_host; \
-  CUDA_CALL(cuMemcpyDtoHAsync(&result_host, result, sizeof(kvp<data_type>),\
+  cub::DeviceReduce::cub_kind(temp, temp_bytes, data, (kvp*)result, n,\
+                              (CUstream)stream);\
+  kvp result_host; \
+  CUDA_CALL(cuMemcpyDtoHAsync(&result_host, result, sizeof(kvp),\
                               (CUstream)stream)); \
   *val = result_host.value; \
   *idx = result_host.key; \


### PR DESCRIPTION
Resolves https://github.com/chapel-lang/chapel/issues/23893
Resolves https://github.com/Cray/chapel-private/issues/5712

This PR aligns `nvidia` reduction support to `amd`: https://github.com/chapel-lang/chapel/pull/23950/files#diff-eb05ab5f4c9820ed534cd67b2f2f83426c7fd52e90c86b5afcbb29dc7992296dR24 where we build the reduction support source only for `CHPL_GPU_ARCH`. This improves the build time of the reduction support by about 4x on my workstation (1 vs 4 minutes).

Related: https://github.com/chapel-lang/chapel/issues/23960

Test:
- [x] nvidia