### PR TITLE
Add a CI check for undocumented symbols

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -83,6 +83,10 @@ jobs:
     - name: run dyno linters
       run: |
         CHPL_HOME=$PWD CHPL_HOST_CC=clang-13 CHPL_HOST_CXX=clang++-13 make run-dyno-linters
+    - name: check undocumented symbols
+    run: |
+        CHPL_HOME=$PWD make chapel-py-venv -j`util/buildRelease/chpl-make-cpu_count`
+        $PWD/tools/chpldoc/findUndocumentedSymbols --ci --ignore-deprecated --ignore-unstable modules/standard
 
   make_check_llvm_none:
     runs-on: ubuntu-latest
@@ -123,19 +127,3 @@ jobs:
     - name: smokeTest lint
       run: |
         ./util/buildRelease/smokeTest lint
-
-  check_stable_docs:
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/${{ github.repository_owner }}/chapel-github-ci:latest
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.github_token }}
-    steps:
-    - uses: actions/checkout@v3
-    - name: make chapel-py-venv
-      run: |
-        CHPL_HOME=$PWD make chapel-py-venv -j`util/buildRelease/chpl-make-cpu_count`
-    - name: find missing stable docs
-      run: |
-        $PWD/tools/chpldoc/findUndocumentedSymbols --ci --ignore-deprecated --ignore-unstable modules/standard

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -86,7 +86,7 @@ jobs:
     - name: check undocumented symbols
       run: |
         CHPL_HOME=$PWD make DYNO_ENABLE_ASSERTIONS=1 make chapel-py-venv -j`util/buildRelease/chpl-make-cpu_count`
-        $PWD/tools/chpldoc/findUndocumentedSymbols --ci --ignore-deprecated --ignore-unstable $PWD/modules/standard
+        CHPL_HOME=$PWD $PWD/tools/chpldoc/findUndocumentedSymbols --ci --ignore-deprecated --ignore-unstable $PWD/modules/standard
 
   make_check_llvm_none:
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -86,7 +86,7 @@ jobs:
     - name: check undocumented symbols
     run: |
         CHPL_HOME=$PWD make chapel-py-venv -j`util/buildRelease/chpl-make-cpu_count`
-        $PWD/tools/chpldoc/findUndocumentedSymbols --ci --ignore-deprecated --ignore-unstable modules/standard
+        $PWD/tools/chpldoc/findUndocumentedSymbols --ci --ignore-deprecated --ignore-unstable $PWD/modules/standard
 
   make_check_llvm_none:
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -85,7 +85,7 @@ jobs:
         CHPL_HOME=$PWD CHPL_HOST_CC=clang-13 CHPL_HOST_CXX=clang++-13 make run-dyno-linters
     - name: check undocumented symbols
       run: |
-        CHPL_HOME=$PWD make chapel-py-venv -j`util/buildRelease/chpl-make-cpu_count`
+        CHPL_HOME=$PWD CHPL_HOST_CC=clang-13 CHPL_HOST_CXX=clang++-13 make chapel-py-venv -j`util/buildRelease/chpl-make-cpu_count`
         $PWD/tools/chpldoc/findUndocumentedSymbols --ci --ignore-deprecated --ignore-unstable $PWD/modules/standard
 
   make_check_llvm_none:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -109,7 +109,7 @@ jobs:
         fetch-depth: 100000
     - name: Set ownership
       run: |
-        chown -R $(id -u):$(id -g) $PWD   
+        chown -R $(id -u):$(id -g) $PWD
     - name: find bad runtime calls
       run: |
         ./util/devel/lookForBadRTCalls
@@ -123,3 +123,19 @@ jobs:
     - name: smokeTest lint
       run: |
         ./util/buildRelease/smokeTest lint
+
+  check_stable_docs:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/chapel-github-ci:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.github_token }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: make chapel-py-venv
+      run: |
+        CHPL_HOME=$PWD make chapel-py-venv -j`util/buildRelease/chpl-make-cpu_count`
+    - name: find missing stable docs
+      run: |
+        $PWD/tools/chpldoc/findUndocumentedSymbols --ci --ignore-deprecated --ignore-unstable modules/standard

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -84,7 +84,7 @@ jobs:
       run: |
         CHPL_HOME=$PWD CHPL_HOST_CC=clang-13 CHPL_HOST_CXX=clang++-13 make run-dyno-linters
     - name: check undocumented symbols
-    run: |
+      run: |
         CHPL_HOME=$PWD make chapel-py-venv -j`util/buildRelease/chpl-make-cpu_count`
         $PWD/tools/chpldoc/findUndocumentedSymbols --ci --ignore-deprecated --ignore-unstable $PWD/modules/standard
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -79,13 +79,13 @@ jobs:
     - uses: actions/checkout@v3
     - name: make test-dyno-with-asserts
       run: |
-        make DYNO_ENABLE_ASSERTIONS=1 test-dyno -j`util/buildRelease/chpl-make-cpu_count`
+        CHPL_HOME=$PWD make DYNO_ENABLE_ASSERTIONS=1 test-dyno -j`util/buildRelease/chpl-make-cpu_count`
     - name: run dyno linters
       run: |
         CHPL_HOME=$PWD CHPL_HOST_CC=clang-13 CHPL_HOST_CXX=clang++-13 make run-dyno-linters
     - name: check undocumented symbols
       run: |
-        CHPL_HOME=$PWD CHPL_HOST_CC=clang-13 CHPL_HOST_CXX=clang++-13 make chapel-py-venv -j`util/buildRelease/chpl-make-cpu_count`
+        CHPL_HOME=$PWD make DYNO_ENABLE_ASSERTIONS=1 make chapel-py-venv -j`util/buildRelease/chpl-make-cpu_count`
         $PWD/tools/chpldoc/findUndocumentedSymbols --ci --ignore-deprecated --ignore-unstable $PWD/modules/standard
 
   make_check_llvm_none:

--- a/tools/chpldoc/findUndocumentedSymbols.py
+++ b/tools/chpldoc/findUndocumentedSymbols.py
@@ -345,12 +345,33 @@ def get_files(files: List[str]) -> Generator:
 
 def main(raw_args: List[str]) -> int:
     a = ap.ArgumentParser()
-    a.add_argument("files", nargs="*")
-    a.add_argument("--ignore-deprecated", action="store_true", default=False)
-    a.add_argument("--ignore-unstable", action="store_true", default=False)
+    a.add_argument(
+        "files",
+        nargs="*",
+        help="a list of Chapel files and/or directories to be searched",
+    )
+    a.add_argument(
+        "--ignore-deprecated",
+        action="store_true",
+        default=False,
+        help="don't report warnings for deprecated symbols",
+    )
+    a.add_argument(
+        "--ignore-unstable",
+        action="store_true",
+        default=False,
+        help="don't report warnings for unstable symbols",
+    )
+    # hidden option, converts warnings to errors to be used in a ci
+    a.add_argument("--ci", action="store_true", default=False, help=ap.SUPPRESS)
+
     args = a.parse_args(raw_args)
     flags = vars(args)
     files = flags.pop("files")
+    ci = flags.pop("ci")
+
+    report_kind = "warning" if not ci else "error"
+    ret_code = 0
 
     curdir = os.path.abspath(os.path.curdir)
 
@@ -365,9 +386,10 @@ def main(raw_args: List[str]) -> int:
             path = os.path.relpath(loc.path(), curdir)
             names = get_node_name(sym)
             for name in names:
-                print(f"warning: '{name}' at {path}:{line} is undocumented")
+                print(f"{report_kind}: '{name}' at {path}:{line} is undocumented")
+                ret_code = 1 if ci else 0
 
-    return 0
+    return ret_code
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds a CI check for undocumented symbols. This currently only checks undeprecated and stable module code in `modules/standard`. The check was added as a part of the the existing dyno checks to reduce the extra time added to the CI.

[Reviewed by @DanilaFe]

