### PR TITLE
Dyno: Fix default calls to initializers to only pass type/param fields

### DIFF
--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -475,8 +475,11 @@ void CallInitDeinit::resolveDefaultInit(const VarLikeDecl* ast, RV& rv) {
       for (const auto& pair : subs) {
         const ID& id = pair.first;
         const QualifiedType& qt = pair.second;
-        UniqueString fname = parsing::fieldIdToName(context, id);
-        actuals.push_back(CallInfoActual(qt, fname));
+        auto fieldAst = parsing::idToAst(context, id)->toVarLikeDecl();
+        if (fieldAst->storageKind() == QualifiedType::TYPE ||
+            fieldAst->storageKind() == QualifiedType::PARAM) {
+          actuals.push_back(CallInfoActual(qt, fieldAst->name()));
+        }
       }
     }
 

--- a/frontend/test/resolution/testCallInitDeinit.cpp
+++ b/frontend/test/resolution/testCallInitDeinit.cpp
@@ -1514,6 +1514,32 @@ static void test18b() {
     });
 }
 
+static void test19() {
+  testActions("test19",
+      R"""(
+      record G {
+        type T;
+        var y : T;
+      }
+
+      record R {
+        type T;
+        var x : G(T);
+      }
+
+      proc R.init(type T) {
+        this.T=T;
+      }
+
+      proc test() {
+        var r : R(int);
+      }
+      )""", {
+        {AssociatedAction::DEFAULT_INIT, "r",          ""},
+        {AssociatedAction::DEINIT,       "test19.test@4",   "r"}
+      } );
+}
+
 // calling function with 'out' intent formal
 
 // calling functions with 'inout' intent formal
@@ -1593,6 +1619,8 @@ int main() {
 
   test18a();
   test18b();
+
+  test19();
 
   return 0;
 }


### PR DESCRIPTION
This PR fixes the invocation of default initializers to only pass type and param arguments, rather than passing something for each "substitution" in the generic type.

Testing:
- [x] full local