### PR TITLE
Skipif the outer access test under GASNet.

### DIFF
--- a/test/gpu/native/errors/outeraccess.skipif
+++ b/test/gpu/native/errors/outeraccess.skipif
@@ -1,0 +1,1 @@
+CHPL_COMM == gasnet


### PR DESCRIPTION
The test fails because of https://github.com/chapel-lang/chapel/issues/20641. This PR just skips it under GASNet.

## Testing
- [x] passes locally under GASNet configuration.