### PR TITLE
Skip this test in --no-local runs

### DIFF
--- a/test/unstable/const-intent/arrayField.skipif
+++ b/test/unstable/const-intent/arrayField.skipif
@@ -1,1 +1,2 @@
 CHPL_COMM!=none
+COMPOPTS <= --no-local


### PR DESCRIPTION
It has inconsistent behavior, but we intend to expand the check on arrays anyways, so skip it until we have done that expansion.

Double checked that the skipif modification was respected in `--no-local` testing