### PR TITLE
Cache results from calls to getConfigParamBool

### DIFF
--- a/compiler/include/config.h
+++ b/compiler/include/config.h
@@ -31,7 +31,7 @@ Expr* getCmdLineConfig(const char *);
 void  useCmdLineConfig(const char *, VarSymbol*);
 VarSymbol* isUsedCmdLineConfig(const char *);
 bool isSetCmdLineConfig(const char *, const char *);
-VarSymbol* getConfigParamBool(ModuleSymbol*, const char*,VarSymbol*);
+VarSymbol* getConfigParamBool(ModuleSymbol*, const char*);
 
 extern bool mainHasArgs;
 extern bool mainPreserveDelimiter;

--- a/compiler/main/config.cpp
+++ b/compiler/main/config.cpp
@@ -95,16 +95,26 @@ bool isSetCmdLineConfig(const char* moduleName, const char* paramName) {
   return false;
 }
 
-
-VarSymbol* getConfigParamBool(ModuleSymbol* modSym, const char* configParamName,
-                              VarSymbol* cachedValue) {
+// Any call to this function MUST cache the result in a local variable
+// Ex:
+// bool usePointerImplementation(void) {
+//   static bool flag = false;
+//   static bool flagLegal = false;
+//   if(!flagLegal) {
+//     flag = getConfigParamBool(baseModule,"flag") == gTrue;
+//     flagLegal = true;
+//   }
+//   return flag;
+// }
+VarSymbol* getConfigParamBool(ModuleSymbol* modSym, const char* configParamName) {
 
   // TODO: This is O(n) number of params, we need a better way to look
   // things up after resolve. I think that 'dyno' can always do the
   // elegant thing here. Just preserve the ID for 'ChapelBase', and then
   // use it in conjunction with a lookup for the config name. You fetch
   // the 'ResolvedExpression' and you're done.
-  if (!cachedValue) {
+  VarSymbol* retVal = nullptr;
+  if (!retVal) {
     if (!modSym->initFn || !modSym->initFn->isResolved()) {
       INT_FATAL(modSym, "Called before '%s' is resolved",
                         modSym->name);
@@ -119,20 +129,20 @@ VarSymbol* getConfigParamBool(ModuleSymbol* modSym, const char* configParamName,
             INT_FATAL("Unexpected config param type or bad AST");
             return nullptr;
           }
-          cachedValue = vs;
+          retVal = vs;
           break;
         }
       }
     }
 
     // Provide a hint, just in case.
-    if (!cachedValue) {
+    if (!retVal) {
       INT_FATAL("Could not find '%s', is it declared in '%s'?",
                 configParamName,
                 modSym->name);
     }
   }
-  return cachedValue;
+  return retVal;
 }
 
 

--- a/compiler/resolution/fcf-support.cpp
+++ b/compiler/resolution/fcf-support.cpp
@@ -971,8 +971,14 @@ const std::vector<FnSymbol*>& ClosureEnv::childFunctions() const {
 ************************************** | *************************************/
 
 bool usePointerImplementation(void) {
-  return getConfigParamBool(baseModule, "fcfsUsePointerImplementation",
-         /*cachedValue*/nullptr) == gTrue;
+  static bool fcfsUsePointerImplementation = false;
+  static bool fcfsUsePointerImplementationLegal = false;
+  if(!fcfsUsePointerImplementationLegal) {
+    fcfsUsePointerImplementation = getConfigParamBool(baseModule,
+        "fcfsUsePointerImplementation") == gTrue;
+    fcfsUsePointerImplementationLegal = true;
+  }
+  return fcfsUsePointerImplementation;
 }
 
 Expr* createFunctionClassInstance(FnSymbol* fn, Expr* use) {

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -14328,8 +14328,7 @@ static bool assocParSafeWarningSilencedByUser(){
     // These checks are expensive so we do them only once
     silencedParSafeWarningLegal = true;
     VarSymbol* noParSafeWarning = getConfigParamBool(baseModule,
-                                                    "noParSafeWarning",
-                                                    /*cachedValue*/nullptr);
+                                                    "noParSafeWarning");
     bool assocParSafeDefaultSet = isSetCmdLineConfig(
                                 /*modName*/"ChapelBase",
                                 /*paramName*/"assocParSafeDefault");


### PR DESCRIPTION
The `getConfigParamBool` function is an expensive operation to get the value of a `config param` which iterates over the `paramMap` in the compiler. This means that we want every place which calls this function to cache the result for later use. So far, there are only two uses of this function which cache the result as of this commit.