### PR TITLE
add optional fileWriter parameters to ChapelIO.write*

### DIFF
--- a/modules/standard/ChapelIO.chpl
+++ b/modules/standard/ChapelIO.chpl
@@ -1134,15 +1134,24 @@ module ChapelIO {
   proc write(const args ...?n) {
     try! stdout.write((...args));
   }
+    /* Equivalent to ``try! writer.write``. See :proc:`IO.fileWriter.write` */
+  proc write(writer: fileWriter, const args ...?n) {
+    try! writer.write((...args));
+  }
+
   /* Equivalent to ``try! stdout.writeln``. See :proc:`IO.fileWriter.writeln` */
   proc writeln(const args ...?n) {
     try! stdout.writeln((...args));
   }
+  /* Equivalent to ``try! writer.writeln``. See :proc:`IO.fileWriter.writeln` */
+  proc writeln(writer: fileWriter, const args ...?n) {
+    try! writer.writeln((...args));
+  }
 
   // documented in the arguments version.
   @chpldoc.nodoc
-  proc writeln() {
-    try! stdout.writeln();
+  proc writeln(writer: fileWriter = stdout) {
+    try! writer.writeln();
   }
 
  /* Equivalent to ``try! stdout.writef``. See
@@ -1152,12 +1161,26 @@ module ChapelIO {
   {
     try! { stdout.writef(fmt, (...args)); }
   }
+ /* Equivalent to ``try! writer.writef``. See
+     :proc:`FormattedIO.fileWriter.writef`. */
+  proc writef(writer: fileWriter, fmt:?t, const args ...?k)
+      where isStringType(t) || isBytesType(t)
+  {
+    try! { writer.writef(fmt, (...args)); }
+  }
   // documented in string version
   @chpldoc.nodoc
   proc writef(fmt:?t)
       where isStringType(t) || isBytesType(t)
   {
     try! { stdout.writef(fmt); }
+  }
+  // documented in string version
+  @chpldoc.nodoc
+  proc writef(writer: fileWriter, fmt:?t)
+      where isStringType(t) || isBytesType(t)
+  {
+    try! { writer.writef(fmt); }
   }
 
   @chpldoc.nodoc


### PR DESCRIPTION
Fixes #24107 by adding overloads or optional parameters to each of the `ChapelIO.write*` procs to support writing to a `fileWriter` other than `stdout`. This allows user code to call e.g. `writeln(IO.stderr, ...)` to write to `stderr` without exception handling code.

Note: this PR doesn't yet have tests; I couldn't work out where to put them as I couldn't find any specific tests for `ChapelIO.write*`. (These procedures are so fundamental that they're used in almost every test anyway!) I'm happy to write some tests if the Chapel team will tell me the best place for them.

