### PR TITLE
Remove find_package(Clang) from frontend linter CMakeLists.txt

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -82,7 +82,7 @@ jobs:
         make DYNO_ENABLE_ASSERTIONS=1 test-dyno -j`util/buildRelease/chpl-make-cpu_count`
     - name: run dyno linters
       run: |
-        CHPL_HOME=$PWD CHPL_HOST_COMPILER=clang make run-dyno-linters
+        CHPL_HOME=$PWD CHPL_HOST_CC=clang-13 CHPL_HOST_CXX=clang++-13 make run-dyno-linters
 
   make_check_llvm_none:
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -82,7 +82,7 @@ jobs:
         make DYNO_ENABLE_ASSERTIONS=1 test-dyno -j`util/buildRelease/chpl-make-cpu_count`
     - name: run dyno linters
       run: |
-        CHPL_HOME=$PWD make run-dyno-linters
+        CHPL_HOME=$PWD CHPL_HOST_COMPILER=clang make run-dyno-linters
 
   make_check_llvm_none:
     runs-on: ubuntu-latest

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -192,7 +192,11 @@ frontend-linters: FORCE $(CHPL_CONFIG_CHECK) $(COMPILER_BUILD)
 
 run-frontend-linters: frontend-linters
 	@echo "Running the frontend linters"
-	@env PATH=$(COMPILER_BUILD)/frontend/util/linters:$(PATH) $(CHPL_MAKE_HOME)/frontend/util/lint --compile-commands $(COMPILER_BUILD) --jobs=-1
+	@if [ "$(CHPL_MAKE_HOST_COMPILER)" != "clang" ]; then \
+	  echo error: run-frontend-linters requires CHPL_HOST_COMPILER=clang ; \
+	  exit 1 ; \
+	fi
+	env PATH=$(COMPILER_BUILD)/frontend/util/linters:$(PATH) $(CHPL_MAKE_HOME)/frontend/util/lint --compile-commands $(COMPILER_BUILD) --jobs=-1
 
 parser: FORCE $(CHPL_CONFIG_CHECK) $(COMPILER_BUILD)
 	cd $(COMPILER_BUILD) && $(CMAKE) $(CHPL_MAKE_HOME) $(CMAKE_FLAGS) && $(MAKE) parser

--- a/frontend/util/linters/CMakeLists.txt
+++ b/frontend/util/linters/CMakeLists.txt
@@ -20,30 +20,6 @@ add_executable(fieldsUsed "fieldsUsed.cpp")
 # store it in the build directory
 set_target_properties(fieldsUsed  PROPERTIES RUNTIME_OUTPUT_DIRECTORY . )
 
-# This option is set from the call to CMake from compiler/dyno/Makefile.help
-# TODO: use DYNO_LLVM_COMP_ARGS DYNO_LLVM_LINK_ARGS instead since
-# these should include clang arguments for CHPL_LLVM=system / CHPL_LLVM=bundled.
-# TODO: Should this be a PATH type rather than a STRING?
-set(DYNO_LINTERS_CLANG_CMAKE_PATH CACHE STRING "Override the path to find a ClangConfig.cmake")
-
-if(DYNO_LINTERS_CLANG_CMAKE_PATH)
-  # this finds the target clang-cpp and also finds an appropriate LLVM version
-  # Not marked as required since this linter is optional
-  find_package(Clang PATHS ${DYNO_LINTERS_CLANG_CMAKE_PATH} NO_DEFAULT_PATH)
-elseif(NOT ${CHPL_LLVM_CLANG_C} STREQUAL "")
-  # message(DEBUG "Looking for ClangConfig.cmake in ${CHPL_LLVM_CLANG_C}/../lib/cmake/clang")
-  # TODO: this is a hack to get the path for the ClangConfig.cmake file
-  string(LENGTH "${CHPL_LLVM_CLANG_C}" CLANG_C_LENGTH)
-  # we expect this path to end with "clang", so remove that and use the rest
-  math(EXPR CLANG_C_TRIM_LENGTH "${CLANG_C_LENGTH} - 5")
-  string(SUBSTRING "${CHPL_LLVM_CLANG_C}" 0 ${CLANG_C_TRIM_LENGTH} CLANG_C_DIR)
-  find_package(Clang PATHS ${CLANG_C_DIR}/../lib/cmake/clang NO_DEFAULT_PATH)
-else()
-  find_package(Clang)
-endif()
-
-message(STATUS "Using libclang from ${Clang_DIR}")
-
 target_link_libraries(fieldsUsed clang-cpp ${CHPL_LLVM_LINK_ARGS})
 # TODO: Why is this needed when it was not needed before?
 target_compile_options(fieldsUsed PRIVATE SHELL:$<$<COMPILE_LANGUAGE:CXX>:${CHPL_LLVM_COMP_ARGS}>)


### PR DESCRIPTION
Resolves #22551

While testing #24019, I added portability testing for Alpine 3.19 and I noticed a problem with the `find_package(Clang)` command supporting the frontend linter, so I investigated.

The frontend linter is not normally built at all (its main use is as a CI check) but because of the way it was using `find_package`, it occasionally introduced portability problems. However, it turns out that the `find_package` command is completely unnecessary and the tool was already finding clang headers and libraries through other cmake variables. So, this PR simply removes the `find_package` command.

Additionally, it adds some checking to give a more straightforward error in the case that the frontend linter is run with `CHPL_HOST_COMPILER=gnu` (or any compiler other than `clang`). In that event, it was trying to pass GCC flags to clang, which caused errors.

Reviewed by @arezaii - thanks!

- [x] full comm=none testing