### PR TITLE
Fix cpu-only test for assertOnGpu

### DIFF
--- a/test/gpu/native/noGpu/assertOnGpu-do-assert.good
+++ b/test/gpu/native/noGpu/assertOnGpu-do-assert.good
@@ -1,2 +1,2 @@
 assertOnGpu.chpl:X: error: Loop is marked with @assertOnGpu but is not eligible for execution on a GPU
-assertOnGpu.chpl:X: note: call has outer var access
+assertOnGpu.chpl:X: note: use of ineligible standard library function 'writeln' in loop body

--- a/test/gpu/native/noGpu/assertOnGpu.prediff
+++ b/test/gpu/native/noGpu/assertOnGpu.prediff
@@ -1,4 +1,5 @@
 #!/bin/sh
 
-sed -i -e 's/chpl:[[:digit:]]\+:/chpl:X:/' $2
-
+if sed -e 's/chpl:[[:digit:]][[:digit:]]*:/chpl:X:/' $2 >$2.tmp; then
+    mv $2.tmp $2
+fi


### PR DESCRIPTION
The error message has improved, but I didn't catch the change because I was running a paratest on GPU-enabled machine.

## Testing
- [x] test passes locally and on test machines.