### PR TITLE
Fix compilation bug involving nested functions

### DIFF
--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -4814,6 +4814,8 @@ void ConvertedSymbolsMap::applyFixups(chpl::Context* context,
     }
 
     se->setSymbol(sym);
+    fixedUp.insert(se);
+
     // Not all symExprs are noted as fixups (due to lowering and AST
     // transformations), so visit the temporary conversion symbol's recorded
     // symExprs to try handle these stragglers.

--- a/test/functions/Issue24493.chpl
+++ b/test/functions/Issue24493.chpl
@@ -1,0 +1,13 @@
+// Force fixups to occur by defining a type 'data' _after_ its uses. Fixups
+// happen when we lower to the middle-end's IR because we may generate
+// resolved mentions of a type before that type itself has been lowered.
+proc main() {
+  proc foo(fn, x: data) { return fn(x); }
+  proc f(x) { return x; }
+  var d = foo(proc(x: data) {
+    writeln('Hello world!');
+    return f(x); 
+  }, new data());
+}
+
+record data {}

--- a/test/functions/Issue24493.good
+++ b/test/functions/Issue24493.good
@@ -1,0 +1,1 @@
+Hello world!


### PR DESCRIPTION
Resolves #24493.

Fix a bug that caused the compiler to crash when compiling code that used nested functions as call actuals. We walk nested functions twice when checking for fixups (and thus note fixups contained in them twice). Note the initial fixup performed in addition to additional fixups to avoid triggering an internal assertion.

TESTING

- [x] `linux64`, `standard`

Reviewed by @DanilaFe. Thanks!