### PR TITLE
Remove deprecated owned.borrow type method

### DIFF
--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -293,16 +293,6 @@ module OwnedObject {
     }
   }
 
-  @deprecated("calling `.borrow()` on an `owned` type is deprecated - please use a cast to `borrowed` instead")
-  proc type _owned.borrow() type {
-    if _to_nilable(chpl_t) == chpl_t {
-      return chpl_t;
-    } else {
-      return _to_nonnil(chpl_t);
-    }
-  }
-
-
   /*
     Assignment between two :type:`owned` transfers ownership of the object
     managed by ``rhs`` to ``lhs``. This is done by setting ``rhs`` to `nil` and

--- a/test/deprecated/deprecateOwnedBorrow.chpl
+++ b/test/deprecated/deprecateOwnedBorrow.chpl
@@ -1,8 +1,0 @@
-
-class MyClass {
-
-}
-type t = owned MyClass;
-type t2 = t.borrow();
-type t3 = t:borrowed;
-writeln(t2 == t3);

--- a/test/deprecated/deprecateOwnedBorrow.good
+++ b/test/deprecated/deprecateOwnedBorrow.good
@@ -1,2 +1,0 @@
-deprecateOwnedBorrow.chpl:6: warning: calling `.borrow()` on an `owned` type is deprecated - please use a cast to `borrowed` instead
-true


### PR DESCRIPTION
Removed the `owned.borrow` type method, deprecated in #22997

Testing
- [x] paratest without comm
- [x] paratest with comm
- [x] build and checked docs

[Reviewed by @ShreyasKhandekar]