### PR TITLE
Add a SKIPIF to stop running some distributed array tests with ROCm 4

### DIFF
--- a/test/gpu/native/distArray/SKIPIF
+++ b/test/gpu/native/distArray/SKIPIF
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+if $CHPL_HOME/util/printchplenv --simple | grep -q "CHPL_GPU=amd"; then
+  if hipcc --version | head -n1 | grep -q "HIP version: 4"; then
+    echo 1
+  else
+    echo 0
+  fi
+else
+  echo 0
+fi


### PR DESCRIPTION
This PR adds a somewhat wonky SKIPIF to stop testing some distributed array tests with AMD GPUs. The tests in question fail in a way that I don't understand and not reproducible with ROCm 5.4. As we are planning to steer away from ROCm 4, I choose not to invest more time towards understanding the problem that doesn't exist with newer ROCms.

Test:
- [x] amd with ROCm 4.5 skips the problematic tests