### PR TITLE
Work around `integral` bug with `--baseline` and add future

### DIFF
--- a/test/library/standard/Types/copyable/copyable-generic.skipif
+++ b/test/library/standard/Types/copyable/copyable-generic.skipif
@@ -1,0 +1,2 @@
+# errors for use of integral type in baseline (bug #24113)
+COMPOPTS <= --baseline

--- a/test/types/integral/integral-alias-baseline.bad
+++ b/test/types/integral/integral-alias-baseline.bad
@@ -1,0 +1,1 @@
+error: Could not find C type for integral_chpl

--- a/test/types/integral/integral-alias-baseline.chpl
+++ b/test/types/integral/integral-alias-baseline.chpl
@@ -1,0 +1,4 @@
+proc main() {
+  type t = integral;
+  writeln(t:string);
+}

--- a/test/types/integral/integral-alias-baseline.future
+++ b/test/types/integral/integral-alias-baseline.future
@@ -1,0 +1,2 @@
+bug: Compiler error for integral type with --baseline
+#24113

--- a/test/types/integral/integral-alias-baseline.good
+++ b/test/types/integral/integral-alias-baseline.good
@@ -1,0 +1,1 @@
+integral

--- a/test/types/integral/integral-alias-baseline.skipif
+++ b/test/types/integral/integral-alias-baseline.skipif
@@ -1,0 +1,2 @@
+# bug is specific to --baseline
+COMPOPTS >= --baseline

--- a/test/types/integral/integral-alias.chpl
+++ b/test/types/integral/integral-alias.chpl
@@ -1,0 +1,4 @@
+proc main() {
+  type t = integral;
+  writeln(t:string);
+}

--- a/test/types/integral/integral-alias.good
+++ b/test/types/integral/integral-alias.good
@@ -1,0 +1,1 @@
+integral

--- a/test/types/integral/integral-alias.skipif
+++ b/test/types/integral/integral-alias.skipif
@@ -1,0 +1,2 @@
+# errors in --baseline (see integral-alias-baseline.future)
+COMPOPTS <= --baseline


### PR DESCRIPTION
Work around the bug with `type t = integral` with `--baseline`, described in https://github.com/chapel-lang/chapel/issues/24113, and add a future for it.

This bug causes the test `library/standard/Types/copyable/copyable-generic` to fail with `--baseline`, so add a skipif for it.

Follow up to https://github.com/chapel-lang/chapel/pull/24058 which added the test.

[trivial, not reviewed]

Testing:
- [x] paratest
- [x] paratest with `--baseline`