### PR TITLE
Documentation updates for split-init and copy elision

### DIFF
--- a/doc/rst/language/spec/variables.rst
+++ b/doc/rst/language/spec/variables.rst
@@ -176,7 +176,8 @@ contain an initialization expression of the same type.
 
 Any variables declared in a particular scope that are initialized with
 split init in multiple branches of a conditional or ``select``
-must be initialized in the same order in all branches.
+must be initialized in the same order in all branches that do not
+unconditionally return.
 
    *Example (simple-split-init.chpl)*
 

--- a/doc/rst/language/spec/variables.rst
+++ b/doc/rst/language/spec/variables.rst
@@ -1129,6 +1129,23 @@ Copy elision does not apply:
       }
       elideCopyBothConditional();
 
+      proc elideCopyParamSelect() {
+        type T = int;
+        var x = makeRecord();
+        var y = x; // copy elided
+        select T {
+          when real {
+            writeln(x);
+          }
+          when string {
+            writeln(x);
+          }
+          otherwise {
+            writeln(y); // compiler can determine this is the only possible branch
+          }
+        }
+      }
+      elideCopyParamSelect();
    .. BLOCK-test-chapeloutput
 
       init (default)
@@ -1145,6 +1162,8 @@ Copy elision does not apply:
       deinit 0
       init (default)
       block ending
+      deinit 0
+      init (default)
       deinit 0
 
 


### PR DESCRIPTION
The docs now reflect the DCE behavior for split-init and copy elision in pull request #24080. I added more examples and reformulated the exceptions for clarity. It should now be a bit easier to understand when copy elision and split-init do not apply. Once reviewed, I'll wait until the DCE pull request is merged to merge this one so that the docs reflect the compiler behavior.