### PR TITLE
Remove 'use GPU' from ChapelGpuSupport

### DIFF
--- a/modules/standard/GPU.chpl
+++ b/modules/standard/GPU.chpl
@@ -253,27 +253,12 @@ module GPU
 
   @chpldoc.nodoc
   proc canAccessPeer(loc1 : locale, loc2 : locale) : bool {
-    extern proc chpl_gpu_can_access_peer(i : c_int, j : c_int) : bool;
-
-    if(!loc1.isGpu() || !loc2.isGpu()) then
-      halt("Non GPU locale passed to 'canAccessPeer'");
-    const loc1Sid = chpl_sublocFromLocaleID(loc1.chpl_localeid());
-    const loc2Sid = chpl_sublocFromLocaleID(loc2.chpl_localeid());
-
-    return chpl_gpu_can_access_peer(loc1Sid, loc2Sid);
+    return chpl_canAccessPeer(loc1, loc2);
   }
 
   @chpldoc.nodoc
   proc setPeerAccess(loc1 : locale, loc2 : locale, shouldEnable : bool) {
-    extern proc chpl_gpu_set_peer_access(
-      i : c_int, j : c_int, shouldEnable : bool) : void;
-
-    if(!loc1.isGpu() || !loc2.isGpu()) then
-      halt("Non GPU locale passed to 'canAccessPeer'");
-    const loc1Sid = chpl_sublocFromLocaleID(loc1.chpl_localeid());
-    const loc2Sid = chpl_sublocFromLocaleID(loc2.chpl_localeid());
-
-    chpl_gpu_set_peer_access(loc1Sid, loc2Sid, shouldEnable);
+    chpl_setPeerAccess(loc1, loc2, shouldEnable);
   }
 
   // ============================

--- a/test/gpu/native/studies/bandwidth/p2p.skipif
+++ b/test/gpu/native/studies/bandwidth/p2p.skipif
@@ -1,2 +1,0 @@
-# we don't support using nvlink with cpu-as-device mode
-CHPL_GPU==cpu


### PR DESCRIPTION
This PR removes 'use GPU' from the internal module `ChapelGpuSupport`. Since `ChapelGpuSupport` is included in each compilation, its having 'use GPU' cased the `GPU` module to be included in each compilation as well. This is undesirable. With this PR, the `GPU` module is compiled only when used/imported from user code.

Implementation notes: this PR moves the implementation of `canAccessPeer()` and `setPeerAccess()` from `GPU` to `ChapelGpuSupport`. These are the only things from `GPU` that `ChapelGpuSupport` used. Now they are available without `use GPU`.

This PR also updates `test/gpu/native/studies/bandwidth/p2p.chpl` to use `canAccessPeer` and `setPeerAccess` from the GPU module instead of calling their underlying extern procs directly. This test now also passes under CHPL_GPU=cpu, checking that `canAccessPeer()` returns false in this configuration.

Testing: `p2p.chpl` under CHPL_GPU=cpu, amd, nvidia.
