### PR TITLE
Address valgrind timeouts

### DIFF
--- a/test/distributions/robust/associative/performance/COMPOPTS
+++ b/test/distributions/robust/associative/performance/COMPOPTS
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+import os
+
+# For valgrind testing, activate backend optimizations
+# (but don't specialize or turn off bounds checking)
+# in order to make the run time more acceptable
+if os.getenv('CHPL_TEST_VGRND_EXE') == 'on':
+    print('--ccflags -O3')

--- a/test/library/packages/Sort/correctness/COMPOPTS
+++ b/test/library/packages/Sort/correctness/COMPOPTS
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+import os
+
+# For valgrind testing, activate backend optimizations
+# (but don't specialize or turn off bounds checking)
+# in order to make the run time more acceptable
+if os.getenv('CHPL_TEST_VGRND_EXE') == 'on':
+    print('--ccflags -O3')

--- a/test/parallel/bundles/bundles.execopts
+++ b/test/parallel/bundles/bundles.execopts
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import os
 
-# Drop the problem size for valgrin
+# Drop the problem size for valgrind
 if os.getenv('CHPL_TEST_VGRND_EXE') == 'on':
     print('--niters=10')


### PR DESCRIPTION
Follow-up to PR #24147. After that PR, we saw valgrind timeouts in several tests that do some sorting. This PR makes the valgrind testing more efficient by compiling with `--ccflags -O3` when valgrind testing is enabled. In my experiments, this makes running these tests under valgrind at least 4 times faster.

This PR also fixes a missing letter in a comment in another test that adjusts how it runs for valgrind testing.

Test change only - not reviewed.