### PR TITLE
Dyno: add non-param casts to and from enums

### DIFF
--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -170,7 +170,8 @@ class UntypedFnSignature {
            idTag == uast::asttags::Record   ||
            idTag == uast::asttags::Tuple    ||
            idTag == uast::asttags::Union    ||
-           idTag == uast::asttags::Variable);
+           idTag == uast::asttags::Variable ||
+           idTag == uast::asttags::Enum);
   }
 
   static const owned<UntypedFnSignature>&

--- a/frontend/include/chpl/types/UintType.h
+++ b/frontend/include/chpl/types/UintType.h
@@ -45,15 +45,15 @@ class UintType final : public PrimitiveType {
 
   static const owned<UintType>& getUintType(Context* context, int bitwidth);
 
-  /** what is stored in bitwidth_ for the default 'uint'? */
-  static int defaultBitwidth() {
-    return 64;
-  }
-
  public:
   ~UintType() = default;
 
   static const UintType* get(Context* context, int bitwidth);
+
+  /** what is stored in bitwidth_ for the default 'uint'? */
+  static int defaultBitwidth() {
+    return 64;
+  }
 
   int bitwidth() const override {
     return bitwidth_;

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -719,6 +719,88 @@ getCompilerGeneratedMethodQuery(Context* context, const Type* type,
   return QUERY_END(result);
 }
 
+static void
+setupGeneratedEnumCastFormals(Context* context,
+                              const EnumType* enumType,
+                              std::vector<UntypedFnSignature::FormalDetail>& ufsFormals,
+                              std::vector<QualifiedType>& formalTypes,
+                              bool isFromCast /* otherwise, it's a "to" cast */) {
+  const Type* fromType;
+  const Type* toType;
+
+  if (isFromCast) {
+    fromType = enumType;
+    toType = AnyIntegralType::get(context);
+  } else {
+    fromType = AnyIntegralType::get(context);
+    toType = enumType;
+  }
+
+  auto fromQt = QualifiedType(QualifiedType::DEFAULT_INTENT, fromType);
+  auto toQt = QualifiedType(QualifiedType::TYPE, toType);
+
+  auto ufsFrom =
+      UntypedFnSignature::FormalDetail(UniqueString::get(context, "from"),
+                                       false, nullptr);
+  ufsFormals.push_back(std::move(ufsFrom));
+  auto ufsTo =
+      UntypedFnSignature::FormalDetail(UniqueString::get(context, "to"),
+                                       false, nullptr);
+  ufsFormals.push_back(std::move(ufsTo));
+
+  formalTypes.push_back(fromQt);
+  formalTypes.push_back(toQt);
+}
+
+static const TypedFnSignature*
+generateToOrFromCastForEnum(Context* context,
+                            const types::QualifiedType& lhs,
+                            const types::QualifiedType& rhs,
+                            bool isFromCast /* otherwise, it's a "to" cast */) {
+  std::vector<UntypedFnSignature::FormalDetail> ufsFormals;
+  std::vector<QualifiedType> formalTypes;
+
+  auto enumType = isFromCast ? lhs.type()->toEnumType() : rhs.type()->toEnumType();
+  setupGeneratedEnumCastFormals(context, enumType, ufsFormals, formalTypes,
+                                isFromCast);
+
+  auto ufs = UntypedFnSignature::get(context,
+                        /*id*/ enumType->id(),
+                        /*name*/ USTR(":"),
+                        /*isMethod*/ false,
+                        /*isTypeConstructor*/ false,
+                        /*isCompilerGenerated*/ true,
+                        /*throws*/ false,
+                        /*idTag*/ parsing::idToTag(context, enumType->id()),
+                        /*kind*/ uast::Function::Kind::OPERATOR,
+                        /*formals*/ std::move(ufsFormals),
+                        /*whereClause*/ nullptr);
+
+  auto ret = TypedFnSignature::get(context,
+                                   ufs,
+                                   std::move(formalTypes),
+                                   TypedFnSignature::WHERE_NONE,
+                                   /* needsInstantiation */ true,
+                                   /* instantiatedFrom */ nullptr,
+                                   /* parentFn */ nullptr,
+                                   /* formalsInstantiated */ Bitmap());
+  return ret;
+}
+
+static const TypedFnSignature*
+generateCastFromEnum(Context* context,
+                     const types::QualifiedType& lhs,
+                     const types::QualifiedType& rhs) {
+  return generateToOrFromCastForEnum(context, lhs, rhs, /*isFromCast*/ true);
+}
+
+static const TypedFnSignature*
+generateCastToEnum(Context* context,
+                   const types::QualifiedType& lhs,
+                   const types::QualifiedType& rhs) {
+  return generateToOrFromCastForEnum(context, lhs, rhs, /*isFromCast*/ false);
+}
+
 /**
   Given a type and a UniqueString representing the name of a method,
   determine if the type needs a method with such a name to be
@@ -731,6 +813,33 @@ const TypedFnSignature*
 getCompilerGeneratedMethod(Context* context, const Type* type,
                            UniqueString name, bool parenless) {
   return getCompilerGeneratedMethodQuery(context, type, name, parenless);
+}
+
+static const TypedFnSignature* const&
+getCompilerGeneratedBinaryOpQuery(Context* context,
+                                  types::QualifiedType lhs,
+                                  types::QualifiedType rhs,
+                                  UniqueString name) {
+  QUERY_BEGIN(getCompilerGeneratedBinaryOpQuery, context, lhs, rhs, name);
+
+  const TypedFnSignature* result = nullptr;
+  if (name == USTR(":")) {
+    if (lhs.type() && lhs.type()->isEnumType()) {
+      result = generateCastFromEnum(context, lhs, rhs);
+    } else if (rhs.type() && rhs.type()->isEnumType()) {
+      result = generateCastToEnum(context, lhs, rhs);
+    }
+  }
+
+  return QUERY_END(result);
+}
+
+const TypedFnSignature*
+getCompilerGeneratedBinaryOp(Context* context,
+                             const types::QualifiedType lhs,
+                             const types::QualifiedType rhs,
+                             UniqueString name) {
+  return getCompilerGeneratedBinaryOpQuery(context, lhs, rhs, name);
 }
 
 

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -761,6 +761,9 @@ generateToOrFromCastForEnum(Context* context,
   std::vector<QualifiedType> formalTypes;
 
   auto enumType = isFromCast ? lhs.type()->toEnumType() : rhs.type()->toEnumType();
+
+  if (enumType->isAbstract()) return nullptr;
+
   setupGeneratedEnumCastFormals(context, enumType, ufsFormals, formalTypes,
                                 isFromCast);
 

--- a/frontend/lib/resolution/default-functions.h
+++ b/frontend/lib/resolution/default-functions.h
@@ -57,6 +57,20 @@ const TypedFnSignature*
 getCompilerGeneratedMethod(Context* context, const types::Type* type,
                            UniqueString name, bool parenless);
 
+/**
+  Given the name of a binary operation and the types of its operands,
+  determine if the compiler needs to provide a generated implementation,
+  and if so, generates and returns a TypedFnSignature representing the
+  generated binary operation.
+
+  If no operation was generated, returns nullptr.
+ */
+const TypedFnSignature*
+getCompilerGeneratedBinaryOp(Context* context,
+                       const types::QualifiedType lhs,
+                       const types::QualifiedType rhs,
+                       UniqueString name);
+
 
 } // end namespace resolution
 } // end namespace chpl

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -1903,10 +1903,6 @@ ApplicabilityResult instantiateSignature(Context* context,
           // to later fields without re-visiting and re-constructing the resolver.
           // TODO: is this too hacky?
           r.byAst(entry.formal()).setType(useType);
-        } else {
-          // Right now, only enums get generic compiler-generated candidates.
-          CHPL_ASSERT(ed);
-          formalTypes.push_back(useType);
         }
 
         // note that a substitution was used here
@@ -1917,6 +1913,12 @@ ApplicabilityResult instantiateSignature(Context* context,
       }
 
       formalIdx++;
+    }
+
+    if (!formal && ed) {
+      // we're in an enum-based generated method; note the type in
+      // formalTypes.
+      formalTypes.push_back(useType);
     }
 
     // At this point, we have computed the instantiated type for this

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -3381,7 +3381,6 @@ considerCompilerGeneratedOperators(Context* context,
     return nullptr;
   }
 
-  debuggerBreakHere();
   auto tfs = getCompilerGeneratedBinaryOp(context, lhsType, rhsType, ci.name());
   return tfs;
 }

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -3418,7 +3418,6 @@ considerCompilerGeneratedCandidates(Context* context,
                                                            ci,
                                                            poi);
   CHPL_ASSERT(instantiated.success());
-  CHPL_ASSERT(instantiated.candidate()->untyped()->idIsFunction());
   CHPL_ASSERT(instantiated.candidate()->instantiatedFrom());
 
   candidates.addCandidate(instantiated.candidate());

--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -855,70 +855,70 @@ static bool helpComputeCompilerGeneratedReturnType(Context* context,
       result = QualifiedType(QualifiedType::CONST_VAR, BoolType::get(context));
       return true;
   } else if (untyped->idIsField() && untyped->isMethod()) {
-      // method accessor - compute the type of the field
-      QualifiedType ft = computeTypeOfField(context,
-                                            sig->formalType(0).type(),
-                                            untyped->id());
-      if (ft.isType() || ft.isParam()) {
-        // return the type as-is (preserving param/type-ness)
-        result = ft;
-      } else if (ft.isConst()) {
-        // return a const ref
-        result = QualifiedType(QualifiedType::CONST_REF, ft.type());
-      } else {
-        // return a ref
-        result = QualifiedType(QualifiedType::REF, ft.type());
-      }
-      return true;
-    } else if (untyped->isMethod() && sig->formalType(0).type()->isDomainType()) {
-      auto dt = sig->formalType(0).type()->toDomainType();
-
-      if (untyped->name() == "idxType") {
-        result = dt->idxType();
-      } else if (untyped->name() == "rank") {
-        // Can't use `RankType::rank` because `D.rank` is defined for associative
-        // domains, even though they don't have a matching substitution.
-        result = QualifiedType(QualifiedType::PARAM,
-                               IntType::get(context, 64),
-                               IntParam::get(context, dt->rankInt()));
-      } else if (untyped->name() == "stridable") {
-        result = dt->stridable();
-      } else if (untyped->name() == "parSafe") {
-        result = dt->parSafe();
-      } else if (untyped->name() == "isRectangular") {
-        auto val = BoolParam::get(context, dt->kind() == DomainType::Kind::Rectangular);
-        auto type = BoolType::get(context);
-        result = QualifiedType(QualifiedType::PARAM, type, val);
-      } else if (untyped->name() == "isAssociative") {
-        auto val = BoolParam::get(context, dt->kind() == DomainType::Kind::Associative);
-        auto type = BoolType::get(context);
-        result = QualifiedType(QualifiedType::PARAM, type, val);
-      } else {
-        CHPL_ASSERT(false && "unhandled compiler-generated domain method");
-        return true;
-      }
-      return true;
-    } else if (untyped->isMethod() && sig->formalType(0).type()->isArrayType()) {
-      auto at = sig->formalType(0).type()->toArrayType();
-
-      if (untyped->name() == "domain") {
-        result = QualifiedType(QualifiedType::CONST_REF, at->domainType().type());
-      } else if (untyped->name() == "eltType") {
-        result = at->eltType();
-      } else {
-        CHPL_ASSERT(false && "unhandled compiler-generated array method");
-      }
-
-      return true;
-    } else if (untyped->isMethod() && sig->formalType(0).type()->isTupleType() &&
-               untyped->name() == "size") {
-      auto tup = sig->formalType(0).type()->toTupleType();
-      result = QualifiedType(QualifiedType::PARAM, IntType::get(context, 0), IntParam::get(context, tup->numElements()));
-      return true;
+    // method accessor - compute the type of the field
+    QualifiedType ft = computeTypeOfField(context,
+                                          sig->formalType(0).type(),
+                                          untyped->id());
+    if (ft.isType() || ft.isParam()) {
+      // return the type as-is (preserving param/type-ness)
+      result = ft;
+    } else if (ft.isConst()) {
+      // return a const ref
+      result = QualifiedType(QualifiedType::CONST_REF, ft.type());
     } else {
-      CHPL_ASSERT(false && "unhandled compiler-generated record method");
+      // return a ref
+      result = QualifiedType(QualifiedType::REF, ft.type());
+    }
+    return true;
+  } else if (untyped->isMethod() && sig->formalType(0).type()->isDomainType()) {
+    auto dt = sig->formalType(0).type()->toDomainType();
+
+    if (untyped->name() == "idxType") {
+      result = dt->idxType();
+    } else if (untyped->name() == "rank") {
+      // Can't use `RankType::rank` because `D.rank` is defined for associative
+      // domains, even though they don't have a matching substitution.
+      result = QualifiedType(QualifiedType::PARAM,
+                             IntType::get(context, 64),
+                             IntParam::get(context, dt->rankInt()));
+    } else if (untyped->name() == "stridable") {
+      result = dt->stridable();
+    } else if (untyped->name() == "parSafe") {
+      result = dt->parSafe();
+    } else if (untyped->name() == "isRectangular") {
+      auto val = BoolParam::get(context, dt->kind() == DomainType::Kind::Rectangular);
+      auto type = BoolType::get(context);
+      result = QualifiedType(QualifiedType::PARAM, type, val);
+    } else if (untyped->name() == "isAssociative") {
+      auto val = BoolParam::get(context, dt->kind() == DomainType::Kind::Associative);
+      auto type = BoolType::get(context);
+      result = QualifiedType(QualifiedType::PARAM, type, val);
+    } else {
+      CHPL_ASSERT(false && "unhandled compiler-generated domain method");
       return true;
     }
+    return true;
+  } else if (untyped->isMethod() && sig->formalType(0).type()->isArrayType()) {
+    auto at = sig->formalType(0).type()->toArrayType();
+
+    if (untyped->name() == "domain") {
+      result = QualifiedType(QualifiedType::CONST_REF, at->domainType().type());
+    } else if (untyped->name() == "eltType") {
+      result = at->eltType();
+    } else {
+      CHPL_ASSERT(false && "unhandled compiler-generated array method");
+    }
+
+    return true;
+  } else if (untyped->isMethod() && sig->formalType(0).type()->isTupleType() &&
+             untyped->name() == "size") {
+    auto tup = sig->formalType(0).type()->toTupleType();
+    result = QualifiedType(QualifiedType::PARAM, IntType::get(context, 0), IntParam::get(context, tup->numElements()));
+    return true;
+  } else {
+    CHPL_ASSERT(false && "unhandled compiler-generated record method");
+    return true;
+  }
 }
 
 // returns 'true' if it was a case handled here & sets 'result' in that case

--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -854,6 +854,13 @@ static bool helpComputeCompilerGeneratedReturnType(Context* context,
   } else if (untyped->name() == USTR("==")) {
       result = QualifiedType(QualifiedType::CONST_VAR, BoolType::get(context));
       return true;
+  } else if (untyped->name() == USTR(":")) {
+    // Assume that compiler-generated casts are actually cast.
+    auto input = sig->formalType(0);
+    auto outputType = sig->formalType(1);
+
+    result = QualifiedType(input.kind(), outputType.type());
+    return true;
   } else if (untyped->idIsField() && untyped->isMethod()) {
     // method accessor - compute the type of the field
     QualifiedType ft = computeTypeOfField(context,


### PR DESCRIPTION
This PR adds casts to and from enums when the enum / integer is not a param value. It does so by mimicking what the production compiler does: building a single, generic "from" function, and a single, generic "to" function. The functions look something like this:

```Chapel
operator :(from: theEnum, type to: integral)
operator :(from: integral, type to: theEnum)
```

This requires some adjustments:
* An easy initial adjustment is that the existing framework relies on the first formal to determine whether a compiler-generated candidate should be considered. However, in the above, the cast _to_ an enum uses a generic integral type as its "receiver". Thus, I make changes to support finding compiler-generated candidates for general binary operation.
* A more significant adjustment is that to make the functions generic, we need to allow them to be instantiated. However, instantiation until this point has relied on the ability to find ASTs associated with each formal. In this PR I adjust the instantiation code to no longer have this assumption.

With this PR, @benharsh's example resolves (when the standard library is enabled):

<details>
<summary>See motivatign example</summary>

```Chapel
enum numbers {
  zero = 0,
  one = 1,
  two = 2,
  three = 3
}

proc foo(param num : int) {
  select num:numbers { // no matching candidates
    when numbers.zero do return 42;
    when numbers.one do return 5.0;
    when numbers.two do return "hello";
  }

  return b"hello";
}

proc baz(num: int) {
  select num:numbers { // no matching candidates
    when numbers.zero do return 0;
    when numbers.one do return 1;
    when numbers.two do return 2;
    otherwise return 3;
  }
}

var x = foo(2);

var y = baz(2);
````
</details>

Reviewed by @benharsh -- thanks!

## Testing
- [x] dyno tests
- [x] paratest