### PR TITLE
Load deps from Spack install on Osprey

### DIFF
--- a/util/cron/load-base-deps.bash
+++ b/util/cron/load-base-deps.bash
@@ -6,6 +6,11 @@
 if [ -f /data/cf/chapel/chpl-deps/setup_chpl_deps.bash ] ; then
   # for chapcs/chapvm, just load all dependencies via spack
   source /data/cf/chapel/chpl-deps/setup_chpl_deps.bash
+elif [ "$(hostname -s)" == "osprey" ]; then
+  # ditto for osprey
+  if [ -f /cray/css/users/chapelu/chpl-deps/load_chpl_deps.bash ] ; then
+    source /cray/css/users/chapelu/chpl-deps/load_chpl_deps.bash
+  fi
 else
   # For our internal testing, this is necessary to get the latest version of gcc
   # on the system.


### PR DESCRIPTION
Switch to loading Chapel nightly test dependencies via new Spack install for Osprey.

[reviewer info placeholder]

Testing:
- [x] a few manual test runs on Osprey with the change