### PR TITLE
Fix problem with chapel-py

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -44,6 +44,7 @@
 #include "version.h"
 #include "visibleFunctions.h"
 
+#include "chpl/framework/check-build.h"
 #include "chpl/framework/Context.h"
 #include "chpl/framework/compiler-configuration.h"
 #include "chpl/parsing/parsing-queries.h"

--- a/frontend/include/chpl/framework/Context.h
+++ b/frontend/include/chpl/framework/Context.h
@@ -334,6 +334,9 @@ class Context {
 
 #ifdef HAVE_LLVM
   owned<llvm::LLVMContext> llvmContext_ = nullptr;
+#else
+  // use a dummy pointer to make sure to have the same memory layout
+  owned<unsigned char> llvmContext_ = nullptr;
 #endif
 
   // --------- end all Context fields ---------
@@ -1021,9 +1024,9 @@ class Context {
           }
         });
   }
-
   /// \endcond
 };
+
 
 } // end namespace chpl
 

--- a/frontend/include/chpl/framework/check-build.h
+++ b/frontend/include/chpl/framework/check-build.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 Hewlett Packard Enterprise Development LP 
+ * Other additional copyright holders may be indicated within.
+ *  
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *      
+ * You may obtain a copy of the License at
+ *      
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *        
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */       
+            
+#ifndef CHPL_FRAMEWORK_CHECK_BUILD_H
+#define CHPL_FRAMEWORK_CHECK_BUILD_H
+
+#include "llvm/Config/llvm-config.h"
+
+/*
+
+This file exists to check that the current configuration used by the header
+files matches the configuration from when the .cpp files in the library were
+built. Include this header file from one .cpp file in an application.  That will
+cause it to run the check at runtime and print an error out to stderr if there
+is a problem.
+
+*/
+
+// should not be necessary to call this directly, but any calls
+// to it should pass no arguments
+bool validateCompiledCorrectly(
+      int headersHaveLlvm=
+#ifdef HAVE_LLVM
+        1,
+#else
+        0,
+#endif
+       int headersLlvmMajor=LLVM_VERSION_MAJOR
+      );
+
+// Initialize a global by running validateCompiledCorrectly()
+// so that it is run automatically if this header file is included.
+static bool compiledCorrectly=validateCompiledCorrectly();
+
+#endif

--- a/frontend/lib/framework/CMakeLists.txt
+++ b/frontend/lib/framework/CMakeLists.txt
@@ -18,6 +18,7 @@
 target_sources(ChplFrontend-obj
                PRIVATE
 
+               check-build.cpp
                Context.cpp
                ErrorBase.cpp
                ErrorMessage.cpp

--- a/frontend/lib/framework/check-build.cpp
+++ b/frontend/lib/framework/check-build.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. 
+ */  
+
+#include "chpl/framework/check-build.h"
+
+#include <cstdio>
+
+bool validateCompiledCorrectly(int headersHaveLlvm, int headersLlvmMajor) {
+  int cppHaveLlvm=
+#ifdef HAVE_LLVM
+        1;
+#else
+        0;
+#endif
+  int cppLlvmMajor=LLVM_VERSION_MAJOR;
+
+  if (headersHaveLlvm != cppHaveLlvm) {
+    const char* headers = headersHaveLlvm ? "with" : "without";
+    const char* cpp =  cppHaveLlvm ? "with" : "without";
+    fprintf(stderr, "Misconfiguration of the C++ Chapel compiler library\n");
+    fprintf(stderr, "  headers in use %s HAVE_LLVM defined\n", headers);
+    fprintf(stderr, "  .cpp files compiled %s HAVE_LLVM defined\n", cpp);
+    return false;
+  }
+
+  if (headersLlvmMajor != cppLlvmMajor) {
+    fprintf(stderr, "Misconfiguration of the C++ Chapel compiler library\n");
+    fprintf(stderr, "  headers in use have LLVM_VERSION_MAJOR %i\n",
+            headersLlvmMajor);
+    fprintf(stderr, "  .cpp files have LLVM_VERSION_MAJOR %i\n", cppLlvmMajor);
+    return false;
+  }
+
+  return true;
+}

--- a/tools/chapel-py/setup.py
+++ b/tools/chapel-py/setup.py
@@ -33,12 +33,16 @@ for line in chpl_variables_lines:
     if len(elms) == 2:
         chpl_variables[elms[0].strip()] = elms[1].strip()
 
+have_llvm = str(chpl_variables.get("CHPL_LLVM"))
 llvm_config = str(chpl_variables.get("CHPL_LLVM_CONFIG"))
 
 host_bin_subdir = str(chpl_variables.get("CHPL_HOST_BIN_SUBDIR"))
 chpl_lib_path = os.path.join(chpl_home, "lib", "compiler", host_bin_subdir)
 
 CXXFLAGS = []
+if have_llvm:
+    CXXFLAGS += ["-DHAVE_LLVM"]
+
 CXXFLAGS += ["-Wno-c99-designator"]
 CXXFLAGS += subprocess.check_output([llvm_config, "--cxxflags"]).decode(sys.stdout.encoding).strip().split()
 CXXFLAGS += ["-std=c++17", "-I{}/frontend/include".format(chpl_home)]

--- a/tools/chapel-py/src/chapel.cpp
+++ b/tools/chapel-py/src/chapel.cpp
@@ -19,6 +19,7 @@
 
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
+#include "chpl/framework/check-build.h"
 #include "chpl/framework/Context.h"
 #include "chpl/parsing/parsing-queries.h"
 #include "iterator-support.h"


### PR DESCRIPTION
This PR fixes a problem with chapel-py on some systems after PR https://github.com/chapel-lang/chapel/pull/24477. That PR added a field to `Context` that depends on `#ifdef HAVE_LLVM`. Due to a mismatch between the library compile environment and the chapel-py compile environment, the `Context` would be allocated without this field, but then the library would try to set it, leading to writing outside of the allocation.

The simple fix to this is to declare a dummy field for the case that LLVM is not available.

Additionally, to avoid this sort of problem in the future, this PR adds a mechanism to check if the relevant `#define`s for the header files match those used when building the library. It uses this from `chpl` and `chapel-py`.

Lastly, to resolve the misconfiguration, it adds `-DHAVE_LLVM` (depending on `CHPL_LLVM`) to the C++ compile configuration for chapel-py.

Resolves https://github.com/Cray/chapel-private/issues/6054

Reviewed by @DanilaFe - thanks!