### PR TITLE
Some performance tuning for sorting

### DIFF
--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -3569,7 +3569,7 @@ module InPlacePartitioning {
 // it is not stable and not fully parallel
 @chpldoc.nodoc
 module MSBRadixSort {
-  import Sort.{defaultComparator, ShellSort};
+  import Sort.{defaultComparator, ShellSort, InsertionSort};
   private use super.RadixSortHelp;
   private use OS.POSIX;
 
@@ -3611,9 +3611,13 @@ module MSBRadixSort {
       return;
 
     if( end_n - start_n < settings.sortSwitch ) {
-      ShellSort.shellSortMoveElts(A, criterion,
-                                  start=start_n,
-                                  end=end_n);
+      // Since the problem size is bounded, insertion sort is faster
+      // than shell sort.
+      // If we want sortSwitch to be pretty big, we can
+      // use quickSort.
+      InsertionSort.insertionSortMoveElts(A, comparator=criterion,
+                                          lo=start_n,
+                                          hi=end_n);
       if settings.CHECK_SORTS then checkSorted(start_n, end_n, A, criterion);
       return;
     }

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -487,6 +487,8 @@ proc sort(ref Data: [?Dom] ?eltType, comparator:?rec=defaultComparator,
       // TODO: use a sample sort if the input does not have enough
       // randomness, according to some heuristic
 
+      // TODO: uncomment the below when implementation is ready
+      /*
       var quickSortSize=50_000;
       // quick sort performs better for middle problem sizes
       // (too large for insertion sort etc, but not big enough
@@ -494,7 +496,7 @@ proc sort(ref Data: [?Dom] ?eltType, comparator:?rec=defaultComparator,
       if Data.domain.size < quickSortSize {
         QuickSort.quickSort(Data, comparator=comparator);
         return;
-      }
+      }*/
 
       if inPlaceAlgorithm {
         // use an in-place algorithm

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -487,16 +487,12 @@ proc sort(ref Data: [?Dom] ?eltType, comparator:?rec=defaultComparator,
       // TODO: use a sample sort if the input does not have enough
       // randomness, according to some heuristic
 
-      // TODO: uncomment the below when implementation is ready
-      /*
-      var quickSortSize=50_000;
-      // quick sort performs better for middle problem sizes
-      // (too large for insertion sort etc, but not big enough
-      //  to overcome the larger constant overhead of radix sort)
-      if Data.domain.size < quickSortSize {
-        QuickSort.quickSort(Data, comparator=comparator);
+      var simplerSortSize=50_000;
+      if Data.domain.size < simplerSortSize {
+        // TODO: use quicksort instead in these small cases
+        MSBRadixSort.msbRadixSort(Data, comparator=comparator);
         return;
-      }*/
+      }
 
       if inPlaceAlgorithm {
         // use an in-place algorithm

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -2271,7 +2271,7 @@ module SequentialInPlacePartitioning {
 module TwoArrayPartitioning {
   private use Math;
   public use List only list;
-  import Sort.{ShellSort, MSBRadixSort, QuickSort};
+  import Sort.{ShellSort, MSBRadixSort};
   import Sort.{RadixSortHelp, ShallowCopy};
   use MSBRadixSort;
 

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -3470,11 +3470,6 @@ module TwoArraySampleSort {
     var baseCaseSize=16;
     var distributedBaseCaseSize=1024;
 
-    var endbit:int;
-    endbit = msbRadixSortParamLastStartBit(Data, comparator);
-    if endbit < 0 then
-      endbit = max(int);
-
     // Allocate the Scratch array.
     pragma "no auto destroy"
     var Scratch: Data.type =
@@ -3485,8 +3480,7 @@ module TwoArraySampleSort {
 
     var state = new TwoArrayBucketizerSharedState(
       bucketizer=new SampleBucketizer(Data.eltType),
-      baseCaseSize=baseCaseSize,
-      endbit=endbit);
+      baseCaseSize=baseCaseSize);
 
     partitioningSortWithScratchSpace(Data.domain.low.safeCast(int),
                                      Data.domain.high.safeCast(int),

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -2285,6 +2285,7 @@ module TwoArrayPartitioning {
   public use List only list;
   import Sort.{ShellSort, MSBRadixSort};
   import Sort.{RadixSortHelp, ShallowCopy};
+  import Sort;
   use MSBRadixSort;
 
   private param debug = false;
@@ -2513,21 +2514,9 @@ module TwoArrayPartitioning {
       if debug then
         writeln("recursing to sort the sample");
 
-      // sort the sample
+      // sort the sample using the usual sorting algorithm
+      Sort.sort(A[start_n..#sampleSize], comparator=criterion);
 
-
-      // TODO: make it adjustable from the settings
-      if sampleSize <= 1024*1024 {
-        // base case sort, parallel OK
-        msbRadixSort(A, start_n, start_n + sampleSize - 1,
-                     criterion,
-                     startbit, state.endbit,
-                     settings=new MSBRadixSortSettings());
-      } else {
-        partitioningSortWithScratchSpace(start_n, start_n + sampleSize - 1,
-                                         A, Scratch,
-                                         state, criterion, startbit);
-      }
       if debug {
         RadixSortHelp.checkSorted(start_n, start_n + sampleSize - 1, A, criterion, startbit);
       }

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -484,6 +484,18 @@ proc sort(ref Data: [?Dom] ?eltType, comparator:?rec=defaultComparator,
     compilerError("stable sort not yet implemented");
   } else {
     if radixSortOk(Data, comparator) {
+      // TODO: use a sample sort if the input does not have enough
+      // randomness, according to some heuristic
+
+      var quickSortSize=50_000;
+      // quick sort performs better for middle problem sizes
+      // (too large for insertion sort etc, but not big enough
+      //  to overcome the larger constant overhead of radix sort)
+      if Data.domain.size < quickSortSize {
+        QuickSort.quickSort(Data, comparator=comparator);
+        return;
+      }
+
       if inPlaceAlgorithm {
         // use an in-place algorithm
         MSBRadixSort.msbRadixSort(Data, comparator=comparator);
@@ -3360,7 +3372,6 @@ module TwoArrayRadixSort {
   import Sort.defaultComparator;
   private use super.TwoArrayPartitioning;
   private use super.RadixSortHelp;
-  private import super.QuickSort;
 
   proc twoArrayRadixSort(ref Data:[], comparator:?rec=defaultComparator) {
 
@@ -3369,16 +3380,7 @@ module TwoArrayRadixSort {
     }
 
     var baseCaseSize=16;
-    var quickSortSize=10000;
     var sequentialSizePerTask=4096;
-    // quick sort performs better for middle problem sizes
-    // (too large for insertion sort, but not big enough
-    //  for radix sort to be beneficial)
-    if Data.domain.size < quickSortSize {
-      QuickSort.quickSort(Data, comparator=comparator);
-      return;
-    }
-
     var endbit:int;
     endbit = msbRadixSortParamLastStartBit(Data, comparator);
     if endbit < 0 then

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -3360,6 +3360,7 @@ module TwoArrayRadixSort {
   import Sort.defaultComparator;
   private use super.TwoArrayPartitioning;
   private use super.RadixSortHelp;
+  private import super.QuickSort;
 
   proc twoArrayRadixSort(ref Data:[], comparator:?rec=defaultComparator) {
 
@@ -3367,9 +3368,16 @@ module TwoArrayRadixSort {
       compilerWarning("twoArrayRadix sort no longer handles distributed arrays. Please use TwoArrayDistributedRadixSort.twoArrayDistributedRadixSort instead (but note that it is not stable)");
     }
 
-    var sequentialSizePerTask=4096;
     var baseCaseSize=16;
-    var distributedBaseCaseSize=1024;
+    var quickSortSize=10000;
+    var sequentialSizePerTask=4096;
+    // quick sort performs better for middle problem sizes
+    // (too large for insertion sort, but not big enough
+    //  for radix sort to be beneficial)
+    if Data.domain.size < quickSortSize {
+      QuickSort.quickSort(Data, comparator=comparator);
+      return;
+    }
 
     var endbit:int;
     endbit = msbRadixSortParamLastStartBit(Data, comparator);

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -3441,7 +3441,8 @@ module TwoArrayRadixSort {
     var Scratch: Data.type =
       Data.domain.buildArray(Data.eltType, initElts=false);
 
-    // TODO: do some relevant first-touch
+    // It would make sense to touch the memory first here, but early experiments
+    // suggest that it doesn't help with CHPL_COMM=none.
     Scratch.dsiElementInitializationComplete();
 
     var state = new TwoArrayBucketizerSharedState(
@@ -3490,7 +3491,7 @@ module TwoArrayDistributedRadixSort {
     var Scratch: Data.type =
       Data.domain.buildArray(Data.eltType, initElts=false);
 
-    // TODO: do some relevant first-touch
+    // TODO: do some first-touch, which should matter for comm=ugni
     Scratch.dsiElementInitializationComplete();
 
     var state1 = new TwoArrayDistributedBucketizerSharedState(
@@ -3536,7 +3537,8 @@ module TwoArraySampleSort {
     var Scratch: Data.type =
       Data.domain.buildArray(Data.eltType, initElts=false);
 
-    // TODO: do some relevant first-touch
+    // It would make sense to touch the memory first here, but early experiments
+    // suggest that it doesn't help with CHPL_COMM=none.
     Scratch.dsiElementInitializationComplete();
 
     var state = new TwoArrayBucketizerSharedState(
@@ -3584,7 +3586,7 @@ module TwoArrayDistributedSampleSort {
     var Scratch: Data.type =
       Data.domain.buildArray(Data.eltType, initElts=false);
 
-    // TODO: do some relevant first-touch
+    // TODO: do some first-touch, which should matter for comm=ugni
     Scratch.dsiElementInitializationComplete();
 
     var state = new TwoArrayDistributedBucketizerSharedState(

--- a/test/library/packages/Sort/correctness/SortTypes.chpl
+++ b/test/library/packages/Sort/correctness/SortTypes.chpl
@@ -58,22 +58,43 @@ proc checkSorts(arr, comparator) {
   var a = arr;
   sort(a, comparator);
   assert(isSorted(a, comparator));
+  // check the various algorithms that can be used by the default sort
   if !isTupleOfString(arr[1].type) {
+    // OK to check radix sorts
+
     // check msbRadixSort
     if verbose then
-      writeln("radix sort");
+      writeln("msbRadixSort");
     var b = arr;
     MSBRadixSort.msbRadixSort(b, comparator);
     assert(isSorted(b, comparator));
     assert(a.equals(b));
+
+    // check twoArrayRadixSort
+    if verbose then
+      writeln("twoArrayRadixSort");
+    var c = arr;
+    TwoArrayRadixSort.twoArrayRadixSort(c, comparator);
+    assert(isSorted(b, comparator));
+    assert(a.equals(b));
   }
-  // check quickSort
+
+  // check quickSort since it is a fallback
   if verbose then
-    writeln("quick sort");
-  var c = arr;
-  QuickSort.quickSort(c, comparator=comparator);
-  assert(isSorted(c, comparator));
-  assert(a.equals(c));
+    writeln("quickSort");
+  var d = arr;
+  QuickSort.quickSort(d, comparator=comparator);
+  assert(isSorted(d, comparator));
+  assert(a.equals(d));
+
+  // check two-array sample sort since in the future
+  // 'proc sort' should use it in some cases
+  if verbose then
+    writeln("twoArraySampleSort");
+  var e = arr;
+  TwoArraySampleSort.twoArraySampleSort(e, comparator=comparator);
+  assert(isSorted(e, comparator));
+  assert(a.equals(e));
 }
 
 proc checkSorts(arr) {

--- a/test/library/packages/Sort/correctness/SortTypes.chpl
+++ b/test/library/packages/Sort/correctness/SortTypes.chpl
@@ -89,12 +89,13 @@ proc checkSorts(arr, comparator) {
 
   // check two-array sample sort since in the future
   // 'proc sort' should use it in some cases
-  if verbose then
-    writeln("twoArraySampleSort");
-  var e = arr;
-  TwoArraySampleSort.twoArraySampleSort(e, comparator=comparator);
-  assert(isSorted(e, comparator));
-  assert(a.equals(e));
+  // TODO: get this working
+  //if verbose then
+  //  writeln("twoArraySampleSort");
+  //var e = arr;
+  //TwoArraySampleSort.twoArraySampleSort(e, comparator=comparator);
+  //assert(isSorted(e, comparator));
+  //assert(a.equals(e));
 }
 
 proc checkSorts(arr) {

--- a/test/library/packages/Sort/performance/sort-performance-explorer.chpl
+++ b/test/library/packages/Sort/performance/sort-performance-explorer.chpl
@@ -155,9 +155,11 @@ proc testsize(size:int) {
 
   var ntrials = 1;
   if mibibytes < 1 then
-    ntrials = 10;
+    ntrials = 200;
+  if kibibytes < 100 then
+    ntrials = 2_000;
   if kibibytes < 1 then
-    ntrials = 100;
+    ntrials = 20_000;
 
   for m in methods {
     const ref cmp = if reverse then reverseComparator else defaultComparator;

--- a/test/library/packages/Sort/performance/sort-performance-explorer.chpl
+++ b/test/library/packages/Sort/performance/sort-performance-explorer.chpl
@@ -93,16 +93,22 @@ proc makeInput(array, inputStrings) {
   }
 }
 
-proc testsize(size:int) {
+proc generateArray(size:int, describe=false) {
   var array:[1..size] int;
 
   if inputDataScheme == 0 {
     // scheme 0 : all zeros
+    if describe then
+      writeln("generating all zeros input");
   } else if inputDataScheme == 1 {
     // scheme 1: random ints
+    if describe then
+      writeln("generating random input");
     fillRandom(array, seed=seed);
   } else if inputDataScheme == 2 {
     // scheme 2: random ints, only top byte set
+    if describe then
+      writeln("generating random input setting only the top byte");
     fillRandom(array, seed=seed);
     for a in array {
       a >>= 56;
@@ -110,6 +116,8 @@ proc testsize(size:int) {
     }
   } else if inputDataScheme == 3 {
     // scheme 3: random ints, only a middle byte set
+    if describe then
+      writeln("generating random input setting only a middle byte");
     fillRandom(array, seed=seed);
     for a in array {
       a >>= 56;
@@ -118,6 +126,8 @@ proc testsize(size:int) {
     }
   } else if inputDataScheme == 4 {
     // scheme 4: random ints, only bottom byte set
+    if describe then
+      writeln("generating random input setting only the bottom byte");
     fillRandom(array, seed=seed);
     for a in array {
       a &= 0xff;
@@ -125,13 +135,31 @@ proc testsize(size:int) {
   } else if inputDataScheme == 5 {
     // scheme 5: heavily skewed distribution,
     // values are (1 << (random % 64))
+    if describe then
+      writeln("generating random powers of 2 input");
     fillRandom(array, seed=seed);
     for a in array {
       var shift = mod(a, 64);
       a = 1 << shift;
     }
+  } else if inputDataScheme == 6 {
+    // scheme 6: data is already in sorted order
+    if describe then
+      writeln("generating already-sorted input");
+    array = 1..size;
+  } else if inputDataScheme == 7 {
+    // scheme 7: data is in reverse sorted order
+    if describe then
+      writeln("generating reverse-sorted input");
+    array = 1..size by -1;
   }
 
+  return array;
+}
+
+proc testsize(size:int) {
+
+  var array = generateArray(size);
 
   var inputStringsDomain = {1..0};
   var inputStrings:[inputStringsDomain] string;
@@ -155,11 +183,11 @@ proc testsize(size:int) {
 
   var ntrials = 1;
   if mibibytes < 1 then
-    ntrials = 200;
+    ntrials = 100;
   if kibibytes < 100 then
-    ntrials = 2_000;
-  if kibibytes < 1 then
-    ntrials = 20_000;
+    ntrials = 1_000;
+  if kibibytes < 0.4 then
+    ntrials = 10_000;
 
   for m in methods {
     const ref cmp = if reverse then reverseComparator else defaultComparator;
@@ -178,6 +206,9 @@ proc testsize(size:int) {
 }
 
 proc main() {
+  // run generateArray to output the distribution
+  generateArray(100, describe=true);
+
   if printStats {
     writeln("Note, speeds are in MiB/s");
     writef("% 16s", "size");

--- a/test/library/packages/Sort/performance/sort-performance-explorer.chpl
+++ b/test/library/packages/Sort/performance/sort-performance-explorer.chpl
@@ -182,12 +182,15 @@ proc testsize(size:int) {
   var input = makeInput(array, inputStrings);
 
   var ntrials = 1;
-  if mibibytes < 1 then
-    ntrials = 100;
-  if kibibytes < 100 then
-    ntrials = 1_000;
-  if kibibytes < 0.4 then
-    ntrials = 10_000;
+  if printStats {
+    // use more trials for small problem sizes when measuring speed
+    if mibibytes < 1 then
+      ntrials = 100;
+    if kibibytes < 100 then
+      ntrials = 1_000;
+    if kibibytes < 0.4 then
+      ntrials = 10_000;
+  }
 
   for m in methods {
     const ref cmp = if reverse then reverseComparator else defaultComparator;
@@ -207,7 +210,7 @@ proc testsize(size:int) {
 
 proc main() {
   // run generateArray to output the distribution
-  generateArray(100, describe=true);
+  generateArray(100, describe=printStats);
 
   if printStats {
     writeln("Note, speeds are in MiB/s");


### PR DESCRIPTION
This PR makes some performance adjustments to Sort.chpl:

 * adjust `sort` to use the older in-place radix sorter for problems too small for TwoArrayRadixSort before creating the Scratch array (because it will not be needed for small subproblems). My experiments indicate using QuickSort in these cases is even better but we aren't quite ready to do that yet.
 * added a skip-ahead mechanism for the two-array radix sort for when multiple key bytes are the same for all elements. To do this, made the `startbit` formal to `bucketize` use `inout` intent; so it might change the start bit being considered during the counting process (if all the data starts with the same pattern)
 * it adds throttling for the case of sorting within a nested parallel region

### Performance Impact

The tables below contain data generated by `sort-performance-explorer.chpl` with and without this PR to see the performance impact. That benchmark supports a bunch of different input patterns, so the tables have different rows for these.

This table shows the change in performance due to the skip-ahead. It's using a problem size of 1GiB of `int`s. Cells are speeds in MiB/s:

|            | before this PR | this PR | note |
|------------|----------------|---------|------|
| all zeros  | 1700.22        | 5329.89 | ~3x faster |
| random     | 4195.17        | 4199.01 | equivalent |
| top byte   | 7185.71        | 7186.77 | equivalent |
| middle byte| 3491.47        | 5511.66 | ~1.5x faster |
| bottom byte| 1702.92        | 4027.71 | ~2x faster |
| powers of 2| 2265.12        | 2203.17 | 3% slower |
| 1..n       | 2042.67        | 3845.47 | ~2x faster |
| 1..n by -1 | 2060.28        | 3845.95 | ~2x faster |

The next table shows the change in performance from using msbRadixSort for small problem sizes instead of the two-array sorter. Here the problem size is 512 bytes of `int`s. Cells are speeds in MiB/s:

|            | before this PR | this PR |
|------------|----------------|---------|
| all zeros  | 6.60572        | 2209.42 |
| random     | 6.56019        | 1493.21 |
| top byte   | 6.58691        | 1530.66 |
| middle byte| 6.5975         | 1470.73 |
| bottom byte| 6.69438        | 1516.4  |
| powers of 2| 6.62409        | 1570.04 |
| 1..n       | 6.59225        | 2219.46 |
| 1..n by -1 | 6.65324        | 1856.58 |

### Future Work

 * Use QuickSort instead of msbRadixSort for small problems since it has lower constant overhead & seems to be faster at these small sizes
 * Add code to do first-touch for the Scratch array in the distributed sorts, which should be relevant with `CHPL_COMM=ugni`
 * Explore using twoArraySample for large arrays with highly skewed distributions. e.g. `./sort-performance-explorer --inputDataScheme=5` shows that it's on the order of 3x faster than the radix sorter in this case. In contrast, the radix sorter is about 50% faster, in my experiments, with randomly distributed data.

### Testing and Review

Reviewed by @vasslitvinov - thanks!

- [x] full comm=none testing
- [x] full comm=gasnet testing