### PR TITLE
Fix typo in test config

### DIFF
--- a/util/cron/test-gpu-ex-rocm-54.bash
+++ b/util/cron/test-gpu-ex-rocm-54.bash
@@ -10,7 +10,7 @@ module load rocm/5.4.3  # pin to rocm 5.4.3
 
 export CHPL_COMM=none
 export CHPL_LLVM=system
-unset CHLP_LLVM_CONFIG  # we need this to avoid warnings
+unset CHPL_LLVM_CONFIG  # we need this to avoid warnings
 export CHPL_LOCALE_MODEL=gpu
 export CHPL_LAUNCHER_PARTITION=bardpeak  # bardpeak is the default queue
 


### PR DESCRIPTION
Fixes a typo in a test config which caused nightly failures

[Not reviewed - trivial]