### PR TITLE
Update proc sort docs about quick sort

### DIFF
--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -435,8 +435,8 @@ The choice of sorting algorithm used is made by the implementation.
 
 .. note::
 
-  This function currently either uses a parallel radix sort or a serial
-  quickSort. The algorithms used will change over time.
+  This function currently either uses a parallel radix sort or a parallel
+  improved quick sort.  The algorithms used will change over time.
 
   It currently uses parallel radix sort if the following conditions are met:
 
@@ -1122,6 +1122,7 @@ module MergeSort {
 
 // this quick sort is not stable
 // it is in-place however
+// it is parallel but has limited parallelism
 @chpldoc.nodoc
 module QuickSort {
   private use Sort;


### PR DESCRIPTION
This PR updates the docs comment for `proc sort` to:
 * make a correction because quickSort is parallel now
 * use the term "improved quick sort" to avoid an interpretation that it is Hoare's original quickSort.
 
See https://chapel.discourse.group/t/comparing-standard-library-sorts-the-impact-of-parallelism/30411/4

Reviewed by @vasslitvinov - thanks!

Open Question:
 * should it, when describing the quick sort, cite Engineering a Sort Function (1993) by Jon L. Bentley , M. Douglas McIlroy ? Citing this in the `proc sort` docs about the current implementation seems like including more information than is needed / necessary there, but we could do it. I don't have a similar radix sort paper to reference at the ready, either.
 * for now I opted not to include this reference in the implementation note, but it would be OK to add it in the future
 