### PR TITLE
Stop testing release/examples with cpu-as-device until we fix an issue

### DIFF
--- a/util/cron/test-gpu-cpu.bash
+++ b/util/cron/test-gpu-cpu.bash
@@ -11,8 +11,10 @@ export CHPL_GPU=cpu
 export CHPL_COMM=none
 export CHPL_GPU_NO_CPU_MODE_WARNING=y
 
-# Now that we can run this config across release/examples, add it here
-export CHPL_NIGHTLY_TEST_DIRS="$CHPL_NIGHTLY_TEST_DIRS release/examples"
+# some tests in release/examples fail after adding the initial support for
+# distributed arrays. We need to have a fix for that before re-enabling
+# release/examples testing.
+# export CHPL_NIGHTLY_TEST_DIRS="$CHPL_NIGHTLY_TEST_DIRS release/examples"
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-cpu"
 $CWD/nightly -cron ${nightly_args}


### PR DESCRIPTION
https://github.com/chapel-lang/chapel/pull/24137 checked in some code that broke some distributed array cases in `release/examples`. This PR disables testing in that directory until we have a solution for the problem.

See https://github.com/Cray/chapel-private/issues/5926#issuecomment-1933054368 for more context.
My task for fixing the underlying issue: https://github.com/Cray/chapel-private/issues/5957