### PR TITLE
Undo update to c2chapel's dependency

### DIFF
--- a/third-party/chpl-venv/c2chapel-requirements.txt
+++ b/third-party/chpl-venv/c2chapel-requirements.txt
@@ -1,3 +1,3 @@
 # tools/c2chapel/Makefile should match so fakeHeaders download matches
-pycparser==2.21
+pycparser==2.20
 pycparserext

--- a/tools/c2chapel/Makefile
+++ b/tools/c2chapel/Makefile
@@ -35,7 +35,7 @@ link=$(bdir)/c2chapel
 
 # Note, this version is used only for the fake headers,
 # but it should probably match third-party/chpl-venv/c2chapel-requirements.txt
-VERSION=2.21
+VERSION=2.20
 TAR=release_v$(VERSION).tar.gz
 
 RELEASE=https://github.com/eliben/pycparser/archive/$(TAR)


### PR DESCRIPTION
Despite this seeming like a reasonable update, this caused c2chapel testing to break with multiple missing extern declarations.  Weird.

We should probably look into making it easier to run c2chapel testing, since the current job only runs on the vms and I was having some difficulty verifying it locally and on our normal testing machine