### PR TITLE
makefile target for building the dyno tests without running them.

### DIFF
--- a/Makefile.devel
+++ b/Makefile.devel
@@ -67,6 +67,9 @@ frontend-docs: FORCE
 test-frontend: FORCE
 	@cd compiler && $(MAKE) test-frontend
 
+frontend-tests: FORCE
+	@cd compiler && $(MAKE) frontend-tests
+
 test-dyno: FORCE test-frontend
 
 run-frontend-linters: FORCE

--- a/Makefile.devel
+++ b/Makefile.devel
@@ -67,7 +67,7 @@ frontend-docs: FORCE
 test-frontend: FORCE
 	@cd compiler && $(MAKE) test-frontend
 
-frontend-tests: FORCE
+frontend-tests:
 	@cd compiler && $(MAKE) frontend-tests
 
 test-dyno: FORCE test-frontend

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -176,6 +176,12 @@ test-frontend: FORCE $(CHPL_CONFIG_CHECK) $(COMPILER_BUILD)
 	  cd $(COMPILER_BUILD)/frontend/test && ctest $$JOBSFLAG . ;
 	@echo "frontend tests are available in build/frontend-test"
 
+frontend-tests: FORCE $(CHPL_CONFIG_CHECK) $(COMPILER_BUILD)
+	@echo "Making the frontend tests..."
+	@cd $(COMPILER_BUILD) && $(CMAKE) $(CHPL_MAKE_HOME) $(CMAKE_FLAGS_NO_NDEBUG) && $(MAKE) tests
+	@echo "Making symbolic link to frontend tests in build/frontend-test"
+	@cd ../build && rm -f frontend-test && ln -s $(COMPILER_BUILD)/frontend/test frontend-test
+
 COPY_IF_DIFFERENT = $(CHPL_MAKE_PYTHON) $(CHPL_MAKE_HOME)/util/config/update-if-different --quiet --copy
 
 frontend-docs: FORCE $(CHPL_CONFIG_CHECK) $(COMPILER_BUILD)

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -168,15 +168,16 @@ frontend-shared: FORCE $(CHPL_CONFIG_CHECK) $(COMPILER_BUILD)
 	@cd $(COMPILER_BUILD) && $(CMAKE) $(CHPL_MAKE_HOME) $(CMAKE_FLAGS) && $(MAKE) ChplFrontendShared
 
 test-frontend: FORCE frontend-tests $(CHPL_CONFIG_CHECK) $(COMPILER_BUILD)
+	@echo "Running the frontend tests..."
 	JOBSFLAG=`echo "$$MAKEFLAGS" | sed -n 's/.*\(-j\|--jobs=\) *\([0-9][0-9]*\).*/-j\2/p'` ; \
 	  cd $(COMPILER_BUILD)/frontend/test && ctest $$JOBSFLAG . ;
-	@echo "frontend tests are available in build/frontend-test"
 
 frontend-tests: $(CHPL_CONFIG_CHECK) $(COMPILER_BUILD)
 	@echo "Making the frontend tests..."
 	@cd $(COMPILER_BUILD) && $(CMAKE) $(CHPL_MAKE_HOME) $(CMAKE_FLAGS_NO_NDEBUG) && $(MAKE) tests
 	@echo "Making symbolic link to frontend tests in build/frontend-test"
 	@cd ../build && rm -f frontend-test && ln -s $(COMPILER_BUILD)/frontend/test frontend-test
+	@echo "frontend tests are available in build/frontend-test"
 
 COPY_IF_DIFFERENT = $(CHPL_MAKE_PYTHON) $(CHPL_MAKE_HOME)/util/config/update-if-different --quiet --copy
 

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -167,16 +167,12 @@ frontend: FORCE $(CHPL_CONFIG_CHECK) $(COMPILER_BUILD)
 frontend-shared: FORCE $(CHPL_CONFIG_CHECK) $(COMPILER_BUILD)
 	@cd $(COMPILER_BUILD) && $(CMAKE) $(CHPL_MAKE_HOME) $(CMAKE_FLAGS) && $(MAKE) ChplFrontendShared
 
-test-frontend: FORCE $(CHPL_CONFIG_CHECK) $(COMPILER_BUILD)
-	@echo "Making and running the frontend tests..."
-	@cd $(COMPILER_BUILD) && $(CMAKE) $(CHPL_MAKE_HOME) $(CMAKE_FLAGS_NO_NDEBUG) && $(MAKE) tests
-	@echo "Making symbolic link to frontend tests in build/frontend-test"
-	@cd ../build && rm -f frontend-test && ln -s $(COMPILER_BUILD)/frontend/test frontend-test
+test-frontend: FORCE frontend-tests $(CHPL_CONFIG_CHECK) $(COMPILER_BUILD)
 	JOBSFLAG=`echo "$$MAKEFLAGS" | sed -n 's/.*\(-j\|--jobs=\) *\([0-9][0-9]*\).*/-j\2/p'` ; \
 	  cd $(COMPILER_BUILD)/frontend/test && ctest $$JOBSFLAG . ;
 	@echo "frontend tests are available in build/frontend-test"
 
-frontend-tests: FORCE $(CHPL_CONFIG_CHECK) $(COMPILER_BUILD)
+frontend-tests: $(CHPL_CONFIG_CHECK) $(COMPILER_BUILD)
 	@echo "Making the frontend tests..."
 	@cd $(COMPILER_BUILD) && $(CMAKE) $(CHPL_MAKE_HOME) $(CMAKE_FLAGS_NO_NDEBUG) && $(MAKE) tests
 	@echo "Making symbolic link to frontend tests in build/frontend-test"


### PR DESCRIPTION
Adds `frontend-tests` as a top level makefile target to build the dyno tests without running them.