### PR TITLE
Fix `sed` calls in `chplcheck` scripts on test machines, and other fixes to our tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ comprt: FORCE
 	@$(MAKE) third-party-try-opt
 	@$(MAKE) always-build-test-venv
 	@$(MAKE) always-build-chpldoc
+	@$(MAKE) always-build-chplcheck
 	@$(MAKE) runtime
 	@$(MAKE) modules
 
@@ -153,6 +154,11 @@ always-build-test-venv: FORCE
 always-build-chpldoc: FORCE
 	-@if [ -n "$$CHPL_ALWAYS_BUILD_CHPLDOC" ]; then \
 	$(MAKE) chpldoc; \
+	fi
+
+always-build-chplcheck: FORCE
+	-@if [ -n "$$CHPL_ALWAYS_BUILD_CHPLCHECK" ]; then \
+	$(MAKE) chplcheck; \
 	fi
 
 chplvis: compiler third-party-fltk FORCE

--- a/test/chplcheck/CaseRules.chpl
+++ b/test/chplcheck/CaseRules.chpl
@@ -61,6 +61,8 @@ module CaseRules {
   }
 
   record testRecord {
-    proc init=(other: testRecord) {}
+    proc init=(other: testRecord) {
+      var temp = other;
+    }
   }
 }

--- a/test/chplcheck/CaseRules.chpl
+++ b/test/chplcheck/CaseRules.chpl
@@ -54,5 +54,9 @@ module CaseRules {
   var justOneCapitalLetterAtTheE: string;
   const justO: real;
 
-  operator +(a: int, b: string) {}
+  operator +(a: int, b: string) {
+    // assign the variables to a temporary to make them not unused anymore.
+    var temp1 = a,
+        temp2 = b;
+  }
 }

--- a/test/chplcheck/CaseRules.chpl
+++ b/test/chplcheck/CaseRules.chpl
@@ -59,4 +59,8 @@ module CaseRules {
     var temp1 = a,
         temp2 = b;
   }
+
+  record testRecord {
+    proc init=(other: testRecord) {}
+  }
 }

--- a/test/chplcheck/CaseRules.good
+++ b/test/chplcheck/CaseRules.good
@@ -10,7 +10,7 @@ CaseRules.chpl:24: node violates rule CamelOrPascalCaseVariables
 CaseRules.chpl:28: node violates rule CamelOrPascalCaseVariables
 CaseRules.chpl:32: node violates rule PascalCaseModules
 CaseRules.chpl:34: node violates rule PascalCaseModules
-CaseRules.chpl:39: node violates rule PascalCaseClasses
 CaseRules.chpl:37: node violates rule PascalCaseClasses
+CaseRules.chpl:39: node violates rule PascalCaseClasses
 CaseRules.chpl:42: node violates rule CamelOrPascalCaseVariables
 CaseRules.chpl:43: node violates rule CamelOrPascalCaseVariables

--- a/test/chplcheck/PREDIFF
+++ b/test/chplcheck/PREDIFF
@@ -5,5 +5,5 @@ $CHPL_HOME/tools/chplcheck/chplcheck --enable-rule ConsecutiveDecls \
   --enable-rule UnusedFormal \
   --enable-rule CamelOrPascalCaseVariables \
   $1.chpl >> $2
-sed -i .tmp "s#$(pwd)/##" $2 # strip the working directory from output
+sed -i.tmp "s#$(pwd)/##" $2 # strip the working directory from output
 rm $2.tmp

--- a/test/chplcheck/PREDIFF
+++ b/test/chplcheck/PREDIFF
@@ -5,5 +5,6 @@ $CHPL_HOME/tools/chplcheck/chplcheck --enable-rule ConsecutiveDecls \
   --enable-rule UnusedFormal \
   --enable-rule CamelOrPascalCaseVariables \
   $1.chpl >> $2
-sed -i.tmp "s#$(pwd)/##" $2 # strip the working directory from output
-rm $2.tmp
+if sed "s#$(pwd)/##" $2 >$2.tmp; then
+    mv $2.tmp $2
+fi

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -53,6 +53,7 @@ def register_rules(driver):
     def CamelCaseFunctions(context, node):
         if node.linkage() == 'extern': return True
         if node.kind() == 'operator': return True
+        if node.name() == 'init=': return True
         return check_camel_case(node)
 
     @driver.basic_rule(Class)


### PR DESCRIPTION
`chplcheck` testing has been broken and I'm the only one who found out because I'm the only one who has `chplcheck` built on `chapdl`. The `PREDIFF` script relies on `sed` which is apparently different between macOS and Linux. Fix the script to use a sed command that works on both. Also fix the `CaseRules` test which turned out to be broken.

Reviewed by @jabraham17 and @brandon-neth -- thanks!

## Testing
- [x] `start_test test/chplcheck` on macOS machine
- [x] `start_test test/chplcheck` on Linux machine