### PR TITLE
Use ROCm's LLVM as system LLVM

### DIFF
--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -78,11 +78,7 @@ def determine_gpu_type():
 
 def get_llvm_override():
     if get() == 'amd':
-        print('version', get_sdk_version())
-        print(get_sdk_version().split('.'))
-        print(get_sdk_version().split('.')[0] == '5')
         if get_sdk_version().split('.')[0] == '5':
-            print('want to override')
             return '{}/llvm/bin/llvm-config'.format(get_sdk_path('amd'))
         pass
     return 'none'

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -89,9 +89,14 @@ def get_llvm_config_version(llvm_config):
             got_version = got_out
 
         if chpl_gpu.get() == 'amd':
-            # strip the "git" suffix
-            if got_version[-4:] == 'git':
-                got_version = got_version[:-4]
+            # strip the "git" suffix. This is a TODO. We want to be able to
+            # detect LLVM "nightly" versions because ROCm seems to ship with
+            # those. A sign for that is the `git` suffix at the end of the
+            # version string. As of today 15.0.0git works for us as, I believe,
+            # it is pretty close to 15.0.0 proper.
+            got_version = got_version.strip()
+            if got_version[-3:] == 'git':
+                got_version = got_version[:-3]
     return got_version
 
 # Returns the full output of clang --version for the passed clang command.

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -7,6 +7,7 @@ import re
 
 import chpl_bin_subdir, chpl_arch, chpl_compiler, chpl_platform, overrides
 from chpl_home_utils import get_chpl_third_party, get_chpl_home
+import chpl_gpu
 from utils import which, memoize, error, run_command, try_run_command, warning
 from collections import defaultdict
 
@@ -87,6 +88,10 @@ def get_llvm_config_version(llvm_config):
         if exists and returncode == 0:
             got_version = got_out
 
+        if chpl_gpu.get() == 'amd':
+            # strip the "git" suffix
+            if got_version[-4:] == 'git':
+                got_version = got_version[:-4]
     return got_version
 
 # Returns the full output of clang --version for the passed clang command.
@@ -238,6 +243,11 @@ def find_system_llvm_config():
     llvm_config = overrides.get('CHPL_LLVM_CONFIG', 'none')
     if llvm_config != 'none':
         return llvm_config
+
+    llvm_config = chpl_gpu.get_llvm_override()
+    if llvm_config != 'none':
+        return llvm_config
+
 
     homebrew_prefix = chpl_platform.get_homebrew_prefix()
 


### PR DESCRIPTION
This PR adjust our environment scripts to use ROCm's LLVM for ROCm version > 5.

When our bundled LLVM is upgraded to 16, we should disallow `CHPL_LLVM=bundled`, but this PR doesn't do that.

Test:
- [x] spot check with ROCm 5.4
- [x] amd with ROCm 4
- [x] nvidia