### PR TITLE
Fix miniBude nightly testing

### DIFF
--- a/test/gpu/native/studies/minibude/Bude.good
+++ b/test/gpu/native/studies/minibude/Bude.good
@@ -17,7 +17,7 @@ config:
   wgsize:       [64]
 device: { index: 0, name: "Chapel CPU" }
 
-Running Chapel on 1 GPU
+Running Chapel on NN GPUs
 
 Largest difference was less than 0.020%.
 

--- a/test/gpu/native/studies/minibude/Bude.prediff
+++ b/test/gpu/native/studies/minibude/Bude.prediff
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 # filter number of gpus run on from output
-cat $2 | sed 's/Running Chapel on [0-9]\+ GPUs\{0,1\}/Running Chapel on NN GPUs/' > $2.prediff.tmp
+cat $2 | sed 's/Running Chapel on [0-9]\{1,\} GPUs\{0,1\}/Running Chapel on NN GPUs/' > $2.prediff.tmp
 mv $2.prediff.tmp $2

--- a/test/gpu/native/studies/minibude/Bude.prediff
+++ b/test/gpu/native/studies/minibude/Bude.prediff
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# filter number of gpus run on from output
+cat $2 | sed 's/Running Chapel on [0-9]\+ GPUs\{0,1\}/Running Chapel on NN GPUs/' > $2.prediff.tmp
+mv $2.prediff.tmp $2

--- a/test/gpu/native/studies/minibude/SKIPIF
+++ b/test/gpu/native/studies/minibude/SKIPIF
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# skip if using CHPL_GPU=cpu
+if [ "$CHPL_GPU" = "cpu" ]; then
+  echo "True"
+  exit
+fi
+
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 
 # We're currently using Josh's fork, at some point this may get integrated into


### PR DESCRIPTION
Fixes a few issues with the test configuration for miniBude in nightly testing.

- SKIPIF testing for CHPL_GPU=cpu
- filter output when running on multiple gpus


Tested on system with 1 gpu, 2 gpus, and with CHPL_GPU=cpu

[Not reviewed, trivial]
