### PR TITLE
bug(dyno): let int->uint pass when formal has default value

### DIFF
--- a/frontend/lib/resolution/Resolver.h
+++ b/frontend/lib/resolution/Resolver.h
@@ -317,6 +317,13 @@ struct Resolver {
   void resolveNamedDecl(const uast::NamedDecl* decl,
                         const types::Type* useType);
 
+  // helper to compute the intent for formals
+  // (including type constructor formals)
+  void computeFormalIntent(const uast::NamedDecl* decl,
+                                 types::QualifiedType::Kind& qtKind,
+                           const types::Type* typePtr,
+                           const types::Param* paramPtr);
+
   // issue ambiguity / no matching candidates / etc error
   void issueErrorForFailedCallResolution(const uast::AstNode* astForErr,
                                          const CallInfo& ci,

--- a/frontend/test/resolution/testTypeAndInit.cpp
+++ b/frontend/test/resolution/testTypeAndInit.cpp
@@ -40,7 +40,20 @@ static void test1() {
   assert(qt.type()->isBoolType());
 }
 
+static void test2() {
+  Context ctx;
+  auto context = &ctx;
+  auto qt = resolveQualifiedTypeOfX(context,
+                                    R""""(
+                                      proc foo(arg: uint = 0) do return arg;
+                                      var x = foo();
+                                    )"""");
+  assert(qt.kind() == QualifiedType::VAR);
+  assert(qt.type()->isUintType());
+}
+
 int main() {
     test1();
+    test2();
     return 0;
 }


### PR DESCRIPTION
This PR adjusts the dyno resolver to allow numeric type conversions when defining initializer expressions (such as default values) for formals. This resolves original issue https://github.com/Cray/chapel-private/issues/5730. 

Prior to this PR, dyno wouldn't allow the following program to compile:
```chapel
proc foo(arg: uint = 0) {
  return arg;
}

var x = foo();
```

Previously, the resolver wouldn't evaluate a possible numeric conversion for `arg` because it hadn't resolved what the `default_intent` should be. This PR moves the intent resolution up for the case of formal initialization expressions with defaults.

TESTING:

- [x] paratest `[Summary: #Successes = 17131 | #Failures = 0 | #Futures = 915]`
- [x] previously failing example resolves

[reviewed by @mppf - thanks!]