### PR TITLE
expand prim string_length_bytes to non-param kinds

### DIFF
--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -73,7 +73,8 @@ static bool toParamIntActual(const QualifiedType& type, int64_t& into) {
   return false;
 }
 
-static bool paramStringBytesHelper(const QualifiedType& type, UniqueString& into, bool isString) {
+static bool paramStringBytesHelper(const QualifiedType& type,
+                                   UniqueString& into, bool isString) {
   if (type.kind() == QualifiedType::PARAM) {
     if (auto t = type.type()) {
       if ((t->isBytesType() && !isString) ||
@@ -830,20 +831,23 @@ CallResolutionResult resolvePrimCall(Context* context,
     case PRIM_STRING_CONCAT:
     case PRIM_STRING_LENGTH_BYTES:
     {
-      UniqueString sParam;
-      auto& actualType = ci.actual(0).type();
-      if (toParamStringActual(actualType, sParam)||
-          toParamBytesActual(actualType, sParam)) {
-        const size_t s = sParam.length();
-        type = QualifiedType(QualifiedType::PARAM,
-                      IntType::get(context, 0),
-                      IntParam::get(context, s));
-        break;
-      } else if (type.kind() != QualifiedType::PARAM) {
-        // error - cannot call PRIM_STRING_LENGTH_BYTES on something that isn't
-        // a param
-        type = CHPL_TYPE_ERROR(context, IncompatibleKinds, QualifiedType::Kind::PARAM,
-                               call, actualType);
+      if (ci.numActuals() > 0) {
+        UniqueString sParam;
+        auto& actualType = ci.actual(0).type();
+        if (toParamStringActual(actualType, sParam)||
+            toParamBytesActual(actualType, sParam)) {
+          const size_t s = sParam.length();
+          type = QualifiedType(QualifiedType::PARAM,
+                               IntType::get(context, 0),
+                               IntParam::get(context, s));
+          break;
+        } else if (actualType.type()->isStringType() ||
+                   actualType.type()->isBytesType()) {
+          // for non-param string/bytes, the return type is just a default int
+          type = QualifiedType(QualifiedType::CONST_VAR,
+                               IntType::get(context, 0));
+          break;
+        }
       }
     }
     case PRIM_STRING_LENGTH_CODEPOINTS:

--- a/frontend/test/resolution/testFunctionCalls.cpp
+++ b/frontend/test/resolution/testFunctionCalls.cpp
@@ -132,11 +132,46 @@ static void test3b() {
   helpTest3(theFunction);
 }
 
+// test that we can handle non-param string for string_length_bytes
+static void test4() {
+  Context ctx;
+  auto context = &ctx;
+  QualifiedType qt =  resolveTypeOfXInit(context,
+                         R""""(
+                           var s:string;
+                           var x = __primitive("string_length_bytes", s);
+                         )"""");
+  assert(qt.kind() == QualifiedType::CONST_VAR);
+  auto typePtr = qt.type();
+  assert(typePtr);
+  assert(typePtr->isIntType());
+  assert(typePtr->toIntType()->bitwidth() == 64);
+}
+
+// test that we can handle non-param bytes for string_length_bytes
+static void test5() {
+  Context ctx;
+  auto context = &ctx;
+  QualifiedType qt =  resolveTypeOfXInit(context,
+                         R""""(
+                           var b:bytes;
+                           var x = __primitive("string_length_bytes", b);
+                         )"""");
+  assert(qt.kind() == QualifiedType::CONST_VAR);
+  auto typePtr = qt.type();
+  assert(typePtr);
+  assert(typePtr->isIntType());
+  assert(typePtr->toIntType()->bitwidth() == 64);
+}
+
 
 int main() {
   test1();
   test2();
   test3a();
   test3b();
+  test4();
+  test5();
+
   return 0;
 }


### PR DESCRIPTION
This PR expands the resolution of the primitive `string_length_bytes` to also work for non-param string and bytes type arguments. This is needed to allow for some module code to resolve using Dyno.

 