### PR TITLE
Add auto-fix warning support to chpl-language-server

### DIFF
--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -161,15 +161,14 @@ def get_symbol_information(
     loc = Location(uri, location_to_range(decl.location()))
     kind = decl_kind(decl)
     if kind:
-        # TODO: should we use DocumentSymbol or SymbolInformation LSP spec says
+        # TODO: should we use DocumentSymbol or SymbolInformation? LSP spec says
         # prefer DocumentSymbol, but nesting doesn't work out of the box.
         # implies that we need some kind of visitor pattern to build a DS tree
         # using symbol information for now, as it sort-of autogets the tree
         # structure
         is_deprecated = chapel.is_deprecated(decl)
-        return SymbolInformation(
-            loc, decl.name(), kind, deprecated=is_deprecated
-        )
+        name = get_symbol_signature(decl)
+        return SymbolInformation(loc, name, kind, deprecated=is_deprecated)
     return None
 
 

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -564,8 +564,12 @@ def run_lsp():
         diag = ls.build_diagnostics(text_doc.uri)
         ls.publish_diagnostics(text_doc.uri, diag)
 
+    @server.feature(TEXT_DOCUMENT_DECLARATION)
     @server.feature(TEXT_DOCUMENT_DEFINITION)
-    async def get_def(ls: ChapelLanguageServer, params: DefinitionParams):
+    async def get_def(
+        ls: ChapelLanguageServer,
+        params: Union[DefinitionParams, DeclarationParams],
+    ):
         text_doc = ls.workspace.get_text_document(params.text_document.uri)
 
         fi, _ = ls.get_file_info(text_doc.uri)


### PR DESCRIPTION
Adds support for LSP CodeActions to chpl-language-server. This allows users to auto-fix subsets of warnings in their code in the IDE.

Currently this has limited support for deprecations based upon regular expressions. This handles most simple deprecations like renamings, but is currently limited by what is resolved by dyno/chapel-py so this may not work for deprecated functions

This also adds support for GotoDeclaration, which for Chapel is the same as GotoDefinition.

[Reviewed by @DanilaFe]