### PR TITLE
Fix use of `/dev/urandom` in default seed initialization

### DIFF
--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -132,6 +132,8 @@ module Random {
           sWhere = here.hash():int;
 
     var randomBits: int = 0;
+    // TODO: separate the "`/dev/urandom` doesn't exist" error handling from the
+    //        readBits error handling
     try {
       IO.openReader("/dev/urandom", region=0..<8).readBits(randomBits, 64);
     } catch {

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -132,13 +132,11 @@ module Random {
           sWhere = here.hash():int;
 
     var randomBits: int = 0;
-    // commented out due to an issue with opening too many fileReaders to
-    // /dev/urandom on some platforms
-    // try {
-    //   IO.openReader("/dev/urandom").readBits(randomBits, 64);
-    // } catch {
-    //   // may not be able to open /dev/urandom, ignore this step
-    // }
+    try {
+      IO.openReader("/dev/urandom", region=0..<8).readBits(randomBits, 64);
+    } catch {
+      // may not be able to open /dev/urandom, ignore this step
+    }
 
     return sWho ^ sWhat ^ sWhen ^ sWhere ^ randomBits;
   }


### PR DESCRIPTION
This PR reinstates the use of `/dev/urandom` for default seed initialization (after https://github.com/chapel-lang/chapel/pull/24324), but ensures that each time the file is opened, only 8 bytes are loaded into the `fileReader`'s buffer.

This change will prevent programs that use many `randomStream`s with default seed values from "overwhelming" `/dev/urandom` by requesting too many bytes in a short span of time.

- [x] paratest
- [x] `/test/library/packages/Channel` tests passing 100 trials on linux VM