### PR TITLE
Bundle chapel-py and chplcheck in the release tarball.

### DIFF
--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -169,7 +169,9 @@ if (exists($ENV{"CHPL_GEN_RELEASE_NO_CLONE"})) {
     "tools/c2chapel",
     "tools/mason",
     "tools/protoc-gen-chpl",
-    "tools/unstableWarningAnonymizer/"
+    "tools/unstableWarningAnonymizer/",
+    "tools/chapel-py",
+    "tools/chplcheck"
 );
 
 


### PR DESCRIPTION
Thanks @bradcray for the catch!

This PR makes sure that `chapel-py` and `chplcheck` are are included in source tarballs of Chapel. 

## Testing

Built the release tarball with:

```
export CHPL_GEN_RELEASE_NO_CLONE
./util/buildRelease/gen_release   
```

Then, built `chplcheck` via the release as follows:

```
source ./util/setchplenv.bash
make chplcheck -j32
```

Running `chplcheck` produced the following:

```
> chplcheck --help
usage: chplcheck [-h] [--disable-rule DISABLED_RULES] [--enable-rule ENABLED_RULES] [--lsp]
                 [filenames ...]
```

Reviewed by @jabraham17 -- thanks!