### PR TITLE
Avoid warning about implicit modules for main files.

### DIFF
--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -111,6 +111,14 @@ static void maybePrintModuleFile(ModTag modTag, const char* path);
 
 class DynoErrorHandler : public chpl::Context::ErrorHandler {
   std::vector<chpl::owned<chpl::ErrorBase>> errors_;
+
+  // we'd like to silence certain types of warnings, but can't do it through
+  // Dyno-as-library because doing so would require knowing the result of
+  // parsing all files, which Dyno, as a query-based API, is not well-suited
+  // for. So, instead, we detect these warnings and stick them into a list
+  // "for later". Once we've parsed all the files, we can then decide whether
+  // to silence them or not.
+  std::vector<chpl::owned<chpl::ErrorBase>> deferredErrors_;
  public:
   DynoErrorHandler() = default;
   ~DynoErrorHandler() = default;
@@ -119,18 +127,31 @@ class DynoErrorHandler : public chpl::Context::ErrorHandler {
     return errors_;
   }
 
+  const std::vector<chpl::owned<chpl::ErrorBase>>& deferredErrors() const {
+    return deferredErrors_;
+  }
+
   virtual void
   report(chpl::Context* context, const chpl::ErrorBase* err) override {
-    errors_.push_back(err->clone());
+    if (err->type() == chpl::ErrorType::ImplicitFileModule) {
+      // Defer implicit module warning until we know which module is the
+      // 'main' one. Knowing this requires having parsed all files and
+      // checking them for 'proc main'.
+      deferredErrors_.push_back(err->clone());
+    } else {
+      errors_.push_back(err->clone());
+    }
   }
 
   inline void clear() { errors_.clear(); }
+  inline void clearDeferred() { deferredErrors_.clear(); }
 };
 
 // Call to insert an instance of the error handler above into the context.
 static DynoErrorHandler* dynoPrepareAndInstallErrorHandler(void);
 
 static bool dynoRealizeErrors(void);
+static bool dynoRealizeDeferredErrors(void);
 
 static ModuleSymbol* dynoParseFile(const char* fileName,
                                    ModTag      modTag,
@@ -1069,34 +1090,63 @@ static DynoErrorHandler* dynoPrepareAndInstallErrorHandler(void) {
 // Only install one of these for the entire session.
 static DynoErrorHandler* gDynoErrorHandler = nullptr;
 
+static bool dynoRealizeError(const chpl::owned<chpl::ErrorBase>& err) {
+  bool hadErrors = false;
+  const chpl::ErrorBase* e = err.get();
+
+  if (e->kind() == chpl::ErrorBase::SYNTAX ||
+      e->kind() == chpl::ErrorBase::ERROR) {
+    // make a note if we found any errors
+    hadErrors = true;
+  }
+
+  // skip emitting warnings for '--no-warnings'
+  if (ignore_warnings && e->kind() == chpl::ErrorBase::WARNING) {
+    return hadErrors;
+  }
+
+  if (fDetailedErrors) {
+    chpl::Context::defaultReportError(gContext, e);
+    // Use production compiler's exit-on-error functionality for errors
+    // reported via new Dyno mechanism
+    setupDynoError(e->kind());
+  } else {
+    // Try to maintain compatibility with the old reporting mechanism
+    dynoDisplayError(gContext, e->toErrorMessage(gContext));
+  }
+  return hadErrors;
+}
+
 static bool dynoRealizeErrors(void) {
   INT_ASSERT(gDynoErrorHandler);
   bool hadErrors = false;
   for (auto& err : gDynoErrorHandler->errors()) {
-    const chpl::ErrorBase* e = err.get();
-
-    if (e->kind() == chpl::ErrorBase::SYNTAX ||
-        e->kind() == chpl::ErrorBase::ERROR) {
-      // make a note if we found any errors
-      hadErrors = true;
-    }
-
-    // skip emitting warnings for '--no-warnings'
-    if (ignore_warnings && e->kind() == chpl::ErrorBase::WARNING) {
-      continue;
-    }
-
-    if (fDetailedErrors) {
-      chpl::Context::defaultReportError(gContext, e);
-      // Use production compiler's exit-on-error functionality for errors
-      // reported via new Dyno mechanism
-      setupDynoError(e->kind());
-    } else {
-      // Try to maintain compatibility with the old reporting mechanism
-      dynoDisplayError(gContext, e->toErrorMessage(gContext));
-    }
+    hadErrors |= dynoRealizeError(err);
   }
   gDynoErrorHandler->clear();
+  return hadErrors;
+}
+
+static bool dynoRealizeDeferredErrors(void) {
+  INT_ASSERT(gDynoErrorHandler);
+  bool hadErrors = false;
+  auto mainModulePath = ModuleSymbol::mainModule()->path();
+
+  for (auto& err : gDynoErrorHandler->deferredErrors()) {
+    if (err->type() == chpl::ErrorType::ImplicitFileModule) {
+      auto errCast = (const chpl::ErrorImplicitFileModule*) err.get();
+      auto implicitMod = std::get<2>(errCast->info());
+
+      if (implicitMod->id().symbolPathWithoutRepeats(gContext) == mainModulePath) {
+        // Do not emit the implicit file module warning for the main module,
+        // since it's a very common pattern.
+        continue;
+      }
+    }
+
+    hadErrors |= dynoRealizeError(err);
+  }
+  gDynoErrorHandler->clearDeferred();
   return hadErrors;
 }
 
@@ -1361,6 +1411,8 @@ void parseAndConvertUast() {
   parseInternalModules();
 
   parseCommandLineFiles();
+
+  dynoRealizeDeferredErrors();
 
   checkConfigs();
 

--- a/frontend/include/chpl/framework/ErrorBase.h
+++ b/frontend/include/chpl/framework/ErrorBase.h
@@ -229,16 +229,16 @@ class GeneralError : public BasicError {
   class Error##NAME__ : public ErrorBase {\
    private:\
     using ErrorInfo = std::tuple<EINFO__>;\
-    ErrorInfo info;\
+    ErrorInfo info_;\
 \
     Error##NAME__(const Error##NAME__& other) = default;\
     Error##NAME__(ErrorInfo info) :\
-      ErrorBase(KIND__, NAME__), info(std::move(info)) {}\
+      ErrorBase(KIND__, NAME__), info_(std::move(info)) {}\
 \
    protected:\
     bool contentsMatchInner(const ErrorBase* other) const override {\
       auto otherCast = static_cast<const Error##NAME__*>(other);\
-      return info == otherCast->info;\
+      return info_ == otherCast->info_;\
     }\
    public:\
     ~Error##NAME__() = default;\
@@ -247,11 +247,13 @@ class GeneralError : public BasicError {
     void write(ErrorWriterBase& writer) const override;\
     void mark(Context* context) const override {\
       ::chpl::mark<ErrorInfo> marker;\
-      marker(context, info);\
+      marker(context, info_);\
     }\
     owned<ErrorBase> clone() const override {\
       return owned<ErrorBase>(new Error##NAME__(*this));\
     }\
+\
+    ErrorInfo info() const { return info_; }\
   };
 #include "chpl/framework/error-classes-list.h"
 #undef DIAGNOSTIC_CLASS

--- a/frontend/include/chpl/framework/ID.h
+++ b/frontend/include/chpl/framework/ID.h
@@ -81,6 +81,16 @@ class ID final {
   UniqueString symbolPath() const { return symbolPath_; }
 
   /**
+    Return a path to the ID symbol scope, but without taking into account
+    repeated names within a symbol. In particular, M.f#0 and M.f#1 would
+    both return M.f.
+
+    This is useful for exposing a "user-facing" path, such as one that a user
+    can specify from the command line.
+   */
+  UniqueString symbolPathWithoutRepeats(Context* context) const;
+
+  /**
     Returns the numbering of this node in a postorder traversal
     of a symbol's nodes. When the AST node defines a new ID symbol scope,
     (as with Function or Module) this will return -1.

--- a/frontend/lib/framework/ID.cpp
+++ b/frontend/lib/framework/ID.cpp
@@ -25,6 +25,20 @@
 
 namespace chpl {
 
+UniqueString ID::symbolPathWithoutRepeats(Context* context) const {
+  std::string ret = "";
+  bool needsDot = false;
+
+  auto expanded = expandSymbolPath(context, symbolPath_);
+  for (auto pathPair : expanded) {
+    if (needsDot) ret += ".";
+    needsDot = true;
+
+    ret += pathPair.first.c_str();
+  }
+
+  return UniqueString::get(context, ret.c_str());
+}
 
 // find the last '.' but don't count \.
 // returns -1 if none was found

--- a/frontend/lib/parsing/parser-error-classes-list.cpp
+++ b/frontend/lib/parsing/parser-error-classes-list.cpp
@@ -47,13 +47,13 @@ namespace chpl {
 // Bison* errors are reported by the Bison parser to yyerror
 
 void ErrorBisonMemoryExhausted::write(ErrorWriterBase& wr) const {
-  auto loc = std::get<const Location>(info);
+  auto loc = std::get<const Location>(info_);
   wr.heading(kind_, type_, loc, "memory exhausted while parsing.");
 }
 
 void ErrorBisonSyntaxError::write(ErrorWriterBase& wr) const {
-  auto loc = std::get<const Location>(info);
-  auto nearestToken = std::get<std::string>(info);
+  auto loc = std::get<const Location>(info_);
+  auto nearestToken = std::get<std::string>(info_);
   wr.heading(kind_, type_, loc,
              (nearestToken.empty() ? "(no token given)"
                                    : "near '" + nearestToken + "'"),
@@ -62,9 +62,9 @@ void ErrorBisonSyntaxError::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorBisonUnknownError::write(ErrorWriterBase& wr) const {
-  auto loc = std::get<const Location>(info);
-  auto errorMessage = std::get<1>(info);
-  auto nearestToken = std::get<2>(info);
+  auto loc = std::get<const Location>(info_);
+  auto errorMessage = std::get<1>(info_);
+  auto nearestToken = std::get<2>(info_);
   wr.heading(kind_, type_, loc,
              "unknown error from Bison parser: ", errorMessage, ".");
   if (!nearestToken.empty()) {
@@ -76,8 +76,8 @@ void ErrorBisonUnknownError::write(ErrorWriterBase& wr) const {
 // other parser errors
 
 void ErrorCannotAttachPragmas::write(ErrorWriterBase& wr) const {
-  auto loc = std::get<const Location>(info);
-  auto stmt = std::get<const uast::AstNode*>(info);
+  auto loc = std::get<const Location>(info_);
+  auto stmt = std::get<const uast::AstNode*>(info_);
   wr.heading(kind_, type_, loc, "cannot attach 'pragma's to this statement.");
   if (stmt) {
     wr.code(stmt);
@@ -88,9 +88,9 @@ void ErrorCannotAttachPragmas::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorCommentEOF::write(ErrorWriterBase& wr) const {
-  auto loc = std::get<0>(info);
-  auto startLoc = std::get<1>(info);
-  auto nestedLoc = std::get<2>(info);
+  auto loc = std::get<0>(info_);
+  auto startLoc = std::get<1>(info_);
+  auto nestedLoc = std::get<2>(info_);
   wr.heading(kind_, type_, loc, "end-of-file in comment.");
   wr.note(startLoc, "unterminated comment here:");
   wr.code(startLoc);
@@ -101,9 +101,9 @@ void ErrorCommentEOF::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorExceptOnlyInvalidExpr::write(ErrorWriterBase& wr) const {
-  auto loc = std::get<0>(info);
-  auto limitLoc = std::get<1>(info);
-  auto limitationKind = std::get<uast::VisibilityClause::LimitationKind>(info);
+  auto loc = std::get<0>(info_);
+  auto limitLoc = std::get<1>(info_);
+  auto limitationKind = std::get<uast::VisibilityClause::LimitationKind>(info_);
   wr.heading(kind_, type_, loc, "incorrect expression in '", limitationKind,
              "' list, identifier expected.");
   wr.message("In the '", limitationKind, "' list here:");
@@ -111,8 +111,8 @@ void ErrorExceptOnlyInvalidExpr::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorExternUnclosedPair::write(ErrorWriterBase& wr) const {
-  auto loc = std::get<const Location>(info);
-  auto pairSymbol = std::get<std::string>(info);
+  auto loc = std::get<const Location>(info_);
+  auto pairSymbol = std::get<std::string>(info_);
   wr.heading(kind_, type_, loc, "missing closing ", pairSymbol,
              " symbol in extern block.");
   wr.message("In this extern block:");
@@ -120,7 +120,7 @@ void ErrorExternUnclosedPair::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorInvalidIndexExpr::write(ErrorWriterBase& wr) const {
-  auto loc = std::get<const Location>(info);
+  auto loc = std::get<const Location>(info_);
   wr.heading(kind_, type_, loc,
              "only identifiers or tuples of identifiers are allowed as index "
              "expressions.");
@@ -129,16 +129,16 @@ void ErrorInvalidIndexExpr::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorInvalidNewForm::write(ErrorWriterBase& wr) const {
-  auto loc = std::get<const Location>(info);
-  auto newExpr = std::get<const uast::AstNode*>(info);
+  auto loc = std::get<const Location>(info_);
+  auto newExpr = std::get<const uast::AstNode*>(info_);
   wr.heading(kind_, type_, loc, "Invalid form for 'new' expression.");
   wr.message("'new' expression used here:");
   wr.code(loc, {newExpr});
 }
 
 void ErrorInvalidNumericLiteral::write(ErrorWriterBase& wr) const {
-  auto loc = std::get<const Location>(info);
-  auto errMessage = std::get<std::string>(info);
+  auto loc = std::get<const Location>(info_);
+  auto errMessage = std::get<std::string>(info_);
   CHPL_ASSERT(!errMessage.empty());
   CHPL_ASSERT(errMessage.back() == '.' &&
          "expected a period at the end of InvalidNumericLiteral message");
@@ -149,8 +149,8 @@ void ErrorInvalidNumericLiteral::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorLabelIneligibleStmt::write(ErrorWriterBase& wr) const {
-  auto loc = std::get<const Location>(info);
-  auto maybeStmt = std::get<const uast::AstNode*>(info);
+  auto loc = std::get<const Location>(info_);
+  auto maybeStmt = std::get<const uast::AstNode*>(info_);
   if (maybeStmt && maybeStmt->tag() == uast::AstTag::EmptyStmt) {
     // this is the case where there is a semicolon following the label name
     wr.heading(kind_, type_, loc,
@@ -164,7 +164,7 @@ void ErrorLabelIneligibleStmt::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorMultipleExternalRenaming::write(ErrorWriterBase& wr) const {
-  auto loc = std::get<const Location>(info);
+  auto loc = std::get<const Location>(info_);
   wr.heading(
       kind_, type_, loc,
       "external symbol renaming can only be applied to one symbol at a time.");
@@ -173,8 +173,8 @@ void ErrorMultipleExternalRenaming::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorNewWithoutArgs::write(ErrorWriterBase& wr) const {
-  auto loc = std::get<const Location>(info);
-  auto expr = std::get<const uast::AstNode*>(info);
+  auto loc = std::get<const Location>(info_);
+  auto expr = std::get<const uast::AstNode*>(info_);
   wr.heading(kind_, type_, loc,
              "'new' expression is missing its argument list.");
   wr.message("'new' expression used here:");
@@ -183,8 +183,8 @@ void ErrorNewWithoutArgs::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorPreIncDecOp::write(ErrorWriterBase& wr) const {
-  auto loc = std::get<const Location>(info);
-  auto isDoublePlus = std::get<bool>(info);
+  auto loc = std::get<const Location>(info_);
+  auto isDoublePlus = std::get<bool>(info_);
   if (isDoublePlus) {
     wr.heading(kind_, type_, loc, "'++' is not a pre-increment.");
   } else {
@@ -195,9 +195,9 @@ void ErrorPreIncDecOp::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorStringLiteralEOF::write(ErrorWriterBase& wr) const {
-  auto loc = std::get<const Location>(info);
-  auto startChar = std::get<char>(info);
-  auto startCharCount = std::get<int>(info);
+  auto loc = std::get<const Location>(info_);
+  auto startChar = std::get<char>(info_);
+  auto startCharCount = std::get<int>(info_);
   auto startDelimiter = std::string((size_t)startCharCount, startChar);
   wr.heading(kind_, type_, loc, "end-of-file in string literal.");
   wr.message("Unterminated string literal here:");
@@ -207,8 +207,8 @@ void ErrorStringLiteralEOF::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorUseImportNeedsModule::write(ErrorWriterBase& wr) const {
-  auto loc = std::get<const Location>(info);
-  auto isImport = std::get<bool>(info);
+  auto loc = std::get<const Location>(info_);
+  auto isImport = std::get<bool>(info_);
   std::string useOrImport = isImport ? "import" : "use";
   wr.heading(kind_, type_, loc, "'", useOrImport,
              "' statements must refer to module",
@@ -220,8 +220,8 @@ void ErrorUseImportNeedsModule::write(ErrorWriterBase& wr) const {
 // catch-alls for simple parsing errors
 
 void ErrorParseErr::write(ErrorWriterBase& wr) const {
-  auto loc = std::get<const Location>(info);
-  auto errorMessage = std::get<std::string>(info);
+  auto loc = std::get<const Location>(info_);
+  auto errorMessage = std::get<std::string>(info_);
   CHPL_ASSERT(errorMessage.back() == '.' &&
          "expected a period at the end of ErrorParseErr message");
   wr.heading(kind_, type_, loc, errorMessage);
@@ -229,8 +229,8 @@ void ErrorParseErr::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorParseSyntax::write(ErrorWriterBase& wr) const {
-  auto loc = std::get<const Location>(info);
-  auto errorMessage = std::get<std::string>(info);
+  auto loc = std::get<const Location>(info_);
+  auto errorMessage = std::get<std::string>(info_);
   CHPL_ASSERT(errorMessage.back() == '.' &&
          "expected a period at the end of ErrorParseSyntax message");
   wr.heading(kind_, type_, loc, errorMessage);
@@ -240,8 +240,8 @@ void ErrorParseSyntax::write(ErrorWriterBase& wr) const {
 /* begin post-parse-checks errors */
 
 void ErrorCantApplyPrivate::write(ErrorWriterBase& wr) const {
-  auto node = std::get<const uast::AstNode*>(info);
-  auto appliedToWhat = std::get<std::string>(info);
+  auto node = std::get<const uast::AstNode*>(info_);
+  auto appliedToWhat = std::get<std::string>(info_);
   wr.heading(kind_, type_, node, "can't apply private to ", appliedToWhat,
              " yet.");
   wr.message("The following declaration has unsupported 'private' modifier:");
@@ -249,9 +249,9 @@ void ErrorCantApplyPrivate::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorWhenAfterOtherwise::write(ErrorWriterBase& wr) const {
-  auto node = std::get<0>(info);
-  auto otherwise = std::get<1>(info);
-  auto when = std::get<2>(info);
+  auto node = std::get<0>(info_);
+  auto otherwise = std::get<1>(info_);
+  auto when = std::get<2>(info_);
   wr.heading(kind_, type_, node, "'otherwise' clause must follow all 'when' clauses.");
   wr.message("In the following 'select' statement:");
   wr.code(node);
@@ -263,9 +263,9 @@ void ErrorWhenAfterOtherwise::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorDisallowedControlFlow::write(ErrorWriterBase& wr) const {
-  auto invalidAst = std::get<0>(info);
-  auto blockingAst = std::get<1>(info);
-  auto allowingAst = std::get<2>(info);
+  auto invalidAst = std::get<0>(info_);
+  auto blockingAst = std::get<1>(info_);
+  auto allowingAst = std::get<2>(info_);
 
   // Match some special cases:
   auto ret = invalidAst->toReturn();
@@ -409,8 +409,8 @@ void ErrorDisallowedControlFlow::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorIllegalUseImport::write(ErrorWriterBase& wr) const {
-  auto clause = std::get<0>(info);
-  auto parent = std::get<1>(info);
+  auto clause = std::get<0>(info_);
+  auto parent = std::get<1>(info_);
   const char* useOrImport = parent->isImport() ? "import" : "use";
   wr.heading(kind_, type_, clause,
              "Illegal expression in '", useOrImport, "' statement");
@@ -419,8 +419,8 @@ void ErrorIllegalUseImport::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorInvalidGpuAssertion::write(ErrorWriterBase& wr) const {
-  auto node = std::get<const uast::AstNode*>(info);
-  // auto attr = std::get<const uast::Attribute*>(info);
+  auto node = std::get<const uast::AstNode*>(info_);
+  // auto attr = std::get<const uast::Attribute*>(info_);
 
   const char* loopTypes = nullptr;
   if (node->isFor()) {
@@ -453,8 +453,8 @@ void ErrorInvalidGpuAssertion::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorInvalidImplementsIdent::write(ErrorWriterBase& wr) const {
-  auto implements = std::get<const uast::Implements*>(info);
-  auto ident = std::get<const uast::Identifier*>(info);
+  auto implements = std::get<const uast::Implements*>(info_);
+  auto ident = std::get<const uast::Identifier*>(info_);
 
   auto typeName = ident->name();
   if (typeName == USTR("domain")) {
@@ -468,8 +468,8 @@ void ErrorInvalidImplementsIdent::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorInvalidParenfulDeprecation::write(ErrorWriterBase& wr) const {
-  auto attributeGroup = std::get<const uast::AttributeGroup*>(info);
-  auto appliedTo = std::get<const uast::AstNode*>(info);
+  auto attributeGroup = std::get<const uast::AttributeGroup*>(info_);
+  auto appliedTo = std::get<const uast::AstNode*>(info_);
 
   wr.heading(kind_, type_, attributeGroup, "the '@deprecated' attribute with 'parenful=true' can only be applied to parenless functions.");
   wr.message("It is used to indicate that a parenless function used to be callable with parentheses.");
@@ -484,9 +484,9 @@ void ErrorInvalidParenfulDeprecation::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorMultipleManagementStrategies::write(ErrorWriterBase& wr) const {
-  auto node = std::get<const uast::AstNode*>(info);
-  auto outerMgt = std::get<1>(info);
-  auto innerMgt = std::get<2>(info);
+  auto node = std::get<const uast::AstNode*>(info_);
+  auto outerMgt = std::get<1>(info_);
+  auto innerMgt = std::get<2>(info_);
   wr.heading(kind_, type_, node,
              "type expression uses multiple memory management strategies ('",
              outerMgt, "' and '", innerMgt, "').");
@@ -501,8 +501,8 @@ void ErrorMultipleManagementStrategies::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorPostParseErr::write(ErrorWriterBase& wr) const {
-  auto node = std::get<const uast::AstNode*>(info);
-  auto errorMessage = std::get<std::string>(info);
+  auto node = std::get<const uast::AstNode*>(info_);
+  auto errorMessage = std::get<std::string>(info_);
   CHPL_ASSERT(errorMessage.back() == '.' &&
          "expected a period at the end of ErrorPostParseErr message");
   wr.heading(kind_, type_, node, errorMessage);
@@ -510,8 +510,8 @@ void ErrorPostParseErr::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorPostParseWarn::write(ErrorWriterBase& wr) const {
-  auto node = std::get<const uast::AstNode*>(info);
-  auto errorMessage = std::get<std::string>(info);
+  auto node = std::get<const uast::AstNode*>(info_);
+  auto errorMessage = std::get<std::string>(info_);
   CHPL_ASSERT(errorMessage.back() == '.' &&
          "expected a period at the end of ErrorPostParseWarn message");
   wr.heading(kind_, type_, node, errorMessage);
@@ -519,8 +519,8 @@ void ErrorPostParseWarn::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorUnsupportedAsIdent::write(ErrorWriterBase& wr) const {
-  auto as = std::get<const uast::As*>(info);
-  auto expectedIdentifier = std::get<const uast::AstNode*>(info);
+  auto as = std::get<const uast::As*>(info_);
+  auto expectedIdentifier = std::get<const uast::AstNode*>(info_);
   wr.heading(kind_, type_, locationOnly(as),
              "this form of 'as' is not yet supported.");
   // determine and report which of the original or new name is invalid

--- a/frontend/lib/resolution/resolution-error-classes-list.cpp
+++ b/frontend/lib/resolution/resolution-error-classes-list.cpp
@@ -159,9 +159,9 @@ static void describeSymbolTrace(ErrorWriterBase& wr,
 
 /* begin resolution errors */
 void ErrorAmbiguousConfigName::write(ErrorWriterBase& wr) const {
-  auto& name = std::get<std::string>(info);
-  auto variable = std::get<const uast::Variable*>(info);
-  auto otherId = std::get<ID>(info);
+  auto& name = std::get<std::string>(info_);
+  auto variable = std::get<const uast::Variable*>(info_);
+  auto otherId = std::get<ID>(info_);
   wr.heading(kind_, type_, locationOnly(variable), "ambiguous config name (", name, ").");
   wr.code(variable);
   wr.note(locationOnly(otherId), "also defined here:");
@@ -170,9 +170,9 @@ void ErrorAmbiguousConfigName::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorAmbiguousConfigSet::write(ErrorWriterBase& wr) const {
-  auto& name1 = std::get<1>(info);
-  auto& name2 = std::get<2>(info);
-  auto variable = std::get<const uast::Variable*>(info);
+  auto& name1 = std::get<1>(info_);
+  auto& name2 = std::get<2>(info_);
+  auto variable = std::get<const uast::Variable*>(info_);
   wr.heading(kind_, type_, locationOnly(variable),
             "config set ambiguously via '-s", name1, "' and '-s", name2, "'");
 }
@@ -218,10 +218,10 @@ void describeAmbiguousMatch(ErrorWriterBase& wr,
 }
 
 void ErrorAmbiguousIdentifier::write(ErrorWriterBase& wr) const {
-  auto ident = std::get<const uast::Identifier*>(info);
-  auto moreMentions = std::get<bool>(info);
-  auto matches = std::get<std::vector<resolution::BorrowedIdsWithName>>(info);
-  auto trace = std::get<std::vector<resolution::ResultVisibilityTrace>>(info);
+  auto ident = std::get<const uast::Identifier*>(info_);
+  auto moreMentions = std::get<bool>(info_);
+  auto matches = std::get<std::vector<resolution::BorrowedIdsWithName>>(info_);
+  auto trace = std::get<std::vector<resolution::ResultVisibilityTrace>>(info_);
 
   wr.heading(kind_, type_, ident,
              "'", ident->name(), "' is ambiguous",
@@ -245,9 +245,9 @@ void ErrorAmbiguousIdentifier::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorAmbiguousVisibilityIdentifier::write(ErrorWriterBase& wr) const {
-  auto name = std::get<UniqueString>(info);
-  auto mentionId = std::get<ID>(info);
-  auto potentialTargetIds = std::get<std::vector<ID>>(info);
+  auto name = std::get<UniqueString>(info_);
+  auto mentionId = std::get<ID>(info_);
+  auto potentialTargetIds = std::get<std::vector<ID>>(info_);
 
   wr.heading(kind_, type_, mentionId,
              "'", name, "' is ambiguous");
@@ -266,8 +266,8 @@ void ErrorAmbiguousVisibilityIdentifier::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorAsWithUseExcept::write(ErrorWriterBase& wr) const {
-  auto use = std::get<const uast::Use*>(info);
-  auto as = std::get<const uast::As*>(info);
+  auto use = std::get<const uast::Use*>(info_);
+  auto as = std::get<const uast::As*>(info_);
   wr.heading(kind_, type_, locationOnly(use),
              "cannot rename in 'except' list.");
   wr.message("The renaming occurs because of the use of 'as' here:");
@@ -275,8 +275,8 @@ void ErrorAsWithUseExcept::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorConstRefCoercion::write(ErrorWriterBase& wr) const {
-  auto ast = std::get<const uast::AstNode*>(info);
-  auto& c = std::get<resolution::MostSpecificCandidate>(info);
+  auto ast = std::get<const uast::AstNode*>(info_);
+  auto& c = std::get<resolution::MostSpecificCandidate>(info_);
 
   auto formalName = c.fn()->formalName(c.constRefCoercionFormal());
 
@@ -298,9 +298,9 @@ void ErrorConstRefCoercion::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorDeprecation::write(ErrorWriterBase& wr) const {
-  auto msg = std::get<std::string>(info);
-  auto mention = std::get<const uast::AstNode*>(info);
-  auto target = std::get<const uast::NamedDecl*>(info);
+  auto msg = std::get<std::string>(info_);
+  auto mention = std::get<const uast::AstNode*>(info_);
+  auto target = std::get<const uast::NamedDecl*>(info_);
   CHPL_ASSERT(mention && target);
 
   wr.headingVerbatim(kind_, type_, mention, msg);
@@ -316,10 +316,10 @@ void ErrorDeprecation::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorDotExprInUseImport::write(ErrorWriterBase& wr) const {
-  auto dot = std::get<const uast::Dot*>(info);
-  auto visibilityClause = std::get<const uast::VisibilityClause*>(info);
+  auto dot = std::get<const uast::Dot*>(info_);
+  auto visibilityClause = std::get<const uast::VisibilityClause*>(info_);
   auto limitationKind =
-      std::get<const uast::VisibilityClause::LimitationKind>(info);
+      std::get<const uast::VisibilityClause::LimitationKind>(info_);
   wr.heading(kind_, type_, locationOnly(dot), "cannot use dot expression '",
              dot, "' in '", limitationKind, "' list.");
   wr.code(visibilityClause, {dot});
@@ -329,9 +329,9 @@ void ErrorDotExprInUseImport::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorDotTypeOnType::write(ErrorWriterBase& wr) const {
-  auto dot = std::get<const uast::Dot*>(info);
-  auto dottedType = std::get<const types::Type*>(info);
-  auto typeDeclId = std::get<ID>(info);
+  auto dot = std::get<const uast::Dot*>(info_);
+  auto dottedType = std::get<const types::Type*>(info_);
+  auto typeDeclId = std::get<ID>(info_);
   const bool haveType = dottedType && !dottedType->isErroneousType();
   if (haveType) {
     wr.heading(kind_, type_, dot, "can't apply '.type' to a type ('",
@@ -357,8 +357,8 @@ void ErrorDotTypeOnType::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorExternCCompilation::write(ErrorWriterBase& wr) const {
-  auto externBlockId = std::get<ID>(info);
-  auto errors = std::get<std::vector<std::pair<Location, std::string>>>(info);
+  auto externBlockId = std::get<ID>(info_);
+  auto errors = std::get<std::vector<std::pair<Location, std::string>>>(info_);
   wr.heading(kind_, type_, externBlockId,
              "running clang on extern block failed",
              (errors.size() > 0 ? " -- clang errors follow" : ""));
@@ -368,8 +368,8 @@ void ErrorExternCCompilation::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorIfVarNonClassType::write(ErrorWriterBase& wr) const {
-  auto cond = std::get<const uast::Conditional*>(info);
-  auto qtVar = std::get<types::QualifiedType>(info);
+  auto cond = std::get<const uast::Conditional*>(info_);
+  auto qtVar = std::get<types::QualifiedType>(info_);
   auto var = cond->condition()->toVariable();
   CHPL_ASSERT(var);
   auto ifKindStr = cond->isExpressionLevel() ? "expression" : "statement";
@@ -381,9 +381,9 @@ void ErrorIfVarNonClassType::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorImplicitFileModule::write(ErrorWriterBase& wr) const {
-  auto code = std::get<const uast::AstNode*>(info);
-  auto lastModule = std::get<1>(info);
-  auto implicitModule = std::get<2>(info);
+  auto code = std::get<const uast::AstNode*>(info_);
+  auto lastModule = std::get<1>(info_);
+  auto implicitModule = std::get<2>(info_);
   wr.heading(kind_, type_, code, "an implicit module named '",
              implicitModule->name(), "' is being introduced to contain "
              "file-scope code.");
@@ -398,9 +398,9 @@ void ErrorImplicitFileModule::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorIncompatibleIfBranches::write(ErrorWriterBase& wr) const {
-  auto ifExpr = std::get<const uast::Conditional*>(info);
-  auto qt1 = std::get<1>(info);
-  auto qt2 = std::get<2>(info);
+  auto ifExpr = std::get<const uast::Conditional*>(info_);
+  auto qt1 = std::get<1>(info_);
+  auto qt2 = std::get<2>(info_);
 
   wr.heading(kind_, type_, ifExpr, "branches of if-expression have incompatible types.");
   wr.message("In the following if-expression:");
@@ -420,9 +420,9 @@ void ErrorIncompatibleIfBranches::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorIncompatibleKinds::write(ErrorWriterBase& wr) const {
-  auto initExpr = std::get<const uast::AstNode*>(info);
-  auto initType = std::get<types::QualifiedType>(info);
-  auto declKind = std::get<types::QualifiedType::Kind>(info);
+  auto initExpr = std::get<const uast::AstNode*>(info_);
+  auto initType = std::get<types::QualifiedType>(info_);
+  auto declKind = std::get<types::QualifiedType::Kind>(info_);
 
   bool valueToType = declKind == types::QualifiedType::Kind::TYPE &&
     initType.kind() != types::QualifiedType::Kind::TYPE;
@@ -469,9 +469,9 @@ void ErrorIncompatibleKinds::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorIncompatibleRangeBounds::write(ErrorWriterBase& wr) const {
-  auto range = std::get<const uast::Range*>(info);
-  auto qt1 = std::get<1>(info);
-  auto qt2 = std::get<2>(info);
+  auto range = std::get<const uast::Range*>(info_);
+  auto qt1 = std::get<1>(info_);
+  auto qt2 = std::get<2>(info_);
 
   wr.heading(kind_, type_, range,
             "bounds of range expression have incompatible types.");
@@ -491,11 +491,11 @@ void ErrorIncompatibleRangeBounds::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorIncompatibleTypeAndInit::write(ErrorWriterBase& wr) const {
-  auto decl = std::get<0>(info);
-  auto type = std::get<1>(info);
-  auto init = std::get<2>(info);
-  auto typeExprType = std::get<3>(info);
-  auto initExprType = std::get<4>(info);
+  auto decl = std::get<0>(info_);
+  auto type = std::get<1>(info_);
+  auto init = std::get<2>(info_);
+  auto typeExprType = std::get<3>(info_);
+  auto initExprType = std::get<4>(info_);
 
   if (auto namedDecl = decl->toNamedDecl()) {
     wr.heading(kind_, type_, decl,
@@ -512,8 +512,8 @@ void ErrorIncompatibleTypeAndInit::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorInvalidClassCast::write(ErrorWriterBase& wr) const {
-  auto primCall = std::get<const uast::PrimCall*>(info);
-  auto& type = std::get<types::QualifiedType>(info);
+  auto primCall = std::get<const uast::PrimCall*>(info_);
+  auto& type = std::get<types::QualifiedType>(info_);
   auto prim = primCall->prim();
 
   if (prim == uast::primtags::PRIM_TO_NILABLE_CLASS_CHECKED && !type.isType()) {
@@ -549,8 +549,8 @@ void ErrorInvalidClassCast::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorInvalidIndexCall::write(ErrorWriterBase& wr) const {
-  auto fnCall = std::get<const uast::FnCall*>(info);
-  auto& type = std::get<types::QualifiedType>(info);
+  auto fnCall = std::get<const uast::FnCall*>(info_);
+  auto& type = std::get<types::QualifiedType>(info_);
 
   wr.heading(kind_, type_, fnCall,
              "invalid use of the 'index' keyword.");
@@ -569,8 +569,8 @@ void ErrorInvalidIndexCall::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorInvalidNewTarget::write(ErrorWriterBase& wr) const {
-  auto newExpr = std::get<const uast::New*>(info);
-  auto type = std::get<types::QualifiedType>(info);
+  auto newExpr = std::get<const uast::New*>(info_);
+  auto type = std::get<types::QualifiedType>(info_);
 
   if (auto primType = type.type()->toPrimitiveType()) {
     wr.heading(kind_, type_, newExpr,
@@ -590,8 +590,8 @@ void ErrorInvalidNewTarget::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorInvalidSuper::write(ErrorWriterBase& wr) const {
-  auto superExpr = std::get<const uast::Identifier*>(info);
-  auto qt = std::get<types::QualifiedType>(info);
+  auto superExpr = std::get<const uast::Identifier*>(info_);
+  auto qt = std::get<types::QualifiedType>(info_);
 
   const types::RecordType* recordType = nullptr;
   if (auto type = qt.type()) {
@@ -618,8 +618,8 @@ void ErrorInvalidSuper::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorMemManagementNonClass::write(ErrorWriterBase& wr) const {
-  auto newCall = std::get<const uast::New*>(info);
-  auto type = std::get<const types::Type*>(info);
+  auto newCall = std::get<const uast::New*>(info_);
+  auto type = std::get<const types::Type*>(info_);
   auto record = type ? type->toRecordType() : nullptr;
 
   if (record) {
@@ -647,17 +647,17 @@ void ErrorMemManagementNonClass::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorMissingInclude::write(ErrorWriterBase& wr) const {
-  auto moduleInclude = std::get<const uast::Include*>(info);
-  auto& filePath = std::get<std::string>(info);
+  auto moduleInclude = std::get<const uast::Include*>(info_);
+  auto& filePath = std::get<std::string>(info_);
   wr.heading(kind_, type_, moduleInclude, "cannot find included submodule");
   wr.code(moduleInclude);
   wr.note(moduleInclude, "expected file at path '", filePath, "'");
 }
 
 void ErrorModuleAsVariable::write(ErrorWriterBase& wr) const {
-  auto node = std::get<0>(info);
-  auto parent = std::get<1>(info);
-  auto mod = std::get<const uast::Module*>(info);
+  auto node = std::get<0>(info_);
+  auto parent = std::get<1>(info_);
+  auto mod = std::get<const uast::Module*>(info_);
   const char* reason = "cannot be mentioned like variables";
 
   if (parent) {
@@ -673,9 +673,9 @@ void ErrorModuleAsVariable::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorMultipleEnumElems::write(ErrorWriterBase& wr) const {
-  auto enumAst = std::get<const uast::Enum*>(info);
-  auto elemName = std::get<UniqueString>(info);
-  auto& possibleElems = std::get<std::vector<ID>>(info);
+  auto enumAst = std::get<const uast::Enum*>(info_);
+  auto elemName = std::get<UniqueString>(info_);
+  auto& possibleElems = std::get<std::vector<ID>>(info_);
 
   wr.heading(kind_, type_, enumAst->id(), "enum '", enumAst->name(),
              "' has multiple elements named '", elemName, "'.");
@@ -690,9 +690,9 @@ void ErrorMultipleEnumElems::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorMultipleInheritance::write(ErrorWriterBase& wr) const {
-  auto theClass = std::get<const uast::Class*>(info);
-  auto firstParent = std::get<1>(info);
-  auto secondParent = std::get<2>(info);
+  auto theClass = std::get<const uast::Class*>(info_);
+  auto firstParent = std::get<1>(info_);
+  auto secondParent = std::get<2>(info_);
 
   wr.heading(kind_, type_, theClass,
              "invalid use of multiple inheritance in class '", theClass->name(),
@@ -706,9 +706,9 @@ void ErrorMultipleInheritance::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorMultipleQuestionArgs::write(ErrorWriterBase& wr) const {
-  auto call = std::get<const uast::FnCall*>(info);
-  auto firstQuestion = std::get<1>(info);
-  auto secondQuestion = std::get<2>(info);
+  auto call = std::get<const uast::FnCall*>(info_);
+  auto firstQuestion = std::get<1>(info_);
+  auto secondQuestion = std::get<2>(info_);
 
   wr.heading(kind_, type_, call, "cannot have '?' more than once in a call");
   wr.message("The first ? argument occurs here:");
@@ -718,10 +718,10 @@ void ErrorMultipleQuestionArgs::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorNestedClassFieldRef::write(ErrorWriterBase& wr) const {
-  auto outerDecl = std::get<0>(info);
-  auto innerDecl = std::get<1>(info);
-  auto reference = std::get<2>(info);
-  auto id = std::get<3>(info);
+  auto outerDecl = std::get<0>(info_);
+  auto innerDecl = std::get<1>(info_);
+  auto reference = std::get<2>(info_);
+  auto id = std::get<3>(info_);
 
   const char* outerName = outerDecl->isClass() ? "class" : "record";
   const char* innerName = innerDecl->isClass() ? "class" : "record";
@@ -748,10 +748,10 @@ void ErrorNestedClassFieldRef::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorNoMatchingCandidates::write(ErrorWriterBase& wr) const {
-  auto node = std::get<const uast::AstNode*>(info);
+  auto node = std::get<const uast::AstNode*>(info_);
   auto call = node->toCall();
-  auto& ci = std::get<resolution::CallInfo>(info);
-  auto& rejected = std::get<std::vector<resolution::ApplicabilityResult>>(info);
+  auto& ci = std::get<resolution::CallInfo>(info_);
+  auto& rejected = std::get<std::vector<resolution::ApplicabilityResult>>(info_);
 
   wr.heading(kind_, type_, node, "unable to resolve call to '", ci.name(), "': no matching candidates.");
   wr.code(node);
@@ -765,7 +765,7 @@ void ErrorNoMatchingCandidates::write(ErrorWriterBase& wr) const {
     auto reason = candidate.reason();
     wr.message("");
     if (reason == resolution::FAIL_CANNOT_PASS &&
-        /* skip printing detailed info here because computing the formal-actual
+        /* skip printing detailed info_ here because computing the formal-actual
            map will go poorly with an unknown formal. */
         candidate.formalReason() != resolution::FAIL_UNKNOWN_FORMAL_TYPE) {
       auto fn = candidate.initialForErr();
@@ -851,20 +851,20 @@ void ErrorNoMatchingCandidates::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorNonIterable::write(ErrorWriterBase &wr) const {
-  auto loop = std::get<0>(info);
-  auto iterand = std::get<1>(info);
-  auto& iterandType = std::get<types::QualifiedType>(info);
+  auto loop = std::get<0>(info_);
+  auto iterand = std::get<1>(info_);
+  auto& iterandType = std::get<types::QualifiedType>(info_);
   wr.heading(kind_, type_, loop, "cannot iterate over ", decayToValue(iterandType), ".");
   wr.message("Used as an iterand in a loop here:");
   wr.code(iterand, { iterand });
 }
 
 void ErrorNotInModule::write(ErrorWriterBase& wr) const {
-  const uast::Dot* dot = std::get<0>(info);
-  //ID moduleId = std::get<1>(info);
-  UniqueString moduleName = std::get<2>(info);
-  ID renameClauseId = std::get<3>(info);
-  bool thereButPrivate = std::get<bool>(info);
+  const uast::Dot* dot = std::get<0>(info_);
+  //ID moduleId = std::get<1>(info_);
+  UniqueString moduleName = std::get<2>(info_);
+  ID renameClauseId = std::get<3>(info_);
+  bool thereButPrivate = std::get<bool>(info_);
 
   if (thereButPrivate) {
     wr.heading(kind_, type_, dot,
@@ -901,8 +901,8 @@ void ErrorNotInModule::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorPhaseTwoInitMarker::write(ErrorWriterBase& wr) const {
-  auto node = std::get<const uast::AstNode*>(info);
-  auto& others = std::get<std::vector<ID>>(info);
+  auto node = std::get<const uast::AstNode*>(info_);
+  auto& others = std::get<std::vector<ID>>(info_);
 
   const char* markerType = node->isInit() ? "init this" : "this.complete()";
   wr.heading(kind_, type_, node,
@@ -915,12 +915,12 @@ void ErrorPhaseTwoInitMarker::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorPotentiallySurprisingShadowing::write(ErrorWriterBase& wr) const {
-  auto id = std::get<0>(info);
-  auto name = std::get<1>(info);
-  auto& result = std::get<2>(info);
-  auto& traceResult = std::get<3>(info);
-  auto& shadowed = std::get<4>(info);
-  auto& traceShadowed = std::get<5>(info);
+  auto id = std::get<0>(info_);
+  auto name = std::get<1>(info_);
+  auto& result = std::get<2>(info_);
+  auto& traceResult = std::get<3>(info_);
+  auto& shadowed = std::get<4>(info_);
+  auto& traceShadowed = std::get<5>(info_);
 
   wr.heading(kind_, type_, id,
              "potentially surprising shadowing for '", name.c_str(), "'");
@@ -961,8 +961,8 @@ void ErrorPotentiallySurprisingShadowing::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorPrivateToPublicInclude::write(ErrorWriterBase& wr) const {
-  auto moduleInclude = std::get<const uast::Include*>(info);
-  auto moduleDef = std::get<const uast::Module*>(info);
+  auto moduleInclude = std::get<const uast::Include*>(info_);
+  auto moduleDef = std::get<const uast::Module*>(info_);
   wr.heading(kind_, type_, moduleInclude,
              "cannot make a private module public through "
              "an include statement");
@@ -972,16 +972,16 @@ void ErrorPrivateToPublicInclude::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorProcDefExplicitAnonFormal::write(ErrorWriterBase& wr) const {
-  auto fn = std::get<const uast::Function*>(info);
-  auto formal = std::get<const uast::Formal*>(info);
+  auto fn = std::get<const uast::Function*>(info_);
+  auto formal = std::get<const uast::Formal*>(info_);
   wr.heading(kind_, type_, formal, "formals in a procedure definition must "
                             "be named");
   wr.code(fn, {formal});
 }
 
 void ErrorProcTypeUnannotatedFormal::write(ErrorWriterBase& wr) const {
-  auto sig = std::get<const uast::FunctionSignature*>(info);
-  auto formal = std::get<const uast::AnonFormal*>(info);
+  auto sig = std::get<const uast::FunctionSignature*>(info_);
+  auto formal = std::get<const uast::AnonFormal*>(info_);
   wr.heading(kind_, type_, formal, "unannotated formal is ambiguous in this "
                             "context");
   wr.code(sig, {formal});
@@ -992,8 +992,8 @@ void ErrorProcTypeUnannotatedFormal::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorPrototypeInclude::write(ErrorWriterBase& wr) const {
-  auto moduleInclude = std::get<const uast::Include*>(info);
-  auto moduleDef = std::get<const uast::Module*>(info);
+  auto moduleInclude = std::get<const uast::Include*>(info_);
+  auto moduleDef = std::get<const uast::Module*>(info_);
   wr.heading(kind_, type_, moduleInclude,
              "cannot apply prototype to module in include statement");
   wr.code(moduleInclude);
@@ -1022,7 +1022,7 @@ static bool firstIdFromDecls(
 }
 
 void ErrorRecursion::write(ErrorWriterBase& wr) const {
-  auto queryName = std::get<UniqueString>(info);
+  auto queryName = std::get<UniqueString>(info_);
   wr.heading(kind_, type_, ID(),
              "recursion detected in query '", queryName.c_str(), "'");
 }
@@ -1051,10 +1051,10 @@ static bool printRecursionTrace(ErrorWriterBase& wr,
 }
 
 void ErrorRecursionFieldDecl::write(ErrorWriterBase& wr) const {
-  auto ast = std::get<const uast::AstNode*>(info);
-  auto ad = std::get<const uast::AggregateDecl*>(info);
-  auto ct = std::get<const types::CompositeType*>(info);
-  auto& trace = std::get<3>(info);
+  auto ast = std::get<const uast::AstNode*>(info_);
+  auto ad = std::get<const uast::AggregateDecl*>(info_);
+  auto ct = std::get<const types::CompositeType*>(info_);
+  auto& trace = std::get<3>(info_);
 
   std::string rootGoalForTrace = "resolving the field";
   if (auto vld = ast->toVarLikeDecl()) {
@@ -1077,8 +1077,8 @@ void ErrorRecursionFieldDecl::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorRecursionModuleStmt::write(ErrorWriterBase& wr) const {
-  auto ast = std::get<const uast::AstNode*>(info);
-  auto& trace = std::get<2>(info);
+  auto ast = std::get<const uast::AstNode*>(info_);
+  auto& trace = std::get<2>(info_);
 
   wr.heading(kind_, type_, ast,
              "encountered recursion while resolving module statement:");
@@ -1092,10 +1092,10 @@ void ErrorRecursionModuleStmt::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorRedefinition::write(ErrorWriterBase& wr) const {
-  auto scopeId = std::get<ID>(info);
-  auto name = std::get<UniqueString>(info);
-  auto& matches = std::get<std::vector<resolution::BorrowedIdsWithName>>(info);
-  auto& trace = std::get<std::vector<resolution::ResultVisibilityTrace>>(info);
+  auto scopeId = std::get<ID>(info_);
+  auto name = std::get<UniqueString>(info_);
+  auto& matches = std::get<std::vector<resolution::BorrowedIdsWithName>>(info_);
+  auto& trace = std::get<std::vector<resolution::ResultVisibilityTrace>>(info_);
 
   // compute the anchor ID for the error message
   ID id;
@@ -1166,9 +1166,9 @@ static const uast::AstNode* getReduceOrScanOp(const uast::AstNode* reduceOrScan)
 }
 
 void ErrorReductionInvalidName::write(ErrorWriterBase& wr) const {
-  auto reduceOrScan = std::get<const uast::AstNode*>(info);
-  auto name = std::get<UniqueString>(info);
-  auto& iterType = std::get<types::QualifiedType>(info);
+  auto reduceOrScan = std::get<const uast::AstNode*>(info_);
+  auto name = std::get<UniqueString>(info_);
+  auto& iterType = std::get<types::QualifiedType>(info_);
 
   auto op = getReduceOrScanOp(reduceOrScan);
   wr.heading(kind_, type_, op,
@@ -1183,8 +1183,8 @@ void ErrorReductionInvalidName::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorReductionNotReduceScanOp::write(ErrorWriterBase& wr) const {
-  auto reduceOrScan = std::get<const uast::AstNode*>(info);
-  auto actualType = std::get<types::QualifiedType>(info);
+  auto reduceOrScan = std::get<const uast::AstNode*>(info_);
+  auto actualType = std::get<types::QualifiedType>(info_);
   const types::BasicClassType* actualClassType = nullptr;
 
   auto op = getReduceOrScanOp(reduceOrScan);
@@ -1210,12 +1210,12 @@ void ErrorReductionNotReduceScanOp::write(ErrorWriterBase& wr) const {
 
 void ErrorSplitInitMismatchedConditionalTypes::write(
     ErrorWriterBase& wr) const {
-  const uast::Variable* var = std::get<0>(info);
-  const uast::AstNode* node = std::get<1>(info);
-  const types::QualifiedType thenType = std::get<2>(info);
-  const types::QualifiedType elseType = std::get<3>(info);
-  const int idx1 = std::get<4>(info);
-  const int idx2 = std::get<5>(info);
+  const uast::Variable* var = std::get<0>(info_);
+  const uast::AstNode* node = std::get<1>(info_);
+  const types::QualifiedType thenType = std::get<2>(info_);
+  const types::QualifiedType elseType = std::get<3>(info_);
+  const int idx1 = std::get<4>(info_);
+  const int idx2 = std::get<5>(info_);
 
   if (node->isConditional()) {
     const uast::Conditional* cond = node->toConditional();
@@ -1248,9 +1248,9 @@ void ErrorSplitInitMismatchedConditionalTypes::write(
 }
 
 void ErrorSuperFromTopLevelModule::write(ErrorWriterBase& wr) const {
-  auto use = std::get<const uast::AstNode*>(info);
-  auto mod = std::get<const uast::Module*>(info);
-  auto useOrImport = std::get<resolution::VisibilityStmtKind>(info);
+  auto use = std::get<const uast::AstNode*>(info_);
+  auto mod = std::get<const uast::Module*>(info_);
+  auto useOrImport = std::get<resolution::VisibilityStmtKind>(info_);
   auto useOrImportStr = (useOrImport == resolution::VIS_USE) ? "use"
                                                              : "import";
   wr.heading(kind_, type_, use, "invalid use of 'super' in '",
@@ -1263,11 +1263,11 @@ void ErrorSuperFromTopLevelModule::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorTertiaryUseImportUnstable::write(ErrorWriterBase& wr) const {
-  auto name = std::get<UniqueString>(info);
-  auto node = std::get<const uast::AstNode*>(info);
-  auto clause = std::get<const uast::VisibilityClause*>(info);
-  auto searchedScope = std::get<const resolution::Scope*>(info);
-  auto useOrImport = std::get<resolution::VisibilityStmtKind>(info);
+  auto name = std::get<UniqueString>(info_);
+  auto node = std::get<const uast::AstNode*>(info_);
+  auto clause = std::get<const uast::VisibilityClause*>(info_);
+  auto searchedScope = std::get<const resolution::Scope*>(info_);
+  auto useOrImport = std::get<resolution::VisibilityStmtKind>(info_);
   auto useOrImportStr = (useOrImport == resolution::VIS_USE) ? "a 'use'"
                                                              : "an 'import'";
   wr.heading(kind_, type_, clause,
@@ -1279,8 +1279,8 @@ void ErrorTertiaryUseImportUnstable::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorTupleDeclMismatchedElems::write(ErrorWriterBase& wr) const {
-  auto decl = std::get<const uast::TupleDecl*>(info);
-  auto type = std::get<const types::TupleType*>(info);
+  auto decl = std::get<const uast::TupleDecl*>(info_);
+  auto type = std::get<const types::TupleType*>(info_);
   wr.heading(kind_, type_, decl,
             "tuple size mismatch in split tuple declaration.");
   wr.code(decl);
@@ -1290,8 +1290,8 @@ void ErrorTupleDeclMismatchedElems::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorTupleDeclNotTuple::write(ErrorWriterBase& wr) const {
-  auto decl = std::get<const uast::TupleDecl*>(info);
-  auto type = std::get<const types::Type*>(info);
+  auto decl = std::get<const uast::TupleDecl*>(info_);
+  auto type = std::get<const types::Type*>(info_);
   wr.heading(kind_, type_, decl,
             "value of non-tuple type '", type, "' cannot be split using a tuple "
             "declaration.");
@@ -1302,15 +1302,15 @@ void ErrorTupleDeclNotTuple::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorTupleDeclUnknownType::write(ErrorWriterBase& wr) const {
-  auto decl = std::get<const uast::TupleDecl*>(info);
+  auto decl = std::get<const uast::TupleDecl*>(info_);
   wr.heading(kind_, type_, decl,
              "value of unknown type cannot be split using tuple assignment.");
   wr.code(decl);
 }
 
 void ErrorTupleExpansionNamedArgs::write(ErrorWriterBase& wr) const {
-  auto fnCall = std::get<const uast::FnCall*>(info);
-  auto tupleOp = std::get<const uast::OpCall*>(info);
+  auto fnCall = std::get<const uast::FnCall*>(info_);
+  auto tupleOp = std::get<const uast::OpCall*>(info_);
 
   wr.heading(kind_, type_, fnCall, "tuple expansion cannot be used to pass "
              "values to a non-variadic named argument.");
@@ -1319,9 +1319,9 @@ void ErrorTupleExpansionNamedArgs::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorTupleExpansionNonTuple::write(ErrorWriterBase& wr) const {
-  auto call = std::get<const uast::FnCall*>(info);
-  auto expansion = std::get<const uast::OpCall*>(info);
-  auto& type = std::get<types::QualifiedType>(info);
+  auto call = std::get<const uast::FnCall*>(info_);
+  auto expansion = std::get<const uast::OpCall*>(info_);
+  auto& type = std::get<types::QualifiedType>(info_);
 
   wr.heading(kind_, type_, call, "cannot apply tuple expansion to an "
              "expression of non-tuple type");
@@ -1332,9 +1332,9 @@ void ErrorTupleExpansionNonTuple::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorUnknownEnumElem::write(ErrorWriterBase& wr) const {
-  auto node = std::get<const uast::AstNode*>(info);
-  auto elemName = std::get<UniqueString>(info);
-  auto enumAst = std::get<const uast::Enum*>(info);
+  auto node = std::get<const uast::AstNode*>(info_);
+  auto elemName = std::get<UniqueString>(info_);
+  auto enumAst = std::get<const uast::Enum*>(info_);
 
   wr.heading(kind_, type_, node, "enum '", enumAst->name(),
              "' has no element named '", elemName, "'.");
@@ -1344,8 +1344,8 @@ void ErrorUnknownEnumElem::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorUnknownIdentifier::write(ErrorWriterBase& wr) const {
-  auto ident = std::get<const uast::Identifier*>(info);
-  auto mentionedMoreThanOnce = std::get<bool>(info);
+  auto ident = std::get<const uast::Identifier*>(info_);
+  auto mentionedMoreThanOnce = std::get<bool>(info_);
 
   wr.heading(kind_, type_, ident,
              "'", ident->name(), "' cannot be found",
@@ -1357,9 +1357,9 @@ void ErrorUnknownIdentifier::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorUnstable::write(ErrorWriterBase& wr) const {
-  auto msg = std::get<std::string>(info);
-  auto mention = std::get<const uast::AstNode*>(info);
-  auto target = std::get<const uast::NamedDecl*>(info);
+  auto msg = std::get<std::string>(info_);
+  auto mention = std::get<const uast::AstNode*>(info_);
+  auto target = std::get<const uast::NamedDecl*>(info_);
   CHPL_ASSERT(mention && target);
 
   wr.headingVerbatim(kind_, type_, mention, msg);
@@ -1375,9 +1375,9 @@ void ErrorUnstable::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorUseImportMultiplyDefined::write(ErrorWriterBase& wr) const {
-  auto symbolName = std::get<UniqueString>(info);
-  auto firstOccurrence = std::get<1>(info);
-  auto secondOccurrence = std::get<2>(info);
+  auto symbolName = std::get<UniqueString>(info_);
+  auto firstOccurrence = std::get<1>(info_);
+  auto secondOccurrence = std::get<2>(info_);
 
   wr.heading(kind_, type_, secondOccurrence, "'",
              symbolName, "' is multiply defined.");
@@ -1388,9 +1388,9 @@ void ErrorUseImportMultiplyDefined::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorUseImportMultiplyMentioned::write(ErrorWriterBase& wr) const {
-  auto symbolName = std::get<UniqueString>(info);
-  auto firstOccurrence = std::get<1>(info);
-  auto secondOccurrence = std::get<2>(info);
+  auto symbolName = std::get<UniqueString>(info_);
+  auto firstOccurrence = std::get<1>(info_);
+  auto secondOccurrence = std::get<2>(info_);
 
   wr.heading(kind_, type_, secondOccurrence, "'",
              symbolName, "' is repeated.");
@@ -1401,9 +1401,9 @@ void ErrorUseImportMultiplyMentioned::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorUseImportNotModule::write(ErrorWriterBase& wr) const {
-  auto id = std::get<const ID>(info);
-  auto moduleName = std::get<std::string>(info);
-  auto useOrImport = std::get<const resolution::VisibilityStmtKind>(info);
+  auto id = std::get<const ID>(info_);
+  auto moduleName = std::get<std::string>(info_);
+  auto useOrImport = std::get<const resolution::VisibilityStmtKind>(info_);
 
   wr.heading(kind_, type_, id, "cannot '", useOrImport, "' symbol '", moduleName,
              "', which is not a ", allowedItem(useOrImport), ".");
@@ -1414,12 +1414,12 @@ void ErrorUseImportNotModule::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorUseImportTransitiveRename::write(ErrorWriterBase& wr) const {
-  auto from = std::get<0>(info);
-  auto middle = std::get<1>(info);
-  auto to = std::get<2>(info);
+  auto from = std::get<0>(info_);
+  auto middle = std::get<1>(info_);
+  auto to = std::get<2>(info_);
 
-  auto firstRename = std::get<3>(info);
-  auto secondRename = std::get<4>(info);
+  auto firstRename = std::get<3>(info_);
+  auto secondRename = std::get<4>(info_);
 
   wr.heading(kind_, type_, secondRename, "'",
              middle, "' is repeated.");
@@ -1432,11 +1432,11 @@ void ErrorUseImportTransitiveRename::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorUseImportUnknownMod::write(ErrorWriterBase& wr) const {
-  auto id = std::get<const ID>(info);
-  auto moduleName = std::get<2>(info);
-  auto previousPartName = std::get<3>(info);
-  auto useOrImport = std::get<const resolution::VisibilityStmtKind>(info);
-  auto& improperMatches = std::get<std::vector<const uast::AstNode*>>(info);
+  auto id = std::get<const ID>(info_);
+  auto moduleName = std::get<2>(info_);
+  auto previousPartName = std::get<3>(info_);
+  auto useOrImport = std::get<const resolution::VisibilityStmtKind>(info_);
+  auto& improperMatches = std::get<std::vector<const uast::AstNode*>>(info_);
 
   if (previousPartName.empty()) {
     wr.heading(kind_, type_, id, "cannot find ", allowedItem(useOrImport),
@@ -1493,11 +1493,11 @@ void ErrorUseImportUnknownMod::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorUseImportUnknownSym::write(ErrorWriterBase& wr) const {
-  auto visibilityClause = std::get<const uast::VisibilityClause*>(info);
-  auto symbolName = std::get<std::string>(info);
-  auto searchedScope = std::get<const resolution::Scope*>(info);
-  auto useOrImport = std::get<const resolution::VisibilityStmtKind>(info);
-  auto isRename = std::get<bool>(info);
+  auto visibilityClause = std::get<const uast::VisibilityClause*>(info_);
+  auto symbolName = std::get<std::string>(info_);
+  auto searchedScope = std::get<const resolution::Scope*>(info_);
+  auto useOrImport = std::get<const resolution::VisibilityStmtKind>(info_);
+  auto isRename = std::get<bool>(info_);
 
   auto limitationKind = visibilityClause->limitationKind();
   if (isRename) {
@@ -1527,8 +1527,8 @@ void ErrorUseImportUnknownSym::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorUseOfLaterVariable::write(ErrorWriterBase& wr) const {
-  auto stmt = std::get<const uast::AstNode*>(info);
-  auto laterId = std::get<ID>(info);
+  auto stmt = std::get<const uast::AstNode*>(info_);
+  auto laterId = std::get<ID>(info_);
   wr.heading(kind_, type_, stmt,
              "statement references a variable before it is defined.");
   wr.message("In the following statement:");
@@ -1539,8 +1539,8 @@ void ErrorUseOfLaterVariable::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorValueUsedAsType::write(ErrorWriterBase& wr) const {
-  auto typeExpr = std::get<const uast::AstNode*>(info);
-  auto type = std::get<types::QualifiedType>(info);
+  auto typeExpr = std::get<const uast::AstNode*>(info_);
+  auto type = std::get<types::QualifiedType>(info_);
   wr.heading(kind_, type_, typeExpr,
              "type specifier is ", type, ", but it was expected to be a type.");
   wr.message("In the following type specifier:");

--- a/frontend/lib/resolution/resolution-error-classes-list.cpp
+++ b/frontend/lib/resolution/resolution-error-classes-list.cpp
@@ -384,7 +384,7 @@ void ErrorImplicitFileModule::write(ErrorWriterBase& wr) const {
   auto code = std::get<const uast::AstNode*>(info_);
   auto lastModule = std::get<1>(info_);
   auto implicitModule = std::get<2>(info_);
-  wr.heading(kind_, type_, code, "an implicit module named '",
+  wr.heading(kind_, type_, locationOnly(code), "an implicit module named '",
              implicitModule->name(), "' is being introduced to contain "
              "file-scope code.");
   wr.message("The following is the first file-scope statement:");


### PR DESCRIPTION
This PR resolves https://github.com/chapel-lang/chapel/issues/24437.

I implemented this by keeping a second list of errors-to-be-emitted in `DynoErrorHandler`, in the production compiler. I didn't implement the warning silencing in Dyno because doing so relies on knowing the set of parsed files. This, in turn, introduces a side effect (order-dependence of queries) which gets in the way of the query system. For instance, a file is considered "main" if it's the only one listed from the command-line. So the following sequence:

1. Parse file 'A' (it's currently the only file, so do not emit warnings)
2. Parse file 'B' (it's not the only file; emit warnings)

Then, in the next generation, we can try run the sequence in reverse: 

1. Parse file 'B' (file contents haven't changed; re-use?)
2. Parse file 'A' (file contents haven't changed; re-use?)

Through re-use, we'd re-emit the warning from B, and not from A -- but now 'B' was the "original" main file.

Even if we know the set of _files_ ahead of time, a similar issue would occur when the 'main' module depends on the presence of a 'main' function. It's a chicken-and-egg problem to parse a single file and detect if it's the main module (since the latter requires parsing all the files and looking for `main`). 

Thus, emitting warnings _always_ and deferring them in caller code seems like the right strategy. Since we reason about main modules in the production compiler anyway, I added the deferring mechanism there.
