### PR TITLE
Load the rocm module late in a config to avoid picking wrong system LLVM

### DIFF
--- a/util/cron/test-perf.gpu-rocm.bash
+++ b/util/cron/test-perf.gpu-rocm.bash
@@ -6,8 +6,6 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-slurm-gasnet-cray-cs.bash
 source $CWD/common-native-gpu.bash
 
-module load rocm
-
 export CHPL_GPU=amd
 export CHPL_LAUNCHER_PARTITION=amdMI60
 export CHPL_GPU_ARCH=gfx906
@@ -20,6 +18,15 @@ source $CWD/common-native-gpu-perf.bash
 # make sure this comes after setting SUBDIR (set by native-gpu-perf) and
 # CONFIG_NAME
 source $CWD/common-perf.bash
+
+# everything we source above will end up sourcing `common.bash` which will then
+# source `load-base-deps.bash`. In the system we run this config,
+# `load-base-deps.bash` ends up exporting
+#   `CHPL_LLVM_CONFIG=(which # llvm-config)`
+# If `rocm` module is loaded, rocm's llvm-config takes precedence over our LLVM
+# install. We don't want that in this system. So `module load rocm` should
+# appear after all the `source`s.
+module load rocm
 
 
 nightly_args="${nightly_args} -startdate 07/20/23"


### PR DESCRIPTION
This should fix the performance testing for ROCm 4. The problem was, one of our dependency scripts is setting `CHPL_LLVM_CONFIG=$(which llvm-config)`. When it is run, we mustn't have the `rocm` module loaded, because then we end up choosing ROCm's LLVM. We don't want that for ROCm 4.x.

This PR adjusts the test config.