### PR TITLE
Grabbag of fixes to make chapel-py more portable

### DIFF
--- a/frontend/lib/CMakeLists.txt
+++ b/frontend/lib/CMakeLists.txt
@@ -93,11 +93,10 @@ endif()
 add_library(ChplFrontendShared SHARED
             $<TARGET_OBJECTS:ChplFrontend-obj>
             $<TARGET_OBJECTS:git-sha-obj>)
-target_link_libraries(ChplFrontendShared ChplFrontend)
 
-target_include_directories(ChplFrontend PUBLIC
-                           ${CHPL_MAIN_INCLUDE_DIR}
-                           ${CHPL_INCLUDE_DIR})
+set(CHPL_FRONTEND_INCLUDES ${CHPL_MAIN_INCLUDE_DIR} ${CHPL_INCLUDE_DIR})
+target_include_directories(ChplFrontend PUBLIC ${CHPL_FRONTEND_INCLUDES})
+target_include_directories(ChplFrontendShared PUBLIC ${CHPL_FRONTEND_INCLUDES})
 
 if (CHPL_LLVM_STATIC_DYNAMIC STREQUAL "static")
   if(APPLE)
@@ -130,8 +129,12 @@ else()
     target_link_libraries(ChplFrontend PUBLIC ${CHPL_LLVM_LINK_ARGS})
 endif()
 
+target_link_libraries(ChplFrontendShared PUBLIC ${CHPL_LLVM_LINK_ARGS})
+
 # TODO: Get printchplenv output proper so that we don't need to SHELL here
 target_compile_options(ChplFrontend PUBLIC
+                       SHELL:$<$<COMPILE_LANGUAGE:CXX>:${CHPL_LLVM_COMP_ARGS}>)
+target_compile_options(ChplFrontendShared PUBLIC
                        SHELL:$<$<COMPILE_LANGUAGE:CXX>:${CHPL_LLVM_COMP_ARGS}>)
 
 

--- a/tools/chapel-py/README.md
+++ b/tools/chapel-py/README.md
@@ -48,17 +48,21 @@ myfile
 ```
 
 ## Installation
+
 Make sure that you have a from-source build of Chapel available in your
 `CHPL_HOME`, and that the Dyno compiler library has been built (this usually
-happens if you build the compiler, or run `make test-frontend`). Currently,
-the build script also requires having LLVM available in your path. With
-those constraints met, you can just run `pip install`:
+happens if you build the compiler, or run `make test-frontend`). Currently, the
+build script also requires having LLVM available in your path. The build script
+also requires that the development package of python be installed (for many
+package managers this is called `python3-devel`). With those constraints met,
+you can just run `pip install`:
 
 ```Bash
 python3 -m pip install -e .
 ```
 
 ## Usage
+
 Check the `chplcheck.py` file in the root directory to see the library
 in action.
 
@@ -78,6 +82,7 @@ The library is split into three major components:
 The following sections document the three modules.
 
 ### `chapel.core`
+
 The main entry point to the Chapel Python API is the `Context` object. This
 is a wrapper around the C++ construct of the same name. The Context in 'dyno'
 is responsible of memoizing computations, interning strings, and more. The
@@ -152,6 +157,7 @@ implementation of the former is included above). It also provides a couple
 of more advanced helpers for dealing with Chapel ASTs.
 
 #### `chapel.parse_attribute`
+
 The `parse_attribute` function, given a "description" of an attribute (its
 name and formal list), tries to parse an `Attribute` AST node. This function
 accounts for named and unnamed actuals, reordering, etc. For instance, given
@@ -193,6 +199,7 @@ def ignores_rule(node, rulename):
 ```
 
 #### `chapel.match_pattern`
+
 This function provides general pattern matching functionality to enable users
 of the Python API to rapidly find "interesting" locations in the AST. It
 supports arbitrary levels of nesting, as well as "named variables" to easily
@@ -455,4 +462,3 @@ def tag_aggregates_with_io_interfaces(rc, root):
 
         yield (record, new_text)
 ```
-

--- a/tools/chapel-py/scripts/generate-pyi.py
+++ b/tools/chapel-py/scripts/generate-pyi.py
@@ -19,7 +19,7 @@
 #
 
 import chapel.core
-from typing import List, Tuple
+from typing import List, Tuple, Optional, Union
 
 
 def _get_base_header() -> str:
@@ -27,7 +27,7 @@ def _get_base_header() -> str:
     return c._get_pyi_file()
 
 
-def _section(*args: str | List[str], indent: int = 4) -> List[str]:
+def _section(*args: Union[str, List[str]], indent: int = 4) -> List[str]:
     temp = []
     for arg in args:
         if not isinstance(arg, list):
@@ -43,9 +43,9 @@ def _wrap_docstring(docstring: str) -> List[str]:
 
 def _wrap_method(
     name: str,
-    args: List[Tuple[str, str | None]] = [],
+    args: List[Tuple[str, Optional[str]]] = [],
     rettype: str = "None",
-    docstring: str | None = None,
+    docstring: Optional[str] = None,
 ) -> List[str]:
     argstr = ""
     for a, t in args:
@@ -163,7 +163,7 @@ def get_AstNode_header() -> str:
         ),
         _wrap_method(
             "attribute_group",
-            rettype="AttributeGroup | None",
+            rettype="typing.Optional[AttributeGroup]",
             docstring="Get the attribute group, if any, associated with this node",
         ),
         _wrap_method(
@@ -173,7 +173,7 @@ def get_AstNode_header() -> str:
         ),
         _wrap_method(
             "parent",
-            rettype="AstNode | None",
+            rettype="typing.Optional[AstNode]",
             docstring="Get the parent node of this AST node",
         ),
         _wrap_method(

--- a/tools/chplcheck/README.md
+++ b/tools/chplcheck/README.md
@@ -189,7 +189,8 @@ def UnusedFormal(context, root):
         formals[formal.unique_id()] = formal
 
     for (use, _) in chapel.each_matching(root, Identifier):
-        if refersto := use.to_node():
+        refersto = use.to_node()
+        if refersto:
             uses.add(refersto.unique_id())
 
     for unused in formals.keys() - uses:

--- a/tools/chplcheck/src/driver.py
+++ b/tools/chplcheck/src/driver.py
@@ -88,7 +88,8 @@ class LintDriver:
 
     def _is_unstable_module(node):
         if isinstance(node, chapel.core.Module):
-            if attrs := node.attribute_group():
+            attrs = node.attribute_group()
+            if attrs:
                 if attrs.is_unstable():
                     return True
         return False

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -142,7 +142,8 @@ def register_rules(driver):
             var_kind = var_node.kind()
 
             var_attributes = ''
-            if var_attribute_group := var_node.attribute_group():
+            var_attribute_group = var_node.attribute_group()
+            if var_attribute_group:
                 var_attributes = " ".join(
                     [a.name() for a in var_attribute_group if a is not None])
 
@@ -225,7 +226,8 @@ def register_rules(driver):
             formals[formal.unique_id()] = formal
 
         for (use, _) in chapel.each_matching(root, Identifier):
-            if refersto := use.to_node():
+            refersto = use.to_node()
+            if refersto:
                 uses.add(refersto.unique_id())
 
         for unused in formals.keys() - uses:
@@ -250,7 +252,8 @@ def register_rules(driver):
                 indices[index.unique_id()] = index
 
         for (use, _) in chapel.each_matching(root, Identifier):
-            if refersto := use.to_node():
+            refersto = use.to_node()
+            if refersto:
                 uses.add(refersto.unique_id())
 
         for unused in indices.keys() - uses:


### PR DESCRIPTION
Grabbag of fixes to make chapel-py work on platforms with older toolchains.

- fix linker build issue with ChplFrontendShared, of which chapel-py is currently the only consumer
  - The way ChplFrontendShared was previously built, it duplicated symbols, causing global objects to be duplicated as well. This was an issue for `rootContext`, where its destructor would be called twice and result in a double free.
- fix type hints in `generate-pyi`
- improve README
- remove uses of the walrus operator in python (`:=`)