### PR TITLE
Fix unknown `-Wno-cast-function-type-strict`

### DIFF
--- a/make/compiler/Makefile.clang
+++ b/make/compiler/Makefile.clang
@@ -180,7 +180,7 @@ CHPL_GASNET_MORE_CFLAGS = -Wno-strict-prototypes -Wno-missing-prototypes -Wno-un
 
 # only use -Wno-cast-function-type-strict when clang version is 16 or greater
 CLANG_VER := $(shell echo __clang_major__ | $(CXX) -E -x c++ - | sed -e '/^\#/d' -e 's/L$$//')
-CHPL_GASNET_MORE_CFLAGS += $(shell test $(DEF_CXX_VER) -gt 15 && echo -Wno-cast-function-type-strict)
+CHPL_GASNET_MORE_CFLAGS += $(shell test $(CLANG_VER) -gt 15 && echo -Wno-cast-function-type-strict)
 
 endif
 


### PR DESCRIPTION
Fixes a typo in a version check that caused CHPL_DEVELOPER=1 builds to fail with clang compilers prior to version 16

## Testing
- Building Chapel with COMM=gasnet and CHPL_DEVELOPER=1
  - [x] clang 14
  - [x] clang 15
  - [x] clang 16

[Reviewed by @mppf]

resolves #24045