### PR TITLE
Fix typos

### DIFF
--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -1313,7 +1313,7 @@ initPrimitive() {
   prim_def(PRIM_CHECK_CONST_ARG_HASH, "check hashes of const arguments", returnInfoVoid, true, true);
 
   // we need to carry information about 'in' intents lowered from foreach loops
-  // until gpu transforms. To do that we add an assigment
+  // until gpu transforms. To do that we add an assignment
   //   `taskIndVar = TASK_INDEPENDENT_SVAR_CAPTURE(capturedVar)` into the AST.
   prim_def(PRIM_TASK_INDEPENDENT_SVAR_CAPTURE, "task independent svar capture", returnInfoUnknown);
 }

--- a/doc/rst/developer/bestPractices/TestSystem.rst
+++ b/doc/rst/developer/bestPractices/TestSystem.rst
@@ -398,7 +398,7 @@ Using precomp, preexec, and prediff files
 When creating a ``.precomp``, ``.preexec``, or ``.prediff`` file, the file
 must be an executable. You can turn your script into an executable by running:
 ``chmod +x foo.precomp``. To specify these files for entire directories,
-the files should be named ``PRECOMP``, ``PREXEC``, and ``PREDIFF``,
+the files should be named ``PRECOMP``, ``PREEXEC``, and ``PREDIFF``,
 respectively.
 
 If you wish to have a system wide ``.prediff`` file, you can use the

--- a/doc/rst/usingchapel/prereqs.rst
+++ b/doc/rst/usingchapel/prereqs.rst
@@ -42,7 +42,7 @@ for using Chapel:
     are currently supported. If a system-wide installation of
     LLVM and clang with one of those versions is not available, you can
     use the bundled LLVM or disable LLVM support (see
-    :ref:`readme-chplenv.CHPL_LLVM`). LLVM 16 support is avaible with certain
+    :ref:`readme-chplenv.CHPL_LLVM`). LLVM 16 support is available with certain
     configurations. If LLVM 16 is the only system-wide install of LLVM, it will
     be used by default. Otherwise you can opt-in to it explicitly by setting
     :ref:`readme-chplenv.CHPL_LLVM_CONFIG`.
@@ -129,7 +129,7 @@ We have used the following commands to install the above prerequisites:
       sudo pacman -S llvm14 clang14
 
 
-  * CentOS 7 Devtoolset 11 (but note `CentOS 7 CHPL_LLVM=system incompatability`_)::
+  * CentOS 7 Devtoolset 11 (but note `CentOS 7 CHPL_LLVM=system incompatibility`_)::
 
       sudo yum install centos-release-scl
       sudo yum install devtoolset-11-gcc*
@@ -161,7 +161,7 @@ We have used the following commands to install the above prerequisites:
       sudo apt-get install llvm-dev llvm clang libclang-dev libclang-cpp-dev libedit-dev
 
 
-  * Fedora 37, 38, 39, 40 (but note `Fedora CHPL_LLVM=system incompatabilities`_)::
+  * Fedora 37, 38, 39, 40 (but note `Fedora CHPL_LLVM=system incompatibilities`_)::
 
       sudo dnf install gcc gcc-c++ m4 perl python3 python3-devel bash make gawk git cmake
       sudo dnf install which diffutils
@@ -212,7 +212,7 @@ We have used the following commands to install the above prerequisites:
 
 
 
-Compatability Notes
+Compatibility Notes
 -------------------
 
 Alpine 3.19 LLVM build issue
@@ -222,14 +222,14 @@ We have observed problems building the bundled LLVM support library on
 Alpine 3.19. These problems can be resolved by installing a compatible
 LLVM package.
 
-CentOS 7 CHPL_LLVM=system incompatability
+CentOS 7 CHPL_LLVM=system incompatibility
 +++++++++++++++++++++++++++++++++++++++++
 
 CentOS 7 does not include a new enough LLVM release to work with
 ``CHPL_LLVM=system``. ``CHPL_LLVM=bundled`` or ``CHPL_LLVM=none`` are
 available as alternatives.
 
-Fedora CHPL_LLVM=system incompatabilities
+Fedora CHPL_LLVM=system incompatibilities
 +++++++++++++++++++++++++++++++++++++++++
 
 Fedora only includes a single version of ``clang``. As

--- a/frontend/include/chpl/resolution/can-pass.h
+++ b/frontend/include/chpl/resolution/can-pass.h
@@ -242,7 +242,7 @@ class KindProperties {
 
   /* Combine two sets of kind properties, strictly enforcing properties of
      the receiver (e.g. (receiver) param + (other) value = invalid, because
-     param-ness is requird).
+     param-ness is required).
 
      const-ness and ref-ness mismatch doesn't raise issues here since const/ref
      checking is a separate pass. */

--- a/frontend/lib/immediates/complex-support.h
+++ b/frontend/lib/immediates/complex-support.h
@@ -23,7 +23,7 @@
 /*
 
  This header exists to work around a problem with complex square root being
- innacurate on libc++ by using C functions to do the complex square root.
+ inaccurate on libc++ by using C functions to do the complex square root.
 
  */
 

--- a/frontend/lib/parsing/parser-error-classes-list.cpp
+++ b/frontend/lib/parsing/parser-error-classes-list.cpp
@@ -253,7 +253,7 @@ void ErrorWhenAfterOtherwise::write(ErrorWriterBase& wr) const {
   auto otherwise = std::get<1>(info);
   auto when = std::get<2>(info);
   wr.heading(kind_, type_, node, "'otherwise' clause must follow all 'when' clauses.");
-  wr.message("In the following 'select' statment:");
+  wr.message("In the following 'select' statement:");
   wr.code(node);
   wr.note(otherwise, "the 'otherwise' clause occurs here:");
   wr.code(otherwise);

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1326,7 +1326,7 @@ void Resolver::resolveNamedDecl(const NamedDecl* decl, const Type* useType) {
 
       // for an initializer expression that is the default value of a formal,
       // check if we have the formal type already and then use that to
-      // compute the QTkind now rather than trying to getTypeForDecl first,
+      // compute the qtKind now rather than trying to getTypeForDecl first,
       // which will fail in cases where an implicit conversion is needed
       if (!isVarArgs && typeExprT.hasTypePtr() &&
           (isFormal || (signatureOnly && isField))) {

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -1023,7 +1023,7 @@ void CallInitDeinit::handleDisjunction(const uast::AstNode * node,
     }
   }
 
-  //propogate out of the disjunction itself
+  //propagate out of the disjunction itself
   processDeinitsAndPropagate(currentFrame, currentParentFrame(), rv);
 }
 

--- a/frontend/lib/resolution/copy-elision.cpp
+++ b/frontend/lib/resolution/copy-elision.cpp
@@ -434,7 +434,7 @@ void FindElidedCopies::handleDisjunction(const AstNode * node,
     //yield the local variables
     saveLocalVarElidedCopies(frame);
 
-    //promote outer varaible access
+    //promote outer variable access
     for (const auto& entry : frame->copyElisionState) {
       ID id = entry.first;
       const CopyElisionState& state = entry.second;

--- a/frontend/test/framework/testErrorTracking.cpp
+++ b/frontend/test/framework/testErrorTracking.cpp
@@ -109,7 +109,7 @@ static void test1() {
   assert(queryThatCapturesErrors(context) == "no errors on the first go; errors on the second go");
   assert(guard.errors().size() == 1);
 
-  // Now the hidden errors have been re-reported; no new errors should be reporterd
+  // Now the hidden errors have been re-reported; no new errors should be reported
   // after the second call.
   assert(queryThatCapturesErrors(context) == "no errors on the first go; errors on the second go");
   assert(guard.errors().size() == 1);
@@ -139,7 +139,7 @@ static void test2() {
   assert(queryThatRunsQueryThatCapturesErrors(context) == "(no errors on the first go; errors on the second go)");
   assert(guard.errors().size() == 1);
 
-  // Now the hidden errors have been re-reported; no new errors should be reporterd
+  // Now the hidden errors have been re-reported; no new errors should be reported
   // after the second call.
   assert(queryThatRunsQueryThatCapturesErrors(context) == "(no errors on the first go; errors on the second go)");
   assert(guard.errors().size() == 1);
@@ -303,7 +303,7 @@ static void test6() {
   // ================
   //   Generation 2
   // ================
-  // Just runthe previous code again, make sure a single error is re-reported.
+  // Just run the previous code again, make sure a single error is re-reported.
   // Run a query that tracks errors. It should detect errors ("errors on the second go"),
   // and also it reports an error of its own, so the error count goes to one.
   assert(queryThatCapturesErrors(context) == "no errors on the first go; errors on the second go");

--- a/frontend/test/resolution/testCanPass.cpp
+++ b/frontend/test/resolution/testCanPass.cpp
@@ -486,7 +486,7 @@ static void test7() {
   r = canPass(c, unmanagedChildQ,  borrowedChild);    assert(doesNotPass(r));
   r = canPass(c, unmanagedChildQ,  borrowedChildQ);   assert(passesBorrowing(r));
 
-  // unamanaged - owned
+  // unmanaged - owned
   r = canPass(c, unmanagedChild,   ownedChild);       assert(doesNotPass(r));
   r = canPass(c, unmanagedChild,   ownedChildQ);      assert(doesNotPass(r));
   r = canPass(c, unmanagedChildQ,  ownedChild);       assert(doesNotPass(r));
@@ -523,7 +523,7 @@ static void test7() {
   r = canPass(c, unmanagedChildQ,  borrowedParent);   assert(doesNotPass(r));
   r = canPass(c, unmanagedChildQ,  borrowedParentQ);  assert(passesBorrowingSubtype(r));
 
-  // unamanaged - owned
+  // unmanaged - owned
   r = canPass(c, unmanagedChild,   ownedParent);      assert(doesNotPass(r));
   r = canPass(c, unmanagedChild,   ownedParentQ);     assert(doesNotPass(r));
   r = canPass(c, unmanagedChildQ,  ownedParent);      assert(doesNotPass(r));

--- a/frontend/test/resolution/testReturnTypes.cpp
+++ b/frontend/test/resolution/testReturnTypes.cpp
@@ -204,8 +204,8 @@ static void test3() {
 }
 
 static void test4() {
-  // test returning a param from an ambigous param-returning function
-  // non-ambigous tests are in testParamIf.
+  // test returning a param from an ambiguous param-returning function
+  // non-ambiguous tests are in testParamIf.
   testProgram({
       lit("1"),
       lit("2")
@@ -864,7 +864,7 @@ static void testSelectTypes() {
     testSelectCases(fooFunc, vals);
   }
   {
-    // mutiple cases in a single 'when'
+    // multiple cases in a single 'when'
     std::string fooFunc = ops + R"""(
     proc foo(type T) type {
       select T {
@@ -1021,7 +1021,7 @@ static void testSelectParams() {
     testSelectCases(fooFunc, vals);
   }
   {
-    // mutiple cases in a single 'when'
+    // multiple cases in a single 'when'
     std::string fooFunc = ops + R"""(
     proc foo(param p) type {
       select p {

--- a/frontend/test/resolution/testScopeResolve.cpp
+++ b/frontend/test/resolution/testScopeResolve.cpp
@@ -450,7 +450,7 @@ static void test11() {
 }
 
 // multiple imports / uses of the same module don't block finding symbols
-// via the second visibility statment onwards.
+// via the second visibility statement onwards.
 static void test12() {
   printf("test12\n");
   Context ctx;
@@ -545,7 +545,7 @@ static void test13() {
   assert(guard.realizeErrors());
 }
 
-// There's specal handling for the rightmost field access. Make sure this
+// There's special handling for the rightmost field access. Make sure this
 // special handling properly handles super.
 static void test14() {
   printf("test14\n");

--- a/frontend/test/resolution/testSplitInit.cpp
+++ b/frontend/test/resolution/testSplitInit.cpp
@@ -566,7 +566,7 @@ static void test21() {
     /* expect errors for now as a temporary workaround */ ERRORS_EXPECTED);
 }
 
-/* not tested -- "ount intent varargs are not supported"
+/* not tested -- "out intent varargs are not supported"
 static void test22() {
   testSplitInit("test22",
     R""""(

--- a/frontend/test/resolution/testVarArgs.cpp
+++ b/frontend/test/resolution/testVarArgs.cpp
@@ -655,7 +655,7 @@ static void testConcrete() {
   testMatcher(Qualifier::DEFAULT_INTENT, "int", "",
               ArgInfo({"int", "int(8)", "int(32)"}));
 
-  // varargs specifiying a tuple as the formal type
+  // varargs specifying a tuple as the formal type
   testMatcher(Qualifier::DEFAULT_INTENT, "(int,int,int)", "",
               ArgInfo(3, "(int,int,int)"));
 

--- a/modules/internal/BytesStringCommon.chpl
+++ b/modules/internal/BytesStringCommon.chpl
@@ -1075,7 +1075,7 @@ module BytesStringCommon {
 
     on __primitive("chpl_on_locale_num",
                    chpl_buildLocaleID(lhs.locale_id, c_sublocid_any)) {
-      // resize the buffer to make room and amoritize resize time for
+      // resize the buffer to make room and amortize resize time for
       // repeated appends
       const newLength = resizeBufferForAppend(lhs, rhs.buffLen);
       // copy the data from rhs
@@ -1098,7 +1098,7 @@ module BytesStringCommon {
 
     on __primitive("chpl_on_locale_num",
                    chpl_buildLocaleID(lhs.locale_id, c_sublocid_any)) {
-      // resize the buffer to make room and amoritize resize time for
+      // resize the buffer to make room and amortize resize time for
       // repeated appends
       const newLength = resizeBufferForAppend(lhs, n);
       // copy the data into the buffer, but only the n bytes requested

--- a/modules/packages/Crypto.chpl
+++ b/modules/packages/Crypto.chpl
@@ -105,10 +105,11 @@ module Crypto {
 
   /* The `CryptoBuffer` class is a wrapper around the internal representation
      of how the values in this library are stored. Every sequence of bytes going
-     into a Crypto utility or coming out of it, is a `CryptoBuffer`.
+     into a Crypto utility or coming out of it is a `CryptoBuffer`.
 
-     A `CryptoBuffer` can enclose a `string` or a `[] uint(8)` passed to its
-     initializer and provides helper functions to access those values.
+     A `CryptoBuffer` can enclose a `string`, `bytes`, or `[] uint(8)`
+     passed to its initializer and provides helper functions to access
+     those values.
 
   */
   class CryptoBuffer {
@@ -140,6 +141,7 @@ module Crypto {
         elt = b;
       }
     }
+
     /* The `CryptoBuffer` class initializer that initializes the buffer
        when a `bytes` is supplied to it.
 
@@ -246,7 +248,7 @@ module Crypto {
 
   /* `RSAKey` class encloses the `EVP_PKEY` object provided by the
      OpenSSL primitives. The `EVP_PKEY` object can contain the public key,
-     private key or both of them. Hence, the contents of an object of the
+     private key, or both of them. Hence, the contents of an object of the
      class `RSAKey` may be decided by the user.
 
      Calling the `RSAKey` initializer without using any key import or export
@@ -264,7 +266,7 @@ module Crypto {
     var keyObj: EVP_PKEY_PTR;
 
     /* The `RSAKey` class initializer that initializes the `EVP_PKEY` object
-       of OpenSSL and basically, initializes a set of public and private keys.
+       of OpenSSL and initializes a set of public and private keys.
 
        It checks for valid RSA key lengths and generates a public key and private
        key pair accordingly.
@@ -312,7 +314,7 @@ module Crypto {
     var value: owned CryptoBuffer;
 
     /* The `Envelope` class initializer that encapsulates the IV, AES encrypted
-       ciphertext buffer and an array of encrypted key buffers.
+       ciphertext buffer, and an array of encrypted key buffers.
 
        :arg iv: Initialization Vector.
        :type iv: `owned CryptoBuffer`
@@ -437,7 +439,7 @@ module Crypto {
        to be used. This initializer sets the byte length of the
        respective hash and allocates a domain for memory allocation
        for hashing. It currently supports the following hashing functions -
-       ``MD5``, ``SHA1``, ``SHA224``, ``SHA256``, ``SHA384``, ``SHA512`` and
+       ``MD5``, ``SHA1``, ``SHA224``, ``SHA256``, ``SHA384``, ``SHA512``, and
        ``RIPEMD160`` consumed via an enum, `Digest`.
 
        :arg digestName: Hashing function to be used.
@@ -481,7 +483,7 @@ module Crypto {
       return this.digestName;
     }
 
-    /* Given a CryptoBuffer (buffer) as input, this function returns it's
+    /* Given a CryptoBuffer (buffer) as input, this function returns its
        hash digest. The returned hash digest is also a buffer that can be
        accessed by using buffer utility functions.
 
@@ -588,7 +590,7 @@ module Crypto {
      Currently, the `AES` class allows symmetric encryption using only the CBC or
      Cipher Block Chaining mode in 128, 192, and 256 key size variants.
 
-     After thorough testing, ECB, OCB and other chaining mode variants will also
+     After thorough testing, ECB, OCB, and other chaining mode variants will also
      be added to this library(TODO).
 
   */
@@ -651,7 +653,7 @@ module Crypto {
     /* This is the 'AES' encrypt routine that encrypts the user supplied message buffer
        using the key and IV.
 
-       The `encrypt` takes in the plaintext buffer, key buffer and IV buffer as the
+       The `encrypt` takes in the plaintext buffer, key buffer, and IV buffer as the
        arguments and returns a buffer of the ciphertext.
 
        :arg plaintext: A `CryptoBuffer` representing the plaintext to be encrypted.
@@ -677,7 +679,7 @@ module Crypto {
     /* This is the 'AES' decrypt routine that decrypts the user supplied ciphertext
        buffer using the same key and IV used for encryption.
 
-       The `decrypt` takes in the ciphertext buffer, key buffer and IV buffer as the
+       The `decrypt` takes in the ciphertext buffer, key buffer, and IV buffer as the
        arguments and returns a buffer of the decrypted plaintext.
 
        :arg ciphertext: A `CryptoBuffer` representing the ciphertext to be decrypted.
@@ -775,7 +777,7 @@ proc bfEncrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer, cip
 
   /* The `Blowfish` class represents a symmetric-key block cipher called Blowfish, designed
      in 1993 by Bruce Schneier. Considering current scenario, the Advanced Encryption
-     Standard(AES) cipher is used more in practice. Since, Blowfish is unpatented and placed
+     Standard(AES) cipher is used more in practice. Since Blowfish is unpatented and placed
      in the public domain, it receives a decent amount of attention from the community.
 
      .. note::
@@ -839,7 +841,7 @@ proc bfEncrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer, cip
     /* This is the 'Blowfish' encrypt routine that encrypts the user supplied message buffer
        using the key and IV.
 
-       The `encrypt` takes in the plaintext buffer, key buffer and IV buffer as the
+       The `encrypt` takes in the plaintext buffer, key buffer, and IV buffer as the
        arguments and returns a buffer of the ciphertext.
 
        :arg plaintext: A `CryptoBuffer` representing the plaintext to be encrypted.
@@ -874,7 +876,7 @@ proc bfEncrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer, cip
     /* This is the 'Blowfish' decrypt routine that decrypts the user supplied ciphertext
        buffer using the same key and IV used for encryption.
 
-       The `decrypt` takes in the ciphertext buffer, key buffer and IV buffer as the
+       The `decrypt` takes in the ciphertext buffer, key buffer, and IV buffer as the
        arguments and returns a buffer of the decrypted plaintext.
 
        :arg ciphertext: A `CryptoBuffer` representing the ciphertext to be decrypted.
@@ -1143,7 +1145,7 @@ proc bfEncrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer, cip
        'RSAKey' objects supplied in the arguments.
 
        The function returns an `Envelope` object that encloses the auto-generated
-       IV, AES encrypted ciphertext and an array of `RSA` encrypted key buffers.
+       IV, AES encrypted ciphertext, and an array of `RSA` encrypted key buffers.
        The number of encrypted keys is equal to the number of `RSAKey` objects
        in the array. This kind of use case is useful specifically in developing
        one-to-many systems such as GPG.
@@ -1163,7 +1165,7 @@ proc bfEncrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer, cip
        :type keys: `[] RSAKey`
 
        :return: An `owned Envelope` object which comprises of the IV buffer,
-                array of RSA encrypted keys and AES encrypted ciphertext.
+                array of RSA encrypted keys, and AES encrypted ciphertext.
        :rtype: `owned Envelope`
 
     */

--- a/test/release/examples/primers/timers.chpl
+++ b/test/release/examples/primers/timers.chpl
@@ -74,7 +74,7 @@ t.stop();
 //
 // It returns a ``timeDelta`` representing the time passed since the Unix
 //  Epoch. The ``timeDelta`` represents the epoch in days, seconds, and
-//  microsends, but we convert this to a single number with the
+//  microseconds, but we convert this to a single number with the
 //  ``totalSeconds()`` method. As a simple example, we can use the following
 // idiom to time the number of seconds something will take:
 //


### PR DESCRIPTION
Fix typos in

primitive.cpp, can-pass.h, complex-support.h,
parser-error-classes-list.cpp, Resolver.cpp,
call-init-deinit.cpp, copy-elision.cpp,
testErrorTracking.cpp, testCanPass.cpp,
testReturnTypes.cpp, testScopeResolve.cpp,
testSplitInit.cpp, testVarArgs.cpp,
BytesStringCommon.chpl, Crypto.chpl
primers/timers.chpl
TestSystem.rst, prereqs.rst
