### PR TITLE
set c++ standard for chpldoc before defining target in cmake

### DIFF
--- a/tools/chpldoc/CMakeLists.txt
+++ b/tools/chpldoc/CMakeLists.txt
@@ -15,6 +15,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# request C++14 -- or C++17 if using LLVM 16
+if (CHPL_LLVM_VERSION VERSION_LESS 16.0)
+  set(CMAKE_CXX_STANDARD 14)
+else()
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 # Write the COPYRIGHT file, or update the existing file if the
 # the $CHPL_HOME/COPYRIGHT file has been modified
@@ -28,13 +35,6 @@ add_custom_command(
   COMMENT "writing COPYRIGHT file updates..."
   VERBATIM)
 add_executable(chpldoc chpldoc.cpp arg.cpp arg-helpers.cpp COPYRIGHT)
-# request C++14 -- or C++17 if using LLVM 16
-if (CHPL_LLVM_VERSION VERSION_LESS 16.0)
-  set(CMAKE_CXX_STANDARD 14)
-else()
-  set(CMAKE_CXX_STANDARD 17)
-endif()
-set(CMAKE_CXX_STANDARD_REQUIRED True)
 target_link_libraries(chpldoc ChplFrontend)
 target_include_directories(chpldoc PRIVATE
                            ${CHPL_MAIN_INCLUDE_DIR}


### PR DESCRIPTION
This PR adjusts the relative positions of setting the global CMake CXX standard value and defining the `chpldoc` target so that setting the value affects the target, where before the target was unaffected by the change. This is an update to https://github.com/chapel-lang/chapel/pull/24008.

This should fix remaining build failures for `chpldoc` when using llvm versions 11 and 12.

[reviewed by @jabraham17 - thank you!]
