### PR TITLE
Avoid crashing when resolving the IO module

### DIFF
--- a/frontend/include/chpl/framework/ErrorWriter.h
+++ b/frontend/include/chpl/framework/ErrorWriter.h
@@ -134,7 +134,7 @@ struct Writer<errordetail::AsFileName<T>> {
 template <>
 struct Writer<const types::Type*> {
   void operator()(Context* context, std::ostream& oss, const types::Type* type) {
-    if (type->isUnknownType()) {
+    if (!type || type->isUnknownType()) {
       oss << "unknown type";
     } else {
       stringify<const types::Type*> str;

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2208,8 +2208,6 @@ QualifiedType Resolver::typeForId(const ID& id, bool localGenericToUnknown) {
     }
   }
 
-  CHPL_ASSERT(ct); // or else, pattern not handled yet
-
   if (ct) {
     auto newDefaultsPolicy = defaultsPolicy;
     if (defaultsPolicy == DefaultsPolicy::USE_DEFAULTS_OTHER_FIELDS &&
@@ -2240,7 +2238,7 @@ QualifiedType Resolver::typeForId(const ID& id, bool localGenericToUnknown) {
 
   // Otherwise it is a case not handled yet
   // TODO: handle outer function variables
-  CHPL_ASSERT(false && "not yet handled");
+  CHPL_UNIMPL("not yet handled");
   auto unknownType = UnknownType::get(context);
   return QualifiedType(QualifiedType::UNKNOWN, unknownType);
 }

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -509,6 +509,11 @@ void CallInitDeinit::resolveAssign(const AstNode* ast,
                                    const QualifiedType& lhsType,
                                    const QualifiedType& rhsType,
                                    RV& rv) {
+  if (lhsType.isUnknown() || lhsType.isErroneousType() ||
+      rhsType.isUnknown() || rhsType.isErroneousType()) {
+    return;
+  }
+
   std::vector<CallInfoActual> actuals;
   actuals.push_back(CallInfoActual(lhsType, UniqueString()));
   actuals.push_back(CallInfoActual(rhsType, UniqueString()));

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -227,7 +227,8 @@ generateInitSignature(Context* context, const CompositeType* inCompType) {
 
   // TODO: generic types
   if (rf.isGeneric()) {
-    CHPL_ASSERT(false && "Not handled yet!");
+    CHPL_UNIMPL("generating 'init' signatures for generic types is not yet supported");
+    return nullptr;
   }
 
   // TODO: super fields and invoking super
@@ -745,16 +746,16 @@ getCompilerGeneratedMethodQuery(Context* context, const Type* type,
       } else if (name == USTR("=")) {
         result = generateRecordAssignment(context, recordType);
       } else {
-        CHPL_ASSERT(false && "record method not implemented yet!");
+        CHPL_UNIMPL("record method not implemented yet!");
       }
     } else if (auto cPtrType = type->toCPtrType()) {
       result = generateCPtrMethod(context, cPtrType, name);
     } else {
-      CHPL_ASSERT(false && "should not be reachable");
+      CHPL_UNIMPL("should not be reachable");
     }
   }
 
-  CHPL_ASSERT(result->untyped()->name() == name);
+  CHPL_ASSERT(result == nullptr || result->untyped()->name() == name);
 
   return QUERY_END(result);
 }

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -3353,7 +3353,6 @@ considerCompilerGeneratedMethods(Context* context,
   // get the compiler-generated function, may be generic
   auto tfs = getCompilerGeneratedMethod(context, receiverType, ci.name(),
                                         ci.isParenless());
-  CHPL_ASSERT(tfs);
   return tfs;
 }
 

--- a/frontend/lib/util/assertions.cpp
+++ b/frontend/lib/util/assertions.cpp
@@ -67,8 +67,8 @@ void chpl_unimpl(const char* filename, const char* func, int lineno,
                  const char* msg) {
   std::string fname(filename);
   auto front = fname.substr(fname.find("frontend"), std::string::npos);
-  printf("[%s:%d in %s] Unimplemented: %s\n", front.c_str(), lineno,
-         func, msg);
+  fprintf(stderr, "[%s:%d in %s] Unimplemented: %s\n", front.c_str(), lineno,
+          func, msg);
 };
 
 


### PR DESCRIPTION
This comes up when you run the language server on the IO module. Prior to this PR, several points of the resolver cause a hard crash (segmentation fault or assertion error), which also crashed the language server. This PR makes tweaks to avoid hard crashes like that, and thus allows LSP to be used with the resolver in more cases.

Reviewed by @mppf -- thanks!

## Testing
- [x] dyno tests
- [x] paratest