### PR TITLE
Driver mode nightly failure bug fixes

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -3058,6 +3058,12 @@ void makeBinary(void) {
   // (Unless we're doing GPU codegen, which currently happens in the compilation
   // phase.)
   INT_ASSERT(!fDriverCompilationPhase || gCodegenGPU);
+  if (!fDriverDoMonolithic) {
+    // Setup/restore filenames to be referenced in makeBinary phase.
+    setupDefaultFilenames();
+    restoreAdditionalSourceFiles();
+    restoreLibraryAndIncludeInfo();
+  }
 
   if(fLlvmCodegen) {
 #ifdef HAVE_LLVM

--- a/compiler/codegen/mli.cpp
+++ b/compiler/codegen/mli.cpp
@@ -35,10 +35,9 @@
 #include <map>
 #include <sstream>
 
-// These are populated after 'codegenMultiLocaleInteropWrappers' is done.
-const char* gMultiLocaleLibMarshallingFile = NULL;
-const char* gMultiLocaleLibClientFile = NULL;
-const char* gMultiLocaleLibServerFile = NULL;
+const char* gMultiLocaleLibMarshallingFile = "chpl_mli_marshalling.c";
+const char* gMultiLocaleLibClientFile = "chpl_mli_client.c";
+const char* gMultiLocaleLibServerFile = "chpl_mli_server.c";
 
 const char* mliClientRuntimeSource = "chpl-mli-client-runtime.c";
 const char* mliServerRuntimeSource = "chpl-mli-server-runtime.c";
@@ -170,9 +169,9 @@ MLIContext::MLIContext(bool debugPrint) {
 
   this->debugPrint = debugPrint;
 
-  openCFile(&this->fiMarshalling, "chpl_mli_marshalling", "c");
-  openCFile(&this->fiClientBundle, "chpl_mli_client", "c");
-  openCFile(&this->fiServerBundle, "chpl_mli_server", "c");
+  openCFile(&this->fiMarshalling, gMultiLocaleLibMarshallingFile);
+  openCFile(&this->fiClientBundle, gMultiLocaleLibClientFile);
+  openCFile(&this->fiServerBundle, gMultiLocaleLibServerFile);
 
   INT_ASSERT(gGenInfo != NULL);
   this->info = gGenInfo;
@@ -181,12 +180,6 @@ MLIContext::MLIContext(bool debugPrint) {
 }
 
 MLIContext::~MLIContext() {
-
-  if (NULL == gMultiLocaleLibMarshallingFile) {
-    gMultiLocaleLibMarshallingFile = this->fiMarshalling.filename;
-    gMultiLocaleLibClientFile = this->fiClientBundle.filename;
-    gMultiLocaleLibServerFile = this->fiServerBundle.filename;
-  }
 
   closeCFile(&this->fiMarshalling, true);
   closeCFile(&this->fiClientBundle, true);

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -4877,11 +4877,7 @@ void makeBinaryLLVM(void) {
 
     initializeGenInfo();
 
-    // setup filenames to be referenced
     setupLLVMCodegenFilenames();
-    setupDefaultFilenames();
-    restoreAdditionalSourceFiles();
-    restoreLibraryAndIncludeInfo();
 
     // regenerate ClangInfo
     assert(!gGenInfo->clangInfo);

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -3014,7 +3014,6 @@ void runClang(const char* just_parse_filename) {
 
       // Include the contents of the server bundle...
       clangOtherArgs.push_back("-include");
-      INT_ASSERT(gMultiLocaleLibServerFile != NULL);
       clangOtherArgs.push_back(gMultiLocaleLibServerFile);
 
       // As well as the path to extra code for the client and server.

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -889,8 +889,8 @@ void codegen_makefile(fileinfo* mainfile, const char** tmpbinname,
   // List source files needed to compile this deliverable.
   if (fMultiLocaleInterop) {
 
-    const char* client = astr(gContext->tmpDir().c_str(), "/", gMultiLocaleLibClientFile);
-    const char* server = astr(gContext->tmpDir().c_str(), "/", gMultiLocaleLibServerFile);
+    const char* client = genIntermediateFilename(gMultiLocaleLibClientFile);
+    const char* server = genIntermediateFilename(gMultiLocaleLibServerFile);
 
     // Only one source file for client (for now).
     fprintf(makefile.fptr, "CHPLSRC = \\\n");


### PR DESCRIPTION
Fix remaining bugs that came up in nightly testing when driver mode was turned on by default.

Fixes:
- Multilocale C interop failures, due to `gMultiLocaleLibServerFile` not being initialized in the makeBinary phase. This was getting set to a constant in the compilation phase anyways, so refactored to just always initialize it with the constant.
- `make-install-check` failures, due to a quirk causing `CHPL_RUNTIME_DIR` to be set incorrectly in sub-invocations for a prefix install. This occurs in `setChplHome`, which is also responsible for setting `CHPL_HOME` and the corresponding environment variable. However, if it detects `CHPL_HOME` is already set in an environment variable, it happens to skip the `CHPL_RUNTIME_DIR` adjustment logic, and it's always the case the environment variable is set in sub-invocations. Since `CHPL_RUNTIME_DIR` and other "chpl home derived variables" also get set to the environment by the driver process, made `setChplHome` read them in from the environment and use those values if present.
- Python interop failures, due to `setupDefaultFilenames` not being run for the makeBinary part of Python compilation, so the Python module name was left blank. Moved the call to it and other filename-setup functions in the makeBinary-phase branch of `makeBinaryLLVM` to close to the top of `makeBinary` itself.

Reviewer notes: Each fix is one commit, matching the order of the above bullets.

[reviewer info placeholder]

Testing:
(each with and without `--compiler-driver`)
- [x] paratest
- [x] C backend paratest
- [x] gasnet paratest