### PR TITLE
add `GPU_MEM_STRATEGY` to list of Chapel variables in overrides.py

### DIFF
--- a/util/chplenv/overrides.py
+++ b/util/chplenv/overrides.py
@@ -34,6 +34,7 @@ chplvars = [
 
              'CHPL_LOCALE_MODEL',
              'CHPL_GPU',
+             'CHPL_GPU_MEM_STRATEGY',
              'CHPL_CUDA_PATH',
              'CHPL_ROCM_PATH',
              'CHPL_GPU_ARCH',


### PR DESCRIPTION
This PR adds a missing gpu variable to the list of known env variables in `overrides.py`. Previously, if this script encountered `CHPL_GPU_MEM_STRATEGY` in a `chplconfig` file it would emit a warning about an unknown variable name.

The problem would really only be visible if you had installed chapel or otherwise edited a `chplconfig` file to contain this key. 

TESTING:

- [x] setting other known gpu vars from https://chapel-lang.org/docs/technotes/gpu.html#gpu-related-environment-variables does not cause a warning
- [x] warning no longer present with this PR
- [x] paratest chapdl-nvidia `[Summary: #Successes = 173 | #Failures = 0 | #Futures = 5]`

[reviewed by @e-kayrakli - thanks!]