### PR TITLE
Add test locking in current behavior for #21296

### DIFF
--- a/test/compflags/unknownLlvmFlag.chpl
+++ b/test/compflags/unknownLlvmFlag.chpl
@@ -1,0 +1,1 @@
+writeln("Got here");

--- a/test/compflags/unknownLlvmFlag.compopts
+++ b/test/compflags/unknownLlvmFlag.compopts
@@ -1,0 +1,1 @@
+--ccflags --fake-flag

--- a/test/compflags/unknownLlvmFlag.good
+++ b/test/compflags/unknownLlvmFlag.good
@@ -1,0 +1,2 @@
+error: unsupported option '--fake-flag'
+Got here

--- a/test/compflags/unknownLlvmFlag.skipif
+++ b/test/compflags/unknownLlvmFlag.skipif
@@ -1,0 +1,1 @@
+CHPL_TARGET_COMPILER!=llvm


### PR DESCRIPTION
This PR is a capture of the behavior reported in https://github.com/chapel-lang/chapel/issues/21296 which seems to be working OK today.  I have a vague memory of someone improving this situation (or something similar to it) recently, though I can't find the PR I'm thinking of with a quick search.  I didn't see any existing tests with 'unsupported option' in their .good files, so am adding this to ensure the behavior does not backslide.

Resolves #21296 (well, something else resolved it; this just locks in that it is resolved).