### PR TITLE
Make 'main' version of docs 2.0 pre-release

### DIFF
--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -76,12 +76,12 @@ master_doc = 'index'
 # 'version' adds a redundant version number onto the top of the sidebar
 # automatically (rtd-theme). We also don't use |version| anywhere in rst
 
-chplversion = '1.34'                  # TODO -- parse from `chpl --version`
+chplversion = '2.0'                  # TODO -- parse from `chpl --version`
 shortversion = chplversion.replace('-', '&#8209') # prevent line-break at hyphen, if any
 html_context = {"chplversion":chplversion}
 
 # The full version, including alpha/beta/rc tags.
-release = '1.34.0 (pre-release)'
+release = '2.0.0 (pre-release)'
 #release = '1.33.0'
 
 # General information about the project.

--- a/doc/util/versionButton.php
+++ b/doc/util/versionButton.php
@@ -88,8 +88,8 @@ if (pagePath == "") {
 }
 function dropSetup() {
   var currentRelease = "1.33"; // what does the public have?
-  var stagedRelease = "1.34";  // is there a release staged but not yet public?
-  var nextRelease = "1.34";    // what's the next release? (on docs/main)
+  var stagedRelease = "2.0";  // is there a release staged but not yet public?
+  var nextRelease = "2.0";    // what's the next release? (on docs/main)
   var button = document.getElementById("versionButton");
   // Uses unicode down-pointing triangle
   var arrow = " &#9660;";


### PR DESCRIPTION
When doing the 1.33 release, we conservatively set the 'main' version of the docs to be 1.34 pre-release.  Now that we're more confident that this month's release will be 2.0, this PR bumps the menu to refer to it as "2.0 pre-release".
