### PR TITLE
exempt foreach intents tests with cpu-as-device mode

### DIFF
--- a/test/gpu/native/intents/SKIPIF
+++ b/test/gpu/native/intents/SKIPIF
@@ -1,0 +1,1 @@
+CHPL_GPU==cpu


### PR DESCRIPTION
Currently when using foreach intents (enabled today using the `--foreach-intents` compiler flag) and cpu-as-device mode `in` intents will exhibit the behavior expected when running a foreach loop on a CPU rather than a GPU.

I think its an open question about what we should do, but in the meantime (since this is work-in-progress and these tests are failing our nightly cpu-as-device job) I'm going to exempt foreach testing for cpu-as-device.