### PR TITLE
Guard collapseTrivialMoves() with --no-return-by-ref

### DIFF
--- a/compiler/passes/denormalize.cpp
+++ b/compiler/passes/denormalize.cpp
@@ -118,7 +118,8 @@ void denormalize(void) {
       } while(deferredSyms.size() > 0);
     }
 
-    collapseTrivialMoves();
+    if (!fReturnByRef)
+      collapseTrivialMoves();
   }
 }
 


### PR DESCRIPTION
This PR disables invoking collapseTrivialMoves() by default. If desired, it can be enabled using the compiler flag `--no-return-by-ref`.

collapseTrivialMoves() was added in #24519 under the presumption that it was harmless. However, we observe it to cause, or at least trigger, the following error when running on NVIDIA GPUs under CUDA 12:
```
# test: gpu/native/studies/shoc/shoc-sort
internal error: gpu-nvidia.c:292: Error calling CUDA function: misaligned address (Code: 716)
```

So I am turning it off by default to clear testing, pending further investigation.

Suggested by @e-kayrakli .