### PR TITLE
Add support for user-defined lint rules

### DIFF
--- a/tools/chplcheck/README.md
+++ b/tools/chplcheck/README.md
@@ -200,3 +200,30 @@ def UnusedFormal(context, root):
 This function performs _two_ pattern-based searches: one for formals, and one
 for identifiers that might reference the formals. It then emits a warning for
 each formal for which there wasn't a corresponding identifier.
+
+## Adding your own rules
+
+Developers may have their own preferences for their code they would like to be enforced by a linter. Rather than adding their own rule to `rules.py`, developers can load a custom rule file that contains all of their custom rules.
+
+For example, the following code is a complete definition of two new rules for chplcheck. Note that the top-level function must be named `rules` and take one argument.
+
+```python3
+# saved in file `myrules.py`
+import chapel
+
+def rules(driver):
+
+  @driver.basic_rule(chapel.Function)
+  def NoFunctionFoo(context, node):
+    return node.name() != "foo"
+
+  @driver.basic_rule(chapel.Variable, default=False)
+  def NoVariableBar(context, node):
+    return node.name() != "bar"
+```
+
+To load these custom rules into chplcheck, the additional command line argument is used.
+
+```bash
+chplcheck --add-rules path/to/my/myrules.py
+```

--- a/tools/chplcheck/src/chplcheck.py
+++ b/tools/chplcheck/src/chplcheck.py
@@ -28,10 +28,35 @@ from driver import LintDriver
 from rules import register_rules
 from lsp import run_lsp
 
+import os
+import sys
+import importlib.util
+
 def print_violation(node, name):
     location = node.location()
     first_line, _ = location.start()
     print("{}:{}: node violates rule {}".format(location.path(), first_line, name))
+
+def load_module(driver: LintDriver, file_path: str):
+    """
+    Load a module from a file path.
+    This is used to extend the linter with custom rules.
+    """
+    module_name = os.path.basename(file_path).removesuffix('.py')
+
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    if spec is None:
+        raise ValueError(f"Could not load module from {file_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    if spec.loader is None:
+        raise ValueError(f"Could not load module from {file_path}")
+    spec.loader.exec_module(module)
+    rule_func_name = "rules"
+    rule_func = getattr(module, rule_func_name, None)
+    if rule_func is None or not callable(rule_func):
+        raise ValueError(f"Could not find rule function '{rule_func_name}' in {file_path}")
+    rule_func(driver)
 
 def main():
     parser = argparse.ArgumentParser( prog='chplcheck', description='A linter for the Chapel language')
@@ -41,11 +66,15 @@ def main():
     parser.add_argument('--lsp', action='store_true', default=False)
     parser.add_argument('--skip-unstable', action='store_true', default=False)
     parser.add_argument('--internal-prefix', action='append', dest='internal_prefixes', default=[])
+    parser.add_argument("--add-rules", action='append', default=[], help="Add a custom rule file")
     args = parser.parse_args()
 
     driver = LintDriver(skip_unstable = args.skip_unstable, internal_prefixes = args.internal_prefixes)
     # register rules before enabling/disabling
     register_rules(driver)
+    for p in args.add_rules:
+        load_module(driver, os.path.abspath(p))
+
     driver.disable_rules(*args.disabled_rules)
     driver.enable_rules(*args.enabled_rules)
 


### PR DESCRIPTION
This PR adds support for user-defined linting rules in chplcheck. This allows a Chapel developer to create and maintain their own set of custom linting rules for chplcheck outside of the chapel-py source tree.

[Reviewed by @DanilaFe]