### PR TITLE
Make munge-with-ids test less sensitive to llvm version

### DIFF
--- a/test/compflags/ferguson/munge-with-ids.good
+++ b/test/compflags/ferguson/munge-with-ids.good
@@ -1,1 +1,1 @@
-define internal i64 @munge-with-ids.foo() #0 {
+define internal i64 @munge-with-ids.foo() #n {

--- a/test/compflags/ferguson/munge-with-ids.prediff
+++ b/test/compflags/ferguson/munge-with-ids.prediff
@@ -8,5 +8,5 @@ LOG=$2
 # include only the 'define' line
 # looking for define internal i64 @munge-with-ids.foo() 
 #
-cat $LOG | grep define > $LOG.tmp
+cat $LOG | grep define | sed 's/#[[:digit:]]\+/#n/' > $LOG.tmp
 mv $LOG.tmp $LOG


### PR DESCRIPTION
Fixes a test which relies on a specific LLVM IR layout to be less sensitive to LLVM version

I saw this test fail when using LLVM 17, it now works with LLVM 17 and other LLVM versions

[Reviewed by @mppf]