### PR TITLE
Miscellaneous dyno fixes in support of "Hello World"

### DIFF
--- a/frontend/include/chpl/types/CompositeType.h
+++ b/frontend/include/chpl/types/CompositeType.h
@@ -219,6 +219,9 @@ class CompositeType : public Type {
   /** Get the locale type */
   static const RecordType* getLocaleType(Context* context);
 
+  /** Get the chpl_localeID_t type */
+  static const RecordType* getLocaleIDType(Context* context);
+
   /** When compiling without a standard library (for testing purposes),
       the compiler code needs to work around the fact that there
       is no definition available for the bundled types needed

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2132,6 +2132,8 @@ QualifiedType Resolver::typeForId(const ID& id, bool localGenericToUnknown) {
   if (asttags::isAggregateDecl(tag)) {
     const Type* t = initialTypeForTypeDecl(context, id);
     return QualifiedType(QualifiedType::TYPE, t);
+  } else if (asttags::isModule(tag)) {
+    return QualifiedType(QualifiedType::MODULE, nullptr);
   }
 
   if (asttags::isFunction(tag)) {
@@ -2154,14 +2156,14 @@ QualifiedType Resolver::typeForId(const ID& id, bool localGenericToUnknown) {
   // Figure out what ID is contained within so we can use the
   // appropriate query.
   ID parentId = id.parentSymbolId(context);
-  auto parentTag = asttags::Module;
+  auto parentTag = asttags::AST_TAG_UNKNOWN;
   if (!parentId.isEmpty()) {
     parentTag = parsing::idToTag(context, parentId);
   }
 
   if (asttags::isModule(parentTag)) {
     // If the id is contained within a module, use typeForModuleLevelSymbol.
-    bool isCurrentModule = !parentId.isEmpty() &&
+    bool isCurrentModule =
         parsing::idToAst(context, parentId)->toModule() == symbol->toModule();
     return typeForModuleLevelSymbol(context, id, isCurrentModule);
   }

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2161,7 +2161,7 @@ QualifiedType Resolver::typeForId(const ID& id, bool localGenericToUnknown) {
 
   if (asttags::isModule(parentTag)) {
     // If the id is contained within a module, use typeForModuleLevelSymbol.
-    bool isCurrentModule =
+    bool isCurrentModule = !parentId.isEmpty() &&
         parsing::idToAst(context, parentId)->toModule() == symbol->toModule();
     return typeForModuleLevelSymbol(context, id, isCurrentModule);
   }

--- a/frontend/lib/resolution/VarScopeVisitor.cpp
+++ b/frontend/lib/resolution/VarScopeVisitor.cpp
@@ -448,9 +448,12 @@ bool VarScopeVisitor::enter(const FnCall* callAst, RV& rv) {
     // This filter is intended as an optimization.
     const MostSpecificCandidates& candidates = rv.byAst(callAst).mostSpecific();
     bool anyInOutInout = false;
+    bool isMethod = false;
     for (const MostSpecificCandidate& candidate : candidates) {
       if (candidate) {
         auto fn = candidate.fn();
+        if (fn->untyped()->isMethod()) isMethod = true;
+
         int n = fn->numFormals();
         for (int i = 0; i < n; i++) {
           const QualifiedType& formalQt = fn->formalType(i);
@@ -477,10 +480,19 @@ bool VarScopeVisitor::enter(const FnCall* callAst, RV& rv) {
       // Use FormalActualMap to figure out which variable ID
       // is passed to a formal with out/in/inout intent.
       // Issue an error if it does not match among return intent overloads.
+      //
+      // TODO: Should we store the resolved CallInfo so we don't need to build
+      // it back up here?
       std::vector<const AstNode*> actualAsts;
       auto ci = CallInfo::create(context, callAst, rv.byPostorder(),
                                  /* raiseErrors */ false,
                                  &actualAsts);
+
+      if (isMethod) {
+        // Create a dummy 'this' actual
+        ci = ci.createWithReceiver(ci, QualifiedType());
+        actualAsts.insert(actualAsts.begin(), nullptr);
+      }
 
       // compute a vector indicating which actuals are passed to
       // an 'out' formal in all return intent overloads
@@ -497,7 +509,9 @@ bool VarScopeVisitor::enter(const FnCall* callAst, RV& rv) {
         Qualifier kind = actualFormalIntents[actualIdx];
 
         // handle an actual that is passed to an 'out'/'in'/'inout' formal
-        if (kind == Qualifier::OUT) {
+        if (actualAst == nullptr) {
+          CHPL_ASSERT(ci.isMethodCall() && actualIdx == 0);
+        } else if (kind == Qualifier::OUT) {
           handleOutFormal(callAst, actualAst,
                           actualFormalTypes[actualIdx], rv);
         } else if (kind == Qualifier::IN || kind == Qualifier::CONST_IN) {

--- a/frontend/lib/resolution/VarScopeVisitor.cpp
+++ b/frontend/lib/resolution/VarScopeVisitor.cpp
@@ -488,7 +488,7 @@ bool VarScopeVisitor::enter(const FnCall* callAst, RV& rv) {
                                  /* raiseErrors */ false,
                                  &actualAsts);
 
-      if (isMethod) {
+      if (isMethod && ci.isMethodCall() == false) {
         // Create a dummy 'this' actual
         ci = ci.createWithReceiver(ci, QualifiedType());
         actualAsts.insert(actualAsts.begin(), nullptr);

--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -287,7 +287,7 @@ bool CanPassResult::canConvertNumeric(Context* context,
     // don't convert bools to reals (per spec: "unintended by programmer")
 
     // coerce any integer type to any width real
-    if (actualT->isNumericType())
+    if (actualT->isIntegralType())
       return true;
 
     // convert real from smaller size

--- a/frontend/lib/resolution/disambiguation.cpp
+++ b/frontend/lib/resolution/disambiguation.cpp
@@ -347,6 +347,16 @@ findMostSpecificCandidatesQuery(Context* context,
     // disambiguateByMatch(dctx, candidates);
     computeMostSpecificCandidates(context, dctx, candidates);
 
+  if (result.numBest() == 1) {
+    MostSpecificCandidate only;
+    if (result.bestRef()) only = result.bestRef();
+    else if (result.bestConstRef()) only = result.bestConstRef();
+    else if (result.bestValue()) only = result.bestValue();
+
+    // Ensure that the only result is in the 'ONLY' slot.
+    result = MostSpecificCandidates::getOnly(only);
+  }
+
   // Delete all of the FormalActualMaps
   for (auto elt : candidates) {
     delete elt;

--- a/frontend/lib/resolution/intents.cpp
+++ b/frontend/lib/resolution/intents.cpp
@@ -40,7 +40,7 @@ static QualifiedType::Kind constIntentForType(const Type* t) {
   if (t->isPrimitiveType() || t->isEnumType() || t->isExternType() ||
       t->isOpaqueType() || t->isTaskIdType()  || t->isNilType() ||
       t->isCStringType() || t->isCVoidPtrType() || t->isCFnPtrType() ||
-      t->isNothingType() || t->isVoidType())
+      t->isNothingType() || t->isVoidType() || t->isCPtrType())
     return QualifiedType::CONST_IN;
 
   if (t->isStringType() || t->isBytesType() ||

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -1617,6 +1617,10 @@ CallResolutionResult resolvePrimCall(Context* context,
       type = QualifiedType(QualifiedType::CONST_VAR,
                            IntType::get(context, 32));
       break;
+    case PRIM_ON_LOCALE_NUM:
+      type = QualifiedType(QualifiedType::CONST_VAR,
+                           CompositeType::getLocaleIDType(context));
+      break;
     case PRIM_USED_MODULES_LIST:
     case PRIM_REFERENCED_MODULES_LIST:
     case PRIM_TUPLE_EXPAND:
@@ -1641,7 +1645,6 @@ CallResolutionResult resolvePrimCall(Context* context,
     case PRIM_LOGICAL_FOLDER:
     case PRIM_WIDE_MAKE:
     case PRIM_WIDE_GET_LOCALE:
-    case PRIM_ON_LOCALE_NUM:
     case PRIM_REGISTER_GLOBAL_VAR:
     case PRIM_BROADCAST_GLOBAL_VARS:
     case PRIM_PRIVATE_BROADCAST:

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -1332,7 +1332,8 @@ CallResolutionResult resolvePrimCall(Context* context,
                                IntParam::get(context, s));
           break;
         } else if (actualType.type()->isStringType() ||
-                   actualType.type()->isBytesType()) {
+                   actualType.type()->isBytesType() ||
+                   actualType.type()->isCStringType()) {
           // for non-param string/bytes, the return type is just a default int
           type = QualifiedType(QualifiedType::CONST_VAR,
                                IntType::get(context, 0));

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -1318,7 +1318,6 @@ CallResolutionResult resolvePrimCall(Context* context,
     /* string operations */
     case PRIM_STRING_COMPARE:
     case PRIM_STRING_CONTAINS:
-    case PRIM_STRING_CONCAT:
     case PRIM_STRING_LENGTH_BYTES:
     {
       if (ci.numActuals() > 0) {
@@ -1340,6 +1339,22 @@ CallResolutionResult resolvePrimCall(Context* context,
           break;
         }
       }
+    }
+    case PRIM_STRING_CONCAT:
+    {
+      if (ci.numActuals() == 2) {
+        auto lhs = ci.actual(0).type();
+        auto rhs = ci.actual(1).type();
+        CHPL_ASSERT(lhs.type() == rhs.type());
+        CHPL_ASSERT(lhs.isParam() && rhs.isParam());
+        CHPL_ASSERT(lhs.type()->isStringType() || lhs.type()->isBytesType());
+
+        auto lstr = lhs.param()->toStringParam()->value();
+        auto rstr = rhs.param()->toStringParam()->value();
+        auto concat = UniqueString::getConcat(context, lstr.c_str(), rstr.c_str());
+        type = QualifiedType(QualifiedType::PARAM, lhs.type(), StringParam::get(context, concat));
+      }
+      break;
     }
     case PRIM_STRING_LENGTH_CODEPOINTS:
     case PRIM_ASCII:

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -1345,14 +1345,15 @@ CallResolutionResult resolvePrimCall(Context* context,
       if (ci.numActuals() == 2) {
         auto lhs = ci.actual(0).type();
         auto rhs = ci.actual(1).type();
-        CHPL_ASSERT(lhs.type() == rhs.type());
-        CHPL_ASSERT(lhs.isParam() && rhs.isParam());
-        CHPL_ASSERT(lhs.type()->isStringType() || lhs.type()->isBytesType());
 
-        auto lstr = lhs.param()->toStringParam()->value();
-        auto rstr = rhs.param()->toStringParam()->value();
-        auto concat = UniqueString::getConcat(context, lstr.c_str(), rstr.c_str());
-        type = QualifiedType(QualifiedType::PARAM, lhs.type(), StringParam::get(context, concat));
+        if (lhs.type() == rhs.type() &&
+            lhs.isParam() && rhs.isParam() &&
+            (lhs.type()->isStringType() || lhs.type()->isBytesType())) {
+          auto lstr = lhs.param()->toStringParam()->value();
+          auto rstr = rhs.param()->toStringParam()->value();
+          auto concat = UniqueString::getConcat(context, lstr.c_str(), rstr.c_str());
+          type = QualifiedType(QualifiedType::PARAM, lhs.type(), StringParam::get(context, concat));
+        }
       }
       break;
     }

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -1514,7 +1514,8 @@ ApplicabilityResult instantiateSignature(Context* context,
 
   const TypedFnSignature* parentFnTyped = nullptr;
   if (sig->parentFn()) {
-    CHPL_ASSERT(false && "generic child functions not yet supported");
+    CHPL_UNIMPL("generic child functions not yet supported");
+    return ApplicabilityResult::failure(sig->id(), FAIL_CANDIDATE_OTHER);
     // TODO: how to compute parentFn for the instantiation?
     // Does the parent function need to be instantiated in some case?
     // Set parentFnTyped somehow.

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2930,6 +2930,21 @@ static bool resolveFnCallSpecial(Context* context,
     return true;
   }
 
+  if (ci.name() == USTR("this") && ci.numActuals() == 2) {
+    // compiler-defined 'this' operator for param-indexed tuples
+    auto thisType = ci.actual(0).type();
+    auto second = ci.actual(1).type();
+    if (thisType.hasTypePtr() && thisType.type()->isTupleType() &&
+        second.isParam() && second.hasParamPtr() &&
+        second.type()->isIntType()) {
+      auto tup = thisType.type()->toTupleType();
+      auto val = second.param()->toIntParam()->value();
+      auto member = tup->elementType(val);
+      exprTypeOut = member;
+      return true;
+    }
+  }
+
   return false;
 }
 

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2901,6 +2901,21 @@ static bool resolveFnCallSpecial(Context* context,
     }
   }
 
+  if (ci.isOpCall() && ci.name() == USTR(":")) {
+    auto src = ci.actual(0).type();
+    auto dst = ci.actual(1).type();
+
+    if (src.isType() && dst.hasTypePtr() && dst.type()->isStringType()) {
+      std::ostringstream oss;
+      src.type()->stringify(oss, chpl::StringifyKind::CHPL_SYNTAX);
+      auto ustr = UniqueString::get(context, oss.str());
+      exprTypeOut = QualifiedType(QualifiedType::PARAM,
+                                  RecordType::getStringType(context),
+                                  StringParam::get(context, ustr));
+      return true;
+    }
+  }
+
   if (ci.name() == USTR("isCoercible")) {
     if (ci.numActuals() != 2) {
       context->error(astForErr, "bad call to %s", ci.name().c_str());

--- a/frontend/lib/types/CompositeType.cpp
+++ b/frontend/lib/types/CompositeType.cpp
@@ -153,6 +153,14 @@ const RecordType* CompositeType::getLocaleType(Context* context) {
                          SubstitutionsMap());
 }
 
+const RecordType* CompositeType::getLocaleIDType(Context* context) {
+  auto name = UniqueString::get(context, "chpl_localeID_t");
+  auto id = ID();
+  return RecordType::get(context, id, name,
+                         /* instantiatedFrom */ nullptr,
+                         SubstitutionsMap());
+}
+
 bool CompositeType::isMissingBundledType(Context* context, ID id) {
   return isMissingBundledClassType(context, id) ||
          isMissingBundledRecordType(context, id);

--- a/frontend/lib/types/Type.cpp
+++ b/frontend/lib/types/Type.cpp
@@ -119,6 +119,7 @@ void Type::gatherBuiltins(Context* context,
   auto localeType = CompositeType::getLocaleType(context);
   gatherType(context, map, "locale", localeType);
   gatherType(context, map, "_locale", localeType);
+  gatherType(context, map, "chpl_localeID_t", CompositeType::getLocaleIDType(context));
 
   auto rangeType = CompositeType::getRangeType(context);
   gatherType(context, map, "range", rangeType);

--- a/frontend/test/resolution/testCanPass.cpp
+++ b/frontend/test/resolution/testCanPass.cpp
@@ -103,6 +103,7 @@ static void test1() {
   QualifiedType int32(QualifiedType::VAR, IntType::get(context, 32));
   QualifiedType int64(QualifiedType::VAR, IntType::get(context, 64));
   QualifiedType real0(QualifiedType::VAR, RealType::get(context, 0));
+  QualifiedType complex128(QualifiedType::VAR, ComplexType::get(context, 0));
 
   CanPassResult r;
   r = canPass(c, int0, int0); assert(passesAsIs(r));
@@ -136,6 +137,9 @@ static void test1() {
   r = canPass(c, int0, int16); assert(doesNotPass(r));
   r = canPass(c, int0, int32); assert(doesNotPass(r));
   r = canPass(c, int0, int64); assert(passesAsIs(r));
+
+  r = canPass(c, int0, complex128); assert(passesNumeric(r));
+  r = canPass(c, complex128, real0); assert(doesNotPass(r));
 }
 
 static void test2() {

--- a/frontend/test/resolution/testDisambiguation.cpp
+++ b/frontend/test/resolution/testDisambiguation.cpp
@@ -335,12 +335,34 @@ static void test4() {
   assert(foundOnlyIdx == 2);
 }
 
+static void test5() {
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  std::string program = R"""(
+    proc foo(arg) where arg.type == int {
+      return 42;
+    }
+
+    proc foo(arg) {
+      return "hello";
+    }
+
+    var x = foo(42);
+    )""";
+
+  auto qt = resolveQualifiedTypeOfX(context, program);
+  assert(qt.type()->isIntType());
+}
+
 int main() {
 
   test1();
   test2();
   test3();
   test4();
+  test5();
 
   return 0;
 }

--- a/frontend/test/resolution/testTuples.cpp
+++ b/frontend/test/resolution/testTuples.cpp
@@ -550,6 +550,31 @@ static void testTupleGeneric() {
   argHelper("(numeric, numeric)", "(5, 'hi')", false);
 }
 
+static void test18() {
+  printf("test18\n");
+  Context ctx;
+  Context* context = &ctx;
+
+  auto program = R""""(
+                  var t = (1, "hello", 3.0);
+                  var x = t(0);
+                  var y = t(1);
+                  var z = t(2);
+                )"""";
+
+  auto m = parseModule(context, std::move(program));
+
+  auto x = findVariable(m, "x");
+  auto y = findVariable(m ,"y");
+  auto z = findVariable(m ,"z");
+
+  const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
+
+  assert(rr.byAst(x).type().type()->isIntType());
+  assert(rr.byAst(y).type().type()->isStringType());
+  assert(rr.byAst(z).type().type()->isRealType());
+}
+
 int main() {
   test1();
   test2();
@@ -568,6 +593,7 @@ int main() {
   test15();
   test16();
   test17();
+  test18();
 
   testTupleGeneric();
 

--- a/frontend/test/resolution/testTypeOperators.cpp
+++ b/frontend/test/resolution/testTypeOperators.cpp
@@ -70,9 +70,27 @@ static void test3() {
   assert(qt1.isParamFalse());
 }
 
+static void test4() {
+  Context ctx;
+  auto context = &ctx;
+  ErrorGuard guard(context);
+
+  QualifiedType qt1 =  resolveTypeOfXInit(context,
+                         R""""(
+                         record R {}
+
+                         var y : R;
+                         param x = y.type:string;
+                         )"""");
+
+  assert(qt1.isParam() && qt1.type()->isStringType());
+  assert(qt1.param()->toStringParam()->value() == "R");
+}
+
 int main() {
   test1();
   test2();
   test3();
+  test4();
   return 0;
 }


### PR DESCRIPTION
This PR includes a number of fixes for dyno resolution bugs encountered while trying to resolve "Hello World":
- Support for chpl_localeID_t and PRIM_ON_LOCALE_NUM
- Fix "can pass" bug that allowed passing complex to real
- Allows c_string in certain primitives
- Implement PRIM_STRING_CONCAT for param values
- Implement casting from type to string (e.g. ``x.type : string``)
- Implement 'this' indexing for tuples with param indices
- Fix some minor mis-uses of CallInfo and MostSpecificCandidates
- Fix an ID-related bug for calls like ``MyModule.foo()``
- Removes a workaround for the ``kind`` field that was recently removed from fileReader/Writer

Testing:
- [x] full local
- [x] full gasnet