### PR TITLE
Tweak css for chpldoc to fix spacing

### DIFF
--- a/doc/rst/meta/static/style.css
+++ b/doc/rst/meta/static/style.css
@@ -15,3 +15,7 @@
 /* Inlined code is black (instead of default red) */
 .pre{ color: #000}
 
+/* Override the default padding added by the RTD theme so that procs render nicely */
+em.property {
+  padding-right: 0px !important;
+}

--- a/doc/rst/meta/static/style.css
+++ b/doc/rst/meta/static/style.css
@@ -16,6 +16,6 @@
 .pre{ color: #000}
 
 /* Override the default padding added by the RTD theme so that procs render nicely */
-em.property {
+.sig.sig-object.chpl em.property:not(:first-child) {
   padding-right: 0px !important;
 }

--- a/doc/rst/meta/static/style.css
+++ b/doc/rst/meta/static/style.css
@@ -15,7 +15,12 @@
 /* Inlined code is black (instead of default red) */
 .pre{ color: #000}
 
-/* Override the default padding added by the RTD theme so that procs render nicely */
+/*
+Override the default padding added by the RTD theme so that procs render
+nicely. This fixes an issue where the padding before a `where` is too large and
+looks funky. Note this should run on everything but the first child
+(`proc`/`iter`) so it is unaffected.
+*/
 .sig.sig-object.chpl em.property:not(:first-child) {
   padding-right: 0px !important;
 }


### PR DESCRIPTION
This PR adjusts the default css theme for the sphinx docs to not have extra padding on some procs

Before:
<img width="550" alt="Screenshot 2024-03-04 at 4 51 18 PM" src="https://github.com/chapel-lang/chapel/assets/15747900/134fea7d-9ccd-41f3-93db-ba9db9144e33">

After:
<img width="520" alt="Screenshot 2024-03-04 at 4 50 45 PM" src="https://github.com/chapel-lang/chapel/assets/15747900/1a804b07-5b12-42e0-a446-98bcf88d4fba">

Tested in firefox and chrome

[Reviewed by @lydia-duncan]