### PR TITLE
Minor Python LSP tweaks

### DIFF
--- a/tools/chapel-py/src/core-types-pernode.cpp
+++ b/tools/chapel-py/src/core-types-pernode.cpp
@@ -20,6 +20,7 @@
 #include "core-types.h"
 #include "chpl/uast/all-uast.h"
 #include "python-types.h"
+#include "chpl/framework/query-impl.h"
 #include "chpl/parsing/parsing-queries.h"
 #include "chpl/resolution/resolution-queries.h"
 #include "chpl/resolution/scope-queries.h"
@@ -132,9 +133,11 @@ static const AstNode* idOrEmptyToAstNodeOrNull(Context* context, const ID& id) {
   return parsing::idToAst(context, id);
 }
 
-static const AstNode* nodeOrNullFromToId(Context* context, const AstNode* node) {
+static const AstNode* const& nodeOrNullFromToId(Context* context, const AstNode* node) {
+  QUERY_BEGIN(nodeOrNullFromToId, context, node);
   auto id = scopeResolveResultsForNode(context, node);
-  return idOrEmptyToAstNodeOrNull(context, id);
+  auto nodeOrNull = idOrEmptyToAstNodeOrNull(context, id);
+  return QUERY_END(nodeOrNull);
 }
 
 /* The METHOD macro is overridden here to actually create a Python-compatible

--- a/tools/chapel-py/src/core-types.cpp
+++ b/tools/chapel-py/src/core-types.cpp
@@ -376,12 +376,8 @@ PyObject* AstNodeObject_iter(AstNodeObject *self) {
 }
 
 PyObject* AstNodeObject_location(AstNodeObject *self) {
-  auto locationObjectPy = PyObject_CallObject((PyObject *) &LocationType, nullptr);
-  auto& location = ((LocationObject*) locationObjectPy)->location;
   auto context = &((ContextObject*) self->contextObject)->context;
-
-  location = parsing::locateAst(context, self->astNode);
-  return locationObjectPy;
+  return wrapLocation(parsing::locateAst(context, self->astNode));
 }
 
 
@@ -427,4 +423,12 @@ PyObject* wrapAstNode(ContextObject* context, const AstNode* node) {
   }
   Py_XDECREF(args);
   return toReturn;
+}
+
+PyObject* wrapLocation(Location loc) {
+  auto locationObjectPy = PyObject_CallObject((PyObject *) &LocationType, nullptr);
+  auto& location = ((LocationObject*) locationObjectPy)->location;
+
+  location = std::move(loc);
+  return locationObjectPy;
 }

--- a/tools/chapel-py/src/core-types.h
+++ b/tools/chapel-py/src/core-types.h
@@ -110,4 +110,9 @@ void setupPerNodeTypes();
  */
 PyObject* wrapAstNode(ContextObject* context, const chpl::uast::AstNode* node);
 
+/**
+  Create a Python object from the given Location.
+ */
+PyObject* wrapLocation(chpl::Location loc);
+
 #endif

--- a/tools/chapel-py/src/method-tables.h
+++ b/tools/chapel-py/src/method-tables.h
@@ -169,8 +169,12 @@ CLASS_END(Domain)
 CLASS_BEGIN(Dot)
   PLAIN_GETTER(Dot, field, "Get the field accessed in the Dot node",
                UniqueString, return node->field())
+  PLAIN_GETTER(Dot, field_location, "Get the textual location of the Dot node's field expression",
+               Location, return chpl::parsing::locateDotFieldWithAst(context, node))
   PLAIN_GETTER(Dot, receiver, "Get the receiver of the Dot node",
                const AstNode*, return node->receiver())
+  PLAIN_GETTER(Dot, to_node, "Get the AST node that this Dot node refers to",
+               const AstNode*, return nodeOrNullFromToId(context, node))
 CLASS_END(Dot)
 
 CLASS_BEGIN(ExternBlock)

--- a/tools/chapel-py/src/python-types.h
+++ b/tools/chapel-py/src/python-types.h
@@ -68,6 +68,7 @@ DEFINE_RETURN_TYPE(const char*, "str", Py_BuildValue("s", TO_WRAP), PyUnicode_As
 DEFINE_RETURN_TYPE(chpl::UniqueString, "str", Py_BuildValue("s", TO_WRAP.c_str()), chpl::UniqueString::get(&CONTEXT->context, PyUnicode_AsUTF8(TO_UNWRAP)));
 DEFINE_RETURN_TYPE(std::string, "str", Py_BuildValue("s", TO_WRAP.c_str()), std::string(PyUnicode_AsUTF8(TO_UNWRAP)));
 DEFINE_RETURN_TYPE(const chpl::uast::AstNode*, "AstNode", wrapAstNode(CONTEXT, TO_WRAP), ((AstNodeObject*) TO_UNWRAP)->astNode);
+DEFINE_RETURN_TYPE(chpl::Location, "Location", wrapLocation(TO_WRAP), ((LocationObject*) TO_UNWRAP)->location);
 DEFINE_RETURN_TYPE(IterAdapterBase*, "typing.Iterator[AstNode]", wrapIterAdapter(CONTEXT, TO_WRAP), ((AstIterObject*) TO_UNWRAP)->iterAdapter);
 
 /* In the `method-tables.h` file, we encode a method signature using the C++

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -183,7 +183,10 @@ class NodeAndRange:
     rng: Range = field(init=False)
 
     def __post_init__(self):
-        self.rng = location_to_range(self.node.location())
+        if isinstance(self.node, chapel.core.Dot):
+            self.rng = location_to_range(self.node.field_location())
+        else:
+            self.rng = location_to_range(self.node.location())
 
     def get_location(self):
         return Location(self.get_uri(), self.rng)
@@ -237,6 +240,10 @@ class FileInfo:
         # get ids
         self.segments = []
         for node, _ in chapel.each_matching(asts, chapel.core.Identifier):
+            to = node.to_node()
+            if to:
+                self.segments.append(ResolvedPair(NodeAndRange(node), NodeAndRange(to)))
+        for node, _ in chapel.each_matching(asts, chapel.core.Dot):
             to = node.to_node()
             if to:
                 self.segments.append(ResolvedPair(NodeAndRange(node), NodeAndRange(to)))


### PR DESCRIPTION
This PR does a few things:

* Makes sure that `nodeOrNullFromToId` is a query, so that repeated calls are memoized. 
* Allows AST node methods to return location objects (with some refactoring to help create Python location objects)
* Adds a method to `Dot` that returns its field location (the substring after the `.`)
* Uses the new `field_location` method to implement goto-def, hover, etc. for dot expressions. 

Reviewed by @jabraham17 -- thanks!