### PR TITLE
chapel-py: Fix segmentation fault in some cases.

### DIFF
--- a/tools/chapel-py/src/resolution.cpp
+++ b/tools/chapel-py/src/resolution.cpp
@@ -30,8 +30,14 @@ using namespace types;
 static const ID scopeResolveViaVisibilityStmt(Context* context, const AstNode* visibilityStmt, const AstNode* node) {
   if (visibilityStmt->isUse() || visibilityStmt->isImport()) {
     auto useParent = parsing::parentAst(context, visibilityStmt);
+    if (!useParent) return ID();
+
     auto scope = resolution::scopeForId(context, useParent->id());
+    if (!scope) return ID();
+
     auto reScope = resolution::resolveVisibilityStmts(context, scope);
+    if (!reScope) return ID();
+
     for (auto visCla: reScope->visibilityClauses()) {
       if(visCla.visibilityClauseId().contains(node->id())) {
         return visCla.scope()->id();


### PR DESCRIPTION
Most of these should never be null, but I suppose it doesn't hurt to be defensive anyway. Fixes a segfault discovered when performing bulk rename in Arkouda.