### PR TITLE
Skip debug test with `--fast`

### DIFF
--- a/test/llvm/dbg-intrinsics/dbg-proc-declare.skipif
+++ b/test/llvm/dbg-intrinsics/dbg-proc-declare.skipif
@@ -1,0 +1,3 @@
+# under newer LLVM versions, `x` is entirely optimized away
+# and no `call void @llvm.dbg.declare` appears in the IR.
+COMPOPTS <= --fast


### PR DESCRIPTION
Skips an LLVM debug info test which fails with newer LLVM versions and `--fast`. This is because the newer versions completely optimize away a variable, and the test is checking that the debug info is emitted for that variable.

Test locally with `start_test --respect-skipifs -compopts --fast test/llvm/dbg-intrinsics/dbg-proc-declare.chpl`

[Reviewed by @mppf]