### PR TITLE
Fix sort issues revealed by Arkouda testing after two-array sort changes

### DIFF
--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -3363,6 +3363,10 @@ module TwoArrayRadixSort {
 
   proc twoArrayRadixSort(ref Data:[], comparator:?rec=defaultComparator) {
 
+    if !domainDistIsLayout(Data.domain) {
+      compilerWarning("twoArrayRadix sort no longer handles distributed arrays. Please use TwoArrayDistributedRadixSort.twoArrayDistributedRadixSort instead (but note that it is not stable)");
+    }
+
     var sequentialSizePerTask=4096;
     var baseCaseSize=16;
     var distributedBaseCaseSize=1024;

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -3381,6 +3381,9 @@ module TwoArrayRadixSort {
     var Scratch: Data.type =
       Data.domain.buildArray(Data.eltType, initElts=false);
 
+    // TODO: do some relevant first-touch
+    Scratch.dsiElementInitializationComplete();
+
     var state = new TwoArrayBucketizerSharedState(
       bucketizer=new RadixBucketizer(),
       baseCaseSize=baseCaseSize,
@@ -3426,6 +3429,9 @@ module TwoArrayDistributedRadixSort {
     pragma "no auto destroy"
     var Scratch: Data.type =
       Data.domain.buildArray(Data.eltType, initElts=false);
+
+    // TODO: do some relevant first-touch
+    Scratch.dsiElementInitializationComplete();
 
     var state1 = new TwoArrayDistributedBucketizerSharedState(
       bucketizerType=RadixBucketizer,
@@ -3475,6 +3481,9 @@ module TwoArraySampleSort {
     var Scratch: Data.type =
       Data.domain.buildArray(Data.eltType, initElts=false);
 
+    // TODO: do some relevant first-touch
+    Scratch.dsiElementInitializationComplete();
+
     var state = new TwoArrayBucketizerSharedState(
       bucketizer=new SampleBucketizer(Data.eltType),
       baseCaseSize=baseCaseSize,
@@ -3520,6 +3529,9 @@ module TwoArrayDistributedSampleSort {
     pragma "no auto destroy"
     var Scratch: Data.type =
       Data.domain.buildArray(Data.eltType, initElts=false);
+
+    // TODO: do some relevant first-touch
+    Scratch.dsiElementInitializationComplete();
 
     var state = new TwoArrayDistributedBucketizerSharedState(
       bucketizerType=SampleBucketizer(Data.eltType),

--- a/test/distributions/robust/arithmetic/modules/test_module_Search.chpl
+++ b/test/distributions/robust/arithmetic/modules/test_module_Search.chpl
@@ -14,7 +14,8 @@ var elem: real;
 
 proc reset(ref A) {
   rng.fill(A);
-  sort(A);
+  QuickSort.quickSort(A); // use quicksort for now to avoid warning
+                          // about sorting a distributed array
   elem = A[idx];
 }
 

--- a/test/library/packages/Sort/RadixSort/distributedRadixSort.chpl
+++ b/test/library/packages/Sort/RadixSort/distributedRadixSort.chpl
@@ -80,7 +80,7 @@ proc randomtest(n:int) {
 
   var timer:stopwatch;
   timer.start();
-  TwoArrayRadixSort.twoArrayRadixSort(A, defaultComparator);
+  TwoArrayDistributedRadixSort.twoArrayDistributedRadixSort(A, defaultComparator);
   timer.stop();
 
   if comms {


### PR DESCRIPTION
Follow-up to PR #24147.

This PR addresses two problems with the two-array sort that came up in testing:
 1. The `twoArrayRadixSort` routine no longer handles distributed arrays, but it used to. PR #24147 changed this to move the dependency on Block to a module that isn't included by default, but that led to timeouts for programs expecting `twoArrayRadixSort` to do something reasonable with a distributed array. This PR makes the issue more apparent by issuing a compilation warning (although it will require other changes to Arkouda).
 2. One of the optimizations / bug fixes in PR #24147 was to adjust the twoArrayRadixSort (and related functions) to allocate the scratch array without initializing the elements. However, I forgot to also tell the runtime that it could go ahead and register the memory. That led to some strange looking errors & halts when using `CHPL_COMM=ugni`. For now, this PR simply adds the call to `Scratch.dsiElementInitializationComplete()`; however, in future work, I will investigate if touching the memory pages in a similar manner to how the count step of the radix sort runs will help performance.

Q: Does `twoArrayRadixSort` work for a distributed array but is just inefficient in that setting? Is that why it's a warning rather than an error?
A: Yes
Q: Could `twoArrayRadixSort` automatically run the distributed sort?
A: No, because it's included by default, and that would cause `Block` to be included by default, leading to an increase in compile times

Reviewed by @vasslitvinov - thanks!

- [x] full comm=none testing
- [x] full comm=gasnet testing