### PR TITLE
Fix maximum AST size reporting in driver mode

### DIFF
--- a/compiler/AST/baseAST.cpp
+++ b/compiler/AST/baseAST.cpp
@@ -90,7 +90,7 @@ void printStatistics(const char* pass) {
   static int last_nasts = -1;
   static int maxK = -1, maxN = -1;
 
-  if (!strcmp(pass, "makeBinary")) {
+  if (strcmp(pass, "codegen") == 0) {
     if (strstr(fPrintStatistics, "m")) {
       fprintf(stderr, "Maximum # of ASTS: %d\n", maxN);
       fprintf(stderr, "Maximum Size (KB): %d\n", maxK);


### PR DESCRIPTION
Fix a bug where driver mode reports near-0 maximum AST size.

This was due to the maximum being emitted immediately after `makeBinary`, which runs in its own driver phase during which there is no AST. Fixed by emitting immediately after `codegen`, the final pass of the first phase.

Thanks @stonea for pointing out this bug.

Follow up to https://github.com/chapel-lang/chapel/pull/23930.

[reviewer info placeholder]

Testing:
- [x] measured AST size matches that with `--no-compiler-driver` previously
- [x] paratest