### PR TITLE
Update spec for marking generic types passed to type formals

### DIFF
--- a/doc/rst/language/spec/generics.rst
+++ b/doc/rst/language/spec/generics.rst
@@ -1053,6 +1053,8 @@ marked with ``(?)``:
 
  * ``class-inherit`` expressions (see :ref:`Inheritance`)
 
+ * generic types passed to a `type` formal argument (see
+   :ref:`Formal_Type_Arguments`)
 
 .. _Generic_Methods:
 


### PR DESCRIPTION
Follow-up to PR #24021.

This PR adds a sentence to the spec section about marking generic types to include cases like `f(myGenericRecord)`.

Reviewed by @benharsh - thanks!