### PR TITLE
LSP: Add support for finding a range of elements given two document positions

### DIFF
--- a/tools/chpl-language-server/src/bisect_compat.py
+++ b/tools/chpl-language-server/src/bisect_compat.py
@@ -34,3 +34,18 @@ def bisect_right(a: Sequence, x, key: Optional[Callable]=None):
         else:
             lo = mid + 1
     return lo
+
+def bisect_left(a: Sequence, x, key: Optional[Callable]=None):
+    lo = 0
+    hi = len(a)
+
+    if key is None:
+        key = lambda e: e
+
+    while lo < hi:
+        mid = (lo + hi) // 2
+        if x <= key(a[mid]):
+            hi = mid
+        else:
+            lo = mid + 1
+    return lo

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -33,7 +33,7 @@ from typing import (
 )
 from collections import defaultdict
 from dataclasses import dataclass, field
-from bisect_compat import bisect_right
+from bisect_compat import bisect_left, bisect_right
 from symbol_signature import get_symbol_signature
 import itertools
 import os
@@ -198,6 +198,15 @@ class PositionList(Generic[EltT]):
         if idx < 0 or pos > self.get_range(self.elts[idx]).end:
             return None
         return self.elts[idx]
+
+    def range(self, rng: Range) -> List[EltT]:
+        start = bisect_right(
+            self.elts, rng.start, key=lambda x: self.get_range(x).start
+        )
+        end = bisect_left(
+            self.elts, rng.end, key=lambda x: self.get_range(x).start
+        )
+        return self.elts[start:end]
 
 
 @dataclass


### PR DESCRIPTION
This helps for things like inlay hints; whenever the server requests some information in the user's view, we can use two binary searches to compute the range.

Reviewed by @jabraham17 -- thanks!