### PR TITLE
Follow 24302 to further adjust Rust sort comparison

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,6 @@ tags
 .idea/
 cmake-build-*/
 .cache/
-target/
-Cargo.lock
 
 # Top level ignores.
 /BUILD_VERSION

--- a/test/library/packages/Sort/performance/comparison/.gitignore
+++ b/test/library/packages/Sort/performance/comparison/.gitignore
@@ -1,0 +1,3 @@
+# Rust related ignores
+target/
+Cargo.lock

--- a/test/library/packages/Sort/performance/comparison/sort-random-rust-rayon/src/main.rs
+++ b/test/library/packages/Sort/performance/comparison/sort-random-rust-rayon/src/main.rs
@@ -1,5 +1,5 @@
 // run it with
-//  cd sort-random-rust
+//  cd sort-random-rust-rayon
 //  cargo run --release
 
 use rand::{distributions::Standard, rngs::SmallRng, Rng, SeedableRng};

--- a/test/library/packages/Sort/performance/comparison/sort-random-rust/.cargo/config.toml
+++ b/test/library/packages/Sort/performance/comparison/sort-random-rust/.cargo/config.toml
@@ -1,5 +1,7 @@
-[build]
-rustflags = [
-  "-C",
-  "target-cpu=native",
-]
+# on the benchmark system, this actually makes it slower,
+# but that might not be true on other systems.
+#[build]
+#rustflags = [
+#  "-C",
+#  "target-cpu=native",
+#]

--- a/test/library/packages/Sort/performance/comparison/sort-random-rust/src/main.rs
+++ b/test/library/packages/Sort/performance/comparison/sort-random-rust/src/main.rs
@@ -2,20 +2,32 @@
 //  cd sort-random-rust
 //  cargo run --release
 
-use rand::{distributions::Standard, rngs::SmallRng, Rng, SeedableRng};
-use rayon::prelude::*;
+use rand::{distributions::Standard, Rng};
 use std::time::Instant;
+// these are used in the alternative way to generate the array in parallel
+//use rand::{rngs::SmallRng,SeedableRng};
+//use rayon::prelude::*;
 
 fn main() {
     let n = 128 * 1024 * 1024;
 
     let t1 = Instant::now();
+
+    // This is arguably the most obvious way to generate the
+    // random array, but it does it in one thread
+    let mut values: Vec<u64> = rand::thread_rng().sample_iter(Standard).take(n).collect();
+
+    // This alternative generates in parallel.
+    // Using it increases the sequential speed (probably due to NUMA effects)
+    /*
     let rng = SmallRng::seed_from_u64(42);
     let mut values = Vec::<u64>::new();
     (0..n)
         .into_par_iter()
         .map_with(rng, |rng, _| rng.sample(Standard))
         .collect_into_vec(&mut values);
+    */
+
     let gen_duration = t1.elapsed();
     println!(
         "generating {} MiB/s",


### PR DESCRIPTION
Follow-up to PR #24302 to adjust `test/library/packages/Sort/performance/comparison`
 * use a subdirectory .gitignore since that is preferred to adjusting the top-level one
 * include the parallel array generation as a commented-out alternative to keep the blog performance reproducible
 * comment out some cargo configuration that makes it slower on the benchmark system


Test change only, not reviewed.