### PR TITLE
Add support for GNU sed on Darwin

### DIFF
--- a/third-party/re2/re2-src/Makefile
+++ b/third-party/re2/re2-src/Makefile
@@ -35,7 +35,15 @@ INSTALL_DATA=$(INSTALL) -m 644
 
 # Work around the weirdness of sed(1) on Darwin. :/
 ifeq ($(shell uname),Darwin)
+# The BSD version of sed doesn't support --version and wants a space before
+# the suffix, the GNU version supports --version and doesn't want a space.
+ifeq ($(shell sed --version >/dev/null 2>&1; echo "$$?"),0)
+# GNU
+SED_INPLACE=sed -i''
+else
+# BSD
 SED_INPLACE=sed -i ''
+endif
 else ifeq ($(shell uname),SunOS)
 SED_INPLACE=sed -i
 else


### PR DESCRIPTION
GNU `sed` handles -i differently from BSD `sed` in that the former doesn't want a space before the suffix while the latter does. With the space GNU `sed` does not create `re2.pc` correctly.