### PR TITLE
Skip 1BRC tests in valgrind config

### DIFF
--- a/test/studies/1brc/SKIPIF
+++ b/test/studies/1brc/SKIPIF
@@ -6,6 +6,12 @@
 # If something fails along the way (perhaps due to a network outage) we'll
 # skip executing the test.
 
+# Skip these tests in the valgrind config (runtime is too long)
+if [[ ${CHPL_NIGHTLY_TEST_CONFIG_NAME} == "valgrind" ]]; then
+  echo "True"
+  exit
+fi
+
 # If we've already generated the input dataset no need to regenerate it
 if [[ -e measurements.txt ]]; then
   echo "False"
@@ -39,7 +45,7 @@ if [[ ! -e measurements.txt ]]; then
   if ! python3 ./create_measurements.py 10_000_000 2> python.out; then
     echo "creating input dataset failed; output:" >&2
     cat python.out >&2
-    return "True"
+    echo "True"
     exit
   fi
 fi

--- a/test/studies/1brc/wget.out
+++ b/test/studies/1brc/wget.out
@@ -1,0 +1,1 @@
+/Users/jcorrado/Documents/chapel_misc/chapel/test/studies/1brc/SKIPIF: line 26: wget: command not found

--- a/test/studies/1brc/wget.out
+++ b/test/studies/1brc/wget.out
@@ -1,1 +1,0 @@
-/Users/jcorrado/Documents/chapel_misc/chapel/test/studies/1brc/SKIPIF: line 26: wget: command not found


### PR DESCRIPTION
The 1BRC tests are timing out under the valgrind config. This PR skips them when `CHPL_NIGHTLY_TEST_CONFIG_NAME==valgrind`.