### PR TITLE
Add language server suppoprt to show function signatures

### DIFF
--- a/modules/standard/ChplConfig.chpl
+++ b/modules/standard/ChplConfig.chpl
@@ -35,47 +35,47 @@ module ChplConfig {
   private use ChapelStandard;
 
   /* See :ref:`readme-chplenv.CHPL_HOME` for more information. */
-  @unstable("'ChplConfig.CHPL_HOME' is unstable and may be replaced with a different way to access this information in the future");
+  @unstable("'ChplConfig.CHPL_HOME' is unstable and may be replaced with a different way to access this information in the future")
   param CHPL_HOME:string;
   CHPL_HOME = __primitive("get compiler variable", "CHPL_HOME");
 
   /* See :ref:`readme-chplenv.CHPL_TARGET_PLATFORM` for more information. */
-  @unstable("'ChplConfig.CHPL_TARGET_PLATFORM' is unstable and may be replaced with a different way to access this information in the future");
+  @unstable("'ChplConfig.CHPL_TARGET_PLATFORM' is unstable and may be replaced with a different way to access this information in the future")
   param CHPL_TARGET_PLATFORM:string;
   CHPL_TARGET_PLATFORM = __primitive("get compiler variable", "CHPL_TARGET_PLATFORM");
 
   /* See :ref:`readme-chplenv.CHPL_HOST_PLATFORM` for more information. */
-  @unstable("'ChplConfig.CHPL_HOST_PLATFORM' is unstable and may be replaced with a different way to access this information in the future");
+  @unstable("'ChplConfig.CHPL_HOST_PLATFORM' is unstable and may be replaced with a different way to access this information in the future")
   param CHPL_HOST_PLATFORM:string;
   CHPL_HOST_PLATFORM = __primitive("get compiler variable", "CHPL_HOST_PLATFORM");
 
   /* See :ref:`readme-chplenv.CHPL_HOST_ARCH` for more information. */
-  @unstable("'ChplConfig.CHPL_HOST_ARCH' is unstable and may be replaced with a different way to access this information in the future");
+  @unstable("'ChplConfig.CHPL_HOST_ARCH' is unstable and may be replaced with a different way to access this information in the future")
   param CHPL_HOST_ARCH:string;
   CHPL_HOST_ARCH = __primitive("get compiler variable", "CHPL_HOST_ARCH");
 
   /* See :ref:`readme-chplenv.CHPL_COMPILER` for more information. */
-  @unstable("'ChplConfig.CHPL_HOST_COMPILER' is unstable and may be replaced with a different way to access this information in the future");
+  @unstable("'ChplConfig.CHPL_HOST_COMPILER' is unstable and may be replaced with a different way to access this information in the future")
   param CHPL_HOST_COMPILER:string;
   CHPL_HOST_COMPILER = __primitive("get compiler variable", "CHPL_HOST_COMPILER");
 
   /* See :ref:`readme-chplenv.CHPL_COMPILER` for more information. */
-  @unstable("'ChplConfig.CHPL_TARGET_COMPILER' is unstable and may be replaced with a different way to access this information in the future");
+  @unstable("'ChplConfig.CHPL_TARGET_COMPILER' is unstable and may be replaced with a different way to access this information in the future")
   param CHPL_TARGET_COMPILER:string;
   CHPL_TARGET_COMPILER = __primitive("get compiler variable", "CHPL_TARGET_COMPILER");
 
   /* See :ref:`readme-chplenv.CHPL_TARGET_ARCH` for more information. */
-  @unstable("'ChplConfig.CHPL_TARGET_ARCH' is unstable and may be replaced with a different way to access this information in the future");
+  @unstable("'ChplConfig.CHPL_TARGET_ARCH' is unstable and may be replaced with a different way to access this information in the future")
   param CHPL_TARGET_ARCH:string;
   CHPL_TARGET_ARCH = __primitive("get compiler variable", "CHPL_TARGET_ARCH");
 
   /* See :ref:`readme-chplenv.CHPL_TARGET_CPU` for more information. */
-  @unstable("'ChplConfig.CHPL_TARGET_CPU' is unstable and may be replaced with a different way to access this information in the future");
+  @unstable("'ChplConfig.CHPL_TARGET_CPU' is unstable and may be replaced with a different way to access this information in the future")
   param CHPL_TARGET_CPU:string;
   CHPL_TARGET_CPU = __primitive("get compiler variable", "CHPL_TARGET_CPU");
 
   /* See :ref:`readme-chplenv.CHPL_LOCALE_MODEL` for more information. */
-  @unstable("'ChplConfig.CHPL_LOCALE_MODEL' is unstable and may be replaced with a different way to access this information in the future");
+  @unstable("'ChplConfig.CHPL_LOCALE_MODEL' is unstable and may be replaced with a different way to access this information in the future")
   param CHPL_LOCALE_MODEL:string;
   CHPL_LOCALE_MODEL = __primitive("get compiler variable", "CHPL_LOCALE_MODEL");
 
@@ -83,48 +83,48 @@ module ChplConfig {
   proc compiledForSingleLocale() param do return _local;
 
   /* See :ref:`readme-chplenv.CHPL_COMM` for more information. */
-  @unstable("'ChplConfig.CHPL_COMM' is unstable and may be replaced with a different way to access this information in the future");
+  @unstable("'ChplConfig.CHPL_COMM' is unstable and may be replaced with a different way to access this information in the future")
   param CHPL_COMM:string;
   CHPL_COMM = __primitive("get compiler variable", "CHPL_COMM");
 
   /* See :ref:`readme-launcher` for more information. */
-  @unstable("'ChplConfig.CHPL_COMM_SUBSTRATE' is unstable and may be replaced with a different way to access this information in the future");
+  @unstable("'ChplConfig.CHPL_COMM_SUBSTRATE' is unstable and may be replaced with a different way to access this information in the future")
   param CHPL_COMM_SUBSTRATE:string;
   CHPL_COMM_SUBSTRATE = __primitive("get compiler variable", "CHPL_COMM_SUBSTRATE");
 
   /* See :ref:`readme-multilocale` for more information. */
-  @unstable("'ChplConfig.CHPL_GASNET_SEGMENT' is unstable and may be replaced with a different way to access this information in the future");
+  @unstable("'ChplConfig.CHPL_GASNET_SEGMENT' is unstable and may be replaced with a different way to access this information in the future")
   param CHPL_GASNET_SEGMENT:string;
   CHPL_GASNET_SEGMENT = __primitive("get compiler variable", "CHPL_GASNET_SEGMENT");
 
   @chpldoc.nodoc
-  @unstable("'ChplConfig.CHPL_LIBFABRIC' is unstable and may be replaced with a different way to access this information in the future");
+  @unstable("'ChplConfig.CHPL_LIBFABRIC' is unstable and may be replaced with a different way to access this information in the future")
   /* See :ref:`readme-chplenv.CHPL_LIBFABRIC` for more information. */
   param CHPL_LIBFABRIC:string;
   CHPL_LIBFABRIC = __primitive("get compiler variable", "CHPL_LIBFABRIC");
 
   /* See :ref:`readme-chplenv.CHPL_TASKS` for more information. */
-  @unstable("'ChplConfig.CHPL_TASKS' is unstable and may be replaced with a different way to access this information in the future");
+  @unstable("'ChplConfig.CHPL_TASKS' is unstable and may be replaced with a different way to access this information in the future")
   param CHPL_TASKS:string;
   CHPL_TASKS = __primitive("get compiler variable", "CHPL_TASKS");
 
   /* See :ref:`readme-chplenv.CHPL_LAUNCHER` for more information. */
-  @unstable("'ChplConfig.CHPL_LAUNCHER' is unstable and may be replaced with a different way to access this information in the future");
+  @unstable("'ChplConfig.CHPL_LAUNCHER' is unstable and may be replaced with a different way to access this information in the future")
   param CHPL_LAUNCHER:string;
   CHPL_LAUNCHER = __primitive("get compiler variable", "CHPL_LAUNCHER");
 
   /* See :ref:`readme-chplenv.CHPL_TIMERS` for more information. */
-  @unstable("'ChplConfig.CHPL_TIMERS' is unstable and may be replaced with a different way to access this information in the future");
+  @unstable("'ChplConfig.CHPL_TIMERS' is unstable and may be replaced with a different way to access this information in the future")
   param CHPL_TIMERS:string;
   CHPL_TIMERS = __primitive("get compiler variable", "CHPL_TIMERS");
 
   /* See :ref:`readme-chplenv.CHPL_UNWIND` for more information. */
-  @unstable("'ChplConfig.CHPL_UNWIND' is unstable and may be replaced with a different way to access this information in the future");
+  @unstable("'ChplConfig.CHPL_UNWIND' is unstable and may be replaced with a different way to access this information in the future")
   param CHPL_UNWIND:string;
   CHPL_UNWIND = __primitive("get compiler variable", "CHPL_UNWIND");
 
   /* See :ref:`readme-chplenv.CHPL_MEM` for more information. */
-  @unstable("'ChplConfig.CHPL_MEM' is unstable and may be replaced with a different way to access this information in the future");
+  @unstable("'ChplConfig.CHPL_MEM' is unstable and may be replaced with a different way to access this information in the future")
   param CHPL_MEM:string;
   CHPL_MEM = __primitive("get compiler variable", "CHPL_MEM");
 
@@ -134,48 +134,48 @@ module ChplConfig {
   CHPL_MAKE = __primitive("get compiler variable", "CHPL_MAKE");
 
   /* See :ref:`readme-chplenv.CHPL_ATOMICS` for more information. */
-  @unstable("'ChplConfig.CHPL_ATOMICS' is unstable and may be replaced with a different way to access this information in the future");
+  @unstable("'ChplConfig.CHPL_ATOMICS' is unstable and may be replaced with a different way to access this information in the future")
   param CHPL_ATOMICS:string;
   CHPL_ATOMICS = __primitive("get compiler variable", "CHPL_ATOMICS");
 
   /* See :ref:`readme-atomics` for more information. */
-  @unstable("'ChplConfig.CHPL_NETWORK_ATOMICS' is unstable and may be replaced with a different way to access this information in the future");
+  @unstable("'ChplConfig.CHPL_NETWORK_ATOMICS' is unstable and may be replaced with a different way to access this information in the future")
   param CHPL_NETWORK_ATOMICS:string;
   CHPL_NETWORK_ATOMICS = __primitive("get compiler variable", "CHPL_NETWORK_ATOMICS");
 
   /* See :ref:`readme-chplenv.CHPL_GMP` for more information. */
-  @unstable("'ChplConfig.CHPL_GMP' is unstable and may be replaced with a different way to access this information in the future");
+  @unstable("'ChplConfig.CHPL_GMP' is unstable and may be replaced with a different way to access this information in the future")
   param CHPL_GMP:string;
   CHPL_GMP = __primitive("get compiler variable", "CHPL_GMP");
 
   /* See :ref:`readme-chplenv.CHPL_HWLOC` for more information. */
-  @unstable("'ChplConfig.CHPL_HWLOC' is unstable and may be replaced with a different way to access this information in the future");
+  @unstable("'ChplConfig.CHPL_HWLOC' is unstable and may be replaced with a different way to access this information in the future")
   param CHPL_HWLOC:string;
   CHPL_HWLOC = __primitive("get compiler variable", "CHPL_HWLOC");
 
   @chpldoc.nodoc
-  @unstable("'ChplConfig.CHPL_JEMALLOC' is unstable and may be replaced with a different way to access this information in the future");
+  @unstable("'ChplConfig.CHPL_JEMALLOC' is unstable and may be replaced with a different way to access this information in the future")
   /* See :ref:`readme-chplenv.CHPL_JEMALLOC` for more information. */
   param CHPL_JEMALLOC:string;
   CHPL_JEMALLOC = __primitive("get compiler variable", "CHPL_TARGET_JEMALLOC");
 
   /* See :ref:`readme-chplenv.CHPL_RE2` for more information. */
-  @unstable("'ChplConfig.CHPL_RE2' is unstable and may be replaced with a different way to access this information in the future");
+  @unstable("'ChplConfig.CHPL_RE2' is unstable and may be replaced with a different way to access this information in the future")
   param CHPL_RE2:string;
   CHPL_RE2 = __primitive("get compiler variable", "CHPL_RE2");
 
   /* See :ref:`readme-chplenv.CHPL_LLVM` for more information. */
-  @unstable("'ChplConfig.CHPL_LLVM' is unstable and may be replaced with a different way to access this information in the future");
+  @unstable("'ChplConfig.CHPL_LLVM' is unstable and may be replaced with a different way to access this information in the future")
   param CHPL_LLVM:string;
   CHPL_LLVM = __primitive("get compiler variable", "CHPL_LLVM");
 
   @chpldoc.nodoc
-  @unstable("'ChplConfig.CHPL_GPU_MEM_STRATEGY' is unstable and may be replaced with a different way to access this information in the future");
+  @unstable("'ChplConfig.CHPL_GPU_MEM_STRATEGY' is unstable and may be replaced with a different way to access this information in the future")
   param CHPL_GPU_MEM_STRATEGY:string;
   CHPL_GPU_MEM_STRATEGY = __primitive("get compiler variable", "CHPL_GPU_MEM_STRATEGY");
 
   @chpldoc.nodoc
-  @unstable("'ChplConfig.CHPL_GPU' is unstable and may be replaced with a different way to access this information in the future");
+  @unstable("'ChplConfig.CHPL_GPU' is unstable and may be replaced with a different way to access this information in the future")
   param CHPL_GPU:string;
   CHPL_GPU = __primitive("get compiler variable", "CHPL_GPU");
 }

--- a/tools/chpl-language-server/src/symbol_signature.py
+++ b/tools/chpl-language-server/src/symbol_signature.py
@@ -1,0 +1,161 @@
+from typing import Optional, Union
+import chapel
+
+
+# TODO: for now, just text based. but should resolve generic types
+def get_symbol_signature(node: chapel.core.AstNode) -> str:
+    """
+    get a string representation of a AstNode's signature
+
+    Note: this is purely textual and does not resolve generic types
+    """
+    if not isinstance(node, chapel.core.NamedDecl):
+        return _node_to_string(node)
+
+    if isinstance(node, chapel.core.Class) or isinstance(
+        node, chapel.core.Record
+    ):
+        return _record_class_to_string(node)
+    elif isinstance(node, chapel.core.Interface):
+        return f"interface {node.name()}"
+    elif isinstance(node, chapel.core.Module):
+        return f"module {node.name()}"
+    elif isinstance(node, chapel.core.Enum):
+        return f"enum {node.name()}"
+    elif isinstance(node, chapel.core.Variable):
+        return _var_to_string(node)
+    elif isinstance(node, chapel.core.Function):
+        return _proc_to_string(node)
+
+    return node.name()
+
+
+def _node_to_string(node: chapel.core.AstNode) -> str:
+    """
+    General helper method to convert an AstNode to a string representation. If
+    it doesn't know how to convert the node, it returns "<...>"
+    """
+    if isinstance(node, chapel.core.NamedDecl):
+        return get_symbol_signature(node)
+    elif isinstance(node, chapel.core.Identifier):
+        return node.name()
+    elif isinstance(node, chapel.core.IntLiteral):
+        return node.text()
+    elif isinstance(node, chapel.core.UintLiteral):
+        return node.text()
+    elif isinstance(node, chapel.core.BoolLiteral):
+        return node.value()
+    elif isinstance(node, chapel.core.ImagLiteral):
+        return node.text()
+    elif isinstance(node, chapel.core.RealLiteral):
+        return node.text()
+    elif isinstance(node, chapel.core.StringLiteral):
+        return '"' + node.value() + '"'
+    elif isinstance(node, chapel.core.CStringLiteral):
+        return 'c"' + node.value() + '"'
+    return "<...>"
+
+
+def _record_class_to_string(
+    node: Union[chapel.core.Record, chapel.core.Class]
+) -> str:
+    """
+    Convert a Record or a Class to a string
+    """
+    keyword = "record" if isinstance(node, chapel.core.Record) else "class"
+
+    s = ""
+    ie = list(node.inherit_exprs())
+    if len(ie) > 0:
+        s = ": " + ", ".join([_node_to_string(x) for x in ie])
+    prefix = ""
+    if node.linkage():
+        prefix += f"{node.linkage()} "
+    if node.linkage_name():
+        prefix += f"{_node_to_string(node.linkage_name())} "
+
+    return f"{prefix}{keyword} {node.name()}{s}"
+
+
+def _var_to_string(node: chapel.core.VarLikeDecl) -> str:
+    """
+    Convert a VarLikeDecl to a string
+    """
+    s = ""
+    if node.visibility():
+        s += f"{node.visibility()} "
+    if node.linkage():
+        s += f"{node.linkage()} "
+    if node.linkage_name():
+        s += f"{_node_to_string(node.linkage_name())} "
+
+    if isinstance(node, chapel.core.Variable):
+        if node.is_config():
+            s += "config "
+    intent = _intent_to_string(node.intent())
+    if intent:
+        s += f"{intent} "
+    s += node.name()
+    type_ = node.type_expression()
+    if type_:
+        s += f": {_node_to_string(type_)}"
+    init = node.init_expression()
+    if init:
+        s += f" = {_node_to_string(init)}"
+    return s
+
+
+def _proc_to_string(node: chapel.core.Function) -> str:
+    """
+    Convert a function to a string
+    """
+    s = ""
+
+    if node.visibility():
+        s += f"{node.visibility()} "
+    if node.linkage():
+        s += f"{node.linkage()} "
+    if node.linkage_name():
+        s += f"{_node_to_string(node.linkage_name())} "
+    if node.is_override():
+        s += "override "
+    if node.is_inline():
+        s += "inline "
+
+    s += f"{node.kind()} "
+    # if it has a this-formal, check for this intent
+    if node.this_formal() and _intent_to_string(node.this_formal().intent()):
+        s += f"{_intent_to_string(node.this_formal().intent())} "
+    s += f"{node.name()}"
+
+    if not node.is_parenless():
+        start_idx = 1 if node.this_formal() else 0
+        formal_strings = [
+            _var_to_string(node.formal(i))
+            for i in range(start_idx, node.num_formals())
+        ]
+        s += f"({', '.join(formal_strings)})"
+
+    if _intent_to_string(node.return_intent()):
+        s += f" {_intent_to_string(node.return_intent())}"
+    if node.return_type():
+        s += f": {_node_to_string(node.return_type())}"
+    if node.throws():
+        s += " throws"
+    if node.where_clause():
+        s += f" where {_node_to_string(node.where_clause())}"
+
+    return s
+
+
+def _intent_to_string(intent: Optional[str]) -> str:
+    """
+    convert an intent (as reported by Dyno) to a user-facing string
+    """
+    remap = {
+        "<default-intent>": "",
+        "<index>": "",
+        "<const-var>": "const",
+    }
+    # use 'intent' as the default, so if no remap no work done
+    return remap.get(intent, intent) if intent else ""

--- a/tools/chpl-language-server/src/symbol_signature.py
+++ b/tools/chpl-language-server/src/symbol_signature.py
@@ -1,3 +1,22 @@
+#
+# Copyright 2024-2024 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 from typing import Optional, Union
 import chapel
 


### PR DESCRIPTION
Adds support for chpl-language server to pretty-print functions when a user hovers over a reference to them.

Also removes extra semicolons from ChplConfig

[Reviewed by @DanilaFe]