### PR TITLE
Add conversion rule from pointer to const pointer to Dyno.

### DIFF
--- a/frontend/include/chpl/types/CPtrType.h
+++ b/frontend/include/chpl/types/CPtrType.h
@@ -86,6 +86,8 @@ class CPtrType final : public Type {
     return eltType_;
   }
 
+  const CPtrType* withoutConst(Context* context) const;
+
   bool isConst() const {
     return isConst_;
   }
@@ -96,22 +98,7 @@ class CPtrType final : public Type {
   }
 
   bool isInstantiationOf(Context* context,
-                         const CPtrType* genericType) const {
-    auto thisFrom = instantiatedFromCPtrType();
-    auto argFrom = genericType->instantiatedFromCPtrType();
-    if (argFrom == nullptr) {
-      // if genericType is not a partial instantiation
-      return (thisFrom != nullptr && thisFrom == genericType);
-    }
-
-    if (thisFrom == argFrom) {
-      // handle the case of genericType being partly instantiated
-      // (or instantiated with a generic type)
-      return isEltTypeInstantiationOf(context, genericType);
-    }
-
-    return false;
-  }
+                         const CPtrType* genericType) const;
 
   virtual void stringify(std::ostream& ss,
                          chpl::StringifyKind stringKind) const override;

--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -821,8 +821,20 @@ CanPassResult CanPassResult::canInstantiate(Context* context,
     }
   } else if (auto actualPt = actualT->toCPtrType()) {
     if (auto formalPt = formalT->toCPtrType()) {
+      // Check first if they're direct instantiations (c_ptr(int(?w)) <- c_ptr(int)).
       if (actualPt->isInstantiationOf(context, formalPt)) {
         return instantiate();
+      }
+
+      // Instantiation might still be possible, together with a coercion, if
+      // the formal is const but the actual isn't.
+      formalPt = formalPt->withoutConst(context);
+
+      if (actualPt->isInstantiationOf(context, formalPt)) {
+        return CanPassResult(/* no fail reason, passes */ {},
+                             /* instantiates */ true,
+                             /* promotes */ false,
+                             /* converts */ ConversionKind::OTHER);
       }
     }
   }

--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -333,8 +333,14 @@ bool
 CanPassResult::canConvertCPtr(Context* context,
                               const Type* actualT,
                               const Type* formalT) {
-  if (actualT->isCPtrType()) {
+  if (auto actualPtr = actualT->toCPtrType()) {
     if (auto formalPtr = formalT->toCPtrType()) {
+      // Allow constness casts: an int* can be a const int*.
+      // In Chapel lingo, `c_ptr(int)` is passable to `c_ptrConst(int)`.
+      if (formalPtr->isConst() && !actualPtr->isConst() &&
+          formalPtr->eltType() == actualPtr->eltType())
+        return true;
+
       return formalPtr->isVoidPtr();
     } else {
       // Check for old c_void_ptr behavior.

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -1352,6 +1352,16 @@ QualifiedType getInstantiationType(Context* context,
       auto ct = ClassType::get(context, bct, manager, dec);
       return QualifiedType(formalType.kind(), ct);
     }
+  } else if (auto actualPt = actualT->toCPtrType()) {
+    if (auto formalPt = formalT->toCPtrType()) {
+      // The only reason we should need an instantiation type is if a constness
+      // coercion was applied, which is only possible for const formal, non-const
+      // actual.
+      CHPL_ASSERT(formalPt->isConst() && !actualPt->isConst());
+
+      auto pt = CPtrType::getConst(context, actualPt->eltType());
+      return QualifiedType(formalType.kind(), pt);
+    }
   }
 
   // TODO: sync type -> value type?

--- a/frontend/test/resolution/testCPtr.cpp
+++ b/frontend/test/resolution/testCPtr.cpp
@@ -245,6 +245,14 @@ static void test17() {
   });
 }
 
+static void test18() {
+  testCPtrArg("c_ptrConst(int)", "c_ptr(int)", [](const TypedFnSignature* fn, const CPtrType* t, ErrorGuard& eg) {
+    assert(t);
+    assert(t->isConst());
+    assert(t->eltType()->isIntType());
+  });
+}
+
 int main() {
   test1();
   test2();
@@ -263,6 +271,7 @@ int main() {
   test15();
   test16();
   test17();
+  test18();
 
   return 0;
 }

--- a/frontend/test/resolution/testCPtr.cpp
+++ b/frontend/test/resolution/testCPtr.cpp
@@ -238,6 +238,7 @@ static void test16() {
 
 static void test17() {
   testCPtrArg("c_ptr(void)", "c_ptrConst(int)", [](const TypedFnSignature* fn, const CPtrType* t, ErrorGuard& eg) {
+    assert(fn);
     assert(t);
     assert(!t->isConst());
     assert(t->isVoidPtr());
@@ -247,6 +248,7 @@ static void test17() {
 
 static void test18() {
   testCPtrArg("c_ptrConst(int)", "c_ptr(int)", [](const TypedFnSignature* fn, const CPtrType* t, ErrorGuard& eg) {
+    assert(fn);
     assert(t);
     assert(t->isConst());
     assert(t->eltType()->isIntType());

--- a/frontend/test/resolution/testCPtr.cpp
+++ b/frontend/test/resolution/testCPtr.cpp
@@ -277,6 +277,20 @@ static void test20() {
   });
 }
 
+static void test21() {
+  testCPtrArg("c_ptr(int(?w))", "c_ptrConst(int(32))", [](const TypedFnSignature* fn, const CPtrType* t, ErrorGuard& eg) {
+    assert(!fn);
+    assert(eg.realizeErrors() == 1);
+  });
+}
+
+static void test22() {
+  testCPtrArg("c_ptr(rec(?t))", "c_ptrConst(rec(int))", [](const TypedFnSignature* fn, const CPtrType* t, ErrorGuard& eg) {
+    assert(!fn);
+    assert(eg.realizeErrors() == 1);
+  });
+}
+
 int main() {
   test1();
   test2();
@@ -298,6 +312,8 @@ int main() {
   test18();
   test19();
   test20();
+  test21();
+  test22();
 
   return 0;
 }

--- a/frontend/test/resolution/testCPtr.cpp
+++ b/frontend/test/resolution/testCPtr.cpp
@@ -253,6 +253,30 @@ static void test18() {
   });
 }
 
+static void test19() {
+  testCPtrArg("c_ptrConst(int(?w))", "c_ptr(int(32))", [](const TypedFnSignature* fn, const CPtrType* t, ErrorGuard& eg) {
+    assert(fn);
+    assert(t);
+    assert(t->isConst());
+    auto eltT = t->eltType();
+    assert(eltT && eltT->isIntType());
+    assert(eltT == IntType::get(eg.context(), 32));
+  });
+}
+
+static void test20() {
+  testCPtrArg("c_ptrConst(rec(?t))", "c_ptr(rec(int))", [](const TypedFnSignature* fn, const CPtrType* t, ErrorGuard& eg) {
+    assert(fn);
+    assert(t);
+    auto eltT = t->eltType();
+    assert(eltT && eltT->isRecordType());
+    auto rt = eltT->toRecordType();
+    assert(rt->name() == "rec");
+    auto& fields = fieldsForTypeDecl(eg.context(), rt, DefaultsPolicy::IGNORE_DEFAULTS);
+    assert(fields.numFields() == 1 && fields.fieldType(0).type()->isIntType());
+  });
+}
+
 int main() {
   test1();
   test2();
@@ -272,6 +296,8 @@ int main() {
   test16();
   test17();
   test18();
+  test19();
+  test20();
 
   return 0;
 }


### PR DESCRIPTION
This was the only missing conversion in Dyno -- non-const pointers can be safely converted to const ones.

This PR also tweaks the instantiation rules to allow `c_ptrConst(?t)` to be instantiated by `c_ptr(X)` etc.. This isn't present in production, but it doesn't seem explicitly ruled out -- the case just didn't seem considered.

Reviewed by @arezaii -- thanks!

## Testing
- [x] dyno test suite
- [x] paratest