### PR TITLE
Allow long-form suffixes to -nl argument

### DIFF
--- a/runtime/src/arg.c
+++ b/runtime/src/arg.c
@@ -260,12 +260,19 @@ void parseNumLocales(const char* numPtr, int32_t lineno, int32_t filename) {
       _argNumLocalesPerNode = c_string_to_int32_t_precise(lpn, &invalid,
                                                    invalidChars);
       const char *t = NULL;
-      if (invalidChars[1] == '\0') {
+      if (invalid) {
         switch(invalidChars[0]) {
           case 's': t = "socket"; invalid = false; break;
           case 'n': t = "numa";invalid = false; break;
           case 'c': t = "core"; invalid = false; break;
           case 'L': t = "cache"; invalid = false; break;
+        }
+        if (!invalid) {
+          // There should be only a single suffix character
+          char *s = strchr(lpn, invalidChars[0]);
+          if ((s == NULL) || (*(s+1) != '\0')) {
+            invalid = true;
+          }
         }
       }
       if (invalid) {

--- a/runtime/src/arg.c
+++ b/runtime/src/arg.c
@@ -270,31 +270,19 @@ void parseNumLocales(const char* numPtr, int32_t lineno, int32_t filename) {
           chpl_error(message, lineno, filename);
         }
 
-        chpl_bool invalidSuffix = false;
-        if (strlen(suffix) == 1) {
-          switch(*suffix) {
-            case 's': t = "socket"; break;
-            case 'n': t = "numa"; break;
-            case 'c': t = "core"; break;
-            case 'L': t = "cache"; break;
-            default: invalidSuffix = true; break;
-          }
-          if (invalidSuffix == false) {
-            invalid = false;
-          }
+        if (!strcmp(suffix, "s") || !strcmp(suffix, "socket")) {
+          t = "socket";
+        } else if (!strcmp(suffix, "numa")) {
+          t = "numa";
+        } else if (!strcmp(suffix, "llc")) {
+          t = "cache";
+        } else if (!strcmp(suffix, "c") || !strcmp(suffix, "core")) {
+          t = "core";
         } else {
-          invalidSuffix = true;
-        }
-        if (invalidSuffix) {
           char *message = chpl_glom_strings(3, "\"", suffix,
                           "\" is not a valid suffix.");
           chpl_error(message, lineno, filename);
         }
-      }
-      if (invalid) {
-        char *message = chpl_glom_strings(3, "\"", lpn,
-                            "\" is not a valid number of co-locales.");
-        chpl_error(message, lineno, filename);
       }
       if (t) {
         chpl_env_set("CHPL_RT_COLOCALE_OBJ_TYPE", t, 1);

--- a/test/runtime/configMatters/launch/jhh/co-locales/co-locales.py
+++ b/test/runtime/configMatters/launch/jhh/co-locales/co-locales.py
@@ -69,7 +69,8 @@ class ColocaleArgs(unittest.TestCase):
 
         # Determine the number of sockets per node
         cmd = ["sinfo", "--format=%X", "--noheader", "--exact"]
-        partition = os.environ.get('CHPL_LAUNCHER_PARTITION')
+        partition = os.environ.get('CHPL_LAUNCHER_PARTITION', None)
+        partition = os.environ.get('SLURM_PARTITION', partition)
         if partition is not None:
             cmd += ["--partition", partition]
             if verbose:
@@ -146,7 +147,7 @@ class ColocaleArgs(unittest.TestCase):
         with self.assertRaises(subprocess.CalledProcessError) as cm:
             output = self.runCmd("./hello -nl 3xZ -v --dry-run")
         self.assertEqual(cm.exception.stdout.strip(),
-            '<command-line arg>:1: error: "Z" is not a valid number of locales per node.')
+            '<command-line arg>:1: error: "Z" is not a valid number of co-locales.')
 
     def test_09_no_default(self):
         """Three nodes, no locales-per-node default"""
@@ -201,7 +202,7 @@ class ColocaleArgs(unittest.TestCase):
 
     def test_16_valid_suffixes(self):
         """Allow valid suffixes"""
-        for s in ['s', 'n', 'L', 'c']:
+        for s in ['s', 'socket', 'numa', 'llc', 'c', 'core']:
             with self.subTest(s=s):
                 output=self.runCmd("./hello -nl 3x2%s -v --dry-run" % s)
                 self.assertTrue('--nodes=3' in output or '-N 3' in output)

--- a/test/runtime/configMatters/launch/jhh/co-locales/co-locales.py
+++ b/test/runtime/configMatters/launch/jhh/co-locales/co-locales.py
@@ -199,6 +199,34 @@ class ColocaleArgs(unittest.TestCase):
         self.assertTrue('--nodes=3' in output or '-N 3' in output)
         self.assertIn('--ntasks=6', output)
 
+    def test_16_valid_suffixes(self):
+        """Allow valid suffixes"""
+        for s in ['s', 'n', 'L', 'c']:
+            with self.subTest(s=s):
+                output=self.runCmd("./hello -nl 3x2%s -v --dry-run" % s)
+                self.assertTrue('--nodes=3' in output or '-N 3' in output)
+                self.assertIn('--ntasks=6', output)
+
+    def test_17_invalid_suffix(self):
+        """Reject invalid suffix"""
+        with self.assertRaises(subprocess.CalledProcessError) as cm:
+            output = self.runCmd("./hello -nl -3x2z -v --dry-run")
+        self.assertEqual(cm.exception.stdout.strip(),
+            '<command-line arg>:1: error: "z" is not a valid suffix.')
+
+    def test_18_invalid_suffix2(self):
+        """Reject invalid suffix that starts with a valid character"""
+        with self.assertRaises(subprocess.CalledProcessError) as cm:
+            output = self.runCmd("./hello -nl -3x2ss -v --dry-run")
+        self.assertEqual(cm.exception.stdout.strip(),
+            '<command-line arg>:1: error: "ss" is not a valid suffix.')
+
+    def test_19_invalid_suffix3(self):
+        """Suffix must follow locales-per-node"""
+        with self.assertRaises(subprocess.CalledProcessError) as cm:
+            output = self.runCmd("./hello -nl -3xs -v --dry-run")
+        self.assertEqual(cm.exception.stdout.strip(),
+            '<command-line arg>:1: error: "s" is not a valid number of co-locales.')
 
 # copied from sub_test.py
 # report an error message and exit


### PR DESCRIPTION

 Allow long-form suffixes to the -nl argument, including "socket", "numa",  "llc", and "core".

Resolves https://github.com/Cray/chapel-private/issues/6041.

Signed-off-by: John H. Hartman <jhh67@users.noreply.github.com>