### PR TITLE
Fix duplicate blockSize errors under GPU specialization

### DIFF
--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -1745,6 +1745,13 @@ static void reportErrorsForBadBlockSizeCalls() {
   CallExpr* explainAnchor = nullptr;
   for_alive_in_Vec(CallExpr, callExpr, gCallExprs) {
     if(callExpr->isPrimitive(PRIM_GPU_SET_BLOCKSIZE)) {
+      if (callExpr->getFunction()->hasFlag(FLAG_GPU_SPECIALIZATION)) {
+        // Assume that this primitive got here by being copied, and that the
+        // other location will error about it. Since both copies of the primitive
+        // will have the same location, erroring here would lead to duplicates.
+        continue;
+      }
+
       USR_FATAL_CONT(callExpr, "'setBlockSize' can only be used in bodies of GPU-eligible loops");
       explainAnchor = callExpr;
 


### PR DESCRIPTION
The bad `set blockSize` primitive gets copied during GPU specialization, which leads to duplicate errors about it. Simply stop warning if the bad primitive lives in a GPU specialization -- for it to be "bad", it must be outside of a loop, and if it's outside of a loop, it won't be removed or modified in the non-specialized function. Thus, the warning will be issued elsewhere.

Reviewed by @e-kayrakli -- thanks!