### PR TITLE
Add chpl-language-server to the release bundle

### DIFF
--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -171,7 +171,8 @@ if (exists($ENV{"CHPL_GEN_RELEASE_NO_CLONE"})) {
     "tools/protoc-gen-chpl",
     "tools/unstableWarningAnonymizer/",
     "tools/chapel-py",
-    "tools/chplcheck"
+    "tools/chplcheck",
+    "tools/chpl-language-server"
 );
 
 


### PR DESCRIPTION
Adds `chpl-language-server` to the release bundle.

Tested by running command locally with `CHPL_GEN_RELEASE_NO_CLONE=1` and ensuring that `make chpl-language-server` works

[Reviewed by @DanilaFe]