### PR TITLE
fix bug that always installed `chpldoc`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -369,8 +369,11 @@ if (INSTALLATION_MODE STREQUAL "prefix")
   set_target_properties(chpl chpldoc ChplFrontendShared
                         PROPERTIES
                         INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib/chapel/${CHPL_MAJOR_VERSION}.${CHPL_MINOR_VERSION}/compiler")
-  install(TARGETS chpl chpldoc OPTIONAL
+  install(TARGETS chpl
           RUNTIME DESTINATION bin)
+  install(TARGETS chpldoc OPTIONAL
+          RUNTIME DESTINATION bin)
+
 else()
   # use relative rpaths for the build and do not change them on install
   if (CMAKE_VERSION VERSION_LESS 3.16)
@@ -394,6 +397,8 @@ else()
                           INSTALL_RPATH ${CHPL_INSTALL_RPATH})
   endif()
 
-  install(TARGETS chpl chpldoc OPTIONAL
+  install(TARGETS chpl
+          RUNTIME DESTINATION "bin/${CHPL_HOST_BIN_SUBDIR}")
+  install(TARGETS chpldoc OPTIONAL
           RUNTIME DESTINATION "bin/${CHPL_HOST_BIN_SUBDIR}")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -369,7 +369,7 @@ if (INSTALLATION_MODE STREQUAL "prefix")
   set_target_properties(chpl chpldoc ChplFrontendShared
                         PROPERTIES
                         INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib/chapel/${CHPL_MAJOR_VERSION}.${CHPL_MINOR_VERSION}/compiler")
-  install(TARGETS chpl chpldoc
+  install(TARGETS chpl chpldoc OPTIONAL
           RUNTIME DESTINATION bin)
 else()
   # use relative rpaths for the build and do not change them on install
@@ -394,6 +394,6 @@ else()
                           INSTALL_RPATH ${CHPL_INSTALL_RPATH})
   endif()
 
-  install(TARGETS chpl chpldoc
+  install(TARGETS chpl chpldoc OPTIONAL
           RUNTIME DESTINATION "bin/${CHPL_HOST_BIN_SUBDIR}")
 endif()

--- a/Makefile
+++ b/Makefile
@@ -264,7 +264,7 @@ check:
 check-chpldoc: chpldoc third-party-test-venv
 	@bash $(CHPL_MAKE_HOME)/util/test/checkChplDoc
 
-install: comprt
+install:
 	@bash $(CHPL_MAKE_HOME)/util/buildRelease/install.sh --stage=${DESTDIR}
 
 # install-chpldoc:

--- a/Makefile
+++ b/Makefile
@@ -267,6 +267,9 @@ check-chpldoc: chpldoc third-party-test-venv
 install: comprt
 	@bash $(CHPL_MAKE_HOME)/util/buildRelease/install.sh --stage=${DESTDIR}
 
+install-chpl: comprt
+	@bash $(CHPL_MAKE_HOME)/util/buildRelease/install.sh --stage=${DESTDIR} --no-chpldoc
+
 -include Makefile.devel
 
 FORCE:

--- a/Makefile
+++ b/Makefile
@@ -267,8 +267,8 @@ check-chpldoc: chpldoc third-party-test-venv
 install: comprt
 	@bash $(CHPL_MAKE_HOME)/util/buildRelease/install.sh --stage=${DESTDIR}
 
-install-chpl: comprt
-	@bash $(CHPL_MAKE_HOME)/util/buildRelease/install.sh --stage=${DESTDIR} --no-chpldoc
+# install-chpldoc:
+# 	@bash $(CHPL_MAKE_HOME)/util/buildRelease/install.sh --stage=${DESTDIR} --chpldoc
 
 -include Makefile.devel
 

--- a/Makefile
+++ b/Makefile
@@ -267,9 +267,6 @@ check-chpldoc: chpldoc third-party-test-venv
 install:
 	@bash $(CHPL_MAKE_HOME)/util/buildRelease/install.sh --stage=${DESTDIR}
 
-# install-chpldoc:
-# 	@bash $(CHPL_MAKE_HOME)/util/buildRelease/install.sh --stage=${DESTDIR} --chpldoc
-
 -include Makefile.devel
 
 FORCE:

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -240,16 +240,11 @@ $(COMPILER_BUILD):
 $(CHPL_BIN_DIR):
 	mkdir -p $@
 
-install-chpl-chpldoc: $(CHPL) $(CHPLDOC)
+install-chpl-chpldoc: FORCE $(CHPL_CONFIG_CHECK)
 # this target is called from the install.sh script, bypassing the normal
 # way of building chpldoc.  So we need to make sure the venv is built
-	@if [ -z "$$CHPL_DONT_BUILD_CHPLDOC_VENV" ]; then \
-	cd $(CHPL_MAKE_HOME)/third-party && $(MAKE) chpldoc-venv; \
-	fi
 	@cd $(COMPILER_BUILD) && $(CMAKE) $(CHPL_MAKE_HOME) $(CMAKE_FLAGS) && $(MAKE) install
 
-install-chpl: $(CHPL)
-	@cd $(COMPILER_BUILD) && $(CMAKE) $(CHPL_MAKE_HOME) $(CMAKE_FLAGS) && $(MAKE) install
 #
 # include standard footer for compiler
 #

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -248,6 +248,8 @@ install-chpl-chpldoc: $(CHPL) $(CHPLDOC)
 	fi
 	@cd $(COMPILER_BUILD) && $(CMAKE) $(CHPL_MAKE_HOME) $(CMAKE_FLAGS) && $(MAKE) install
 
+install-chpl: $(CHPL)
+	@cd $(COMPILER_BUILD) && $(CMAKE) $(CHPL_MAKE_HOME) $(CMAKE_FLAGS) && $(MAKE) install
 #
 # include standard footer for compiler
 #

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -241,8 +241,10 @@ $(CHPL_BIN_DIR):
 	mkdir -p $@
 
 install-chpl-chpldoc: FORCE $(CHPL_CONFIG_CHECK)
-# this target is called from the install.sh script, bypassing the normal
-# way of building chpldoc.  So we need to make sure the venv is built
+# this target is called by the install.sh script which is called by a `make install`
+# from the top-level directory.
+# CMake will ensure chpl is built and optionally install chpldoc if it was already
+# built
 	@cd $(COMPILER_BUILD) && $(CMAKE) $(CHPL_MAKE_HOME) $(CMAKE_FLAGS) && $(MAKE) install
 
 #

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -191,7 +191,7 @@ frontend-docs: FORCE $(CHPL_CONFIG_CHECK) $(COMPILER_BUILD)
 
 frontend-linters: FORCE $(CHPL_CONFIG_CHECK) $(COMPILER_BUILD)
 	@echo "Making the frontend linters"
-	cd $(COMPILER_BUILD) && $(CMAKE) $(CHPL_MAKE_HOME) $(CMAKE_FLAGS) && cd frontend/util && $(MAKE)
+	cd $(COMPILER_BUILD) && $(CMAKE) $(CHPL_MAKE_HOME) $(CMAKE_FLAGS) && cd frontend/util/linters && $(MAKE) fieldsUsed
 
 run-frontend-linters: frontend-linters
 	@echo "Running the frontend linters"

--- a/frontend/util/linters/CMakeLists.txt
+++ b/frontend/util/linters/CMakeLists.txt
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(fieldsUsed "fieldsUsed.cpp")
+add_executable(fieldsUsed EXCLUDE_FROM_ALL "fieldsUsed.cpp")
 
 # store it in the build directory
 set_target_properties(fieldsUsed  PROPERTIES RUNTIME_OUTPUT_DIRECTORY . )

--- a/tools/chpldoc/CMakeLists.txt
+++ b/tools/chpldoc/CMakeLists.txt
@@ -30,7 +30,7 @@ add_custom_command(
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../../COPYRIGHT
   COMMENT "writing COPYRIGHT file updates..."
   VERBATIM)
-add_executable(chpldoc chpldoc.cpp arg.cpp arg-helpers.cpp COPYRIGHT)
+add_executable(chpldoc EXCLUDE_FROM_ALL chpldoc.cpp arg.cpp arg-helpers.cpp COPYRIGHT)
 target_link_libraries(chpldoc ChplFrontend)
 target_include_directories(chpldoc PRIVATE
                            ${CHPL_MAIN_INCLUDE_DIR}

--- a/util/buildRelease/install.sh
+++ b/util/buildRelease/install.sh
@@ -239,10 +239,8 @@ myinstallfileto () {
   fi
 }
 
-# these makefile targets run 'cmake' to install the compiler library, 'chpl',
-# and optionally 'chpldoc'
-# if [ $BUILD_CHPLDOC -eq 1 ]
-# then
+# this makefile target runs 'cmake' to install the compiler library, 'chpl',
+# and optionally 'chpldoc' if it was built
 (cd compiler && "$MAKE" install-chpl-chpldoc)
 
 

--- a/util/buildRelease/install.sh
+++ b/util/buildRelease/install.sh
@@ -3,7 +3,7 @@
 STAGE=""
 STAGE_SET=0
 PREFIX=""
-BUILD_CHPLDOC=1
+BUILD_CHPLDOC=0
 # Different from DESTDIR, which is for staged installs
 # this variable is for installing the Chapel directory in one place
 # (to mirror release / source checkout)
@@ -25,8 +25,8 @@ do
       fi
       shift
       ;;
-    --no-chpldoc)
-      BUILD_CHPLDOC=0
+    --chpldoc)
+      BUILD_CHPLDOC=1
       shift
       ;;
     *)
@@ -37,7 +37,7 @@ do
       echo "                e.g. for staged installation as with"
       echo "                     the DESTDIR Makefile variable"
       echo
-      echo "       --no-chpldoc don't install chpldoc with chpl"
+      echo "       --chpldoc install chpldoc with chpl"
       echo
       exit -1
     ;;
@@ -240,14 +240,12 @@ myinstallfileto () {
   fi
 }
 
-# run 'cmake' to install the compiler library, 'chpl', and optionally 'chpldoc'
-if [ $BUILD_CHPLDOC -eq 1 ]
-then
-  (cd compiler && "$MAKE" install-chpl-chpldoc)
-else
-  (cd compiler && "$MAKE" install-chpl)
-fi
-# (cd compiler && "$MAKE" install-chpl-chpldoc)
+# these makefile targets run 'cmake' to install the compiler library, 'chpl',
+# and optionally 'chpldoc'
+# if [ $BUILD_CHPLDOC -eq 1 ]
+# then
+(cd compiler && "$MAKE" install-chpl-chpldoc)
+
 
 # copy compiler and runtime lib
 myinstalldir  lib                     "$DEST_RUNTIME_LIB"

--- a/util/buildRelease/install.sh
+++ b/util/buildRelease/install.sh
@@ -3,7 +3,6 @@
 STAGE=""
 STAGE_SET=0
 PREFIX=""
-BUILD_CHPLDOC=0
 # Different from DESTDIR, which is for staged installs
 # this variable is for installing the Chapel directory in one place
 # (to mirror release / source checkout)
@@ -25,10 +24,6 @@ do
       fi
       shift
       ;;
-    --chpldoc)
-      BUILD_CHPLDOC=1
-      shift
-      ;;
     *)
       echo
       echo "Usage: $0 [--stage=DESTDIR]"
@@ -36,8 +31,6 @@ do
       echo "       --stage=DESTDIR prepends DESTDIR to prefix"
       echo "                e.g. for staged installation as with"
       echo "                     the DESTDIR Makefile variable"
-      echo
-      echo "       --chpldoc install chpldoc with chpl"
       echo
       exit -1
     ;;
@@ -113,6 +106,12 @@ esac
 CHPL_PYTHON=`"$CHPL_HOME"/util/config/find-python.sh`
 CHPL_BIN_SUBDIR=`"$CHPL_PYTHON" "$CHPL_HOME"/util/chplenv/chpl_bin_subdir.py`
 VERS=`$CHPL_HOME/bin/$CHPL_BIN_SUBDIR/chpl --version`
+if [ $? -ne 0 ]
+then
+  echo "Error: failed to run chpl --version; Have you already built the compiler using make?"
+  echo "       If not, please run 'make' before running this script."
+  exit -1
+fi
 # Remove the "chpl version " part
 VERS=${VERS#chpl version }
 # Replace the periods with spaces.
@@ -322,7 +321,7 @@ do
 
   # chpl-venv also needs to copy chpldoc-sphinx-project
   # but this never contains executables so should go in DEST_CHPL_HOME
-  if [ -d third-party/"$dir"/chpldoc-sphinx-project ] && [ $BUILD_CHPLDOC -eq 1 ]
+  if [ -d third-party/"$dir"/chpldoc-sphinx-project ]
   then
     myinstalldir "third-party/$dir/chpldoc-sphinx-project" "$DEST_CHPL_HOME/third-party/$dir/chpldoc-sphinx-project/"
   fi

--- a/util/buildRelease/install.sh
+++ b/util/buildRelease/install.sh
@@ -3,6 +3,7 @@
 STAGE=""
 STAGE_SET=0
 PREFIX=""
+BUILD_CHPLDOC=1
 # Different from DESTDIR, which is for staged installs
 # this variable is for installing the Chapel directory in one place
 # (to mirror release / source checkout)
@@ -24,6 +25,10 @@ do
       fi
       shift
       ;;
+    --no-chpldoc)
+      BUILD_CHPLDOC=0
+      shift
+      ;;
     *)
       echo
       echo "Usage: $0 [--stage=DESTDIR]"
@@ -31,6 +36,8 @@ do
       echo "       --stage=DESTDIR prepends DESTDIR to prefix"
       echo "                e.g. for staged installation as with"
       echo "                     the DESTDIR Makefile variable"
+      echo
+      echo "       --no-chpldoc don't install chpldoc with chpl"
       echo
       exit -1
     ;;
@@ -71,7 +78,7 @@ else
     read -r DEST_DIR < "$CHPL_HOME/configured-chpl-home"
     DEST_DIR="${STAGE}${DEST_DIR}"
     mkdir -p "$DEST_DIR"
-    
+
     if [ ! -d "$DEST_DIR" ]
     then
       echo "Exiting: Installation dest path '$DEST_DIR' does not exist"
@@ -233,8 +240,14 @@ myinstallfileto () {
   fi
 }
 
-# run 'cmake' to install the compiler library, 'chpl' and 'chpldoc'
-(cd compiler && "$MAKE" install-chpl-chpldoc)
+# run 'cmake' to install the compiler library, 'chpl', and optionally 'chpldoc'
+if [ $BUILD_CHPLDOC -eq 1 ]
+then
+  (cd compiler && "$MAKE" install-chpl-chpldoc)
+else
+  (cd compiler && "$MAKE" install-chpl)
+fi
+# (cd compiler && "$MAKE" install-chpl-chpldoc)
 
 # copy compiler and runtime lib
 myinstalldir  lib                     "$DEST_RUNTIME_LIB"
@@ -311,7 +324,7 @@ do
 
   # chpl-venv also needs to copy chpldoc-sphinx-project
   # but this never contains executables so should go in DEST_CHPL_HOME
-  if [ -d third-party/"$dir"/chpldoc-sphinx-project ]
+  if [ -d third-party/"$dir"/chpldoc-sphinx-project ] && [ $BUILD_CHPLDOC -eq 1 ]
   then
     myinstalldir "third-party/$dir/chpldoc-sphinx-project" "$DEST_CHPL_HOME/third-party/$dir/chpldoc-sphinx-project/"
   fi


### PR DESCRIPTION
This PR fixes a bug that was introduced sometime around the introduction of CMake to handle the installation process for `chpl` and `chpldoc`. The fix allows `make install` to only install `chpldoc` if it has been built already using `make chpldoc`. This aligns with the previous behavior before the bug. 

There are two parts to the resolution. First, make `chpldoc` excluded from the `all` target in CMake. Then separate the install commands in CMake so that `chpl` is still required to be built before `make install`, but `chpldoc` will only be installed if it was found in the build directory. 

TESTING:

- [x] make install errors if `chpl` wasn't built first
- [x] `make install` doesn't build `chpldoc`
- [x] `make install` does install `chpldoc` if `make chpldoc` was called previously (e.g., `chpldoc` binary exists in build directory)

[reviewed by @mppf - thanks!]