### PR TITLE
Split docker image into multiple stages and improve cache behavior

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,9 +54,10 @@ COPY . .
 
 # build Chapel for both C and LLVM backends
 RUN CHPL_TARGET_COMPILER=llvm make \
-    && CHPL_TARGET_COMPILER=gnu make \
-    && make chpldoc test-venv mason \
-    && make cleanall
+    && CHPL_TARGET_COMPILER=gnu make
+RUN make chpldoc test-venv mason
+RUN make chapel-py-venv chplcheck chpl-language-server
+RUN make cleanall
 
 # Hack to get access to Chapel binaries
 RUN cd $CHPL_HOME/bin && ln -s */* .

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,11 +63,11 @@ FROM chapel-base as chapel-build
 COPY . .
 
 # build Chapel for both C and LLVM backends
-RUN CHPL_TARGET_COMPILER=llvm make -j10 \
-    && CHPL_TARGET_COMPILER=gnu make -j10
-RUN make chpldoc test-venv mason -j10
-RUN make chapel-py-venv chplcheck chpl-language-server -j10
-RUN make cleanall -j10
+RUN CHPL_TARGET_COMPILER=llvm make \
+    && CHPL_TARGET_COMPILER=gnu make
+RUN make chpldoc test-venv mason
+RUN make chapel-py-venv chplcheck chpl-language-server
+RUN make cleanall
 
 # Hack to get access to Chapel binaries
 RUN cd $CHPL_HOME/bin && ln -s */* .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM debian:11
+# Common stage: install dependencies, set up the Debian image
+# ===========================================================
+
+FROM debian:11 AS chapel-base
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     bash \
@@ -48,17 +51,37 @@ ENV CHPL_HOME=/opt/chapel \
     CHPL_GMP=system \
     CHPL_LLVM=system
 
-# acquire sources
 WORKDIR $CHPL_HOME
+
+
+# Build stage: build Chapel from sources
+# ======================================
+
+FROM chapel-base as chapel-build
+
+# acquire sources
 COPY . .
 
 # build Chapel for both C and LLVM backends
-RUN CHPL_TARGET_COMPILER=llvm make \
-    && CHPL_TARGET_COMPILER=gnu make
-RUN make chpldoc test-venv mason
-RUN make chapel-py-venv chplcheck chpl-language-server
-RUN make cleanall
+RUN CHPL_TARGET_COMPILER=llvm make -j10 \
+    && CHPL_TARGET_COMPILER=gnu make -j10
+RUN make chpldoc test-venv mason -j10
+RUN make chapel-py-venv chplcheck chpl-language-server -j10
+RUN make cleanall -j10
 
 # Hack to get access to Chapel binaries
 RUN cd $CHPL_HOME/bin && ln -s */* .
+
+# The .git folder is huge and we really don't need it.
+RUN rm -rf .git
+RUN for subdir in `ls test`; do; if [ "$subdir" != "release" ]; then; rm -rf "test/$subdir"; fi; done
+RUN rm -rf third-party/llvm/llvm-src
+
+
+# Final stage: copy build results, but omit large files.
+# ======================================
+
+FROM chapel-base as chapel
+COPY --from=chapel-build $CHPL_HOME $CHPL_HOME
+
 ENV PATH="${PATH}:${CHPL_HOME}/bin:${CHPL_HOME}/util"

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,11 @@ RUN cd $CHPL_HOME/bin && ln -s */* .
 
 # The .git folder is huge and we really don't need it.
 RUN rm -rf .git
-RUN for subdir in `ls test`; do; if [ "$subdir" != "release" ]; then; rm -rf "test/$subdir"; fi; done
+RUN for subdir in `ls test || true`; do \
+      if [ "$subdir" != "release" ]; then \
+        rm -rf "test/$subdir"; \
+      fi \
+    done
 RUN rm -rf third-party/llvm/llvm-src
 
 


### PR DESCRIPTION
This PR does a major and a minor thing:

* __Major__: splits the dockerfile into multiple stages: a 'common' stage which represents the build-and-run environment of the final image, a 'build' environment which contains all the sources etc. necessary to build Chapel, and a 'release' environment which contains the final build products etc. The multi-stage nature of the build allows files that we don't care about (the `.git` directory, the LLVM sources, most of the `test` directory) to be skipped when building the final image. This way, we are able to strip off at least 0.6GB from the image, and that's not including the size of `.git` (not included in my experiments).
* __Minor__: Adds a `.dockerignore` file that ignores the `Dockerfile`. This way, the `COPY . .` has less of a chance to invalidate the cache as you are iterating on the docker image by tweaking the Dockerfile.

Reviewed by @riftEmber -- thanks!

## Testing
- [x] Image build succeeded
- [x] Successfully used image in a devcontainer