### PR TITLE
Set `libDir` as part of `setupDefaultFilenames` for driver python multilocale

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2462,6 +2462,9 @@ void setupDefaultFilenames() {
     strncpy(pythonModulename, executableFilename, sizeof(pythonModulename)-1);
     pythonModulename[sizeof(pythonModulename)-1] = '\0';
   }
+
+  // Set the name of the library dir in library mode.
+  if (fLibraryCompile) ensureLibDirExists();
 }
 
 static std::map<const char*, Type*> cnameToTypeMap;


### PR DESCRIPTION
Fix python multilocale library compilation for driver mode.

Multilocale python compilation uses library mode, with library output to `libDir`. The `libDir` path gets set to the Python module name in `ensureLibDirExists`, which is hit a few times in the `compilation` phase. Although the `makeBinary` phase has access to the Python module name (since fix in https://github.com/chapel-lang/chapel/pull/24166), it tries to use the unset `libDir` without ever hitting `ensureLibDirExists`. Fix by running `ensureLibDirExists` in `setupDefaultFilenames` so it happens for the `makeBinary` phase as well.

Follow up to https://github.com/chapel-lang/chapel/pull/23930.

[trivial fix, not reviewed]

Testing:
(with and without `--no-compiler-driver`)
- [x] paratest
- [x] C backend paratest
- [x] gasnet paratest
- [x] nightly failure fixed in reproducing configuration