### PR TITLE
Emit non-internal errors when `setBlockSize` is used outside of a GPU loop

### DIFF
--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -1620,7 +1620,7 @@ static void reportErrorsForBadBlockSizeCalls() {
   CallExpr* explainAnchor = nullptr;
   for_alive_in_Vec(CallExpr, callExpr, gCallExprs) {
     if(callExpr->isPrimitive(PRIM_GPU_SET_BLOCKSIZE)) {
-      USR_FATAL_CONT(callExpr, "'setBlockSize' must only be used in bodies of GPU-eligible loops");
+      USR_FATAL_CONT(callExpr, "'setBlockSize' can only be used in bodies of GPU-eligible loops");
       explainAnchor = callExpr;
 
       debuggerBreakHere();

--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -1624,8 +1624,13 @@ static void reportErrorsForBadBlockSizeCalls() {
       explainAnchor = callExpr;
 
       // Search forward to try find the CForLoop corresponding to the GPU loop.
+      // This is just a heuristic to detect common erroneous uses for setBlockSize.
       auto search = callExpr->next;
       while (search) {
+        // Try recognizing a GPU-eligible loop that the blockSize call could've
+        // applied to by detecting the loop's dynamic launch check (i.e.,
+        // the "if runningOnGpuLocale()" conditional).
+
         auto condStmt = toCondStmt(search);
         if (gpuBranches.count(condStmt) > 0) {
           USR_PRINT(condStmt, "if you meant to set the block size of this GPU "

--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -1623,8 +1623,6 @@ static void reportErrorsForBadBlockSizeCalls() {
       USR_FATAL_CONT(callExpr, "'setBlockSize' can only be used in bodies of GPU-eligible loops");
       explainAnchor = callExpr;
 
-      debuggerBreakHere();
-
       // Search forward to try find the CForLoop corresponding to the GPU loop.
       auto search = callExpr->next;
       while (search) {

--- a/test/gpu/native/errors/badblocksize.chpl
+++ b/test/gpu/native/errors/badblocksize.chpl
@@ -1,0 +1,8 @@
+use GPU;
+
+on here.gpus[0] {
+  var A: [1..10] int;
+
+  setBlockSize(1024);
+  foreach a in A do a+= 1;
+}

--- a/test/gpu/native/errors/badblocksize.good
+++ b/test/gpu/native/errors/badblocksize.good
@@ -1,2 +1,2 @@
-badblocksize.chpl:6: error: 'setBlockSize' must only be used in bodies of GPU-eligible loops
+badblocksize.chpl:6: error: 'setBlockSize' can only be used in bodies of GPU-eligible loops
 badblocksize.chpl:7: note: if you meant to set the block size of this GPU loop, move the 'setBlockSize' call into the loop body

--- a/test/gpu/native/errors/badblocksize.good
+++ b/test/gpu/native/errors/badblocksize.good
@@ -1,0 +1,2 @@
+badblocksize.chpl:6: error: 'setBlockSize' must only be used in bodies of GPU-eligible loops
+badblocksize.chpl:7: note: if you meant to set the block size of this GPU loop, move the 'setBlockSize' call into the loop body


### PR DESCRIPTION
A user coming from CUDA might think that they need to set the block size using a function call before calling the loop:

```Chapel
  setBlockSize(1024);
  foreach a in A do a+= 1;
```

However, `setBlockSize` is actually a special function that the compiler recognizes and handles. In the case above, the function is not in a format that the compiler expects, resulting in an internal error. This PR simply improves the error messages to explain what's wrong. 

Reviewed by @e-kayrakli -- thanks!

## Testing
- [x] `test/gpu/native`