### PR TITLE
Remove emailer code from `testRelease`

### DIFF
--- a/util/buildRelease/testRelease
+++ b/util/buildRelease/testRelease
@@ -40,11 +40,7 @@ if ($basetmpdir eq "") {
 if ($basetmpdir eq "") {
     $basetmpdir = "/tmp";
 }
-if ($debug == 1) {
-    $tmpdir = "$basetmpdir/chapel-testRelease-dbg.$user.deleteme";
-} else {
-    $tmpdir = "$basetmpdir/chapel-testRelease-crn.$user.deleteme";
-}
+$tmpdir = "$basetmpdir/chapel-testRelease.$user.deleteme";
 
 
 $somethingfailed = 0;

--- a/util/buildRelease/testRelease
+++ b/util/buildRelease/testRelease
@@ -7,48 +7,12 @@ $cwd = abs_path(dirname(__FILE__));
 $chplhomedir = abs_path("$cwd/../..");
 
 
-# Mailing lists.
-$failuremail = "chapel+tests\@discoursemail.com";
-$allmail = "chapel-test-results-all\@lists.sourceforge.net";
-$replymail = "";
-
-$printusage = 1;
-$debug = 1;
-
-while (@ARGV) {
-    $flag = shift @ARGV;
-    if ($flag eq "-debug") {
-	$debug = 1;
-        $printusage = 0;
-    } elsif ($flag eq "-cron") {
-	$debug = 0;
-        $printusage = 0;
-    } else {
-        $printusage = 1;
-        last;
-    }
-}
-
-if ($printusage == 1) {
-    print "testRelease [-debug|-cron]\n";
-    print "\t-debug     : test the release for individual user\n";
-    print "\t-cron      : use for nightly cron runs only (mails team)\n";
-    exit 1;
-}
-
-
 #
 # get uniquifiers
 #
 $pid = getpgrp();
 $user = `whoami`;
 chomp($user);
-$debugmail = $ENV{'CHPL_NIGHTLY_DEBUG_EMAIL'};
-if ($debug == 1 && $debugmail eq "") {
-    print "Set CHPL_NIGHTLY_DEBUG_EMAIL to use debug mode\n";
-    exit 1;
-}
-
 
 
 #
@@ -83,30 +47,6 @@ if ($debug == 1) {
 }
 
 
-
-#
-# set mail options. Default to util/test/send_email.py, if available and
-# working. If not available or not working, default to 'mail'.
-#
-$mailer = $ENV{'CHPL_MAILER'};
-if ($mailer eq "") {
-    $chplsendemail = "$chplhomedir/util/test/send_email.py";
-    `$chplsendemail --help >/dev/null 2>&1`;
-    if ($? == 0) {
-        $header = "";
-        if ($replymail ne "") {
-          $header = "Reply-To=$replymail,";
-        }
-        $header .= "Precedence=bulk";
-        $mailer = "$chplsendemail --header=$header";
-    } else {
-        print "[Error: send_email.py failed to run. Defaulting to 'mail'.]\n";
-        $mailer = "mail";
-    }
-}
-print "\$mailer = $mailer\n";
-
-
 $somethingfailed = 0;
 
 
@@ -135,53 +75,6 @@ $teststatus = mysystem("cd $tmpdir/chapel-test && $chplhome/util/buildRelease/te
 
 
 #
-# send mail
-#
-if ($teststatus == 0 or $teststatus == 2) {
-    $failures = `grep \\\\[Error $tmpdir/chapel-test/examples/Logs/testReleaseHelp.log | wc -l`; chomp($failures);
-    if ($failures == "0") {
-        $shortstatus = "Passed";
-        $successmail = "$allmail";
-    } else {
-        $shortstatus = "Failed: Tests";
-        $successmail = "$failuremail";
-    }
-} else {
-    $shortstatus = "Failed: Something";
-    $successmail = "$failuremail";
-}
-if ($debug == 1) {
-    $mailsubject = "Dbug Release $shortstatus ($platform)";
-} else {
-    $mailsubject = "Cron Release $shortstatus ($platform)";
-}
-    
-if ($debug == 1) {
-    $mailcommand = "| $mailer -s \"$mailsubject \" $debugmail";
-} else {
-    $mailcommand = "| $mailer -s \"$mailsubject \" $successmail";
-}
-    
-if (!exists($ENV{"CHPL_TEST_NOMAIL"}) or grep {$ENV{"CHPL_TEST_NOMAIL"} =~ /^$_$/i} ('','\s*','0','f(alse)?','no?')) {
-    open(MAIL, $mailcommand);
-
-    print MAIL "=== Results - testRelease =================================================\n";
-    print MAIL "Hostname:   ", `hostname`;
-    print MAIL "Build: ", $buildurl, "\n";
-    print MAIL "\$tmpdir:    $tmpdir\n";
-    print MAIL "\$chplhome:  $chplhome\n";
-    print MAIL "Ended:      ", scalar(localtime()), "\n";
-    print MAIL "\n";
-
-    print MAIL `cat $tmpdir/chapel-test/examples/Logs/testReleaseHelp.log.summary`;
-    
-    close(MAIL);
-} else {
-    print "CHPL_TEST_NOMAIL: No $mailcommand\n";
-}
-    
-    
-#
 # clean up
 #
 if ($somethingfailed == 0) {
@@ -200,41 +93,15 @@ sub mysystem {
     $command = $_[0];
     $errorname = $_[1];
     $fatal = $_[2];
-    $mailmsg = $_[3];
 
     $status = system($command);
     if ($status != 0) {
-	$somethingfailed = 1;
+        $somethingfailed = 1;
         $status = $status / 256;
-	print "Error $_[1]: $status\n";
-
-    if ($mailmsg != 0) {
-        if ($debug == 1) {
-            $mailsubject = "Dbug Release Failed ($platform)";
-            $mailcommand = "| $mailer -s \"$mailsubject \" $debugmail";
-        } else {
-            $mailsubject = "Cron Release Failed ($platform)";
-            $mailcommand = "| $mailer -s \"$mailsubject \" $failuremail";
+        print "Error $_[1]: $status\n";
+        if ($fatal != 0) {
+          exit 1;
         }
-
-        if (!exists($ENV{"CHPL_TEST_NOMAIL"}) or grep {$ENV{"CHPL_TEST_NOMAIL"} =~ /^$_$/i} ('','\s*','0','f(alse)?','no?')) {
-            print "Trying to mail message... using $mailcommand\n";
-            open(MAIL, $mailcommand);
-            print MAIL "=== Summary - testRelease =====================================\n";
-            print MAIL "ERROR $_[1]: $status\n";
-            $host = `hostname`; chomp($host);
-            print MAIL "(workspace left at $host:$tmpdir)\n";
-            print MAIL "(or better, visit 'release-tarball-smoke-test' in jenkins)\n";
-            print MAIL "=== End Summary ===============================================\n";
-            close(MAIL);
-        } else {
-            print "CHPL_TEST_NOMAIL: No $mailcommand\n";
-        }
-    }
-
-	if ($fatal != 0) {
-	    exit 1;
-	}
     }
     $status;
 }

--- a/util/cron/test-release.bash
+++ b/util/cron/test-release.bash
@@ -8,4 +8,4 @@ WORKSPACE=${WORKSPACE:-$CWD/../..}
 export TMPDIR=$(mktemp -d $WORKSPACE/chapel-test-release.XXXXXX)
 export CHPL_GEN_RELEASE_TMPDIR=$TMPDIR
 
-$CWD/../buildRelease/testRelease -cron
+$CWD/../buildRelease/testRelease


### PR DESCRIPTION
Remove emailing code from `util/cron/testRelease` as it is undesired and redundant with the email sent by Jenkins.

Includes removing the `-debug` and `-cron` arguments for this script as they were used only to control emailing behavior.

Resolves https://github.com/Cray/chapel-private/issues/5763.

[reviewer info placeholder]

Testing:
- [x] manual run doesn't generate email
- [x] manual run still exits with error correctly