### PR TITLE
Remove unstable 'imag' overloads of 'fma()'

### DIFF
--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -1527,16 +1527,4 @@ module Math {
   inline proc fma(x: real(32), y: real(32), z: real(32)): real(32) {
     return fmaSelectPrimitiveOrExternCall(x, y, z);
   }
-
-  @unstable("The 'fma()' procedure was recently added, and may change based on feedback")
-  inline proc fma(x: imag(64), y: imag(64), z: imag(64)): imag(64) {
-    type t = real(64);
-    return fmaSelectPrimitiveOrExternCall(x:t, y:t, z:t):imag(64);
-  }
-
-  @unstable("The 'fma()' procedure was recently added, and may change based on feedback")
-  inline proc fma(x: imag(32), y: imag(32), z: imag(32)): imag(32) {
-    type t = real(32);
-    return fmaSelectPrimitiveOrExternCall(x:t, y:t, z:t):imag(32);
-  }
 }

--- a/test/library/standard/Math/fma.chpl
+++ b/test/library/standard/Math/fma.chpl
@@ -53,14 +53,6 @@ iter streamRandomReal64(hi: int=4096) {
   for triple in streamRandomNumeric(real(64), hi) do yield triple;
 }
 
-iter streamRandomImag32(hi: int=4096) {
-  for triple in streamRandomNumeric(imag(32), hi) do yield triple;
-}
-
-iter streamRandomImag64(hi: int=4096) {
-  for triple in streamRandomNumeric(imag(64), hi) do yield triple;
-}
-
 proc test0() {
   extern proc fmaf(x: real(32), y: real(32), z:real(32)): real(32);
   for (x, y, z) in streamRandomReal32() {
@@ -92,32 +84,8 @@ proc test2() {
   }
 }
 
-proc test3() {
-  extern proc fmaf(x: real(32), y: real(32), z:real(32)): real(32);
-  for (x, y, z) in streamRandomImag32() {
-    const n1 = Math.fma(x, y, z);
-    type t = real(32);
-    const n2 = fmaf(x:t, y:t, z:t):imag(32);
-    const ok = isClose(n1, n2);
-    assert(ok);
-  }
-}
-
-proc test4() {
-  extern proc fma(x: real(64), y: real(64), z:real(64)): real(64);
-  for (x, y, z) in streamRandomImag64() {
-    const n1 = Math.fma(x, y, z);
-    type t = real(64);
-    const n2 = fma(x:t, y:t, z:t):imag(64);
-    const ok = isClose(n1, n2);
-    assert(ok);
-  }
-}
-
 proc main() {
   test0();
   test1();
   test2();
-  test3();
-  test4();
 }


### PR DESCRIPTION
Remove unstable `imag` overloads of `fma()` since they compute an incorrect result. We can add additional overloads if users request them.

Reviewed by @mppf. Thanks!