### PR TITLE
LSP: show instantiations and highlight dead code

### DIFF
--- a/third-party/chpl-venv/chplcheck-requirements.txt
+++ b/third-party/chpl-venv/chplcheck-requirements.txt
@@ -1,6 +1,6 @@
 attrs==23.1.0
 cattrs==23.1.2
-lsprotocol==2023.0.0b1
-pygls==1.1.1
+lsprotocol==2023.0.1
+pygls==1.3.0
 typeguard==3.0.2
 ConfigArgParse==1.7

--- a/tools/chapel-py/src/chapel.cpp
+++ b/tools/chapel-py/src/chapel.cpp
@@ -62,6 +62,9 @@ PyMODINIT_FUNC PyInit_core() {
   if (ParamObject::ready() < 0) return nullptr;
   if (ErrorObject::ready() < 0) return nullptr;
   if (ErrorManagerObject::ready() < 0) return nullptr;
+  if (ResolvedExpressionObject::ready() < 0) return nullptr;
+  if (MostSpecificCandidateObject::ready() < 0) return nullptr;
+  if (TypedSignatureObject::ready() < 0) return nullptr;
 
   chapelModule = PyModule_Create(&ChapelModule);
   if (!chapelModule) return nullptr;
@@ -79,6 +82,9 @@ PyMODINIT_FUNC PyInit_core() {
   if (ParamObject::addToModule(chapelModule) < 0) return nullptr;
   if (ErrorObject::addToModule(chapelModule) < 0) return nullptr;
   if (ErrorManagerObject::addToModule(chapelModule) < 0) return nullptr;
+  if (ResolvedExpressionObject::addToModule(chapelModule) < 0) return nullptr;
+  if (MostSpecificCandidateObject::addToModule(chapelModule) < 0) return nullptr;
+  if (TypedSignatureObject::addToModule(chapelModule) < 0) return nullptr;
 
   return chapelModule;
 }

--- a/tools/chapel-py/src/error-tracker.cpp
+++ b/tools/chapel-py/src/error-tracker.cpp
@@ -43,5 +43,6 @@ void PythonErrorHandler::report(chpl::Context* context, const chpl::ErrorBase* e
   }
 
   // There's an error list! Create an error object and store it into the list.
-  PyList_Append(errorLists.back(), ErrorObject::create((ContextObject*) contextObject, err->clone()));
+  auto errObj = ErrorObject::create((ContextObject*) contextObject, err->clone());
+  PyList_Append(errorLists.back(), (PyObject*) errObj);
 }

--- a/tools/chapel-py/src/method-tables/core-methods.h
+++ b/tools/chapel-py/src/method-tables/core-methods.h
@@ -28,7 +28,7 @@ CLASS_BEGIN(Context)
   PLAIN_GETTER(Context, introspect_parsed_files, "Inspect the list of files that have been parsed by the Context",
                std::vector<chpl::UniqueString>, return parsing::introspectParsedFiles(&node))
   PLAIN_GETTER(Context, track_errors, "Return a context manager that tracks errors emitted by this Context",
-               PyObject*, std::ignore = node; return ErrorManagerObject::create(contextObject, std::make_tuple()))
+               ErrorManagerObject*, std::ignore = node; return ErrorManagerObject::create(contextObject, std::make_tuple()))
   PLAIN_GETTER(Context, _get_pyi_file, "Generate a stub file for the Chapel AST nodes",
                std::string, std::ignore = node; return generatePyiFile())
 
@@ -119,12 +119,12 @@ CLASS_END(ErrorManager)
 
 CLASS_BEGIN(ResolvedExpression)
   PLAIN_GETTER(ResolvedExpression, most_specific_candidate, "If this node is a call, return the most specific overload selected by call resolution.",
-               PyObject*,
+               std::optional<MostSpecificCandidateObject*>,
 
                if (auto& msc = node->mostSpecific().only()) {
                  return MostSpecificCandidateObject::create(contextObject, {&msc, node->poiScope()});
                }
-               Py_RETURN_NONE)
+               return {})
   PLAIN_GETTER(ResolvedExpression, type, "Retrieve the type of the expression.",
                std::optional<QualifiedTypeTuple>,
 
@@ -138,7 +138,7 @@ CLASS_END(ResolvedExpression)
 
 CLASS_BEGIN(MostSpecificCandidate)
   PLAIN_GETTER(MostSpecificCandidate, function, "Get the signature of the function called by this candidate.",
-               PyObject*, return TypedSignatureObject::create(contextObject, {node.candidate->fn(), node.poiScope }))
+               TypedSignatureObject*, return TypedSignatureObject::create(contextObject, {node.candidate->fn(), node.poiScope }))
   PLAIN_GETTER(MostSpecificCandidate, formal_actual_mapping, "Get the index of the function's formal for each of the call's actuals.",
                std::vector<int>,
 

--- a/tools/chapel-py/src/method-tables/core-methods.h
+++ b/tools/chapel-py/src/method-tables/core-methods.h
@@ -62,6 +62,8 @@ CLASS_BEGIN(Context)
 
          auto prepareToGc = std::get<0>(args);
          node.advanceToNextRevision(prepareToGc))
+  METHOD(Context, get_file_text, "Get the text of the file at the given path",
+         std::string(chpl::UniqueString), return parsing::fileText(&node, std::get<0>(args)).text())
 CLASS_END(Context)
 
 CLASS_BEGIN(Location)

--- a/tools/chapel-py/src/method-tables/uast-methods.h
+++ b/tools/chapel-py/src/method-tables/uast-methods.h
@@ -77,14 +77,14 @@ CLASS_BEGIN(AstNode)
   PLAIN_GETTER(AstNode, called_fn, "Get the function being invoked by this node",
                const chpl::uast::AstNode*, return calledFnForNode(context, node))
   PLAIN_GETTER(AstNode, resolve, "Perform resolution on code surrounding this node to determine its type and other information.",
-               PyObject*, return ResolvedExpressionObject::create(contextObject, resolveResultsForNode(context, node)))
+               std::optional<ResolvedExpressionObject*>, return ResolvedExpressionObject::tryCreate(contextObject, resolveResultsForNode(context, node)))
   METHOD(AstNode, resolve_via, "Use a given function's type information to determine the information of this node.",
-         PyObject*(PyObject*),
+         std::optional<ResolvedExpressionObject*>(TypedSignatureObject*),
 
-         auto sigObj = (TypedSignatureObject*) std::get<0>(args);
+         auto sigObj = std::get<0>(args);
          auto resolvedFn = resolution::resolveFunction(context, sigObj->value_.signature, sigObj->value_.poiScope);
          auto r = resolvedFn->byAstOrNull(node);
-         return ResolvedExpressionObject::create(contextObject, r))
+         return ResolvedExpressionObject::tryCreate(contextObject, r))
 CLASS_END(AstNode)
 
 CLASS_BEGIN(AnonFormal)

--- a/tools/chapel-py/src/method-tables/uast-methods.h
+++ b/tools/chapel-py/src/method-tables/uast-methods.h
@@ -76,6 +76,15 @@ CLASS_BEGIN(AstNode)
                return std::make_tuple(intentToString(qt.kind()), qt.type(), qt.param()))
   PLAIN_GETTER(AstNode, called_fn, "Get the function being invoked by this node",
                const chpl::uast::AstNode*, return calledFnForNode(context, node))
+  PLAIN_GETTER(AstNode, resolve, "Perform resolution on code surrounding this node to determine its type and other information.",
+               PyObject*, return ResolvedExpressionObject::create(contextObject, resolveResultsForNode(context, node)))
+  METHOD(AstNode, resolve_via, "Use a given function's type information to determine the information of this node.",
+         PyObject*(PyObject*),
+
+         auto sigObj = (TypedSignatureObject*) std::get<0>(args);
+         auto resolvedFn = resolution::resolveFunction(context, sigObj->value_.signature, sigObj->value_.poiScope);
+         auto r = resolvedFn->byAstOrNull(node);
+         return ResolvedExpressionObject::create(contextObject, r))
 CLASS_END(AstNode)
 
 CLASS_BEGIN(AnonFormal)

--- a/tools/chapel-py/src/method-tables/uast-methods.h
+++ b/tools/chapel-py/src/method-tables/uast-methods.h
@@ -56,15 +56,9 @@ CLASS_BEGIN(AstNode)
                node->id().stringify(ss, CHPL_SYNTAX);
                return ss.str())
   PLAIN_GETTER(AstNode, scope, "Get the scope for this AST node",
-               ScopeObject*,
+               std::optional<ScopeObject*>,
 
-               // XXX: bit of a hack. This returns a PyObject* because it can
-               // be 'None'. However, to match the lambda return type, we should
-               // return ScopeObject*. The wrapping casts it right back to
-               // a PyObject*, so this is safe. Using ScopeObject* instead
-               // of PyObject* as a return type is better because we can
-               // generate more specific Python type signatures.
-               return (ScopeObject*) ScopeObject::create(contextObject, resolution::scopeForId(context, node->id())))
+               return ScopeObject::tryCreate(contextObject, resolution::scopeForId(context, node->id())))
   PLAIN_GETTER(AstNode, type, "Get the type of this AST node, as a 3-tuple of (kind, type, param).",
                std::optional<QualifiedTypeTuple>,
 

--- a/tools/chapel-py/src/python-class.h
+++ b/tools/chapel-py/src/python-class.h
@@ -39,17 +39,14 @@ struct PythonClass {
   // If T is a pointer, allow ::create() to be called with nullptr, and
   // just return None.
   template <typename Q = T>
-  static typename std::enable_if<std::is_pointer_v<Q>, PyObject*>::type returnNoneIfNeeded(const Q& val) {
-    if (val == nullptr) {
-      Py_RETURN_NONE;
-    }
-    return nullptr;
+  static typename std::enable_if<std::is_pointer_v<Q>, bool>::type shouldReturnNone(const Q& val) {
+    return val == nullptr;
   }
 
   // If T is a not a pointer, we can't detect 'nullptr'.
   template <typename Q = T>
-  static typename std::enable_if<!std::is_pointer_v<Q>, PyObject*>::type returnNoneIfNeeded(const Q& val) {
-    return nullptr;
+  static typename std::enable_if<!std::is_pointer_v<Q>, bool>::type shouldReturnNone(const Q& val) {
+    return false;
   }
 
   UnwrappedT unwrap() { return value_; }
@@ -95,16 +92,25 @@ struct PythonClass {
 
   /** ===== Public convenience methods for using this object ===== */
 
-  static PyObject* create(T createFrom) {
-    if (auto obj = PythonClass<Self, T>::returnNoneIfNeeded(createFrom)) {
-      return obj;
+  static Self* create(T createFrom) {
+    if (PythonClass<Self, T>::shouldReturnNone(createFrom)) {
+      PyErr_SetString(PyExc_RuntimeError, "Attempt to create a Python object from nullptr.");
+      return nullptr;
     }
 
     auto selfObjectPy = PyObject_CallObject((PyObject *) &Self::PythonType, nullptr);
     auto& val = ((Self*) selfObjectPy)->value_;
 
     val = std::move(createFrom);
-    return selfObjectPy;
+    return (Self*) selfObjectPy;
+  }
+
+  static std::optional<Self*> tryCreate(T createFrom) {
+    if (PythonClass<Self, T>::shouldReturnNone(createFrom)) {
+      return {};
+    }
+
+    return Self::create(std::move(createFrom));
   }
 };
 
@@ -155,10 +161,11 @@ struct PythonClassWithObject : public PythonClass<Self, T> {
 
   ContextObject* context() { return (ContextObject*) contextObject; }
 
-  static PyObject* create(T createFrom) = delete; /* Don't you mention Liskov to me! */
-  static PyObject* create(ContextObject* context, T createFrom) {
-    if (auto obj = PythonClass<Self, T>::returnNoneIfNeeded(createFrom)) {
-      return obj;
+  static Self* create(T createFrom) = delete; /* Don't you mention Liskov to me! */
+  static Self* create(ContextObject* context, T createFrom) {
+    if (PythonClass<Self, T>::shouldReturnNone(createFrom)) {
+      PyErr_SetString(PyExc_RuntimeError, "Attempt to create a Python object from nullptr.");
+      return nullptr;
     }
 
     PyObject* args = Py_BuildValue("(O)", (PyObject*) context);
@@ -166,7 +173,13 @@ struct PythonClassWithObject : public PythonClass<Self, T> {
     auto& val = ((Self*) selfObjectPy)->value_;
 
     val = std::move(createFrom);
-    return selfObjectPy;
+    return (Self*) selfObjectPy;
+  }
+  static std::optional<Self*> tryCreate(ContextObject* context, T createFrom) {
+    if (PythonClass<Self, T>::shouldReturnNone(createFrom)) {
+      return {};
+    }
+    return create(context, std::move(createFrom));
   }
 };
 

--- a/tools/chapel-py/src/python-types.h
+++ b/tools/chapel-py/src/python-types.h
@@ -214,7 +214,7 @@ DEFINE_INOUT_TYPE(std::string, "str", Py_BuildValue("s", TO_WRAP.c_str()), std::
 DEFINE_INOUT_TYPE(const chpl::uast::AstNode*, "AstNode", wrapAstNode(CONTEXT, TO_WRAP), ((AstNodeObject*) TO_UNWRAP)->value_);
 DEFINE_INOUT_TYPE(const chpl::types::Type*, "ChapelType", wrapType(CONTEXT, TO_WRAP), ((ChapelTypeObject*) TO_UNWRAP)->value_);
 DEFINE_INOUT_TYPE(const chpl::types::Param*, "Param", wrapParam(CONTEXT, TO_WRAP), ((ParamObject*) TO_UNWRAP)->value_);
-DEFINE_INOUT_TYPE(chpl::Location, "Location", LocationObject::create(TO_WRAP), ((LocationObject*) TO_UNWRAP)->value_);
+DEFINE_INOUT_TYPE(chpl::Location, "Location", (PyObject*) LocationObject::create(TO_WRAP), ((LocationObject*) TO_UNWRAP)->value_);
 DEFINE_INOUT_TYPE(IterAdapterBase*, "typing.Iterator[AstNode]", wrapIterAdapter(CONTEXT, TO_WRAP), ((AstIterObject*) TO_UNWRAP)->iterAdapter);
 DEFINE_INOUT_TYPE(PyObject*, "typing.Any", TO_WRAP, TO_UNWRAP);
 

--- a/tools/chapel-py/src/resolution.cpp
+++ b/tools/chapel-py/src/resolution.cpp
@@ -114,7 +114,7 @@ static const resolution::ResolvedExpression* resolveViaModule(Context* context, 
   return nullptr;
 }
 
-static const resolution::ResolvedExpression* resolveResultsForNode(Context* context, const AstNode* node) {
+const resolution::ResolvedExpression* resolveResultsForNode(Context* context, const AstNode* node) {
   const AstNode* search = node;
   while (search) {
     auto rr = resolveViaFunction(context, search, node);

--- a/tools/chapel-py/src/resolution.h
+++ b/tools/chapel-py/src/resolution.h
@@ -19,6 +19,10 @@
 
 #include "chpl/uast/AstNode.h"
 #include "chpl/types/Type.h"
+#include "chpl/resolution/resolution-types.h"
+
+const chpl::resolution::ResolvedExpression*
+resolveResultsForNode(chpl::Context* context, const chpl::uast::AstNode* node);
 
 const chpl::uast::AstNode* const&
 nodeOrNullFromToId(chpl::Context* context, const chpl::uast::AstNode* node);

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -511,6 +511,10 @@ class FileInfo:
 
         return None
 
+    def file_lines(self) -> List[str]:
+        file_text = self.context.context.get_file_text(self.uri[len("file://") :])
+        return file_text.splitlines()
+
 
 class WorkspaceConfig:
     def __init__(self, ls: "ChapelLanguageServer", json: Dict[str, Any]):
@@ -1206,7 +1210,7 @@ def run_lsp():
                         dead_branch = ast.else_block() if val.value() else ast.then_block()
                         if dead_branch:
                             loc = dead_branch.location()
-                            tokens.extend(range_to_tokens(loc, text_doc.lines))
+                            tokens.extend(range_to_tokens(loc, fi.file_lines()))
 
         return SemanticTokens(data=encode_deltas(tokens))
 

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -219,7 +219,6 @@ def range_to_tokens(rng: chapel.Location, lines: List[str]) -> List[Tuple[int, i
     (line_start, char_start) = rng.start()
     (line_end, char_end) = rng.end()
 
-    last_start = char_start
     if line_start == line_end:
         return [(line_start - 1, char_start - 1, char_end - char_start)]
 

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -724,7 +724,7 @@ class ChapelLanguageServer(LanguageServer):
         # an explicit type, and whose type is valid.
         _, type_, _ = qt
         if (
-            not isinstance(decl.node, chapel.Variable)
+            not isinstance(decl.node, (chapel.Variable, chapel.Formal))
             or decl.node.type_expression() is not None
             or isinstance(type_, chapel.ErroneousType)
         ):


### PR DESCRIPTION
This PR makes use of the recent resolution support in `chapel-py` to display instantiations for functions and highlight dead code. Thus, if you have a generic function that's called with a certain argument, and performs some param-logic using that type, you can now get visual feedback on this:

<img width="791" alt="Screen Shot 2024-02-15 at 12 02 48 PM" src="https://github.com/chapel-lang/chapel/assets/4361282/03f97110-9393-4edc-b598-5ded8174a748">

To support this, the PR makes the following changes:

* Exposes some of Dyno's resolution types to the Python bindings
  * This includes `ResolvedExpression`, `TypedFnSignature`, and `MostSpecificCandidate`.
  * For these, I explicitly bundle in the POI scope, which Dyno does __not__ do. By bundling the POI scope,
    we can do things via simple method calls like `x.resolve()` that would otherwise require retrieving data from other
    sources `(x.resolve(somethingElse.getPoiScope())`
* Exposing some resolution methods to the Python bindings
  * This includes `AstNode.resolve` and `AstNode.resolve_via`. In the future, I plan to fuse these into a single form with a `via` kwarg, but that will require some more infrastructure changes on the C++ side.
  * This also includes `.most_specific_candidate()` and `.function()`. 
* For the sake of improving the `.pyi` files, adds a `::tryCreate` API to supplement `::create`.
  * `::create` no longer returns `None` for null pointers, throwing exceptions instead
  * `::tryCreate` returns an `optional<Self*>`, which allows it to fit natively into the Python marshalling (using it means `Optional[X]` is reported instead of `X`) 
  * All `PyObject*`-returning methods that returned builtin types are switched to return the builtin type directly.

