### PR TITLE
GPU and LLVM util changes to enable AMD support in spack

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -4870,7 +4870,7 @@ static void makeBinaryLLVMForHIP(const std::string& artifactFilename,
 #endif
   auto sdkString = std::string(gGpuSdkPath);
   // check file exists, maybe use alternate path (say if spack installed)
-  std::string lldBin = pathExists((sdkString + "/llvm/bin/").c_str()) ?
+  std::string lldBin = pathExists((sdkString + "/llvm/bin/lld").c_str()) ?
                        sdkString + "/llvm/bin/lld"  :
                        sdkString + "/bin/lld";
   for (auto& gpuArch : gpuArches) {

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -4868,6 +4868,11 @@ static void makeBinaryLLVMForHIP(const std::string& artifactFilename,
   std::string inputs = "-inputs=/dev/null";
   std::string outputs = "-outputs=" + fatbinFilename;
 #endif
+  auto sdkString = std::string(gGpuSdkPath);
+  // check file exists, maybe use alternate path (say if spack installed)
+  std::string lldBin = pathExists((sdkString + "/llvm/bin/").c_str()) ?
+                       sdkString + "/llvm/bin/lld"  :
+                       sdkString + "/bin/lld";
   for (auto& gpuArch : gpuArches) {
     std::string gpuObject = gpuObjFilename + "_" + gpuArch + ".o";
     std::string gpuOut = outFilenamePrefix + "_" + gpuArch + ".out";
@@ -4877,8 +4882,9 @@ static void makeBinaryLLVMForHIP(const std::string& artifactFilename,
                          "--triple=amdgcn-amd-amdhsa --mcpu=" + gpuArch + " " +
                          artifactFilename + " " +
                          "-o " + gpuObject;
-    std::string lldCmd = std::string(gGpuSdkPath) +
-                        "/bin/lld -flavor gnu" +
+
+    std::string lldCmd = lldBin +
+                         " -flavor gnu" +
                          " --no-undefined -shared" +
                          " -plugin-opt=-amdgpu-internalize-symbols" +
                          " -plugin-opt=mcpu=" + gpuArch +

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -4878,7 +4878,7 @@ static void makeBinaryLLVMForHIP(const std::string& artifactFilename,
                          artifactFilename + " " +
                          "-o " + gpuObject;
     std::string lldCmd = std::string(gGpuSdkPath) +
-                        "/llvm/bin/lld -flavor gnu" +
+                        "/bin/lld -flavor gnu" +
                          " --no-undefined -shared" +
                          " -plugin-opt=-amdgpu-internalize-symbols" +
                          " -plugin-opt=mcpu=" + gpuArch +

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -298,7 +298,9 @@ def get_sdk_version():
                 if match:
                     rocm_version = match.group(1)
                 else:
-                    rocm_version="5.4.3"
+                    match = re.search(r"llvm-amdgpu-([\d\.]+)", my_stdout)
+                    if match:
+                        rocm_version = match.group(1)
         return rocm_version
 
     if get() == 'nvidia':

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -297,8 +297,10 @@ def get_sdk_version():
                 match = re.search(r"rocm?-([\d\.]+)", my_stdout)
                 if match:
                     rocm_version = match.group(1)
+                else:
+                    rocm_version="5.4.3"
         return rocm_version
-    
+
     if get() == 'nvidia':
         chpl_cuda_path = get_sdk_path('nvidia')
         version_file_json = '%s/version.json' % chpl_cuda_path

--- a/util/chplenv/compile_link_args_utils.py
+++ b/util/chplenv/compile_link_args_utils.py
@@ -106,9 +106,7 @@ def get_runtime_link_args(runtime_subdir):
             lib_path = os.path.join(sdk_path, "lib")
             system.append("-L" + lib_path)
             system.append("-Wl,-rpath," + lib_path)
-            system.append("-L" + "/chapel/home/rezaii/git/spack/opt/spack/linux-sles15-zen/gcc-7.5.0/hip-5.4.3-fmhis32cckubpd4hmorgn7cn2mbin44y/lib")
             system.append("-lamdhip64")
-            system.append("-L"+"/chapel/home/rezaii/git/spack/opt/spack/linux-sles15-zen/gcc-7.5.0/hsa-rocr-dev-5.4.3-pw2zlzkhtq2szfgvxjgcsboyoitfq3gx/lib")
             system.append("-lhsa-runtime64")
 
     # always link with the math library

--- a/util/chplenv/compile_link_args_utils.py
+++ b/util/chplenv/compile_link_args_utils.py
@@ -106,7 +106,9 @@ def get_runtime_link_args(runtime_subdir):
             lib_path = os.path.join(sdk_path, "lib")
             system.append("-L" + lib_path)
             system.append("-Wl,-rpath," + lib_path)
+            system.append("-L" + "/chapel/home/rezaii/git/spack/opt/spack/linux-sles15-zen/gcc-7.5.0/hip-5.4.3-fmhis32cckubpd4hmorgn7cn2mbin44y/lib")
             system.append("-lamdhip64")
+            system.append("-L"+"/chapel/home/rezaii/git/spack/opt/spack/linux-sles15-zen/gcc-7.5.0/hsa-rocr-dev-5.4.3-pw2zlzkhtq2szfgvxjgcsboyoitfq3gx/lib")
             system.append("-lhsa-runtime64")
 
     # always link with the math library


### PR DESCRIPTION
These are the changes I found necessary to get Chapel with AMD GPU support working in spack. When using spack to install the dependencies for our rocm support, the paths are not necessarily the same as we have been expecting. With these changes, I was able to get spack to build and run with AMD GPU support on `chapdl-amd`

[reviewed by @DanilaFe - thank you!]