### PR TITLE
Add GPU primitives to Dyno

### DIFF
--- a/frontend/include/chpl/types/IntType.h
+++ b/frontend/include/chpl/types/IntType.h
@@ -45,16 +45,16 @@ class IntType final : public PrimitiveType {
 
   static const owned<IntType>& getIntType(Context* context, int bitwidth);
 
-  /** what is stored in bitwidth_ for the default 'int'? */
-  static int defaultBitwidth() {
-    return 64;
-  }
-
  public:
   ~IntType() = default;
 
   /** Get an integer type. Bitwidth 0 creates a default width int. */
   static const IntType* get(Context* context, int bitwidth);
+
+  /** what is stored in bitwidth_ for the default 'int'? */
+  static int defaultBitwidth() {
+    return 64;
+  }
 
   int bitwidth() const override {
     return bitwidth_;

--- a/frontend/include/chpl/types/Type.h
+++ b/frontend/include/chpl/types/Type.h
@@ -146,10 +146,20 @@ class Type {
 
   virtual void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const;
 
+  /** Check if this type is particular subclass. The call someType->is<IntType>()
+      returns whether or not someType is an IntType.
+   */
+  template <typename TargetType>
+  bool is() const = delete;
+
   // define is__ methods for the various Type subclasses
   // using macros and type-classes-list.h
   /// \cond DO_NOT_DOCUMENT
   #define TYPE_IS(NAME) \
+    template <> \
+    bool is<NAME>() const { \
+      return this->is##NAME(); \
+    } \
     bool is##NAME() const { \
       return typetags::is##NAME(this->tag_); \
     }
@@ -229,11 +239,29 @@ class Type {
    */
   const CompositeType* getCompositeType() const;
 
+  /** Try cast to a type known at compile-time. The call someType->to<IntType>()
+      returns nullptr if someType is not an IntType, and cast to IntType
+      if it is.
+   */
+  template <typename TargetType>
+  const TargetType* to() const = delete;
+
+  template <typename TargetType>
+  TargetType* to() = delete;
+
   // define to__ methods for the various Type subclasses
   // using macros and type-classes-list.h
   // Note: these offer equivalent functionality to C++ dynamic_cast<DstType*>
   /// \cond DO_NOT_DOCUMENT
   #define TYPE_TO(NAME) \
+    template <> \
+    const NAME * to<NAME>() const { \
+      return this->to##NAME(); \
+    } \
+    template <> \
+    NAME * to<NAME>() { \
+      return this->to##NAME(); \
+    } \
     const NAME * to##NAME() const { \
       return this->is##NAME() ? (const NAME *)this : nullptr; \
     } \

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -328,6 +328,29 @@ static QualifiedType primGpuAllocShared(Context* context, const CallInfo& ci) {
   return QualifiedType(QualifiedType::CONST_VAR, CPtrType::getCVoidPtrType(context));
 }
 
+static QualifiedType primGpuSetBlockSize(Context* context, const CallInfo& ci) {
+  if (ci.numActuals() != 1) return QualifiedType();
+
+  auto firstActualType = ci.actual(0).type();
+  if (!firstActualType.type() || !firstActualType.type()->isIntegralType()) {
+    return QualifiedType();
+  }
+
+  return QualifiedType(QualifiedType::CONST_VAR, VoidType::get(context));
+}
+
+static QualifiedType primAssertOnGpu(Context* context, const CallInfo& ci) {
+  if (ci.numActuals() != 1) return QualifiedType();
+
+  auto firstActualType = ci.actual(0).type();
+  if (!firstActualType.type() || !firstActualType.type()->isBoolType() ||
+      firstActualType.kind() != QualifiedType::PARAM || !firstActualType.param()) {
+    return QualifiedType();
+  }
+
+  return QualifiedType(QualifiedType::CONST_VAR, VoidType::get(context));
+}
+
 static QualifiedType primTypeof(Context* context, PrimitiveTag prim, const CallInfo& ci) {
   if (ci.numActuals() != 1) return QualifiedType();
 
@@ -1445,7 +1468,13 @@ CallResolutionResult resolvePrimCall(Context* context,
       break;
 
     case PRIM_GPU_SET_BLOCKSIZE:
+      type = primGpuSetBlockSize(context, ci);
+      break;
+
     case PRIM_ASSERT_ON_GPU:
+      type = primAssertOnGpu(context, ci);
+      break;
+
     case PRIM_GPU_ELIGIBLE:
     case PRIM_GPU_INIT_KERNEL_CFG:
     case PRIM_GPU_DEINIT_KERNEL_CFG:

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -1379,6 +1379,7 @@ CallResolutionResult resolvePrimCall(Context* context,
     case PRIM_ARRAY_SHIFT_BASE_POINTER:
     case PRIM_AUTO_DESTROY_RUNTIME_TYPE:
     case PRIM_CREATE_FN_TYPE:
+    case PRIM_GPU_SYNC_THREADS:
       type = QualifiedType(QualifiedType::CONST_VAR,
                            VoidType::get(context));
       break;
@@ -1443,7 +1444,6 @@ CallResolutionResult resolvePrimCall(Context* context,
       type = primGpuAllocShared(context, ci);
       break;
 
-    case PRIM_GPU_SYNC_THREADS:
     case PRIM_GPU_SET_BLOCKSIZE:
     case PRIM_ASSERT_ON_GPU:
     case PRIM_GPU_ELIGIBLE:

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -316,6 +316,18 @@ static QualifiedType primAddrOf(Context* context, const CallInfo& ci) {
   return QualifiedType(kp.toKind(), actualQt.type());
 }
 
+static QualifiedType primGpuAllocShared(Context* context, const CallInfo& ci) {
+  if (ci.numActuals() != 1) return QualifiedType();
+
+  auto firstActualType = ci.actual(0).type();
+  if (!firstActualType.type() || !firstActualType.type()->isIntType() ||
+      firstActualType.kind() != QualifiedType::PARAM || !firstActualType.param()) {
+    return QualifiedType();
+  }
+
+  return QualifiedType(QualifiedType::CONST_VAR, CPtrType::getCVoidPtrType(context));
+}
+
 static QualifiedType primTypeof(Context* context, PrimitiveTag prim, const CallInfo& ci) {
   if (ci.numActuals() != 1) return QualifiedType();
 
@@ -1424,7 +1436,13 @@ CallResolutionResult resolvePrimCall(Context* context,
     case PRIM_GET_DYNAMIC_END_COUNT:
     case PRIM_GPU_KERNEL_LAUNCH:
     case PRIM_GPU_KERNEL_LAUNCH_FLAT:
+      CHPL_UNIMPL("misc primitives");
+      break;
+
     case PRIM_GPU_ALLOC_SHARED:
+      type = primGpuAllocShared(context, ci);
+      break;
+
     case PRIM_GPU_SYNC_THREADS:
     case PRIM_GPU_SET_BLOCKSIZE:
     case PRIM_ASSERT_ON_GPU:

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -1283,6 +1283,18 @@ CallResolutionResult resolvePrimCall(Context* context,
     /* primitives that return an int32 */
     case PRIM_GETCID:
     case PRIM_GET_USER_FILE:
+    case PRIM_GPU_THREADIDX_X:
+    case PRIM_GPU_THREADIDX_Y:
+    case PRIM_GPU_THREADIDX_Z:
+    case PRIM_GPU_BLOCKIDX_X:
+    case PRIM_GPU_BLOCKIDX_Y:
+    case PRIM_GPU_BLOCKIDX_Z:
+    case PRIM_GPU_BLOCKDIM_X:
+    case PRIM_GPU_BLOCKDIM_Y:
+    case PRIM_GPU_BLOCKDIM_Z:
+    case PRIM_GPU_GRIDDIM_X:
+    case PRIM_GPU_GRIDDIM_Y:
+    case PRIM_GPU_GRIDDIM_Z:
       type = QualifiedType(QualifiedType::CONST_VAR,
                            IntType::get(context, 32));
       break;
@@ -1412,18 +1424,6 @@ CallResolutionResult resolvePrimCall(Context* context,
     case PRIM_GET_DYNAMIC_END_COUNT:
     case PRIM_GPU_KERNEL_LAUNCH:
     case PRIM_GPU_KERNEL_LAUNCH_FLAT:
-    case PRIM_GPU_THREADIDX_X:
-    case PRIM_GPU_THREADIDX_Y:
-    case PRIM_GPU_THREADIDX_Z:
-    case PRIM_GPU_BLOCKIDX_X:
-    case PRIM_GPU_BLOCKIDX_Y:
-    case PRIM_GPU_BLOCKIDX_Z:
-    case PRIM_GPU_BLOCKDIM_X:
-    case PRIM_GPU_BLOCKDIM_Y:
-    case PRIM_GPU_BLOCKDIM_Z:
-    case PRIM_GPU_GRIDDIM_X:
-    case PRIM_GPU_GRIDDIM_Y:
-    case PRIM_GPU_GRIDDIM_Z:
     case PRIM_GPU_ALLOC_SHARED:
     case PRIM_GPU_SYNC_THREADS:
     case PRIM_GPU_SET_BLOCKSIZE:

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -1402,7 +1402,12 @@ CallResolutionResult resolvePrimCall(Context* context,
     case PRIM_ARRAY_SHIFT_BASE_POINTER:
     case PRIM_AUTO_DESTROY_RUNTIME_TYPE:
     case PRIM_CREATE_FN_TYPE:
+    case PRIM_GPU_KERNEL_LAUNCH:
+    case PRIM_GPU_KERNEL_LAUNCH_FLAT:
     case PRIM_GPU_SYNC_THREADS:
+    case PRIM_GPU_ELIGIBLE:
+    case PRIM_GPU_DEINIT_KERNEL_CFG:
+    case PRIM_GPU_ARG:
       type = QualifiedType(QualifiedType::CONST_VAR,
                            VoidType::get(context));
       break;
@@ -1458,8 +1463,6 @@ CallResolutionResult resolvePrimCall(Context* context,
     case PRIM_SET_REFERENCE:
     case PRIM_GET_END_COUNT:
     case PRIM_GET_DYNAMIC_END_COUNT:
-    case PRIM_GPU_KERNEL_LAUNCH:
-    case PRIM_GPU_KERNEL_LAUNCH_FLAT:
       CHPL_UNIMPL("misc primitives");
       break;
 
@@ -1475,10 +1478,10 @@ CallResolutionResult resolvePrimCall(Context* context,
       type = primAssertOnGpu(context, ci);
       break;
 
-    case PRIM_GPU_ELIGIBLE:
     case PRIM_GPU_INIT_KERNEL_CFG:
-    case PRIM_GPU_DEINIT_KERNEL_CFG:
-    case PRIM_GPU_ARG:
+      type = QualifiedType(QualifiedType::CONST_VAR, CPtrType::getCVoidPtrType(context));
+      break;
+
     case PRIM_SIZEOF_BUNDLE:
     case PRIM_SIZEOF_DDATA_ELEMENT:
     case PRIM_LIFETIME_OF:

--- a/frontend/test/resolution/testRuntimePrimitives.cpp
+++ b/frontend/test/resolution/testRuntimePrimitives.cpp
@@ -225,6 +225,18 @@ static void test20() {
   primTypeHelper<VoidType>("gpu syncThreads", {});
 }
 
+static void test21() {
+  primTypeHelper<VoidType>("chpl_assert_on_gpu", {"true"});
+  primTypeHelper<VoidType>("chpl_assert_on_gpu", {"false"});
+  primTypeHelper<ErroneousType>("chpl_assert_on_gpu", {"v"}, "var v: bool;", QualifiedType::UNKNOWN);
+}
+
+static void test22() {
+  primTypeHelper<VoidType>("gpu set blockSize", {"128"});
+  primTypeHelper<VoidType>("gpu set blockSize", {"v"}, "var v = 128;");
+  primTypeHelper<ErroneousType>("gpu set blockSize", {"v"}, "var v: string;", QualifiedType::UNKNOWN);
+}
+
 int main() {
   testVoidPrims();
   test1();
@@ -247,6 +259,8 @@ int main() {
   test18();
   test19();
   test20();
+  test21();
+  test22();
 
   return 0;
 }

--- a/frontend/test/resolution/testRuntimePrimitives.cpp
+++ b/frontend/test/resolution/testRuntimePrimitives.cpp
@@ -21,303 +21,179 @@
 
 #include "chpl/types/all-types.h"
 
-
-static void voidTypeTestHelper(std::string program) {
+template <typename F>
+static void predicatePrimTypeHelper(const char* primName, std::vector<const char*> args,
+                                    F&& predicate,
+                                    const char* prelude = "",
+                                    QualifiedType::Kind expectedKind = QualifiedType::CONST_VAR) {
+  std::string program = prelude;
+  program += "var x = __primitive(\"";
+  program += primName;
+  program += "\"";
+  for (auto arg : args) {
+    program += ", ";
+    program += arg;
+  }
+  program += ");";
   Context ctx;
   auto context = &ctx;
-  QualifiedType qt =  resolveTypeOfXInit(context, program);
-  assert(qt.kind() == QualifiedType::CONST_VAR);
+  QualifiedType qt =  resolveTypeOfXInit(context, std::move(program));
+  assert(qt.kind() == expectedKind);
   auto typePtr = qt.type();
   assert(typePtr);
-  assert(typePtr->isVoidType());
+  assert(predicate(typePtr, qt.param()));
+}
+
+template <typename T>
+static void primTypeHelper(const char* primName, std::vector<const char*> args, const char* prelude = "", QualifiedType::Kind expectedKind = QualifiedType::CONST_VAR) {
+  predicatePrimTypeHelper(primName, args, [](const Type* typePtr, const Param* param) {
+    return typePtr->is<T>();
+  }, prelude, expectedKind);
+}
+
+static void intPrimTypeHelper(int width, const char* primName, std::vector<const char*> args, const char* prelude = "", QualifiedType::Kind expectedKind = QualifiedType::CONST_VAR) {
+  predicatePrimTypeHelper(primName, args, [width](const Type* typePtr, const Param* param) {
+    return typePtr->isIntType() && typePtr->toIntType()->bitwidth() == width;
+  }, prelude, expectedKind);
+}
+
+static void realPrimTypeHelper(int width, const char* primName, std::vector<const char*> args, const char* prelude = "", QualifiedType::Kind expectedKind = QualifiedType::CONST_VAR) {
+  predicatePrimTypeHelper(primName, args, [width](const Type* typePtr, const Param* param) {
+    return typePtr->isRealType() && typePtr->toRealType()->bitwidth() == width;
+  }, prelude, expectedKind);
 }
 
 // tests for primitives that should return void
 static void testVoidPrims() {
   // test for primitive "chpl_init_record"
-  voidTypeTestHelper(R"""(var x = __primitive("chpl_init_record");)""");
+  primTypeHelper<VoidType>("chpl_init_record", {});
 
   // test for primitive "chpl_comm_get"
-  voidTypeTestHelper(R"""(var x = __primitive("chpl_comm_get");)""");
+  primTypeHelper<VoidType>("chpl_comm_get", {});
 
   // test for primitive "chpl_comm_put"
-  voidTypeTestHelper(R"""(var x = __primitive("chpl_comm_put");)""");
+  primTypeHelper<VoidType>("chpl_comm_put", {});
 
   // test for primitive "chpl_comm_array_get"
-  voidTypeTestHelper(R"""(var x = __primitive("chpl_comm_array_get");)""");
+  primTypeHelper<VoidType>("chpl_comm_array_get", {});
 
   // test for primitive "chpl_comm_array_put"
-  voidTypeTestHelper(R"""(var x = __primitive("chpl_comm_array_put");)""");
+  primTypeHelper<VoidType>("chpl_comm_array_put", {});
 
   // test for primitive "chpl_comm_remote_prefetch"
-  voidTypeTestHelper(R"""(var x = __primitive("chpl_comm_remote_prefetch");)""");
+  primTypeHelper<VoidType>("chpl_comm_remote_prefetch", {});
 
   // test for primitive "chpl_comm_get_strd"
-  voidTypeTestHelper(R"""(var x = __primitive("chpl_comm_get_strd");)""");
+  primTypeHelper<VoidType>("chpl_comm_get_strd", {});
 
   // test for primitive "chpl_comm_put_strd"
-  voidTypeTestHelper(R"""(var x = __primitive("chpl_comm_put_strd");)""");
+  primTypeHelper<VoidType>("chpl_comm_put_strd", {});
 
   // test for primitive "shift_base_pointer"
-  voidTypeTestHelper(R"""(var x = __primitive("shift_base_pointer");)""");
+  primTypeHelper<VoidType>("shift_base_pointer", {});
 
   // test for primitive "array_set"
-  voidTypeTestHelper(R"""(var x = __primitive("array_set");)""");
+  primTypeHelper<VoidType>("array_set", {});
 
   // test for primitive "array_set_first"
-  voidTypeTestHelper(R"""(var x = __primitive("array_set_first");)""");
+  primTypeHelper<VoidType>("array_set_first", {});
 
   // test for primitive "auto destroy runtime type"
-  voidTypeTestHelper(R"""(var x = __primitive("auto destroy runtime type");)""");
+  primTypeHelper<VoidType>("auto destroy runtime type", {});
 
   // test for primitive "create fn type"
-  voidTypeTestHelper(R"""(var x = __primitive("create fn type");)""");
+  primTypeHelper<VoidType>("create fn type", {});
 }
 
 // test that we can handle non-param string for string_length_bytes
 static void test1() {
-  Context ctx;
-  auto context = &ctx;
-  QualifiedType qt =  resolveTypeOfXInit(context,
-                         R""""(
-                           var s:string;
-                           var x = __primitive("string_length_bytes", s);
-                         )"""");
-  assert(qt.kind() == QualifiedType::CONST_VAR);
-  auto typePtr = qt.type();
-  assert(typePtr);
-  assert(typePtr->isIntType());
-  assert(typePtr->toIntType()->bitwidth() == 64);
+  intPrimTypeHelper(IntType::defaultBitwidth(), "string_length_bytes", {"s"}, "var s: string;");
 }
 
 // test that we can handle non-param bytes for string_length_bytes
 static void test2() {
-  Context ctx;
-  auto context = &ctx;
-  QualifiedType qt =  resolveTypeOfXInit(context,
-                         R""""(
-                           var b:bytes;
-                           var x = __primitive("string_length_bytes", b);
-                         )"""");
-  assert(qt.kind() == QualifiedType::CONST_VAR);
-  auto typePtr = qt.type();
-  assert(typePtr);
-  assert(typePtr->isIntType());
-  assert(typePtr->toIntType()->bitwidth() == 64);
+  intPrimTypeHelper(IntType::defaultBitwidth(), "string_length_bytes", {"b"}, "var b: bytes;");
 }
 
 static void test3() {
   // test for primitive return type for get real/imag
-  Context ctx;
-  auto context = &ctx;
-  QualifiedType qt =  resolveTypeOfXInit(context,
-                         R""""(
-                           var a: complex(128);
-                           var x = __primitive("complex_get_real", a);
-                         )"""");
-  assert(qt.kind() == QualifiedType::REF);
-  auto typePtr = qt.type();
-  assert(typePtr);
-  auto realPtr = typePtr->toRealType();
-  assert(realPtr->bitwidth()==64);
+  realPrimTypeHelper(64, "complex_get_real", {"a"}, "var a: complex(128);", QualifiedType::REF);
 }
 
 static void test4() {
   // test for primitive return type for get real/imag
-  Context ctx;
-  auto context = &ctx;
-  QualifiedType qt =  resolveTypeOfXInit(context,
-                         R""""(
-                           var a: complex(64);
-                           var x = __primitive("complex_get_real", a);
-                         )"""");
-  assert(qt.kind() == QualifiedType::REF);
-  auto typePtr = qt.type();
-  assert(typePtr);
-  auto realPtr = typePtr->toRealType();
-  assert(realPtr->bitwidth()==32);
+  realPrimTypeHelper(32, "complex_get_real", {"a"}, "var a: complex(64);", QualifiedType::REF);
 }
 
 static void test5() {
   // test for primitive return type for get real/imag
-  Context ctx;
-  auto context = &ctx;
-  QualifiedType qt =  resolveTypeOfXInit(context,
-                         R""""(
-                           var a: complex(128);
-                           var x = __primitive("complex_get_imag", a);
-                         )"""");
-  assert(qt.kind() == QualifiedType::REF);
-  auto typePtr = qt.type();
-  assert(typePtr);
-  auto realPtr = typePtr->toRealType();
-  assert(realPtr->bitwidth()==64);
+  realPrimTypeHelper(64, "complex_get_imag", {"a"}, "var a: complex(128);", QualifiedType::REF);
 }
 
 static void test6() {
   // test for primitive return type for get real/imag
-  Context ctx;
-  auto context = &ctx;
-  QualifiedType qt =  resolveTypeOfXInit(context,
-                         R""""(
-                           var a: complex(64);
-                           var x = __primitive("complex_get_imag", a);
-                         )"""");
-  assert(qt.kind() == QualifiedType::REF);
-  auto typePtr = qt.type();
-  assert(typePtr);
-  auto realPtr = typePtr->toRealType();
-  assert(realPtr->bitwidth()==32);
+  realPrimTypeHelper(32, "complex_get_imag", {"a"}, "var a: complex(64);", QualifiedType::REF);
 }
 
 static void test7() {
   // test for primitive "is wide pointer", which should return a bool
-  Context ctx;
-  auto context = &ctx;
-  QualifiedType qt =  resolveTypeOfXInit(context,
-                         R""""(
-                           var x = __primitive("is wide pointer");
-                         )"""");
-  assert(qt.kind() == QualifiedType::CONST_VAR);
-  auto typePtr = qt.type();
-  assert(typePtr);
-  assert(typePtr->isBoolType());
+  primTypeHelper<BoolType>("is wide pointer", {});
 }
 
 // test for primitive "_wide_get_addr", which should return a void ptr
 static void test8() {
-  Context ctx;
-  auto context = &ctx;
-  QualifiedType qt =  resolveTypeOfXInit(context,
-                         R""""(
-                           var x = __primitive("_wide_get_addr");
-                         )"""");
-  assert(qt.kind() == QualifiedType::CONST_VAR);
-  auto typePtr = qt.type();
-  assert(typePtr);
-  auto cPtrType = typePtr->toCPtrType();
-  assert(cPtrType);
-  assert(cPtrType->isVoidPtr());
+  predicatePrimTypeHelper("_wide_get_addr", {}, [](const Type* typePtr, const Param* param) {
+    return typePtr->isCPtrType() && typePtr->toCPtrType()->isVoidPtr();
+  });
 }
 
 // test for primitive "steal", which should return the type of the argument
 static void test9() {
-  Context ctx;
-  auto context = &ctx;
-  QualifiedType qt =  resolveTypeOfXInit(context,
-                         R""""(
-                           var a = 1;
-                           var x = __primitive("steal", a);
-                         )"""");
-  assert(qt.kind() == QualifiedType::CONST_VAR);
-  auto typePtr = qt.type();
-  assert(typePtr);
-  assert(typePtr->isIntType());
+  intPrimTypeHelper(IntType::defaultBitwidth(), "steal", {"v"}, "var v: int;");
+  primTypeHelper<BoolType>("steal", {"v"}, "var v: bool;");
+  realPrimTypeHelper(32, "steal", {"v"}, "var v: real(32);");
+  realPrimTypeHelper(64, "steal", {"v"}, "var v: real(64);");
 }
 
 // test for primitive "getcid", which should return an int32
 static void test10() {
-  Context ctx;
-  auto context = &ctx;
-  QualifiedType qt =  resolveTypeOfXInit(context,
-                         R""""(
-                           var x = __primitive("getcid");
-                         )"""");
-  assert(qt.kind() == QualifiedType::CONST_VAR);
-  auto typePtr = qt.type();
-  assert(typePtr);
-  assert(typePtr->isIntType());
-  assert(typePtr->toIntType()->bitwidth() == 32);
+  intPrimTypeHelper(32, "getcid", {});
 }
 
 // test for primitive "get_union_id", which should return a default int
 static void test11() {
-  Context ctx;
-  auto context = &ctx;
-  QualifiedType qt =  resolveTypeOfXInit(context,
-                         R""""(
-                           var x = __primitive("get_union_id");
-                         )"""");
-  assert(qt.kind() == QualifiedType::CONST_VAR);
-  auto typePtr = qt.type();
-  assert(typePtr);
-  assert(typePtr->isIntType());
-  assert(typePtr->toIntType()->bitwidth() == 64);
+  intPrimTypeHelper(IntType::defaultBitwidth(), "get_union_id", {});
 }
-
 
 // "chpl_task_getRequestedSubloc", which should return int 64
 static void test12() {
-  Context ctx;
-  auto context = &ctx;
-  QualifiedType qt =  resolveTypeOfXInit(context,
-                         R"""(var x = __primitive("chpl_task_getRequestedSubloc");)""");
-  assert(qt.kind() == QualifiedType::CONST_VAR);
-  auto typePtr = qt.type();
-  assert(typePtr);
-  assert(typePtr->isIntType());
-  assert(typePtr->toIntType()->bitwidth() == 64);
+  intPrimTypeHelper(64, "chpl_task_getRequestedSubloc", {});
 }
 
 // "class name by id", which should return a cString
 static void test13() {
-  Context ctx;
-  auto context = &ctx;
-  QualifiedType qt =  resolveTypeOfXInit(context,
-                         R"""(var x = __primitive("class name by id");)""");
-  assert(qt.kind() == QualifiedType::CONST_VAR);
-  auto typePtr = qt.type();
-  assert(typePtr);
-  assert(typePtr->isCStringType());
+  primTypeHelper<CStringType>("class name by id", {});
 }
 
 // "ref to string", which should return a cString
 static void test14() {
-  Context ctx;
-  auto context = &ctx;
-  QualifiedType qt =  resolveTypeOfXInit(context,
-                         R"""(var x = __primitive("ref to string");)""");
-  assert(qt.kind() == QualifiedType::CONST_VAR);
-  auto typePtr = qt.type();
-  assert(typePtr);
-  assert(typePtr->isCStringType());
+  primTypeHelper<CStringType>("ref to string", {});
 }
 
 // "chpl_lookupFilename", which should return a cString
 static void test15() {
-  Context ctx;
-  auto context = &ctx;
-  QualifiedType qt =  resolveTypeOfXInit(context,
-                         R"""(var x = __primitive("chpl_lookupFilename");)""");
-  assert(qt.kind() == QualifiedType::CONST_VAR);
-  auto typePtr = qt.type();
-  assert(typePtr);
-  assert(typePtr->isCStringType());
+  primTypeHelper<CStringType>("chpl_lookupFilename", {});
 }
 
 
 // "_get_user_line", which should return a default int.
 static void test16() {
-  Context ctx;
-  auto context = &ctx;
-  QualifiedType qt =  resolveTypeOfXInit(context,
-                         R"""(var x = __primitive("_get_user_line");)""");
-  assert(qt.kind() == QualifiedType::CONST_VAR);
-  auto typePtr = qt.type();
-  assert(typePtr);
-  assert(typePtr->isIntType() && typePtr->toIntType()->isDefaultWidth());
+  intPrimTypeHelper(IntType::defaultBitwidth(), "_get_user_line", {});
 }
 
 // "_get_user_file", which should return an int32
 static void test17() {
-  Context ctx;
-  auto context = &ctx;
-  QualifiedType qt =  resolveTypeOfXInit(context,
-                         R"""(var x = __primitive("_get_user_file");)""");
-  assert(qt.kind() == QualifiedType::CONST_VAR);
-  auto typePtr = qt.type();
-  assert(typePtr);
-  assert(typePtr->isIntType() && typePtr->toIntType()->bitwidth() == 32);
+  intPrimTypeHelper(32, "_get_user_file", {});
 }
 
 int main() {

--- a/frontend/test/resolution/testRuntimePrimitives.cpp
+++ b/frontend/test/resolution/testRuntimePrimitives.cpp
@@ -221,6 +221,10 @@ static void test19() {
   primTypeHelper<ErroneousType>("gpu allocShared", {"v"}, "var v = 1024;", QualifiedType::UNKNOWN);
 }
 
+static void test20() {
+  primTypeHelper<VoidType>("gpu syncThreads", {});
+}
+
 int main() {
   testVoidPrims();
   test1();
@@ -242,6 +246,7 @@ int main() {
   test17();
   test18();
   test19();
+  test20();
 
   return 0;
 }

--- a/frontend/test/resolution/testRuntimePrimitives.cpp
+++ b/frontend/test/resolution/testRuntimePrimitives.cpp
@@ -63,6 +63,12 @@ static void realPrimTypeHelper(int width, const char* primName, std::vector<cons
   }, prelude, expectedKind);
 }
 
+static void voidPtrPrimTypeHelper(const char* primName, std::vector<const char*> args, const char* prelude = "", QualifiedType::Kind expectedKind = QualifiedType::CONST_VAR) {
+  predicatePrimTypeHelper(primName, args, [](const Type* typePtr, const Param* param) {
+    return typePtr->isCPtrType() && typePtr->toCPtrType()->isVoidPtr();
+  }, prelude, expectedKind);
+}
+
 // tests for primitives that should return void
 static void testVoidPrims() {
   // test for primitive "chpl_init_record"
@@ -142,9 +148,7 @@ static void test7() {
 
 // test for primitive "_wide_get_addr", which should return a void ptr
 static void test8() {
-  predicatePrimTypeHelper("_wide_get_addr", {}, [](const Type* typePtr, const Param* param) {
-    return typePtr->isCPtrType() && typePtr->toCPtrType()->isVoidPtr();
-  });
+  voidPtrPrimTypeHelper("_wide_get_addr", {});
 }
 
 // test for primitive "steal", which should return the type of the argument
@@ -211,6 +215,12 @@ static void test18() {
   intPrimTypeHelper(32, "gpu gridDim z", {});
 }
 
+static void test19() {
+  voidPtrPrimTypeHelper("gpu allocShared", {"512"});
+  voidPtrPrimTypeHelper("gpu allocShared", {"1024"});
+  primTypeHelper<ErroneousType>("gpu allocShared", {"v"}, "var v = 1024;", QualifiedType::UNKNOWN);
+}
+
 int main() {
   testVoidPrims();
   test1();
@@ -231,6 +241,7 @@ int main() {
   test16();
   test17();
   test18();
+  test19();
 
   return 0;
 }

--- a/frontend/test/resolution/testRuntimePrimitives.cpp
+++ b/frontend/test/resolution/testRuntimePrimitives.cpp
@@ -237,6 +237,20 @@ static void test22() {
   primTypeHelper<ErroneousType>("gpu set blockSize", {"v"}, "var v: string;", QualifiedType::UNKNOWN);
 }
 
+static void test23() {
+  // Much like the primitives Ahmad added earlier, these will not be checked
+  // for proper arguments etc. since they are added late during compilation
+  // (after LICM at the time of writing) and thus would not be typechecked
+  // by Dyno anyway.
+
+  primTypeHelper<VoidType>("gpu kernel launch", {});
+  primTypeHelper<VoidType>("gpu kernel launch flat", {});
+  primTypeHelper<VoidType>("gpu eligible", {});
+  voidPtrPrimTypeHelper("gpu init kernel cfg", {});
+  primTypeHelper<VoidType>("gpu deinit kernel cfg", {});
+  primTypeHelper<VoidType>("gpu arg", {});
+}
+
 int main() {
   testVoidPrims();
   test1();
@@ -261,6 +275,7 @@ int main() {
   test20();
   test21();
   test22();
+  test23();
 
   return 0;
 }

--- a/frontend/test/resolution/testRuntimePrimitives.cpp
+++ b/frontend/test/resolution/testRuntimePrimitives.cpp
@@ -185,7 +185,6 @@ static void test15() {
   primTypeHelper<CStringType>("chpl_lookupFilename", {});
 }
 
-
 // "_get_user_line", which should return a default int.
 static void test16() {
   intPrimTypeHelper(IntType::defaultBitwidth(), "_get_user_line", {});
@@ -194,6 +193,22 @@ static void test16() {
 // "_get_user_file", which should return an int32
 static void test17() {
   intPrimTypeHelper(32, "_get_user_file", {});
+}
+
+// various GPU x/y/z primitives, which all return int(32).
+static void test18() {
+  intPrimTypeHelper(32, "gpu threadIdx x", {});
+  intPrimTypeHelper(32, "gpu threadIdx y", {});
+  intPrimTypeHelper(32, "gpu threadIdx z", {});
+  intPrimTypeHelper(32, "gpu blockIdx x", {});
+  intPrimTypeHelper(32, "gpu blockIdx y", {});
+  intPrimTypeHelper(32, "gpu blockIdx z", {});
+  intPrimTypeHelper(32, "gpu blockDim x", {});
+  intPrimTypeHelper(32, "gpu blockDim y", {});
+  intPrimTypeHelper(32, "gpu blockDim z", {});
+  intPrimTypeHelper(32, "gpu gridDim x", {});
+  intPrimTypeHelper(32, "gpu gridDim y", {});
+  intPrimTypeHelper(32, "gpu gridDim z", {});
 }
 
 int main() {
@@ -215,6 +230,7 @@ int main() {
   test15();
   test16();
   test17();
+  test18();
 
   return 0;
 }


### PR DESCRIPTION
This PR adds GPU primitives to Dyno. While there, it also modifies the code for testing primitives to considerably clean it up, and adds new `to` methods to types to make it possible to use them from a templated context. 

### The new 'to' methods
The `toWhateverType` methods on types and AST nodes a great, but a problem with them is that the target of the conversion is encoded in the name. Thus, it's impossible to e.g., accept a general AST node type as a template parameter, and then call the appropriate `toWhatever` method on it. I've hit this a couple of times before, and decided to improve the situation.

The situation is improved by adding a new `to<TargetType>` template, which makes it possible to perform a cast from a base type to a subclass type given by a template argument. The template `to<Whatever>` simply calls `toWhatever()`. I added similar overloads for `is`.

### Cleaned up primitive test methods
All the runtime primitive testing code calls some primitive, and then checks that the return type is _something_. Thus, I added a general helper that contains building the test program, creating the context, and performing the type checking. This helper, `predicatePrimTypeHelper`, accepts a predicate (either a C++ lambda or a function pointer), and runs it on the result of type checking. In combination with the `is<Type>` and `to<Type>` helpers, this makes it possible to write one-line tests for practically ever test case.

### Added GPU primitives
I've added handling for GPU primitives to dyno, tested using the new helpers above. For primitives accessible from Chapel code (i.e., from standard library functions that invoke the primitives), I added a rudimentary level of error checking (ensuring that something is a param, checking the number of arguments, etc.). This was because I had previously hit compiler segfaults when misusing the primitives, and an error message would be nicer. For other primitives, inserted during the `gpuTransforms` pass, I added only the return types, without any error checking.

Reviewed by @arezaii -- thanks!

# Testing
- [x] dyno tests
- [x] paratest