### PR TITLE
Skip broken colocales test

### DIFF
--- a/test/runtime/jhh/colocales/SKIPIF
+++ b/test/runtime/jhh/colocales/SKIPIF
@@ -1,0 +1,1 @@
+echo True


### PR DESCRIPTION
Skip this test until I figure out why it's broken on Jenkins but not elsewhere.