### PR TITLE
Fix issues with new perf test in nightly

### DIFF
--- a/test/studies/sinLUT/PREDIFF
+++ b/test/studies/sinLUT/PREDIFF
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+
+# only do this if '-scorrectness=true'
+if [[ "$5" != *"-scorrectness=true"* ]]; then
+  exit 0
+fi
+
 cp $2 $2.prediff.tmp
 > $2
 

--- a/test/studies/sinLUT/chplSin.chpl
+++ b/test/studies/sinLUT/chplSin.chpl
@@ -54,7 +54,7 @@ proc fast_sin(size: uint(32), iterations : int(32)): real(32) {
 
 proc main()
 {
-    var iterations : int(32) = 100_000_000;
+    var iterations = if !correctness then 100_000_000:int(32) else 1_000:int(32);
     const size:uint(32) = 256;
 
     var calc = new stopwatch();

--- a/test/studies/sinLUT/chplSinBlock.chpl
+++ b/test/studies/sinLUT/chplSinBlock.chpl
@@ -93,7 +93,7 @@ proc fast_sin(size: uint(32), iterations : int(32)): real(32) {
 
 proc main()
 {
-    var iterations : int(32) = 100_000_000;
+    var iterations = if !correctness then 100_000_000:int(32) else 1_000:int(32);
     const size:uint(32) = 256;
 
     var calc = new stopwatch();

--- a/test/studies/sinLUT/chplSinReplicated.chpl
+++ b/test/studies/sinLUT/chplSinReplicated.chpl
@@ -92,7 +92,7 @@ proc fast_sin(size: uint(32), iterations : int(32)): real(32) {
 
 proc main()
 {
-    var iterations : int(32) = 100_000_000;
+    var iterations = if !correctness then 100_000_000:int(32) else 1_000:int(32);
     const size:uint(32) = 256;
 
     var calc = new stopwatch();

--- a/test/studies/sinLUT/chplSinReplicatedReplicand.chpl
+++ b/test/studies/sinLUT/chplSinReplicatedReplicand.chpl
@@ -92,7 +92,7 @@ proc fast_sin(size: uint(32), iterations : int(32)): real(32) {
 
 proc main()
 {
-    var iterations : int(32) = 100_000_000;
+    var iterations = if !correctness then 100_000_000:int(32) else 1_000:int(32);
     const size:uint(32) = 256;
 
     var calc = new stopwatch();


### PR DESCRIPTION
Fixes two distinct issues with new perf tests I added yesterday.

- A late breaking change meant that I added a PREDIFF, which I did not expect to run for the perf configs. This prevented the timings from being found. The solution is to use the prediff when doing correctness testing
- ASAN+gasnet testing caused the correctness testing to timeout. The solution is to do less iterations for a correctness test

Testing - done on macos and linux, with and without comm
- `start_test test/studies/sinLUT`
- `start_test --performance test/studies/sinLUT`
- `start_test --performance --perflabel ml- test/studies/sinLUT`

[Reviewed by @jeremiah-corrado]
