### PR TITLE
Resolve asan failure originating in `random.sample`

### DIFF
--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -1008,7 +1008,7 @@ module Random {
     /*
       Sample ``n`` random indices from a domain.
 
-      :arg d: The 1D rectangular domain to sample from. Its ``idxType`` should:q:q
+      :arg d: The 1D rectangular domain to sample from. Its ``idxType`` should
               be coercible from this stream's ``eltType``.
       :arg n: The number of indices to sample
       :arg withReplacement: Whether or not to sample with replacement

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -993,8 +993,6 @@ module Random {
     proc ref sample(const ref arr: [?d] ?t, n: int, withReplacement=false): [] t throws
       where is1DRectangularDomain(d) && isCoercible(this.eltType, d.idxType)
     {
-      use CopyAggregation;
-
       if d.size < 1 then
         throw new IllegalArgumentError("Cannot sample from an empty array");
 
@@ -1003,15 +1001,14 @@ module Random {
 
       const ds = this.sample(d, n, withReplacement);
       var res: [0..<n] t;
-      forall (i, di) in zip(res.domain, ds) with (var agg = new DstAggregator(t))
-        do agg.copy(res[i], arr[di]); // res[i] = arr[di];
+      forall (i, di) in zip(res.domain, ds) do res[i] = arr[di];
       return res;
     }
 
     /*
       Sample ``n`` random indices from a domain.
 
-      :arg d: The 1D rectangular domain to sample from. Its ``idxType`` should
+      :arg d: The 1D rectangular domain to sample from. Its ``idxType`` should:q:q
               be coercible from this stream's ``eltType``.
       :arg n: The number of indices to sample
       :arg withReplacement: Whether or not to sample with replacement


### PR DESCRIPTION
`Random.sample` was using a `DstAggregator` where it should have been using a `SrcAggregator` which was causing a segfault in some multi-locale configurations.

This PR removes the use of aggregators from `Random.sample` all together, where it could be reintroduced later as a performance optimization.

- [x] all Random module tests passing