### PR TITLE
Update sort to use the faster two-array implementation

### DIFF
--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -470,7 +470,6 @@ The choice of sorting algorithm used is made by the implementation.
  */
 proc sort(ref Data: [?Dom] ?eltType, comparator:?rec=defaultComparator,
           stable:bool = false, minimizeMemory:bool=false) {
-  // TODO: This should have a flag `stable` to request a stable sort
   chpl_check_comparator(comparator, eltType);
 
   if Dom.low >= Dom.high then

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -3292,6 +3292,7 @@ module TwoArrayRadixSort {
       endbit = max(int);
 
     // Allocate the Scratch array.
+    pragma "no auto destroy"
     var Scratch: Data.type;
 
     if Data._instance.isDefaultRectangular() {
@@ -3325,6 +3326,8 @@ module TwoArrayRadixSort {
                                        state1, state2,
                                        comparator, 0);
     }
+
+    _do_destroy_array(Scratch, deinitElts=false);
   }
 }
 
@@ -3349,6 +3352,7 @@ module TwoArraySampleSort {
       endbit = max(int);
 
     // Allocate the Scratch array.
+    pragma "no auto destroy"
     var Scratch: Data.type;
 
     if Data._instance.isDefaultRectangular() {
@@ -3373,6 +3377,8 @@ module TwoArraySampleSort {
                                        Data, Scratch,
                                        state, comparator, 0);
     }
+
+    _do_destroy_array(Scratch, deinitElts=false);
   }
 }
 

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -1958,7 +1958,7 @@ module RadixSortHelp {
 
     // yields (index, bucket index) for A[start_n..end_n]
     iter classify(A, start_n, end_n, criterion, startbit) {
-      type idxType = A.idxType;
+      type idxType = if isArray(A) then A.idxType else int;
       var cur = start_n;
       while cur <= end_n-(classifyUnrollFactor-1) {
         for /*param*/ j in 0..classifyUnrollFactor-1 {
@@ -3465,30 +3465,15 @@ module TwoArraySampleSort {
     var Scratch: Data.type =
       Data.domain.buildArray(Data.eltType, initElts=false);
 
-    if Data._instance.isDefaultRectangular() {
-      var state = new TwoArrayBucketizerSharedState(
-        bucketizer=new SampleBucketizer(Data.eltType),
-        baseCaseSize=baseCaseSize,
-        endbit=endbit);
+    var state = new TwoArrayBucketizerSharedState(
+      bucketizer=new SampleBucketizer(Data.eltType),
+      baseCaseSize=baseCaseSize,
+      endbit=endbit);
 
-      partitioningSortWithScratchSpace(Data.domain.low.safeCast(int),
-                                       Data.domain.high.safeCast(int),
-                                       Data, Scratch,
-                                       state, comparator, 0);
-    } else {
-      var state = new TwoArrayDistributedBucketizerSharedState(
-        bucketizerType=SampleBucketizer(Data.eltType),
-        numLocales=Data.targetLocales().size,
-        baseCaseSize=baseCaseSize,
-        distributedBaseCaseSize=distributedBaseCaseSize,
-        endbit=endbit);
-
-      distributedPartitioningSortWithScratchSpace(
-                                       Data.domain.low.safeCast(int),
-                                       Data.domain.high.safeCast(int),
-                                       Data, Scratch,
-                                       state, comparator, 0);
-    }
+    partitioningSortWithScratchSpace(Data.domain.low.safeCast(int),
+                                     Data.domain.high.safeCast(int),
+                                     Data, Scratch,
+                                     state, comparator, 0);
 
     _do_destroy_array(Scratch, deinitElts=false);
   }

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -3293,7 +3293,7 @@ module TwoArrayRadixSort {
 
     // Allocate the Scratch array.
     pragma "no auto destroy"
-    var Scratch: Data.type;
+    var Scratch: Data.type = noinit;
 
     if Data._instance.isDefaultRectangular() {
       var state = new TwoArrayBucketizerSharedState(

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -1409,7 +1409,7 @@ module ShellSort {
     // and see Marcin Ciura - Best Increments for the Average Case of Shellsort
     // for the choice of these increments.
     var js,hs:idxType;
-    var v,tmp:Data.eltType;
+    var v:Data.eltType;
     const incs = (701, 301, 132, 57, 23, 10, 4, 1);
     for hh in incs {
       // skip past cases in which the 'incs' value was too big for

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -2705,6 +2705,12 @@ module TwoArrayPartitioning {
 
         if task.doSort {
           // Sort it serially.
+          // Note that the subproblems here are on the order of 500,000 elements
+          // because the two-array method will create small subproblems as soon
+          // as it does not seem useful to use parallelism to sort.
+          // Because of this, it matters to use a radix sort here.
+          // It also seems to matter to use an in-place algorithm here,
+          // but I am not completely confident of that.
           msbRadixSort(A, task.start, taskEnd,
                        criterion,
                        task.startbit, state.endbit,

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -2614,7 +2614,7 @@ module TwoArrayPartitioning {
                                 start_n, sampleSize, sampleStep, numBuckets);
       if debug {
         writeln("sample bucketizer ", state.bucketizer);
-        writef("A %i %i A=%xt\n", start_n, end_n, A[start_n..end_n]);
+        writef("A %i %i A=%?\n", start_n, end_n, A[start_n..end_n]);
       }
     }
 
@@ -2636,7 +2636,7 @@ module TwoArrayPartitioning {
 
     if debug {
       writeln("partitioningSortWithScratchSpace(", start_n, ",", end_n, ")");
-      writef("A %i %i A=%xt\n", start_n, end_n, A[start_n..end_n]);
+      writef("A %i %i A=%?\n", start_n, end_n, A[start_n..end_n]);
     }
 
 
@@ -2668,7 +2668,7 @@ module TwoArrayPartitioning {
                   criterion, task.startbit);
         // bucketized data now in Scratch
         if debug {
-          writef("pb %i %i Scratch=%xt\n", task.start, taskEnd, Scratch[task.start..taskEnd]);
+          writef("pb %i %i Scratch=%?\n", task.start, taskEnd, Scratch[task.start..taskEnd]);
         }
       } else {
         partitioningSortWithScratchSpaceHandleSampling(
@@ -2680,7 +2680,7 @@ module TwoArrayPartitioning {
                   criterion, task.startbit);
         // bucketized data now in A
         if debug {
-          writef("pb %i %i A=%xt\n", task.start, taskEnd, A[task.start..taskEnd]);
+          writef("pb %i %i A=%?\n", task.start, taskEnd, A[task.start..taskEnd]);
         }
       }
       const nowInA = !task.inA;
@@ -2742,7 +2742,7 @@ module TwoArrayPartitioning {
       const size = task.size;
       const taskEnd = task.start + size - 1;
       if debug {
-        writef("doing small task %i %i A=%xt\n", task.start, taskEnd, A[task.start..taskEnd]);
+        writef("doing small task %i %i A=%?\n", task.start, taskEnd, A[task.start..taskEnd]);
       }
 
       if !task.inA {
@@ -2765,8 +2765,8 @@ module TwoArrayPartitioning {
     }
 
     if debug {
-      writef("ps %i %i A=%xt\n", start_n, end_n, A[start_n..end_n]);
-      writef("ps %i %i Scratch=%xt\n", start_n, end_n, Scratch[start_n..end_n]);
+      writef("ps %i %i A=%?\n", start_n, end_n, A[start_n..end_n]);
+      writef("ps %i %i Scratch=%?\n", start_n, end_n, Scratch[start_n..end_n]);
       RadixSortHelp.checkSorted(start_n, end_n, A, criterion, startbit);
     }
   }
@@ -2874,7 +2874,7 @@ module TwoArrayPartitioning {
                                 start_n, sampleSize, sampleStep, numBuckets);
       if debug {
         writeln("sample bucketizer ", state.perLocale[0].compat.bucketizer);
-        writef("A %i %i A=%xt\n", start_n, end_n, A[start_n..end_n]);
+        writef("A %i %i A=%?\n", start_n, end_n, A[start_n..end_n]);
       }
 
       // Now copy the bucketizer sample to all other locales
@@ -3030,7 +3030,7 @@ module TwoArrayPartitioning {
         // Now the data is in Scratch
 
         if debugDist {
-          writef("%i after bucketize local portions, Scratch is %xt\n",
+          writef("%i after bucketize local portions, Scratch is %?\n",
               bktLocId,
               Scratch[bktTask.start..#bktTask.size]);
         }
@@ -3236,7 +3236,7 @@ module TwoArrayPartitioning {
     // Part B: Handle the "small" subproblems
 
     if debugDist then
-      writef("After big tasks, A is: %xt\n", A);
+      writef("After big tasks, A is: %?\n", A);
 
     // Always use state 1 for small subproblems...
     ref state = state1;
@@ -3262,13 +3262,13 @@ module TwoArrayPartitioning {
 
         if debugDist {
           checkSorted(task.start, taskEnd, A, criterion);
-          writef("%i after small sort, dst is %xt\n", tid, A[task.start..taskEnd]);
+          writef("%i after small sort, dst is %?\n", tid, A[task.start..taskEnd]);
         }
       }
     }
 
     if debugDist {
-      writef("After small tasks, A is: %xt\n", A);
+      writef("After small tasks, A is: %?\n", A);
       checkSorted(start_n, end_n, A, criterion);
     }
   }

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -459,9 +459,12 @@ algorithm used is made by the implementation.
 :type Data: [] `eltType`
 :arg comparator: :ref:`Comparator <comparators>` record that defines how the
   data is sorted.
-
+:arg mimimizeMemory: Defaults to ``false``. If it is ``false``, the
+implementation can make a copy of ``Data`` for scratch storage during the sort.
+If it is ``true``, it will use an implementation that uses less memory.
  */
-proc sort(ref Data: [?Dom] ?eltType, comparator:?rec=defaultComparator) {
+proc sort(ref Data: [?Dom] ?eltType, comparator:?rec=defaultComparator,
+          minimizeMemory=false) {
   // TODO: This should have a flag `stable` to request a stable sort
   chpl_check_comparator(comparator, eltType);
 
@@ -469,7 +472,11 @@ proc sort(ref Data: [?Dom] ?eltType, comparator:?rec=defaultComparator) {
     return;
 
   if radixSortOk(Data, comparator) {
-    MSBRadixSort.msbRadixSort(Data, comparator=comparator);
+    if minimizeMemory {
+      MSBRadixSort.msbRadixSort(Data, comparator=comparator);
+    } else {
+      TwoArrayRadixSort.twoArrayRadixSort(Data, comparator=comparator);
+    }
   } else {
     QuickSort.quickSort(Data, comparator=comparator);
   }

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -423,13 +423,15 @@ proc radixSortOk(Data: [?Dom] ?eltType, comparator) param {
 /*
 
 Sort the elements in a 1D rectangular array. After the call, the ``Data`` array
-will store elements n sorted order.
+will store elements in sorted order.
 
 The choice of sorting algorithm used is made by the implementation.
 
 .. note::
 
-  Elements will be moved, swapped, or assigned in to place.
+  When reordering elements, the sort implementation might use assignment, memory
+  moves, or the swap operator. Additionally, the sort might create
+  copy-initialize elements, for example, to create a pivot.
 
 .. note::
 
@@ -599,6 +601,7 @@ iter sorted(x, comparator:?rec=defaultComparator) {
 
 // bubble sort is generally too slow to be useful in practice
 // but, it is stable and in-place
+@chpldoc.nodoc
 module BubbleSort {
   import Sort.{defaultComparator, chpl_check_comparator, chpl_compare};
 
@@ -636,7 +639,7 @@ module BubbleSort {
   }
 }
 
-// heap sort has good nlogn worst case performance
+// heap sort has good n*log(n) worst case performance
 // it is in-place but not stable.
 @chpldoc.nodoc
 module HeapSort {
@@ -2073,7 +2076,6 @@ module ShallowCopy {
       assert(A.domain.contains(src_idx..#nElts_idx));
     }
 
-
     if A._instance.isDefaultRectangular() {
       type st = __primitive("static field type", A._value, "eltType");
       var size = (nElts:c_size_t)*c_sizeof(st);
@@ -2601,9 +2603,9 @@ module TwoArrayPartitioning {
         const binStartBit = state.bucketizer.getNextStartBit(task.startbit);
 
         const sortit =
-          state.bucketizer.getBinsToRecursivelySort().contains(bin) &&
+          binSize > 1 && // have 2 or more elements to sort
           binStartBit <= state.endbit && // have bits to sort
-          binSize > 1;
+          state.bucketizer.getBinsToRecursivelySort().contains(bin);
 
         if binSize == 0 {
           // Do nothing

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -459,26 +459,34 @@ algorithm used is made by the implementation.
 :type Data: [] `eltType`
 :arg comparator: :ref:`Comparator <comparators>` record that defines how the
   data is sorted.
+:arg stable: Defaults to ``false``. If it is ``false``, the implementation
+  can sort in a way that reorders equal keys. If it is ``true``, it will use a
+  stable algorithm in order to preserve the order of equal keys.
 :arg mimimizeMemory: Defaults to ``false``. If it is ``false``, the
   implementation can make a copy of ``Data`` for scratch storage during the
-  sort. If it is ``true``, it will use an implementation that uses less memory.
+  sort. If it is ``true``, it will use an in-place algorithm in order to use
+  less memory.
  */
 proc sort(ref Data: [?Dom] ?eltType, comparator:?rec=defaultComparator,
-          minimizeMemory=false) {
+          stable:bool = false, minimizeMemory:bool=false) {
   // TODO: This should have a flag `stable` to request a stable sort
   chpl_check_comparator(comparator, eltType);
 
   if Dom.low >= Dom.high then
     return;
 
-  if radixSortOk(Data, comparator) {
-    if minimizeMemory {
-      MSBRadixSort.msbRadixSort(Data, comparator=comparator);
-    } else {
-      TwoArrayRadixSort.twoArrayRadixSort(Data, comparator=comparator);
-    }
+  if stable {
+    MergeSort.mergeSort(Data, comparator=comparator);
   } else {
-    QuickSort.quickSort(Data, comparator=comparator);
+    if radixSortOk(Data, comparator) {
+      if minimizeMemory {
+        MSBRadixSort.msbRadixSort(Data, comparator=comparator);
+      } else {
+        TwoArrayRadixSort.twoArrayRadixSort(Data, comparator=comparator);
+      }
+    } else {
+      QuickSort.quickSort(Data, comparator=comparator);
+    }
   }
 }
 

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -460,8 +460,8 @@ algorithm used is made by the implementation.
 :arg comparator: :ref:`Comparator <comparators>` record that defines how the
   data is sorted.
 :arg mimimizeMemory: Defaults to ``false``. If it is ``false``, the
-implementation can make a copy of ``Data`` for scratch storage during the sort.
-If it is ``true``, it will use an implementation that uses less memory.
+  implementation can make a copy of ``Data`` for scratch storage during the
+  sort. If it is ``true``, it will use an implementation that uses less memory.
  */
 proc sort(ref Data: [?Dom] ?eltType, comparator:?rec=defaultComparator,
           minimizeMemory=false) {

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -422,16 +422,16 @@ proc radixSortOk(Data: [?Dom] ?eltType, comparator) param {
 
 /*
 
-Sort the elements in a 1D rectangular array. After the call, the ``Data`` array
-will store elements in sorted order.
+Sort the elements in the 1D rectangular array ``Data``.
+After the call, ``Data`` will store elements in sorted order.
 
 The choice of sorting algorithm used is made by the implementation.
 
 .. note::
 
   When reordering elements, the sort implementation might use assignment, memory
-  moves, or the swap operator. Additionally, the sort might create
-  copy-initialize elements, for example, to create a pivot.
+  moves, or the swap operator. Additionally, the sort might
+  copy-initialize some elements, for example, to create a pivot in quicksort.
 
 .. note::
 
@@ -465,13 +465,13 @@ The choice of sorting algorithm used is made by the implementation.
 :arg stable: Defaults to ``false``. If it is ``false``, the implementation
   can sort in a way that reorders equal keys. If it is ``true``, it will use a
   stable algorithm in order to preserve the order of equal keys.
-:arg mimimizeMemory: Defaults to ``false``. If it is ``false``, the
+:arg inPlaceAlgorithm: Defaults to ``false``. If it is ``false``, the
   implementation can make a copy of ``Data`` for scratch storage during the
   sort. If it is ``true``, it will use an in-place algorithm in order to use
   less memory.
  */
 proc sort(ref Data: [?Dom] ?eltType, comparator:?rec=defaultComparator,
-          param stable:bool = false, param minimizeMemory:bool = false) {
+          param stable:bool = false, param inPlaceAlgorithm:bool = false) {
   chpl_check_comparator(comparator, eltType);
 
   if Dom.low >= Dom.high then
@@ -484,7 +484,7 @@ proc sort(ref Data: [?Dom] ?eltType, comparator:?rec=defaultComparator,
     compilerError("stable sort not yet implemented");
   } else {
     if radixSortOk(Data, comparator) {
-      if minimizeMemory {
+      if inPlaceAlgorithm {
         // use an in-place algorithm
         MSBRadixSort.msbRadixSort(Data, comparator=comparator);
       } else {

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -469,22 +469,29 @@ The choice of sorting algorithm used is made by the implementation.
   less memory.
  */
 proc sort(ref Data: [?Dom] ?eltType, comparator:?rec=defaultComparator,
-          stable:bool = false, minimizeMemory:bool=false) {
+          param stable:bool = false, param minimizeMemory:bool = false) {
   chpl_check_comparator(comparator, eltType);
 
   if Dom.low >= Dom.high then
     return;
 
   if stable {
-    MergeSort.mergeSort(Data, comparator=comparator);
+    // TODO: implement a stable merge sort with parallel merge
+    // TODO: create an in-place merge sort for the stable+minimizeMemory case
+    // TODO: create a stable variant of the radix sort
+    compilerError("stable sort not yet implemented");
   } else {
     if radixSortOk(Data, comparator) {
       if minimizeMemory {
+        // use an in-place algorithm
         MSBRadixSort.msbRadixSort(Data, comparator=comparator);
       } else {
+        // use the two-array radix sort which is more parallel / faster
         TwoArrayRadixSort.twoArrayRadixSort(Data, comparator=comparator);
       }
     } else {
+      // use quick sort, which is currently in-place
+      // TODO: use a parallel sample sort instead
       QuickSort.quickSort(Data, comparator=comparator);
     }
   }

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -2159,9 +2159,10 @@ module SequentialInPlacePartitioning {
 module TwoArrayPartitioning {
   private use BlockDist;
   private use Math;
-  private use super.MSBRadixSort;
   public use List only list;
-  import Sort.{ShellSort, RadixSortHelp, SampleSortHelp, ShallowCopy};
+  import Sort.{ShellSort, MSBRadixSort, QuickSort};
+  import Sort.{RadixSortHelp, SampleSortHelp, ShallowCopy};
+  use MSBRadixSort;
 
   private param debug = false;
   private param debugDist = false;

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -3293,7 +3293,8 @@ module TwoArrayRadixSort {
 
     // Allocate the Scratch array.
     pragma "no auto destroy"
-    var Scratch: Data.type = noinit;
+    var Scratch: Data.type =
+      Data.domain.buildArray(Data.eltType, initElts=false);
 
     if Data._instance.isDefaultRectangular() {
       var state = new TwoArrayBucketizerSharedState(
@@ -3353,7 +3354,8 @@ module TwoArraySampleSort {
 
     // Allocate the Scratch array.
     pragma "no auto destroy"
-    var Scratch: Data.type;
+    var Scratch: Data.type =
+      Data.domain.buildArray(Data.eltType, initElts=false);
 
     if Data._instance.isDefaultRectangular() {
       var state = new TwoArrayBucketizerSharedState(

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -422,13 +422,14 @@ proc radixSortOk(Data: [?Dom] ?eltType, comparator) param {
 
 /*
 
-Sort the elements in a 1D rectangular array.  The choice of sorting
-algorithm used is made by the implementation.
+Sort the elements in a 1D rectangular array. After the call, the ``Data`` array
+will store elements n sorted order.
+
+The choice of sorting algorithm used is made by the implementation.
 
 .. note::
 
-  This function does not run a stable sort. Elements that compare
-  the same can be rearranged by this call.
+  Elements will be moved, swapped, or assigned in to place.
 
 .. note::
 
@@ -589,7 +590,9 @@ iter sorted(x, comparator:?rec=defaultComparator) {
   }
 }
 
-@chpldoc.nodoc
+
+// bubble sort is generally too slow to be useful in practice
+// but, it is stable and in-place
 module BubbleSort {
   import Sort.{defaultComparator, chpl_check_comparator, chpl_compare};
 
@@ -627,6 +630,8 @@ module BubbleSort {
   }
 }
 
+// heap sort has good nlogn worst case performance
+// it is in-place but not stable.
 @chpldoc.nodoc
 module HeapSort {
   import Sort.{defaultComparator, chpl_check_comparator, chpl_compare};
@@ -693,6 +698,8 @@ module HeapSort {
   }
 }
 
+// insertion sort is stable and in-place but has
+// poor time complexity (O(n**2)) for large problem sizes
 @chpldoc.nodoc
 module InsertionSort {
   private use Sort;
@@ -767,6 +774,8 @@ module InsertionSort {
   }
 }
 
+// binary insertion sort is similar to insertion sort (stable, in-place)
+// and still O(n**2) but it can reduce the number of comparisons
 @chpldoc.nodoc
 module BinaryInsertionSort {
   private use Sort;
@@ -837,6 +846,7 @@ module BinaryInsertionSort {
   }
 }
 
+// TimSort is stable, nlogn, but not in-place
 @chpldoc.nodoc
 module TimSort {
   private use Sort;
@@ -952,6 +962,11 @@ module TimSort {
 }
 
 
+// merge sort has in-place and not in-place variants
+// this implements a version using scratch space (not in place)
+// also, this version uses partial parallelism (for recursive subproblems)
+// could be faster using a parallel merge algorithm or with a k-way merge.
+// merge sort is a stable sort
 @chpldoc.nodoc
 module MergeSort {
   private use Sort;
@@ -1085,6 +1100,8 @@ module MergeSort {
   }
 }
 
+// this quick sort is not stable
+// it is in-place however
 @chpldoc.nodoc
 module QuickSort {
   private use Sort;
@@ -1334,6 +1351,7 @@ module QuickSort {
     }
 }
 
+// this selection sort is in-place but not stable
 @chpldoc.nodoc
 module SelectionSort {
   private use Sort;
@@ -1348,6 +1366,7 @@ module SelectionSort {
 
    */
   proc selectionSort(ref Data: [?Dom] ?eltType, comparator:?rec=defaultComparator) {
+    // note: selection sort is not a stable sort
 
     if Dom.rank != 1 {
       compilerError("selectionSort() requires 1-D array");
@@ -1369,6 +1388,7 @@ module SelectionSort {
   }
 }
 
+// shell sort is in-place but not stable
 @chpldoc.nodoc
 module ShellSort {
   private use Sort;
@@ -1678,6 +1698,8 @@ module RadixSortHelp {
   // That would need to change if it were to increase.
   //
   // At the same time, using a value less than 8 will probably perform poorly.
+  // TODO: parameterize functions using this so that different
+  // algorithms can use a different number of radix bits
   param RADIX_BITS = 8;
 
   param classifyUnrollFactor = 7;
@@ -3308,6 +3330,8 @@ module InPlacePartitioning {
 }
 
 
+// the algorithm here is also called "American Flag Sort"
+// it is not stable and not fully parallel
 @chpldoc.nodoc
 module MSBRadixSort {
   import Sort.{defaultComparator, ShellSort};

--- a/test/compflags/ferguson/print-module-resolution.good
+++ b/test/compflags/ferguson/print-module-resolution.good
@@ -118,12 +118,16 @@ List
   from print-module-resolution.ChapelStandard.LocaleModel.LocaleModelHelpFlat.LocaleModelHelpSetup.DefaultRectangular.ChapelArray.Sort.List
 RadixSortHelp
   from print-module-resolution.ChapelStandard.LocaleModel.LocaleModelHelpFlat.LocaleModelHelpSetup.DefaultRectangular.ChapelArray.Sort.MSBRadixSort.RadixSortHelp
+ShallowCopy
+  from print-module-resolution.ChapelStandard.LocaleModel.LocaleModelHelpFlat.LocaleModelHelpSetup.DefaultRectangular.ChapelArray.Sort.MSBRadixSort.ShellSort.ShallowCopy
 ShellSort
   from print-module-resolution.ChapelStandard.LocaleModel.LocaleModelHelpFlat.LocaleModelHelpSetup.DefaultRectangular.ChapelArray.Sort.MSBRadixSort.ShellSort
 MSBRadixSort
   from print-module-resolution.ChapelStandard.LocaleModel.LocaleModelHelpFlat.LocaleModelHelpSetup.DefaultRectangular.ChapelArray.Sort.MSBRadixSort
-ShallowCopy
-  from print-module-resolution.ChapelStandard.LocaleModel.LocaleModelHelpFlat.LocaleModelHelpSetup.DefaultRectangular.ChapelArray.Sort.QuickSort.ShallowCopy
+TwoArrayPartitioning
+  from print-module-resolution.ChapelStandard.LocaleModel.LocaleModelHelpFlat.LocaleModelHelpSetup.DefaultRectangular.ChapelArray.Sort.TwoArrayRadixSort.TwoArrayPartitioning
+TwoArrayRadixSort
+  from print-module-resolution.ChapelStandard.LocaleModel.LocaleModelHelpFlat.LocaleModelHelpSetup.DefaultRectangular.ChapelArray.Sort.TwoArrayRadixSort
 InsertionSort
   from print-module-resolution.ChapelStandard.LocaleModel.LocaleModelHelpFlat.LocaleModelHelpSetup.DefaultRectangular.ChapelArray.Sort.QuickSort.InsertionSort
 QuickSort

--- a/test/library/packages/Sort/RadixSort/distributedRadixSort.chpl
+++ b/test/library/packages/Sort/RadixSort/distributedRadixSort.chpl
@@ -20,7 +20,7 @@ proc simpletestcore(input:[]) {
     writef("input %xt\n", input);
   }
 
-  TwoArrayRadixSort.twoArrayRadixSort(A, defaultComparator);
+ TwoArrayDistributedRadixSort.twoArrayDistributedRadixSort(A, defaultComparator);
 
   if debug {
     writef("output %xt\n", A);

--- a/test/library/packages/Sort/correctness/SortTypes.chpl
+++ b/test/library/packages/Sort/correctness/SortTypes.chpl
@@ -74,6 +74,12 @@ proc checkSorts(arr, comparator) {
   QuickSort.quickSort(c, comparator=comparator);
   assert(isSorted(c, comparator));
   assert(a.equals(c));
+
+  // check shellSortMoveElts
+  var d = arr;
+  ShellSort.shellSortMoveElts(d, comparator=comparator);
+  assert(isSorted(d, comparator));
+  assert(a.equals(d));
 }
 
 proc checkSorts(arr) {

--- a/test/library/packages/Sort/correctness/two-array-radix-sort-bug.chpl
+++ b/test/library/packages/Sort/correctness/two-array-radix-sort-bug.chpl
@@ -36,9 +36,9 @@ proc testDist() {
 
   fillRandom(A, seed=seed);
   A = abs(A) % bound;
-  writeln("TwoArrayRadixSort.twoArrayRadixSort");
+  writeln("TwoArrayDistributedRadixSort.twoArrayDistributedRadixSort");
   var AA = A;
-  TwoArrayRadixSort.twoArrayRadixSort(AA);
+  TwoArrayDistributedRadixSort.twoArrayDistributedRadixSort(AA);
   writeln("Result is sorted? ", isSorted(AA));
 
   writeln("standard sort");

--- a/test/library/packages/Sort/correctness/two-array-radix-sort-bug.good
+++ b/test/library/packages/Sort/correctness/two-array-radix-sort-bug.good
@@ -5,7 +5,7 @@ standard sort
 Result is sorted? true
 
 testing distributed sorting
-TwoArrayRadixSort.twoArrayRadixSort
+TwoArrayDistributedRadixSort.twoArrayDistributedRadixSort
 Result is sorted? true
 standard sort
 Result is sorted? true

--- a/test/library/packages/Sort/performance/comparison/chapel-sort-older-radix-sort.chpl
+++ b/test/library/packages/Sort/performance/comparison/chapel-sort-older-radix-sort.chpl
@@ -1,0 +1,21 @@
+// chpl --fast chapel-sort-two-array-random.chpl
+
+use Sort;
+use Time;
+use Random;
+
+config const n = 128*1024*1024;
+
+proc main() {
+  var A:[1..n] uint;
+
+  fillRandom(A);
+
+  var timer:stopwatch;
+  timer.start();
+  MSBRadixSort.msbRadixSort(A);
+  timer.stop();
+
+  writeln("Sorted ", n, " elements in ", timer.elapsed(), " seconds");
+  writeln(8*n/timer.elapsed()/1024.0/1024.0, " MiB/s");
+}

--- a/test/library/packages/Sort/performance/comparison/julia-sort-random.jl
+++ b/test/library/packages/Sort/performance/comparison/julia-sort-random.jl
@@ -1,5 +1,5 @@
 # run it with
-#   julia sort-random.jl
+#   julia julia-sort-random.jl
 
 function testSort(n)
   v = rand(Int, n)

--- a/test/library/packages/Sort/performance/comparison/sort-random-rust/Cargo.toml
+++ b/test/library/packages/Sort/performance/comparison/sort-random-rust/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "sort-random-rust"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+rand = "0.8.4"
+

--- a/test/library/packages/Sort/performance/comparison/sort-random-rust/src/main.rs
+++ b/test/library/packages/Sort/performance/comparison/sort-random-rust/src/main.rs
@@ -1,0 +1,19 @@
+// run it with
+//  cd sort-random-rust
+//  cargo build --release
+//  target/release/sort-random-rust
+use rand::prelude::*;
+use rand::distributions::Standard;
+use std::time::Instant;
+
+fn main() {
+    let n = 1024*1024*128;
+    let mut values: Vec<u64> = rand::thread_rng().sample_iter(Standard).take(n).collect();
+
+    let start = Instant::now();
+    values.sort_unstable();
+    let duration = start.elapsed();
+
+    println!("{:?} MiB/s", 8.0*(n as f64)/duration.as_secs_f64()/1024.0/1024.0);
+}
+

--- a/test/library/packages/Sort/performance/comparison/sort-random.jl
+++ b/test/library/packages/Sort/performance/comparison/sort-random.jl
@@ -1,0 +1,11 @@
+# run it with
+#   julia sort-random.jl
+
+function testSort(n)
+  v = rand(Int, n)
+  @timed sort!(v);
+end
+
+n = 1024*1024*128
+t = testSort(n)
+println(8*n / t.time / 1024.0 / 1024.0, " MiB/s")

--- a/test/library/packages/Sort/performance/dist-performance.chpl
+++ b/test/library/packages/Sort/performance/dist-performance.chpl
@@ -72,7 +72,7 @@ proc main() {
   fillRandom(A, seed=314159265);
 
   startDiag();
-  TwoArrayRadixSort.twoArrayRadixSort(A);
+  TwoArrayDistributedRadixSort.twoArrayDistributedRadixSort(A);
   endDiag("Sort");
   assert(isSorted(A));
 }

--- a/test/modules/sungeun/init/printModuleInitOrder.good
+++ b/test/modules/sungeun/init/printModuleInitOrder.good
@@ -33,8 +33,10 @@ Initializing Modules:
           MSBRadixSort
            RadixSortHelp
            ShellSort
+            ShallowCopy
+          TwoArrayRadixSort
+           TwoArrayPartitioning
           QuickSort
-           ShallowCopy
            InsertionSort
         ChapelDistribution
          ChapelHashtable


### PR DESCRIPTION
This PR updates the `proc sort` in the `Sort` package module to use the two-array sort.

This PR:
 * adds an optional `param` arguments that can request an in-place/lower-memory sort. The one requesting an in-place algorithm is `inPlaceAlgorithm` to avoid confusion with the fact that the `sort` call modifies the passed array in-place rather than returning a new an array. The one requesting a stable sort is just called `stable` but that currently leads to a compilerError about it being unimplemented.
 * fixes a few bugs in the two-array sort code especially for records and arrays with idxType not `int`.
 * rearranges the code in the Sort module to put the sample sort and distributed two array sorts into different modules so that we can avoid using Random and/or BlockDist on every compile (since Sort itself is used in the internal modules).

Reviewed by @vasslitvinov - thanks!

- [x] full comm=none testing