### PR TITLE
Fix test failures after adjustments to kernel launch

### DIFF
--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -1291,8 +1291,8 @@ static void generateGPUKernelCall(const GpuizableLoop &gpuLoop,
       // just copy the value pointed by it.
       // ENGIN: it is questionable whether we want to do this. This is creating
       // a copy of something that was referred to by this `ref`. Accessing a
-      // `ref` shouldn't trigger a copy, unles... it was put to a "task private"
-      // variable:
+      // `ref` shouldn't trigger a copy, unless... it was put to a "task
+      // private" variable:
       // ref x = y; foreach ... with (var inBody = x)
       gpuBlock->insertAtTail(new CallExpr(PRIM_GPU_ARG, cfg, actualSym,
                                           new_IntSymbol(GpuArgKind::OFFLOAD)));

--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -1289,6 +1289,11 @@ static void generateGPUKernelCall(const GpuizableLoop &gpuLoop,
       // ref: we assume that it is not on GPU memory to be safe, so offload it,
       // but while doing so, we don't need to get the address of it. Because we
       // just copy the value pointed by it.
+      // ENGIN: it is questionable whether we want to do this. This is creating
+      // a copy of something that was referred to by this `ref`. Accessing a
+      // `ref` shouldn't trigger a copy, unles... it was put to a "task private"
+      // variable:
+      // ref x = y; foreach ... with (var inBody = x)
       gpuBlock->insertAtTail(new CallExpr(PRIM_GPU_ARG, cfg, actualSym,
                                           new_IntSymbol(GpuArgKind::OFFLOAD)));
     }

--- a/test/gpu/native/diags.cpu.good
+++ b/test/gpu/native/diags.cpu.good
@@ -6,6 +6,12 @@ Start
 0 (cpu): diags.chpl:nn: free xxB of _EndCount(atomic int(64),int(64)) at 0xPREDIFFED
 0 (gpu 0): diags.chpl:nn: allocate xxB of [domain(1,int(64),one)] int(64) at 0xPREDIFFED
 0 (gpu 0): diags.chpl:nn: allocate xxB of array elements at 0xPREDIFFED
+0 (gpu 0): diags.chpl:nn: allocate xxB of metadata about kernel parameters at 0xPREDIFFED
+0 (gpu 0): diags.chpl:nn: allocate xxB of array of pointers to kernel args at 0xPREDIFFED
+0 (gpu 0): diags.chpl:nn: allocate xxB of metadata about kernel parameters at 0xPREDIFFED
+0 (gpu 0): diags.chpl:nn: free xxB of metadata about kernel parameters at 0xPREDIFFED
+0 (gpu 0): diags.chpl:nn: free xxB of array of pointers to kernel args at 0xPREDIFFED
+0 (gpu 0): diags.chpl:nn: free xxB of metadata about kernel parameters at 0xPREDIFFED
 0 (gpu 0): diags.chpl:nn: free xxB of array elements at 0xPREDIFFED
 0 (gpu 0): diags.chpl:nn: free xxB of [domain(1,int(64),one)] int(64) at 0xPREDIFFED
 2 2 2 2 2 2 2 2 2 2

--- a/test/gpu/native/noGpu/basicMem.comm-none.good
+++ b/test/gpu/native/noGpu/basicMem.comm-none.good
@@ -1,6 +1,12 @@
 0 (gpu 0): basicMem.chpl:5: allocate 88B of domain(1,int(64),one) at 0xPREDIFFED
 0 (gpu 0): basicMem.chpl:5: allocate 168B of [domain(1,int(64),one)] int(64) at 0xPREDIFFED
 0 (gpu 0): basicMem.chpl:5: allocate 80B of array elements at 0xPREDIFFED
+0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1517: allocate 48B of metadata about kernel parameters at 0xPREDIFFED
+0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1517: allocate 40B of array of pointers to kernel args at 0xPREDIFFED
+0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1517: allocate 5B of metadata about kernel parameters at 0xPREDIFFED
+0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1517: free 5B of metadata about kernel parameters at 0xPREDIFFED
+0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1517: free 40B of array of pointers to kernel args at 0xPREDIFFED
+0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1517: free 48B of metadata about kernel parameters at 0xPREDIFFED
 0 (gpu 0): basicMem.chpl:5: free 80B of array elements at 0xPREDIFFED
 0 (gpu 0): basicMem.chpl:5: free 168B of [domain(1,int(64),one)] int(64) at 0xPREDIFFED
 0 (gpu 0): basicMem.chpl:5: free 88B of domain(1,int(64),one) at 0xPREDIFFED

--- a/test/gpu/native/noGpu/basicMem.good
+++ b/test/gpu/native/noGpu/basicMem.good
@@ -3,6 +3,12 @@
 0 (gpu 0): basicMem.chpl:5: allocate 88B of domain(1,int(64),one) at 0xPREDIFFED
 0 (gpu 0): basicMem.chpl:5: allocate 168B of [domain(1,int(64),one)] int(64) at 0xPREDIFFED
 0 (gpu 0): basicMem.chpl:5: allocate 80B of array elements at 0xPREDIFFED
+0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1517: allocate 48B of metadata about kernel parameters at 0xPREDIFFED
+0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1517: allocate 40B of array of pointers to kernel args at 0xPREDIFFED
+0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1517: allocate 5B of metadata about kernel parameters at 0xPREDIFFED
+0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1517: free 5B of metadata about kernel parameters at 0xPREDIFFED
+0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1517: free 40B of array of pointers to kernel args at 0xPREDIFFED
+0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1517: free 48B of metadata about kernel parameters at 0xPREDIFFED
 0 (gpu 0): basicMem.chpl:5: free 80B of array elements at 0xPREDIFFED
 0 (gpu 0): basicMem.chpl:5: free 168B of [domain(1,int(64),one)] int(64) at 0xPREDIFFED
 0 (gpu 0): basicMem.chpl:5: free 88B of domain(1,int(64),one) at 0xPREDIFFED

--- a/test/gpu/native/studies/transpose/transpose.chpl
+++ b/test/gpu/native/studies/transpose/transpose.chpl
@@ -112,14 +112,12 @@ inline proc transposeLowLevel(original, ref output) {
   // arguments are: number of parameters, line no, file no
   var cfg = __primitive("gpu init kernel cfg", 4, 0, 0);
 
-  // 0 is an enum value that says: "pass this directly"
   // 1 is an enum value that says: "pass the address of this to the
-  //   kernel_params, while not offloading anything". I am not entirely sure why
-  //   we need to do that for C pointers
+  //   kernel_params, while not offloading anything".
   __primitive("gpu arg", cfg, c_ptrTo(output), 1);
   __primitive("gpu arg", cfg, c_ptrToConst(original), 1);
-  __primitive("gpu arg", cfg, sizeX, 0);
-  __primitive("gpu arg", cfg, sizeY, 0);
+  __primitive("gpu arg", cfg, sizeX, 1);
+  __primitive("gpu arg", cfg, sizeY, 1);
 
   __primitive("gpu kernel launch",
           "transposeMatrix":chpl_c_string,


### PR DESCRIPTION
- Adjusts some tests' good files to add new verbose output.
- Fixes the transpose test's low-level launch that was failing with --fast
- Add a comment in the compiler for a case that strikes me as wrong