### PR TITLE
Change define about exit to a script to check sources

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -113,6 +113,9 @@ jobs:
     - name: find bad runtime calls
       run: |
         ./util/devel/lookForBadRTCalls
+    - name: find bad compiler calls
+      run: |
+        ./util/devel/lookForBadCompCalls
     - name: check annotations
       run: |
         CHPL_LLVM=none make test-venv

--- a/compiler/include/misc.h
+++ b/compiler/include/misc.h
@@ -30,13 +30,6 @@
 #include "chpl/util/break.h"
 #include "chpl/framework/ErrorBase.h"
 
-#ifdef HAVE_LLVM
-#define exit(x) clean_exit(x)
-#else
-// This interferes with uses of exit() in LLVM header files.
-#define exit(x) dont_use_exit_use_clean_exit_instead
-#endif
-
 #if defined(__GNUC__) && __GNUC__ >= 3
 #define chpl_noreturn __attribute__((__noreturn__))
 #else

--- a/frontend/lib/immediates/make_prims/make_prims.cpp
+++ b/frontend/lib/immediates/make_prims/make_prims.cpp
@@ -181,7 +181,7 @@ main(int argc, char *argv[]) {
 
   if (argc < 1 || buf_read(argv[1], &buf, &len) < 0) {
     printf("unable to read file '%s'", argv[i]);
-    exit(-1);
+    return -1;
   }
   get_lines(buf, lines);
 

--- a/util/devel/lookForBadCompCalls
+++ b/util/devel/lookForBadCompCalls
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+
+"""Check Chapel compiler for 'inappropriate' function calls
+
+Check for exit routines (should call clean_exit instead).
+"""
+
+import os
+import sys
+import look_for_calls
+
+chplenv_dir = os.path.join(os.path.dirname(__file__), '..', 'chplenv')
+sys.path.insert(0, os.path.abspath(chplenv_dir))
+
+from chpl_home_utils import get_chpl_home
+
+
+def main():
+    """Check compiler for "bad function calls"""
+    chpl_home = get_chpl_home()
+    compiler_dir = os.path.join(chpl_home, 'compiler')
+    frontend_dir = os.path.join(chpl_home, 'frontend')
+
+    # Check runtime for exit calls
+    exit_exclude_paths = ['compiler/util/misc.cpp',
+                          'frontend/include/chpl/resolution/ResolvedVisitor.h',
+                          'frontend/include/chpl/uast/AstNode.h',
+                          'frontend/lib/parsing/flex-chpl-lib.cpp',
+                          'frontend/test/framework/testUniqueString.cpp',
+                          'frontend/test/resolution/testErrors.cpp',
+                          'frontend/test/resolution/testExternBlocks.cpp',
+                          'frontend/test/resolution/testInteractive.cpp'
+                         ]
+    exit_funcs = look_for_calls.get_exit_funcs()
+    found1 = look_for_calls.check_for_calls(exit_funcs,
+                                            compiler_dir,
+                                            exit_exclude_paths)
+    found2 = look_for_calls.check_for_calls(exit_funcs,
+                                            frontend_dir,
+                                            exit_exclude_paths)
+    return found1 or found2
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/util/devel/lookForBadCompCalls
+++ b/util/devel/lookForBadCompCalls
@@ -16,12 +16,12 @@ from chpl_home_utils import get_chpl_home
 
 
 def main():
-    """Check compiler for "bad function calls"""
+    """Check compiler for bad function calls"""
     chpl_home = get_chpl_home()
     compiler_dir = os.path.join(chpl_home, 'compiler')
     frontend_dir = os.path.join(chpl_home, 'frontend')
 
-    # Check runtime for exit calls
+    # Check compiler for exit calls
     exit_exclude_paths = ['compiler/util/misc.cpp',
                           'frontend/include/chpl/resolution/ResolvedVisitor.h',
                           'frontend/include/chpl/uast/AstNode.h',

--- a/util/devel/lookForBadCompCalls
+++ b/util/devel/lookForBadCompCalls
@@ -26,10 +26,8 @@ def main():
                           'frontend/include/chpl/resolution/ResolvedVisitor.h',
                           'frontend/include/chpl/uast/AstNode.h',
                           'frontend/lib/parsing/flex-chpl-lib.cpp',
-                          'frontend/test/framework/testUniqueString.cpp',
-                          'frontend/test/resolution/testErrors.cpp',
-                          'frontend/test/resolution/testExternBlocks.cpp',
-                          'frontend/test/resolution/testInteractive.cpp'
+                          # and frontend/test can use exit
+                          'frontend/test/',
                          ]
     exit_funcs = look_for_calls.get_exit_funcs()
     found1 = look_for_calls.check_for_calls(exit_funcs,


### PR DESCRIPTION
This PR replaces the `#define exit` in `compiler/include/misc.h` with a script that checks for calls to `exit` similarly to the way that `lookForBadRTCalls` already works.

The `#define exit` causes problems when using the LLVM Support Library with `CHPL_LLVM=none`. If `CHPL_LLVM=llvm` then the `#define exit` error was already disabled.

Reviewed by @ronawho - thanks!

- [x] full comm=none testing