### PR TITLE
Skip nqueens on cygwin and valgrind test configs

### DIFF
--- a/test/library/packages/DistributedBag/nqueens.skipif
+++ b/test/library/packages/DistributedBag/nqueens.skipif
@@ -1,0 +1,3 @@
+# this test runs long enough to timeout on cygwin and valgrind
+CHPL_HOST_PLATFORM <= cygwin
+CHPL_TEST_VGRND_EXE == on


### PR DESCRIPTION
Follow-up to PR #23204.

Skip the new nqueens test on valgrind and cygwin testing configurations where it is timing out. We will still have basic testing of the data structure in these configurations with other tests.

Test change only - not reviewed.