### PR TITLE
Relax floating point restrictions on sqrt and abs optimization

### DIFF
--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -2188,7 +2188,7 @@ static GenRet codegenSqrt(GenRet a) {
   GenRet ret;
   if (a.chplType && a.chplType->symbol->isRefOrWideRef()) a = codegenDeref(a);
   GenRet av = codegenValue(a);
-  if (info->cfile || ffloatOpt == -1 /*strict float*/) {
+  if (info->cfile) {
     ret = emitSqrtCMath(av);
   } else {
     ret = emitSqrtLLVMIntrinsic(av);
@@ -2234,7 +2234,7 @@ static GenRet codegenAbs(GenRet a) {
   GenRet ret;
   if (a.chplType && a.chplType->symbol->isRefOrWideRef()) a = codegenDeref(a);
   GenRet av = codegenValue(a);
-  if (info->cfile || ffloatOpt == -1 /*strict float*/) {
+  if (info->cfile) {
     ret = emitAbsCMath(av);
   } else {
     ret = emitAbsLLVMIntrinsic(av);


### PR DESCRIPTION
This PR relaxes the restriction on #24455 that we could only codegen sqrt and abs directly to LLVM IR in non-strict floating point mode. Based on discussion in #24464, this PR relaxes that.

Tested locally

[Reviewed by @mppf]