### PR TITLE
Remove two halts and use fallback code instead

### DIFF
--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -2086,7 +2086,8 @@ module ShallowCopy {
                                        /*src*/ A,
                                        {src_idx..#nElts_idx});
       if !ok {
-        halt("bulk transfer failed in sorting");
+        // fall back on PRIM_ASSIGN to move the elements
+        // at present, this is needed for Cyclic and Replicated.
         foreach i in 0..#nElts {
           __primitive("=", A[dst_idx+i:idxType], A[src_idx+i:idxType]);
         }
@@ -2127,7 +2128,8 @@ module ShallowCopy {
                                        /*src*/ SrcA,
                                        {src_idx..#nElts_src_idx});
       if !ok {
-        halt("bulk transfer failed in sorting");
+        // fall back on PRIM_ASSIGN to move the elements
+        // at present, this is needed for Cyclic and Replicated.
         foreach i in 0..#nElts_dst_idx {
           __primitive("=", DstA[dst_idx+i], SrcA[src_idx+i:SrcA.idxType]);
         }


### PR DESCRIPTION
Follow-up to PR #24147.

This PR removes two halts if bulk transfer fails & uses the already existing fallback code in that case. These halts were coming up in nightly testing in two configurations that can be reproduced with:

```
./util/start_test  test/distributions/robust/arithmetic/modules/test_module_Search.chpl -compopts -sdistType=DistType.replicated

./util/start_test  test/distributions/robust/arithmetic/modules/test_module_Search.chpl -compopts -sdistType=DistType.cyclic
```

I think we probably want bulk transfer to work for Cyclic but we have issue #17764 for that.

Trivial and not reviewed.

- [x] reproducers above now pass with quickstart + CHPL_COMM=gasnet 
- [x] full comm=none testing
- [x] full gasnet testing