### PR TITLE
update v1.34 - v2.0 in several places

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,8 +35,8 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 # Handle all (most?) the versioning information in one place
 # These values will be written to <build_dir>/frontend/include/chpl/config/config.h
 
-set(CHPL_MAJOR_VERSION 1)
-set(CHPL_MINOR_VERSION 34)
+set(CHPL_MAJOR_VERSION 2)
+set(CHPL_MINOR_VERSION 0)
 set(CHPL_PATCH_VERSION 0)
 set(CHPL_BUILD_VERSION 0)
 

--- a/doc/rst/language/evolution.rst
+++ b/doc/rst/language/evolution.rst
@@ -14,7 +14,7 @@ The purpose of this flag is to identify portions of a program that use a
 language or library feature has recently changed meaning or which is
 expected to change meaning in the future.
 
-version 1.34, March 2024
+version 2.0, March 2024
 ------------------------
 
 .. _readme-evolution.default-task-intent-arrays:
@@ -22,7 +22,7 @@ version 1.34, March 2024
 Default task intents for arrays
 *******************************
 
-In 1.34, the default task intent for an array is now determined by the outer
+In 2.0, the default task intent for an array is now determined by the outer
 variable. If the outer array is ``const`` then the default intent is ``const``,
 otherwise the default intent is ``ref``. Therefore, if an array is modifiable
 outside a parallel block, it is modifiable inside the parallel block. It is no
@@ -44,8 +44,8 @@ The default task intent for ``A`` is ``ref``, since the argument formal ``A``
 is mutable. This simplifies parallel code, making it simpler and cleaner to
 write.
 
-Prior to 1.34, the above ``begin`` would have resulted in a deprecation
-warning. In 1.34, this is valid code again.
+Prior to 2.0, the above ``begin`` would have resulted in a deprecation
+warning. In 2.0, this is valid code again.
 
 version 1.32, September 2023
 ----------------------------

--- a/doc/rst/technotes/driver.rst
+++ b/doc/rst/technotes/driver.rst
@@ -21,7 +21,7 @@ subprocesses depending on which backend is used. By contrast, many compiler
 executables (including ``gcc`` and ``clang``) are actually `compiler drivers`.
 A compiler driver is a smaller program responsible for processing arguments and
 invoking separate processes for the different stages of compilation required. As
-of release 1.34, ``chpl`` runs as a compiler driver by default, with the
+of release 2.0, ``chpl`` runs as a compiler driver by default, with the
 following phases run as separate subprocesses:
 
 - ``compilation``: Everything through code generation (C code or LLVM bitcode).
@@ -82,7 +82,7 @@ Development History
   phases: `compilation`, which is responsible for everything through code
   generation (C code or LLVM bitcode), and `makeBinary`, which is responsible
   for binary generation (including linking).
-- In release 1.34, the driver mode is on by default, and the
+- In release 2.0, the driver mode is on by default, and the
   ``--compiler-driver`` flag is unstable. The new unstable
   ``--no-compiler-driver`` flag allows opting out of the driver mode and will
   cause the compiler to run monolithically as before. Both flags will be removed

--- a/doc/rst/technotes/ioSerializers.rst
+++ b/doc/rst/technotes/ioSerializers.rst
@@ -50,7 +50,7 @@ serialization and deserialization.
 In Chapel 1.32, Serializers and Deserializers are enabled by default. Users
 wishing to opt-out of this capability can recompile their programs with
 the config param ``useIOSerializers`` set to ``false``. This config param
-will be available through the Chapel 1.34 release at minimum.
+will be available through the Chapel 2.0 release at minimum.
 
 API Changes to Standard IO
 --------------------------

--- a/frontend/lib/uast/post-parse-checks.cpp
+++ b/frontend/lib/uast/post-parse-checks.cpp
@@ -691,7 +691,7 @@ void Visitor::checkSparseKeyword(const FnCall* node) {
                " their behavior is likely to change in the future.");
 }
 
-// TODO: remove this check and warning after 1.34?
+// TODO: remove this check and warning after 2.0?
 void Visitor::checkPrimCallInUserCode(const PrimCall* node) {
   // suppress this warning from chpldoc
   if (isUserCode())
@@ -1648,7 +1648,7 @@ void Visitor::checkOtherwiseAfterWhens(const Select* sel) {
     if (seenOtherwise && !when->isOtherwise()) {
       CHPL_REPORT(context_, WhenAfterOtherwise, sel, seenOtherwise, when);
       break;
-    } 
+    }
     if (when->isOtherwise())  seenOtherwise = when;
   }
 }

--- a/man/confchpl.rst
+++ b/man/confchpl.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.34.0 pre-release 
+:Version: 2.0.0 pre-release
 :Manual section: 1
 :Title: \\fBchpl\\fP
 :Subtitle: Compiler for the Chapel Programming Language

--- a/man/confchpldoc.rst
+++ b/man/confchpldoc.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.34.0 pre-release
+:Version: 2.0.0 pre-release
 :Manual section: 1
 :Title: \\fBchpldoc\\fP
 :Subtitle: the Chapel Documentation Tool

--- a/test/compflags/bradc/printstuff/version.goodstart
+++ b/test/compflags/bradc/printstuff/version.goodstart
@@ -1,1 +1,1 @@
- version 1.34.0
+ version 2.0.0

--- a/test/deprecated/chplCommGetPut.chpl
+++ b/test/deprecated/chplCommGetPut.chpl
@@ -1,7 +1,7 @@
 /*
  Test to make sure we do/don't warn about the changed behavior (depending on
  if using chpl or chpldoc) in these primitives from v1.31 to v1.32.
- Should remove when we stop warning about the change, likely with v1.34.
+ Should remove when we stop warning about the change.
 */
 
 inline proc GET(addr, node, rAddr, size) {

--- a/test/mason/chplVersion/tomls/pass/ivrsChooses.good
+++ b/test/mason/chplVersion/tomls/pass/ivrsChooses.good
@@ -10,18 +10,18 @@ version = "0.1.0"
 chplVersion = "CHPL_CUR_FULL..CHPL_CUR_FULL"
 name = "badThenGood"
 source = "foo"
-version = "0.2.0"
+version = "0.3.0"
 
 [usesBad]
 chplVersion = "CHPL_CUR_FULL..CHPL_CUR_FULL"
-dependencies = ["badThenGood 0.2.0 foo"]
+dependencies = ["badThenGood 0.3.0 foo"]
 name = "usesBad"
 source = "foo"
 version = "0.1.0"
 
 [usesGood]
 chplVersion = "CHPL_CUR_FULL..CHPL_CUR_FULL"
-dependencies = ["badThenGood 0.2.0 foo"]
+dependencies = ["badThenGood 0.3.0 foo"]
 name = "usesGood"
 source = "foo"
 version = "0.1.0"


### PR DESCRIPTION
This PR updates the Chapel version number in advance of the release of Chapel 2.0.

Updates to the major version were caught in mason tests which check for compatibility of package dependencies w.r.t the chapel version. I updated the `.good` file to expect a more recent version of the dependency, based on the updated version of Chapel



TESTING:
- [x] paratest `[Summary: #Successes = 17145 | #Failures = 0 | #Futures = 917]`
- [x] make docs, ensure 2.0 displayed instead of 1.34

[reviewed by @mppf - thanks!]