### PR TITLE
Avoid gcc 8.1 with xc testing

### DIFF
--- a/util/build_configs/cray-internal/setenv-xc-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-x86_64.bash
@@ -310,7 +310,7 @@ else
         list_loaded_modules
     fi
 
-    gen_version_gcc=8.1.0
+    gen_version_gcc=9.3.0
     gen_version_intel=2022.0.1
     gen_version_cce=10.0.3
 


### PR DESCRIPTION
Resolves an issue in nightly testing due to a bug in gcc8.1 that prevents building LLVM 17. This bug exists in gcc 8.1 and 8.2, but the particular test system has gcc 9.3.

<details>

This particular bug comes from using an enum in a constant expression. See this compiler explorer example which tests multiple compiler versions: https://godbolt.org/z/7d68GK45n.

The original code that caused this problem was the `static constexpr fltSemantics = ...` definitions in `lib/Support/APFloat.cpp` in LLVM 17.

This is the same code from the above link, inlined here

```c++
enum class myEnum {
  A, B
};
struct myStruct {
  int i;
  int j;
  myEnum k = myEnum::A;
};

static constexpr myStruct foo = {1, 2};

myStruct get() {
  return foo;
}
```

</details>

Tested manually on the failing system

[Reviewed by @tzinsky]

