### PR TITLE
Promote a future that passes after #24560

### DIFF
--- a/test/library/standard/List/initEquals/listInitEqualsArrayBug.chpl
+++ b/test/library/standard/List/initEquals/listInitEqualsArrayBug.chpl
@@ -2,8 +2,8 @@ use List;
 
 // this works, creates a list of arrays
 var a: list(?) = [[1,2,3],[4,5,6]];
-compilerWarning(a.type:string);
+writeln(a.type:string, " = ", a);
 
 // this segfaults at runtime, no matter the domain used for the array
 var b: list([1..3] int) = [[1,2,3],[4,5,6]];
-compilerWarning(b.type:string);
+writeln(b.type:string, " = ", b);

--- a/test/library/standard/List/initEquals/listInitEqualsArrayBug.future
+++ b/test/library/standard/List/initEquals/listInitEqualsArrayBug.future
@@ -1,2 +1,0 @@
-bug: init= segfaults at runtime
-#24305

--- a/test/library/standard/List/initEquals/listInitEqualsArrayBug.good
+++ b/test/library/standard/List/initEquals/listInitEqualsArrayBug.good
@@ -1,2 +1,2 @@
-listInitEqualsArrayBug.chpl:5: warning: list([domain(1,int(64),one)] int(64),false)
-listInitEqualsArrayBug.chpl:9: warning: list([domain(1,int(64),one)] int(64),false)
+list([domain(1,int(64),one)] int(64),false) = [1 2 3, 4 5 6]
+list([domain(1,int(64),one)] int(64),false) = [1 2 3, 4 5 6]


### PR DESCRIPTION
Resolves #24305.

This future passes because array types at arbitrary depths are now converted into array types instead of loops.

Reviewed by @jabraham17. Thanks!