### PR TITLE
Split issue 6188 future to a passing llvm test and a non-llvm future

### DIFF
--- a/test/compflags/checks/checkModByZeroScope-llvm-none.chpl
+++ b/test/compflags/checks/checkModByZeroScope-llvm-none.chpl
@@ -1,0 +1,8 @@
+/* Future for scoped modulus zero error message */
+
+{
+  var numint = 10,
+      denomint = 0;
+
+  writeln(numint % denomint);
+}

--- a/test/compflags/checks/checkModByZeroScope-llvm-none.future
+++ b/test/compflags/checks/checkModByZeroScope-llvm-none.future
@@ -13,3 +13,7 @@ writeln_chpl2(((int64_t)((INT64(10) % INT64(0)))), INT64(7), INT32(51));
 This is caused by an optimization where code gen effectively treats variables
 as params where appropriate, within a scoped section. See the related issue for
 more information.
+
+This test works with the llvm backend.  When this future passes, it
+may be removed entirely in favor of removing the
+checkModByZeroScope.skipif file.

--- a/test/compflags/checks/checkModByZeroScope-llvm-none.future
+++ b/test/compflags/checks/checkModByZeroScope-llvm-none.future
@@ -1,4 +1,5 @@
 error message: Scoped modulus zero
+#6188
 
 At the time of this writing, this test yields the following output from the
 backend compiler:

--- a/test/compflags/checks/checkModByZeroScope-llvm-none.good
+++ b/test/compflags/checks/checkModByZeroScope-llvm-none.good
@@ -1,0 +1,1 @@
+checkModByZeroScope-llvm-none.chpl:7: error: halt reached - Attempt to compute a modulus by zero

--- a/test/compflags/checks/checkModByZeroScope-llvm-none.skipif
+++ b/test/compflags/checks/checkModByZeroScope-llvm-none.skipif
@@ -1,0 +1,1 @@
+CHPL_LLVM!=none

--- a/test/compflags/checks/checkModByZeroScope.good
+++ b/test/compflags/checks/checkModByZeroScope.good
@@ -1,1 +1,1 @@
-checkDivByZero.chpl:7: error: halt reached - Attempt to divide by zero
+checkModByZeroScope.chpl:7: error: halt reached - Attempt to compute a modulus by zero

--- a/test/compflags/checks/checkModByZeroScope.skipif
+++ b/test/compflags/checks/checkModByZeroScope.skipif
@@ -1,0 +1,1 @@
+CHPL_LLVM==none

--- a/test/compflags/checks/checkModByZeroScope.skipif
+++ b/test/compflags/checks/checkModByZeroScope.skipif
@@ -1,1 +1,3 @@
+# Currently this fails under gcc, see ./checkModByZeroScope-llvm-none.future
 CHPL_LLVM==none
+CHPL_TARGET_COMPILER==gnu


### PR DESCRIPTION
The checkModByZeroScope test for #6188 works under llvm, but still hits the backend C error under gcc.  Split the non-llvm version out to its own future.

Update the checkModByZeroScope.good file to have the correct filename and error message so that it's detected as passing.
