### PR TITLE
Fixes incorrect locations and errors in language server

### DIFF
--- a/tools/chapel-py/src/chapel/lsp/__init__.py
+++ b/tools/chapel-py/src/chapel/lsp/__init__.py
@@ -29,8 +29,8 @@ def location_to_range(location) -> Range:
     start = location.start()
     end = location.end()
     return Range(
-        start=Position(start[0] - 1, start[1] - 1),
-        end=Position(end[0] - 1, end[1] - 1),
+        start=Position(max(start[0] - 1, 0), max(start[1] - 1, 0)),
+        end=Position(max(0, end[0] - 1), max(end[1] - 1, 0)),
     )
 
 def error_to_diagnostic(error) -> Diagnostic:

--- a/tools/chapel-py/src/chapel/lsp/__init__.py
+++ b/tools/chapel-py/src/chapel/lsp/__init__.py
@@ -28,10 +28,9 @@ def location_to_range(location) -> Range:
 
     start = location.start()
     end = location.end()
-    # NOTE: we want the char number to be one extra, otherwise single character identifiers don't work right
     return Range(
         start=Position(start[0] - 1, start[1] - 1),
-        end=Position(end[0] - 1, end[1]),
+        end=Position(end[0] - 1, end[1] - 1),
     )
 
 def error_to_diagnostic(error) -> Diagnostic:

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -258,7 +258,7 @@ class FileInfo:
             self.segments, position, key=lambda s: s.ident.rng.start
         )
         idx -= 1
-        if idx < 0 or position >= self.segments[idx].ident.rng.end:
+        if idx < 0 or position > self.segments[idx].ident.rng.end:
             return None
         return self.segments[idx]
 

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -236,7 +236,7 @@ class FileInfo:
         Note: this is a potentially expensive operation, it should only be done
         when advancing the revision
         """
-        asts = self.get_asts()
+        asts = self.parse_file()
         # get ids
         self.segments = []
         for node, _ in chapel.each_matching(asts, chapel.core.Identifier):
@@ -248,7 +248,7 @@ class FileInfo:
             if to:
                 self.segments.append(ResolvedPair(NodeAndRange(node), NodeAndRange(to)))
         self.segments.sort(key=lambda s: s.ident.rng.start)
-        self.siblings = chapel.SiblingMap(self.get_asts())
+        self.siblings = chapel.SiblingMap(asts)
 
     def get_segment_at_position(
         self, position: Position

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -301,9 +301,6 @@ def run_lsp():
         """
 
         fi, errors = get_context(uri, do_update=True)
-        with fi.context.track_errors() as new_errors:
-            _ = fi.parse_file()
-        errors.extend(new_errors)
 
         diagnostics = [error_to_diagnostic(e) for e in errors]
         return diagnostics


### PR DESCRIPTION
Fixes two bugs in chpl-language-server

- Locations had an off-by-one error that caused locations to not show properly. This was an intentional off-by-one (see deleted comment), but the actual correct fix was a comparison in the binary search
- errors reported from the context where not being reported