### PR TITLE
Adjust GPUization error wording

### DIFF
--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -780,7 +780,7 @@ bool GpuizableLoop::callsInBodyAreGpuizableHelp(BlockStmt* blk,
 
       if (hasOuterVarAccesses(fn)) {
         assertionReporter_.pushCall(call);
-        assertionReporter_.reportNotGpuizable(loop_, call, "called function has outer var access");
+        assertionReporter_.reportNotGpuizable(loop_, fn, "called function has outer var access");
         assertionReporter_.popCall();
         return false;
       }

--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -779,7 +779,9 @@ bool GpuizableLoop::callsInBodyAreGpuizableHelp(BlockStmt* blk,
       }
 
       if (hasOuterVarAccesses(fn)) {
-        assertionReporter_.reportNotGpuizable(loop_, call, "call has outer var access");
+        assertionReporter_.pushCall(call);
+        assertionReporter_.reportNotGpuizable(loop_, call, "called function has outer var access");
+        assertionReporter_.popCall();
         return false;
       }
 

--- a/test/gpu/native/assertOnFailToGpuize.3.good
+++ b/test/gpu/native/assertOnFailToGpuize.3.good
@@ -10,4 +10,5 @@ assertOnFailToGpuize.chpl:79: warning: the functional form of assertOnGpu() is d
 assertOnFailToGpuize.chpl:80: warning: the functional form of assertOnGpu() is deprecated. Please use the @assertOnGpu loop attribute instead.
 assertOnFailToGpuize.chpl:81: warning: the functional form of assertOnGpu() is deprecated. Please use the @assertOnGpu loop attribute instead.
 assertOnFailToGpuize.chpl:38: error: Loop contains assertOnGpu() but is not eligible for execution on a GPU
-assertOnFailToGpuize.chpl:40: note: call has outer var access
+assertOnFailToGpuize.chpl:13: note: called function has outer var access
+assertOnFailToGpuize.chpl:40: note:   reached via call to 'usesOutsideVar' in loop body here

--- a/test/gpu/native/assertOnFailToGpuizeAttr.3.good
+++ b/test/gpu/native/assertOnFailToGpuizeAttr.3.good
@@ -1,2 +1,3 @@
 assertOnFailToGpuizeAttr.chpl:40: error: Loop is marked with @assertOnGpu but is not eligible for execution on a GPU
-assertOnFailToGpuizeAttr.chpl:41: note: call has outer var access
+assertOnFailToGpuizeAttr.chpl:13: note: called function has outer var access
+assertOnFailToGpuizeAttr.chpl:41: note:   reached via call to 'usesOutsideVar' in loop body here

--- a/test/gpu/native/errors/outeraccess.good
+++ b/test/gpu/native/errors/outeraccess.good
@@ -1,4 +1,5 @@
 outeraccess.chpl:17: error: Loop is marked with @assertOnGpu but is not eligible for execution on a GPU
-outeraccess.chpl:8: note: call has outer var access
+outeraccess.chpl:3: note: called function has outer var access
+outeraccess.chpl:8: note:   reached via call to 'f1' here
 outeraccess.chpl:12: note:   reached via call to 'f2' here
 outeraccess.chpl:18: note:   reached via call to 'f3' in loop body here


### PR DESCRIPTION
The error would say "call has outer variable access", but the thing that has the outer variable access is actually the function. So, add the call to the trace, but say that the _function_ is what has the outer variable access.

Reviewed by @e-kayrakli -- thanks!

## Testing
- [x] `test/gpu/native`