### PR TITLE
Fix trying to restore filenames in compilation phase on GPU

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -3058,7 +3058,7 @@ void makeBinary(void) {
   // (Unless we're doing GPU codegen, which currently happens in the compilation
   // phase.)
   INT_ASSERT(!fDriverCompilationPhase || gCodegenGPU);
-  if (!fDriverDoMonolithic) {
+  if (fDriverMakeBinaryPhase) {
     // Setup/restore filenames to be referenced in makeBinary phase.
     setupDefaultFilenames();
     restoreAdditionalSourceFiles();


### PR DESCRIPTION
Prevent trying to restore filenames from tmp file in compilation phase, which contains the invocation of `makeBinary` for GPU backend.

Follow up to https://github.com/chapel-lang/chapel/pull/24166.

[trivial, not reviewed]

Testing:
- [x] paratest
- [x] paratest with `--compiler-driver`
- [x] GPU tests