### PR TITLE
Use chapeldomain version 0.0.30

### DIFF
--- a/third-party/chpl-venv/chpldoc-requirements3.txt
+++ b/third-party/chpl-venv/chpldoc-requirements3.txt
@@ -1,4 +1,4 @@
 # Split into 3 files to work around problems with CHPL_PIP_FROM_SOURCE
 sphinx-rtd-theme==2.0.0
-sphinxcontrib-chapeldomain==0.0.29
+sphinxcontrib-chapeldomain==0.0.30
 breathe==4.35.0


### PR DESCRIPTION
Bump chapeldomain requiremnts to use version 0.0.30, which brings in a fix for https://github.com/chapel-lang/chapel/issues/18469

resolves https://github.com/chapel-lang/chapel/issues/18469

tested locally

[reviewed by @]