### PR TITLE
Add 'getFile()' to 'fileReader' and 'fileWriter'

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -2483,6 +2483,18 @@ class _serializeWrapper : writeSerializable {
   }
 }
 
+// Get the internal file, bump its reference count, and wrap it in a 'file'.
+private inline
+proc chpl_fileFromReaderOrWriter(readerOrWriter): file {
+  var fp: qio_file_ptr_t;
+  qio_channel_get_file_ptr(readerOrWriter._channel_internal, fp);
+  qio_file_retain(fp);
+  var ret: file;
+  ret._home = readerOrWriter._home;
+  ret._file_internal = fp;
+  return ret;
+}
+
 /*
 
 A ``fileReader`` supports sequential reading from an underlying :record:`file`
@@ -2540,6 +2552,12 @@ record fileReader {
   @chpldoc.nodoc
   var _readWriteThisFromLocale = nilLocale;
 }
+
+/**
+  Get the :record:`file` type underlying a :record:`fileReader`.
+*/
+@unstable("The 'fileReader.getFile()' method may change based on feedback")
+proc fileReader.getFile() do return chpl_fileFromReaderOrWriter(this);
 
 pragma "ignore deprecated use"
 @chpldoc.nodoc
@@ -2632,6 +2650,12 @@ proc fileWriter._kind param do return kind;
 proc fileWriter.writing param: bool {
   return true;
 }
+
+/**
+  Get the :record:`file` type underlying a :record:`fileWriter`.
+*/
+@unstable("The 'fileWriter.getFile()' method may change based on feedback")
+proc fileWriter.getFile() do return chpl_fileFromReaderOrWriter(this);
 
 @chpldoc.nodoc
 proc fileWriter._writing param: bool do return true;

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -2553,7 +2553,7 @@ record fileReader {
   var _readWriteThisFromLocale = nilLocale;
 }
 
-/**
+/*
   Get the :record:`file` type underlying a :record:`fileReader`.
 */
 @unstable("The 'fileReader.getFile()' method may change based on feedback")
@@ -2651,7 +2651,7 @@ proc fileWriter.writing param: bool {
   return true;
 }
 
-/**
+/*
   Get the :record:`file` type underlying a :record:`fileWriter`.
 */
 @unstable("The 'fileWriter.getFile()' method may change based on feedback")

--- a/test/library/standard/IO/FileReaderOrWriterGetFile.chpl
+++ b/test/library/standard/IO/FileReaderOrWriterGetFile.chpl
@@ -1,0 +1,33 @@
+use IO;
+
+proc main() {
+  var f1 = openTempFile();
+  var fr1 = f1.reader();
+  var fw1 = f1.writer();
+
+  {
+    fw1.write('Hello!');
+    fw1.flush();
+
+    var f2 = fw1.getFile();
+    assert(f1 == f2);
+
+    var fr2 = f2.reader();
+    var s: string;
+    fr2.readAll(s);
+    assert(s == 'Hello!');
+  }
+
+  {
+    var f3 = fr1.getFile();
+    assert(f3 == f1);
+
+    var fw3 = f3.writer();
+    fw3.write('Super!');
+    fw3.flush();
+
+    var s: string;
+    fr1.readAll(s);
+    assert(s == 'Super!');
+  }
+}


### PR DESCRIPTION
Resolves #23066.

Add the `getFile()` method to the `fileReader` and `fileWriter` records. This method gets the underlying file the reader or writer is using.

The methods are marked as `@unstable` and indicate they may change based on feedback. The `@unstable` tag can be removed after a final review has occurred. The methods are named `getFile()` instead of `file()` due to name conflicts with the `IO.file` type that are a hassle to fix.

This PR is a patch from @mppf that has been adapted. Thanks, Michael!

TESTING

- [x] `linux64`, `standard`

Reviewed by @lydia-duncan. Thanks!