### PR TITLE
Downgrade filelock depended on by start_test to a slightly older version

### DIFF
--- a/third-party/chpl-venv/test-requirements.txt
+++ b/third-party/chpl-venv/test-requirements.txt
@@ -1,4 +1,4 @@
 PyYAML==6.0.1
-filelock==3.13.1
+filelock==3.12.2
 argcomplete==3.2.1
 setuptools==69.0.3


### PR DESCRIPTION
The version I grabbed actually required Python 3.8 (as opposed to some of these packages which say they do, but don't necessarily need that recent a version of Python).  Though we can drop our Python 3.7 testing, this is still a more recent version of filelock than we had been using before, so in the interest of getting testing back fully (especially since I put off upgrading Sphinx fully), take the path of least resistance until we have updated the versions of Python we are testing.

Passed a full paratest with futures