### PR TITLE
Update line numbers in .good for #24127

### DIFF
--- a/test/gpu/native/noGpu/basicMem.comm-none.good
+++ b/test/gpu/native/noGpu/basicMem.comm-none.good
@@ -1,12 +1,12 @@
 0 (gpu 0): basicMem.chpl:5: allocate 88B of domain(1,int(64),one) at 0xPREDIFFED
-0 (gpu 0): basicMem.chpl:5: allocate 168B of [domain(1,int(64),one)] int(64) at 0xPREDIFFED
+0 (gpu 0): basicMem.chpl:5: allocate 160B of [domain(1,int(64),one)] int(64) at 0xPREDIFFED
 0 (gpu 0): basicMem.chpl:5: allocate 80B of array elements at 0xPREDIFFED
-0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1513: allocate 48B of metadata about kernel parameters at 0xPREDIFFED
-0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1513: allocate 40B of array of pointers to kernel args at 0xPREDIFFED
-0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1513: allocate 5B of metadata about kernel parameters at 0xPREDIFFED
-0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1513: free 5B of metadata about kernel parameters at 0xPREDIFFED
-0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1513: free 40B of array of pointers to kernel args at 0xPREDIFFED
-0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1513: free 48B of metadata about kernel parameters at 0xPREDIFFED
+0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1519: allocate 48B of metadata about kernel parameters at 0xPREDIFFED
+0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1519: allocate 40B of array of pointers to kernel args at 0xPREDIFFED
+0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1519: allocate 5B of metadata about kernel parameters at 0xPREDIFFED
+0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1519: free 5B of metadata about kernel parameters at 0xPREDIFFED
+0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1519: free 40B of array of pointers to kernel args at 0xPREDIFFED
+0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1519: free 48B of metadata about kernel parameters at 0xPREDIFFED
 0 (gpu 0): basicMem.chpl:5: free 80B of array elements at 0xPREDIFFED
-0 (gpu 0): basicMem.chpl:5: free 168B of [domain(1,int(64),one)] int(64) at 0xPREDIFFED
+0 (gpu 0): basicMem.chpl:5: free 160B of [domain(1,int(64),one)] int(64) at 0xPREDIFFED
 0 (gpu 0): basicMem.chpl:5: free 88B of domain(1,int(64),one) at 0xPREDIFFED

--- a/test/gpu/native/noGpu/basicMem.good
+++ b/test/gpu/native/noGpu/basicMem.good
@@ -1,14 +1,14 @@
 0 (cpu): --:0: allocate 12B of comm layer remote fork done flag(s) at 0xPREDIFFED
 0 (cpu): --:0: allocate 20B of comm layer private broadcast data at 0xPREDIFFED
 0 (gpu 0): basicMem.chpl:5: allocate 88B of domain(1,int(64),one) at 0xPREDIFFED
-0 (gpu 0): basicMem.chpl:5: allocate 168B of [domain(1,int(64),one)] int(64) at 0xPREDIFFED
+0 (gpu 0): basicMem.chpl:5: allocate 160B of [domain(1,int(64),one)] int(64) at 0xPREDIFFED
 0 (gpu 0): basicMem.chpl:5: allocate 80B of array elements at 0xPREDIFFED
-0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1513: allocate 48B of metadata about kernel parameters at 0xPREDIFFED
-0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1513: allocate 40B of array of pointers to kernel args at 0xPREDIFFED
-0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1513: allocate 5B of metadata about kernel parameters at 0xPREDIFFED
-0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1513: free 5B of metadata about kernel parameters at 0xPREDIFFED
-0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1513: free 40B of array of pointers to kernel args at 0xPREDIFFED
-0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1513: free 48B of metadata about kernel parameters at 0xPREDIFFED
+0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1519: allocate 48B of metadata about kernel parameters at 0xPREDIFFED
+0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1519: allocate 40B of array of pointers to kernel args at 0xPREDIFFED
+0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1519: allocate 5B of metadata about kernel parameters at 0xPREDIFFED
+0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1519: free 5B of metadata about kernel parameters at 0xPREDIFFED
+0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1519: free 40B of array of pointers to kernel args at 0xPREDIFFED
+0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1519: free 48B of metadata about kernel parameters at 0xPREDIFFED
 0 (gpu 0): basicMem.chpl:5: free 80B of array elements at 0xPREDIFFED
-0 (gpu 0): basicMem.chpl:5: free 168B of [domain(1,int(64),one)] int(64) at 0xPREDIFFED
+0 (gpu 0): basicMem.chpl:5: free 160B of [domain(1,int(64),one)] int(64) at 0xPREDIFFED
 0 (gpu 0): basicMem.chpl:5: free 88B of domain(1,int(64),one) at 0xPREDIFFED


### PR DESCRIPTION
This PR reacts to #24127 analogously to #24157, following the same argument in favor of changing the line numbers vs. introducing a prediff.

Additionally, it reflects a reduction in the allocation/freeing size of `[domain(1,int(64),one)] int(64)` from 168 to 160 bytes. I did not investigate where that comes from.