### PR TITLE
Take 'this' by ref in DstAggregator.copy

### DIFF
--- a/modules/packages/CopyAggregation.chpl
+++ b/modules/packages/CopyAggregation.chpl
@@ -111,7 +111,7 @@ module CopyAggregation {
     type elemType;
     @chpldoc.nodoc
     var agg: if aggregate then DstAggregatorImpl(elemType) else nothing;
-    inline proc copy(ref dst: elemType, const in srcVal: elemType) {
+    inline proc ref copy(ref dst: elemType, const in srcVal: elemType) {
       if aggregate then agg.copy(dst, srcVal);
                    else dst = srcVal;
     }


### PR DESCRIPTION
Updates DstAggregator.copy to take 'this' by ref, avoiding a deprecation warning about inferring default intents.

- [x] local paratest
- [x] gasnet paratest