### PR TITLE
Fix C++ portability issue with using CMPLX

### DIFF
--- a/runtime/include/chpltypes.h
+++ b/runtime/include/chpltypes.h
@@ -255,7 +255,11 @@ typedef struct chpl_main_argument_s {
 } chpl_main_argument;
 
 static inline _complex128 _chpl_complex128(_real64 re, _real64 im) {
-#ifdef CMPLX
+// though CMPLX works for some C++ compilers, it doesn't work for all in our
+// test environments, so dodge it to be safe;  Currently, we only compile
+// this header using a C++ compiler when compiling our re2 stubs, which
+// don't seem to use this routine anyway.
+#if defined(CMPLX) && !defined(__cplusplus)
   return CMPLX(re, im);
 #else
 #ifndef CHPL_DONT_USE_CMPLX_PTR_ALIASING
@@ -273,7 +277,11 @@ static inline _complex128 _chpl_complex128(_real64 re, _real64 im) {
 }
 
 static inline _complex64 _chpl_complex64(_real32 re, _real32 im) {
-#ifdef CMPLXF
+// though CMPLXF works for some C++ compilers, it doesn't work for all in our
+// test environments, so dodge it to be safe;  Currently, we only compile
+// this header using a C++ compiler when compiling our re2 stubs, which
+// don't seem to use this routine anyway.
+#if defined(CMPLX) && !defined(__cplusplus)
   return CMPLXF(re, im);
 #else
 #ifndef CHPL_DONT_USE_CMPLX_PTR_ALIASING


### PR DESCRIPTION
Though compiling PR #24184 with a back-end C++ compiler worked on my laptop and chapcs11, it caused problems with other C++ compilers, like g++ (SUSE Linux) 7.5.0 on [redacted] and some of our other nightly configurations.

At present, it's somewhat circumstantial that we compile this code with a C++ compiler: It only happens when compiling our qio re2 shim code, and that code doesn't rely on these tuple-to-complex conversion routines anyway.  As a result, what I've done here is to beef up my #ifndef to skip over the new preferred path of code when we're compiling for C++ to be safe, and on the assumption that it doesn't really matter anyway (won't be called); and even if that changes in the future, the fallback paths from #24184 ought to work...
