### PR TITLE
Downgrade setuptools for Python 3.7 compatability.

### DIFF
--- a/third-party/chpl-venv/test-requirements.txt
+++ b/third-party/chpl-venv/test-requirements.txt
@@ -1,4 +1,4 @@
 PyYAML==6.0.1
 filelock==3.12.2
 argcomplete==3.1.2
-setuptools==69.0.3
+setuptools==68.0.0


### PR DESCRIPTION
I'm hoping this will be the last one to downgrade.  If not, I may just remove the Python 3.7 job, since we have the okay from some users that were bit by Python compatibility in the past.

Running a full paratest with futures