### PR TITLE
Bundle of doc cleanups

### DIFF
--- a/doc/rst/meta/modules/standard.rst
+++ b/doc/rst/meta/modules/standard.rst
@@ -41,9 +41,9 @@ Diagnostics
    :maxdepth: 1
 
    CommDiagnostics <standard/CommDiagnostics>
+   Debugger <standard/Debugger>
    GpuDiagnostics <standard/GpuDiagnostics>
    MemDiagnostics <standard/MemDiagnostics>
-   Debugger <standard/Debugger>
 
 
 Files/IO

--- a/doc/rst/usingchapel/prereqs.rst
+++ b/doc/rst/usingchapel/prereqs.rst
@@ -44,7 +44,8 @@ for using Chapel:
     use the bundled LLVM or disable LLVM support (see
     :ref:`readme-chplenv.CHPL_LLVM`). LLVM 16 support is avaible with certain
     configurations. If LLVM 16 is the only system-wide install of LLVM, it will
-    be used by default. Otherwise you can opt-in to it explicitly by setting :ref:`readme-chplenv.CHPL_LLVM_CONFIG`.
+    be used by default. Otherwise you can opt-in to it explicitly by setting
+    :ref:`readme-chplenv.CHPL_LLVM_CONFIG`.
 
 In addition, several optional components have additional requirements:
 

--- a/doc/rst/usingchapel/prereqs.rst
+++ b/doc/rst/usingchapel/prereqs.rst
@@ -42,7 +42,9 @@ for using Chapel:
     are currently supported. If a system-wide installation of
     LLVM and clang with one of those versions is not available, you can
     use the bundled LLVM or disable LLVM support (see
-    :ref:`readme-chplenv.CHPL_LLVM`).
+    :ref:`readme-chplenv.CHPL_LLVM`). LLVM 16 support is avaible with certain
+    configurations. If LLVM 16 is the only system-wide install of LLVM, it will
+    be used by default. Otherwise you can opt-in to it explicitly by setting :ref:`readme-chplenv.CHPL_LLVM_CONFIG`.
 
 In addition, several optional components have additional requirements:
 


### PR DESCRIPTION
Bundle of 2 cleanups to the docs

- Fix alphabetization of the Diagnostics section for standard modules
- Add a note about LLVM 16 to the prerequisites section

Build docs locally

[Reviewed by @ShreyasKhandekar]