### PR TITLE
Fix regular expressions in usemath test with updated chapeldomain

### DIFF
--- a/test/library/standard/Math/docs/usemath.doc.prediff
+++ b/test/library/standard/Math/docs/usemath.doc.prediff
@@ -72,11 +72,11 @@ for l in lines:
             name = m.group(1)
             sets[state].add(name)
         # add params
-        for m in re.finditer(r'param (\S*?) =', l):
+        for m in re.finditer(r'param (\S*?) +=', l):
             name = m.group(1)
             sets[state].add(name)
         # parenless proc params
-        for m in re.finditer(r'proc (\S*?) param', l):
+        for m in re.finditer(r'proc (\S*?) +param', l):
             name = m.group(1)
             sets[state].add(name)
         # check for deprecated and remove


### PR DESCRIPTION
Updates to `chapeldomain` changed the plaintext output of documentation, which broke the regexes that processed that structure. This PR fixes the regexes -- by adding "one or more spaces" instead of "one space".

Reviewed by @jabraham17 -- thanks!