### PR TITLE
Don't pass EXECOPTS as arguments to unittest

### DIFF
--- a/test/runtime/jhh/colocales/sub_test
+++ b/test/runtime/jhh/colocales/sub_test
@@ -8,5 +8,5 @@ export PYTHONPATH=${PYTHONPATH:+${PYTHONPATH}:}$dirs
 export PATH=${PATH:+${PATH}:}$CHPL_HOME/util/config
 
 for file in *.py; do
-    python3 $file $@ ${EXECOPTS} -v
+    python3 $file $@ -v
 done


### PR DESCRIPTION
EXECOPTS should only be passed as arguments to Chapel test programs, not to the Python unittest framework as it likely contains arguments such as --memLeaks that unittest will reject.