### PR TITLE
Fix `--llvm-print-ir` with llvm 17

### DIFF
--- a/compiler/llvm/llvmExtractIR.cpp
+++ b/compiler/llvm/llvmExtractIR.cpp
@@ -102,6 +102,8 @@ std::unique_ptr<Module> extractLLVM(const llvm::Module* fromModule,
   PM.addPass(GlobalDCEPass());           // Delete unreachable globals
   PM.addPass(StripDeadDebugInfoPass());  // Remove dead debug info
   PM.addPass(StripDeadPrototypesPass()); // Remove dead func decls
+
+  PM.run(M, MAM);
 #else
   legacy::PassManager Passes;
 


### PR DESCRIPTION
Fixes `--llvm-print-ir` when using llvm 17. The passes that strip unnecessary symbols where being built but never run.

Resolves #24448

[Reviewed by @mppf]