### PR TITLE
Homebrew updates for the 1.32 and 1.33 release

### DIFF
--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -49,6 +49,11 @@ class Chapel < Formula
       CHPL_LLVM_CONFIG=#{llvm.opt_bin}/llvm-config
       CHPL_LLVM_GCC_PREFIX=none
     EOS
+    # CHPL_MEM and CHPL_TASKS are currently being set this way due
+    # to this PR: https://github.com/chapel-lang/chapel/pull/23415.
+    # This is a workaround for an issue where the bundled jemalloc
+    # makefile is being run and failing when we are supposed to use
+    # the system jemalloc.
 
     # Must be built from within CHPL_HOME to prevent build bugs.
     # https://github.com/Homebrew/legacy-homebrew/pull/35166

--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -1,34 +1,28 @@
 class Chapel < Formula
   desc "Programming language for productive parallel computing at scale"
   homepage "https://chapel-lang.org/"
-  url "https://github.com/chapel-lang/chapel/releases/download/1.31.0/chapel-1.31.0.tar.gz"
-  sha256 "4b861c9a354f6fcf66081256f7ec703d6dd2cd68ea363b400d10ac00bf308679"
+  url "https://github.com/chapel-lang/chapel/releases/download/1.33.0/chapel-1.33.0.tar.gz"
+  sha256 "9dfd9bbab3eb1acf10242db909ccf17c1b07634452ca6ba8b238e69788d82883"
   license "Apache-2.0"
   head "https://github.com/chapel-lang/chapel.git", branch: "main"
 
   bottle do
-    sha256 arm64_ventura:  "8563f116d96b3c89a6de8316020ab25fd27be13f7641d8f223c7c79770eba8ca"
-    sha256 arm64_monterey: "6f6da8d43cd744b9e6a8f0026962dcb66c86fe4ffb5dc684e5302a58fbd01247"
-    sha256 arm64_big_sur:  "d8e8968e2a6a885e54ae793a64f3c04808325bd9b35544605f39a4402c827a53"
-    sha256 ventura:        "fd44d28f8b6a382bda9e5674751b6a0033b9f5a42ab836ac7b305a9a3ba43167"
-    sha256 monterey:       "5a446383b71d0ceb4dec422970758814f42f938ead19691797cfb8a549e82fcf"
-    sha256 big_sur:        "d0ec7384c879c36473cd676307d4364d4275d3a9153975c1fa0a1c6057bedcec"
-    sha256 x86_64_linux:   "dfbcffa1fa5acc1f8ff983b47a3617c8cdaa40c7a218ab8db24e4b165eeef431"
+    sha256 arm64_sonoma:   "bf48565f37d29f78919cdc53c05e23e5e610e915e82ede08573b06d4a9746d40"
+    sha256 arm64_ventura:  "ac622257bbef56945f8241d87a63982dae2311fa803f3233788c4a2d85af6b0b"
+    sha256 arm64_monterey: "03757fe09bfdbc1651aaa6b6ffbc54b14022ff13e19d62ca3abfe778de11371a"
+    sha256 sonoma:         "1a16b40a4a13bca828f12a497c521cbbd6d0add7c819a47583c4273769e921b8"
+    sha256 ventura:        "ad445bd4da02eca77f983c75d098716251df6af33e992627800bc4167b8b5947"
+    sha256 monterey:       "984f5634eb6875a9c4b311044305d6fea01a4c04e768d2e3e20dc617e7d91d27"
+    sha256 x86_64_linux:   "2e9f4c854f3bf0b2aa571c489e62ab7f398b1dfcb7ce87c12dc48930d94e6fac"
   end
 
   depends_on "cmake"
   depends_on "gmp"
-  depends_on "llvm@14"
+  depends_on "llvm@15"
   depends_on "python@3.11"
 
   # LLVM is built with gcc11 and we will fail on linux with gcc version 5.xx
   fails_with gcc: "5"
-
-  # Work around Homebrew 11-arm64 CI issue, which outputs unwanted objc warnings like:
-  # objc[42134]: Class ... is implemented in both ... One of the two will be used. Which one is undefined.
-  # These end up incorrectly failing checkChplInstall test script when it checks for stdout/stderr.
-  # TODO: remove when Homebrew CI no longer outputs these warnings or 11-arm64 is no longer used.
-  patch :DATA
 
   def llvm
     deps.map(&:to_formula).find { |f| f.name.match? "^llvm" }
@@ -111,17 +105,3 @@ class Chapel < Formula
     system bin/"chpl", "--print-passes", "--print-commands", libexec/"examples/hello.chpl"
   end
 end
-
-__END__
-diff --git a/util/test/checkChplInstall b/util/test/checkChplInstall
-index 7d2eb78a88..a9ddf22054 100755
---- a/util/test/checkChplInstall
-+++ b/util/test/checkChplInstall
-@@ -189,6 +189,7 @@ fi
- if [ -n "${TEST_COMP_OUT}" ]; then
-     # apply "prediff"-like filter to remove gmake "clock skew detected" warnings, if any
-     TEST_COMP_OUT=$( grep <<<"${TEST_COMP_OUT}" -v \
-+        -e '^objc\(\[[0-9]*\]\)*: Class .* is implemented in both .* One of the two will be used\. Which one is undefined\. *$' \
-         -e '^g*make\(\[[0-9]*\]\)*: Warning: File .* has modification time .* in the future *$' \
-         -e '^g*make\(\[[0-9]*\]\)*: warning:  Clock skew detected\.  Your build may be incomplete\. *$' )
- fi

--- a/util/packaging/homebrew/chapel-release.rb
+++ b/util/packaging/homebrew/chapel-release.rb
@@ -44,6 +44,8 @@ class Chapel < Formula
     (libexec/"chplconfig").write <<~EOS
       CHPL_RE2=bundled
       CHPL_GMP=system
+    # These lines are added as part of this PR: https://github.com/chapel-lang/chapel/pull/23415.
+    # This is a workaround for an issue where the 
       CHPL_MEM=cstdlib
       CHPL_TASKS=fifo
       CHPL_LLVM_CONFIG=#{llvm.opt_bin}/llvm-config


### PR DESCRIPTION
The chapel-release.rb file now matches the currently released homebrew formula and the chapel-main.rb is configured for the 1.33 release.