### PR TITLE
Update line numbers in .good for #24136

### DIFF
--- a/test/gpu/native/noGpu/basicMem.comm-none.good
+++ b/test/gpu/native/noGpu/basicMem.comm-none.good
@@ -1,12 +1,12 @@
 0 (gpu 0): basicMem.chpl:5: allocate 88B of domain(1,int(64),one) at 0xPREDIFFED
 0 (gpu 0): basicMem.chpl:5: allocate 168B of [domain(1,int(64),one)] int(64) at 0xPREDIFFED
 0 (gpu 0): basicMem.chpl:5: allocate 80B of array elements at 0xPREDIFFED
-0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1517: allocate 48B of metadata about kernel parameters at 0xPREDIFFED
-0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1517: allocate 40B of array of pointers to kernel args at 0xPREDIFFED
-0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1517: allocate 5B of metadata about kernel parameters at 0xPREDIFFED
-0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1517: free 5B of metadata about kernel parameters at 0xPREDIFFED
-0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1517: free 40B of array of pointers to kernel args at 0xPREDIFFED
-0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1517: free 48B of metadata about kernel parameters at 0xPREDIFFED
+0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1513: allocate 48B of metadata about kernel parameters at 0xPREDIFFED
+0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1513: allocate 40B of array of pointers to kernel args at 0xPREDIFFED
+0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1513: allocate 5B of metadata about kernel parameters at 0xPREDIFFED
+0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1513: free 5B of metadata about kernel parameters at 0xPREDIFFED
+0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1513: free 40B of array of pointers to kernel args at 0xPREDIFFED
+0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1513: free 48B of metadata about kernel parameters at 0xPREDIFFED
 0 (gpu 0): basicMem.chpl:5: free 80B of array elements at 0xPREDIFFED
 0 (gpu 0): basicMem.chpl:5: free 168B of [domain(1,int(64),one)] int(64) at 0xPREDIFFED
 0 (gpu 0): basicMem.chpl:5: free 88B of domain(1,int(64),one) at 0xPREDIFFED

--- a/test/gpu/native/noGpu/basicMem.good
+++ b/test/gpu/native/noGpu/basicMem.good
@@ -3,12 +3,12 @@
 0 (gpu 0): basicMem.chpl:5: allocate 88B of domain(1,int(64),one) at 0xPREDIFFED
 0 (gpu 0): basicMem.chpl:5: allocate 168B of [domain(1,int(64),one)] int(64) at 0xPREDIFFED
 0 (gpu 0): basicMem.chpl:5: allocate 80B of array elements at 0xPREDIFFED
-0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1517: allocate 48B of metadata about kernel parameters at 0xPREDIFFED
-0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1517: allocate 40B of array of pointers to kernel args at 0xPREDIFFED
-0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1517: allocate 5B of metadata about kernel parameters at 0xPREDIFFED
-0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1517: free 5B of metadata about kernel parameters at 0xPREDIFFED
-0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1517: free 40B of array of pointers to kernel args at 0xPREDIFFED
-0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1517: free 48B of metadata about kernel parameters at 0xPREDIFFED
+0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1513: allocate 48B of metadata about kernel parameters at 0xPREDIFFED
+0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1513: allocate 40B of array of pointers to kernel args at 0xPREDIFFED
+0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1513: allocate 5B of metadata about kernel parameters at 0xPREDIFFED
+0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1513: free 5B of metadata about kernel parameters at 0xPREDIFFED
+0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1513: free 40B of array of pointers to kernel args at 0xPREDIFFED
+0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1513: free 48B of metadata about kernel parameters at 0xPREDIFFED
 0 (gpu 0): basicMem.chpl:5: free 80B of array elements at 0xPREDIFFED
 0 (gpu 0): basicMem.chpl:5: free 168B of [domain(1,int(64),one)] int(64) at 0xPREDIFFED
 0 (gpu 0): basicMem.chpl:5: free 88B of domain(1,int(64),one) at 0xPREDIFFED


### PR DESCRIPTION
This PR updates .good files with line numbers that changed due to #24136.

Could we instead prediff-out these line numbers?

Yes, by copying from one of multiple existing prediff scripts (possibly using a more specific path) that contain this:

```bash
!/usr/bin/env bash
# Ignore line numbers in modules.

sed '\|CHPL_HOME/modules|s/:[0-9]*:/:nnnn:/' $2 > $2.tmp
mv $2.tmp $2
```

SHOULD we prediff-out the these line numbers?

Citing Engin, "this is one of those cases where it is not as clear to me: this is a memory diagnostic test, and it is kind of important to see which line numbers are producing the message." So I choose to retain the (very mild) maintenance burden of keeping the explicit line numbers in order to provide more robust testing.

For a general background, we apply the above prediff conversion in 50+ .prediff and PREDIFF scripts. Furthermore we convert such line numbers automatically when comparing against .bad files, see `diff-ignoring-module-line-numbers`. We may want to make this conversion automatic for .good files as well, which I am leaving outside the scope of this PR.