### PR TITLE
Skip 1BRC tests in valgrind config

### DIFF
--- a/test/studies/1brc/SKIPIF
+++ b/test/studies/1brc/SKIPIF
@@ -12,6 +12,11 @@ if [[ ${CHPL_NIGHTLY_TEST_CONFIG_NAME} == "valgrind" ]]; then
   exit
 fi
 
+if [[ ${CHPL_TEST_VGRND_EXE} == "on" ]]; then
+  echo "True"
+  exit
+fi
+
 # If we've already generated the input dataset no need to regenerate it
 if [[ -e measurements.txt ]]; then
   echo "False"


### PR DESCRIPTION
Add check for `CHPL_TEST_VGRND_EXE` to the 1brc skipif file. Should prevent these tests from running and timing out in the valgrind test config.