### PR TITLE
Rust sorting benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ tags
 .idea/
 cmake-build-*/
 .cache/
+target/
+Cargo.lock
 
 # Top level ignores.
 /BUILD_VERSION

--- a/test/library/packages/Sort/performance/comparison/sort-random-rust-rayon/.cargo/config.toml
+++ b/test/library/packages/Sort/performance/comparison/sort-random-rust-rayon/.cargo/config.toml
@@ -1,0 +1,5 @@
+[build]
+rustflags = [
+  "-C",
+  "target-cpu=native",
+]

--- a/test/library/packages/Sort/performance/comparison/sort-random-rust-rayon/Cargo.toml
+++ b/test/library/packages/Sort/performance/comparison/sort-random-rust-rayon/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "sort-random-rust"
+name = "sort-random-rust-rayon"
 version = "0.0.0"
 edition = "2021"
 publish = false

--- a/test/library/packages/Sort/performance/comparison/sort-random-rust-rayon/src/main.rs
+++ b/test/library/packages/Sort/performance/comparison/sort-random-rust-rayon/src/main.rs
@@ -23,8 +23,7 @@ fn main() {
     );
 
     let start = Instant::now();
-    // Without rayon.
-    values.sort_unstable();
+    values.par_sort_unstable();
     let duration = start.elapsed();
 
     println!(

--- a/test/library/packages/Sort/performance/comparison/sort-random-rust/.cargo/config.toml
+++ b/test/library/packages/Sort/performance/comparison/sort-random-rust/.cargo/config.toml
@@ -1,0 +1,5 @@
+[build]
+rustflags = [
+  "-C",
+  "target-cpu=native",
+]

--- a/test/library/packages/Sort/performance/comparison/sort-random-rust/Cargo.toml
+++ b/test/library/packages/Sort/performance/comparison/sort-random-rust/Cargo.toml
@@ -3,8 +3,11 @@ name = "sort-random-rust"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 rand = "0.8.4"
 
+[profile.release]
+lto = true
+codegen-units = 1
+strip = true
+panic = "abort"

--- a/test/library/packages/Sort/performance/comparison/sort-random-rust/Cargo.toml
+++ b/test/library/packages/Sort/performance/comparison/sort-random-rust/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rand = "0.8.4"
+rand = { version = "0.8.4", features = ["small_rng"] }
+rayon = "1.8.1"
 
 [profile.release]
 lto = true

--- a/test/library/packages/Sort/performance/comparison/sort-random-rust/src/main.rs
+++ b/test/library/packages/Sort/performance/comparison/sort-random-rust/src/main.rs
@@ -7,6 +7,12 @@ use rayon::prelude::*;
 use std::time::Instant;
 
 fn main() {
+    // 4 threads performed the best on my 8 core machine.
+    rayon::ThreadPoolBuilder::new()
+        .num_threads(4)
+        .build_global()
+        .unwrap();
+
     let n = 128 * 1024 * 1024;
 
     let t1 = Instant::now();
@@ -23,7 +29,7 @@ fn main() {
     );
 
     let start = Instant::now();
-    values.sort_unstable();
+    values.par_sort_unstable();
     let duration = start.elapsed();
 
     println!(

--- a/test/library/packages/Sort/performance/comparison/sort-random-rust/src/main.rs
+++ b/test/library/packages/Sort/performance/comparison/sort-random-rust/src/main.rs
@@ -1,7 +1,7 @@
 // run it with
 //  cd sort-random-rust
-//  cargo build --release
-//  target/release/sort-random-rust
+//  cargo run --release
+
 use rand::distributions::Standard;
 use rand::prelude::*;
 use std::time::Instant;

--- a/test/library/packages/Sort/performance/comparison/sort-random-rust/src/main.rs
+++ b/test/library/packages/Sort/performance/comparison/sort-random-rust/src/main.rs
@@ -2,15 +2,20 @@
 //  cd sort-random-rust
 //  cargo run --release
 
-use rand::distributions::Standard;
-use rand::prelude::*;
+use rand::{distributions::Standard, rngs::SmallRng, Rng, SeedableRng};
+use rayon::prelude::*;
 use std::time::Instant;
 
 fn main() {
     let n = 128 * 1024 * 1024;
 
     let t1 = Instant::now();
-    let mut values: Vec<u64> = rand::thread_rng().sample_iter(Standard).take(n).collect();
+    let rng = SmallRng::seed_from_u64(42);
+    let mut values = Vec::<u64>::new();
+    (0..n)
+        .into_par_iter()
+        .map_with(rng, |rng, _| rng.sample(Standard))
+        .collect_into_vec(&mut values);
     let gen_duration = t1.elapsed();
     println!(
         "generating {:?} MiB/s",

--- a/test/library/packages/Sort/performance/comparison/sort-random-rust/src/main.rs
+++ b/test/library/packages/Sort/performance/comparison/sort-random-rust/src/main.rs
@@ -18,7 +18,7 @@ fn main() {
         .collect_into_vec(&mut values);
     let gen_duration = t1.elapsed();
     println!(
-        "generating {:?} MiB/s",
+        "generating {} MiB/s",
         8.0 * (n as f64) / gen_duration.as_secs_f64() / 1024.0 / 1024.0
     );
 
@@ -27,12 +27,12 @@ fn main() {
     let duration = start.elapsed();
 
     println!(
-        "{:?} MiB/s",
+        "{} MiB/s",
         8.0 * (n as f64) / duration.as_secs_f64() / 1024.0 / 1024.0
     );
 
     println!(
-        "{:?} million elements sorted per second",
+        "{} million elements sorted per second",
         (n as f64) / duration.as_secs_f64() / 1000.0 / 1000.0
     );
 }

--- a/test/library/packages/Sort/performance/comparison/sort-random-rust/src/main.rs
+++ b/test/library/packages/Sort/performance/comparison/sort-random-rust/src/main.rs
@@ -2,24 +2,32 @@
 //  cd sort-random-rust
 //  cargo build --release
 //  target/release/sort-random-rust
-use rand::prelude::*;
 use rand::distributions::Standard;
+use rand::prelude::*;
 use std::time::Instant;
 
 fn main() {
-    let n = 128*1024*1024;
+    let n = 128 * 1024 * 1024;
 
     let t1 = Instant::now();
     let mut values: Vec<u64> = rand::thread_rng().sample_iter(Standard).take(n).collect();
     let gen_duration = t1.elapsed();
-    println!("generating {:?} MiB/s", 8.0*(n as f64)/gen_duration.as_secs_f64()/1024.0/1024.0);
+    println!(
+        "generating {:?} MiB/s",
+        8.0 * (n as f64) / gen_duration.as_secs_f64() / 1024.0 / 1024.0
+    );
 
     let start = Instant::now();
     values.sort_unstable();
     let duration = start.elapsed();
 
-    println!("{:?} MiB/s", 8.0*(n as f64)/duration.as_secs_f64()/1024.0/1024.0);
+    println!(
+        "{:?} MiB/s",
+        8.0 * (n as f64) / duration.as_secs_f64() / 1024.0 / 1024.0
+    );
 
-    println!("{:?} million elements sorted per second",
-             (n as f64)/duration.as_secs_f64()/1000.0/1000.0);
+    println!(
+        "{:?} million elements sorted per second",
+        (n as f64) / duration.as_secs_f64() / 1000.0 / 1000.0
+    );
 }


### PR DESCRIPTION
On my machine, Rust has almost the same performance now. Please update your blog post for a better comparison.

Why would you use the `rand` crate for random number generation and not `rayon` for parallelism?

`rayon` is written in 100% Rust. About the "Standard library" thing: Rust by design keeps its standard library as small as possible. Major crates like `rayon` are often maintained by the Rust maintainers themself. For `rayon`, the two main maintainers Josh Stone and Niko Matsakis are core Rust contributors. Niko is even a team leader of the language team: https://www.rust-lang.org/governance