### PR TITLE
Remove need for `chapel.core` in python bindings

### DIFF
--- a/tools/chapel-py/README.md
+++ b/tools/chapel-py/README.md
@@ -11,7 +11,6 @@ anywhere in `myfile.chpl`.
 
 ```Python
 from chapel import *
-from chapel.core import *
 
 ctx = Context()
 ast = ctx.parse("myfile.chpl")
@@ -68,22 +67,23 @@ in action.
 
 The library is split into three major components:
 
-* The `chapel.core` module which provides the parts of this library that are
-  bridged from C++. This includes the AST node class hierarchy, the `Context`
-  object, and some other supporting code.
-* The `chapel` module provides higher-level, pure Python implementations of
-  certain utility functions. For instance, it provides the `preorder` and `postorder`
-  traversal iterators, and a `match` function to perform AST pattern matching.
+* The `chapel` module provides the AST node class hierarchy and the `Context`
+  object. It also provides some higher-level, pure Python implementations of
+  certain utility functions. For instance, it provides the `preorder` and
+  `postorder`, traversal iterators, and a `match` function to perform AST
+  pattern matching.
 * The `chapel.replace` module provides the "replacer API", which is intended
   to perform transformations on existing Chapel files for various reasons. For
   instance, deprecations and syntax changes can be performed automatically using
   the replacer API, by finding AST patterns and performing string substitution.
 * The `chapel.lsp` module provides a few helpers to tranform Dyno types to LSP
   (Language Server Protocol) types.
+* The `chapel.core` module which provides the parts of this library that are
+  bridged from C++. Most users should not need to use this library, as all symbols are forwarded to `chapel`.
 
 The following sections document the three modules.
 
-### `chapel.core`
+### `chapel`
 
 The main entry point to the Chapel Python API is the `Context` object. This
 is a wrapper around the C++ construct of the same name. The Context in 'dyno'
@@ -151,9 +151,7 @@ METHOD_TABLE(START_NamedDecl,
 );
 ```
 
-### `chapel`
-
-The `chapel` module provides convenience functions for working with the library.
+The `chapel` module also provides convenience functions for working with the library.
 For instance, it provides the `postorder` and `preorder` iterators (the
 implementation of the former is included above). It also provides a couple
 of more advanced helpers for dealing with Chapel ASTs.

--- a/tools/chapel-py/examples/replace.py
+++ b/tools/chapel-py/examples/replace.py
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-from chapel.core import *
+from chapel import *
 from chapel.replace import run, fuse, rename_formals, rename_named_actuals
 import chapel
 from collections import defaultdict

--- a/tools/chapel-py/scripts/generate-pyi.py
+++ b/tools/chapel-py/scripts/generate-pyi.py
@@ -94,7 +94,7 @@ def get_Context_header() -> str:
         _wrap_method(
             "track_errors",
             rettype="ErrorManager",
-            docstring="Generate a stub file for the Chapel AST nodes",
+            docstring="Return a context manager that tracks errors emitted by this Context",
         ),
         _wrap_method(
             "_get_pyi_file",

--- a/tools/chapel-py/setup.py
+++ b/tools/chapel-py/setup.py
@@ -24,7 +24,7 @@ import os
 import sys
 import glob
 
-chpl_home = os.getenv('CHPL_HOME')
+chpl_home = str(os.getenv('CHPL_HOME'))
 chpl_printchplenv = os.path.join(chpl_home, "util", "printchplenv")
 chpl_variables_lines = subprocess.check_output([chpl_printchplenv, "--internal", "--all", " --anonymize", "--simple"]).decode(sys.stdout.encoding).strip().splitlines()
 chpl_variables = dict()
@@ -33,9 +33,10 @@ for line in chpl_variables_lines:
     if len(elms) == 2:
         chpl_variables[elms[0].strip()] = elms[1].strip()
 
-llvm_config = chpl_variables.get("CHPL_LLVM_CONFIG")
+llvm_config = str(chpl_variables.get("CHPL_LLVM_CONFIG"))
 
-chpl_lib_path = os.path.join(chpl_home, "lib", "compiler", chpl_variables.get("CHPL_HOST_BIN_SUBDIR"))
+host_bin_subdir = str(chpl_variables.get("CHPL_HOST_BIN_SUBDIR"))
+chpl_lib_path = os.path.join(chpl_home, "lib", "compiler", host_bin_subdir)
 
 CXXFLAGS = []
 CXXFLAGS += ["-Wno-c99-designator"]

--- a/tools/chapel-py/src/chapel.cpp
+++ b/tools/chapel-py/src/chapel.cpp
@@ -95,7 +95,3 @@ PyMODINIT_FUNC PyInit_core() {
 }
 
 }
-
-int main() {
-  chpl::Context myContext;
-}

--- a/tools/chapel-py/src/chapel/__init__.py
+++ b/tools/chapel-py/src/chapel/__init__.py
@@ -18,6 +18,7 @@
 #
 
 from . import core
+from .core import *
 from collections import defaultdict
 import os
 from typing import Dict, List, Optional
@@ -42,7 +43,7 @@ def postorder(node):
     yield node
 
 
-def is_deprecated(node: core.AstNode) -> bool:
+def is_deprecated(node: AstNode) -> bool:
     """
     Returns true if node is marked with a @deprecated attribute
     """
@@ -52,7 +53,7 @@ def is_deprecated(node: core.AstNode) -> bool:
     return False
 
 
-def is_unstable(node: core.AstNode) -> bool:
+def is_unstable(node: AstNode) -> bool:
     """
     Returns true if node is marked with a @unstable attribute
     """
@@ -62,7 +63,7 @@ def is_unstable(node: core.AstNode) -> bool:
     return False
 
 
-def is_docstring_comment(comment: core.Comment) -> bool:
+def is_docstring_comment(comment: Comment) -> bool:
     """
     comment is a docstring if it doesn't begin with '//'
     """
@@ -77,11 +78,11 @@ class SiblingMap:
     @visitor.visitor
     class SiblingVisitor:
         def __init__(self):
-            self.stack: List[Optional[core.AstNode]] = [None]
-            self.map: Dict[str, core.AstNode] = {}
+            self.stack: List[Optional[AstNode]] = [None]
+            self.map: Dict[str, AstNode] = {}
 
         @visitor.enter
-        def enter_AstNode(self, node: core.AstNode):
+        def enter_AstNode(self, node: AstNode):
             if len(self.stack) > 0:
                 peeked = self.stack[-1]
                 if peeked:
@@ -89,29 +90,29 @@ class SiblingMap:
             self.stack.append(None)
 
         @visitor.exit
-        def exit_AstNode(self, node: core.AstNode):
+        def exit_AstNode(self, node: AstNode):
             self.stack.pop()
             if len(self.stack) > 0:
                 self.stack[-1] = node
 
-    def __init__(self, top_level_modules: List[core.AstNode]):
+    def __init__(self, top_level_modules: List[AstNode]):
         vis = SiblingMap.SiblingVisitor()
         for m in top_level_modules:
             vis.visit(m)
         self.siblings = vis.map
 
-    def get_sibling(self, node: core.AstNode) -> Optional[core.AstNode]:
+    def get_sibling(self, node: AstNode) -> Optional[AstNode]:
         return self.siblings.get(node.unique_id(), None)
 
 
-def get_docstring(node: core.AstNode, sibling_map: SiblingMap) -> Optional[str]:
+def get_docstring(node: AstNode, sibling_map: SiblingMap) -> Optional[str]:
     """
     Get the docstring for a node, if it exists
     """
     prev_sibling = sibling_map.get_sibling(node)
     if (
         prev_sibling
-        and isinstance(prev_sibling, core.Comment)
+        and isinstance(prev_sibling, Comment)
         and is_docstring_comment(prev_sibling)
     ):
         return prev_sibling.text().lstrip().lstrip("/*").rstrip("*/")
@@ -302,7 +303,7 @@ def match_pattern(ast, pattern):
                     return False
 
             return True
-        elif issubclass(pat, core.AstNode):
+        elif issubclass(pat, AstNode):
             # Just check if the AST node matches
             return isinstance(ast, pat)
         else:
@@ -339,7 +340,7 @@ def files_with_contexts(files):
         buckets[bucket].append(filename)
 
     for bucket in buckets:
-        ctx = core.Context()
+        ctx = Context()
         to_yield = buckets[bucket]
 
         for filename in to_yield:

--- a/tools/chapel-py/src/chapel/replace/__init__.py
+++ b/tools/chapel-py/src/chapel/replace/__init__.py
@@ -19,7 +19,7 @@
 
 import argparse
 import chapel
-import chapel.core
+import chapel
 import os
 import sys
 import typing
@@ -61,7 +61,7 @@ class ReplacementContext:
         (row, col) = loc
         return self.lines[row] + (col - 1)
 
-    def node_idx_range(self, node: chapel.core.AstNode) -> (int, int):
+    def node_idx_range(self, node: chapel.AstNode) -> (int, int):
         """
         Given a node, determine where it starts and ends in the given source
         file.
@@ -72,7 +72,7 @@ class ReplacementContext:
         range_end = self.loc_to_idx(loc.end())
         return (range_start, range_end)
 
-    def node_exact_string(self, node: chapel.core.AstNode) -> str:
+    def node_exact_string(self, node: chapel.AstNode) -> str:
         """
         Return the substring that corresponds to the given node in the source
         file.
@@ -80,7 +80,7 @@ class ReplacementContext:
         (range_start, range_end) = self.node_idx_range(node)
         return self.content[range_start:range_end]
 
-    def node_indent(self, node: chapel.core.AstNode) -> int:
+    def node_indent(self, node: chapel.AstNode) -> int:
         """
         Determine the number of characters between the given node and the
         beginning of the line.
@@ -88,7 +88,7 @@ class ReplacementContext:
         (range_start, _) = self.node_idx_range(node)
         return range_start - self.lines[self.lines_back[range_start]]
 
-def rename_formals(rc: ReplacementContext, fn: chapel.core.Function, renames):
+def rename_formals(rc: ReplacementContext, fn: chapel.Function, renames):
     """
     Helper iterator to be used in finder functions. Given a function
     and a map of ('original formal name' -> 'new formal name'), yields
@@ -104,7 +104,7 @@ def rename_formals(rc: ReplacementContext, fn: chapel.core.Function, renames):
 
         yield (child, name_replacer(name))
 
-def rename_named_actuals(rc: ReplacementContext, call: chapel.core.Call, renames):
+def rename_named_actuals(rc: ReplacementContext, call: chapel.Call, renames):
     """
     Helper iterator to be used in finder functions. Given a function call expression,
     and a map of ('original name' -> 'new name'), yields
@@ -123,7 +123,7 @@ def rename_named_actuals(rc: ReplacementContext, call: chapel.core.Call, renames
 
 
 def replace(finder: typing.Generator,
-            ctx: chapel.core.Context,
+            ctx: chapel.Context,
             filename: str) -> str:
     """
     Drives replacement of text based on matches found in `finder`.
@@ -159,7 +159,7 @@ def replace(finder: typing.Generator,
                 else:
                     nodes_to_replace[uid] = replace_with(nodes_to_replace[uid])
 
-    def recurse(node: chapel.core.AstNode):
+    def recurse(node: chapel.AstNode):
         my_replace = None
         if node.unique_id() in nodes_to_replace:
             my_replace = nodes_to_replace[node.unique_id()]
@@ -201,7 +201,7 @@ def replace(finder: typing.Generator,
 
     return new_content
 
-def _do_replace(finder: typing.Generator, ctx: chapel.core.Context, filename: str, suffix: str, inplace: bool):
+def _do_replace(finder: typing.Generator, ctx: chapel.Context, filename: str, suffix: str, inplace: bool):
 
     new_content = replace(finder, ctx, filename)
 

--- a/tools/chapel-py/src/chapel/visitor/__init__.py
+++ b/tools/chapel-py/src/chapel/visitor/__init__.py
@@ -17,6 +17,7 @@
 # limitations under the License.
 #
 
+# use core to prevent circular dependency
 import chapel.core
 
 from collections import defaultdict

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -210,7 +210,7 @@ class NodeAndRange:
             self.rng = location_to_range(self.node.field_location())
         elif isinstance(
             self.node,
-            (chapel.core.Formal, chapel.core.Module, chapel.core.TypeDecl),
+            (chapel.Formal, chapel.Module, chapel.TypeDecl),
         ):
             self.rng = location_to_range(self.node.name_location())
         else:
@@ -237,7 +237,7 @@ class ContextContainer:
     def __init__(self, file: str, config: Optional["WorkspaceConfig"]):
         self.file_paths: List[str] = []
         self.module_paths: List[str] = [file]
-        self.context: chapel.core.Context = chapel.core.Context()
+        self.context: chapel.Context = chapel.Context()
         self.file_infos: List["FileInfo"] = []
 
         if config:
@@ -313,7 +313,7 @@ class FileInfo:
             return self.parse_file()
 
     def _note_reference(
-        self, node: Union[chapel.core.Dot, chapel.core.Identifier]
+        self, node: Union[chapel.Dot, chapel.Identifier]
     ):
         """
         Given a node that can refer to another node, note what it refers

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -40,7 +40,7 @@ import os
 import json
 
 
-import chapel.core
+import chapel
 from chapel.lsp import location_to_range, error_to_diagnostic
 from chapel.visitor import visitor, enter
 from pygls.server import LanguageServer
@@ -86,20 +86,20 @@ from lsprotocol.types import (
 )
 
 
-def decl_kind(decl: chapel.core.NamedDecl) -> Optional[SymbolKind]:
-    if isinstance(decl, chapel.core.Module) and decl.kind() != "implicit":
+def decl_kind(decl: chapel.NamedDecl) -> Optional[SymbolKind]:
+    if isinstance(decl, chapel.Module) and decl.kind() != "implicit":
         return SymbolKind.Module
-    elif isinstance(decl, chapel.core.Class):
+    elif isinstance(decl, chapel.Class):
         return SymbolKind.Class
-    elif isinstance(decl, chapel.core.Record):
+    elif isinstance(decl, chapel.Record):
         return SymbolKind.Struct
-    elif isinstance(decl, chapel.core.Interface):
+    elif isinstance(decl, chapel.Interface):
         return SymbolKind.Interface
-    elif isinstance(decl, chapel.core.Enum):
+    elif isinstance(decl, chapel.Enum):
         return SymbolKind.Enum
-    elif isinstance(decl, chapel.core.EnumElement):
+    elif isinstance(decl, chapel.EnumElement):
         return SymbolKind.EnumMember
-    elif isinstance(decl, chapel.core.Function):
+    elif isinstance(decl, chapel.Function):
         if decl.is_method():
             return SymbolKind.Method
         elif decl.name() in ("init", "init="):
@@ -108,7 +108,7 @@ def decl_kind(decl: chapel.core.NamedDecl) -> Optional[SymbolKind]:
             return SymbolKind.Operator
         else:
             return SymbolKind.Function
-    elif isinstance(decl, chapel.core.Variable):
+    elif isinstance(decl, chapel.Variable):
         if decl.is_field():
             return SymbolKind.Field
         elif decl.intent() == "<const-var>":
@@ -141,7 +141,7 @@ def decl_kind_to_completion_kind(kind: SymbolKind) -> CompletionItemKind:
 
 
 def completion_item_for_decl(
-    decl: chapel.core.NamedDecl,
+    decl: chapel.NamedDecl,
 ) -> Optional[CompletionItem]:
     kind = decl_kind(decl)
     if not kind:
@@ -156,7 +156,7 @@ def completion_item_for_decl(
 
 
 def get_symbol_information(
-    decl: chapel.core.NamedDecl, uri: str
+    decl: chapel.NamedDecl, uri: str
 ) -> Optional[SymbolInformation]:
     loc = Location(uri, location_to_range(decl.location()))
     kind = decl_kind(decl)
@@ -202,11 +202,11 @@ class PositionList(Generic[EltT]):
 
 @dataclass
 class NodeAndRange:
-    node: chapel.core.AstNode
+    node: chapel.AstNode
     rng: Range = field(init=False)
 
     def __post_init__(self):
-        if isinstance(self.node, chapel.core.Dot):
+        if isinstance(self.node, chapel.Dot):
             self.rng = location_to_range(self.node.field_location())
         elif isinstance(
             self.node,
@@ -287,15 +287,15 @@ class FileInfo:
     def_segments: PositionList[NodeAndRange] = field(init=False)
     uses_here: Dict[str, List[NodeAndRange]] = field(init=False)
     siblings: chapel.SiblingMap = field(init=False)
-    used_modules: List[chapel.core.Module] = field(init=False)
-    possibly_visible_decls: List[chapel.core.NamedDecl] = field(init=False)
+    used_modules: List[chapel.Module] = field(init=False)
+    possibly_visible_decls: List[chapel.NamedDecl] = field(init=False)
 
     def __post_init__(self):
         self.use_segments = PositionList(lambda x: x.ident.rng)
         self.def_segments = PositionList(lambda x: x.rng)
         self.rebuild_index()
 
-    def parse_file(self) -> List[chapel.core.AstNode]:
+    def parse_file(self) -> List[chapel.AstNode]:
         """
         Parses this file and returns the toplevel ast elements
 
@@ -305,7 +305,7 @@ class FileInfo:
 
         return self.context.context.parse(self.uri[len("file://") :])
 
-    def get_asts(self) -> List[chapel.core.AstNode]:
+    def get_asts(self) -> List[chapel.AstNode]:
         """
         Returns toplevel ast elements. This method silences all errors.
         """
@@ -329,18 +329,18 @@ class FileInfo:
         )
 
     @enter
-    def _enter_Identifier(self, node: chapel.core.Identifier):
+    def _enter_Identifier(self, node: chapel.Identifier):
         self._note_reference(node)
 
     @enter
-    def _enter_Dot(self, node: chapel.core.Dot):
+    def _enter_Dot(self, node: chapel.Dot):
         self._note_reference(node)
 
     @enter
-    def _enter_NamedDecl(self, node: chapel.core.NamedDecl):
+    def _enter_NamedDecl(self, node: chapel.NamedDecl):
         self.def_segments.append(NodeAndRange(node))
 
-    def _collect_used_modules(self, asts: List[chapel.core.AstNode]):
+    def _collect_used_modules(self, asts: List[chapel.AstNode]):
         self.used_modules = []
         for ast in asts:
             scope = ast.scope()
@@ -351,7 +351,7 @@ class FileInfo:
         self.possibly_visible_decls = []
         for mod in self.used_modules:
             for child in mod:
-                if not isinstance(child, chapel.core.NamedDecl):
+                if not isinstance(child, chapel.NamedDecl):
                     continue
 
                 if child.visibility() == "private":
@@ -612,7 +612,7 @@ def run_lsp():
         # doesn't descend into nested definitions for Functions
         def preorder_ignore_funcs(node):
             yield node
-            if isinstance(node, chapel.core.Function):
+            if isinstance(node, chapel.Function):
                 return
             for child in node:
                 yield from preorder_ignore_funcs(child)
@@ -620,7 +620,7 @@ def run_lsp():
         syms = []
         for node, _ in chapel.each_matching(
             fi.get_asts(),
-            chapel.core.NamedDecl,
+            chapel.NamedDecl,
             iterator=preorder_ignore_funcs,
         ):
             si = get_symbol_information(node, text_doc.uri)

--- a/tools/chpl-language-server/src/symbol_signature.py
+++ b/tools/chpl-language-server/src/symbol_signature.py
@@ -22,66 +22,66 @@ import chapel
 
 
 # TODO: for now, just text based. but should resolve generic types
-def get_symbol_signature(node: chapel.core.AstNode) -> str:
+def get_symbol_signature(node: chapel.AstNode) -> str:
     """
     get a string representation of a AstNode's signature
 
     Note: this is purely textual and does not resolve generic types
     """
-    if not isinstance(node, chapel.core.NamedDecl):
+    if not isinstance(node, chapel.NamedDecl):
         return _node_to_string(node)
 
-    if isinstance(node, chapel.core.Class) or isinstance(
-        node, chapel.core.Record
+    if isinstance(node, chapel.Class) or isinstance(
+        node, chapel.Record
     ):
         return _record_class_to_string(node)
-    elif isinstance(node, chapel.core.Interface):
+    elif isinstance(node, chapel.Interface):
         return f"interface {node.name()}"
-    elif isinstance(node, chapel.core.Module):
+    elif isinstance(node, chapel.Module):
         return f"module {node.name()}"
-    elif isinstance(node, chapel.core.Enum):
+    elif isinstance(node, chapel.Enum):
         return f"enum {node.name()}"
-    elif isinstance(node, chapel.core.Variable):
+    elif isinstance(node, chapel.Variable):
         return _var_to_string(node)
-    elif isinstance(node, chapel.core.Function):
+    elif isinstance(node, chapel.Function):
         return _proc_to_string(node)
 
     return node.name()
 
 
-def _node_to_string(node: chapel.core.AstNode) -> str:
+def _node_to_string(node: chapel.AstNode) -> str:
     """
     General helper method to convert an AstNode to a string representation. If
     it doesn't know how to convert the node, it returns "<...>"
     """
-    if isinstance(node, chapel.core.NamedDecl):
+    if isinstance(node, chapel.NamedDecl):
         return get_symbol_signature(node)
-    elif isinstance(node, chapel.core.Identifier):
+    elif isinstance(node, chapel.Identifier):
         return node.name()
-    elif isinstance(node, chapel.core.IntLiteral):
+    elif isinstance(node, chapel.IntLiteral):
         return node.text()
-    elif isinstance(node, chapel.core.UintLiteral):
+    elif isinstance(node, chapel.UintLiteral):
         return node.text()
-    elif isinstance(node, chapel.core.BoolLiteral):
+    elif isinstance(node, chapel.BoolLiteral):
         return node.value()
-    elif isinstance(node, chapel.core.ImagLiteral):
+    elif isinstance(node, chapel.ImagLiteral):
         return node.text()
-    elif isinstance(node, chapel.core.RealLiteral):
+    elif isinstance(node, chapel.RealLiteral):
         return node.text()
-    elif isinstance(node, chapel.core.StringLiteral):
+    elif isinstance(node, chapel.StringLiteral):
         return '"' + node.value() + '"'
-    elif isinstance(node, chapel.core.CStringLiteral):
+    elif isinstance(node, chapel.CStringLiteral):
         return 'c"' + node.value() + '"'
     return "<...>"
 
 
 def _record_class_to_string(
-    node: Union[chapel.core.Record, chapel.core.Class]
+    node: Union[chapel.Record, chapel.Class]
 ) -> str:
     """
     Convert a Record or a Class to a string
     """
-    keyword = "record" if isinstance(node, chapel.core.Record) else "class"
+    keyword = "record" if isinstance(node, chapel.Record) else "class"
 
     s = ""
     ie = list(node.inherit_exprs())
@@ -96,7 +96,7 @@ def _record_class_to_string(
     return f"{prefix}{keyword} {node.name()}{s}"
 
 
-def _var_to_string(node: chapel.core.VarLikeDecl) -> str:
+def _var_to_string(node: chapel.VarLikeDecl) -> str:
     """
     Convert a VarLikeDecl to a string
     """
@@ -108,7 +108,7 @@ def _var_to_string(node: chapel.core.VarLikeDecl) -> str:
     if node.linkage_name():
         s += f"{_node_to_string(node.linkage_name())} "
 
-    if isinstance(node, chapel.core.Variable):
+    if isinstance(node, chapel.Variable):
         if node.is_config():
             s += "config "
     intent = _intent_to_string(node.intent())
@@ -124,7 +124,7 @@ def _var_to_string(node: chapel.core.VarLikeDecl) -> str:
     return s
 
 
-def _proc_to_string(node: chapel.core.Function) -> str:
+def _proc_to_string(node: chapel.Function) -> str:
     """
     Convert a function to a string
     """

--- a/tools/chplcheck/src/chplcheck.py
+++ b/tools/chplcheck/src/chplcheck.py
@@ -20,7 +20,7 @@
 #
 
 import chapel
-import chapel.core
+import chapel
 import chapel.replace
 import sys
 import argparse

--- a/tools/chplcheck/src/driver.py
+++ b/tools/chplcheck/src/driver.py
@@ -18,7 +18,7 @@
 #
 
 import chapel
-import chapel.core
+import chapel
 import functools
 
 IgnoreAttr = ("chplcheck.ignore", ["rule", "comment"])
@@ -87,7 +87,7 @@ class LintDriver:
         return any(node.name().startswith(p) for p in self.internal_prefixes)
 
     def _is_unstable_module(node):
-        if isinstance(node, chapel.core.Module):
+        if isinstance(node, chapel.Module):
             attrs = node.attribute_group()
             if attrs:
                 if attrs.is_unstable():

--- a/tools/chplcheck/src/lsp.py
+++ b/tools/chplcheck/src/lsp.py
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-import chapel.core
+import chapel
 import chapel.lsp
 from pygls.server import LanguageServer
 from lsprotocol.types import TEXT_DOCUMENT_DID_OPEN, DidOpenTextDocumentParams

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -18,7 +18,7 @@
 #
 
 import chapel
-from chapel.core import *
+from chapel import *
 import re
 
 def name_for_linting(node):

--- a/tools/chpldoc/findUndocumentedSymbols.py
+++ b/tools/chpldoc/findUndocumentedSymbols.py
@@ -77,7 +77,7 @@ import os
 import argparse as ap
 import itertools
 import glob
-import chapel.core as dyno
+import chapel
 from chapel import each_matching, files_with_contexts
 
 
@@ -86,10 +86,10 @@ helpers
 """
 
 
-def get_module(n: dyno.AstNode) -> dyno.AstNode:
+def get_module(n: chapel.AstNode) -> chapel.AstNode:
     if n is None:
         return None
-    if isinstance(n, dyno.Module):
+    if isinstance(n, chapel.Module):
         return n
     parent = n.parent()
     if parent:
@@ -97,7 +97,7 @@ def get_module(n: dyno.AstNode) -> dyno.AstNode:
     return None
 
 
-def node_has_attribute(node: dyno.AstNode, marker: str) -> bool:
+def node_has_attribute(node: chapel.AstNode, marker: str) -> bool:
     """
     a symbol has an attribute if it has an attribute that matches the argument
     """
@@ -106,17 +106,17 @@ def node_has_attribute(node: dyno.AstNode, marker: str) -> bool:
         return any(a.name() == marker for a in attrs)
 
 
-def is_deprecated(node: dyno.AstNode) -> bool:
+def is_deprecated(node: chapel.AstNode) -> bool:
     """a node is deprecated if it or its parent has an attribute that is deprecated"""
     return node_has_attribute(node, "deprecated")
 
 
-def is_unstable(node: dyno.AstNode) -> bool:
+def is_unstable(node: chapel.AstNode) -> bool:
     """a node is unstable if it or its parent has an attribute that is unstable"""
     return node_has_attribute(node, "unstable")
 
 
-def is_nodoc(node: dyno.AstNode) -> bool:
+def is_nodoc(node: chapel.AstNode) -> bool:
     """
     a symbol is marked nodoc for the following reasons
     - symbol has attribute `@chpldoc.nodoc`
@@ -140,7 +140,7 @@ def is_nodoc(node: dyno.AstNode) -> bool:
     # even though arguably `y` is documentable. This is an uncommon scenario
     # and one `chpldoc` also doesn't handle currently
     if (
-        isinstance(node, dyno.MultiDecl)
+        isinstance(node, chapel.MultiDecl)
         and any(
             n.name().startswith("chpl_") for n in node if hasattr(n, "name")
         )
@@ -154,12 +154,12 @@ def is_nodoc(node: dyno.AstNode) -> bool:
     return False
 
 
-def is_docstring_comment(c: dyno.Comment) -> bool:
+def is_docstring_comment(c: chapel.Comment) -> bool:
     """c is a docstring if it doesn't begin with '//'"""
     return not c.text().startswith("//")
 
 
-def get_node_name(node: dyno.AstNode) -> List[str]:
+def get_node_name(node: chapel.AstNode) -> List[str]:
     """
     get the name of a node, even when it may not have a `name()` method
 
@@ -170,17 +170,17 @@ def get_node_name(node: dyno.AstNode) -> List[str]:
 
     """
 
-    def get_simple_node_names(node: dyno.AstNode) -> List[str]:
+    def get_simple_node_names(node: chapel.AstNode) -> List[str]:
         names: List[str] = []
         if hasattr(node, "name"):
             names.append(node.name())
-        elif isinstance(node, dyno.MultiDecl):
+        elif isinstance(node, chapel.MultiDecl):
             names.extend(c.name() for c in node)
         else:
             names.append(str(node))
         return names
 
-    def get_single_name(node: dyno.AstNode) -> str:
+    def get_single_name(node: chapel.AstNode) -> str:
         names = get_simple_node_names(node)
         if len(names) != 1:
             print("Error: violated invariant")
@@ -193,7 +193,7 @@ def get_node_name(node: dyno.AstNode) -> List[str]:
     for name in base_names:
         # handles secondary methods
         if (
-            isinstance(node, dyno.Function)
+            isinstance(node, chapel.Function)
             and node.this_formal()
             and node.this_formal().type_expression()
         ):
@@ -201,8 +201,8 @@ def get_node_name(node: dyno.AstNode) -> List[str]:
             name = f"{aggregate_name}.{name}"
         # handles primary methods and fields
         elif node.parent() and (
-            isinstance(node.parent(), dyno.AggregateDecl)
-            or isinstance(node.parent(), dyno.Interface)
+            isinstance(node.parent(), chapel.AggregateDecl)
+            or isinstance(node.parent(), chapel.Interface)
         ):
             aggregate_name = get_single_name(node.parent())
             name = f"{aggregate_name}.{name}"
@@ -231,7 +231,7 @@ main code
 class FindUndocumentedSymbols:
     def __init__(
         self,
-        asts: List[dyno.AstNode],
+        asts: List[chapel.AstNode],
         ignore_deprecated: bool = False,
         ignore_unstable: bool = False,
     ):
@@ -239,42 +239,42 @@ class FindUndocumentedSymbols:
         self.ignore_deprecated = ignore_deprecated
         self.ignore_unstable = ignore_unstable
 
-    def _parent_is_module_or_aggregate(node: dyno.AstNode, match):
-        return isinstance(node.parent(), (dyno.Module, dyno.AggregateDecl))
+    def _parent_is_module_or_aggregate(node: chapel.AstNode, match):
+        return isinstance(node.parent(), (chapel.Module, chapel.AggregateDecl))
 
     # (pattern, extra check fun)
     documentable_symbol_patterns = {
         "function": (
-            dyno.Function,
+            chapel.Function,
             lambda node, match: isinstance(
-                node.parent(), (dyno.Module, dyno.AggregateDecl, dyno.Interface)
+                node.parent(), (chapel.Module, chapel.AggregateDecl, chapel.Interface)
             ),
         ),
-        "module": (dyno.Module, lambda node, match: node.kind() != "implicit"),
+        "module": (chapel.Module, lambda node, match: node.kind() != "implicit"),
         "aggregate_decl": (
-            dyno.AggregateDecl,
+            chapel.AggregateDecl,
             _parent_is_module_or_aggregate,
         ),
         "decl": (
-            dyno.Variable,
+            chapel.Variable,
             _parent_is_module_or_aggregate,
         ),
         "multi_decl": (
-            dyno.MultiDecl,
+            chapel.MultiDecl,
             _parent_is_module_or_aggregate,
         ),
         "enum": (
-            dyno.Enum,
+            chapel.Enum,
             _parent_is_module_or_aggregate,
         ),
-        "enum_element": (dyno.EnumElement, None),
+        "enum_element": (chapel.EnumElement, None),
         "interface": (
-            dyno.Interface,
+            chapel.Interface,
             _parent_is_module_or_aggregate,
         ),
     }
 
-    def _get_previous_sibling(self, node: dyno.AstNode):
+    def _get_previous_sibling(self, node: chapel.AstNode):
         parent = node.parent()
         lookin = parent if parent else self.asts
         for sib1, sib2 in look_ahead(lookin):
@@ -286,7 +286,7 @@ class FindUndocumentedSymbols:
         for a in self.asts:
             yield from self._get_documentable_symbols(a)
 
-    def _get_documentable_symbols(self, root: dyno.AstNode) -> Generator:
+    def _get_documentable_symbols(self, root: chapel.AstNode) -> Generator:
         def _preorder(node):
             """
             this preorder function respects `--ignore-[deprecated|unstable]`
@@ -314,7 +314,7 @@ class FindUndocumentedSymbols:
             for node, _ in matches:
                 yield node
 
-    def has_doc_comment(self, node: dyno.AstNode) -> bool:
+    def has_doc_comment(self, node: chapel.AstNode) -> bool:
         """
         This node has a doc comment if
         - the previous node is a comment
@@ -323,7 +323,7 @@ class FindUndocumentedSymbols:
         prev = self._get_previous_sibling(node)
         if (
             prev
-            and isinstance(prev, dyno.Comment)
+            and isinstance(prev, chapel.Comment)
             and is_docstring_comment(prev)
         ):
             return True


### PR DESCRIPTION
Removes the need for `chapel.core` from the python bindings, making all the C extension code visible from the top level module `chapel`. This hides some of the implementation details and opens up some possibilities for wrapping C types with python code.

[Reviewed by @DanilaFe]