### PR TITLE
Avoid a memory leak when sorting domains

### DIFF
--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -764,6 +764,7 @@ module InsertionSort {
 
     for i in low..high by stride {
       pragma "no auto destroy"
+      pragma "no copy"
       var ithVal = ShallowCopy.shallowCopyInit(Data[i]);
 
       var inserted = false;
@@ -1157,6 +1158,7 @@ module QuickSort {
 
     // Now swap the pivot to a local variable
     pragma "no auto destroy"
+    pragma "no copy"
     var piv: eltType = ShallowCopy.shallowCopyInit(Data[lo]); // leaves Data[lo] empty
 
     while true {
@@ -1475,6 +1477,7 @@ module ShellSort {
       for is in hs..end {
         // move Data[is] into v
         pragma "no auto destroy"
+        pragma "no copy"
         var v = ShallowCopy.shallowCopyInit(Data[is]);
         js = is;
         while js >= hs && chpl_compare(v,Data[js-h],comparator) < 0 {
@@ -2054,7 +2057,6 @@ module ShallowCopy {
     }
   }
 
-  // TODO: These shallowCopy functions should handle Block,Cyclic arrays
   inline proc shallowCopy(ref A, dst, src, nElts) {
 
     // Ideally this would just be

--- a/test/library/packages/Sort/correctness/SortTypes.chpl
+++ b/test/library/packages/Sort/correctness/SortTypes.chpl
@@ -74,12 +74,6 @@ proc checkSorts(arr, comparator) {
   QuickSort.quickSort(c, comparator=comparator);
   assert(isSorted(c, comparator));
   assert(a.equals(c));
-
-  // check shellSortMoveElts
-  var d = arr;
-  ShellSort.shellSortMoveElts(d, comparator=comparator);
-  assert(isSorted(d, comparator));
-  assert(a.equals(d));
 }
 
 proc checkSorts(arr) {


### PR DESCRIPTION
Follow-up to PR #24147.

Fixes a problem where the test `test/domains/vass/arrays-of-domains.chpl` would leak memory. For some reason (that I did not dig in to), code like `var x = shallowCopyInit(src)` calls the usual initCopy when applied to domains. But, in the sorting code, we need it to not do that, so I added a `pragma "no copy"` to avoid it. (Note that such variables already need `pragma "no auto destroy"` in the sorting code).

Additionally, this PR removes testing for shellSortMoveElts (which is called within other sort code) from the test module SortTypes because this was making these test much slower, leading to timeouts.

Reviewed by @vasslitvinov - thanks!

- [x] full comm=none testing

Future Work:
 * #16431 investigate "move" memory management for domains, which I worked around here