### PR TITLE
Limit GPU distributed array support to only locally-accessed arrays

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -1492,7 +1492,6 @@ inline proc BlockArr.dsiBoundsCheck(i: rank*idxType) {
 }
 
 pragma "fn unordered safe"
-pragma "not called from gpu"
 proc BlockArr.nonLocalAccess(i: rank*idxType) ref {
   if doRADOpt {
     if const myLocArr = this.myLocArr {


### PR DESCRIPTION
This PR fixes a bug where distributed array accesses on non-GPU-bound loops could cause compilation errors. This is because we try to write a stub for nonLocalAccess when it is called from a GPU kernel. The way we do that is less than ideal and caused problems before (https://github.com/Cray/chapel-private/issues/5957).

To fix, we remove the special pragma on the `nonLocalAccess`. With that, we'll still be able to use distributed arrays in GPU kernels in rudimentary cases as before. They just have to be accessed via `localAccess`, either manually, or through automatic local access optimization.

Test
- [x] nvidia
- [x] amd 