### PR TITLE
Add a license comment to a new file

### DIFF
--- a/frontend/test/resolution/testTestPrimitives.cpp
+++ b/frontend/test/resolution/testTestPrimitives.cpp
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2024 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <vector>
 #include "test-resolution.h"
 #include "chpl/resolution/resolution-queries.h"


### PR DESCRIPTION
CI checks didn't catch this one because I opened the PR before the error period, I suppose.

Trivial, will not be reviewed.