### PR TITLE
Don't perform const checks on type arguments, even if they're runtime types

### DIFF
--- a/compiler/passes/resolveIntents.cpp
+++ b/compiler/passes/resolveIntents.cpp
@@ -260,6 +260,13 @@ IntentTag blankIntentForExternFnArg(Type* type) {
 // behavior in the future, so want to generate a warning if it occurs (and one
 // of the primitives will handle generating that warning).
 static void warnForInferredConstRef(ArgSymbol* arg) {
+  // Exit early if the argument is a _RuntimeTypeInfo, that should only be used
+  // to replace type arguments and types are never changed after they are
+  // created (so wouldn't cause problems)
+  if (strcmp(arg->type->symbol->name, astr("_RuntimeTypeInfo")) == 0) {
+    return;
+  }
+
   SET_LINENO(arg);
 
   FnSymbol* fn = toFnSymbol(arg->defPoint->parentSymbol);


### PR DESCRIPTION
Fixes a bug that we encountered when testing an unstable warning for associative domains - that test had a type argument which was getting passed a runtime type. Since runtime types by definition must exist at runtime, the argument had been transformed and was now relying on the default argument intent, making it inaccurately eligible for the indirect modification const check.  Something about the runtime type was causing valgrind to complain, which is how we noticed these unnecessary checks were getting inserted.

Type variables are only created, they cannot be modified, so it is unnecessary to worry about if they will be indirectly modified over the course of a function which takes them as an argument.  So just avoid inserting the checks when we know we have been given a runtime type info argument.

Verified that the test no longer gets a const check inserted for that argument but that const checks are still inserted by checking the generated code.

Passed a full paratest with futures, and checked the test that failed before with valgrind works locally (though that's APPARENTLY not necessarily a determining factor about whether it will work in nightly, grumble grumble valgrind grumble grumble)