### PR TITLE
Fix chpl_llvm.py for AMD GPU + bunded-but-not-built LLVM

### DIFF
--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -88,7 +88,7 @@ def get_llvm_config_version(llvm_config):
         if exists and returncode == 0:
             got_version = got_out
 
-        if chpl_gpu.get() == 'amd':
+        if got_version != None and chpl_gpu.get() == 'amd':
             # strip the "git" suffix. This is a TODO. We want to be able to
             # detect LLVM "nightly" versions because ROCm seems to ship with
             # those. A sign for that is the `git` suffix at the end of the

--- a/util/cron/test-gpu-ex-rocm-54.bash
+++ b/util/cron/test-gpu-ex-rocm-54.bash
@@ -20,4 +20,4 @@ export CHPL_GPU_ARCH=gfx90a
 export CHPL_NIGHTLY_TEST_DIRS="gpu/native"
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-ex-rocm-54"
-$CWD/nightly -cron ${nightly_args}
+$CWD/nightly -cron -compopts --no-compiler-driver ${nightly_args}


### PR DESCRIPTION
This PR is a follow on to https://github.com/chapel-lang/chapel/pull/24195 and it is supposed to fix cases where we are using bundled LLVM whose `llvm-config` hasn't been built yet.