### PR TITLE
Disable generation of '.dSYM' archives when compiling with '--library'

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -5179,9 +5179,12 @@ void makeBinaryLLVM(void) {
                      dotOFiles, clangLDArgs);
     }
 
+    // TODO: Library compiles can produce a '.a' archive as output which
+    // 'dsymutil' doesn't seem to know how to handle. So we'll probably
+    // need a more complicated invocation.
     const bool generateDarwinSymArchive =
-          strcmp(CHPL_TARGET_PLATFORM, "darwin") == 0 &&
-          debugCCode;
+          !strcmp(CHPL_TARGET_PLATFORM, "darwin") && debugCCode &&
+          !fLibraryCompile;
 
     if (generateDarwinSymArchive) {
       const char* bin = "dsymutil";


### PR DESCRIPTION
This PR disables generation of OSX `.dSYM` debugging archives when compiling Chapel programs with `--library`. Libraries can produce `.a` archive files which the `dsymutil` tool does not understand how to unpack directly. Enabling debug symbols for libraries under OSX is future work.