### PR TITLE
Improve chpl-language-server portability

### DIFF
--- a/tools/chpl-language-server/src/bisect_compat.py
+++ b/tools/chpl-language-server/src/bisect_compat.py
@@ -1,0 +1,18 @@
+
+from typing import Callable, Sequence, Optional
+
+# reimplement bisect with a key, since the parameter wasn't added until python 3.10+
+def bisect_right(a: Sequence, x, key: Optional[Callable]=None):
+    lo = 0
+    hi = len(a)
+
+    if key is None:
+        key = lambda e: e
+
+    while lo < hi:
+        mid = (lo + hi) // 2
+        if x < key(a[mid]):
+            hi = mid
+        else:
+            lo = mid + 1
+    return lo

--- a/tools/chpl-language-server/src/bisect_compat.py
+++ b/tools/chpl-language-server/src/bisect_compat.py
@@ -1,3 +1,21 @@
+#
+# Copyright 2024-2024 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 from typing import Callable, Sequence, Optional
 

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -20,7 +20,7 @@
 
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 from dataclasses import dataclass, field
-from bisect import bisect_right
+from bisect_compat import bisect_right
 import itertools
 
 


### PR DESCRIPTION
Improves the portability of chpl-langauge-server to work with python3 versions older than 3.10. We were relying on `bisect_right` with a `key` parameter, which was not added until 3.10. To work with older python3 versions, this PR implements `bisect_right` manually

[Reviewed by @DanilaFe]