### PR TITLE
Correctly remove old docker image instead of container in test

### DIFF
--- a/util/cron/test-docker.bash
+++ b/util/cron/test-docker.bash
@@ -17,7 +17,7 @@ build_image(){
 local imageName="$1"
 local script="$2" 
 # Remove any existing image with the tag before building docker image
-docker rm --force $imageName
+docker image rm --force $imageName
 docker build . -t $imageName
 containerid= docker image ls | grep $imageName | awk '{print$3}'
 cd ${CHPL_HOME}/util/cron


### PR DESCRIPTION
The `util/cron/test-docker.bash` script has a line to remove existing images of the same name before building our new test image. However, it runs `docker rm` (which removes _containers_) instead of `docker image rm`, so it hasn't been getting rid of old images at all. Fix the command to avoid leaving around old test images.

[reviewer info placeholder]