### PR TITLE
Update chplspell dictionaries

### DIFF
--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -420,7 +420,7 @@ class GpuAssertionReporter {
     ssize_t firstPrintableStackElement = findFirstPrintableStackElement();
     // If the call is in user code, we can print it as usual.
     // But if it's in module code, maybe we don't want to show the exact reason
-    // GPUization failed (it's an implementation detail). Instead, we want
+    // gpuization failed (it's an implementation detail). Instead, we want
     // to call out a standard function as being ineligible for GPU execution.
     //
     // If no stack element is printable, begrudgingly print the call anyway.

--- a/util/devel/chplspell-dictionary
+++ b/util/devel/chplspell-dictionary
@@ -2722,6 +2722,7 @@ pnext
 rnext
 
 FILEID: 2d19bb3e-1d83-11e6-a3a6-10ddb1d4c3d5
+npath
 sfname
 sysctypes
 urse
@@ -2832,6 +2833,7 @@ FILEID: 803ee256-1d85-11e6-a3a6-10ddb1d4c3d5
 bbcopy
 dbaadab
 ftemp
+gpuized
 newresult
 origfn
 rauto
@@ -3347,6 +3349,7 @@ FILEID: 515baeda-2ada-11e6-a3a6-10ddb1d4c3d5
 algebralib
 archlinux
 binarytrees
+buildinglargerpackages
 chpldocumentation
 chplspell
 circularities
@@ -3381,6 +3384,7 @@ libtool
 lmod
 lstlisting
 maxyear
+memcmp
 memkind
 memleakslog
 minyear
@@ -4721,6 +4725,7 @@ FILEID: e9a3e440-9db7-11e7-a204-10ddb1d4c3d5
 stddev
 
 FILEID: cd28f34a-a1b9-11e7-a204-10ddb1d4c3d5
+apptainer
 bullseye
 centos
 cmake
@@ -4730,6 +4735,7 @@ fossa
 indri
 kitware
 kudu
+mantic
 pacman
 xvzf
 
@@ -4741,6 +4747,7 @@ pycparserext
 
 FILEID: cd80a742-ad6d-11e7-a204-10ddb1d4c3d5
 intented
+rsum
 
 FILEID: da2ea3b8-ad6d-11e7-a204-10ddb1d4c3d5
 adom
@@ -4811,6 +4818,7 @@ fabsall
 fids
 freeinfo
 hmem
+indexth
 lcpus
 libiberty
 librdmacm
@@ -4893,6 +4901,7 @@ testmain
 FILEID: a0e68d14-3a21-11e8-af7e-10ddb1d4c3d5
 dabc
 mytest
+prediffs
 
 FILEID: c51f1070-3a21-11e8-af7e-10ddb1d4c3d5
 abcdefghijklmnopqrstuvwxyz
@@ -4969,9 +4978,12 @@ locdoms
 
 FILEID: 203d644e-8648-11e8-ad82-10ddb1d4c3d5
 andnot
+busid
 cpukinds
 nbobjs
 nics
+nonio
+numas
 schedaffinity
 sobj
 thisthread
@@ -5530,8 +5542,10 @@ threadidx
 
 FILEID: 65cc59e0-f560-11eb-bb15-35b7469d4b43
 allocas
+cgscc
 dtype
 hipcc
+idstr
 inalloca
 isinstance
 ndarray
@@ -5641,6 +5655,7 @@ acct
 
 FILEID: e72aeca4-45ab-11ec-a187-336475c959d4
 doit
+gpuized
 griddim
 uize
 xtract
@@ -6125,11 +6140,13 @@ filenamelookupposition
 FILEID: 70eb8f46-a729-11ec-866d-111c8d7a1817
 aopen
 asynchrony
+gpuopen
 hipcc
 nsight
 nvcc
 nvptx
 ptxas
+sdma
 senable
 shocsort
 triadchpl
@@ -6648,6 +6665,8 @@ FILEID: d484d08e-5502-11ee-81ec-fb959b7aa6d7
 rehook
 
 FILEID: d9c9da26-5502-11ee-81ec-fb959b7aa6d7
+cmplx
+cmplxf
 izing
 rehook
 
@@ -6707,6 +6726,35 @@ useed
 
 FILEID: 9d9ca5ac-9250-11ee-8bda-4776592287bc
 chplconstargcheck
+
+FILEID: 15d77cf4-bd7b-11ee-b488-ff57a08c3497
+cgam
+
+FILEID: 868a79d8-bd7b-11ee-b488-ff57a08c3497
+pragmatags
+
+FILEID: b04803a8-bd7b-11ee-b488-ff57a08c3497
+cimag
+cimagf
+cmplx
+cmplxf
+creal
+crealf
+csqrt
+csqrtf
+
+FILEID: ca233edc-bd7b-11ee-b488-ff57a08c3497
+pragmatags
+
+FILEID: 1f7f5960-bd7c-11ee-b488-ff57a08c3497
+nlines
+
+FILEID: 386cfb80-bd7c-11ee-b488-ff57a08c3497
+deadcode
+splitreq
+
+FILEID: 43c3e828-bd85-11ee-b488-ff57a08c3497
+myvar
 
 NATURAL:
 aarch
@@ -6773,6 +6821,8 @@ angeles
 aniket
 ankush
 anonymize
+anonymized
+anonymizer
 ansi
 antialias
 anubhav
@@ -6822,6 +6872,7 @@ asenjo
 ashwin
 asinh
 asprintf
+assignability
 astfalk
 astimezone
 astloc
@@ -7056,6 +7107,7 @@ cholesky
 chowdhury
 chown
 chpl
+chplcheck
 chplconfig
 chpldef
 chpldoc
@@ -7116,6 +7168,7 @@ codereview
 codesign
 coforall
 coforalls
+coghlan
 cohen
 colocales
 colorado
@@ -7278,6 +7331,7 @@ densifications
 densify
 deprioritized
 deps
+deques
 dequeue
 dequeued
 dequeuer
@@ -8105,6 +8159,7 @@ katz
 kaur
 kayah
 kayraklioglu
+kbrady
 keasler
 keaton
 keepalive

--- a/util/devel/chplspell-dictionary.fileids.json
+++ b/util/devel/chplspell-dictionary.fileids.json
@@ -191,6 +191,9 @@
   "2c837c22-d1aa-11e8-954d-10ddb1d4c3d5": [
     "compiler/llvm/llvmDebug.cpp"
   ],
+  "15d77cf4-bd7b-11ee-b488-ff57a08c3497": [
+    "compiler/llvm/llvmExtractIR.cpp"
+  ],
   "1de0f71c-d1aa-11e8-954d-10ddb1d4c3d5": [
     "compiler/llvm/llvmGlobalToWide.cpp"
   ],
@@ -677,6 +680,9 @@
   "a9aa4b58-9f70-11ec-866d-111c8d7a1817": [
     "frontend/include/chpl/types/RealType.h"
   ],
+  "868a79d8-bd7b-11ee-b488-ff57a08c3497": [
+    "frontend/include/chpl/types/Type.h"
+  ],
   "16268030-9f71-11ec-866d-111c8d7a1817": [
     "frontend/include/chpl/types/UnknownType.h"
   ],
@@ -986,6 +992,9 @@
   "7003a24e-5a61-11ed-baec-ef9f14c5b529": [
     "frontend/lib/framework/error-classes-list.cpp"
   ],
+  "b04803a8-bd7b-11ee-b488-ff57a08c3497": [
+    "frontend/lib/immediates/complex-support.c"
+  ],
   "360f852e-9f74-11ec-866d-111c8d7a1817": [
     "frontend/lib/immediates/num.cpp"
   ],
@@ -1067,6 +1076,9 @@
   "bd49d274-9f74-11ec-866d-111c8d7a1817": [
     "frontend/lib/types/Param.cpp"
   ],
+  "ca233edc-bd7b-11ee-b488-ff57a08c3497": [
+    "frontend/lib/types/Type.cpp"
+  ],
   "2c60856a-e3ac-11ec-a8be-cd81bce0efc4": [
     "frontend/lib/uast/AstNode.cpp"
   ],
@@ -1105,6 +1117,9 @@
   ],
   "eda6a798-12c0-11ed-a8be-cd81bce0efc4": [
     "frontend/lib/util/terminal.cpp"
+  ],
+  "43c3e828-bd85-11ee-b488-ff57a08c3497": [
+    "frontend/test/resolution/testScopeResolve.cpp"
   ],
   "3eb6fb72-300f-11ed-b71b-d7492178b4dc": [
     "frontend/tools/chpldoc/arg.cpp"
@@ -1260,6 +1275,9 @@
   "2127a88e-1f1a-11e6-a3a6-10ddb1d4c3d5": [
     "modules/packages/Curl.chpl"
   ],
+  "386cfb80-bd7c-11ee-b488-ff57a08c3497": [
+    "modules/packages/DistributedBag.chpl"
+  ],
   "733029d2-8aba-11e7-b3f1-10ddb1d4c3d5": [
     "modules/packages/DistributedBagDeprecated.chpl"
   ],
@@ -1301,6 +1319,9 @@
   ],
   "8885f7a4-9250-11ee-8bda-4776592287bc": [
     "modules/packages/NPBRandom.chpl"
+  ],
+  "1f7f5960-bd7c-11ee-b488-ff57a08c3497": [
+    "modules/packages/ParallelIO.chpl"
   ],
   "10db92e8-fecb-11ea-b2e8-10ddb1d4c3d5": [
     "modules/packages/ProtobufProtocolSupport.chpl"


### PR DESCRIPTION
Update chplspell dictionaries

Without the change to `gpuTransforms.cpp`, the dictionary would need to include `uization` because it treats "GPUization" as GP + Uization. Thankfully the capitalization of "gpuization" is a better fit with the other occurrences of this word. While the dictionary already contains "ufunction" and "lcode" and some others in order to accept "CUfunction" and "CURLcode" et al. for the same reason, these are more benign than "uization" and also we cannot change them.