### PR TITLE
dyno: Add support for catchless try/try! in throwing functions

### DIFF
--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -4157,6 +4157,14 @@ void Resolver::exit(const Try* node) {
   if (initResolver && node->isTryBang() && node->numHandlers() > 0) {
     context->error(node, "Only catch-less try! statements are allowed in initializers for now");
   }
+  // Node inherits the type of its expression if it is not a statement.
+  if (node->isExpressionLevel()) {
+    auto expr = node->stmt(0);
+    CHPL_ASSERT(expr);
+    auto& reNode = byPostorder.byAst(node);
+    auto& reExpr = byPostorder.byAst(expr);
+    reNode.setType(reExpr.type());
+  }
   exitScope(node);
 }
 

--- a/frontend/lib/resolution/try-catch-analysis.cpp
+++ b/frontend/lib/resolution/try-catch-analysis.cpp
@@ -232,7 +232,7 @@ struct TryCatchAnalyzer {
                 break;
               }
             }
-            if (!foundCatchAll) {
+            if (!foundCatchAll && !canThrow()) {
               context->error(ast, "call to throwing function '%s' is "
                                   "in a try but not handled",
                                   bestResFn->untyped()->name().c_str());

--- a/frontend/test/resolution/testCatch.cpp
+++ b/frontend/test/resolution/testCatch.cpp
@@ -842,6 +842,21 @@ static void test24(Parser* parser) {
   assert(guard.realizeErrors() == 2);
 }
 
+static void test25() {
+  Context context;
+  auto ctx = &context;
+  ErrorGuard guard(ctx);
+
+  auto t = resolveTypeOfX(ctx,
+                R""""(
+                  proc inner() throws { throw new Error(); }
+                  proc outer() throws { try inner(); return 0; }
+                  var x = try! outer();
+                )"""");
+  assert(t && t->isIntType());
+  assert(!guard.realizeErrors());
+}
+
 
 // TODO: error handling in defer blocks must be complete
 
@@ -877,6 +892,8 @@ int main() {
   test22(p);
   test23(p);
   test24(p);
+
+  test25();
 
   return 0;
 }


### PR DESCRIPTION
Add support for writing catchless `try`/`try!` within functions marked `throws`. While here, also propagate types from child expressions of `try` to the `try` expression itself.

Reviewed by @arezaii. Thanks!