### PR TITLE
clean up launcher -nl suffix tests

### DIFF
--- a/test/runtime/configMatters/launch/jhh/co-locales/co-locales.py
+++ b/test/runtime/configMatters/launch/jhh/co-locales/co-locales.py
@@ -199,7 +199,7 @@ class ColocaleArgs(unittest.TestCase):
         with self.assertRaises(subprocess.CalledProcessError) as cm:
             output = self.runCmd("./hello -nl -3x2z -v --dry-run")
         self.assertEqual(cm.exception.stdout.strip(),
-            '<command-line arg>:1: error: "2z" is not a valid number of co-locales.')
+            '<command-line arg>:1: error: "z" is not a valid suffix.')
 
     def test_18_invalid_suffix2(self):
         """Reject invalid suffix that starts with a valid character"""


### PR DESCRIPTION
Added launcher tests for the `-nl `argument suffix. Also, removed dependencies on `sinfo` and  `sbatch` so the tests can be run on a system on which `slurm` is not installed, and fixed the wording of a few error messages.

Resolves https://github.com/Cray/chapel-private/issues/5997.