### PR TITLE
Improve default seed generation in Random module

### DIFF
--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -127,8 +127,8 @@ module Random {
     extern proc getpid(): CTypes.c_int;
 
     const sWho = chpl_task_getId().hash():int,
-          sWhat = getpid():int,
-          sWhen = (Time.timeSinceEpoch().totalSeconds()*1_000_000):int,
+          sWhat = (getpid():int).hash():int,
+          sWhen = Time.timeSinceEpoch().totalSeconds().hash():int,
           sWhere = here.hash():int;
 
     try {

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -121,11 +121,11 @@ module Random {
     return d.isRectangular() && d.rank == 1;
 
 
-  private proc oddTimeSeed(): int(64) {
+  private proc randomishSeed(): int(64) {
     use Time;
-    const seed = (timeSinceEpoch().totalSeconds()*1_000_000): int;
-    const oddseed = if seed % 2 == 0 then seed + 1 else seed;
-    return oddseed;
+    const now = (timeSinceEpoch().totalSeconds()*1_000_000): int;
+
+    return now | (here.hash(): int(64));
   }
 
   pragma "last resort"
@@ -527,7 +527,7 @@ module Random {
     @unstable("The :record:`randomStream` initializer that generates a seed is unstable and subject to change")
     proc init(type eltType) where isNumericOrBoolType(eltType) {
       this.eltType = eltType;
-      this.seed = oddTimeSeed();
+      this.seed = randomishSeed();
       this.pcg = new PCGImpl(eltType, this.seed);
     }
 

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -179,7 +179,6 @@ module Random {
 
     :arg arr: An array of numeric values
   */
-  @unstable("the overload of fillRandom that generates its own seed is unstable")
   proc fillRandom(ref arr: [] ?t)
     where isNumericOrBoolType(t) && arr.isRectangular()
   {
@@ -237,7 +236,6 @@ module Random {
     :arg min: The (inclusive) lower bound for the random values
     :arg max: The (inclusive) upper bound for the random values
   */
-  @unstable("the overload of fillRandom that generates its own seed is unstable")
   proc fillRandom(ref arr: [] ?t, min: t, max: t)
     where isNumericOrBoolType(t) && arr.isRectangular()
   {
@@ -295,7 +293,6 @@ module Random {
 
     :arg arr: A non-strided default rectangular 1D array
   */
-  @unstable("the overload of shuffle that generates its own seed is unstable")
   proc shuffle(ref arr: [?d]) where is1DRectangularDomain(d) {
     var rs = new randomStream(d.idxType);
     rs.shuffle(arr);
@@ -535,7 +532,6 @@ module Random {
       A seed value will be generated in an implementation specific manner
       that depends on the current time.
     */
-    @unstable("The :record:`randomStream` initializer that generates a seed is unstable and subject to change")
     proc init(type eltType) where isNumericOrBoolType(eltType) {
       this.eltType = eltType;
       this.seed = randomishSeed();

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -131,12 +131,14 @@ module Random {
           sWhen = Time.timeSinceEpoch().totalSeconds().hash():int,
           sWhere = here.hash():int;
 
+    var randomBits: int = 0;
     try {
-      var urand = IO.openReader("/dev/urandom");
-      return sWho ^ sWhat ^ sWhen ^ sWhere ^ urand.readBits(int, 64);
+      IO.openReader("/dev/urandom").readBits(randomBits, 64);
     } catch {
-      return sWho ^ sWhat ^ sWhen ^ sWhere;
+      // may not be able to open /dev/urandom, ignore this step
     }
+
+    return sWho ^ sWhat ^ sWhen ^ sWhere ^ randomBits;
   }
 
   pragma "last resort"

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -133,7 +133,7 @@ module Random {
 
     try {
       var urand = IO.openReader("/dev/urandom");
-      return sWho ^ sWhat ^ sWhen ^ sWhere ^ urand.read(int);
+      return sWho ^ sWhat ^ sWhen ^ sWhere ^ urand.readBits(int, 64);
     } catch {
       return sWho ^ sWhat ^ sWhen ^ sWhere;
     }

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -181,6 +181,7 @@ module Random {
 
     :arg arr: An array of numeric values
   */
+  @unstable("the overload of 'fillRandom' that generates its own seed is unstable")
   proc fillRandom(ref arr: [] ?t)
     where isNumericOrBoolType(t) && arr.isRectangular()
   {
@@ -238,6 +239,7 @@ module Random {
     :arg min: The (inclusive) lower bound for the random values
     :arg max: The (inclusive) upper bound for the random values
   */
+  @unstable("the overload of 'fillRandom' that generates its own seed is unstable")
   proc fillRandom(ref arr: [] ?t, min: t, max: t)
     where isNumericOrBoolType(t) && arr.isRectangular()
   {
@@ -295,6 +297,7 @@ module Random {
 
     :arg arr: A non-strided default rectangular 1D array
   */
+  @unstable("the overload of 'shuffle' that generates its own seed is unstable")
   proc shuffle(ref arr: [?d]) where is1DRectangularDomain(d) {
     var rs = new randomStream(d.idxType);
     rs.shuffle(arr);
@@ -534,6 +537,7 @@ module Random {
       A seed value will be generated in an implementation specific manner
       that depends on the current time.
     */
+    @unstable("The :record:`randomStream` initializer that generates a seed is unstable and subject to change")
     proc init(type eltType) where isNumericOrBoolType(eltType) {
       this.eltType = eltType;
       this.seed = randomishSeed();

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -121,11 +121,15 @@ module Random {
     return d.isRectangular() && d.rank == 1;
 
 
-  private proc randomishSeed(): int(64) {
-    use Time;
-    const now = (timeSinceEpoch().totalSeconds()*1_000_000): int;
+  private proc randomishSeed(): int {
+    import Time;
+    extern proc chpl_task_getId(): chpl_taskID_t;
 
-    return now | (here.hash(): int(64));
+    const sWhen = (Time.timeSinceEpoch().totalSeconds()*1_000_000):int,
+          sWhere = here.hash():int,
+          sWho = chpl_task_getId().hash():int;
+
+    return sWhen ^ sWhere ^ sWho;
   }
 
   pragma "last resort"

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -122,14 +122,21 @@ module Random {
 
 
   private proc randomishSeed(): int {
-    import Time;
+    import Time, IO, CTypes;
     extern proc chpl_task_getId(): chpl_taskID_t;
+    extern proc getpid(): CTypes.c_int;
 
-    const sWhen = (Time.timeSinceEpoch().totalSeconds()*1_000_000):int,
-          sWhere = here.hash():int,
-          sWho = chpl_task_getId().hash():int;
+    const sWho = chpl_task_getId().hash():int,
+          sWhat = getpid():int,
+          sWhen = (Time.timeSinceEpoch().totalSeconds()*1_000_000):int,
+          sWhere = here.hash():int;
 
-    return sWhen ^ sWhere ^ sWho;
+    try {
+      var urand = IO.openReader("/dev/urandom");
+      return sWho ^ sWhat ^ sWhen ^ sWhere ^ urand.read(int);
+    } catch {
+      return sWho ^ sWhat ^ sWhen ^ sWhere;
+    }
   }
 
   pragma "last resort"

--- a/test/classes/weakPointers/passiveCache.good
+++ b/test/classes/weakPointers/passiveCache.good
@@ -3,4 +3,6 @@ passiveCache.chpl:46: In method 'buildAndSave':
 passiveCache.chpl:48: warning: The `weak` type is experimental; expect this API to change in the future.
   passiveCache.chpl:38: called as (PassiveCache(basicClass)).buildAndSave(key: int(64)) from method 'getOrBuild'
   passiveCache.chpl:66: called as (PassiveCache(basicClass)).getOrBuild(key: int(64))
+passiveCache.chpl:61: In function 'main':
+passiveCache.chpl:72: warning: the overload of 'fillRandom' that generates its own seed is unstable
 true

--- a/test/classes/weakPointers/passiveCache.good
+++ b/test/classes/weakPointers/passiveCache.good
@@ -3,6 +3,4 @@ passiveCache.chpl:46: In method 'buildAndSave':
 passiveCache.chpl:48: warning: The `weak` type is experimental; expect this API to change in the future.
   passiveCache.chpl:38: called as (PassiveCache(basicClass)).buildAndSave(key: int(64)) from method 'getOrBuild'
   passiveCache.chpl:66: called as (PassiveCache(basicClass)).getOrBuild(key: int(64))
-passiveCache.chpl:61: In function 'main':
-passiveCache.chpl:72: warning: the overload of fillRandom that generates its own seed is unstable
 true

--- a/test/unstable/randomModule.chpl
+++ b/test/unstable/randomModule.chpl
@@ -4,11 +4,18 @@ use Random;
 
 var a: [1..10] int;
 
+// overload that doesn't accept a seed is unstable
+fillRandom(a);
+
+// overload that doesn't accept a seed is unstable
+shuffle(a);
+
 permutation(a);
 permutation(a, 123);
 writeln(a);
 
-var rs = new randomStream(int, 123);
+var rs = new randomStream(int, 123),
+    rsu = new randomStream(int);
 
 rs.permutation(a);
 writeln(a);

--- a/test/unstable/randomModule.chpl
+++ b/test/unstable/randomModule.chpl
@@ -4,12 +4,6 @@ use Random;
 
 var a: [1..10] int;
 
-// overload that doesn't accept a seed is unstable
-fillRandom(a);
-
-// overload that doesn't accept a seed is unstable
-shuffle(a);
-
 permutation(a);
 permutation(a, 123);
 writeln(a);

--- a/test/unstable/randomModule.good
+++ b/test/unstable/randomModule.good
@@ -1,17 +1,15 @@
-randomModule.chpl:8: warning: the overload of fillRandom that generates its own seed is unstable
-randomModule.chpl:11: warning: the overload of shuffle that generates its own seed is unstable
+randomModule.chpl:7: warning: 'permutation' is unstable and subject to change
+randomModule.chpl:8: warning: 'permutation' is unstable and subject to change
 randomModule.chpl:13: warning: 'permutation' is unstable and subject to change
-randomModule.chpl:14: warning: 'permutation' is unstable and subject to change
-randomModule.chpl:19: warning: 'permutation' is unstable and subject to change
-randomModule.chpl:22: warning: 'choice' is unstable and subject to change
-randomModule.chpl:23: warning: 'choice' is unstable and subject to change
-randomModule.chpl:24: warning: 'choice' is unstable and subject to change
-randomModule.chpl:26: warning: 'skipToNth' is unstable and subject to change
-randomModule.chpl:27: warning: 'getNth' is unstable and subject to change
-randomModule.chpl:29: warning: 'iterate' is unstable and subject to change
-randomModule.chpl:29: warning: 'iterate' is unstable and subject to change
-randomModule.chpl:33: warning: 'iterate' is unstable and subject to change
-randomModule.chpl:33: warning: 'iterate' is unstable and subject to change
+randomModule.chpl:16: warning: 'choice' is unstable and subject to change
+randomModule.chpl:17: warning: 'choice' is unstable and subject to change
+randomModule.chpl:18: warning: 'choice' is unstable and subject to change
+randomModule.chpl:20: warning: 'skipToNth' is unstable and subject to change
+randomModule.chpl:21: warning: 'getNth' is unstable and subject to change
+randomModule.chpl:23: warning: 'iterate' is unstable and subject to change
+randomModule.chpl:23: warning: 'iterate' is unstable and subject to change
+randomModule.chpl:27: warning: 'iterate' is unstable and subject to change
+randomModule.chpl:27: warning: 'iterate' is unstable and subject to change
 6 7 9 5 3 8 2 1 4 10
 6 7 9 5 3 8 2 1 4 10
 8

--- a/test/unstable/randomModule.good
+++ b/test/unstable/randomModule.good
@@ -1,15 +1,18 @@
-randomModule.chpl:7: warning: 'permutation' is unstable and subject to change
-randomModule.chpl:8: warning: 'permutation' is unstable and subject to change
+randomModule.chpl:8: warning: the overload of 'fillRandom' that generates its own seed is unstable
+randomModule.chpl:11: warning: the overload of 'shuffle' that generates its own seed is unstable
 randomModule.chpl:13: warning: 'permutation' is unstable and subject to change
-randomModule.chpl:16: warning: 'choice' is unstable and subject to change
-randomModule.chpl:17: warning: 'choice' is unstable and subject to change
-randomModule.chpl:18: warning: 'choice' is unstable and subject to change
-randomModule.chpl:20: warning: 'skipToNth' is unstable and subject to change
-randomModule.chpl:21: warning: 'getNth' is unstable and subject to change
-randomModule.chpl:23: warning: 'iterate' is unstable and subject to change
-randomModule.chpl:23: warning: 'iterate' is unstable and subject to change
-randomModule.chpl:27: warning: 'iterate' is unstable and subject to change
-randomModule.chpl:27: warning: 'iterate' is unstable and subject to change
+randomModule.chpl:14: warning: 'permutation' is unstable and subject to change
+randomModule.chpl:18: warning: The randomStream initializer that generates a seed is unstable and subject to change
+randomModule.chpl:20: warning: 'permutation' is unstable and subject to change
+randomModule.chpl:23: warning: 'choice' is unstable and subject to change
+randomModule.chpl:24: warning: 'choice' is unstable and subject to change
+randomModule.chpl:25: warning: 'choice' is unstable and subject to change
+randomModule.chpl:27: warning: 'skipToNth' is unstable and subject to change
+randomModule.chpl:28: warning: 'getNth' is unstable and subject to change
+randomModule.chpl:30: warning: 'iterate' is unstable and subject to change
+randomModule.chpl:30: warning: 'iterate' is unstable and subject to change
+randomModule.chpl:34: warning: 'iterate' is unstable and subject to change
+randomModule.chpl:34: warning: 'iterate' is unstable and subject to change
 6 7 9 5 3 8 2 1 4 10
 6 7 9 5 3 8 2 1 4 10
 8


### PR DESCRIPTION
Improve the default seed generated for a `randomStream` by including the following pieces of information:
* process ID
* task ID
* locale ID
* current time
* bits from `/dev/urandom` (if available)

This extra information will significantly reduce the likelihood that two `randomStream`'s generated around the same time will have the same seed value.

Resolves: https://github.com/chapel-lang/chapel/issues/24178

- [x] paratest