### PR TITLE
chapel-py: various changes to narrow the Python types listed in .pyi

### DIFF
--- a/frontend/include/chpl/uast/FunctionSignature.h
+++ b/frontend/include/chpl/uast/FunctionSignature.h
@@ -150,8 +150,8 @@ class FunctionSignature final : public AstNode {
     Return a way to iterate over the formals, including the method
     receiver, if present, as the first formal.
   */
-  AstListIteratorPair<AstNode> formals() const {
-    return childRange<AstNode>(formalsChildNum_, numFormals_);
+  AstListIteratorPair<Decl> formals() const {
+    return childRange<Decl>(formalsChildNum_, numFormals_);
   }
 
   /**

--- a/tools/chapel-py/src/chapel.cpp
+++ b/tools/chapel-py/src/chapel.cpp
@@ -48,7 +48,7 @@ PyMODINIT_FUNC PyInit_core() {
   setupGeneratedTypes();
 
 #define READY_TYPE(NAME) if (PyType_Ready(&NAME##Type) < 0) return nullptr;
-#define GENERATED_TYPE(ROOT, NAME, TYPE, TAG, FLAGS) READY_TYPE(NAME)
+#define GENERATED_TYPE(ROOT, ROOT_TYPE, NAME, TYPE, TAG, FLAGS) READY_TYPE(NAME)
 #include "generated-types-list.h"
 #undef GENERATED_TYPE
   READY_TYPE(AstIter)
@@ -70,7 +70,7 @@ PyMODINIT_FUNC PyInit_core() {
   if (!chapelModule) return nullptr;
 
 #define ADD_TYPE(NAME) if (PyModule_AddObject(chapelModule, #NAME, (PyObject*) &NAME##Type) < 0) return nullptr;
-#define GENERATED_TYPE(ROOT, NAME, TYPE, TAG, FLAGS) ADD_TYPE(NAME)
+#define GENERATED_TYPE(ROOT, ROOT_TYPE, NAME, TYPE, TAG, FLAGS) ADD_TYPE(NAME)
 #include "generated-types-list.h"
 #undef GENERATED_TYPE
 

--- a/tools/chapel-py/src/chapel.cpp
+++ b/tools/chapel-py/src/chapel.cpp
@@ -48,7 +48,7 @@ PyMODINIT_FUNC PyInit_core() {
   setupGeneratedTypes();
 
 #define READY_TYPE(NAME) if (PyType_Ready(&NAME##Type) < 0) return nullptr;
-#define GENERATED_TYPE(ROOT, NAME, TAG, FLAGS) READY_TYPE(NAME)
+#define GENERATED_TYPE(ROOT, NAME, TYPE, TAG, FLAGS) READY_TYPE(NAME)
 #include "generated-types-list.h"
 #undef GENERATED_TYPE
   READY_TYPE(AstIter)
@@ -70,7 +70,7 @@ PyMODINIT_FUNC PyInit_core() {
   if (!chapelModule) return nullptr;
 
 #define ADD_TYPE(NAME) if (PyModule_AddObject(chapelModule, #NAME, (PyObject*) &NAME##Type) < 0) return nullptr;
-#define GENERATED_TYPE(ROOT, NAME, TAG, FLAGS) ADD_TYPE(NAME)
+#define GENERATED_TYPE(ROOT, NAME, TYPE, TAG, FLAGS) ADD_TYPE(NAME)
 #include "generated-types-list.h"
 #undef GENERATED_TYPE
 

--- a/tools/chapel-py/src/core-types-gen.cpp
+++ b/tools/chapel-py/src/core-types-gen.cpp
@@ -46,7 +46,7 @@ using namespace uast;
   } \
 
 /* Use the X-macros pattern to invoke DEFINE_INIT_FOR for each AST node type. */
-#define GENERATED_TYPE(ROOT, NAME, TYPE, TAG, FLAGS) DEFINE_INIT_FOR(NAME, TAG)
+#define GENERATED_TYPE(ROOT, ROOT_TYPE, NAME, TYPE, TAG, FLAGS) DEFINE_INIT_FOR(NAME, TAG)
 #include "generated-types-list.h"
 
 static const char* blockStyleToString(BlockStyle blockStyle) {
@@ -146,7 +146,7 @@ ACTUAL_ITERATOR(FnCall);
   }; \
 
 /* Now, invoke DEFINE_PY_TYPE_FOR for each AST node to get our type objects. */
-#define GENERATED_TYPE(ROOT, NAME, TYPE, TAG, FLAGS) DEFINE_PY_TYPE_FOR(NAME)
+#define GENERATED_TYPE(ROOT, ROOT_TYPE, NAME, TYPE, TAG, FLAGS) DEFINE_PY_TYPE_FOR(NAME)
 #include "generated-types-list.h"
 
 #define INITIALIZE_PY_TYPE_FOR(NAME, TYPE, TAG, FLAGS)\
@@ -161,6 +161,6 @@ ACTUAL_ITERATOR(FnCall);
   TYPE.tp_new = PyType_GenericNew; \
 
 void setupGeneratedTypes() {
-#define GENERATED_TYPE(ROOT, NAME, TYPE, TAG, FLAGS) INITIALIZE_PY_TYPE_FOR(NAME, NAME##Type, TAG, FLAGS)
+#define GENERATED_TYPE(ROOT, ROOT_TYPE, NAME, TYPE, TAG, FLAGS) INITIALIZE_PY_TYPE_FOR(NAME, NAME##Type, TAG, FLAGS)
 #include "generated-types-list.h"
 }

--- a/tools/chapel-py/src/core-types-gen.cpp
+++ b/tools/chapel-py/src/core-types-gen.cpp
@@ -46,7 +46,7 @@ using namespace uast;
   } \
 
 /* Use the X-macros pattern to invoke DEFINE_INIT_FOR for each AST node type. */
-#define GENERATED_TYPE(ROOT, NAME, TAG, FLAGS) DEFINE_INIT_FOR(NAME, TAG)
+#define GENERATED_TYPE(ROOT, NAME, TYPE, TAG, FLAGS) DEFINE_INIT_FOR(NAME, TAG)
 #include "generated-types-list.h"
 
 static const char* blockStyleToString(BlockStyle blockStyle) {
@@ -146,7 +146,7 @@ ACTUAL_ITERATOR(FnCall);
   }; \
 
 /* Now, invoke DEFINE_PY_TYPE_FOR for each AST node to get our type objects. */
-#define GENERATED_TYPE(ROOT, NAME, TAG, FLAGS) DEFINE_PY_TYPE_FOR(NAME)
+#define GENERATED_TYPE(ROOT, NAME, TYPE, TAG, FLAGS) DEFINE_PY_TYPE_FOR(NAME)
 #include "generated-types-list.h"
 
 #define INITIALIZE_PY_TYPE_FOR(NAME, TYPE, TAG, FLAGS)\
@@ -161,6 +161,6 @@ ACTUAL_ITERATOR(FnCall);
   TYPE.tp_new = PyType_GenericNew; \
 
 void setupGeneratedTypes() {
-#define GENERATED_TYPE(ROOT, NAME, TAG, FLAGS) INITIALIZE_PY_TYPE_FOR(NAME, NAME##Type, TAG, FLAGS)
+#define GENERATED_TYPE(ROOT, NAME, TYPE, TAG, FLAGS) INITIALIZE_PY_TYPE_FOR(NAME, NAME##Type, TAG, FLAGS)
 #include "generated-types-list.h"
 }

--- a/tools/chapel-py/src/core-types-gen.h
+++ b/tools/chapel-py/src/core-types-gen.h
@@ -42,7 +42,7 @@
   extern PyTypeObject NAME##Type;
 
 /* Generate a Python object for reach AST node type. */
-#define GENERATED_TYPE(ROOT, NAME, TAG, FLAGS) DECLARE_PY_OBJECT_FOR(ROOT, NAME)
+#define GENERATED_TYPE(ROOT, NAME, TYPE, TAG, FLAGS) DECLARE_PY_OBJECT_FOR(ROOT, NAME)
 #include "generated-types-list.h"
 #undef DECLARE_PY_OBJECT_FOR
 

--- a/tools/chapel-py/src/core-types-gen.h
+++ b/tools/chapel-py/src/core-types-gen.h
@@ -42,7 +42,7 @@
   extern PyTypeObject NAME##Type;
 
 /* Generate a Python object for reach AST node type. */
-#define GENERATED_TYPE(ROOT, NAME, TYPE, TAG, FLAGS) DECLARE_PY_OBJECT_FOR(ROOT, NAME)
+#define GENERATED_TYPE(ROOT, ROOT_TYPE, NAME, TYPE, TAG, FLAGS) DECLARE_PY_OBJECT_FOR(ROOT, NAME)
 #include "generated-types-list.h"
 #undef DECLARE_PY_OBJECT_FOR
 

--- a/tools/chapel-py/src/core-types.cpp
+++ b/tools/chapel-py/src/core-types.cpp
@@ -70,7 +70,7 @@ struct ParentTypeInfo {
   static PyTypeObject* parentTypeObject() { return nullptr; }
 };
 
-#define GENERATED_TYPE(ROOT, NAME, TYPE, TAG, FLAGS) \
+#define GENERATED_TYPE(ROOT, ROOT_TYPE, NAME, TYPE, TAG, FLAGS) \
   template <> \
   struct ParentTypeInfo<NAME##Object> { \
     static PyTypeObject* parentTypeObject() { \
@@ -134,7 +134,7 @@ std::string generatePyiFile() {
       ss << "    pass" << std::endl; \
     } \
 
-  #define GENERATED_TYPE(ROOT, NAME, TYPE, TAG, FLAGS) ENSURE_ALL_CLASSES(NAME, TAG)
+  #define GENERATED_TYPE(ROOT, ROOT_TYPE, NAME, TYPE, TAG, FLAGS) ENSURE_ALL_CLASSES(NAME, TAG)
   #include "generated-types-list.h"
   #undef ENSURE_ALL_CLASSES
 

--- a/tools/chapel-py/src/core-types.cpp
+++ b/tools/chapel-py/src/core-types.cpp
@@ -203,7 +203,8 @@ PyTypeObject* parentTypeFor(chpl::types::paramtags::ParamTag tag) {
 PyObject* wrapGeneratedType(ContextObject* context, const AstNode* node) {
   PyObject* toReturn = nullptr;
   if (node == nullptr) {
-    Py_RETURN_NONE;
+    PyErr_SetString(PyExc_RuntimeError, "implementation attempted to wrap a null pointer");
+    return nullptr;
   }
   PyObject* args = Py_BuildValue("(O)", (PyObject*) context);
   switch (node->tag()) {
@@ -232,7 +233,8 @@ PyObject* wrapGeneratedType(ContextObject* context, const AstNode* node) {
 PyObject* wrapGeneratedType(ContextObject* context, const types::Type* node) {
   PyObject* toReturn = nullptr;
   if (node == nullptr) {
-    Py_RETURN_NONE;
+    PyErr_SetString(PyExc_RuntimeError, "implementation attempted to wrap a null pointer");
+    return nullptr;
   }
   PyObject* args = Py_BuildValue("(O)", (PyObject*) context);
   switch (node->tag()) {
@@ -261,7 +263,8 @@ PyObject* wrapGeneratedType(ContextObject* context, const types::Type* node) {
 PyObject* wrapGeneratedType(ContextObject* context, const chpl::types::Param* node) {
   PyObject* toReturn = nullptr;
   if (node == nullptr) {
-    Py_RETURN_NONE;
+    PyErr_SetString(PyExc_RuntimeError, "implementation attempted to wrap a null pointer");
+    return nullptr;
   }
   PyObject* args = Py_BuildValue("(O)", (PyObject*) context);
   switch (node->tag()) {

--- a/tools/chapel-py/src/core-types.cpp
+++ b/tools/chapel-py/src/core-types.cpp
@@ -70,7 +70,7 @@ struct ParentTypeInfo {
   static PyTypeObject* parentTypeObject() { return nullptr; }
 };
 
-#define GENERATED_TYPE(ROOT, NAME, TAG, FLAGS) \
+#define GENERATED_TYPE(ROOT, NAME, TYPE, TAG, FLAGS) \
   template <> \
   struct ParentTypeInfo<NAME##Object> { \
     static PyTypeObject* parentTypeObject() { \
@@ -134,7 +134,7 @@ std::string generatePyiFile() {
       ss << "    pass" << std::endl; \
     } \
 
-  #define GENERATED_TYPE(ROOT, NAME, TAG, FLAGS) ENSURE_ALL_CLASSES(NAME, TAG)
+  #define GENERATED_TYPE(ROOT, NAME, TYPE, TAG, FLAGS) ENSURE_ALL_CLASSES(NAME, TAG)
   #include "generated-types-list.h"
   #undef ENSURE_ALL_CLASSES
 

--- a/tools/chapel-py/src/core-types.cpp
+++ b/tools/chapel-py/src/core-types.cpp
@@ -200,7 +200,7 @@ PyTypeObject* parentTypeFor(chpl::types::paramtags::ParamTag tag) {
   return &ParamObject::PythonType;
 }
 
-PyObject* wrapAstNode(ContextObject* context, const AstNode* node) {
+PyObject* wrapGeneratedType(ContextObject* context, const AstNode* node) {
   PyObject* toReturn = nullptr;
   if (node == nullptr) {
     Py_RETURN_NONE;
@@ -229,7 +229,7 @@ PyObject* wrapAstNode(ContextObject* context, const AstNode* node) {
   return toReturn;
 }
 
-PyObject* wrapType(ContextObject* context, const types::Type* node) {
+PyObject* wrapGeneratedType(ContextObject* context, const types::Type* node) {
   PyObject* toReturn = nullptr;
   if (node == nullptr) {
     Py_RETURN_NONE;
@@ -258,7 +258,7 @@ PyObject* wrapType(ContextObject* context, const types::Type* node) {
   return toReturn;
 }
 
-PyObject* wrapParam(ContextObject* context, const chpl::types::Param* node) {
+PyObject* wrapGeneratedType(ContextObject* context, const chpl::types::Param* node) {
   PyObject* toReturn = nullptr;
   if (node == nullptr) {
     Py_RETURN_NONE;

--- a/tools/chapel-py/src/core-types.cpp
+++ b/tools/chapel-py/src/core-types.cpp
@@ -117,6 +117,10 @@ std::string generatePyiFile() {
     ss << "        " << DOCSTR << std::endl; \
     ss << "        \"\"\"" << std::endl; \
     ss << "        ..." << std::endl << std::endl;
+  #define ITER_PROTOTYPE(NODE, TYPE) \
+    printedAnything = true; \
+    ss << "    def __iter__(self) -> typing.Iterator[" << PythonReturnTypeInfo<TYPE>::typeString() << "]:" << std::endl; \
+    ss << "        ..." << std::endl << std::endl;
   #define CLASS_END(NODE) \
     if (!printedAnything) { \
       ss << "    pass" << std::endl; \

--- a/tools/chapel-py/src/core-types.h
+++ b/tools/chapel-py/src/core-types.h
@@ -27,6 +27,18 @@
 #include "error-tracker.h"
 #include "python-class.h"
 
+/* Tiny helper class to support marshalling to and from Python types.
+   This wraps a regular pointers, but instead of throwing Python exceptions
+   when the underlying pointer is 'null', it returns None. */
+template <typename T>
+struct Nilable {
+  T value;
+
+  Nilable() : value(nullptr) {}
+  Nilable(T value) : value(value) {}
+};
+
+
 PyTypeObject* parentTypeFor(chpl::uast::asttags::AstTag tag);
 PyTypeObject* parentTypeFor(chpl::types::typetags::TypeTag tag);
 PyTypeObject* parentTypeFor(chpl::types::paramtags::ParamTag tag);
@@ -57,7 +69,7 @@ struct AstNodeObject : public PythonClassWithObject<AstNodeObject, const chpl::u
   }
 };
 
-using QualifiedTypeTuple = std::tuple<const char*, const chpl::types::Type*, const chpl::types::Param*>;
+using QualifiedTypeTuple = std::tuple<const char*, Nilable<const chpl::types::Type*>, Nilable<const chpl::types::Param*>>;
 
 struct ChapelTypeObject  : public PythonClassWithObject<ChapelTypeObject, const chpl::types::Type*> {
   static constexpr const char* Name = "ChapelType";

--- a/tools/chapel-py/src/core-types.h
+++ b/tools/chapel-py/src/core-types.h
@@ -155,17 +155,17 @@ std::string generatePyiFile();
   Create a Python object of the class corresponding to the given AST node's
   type. For example, an Identifier node will be wrapped in a chapel.Identifier.
  */
-PyObject* wrapAstNode(ContextObject* context, const chpl::uast::AstNode* node);
+PyObject* wrapGeneratedType(ContextObject* context, const chpl::uast::AstNode* node);
 
 /**
   Create a Python object of the class corresponding to the given Type*.
   For example, an ArrayType type will be wrapped in a chapel.ArrayType.
  */
-PyObject* wrapType(ContextObject* context, const chpl::types::Type* node);
+PyObject* wrapGeneratedType(ContextObject* context, const chpl::types::Type* node);
 
 /**
   Creates a Python object of the class corresponding to the given Param*.
  */
-PyObject* wrapParam(ContextObject* context, const chpl::types::Param* node);
+PyObject* wrapGeneratedType(ContextObject* context, const chpl::types::Param* node);
 
 #endif

--- a/tools/chapel-py/src/core-types.h
+++ b/tools/chapel-py/src/core-types.h
@@ -27,9 +27,10 @@
 #include "error-tracker.h"
 #include "python-class.h"
 
-/* Tiny helper class to support marshalling to and from Python types.
-   This wraps a regular pointers, but instead of throwing Python exceptions
-   when the underlying pointer is 'null', it returns None. */
+/* Tiny helper class to support marshaling to and from Python types.
+   This wraps regular pointers. However, during marshaling, instead of
+   throwing Python exceptions when the underlying pointer is 'null', it
+   returns None. */
 template <typename T>
 struct Nilable {
   T value;

--- a/tools/chapel-py/src/generated-types-list.h
+++ b/tools/chapel-py/src/generated-types-list.h
@@ -17,39 +17,50 @@
  * limitations under the License.
  */
 
+/*
+ The macros have the following arguments:
+
+  1. ROOT: The name of the (Python) root type for the type hierarchy (e.g. AstNode).
+  2. ROOT_TYPE: The C++ type (without pointers) of values contained in the type hiearrchy (e.g. chpl::uast::AstNode).
+  3. NAME: The name of the type (e.g. Module).
+  4. TYPE: The C++ type (without pointers) for the generated type (e.g. chpl::uast::Module).
+  5. TAG: The name of the tag for the type (e.g. chpl::uast::asttags::Module).
+  6. FLAGS: The Python flags for the type (e.g. Py_TPFLAGS_DEFAULT).
+ */
+
 #ifndef GENERATED_TYPE
-#define GENERATED_TYPE(ROOT, NAME, TYPE, TAG, FLAGS)
+#define GENERATED_TYPE(ROOT, ROOT_TYPE, NAME, TYPE, TAG, FLAGS)
 #endif
 
 #ifndef GENERATED_TYPE_BEGIN
-#define GENERATED_TYPE_BEGIN(ROOT, NAME, TYPE, TAG, FLAGS)
+#define GENERATED_TYPE_BEGIN(ROOT, ROOT_TYPE, NAME, TYPE, TAG, FLAGS)
 #endif
 
 #ifndef GENERATED_TYPE_END
-#define GENERATED_TYPE_END(ROOT, NAME, TYPE, TAG, FLAGS)
+#define GENERATED_TYPE_END(ROOT, ROOT_TYPE, NAME, TYPE, TAG, FLAGS)
 #endif
 
-#define TYPE_NODE(NAME) GENERATED_TYPE(ChapelType, NAME, chpl::types::NAME, chpl::types::typetags::NAME, Py_TPFLAGS_DEFAULT)
-#define BUILTIN_TYPE_NODE(NAME, CHPL_NAME) GENERATED_TYPE(ChapelType, NAME, chpl::types::NAME, chpl::types::typetags::NAME, Py_TPFLAGS_DEFAULT)
-#define TYPE_BEGIN_SUBCLASSES(NAME) GENERATED_TYPE(ChapelType, NAME, chpl::types::NAME, chpl::types::typetags::START_##NAME, Py_TPFLAGS_BASETYPE) GENERATED_TYPE_BEGIN(ChapelType, NAME, chpl::types::NAME, chpl::types::typetags::START_##NAME, Py_TPFLAGS_BASETYPE)
-#define TYPE_END_SUBCLASSES(NAME) GENERATED_TYPE_END(ChapelType, NAME, chpl::types::NAME, chpl::types::typetags::END_##NAME, Py_TPFLAGS_BASETYPE)
+#define TYPE_NODE(NAME) GENERATED_TYPE(ChapelType, chpl::types::Type, NAME, chpl::types::NAME, chpl::types::typetags::NAME, Py_TPFLAGS_DEFAULT)
+#define BUILTIN_TYPE_NODE(NAME, CHPL_NAME) GENERATED_TYPE(ChapelType, chpl::types::Type, NAME, chpl::types::NAME, chpl::types::typetags::NAME, Py_TPFLAGS_DEFAULT)
+#define TYPE_BEGIN_SUBCLASSES(NAME) GENERATED_TYPE(ChapelType, chpl::types::Type, NAME, chpl::types::NAME, chpl::types::typetags::START_##NAME, Py_TPFLAGS_BASETYPE) GENERATED_TYPE_BEGIN(ChapelType, chpl::types::Type, NAME, chpl::types::NAME, chpl::types::typetags::START_##NAME, Py_TPFLAGS_BASETYPE)
+#define TYPE_END_SUBCLASSES(NAME) GENERATED_TYPE_END(ChapelType, chpl::types::Type, NAME, chpl::types::NAME, chpl::types::typetags::END_##NAME, Py_TPFLAGS_BASETYPE)
 #include "chpl/types/type-classes-list.h"
 #undef TYPE_NODE
 #undef BUILTIN_TYPE_NODE
 #undef TYPE_BEGIN_SUBCLASSES
 #undef TYPE_END_SUBCLASSES
 
-#define AST_NODE(NAME) GENERATED_TYPE(AstNode, NAME, chpl::uast::NAME, chpl::uast::asttags::NAME, Py_TPFLAGS_DEFAULT)
-#define AST_LEAF(NAME) GENERATED_TYPE(AstNode, NAME, chpl::uast::NAME, chpl::uast::asttags::NAME, Py_TPFLAGS_DEFAULT)
-#define AST_BEGIN_SUBCLASSES(NAME) GENERATED_TYPE(AstNode, NAME, chpl::uast::NAME, chpl::uast::asttags::START_##NAME, Py_TPFLAGS_BASETYPE) GENERATED_TYPE_BEGIN(AstNode, NAME, chpl::uast::NAME, chpl::uast::asttags::START_##NAME, Py_TPFLAGS_BASETYPE)
-#define AST_END_SUBCLASSES(NAME) GENERATED_TYPE_END(AstNode, NAME, chpl::uast::NAME, chpl::uast::asttags::END_##NAME, Py_TPFLAGS_BASETYPE)
+#define AST_NODE(NAME) GENERATED_TYPE(AstNode, chpl::uast::AstNode, NAME, chpl::uast::NAME, chpl::uast::asttags::NAME, Py_TPFLAGS_DEFAULT)
+#define AST_LEAF(NAME) GENERATED_TYPE(AstNode, chpl::uast::AstNode, NAME, chpl::uast::NAME, chpl::uast::asttags::NAME, Py_TPFLAGS_DEFAULT)
+#define AST_BEGIN_SUBCLASSES(NAME) GENERATED_TYPE(AstNode, chpl::uast::AstNode, NAME, chpl::uast::NAME, chpl::uast::asttags::START_##NAME, Py_TPFLAGS_BASETYPE) GENERATED_TYPE_BEGIN(AstNode, chpl::uast::AstNode, NAME, chpl::uast::NAME, chpl::uast::asttags::START_##NAME, Py_TPFLAGS_BASETYPE)
+#define AST_END_SUBCLASSES(NAME) GENERATED_TYPE_END(AstNode, chpl::uast::AstNode, NAME, chpl::uast::NAME, chpl::uast::asttags::END_##NAME, Py_TPFLAGS_BASETYPE)
 #include "chpl/uast/uast-classes-list.h"
 #undef AST_NODE
 #undef AST_LEAF
 #undef AST_BEGIN_SUBCLASSES
 #undef AST_END_SUBCLASSES
 
-#define PARAM_NODE(NAME, TYPE) GENERATED_TYPE(Param, NAME, chpl::uast::NAME, chpl::types::paramtags::NAME, Py_TPFLAGS_DEFAULT)
+#define PARAM_NODE(NAME, TYPE) GENERATED_TYPE(Param, chpl::types::Param, NAME, chpl::types::NAME, chpl::types::paramtags::NAME, Py_TPFLAGS_DEFAULT)
 #include "chpl/types/param-classes-list.h"
 #undef PARAM_NODE
 

--- a/tools/chapel-py/src/generated-types-list.h
+++ b/tools/chapel-py/src/generated-types-list.h
@@ -18,38 +18,38 @@
  */
 
 #ifndef GENERATED_TYPE
-#define GENERATED_TYPE(ROOT, NAME, TAG, FLAGS)
+#define GENERATED_TYPE(ROOT, NAME, TYPE, TAG, FLAGS)
 #endif
 
 #ifndef GENERATED_TYPE_BEGIN
-#define GENERATED_TYPE_BEGIN(ROOT, NAME, TAG, FLAGS)
+#define GENERATED_TYPE_BEGIN(ROOT, NAME, TYPE, TAG, FLAGS)
 #endif
 
 #ifndef GENERATED_TYPE_END
-#define GENERATED_TYPE_END(ROOT, NAME, TAG, FLAGS)
+#define GENERATED_TYPE_END(ROOT, NAME, TYPE, TAG, FLAGS)
 #endif
 
-#define TYPE_NODE(NAME) GENERATED_TYPE(ChapelType, NAME, chpl::types::typetags::NAME, Py_TPFLAGS_DEFAULT)
-#define BUILTIN_TYPE_NODE(NAME, CHPL_NAME) GENERATED_TYPE(ChapelType, NAME, chpl::types::typetags::NAME, Py_TPFLAGS_DEFAULT)
-#define TYPE_BEGIN_SUBCLASSES(NAME) GENERATED_TYPE(ChapelType, NAME, chpl::types::typetags::START_##NAME, Py_TPFLAGS_BASETYPE) GENERATED_TYPE_BEGIN(ChapelType, NAME, chpl::types::typetags::START_##NAME, Py_TPFLAGS_BASETYPE)
-#define TYPE_END_SUBCLASSES(NAME) GENERATED_TYPE_END(ChapelType, NAME, chpl::types::typetags::END_##NAME, Py_TPFLAGS_BASETYPE)
+#define TYPE_NODE(NAME) GENERATED_TYPE(ChapelType, NAME, chpl::types::NAME, chpl::types::typetags::NAME, Py_TPFLAGS_DEFAULT)
+#define BUILTIN_TYPE_NODE(NAME, CHPL_NAME) GENERATED_TYPE(ChapelType, NAME, chpl::types::NAME, chpl::types::typetags::NAME, Py_TPFLAGS_DEFAULT)
+#define TYPE_BEGIN_SUBCLASSES(NAME) GENERATED_TYPE(ChapelType, NAME, chpl::types::NAME, chpl::types::typetags::START_##NAME, Py_TPFLAGS_BASETYPE) GENERATED_TYPE_BEGIN(ChapelType, NAME, chpl::types::NAME, chpl::types::typetags::START_##NAME, Py_TPFLAGS_BASETYPE)
+#define TYPE_END_SUBCLASSES(NAME) GENERATED_TYPE_END(ChapelType, NAME, chpl::types::NAME, chpl::types::typetags::END_##NAME, Py_TPFLAGS_BASETYPE)
 #include "chpl/types/type-classes-list.h"
 #undef TYPE_NODE
 #undef BUILTIN_TYPE_NODE
 #undef TYPE_BEGIN_SUBCLASSES
 #undef TYPE_END_SUBCLASSES
 
-#define AST_NODE(NAME) GENERATED_TYPE(AstNode, NAME, chpl::uast::asttags::NAME, Py_TPFLAGS_DEFAULT)
-#define AST_LEAF(NAME) GENERATED_TYPE(AstNode, NAME, chpl::uast::asttags::NAME, Py_TPFLAGS_DEFAULT)
-#define AST_BEGIN_SUBCLASSES(NAME) GENERATED_TYPE(AstNode, NAME, chpl::uast::asttags::START_##NAME, Py_TPFLAGS_BASETYPE) GENERATED_TYPE_BEGIN(AstNode, NAME, chpl::uast::asttags::START_##NAME, Py_TPFLAGS_BASETYPE)
-#define AST_END_SUBCLASSES(NAME) GENERATED_TYPE_END(AstNode, NAME, chpl::uast::asttags::END_##NAME, Py_TPFLAGS_BASETYPE)
+#define AST_NODE(NAME) GENERATED_TYPE(AstNode, NAME, chpl::uast::NAME, chpl::uast::asttags::NAME, Py_TPFLAGS_DEFAULT)
+#define AST_LEAF(NAME) GENERATED_TYPE(AstNode, NAME, chpl::uast::NAME, chpl::uast::asttags::NAME, Py_TPFLAGS_DEFAULT)
+#define AST_BEGIN_SUBCLASSES(NAME) GENERATED_TYPE(AstNode, NAME, chpl::uast::NAME, chpl::uast::asttags::START_##NAME, Py_TPFLAGS_BASETYPE) GENERATED_TYPE_BEGIN(AstNode, NAME, chpl::uast::NAME, chpl::uast::asttags::START_##NAME, Py_TPFLAGS_BASETYPE)
+#define AST_END_SUBCLASSES(NAME) GENERATED_TYPE_END(AstNode, NAME, chpl::uast::NAME, chpl::uast::asttags::END_##NAME, Py_TPFLAGS_BASETYPE)
 #include "chpl/uast/uast-classes-list.h"
 #undef AST_NODE
 #undef AST_LEAF
 #undef AST_BEGIN_SUBCLASSES
 #undef AST_END_SUBCLASSES
 
-#define PARAM_NODE(NAME, TYPE) GENERATED_TYPE(Param, NAME, chpl::types::paramtags::NAME, Py_TPFLAGS_DEFAULT)
+#define PARAM_NODE(NAME, TYPE) GENERATED_TYPE(Param, NAME, chpl::uast::NAME, chpl::types::paramtags::NAME, Py_TPFLAGS_DEFAULT)
 #include "chpl/types/param-classes-list.h"
 #undef PARAM_NODE
 

--- a/tools/chapel-py/src/iterator-support.cpp
+++ b/tools/chapel-py/src/iterator-support.cpp
@@ -65,7 +65,7 @@ PyObject* AstIterObject_iter(AstIterObject *self) {
 PyObject* AstIterObject_next(AstIterObject *self) {
   if (self->iterAdapter) {
     if (auto nextNode = self->iterAdapter->next()) {
-      return wrapAstNode((ContextObject*) self->contextObject, nextNode);
+      return wrapGeneratedType((ContextObject*) self->contextObject, nextNode);
     }
   }
   PyErr_SetNone(PyExc_StopIteration);
@@ -117,7 +117,7 @@ PyObject* AstCallIterObject_next(AstCallIterObject *self) {
     return nullptr;
   }
   auto argName = self->nameGetter(self->container, self->current);
-  auto child = wrapAstNode((ContextObject*) self->contextObject,
+  auto child = wrapGeneratedType((ContextObject*) self->contextObject,
                            self->childGetter(self->container, self->current));
   PyObject* toReturn = nullptr;
   if (!argName.isEmpty()) {

--- a/tools/chapel-py/src/iterator-support.cpp
+++ b/tools/chapel-py/src/iterator-support.cpp
@@ -64,8 +64,8 @@ PyObject* AstIterObject_iter(AstIterObject *self) {
 
 PyObject* AstIterObject_next(AstIterObject *self) {
   if (self->iterAdapter) {
-    if (auto nextNode = self->iterAdapter->next()) {
-      return wrapGeneratedType((ContextObject*) self->contextObject, nextNode);
+    if (auto nextNode = self->iterAdapter->next((ContextObject*) self->contextObject)) {
+      return nextNode;
     }
   }
   PyErr_SetNone(PyExc_StopIteration);

--- a/tools/chapel-py/src/iterator-support.h
+++ b/tools/chapel-py/src/iterator-support.h
@@ -32,7 +32,7 @@ struct IterAdapterBase {
 
 template <typename T>
 struct TypedIterAdapterBase : IterAdapterBase {
-  virtual ~IterAdapterBase() = default;
+  virtual ~TypedIterAdapterBase() = default;
   virtual T typedNext() = 0;
 
   PyObject* next(ContextObject* contextObject) override {

--- a/tools/chapel-py/src/iterator-support.h
+++ b/tools/chapel-py/src/iterator-support.h
@@ -27,11 +27,27 @@
 
 struct IterAdapterBase {
   virtual ~IterAdapterBase() = default;
-  virtual const chpl::uast::AstNode* next() = 0;
+  virtual PyObject* next(ContextObject*) = 0;
+};
+
+template <typename T>
+struct TypedIterAdapterBase : IterAdapterBase {
+  virtual ~IterAdapterBase() = default;
+  virtual T typedNext() = 0;
+
+  PyObject* next(ContextObject* contextObject) override {
+    if (auto nextVal = typedNext()) {
+      return wrapGeneratedType(contextObject, nextVal);
+    }
+    return nullptr;
+  }
 };
 
 template <typename IterPair>
-struct IterAdapter : IterAdapterBase {
+using IterPairValueType = typename decltype(std::declval<IterPair>().begin())::value_type;
+
+template <typename IterPair>
+struct IterAdapter : TypedIterAdapterBase<IterPairValueType<IterPair>> {
  private:
   using IterType = decltype(std::declval<IterPair>().begin());
   IterType current;
@@ -40,7 +56,7 @@ struct IterAdapter : IterAdapterBase {
  public:
   IterAdapter(IterPair pair) : current(pair.begin()), end(pair.end()) {}
 
-  const chpl::uast::AstNode* next() override {
+  IterPairValueType<IterPair> typedNext() override {
     if (current == end) return nullptr;
     return *(current++);
   }
@@ -82,7 +98,7 @@ PyObject* AstCallIterObject_next(AstCallIterObject *self);
 PyObject* wrapIterAdapter(ContextObject* context, IterAdapterBase* iterAdapter);
 
 template <typename IterPair>
-static IterAdapterBase* mkIterPair(const IterPair& pair) {
+static TypedIterAdapterBase<IterPairValueType<IterPair>>* mkIterPair(const IterPair& pair) {
   return new IterAdapter<decltype(pair)>(pair);
 }
 

--- a/tools/chapel-py/src/method-tables.h
+++ b/tools/chapel-py/src/method-tables.h
@@ -67,6 +67,14 @@
 #define METHOD_PROTOTYPE(NODE, NAME, DOCSTR)
 #endif
 
+//
+// Forward declares a prototype for __iter__, which due to current limitations
+// cannot be implemented in method tables. The TYPE argument is the (C++)
+// type yielded by the iterator.
+#ifndef ITER_PROTOTYPE
+#define ITER_PROTOTYPE(NODE, TYPE)
+#endif
+
 #include "method-tables/core-methods.h"
 #include "method-tables/param-methods.h"
 #include "method-tables/type-methods.h"
@@ -80,3 +88,4 @@
 #undef METHOD
 #undef PLAIN_GETTER
 #undef METHOD_PROTOTYPE
+#undef ITER_PROTOTYPE

--- a/tools/chapel-py/src/method-tables/core-methods.h
+++ b/tools/chapel-py/src/method-tables/core-methods.h
@@ -183,5 +183,5 @@ CLASS_BEGIN(TypedSignature)
   PLAIN_GETTER(TypedSignature, is_instantiation, "Check if this function is an instantiation of a generic function",
                bool, return node.signature->instantiatedFrom() != nullptr)
   PLAIN_GETTER(TypedSignature, ast, "Get the AST from which this function signature is computed",
-               const chpl::uast::AstNode*, return chpl::parsing::idToAst(context, node.signature->id()))
+               Nilable<const chpl::uast::AstNode*>, return chpl::parsing::idToAst(context, node.signature->id()))
 CLASS_END(TypedSignature)

--- a/tools/chapel-py/src/method-tables/core-methods.h
+++ b/tools/chapel-py/src/method-tables/core-methods.h
@@ -77,15 +77,18 @@ CLASS_END(Location)
 
 CLASS_BEGIN(Scope)
   PLAIN_GETTER(Scope, used_imported_modules, "Get the modules that were used or imported in this scope",
-               std::vector<const chpl::uast::AstNode*>,
+               std::vector<const chpl::uast::Module*>,
 
                auto& moduleIds = resolution::findUsedImportedModules(context, node);
                std::set<ID> reportedIds;
-               std::vector<const chpl::uast::AstNode*> toReturn;
+               std::vector<const chpl::uast::Module*> toReturn;
                for (size_t i = 0; i < moduleIds.size(); i++) {
                  auto& id = moduleIds[i];
                  if (!reportedIds.insert(id).second) continue;
-                 toReturn.push_back(parsing::idToAst(context, id));
+                 auto ast = parsing::idToAst(context, id);
+                 if (auto mod = ast->toModule()) {
+                   toReturn.push_back(mod);
+                 }
                }
                return toReturn)
 CLASS_END(Scope)

--- a/tools/chapel-py/src/method-tables/core-methods.h
+++ b/tools/chapel-py/src/method-tables/core-methods.h
@@ -86,9 +86,9 @@ CLASS_BEGIN(Scope)
                  auto& id = moduleIds[i];
                  if (!reportedIds.insert(id).second) continue;
                  auto ast = parsing::idToAst(context, id);
-                 if (auto mod = ast->toModule()) {
-                   toReturn.push_back(mod);
-                 }
+                 auto mod = ast->toModule();
+                 CHPL_ASSERT(mod != nullptr);
+                 toReturn.push_back(mod);
                }
                return toReturn)
 CLASS_END(Scope)

--- a/tools/chapel-py/src/method-tables/type-methods.h
+++ b/tools/chapel-py/src/method-tables/type-methods.h
@@ -33,5 +33,5 @@ CLASS_END(ChapelType)
 
 CLASS_BEGIN(CompositeType)
   PLAIN_GETTER(CompositeType, decl, "Get the chpl::uast::AstNode that declares this CompositeType",
-               const chpl::uast::AstNode*, return parsing::idToAst(context, node->id()))
+               Nilable<const chpl::uast::AstNode*>, return parsing::idToAst(context, node->id()))
 CLASS_END(CompositeType)

--- a/tools/chapel-py/src/method-tables/uast-methods.h
+++ b/tools/chapel-py/src/method-tables/uast-methods.h
@@ -29,6 +29,7 @@
 //
 
 CLASS_BEGIN(AstNode)
+  ITER_PROTOTYPE(AstNode, const chpl::uast::AstNode*)
   PLAIN_GETTER(AstNode, dump, "Dump the internal representation of the given AST node",
                void, node->dump())
   PLAIN_GETTER(AstNode, tag, "Get a string representation of the AST node's type",

--- a/tools/chapel-py/src/method-tables/uast-methods.h
+++ b/tools/chapel-py/src/method-tables/uast-methods.h
@@ -198,7 +198,7 @@ CLASS_END(ExternBlock)
 
 CLASS_BEGIN(FunctionSignature)
   PLAIN_GETTER(FunctionSignature, formals, "Get the formals for this FunctionSignature node",
-               IterAdapterBase*, return mkIterPair(node->formals()))
+               TypedIterAdapterBase<const chpl::uast::Decl*>*, return mkIterPair(node->formals()))
   PLAIN_GETTER(FunctionSignature, is_parenless, "Check if this FunctionSignature node is parenless",
                bool, return node->isParenless())
   PLAIN_GETTER(FunctionSignature, kind, "Get the kind of this FunctionSignature node",
@@ -235,7 +235,7 @@ CLASS_BEGIN(Import)
   PLAIN_GETTER(Import, visibility, "Get the visibility of this Import node",
                const char*, return Decl::visibilityToString(node->visibility()))
   PLAIN_GETTER(Import, visibility_clauses, "Get the visibility clauses of this Import node",
-               IterAdapterBase*, return mkIterPair(node->visibilityClauses()))
+               TypedIterAdapterBase<const chpl::uast::VisibilityClause*>*, return mkIterPair(node->visibilityClauses()))
 CLASS_END(Import)
 
 CLASS_BEGIN(Include)
@@ -289,7 +289,7 @@ CLASS_BEGIN(Select)
   PLAIN_GETTER(Select, exprs, "Get the expression of this Select node",
                const chpl::uast::AstNode*, return node->expr())
   PLAIN_GETTER(Select, when_stmts, "Get the When statements of this Select node",
-               IterAdapterBase*, return mkIterPair(node->whenStmts()))
+               TypedIterAdapterBase<const chpl::uast::When*>*, return mkIterPair(node->whenStmts()))
 CLASS_END(Select)
 
 CLASS_BEGIN(Throw)
@@ -301,7 +301,7 @@ CLASS_BEGIN(Try)
   PLAIN_GETTER(Try, body, "Get the body of this Try node",
                const chpl::uast::Block*, return node->body())
   PLAIN_GETTER(Try, handlers, "Get the Catch node handlers of this Try node",
-               IterAdapterBase*, return mkIterPair(node->handlers()))
+               TypedIterAdapterBase<const chpl::uast::Catch*>*, return mkIterPair(node->handlers()))
   PLAIN_GETTER(Try, is_expression_level, "Check if this Try node is expression level",
                bool, return node->isExpressionLevel())
   PLAIN_GETTER(Try, is_try_bang, "Check if this Try node is a 'try!'",
@@ -312,7 +312,7 @@ CLASS_BEGIN(Use)
   PLAIN_GETTER(Use, visibility, "Get the visibility of this Use node",
                const char*, return Decl::visibilityToString(node->visibility()))
   PLAIN_GETTER(Use, visibility_clauses, "Get the visibility clauses of this Use node",
-               IterAdapterBase*, return mkIterPair(node->visibilityClauses()))
+               TypedIterAdapterBase<const chpl::uast::VisibilityClause*>*, return mkIterPair(node->visibilityClauses()))
 CLASS_END(Use)
 
 CLASS_BEGIN(VisibilityClause)
@@ -493,7 +493,7 @@ CLASS_END(Decl)
 
 CLASS_BEGIN(TupleDecl)
   PLAIN_GETTER(TupleDecl, decls, "Get the declarations for this TupleDecl node",
-               IterAdapterBase*, return mkIterPair(node->decls()))
+               TypedIterAdapterBase<const chpl::uast::Decl*>*, return mkIterPair(node->decls()))
   PLAIN_GETTER(TupleDecl, init_expression, "Get the init expression of this TupleDecl node",
                const chpl::uast::AstNode*, return node->typeExpression())
   PLAIN_GETTER(TupleDecl, intent_or_kind, "Get the intent or kind of this TupleDecl node",
@@ -524,7 +524,7 @@ CLASS_END(EnumElement)
 
 CLASS_BEGIN(Function)
   PLAIN_GETTER(Function, formals, "Get the formals for this Function node",
-               IterAdapterBase*, return mkIterPair(node->formals()))
+               TypedIterAdapterBase<const chpl::uast::Decl*>*, return mkIterPair(node->formals()))
   PLAIN_GETTER(Function, body, "Get the body for this function",
                const chpl::uast::Block*, return node->body())
   METHOD(Function, formal, "Get the n'th Formal of this Function node",

--- a/tools/chapel-py/src/method-tables/uast-methods.h
+++ b/tools/chapel-py/src/method-tables/uast-methods.h
@@ -34,13 +34,13 @@ CLASS_BEGIN(AstNode)
   PLAIN_GETTER(AstNode, tag, "Get a string representation of the AST node's type",
                const char*, return chpl::uast::asttags::tagToString(node->tag()))
   PLAIN_GETTER(AstNode, attribute_group, "Get the attribute group, if any, associated with this node",
-               const chpl::uast::AttributeGroup*, return node->attributeGroup())
+               Nilable<const chpl::uast::AttributeGroup*>, return node->attributeGroup())
   PLAIN_GETTER(AstNode, location, "Get the location of this AST node in its file",
                chpl::Location, return chpl::parsing::locateAst(context, node))
   PLAIN_GETTER(AstNode, parent, "Get the parent node of this AST node",
-               const chpl::uast::AstNode*, return chpl::parsing::parentAst(context, node))
+               Nilable<const chpl::uast::AstNode*>, return chpl::parsing::parentAst(context, node))
   PLAIN_GETTER(AstNode, parent_symbol, "Get the parent symbol of this AST node (e.g., module, variable, etc.)",
-               const chpl::uast::AstNode*,
+               Nilable<const chpl::uast::AstNode*>,
 
                auto id = node->id();
                auto parentId = id.parentSymbolId(context);
@@ -75,7 +75,7 @@ CLASS_BEGIN(AstNode)
 
                return std::make_tuple(intentToString(qt.kind()), qt.type(), qt.param()))
   PLAIN_GETTER(AstNode, called_fn, "Get the function being invoked by this node",
-               const chpl::uast::AstNode*, return calledFnForNode(context, node))
+               Nilable<const chpl::uast::AstNode*>, return calledFnForNode(context, node))
   PLAIN_GETTER(AstNode, resolve, "Perform resolution on code surrounding this node to determine its type and other information.",
                std::optional<ResolvedExpressionObject*>,
 
@@ -94,7 +94,7 @@ CLASS_BEGIN(AnonFormal)
   PLAIN_GETTER(AnonFormal, intent, "Get the intent for this AnonFormal node",
                const char*, return intentToString(node->intent()))
   PLAIN_GETTER(AnonFormal, type_expression, "Get the type expression for this AnonFormal node",
-               const chpl::uast::AstNode*, return node->typeExpression())
+               Nilable<const chpl::uast::AstNode*>, return node->typeExpression())
 CLASS_END(AnonFormal)
 
 CLASS_BEGIN(As)
@@ -128,12 +128,12 @@ CLASS_END(AttributeGroup)
 
 CLASS_BEGIN(Break)
   PLAIN_GETTER(Break, target, "Get the target from this Break node",
-               const chpl::uast::Identifier*, return node->target())
+               Nilable<const chpl::uast::Identifier*>, return node->target())
 CLASS_END(Break)
 
 CLASS_BEGIN(Catch)
   PLAIN_GETTER(Catch, target, "Get the error from this Catch node",
-               const chpl::uast::Variable*, return node->error())
+               Nilable<const chpl::uast::Variable*>, return node->error())
   PLAIN_GETTER(Catch, body, "Get the body from this Catch node",
                const chpl::uast::Block*, return node->body())
   PLAIN_GETTER(Catch, has_parens_around_error, "Check if this Catch uses parentheses",
@@ -142,7 +142,7 @@ CLASS_END(Catch)
 
 CLASS_BEGIN(Cobegin)
   PLAIN_GETTER(Cobegin, with_clause, "Get the WithClause from this Cobegin node",
-               const chpl::uast::WithClause*, return node->withClause())
+               Nilable<const chpl::uast::WithClause*>, return node->withClause())
   PLAIN_GETTER(Cobegin, task_bodies, "Get tasks from this Cobegin node",
                IterAdapterBase*, return mkIterPair(node->taskBodies()))
 CLASS_END(Cobegin)
@@ -151,7 +151,7 @@ CLASS_BEGIN(Conditional)
   PLAIN_GETTER(Conditional, condition, "Get the condition of this Conditional node",
                const chpl::uast::AstNode*, return node->condition())
   PLAIN_GETTER(Conditional, else_block, "Get the else block of this Conditional node or None if no else block",
-               const chpl::uast::Block*, return node->elseBlock())
+               Nilable<const chpl::uast::Block*>, return node->elseBlock())
   PLAIN_GETTER(Conditional, is_expression_level, "Checks if this Conditional node is expression-level",
                bool, return node->isExpressionLevel())
   PLAIN_GETTER(Conditional, then_block, "Get the then block of this Conditional node",
@@ -165,7 +165,7 @@ CLASS_END(Comment)
 
 CLASS_BEGIN(Continue)
   PLAIN_GETTER(Continue, target, "Get the target from this Continue node",
-               const chpl::uast::Identifier*, return node->target())
+               Nilable<const chpl::uast::Identifier*>, return node->target())
 CLASS_END(Continue)
 
 CLASS_BEGIN(Delete)
@@ -188,7 +188,7 @@ CLASS_BEGIN(Dot)
   PLAIN_GETTER(Dot, receiver, "Get the receiver of the Dot node",
                const chpl::uast::AstNode*, return node->receiver())
   PLAIN_GETTER(Dot, to_node, "Get the AST node that this Dot node refers to",
-               const chpl::uast::AstNode*, return nodeOrNullFromToId(context, node))
+               Nilable<const chpl::uast::AstNode*>, return nodeOrNullFromToId(context, node))
 CLASS_END(Dot)
 
 CLASS_BEGIN(ExternBlock)
@@ -206,9 +206,9 @@ CLASS_BEGIN(FunctionSignature)
   PLAIN_GETTER(FunctionSignature, return_intent, "Get the return intent of this FunctionSignature node",
                const char*,  return intentToString(node->returnIntent()))
   PLAIN_GETTER(FunctionSignature, return_type, "Get the return type for this FunctionSignature node",
-               const chpl::uast::AstNode*, return node->returnType())
+               Nilable<const chpl::uast::AstNode*>, return node->returnType())
   PLAIN_GETTER(FunctionSignature, this_formal, "Get the this formal for this FunctionSignature node",
-               const chpl::uast::Formal*, return node->thisFormal())
+               Nilable<const chpl::uast::Formal*>, return node->thisFormal())
   PLAIN_GETTER(FunctionSignature, throws, "Check if this FunctionSignature node is marked throws",
                bool, return node->throws())
 CLASS_END(FunctionSignature)
@@ -217,7 +217,7 @@ CLASS_BEGIN(Implements)
   PLAIN_GETTER(Implements, interface_name, "Get the interface name of this Implements node",
                chpl::UniqueString, return node->interfaceName())
   PLAIN_GETTER(Implements, type_ident, "Get the type identifier from this Implements node",
-               const chpl::uast::Identifier*, return node->typeIdent())
+               Nilable<const chpl::uast::Identifier*>, return node->typeIdent())
   PLAIN_GETTER(Implements, interface_expr, "Get the interface expression from this Implements node",
                const chpl::uast::AstNode*, return node->interfaceExpr())
   PLAIN_GETTER(Implements, is_expression_level, "Check if this Implements node is expression level",
@@ -228,7 +228,7 @@ CLASS_BEGIN(Identifier)
   PLAIN_GETTER(Identifier, name, "Get the name of this Identifier node",
                chpl::UniqueString, return node->name())
   PLAIN_GETTER(Identifier, to_node, "Get the AST node that this Identifier node refers to",
-               const chpl::uast::AstNode*, return nodeOrNullFromToId(context, node))
+               Nilable<const chpl::uast::AstNode*>, return nodeOrNullFromToId(context, node))
 CLASS_END(Identifier)
 
 CLASS_BEGIN(Import)
@@ -268,11 +268,11 @@ CLASS_END(New)
 
 CLASS_BEGIN(Range)
   PLAIN_GETTER(Range, lower_bound, "Get the lower bound of this Range node",
-               const chpl::uast::AstNode*, return node->lowerBound())
+               Nilable<const chpl::uast::AstNode*>, return node->lowerBound())
   PLAIN_GETTER(Range, op_kind, "Get the op kind of this Range node",
                const char*, return opKindToString(node->opKind()))
   PLAIN_GETTER(Range, upper_bound, "Get the upper bound of this Range node",
-               const chpl::uast::AstNode*, return node->upperBound())
+               Nilable<const chpl::uast::AstNode*>, return node->upperBound())
 CLASS_END(Range)
 
 CLASS_BEGIN(Require)
@@ -282,7 +282,7 @@ CLASS_END(Require)
 
 CLASS_BEGIN(Return)
   PLAIN_GETTER(Return, value, "Get the expression returned by this Return node",
-               const chpl::uast::AstNode*, return node->value())
+               Nilable<const chpl::uast::AstNode*>, return node->value())
 CLASS_END(Return)
 
 CLASS_BEGIN(Select)
@@ -327,7 +327,7 @@ CLASS_END(WithClause)
 
 CLASS_BEGIN(Yield)
   PLAIN_GETTER(Yield, value, "Get the expression yielded by this Yield node",
-               const chpl::uast::AstNode*, return node->value())
+               Nilable<const chpl::uast::AstNode*>, return node->value())
 CLASS_END(Yield)
 
 CLASS_BEGIN(SimpleBlockLike)
@@ -337,12 +337,12 @@ CLASS_END(SimpleBlockLike)
 
 CLASS_BEGIN(Begin)
   PLAIN_GETTER(Begin, with_clause, "Get the WithClause of this Begin node",
-               const chpl::uast::WithClause*, return node->withClause())
+               Nilable<const chpl::uast::WithClause*>, return node->withClause())
 CLASS_END(Begin)
 
 CLASS_BEGIN(Local)
   PLAIN_GETTER(Local, condition, "Get the condition of this Local node",
-               const chpl::uast::AstNode*, return node->condition())
+               Nilable<const chpl::uast::AstNode*>, return node->condition())
 CLASS_END(Local)
 
 CLASS_BEGIN(Manage)
@@ -357,7 +357,7 @@ CLASS_END(On)
 
 CLASS_BEGIN(Serial)
   PLAIN_GETTER(Serial, condition, "Get the condition of this Serial node",
-               const chpl::uast::AstNode*, return node->condition())
+               Nilable<const chpl::uast::AstNode*>, return node->condition())
 CLASS_END(Serial)
 
 CLASS_BEGIN(When)
@@ -390,13 +390,13 @@ CLASS_END(While)
 
 CLASS_BEGIN(IndexableLoop)
   PLAIN_GETTER(IndexableLoop, index, "Get the index of this IndexableLoop node",
-               const chpl::uast::Decl*, return node->index())
+               Nilable<const chpl::uast::Decl*>, return node->index())
   PLAIN_GETTER(IndexableLoop, is_expression_level, "Check if this IndexableLoop node is expression level",
                bool, return node->isExpressionLevel())
   PLAIN_GETTER(IndexableLoop, iterand, "Get the iterand of this IndexableLoop node",
                const chpl::uast::AstNode*, return node->iterand())
   PLAIN_GETTER(IndexableLoop, with_clause, "Get the WithClause of this IndexableLoop node",
-               const chpl::uast::WithClause*, return node->withClause())
+               Nilable<const chpl::uast::WithClause*>, return node->withClause())
 CLASS_END(IndexableLoop)
 
 CLASS_BEGIN(BracketLoop)
@@ -486,7 +486,7 @@ CLASS_BEGIN(Decl)
   PLAIN_GETTER(Decl, linkage, "Get the linkage of this Decl node",
                const char*, return Decl::linkageToString(node->linkage()))
   PLAIN_GETTER(Decl, linkage_name, "Get the linkage name of this Decl node",
-               const chpl::uast::AstNode*, return node->linkageName())
+               Nilable<const chpl::uast::AstNode*>, return node->linkageName())
   PLAIN_GETTER(Decl, visibility, "Get the visibility of this Decl node",
                const char*, return Decl::visibilityToString(node->visibility()))
 CLASS_END(Decl)
@@ -495,16 +495,16 @@ CLASS_BEGIN(TupleDecl)
   PLAIN_GETTER(TupleDecl, decls, "Get the declarations for this TupleDecl node",
                TypedIterAdapterBase<const chpl::uast::Decl*>*, return mkIterPair(node->decls()))
   PLAIN_GETTER(TupleDecl, init_expression, "Get the init expression of this TupleDecl node",
-               const chpl::uast::AstNode*, return node->typeExpression())
+               Nilable<const chpl::uast::AstNode*>, return node->typeExpression())
   PLAIN_GETTER(TupleDecl, intent_or_kind, "Get the intent or kind of this TupleDecl node",
                const char*, return TupleDecl::intentOrKindToString(node->intentOrKind()))
   PLAIN_GETTER(TupleDecl, type_expression, "Get the type expression of this TupleDecl node",
-               const chpl::uast::AstNode*, return node->initExpression())
+               Nilable<const chpl::uast::AstNode*>, return node->initExpression())
 CLASS_END(TupleDecl)
 
 CLASS_BEGIN(ForwardingDecl)
   PLAIN_GETTER(ForwardingDecl, expr, "Get the expression of this ForwardingDecl node",
-               const chpl::uast::AstNode*, return node->expr())
+               Nilable<const chpl::uast::AstNode*>, return node->expr())
 CLASS_END(ForwardingDecl)
 
 CLASS_BEGIN(NamedDecl)
@@ -519,14 +519,14 @@ CLASS_END(NamedDecl)
 
 CLASS_BEGIN(EnumElement)
   PLAIN_GETTER(EnumElement, init_expression, "Get the init expression of this EnumElement node",
-               const chpl::uast::AstNode*, return node->initExpression())
+               Nilable<const chpl::uast::AstNode*>, return node->initExpression())
 CLASS_END(EnumElement)
 
 CLASS_BEGIN(Function)
   PLAIN_GETTER(Function, formals, "Get the formals for this Function node",
                TypedIterAdapterBase<const chpl::uast::Decl*>*, return mkIterPair(node->formals()))
   PLAIN_GETTER(Function, body, "Get the body for this function",
-               const chpl::uast::Block*, return node->body())
+               Nilable<const chpl::uast::Block*>, return node->body())
   METHOD(Function, formal, "Get the n'th Formal of this Function node",
          const chpl::uast::Decl*(int), return node->formal(std::get<0>(args)))
   PLAIN_GETTER(Function, is_anonymous, "Check if this Function node is anonymous",
@@ -550,13 +550,13 @@ CLASS_BEGIN(Function)
   PLAIN_GETTER(Function, return_intent, "Get the return intent of this Function node",
                const char*,  return intentToString(node->returnIntent()))
   PLAIN_GETTER(Function, return_type, "Get the return type for this Function node",
-               const chpl::uast::AstNode*, return node->returnType())
+               Nilable<const chpl::uast::AstNode*>, return node->returnType())
   PLAIN_GETTER(Function, this_formal, "Get the this formal for this Function node",
-               const chpl::uast::Decl*, return node->thisFormal())
+               Nilable<const chpl::uast::Decl*>, return node->thisFormal())
   PLAIN_GETTER(Function, throws, "Check if this Function node is marked throws",
                bool, return node->throws())
   PLAIN_GETTER(Function, where_clause, "Get the where clause for this Function node",
-               const chpl::uast::AstNode*, return node->whereClause())
+               Nilable<const chpl::uast::AstNode*>, return node->whereClause())
 CLASS_END(Function)
 
 CLASS_BEGIN(Interface)
@@ -580,18 +580,18 @@ CLASS_END(ReduceIntent)
 
 CLASS_BEGIN(VarLikeDecl)
   PLAIN_GETTER(VarLikeDecl, init_expression, "Get the init expression of this VarLikeDecl node",
-               const chpl::uast::AstNode*, return node->initExpression())
+               Nilable<const chpl::uast::AstNode*>, return node->initExpression())
   PLAIN_GETTER(VarLikeDecl, storage_kind, "Get the storage kind of this VarLikeDecl node",
                const char*, return qualifierToString(node->storageKind()))
   PLAIN_GETTER(VarLikeDecl, type_expression, "Get the type expression of this VarLikeDecl node",
-               const chpl::uast::AstNode*, return node->typeExpression())
+               Nilable<const chpl::uast::AstNode*>, return node->typeExpression())
   PLAIN_GETTER(VarLikeDecl, intent, "Get the intent for this VarLikeDecl node",
                const char*, return intentToString(node->storageKind()))
 CLASS_END(VarLikeDecl)
 
 CLASS_BEGIN(VarArgFormal)
   PLAIN_GETTER(VarArgFormal, count, "Get the count expression of this VarArgFormal node",
-               const chpl::uast::AstNode*, return node->count())
+               Nilable<const chpl::uast::AstNode*>, return node->count())
 CLASS_END(VarArgFormal)
 
 CLASS_BEGIN(Variable)

--- a/tools/chapel-py/src/method-tables/uast-methods.h
+++ b/tools/chapel-py/src/method-tables/uast-methods.h
@@ -34,7 +34,7 @@ CLASS_BEGIN(AstNode)
   PLAIN_GETTER(AstNode, tag, "Get a string representation of the AST node's type",
                const char*, return chpl::uast::asttags::tagToString(node->tag()))
   PLAIN_GETTER(AstNode, attribute_group, "Get the attribute group, if any, associated with this node",
-               const chpl::uast::AstNode*, return node->attributeGroup())
+               const chpl::uast::AttributeGroup*, return node->attributeGroup())
   PLAIN_GETTER(AstNode, location, "Get the location of this AST node in its file",
                chpl::Location, return chpl::parsing::locateAst(context, node))
   PLAIN_GETTER(AstNode, parent, "Get the parent node of this AST node",
@@ -128,21 +128,21 @@ CLASS_END(AttributeGroup)
 
 CLASS_BEGIN(Break)
   PLAIN_GETTER(Break, target, "Get the target from this Break node",
-               const chpl::uast::AstNode*, return node->target())
+               const chpl::uast::Identifier*, return node->target())
 CLASS_END(Break)
 
 CLASS_BEGIN(Catch)
   PLAIN_GETTER(Catch, target, "Get the error from this Catch node",
-               const chpl::uast::AstNode*, return node->error())
+               const chpl::uast::Variable*, return node->error())
   PLAIN_GETTER(Catch, body, "Get the body from this Catch node",
-               const chpl::uast::AstNode*, return node->body())
+               const chpl::uast::Block*, return node->body())
   PLAIN_GETTER(Catch, has_parens_around_error, "Check if this Catch uses parentheses",
                bool, return node->hasParensAroundError())
 CLASS_END(Catch)
 
 CLASS_BEGIN(Cobegin)
   PLAIN_GETTER(Cobegin, with_clause, "Get the WithClause from this Cobegin node",
-               const chpl::uast::AstNode*, return node->withClause())
+               const chpl::uast::WithClause*, return node->withClause())
   PLAIN_GETTER(Cobegin, task_bodies, "Get tasks from this Cobegin node",
                IterAdapterBase*, return mkIterPair(node->taskBodies()))
 CLASS_END(Cobegin)
@@ -151,11 +151,11 @@ CLASS_BEGIN(Conditional)
   PLAIN_GETTER(Conditional, condition, "Get the condition of this Conditional node",
                const chpl::uast::AstNode*, return node->condition())
   PLAIN_GETTER(Conditional, else_block, "Get the else block of this Conditional node or None if no else block",
-               const chpl::uast::AstNode*, return node->elseBlock())
+               const chpl::uast::Block*, return node->elseBlock())
   PLAIN_GETTER(Conditional, is_expression_level, "Checks if this Conditional node is expression-level",
                bool, return node->isExpressionLevel())
   PLAIN_GETTER(Conditional, then_block, "Get the then block of this Conditional node",
-               const chpl::uast::AstNode*, return node->thenBlock())
+               const chpl::uast::Block*, return node->thenBlock())
 CLASS_END(Conditional)
 
 CLASS_BEGIN(Comment)
@@ -165,7 +165,7 @@ CLASS_END(Comment)
 
 CLASS_BEGIN(Continue)
   PLAIN_GETTER(Continue, target, "Get the target from this Continue node",
-               const chpl::uast::AstNode*, return node->target())
+               const chpl::uast::Identifier*, return node->target())
 CLASS_END(Continue)
 
 CLASS_BEGIN(Delete)
@@ -208,7 +208,7 @@ CLASS_BEGIN(FunctionSignature)
   PLAIN_GETTER(FunctionSignature, return_type, "Get the return type for this FunctionSignature node",
                const chpl::uast::AstNode*, return node->returnType())
   PLAIN_GETTER(FunctionSignature, this_formal, "Get the this formal for this FunctionSignature node",
-               const chpl::uast::AstNode*, return node->thisFormal())
+               const chpl::uast::Formal*, return node->thisFormal())
   PLAIN_GETTER(FunctionSignature, throws, "Check if this FunctionSignature node is marked throws",
                bool, return node->throws())
 CLASS_END(FunctionSignature)
@@ -217,7 +217,7 @@ CLASS_BEGIN(Implements)
   PLAIN_GETTER(Implements, interface_name, "Get the interface name of this Implements node",
                chpl::UniqueString, return node->interfaceName())
   PLAIN_GETTER(Implements, type_ident, "Get the type identifier from this Implements node",
-               const chpl::uast::AstNode*, return node->typeIdent())
+               const chpl::uast::Identifier*, return node->typeIdent())
   PLAIN_GETTER(Implements, interface_expr, "Get the interface expression from this Implements node",
                const chpl::uast::AstNode*, return node->interfaceExpr())
   PLAIN_GETTER(Implements, is_expression_level, "Check if this Implements node is expression level",
@@ -249,12 +249,12 @@ CLASS_END(Include)
 
 CLASS_BEGIN(Init)
   PLAIN_GETTER(Init, target, "Get the target of this Init node",
-               const chpl::uast::AstNode*, return node->target())
+               const chpl::uast::Identifier*, return node->target())
 CLASS_END(Init)
 
 CLASS_BEGIN(Label)
   PLAIN_GETTER(Label, loop, "Get the loop this Label node is attached to",
-               const chpl::uast::AstNode*, return node->loop())
+               const chpl::uast::Loop*, return node->loop())
   PLAIN_GETTER(Label, name, "Get the name of this Label node",
                chpl::UniqueString, return node->name())
 CLASS_END(Label)
@@ -299,7 +299,7 @@ CLASS_END(Throw)
 
 CLASS_BEGIN(Try)
   PLAIN_GETTER(Try, body, "Get the body of this Try node",
-               const chpl::uast::AstNode*, return node->body())
+               const chpl::uast::Block*, return node->body())
   PLAIN_GETTER(Try, handlers, "Get the Catch node handlers of this Try node",
                IterAdapterBase*, return mkIterPair(node->handlers()))
   PLAIN_GETTER(Try, is_expression_level, "Check if this Try node is expression level",
@@ -337,7 +337,7 @@ CLASS_END(SimpleBlockLike)
 
 CLASS_BEGIN(Begin)
   PLAIN_GETTER(Begin, with_clause, "Get the WithClause of this Begin node",
-               const chpl::uast::AstNode*, return node->withClause())
+               const chpl::uast::WithClause*, return node->withClause())
 CLASS_END(Begin)
 
 CLASS_BEGIN(Local)
@@ -364,7 +364,7 @@ CLASS_BEGIN(When)
   PLAIN_GETTER(When, block_style, "Get the block style of this When node",
                const char*, return blockStyleToString(node->blockStyle()))
   PLAIN_GETTER(When, body, "Get the body of this When node",
-               const chpl::uast::AstNode*, return node->body())
+               const chpl::uast::Block*, return node->body())
   PLAIN_GETTER(When, case_exprs, "Get the case expressions of this When node",
                IterAdapterBase*, return mkIterPair(node->caseExprs()))
   PLAIN_GETTER(When, is_otherwise, "Check if this When node uses the otherwise keyword",
@@ -375,7 +375,7 @@ CLASS_BEGIN(Loop)
   PLAIN_GETTER(Loop, block_style, "Get the block style of this Loop node",
                const char*, return blockStyleToString(node->blockStyle()))
   PLAIN_GETTER(Loop, body, "Get the body of this Loop node",
-               const chpl::uast::AstNode*, return node->body())
+               const chpl::uast::Block*, return node->body())
 CLASS_END(Loop)
 
 CLASS_BEGIN(DoWhile)
@@ -390,13 +390,13 @@ CLASS_END(While)
 
 CLASS_BEGIN(IndexableLoop)
   PLAIN_GETTER(IndexableLoop, index, "Get the index of this IndexableLoop node",
-               const chpl::uast::AstNode*, return node->index())
+               const chpl::uast::Decl*, return node->index())
   PLAIN_GETTER(IndexableLoop, is_expression_level, "Check if this IndexableLoop node is expression level",
                bool, return node->isExpressionLevel())
   PLAIN_GETTER(IndexableLoop, iterand, "Get the iterand of this IndexableLoop node",
                const chpl::uast::AstNode*, return node->iterand())
   PLAIN_GETTER(IndexableLoop, with_clause, "Get the WithClause of this IndexableLoop node",
-               const chpl::uast::AstNode*, return node->withClause())
+               const chpl::uast::WithClause*, return node->withClause())
 CLASS_END(IndexableLoop)
 
 CLASS_BEGIN(BracketLoop)
@@ -526,9 +526,9 @@ CLASS_BEGIN(Function)
   PLAIN_GETTER(Function, formals, "Get the formals for this Function node",
                IterAdapterBase*, return mkIterPair(node->formals()))
   PLAIN_GETTER(Function, body, "Get the body for this function",
-               const chpl::uast::AstNode*, return node->body())
+               const chpl::uast::Block*, return node->body())
   METHOD(Function, formal, "Get the n'th Formal of this Function node",
-         const chpl::uast::AstNode*(int), return node->formal(std::get<0>(args)))
+         const chpl::uast::Decl*(int), return node->formal(std::get<0>(args)))
   PLAIN_GETTER(Function, is_anonymous, "Check if this Function node is anonymous",
                bool, return node->isAnonymous())
   PLAIN_GETTER(Function, is_inline, "Check if this Function node is marked inline",
@@ -552,7 +552,7 @@ CLASS_BEGIN(Function)
   PLAIN_GETTER(Function, return_type, "Get the return type for this Function node",
                const chpl::uast::AstNode*, return node->returnType())
   PLAIN_GETTER(Function, this_formal, "Get the this formal for this Function node",
-               const chpl::uast::AstNode*, return node->thisFormal())
+               const chpl::uast::Decl*, return node->thisFormal())
   PLAIN_GETTER(Function, throws, "Check if this Function node is marked throws",
                bool, return node->throws())
   PLAIN_GETTER(Function, where_clause, "Get the where clause for this Function node",

--- a/tools/chapel-py/src/python-types.h
+++ b/tools/chapel-py/src/python-types.h
@@ -206,6 +206,29 @@ std::string iteratorTypeString() {
   return std::string("typing.Iterator[") + PythonReturnTypeInfo<T>::typeString() + "]";
 }
 
+template <typename T>
+PyObject* wrapNilable(ContextObject* context, const Nilable<T>& opt) {
+  if (opt.value) {
+    return PythonReturnTypeInfo<T>::wrap(context, opt.value);
+  } else {
+    Py_RETURN_NONE;
+  }
+}
+
+template <typename T>
+Nilable<T> unwrapNilable(ContextObject* context, PyObject* opt) {
+  if (opt == Py_None) {
+    return {nullptr};
+  } else {
+    return PythonReturnTypeInfo<T>::unwrap(context, opt);
+  }
+}
+
+template <typename T>
+std::string nilableTypeString() {
+  return std::string("typing.Optional[") + PythonReturnTypeInfo<T>::typeString() + "]";
+}
+
 
 /* Invoke the DEFINE_INOUT_TYPE macro for each type we want to support.
    New types should be added here. We might consider performing these invocations
@@ -232,6 +255,8 @@ template <typename T>
 T_DEFINE_INOUT_TYPE(std::set<T>, setTypeString<T>(), wrapSet(CONTEXT, TO_WRAP), unwrapSet<T>(CONTEXT, TO_UNWRAP));
 template <typename T>
 T_DEFINE_INOUT_TYPE(std::optional<T>, optionalTypeString<T>(), wrapOptional(CONTEXT, TO_WRAP), unwrapOptional<T>(CONTEXT, TO_UNWRAP));
+template <typename T>
+T_DEFINE_INOUT_TYPE(Nilable<T>, nilableTypeString<T>(), wrapNilable(CONTEXT, TO_WRAP), unwrapNilable<T>(CONTEXT, TO_UNWRAP));
 template <typename ... Elems>
 T_DEFINE_INOUT_TYPE(std::tuple<Elems...>, tupleTypeString<Elems...>(), wrapTuple(CONTEXT, TO_WRAP), unwrapTuple<Elems...>(CONTEXT, TO_UNWRAP));
 template <typename ElemType>

--- a/tools/chapel-py/src/python-types.h
+++ b/tools/chapel-py/src/python-types.h
@@ -201,6 +201,12 @@ std::string tupleTypeString() {
   return tupleTypeStringImpl<Elems...>(std::make_index_sequence<sizeof...(Elems)>());
 }
 
+template <typename T>
+std::string iteratorTypeString() {
+  return std::string("typing.Iterator[") + PythonReturnTypeInfo<T>::typeString() + "]";
+}
+
+
 /* Invoke the DEFINE_INOUT_TYPE macro for each type we want to support.
    New types should be added here. We might consider performing these invocations
    using X-macros for the entire AST class hierarchy if we wanted to be
@@ -228,6 +234,8 @@ template <typename T>
 T_DEFINE_INOUT_TYPE(std::optional<T>, optionalTypeString<T>(), wrapOptional(CONTEXT, TO_WRAP), unwrapOptional<T>(CONTEXT, TO_UNWRAP));
 template <typename ... Elems>
 T_DEFINE_INOUT_TYPE(std::tuple<Elems...>, tupleTypeString<Elems...>(), wrapTuple(CONTEXT, TO_WRAP), unwrapTuple<Elems...>(CONTEXT, TO_UNWRAP));
+template <typename ElemType>
+T_DEFINE_INOUT_TYPE(TypedIterAdapterBase<ElemType>*, iteratorTypeString<ElemType>(), wrapIterAdapter(CONTEXT, TO_WRAP), (TypedIterAdapterBase<ElemType>*) ((AstIterObject*) TO_UNWRAP)->iterAdapter);
 
 #define GENERATED_TYPE(ROOT, ROOT_TYPE, NAME, TYPE, TAG, FLAGS) \
   DEFINE_INOUT_TYPE(const TYPE*, #NAME, wrapGeneratedType(CONTEXT, (ROOT_TYPE*) TO_WRAP), ((ROOT##Object*) TO_UNWRAP)->value_->to##NAME());

--- a/tools/chapel-py/src/python-types.h
+++ b/tools/chapel-py/src/python-types.h
@@ -229,6 +229,10 @@ T_DEFINE_INOUT_TYPE(std::optional<T>, optionalTypeString<T>(), wrapOptional(CONT
 template <typename ... Elems>
 T_DEFINE_INOUT_TYPE(std::tuple<Elems...>, tupleTypeString<Elems...>(), wrapTuple(CONTEXT, TO_WRAP), unwrapTuple<Elems...>(CONTEXT, TO_UNWRAP));
 
+#define GENERATED_TYPE(ROOT, ROOT_TYPE, NAME, TYPE, TAG, FLAGS) \
+  DEFINE_INOUT_TYPE(const TYPE*, #NAME, wrapGeneratedType(CONTEXT, (ROOT_TYPE*) TO_WRAP), ((ROOT##Object*) TO_UNWRAP)->value_->to##NAME());
+#include "generated-types-list.h"
+
 #undef T_DEFINE_INOUT_TYPE
 #undef DEFINE_INOUT_TYPE
 

--- a/tools/chapel-py/src/python-types.h
+++ b/tools/chapel-py/src/python-types.h
@@ -211,9 +211,9 @@ DEFINE_INOUT_TYPE(int, "int", Py_BuildValue("i", TO_WRAP), PyLong_AsLong(TO_UNWR
 DEFINE_INOUT_TYPE(const char*, "str", Py_BuildValue("s", TO_WRAP), PyUnicode_AsUTF8(TO_UNWRAP));
 DEFINE_INOUT_TYPE(chpl::UniqueString, "str", Py_BuildValue("s", TO_WRAP.c_str()), chpl::UniqueString::get(&CONTEXT->value_, PyUnicode_AsUTF8(TO_UNWRAP)));
 DEFINE_INOUT_TYPE(std::string, "str", Py_BuildValue("s", TO_WRAP.c_str()), std::string(PyUnicode_AsUTF8(TO_UNWRAP)));
-DEFINE_INOUT_TYPE(const chpl::uast::AstNode*, "AstNode", wrapAstNode(CONTEXT, TO_WRAP), ((AstNodeObject*) TO_UNWRAP)->value_);
-DEFINE_INOUT_TYPE(const chpl::types::Type*, "ChapelType", wrapType(CONTEXT, TO_WRAP), ((ChapelTypeObject*) TO_UNWRAP)->value_);
-DEFINE_INOUT_TYPE(const chpl::types::Param*, "Param", wrapParam(CONTEXT, TO_WRAP), ((ParamObject*) TO_UNWRAP)->value_);
+DEFINE_INOUT_TYPE(const chpl::uast::AstNode*, "AstNode", wrapGeneratedType(CONTEXT, TO_WRAP), ((AstNodeObject*) TO_UNWRAP)->value_);
+DEFINE_INOUT_TYPE(const chpl::types::Type*, "ChapelType", wrapGeneratedType(CONTEXT, TO_WRAP), ((ChapelTypeObject*) TO_UNWRAP)->value_);
+DEFINE_INOUT_TYPE(const chpl::types::Param*, "Param", wrapGeneratedType(CONTEXT, TO_WRAP), ((ParamObject*) TO_UNWRAP)->value_);
 DEFINE_INOUT_TYPE(chpl::Location, "Location", (PyObject*) LocationObject::create(TO_WRAP), ((LocationObject*) TO_UNWRAP)->value_);
 DEFINE_INOUT_TYPE(IterAdapterBase*, "typing.Iterator[AstNode]", wrapIterAdapter(CONTEXT, TO_WRAP), ((AstIterObject*) TO_UNWRAP)->iterAdapter);
 DEFINE_INOUT_TYPE(PyObject*, "typing.Any", TO_WRAP, TO_UNWRAP);

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -556,6 +556,8 @@ class FileInfo:
 
             sig = candidate.function()
             fn = sig.ast()
+            if not fn:
+                continue
 
             # Even if we don't descend into it (and even if it's not an
             # instantiation), track the call that invoked this function.
@@ -1289,6 +1291,9 @@ def run_lsp():
             return None
 
         decl = type_.decl()
+        if not decl:
+            return None
+
         return location_to_location(decl.location())
 
     @server.feature(TEXT_DOCUMENT_DOCUMENT_SYMBOL)

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -118,6 +118,8 @@ def register_rules(driver):
             if isinstance(node, MultiDecl):
                 for child in node:
                     if isinstance(child, Variable): var_node = child
+                else:
+                    return None
             elif isinstance(node, Variable):
                 var_node = node
             else:


### PR DESCRIPTION
This PR makes some changes to the method tables and marshaling API to generate better (Python) type information about the types exposed by the python bindings. Importantly, these changes __only affect the types as reported by the generated .pyi` file__: this change affects developers who program using `chapel-py`. The changes are as follows:

* Allow returning subclasses (e.g. `IntLiteral*`) instead of the parent class (e.g. `AstNode*`) where appropriate. This makes it possible to narrow the types of methods that are known to return certain subsets of the class hierarchy: `Function.formal(i)` now reports returning a `chapel.Decl` instead of a `chapel.AstNode` on the Python side.
    * To make use of X-macros for "all generated types", this required some changes to said X-macros (adding explicit fully-qualified (C++) type arguments, so that marshaling code can cast to and from these types) and to surrounding methods (`wrapAstNode`, `wrapType`, and `wrapParam` are all renamed to `wrapGeneratedType`, relying on overloading).
* Provide an intermediate "base class" for adapters that includes the type parameter. Thus, we can return `Iterable[Module]` instead of `Iterable[AstNode]`.
* Disallows `nullptr` for wrapping AST nodes, types, and params, throwing Python exceptions in that case. For situations where returning a `nullptr` is possible (e.g., getting the initialization expression from a variable -- not all variables have init exprs), provides a `Nilable` wrapper class. This class is used to tag types in `PLAIN_GETTER` and `METHOD` calls, and causes a `== nullptr` check to occur. This wrapper results in the method being marked `Optional[X]`. Prior to this, any method that returned `AstNode` could return `None`; now, `None`-returning methods are explicitly tagged.
* Adds an `ITER_PROTOTYPE`  X-macro (currently used only for .pyi generation) which allows `__iter__` method signatures to be generated for relevant types. This, in turn, tells typecheckers that `AstNode` is iterable.

Reviewed by @jabraham17 -- thanks!