### PR TITLE
Fix test errors after parser fix

### DIFF
--- a/frontend/lib/parsing/bison-chpl-lib.cpp
+++ b/frontend/lib/parsing/bison-chpl-lib.cpp
@@ -9788,7 +9788,7 @@ yyreduce:
   case 508: /* var_decl_stmt: var_decl_type error TSEMI  */
 #line 2814 "chpl.ypp"
   {
-    (yyval.commentsAndStmt) = { .comments=nullptr, .stmt=context->syntax((yylsp[-1]), "invalid variable declaration") };
+    (yyval.commentsAndStmt) = { .comments=nullptr, .stmt=ErroneousExpression::build(BUILDER, LOC((yylsp[-1]))).release() };
     context->resetDeclStateOnError();
   }
 #line 9795 "bison-chpl-lib.cpp"

--- a/frontend/lib/parsing/chpl.ypp
+++ b/frontend/lib/parsing/chpl.ypp
@@ -2812,7 +2812,7 @@ var_decl_stmt:
   }
 | var_decl_type error TSEMI
   {
-    $$ = { .comments=nullptr, .stmt=context->syntax(@2, "invalid variable declaration") };
+    $$ = { .comments=nullptr, .stmt=ErroneousExpression::build(BUILDER, LOC(@2)).release() };
     context->resetDeclStateOnError();
   }
 ;

--- a/frontend/test/parsing/testParseErrors.cpp
+++ b/frontend/test/parsing/testParseErrors.cpp
@@ -36,7 +36,7 @@ static void test0(Parser* parser) {
       "  var x = A[\n"
       "}}\n"
       "var y = 1;\n");
-  assert(guard.realizeErrors() == 2);
+  assert(guard.realizeErrors() == 1);
 }
 
 static void test1(Parser* parser) {
@@ -64,7 +64,7 @@ static void test3(Parser* parser) {
       "class C {\n"
       "  var a: pwned C;\n"
       "}\n");
-  assert(guard.realizeErrors() == 2);
+  assert(guard.realizeErrors() == 1);
 }
 
 int main() {

--- a/test/functions/generic/genericReturnMemKind.bad
+++ b/test/functions/generic/genericReturnMemKind.bad
@@ -1,4 +1,2 @@
 genericReturnMemKind.chpl:11: syntax error: near 'return'
 genericReturnMemKind.chpl:30: syntax error: near 'yield'
-genericReturnMemKind.chpl:11: error: no-op procedures are only legal for extern functions
-genericReturnMemKind.chpl:30: error: no-op procedures are only legal for extern functions

--- a/test/parsing/ferguson/many-errors-2.good
+++ b/test/parsing/ferguson/many-errors-2.good
@@ -4,4 +4,3 @@ many-errors-2.chpl:9: syntax error: near '}'
 many-errors-2.chpl:12: syntax error: near 'x'
 many-errors-2.chpl:16: syntax error: near 'x'
 many-errors-2.chpl:1: warning: an implicit module named 'many-errors-2' is being introduced to contain file-scope code
-many-errors-2.chpl:1: error: attempt to redefine reserved type 'real'


### PR DESCRIPTION
This PR reverts a late change in #23973 which broke a number of tests. Adding an extra `context->syntax(...)` created extra syntax errors in unwanted places, this PR removes that.

Ran full paratests with comm=none and comm=gasnet

[Reviewed by @dlongnecke-cray]