### PR TITLE
Add type inferene for `_get_user_line` and `_get_user_file` prims. They're just ints!

### DIFF
--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -966,11 +966,13 @@ CallResolutionResult resolvePrimCall(Context* context,
     /* primitives that return default int */
     case PRIM_GET_UNION_ID:
     case PRIM_GET_REQUESTED_SUBLOC:
+    case PRIM_GET_USER_LINE:
       type = QualifiedType(QualifiedType::CONST_VAR,
                            IntType::get(context, 0));
       break;
     /* primitives that return an int32 */
     case PRIM_GETCID:
+    case PRIM_GET_USER_FILE:
       type = QualifiedType(QualifiedType::CONST_VAR,
                            IntType::get(context, 32));
       break;
@@ -1169,8 +1171,6 @@ CallResolutionResult resolvePrimCall(Context* context,
     case PRIM_PRIVATE_BROADCAST:
     case PRIM_CAPTURE_FN:
     case PRIM_CAPTURE_FN_TO_CLASS:
-    case PRIM_GET_USER_LINE:
-    case PRIM_GET_USER_FILE:
     case PRIM_RESOLUTION_POINT:
     case PRIM_FTABLE_CALL:
     case PRIM_GET_SVEC_MEMBER:

--- a/frontend/test/resolution/testRuntimePrimitives.cpp
+++ b/frontend/test/resolution/testRuntimePrimitives.cpp
@@ -296,6 +296,30 @@ static void test15() {
 }
 
 
+// "_get_user_line", which should return a default int.
+static void test16() {
+  Context ctx;
+  auto context = &ctx;
+  QualifiedType qt =  resolveTypeOfXInit(context,
+                         R"""(var x = __primitive("_get_user_line");)""");
+  assert(qt.kind() == QualifiedType::CONST_VAR);
+  auto typePtr = qt.type();
+  assert(typePtr);
+  assert(typePtr->isIntType() && typePtr->toIntType()->isDefaultWidth());
+}
+
+// "_get_user_file", which should return an int32
+static void test17() {
+  Context ctx;
+  auto context = &ctx;
+  QualifiedType qt =  resolveTypeOfXInit(context,
+                         R"""(var x = __primitive("_get_user_file");)""");
+  assert(qt.kind() == QualifiedType::CONST_VAR);
+  auto typePtr = qt.type();
+  assert(typePtr);
+  assert(typePtr->isIntType() && typePtr->toIntType()->bitwidth() == 32);
+}
+
 int main() {
   testVoidPrims();
   test1();
@@ -313,6 +337,8 @@ int main() {
   test13();
   test14();
   test15();
+  test16();
+  test17();
 
   return 0;
 }


### PR DESCRIPTION
Not sure how much more I have to say. The primitives are complicated in the backend, because we need to thread user line information throughout various functions as extra arguments. However, it seems like Dyno resolution need not concern itself with this.

Reviewed by @arezaii -- thanks!

## Testing
- [x] dyno tests
- [x] paratest