### PR TITLE
Ignore no matches from `grep` in `checkCopyrights.bash`

### DIFF
--- a/util/test/checkCopyrights.bash
+++ b/util/test/checkCopyrights.bash
@@ -18,8 +18,6 @@
 #  Make*
 #
 
-set -e
-
 # Skip check if we are within a grace period at the beginning of a new year.
 grace_period_end="01-07"
 # Get today's date and the grace period end date as %m%d format for comparison.


### PR DESCRIPTION
Prevent `checkCopyrights.bash` exiting with error when no files are missing copyright.

With the addition of `set -e` in `util/test/checkCopyrights.bash` in https://github.com/chapel-lang/chapel/pull/24126, when the `grep` for files without copyright turns up no results, the resulting exit code 1 causes the script to fail. Since there are many `grep`s in this file and they are the core functionality, we might as well turn off `set -e` rather than manually ignore errors in each instance.

Follow up to https://github.com/chapel-lang/chapel/pull/24126.

[trivial, not reviewed]

Testing:
- [x] `checkCopyrights.bash` works on macOS (including nightly failing machine) and Linux
- [x] `checkCopyrights.bash` still errors for missing copyright