### PR TITLE
Start linting some standard modules in CI checks

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -87,6 +87,9 @@ jobs:
       run: |
         CHPL_HOME=$PWD make DYNO_ENABLE_ASSERTIONS=1 make chapel-py-venv -j`util/buildRelease/chpl-make-cpu_count`
         CHPL_HOME=$PWD $PWD/tools/chpldoc/findUndocumentedSymbols --ci --ignore-deprecated --ignore-unstable $PWD/modules/standard
+    - name: lint standard modules
+      run: |
+        CHPL_HOME=$PWD make DYNO_ENABLE_ASSERTIONS=1 lint-standard-modules -j`util/buildRelease/chpl-make-cpu_count`
 
   make_check_llvm_none:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,9 @@
 #
 MAKEFLAGS = --no-print-directory
 
+MODULES_TO_LINT = \
+	$(shell find $(CHPL_MAKE_HOME)/modules/dists -name '*.chpl')
+
 export CHPL_MAKE_HOME=$(shell pwd)
 export CHPL_MAKE_PYTHON := $(shell $(CHPL_MAKE_HOME)/util/config/find-python.sh)
 
@@ -180,6 +183,12 @@ chplcheck: frontend-shared FORCE
 	@# Best not to depend on chapel-py-venv here, because at the time of
 	@# writing this target is always FORCEd (so we'd end up building it twice).
 	cd tools/chplcheck && $(MAKE) all install
+
+lint-standard-modules: chplcheck FORCE
+	chplcheck --skip-unstable \
+		--internal-prefix "_" \
+		--internal-prefix "chpl_" \
+		$(MODULES_TO_LINT)
 
 compile-util-python: FORCE
 	@if $(CHPL_MAKE_PYTHON) -m compileall -h > /dev/null 2>&1 ; then \

--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,7 @@ chplcheck: frontend-shared FORCE
 	cd tools/chplcheck && $(MAKE) all install
 
 lint-standard-modules: chplcheck FORCE
-	chplcheck --skip-unstable \
+	tools/chplcheck/chplcheck --skip-unstable \
 		--internal-prefix "_" \
 		--internal-prefix "chpl_" \
 		$(MODULES_TO_LINT)

--- a/Makefile.devel
+++ b/Makefile.devel
@@ -16,9 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-MODULES_TO_LINT = \
-	$(shell find $(CHPL_MAKE_HOME)/modules/dists -name '*.chpl')
-
 export CHPL_MAKE_PYTHON := $(shell $(CHPL_MAKE_HOME)/util/config/find-python.sh)
 
 develall:
@@ -76,12 +73,6 @@ run-frontend-linters: FORCE
 	@cd compiler && $(MAKE) run-frontend-linters
 
 run-dyno-linters: run-frontend-linters FORCE
-
-lint-standard-modules: FORCE
-	chplcheck --skip-unstable \
-		--internal-prefix "_" \
-		--internal-prefix "chpl_" \
-		$(MODULES_TO_LINT)
 
 test-chpldef: FORCE
 	@cd compiler && $(MAKE) test-chpldef

--- a/Makefile.devel
+++ b/Makefile.devel
@@ -16,6 +16,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+MODULES_TO_LINT = \
+	$(shell find $(CHPL_MAKE_HOME)/modules/dists -name '*.chpl')
+
 export CHPL_MAKE_PYTHON := $(shell $(CHPL_MAKE_HOME)/util/config/find-python.sh)
 
 develall:
@@ -73,6 +76,12 @@ run-frontend-linters: FORCE
 	@cd compiler && $(MAKE) run-frontend-linters
 
 run-dyno-linters: run-frontend-linters FORCE
+
+lint-standard-modules: FORCE
+	chplcheck --skip-unstable \
+		--internal-prefix "_" \
+		--internal-prefix "chpl_" \
+		$(MODULES_TO_LINT)
 
 test-chpldef: FORCE
 	@cd compiler && $(MAKE) test-chpldef

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -1788,14 +1788,14 @@ proc type BlockDom.chpl__deserialize(data) {
 
 override proc BlockDom.dsiSupportsPrivatization() param do return true;
 
-record BlockDomPrvData {
+record blockDomPrvData {
   var distpid;
   var dims;
   var locdoms;  //todo rvf its elements along with the rest of the record
 }
 
 proc BlockDom.dsiGetPrivatizeData() {
-  return new BlockDomPrvData(dist.pid, whole.dims(), locDoms);
+  return new blockDomPrvData(dist.pid, whole.dims(), locDoms);
 }
 
 proc BlockDom.dsiPrivatize(privatizeData) {
@@ -1836,13 +1836,13 @@ proc type BlockArr.chpl__deserialize(data) {
 
 override proc BlockArr.dsiSupportsPrivatization() param do return true;
 
-record BlockArrPrvData {
+record blockArrPrvData {
   var dompid;
   var locarr;  //todo rvf its elements along with the rest of the record
 }
 
 proc BlockArr.dsiGetPrivatizeData() {
-  return new BlockArrPrvData(dom.pid, locArr);
+  return new blockArrPrvData(dom.pid, locArr);
 }
 
 proc BlockArr.dsiPrivatize(privatizeData) {

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -797,7 +797,7 @@ proc BlockImpl.dsiClone() {
 }
 
 override proc BlockImpl.dsiDestroyDist() {
-  coforall ld in locDist do {
+  coforall ld in locDist {
     on ld do
       delete ld;
   }

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -465,7 +465,7 @@ class CyclicImpl: BaseDist, writeSerializable {
   }
 
   override proc dsiDestroyDist() {
-    coforall ld in locDist do {
+    coforall ld in locDist {
       on ld do
         delete ld;
     }
@@ -831,7 +831,7 @@ iter CyclicDom.these(param tag: iterKind) where tag == iterKind.leader {
 
     // Forward to defaultRectangular to iterate over the indices we own locally
     for followThis in locDom.myBlock.these(iterKind.leader, maxTasks,
-                                           myIgnoreRunning, minSize) do {
+                                           myIgnoreRunning, minSize) {
       // translate the 0-based indices yielded back to our indexing scheme
       const newFollowThis = chpl__followThisToOrig(idxType, followThis, locDom.myBlock);
 
@@ -1063,7 +1063,7 @@ inline proc _remoteAccessData.getDataIndex(
   if ! strides.isOne() {
     compilerError("RADOpt not supported for strided cyclic arrays.");
   } else {
-    for param i in 0..rank-1 do {
+    for param i in 0..rank-1 {
       sum += (((ind(i) - off(i)):int * blk(i))-startIdx(i):int)/dimLen(i);
     }
   }

--- a/modules/dists/DSIUtil.chpl
+++ b/modules/dists/DSIUtil.chpl
@@ -51,7 +51,7 @@ proc _computeChunkStuff(maxTasks, ignoreRunning, minSize, ranges,
   param rank=ranges.size;
   type EC = uint; // type for element counts
   var numElems = 1:EC;
-  for param i in 0..rank-1 do {
+  for param i in 0..rank-1 {
     numElems *= ranges(i).sizeAs(EC);
   }
 
@@ -65,7 +65,7 @@ proc _computeChunkStuff(maxTasks, ignoreRunning, minSize, ranges,
   var maxDim = -1;
   var maxElems = min(EC);
   // break/continue don't work with param loops (known future)
-  for /* param */ i in 0..rank-1 do {
+  for /* param */ i in 0..rank-1 {
     const curElems = ranges(i).sizeAs(EC);
     if curElems >= numChunks:EC {
       parDim = i;

--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -97,7 +97,7 @@ class SparseBlockDom: BaseSparseDomImpl(?) {
     //    writeln("In setup");
     var thisid = this.locale.id;
     if locDoms(dist.targetLocDom.lowBound) == nil {
-      coforall localeIdx in dist.targetLocDom do {
+      coforall localeIdx in dist.targetLocDom {
         on dist.targetLocales(localeIdx) do {
           //                    writeln("Setting up on ", here.id);
           //                    writeln("setting up on ", localeIdx, ", whole is: ", whole, ", chunk is: ", dist.getChunk(whole,localeIdx));
@@ -122,7 +122,7 @@ class SparseBlockDom: BaseSparseDomImpl(?) {
   }
 
   override proc dsiDestroyDom() {
-    coforall localeIdx in dist.targetLocDom do {
+    coforall localeIdx in dist.targetLocDom {
       on locDoms(localeIdx) do
         delete locDoms(localeIdx);
     }

--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -231,7 +231,7 @@ class SparseBlockDom: BaseSparseDomImpl(?) {
   proc dsiSerialWrite(f) {
     if (rank == 1) {
       f.write("{");
-      for locdom in locDoms do {
+      for locdom in locDoms {
         // on locdom do {
         if (locdom!.dsiNumIndices) {
             f.write(" ");
@@ -803,7 +803,7 @@ proc LocSparseBlockArr.this(i) ref {
 proc SparseBlockArr.dsiSerialWrite(f) {
   if (rank == 1) {
     f.write("[");
-    for locarr in locArr do {
+    for locarr in locArr {
       // on locdom do {
       if (locarr!.locDom.dsiNumIndices) {
         f.write(" ");

--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -52,7 +52,7 @@ config param debugSparseBlockDistBulkTransfer = false;
 // just use Block.
 
 // Helper type for sorting locales
-record TargetLocaleComparator {
+record targetLocaleComparator {
   param rank;
   type idxType;
   type sparseLayoutType;
@@ -177,7 +177,7 @@ class SparseBlockDom: BaseSparseDomImpl(?) {
     }
 
     // without _new_, record functions throw null deref
-    var comp = new TargetLocaleComparator(rank=rank, idxType=idxType,
+    var comp = new targetLocaleComparator(rank=rank, idxType=idxType,
                                           sparseLayoutType=sparseLayoutType,
                                           dist=dist);
 

--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -165,12 +165,12 @@ class SparseBlockDom: BaseSparseDomImpl(?) {
       var retval = 0;
       on addOn {
         if inds.locale == here {
-          retval = bulkAddHere_help(inds, dataSorted, isUnique);
+          retval = _bulkAddHere_help(inds, dataSorted, isUnique);
         }
         else {
           var _local_inds: [indsDom] index(rank, idxType);
           _local_inds = inds;
-          retval = bulkAddHere_help(_local_inds, dataSorted, isUnique);
+          retval = _bulkAddHere_help(_local_inds, dataSorted, isUnique);
         }
       }
       return retval;
@@ -217,7 +217,7 @@ class SparseBlockDom: BaseSparseDomImpl(?) {
     return _retval;
   }
 
-  proc bulkAddHere_help(inds: [] index(rank,idxType),
+  proc _bulkAddHere_help(inds: [] index(rank,idxType),
       dataSorted=false, isUnique=false) {
 
     const _retval = myLocDom!.mySparseBlock.bulkAdd(inds, dataSorted=true,

--- a/modules/dists/dims/BlockCycDim.chpl
+++ b/modules/dists/dims/BlockCycDim.chpl
@@ -22,6 +22,9 @@
 // Block-cyclic dimension specifier - for use with DimensionalDist2D.
 //
 
+@unstable("BlockCycDim is intended for use with DimensionalDist2D, which is unstable")
+prototype module BlockCycDim {
+
 private use DimensionalDist2D;
 import RangeChunk;
 
@@ -813,4 +816,6 @@ iter BlockCyclic1dom.dsiFollowerArrayIterator1d(undensRange): (locIdT, idxType) 
       foreach stoIdx in stoIxs do
         yield (locNo, stoIdx);
   }
+}
+
 }

--- a/modules/dists/dims/BlockDim.chpl
+++ b/modules/dists/dims/BlockDim.chpl
@@ -18,9 +18,13 @@
  * limitations under the License.
  */
 
+
 //
 // Block dimension specifier - for use with DimensionalDist2D.
 //
+
+@unstable("BlockDim is intended for use with DimensionalDist2D, which is unstable")
+prototype module BlockDim {
 
 private use DimensionalDist2D;
 
@@ -325,4 +329,6 @@ iter Block1dom.dsiFollowerArrayIterator1d(undensRange): (locIdT, idxType) {
       }
     }
   }
+}
+
 }

--- a/modules/dists/dims/ReplicatedDim.chpl
+++ b/modules/dists/dims/ReplicatedDim.chpl
@@ -25,6 +25,9 @@
 // The required methods are marked with 'REQ' followed by a brief description.
 //
 
+@unstable("ReplicatedDim is intended for use with DimensionalDist2D, which is unstable")
+prototype module ReplicatedDim {
+
 private use DimensionalDist2D;
 import RangeChunk;
 
@@ -337,4 +340,6 @@ iter Replicated1dom.dsiFollowerArrayIterator1d(undensRange): (locIdT, idxType) {
   assert(localLocIDlegit);
   foreach i in undensRange do
     yield (localLocID, i);
+}
+
 }

--- a/test/chplcheck/CaseRules.chpl
+++ b/test/chplcheck/CaseRules.chpl
@@ -65,4 +65,14 @@ module CaseRules {
       var temp = other;
     }
   }
+
+  class ParentClassWithBadMethod {
+    proc badly_capitalized() {}
+  }
+
+  class ChildThatOverridesBadMethod : ParentClassWithBadMethod {
+    // shouldn't warn: override procs are exempt from capitalization rules,
+    // because the parent controls the name.
+    override proc badly_capitalized() {}
+  }
 }

--- a/test/chplcheck/CaseRules.good
+++ b/test/chplcheck/CaseRules.good
@@ -14,3 +14,4 @@ CaseRules.chpl:37: node violates rule PascalCaseClasses
 CaseRules.chpl:39: node violates rule PascalCaseClasses
 CaseRules.chpl:42: node violates rule CamelOrPascalCaseVariables
 CaseRules.chpl:43: node violates rule CamelOrPascalCaseVariables
+CaseRules.chpl:70: node violates rule CamelCaseFunctions

--- a/test/chplcheck/ChplPrefixReserved.good
+++ b/test/chplcheck/ChplPrefixReserved.good
@@ -1,3 +1,6 @@
+ChplPrefixReserved.chpl:2: node violates rule CamelOrPascalCaseVariables
 ChplPrefixReserved.chpl:2: node violates rule ChplPrefixReserved
+ChplPrefixReserved.chpl:3: node violates rule CamelCaseFunctions
 ChplPrefixReserved.chpl:3: node violates rule ChplPrefixReserved
+ChplPrefixReserved.chpl:4: node violates rule CamelCaseRecords
 ChplPrefixReserved.chpl:4: node violates rule ChplPrefixReserved

--- a/test/chplcheck/PREDIFF
+++ b/test/chplcheck/PREDIFF
@@ -5,7 +5,7 @@ $CHPL_HOME/tools/chplcheck/chplcheck --enable-rule ConsecutiveDecls \
   --enable-rule UnusedFormal \
   --enable-rule CamelOrPascalCaseVariables \
   --enable-rule NestedCoforalls \
-  --internal-prefix "myprefix_" \
+  --internal-prefix "myprefix_" --internal-prefix "_" \
   --skip-unstable \
   $1.chpl >> $2
 if sed "s#$(pwd)/##" $2 >$2.tmp; then

--- a/test/chplcheck/PREDIFF
+++ b/test/chplcheck/PREDIFF
@@ -5,6 +5,8 @@ $CHPL_HOME/tools/chplcheck/chplcheck --enable-rule ConsecutiveDecls \
   --enable-rule UnusedFormal \
   --enable-rule CamelOrPascalCaseVariables \
   --enable-rule NestedCoforalls \
+  --internal-prefix "myprefix_" \
+  --skip-unstable \
   $1.chpl >> $2
 if sed "s#$(pwd)/##" $2 >$2.tmp; then
     mv $2.tmp $2

--- a/test/chplcheck/PREDIFF
+++ b/test/chplcheck/PREDIFF
@@ -4,6 +4,7 @@ $CHPL_HOME/tools/chplcheck/chplcheck --enable-rule ConsecutiveDecls \
   --enable-rule UseExplicitModules \
   --enable-rule UnusedFormal \
   --enable-rule CamelOrPascalCaseVariables \
+  --enable-rule NestedCoforalls \
   $1.chpl >> $2
 if sed "s#$(pwd)/##" $2 >$2.tmp; then
     mv $2.tmp $2

--- a/test/chplcheck/SkipUnstableInternal.chpl
+++ b/test/chplcheck/SkipUnstableInternal.chpl
@@ -1,0 +1,22 @@
+module Main {
+  @unstable("This file is unstable")
+  module Unstable {
+      record snake_case_rec {}
+      var snake_case_var = 42;
+      proc snake_case_proc() {}
+
+      record myprefix_snake_case_rec {}
+      var myprefix_snake_case_var = 42;
+      proc myprefix_snake_case_proc() {}
+  }
+
+  module Stable {
+      record snake_case_rec {}
+      var snake_case_var = 42;
+      proc snake_case_proc() {}
+
+      record myprefix_snake_case_rec {}
+      var myprefix_snake_case_var = 42;
+      proc myprefix_snake_case_proc() {}
+  }
+}

--- a/test/chplcheck/SkipUnstableInternal.good
+++ b/test/chplcheck/SkipUnstableInternal.good
@@ -1,0 +1,3 @@
+SkipUnstableInternal.chpl:14: node violates rule CamelCaseRecords
+SkipUnstableInternal.chpl:15: node violates rule CamelOrPascalCaseVariables
+SkipUnstableInternal.chpl:16: node violates rule CamelCaseFunctions

--- a/test/chplcheck/Unused.chpl
+++ b/test/chplcheck/Unused.chpl
@@ -2,7 +2,11 @@ module Unused {
   proc myProc(A, B) {
     for i in 1..10 do writeln(A);
 
-    for (i,j) in {1..10,1..10} do 
+    for (i,j) in {1..10,1..10} do
+      writeln(i);
+
+    // Shouldn't warn: j is underscore, aka "I don't care"
+    for (i,_) in {1..10,1..10} do
       writeln(i);
 
     for i in 1..10 {

--- a/test/chplcheck/Unused.good
+++ b/test/chplcheck/Unused.good
@@ -1,4 +1,4 @@
 Unused.chpl:2: node violates rule UnusedFormal
 Unused.chpl:3: node violates rule UnusedLoopIndex
 Unused.chpl:5: node violates rule UnusedLoopIndex
-Unused.chpl:9: node violates rule UnusedLoopIndex
+Unused.chpl:13: node violates rule UnusedLoopIndex

--- a/test/chplcheck/UnusedFormalBug.bad
+++ b/test/chplcheck/UnusedFormalBug.bad
@@ -1,1 +1,1 @@
-UnusedFormalBug.chpl:2: node violates rule UnusedFormal
+UnusedFormalBug.chpl:3: node violates rule UnusedFormal

--- a/test/chplcheck/UnusedFormalBug.chpl
+++ b/test/chplcheck/UnusedFormalBug.chpl
@@ -1,4 +1,6 @@
-var A: [1..10] int;
-proc foo(A) {
-  A[1] = 2;
+module UnusedFormalBug {
+  var A: [1..10] int;
+  proc foo(A) {
+    A[1] = 2;
+  }
 }

--- a/tools/chplcheck/src/chplcheck.py
+++ b/tools/chplcheck/src/chplcheck.py
@@ -54,6 +54,8 @@ def main():
         run_lsp(driver)
         return
 
+    printed_warning = False
+
     for (filename, context) in chapel.files_with_contexts(args.filenames):
         # Silence errors, warnings etc. -- we're just linting.
         with context.track_errors() as errors:
@@ -63,6 +65,10 @@ def main():
             violations.sort(key=lambda f : f[0].location().start()[0])
             for (node, rule) in violations:
                 print_violation(node, rule)
+                printed_warning = True
+
+    if printed_warning:
+        sys.exit(1)
 
 if __name__ == "__main__":
     main()

--- a/tools/chplcheck/src/chplcheck.py
+++ b/tools/chplcheck/src/chplcheck.py
@@ -41,9 +41,10 @@ def main():
     parser.add_argument('--enable-rule', action='append', dest='enabled_rules', default=[])
     parser.add_argument('--lsp', action='store_true', default=False)
     parser.add_argument('--skip-unstable', action='store_true', default=False)
+    parser.add_argument('--internal-prefix', action='append', dest='internal_prefixes', default=[])
     args = parser.parse_args()
 
-    driver = LintDriver(skip_unstable = args.skip_unstable)
+    driver = LintDriver(skip_unstable = args.skip_unstable, internal_prefixes = args.internal_prefixes)
     # register rules before enabling/disabling
     register_rules(driver)
     driver.disable_rules(*args.disabled_rules)

--- a/tools/chplcheck/src/chplcheck.py
+++ b/tools/chplcheck/src/chplcheck.py
@@ -40,9 +40,10 @@ def main():
     parser.add_argument('--disable-rule', action='append', dest='disabled_rules', default=[])
     parser.add_argument('--enable-rule', action='append', dest='enabled_rules', default=[])
     parser.add_argument('--lsp', action='store_true', default=False)
+    parser.add_argument('--skip-unstable', action='store_true', default=False)
     args = parser.parse_args()
 
-    driver = LintDriver()
+    driver = LintDriver(skip_unstable = args.skip_unstable)
     # register rules before enabling/disabling
     register_rules(driver)
     driver.disable_rules(*args.disabled_rules)

--- a/tools/chplcheck/src/driver.py
+++ b/tools/chplcheck/src/driver.py
@@ -98,6 +98,7 @@ class LintDriver:
     def _preorder_skip_unstable_modules(self, node):
         if not self.skip_unstable:
             yield from chapel.preorder(node)
+            return
 
         def recurse(node):
             if LintDriver._is_unstable_module(node):return

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -72,7 +72,7 @@ def register_rules(driver):
     def DoKeywordAndBlock(context, node):
         return node.block_style() != "unnecessary"
 
-    @driver.basic_rule(Coforall)
+    @driver.basic_rule(Coforall, default=False)
     def NestedCoforalls(context, node):
         parent = node.parent()
         while parent is not None:

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -51,9 +51,14 @@ def register_rules(driver):
 
     @driver.basic_rule(Function)
     def CamelCaseFunctions(context, node):
+        # Override functions / methods can't control the name, that's up
+        # to the parent.
+        if node.is_override(): return True
+
         if node.linkage() == 'extern': return True
         if node.kind() == 'operator': return True
         if node.name() == 'init=': return True
+
         return check_camel_case(node)
 
     @driver.basic_rule(Class)

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -236,7 +236,7 @@ def register_rules(driver):
 
         def variables(node):
             if isinstance(node, Variable):
-                yield node
+                if node.name() != "_": yield node
             elif isinstance(node, TupleDecl):
                 for child in node:
                     yield from variables(child)

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -24,8 +24,6 @@ import re
 
 def name_for_linting(node):
     name = node.name()
-    if name.startswith("chpl_"):
-        name = name.removeprefix("chpl_")
 
     # Strip dollar signs.
     name = name.replace("$", "")
@@ -33,10 +31,10 @@ def name_for_linting(node):
     return name
 
 def check_camel_case(node):
-    return re.fullmatch(r'_?([a-z]+([A-Z][a-z]*|\d+)*|[A-Z]+)?', name_for_linting(node))
+    return re.fullmatch(r'([a-z]+([A-Z][a-z]*|\d+)*|[A-Z]+)?', name_for_linting(node))
 
 def check_pascal_case(node):
-    return re.fullmatch(r'_?(([A-Z][a-z]*|\d+)+|[A-Z]+)?', name_for_linting(node))
+    return re.fullmatch(r'(([A-Z][a-z]*|\d+)+|[A-Z]+)?', name_for_linting(node))
 
 def register_rules(driver):
     @driver.basic_rule(VarLikeDecl, default=False)


### PR DESCRIPTION
This PR uses `chplcheck` to start linting modules in our `modules/` folder. For the time being, it lints only `modules/dists`, which is the first directory there alphabetically. Since adding each new directory requires some manual involvement to fix linter issues, the checks will be run on progressively more standard modules as they are brought to compliance. 

This PR also:

* Tweaks the `UnusedLoopIndex` rule to handle `_` properly (i.e. not warn!)
* Disables the `NestedCoforalls` rule.
* Adds a flag to skip unstable modules (since we don't want to put in the effort to make them lint-free)
* Also adds logic to skip linting variables starting with `chpl_` and `_` (specified from the command line), since these are internal implementation details and not worth our attention.
* Tweaks `CamelCaseFunctions` to not warn for override procedures.
* Adjusts the linter to exit with a nonzero code if it detects problems.

Reviewed by @jabraham17 -- thanks!

# Future work
Add an option to skip warnings for deprecated modules, too. Currently not needed for a proof of concept and not implemented in this PR.

# Testing
- [x] gasnet paratest
- [x] local paratest
- [x] CI checks pass