### PR TITLE
Dyno resolve `if var` decl type with nilable classes

### DIFF
--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2329,6 +2329,11 @@ bool Resolver::enter(const uast::Conditional* cond) {
       auto t = reVar.type().type();
       bool ok = t->isClassType() || t->isBasicClassType();
       if (!ok) CHPL_REPORT(context, IfVarNonClassType, cond, reVar.type());
+      /* if (auto ct = t->toClassType()) { */
+      /*   reVar.setType(QualifiedType( */
+      /*       reVar.type().kind(), */
+      /*       ct->withDecorator(context, ct->decorator().addNonNil()))); */
+      /* } */
     }
   }
 

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1972,7 +1972,7 @@ bool Resolver::resolveSpecialNewCall(const Call* call) {
     if (auto cls = type->toClassType()) {
       auto newCls = qtNewExpr.type()->toClassType();
       CHPL_ASSERT(newCls);
-      /* CHPL_ASSERT(!cls->manager() && cls->decorator().isNilable()); */
+      CHPL_ASSERT(!cls->manager());
       CHPL_ASSERT(cls->decorator().isBorrowed());
       CHPL_ASSERT(cls->basicClassType());
       type = ClassType::get(context, cls->basicClassType(),

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1972,7 +1972,7 @@ bool Resolver::resolveSpecialNewCall(const Call* call) {
     if (auto cls = type->toClassType()) {
       auto newCls = qtNewExpr.type()->toClassType();
       CHPL_ASSERT(newCls);
-      CHPL_ASSERT(!cls->manager() && cls->decorator().isNonNilable());
+      /* CHPL_ASSERT(!cls->manager() && cls->decorator().isNilable()); */
       CHPL_ASSERT(cls->decorator().isBorrowed());
       CHPL_ASSERT(cls->basicClassType());
       type = ClassType::get(context, cls->basicClassType(),

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2329,11 +2329,11 @@ bool Resolver::enter(const uast::Conditional* cond) {
       auto t = reVar.type().type();
       bool ok = t->isClassType() || t->isBasicClassType();
       if (!ok) CHPL_REPORT(context, IfVarNonClassType, cond, reVar.type());
-      /* if (auto ct = t->toClassType()) { */
-      /*   reVar.setType(QualifiedType( */
-      /*       reVar.type().kind(), */
-      /*       ct->withDecorator(context, ct->decorator().addNonNil()))); */
-      /* } */
+      if (auto ct = t->toClassType()) {
+        reVar.setType(QualifiedType(
+            reVar.type().kind(),
+            ct->withDecorator(context, ct->decorator().addNonNil())));
+      }
     }
   }
 

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1972,7 +1972,7 @@ bool Resolver::resolveSpecialNewCall(const Call* call) {
     if (auto cls = type->toClassType()) {
       auto newCls = qtNewExpr.type()->toClassType();
       CHPL_ASSERT(newCls);
-      CHPL_ASSERT(!cls->manager());
+      CHPL_ASSERT(!cls->manager() && cls->decorator().isNonNilable());
       CHPL_ASSERT(cls->decorator().isBorrowed());
       CHPL_ASSERT(cls->basicClassType());
       type = ClassType::get(context, cls->basicClassType(),

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -733,7 +733,6 @@ void CallInitDeinit::resolveDeinit(const AstNode* ast,
                       /* isParenless */ false,
                       actuals);
   const Scope* scope = scopeForId(context, ast->id());
-  gdbShouldBreakHere();
   auto c = resolveGeneratedCall(context, ast, ci, scope, resolver.poiScope);
 
   // Should we associate it with the current statement or the current block?

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -616,7 +616,13 @@ void CallInitDeinit::resolveMoveInit(const AstNode* ast,
   if (isTypeParam(lhsType.kind())) {
     // OK, nothing else to do
   } else if (isValue(lhsType.kind()) && isValueOrParam(rhsType.kind())) {
-    if (canPass(context, rhsType, lhsType).passes()) {
+    // Accept if we can pass with only a subtype conversion
+    // (for passing non-nilable to nilable).
+    auto canPassResult = canPass(context, rhsType, lhsType);
+    if (canPassResult.passes() &&
+        (!canPassResult.converts() ||
+         canPassResult.conversionKind() ==
+             CanPassResult::ConversionKind::SUBTYPE)) {
       // Future TODO: might need to call something provided by the record
       // author to be a hook for move initialization across locales
       // (see issue #15676).

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -616,7 +616,7 @@ void CallInitDeinit::resolveMoveInit(const AstNode* ast,
   if (isTypeParam(lhsType.kind())) {
     // OK, nothing else to do
   } else if (isValue(lhsType.kind()) && isValueOrParam(rhsType.kind())) {
-    if (lhsType.type() == rhsType.type()) {
+    if (canPass(context, rhsType, lhsType).passes()) {
       // Future TODO: might need to call something provided by the record
       // author to be a hook for move initialization across locales
       // (see issue #15676).
@@ -733,6 +733,7 @@ void CallInitDeinit::resolveDeinit(const AstNode* ast,
                       /* isParenless */ false,
                       actuals);
   const Scope* scope = scopeForId(context, ast->id());
+  gdbShouldBreakHere();
   auto c = resolveGeneratedCall(context, ast, ci, scope, resolver.poiScope);
 
   // Should we associate it with the current statement or the current block?

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -198,8 +198,8 @@ generateInitParts(Context* context,
   // If the receiver is a basic class C, use 'const in x: borrowed C'.
   } else if (auto basic = compType->toBasicClassType()) {
     const Type* manager = nullptr;
-    auto nonNilBorrowed  = ClassTypeDecorator::BORROWED_NONNIL;
-    auto decor = ClassTypeDecorator(nonNilBorrowed);
+    auto nilableBorrowed  = ClassTypeDecorator::BORROWED_NILABLE;
+    auto decor = ClassTypeDecorator(nilableBorrowed);
     auto receiverType = ClassType::get(context, basic, manager, decor);
     CHPL_ASSERT(receiverType);
     qtReceiver = QualifiedType(QualifiedType::CONST_IN, receiverType);

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -195,13 +195,13 @@ generateInitParts(Context* context,
   if (compType->isRecordType() || compType->isUnionType()) {
     qtReceiver = QualifiedType(QualifiedType::REF, compType);
 
-  // If the receiver is a basic class C, use 'const in x: borrowed C?'.
+  // If the receiver is a basic class C, use 'const in x: borrowed C'.
   } else if (auto basic = compType->toBasicClassType()) {
     const Type* manager = nullptr;
-    auto borrowedNilableDecor =
-        ClassTypeDecorator(ClassTypeDecorator::BORROWED_NILABLE);
+    auto borrowedNonnilDecor =
+        ClassTypeDecorator(ClassTypeDecorator::BORROWED_NONNIL);
     auto receiverType =
-        ClassType::get(context, basic, manager, borrowedNilableDecor);
+        ClassType::get(context, basic, manager, borrowedNonnilDecor);
     CHPL_ASSERT(receiverType);
     qtReceiver = QualifiedType(QualifiedType::CONST_IN, receiverType);
 

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -195,12 +195,13 @@ generateInitParts(Context* context,
   if (compType->isRecordType() || compType->isUnionType()) {
     qtReceiver = QualifiedType(QualifiedType::REF, compType);
 
-  // If the receiver is a basic class C, use 'const in x: borrowed C'.
+  // If the receiver is a basic class C, use 'const in x: borrowed C?'.
   } else if (auto basic = compType->toBasicClassType()) {
     const Type* manager = nullptr;
-    auto nilableBorrowed  = ClassTypeDecorator::BORROWED_NILABLE;
-    auto decor = ClassTypeDecorator(nilableBorrowed);
-    auto receiverType = ClassType::get(context, basic, manager, decor);
+    auto borrowedNilableDecor =
+        ClassTypeDecorator(ClassTypeDecorator::BORROWED_NILABLE);
+    auto receiverType =
+        ClassType::get(context, basic, manager, borrowedNilableDecor);
     CHPL_ASSERT(receiverType);
     qtReceiver = QualifiedType(QualifiedType::CONST_IN, receiverType);
 

--- a/frontend/test/resolution/testCallInitDeinit.cpp
+++ b/frontend/test/resolution/testCallInitDeinit.cpp
@@ -1563,6 +1563,8 @@ static void test20a() {
 }
 
 // Generic instantiation version
+// TODO: Uncomment once we support init of generic types. May need to update
+// expected associated actions as well.
 /* static void test20b() { */
 /*   testActions("test20b", */
 /*     R""""( */

--- a/frontend/test/resolution/testCallInitDeinit.cpp
+++ b/frontend/test/resolution/testCallInitDeinit.cpp
@@ -1605,7 +1605,6 @@ static void test20c() {
     )"""",
     {
       {AssociatedAction::NEW_INIT,   "M.foo@6",    ""},
-      /* {AssociatedAction::INIT_OTHER, "x",          ""}, */
       {AssociatedAction::DEINIT,     "M.foo@10",   "x"},
     });
 }

--- a/frontend/test/resolution/testCallInitDeinit.cpp
+++ b/frontend/test/resolution/testCallInitDeinit.cpp
@@ -1540,6 +1540,76 @@ static void test19() {
       } );
 }
 
+// Returning a non-nilable 'new' local variable
+static void test20a() {
+  testActions("test20a",
+    R""""(
+      module M {
+        class C {}
+        proc C.init() {}
+        operator C.=(ref lhs: C, rhs: C) { }
+        proc C.deinit() { }
+
+        proc foo() {
+          var x : owned C = new C();
+          return x;
+        }
+      }
+    )"""",
+    {
+      {AssociatedAction::NEW_INIT, "M.foo@5",          ""},
+      {AssociatedAction::DEINIT,   "M.foo@9",          "x"},
+    });
+}
+
+// Generic instantiation version
+/* static void test20b() { */
+/*   testActions("test20b", */
+/*     R""""( */
+/*       module M { */
+/*         class C { */
+/*           var x; */
+/*         } */
+/*         proc C.init(x) {this.x = x;} */
+/*         operator C.=(ref lhs: C(?), rhs: C(?)) { } */
+/*         proc C.deinit() { } */
+
+/*         proc foo() { */
+/*           var x : owned C = new C(3); */
+/*           return x; */
+/*         } */
+/*       } */
+/*     )"""", */
+/*     { */
+/*       {AssociatedAction::NEW_INIT,   "M.foo@6",    ""}, */
+/*       {AssociatedAction::INIT_OTHER, "x",          ""}, */
+/*       {AssociatedAction::DEINIT,     "M.foo@10",   "x"}, */
+/*     }); */
+/* } */
+
+// Nilable version
+static void test20c() {
+  testActions("test20c",
+    R""""(
+      module M {
+        class C {}
+        proc C.init() {}
+        operator C.=(ref lhs: C, rhs: C) { }
+        proc C.deinit() { }
+
+        proc foo() {
+          var x : owned C? = new C();
+          return x;
+        }
+      }
+    )"""",
+    {
+      {AssociatedAction::NEW_INIT,   "M.foo@6",    ""},
+      /* {AssociatedAction::INIT_OTHER, "x",          ""}, */
+      {AssociatedAction::DEINIT,     "M.foo@10",   "x"},
+    });
+}
+
 // calling function with 'out' intent formal
 
 // calling functions with 'inout' intent formal
@@ -1621,6 +1691,10 @@ int main() {
   test18b();
 
   test19();
+
+  test20a();
+  /* test20b(); */
+  test20c();
 
   return 0;
 }

--- a/frontend/test/resolution/testIf.cpp
+++ b/frontend/test/resolution/testIf.cpp
@@ -353,6 +353,42 @@ static void testIfVarErrorNonClassType() {
   guard.realizeErrors();
 }
 
+static void testIfVarNonNilInThen() {
+  Context context;
+  auto ctx = &context;
+  ErrorGuard guard(ctx);
+
+  auto path = TEST_NAME_FROM_FN_NAME(ctx);
+  std::string contents =
+    R""""(
+    class Bar {
+      var _msg : string;
+      proc message():string {
+        return _msg;
+      }
+    }
+
+    proc foo() {
+      var e : owned Bar? = new Bar("foo");
+      return e;
+    }
+
+    if var err = foo() {
+      var x = err.message();
+    }
+    )"""";
+  setFileText(ctx, path, contents);
+
+  auto& br = parseAndReportErrors(ctx, path);
+  auto mod = br.singleModule();
+  assert(mod);
+
+  auto& rr = resolveModule(ctx, mod->id());
+  (void)rr;
+  assert(guard.numErrors() == 0);
+  guard.realizeErrors();
+}
+
 int main() {
   test1();
   test2();
@@ -365,5 +401,7 @@ int main() {
   testIfVarErrorUseInElseBranch3();
   testIfVarErrorUseInElseBranch4();
   testIfVarErrorNonClassType();
+  testIfVarNonNilInThen();
+
   return 0;
 }

--- a/frontend/test/resolution/testNew.cpp
+++ b/frontend/test/resolution/testNew.cpp
@@ -246,7 +246,7 @@ static void testTertMethodCallCrossModule() {
                                  nullptr,
                                  recvDecor);
   auto qtReceiver = QualifiedType(QualifiedType::CONST_IN, recvType);
-  assert(tfsInit->formalType(0) == qtReceiver);
+  /* assert(tfsInit->formalType(0) == qtReceiver); */
   assert(!tfsInit->needsInstantiation());
   assert(!tfsInit->formalIsInstantiated(0)); // Is concrete!
 

--- a/frontend/test/resolution/testNew.cpp
+++ b/frontend/test/resolution/testNew.cpp
@@ -241,12 +241,12 @@ static void testTertMethodCallCrossModule() {
   assert(ufsInit->isCompilerGenerated());
   assert(tfsInit->numFormals() == 1);
   assert(tfsInit->formalName(0) == "this");
-  auto recvDecor = ClassTypeDecorator(ClassTypeDecorator::BORROWED_NONNIL);
+  auto recvDecor = ClassTypeDecorator(ClassTypeDecorator::BORROWED_NILABLE);
   auto recvType = ClassType::get(ctx, clsX->basicClassType(),
                                  nullptr,
                                  recvDecor);
   auto qtReceiver = QualifiedType(QualifiedType::CONST_IN, recvType);
-  /* assert(tfsInit->formalType(0) == qtReceiver); */
+  assert(tfsInit->formalType(0) == qtReceiver);
   assert(!tfsInit->needsInstantiation());
   assert(!tfsInit->formalIsInstantiated(0)); // Is concrete!
 

--- a/frontend/test/resolution/testNew.cpp
+++ b/frontend/test/resolution/testNew.cpp
@@ -241,7 +241,7 @@ static void testTertMethodCallCrossModule() {
   assert(ufsInit->isCompilerGenerated());
   assert(tfsInit->numFormals() == 1);
   assert(tfsInit->formalName(0) == "this");
-  auto recvDecor = ClassTypeDecorator(ClassTypeDecorator::BORROWED_NILABLE);
+  auto recvDecor = ClassTypeDecorator(ClassTypeDecorator::BORROWED_NONNIL);
   auto recvType = ClassType::get(ctx, clsX->basicClassType(),
                                  nullptr,
                                  recvDecor);


### PR DESCRIPTION
Make dyno resolution treat a nilable class type declared in an `if var` as non-nilable inside the `then` body, since it must be non-nil there.

Along the way, make it possible to init/deinit a nilable class type from a `new` non-nilable value, as is possible in the production compiler. The `init` is made possible by accepting a subtype conversion (which includes nilability) in move-init. `Deinit` is made possible by changing the nilable to be deinited to non-nilable, as we'll have a runtime check to avoid deiniting `nil`. 

Resolves https://github.com/Cray/chapel-private/issues/5975.

[reviewer info placeholder]

Testing:
- [x] dyno tests
- [x] paratest