### PR TITLE
implement return type resolution of prims get_real and get_imag in dyno

### DIFF
--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -1012,8 +1012,6 @@ CallResolutionResult resolvePrimCall(Context* context,
       break;
     /* primitives that return real parts from a complex */
     case PRIM_GET_REAL:
-      type = primComplexGetReal(context, ci);
-      break;
     case PRIM_GET_IMAG:
       type = primComplexGetReal(context, ci);
       break;

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -617,7 +617,8 @@ static QualifiedType primObjectToInt(Context* context, const CallInfo& ci) {
 /*
   for get real/imag primitives
 */
-static QualifiedType primComplexGetReal(Context* context, const CallInfo& ci) {
+static QualifiedType
+primComplexGetComponent(Context* context, const CallInfo& ci) {
   QualifiedType ret = QualifiedType();
 
   if (ci.numActuals() != 1) return ret;
@@ -1013,7 +1014,7 @@ CallResolutionResult resolvePrimCall(Context* context,
     /* primitives that return real parts from a complex */
     case PRIM_GET_REAL:
     case PRIM_GET_IMAG:
-      type = primComplexGetReal(context, ci);
+      type = primComplexGetComponent(context, ci);
       break;
     /* primitives that are not yet handled in dyno */
     case PRIM_ACTUALS_LIST:

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -614,6 +614,24 @@ static QualifiedType primObjectToInt(Context* context, const CallInfo& ci) {
   return QualifiedType(argType.kind(), IntType::get(context, 64));
 }
 
+/*
+  for get real/imag primitives
+*/
+static QualifiedType primComplexGetReal(Context* context, const CallInfo& ci) {
+  QualifiedType ret = QualifiedType();
+
+  if (ci.numActuals() != 1) return ret;
+
+  if (auto comp = ci.actual(0).type().type()->toComplexType()) {
+    if (comp->bitwidth() == 64) {
+      ret = QualifiedType(QualifiedType::REF, RealType::get(context, 32));
+    } else if (comp->bitwidth() == 128) {
+      ret = QualifiedType(QualifiedType::REF, RealType::get(context, 64));
+    }
+  }
+  return ret;
+}
+
 CallResolutionResult resolvePrimCall(Context* context,
                                      const PrimCall* call,
                                      const CallInfo& ci,
@@ -992,7 +1010,13 @@ CallResolutionResult resolvePrimCall(Context* context,
         type = QualifiedType(QualifiedType::PARAM, st, sp);
       }
       break;
-
+    /* primitives that return real parts from a complex */
+    case PRIM_GET_REAL:
+      type = primComplexGetReal(context, ci);
+      break;
+    case PRIM_GET_IMAG:
+      type = primComplexGetReal(context, ci);
+      break;
     /* primitives that are not yet handled in dyno */
     case PRIM_ACTUALS_LIST:
     case PRIM_REF_TO_STRING:
@@ -1001,8 +1025,6 @@ CallResolutionResult resolvePrimCall(Context* context,
     case PRIM_GET_MEMBER:
     case PRIM_GET_MEMBER_VALUE:
     case PRIM_NEW:
-    case PRIM_GET_REAL:
-    case PRIM_GET_IMAG:
     case PRIM_QUERY:
     case PRIM_QUERY_PARAM_FIELD:
     case PRIM_QUERY_TYPE_FIELD:

--- a/frontend/test/resolution/testFunctionCalls.cpp
+++ b/frontend/test/resolution/testFunctionCalls.cpp
@@ -164,6 +164,70 @@ static void test5() {
   assert(typePtr->toIntType()->bitwidth() == 64);
 }
 
+static void test6() {
+  // test for primitive return type for get real/imag
+  Context ctx;
+  auto context = &ctx;
+  QualifiedType qt =  resolveTypeOfXInit(context,
+                         R""""(
+                           var a: complex(128);
+                           var x = __primitive("complex_get_real", a);
+                         )"""");
+  assert(qt.kind() == QualifiedType::REF);
+  auto typePtr = qt.type();
+  assert(typePtr);
+  auto realPtr = typePtr->toRealType();
+  assert(realPtr->bitwidth()==64);
+}
+
+static void test7() {
+  // test for primitive return type for get real/imag
+  Context ctx;
+  auto context = &ctx;
+  QualifiedType qt =  resolveTypeOfXInit(context,
+                         R""""(
+                           var a: complex(64);
+                           var x = __primitive("complex_get_real", a);
+                         )"""");
+  assert(qt.kind() == QualifiedType::REF);
+  auto typePtr = qt.type();
+  assert(typePtr);
+  auto realPtr = typePtr->toRealType();
+  assert(realPtr->bitwidth()==32);
+}
+
+static void test8() {
+  // test for primitive return type for get real/imag
+  Context ctx;
+  auto context = &ctx;
+  QualifiedType qt =  resolveTypeOfXInit(context,
+                         R""""(
+                           var a: complex(128);
+                           var x = __primitive("complex_get_imag", a);
+                         )"""");
+  assert(qt.kind() == QualifiedType::REF);
+  auto typePtr = qt.type();
+  assert(typePtr);
+  auto realPtr = typePtr->toRealType();
+  assert(realPtr->bitwidth()==64);
+}
+
+static void test9() {
+  // test for primitive return type for get real/imag
+  Context ctx;
+  auto context = &ctx;
+  QualifiedType qt =  resolveTypeOfXInit(context,
+                         R""""(
+                           var a: complex(64);
+                           var x = __primitive("complex_get_imag", a);
+                         )"""");
+  assert(qt.kind() == QualifiedType::REF);
+  auto typePtr = qt.type();
+  assert(typePtr);
+  auto realPtr = typePtr->toRealType();
+  assert(realPtr->bitwidth()==32);
+}
+
 
 int main() {
   test1();
@@ -172,6 +236,10 @@ int main() {
   test3b();
   test4();
   test5();
+  test6();
+  test7();
+  test8();
+  test9();
 
   return 0;
 }


### PR DESCRIPTION
This PR implements resolution of the return types for `PRIM_GET_REAL` and `PRIM_GET_IMAG` in Dyno.

The backing issue for implementing these primitives is https://github.com/Cray/chapel-private/issues/5512

[reviewed by @riftEmber - thanks!]