### PR TITLE
Speed up min() and max() on reals

### DIFF
--- a/modules/standard/AutoMath.chpl
+++ b/modules/standard/AutoMath.chpl
@@ -334,9 +334,9 @@ module AutoMath {
   inline proc max(x: uint(64), y: uint(64)) do return if x > y then x else y;
 
   @chpldoc.nodoc
-  inline proc max(x: real(32), y: real(32)) do return if (x > y) | isNan(x) then x else y;
+  inline proc max(x: real(32), y: real(32)) do return if (x > y) || isNan(x) then x else y;
   @chpldoc.nodoc
-  inline proc max(x: real(64), y: real(64)) do return if (x > y) | isNan(x) then x else y;
+  inline proc max(x: real(64), y: real(64)) do return if (x > y) || isNan(x) then x else y;
 
   @chpldoc.nodoc
   inline proc max(x: int(8), y: uint(8)) do return if x > y then x : uint(8) else y;
@@ -403,9 +403,9 @@ module AutoMath {
   inline proc min(x: uint(64), y: uint(64)) do return if x < y then x else y;
 
   @chpldoc.nodoc
-  inline proc min(x: real(32), y: real(32)) do return if (x < y) | isNan(x) then x else y;
+  inline proc min(x: real(32), y: real(32)) do return if (x < y) || isNan(x) then x else y;
   @chpldoc.nodoc
-  inline proc min(x: real(64), y: real(64)) do return if (x < y) | isNan(x) then x else y;
+  inline proc min(x: real(64), y: real(64)) do return if (x < y) || isNan(x) then x else y;
 
   @chpldoc.nodoc
   inline proc min(x: int(8), y: uint(8)) do return if x < y then x else y : int(8);


### PR DESCRIPTION
#13824 used `|` instead of the conventional `||` for min and max on reals. This [raised some eyebrows](https://github.com/chapel-lang/chapel/issues/13922#issuecomment-528646124) back then, yet remained this way. 

This PR switches them to `||` because [this has been observed to improve performance](https://github.com/chapel-lang/chapel/issues/14000#issuecomment-1911475870) -- thanks @damianmoz for this finding.

Damian also reports that at the time of 13824 `|` was faster in his testing, which most likely used GCC. He also suggests that we may want to switch to compiler intrinsics for these.

No test changes. Passes {standard, gasnet} paratests with {llvm, gnu} backends.