### PR TITLE
Implement whole-workspace reference tracking and update existing features to make use of it

### DIFF
--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -200,7 +200,7 @@ def completion_item_for_decl(
 
 
 def location_to_location(loc) -> Location:
-    return Location("file://" + loc.path(), location_to_range(loc))
+    return Location("file://" + os.path.abspath(loc.path()), location_to_range(loc))
 
 
 def get_symbol_information(
@@ -345,7 +345,7 @@ class NodeAndRange:
         return Location(self.get_uri(), self.rng)
 
     def get_uri(self):
-        path = self.node.location().path()
+        path = os.path.abspath(self.node.location().path())
         return f"file://{path}"
 
 

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -1213,6 +1213,8 @@ def run_lsp():
                 edits[nr.get_uri()] = []
             edits[nr.get_uri()].append(TextEdit(nr.rng, params.new_name))
 
+        ls.eagerly_process_all_files(fi.context)
+
         add_to_edits(node_and_loc)
         for uselist in fi.context.global_uses[node_and_loc.node.unique_id()]:
             for use in uselist:

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -1214,8 +1214,9 @@ def run_lsp():
             edits[nr.get_uri()].append(TextEdit(nr.rng, params.new_name))
 
         add_to_edits(node_and_loc)
-        for use in fi.uses_here[node_and_loc.node.unique_id()]:
-            add_to_edits(use)
+        for uselist in fi.context.global_uses[node_and_loc.node.unique_id()]:
+            for use in uselist:
+                add_to_edits(use)
 
         return WorkspaceEdit(changes=edits)
 

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -515,7 +515,9 @@ class FileInfo:
                 self.possibly_visible_decls.append(child)
 
     def _search_instantiations(
-        self, root: Union[chapel.AstNode, List[chapel.AstNode]], via: Optional[chapel.TypedSignature] = None
+        self,
+        root: Union[chapel.AstNode, List[chapel.AstNode]],
+        via: Optional[chapel.TypedSignature] = None,
     ):
         for node in chapel.preorder(root):
             if not isinstance(node, chapel.FnCall):
@@ -746,7 +748,6 @@ class ChapelLanguageServer(LanguageServer):
         if cfg:
             for file in cfg.files:
                 self.get_file_info("file://" + file, do_update=False)
-
 
     def get_file_info(
         self, uri: str, do_update: bool = False
@@ -1352,9 +1353,7 @@ def run_lsp():
                 start_pos = location_to_range(ast.location()).start
                 instantiation = fi.get_inst_segment_at_position(start_pos)
                 tokens.extend(
-                    ls.get_dead_code_tokens(
-                        ast, fi.file_lines(), instantiation
-                    )
+                    ls.get_dead_code_tokens(ast, fi.file_lines(), instantiation)
                 )
 
         return SemanticTokens(data=encode_deltas(tokens, 0, 0))


### PR DESCRIPTION
This PR modifies the 'use tracking' aspect of the language server to lift uses to the "dyno context" level. Since Dyno contexts are created such that one context is shared among multiple files compiled together, this leads to a "workspace-wide rename" functionality. 

The PR works by replacing the `Dict[NodeId, List[Reference]]` with a `Dict[NodeId, ReferenceList]`, where `ReferenceList` is a new class. The `ReferenceList` class is _also_ inserted into the "dyno context" container, also associated with a `NodeId`. The context-level container is `Dict[NodeId, List[ReferenceList]]`, containing reference lists from multiple files. By making the `ReferenceList` object be shared between the `FileInfo` and the context container, so when the `FileInfo` is updated, so is the corresponding entry in the `ContextContainer`. From there, LSP features that need global symbols (find references, rename) can simply use the context-level list instead of `uses_here`.

Reviewed by @jabraham17 -- thanks!