### PR TITLE
Warn when a generic type is passed to a function

### DIFF
--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -2800,7 +2800,10 @@ static bool moveMakesTypeAlias(CallExpr* call) {
 ************************************** | *************************************/
 
 static void emitTypeAliasInit(Expr* after, Symbol* var, Expr* init) {
-  propagateMarkedGeneric(var, init);
+  if (var->hasFlag(FLAG_TEMP)) {
+    // propagate (?) through type temps for 'owned MyClass(?)' etc
+    propagateMarkedGeneric(var, init);
+  }
 
   // Generate a type constructor call for generic-with-defaults types
   // (Note, this does not work correctly during resolution).

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -9998,8 +9998,10 @@ static Type* resolveGenericActual(SymExpr* se, CallExpr* inCall,
 }
 
 static bool suppressWarnGenericActual(CallExpr* call) {
-  if (!call) return false;
-  return call->isPrimitive(PRIM_DEFAULT_INIT_VAR);
+  // not finding a call happens for specified return types
+  if (!call) return true;
+  // we generate other warnings for these cases, no need to warn here.
+  return call->isPrimitive();
 }
 
 static Type* resolveGenericActual(SymExpr* se, Type* type, CallExpr* inCall) {

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -10013,7 +10013,12 @@ static Type* resolveGenericActual(SymExpr* se, Type* type) {
       if (!isMethodReceiver && !genericWithDefaults) {
         gdbShouldBreakHere();
         checkSurprisingGenericDecls(se->symbol(), se, nullptr);
-        USR_WARN(se, "foo foo foo");
+        if (!se->getFunction()->hasFlag(FLAG_COMPILER_GENERATED)) {
+          USR_WARN(se, "please add '(?)' to type '%s' because it is generic", se->symbol()->name);
+          if (fWarnUnstable) {
+            USR_PRINT("this warning may be an error in the future");
+          }
+        }
       }
     }
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3862,7 +3862,8 @@ static void maybeWarnGenericActual(SymExpr* se, Type* type, CallExpr* inCall) {
 
   if (AggregateType* at = toAggregateType(type)) {
     if (at->symbol->hasFlag(FLAG_GENERIC) &&
-        !se->symbol()->hasFlag(FLAG_MARKED_GENERIC)) {
+        !se->symbol()->hasFlag(FLAG_MARKED_GENERIC) &&
+        !isBuiltinGenericType(type)) {
       bool isMethodReceiver = false;
       if (SymExpr* prevSe = toSymExpr(se->prev)) {
         if (prevSe->symbol() == gMethodToken) {

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -9970,10 +9970,21 @@ void resolveGenericActuals(CallExpr* call) {
 }
 
 static bool suppressWarnGenericActual(CallExpr* call) {
-  // not finding a call happens for specified return types
+  // not finding a call happens for specified return types,
+  // so suppress the warning there
   if (!call) return true;
+
   // we generate other warnings for these cases, no need to warn here.
-  return call->isPrimitive();
+  if (call->isPrimitive()) return true;
+
+  // and, don't emit a warning for calls to a function marked
+  // with a flag to suppress this warning
+  FnSymbol* fn = call->resolvedOrVirtualFunction();
+  if (fn && fn->hasFlag(FLAG_SUPPRESS_GENERIC_ACTUAL_WARNING))
+    return true;
+
+  // otherwise, don't suppress the warning
+  return false;
 }
 
 static void maybeWarnGenericActual(SymExpr* se, Type* type, CallExpr* inCall) {

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3876,7 +3876,6 @@ static void maybeWarnGenericActual(SymExpr* se, Type* type, CallExpr* inCall) {
       bool genericWithDefaults = at->isGenericWithDefaults();
 
       if (!isMethodReceiver && !genericWithDefaults) {
-        gdbShouldBreakHere();
         checkSurprisingGenericDecls(se->symbol(), se, nullptr);
         if (!se->getFunction()->hasFlag(FLAG_COMPILER_GENERATED)) {
           const char* name = se->symbol()->name;

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3856,6 +3856,10 @@ static bool suppressWarnGenericActual(CallExpr* call) {
 }
 
 static void maybeWarnGenericActual(SymExpr* se, Type* type, CallExpr* inCall) {
+  if (DecoratedClassType* dt = toDecoratedClassType(type)) {
+    type = dt->getCanonicalClass();
+  }
+
   if (AggregateType* at = toAggregateType(type)) {
     if (at->symbol->hasFlag(FLAG_GENERIC) &&
         !se->symbol()->hasFlag(FLAG_MARKED_GENERIC)) {

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -10000,6 +10000,23 @@ static Type* resolveGenericActual(SymExpr* se, Type* type) {
   }
 
   if (AggregateType* at = toAggregateType(type)) {
+    if (at->symbol->hasFlag(FLAG_GENERIC) &&
+        !se->symbol()->hasFlag(FLAG_MARKED_GENERIC)) {
+      bool isMethodReceiver = false;
+      if (SymExpr* prevSe = toSymExpr(se->prev)) {
+        if (prevSe->symbol() == gMethodToken) {
+          isMethodReceiver = true;
+        }
+      }
+      bool genericWithDefaults = at->isGenericWithDefaults();
+
+      if (!isMethodReceiver && !genericWithDefaults) {
+        gdbShouldBreakHere();
+        checkSurprisingGenericDecls(se->symbol(), se, nullptr);
+        USR_WARN(se, "foo foo foo");
+      }
+    }
+
     if (at->symbol->hasFlag(FLAG_GENERIC) && at->isGenericWithDefaults()) {
       CallExpr*   cc    = new CallExpr(at->symbol);
 

--- a/frontend/include/chpl/uast/PragmaList.h
+++ b/frontend/include/chpl/uast/PragmaList.h
@@ -569,6 +569,7 @@ PRAGMA(SHOULD_NOT_PASS_BY_REF, npr, "should not pass by ref", "this symbol shoul
 PRAGMA(SUPER_CLASS, npr, "super class", ncm)
 PRAGMA(SUPER_TEMP, npr, "temporary of super field", ncm)
 PRAGMA(SUPPRESS_LVALUE_ERRORS, ypr, "suppress lvalue error", "do not report an lvalue error if it occurs in a function with this flag")
+PRAGMA(SUPPRESS_GENERIC_ACTUAL_WARNING, ypr, "suppress generic actual warning", "do not report a generic actual warning for calls to this function")
 
 // represents an interface formal, assoc. type, or required function
 // within a constrained generic function

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -3286,12 +3286,18 @@ module ChapelBase {
   inline operator <=(param a: int(64), b: int(64)) do return __primitive("<=", a, b);
 
 
+  pragma "suppress generic actual warning"
   proc isGenericType(type t) param do return __primitive("is generic type", t);
+  pragma "suppress generic actual warning"
   proc isNilableClassType(type t) param do return __primitive("is nilable class type", t);
+  pragma "suppress generic actual warning"
   proc isNonNilableClassType(type t) param do return __primitive("is non nilable class type", t);
 
+  pragma "suppress generic actual warning"
   proc isBorrowedOrUnmanagedClassType(type t:unmanaged) param do return true;
+  pragma "suppress generic actual warning"
   proc isBorrowedOrUnmanagedClassType(type t:borrowed) param do return true;
+  pragma "suppress generic actual warning"
   proc isBorrowedOrUnmanagedClassType(type t) param do return false;
 
   // These style element #s are used in the default Writer and Reader.
@@ -3371,6 +3377,7 @@ module ChapelBase {
   // this could in principle be just _unmanaged (similar to type
   // constructor for a record) but that is more challenging because
   // _unmanaged is a built-in non-record type.
+  pragma "suppress generic actual warning"
   proc _to_unmanaged(type t) type {
     type rt = __primitive("to unmanaged class", t);
     return rt;
@@ -3380,6 +3387,7 @@ module ChapelBase {
     return ret;
   }
   // type constructor for converting to a borrow
+  pragma "suppress generic actual warning"
   proc _to_borrowed(type t) type {
     type rt = __primitive("to borrowed class", t);
     return rt;
@@ -3389,6 +3397,7 @@ module ChapelBase {
     return ret;
   }
   // changing nilability
+  pragma "suppress generic actual warning"
   proc _to_nonnil(type t) type {
     type rt = __primitive("to non nilable class", t);
     return rt;
@@ -3397,6 +3406,7 @@ module ChapelBase {
     var ret = __primitive("to non nilable class", arg);
     return ret;
   }
+  pragma "suppress generic actual warning"
   proc _to_nilable(type t) type {
     type rt = __primitive("to nilable class", t);
     return rt;

--- a/modules/standard/Reflection.chpl
+++ b/modules/standard/Reflection.chpl
@@ -36,6 +36,7 @@ chpl_unstableStandardSymbolForTesting;
 /* Ensure that a query about fields is applied to a class/record/union type.
    Return that type. If it is a class type, strip any decorators/mem managers.
 */
+pragma "suppress generic actual warning"
 private proc checkQueryT(type t) type {
   if isClassType(t) then
     return t: borrowed class;
@@ -52,6 +53,7 @@ private proc checkValidQueryT(type t) param {
 /* Return the number of fields in a class or record as a param.
    The count of fields includes types and param fields.
  */
+pragma "suppress generic actual warning"
 proc getNumFields(type t) param : int do
   return __primitive("num fields", checkQueryT(t));
 
@@ -68,6 +70,7 @@ proc numFields(type t) param : int do return getNumFields(t);
    :arg idx: which field to get the name of
    :returns: the name of the field, as a param string
  */
+pragma "suppress generic actual warning"
 proc getFieldName(type t, param idx:int) param : string do
   return __primitive("field num to name", checkQueryT(t), idx+1);
 
@@ -169,10 +172,12 @@ inline proc getField(const ref obj:?t, param name:string) const ref {
    types can be added to isImplementedWithRecords() as needed.
 */
 
+pragma "suppress generic actual warning"
 @chpldoc.nodoc
 proc isImplementedWithRecords(type t) param do
   return isRangeType(t) || isStringType(t);
 
+pragma "suppress generic actual warning"
 @chpldoc.nodoc
 proc numImplementationFields(type t) param : int
   where isImplementedWithRecords(t) do
@@ -240,6 +245,7 @@ proc getFieldRef(ref x:?t, param s:string) ref {
    :returns: an index usable in :proc:`getField`, or ``-1`` if the field
              was not found.
  */
+pragma "suppress generic actual warning"
 proc getFieldIndex(type t, param name:string) param : int do
   return __primitive("field name to num", checkQueryT(t), name)-1;
 
@@ -250,6 +256,7 @@ proc getFieldIndex(type t, param name:string) param : int do
    :arg name: the name of a field
    :returns: ``true`` if the field is present.
  */
+pragma "suppress generic actual warning"
 proc hasField(type t, param name:string) param : bool do
   return getFieldIndex(t, name) >= 0;
 
@@ -260,6 +267,7 @@ proc hasField(type t, param name:string) param : bool do
    :arg idx: which field to query
    :returns: ``true`` if the field is instantiated
 */
+pragma "suppress generic actual warning"
 @unstable(reason="'isFieldBound' is unstable - consider using 'T.fieldName != ?' syntax instead")
 proc isFieldBound(type t, param idx: int) param : bool {
   return __primitive("is bound", checkQueryT(t),
@@ -273,6 +281,7 @@ proc isFieldBound(type t, param idx: int) param : bool {
    :arg name: the name of a field
    :returns: ``true`` if the field is instantiated
 */
+pragma "suppress generic actual warning"
 @unstable(reason="'isFieldBound' is unstable - consider using 'T.fieldName != ?' syntax instead")
 proc isFieldBound(type t, param name : string) param : bool {
   return __primitive("is bound", checkQueryT(t), name);

--- a/modules/standard/Types.chpl
+++ b/modules/standard/Types.chpl
@@ -114,9 +114,11 @@ proc isEnumType(type t) param {
 }
 
 /* Return true if ``t`` is a class type. Otherwise return false. */
+pragma "suppress generic actual warning"
 proc isClassType(type t) param do return __primitive("is class type", t);
 
 /* Return true if ``t`` is a record type. Otherwise return false. */
+pragma "suppress generic actual warning"
 proc isRecordType(type t) param {
   if __primitive("is record type", t) == false then
     return false;
@@ -138,6 +140,7 @@ proc isRecordType(type t) param {
 }
 
 /* Return true if ``t`` is a union type. Otherwise return false. */
+pragma "suppress generic actual warning"
 proc isUnionType(type t) param do return __primitive("is union type", t);
 
 /* Returns ``true`` if its argument is a tuple type.  */
@@ -455,8 +458,10 @@ proc isSingle(type t)    param do  return isSingleType(t);
 @chpldoc.nodoc
 proc isAtomic(type t)    param do  return isAtomicType(t);
 
+pragma "suppress generic actual warning"
 @chpldoc.nodoc
 proc isGeneric(type t)   param do  return isGenericType(t);
+
 @chpldoc.nodoc
 proc isHomogeneousTuple(type t)  param do  return isHomogeneousTupleType(t);
 @chpldoc.nodoc

--- a/test/arrays/compilerErrors/array-of-generic-class.chpl
+++ b/test/arrays/compilerErrors/array-of-generic-class.chpl
@@ -1,2 +1,2 @@
 class GenericClass { var x; }
-var A:[1..10] GenericClass;
+var A:[1..10] GenericClass(?);

--- a/test/arrays/compilerErrors/array-of-generic-record.chpl
+++ b/test/arrays/compilerErrors/array-of-generic-record.chpl
@@ -1,2 +1,2 @@
 record GenericRecord { var x; }
-var A:[1..10] GenericRecord;
+var A:[1..10] GenericRecord(?);

--- a/test/arrays/compilerErrors/arrayFieldOfSharedGenericClassType.chpl
+++ b/test/arrays/compilerErrors/arrayFieldOfSharedGenericClassType.chpl
@@ -2,7 +2,7 @@ param entries:int = 4;
 
 record table {
     param entries;
-    forwarding var columns: [0..entries-1] shared column;
+    forwarding var columns: [0..entries-1] shared column(?);
 
     proc init(param entries:int) {
         this.entries = entries;

--- a/test/classes/ferguson/class-alias-generic-arg.chpl
+++ b/test/classes/ferguson/class-alias-generic-arg.chpl
@@ -9,5 +9,5 @@ proc doit(type C)
   writeln(c.x);
 }
 
-doit(A);
+doit(A(?));
 

--- a/test/classes/generic/nestedGenericTypes.chpl
+++ b/test/classes/generic/nestedGenericTypes.chpl
@@ -1,6 +1,6 @@
 class MyGenericClass { var x; }
 record Wrapper { var impl; }
-var x: Wrapper(unmanaged MyGenericClass)
+var x: Wrapper(unmanaged MyGenericClass(?))
   = new Wrapper(new unmanaged MyGenericClass(1));
 writeln(x);
 delete x.impl;

--- a/test/classes/nilability/nil-non-subtype.chpl
+++ b/test/classes/nilability/nil-non-subtype.chpl
@@ -20,7 +20,7 @@ proc test(type A, type B) {
 
 proc main() {
   test(C, C?);
-  test(G, G?);
+  test(G(?), G?(?));
   test(G(int), G(int)?);
   test(D, C?);
 }

--- a/test/classes/nilability/question-mark-variations.chpl
+++ b/test/classes/nilability/question-mark-variations.chpl
@@ -51,7 +51,7 @@ proc factory1(type t) {
 proc factory2(type t) {
   return new t(1);
 }
-var d0 = factory1(C?);
+var d0 = factory1(C(?)?);
 writeln("d0 ", d0.type:string, " ", d0);
 var d1 = factory2(C(int)?);
 writeln("d1 ", d1.type:string, " ", d1);

--- a/test/functions/generic/poi/check-gc-reuse-inits.chpl
+++ b/test/functions/generic/poi/check-gc-reuse-inits.chpl
@@ -43,7 +43,7 @@ module User {
     r1 = r2;                  // =
     var lt = r1 < r2;         // <
     var castF = r1: int;      // _cast from
-    var castT = 1: MyRecord;  // _cast to
+    var castT = 1: MyRecord(?);  // _cast to
   }
   proc u2() {
     {
@@ -54,7 +54,7 @@ module User {
       r1 = r2;                  // =
       var lt = r1 < r2;         // <
       var castF = r1: int;      // _cast from
-      var castT = 1: MyRecord;  // _cast to
+      var castT = 1: MyRecord(?);  // _cast to
     }
   }
   proc u3() {
@@ -73,7 +73,7 @@ module User {
     r1 = r2;                  // =
     var lt = r1 < r2;         // <
     var castF = r1: int;      // _cast from
-    var castT = 1: MyRecord;  // _cast to
+    var castT = 1: MyRecord(?);  // _cast to
   }
 
   proc main {
@@ -120,7 +120,7 @@ module More1 {
     r1 = r2;                  // =
     var lt = r1 < r2;         // <
     var castF = r1: int;      // _cast from
-    var castT = 1: MyRecord;  // _cast to
+    var castT = 1: MyRecord(?);  // _cast to
   }
   proc m1gen(param p) {
     note("More1.m1gen", 1);
@@ -130,7 +130,7 @@ module More1 {
     r1 = r2;                  // =
     var lt = r1 < r2;         // <
     var castF = r1: int;      // _cast from
-    var castT = 1: MyRecord;  // _cast to
+    var castT = 1: MyRecord(?);  // _cast to
   }
 }
 
@@ -149,7 +149,7 @@ module More2 {
     r1 = r2;                  // =
     var lt = r1 < r2;         // <
     var castF = r1: int;      // _cast from
-    var castT = 1: MyRecord;  // _cast to
+    var castT = 1: MyRecord(?);  // _cast to
   }
 }
 
@@ -175,7 +175,7 @@ module Combo1 {
     r1 = r2;                  // =
     var lt = r1 < r2;         // <
     var castF = r1: int;      // _cast from
-    var castT = 1: MyRecord;  // _cast to
+    var castT = 1: MyRecord(?);  // _cast to
   }
 }
 
@@ -190,7 +190,7 @@ module Combo2 {
     r1 = r2;                  // =
     var lt = r1 < r2;         // <
     var castF = r1: int;      // _cast from
-    var castT = 1: MyRecord;  // _cast to
+    var castT = 1: MyRecord(?);  // _cast to
   }
   proc combo2b() {
     use Combo1;

--- a/test/functions/generic/poi/check-gc-reuse-opers.chpl
+++ b/test/functions/generic/poi/check-gc-reuse-opers.chpl
@@ -24,7 +24,7 @@ module Lib {
   proc libAS(myArg) { r1 = r2;                  } // =
   proc libLT(myArg) { var lt = r1 < r2;         } // <
   proc libCF(myArg) { var castF = r1: int;      } // cast from
-  proc libCT(myArg) { var castT = 1: MyRecord;  } // cast to
+  proc libCT(myArg) { var castT = 1: MyRecord(?);  } // cast to
 }
 
 module User {

--- a/test/functions/generic/warn-generic-actual.chpl
+++ b/test/functions/generic/warn-generic-actual.chpl
@@ -57,3 +57,9 @@ proc test5() {
   f(integral); // do not warn (built in generic type)
 }
 test5();
+
+proc type C.typeMethod() { }
+proc test6() {
+  C.typeMethod(); // do not warn (method receiver)
+}
+test6();

--- a/test/functions/generic/warn-generic-actual.chpl
+++ b/test/functions/generic/warn-generic-actual.chpl
@@ -34,3 +34,11 @@ proc test2() {
   f(T(?)); // do not warn
 }
 test2();
+
+pragma "suppress generic actual warning"
+proc g(type t) { }
+
+proc test3() {
+  g(genericRecord); // do not warn (suppressed by pragma)
+}
+test3();

--- a/test/functions/generic/warn-generic-actual.chpl
+++ b/test/functions/generic/warn-generic-actual.chpl
@@ -1,0 +1,36 @@
+proc f(type t) { }
+record genericRecord { type eltType; }
+
+f(genericRecord); // warn
+f(genericRecord(?)); // do not warn
+
+type T = genericRecord(?);
+f(T); // warn
+f(T(?)); // do not warn
+
+// same, within a function
+proc test0() {
+  f(genericRecord); // warn
+  f(genericRecord(?)); // do not warn
+
+  type T = genericRecord(?);
+  f(T); // warn
+  f(T(?)); // do not warn
+}
+test0();
+
+// same, within a function, with a type alias
+proc test1() {
+  type T = genericRecord(?);
+  f(T); // warn
+  f(T(?)); // do not warn
+}
+test1();
+
+// within a function, with a type alias, no (?) on type =
+proc test2() {
+  type T = genericRecord;
+  f(T); // warn
+  f(T(?)); // do not warn
+}
+test2();

--- a/test/functions/generic/warn-generic-actual.chpl
+++ b/test/functions/generic/warn-generic-actual.chpl
@@ -35,10 +35,20 @@ proc test2() {
 }
 test2();
 
+class C { type t; }
+proc test3() {
+  f(C); // warn
+  f(borrowed C); // warn
+  f(unmanaged C); // warn
+  f(owned C); // warn
+  f(shared C); // warn
+}
+test3();
+
 pragma "suppress generic actual warning"
 proc g(type t) { }
 
-proc test3() {
+proc test4() {
   g(genericRecord); // do not warn (suppressed by pragma)
 }
-test3();
+test4();

--- a/test/functions/generic/warn-generic-actual.chpl
+++ b/test/functions/generic/warn-generic-actual.chpl
@@ -52,3 +52,8 @@ proc test4() {
   g(genericRecord); // do not warn (suppressed by pragma)
 }
 test4();
+
+proc test5() {
+  f(integral); // do not warn (built in generic type)
+}
+test5();

--- a/test/functions/generic/warn-generic-actual.good
+++ b/test/functions/generic/warn-generic-actual.good
@@ -10,6 +10,6 @@ warn-generic-actual.chpl:33: warning: please add '(?)' to type 'T' because it is
 warn-generic-actual.chpl:39: In function 'test3':
 warn-generic-actual.chpl:40: warning: please add '(?)' to type 'C' because it is generic
 warn-generic-actual.chpl:41: warning: please add '(?)' to type 'C' because it is generic
-warn-generic-actual.chpl:42: warning: please add '(?)' to type 'unmanaged C' because it is generic
-warn-generic-actual.chpl:43: warning: please add '(?)' to type 'call_tmp' because it is generic
-warn-generic-actual.chpl:44: warning: please add '(?)' to type 'call_tmp' because it is generic
+warn-generic-actual.chpl:42: warning: please add '(?)' to type 'C' because it is generic
+warn-generic-actual.chpl:43: warning: please add '(?)' to type 'C' because it is generic
+warn-generic-actual.chpl:44: warning: please add '(?)' to type 'C' because it is generic

--- a/test/functions/generic/warn-generic-actual.good
+++ b/test/functions/generic/warn-generic-actual.good
@@ -7,3 +7,9 @@ warn-generic-actual.chpl:23: In function 'test1':
 warn-generic-actual.chpl:25: warning: please add '(?)' to type 'T' because it is generic
 warn-generic-actual.chpl:31: In function 'test2':
 warn-generic-actual.chpl:33: warning: please add '(?)' to type 'T' because it is generic
+warn-generic-actual.chpl:39: In function 'test3':
+warn-generic-actual.chpl:40: warning: please add '(?)' to type 'C' because it is generic
+warn-generic-actual.chpl:41: warning: please add '(?)' to type 'C' because it is generic
+warn-generic-actual.chpl:42: warning: please add '(?)' to type 'unmanaged C' because it is generic
+warn-generic-actual.chpl:43: warning: please add '(?)' to type 'call_tmp' because it is generic
+warn-generic-actual.chpl:44: warning: please add '(?)' to type 'call_tmp' because it is generic

--- a/test/functions/generic/warn-generic-actual.good
+++ b/test/functions/generic/warn-generic-actual.good
@@ -1,0 +1,9 @@
+warn-generic-actual.chpl:4: warning: please add '(?)' to type 'genericRecord' because it is generic
+warn-generic-actual.chpl:8: warning: please add '(?)' to type 'T' because it is generic
+warn-generic-actual.chpl:12: In function 'test0':
+warn-generic-actual.chpl:13: warning: please add '(?)' to type 'genericRecord' because it is generic
+warn-generic-actual.chpl:17: warning: please add '(?)' to type 'T' because it is generic
+warn-generic-actual.chpl:23: In function 'test1':
+warn-generic-actual.chpl:25: warning: please add '(?)' to type 'T' because it is generic
+warn-generic-actual.chpl:31: In function 'test2':
+warn-generic-actual.chpl:33: warning: please add '(?)' to type 'T' because it is generic

--- a/test/functions/lydia/genericActualTypeArg.chpl
+++ b/test/functions/lydia/genericActualTypeArg.chpl
@@ -3,7 +3,7 @@ proc bar(type t) {
 }
 
 bar(int);
-bar(Foo);
+bar(Foo(?));
 
 
 class Foo {

--- a/test/functions/resolution/errors/printAdditionalErrors-1.all.good
+++ b/test/functions/resolution/errors/printAdditionalErrors-1.all.good
@@ -1,6 +1,6 @@
 printAdditionalErrors-1.chpl:8: In function 'f1':
 printAdditionalErrors-1.chpl:9: warning: postponed error: fatal error in f1()
-  $CHPL_HOME/modules/standard/Reflection.chpl:293: called as f1(x: int(64)) from function 'canResolve'
+  $CHPL_HOME/modules/standard/Reflection.chpl:302: called as f1(x: int(64)) from function 'canResolve'
   printAdditionalErrors-1.chpl:17: called as canResolve(param fname = "f1", args(0): int(64)) from module 'printAdditionalErrors-1'
 printAdditionalErrors-1.chpl:19: warning: NOOOO, f1() does not resolve
 printAdditionalErrors-1.chpl:11: In function 'f2':
@@ -11,5 +11,5 @@ printAdditionalErrors-1.chpl:15: error: unresolved call 'f1(3, 4)'
 printAdditionalErrors-1.chpl:8: note: this candidate did not match: f1(x: int)
 printAdditionalErrors-1.chpl:15: note: because call includes 2 arguments
 printAdditionalErrors-1.chpl:8: note: but function can only accept 1 argument
-  $CHPL_HOME/modules/standard/Reflection.chpl:293: called as f3(x: int(64)) from function 'canResolve'
+  $CHPL_HOME/modules/standard/Reflection.chpl:302: called as f3(x: int(64)) from function 'canResolve'
   printAdditionalErrors-1.chpl:25: called as canResolve(param fname = "f3", args(0): int(64)) from module 'printAdditionalErrors-1'

--- a/test/functions/resolution/errors/printAdditionalErrors-2.good
+++ b/test/functions/resolution/errors/printAdditionalErrors-2.good
@@ -1,6 +1,6 @@
 printAdditionalErrors-2.chpl:18: In function 'asdf':
 printAdditionalErrors-2.chpl:19: warning: postponed error: fatal error in asdf
-  $CHPL_HOME/modules/standard/Reflection.chpl:293: called as asdf(x: int(64)) from function 'canResolve'
+  $CHPL_HOME/modules/standard/Reflection.chpl:302: called as asdf(x: int(64)) from function 'canResolve'
   printAdditionalErrors-2.chpl:13: called as canResolve(param fname = "asdf", args(0): int(64)) from function 'chpl__coerceMove'
   printAdditionalErrors-2.chpl:3: called as chpl__coerceMove(hi: string, b: bool) from module 'printAdditionalErrors-2'
 printAdditionalErrors-2.chpl:3: error: invalid copy-initialization

--- a/test/functions/vass/declaredGenericReturnTuple.chpl
+++ b/test/functions/vass/declaredGenericReturnTuple.chpl
@@ -18,15 +18,15 @@ iter i2(): (VectorListElement(?),) { yield (VLE,); }
 for j2 in i2() do writeln(j2);
 
 // Ensure that these tuples are generic.
-type t1 = (VectorListElement,);
+type t1 = (VectorListElement(?),);
 compilerWarning(t1:string, "  isGeneric: ", isGeneric(t1):string);
 
 record myRecord { type t; }
-type t2 = (myRecord,);
+type t2 = (myRecord(?),);
 compilerWarning(t2:string, "  isGeneric: ", isGeneric(t2):string);
 
-type t3 = (myRecord, VectorListElement);
+type t3 = (myRecord(?), VectorListElement(?));
 compilerWarning(t3:string, "  isGeneric: ", isGeneric(t3):string);
 
-type t4 = (int, owned VectorListElement);
+type t4 = (int, owned VectorListElement(?));
 compilerWarning(t4:string, "  isGeneric: ", isGeneric(t4):string);

--- a/test/io/serializers/generic-type.chpl
+++ b/test/io/serializers/generic-type.chpl
@@ -12,11 +12,7 @@ proc main() {
     f.writer(locking=false).write(new R(int, 5));
   }
   {
-<<<<<<< HEAD
-    var val = f.reader(locking=false).read(R);
-=======
-    var val = f.reader().read(R(?));
->>>>>>> e71cc1fc7c (Update some tests that are properly generating errors)
+    var val = f.reader(locking=false).read(R(?));
     writeln(val);
   }
 }

--- a/test/io/serializers/generic-type.chpl
+++ b/test/io/serializers/generic-type.chpl
@@ -12,7 +12,11 @@ proc main() {
     f.writer(locking=false).write(new R(int, 5));
   }
   {
+<<<<<<< HEAD
     var val = f.reader(locking=false).read(R);
+=======
+    var val = f.reader().read(R(?));
+>>>>>>> e71cc1fc7c (Update some tests that are properly generating errors)
     writeln(val);
   }
 }

--- a/test/library/standard/Reflection/field-queries-ok.chpl
+++ b/test/library/standard/Reflection/field-queries-ok.chpl
@@ -32,15 +32,15 @@ class CGen {
   var f1, f2, f3, f4, f5, f6;
 }
 
-test(CGen);
-test(CGen: owned class);
-test(CGen: owned class?);
-test(CGen: shared class);
-test(CGen: shared class?);
-test(CGen: borrowed class);
-test(CGen: borrowed class?);
-test(CGen: unmanaged class);
-test(CGen: unmanaged class?);
+test(CGen(?));
+test(CGen(?): owned class);
+test(CGen(?): owned class?);
+test(CGen(?): shared class);
+test(CGen(?): shared class?);
+test(CGen(?): borrowed class);
+test(CGen(?): borrowed class?);
+test(CGen(?): unmanaged class);
+test(CGen(?): unmanaged class?);
 
 
 record RCon {
@@ -54,7 +54,7 @@ record RGen {
   var f1, f2, f3, f4, f5, f6;
 }
 
-test(RGen);
+test(RGen(?));
 
 
 union UCon {
@@ -68,7 +68,7 @@ union UGen {
   var f1, f2, f3, f4, f5, f6;
 }
 
-test(UGen);
+test(UGen(?));
 
 
 compilerError("=== done ===");

--- a/test/library/standard/Set/init/setInitGenericError.chpl
+++ b/test/library/standard/Set/init/setInitGenericError.chpl
@@ -5,5 +5,5 @@ record R {
   var y = 10;
 }
 
-var s = new set(R);
+var s = new set(R(?));
 writeln(s);

--- a/test/library/standard/Types/copyable/copyable-generic.chpl
+++ b/test/library/standard/Types/copyable/copyable-generic.chpl
@@ -36,8 +36,8 @@ proc main() {
 
   // generic composite not ok
   // using nil value and not checking it, as these can't be instantiated
-  checkNo(GenericRecord, nil, onlyType = true);
-  checkNo(GenericRecordWithSomeDefaults, nil, onlyType = true);
+  checkNo(GenericRecord(?), nil, onlyType = true);
+  checkNo(GenericRecordWithSomeDefaults(?), nil, onlyType = true);
 
   // generic with all defaults ok
   checkNormal(GenericRecordWithSomeDefaults(int, real), grSomeDefaultsFilledIn);

--- a/test/optimizations/constDomain/domainField2.chpl
+++ b/test/optimizations/constDomain/domainField2.chpl
@@ -70,7 +70,7 @@ proc returnVar() {
     var a: [d] int;
   }
 
-  testAll(R);
+  testAll(R(?));
 }
 
 {
@@ -81,7 +81,7 @@ proc returnVar() {
     var a: [d] int;
   }
 
-  testAll(R);
+  testAll(R(?));
 }
 
 {
@@ -116,7 +116,7 @@ proc returnVar() {
     proc init(d) { this.d = d; }
   }
 
-  testAll(R);
+  testAll(R(?));
 }
 
 {
@@ -129,7 +129,7 @@ proc returnVar() {
     proc init(in d) { this.d = d; }
   }
 
-  testAll(R);
+  testAll(R(?));
 }
 
 {
@@ -142,7 +142,7 @@ proc returnVar() {
     proc init(const in d) { this.d = d; }
   }
 
-  testAll(R);
+  testAll(R(?));
 }
 
 {
@@ -194,7 +194,7 @@ proc returnVar() {
     proc init(d: domain(1, int)) { this.d = d; }
   }
 
-  testAll(R);
+  testAll(R(?));
 }
 
 {
@@ -207,7 +207,7 @@ proc returnVar() {
     proc init(in d: domain(1, int)) { this.d = d; }
   }
 
-  testAll(R);
+  testAll(R(?));
 }
 
 {
@@ -220,7 +220,7 @@ proc returnVar() {
     proc init(const in d: domain(1, int)) { this.d = d; }
   }
 
-  testAll(R);
+  testAll(R(?));
 }
 
 {
@@ -272,7 +272,7 @@ proc returnVar() {
     proc init(d) { this.d = d; }
   }
 
-  testAll(R);
+  testAll(R(?));
 }
 
 {
@@ -285,7 +285,7 @@ proc returnVar() {
     proc init(in d) { this.d = d; }
   }
 
-  testAll(R);
+  testAll(R(?));
 }
 
 {
@@ -298,7 +298,7 @@ proc returnVar() {
     proc init(const in d) { this.d = d; }
   }
 
-  testAll(R);
+  testAll(R(?));
 }
 
 {
@@ -350,7 +350,7 @@ proc returnVar() {
     proc init(d: domain(1, int)) { this.d = d; }
   }
 
-  testAll(R);
+  testAll(R(?));
 }
 
 {
@@ -363,7 +363,7 @@ proc returnVar() {
     proc init(in d: domain(1, int)) { this.d = d; }
   }
 
-  testAll(R);
+  testAll(R(?));
 }
 
 {
@@ -376,7 +376,7 @@ proc returnVar() {
     proc init(const in d: domain(1, int)) { this.d = d; }
   }
 
-  testAll(R);
+  testAll(R(?));
 }
 
 {

--- a/test/studies/adventOfCode/2021/bradc/futures/day18-bug2.bad
+++ b/test/studies/adventOfCode/2021/bradc/futures/day18-bug2.bad
@@ -5,6 +5,9 @@ day18-bug2.chpl:23: warning: please use '?' when declaring a routine with a gene
 day18-bug2.chpl:23: note: for example with 'Node(?)'
 day18-bug2.chpl:26: warning: please use '?' when declaring a variable with generic type
 day18-bug2.chpl:26: note: for example with 'Node(?)'
+$CHPL_HOME/modules/internal/OwnedObject.chpl:133: In method 'init=':
+$CHPL_HOME/modules/internal/OwnedObject.chpl:137: warning: please add '(?)' to type 'call_tmp' because it is generic
+  day18-bug2.chpl:26: called as (owned Node?).init=(src: nil)
 $CHPL_HOME/modules/internal/OwnedObject.chpl:57: In initializer:
 $CHPL_HOME/modules/internal/OwnedObject.chpl:62: error: Could not coerce 'nil' to 'borrowed Node?' in initialization
   $CHPL_HOME/modules/internal/OwnedObject.chpl:137: called as owned.init(type chpl_t = borrowed Node?)

--- a/test/studies/adventOfCode/2021/bradc/futures/day18-bug2.bad
+++ b/test/studies/adventOfCode/2021/bradc/futures/day18-bug2.bad
@@ -6,7 +6,7 @@ day18-bug2.chpl:23: note: for example with 'Node(?)'
 day18-bug2.chpl:26: warning: please use '?' when declaring a variable with generic type
 day18-bug2.chpl:26: note: for example with 'Node(?)'
 $CHPL_HOME/modules/internal/OwnedObject.chpl:133: In method 'init=':
-$CHPL_HOME/modules/internal/OwnedObject.chpl:137: warning: please add '(?)' to type 'call_tmp' because it is generic
+$CHPL_HOME/modules/internal/OwnedObject.chpl:137: warning: please add '(?)' to type 'Node' because it is generic
   day18-bug2.chpl:26: called as (owned Node?).init=(src: nil)
 $CHPL_HOME/modules/internal/OwnedObject.chpl:57: In initializer:
 $CHPL_HOME/modules/internal/OwnedObject.chpl:62: error: Could not coerce 'nil' to 'borrowed Node?' in initialization

--- a/test/types/partial/inOrder.chpl
+++ b/test/types/partial/inOrder.chpl
@@ -36,7 +36,7 @@ proc testAliases() {
 }
 
 proc testFunctions() {
-  var A = makeR(R, int, string, 5);
+  var A = makeR(R(?), int, string, 5);
   writeln(A.type:string);
   writeln(A);
 

--- a/test/types/partial/initeq.chpl
+++ b/test/types/partial/initeq.chpl
@@ -47,7 +47,7 @@ proc main() {
     writeln(b);
   }
   {
-    helper(W, "hello");
-    helper(W, 1234);
+    helper(W(?), "hello");
+    helper(W(?), 1234);
   }
 }

--- a/test/types/partial/partialTypeFormal.chpl
+++ b/test/types/partial/partialTypeFormal.chpl
@@ -12,10 +12,10 @@ proc foo(type T, x : T(int, ?)) {
 
 proc main() {
   var x = new R(int, 5);
-  foo(R, x);
+  foo(R(?), x);
 
   if error {
     var y = new R(real, 5);
-    foo(R, y);
+    foo(R(?), y);
   }
 }

--- a/test/types/range/userAPI/partialInit.chpl
+++ b/test/types/range/userAPI/partialInit.chpl
@@ -4,10 +4,10 @@ proc main() {
   // expression
   type SR = range(strides=strideKind.any, ?);
 
-  var A : SR = 1..10;
+  var A : SR(?) = 1..10;
   writeln(A.type:string, ": ", A);
 
-  var B : SR = 1:uint .. 10:uint;
+  var B : SR(?) = 1:uint .. 10:uint;
   writeln(B.type:string, ": ", B);
 }
 

--- a/test/types/records/generic/generic-with-defaults-q-problem.chpl
+++ b/test/types/records/generic/generic-with-defaults-q-problem.chpl
@@ -7,6 +7,6 @@ record K {
 }
 
 {
-  writeln(isGeneric(K));
+  writeln(isGeneric(K(?)));
   var kk = new K(new GRD(int));
 }

--- a/test/types/records/generic/generic-with-defaults-q-problem.chpl
+++ b/test/types/records/generic/generic-with-defaults-q-problem.chpl
@@ -7,6 +7,6 @@ record K {
 }
 
 {
-  writeln(isGeneric(K(?)));
+  writeln(isGeneric(K));
   var kk = new K(new GRD(int));
 }

--- a/test/types/typeFunctions/generic-type-and-default-argument.chpl
+++ b/test/types/typeFunctions/generic-type-and-default-argument.chpl
@@ -8,6 +8,6 @@ record R {
 proc f(type t, type u = t.tt) {
   writeln("t=", t:string, " u=", u:string);
 }
-f(R);
+f(R(?));
 
 // see also test/classes/bradc/paramInClass/weirdParamInit4

--- a/test/types/typeFunctions/isgeneric.chpl
+++ b/test/types/typeFunctions/isgeneric.chpl
@@ -7,16 +7,16 @@ record GenericC { var x; }
 assert(!isGeneric(int));
 assert(!isGenericType(int));
 
-assert(isGeneric(GenericR));
-assert(isGenericType(GenericR));
+assert(isGeneric(GenericR(?)));
+assert(isGenericType(GenericR(?)));
 assert(!isGeneric(GenericR(int)));
 assert(!isGenericType(GenericR(int)));
 
 assert(!isGeneric(ConcreteR));
 assert(!isGenericType(ConcreteR));
 
-assert(isGeneric(GenericC));
-assert(isGenericType(GenericC));
+assert(isGeneric(GenericC(?)));
+assert(isGenericType(GenericC(?)));
 assert(!isGeneric(GenericC(string)));
 assert(!isGenericType(GenericC(string)));
 

--- a/test/types/type_variables/ferguson/generic-type-actual-used-next.chpl
+++ b/test/types/type_variables/ferguson/generic-type-actual-used-next.chpl
@@ -5,4 +5,4 @@ proc f(type t, x: t) {
 }
 
 var x = new GenericRecord(1);
-f(GenericRecord, x);
+f(GenericRecord(?), x);

--- a/test/types/type_variables/ferguson/some-defaults-ignored.chpl
+++ b/test/types/type_variables/ferguson/some-defaults-ignored.chpl
@@ -15,5 +15,5 @@ proc printType(type t) {
     writeln(".rank: ", t.rank:string);
 }
 
-printType(R);
+printType(R(?));
 printType(R());

--- a/test/types/type_variables/ferguson/some-defaults-ignored.good
+++ b/test/types/type_variables/ferguson/some-defaults-ignored.good
@@ -1,5 +1,6 @@
 some-defaults-ignored.chpl:19: warning: unstable type construction with some generic defaults
 some-defaults-ignored.chpl:1: note: this type construction might ignore field defaults in the type declared here but that may change
+some-defaults-ignored.chpl:19: warning: please add '(?)' to type 'call_tmp' because it is generic
 R
 .t is uninstantiated
 .rank is uninstantiated

--- a/test/types/type_variables/ferguson/some-defaults-ignored.good
+++ b/test/types/type_variables/ferguson/some-defaults-ignored.good
@@ -1,6 +1,6 @@
 some-defaults-ignored.chpl:19: warning: unstable type construction with some generic defaults
 some-defaults-ignored.chpl:1: note: this type construction might ignore field defaults in the type declared here but that may change
-some-defaults-ignored.chpl:19: warning: please add '(?)' to type 'call_tmp' because it is generic
+some-defaults-ignored.chpl:19: warning: please add '(?)' to type 'R' because it is generic
 R
 .t is uninstantiated
 .rank is uninstantiated

--- a/test/types/type_variables/ferguson/warn-generic-var-field-no-q.chpl
+++ b/test/types/type_variables/ferguson/warn-generic-var-field-no-q.chpl
@@ -34,7 +34,7 @@ proc main() {
   var myvar5: GR = new GR(int, 5);
   var myvar6: GR(?) = new GR(int, 6);
 
-  genericFn(GR);
+  genericFn(GR(?));
 
   compilerError("done");
 }

--- a/test/users/alvaradoo/refToSubclassInternalError-shared.chpl
+++ b/test/users/alvaradoo/refToSubclassInternalError-shared.chpl
@@ -20,7 +20,7 @@ proc populate(dataArray, inputVertices, ref vertexProps, dataTypeMap, colId) {
   writeln("## Inserting ", etype, " data ##");
   forall (v,j) in zip(inputVertices,inputVertices.domain) {
     writeln("Attempting to insert data ", dataArray[j], " for vertex ", inputVertices[j]);
-    ref currentProperty: shared Property = vertexProps[v,etypeInd];
+    ref currentProperty: shared Property(?) = vertexProps[v,etypeInd];
     currentProperty!.dataType = etypeInd;
     //currentProperty!.propertyIdentifier += colId; // error
     //currentProperty!.propertyValue[colId] = dataArray[j]; // error


### PR DESCRIPTION
For https://github.com/Cray/chapel-private/issues/5693.

This PR adds a warning when an actual argument in a call is generic but does not include `(?)`. The purpose of this is to emphasize that the type is generic since typical uses of type arguments use concrete types. For example:

``` chapel
proc f(type t) { }
record genericRecord { type eltType; }

f(genericRecord); // warn
f(genericRecord(?)); // do not warn
```

Occasionally, there are generic functions for which this warning does not make sense. One example is `proc isGeneric(type t)`. The warning can be disabled for such functions with `pragma "suppress generic actual warning"`, but in the future I expect we will add one or more attributes for this.

At present, the warning does not apply to a generic-management class type, so for example, if we have `class C`, `f(C)` does not generate the warning. The reason is that we currently don't have syntax for explicitly specifying generic management (`(?)` means something else: that the class fields are generic).

See the new test `test/functions/generic/warn-generic-actual.chpl` for more examples.

Reviewed by @benharsh & @bradcray helped with development and review - thanks!

- [x] comm=none testing
- [x] gasnet testing
