### PR TITLE
Fix `Random` test failure for `--fast` config

### DIFF
--- a/test/library/standard/Random/elliot/testBadNth.compopts
+++ b/test/library/standard/Random/elliot/testBadNth.compopts
@@ -1,0 +1,1 @@
+--checks=yes


### PR DESCRIPTION
`test/library/standard/Random/elliot/testBadNth` was failing in a test config that uses `--fast` because it relies on checks being enabled. This PR turns on checks for that test.

