### PR TITLE
Improve how tuples are converted into complex values

### DIFF
--- a/runtime/include/chplcast.h
+++ b/runtime/include/chplcast.h
@@ -58,21 +58,15 @@ _real32 c_string_to_real32_precise(c_string str, int* invalid, char* invalidCh);
 _real64 c_string_to_real64_precise(c_string str, int* invalid, char* invalidCh);
 _imag32 c_string_to_imag32_precise(c_string str, int* invalid, char* invalidCh);
 _imag64 c_string_to_imag64_precise(c_string str, int* invalid, char* invalidCh);
-
-#ifndef __cplusplus
 _complex64 c_string_to_complex64_precise(c_string str, int* invalid, char* invalidCh);
 _complex128 c_string_to_complex128_precise(c_string str, int* invalid, char* invalidCh);
-#endif
 
 _real32 c_string_to_real32(c_string str, chpl_bool* err, int lineno, int32_t filename);
 _real64 c_string_to_real64(c_string str, chpl_bool* err, int lineno, int32_t filename);
 _imag32 c_string_to_imag32(c_string str, chpl_bool* err, int lineno, int32_t filename);
 _imag64 c_string_to_imag64(c_string str, chpl_bool* err, int lineno, int32_t filename);
-
-#ifndef __cplusplus
 _complex64 c_string_to_complex64(c_string str, chpl_bool* err, int lineno, int32_t filename);
 _complex128 c_string_to_complex128(c_string str, chpl_bool* err, int lineno, int32_t filename);
-#endif
 
 
 /* every other primitive type to string */

--- a/runtime/include/chplcast.h
+++ b/runtime/include/chplcast.h
@@ -58,15 +58,21 @@ _real32 c_string_to_real32_precise(c_string str, int* invalid, char* invalidCh);
 _real64 c_string_to_real64_precise(c_string str, int* invalid, char* invalidCh);
 _imag32 c_string_to_imag32_precise(c_string str, int* invalid, char* invalidCh);
 _imag64 c_string_to_imag64_precise(c_string str, int* invalid, char* invalidCh);
+
+#ifndef __cplusplus
 _complex64 c_string_to_complex64_precise(c_string str, int* invalid, char* invalidCh);
 _complex128 c_string_to_complex128_precise(c_string str, int* invalid, char* invalidCh);
+#endif
 
 _real32 c_string_to_real32(c_string str, chpl_bool* err, int lineno, int32_t filename);
 _real64 c_string_to_real64(c_string str, chpl_bool* err, int lineno, int32_t filename);
 _imag32 c_string_to_imag32(c_string str, chpl_bool* err, int lineno, int32_t filename);
 _imag64 c_string_to_imag64(c_string str, chpl_bool* err, int lineno, int32_t filename);
+
+#ifndef __cplusplus
 _complex64 c_string_to_complex64(c_string str, chpl_bool* err, int lineno, int32_t filename);
 _complex128 c_string_to_complex128(c_string str, chpl_bool* err, int lineno, int32_t filename);
+#endif
 
 
 /* every other primitive type to string */

--- a/runtime/include/chpltypes.h
+++ b/runtime/include/chpltypes.h
@@ -31,6 +31,8 @@
 #include <string.h>
 #include <sys/time.h> // for struct timeval
 
+// Skip complex stuff when compiling this header with C++ compiler, as for re2
+#ifndef __cplusplus
 #include <complex.h>
 typedef float _Complex        _complex64;
 typedef double _Complex       _complex128;
@@ -38,6 +40,7 @@ typedef double _Complex       _complex128;
 // clang doesn't have _Complex_I but it supports initializer lists for complex
 #ifndef _Complex_I
 static const _complex64 _Complex_I = {0.0f, 1.0f};
+#endif
 #endif
 
 #ifdef __cplusplus
@@ -254,11 +257,13 @@ typedef struct chpl_main_argument_s {
   int32_t return_value;
 } chpl_main_argument;
 
+// Skip complex stuff when compiling this header with C++ compiler, as for re2
+#ifndef __cplusplus
 static inline _complex128 _chpl_complex128(_real64 re, _real64 im) {
-  return re + im*_Complex_I;
+  return CMPLX(re, im);
 }
 static inline _complex64 _chpl_complex64(_real32 re, _real32 im) {
-  return re + im*_Complex_I;
+  return CMPLXF(re, im);
 }
 
 static inline _real64* complex128GetRealRef(_complex128* cplx) {
@@ -307,6 +312,7 @@ static inline _complex64 complexSubtract64(_complex64 c1, _complex64 c2) {
 static inline _complex64 complexUnaryMinus64(_complex64 c1) {
   return -c1;
 }
+#endif
 
 /* This should be moved somewhere else, but where is the question */
 static inline const char* chpl_get_argument_i(chpl_main_argument* args, int32_t i)

--- a/runtime/include/chpltypes.h
+++ b/runtime/include/chpltypes.h
@@ -31,8 +31,6 @@
 #include <string.h>
 #include <sys/time.h> // for struct timeval
 
-// Skip complex stuff when compiling this header with C++ compiler, as for re2
-#ifndef __cplusplus
 #include <complex.h>
 typedef float _Complex        _complex64;
 typedef double _Complex       _complex128;
@@ -40,7 +38,6 @@ typedef double _Complex       _complex128;
 // clang doesn't have _Complex_I but it supports initializer lists for complex
 #ifndef _Complex_I
 static const _complex64 _Complex_I = {0.0f, 1.0f};
-#endif
 #endif
 
 #ifdef __cplusplus
@@ -257,14 +254,20 @@ typedef struct chpl_main_argument_s {
   int32_t return_value;
 } chpl_main_argument;
 
-// Skip complex stuff when compiling this header with C++ compiler, as for re2
+// Skip these routines when cmopiling this header with the C++
+// compiler (as we do when compiling re2 headers) because these
+// CMPLX*() macros are not available in C++.  This should not be an
+// issue since we don't use complex in re2.
 #ifndef __cplusplus
+
 static inline _complex128 _chpl_complex128(_real64 re, _real64 im) {
   return CMPLX(re, im);
 }
 static inline _complex64 _chpl_complex64(_real32 re, _real32 im) {
   return CMPLXF(re, im);
 }
+
+#endif
 
 static inline _real64* complex128GetRealRef(_complex128* cplx) {
   return ((_real64*)cplx) + 0;
@@ -312,7 +315,6 @@ static inline _complex64 complexSubtract64(_complex64 c1, _complex64 c2) {
 static inline _complex64 complexUnaryMinus64(_complex64 c1) {
   return -c1;
 }
-#endif
 
 /* This should be moved somewhere else, but where is the question */
 static inline const char* chpl_get_argument_i(chpl_main_argument* args, int32_t i)

--- a/runtime/include/chpltypes.h
+++ b/runtime/include/chpltypes.h
@@ -259,8 +259,8 @@ static inline _complex128 _chpl_complex128(_real64 re, _real64 im) {
   return CMPLX(re, im);
 #else
 #ifndef CHPL_DONT_USE_CMPLX_PTR_ALIASING
-#define cmplx_re64(c) (_Generic((c), _complex128 : ((double *)&(c)))[0])
-#define cmplx_im64(c) (_Generic((c), _complex128 : ((double *)&(c)))[1])
+#define cmplx_re64(c) (((double *)&(c))[0])
+#define cmplx_im64(c) (((double *)&(c))[1])
   _complex128 val;
   cmplx_re64(val) = re;
   cmplx_im64(val) = im;
@@ -277,8 +277,8 @@ static inline _complex64 _chpl_complex64(_real32 re, _real32 im) {
   return CMPLXF(re, im);
 #else
 #ifndef CHPL_DONT_USE_CMPLX_PTR_ALIASING
-#define cmplx_re32(c) (_Generic((c), _complex64 : ((float *)&(c)))[0])
-#define cmplx_im32(c) (_Generic((c), _complex64 : ((float *)&(c)))[1])
+#define cmplx_re32(c) (((float *)&(c))[0])
+#define cmplx_im32(c) (((float *)&(c))[1])
   _complex64 val;
   cmplx_re32(val) = re;
   cmplx_im32(val) = im;

--- a/runtime/include/chpltypes.h
+++ b/runtime/include/chpltypes.h
@@ -258,7 +258,7 @@ static inline _complex128 _chpl_complex128(_real64 re, _real64 im) {
 #ifdef CMPLX
   return CMPLX(re, im);
 #else
-#ifndef DONT_USE_CMPLX_PTR_ALIASING
+#ifndef CHPL_DONT_USE_CMPLX_PTR_ALIASING
 #define cmplx_re64(c) (_Generic((c), _complex128 : ((double *)&(c)))[0])
 #define cmplx_im64(c) (_Generic((c), _complex128 : ((double *)&(c)))[1])
   _complex128 val;
@@ -276,7 +276,7 @@ static inline _complex64 _chpl_complex64(_real32 re, _real32 im) {
 #ifdef CMPLXF
   return CMPLXF(re, im);
 #else
-#ifndef DONT_USE_CMPLX_PTR_ALIASING
+#ifndef CHPL_DONT_USE_CMPLX_PTR_ALIASING
 #define cmplx_re32(c) (_Generic((c), _complex64 : ((float *)&(c)))[0])
 #define cmplx_im32(c) (_Generic((c), _complex64 : ((float *)&(c)))[1])
   _complex64 val;

--- a/test/types/complex/bradc/tupleToComplex.chpl
+++ b/test/types/complex/bradc/tupleToComplex.chpl
@@ -1,0 +1,27 @@
+{
+  var x = (-18.0, inf);
+  writeln(x, ": ", x.type:string);
+  var y = x: complex(128);
+  writeln(y, ": ", y.type:string);
+  writeln((y.re, y.im));
+  writeln();
+}
+
+{
+  var x = (-18.0:real(32), inf:real(32));
+  writeln(x, ": ", x.type:string);
+  var y = x: complex(64);
+  writeln(y, ": ", y.type:string);
+  writeln((y.re, y.im));
+  writeln();
+}
+
+{
+  var x = (-18.0:real(32), inf:real(32));
+  writeln(x, ": ", x.type:string);
+  var y = x: complex(128);
+  writeln(y, ": ", y.type:string);
+  writeln((y.re, y.im));
+  writeln();
+}
+

--- a/test/types/complex/bradc/tupleToComplex.good
+++ b/test/types/complex/bradc/tupleToComplex.good
@@ -1,0 +1,12 @@
+(-18.0, inf): 2*real(64)
+-18.0 + infi: complex(128)
+(-18.0, inf)
+
+(-18.0, inf): 2*real(32)
+-18.0 + infi: complex(64)
+(-18.0, inf)
+
+(-18.0, inf): 2*real(32)
+-18.0 + infi: complex(128)
+(-18.0, inf)
+


### PR DESCRIPTION
This updates the implementation of the _chpl_complexNNN() routines in the runtime which are used to convert a Chapel 2-tuple of reals into a complex.  Specifically, my rewrite tries to use the 'CMPLX()' initializer macros rather than math to initialize the complex values.  The motivation for this is to work around [an issue](https://chapel.discourse.group/t/complex-imaginary-multiplication/29534) in which inf/nan values would creep in due to an apparent [bug](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=48760).  See the output of the test added in this PR prior to this change to see the old, odd behavior.

When this macro isn't available (as with when using C++ compilers and potentially some others?  CI failed when I didn't have this option available), I am currently falling back to an aliasing-based approach to poke the real and imaginary values into the complex and then returning it.  This generates the correct values as well, though feels a bit squirrely.

By building the runtime with `CHPL_DONT_USE_CMPLX_PTR_ALIASING`, you can go back to the original implementation we've used, which performs math and gets the "mathematically wrong" answer.

If anyone going forward has suggestions for making these conversion routines work equally well in C as C++ with fewer options involved, I'm all ears.  This was the best I was able to come up with after some internet browsing.