### PR TITLE
Prediff-out the array size in basicMem.good

### DIFF
--- a/test/gpu/native/noGpu/basicMem.comm-none.good
+++ b/test/gpu/native/noGpu/basicMem.comm-none.good
@@ -1,5 +1,5 @@
 0 (gpu 0): basicMem.chpl:5: allocate 88B of domain(1,int(64),one) at 0xPREDIFFED
-0 (gpu 0): basicMem.chpl:5: allocate 160B of [domain(1,int(64),one)] int(64) at 0xPREDIFFED
+0 (gpu 0): basicMem.chpl:5: allocate 1nnB of [domain(1,int(64),one)] int(64) at 0xPREDIFFED
 0 (gpu 0): basicMem.chpl:5: allocate 80B of array elements at 0xPREDIFFED
 0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1519: allocate 48B of metadata about kernel parameters at 0xPREDIFFED
 0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1519: allocate 40B of array of pointers to kernel args at 0xPREDIFFED
@@ -8,5 +8,5 @@
 0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1519: free 40B of array of pointers to kernel args at 0xPREDIFFED
 0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1519: free 48B of metadata about kernel parameters at 0xPREDIFFED
 0 (gpu 0): basicMem.chpl:5: free 80B of array elements at 0xPREDIFFED
-0 (gpu 0): basicMem.chpl:5: free 160B of [domain(1,int(64),one)] int(64) at 0xPREDIFFED
+0 (gpu 0): basicMem.chpl:5: free 1nnB of [domain(1,int(64),one)] int(64) at 0xPREDIFFED
 0 (gpu 0): basicMem.chpl:5: free 88B of domain(1,int(64),one) at 0xPREDIFFED

--- a/test/gpu/native/noGpu/basicMem.good
+++ b/test/gpu/native/noGpu/basicMem.good
@@ -1,7 +1,7 @@
 0 (cpu): --:0: allocate 12B of comm layer remote fork done flag(s) at 0xPREDIFFED
 0 (cpu): --:0: allocate 20B of comm layer private broadcast data at 0xPREDIFFED
 0 (gpu 0): basicMem.chpl:5: allocate 88B of domain(1,int(64),one) at 0xPREDIFFED
-0 (gpu 0): basicMem.chpl:5: allocate 160B of [domain(1,int(64),one)] int(64) at 0xPREDIFFED
+0 (gpu 0): basicMem.chpl:5: allocate 1nnB of [domain(1,int(64),one)] int(64) at 0xPREDIFFED
 0 (gpu 0): basicMem.chpl:5: allocate 80B of array elements at 0xPREDIFFED
 0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1519: allocate 48B of metadata about kernel parameters at 0xPREDIFFED
 0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1519: allocate 40B of array of pointers to kernel args at 0xPREDIFFED
@@ -10,5 +10,5 @@
 0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1519: free 40B of array of pointers to kernel args at 0xPREDIFFED
 0 (gpu 0): $CHPL_HOME/modules/internal/ChapelBase.chpl:1519: free 48B of metadata about kernel parameters at 0xPREDIFFED
 0 (gpu 0): basicMem.chpl:5: free 80B of array elements at 0xPREDIFFED
-0 (gpu 0): basicMem.chpl:5: free 160B of [domain(1,int(64),one)] int(64) at 0xPREDIFFED
+0 (gpu 0): basicMem.chpl:5: free 1nnB of [domain(1,int(64),one)] int(64) at 0xPREDIFFED
 0 (gpu 0): basicMem.chpl:5: free 88B of domain(1,int(64),one) at 0xPREDIFFED

--- a/test/gpu/native/noGpu/basicMem.prediff
+++ b/test/gpu/native/noGpu/basicMem.prediff
@@ -2,3 +2,4 @@
 
 sed -i -e 's/0x.*/0xPREDIFFED/' $2
 sed -i -e '/<internal>/d' $2
+sed -i -e '/basicMem.chpl:5:.*\[domain(1,int(64),one)\] int(64) at/s/ 1[0-9][0-9]B / 1nnB /' $2


### PR DESCRIPTION
This extends the prediff for basicMem.chpl to canonicalize the size of `[domain(1,int(64),one)] int(64)` in the "allocate"/"free" lines of the test's output.

In #24226 I changed basicMem.good to contain 160 instead of the previous 168 bytes in those lines. I did so based on the test behavior that I observed on my laptop. However apparently that size is platform-dependent because it is still 168 bytes in our nightly testing.

Since the test is not intended to lock in the size of the array, this PR makes the prediff replace any size between 100 and 199 bytes with "1nn".

Trivial, not reviewed.