### PR TITLE
Add 1 to options for `isTrue` in makefiles

### DIFF
--- a/make/Makefile.base
+++ b/make/Makefile.base
@@ -24,7 +24,7 @@
 #
 # utilities
 #
-isTrue = $(filter yes Yes YES y Y true True TRUE t T, $(1))
+isTrue = $(filter yes Yes YES y Y true True TRUE t T 1, $(1))
 
 MAKEFLAGS = --no-print-directory
 


### PR DESCRIPTION
Adds 1 to options for `isTrue` to determine if an env var is set to true. Only a few env vars use this (like `CHPL_COMM_OFI_USE_HUGEPAGES`), but its confusing when `export CHPL_COMM_OFI_USE_HUGEPAGES=1` does not actually turn on huge page support like any other environment variable.

Tested by building with explicit huge pages with `export CHPL_COMM_OFI_USE_HUGEPAGES=1`