### PR TITLE
Implicitly bind co-locales to architectural features

### DIFF
--- a/test/runtime/jhh/colocales/colocales.c
+++ b/test/runtime/jhh/colocales/colocales.c
@@ -74,11 +74,12 @@ int main(int argc, char* argv[]) {
   }
   setenv("CHPL_RT_LOCALES_PER_NODE", numLocalesStr, 1);
   chpl__init_colocales(0, 0); // unsure why this is needed
+  chpl_topo_pre_comm_init(mask);
+  chpl_comm_init(NULL, NULL);
   chpl_set_num_locales_on_node(numLocales);
   if (rank != -1) {
     chpl_set_local_rank(rank);
   }
-  chpl_topo_pre_comm_init(mask);
   chpl_topo_post_comm_init();
   chpl_topo_post_args_init();
 

--- a/test/runtime/jhh/colocales/colocales.c
+++ b/test/runtime/jhh/colocales/colocales.c
@@ -13,6 +13,8 @@
 #include "lib/colocales.h"
 #include <hwloc.h>
 
+extern int verbosity;
+
 void Usage(char *name) {
   fprintf(stderr, "Usage: %s [-m mask] [-N nic] [-n numColocales] [-r rank]\n", name);
   fprintf(stderr, "\t-m <mask>\tMask off accessible PUs\n");
@@ -33,7 +35,7 @@ int main(int argc, char* argv[]) {
   char *numLocalesStr = "1";
   char *nic = NULL;
 
-  while ((opt = getopt(argc, argv, "m:N:n:r:")) != -1) {
+  while ((opt = getopt(argc, argv, "m:N:n:r:v")) != -1) {
     switch(opt) {
       case 'm':
         mask = optarg;
@@ -47,6 +49,9 @@ int main(int argc, char* argv[]) {
         break;
       case 'N':
         nic = optarg;
+        break;
+      case 'v':
+        verbosity++;
         break;
       case 'h':
         Usage(argv[0]);
@@ -75,6 +80,7 @@ int main(int argc, char* argv[]) {
   }
   chpl_topo_pre_comm_init(mask);
   chpl_topo_post_comm_init();
+  chpl_topo_post_args_init();
 
   hwloc_topology_t topology = (hwloc_topology_t) chpl_topo_getHwlocTopology();
 


### PR DESCRIPTION
   If the number of co-locales on a node equals the number of an architectural feature (sockets, NUMA domains, level 3 caches, or cores), then the co-locales will be bound (confined) to the feature. Thus, '-nl 3x2' on nodes with two sockets will run each co-locale in its own socket.