### PR TITLE
Update CI actions to use checkout@V4 to resolve node.js warning

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,7 +26,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: make check
       run: |
         ./util/buildRelease/smokeTest chpl
@@ -39,7 +39,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
     steps:
-    - uses: actions/checkout@v3 
+    - uses: actions/checkout@v4
     - name: make frontend-docs
       run: |
         make frontend-docs
@@ -61,7 +61,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: make mason
       # Use a quickstart config to keep it from running to long
       # While there, run a make check in that config for more coverage
@@ -76,7 +76,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: make test-dyno-with-asserts
       run: |
         CHPL_HOME=$PWD make DYNO_ENABLE_ASSERTIONS=1 test-dyno -j`util/buildRelease/chpl-make-cpu_count`
@@ -99,7 +99,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: set llvm_none make check
       run: |
        CHPL_LLVM=none ./util/buildRelease/smokeTest chpl
@@ -111,7 +111,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 100000
     - name: Set ownership

--- a/.github/workflows/build-CI-container.yml
+++ b/.github/workflows/build-CI-container.yml
@@ -34,7 +34,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1.14.1
         with:

--- a/.github/workflows/email.yml
+++ b/.github/workflows/email.yml
@@ -5,44 +5,44 @@ on:
     pull_request_target:
       types:
         - closed
-      
-jobs: 
+
+jobs:
   send_email:
-   # run this workflow step only when the PR is merged 
-    if:  github.event.pull_request.merged == true 
-    runs-on: ubuntu-latest 
+   # run this workflow step only when the PR is merged
+    if:  github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
     steps:
       - name: print git events
-        run:  cat "$GITHUB_EVENT_PATH"                     
+        run:  cat "$GITHUB_EVENT_PATH"
       - name: print GitHub context
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT" 
+        run: echo "$GITHUB_CONTEXT"
      # This workflow step will parse github env. The parsed env will be used in the email body.
       - name: get commits payload
         id: build-payload
         env:
            PR_LINK: ${{github.event.pull_request._links.html.href}}
-        run: |      
-              echo "LINK=$(echo $PR_LINK )" >> $GITHUB_ENV   
+        run: |
+              echo "LINK=$(echo $PR_LINK )" >> $GITHUB_ENV
               echo "AUTHOR=$(echo ${{github.event.pull_request.head.user.login}})" >> $GITHUB_ENV
-              echo "COMPARE_URL= $( echo '${{github.event.repository.html_url}}/compare/${{github.event.pull_request.base.sha}}...${{github.event.pull_request.head.sha}}' )" >> $GITHUB_ENV      
-              echo "FILES_CHANGED=$(echo '$PR_LINK/files' )" >> $GITHUB_ENV     
-  
+              echo "COMPARE_URL= $( echo '${{github.event.repository.html_url}}/compare/${{github.event.pull_request.base.sha}}...${{github.event.pull_request.head.sha}}' )" >> $GITHUB_ENV
+              echo "FILES_CHANGED=$(echo '$PR_LINK/files' )" >> $GITHUB_ENV
+
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         # To get git diff on the files that were changed in the PR checkout with fetch-depth 2.
         with:
-          fetch-depth: 0 
-      # this step will (1) get the merge log for the merge_commit_sha and save it to the git  actions EN for later use in the email body. 
+          fetch-depth: 0
+      # this step will (1) get the merge log for the merge_commit_sha and save it to the git  actions EN for later use in the email body.
       # (2) Get the files changed on the merge commit using the git log --name-status command.
       - name: Get merge log
         id: merge-log
         env:
            MERGE_SHA: ${{github.event.pull_request.merge_commit_sha}}
-        run: |   
+        run: |
               merge_log=$(git show -s --format=%B $MERGE_SHA )
-              echo "$merge_log" 
+              echo "$merge_log"
               echo 'MERGE<<EOF' >> $GITHUB_ENV
               echo "$merge_log" >> $GITHUB_ENV
               echo 'EOF' >> $GITHUB_ENV
@@ -52,12 +52,12 @@ jobs:
               diff_max_lines=1000
               diff=$(echo "$diff" | awk "NR <= $diff_max_lines; NR > $diff_max_lines { print \"(diff output truncated at $diff_max_lines lines)\"; exit }")
 
-              echo "$diff" 
+              echo "$diff"
               echo 'DIFF<<EOF' >> $GITHUB_ENV
               echo "$diff" >> $GITHUB_ENV
-              echo 'EOF' >> $GITHUB_ENV                   
-      
-      - name: Send mail  
+              echo 'EOF' >> $GITHUB_ENV
+
+      - name: Send mail
         uses: dawidd6/action-send-mail@v3
         with:
            # Required mail server address if not connection_url:
@@ -66,7 +66,7 @@ jobs:
            # Optional whether this connection use TLS (default is true if server_port is 465)
            secure: true
            # Optional (recommended): mail server username:
-           username:  ${{ secrets.MAIL_USERNAME}} 
+           username:  ${{ secrets.MAIL_USERNAME}}
            # Optional (recommended) mail server password:
            password: ${{secrets.MAIL_PASSWORD}}
            # Required mail subject:
@@ -76,18 +76,18 @@ jobs:
            # Required sender full name (address can be skipped):
            from:  ${{env.AUTHOR}}
            body: |
-              
-              Branch: ${{github.ref}} 
-              Revision: ${{ github.event.pull_request.merge_commit_sha }} 
-              Author: ${{ env.AUTHOR}} 
-              Link: ${{github.event.pull_request._links.html.href}}              
-              Log Message: 
-              ${{env.MERGE}} 
+
+              Branch: ${{github.ref}}
+              Revision: ${{ github.event.pull_request.merge_commit_sha }}
+              Author: ${{ env.AUTHOR}}
+              Link: ${{github.event.pull_request._links.html.href}}
+              Log Message:
+              ${{env.MERGE}}
 
               Compare: ${{env.COMPARE_URL}}
 
-              Diff: 
-                       ${{env.DIFF}} 
+              Diff:
+                       ${{env.DIFF}}
                        ${{github.event.pull_request.diff_url}}
            # Optional priority: 'high', 'normal' (default) or 'low'
            priority: low


### PR DESCRIPTION
Github's CI migrated to a new version of node.js and this causes
warnings on our CI jobs.   The new version of the checkout action
picks up this new version of node to resolve the warnings.