### PR TITLE
Stop testing chpldoc in Python 3.7 job

### DIFF
--- a/util/cron/test-linux64-python37.bash
+++ b/util/cron/test-linux64-python37.bash
@@ -10,4 +10,4 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-python37"
 
 set_python_version "3.7"
 
-$CWD/nightly -cron -hellos ${nightly_args}
+$CWD/nightly -cron -pythonDep ${nightly_args}


### PR DESCRIPTION
Some of the packages that we've updated to in order to support chpldoc require Python 3.8.  We've asked users that were bit by dropping Python versions in the past and they are okay with dropping support for Python 3.7, so treat it like we treat our Python 3.5 and 3.6 jobs.

----
Signed-off-by: Lydia Duncan <lydia-duncan@users.noreply.github.com>