### PR TITLE
LSP: make use of Dyno resolver to provide inlay hints and go-to-type-definition

### DIFF
--- a/third-party/chpl-venv/chplcheck-requirements.txt
+++ b/third-party/chpl-venv/chplcheck-requirements.txt
@@ -3,3 +3,4 @@ cattrs==23.1.2
 lsprotocol==2023.0.0b1
 pygls==1.1.1
 typeguard==3.0.2
+ConfigArgParse==1.7

--- a/tools/chapel-py/scripts/generate-pyi.py
+++ b/tools/chapel-py/scripts/generate-pyi.py
@@ -199,7 +199,7 @@ def get_AstNode_header() -> str:
         ),
         _wrap_method(
             "type",
-            rettype="typing.Tuple[str, typing.Optional[ChapelType], typing.Optional[Param]]",
+            rettype="typing.Optional[typing.Tuple[str, typing.Optional[ChapelType], typing.Optional[Param]]]",
             docstring="Get the type for this AST node, as a tuple of (kind, type, param value)",
         ),
         _wrap_method(

--- a/tools/chapel-py/scripts/generate-pyi.py
+++ b/tools/chapel-py/scripts/generate-pyi.py
@@ -203,6 +203,11 @@ def get_AstNode_header() -> str:
             docstring="Get the type for this AST node, as a tuple of (kind, type, param value)",
         ),
         _wrap_method(
+            "called_fn",
+            rettype="typing.Optional[Function]",
+            docstring="Get the function called by this node, if any",
+        ),
+        _wrap_method(
             "parent",
             rettype="typing.Optional[AstNode]",
             docstring="Get the parent node of this AST node",

--- a/tools/chapel-py/src/chapel/__init__.py
+++ b/tools/chapel-py/src/chapel/__init__.py
@@ -22,8 +22,10 @@ from .core import *
 from collections import defaultdict
 import os
 from typing import Dict, List, Optional
+import typing
 from . import visitor
 
+QualifiedType = typing.Tuple[str, Optional[ChapelType], Optional[Param]]
 
 def preorder(node):
     """

--- a/tools/chapel-py/src/core-types.cpp
+++ b/tools/chapel-py/src/core-types.cpp
@@ -420,17 +420,17 @@ void AstNodeObject_dealloc(AstNodeObject* self) {
   Py_TYPE(self)->tp_free((PyObject *) self);
 }
 
-PyObject* AstNodeObject_dump(AstNodeObject *self, PyObject *Py_UNUSED(ignored)) {
+PyObject* AstNodeObject_dump(AstNodeObject *self) {
   self->ptr->dump();
   Py_RETURN_NONE;
 }
 
-PyObject* AstNodeObject_tag(AstNodeObject *self, PyObject *Py_UNUSED(ignored)) {
+PyObject* AstNodeObject_tag(AstNodeObject *self) {
   const char* nodeType = asttags::tagToString(self->ptr->tag());
   return Py_BuildValue("s", nodeType);
 }
 
-PyObject* AstNodeObject_unique_id(AstNodeObject *self, PyObject *Py_UNUSED(ignored)) {
+PyObject* AstNodeObject_unique_id(AstNodeObject *self) {
   std::stringstream ss;
   self->ptr->id().stringify(ss, CHPL_SYNTAX);
   auto uniqueID = ss.str();
@@ -438,12 +438,12 @@ PyObject* AstNodeObject_unique_id(AstNodeObject *self, PyObject *Py_UNUSED(ignor
 }
 
 
-PyObject* AstNodeObject_attribute_group(AstNodeObject *self, PyObject *Py_UNUSED(ignored)) {
+PyObject* AstNodeObject_attribute_group(AstNodeObject *self) {
   return wrapAstNode((ContextObject*) self->contextObject,
                      self->ptr->attributeGroup());
 }
 
-PyObject* AstNodeObject_pragmas(AstNodeObject *self, PyObject *Py_UNUSED(ignored)) {
+PyObject* AstNodeObject_pragmas(AstNodeObject *self) {
   PyObject* elms = PySet_New(NULL);
   auto attrs = self->ptr->attributeGroup();
   if (attrs) {
@@ -455,7 +455,7 @@ PyObject* AstNodeObject_pragmas(AstNodeObject *self, PyObject *Py_UNUSED(ignored
   return elms;
 }
 
-PyObject* AstNodeObject_parent(AstNodeObject* self, PyObject *Py_UNUSED(ignored)) {
+PyObject* AstNodeObject_parent(AstNodeObject* self) {
   auto contextObject = (ContextObject*) self->contextObject;
   auto context = &contextObject->context;
 
@@ -487,7 +487,7 @@ PyObject* AstNodeObject_scope(AstNodeObject *self) {
   return scopeObjectPy;
 }
 
-PyObject* AstNodeObject_type(AstNodeObject *self, PyObject *Py_UNUSED(ignored)) {
+PyObject* AstNodeObject_type(AstNodeObject *self) {
   auto contextObject = (ContextObject*) self->contextObject;
   auto context = &contextObject->context;
 
@@ -503,7 +503,7 @@ PyObject* AstNodeObject_type(AstNodeObject *self, PyObject *Py_UNUSED(ignored)) 
   return ret;
 }
 
-PyObject* AstNodeObject_called_fn(AstNodeObject *self, PyObject *Py_UNUSED(ignored)) {
+PyObject* AstNodeObject_called_fn(AstNodeObject *self) {
   auto contextObject = (ContextObject*) self->contextObject;
   auto context = &contextObject->context;
 

--- a/tools/chapel-py/src/core-types.cpp
+++ b/tools/chapel-py/src/core-types.cpp
@@ -383,6 +383,7 @@ static PyMethodDef AstNodeObject_methods[] = {
   {"unique_id", (PyCFunction) AstNodeObject_unique_id, METH_NOARGS, "Get a unique identifier for this AST node"},
   {"scope", (PyCFunction) AstNodeObject_scope, METH_NOARGS, "Get the scope for this AST node"},
   {"type", (PyCFunction) AstNodeObject_type, METH_NOARGS, "Get the type of this AST node"},
+  {"called_fn", (PyCFunction) AstNodeObject_called_fn, METH_NOARGS, "Get the function being invoked by this node"},
   {NULL, NULL, 0, NULL} /* Sentinel */
 };
 
@@ -500,6 +501,13 @@ PyObject* AstNodeObject_type(AstNodeObject *self, PyObject *Py_UNUSED(ignored)) 
                                     wrapParam(contextObject, qt.param()));
 
   return ret;
+}
+
+PyObject* AstNodeObject_called_fn(AstNodeObject *self, PyObject *Py_UNUSED(ignored)) {
+  auto contextObject = (ContextObject*) self->contextObject;
+  auto context = &contextObject->context;
+
+  return wrapAstNode(contextObject, calledFnForNode(context, self->ptr));
 }
 
 static PyMethodDef ChapelTypeObject_methods[] = {

--- a/tools/chapel-py/src/core-types.h
+++ b/tools/chapel-py/src/core-types.h
@@ -83,17 +83,17 @@ void setupAstNodeType();
 
 int AstNodeObject_init(AstNodeObject* self, PyObject* args, PyObject* kwargs);
 void AstNodeObject_dealloc(AstNodeObject* self);
-PyObject* AstNodeObject_dump(AstNodeObject *self, PyObject *Py_UNUSED(ignored));
-PyObject* AstNodeObject_tag(AstNodeObject *self, PyObject *Py_UNUSED(ignored));
-PyObject* AstNodeObject_unique_id(AstNodeObject *self, PyObject *Py_UNUSED(ignored));
-PyObject* AstNodeObject_attribute_group(AstNodeObject *self, PyObject *Py_UNUSED(ignored));
-PyObject* AstNodeObject_pragmas(AstNodeObject *self, PyObject *Py_UNUSED(ignored));
-PyObject* AstNodeObject_parent(AstNodeObject* self, PyObject *Py_UNUSED(ignored));
+PyObject* AstNodeObject_dump(AstNodeObject *self);
+PyObject* AstNodeObject_tag(AstNodeObject *self);
+PyObject* AstNodeObject_unique_id(AstNodeObject *self);
+PyObject* AstNodeObject_attribute_group(AstNodeObject *self);
+PyObject* AstNodeObject_pragmas(AstNodeObject *self);
+PyObject* AstNodeObject_parent(AstNodeObject* self);
 PyObject* AstNodeObject_iter(AstNodeObject *self);
 PyObject* AstNodeObject_location(AstNodeObject *self);
 PyObject* AstNodeObject_scope(AstNodeObject *self);
-PyObject* AstNodeObject_type(AstNodeObject *self, PyObject *Py_UNUSED(ignored));
-PyObject* AstNodeObject_called_fn(AstNodeObject *self, PyObject *Py_UNUSED(ignored));
+PyObject* AstNodeObject_type(AstNodeObject *self);
+PyObject* AstNodeObject_called_fn(AstNodeObject *self);
 
 typedef struct {
   PyObject_HEAD

--- a/tools/chapel-py/src/core-types.h
+++ b/tools/chapel-py/src/core-types.h
@@ -93,6 +93,7 @@ PyObject* AstNodeObject_iter(AstNodeObject *self);
 PyObject* AstNodeObject_location(AstNodeObject *self);
 PyObject* AstNodeObject_scope(AstNodeObject *self);
 PyObject* AstNodeObject_type(AstNodeObject *self, PyObject *Py_UNUSED(ignored));
+PyObject* AstNodeObject_called_fn(AstNodeObject *self, PyObject *Py_UNUSED(ignored));
 
 typedef struct {
   PyObject_HEAD

--- a/tools/chapel-py/src/method-tables.h
+++ b/tools/chapel-py/src/method-tables.h
@@ -613,6 +613,11 @@ CLASS_BEGIN(StringParam)
                UniqueString, return node->value())
 CLASS_END(StringParam)
 
+CLASS_BEGIN(CompositeType)
+  PLAIN_GETTER(CompositeType, decl, "Get the location where this composite type is declared",
+               const AstNode*, return parsing::idToAst(context, node->id()))
+CLASS_END(CompositeType)
+
 //
 // Cleanup and undefine all macros
 //

--- a/tools/chapel-py/src/method-tables.h
+++ b/tools/chapel-py/src/method-tables.h
@@ -430,6 +430,8 @@ CLASS_BEGIN(Call)
                IterAdapterBase*, return mkIterPair(node->actuals()))
   PLAIN_GETTER(Call, called_expression, "Get the expression invoked by this Call node",
                const AstNode*, return node->calledExpression())
+  PLAIN_GETTER(Call, formal_actual_mapping, "Get the index of the function's formal for each of the call's actuals.",
+               std::vector<int>, return actualOrderForNode(context, node))
 CLASS_END(Call)
 
 CLASS_BEGIN(FnCall)

--- a/tools/chapel-py/src/method-tables.h
+++ b/tools/chapel-py/src/method-tables.h
@@ -614,7 +614,7 @@ CLASS_BEGIN(StringParam)
 CLASS_END(StringParam)
 
 CLASS_BEGIN(CompositeType)
-  PLAIN_GETTER(CompositeType, decl, "Get the location where this composite type is declared",
+  PLAIN_GETTER(CompositeType, decl, "Get the AstNode that declares this CompositeType",
                const AstNode*, return parsing::idToAst(context, node->id()))
 CLASS_END(CompositeType)
 

--- a/tools/chapel-py/src/resolution.h
+++ b/tools/chapel-py/src/resolution.h
@@ -25,3 +25,9 @@ nodeOrNullFromToId(chpl::Context* context, const chpl::uast::AstNode* node);
 
 chpl::types::QualifiedType const&
 typeForNode(chpl::Context* context, const chpl::uast::AstNode* node);
+
+const chpl::uast::AstNode* const&
+calledFnForNode(chpl::Context* context, const chpl::uast::AstNode* node);
+
+std::vector<int> const&
+actualOrderForNode(chpl::Context* context, const chpl::uast::AstNode* node);

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -626,7 +626,9 @@ class ChapelLanguageServer(LanguageServer):
         if uri in self.configurations:
             del self.configurations[uri]
 
-    def _get_param_inlays(self, decl: NodeAndRange, qt: chapel.QualifiedType) -> List[InlayHint]:
+    def _get_param_inlays(
+        self, decl: NodeAndRange, qt: chapel.QualifiedType
+    ) -> List[InlayHint]:
         if not self.param_inlays:
             return []
 
@@ -642,7 +644,9 @@ class ChapelLanguageServer(LanguageServer):
             )
         ]
 
-    def _get_type_inlays(self, decl: NodeAndRange, qt: chapel.QualifiedType) -> List[InlayHint]:
+    def _get_type_inlays(
+        self, decl: NodeAndRange, qt: chapel.QualifiedType
+    ) -> List[InlayHint]:
         if not self.type_inlays:
             return []
 
@@ -948,7 +952,12 @@ def run_lsp():
         fi, _ = ls.get_file_info(text_doc.uri)
 
         decls = fi.def_segments.range(params.range)
-        calls = list(call for call, _ in chapel.each_matching(fi.get_asts(), chapel.core.FnCall))
+        calls = list(
+            call
+            for call, _ in chapel.each_matching(
+                fi.get_asts(), chapel.core.FnCall
+            )
+        )
 
         inlays: List[InlayHint] = []
         with fi.context.context.track_errors() as _:

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -449,7 +449,7 @@ class WorkspaceConfig:
 
             if not isinstance(compile_commands, list):
                 ls.show_message(
-                    "invalid .cls-info.json file", MessageType.Error
+                    "invalid .cls-commands.json file", MessageType.Error
                 )
                 continue
 
@@ -459,7 +459,7 @@ class WorkspaceConfig:
             # at least one compile command.
             if len(compile_commands) == 0:
                 ls.show_message(
-                    ".cls-info.json file contains invalid file commands",
+                    ".cls-commands.json file contains invalid file commands",
                     MessageType.Error,
                 )
                 continue
@@ -612,7 +612,7 @@ class ChapelLanguageServer(LanguageServer):
             return "\n".join(lines)
 
     def register_workspace(self, uri: str):
-        path = os.path.join(uri[len("file://") :], ".cls-info.json")
+        path = os.path.join(uri[len("file://") :], ".cls-commands.json")
         config = WorkspaceConfig.from_file(self, path)
         if config:
             self.configurations[uri] = config

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -727,7 +727,7 @@ def run_lsp():
     Start a language server on the standard input/output
     """
     parser = configargparse.ArgParser(
-        default_config_files=[".cls-config.yml"],
+        default_config_files=[], # Empty for now because cwd() is odd with VSCode etc.
         config_file_parser_class=configargparse.YAMLConfigFileParser,
     )
 

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -101,6 +101,7 @@ from lsprotocol.types import (
     InlayHintParams,
     InlayHint,
 )
+from lsprotocol.types import WORKSPACE_INLAY_HINT_REFRESH
 
 
 def decl_kind(decl: chapel.NamedDecl) -> Optional[SymbolKind]:
@@ -651,6 +652,7 @@ def run_lsp():
         text_doc = ls.workspace.get_text_document(params.text_document.uri)
         diag = ls.build_diagnostics(text_doc.uri)
         ls.publish_diagnostics(text_doc.uri, diag)
+        ls.lsp.send_request_async(WORKSPACE_INLAY_HINT_REFRESH)
 
     @server.feature(TEXT_DOCUMENT_DECLARATION)
     @server.feature(TEXT_DOCUMENT_DEFINITION)

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -883,10 +883,14 @@ def run_lsp():
                             # For only, onle show named arguments for literals
                             continue
 
+                        fml = fn.formal(i)
+                        if not isinstance(fml, chapel.core.Formal):
+                            continue
+
                         begin = location_to_range(act.location()).start
                         value_list.append(InlayHint(
                             position = begin,
-                            label = fn.formal(i).name() + " = ",
+                            label = fml.name() + " = ",
                         ))
 
         return value_list

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -677,6 +677,8 @@ class ChapelLanguageServer(LanguageServer):
             return []
 
         qt = decl.node.type()
+        if qt is None:
+            return []
 
         inlays = []
         inlays.extend(self._get_param_inlays(decl, qt))

--- a/tools/chpl-language-server/src/chpl-shim.py
+++ b/tools/chpl-language-server/src/chpl-shim.py
@@ -79,7 +79,7 @@ def run_toplevel():
                 for key, value in from_file.items():
                     commands[key].append(value)
 
-    with open(".cls-info.json", "w") as f:
+    with open(".cls-commands.json", "w") as f:
         json.dump(commands, f)
 
 


### PR DESCRIPTION
This PR makes use of the changes in https://github.com/chapel-lang/chapel/pull/24283 to add some user-facing features. These features are:

* Support for (currently disabled due to editor quirks) for a user-provided configuration file (`.cls-config.toml`). This file can be used to enable to the resolver (off by default), which in turn allows for all the features listed below. The configuration options exposed in this file are also exposed by the executable as command-line flags.
* Labeling literal actuals to calls with their formal names. Thus, `f("Jackson")` gets rendered in VSCode as `f(firstName = "Jackson")`. 
  ![image](https://github.com/chapel-lang/chapel/assets/4361282/2b950627-45c0-4b88-b712-3647960c650c)
* Showing the inferred type of a declaration if it doesn't have an explicit type.
  ![Screen Shot 2024-01-29 at 6 20 38 PM](https://github.com/chapel-lang/chapel/assets/4361282/fec19f07-e3a8-452b-99f7-9a57f490a8af)
* Go-to-type definition (currently only within a particular file). 

This PR also changes `.cls-info.json` to be `.cls-commands.json`, to make the thing that inspired the file format: `compile-commands.json`.

Reviewed by @jabraham17 -- thanks!

- [x] This PR depends on #24284, and is left as a draft until it merges.

  