### PR TITLE
Fix "[test: " line in test output

### DIFF
--- a/test/runtime/jhh/cpuKinds/cpuKinds.py
+++ b/test/runtime/jhh/cpuKinds/cpuKinds.py
@@ -158,7 +158,10 @@ def main(argv):
 
     compiler = argv[1]
     del argv[1]
-    localDir = sub_test.get_local_dir(sub_test.get_chpl_base(compiler))
+    baseDir = sub_test.get_chpl_base(compiler)
+    homeDir = sub_test.get_chpl_home(baseDir)
+    testDir = sub_test.get_test_dir(homeDir)
+    localDir = sub_test.get_local_dir(testDir)
     name = os.path.join(localDir, argv[0])
     base = os.path.splitext(os.path.basename(argv[0]))[0]
 


### PR DESCRIPTION
For consistency with the output of other tests, the "[test: " line in the test output should not contain the initial "test/" directory, e.g. it should be [test: runtime/jhh/cpuKinds/cpuKinds.py], not [test: test/runtime/jhh/cpuKinds/cpuKinds.py].