### PR TITLE
Fix a uAST conversion bug that incorrectly converted some array types

### DIFF
--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -1430,10 +1430,16 @@ static Expr* preFoldPrimOp(CallExpr* call) {
         msgType = dtBorrowed;
 
       Type* t = e->typeInfo();
-      if (!isClassLikeOrManaged(t))
+      bool emit = true;
+
+      if (auto fn = toFnSymbol(call->parentSymbol)) {
+        emit = !fn->isCompilerGenerated();
+      }
+
+      if (emit && !isClassLikeOrManaged(t))
         USR_FATAL_CONT(call, "cannot make %s into a %s class",
                              toString(t), toString(msgType));
-      if (!isTypeExpr(e))
+      if (emit && !isTypeExpr(e))
         USR_FATAL_CONT(call, "cannot use decorator %s on a value",
                              toString(msgType));
 

--- a/test/classes/delete-free/borrowed/borrowed-array.good
+++ b/test/classes/delete-free/borrowed/borrowed-array.good
@@ -1,3 +1,1 @@
 borrowed-array.chpl:2: error: cannot make [domain(1,int(64),one)] real(64) into a borrowed class
-borrowed-array.chpl:2: error: assigning to a range with boundKind.both from a range with boundKind.neither without an explicit cast
-note: An additional error is hidden. Use --print-additional-errors to see it.

--- a/test/classes/errors/Issue18717.chpl
+++ b/test/classes/errors/Issue18717.chpl
@@ -1,0 +1,19 @@
+record Chunk {
+  type eltType;
+  var D: domain(1);
+  var data: borrowed [D] eltType;
+
+  proc init(type eltType) {
+    this.eltType = eltType;
+  }
+
+  proc init(array: [?X] ?t) {
+    this.eltType = t;
+    this.D = X;
+    this.data = array;
+  }
+}
+
+proc main() {
+  var x = new Chunk([1, 2, 3]);
+}

--- a/test/classes/errors/Issue18717.good
+++ b/test/classes/errors/Issue18717.good
@@ -1,0 +1,3 @@
+Issue18717.chpl:10: In initializer:
+Issue18717.chpl:4: error: cannot make [domain(1,int(64),one)] int(64) into a borrowed class
+  Issue18717.chpl:18: called as Chunk.init(array: [domain(1,int(64),one)] int(64))


### PR DESCRIPTION
Resolves #18717.

Fixes a bug which caused an array type preceded by the `borrowed` keyword to be incorrectly transformed into a loop. This led to internal errors when the loop was queried for its type information.

At a syntactic level, array types and loops are indistinguishable. However, in type-only contexts (such as for formal types, or for return types) we can always convert a "loop" into an array type. This PR adjusts the uAST converter so that it can handle converting array types at arbitrary depths. This covers array types that follow the `borrowed` keyword (which is represented as a "call").

TESTING

- [x] `linux64`, `standard`
- [x] `linux64`, `COMM=gasnet`

Reviewed by @mppf, @vasslitvinov. Thanks!