### PR TITLE
Update copyright on DistributedBagDeprecated.chpl

### DIFF
--- a/modules/packages/DistributedBagDeprecated.chpl
+++ b/modules/packages/DistributedBagDeprecated.chpl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+ * Copyright 2020-2024 Hewlett Packard Enterprise Development LP
  * Copyright 2004-2019 Cray Inc.
  * Other additional copyright holders may be indicated within.
  *


### PR DESCRIPTION
Follow-up to PR #23204. This PR just updates the copyright in a new file.

Trivial and not reviewed. Comment change only.