### PR TITLE
Fix 'can instantiate'-driven error in interface resolution

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -959,12 +959,9 @@ bool canInstantiate(Type* actualType, Type* formalType) {
         // By the above condition, x1 != x2, but instantiation is still possible
         // if one of the xs instantiates another. Strip the 'owned' etc.
         // In that case, compare the underlying types.
-        bool isActualAnyManaged = isDecoratedClassType(actualType) &&
-          (actualDec & ClassTypeDecorator::MANAGEMENT_MASK) == ClassTypeDecorator::GENERIC;
         bool isFormalAnyManaged = isDecoratedClassType(formalType) &&
-          (formalDec & ClassTypeDecorator::MANAGEMENT_MASK) == ClassTypeDecorator::GENERIC;
-        if ((isActualAnyManaged || isFormalAnyManaged) &&
-            instantiatedFieldsMatch(actualC, formalC)) {
+          isDecoratorUnknownManagement(formalDec);
+        if (isFormalAnyManaged && instantiatedFieldsMatch(actualC, formalC)) {
           return true;
         }
       }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -950,6 +950,23 @@ bool canInstantiate(Type* actualType, Type* formalType) {
         if (instantiatedFieldsMatch(actualType, formalType)) {
           return true;
         }
+
+        // We may have a 'DecoratedClassType' as one of the arguments
+        // (e.g. anymanaged x1) and a regular class (e.g. shared(x2)) as another.
+        // This would've failed the check above, since anymanaged x1 is not
+        // an aggregate typem and x1 is not an instantiation of shared(x2), either.
+        //
+        // By the above condition, x1 != x2, but instantiation is still possible
+        // if one of the xs instantiates another. Strip the 'owned' etc.
+        // In that case, compare the underlying types.
+        bool isActualAnyManaged = isDecoratedClassType(actualType) &&
+          (actualDec & ClassTypeDecorator::MANAGEMENT_MASK) == ClassTypeDecorator::GENERIC;
+        bool isFormalAnyManaged = isDecoratedClassType(formalType) &&
+          (formalDec & ClassTypeDecorator::MANAGEMENT_MASK) == ClassTypeDecorator::GENERIC;
+        if ((isActualAnyManaged || isFormalAnyManaged) &&
+            instantiatedFieldsMatch(actualC, formalC)) {
+          return true;
+        }
       }
     }
   } else {

--- a/test/classes/corrado/interfaces_warning_bug.bad
+++ b/test/classes/corrado/interfaces_warning_bug.bad
@@ -1,2 +1,0 @@
-interfaces_warning_bug.chpl:16: warning: owned thing(int(64)) is being used in a 'manage' statement via its 'enterContext' and 'exitContext' methods. However, owned thing(int(64)) does not implement contextManager. In the future, this will result in an error.
-5

--- a/test/classes/corrado/interfaces_warning_bug.future
+++ b/test/classes/corrado/interfaces_warning_bug.future
@@ -1,1 +1,0 @@
-erroneous warning about generic class not implementing 'contextManager': https://github.com/chapel-lang/chapel/issues/24408

--- a/test/classes/generic/canInstantiate-generic.1.good
+++ b/test/classes/generic/canInstantiate-generic.1.good
@@ -1,0 +1,13 @@
+canInstantiate-generic.chpl:27: warning: ----------------------------------------------------------------
+canInstantiate-generic.chpl:28: warning: Delete this test when implicit sync reads are no longer allowed.
+canInstantiate-generic.chpl:29: warning: ----------------------------------------------------------------
+canInstantiate-generic.chpl:35: In function 'test':
+canInstantiate-generic.chpl:35: warning: partial instantiation without '?' argument
+canInstantiate-generic.chpl:35: note: opt in to partial instantiation explicitly with a trailing '?' argument
+canInstantiate-generic.chpl:35: note: or, add arguments to instantiate the following fields in generic type 'sync NotGen':
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:nnnn: note:   generic type field 'valType'
+canInstantiate-generic.chpl:38: warning: implicitly reading from a sync is deprecated; apply a 'read??()' method to the actual
+canInstantiate-generic.chpl:38: error: in call to 'test', cannot pass result of coercion by reference
+canInstantiate-generic.chpl:38: note: implicit coercion from 'sync owned NotGen' to 'owned NotGen'
+canInstantiate-generic.chpl:34: note: when passing to 'const ref' intent formal 'myvalue'
+canInstantiate-generic.chpl:38: warning: Accepted

--- a/test/classes/generic/canInstantiate-generic.2.good
+++ b/test/classes/generic/canInstantiate-generic.2.good
@@ -1,0 +1,15 @@
+canInstantiate-generic.chpl:27: warning: ----------------------------------------------------------------
+canInstantiate-generic.chpl:28: warning: Delete this test when implicit sync reads are no longer allowed.
+canInstantiate-generic.chpl:29: warning: ----------------------------------------------------------------
+canInstantiate-generic.chpl:34: In function 'test':
+canInstantiate-generic.chpl:34: warning: need '(?)' on the type 'Gen' of the formal 'myvalue' because this type is generic
+canInstantiate-generic.chpl:35: In function 'test':
+canInstantiate-generic.chpl:35: warning: partial instantiation without '?' argument
+canInstantiate-generic.chpl:35: note: opt in to partial instantiation explicitly with a trailing '?' argument
+canInstantiate-generic.chpl:35: note: or, add arguments to instantiate the following fields in generic type 'sync Gen':
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:nnnn: note:   generic type field 'valType'
+canInstantiate-generic.chpl:38: warning: implicitly reading from a sync is deprecated; apply a 'read??()' method to the actual
+canInstantiate-generic.chpl:38: error: in call to 'test', cannot pass result of coercion by reference
+canInstantiate-generic.chpl:38: note: implicit coercion from 'sync owned Gen(int(64))' to 'owned Gen(int(64))'
+canInstantiate-generic.chpl:34: note: when passing to 'const ref' intent formal 'myvalue'
+canInstantiate-generic.chpl:38: warning: Accepted

--- a/test/classes/generic/canInstantiate-generic.3.good
+++ b/test/classes/generic/canInstantiate-generic.3.good
@@ -1,0 +1,9 @@
+canInstantiate-generic.chpl:27: warning: ----------------------------------------------------------------
+canInstantiate-generic.chpl:28: warning: Delete this test when implicit sync reads are no longer allowed.
+canInstantiate-generic.chpl:29: warning: ----------------------------------------------------------------
+canInstantiate-generic.chpl:35: In function 'test':
+canInstantiate-generic.chpl:35: warning: partial instantiation without '?' argument
+canInstantiate-generic.chpl:35: note: opt in to partial instantiation explicitly with a trailing '?' argument
+canInstantiate-generic.chpl:35: note: or, add arguments to instantiate the following fields in generic type 'sync NotGen':
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:nnnn: note:   generic type field 'valType'
+canInstantiate-generic.chpl:38: warning: Fell through

--- a/test/classes/generic/canInstantiate-generic.4.good
+++ b/test/classes/generic/canInstantiate-generic.4.good
@@ -1,0 +1,11 @@
+canInstantiate-generic.chpl:27: warning: ----------------------------------------------------------------
+canInstantiate-generic.chpl:28: warning: Delete this test when implicit sync reads are no longer allowed.
+canInstantiate-generic.chpl:29: warning: ----------------------------------------------------------------
+canInstantiate-generic.chpl:34: In function 'test':
+canInstantiate-generic.chpl:34: warning: need '(?)' on the type 'Gen' of the formal 'myvalue' because this type is generic
+canInstantiate-generic.chpl:35: In function 'test':
+canInstantiate-generic.chpl:35: warning: partial instantiation without '?' argument
+canInstantiate-generic.chpl:35: note: opt in to partial instantiation explicitly with a trailing '?' argument
+canInstantiate-generic.chpl:35: note: or, add arguments to instantiate the following fields in generic type 'sync Gen':
+$CHPL_HOME/modules/internal/ChapelSyncvar.chpl:nnnn: note:   generic type field 'valType'
+canInstantiate-generic.chpl:38: warning: Fell through

--- a/test/classes/generic/canInstantiate-generic.chpl
+++ b/test/classes/generic/canInstantiate-generic.chpl
@@ -1,0 +1,38 @@
+class Gen {
+  type t;
+  var x: t;
+}
+
+class NotGen {
+  var x: int;
+}
+
+config param useGeneric = false;
+config param useSyncFormal = true;
+type FormalType = if useGeneric then Gen(?) else NotGen;
+type ActualType = if useGeneric then owned Gen(int) else owned NotGen;
+
+// The essence of this test is to serve as a regression test for a bug
+// caused by the 'canInstantiate' check in the compiler. This incorrectly
+// returned false for ('anymanaged Gen' <- 'owned Gen(int)'), whereas
+// ('anymanaged NotGen' <- 'owned NotGen') was correctly allowed.
+//
+// The only way get trigger the bug through function calls is by using
+// the special logic for syncs / singles when computing the instantiation type.
+// To make this work, this PR makes use of a deprecated implicit read for syncs.
+// When the deprecation goes through and the implicit read is removed, this test
+// will stop working, and there will be no way to detect any difference in behavior
+// between the buggy and non-buggy 'canInstantiate'. This test should be removed
+// then.
+compilerWarning("----------------------------------------------------------------");
+compilerWarning("Delete this test when implicit sync reads are no longer allowed.");
+compilerWarning("----------------------------------------------------------------");
+
+pragma "last resort"
+proc test(x) { compilerWarning("Fell through"); }
+
+proc test(myvalue: FormalType) where useSyncFormal { compilerWarning("Accepted"); }
+proc test(myvalue: sync FormalType) where !useSyncFormal { compilerWarning("Accepted"); }
+
+var value: sync ActualType;
+test(value);

--- a/test/classes/generic/canInstantiate-generic.compopts
+++ b/test/classes/generic/canInstantiate-generic.compopts
@@ -1,0 +1,4 @@
+-suseGeneric=false -suseSyncFormal=true # canInstantiate-generic.1.good
+-suseGeneric=true -suseSyncFormal=true # canInstantiate-generic.2.good
+-suseGeneric=false -suseSyncFormal=false # canInstantiate-generic.3.good
+-suseGeneric=true -suseSyncFormal=false # canInstantiate-generic.4.good

--- a/test/classes/generic/canInstantiate-generic.prediff
+++ b/test/classes/generic/canInstantiate-generic.prediff
@@ -1,0 +1,1 @@
+../../../util/test/prediff-obscure-module-linenos

--- a/test/constrained-generics/basic/generic/generic-classes.chpl
+++ b/test/constrained-generics/basic/generic/generic-classes.chpl
@@ -1,0 +1,10 @@
+interface someInterface {}
+
+class myClass : someInterface {
+  type T;
+}
+
+proc test(x : someInterface) {}
+
+var x = new myClass(int);
+test(x);

--- a/test/studies/1brc/aggregators.good
+++ b/test/studies/1brc/aggregators.good
@@ -1,2 +1,0 @@
-aggregators.chpl:86: In method 'flush':
-aggregators.chpl:88: warning: borrowed sharedLock(map(bytes,tempData,false)) is being used in a 'manage' statement via its 'enterContext' and 'exitContext' methods. However, borrowed sharedLock(map(bytes,tempData,false)) does not implement contextManager. In the future, this will result in an error.


### PR DESCRIPTION
Fixes https://github.com/chapel-lang/chapel/issues/24408. 

Code in interface resolution attempts to check if an (instantiated) interface statement really does produce an interface for the given actual type. This code uses `canInstantiate`; however, prior to this PR, `canInstantiate ` seemed to return false for an `owned T(x)` being passed to an `anymanaged T` (`T` generic). This was because `anymanaged T` is not a class container, but `owned T` is. The invalid return from `canInstantiate` causes interface resolution based on generic `implements` statements (such as those written during a class declaration as `class c : myInterface`) to fail when it should succeed. This caused the warning in #24408 , because an implementation of `contextManager` really was not found (the warning was not spurious).

This PR fixes the issue by handling the case where one of the input types is `anymanaged`. In this case, instead of comparing `owned(T(x))` to `T`, only the 'canonical class types' are considered `T(x)` to `T`. 

Note that this error didn't occur for concrete classes because an earlier check detects the case where the canonical classes are equal.

Reviewed by @mppf -- thanks!

## Testing
- [x] paratest