### PR TITLE
Remove debugging code that seeped in inadvertently

### DIFF
--- a/compiler/main/runpasses.cpp
+++ b/compiler/main/runpasses.cpp
@@ -243,8 +243,6 @@ static void runPass(PhaseTracker& tracker, size_t passIndex) {
   if (fPrintStatistics[0] != '\0' && passIndex > 0)
     printStatistics("clean");
 
-  breakOnID = 28241;
-
   (*(info->passFunction))();
 
   //


### PR DESCRIPTION
This code seeped in in https://github.com/chapel-lang/chapel/pull/24451. My bad!