### PR TITLE
Small LSP fixes to work with vscode

### DIFF
--- a/tools/chpldef/Server.cpp
+++ b/tools/chpldef/Server.cpp
@@ -82,6 +82,10 @@ Server::Server(Server::Configuration config)
   errorHandler_ = handler.get();
   chapel_.installErrorHandler(std::move(handler));
 
+  if (config.enableStandardLibrary) {
+    chpl::parsing::setupModuleSearchPaths(&chapel_, false, false, {}, {});
+  }
+
   // Open the server log.
   Logger logger;
   if (!config_.logFile.empty()) {

--- a/tools/chpldef/Server.cpp
+++ b/tools/chpldef/Server.cpp
@@ -205,7 +205,9 @@ bool Server::handle(chpl::owned<Message> msg) {
   switch (msg->behavior()) {
     case Message::INCOMING_REQUEST:
     case Message::INCOMING_NOTIFY: {
-      if (msg->status() == Message::FAILED) CHPLDEF_TODO();
+      if (msg->status() == Message::FAILED) {
+        this->message("error %s: %s\n", msg->errorToString(), msg->note().c_str());
+        CHPLDEF_TODO(); }
       msg->handle(this);
       if (msg->status() == Message::FAILED) CHPLDEF_TODO();
       if (!msg->isNotification()) sendMessage(msg.get());

--- a/tools/chpldef/Server.h
+++ b/tools/chpldef/Server.h
@@ -29,6 +29,7 @@
 #include "chpl/framework/Context.h"
 #include "chpl/framework/ErrorBase.h"
 #include "chpl/framework/UniqueString.h"
+#include "chpl/parsing/parsing-queries.h"
 #include "chpl/uast/AstNode.h"
 #include "llvm/Support/JSON.h"
 #include <chrono>
@@ -243,6 +244,9 @@ private:
     if (shouldGarbageCollect()) chapel_.collectGarbage();
     if (c & CHPL_BUMP_REVISION) {
       chapel_.advanceToNextRevision(shouldPrepareToGarbageCollect());
+      if (config_.enableStandardLibrary) {
+        chpl::parsing::setupModuleSearchPaths(&chapel_, false, false, {}, {});
+      }
       ++revision_;
     }
   }

--- a/tools/chpldef/Server.h
+++ b/tools/chpldef/Server.h
@@ -153,6 +153,8 @@ protected:
   friend chpldef::Initialized;
   friend chpldef::Shutdown;
   friend chpldef::DidOpen;
+  friend chpldef::DidChange;
+  friend chpldef::DidClose;
 
   inline void setState(State state) { state_ = state; }
   inline TextRegistry& mutableTextRegistry() { return textRegistry_; }

--- a/tools/chpldef/compiler-gadgets.cpp
+++ b/tools/chpldef/compiler-gadgets.cpp
@@ -77,12 +77,16 @@ mapLinesToIdsInModuleImpl(chpl::Context* chapel, chpl::UniqueString uri) {
   return ret;
 }
 
-const LineToIdsMap&
+//
+// TODO: for some reason, with this written as a query this function will never run
+//
+const LineToIdsMap
 mapLinesToIdsInModule(chpl::Context* chapel, chpl::UniqueString uri) {
   using namespace chpl;
-  QUERY_BEGIN(mapLinesToIdsInModule, chapel, uri);
+  // QUERY_BEGIN(mapLinesToIdsInModule, chapel, uri);
   auto ret = mapLinesToIdsInModuleImpl(chapel, uri);
-  return QUERY_END(ret);
+  // return QUERY_END(ret);
+  return ret;
 }
 
 chpl::Location

--- a/tools/chpldef/compiler-gadgets.cpp
+++ b/tools/chpldef/compiler-gadgets.cpp
@@ -53,7 +53,7 @@ static void doMapLinesInModule(chpl::Context* chapel,
     // Push back the occupied lines. This is usually just one line but can
     // be up to 3 in the case of a dot expression.
     if (isSymbolOfInterest(ast)) {
-      auto loc = br.idToLocation(ast->id(), chpl::UniqueString());
+      auto loc = br.idToLocation(chapel, ast->id(), chpl::UniqueString());
       CHPL_ASSERT(!loc.isEmpty());
       for (int i = loc.firstLine(); i <= loc.lastLine(); i++) {
         auto& v = m[i];

--- a/tools/chpldef/compiler-gadgets.h
+++ b/tools/chpldef/compiler-gadgets.h
@@ -51,7 +51,7 @@ const chpl::uast::BuilderResult&
 parseFromUri(chpl::Context* chapel, const std::string& uri);
 
 /** A compiler query which maps source lines to AST nodes on that line. */
-const LineToIdsMap&
+const LineToIdsMap
 mapLinesToIdsInModule(chpl::Context* chapel, chpl::UniqueString uri);
 
 /** Given a cursor position and URI, create a Chapel location. */

--- a/tools/chpldef/compute-goto-declaration.cpp
+++ b/tools/chpldef/compute-goto-declaration.cpp
@@ -171,7 +171,7 @@ sourceAstToIds(Server* ctx, const chpl::uast::AstNode* ast) {
     if (auto id = re->toId()) {
       ret.push_back(std::move(id));
     } else if (auto tfs = ms.only()) {
-      ret.push_back(tfs->id());
+      ret.push_back(tfs.fn()->id());
     } else {
       CHPLDEF_TODO();
     }

--- a/tools/chpldef/compute-lifecycle.cpp
+++ b/tools/chpldef/compute-lifecycle.cpp
@@ -23,7 +23,6 @@
 #include "chpl/parsing/parsing-queries.h"
 
 namespace {
-  static constexpr bool UNSUPPORTED_DELIBERATELY = false;
   static constexpr bool UNSUPPORTED_TODO = false;
   static constexpr bool SUPPORTED = true;
 }
@@ -48,7 +47,7 @@ doConfigureStaticCapabilities(Server* ctx, ServerCapabilities& x) {
   x.textDocumentSync                  = configureTextDocumentSync(ctx);
   x.hoverProvider                     = UNSUPPORTED_TODO;
   x.declarationProvider               = SUPPORTED;
-  x.definitionProvider                = UNSUPPORTED_DELIBERATELY;
+  x.definitionProvider                = SUPPORTED;
   x.typeDefinitionProvider            = UNSUPPORTED_TODO;
   x.implementationProvider            = UNSUPPORTED_TODO;
   x.referencesProvider                = UNSUPPORTED_TODO;

--- a/tools/chpldef/compute-synchronization.cpp
+++ b/tools/chpldef/compute-synchronization.cpp
@@ -57,7 +57,17 @@ DidOpen::ComputeResult DidOpen::compute(Server* ctx, ComputeParams p) {
 
 template<>
 DidChange::ComputeResult DidChange::compute(Server* ctx, ComputeParams p) {
-  CHPLDEF_TODO();
+  auto& tdi = p.textDocument;
+  auto& e = ctx->mutableTextRegistry()[tdi.uri];
+
+  ctx->withChapel(Server::CHPL_BUMP_REVISION, [&](auto chapel) {
+    auto& fc = chpl::parsing::fileText(chapel, tdi.uri);
+    CHPL_ASSERT(!fc.error());
+    // TODO: should be using versions
+    // e.version = tdi.version;
+    e.lastRevisionContentsUpdated = ctx->revision();
+  });
+
   return {};
 }
 
@@ -70,7 +80,11 @@ DidSave::ComputeResult DidSave::compute(Server* ctx, ComputeParams p) {
 
 template<>
 DidClose::ComputeResult DidClose::compute(Server* ctx, ComputeParams p) {
-  CHPLDEF_TODO();
+  auto& tdi = p.textDocument;
+  // TODO: error checking
+  if(ctx->mutableTextRegistry().count(tdi.uri) > 0) {
+    ctx->mutableTextRegistry().erase(tdi.uri);
+  }
   return {};
 }
 

--- a/tools/chpldef/protocol-types.cpp
+++ b/tools/chpldef/protocol-types.cpp
@@ -42,6 +42,7 @@ static void doAddField(chpldef::JsonObject& obj, const char* name,
 
 /** Helper to make reading JSON object fields less painful. */
 #define MAP_(m__, name__) (m__.map(#name__, name__))
+#define MAP_OPTIONAL_(m__, name__) (m__.mapOptional(#name__, name__))
 
 namespace chpldef {
 
@@ -204,9 +205,18 @@ bool DidCloseParams::fromJson(const JsonValue& j, JsonPath p) {
   return m && MAP_(m, textDocument);
 }
 
+bool TextDocumentContentChangeEvent::fromJson(const JsonValue& j, JsonPath p) {
+  JsonMapper m(j, p);
+  if (m) {
+    m.mapOptional("range", range);
+    return MAP_(m, text);
+  }
+  return false;
+}
+
 bool DidChangeParams::fromJson(const JsonValue& j, JsonPath p) {
   JsonMapper m(j, p);
-  return m && MAP_(m, textDocument);
+  return m && MAP_(m, textDocument) && MAP_(m, contentChanges);
 }
 
 JsonValue SaveOptions::toJson() const {

--- a/tools/chpldef/protocol-types.h
+++ b/tools/chpldef/protocol-types.h
@@ -238,31 +238,6 @@ struct DidOpenParams : ProtocolTypeRecv {
   virtual bool fromJson(const JsonValue& j, JsonPath p) override;
 };
 
-struct DidChangeParams : ProtocolTypeRecv {
-  TextDocumentItem textDocument;
-
-  virtual bool fromJson(const JsonValue& j, JsonPath p) override;
-};
-
-struct DidSaveParams : ProtocolTypeRecv {
-  TextDocumentItem textDocument;
-
-  virtual bool fromJson(const JsonValue& j, JsonPath p) override;
-};
-
-struct DidCloseParams : ProtocolTypeRecv {
-  TextDocumentItem textDocument;
-
-  virtual bool fromJson(const JsonValue& j, JsonPath p) override;
-};
-
-struct TextDocumentIdentifier : ProtocolTypeRecv {
-  std::string uri;
-
-  TextDocumentIdentifier() = default;
-  TextDocumentIdentifier(std::string uri) : uri(std::move(uri)) {}
-  virtual bool fromJson(const JsonValue& j, JsonPath p) override;
-};
 
 struct Position : ProtocolType {
   uint64_t line = 0;            /** Zero-based position. */
@@ -314,6 +289,50 @@ struct Range : ProtocolType {
 
   /** Determine if the end position is less than the start position. */
   bool isNegative() const;
+};
+
+
+struct TextDocumentContentChangeEvent : ProtocolTypeRecv {
+	Range range;
+	std::string text;
+
+  TextDocumentContentChangeEvent() = default;
+  TextDocumentContentChangeEvent(Range range, std::string text)
+    : range(std::move(range)), text(text)  {}
+  virtual bool fromJson(const JsonValue& j, JsonPath p) override;
+};
+
+
+struct TextDocumentIdentifier : ProtocolTypeRecv {
+  std::string uri;
+
+  TextDocumentIdentifier() = default;
+  TextDocumentIdentifier(std::string uri) : uri(std::move(uri)) {}
+  virtual bool fromJson(const JsonValue& j, JsonPath p) override;
+};
+
+// TODO: DidChange actually takes `VersionedTextDocumentIdentifier`, but thats not implemented yet and this works well enough for now
+struct DidChangeParams : ProtocolTypeRecv {
+  TextDocumentIdentifier textDocument;
+
+  std::vector<TextDocumentContentChangeEvent> contentChanges;
+
+DidChangeParams() = default;
+  DidChangeParams(TextDocumentIdentifier textDocument, std::vector<TextDocumentContentChangeEvent> contentChanges)
+    : textDocument(std::move(textDocument)), contentChanges(std::move(contentChanges))  {}
+  virtual bool fromJson(const JsonValue& j, JsonPath p) override;
+};
+
+struct DidSaveParams : ProtocolTypeRecv {
+  TextDocumentItem textDocument;
+
+  virtual bool fromJson(const JsonValue& j, JsonPath p) override;
+};
+
+struct DidCloseParams : ProtocolTypeRecv {
+  TextDocumentIdentifier textDocument;
+
+  virtual bool fromJson(const JsonValue& j, JsonPath p) override;
 };
 
 struct TextDocumentPositionParams : ProtocolTypeRecv {

--- a/tools/chpldef/protocol-types.h
+++ b/tools/chpldef/protocol-types.h
@@ -293,8 +293,8 @@ struct Range : ProtocolType {
 
 
 struct TextDocumentContentChangeEvent : ProtocolTypeRecv {
-	Range range;
-	std::string text;
+  Range range;
+  std::string text;
 
   TextDocumentContentChangeEvent() = default;
   TextDocumentContentChangeEvent(Range range, std::string text)


### PR DESCRIPTION
Fixes a few things in chpldef to allow it to build and run. Also extends it to work on the standard library.

Enabled the definition provider, as in vscode this is by default tied to a keybinding while the declaration provider is not.



[Reviewed by @]