### PR TITLE
Skipif this test to work around issue #24113

### DIFF
--- a/test/functions/generic/warn-generic-actual.skipif
+++ b/test/functions/generic/warn-generic-actual.skipif
@@ -1,0 +1,2 @@
+# work around issue #24113
+COMPOPTS <= --baseline


### PR DESCRIPTION
Follow-up to PR #24021 to address a test failing with `--baseline`.

This PR just adds a .skipif file as a work around to issue #24113.

Test change only - not reviewed.