### PR TITLE
Avoid deprecation warnings with llvm11 and llvm 12

### DIFF
--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -355,6 +355,13 @@ ifeq ($(shell test $(GNU_GPP_MAJOR_VERSION) -ge 13; echo "$$?"),0)
 WARN_CXXFLAGS += -Wno-dangling-reference
 endif
 
+#
+# Don't warn for deprecated declarations with llvm 11, its a very noisy warning
+#
+ifeq ($(shell test $(CHPL_MAKE_LLVM_VERSION) -eq 11; echo "$$?"),0)
+WARN_CXXFLAGS += -Wno-deprecated-declarations
+endif
+
 
 
 ifeq ($(GNU_GPP_SUPPORTS_MISSING_DECLS),1)

--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -356,13 +356,14 @@ WARN_CXXFLAGS += -Wno-dangling-reference
 endif
 
 #
-# Don't warn for deprecated declarations with llvm 11, its a very noisy warning
+# Don't warn for deprecated declarations with llvm 11 and 12, its a very noisy warning
 #
 ifeq ($(shell test $(CHPL_MAKE_LLVM_VERSION) -eq 11; echo "$$?"),0)
 WARN_CXXFLAGS += -Wno-deprecated-declarations
 endif
-
-
+ifeq ($(shell test $(CHPL_MAKE_LLVM_VERSION) -eq 12; echo "$$?"),0)
+WARN_CXXFLAGS += -Wno-deprecated-declarations
+endif
 
 ifeq ($(GNU_GPP_SUPPORTS_MISSING_DECLS),1)
 WARN_CXXFLAGS += -Wmissing-declarations


### PR DESCRIPTION
Turns off `deprecated-declarations` when compiling with llvm 11 and 12. This PR takes the approach of using `-Wno-`, rather than using `-Wno-error=` as the amount of warnings took over the output.

Tested build on system with llvm 11

[Reviewed by @mppf]