### PR TITLE
Remove old flag from SSCA2 multilocale performance testing compiler options

### DIFF
--- a/test/studies/ssca2/main/SSCA2_main.ml-compopts
+++ b/test/studies/ssca2/main/SSCA2_main.ml-compopts
@@ -1,1 +1,1 @@
--M SSCA2_Modules SSCA2_Modules/SSCA2_kernels.chpl SSCA2_Modules/analyze_torus_graphs_stencil_rep_v1.chpl -sBUILD_TORUS_VERSIONS=false -sREPRODUCIBLE_PROBLEMS=true -sPRINT_TIMING_STATISTICS=true -sSERIAL_GRAPH_GEN=false -suseNewFileReaderRegionBounds=true
+-M SSCA2_Modules SSCA2_Modules/SSCA2_kernels.chpl SSCA2_Modules/analyze_torus_graphs_stencil_rep_v1.chpl -sBUILD_TORUS_VERSIONS=false -sREPRODUCIBLE_PROBLEMS=true -sPRINT_TIMING_STATISTICS=true -sSERIAL_GRAPH_GEN=false


### PR DESCRIPTION
I think this got missed because it only happens in multilocale performance testing and because the test itself suppresses some warnings.