### PR TITLE
Don't run colocales test with multi-locales

### DIFF
--- a/test/runtime/jhh/colocales/SKIPIF
+++ b/test/runtime/jhh/colocales/SKIPIF
@@ -1,1 +1,0 @@
-echo True

--- a/test/runtime/jhh/colocales/colocales.py
+++ b/test/runtime/jhh/colocales/colocales.py
@@ -45,8 +45,15 @@ def skipif():
     env = {k.strip():v for k,v in printchplenv.ENV_VALS.items()}
 
     # Verify Chapel configuration
+
+    # Tests requires hwloc
     if env.get('CHPL_HWLOC', 'none') == 'none':
         skipReason = "CHPL_HWLOC == none"
+        return
+
+    # Don't test in multi-locale configurations
+    if env.get('CHPL_COMM', 'none') != 'none':
+        skipReason = "CHPL_COMM != none"
         return
 
 def stringify(lst):
@@ -264,7 +271,10 @@ def main(argv):
     compiler = argv[1]
     os.environ['CHPL_COMPILER'] = compiler
     del argv[1]
-    localDir = sub_test.get_local_dir(sub_test.get_chpl_base(compiler))
+    baseDir = sub_test.get_chpl_base(compiler)
+    homeDir = sub_test.get_chpl_home(baseDir)
+    testDir = sub_test.get_test_dir(homeDir)
+    localDir = sub_test.get_local_dir(testDir)
     name = os.path.join(localDir, argv[0])
     base = os.path.splitext(os.path.basename(argv[0]))[0]
 


### PR DESCRIPTION
It's not necessary to run the colocales test with `CHPL_COMM != none`. Also fixed the format of the "[test: " line in the output to not include the initial "test" directory so as to conform to the standard `sub_test` output.