### PR TITLE
Resolve chpldoc build failure with Sphinx and update dependencies

### DIFF
--- a/doc/Makefile.sphinx
+++ b/doc/Makefile.sphinx
@@ -8,7 +8,7 @@ CHPLDEPS = $(shell $(CHPL_MAKE_PYTHON) $(CHPL_MAKE_HOME)/util/chplenv/chpl_home_
 COPY_IF_DIFFERENT = $(CHPL_MAKE_PYTHON) $(CHPL_MAKE_HOME)/util/config/update-if-different --copy
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -n -W --keep-going
+SPHINXOPTS    = -W --keep-going
 SPHINXBUILD = $(CHPL_MAKE_PYTHON) $(CHPLDEPS) sphinx-build
 PAPER         =
 SOURCEDIR     = rst

--- a/third-party/chpl-venv/chpldoc-requirements1.txt
+++ b/third-party/chpl-venv/chpldoc-requirements1.txt
@@ -1,2 +1,2 @@
 # Split into 3 files to work around problems with CHPL_PIP_FROM_SOURCE
-MarkupSafe==2.1.1
+MarkupSafe==2.1.3

--- a/third-party/chpl-venv/chpldoc-requirements2.txt
+++ b/third-party/chpl-venv/chpldoc-requirements2.txt
@@ -1,7 +1,7 @@
 # Split into 3 files to work around problems with CHPL_PIP_FROM_SOURCE
 Jinja2==3.1.2
 Pygments==2.12.0
-Sphinx==4.5.0
+Sphinx==5.3.0
 urllib3<1.27,>=1.21.1
-docutils==0.16.0
+docutils==0.18
 babel==2.10.3

--- a/third-party/chpl-venv/chpldoc-requirements2.txt
+++ b/third-party/chpl-venv/chpldoc-requirements2.txt
@@ -1,6 +1,6 @@
 # Split into 3 files to work around problems with CHPL_PIP_FROM_SOURCE
-Jinja2==3.1.2
-Pygments==2.12.0
+Jinja2==3.1.3
+Pygments==2.17.2
 Sphinx==5.3.0
 urllib3<1.27,>=1.21.1
 docutils==0.18

--- a/third-party/chpl-venv/chpldoc-requirements3.txt
+++ b/third-party/chpl-venv/chpldoc-requirements3.txt
@@ -1,4 +1,4 @@
 # Split into 3 files to work around problems with CHPL_PIP_FROM_SOURCE
-sphinx-rtd-theme==1.0.0
+sphinx-rtd-theme==2.0.0
 sphinxcontrib-chapeldomain==0.0.28
-breathe==4.31.0
+breathe==4.35.0

--- a/third-party/chpl-venv/chpldoc-requirements3.txt
+++ b/third-party/chpl-venv/chpldoc-requirements3.txt
@@ -1,4 +1,4 @@
 # Split into 3 files to work around problems with CHPL_PIP_FROM_SOURCE
 sphinx-rtd-theme==2.0.0
-sphinxcontrib-chapeldomain==0.0.28
+sphinxcontrib-chapeldomain==0.0.29
 breathe==4.35.0


### PR DESCRIPTION
chpldoc was failing to build because Sphinx is dropping support for versions older then 5.0 (by updating their dependencies to require later versions).  Update the version of Sphinx we rely on in chpldoc itself as well as in the Chapel sphinx domain.

This caused us to need to update the version of breathe we rely on to build the compiler documentation.  That version of breathe generates extra warnings for links that don't exist, so we need to temporarily turn off those warnings until the dyno subteam is able to resolve them.  Our hope is to restore these warnings quickly, so that we can ensure our documentation links work.

While here, I also updated several other Python dependencies that had newer versions.

Updated:
- MarkupSafe from 2.1.1 to 2.1.3
- Jinja2 from 3.1.2 to 3.1.3
- Pygments from 2.12.0 to 2.17.2
- Sphinx from 4.5.0 to 5.3.0
- docutils from 0.16 to 0.18
- sphinx-rtd-theme from 1.0.0 to 2.0.0
- breathe from 4.31.0 to 4.35.0
- sphinxcontrib-chapeldomain from 0.0.28 to 0.0.29

I believe there are other dependency updates I can make but in the interest of fixing testing, I will limit this PR to the current ones.

Note:
- We did not update Sphinx to the latest version, because it requires later versions of Python than we test
- We did not update docutils to the latest version, because Sphinx is behind and also because 0.19 was encountering some errors for the Chapel sphinx domain which it did not seem worth investigating at the moment (but that should be investigated if they are not resolved in later versions of our dependencies)