### PR TITLE
update platform docs for windows

### DIFF
--- a/doc/rst/platforms/index.rst
+++ b/doc/rst/platforms/index.rst
@@ -11,7 +11,7 @@ Major Platforms
 
    macosx
    cray
-   cygwin
+   windows
    aws
    raspberrypi
 

--- a/doc/rst/platforms/windows.rst
+++ b/doc/rst/platforms/windows.rst
@@ -15,18 +15,22 @@ and should not be expected to result in good performance.
 Using Chapel on WSL
 -------------------
 
-The Windows Subsystem for Linux (WSL) is a compatibility layer for running
-Linux binary executables natively on Windows. It provides a Linux-compatible
-kernel interface developed by Microsoft, and it can run a variety of
-Linux distributions. For more information on WSL, see the
+WSL is a compatibility layer for running Linux binary executables natively on
+Windows. It provides a Linux-compatible kernel interface, and it can run a
+variety of Linux distributions. For more information on WSL, see the
 `WSL documentation <https://docs.microsoft.com/en-us/windows/wsl/about>`_.
 
 To use Chapel on WSL, you will need to install a Linux distribution from the
 Microsoft Store. We recommend using Ubuntu, but others will likely work.
 Once you have installed your distribution, get the list of prerequisites
 from :ref:`readme-prereqs` and install Chapel as you would on a native Linux
-system. There are no platform specific settings for Chapel on WSL at this time.
+system. There are no platform-specific settings for Chapel on WSL at this time.
 
+  .. note::
+
+    This configuration is not currently tested nightly. Please report any issues
+    you encounter when using Chapel on WSL by `filing a bug report
+    <https://github.com/chapel-lang/chapel/issues/new>`_
 
 ----------------------
 Using Chapel on Cygwin

--- a/doc/rst/platforms/windows.rst
+++ b/doc/rst/platforms/windows.rst
@@ -1,8 +1,36 @@
-.. _readme-cygwin:
+.. _readme-windows:
 
-======================
+=======================
+Using Chapel on Windows
+=======================
+
+Chapel can be used on Windows systems in two ways: via the Windows Subsystem
+for Linux (WSL) or via Cygwin. The WSL approach is the preferred method for
+running Chapel on Windows, as it provides a more native Linux environment and
+better performance. The Cygwin approach is supported as a portability option
+and should not be expected to result in good performance.
+
+
+-------------------
+Using Chapel on WSL
+-------------------
+
+The Windows Subsystem for Linux (WSL) is a compatibility layer for running
+Linux binary executables natively on Windows. It provides a Linux-compatible
+kernel interface developed by Microsoft, and it can run a variety of
+Linux distributions. For more information on WSL, see the
+`WSL documentation <https://docs.microsoft.com/en-us/windows/wsl/about>`_.
+
+To use Chapel on WSL, you will need to install a Linux distribution from the
+Microsoft Store. We recommend using Ubuntu, but others will likely work.
+Once you have installed your distribution, get the list of prerequisites
+from :ref:`readme-prereqs` and install Chapel as you would on a native Linux
+system. There are no platform specific settings for Chapel on WSL at this time.
+
+
+----------------------
 Using Chapel on Cygwin
-======================
+----------------------
 
 Chapel can be used on both 32-bit and 64-bit installations of Cygwin.
 Chapel can be sensitive to directories with spaces, but otherwise it
@@ -13,7 +41,7 @@ will work on Cygwin just like any other platform.
      Please note that running Chapel on Cygwin is supported only as a
      portability option and should not be expected to result in good
      performance.  For users wanting to run Chapel on Windows systems,
-     the preferred approach is to use the Windows Subsystem for Linux
+     the preferred approach is to use the Windows Subsystem for Linux (WSL)
      / Linux Bash Shell.
 
 

--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -541,7 +541,7 @@ Performance Tips
   you may wish to install `NVIDIA's `driver persistence daemon
   <https://docs.nvidia.com/deploy/driver-persistence/index.html#persistence-daemon>`_
   to alleviate this issue.
-  
+
 Tested Configurations
 ---------------------
 
@@ -559,6 +559,20 @@ marked with * are covered in our nightly testing configuration.
   * Hardware: MI60*, MI100 and MI250X
 
   * Software:ROCm 4.2*, 4.4, 5.4
+
+
+GPU Support on WSL
+------------------------------------------------
+
+Starting with Chapel 2.0, we have demonstrated the ability to use NVIDIA GPUs
+through WSL. To enable GPU support on WSL we require the CUDA Toolkit to be
+installed in the WSL environment and the NVIDIA driver to be installed on the
+Windows host.
+See the `NVIDIA documentation
+<https://docs.nvidia.com/cuda/wsl-user-guide/index.html#getting-started-with-cuda-on-wsl-2>`_
+for more information on setting up CUDA on WSL.
+See `Using Chapel on WSL <../platforms/windows.html#using-chapel-on-wsl>`_
+for more information on using Chapel with WSL.
 
 
 Further Information

--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -561,19 +561,22 @@ marked with * are covered in our nightly testing configuration.
   * Software:ROCm 4.2*, 4.4, 5.4
 
 
-GPU Support on WSL
+GPU Support on Windows Subsystem for Linux
 ------------------------------------------------
 
-Starting with Chapel 2.0, we have demonstrated the ability to use NVIDIA GPUs
-through WSL. To enable GPU support on WSL we require the CUDA Toolkit to be
-installed in the WSL environment and the NVIDIA driver to be installed on the
-Windows host.
-See the `NVIDIA documentation
+NVIDIA GPUs can be used on Windows through through WSL. To enable GPU support on
+WSL we require the CUDA Toolkit to be installed in the WSL environment and the
+NVIDIA driver to be installed on the Windows host. See the `NVIDIA documentation
 <https://docs.nvidia.com/cuda/wsl-user-guide/index.html#getting-started-with-cuda-on-wsl-2>`_
 for more information on setting up CUDA on WSL.
 See `Using Chapel on WSL <../platforms/windows.html#using-chapel-on-wsl>`_
 for more information on using Chapel with WSL.
 
+  .. note::
+
+    This configuration is not currently tested nightly. Please report any issues
+    you encounter when using Chapel on WSL by `filing a bug report
+    <https://github.com/chapel-lang/chapel/issues/new>`_
 
 Further Information
 -------------------


### PR DESCRIPTION
This PR updates our platform specific documentation for Windows. Specifically it moves Cygwin to a section within Windows and adds a section above it for WSL. 

I have also added a small section to the GPU technote indicating it's possible to use NVidia GPUs through WSL.

TESTING:

- [x] generated docs and previewed Windows and GPU pages

[reviewed by @e-kayrakli - thanks!]