### PR TITLE
Dyno resolve calls to `this` on fields

### DIFF
--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -3484,7 +3484,6 @@ void Resolver::exit(const Dot* dot) {
   if (resolvingCalledDot && !scopeResolveOnly) {
     // We will handle it when resolving the FnCall.
 
-    gdbShouldBreakHere();
     // Try to resolve a it as a field/parenless proc so we can resolve 'this' on
     // it later if needed.
     if (!receiver.type().isUnknown() && receiver.type().type() &&

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -3479,12 +3479,12 @@ void Resolver::exit(const Dot* dot) {
 
   ResolvedExpression& receiver = byPostorder.byAst(dot->receiver());
 
-  bool resolvingCalledDot = (inLeafCall &&
-                             dot == inLeafCall->calledExpression());
-  if (resolvingCalledDot && !scopeResolveOnly) {
-    // we will handle it when resolving the FnCall
-    return;
-  }
+  /* bool resolvingCalledDot = (inLeafCall && */
+  /*                            dot == inLeafCall->calledExpression()); */
+  /* if (resolvingCalledDot && !scopeResolveOnly) { */
+  /*   // we will handle it when resolving the FnCall */
+  /*   return; */
+  /* } */
 
   if (dot->field() == USTR("type")) {
     const Type* receiverType;
@@ -3611,9 +3611,11 @@ void Resolver::exit(const Dot* dot) {
                       actuals);
   auto inScope = scopeStack.back();
   auto c = resolveGeneratedCall(context, dot, ci, inScope, poiScope);
-  // save the most specific candidates in the resolution result for the id
-  ResolvedExpression& r = byPostorder.byAst(dot);
-  handleResolvedCall(r, dot, ci, c);
+  if (!c.mostSpecific().isEmpty()) {
+    // save the most specific candidates in the resolution result for the id
+    ResolvedExpression& r = byPostorder.byAst(dot);
+    handleResolvedCall(r, dot, ci, c);
+  }
 }
 
 bool Resolver::enter(const New* node) {

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -322,10 +322,13 @@ CallInfo CallInfo::create(Context* context,
     }
   }
 
-  // Get the type of the called expression.
+  // Set up a method call if relevant.
   if (auto calledExpr = call->calledExpression()) {
+    // It shouldn't be possible to have definitions that could match either a
+    // normal method call or a call to 'this' on a field, so no need to
+    // disambiguate here; assume it'll be one or the other.
     if (byPostorder.hasAst(calledExpr)) {
-      // Construct a call to 'this' if relevant.
+      // If we have a resolved type for the expression, call its 'this'.
       const ResolvedExpression& r = byPostorder.byAst(calledExpr);
       calledType = r.type();
 
@@ -345,7 +348,7 @@ CallInfo CallInfo::create(Context* context,
         calledType = QualifiedType(QualifiedType::FUNCTION, nullptr);
       }
     } else if (!call->isOpCall()) {
-      // Check for method call, maybe construct a receiver.
+      // Check for normal method call, maybe construct a receiver.
       if (auto called = call->calledExpression()) {
         if (auto calledDot = called->toDot()) {
           const AstNode* receiver = calledDot->receiver();

--- a/frontend/test/resolution/testResolve.cpp
+++ b/frontend/test/resolution/testResolve.cpp
@@ -1168,6 +1168,36 @@ static void test21() {
   }
 }
 
+// Check calling implicit 'this' on a field.
+static void test22() {
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  std::string contents =
+      R""""(
+      module M {
+        record Inner {
+          proc this(arg: int) {
+            return arg;
+          }
+        }
+        record Outer {
+          var inner : Inner;
+        }
+        var outer : Outer;
+        var x = outer.inner(3);
+      }
+      )"""";
+
+  auto type = resolveTypeOfXInit(context, contents, /* requireKnown */ true);
+  assert(type.type());
+  assert(!type.isUnknown());
+  assert(type.type()->isIntType());
+
+  guard.realizeErrors();
+}
+
 int main() {
   test1();
   test2();
@@ -1190,6 +1220,7 @@ int main() {
   test19();
   test20();
   test21();
+  test22();
 
   return 0;
 }

--- a/frontend/test/resolution/testResolverVerboseErrors.cpp
+++ b/frontend/test/resolution/testResolverVerboseErrors.cpp
@@ -281,14 +281,9 @@ r.x("hello");
 
 static const char* errorOther = R"""(
 ─── error in file.chpl:6 [NoMatchingCandidates] ───
-  Unable to resolve call to 'x': no matching candidates.
+  Unable to resolve call to 'this': no matching candidates.
       |
     6 | r.x("hello");
-      |
-  
-  The following candidate didn't match:
-      |
-    2 |     var x: int;
       |
 )""";
 


### PR DESCRIPTION
Add support for resolving calls to the `this` method of a field in Dyno.

If there's a field matching the name called, this implementation will try to resolve it as a `this` call and fail otherwise; else, try to resolve as a normal method call. It doesn't support cases where a field and a method have the same name, however in https://github.com/chapel-lang/chapel/issues/24376 we decided to consider that illegal anyways.

Resolves https://github.com/Cray/chapel-private/issues/5923.

[reviewer info placeholder]

Testing:
- [x] dyno tests
- [x] paratest
- [x] reproducer from https://github.com/Cray/chapel-private/issues/5923 no longer fails