### PR TITLE
Skip new test for CHPL_TARGET_COMPILER!=llvm

### DIFF
--- a/test/compflags/ferguson/gen-lib-flags/SKIPIF
+++ b/test/compflags/ferguson/gen-lib-flags/SKIPIF
@@ -1,0 +1,1 @@
+CHPL_TARGET_COMPILER!=llvm


### PR DESCRIPTION
Follow-up to PR #24032 to skip a new test when `CHPL_TARGET_COMPILER!=llvm` because it gives an unrelated error in that case.

Test change only - not reviewed.