### PR TITLE
Reject candidates that would cause constness errors

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1728,7 +1728,8 @@ bool doCanDispatch(Type*     actualType,
                   isAtomicType(formalValType))) ||
                (formalSym->intent == INTENT_REF &&
                 formalSym == fn->_this &&
-                fn->hasFlag(FLAG_REF_TO_CONST_WHEN_CONST_THIS))) {
+                (fn->hasFlag(FLAG_REF_TO_CONST_WHEN_CONST_THIS) ||
+                 fn->isInitializer() || fn->isCopyInit()))) {
       // these will turn into 'const ref'
       // uncomment this line to allow implicit conversion
       //formalType = formalType->getValType();

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1722,6 +1722,8 @@ bool doCanDispatch(Type*     actualType,
       formalType = formalValType;
     } else if (formalSym->intent == INTENT_CONST_REF ||
                formalSym->intent == INTENT_CONST ||
+               formalSym->intent == INTENT_IN || // TODO: is it possible?
+               formalSym->intent == INTENT_CONST_IN ||
                (formalSym->intent == INTENT_BLANK &&
                 !(isSyncType(formalValType) ||
                   isSingleType(formalValType) ||


### PR DESCRIPTION
Open Question: Is this a breaking language change after the 2.0 release?

This PR implements one improvement discussed in issue #22809. It changes function resolution to consider something a candidate only if there are not constness errors. For example, if we have `proc foo(ref fml: int) { }` and `const x: int = 1`, `foo(x)` would previously resolve to call `foo` and then issue a const-ness error; however this PR changes `foo(x)` to not consider this `foo` a candidate.

This might be more interesting in the presence of multiple overloads, e.g.:

``` chapel
proc bar(ref x: int) { writeln("In ref bar()"); }
proc bar(const ref x: int) { writeln("In const ref bar()"); }

const x: int;
bar(x); // with this PR, chooses 'bar(const ref x: int)' because the other overload is not a candidate
```

With this draft version of the change, there are 71 failures. So far, I have not sought to adjust tests at all. Most, but not necessarily all, of these failures have to do with changes to the const checking errors.

<details>

```
[Summary: #Successes = 17079 | #Failures = 71 | #Futures = 915]
[END]
[Test Summary - 231215.154436]
[Error matching .bad file for arrays/const/modify-const-array-of-record]
[Error matching compiler output for arrays/vass/const-checking.elems]
[Error matching compiler output for classes/ferguson/delete-free/owned-const-in-error]
[Error matching compiler output for classes/ferguson/delete-free/owned-in-record-const-error]
[Error matching .bad file for classes/initializers/records/array-from-for-expr]
[Error matching compiler output for classes/nilability/if-var-2-const]
[Error matching compiler output for classes/nilability/while-var-error-const]
[Error matching compiler output for domains/compilerErrors/constDomain1]
[Error matching compiler output for domains/compilerErrors/constDomain10]
[Error matching compiler output for domains/compilerErrors/constDomain11]
[Error matching compiler output for domains/compilerErrors/constDomain2]
[Error matching compiler output for domains/compilerErrors/constDomain3]
[Error matching compiler output for domains/compilerErrors/constDomain4]
[Error matching compiler output for domains/compilerErrors/constDomain5]
[Error matching compiler output for domains/compilerErrors/constDomain6]
[Error matching compiler output for domains/compilerErrors/constDomain7]
[Error matching compiler output for domains/compilerErrors/constDomain8]
[Error matching compiler output for domains/compilerErrors/constDomain9]
[Error matching .bad file for expressions/loop-expr/recordWrappedClassBug]
[Error matching compiler output for extern/bradc/vars/externConsts2]
[Error matching compiler output for extern/ferguson/externblock/enum-const]
[Error matching compiler output for functions/bradc/intents/intents-strings (compopts: 2)]
[Error matching compiler output for functions/deitz/iterators/test_var_iterator5_error]
[Error matching compiler output for functions/deitz/test_inout_const]
[Error matching compiler output for functions/ferguson/ref-pair/array-tasks-const1]
[Error matching compiler output for functions/ferguson/ref-pair/const-error-iterated]
[Error matching compiler output for functions/ferguson/ref-pair/const-error-iterated2]
[Error matching compiler output for functions/ferguson/ref-pair/const-error]
[Error matching compiler output for functions/ferguson/ref-pair/record-this-intent-const-error]
[Error matching compiler output for functions/vass/const-ref-lvalue-error]
[Error matching .bad file for functions/vass/lvalue-error-messages]
[Error matching compiler output for functions/vass/varargs-2]
[Error matching compiler output for multilocale/bradc/assignRemoteConst]
[Error matching compiler output for parallel/forall/checks/const-indices-blc]
[Error matching compiler output for parallel/forall/checks/const-indices-vass]
[Error matching compiler output for parallel/forall/checks/forall-inout-domain-bug-16301]
[Error matching compiler output for parallel/forall/task-private-vars/const-errors]
[Error matching compiler output for parallel/forall/vass/other/const-errors-due-to-intents]
[Error matching compiler output for parallel/forall/vass/other/fields-of-this-2-const-var]
[Error matching compiler output for parallel/taskPar/taskIntents/constInArrIntent (compopts: 2)]
[Error matching compiler output for parallel/taskPar/taskIntents/constInArrIntent2 (compopts: 2)]
[Error matching compiler output for parallel/taskPar/taskIntents/fields-of-this-2-const-var]
[Error matching .bad file for parallel/taskPar/taskIntents/inCopyPassedToRef]
[Error matching compiler output for parallel/taskPar/vass/const-in-intent-arrays-domains]
[Error matching compiler output for performance/vectorization/vectorizeOnly/constChecking/leaderFollowerConstChecking]
[Error matching compiler output for performance/vectorization/vectorizeOnly/constChecking/serialConstChecking]
[Error matching compiler output for performance/vectorization/vectorizeOnly/constChecking/standaloneConstChecking]
[Error matching compiler output for release/examples/users-guide/base/constParam (compopts: 2)]
[Error matching compiler output for release/examples/users-guide/base/forloops (compopts: 1)]
[Error matching compiler output for release/examples/users-guide/datapar/promotion (compopts: 3)]
[Error matching compiler output for statements/bradc/loops/modifyIndices]
[Error matching compiler output for statements/elliot/loops/modifyIndicesLeaderFollower]
[Error matching compiler output for statements/elliot/loops/modifyIndicesSerial]
[Error matching compiler output for statements/elliot/loops/modifyIndicesStandalone]
[Error matching compiler output for statements/foreach/constIntent]
[Error matching compiler output for statements/manage/ExplicitConstRefResourceMutation]
[Error matching compiler output for statements/vass/index-variable-const-errors]
[Error matching .bad file for studies/shootout/reverse-complement/bradc/revcomp-blc-begin-const-ref]
[Error matching compiler output for trivial/deitz/coerce-assign/assign_const]
[Error matching compiler output for types/records/const-checking/assignments]
[Error matching .bad file for types/records/const-checking/postinit-of-const]
[Error matching compiler output for types/records/const-checking/this-in-method]
[Error matching compiler output for types/records/init/copy/copyWithRefOther3]
[Error matching .bad file for types/records/split-init/for-expr-owned-bug]
[Error matching compiler output for types/records/split-init/split-init-const-error]
[Error matching compiler output for types/records/split-init/split-init-const]
[Error matching compiler output for types/string/sungeun/c_string/intents (compopts: 2)]
[Error matching compiler output for types/tuple/const/tupleModifyBlankArgElem]
[Error matching .bad file for users/vass/issue-16490-2]
[Error matching .bad file for variables/constants/assignConstError]
[Error matching compiler output for variables/diten/loopIndexConst]
[Summary: #Successes = 17079 | #Failures = 71 | #Futures = 915]
```

</details>

If we proceed with this change, it will be important to adjust the code to describe why a candidate did not match to describe constness of the actual. Without, some of the error messages are not very understandable.