### PR TITLE
Remove default-seed unstable warnings from the Random module

### DIFF
--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -34,18 +34,19 @@
 
     * :proc:`fillRandom` fills an array with random numbers in parallel
     * :proc:`shuffle` randomly re-arranges the elements of an array
-    * :proc:`permutation` creates a random permutation of an array's domain (*unstable*).
+    * :proc:`permute` creates a random permutation of an array's domain
 
     Seed Generation
     ---------------
 
-    The :record:`randomStream` type can be initialized with a seed value.
-    When not provided explicitly, a seed will be generated in an
-    implementation specific manner based on the current time. This behavior
-    is currently unstable and may change in the future.
+    The :record:`randomStream` type can be initialized with a seed value. Two
+    ``randomStream`` instances initialized with the same seed with produce
+    identical sequences of random numbers.
 
-    Additionally, the standalone methods in this module that generate their
-    own seed values are currently unstable.
+    When not provided explicitly, a seed value will be generated in an
+    implementation specific manner which is designed to minimize the chance
+    that two distinct invocations of the initializer will produce the same
+    seed.
 
     Prior to Chapel 1.33, seed values could be generated with the now
     deprecated ``RandomSupport.SeedGenerator`` type. For a non-deprecated
@@ -181,7 +182,6 @@ module Random {
 
     :arg arr: An array of numeric values
   */
-  @unstable("the overload of 'fillRandom' that generates its own seed is unstable")
   proc fillRandom(ref arr: [] ?t)
     where isNumericOrBoolType(t) && arr.isRectangular()
   {
@@ -239,7 +239,6 @@ module Random {
     :arg min: The (inclusive) lower bound for the random values
     :arg max: The (inclusive) upper bound for the random values
   */
-  @unstable("the overload of 'fillRandom' that generates its own seed is unstable")
   proc fillRandom(ref arr: [] ?t, min: t, max: t)
     where isNumericOrBoolType(t) && arr.isRectangular()
   {
@@ -297,7 +296,6 @@ module Random {
 
     :arg arr: A non-strided default rectangular 1D array
   */
-  @unstable("the overload of 'shuffle' that generates its own seed is unstable")
   proc shuffle(ref arr: [?d]) where is1DRectangularDomain(d) {
     var rs = new randomStream(d.idxType);
     rs.shuffle(arr);
@@ -337,7 +335,6 @@ module Random {
     :return: A new array containing each of the values from ``arr`` in a
               pseudo-random order.
   */
-  @unstable("the overload of 'permute' that generates its own seed is unstable")
   proc permute(const ref arr: [?d] ?t): [] t
     where is1DRectangularDomain(d)
   {
@@ -369,7 +366,6 @@ module Random {
     :return: An array containing each of the indices from ``d`` in a
               pseudo-random order.
   */
-  @unstable("the overload of 'permute' that generates its own seed is unstable")
   proc permute(d: domain(?)): [] d.idxType
     where is1DRectangularDomain(d)
   {
@@ -398,7 +394,6 @@ module Random {
     :return: An array containing each of the values from ``r`` in a
               pseudo-random order.
   */
-  @unstable("the overload of 'permute' that generates its own seed is unstable")
   proc permute(r: range(bounds=boundKind.both, ?)): [] r.idxType {
     var rs = new randomStream(r.idxType);
     return rs.permute(r);
@@ -494,33 +489,36 @@ module Random {
         * :proc:`randomStream.fill` to fill an array with random numbers
         * :proc:`randomStream.shuffle` to randomly re-arrange the elements of an
           array
-        * :proc:`randomStream.permutation` to create a random permutation of
-          an arrays domain, and store it in the array (*unstable*)
+        * :proc:`randomStream.permute` to create a random permutation of
+          an arrays domain, and store it in the array
         * :proc:`randomStream.choice` to randomly sample from an array or
           range (*unstable*)
 
     Note that these methods have top-level counterparts that will internally
-    create a ``randomStream`` and then call the corresponding method on it. These
-    can be convenient for one-off uses, but if you are generating many random
-    numbers, it is generally more efficient to create a ``randomStream`` and use
-    it repeatedly.
+    create a ``randomStream`` and then call the corresponding method on it —
+    convenient for one-off uses. To generate many random numbers, it is
+    generally more efficient to create a ``randomStream`` and call the relevant
+    method on it repeatedly.
 
     An individual random number can be requested using :proc:`randomStream.getNext`
     which will advance the stream to the next position and return the value at
     that position. The position of the stream can also be manipulated using:
 
       * :proc:`randomStream.skipToNth` to skip to a particular position in the
-        stream
+        stream (*unstable*)
       * :proc:`randomStream.getNth` to skip to a particular position in the
         stream and return the value at that position (*unstable*)
 
-    A ``randomStream`` can be initialized with a seed value. When not provided
-    explicitly, a seed will be generated in an implementation specific manner
-    that depends upon the current time (*this behavior is currently unstable*).
+    A ``randomStream`` can be initialized with a user-provided seed value. Two
+    ``randomStream`` instances initialized with the same seed will produce
+    identical sequences of random numbers. When not provided explicitly, a seed
+    value will be generated in an implementation specific manner designed to
+    minimize the chance that two distinct instances of the ``randomStream``
+    will have the same seed.
 
     When copied, the ``randomStream``'s seed, state, and position will also be
-    copied. This means that the copy will produce the same sequence of random
-    numbers as the original without affecting the original.
+    copied. This means that the copy and original will produce the same sequence
+    of random numbers as the original without affecting each others state.
 
     .. note:: **Implementation Details:**
 
@@ -604,9 +602,6 @@ module Random {
 
     /*
       The seed value for the PCG random number generator.
-
-      When not provided explicitly, a seed will be generated in an implementation
-      specific manner that depends upon the current time.
     */
     const seed: int;
 
@@ -628,7 +623,6 @@ module Random {
       A seed value will be generated in an implementation specific manner
       that depends on the current time.
     */
-    @unstable("The :record:`randomStream` initializer that generates a seed is unstable and subject to change")
     proc init(type eltType) where isNumericOrBoolType(eltType) {
       this.eltType = eltType;
       this.seed = randomishSeed();

--- a/test/classes/weakPointers/passiveCache.good
+++ b/test/classes/weakPointers/passiveCache.good
@@ -3,6 +3,4 @@ passiveCache.chpl:46: In method 'buildAndSave':
 passiveCache.chpl:48: warning: The `weak` type is experimental; expect this API to change in the future.
   passiveCache.chpl:38: called as (PassiveCache(basicClass)).buildAndSave(key: int(64)) from method 'getOrBuild'
   passiveCache.chpl:66: called as (PassiveCache(basicClass)).getOrBuild(key: int(64))
-passiveCache.chpl:61: In function 'main':
-passiveCache.chpl:72: warning: the overload of 'fillRandom' that generates its own seed is unstable
 true

--- a/test/unstable/randomModule.chpl
+++ b/test/unstable/randomModule.chpl
@@ -2,21 +2,9 @@ use Random;
 
 use Random;
 
-var a: [1..10] int;
-
-// overload that doesn't accept a seed is unstable
-fillRandom(a);
-
-// overload that doesn't accept a seed is unstable
-shuffle(a);
-
-// overload that doesn't accept a seed is unstable
-permute(a);
-
 var rs = new randomStream(int, 123),
-    rsu = new randomStream(int);
+    a = [i in 1..10] i;
 
-a = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 writeln(rs.choice(a, 1));
 writeln(rs.choice(1..10, 1));
 writeln(rs.choice(a.domain, 1));

--- a/test/unstable/randomModule.good
+++ b/test/unstable/randomModule.good
@@ -1,16 +1,12 @@
-randomModule.chpl:8: warning: the overload of 'fillRandom' that generates its own seed is unstable
-randomModule.chpl:11: warning: the overload of 'shuffle' that generates its own seed is unstable
-randomModule.chpl:14: warning: the overload of 'permute' that generates its own seed is unstable
-randomModule.chpl:17: warning: The randomStream initializer that generates a seed is unstable and subject to change
-randomModule.chpl:20: warning: 'choice' is unstable and subject to change
-randomModule.chpl:21: warning: 'choice' is unstable and subject to change
-randomModule.chpl:22: warning: 'choice' is unstable and subject to change
-randomModule.chpl:24: warning: 'skipToNth' is unstable and subject to change
-randomModule.chpl:25: warning: 'getNth' is unstable and subject to change
-randomModule.chpl:27: warning: 'iterate' is unstable and subject to change
-randomModule.chpl:27: warning: 'iterate' is unstable and subject to change
-randomModule.chpl:31: warning: 'iterate' is unstable and subject to change
-randomModule.chpl:31: warning: 'iterate' is unstable and subject to change
+randomModule.chpl:8: warning: 'choice' is unstable and subject to change
+randomModule.chpl:9: warning: 'choice' is unstable and subject to change
+randomModule.chpl:10: warning: 'choice' is unstable and subject to change
+randomModule.chpl:12: warning: 'skipToNth' is unstable and subject to change
+randomModule.chpl:13: warning: 'getNth' is unstable and subject to change
+randomModule.chpl:15: warning: 'iterate' is unstable and subject to change
+randomModule.chpl:15: warning: 'iterate' is unstable and subject to change
+randomModule.chpl:19: warning: 'iterate' is unstable and subject to change
+randomModule.chpl:19: warning: 'iterate' is unstable and subject to change
 1
 4
 4


### PR DESCRIPTION
Following, https://github.com/chapel-lang/chapel/pull/24273, unstable warnings on procedures that use default seed initailization can now be removed.

This PR removes those warnings and improves the documentation about default seeds. It also makes some other minor documentation improvements.

- [ ] paratest
- [ ] inspected built docs