### PR TITLE
Make a distributed array test a future

### DIFF
--- a/test/gpu/native/distArray/blockUseInFunction.future
+++ b/test/gpu/native/distArray/blockUseInFunction.future
@@ -1,0 +1,14 @@
+bug: `dsiAccess` method of BlockDist causes misaligned access in CUDA 12
+#24429
+
+The issue probably has something to do with struct padding (likely involving
+`myLocArr.locDom`). It is reproducible in CUDA 12 but not in 11. I don't know
+what to make of it, but either some stricter checking or some sort of memory
+mapping/randomization heuristic new in CUDA 12 exposing it.
+
+I tested both CUDA 11.8 and 12 with bundled LLVM 17. While there's something
+LLVM can help with us here, I don't think LLVM version is the source of the
+problem.
+
+Because this code currently has different behaviors based on CUDA versions, I am
+not adding a bad file.


### PR DESCRIPTION
This PR makes an existing test a future. The bug in question is captured in https://github.com/chapel-lang/chapel/issues/24429.