### PR TITLE
Fix some iterator-context test failures

### DIFF
--- a/test/users/engin/context/basicArrayHoist-link-for-memleaks.execopts
+++ b/test/users/engin/context/basicArrayHoist-link-for-memleaks.execopts
@@ -1,1 +1,1 @@
---memLeaks --doVerboseMem=false
+--memLeaks

--- a/test/users/engin/context/basicArrayHoist.chpl
+++ b/test/users/engin/context/basicArrayHoist.chpl
@@ -6,7 +6,7 @@ use Iterators.SimpleOneDim;
 config param hoistArray = true;
 
 config const n = 20;
-config const doVerboseMem = true;
+config const doVerboseMem = false;
 
 if doVerboseMem then startVerboseMem();
 forall i in simpleOneDim(n) {  // context should be coming from a new syntax

--- a/test/users/engin/context/basicArrayHoist.execopts
+++ b/test/users/engin/context/basicArrayHoist.execopts
@@ -1,1 +1,1 @@
---memTrack
+--memTrack --doVerboseMem=true

--- a/test/users/engin/context/basicBarrier.chpl
+++ b/test/users/engin/context/basicBarrier.chpl
@@ -1,6 +1,5 @@
 use IO;
 use Collectives;
-use MemDiagnostics;
 
 use ChapelContextSupport;
 use Iterators.SimpleOneDim;
@@ -8,9 +7,7 @@ use Iterators.SimpleOneDim;
 config param hoistArray = true;
 
 config const n = 20;
-config const doVerboseMem = true;
 
-if doVerboseMem then startVerboseMem();
 forall i in simpleOneDim(n) {  // context should be coming from a new syntax
   const context = new Context();
   const vectorContext = __primitive("outer context", context);
@@ -38,5 +35,3 @@ forall i in simpleOneDim(n) {  // context should be coming from a new syntax
   if localTaskContext.taskId == 1 then
     writeln("%2i: ".format(i), a);
 }
-
-if doVerboseMem then stopVerboseMem();

--- a/test/users/engin/context/basicBarrier.comm-none.good
+++ b/test/users/engin/context/basicBarrier.comm-none.good
@@ -1,1 +1,1 @@
-basicBarrier.chpl:19: error: could not find the 4-th outer context in the iterator for the enclosing loop
+basicBarrier.chpl:16: error: could not find the 4-th outer context in the iterator for the enclosing loop

--- a/test/users/engin/context/basicTaskIds.chpl
+++ b/test/users/engin/context/basicTaskIds.chpl
@@ -1,13 +1,10 @@
 use IO;
-use MemDiagnostics;
 
 use ChapelContextSupport;
 use Iterators.SimpleOneDim;
 
 config const n = 20;
-config const doVerboseMem = true;
 
-if doVerboseMem then startVerboseMem();
 forall i in simpleOneDim(n) {  // context should be coming from a new syntax
   const context = new Context();
   const vectorContext = __primitive("outer context", context);
@@ -20,4 +17,3 @@ forall i in simpleOneDim(n) {  // context should be coming from a new syntax
             preLocaleTaskContext);
   }
 }
-if doVerboseMem then stopVerboseMem();

--- a/test/users/engin/context/basicTaskIds.comm-none.good
+++ b/test/users/engin/context/basicTaskIds.comm-none.good
@@ -1,1 +1,1 @@
-basicTaskIds.chpl:16: error: could not find the 4-th outer context in the iterator for the enclosing loop
+basicTaskIds.chpl:13: error: could not find the 4-th outer context in the iterator for the enclosing loop


### PR DESCRIPTION
This PR fixes failures in `basicBarrier` and `basicTaskIds` when tested with `-memleaks` under gasnet. These two tests used to turn on `startVerboseMem()` unintentionally. This produced no output by default, however produced verbose-memory diagnostics upon `-memleaks`, which implicitly turns on `--memTrack`. There were no failures in memleaks testing for local compilation because in the `--local` mode these tests produce compilation errors and so are not executed.

Since `startVerboseMem()` is unrelated to what these two tests are testing, I removed it. While there, I switched `basicArrayHoist.chpl` to avoid `startVerboseMem()` by default, so that the default behavior is more user-friendly.

Testing: `test/users/engin/context` under several configurations.