### PR TITLE
Add remaining missing uast accessors to python bindings

### DIFF
--- a/tools/chapel-py/src/method-tables.h
+++ b/tools/chapel-py/src/method-tables.h
@@ -173,6 +173,13 @@ CLASS_BEGIN(Identifier)
                const AstNode*, return nodeOrNullFromToId(context, node))
 CLASS_END(Identifier)
 
+CLASS_BEGIN(Import)
+  PLAIN_GETTER(Import, name, "Get the visibility of this Import node",
+               const char*, return Decl::visibilityToString(node->visibility()))
+  PLAIN_GETTER(Import, visibility_clauses, "Get the visibility clauses of this Import node",
+               IterAdapterBase*, return mkIterPair(node->visibilityClauses()))
+CLASS_END(Import)
+
 CLASS_BEGIN(Init)
   PLAIN_GETTER(Init, target, "Get the target of this Init node",
                const AstNode*, return node->target())

--- a/tools/chapel-py/src/method-tables.h
+++ b/tools/chapel-py/src/method-tables.h
@@ -480,6 +480,11 @@ CLASS_BEGIN(TupleDecl)
                const AstNode*, return node->initExpression())
 CLASS_END(TupleDecl)
 
+CLASS_BEGIN(ForwardingDecl)
+  PLAIN_GETTER(ForwardingDecl, expr, "Get the expression of this ForwardingDecl node",
+               const AstNode*, return node->expr())
+CLASS_END(ForwardingDecl)
+
 CLASS_BEGIN(START_NamedDecl)
   PLAIN_GETTER(NamedDecl, name, "Get the name of this NamedDecl node",
                UniqueString, return node->name())

--- a/tools/chapel-py/src/method-tables.h
+++ b/tools/chapel-py/src/method-tables.h
@@ -188,6 +188,17 @@ CLASS_BEGIN(FunctionSignature)
                bool, return node->throws())
 CLASS_END(FunctionSignature)
 
+CLASS_BEGIN(Implements)
+  PLAIN_GETTER(Implements, interface_name, "Get the interface name of this Implements node",
+               UniqueString, return node->interfaceName())
+  PLAIN_GETTER(Implements, type_ident, "Get the type identifier from this Implements node",
+               const Identifier*, return node->typeIdent())
+  PLAIN_GETTER(Implements, interface_expr, "Get the interface expression from this Implements node",
+               const AstNode*, return node->interfaceExpr())
+  PLAIN_GETTER(Implements, is_expression_level, "Check if this Implements node is expression level",
+               bool, return node->isExpressionLevel())
+CLASS_END(Implements)
+
 CLASS_BEGIN(Identifier)
   PLAIN_GETTER(Identifier, name, "Get the name of this Identifier node",
                UniqueString, return node->name())
@@ -460,6 +471,15 @@ CLASS_BEGIN(Function)
   PLAIN_GETTER(Function, where_clause, "Get the where clause for this Function node",
                const AstNode*, return node->whereClause())
 CLASS_END(Function)
+
+CLASS_BEGIN(Interface)
+  PLAIN_GETTER(Interface, stmts, "Get the statements for this Interface node",
+               IterAdapterBase*, return mkIterPair(node->stmts()))
+  PLAIN_GETTER(Interface, formals, "Get the formals for this Interface node",
+               IterAdapterBase*, return mkIterPair(node->formals()))
+  PLAIN_GETTER(Interface, is_formal_list_explicit, "Check if this Interface node has an explicit formal list",
+               bool, return node->isFormalListExplicit())
+CLASS_END(Interface)
 
 CLASS_BEGIN(Module)
   PLAIN_GETTER(Module, kind, "Get the kind of this Module node",

--- a/tools/chapel-py/src/method-tables.h
+++ b/tools/chapel-py/src/method-tables.h
@@ -553,17 +553,14 @@ CLASS_BEGIN(START_VarLikeDecl)
                const char*, return qualifierToString(node->storageKind()))
   PLAIN_GETTER(VarLikeDecl, type_expression, "Get the type expression of this VarLikeDecl node",
                const AstNode*, return node->typeExpression())
+  PLAIN_GETTER(VarLikeDecl, intent, "Get the intent for this VarLikeDecl node",
+               const char*, return intentToString(node->intent()))
 CLASS_END(START_VarLikeDecl)
 
-CLASS_BEGIN(Formal)
-  PLAIN_GETTER(Formal, intent, "Get the intent for this Formal node",
-               const char*, return intentToString(node->intent()))
-CLASS_END(Formal)
-
-CLASS_BEGIN(TaskVar)
-  PLAIN_GETTER(TaskVar, intent, "Get the intent of this TaskVar node",
-               const char*, return intentToString(node->intent()))
-CLASS_END(TaskVar)
+CLASS_BEGIN(VarArgFormal)
+  PLAIN_GETTER(VarArgFormal, count, "Get the count expression of this VarArgFormal node",
+               const AstNode*, return node->count())
+CLASS_END(VarArgFormal)
 
 CLASS_BEGIN(Variable)
   PLAIN_GETTER(Variable, is_config, "Check if this Variable node is a config variable",

--- a/tools/chapel-py/src/method-tables.h
+++ b/tools/chapel-py/src/method-tables.h
@@ -171,6 +171,11 @@ CLASS_BEGIN(Dot)
                const AstNode*, return node->receiver())
 CLASS_END(Dot)
 
+CLASS_BEGIN(ExternBlock)
+  PLAIN_GETTER(ExternBlock, code, "Get C code of this ExternBlock node",
+               std::string, return node->code())
+CLASS_END(ExternBlock)
+
 CLASS_BEGIN(FunctionSignature)
   PLAIN_GETTER(FunctionSignature, formals, "Get the formals for this FunctionSignature node",
                IterAdapterBase*, return mkIterPair(node->formals()))

--- a/tools/chapel-py/src/method-tables.h
+++ b/tools/chapel-py/src/method-tables.h
@@ -117,16 +117,16 @@ CLASS_END(Break)
 
 CLASS_BEGIN(Catch)
   PLAIN_GETTER(Catch, target, "Get the error from this Catch node",
-               const Variable*, return node->error())
+               const AstNode*, return node->error())
   PLAIN_GETTER(Catch, body, "Get the body from this Catch node",
-               const Block*, return node->body())
+               const AstNode*, return node->body())
   PLAIN_GETTER(Catch, has_parens_around_error, "Check if this Catch uses parentheses",
                bool, return node->hasParensAroundError())
 CLASS_END(Catch)
 
 CLASS_BEGIN(Cobegin)
   PLAIN_GETTER(Cobegin, with_clause, "Get the error from this Cobegin node",
-               const WithClause*, return node->withClause())
+               const AstNode*, return node->withClause())
   PLAIN_GETTER(Cobegin, task_bodies, "Get the error from this Cobegin node",
                IterAdapterBase*, return mkIterPair(node->taskBodies()))
 CLASS_END(Cobegin)
@@ -192,7 +192,7 @@ CLASS_BEGIN(Implements)
   PLAIN_GETTER(Implements, interface_name, "Get the interface name of this Implements node",
                UniqueString, return node->interfaceName())
   PLAIN_GETTER(Implements, type_ident, "Get the type identifier from this Implements node",
-               const Identifier*, return node->typeIdent())
+               const AstNode*, return node->typeIdent())
   PLAIN_GETTER(Implements, interface_expr, "Get the interface expression from this Implements node",
                const AstNode*, return node->interfaceExpr())
   PLAIN_GETTER(Implements, is_expression_level, "Check if this Implements node is expression level",
@@ -267,7 +267,7 @@ CLASS_END(Throw)
 
 CLASS_BEGIN(Try)
   PLAIN_GETTER(Try, body, "Get the body of this Try node",
-               const Block*, return node->body())
+               const AstNode*, return node->body())
   PLAIN_GETTER(Try, handlers, "Get the Catch node handlers of this Try node",
                IterAdapterBase*, return mkIterPair(node->handlers()))
   PLAIN_GETTER(Try, is_expression_level, "Check if this Try node is expression level",

--- a/tools/chapel-py/src/method-tables.h
+++ b/tools/chapel-py/src/method-tables.h
@@ -260,6 +260,13 @@ CLASS_BEGIN(Return)
                const AstNode*, return node->value())
 CLASS_END(Return)
 
+CLASS_BEGIN(Select)
+  PLAIN_GETTER(Select, exprs, "Get the expression of this Select node",
+               const AstNode*, return node->expr())
+  PLAIN_GETTER(Select, when_stmts, "Get the When statements of this Select node",
+               IterAdapterBase*, return mkIterPair(node->whenStmts()))
+CLASS_END(Select)
+
 CLASS_BEGIN(Throw)
   PLAIN_GETTER(Throw, error_expression, "Get the expression thrown by this Throw node",
                const AstNode*, return node->errorExpression())
@@ -322,6 +329,17 @@ CLASS_BEGIN(Serial)
   PLAIN_GETTER(Serial, condition, "Get the condition of this Serial node",
                const AstNode*, return node->condition())
 CLASS_END(Serial)
+
+CLASS_BEGIN(When)
+  PLAIN_GETTER(When, block_style, "Get the block style of this When node",
+               const char*, return blockStyleToString(node->blockStyle()))
+  PLAIN_GETTER(When, body, "Get the body of this When node",
+               const AstNode*, return node->body())
+  PLAIN_GETTER(When, case_exprs, "Get the case expressions of this When node",
+               IterAdapterBase*, return mkIterPair(node->caseExprs()))
+  PLAIN_GETTER(When, is_otherwise, "Check if this When node uses the otherwise keyword",
+               bool, return node->isOtherwise())
+CLASS_END(When)
 
 CLASS_BEGIN(START_Loop)
   PLAIN_GETTER(Loop, block_style, "Get the block style of this Loop node",

--- a/tools/chapel-py/src/method-tables.h
+++ b/tools/chapel-py/src/method-tables.h
@@ -187,7 +187,7 @@ CLASS_BEGIN(Import)
 CLASS_END(Import)
 
 CLASS_BEGIN(Include)
-  PLAIN_GETTER(Include, name, "Get the visibility of this Include node",
+  PLAIN_GETTER(Include, name, "Get the name of this Include node",
                const char*, return node->name())
   PLAIN_GETTER(Include, is_prototype, "Check if this Include node is for a prototype module",
                bool, return node->isPrototype())

--- a/tools/chapel-py/src/method-tables.h
+++ b/tools/chapel-py/src/method-tables.h
@@ -559,7 +559,7 @@ CLASS_BEGIN(START_VarLikeDecl)
   PLAIN_GETTER(VarLikeDecl, type_expression, "Get the type expression of this VarLikeDecl node",
                const AstNode*, return node->typeExpression())
   PLAIN_GETTER(VarLikeDecl, intent, "Get the intent for this VarLikeDecl node",
-               const char*, return intentToString(node->intent()))
+               const char*, return intentToString(node->storageKind()))
 CLASS_END(START_VarLikeDecl)
 
 CLASS_BEGIN(VarArgFormal)

--- a/tools/chapel-py/src/method-tables.h
+++ b/tools/chapel-py/src/method-tables.h
@@ -441,6 +441,11 @@ CLASS_BEGIN(OpCall)
                UniqueString, return node->op())
 CLASS_END(OpCall)
 
+CLASS_BEGIN(PrimCall)
+  PLAIN_GETTER(PrimCall, prim, "Get the primitive name for this PrimCall node",
+               const char*, return chpl::uast::primtags::primTagToName(node->prim()))
+CLASS_END(PrimCall)
+
 CLASS_BEGIN(Reduce)
   PLAIN_GETTER(Reduce, iterand, "Get the iterand for this Reduce node",
                const AstNode*, return node->iterand())

--- a/tools/chapel-py/src/method-tables.h
+++ b/tools/chapel-py/src/method-tables.h
@@ -180,7 +180,7 @@ CLASS_BEGIN(Identifier)
 CLASS_END(Identifier)
 
 CLASS_BEGIN(Import)
-  PLAIN_GETTER(Import, name, "Get the visibility of this Import node",
+  PLAIN_GETTER(Import, visibility, "Get the visibility of this Import node",
                const char*, return Decl::visibilityToString(node->visibility()))
   PLAIN_GETTER(Import, visibility_clauses, "Get the visibility clauses of this Import node",
                IterAdapterBase*, return mkIterPair(node->visibilityClauses()))
@@ -235,7 +235,7 @@ CLASS_END(Throw)
 
 
 CLASS_BEGIN(Use)
-  PLAIN_GETTER(Use, name, "Get the visibility of this Use node",
+  PLAIN_GETTER(Use, visibility, "Get the visibility of this Use node",
                const char*, return Decl::visibilityToString(node->visibility()))
   PLAIN_GETTER(Use, visibility_clauses, "Get the visibility clauses of this Use node",
                IterAdapterBase*, return mkIterPair(node->visibilityClauses()))

--- a/tools/chapel-py/src/method-tables.h
+++ b/tools/chapel-py/src/method-tables.h
@@ -250,6 +250,11 @@ CLASS_BEGIN(Range)
                const AstNode*, return node->upperBound())
 CLASS_END(Range)
 
+CLASS_BEGIN(Require)
+  PLAIN_GETTER(Require, exprs, "Get the expressions of this Require node",
+               IterAdapterBase*, return mkIterPair(node->exprs()))
+CLASS_END(Require)
+
 CLASS_BEGIN(Return)
   PLAIN_GETTER(Return, value, "Get the expression returned by this Return node",
                const AstNode*, return node->value())
@@ -260,6 +265,16 @@ CLASS_BEGIN(Throw)
                const AstNode*, return node->errorExpression())
 CLASS_END(Throw)
 
+CLASS_BEGIN(Try)
+  PLAIN_GETTER(Try, body, "Get the body of this Try node",
+               const Block*, return node->body())
+  PLAIN_GETTER(Try, handlers, "Get the Catch node handlers of this Try node",
+               IterAdapterBase*, return mkIterPair(node->handlers()))
+  PLAIN_GETTER(Try, is_expression_level, "Check if this Try node is expression level",
+               bool, return node->isExpressionLevel())
+  PLAIN_GETTER(Try, is_try_bang, "Check if this Try node is a 'try!'",
+               bool, return node->isTryBang())
+CLASS_END(Try)
 
 CLASS_BEGIN(Use)
   PLAIN_GETTER(Use, visibility, "Get the visibility of this Use node",

--- a/tools/chapel-py/src/method-tables.h
+++ b/tools/chapel-py/src/method-tables.h
@@ -438,6 +438,13 @@ CLASS_BEGIN(Reduce)
                const AstNode*, return node->op())
 CLASS_END(Reduce)
 
+CLASS_BEGIN(Scan)
+  PLAIN_GETTER(Scan, iterand, "Get the iterand for this Scan node",
+               const AstNode*, return node->iterand())
+  PLAIN_GETTER(Scan, op, "Get the op for this Scan node",
+               const AstNode*, return node->op())
+CLASS_END(Scan)
+
 CLASS_BEGIN(START_Decl)
   PLAIN_GETTER(Decl, linkage, "Get the linkage of this Decl node",
                const char*, return Decl::linkageToString(node->linkage()))

--- a/tools/chapel-py/src/method-tables.h
+++ b/tools/chapel-py/src/method-tables.h
@@ -186,6 +186,15 @@ CLASS_BEGIN(Import)
                IterAdapterBase*, return mkIterPair(node->visibilityClauses()))
 CLASS_END(Import)
 
+CLASS_BEGIN(Include)
+  PLAIN_GETTER(Include, name, "Get the visibility of this Include node",
+               const char*, return node->name())
+  PLAIN_GETTER(Include, is_prototype, "Check if this Include node is for a prototype module",
+               bool, return node->isPrototype())
+  PLAIN_GETTER(Include, visibility, "Get the visibility of this Include node",
+               const char*, return Decl::visibilityToString(node->visibility()))
+CLASS_END(Include)
+
 CLASS_BEGIN(Init)
   PLAIN_GETTER(Init, target, "Get the target of this Init node",
                const AstNode*, return node->target())

--- a/tools/chapel-py/src/method-tables.h
+++ b/tools/chapel-py/src/method-tables.h
@@ -83,6 +83,12 @@ CLASS_BEGIN(AnonFormal)
                const AstNode*, return node->typeExpression())
 CLASS_END(AnonFormal)
 
+CLASS_BEGIN(As)
+  PLAIN_GETTER(As, symbol, "Get the symbol for this As node",
+               const AstNode*, return node->symbol())
+  PLAIN_GETTER(As, rename, "Get the rename for this As node",
+               const AstNode*, return node->rename())
+CLASS_END(As)
 
 CLASS_BEGIN(Array)
   PLAIN_GETTER(Array, exprs, "Get the expressions from this Array node",
@@ -217,6 +223,14 @@ CLASS_BEGIN(Throw)
   PLAIN_GETTER(Throw, error_expression, "Get the expression thrown by this Throw node",
                const AstNode*, return node->errorExpression())
 CLASS_END(Throw)
+
+
+CLASS_BEGIN(Use)
+  PLAIN_GETTER(Use, name, "Get the visibility of this Use node",
+               const char*, return Decl::visibilityToString(node->visibility()))
+  PLAIN_GETTER(Use, visibility_clauses, "Get the visibility clauses of this Use node",
+               IterAdapterBase*, return mkIterPair(node->visibilityClauses()))
+CLASS_END(Use)
 
 CLASS_BEGIN(VisibilityClause)
   PLAIN_GETTER(VisibilityClause, symbol, "Get the symbol referenced by this VisibilityClause node",

--- a/tools/chapel-py/src/method-tables.h
+++ b/tools/chapel-py/src/method-tables.h
@@ -125,9 +125,9 @@ CLASS_BEGIN(Catch)
 CLASS_END(Catch)
 
 CLASS_BEGIN(Cobegin)
-  PLAIN_GETTER(Cobegin, with_clause, "Get the error from this Cobegin node",
+  PLAIN_GETTER(Cobegin, with_clause, "Get the WithClause from this Cobegin node",
                const AstNode*, return node->withClause())
-  PLAIN_GETTER(Cobegin, task_bodies, "Get the error from this Cobegin node",
+  PLAIN_GETTER(Cobegin, task_bodies, "Get tasks from this Cobegin node",
                IterAdapterBase*, return mkIterPair(node->taskBodies()))
 CLASS_END(Cobegin)
 
@@ -136,7 +136,7 @@ CLASS_BEGIN(Conditional)
                const AstNode*, return node->condition())
   PLAIN_GETTER(Conditional, else_block, "Get the else block of this Conditional node or None if no else block",
                const AstNode*, return node->elseBlock())
-  PLAIN_GETTER(Conditional, is_expression_level, "Checks if this Conditional node is expression level",
+  PLAIN_GETTER(Conditional, is_expression_level, "Checks if this Conditional node is expression-level",
                bool, return node->isExpressionLevel())
   PLAIN_GETTER(Conditional, then_block, "Get the then block of this Conditional node",
                const AstNode*, return node->thenBlock())

--- a/tools/chapel-py/src/method-tables.h
+++ b/tools/chapel-py/src/method-tables.h
@@ -188,7 +188,7 @@ CLASS_END(Import)
 
 CLASS_BEGIN(Include)
   PLAIN_GETTER(Include, name, "Get the name of this Include node",
-               const char*, return node->name())
+               UniqueString, return node->name())
   PLAIN_GETTER(Include, is_prototype, "Check if this Include node is for a prototype module",
                bool, return node->isPrototype())
   PLAIN_GETTER(Include, visibility, "Get the visibility of this Include node",

--- a/tools/chapel-py/src/method-tables.h
+++ b/tools/chapel-py/src/method-tables.h
@@ -115,6 +115,22 @@ CLASS_BEGIN(Break)
                const AstNode*, return node->target())
 CLASS_END(Break)
 
+CLASS_BEGIN(Catch)
+  PLAIN_GETTER(Catch, target, "Get the error from this Catch node",
+               const Variable*, return node->error())
+  PLAIN_GETTER(Catch, body, "Get the body from this Catch node",
+               const Block*, return node->body())
+  PLAIN_GETTER(Catch, has_parens_around_error, "Check if this Catch uses parentheses",
+               bool, return node->hasParensAroundError())
+CLASS_END(Catch)
+
+CLASS_BEGIN(Cobegin)
+  PLAIN_GETTER(Cobegin, with_clause, "Get the error from this Cobegin node",
+               const WithClause*, return node->withClause())
+  PLAIN_GETTER(Cobegin, task_bodies, "Get the error from this Cobegin node",
+               IterAdapterBase*, return mkIterPair(node->taskBodies()))
+CLASS_END(Cobegin)
+
 CLASS_BEGIN(Conditional)
   PLAIN_GETTER(Conditional, condition, "Get the condition of this Conditional node",
                const AstNode*, return node->condition())

--- a/tools/chapel-py/src/method-tables.h
+++ b/tools/chapel-py/src/method-tables.h
@@ -325,6 +325,11 @@ CLASS_BEGIN(Local)
                const AstNode*, return node->condition())
 CLASS_END(Local)
 
+CLASS_BEGIN(Manage)
+  PLAIN_GETTER(Manage, managers, "Get the managers of this Manage node",
+               IterAdapterBase*, return mkIterPair(node->managers()))
+CLASS_END(Manage)
+
 CLASS_BEGIN(On)
   PLAIN_GETTER(On, destination, "Get the destination of this On node",
                const AstNode*, return node->destination())


### PR DESCRIPTION
Adds the remaining uast accesor methods to the frontend python bindings, chapel-py.

List of classes added:
- Import
- Use
- As
- Include
- Require
- Interface
- Implements
- Try
- Catch
- Cobegin
- Select
- When
- Scan
- ExternBlock
- PrimCall
- Manage
- VarArgFormal
- ForwardingDecl


[Reviewed by @DanilaFe]

closes https://github.com/Cray/chapel-private/issues/5622