### PR TITLE
Restore non-serial promotion for domain.add()

### DIFF
--- a/doc/rst/language/spec/domains.rst
+++ b/doc/rst/language/spec/domains.rst
@@ -430,7 +430,7 @@ subdomain has the same type as its parent domain, and by default it
 inherits the distribution of its parent domain. All domain types support
 subdomains.
 
-Simple subdomains are subdomains which are not sparse. Sparse subdomains
+Simple subdomains are subdomains that are not sparse. Sparse subdomains
 are discussed in the following section
 (:ref:`Sparse_Subdomain_Types_and_Values`). A simple subdomain
 inherits its representation (regular or irregular) from its base domain
@@ -483,10 +483,8 @@ The default value of a simple subdomain type is the same as the default
 value of its parent’s type (:ref:`Rectangular_Domain_Values`,
 :ref:`Associative_Domain_Values`).
 
-A simple subdomain variable can be initialized or assigned to with a
-tuple of values of the parent’s ``idxType``. Indices can also be added
-to or removed from a simple subdomain as described in
-:ref:`Adding_and_Removing_Domain_Indices`. It is an error to
+A simple subdomain can be initialized or otherwise operated on
+in the same way as its parent domain. It is an error to
 attempt to add an index to a subdomain that is not also a member of the
 parent domain.
 
@@ -533,8 +531,12 @@ the domain describes. If the parent domain defines an iteration order
 over its indices, the sparse subdomain inherits that order.
 
 There is no literal syntax for a sparse subdomain. However, a variable
-of a sparse subdomain type can be initialized using a tuple of values of
-the parent domain’s index type.
+of a sparse subdomain type can be initialized or assigned to
+with a tuple containing the desired index values.
+Each index value must be of the parent’s ``rank*idxType``, or,
+for a one-dimensional domain, of the parent's ``idxType``.
+Indices can also be added to or removed from a sparse subdomain
+as described in :ref:`Adding_and_Removing_Domain_Indices`.
 
 The default value for a sparse subdomain value is the empty set.
 

--- a/test/arrays/localQueries/localAccess.chpl
+++ b/test/arrays/localQueries/localAccess.chpl
@@ -25,8 +25,7 @@ var baseDom = {1..10};
 }
 
 {
-  var assocDom: domain(string);
-  assocDom += ["foo", "bar"];
+  var assocDom: domain(string)  = {"foo", "bar"};
   test(assocDom);
 }
 

--- a/test/domains/compilerErrors/promo-unsafe.chpl
+++ b/test/domains/compilerErrors/promo-unsafe.chpl
@@ -1,0 +1,9 @@
+
+var ad: domain(int, parSafe=false);
+ad.add([123]);  // par-unsafe if adding multiple elements
+writeln(ad);
+
+var rd = {1..1000};
+var sd: sparse subdomain(rd);
+sd.add([321]);  // par-unsafe if adding multiple elements
+writeln(sd);

--- a/test/domains/compilerErrors/promo-unsafe.good
+++ b/test/domains/compilerErrors/promo-unsafe.good
@@ -1,0 +1,4 @@
+promo-unsafe.chpl:3: warning: this promoted addition of indices to an associative domain may be unsafe due to race conditions; consider replacing promotion with an explicit for loop or declaring the domain type with 'parSafe=true'
+promo-unsafe.chpl:8: warning: this promoted addition of indices to a sparse domain may be unsafe due to race conditions; consider replacing promotion with an explicit for loop
+{123}
+{321}

--- a/test/domains/userAPI/contains.good
+++ b/test/domains/userAPI/contains.good
@@ -1,3 +1,4 @@
+contains.chpl:29: warning: this promoted addition of indices to an associative domain may be unsafe due to race conditions; consider replacing promotion with an explicit for loop or declaring the domain type with 'parSafe=true'
 110
 120
 130


### PR DESCRIPTION
This PR reverses the part of #24565 that forced a promoted `add` to a sparse or non-parSafe domain to execute serially. Instead it makes the compiler issue a warning that such promoted add can lead to races. The reason for the reversal is that we are not sure the "force to execute serially" is a good solution and we have not discussed it adequately.

This PR also reverses the change that 24565 made to `test/arrays/localQueries/localAccess.chpl` because it would be racy otherwise. It also records the warning issued in contains.chpl. So far this test has been passing despite the race in `assoc_sub2 += n..#10;` where `assoc_sub2` is a parSafe=false domain, so I am leaving the code unchanged.

While there, correct+clarify pieces of the language spec on domains.

Testing: standard and gasnet paratests.