### PR TITLE
'domainDistIsLayout' --> 'chpl_domainDistIsLayout'

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1954,7 +1954,7 @@ module ChapelArray {
     }
 
     proc chpl_isNonDistributedArray() param {
-      return domainDistIsLayout(_getDomain(chpl__getActualArray(_value).dom));
+      return chpl_domainDistIsLayout(_getDomain(chpl__getActualArray(_value).dom));
     }
 
     /* Return true if the argument ``a`` is an array with a rectangular
@@ -3820,7 +3820,7 @@ module ChapelArray {
   // 'castToVoidStar' says whether we should cast the result to c_ptr(void)
 
   proc chpl_arrayToPtrErrorHelper(const ref arr: []) {
-    if (!arr.isRectangular() || !domainDistIsLayout(arr.domain)) then
+    if (!arr.isRectangular() || !chpl_domainDistIsLayout(arr.domain)) then
       compilerError("Only single-locale rectangular arrays can be passed to an external routine argument with array type", errorDepth=3);
 
     if (arr._value.locale != here) then

--- a/modules/internal/ChapelDomain.chpl
+++ b/modules/internal/ChapelDomain.chpl
@@ -837,23 +837,21 @@ module ChapelDomain {
 
   // This function exists to avoid communication from computing _value when
   // the result is param.
-  /* Returns true if the distribution of `d` is a layout,
-     that is, all indices of `d` are owned by the current locale. */
-  proc domainDistIsLayout(d: domain) param {
+  proc chpl_domainDistIsLayout(d: domain) param {
     return d.distribution._value.dsiIsLayout();
   }
 
   pragma "find user line"
   pragma "coerce fn"
   proc chpl__coerceCopy(type dstType:_domain, rhs:_domain, definedConst: bool) {
-    param rhsIsLayout = domainDistIsLayout(rhs);
+    param rhsIsLayout = chpl_domainDistIsLayout(rhs);
 
     pragma "no copy"
     var lhs = chpl__coerceHelp(dstType, definedConst);
     lhs = rhs;
 
     // Error for assignment between local and distributed domains.
-    if domainDistIsLayout(lhs) && !rhsIsLayout then
+    if chpl_domainDistIsLayout(lhs) && !rhsIsLayout then
       compilerWarning("initializing a non-distributed domain from a distributed domain. If you didn't mean to do that, add a dmapped clause to the type expression or remove the type expression altogether");
 
     return lhs;
@@ -862,7 +860,7 @@ module ChapelDomain {
   pragma "coerce fn"
   proc chpl__coerceMove(type dstType:_domain, in rhs:_domain,
                         definedConst: bool) {
-    param rhsIsLayout = domainDistIsLayout(rhs);
+    param rhsIsLayout = chpl_domainDistIsLayout(rhs);
 
     // TODO: just return rhs
     // if the domain types are the same and their runtime types
@@ -873,7 +871,7 @@ module ChapelDomain {
     lhs = rhs;
 
     // Error for assignment between local and distributed domains.
-    if domainDistIsLayout(lhs) && !rhsIsLayout then
+    if chpl_domainDistIsLayout(lhs) && !rhsIsLayout then
       compilerWarning("initializing a non-distributed domain from a distributed domain. If you didn't mean to do that, add a dmapped clause to the type expression or remove the type expression altogether");
 
     return lhs;

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -3430,7 +3430,7 @@ module TwoArrayRadixSort {
 
   proc twoArrayRadixSort(ref Data:[], comparator:?rec=defaultComparator) {
 
-    if !domainDistIsLayout(Data.domain) {
+    if !chpl_domainDistIsLayout(Data.domain) {
       compilerWarning("twoArrayRadix sort no longer handles distributed arrays. Please use TwoArrayDistributedRadixSort.twoArrayDistributedRadixSort instead (but note that it is not stable)");
     }
 


### PR DESCRIPTION
This PR adds the `chpl_` prefix to `domainDistIsLayout()` in order to remove it from the public API.

domainDistIsLayout() was made public in #18829 so it can be used across the internal modules. We consider such addition a bug because this function has not received a design review and was/is not intended to be user-facing. This PR fixes that bug.

This also removes the intended-for-user comment added to domainDistIsLayout in #23664, as it is no longer needed.

Testing: standard and gasnet paratests.