### PR TITLE
Set CHPL_RT_MAX_HEAP_SIZE

### DIFF
--- a/util/cron/test-hpe-cray-ex-ofi.bash
+++ b/util/cron/test-hpe-cray-ex-ofi.bash
@@ -9,5 +9,6 @@ source $CWD/common-hpe-cray-ex.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="hpe-cray-ex-ofi"
 export CHPL_RT_COMM_OFI_EXPECTED_PROVIDER="cxi"
+export CHPL_RT_MAX_HEAP_SIZE=16g
 
 $CWD/nightly -cron -examples ${nightly_args}


### PR DESCRIPTION
On a HPE Cray EX test machine cxi services sometimes die expectedly. The probability of this happening appears to be proportional to the size of the heap. Limit the size of the heap to 16GB via CHPL_RT_MAX_HEAP_SIZE as a larger heap is not needed by the tests and it reduces the chance of spurious test failures.