### PR TITLE
Verify cxi ofi provider is selected when testing

### DIFF
--- a/util/cron/test-hpe-cray-ex-ofi.bash
+++ b/util/cron/test-hpe-cray-ex-ofi.bash
@@ -8,5 +8,6 @@ source $CWD/common-ofi.bash || \
 source $CWD/common-hpe-cray-ex.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="hpe-cray-ex-ofi"
+export CHPL_RT_COMM_OFI_EXPECTED_PROVIDER="cxi"
 
 $CWD/nightly -cron -examples ${nightly_args}


### PR DESCRIPTION
Verify that the `cxi` provider is selected when testing on HPE Cray EX machines by setting `CHPL_RT_COMM_OFI_EXPECTED_PROVIDER`. This is facilitate debugging an issue in which on some HPE Cray EX machines `fi_getinfo` sometimes does not return the `cxi` provider.