### PR TITLE
Fix bug when writing DefaultRectangular arrays in binary across locales

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1839,7 +1839,10 @@ module DefaultRectangular {
                             _isSimpleIoType(arr.eltType);
 
     const len = dom.dsiNumIndices:int;
-    if useBulkElements && arr.isDataContiguous(dom) && len > 0 {
+    var dataLoc = if len > 0 then arr.dsiAccess(dom.dsiFirst).locale
+                  else here;
+    if useBulkElements && arr.isDataContiguous(dom) && len > 0 &&
+      f._home == dataLoc {
       var ptr = c_addrOf(arr.dsiAccess(dom.dsiFirst));
       if f._writing then
         helper.writeBulkElements(ptr, len);

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3751,6 +3751,12 @@ record binarySerializer {
 
         This method is only optimized for the case where the
         ``binarySerializer`` has been configured for ``native`` endianness.
+
+      .. warning::
+
+        This method should only be called when the ``data`` argument is located
+        on the same locale as the underlying ``file`` of this serializer.
+        Otherwise the ``c_ptr`` will be invalid.
     */
     proc writeBulkElements(data: c_ptr(?eltType), numElements: int) throws
     where isNumericType(eltType) {
@@ -4235,6 +4241,12 @@ record binaryDeserializer {
 
         This method is only optimized for the case where the
         ``binaryDeserializer`` has been configured for ``native`` endianness.
+
+      .. warning::
+
+        This method should only be called when the ``data`` argument is located
+        on the same locale as the underlying ``file`` of this deserializer.
+        Otherwise the ``c_ptr`` will be invalid.
     */
     proc readBulkElements(data: c_ptr(?eltType), numElements: int) throws
     where isNumericType(eltType) {


### PR DESCRIPTION
This PR fixes a bug where reading or writing a DefaultRectangular array using ``binary(De)Serializer`` to a remote locale would fail at runtime. The runtime error message would unhelpfully point to the DefaultRectangular implementation and complain about using remote data with ``c_pointer_return``.

The core issue was that we should not have been trying to get a ``c_ptr`` to the array's data when that data and the file did not exist on the same locale. This PR updates the implementation to check the locality of the data and file before trying the optimized "bulk elements" path, and otherwise will fall back on the element-by-element approach.

A potential future optimization could be to create a small local buffer on the file's locale into which we could copy chunks of the array's data.

The documentation for binary(De)Serializer's "bulk elements" methods is updated to point out this locality issue with the ``c_ptr`` argument.

Testing:
- [x] local
- [x] gasnet