### PR TITLE
Implement `pragma "last resort"` resolution in Dyno

### DIFF
--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -3364,15 +3364,6 @@ void Resolver::exit(const Call* call) {
 
     // handle type inference for variables split-inited by 'out' formals
     adjustTypesForOutFormals(ci, actualAsts, c.mostSpecific());
-  } else {
-    // For practical development/debugging, set the ResolvedExpression for
-    // this call in case resolution proceeds to the point where some other
-    // part of resolution assumes there is an entry for this call.
-    //
-    // Otherwise we would run into out_of_range exceptions when accessing
-    // the resolution result.
-    ResolvedExpression& r = byPostorder.byAst(call);
-    r.setType(QualifiedType());
   }
 
   inLeafCall = nullptr;

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1494,6 +1494,7 @@ bool Resolver::handleResolvedCallWithoutError(ResolvedExpression& r,
 
   if (!c.exprType().hasTypePtr()) {
     r.setType(QualifiedType(r.type().kind(), ErroneousType::get(context)));
+    r.setMostSpecific(c.mostSpecific());
     return true;
   } else {
     r.setPoiScope(c.poiInfo().poiScope());

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -3265,12 +3265,16 @@ struct LastResortCandidateGroups {
   chpl::optional<CandidatesVec> nonPoi;
   // Poi candidates from innermost (more preferred) to outermost scope.
   std::vector<CandidatesVec> poi;
-
-  // Forwarding candidate groups
-  owned<LastResortCandidateGroups> forwardingCandidateGroups = nullptr;
-  // Forwarding-to information, used if this instance is from forwarding.
+  // Forwarding-to information for non-poi and poi candidates, respectively.
+  // These are used if this LastResortCandidateGroups is for candidates from
+  // forwarding.
   ForwardingInfoVec nonPoiForwardingInfo;
   std::vector<ForwardingInfoVec> poiForwardingInfo;
+
+  // A LastResortCandidateGroups for candidates found via forwarding from the
+  // site of the current group. This is effectively a linked list due to the
+  // possibility of forwards-to-forwards.
+  owned<LastResortCandidateGroups> forwardingCandidateGroups = nullptr;
 };
 
 // Returns candidates with last resort candidates removed and saved in a

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -57,6 +57,8 @@ namespace resolution {
 using namespace uast;
 using namespace types;
 
+// TODO: Since these are always used together with corresponding indices, tie
+// them together in a tuple or new data structure.
 using CandidatesVec = std::vector<const TypedFnSignature*>;
 using ForwardingInfoVec = std::vector<QualifiedType>;
 

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -3181,8 +3181,8 @@ struct LastResortCandidateGroups {
   }
 
   // Retrieve the last group added.
-  // This method assumes at least one group has been added.
   const CandidatesVec& lastGroup() const {
+    CHPL_ASSERT(nonPoiSet && "expected at least one group added");
     if (numPoiGroups() > 0) {
       return poi.back();
     } else {

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -3199,7 +3199,7 @@ struct LastResortCandidateGroups {
     // recurse into other's forwarding groups
     if (forwardingCandidateGroups) {
       forwardingCandidateGroups->mergeWithGroups(
-          std::move(*other.forwardingCandidateGroups));
+          std::move(other.getForwardingGroups()));
     } else {
       forwardingCandidateGroups = std::move(other.forwardingCandidateGroups);
     }

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -3356,7 +3356,7 @@ static bool isInsideForwarding(Context* context, const Call* call) {
 // separate list.
 static void filterCandidatesLastResort(
     Context* context, const CandidatesVec& list, CandidatesVec& result,
-    std::vector<const CandidatesVec>& lastResort) {
+    std::vector<CandidatesVec>& lastResort) {
   CandidatesVec newLastResortCandidates;
 
   for (auto& candidate : list) {
@@ -3396,7 +3396,7 @@ gatherAndFilterCandidates(Context* context,
   CandidatesVec candidates;
   // Last resort candidates, grouped by without-POI, then from innermost POI
   // scope outward, then forwading.
-  std::vector<const CandidatesVec> lrcGroups;
+  std::vector<CandidatesVec> lrcGroups;
   CheckedScopes visited;
   firstPoiCandidate = 0;
 

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -3198,7 +3198,10 @@ struct LastResortCandidateGroups {
   }
 
   const CandidatesVec nonPoiCandidates() const {
-    return nonPoi.value_or(CandidatesVec());
+    if (nonPoi)
+      return *nonPoi;
+    else
+      return CandidatesVec();
   }
 
   const size_t numPoiGroups() const {

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -3566,7 +3566,7 @@ gatherAndFilterCandidates(Context* context,
 
   // If no candidates have been found, consider last resort candidates from
   // innermost to outermost.
-  for (int i = 0; i < lrcGroups.size(); i++) {
+  for (size_t i = 0; i < lrcGroups.size(); i++) {
     if (candidates.empty()) {
       candidates = lrcGroups[i];
       // Bump firstPoiCandidate index after non-POI last resorts
@@ -3578,7 +3578,7 @@ gatherAndFilterCandidates(Context* context,
     }
   }
   // If still no candidates, repeat for last resort candidates from forwarding.
-  for (int i = 0; i < forwardingLrcGroups.size(); i++) {
+  for (size_t i = 0; i < forwardingLrcGroups.size(); i++) {
     if (candidates.empty()) {
       candidates = forwardingLrcGroups[i];
       forwardingInfo = forwardingLrcForwardingTo[i];

--- a/frontend/test/resolution/testForwarding.cpp
+++ b/frontend/test/resolution/testForwarding.cpp
@@ -456,7 +456,44 @@ static void testForwardForwardExpr() {
   forwardForwardHelper("forwarding var x = bar();", /*isVar=*/true);
 }
 
-// TODO: forwarding with only, except
+// Two different levels of forwarding->forwarding
+static void test7() {
+  printf("test7\n");
+
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  const char* contents =
+    R""""(
+    module M {
+      operator +=(ref lhs: int, rhs: int) { }
+      record Inner {
+        var i: int;
+        pragma "last resort"
+        proc ref addOne() {
+          i += 1;
+          return 1.0;
+        }
+      }
+      record Middle {
+        forwarding var impl: Inner;
+      }
+      record Outer {
+        forwarding var impl: Middle;
+        forwarding var anotherImpl: Inner;
+      }
+
+      var rec: Outer;
+      var x = rec.addOne();
+    }
+    )"""";
+
+  auto qt = resolveQualifiedTypeOfX(context, contents);
+  assert(qt.type()->isRealType());
+
+  guard.realizeErrors();
+}
 
 
 int main() {
@@ -471,6 +508,10 @@ int main() {
 
   testExpr();
   testForwardForwardExpr();
+
+  test7();
+
+  // TODO: forwarding with only, except
 
   return 0;
 }

--- a/frontend/test/resolution/testOperatorOverloads.cpp
+++ b/frontend/test/resolution/testOperatorOverloads.cpp
@@ -355,6 +355,25 @@ static void test8() {
   assert(initType.kind() == QualifiedType::VAR);
 }
 
+// Ambiguous overloads with last resort.
+static void test9() {
+  Context ctx;
+  auto context = &ctx;
+
+  QualifiedType qt = resolveTypeOfXInit(context,
+                                        R""""(
+      record R {
+        var field: int;
+        operator :(z: R, type t: int) { return z.field; }
+        pragma "last resort"
+        operator :(z: R, type t: int) { return z.field + 1; }
+      }
+      var myR: R;
+      var x = myR : int;
+    )"""");
+  assert(qt.type() && qt.type()->isIntType());
+  assert(qt.kind() == QualifiedType::CONST_VAR);
+}
 
 int main() {
   test1();
@@ -365,6 +384,7 @@ int main() {
   test6();
   test7();
   test8();
+  test9();
 
   return 0;
 }

--- a/frontend/test/resolution/testResolve.cpp
+++ b/frontend/test/resolution/testResolve.cpp
@@ -950,7 +950,7 @@ static void test20() {
 
     assert(guard.numErrors() == 1);
     assert(guard.error(0)->message() ==
-           "Could not resolve call to foo: ambiguity");
+           "Cannot resolve call to 'foo': ambiguity");
     guard.realizeErrors();
 
     context->collectGarbage();
@@ -984,7 +984,7 @@ static void test20() {
     assert(m->numStmts() == 3);
 
     // variable initialized with foo call
-    const Variable* x = m->stmt(1)->toVariable();
+    const Variable* x = m->stmt(2)->toVariable();
     assert(x);
     const AstNode* rhs = x->initExpression();
     assert(rhs);
@@ -1000,7 +1000,7 @@ static void test20() {
     // Check we called the correct foo.
     assert(c.fn()->untyped()->name() == "foo");
     assert(c.fn()->numFormals() == 1);
-    assert(c.fn()->formalName(0) == "x");
+    assert(c.fn()->formalName(0) == "y");
     assert(c.fn()->formalType(0).type());
     assert(c.fn()->formalType(0).type()->isIntType());
 

--- a/frontend/test/resolution/testResolve.cpp
+++ b/frontend/test/resolution/testResolve.cpp
@@ -1006,6 +1006,64 @@ static void test20() {
 
     context->collectGarbage();
   }
+
+  // Test resolving between forwarded-to methods where just one is last resort.
+  {
+    printf("part 4\n");
+    context->advanceToNextRevision(true);
+
+    auto path = UniqueString::get(context, "input.chpl");
+    std::string contents = R""""(
+        module M {
+          record MyImpl {
+            proc foo(x: int) {
+              return x;
+            }
+            pragma "last resort"
+            proc foo(y: int) {
+              return y;
+            }
+          }
+          record MyForward {
+            forwarding var impl: MyImpl;
+          }
+          var mf: MyForward;
+          var x = mf.foo(4);
+        }
+                          )"""";
+
+    setFileText(context, path, contents);
+
+    const ModuleVec& vec = parseToplevel(context, path);
+    assert(vec.size() == 1);
+    const Module* m = vec[0]->toModule();
+    assert(m);
+    assert(m->numStmts() == 4);
+
+    // variable initialized with foo call
+    const Variable* x = m->stmt(3)->toVariable();
+    assert(x);
+    const AstNode* rhs = x->initExpression();
+    assert(rhs);
+    const FnCall* fnCall = rhs->toFnCall();
+    assert(fnCall);
+
+    // Get called foo
+    const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
+    const ResolvedExpression& re = rr.byAst(fnCall);
+    auto c = re.mostSpecific().only();
+    assert(c);
+
+    // Check we called the correct foo.
+    assert(c.fn()->untyped()->name() == "foo");
+    assert(c.fn()->numFormals() == 2);
+    assert(c.fn()->formalName(0) == "this");
+    assert(c.fn()->formalName(1) == "x");
+    assert(c.fn()->formalType(1).type());
+    assert(c.fn()->formalType(1).type()->isIntType());
+
+    context->collectGarbage();
+  }
 }
 
 int main() {

--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -495,12 +495,6 @@ module CTypes {
     }
     return __primitive("cast", t, x);
   }
-  // c_ptr(void) specialization to allow implicit conversion of casted value
-  pragma "last resort"
-  @chpldoc.nodoc
-  inline operator :(x:c_ptr(void), type t:c_ptr) {
-    return __primitive("cast", t, x);
-  }
   @chpldoc.nodoc
   inline operator c_ptrConst.:(x:c_ptrConst, type t:c_ptrConst) {
     // emit warning for C strict aliasing violations
@@ -563,6 +557,8 @@ module CTypes {
   inline operator :(x:c_ptrConst, type t:c_ptrConst(void)) {
     return __primitive("cast", t, x);
   }
+  // c_ptr(void) specialization of c_ptr->c_ptr cast, to enable implicit
+  // conversion of casted value to c_ptr(void)
   @chpldoc.nodoc
   inline operator :(x:c_ptr(void), type t:c_ptr) {
     return __primitive("cast", t, x);


### PR DESCRIPTION
Implement resolution of functions with `pragma "last resort"` in Dyno.

Modeled off of how the production compiler resolves `last resort`s -- `last resort` candidates are kept aside and not considered unless no non-`last resort`s work. If they're needed, they are considered in groups starting from non-POI through each successive containing POI scope, stopping after any group that has any candidates. Includes handling of forwarded-to `last resort` methods, with forwards-to-forwards treated as less preferable.

This originally surfaced in https://github.com/Cray/chapel-private/issues/5863 as two identical `c_ptr(void)->c_ptr(T)` casts (one of which was last resort) being considered ambiguous by Dyno but not production.

Thanks @DanilaFe for help ensuring the resolution behavior for forwarded-to methods was correct.

Resolves https://github.com/Cray/chapel-private/issues/5863.

Future work:
- Combine `CandidatesVec` and `ForwardingInfoVec` into one data structure since they're always used together.

[reviewer info placeholder]

Testing:
- [x] dyno tests
- [x] paratest
- [x] bug reproducer no longer errors