### PR TITLE
Remove uses of '\+' from invocations of sed.

### DIFF
--- a/test/gpu/native/diags.prediff
+++ b/test/gpu/native/diags.prediff
@@ -1,10 +1,10 @@
 #!/bin/sh
 
 sed -e 's/0x.*/0xPREDIFFED/' \
-    -e 's/\.chpl:[[:digit:]]\+:/.chpl:nn:/' \
-    -e '/allocate [[:digit:]]\+B of comm layer/d' \
-    -e '/allocate [[:digit:]]\+B of gpu layer/d' \
-    -e 's/allocate [[:digit:]]\+B of/allocate xxB of/' \
-    -e 's/free [[:digit:]]\+B of/free xxB of/' \
+    -e 's/\.chpl:[[:digit:]][[:digit:]]*:/.chpl:nn:/' \
+    -e '/allocate [[:digit:]][[:digit:]]*B of comm layer/d' \
+    -e '/allocate [[:digit:]][[:digit:]]*B of gpu layer/d' \
+    -e 's/allocate [[:digit:]][[:digit:]]*B of/allocate xxB of/' \
+    -e 's/free [[:digit:]][[:digit:]]*B of/free xxB of/' \
     -e '/^.*tasking layer unspecified data.*$/d' $2 > $2.tmp
 mv $2.tmp $2

--- a/test/gpu/native/reduction/stringError.prediff
+++ b/test/gpu/native/reduction/stringError.prediff
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-sed -e "s/\.chpl:[0-9]\+:/.chpl:prediffed:/" $2 > $2.tmp
+sed -e "s/\.chpl:[0-9][0-9]*:/.chpl:prediffed:/" $2 > $2.tmp
 mv $2.tmp $2

--- a/test/gpu/native/savec.prediff
+++ b/test/gpu/native/savec.prediff
@@ -2,5 +2,5 @@
 
 # Get list of all .o and .s files. Exclude 'savec.tmp_launcher.o' since we want this test
 # to pass regardless of whether a launcher is being used or not.
-find savec_dir -type f -name "*.o" -o -name "*.s" | grep -v -e "savec\.tmp_launcher\.o" -e "chpl__gpu.\+\.o" | sort >> $2
+find savec_dir -type f -name "*.o" -o -name "*.s" | grep -v -e "savec\.tmp_launcher\.o" -e "chpl__gpu..*\.o" | sort >> $2
 find savec_dir -type f -name "chpl__gpu_*.o" | sort >> $2

--- a/test/localeModels/gbt/maxTaskPar.prediff
+++ b/test/localeModels/gbt/maxTaskPar.prediff
@@ -7,9 +7,9 @@ tasks=$($CHPL_HOME/util/chplenv/chpl_tasks.py)
 
 function cores_from_lscpu_or_proc_cpuinfo() {
   numCoresPerSocket=$( lscpu 2>/dev/null | grep -m 1 '^Core(s) per socket:' |
-                       sed 's/^[^0-9]*\([0-9]\+\).*$/\1/' )
+                       sed 's/^[^0-9]*\([0-9][0-9]*\).*$/\1/' )
   numSockets=$( lscpu 2>/dev/null | grep -m 1 '^Socket(s):' |
-                sed 's/^[^0-9]*\([0-9]\+\).*$/\1/' )
+                sed 's/^[^0-9]*\([0-9][0-9]*\).*$/\1/' )
   if [[ -n $numCoresPerSocket && -n $numSockets ]] ; then
     numCores=$(( $numCoresPerSocket * $numSockets ))
     return
@@ -27,11 +27,11 @@ function cores_from_lscpu_or_proc_cpuinfo() {
     #   (This is broken in cygwin at least sometimes.)   Otherwise,
     #   "siblings"/"cpu cores" is the logical/physical CPU ratio.
     #
-    numPUs=$( grep -c '^processor[[:space:]]\+: ' /proc/cpuinfo )
-    numCores1=$( grep -m 1 '^cpu cores[[:space:]]\+: ' /proc/cpuinfo |
-                 sed 's/^[^[:digit:]]*\([[:digit:]]\+\).*$/\1/' )
-    numSibs1=$( grep -m 1 '^siblings[[:space:]]\+: ' /proc/cpuinfo |
-                sed 's/^[^[:digit:]]*\([[:digit:]]\+\).*$/\1/' )
+    numPUs=$( grep -c '^processor[[:space:]][[:space:]]*: ' /proc/cpuinfo )
+    numCores1=$( grep -m 1 '^cpu cores[[:space:]][[:space:]]*: ' /proc/cpuinfo |
+                 sed 's/^[^[:digit:]]*\([[:digit:]][[:digit:]]*\).*$/\1/' )
+    numSibs1=$( grep -m 1 '^siblings[[:space:]][[:space:]]*: ' /proc/cpuinfo |
+                sed 's/^[^[:digit:]]*\([[:digit:]][[:digit:]]*\).*$/\1/' )
     if [[ -z $numCores1 || -z $numSibs1 ]] ; then
       numCores=$numPUs
     else

--- a/test/runtime/gbt/numThreadsSymbolicLogical.prediff
+++ b/test/runtime/gbt/numThreadsSymbolicLogical.prediff
@@ -1,4 +1,4 @@
 #! /bin/bash -norc
-numPUs=$( grep -c '^processor[[:space:]]\+: ' /proc/cpuinfo )
+numPUs=$( grep -c '^processor[[:space:]][[:space:]]*: ' /proc/cpuinfo )
 
 echo $numPUs > $1.good

--- a/test/runtime/gbt/numThreadsSymbolicPhysical.prediff
+++ b/test/runtime/gbt/numThreadsSymbolicPhysical.prediff
@@ -1,18 +1,18 @@
 #! /bin/bash -norc
 numCoresPerSocket=$( lscpu 2>/dev/null | grep -m 1 '^Core(s) per socket:' |
-                     sed 's/^[^0-9]*\([0-9]\+\).*$/\1/' )
+                     sed 's/^[^0-9]*\([0-9][0-9]*\).*$/\1/' )
 numSockets=$( lscpu 2>/dev/null | grep -m 1 '^Socket(s):' |
-              sed 's/^[^0-9]*\([0-9]\+\).*$/\1/' )
+              sed 's/^[^0-9]*\([0-9][0-9]*\).*$/\1/' )
 if [[ -n $numCoresPerSocket && -n $numSockets ]] ; then
   numCores=$(( $numCoresPerSocket * $numSockets ))
   echo $numCores > $1.good
   exit 0
 fi
-numPUs=$( grep -c '^processor[[:space:]]\+: ' /proc/cpuinfo )
-numCores1=$( grep -m 1 '^cpu cores[[:space:]]\+: ' /proc/cpuinfo |
-             sed 's/^[^0-9]*\([0-9]\+\).*$/\1/' )
-numSibs1=$( grep -m 1 '^siblings[[:space:]]\+: ' /proc/cpuinfo |
-            sed 's/^[^0-9]*\([0-9]\+\).*$/\1/' )
+numPUs=$( grep -c '^processor[[:space:]][[:space:]]*: ' /proc/cpuinfo )
+numCores1=$( grep -m 1 '^cpu cores[[:space:]][[:space:]]*: ' /proc/cpuinfo |
+             sed 's/^[^0-9]*\([0-9][0-9]*\).*$/\1/' )
+numSibs1=$( grep -m 1 '^siblings[[:space:]][[:space:]]*: ' /proc/cpuinfo |
+            sed 's/^[^0-9]*\([0-9][0-9]*\).*$/\1/' )
 if [[ -z $numCores1 || -z $numSibs1 ]] ; then
   numCores=$numPUs
 else

--- a/test/studies/lsms/shemmy/m-lsms.par-forall.prediff
+++ b/test/studies/lsms/shemmy/m-lsms.par-forall.prediff
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-sed 's@([0-9]\+)@(NNN)@' < $2 > $2.tmp
+sed 's@([0-9][0-9]*)@(NNN)@' < $2 > $2.tmp
 cp $2.tmp $2
 echo original output is preserved in $2.tmp


### PR DESCRIPTION
'\+' is a GNU extension and doesn't work on some platforms, including macOS. Replace it with the standard `*` using the equivalence `a+` <-> `aa*`.

Reviewed by @jabraham17 -- thanks!

## Testing
- [x] paratest
- [x] `test/gpu/native`