### PR TITLE
Generalize NIC selection

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1464,6 +1464,11 @@ struct fi_info* findProvInList(struct fi_info* info,
         inAddr.device = pci->device_id;
         inAddr.function = pci->function_id;
         addr = chpl_topo_selectNicByType(&inAddr, &pciAddr);
+        if (addr == NULL) {
+          // warn that something went wrong, but use this NIC so we don't
+          // come to a halt.
+          chpl_warning("internal error finding NIC in topology", 0, 0);
+        }
         // Remember this NIC in case the NIC suggested by the topology layer
         // isn't in the list of infos, in which case we'll use this one.
         best = info;

--- a/runtime/src/topo/hwloc/topo-hwloc.c
+++ b/runtime/src/topo/hwloc/topo-hwloc.c
@@ -103,6 +103,10 @@ static hwloc_obj_t root = NULL;
 // Our socket, if applicable.
 static hwloc_obj_t socket = NULL;
 
+// Logical CPU sets for all locales on this node. Entries are NULL if
+// we don't have that info.
+static hwloc_cpuset_t *logAccSets = NULL;
+
 
 static hwloc_obj_t getNumaObj(c_sublocid_t);
 static void alignAddrSize(void*, size_t, chpl_bool,
@@ -259,6 +263,15 @@ void chpl_topo_exit(void) {
     logAccMask = NULL;
   }
 
+  if (logAccSets != NULL) {
+    for (int i = 0; i < chpl_get_num_locales_on_node(); i++) {
+      if (logAccSets[i] != NULL) {
+        hwloc_bitmap_free(logAccSets[i]);
+      }
+    }
+    sys_free(logAccSets);
+    logAccSets = NULL;
+  }
   hwloc_topology_destroy(topology);
 }
 
@@ -312,10 +325,8 @@ static void filterPUsByKind(int numKinds, chpl_bool *ignoreKinds,
       if (debug) {
         char buf[1024];
         hwloc_bitmap_list_snprintf(buf, sizeof(buf), pu->cpuset);
-        _DBG_P("filterPUsByKind PU cpuset: %s", buf);
       }
       int kind = hwloc_cpukinds_get_by_cpuset(topology, pu->cpuset, 0);
-      _DBG_P("kind = %d, numKinds = %d", kind, numKinds);
       CHK_ERR_ERRNO((kind >= 0) && (kind < numKinds));
       if (ignoreKinds[kind]) {
         hwloc_bitmap_andnot(cpuset, cpuset, pu->cpuset);
@@ -379,6 +390,11 @@ static void cpuInfoInit(void) {
   // accessible PUs
 
   logAccSet = hwloc_bitmap_dup(hwloc_topology_get_allowed_cpuset(topology));
+  if (debug) {
+    char buf[1024];
+    hwloc_bitmap_list_snprintf(buf, sizeof(buf), logAccSet);
+    _DBG_P("logAccSet before masking: %s", buf);
+  }
   if (logAccMask) {
     // Modify accessible PUs for testing purposes.
     hwloc_bitmap_and(logAccSet, logAccSet, logAccMask);
@@ -393,7 +409,11 @@ static void cpuInfoInit(void) {
   filterPUsByKind(numKinds, ignoreKinds, logAccSet);
   numCPUsLogAcc = hwloc_bitmap_weight(logAccSet);
   _DBG_P("numCPUsLogAcc = %d", numCPUsLogAcc);
-
+  if (debug) {
+    char buf[1024];
+    hwloc_bitmap_list_snprintf(buf, sizeof(buf), logAccSet);
+    _DBG_P("logAccSet after filtering: %s", buf);
+  }
 
   // accessible cores
 
@@ -405,11 +425,7 @@ static void cpuInfoInit(void) {
     // filter the core's PUs
     hwloc_cpuset_t cpuset = NULL;
     CHK_ERR_ERRNO((cpuset = hwloc_bitmap_dup(core->cpuset)) != NULL);
-      char buf[1024];
-      hwloc_bitmap_list_snprintf(buf, sizeof(buf), cpuset);
-      _DBG_P("core cpuset: %s", buf);
     // filter the core's PUs in case they are hybrid
-    _DBG_P("filtering core's cpuset");
     filterPUsByKind(numKinds, ignoreKinds, cpuset);
 
     // determine the max # PUs in a core
@@ -508,6 +524,7 @@ static void partitionResources(void) {
   if (numLocalesOnNode > 1) {
     oversubscribed = true;
   }
+  logAccSets = sys_calloc(numLocalesOnNode, sizeof(hwloc_cpuset_t));
   if ((expectedLocalesOnNode > 1) || useSocket) {
     // We get our own socket if all cores are accessible, we know our local
     // rank, and the number of locales on the node is less than or equal to
@@ -528,6 +545,19 @@ static void partitionResources(void) {
           socket = hwloc_get_obj_inside_cpuset_by_type(topology,
                                     root->cpuset, HWLOC_OBJ_PACKAGE, rank);
           CHK_ERR(socket != NULL);
+
+          // Compute the accessible PUs for all locales on this node based
+          // on the socket each occupies. This is used to determine which
+          // NIC each locale should use.
+
+          for (int i = 0; i < numLocalesOnNode; i++) {
+            hwloc_obj_t obj;
+            CHK_ERR(obj = hwloc_get_obj_inside_cpuset_by_type(topology,
+                                    root->cpuset, HWLOC_OBJ_PACKAGE, i));
+            hwloc_cpuset_t s = hwloc_bitmap_dup(obj->cpuset);
+            hwloc_bitmap_and(s, s, logAccSet);
+            logAccSets[i] = s;
+          }
 
           // Limit the accessible cores and PUs to those in our socket.
 
@@ -555,6 +585,10 @@ static void partitionResources(void) {
                  "greater than the number of sockets (%d > %d).",
                  numLocalesOnNode, numSockets);
         chpl_error(msg, 0, 0);
+      } else {
+        // We don't know which PUs other locales on the same node are using,
+        // so just set our own.
+        logAccSets[0] = hwloc_bitmap_dup(logAccSet);
       }
     }
   }
@@ -604,24 +638,9 @@ static void partitionResources(void) {
 
 #undef NEXT_OBJ
 
-// If we are running in a socket then cpuInfoInit will assign each locale to
-// the socket whose logical index is equal to the locale's local rank. This
-// function returns the socket number for the given locale. Right now it's
-// the identity mapping, but should be changed if the way cpuInfoInit does
-// the mapping is changed.
-static
-int getSocketNumber(int localRank) {
-  int result = -1;
-  if (socket != NULL) {
-    result = localRank;
-  }
-  return result;
-}
-
 void chpl_topo_post_args_init(void) {
-  if ((verbosity >= 2) && (socket != NULL)) {
-    printf("%d: using socket %d\n", chpl_nodeID,
-           socket->logical_index);
+  if ((verbosity >= 2) && (root != hwloc_get_root_obj(topology))) {
+    printf("%d: using socket %d\n", chpl_nodeID, root->logical_index);
   }
 }
 
@@ -887,9 +906,8 @@ void chpl_topo_interleaveMemLocality(void* p, size_t size) {
       !topoSupport->membind->interleave_membind) {
     return;
   }
-
   hwloc_bitmap_t set;
-  set = hwloc_bitmap_dup(root->cpuset);
+  set = hwloc_bitmap_dup(hwloc_get_root_obj(topology)->cpuset);
 
   flags = 0;
   CHK_ERR_ERRNO(hwloc_set_area_membind(topology, p, size, set, HWLOC_MEMBIND_INTERLEAVE, flags) == 0);
@@ -1054,195 +1072,200 @@ chpl_bool chpl_topo_isOversubscribed(void) {
   _DBG_P("oversubscribed = %s", oversubscribed ? "True" : "False");
   return oversubscribed;
 }
-//
-// Information used to sort NICs and to track which ones have already
-// been assigned to a locale.
-//
-typedef struct nic_info_t {
-  int         socket;
-  hwloc_obj_t obj;
-  chpl_bool   assigned;
-} nic_info_t;
 
 //
-// Comparison function for sort. Sorts based on socket then PCI address.
+// Returns the shortest path from obj0 to obj1 in the topology. The
+// hwloc_get_common_ancestor_obj function does not work on objects that do
+// not have a cpuset, such as I/O objects, so first find a non-I/O ancestor
+// of the specified objects. The checks for NULL are because it isn't clear
+// when hwloc might return NULL for various (potentially future) topologies
+// and the hwloc routines seg fault when passed NULL. This function returns
+// zero if it cannot compute the distance.
 //
-static int compareNics(const void *a, const void *b)
-{
-  nic_info_t *nicA = (nic_info_t *) a;
-  nic_info_t *nicB = (nic_info_t *) b;
-
-  int result;
-
-  result = nicA->socket - nicB->socket;
-  if (result == 0) {
-    struct hwloc_pcidev_attr_s *attrA = &(nicA->obj->attr->pcidev);
-    struct hwloc_pcidev_attr_s *attrB = &(nicB->obj->attr->pcidev);
-    result = attrA->domain - attrB->domain;
-    if (result == 0) {
-      result = attrA->bus - attrB->bus;
-      if (result == 0) {
-        result = attrA->dev - attrB->dev;
-        if (result == 0) {
-          result = attrA->func - attrB->func;
+static int
+distance(hwloc_topology_t topology, hwloc_obj_t obj0, hwloc_obj_t obj1) {
+  int dist = 0;
+  if ((obj0 != NULL) && (obj1 != NULL)) {
+    hwloc_obj_t nonio0 = hwloc_get_non_io_ancestor_obj(topology, obj0);
+    hwloc_obj_t nonio1 = hwloc_get_non_io_ancestor_obj(topology, obj1);
+    if ((nonio0 != NULL) && (nonio1 != NULL)) {
+      hwloc_obj_t common = hwloc_get_common_ancestor_obj(topology, nonio0,
+                                                 nonio1);
+      if (common != NULL) {
+        dist = (nonio0->depth - common->depth) +
+               (nonio1->depth - common->depth);
+        if (dist < 0) {
+          dist = 0;
         }
       }
     }
   }
-  return result;
+  return dist;
 }
 
 //
-// Given a NIC, determines which NIC of the same type (same vendor and device)
-// is the best to use. The "best" NIC is one in the same socket as this
-// locale. If there isn't a NIC in our socket then use an "extra" NIC if some
-// sockets have more than one, otherwise use an already-assigned NIC. In
-// either case choose a NIC in a round-robin fashion from those locales that
-// do not have a NIC in their socket.
+// Comparison function for sort. Sorts objects based on OS index.
+//
+static int compareObjs(const void *a, const void *b)
+{
+  hwloc_obj_t objA = (hwloc_obj_t) a;
+  hwloc_obj_t objB = (hwloc_obj_t) b;
+
+  return (objA->os_index - objB->os_index);
+}
+
+//
+// Given a NIC with the specified PCI address, determines which NIC of the
+// same type (same PCI Vendor ID and PCI Device ID) is the best to use under
+// the following constraints:
+//  * every locale is assigned exactly one NIC
+//  * a NIC is shared between locales only if necessary
+//  * a locale should use the NIC that is closest to it in the hwloc topology,
+//    subject to the above constraints
+//
+// Returns the PCI address of the NIC that should be used, NULL if there
+// was an error.
 //
 
 chpl_topo_pci_addr_t *chpl_topo_selectNicByType(chpl_topo_pci_addr_t *inAddr,
                                                 chpl_topo_pci_addr_t *outAddr)
 {
-  hwloc_obj_t nic = NULL;
-  struct hwloc_pcidev_attr_s *nicAttr;
-  chpl_topo_pci_addr_t *result = NULL;
-  nic_info_t *nics = NULL;
-  int *assignedNics = NULL;
 
-  if (root->type != HWLOC_OBJ_PACKAGE) {
-    // We aren't running in a socket, so we don't care which NIC is used.
-    goto done;
-  }
+  hwloc_obj_t           nic = NULL;
+  chpl_topo_pci_addr_t  *result = NULL;
+  int numLocales = chpl_get_num_locales_on_node();
+  struct hwloc_pcidev_attr_s *nicAttr;
+  int localRank = chpl_get_local_rank();
+
+  _DBG_P("chpl_topo_selectNicByType: %04x:%02x:%02x.%x", inAddr->domain,
+             inAddr->bus, inAddr->device, inAddr->function);
+  _DBG_P("numLocales %d rank %d", numLocales, localRank);
 
   // find the PCI object corresponding to the specified NIC
-  for (hwloc_obj_t obj = hwloc_get_next_pcidev(topology, NULL);
-       obj != NULL;
-       obj = hwloc_get_next_pcidev(topology, obj)) {
-    if (obj->type == HWLOC_OBJ_PCI_DEVICE) {
-      struct hwloc_pcidev_attr_s *attr = &(obj->attr->pcidev);
-      if ((attr->domain == inAddr->domain) && (attr->bus == inAddr->bus) &&
-          (attr->dev == inAddr->device) && (attr->func == inAddr->function)) {
-        nic = obj;
-        break;
+  nic = hwloc_get_pcidev_by_busid(topology, inAddr->domain, inAddr->bus,
+                                  inAddr->device, inAddr->function);
+  if (nic != NULL) {
+    if ((numLocales > 1) && (localRank >= 0)) {
+      // Find all the NICS with the same vendor and device as the specified NIC.
+      nicAttr = &(nic->attr->pcidev);
+      int maxNics = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_PCI_DEVICE);
+      hwloc_obj_t nics[maxNics];
+      int numNics = 0;
+
+      for (hwloc_obj_t obj = hwloc_get_next_pcidev(topology, NULL);
+           obj != NULL;
+           obj = hwloc_get_next_pcidev(topology, obj)) {
+
+        if (obj->type == HWLOC_OBJ_PCI_DEVICE) {
+          struct hwloc_pcidev_attr_s *attr = &(obj->attr->pcidev);
+          if ((attr->vendor_id == nicAttr->vendor_id) &&
+              (attr->device_id == nicAttr->device_id)) {
+              nics[numNics++] = obj;
+          }
+        }
+      }
+      if (numNics > 1) {
+        //
+        // Sort the NICs so that all locales have them in the same order,
+        // should hwloc return them in different orders to different locales.
+        //
+        qsort(nics, numNics, sizeof(*nics), compareObjs);
+
+        //
+        // Build a distance matrix between locales and NICs. Then search the
+        // matrix for the shortest distance and assign the NIC to the locale.
+        // Repeat for all unassigned NICs and locales until either all
+        // locales have a NIC or there are no more unassigned NICs. In the
+        // latter situation locales will have to share NICs, so mark all NICs
+        // as unassigned and repeat the process.
+        //
+        hwloc_obj_t locales[numLocales];
+        hwloc_obj_t assigned[numLocales]; // NIC assigned to the locale
+        int numAssigned = 0;
+        int distances[numNics][numLocales];
+
+        for (int j = 0; j < numLocales; j++) {
+          if (logAccSets[j] != NULL) {
+            CHK_ERR(locales[j] =  hwloc_get_obj_covering_cpuset(topology,
+                                                              logAccSets[j]));
+          } else {
+            locales[j] = NULL;
+          }
+          assigned[j] = NULL;
+        }
+
+        // Compute the distances between locales and NICs. If locales[j]
+        // is NULL then we don't know which PUs that locale is using, so
+        // we ignore it by setting its distances to infinite.
+
+        for (int i = 0; i < numNics; i++) {
+          for (int j = 0; j < numLocales; j++) {
+            if (locales[j] != NULL) {
+              distances[i][j] = distance(topology, nics[i], locales[j]);
+            } else {
+              distances[i][j] = INT32_MAX;
+            }
+          }
+        }
+        if (debug) {
+          fprintf(stderr, "distances:\n");
+          for (int i = 0; i < numNics; i++) {
+            for (int j = 0; j < numLocales; j++) {
+              fprintf(stderr, "%02d ", distances[i][j]);
+            }
+            fprintf(stderr, "\n");
+          }
+        }
+
+        chpl_bool finished = false;
+        while (!finished && (numAssigned < numLocales)) {
+
+          _DBG_P("outer loop: numAssigned %d", numAssigned);
+          // The used array keeps track of NICs that have been assigned in
+          // this iteration.
+          chpl_bool used[numNics];
+          for (int i = 0; i < numNics; i++) {
+            used[i] = false;
+          }
+          // Find the minimum distance between a locale that hasn't been
+          // assigned a NIC and a NIC that hasn't been assigned in this
+          // iteration ("used") and assign that NIC to that locale.
+          int numAvail = numNics;
+          while((numAvail > 0) && (numAssigned < numLocales)) {
+              int minimum = INT32_MAX;
+              int minNic = -1;
+              int minLoc = -1;
+              for (int i = 0; i < numNics; i++) {
+                if (!used[i]) {
+                  for (int j = 0; j < numLocales; j++) {
+                      if ((!assigned[j]) && (distances[i][j] < minimum)) {
+                          minimum = distances[i][j];
+                          minNic = i;
+                          minLoc = j;
+                      }
+                  }
+                }
+              }
+              assert((minLoc >= 0) && (minNic >= 0));
+              assigned[minLoc] = nics[minNic];
+              used[minNic] = true;
+              if (minLoc == localRank) {
+                // We are done once we find our NIC.
+                nic = nics[minNic];
+                finished = true;
+                break;
+              }
+              numAssigned++;
+              numAvail--;
+          }
+        }
       }
     }
-  }
-  if (nic == NULL) {
+  } else {
     _DBG_P("Could not find NIC %04x:%02x:%02x.%x", inAddr->domain,
            inAddr->bus, inAddr->device, inAddr->function);
-    goto done;
   }
 
-  // Find all the NICS of the same vendor and device as the specified NIC and
-  // sort them by socket and PCI address.
-
-  nicAttr = &(nic->attr->pcidev);
-  int maxNics = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_PCI_DEVICE);
-  CHK_ERR(nics = sys_calloc(maxNics, sizeof(*nics)));
-  int numNics = 0;
-
-  for (hwloc_obj_t obj = hwloc_get_next_pcidev(topology, NULL);
-       obj != NULL;
-       obj = hwloc_get_next_pcidev(topology, obj)) {
-
-    if (obj->type == HWLOC_OBJ_PCI_DEVICE) {
-      struct hwloc_pcidev_attr_s *attr = &(obj->attr->pcidev);
-      if ((attr->vendor_id == nicAttr->vendor_id) &&
-          (attr->device_id == nicAttr->device_id)) {
-        hwloc_obj_t sobj = hwloc_get_ancestor_obj_by_type(topology,
-                                                          HWLOC_OBJ_PACKAGE,
-                                                          obj);
-        if (sobj == NULL) {
-          _DBG_P("Could not find socket for NIC %04x:%02x:%02x.%x",
-                 attr->domain, attr->bus, attr->dev, attr->func);
-          goto done;
-        }
-        nics[numNics].socket = sobj->logical_index;
-        nics[numNics].obj = obj;
-        nics[numNics].assigned = false;
-        numNics++;
-      }
-    }
-  }
-  qsort(nics, numNics, sizeof(*nics), compareNics);
-
-  // Use the first NIC in our socket if there is one.
-
-  for (int i = 0; i < numNics; i++) {
-    if (nics[i].socket == root->logical_index) {
-      nic = nics[i].obj;
-      goto done;
-    }
-  }
-
-  // There isn't a NIC in our socket. Use the nth unassigned NIC, where
-  // n is our rank among the locales that don't have NICs, modulo
-  // the number of unassigned NICs. Otherwise use the nth assigned NIC.
-
-  int numLocalesOnNode = chpl_get_num_locales_on_node();
-  CHK_ERR(assignedNics = sys_calloc(numLocalesOnNode, sizeof(*assignedNics)));
-
-  for (int i = 0; i < numLocalesOnNode; i++) {
-    assignedNics[i] = -1;
-  }
-
-  // Look for extra (unassigned) NICs. Any NIC whose socket number matches
-  // a locale's socket number will be assigned above. The rest are extra.
-
-  int numAssignedNics = 0;
-  for (int lid = 0; lid < numLocalesOnNode; lid++) {
-    for (int nid = 0; nid < numNics; nid++) {
-      if (nics[nid].socket == getSocketNumber(lid)) {
-        assignedNics[lid] = nid;
-        nics[nid].assigned = true;
-        numAssignedNics++;
-        break;
-      }
-    }
-  }
-
-  // Determine our rank within the locales that do not have a NIC assigned.
-
-  int unmatchedLocales = 0;
-  int unassignedRank = -1;
-  int rank = chpl_get_local_rank();
-  for (int lid = 0; lid < numLocalesOnNode; lid++) {
-    if (lid == rank) {
-      unassignedRank = unmatchedLocales;
-      break;
-    }
-    if (assignedNics[lid] == -1) {
-      unmatchedLocales++;
-    }
-  }
-  CHK_ERR(unassignedRank != -1);
-
-  if (numAssignedNics == numNics) {
-
-    // All NICs are assigned, we'll have to share one.
-
-    nic = nics[unassignedRank % numNics].obj;
-  } else {
-
-    // Use an unassigned NIC, perhaps sharing one if necessary.
-    // Note that this can lead to unbalanced loads, but should be uncommon.
-
-    unassignedRank %= (numNics - numAssignedNics);
-
-    int count = 0;
-    for (int nid = 0; nid < numNics; nid++) {
-      if (nics[nid].assigned == false) {
-        if (unassignedRank == count) {
-          nic = nics[nid].obj;
-          goto done;
-        }
-        count++;
-      }
-    }
-  }
-
-done:
   if (nic != NULL) {
     nicAttr = &(nic->attr->pcidev);
     if (outAddr != NULL) {
@@ -1253,15 +1276,8 @@ done:
       result = outAddr;
     }
   }
-  if (nics != NULL) {
-    sys_free(nics);
-  }
-  if (assignedNics != NULL) {
-    sys_free(assignedNics);
-  }
   return result;
 }
-
 
 static
 void chk_err_fn(const char* file, int lineno, const char* what) {

--- a/runtime/src/topo/none/topo-none.c
+++ b/runtime/src/topo/none/topo-none.c
@@ -104,6 +104,7 @@ chpl_bool chpl_topo_isOversubscribed(void) {
 
 chpl_topo_pci_addr_t *chpl_topo_selectNicByType(chpl_topo_pci_addr_t *inAddr,
                                             chpl_topo_pci_addr_t *outAddr) {
-  return NULL;
+  *outAddr = *inAddr;
+  return outAddr;
 }
 

--- a/test/runtime/jhh/colocales/Makefile
+++ b/test/runtime/jhh/colocales/Makefile
@@ -1,0 +1,15 @@
+# This Makefile creates the colocales test stub.
+
+all: colocales
+
+COMPILE = $(shell $(CHPL_HOME)/util/config/compileline --compile)
+LIBS = $(shell $(CHPL_HOME)/util/config/compileline --libraries)
+
+colocales: lib/libcolocales.a colocales.c
+	$(COMPILE) -g colocales.c -Llib -l$@ $(LIBS) -o $@
+
+lib/libcolocales.a: colocales.chpl
+	chpl colocales.chpl --library
+
+clean::
+	rm -rf colocales lib colocales.dSYM

--- a/test/runtime/jhh/colocales/Makefile
+++ b/test/runtime/jhh/colocales/Makefile
@@ -2,6 +2,10 @@
 
 all: colocales
 
+ifeq ($(CHPL_COMPILER),)
+  CHPL_COMPILER = chpl
+endif
+
 COMPILE = $(shell $(CHPL_HOME)/util/config/compileline --compile)
 LIBS = $(shell $(CHPL_HOME)/util/config/compileline --libraries)
 
@@ -9,7 +13,7 @@ colocales: lib/libcolocales.a colocales.c
 	$(COMPILE) -g colocales.c -Llib -l$@ $(LIBS) -o $@
 
 lib/libcolocales.a: colocales.chpl
-	chpl colocales.chpl --library
+	$(CHPL_COMPILER) colocales.chpl --library
 
 clean::
 	rm -rf colocales lib colocales.dSYM

--- a/test/runtime/jhh/colocales/README
+++ b/test/runtime/jhh/colocales/README
@@ -1,0 +1,7 @@
+This directory contains unit tests for colocales, including NIC selection.
+The tests are based on Python's unittest and are contained in colocales.py.
+The tests invoke the "colocale" executable, which is created by compiling
+colocales.chpl with the "--library" argument to produce a library that is
+linked against the colocales.c test harness. The sub_test script simply runs
+all *.py files in this directory. The *.xml files contain hwloc descriptions
+of the machine topologies used in the tests.

--- a/test/runtime/jhh/colocales/colocales.c
+++ b/test/runtime/jhh/colocales/colocales.c
@@ -1,0 +1,123 @@
+/*
+ * This is a test harness for testing which physical CPUs, logical CPUs, and
+ * NIC the runtime assigns to the process (locale) based on how many
+ * processes are running on the node and the rank of this process. It
+ * initializes just enough of the runtime as necessary to provide this
+ * information, then prints the results. The '-N' argument specifies the
+ * initial NIC such as might be returned by fi_getinfo, and if specified
+ * chpl_topo_selectNicByType() is called to determine which NIC of the same
+ * type the process should use.
+ */
+
+#include <stdio.h>
+#include "lib/colocales.h"
+#include <hwloc.h>
+
+void Usage(char *name) {
+  fprintf(stderr, "Usage: %s [-m mask] [-N nic] [-n numColocales] [-r rank]\n", name);
+  fprintf(stderr, "\t-m <mask>\tMask off accessible PUs\n");
+  fprintf(stderr, "\t-N <nic>\tNIC bus address\n");
+  fprintf(stderr, "\t-n <numLocales>\tNumber of locales on node\n");
+  fprintf(stderr, "\t-r <rank>\tLocal rank\n");
+  fprintf(stderr, "\t-h\t\tPrint this message\n");
+}
+
+// Prints all physical and logical CPUs.
+int main(int argc, char* argv[]) {
+  int opt;
+  int count;
+  int *cpus = NULL;
+  char *mask = NULL;
+  int rank = -1;
+  int numLocales = 1;
+  char *numLocalesStr = NULL;
+  char *nic = NULL;
+
+  while ((opt = getopt(argc, argv, "m:N:n:r:")) != -1) {
+    switch(opt) {
+      case 'm':
+        mask = optarg;
+        break;
+      case 'n':
+        numLocales = atoi(optarg);
+        numLocalesStr = optarg;
+        break;
+      case 'r':
+        rank = atoi(optarg);
+        break;
+      case 'N':
+        nic = optarg;
+        break;
+      case 'h':
+        Usage(argv[0]);
+        exit(0);
+        break;
+      case '?':
+      default:
+        Usage(argv[0]);
+        exit(1);
+    }
+  }
+  if (optind < argc) {
+    Usage(argv[0]);
+    exit(1);
+  }
+
+  if (numLocales > 1) {
+    setenv("CHPL_RT_LOCALES_PER_NODE", numLocalesStr, 1);
+  } else {
+    unsetenv("CHPL_RT_LOCALES_PER_NODE");
+  }
+  chpl__init_colocales(0, 0); // unsure why this is needed
+  chpl_set_num_locales_on_node(numLocales);
+  if (rank != -1) {
+    chpl_set_local_rank(rank);
+  }
+  chpl_topo_pre_comm_init(mask);
+  chpl_topo_post_comm_init();
+
+  hwloc_topology_t topology = (hwloc_topology_t) chpl_topo_getHwlocTopology();
+
+  bool physical = false;
+  do {
+    physical = !physical;
+    if (physical) {
+      count = chpl_topo_getNumCPUsPhysical(true /* accessible_only */);
+    } else {
+      count = chpl_topo_getNumCPUsLogical(true /* accessible_only */);
+    }
+    cpus = malloc(count * sizeof(*cpus));
+    count = chpl_topo_getCPUs(physical, cpus, count);
+    printf("%s CPUs:", physical ? "Physical" : "Logical");
+    for (int i = 0; i < count; i++) {
+      printf(" %d", cpus[i]);
+    }
+    printf("\n");
+    free(cpus);
+  } while (physical);
+
+  if (nic != NULL) {
+    hwloc_obj_t obj = hwloc_get_pcidev_by_busidstring(topology, nic);
+    if (obj == NULL) {
+      fprintf(stderr, "Cannot find NIC w/ bus address \"%s\"\n", nic);
+      exit(1);
+    }
+    struct hwloc_pcidev_attr_s *attr = &(obj->attr->pcidev);
+    chpl_topo_pci_addr_t inAddr;
+    chpl_topo_pci_addr_t outAddr;
+    chpl_topo_pci_addr_t *result;
+
+    inAddr.domain = attr->domain;
+    inAddr.bus = attr->bus;
+    inAddr.device = attr->dev;
+    inAddr.function = attr->func;
+
+    result = chpl_topo_selectNicByType(&inAddr, &outAddr);
+    if (result == NULL) {
+      fprintf(stderr, "chpl_topo_selectNicByType returned NULL\n");
+      exit(1);
+    }
+    printf("NIC: %04x:%02x:%02x.%x\n", result->domain, result->bus,
+           result->device, result->function);
+  }
+}

--- a/test/runtime/jhh/colocales/colocales.chpl
+++ b/test/runtime/jhh/colocales/colocales.chpl
@@ -1,0 +1,2 @@
+// This is an empty file used to create the Chapel library.
+;

--- a/test/runtime/jhh/colocales/colocales.py
+++ b/test/runtime/jhh/colocales/colocales.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+
+"""
+Co-locale tests. Usage: ./colocales.py. The -v flag prints
+verbose output, the -f flag will cause testing to stop when the
+first test fails.
+"""
+
+import unittest
+import subprocess
+import os
+import sys
+import time
+import shutil
+
+if not 'CHPL_HOME' in os.environ:
+    print('CHPL_HOME is not set')
+    sys.exit(1)
+
+import sub_test
+import printchplenv
+
+
+verbose = False
+skipReason = None
+
+def runCmd(cmd, env=None, check=True):
+    if type(cmd) is str:
+        cmd = cmd.split()
+    if env is None:
+        proc = subprocess.run(cmd, text=True, check=check,
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    else:
+        proc = subprocess.run(cmd, text=True, check=check, env=env,
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    return proc.stdout
+
+def skipif():
+    global skipReason
+    global launcher, comm
+
+    # Get the Chapel configuration
+    printchplenv.compute_all_values()
+    # strip the padding printchplenv puts on some of the keys
+    env = {k.strip():v for k,v in printchplenv.ENV_VALS.items()}
+
+    # Verify Chapel configuration
+    # It's only necessary to run this on a single locale.
+    if env.get('CHPL_COMM', 'none') != 'none':
+        skipReason = "CHPL_COMM != none"
+        return
+    if env.get('CHPL_HWLOC', 'none') == 'none':
+        skipReason = "CHPL_HWLOC == none"
+        return
+
+def stringify(lst):
+    return " ".join([str(i) for i in lst])
+
+"""
+This class defines utility functions and the test cases (which start
+with 'test_'). The tests in this class are not run directly, but instead are
+run from subclasses that use different machine topologies. The outer class
+'TestCases' prevents the unittest framework from trying to run the test cases
+in TestCase.
+"""
+class TestCases(object):
+    class TestCase(unittest.TestCase):
+        def setUp(self):
+            if skipReason is not None:
+                self.skipTest(skipReason)
+            self.env = os.environ.copy()
+
+        def runCmd(self, cmd, env=None):
+            if env is None:
+                env = self.env
+            output = runCmd(cmd, env=env, check=False);
+            return output
+
+        # Returns a list of cores in the specified partition
+        def getCores(self,  index, partitions):
+            if index == "all":
+                return sorted([x for lst in [self.getCores(i, partitions)
+                              for i in range(0,partitions)] for x in lst])
+            else:
+                coresPerPartition = int((self.cores * self.sockets) /
+                                        partitions)
+                return [i + (index * coresPerPartition)
+                                for i in range(0,coresPerPartition)]
+
+        # Returns a list of cores in the specified socket.
+        def getSocketCores(self, socket):
+            return self.getCores(socket, self.sockets)
+
+        # Returns a list of threads (PUs) in the specified partition
+        def getThreads(self, index, partitions):
+            if index == "all":
+                return sorted([x for lst in [self.getThreads(i, partitions)
+                            for i in range(0,partitions)] for x in lst])
+            cores = self.getCores(index, partitions)
+            threads = []
+            for t in range(0, self.threads):
+                threads += [cores[i] + (t * self.sockets * self.cores)
+                            for i in range(0, len(cores))]
+            return threads
+
+        # Returns a list of threads in the specified socket
+        def getSocketThreads(self, socket):
+            return self.getThreads(socket, self.sockets)
+
+        """
+        One locale, should have access to all cores and threads and use the
+        suggested NIC.
+        """
+        def test_00_base(self):
+            output = self.runCmd("./colocales -N %s" % self.nics[0])
+            cpus = " ".join([str(i) for i in self.getSocketCores("all")])
+            self.assertIn("Physical CPUs: " + cpus, output)
+            cpus = " ".join([str(i) for i in self.getSocketThreads("all")])
+            self.assertIn("Logical CPUs: " + cpus, output)
+            self.assertIn("NIC: " + self.nics[0], output)
+
+        """
+        One locale, should have access to all cores and threads and use
+        another NIC when it is suggested.
+        """
+        def test_01_use_another_NIC(self):
+            if (len(self.nics) == 1):
+                self.skipTest("only one NIC")
+            output = self.runCmd("./colocales -N %s" % self.nics[1])
+            self.assertIn("NIC: " + self.nics[1], output)
+
+        """
+        Locale in socket should use cores and threads in that socket and
+        the closest NIC.
+        """
+        def test_02_in_socket(self):
+            env = self.env.copy()
+            env['CHPL_RT_LOCALES_PER_NODE'] = str(self.sockets)
+            for i in range(0, self.sockets):
+                with self.subTest(i=i):
+                    output = self.runCmd("./colocales -r %d -n %d -N %s" %
+                                     (i, self.sockets, self.nicForSocket[i]),
+                                     env=env)
+                    cpus = stringify(self.getSocketCores(i))
+                    self.assertIn("Physical CPUs: %s\n" % cpus, output)
+                    cpus = stringify(self.getSocketThreads(i))
+                    self.assertIn("Logical CPUs: %s\n" % cpus, output)
+                    self.assertIn("NIC: " + self.nicForSocket[i], output)
+
+
+"""
+These classes represent different machine topologies based on real machines.
+The topologies are stored in the XML files. We could extract the number of
+sockets, cores, etc., from those files, but for now we just hard-code that
+information because there are only a few configurations.
+"""
+
+"""
+HPE Cray EX. Two sockets, four NUMA domains per socket, 64 cores per socket,
+two threads per core, and one NIC per socket.
+"""
+class Ex2Tests(TestCases.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.env['HWLOC_XMLFILE'] = 'ex2.xml'
+        self.sockets = 2
+        self.numas = 4
+        self.cores = 64
+        self.threads = 2
+        self.nics= ['0000:21:00.0', '0000:a1:00.0']
+        self.nicForSocket = ['0000:21:00.0', '0000:a1:00.0']
+
+"""
+AWS hpc6a.48xlarge instance. Two sockets, two NUMA domains per socket, 48
+cores per socket, one thread per core, and one NIC not in a socket.
+domains.
+"""
+class Hpc6aTests(TestCases.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.env['HWLOC_XMLFILE'] = 'hpc6a.48xlarge.xml'
+        self.sockets = 2
+        self.numas = 2
+        self.cores = 48
+        self.threads = 1
+        self.nics= ['0000:00:06.0']
+        self.nicForSocket = ['0000:00:06.0', '0000:00:06.0']
+
+# AWS m6in-dy-m6in32xlarge instance. Two sockets, one NUMA domain per socket,
+# 32 cores per socket, one thread per core, and two NICs not in sockets.
+
+class M6inTests(TestCases.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.env['HWLOC_XMLFILE'] = 'm6in-dy-m6in32xlarge.xml'
+        self.sockets = 2
+        self.numas = 1
+        self.cores = 32
+        self.threads = 2
+        self.nics= ['0000:00:06.0', '0000:00:08.0']
+
+    """
+    The base test_02_in_socket test doesn't work because the NICs are not in
+    sockets in this topology. Instead, check that the two locales use
+    different NICs.
+    """
+    def test_02_in_socket(self):
+        self.env['CHPL_RT_LOCALES_PER_NODE'] = '2'
+        output = self.runCmd("./colocales -r 0 -n 2 -N %s" % self.nics[0])
+        for line in output.split('\n'):
+            if line.startswith("NIC:"):
+                nic0 = line.split()[1]
+                self.assertIn(nic0, self.nics)
+                break
+        output = self.runCmd("./colocales -r 1 -n 2 -N %s" % self.nics[0])
+        for line in output.split('\n'):
+            if line.startswith("NIC:"):
+                nic1 = line.split()[1]
+                self.assertIn(nic1, self.nics)
+                self.assertNotEqual(nic0, nic1)
+                break
+
+def main(argv):
+    global verbose
+
+    startTime=time.time()
+    failfast = False
+    if "-f" in argv or "--force" in argv:
+        failfast = True
+        try:
+            argv.remove("-f")
+            argv.remove("--force")
+        except:
+            pass
+    if "-v" in argv or "--verbose" in argv:
+        verbose = True
+
+    skipif()
+
+    if len(argv) < 2:
+        print('usage: %s COMPILER [options]' % argv[0])
+        sys.exit(0)
+
+    compiler = argv[1]
+    del argv[1]
+    localDir = sub_test.get_local_dir(sub_test.get_chpl_base(compiler))
+    name = os.path.join(localDir, argv[0])
+    base = os.path.splitext(os.path.basename(argv[0]))[0]
+
+    sub_test.printStartOfTestMsg(time.localtime())
+    sub_test.printTestName(name)
+
+    if skipReason is None:
+        if verbose:
+            print("Building test harness")
+        runCmd("make clean")
+        runCmd("make")
+    if verbose:
+        print("Running tests")
+        verbosity=2
+    else:
+        verbosity=1
+    prog = unittest.main(argv=argv, failfast=failfast, exit=False,
+                         verbosity=verbosity)
+
+
+    """
+    Produce output that start_test can parse. To start_test this is a single
+    test. Report report success if all tests succeeded, an error if any test
+    failed, and nothing if all tests were skipped.
+    """
+
+    elapsedTime = time.time() - startTime
+
+    if len(prog.result.skipped) > 0:
+        sub_test.printSkipping(name, skipReason)
+        print("Skipped %d tests in %s" % (len(prog.result.skipped), name))
+    if len(prog.result.skipped) != prog.result.testsRun:
+        if len(prog.result.errors) > 0 or len(prog.result.failures) > 0:
+            print("[Error running tests in %s]" % name)
+        else:
+            print("[Success matching tests in %s]" % name)
+    sub_test.printEndOfTestMsg(name, elapsedTime)
+    sub_test.cleanup(base, False)
+    runCmd("make clean")
+    sub_test.print_elapsed_sub_test_time(name, elapsedTime)
+
+if __name__ == '__main__':
+    main(sys.argv)
+

--- a/test/runtime/jhh/colocales/ex2.xml
+++ b/test/runtime/jhh/colocales/ex2.xml
@@ -1,0 +1,1951 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc2.dtd">
+<topology version="2.0">
+  <object type="Machine" os_index="0" cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" nodeset="0x000000ff" complete_nodeset="0x000000ff" allowed_nodeset="0x000000ff" gp_index="1">
+    <info name="DMIProductName" value="HPE_CRAY_EX425"/>
+    <info name="DMIProductVersion" value="1.7.0"/>
+    <info name="DMIBoardVendor" value="HPE"/>
+    <info name="DMIBoardName" value="HPE CRAY EX425"/>
+    <info name="DMIBoardVersion" value="WMNC"/>
+    <info name="DMIBoardAssetTag" value="UNKNOWN"/>
+    <info name="DMIChassisVendor" value="HPE"/>
+    <info name="DMIChassisType" value="17"/>
+    <info name="DMIChassisVersion" value="HPE Cray EX supercomputers"/>
+    <info name="DMIChassisAssetTag" value="UNKNOWN"/>
+    <info name="DMIBIOSVendor" value="HPE"/>
+    <info name="DMIBIOSVersion" value="1.7.0"/>
+    <info name="DMIBIOSDate" value="04-14-2023"/>
+    <info name="DMISysVendor" value="HPE"/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/slurm/uid_160156448/job_634290/step_0"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="5.14.21-150400.24.46_12.0.74-cray_shasta_c"/>
+    <info name="OSVersion" value="#1 SMP Sun Jul 23 15:24:30 UTC 2023 (1de3e22)"/>
+    <info name="HostName" value="nid000008"/>
+    <info name="Architecture" value="x86_64"/>
+    <info name="hwlocVersion" value="2.8.0"/>
+    <info name="ProcessName" value="lstopo"/>
+    <object type="Package" os_index="0" cpuset="0xffffffff,0xffffffff,,,0xffffffff,0xffffffff" complete_cpuset="0xffffffff,0xffffffff,,,0xffffffff,0xffffffff" nodeset="0x0000000f" complete_nodeset="0x0000000f" gp_index="3">
+      <info name="CPUVendor" value="AuthenticAMD"/>
+      <info name="CPUFamilyNumber" value="25"/>
+      <info name="CPUModelNumber" value="1"/>
+      <info name="CPUModel" value="AMD EPYC 7713 64-Core Processor                "/>
+      <info name="CPUStepping" value="1"/>
+      <object type="Group" cpuset="0x0000ffff,,,,0x0000ffff" complete_cpuset="0x0000ffff,,,,0x0000ffff" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="924" kind="1001" subkind="0">
+        <object type="NUMANode" os_index="0" cpuset="0x0000ffff,,,,0x0000ffff" complete_cpuset="0x0000ffff,,,,0x0000ffff" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="916" local_memory="33420181504">
+          <page_type size="4096" count="8159224"/>
+          <page_type size="2097152" count="0"/>
+          <page_type size="4194304" count="0"/>
+          <page_type size="8388608" count="0"/>
+          <page_type size="16777216" count="0"/>
+          <page_type size="33554432" count="0"/>
+          <page_type size="67108864" count="0"/>
+          <page_type size="134217728" count="0"/>
+          <page_type size="268435456" count="0"/>
+          <page_type size="536870912" count="0"/>
+          <page_type size="1073741824" count="0"/>
+          <page_type size="2147483648" count="0"/>
+        </object>
+        <object type="L3Cache" os_index="0" cpuset="0x000000ff,,,,0x000000ff" complete_cpuset="0x000000ff,,,,0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="9" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L2Cache" os_index="0" cpuset="0x00000001,,,,0x00000001" complete_cpuset="0x00000001,,,,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="8" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="0" cpuset="0x00000001,,,,0x00000001" complete_cpuset="0x00000001,,,,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="6" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="0" cpuset="0x00000001,,,,0x00000001" complete_cpuset="0x00000001,,,,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="7" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="0" cpuset="0x00000001,,,,0x00000001" complete_cpuset="0x00000001,,,,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="2">
+                  <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="5"/>
+                  <object type="PU" os_index="128" cpuset="0x00000001,,,,0x0" complete_cpuset="0x00000001,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="788"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="1" cpuset="0x00000002,,,,0x00000002" complete_cpuset="0x00000002,,,,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="15" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="1" cpuset="0x00000002,,,,0x00000002" complete_cpuset="0x00000002,,,,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="13" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="1" cpuset="0x00000002,,,,0x00000002" complete_cpuset="0x00000002,,,,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="14" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="1" cpuset="0x00000002,,,,0x00000002" complete_cpuset="0x00000002,,,,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="10">
+                  <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="12"/>
+                  <object type="PU" os_index="129" cpuset="0x00000002,,,,0x0" complete_cpuset="0x00000002,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="789"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="2" cpuset="0x00000004,,,,0x00000004" complete_cpuset="0x00000004,,,,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="21" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="2" cpuset="0x00000004,,,,0x00000004" complete_cpuset="0x00000004,,,,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="19" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="2" cpuset="0x00000004,,,,0x00000004" complete_cpuset="0x00000004,,,,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="20" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="2" cpuset="0x00000004,,,,0x00000004" complete_cpuset="0x00000004,,,,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="16">
+                  <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="18"/>
+                  <object type="PU" os_index="130" cpuset="0x00000004,,,,0x0" complete_cpuset="0x00000004,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="790"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="3" cpuset="0x00000008,,,,0x00000008" complete_cpuset="0x00000008,,,,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="27" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="3" cpuset="0x00000008,,,,0x00000008" complete_cpuset="0x00000008,,,,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="25" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="3" cpuset="0x00000008,,,,0x00000008" complete_cpuset="0x00000008,,,,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="26" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="3" cpuset="0x00000008,,,,0x00000008" complete_cpuset="0x00000008,,,,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="22">
+                  <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="24"/>
+                  <object type="PU" os_index="131" cpuset="0x00000008,,,,0x0" complete_cpuset="0x00000008,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="791"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="4" cpuset="0x00000010,,,,0x00000010" complete_cpuset="0x00000010,,,,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="33" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="4" cpuset="0x00000010,,,,0x00000010" complete_cpuset="0x00000010,,,,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="31" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="4" cpuset="0x00000010,,,,0x00000010" complete_cpuset="0x00000010,,,,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="32" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="4" cpuset="0x00000010,,,,0x00000010" complete_cpuset="0x00000010,,,,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="28">
+                  <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="30"/>
+                  <object type="PU" os_index="132" cpuset="0x00000010,,,,0x0" complete_cpuset="0x00000010,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="792"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="5" cpuset="0x00000020,,,,0x00000020" complete_cpuset="0x00000020,,,,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="39" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="5" cpuset="0x00000020,,,,0x00000020" complete_cpuset="0x00000020,,,,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="37" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="5" cpuset="0x00000020,,,,0x00000020" complete_cpuset="0x00000020,,,,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="38" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="5" cpuset="0x00000020,,,,0x00000020" complete_cpuset="0x00000020,,,,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="34">
+                  <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="36"/>
+                  <object type="PU" os_index="133" cpuset="0x00000020,,,,0x0" complete_cpuset="0x00000020,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="793"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="6" cpuset="0x00000040,,,,0x00000040" complete_cpuset="0x00000040,,,,0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="45" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="6" cpuset="0x00000040,,,,0x00000040" complete_cpuset="0x00000040,,,,0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="43" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="6" cpuset="0x00000040,,,,0x00000040" complete_cpuset="0x00000040,,,,0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="44" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="6" cpuset="0x00000040,,,,0x00000040" complete_cpuset="0x00000040,,,,0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="40">
+                  <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="42"/>
+                  <object type="PU" os_index="134" cpuset="0x00000040,,,,0x0" complete_cpuset="0x00000040,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="794"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="7" cpuset="0x00000080,,,,0x00000080" complete_cpuset="0x00000080,,,,0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="51" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="7" cpuset="0x00000080,,,,0x00000080" complete_cpuset="0x00000080,,,,0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="49" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="7" cpuset="0x00000080,,,,0x00000080" complete_cpuset="0x00000080,,,,0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="50" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="7" cpuset="0x00000080,,,,0x00000080" complete_cpuset="0x00000080,,,,0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="46">
+                  <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="48"/>
+                  <object type="PU" os_index="135" cpuset="0x00000080,,,,0x0" complete_cpuset="0x00000080,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="795"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L3Cache" os_index="1" cpuset="0x0000ff00,,,,0x0000ff00" complete_cpuset="0x0000ff00,,,,0x0000ff00" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="58" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L2Cache" os_index="8" cpuset="0x00000100,,,,0x00000100" complete_cpuset="0x00000100,,,,0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="57" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="8" cpuset="0x00000100,,,,0x00000100" complete_cpuset="0x00000100,,,,0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="55" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="8" cpuset="0x00000100,,,,0x00000100" complete_cpuset="0x00000100,,,,0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="56" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="8" cpuset="0x00000100,,,,0x00000100" complete_cpuset="0x00000100,,,,0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="52">
+                  <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="54"/>
+                  <object type="PU" os_index="136" cpuset="0x00000100,,,,0x0" complete_cpuset="0x00000100,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="796"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="9" cpuset="0x00000200,,,,0x00000200" complete_cpuset="0x00000200,,,,0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="64" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="9" cpuset="0x00000200,,,,0x00000200" complete_cpuset="0x00000200,,,,0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="62" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="9" cpuset="0x00000200,,,,0x00000200" complete_cpuset="0x00000200,,,,0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="63" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="9" cpuset="0x00000200,,,,0x00000200" complete_cpuset="0x00000200,,,,0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="59">
+                  <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="61"/>
+                  <object type="PU" os_index="137" cpuset="0x00000200,,,,0x0" complete_cpuset="0x00000200,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="797"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="10" cpuset="0x00000400,,,,0x00000400" complete_cpuset="0x00000400,,,,0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="70" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="10" cpuset="0x00000400,,,,0x00000400" complete_cpuset="0x00000400,,,,0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="68" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="10" cpuset="0x00000400,,,,0x00000400" complete_cpuset="0x00000400,,,,0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="69" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="10" cpuset="0x00000400,,,,0x00000400" complete_cpuset="0x00000400,,,,0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="65">
+                  <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="67"/>
+                  <object type="PU" os_index="138" cpuset="0x00000400,,,,0x0" complete_cpuset="0x00000400,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="798"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="11" cpuset="0x00000800,,,,0x00000800" complete_cpuset="0x00000800,,,,0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="76" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="11" cpuset="0x00000800,,,,0x00000800" complete_cpuset="0x00000800,,,,0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="74" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="11" cpuset="0x00000800,,,,0x00000800" complete_cpuset="0x00000800,,,,0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="75" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="11" cpuset="0x00000800,,,,0x00000800" complete_cpuset="0x00000800,,,,0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="71">
+                  <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="73"/>
+                  <object type="PU" os_index="139" cpuset="0x00000800,,,,0x0" complete_cpuset="0x00000800,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="799"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="12" cpuset="0x00001000,,,,0x00001000" complete_cpuset="0x00001000,,,,0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="82" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="12" cpuset="0x00001000,,,,0x00001000" complete_cpuset="0x00001000,,,,0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="80" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="12" cpuset="0x00001000,,,,0x00001000" complete_cpuset="0x00001000,,,,0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="81" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="12" cpuset="0x00001000,,,,0x00001000" complete_cpuset="0x00001000,,,,0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="77">
+                  <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="79"/>
+                  <object type="PU" os_index="140" cpuset="0x00001000,,,,0x0" complete_cpuset="0x00001000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="800"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="13" cpuset="0x00002000,,,,0x00002000" complete_cpuset="0x00002000,,,,0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="88" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="13" cpuset="0x00002000,,,,0x00002000" complete_cpuset="0x00002000,,,,0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="86" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="13" cpuset="0x00002000,,,,0x00002000" complete_cpuset="0x00002000,,,,0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="87" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="13" cpuset="0x00002000,,,,0x00002000" complete_cpuset="0x00002000,,,,0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="83">
+                  <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="85"/>
+                  <object type="PU" os_index="141" cpuset="0x00002000,,,,0x0" complete_cpuset="0x00002000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="801"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="14" cpuset="0x00004000,,,,0x00004000" complete_cpuset="0x00004000,,,,0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="94" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="14" cpuset="0x00004000,,,,0x00004000" complete_cpuset="0x00004000,,,,0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="92" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="14" cpuset="0x00004000,,,,0x00004000" complete_cpuset="0x00004000,,,,0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="93" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="14" cpuset="0x00004000,,,,0x00004000" complete_cpuset="0x00004000,,,,0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="89">
+                  <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="91"/>
+                  <object type="PU" os_index="142" cpuset="0x00004000,,,,0x0" complete_cpuset="0x00004000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="802"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="15" cpuset="0x00008000,,,,0x00008000" complete_cpuset="0x00008000,,,,0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="100" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="15" cpuset="0x00008000,,,,0x00008000" complete_cpuset="0x00008000,,,,0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="98" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="15" cpuset="0x00008000,,,,0x00008000" complete_cpuset="0x00008000,,,,0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="99" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="15" cpuset="0x00008000,,,,0x00008000" complete_cpuset="0x00008000,,,,0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="95">
+                  <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="97"/>
+                  <object type="PU" os_index="143" cpuset="0x00008000,,,,0x0" complete_cpuset="0x00008000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="803"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Group" cpuset="0xffff0000,,,,0xffff0000" complete_cpuset="0xffff0000,,,,0xffff0000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="925" kind="1001" subkind="0">
+        <object type="NUMANode" os_index="1" cpuset="0xffff0000,,,,0xffff0000" complete_cpuset="0xffff0000,,,,0xffff0000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="917" local_memory="33814577152">
+          <page_type size="4096" count="8254488"/>
+          <page_type size="2097152" count="2"/>
+          <page_type size="4194304" count="0"/>
+          <page_type size="8388608" count="0"/>
+          <page_type size="16777216" count="0"/>
+          <page_type size="33554432" count="0"/>
+          <page_type size="67108864" count="0"/>
+          <page_type size="134217728" count="0"/>
+          <page_type size="268435456" count="0"/>
+          <page_type size="536870912" count="0"/>
+          <page_type size="1073741824" count="0"/>
+          <page_type size="2147483648" count="0"/>
+        </object>
+        <object type="L3Cache" os_index="2" cpuset="0x00ff0000,,,,0x00ff0000" complete_cpuset="0x00ff0000,,,,0x00ff0000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="107" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L2Cache" os_index="16" cpuset="0x00010000,,,,0x00010000" complete_cpuset="0x00010000,,,,0x00010000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="106" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="16" cpuset="0x00010000,,,,0x00010000" complete_cpuset="0x00010000,,,,0x00010000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="104" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="16" cpuset="0x00010000,,,,0x00010000" complete_cpuset="0x00010000,,,,0x00010000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="105" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="16" cpuset="0x00010000,,,,0x00010000" complete_cpuset="0x00010000,,,,0x00010000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="101">
+                  <object type="PU" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="103"/>
+                  <object type="PU" os_index="144" cpuset="0x00010000,,,,0x0" complete_cpuset="0x00010000,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="804"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="17" cpuset="0x00020000,,,,0x00020000" complete_cpuset="0x00020000,,,,0x00020000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="113" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="17" cpuset="0x00020000,,,,0x00020000" complete_cpuset="0x00020000,,,,0x00020000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="111" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="17" cpuset="0x00020000,,,,0x00020000" complete_cpuset="0x00020000,,,,0x00020000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="112" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="17" cpuset="0x00020000,,,,0x00020000" complete_cpuset="0x00020000,,,,0x00020000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="108">
+                  <object type="PU" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="110"/>
+                  <object type="PU" os_index="145" cpuset="0x00020000,,,,0x0" complete_cpuset="0x00020000,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="805"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="18" cpuset="0x00040000,,,,0x00040000" complete_cpuset="0x00040000,,,,0x00040000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="119" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="18" cpuset="0x00040000,,,,0x00040000" complete_cpuset="0x00040000,,,,0x00040000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="117" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="18" cpuset="0x00040000,,,,0x00040000" complete_cpuset="0x00040000,,,,0x00040000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="118" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="18" cpuset="0x00040000,,,,0x00040000" complete_cpuset="0x00040000,,,,0x00040000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="114">
+                  <object type="PU" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="116"/>
+                  <object type="PU" os_index="146" cpuset="0x00040000,,,,0x0" complete_cpuset="0x00040000,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="806"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="19" cpuset="0x00080000,,,,0x00080000" complete_cpuset="0x00080000,,,,0x00080000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="125" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="19" cpuset="0x00080000,,,,0x00080000" complete_cpuset="0x00080000,,,,0x00080000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="123" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="19" cpuset="0x00080000,,,,0x00080000" complete_cpuset="0x00080000,,,,0x00080000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="124" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="19" cpuset="0x00080000,,,,0x00080000" complete_cpuset="0x00080000,,,,0x00080000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="120">
+                  <object type="PU" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="122"/>
+                  <object type="PU" os_index="147" cpuset="0x00080000,,,,0x0" complete_cpuset="0x00080000,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="807"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="20" cpuset="0x00100000,,,,0x00100000" complete_cpuset="0x00100000,,,,0x00100000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="131" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="20" cpuset="0x00100000,,,,0x00100000" complete_cpuset="0x00100000,,,,0x00100000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="129" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="20" cpuset="0x00100000,,,,0x00100000" complete_cpuset="0x00100000,,,,0x00100000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="130" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="20" cpuset="0x00100000,,,,0x00100000" complete_cpuset="0x00100000,,,,0x00100000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="126">
+                  <object type="PU" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="128"/>
+                  <object type="PU" os_index="148" cpuset="0x00100000,,,,0x0" complete_cpuset="0x00100000,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="808"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="21" cpuset="0x00200000,,,,0x00200000" complete_cpuset="0x00200000,,,,0x00200000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="137" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="21" cpuset="0x00200000,,,,0x00200000" complete_cpuset="0x00200000,,,,0x00200000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="135" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="21" cpuset="0x00200000,,,,0x00200000" complete_cpuset="0x00200000,,,,0x00200000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="136" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="21" cpuset="0x00200000,,,,0x00200000" complete_cpuset="0x00200000,,,,0x00200000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="132">
+                  <object type="PU" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="134"/>
+                  <object type="PU" os_index="149" cpuset="0x00200000,,,,0x0" complete_cpuset="0x00200000,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="809"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="22" cpuset="0x00400000,,,,0x00400000" complete_cpuset="0x00400000,,,,0x00400000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="143" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="22" cpuset="0x00400000,,,,0x00400000" complete_cpuset="0x00400000,,,,0x00400000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="141" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="22" cpuset="0x00400000,,,,0x00400000" complete_cpuset="0x00400000,,,,0x00400000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="142" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="22" cpuset="0x00400000,,,,0x00400000" complete_cpuset="0x00400000,,,,0x00400000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="138">
+                  <object type="PU" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="140"/>
+                  <object type="PU" os_index="150" cpuset="0x00400000,,,,0x0" complete_cpuset="0x00400000,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="810"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="23" cpuset="0x00800000,,,,0x00800000" complete_cpuset="0x00800000,,,,0x00800000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="149" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="23" cpuset="0x00800000,,,,0x00800000" complete_cpuset="0x00800000,,,,0x00800000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="147" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="23" cpuset="0x00800000,,,,0x00800000" complete_cpuset="0x00800000,,,,0x00800000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="148" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="23" cpuset="0x00800000,,,,0x00800000" complete_cpuset="0x00800000,,,,0x00800000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="144">
+                  <object type="PU" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="146"/>
+                  <object type="PU" os_index="151" cpuset="0x00800000,,,,0x0" complete_cpuset="0x00800000,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="811"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L3Cache" os_index="3" cpuset="0xff000000,,,,0xff000000" complete_cpuset="0xff000000,,,,0xff000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="156" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L2Cache" os_index="24" cpuset="0x01000000,,,,0x01000000" complete_cpuset="0x01000000,,,,0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="155" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="24" cpuset="0x01000000,,,,0x01000000" complete_cpuset="0x01000000,,,,0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="153" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="24" cpuset="0x01000000,,,,0x01000000" complete_cpuset="0x01000000,,,,0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="154" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="24" cpuset="0x01000000,,,,0x01000000" complete_cpuset="0x01000000,,,,0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="150">
+                  <object type="PU" os_index="24" cpuset="0x01000000" complete_cpuset="0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="152"/>
+                  <object type="PU" os_index="152" cpuset="0x01000000,,,,0x0" complete_cpuset="0x01000000,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="812"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="25" cpuset="0x02000000,,,,0x02000000" complete_cpuset="0x02000000,,,,0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="162" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="25" cpuset="0x02000000,,,,0x02000000" complete_cpuset="0x02000000,,,,0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="160" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="25" cpuset="0x02000000,,,,0x02000000" complete_cpuset="0x02000000,,,,0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="161" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="25" cpuset="0x02000000,,,,0x02000000" complete_cpuset="0x02000000,,,,0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="157">
+                  <object type="PU" os_index="25" cpuset="0x02000000" complete_cpuset="0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="159"/>
+                  <object type="PU" os_index="153" cpuset="0x02000000,,,,0x0" complete_cpuset="0x02000000,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="813"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="26" cpuset="0x04000000,,,,0x04000000" complete_cpuset="0x04000000,,,,0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="168" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="26" cpuset="0x04000000,,,,0x04000000" complete_cpuset="0x04000000,,,,0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="166" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="26" cpuset="0x04000000,,,,0x04000000" complete_cpuset="0x04000000,,,,0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="167" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="26" cpuset="0x04000000,,,,0x04000000" complete_cpuset="0x04000000,,,,0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="163">
+                  <object type="PU" os_index="26" cpuset="0x04000000" complete_cpuset="0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="165"/>
+                  <object type="PU" os_index="154" cpuset="0x04000000,,,,0x0" complete_cpuset="0x04000000,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="814"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="27" cpuset="0x08000000,,,,0x08000000" complete_cpuset="0x08000000,,,,0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="174" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="27" cpuset="0x08000000,,,,0x08000000" complete_cpuset="0x08000000,,,,0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="172" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="27" cpuset="0x08000000,,,,0x08000000" complete_cpuset="0x08000000,,,,0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="173" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="27" cpuset="0x08000000,,,,0x08000000" complete_cpuset="0x08000000,,,,0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="169">
+                  <object type="PU" os_index="27" cpuset="0x08000000" complete_cpuset="0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="171"/>
+                  <object type="PU" os_index="155" cpuset="0x08000000,,,,0x0" complete_cpuset="0x08000000,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="815"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="28" cpuset="0x10000000,,,,0x10000000" complete_cpuset="0x10000000,,,,0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="180" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="28" cpuset="0x10000000,,,,0x10000000" complete_cpuset="0x10000000,,,,0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="178" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="28" cpuset="0x10000000,,,,0x10000000" complete_cpuset="0x10000000,,,,0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="179" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="28" cpuset="0x10000000,,,,0x10000000" complete_cpuset="0x10000000,,,,0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="175">
+                  <object type="PU" os_index="28" cpuset="0x10000000" complete_cpuset="0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="177"/>
+                  <object type="PU" os_index="156" cpuset="0x10000000,,,,0x0" complete_cpuset="0x10000000,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="816"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="29" cpuset="0x20000000,,,,0x20000000" complete_cpuset="0x20000000,,,,0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="186" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="29" cpuset="0x20000000,,,,0x20000000" complete_cpuset="0x20000000,,,,0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="184" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="29" cpuset="0x20000000,,,,0x20000000" complete_cpuset="0x20000000,,,,0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="185" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="29" cpuset="0x20000000,,,,0x20000000" complete_cpuset="0x20000000,,,,0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="181">
+                  <object type="PU" os_index="29" cpuset="0x20000000" complete_cpuset="0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="183"/>
+                  <object type="PU" os_index="157" cpuset="0x20000000,,,,0x0" complete_cpuset="0x20000000,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="817"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="30" cpuset="0x40000000,,,,0x40000000" complete_cpuset="0x40000000,,,,0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="192" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="30" cpuset="0x40000000,,,,0x40000000" complete_cpuset="0x40000000,,,,0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="190" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="30" cpuset="0x40000000,,,,0x40000000" complete_cpuset="0x40000000,,,,0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="191" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="30" cpuset="0x40000000,,,,0x40000000" complete_cpuset="0x40000000,,,,0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="187">
+                  <object type="PU" os_index="30" cpuset="0x40000000" complete_cpuset="0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="189"/>
+                  <object type="PU" os_index="158" cpuset="0x40000000,,,,0x0" complete_cpuset="0x40000000,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="818"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="31" cpuset="0x80000000,,,,0x80000000" complete_cpuset="0x80000000,,,,0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="198" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="31" cpuset="0x80000000,,,,0x80000000" complete_cpuset="0x80000000,,,,0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="196" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="31" cpuset="0x80000000,,,,0x80000000" complete_cpuset="0x80000000,,,,0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="197" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="31" cpuset="0x80000000,,,,0x80000000" complete_cpuset="0x80000000,,,,0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="193">
+                  <object type="PU" os_index="31" cpuset="0x80000000" complete_cpuset="0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="195"/>
+                  <object type="PU" os_index="159" cpuset="0x80000000,,,,0x0" complete_cpuset="0x80000000,,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="819"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" gp_index="1040" bridge_type="0-1" depth="0" bridge_pci="0000:[40-43]">
+          <object type="Bridge" gp_index="1012" bridge_type="1-1" depth="1" bridge_pci="0000:[41-41]" pci_busid="0000:40:01.1" pci_type="0604 [1022:1483] [1022:1453] 00" pci_link_speed="0.250000">
+            <object type="PCIDev" gp_index="976" pci_busid="0000:41:00.0" pci_type="0200 [8086:1537] [ffff:0000] 03" pci_link_speed="0.250000">
+              <object type="OSDev" gp_index="1046" name="nmn0" osdev_type="2">
+                <info name="Address" value="00:40:a6:83:02:a9"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Group" cpuset="0x0000ffff,,,,0x0000ffff,0x0" complete_cpuset="0x0000ffff,,,,0x0000ffff,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="926" kind="1001" subkind="0">
+        <object type="NUMANode" os_index="2" cpuset="0x0000ffff,,,,0x0000ffff,0x0" complete_cpuset="0x0000ffff,,,,0x0000ffff,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="918" local_memory="33814581248">
+          <page_type size="4096" count="8255513"/>
+          <page_type size="2097152" count="0"/>
+          <page_type size="4194304" count="0"/>
+          <page_type size="8388608" count="0"/>
+          <page_type size="16777216" count="0"/>
+          <page_type size="33554432" count="0"/>
+          <page_type size="67108864" count="0"/>
+          <page_type size="134217728" count="0"/>
+          <page_type size="268435456" count="0"/>
+          <page_type size="536870912" count="0"/>
+          <page_type size="1073741824" count="0"/>
+          <page_type size="2147483648" count="0"/>
+        </object>
+        <object type="L3Cache" os_index="4" cpuset="0x000000ff,,,,0x000000ff,0x0" complete_cpuset="0x000000ff,,,,0x000000ff,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="205" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L2Cache" os_index="32" cpuset="0x00000001,,,,0x00000001,0x0" complete_cpuset="0x00000001,,,,0x00000001,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="204" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="32" cpuset="0x00000001,,,,0x00000001,0x0" complete_cpuset="0x00000001,,,,0x00000001,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="202" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="32" cpuset="0x00000001,,,,0x00000001,0x0" complete_cpuset="0x00000001,,,,0x00000001,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="203" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="32" cpuset="0x00000001,,,,0x00000001,0x0" complete_cpuset="0x00000001,,,,0x00000001,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="199">
+                  <object type="PU" os_index="32" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="201"/>
+                  <object type="PU" os_index="160" cpuset="0x00000001,,,,,0x0" complete_cpuset="0x00000001,,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="820"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="33" cpuset="0x00000002,,,,0x00000002,0x0" complete_cpuset="0x00000002,,,,0x00000002,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="211" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="33" cpuset="0x00000002,,,,0x00000002,0x0" complete_cpuset="0x00000002,,,,0x00000002,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="209" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="33" cpuset="0x00000002,,,,0x00000002,0x0" complete_cpuset="0x00000002,,,,0x00000002,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="210" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="33" cpuset="0x00000002,,,,0x00000002,0x0" complete_cpuset="0x00000002,,,,0x00000002,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="206">
+                  <object type="PU" os_index="33" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="208"/>
+                  <object type="PU" os_index="161" cpuset="0x00000002,,,,,0x0" complete_cpuset="0x00000002,,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="821"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="34" cpuset="0x00000004,,,,0x00000004,0x0" complete_cpuset="0x00000004,,,,0x00000004,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="217" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="34" cpuset="0x00000004,,,,0x00000004,0x0" complete_cpuset="0x00000004,,,,0x00000004,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="215" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="34" cpuset="0x00000004,,,,0x00000004,0x0" complete_cpuset="0x00000004,,,,0x00000004,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="216" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="34" cpuset="0x00000004,,,,0x00000004,0x0" complete_cpuset="0x00000004,,,,0x00000004,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="212">
+                  <object type="PU" os_index="34" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="214"/>
+                  <object type="PU" os_index="162" cpuset="0x00000004,,,,,0x0" complete_cpuset="0x00000004,,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="822"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="35" cpuset="0x00000008,,,,0x00000008,0x0" complete_cpuset="0x00000008,,,,0x00000008,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="223" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="35" cpuset="0x00000008,,,,0x00000008,0x0" complete_cpuset="0x00000008,,,,0x00000008,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="221" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="35" cpuset="0x00000008,,,,0x00000008,0x0" complete_cpuset="0x00000008,,,,0x00000008,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="222" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="35" cpuset="0x00000008,,,,0x00000008,0x0" complete_cpuset="0x00000008,,,,0x00000008,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="218">
+                  <object type="PU" os_index="35" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="220"/>
+                  <object type="PU" os_index="163" cpuset="0x00000008,,,,,0x0" complete_cpuset="0x00000008,,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="823"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="36" cpuset="0x00000010,,,,0x00000010,0x0" complete_cpuset="0x00000010,,,,0x00000010,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="229" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="36" cpuset="0x00000010,,,,0x00000010,0x0" complete_cpuset="0x00000010,,,,0x00000010,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="227" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="36" cpuset="0x00000010,,,,0x00000010,0x0" complete_cpuset="0x00000010,,,,0x00000010,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="228" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="36" cpuset="0x00000010,,,,0x00000010,0x0" complete_cpuset="0x00000010,,,,0x00000010,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="224">
+                  <object type="PU" os_index="36" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="226"/>
+                  <object type="PU" os_index="164" cpuset="0x00000010,,,,,0x0" complete_cpuset="0x00000010,,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="824"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="37" cpuset="0x00000020,,,,0x00000020,0x0" complete_cpuset="0x00000020,,,,0x00000020,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="235" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="37" cpuset="0x00000020,,,,0x00000020,0x0" complete_cpuset="0x00000020,,,,0x00000020,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="233" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="37" cpuset="0x00000020,,,,0x00000020,0x0" complete_cpuset="0x00000020,,,,0x00000020,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="234" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="37" cpuset="0x00000020,,,,0x00000020,0x0" complete_cpuset="0x00000020,,,,0x00000020,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="230">
+                  <object type="PU" os_index="37" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="232"/>
+                  <object type="PU" os_index="165" cpuset="0x00000020,,,,,0x0" complete_cpuset="0x00000020,,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="825"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="38" cpuset="0x00000040,,,,0x00000040,0x0" complete_cpuset="0x00000040,,,,0x00000040,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="241" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="38" cpuset="0x00000040,,,,0x00000040,0x0" complete_cpuset="0x00000040,,,,0x00000040,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="239" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="38" cpuset="0x00000040,,,,0x00000040,0x0" complete_cpuset="0x00000040,,,,0x00000040,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="240" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="38" cpuset="0x00000040,,,,0x00000040,0x0" complete_cpuset="0x00000040,,,,0x00000040,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="236">
+                  <object type="PU" os_index="38" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="238"/>
+                  <object type="PU" os_index="166" cpuset="0x00000040,,,,,0x0" complete_cpuset="0x00000040,,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="826"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="39" cpuset="0x00000080,,,,0x00000080,0x0" complete_cpuset="0x00000080,,,,0x00000080,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="247" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="39" cpuset="0x00000080,,,,0x00000080,0x0" complete_cpuset="0x00000080,,,,0x00000080,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="245" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="39" cpuset="0x00000080,,,,0x00000080,0x0" complete_cpuset="0x00000080,,,,0x00000080,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="246" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="39" cpuset="0x00000080,,,,0x00000080,0x0" complete_cpuset="0x00000080,,,,0x00000080,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="242">
+                  <object type="PU" os_index="39" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="244"/>
+                  <object type="PU" os_index="167" cpuset="0x00000080,,,,,0x0" complete_cpuset="0x00000080,,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="827"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L3Cache" os_index="5" cpuset="0x0000ff00,,,,0x0000ff00,0x0" complete_cpuset="0x0000ff00,,,,0x0000ff00,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="254" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L2Cache" os_index="40" cpuset="0x00000100,,,,0x00000100,0x0" complete_cpuset="0x00000100,,,,0x00000100,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="253" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="40" cpuset="0x00000100,,,,0x00000100,0x0" complete_cpuset="0x00000100,,,,0x00000100,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="251" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="40" cpuset="0x00000100,,,,0x00000100,0x0" complete_cpuset="0x00000100,,,,0x00000100,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="252" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="40" cpuset="0x00000100,,,,0x00000100,0x0" complete_cpuset="0x00000100,,,,0x00000100,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="248">
+                  <object type="PU" os_index="40" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="250"/>
+                  <object type="PU" os_index="168" cpuset="0x00000100,,,,,0x0" complete_cpuset="0x00000100,,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="828"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="41" cpuset="0x00000200,,,,0x00000200,0x0" complete_cpuset="0x00000200,,,,0x00000200,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="260" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="41" cpuset="0x00000200,,,,0x00000200,0x0" complete_cpuset="0x00000200,,,,0x00000200,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="258" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="41" cpuset="0x00000200,,,,0x00000200,0x0" complete_cpuset="0x00000200,,,,0x00000200,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="259" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="41" cpuset="0x00000200,,,,0x00000200,0x0" complete_cpuset="0x00000200,,,,0x00000200,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="255">
+                  <object type="PU" os_index="41" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="257"/>
+                  <object type="PU" os_index="169" cpuset="0x00000200,,,,,0x0" complete_cpuset="0x00000200,,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="829"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="42" cpuset="0x00000400,,,,0x00000400,0x0" complete_cpuset="0x00000400,,,,0x00000400,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="266" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="42" cpuset="0x00000400,,,,0x00000400,0x0" complete_cpuset="0x00000400,,,,0x00000400,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="264" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="42" cpuset="0x00000400,,,,0x00000400,0x0" complete_cpuset="0x00000400,,,,0x00000400,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="265" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="42" cpuset="0x00000400,,,,0x00000400,0x0" complete_cpuset="0x00000400,,,,0x00000400,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="261">
+                  <object type="PU" os_index="42" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="263"/>
+                  <object type="PU" os_index="170" cpuset="0x00000400,,,,,0x0" complete_cpuset="0x00000400,,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="830"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="43" cpuset="0x00000800,,,,0x00000800,0x0" complete_cpuset="0x00000800,,,,0x00000800,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="272" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="43" cpuset="0x00000800,,,,0x00000800,0x0" complete_cpuset="0x00000800,,,,0x00000800,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="270" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="43" cpuset="0x00000800,,,,0x00000800,0x0" complete_cpuset="0x00000800,,,,0x00000800,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="271" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="43" cpuset="0x00000800,,,,0x00000800,0x0" complete_cpuset="0x00000800,,,,0x00000800,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="267">
+                  <object type="PU" os_index="43" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="269"/>
+                  <object type="PU" os_index="171" cpuset="0x00000800,,,,,0x0" complete_cpuset="0x00000800,,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="831"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="44" cpuset="0x00001000,,,,0x00001000,0x0" complete_cpuset="0x00001000,,,,0x00001000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="278" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="44" cpuset="0x00001000,,,,0x00001000,0x0" complete_cpuset="0x00001000,,,,0x00001000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="276" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="44" cpuset="0x00001000,,,,0x00001000,0x0" complete_cpuset="0x00001000,,,,0x00001000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="277" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="44" cpuset="0x00001000,,,,0x00001000,0x0" complete_cpuset="0x00001000,,,,0x00001000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="273">
+                  <object type="PU" os_index="44" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="275"/>
+                  <object type="PU" os_index="172" cpuset="0x00001000,,,,,0x0" complete_cpuset="0x00001000,,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="832"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="45" cpuset="0x00002000,,,,0x00002000,0x0" complete_cpuset="0x00002000,,,,0x00002000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="284" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="45" cpuset="0x00002000,,,,0x00002000,0x0" complete_cpuset="0x00002000,,,,0x00002000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="282" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="45" cpuset="0x00002000,,,,0x00002000,0x0" complete_cpuset="0x00002000,,,,0x00002000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="283" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="45" cpuset="0x00002000,,,,0x00002000,0x0" complete_cpuset="0x00002000,,,,0x00002000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="279">
+                  <object type="PU" os_index="45" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="281"/>
+                  <object type="PU" os_index="173" cpuset="0x00002000,,,,,0x0" complete_cpuset="0x00002000,,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="833"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="46" cpuset="0x00004000,,,,0x00004000,0x0" complete_cpuset="0x00004000,,,,0x00004000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="290" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="46" cpuset="0x00004000,,,,0x00004000,0x0" complete_cpuset="0x00004000,,,,0x00004000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="288" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="46" cpuset="0x00004000,,,,0x00004000,0x0" complete_cpuset="0x00004000,,,,0x00004000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="289" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="46" cpuset="0x00004000,,,,0x00004000,0x0" complete_cpuset="0x00004000,,,,0x00004000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="285">
+                  <object type="PU" os_index="46" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="287"/>
+                  <object type="PU" os_index="174" cpuset="0x00004000,,,,,0x0" complete_cpuset="0x00004000,,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="834"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="47" cpuset="0x00008000,,,,0x00008000,0x0" complete_cpuset="0x00008000,,,,0x00008000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="296" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="47" cpuset="0x00008000,,,,0x00008000,0x0" complete_cpuset="0x00008000,,,,0x00008000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="294" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="47" cpuset="0x00008000,,,,0x00008000,0x0" complete_cpuset="0x00008000,,,,0x00008000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="295" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="47" cpuset="0x00008000,,,,0x00008000,0x0" complete_cpuset="0x00008000,,,,0x00008000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="291">
+                  <object type="PU" os_index="47" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="293"/>
+                  <object type="PU" os_index="175" cpuset="0x00008000,,,,,0x0" complete_cpuset="0x00008000,,,,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="835"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" gp_index="1039" bridge_type="0-1" depth="0" bridge_pci="0000:[20-23]">
+          <object type="Bridge" gp_index="994" bridge_type="1-1" depth="1" bridge_pci="0000:[21-21]" pci_busid="0000:20:03.1" pci_type="0604 [1022:1483] [1022:1453] 00" pci_link_speed="31.507692">
+            <object type="PCIDev" gp_index="1026" pci_busid="0000:21:00.0" pci_type="0200 [17db:0501] [17db:0000] 02" pci_link_speed="31.507692">
+              <object type="OSDev" gp_index="1047" name="hsn0" osdev_type="2">
+                <info name="Address" value="02:00:00:00:00:62"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Group" cpuset="0xffff0000,,,,0xffff0000,0x0" complete_cpuset="0xffff0000,,,,0xffff0000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="927" kind="1001" subkind="0">
+        <object type="NUMANode" os_index="3" cpuset="0xffff0000,,,,0xffff0000,0x0" complete_cpuset="0xffff0000,,,,0xffff0000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="919" local_memory="33801994240">
+          <page_type size="4096" count="8252440"/>
+          <page_type size="2097152" count="0"/>
+          <page_type size="4194304" count="0"/>
+          <page_type size="8388608" count="0"/>
+          <page_type size="16777216" count="0"/>
+          <page_type size="33554432" count="0"/>
+          <page_type size="67108864" count="0"/>
+          <page_type size="134217728" count="0"/>
+          <page_type size="268435456" count="0"/>
+          <page_type size="536870912" count="0"/>
+          <page_type size="1073741824" count="0"/>
+          <page_type size="2147483648" count="0"/>
+        </object>
+        <object type="L3Cache" os_index="6" cpuset="0x00ff0000,,,,0x00ff0000,0x0" complete_cpuset="0x00ff0000,,,,0x00ff0000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="303" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L2Cache" os_index="48" cpuset="0x00010000,,,,0x00010000,0x0" complete_cpuset="0x00010000,,,,0x00010000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="302" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="48" cpuset="0x00010000,,,,0x00010000,0x0" complete_cpuset="0x00010000,,,,0x00010000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="300" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="48" cpuset="0x00010000,,,,0x00010000,0x0" complete_cpuset="0x00010000,,,,0x00010000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="301" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="48" cpuset="0x00010000,,,,0x00010000,0x0" complete_cpuset="0x00010000,,,,0x00010000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="297">
+                  <object type="PU" os_index="48" cpuset="0x00010000,0x0" complete_cpuset="0x00010000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="299"/>
+                  <object type="PU" os_index="176" cpuset="0x00010000,,,,,0x0" complete_cpuset="0x00010000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="836"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="49" cpuset="0x00020000,,,,0x00020000,0x0" complete_cpuset="0x00020000,,,,0x00020000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="309" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="49" cpuset="0x00020000,,,,0x00020000,0x0" complete_cpuset="0x00020000,,,,0x00020000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="307" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="49" cpuset="0x00020000,,,,0x00020000,0x0" complete_cpuset="0x00020000,,,,0x00020000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="308" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="49" cpuset="0x00020000,,,,0x00020000,0x0" complete_cpuset="0x00020000,,,,0x00020000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="304">
+                  <object type="PU" os_index="49" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="306"/>
+                  <object type="PU" os_index="177" cpuset="0x00020000,,,,,0x0" complete_cpuset="0x00020000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="837"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="50" cpuset="0x00040000,,,,0x00040000,0x0" complete_cpuset="0x00040000,,,,0x00040000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="315" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="50" cpuset="0x00040000,,,,0x00040000,0x0" complete_cpuset="0x00040000,,,,0x00040000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="313" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="50" cpuset="0x00040000,,,,0x00040000,0x0" complete_cpuset="0x00040000,,,,0x00040000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="314" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="50" cpuset="0x00040000,,,,0x00040000,0x0" complete_cpuset="0x00040000,,,,0x00040000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="310">
+                  <object type="PU" os_index="50" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="312"/>
+                  <object type="PU" os_index="178" cpuset="0x00040000,,,,,0x0" complete_cpuset="0x00040000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="838"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="51" cpuset="0x00080000,,,,0x00080000,0x0" complete_cpuset="0x00080000,,,,0x00080000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="321" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="51" cpuset="0x00080000,,,,0x00080000,0x0" complete_cpuset="0x00080000,,,,0x00080000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="319" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="51" cpuset="0x00080000,,,,0x00080000,0x0" complete_cpuset="0x00080000,,,,0x00080000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="320" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="51" cpuset="0x00080000,,,,0x00080000,0x0" complete_cpuset="0x00080000,,,,0x00080000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="316">
+                  <object type="PU" os_index="51" cpuset="0x00080000,0x0" complete_cpuset="0x00080000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="318"/>
+                  <object type="PU" os_index="179" cpuset="0x00080000,,,,,0x0" complete_cpuset="0x00080000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="839"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="52" cpuset="0x00100000,,,,0x00100000,0x0" complete_cpuset="0x00100000,,,,0x00100000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="327" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="52" cpuset="0x00100000,,,,0x00100000,0x0" complete_cpuset="0x00100000,,,,0x00100000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="325" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="52" cpuset="0x00100000,,,,0x00100000,0x0" complete_cpuset="0x00100000,,,,0x00100000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="326" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="52" cpuset="0x00100000,,,,0x00100000,0x0" complete_cpuset="0x00100000,,,,0x00100000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="322">
+                  <object type="PU" os_index="52" cpuset="0x00100000,0x0" complete_cpuset="0x00100000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="324"/>
+                  <object type="PU" os_index="180" cpuset="0x00100000,,,,,0x0" complete_cpuset="0x00100000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="840"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="53" cpuset="0x00200000,,,,0x00200000,0x0" complete_cpuset="0x00200000,,,,0x00200000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="333" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="53" cpuset="0x00200000,,,,0x00200000,0x0" complete_cpuset="0x00200000,,,,0x00200000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="331" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="53" cpuset="0x00200000,,,,0x00200000,0x0" complete_cpuset="0x00200000,,,,0x00200000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="332" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="53" cpuset="0x00200000,,,,0x00200000,0x0" complete_cpuset="0x00200000,,,,0x00200000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="328">
+                  <object type="PU" os_index="53" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="330"/>
+                  <object type="PU" os_index="181" cpuset="0x00200000,,,,,0x0" complete_cpuset="0x00200000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="841"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="54" cpuset="0x00400000,,,,0x00400000,0x0" complete_cpuset="0x00400000,,,,0x00400000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="339" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="54" cpuset="0x00400000,,,,0x00400000,0x0" complete_cpuset="0x00400000,,,,0x00400000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="337" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="54" cpuset="0x00400000,,,,0x00400000,0x0" complete_cpuset="0x00400000,,,,0x00400000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="338" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="54" cpuset="0x00400000,,,,0x00400000,0x0" complete_cpuset="0x00400000,,,,0x00400000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="334">
+                  <object type="PU" os_index="54" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="336"/>
+                  <object type="PU" os_index="182" cpuset="0x00400000,,,,,0x0" complete_cpuset="0x00400000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="842"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="55" cpuset="0x00800000,,,,0x00800000,0x0" complete_cpuset="0x00800000,,,,0x00800000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="345" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="55" cpuset="0x00800000,,,,0x00800000,0x0" complete_cpuset="0x00800000,,,,0x00800000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="343" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="55" cpuset="0x00800000,,,,0x00800000,0x0" complete_cpuset="0x00800000,,,,0x00800000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="344" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="55" cpuset="0x00800000,,,,0x00800000,0x0" complete_cpuset="0x00800000,,,,0x00800000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="340">
+                  <object type="PU" os_index="55" cpuset="0x00800000,0x0" complete_cpuset="0x00800000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="342"/>
+                  <object type="PU" os_index="183" cpuset="0x00800000,,,,,0x0" complete_cpuset="0x00800000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="843"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L3Cache" os_index="7" cpuset="0xff000000,,,,0xff000000,0x0" complete_cpuset="0xff000000,,,,0xff000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="352" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L2Cache" os_index="56" cpuset="0x01000000,,,,0x01000000,0x0" complete_cpuset="0x01000000,,,,0x01000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="351" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="56" cpuset="0x01000000,,,,0x01000000,0x0" complete_cpuset="0x01000000,,,,0x01000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="349" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="56" cpuset="0x01000000,,,,0x01000000,0x0" complete_cpuset="0x01000000,,,,0x01000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="350" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="56" cpuset="0x01000000,,,,0x01000000,0x0" complete_cpuset="0x01000000,,,,0x01000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="346">
+                  <object type="PU" os_index="56" cpuset="0x01000000,0x0" complete_cpuset="0x01000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="348"/>
+                  <object type="PU" os_index="184" cpuset="0x01000000,,,,,0x0" complete_cpuset="0x01000000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="844"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="57" cpuset="0x02000000,,,,0x02000000,0x0" complete_cpuset="0x02000000,,,,0x02000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="358" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="57" cpuset="0x02000000,,,,0x02000000,0x0" complete_cpuset="0x02000000,,,,0x02000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="356" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="57" cpuset="0x02000000,,,,0x02000000,0x0" complete_cpuset="0x02000000,,,,0x02000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="357" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="57" cpuset="0x02000000,,,,0x02000000,0x0" complete_cpuset="0x02000000,,,,0x02000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="353">
+                  <object type="PU" os_index="57" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="355"/>
+                  <object type="PU" os_index="185" cpuset="0x02000000,,,,,0x0" complete_cpuset="0x02000000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="845"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="58" cpuset="0x04000000,,,,0x04000000,0x0" complete_cpuset="0x04000000,,,,0x04000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="364" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="58" cpuset="0x04000000,,,,0x04000000,0x0" complete_cpuset="0x04000000,,,,0x04000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="362" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="58" cpuset="0x04000000,,,,0x04000000,0x0" complete_cpuset="0x04000000,,,,0x04000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="363" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="58" cpuset="0x04000000,,,,0x04000000,0x0" complete_cpuset="0x04000000,,,,0x04000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="359">
+                  <object type="PU" os_index="58" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="361"/>
+                  <object type="PU" os_index="186" cpuset="0x04000000,,,,,0x0" complete_cpuset="0x04000000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="846"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="59" cpuset="0x08000000,,,,0x08000000,0x0" complete_cpuset="0x08000000,,,,0x08000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="370" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="59" cpuset="0x08000000,,,,0x08000000,0x0" complete_cpuset="0x08000000,,,,0x08000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="368" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="59" cpuset="0x08000000,,,,0x08000000,0x0" complete_cpuset="0x08000000,,,,0x08000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="369" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="59" cpuset="0x08000000,,,,0x08000000,0x0" complete_cpuset="0x08000000,,,,0x08000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="365">
+                  <object type="PU" os_index="59" cpuset="0x08000000,0x0" complete_cpuset="0x08000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="367"/>
+                  <object type="PU" os_index="187" cpuset="0x08000000,,,,,0x0" complete_cpuset="0x08000000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="847"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="60" cpuset="0x10000000,,,,0x10000000,0x0" complete_cpuset="0x10000000,,,,0x10000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="376" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="60" cpuset="0x10000000,,,,0x10000000,0x0" complete_cpuset="0x10000000,,,,0x10000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="374" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="60" cpuset="0x10000000,,,,0x10000000,0x0" complete_cpuset="0x10000000,,,,0x10000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="375" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="60" cpuset="0x10000000,,,,0x10000000,0x0" complete_cpuset="0x10000000,,,,0x10000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="371">
+                  <object type="PU" os_index="60" cpuset="0x10000000,0x0" complete_cpuset="0x10000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="373"/>
+                  <object type="PU" os_index="188" cpuset="0x10000000,,,,,0x0" complete_cpuset="0x10000000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="848"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="61" cpuset="0x20000000,,,,0x20000000,0x0" complete_cpuset="0x20000000,,,,0x20000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="382" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="61" cpuset="0x20000000,,,,0x20000000,0x0" complete_cpuset="0x20000000,,,,0x20000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="380" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="61" cpuset="0x20000000,,,,0x20000000,0x0" complete_cpuset="0x20000000,,,,0x20000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="381" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="61" cpuset="0x20000000,,,,0x20000000,0x0" complete_cpuset="0x20000000,,,,0x20000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="377">
+                  <object type="PU" os_index="61" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="379"/>
+                  <object type="PU" os_index="189" cpuset="0x20000000,,,,,0x0" complete_cpuset="0x20000000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="849"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="62" cpuset="0x40000000,,,,0x40000000,0x0" complete_cpuset="0x40000000,,,,0x40000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="388" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="62" cpuset="0x40000000,,,,0x40000000,0x0" complete_cpuset="0x40000000,,,,0x40000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="386" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="62" cpuset="0x40000000,,,,0x40000000,0x0" complete_cpuset="0x40000000,,,,0x40000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="387" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="62" cpuset="0x40000000,,,,0x40000000,0x0" complete_cpuset="0x40000000,,,,0x40000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="383">
+                  <object type="PU" os_index="62" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="385"/>
+                  <object type="PU" os_index="190" cpuset="0x40000000,,,,,0x0" complete_cpuset="0x40000000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="850"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="63" cpuset="0x80000000,,,,0x80000000,0x0" complete_cpuset="0x80000000,,,,0x80000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="394" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="63" cpuset="0x80000000,,,,0x80000000,0x0" complete_cpuset="0x80000000,,,,0x80000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="392" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="63" cpuset="0x80000000,,,,0x80000000,0x0" complete_cpuset="0x80000000,,,,0x80000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="393" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="63" cpuset="0x80000000,,,,0x80000000,0x0" complete_cpuset="0x80000000,,,,0x80000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="389">
+                  <object type="PU" os_index="63" cpuset="0x80000000,0x0" complete_cpuset="0x80000000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="391"/>
+                  <object type="PU" os_index="191" cpuset="0x80000000,,,,,0x0" complete_cpuset="0x80000000,,,,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="851"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="Package" os_index="1" cpuset="0xffffffff,0xffffffff,,,0xffffffff,0xffffffff,,0x0" complete_cpuset="0xffffffff,0xffffffff,,,0xffffffff,0xffffffff,,0x0" nodeset="0x000000f0" complete_nodeset="0x000000f0" gp_index="396">
+      <info name="CPUVendor" value="AuthenticAMD"/>
+      <info name="CPUFamilyNumber" value="25"/>
+      <info name="CPUModelNumber" value="1"/>
+      <info name="CPUModel" value="AMD EPYC 7713 64-Core Processor                "/>
+      <info name="CPUStepping" value="1"/>
+      <object type="Group" cpuset="0x0000ffff,,,,0x0000ffff,,0x0" complete_cpuset="0x0000ffff,,,,0x0000ffff,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="928" kind="1001" subkind="0">
+        <object type="NUMANode" os_index="4" cpuset="0x0000ffff,,,,0x0000ffff,,0x0" complete_cpuset="0x0000ffff,,,,0x0000ffff,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="920" local_memory="33814581248">
+          <page_type size="4096" count="8255513"/>
+          <page_type size="2097152" count="0"/>
+          <page_type size="4194304" count="0"/>
+          <page_type size="8388608" count="0"/>
+          <page_type size="16777216" count="0"/>
+          <page_type size="33554432" count="0"/>
+          <page_type size="67108864" count="0"/>
+          <page_type size="134217728" count="0"/>
+          <page_type size="268435456" count="0"/>
+          <page_type size="536870912" count="0"/>
+          <page_type size="1073741824" count="0"/>
+          <page_type size="2147483648" count="0"/>
+        </object>
+        <object type="L3Cache" os_index="8" cpuset="0x000000ff,,,,0x000000ff,,0x0" complete_cpuset="0x000000ff,,,,0x000000ff,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="402" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L2Cache" os_index="64" cpuset="0x00000001,,,,0x00000001,,0x0" complete_cpuset="0x00000001,,,,0x00000001,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="401" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="64" cpuset="0x00000001,,,,0x00000001,,0x0" complete_cpuset="0x00000001,,,,0x00000001,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="399" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="64" cpuset="0x00000001,,,,0x00000001,,0x0" complete_cpuset="0x00000001,,,,0x00000001,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="400" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="0" cpuset="0x00000001,,,,0x00000001,,0x0" complete_cpuset="0x00000001,,,,0x00000001,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="395">
+                  <object type="PU" os_index="64" cpuset="0x00000001,,0x0" complete_cpuset="0x00000001,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="398"/>
+                  <object type="PU" os_index="192" cpuset="0x00000001,,,,,,0x0" complete_cpuset="0x00000001,,,,,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="852"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="65" cpuset="0x00000002,,,,0x00000002,,0x0" complete_cpuset="0x00000002,,,,0x00000002,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="408" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="65" cpuset="0x00000002,,,,0x00000002,,0x0" complete_cpuset="0x00000002,,,,0x00000002,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="406" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="65" cpuset="0x00000002,,,,0x00000002,,0x0" complete_cpuset="0x00000002,,,,0x00000002,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="407" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="1" cpuset="0x00000002,,,,0x00000002,,0x0" complete_cpuset="0x00000002,,,,0x00000002,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="403">
+                  <object type="PU" os_index="65" cpuset="0x00000002,,0x0" complete_cpuset="0x00000002,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="405"/>
+                  <object type="PU" os_index="193" cpuset="0x00000002,,,,,,0x0" complete_cpuset="0x00000002,,,,,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="853"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="66" cpuset="0x00000004,,,,0x00000004,,0x0" complete_cpuset="0x00000004,,,,0x00000004,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="414" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="66" cpuset="0x00000004,,,,0x00000004,,0x0" complete_cpuset="0x00000004,,,,0x00000004,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="412" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="66" cpuset="0x00000004,,,,0x00000004,,0x0" complete_cpuset="0x00000004,,,,0x00000004,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="413" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="2" cpuset="0x00000004,,,,0x00000004,,0x0" complete_cpuset="0x00000004,,,,0x00000004,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="409">
+                  <object type="PU" os_index="66" cpuset="0x00000004,,0x0" complete_cpuset="0x00000004,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="411"/>
+                  <object type="PU" os_index="194" cpuset="0x00000004,,,,,,0x0" complete_cpuset="0x00000004,,,,,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="854"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="67" cpuset="0x00000008,,,,0x00000008,,0x0" complete_cpuset="0x00000008,,,,0x00000008,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="420" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="67" cpuset="0x00000008,,,,0x00000008,,0x0" complete_cpuset="0x00000008,,,,0x00000008,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="418" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="67" cpuset="0x00000008,,,,0x00000008,,0x0" complete_cpuset="0x00000008,,,,0x00000008,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="419" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="3" cpuset="0x00000008,,,,0x00000008,,0x0" complete_cpuset="0x00000008,,,,0x00000008,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="415">
+                  <object type="PU" os_index="67" cpuset="0x00000008,,0x0" complete_cpuset="0x00000008,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="417"/>
+                  <object type="PU" os_index="195" cpuset="0x00000008,,,,,,0x0" complete_cpuset="0x00000008,,,,,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="855"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="68" cpuset="0x00000010,,,,0x00000010,,0x0" complete_cpuset="0x00000010,,,,0x00000010,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="426" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="68" cpuset="0x00000010,,,,0x00000010,,0x0" complete_cpuset="0x00000010,,,,0x00000010,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="424" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="68" cpuset="0x00000010,,,,0x00000010,,0x0" complete_cpuset="0x00000010,,,,0x00000010,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="425" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="4" cpuset="0x00000010,,,,0x00000010,,0x0" complete_cpuset="0x00000010,,,,0x00000010,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="421">
+                  <object type="PU" os_index="68" cpuset="0x00000010,,0x0" complete_cpuset="0x00000010,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="423"/>
+                  <object type="PU" os_index="196" cpuset="0x00000010,,,,,,0x0" complete_cpuset="0x00000010,,,,,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="856"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="69" cpuset="0x00000020,,,,0x00000020,,0x0" complete_cpuset="0x00000020,,,,0x00000020,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="432" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="69" cpuset="0x00000020,,,,0x00000020,,0x0" complete_cpuset="0x00000020,,,,0x00000020,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="430" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="69" cpuset="0x00000020,,,,0x00000020,,0x0" complete_cpuset="0x00000020,,,,0x00000020,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="431" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="5" cpuset="0x00000020,,,,0x00000020,,0x0" complete_cpuset="0x00000020,,,,0x00000020,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="427">
+                  <object type="PU" os_index="69" cpuset="0x00000020,,0x0" complete_cpuset="0x00000020,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="429"/>
+                  <object type="PU" os_index="197" cpuset="0x00000020,,,,,,0x0" complete_cpuset="0x00000020,,,,,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="857"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="70" cpuset="0x00000040,,,,0x00000040,,0x0" complete_cpuset="0x00000040,,,,0x00000040,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="438" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="70" cpuset="0x00000040,,,,0x00000040,,0x0" complete_cpuset="0x00000040,,,,0x00000040,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="436" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="70" cpuset="0x00000040,,,,0x00000040,,0x0" complete_cpuset="0x00000040,,,,0x00000040,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="437" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="6" cpuset="0x00000040,,,,0x00000040,,0x0" complete_cpuset="0x00000040,,,,0x00000040,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="433">
+                  <object type="PU" os_index="70" cpuset="0x00000040,,0x0" complete_cpuset="0x00000040,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="435"/>
+                  <object type="PU" os_index="198" cpuset="0x00000040,,,,,,0x0" complete_cpuset="0x00000040,,,,,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="858"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="71" cpuset="0x00000080,,,,0x00000080,,0x0" complete_cpuset="0x00000080,,,,0x00000080,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="444" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="71" cpuset="0x00000080,,,,0x00000080,,0x0" complete_cpuset="0x00000080,,,,0x00000080,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="442" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="71" cpuset="0x00000080,,,,0x00000080,,0x0" complete_cpuset="0x00000080,,,,0x00000080,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="443" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="7" cpuset="0x00000080,,,,0x00000080,,0x0" complete_cpuset="0x00000080,,,,0x00000080,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="439">
+                  <object type="PU" os_index="71" cpuset="0x00000080,,0x0" complete_cpuset="0x00000080,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="441"/>
+                  <object type="PU" os_index="199" cpuset="0x00000080,,,,,,0x0" complete_cpuset="0x00000080,,,,,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="859"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L3Cache" os_index="9" cpuset="0x0000ff00,,,,0x0000ff00,,0x0" complete_cpuset="0x0000ff00,,,,0x0000ff00,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="451" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L2Cache" os_index="72" cpuset="0x00000100,,,,0x00000100,,0x0" complete_cpuset="0x00000100,,,,0x00000100,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="450" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="72" cpuset="0x00000100,,,,0x00000100,,0x0" complete_cpuset="0x00000100,,,,0x00000100,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="448" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="72" cpuset="0x00000100,,,,0x00000100,,0x0" complete_cpuset="0x00000100,,,,0x00000100,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="449" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="8" cpuset="0x00000100,,,,0x00000100,,0x0" complete_cpuset="0x00000100,,,,0x00000100,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="445">
+                  <object type="PU" os_index="72" cpuset="0x00000100,,0x0" complete_cpuset="0x00000100,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="447"/>
+                  <object type="PU" os_index="200" cpuset="0x00000100,,,,,,0x0" complete_cpuset="0x00000100,,,,,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="860"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="73" cpuset="0x00000200,,,,0x00000200,,0x0" complete_cpuset="0x00000200,,,,0x00000200,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="457" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="73" cpuset="0x00000200,,,,0x00000200,,0x0" complete_cpuset="0x00000200,,,,0x00000200,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="455" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="73" cpuset="0x00000200,,,,0x00000200,,0x0" complete_cpuset="0x00000200,,,,0x00000200,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="456" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="9" cpuset="0x00000200,,,,0x00000200,,0x0" complete_cpuset="0x00000200,,,,0x00000200,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="452">
+                  <object type="PU" os_index="73" cpuset="0x00000200,,0x0" complete_cpuset="0x00000200,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="454"/>
+                  <object type="PU" os_index="201" cpuset="0x00000200,,,,,,0x0" complete_cpuset="0x00000200,,,,,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="861"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="74" cpuset="0x00000400,,,,0x00000400,,0x0" complete_cpuset="0x00000400,,,,0x00000400,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="463" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="74" cpuset="0x00000400,,,,0x00000400,,0x0" complete_cpuset="0x00000400,,,,0x00000400,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="461" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="74" cpuset="0x00000400,,,,0x00000400,,0x0" complete_cpuset="0x00000400,,,,0x00000400,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="462" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="10" cpuset="0x00000400,,,,0x00000400,,0x0" complete_cpuset="0x00000400,,,,0x00000400,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="458">
+                  <object type="PU" os_index="74" cpuset="0x00000400,,0x0" complete_cpuset="0x00000400,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="460"/>
+                  <object type="PU" os_index="202" cpuset="0x00000400,,,,,,0x0" complete_cpuset="0x00000400,,,,,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="862"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="75" cpuset="0x00000800,,,,0x00000800,,0x0" complete_cpuset="0x00000800,,,,0x00000800,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="469" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="75" cpuset="0x00000800,,,,0x00000800,,0x0" complete_cpuset="0x00000800,,,,0x00000800,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="467" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="75" cpuset="0x00000800,,,,0x00000800,,0x0" complete_cpuset="0x00000800,,,,0x00000800,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="468" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="11" cpuset="0x00000800,,,,0x00000800,,0x0" complete_cpuset="0x00000800,,,,0x00000800,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="464">
+                  <object type="PU" os_index="75" cpuset="0x00000800,,0x0" complete_cpuset="0x00000800,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="466"/>
+                  <object type="PU" os_index="203" cpuset="0x00000800,,,,,,0x0" complete_cpuset="0x00000800,,,,,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="863"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="76" cpuset="0x00001000,,,,0x00001000,,0x0" complete_cpuset="0x00001000,,,,0x00001000,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="475" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="76" cpuset="0x00001000,,,,0x00001000,,0x0" complete_cpuset="0x00001000,,,,0x00001000,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="473" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="76" cpuset="0x00001000,,,,0x00001000,,0x0" complete_cpuset="0x00001000,,,,0x00001000,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="474" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="12" cpuset="0x00001000,,,,0x00001000,,0x0" complete_cpuset="0x00001000,,,,0x00001000,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="470">
+                  <object type="PU" os_index="76" cpuset="0x00001000,,0x0" complete_cpuset="0x00001000,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="472"/>
+                  <object type="PU" os_index="204" cpuset="0x00001000,,,,,,0x0" complete_cpuset="0x00001000,,,,,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="864"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="77" cpuset="0x00002000,,,,0x00002000,,0x0" complete_cpuset="0x00002000,,,,0x00002000,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="481" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="77" cpuset="0x00002000,,,,0x00002000,,0x0" complete_cpuset="0x00002000,,,,0x00002000,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="479" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="77" cpuset="0x00002000,,,,0x00002000,,0x0" complete_cpuset="0x00002000,,,,0x00002000,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="480" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="13" cpuset="0x00002000,,,,0x00002000,,0x0" complete_cpuset="0x00002000,,,,0x00002000,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="476">
+                  <object type="PU" os_index="77" cpuset="0x00002000,,0x0" complete_cpuset="0x00002000,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="478"/>
+                  <object type="PU" os_index="205" cpuset="0x00002000,,,,,,0x0" complete_cpuset="0x00002000,,,,,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="865"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="78" cpuset="0x00004000,,,,0x00004000,,0x0" complete_cpuset="0x00004000,,,,0x00004000,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="487" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="78" cpuset="0x00004000,,,,0x00004000,,0x0" complete_cpuset="0x00004000,,,,0x00004000,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="485" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="78" cpuset="0x00004000,,,,0x00004000,,0x0" complete_cpuset="0x00004000,,,,0x00004000,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="486" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="14" cpuset="0x00004000,,,,0x00004000,,0x0" complete_cpuset="0x00004000,,,,0x00004000,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="482">
+                  <object type="PU" os_index="78" cpuset="0x00004000,,0x0" complete_cpuset="0x00004000,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="484"/>
+                  <object type="PU" os_index="206" cpuset="0x00004000,,,,,,0x0" complete_cpuset="0x00004000,,,,,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="866"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="79" cpuset="0x00008000,,,,0x00008000,,0x0" complete_cpuset="0x00008000,,,,0x00008000,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="493" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="79" cpuset="0x00008000,,,,0x00008000,,0x0" complete_cpuset="0x00008000,,,,0x00008000,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="491" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="79" cpuset="0x00008000,,,,0x00008000,,0x0" complete_cpuset="0x00008000,,,,0x00008000,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="492" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="15" cpuset="0x00008000,,,,0x00008000,,0x0" complete_cpuset="0x00008000,,,,0x00008000,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="488">
+                  <object type="PU" os_index="79" cpuset="0x00008000,,0x0" complete_cpuset="0x00008000,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="490"/>
+                  <object type="PU" os_index="207" cpuset="0x00008000,,,,,,0x0" complete_cpuset="0x00008000,,,,,,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" gp_index="867"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Group" cpuset="0xffff0000,,,,0xffff0000,,0x0" complete_cpuset="0xffff0000,,,,0xffff0000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="929" kind="1001" subkind="0">
+        <object type="NUMANode" os_index="5" cpuset="0xffff0000,,,,0xffff0000,,0x0" complete_cpuset="0xffff0000,,,,0xffff0000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="921" local_memory="33814577152">
+          <page_type size="4096" count="8255512"/>
+          <page_type size="2097152" count="0"/>
+          <page_type size="4194304" count="0"/>
+          <page_type size="8388608" count="0"/>
+          <page_type size="16777216" count="0"/>
+          <page_type size="33554432" count="0"/>
+          <page_type size="67108864" count="0"/>
+          <page_type size="134217728" count="0"/>
+          <page_type size="268435456" count="0"/>
+          <page_type size="536870912" count="0"/>
+          <page_type size="1073741824" count="0"/>
+          <page_type size="2147483648" count="0"/>
+        </object>
+        <object type="L3Cache" os_index="10" cpuset="0x00ff0000,,,,0x00ff0000,,0x0" complete_cpuset="0x00ff0000,,,,0x00ff0000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="500" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L2Cache" os_index="80" cpuset="0x00010000,,,,0x00010000,,0x0" complete_cpuset="0x00010000,,,,0x00010000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="499" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="80" cpuset="0x00010000,,,,0x00010000,,0x0" complete_cpuset="0x00010000,,,,0x00010000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="497" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="80" cpuset="0x00010000,,,,0x00010000,,0x0" complete_cpuset="0x00010000,,,,0x00010000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="498" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="16" cpuset="0x00010000,,,,0x00010000,,0x0" complete_cpuset="0x00010000,,,,0x00010000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="494">
+                  <object type="PU" os_index="80" cpuset="0x00010000,,0x0" complete_cpuset="0x00010000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="496"/>
+                  <object type="PU" os_index="208" cpuset="0x00010000,,,,,,0x0" complete_cpuset="0x00010000,,,,,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="868"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="81" cpuset="0x00020000,,,,0x00020000,,0x0" complete_cpuset="0x00020000,,,,0x00020000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="506" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="81" cpuset="0x00020000,,,,0x00020000,,0x0" complete_cpuset="0x00020000,,,,0x00020000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="504" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="81" cpuset="0x00020000,,,,0x00020000,,0x0" complete_cpuset="0x00020000,,,,0x00020000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="505" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="17" cpuset="0x00020000,,,,0x00020000,,0x0" complete_cpuset="0x00020000,,,,0x00020000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="501">
+                  <object type="PU" os_index="81" cpuset="0x00020000,,0x0" complete_cpuset="0x00020000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="503"/>
+                  <object type="PU" os_index="209" cpuset="0x00020000,,,,,,0x0" complete_cpuset="0x00020000,,,,,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="869"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="82" cpuset="0x00040000,,,,0x00040000,,0x0" complete_cpuset="0x00040000,,,,0x00040000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="512" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="82" cpuset="0x00040000,,,,0x00040000,,0x0" complete_cpuset="0x00040000,,,,0x00040000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="510" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="82" cpuset="0x00040000,,,,0x00040000,,0x0" complete_cpuset="0x00040000,,,,0x00040000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="511" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="18" cpuset="0x00040000,,,,0x00040000,,0x0" complete_cpuset="0x00040000,,,,0x00040000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="507">
+                  <object type="PU" os_index="82" cpuset="0x00040000,,0x0" complete_cpuset="0x00040000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="509"/>
+                  <object type="PU" os_index="210" cpuset="0x00040000,,,,,,0x0" complete_cpuset="0x00040000,,,,,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="870"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="83" cpuset="0x00080000,,,,0x00080000,,0x0" complete_cpuset="0x00080000,,,,0x00080000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="518" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="83" cpuset="0x00080000,,,,0x00080000,,0x0" complete_cpuset="0x00080000,,,,0x00080000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="516" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="83" cpuset="0x00080000,,,,0x00080000,,0x0" complete_cpuset="0x00080000,,,,0x00080000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="517" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="19" cpuset="0x00080000,,,,0x00080000,,0x0" complete_cpuset="0x00080000,,,,0x00080000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="513">
+                  <object type="PU" os_index="83" cpuset="0x00080000,,0x0" complete_cpuset="0x00080000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="515"/>
+                  <object type="PU" os_index="211" cpuset="0x00080000,,,,,,0x0" complete_cpuset="0x00080000,,,,,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="871"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="84" cpuset="0x00100000,,,,0x00100000,,0x0" complete_cpuset="0x00100000,,,,0x00100000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="524" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="84" cpuset="0x00100000,,,,0x00100000,,0x0" complete_cpuset="0x00100000,,,,0x00100000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="522" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="84" cpuset="0x00100000,,,,0x00100000,,0x0" complete_cpuset="0x00100000,,,,0x00100000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="523" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="20" cpuset="0x00100000,,,,0x00100000,,0x0" complete_cpuset="0x00100000,,,,0x00100000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="519">
+                  <object type="PU" os_index="84" cpuset="0x00100000,,0x0" complete_cpuset="0x00100000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="521"/>
+                  <object type="PU" os_index="212" cpuset="0x00100000,,,,,,0x0" complete_cpuset="0x00100000,,,,,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="872"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="85" cpuset="0x00200000,,,,0x00200000,,0x0" complete_cpuset="0x00200000,,,,0x00200000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="530" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="85" cpuset="0x00200000,,,,0x00200000,,0x0" complete_cpuset="0x00200000,,,,0x00200000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="528" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="85" cpuset="0x00200000,,,,0x00200000,,0x0" complete_cpuset="0x00200000,,,,0x00200000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="529" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="21" cpuset="0x00200000,,,,0x00200000,,0x0" complete_cpuset="0x00200000,,,,0x00200000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="525">
+                  <object type="PU" os_index="85" cpuset="0x00200000,,0x0" complete_cpuset="0x00200000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="527"/>
+                  <object type="PU" os_index="213" cpuset="0x00200000,,,,,,0x0" complete_cpuset="0x00200000,,,,,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="873"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="86" cpuset="0x00400000,,,,0x00400000,,0x0" complete_cpuset="0x00400000,,,,0x00400000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="536" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="86" cpuset="0x00400000,,,,0x00400000,,0x0" complete_cpuset="0x00400000,,,,0x00400000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="534" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="86" cpuset="0x00400000,,,,0x00400000,,0x0" complete_cpuset="0x00400000,,,,0x00400000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="535" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="22" cpuset="0x00400000,,,,0x00400000,,0x0" complete_cpuset="0x00400000,,,,0x00400000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="531">
+                  <object type="PU" os_index="86" cpuset="0x00400000,,0x0" complete_cpuset="0x00400000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="533"/>
+                  <object type="PU" os_index="214" cpuset="0x00400000,,,,,,0x0" complete_cpuset="0x00400000,,,,,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="874"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="87" cpuset="0x00800000,,,,0x00800000,,0x0" complete_cpuset="0x00800000,,,,0x00800000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="542" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="87" cpuset="0x00800000,,,,0x00800000,,0x0" complete_cpuset="0x00800000,,,,0x00800000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="540" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="87" cpuset="0x00800000,,,,0x00800000,,0x0" complete_cpuset="0x00800000,,,,0x00800000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="541" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="23" cpuset="0x00800000,,,,0x00800000,,0x0" complete_cpuset="0x00800000,,,,0x00800000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="537">
+                  <object type="PU" os_index="87" cpuset="0x00800000,,0x0" complete_cpuset="0x00800000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="539"/>
+                  <object type="PU" os_index="215" cpuset="0x00800000,,,,,,0x0" complete_cpuset="0x00800000,,,,,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="875"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L3Cache" os_index="11" cpuset="0xff000000,,,,0xff000000,,0x0" complete_cpuset="0xff000000,,,,0xff000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="549" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L2Cache" os_index="88" cpuset="0x01000000,,,,0x01000000,,0x0" complete_cpuset="0x01000000,,,,0x01000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="548" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="88" cpuset="0x01000000,,,,0x01000000,,0x0" complete_cpuset="0x01000000,,,,0x01000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="546" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="88" cpuset="0x01000000,,,,0x01000000,,0x0" complete_cpuset="0x01000000,,,,0x01000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="547" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="24" cpuset="0x01000000,,,,0x01000000,,0x0" complete_cpuset="0x01000000,,,,0x01000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="543">
+                  <object type="PU" os_index="88" cpuset="0x01000000,,0x0" complete_cpuset="0x01000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="545"/>
+                  <object type="PU" os_index="216" cpuset="0x01000000,,,,,,0x0" complete_cpuset="0x01000000,,,,,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="876"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="89" cpuset="0x02000000,,,,0x02000000,,0x0" complete_cpuset="0x02000000,,,,0x02000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="555" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="89" cpuset="0x02000000,,,,0x02000000,,0x0" complete_cpuset="0x02000000,,,,0x02000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="553" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="89" cpuset="0x02000000,,,,0x02000000,,0x0" complete_cpuset="0x02000000,,,,0x02000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="554" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="25" cpuset="0x02000000,,,,0x02000000,,0x0" complete_cpuset="0x02000000,,,,0x02000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="550">
+                  <object type="PU" os_index="89" cpuset="0x02000000,,0x0" complete_cpuset="0x02000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="552"/>
+                  <object type="PU" os_index="217" cpuset="0x02000000,,,,,,0x0" complete_cpuset="0x02000000,,,,,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="877"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="90" cpuset="0x04000000,,,,0x04000000,,0x0" complete_cpuset="0x04000000,,,,0x04000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="561" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="90" cpuset="0x04000000,,,,0x04000000,,0x0" complete_cpuset="0x04000000,,,,0x04000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="559" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="90" cpuset="0x04000000,,,,0x04000000,,0x0" complete_cpuset="0x04000000,,,,0x04000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="560" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="26" cpuset="0x04000000,,,,0x04000000,,0x0" complete_cpuset="0x04000000,,,,0x04000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="556">
+                  <object type="PU" os_index="90" cpuset="0x04000000,,0x0" complete_cpuset="0x04000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="558"/>
+                  <object type="PU" os_index="218" cpuset="0x04000000,,,,,,0x0" complete_cpuset="0x04000000,,,,,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="878"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="91" cpuset="0x08000000,,,,0x08000000,,0x0" complete_cpuset="0x08000000,,,,0x08000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="567" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="91" cpuset="0x08000000,,,,0x08000000,,0x0" complete_cpuset="0x08000000,,,,0x08000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="565" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="91" cpuset="0x08000000,,,,0x08000000,,0x0" complete_cpuset="0x08000000,,,,0x08000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="566" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="27" cpuset="0x08000000,,,,0x08000000,,0x0" complete_cpuset="0x08000000,,,,0x08000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="562">
+                  <object type="PU" os_index="91" cpuset="0x08000000,,0x0" complete_cpuset="0x08000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="564"/>
+                  <object type="PU" os_index="219" cpuset="0x08000000,,,,,,0x0" complete_cpuset="0x08000000,,,,,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="879"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="92" cpuset="0x10000000,,,,0x10000000,,0x0" complete_cpuset="0x10000000,,,,0x10000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="573" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="92" cpuset="0x10000000,,,,0x10000000,,0x0" complete_cpuset="0x10000000,,,,0x10000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="571" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="92" cpuset="0x10000000,,,,0x10000000,,0x0" complete_cpuset="0x10000000,,,,0x10000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="572" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="28" cpuset="0x10000000,,,,0x10000000,,0x0" complete_cpuset="0x10000000,,,,0x10000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="568">
+                  <object type="PU" os_index="92" cpuset="0x10000000,,0x0" complete_cpuset="0x10000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="570"/>
+                  <object type="PU" os_index="220" cpuset="0x10000000,,,,,,0x0" complete_cpuset="0x10000000,,,,,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="880"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="93" cpuset="0x20000000,,,,0x20000000,,0x0" complete_cpuset="0x20000000,,,,0x20000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="579" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="93" cpuset="0x20000000,,,,0x20000000,,0x0" complete_cpuset="0x20000000,,,,0x20000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="577" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="93" cpuset="0x20000000,,,,0x20000000,,0x0" complete_cpuset="0x20000000,,,,0x20000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="578" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="29" cpuset="0x20000000,,,,0x20000000,,0x0" complete_cpuset="0x20000000,,,,0x20000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="574">
+                  <object type="PU" os_index="93" cpuset="0x20000000,,0x0" complete_cpuset="0x20000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="576"/>
+                  <object type="PU" os_index="221" cpuset="0x20000000,,,,,,0x0" complete_cpuset="0x20000000,,,,,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="881"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="94" cpuset="0x40000000,,,,0x40000000,,0x0" complete_cpuset="0x40000000,,,,0x40000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="585" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="94" cpuset="0x40000000,,,,0x40000000,,0x0" complete_cpuset="0x40000000,,,,0x40000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="583" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="94" cpuset="0x40000000,,,,0x40000000,,0x0" complete_cpuset="0x40000000,,,,0x40000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="584" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="30" cpuset="0x40000000,,,,0x40000000,,0x0" complete_cpuset="0x40000000,,,,0x40000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="580">
+                  <object type="PU" os_index="94" cpuset="0x40000000,,0x0" complete_cpuset="0x40000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="582"/>
+                  <object type="PU" os_index="222" cpuset="0x40000000,,,,,,0x0" complete_cpuset="0x40000000,,,,,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="882"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="95" cpuset="0x80000000,,,,0x80000000,,0x0" complete_cpuset="0x80000000,,,,0x80000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="591" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="95" cpuset="0x80000000,,,,0x80000000,,0x0" complete_cpuset="0x80000000,,,,0x80000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="589" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="95" cpuset="0x80000000,,,,0x80000000,,0x0" complete_cpuset="0x80000000,,,,0x80000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="590" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="31" cpuset="0x80000000,,,,0x80000000,,0x0" complete_cpuset="0x80000000,,,,0x80000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="586">
+                  <object type="PU" os_index="95" cpuset="0x80000000,,0x0" complete_cpuset="0x80000000,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="588"/>
+                  <object type="PU" os_index="223" cpuset="0x80000000,,,,,,0x0" complete_cpuset="0x80000000,,,,,,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" gp_index="883"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Group" cpuset="0x0000ffff,,,,0x0000ffff,,,0x0" complete_cpuset="0x0000ffff,,,,0x0000ffff,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="930" kind="1001" subkind="0">
+        <object type="NUMANode" os_index="6" cpuset="0x0000ffff,,,,0x0000ffff,,,0x0" complete_cpuset="0x0000ffff,,,,0x0000ffff,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="922" local_memory="33814581248">
+          <page_type size="4096" count="8255513"/>
+          <page_type size="2097152" count="0"/>
+          <page_type size="4194304" count="0"/>
+          <page_type size="8388608" count="0"/>
+          <page_type size="16777216" count="0"/>
+          <page_type size="33554432" count="0"/>
+          <page_type size="67108864" count="0"/>
+          <page_type size="134217728" count="0"/>
+          <page_type size="268435456" count="0"/>
+          <page_type size="536870912" count="0"/>
+          <page_type size="1073741824" count="0"/>
+          <page_type size="2147483648" count="0"/>
+        </object>
+        <object type="L3Cache" os_index="12" cpuset="0x000000ff,,,,0x000000ff,,,0x0" complete_cpuset="0x000000ff,,,,0x000000ff,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="598" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L2Cache" os_index="96" cpuset="0x00000001,,,,0x00000001,,,0x0" complete_cpuset="0x00000001,,,,0x00000001,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="597" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="96" cpuset="0x00000001,,,,0x00000001,,,0x0" complete_cpuset="0x00000001,,,,0x00000001,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="595" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="96" cpuset="0x00000001,,,,0x00000001,,,0x0" complete_cpuset="0x00000001,,,,0x00000001,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="596" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="32" cpuset="0x00000001,,,,0x00000001,,,0x0" complete_cpuset="0x00000001,,,,0x00000001,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="592">
+                  <object type="PU" os_index="96" cpuset="0x00000001,,,0x0" complete_cpuset="0x00000001,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="594"/>
+                  <object type="PU" os_index="224" cpuset="0x00000001,,,,,,,0x0" complete_cpuset="0x00000001,,,,,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="884"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="97" cpuset="0x00000002,,,,0x00000002,,,0x0" complete_cpuset="0x00000002,,,,0x00000002,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="604" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="97" cpuset="0x00000002,,,,0x00000002,,,0x0" complete_cpuset="0x00000002,,,,0x00000002,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="602" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="97" cpuset="0x00000002,,,,0x00000002,,,0x0" complete_cpuset="0x00000002,,,,0x00000002,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="603" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="33" cpuset="0x00000002,,,,0x00000002,,,0x0" complete_cpuset="0x00000002,,,,0x00000002,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="599">
+                  <object type="PU" os_index="97" cpuset="0x00000002,,,0x0" complete_cpuset="0x00000002,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="601"/>
+                  <object type="PU" os_index="225" cpuset="0x00000002,,,,,,,0x0" complete_cpuset="0x00000002,,,,,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="885"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="98" cpuset="0x00000004,,,,0x00000004,,,0x0" complete_cpuset="0x00000004,,,,0x00000004,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="610" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="98" cpuset="0x00000004,,,,0x00000004,,,0x0" complete_cpuset="0x00000004,,,,0x00000004,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="608" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="98" cpuset="0x00000004,,,,0x00000004,,,0x0" complete_cpuset="0x00000004,,,,0x00000004,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="609" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="34" cpuset="0x00000004,,,,0x00000004,,,0x0" complete_cpuset="0x00000004,,,,0x00000004,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="605">
+                  <object type="PU" os_index="98" cpuset="0x00000004,,,0x0" complete_cpuset="0x00000004,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="607"/>
+                  <object type="PU" os_index="226" cpuset="0x00000004,,,,,,,0x0" complete_cpuset="0x00000004,,,,,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="886"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="99" cpuset="0x00000008,,,,0x00000008,,,0x0" complete_cpuset="0x00000008,,,,0x00000008,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="616" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="99" cpuset="0x00000008,,,,0x00000008,,,0x0" complete_cpuset="0x00000008,,,,0x00000008,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="614" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="99" cpuset="0x00000008,,,,0x00000008,,,0x0" complete_cpuset="0x00000008,,,,0x00000008,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="615" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="35" cpuset="0x00000008,,,,0x00000008,,,0x0" complete_cpuset="0x00000008,,,,0x00000008,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="611">
+                  <object type="PU" os_index="99" cpuset="0x00000008,,,0x0" complete_cpuset="0x00000008,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="613"/>
+                  <object type="PU" os_index="227" cpuset="0x00000008,,,,,,,0x0" complete_cpuset="0x00000008,,,,,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="887"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="100" cpuset="0x00000010,,,,0x00000010,,,0x0" complete_cpuset="0x00000010,,,,0x00000010,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="622" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="100" cpuset="0x00000010,,,,0x00000010,,,0x0" complete_cpuset="0x00000010,,,,0x00000010,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="620" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="100" cpuset="0x00000010,,,,0x00000010,,,0x0" complete_cpuset="0x00000010,,,,0x00000010,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="621" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="36" cpuset="0x00000010,,,,0x00000010,,,0x0" complete_cpuset="0x00000010,,,,0x00000010,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="617">
+                  <object type="PU" os_index="100" cpuset="0x00000010,,,0x0" complete_cpuset="0x00000010,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="619"/>
+                  <object type="PU" os_index="228" cpuset="0x00000010,,,,,,,0x0" complete_cpuset="0x00000010,,,,,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="888"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="101" cpuset="0x00000020,,,,0x00000020,,,0x0" complete_cpuset="0x00000020,,,,0x00000020,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="628" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="101" cpuset="0x00000020,,,,0x00000020,,,0x0" complete_cpuset="0x00000020,,,,0x00000020,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="626" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="101" cpuset="0x00000020,,,,0x00000020,,,0x0" complete_cpuset="0x00000020,,,,0x00000020,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="627" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="37" cpuset="0x00000020,,,,0x00000020,,,0x0" complete_cpuset="0x00000020,,,,0x00000020,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="623">
+                  <object type="PU" os_index="101" cpuset="0x00000020,,,0x0" complete_cpuset="0x00000020,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="625"/>
+                  <object type="PU" os_index="229" cpuset="0x00000020,,,,,,,0x0" complete_cpuset="0x00000020,,,,,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="889"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="102" cpuset="0x00000040,,,,0x00000040,,,0x0" complete_cpuset="0x00000040,,,,0x00000040,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="634" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="102" cpuset="0x00000040,,,,0x00000040,,,0x0" complete_cpuset="0x00000040,,,,0x00000040,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="632" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="102" cpuset="0x00000040,,,,0x00000040,,,0x0" complete_cpuset="0x00000040,,,,0x00000040,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="633" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="38" cpuset="0x00000040,,,,0x00000040,,,0x0" complete_cpuset="0x00000040,,,,0x00000040,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="629">
+                  <object type="PU" os_index="102" cpuset="0x00000040,,,0x0" complete_cpuset="0x00000040,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="631"/>
+                  <object type="PU" os_index="230" cpuset="0x00000040,,,,,,,0x0" complete_cpuset="0x00000040,,,,,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="890"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="103" cpuset="0x00000080,,,,0x00000080,,,0x0" complete_cpuset="0x00000080,,,,0x00000080,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="640" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="103" cpuset="0x00000080,,,,0x00000080,,,0x0" complete_cpuset="0x00000080,,,,0x00000080,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="638" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="103" cpuset="0x00000080,,,,0x00000080,,,0x0" complete_cpuset="0x00000080,,,,0x00000080,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="639" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="39" cpuset="0x00000080,,,,0x00000080,,,0x0" complete_cpuset="0x00000080,,,,0x00000080,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="635">
+                  <object type="PU" os_index="103" cpuset="0x00000080,,,0x0" complete_cpuset="0x00000080,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="637"/>
+                  <object type="PU" os_index="231" cpuset="0x00000080,,,,,,,0x0" complete_cpuset="0x00000080,,,,,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="891"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L3Cache" os_index="13" cpuset="0x0000ff00,,,,0x0000ff00,,,0x0" complete_cpuset="0x0000ff00,,,,0x0000ff00,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="647" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L2Cache" os_index="104" cpuset="0x00000100,,,,0x00000100,,,0x0" complete_cpuset="0x00000100,,,,0x00000100,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="646" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="104" cpuset="0x00000100,,,,0x00000100,,,0x0" complete_cpuset="0x00000100,,,,0x00000100,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="644" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="104" cpuset="0x00000100,,,,0x00000100,,,0x0" complete_cpuset="0x00000100,,,,0x00000100,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="645" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="40" cpuset="0x00000100,,,,0x00000100,,,0x0" complete_cpuset="0x00000100,,,,0x00000100,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="641">
+                  <object type="PU" os_index="104" cpuset="0x00000100,,,0x0" complete_cpuset="0x00000100,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="643"/>
+                  <object type="PU" os_index="232" cpuset="0x00000100,,,,,,,0x0" complete_cpuset="0x00000100,,,,,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="892"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="105" cpuset="0x00000200,,,,0x00000200,,,0x0" complete_cpuset="0x00000200,,,,0x00000200,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="653" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="105" cpuset="0x00000200,,,,0x00000200,,,0x0" complete_cpuset="0x00000200,,,,0x00000200,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="651" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="105" cpuset="0x00000200,,,,0x00000200,,,0x0" complete_cpuset="0x00000200,,,,0x00000200,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="652" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="41" cpuset="0x00000200,,,,0x00000200,,,0x0" complete_cpuset="0x00000200,,,,0x00000200,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="648">
+                  <object type="PU" os_index="105" cpuset="0x00000200,,,0x0" complete_cpuset="0x00000200,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="650"/>
+                  <object type="PU" os_index="233" cpuset="0x00000200,,,,,,,0x0" complete_cpuset="0x00000200,,,,,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="893"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="106" cpuset="0x00000400,,,,0x00000400,,,0x0" complete_cpuset="0x00000400,,,,0x00000400,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="659" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="106" cpuset="0x00000400,,,,0x00000400,,,0x0" complete_cpuset="0x00000400,,,,0x00000400,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="657" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="106" cpuset="0x00000400,,,,0x00000400,,,0x0" complete_cpuset="0x00000400,,,,0x00000400,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="658" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="42" cpuset="0x00000400,,,,0x00000400,,,0x0" complete_cpuset="0x00000400,,,,0x00000400,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="654">
+                  <object type="PU" os_index="106" cpuset="0x00000400,,,0x0" complete_cpuset="0x00000400,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="656"/>
+                  <object type="PU" os_index="234" cpuset="0x00000400,,,,,,,0x0" complete_cpuset="0x00000400,,,,,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="894"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="107" cpuset="0x00000800,,,,0x00000800,,,0x0" complete_cpuset="0x00000800,,,,0x00000800,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="665" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="107" cpuset="0x00000800,,,,0x00000800,,,0x0" complete_cpuset="0x00000800,,,,0x00000800,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="663" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="107" cpuset="0x00000800,,,,0x00000800,,,0x0" complete_cpuset="0x00000800,,,,0x00000800,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="664" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="43" cpuset="0x00000800,,,,0x00000800,,,0x0" complete_cpuset="0x00000800,,,,0x00000800,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="660">
+                  <object type="PU" os_index="107" cpuset="0x00000800,,,0x0" complete_cpuset="0x00000800,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="662"/>
+                  <object type="PU" os_index="235" cpuset="0x00000800,,,,,,,0x0" complete_cpuset="0x00000800,,,,,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="895"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="108" cpuset="0x00001000,,,,0x00001000,,,0x0" complete_cpuset="0x00001000,,,,0x00001000,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="671" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="108" cpuset="0x00001000,,,,0x00001000,,,0x0" complete_cpuset="0x00001000,,,,0x00001000,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="669" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="108" cpuset="0x00001000,,,,0x00001000,,,0x0" complete_cpuset="0x00001000,,,,0x00001000,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="670" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="44" cpuset="0x00001000,,,,0x00001000,,,0x0" complete_cpuset="0x00001000,,,,0x00001000,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="666">
+                  <object type="PU" os_index="108" cpuset="0x00001000,,,0x0" complete_cpuset="0x00001000,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="668"/>
+                  <object type="PU" os_index="236" cpuset="0x00001000,,,,,,,0x0" complete_cpuset="0x00001000,,,,,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="896"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="109" cpuset="0x00002000,,,,0x00002000,,,0x0" complete_cpuset="0x00002000,,,,0x00002000,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="677" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="109" cpuset="0x00002000,,,,0x00002000,,,0x0" complete_cpuset="0x00002000,,,,0x00002000,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="675" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="109" cpuset="0x00002000,,,,0x00002000,,,0x0" complete_cpuset="0x00002000,,,,0x00002000,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="676" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="45" cpuset="0x00002000,,,,0x00002000,,,0x0" complete_cpuset="0x00002000,,,,0x00002000,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="672">
+                  <object type="PU" os_index="109" cpuset="0x00002000,,,0x0" complete_cpuset="0x00002000,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="674"/>
+                  <object type="PU" os_index="237" cpuset="0x00002000,,,,,,,0x0" complete_cpuset="0x00002000,,,,,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="897"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="110" cpuset="0x00004000,,,,0x00004000,,,0x0" complete_cpuset="0x00004000,,,,0x00004000,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="683" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="110" cpuset="0x00004000,,,,0x00004000,,,0x0" complete_cpuset="0x00004000,,,,0x00004000,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="681" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="110" cpuset="0x00004000,,,,0x00004000,,,0x0" complete_cpuset="0x00004000,,,,0x00004000,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="682" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="46" cpuset="0x00004000,,,,0x00004000,,,0x0" complete_cpuset="0x00004000,,,,0x00004000,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="678">
+                  <object type="PU" os_index="110" cpuset="0x00004000,,,0x0" complete_cpuset="0x00004000,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="680"/>
+                  <object type="PU" os_index="238" cpuset="0x00004000,,,,,,,0x0" complete_cpuset="0x00004000,,,,,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="898"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="111" cpuset="0x00008000,,,,0x00008000,,,0x0" complete_cpuset="0x00008000,,,,0x00008000,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="689" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="111" cpuset="0x00008000,,,,0x00008000,,,0x0" complete_cpuset="0x00008000,,,,0x00008000,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="687" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="111" cpuset="0x00008000,,,,0x00008000,,,0x0" complete_cpuset="0x00008000,,,,0x00008000,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="688" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="47" cpuset="0x00008000,,,,0x00008000,,,0x0" complete_cpuset="0x00008000,,,,0x00008000,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="684">
+                  <object type="PU" os_index="111" cpuset="0x00008000,,,0x0" complete_cpuset="0x00008000,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="686"/>
+                  <object type="PU" os_index="239" cpuset="0x00008000,,,,,,,0x0" complete_cpuset="0x00008000,,,,,,,0x0" nodeset="0x00000040" complete_nodeset="0x00000040" gp_index="899"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Bridge" gp_index="1043" bridge_type="0-1" depth="0" bridge_pci="0000:[a0-a3]">
+          <object type="Bridge" gp_index="980" bridge_type="1-1" depth="1" bridge_pci="0000:[a1-a1]" pci_busid="0000:a0:03.1" pci_type="0604 [1022:1483] [1022:1453] 00" pci_link_speed="31.507692">
+            <object type="PCIDev" gp_index="1015" pci_busid="0000:a1:00.0" pci_type="0200 [17db:0501] [17db:0000] 02" pci_link_speed="31.507692">
+              <object type="OSDev" gp_index="1048" name="hsn1" osdev_type="2">
+                <info name="Address" value="02:00:00:00:00:a2"/>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="Group" cpuset="0xffff0000,,,,0xffff0000,,,0x0" complete_cpuset="0xffff0000,,,,0xffff0000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="931" kind="1001" subkind="0">
+        <object type="NUMANode" os_index="7" cpuset="0xffff0000,,,,0xffff0000,,,0x0" complete_cpuset="0xffff0000,,,,0xffff0000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="923" local_memory="33401483264">
+          <page_type size="4096" count="8154659"/>
+          <page_type size="2097152" count="0"/>
+          <page_type size="4194304" count="0"/>
+          <page_type size="8388608" count="0"/>
+          <page_type size="16777216" count="0"/>
+          <page_type size="33554432" count="0"/>
+          <page_type size="67108864" count="0"/>
+          <page_type size="134217728" count="0"/>
+          <page_type size="268435456" count="0"/>
+          <page_type size="536870912" count="0"/>
+          <page_type size="1073741824" count="0"/>
+          <page_type size="2147483648" count="0"/>
+        </object>
+        <object type="L3Cache" os_index="14" cpuset="0x00ff0000,,,,0x00ff0000,,,0x0" complete_cpuset="0x00ff0000,,,,0x00ff0000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="696" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L2Cache" os_index="112" cpuset="0x00010000,,,,0x00010000,,,0x0" complete_cpuset="0x00010000,,,,0x00010000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="695" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="112" cpuset="0x00010000,,,,0x00010000,,,0x0" complete_cpuset="0x00010000,,,,0x00010000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="693" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="112" cpuset="0x00010000,,,,0x00010000,,,0x0" complete_cpuset="0x00010000,,,,0x00010000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="694" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="48" cpuset="0x00010000,,,,0x00010000,,,0x0" complete_cpuset="0x00010000,,,,0x00010000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="690">
+                  <object type="PU" os_index="112" cpuset="0x00010000,,,0x0" complete_cpuset="0x00010000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="692"/>
+                  <object type="PU" os_index="240" cpuset="0x00010000,,,,,,,0x0" complete_cpuset="0x00010000,,,,,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="900"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="113" cpuset="0x00020000,,,,0x00020000,,,0x0" complete_cpuset="0x00020000,,,,0x00020000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="702" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="113" cpuset="0x00020000,,,,0x00020000,,,0x0" complete_cpuset="0x00020000,,,,0x00020000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="700" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="113" cpuset="0x00020000,,,,0x00020000,,,0x0" complete_cpuset="0x00020000,,,,0x00020000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="701" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="49" cpuset="0x00020000,,,,0x00020000,,,0x0" complete_cpuset="0x00020000,,,,0x00020000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="697">
+                  <object type="PU" os_index="113" cpuset="0x00020000,,,0x0" complete_cpuset="0x00020000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="699"/>
+                  <object type="PU" os_index="241" cpuset="0x00020000,,,,,,,0x0" complete_cpuset="0x00020000,,,,,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="901"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="114" cpuset="0x00040000,,,,0x00040000,,,0x0" complete_cpuset="0x00040000,,,,0x00040000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="708" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="114" cpuset="0x00040000,,,,0x00040000,,,0x0" complete_cpuset="0x00040000,,,,0x00040000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="706" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="114" cpuset="0x00040000,,,,0x00040000,,,0x0" complete_cpuset="0x00040000,,,,0x00040000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="707" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="50" cpuset="0x00040000,,,,0x00040000,,,0x0" complete_cpuset="0x00040000,,,,0x00040000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="703">
+                  <object type="PU" os_index="114" cpuset="0x00040000,,,0x0" complete_cpuset="0x00040000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="705"/>
+                  <object type="PU" os_index="242" cpuset="0x00040000,,,,,,,0x0" complete_cpuset="0x00040000,,,,,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="902"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="115" cpuset="0x00080000,,,,0x00080000,,,0x0" complete_cpuset="0x00080000,,,,0x00080000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="714" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="115" cpuset="0x00080000,,,,0x00080000,,,0x0" complete_cpuset="0x00080000,,,,0x00080000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="712" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="115" cpuset="0x00080000,,,,0x00080000,,,0x0" complete_cpuset="0x00080000,,,,0x00080000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="713" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="51" cpuset="0x00080000,,,,0x00080000,,,0x0" complete_cpuset="0x00080000,,,,0x00080000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="709">
+                  <object type="PU" os_index="115" cpuset="0x00080000,,,0x0" complete_cpuset="0x00080000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="711"/>
+                  <object type="PU" os_index="243" cpuset="0x00080000,,,,,,,0x0" complete_cpuset="0x00080000,,,,,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="903"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="116" cpuset="0x00100000,,,,0x00100000,,,0x0" complete_cpuset="0x00100000,,,,0x00100000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="720" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="116" cpuset="0x00100000,,,,0x00100000,,,0x0" complete_cpuset="0x00100000,,,,0x00100000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="718" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="116" cpuset="0x00100000,,,,0x00100000,,,0x0" complete_cpuset="0x00100000,,,,0x00100000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="719" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="52" cpuset="0x00100000,,,,0x00100000,,,0x0" complete_cpuset="0x00100000,,,,0x00100000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="715">
+                  <object type="PU" os_index="116" cpuset="0x00100000,,,0x0" complete_cpuset="0x00100000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="717"/>
+                  <object type="PU" os_index="244" cpuset="0x00100000,,,,,,,0x0" complete_cpuset="0x00100000,,,,,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="904"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="117" cpuset="0x00200000,,,,0x00200000,,,0x0" complete_cpuset="0x00200000,,,,0x00200000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="726" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="117" cpuset="0x00200000,,,,0x00200000,,,0x0" complete_cpuset="0x00200000,,,,0x00200000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="724" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="117" cpuset="0x00200000,,,,0x00200000,,,0x0" complete_cpuset="0x00200000,,,,0x00200000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="725" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="53" cpuset="0x00200000,,,,0x00200000,,,0x0" complete_cpuset="0x00200000,,,,0x00200000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="721">
+                  <object type="PU" os_index="117" cpuset="0x00200000,,,0x0" complete_cpuset="0x00200000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="723"/>
+                  <object type="PU" os_index="245" cpuset="0x00200000,,,,,,,0x0" complete_cpuset="0x00200000,,,,,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="905"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="118" cpuset="0x00400000,,,,0x00400000,,,0x0" complete_cpuset="0x00400000,,,,0x00400000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="732" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="118" cpuset="0x00400000,,,,0x00400000,,,0x0" complete_cpuset="0x00400000,,,,0x00400000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="730" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="118" cpuset="0x00400000,,,,0x00400000,,,0x0" complete_cpuset="0x00400000,,,,0x00400000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="731" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="54" cpuset="0x00400000,,,,0x00400000,,,0x0" complete_cpuset="0x00400000,,,,0x00400000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="727">
+                  <object type="PU" os_index="118" cpuset="0x00400000,,,0x0" complete_cpuset="0x00400000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="729"/>
+                  <object type="PU" os_index="246" cpuset="0x00400000,,,,,,,0x0" complete_cpuset="0x00400000,,,,,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="906"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="119" cpuset="0x00800000,,,,0x00800000,,,0x0" complete_cpuset="0x00800000,,,,0x00800000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="738" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="119" cpuset="0x00800000,,,,0x00800000,,,0x0" complete_cpuset="0x00800000,,,,0x00800000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="736" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="119" cpuset="0x00800000,,,,0x00800000,,,0x0" complete_cpuset="0x00800000,,,,0x00800000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="737" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="55" cpuset="0x00800000,,,,0x00800000,,,0x0" complete_cpuset="0x00800000,,,,0x00800000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="733">
+                  <object type="PU" os_index="119" cpuset="0x00800000,,,0x0" complete_cpuset="0x00800000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="735"/>
+                  <object type="PU" os_index="247" cpuset="0x00800000,,,,,,,0x0" complete_cpuset="0x00800000,,,,,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="907"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="L3Cache" os_index="15" cpuset="0xff000000,,,,0xff000000,,,0x0" complete_cpuset="0xff000000,,,,0xff000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="745" cache_size="33554432" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="L2Cache" os_index="120" cpuset="0x01000000,,,,0x01000000,,,0x0" complete_cpuset="0x01000000,,,,0x01000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="744" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="120" cpuset="0x01000000,,,,0x01000000,,,0x0" complete_cpuset="0x01000000,,,,0x01000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="742" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="120" cpuset="0x01000000,,,,0x01000000,,,0x0" complete_cpuset="0x01000000,,,,0x01000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="743" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="56" cpuset="0x01000000,,,,0x01000000,,,0x0" complete_cpuset="0x01000000,,,,0x01000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="739">
+                  <object type="PU" os_index="120" cpuset="0x01000000,,,0x0" complete_cpuset="0x01000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="741"/>
+                  <object type="PU" os_index="248" cpuset="0x01000000,,,,,,,0x0" complete_cpuset="0x01000000,,,,,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="908"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="121" cpuset="0x02000000,,,,0x02000000,,,0x0" complete_cpuset="0x02000000,,,,0x02000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="751" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="121" cpuset="0x02000000,,,,0x02000000,,,0x0" complete_cpuset="0x02000000,,,,0x02000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="749" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="121" cpuset="0x02000000,,,,0x02000000,,,0x0" complete_cpuset="0x02000000,,,,0x02000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="750" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="57" cpuset="0x02000000,,,,0x02000000,,,0x0" complete_cpuset="0x02000000,,,,0x02000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="746">
+                  <object type="PU" os_index="121" cpuset="0x02000000,,,0x0" complete_cpuset="0x02000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="748"/>
+                  <object type="PU" os_index="249" cpuset="0x02000000,,,,,,,0x0" complete_cpuset="0x02000000,,,,,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="909"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="122" cpuset="0x04000000,,,,0x04000000,,,0x0" complete_cpuset="0x04000000,,,,0x04000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="757" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="122" cpuset="0x04000000,,,,0x04000000,,,0x0" complete_cpuset="0x04000000,,,,0x04000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="755" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="122" cpuset="0x04000000,,,,0x04000000,,,0x0" complete_cpuset="0x04000000,,,,0x04000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="756" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="58" cpuset="0x04000000,,,,0x04000000,,,0x0" complete_cpuset="0x04000000,,,,0x04000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="752">
+                  <object type="PU" os_index="122" cpuset="0x04000000,,,0x0" complete_cpuset="0x04000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="754"/>
+                  <object type="PU" os_index="250" cpuset="0x04000000,,,,,,,0x0" complete_cpuset="0x04000000,,,,,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="910"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="123" cpuset="0x08000000,,,,0x08000000,,,0x0" complete_cpuset="0x08000000,,,,0x08000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="763" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="123" cpuset="0x08000000,,,,0x08000000,,,0x0" complete_cpuset="0x08000000,,,,0x08000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="761" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="123" cpuset="0x08000000,,,,0x08000000,,,0x0" complete_cpuset="0x08000000,,,,0x08000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="762" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="59" cpuset="0x08000000,,,,0x08000000,,,0x0" complete_cpuset="0x08000000,,,,0x08000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="758">
+                  <object type="PU" os_index="123" cpuset="0x08000000,,,0x0" complete_cpuset="0x08000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="760"/>
+                  <object type="PU" os_index="251" cpuset="0x08000000,,,,,,,0x0" complete_cpuset="0x08000000,,,,,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="911"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="124" cpuset="0x10000000,,,,0x10000000,,,0x0" complete_cpuset="0x10000000,,,,0x10000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="769" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="124" cpuset="0x10000000,,,,0x10000000,,,0x0" complete_cpuset="0x10000000,,,,0x10000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="767" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="124" cpuset="0x10000000,,,,0x10000000,,,0x0" complete_cpuset="0x10000000,,,,0x10000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="768" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="60" cpuset="0x10000000,,,,0x10000000,,,0x0" complete_cpuset="0x10000000,,,,0x10000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="764">
+                  <object type="PU" os_index="124" cpuset="0x10000000,,,0x0" complete_cpuset="0x10000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="766"/>
+                  <object type="PU" os_index="252" cpuset="0x10000000,,,,,,,0x0" complete_cpuset="0x10000000,,,,,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="912"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="125" cpuset="0x20000000,,,,0x20000000,,,0x0" complete_cpuset="0x20000000,,,,0x20000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="775" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="125" cpuset="0x20000000,,,,0x20000000,,,0x0" complete_cpuset="0x20000000,,,,0x20000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="773" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="125" cpuset="0x20000000,,,,0x20000000,,,0x0" complete_cpuset="0x20000000,,,,0x20000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="774" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="61" cpuset="0x20000000,,,,0x20000000,,,0x0" complete_cpuset="0x20000000,,,,0x20000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="770">
+                  <object type="PU" os_index="125" cpuset="0x20000000,,,0x0" complete_cpuset="0x20000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="772"/>
+                  <object type="PU" os_index="253" cpuset="0x20000000,,,,,,,0x0" complete_cpuset="0x20000000,,,,,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="913"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="126" cpuset="0x40000000,,,,0x40000000,,,0x0" complete_cpuset="0x40000000,,,,0x40000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="781" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="126" cpuset="0x40000000,,,,0x40000000,,,0x0" complete_cpuset="0x40000000,,,,0x40000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="779" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="126" cpuset="0x40000000,,,,0x40000000,,,0x0" complete_cpuset="0x40000000,,,,0x40000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="780" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="62" cpuset="0x40000000,,,,0x40000000,,,0x0" complete_cpuset="0x40000000,,,,0x40000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="776">
+                  <object type="PU" os_index="126" cpuset="0x40000000,,,0x0" complete_cpuset="0x40000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="778"/>
+                  <object type="PU" os_index="254" cpuset="0x40000000,,,,,,,0x0" complete_cpuset="0x40000000,,,,,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="914"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="L2Cache" os_index="127" cpuset="0x80000000,,,,0x80000000,,,0x0" complete_cpuset="0x80000000,,,,0x80000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="787" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="L1Cache" os_index="127" cpuset="0x80000000,,,,0x80000000,,,0x0" complete_cpuset="0x80000000,,,,0x80000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="785" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="L1iCache" os_index="127" cpuset="0x80000000,,,,0x80000000,,,0x0" complete_cpuset="0x80000000,,,,0x80000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="786" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="63" cpuset="0x80000000,,,,0x80000000,,,0x0" complete_cpuset="0x80000000,,,,0x80000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="782">
+                  <object type="PU" os_index="127" cpuset="0x80000000,,,0x0" complete_cpuset="0x80000000,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="784"/>
+                  <object type="PU" os_index="255" cpuset="0x80000000,,,,,,,0x0" complete_cpuset="0x80000000,,,,,,,0x0" nodeset="0x00000080" complete_nodeset="0x00000080" gp_index="915"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+  </object>
+  <distances2 type="NUMANode" nbobjs="8" kind="5" name="NUMALatency" indexing="os">
+    <indexes length="16">0 1 2 3 4 5 6 7 </indexes>
+    <u64values length="30">10 12 12 12 32 32 32 32 12 10 </u64values>
+    <u64values length="30">12 12 32 32 32 32 12 12 10 12 </u64values>
+    <u64values length="30">32 32 32 32 12 12 12 10 32 32 </u64values>
+    <u64values length="30">32 32 32 32 32 32 10 12 12 12 </u64values>
+    <u64values length="30">32 32 32 32 12 10 12 12 32 32 </u64values>
+    <u64values length="30">32 32 12 12 10 12 32 32 32 32 </u64values>
+    <u64values length="12">12 12 12 10 </u64values>
+  </distances2>
+  <support name="discovery.pu"/>
+  <support name="discovery.numa"/>
+  <support name="discovery.numa_memory"/>
+  <support name="discovery.disallowed_pu"/>
+  <support name="discovery.disallowed_numa"/>
+  <support name="discovery.cpukind_efficiency"/>
+  <support name="cpubind.set_thisproc_cpubind"/>
+  <support name="cpubind.get_thisproc_cpubind"/>
+  <support name="cpubind.set_proc_cpubind"/>
+  <support name="cpubind.get_proc_cpubind"/>
+  <support name="cpubind.set_thisthread_cpubind"/>
+  <support name="cpubind.get_thisthread_cpubind"/>
+  <support name="cpubind.set_thread_cpubind"/>
+  <support name="cpubind.get_thread_cpubind"/>
+  <support name="cpubind.get_thisproc_last_cpu_location"/>
+  <support name="cpubind.get_proc_last_cpu_location"/>
+  <support name="cpubind.get_thisthread_last_cpu_location"/>
+  <support name="membind.set_thisthread_membind"/>
+  <support name="membind.get_thisthread_membind"/>
+  <support name="membind.set_area_membind"/>
+  <support name="membind.get_area_membind"/>
+  <support name="membind.alloc_membind"/>
+  <support name="membind.firsttouch_membind"/>
+  <support name="membind.bind_membind"/>
+  <support name="membind.interleave_membind"/>
+  <support name="membind.migrate_membind"/>
+  <support name="membind.get_area_memlocation"/>
+  <support name="custom.exported_support"/>
+  <cpukind cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff">
+    <info name="FrequencyMaxMHz" value="2000"/>
+  </cpukind>
+</topology>

--- a/test/runtime/jhh/colocales/hpc6a.48xlarge.xml
+++ b/test/runtime/jhh/colocales/hpc6a.48xlarge.xml
@@ -1,0 +1,1297 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc.dtd">
+<topology>
+  <object type="Machine" os_index="0" cpuset="0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0xffffffff,0xffffffff,0xffffffff" online_cpuset="0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0xffffffff,0xffffffff,0xffffffff" nodeset="0x0000000f" complete_nodeset="0x0000000f" allowed_nodeset="0x0000000f">
+    <page_type size="4096" count="0"/>
+    <page_type size="2097152" count="0"/>
+    <page_type size="1073741824" count="0"/>
+    <info name="DMIProductName" value="hpc6a.48xlarge"/>
+    <info name="DMIProductVersion" value=""/>
+    <info name="DMIBoardVendor" value="Amazon EC2"/>
+    <info name="DMIBoardName" value=""/>
+    <info name="DMIBoardVersion" value=""/>
+    <info name="DMIBoardAssetTag" value="i-04a61fa42d3390ad2"/>
+    <info name="DMIChassisVendor" value="Amazon EC2"/>
+    <info name="DMIChassisType" value="1"/>
+    <info name="DMIChassisVersion" value=""/>
+    <info name="DMIChassisAssetTag" value="Amazon EC2"/>
+    <info name="DMIBIOSVendor" value="Amazon EC2"/>
+    <info name="DMIBIOSVersion" value="1.0"/>
+    <info name="DMIBIOSDate" value="10/16/2017"/>
+    <info name="DMISysVendor" value="Amazon EC2"/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="5.10.192-183.736.amzn2.x86_64"/>
+    <info name="OSVersion" value="#1 SMP Wed Sep 6 21:15:41 UTC 2023"/>
+    <info name="HostName" value="hpc6a-dy-hpc6a48xlarge-1"/>
+    <info name="Architecture" value="x86_64"/>
+    <info name="hwlocVersion" value="1.11.8"/>
+    <info name="ProcessName" value="hwloc-ls"/>
+    <distances nbobjs="4" relative_depth="2" latency_base="10.000000">
+      <latency value="1.000000"/>
+      <latency value="1.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="1.200000"/>
+      <latency value="1.000000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="1.000000"/>
+      <latency value="1.200000"/>
+      <latency value="3.200000"/>
+      <latency value="3.200000"/>
+      <latency value="1.200000"/>
+      <latency value="1.000000"/>
+    </distances>
+    <object type="Package" os_index="0" cpuset="0x0000ffff,0xffffffff" complete_cpuset="0x0000ffff,0xffffffff" online_cpuset="0x0000ffff,0xffffffff" allowed_cpuset="0x0000ffff,0xffffffff" nodeset="0x00000003" complete_nodeset="0x00000003" allowed_nodeset="0x00000003">
+      <info name="CPUVendor" value="AuthenticAMD"/>
+      <info name="CPUFamilyNumber" value="25"/>
+      <info name="CPUModelNumber" value="1"/>
+      <info name="CPUModel" value="AMD EPYC 7R13 Processor"/>
+      <info name="CPUStepping" value="1"/>
+      <object type="NUMANode" os_index="0" cpuset="0x00ffffff" complete_cpuset="0x00ffffff" online_cpuset="0x00ffffff" allowed_cpuset="0x00ffffff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" local_memory="99263897600">
+        <page_type size="4096" count="22882158"/>
+        <page_type size="2097152" count="2641"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x000000ff" complete_cpuset="0x000000ff" online_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="16777216" depth="3" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" online_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="16777216" depth="3" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x00ff0000" complete_cpuset="0x00ff0000" online_cpuset="0x00ff0000" allowed_cpuset="0x00ff0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="16777216" depth="3" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00010000" complete_cpuset="0x00010000" online_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00010000" complete_cpuset="0x00010000" online_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00010000" complete_cpuset="0x00010000" online_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" online_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" online_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00020000" complete_cpuset="0x00020000" online_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00020000" complete_cpuset="0x00020000" online_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00020000" complete_cpuset="0x00020000" online_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" online_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" online_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00040000" complete_cpuset="0x00040000" online_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00040000" complete_cpuset="0x00040000" online_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00040000" complete_cpuset="0x00040000" online_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" online_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" online_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00080000" complete_cpuset="0x00080000" online_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00080000" complete_cpuset="0x00080000" online_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00080000" complete_cpuset="0x00080000" online_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" online_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" online_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00100000" complete_cpuset="0x00100000" online_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00100000" complete_cpuset="0x00100000" online_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00100000" complete_cpuset="0x00100000" online_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" online_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" online_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00200000" complete_cpuset="0x00200000" online_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00200000" complete_cpuset="0x00200000" online_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00200000" complete_cpuset="0x00200000" online_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" online_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" online_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00400000" complete_cpuset="0x00400000" online_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00400000" complete_cpuset="0x00400000" online_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00400000" complete_cpuset="0x00400000" online_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" online_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" online_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00800000" complete_cpuset="0x00800000" online_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00800000" complete_cpuset="0x00800000" online_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00800000" complete_cpuset="0x00800000" online_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" online_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" online_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="1" cpuset="0x0000ffff,0xff000000" complete_cpuset="0x0000ffff,0xff000000" online_cpuset="0x0000ffff,0xff000000" allowed_cpuset="0x0000ffff,0xff000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" local_memory="99331612672">
+        <page_type size="4096" count="22899202"/>
+        <page_type size="2097152" count="2640"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0xff000000" complete_cpuset="0xff000000" online_cpuset="0xff000000" allowed_cpuset="0xff000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="16777216" depth="3" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x01000000" complete_cpuset="0x01000000" online_cpuset="0x01000000" allowed_cpuset="0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x01000000" complete_cpuset="0x01000000" online_cpuset="0x01000000" allowed_cpuset="0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x01000000" complete_cpuset="0x01000000" online_cpuset="0x01000000" allowed_cpuset="0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="32" cpuset="0x01000000" complete_cpuset="0x01000000" online_cpuset="0x01000000" allowed_cpuset="0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="24" cpuset="0x01000000" complete_cpuset="0x01000000" online_cpuset="0x01000000" allowed_cpuset="0x01000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x02000000" complete_cpuset="0x02000000" online_cpuset="0x02000000" allowed_cpuset="0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x02000000" complete_cpuset="0x02000000" online_cpuset="0x02000000" allowed_cpuset="0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x02000000" complete_cpuset="0x02000000" online_cpuset="0x02000000" allowed_cpuset="0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="33" cpuset="0x02000000" complete_cpuset="0x02000000" online_cpuset="0x02000000" allowed_cpuset="0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="25" cpuset="0x02000000" complete_cpuset="0x02000000" online_cpuset="0x02000000" allowed_cpuset="0x02000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x04000000" complete_cpuset="0x04000000" online_cpuset="0x04000000" allowed_cpuset="0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x04000000" complete_cpuset="0x04000000" online_cpuset="0x04000000" allowed_cpuset="0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x04000000" complete_cpuset="0x04000000" online_cpuset="0x04000000" allowed_cpuset="0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="34" cpuset="0x04000000" complete_cpuset="0x04000000" online_cpuset="0x04000000" allowed_cpuset="0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="26" cpuset="0x04000000" complete_cpuset="0x04000000" online_cpuset="0x04000000" allowed_cpuset="0x04000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x08000000" complete_cpuset="0x08000000" online_cpuset="0x08000000" allowed_cpuset="0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x08000000" complete_cpuset="0x08000000" online_cpuset="0x08000000" allowed_cpuset="0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x08000000" complete_cpuset="0x08000000" online_cpuset="0x08000000" allowed_cpuset="0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="35" cpuset="0x08000000" complete_cpuset="0x08000000" online_cpuset="0x08000000" allowed_cpuset="0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="27" cpuset="0x08000000" complete_cpuset="0x08000000" online_cpuset="0x08000000" allowed_cpuset="0x08000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x10000000" complete_cpuset="0x10000000" online_cpuset="0x10000000" allowed_cpuset="0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x10000000" complete_cpuset="0x10000000" online_cpuset="0x10000000" allowed_cpuset="0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x10000000" complete_cpuset="0x10000000" online_cpuset="0x10000000" allowed_cpuset="0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="36" cpuset="0x10000000" complete_cpuset="0x10000000" online_cpuset="0x10000000" allowed_cpuset="0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="28" cpuset="0x10000000" complete_cpuset="0x10000000" online_cpuset="0x10000000" allowed_cpuset="0x10000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x20000000" complete_cpuset="0x20000000" online_cpuset="0x20000000" allowed_cpuset="0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x20000000" complete_cpuset="0x20000000" online_cpuset="0x20000000" allowed_cpuset="0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x20000000" complete_cpuset="0x20000000" online_cpuset="0x20000000" allowed_cpuset="0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="37" cpuset="0x20000000" complete_cpuset="0x20000000" online_cpuset="0x20000000" allowed_cpuset="0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="29" cpuset="0x20000000" complete_cpuset="0x20000000" online_cpuset="0x20000000" allowed_cpuset="0x20000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x40000000" complete_cpuset="0x40000000" online_cpuset="0x40000000" allowed_cpuset="0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x40000000" complete_cpuset="0x40000000" online_cpuset="0x40000000" allowed_cpuset="0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x40000000" complete_cpuset="0x40000000" online_cpuset="0x40000000" allowed_cpuset="0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="38" cpuset="0x40000000" complete_cpuset="0x40000000" online_cpuset="0x40000000" allowed_cpuset="0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="30" cpuset="0x40000000" complete_cpuset="0x40000000" online_cpuset="0x40000000" allowed_cpuset="0x40000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x80000000" complete_cpuset="0x80000000" online_cpuset="0x80000000" allowed_cpuset="0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x80000000" complete_cpuset="0x80000000" online_cpuset="0x80000000" allowed_cpuset="0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x80000000" complete_cpuset="0x80000000" online_cpuset="0x80000000" allowed_cpuset="0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="39" cpuset="0x80000000" complete_cpuset="0x80000000" online_cpuset="0x80000000" allowed_cpuset="0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="31" cpuset="0x80000000" complete_cpuset="0x80000000" online_cpuset="0x80000000" allowed_cpuset="0x80000000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x000000ff,0x0" complete_cpuset="0x000000ff,0x0" online_cpuset="0x000000ff,0x0" allowed_cpuset="0x000000ff,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="16777216" depth="3" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" online_cpuset="0x00000001,0x0" allowed_cpuset="0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" online_cpuset="0x00000001,0x0" allowed_cpuset="0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" online_cpuset="0x00000001,0x0" allowed_cpuset="0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="40" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" online_cpuset="0x00000001,0x0" allowed_cpuset="0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="32" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" online_cpuset="0x00000001,0x0" allowed_cpuset="0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" online_cpuset="0x00000002,0x0" allowed_cpuset="0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" online_cpuset="0x00000002,0x0" allowed_cpuset="0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" online_cpuset="0x00000002,0x0" allowed_cpuset="0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="41" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" online_cpuset="0x00000002,0x0" allowed_cpuset="0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="33" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" online_cpuset="0x00000002,0x0" allowed_cpuset="0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" online_cpuset="0x00000004,0x0" allowed_cpuset="0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" online_cpuset="0x00000004,0x0" allowed_cpuset="0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" online_cpuset="0x00000004,0x0" allowed_cpuset="0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="42" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" online_cpuset="0x00000004,0x0" allowed_cpuset="0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="34" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" online_cpuset="0x00000004,0x0" allowed_cpuset="0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" online_cpuset="0x00000008,0x0" allowed_cpuset="0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" online_cpuset="0x00000008,0x0" allowed_cpuset="0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" online_cpuset="0x00000008,0x0" allowed_cpuset="0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="43" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" online_cpuset="0x00000008,0x0" allowed_cpuset="0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="35" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" online_cpuset="0x00000008,0x0" allowed_cpuset="0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" online_cpuset="0x00000010,0x0" allowed_cpuset="0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" online_cpuset="0x00000010,0x0" allowed_cpuset="0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" online_cpuset="0x00000010,0x0" allowed_cpuset="0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="44" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" online_cpuset="0x00000010,0x0" allowed_cpuset="0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="36" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" online_cpuset="0x00000010,0x0" allowed_cpuset="0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" online_cpuset="0x00000020,0x0" allowed_cpuset="0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" online_cpuset="0x00000020,0x0" allowed_cpuset="0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" online_cpuset="0x00000020,0x0" allowed_cpuset="0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="45" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" online_cpuset="0x00000020,0x0" allowed_cpuset="0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="37" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" online_cpuset="0x00000020,0x0" allowed_cpuset="0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" online_cpuset="0x00000040,0x0" allowed_cpuset="0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" online_cpuset="0x00000040,0x0" allowed_cpuset="0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" online_cpuset="0x00000040,0x0" allowed_cpuset="0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="46" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" online_cpuset="0x00000040,0x0" allowed_cpuset="0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="38" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" online_cpuset="0x00000040,0x0" allowed_cpuset="0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" online_cpuset="0x00000080,0x0" allowed_cpuset="0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" online_cpuset="0x00000080,0x0" allowed_cpuset="0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" online_cpuset="0x00000080,0x0" allowed_cpuset="0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="47" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" online_cpuset="0x00000080,0x0" allowed_cpuset="0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="39" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" online_cpuset="0x00000080,0x0" allowed_cpuset="0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x0000ff00,0x0" complete_cpuset="0x0000ff00,0x0" online_cpuset="0x0000ff00,0x0" allowed_cpuset="0x0000ff00,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="16777216" depth="3" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" online_cpuset="0x00000100,0x0" allowed_cpuset="0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" online_cpuset="0x00000100,0x0" allowed_cpuset="0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" online_cpuset="0x00000100,0x0" allowed_cpuset="0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="48" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" online_cpuset="0x00000100,0x0" allowed_cpuset="0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="40" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" online_cpuset="0x00000100,0x0" allowed_cpuset="0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" online_cpuset="0x00000200,0x0" allowed_cpuset="0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" online_cpuset="0x00000200,0x0" allowed_cpuset="0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" online_cpuset="0x00000200,0x0" allowed_cpuset="0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="49" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" online_cpuset="0x00000200,0x0" allowed_cpuset="0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="41" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" online_cpuset="0x00000200,0x0" allowed_cpuset="0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" online_cpuset="0x00000400,0x0" allowed_cpuset="0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" online_cpuset="0x00000400,0x0" allowed_cpuset="0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" online_cpuset="0x00000400,0x0" allowed_cpuset="0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="50" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" online_cpuset="0x00000400,0x0" allowed_cpuset="0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="42" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" online_cpuset="0x00000400,0x0" allowed_cpuset="0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" online_cpuset="0x00000800,0x0" allowed_cpuset="0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" online_cpuset="0x00000800,0x0" allowed_cpuset="0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" online_cpuset="0x00000800,0x0" allowed_cpuset="0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="51" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" online_cpuset="0x00000800,0x0" allowed_cpuset="0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="43" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" online_cpuset="0x00000800,0x0" allowed_cpuset="0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" online_cpuset="0x00001000,0x0" allowed_cpuset="0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" online_cpuset="0x00001000,0x0" allowed_cpuset="0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" online_cpuset="0x00001000,0x0" allowed_cpuset="0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="52" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" online_cpuset="0x00001000,0x0" allowed_cpuset="0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="44" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" online_cpuset="0x00001000,0x0" allowed_cpuset="0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" online_cpuset="0x00002000,0x0" allowed_cpuset="0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" online_cpuset="0x00002000,0x0" allowed_cpuset="0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" online_cpuset="0x00002000,0x0" allowed_cpuset="0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="53" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" online_cpuset="0x00002000,0x0" allowed_cpuset="0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="45" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" online_cpuset="0x00002000,0x0" allowed_cpuset="0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" online_cpuset="0x00004000,0x0" allowed_cpuset="0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" online_cpuset="0x00004000,0x0" allowed_cpuset="0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" online_cpuset="0x00004000,0x0" allowed_cpuset="0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="54" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" online_cpuset="0x00004000,0x0" allowed_cpuset="0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="46" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" online_cpuset="0x00004000,0x0" allowed_cpuset="0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" online_cpuset="0x00008000,0x0" allowed_cpuset="0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" online_cpuset="0x00008000,0x0" allowed_cpuset="0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" online_cpuset="0x00008000,0x0" allowed_cpuset="0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="55" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" online_cpuset="0x00008000,0x0" allowed_cpuset="0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="47" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" online_cpuset="0x00008000,0x0" allowed_cpuset="0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="Package" os_index="1" cpuset="0xffffffff,0xffff0000,0x0" complete_cpuset="0xffffffff,0xffff0000,0x0" online_cpuset="0xffffffff,0xffff0000,0x0" allowed_cpuset="0xffffffff,0xffff0000,0x0" nodeset="0x0000000c" complete_nodeset="0x0000000c" allowed_nodeset="0x0000000c">
+      <info name="CPUVendor" value="AuthenticAMD"/>
+      <info name="CPUFamilyNumber" value="25"/>
+      <info name="CPUModelNumber" value="1"/>
+      <info name="CPUModel" value="AMD EPYC 7R13 Processor"/>
+      <info name="CPUStepping" value="1"/>
+      <object type="NUMANode" os_index="2" cpuset="0x000000ff,0xffff0000,0x0" complete_cpuset="0x000000ff,0xffff0000,0x0" online_cpuset="0x000000ff,0xffff0000,0x0" allowed_cpuset="0x000000ff,0xffff0000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" local_memory="99279757312">
+        <page_type size="4096" count="22886542"/>
+        <page_type size="2097152" count="2640"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x00ff0000,0x0" complete_cpuset="0x00ff0000,0x0" online_cpuset="0x00ff0000,0x0" allowed_cpuset="0x00ff0000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="16777216" depth="3" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00010000,0x0" complete_cpuset="0x00010000,0x0" online_cpuset="0x00010000,0x0" allowed_cpuset="0x00010000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00010000,0x0" complete_cpuset="0x00010000,0x0" online_cpuset="0x00010000,0x0" allowed_cpuset="0x00010000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00010000,0x0" complete_cpuset="0x00010000,0x0" online_cpuset="0x00010000,0x0" allowed_cpuset="0x00010000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="0" cpuset="0x00010000,0x0" complete_cpuset="0x00010000,0x0" online_cpuset="0x00010000,0x0" allowed_cpuset="0x00010000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="48" cpuset="0x00010000,0x0" complete_cpuset="0x00010000,0x0" online_cpuset="0x00010000,0x0" allowed_cpuset="0x00010000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" online_cpuset="0x00020000,0x0" allowed_cpuset="0x00020000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" online_cpuset="0x00020000,0x0" allowed_cpuset="0x00020000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" online_cpuset="0x00020000,0x0" allowed_cpuset="0x00020000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="1" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" online_cpuset="0x00020000,0x0" allowed_cpuset="0x00020000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="49" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" online_cpuset="0x00020000,0x0" allowed_cpuset="0x00020000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" online_cpuset="0x00040000,0x0" allowed_cpuset="0x00040000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" online_cpuset="0x00040000,0x0" allowed_cpuset="0x00040000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" online_cpuset="0x00040000,0x0" allowed_cpuset="0x00040000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="2" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" online_cpuset="0x00040000,0x0" allowed_cpuset="0x00040000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="50" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" online_cpuset="0x00040000,0x0" allowed_cpuset="0x00040000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00080000,0x0" complete_cpuset="0x00080000,0x0" online_cpuset="0x00080000,0x0" allowed_cpuset="0x00080000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00080000,0x0" complete_cpuset="0x00080000,0x0" online_cpuset="0x00080000,0x0" allowed_cpuset="0x00080000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00080000,0x0" complete_cpuset="0x00080000,0x0" online_cpuset="0x00080000,0x0" allowed_cpuset="0x00080000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="3" cpuset="0x00080000,0x0" complete_cpuset="0x00080000,0x0" online_cpuset="0x00080000,0x0" allowed_cpuset="0x00080000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="51" cpuset="0x00080000,0x0" complete_cpuset="0x00080000,0x0" online_cpuset="0x00080000,0x0" allowed_cpuset="0x00080000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00100000,0x0" complete_cpuset="0x00100000,0x0" online_cpuset="0x00100000,0x0" allowed_cpuset="0x00100000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00100000,0x0" complete_cpuset="0x00100000,0x0" online_cpuset="0x00100000,0x0" allowed_cpuset="0x00100000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00100000,0x0" complete_cpuset="0x00100000,0x0" online_cpuset="0x00100000,0x0" allowed_cpuset="0x00100000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="4" cpuset="0x00100000,0x0" complete_cpuset="0x00100000,0x0" online_cpuset="0x00100000,0x0" allowed_cpuset="0x00100000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="52" cpuset="0x00100000,0x0" complete_cpuset="0x00100000,0x0" online_cpuset="0x00100000,0x0" allowed_cpuset="0x00100000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" online_cpuset="0x00200000,0x0" allowed_cpuset="0x00200000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" online_cpuset="0x00200000,0x0" allowed_cpuset="0x00200000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" online_cpuset="0x00200000,0x0" allowed_cpuset="0x00200000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="5" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" online_cpuset="0x00200000,0x0" allowed_cpuset="0x00200000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="53" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" online_cpuset="0x00200000,0x0" allowed_cpuset="0x00200000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" online_cpuset="0x00400000,0x0" allowed_cpuset="0x00400000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" online_cpuset="0x00400000,0x0" allowed_cpuset="0x00400000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" online_cpuset="0x00400000,0x0" allowed_cpuset="0x00400000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="6" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" online_cpuset="0x00400000,0x0" allowed_cpuset="0x00400000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="54" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" online_cpuset="0x00400000,0x0" allowed_cpuset="0x00400000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00800000,0x0" complete_cpuset="0x00800000,0x0" online_cpuset="0x00800000,0x0" allowed_cpuset="0x00800000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00800000,0x0" complete_cpuset="0x00800000,0x0" online_cpuset="0x00800000,0x0" allowed_cpuset="0x00800000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00800000,0x0" complete_cpuset="0x00800000,0x0" online_cpuset="0x00800000,0x0" allowed_cpuset="0x00800000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="7" cpuset="0x00800000,0x0" complete_cpuset="0x00800000,0x0" online_cpuset="0x00800000,0x0" allowed_cpuset="0x00800000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="55" cpuset="0x00800000,0x0" complete_cpuset="0x00800000,0x0" online_cpuset="0x00800000,0x0" allowed_cpuset="0x00800000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0xff000000,0x0" complete_cpuset="0xff000000,0x0" online_cpuset="0xff000000,0x0" allowed_cpuset="0xff000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="16777216" depth="3" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x01000000,0x0" complete_cpuset="0x01000000,0x0" online_cpuset="0x01000000,0x0" allowed_cpuset="0x01000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x01000000,0x0" complete_cpuset="0x01000000,0x0" online_cpuset="0x01000000,0x0" allowed_cpuset="0x01000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x01000000,0x0" complete_cpuset="0x01000000,0x0" online_cpuset="0x01000000,0x0" allowed_cpuset="0x01000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="8" cpuset="0x01000000,0x0" complete_cpuset="0x01000000,0x0" online_cpuset="0x01000000,0x0" allowed_cpuset="0x01000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="56" cpuset="0x01000000,0x0" complete_cpuset="0x01000000,0x0" online_cpuset="0x01000000,0x0" allowed_cpuset="0x01000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" online_cpuset="0x02000000,0x0" allowed_cpuset="0x02000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" online_cpuset="0x02000000,0x0" allowed_cpuset="0x02000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" online_cpuset="0x02000000,0x0" allowed_cpuset="0x02000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="9" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" online_cpuset="0x02000000,0x0" allowed_cpuset="0x02000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="57" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" online_cpuset="0x02000000,0x0" allowed_cpuset="0x02000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" online_cpuset="0x04000000,0x0" allowed_cpuset="0x04000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" online_cpuset="0x04000000,0x0" allowed_cpuset="0x04000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" online_cpuset="0x04000000,0x0" allowed_cpuset="0x04000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="10" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" online_cpuset="0x04000000,0x0" allowed_cpuset="0x04000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="58" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" online_cpuset="0x04000000,0x0" allowed_cpuset="0x04000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x08000000,0x0" complete_cpuset="0x08000000,0x0" online_cpuset="0x08000000,0x0" allowed_cpuset="0x08000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x08000000,0x0" complete_cpuset="0x08000000,0x0" online_cpuset="0x08000000,0x0" allowed_cpuset="0x08000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x08000000,0x0" complete_cpuset="0x08000000,0x0" online_cpuset="0x08000000,0x0" allowed_cpuset="0x08000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="11" cpuset="0x08000000,0x0" complete_cpuset="0x08000000,0x0" online_cpuset="0x08000000,0x0" allowed_cpuset="0x08000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="59" cpuset="0x08000000,0x0" complete_cpuset="0x08000000,0x0" online_cpuset="0x08000000,0x0" allowed_cpuset="0x08000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x10000000,0x0" complete_cpuset="0x10000000,0x0" online_cpuset="0x10000000,0x0" allowed_cpuset="0x10000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x10000000,0x0" complete_cpuset="0x10000000,0x0" online_cpuset="0x10000000,0x0" allowed_cpuset="0x10000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x10000000,0x0" complete_cpuset="0x10000000,0x0" online_cpuset="0x10000000,0x0" allowed_cpuset="0x10000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="12" cpuset="0x10000000,0x0" complete_cpuset="0x10000000,0x0" online_cpuset="0x10000000,0x0" allowed_cpuset="0x10000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="60" cpuset="0x10000000,0x0" complete_cpuset="0x10000000,0x0" online_cpuset="0x10000000,0x0" allowed_cpuset="0x10000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" online_cpuset="0x20000000,0x0" allowed_cpuset="0x20000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" online_cpuset="0x20000000,0x0" allowed_cpuset="0x20000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" online_cpuset="0x20000000,0x0" allowed_cpuset="0x20000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="13" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" online_cpuset="0x20000000,0x0" allowed_cpuset="0x20000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="61" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" online_cpuset="0x20000000,0x0" allowed_cpuset="0x20000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" online_cpuset="0x40000000,0x0" allowed_cpuset="0x40000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" online_cpuset="0x40000000,0x0" allowed_cpuset="0x40000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" online_cpuset="0x40000000,0x0" allowed_cpuset="0x40000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="14" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" online_cpuset="0x40000000,0x0" allowed_cpuset="0x40000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="62" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" online_cpuset="0x40000000,0x0" allowed_cpuset="0x40000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x80000000,0x0" complete_cpuset="0x80000000,0x0" online_cpuset="0x80000000,0x0" allowed_cpuset="0x80000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x80000000,0x0" complete_cpuset="0x80000000,0x0" online_cpuset="0x80000000,0x0" allowed_cpuset="0x80000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x80000000,0x0" complete_cpuset="0x80000000,0x0" online_cpuset="0x80000000,0x0" allowed_cpuset="0x80000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="15" cpuset="0x80000000,0x0" complete_cpuset="0x80000000,0x0" online_cpuset="0x80000000,0x0" allowed_cpuset="0x80000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="63" cpuset="0x80000000,0x0" complete_cpuset="0x80000000,0x0" online_cpuset="0x80000000,0x0" allowed_cpuset="0x80000000,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x000000ff,,0x0" complete_cpuset="0x000000ff,,0x0" online_cpuset="0x000000ff,,0x0" allowed_cpuset="0x000000ff,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="16777216" depth="3" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00000001,,0x0" complete_cpuset="0x00000001,,0x0" online_cpuset="0x00000001,,0x0" allowed_cpuset="0x00000001,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000001,,0x0" complete_cpuset="0x00000001,,0x0" online_cpuset="0x00000001,,0x0" allowed_cpuset="0x00000001,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000001,,0x0" complete_cpuset="0x00000001,,0x0" online_cpuset="0x00000001,,0x0" allowed_cpuset="0x00000001,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="16" cpuset="0x00000001,,0x0" complete_cpuset="0x00000001,,0x0" online_cpuset="0x00000001,,0x0" allowed_cpuset="0x00000001,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="64" cpuset="0x00000001,,0x0" complete_cpuset="0x00000001,,0x0" online_cpuset="0x00000001,,0x0" allowed_cpuset="0x00000001,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000002,,0x0" complete_cpuset="0x00000002,,0x0" online_cpuset="0x00000002,,0x0" allowed_cpuset="0x00000002,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000002,,0x0" complete_cpuset="0x00000002,,0x0" online_cpuset="0x00000002,,0x0" allowed_cpuset="0x00000002,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000002,,0x0" complete_cpuset="0x00000002,,0x0" online_cpuset="0x00000002,,0x0" allowed_cpuset="0x00000002,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="17" cpuset="0x00000002,,0x0" complete_cpuset="0x00000002,,0x0" online_cpuset="0x00000002,,0x0" allowed_cpuset="0x00000002,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="65" cpuset="0x00000002,,0x0" complete_cpuset="0x00000002,,0x0" online_cpuset="0x00000002,,0x0" allowed_cpuset="0x00000002,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000004,,0x0" complete_cpuset="0x00000004,,0x0" online_cpuset="0x00000004,,0x0" allowed_cpuset="0x00000004,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000004,,0x0" complete_cpuset="0x00000004,,0x0" online_cpuset="0x00000004,,0x0" allowed_cpuset="0x00000004,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000004,,0x0" complete_cpuset="0x00000004,,0x0" online_cpuset="0x00000004,,0x0" allowed_cpuset="0x00000004,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="18" cpuset="0x00000004,,0x0" complete_cpuset="0x00000004,,0x0" online_cpuset="0x00000004,,0x0" allowed_cpuset="0x00000004,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="66" cpuset="0x00000004,,0x0" complete_cpuset="0x00000004,,0x0" online_cpuset="0x00000004,,0x0" allowed_cpuset="0x00000004,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000008,,0x0" complete_cpuset="0x00000008,,0x0" online_cpuset="0x00000008,,0x0" allowed_cpuset="0x00000008,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000008,,0x0" complete_cpuset="0x00000008,,0x0" online_cpuset="0x00000008,,0x0" allowed_cpuset="0x00000008,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000008,,0x0" complete_cpuset="0x00000008,,0x0" online_cpuset="0x00000008,,0x0" allowed_cpuset="0x00000008,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="19" cpuset="0x00000008,,0x0" complete_cpuset="0x00000008,,0x0" online_cpuset="0x00000008,,0x0" allowed_cpuset="0x00000008,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="67" cpuset="0x00000008,,0x0" complete_cpuset="0x00000008,,0x0" online_cpuset="0x00000008,,0x0" allowed_cpuset="0x00000008,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000010,,0x0" complete_cpuset="0x00000010,,0x0" online_cpuset="0x00000010,,0x0" allowed_cpuset="0x00000010,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000010,,0x0" complete_cpuset="0x00000010,,0x0" online_cpuset="0x00000010,,0x0" allowed_cpuset="0x00000010,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000010,,0x0" complete_cpuset="0x00000010,,0x0" online_cpuset="0x00000010,,0x0" allowed_cpuset="0x00000010,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="20" cpuset="0x00000010,,0x0" complete_cpuset="0x00000010,,0x0" online_cpuset="0x00000010,,0x0" allowed_cpuset="0x00000010,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="68" cpuset="0x00000010,,0x0" complete_cpuset="0x00000010,,0x0" online_cpuset="0x00000010,,0x0" allowed_cpuset="0x00000010,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000020,,0x0" complete_cpuset="0x00000020,,0x0" online_cpuset="0x00000020,,0x0" allowed_cpuset="0x00000020,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000020,,0x0" complete_cpuset="0x00000020,,0x0" online_cpuset="0x00000020,,0x0" allowed_cpuset="0x00000020,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000020,,0x0" complete_cpuset="0x00000020,,0x0" online_cpuset="0x00000020,,0x0" allowed_cpuset="0x00000020,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="21" cpuset="0x00000020,,0x0" complete_cpuset="0x00000020,,0x0" online_cpuset="0x00000020,,0x0" allowed_cpuset="0x00000020,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="69" cpuset="0x00000020,,0x0" complete_cpuset="0x00000020,,0x0" online_cpuset="0x00000020,,0x0" allowed_cpuset="0x00000020,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000040,,0x0" complete_cpuset="0x00000040,,0x0" online_cpuset="0x00000040,,0x0" allowed_cpuset="0x00000040,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000040,,0x0" complete_cpuset="0x00000040,,0x0" online_cpuset="0x00000040,,0x0" allowed_cpuset="0x00000040,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000040,,0x0" complete_cpuset="0x00000040,,0x0" online_cpuset="0x00000040,,0x0" allowed_cpuset="0x00000040,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="22" cpuset="0x00000040,,0x0" complete_cpuset="0x00000040,,0x0" online_cpuset="0x00000040,,0x0" allowed_cpuset="0x00000040,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="70" cpuset="0x00000040,,0x0" complete_cpuset="0x00000040,,0x0" online_cpuset="0x00000040,,0x0" allowed_cpuset="0x00000040,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000080,,0x0" complete_cpuset="0x00000080,,0x0" online_cpuset="0x00000080,,0x0" allowed_cpuset="0x00000080,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000080,,0x0" complete_cpuset="0x00000080,,0x0" online_cpuset="0x00000080,,0x0" allowed_cpuset="0x00000080,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000080,,0x0" complete_cpuset="0x00000080,,0x0" online_cpuset="0x00000080,,0x0" allowed_cpuset="0x00000080,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="23" cpuset="0x00000080,,0x0" complete_cpuset="0x00000080,,0x0" online_cpuset="0x00000080,,0x0" allowed_cpuset="0x00000080,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
+                  <object type="PU" os_index="71" cpuset="0x00000080,,0x0" complete_cpuset="0x00000080,,0x0" online_cpuset="0x00000080,,0x0" allowed_cpuset="0x00000080,,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="NUMANode" os_index="3" cpuset="0xffffff00,,0x0" complete_cpuset="0xffffff00,,0x0" online_cpuset="0xffffff00,,0x0" allowed_cpuset="0xffffff00,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" local_memory="99331137536">
+        <page_type size="4096" count="22899086"/>
+        <page_type size="2097152" count="2640"/>
+        <page_type size="1073741824" count="0"/>
+        <object type="Cache" cpuset="0x0000ff00,,0x0" complete_cpuset="0x0000ff00,,0x0" online_cpuset="0x0000ff00,,0x0" allowed_cpuset="0x0000ff00,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="16777216" depth="3" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00000100,,0x0" complete_cpuset="0x00000100,,0x0" online_cpuset="0x00000100,,0x0" allowed_cpuset="0x00000100,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000100,,0x0" complete_cpuset="0x00000100,,0x0" online_cpuset="0x00000100,,0x0" allowed_cpuset="0x00000100,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000100,,0x0" complete_cpuset="0x00000100,,0x0" online_cpuset="0x00000100,,0x0" allowed_cpuset="0x00000100,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="32" cpuset="0x00000100,,0x0" complete_cpuset="0x00000100,,0x0" online_cpuset="0x00000100,,0x0" allowed_cpuset="0x00000100,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="72" cpuset="0x00000100,,0x0" complete_cpuset="0x00000100,,0x0" online_cpuset="0x00000100,,0x0" allowed_cpuset="0x00000100,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000200,,0x0" complete_cpuset="0x00000200,,0x0" online_cpuset="0x00000200,,0x0" allowed_cpuset="0x00000200,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000200,,0x0" complete_cpuset="0x00000200,,0x0" online_cpuset="0x00000200,,0x0" allowed_cpuset="0x00000200,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000200,,0x0" complete_cpuset="0x00000200,,0x0" online_cpuset="0x00000200,,0x0" allowed_cpuset="0x00000200,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="33" cpuset="0x00000200,,0x0" complete_cpuset="0x00000200,,0x0" online_cpuset="0x00000200,,0x0" allowed_cpuset="0x00000200,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="73" cpuset="0x00000200,,0x0" complete_cpuset="0x00000200,,0x0" online_cpuset="0x00000200,,0x0" allowed_cpuset="0x00000200,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000400,,0x0" complete_cpuset="0x00000400,,0x0" online_cpuset="0x00000400,,0x0" allowed_cpuset="0x00000400,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000400,,0x0" complete_cpuset="0x00000400,,0x0" online_cpuset="0x00000400,,0x0" allowed_cpuset="0x00000400,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000400,,0x0" complete_cpuset="0x00000400,,0x0" online_cpuset="0x00000400,,0x0" allowed_cpuset="0x00000400,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="34" cpuset="0x00000400,,0x0" complete_cpuset="0x00000400,,0x0" online_cpuset="0x00000400,,0x0" allowed_cpuset="0x00000400,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="74" cpuset="0x00000400,,0x0" complete_cpuset="0x00000400,,0x0" online_cpuset="0x00000400,,0x0" allowed_cpuset="0x00000400,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000800,,0x0" complete_cpuset="0x00000800,,0x0" online_cpuset="0x00000800,,0x0" allowed_cpuset="0x00000800,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00000800,,0x0" complete_cpuset="0x00000800,,0x0" online_cpuset="0x00000800,,0x0" allowed_cpuset="0x00000800,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000800,,0x0" complete_cpuset="0x00000800,,0x0" online_cpuset="0x00000800,,0x0" allowed_cpuset="0x00000800,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="35" cpuset="0x00000800,,0x0" complete_cpuset="0x00000800,,0x0" online_cpuset="0x00000800,,0x0" allowed_cpuset="0x00000800,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="75" cpuset="0x00000800,,0x0" complete_cpuset="0x00000800,,0x0" online_cpuset="0x00000800,,0x0" allowed_cpuset="0x00000800,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00001000,,0x0" complete_cpuset="0x00001000,,0x0" online_cpuset="0x00001000,,0x0" allowed_cpuset="0x00001000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00001000,,0x0" complete_cpuset="0x00001000,,0x0" online_cpuset="0x00001000,,0x0" allowed_cpuset="0x00001000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00001000,,0x0" complete_cpuset="0x00001000,,0x0" online_cpuset="0x00001000,,0x0" allowed_cpuset="0x00001000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="36" cpuset="0x00001000,,0x0" complete_cpuset="0x00001000,,0x0" online_cpuset="0x00001000,,0x0" allowed_cpuset="0x00001000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="76" cpuset="0x00001000,,0x0" complete_cpuset="0x00001000,,0x0" online_cpuset="0x00001000,,0x0" allowed_cpuset="0x00001000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00002000,,0x0" complete_cpuset="0x00002000,,0x0" online_cpuset="0x00002000,,0x0" allowed_cpuset="0x00002000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00002000,,0x0" complete_cpuset="0x00002000,,0x0" online_cpuset="0x00002000,,0x0" allowed_cpuset="0x00002000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00002000,,0x0" complete_cpuset="0x00002000,,0x0" online_cpuset="0x00002000,,0x0" allowed_cpuset="0x00002000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="37" cpuset="0x00002000,,0x0" complete_cpuset="0x00002000,,0x0" online_cpuset="0x00002000,,0x0" allowed_cpuset="0x00002000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="77" cpuset="0x00002000,,0x0" complete_cpuset="0x00002000,,0x0" online_cpuset="0x00002000,,0x0" allowed_cpuset="0x00002000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00004000,,0x0" complete_cpuset="0x00004000,,0x0" online_cpuset="0x00004000,,0x0" allowed_cpuset="0x00004000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00004000,,0x0" complete_cpuset="0x00004000,,0x0" online_cpuset="0x00004000,,0x0" allowed_cpuset="0x00004000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00004000,,0x0" complete_cpuset="0x00004000,,0x0" online_cpuset="0x00004000,,0x0" allowed_cpuset="0x00004000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="38" cpuset="0x00004000,,0x0" complete_cpuset="0x00004000,,0x0" online_cpuset="0x00004000,,0x0" allowed_cpuset="0x00004000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="78" cpuset="0x00004000,,0x0" complete_cpuset="0x00004000,,0x0" online_cpuset="0x00004000,,0x0" allowed_cpuset="0x00004000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00008000,,0x0" complete_cpuset="0x00008000,,0x0" online_cpuset="0x00008000,,0x0" allowed_cpuset="0x00008000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00008000,,0x0" complete_cpuset="0x00008000,,0x0" online_cpuset="0x00008000,,0x0" allowed_cpuset="0x00008000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00008000,,0x0" complete_cpuset="0x00008000,,0x0" online_cpuset="0x00008000,,0x0" allowed_cpuset="0x00008000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="39" cpuset="0x00008000,,0x0" complete_cpuset="0x00008000,,0x0" online_cpuset="0x00008000,,0x0" allowed_cpuset="0x00008000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="79" cpuset="0x00008000,,0x0" complete_cpuset="0x00008000,,0x0" online_cpuset="0x00008000,,0x0" allowed_cpuset="0x00008000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0x00ff0000,,0x0" complete_cpuset="0x00ff0000,,0x0" online_cpuset="0x00ff0000,,0x0" allowed_cpuset="0x00ff0000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="16777216" depth="3" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00010000,,0x0" complete_cpuset="0x00010000,,0x0" online_cpuset="0x00010000,,0x0" allowed_cpuset="0x00010000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00010000,,0x0" complete_cpuset="0x00010000,,0x0" online_cpuset="0x00010000,,0x0" allowed_cpuset="0x00010000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00010000,,0x0" complete_cpuset="0x00010000,,0x0" online_cpuset="0x00010000,,0x0" allowed_cpuset="0x00010000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="40" cpuset="0x00010000,,0x0" complete_cpuset="0x00010000,,0x0" online_cpuset="0x00010000,,0x0" allowed_cpuset="0x00010000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="80" cpuset="0x00010000,,0x0" complete_cpuset="0x00010000,,0x0" online_cpuset="0x00010000,,0x0" allowed_cpuset="0x00010000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00020000,,0x0" complete_cpuset="0x00020000,,0x0" online_cpuset="0x00020000,,0x0" allowed_cpuset="0x00020000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00020000,,0x0" complete_cpuset="0x00020000,,0x0" online_cpuset="0x00020000,,0x0" allowed_cpuset="0x00020000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00020000,,0x0" complete_cpuset="0x00020000,,0x0" online_cpuset="0x00020000,,0x0" allowed_cpuset="0x00020000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="41" cpuset="0x00020000,,0x0" complete_cpuset="0x00020000,,0x0" online_cpuset="0x00020000,,0x0" allowed_cpuset="0x00020000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="81" cpuset="0x00020000,,0x0" complete_cpuset="0x00020000,,0x0" online_cpuset="0x00020000,,0x0" allowed_cpuset="0x00020000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00040000,,0x0" complete_cpuset="0x00040000,,0x0" online_cpuset="0x00040000,,0x0" allowed_cpuset="0x00040000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00040000,,0x0" complete_cpuset="0x00040000,,0x0" online_cpuset="0x00040000,,0x0" allowed_cpuset="0x00040000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00040000,,0x0" complete_cpuset="0x00040000,,0x0" online_cpuset="0x00040000,,0x0" allowed_cpuset="0x00040000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="42" cpuset="0x00040000,,0x0" complete_cpuset="0x00040000,,0x0" online_cpuset="0x00040000,,0x0" allowed_cpuset="0x00040000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="82" cpuset="0x00040000,,0x0" complete_cpuset="0x00040000,,0x0" online_cpuset="0x00040000,,0x0" allowed_cpuset="0x00040000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00080000,,0x0" complete_cpuset="0x00080000,,0x0" online_cpuset="0x00080000,,0x0" allowed_cpuset="0x00080000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00080000,,0x0" complete_cpuset="0x00080000,,0x0" online_cpuset="0x00080000,,0x0" allowed_cpuset="0x00080000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00080000,,0x0" complete_cpuset="0x00080000,,0x0" online_cpuset="0x00080000,,0x0" allowed_cpuset="0x00080000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="43" cpuset="0x00080000,,0x0" complete_cpuset="0x00080000,,0x0" online_cpuset="0x00080000,,0x0" allowed_cpuset="0x00080000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="83" cpuset="0x00080000,,0x0" complete_cpuset="0x00080000,,0x0" online_cpuset="0x00080000,,0x0" allowed_cpuset="0x00080000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00100000,,0x0" complete_cpuset="0x00100000,,0x0" online_cpuset="0x00100000,,0x0" allowed_cpuset="0x00100000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00100000,,0x0" complete_cpuset="0x00100000,,0x0" online_cpuset="0x00100000,,0x0" allowed_cpuset="0x00100000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00100000,,0x0" complete_cpuset="0x00100000,,0x0" online_cpuset="0x00100000,,0x0" allowed_cpuset="0x00100000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="44" cpuset="0x00100000,,0x0" complete_cpuset="0x00100000,,0x0" online_cpuset="0x00100000,,0x0" allowed_cpuset="0x00100000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="84" cpuset="0x00100000,,0x0" complete_cpuset="0x00100000,,0x0" online_cpuset="0x00100000,,0x0" allowed_cpuset="0x00100000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00200000,,0x0" complete_cpuset="0x00200000,,0x0" online_cpuset="0x00200000,,0x0" allowed_cpuset="0x00200000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00200000,,0x0" complete_cpuset="0x00200000,,0x0" online_cpuset="0x00200000,,0x0" allowed_cpuset="0x00200000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00200000,,0x0" complete_cpuset="0x00200000,,0x0" online_cpuset="0x00200000,,0x0" allowed_cpuset="0x00200000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="45" cpuset="0x00200000,,0x0" complete_cpuset="0x00200000,,0x0" online_cpuset="0x00200000,,0x0" allowed_cpuset="0x00200000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="85" cpuset="0x00200000,,0x0" complete_cpuset="0x00200000,,0x0" online_cpuset="0x00200000,,0x0" allowed_cpuset="0x00200000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00400000,,0x0" complete_cpuset="0x00400000,,0x0" online_cpuset="0x00400000,,0x0" allowed_cpuset="0x00400000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00400000,,0x0" complete_cpuset="0x00400000,,0x0" online_cpuset="0x00400000,,0x0" allowed_cpuset="0x00400000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00400000,,0x0" complete_cpuset="0x00400000,,0x0" online_cpuset="0x00400000,,0x0" allowed_cpuset="0x00400000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="46" cpuset="0x00400000,,0x0" complete_cpuset="0x00400000,,0x0" online_cpuset="0x00400000,,0x0" allowed_cpuset="0x00400000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="86" cpuset="0x00400000,,0x0" complete_cpuset="0x00400000,,0x0" online_cpuset="0x00400000,,0x0" allowed_cpuset="0x00400000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00800000,,0x0" complete_cpuset="0x00800000,,0x0" online_cpuset="0x00800000,,0x0" allowed_cpuset="0x00800000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x00800000,,0x0" complete_cpuset="0x00800000,,0x0" online_cpuset="0x00800000,,0x0" allowed_cpuset="0x00800000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00800000,,0x0" complete_cpuset="0x00800000,,0x0" online_cpuset="0x00800000,,0x0" allowed_cpuset="0x00800000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="47" cpuset="0x00800000,,0x0" complete_cpuset="0x00800000,,0x0" online_cpuset="0x00800000,,0x0" allowed_cpuset="0x00800000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="87" cpuset="0x00800000,,0x0" complete_cpuset="0x00800000,,0x0" online_cpuset="0x00800000,,0x0" allowed_cpuset="0x00800000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+        <object type="Cache" cpuset="0xff000000,,0x0" complete_cpuset="0xff000000,,0x0" online_cpuset="0xff000000,,0x0" allowed_cpuset="0xff000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="16777216" depth="3" cache_linesize="64" cache_associativity="8" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x01000000,,0x0" complete_cpuset="0x01000000,,0x0" online_cpuset="0x01000000,,0x0" allowed_cpuset="0x01000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x01000000,,0x0" complete_cpuset="0x01000000,,0x0" online_cpuset="0x01000000,,0x0" allowed_cpuset="0x01000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x01000000,,0x0" complete_cpuset="0x01000000,,0x0" online_cpuset="0x01000000,,0x0" allowed_cpuset="0x01000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="48" cpuset="0x01000000,,0x0" complete_cpuset="0x01000000,,0x0" online_cpuset="0x01000000,,0x0" allowed_cpuset="0x01000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="88" cpuset="0x01000000,,0x0" complete_cpuset="0x01000000,,0x0" online_cpuset="0x01000000,,0x0" allowed_cpuset="0x01000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x02000000,,0x0" complete_cpuset="0x02000000,,0x0" online_cpuset="0x02000000,,0x0" allowed_cpuset="0x02000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x02000000,,0x0" complete_cpuset="0x02000000,,0x0" online_cpuset="0x02000000,,0x0" allowed_cpuset="0x02000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x02000000,,0x0" complete_cpuset="0x02000000,,0x0" online_cpuset="0x02000000,,0x0" allowed_cpuset="0x02000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="49" cpuset="0x02000000,,0x0" complete_cpuset="0x02000000,,0x0" online_cpuset="0x02000000,,0x0" allowed_cpuset="0x02000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="89" cpuset="0x02000000,,0x0" complete_cpuset="0x02000000,,0x0" online_cpuset="0x02000000,,0x0" allowed_cpuset="0x02000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x04000000,,0x0" complete_cpuset="0x04000000,,0x0" online_cpuset="0x04000000,,0x0" allowed_cpuset="0x04000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x04000000,,0x0" complete_cpuset="0x04000000,,0x0" online_cpuset="0x04000000,,0x0" allowed_cpuset="0x04000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x04000000,,0x0" complete_cpuset="0x04000000,,0x0" online_cpuset="0x04000000,,0x0" allowed_cpuset="0x04000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="50" cpuset="0x04000000,,0x0" complete_cpuset="0x04000000,,0x0" online_cpuset="0x04000000,,0x0" allowed_cpuset="0x04000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="90" cpuset="0x04000000,,0x0" complete_cpuset="0x04000000,,0x0" online_cpuset="0x04000000,,0x0" allowed_cpuset="0x04000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x08000000,,0x0" complete_cpuset="0x08000000,,0x0" online_cpuset="0x08000000,,0x0" allowed_cpuset="0x08000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x08000000,,0x0" complete_cpuset="0x08000000,,0x0" online_cpuset="0x08000000,,0x0" allowed_cpuset="0x08000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x08000000,,0x0" complete_cpuset="0x08000000,,0x0" online_cpuset="0x08000000,,0x0" allowed_cpuset="0x08000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="51" cpuset="0x08000000,,0x0" complete_cpuset="0x08000000,,0x0" online_cpuset="0x08000000,,0x0" allowed_cpuset="0x08000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="91" cpuset="0x08000000,,0x0" complete_cpuset="0x08000000,,0x0" online_cpuset="0x08000000,,0x0" allowed_cpuset="0x08000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x10000000,,0x0" complete_cpuset="0x10000000,,0x0" online_cpuset="0x10000000,,0x0" allowed_cpuset="0x10000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x10000000,,0x0" complete_cpuset="0x10000000,,0x0" online_cpuset="0x10000000,,0x0" allowed_cpuset="0x10000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x10000000,,0x0" complete_cpuset="0x10000000,,0x0" online_cpuset="0x10000000,,0x0" allowed_cpuset="0x10000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="52" cpuset="0x10000000,,0x0" complete_cpuset="0x10000000,,0x0" online_cpuset="0x10000000,,0x0" allowed_cpuset="0x10000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="92" cpuset="0x10000000,,0x0" complete_cpuset="0x10000000,,0x0" online_cpuset="0x10000000,,0x0" allowed_cpuset="0x10000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x20000000,,0x0" complete_cpuset="0x20000000,,0x0" online_cpuset="0x20000000,,0x0" allowed_cpuset="0x20000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x20000000,,0x0" complete_cpuset="0x20000000,,0x0" online_cpuset="0x20000000,,0x0" allowed_cpuset="0x20000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x20000000,,0x0" complete_cpuset="0x20000000,,0x0" online_cpuset="0x20000000,,0x0" allowed_cpuset="0x20000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="53" cpuset="0x20000000,,0x0" complete_cpuset="0x20000000,,0x0" online_cpuset="0x20000000,,0x0" allowed_cpuset="0x20000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="93" cpuset="0x20000000,,0x0" complete_cpuset="0x20000000,,0x0" online_cpuset="0x20000000,,0x0" allowed_cpuset="0x20000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x40000000,,0x0" complete_cpuset="0x40000000,,0x0" online_cpuset="0x40000000,,0x0" allowed_cpuset="0x40000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x40000000,,0x0" complete_cpuset="0x40000000,,0x0" online_cpuset="0x40000000,,0x0" allowed_cpuset="0x40000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x40000000,,0x0" complete_cpuset="0x40000000,,0x0" online_cpuset="0x40000000,,0x0" allowed_cpuset="0x40000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="54" cpuset="0x40000000,,0x0" complete_cpuset="0x40000000,,0x0" online_cpuset="0x40000000,,0x0" allowed_cpuset="0x40000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="94" cpuset="0x40000000,,0x0" complete_cpuset="0x40000000,,0x0" online_cpuset="0x40000000,,0x0" allowed_cpuset="0x40000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x80000000,,0x0" complete_cpuset="0x80000000,,0x0" online_cpuset="0x80000000,,0x0" allowed_cpuset="0x80000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="Inclusive" value="1"/>
+            <object type="Cache" cpuset="0x80000000,,0x0" complete_cpuset="0x80000000,,0x0" online_cpuset="0x80000000,,0x0" allowed_cpuset="0x80000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x80000000,,0x0" complete_cpuset="0x80000000,,0x0" online_cpuset="0x80000000,,0x0" allowed_cpuset="0x80000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="55" cpuset="0x80000000,,0x0" complete_cpuset="0x80000000,,0x0" online_cpuset="0x80000000,,0x0" allowed_cpuset="0x80000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
+                  <object type="PU" os_index="95" cpuset="0x80000000,,0x0" complete_cpuset="0x80000000,,0x0" online_cpuset="0x80000000,,0x0" allowed_cpuset="0x80000000,,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="Bridge" os_index="0" bridge_type="0-1" depth="0" bridge_pci="0000:[00-00]">
+      <object type="PCIDev" os_index="48" pci_busid="0000:00:03.0" pci_type="0300 [1d0f:1111] [0000:0000] 00" pci_link_speed="0.000000">
+        <info name="PCISlot" value="3"/>
+      </object>
+      <object type="PCIDev" os_index="64" pci_busid="0000:00:04.0" pci_type="0108 [1d0f:8061] [1d0f:0000] 00" pci_link_speed="0.000000">
+        <info name="PCISlot" value="4"/>
+      </object>
+      <object type="PCIDev" os_index="80" pci_busid="0000:00:05.0" pci_type="0200 [1d0f:ec20] [1d0f:ec20] 00" pci_link_speed="0.000000">
+        <info name="PCISlot" value="5"/>
+        <object type="OSDev" name="eth0" osdev_type="2">
+          <info name="Address" value="06:a4:ea:d5:09:0d"/>
+        </object>
+      </object>
+      <object type="PCIDev" os_index="96" pci_busid="0000:00:06.0" pci_type="0200 [1d0f:efa1] [1d0f:efa1] 00" pci_link_speed="0.000000">
+        <info name="PCISlot" value="6"/>
+        <object type="OSDev" name="rdmap0s6" osdev_type="3">
+          <info name="NodeGUID" value="0000:0000:0000:0000"/>
+          <info name="SysImageGUID" value="0000:0000:0000:0000"/>
+          <info name="Port1State" value="4"/>
+          <info name="Port1LID" value="0x0"/>
+          <info name="Port1LMC" value="1"/>
+          <info name="Port1GID0" value="fe80:0000:0000:0000:04a4:eaff:fed5:090d"/>
+        </object>
+      </object>
+    </object>
+  </object>
+</topology>

--- a/test/runtime/jhh/colocales/m6in-dy-m6in32xlarge.xml
+++ b/test/runtime/jhh/colocales/m6in-dy-m6in32xlarge.xml
@@ -1,0 +1,949 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc.dtd">
+<topology>
+  <object type="Machine" os_index="0" cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff" online_cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff" nodeset="0x00000003" complete_nodeset="0x00000003" allowed_nodeset="0x00000003">
+    <page_type size="4096" count="0"/>
+    <page_type size="2097152" count="0"/>
+    <page_type size="1073741824" count="0"/>
+    <info name="DMIProductName" value="m6in.32xlarge"/>
+    <info name="DMIProductVersion" value=""/>
+    <info name="DMIBoardVendor" value="Amazon EC2"/>
+    <info name="DMIBoardName" value=""/>
+    <info name="DMIBoardVersion" value=""/>
+    <info name="DMIBoardAssetTag" value="i-05df912ac6829601c"/>
+    <info name="DMIChassisVendor" value="Amazon EC2"/>
+    <info name="DMIChassisType" value="1"/>
+    <info name="DMIChassisVersion" value=""/>
+    <info name="DMIChassisAssetTag" value="Amazon EC2"/>
+    <info name="DMIBIOSVendor" value="Amazon EC2"/>
+    <info name="DMIBIOSVersion" value="1.0"/>
+    <info name="DMIBIOSDate" value="10/16/2017"/>
+    <info name="DMISysVendor" value="Amazon EC2"/>
+    <info name="Backend" value="Linux"/>
+    <info name="LinuxCgroup" value="/"/>
+    <info name="OSName" value="Linux"/>
+    <info name="OSRelease" value="5.10.192-183.736.amzn2.x86_64"/>
+    <info name="OSVersion" value="#1 SMP Wed Sep 6 21:15:41 UTC 2023"/>
+    <info name="HostName" value="m6in-dy-m6in32xlarge-5"/>
+    <info name="Architecture" value="x86_64"/>
+    <info name="hwlocVersion" value="1.11.8"/>
+    <info name="ProcessName" value="hwloc-ls"/>
+    <distances nbobjs="2" relative_depth="1" latency_base="10.000000">
+      <latency value="1.000000"/>
+      <latency value="2.000000"/>
+      <latency value="2.000000"/>
+      <latency value="1.000000"/>
+    </distances>
+    <object type="NUMANode" os_index="0" cpuset="0xffffffff,,0xffffffff" complete_cpuset="0xffffffff,,0xffffffff" online_cpuset="0xffffffff,,0xffffffff" allowed_cpuset="0xffffffff,,0xffffffff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" local_memory="266254057472">
+      <page_type size="4096" count="61398440"/>
+      <page_type size="2097152" count="7041"/>
+      <page_type size="1073741824" count="0"/>
+      <object type="Package" os_index="0" cpuset="0xffffffff,,0xffffffff" complete_cpuset="0xffffffff,,0xffffffff" online_cpuset="0xffffffff,,0xffffffff" allowed_cpuset="0xffffffff,,0xffffffff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+        <info name="CPUVendor" value="GenuineIntel"/>
+        <info name="CPUFamilyNumber" value="6"/>
+        <info name="CPUModelNumber" value="106"/>
+        <info name="CPUModel" value="Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz"/>
+        <info name="CPUStepping" value="6"/>
+        <object type="Cache" cpuset="0xffffffff,,0xffffffff" complete_cpuset="0xffffffff,,0xffffffff" online_cpuset="0xffffffff,,0xffffffff" allowed_cpuset="0xffffffff,,0xffffffff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="56623104" depth="3" cache_linesize="64" cache_associativity="12" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00000001,,0x00000001" complete_cpuset="0x00000001,,0x00000001" online_cpuset="0x00000001,,0x00000001" allowed_cpuset="0x00000001,,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000001,,0x00000001" complete_cpuset="0x00000001,,0x00000001" online_cpuset="0x00000001,,0x00000001" allowed_cpuset="0x00000001,,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000001,,0x00000001" complete_cpuset="0x00000001,,0x00000001" online_cpuset="0x00000001,,0x00000001" allowed_cpuset="0x00000001,,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="0" cpuset="0x00000001,,0x00000001" complete_cpuset="0x00000001,,0x00000001" online_cpuset="0x00000001,,0x00000001" allowed_cpuset="0x00000001,,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" online_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="64" cpuset="0x00000001,,0x0" complete_cpuset="0x00000001,,0x0" online_cpuset="0x00000001,,0x0" allowed_cpuset="0x00000001,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000002,,0x00000002" complete_cpuset="0x00000002,,0x00000002" online_cpuset="0x00000002,,0x00000002" allowed_cpuset="0x00000002,,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000002,,0x00000002" complete_cpuset="0x00000002,,0x00000002" online_cpuset="0x00000002,,0x00000002" allowed_cpuset="0x00000002,,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000002,,0x00000002" complete_cpuset="0x00000002,,0x00000002" online_cpuset="0x00000002,,0x00000002" allowed_cpuset="0x00000002,,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="1" cpuset="0x00000002,,0x00000002" complete_cpuset="0x00000002,,0x00000002" online_cpuset="0x00000002,,0x00000002" allowed_cpuset="0x00000002,,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" online_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="65" cpuset="0x00000002,,0x0" complete_cpuset="0x00000002,,0x0" online_cpuset="0x00000002,,0x0" allowed_cpuset="0x00000002,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000004,,0x00000004" complete_cpuset="0x00000004,,0x00000004" online_cpuset="0x00000004,,0x00000004" allowed_cpuset="0x00000004,,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000004,,0x00000004" complete_cpuset="0x00000004,,0x00000004" online_cpuset="0x00000004,,0x00000004" allowed_cpuset="0x00000004,,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000004,,0x00000004" complete_cpuset="0x00000004,,0x00000004" online_cpuset="0x00000004,,0x00000004" allowed_cpuset="0x00000004,,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="2" cpuset="0x00000004,,0x00000004" complete_cpuset="0x00000004,,0x00000004" online_cpuset="0x00000004,,0x00000004" allowed_cpuset="0x00000004,,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" online_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="66" cpuset="0x00000004,,0x0" complete_cpuset="0x00000004,,0x0" online_cpuset="0x00000004,,0x0" allowed_cpuset="0x00000004,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000008,,0x00000008" complete_cpuset="0x00000008,,0x00000008" online_cpuset="0x00000008,,0x00000008" allowed_cpuset="0x00000008,,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000008,,0x00000008" complete_cpuset="0x00000008,,0x00000008" online_cpuset="0x00000008,,0x00000008" allowed_cpuset="0x00000008,,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000008,,0x00000008" complete_cpuset="0x00000008,,0x00000008" online_cpuset="0x00000008,,0x00000008" allowed_cpuset="0x00000008,,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="3" cpuset="0x00000008,,0x00000008" complete_cpuset="0x00000008,,0x00000008" online_cpuset="0x00000008,,0x00000008" allowed_cpuset="0x00000008,,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" online_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="67" cpuset="0x00000008,,0x0" complete_cpuset="0x00000008,,0x0" online_cpuset="0x00000008,,0x0" allowed_cpuset="0x00000008,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000010,,0x00000010" complete_cpuset="0x00000010,,0x00000010" online_cpuset="0x00000010,,0x00000010" allowed_cpuset="0x00000010,,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000010,,0x00000010" complete_cpuset="0x00000010,,0x00000010" online_cpuset="0x00000010,,0x00000010" allowed_cpuset="0x00000010,,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000010,,0x00000010" complete_cpuset="0x00000010,,0x00000010" online_cpuset="0x00000010,,0x00000010" allowed_cpuset="0x00000010,,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="4" cpuset="0x00000010,,0x00000010" complete_cpuset="0x00000010,,0x00000010" online_cpuset="0x00000010,,0x00000010" allowed_cpuset="0x00000010,,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" online_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="68" cpuset="0x00000010,,0x0" complete_cpuset="0x00000010,,0x0" online_cpuset="0x00000010,,0x0" allowed_cpuset="0x00000010,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000020,,0x00000020" complete_cpuset="0x00000020,,0x00000020" online_cpuset="0x00000020,,0x00000020" allowed_cpuset="0x00000020,,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000020,,0x00000020" complete_cpuset="0x00000020,,0x00000020" online_cpuset="0x00000020,,0x00000020" allowed_cpuset="0x00000020,,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000020,,0x00000020" complete_cpuset="0x00000020,,0x00000020" online_cpuset="0x00000020,,0x00000020" allowed_cpuset="0x00000020,,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="5" cpuset="0x00000020,,0x00000020" complete_cpuset="0x00000020,,0x00000020" online_cpuset="0x00000020,,0x00000020" allowed_cpuset="0x00000020,,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" online_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="69" cpuset="0x00000020,,0x0" complete_cpuset="0x00000020,,0x0" online_cpuset="0x00000020,,0x0" allowed_cpuset="0x00000020,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000040,,0x00000040" complete_cpuset="0x00000040,,0x00000040" online_cpuset="0x00000040,,0x00000040" allowed_cpuset="0x00000040,,0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000040,,0x00000040" complete_cpuset="0x00000040,,0x00000040" online_cpuset="0x00000040,,0x00000040" allowed_cpuset="0x00000040,,0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000040,,0x00000040" complete_cpuset="0x00000040,,0x00000040" online_cpuset="0x00000040,,0x00000040" allowed_cpuset="0x00000040,,0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="6" cpuset="0x00000040,,0x00000040" complete_cpuset="0x00000040,,0x00000040" online_cpuset="0x00000040,,0x00000040" allowed_cpuset="0x00000040,,0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" online_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="70" cpuset="0x00000040,,0x0" complete_cpuset="0x00000040,,0x0" online_cpuset="0x00000040,,0x0" allowed_cpuset="0x00000040,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000080,,0x00000080" complete_cpuset="0x00000080,,0x00000080" online_cpuset="0x00000080,,0x00000080" allowed_cpuset="0x00000080,,0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000080,,0x00000080" complete_cpuset="0x00000080,,0x00000080" online_cpuset="0x00000080,,0x00000080" allowed_cpuset="0x00000080,,0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000080,,0x00000080" complete_cpuset="0x00000080,,0x00000080" online_cpuset="0x00000080,,0x00000080" allowed_cpuset="0x00000080,,0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="7" cpuset="0x00000080,,0x00000080" complete_cpuset="0x00000080,,0x00000080" online_cpuset="0x00000080,,0x00000080" allowed_cpuset="0x00000080,,0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" online_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="71" cpuset="0x00000080,,0x0" complete_cpuset="0x00000080,,0x0" online_cpuset="0x00000080,,0x0" allowed_cpuset="0x00000080,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000100,,0x00000100" complete_cpuset="0x00000100,,0x00000100" online_cpuset="0x00000100,,0x00000100" allowed_cpuset="0x00000100,,0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000100,,0x00000100" complete_cpuset="0x00000100,,0x00000100" online_cpuset="0x00000100,,0x00000100" allowed_cpuset="0x00000100,,0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000100,,0x00000100" complete_cpuset="0x00000100,,0x00000100" online_cpuset="0x00000100,,0x00000100" allowed_cpuset="0x00000100,,0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="8" cpuset="0x00000100,,0x00000100" complete_cpuset="0x00000100,,0x00000100" online_cpuset="0x00000100,,0x00000100" allowed_cpuset="0x00000100,,0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" online_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="72" cpuset="0x00000100,,0x0" complete_cpuset="0x00000100,,0x0" online_cpuset="0x00000100,,0x0" allowed_cpuset="0x00000100,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000200,,0x00000200" complete_cpuset="0x00000200,,0x00000200" online_cpuset="0x00000200,,0x00000200" allowed_cpuset="0x00000200,,0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000200,,0x00000200" complete_cpuset="0x00000200,,0x00000200" online_cpuset="0x00000200,,0x00000200" allowed_cpuset="0x00000200,,0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000200,,0x00000200" complete_cpuset="0x00000200,,0x00000200" online_cpuset="0x00000200,,0x00000200" allowed_cpuset="0x00000200,,0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="9" cpuset="0x00000200,,0x00000200" complete_cpuset="0x00000200,,0x00000200" online_cpuset="0x00000200,,0x00000200" allowed_cpuset="0x00000200,,0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" online_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="73" cpuset="0x00000200,,0x0" complete_cpuset="0x00000200,,0x0" online_cpuset="0x00000200,,0x0" allowed_cpuset="0x00000200,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000400,,0x00000400" complete_cpuset="0x00000400,,0x00000400" online_cpuset="0x00000400,,0x00000400" allowed_cpuset="0x00000400,,0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000400,,0x00000400" complete_cpuset="0x00000400,,0x00000400" online_cpuset="0x00000400,,0x00000400" allowed_cpuset="0x00000400,,0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000400,,0x00000400" complete_cpuset="0x00000400,,0x00000400" online_cpuset="0x00000400,,0x00000400" allowed_cpuset="0x00000400,,0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="10" cpuset="0x00000400,,0x00000400" complete_cpuset="0x00000400,,0x00000400" online_cpuset="0x00000400,,0x00000400" allowed_cpuset="0x00000400,,0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" online_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="74" cpuset="0x00000400,,0x0" complete_cpuset="0x00000400,,0x0" online_cpuset="0x00000400,,0x0" allowed_cpuset="0x00000400,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000800,,0x00000800" complete_cpuset="0x00000800,,0x00000800" online_cpuset="0x00000800,,0x00000800" allowed_cpuset="0x00000800,,0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000800,,0x00000800" complete_cpuset="0x00000800,,0x00000800" online_cpuset="0x00000800,,0x00000800" allowed_cpuset="0x00000800,,0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000800,,0x00000800" complete_cpuset="0x00000800,,0x00000800" online_cpuset="0x00000800,,0x00000800" allowed_cpuset="0x00000800,,0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="11" cpuset="0x00000800,,0x00000800" complete_cpuset="0x00000800,,0x00000800" online_cpuset="0x00000800,,0x00000800" allowed_cpuset="0x00000800,,0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" online_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="75" cpuset="0x00000800,,0x0" complete_cpuset="0x00000800,,0x0" online_cpuset="0x00000800,,0x0" allowed_cpuset="0x00000800,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00001000,,0x00001000" complete_cpuset="0x00001000,,0x00001000" online_cpuset="0x00001000,,0x00001000" allowed_cpuset="0x00001000,,0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00001000,,0x00001000" complete_cpuset="0x00001000,,0x00001000" online_cpuset="0x00001000,,0x00001000" allowed_cpuset="0x00001000,,0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00001000,,0x00001000" complete_cpuset="0x00001000,,0x00001000" online_cpuset="0x00001000,,0x00001000" allowed_cpuset="0x00001000,,0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="12" cpuset="0x00001000,,0x00001000" complete_cpuset="0x00001000,,0x00001000" online_cpuset="0x00001000,,0x00001000" allowed_cpuset="0x00001000,,0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" online_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="76" cpuset="0x00001000,,0x0" complete_cpuset="0x00001000,,0x0" online_cpuset="0x00001000,,0x0" allowed_cpuset="0x00001000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00002000,,0x00002000" complete_cpuset="0x00002000,,0x00002000" online_cpuset="0x00002000,,0x00002000" allowed_cpuset="0x00002000,,0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00002000,,0x00002000" complete_cpuset="0x00002000,,0x00002000" online_cpuset="0x00002000,,0x00002000" allowed_cpuset="0x00002000,,0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00002000,,0x00002000" complete_cpuset="0x00002000,,0x00002000" online_cpuset="0x00002000,,0x00002000" allowed_cpuset="0x00002000,,0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="13" cpuset="0x00002000,,0x00002000" complete_cpuset="0x00002000,,0x00002000" online_cpuset="0x00002000,,0x00002000" allowed_cpuset="0x00002000,,0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" online_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="77" cpuset="0x00002000,,0x0" complete_cpuset="0x00002000,,0x0" online_cpuset="0x00002000,,0x0" allowed_cpuset="0x00002000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00004000,,0x00004000" complete_cpuset="0x00004000,,0x00004000" online_cpuset="0x00004000,,0x00004000" allowed_cpuset="0x00004000,,0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00004000,,0x00004000" complete_cpuset="0x00004000,,0x00004000" online_cpuset="0x00004000,,0x00004000" allowed_cpuset="0x00004000,,0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00004000,,0x00004000" complete_cpuset="0x00004000,,0x00004000" online_cpuset="0x00004000,,0x00004000" allowed_cpuset="0x00004000,,0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="14" cpuset="0x00004000,,0x00004000" complete_cpuset="0x00004000,,0x00004000" online_cpuset="0x00004000,,0x00004000" allowed_cpuset="0x00004000,,0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" online_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="78" cpuset="0x00004000,,0x0" complete_cpuset="0x00004000,,0x0" online_cpuset="0x00004000,,0x0" allowed_cpuset="0x00004000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00008000,,0x00008000" complete_cpuset="0x00008000,,0x00008000" online_cpuset="0x00008000,,0x00008000" allowed_cpuset="0x00008000,,0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00008000,,0x00008000" complete_cpuset="0x00008000,,0x00008000" online_cpuset="0x00008000,,0x00008000" allowed_cpuset="0x00008000,,0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00008000,,0x00008000" complete_cpuset="0x00008000,,0x00008000" online_cpuset="0x00008000,,0x00008000" allowed_cpuset="0x00008000,,0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="15" cpuset="0x00008000,,0x00008000" complete_cpuset="0x00008000,,0x00008000" online_cpuset="0x00008000,,0x00008000" allowed_cpuset="0x00008000,,0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" online_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="79" cpuset="0x00008000,,0x0" complete_cpuset="0x00008000,,0x0" online_cpuset="0x00008000,,0x0" allowed_cpuset="0x00008000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00010000,,0x00010000" complete_cpuset="0x00010000,,0x00010000" online_cpuset="0x00010000,,0x00010000" allowed_cpuset="0x00010000,,0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00010000,,0x00010000" complete_cpuset="0x00010000,,0x00010000" online_cpuset="0x00010000,,0x00010000" allowed_cpuset="0x00010000,,0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00010000,,0x00010000" complete_cpuset="0x00010000,,0x00010000" online_cpuset="0x00010000,,0x00010000" allowed_cpuset="0x00010000,,0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="16" cpuset="0x00010000,,0x00010000" complete_cpuset="0x00010000,,0x00010000" online_cpuset="0x00010000,,0x00010000" allowed_cpuset="0x00010000,,0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" online_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="80" cpuset="0x00010000,,0x0" complete_cpuset="0x00010000,,0x0" online_cpuset="0x00010000,,0x0" allowed_cpuset="0x00010000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00020000,,0x00020000" complete_cpuset="0x00020000,,0x00020000" online_cpuset="0x00020000,,0x00020000" allowed_cpuset="0x00020000,,0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00020000,,0x00020000" complete_cpuset="0x00020000,,0x00020000" online_cpuset="0x00020000,,0x00020000" allowed_cpuset="0x00020000,,0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00020000,,0x00020000" complete_cpuset="0x00020000,,0x00020000" online_cpuset="0x00020000,,0x00020000" allowed_cpuset="0x00020000,,0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="17" cpuset="0x00020000,,0x00020000" complete_cpuset="0x00020000,,0x00020000" online_cpuset="0x00020000,,0x00020000" allowed_cpuset="0x00020000,,0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" online_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="81" cpuset="0x00020000,,0x0" complete_cpuset="0x00020000,,0x0" online_cpuset="0x00020000,,0x0" allowed_cpuset="0x00020000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00040000,,0x00040000" complete_cpuset="0x00040000,,0x00040000" online_cpuset="0x00040000,,0x00040000" allowed_cpuset="0x00040000,,0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00040000,,0x00040000" complete_cpuset="0x00040000,,0x00040000" online_cpuset="0x00040000,,0x00040000" allowed_cpuset="0x00040000,,0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00040000,,0x00040000" complete_cpuset="0x00040000,,0x00040000" online_cpuset="0x00040000,,0x00040000" allowed_cpuset="0x00040000,,0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="18" cpuset="0x00040000,,0x00040000" complete_cpuset="0x00040000,,0x00040000" online_cpuset="0x00040000,,0x00040000" allowed_cpuset="0x00040000,,0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" online_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="82" cpuset="0x00040000,,0x0" complete_cpuset="0x00040000,,0x0" online_cpuset="0x00040000,,0x0" allowed_cpuset="0x00040000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00080000,,0x00080000" complete_cpuset="0x00080000,,0x00080000" online_cpuset="0x00080000,,0x00080000" allowed_cpuset="0x00080000,,0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00080000,,0x00080000" complete_cpuset="0x00080000,,0x00080000" online_cpuset="0x00080000,,0x00080000" allowed_cpuset="0x00080000,,0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00080000,,0x00080000" complete_cpuset="0x00080000,,0x00080000" online_cpuset="0x00080000,,0x00080000" allowed_cpuset="0x00080000,,0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="19" cpuset="0x00080000,,0x00080000" complete_cpuset="0x00080000,,0x00080000" online_cpuset="0x00080000,,0x00080000" allowed_cpuset="0x00080000,,0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" online_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="83" cpuset="0x00080000,,0x0" complete_cpuset="0x00080000,,0x0" online_cpuset="0x00080000,,0x0" allowed_cpuset="0x00080000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00100000,,0x00100000" complete_cpuset="0x00100000,,0x00100000" online_cpuset="0x00100000,,0x00100000" allowed_cpuset="0x00100000,,0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00100000,,0x00100000" complete_cpuset="0x00100000,,0x00100000" online_cpuset="0x00100000,,0x00100000" allowed_cpuset="0x00100000,,0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00100000,,0x00100000" complete_cpuset="0x00100000,,0x00100000" online_cpuset="0x00100000,,0x00100000" allowed_cpuset="0x00100000,,0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="20" cpuset="0x00100000,,0x00100000" complete_cpuset="0x00100000,,0x00100000" online_cpuset="0x00100000,,0x00100000" allowed_cpuset="0x00100000,,0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" online_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="84" cpuset="0x00100000,,0x0" complete_cpuset="0x00100000,,0x0" online_cpuset="0x00100000,,0x0" allowed_cpuset="0x00100000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00200000,,0x00200000" complete_cpuset="0x00200000,,0x00200000" online_cpuset="0x00200000,,0x00200000" allowed_cpuset="0x00200000,,0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00200000,,0x00200000" complete_cpuset="0x00200000,,0x00200000" online_cpuset="0x00200000,,0x00200000" allowed_cpuset="0x00200000,,0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00200000,,0x00200000" complete_cpuset="0x00200000,,0x00200000" online_cpuset="0x00200000,,0x00200000" allowed_cpuset="0x00200000,,0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="21" cpuset="0x00200000,,0x00200000" complete_cpuset="0x00200000,,0x00200000" online_cpuset="0x00200000,,0x00200000" allowed_cpuset="0x00200000,,0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" online_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="85" cpuset="0x00200000,,0x0" complete_cpuset="0x00200000,,0x0" online_cpuset="0x00200000,,0x0" allowed_cpuset="0x00200000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00400000,,0x00400000" complete_cpuset="0x00400000,,0x00400000" online_cpuset="0x00400000,,0x00400000" allowed_cpuset="0x00400000,,0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00400000,,0x00400000" complete_cpuset="0x00400000,,0x00400000" online_cpuset="0x00400000,,0x00400000" allowed_cpuset="0x00400000,,0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00400000,,0x00400000" complete_cpuset="0x00400000,,0x00400000" online_cpuset="0x00400000,,0x00400000" allowed_cpuset="0x00400000,,0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="22" cpuset="0x00400000,,0x00400000" complete_cpuset="0x00400000,,0x00400000" online_cpuset="0x00400000,,0x00400000" allowed_cpuset="0x00400000,,0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" online_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="86" cpuset="0x00400000,,0x0" complete_cpuset="0x00400000,,0x0" online_cpuset="0x00400000,,0x0" allowed_cpuset="0x00400000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00800000,,0x00800000" complete_cpuset="0x00800000,,0x00800000" online_cpuset="0x00800000,,0x00800000" allowed_cpuset="0x00800000,,0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00800000,,0x00800000" complete_cpuset="0x00800000,,0x00800000" online_cpuset="0x00800000,,0x00800000" allowed_cpuset="0x00800000,,0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00800000,,0x00800000" complete_cpuset="0x00800000,,0x00800000" online_cpuset="0x00800000,,0x00800000" allowed_cpuset="0x00800000,,0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="23" cpuset="0x00800000,,0x00800000" complete_cpuset="0x00800000,,0x00800000" online_cpuset="0x00800000,,0x00800000" allowed_cpuset="0x00800000,,0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" online_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="87" cpuset="0x00800000,,0x0" complete_cpuset="0x00800000,,0x0" online_cpuset="0x00800000,,0x0" allowed_cpuset="0x00800000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x01000000,,0x01000000" complete_cpuset="0x01000000,,0x01000000" online_cpuset="0x01000000,,0x01000000" allowed_cpuset="0x01000000,,0x01000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x01000000,,0x01000000" complete_cpuset="0x01000000,,0x01000000" online_cpuset="0x01000000,,0x01000000" allowed_cpuset="0x01000000,,0x01000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x01000000,,0x01000000" complete_cpuset="0x01000000,,0x01000000" online_cpuset="0x01000000,,0x01000000" allowed_cpuset="0x01000000,,0x01000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="24" cpuset="0x01000000,,0x01000000" complete_cpuset="0x01000000,,0x01000000" online_cpuset="0x01000000,,0x01000000" allowed_cpuset="0x01000000,,0x01000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="24" cpuset="0x01000000" complete_cpuset="0x01000000" online_cpuset="0x01000000" allowed_cpuset="0x01000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="88" cpuset="0x01000000,,0x0" complete_cpuset="0x01000000,,0x0" online_cpuset="0x01000000,,0x0" allowed_cpuset="0x01000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x02000000,,0x02000000" complete_cpuset="0x02000000,,0x02000000" online_cpuset="0x02000000,,0x02000000" allowed_cpuset="0x02000000,,0x02000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x02000000,,0x02000000" complete_cpuset="0x02000000,,0x02000000" online_cpuset="0x02000000,,0x02000000" allowed_cpuset="0x02000000,,0x02000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x02000000,,0x02000000" complete_cpuset="0x02000000,,0x02000000" online_cpuset="0x02000000,,0x02000000" allowed_cpuset="0x02000000,,0x02000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="25" cpuset="0x02000000,,0x02000000" complete_cpuset="0x02000000,,0x02000000" online_cpuset="0x02000000,,0x02000000" allowed_cpuset="0x02000000,,0x02000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="25" cpuset="0x02000000" complete_cpuset="0x02000000" online_cpuset="0x02000000" allowed_cpuset="0x02000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="89" cpuset="0x02000000,,0x0" complete_cpuset="0x02000000,,0x0" online_cpuset="0x02000000,,0x0" allowed_cpuset="0x02000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x04000000,,0x04000000" complete_cpuset="0x04000000,,0x04000000" online_cpuset="0x04000000,,0x04000000" allowed_cpuset="0x04000000,,0x04000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x04000000,,0x04000000" complete_cpuset="0x04000000,,0x04000000" online_cpuset="0x04000000,,0x04000000" allowed_cpuset="0x04000000,,0x04000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x04000000,,0x04000000" complete_cpuset="0x04000000,,0x04000000" online_cpuset="0x04000000,,0x04000000" allowed_cpuset="0x04000000,,0x04000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="26" cpuset="0x04000000,,0x04000000" complete_cpuset="0x04000000,,0x04000000" online_cpuset="0x04000000,,0x04000000" allowed_cpuset="0x04000000,,0x04000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="26" cpuset="0x04000000" complete_cpuset="0x04000000" online_cpuset="0x04000000" allowed_cpuset="0x04000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="90" cpuset="0x04000000,,0x0" complete_cpuset="0x04000000,,0x0" online_cpuset="0x04000000,,0x0" allowed_cpuset="0x04000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x08000000,,0x08000000" complete_cpuset="0x08000000,,0x08000000" online_cpuset="0x08000000,,0x08000000" allowed_cpuset="0x08000000,,0x08000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x08000000,,0x08000000" complete_cpuset="0x08000000,,0x08000000" online_cpuset="0x08000000,,0x08000000" allowed_cpuset="0x08000000,,0x08000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x08000000,,0x08000000" complete_cpuset="0x08000000,,0x08000000" online_cpuset="0x08000000,,0x08000000" allowed_cpuset="0x08000000,,0x08000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="27" cpuset="0x08000000,,0x08000000" complete_cpuset="0x08000000,,0x08000000" online_cpuset="0x08000000,,0x08000000" allowed_cpuset="0x08000000,,0x08000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="27" cpuset="0x08000000" complete_cpuset="0x08000000" online_cpuset="0x08000000" allowed_cpuset="0x08000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="91" cpuset="0x08000000,,0x0" complete_cpuset="0x08000000,,0x0" online_cpuset="0x08000000,,0x0" allowed_cpuset="0x08000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x10000000,,0x10000000" complete_cpuset="0x10000000,,0x10000000" online_cpuset="0x10000000,,0x10000000" allowed_cpuset="0x10000000,,0x10000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x10000000,,0x10000000" complete_cpuset="0x10000000,,0x10000000" online_cpuset="0x10000000,,0x10000000" allowed_cpuset="0x10000000,,0x10000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x10000000,,0x10000000" complete_cpuset="0x10000000,,0x10000000" online_cpuset="0x10000000,,0x10000000" allowed_cpuset="0x10000000,,0x10000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="28" cpuset="0x10000000,,0x10000000" complete_cpuset="0x10000000,,0x10000000" online_cpuset="0x10000000,,0x10000000" allowed_cpuset="0x10000000,,0x10000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="28" cpuset="0x10000000" complete_cpuset="0x10000000" online_cpuset="0x10000000" allowed_cpuset="0x10000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="92" cpuset="0x10000000,,0x0" complete_cpuset="0x10000000,,0x0" online_cpuset="0x10000000,,0x0" allowed_cpuset="0x10000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x20000000,,0x20000000" complete_cpuset="0x20000000,,0x20000000" online_cpuset="0x20000000,,0x20000000" allowed_cpuset="0x20000000,,0x20000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x20000000,,0x20000000" complete_cpuset="0x20000000,,0x20000000" online_cpuset="0x20000000,,0x20000000" allowed_cpuset="0x20000000,,0x20000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x20000000,,0x20000000" complete_cpuset="0x20000000,,0x20000000" online_cpuset="0x20000000,,0x20000000" allowed_cpuset="0x20000000,,0x20000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="29" cpuset="0x20000000,,0x20000000" complete_cpuset="0x20000000,,0x20000000" online_cpuset="0x20000000,,0x20000000" allowed_cpuset="0x20000000,,0x20000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="29" cpuset="0x20000000" complete_cpuset="0x20000000" online_cpuset="0x20000000" allowed_cpuset="0x20000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="93" cpuset="0x20000000,,0x0" complete_cpuset="0x20000000,,0x0" online_cpuset="0x20000000,,0x0" allowed_cpuset="0x20000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x40000000,,0x40000000" complete_cpuset="0x40000000,,0x40000000" online_cpuset="0x40000000,,0x40000000" allowed_cpuset="0x40000000,,0x40000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x40000000,,0x40000000" complete_cpuset="0x40000000,,0x40000000" online_cpuset="0x40000000,,0x40000000" allowed_cpuset="0x40000000,,0x40000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x40000000,,0x40000000" complete_cpuset="0x40000000,,0x40000000" online_cpuset="0x40000000,,0x40000000" allowed_cpuset="0x40000000,,0x40000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="30" cpuset="0x40000000,,0x40000000" complete_cpuset="0x40000000,,0x40000000" online_cpuset="0x40000000,,0x40000000" allowed_cpuset="0x40000000,,0x40000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="30" cpuset="0x40000000" complete_cpuset="0x40000000" online_cpuset="0x40000000" allowed_cpuset="0x40000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="94" cpuset="0x40000000,,0x0" complete_cpuset="0x40000000,,0x0" online_cpuset="0x40000000,,0x0" allowed_cpuset="0x40000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x80000000,,0x80000000" complete_cpuset="0x80000000,,0x80000000" online_cpuset="0x80000000,,0x80000000" allowed_cpuset="0x80000000,,0x80000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x80000000,,0x80000000" complete_cpuset="0x80000000,,0x80000000" online_cpuset="0x80000000,,0x80000000" allowed_cpuset="0x80000000,,0x80000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x80000000,,0x80000000" complete_cpuset="0x80000000,,0x80000000" online_cpuset="0x80000000,,0x80000000" allowed_cpuset="0x80000000,,0x80000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="31" cpuset="0x80000000,,0x80000000" complete_cpuset="0x80000000,,0x80000000" online_cpuset="0x80000000,,0x80000000" allowed_cpuset="0x80000000,,0x80000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
+                  <object type="PU" os_index="31" cpuset="0x80000000" complete_cpuset="0x80000000" online_cpuset="0x80000000" allowed_cpuset="0x80000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                  <object type="PU" os_index="95" cpuset="0x80000000,,0x0" complete_cpuset="0x80000000,,0x0" online_cpuset="0x80000000,,0x0" allowed_cpuset="0x80000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="NUMANode" os_index="1" cpuset="0xffffffff,,0xffffffff,0x0" complete_cpuset="0xffffffff,,0xffffffff,0x0" online_cpuset="0xffffffff,,0xffffffff,0x0" allowed_cpuset="0xffffffff,,0xffffffff,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" local_memory="266269437952">
+      <page_type size="4096" count="61402707"/>
+      <page_type size="2097152" count="7040"/>
+      <page_type size="1073741824" count="0"/>
+      <object type="Package" os_index="1" cpuset="0xffffffff,,0xffffffff,0x0" complete_cpuset="0xffffffff,,0xffffffff,0x0" online_cpuset="0xffffffff,,0xffffffff,0x0" allowed_cpuset="0xffffffff,,0xffffffff,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+        <info name="CPUVendor" value="GenuineIntel"/>
+        <info name="CPUFamilyNumber" value="6"/>
+        <info name="CPUModelNumber" value="106"/>
+        <info name="CPUModel" value="Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz"/>
+        <info name="CPUStepping" value="6"/>
+        <object type="Cache" cpuset="0xffffffff,,0xffffffff,0x0" complete_cpuset="0xffffffff,,0xffffffff,0x0" online_cpuset="0xffffffff,,0xffffffff,0x0" allowed_cpuset="0xffffffff,,0xffffffff,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="56623104" depth="3" cache_linesize="64" cache_associativity="12" cache_type="0">
+          <info name="Inclusive" value="0"/>
+          <object type="Cache" cpuset="0x00000001,,0x00000001,0x0" complete_cpuset="0x00000001,,0x00000001,0x0" online_cpuset="0x00000001,,0x00000001,0x0" allowed_cpuset="0x00000001,,0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000001,,0x00000001,0x0" complete_cpuset="0x00000001,,0x00000001,0x0" online_cpuset="0x00000001,,0x00000001,0x0" allowed_cpuset="0x00000001,,0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000001,,0x00000001,0x0" complete_cpuset="0x00000001,,0x00000001,0x0" online_cpuset="0x00000001,,0x00000001,0x0" allowed_cpuset="0x00000001,,0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="0" cpuset="0x00000001,,0x00000001,0x0" complete_cpuset="0x00000001,,0x00000001,0x0" online_cpuset="0x00000001,,0x00000001,0x0" allowed_cpuset="0x00000001,,0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="32" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" online_cpuset="0x00000001,0x0" allowed_cpuset="0x00000001,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="96" cpuset="0x00000001,,,0x0" complete_cpuset="0x00000001,,,0x0" online_cpuset="0x00000001,,,0x0" allowed_cpuset="0x00000001,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000002,,0x00000002,0x0" complete_cpuset="0x00000002,,0x00000002,0x0" online_cpuset="0x00000002,,0x00000002,0x0" allowed_cpuset="0x00000002,,0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000002,,0x00000002,0x0" complete_cpuset="0x00000002,,0x00000002,0x0" online_cpuset="0x00000002,,0x00000002,0x0" allowed_cpuset="0x00000002,,0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000002,,0x00000002,0x0" complete_cpuset="0x00000002,,0x00000002,0x0" online_cpuset="0x00000002,,0x00000002,0x0" allowed_cpuset="0x00000002,,0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="1" cpuset="0x00000002,,0x00000002,0x0" complete_cpuset="0x00000002,,0x00000002,0x0" online_cpuset="0x00000002,,0x00000002,0x0" allowed_cpuset="0x00000002,,0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="33" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" online_cpuset="0x00000002,0x0" allowed_cpuset="0x00000002,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="97" cpuset="0x00000002,,,0x0" complete_cpuset="0x00000002,,,0x0" online_cpuset="0x00000002,,,0x0" allowed_cpuset="0x00000002,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000004,,0x00000004,0x0" complete_cpuset="0x00000004,,0x00000004,0x0" online_cpuset="0x00000004,,0x00000004,0x0" allowed_cpuset="0x00000004,,0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000004,,0x00000004,0x0" complete_cpuset="0x00000004,,0x00000004,0x0" online_cpuset="0x00000004,,0x00000004,0x0" allowed_cpuset="0x00000004,,0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000004,,0x00000004,0x0" complete_cpuset="0x00000004,,0x00000004,0x0" online_cpuset="0x00000004,,0x00000004,0x0" allowed_cpuset="0x00000004,,0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="2" cpuset="0x00000004,,0x00000004,0x0" complete_cpuset="0x00000004,,0x00000004,0x0" online_cpuset="0x00000004,,0x00000004,0x0" allowed_cpuset="0x00000004,,0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="34" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" online_cpuset="0x00000004,0x0" allowed_cpuset="0x00000004,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="98" cpuset="0x00000004,,,0x0" complete_cpuset="0x00000004,,,0x0" online_cpuset="0x00000004,,,0x0" allowed_cpuset="0x00000004,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000008,,0x00000008,0x0" complete_cpuset="0x00000008,,0x00000008,0x0" online_cpuset="0x00000008,,0x00000008,0x0" allowed_cpuset="0x00000008,,0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000008,,0x00000008,0x0" complete_cpuset="0x00000008,,0x00000008,0x0" online_cpuset="0x00000008,,0x00000008,0x0" allowed_cpuset="0x00000008,,0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000008,,0x00000008,0x0" complete_cpuset="0x00000008,,0x00000008,0x0" online_cpuset="0x00000008,,0x00000008,0x0" allowed_cpuset="0x00000008,,0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="3" cpuset="0x00000008,,0x00000008,0x0" complete_cpuset="0x00000008,,0x00000008,0x0" online_cpuset="0x00000008,,0x00000008,0x0" allowed_cpuset="0x00000008,,0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="35" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" online_cpuset="0x00000008,0x0" allowed_cpuset="0x00000008,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="99" cpuset="0x00000008,,,0x0" complete_cpuset="0x00000008,,,0x0" online_cpuset="0x00000008,,,0x0" allowed_cpuset="0x00000008,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000010,,0x00000010,0x0" complete_cpuset="0x00000010,,0x00000010,0x0" online_cpuset="0x00000010,,0x00000010,0x0" allowed_cpuset="0x00000010,,0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000010,,0x00000010,0x0" complete_cpuset="0x00000010,,0x00000010,0x0" online_cpuset="0x00000010,,0x00000010,0x0" allowed_cpuset="0x00000010,,0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000010,,0x00000010,0x0" complete_cpuset="0x00000010,,0x00000010,0x0" online_cpuset="0x00000010,,0x00000010,0x0" allowed_cpuset="0x00000010,,0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="4" cpuset="0x00000010,,0x00000010,0x0" complete_cpuset="0x00000010,,0x00000010,0x0" online_cpuset="0x00000010,,0x00000010,0x0" allowed_cpuset="0x00000010,,0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="36" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" online_cpuset="0x00000010,0x0" allowed_cpuset="0x00000010,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="100" cpuset="0x00000010,,,0x0" complete_cpuset="0x00000010,,,0x0" online_cpuset="0x00000010,,,0x0" allowed_cpuset="0x00000010,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000020,,0x00000020,0x0" complete_cpuset="0x00000020,,0x00000020,0x0" online_cpuset="0x00000020,,0x00000020,0x0" allowed_cpuset="0x00000020,,0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000020,,0x00000020,0x0" complete_cpuset="0x00000020,,0x00000020,0x0" online_cpuset="0x00000020,,0x00000020,0x0" allowed_cpuset="0x00000020,,0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000020,,0x00000020,0x0" complete_cpuset="0x00000020,,0x00000020,0x0" online_cpuset="0x00000020,,0x00000020,0x0" allowed_cpuset="0x00000020,,0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="5" cpuset="0x00000020,,0x00000020,0x0" complete_cpuset="0x00000020,,0x00000020,0x0" online_cpuset="0x00000020,,0x00000020,0x0" allowed_cpuset="0x00000020,,0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="37" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" online_cpuset="0x00000020,0x0" allowed_cpuset="0x00000020,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="101" cpuset="0x00000020,,,0x0" complete_cpuset="0x00000020,,,0x0" online_cpuset="0x00000020,,,0x0" allowed_cpuset="0x00000020,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000040,,0x00000040,0x0" complete_cpuset="0x00000040,,0x00000040,0x0" online_cpuset="0x00000040,,0x00000040,0x0" allowed_cpuset="0x00000040,,0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000040,,0x00000040,0x0" complete_cpuset="0x00000040,,0x00000040,0x0" online_cpuset="0x00000040,,0x00000040,0x0" allowed_cpuset="0x00000040,,0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000040,,0x00000040,0x0" complete_cpuset="0x00000040,,0x00000040,0x0" online_cpuset="0x00000040,,0x00000040,0x0" allowed_cpuset="0x00000040,,0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="6" cpuset="0x00000040,,0x00000040,0x0" complete_cpuset="0x00000040,,0x00000040,0x0" online_cpuset="0x00000040,,0x00000040,0x0" allowed_cpuset="0x00000040,,0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="38" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" online_cpuset="0x00000040,0x0" allowed_cpuset="0x00000040,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="102" cpuset="0x00000040,,,0x0" complete_cpuset="0x00000040,,,0x0" online_cpuset="0x00000040,,,0x0" allowed_cpuset="0x00000040,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000080,,0x00000080,0x0" complete_cpuset="0x00000080,,0x00000080,0x0" online_cpuset="0x00000080,,0x00000080,0x0" allowed_cpuset="0x00000080,,0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000080,,0x00000080,0x0" complete_cpuset="0x00000080,,0x00000080,0x0" online_cpuset="0x00000080,,0x00000080,0x0" allowed_cpuset="0x00000080,,0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000080,,0x00000080,0x0" complete_cpuset="0x00000080,,0x00000080,0x0" online_cpuset="0x00000080,,0x00000080,0x0" allowed_cpuset="0x00000080,,0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="7" cpuset="0x00000080,,0x00000080,0x0" complete_cpuset="0x00000080,,0x00000080,0x0" online_cpuset="0x00000080,,0x00000080,0x0" allowed_cpuset="0x00000080,,0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="39" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" online_cpuset="0x00000080,0x0" allowed_cpuset="0x00000080,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="103" cpuset="0x00000080,,,0x0" complete_cpuset="0x00000080,,,0x0" online_cpuset="0x00000080,,,0x0" allowed_cpuset="0x00000080,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000100,,0x00000100,0x0" complete_cpuset="0x00000100,,0x00000100,0x0" online_cpuset="0x00000100,,0x00000100,0x0" allowed_cpuset="0x00000100,,0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000100,,0x00000100,0x0" complete_cpuset="0x00000100,,0x00000100,0x0" online_cpuset="0x00000100,,0x00000100,0x0" allowed_cpuset="0x00000100,,0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000100,,0x00000100,0x0" complete_cpuset="0x00000100,,0x00000100,0x0" online_cpuset="0x00000100,,0x00000100,0x0" allowed_cpuset="0x00000100,,0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="8" cpuset="0x00000100,,0x00000100,0x0" complete_cpuset="0x00000100,,0x00000100,0x0" online_cpuset="0x00000100,,0x00000100,0x0" allowed_cpuset="0x00000100,,0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="40" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" online_cpuset="0x00000100,0x0" allowed_cpuset="0x00000100,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="104" cpuset="0x00000100,,,0x0" complete_cpuset="0x00000100,,,0x0" online_cpuset="0x00000100,,,0x0" allowed_cpuset="0x00000100,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000200,,0x00000200,0x0" complete_cpuset="0x00000200,,0x00000200,0x0" online_cpuset="0x00000200,,0x00000200,0x0" allowed_cpuset="0x00000200,,0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000200,,0x00000200,0x0" complete_cpuset="0x00000200,,0x00000200,0x0" online_cpuset="0x00000200,,0x00000200,0x0" allowed_cpuset="0x00000200,,0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000200,,0x00000200,0x0" complete_cpuset="0x00000200,,0x00000200,0x0" online_cpuset="0x00000200,,0x00000200,0x0" allowed_cpuset="0x00000200,,0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="9" cpuset="0x00000200,,0x00000200,0x0" complete_cpuset="0x00000200,,0x00000200,0x0" online_cpuset="0x00000200,,0x00000200,0x0" allowed_cpuset="0x00000200,,0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="41" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" online_cpuset="0x00000200,0x0" allowed_cpuset="0x00000200,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="105" cpuset="0x00000200,,,0x0" complete_cpuset="0x00000200,,,0x0" online_cpuset="0x00000200,,,0x0" allowed_cpuset="0x00000200,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000400,,0x00000400,0x0" complete_cpuset="0x00000400,,0x00000400,0x0" online_cpuset="0x00000400,,0x00000400,0x0" allowed_cpuset="0x00000400,,0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000400,,0x00000400,0x0" complete_cpuset="0x00000400,,0x00000400,0x0" online_cpuset="0x00000400,,0x00000400,0x0" allowed_cpuset="0x00000400,,0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000400,,0x00000400,0x0" complete_cpuset="0x00000400,,0x00000400,0x0" online_cpuset="0x00000400,,0x00000400,0x0" allowed_cpuset="0x00000400,,0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="10" cpuset="0x00000400,,0x00000400,0x0" complete_cpuset="0x00000400,,0x00000400,0x0" online_cpuset="0x00000400,,0x00000400,0x0" allowed_cpuset="0x00000400,,0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="42" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" online_cpuset="0x00000400,0x0" allowed_cpuset="0x00000400,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="106" cpuset="0x00000400,,,0x0" complete_cpuset="0x00000400,,,0x0" online_cpuset="0x00000400,,,0x0" allowed_cpuset="0x00000400,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00000800,,0x00000800,0x0" complete_cpuset="0x00000800,,0x00000800,0x0" online_cpuset="0x00000800,,0x00000800,0x0" allowed_cpuset="0x00000800,,0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00000800,,0x00000800,0x0" complete_cpuset="0x00000800,,0x00000800,0x0" online_cpuset="0x00000800,,0x00000800,0x0" allowed_cpuset="0x00000800,,0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00000800,,0x00000800,0x0" complete_cpuset="0x00000800,,0x00000800,0x0" online_cpuset="0x00000800,,0x00000800,0x0" allowed_cpuset="0x00000800,,0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="11" cpuset="0x00000800,,0x00000800,0x0" complete_cpuset="0x00000800,,0x00000800,0x0" online_cpuset="0x00000800,,0x00000800,0x0" allowed_cpuset="0x00000800,,0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="43" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" online_cpuset="0x00000800,0x0" allowed_cpuset="0x00000800,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="107" cpuset="0x00000800,,,0x0" complete_cpuset="0x00000800,,,0x0" online_cpuset="0x00000800,,,0x0" allowed_cpuset="0x00000800,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00001000,,0x00001000,0x0" complete_cpuset="0x00001000,,0x00001000,0x0" online_cpuset="0x00001000,,0x00001000,0x0" allowed_cpuset="0x00001000,,0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00001000,,0x00001000,0x0" complete_cpuset="0x00001000,,0x00001000,0x0" online_cpuset="0x00001000,,0x00001000,0x0" allowed_cpuset="0x00001000,,0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00001000,,0x00001000,0x0" complete_cpuset="0x00001000,,0x00001000,0x0" online_cpuset="0x00001000,,0x00001000,0x0" allowed_cpuset="0x00001000,,0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="12" cpuset="0x00001000,,0x00001000,0x0" complete_cpuset="0x00001000,,0x00001000,0x0" online_cpuset="0x00001000,,0x00001000,0x0" allowed_cpuset="0x00001000,,0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="44" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" online_cpuset="0x00001000,0x0" allowed_cpuset="0x00001000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="108" cpuset="0x00001000,,,0x0" complete_cpuset="0x00001000,,,0x0" online_cpuset="0x00001000,,,0x0" allowed_cpuset="0x00001000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00002000,,0x00002000,0x0" complete_cpuset="0x00002000,,0x00002000,0x0" online_cpuset="0x00002000,,0x00002000,0x0" allowed_cpuset="0x00002000,,0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00002000,,0x00002000,0x0" complete_cpuset="0x00002000,,0x00002000,0x0" online_cpuset="0x00002000,,0x00002000,0x0" allowed_cpuset="0x00002000,,0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00002000,,0x00002000,0x0" complete_cpuset="0x00002000,,0x00002000,0x0" online_cpuset="0x00002000,,0x00002000,0x0" allowed_cpuset="0x00002000,,0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="13" cpuset="0x00002000,,0x00002000,0x0" complete_cpuset="0x00002000,,0x00002000,0x0" online_cpuset="0x00002000,,0x00002000,0x0" allowed_cpuset="0x00002000,,0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="45" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" online_cpuset="0x00002000,0x0" allowed_cpuset="0x00002000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="109" cpuset="0x00002000,,,0x0" complete_cpuset="0x00002000,,,0x0" online_cpuset="0x00002000,,,0x0" allowed_cpuset="0x00002000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00004000,,0x00004000,0x0" complete_cpuset="0x00004000,,0x00004000,0x0" online_cpuset="0x00004000,,0x00004000,0x0" allowed_cpuset="0x00004000,,0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00004000,,0x00004000,0x0" complete_cpuset="0x00004000,,0x00004000,0x0" online_cpuset="0x00004000,,0x00004000,0x0" allowed_cpuset="0x00004000,,0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00004000,,0x00004000,0x0" complete_cpuset="0x00004000,,0x00004000,0x0" online_cpuset="0x00004000,,0x00004000,0x0" allowed_cpuset="0x00004000,,0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="14" cpuset="0x00004000,,0x00004000,0x0" complete_cpuset="0x00004000,,0x00004000,0x0" online_cpuset="0x00004000,,0x00004000,0x0" allowed_cpuset="0x00004000,,0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="46" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" online_cpuset="0x00004000,0x0" allowed_cpuset="0x00004000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="110" cpuset="0x00004000,,,0x0" complete_cpuset="0x00004000,,,0x0" online_cpuset="0x00004000,,,0x0" allowed_cpuset="0x00004000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00008000,,0x00008000,0x0" complete_cpuset="0x00008000,,0x00008000,0x0" online_cpuset="0x00008000,,0x00008000,0x0" allowed_cpuset="0x00008000,,0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00008000,,0x00008000,0x0" complete_cpuset="0x00008000,,0x00008000,0x0" online_cpuset="0x00008000,,0x00008000,0x0" allowed_cpuset="0x00008000,,0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00008000,,0x00008000,0x0" complete_cpuset="0x00008000,,0x00008000,0x0" online_cpuset="0x00008000,,0x00008000,0x0" allowed_cpuset="0x00008000,,0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="15" cpuset="0x00008000,,0x00008000,0x0" complete_cpuset="0x00008000,,0x00008000,0x0" online_cpuset="0x00008000,,0x00008000,0x0" allowed_cpuset="0x00008000,,0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="47" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" online_cpuset="0x00008000,0x0" allowed_cpuset="0x00008000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="111" cpuset="0x00008000,,,0x0" complete_cpuset="0x00008000,,,0x0" online_cpuset="0x00008000,,,0x0" allowed_cpuset="0x00008000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00010000,,0x00010000,0x0" complete_cpuset="0x00010000,,0x00010000,0x0" online_cpuset="0x00010000,,0x00010000,0x0" allowed_cpuset="0x00010000,,0x00010000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00010000,,0x00010000,0x0" complete_cpuset="0x00010000,,0x00010000,0x0" online_cpuset="0x00010000,,0x00010000,0x0" allowed_cpuset="0x00010000,,0x00010000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00010000,,0x00010000,0x0" complete_cpuset="0x00010000,,0x00010000,0x0" online_cpuset="0x00010000,,0x00010000,0x0" allowed_cpuset="0x00010000,,0x00010000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="16" cpuset="0x00010000,,0x00010000,0x0" complete_cpuset="0x00010000,,0x00010000,0x0" online_cpuset="0x00010000,,0x00010000,0x0" allowed_cpuset="0x00010000,,0x00010000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="48" cpuset="0x00010000,0x0" complete_cpuset="0x00010000,0x0" online_cpuset="0x00010000,0x0" allowed_cpuset="0x00010000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="112" cpuset="0x00010000,,,0x0" complete_cpuset="0x00010000,,,0x0" online_cpuset="0x00010000,,,0x0" allowed_cpuset="0x00010000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00020000,,0x00020000,0x0" complete_cpuset="0x00020000,,0x00020000,0x0" online_cpuset="0x00020000,,0x00020000,0x0" allowed_cpuset="0x00020000,,0x00020000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00020000,,0x00020000,0x0" complete_cpuset="0x00020000,,0x00020000,0x0" online_cpuset="0x00020000,,0x00020000,0x0" allowed_cpuset="0x00020000,,0x00020000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00020000,,0x00020000,0x0" complete_cpuset="0x00020000,,0x00020000,0x0" online_cpuset="0x00020000,,0x00020000,0x0" allowed_cpuset="0x00020000,,0x00020000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="17" cpuset="0x00020000,,0x00020000,0x0" complete_cpuset="0x00020000,,0x00020000,0x0" online_cpuset="0x00020000,,0x00020000,0x0" allowed_cpuset="0x00020000,,0x00020000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="49" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" online_cpuset="0x00020000,0x0" allowed_cpuset="0x00020000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="113" cpuset="0x00020000,,,0x0" complete_cpuset="0x00020000,,,0x0" online_cpuset="0x00020000,,,0x0" allowed_cpuset="0x00020000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00040000,,0x00040000,0x0" complete_cpuset="0x00040000,,0x00040000,0x0" online_cpuset="0x00040000,,0x00040000,0x0" allowed_cpuset="0x00040000,,0x00040000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00040000,,0x00040000,0x0" complete_cpuset="0x00040000,,0x00040000,0x0" online_cpuset="0x00040000,,0x00040000,0x0" allowed_cpuset="0x00040000,,0x00040000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00040000,,0x00040000,0x0" complete_cpuset="0x00040000,,0x00040000,0x0" online_cpuset="0x00040000,,0x00040000,0x0" allowed_cpuset="0x00040000,,0x00040000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="18" cpuset="0x00040000,,0x00040000,0x0" complete_cpuset="0x00040000,,0x00040000,0x0" online_cpuset="0x00040000,,0x00040000,0x0" allowed_cpuset="0x00040000,,0x00040000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="50" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" online_cpuset="0x00040000,0x0" allowed_cpuset="0x00040000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="114" cpuset="0x00040000,,,0x0" complete_cpuset="0x00040000,,,0x0" online_cpuset="0x00040000,,,0x0" allowed_cpuset="0x00040000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00080000,,0x00080000,0x0" complete_cpuset="0x00080000,,0x00080000,0x0" online_cpuset="0x00080000,,0x00080000,0x0" allowed_cpuset="0x00080000,,0x00080000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00080000,,0x00080000,0x0" complete_cpuset="0x00080000,,0x00080000,0x0" online_cpuset="0x00080000,,0x00080000,0x0" allowed_cpuset="0x00080000,,0x00080000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00080000,,0x00080000,0x0" complete_cpuset="0x00080000,,0x00080000,0x0" online_cpuset="0x00080000,,0x00080000,0x0" allowed_cpuset="0x00080000,,0x00080000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="19" cpuset="0x00080000,,0x00080000,0x0" complete_cpuset="0x00080000,,0x00080000,0x0" online_cpuset="0x00080000,,0x00080000,0x0" allowed_cpuset="0x00080000,,0x00080000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="51" cpuset="0x00080000,0x0" complete_cpuset="0x00080000,0x0" online_cpuset="0x00080000,0x0" allowed_cpuset="0x00080000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="115" cpuset="0x00080000,,,0x0" complete_cpuset="0x00080000,,,0x0" online_cpuset="0x00080000,,,0x0" allowed_cpuset="0x00080000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00100000,,0x00100000,0x0" complete_cpuset="0x00100000,,0x00100000,0x0" online_cpuset="0x00100000,,0x00100000,0x0" allowed_cpuset="0x00100000,,0x00100000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00100000,,0x00100000,0x0" complete_cpuset="0x00100000,,0x00100000,0x0" online_cpuset="0x00100000,,0x00100000,0x0" allowed_cpuset="0x00100000,,0x00100000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00100000,,0x00100000,0x0" complete_cpuset="0x00100000,,0x00100000,0x0" online_cpuset="0x00100000,,0x00100000,0x0" allowed_cpuset="0x00100000,,0x00100000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="20" cpuset="0x00100000,,0x00100000,0x0" complete_cpuset="0x00100000,,0x00100000,0x0" online_cpuset="0x00100000,,0x00100000,0x0" allowed_cpuset="0x00100000,,0x00100000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="52" cpuset="0x00100000,0x0" complete_cpuset="0x00100000,0x0" online_cpuset="0x00100000,0x0" allowed_cpuset="0x00100000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="116" cpuset="0x00100000,,,0x0" complete_cpuset="0x00100000,,,0x0" online_cpuset="0x00100000,,,0x0" allowed_cpuset="0x00100000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00200000,,0x00200000,0x0" complete_cpuset="0x00200000,,0x00200000,0x0" online_cpuset="0x00200000,,0x00200000,0x0" allowed_cpuset="0x00200000,,0x00200000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00200000,,0x00200000,0x0" complete_cpuset="0x00200000,,0x00200000,0x0" online_cpuset="0x00200000,,0x00200000,0x0" allowed_cpuset="0x00200000,,0x00200000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00200000,,0x00200000,0x0" complete_cpuset="0x00200000,,0x00200000,0x0" online_cpuset="0x00200000,,0x00200000,0x0" allowed_cpuset="0x00200000,,0x00200000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="21" cpuset="0x00200000,,0x00200000,0x0" complete_cpuset="0x00200000,,0x00200000,0x0" online_cpuset="0x00200000,,0x00200000,0x0" allowed_cpuset="0x00200000,,0x00200000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="53" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" online_cpuset="0x00200000,0x0" allowed_cpuset="0x00200000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="117" cpuset="0x00200000,,,0x0" complete_cpuset="0x00200000,,,0x0" online_cpuset="0x00200000,,,0x0" allowed_cpuset="0x00200000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00400000,,0x00400000,0x0" complete_cpuset="0x00400000,,0x00400000,0x0" online_cpuset="0x00400000,,0x00400000,0x0" allowed_cpuset="0x00400000,,0x00400000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00400000,,0x00400000,0x0" complete_cpuset="0x00400000,,0x00400000,0x0" online_cpuset="0x00400000,,0x00400000,0x0" allowed_cpuset="0x00400000,,0x00400000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00400000,,0x00400000,0x0" complete_cpuset="0x00400000,,0x00400000,0x0" online_cpuset="0x00400000,,0x00400000,0x0" allowed_cpuset="0x00400000,,0x00400000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="22" cpuset="0x00400000,,0x00400000,0x0" complete_cpuset="0x00400000,,0x00400000,0x0" online_cpuset="0x00400000,,0x00400000,0x0" allowed_cpuset="0x00400000,,0x00400000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="54" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" online_cpuset="0x00400000,0x0" allowed_cpuset="0x00400000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="118" cpuset="0x00400000,,,0x0" complete_cpuset="0x00400000,,,0x0" online_cpuset="0x00400000,,,0x0" allowed_cpuset="0x00400000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x00800000,,0x00800000,0x0" complete_cpuset="0x00800000,,0x00800000,0x0" online_cpuset="0x00800000,,0x00800000,0x0" allowed_cpuset="0x00800000,,0x00800000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x00800000,,0x00800000,0x0" complete_cpuset="0x00800000,,0x00800000,0x0" online_cpuset="0x00800000,,0x00800000,0x0" allowed_cpuset="0x00800000,,0x00800000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x00800000,,0x00800000,0x0" complete_cpuset="0x00800000,,0x00800000,0x0" online_cpuset="0x00800000,,0x00800000,0x0" allowed_cpuset="0x00800000,,0x00800000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="23" cpuset="0x00800000,,0x00800000,0x0" complete_cpuset="0x00800000,,0x00800000,0x0" online_cpuset="0x00800000,,0x00800000,0x0" allowed_cpuset="0x00800000,,0x00800000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="55" cpuset="0x00800000,0x0" complete_cpuset="0x00800000,0x0" online_cpuset="0x00800000,0x0" allowed_cpuset="0x00800000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="119" cpuset="0x00800000,,,0x0" complete_cpuset="0x00800000,,,0x0" online_cpuset="0x00800000,,,0x0" allowed_cpuset="0x00800000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x01000000,,0x01000000,0x0" complete_cpuset="0x01000000,,0x01000000,0x0" online_cpuset="0x01000000,,0x01000000,0x0" allowed_cpuset="0x01000000,,0x01000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x01000000,,0x01000000,0x0" complete_cpuset="0x01000000,,0x01000000,0x0" online_cpuset="0x01000000,,0x01000000,0x0" allowed_cpuset="0x01000000,,0x01000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x01000000,,0x01000000,0x0" complete_cpuset="0x01000000,,0x01000000,0x0" online_cpuset="0x01000000,,0x01000000,0x0" allowed_cpuset="0x01000000,,0x01000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="24" cpuset="0x01000000,,0x01000000,0x0" complete_cpuset="0x01000000,,0x01000000,0x0" online_cpuset="0x01000000,,0x01000000,0x0" allowed_cpuset="0x01000000,,0x01000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="56" cpuset="0x01000000,0x0" complete_cpuset="0x01000000,0x0" online_cpuset="0x01000000,0x0" allowed_cpuset="0x01000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="120" cpuset="0x01000000,,,0x0" complete_cpuset="0x01000000,,,0x0" online_cpuset="0x01000000,,,0x0" allowed_cpuset="0x01000000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x02000000,,0x02000000,0x0" complete_cpuset="0x02000000,,0x02000000,0x0" online_cpuset="0x02000000,,0x02000000,0x0" allowed_cpuset="0x02000000,,0x02000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x02000000,,0x02000000,0x0" complete_cpuset="0x02000000,,0x02000000,0x0" online_cpuset="0x02000000,,0x02000000,0x0" allowed_cpuset="0x02000000,,0x02000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x02000000,,0x02000000,0x0" complete_cpuset="0x02000000,,0x02000000,0x0" online_cpuset="0x02000000,,0x02000000,0x0" allowed_cpuset="0x02000000,,0x02000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="25" cpuset="0x02000000,,0x02000000,0x0" complete_cpuset="0x02000000,,0x02000000,0x0" online_cpuset="0x02000000,,0x02000000,0x0" allowed_cpuset="0x02000000,,0x02000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="57" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" online_cpuset="0x02000000,0x0" allowed_cpuset="0x02000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="121" cpuset="0x02000000,,,0x0" complete_cpuset="0x02000000,,,0x0" online_cpuset="0x02000000,,,0x0" allowed_cpuset="0x02000000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x04000000,,0x04000000,0x0" complete_cpuset="0x04000000,,0x04000000,0x0" online_cpuset="0x04000000,,0x04000000,0x0" allowed_cpuset="0x04000000,,0x04000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x04000000,,0x04000000,0x0" complete_cpuset="0x04000000,,0x04000000,0x0" online_cpuset="0x04000000,,0x04000000,0x0" allowed_cpuset="0x04000000,,0x04000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x04000000,,0x04000000,0x0" complete_cpuset="0x04000000,,0x04000000,0x0" online_cpuset="0x04000000,,0x04000000,0x0" allowed_cpuset="0x04000000,,0x04000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="26" cpuset="0x04000000,,0x04000000,0x0" complete_cpuset="0x04000000,,0x04000000,0x0" online_cpuset="0x04000000,,0x04000000,0x0" allowed_cpuset="0x04000000,,0x04000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="58" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" online_cpuset="0x04000000,0x0" allowed_cpuset="0x04000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="122" cpuset="0x04000000,,,0x0" complete_cpuset="0x04000000,,,0x0" online_cpuset="0x04000000,,,0x0" allowed_cpuset="0x04000000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x08000000,,0x08000000,0x0" complete_cpuset="0x08000000,,0x08000000,0x0" online_cpuset="0x08000000,,0x08000000,0x0" allowed_cpuset="0x08000000,,0x08000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x08000000,,0x08000000,0x0" complete_cpuset="0x08000000,,0x08000000,0x0" online_cpuset="0x08000000,,0x08000000,0x0" allowed_cpuset="0x08000000,,0x08000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x08000000,,0x08000000,0x0" complete_cpuset="0x08000000,,0x08000000,0x0" online_cpuset="0x08000000,,0x08000000,0x0" allowed_cpuset="0x08000000,,0x08000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="27" cpuset="0x08000000,,0x08000000,0x0" complete_cpuset="0x08000000,,0x08000000,0x0" online_cpuset="0x08000000,,0x08000000,0x0" allowed_cpuset="0x08000000,,0x08000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="59" cpuset="0x08000000,0x0" complete_cpuset="0x08000000,0x0" online_cpuset="0x08000000,0x0" allowed_cpuset="0x08000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="123" cpuset="0x08000000,,,0x0" complete_cpuset="0x08000000,,,0x0" online_cpuset="0x08000000,,,0x0" allowed_cpuset="0x08000000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x10000000,,0x10000000,0x0" complete_cpuset="0x10000000,,0x10000000,0x0" online_cpuset="0x10000000,,0x10000000,0x0" allowed_cpuset="0x10000000,,0x10000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x10000000,,0x10000000,0x0" complete_cpuset="0x10000000,,0x10000000,0x0" online_cpuset="0x10000000,,0x10000000,0x0" allowed_cpuset="0x10000000,,0x10000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x10000000,,0x10000000,0x0" complete_cpuset="0x10000000,,0x10000000,0x0" online_cpuset="0x10000000,,0x10000000,0x0" allowed_cpuset="0x10000000,,0x10000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="28" cpuset="0x10000000,,0x10000000,0x0" complete_cpuset="0x10000000,,0x10000000,0x0" online_cpuset="0x10000000,,0x10000000,0x0" allowed_cpuset="0x10000000,,0x10000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="60" cpuset="0x10000000,0x0" complete_cpuset="0x10000000,0x0" online_cpuset="0x10000000,0x0" allowed_cpuset="0x10000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="124" cpuset="0x10000000,,,0x0" complete_cpuset="0x10000000,,,0x0" online_cpuset="0x10000000,,,0x0" allowed_cpuset="0x10000000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x20000000,,0x20000000,0x0" complete_cpuset="0x20000000,,0x20000000,0x0" online_cpuset="0x20000000,,0x20000000,0x0" allowed_cpuset="0x20000000,,0x20000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x20000000,,0x20000000,0x0" complete_cpuset="0x20000000,,0x20000000,0x0" online_cpuset="0x20000000,,0x20000000,0x0" allowed_cpuset="0x20000000,,0x20000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x20000000,,0x20000000,0x0" complete_cpuset="0x20000000,,0x20000000,0x0" online_cpuset="0x20000000,,0x20000000,0x0" allowed_cpuset="0x20000000,,0x20000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="29" cpuset="0x20000000,,0x20000000,0x0" complete_cpuset="0x20000000,,0x20000000,0x0" online_cpuset="0x20000000,,0x20000000,0x0" allowed_cpuset="0x20000000,,0x20000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="61" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" online_cpuset="0x20000000,0x0" allowed_cpuset="0x20000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="125" cpuset="0x20000000,,,0x0" complete_cpuset="0x20000000,,,0x0" online_cpuset="0x20000000,,,0x0" allowed_cpuset="0x20000000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x40000000,,0x40000000,0x0" complete_cpuset="0x40000000,,0x40000000,0x0" online_cpuset="0x40000000,,0x40000000,0x0" allowed_cpuset="0x40000000,,0x40000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x40000000,,0x40000000,0x0" complete_cpuset="0x40000000,,0x40000000,0x0" online_cpuset="0x40000000,,0x40000000,0x0" allowed_cpuset="0x40000000,,0x40000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x40000000,,0x40000000,0x0" complete_cpuset="0x40000000,,0x40000000,0x0" online_cpuset="0x40000000,,0x40000000,0x0" allowed_cpuset="0x40000000,,0x40000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="30" cpuset="0x40000000,,0x40000000,0x0" complete_cpuset="0x40000000,,0x40000000,0x0" online_cpuset="0x40000000,,0x40000000,0x0" allowed_cpuset="0x40000000,,0x40000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="62" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" online_cpuset="0x40000000,0x0" allowed_cpuset="0x40000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="126" cpuset="0x40000000,,,0x0" complete_cpuset="0x40000000,,,0x0" online_cpuset="0x40000000,,,0x0" allowed_cpuset="0x40000000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+          <object type="Cache" cpuset="0x80000000,,0x80000000,0x0" complete_cpuset="0x80000000,,0x80000000,0x0" online_cpuset="0x80000000,,0x80000000,0x0" allowed_cpuset="0x80000000,,0x80000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="1310720" depth="2" cache_linesize="64" cache_associativity="20" cache_type="0">
+            <info name="Inclusive" value="0"/>
+            <object type="Cache" cpuset="0x80000000,,0x80000000,0x0" complete_cpuset="0x80000000,,0x80000000,0x0" online_cpuset="0x80000000,,0x80000000,0x0" allowed_cpuset="0x80000000,,0x80000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="49152" depth="1" cache_linesize="64" cache_associativity="12" cache_type="1">
+              <info name="Inclusive" value="0"/>
+              <object type="Cache" cpuset="0x80000000,,0x80000000,0x0" complete_cpuset="0x80000000,,0x80000000,0x0" online_cpuset="0x80000000,,0x80000000,0x0" allowed_cpuset="0x80000000,,0x80000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="Inclusive" value="0"/>
+                <object type="Core" os_index="31" cpuset="0x80000000,,0x80000000,0x0" complete_cpuset="0x80000000,,0x80000000,0x0" online_cpuset="0x80000000,,0x80000000,0x0" allowed_cpuset="0x80000000,,0x80000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
+                  <object type="PU" os_index="63" cpuset="0x80000000,0x0" complete_cpuset="0x80000000,0x0" online_cpuset="0x80000000,0x0" allowed_cpuset="0x80000000,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                  <object type="PU" os_index="127" cpuset="0x80000000,,,0x0" complete_cpuset="0x80000000,,,0x0" online_cpuset="0x80000000,,,0x0" allowed_cpuset="0x80000000,,,0x0" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
+                </object>
+              </object>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="Bridge" os_index="0" bridge_type="0-1" depth="0" bridge_pci="0000:[00-00]">
+      <object type="PCIDev" os_index="0" pci_busid="0000:00:00.0" pci_type="0600 [8086:1237] [1d0f:1237] 00" pci_link_speed="0.000000"/>
+      <object type="PCIDev" os_index="16" pci_busid="0000:00:01.0" pci_type="0601 [8086:7000] [0000:0000] 00" pci_link_speed="0.000000">
+        <info name="PCISlot" value="1"/>
+      </object>
+      <object type="PCIDev" os_index="19" pci_busid="0000:00:01.3" pci_type="0000 [8086:7113] [0000:0000] 08" pci_link_speed="0.000000">
+        <info name="PCISlot" value="1"/>
+      </object>
+      <object type="PCIDev" os_index="48" pci_busid="0000:00:03.0" pci_type="0300 [1d0f:1111] [0000:0000] 00" pci_link_speed="0.000000">
+        <info name="PCISlot" value="3"/>
+      </object>
+      <object type="PCIDev" os_index="64" pci_busid="0000:00:04.0" pci_type="0108 [1d0f:8061] [1d0f:0000] 00" pci_link_speed="0.000000">
+        <info name="PCISlot" value="4"/>
+      </object>
+      <object type="PCIDev" os_index="80" pci_busid="0000:00:05.0" pci_type="0200 [1d0f:ec20] [1d0f:ec20] 00" pci_link_speed="0.000000">
+        <info name="PCISlot" value="5"/>
+        <object type="OSDev" name="eth0" osdev_type="2">
+          <info name="Address" value="06:35:11:da:44:af"/>
+        </object>
+      </object>
+      <object type="PCIDev" os_index="96" pci_busid="0000:00:06.0" pci_type="0200 [1d0f:efa1] [1d0f:efa1] 00" pci_link_speed="0.000000">
+        <info name="PCISlot" value="6"/>
+        <object type="OSDev" name="rdmap0s6" osdev_type="3">
+          <info name="NodeGUID" value="0000:0000:0000:0000"/>
+          <info name="SysImageGUID" value="0000:0000:0000:0000"/>
+          <info name="Port1State" value="4"/>
+          <info name="Port1LID" value="0x0"/>
+          <info name="Port1LMC" value="1"/>
+          <info name="Port1GID0" value="fe80:0000:0000:0000:0435:11ff:feda:44af"/>
+        </object>
+      </object>
+      <object type="PCIDev" os_index="112" pci_busid="0000:00:07.0" pci_type="0200 [1d0f:ec20] [1d0f:ec20] 00" pci_link_speed="0.000000">
+        <info name="PCISlot" value="7"/>
+        <object type="OSDev" name="eth1" osdev_type="2">
+          <info name="Address" value="06:53:72:0b:a7:09"/>
+        </object>
+      </object>
+      <object type="PCIDev" os_index="128" pci_busid="0000:00:08.0" pci_type="0200 [1d0f:efa1] [1d0f:efa1] 00" pci_link_speed="0.000000">
+        <info name="PCISlot" value="8"/>
+        <object type="OSDev" name="rdmap0s8" osdev_type="3">
+          <info name="NodeGUID" value="0000:0000:0000:0000"/>
+          <info name="SysImageGUID" value="0000:0000:0000:0000"/>
+          <info name="Port1State" value="4"/>
+          <info name="Port1LID" value="0x0"/>
+          <info name="Port1LMC" value="1"/>
+          <info name="Port1GID0" value="fe80:0000:0000:0000:0453:72ff:fe0b:a709"/>
+        </object>
+      </object>
+    </object>
+  </object>
+</topology>

--- a/test/runtime/jhh/colocales/sub_test
+++ b/test/runtime/jhh/colocales/sub_test
@@ -2,12 +2,6 @@
 
 # Runs all *.py files in the current directory.
 
-# start_test removes directories under $CHPL_HOME from the path.
-# Put them back so the Python scripts can compile the test program.
-pushd $CHPL_HOME
-source util/setchplenv.bash
-popd
-
 dirs=$CHPL_HOME/util/chplenv:$CHPL_HOME/util/test
 export PYTHONPATH=${PYTHONPATH:+${PYTHONPATH}:}$dirs
 

--- a/test/runtime/jhh/colocales/sub_test
+++ b/test/runtime/jhh/colocales/sub_test
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Runs all *.py files in the current directory.
+
+# start_test removes directories under $CHPL_HOME from the path.
+# Put them back so the Python scripts can compile the test program.
+pushd $CHPL_HOME
+source util/setchplenv.bash
+popd
+
+dirs=$CHPL_HOME/util/chplenv:$CHPL_HOME/util/test
+export PYTHONPATH=${PYTHONPATH:+${PYTHONPATH}:}$dirs
+
+export PATH=${PATH:+${PATH}:}$CHPL_HOME/util/config
+
+for file in *.py; do
+    python3 $file $@ ${EXECOPTS} -v
+done


### PR DESCRIPTION
Generalizes NIC selection to handle NICs that aren't in a socket. The assignment is based on the locales' cpusets and distances to NICs, rather than on locales and NICs sharing sockets. Each locale is represented by the lowest common ancestor of its cpuset, and each NIC is represented by its lowest ancestor that has a cpuset. The distance between a locale and a NIC is the length of the path between them in the topology. The assignment process is a greedy algorithm that finds the shortest path and assigns that NIC to that locale. Then it repeats with the remaining locales and NICs until all locales have a NIC or there are no remaining NICs. If some locales do not have a NIC the entire process is repeated until all locales are assigned a NIC. This heuristic avoids sharing NICs unless there are are more locales than NICs.
