### PR TITLE
Fix docs build errors from frontend C++ code docs

### DIFF
--- a/frontend/doc/doxygen-pitfalls.txt
+++ b/frontend/doc/doxygen-pitfalls.txt
@@ -3,6 +3,7 @@ COMMON PITFALLS WITH DOXYGEN (THAT BREAK THE DOCS BUILD)
 Whenever you run into a Doxygen problem that breaks the docs build,
 make sure to explain what you did to fix it here.
 
+
 ---
 ERROR: "WARNING: cpp: identifier reference target not found
 ---
@@ -50,3 +51,25 @@ function inside a DO_NOT_DOCUMENT block like so:
 These probably aren't worth figuring out how to fix, and they don't
 really need documentation anyway.
 
+
+---
+"WARNING: Invalid C++ declaration: Expected identifier in nested name."
+---
+
+This seems to come up in a setting like
+
+  class Something {
+    enum {
+      A = 1,
+      B = 2
+    };
+  }
+
+it seems to be sensitive to the version of doxygen.
+
+If doc/rst/conf.py includes `breathe_debug_trace_directives = True`
+then the log will include something like:
+
+  Running directive: .. cpp:enum:: 
+
+for this case.

--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -41,6 +41,7 @@ class BorrowedIdsWithName;
 class IdAndFlags {
  public:
   // helper types
+  /// \cond DO_NOT_DOCUMENT
   enum {
     /** Public */
     PUBLIC = 1,
@@ -62,6 +63,8 @@ class IdAndFlags {
     NOT_METHOD = 128,
     // note: if adding something here, also update flagsToString
   };
+  /// \endcond
+
   /**
     A bit-set of the flags defined in the above enum.
     Represents a conjunction / AND of all the set bit.
@@ -578,6 +581,7 @@ using DeclMap = std::unordered_map<UniqueString, OwnedIdsWithName>;
 class Scope {
  public:
   // supporting types/enums
+  /// \cond DO_NOT_DOCUMENT
   enum {
     CONTAINS_FUNCTION_DECLS = 1,
     CONTAINS_USE_IMPORT = 2,
@@ -585,6 +589,8 @@ class Scope {
     METHOD_SCOPE = 8,
     CONTAINS_EXTERN_BLOCK = 16,
   };
+  /// \endcond
+
   /** A bit-set of the flags defined in the above enum */
   using ScopeFlags = unsigned int;
 
@@ -979,6 +985,7 @@ enum VisibilityStmtKind {
   VIS_IMPORT,
 };
 
+/// \cond DO_NOT_DOCUMENT
 enum {
   /**
     When looking at a scope, find symbols declared in that scope.
@@ -1046,6 +1053,7 @@ enum {
    */
   LOOKUP_METHODS = 2048,
 };
+/// \endcond
 
 /** LookupConfig is a bit-set of the LOOKUP_ flags defined above */
 using LookupConfig = unsigned int;

--- a/frontend/include/chpl/types/ClassTypeDecorator.h
+++ b/frontend/include/chpl/types/ClassTypeDecorator.h
@@ -54,11 +54,15 @@ class ClassTypeDecorator final {
     GENERIC_NONNIL    = 13,
     GENERIC_NILABLE   = 14,
   };
+
+  /// \cond DO_NOT_DOCUMENT
   enum {
     NUM_DECORATORS = 12,
     MANAGEMENT_MASK = 0xfc,
     NILABILITY_MASK = 0x03,
   };
+  /// \endcond
+
 
   /** Given an integer i with 0 <= i < NUM_DECORATORS
       returns a decorator with that number. This can be used to


### PR DESCRIPTION
This PR adds a workaround to avoid "Invalid C++ declaration" errors when doing `make docs`. Oddly enough, the errors seemed to go away with a second `make docs`, and appeared on some platforms but not others.

The errors looked like this:

```
/some/path/to/file.rst:11: WARNING: Invalid C++ declaration: Expected identifier in nested name. [error at 0]
```

It seems to be connected to unnamed enums declared within a class, e.g.

``` c++
class Something {
  enum {
    A = 1,
    B = 2
  };
}
```

This PR works around the problem by adding `/// \cond DO_NOT_DOCUMENT` around such enums.

Reviewed by @arezaii - thanks!

- [x] resolved the problem on a system with doxygen 1.10 where it was appearing
- [x] full comm=none testing