### PR TITLE
Resolve module-level split-init'd `param`s' values in dyno

### DIFF
--- a/frontend/include/chpl/resolution/resolution-queries.h
+++ b/frontend/include/chpl/resolution/resolution-queries.h
@@ -49,7 +49,8 @@ const ResolutionResultByPostorderID& scopeResolveModule(Context* context,
 /**
   Compute the type for a NamedDecl with a particular id.
  */
-const types::QualifiedType& typeForModuleLevelSymbol(Context* context, ID id);
+const types::QualifiedType& typeForModuleLevelSymbol(
+    Context* context, ID id, bool currentModule = false);
 
 /**
   Compute the type for a Builtin type using just its name

--- a/frontend/include/chpl/types/QualifiedType.h
+++ b/frontend/include/chpl/types/QualifiedType.h
@@ -209,6 +209,11 @@ class QualifiedType final {
     return uast::isGenericQualifier(kind_);
   }
 
+  /**
+    Returns true if the type might need to get more info from split-init.
+  */
+  bool needsSplitInitTypeInfo(Context* context) const;
+
   bool operator==(const QualifiedType& other) const {
     return kind_ == other.kind_ &&
            type_ == other.type_ &&

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1591,12 +1591,7 @@ void Resolver::adjustTypesForSplitInit(ID id,
   ResolvedExpression& lhs = byPostorder.byId(id);
   QualifiedType lhsType = lhs.type();
 
-  // check to see if it is generic/unknown
-  // (otherwise we do not need to infer anything)
-  // If it is a param, continue as we still need the param value.
-  if (!lhsType.isParam() && !lhsType.isUnknownKindOrType() &&
-      getTypeGenericity(context, lhsType.type()) != Type::GENERIC)
-    return;
+  if (!lhsType.needsSplitInitTypeInfo(context)) return;
 
   const Param* p = rhsType.param();
   auto useKind = lhsType.kind();

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1593,7 +1593,8 @@ void Resolver::adjustTypesForSplitInit(ID id,
 
   // check to see if it is generic/unknown
   // (otherwise we do not need to infer anything)
-  if (!lhsType.isUnknownKindOrType() &&
+  // If it is a param, continue as we still need the param value.
+  if (!lhsType.isParam() && !lhsType.isUnknownKindOrType() &&
       getTypeGenericity(context, lhsType.type()) != Type::GENERIC)
     return;
 

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2134,7 +2134,9 @@ QualifiedType Resolver::typeForId(const ID& id, bool localGenericToUnknown) {
 
   if (asttags::isModule(parentTag)) {
     // If the id is contained within a module, use typeForModuleLevelSymbol.
-    return typeForModuleLevelSymbol(context, id);
+    bool isCurrentModule =
+        parsing::idToAst(context, parentId)->toModule() == symbol->toModule();
+    return typeForModuleLevelSymbol(context, id, isCurrentModule);
   }
 
   // If the id is contained within a class/record/union that we are resolving,

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -241,8 +241,9 @@ scopeResolveModule(Context* context, ID id) {
 
 }
 
-const QualifiedType& typeForModuleLevelSymbol(Context* context, ID id) {
-  QUERY_BEGIN(typeForModuleLevelSymbol, context, id);
+const QualifiedType& typeForModuleLevelSymbol(Context* context, ID id,
+                                              bool isCurrentModule) {
+  QUERY_BEGIN(typeForModuleLevelSymbol, context, id, isCurrentModule);
 
   QualifiedType result;
 
@@ -251,6 +252,12 @@ const QualifiedType& typeForModuleLevelSymbol(Context* context, ID id) {
     const auto& resolvedStmt = resolveModuleStmt(context, id);
     if (resolvedStmt.hasId(id)) {
       result = resolvedStmt.byId(id).type();
+      if (result.needsSplitInitTypeInfo(context) && !isCurrentModule) {
+        ID moduleId = parsing::idToParentId(context, id);
+        const auto& resolvedModule = resolveModule(context, moduleId);
+        assert(resolvedModule.hasId(id));
+        result = resolvedModule.byId(id).type();
+      }
     } else {
       // fall back to default value
       result = QualifiedType();

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -114,9 +114,10 @@ static void updateTypeForModuleLevelSplitInit(Context* context, ID id,
   const QualifiedType lhsType = lhs.type();
   const QualifiedType rhsType = rhs.type();
 
-  // check to see if it is generic/unknown
-  // (otherwise we do not need to infer anything)
-  if (!lhsType.isUnknownKindOrType() &&
+  // Check to see if it is generic/unknown
+  // (otherwise we do not need to infer anything).
+  // If it is a param, continue as we still need the param value.
+  if (!lhsType.isParam() && !lhsType.isUnknownKindOrType() &&
       getTypeGenericity(context, lhsType.type()) != Type::GENERIC)
     return;
 

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -114,12 +114,7 @@ static void updateTypeForModuleLevelSplitInit(Context* context, ID id,
   const QualifiedType lhsType = lhs.type();
   const QualifiedType rhsType = rhs.type();
 
-  // Check to see if it is generic/unknown
-  // (otherwise we do not need to infer anything).
-  // If it is a param, continue as we still need the param value.
-  if (!lhsType.isParam() && !lhsType.isUnknownKindOrType() &&
-      getTypeGenericity(context, lhsType.type()) != Type::GENERIC)
-    return;
+  if (!lhsType.needsSplitInitTypeInfo(context)) return;
 
   const Param* p = rhsType.param();
   if (lhsType.kind() != QualifiedType::PARAM) {

--- a/frontend/lib/types/QualifiedType.cpp
+++ b/frontend/lib/types/QualifiedType.cpp
@@ -60,6 +60,12 @@ bool QualifiedType::isParamKnownTuple() const {
   return false;
 }
 
+bool QualifiedType::needsSplitInitTypeInfo(Context* context) const {
+  return (isParam() && !hasParamPtr()) ||
+    isUnknownKindOrType() ||
+    resolution::getTypeGenericity(context, type()) == Type::GENERIC;
+}
+
 bool QualifiedType::update(QualifiedType& keep, QualifiedType& addin) {
   return defaultUpdate(keep, addin);
 }

--- a/frontend/test/resolution/testResolve.cpp
+++ b/frontend/test/resolution/testResolve.cpp
@@ -800,7 +800,8 @@ static void test19() {
 
   module N {
     use M;
-    var y = z;
+    var y;
+    y = z;
   }
   )"""";
 

--- a/frontend/test/resolution/testResolve.cpp
+++ b/frontend/test/resolution/testResolve.cpp
@@ -740,7 +740,7 @@ static void test17() {
 
       param foo_param;
       foo_param = 5;
-      param bar_param;
+      param bar_param:string;
       bar_param = "bar_param";
 
       )""", { "foo", "bar", "foo_param", "bar_param"});

--- a/frontend/test/resolution/testSplitInit.cpp
+++ b/frontend/test/resolution/testSplitInit.cpp
@@ -1958,6 +1958,38 @@ static void test65a() {
     {"x"});
 }
 
+// Test params are split-inited to their param value when their type is known.
+static void test68() {
+  testSplitInit("test68",
+    R""""(
+      module M {
+        // this would be in the standard library...
+        operator =(ref lhs: int, rhs: int) {
+          __primitive("=", lhs, rhs);
+        }
+
+        proc test() {
+          param x:int;
+          x = 5;
+          var y;
+          // x should be param 5...
+          select x {
+            when 5 {
+              // ... so y should get split-init to 1
+              y = 1;
+            }
+            otherwise {
+              // ... but if y is split-init to a string,
+              // x (erroneously) wasn't param 5.
+              y = "string";
+            }
+          }
+        }
+      }
+    )"""",
+    {"x", "y"});
+}
+
 int main() {
   test1();
   test2();
@@ -2031,5 +2063,7 @@ int main() {
   test66();
   test67();
   testParamTrueWhen();
+  test68();
+
   return 0;
 }


### PR DESCRIPTION
Get resolving the `param` value of `param`s split-init'd at module level working.

Previously, https://github.com/chapel-lang/chapel/pull/24116 got some cases of resolving module-level split-inits working, but it did not fix the original motivating case from https://github.com/Cray/chapel-private/issues/5602. This PR resolves two bugs that prevented it from working:
- Previously, split-init would be skipped for variables that have a declared type, since there's no need to infer their type. However, for `param`s this meant we wouldn't get their `param` value, which is part of their type. Fixed by changing to skipping variables with declared type, _unless_ they are `param` and don't have a value yet.
- The implementation of module-level split-init adjustments is in `resolveModule`. But in this case, we need the type of something split-init'd in another module which has not yet been `resolveModule`'d, so its type wasn't getting set in time. Fixed by using `resolveModule` from `typeForModuleLevelSymbol` if the result of just `resolveModuleStmt` is missing info that split-init might fill in. This doesn't make any additional mutually-recursive module cases run into a recursive query, as it is guarded to not run from within resolution of the module with the split-init'd thing.

Follow up to https://github.com/chapel-lang/chapel/pull/24116.

Resolves https://github.com/Cray/chapel-private/issues/5602.

[reviewer info placeholder]

Testing:
- [x] paratest
- [x] dyno tests
- [x] reproducer in backing issue no longer fails