### PR TITLE
Fix test failure from #24527

### DIFF
--- a/test/io/vass/time-write.chpl
+++ b/test/io/vass/time-write.chpl
@@ -129,7 +129,7 @@ inline proc addTime(ref t: real) {
 
 }
 
-const reportFormat = "%-24s " + fmt + "\n";
+const reportFormat = "%<24s " + fmt + "\n";
 inline proc reportTime(title: string, time: real) {
   info.writef(reportFormat, title, time);
 }


### PR DESCRIPTION
Update the left-justification format specifier from `-` to `<` in io/vass/time-write.chpl. With this change, the test is passing in its performance configuration.