### PR TITLE
Add alpine 3.19 to portability testing

### DIFF
--- a/doc/rst/usingchapel/prereqs.rst
+++ b/doc/rst/usingchapel/prereqs.rst
@@ -94,10 +94,11 @@ We have used the following commands to install the above prerequisites:
       sudo apk add llvm-dev clang-dev clang-static llvm-static
 
 
-  * Alpine 3.18::
+  * Alpine 3.18, 3.19 (but note `Alpine 3.19 LLVM build issue`_)::
 
       sudo apk add gcc g++ m4 perl python3 python3-dev bash make gawk git cmake
       sudo apk add llvm15-dev clang15-dev llvm15-static clang15-static
+
 
   * Amazon Linux 2::
 
@@ -210,8 +211,16 @@ We have used the following commands to install the above prerequisites:
       sudo apt-get install llvm-dev llvm clang libclang-dev libclang-cpp-dev libedit-dev
 
 
+
 Compatability Notes
 -------------------
+
+Alpine 3.19 LLVM build issue
+++++++++++++++++++++++++++++
+
+We have observed problems building the bundled LLVM support library on
+Alpine 3.19. These problems can be resolved by installing a compatible
+LLVM package.
 
 CentOS 7 CHPL_LLVM=system incompatability
 +++++++++++++++++++++++++++++++++++++++++

--- a/util/devel/test/apptainer/current/alpine-3.18-nollvm/image.def
+++ b/util/devel/test/apptainer/current/alpine-3.18-nollvm/image.def
@@ -1,5 +1,5 @@
 BootStrap: docker
-From: alpine:3.17
+From: alpine:3.18
 
 %files
     ../../provision-scripts/* /provision-scripts/

--- a/util/devel/test/apptainer/current/alpine-3.19-nollvm/image.def
+++ b/util/devel/test/apptainer/current/alpine-3.19-nollvm/image.def
@@ -1,0 +1,11 @@
+BootStrap: docker
+From: alpine:3.19
+
+%files
+    ../../provision-scripts/* /provision-scripts/
+
+%post
+    /provision-scripts/apk-deps.sh
+
+%runscript
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/alpine-3.19/image.def
+++ b/util/devel/test/apptainer/current/alpine-3.19/image.def
@@ -6,7 +6,7 @@ From: alpine:3.19
 
 %post
     /provision-scripts/apk-deps.sh
-    # default llvm/clang version is 17
+    # For Alpine 3.19, default llvm/clang version is 17
     /provision-scripts/apk-llvm15.sh
 
 %runscript

--- a/util/devel/test/apptainer/current/alpine-3.19/image.def
+++ b/util/devel/test/apptainer/current/alpine-3.19/image.def
@@ -1,0 +1,13 @@
+BootStrap: docker
+From: alpine:3.19
+
+%files
+    ../../provision-scripts/* /provision-scripts/
+
+%post
+    /provision-scripts/apk-deps.sh
+    # default llvm/clang version is 17
+    /provision-scripts/apk-llvm15.sh
+
+%runscript
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/vagrant/README-distro-timelines.txt
+++ b/util/devel/test/vagrant/README-distro-timelines.txt
@@ -17,6 +17,7 @@ x 3.15  EOL 2023-11-01
   3.16  EOL 2024-05-23
   3.17  EOL 2024-11-22
   3.18  EOL 2025-05-09
+  3.19  EOL 2025-11-01
 
 Amazon Linux
        -- see https://docs.aws.amazon.com/linux/al2022/ug/release-cadence.html


### PR DESCRIPTION
This PR adds apptainer testing for Alpine 3.19 which was recently released. Alpine 3.19 with a system install of LLVM should work OK after PRs #24019 and #24059. However, I observed problems building the LLVM Support library if no system LLVM is present. The error looked like this for me:

```
[  0%] Building CXX object lib/Support/CMakeFiles/LLVMSupport.dir/raw_ostream.cpp.o
/home/mppf/w/vagrant/util/devel/test/apptainer/current/alpine-3.19-nollvm/chapel/third-party/llvm/llvm-src/lib/Support/raw_ostream.cpp: In member function 'uint64_t llvm::raw_fd_ostream::seek(uint64_t)':
/home/mppf/w/vagrant/util/devel/test/apptainer/current/alpine-3.19-nollvm/chapel/third-party/llvm/llvm-src/lib/Support/raw_ostream.cpp:808:11: error: '::lseek6' has not been declared; did you mean 'lseek'?
  808 |   pos = ::lseek64(FD, off, SEEK_SET);
      |           ^~~~~~~
      |           lseek

```

This issue might well have been already resolved in newer LLVM versions. Alpine 3.19 includes packages for LLVM 17, so I would expect that this is either fixed in LLVM 17 or is an issue known to the Alpine LLVM package maintainers.

This PR also updates prereqs.rst to include the commands to install the prerequisites on Alpine 3.19 as well as a compatibility note.

Reviewed by @riftEmber - thanks!