### PR TITLE
Dyno: Fix bug involving type queries and fields depending on generic types.

### DIFF
--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -3351,7 +3351,10 @@ void Resolver::exit(const Call* call) {
       if (t != nullptr && t->isErroneousType()) {
         // always skip if there is an ErroneousType
         skip = ERRONEOUS_ACT;
-      } else if (!toId.isEmpty() && !isNonOutFormal) {
+      } else if (!toId.isEmpty() && !isNonOutFormal &&
+                 qt.kind() != QualifiedType::PARAM &&
+                 qt.kind() != QualifiedType::TYPE &&
+                 qt.isRef() == false) {
         // don't skip because it could be initialized with 'out' intent,
         // but not for non-out formals because they can't be split-initialized.
       } else {

--- a/frontend/test/resolution/testTypeOperators.cpp
+++ b/frontend/test/resolution/testTypeOperators.cpp
@@ -64,7 +64,7 @@ static void test3() {
   auto context = &ctx;
   QualifiedType qt1 =  resolveTypeOfXInit(context,
                          R""""(
-                         param p : int;
+                         param p : int = 0;
                          var x = p == 1;
                          )"""");
   assert(qt1.isParamFalse());

--- a/frontend/test/resolution/testTypeQueries.cpp
+++ b/frontend/test/resolution/testTypeQueries.cpp
@@ -558,6 +558,34 @@ static void test17() {
   assert(qt.isErroneousType());
 }
 
+static void test18() {
+  printf("test17\n");
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  auto qt = resolveQualifiedTypeOfX(context, R"""(
+    proc foo(param val: bool) type {
+      if val then return string;
+      else return int;
+    }
+
+    record R {
+      param val : bool;
+      var data : foo(val);
+    }
+
+    proc helper(arg: R(?val)) {
+      return arg.data;
+    }
+
+    var r : R(true);
+    var x = helper(r);
+    )""");
+
+  assert(qt.type()->isStringType());
+}
+
 int main() {
   test1();
   test2();
@@ -578,6 +606,7 @@ int main() {
   test15();
   test16();
   test17();
+  test18();
 
   return 0;
 }


### PR DESCRIPTION
This PR fixes a dyno bug in which we would incorrectly attempt to instantiate types with an un-substituted type query, which could result in false errors. For example, in the following snippet, the compiler would encounter errors when resolving the ``data`` field. This was because at a particular stage of resolution we don't know the type of ``?val``, but resolution was trying to instantiate the expression ``R(?val)`` anyways.

```chpl
    record R {
      param val : bool;
      var data : foo(val);
    }
    proc helper(arg: R(?val)) {
      return arg.data;
    }
```

This PR resolves this issue by adjusting the cases in which we will "skip" resolution of an expression during certain preliminary stages of resolving a function signature.

Testing:
- [x] full local