### PR TITLE
Extend the man page description of `--[no-]const-arg-checks`

### DIFF
--- a/man/chpl.rst
+++ b/man/chpl.rst
@@ -390,8 +390,12 @@ OPTIONS
 
 **\--[no-]const-arg-checks**
 
-    Enable [disable] const argument checks (only when --warn-unstable is also
-    used)
+    Enable [disable] const argument checks (only when **--warn-unstable** is
+    also used).  These checks will warn when an argument is inferred to be
+    `const ref` and is indirectly modified over the course of the function.  To
+    silence the warning for a particular argument, give it a concrete argument
+    intent (such as `const ref` or `const in`, depending on if the indirect
+    modification behavior should be preserved or avoided).
 
 **\--[no-]div-by-zero-checks**
 


### PR DESCRIPTION
Brad pointed out that we didn't have documentation for the `const` and default argument intent indirect modification warning.  Since the check is implementation-specific, it doesn't make sense to mention it in the spec.  Brad suggested the man page as a place people are likely to encounter it in the steady state (and the entry didn't necessarily give sufficient context to begin with).

Here's how the entry now renders
<img width="538" alt="Screenshot 2024-03-12 at 8 19 33 AM" src="https://github.com/chapel-lang/chapel/assets/2454710/de16edc3-cae8-48a2-a0a6-8d77eb3e88e6">

Passed a full paratest with futures.
