### PR TITLE
Install Python-based tools using `make install`; make changes to `chpl` and `chpldoc` to work better in prefix installs

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -343,6 +343,7 @@ static bool fPrintLicense = false;
 static bool fPrintSettingsHelp = false;
 static bool fPrintVersion = false;
 static bool fPrintChplHome = false;
+static bool fPrintInstallPrefix = false;
 
 std::string llvmFlags;
 std::string llvmRemarksFilters;
@@ -1421,6 +1422,7 @@ static ArgumentDescription arg_desc[] = {
  {"help-settings", ' ', NULL, "Current flag settings", "F", &fPrintSettingsHelp, "", driverSetHelpTrue},
  {"license", ' ', NULL, "Show license", "F", &fPrintLicense, NULL, NULL},
  {"print-chpl-home", ' ', NULL, "Print CHPL_HOME and exit", "F", &fPrintChplHome, NULL,NULL},
+ {"print-install-prefix", ' ', NULL, "Print the installation prefix, if any, and exit", "F", &fPrintInstallPrefix, NULL,NULL},
  {"version", ' ', NULL, "Show version", "F", &fPrintVersion, NULL, NULL},
 
  // NOTE: Developer flags should not have 1-character equivalents
@@ -1648,6 +1650,10 @@ static void printStuff(const char* argv0) {
   }
   if( fPrintChplHome ) {
     printf("%s\n", CHPL_HOME);
+    printedSomething = true;
+  }
+  if ( fPrintInstallPrefix ) {
+    printf("%s\n", get_configured_prefix());
     printedSomething = true;
   }
   if ( fPrintChplLoc ) {

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -407,12 +407,6 @@ std::vector<UniqueString> gDynoGenLibSourcePaths;
 // what top-level module names as astrs were requested to be stored in the lib?
 std::unordered_set<const char*> gDynoGenLibModuleNameAstrs;
 
-static bool isMaybeChplHome(const char* path)
-{
-  return chpl::isMaybeChplHome(std::string(path));
-
-}
-
 static void setChplHomeDerivedVars() {
   int rc;
   rc = snprintf(CHPL_RUNTIME_LIB, FILENAME_MAX, "%s/%s",
@@ -468,134 +462,35 @@ static bool restoreChplHomeDerivedFromEnv() {
   return haveAll;
 }
 
+int main(int argc, char* argv[]);
+
 static void setupChplHome(const char* argv0) {
-  const char* chpl_home = getenv("CHPL_HOME");
-  char*       guess     = NULL;
-  bool        installed = false;
   char        majMinorVers[64];
+  std::string foundChplHome;
+  bool        installed = false;
+  bool        fromEnv   = false;
+  std::string diagnosticMsg;
 
   // Get major.minor version string (used below)
   get_major_minor_version(majMinorVers, sizeof(majMinorVers));
 
-  // Get the executable path.
-  guess = findProgramPath(argv0);
+  auto err = chpl::findChplHome(argv0, (void*) main, foundChplHome,
+                                installed, fromEnv, diagnosticMsg);
 
-  if (guess) {
-    // Determine CHPL_HOME based on the exe path.
-    // Determined exe path, but don't have a env var set
-    // Look for ../../../util/chplenv
-    // Remove the /bin/some-platform/chpl part
-    // from the path.
-    if( guess[0] ) {
-      int j = strlen(guess) - 5; // /bin and '\0'
-      for( ; j >= 0; j-- ) {
-        if( guess[j] == '/' &&
-            guess[j+1] == 'b' &&
-            guess[j+2] == 'i' &&
-            guess[j+3] == 'n' ) {
-          guess[j] = '\0';
-          break;
-        }
-      }
-    }
-
-    if( isMaybeChplHome(guess) ) {
-      // OK!
+  if (!diagnosticMsg.empty()) {
+    if (err) {
+      USR_FATAL("%s\n", diagnosticMsg.c_str());
     } else {
-      // Maybe we are in e.g. /usr/bin.
-      free(guess);
-      guess = NULL;
+      USR_WARN("%s\n", diagnosticMsg.c_str());
     }
+  } else if (err) {
+    USR_FATAL("$CHPL_HOME must be set to run chpl");
   }
 
-  // Compute a predefined location based on the prefix. If we find that
-  // the CHPL_HOME lies in this location, we can reason that this is
-  // a prefix-based installation, and install should be true.
-  //
-  // Check for Chapel libraries at installed prefix
-  // e.g. /usr/share/chapel/<vers>
-
-  char home_from_prefix[FILENAME_MAX+1] = "";
-
-  int rc;
-  rc = snprintf(home_from_prefix, FILENAME_MAX, "%s/%s/%s",
-              get_configured_prefix(), // e.g. /usr
-              "share/chapel",
-              majMinorVers);
-  if ( rc >= FILENAME_MAX ) {
-    // This is just a check, and we might well find a working path some
-    // other way, so do not report errors.
-    home_from_prefix[0] = '\0';
-  } else if (!isMaybeChplHome(home_from_prefix)) {
-    // If it's not a valid file, skip using it from now on.
-    home_from_prefix[0] = '\0';
+  if (foundChplHome.size() > FILENAME_MAX) {
+    USR_FATAL("$CHPL_HOME=%s path too long", foundChplHome.c_str());
   }
-
-  if( chpl_home ) {
-    if( strlen(chpl_home) > FILENAME_MAX )
-      USR_FATAL("$CHPL_HOME=%s path too long", chpl_home);
-
-    if ( isSameFile(chpl_home, home_from_prefix) ) {
-      // We have env var and it matches the prefix-based guess.
-      // Assume we're in a prefix-based installation.
-      installed = true;
-    }
-
-    if( guess == NULL ) {
-      // Could not find exe path, but have a env var set
-    } else {
-      // We have env var and found exe path.
-      // Check that they match and emit a warning if not.
-      if( ! isSameFile(chpl_home, guess) ) {
-        // Not the same. Emit warning.
-        USR_WARN("$CHPL_HOME=%s mismatched with executable home=%s",
-                 chpl_home, guess);
-      }
-    }
-    // Since we have an enviro var, always use that.
-    strncpy(CHPL_HOME, chpl_home, FILENAME_MAX);
-  } else {
-
-    // Having exhausted the guess and the environment variable, our last
-    // resort is the prefix-based guess.
-    if( guess == NULL ) {
-      if ( rc >= FILENAME_MAX ) USR_FATAL("Installed pathname too long");
-
-      // If we dind't discard it earlier (too long, not valid directory),
-      // use the prefix-based guess.
-      if (home_from_prefix[0]) {
-        guess = strdup(home_from_prefix);
-        installed = true;
-      }
-    }
-
-    if( guess == NULL ) {
-      // Could not find enviro var, and could not
-      // guess at exe's path name.
-      USR_FATAL("$CHPL_HOME must be set to run chpl");
-    } else {
-      int rc;
-
-      if( strlen(guess) > FILENAME_MAX )
-        USR_FATAL("chpl guessed home %s too long", guess);
-
-      // Determined exe path, but don't have a env var set
-      strncpy(CHPL_HOME, guess, FILENAME_MAX);
-      // Also need to setenv in this case.
-      rc = setenv("CHPL_HOME", guess, 0);
-      if( rc ) USR_FATAL("Could not setenv CHPL_HOME");
-    }
-  }
-
-  // Check that the resulting path is a Chapel distribution.
-  if( ! isMaybeChplHome(CHPL_HOME) ) {
-    // Bad enviro var.
-    USR_WARN("CHPL_HOME=%s is not a Chapel distribution", CHPL_HOME);
-  }
-
-  if( guess )
-    free(guess);
-
+  strncpy(CHPL_HOME, foundChplHome.c_str(), FILENAME_MAX);
 
 
   // Get derived-from-home vars

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -343,7 +343,7 @@ static bool fPrintLicense = false;
 static bool fPrintSettingsHelp = false;
 static bool fPrintVersion = false;
 static bool fPrintChplHome = false;
-static bool fPrintInstallPrefix = false;
+static bool fPrintBootstrapCommands = false;
 
 std::string llvmFlags;
 std::string llvmRemarksFilters;
@@ -1444,7 +1444,7 @@ static ArgumentDescription arg_desc[] = {
  {"help-settings", ' ', NULL, "Current flag settings", "F", &fPrintSettingsHelp, "", driverSetHelpTrue},
  {"license", ' ', NULL, "Show license", "F", &fPrintLicense, NULL, NULL},
  {"print-chpl-home", ' ', NULL, "Print CHPL_HOME and exit", "F", &fPrintChplHome, NULL,NULL},
- {"print-install-prefix", ' ', NULL, "Print the installation prefix, if any, and exit", "F", &fPrintInstallPrefix, NULL,NULL},
+ {"print-bootstrap-commands", ' ', NULL, "Print the installation prefix, if any, and exit", "F", &fPrintBootstrapCommands, NULL,NULL},
  {"version", ' ', NULL, "Show version", "F", &fPrintVersion, NULL, NULL},
 
  // NOTE: Developer flags should not have 1-character equivalents
@@ -1674,8 +1674,9 @@ static void printStuff(const char* argv0) {
     printf("%s\n", CHPL_HOME);
     printedSomething = true;
   }
-  if ( fPrintInstallPrefix ) {
-    printf("%s\n", get_configured_prefix());
+  if ( fPrintBootstrapCommands ) {
+    printf("export CHPL_HOME='%s'\n", CHPL_HOME);
+    printf("export CHPL_THIRD_PARTY='%s'\n", CHPL_THIRD_PARTY);
     printedSomething = true;
   }
   if ( fPrintChplLoc ) {

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1339,7 +1339,6 @@ static ArgumentDescription arg_desc[] = {
  {"help-settings", ' ', NULL, "Current flag settings", "F", &fPrintSettingsHelp, "", driverSetHelpTrue},
  {"license", ' ', NULL, "Show license", "F", &fPrintLicense, NULL, NULL},
  {"print-chpl-home", ' ', NULL, "Print CHPL_HOME and exit", "F", &fPrintChplHome, NULL,NULL},
- {"print-bootstrap-commands", ' ', NULL, "Print the installation prefix, if any, and exit", "F", &fPrintBootstrapCommands, NULL,NULL},
  {"version", ' ', NULL, "Show version", "F", &fPrintVersion, NULL, NULL},
 
  // NOTE: Developer flags should not have 1-character equivalents
@@ -1369,6 +1368,7 @@ static ArgumentDescription arg_desc[] = {
  {"parse-only", ' ', NULL, "Stop compiling after 'parse' pass for syntax checking", "N", &fParseOnly, NULL, NULL},
  {"parser-debug", ' ', NULL, "Set parser debug level", "+", &debugParserLevel, "CHPL_PARSER_DEBUG", NULL},
  {"debug-short-loc", ' ', NULL, "Display long [short] location in certain debug outputs", "N", &debugShortLoc, "CHPL_DEBUG_SHORT_LOC", NULL},
+ {"print-bootstrap-commands", ' ', NULL, "Print a Bash bootstrap script to be executed by scripts to determine necessary environment variables.", "F", &fPrintBootstrapCommands, NULL,NULL},
  {"print-emitted-code-size", ' ', NULL, "Print emitted code size", "F", &fPrintEmittedCodeSize, NULL, NULL},
  {"print-module-resolution", ' ', NULL, "Print name of module being resolved", "F", &fPrintModuleResolution, "CHPL_PRINT_MODULE_RESOLUTION", NULL},
  {"print-dispatch", ' ', NULL, "Print dynamic dispatch table", "F", &fPrintDispatch, NULL, NULL},

--- a/frontend/include/chpl/util/chplenv.h
+++ b/frontend/include/chpl/util/chplenv.h
@@ -67,15 +67,14 @@ bool isMaybeChplHome(std::string path);
 /*
   Try to locate a proper CHPL_HOME value given the `main` executable's name
   and memory address. Output variables chplHomeOut, installed, fromEnv, and
-  warningMessage are used to capture probable CHPL_HOME, whether chpl appears
+  diagnosticMessage are used to capture probable CHPL_HOME, whether chpl appears
   to be installed, whether we got the value of CHPL_HOME from the environment var,
-  and a possible warning message if CHPL_HOME and the chpl executable's location
-  do not match.
+  and a possible diagnostic message if the function needs to report an issue.
 */
 std::error_code findChplHome(char* argv0, void* mainAddr,
                              std::string& chplHomeOut,
                              bool& installed, bool& fromEnv,
-                             std::string& warningMessage);
+                             std::string& diagnosticMessage);
 
 } // namespace chpl
 

--- a/frontend/include/chpl/util/chplenv.h
+++ b/frontend/include/chpl/util/chplenv.h
@@ -71,7 +71,7 @@ bool isMaybeChplHome(std::string path);
   to be installed, whether we got the value of CHPL_HOME from the environment var,
   and a possible diagnostic message if the function needs to report an issue.
 */
-std::error_code findChplHome(char* argv0, void* mainAddr,
+std::error_code findChplHome(const char* argv0, void* mainAddr,
                              std::string& chplHomeOut,
                              bool& installed, bool& fromEnv,
                              std::string& diagnosticMessage);

--- a/frontend/lib/util/chplenv.cpp
+++ b/frontend/lib/util/chplenv.cpp
@@ -175,7 +175,7 @@ std::error_code findChplHome(const char* argv0, void* mainAddr,
 
     // Emit a warning if we could guess the CHPL_HOME from the binary's path,
     // but it's not the same path as the environment variable.
-    if (!guessFromBinaryPath.empty() && 
+    if (!guessFromBinaryPath.empty() &&
         !isSameFile(chplHomeEnv, guessFromBinaryPath.c_str())) {
       diagnosticMessage = "$CHPL_HOME=" + std::string(chplHomeEnv) +
                        " is mismatched with executable home=" +
@@ -187,7 +187,7 @@ std::error_code findChplHome(const char* argv0, void* mainAddr,
 
     installed = true;
 
-    if (setenv("CHPL_HOME", guessFromBinaryPath.c_str(), 0)) {
+    if (setenv("CHPL_HOME", guessFromPrefix.c_str(), 0)) {
       return std::error_code(errno, std::system_category());
     }
 

--- a/frontend/lib/util/chplenv.cpp
+++ b/frontend/lib/util/chplenv.cpp
@@ -119,7 +119,7 @@ bool isMaybeChplHome(std::string path) {
   return llvm::sys::fs::exists(path);
 }
 
-std::error_code findChplHome(char* argv0, void* mainAddr,
+std::error_code findChplHome(const char* argv0, void* mainAddr,
                              std::string& chplHomeOut,
                              bool& installed, bool& fromEnv,
                              std::string& diagnosticMessage) {

--- a/frontend/lib/util/chplenv.cpp
+++ b/frontend/lib/util/chplenv.cpp
@@ -131,7 +131,7 @@ std::error_code findChplHome(const char* argv0, void* mainAddr,
 
   // First, Try figuring CHPL_HOME out from the binary's location.
   // If we're running from /path/to/folder/bin/darwin/chpl,
-  // CHPL_HOMe might be /path/to/folder.
+  // CHPL_HOME might be /path/to/folder.
   if (!guessFromBinaryPath.empty()) {
     // truncate path at /bin
     auto binIdx = guessFromBinaryPath.rfind("/bin");

--- a/frontend/lib/util/chplenv.cpp
+++ b/frontend/lib/util/chplenv.cpp
@@ -122,109 +122,86 @@ bool isMaybeChplHome(std::string path) {
 std::error_code findChplHome(char* argv0, void* mainAddr,
                              std::string& chplHomeOut,
                              bool& installed, bool& fromEnv,
-                             std::string& warningMessage) {
+                             std::string& diagnosticMessage) {
   std::string versionString = getMajorMinorVersion();
-  std::string guess = getExecutablePath(argv0, mainAddr);
+  std::string guessFromBinaryPath = getExecutablePath(argv0, mainAddr);
+  chplHomeOut = std::string();
 
-  const char* chpl_home = getenv("CHPL_HOME");
+  const char* chplHomeEnv = getenv("CHPL_HOME");
 
-  if (!guess.empty()) {
+  // First, Try figuring CHPL_HOME out from the binary's location.
+  // If we're running from /path/to/folder/bin/darwin/chpl,
+  // CHPL_HOMe might be /path/to/folder.
+  if (!guessFromBinaryPath.empty()) {
     // truncate path at /bin
-    char* tmp_guess = strdup(guess.c_str());
-    if ( tmp_guess[0] ) {
-      int j = strlen(tmp_guess) - 5; // /bin and '\0'
-      for ( ; j >= 0; j-- ) {
-        if ( tmp_guess[j] == '/' &&
-            tmp_guess[j+1] == 'b' &&
-            tmp_guess[j+2] == 'i' &&
-            tmp_guess[j+3] == 'n' ) {
-          tmp_guess[j] = '\0';
-          break;
-        }
-      }
+    auto binIdx = guessFromBinaryPath.rfind("/bin");
+    if (binIdx != std::string::npos) {
+      guessFromBinaryPath.resize(binIdx);
     }
-    guess = std::string(tmp_guess);
-    if (isMaybeChplHome(guess)) {
-      chplHomeOut = guess;
+
+    if (isMaybeChplHome(guessFromBinaryPath)) {
+      chplHomeOut = guessFromBinaryPath;
     } else {
-      guess = "";
+      guessFromBinaryPath.clear();
     }
   }
 
-  if (chpl_home) {
+  // Compute a predefined location based on the prefix. If we find that
+  // the CHPL_HOME lies in this location, we can reason that this is
+  // a prefix-based installation, and install should be true.
+  //
+  // Check for Chapel libraries at installed prefix
+  // e.g. /usr/share/chapel/<vers>
+  std::string guessFromPrefix = std::string()
+    + getConfiguredPrefix() + "/"
+    + "share/chapel/"
+    + versionString;
+  if (!isMaybeChplHome(guessFromPrefix)) {
+    guessFromPrefix.clear();
+  }
+
+  if (chplHomeEnv) {
+    // If the CHPL_HOME environment variable is set, that is our source of
+    // truth. Do some more work to compare it to other guesses and gather info.
+
+    chplHomeOut = chplHomeEnv;
     fromEnv = true;
-    if(strlen(chpl_home) > FILENAME_MAX)
-      // USR_FATAL("$CHPL_HOME=%s path too long", chpl_home);
-      // error_state
-      // TODO: customize error message?
-      return std::make_error_code(std::errc::filename_too_long);
-    if (guess.empty()) {
-      // Could not find exe path, but have a env var set
-      chplHomeOut = std::string(chpl_home);
-    } else {
-      // We have env var and found exe path.
-      // Check that they match and emit a warning if not.
-      if ( ! isSameFile(chpl_home, guess.c_str()) ) {
-        // Not the same. Emit warning.
-        //USR_WARN("$CHPL_HOME=%s mismatched with executable home=%s",
-        //         chpl_home, guess);
-        warningMessage = "$CHPL_HOME=" + std::string(chpl_home) + " is mismatched with executable home=" + guess;
-      }
-      // Since we have an enviro var, always use that.
-      chplHomeOut = std::string(chpl_home);
-    }
-  } else {
-    // Check in a default location too
-    if (guess.empty()) {
-      char TEST_HOME[FILENAME_MAX+1] = "";
 
-      // Check for Chapel libraries at installed prefix
-      // e.g. /usr/share/chapel/<vers>
-      int rc;
-      rc = snprintf(TEST_HOME, FILENAME_MAX, "%s/%s/%s",
-                    getConfiguredPrefix(), // e.g. /usr
-                    "share/chapel",
-                    versionString.c_str());
-      if (rc >= FILENAME_MAX) {
-        // USR_FATAL("Installed pathname too long");
-        // TODO: return an error here
-        return std::make_error_code(std::errc::filename_too_long);
-      }
-
-      if (isMaybeChplHome(TEST_HOME)) {
-        guess = strdup(TEST_HOME);
-        installed = true;
-       }
+    if (isSameFile(chplHomeEnv, guessFromPrefix.c_str())) {
+      // The pre-configured prefix path matches the variable in the environment;
+      // this indicates that the CHPL_HOME is from a prefix-based installation.
+      installed = true;
     }
 
-    if (guess.empty()) {
-      // Could not find enviro var, and could not
-      // guess at exe's path name.
-      // USR_FATAL("$CHPL_HOME must be set to run chpl");
-      // TODO: customize the error message
-      return std::make_error_code(std::errc::no_such_file_or_directory);
-    } else {
-      int rc;
-
-      if (guess.length() > FILENAME_MAX) {
-      // USR_FATAL("chpl guessed home %s too long", guess);
-        return std::make_error_code(std::errc::filename_too_long);
-      }
-      // Determined exe path, but don't have a env var set
-        rc = setenv("CHPL_HOME", guess.c_str(), 0);
-        if ( rc ) {
-          // USR_FATAL("Could not setenv CHPL_HOME");
-          // TODO: customize the error message
-          return std::make_error_code(std::errc::no_such_file_or_directory);
-         }
-         chplHomeOut = guess;
+    // Emit a warning if we could guess the CHPL_HOME from the binary's path,
+    // but it's not the same path as the environment variable.
+    if (!guessFromBinaryPath.empty() && 
+        !isSameFile(chplHomeEnv, guessFromBinaryPath.c_str())) {
+      diagnosticMessage = "$CHPL_HOME=" + std::string(chplHomeEnv) +
+                       " is mismatched with executable home=" +
+                       guessFromBinaryPath;
     }
+  } else if (guessFromBinaryPath.empty() && !guessFromPrefix.empty()) {
+    // If no environment variable set, and the path-based guess failed,
+    // the last resort is a prefix-based guess; in this case, installed = true.
+
+    installed = true;
+
+    if (setenv("CHPL_HOME", guessFromBinaryPath.c_str(), 0)) {
+      return std::error_code(errno, std::system_category());
+    }
+
+    chplHomeOut = guessFromPrefix;
   }
+
+  if (chplHomeOut.empty()) {
+    diagnosticMessage = "CHPL_HOME must be set";
+    return std::make_error_code(std::errc::no_such_file_or_directory);
+  }
+
   // Check that the resulting path is a Chapel distribution.
   if (!isMaybeChplHome(chplHomeOut.c_str())) {
-    // Bad enviro var.
-    //USR_WARN("CHPL_HOME=%s is not a Chapel distribution", CHPL_HOME);
-    warningMessage = "CHPL_HOME=" + chplHomeOut + " is not a Chapel distribution";
+    diagnosticMessage = "CHPL_HOME=" + chplHomeOut + " is not a Chapel distribution";
   }
   return std::error_code();
 }

--- a/tools/c2chapel/c2chapel
+++ b/tools/c2chapel/c2chapel
@@ -21,8 +21,14 @@
 #
 
 if [ -z "$CHPL_HOME" ]; then
-  echo "Error: CHPL_HOME is not set"
-  exit 1
+  # We need CHPL_HOME to find run-in-venv.bash. Try falling back to a
+  # compiler in PATH.
+  if output=$(chpl --print-bootstrap-commands); then
+    eval "$output"
+  else
+    echo "Error: CHPL_HOME is not set" 1>&2
+    exit 1
+  fi
 fi
 
 exec $CHPL_HOME/util/config/run-in-venv.bash \

--- a/tools/chpl-language-server/chpl-language-server
+++ b/tools/chpl-language-server/chpl-language-server
@@ -20,19 +20,13 @@
 #
 
 if [ -z "$CHPL_HOME" ]; then
-  # compute the chpl home directory
-
-  # first try using 'chpl' in PATH
-  if output=$(chpl --print-chpl-home); then
-    export CHPL_HOME="$output"
-
-    # Since we have chpl in path, use it to infer the third-party directory,
-    # which is needed for the virtual environments.
-    if prefix=$(chpl --print-install-prefix) && [ -n "$prefix" ]; then
-      export CHPL_THIRD_PARTY="$prefix/lib/chapel/1.34/third-party/"
-    fi
+  # We need CHPL_HOME to find run-in-venv.bash. Try falling back to a
+  # compiler in PATH.
+  if output=$(chpl --print-bootstrap-commands); then
+    eval "$output"
   else
-    export CHPL_HOME=$(cd $(dirname $0) ; cd ..; cd ..; pwd)
+    echo "Error: CHPL_HOME is not set" 1>&2
+    exit 1
   fi
 fi
 

--- a/tools/chpl-language-server/chpl-language-server
+++ b/tools/chpl-language-server/chpl-language-server
@@ -20,8 +20,20 @@
 #
 
 if [ -z "$CHPL_HOME" ]; then
-  echo "Error: CHPL_HOME is not set"
-  exit 1
+  # compute the chpl home directory
+
+  # first try using 'chpl' in PATH
+  if output=$(chpl --print-chpl-home); then
+    export CHPL_HOME="$output"
+
+    # Since we have chpl in path, use it to infer the third-party directory,
+    # which is needed for the virtual environments.
+    if prefix=$(chpl --print-install-prefix) && [ -n "$prefix" ]; then
+      export CHPL_THIRD_PARTY="$prefix/lib/chapel/1.34/third-party/"
+    fi
+  else
+    export CHPL_HOME=$(cd $(dirname $0) ; cd ..; cd ..; pwd)
+  fi
 fi
 
 exec $CHPL_HOME/util/config/run-in-venv-with-python-bindings.bash \

--- a/tools/chplcheck/chplcheck
+++ b/tools/chplcheck/chplcheck
@@ -21,8 +21,14 @@
 #
 
 if [ -z "$CHPL_HOME" ]; then
-  echo "Error: CHPL_HOME is not set"
-  exit 1
+  # We need CHPL_HOME to find run-in-venv.bash. Try falling back to a
+  # compiler in PATH.
+  if output=$(chpl --print-bootstrap-commands); then
+    eval "$output"
+  else
+    echo "Error: CHPL_HOME is not set" 1>&2
+    exit 1
+  fi
 fi
 
 exec $CHPL_HOME/util/config/run-in-venv-with-python-bindings.bash \

--- a/tools/chpldoc/chpldoc.cpp
+++ b/tools/chpldoc/chpldoc.cpp
@@ -2269,13 +2269,13 @@ class ChpldocErrorHandler : public Context::ErrorHandler {
 
 int main(int argc, char** argv) {
   Args args = parseArgs(argc, argv, (void*)main);
-  std::string warningMsg;
+  std::string diagnosticMsg;
   bool foundEnv = false;
   bool installed = false;
   // if user overrides CHPL_HOME from command line, don't go looking for trouble
   if (CHPL_HOME.empty()) {
     std::error_code err = findChplHome(argv[0], (void*)main, CHPL_HOME,
-                                       installed, foundEnv, warningMsg);
+                                       installed, foundEnv, diagnosticMsg);
     if (installed) {
       // need to determine and update third-party location before calling
       // getChplDepsApp to make sure we get an updated path in the case
@@ -2285,12 +2285,16 @@ int main(int argc, char** argv) {
       CHPL_THIRD_PARTY += getMajorMinorVersion();
       CHPL_THIRD_PARTY += "/third-party";
     }
-    if (!warningMsg.empty()) {
-      fprintf(stderr, "%s\n", warningMsg.c_str());
-    }
-    if (err) {
+
+    // When error code is set, diagnosticMsg contains the error.
+    if (!diagnosticMsg.empty()) {
+      fprintf(stderr, "%s\n", diagnosticMsg.c_str());
+    } else if (err) {
       fprintf(stderr, "CHPL_HOME not set to a valid value. Please set CHPL_HOME or pass a value "
                       "using the --home option\n" );
+    }
+
+    if (err) {
       clean_exit(1);
     }
   }

--- a/util/buildRelease/install.sh
+++ b/util/buildRelease/install.sh
@@ -343,12 +343,48 @@ C2CHAPEL="bin/$CHPL_BIN_SUBDIR"/c2chapel
 # copy c2chapel
 if [ -f "$C2CHAPEL" ]
 then
+  myinstalldir "tools/c2chapel/install" "$DEST_CHPL_HOME/tools/c2chapel/install"
+  myinstallfile "tools/c2chapel/c2chapel" "$DEST_CHPL_HOME/tools/c2chapel"
+  myinstallfile "tools/c2chapel/c2chapel.py" "$DEST_CHPL_HOME/tools/c2chapel"
+  myinstallfile "tools/c2chapel/utils/custom.h" "$DEST_CHPL_HOME/tools/c2chapel/util"
+
   if [ ! -z "$PREFIX" ]
   then
-    myinstallfile "$C2CHAPEL" "$PREFIX/bin"
+    ln -s "$DEST_CHPL_HOME/tools/c2chapel/c2chapel" "$PREFIX/bin"/c2chapel
   else
-    myinstallfile "$C2CHAPEL" "$DEST_CHPL_HOME/tools/c2chapel"
     ln -s "$DEST_CHPL_HOME/tools/c2chapel/c2chapel" "$DEST_DIR/bin/$CHPL_BIN_SUBDIR"/c2chapel
+  fi
+fi
+
+CHPLCHECK="bin/$CHPL_BIN_SUBDIR"/chplcheck
+
+# copy chplcheck
+if [ -f "$CHPLCHECK" ]
+then
+  myinstallfile "tools/chplcheck/chplcheck" "$DEST_CHPL_HOME/tools/chplcheck"
+  myinstalldir "tools/chplcheck/src" "$DEST_CHPL_HOME/tools/chplcheck/src"
+
+  if [ ! -z "$PREFIX" ]
+  then
+    ln -s "$DEST_CHPL_HOME/tools/chplcheck/chplcheck" "$PREFIX/bin"/chplcheck
+  else
+    ln -s "$DEST_CHPL_HOME/tools/chplcheck/chplcheck" "$DEST_DIR/bin/$CHPL_BIN_SUBDIR"/chplcheck
+  fi
+fi
+
+CHPL_LANGUAGE_SERVER="bin/$CHPL_BIN_SUBDIR"/chpl-language-server
+
+# copy chpl-language-server
+if [ -f "$CHPL_LANGUAGE_SERVER" ]
+then
+  myinstallfile "tools/chpl-language-server/chpl-language-server" "$DEST_CHPL_HOME/tools/chpl-language-server"
+  myinstalldir "tools/chpl-language-server/src" "$DEST_CHPL_HOME/tools/chpl-language-server/src"
+
+  if [ ! -z "$PREFIX" ]
+  then
+    ln -s "$DEST_CHPL_HOME/tools/chpl-language-server/chpl-language-server" "$PREFIX/bin"/chpl-language-server
+  else
+    ln -s "$DEST_CHPL_HOME/tools/chpl-language-server/chpl-language-server" "$DEST_DIR/bin/$CHPL_BIN_SUBDIR"/chpl-language-server
   fi
 fi
 

--- a/util/buildRelease/install.sh
+++ b/util/buildRelease/install.sh
@@ -338,6 +338,19 @@ then
   fi
 fi
 
+C2CHAPEL="bin/$CHPL_BIN_SUBDIR"/c2chapel
+
+# copy c2chapel
+if [ -f "$C2CHAPEL" ]
+then
+  if [ ! -z "$PREFIX" ]
+  then
+    myinstallfile "$C2CHAPEL" "$PREFIX/bin"
+  else
+    myinstallfile "$C2CHAPEL" "$DEST_CHPL_HOME/tools/c2chapel"
+    ln -s "$DEST_CHPL_HOME/tools/c2chapel/c2chapel" "$DEST_DIR/bin/$CHPL_BIN_SUBDIR"/c2chapel
+  fi
+fi
 
 # copy chplconfig
 if [ -f chplconfig ]

--- a/util/chpl-completion.bash
+++ b/util/chpl-completion.bash
@@ -316,6 +316,7 @@ _chpl ()
 --preserve-inlined-line-numbers \
 --print-additional-errors \
 --print-all-candidates \
+--print-bootstrap-commands \
 --print-callgraph \
 --print-callstack-on-error \
 --print-chpl-home \


### PR DESCRIPTION
This PR was created with the intention of adding support for installing `c2chapel` and other Python-based tooling when it has been built. However, doing so -- particularly in the prefix-based installation case -- required some additional implementation work in `chpl` and `chpldoc`.

The main problem was the `CHPL_THIRD_PARTY` directory, which is transitively (via `chpl_home_utils.py`)  used by all the `run-in-venv` scripts and `chpldoc`. Two problems stemmed from the environment variable:

* This directory is correctly inferred when the environment is completely blank, but in an explicitly-set `CHPL_HOME`, it points to an (assumed) home-based directory. Thus, `export CHPL_HOME=$(chpl --print-chpl-home)`  breaks both `chpl` and `chpldoc`. 
* It's very hard to find this directory (and therefore `chpldeps`, which goes through `CHPL_THIRD_PARTY`) when the top-level program is a bash script invoked from `/bin`. In particular, invoking `chpl_home_utils.py` etc. requires knowing the path to `/share`, which the first running script doesn't know. So we need some sort of bootstrapping.

This PR addresses this by adding a `--print-bootstrap-commands` developer flag to Chapel, which prints a couple of `export` statements with `CHPL_HOME` and `CHPL_THIRD_PARTY`. These statements are enough to locate and get proper output from `chpl_homeutils.py`, which I expect to be the source of truth for subsequent queries. It also fixes the "incorrect `--prefix` detection" issue by adjusting the `CHPL_HOME` processing logic.

While adjusting the `CHPL_HOME` logic, I noticed that it lives in two places: Dyno and the production compiler. I believe that the Dyno version is a port of the production version; I did my best to simplify the Dyno version, and then called out to it from the production compiler. The net result should be that `chpldoc` and `chpl` behave the same way w.r.t. environment variables. Since in Dyno we use C++ strings etc., the logic (which until now used `fprintf` and fixed-sized buffers, and returned on length errors) has been considerably simplified. Only the production compiler is left to use fixed-size buffers, and one corresponding length check is left to support that.

Reviewed by @arezaii -- thanks!

## Testing
- [x] paratest
- [x] `test_install`