### PR TITLE
Downgrade the version of argcomplete we're using

### DIFF
--- a/third-party/chpl-venv/test-requirements.txt
+++ b/third-party/chpl-venv/test-requirements.txt
@@ -1,4 +1,4 @@
 PyYAML==6.0.1
 filelock==3.12.2
-argcomplete==3.2.1
+argcomplete==3.1.2
 setuptools==69.0.3


### PR DESCRIPTION
The old version was not compatible with Python 3.7, but this new version is still newer than the one we were previously using

Running a full paratest with futures