### PR TITLE
LinearAlgebra.solve() constant formals

### DIFF
--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -1857,10 +1857,10 @@ proc solve_triu(const ref U: [?Udom] ?eltType, const ref b: [?bdom] eltType) {
 
      Arrays with any offset are supported, and ``x`` inherits the indexing.
 */
-proc solve(A: [?Adom] ?eltType, ref b: [?bdom] eltType) {
+proc solve(const ref A: [?Adom] ?eltType, const ref b: [?bdom] eltType) {
   var (LU, ipiv) = lu(A);
-  b = permute(ipiv, b, true);
-  var z = solve_tril(LU, b);
+  var y = permute(ipiv, b, true);
+  var z = solve_tril(LU, y);
   var x = solve_triu(LU, z);
   return x;
 }

--- a/test/library/packages/LinearAlgebra/correctness/no-dependencies/solveLU.chpl
+++ b/test/library/packages/LinearAlgebra/correctness/no-dependencies/solveLU.chpl
@@ -35,7 +35,7 @@ var res = true;
 
     // solve
     const x = solve(Ao, bo);
-    bo = b; // `solve` overrites bo
+    assertAlmostEqual(b, bo, "solve() modified its argument");
 
     // check results
     if !almostEquals(dot(Ao, x), bo) {


### PR DESCRIPTION
This PR addresses a concern raised in #24095 that LinearAlgebra's `solve()` modifies its second argument. The comments on that issue agree that ideally `solve()` should not modify its arguments.

With this PR, the actual arguments to `sort()` are no longer modified. It uses the solution proposed by @damianmoz in https://github.com/chapel-lang/chapel/issues/24095#issuecomment-1858606584. While there, mark the formals as passed by ref because there is no need to copy the actuals into the formals.

Next steps: see if we want to apply the explicit intent `const` or `const ref` to the formals of other functions in LinearAlgebra. Another thought: replace `var` with `const` for local variables that are not intended for modification, such as `x`, `y`, `z` in the `solve()`.

Testing: standard and gasnet paratests. Yes, this includes `library/packages/LinearAlgebra/correctness/no-dependencies/solveLU`