### PR TITLE
Update a missed copyright notice for 2024

### DIFF
--- a/frontend/test/resolution/testTypePropertyPrimitives.cpp
+++ b/frontend/test/resolution/testTypePropertyPrimitives.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+ * Copyright 2021-2024 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,


### PR DESCRIPTION
Update copyright notice in `frontend/test/resolution/testTypePropertyPrimitives.cpp` for 2024.

Missed in https://github.com/chapel-lang/chapel/pull/24122 because the file was added while that PR was in flight.

[trivial, not reviewed]

Testing:
- [x] `checkCopyrights.bash` now passes