### PR TITLE
Make clang checks of bad `--ccflags` fatal

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -1702,7 +1702,7 @@ void setupClang(GenInfo* info, std::string mainFile)
       TheDriver.BuildCompilation(clangInfo->driverArgsCStrings));
 
   if (diagClient->getNumErrors() > 0) {
-    USR_FATAL("error in back-end LLVM cmopilation");
+    USR_FATAL("error in back-end LLVM compilation");
   }
 
   clang::driver::Command* job = NULL;

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -1701,6 +1701,10 @@ void setupClang(GenInfo* info, std::string mainFile)
   std::unique_ptr<clang::driver::Compilation> C(
       TheDriver.BuildCompilation(clangInfo->driverArgsCStrings));
 
+  if (diagClient->getNumErrors() > 0) {
+    USR_FATAL("error in back-end LLVM cmopilation");
+  }
+
   clang::driver::Command* job = NULL;
 
   if (usingGpuLocaleModel() == false) {

--- a/test/compflags/unknownLlvmFlag.good
+++ b/test/compflags/unknownLlvmFlag.good
@@ -1,2 +1,2 @@
 error: unsupported option '--fake-flag'
-error: error in back-end LLVM cmopilation
+error: error in back-end LLVM compilation

--- a/test/compflags/unknownLlvmFlag.good
+++ b/test/compflags/unknownLlvmFlag.good
@@ -1,2 +1,2 @@
 error: unsupported option '--fake-flag'
-Got here
+error: error in back-end LLVM cmopilation


### PR DESCRIPTION
[designed by @riftEmber, typed up by me]

Prior to this PR, if the LLVM back-end's processing of `--ccflags` turned up any bad/unexpected flags, an error would be printed, but the Chapel compiler would continue.  As an example of that, the existing `unknownLlvmFlag.chpl` test would issue the LLVM error, then complete compilation, permitting the program to be run.  Here, we detect the presence of the the error when asking `clang` to process `--ccflags`, and halt the Chapel compiler as a result, which seems appropriate for an erroneous condition.

This change was motivated by the fact that the `--compiler-driver` mode invokes this check twice, so was generating the error message twice.  By having the first case halt after generating an error, both modes now behave the same and the error message is only printed once.

Beyond the change itself, the only other change required was to update the only test we seem to have so far that generates an error in the LLVM back-end to not include the output of the executable and add the new error message.  Surprisingly, no other tests needed updating in a comm=none paratest run.