### PR TITLE
Fix testing failure for AtomicIncAggregator on 32-bit platforms

### DIFF
--- a/test/studies/bale/aggregation/AtomicAggregation.chpl
+++ b/test/studies/bale/aggregation/AtomicAggregation.chpl
@@ -54,10 +54,10 @@ module AtomicAggregation {
     var bufferIdxs: c_ptr(int);
 
     proc ref postinit() {
-      lBuffers = allocate(c_ptr(aggType), numLocales);
+      lBuffers = allocate(c_ptr(aggType), numLocales:c_size_t);
       bufferIdxs = bufferIdxAlloc();
       for loc in myLocaleSpace {
-        lBuffers[loc] = allocate(aggType, bufferSize);
+        lBuffers[loc] = allocate(aggType, bufferSize:c_size_t);
         bufferIdxs[loc] = 0;
         rBuffers[loc] = new remoteBuffer(aggType, bufferSize, loc);
       }


### PR DESCRIPTION
Fixes an issue that came up in nightly testing of AtomicIncAggregator on 32 bit platforms. This is fixed both with a cast on the `allocate` call and by turning off the aggregator when COMM=none. This is done similarly to [Src|Dst]Aggregator where if COMM=NONE then the aggregator does nothing.

This potentially exposes a larger issue with aggregators, which has its own issue (#24148)

Tested locally w/wo comm.

[Reviewed by @stonea]