### PR TITLE
Miscellaneous Dyno Fixes

### DIFF
--- a/compiler/etc/lldb.commands
+++ b/compiler/etc/lldb.commands
@@ -3,6 +3,7 @@ command regex view   's/(.*)/expr -- print_view(%1)/'
 command regex iview  's/(.*)/expr -- iprint_view(%1)/'
 command regex nview  's/(.*)/expr -- nprint_view(%1)/'
 command regex lview  's/(.*)/expr -- list_view(%1)/'
+command regex dview 's/(.*)/expr -- (%1).dump()/'
 command regex flags  's/(.*)/expr -- viewFlags(%1)/'
 command regex loc    's/(.*)/expr -- ::stringLoc(%1)/'
 

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -145,6 +145,7 @@ class UntypedFnSignature {
     CHPL_ASSERT(idTag == uast::asttags::Function ||
            idTag == uast::asttags::Class    ||
            idTag == uast::asttags::Record   ||
+           idTag == uast::asttags::Tuple    ||
            idTag == uast::asttags::Union    ||
            idTag == uast::asttags::Variable);
   }

--- a/frontend/include/chpl/types/type-classes-list.h
+++ b/frontend/include/chpl/types/type-classes-list.h
@@ -58,7 +58,7 @@ TYPE_NODE(CPtrType)
 
 TYPE_BEGIN_SUBCLASSES(BuiltinType)
   // concrete builtin types
-  BUILTIN_TYPE_NODE(CFnPtrType, "c_fn_ptr")
+  BUILTIN_TYPE_NODE(CFnPtrType, "chpl_c_fn_ptr")
   BUILTIN_TYPE_NODE(CVoidPtrType, "chpl__c_void_ptr")
   BUILTIN_TYPE_NODE(OpaqueType, "opaque")
   BUILTIN_TYPE_NODE(SyncAuxType, "_sync_aux_t")

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -3888,7 +3888,8 @@ bool Resolver::enter(const IndexableLoop* loop) {
 
         // TODO: resolve array types when the iterand is something other than
         // a domain.
-        if (eltType.isType()) {
+        if (eltType.isType() || eltType.kind() == QualifiedType::TYPE_QUERY) {
+          eltType = QualifiedType(QualifiedType::TYPE, eltType.type());
           auto arrayType = ArrayType::getArrayType(context, iterandType, eltType);
 
           ResolvedExpression& re = byPostorder.byAst(loop);

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -3341,11 +3341,18 @@ void Resolver::exit(const Call* call) {
       }
       QualifiedType qt = actual.type();
       const Type* t = qt.type();
+
+      const AstNode* formalAst = toId.isEmpty() ? nullptr : parsing::idToAst(context, toId);
+      bool isNonOutFormal = formalAst != nullptr &&
+                            formalAst->isFormal() &&
+                            formalAst->toFormal()->intent() != Formal::Intent::OUT;
+
       if (t != nullptr && t->isErroneousType()) {
         // always skip if there is an ErroneousType
         skip = ERRONEOUS_ACT;
-      } else if (!toId.isEmpty()) {
-        // don't skip because it could be initialized with 'out' intent
+      } else if (!toId.isEmpty() && !isNonOutFormal) {
+        // don't skip because it could be initialized with 'out' intent,
+        // but not for non-out formals because they can't be split-initialized.
       } else {
         if (qt.isParam() && qt.param() == nullptr) {
           skip = UNKNOWN_PARAM;

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -376,6 +376,7 @@ Resolver::paramLoopResolver(Resolver& parent,
   ret.parentResolver = &parent;
   ret.declStack = parent.declStack;
   ret.byPostorder.setupForParamLoop(loop, parent.byPostorder);
+  ret.typedSignature = parent.typedSignature;
 
   return ret;
 }

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1396,6 +1396,7 @@ void Resolver::resolveNamedDecl(const NamedDecl* decl, const Type* useType) {
       if (declaredKind == QualifiedType::DEFAULT_INTENT ||
           declaredKind == QualifiedType::CONST_INTENT) {
         typePtr = tupleType->toReferentialTuple(context);
+        qtKind = QualifiedType::CONST_REF;
       } else if (qtKind == QualifiedType::VAR ||
                  qtKind == QualifiedType::CONST_VAR ||
                  qtKind == QualifiedType::CONST_REF ||

--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -1035,6 +1035,21 @@ CanPassResult CanPassResult::canPass(Context* context,
     case QualifiedType::REF_MAYBE_CONST:
     case QualifiedType::TYPE:
       {
+        auto actualTup = actualT->toTupleType();
+        if (actualTup != nullptr  && formalT->isTupleType()) {
+          if (actualTup->isVarArgTuple() &&
+              actualTup->toReferentialTuple(context) == formalT) {
+            // Supports code like:
+            //   proc foo(args...) do
+            //     bar(args);
+            //
+            // TODO: Should this register as a conversion?
+            return passAsIs();
+          } else if (formalQT.kind() == QualifiedType::TYPE &&
+                actualTup->toValueTuple(context) == formalT) {
+            return passAsIs();
+          }
+        }
         // TODO: promotion
         return canPassSubtype(context, actualT, formalT);
       }

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -883,7 +883,7 @@ static QualifiedType primIsRecordType(Context* context, const CallInfo& ci) {
 
 static QualifiedType primIsFcfType(Context* context, const CallInfo& ci) {
   CHPL_UNIMPL("PRIM_IS_FCF_TYPE");
-  return QualifiedType();
+  return makeParamBool(context, false);
 }
 
 static QualifiedType primIsUnionType(Context* context, const CallInfo& ci) {

--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -910,6 +910,11 @@ static bool helpComputeCompilerGeneratedReturnType(Context* context,
       }
 
       return true;
+    } else if (untyped->isMethod() && sig->formalType(0).type()->isTupleType() &&
+               untyped->name() == "size") {
+      auto tup = sig->formalType(0).type()->toTupleType();
+      result = QualifiedType(QualifiedType::PARAM, IntType::get(context, 0), IntParam::get(context, tup->numElements()));
+      return true;
     } else {
       CHPL_ASSERT(false && "unhandled compiler-generated record method");
       return true;

--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -959,8 +959,10 @@ static bool helpComputeReturnType(Context* context,
     }
 
     // if there are no returns with a value, use void return type
-    if (fn->linkage() != Decl::EXTERN &&
-        fnAstReturnsNonVoid(context, ast->id()) == false) {
+    if (fn->linkage() == Decl::EXTERN && fn->returnType() == nullptr) {
+      result = QualifiedType(QualifiedType::CONST_VAR, VoidType::get(context));
+      return true;
+    } else if (fnAstReturnsNonVoid(context, ast->id()) == false) {
       result = QualifiedType(QualifiedType::CONST_VAR, VoidType::get(context));
       return true;
     }

--- a/frontend/lib/types/Type.cpp
+++ b/frontend/lib/types/Type.cpp
@@ -129,6 +129,10 @@ void Type::gatherBuiltins(Context* context,
   gatherType(context, map, "domain", DomainType::getGenericDomainType(context));
 
   gatherType(context, map, "class", AnyClassType::get(context));
+  auto genericBorrowed = ClassType::get(context, AnyClassType::get(context), nullptr, ClassTypeDecorator(ClassTypeDecorator::BORROWED));
+  gatherType(context, map, "borrowed", genericBorrowed);
+  auto genericUnmanaged = ClassType::get(context, AnyClassType::get(context), nullptr, ClassTypeDecorator(ClassTypeDecorator::UNMANAGED));
+  gatherType(context, map, "unmanaged", genericUnmanaged);
 
   gatherType(context, map, "c_ptr", CPtrType::get(context));
 

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -307,7 +307,7 @@ module ChapelLocale {
     // Every locale has a parent, except for the root locale.
     // The parent of the root locale is nil (by definition).
     @chpldoc.nodoc
-    const parent = nilLocale;
+    const parent : locale = nilLocale;
 
     @chpldoc.nodoc var nPUsLogAcc: int;     // HW threads, accessible
     @chpldoc.nodoc var nPUsLogAll: int;     // HW threads, all

--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -589,7 +589,7 @@ module CTypes {
   }
   pragma "last resort"
   @chpldoc.nodoc
-  inline operator :(x:c_ptr(void), type t:_anyManagementAnyNilable) {
+  inline operator :(x:c_ptr(void), type t:class) {
     if isUnmanagedClass(t) || isBorrowedClass(t) {
       compilerError("invalid cast from c_ptr(void) to "+ t:string +
                     " - cast to "+ _to_nilable(t):string +" instead");


### PR DESCRIPTION
This PR includes various bug fixes for dyno:
- Fixes name of ``c_fn_ptr``
- Silences errors for PRIM_IS_FCF_TYPE to simply return ``false`` for now.
- Correctly computes ``void`` return type of extern procs when no return type is declared
- basic support for "unmanaged" and "borrowed" type classes
- Modifies ChapelLocale implementation to avoid recursive resolution
- Avoids need to re-implement ``_anyManagedAnyNilable`` in dyno by using ``class``
- Implements default-init-then-assign for extern variables, which don't necessarily support ``init=``
- Fixes a minor bug for param for-loops where resolution was missing the typed signature
- Implement implicit conversions between vararg-tuples, reference tuples, and value tuples
- Support for ``.size`` on tuples, and allowing other methods on tuples
- Allow unresolved formals passed as actuals to trigger the "skip" condition when resolving a call
- Correctly sets the type for array expressions with a type query

This PR also adds a new debugging helper command for printing things using dyno's debugging ``dump`` methods.

Testing:
- [x] full local
- [x] full gasnet