### PR TITLE
`otherwise` required to come at the end of `select` statements

### DIFF
--- a/doc/rst/language/spec/statements.rst
+++ b/doc/rst/language/spec/statements.rst
@@ -388,8 +388,8 @@ that comparison is ``true`` will be selected and control transferred to
 the associated statement. If the comparison is always ``false``, the
 statement associated with the keyword ``otherwise``, if it exists, will
 be selected and control transferred to it. There may be at most one
-``otherwise`` statement and its location within the select statement
-does not matter.
+``otherwise`` statement and it must be the last clause of the `select`
+statement.
 
 Each statement embedded in the *when-statement* or the
 *otherwise-statement* has its own scope whether or not an explicit block

--- a/frontend/include/chpl/parsing/parser-error-classes-list.h
+++ b/frontend/include/chpl/parsing/parser-error-classes-list.h
@@ -59,7 +59,7 @@ PARSER_SYNTAX_CLASS(ParseSyntax, std::string)
 
 /* begin post-parse-checks errors */
 POSTPARSE_ERROR_CLASS(CantApplyPrivate, std::string)
-POSTPARSE_ERROR_CLASS(WhenAfterOtherwise, const uast::Select*)
+POSTPARSE_ERROR_CLASS(WhenAfterOtherwise, const uast::When*, const uast::When*)
 ERROR_CLASS(DisallowedControlFlow, const uast::AstNode*, const uast::AstNode*, const uast::AstNode*)
 ERROR_CLASS(IllegalUseImport, const uast::AstNode*, const uast::AstNode*)
 ERROR_CLASS(InvalidGpuAssertion, const uast::AstNode*, const uast::Attribute*)

--- a/frontend/include/chpl/parsing/parser-error-classes-list.h
+++ b/frontend/include/chpl/parsing/parser-error-classes-list.h
@@ -59,6 +59,7 @@ PARSER_SYNTAX_CLASS(ParseSyntax, std::string)
 
 /* begin post-parse-checks errors */
 POSTPARSE_ERROR_CLASS(CantApplyPrivate, std::string)
+POSTPARSE_ERROR_CLASS(WhenAfterOtherwise, const uast::Select*)
 ERROR_CLASS(DisallowedControlFlow, const uast::AstNode*, const uast::AstNode*, const uast::AstNode*)
 ERROR_CLASS(IllegalUseImport, const uast::AstNode*, const uast::AstNode*)
 ERROR_CLASS(InvalidGpuAssertion, const uast::AstNode*, const uast::Attribute*)

--- a/frontend/lib/parsing/parser-error-classes-list.cpp
+++ b/frontend/lib/parsing/parser-error-classes-list.cpp
@@ -249,10 +249,17 @@ void ErrorCantApplyPrivate::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorWhenAfterOtherwise::write(ErrorWriterBase& wr) const {
-  auto node = std::get<const uast::Select*>(info);
-  wr.heading(kind_, type_, node, "otherwise clause must follow all when clauses.");
-  wr.message("The following select statement has improperly ordered blocks:");
+  auto node = std::get<0>(info);
+  auto otherwise = std::get<1>(info);
+  auto when = std::get<2>(info);
+  wr.heading(kind_, type_, node, "'otherwise' clause must follow all 'when' clauses.");
+  wr.message("In the following 'select' statment:");
   wr.code(node);
+  wr.note(otherwise, "the 'otherwise' clause occurs here:");
+  wr.code(otherwise);
+  wr.note(when, "however, the following 'when' clause is found below it:");
+  wr.code(when);
+  wr.message("Chapel requires 'otherwise' clauses to occur last within 'select' statements.");
 }
 
 void ErrorDisallowedControlFlow::write(ErrorWriterBase& wr) const {

--- a/frontend/lib/parsing/parser-error-classes-list.cpp
+++ b/frontend/lib/parsing/parser-error-classes-list.cpp
@@ -248,6 +248,13 @@ void ErrorCantApplyPrivate::write(ErrorWriterBase& wr) const {
   wr.code(node);
 }
 
+void ErrorWhenAfterOtherwise::write(ErrorWriterBase& wr) const {
+  auto node = std::get<const uast::Select*>(info);
+  wr.heading(kind_, type_, node, "otherwise clause must follow all when clauses.");
+  wr.message("The following select statement has improperly ordered blocks:");
+  wr.code(node);
+}
+
 void ErrorDisallowedControlFlow::write(ErrorWriterBase& wr) const {
   auto invalidAst = std::get<0>(info);
   auto blockingAst = std::get<1>(info);

--- a/frontend/lib/uast/post-parse-checks.cpp
+++ b/frontend/lib/uast/post-parse-checks.cpp
@@ -146,6 +146,7 @@ struct Visitor {
   void checkLambdaDeprecated(const Function* node);
   void checkCStringLiteral(const CStringLiteral* node);
   void checkAllowedImplementsTypeIdent(const Implements* impl, const Identifier* node);
+  void checkOtherwiseAfterWhens(const Select* sel);
   /*
   TODO
   void checkProcedureFormalsAgainstRetType(const Function* node);
@@ -189,6 +190,7 @@ struct Visitor {
   void visit(const OpCall* node);
   void visit(const PrimCall* node);
   void visit(const Return* node);
+  void visit(const Select* node);
   void visit(const TypeQuery* node);
   void visit(const Union* node);
   void visit(const Use* node);
@@ -1535,6 +1537,21 @@ void Visitor::visit(const Return* node) {
   const AstNode* allowingNode;
   if (!checkParentsForControlFlow(parents_, nodeAllowsReturn, node, blockingNode, allowingNode)) {
     CHPL_REPORT(context_, DisallowedControlFlow, node, blockingNode, allowingNode);
+  }
+}
+
+void Visitor::visit(const Select* node) {
+  checkOtherwiseAfterWhens(node);
+}
+
+void Visitor::checkOtherwiseAfterWhens(const Select* sel) {
+  bool seenOtherwise = false;
+  for(size_t i = 0; i < sel->numWhenStmts(); i++) {
+    auto when = sel->whenStmt(i);
+    if (seenOtherwise && !when->isOtherwise()) {
+      CHPL_REPORT(context_, WhenAfterOtherwise, sel, sel);
+    } 
+    seenOtherwise |= when->isOtherwise();
   }
 }
 

--- a/frontend/lib/uast/post-parse-checks.cpp
+++ b/frontend/lib/uast/post-parse-checks.cpp
@@ -1546,7 +1546,7 @@ void Visitor::visit(const Select* node) {
 
 void Visitor::checkOtherwiseAfterWhens(const Select* sel) {
   bool seenOtherwise = false;
-  for(size_t i = 0; i < sel->numWhenStmts(); i++) {
+  for(int i = 0; i < sel->numWhenStmts(); i++) {
     auto when = sel->whenStmt(i);
     if (seenOtherwise && !when->isOtherwise()) {
       CHPL_REPORT(context_, WhenAfterOtherwise, sel, sel);

--- a/frontend/lib/uast/post-parse-checks.cpp
+++ b/frontend/lib/uast/post-parse-checks.cpp
@@ -1545,13 +1545,14 @@ void Visitor::visit(const Select* node) {
 }
 
 void Visitor::checkOtherwiseAfterWhens(const Select* sel) {
-  bool seenOtherwise = false;
+  const When* seenOtherwise = nullptr;
   for(int i = 0; i < sel->numWhenStmts(); i++) {
     auto when = sel->whenStmt(i);
     if (seenOtherwise && !when->isOtherwise()) {
-      CHPL_REPORT(context_, WhenAfterOtherwise, sel, sel);
+      CHPL_REPORT(context_, WhenAfterOtherwise, sel, seenOtherwise, when);
+      break;
     } 
-    seenOtherwise |= when->isOtherwise();
+    if (when->isOtherwise())  seenOtherwise = when;
   }
 }
 

--- a/frontend/test/parsing/testParseSelect.cpp
+++ b/frontend/test/parsing/testParseSelect.cpp
@@ -197,7 +197,7 @@ static void test4(Parser* parser) {
   assert(mod->stmt(1)->isSelect());
   assert(mod->stmt(2)->isComment());
   auto& error = guard.error(0);
-  const char* expected = "otherwise clause must follow all when clauses";
+  const char* expected = "'otherwise' clause must follow all 'when' clauses";
   auto actual = error->message();
   assert(actual == expected);
   guard.clearErrors();

--- a/frontend/test/parsing/testParseSelect.cpp
+++ b/frontend/test/parsing/testParseSelect.cpp
@@ -197,9 +197,7 @@ static void test4(Parser* parser) {
   assert(mod->stmt(1)->isSelect());
   assert(mod->stmt(2)->isComment());
   auto& error = guard.error(0);
-  const char* expected = "'otherwise' clause must follow all 'when' clauses";
-  auto actual = error->message();
-  assert(actual == expected);
+  assert(error->type() == ErrorType::WhenAfterOtherwise);
   guard.clearErrors();
 }
 


### PR DESCRIPTION
To better match the documented behavior of `select` statements (control transfers to first match) and the natural language analogy of `select`-`when`-`otherwise`, and to simplify the compiler treatment of select statements, `otherwise` clauses are now required to come at the end of the `select` statements.

Pull request updates the documentation to match this and adds a post-parse check and tests for it.

Resolves #24030.

Tested locally

Reviewed by: @DanilaFe 