### PR TITLE
LSP: add support for call hierarchy

### DIFF
--- a/tools/chapel-py/src/method-tables/uast-methods.h
+++ b/tools/chapel-py/src/method-tables/uast-methods.h
@@ -39,6 +39,12 @@ CLASS_BEGIN(AstNode)
                chpl::Location, return chpl::parsing::locateAst(context, node))
   PLAIN_GETTER(AstNode, parent, "Get the parent node of this AST node",
                const chpl::uast::AstNode*, return chpl::parsing::parentAst(context, node))
+  PLAIN_GETTER(AstNode, parent_symbol, "Get the parent symbol of this AST node (e.g., module, variable, etc.)",
+               const chpl::uast::AstNode*,
+
+               auto id = node->id();
+               auto parentId = id.parentSymbolId(context);
+               return parsing::idToAst(context, parentId))
   PLAIN_GETTER(AstNode, pragmas, "Get the pragmas of this AST node",
                std::set<std::string>,
 

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -438,9 +438,13 @@ class FileInfo:
         Tuple[NodeAndRange, chapel.TypedSignature]
     ] = field(init=False)
     uses_here: Dict[str, References] = field(init=False)
-    instantiations: Dict[str, Dict[chapel.TypedSignature, List[Tuple[chapel.FnCall, Optional[chapel.TypedSignature]]]]] = field(
-        init=False
-    )
+    instantiations: Dict[
+        str,
+        Dict[
+            chapel.TypedSignature,
+            List[Tuple[chapel.FnCall, Optional[chapel.TypedSignature]]],
+        ],
+    ] = field(init=False)
     siblings: chapel.SiblingMap = field(init=False)
     used_modules: List[chapel.Module] = field(init=False)
     possibly_visible_decls: List[chapel.NamedDecl] = field(init=False)
@@ -583,7 +587,9 @@ class FileInfo:
             with self.context.context.track_errors() as _:
                 self._search_instantiations(asts)
 
-    def called_function_at_position(self, position: Position) -> Optional[chapel.TypedSignature]:
+    def called_function_at_position(
+        self, position: Position
+    ) -> Optional[chapel.TypedSignature]:
         """
         Given a particular position, finds function being called at that
         position.
@@ -695,7 +701,9 @@ class FileInfo:
             -1,
         )
 
-    def concrete_instantiation_for(self, fn: chapel.Function) -> Optional[chapel.TypedSignature]:
+    def concrete_instantiation_for(
+        self, fn: chapel.Function
+    ) -> Optional[chapel.TypedSignature]:
         """
         If all we have is a function ID, we can still select a particular
         typed signature for it in some cases, even without calls: the
@@ -1115,9 +1123,21 @@ class ChapelLanguageServer(LanguageServer):
 
         return item
 
-    def unpack_call_hierarchy_item(self, item: CallHierarchyItem) -> Optional[Tuple[FileInfo, chapel.Function, Optional[chapel.TypedSignature]]]:
-        if item.data is None or not isinstance(item.data, list) or not isinstance(item.data[0], str) or not isinstance(item.data[1], int):
-            self.show_message("Call hierarchy item contains missing or invalid additional data", MessageType.Error)
+    def unpack_call_hierarchy_item(
+        self, item: CallHierarchyItem
+    ) -> Optional[
+        Tuple[FileInfo, chapel.Function, Optional[chapel.TypedSignature]]
+    ]:
+        if (
+            item.data is None
+            or not isinstance(item.data, list)
+            or not isinstance(item.data[0], str)
+            or not isinstance(item.data[1], int)
+        ):
+            self.show_message(
+                "Call hierarchy item contains missing or invalid additional data",
+                MessageType.Error,
+            )
             return None
         uid, idx = item.data
 
@@ -1595,8 +1615,10 @@ def run_lsp():
 
         calls = fi.instantiations[fn.unique_id()][instantiation]
         hack_id_to_node: Dict[str, chapel.NamedDecl] = {}
-        incoming_calls: Dict[Union[chapel.TypedSignature, str], List[chapel.FnCall]] = defaultdict(list)
-        for (call, via) in calls:
+        incoming_calls: Dict[
+            Union[chapel.TypedSignature, str], List[chapel.FnCall]
+        ] = defaultdict(list)
+        for call, via in calls:
             # If the call is from an instantiation, use the instantiation
             # as the hierarchy item anchor.
             if via is not None:

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -1613,6 +1613,9 @@ def run_lsp():
         if instantiation is None:
             return []
 
+        # Here too, because there's no chapel-py way to convert an ID back
+        # to a node, note the node whose ID we use in a dictionary (hack_id_to_node)
+        # to look up later.
         calls = fi.instantiations[fn.unique_id()][instantiation]
         hack_id_to_node: Dict[str, chapel.NamedDecl] = {}
         incoming_calls: Dict[

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -355,6 +355,16 @@ class NodeAndRange:
         path = os.path.abspath(self.node.location().path())
         return f"file://{path}"
 
+    @staticmethod
+    def for_entire_node(node: chapel.AstNode):
+        """
+        Create a NodeAndRange whose location spans the entire AST node, rather
+        than its "relevant-for-hover" piece (i.e., its name).
+        """
+        res = NodeAndRange(node)
+        res.rng = location_to_range(node.location())
+        return res
+
 
 @dataclass
 class ResolvedPair:
@@ -1528,7 +1538,9 @@ def run_lsp():
             return
 
         inst = fi.nth_instantiation(node, i)
-        fi.instantiation_segments.overwrite((decl, inst))
+        fi.instantiation_segments.overwrite(
+            (NodeAndRange.for_entire_node(decl.node), inst)
+        )
 
         ls.lsp.send_request_async(WORKSPACE_INLAY_HINT_REFRESH)
         ls.lsp.send_request_async(WORKSPACE_SEMANTIC_TOKENS_REFRESH)


### PR DESCRIPTION
This PR implements support for call hierarchies. In doing so, it makes the following changes:

* Tweaks the id-to-instantiation list to use a `Dict`, which makes it preserve insertion order. This helps ensure that within a particular generation, indices into that list are constant.
* Adjusts the 'Dict' to also include call information for each instantiation, as well as the relevant instantiation if the call itself was made from an instantiated function. This helps compute 'incoming calls' for each function.
* Adjust the instantiation list to also store concrete function signatures. I leave it as future work to rename the "instantiations" field (and related accessors) to avoid implying that only generic instantiations are stored. The reason this change is needed is to provide "incoming calls" for concrete functions. The "Show instantiations" buttons are not shown for concrete signatures.

The rest of the implementation is relatively unremarkable.

Reviewed by @jabraham17 -- thanks!