### PR TITLE
Update future with issue number

### DIFF
--- a/test/library/standard/List/initEquals/listInitEqualsArrayBug.future
+++ b/test/library/standard/List/initEquals/listInitEqualsArrayBug.future
@@ -1,1 +1,2 @@
 bug: init= segfaults at runtime
+#24305


### PR DESCRIPTION
Update `test/library/standard/List/initEquals/listInitEqualsArrayBug.future` with the issue number for the bug.

[Not reviewed - trivial]