### PR TITLE
Set CHPL_TARGET_CPU=native in GPU performance testing

### DIFF
--- a/util/cron/test-perf.gpu-cuda.bash
+++ b/util/cron/test-perf.gpu-cuda.bash
@@ -20,6 +20,7 @@ source $CWD/common-native-gpu-perf.bash
 # make sure this comes after setting SUBDIR (set by native-gpu-perf) and
 # CONFIG_NAME
 source $CWD/common-perf.bash
+export CHPL_TARGET_CPU=native
 
 
 nightly_args="${nightly_args} -startdate 07/15/22"

--- a/util/cron/test-perf.gpu-cuda.um.bash
+++ b/util/cron/test-perf.gpu-cuda.um.bash
@@ -21,6 +21,7 @@ source $CWD/common-native-gpu-perf.bash
 # make sure this comes after setting SUBDIR (set by native-gpu-perf) and
 # CONFIG_NAME
 source $CWD/common-perf.bash
+export CHPL_TARGET_CPU=native
 
 SHORT_NAME=um
 nightly_args="${nightly_args} -performance-description $SHORT_NAME -performance-configs default:v,$SHORT_NAME:v -sync-dir-suffix $SHORT_NAME"

--- a/util/cron/test-perf.gpu-rocm.bash
+++ b/util/cron/test-perf.gpu-rocm.bash
@@ -20,6 +20,7 @@ source $CWD/common-native-gpu-perf.bash
 # make sure this comes after setting SUBDIR (set by native-gpu-perf) and
 # CONFIG_NAME
 source $CWD/common-perf.bash
+export CHPL_TARGET_CPU=native
 
 
 nightly_args="${nightly_args} -startdate 07/20/23"


### PR DESCRIPTION
We got confused by lack of this setting in the past. Without it, runs always generate warnings that get ignored in the performance setting. That is fine in steady state, but if there's a failure, we see the warning in the full output, which is almost always a red herring.