### PR TITLE
Unify `CandidatesVec` and `ForwardingInfoVec` into `CandidatesAndForwardingInfo`

### DIFF
--- a/frontend/include/chpl/resolution/disambiguation.h
+++ b/frontend/include/chpl/resolution/disambiguation.h
@@ -45,8 +45,7 @@ namespace resolution {
 MostSpecificCandidates
 findMostSpecificCandidates(
     Context* context,
-    const std::vector<const TypedFnSignature*>& lst,
-    const std::vector<types::QualifiedType>& forwardingInfo,
+    const CandidatesAndForwardingInfo& lst,
     const CallInfo& call,
     const Scope* callInScope,
     const PoiScope* callInPoiScope);

--- a/frontend/include/chpl/resolution/resolution-queries.h
+++ b/frontend/include/chpl/resolution/resolution-queries.h
@@ -293,8 +293,6 @@ const TypedFnSignature* inferRefMaybeConstFormals(Context* context,
 
 /////// call resolution
 
-struct CandidatesAndForwardingInfo;
-
 /**
   Compute the (potentially generic) TypedFnSignatures of possibly applicable
   candidate functions from a list of visible functions.

--- a/frontend/include/chpl/resolution/resolution-queries.h
+++ b/frontend/include/chpl/resolution/resolution-queries.h
@@ -293,11 +293,13 @@ const TypedFnSignature* inferRefMaybeConstFormals(Context* context,
 
 /////// call resolution
 
+struct CandidatesAndForwardingInfo;
+
 /**
   Compute the (potentially generic) TypedFnSignatures of possibly applicable
   candidate functions from a list of visible functions.
  */
-const std::vector<const TypedFnSignature*>&
+const CandidatesAndForwardingInfo&
 filterCandidatesInitial(Context* context,
                         std::vector<BorrowedIdsWithName> lst,
                         CallInfo call);
@@ -313,11 +315,11 @@ filterCandidatesInitial(Context* context,
  */
 void
 filterCandidatesInstantiating(Context* context,
-                              const std::vector<const TypedFnSignature*>& lst,
+                              const CandidatesAndForwardingInfo& lst,
                               const CallInfo& call,
                               const Scope* inScope,
                               const PoiScope* inPoiScope,
-                              std::vector<const TypedFnSignature*>& result,
+                              CandidatesAndForwardingInfo& result,
                               std::vector<ApplicabilityResult>* rejected = nullptr);
 
 /**

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -900,12 +900,6 @@ struct CandidatesAndForwardingInfo {
      if (forwardingTo) {
        forwardingInfo.push_back(*forwardingTo);
      }
-
-     /* // Consistency check: If we're using forwarding info, the number of */
-     /* // candidates should always match the number of forwarding info entries. */
-     /* if (!forwardingInfo.empty()) { */
-     /*   CHPL_ASSERT(candidates.size() == forwardingInfo.size()); */
-     /* } */
    }
 
    // Compute and fill in forwarding info for a range of newly-added candidates.

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -895,13 +895,9 @@ struct CandidatesAndForwardingInfo {
  public:
   using const_iterator = std::vector<const TypedFnSignature*>::const_iterator;
 
-  // Add a candidate and optional forwarding info.
-  void addCandidate(const TypedFnSignature* candidate,
-                    const types::QualifiedType* forwardingTo = nullptr) {
+  // Add a candidate without forwarding info.
+  void addCandidate(const TypedFnSignature* candidate) {
     candidates.push_back(candidate);
-    if (forwardingTo) {
-      forwardingInfo.push_back(*forwardingTo);
-    }
   }
 
   // Compute and fill in forwarding info for a range of newly-added candidates.

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -885,6 +885,109 @@ class TypedFnSignature {
   /// \endcond DO_NOT_DOCUMENT
 };
 
+// Container for resolution candidates and (if applicable) their correponding
+// forwarding-to types.
+struct CandidatesAndForwardingInfo {
+  private:
+  std::vector<const TypedFnSignature*> candidates;
+  std::vector<types::QualifiedType> forwardingInfo;
+
+  public:
+   // Add a candidate and optional forwarding info.
+   void addCandidate(const TypedFnSignature* candidate,
+                     const types::QualifiedType* forwardingTo = nullptr) {
+     candidates.push_back(candidate);
+     if (forwardingTo) {
+       forwardingInfo.push_back(*forwardingTo);
+     }
+
+     /* // Consistency check: If we're using forwarding info, the number of */
+     /* // candidates should always match the number of forwarding info entries. */
+     /* if (!forwardingInfo.empty()) { */
+     /*   CHPL_ASSERT(candidates.size() == forwardingInfo.size()); */
+     /* } */
+   }
+
+   // Compute and fill in forwarding info for a range of newly-added candidates.
+   void helpComputeForwardingTo(const CallInfo& fci, size_t start) {
+     types::QualifiedType forwardingReceiverActualType = fci.calledType();
+     forwardingInfo.resize(start);
+     for (size_t i = start; i < candidates.size(); i++) {
+       forwardingInfo.push_back(forwardingReceiverActualType);
+     }
+   }
+
+   // Move the contents of another container into this one, clearing out the
+   // other.
+   void takeFromOther(CandidatesAndForwardingInfo& other) {
+     candidates.insert(candidates.end(),
+                       std::make_move_iterator(other.candidates.begin()),
+                       std::make_move_iterator(other.candidates.end()));
+     forwardingInfo.insert(
+         forwardingInfo.end(),
+         std::make_move_iterator(other.forwardingInfo.begin()),
+         std::make_move_iterator(other.forwardingInfo.end()));
+     other.candidates.clear();
+     other.forwardingInfo.clear();
+   }
+
+   // Get the candidate at the provided index with no bounds checking.
+   const TypedFnSignature* get(size_t i) const { return candidates[i]; }
+
+   // Get the forwarding info at the provided index with no bounds checking.
+   types::QualifiedType getForwardingInfo(size_t i) const { return forwardingInfo[i]; }
+
+   // Check if any candidates are present
+   bool empty() const {
+     return candidates.empty();
+   }
+
+   // Get the number of candidates
+   size_t size() const {
+     return candidates.size();
+   }
+
+   // Return true if this container stores any forwarding info
+   bool hasForwardingInfo() const {
+     return !forwardingInfo.empty();
+   }
+
+   // Iterator over contained candidates
+   std::vector<const TypedFnSignature*>::const_iterator begin() const {
+     return candidates.begin();
+   }
+   std::vector<const TypedFnSignature*>::const_iterator end() const {
+     return candidates.end();
+   }
+
+   /* Query system supporting functions */
+
+   static bool update(CandidatesAndForwardingInfo& keep,
+                      CandidatesAndForwardingInfo& addin) {
+     return defaultUpdate(keep, addin);
+   }
+   size_t hash() const {
+     return chpl::hash(candidates, forwardingInfo);
+   }
+   void mark(Context* context) const {
+     for (const auto& candidate : candidates) {
+       context->markPointer(candidate);
+     }
+     for (const auto& info : forwardingInfo) {
+       info.mark(context);
+     }
+   }
+   bool operator==(const CandidatesAndForwardingInfo& other) const {
+     return candidates == other.candidates &&
+            forwardingInfo == other.forwardingInfo;
+   }
+   void swap(CandidatesAndForwardingInfo& other) {
+     std::swap(candidates, other.candidates);
+     std::swap(forwardingInfo, other.forwardingInfo);
+   }
+   void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const;
+};
+
 /**
   An enum that represents the reason why a function candidate was filtered out
   during call resolution.
@@ -2295,6 +2398,14 @@ template<> struct hash<chpl::resolution::CallInfoActual>
 template<> struct hash<chpl::resolution::CallInfo>
 {
   size_t operator()(const chpl::resolution::CallInfo& key) const {
+    return key.hash();
+  }
+};
+
+template <>
+struct hash<chpl::resolution::CandidatesAndForwardingInfo> {
+  size_t operator()(
+      const chpl::resolution::CandidatesAndForwardingInfo& key) const {
     return key.hash();
   }
 };

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -890,6 +890,9 @@ class TypedFnSignature {
 struct CandidatesAndForwardingInfo {
  private:
   std::vector<const TypedFnSignature*> candidates;
+  // Note we have a (small) storage footprint for forwardingInfo even in the
+  // relatively common case where it is unused; could potentially use something
+  // lighter than this struct for candidates without forwarding info.
   std::vector<types::QualifiedType> forwardingInfo;
 
  public:

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -926,8 +926,10 @@ struct CandidatesAndForwardingInfo {
   // Get the candidate at the provided index with no bounds checking.
   const TypedFnSignature* get(size_t i) const { return candidates[i]; }
 
-  // Get the forwarding info at the provided index with no bounds checking.
+  // Get the forwarding info at the provided index.
+  // Fails if there isn't forwarding info saved for each candidate.
   const types::QualifiedType& getForwardingInfo(size_t i) const {
+    CHPL_ASSERT(candidates.size() == forwardingInfo.size());
     return forwardingInfo[i];
   }
 

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -893,6 +893,8 @@ struct CandidatesAndForwardingInfo {
   std::vector<types::QualifiedType> forwardingInfo;
 
  public:
+  using const_iterator = std::vector<const TypedFnSignature*>::const_iterator;
+
   // Add a candidate and optional forwarding info.
   void addCandidate(const TypedFnSignature* candidate,
                     const types::QualifiedType* forwardingTo = nullptr) {
@@ -929,7 +931,7 @@ struct CandidatesAndForwardingInfo {
   const TypedFnSignature* get(size_t i) const { return candidates[i]; }
 
   // Get the forwarding info at the provided index with no bounds checking.
-  types::QualifiedType getForwardingInfo(size_t i) const {
+  const types::QualifiedType& getForwardingInfo(size_t i) const {
     return forwardingInfo[i];
   }
 
@@ -943,10 +945,10 @@ struct CandidatesAndForwardingInfo {
   bool hasForwardingInfo() const { return !forwardingInfo.empty(); }
 
   // Iterator over contained candidates
-  std::vector<const TypedFnSignature*>::const_iterator begin() const {
+  const_iterator begin() const {
     return candidates.begin();
   }
-  std::vector<const TypedFnSignature*>::const_iterator end() const {
+  const_iterator end() const {
     return candidates.end();
   }
 
@@ -958,12 +960,8 @@ struct CandidatesAndForwardingInfo {
   }
   size_t hash() const { return chpl::hash(candidates, forwardingInfo); }
   void mark(Context* context) const {
-    for (const auto& candidate : candidates) {
-      context->markPointer(candidate);
-    }
-    for (const auto& info : forwardingInfo) {
-      info.mark(context);
-    }
+    chpl::mark<decltype(candidates)>{}(context, candidates);
+    chpl::mark<decltype(forwardingInfo)>{}(context, forwardingInfo);
   }
   bool operator==(const CandidatesAndForwardingInfo& other) const {
     return candidates == other.candidates &&

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -927,23 +927,23 @@ struct CandidatesAndForwardingInfo {
   }
 
   // Get the candidate at the provided index with no bounds checking.
-  const TypedFnSignature* get(size_t i) const { return candidates[i]; }
+  inline const TypedFnSignature* get(size_t i) const { return candidates[i]; }
 
   // Get the forwarding info at the provided index.
   // Fails if there isn't forwarding info saved for each candidate.
-  const types::QualifiedType& getForwardingInfo(size_t i) const {
+  inline const types::QualifiedType& getForwardingInfo(size_t i) const {
     CHPL_ASSERT(candidates.size() == forwardingInfo.size());
     return forwardingInfo[i];
   }
 
   // Check if any candidates are present
-  bool empty() const { return candidates.empty(); }
+  inline bool empty() const { return candidates.empty(); }
 
   // Get the number of candidates
-  size_t size() const { return candidates.size(); }
+  inline size_t size() const { return candidates.size(); }
 
   // Return true if this container stores any forwarding info
-  bool hasForwardingInfo() const { return !forwardingInfo.empty(); }
+  inline bool hasForwardingInfo() const { return !forwardingInfo.empty(); }
 
   // Iterator over contained candidates
   const_iterator begin() const { return candidates.begin(); }

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -904,8 +904,9 @@ struct CandidatesAndForwardingInfo {
 
   // Compute and fill in forwarding info for a range of newly-added candidates.
   void helpComputeForwardingTo(const CallInfo& fci, size_t start) {
-    types::QualifiedType forwardingReceiverActualType = fci.calledType();
+    CHPL_ASSERT(forwardingInfo.size() <= start);
     forwardingInfo.resize(start);
+    types::QualifiedType forwardingReceiverActualType = fci.calledType();
     for (size_t i = start; i < candidates.size(); i++) {
       forwardingInfo.push_back(forwardingReceiverActualType);
     }

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -888,98 +888,91 @@ class TypedFnSignature {
 // Container for resolution candidates and (if applicable) their correponding
 // forwarding-to types.
 struct CandidatesAndForwardingInfo {
-  private:
+ private:
   std::vector<const TypedFnSignature*> candidates;
   std::vector<types::QualifiedType> forwardingInfo;
 
-  public:
-   // Add a candidate and optional forwarding info.
-   void addCandidate(const TypedFnSignature* candidate,
-                     const types::QualifiedType* forwardingTo = nullptr) {
-     candidates.push_back(candidate);
-     if (forwardingTo) {
-       forwardingInfo.push_back(*forwardingTo);
-     }
-   }
+ public:
+  // Add a candidate and optional forwarding info.
+  void addCandidate(const TypedFnSignature* candidate,
+                    const types::QualifiedType* forwardingTo = nullptr) {
+    candidates.push_back(candidate);
+    if (forwardingTo) {
+      forwardingInfo.push_back(*forwardingTo);
+    }
+  }
 
-   // Compute and fill in forwarding info for a range of newly-added candidates.
-   void helpComputeForwardingTo(const CallInfo& fci, size_t start) {
-     types::QualifiedType forwardingReceiverActualType = fci.calledType();
-     forwardingInfo.resize(start);
-     for (size_t i = start; i < candidates.size(); i++) {
-       forwardingInfo.push_back(forwardingReceiverActualType);
-     }
-   }
+  // Compute and fill in forwarding info for a range of newly-added candidates.
+  void helpComputeForwardingTo(const CallInfo& fci, size_t start) {
+    types::QualifiedType forwardingReceiverActualType = fci.calledType();
+    forwardingInfo.resize(start);
+    for (size_t i = start; i < candidates.size(); i++) {
+      forwardingInfo.push_back(forwardingReceiverActualType);
+    }
+  }
 
-   // Move the contents of another container into this one, clearing out the
-   // other.
-   void takeFromOther(CandidatesAndForwardingInfo& other) {
-     candidates.insert(candidates.end(),
-                       std::make_move_iterator(other.candidates.begin()),
-                       std::make_move_iterator(other.candidates.end()));
-     forwardingInfo.insert(
-         forwardingInfo.end(),
-         std::make_move_iterator(other.forwardingInfo.begin()),
-         std::make_move_iterator(other.forwardingInfo.end()));
-     other.candidates.clear();
-     other.forwardingInfo.clear();
-   }
+  // Move the contents of another container into this one, clearing out the
+  // other.
+  void takeFromOther(CandidatesAndForwardingInfo& other) {
+    candidates.insert(candidates.end(),
+                      std::make_move_iterator(other.candidates.begin()),
+                      std::make_move_iterator(other.candidates.end()));
+    forwardingInfo.insert(forwardingInfo.end(),
+                          std::make_move_iterator(other.forwardingInfo.begin()),
+                          std::make_move_iterator(other.forwardingInfo.end()));
+    other.candidates.clear();
+    other.forwardingInfo.clear();
+  }
 
-   // Get the candidate at the provided index with no bounds checking.
-   const TypedFnSignature* get(size_t i) const { return candidates[i]; }
+  // Get the candidate at the provided index with no bounds checking.
+  const TypedFnSignature* get(size_t i) const { return candidates[i]; }
 
-   // Get the forwarding info at the provided index with no bounds checking.
-   types::QualifiedType getForwardingInfo(size_t i) const { return forwardingInfo[i]; }
+  // Get the forwarding info at the provided index with no bounds checking.
+  types::QualifiedType getForwardingInfo(size_t i) const {
+    return forwardingInfo[i];
+  }
 
-   // Check if any candidates are present
-   bool empty() const {
-     return candidates.empty();
-   }
+  // Check if any candidates are present
+  bool empty() const { return candidates.empty(); }
 
-   // Get the number of candidates
-   size_t size() const {
-     return candidates.size();
-   }
+  // Get the number of candidates
+  size_t size() const { return candidates.size(); }
 
-   // Return true if this container stores any forwarding info
-   bool hasForwardingInfo() const {
-     return !forwardingInfo.empty();
-   }
+  // Return true if this container stores any forwarding info
+  bool hasForwardingInfo() const { return !forwardingInfo.empty(); }
 
-   // Iterator over contained candidates
-   std::vector<const TypedFnSignature*>::const_iterator begin() const {
-     return candidates.begin();
-   }
-   std::vector<const TypedFnSignature*>::const_iterator end() const {
-     return candidates.end();
-   }
+  // Iterator over contained candidates
+  std::vector<const TypedFnSignature*>::const_iterator begin() const {
+    return candidates.begin();
+  }
+  std::vector<const TypedFnSignature*>::const_iterator end() const {
+    return candidates.end();
+  }
 
-   /* Query system supporting functions */
+  /* Query system supporting functions */
 
-   static bool update(CandidatesAndForwardingInfo& keep,
-                      CandidatesAndForwardingInfo& addin) {
-     return defaultUpdate(keep, addin);
-   }
-   size_t hash() const {
-     return chpl::hash(candidates, forwardingInfo);
-   }
-   void mark(Context* context) const {
-     for (const auto& candidate : candidates) {
-       context->markPointer(candidate);
-     }
-     for (const auto& info : forwardingInfo) {
-       info.mark(context);
-     }
-   }
-   bool operator==(const CandidatesAndForwardingInfo& other) const {
-     return candidates == other.candidates &&
-            forwardingInfo == other.forwardingInfo;
-   }
-   void swap(CandidatesAndForwardingInfo& other) {
-     std::swap(candidates, other.candidates);
-     std::swap(forwardingInfo, other.forwardingInfo);
-   }
-   void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const;
+  static bool update(CandidatesAndForwardingInfo& keep,
+                     CandidatesAndForwardingInfo& addin) {
+    return defaultUpdate(keep, addin);
+  }
+  size_t hash() const { return chpl::hash(candidates, forwardingInfo); }
+  void mark(Context* context) const {
+    for (const auto& candidate : candidates) {
+      context->markPointer(candidate);
+    }
+    for (const auto& info : forwardingInfo) {
+      info.mark(context);
+    }
+  }
+  bool operator==(const CandidatesAndForwardingInfo& other) const {
+    return candidates == other.candidates &&
+           forwardingInfo == other.forwardingInfo;
+  }
+  void swap(CandidatesAndForwardingInfo& other) {
+    std::swap(candidates, other.candidates);
+    std::swap(forwardingInfo, other.forwardingInfo);
+  }
+  void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const;
 };
 
 /**

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -943,12 +943,8 @@ struct CandidatesAndForwardingInfo {
   bool hasForwardingInfo() const { return !forwardingInfo.empty(); }
 
   // Iterator over contained candidates
-  const_iterator begin() const {
-    return candidates.begin();
-  }
-  const_iterator end() const {
-    return candidates.end();
-  }
+  const_iterator begin() const { return candidates.begin(); }
+  const_iterator end() const { return candidates.end(); }
 
   /* Query system supporting functions */
 

--- a/frontend/lib/resolution/disambiguation.cpp
+++ b/frontend/lib/resolution/disambiguation.cpp
@@ -316,13 +316,12 @@ static void gatherVecsByReturnIntent(const DisambiguationContext& dctx,
 
 static const MostSpecificCandidates&
 findMostSpecificCandidatesQuery(Context* context,
-                                std::vector<const TypedFnSignature*> lst,
-                                std::vector<QualifiedType> forwardingInfo,
+                                CandidatesAndForwardingInfo lst,
                                 CallInfo call,
                                 const Scope* callInScope,
                                 const PoiScope* callInPoiScope) {
   QUERY_BEGIN(findMostSpecificCandidatesQuery, context,
-              lst, forwardingInfo, call, callInScope, callInPoiScope);
+              lst, call, callInScope, callInPoiScope);
 
   // Construct the DisambiguationContext
   bool explain = true;
@@ -336,11 +335,11 @@ findMostSpecificCandidatesQuery(Context* context,
     int n = lst.size();
     for (int i = 0; i < n; i++) {
       QualifiedType forwardingTo;
-      if (!forwardingInfo.empty()) {
-        forwardingTo = forwardingInfo[i];
+      if (lst.hasForwardingInfo()) {
+        forwardingTo = lst.getForwardingInfo(i);
       }
       candidates.push_back(
-          new DisambiguationCandidate(lst[i], forwardingTo, call, i));
+          new DisambiguationCandidate(lst.get(i), forwardingTo, call, i));
     }
   }
 
@@ -359,8 +358,7 @@ findMostSpecificCandidatesQuery(Context* context,
 // entry point for disambiguation
 MostSpecificCandidates
 findMostSpecificCandidates(Context* context,
-                           const std::vector<const TypedFnSignature*>& lst,
-                           const std::vector<QualifiedType>& forwardingInfo,
+                           const CandidatesAndForwardingInfo& lst,
                            const CallInfo& call,
                            const Scope* callInScope,
                            const PoiScope* callInPoiScope) {
@@ -371,7 +369,8 @@ findMostSpecificCandidates(Context* context,
 
   if (lst.size() == 1) {
     // If there is just one candidate, return it
-    auto msc = MostSpecificCandidate::fromTypedFnSignature(context, lst[0], call);
+    auto msc =
+        MostSpecificCandidate::fromTypedFnSignature(context, lst.get(0), call);
     return MostSpecificCandidates::getOnly(msc);
   }
 
@@ -379,8 +378,7 @@ findMostSpecificCandidates(Context* context,
   // run the query to handle the more complex case
   // TODO: is it worth storing this in a query? Or should
   // we recompute it each time?
-  return findMostSpecificCandidatesQuery(context, lst, forwardingInfo,
-                                         call,
+  return findMostSpecificCandidatesQuery(context, lst, call,
                                          callInScope, callInPoiScope);
 }
 

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -31,6 +31,7 @@
 #include "chpl/resolution/scope-queries.h"
 #include "chpl/types/all-types.h"
 #include "chpl/uast/all-uast.h"
+#include "chpl/util/hash.h"
 
 #include "Resolver.h"
 #include "call-init-deinit.h"
@@ -56,11 +57,6 @@ namespace resolution {
 
 using namespace uast;
 using namespace types;
-
-// TODO: Since these are always used together with corresponding indices, tie
-// them together in a tuple or new data structure.
-using CandidatesVec = std::vector<const TypedFnSignature*>;
-using ForwardingInfoVec = std::vector<QualifiedType>;
 
 const ResolutionResultByPostorderID& resolveModuleStmt(Context* context,
                                                        ID id) {
@@ -2429,22 +2425,21 @@ isCandidateApplicableInitialQuery(Context* context,
   return QUERY_END(result);
 }
 
-static const std::pair<std::vector<const TypedFnSignature*>,
+static const std::pair<CandidatesAndForwardingInfo,
                        std::vector<ApplicabilityResult>>&
 filterCandidatesInitialGatherRejected(Context* context,
                                       std::vector<BorrowedIdsWithName> lst,
-                                      CallInfo call,
-                                      bool gatherRejected) {
+                                      CallInfo call, bool gatherRejected) {
   QUERY_BEGIN(filterCandidatesInitialGatherRejected, context, lst, call, gatherRejected);
 
-  std::vector<const TypedFnSignature*> matching;
+  CandidatesAndForwardingInfo matching;
   std::vector<ApplicabilityResult> rejected;
 
   for (const BorrowedIdsWithName& ids : lst) {
     for (const ID& id : ids) {
       auto s = isCandidateApplicableInitialQuery(context, id, call);
       if (s.success()) {
-        matching.push_back(s.candidate());
+        matching.addCandidate(s.candidate());
       } else if (gatherRejected) {
         rejected.push_back(s);
       }
@@ -2455,7 +2450,7 @@ filterCandidatesInitialGatherRejected(Context* context,
   return QUERY_END(result);
 }
 
-const std::vector<const TypedFnSignature*>&
+const CandidatesAndForwardingInfo&
 filterCandidatesInitial(Context* context,
                         std::vector<BorrowedIdsWithName> lst,
                         CallInfo call) {
@@ -2466,11 +2461,11 @@ filterCandidatesInitial(Context* context,
 
 void
 filterCandidatesInstantiating(Context* context,
-                              const std::vector<const TypedFnSignature*>& lst,
+                              const CandidatesAndForwardingInfo& lst,
                               const CallInfo& call,
                               const Scope* inScope,
                               const PoiScope* inPoiScope,
-                              std::vector<const TypedFnSignature*>& result,
+                              CandidatesAndForwardingInfo& result,
                               std::vector<ApplicabilityResult>* rejected) {
 
   // Performance: Would it help to make this a query?
@@ -2491,13 +2486,13 @@ filterCandidatesInstantiating(Context* context,
                                              call,
                                              instantiationPoiScope);
       if (instantiated.success()) {
-        result.push_back(instantiated.candidate());
+        result.addCandidate(instantiated.candidate());
       } if (rejected) {
         rejected->push_back(std::move(instantiated));
       }
     } else {
       // if it's already concrete, we already know it is a candidate.
-      result.push_back(typedSignature);
+      result.addCandidate(typedSignature);
     }
   }
 }
@@ -2970,10 +2965,9 @@ static bool resolveFnCallSpecialType(Context* context,
   return false;
 }
 
-static void buildReaderWriterTypeCtor(Context* context,
-                                      const CallInfo& ci,
-                                      const TypedFnSignature* initial,
-                                      CandidatesVec& initialCandidates) {
+static void buildReaderWriterTypeCtor(
+    Context* context, const CallInfo& ci, const TypedFnSignature* initial,
+    CandidatesAndForwardingInfo& initialCandidates) {
   std::vector<UntypedFnSignature::FormalDetail> formals;
   // Move 'kind' to the end and allow the first two args to just be
   // 'locking' and  '(de)serializerType'
@@ -3015,7 +3009,7 @@ static void buildReaderWriterTypeCtor(Context* context,
                                       /* parentFn */ nullptr,
                                       /* formalsInstantiated */ Bitmap());
 
-  initialCandidates.push_back(result);
+  initialCandidates.addCandidate(result);
 }
 
 static MostSpecificCandidates
@@ -3025,14 +3019,14 @@ resolveFnCallForTypeCtor(Context* context,
                          const PoiScope* inPoiScope,
                          PoiInfo& poiInfo) {
 
-  CandidatesVec initialCandidates;
-  CandidatesVec candidates;
+  CandidatesAndForwardingInfo initialCandidates;
+  CandidatesAndForwardingInfo candidates;
 
   CHPL_ASSERT(ci.calledType().type() != nullptr);
   CHPL_ASSERT(!ci.calledType().type()->isUnknownType());
 
   auto initial = typeConstructorInitial(context, ci.calledType().type());
-  initialCandidates.push_back(initial);
+  initialCandidates.addCandidate(initial);
 
   //
   // Adds an alternative type constructor for fileReader/Writer to support
@@ -3059,14 +3053,10 @@ resolveFnCallForTypeCtor(Context* context,
                                 /* rejected */ nullptr);
 
 
-  ForwardingInfoVec forwardingInfo;
-
   // find most specific candidates / disambiguate
   // Note: at present there can only be one candidate here
   MostSpecificCandidates mostSpecific =
-    findMostSpecificCandidates(context,
-                               candidates, forwardingInfo,
-                               ci, inScope, inPoiScope);
+      findMostSpecificCandidates(context, candidates, ci, inScope, inPoiScope);
 
   return mostSpecific;
 }
@@ -3076,7 +3066,7 @@ considerCompilerGeneratedCandidates(Context* context,
                                    const CallInfo& ci,
                                    const Scope* inScope,
                                    const PoiScope* inPoiScope,
-                                   CandidatesVec& candidates) {
+                                   CandidatesAndForwardingInfo& candidates) {
 
   // only consider compiler-generated methods and opcalls, for now
   if (!ci.isMethodCall() && !ci.isOpCall()) return;
@@ -3106,7 +3096,7 @@ considerCompilerGeneratedCandidates(Context* context,
 
   // OK, already concrete, store and return
   if (!tfs->needsInstantiation()) {
-    candidates.push_back(tfs);
+    candidates.addCandidate(tfs);
     return;
   }
 
@@ -3120,7 +3110,7 @@ considerCompilerGeneratedCandidates(Context* context,
   CHPL_ASSERT(instantiated.candidate()->untyped()->idIsFunction());
   CHPL_ASSERT(instantiated.candidate()->instantiatedFrom());
 
-  candidates.push_back(instantiated.candidate());
+  candidates.addCandidate(instantiated.candidate());
 }
 
 static std::vector<BorrowedIdsWithName>
@@ -3167,18 +3157,6 @@ lookupCalledExpr(Context* context,
   return ret;
 }
 
-static void helpComputeForwardingTo(const CallInfo& fci,
-                                    size_t start,
-                                    const CandidatesVec& candidates,
-                                    std::vector<QualifiedType>& forwardingTo) {
-  QualifiedType forwardingReceiverActualType = fci.calledType();
-  size_t n = candidates.size();
-  forwardingTo.resize(start);
-  for (size_t i = start; i < n; i++) {
-    forwardingTo.push_back(forwardingReceiverActualType);
-  }
-}
-
 // Container for ordering groups of last resort candidates by resolution
 // preference.
 struct LastResortCandidateGroups {
@@ -3189,16 +3167,9 @@ struct LastResortCandidateGroups {
     // merge non-poi candidate group and forwarding info
     if (other.nonPoi) {
       if (nonPoi) {
-        nonPoi->insert(nonPoi->end(),
-                       std::make_move_iterator(other.nonPoi->begin()),
-                       std::make_move_iterator(other.nonPoi->end()));
-        nonPoiForwardingInfo.insert(
-            nonPoiForwardingInfo.end(),
-            std::make_move_iterator(other.nonPoiForwardingInfo.begin()),
-            std::make_move_iterator(other.nonPoiForwardingInfo.end()));
+        nonPoi->takeFromOther(*other.nonPoi);
       } else {
         nonPoi = std::move(other.nonPoi);
-        nonPoiForwardingInfo = std::move(other.nonPoiForwardingInfo);
       }
     }
 
@@ -3207,20 +3178,12 @@ struct LastResortCandidateGroups {
          i++) {
       if (i < this->poi.size() && i < other.poi.size()) {
         // both have a poi candidates group at this index
-        this->poi[i].insert(this->poi[i].end(),
-                            std::make_move_iterator(other.poi[i].begin()),
-                            std::make_move_iterator(other.poi[i].end()));
-        this->poiForwardingInfo[i].insert(
-            this->poiForwardingInfo[i].end(),
-            std::make_move_iterator(other.poiForwardingInfo[i].begin()),
-            std::make_move_iterator(other.poiForwardingInfo[i].end()));
+        this->poi[i].takeFromOther(other.poi[i]);
       } else if (i < this->poi.size()) {
         // only this one has a group here, nothing to do
       } else {
         // only the other has a group
         this->poi.push_back(std::move(other.poi[i]));
-        this->poiForwardingInfo.push_back(
-            std::move(other.poiForwardingInfo[i]));
       }
     }
 
@@ -3249,55 +3212,39 @@ struct LastResortCandidateGroups {
   //   with, and set to the end of the non-poi candidates if they are returned.
   // - forwardingInfo: Forwarding info for the returned group, set if it comes
   //   from forwarding.
-  const CandidatesVec firstNonEmptyCandidatesGroup(
-      size_t* firstPoiCandidate, ForwardingInfoVec* forwardingInfo,
-      bool inForwardingGroups = false) const {
+  const CandidatesAndForwardingInfo firstNonEmptyCandidatesGroup(
+      size_t* firstPoiCandidate) const {
     if (nonPoi && !nonPoi->empty()) {
       *firstPoiCandidate = nonPoi->size();
-      if (inForwardingGroups) *forwardingInfo = nonPoiForwardingInfo;
       return *nonPoi;
     }
     for (size_t i = 0; i < poi.size(); i++) {
       if (!poi[i].empty()) {
-        if (inForwardingGroups) *forwardingInfo = poiForwardingInfo[i];
         return poi[i];
       }
     }
     if (forwardingCandidateGroups) {
       return forwardingCandidateGroups->firstNonEmptyCandidatesGroup(
-          firstPoiCandidate, forwardingInfo, /* inForwardingGroups */ true);
+          firstPoiCandidate);
     }
-    return CandidatesVec();
+    return CandidatesAndForwardingInfo();
   }
 
-  void addNonPoiCandidates(CandidatesVec&& group,
-                           ForwardingInfoVec* forwardingInfo = nullptr) {
+  void addNonPoiCandidates(CandidatesAndForwardingInfo&& group) {
     CHPL_ASSERT(!nonPoi && "non poi candidates already set");
     this->nonPoi = std::move(group);
-    if (forwardingInfo) {
-      this->nonPoiForwardingInfo = *forwardingInfo;
-    }
   }
 
-  void addPoiCandidates(CandidatesVec&& group,
-                        ForwardingInfoVec* forwardingInfo = nullptr) {
+  void addPoiCandidates(CandidatesAndForwardingInfo&& group) {
     CHPL_ASSERT(nonPoi && "setting poi candidates before non poi");
     this->poi.push_back(std::move(group));
-    if (forwardingInfo) {
-      this->poiForwardingInfo.push_back(*forwardingInfo);
-    }
   }
 
  private:
   // Non-poi candidates (most preferred).
-  chpl::optional<CandidatesVec> nonPoi;
+  chpl::optional<CandidatesAndForwardingInfo> nonPoi;
   // Poi candidates from innermost (more preferred) to outermost scope.
-  std::vector<CandidatesVec> poi;
-  // Forwarding-to information for non-poi and poi candidates, respectively.
-  // These are used if this LastResortCandidateGroups is for candidates from
-  // forwarding.
-  ForwardingInfoVec nonPoiForwardingInfo;
-  std::vector<ForwardingInfoVec> poiForwardingInfo;
+  std::vector<CandidatesAndForwardingInfo> poi;
 
   // A LastResortCandidateGroups for candidates found via forwarding from the
   // site of the current group. This is effectively a linked list due to the
@@ -3308,15 +3255,15 @@ struct LastResortCandidateGroups {
 // Returns candidates with last resort candidates removed and saved in a
 // separate list.
 static void filterCandidatesLastResort(
-    Context* context, const CandidatesVec& list, CandidatesVec& result,
-    CandidatesVec& lastResort) {
+    Context* context, const CandidatesAndForwardingInfo& list, CandidatesAndForwardingInfo& result,
+    CandidatesAndForwardingInfo& lastResort) {
   for (auto& candidate : list) {
     auto attrs =
         parsing::idToAttributeGroup(context, candidate->untyped()->id());
     if (attrs && attrs->hasPragma(PRAGMA_LAST_RESORT)) {
-      lastResort.push_back(candidate);
+      lastResort.addCandidate(candidate);
     } else {
-      result.push_back(candidate);
+      result.addCandidate(candidate);
     }
   }
 }
@@ -3333,10 +3280,8 @@ gatherAndFilterCandidatesForwarding(Context* context,
                                     const CallInfo& ci,
                                     const Scope* inScope,
                                     const PoiScope* inPoiScope,
-                                    CandidatesVec& nonPoiCandidates,
-                                    CandidatesVec& poiCandidates,
-                                    ForwardingInfoVec& nonPoiForwardingTo,
-                                    ForwardingInfoVec& poiForwardingTo,
+                                    CandidatesAndForwardingInfo& nonPoiCandidates,
+                                    CandidatesAndForwardingInfo& poiCandidates,
                                     LastResortCandidateGroups& lrcGroups) {
 
   const Type* receiverType = ci.actual(0).type().type();
@@ -3416,7 +3361,7 @@ gatherAndFilterCandidatesForwarding(Context* context,
       considerCompilerGeneratedCandidates(context, fci, inScope, inPoiScope,
                                           nonPoiCandidates);
       // update forwardingTo
-      helpComputeForwardingTo(fci, start, nonPoiCandidates, nonPoiForwardingTo);
+      nonPoiCandidates.helpComputeForwardingTo(fci, start);
 
       // don't worry about last resort for compiler generated candidates
     }
@@ -3424,8 +3369,7 @@ gatherAndFilterCandidatesForwarding(Context* context,
     // next, look for candidates without using POI.
     {
       int i = 0;
-      CandidatesVec newLrcGroup;
-      ForwardingInfoVec newLrcForwardingTo;
+      CandidatesAndForwardingInfo newLrcGroup;
       for (const auto& fci : forwardingCis) {
         size_t start = nonPoiCandidates.size();
         // compute the potential functions that it could resolve to
@@ -3436,7 +3380,7 @@ gatherAndFilterCandidatesForwarding(Context* context,
           filterCandidatesInitial(context, std::move(v), fci);
 
         // find candidates, doing instantiation if necessary
-        CandidatesVec candidatesWithInstantiations;
+        CandidatesAndForwardingInfo candidatesWithInstantiations;
         filterCandidatesInstantiating(context,
                                       initialCandidates,
                                       fci,
@@ -3450,13 +3394,11 @@ gatherAndFilterCandidatesForwarding(Context* context,
                                    nonPoiCandidates, newLrcGroup);
 
         // update forwardingTo (for candidates and last resort candidates)
-        helpComputeForwardingTo(fci, start,
-                                nonPoiCandidates, nonPoiForwardingTo);
-        helpComputeForwardingTo(fci, start, newLrcGroup, newLrcForwardingTo);
+        nonPoiCandidates.helpComputeForwardingTo(fci, start);
+        newLrcGroup.helpComputeForwardingTo(fci, start);
         i++;
       }
-      lrcGroups.addNonPoiCandidates(std::move(newLrcGroup),
-                                    &newLrcForwardingTo);
+      lrcGroups.addNonPoiCandidates(std::move(newLrcGroup));
     }
 
     // next, look for candidates using POI
@@ -3471,8 +3413,7 @@ gatherAndFilterCandidatesForwarding(Context* context,
 
 
       int i = 0;
-      CandidatesVec newLrcGroup;
-      ForwardingInfoVec newLrcForwardingTo;
+      CandidatesAndForwardingInfo newLrcGroup;
       for (const auto& fci : forwardingCis) {
         size_t start = poiCandidates.size();
 
@@ -3484,7 +3425,7 @@ gatherAndFilterCandidatesForwarding(Context* context,
           filterCandidatesInitial(context, std::move(v), fci);
 
         // find candidates, doing instantiation if necessary
-        CandidatesVec candidatesWithInstantiations;
+        CandidatesAndForwardingInfo candidatesWithInstantiations;
         filterCandidatesInstantiating(context,
                                       initialCandidates,
                                       fci,
@@ -3498,11 +3439,11 @@ gatherAndFilterCandidatesForwarding(Context* context,
                                    poiCandidates, newLrcGroup);
 
         // update forwardingTo (for candidates and last resort candidates)
-        helpComputeForwardingTo(fci, start, poiCandidates, poiForwardingTo);
-        helpComputeForwardingTo(fci, start, newLrcGroup, newLrcForwardingTo);
+        poiCandidates.helpComputeForwardingTo(fci, start);
+        newLrcGroup.helpComputeForwardingTo(fci, start);
         i++;
       }
-      lrcGroups.addPoiCandidates(std::move(newLrcGroup), &newLrcForwardingTo);
+      lrcGroups.addPoiCandidates(std::move(newLrcGroup));
     }
 
     // If no candidates were found and it's a method, try forwarding
@@ -3517,8 +3458,6 @@ gatherAndFilterCandidatesForwarding(Context* context,
                                                 inScope, inPoiScope,
                                                 nonPoiCandidates,
                                                 poiCandidates,
-                                                nonPoiForwardingTo,
-                                                poiForwardingTo,
                                                 thisForwardingLrcGroups);
           }
         }
@@ -3566,16 +3505,15 @@ static bool isInsideForwarding(Context* context, const Call* call) {
 // If forwarding is used, it will have an element for each of the returned
 // candidates and will indicate the actual type that is passed
 // to the 'this' receiver formal.
-static CandidatesVec
+static CandidatesAndForwardingInfo
 gatherAndFilterCandidates(Context* context,
                           const Call* call,
                           const CallInfo& ci,
                           const Scope* inScope,
                           const PoiScope* inPoiScope,
                           size_t& firstPoiCandidate,
-                          ForwardingInfoVec& forwardingInfo,
                           std::vector<ApplicabilityResult>* rejected) {
-  CandidatesVec candidates;
+  CandidatesAndForwardingInfo candidates;
   LastResortCandidateGroups lrcGroups;
   CheckedScopes visited;
   firstPoiCandidate = 0;
@@ -3608,7 +3546,7 @@ gatherAndFilterCandidates(Context* context,
     }
 
     // find candidates, doing instantiation if necessary
-    CandidatesVec candidatesWithInstantiations;
+    CandidatesAndForwardingInfo candidatesWithInstantiations;
     filterCandidatesInstantiating(context,
                                   initialCandidates,
                                   ci,
@@ -3618,7 +3556,7 @@ gatherAndFilterCandidates(Context* context,
                                   rejected);
 
     // filter out last resort candidates
-    CandidatesVec lrcGroup;
+    CandidatesAndForwardingInfo lrcGroup;
     filterCandidatesLastResort(context, candidatesWithInstantiations,
                                candidates, lrcGroup);
     lrcGroups.addNonPoiCandidates(std::move(lrcGroup));
@@ -3651,7 +3589,7 @@ gatherAndFilterCandidates(Context* context,
     }
 
     // find candidates, doing instantiation if necessary
-    CandidatesVec candidatesWithInstantiations;
+    CandidatesAndForwardingInfo candidatesWithInstantiations;
     filterCandidatesInstantiating(context,
                                   initialCandidates,
                                   ci,
@@ -3661,7 +3599,7 @@ gatherAndFilterCandidates(Context* context,
                                   rejected);
 
     // filter out last resort candidates
-    CandidatesVec lrcGroup;
+    CandidatesAndForwardingInfo lrcGroup;
     filterCandidatesLastResort(context, candidatesWithInstantiations,
                                candidates, lrcGroup);
     lrcGroups.addPoiCandidates(std::move(lrcGroup));
@@ -3692,36 +3630,22 @@ gatherAndFilterCandidates(Context* context,
 
     if (typeUsesForwarding(context, receiverType) &&
         !isInsideForwarding(context, call)) {
-      CandidatesVec nonPoiCandidates;
-      CandidatesVec poiCandidates;
-      ForwardingInfoVec nonPoiForwardingTo;
-      ForwardingInfoVec poiForwardingTo;
+      CandidatesAndForwardingInfo nonPoiCandidates;
+      CandidatesAndForwardingInfo poiCandidates;
 
       gatherAndFilterCandidatesForwarding(
           context, call, ci, inScope, inPoiScope, nonPoiCandidates,
-          poiCandidates, nonPoiForwardingTo, poiForwardingTo,
-          lrcGroups.getForwardingGroups());
+          poiCandidates, lrcGroups.getForwardingGroups());
 
-      // append non-poi candidates
-      candidates.insert(candidates.end(),
-                        nonPoiCandidates.begin(), nonPoiCandidates.end());
-      forwardingInfo.insert(forwardingInfo.end(),
-                            nonPoiForwardingTo.begin(),
-                            nonPoiForwardingTo.end());
-      // append poi candidates
-      firstPoiCandidate = candidates.size();
-      candidates.insert(candidates.end(),
-                        poiCandidates.begin(), poiCandidates.end());
-      forwardingInfo.insert(forwardingInfo.end(),
-                            poiForwardingTo.begin(),
-                            poiForwardingTo.end());
+      // append candidates from forwarding
+      candidates.takeFromOther(nonPoiCandidates);
+      candidates.takeFromOther(poiCandidates);
     }
   }
 
   // If no candidates have been found, consider last resort candidates.
   if (candidates.empty()) {
-    candidates = lrcGroups.firstNonEmptyCandidatesGroup(&firstPoiCandidate,
-                                                        &forwardingInfo);
+    candidates = lrcGroups.firstNonEmptyCandidatesGroup(&firstPoiCandidate);
   }
 
   return candidates;
@@ -3732,8 +3656,7 @@ gatherAndFilterCandidates(Context* context,
 // * gather POI info from any instantiations
 static MostSpecificCandidates
 findMostSpecificAndCheck(Context* context,
-                         const CandidatesVec& candidates,
-                         const ForwardingInfoVec& forwardingInfo,
+                         const CandidatesAndForwardingInfo& candidates,
                          size_t firstPoiCandidate,
                          const Call* call,
                          const CallInfo& ci,
@@ -3743,8 +3666,7 @@ findMostSpecificAndCheck(Context* context,
 
   // find most specific candidates / disambiguate
   MostSpecificCandidates mostSpecific =
-    findMostSpecificCandidates(context, candidates, forwardingInfo,
-                               ci, inScope, inPoiScope);
+      findMostSpecificCandidates(context, candidates, ci, inScope, inPoiScope);
 
   // perform fn signature checking for any instantiated candidates that are used
   for (const MostSpecificCandidate& candidate : mostSpecific) {
@@ -3758,7 +3680,7 @@ findMostSpecificAndCheck(Context* context,
     size_t n = candidates.size();
     for (size_t i = firstPoiCandidate; i < n; i++) {
       for (const MostSpecificCandidate& candidate : mostSpecific) {
-        if (candidate.fn() == candidates[i]) {
+        if (candidate.fn() == candidates.get(i)) {
           poiInfo.addIds(call->id(), candidate.fn()->id());
         }
       }
@@ -3780,22 +3702,16 @@ resolveFnCallFilterAndFindMostSpecific(Context* context,
 
   // search for candidates at each POI until we have found candidate(s)
   size_t firstPoiCandidate = 0;
-  ForwardingInfoVec forwardingInfo;
-  CandidatesVec candidates = gatherAndFilterCandidates(context, call, ci,
-                                                       inScope, inPoiScope,
-                                                       firstPoiCandidate,
-                                                       forwardingInfo,
-                                                       rejected);
+  CandidatesAndForwardingInfo candidates = gatherAndFilterCandidates(
+      context, call, ci, inScope, inPoiScope, firstPoiCandidate, rejected);
 
   // * find most specific candidates / disambiguate
   // * check signatures
   // * gather POI info
 
   MostSpecificCandidates mostSpecific =
-    findMostSpecificAndCheck(context,
-                             candidates, forwardingInfo, firstPoiCandidate,
-                             call, ci,
-                             inScope, inPoiScope, poiInfo);
+      findMostSpecificAndCheck(context, candidates, firstPoiCandidate, call, ci,
+                               inScope, inPoiScope, poiInfo);
 
   return mostSpecific;
 }

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -763,6 +763,19 @@ void TypedFnSignature::stringify(std::ostream& ss,
   ss << ")";
 }
 
+void CandidatesAndForwardingInfo::stringify(
+    std::ostream& ss, chpl::StringifyKind stringKind) const {
+  ss << "CandidatesAndForwardingInfo: ";
+  ss << "(candidates) ";
+  for (const auto& candidate : candidates) {
+    candidate->stringify(ss, stringKind);
+  }
+  ss << "(forwarding info) ";
+  for (const auto& info : forwardingInfo) {
+    info.stringify(ss, stringKind);
+  }
+}
+
 void CallInfoActual::stringify(std::ostream& ss,
                                chpl::StringifyKind stringKind) const {
   if (!byName_.isEmpty()) {


### PR DESCRIPTION
Replace usage of `CandidatesVec` and `ForwardingInfoVec` with a new `struct CandidatesAndForwardingInfo` that combines the two, as they are nearly always used together.

Use of the forwarding info part of `CandidatesAndForwardingInfo` is optional since sometimes we don't care about it.

Follow up to https://github.com/chapel-lang/chapel/pull/24282.

[reviewer info placeholder]

Testing:
- [x] paratest
- [x] dyno tests