### PR TITLE
Remove extraneous assert for invalid pragma

### DIFF
--- a/frontend/lib/parsing/ParserContextImpl.h
+++ b/frontend/lib/parsing/ParserContextImpl.h
@@ -478,10 +478,6 @@ ParserContext::buildPragmaStmt(YYLTYPE loc, CommentsAndStmt cs) {
     // Clean up the attribute parts.
     resetAttributeGroupPartsState();
   } else {
-    // CHPL_ASSERT(numAttributesBuilt == 0);
-    if(cs.stmt)
-      CHPL_ASSERT(hasAttributeGroupParts);
-
     // TODO: The original builder also states the first pragma.
     CHPL_PARSER_REPORT(this, CannotAttachPragmas, loc, cs.stmt);
 

--- a/frontend/test/parsing/testParseErrors.cpp
+++ b/frontend/test/parsing/testParseErrors.cpp
@@ -67,6 +67,15 @@ static void test3(Parser* parser) {
   assert(guard.realizeErrors() == 2);
 }
 
+
+static void test4(Parser* parser) {
+  ErrorGuard guard(parser->context());
+  auto parseResult = parseStringAndReportErrors(parser, "test4.chpl",
+      "pragma \"lineno ok\"\n"
+      "use foo;\n");
+  assert(guard.realizeErrors() == 1);
+}
+
 int main() {
   Context::Configuration config_devel;
   config_devel.chplEnvOverrides.insert({"CHPL_DEVELOPER", "1"});
@@ -87,6 +96,8 @@ int main() {
   test2(p);
   test3(pd);
   test3(p);
+  test4(pd);
+  test4(p);
 
   return 0;
 }


### PR DESCRIPTION
Removes an assert in `ParserContextImpl.h` when erroring on a misused pragma. This check isn't really needed, and causes developer builds to fail with an internal error.

Followup to #23973, which fixed other cases.

## Testing
- paratest with comm none
- paratest with comm gasnet

[Reviewed by @]