### PR TITLE
Prototype for opening a fileReader directly to a string

### DIFF
--- a/test/library/standard/IO/openReaderToString.chpl
+++ b/test/library/standard/IO/openReaderToString.chpl
@@ -1,0 +1,17 @@
+use IO, JSON, List;
+
+const myJsonData = "{\"x\": 3.14159, \"y\": \"data\"}";
+var r = openStringReader(myJsonData, deserializer = new jsonDeserializer());
+
+var thing:rec;
+r.read(thing);
+writeln(thing);
+
+record rec {
+    var x: real;
+    var y: string;
+}
+
+var r2 = openStringReader("hello world!\nI'm a string!");
+write(r2.readLine());
+writeln(r2.readLine());

--- a/test/library/standard/IO/openReaderToString.good
+++ b/test/library/standard/IO/openReaderToString.good
@@ -1,0 +1,3 @@
+(x = 3.14159, y = data)
+hello world!
+I'm a string!


### PR DESCRIPTION
This PR adds an `openStringReader` factory function to the IO module which opens a `fileReader` directly to a string.

Under the hood, it creates a memory file, populating it with the string's contents, and then returns a fileReader to the memory file.

- [ ] paratest