### PR TITLE
Use resolution when hovering over a symbol in chpl-language-server

### DIFF
--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -639,6 +639,7 @@ class ChapelLanguageServer(LanguageServer):
         self.literal_arg_inlays: bool = config.literal_arg_inlays
         self.param_inlays: bool = config.param_inlays
         self.dead_code: bool = config.dead_code
+        self.eval_expressions: bool = config.eval_expressions
 
         self._setup_regexes()
 
@@ -900,7 +901,7 @@ class ChapelLanguageServer(LanguageServer):
     def get_tooltip(
         self, node: chapel.AstNode, siblings: chapel.SiblingMap
     ) -> str:
-        signature = get_symbol_signature(node, resolve=ls.use_resolver)
+        signature = get_symbol_signature(node, eval_expressions=self.eval_expressions, resolve=self.use_resolver)
         docstring = chapel.get_docstring(node, siblings)
         text = f"```chapel\n{signature}\n```"
         if docstring:
@@ -959,6 +960,7 @@ def run_lsp():
     add_bool_flag("param-inlays", "param_inlays", True)
     add_bool_flag("literal-arg-inlays", "literal_arg_inlays", True)
     add_bool_flag("dead-code", "dead_code", True)
+    add_bool_flag('evaluate-expressions', 'eval_expressions', True)
 
     server = ChapelLanguageServer(parser.parse_args())
 

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -898,7 +898,11 @@ class ChapelLanguageServer(LanguageServer):
     def get_tooltip(
         self, node: chapel.AstNode, siblings: chapel.SiblingMap
     ) -> str:
-        signature = get_symbol_signature(node, eval_expressions=self.eval_expressions, resolve=self.use_resolver)
+        signature = get_symbol_signature(
+            node,
+            eval_expressions=self.eval_expressions,
+            resolve=self.use_resolver,
+        )
         docstring = chapel.get_docstring(node, siblings)
         text = f"```chapel\n{signature}\n```"
         if docstring:

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -1090,12 +1090,12 @@ def run_lsp():
         text_doc = ls.workspace.get_text_document(params.text_document.uri)
 
         fi, _ = ls.get_file_info(text_doc.uri)
-
         segment = fi.get_use_or_def_segment_at_position(params.position)
         if not segment:
             return None
+        node_fi, _ = ls.get_file_info(segment.get_uri())
 
-        text = ls.get_tooltip(resolved_to.node, node_fi.siblings)
+        text = ls.get_tooltip(segment.node, node_fi.siblings)
         content = MarkupContent(MarkupKind.Markdown, text)
         return Hover(content, range=segment.get_location().range)
 

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -563,19 +563,16 @@ class FileInfo:
         of a definition: its type, references to it, etc. However, it is
         convenient to be able to "find references" and "go to type definition"
         from references to a definition too. Thus, this method returns
-        a definition when it can, and falls back to references otherwise.
+        a reference when it can, and falls back to definition otherwise.
         """
 
-        segment_def = self.get_def_segment_at_position(position)
-        segment_use = self.get_use_segment_at_position(position)
-
-        if segment_def and not segment_use:
-            return segment_def
-        elif segment_use and not segment_def:
-            return segment_use.resolved_to
-        elif segment_use and segment_def:
-            # prefer the use
-            return segment_use.resolved_to
+        segment = self.get_use_segment_at_position(position)
+        if segment:
+            return segment.resolved_to
+        else:
+            segment = self.get_def_segment_at_position(position)
+            if segment:
+                return segment
 
         return None
 

--- a/tools/chpl-language-server/src/symbol_signature.py
+++ b/tools/chpl-language-server/src/symbol_signature.py
@@ -17,11 +17,34 @@
 # limitations under the License.
 #
 
-from typing import Optional, Union
+from typing import List, Optional, Union
 import chapel
 
 
-def get_symbol_signature(node: chapel.AstNode, eval_expressions: bool = True, resolve: bool = False) -> str:
+class SymbolSignature:
+    def __init__(self, node: chapel.AstNode):
+        self.node = node
+        self._signature = get_symbol_signature(self.node, False, False)
+
+    def compute_type(self):
+        """
+        if types aren't textually present, try to resolve them
+
+        Note: this is a temporary method that will go away when the resolver is fully online
+        """
+        self._signature = get_symbol_signature(self.node, False, True)
+
+    def compute_value(self):
+        """evaluate expressions"""
+        self._signature = get_symbol_signature(self.node, True, True)
+
+    def __str__(self) -> str:
+        return self._signature
+
+
+def get_symbol_signature(
+    node: chapel.AstNode, eval_expressions: bool = True, resolve: bool = False
+) -> str:
     """
     get a string representation of a AstNode's signature
 
@@ -30,9 +53,7 @@ def get_symbol_signature(node: chapel.AstNode, eval_expressions: bool = True, re
     if not isinstance(node, chapel.NamedDecl):
         return _node_to_string(node, eval_expressions, resolve)
 
-    if isinstance(node, chapel.Class) or isinstance(
-        node, chapel.Record
-    ):
+    if isinstance(node, chapel.Class) or isinstance(node, chapel.Record):
         return _record_class_to_string(node)
     elif isinstance(node, chapel.Interface):
         return f"interface {node.name()}"
@@ -48,7 +69,9 @@ def get_symbol_signature(node: chapel.AstNode, eval_expressions: bool = True, re
     return node.name()
 
 
-def _node_to_string(node: chapel.AstNode, eval_expressions: bool = True, resolve: bool = False) -> str:
+def _node_to_string(
+    node: chapel.AstNode, eval_expressions: bool = True, resolve: bool = False
+) -> str:
     """
     General helper method to convert an AstNode to a string representation. If
     it doesn't know how to convert the node, it returns "<...>"
@@ -74,9 +97,7 @@ def _node_to_string(node: chapel.AstNode, eval_expressions: bool = True, resolve
     return "<...>"
 
 
-def _record_class_to_string(
-    node: Union[chapel.Record, chapel.Class]
-) -> str:
+def _record_class_to_string(node: Union[chapel.Record, chapel.Class]) -> str:
     """
     Convert a Record or a Class to a string
     """
@@ -95,7 +116,11 @@ def _record_class_to_string(
     return f"{prefix}{keyword} {node.name()}{s}"
 
 
-def _var_to_string(node: chapel.VarLikeDecl, eval_expressions: bool = True, resolve: bool = False) -> str:
+def _var_to_string(
+    node: chapel.VarLikeDecl,
+    eval_expressions: bool = True,
+    resolve: bool = False,
+) -> str:
     """
     Convert a VarLikeDecl to a string
     """
@@ -181,7 +206,9 @@ def _intent_to_string(intent: Optional[str]) -> str:
     return remap.get(intent, intent) if intent else ""
 
 
-def get_symbol_type(node: chapel.AstNode, resolve: bool = False) -> Optional[str]:
+def get_symbol_type(
+    node: chapel.AstNode, resolve: bool = False
+) -> Optional[str]:
     """Get the type of a symbol"""
 
     qt = node.type() if resolve else None
@@ -198,9 +225,11 @@ def get_symbol_type(node: chapel.AstNode, resolve: bool = False) -> Optional[str
             return "<error>"
         return str(type_)
 
-def get_symbol_value(node: chapel.AstNode, eval_expressions: bool = True, resolve: bool = False) -> Optional[str]:
-    """Get the value of a symbol"""
 
+def get_symbol_value(
+    node: chapel.AstNode, eval_expressions: bool = True, resolve: bool = False
+) -> Optional[str]:
+    """Get the value of a symbol"""
 
     qt = node.type() if resolve and eval_expressions else None
 

--- a/tools/chpl-language-server/src/symbol_signature.py
+++ b/tools/chpl-language-server/src/symbol_signature.py
@@ -19,12 +19,49 @@
 
 from typing import List, Optional, Union
 import chapel
+from dataclasses import dataclass
+import enum
+
+
+class ComponentTag(enum.Enum):
+    STRING = enum.auto()
+    TYPE = enum.auto()
+    PARAM_VALUE = enum.auto()
+    PLACEHOLDER = enum.auto()
+
+
+@dataclass
+class Component:
+    tag: ComponentTag
+    value: Union[str, None]
+    node: Optional[chapel.AstNode] = None
+
+    @staticmethod
+    def to_string(comps: List["Component"]) -> str:
+        s = ""
+        for comp in comps:
+            if comp.tag in (
+                ComponentTag.STRING,
+                ComponentTag.TYPE,
+                ComponentTag.PARAM_VALUE,
+            ):
+                if comp.value is not None:
+                    s += str(comp.value)
+            elif comp.tag == ComponentTag.PLACEHOLDER:
+                s += "<...>"
+            else:
+                assert False, f"unknown component tag {comp.tag}"
+        return s
+
+
+def _wrap_str(s: str) -> Component:
+    return Component(ComponentTag.STRING, s)
 
 
 class SymbolSignature:
     def __init__(self, node: chapel.AstNode):
         self.node = node
-        self._signature = get_symbol_signature(self.node, False, False)
+        self._signature = _get_symbol_signature(self.node)
 
     def compute_type(self):
         """
@@ -32,165 +69,210 @@ class SymbolSignature:
 
         Note: this is a temporary method that will go away when the resolver is fully online
         """
-        self._signature = get_symbol_signature(self.node, False, True)
+        for i in range(len(self._signature)):
+            tag = self._signature[i].tag
+            node = self._signature[i].node
+            if tag == ComponentTag.TYPE and node is not None:
+                type_str = _resolve_type_str(node)
+                if type_str:
+                    self._signature[i] = _wrap_str(": " + type_str)
 
     def compute_value(self):
         """evaluate expressions"""
-        self._signature = get_symbol_signature(self.node, True, True)
+        for i in range(len(self._signature)):
+            tag = self._signature[i].tag
+            node = self._signature[i].node
+            if tag == ComponentTag.PARAM_VALUE and node is not None:
+                param_str = _resolve_param_str(node)
+                if param_str:
+                    self._signature[i] = _wrap_str(" = " + param_str)
 
     def __str__(self) -> str:
-        return self._signature
+        return Component.to_string(self._signature)
 
 
-def get_symbol_signature(
-    node: chapel.AstNode, eval_expressions: bool = True, resolve: bool = False
-) -> str:
-    """
-    get a string representation of a AstNode's signature
+def _resolve_type_str(node: chapel.AstNode) -> Optional[str]:
+    """Resolve a type expression to a string"""
+    qt = node.type()
+    if not qt:
+        return None
+    _, type_, _ = qt
+    if isinstance(type_, chapel.ErroneousType):
+        return None
+    return str(type_)
 
-    If resolve is True, it will attempt to resolve inferred types and values
-    """
+
+def _resolve_param_str(node: chapel.AstNode) -> Optional[str]:
+    """Resolve a type expression to a string"""
+    qt = node.type()
+    if not qt:
+        return None
+    _, _, param = qt
+    if param is None:
+        return None
+    return str(param)
+
+
+def _get_symbol_signature(node: chapel.AstNode) -> List[Component]:
     if not isinstance(node, chapel.NamedDecl):
-        return _node_to_string(node, eval_expressions, resolve)
+        return _node_to_string(node)
 
     if isinstance(node, chapel.Class) or isinstance(node, chapel.Record):
         return _record_class_to_string(node)
     elif isinstance(node, chapel.Interface):
-        return f"interface {node.name()}"
+        return [_wrap_str(f"interface {node.name()}")]
     elif isinstance(node, chapel.Module):
-        return f"module {node.name()}"
+        return [_wrap_str(f"module {node.name()}")]
     elif isinstance(node, chapel.Enum):
-        return f"enum {node.name()}"
-    elif isinstance(node, chapel.Variable):
-        return _var_to_string(node, eval_expressions, resolve)
+        return [_wrap_str(f"enum {node.name()}")]
+    elif isinstance(node, chapel.VarLikeDecl):
+        return _var_to_string(node)
     elif isinstance(node, chapel.Function):
         return _proc_to_string(node)
 
-    return node.name()
+    return [_wrap_str(node.name())]
 
 
-def _node_to_string(
-    node: chapel.AstNode, eval_expressions: bool = True, resolve: bool = False
-) -> str:
+def _node_to_string(node: chapel.AstNode) -> List[Component]:
     """
     General helper method to convert an AstNode to a string representation. If
     it doesn't know how to convert the node, it returns "<...>"
     """
     if isinstance(node, chapel.NamedDecl):
-        return get_symbol_signature(node, eval_expressions, resolve)
+        return _get_symbol_signature(node)
     elif isinstance(node, chapel.Identifier):
-        return node.name()
-    elif isinstance(node, chapel.IntLiteral):
-        return node.text()
-    elif isinstance(node, chapel.UintLiteral):
-        return node.text()
+        return [_wrap_str(node.name())]
     elif isinstance(node, chapel.BoolLiteral):
-        return node.value()
-    elif isinstance(node, chapel.ImagLiteral):
-        return node.text()
-    elif isinstance(node, chapel.RealLiteral):
-        return node.text()
+        return [_wrap_str(node.value())]
+    elif isinstance(
+        node,
+        (
+            chapel.IntLiteral,
+            chapel.UintLiteral,
+            chapel.ImagLiteral,
+            chapel.RealLiteral,
+        ),
+    ):
+        return [_wrap_str(node.text())]
     elif isinstance(node, chapel.StringLiteral):
-        return '"' + node.value() + '"'
+        return [_wrap_str('"' + node.value() + '"')]
     elif isinstance(node, chapel.CStringLiteral):
-        return 'c"' + node.value() + '"'
-    return "<...>"
+        return [_wrap_str('c"' + node.value() + '"')]
+    return [Component(ComponentTag.PLACEHOLDER, None)]
 
 
-def _record_class_to_string(node: Union[chapel.Record, chapel.Class]) -> str:
+def _record_class_to_string(
+    node: Union[chapel.Record, chapel.Class]
+) -> List[Component]:
     """
     Convert a Record or a Class to a string
     """
-    keyword = "record" if isinstance(node, chapel.Record) else "class"
+    comps = []
+    if node.linkage():
+        comps.append(_wrap_str(f"{node.linkage()} "))
+    if node.linkage_name():
+        comps.extend(_node_to_string(node.linkage_name()))
 
-    s = ""
+    keyword = "record" if isinstance(node, chapel.Record) else "class"
+    comps.append(_wrap_str(f"{keyword} {node.name()}"))
+
     ie = list(node.inherit_exprs())
     if len(ie) > 0:
-        s = ": " + ", ".join([_node_to_string(x) for x in ie])
-    prefix = ""
-    if node.linkage():
-        prefix += f"{node.linkage()} "
-    if node.linkage_name():
-        prefix += f"{_node_to_string(node.linkage_name())} "
+        comps.append(_wrap_str(": "))
+        do_comma = False
+        for x in ie:
+            if do_comma:
+                comps.append(_wrap_str(", "))
+            do_comma = True
+            comps.extend(_node_to_string(x))
 
-    return f"{prefix}{keyword} {node.name()}{s}"
+    return comps
 
 
-def _var_to_string(
-    node: chapel.VarLikeDecl,
-    eval_expressions: bool = True,
-    resolve: bool = False,
-) -> str:
+def _var_to_string(node: chapel.VarLikeDecl) -> List[Component]:
     """
     Convert a VarLikeDecl to a string
     """
-    s = ""
+    comps = []
+
     if node.visibility():
-        s += f"{node.visibility()} "
+        comps.append(_wrap_str(f"{node.visibility()} "))
     if node.linkage():
-        s += f"{node.linkage()} "
+        comps.append(_wrap_str(f"{node.linkage()} "))
     if node.linkage_name():
-        s += f"{_node_to_string(node.linkage_name())} "
+        comps.extend(_node_to_string(node.linkage_name()))
 
     if isinstance(node, chapel.Variable):
         if node.is_config():
-            s += "config "
+            comps.append(_wrap_str("config "))
     intent = _intent_to_string(node.intent())
     if intent:
-        s += f"{intent} "
-    s += node.name()
+        comps.append(_wrap_str(f"{intent} "))
 
-    type_ = get_symbol_type(node, resolve)
-    if type_ is not None:
-        s += f": {type_}"
-    val = get_symbol_value(node, eval_expressions, resolve)
-    if val is not None:
-        s += f" = {val}"
+    comps.append(_wrap_str(node.name()))
 
-    return s
+    type_str = None
+    type_ = node.type_expression()
+    if type_:
+        type_str = ": " + Component.to_string(_node_to_string(type_))
+    comps.append(Component(ComponentTag.TYPE, type_str, node))
+
+    init_str = None
+    init = node.init_expression()
+    if init:
+        init_str = " = " + Component.to_string(_node_to_string(init))
+    comps.append(Component(ComponentTag.PARAM_VALUE, init_str, node))
+
+    return comps
 
 
-def _proc_to_string(node: chapel.Function) -> str:
+def _proc_to_string(node: chapel.Function) -> List[Component]:
     """
     Convert a function to a string
     """
-    s = ""
+    comps = []
 
     if node.visibility():
-        s += f"{node.visibility()} "
+        comps.append(_wrap_str(f"{node.visibility()} "))
     if node.linkage():
-        s += f"{node.linkage()} "
+        comps.append(_wrap_str(f"{node.linkage()} "))
     if node.linkage_name():
-        s += f"{_node_to_string(node.linkage_name())} "
+        comps.extend(_node_to_string(node.linkage_name()))
     if node.is_override():
-        s += "override "
+        comps.append(_wrap_str("override "))
     if node.is_inline():
-        s += "inline "
+        comps.append(_wrap_str("inline "))
 
-    s += f"{node.kind()} "
+
+    comps.append(_wrap_str(f"{node.kind()} "))
     # if it has a this-formal, check for this intent
     if node.this_formal() and _intent_to_string(node.this_formal().intent()):
-        s += f"{_intent_to_string(node.this_formal().intent())} "
-    s += f"{node.name()}"
+        comps.append(_wrap_str(f"{_intent_to_string(node.this_formal().intent())} "))
+    comps.append(_wrap_str(node.name()))
 
     if not node.is_parenless():
         start_idx = 1 if node.this_formal() else 0
-        formal_strings = [
-            _var_to_string(node.formal(i))
-            for i in range(start_idx, node.num_formals())
-        ]
-        s += f"({', '.join(formal_strings)})"
+        comps.append(_wrap_str("("))
+        do_comma = False
+        for i in range(start_idx, node.num_formals()):
+            if do_comma:
+                comps.append(_wrap_str(", "))
+            do_comma = True
+            comps.extend(_node_to_string(node.formal(i)))
+        comps.append(_wrap_str(")"))
 
     if _intent_to_string(node.return_intent()):
-        s += f" {_intent_to_string(node.return_intent())}"
+        comps.append(_wrap_str(f" {_intent_to_string(node.return_intent())}"))
     if node.return_type():
-        s += f": {_node_to_string(node.return_type())}"
+        comps.append(_wrap_str(f": "))
+        comps.extend(_node_to_string(node.return_type()))
     if node.throws():
-        s += " throws"
+        comps.append(_wrap_str(" throws"))
     if node.where_clause():
-        s += f" where {_node_to_string(node.where_clause())}"
+        comps.append(_wrap_str(" where "))
+        comps.extend(_node_to_string(node.where_clause()))
 
-    return s
+    return comps
 
 
 def _intent_to_string(intent: Optional[str]) -> str:
@@ -204,42 +286,3 @@ def _intent_to_string(intent: Optional[str]) -> str:
     }
     # use 'intent' as the default, so if no remap no work done
     return remap.get(intent, intent) if intent else ""
-
-
-def get_symbol_type(
-    node: chapel.AstNode, resolve: bool = False
-) -> Optional[str]:
-    """Get the type of a symbol"""
-
-    qt = node.type() if resolve else None
-    if not qt:
-        # could not resolve the type, try and interpolate the type_expression (if it has one)
-        if isinstance(node, chapel.VarLikeDecl):
-            type_ = node.type_expression()
-            if type_:
-                return _node_to_string(type_, resolve)
-        return None
-    else:
-        _, type_, _ = qt
-        if isinstance(type_, chapel.ErroneousType):
-            return "<error>"
-        return str(type_)
-
-
-def get_symbol_value(
-    node: chapel.AstNode, eval_expressions: bool = True, resolve: bool = False
-) -> Optional[str]:
-    """Get the value of a symbol"""
-
-    qt = node.type() if resolve and eval_expressions else None
-
-    if not qt or qt[2] is None:
-        # could not resolve the type, try and interpolate the init_expression (if it has one)
-        if isinstance(node, chapel.VarLikeDecl):
-            init = node.init_expression()
-            if init:
-                return _node_to_string(init, resolve)
-        return None
-    else:
-        _, _, param = qt
-        return str(param)


### PR DESCRIPTION
Add experimental type and param value resolution to the existing hover capability in chpl-language-server. This is enabled when `--resolve` is used.

This PR also includes a substantial rewrite of SymbolSignature, which should allow for more customization in the future 

[Reviewed by @DanilaFe]