### PR TITLE
Add a missing semi-colon to the external-procedure-declaration-statement

### DIFF
--- a/doc/rst/language/spec/interoperability.rst
+++ b/doc/rst/language/spec/interoperability.rst
@@ -63,7 +63,7 @@ An external procedure declaration has the following syntax:
 .. code-block:: syntax
 
    external-procedure-declaration-statement:
-     'extern' external-name[OPT] 'proc' identifier argument-list return-intent[OPT] return-type[OPT]
+     'extern' external-name[OPT] 'proc' identifier argument-list return-intent[OPT] return-type[OPT] ;
 
 Chapel code will call the external function using the parameter types
 supplied in the ``extern`` declaration. Therefore, in general, the type


### PR DESCRIPTION
This should be one of the last things needed for #22088, after Guillaume's documentation updates earlier.

Resolves #22088 

Thanks to Brad for pointing it out!

Letting CI testing double check the fresh doc build, but it looked fine locally