### PR TITLE
Fix issue with Module locations being incorrectly reported

### DIFF
--- a/frontend/lib/parsing/bison-chpl-lib.cpp
+++ b/frontend/lib/parsing/bison-chpl-lib.cpp
@@ -7062,7 +7062,7 @@ yyreduce:
       ModuleParts parts = (yyvsp[-2].moduleParts);
       ParserExprList* body = context->makeList();
       context->appendList(body, context->gatherComments((yylsp[0])));
-      auto mod = Module::build(BUILDER, LOC((yylsp[-2])), toOwned(parts.attributeGroup),
+      auto mod = Module::build(BUILDER, LOC((yyloc)), toOwned(parts.attributeGroup),
                                parts.visibility,
                                parts.name,
                                parts.kind,
@@ -7081,7 +7081,7 @@ yyreduce:
       ModuleParts parts = (yyvsp[-3].moduleParts);
       ParserExprList* body = (yyvsp[-1].exprList);
       context->appendList(body, context->gatherComments((yylsp[0])));
-      auto mod = Module::build(BUILDER, LOC((yylsp[-3])), toOwned(parts.attributeGroup),
+      auto mod = Module::build(BUILDER, LOC((yyloc)), toOwned(parts.attributeGroup),
                                parts.visibility,
                                parts.name,
                                parts.kind,
@@ -7098,7 +7098,7 @@ yyreduce:
       ModuleParts parts = (yyvsp[-3].moduleParts);
       auto err = ErroneousExpression::build(BUILDER, LOC((yylsp[-1])));
       ParserExprList* body = context->makeList(std::move(err));
-      auto mod = Module::build(BUILDER, LOC((yylsp[-3])), toOwned(parts.attributeGroup),
+      auto mod = Module::build(BUILDER, LOC((yyloc)), toOwned(parts.attributeGroup),
                                parts.visibility,
                                parts.name,
                                parts.kind,

--- a/frontend/lib/parsing/chpl.ypp
+++ b/frontend/lib/parsing/chpl.ypp
@@ -965,7 +965,7 @@ module_decl_stmt:
       ModuleParts parts = $1;
       ParserExprList* body = context->makeList();
       context->appendList(body, context->gatherComments(@3));
-      auto mod = Module::build(BUILDER, LOC(@1), toOwned(parts.attributeGroup),
+      auto mod = Module::build(BUILDER, LOC(@$), toOwned(parts.attributeGroup),
                                parts.visibility,
                                parts.name,
                                parts.kind,
@@ -980,7 +980,7 @@ module_decl_stmt:
       ModuleParts parts = $1;
       ParserExprList* body = $3;
       context->appendList(body, context->gatherComments(@4));
-      auto mod = Module::build(BUILDER, LOC(@1), toOwned(parts.attributeGroup),
+      auto mod = Module::build(BUILDER, LOC(@$), toOwned(parts.attributeGroup),
                                parts.visibility,
                                parts.name,
                                parts.kind,
@@ -993,7 +993,7 @@ module_decl_stmt:
       ModuleParts parts = $1;
       auto err = ErroneousExpression::build(BUILDER, LOC(@3));
       ParserExprList* body = context->makeList(std::move(err));
-      auto mod = Module::build(BUILDER, LOC(@1), toOwned(parts.attributeGroup),
+      auto mod = Module::build(BUILDER, LOC(@$), toOwned(parts.attributeGroup),
                                parts.visibility,
                                parts.name,
                                parts.kind,

--- a/frontend/lib/parsing/parser-error-classes-list.cpp
+++ b/frontend/lib/parsing/parser-error-classes-list.cpp
@@ -214,7 +214,7 @@ void ErrorUseImportNeedsModule::write(ErrorWriterBase& wr) const {
              "' statements must refer to module",
              (isImport ? "" : " or 'enum'"), " symbols.");
   wr.message("In the following '", useOrImport, "' statement:");
-  wr.code(loc);
+  wr.codeForLocation(loc);
 }
 
 // catch-alls for simple parsing errors

--- a/test/errors/scope-resolution/fullImportPath.1.good
+++ b/test/errors/scope-resolution/fullImportPath.1.good
@@ -1,5 +1,5 @@
-fullImportPath.chpl:9: In module 'M4':
-fullImportPath.chpl:10: error: cannot find module named 'ToLookFor'
+fullImportPath.chpl:10: In module 'M4':
+fullImportPath.chpl:11: error: cannot find module named 'ToLookFor'
 fullImportPath.chpl:3: note: a module named 'ToLookFor' is defined here
 fullImportPath.chpl:3: note: however, a full path or an explicit relative import is required for modules that are not at the root level
-fullImportPath.chpl:10: note: For non-root-level modules, please specify the full path to the module or use a relative import e.g. 'import this.M' or 'import super.M'
+fullImportPath.chpl:11: note: For non-root-level modules, please specify the full path to the module or use a relative import e.g. 'import this.M' or 'import super.M'

--- a/test/errors/scope-resolution/fullImportPath.1.good
+++ b/test/errors/scope-resolution/fullImportPath.1.good
@@ -1,5 +1,5 @@
-fullImportPath.chpl:8: In module 'M4':
-fullImportPath.chpl:9: error: cannot find module named 'ToLookFor'
+fullImportPath.chpl:9: In module 'M4':
+fullImportPath.chpl:10: error: cannot find module named 'ToLookFor'
 fullImportPath.chpl:3: note: a module named 'ToLookFor' is defined here
 fullImportPath.chpl:3: note: however, a full path or an explicit relative import is required for modules that are not at the root level
-fullImportPath.chpl:9: note: For non-root-level modules, please specify the full path to the module or use a relative import e.g. 'import this.M' or 'import super.M'
+fullImportPath.chpl:10: note: For non-root-level modules, please specify the full path to the module or use a relative import e.g. 'import this.M' or 'import super.M'

--- a/test/errors/scope-resolution/fullImportPath.2.good
+++ b/test/errors/scope-resolution/fullImportPath.2.good
@@ -1,16 +1,16 @@
-─── error in fullImportPath.chpl:9 [UseImportUnknownMod] ───
+─── error in fullImportPath.chpl:10 [UseImportUnknownMod] ───
   Cannot find module named 'ToLookFor'.
   In the following 'import' statement:
-      |
-    9 |                 import ToLookFor;
-      |                        ⎺⎺⎺⎺⎺⎺⎺⎺⎺
-      |
+       |
+    10 |                 import ToLookFor;
+       |                        ⎺⎺⎺⎺⎺⎺⎺⎺⎺
+       |
   The following declarations are not covered by the 'import' statement but seem similar to what you meant.
   
   A module named 'ToLookFor' is defined here:
       |
-    3 |     module ToLookFor {}
-      |     ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+    3 |     module ToLookFor {
+      |     ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
       |
   However, a full path or an explicit relative import is required for modules that are not at the root level.
   

--- a/test/errors/scope-resolution/fullImportPath.2.good
+++ b/test/errors/scope-resolution/fullImportPath.2.good
@@ -1,8 +1,8 @@
-─── error in fullImportPath.chpl:10 [UseImportUnknownMod] ───
+─── error in fullImportPath.chpl:11 [UseImportUnknownMod] ───
   Cannot find module named 'ToLookFor'.
   In the following 'import' statement:
        |
-    10 |                 import ToLookFor;
+    11 |                 import ToLookFor;
        |                        ⎺⎺⎺⎺⎺⎺⎺⎺⎺
        |
   The following declarations are not covered by the 'import' statement but seem similar to what you meant.

--- a/test/errors/scope-resolution/fullImportPath.chpl
+++ b/test/errors/scope-resolution/fullImportPath.chpl
@@ -1,6 +1,7 @@
 // param ToLookFor = "??";
 module M1 {
     module ToLookFor {
+      // Multiple lines on purpose to test error message printing
     }
     module M2 {
         module ToLookFor {}

--- a/test/errors/scope-resolution/fullImportPath.chpl
+++ b/test/errors/scope-resolution/fullImportPath.chpl
@@ -1,6 +1,7 @@
 // param ToLookFor = "??";
 module M1 {
-    module ToLookFor {}
+    module ToLookFor {
+    }
     module M2 {
         module ToLookFor {}
         module M3 {


### PR DESCRIPTION
Fixes the locations reported by Chapel for Modules to represent the entire module, rather than just the name. This matches how other blocked constructs report their locations like `class` and `record`.

Ran full paratest w/wo comm

[reviewed by @DanilaFe]