### PR TITLE
Fix the 'hover over inlay' hint for tuples.

### DIFF
--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -818,10 +818,12 @@ class ChapelLanguageServer(LanguageServer):
         label = InlayHintLabelPart(str(type_))
         if isinstance(type_, chapel.CompositeType):
             typedecl = type_.decl()
-            text = self.get_tooltip(typedecl, siblings)
-            content = MarkupContent(MarkupKind.Markdown, text)
-            label.tooltip = content
-            label.location = location_to_location(typedecl.location())
+
+            if typedecl:
+                text = self.get_tooltip(typedecl, siblings)
+                content = MarkupContent(MarkupKind.Markdown, text)
+                label.tooltip = content
+                label.location = location_to_location(typedecl.location())
 
         return [
             InlayHint(


### PR DESCRIPTION
A tuple is a `CompositeType`, but it does not have a `decl` AST node. Thus, `None` slips into the `get_tooltip` method, and causes an error. This PR guards against `None` here. The same issue does not occur in regular `get_tooltip` because it relies on 'to-segments', which are guaranteed to have a node they refer to.

Reviewed by @jabraham17 -- thanks!