### PR TITLE
Add tests locking in current behavior w.r.t. #21298

### DIFF
--- a/test/classes/errors/int-error-generic-field.chpl
+++ b/test/classes/errors/int-error-generic-field.chpl
@@ -1,0 +1,13 @@
+module foo {
+    import IO;
+    class bar {
+        const stream: IO.fileWriter;
+        proc init(stream: IO.fileWriter = IO.stdout) {
+            this.stream  = stream;
+        }
+        proc deinit() {
+            stream.flush();
+        }
+    }
+    var test = new bar();
+}

--- a/test/classes/errors/int-error-generic-field.good
+++ b/test/classes/errors/int-error-generic-field.good
@@ -1,0 +1,9 @@
+int-error-generic-field.chpl:5: In initializer:
+int-error-generic-field.chpl:5: warning: need '(?)' on the type 'fileWriter' of the formal 'stream' because this type is generic
+int-error-generic-field.chpl:4: warning: please use '?' when declaring a field with generic type
+int-error-generic-field.chpl:4: note: for example with 'fileWriter(?)'
+int-error-generic-field.chpl:8: In method 'deinit':
+int-error-generic-field.chpl:9: error: call to throwing function flush without throws, try, or try! (relaxed mode)
+$CHPL_HOME/modules/standard/IO.chpl:9703: note: throwing function flush defined here
+  $CHPL_HOME/modules/internal/ChapelBase.chpl:2601: called as (bar(fileWriter(true,defaultSerializer))).deinit()
+  within internal functions (use --print-callstack-on-error to see)

--- a/test/classes/errors/int-error-generic-field2.chpl
+++ b/test/classes/errors/int-error-generic-field2.chpl
@@ -1,0 +1,13 @@
+module foo {
+    import IO;
+    class bar {
+        const stream: IO.fileWriter(?);
+        proc init(stream: IO.fileWriter(?) = IO.stdout) {
+            this.stream  = stream;
+        }
+        proc deinit() {
+            try! stream.flush();
+        }
+    }
+    var test = new bar();
+}


### PR DESCRIPTION
This PR adds a pair of tests that lock in the current behavior for a test reported as resulting in an internal error in https://github.com/chapel-lang/chapel/issues/21298.  It seems that the behavior has improved since then, likely due to Michael's work in adding warnings around generic types, but possibly other changes as well.

Resolves #21298.
