### PR TITLE
Rename nightly test script `test-monolithic.bash`->`test-no-compiler-driver.bash`

### DIFF
--- a/util/cron/test-no-compiler-driver.bash
+++ b/util/cron/test-no-compiler-driver.bash
@@ -1,12 +1,11 @@
 #!/usr/bin/env bash
 #
-# Test --no-compiler-driver ("monolithic") configuration on full suite
-# on linux64.
+# Test --no-compiler-driver configuration on full suite on linux64.
 
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common.bash
 source $CWD/common-localnode-paratest.bash
 
-export CHPL_NIGHTLY_TEST_CONFIG_NAME="monolithic"
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="no-compiler-driver"
 
 $CWD/nightly -cron -compopts --no-compiler-driver $(get_nightly_paratest_args)


### PR DESCRIPTION
Rename the `util/cron/test-monolithic.bash` script to `test-no-compiler-driver.bash` for clarity.

To be merged with https://github.hpe.com/hpe/hpc-chapel-ci-config/pull/1098 making the change in CI configuration.

[trivial, not reviewed]