### PR TITLE
Parse again on return key in `testInteractive`

### DIFF
--- a/frontend/test/resolution/testInteractive.cpp
+++ b/frontend/test/resolution/testInteractive.cpp
@@ -360,14 +360,16 @@ int main(int argc, char** argv) {
     int ch = 0;
     do {
       ch = getc(stdin);
-    } while (ch != 0 && (ch == ' '));
+    } while (ch != 0 && ch == ' ');
 
     if (ch == 'g' || ch == 'G') {
       gc = true;
-    } else if (!(ch == 'Y' || ch == 'y' || ch == '\n')) {
+    } else if (ch == 'Y' || ch == 'y' || ch == '\n') {
+      printf("\n");
+      continue;
+    } else {
       break;
     }
-    printf("\n");
   }
 
   return 0;

--- a/frontend/test/resolution/testInteractive.cpp
+++ b/frontend/test/resolution/testInteractive.cpp
@@ -360,7 +360,7 @@ int main(int argc, char** argv) {
     int ch = 0;
     do {
       ch = getc(stdin);
-    } while (ch != 0 && (ch == ' ' || ch == '\n'));
+    } while (ch != 0 && (ch == ' '));
 
     if (ch == 'g' || ch == 'G') {
       gc = true;


### PR DESCRIPTION
Adjusts the Dyno `parseInteractive` tool to re-run on `Return` input in addition to `Y`/`y`.

The tool runs once then prompts for input like so:
```
Would you like to incrementally parse again? [Y]:
```
To me the `[Y]` implies (by some familiar command-line tool convention) that `Y` is the default action if no input is specified, so I've always expected hitting return would cause it to run again. However, newlines are actually ignored as input, so hitting it does nothing; this seems like it might be unintentional since slightly further down in code we have `\n` written as one of the characters that would cause it to re-run, but that part of the condition isn't reachable. This PR changes the script to re-run on `\n` input.

I'll plan to bring this up to the Dyno team before merge since it might be disorienting or inconvenient for someone's workflow.

[reviewer info placeholder]

Testing:
- [x] `testInteractive` behaves correctly to input
- [x] dyno tests