### PR TITLE
make sure any needed llvm targets built before dyno tests

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -174,6 +174,8 @@ test-frontend: FORCE frontend-tests $(CHPL_CONFIG_CHECK) $(COMPILER_BUILD)
 
 frontend-tests: $(CHPL_CONFIG_CHECK) $(COMPILER_BUILD)
 	@echo "Making the frontend tests..."
+	@cd ../third-party && $(MAKE) llvm
+	@cd ../third-party && $(MAKE) CHPL_MAKE_HOST_TARGET=--host jemalloc
 	@cd $(COMPILER_BUILD) && $(CMAKE) $(CHPL_MAKE_HOME) $(CMAKE_FLAGS_NO_NDEBUG) && $(MAKE) tests
 	@echo "Making symbolic link to frontend tests in build/frontend-test"
 	@cd ../build && rm -f frontend-test && ln -s $(COMPILER_BUILD)/frontend/test frontend-test


### PR DESCRIPTION
This PR updates the `frontend-tests` `make` target to ensure third-party deps are built before trying to build the tests. Prior to this, running `make clobber && make test-frontend` or `make clobber && make test-dyno` would produce an error from `cmake` about a linker path flag including a space. 

The `cmake` error is confusing. I believe it was caused because the third party llvm install dir didn't exist and that caused the flag value to be malformed. This remains a todo to fix.