### PR TITLE
Fix failing stream performance tests following switch to PCG random number generator

### DIFF
--- a/test/studies/hpcc/STREAMS/bradc/stream-block1d-dom.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1d-dom.chpl
@@ -11,7 +11,7 @@ config const m = computeProblemSize(elemType, numVectors),
              alpha = 3.0;
 
 config const numTrials = 10,
-             epsilon = 0.0;
+             epsilon = 1e-15;
 
 config const useRandomSeed = true;
 

--- a/test/studies/hpcc/STREAMS/bradc/stream-block1d-local.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1d-local.chpl
@@ -11,7 +11,7 @@ config const m = computeProblemSize(elemType, numVectors),
              alpha = 3.0;
 
 config const numTrials = 10,
-             epsilon = 0.0;
+             epsilon = 1e-15;
 
 config const useRandomSeed = true;
 

--- a/test/studies/hpcc/STREAMS/bradc/stream-block1d.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1d.chpl
@@ -11,7 +11,7 @@ config const m = computeProblemSize(elemType, numVectors),
              alpha = 3.0;
 
 config const numTrials = 10,
-             epsilon = 0.0;
+             epsilon = 1e-15;
 
 config const useRandomSeed = true;
 

--- a/test/studies/hpcc/STREAMS/bradc/stream-block1dclass.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1dclass.chpl
@@ -11,7 +11,7 @@ config const m = computeProblemSize(elemType, numVectors),
              alpha = 3.0;
 
 config const numTrials = 10,
-             epsilon = 0.0;
+             epsilon = 1e-15;
 
 config const useRandomSeed = true;
 

--- a/test/studies/hpcc/STREAMS/bradc/stream-block1dpar-arr.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1dpar-arr.chpl
@@ -11,7 +11,7 @@ config const m = computeProblemSize(elemType, numVectors),
              alpha = 3.0;
 
 config const numTrials = 10,
-             epsilon = 0.0;
+             epsilon = 1e-15;
 
 config const useRandomSeed = true;
 

--- a/test/studies/hpcc/STREAMS/bradc/stream-block1dpar.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1dpar.chpl
@@ -11,7 +11,7 @@ config const m = computeProblemSize(elemType, numVectors),
              alpha = 3.0;
 
 config const numTrials = 10,
-             epsilon = 0.0;
+             epsilon = 1e-15;
 
 config const useRandomSeed = true;
 

--- a/test/studies/hpcc/STREAMS/bradc/stream-nopromote.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-nopromote.chpl
@@ -12,7 +12,7 @@ config const m = computeProblemSize(elemType, numVectors),
              alpha = 3.0;
 
 config const numTrials = 10,
-             epsilon = 0.0;
+             epsilon = 1e-15;
 
 config const useRandomSeed = true;
 

--- a/test/studies/hpcc/STREAMS/elliot/stream-spmd-barrier.chpl
+++ b/test/studies/hpcc/STREAMS/elliot/stream-spmd-barrier.chpl
@@ -17,7 +17,7 @@ config const m = computeProblemSize(elemType, numVectors),
              alpha = 3.0;
 
 config const numTrials = 10,
-             epsilon = 0.0;
+             epsilon = 1e-15;
 
 config const useRandomSeed = true;
 

--- a/test/studies/hpcc/STREAMS/elliot/stream-task-placement.chpl
+++ b/test/studies/hpcc/STREAMS/elliot/stream-task-placement.chpl
@@ -12,7 +12,7 @@ config const m = computeProblemSize(elemType, numVectors),
              alpha = 3.0;
 
 config const numTrials = 10,
-             epsilon = 0.0;
+             epsilon = 1e-15;
 
 config const useRandomSeed = true;
 

--- a/test/studies/hpcc/STREAMS/stream-nopromote.chpl
+++ b/test/studies/hpcc/STREAMS/stream-nopromote.chpl
@@ -10,7 +10,7 @@ config const m = computeProblemSize(elemType, numVectors),
              alpha = 3.0;
 
 config const numTrials = 10,
-             epsilon = 0.0;
+             epsilon = 1e-15;
 
 config const useRandomSeed = true;
 


### PR DESCRIPTION
Performance validation was failing for some of the STREAM benchmarks following https://github.com/chapel-lang/chapel/pull/24081. This was occuring in 32-bit testing and for some intel compiler configurations.

With the NPB random number generator, the benchmarks were able to pass with an epsilon of `0.0`; however, with the update to PCG, an epsilon of `1e-15` is required. (This is likely related to the fact that NPB creates random numbers that have exact floating point representations while PCG does not).

Note: under normal configurations (LLVM/gcc/clang on a 64-bit system), the STREAM tests that use promotion were also failing with the PCG rng for similar reasons. Those tests were already updated to use an epsilon of `1e-15` in the above mentioned PR. The remaining tests (those that don't use promotion) are only failing for 32-bit linux and intel-cc. Thus, this PR updates the remaining stream tests to use the larger epsilon value.

- [x] stream tests passing on 32-bit linux