### PR TITLE
Avoid boolean `&` warning in `testRecursionFails`

### DIFF
--- a/frontend/test/framework/testRecursionFails.cpp
+++ b/frontend/test/framework/testRecursionFails.cpp
@@ -161,13 +161,16 @@ static bool const& queryF(Context* context, bool callFFirst, bool runHandler) {
 static bool const& queryG(Context* context, bool callFFirst, bool runHandler) {
   QUERY_BEGIN(queryG, context, callFFirst, runHandler);
 
+  // Use bitwise & instead of logical && to avoid short-circuiting.
+  // Some compilers warn for & with boolean operands, so cast to int to ignore
+  // the warning.
   bool res;
   if (callFFirst) {
-    res = queryF(context, callFFirst, runHandler) &
-          queryG(context, callFFirst, runHandler);
+    res = (int)queryF(context, callFFirst, runHandler) &
+          (int)queryG(context, callFFirst, runHandler);
   } else {
-    res = queryG(context, callFFirst, runHandler) &
-          queryF(context, callFFirst, runHandler);
+    res = (int)queryG(context, callFFirst, runHandler) &
+          (int)queryF(context, callFFirst, runHandler);
   }
 
   if (runHandler) {


### PR DESCRIPTION
Cast boolean operands to `&` in `testRecursionFails` to ints, to avoid warnings with some compilers.

Compiling `testRecursionFails` fails on my system since https://github.com/chapel-lang/chapel/pull/24321 with this error:
```
/Users/rift/chapel/frontend/test/framework/testRecursionFails.cpp:166:11: error: use of bitwise '&' with boolean operands [-Werror,-Wbitwise-instead-of-logical]
    res = queryF(context, callFFirst, runHandler) &
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                  &&
/Users/rift/chapel/frontend/test/framework/testRecursionFails.cpp:166:11: note: cast one or both operands to int to silence this warning
```

I see this didn't come up in CI checks on that PR and assume it is compiler version specific. Casting to int should avoid the error for compilers that care about it without breaking anything. Switching to logical `&&` isn't an option as it short-circuits and we don't want that.

[reviewer info placeholder]

Testing:
- [x] dyno tests in CI
- [x] dyno tests on my local