### PR TITLE
Temporary fix for random seed initialization timeouts

### DIFF
--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -132,11 +132,13 @@ module Random {
           sWhere = here.hash():int;
 
     var randomBits: int = 0;
-    try {
-      IO.openReader("/dev/urandom").readBits(randomBits, 64);
-    } catch {
-      // may not be able to open /dev/urandom, ignore this step
-    }
+    // commented out due to an issue with opening too many fileReaders to
+    // /dev/urandom on some platforms
+    // try {
+    //   IO.openReader("/dev/urandom").readBits(randomBits, 64);
+    // } catch {
+    //   // may not be able to open /dev/urandom, ignore this step
+    // }
 
     return sWho ^ sWhat ^ sWhen ^ sWhere ^ randomBits;
   }


### PR DESCRIPTION
The recent improvements to default seed generation in the Random module were causing timeouts in a few tests that concurrently create many `randomStream`'s.

This is a temporary fix to correct those test timeouts. A more permanent solution is in the works.
