### PR TITLE
fix size_t to int comparison and unused variable warnings in dyno tests

### DIFF
--- a/frontend/test/resolution/testTestPrimitives.cpp
+++ b/frontend/test/resolution/testTestPrimitives.cpp
@@ -70,7 +70,7 @@ static void testGatherTests(const std::vector<std::pair<std::string, std::string
         assert(gatherResult.type().isParam());
         assert(gatherResult.type().param());
         assert(gatherResult.type().param()->isIntParam());
-        assert(gatherResult.type().param()->toIntParam()->value() == expectedTestNames.size());
+        assert((size_t)(gatherResult.type().param()->toIntParam()->value()) == expectedTestNames.size());
       }
     }
   }
@@ -84,7 +84,7 @@ static void testGatherTests(const std::vector<std::pair<std::string, std::string
   std::sort(actualTestNames.begin(), actualTestNames.end());
 
   assert(expectedTestNames.size() == expectedTestNames.size());
-  for (int i = 0; i < expectedTestNames.size(); i++) {
+  for (size_t i = 0; i < expectedTestNames.size(); i++) {
     assert(expectedTestNames[i] == actualTestNames[i]);
   }
 }

--- a/frontend/test/resolution/testTypePropertyPrimitives.cpp
+++ b/frontend/test/resolution/testTypePropertyPrimitives.cpp
@@ -34,7 +34,7 @@ struct Test {
     TRUE,
     FALSE,
     STRING,
-    ERROR 
+    ERROR
   };
 
   struct PrimitiveCalls {
@@ -62,7 +62,7 @@ static bool
 isParamStringMatch(chpl::types::QualifiedType qt, std::string str,
                    std::string& out) {
   if (qt.kind() == QualifiedType::PARAM) {
-    if (auto t = qt.type()) {
+    if (qt.type()) {
       if (auto p = qt.param()) {
         if (auto sp = p->toStringParam()) {
           out = sp->value().c_str();
@@ -119,7 +119,7 @@ static void testPrimitive(const Test& tpg) {
     ps << "param " << var << " = " << "__primitive(\"";
     ps << tagStr << "\", ";
 
-    for (int i = 0; i < call.actuals.size(); i++) {
+    for (size_t i = 0; i < call.actuals.size(); i++) {
       ps << call.actuals[i];
       bool last = (i+1) == call.actuals.size();
       if (!last) ps << ", ";


### PR DESCRIPTION
This PR fixes some warnings that were treated as errors in the dyno tests. 

trivial test changes only, not reviewed.

(docs failures are unrelated and known to be caused by `chpldoc` dependency failures)
