### PR TITLE
Also suppressif check-sqrt on chapvm

### DIFF
--- a/test/llvm/no-math-errno/check-sqrt-noieee.suppressif
+++ b/test/llvm/no-math-errno/check-sqrt-noieee.suppressif
@@ -14,4 +14,4 @@
 import os
 
 machine=os.uname()[1].split('.', 1)[0]
-print (machine.startswith('chapcs'))
+print (machine.startswith('chapcs') or machine.startswith('chapvm'))


### PR DESCRIPTION
Follow-up to PR #24066 and PR #24106 to extend the `suppressif` to another testing configuration.

Note: I created issue #24112 about the problem that these .suppressif files are suppressing.

Test change only - not reviewed.