### PR TITLE
Update the spec description of numeric types

### DIFF
--- a/doc/rst/language/spec/conversions.rst
+++ b/doc/rst/language/spec/conversions.rst
@@ -679,6 +679,9 @@ for converting from real, except that the imaginary part of the result
 is set using the input value, and the real part of the result is set to
 zero.
 
+Explicitly converting between ``real(k)`` and ``imag(k)`` will copy the
+represented number while changing whether or not it is imaginary.
+
 .. _Explicit_Tuple_to_Complex_Conversion:
 
 Explicit Tuple to Complex Conversion

--- a/doc/rst/language/spec/types.rst
+++ b/doc/rst/language/spec/types.rst
@@ -208,10 +208,11 @@ not initialized to something else (see also :ref:`Chapter-Variables`).
       var z: bool;
 
    All three variables have type ``bool``.  Note that the types of ``x``
-   an ``y`` are optional; the program indicates the type of ``x`` but
-   infers the type of ``y``.  See :ref:`Chapter-Variables` for more
-   details. The last variable is initialized to the default value of
-   ``bool``, which is ``false`` (see :ref:`Default_Values_For_Types`).
+   and ``y`` are optional; the program indicates the type of ``x`` but
+   the compiler infers the type of ``y``.  See :ref:`Chapter-Variables`
+   for more details. The last variable is initialized to the default
+   value of ``bool``, which is ``false`` (see
+   :ref:`Default_Values_For_Types`).
 
    .. BLOCK-test-chapelpost
 
@@ -236,7 +237,7 @@ represent them. Valid bit-sizes are 8, 16, 32, and 64. The default
 signed integral type, ``int``, is a synonym for ``int(64)``; and the
 default unsigned integral type, ``uint``, is a synonym for ``uint(64)``.
 
-Variables of integral have a default value of ``0`` if they are
+Variables of integral type have a default value of ``0`` if they are
 not initialized to something else (see also :ref:`Chapter-Variables`).
 
 The integral types and their ranges are given in the following table:
@@ -339,8 +340,8 @@ without an exponent (see :ref:`Literals` for details):
 
    *Example (harmonic.chpl)*.
 
-   For example, this program computes the first ``n`` terms of harmonic
-   series.
+   For example, this program computes the first ``n`` terms of the
+   harmonic series.
 
    First, it defines a ``config const`` to allow setting the value of
    ``n`` on the command line (see :ref:`Variable_Declarations`):

--- a/doc/rst/language/spec/types.rst
+++ b/doc/rst/language/spec/types.rst
@@ -110,9 +110,31 @@ See :ref:`Compile-Time_Constants`
 The Void Type
 ~~~~~~~~~~~~~
 
-The ``void`` type is used to represent the lack of a value, for example
-when a function has no arguments and/or no return type. It is an error
-to assign the result of a function that returns ``void`` to a variable.
+The ``void`` type is used to represent the lack of a value. It is
+primarily used to indicate that a function does not return anything.
+
+   *Example (returnVoid.chpl)*.
+
+   For example, the below declares ``f`` to return ``void``:
+
+   .. code-block:: chapel
+
+      proc f() : void { }
+
+   The compiler can infer the return type of ``void`` as well. See
+   See :ref:`Return_Types` for more information.
+
+   .. BLOCK-test-chapelpost
+
+      f();
+      writeln("done");
+
+   .. BLOCK-test-chapeloutput
+
+      done
+
+It is an error to assign the result of a function that returns ``void``
+to a variable.
 
 .. _The_Nothing_type:
 
@@ -133,6 +155,29 @@ representation at run-time.
    The ``nothing`` type can be used to conditionally remove a variable
    or field from the code based on a ``param`` conditional expression.
 
+   *Example (noneNothing.chpl)*.
+
+   The ``nothing`` type and ``none`` values typically come up in a
+   generic programming context (see also :ref:`Chapter-Generics`). For
+   example, the following program defines a generic function ``g`` that
+   can determine if it was called with an integer or with ``none``:
+
+   .. code-block:: chapel
+
+      proc g(arg) {
+        if arg.type != nothing {
+          writeln(arg);
+        }
+      }
+      g(1);    // outputs 1
+      g(none); // does not create output
+
+   .. BLOCK-test-chapeloutput
+
+       1
+
+
+
 .. _The_Bool_Type:
 
 The Bool Type
@@ -147,6 +192,40 @@ Some statements require expressions of ``bool`` type and Chapel supports
 a special conversion of values to ``bool`` type when used in this
 context (:ref:`Implicit_Statement_Bool_Conversions`).
 
+Variables of type ``bool`` have a default value of ``false`` if they are
+not initialized to something else (see also :ref:`Chapter-Variables`).
+
+   *Example (bools.chpl)*.
+
+   This program demonstrates creating a variable with type ``bool`` and
+   setting it to ``true``, and then setting another variable to the
+   logical negation of it:
+
+   .. code-block:: chapel
+
+      var x: bool = true;
+      var y = !x;
+      var z: bool;
+
+   All three variables have type ``bool``.  Note that the types of ``x``
+   an ``y`` are optional; the program indicates the type of ``x`` but
+   infers the type of ``y``.  See :ref:`Chapter-Variables` for more
+   details. The last variable is initialized to the default value of
+   ``bool``, which is ``false`` (see :ref:`Default_Values_For_Types`).
+
+   .. BLOCK-test-chapelpost
+
+      writeln(x);
+      writeln(y);
+      writeln(z);
+
+   .. BLOCK-test-chapeloutput
+
+      true
+      false
+      false
+
+
 .. _Signed_and_Unsigned_Integral_Types:
 
 Signed and Unsigned Integral Types
@@ -156,6 +235,9 @@ The integral types can be parameterized by the number of bits used to
 represent them. Valid bit-sizes are 8, 16, 32, and 64. The default
 signed integral type, ``int``, is a synonym for ``int(64)``; and the
 default unsigned integral type, ``uint``, is a synonym for ``uint(64)``.
+
+Variables of integral have a default value of ``0`` if they are
+not initialized to something else (see also :ref:`Chapter-Variables`).
 
 The integral types and their ranges are given in the following table:
 
@@ -175,11 +257,54 @@ uint(64), uint 0                    18446744073709551615
 Integer literals such as `3` have type ``int``. However, such literals
 can implicitly convert to other numeric types that can losslessly store
 the value. See :ref:`Implicit_Compile_Time_Constant_Conversions`.
+Integer literals can be written in hexadecimal, octal, or binary. See
+:ref:`Literals`.
+
+Signed or unsigned integral types of smaller width can implicitly convert
+to signed integral types of larger width.  Additionally, unsigned
+integral types of a smaller width can implicitly convert to an unsigned
+integral type of larger width. See :`Implicit_NumBool_Conversions` for
+details.
 
 It is possible for overflow to occur with binary operators on integers.
 For signed integers, overflow leads to undefined behavior. For unsigned
-integers, overflow leads to wrapping according to two's complement
-arithmetic.
+integers, overflow leads to wrapping since any bits not representable
+will be discarded.
+
+   *Example (integers.chpl)*.
+
+   Here, ``x`` is inferred to have type ``int``:
+
+   .. code-block:: chapel
+
+      var x = 1;
+
+   and ``y`` is initialized by converting ``2`` to a ``uint(8)``:
+
+   .. code-block:: chapel
+
+      var y:uint(8) = 2;
+
+   Then, ``z`` is set to an expression that would evaluate to ``257``,
+   but that is not representable as a ``uint(8)``, so it results in the
+   wrapped value ``1``.
+
+   .. code-block:: chapel
+
+      var z = 255 + y;
+
+   .. BLOCK-test-chapelpost
+
+      writeln("x = ", x, " : ", x.type:string);
+      writeln("y = ", y, " : ", y.type:string);
+      writeln("z = ", z, " : ", z.type:string);
+
+   .. BLOCK-test-chapeloutput
+
+      x = 1 : int(64)
+      y = 2 : uint(8)
+      z = 1 : uint(8)
+
 
 
 .. _Real_Types:
@@ -187,18 +312,81 @@ arithmetic.
 Real Types
 ~~~~~~~~~~
 
-Like the integral types, the real types can be parameterized by the
-number of bits used to represent them. The default real type, ``real``,
-is 64 bits. The real types that are supported are machine-dependent, but
-usually include ``real(32)`` (single precision) and ``real(64)`` (double
-precision) following the IEEE 754 standard.
+Unlike integral types, ``real`` types are floating point types that can
+store fractional values. Like the integral types, the real types can be
+parameterized by the number of bits used to represent them. The default
+real type, ``real``, is 64 bits. The real types that are supported are
+machine-dependent, but usually include ``real(32)`` (single precision)
+and ``real(64)`` (double precision) following the IEEE 754 standard.
+
+Variables of ``real`` type have a default value of ``0.0`` if they are
+not initialized to something else (see also :ref:`Chapter-Variables`).
+
+All integral types can implicitly convert to all ``real`` types, and
+``real(32)`` can implicitly convert to ``real(64)``. See
+:ref:`Implicit_NumBool_Conversions` for details.
+
+``real`` literals such as `5.2` have type ``real``. However, such literals
+can implicitly convert to other numeric types that can losslessly store
+the value. See :ref:`Implicit_Compile_Time_Constant_Conversions`.
+``real`` literals can be written in decimal or hexadecimal and with or
+without an exponent (see :ref:`Literals` for details):
+
+ * in decimal without an exponent, e.g. ``5.2``
+ * in decimal with an exponent, e.g. ``6.02e23``
+ * in hexadecimal without an exponent, e.g. ``0x2.fe``
+ * in hexadecimal with a decimal exponent, e.g. ``0x2.fep23``
+
+   *Example (harmonic.chpl)*.
+
+   For example, this program computes the first ``n`` terms of harmonic
+   series.
+
+   First, it defines a ``config const`` to allow setting the value of
+   ``n`` on the command line (see :ref:`Variable_Declarations`):
+
+   .. code-block:: chapel
+
+      config const n = 100;
+
+   Next, it declares a ``real`` variable. Since this variable isn't
+   initialized, it will be initialized to 0.0:
+
+   .. code-block:: chapel
+
+      var sum:real;
+
+   Then, it loops over the first `n` elements and adds them to the
+   sum (see also :ref:`The_For_Loop`):
+
+   .. code-block:: chapel
+
+      for i in 1..n {
+        sum += 1.0/i;
+      }
+
+   Note that it uses `1.0/i` in order to do a floating point division. If
+   it used `1/i`, it would do integer division (rounding towards zero),
+   which evaluates to 0 in this case.
+
+   Finally, it prints out the sum:
+
+   .. code-block:: chapel
+
+      writeln(sum);
+
+   .. BLOCK-test-chapeloutput
+
+      5.18738
+
 
 .. _Imaginary_Types:
 
 Imaginary Types
 ~~~~~~~~~~~~~~~
 
-The imaginary types can be parameterized by the number of bits used to
+Imaginary types are floating-point types, and similarly to ``real``
+types, they can be parameterized by the number of bits used to
 represent them. The default imaginary type, ``imag``, is 64 bits. The
 imaginary types that are supported are machine-dependent, but usually
 include ``imag(32)`` and ``imag(64)``.
@@ -208,6 +396,56 @@ include ``imag(32)`` and ``imag(64)``.
    The imaginary type is included to avoid numeric instabilities and
    under-optimized code stemming from always converting real values to
    complex values with a zero imaginary part.
+
+Imaginary literals can be created by appending ``i`` to a numeric
+literal; for example, ``0.6i``. Such literals have type ``imag``.
+However, such literals can implicitly convert to other numeric types that
+can losslessly store the value. See
+:ref:`Implicit_Compile_Time_Constant_Conversions`.  As with ``real``
+literals, imaginary literals can be written in decimal or hexadecimal and
+with or without an exponent (see :ref:`Literals` for details):
+
+Variables of ``imag`` type have a default value of ``0.0i`` if they are
+not initialized to something else (see also :ref:`Chapter-Variables`).
+
+It is possible to convert between a ``real`` value and an ``imag`` value
+using an explicit cast (see :ref:`Explicit_Conversions`). Similarly, an
+``imag`` value can be cast to a ``real`` value. Such casts preserve the
+floating-point value while changing whether or not it is imaginary.
+
+   *Example (imaginary.chpl)*.
+
+   For example, this program creates a imaginary numbers in two different
+   ways. First, ``a`` is an ``imag`` variable initialized to a literal:
+
+   .. code-block:: chapel
+
+      var a = 0.6i;
+
+   Now, suppose we have a ``real`` value ``s``:
+
+   .. code-block:: chapel
+
+      var s = 10.25;
+
+   We can initialize an ``imag`` variable with the same numeric value,
+   but as an imaginary value, with a cast:
+
+   .. code-block:: chapel
+
+      var b = s:imag;
+      assert(b == 10.25i);
+
+   .. BLOCK-test-chapelpost
+
+      writeln("a = ", a, " : ", a.type:string);
+      writeln("b = ", b, " : ", b.type:string);
+
+   .. BLOCK-test-chapeloutput
+
+      a = 0.6i : imag(64)
+      b = 10.25i : imag(64)
+
 
 .. _Complex_Types:
 

--- a/doc/rst/language/spec/types.rst
+++ b/doc/rst/language/spec/types.rst
@@ -176,8 +176,6 @@ representation at run-time.
 
        1
 
-
-
 .. _The_Bool_Type:
 
 The Bool Type
@@ -211,8 +209,7 @@ not initialized to something else (see also :ref:`Chapter-Variables`).
    and ``y`` are optional; the program indicates the type of ``x`` but
    the compiler infers the type of ``y``.  See :ref:`Chapter-Variables`
    for more details. The last variable is initialized to the default
-   value of ``bool``, which is ``false`` (see
-   :ref:`Default_Values_For_Types`).
+   value of ``bool``, which is ``false`` (see :ref:`Default_Values_For_Types`).
 
    .. BLOCK-test-chapelpost
 
@@ -261,11 +258,12 @@ the value. See :ref:`Implicit_Compile_Time_Constant_Conversions`.
 Integer literals can be written in hexadecimal, octal, or binary. See
 :ref:`Literals`.
 
-Signed or unsigned integral types of smaller width can implicitly convert
-to signed integral types of larger width.  Additionally, unsigned
-integral types of a smaller width can implicitly convert to an unsigned
-integral type of larger width. See :`Implicit_NumBool_Conversions` for
-details.
+Signed integral types of can implicitly convert to signed integral types
+of larger width. Additionally, signed integral types can implicitly
+convert to unsigned integral types of the same or larger width. Unsigned
+integral types can implicitly convert to both signed and unsigned
+integral type of larger width. See :ref:`Implicit_NumBool_Conversions`
+for details.
 
 It is possible for overflow to occur with binary operators on integers.
 For signed integers, overflow leads to undefined behavior. For unsigned
@@ -368,7 +366,7 @@ without an exponent (see :ref:`Literals` for details):
 
    Note that it uses `1.0/i` in order to do a floating point division. If
    it used `1/i`, it would do integer division (rounding towards zero),
-   which evaluates to 0 in this case.
+   which evaluates to ``0`` for ``i > 1``.
 
    Finally, it prints out the sum:
 
@@ -416,7 +414,7 @@ floating-point value while changing whether or not it is imaginary.
 
    *Example (imaginary.chpl)*.
 
-   For example, this program creates a imaginary numbers in two different
+   For example, this program creates imaginary numbers in two different
    ways. First, ``a`` is an ``imag`` variable initialized to a literal:
 
    .. code-block:: chapel


### PR DESCRIPTION
This PR adds information to the description of numeric types in the types.rst spec chapter. It adds examples and links to later sections since it forms a jumping-off point and it's fairly early in the spec, in terms of chapters, for anyone reading it consecutively.

One of the main motivations of this PR is to describe in the spec the behavior of casting between `real` and `imag` types.

I created this PR to address https://chapel.discourse.group/t/getting-the-imaginary-part-of-an-imaginary-number/31200

Reviewed by @vasslitvinov - thanks!

- [x] full comm=none testing