### PR TITLE
Add co-locale support to smp launcher

### DIFF
--- a/doc/rst/usingchapel/multilocale.rst
+++ b/doc/rst/usingchapel/multilocale.rst
@@ -193,6 +193,7 @@ gasnet      gasnetrun_*
 gasnet      pbs-gasnetrun_ibv
 gasnet      slurm-gasnetrun_*
 gasnet      slurm-srun
+gasnet      smp
 ofi         slurm-srun
 =========   =============
 

--- a/runtime/src/launch/smp/launch-smp.c
+++ b/runtime/src/launch/smp/launch-smp.c
@@ -24,14 +24,16 @@
 #include "chpllaunch.h"
 
 
-// Simple launcher that just sets GASNET_PSHM_NODES and launchers the _real
+// Simple launcher that just sets GASNET_PSHM_NODES and launches the _real
 
 int chpl_launch(int argc, char* argv[], int32_t numLocales,
                 int32_t numLocalesPerNode) {
   char baseCommand[4096];
 
-  if (numLocalesPerNode > 1) {
-    chpl_launcher_no_colocales_error(NULL);
+  int32_t numNodes = (numLocales + numLocalesPerNode - 1) / numLocalesPerNode;
+
+  if ((numLocalesPerNode > 1) && (numNodes != 1)) {
+    chpl_error("smp launcher does not support multiple nodes", 0, 0);
   }
 
   chpl_env_set_uint("GASNET_PSHM_NODES", numLocales, 1);

--- a/runtime/src/topo/hwloc/topo-hwloc.c
+++ b/runtime/src/topo/hwloc/topo-hwloc.c
@@ -33,6 +33,7 @@
 #include "chpltypes.h"
 #include "error.h"
 #include "chpl-mem-sys.h"
+#include "chplexit.h"
 
 #include <errno.h>
 #include <pthread.h>
@@ -569,6 +570,8 @@ static void partitionResources(void) {
                  "%d sockets and %d NUMA domains.",
                  numLocalesOnNode, numSockets, numNumas);
         chpl_error(msg, 0, 0);
+      } else {
+        chpl_exit_any(1);
       }
       // Use the socket/NUMA whose logical index corresponds to our local rank.
       CHK_ERR(myRoot = hwloc_get_obj_inside_cpuset_by_type(topology,


### PR DESCRIPTION
Add support for co-locales to the `smp` launcher. The `smp` launcher runs the locales on the local machine, thus when using the "-nl NxL" argument N must be one, otherwise it's an error.