### PR TITLE
chapel-py: allow accepting and returning lists of arbitrary types in methods

### DIFF
--- a/tools/chapel-py/src/core-types.cpp
+++ b/tools/chapel-py/src/core-types.cpp
@@ -170,9 +170,9 @@ static void printTypedPythonFunctionArgs(std::ostringstream& ss, std::index_sequ
   // in this case, a variadic list of tuple indices. That's what this
   // function does.
   //
-  // From there, we can use variadic template expansion to print the TypeString
+  // From there, we can use variadic template expansion to print the typeString
   // corresponding to each element / index of the tuple. If we just wanted to
-  // print the TypeStrings without spaces or punctuation, we could have used
+  // print the typeStrings without spaces or punctuation, we could have used
   // (<<) with a fold expression[1]. However, we want to print a comma and
   // more, so it's more convenient to use a wrapper function printArg to handle
   // the formatting.
@@ -180,11 +180,11 @@ static void printTypedPythonFunctionArgs(std::ostringstream& ss, std::index_sequ
   // [1]: https://en.cppreference.com/w/cpp/language/fold
 
   int counter = 0;
-  auto printArg = [&](const char* arg) {
+  auto printArg = [&](const std::string& arg) {
     ss << ", arg" << counter++ << ": " << arg;
   };
 
-  (printArg(std::tuple_element<Indices, Tuple>::type::TypeString), ...);
+  (printArg(std::tuple_element<Indices, Tuple>::type::typeString()), ...);
 }
 
 
@@ -242,7 +242,7 @@ PyObject* ContextObject_get_pyi_file(ContextObject *self, PyObject* args) {
   #define METHOD(NODE, NAME, DOCSTR, TYPEFN, BODY) \
     ss << "    def " << #NAME << "(self"; \
     printTypedPythonFunctionArgs<PythonFnHelper<TYPEFN>::ArgTypeInfo>(ss, std::make_index_sequence<std::tuple_size<PythonFnHelper<TYPEFN>::ArgTypeInfo>::value>()); \
-    ss << ") -> " << PythonFnHelper<TYPEFN>::ReturnTypeInfo::TypeString << ":" << std::endl;\
+    ss << ") -> " << PythonFnHelper<TYPEFN>::ReturnTypeInfo::typeString() << ":" << std::endl;\
     ss << "        \"\"\"" << std::endl; \
     ss << "        " << DOCSTR << std::endl; \
     ss << "        \"\"\"" << std::endl; \

--- a/tools/chapel-py/src/python-types.h
+++ b/tools/chapel-py/src/python-types.h
@@ -71,7 +71,7 @@ PyObject* wrapVector(ContextObject* CONTEXT, const std::vector<T>& vec) {
 
 template <typename T>
 std::vector<T> unwrapVector(ContextObject* CONTEXT, PyObject* vec) {
-  std::vector<T> toReturn;
+  std::vector<T> toReturn(PyList_Size(vec));
   for (ssize_t i = 0; i < PyList_Size(vec); i++) {
     toReturn.push_back(PythonReturnTypeInfo<T>::unwrap(CONTEXT, PyList_GetItem(vec, i)));
   }


### PR DESCRIPTION
This PR defines the to- and from- conversion for vectors of Python-convertible types. This makes it possible to return and accept lists of things in methods listed in `method-tables.h`. This is particularly useful for future work, such as returning formal-actual maps (which can be represented as a vector of indices). 

Reviewed by @jabraham17 -- thanks!