### PR TITLE
Update Sort comparison tests

### DIFF
--- a/test/library/packages/Sort/performance/comparison/chapel-quicksort-random.chpl
+++ b/test/library/packages/Sort/performance/comparison/chapel-quicksort-random.chpl
@@ -1,6 +1,7 @@
 // chpl --fast chapel-quicksort-random.chpl
 
 use Sort;
+use QuickSort;
 use Time;
 use Random;
 

--- a/test/library/packages/Sort/performance/comparison/numpy-sort-random.py
+++ b/test/library/packages/Sort/performance/comparison/numpy-sort-random.py
@@ -2,15 +2,15 @@ import numpy
 import random
 import time
 
-#n = 1024*1024*16 # for 128MiB
-n = 1024*1024*128 # for 1GiB
+#n = 1024*1024*16 # for 16MiB
+n = 1024*1024*128 # for 128MiB
 
 # Note, this actually never generates the maximal element... oh well.
 array = numpy.random.randint(0, 0xffffffffffffffff, size=n, dtype=numpy.uint64)
 
-start = time.clock()
+start = time.time()
 array.sort()
-stop = time.clock()
+stop = time.time()
 
 print ("Sorted ", n, " elements in ", stop-start, " seconds")
 print (((8*n) / (stop-start))/1024.0/1024.0, " MiB/s")

--- a/test/library/packages/Sort/performance/comparison/python-sort-random.py
+++ b/test/library/packages/Sort/performance/comparison/python-sort-random.py
@@ -1,13 +1,13 @@
 import random
 import time
 
-#n = 1024*1024*16 # for 128MiB
-n = 1024*1024*128 # for 1GiB
+#n = 1024*1024*16 # for 16MiB
+n = 1024*1024*128 # for 128MiB
 
 array = [random.randint(0, 0xffffffffffffffff) for _ in range(n)]
-start = time.clock()
+start = time.time()
 array.sort()
-stop = time.clock()
+stop = time.time()
 
 print ("Sorted ", n, " elements in ", stop-start, " seconds")
 print (((8*n) / (stop-start))/1024.0/1024.0, " MiB/s")


### PR DESCRIPTION
These tests are not run in any testing config & only run manually.

This PR updates a few tests to fix incorrect comments, handle Python 3 deprecation of `time.clock()`, and handle Chapel changes.

Test change only -- not reviewed.