### PR TITLE
fix libcuda path when running in WSL

### DIFF
--- a/util/chplenv/chpl_platform.py
+++ b/util/chplenv/chpl_platform.py
@@ -77,6 +77,12 @@ def get(flag='host'):
 
 
 @memoize
+def is_wsl():
+    name = (platform.uname().release).lower()
+    if name.endswith('-microsoft') or name.endswith('-microsoft-standard-wsl2'):
+        return True
+
+@memoize
 def get_mac_os_version():
     release, version, machine = platform.mac_ver()
     return release

--- a/util/chplenv/compile_link_args_utils.py
+++ b/util/chplenv/compile_link_args_utils.py
@@ -100,8 +100,11 @@ def get_runtime_link_args(runtime_subdir):
         sdk_path = chpl_gpu.get_sdk_path(gpu_type)
         if gpu_type == "nvidia":
             system.append("-L" + os.path.join(sdk_path, "lib64"))
-            system.append("-lcuda")
             system.append("-lcudart")
+            if chpl_platform.is_wsl():
+                # WSL needs to link with libcuda that belongs to the driver hosted in Windows
+                system.append("-L" + os.path.join("/usr", "lib", "wsl", "lib"))
+            system.append("-lcuda")
         elif gpu_type == "amd":
             lib_path = os.path.join(sdk_path, "lib")
             system.append("-L" + lib_path)


### PR DESCRIPTION
This PR adds the ability to detect if we are using an NVidia GPU while running in Windows Subsystem for Linux (WSL) and make appropriate additions to properly detect the location of `libcuda`. 

This change was needed because WSL has a special configuration w.r.t. the GPU drivers where the drivers are installed only in Windows and then made available to WSL.

TESTING:

- [x] paratest on chapdl-nvidia `[Summary: #Successes = 176 | #Failures = 0 | #Futures = 6]`
- [x] code targeting GPU compiles and runs in WSL with an NVidia GPU

[reviewed by @e-kayrakli - thanks!]