### PR TITLE
Wrap runtime hip calls to catch errors

### DIFF
--- a/runtime/src/gpu/amd/gpu-amd-reduce.cc
+++ b/runtime/src/gpu/amd/gpu-amd-reduce.cc
@@ -77,11 +77,11 @@ void chpl_gpu_impl_##chpl_kind##_reduce_##data_type(data_type* data, int n,\
   ROCM_CALL(hipMalloc(&result, sizeof(kvp))); \
   void* temp = NULL; \
   size_t temp_bytes = 0; \
-  hipcub::DeviceReduce::impl_kind(temp, temp_bytes, data, (kvp*)result, n,\
-                                  (hipStream_t)stream);\
+  ROCM_CALL(hipcub::DeviceReduce::impl_kind(temp, temp_bytes, data, (kvp*)result, \
+                                            n, (hipStream_t)stream)); \
   ROCM_CALL(hipMalloc(&temp, temp_bytes)); \
-  hipcub::DeviceReduce::impl_kind(temp, temp_bytes, data, (kvp*)result, n,\
-                                  (hipStream_t)stream);\
+  ROCM_CALL(hipcub::DeviceReduce::impl_kind(temp, temp_bytes, data, (kvp*)result, \
+                                            n, (hipStream_t)stream)); \
   kvp result_host; \
   ROCM_CALL(hipMemcpyDtoHAsync(&result_host, result, sizeof(kvp),\
                                (hipStream_t)stream)); \


### PR DESCRIPTION
Fixes an issue in nightly testing where a C++ version upgrade caused hip calls in the runtime that were missing a `ROCM_CALL` wrapper to start failing.

Tested build on nightly test system with rocm 5.4

[Reviewed by @e-kayrakli]