### PR TITLE
fix [chpldoc]: adjust cxx standard based on LLVM version

### DIFF
--- a/tools/chpldoc/CMakeLists.txt
+++ b/tools/chpldoc/CMakeLists.txt
@@ -28,7 +28,13 @@ add_custom_command(
   COMMENT "writing COPYRIGHT file updates..."
   VERBATIM)
 add_executable(chpldoc chpldoc.cpp arg.cpp arg-helpers.cpp COPYRIGHT)
-set_property(TARGET chpldoc PROPERTY CXX_STANDARD 17)
+# request C++14 -- or C++17 if using LLVM 16
+if (CHPL_LLVM_VERSION VERSION_LESS 16.0)
+  set(CMAKE_CXX_STANDARD 14)
+else()
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+set(CMAKE_CXX_STANDARD_REQUIRED True)
 target_link_libraries(chpldoc ChplFrontend)
 target_include_directories(chpldoc PRIVATE
                            ${CHPL_MAIN_INCLUDE_DIR}


### PR DESCRIPTION
This PR fixes build issues for `chpldoc` on older versions of LLVM and GCC. Similar to the changes in https://github.com/chapel-lang/chapel/pull/22260, this adds a check for LLVM versions < 16.0 and assigns the `CXX_STANDARD` as either 14 or 17.

TESTING:

- [x] built `chpldoc` (with warnings) using `gcc 6.3`
- [x] built `chpldoc` (with warnings) using `LLVM 12`
- [x] paratest `[Summary: #Successes = 17127 | #Failures = 0 | #Futures = 915]`

[reviewed by @jabraham17 - thank you!]