### PR TITLE
Recover nvidia gpu performance for sqrt

### DIFF
--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -2188,7 +2188,9 @@ static GenRet codegenSqrt(GenRet a) {
   GenRet ret;
   if (a.chplType && a.chplType->symbol->isRefOrWideRef()) a = codegenDeref(a);
   GenRet av = codegenValue(a);
-  if (info->cfile) {
+  if (info->cfile ||
+      (usingGpuLocaleModel() &&
+       getGpuCodegenType() == GpuCodegenType::GPU_CG_NVIDIA_CUDA)) {
     ret = emitSqrtCMath(av);
   } else {
     ret = emitSqrtLLVMIntrinsic(av);

--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -2150,6 +2150,13 @@ static GenRet codegenFma(GenRet a, GenRet b, GenRet c) {
   return ret;
 }
 
+static bool preferCMathOverLLVMIntr() {
+  // prefer using the cmath implementation if using CHPL_GPU=nvidia for better
+  // performance
+  return usingGpuLocaleModel() &&
+         getGpuCodegenType() == GpuCodegenType::GPU_CG_NVIDIA_CUDA;
+}
+
 static GenRet emitSqrtCMath(GenRet av) {
   GenRet ret;
   if (av.chplType == dtReal[FLOAT_SIZE_64]) {
@@ -2188,9 +2195,7 @@ static GenRet codegenSqrt(GenRet a) {
   GenRet ret;
   if (a.chplType && a.chplType->symbol->isRefOrWideRef()) a = codegenDeref(a);
   GenRet av = codegenValue(a);
-  if (info->cfile ||
-      (usingGpuLocaleModel() &&
-       getGpuCodegenType() == GpuCodegenType::GPU_CG_NVIDIA_CUDA)) {
+  if (info->cfile || preferCMathOverLLVMIntr()) {
     ret = emitSqrtCMath(av);
   } else {
     ret = emitSqrtLLVMIntrinsic(av);
@@ -2236,7 +2241,7 @@ static GenRet codegenAbs(GenRet a) {
   GenRet ret;
   if (a.chplType && a.chplType->symbol->isRefOrWideRef()) a = codegenDeref(a);
   GenRet av = codegenValue(a);
-  if (info->cfile) {
+  if (info->cfile || preferCMathOverLLVMIntr()) {
     ret = emitAbsCMath(av);
   } else {
     ret = emitAbsLLVMIntrinsic(av);


### PR DESCRIPTION
This PR recovers a performance regression seen in our nightly testing for GPU kernels that make heavy usage of sqrt. 

For GPU codegen, we do `linkGpuDeviceLibraries()`, which among other things replaces the libc `sqrt` with a special gpu optimized `sqrt` (at least for nvidia). This PR #24455 changed how we codegen `sqrt` to directly codegen to LLVM, meaning we were no longer getting the "special" nvidia sqrt. Note that using the `sqrt` intrinsic resulted in an AMD gpu improvement.

Testing using `test/gpu/native/studies/coral`, lower is better

|    | llvm sqrt intrinsic | libc sqrt | percent diff |
| --- | --- | --- | --- |
| nvidia (sm_60) | 1.20545 | 0.993516 | 19% |
| amd (gfx908) | 1.69853 | 1.87864 | -10% |

Based on this, this PR turns off the `sqrt` intrinsic transformation only for GPU codegen with nvidia

[reviewed by @e-kayrakli]