### PR TITLE
Resolve generic record future 

### DIFF
--- a/test/types/records/generic/issue-22011-resolve-warning.chpl
+++ b/test/types/records/generic/issue-22011-resolve-warning.chpl
@@ -1,0 +1,11 @@
+record generic_record {
+    var x;
+}
+
+record wrapper_record {
+    type t;
+}
+
+record R {
+    var field: wrapper_record(generic_record(?));
+}

--- a/test/types/records/generic/issue-22011-resolve-warning.chpl
+++ b/test/types/records/generic/issue-22011-resolve-warning.chpl
@@ -9,3 +9,10 @@ record wrapper_record {
 record R {
     var field: wrapper_record(generic_record(?));
 }
+
+var gr = new generic_record(x=10);
+writeln(gr, ": ", gr.type:string);
+var wrap = new wrapper_record(gr.type);
+writeln(wrap, ": ", wrap.type:string);
+var r = new R(field = wrap);
+writeln(r, ": ", r.type:string);

--- a/test/types/records/generic/issue-22011-resolve-warning.good
+++ b/test/types/records/generic/issue-22011-resolve-warning.good
@@ -1,0 +1,3 @@
+(x = 10): generic_record(int(64))
+(): wrapper_record(generic_record(int(64)))
+(field = ()): R(wrapper_record(generic_record(int(64))))

--- a/test/types/records/generic/issue-22011.bad
+++ b/test/types/records/generic/issue-22011.bad
@@ -1,5 +1,0 @@
-issue-22011.chpl:10: warning: partial instantiation without '?' argument
-issue-22011.chpl:10: note: opt in to partial instantiation explicitly with a trailing '?' argument
-issue-22011.chpl:10: note: or, add arguments to instantiate the following fields in generic type 'wrapper_record(generic_record)':
-issue-22011.chpl:6: note:   generic type field 't'
-issue-22011.chpl:10: error: could not determine the concrete type for the generic return type 'wrapper_record(generic_record)'

--- a/test/types/records/generic/issue-22011.future
+++ b/test/types/records/generic/issue-22011.future
@@ -1,3 +1,0 @@
-bug: implicitly generic records have their field accessors resolved as if concrete
-
-#22011

--- a/test/types/records/generic/issue-22011.good
+++ b/test/types/records/generic/issue-22011.good
@@ -1,0 +1,5 @@
+issue-22011.chpl:10: warning: partial instantiation without '?' argument
+issue-22011.chpl:10: note: opt in to partial instantiation explicitly with a trailing '?' argument
+issue-22011.chpl:10: note: or, add arguments to instantiate the following fields in generic type 'wrapper_record(generic_record)':
+issue-22011.chpl:6: note:   generic type field 't'
+issue-22011.chpl:10: error: could not determine the concrete type for the generic return type 'wrapper_record(generic_record)'


### PR DESCRIPTION
Resolves the future from #22011. This test gives both a warning and an error. Responding to the suggestion from the warning and adding a `(?)` causes the error to go away. This PR keeps the original test (locking in the error message) and adds a second test with the `(?)` fix.

Tested locally

[Reviewed by @bradcray]

Resolves #22011