### PR TITLE
Skip concurrentMap 1BRC implementation for memleaks testing

### DIFF
--- a/test/studies/1brc/concurrentMapVer.skipif
+++ b/test/studies/1brc/concurrentMapVer.skipif
@@ -13,3 +13,7 @@ CHPL_TARGET_COMPILER==intel
 CHPL_TARGET_COMPILER==cray-prgenv-intel
 # AtomicObjects uses x86-64 instructions in the inline assembly
 CHPL_TARGET_ARCH != x86_64
+
+# The concurrentMap leaks memory
+CHPL_NIGHTLY_TEST_CONFIG_NAME==memleaks
+CHPL_NIGHTLY_TEST_CONFIG_NAME==valgrind


### PR DESCRIPTION
The concurrentMap module has a memory leak bug. This PR skips the concurrent map version of the 1BRC test for the memleaks and valgrind configs.