### PR TITLE
Clean chapel-py build folder on make clean

### DIFF
--- a/third-party/chpl-venv/Makefile
+++ b/third-party/chpl-venv/Makefile
@@ -19,6 +19,7 @@ all: test-venv chpldoc-venv
 
 clean: FORCE
 	rm -rf build
+	rm -rf $(CHPL_MAKE_HOME)/tools/chapel-py/build
 
 cleanall: FORCE clean
 


### PR DESCRIPTION
Previously, the folder `$(CHPL_MAKE_HOME)/tools/chapel-py/build` which was generated by `make chapel-py-venv` would not be cleaned up by `make clean` or `make clobber`. This could sometimes result in unexpected behavior

[Reviewed by @]