### PR TITLE
Add a 'visitor' API to chapel-py

### DIFF
--- a/tools/chapel-py/setup.py
+++ b/tools/chapel-py/setup.py
@@ -49,6 +49,6 @@ LDFLAGS += ["-L{}".format(chpl_lib_path), "-lChplFrontendShared", "-Wl,-rpath", 
 setup(name = "chapel",
       version = "0.1",
       package_dir = {'': 'src'},
-      packages = ['chapel', 'chapel.replace'],
+      packages = ['chapel', 'chapel.replace', 'chapel.visitor'],
       ext_modules = [Extension("chapel.core", glob.glob("src/*.cpp"), extra_compile_args = CXXFLAGS, extra_link_args=LDFLAGS)]
       )

--- a/tools/chapel-py/src/chapel/visitor/__init__.py
+++ b/tools/chapel-py/src/chapel/visitor/__init__.py
@@ -1,0 +1,90 @@
+import chapel.core
+
+from collections import defaultdict
+from inspect import signature
+
+def _try_call(dispatch_table, visitor, node, method_type):
+    node_type = type(node)
+    while node_type is not object:
+        if node_type in dispatch_table:
+            methods = dispatch_table[node_type]
+            if method_type in methods:
+                return [methods[method_type](visitor, node)]
+        node_type = node_type.__base__
+    return None
+
+def _visitor_visit(dispatch_table):
+    def _do_visit(self, node):
+        if isinstance(node, list):
+            for child in node:
+                _do_visit(self, child)
+            return
+
+        if _try_call(dispatch_table, self, node, "enter") != [False]:
+            for child in node:
+                _do_visit(self, child)
+        _try_call(dispatch_table, self, node, "exit")
+    return _do_visit
+
+def enter(method):
+    """
+    Annotates a class method as being an 'enter' function. An 'enter'
+    function is called on a node before its children are visited. If
+    it returns a boolean, this boolean is used to determine whether or not
+    the children are visited. Returning 'False' indicates that children
+    should be skipped; returning 'True' indicates that children should be
+    visited.
+
+    The 'exit' function is always called, even if the children were not
+    visited.
+    """
+    method.__chapel_visitor_method__ = "enter"
+    return method
+
+def exit(method):
+    """
+    Annotates a class method as being an 'exit' function. An 'exit'
+    function is called after a node's children were (or would have been)
+    visited.
+    """
+    method.__chapel_visitor_method__ = "exit"
+    return method
+
+def visitor(clazz):
+    """
+    Marks a class as being a visitor. This will add a 'visit' method to
+    the class (overriding one if it exists), which can be used to recursively
+    traverse an AST. The behavior of the 'visit' method is controlled via
+    other methods defined on the class, particularly those annotated with
+    @enter and @exit.
+
+    The traversal proceeds by means of 'enter' and 'exit' functions; see
+    the documentation for those functions for more information. Enter
+    and exit functions are both expected to take a single argument in addition
+    to 'self': the node type being visited. A type annotation is required,
+    and is used to determine what type of node the function should operate on.
+    """
+
+    dispatch_table = defaultdict(lambda: {})
+
+    # Detect all visitor-like methods.
+    for name, var in vars(clazz).items():
+        if not callable(var): continue
+        if not hasattr(var, "__chapel_visitor_method__"): continue
+
+        sig = signature(var)
+        if 'self' not in sig.parameters: continue
+        if len(sig.parameters) != 2: continue
+
+        # Detect the type of the second argument. It's an OrderedDict
+        # so we can use numbers.
+        arg = list(sig.parameters.values())[1]
+
+        # Check if the type is a subtype of AstNode
+        if not issubclass(arg.annotation, chapel.core.AstNode): continue
+
+        dispatch_table[arg.annotation][var.__chapel_visitor_method__] = var
+
+    clazz.visit = _visitor_visit(dispatch_table)
+    return clazz
+

--- a/tools/chapel-py/src/chapel/visitor/__init__.py
+++ b/tools/chapel-py/src/chapel/visitor/__init__.py
@@ -1,3 +1,22 @@
+#
+# Copyright 2024 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import chapel.core
 
 from collections import defaultdict


### PR DESCRIPTION
Example Python code:

```Python
from chapel import *
from chapel.core import *
from chapel.visitor import *
from inspect import signature
from collections import defaultdict


@visitor
class Test:
    @enter
    def enter_named_decl(self, x: NamedDecl):
        print("Entering a named decl with name " + x.name())

    @enter
    def enter_ident(self, x: Identifier):
        print("Entering an identifier with name " + x.name())

    @exit
    def exit_ident(self, x: Identifier):
        print("Exiting an identifier with name " + x.name())

    @enter
    def enter_opcall(self, x: OpCall):
        print("Entering an op with name " + x.op() + ", and not visiting the children.")
        return False

    @exit
    def exit_opcall(self, x: OpCall):
        print("Exiting the op.")

context = Context()
asts = context.parse("fib.chpl")

Test().visit(asts)
```

This roughly mirrors Dyno's C++ visitors, but with a few notable differences:
* It's all done at 'runtime' in Python vita decorators and a light sprinkle of metaprogramming.
* The absence of a general 'visit' method is allowed, and treated as a no-op (empty `enter` visits children). This makes it possible to write a visitor with very little code.
* Since Python doesn't have overloading, type hints are used to determine which method should be called on which node.
* `@exit` and `@enter`, rather than proper naming, are used to denote enter and exit functions.

Reviewed by @jabraham17 -- thanks!