### PR TITLE
Adjust c2chapel to handle forward declared structs/unions

### DIFF
--- a/test/c2chapel/testStructs.c
+++ b/test/c2chapel/testStructs.c
@@ -19,3 +19,11 @@ void fnStruct_call(fnStruct f) {
   printf("Calling fnStruct.fn(42):\n");
   f.fn(42);
 }
+
+void printForwardDeclStruct1(const forwardDeclStruct1* s) {
+  printf("%d\n", s->x);
+}
+
+void printForwardDeclStruct2(const struct forwardDeclStruct2* s) {
+  printf("%d\n", s->x);
+}

--- a/test/c2chapel/testStructs.chpl
+++ b/test/c2chapel/testStructs.chpl
@@ -28,4 +28,12 @@ proc main() {
 
   z.fn = c_ptrTo(bar);
   fnStruct_call(z);
+
+  var fds1: forwardDeclStruct1;
+  fds1.x = 8;
+  printForwardDeclStruct1(fds1);
+
+  var fds2: forwardDeclStruct2;
+  fds2.x = 16;
+  printForwardDeclStruct2(fds2);
 }

--- a/test/c2chapel/testStructs.good
+++ b/test/c2chapel/testStructs.good
@@ -11,3 +11,5 @@ Calling fnStruct.fn(42):
 In foo function, given: 42
 Calling fnStruct.fn(42):
 In bar function! got: 42
+8
+16

--- a/test/c2chapel/testStructs.h
+++ b/test/c2chapel/testStructs.h
@@ -22,3 +22,15 @@ typedef struct {
 } fnStruct;
 
 void fnStruct_call(fnStruct f);
+
+struct forwardDeclStruct1;
+
+typedef struct forwardDeclStruct1 { int x; } forwardDeclStruct1;
+
+void printForwardDeclStruct1(const forwardDeclStruct1*);
+
+struct forwardDeclStruct2;
+
+struct forwardDeclStruct2 { int x; };
+
+void printForwardDeclStruct2(const struct forwardDeclStruct2*);

--- a/tools/c2chapel/c2chapel.py
+++ b/tools/c2chapel/c2chapel.py
@@ -367,6 +367,9 @@ def getStructOrUnionDef(decl):
         return None
 
 
+def isStructOrUnionForwardDeclared(node):
+    return isStructOrUnionType(node) and not node.decls
+
 def genStructOrUnion(structOrUnion, name="", isAnon=False):
     if name == "":
         if structOrUnion.name is not None:
@@ -392,7 +395,7 @@ def genStructOrUnion(structOrUnion, name="", isAnon=False):
     foundTypes.add(name)
 
     # Forward Declaration
-    if not structOrUnion.decls:
+    if isStructOrUnionForwardDeclared(structOrUnion):
         print()
         return
 
@@ -458,8 +461,14 @@ def genTypeEnum(decl):
 # Simple visitor to all function declarations
 class ChapelVisitor(c_ast.NodeVisitor):
     def visit_StructOrUnion(self, node):
-        typeDefs[node.name] = None
         genStructOrUnion(node, isAnon=False)
+        # If this is not a forward declaration, then preemptively prune this
+        # struct or union from the typedef map (since this is the type's
+        # definition). However, if this _was_ a forward declaration, then we
+        # want to handle the possibility of an embedded definition later.
+        # E.g., 'typedef struct foo { int x; } foo;'
+        if not isStructOrUnionForwardDeclared(node):
+            typeDefs[node.name] = None
 
     def visit_Typedef(self, node):
         if node.name not in typeDefs:


### PR DESCRIPTION
Resolves #24167.

Adjust `c2chapel` to not skip a typedef for `foo` if we have only encountered a forward declaration for `foo` beforehand.

TESTING
- [x] `linux64`, `standard`

Reviewed by @riftEmber. Thanks!