### PR TITLE
Minor docker tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,9 +54,10 @@ COPY . .
 
 # build Chapel for both C and LLVM backends
 RUN CHPL_TARGET_COMPILER=llvm make \
-    && CHPL_TARGET_COMPILER=gnu make \
-    && make chpldoc test-venv mason \
-    && make cleanall
+    && CHPL_TARGET_COMPILER=gnu make
+RUN make chpldoc test-venv mason
+RUN make chapel-py-venv chplcheck chpl-language-server
+RUN make cleanall
 
 # Hack to get access to Chapel binaries
 RUN cd $CHPL_HOME/bin && ln -s */* .


### PR DESCRIPTION
This PR tweaks our main `Dockerfile` somewhat. In particular, it:

1. Splits the build into several steps. Currently this doesn't do much to affect cache behavior, because of #24397. However, it's cleaner, and if we ever fix the `COPY . .` thing, that should help things.
2. Adds `chapel-py-venv`, `chpl-language-server`, and `chplcheck` to the Dockerfile. This makes it possible to use `chpl-language-server` and `chplcheck` from inside the Docker image. This is helpful for cases like GitHub codespaces, where editor support would rely on these tools.

~~This PR depends on https://github.com/chapel-lang/chapel/pull/24384 and https://github.com/chapel-lang/chapel/pull/24393, which makes the diff huge. The actual changes in this PR specifically are to `Dockerfile`~~. They have merged!

In a team discussion, everyone who voted seemed in favor of including the Python bindings into the docker image.

Reviewed by @riftEmber -- thanks!