### PR TITLE
Fix sinLUT tests

### DIFF
--- a/test/studies/sinLUT/PREDIFF
+++ b/test/studies/sinLUT/PREDIFF
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+cp $2 $2.prediff.tmp
+> $2
+
+# check that Chapel Calculated == Chapel Lookup
+calc=`sed '1q;d' $2.prediff.tmp | sed 's/.*: //'`
+lookup=`sed '2q;d' $2.prediff.tmp | sed 's/.*: //'`
+if [ "$calc" = "$lookup" ]; then
+    echo "Chapel Calculated == Chapel Lookup" >> $2
+else
+    echo "Chapel Calculated != Chapel Lookup" >> $2
+fi
+# check that C Caclulated == C Lookup
+calc=`sed '3q;d' $2.prediff.tmp | sed 's/.*: //'`
+lookup=`sed '4q;d' $2.prediff.tmp | sed 's/.*: //'`
+if [ "$calc" = "$lookup" ]; then
+    echo "C Calculated == C Lookup" >> $2
+else
+    echo "C Calculated != C Lookup" >> $2
+fi
+
+rm $2.prediff.tmp

--- a/test/studies/sinLUT/c_sin.c
+++ b/test/studies/sinLUT/c_sin.c
@@ -2,16 +2,14 @@
 #include <stdio.h>
 #include <math.h>
 #include <stdlib.h>
-#include <time.h>
 
 #include "c_sin.h"
 
 static float table[256];
 
-float c_sin(unsigned int size, int iterations, float* resArray)
+float c_sin(unsigned int size, int iterations, unsigned int seed, float* resArray)
 {
-	  time_t t;
-	  srand((unsigned )time(&t));
+	  srand(seed);
 
     for (int i=0; i < iterations; i++)
 	  {
@@ -28,11 +26,10 @@ void fillTable(unsigned int size)
         table[i] = sin(2.0 * 3.1415927 * (float) i / (float) size);
 }
 
-float c_table(unsigned int size, int iterations, float* resArray)
+float c_table(unsigned int size, int iterations, unsigned int seed, float* resArray)
 {
-	  time_t t;
     fillTable(size);
-    srand((unsigned )time(&t));
+    srand(seed);
 
     for (int i=0; i < iterations; i++)
     {

--- a/test/studies/sinLUT/c_sin.h
+++ b/test/studies/sinLUT/c_sin.h
@@ -1,4 +1,4 @@
-float c_sin(unsigned int size, int iterations, float* resArray);
+float c_sin(unsigned int size, int iterations, unsigned int seed, float* resArray);
 void fillTable(unsigned int size);
-float c_table(unsigned int size, int iterations, float* resArray);
+float c_table(unsigned int size, int iterations, unsigned int seed, float* resArray);
 

--- a/test/studies/sinLUT/chplSin.chpl
+++ b/test/studies/sinLUT/chplSin.chpl
@@ -4,11 +4,17 @@ use Time;
 use Math;
 use CTypes;
 
-config const seed = 314159;
+config const seed: uint(32) = 314159;
 config const correctness = false;
 
-extern proc c_sin(size: uint(32), iterations: int(32), resArray: c_ptr(real(32))): real(32);
-extern proc c_table(size: uint(32), iterations: int(32), resArray: c_ptr(real(32))): real(32);
+extern proc c_sin(size: uint(32),
+                  iterations: int(32),
+                  seed: uint(32),
+                  resArray: c_ptr(real(32))): real(32);
+extern proc c_table(size: uint(32),
+                    iterations: int(32),
+                    seed: uint(32),
+                    resArray: c_ptr(real(32))): real(32);
 
 proc sin_calc(size: uint(32), iterations : int(32)): real(32) {
 
@@ -76,7 +82,7 @@ proc main()
     var resArray = allocate(real(32), iterations);
 
     c_calc.start();
-    var c_calc_res = c_sin(size, iterations, resArray);
+    var c_calc_res = c_sin(size, iterations, seed, resArray);
     c_calc.stop();
     write("C Calculated: ");
     if correctness
@@ -84,7 +90,7 @@ proc main()
       else writeln(c_calc.elapsed(), " seconds");
 
     c_lookup.start();
-    var table_calc_res = c_table(size, iterations, resArray);
+    var table_calc_res = c_table(size, iterations, seed, resArray);
     c_lookup.stop();
     write("C Lookup: ");
     if correctness

--- a/test/studies/sinLUT/chplSin.good
+++ b/test/studies/sinLUT/chplSin.good
@@ -1,4 +1,2 @@
-Chapel Calculated: -1.2311
-Chapel Lookup: -1.2311
-C Calculated: -4.23134
-C Lookup: -4.23134
+Chapel Calculated == Chapel Lookup
+C Calculated == C Lookup

--- a/test/studies/sinLUT/chplSin.good
+++ b/test/studies/sinLUT/chplSin.good
@@ -1,4 +1,4 @@
 Chapel Calculated: -1.2311
 Chapel Lookup: -1.2311
-C Calculated: -1.2311
-C Lookup: -1.2311
+C Calculated: -4.23134
+C Lookup: -4.23134

--- a/test/studies/sinLUT/chplSinBlock.chpl
+++ b/test/studies/sinLUT/chplSinBlock.chpl
@@ -5,11 +5,17 @@ use Math;
 use CTypes;
 use BlockDist;
 
-config const seed = 314159;
+config const seed: uint(32) = 314159;
 config const correctness = false;
 
-extern proc c_sin(size: uint(32), iterations: int(32), resArray: c_ptr(real(32))): real(32);
-extern proc c_table(size: uint(32), iterations: int(32), resArray: c_ptr(real(32))): real(32);
+extern proc c_sin(size: uint(32),
+                  iterations: int(32),
+                  seed: uint(32),
+                  resArray: c_ptr(real(32))): real(32);
+extern proc c_table(size: uint(32),
+                    iterations: int(32),
+                    seed: uint(32),
+                    resArray: c_ptr(real(32))): real(32);
 
 proc sin_calc(size: uint(32), iterations : int(32)): real(32) {
 
@@ -115,7 +121,7 @@ proc main()
     var resArray = allocate(real(32), iterations);
 
     c_calc.start();
-    var c_calc_res = c_sin(size, iterations, resArray);
+    var c_calc_res = c_sin(size, iterations, seed, resArray);
     c_calc.stop();
     write("C Calculated: ");
     if correctness
@@ -123,7 +129,7 @@ proc main()
       else writeln(c_calc.elapsed(), " seconds");
 
     c_lookup.start();
-    var table_calc_res = c_table(size, iterations, resArray);
+    var table_calc_res = c_table(size, iterations, seed, resArray);
     c_lookup.stop();
     write("C Lookup: ");
     if correctness

--- a/test/studies/sinLUT/chplSinBlock.good
+++ b/test/studies/sinLUT/chplSinBlock.good
@@ -1,4 +1,2 @@
-Chapel Calculated: -1.2311
-Chapel Lookup: -1.2311
-C Calculated: -4.23134
-C Lookup: -4.23134
+Chapel Calculated == Chapel Lookup
+C Calculated == C Lookup

--- a/test/studies/sinLUT/chplSinBlock.good
+++ b/test/studies/sinLUT/chplSinBlock.good
@@ -1,4 +1,4 @@
 Chapel Calculated: -1.2311
 Chapel Lookup: -1.2311
-C Calculated: -1.2311
-C Lookup: -1.2311
+C Calculated: -4.23134
+C Lookup: -4.23134

--- a/test/studies/sinLUT/chplSinReplicated.chpl
+++ b/test/studies/sinLUT/chplSinReplicated.chpl
@@ -5,11 +5,17 @@ use Math;
 use CTypes;
 use ReplicatedDist;
 
-config const seed = 314159;
+config const seed: uint(32) = 314159;
 config const correctness = false;
 
-extern proc c_sin(size: uint(32), iterations: int(32), resArray: c_ptr(real(32))): real(32);
-extern proc c_table(size: uint(32), iterations: int(32), resArray: c_ptr(real(32))): real(32);
+extern proc c_sin(size: uint(32),
+                  iterations: int(32),
+                  seed: uint(32),
+                  resArray: c_ptr(real(32))): real(32);
+extern proc c_table(size: uint(32),
+                    iterations: int(32),
+                    seed: uint(32),
+                    resArray: c_ptr(real(32))): real(32);
 
 proc sin_calc(size: uint(32), iterations : int(32)): real(32) {
 
@@ -114,7 +120,7 @@ proc main()
     var resArray = allocate(real(32), iterations);
 
     c_calc.start();
-    var c_calc_res = c_sin(size, iterations, resArray);
+    var c_calc_res = c_sin(size, iterations, seed, resArray);
     c_calc.stop();
     write("C Calculated: ");
     if correctness
@@ -122,7 +128,7 @@ proc main()
       else writeln(c_calc.elapsed(), " seconds");
 
     c_lookup.start();
-    var table_calc_res = c_table(size, iterations, resArray);
+    var table_calc_res = c_table(size, iterations, seed, resArray);
     c_lookup.stop();
     write("C Lookup: ");
     if correctness

--- a/test/studies/sinLUT/chplSinReplicated.good
+++ b/test/studies/sinLUT/chplSinReplicated.good
@@ -1,4 +1,2 @@
-Chapel Calculated: -1.2311
-Chapel Lookup: -1.2311
-C Calculated: -4.23134
-C Lookup: -4.23134
+Chapel Calculated == Chapel Lookup
+C Calculated == C Lookup

--- a/test/studies/sinLUT/chplSinReplicated.good
+++ b/test/studies/sinLUT/chplSinReplicated.good
@@ -1,4 +1,4 @@
 Chapel Calculated: -1.2311
 Chapel Lookup: -1.2311
-C Calculated: -1.2311
-C Lookup: -1.2311
+C Calculated: -4.23134
+C Lookup: -4.23134

--- a/test/studies/sinLUT/chplSinReplicatedReplicand.chpl
+++ b/test/studies/sinLUT/chplSinReplicatedReplicand.chpl
@@ -5,11 +5,17 @@ use Math;
 use CTypes;
 use ReplicatedDist;
 
-config const seed = 314159;
+config const seed: uint(32) = 314159;
 config const correctness = false;
 
-extern proc c_sin(size: uint(32), iterations: int(32), resArray: c_ptr(real(32))): real(32);
-extern proc c_table(size: uint(32), iterations: int(32), resArray: c_ptr(real(32))): real(32);
+extern proc c_sin(size: uint(32),
+                  iterations: int(32),
+                  seed: uint(32),
+                  resArray: c_ptr(real(32))): real(32);
+extern proc c_table(size: uint(32),
+                    iterations: int(32),
+                    seed: uint(32),
+                    resArray: c_ptr(real(32))): real(32);
 
 proc sin_calc(size: uint(32), iterations : int(32)): real(32) {
 
@@ -114,7 +120,7 @@ proc main()
     var resArray = allocate(real(32), iterations);
 
     c_calc.start();
-    var c_calc_res = c_sin(size, iterations, resArray);
+    var c_calc_res = c_sin(size, iterations, seed, resArray);
     c_calc.stop();
     write("C Calculated: ");
     if correctness
@@ -122,7 +128,7 @@ proc main()
       else writeln(c_calc.elapsed(), " seconds");
 
     c_lookup.start();
-    var table_calc_res = c_table(size, iterations, resArray);
+    var table_calc_res = c_table(size, iterations, seed, resArray);
     c_lookup.stop();
     write("C Lookup: ");
     if correctness

--- a/test/studies/sinLUT/chplSinReplicatedReplicand.good
+++ b/test/studies/sinLUT/chplSinReplicatedReplicand.good
@@ -1,4 +1,2 @@
-Chapel Calculated: -1.2311
-Chapel Lookup: -1.2311
-C Calculated: -4.23134
-C Lookup: -4.23134
+Chapel Calculated == Chapel Lookup
+C Calculated == C Lookup

--- a/test/studies/sinLUT/chplSinReplicatedReplicand.good
+++ b/test/studies/sinLUT/chplSinReplicatedReplicand.good
@@ -1,4 +1,4 @@
 Chapel Calculated: -1.2311
 Chapel Lookup: -1.2311
-C Calculated: -1.2311
-C Lookup: -1.2311
+C Calculated: -4.23134
+C Lookup: -4.23134


### PR DESCRIPTION
Fixes the .good files for the sinLUT tests I added. These were relying on random numbers with a seed that varied. This PR passes a seed value to `srand` that is constant.

Also, due to platform differences in the `rand` algorithm, this PR adds a PREDIFF to validate that Calculated and Lookup give the same answer, since putting just the value returned in the good file is not portable.

tested on MacOS and Linux, with and without comm

[Reviewed by @benharsh]