### PR TITLE
Store formal-actual maps in found candidates

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -466,7 +466,7 @@ const char* Symbol::getSanitizedMsg(std::string msg) const {
   return astr(chpl::removeSphinxMarkup(msg));
 }
 
-std::unordered_set<std::pair<Symbol*,Expr*>> dedupDeprecationWarnings;
+std::unordered_set<std::pair<Symbol*,Expr*>, chpl::detail::hasher<std::pair<Symbol*, Expr*>>> dedupDeprecationWarnings;
 
 void Symbol::maybeGenerateDeprecationWarning(Expr* context) {
   if (!this->hasFlag(FLAG_DEPRECATED)) return;
@@ -535,7 +535,7 @@ static bool isUnstableShouldWarn(Symbol* sym, Expr* initialContext) {
   return fWarnUnstable;
 }
 
-std::unordered_set<std::pair<Symbol*,Expr*>> dedupUnstableWarnings;
+std::unordered_set<std::pair<Symbol*,Expr*>, chpl::detail::hasher<std::pair<Symbol*, Expr*>>> dedupUnstableWarnings;
 
 //based on maybeGenerateDeprecationWarning
 void Symbol::maybeGenerateUnstableWarning(Expr* context) {

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -70,7 +70,8 @@ using VisitedModulesSet = std::set<std::pair<ModuleSymbol*, const char*>>;
 // key: pair of module symbol and name to lookup
 // value: vector of Symbol* that it resolved to
 static std::unordered_map<std::pair<ModuleSymbol*, const char*>,
-                          std::vector<Symbol*>> modSymsCache;
+                          std::vector<Symbol*>,
+                          chpl::detail::hasher<std::pair<ModuleSymbol*, const char*>>> modSymsCache;
 
 // To avoid duplicate user warnings in checkIdInsideWithClause().
 // Using pair<> instead of astlocT to avoid defining operator<.

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -1214,7 +1214,7 @@ class MostSpecificCandidate {
   friend class MostSpecificCandidates;
 
   const TypedFnSignature* fn_;
-  optional<FormalActualMap> faMap_;
+  owned<FormalActualMap> faMap_;
   int constRefCoercionFormal_;
   int constRefCoercionActual_;
 
@@ -1222,7 +1222,7 @@ class MostSpecificCandidate {
                         FormalActualMap faMap,
                         int constRefCoercionFormal,
                         int constRefCoercionActual)
-    : fn_(fn), faMap_(std::move(faMap)),
+    : fn_(fn), faMap_(new FormalActualMap(std::move(faMap))),
       constRefCoercionFormal_(constRefCoercionFormal),
       constRefCoercionActual_(constRefCoercionActual) {}
 
@@ -1231,6 +1231,20 @@ class MostSpecificCandidate {
     : fn_(nullptr), faMap_(),
       constRefCoercionFormal_(-1),
       constRefCoercionActual_(-1) {}
+
+  MostSpecificCandidate& operator=(MostSpecificCandidate&& other) = default;
+  MostSpecificCandidate& operator=(const MostSpecificCandidate& other) {
+    fn_ = other.fn_;
+    if (other.faMap_) {
+      faMap_ = toOwned(new FormalActualMap(*other.faMap_));
+    }
+    constRefCoercionFormal_ = other.constRefCoercionFormal_;
+    constRefCoercionActual_ = other.constRefCoercionActual_;
+    return *this;
+  }
+
+  MostSpecificCandidate(MostSpecificCandidate&& other) = default;
+  MostSpecificCandidate(const MostSpecificCandidate& other) { *this = other; }
 
   static MostSpecificCandidate fromTypedFnSignature(Context* context,
                                         const TypedFnSignature* fn,

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -1270,8 +1270,16 @@ class MostSpecificCandidate {
   }
 
   bool operator==(const MostSpecificCandidate& other) const {
+    bool faMapsEqual = faMap_ == other.faMap_;
+    if (!faMapsEqual && faMap_ && other.faMap_) {
+      // Try a deep comparison to avoid unnecessary cache invalidation when
+      // bumping generations. The pointers may differ, but contain the enclosed
+      // maps can be equivalent.
+      faMapsEqual = *faMap_ == *other.faMap_;
+    }
+
     return fn_ == other.fn_ &&
-           faMap_ == other.faMap_ &&
+           faMapsEqual &&
            constRefCoercionFormal_ == other.constRefCoercionFormal_ &&
            constRefCoercionActual_ == other.constRefCoercionActual_;
   }

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -1273,7 +1273,7 @@ class MostSpecificCandidate {
     bool faMapsEqual = faMap_ == other.faMap_;
     if (!faMapsEqual && faMap_ && other.faMap_) {
       // Try a deep comparison to avoid unnecessary cache invalidation when
-      // bumping generations. The pointers may differ, but contain the enclosed
+      // bumping generations. The pointers may differ, but the contained
       // maps can be equivalent.
       faMapsEqual = *faMap_ == *other.faMap_;
     }
@@ -1297,6 +1297,18 @@ class MostSpecificCandidate {
 
   size_t hash() const {
     return chpl::hash(fn_, faMap_, constRefCoercionFormal_, constRefCoercionActual_);
+  }
+
+  static bool update(MostSpecificCandidate& keep,
+                     MostSpecificCandidate& addin) {
+    return defaultUpdate(keep, addin);
+  }
+
+  void swap(MostSpecificCandidate& other) {
+    std::swap(fn_, other.fn_);
+    std::swap(faMap_, other.faMap_);
+    std::swap(constRefCoercionFormal_, other.constRefCoercionFormal_);
+    std::swap(constRefCoercionActual_, other.constRefCoercionActual_);
   }
 
   void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const;

--- a/frontend/include/chpl/util/hash.h
+++ b/frontend/include/chpl/util/hash.h
@@ -33,6 +33,17 @@
 
 namespace chpl {
 
+namespace detail {
+
+template <typename T>
+struct hasher {
+  size_t operator()(const T& x) const {
+    return std::hash<T>{}(x);
+  }
+};
+
+} // end namespace detail
+
 // Combine two hash functions
 inline size_t hash_combine(size_t hash, size_t other) {
   return hash ^ (other + 0x9e3779b9 + (hash << 6) + (hash >> 2));
@@ -71,7 +82,7 @@ inline size_t hash(const std::string& s)
 // Default hash function for one argument
 template<typename T>
 inline size_t hash(const T& x) {
-  std::hash<T> hasher;
+  detail::hasher<T> hasher;
   return hasher(x);
 }
 
@@ -137,41 +148,40 @@ inline size_t hashPair(const std::pair<T, U>& key) {
 }
 
 
+namespace detail {
 
-} // end namespace chpl
-
-namespace std {
-
-// These std::hash functions are here b/c the hash functions
+// These hasher specialization are here b/c the hash functions
 // above can't have partial template specialization.
-template<typename T> struct hash<std::vector<T>> {
+template<typename T> struct hasher<std::vector<T>> {
   size_t operator()(const std::vector<T>& key) const {
     return chpl::hashVector(key);
   }
 };
-template<typename T> struct hash<std::set<T>> {
+template<typename T> struct hasher<std::set<T>> {
   size_t operator()(const std::set<T>& key) const {
     return chpl::hashSet(key);
   }
 };
-template<typename T> struct hash<chpl::owned<T>> {
+template<typename T> struct hasher<chpl::owned<T>> {
   size_t operator()(const chpl::owned<T>& key) const {
     return chpl::hashOwned(key);
   }
 };
-template<typename T, typename U> struct hash<std::pair<T,U>> {
+template<typename T, typename U> struct hasher<std::pair<T,U>> {
   size_t operator()(const std::pair<T,U>& key) const {
     return chpl::hashPair(key);
   }
 };
-template <typename ... Ts> struct hash<std::tuple<Ts...>> {
+template <typename ... Ts> struct hasher<std::tuple<Ts...>> {
   size_t operator()(const std::tuple<Ts...>& key) const {
     return chpl::hash(key);
   }
 };
 
 
-} // end namespace std
+} // end namespace detail
 
+
+} // end namespace chpl
 
 #endif

--- a/frontend/include/chpl/util/hash.h
+++ b/frontend/include/chpl/util/hash.h
@@ -29,6 +29,8 @@
 #include <utility>
 #include <vector>
 
+#include "chpl/util/memory.h"
+
 namespace chpl {
 
 // Combine two hash functions
@@ -143,6 +145,21 @@ template<typename T> struct hash<std::set<T>> {
     return chpl::hashSet(key);
   }
 };
+
+// std::hash is already defined for std::optional<T>, which is what we use
+// for LLVM >= 16. So, only define it for LLVM < 16.
+#if LLVM_VERSION_MAJOR < 16
+template<typename T> struct hash<chpl::optional<T>> {
+  size_t operator()(const chpl::optional<T>& key) const {
+    if (key) {
+      return chpl::hash(*key);
+    } else {
+      return 0;
+    }
+  }
+};
+#endif
+
 template<typename T, typename U> struct hash<std::pair<T,U>> {
   size_t operator()(const std::pair<T,U>& key) const {
     return chpl::hashPair(key);

--- a/frontend/include/chpl/util/hash.h
+++ b/frontend/include/chpl/util/hash.h
@@ -118,6 +118,15 @@ inline size_t hashSet(const std::set<T>& key) {
   return ret;
 }
 
+template<typename T>
+inline size_t hashOwned(const chpl::owned<T>& key) {
+  size_t ret = 0;
+  if (key) {
+    ret = hash_combine(ret, hash(*key));
+  }
+  return ret;
+}
+
 // Hash function for pair
 template<typename T, typename U>
 inline size_t hashPair(const std::pair<T, U>& key) {
@@ -145,21 +154,11 @@ template<typename T> struct hash<std::set<T>> {
     return chpl::hashSet(key);
   }
 };
-
-// std::hash is already defined for std::optional<T>, which is what we use
-// for LLVM >= 16. So, only define it for LLVM < 16.
-#if LLVM_VERSION_MAJOR < 16
-template<typename T> struct hash<chpl::optional<T>> {
-  size_t operator()(const chpl::optional<T>& key) const {
-    if (key) {
-      return chpl::hash(*key);
-    } else {
-      return 0;
-    }
+template<typename T> struct hash<chpl::owned<T>> {
+  size_t operator()(const chpl::owned<T>& key) const {
+    return chpl::hashOwned(key);
   }
 };
-#endif
-
 template<typename T, typename U> struct hash<std::pair<T,U>> {
   size_t operator()(const std::pair<T,U>& key) const {
     return chpl::hashPair(key);

--- a/frontend/lib/resolution/VarScopeVisitor.cpp
+++ b/frontend/lib/resolution/VarScopeVisitor.cpp
@@ -705,8 +705,7 @@ computeActualFormalIntents(Context* context,
   bool firstCandidate = true;
   for (const MostSpecificCandidate& candidate : candidates) {
     if (candidate) {
-      auto fn = candidate.fn();
-      auto formalActualMap = FormalActualMap(fn, ci);
+      auto& formalActualMap = candidate.formalActualMap();
       for (int actualIdx = 0; actualIdx < nActuals; actualIdx++) {
         const FormalActual* fa = formalActualMap.byActualIdx(actualIdx);
         auto intent  = normalizeFormalIntent(fa->formalType().kind());

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -844,7 +844,7 @@ MostSpecificCandidate MostSpecificCandidate::fromTypedFnSignature(Context* conte
     }
   }
 
-  return MostSpecificCandidate(fn, coercionFormal, coercionActual);
+  return MostSpecificCandidate(fn, faMap, coercionFormal, coercionActual);
 }
 
 MostSpecificCandidate MostSpecificCandidate::fromTypedFnSignature(Context* context,

--- a/frontend/test/framework/CMakeLists.txt
+++ b/frontend/test/framework/CMakeLists.txt
@@ -21,6 +21,7 @@ set_tests_properties(testRecursionFails PROPERTIES WILL_FAIL TRUE)
 comp_unit_test(testDependencies)
 comp_unit_test(testErrorTracking)
 comp_unit_test(testIds)
+comp_unit_test(testQueryEquivalence)
 comp_unit_test(testUniqueString)
 comp_unit_test(testVarint)
 

--- a/frontend/test/framework/testQueryEquivalence.cpp
+++ b/frontend/test/framework/testQueryEquivalence.cpp
@@ -27,7 +27,6 @@ using namespace uast;
 using namespace types;
 
 static int mscQueryCounter = 0;
-static const FormalActualMap* oldFaMapPtr = nullptr;
 
 static MostSpecificCandidate const& mscQuery(Context* context) {
   QUERY_BEGIN_INPUT(mscQuery, context);
@@ -77,12 +76,6 @@ static MostSpecificCandidate const& mscQuery(Context* context) {
   assert(faMap.isValid());
 
   auto msc = MostSpecificCandidate::fromTypedFnSignature(context, typed, std::move(faMap));
-
-  // The test results are only testing what we want (deep == comparison) if
-  // the enclosed pointers are not shallowly equal. Make sure a new owned<FAMap>
-  // was allocated.
-  assert(&msc.formalActualMap() != oldFaMapPtr);
-  oldFaMapPtr = &msc.formalActualMap();
 
   return QUERY_END(msc);
 }

--- a/frontend/test/framework/testQueryEquivalence.cpp
+++ b/frontend/test/framework/testQueryEquivalence.cpp
@@ -17,6 +17,13 @@
  * limitations under the License.
  */
 
+/* An important aspect of data structures in Dyno is that they behave properly
+   under the query system. This means that they support re-use and memoization
+   of queries. These tests are intended to lock in the behavior of data structures
+   under the query framework. In particular, they currently test that equivalent
+   but unequal data structures used in queries still allow the queries to be
+   re-used across generations. */
+
 #include "chpl/resolution/resolution-types.h"
 #include "chpl/framework/query-impl.h"
 #include "chpl/types/all-types.h"

--- a/frontend/test/framework/testQueryEquivalence.cpp
+++ b/frontend/test/framework/testQueryEquivalence.cpp
@@ -1,0 +1,152 @@
+#include "chpl/resolution/resolution-types.h"
+#include "chpl/framework/query-impl.h"
+#include "chpl/types/all-types.h"
+
+using namespace chpl;
+using namespace resolution;
+using namespace uast;
+using namespace types;
+
+static int mscQueryCounter = 0;
+static const FormalActualMap* oldFaMapPtr = nullptr;
+
+static MostSpecificCandidate const& mscQuery(Context* context) {
+  QUERY_BEGIN_INPUT(mscQuery, context);
+
+  mscQueryCounter++;
+
+  auto untyped = UntypedFnSignature::get(context,
+      /* ID */ ID(),
+      /* name */ UniqueString::get(context, "foo"),
+      /* isMethod */ false,
+      /* isTypeConstructor */ false,
+      /* isCompilerGenerated */ true,
+      /* throws */ false,
+      /* idTag */ uast::asttags::AstTag::Function,
+      /* kind */ uast::Function::Kind::PROC,
+      /* formals */ { UntypedFnSignature::FormalDetail {
+        UniqueString::get(context, "x"),
+        /* hasDefaultValue */ false,
+        /* decl */ nullptr,
+      }},
+      /* whereClause */ nullptr
+  );
+
+  auto typed = TypedFnSignature::get(context, untyped,
+      /* formalTypes */ { QualifiedType(QualifiedType::CONST_IN, IntType::get(context, 32)) },
+      TypedFnSignature::WHERE_NONE,
+      /* needsInstantiation */ false,
+      /* instantiatedFrom */ nullptr,
+      /* parentFn */ nullptr,
+      /* instantiatedFormals */ Bitmap{});
+
+  auto ci = CallInfo(
+      /* name */ UniqueString::get(context, "foo"),
+      /* calledType */ QualifiedType(),
+      /* isMethodCall */ false,
+      /* hasQuestionArg */ false,
+      /* isParenless */ false,
+      /* actuals */ {
+        CallInfoActual {
+          QualifiedType(QualifiedType::VAR, IntType::get(context, 32)),
+          UniqueString(),
+        }
+      });
+
+  auto faMap = FormalActualMap(typed, ci);
+
+  assert(faMap.isValid());
+
+  auto msc = MostSpecificCandidate::fromTypedFnSignature(context, typed, std::move(faMap));
+
+  // The test results are only testing what we want (deep == comparison) if
+  // the enclosed pointers are not shallowly equal. Make sure a new owned<FAMap>
+  // was allocated.
+  assert(&msc.formalActualMap() != oldFaMapPtr);
+  oldFaMapPtr = &msc.formalActualMap();
+
+  return QUERY_END(msc);
+}
+
+static int usesMscQueryCounter = 0;
+
+static bool const& usesMscQuery(Context* context) {
+  QUERY_BEGIN(usesMscQuery, context);
+
+  usesMscQueryCounter++;
+  std::ignore = mscQuery(context);
+
+  return QUERY_END(true);
+}
+
+static int mscsQueryCounter = 0;
+
+static MostSpecificCandidates const& mscsQuery(Context* context) {
+  QUERY_BEGIN_INPUT(mscsQuery, context);
+
+  mscsQueryCounter++;
+  auto& mostSpecific = mscQuery(context);
+  auto res = MostSpecificCandidates::getOnly(mostSpecific);
+
+  return QUERY_END(res);
+}
+
+static int usesMscsQueryCounter = 0;
+
+static bool const& usesMscsQuery(Context* context) {
+  QUERY_BEGIN(usesMscsQuery, context);
+
+  usesMscsQueryCounter++;
+  std::ignore = mscsQuery(context);
+
+  return QUERY_END(true);
+}
+
+static void test1() {
+  Context ctx;
+  Context* context = &ctx;
+
+  assert(usesMscQueryCounter == 0);
+  assert(mscQueryCounter == 0);
+
+  std::ignore = usesMscQuery(context);
+  assert(usesMscQueryCounter == 1);
+  assert(mscQueryCounter == 1);
+
+  std::ignore = usesMscQuery(context);
+  assert(usesMscQueryCounter == 1);
+  assert(mscQueryCounter == 1);
+
+  ctx.advanceToNextRevision(false);
+
+  std::ignore = usesMscQuery(context);
+  assert(usesMscQueryCounter == 1);
+  assert(mscQueryCounter == 2);
+}
+
+static void test2() {
+  Context ctx;
+  Context* context = &ctx;
+
+  assert(usesMscsQueryCounter == 0);
+  assert(mscsQueryCounter == 0);
+
+  std::ignore = usesMscsQuery(context);
+  assert(usesMscsQueryCounter == 1);
+  assert(mscsQueryCounter == 1);
+
+  std::ignore = usesMscsQuery(context);
+  assert(usesMscsQueryCounter == 1);
+  assert(mscsQueryCounter == 1);
+
+  ctx.advanceToNextRevision(false);
+
+  std::ignore = usesMscsQuery(context);
+  assert(usesMscsQueryCounter == 1);
+  assert(mscsQueryCounter == 2);
+}
+
+int main() {
+  test1();
+  test2();
+}

--- a/frontend/test/framework/testQueryEquivalence.cpp
+++ b/frontend/test/framework/testQueryEquivalence.cpp
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2024 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "chpl/resolution/resolution-types.h"
 #include "chpl/framework/query-impl.h"
 #include "chpl/types/all-types.h"


### PR DESCRIPTION
This improves the ergonomics of Dyno-as-an-API. If I resolve a function call node, I implicitly know that its actuals map properly to its formals. However, until now, without constructing a brand-new `CallInfo` object, it was impossible to access formal information in Dyno. This was reflected in my efforts to get inlay hints in the LSP, where I was trying to mark each actual with the name of the formal it's passed to; I just couldn't do it.

This PR adjusts `MostSpecificCandidate` to contain a `FormalActualMap` when it's non-empty (i.e, when its `fn` is non-`null`). To reduce the memory footprint of this change (since all `ResolvedExpression`s have a `MostSpecificCandidates` value), this is implemented using a heap-allocated `owned` pointer. This pointer is copied when the map itself is copied. When a candidate's `fn` is `null`, so is the `faMap_` pointer, so only a word of space is used.

Finally, this PR provides a template specialization for Chapel's `hash` for `owned<T>`, which I think is necessary for `==` and `hash` to work with deep comparisons like they need to. In particular, it ensures the property that `faMap1 == faMap2 => hash(faMap1) == hash(faMap2)`. I noted that it was a little sketchy modifying the `std::hash` for `unique_ptr`; further investigation suggests that doing so is not recommended for _any_ builtin type (e.g. vector, set, pair -- all things we had specializations for). I thus extracted our partial specializations into a custom struct, `chpl::detail::hasher<T>`, which falls back to `std::hash<T>`. This required some tweaks to the production compiler code where we apparently relied on our own custom hashing of pairs.

Reviewed by @mppf -- thanks!

## Testing
- [x] paratest