### PR TITLE
--print-additional-errors : another use

### DIFF
--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -68,9 +68,9 @@ bool       isTupleContainingAnyReferences(Type* t);
 void       ensureEnumTypeResolved(EnumType* etype);
 
 bool       tryingToResolve();
-
 void       resolveFnForCall(FnSymbol* fn, CallExpr* call);
 FnSymbol*  tryResolveFunction(FnSymbol* fn);
+void       printCallstackForLastError();
 
 bool       canInstantiate(Type* actualType, Type* formalType);
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -11019,8 +11019,10 @@ static bool isStringLiteral(Symbol* sym) {
 
 // This enables printing the callstack for the error.
 static void reportPostponedError(BaseAST* ref, const char* errorMessage) {
-  if (fPrintAdditionalErrors)
+  if (fPrintAdditionalErrors) {
     USR_WARN(ref, "postponed error: %s", errorMessage);
+    printCallstackForLastError(); // this info may get lost later
+  }
 }
 
 static void resolveExprMaybeIssueError(CallExpr* call) {

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -11017,6 +11017,12 @@ static bool isStringLiteral(Symbol* sym) {
   return retval;
 }
 
+// This enables printing the callstack for the error.
+static void reportPostponedError(BaseAST* ref, const char* errorMessage) {
+  if (fPrintAdditionalErrors)
+    USR_WARN(ref, "postponed error: %s", errorMessage);
+}
+
 static void resolveExprMaybeIssueError(CallExpr* call) {
   //
   // Disable compiler warnings in internal modules that are triggered within
@@ -11115,6 +11121,8 @@ static void resolveExprMaybeIssueError(CallExpr* call) {
         if (FnSymbol* fn = callStack.v[head]->resolvedFunction())
           outerCompilerErrorMap[fn] = str;
       } else {
+        reportPostponedError(from, str);
+
         tryResolveStates.back() = CHECK_FAILED;
 
         if (tryResolveFunctions.size() > 0) {

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -516,7 +516,7 @@ static void printCallstack(FnSymbol* errFn, FnSymbol* prevFn,
 // Print instantiation information for err_fn.
 // Should be called at USR_STOP or just before the next
 // error changing err_fn is printed.
-static void printCallstackForLastError() {
+void printCallstackForLastError() {
   if (err_fn_header_printed && err_fn) {
     // Clear out err_fn to avoid infinite loop if an error
     // is encountered when printing the call stack.

--- a/test/functions/resolution/errors/printAdditionalErrors-1.all.good
+++ b/test/functions/resolution/errors/printAdditionalErrors-1.all.good
@@ -1,0 +1,15 @@
+printAdditionalErrors-1.chpl:8: In function 'f1':
+printAdditionalErrors-1.chpl:9: warning: postponed error: fatal error in f1()
+  $CHPL_HOME/modules/standard/Reflection.chpl:293: called as f1(x: int(64)) from function 'canResolve'
+  printAdditionalErrors-1.chpl:17: called as canResolve(param fname = "f1", args(0): int(64)) from module 'printAdditionalErrors-1'
+printAdditionalErrors-1.chpl:19: warning: NOOOO, f1() does not resolve
+printAdditionalErrors-1.chpl:11: In function 'f2':
+printAdditionalErrors-1.chpl:12: error: cannot initialize 'y' of type 'int(8)' from a 'int(64)'
+printAdditionalErrors-1.chpl:22: warning: YESSS, f2() resolves
+printAdditionalErrors-1.chpl:14: In function 'f3':
+printAdditionalErrors-1.chpl:15: error: unresolved call 'f1(3, 4)'
+printAdditionalErrors-1.chpl:8: note: this candidate did not match: f1(x: int)
+printAdditionalErrors-1.chpl:15: note: because call includes 2 arguments
+printAdditionalErrors-1.chpl:8: note: but function can only accept 1 argument
+  $CHPL_HOME/modules/standard/Reflection.chpl:293: called as f3(x: int(64)) from function 'canResolve'
+  printAdditionalErrors-1.chpl:25: called as canResolve(param fname = "f3", args(0): int(64)) from module 'printAdditionalErrors-1'

--- a/test/functions/resolution/errors/printAdditionalErrors-1.chpl
+++ b/test/functions/resolution/errors/printAdditionalErrors-1.chpl
@@ -1,0 +1,29 @@
+// 2024-01 Vass: this test locks in the existing behavior.
+// Today's behavior for f2 and f3 is questionable,
+// especially that canResolve("f3"...) aborts compilation,
+// so feel free to improve.
+
+use Reflection;
+
+proc f1(x: int) do
+  compilerError("fatal error in f1()");
+
+proc f2(x: int) do
+  const y: int(8) = x;  // error: int(8) <-- int(64)
+
+proc f3(x: int) do
+  f1(3,4);              // error: f1 accepts only one argument
+
+if canResolve("f1", 5)
+  then compilerWarning("YESSS, f1() resolves");
+  else compilerWarning("NOOOO, f1() does not resolve");
+
+if canResolve("f2", 5)
+  then compilerWarning("YESSS, f2() resolves");
+  else compilerWarning("NOOOO, f2() does not resolve");
+
+if canResolve("f3", 5)
+  then compilerWarning("YESSS, f3() resolves");
+  else compilerWarning("NOOOO, f3() does not resolve");
+
+compilerError("SUCCESSFULL COMPILATION");

--- a/test/functions/resolution/errors/printAdditionalErrors-1.compopts
+++ b/test/functions/resolution/errors/printAdditionalErrors-1.compopts
@@ -1,2 +1,3 @@
-                           # printAdditionalErrors-1.dflt.good
---print-additional-errors  # printAdditionalErrors-1.pae.good
+                                                     # printAdditionalErrors-1.dflt.good
+--print-additional-errors                            # printAdditionalErrors-1.pae.good
+--print-additional-errors --print-callstack-on-error # printAdditionalErrors-1.all.good

--- a/test/functions/resolution/errors/printAdditionalErrors-1.compopts
+++ b/test/functions/resolution/errors/printAdditionalErrors-1.compopts
@@ -1,0 +1,2 @@
+                           # printAdditionalErrors-1.dflt.good
+--print-additional-errors  # printAdditionalErrors-1.pae.good

--- a/test/functions/resolution/errors/printAdditionalErrors-1.dflt.good
+++ b/test/functions/resolution/errors/printAdditionalErrors-1.dflt.good
@@ -1,0 +1,9 @@
+printAdditionalErrors-1.chpl:19: warning: NOOOO, f1() does not resolve
+printAdditionalErrors-1.chpl:11: In function 'f2':
+printAdditionalErrors-1.chpl:12: error: cannot initialize 'y' of type 'int(8)' from a 'int(64)'
+printAdditionalErrors-1.chpl:22: warning: YESSS, f2() resolves
+printAdditionalErrors-1.chpl:14: In function 'f3':
+printAdditionalErrors-1.chpl:15: error: unresolved call 'f1(3, 4)'
+printAdditionalErrors-1.chpl:8: note: this candidate did not match: f1(x: int)
+printAdditionalErrors-1.chpl:15: note: because call includes 2 arguments
+printAdditionalErrors-1.chpl:8: note: but function can only accept 1 argument

--- a/test/functions/resolution/errors/printAdditionalErrors-1.pae.good
+++ b/test/functions/resolution/errors/printAdditionalErrors-1.pae.good
@@ -1,0 +1,11 @@
+printAdditionalErrors-1.chpl:8: In function 'f1':
+printAdditionalErrors-1.chpl:9: warning: postponed error: fatal error in f1()
+printAdditionalErrors-1.chpl:19: warning: NOOOO, f1() does not resolve
+printAdditionalErrors-1.chpl:11: In function 'f2':
+printAdditionalErrors-1.chpl:12: error: cannot initialize 'y' of type 'int(8)' from a 'int(64)'
+printAdditionalErrors-1.chpl:22: warning: YESSS, f2() resolves
+printAdditionalErrors-1.chpl:14: In function 'f3':
+printAdditionalErrors-1.chpl:15: error: unresolved call 'f1(3, 4)'
+printAdditionalErrors-1.chpl:8: note: this candidate did not match: f1(x: int)
+printAdditionalErrors-1.chpl:15: note: because call includes 2 arguments
+printAdditionalErrors-1.chpl:8: note: but function can only accept 1 argument

--- a/test/functions/resolution/errors/printAdditionalErrors-2.chpl
+++ b/test/functions/resolution/errors/printAdditionalErrors-2.chpl
@@ -1,0 +1,19 @@
+use Reflection;
+
+var bye = chpl__coerceMove("hi", false);
+
+pragma "coerce fn"
+proc chpl__coerceMove(hi:string, b: bool) {
+  // Curiously, if we call asdf() directly, its compilerError()
+  // aborts compilation directly, without getting postponed
+  // or reporting "invalid copy-initialization":
+  //asdf(5);
+
+  // This results in a postponed error and "invalid copy-initialization":
+  canResolve("asdf", 5);
+
+  return "bye";
+}
+
+proc asdf(x: int) do
+  compilerError("fatal error in asdf", 0);

--- a/test/functions/resolution/errors/printAdditionalErrors-2.compopts
+++ b/test/functions/resolution/errors/printAdditionalErrors-2.compopts
@@ -1,0 +1,1 @@
+--print-additional-errors --print-callstack-on-error

--- a/test/functions/resolution/errors/printAdditionalErrors-2.good
+++ b/test/functions/resolution/errors/printAdditionalErrors-2.good
@@ -1,0 +1,7 @@
+printAdditionalErrors-2.chpl:18: In function 'asdf':
+printAdditionalErrors-2.chpl:19: warning: postponed error: fatal error in asdf
+  $CHPL_HOME/modules/standard/Reflection.chpl:293: called as asdf(x: int(64)) from function 'canResolve'
+  printAdditionalErrors-2.chpl:13: called as canResolve(param fname = "asdf", args(0): int(64)) from function 'chpl__coerceMove'
+  printAdditionalErrors-2.chpl:3: called as chpl__coerceMove(hi: string, b: bool) from module 'printAdditionalErrors-2'
+printAdditionalErrors-2.chpl:3: error: invalid copy-initialization
+printAdditionalErrors-2.chpl:3: error: fatal error in asdf


### PR DESCRIPTION
This PR enables the existing compiler option `--print-additional-errors` to print errors that are being postponed, ex., when resolving copy initialization, such as chpl__coerceCopy and chpl__coerceMove, as in `var B = (an array slice);`.

The benefit is that this enables printing the call stack leading to such an error. When a postponed error is finally printed, if at all, the call stack is no longer available. Without a call stack, it is often impossible to detect the cause of the error without running the compiler under the debugger.

Next steps: have the compiler recommend compiling with `--print-additional-errors` when this can explain the final compilation error.

Testing: standard and gasnet paratests; distribution robustness suite.