### PR TITLE
fix for recently added nightly minibude testing

### DIFF
--- a/test/gpu/native/studies/minibude/SKIPIF
+++ b/test/gpu/native/studies/minibude/SKIPIF
@@ -3,8 +3,8 @@
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 
 # We're currently using Josh's fork, at some point this may get integrated into
-# the main minbude repos here: git@github.com:xianghao-wang/miniBUDE.git
-MINIBUDE_URL=${MINIBUDE_URL:-git@github.com:milthorpe/miniBUDE.git}
+# the main minbude repos here: https://github.com/UoB-HPC/miniBUDE.git
+MINIBUDE_URL=${MINIBUDE_URL:-https://github.com/milthorpe/miniBUDE.git}
 MINIBUDE_BRANCH=${MINIBUDE_BRANCH:-v2}
 
 # Clone miniBUDE, skipif clone failed, add extra output to fail nightly job


### PR DESCRIPTION
The system we do nightly testing on for minibude has issues doing `git clone` with an ssh-based url. This PR simply updates the url we clone from to use https rather than ssh (which is also what we do for nightly chop testing).