### PR TITLE
Fix test prediff to use more portable sed

### DIFF
--- a/test/compflags/ferguson/munge-with-ids.prediff
+++ b/test/compflags/ferguson/munge-with-ids.prediff
@@ -8,5 +8,5 @@ LOG=$2
 # include only the 'define' line
 # looking for define internal i64 @munge-with-ids.foo() 
 #
-cat $LOG | grep define | sed 's/#[[:digit:]]\+/#n/' > $LOG.tmp
+cat $LOG | grep define | sed -E 's/#[[:digit:]]+/#n/' > $LOG.tmp
 mv $LOG.tmp $LOG


### PR DESCRIPTION
Fixes test using sed which failed in Mac nightly testing since the `sed` command did not match.

Tested on Mac and Linux

[Not reviewed - trivial]