### PR TITLE
Made driver technote clarifications

### DIFF
--- a/doc/rst/technotes/driver.rst
+++ b/doc/rst/technotes/driver.rst
@@ -12,7 +12,8 @@ Compiler Driver Mode
    filing an issue as described in :ref:`readme-bugs`. Driver mode can be
    disabled with the ``--no-compiler-driver`` compiler flag, to determine if the
    problem is specific to driver mode or as a temporary workaround before it is
-   fixed.
+   fixed. This flag will be removed at some point in the future when driver mode
+   becomes the only option.
 
 The Chapel compiler ``chpl`` previously ran as a single executable responsible
 for compilation, assembly, and linking, with some components done in

--- a/doc/rst/technotes/driver.rst
+++ b/doc/rst/technotes/driver.rst
@@ -23,8 +23,10 @@ A compiler driver is a smaller program responsible for processing arguments and
 invoking separate processes for the different stages of compilation required. As
 of release 1.34, ``chpl`` runs as a compiler driver by default, with the
 following phases run as separate subprocesses:
+
 - ``compilation``: Everything through code generation (C code or LLVM bitcode).
 - ``makeBinary``: Binary generation (including linking).
+
 Driver mode can be opted-out of with ``--no-compiler-driver``. This flag will be
 removed at some point in the future when driver mode becomes the only option.
 

--- a/doc/rst/technotes/driver.rst
+++ b/doc/rst/technotes/driver.rst
@@ -25,7 +25,7 @@ of release 1.34, ``chpl`` runs as a compiler driver by default, with the
 following phases run as separate subprocesses:
 
 - ``compilation``: Everything through code generation (C code or LLVM bitcode).
-- ``makeBinary``: Binary generation (including linking).
+- ``makeBinary``: Compiling C or LLVM code to an executable.
 
 Driver mode can be opted-out of with ``--no-compiler-driver``. This flag will be
 removed at some point in the future when driver mode becomes the only option.

--- a/doc/rst/technotes/driver.rst
+++ b/doc/rst/technotes/driver.rst
@@ -16,14 +16,17 @@ Compiler Driver Mode
    becomes the only option.
 
 The Chapel compiler ``chpl`` previously ran as a single executable responsible
-for compilation, assembly, and linking, with some components done in
+for all steps of compilation, with some components done in
 subprocesses depending on which backend is used. By contrast, many compiler
 executables (including ``gcc`` and ``clang``) are actually `compiler drivers`.
 A compiler driver is a smaller program responsible for processing arguments and
 invoking separate processes for the different stages of compilation required. As
-of release 1.34, ``chpl`` runs as a compiler driver by default, which can be
-opted-out of with ``--no-compiler-driver``. This flag will be removed at some
-point in the future when driver mode becomes the only option.
+of release 1.34, ``chpl`` runs as a compiler driver by default, with the
+following phases run as separate subprocesses:
+- ``compilation``: Everything through code generation (C code or LLVM bitcode).
+- ``makeBinary``: Binary generation (including linking).
+Driver mode can be opted-out of with ``--no-compiler-driver``. This flag will be
+removed at some point in the future when driver mode becomes the only option.
 
 ---------------------
 Motivation for Driver

--- a/doc/rst/technotes/driver.rst
+++ b/doc/rst/technotes/driver.rst
@@ -21,7 +21,7 @@ subprocesses depending on which backend is used. By contrast, many compiler
 executables (including ``gcc`` and ``clang``) are actually `compiler drivers`.
 A compiler driver is a smaller program responsible for processing arguments and
 invoking separate processes for the different stages of compilation required. As
-of release 1.33, ``chpl`` runs as a compiler driver by default, which can be
+of release 1.34, ``chpl`` runs as a compiler driver by default, which can be
 opted-out of with ``--no-compiler-driver``. This flag will be removed at some
 point in the future when driver mode becomes the only option.
 


### PR DESCRIPTION
Make a few clarifications to the driver mode technote.

- Add a message to the "Note" section at the top of the driver technote pointing out that `--no-compiler-driver` will be going away at some point.
- Fix a sentence which incorrectly states the driver was turned on by default for 1.33 -- it was for 1.34.
- Note the names of the phases in the first paragraph.

Made with suggestions from @vasslitvinov , thanks!

[trivial doc update, not reviewed]