### PR TITLE
Promote a foreach intent future into a test

### DIFF
--- a/test/performance/vectorization/vectorizeOnly/vectorizeOnlyWithIntents.future
+++ b/test/performance/vectorization/vectorizeOnly/vectorizeOnlyWithIntents.future
@@ -1,3 +1,0 @@
-unimplemented feature: outer scope intents for 'foreach' loops
-
-#18500


### PR DESCRIPTION
This future passes as of the addition of implicit foreach intents in https://github.com/chapel-lang/chapel/pull/24451.