### PR TITLE
Suppress gpu test that tests the compiler driver

### DIFF
--- a/test/gpu/native/compilerDriver.suppressif
+++ b/test/gpu/native/compilerDriver.suppressif
@@ -1,0 +1,2 @@
+# this test fails with llvm ir failures when using rocm
+CHPL_GPU==amd


### PR DESCRIPTION
Suppresses a test which fails in some nightly configs due to invalid llvm ir.

[Not reviewed - trivial]