### PR TITLE
Add the assoc par safe change to language evolution

### DIFF
--- a/doc/rst/language/evolution.rst
+++ b/doc/rst/language/evolution.rst
@@ -47,6 +47,120 @@ write.
 Prior to 2.0, the above ``begin`` would have resulted in a deprecation
 warning. In 2.0, this is valid code again.
 
+.. _readme-evolution.assoc-dom-par-safe:
+
+Associative Domains default to ``parSafe=false``
+************************************************
+Associative domains have been stabilized and prioritize performance by
+default; however, some diligence is cruicial for optimal use.
+
+Associative domains in Chapel have a ``parSafe`` setting that
+determines their behavior when operated on by concurrent tasks.
+
+``parSafe`` stands for "parallel safety". Setting
+``parSafe=true`` allows for multiple tasks to modify
+an associative domain's index set concurrently without race conditions.
+It is important to note that ``parSafe=true`` does not protect the
+user against all race conditions. For example, iterating over an associative
+domain while another task modifies it represents a race condition and the
+behavior is undefined.
+See the `documentation <https://chapel-lang.org/docs/1.33/language/spec/domains.html?highlight=parsafe#parallel-safety-with-respect-to-domains-and-arrays>`_
+on parallel safety for domains for examples and more information.
+
+The default of ``parSafe=true`` added overhead to operations and made
+programs slower by default, even when such safety guarantees were not needed.
+This is because it uses locking on the underlying data structure each time the
+domain is modified. This overhead is unnecessary, for example, when the domain
+is operated upon by a single task.
+
+Motivated by this we have changed their default from
+``parSafe=true`` to ``parSafe=false``.
+With this change associative domains have been stabilized, except for domains
+requesting ``parSafe=true``.
+Here's a breakdown of the changes and how they might impact
+your programs:
+
+1. New default for associative domains:
+    * Previously, associative domains were ``parSafe`` by default. This has
+      changed to ``parSafe=false``. For example:
+
+      .. code-block:: chapel
+
+          var dom: domain(int);
+
+      used to imply that ``dom`` was set to ``parSafe=true`` but now it defaults
+      to ``parSafe=false``.
+    * This means that the checks to guarantee parallel safety are no longer
+      inserted by default, thus improving performance; furthermore, it now
+      requires additional diligence to ensure parallel safety.
+    * In order to ease the transition, users can temporarily revert to the old
+      behavior by compiling with the ``-s parSafeOnByDefault`` flag.
+
+      .. code-block:: console
+
+          $ chpl defaultAssociativeDomain.chpl -s parSafeOnByDefault
+
+      If a program used associative domains and relied on ``parSafe=true``,
+      it might be useful to try compiling with ``-s parSafeOnByDefault`` and
+      then add an explicit ``parSafe`` argument for each associative domain
+      individually, to ensure no races are introduced into the
+      program by forgoing the parallel safety guarantees.
+    * A warning will be generated for domains without an explicit ``parSafe``
+      setting unless you compile with ``-s noParSafeWarning``.
+
+      .. code-block:: chapel
+
+          var d1: domain(int);                 // warns
+          var d2: domain(int, parSafe=false);  // does not warn
+
+      where the compilation output of the above program would look as follows:
+
+      .. code-block:: console
+
+          $ chpl assocDomWarn.chpl
+          assocDomWarn.chpl:1: warning: The default parSafe mode for associative domains and arrays (like 'd1') is changing from 'true' to 'false'. To suppress this warning, use an explicit parSafe argument (ex: domain(int, parSafe=false)), or compile with '-snoParSafeWarning'. To use the old default of parSafe=true, compile with '-sparSafeOnByDefault'.
+
+    * Since ``const`` domains are never modified, they are exempt from these
+      warnings as changing their default to ``parSafe=false`` does not have the
+      potential to impact correctness.
+
+      .. code-block:: chapel
+
+          const dom: domain(int);  // does not warn
+
+2. ``parSafe=true`` domains are unstable:
+    * Domains using ``parSafe=true`` are still considered unstable, and continue
+      to trigger unstable warnings when declared. For example:
+
+      .. code-block:: chapel
+
+          var dom: domain(int, parSafe=true);  // generates unstable warning
+
+      generates the following compilation output:
+
+      .. code-block:: console
+
+          $ chpl assocDomainUnstable.chpl --warn-unstable
+          assocDomainUnstable.chpl:1: warning: parSafe=true is unstable for associative domains
+
+3. Associative domain literals:
+    * Associative domain literals also generate warnings by default. Use
+      explicit type declarations like ``domain(int, parSafe=false)`` to avoid
+      them.
+
+      .. code-block:: chapel
+
+          var d1 = {"Mon", "Tue", "Wed"};                                // warns
+          var d2: domain(string, parSafe=false) = {"Mon", "Tue", "Wed"}; // does not warn
+
+      where the compilation output of the above program would look as follows:
+
+      .. code-block::  console
+
+          $ chpl assocLiteralWarn.chpl
+          assocLiteralWarn.chpl:1: warning: The default parSafe mode for associative domains and arrays (like 'd1') is changing from 'true' to 'false'. To suppress this warning, use an explicit parSafe argument (ex: domain(int, parSafe=false)), or compile with '-snoParSafeWarning'. To use the old default of parSafe=true, compile with '-sparSafeOnByDefault'.
+
+
 version 1.32, September 2023
 ----------------------------
 

--- a/doc/rst/language/evolution.rst
+++ b/doc/rst/language/evolution.rst
@@ -52,20 +52,20 @@ warning. In 2.0, this is valid code again.
 Associative Domains default to ``parSafe=false``
 ************************************************
 Associative domains have been stabilized and prioritize performance by
-default; however, some diligence is cruicial for optimal use.
+default; however, some diligence is is required for correct use..
 
 Associative domains in Chapel have a ``parSafe`` setting that
 determines their behavior when operated on by concurrent tasks.
 
 ``parSafe`` stands for "parallel safety". Setting
-``parSafe=true`` allows for multiple tasks to modify
+``parSafe=true`` allows multiple tasks to modify
 an associative domain's index set concurrently without race conditions.
 It is important to note that ``parSafe=true`` does not protect the
 user against all race conditions. For example, iterating over an associative
 domain while another task modifies it represents a race condition and the
 behavior is undefined.
 See the `documentation <https://chapel-lang.org/docs/1.33/language/spec/domains.html?highlight=parsafe#parallel-safety-with-respect-to-domains-and-arrays>`_
-on parallel safety for domains for examples and more information.
+for  more information.
 
 The default of ``parSafe=true`` added overhead to operations and made
 programs slower by default, even when such safety guarantees were not needed.
@@ -76,13 +76,13 @@ is operated upon by a single task.
 Motivated by this we have changed their default from
 ``parSafe=true`` to ``parSafe=false``.
 With this change associative domains have been stabilized, except for domains
-requesting ``parSafe=true``.
+requesting ``parSafe=true``, which remain unstable.
 
 Here's a breakdown of the changes and how they might impact
 your programs:
 
 1. New default for associative domains:
-    * Previously, associative domains were ``parSafe`` by default. This has
+    * Previously, associative domains were "parSafe" by default. This has
       changed to ``parSafe=false``. For example:
 
       .. code-block:: chapel
@@ -92,10 +92,12 @@ your programs:
       used to imply that ``dom`` was set to ``parSafe=true`` but now it defaults
       to ``parSafe=false``.
     * This means that the checks to guarantee parallel safety are no longer
-      inserted by default, thus improving performance; furthermore, it now
-      requires additional diligence to ensure parallel safety.
+      inserted by default, thus improving performance.
+      Therefore, it is now the user's responsibility to ensure parallel safety
+      as needed.
     * A warning will be generated for domains without an explicit ``parSafe``
-      setting unless you compile with ``-s noParSafeWarning``.
+      setting, to draw user attention to code that may need to be updated,
+       unless compiled with ``-s noParSafeWarning``.
 
       .. code-block:: chapel
 

--- a/doc/rst/language/evolution.rst
+++ b/doc/rst/language/evolution.rst
@@ -97,7 +97,7 @@ your programs:
       as needed.
     * A warning will be generated for domains without an explicit ``parSafe``
       setting, to draw user attention to code that may need to be updated,
-       unless compiled with ``-s noParSafeWarning``.
+      unless compiled with ``-s noParSafeWarning``.
 
       .. code-block:: chapel
 

--- a/doc/rst/language/evolution.rst
+++ b/doc/rst/language/evolution.rst
@@ -135,7 +135,7 @@ your programs:
       program by forgoing the parallel safety guarantees.
 
 2. ``parSafe=true`` domains are unstable:
-    * Domains using ``parSafe=true`` are still considered unstable, and continue
+    * Domains using ``parSafe=true`` are still considered unstable and continue
       to trigger unstable warnings when declared. For example:
 
       .. code-block:: chapel

--- a/doc/rst/language/evolution.rst
+++ b/doc/rst/language/evolution.rst
@@ -77,6 +77,7 @@ Motivated by this we have changed their default from
 ``parSafe=true`` to ``parSafe=false``.
 With this change associative domains have been stabilized, except for domains
 requesting ``parSafe=true``.
+
 Here's a breakdown of the changes and how they might impact
 your programs:
 
@@ -93,18 +94,6 @@ your programs:
     * This means that the checks to guarantee parallel safety are no longer
       inserted by default, thus improving performance; furthermore, it now
       requires additional diligence to ensure parallel safety.
-    * In order to ease the transition, users can temporarily revert to the old
-      behavior by compiling with the ``-s parSafeOnByDefault`` flag.
-
-      .. code-block:: console
-
-          $ chpl defaultAssociativeDomain.chpl -s parSafeOnByDefault
-
-      If a program used associative domains and relied on ``parSafe=true``,
-      it might be useful to try compiling with ``-s parSafeOnByDefault`` and
-      then add an explicit ``parSafe`` argument for each associative domain
-      individually, to ensure no races are introduced into the
-      program by forgoing the parallel safety guarantees.
     * A warning will be generated for domains without an explicit ``parSafe``
       setting unless you compile with ``-s noParSafeWarning``.
 
@@ -117,8 +106,10 @@ your programs:
 
       .. code-block:: console
 
-          $ chpl assocDomWarn.chpl
-          assocDomWarn.chpl:1: warning: The default parSafe mode for associative domains and arrays (like 'd1') is changing from 'true' to 'false'. To suppress this warning, use an explicit parSafe argument (ex: domain(int, parSafe=false)), or compile with '-snoParSafeWarning'. To use the old default of parSafe=true, compile with '-sparSafeOnByDefault'.
+          $ chpl foo.chpl
+          foo.chpl:1: warning: The default parSafe mode for associative domains and arrays (like 'd1') is changing from 'true' to 'false'.
+          foo.chpl:1: note: To suppress this warning you can make your domain const, use an explicit parSafe argument (ex: domain(int, parSafe=false)), or compile with '-snoParSafeWarning'.
+          foo.chpl:1: note: To use the old default of parSafe=true, compile with '-sassocParSafeDefault=true'.
 
     * Since ``const`` domains are never modified, they are exempt from these
       warnings as changing their default to ``parSafe=false`` does not have the
@@ -127,6 +118,19 @@ your programs:
       .. code-block:: chapel
 
           const dom: domain(int);  // does not warn
+
+    * In order to ease the transition, users can temporarily revert to the old
+      behavior by compiling with ``-s assocParSafeDefault=true``.
+
+      .. code-block:: console
+
+          $ chpl defaultAssociativeDomain.chpl -s assocParSafeDefault=true
+
+      If a program used associative domains and relied on ``parSafe=true``,
+      it might be useful to try compiling with ``-s assocParSafeDefault=true`` and
+      then add an explicit ``parSafe`` argument for each associative domain
+      individually, to ensure no races are introduced into the
+      program by forgoing the parallel safety guarantees.
 
 2. ``parSafe=true`` domains are unstable:
     * Domains using ``parSafe=true`` are still considered unstable, and continue
@@ -140,8 +144,8 @@ your programs:
 
       .. code-block:: console
 
-          $ chpl assocDomainUnstable.chpl --warn-unstable
-          assocDomainUnstable.chpl:1: warning: parSafe=true is unstable for associative domains
+          $ chpl bar.chpl --warn-unstable
+          bar.chpl:1: warning: parSafe=true is unstable for associative domains
 
 3. Associative domain literals:
     * Associative domain literals also generate warnings by default. Use
@@ -157,9 +161,10 @@ your programs:
 
       .. code-block::  console
 
-          $ chpl assocLiteralWarn.chpl
-          assocLiteralWarn.chpl:1: warning: The default parSafe mode for associative domains and arrays (like 'd1') is changing from 'true' to 'false'. To suppress this warning, use an explicit parSafe argument (ex: domain(int, parSafe=false)), or compile with '-snoParSafeWarning'. To use the old default of parSafe=true, compile with '-sparSafeOnByDefault'.
-
+          $ chpl baz.chpl
+          baz.chpl:1: warning: The default parSafe mode for associative domains and arrays (like 'd1') is changing from 'true' to 'false'.
+          baz.chpl:1: note: To suppress this warning you can make your domain const, use an explicit parSafe argument (ex: domain(int, parSafe=false)), or compile with '-snoParSafeWarning'.
+          baz.chpl:1: note: To use the old default of parSafe=true, compile with '-sassocParSafeDefault=true'.
 
 version 1.32, September 2023
 ----------------------------

--- a/doc/rst/language/spec/arrays.rst
+++ b/doc/rst/language/spec/arrays.rst
@@ -243,14 +243,6 @@ list of index-to-value bindings within square brackets. It is expected
 that the indices in the listing match in type and, likewise, the types
 of values in the listing also match. A trailing comma is allowed.
 
-.. warning::
-
-   Associative domains and arrays are currently unstable.
-   Their functionality is likely to change in the future.
-   Chapel provides stable `map` and `set` data types
-   [see modules :mod:`Set` and :mod:`Map`]
-   that can be used instead in many cases.
-
 
 .. code-block:: syntax
 

--- a/doc/rst/language/spec/domains.rst
+++ b/doc/rst/language/spec/domains.rst
@@ -98,24 +98,24 @@ may make concurrent queries and iterations on a domain as long as
 another task is not simultaneously modifying the domain's index
 set.
 
-By default, associative domains do not permit multiple tasks
-to modify their index sets concurrently without race conditions.
-This setting is controlled by the ``parSafe`` parameter of the domain type,
-which defaults to ``false``. This is because ``parSafe`` uses locking on
-the underlying data structure each time the domain is modified. This
-overhead is unnecessary, for example, when the domain is operated upon by a
-single task.
-
-Setting ``parSafe`` to ``true`` allows multiple tasks to modify the index set
-of an associative domain concurrently. This might be useful when the domain is
-operated upon by multiple tasks. However, it is the user's responsibility to
-ensure that the domain is not accessed while its index set is being modified.
-The following example demonstrates how to create a parallel-safe associative
-domain of strings:
+An associative domain may permit multiple tasks to modify its index
+set concurrently in a parallel-safe manner if its type is declared with
+``parSafe=true``. The following example demonstrates how to create a
+parallel-safe associative domain of strings:
 
   .. code-block:: chapel
 
     var D: domain(string, parSafe=true);
+
+Note that declaring a domain with ``parSafe=true`` adds some amount of overhead
+to many domain operations. This is because such a domain uses locking on the
+underlying data structure each time the domain is modified. This overhead is
+unnecessary, for example, when the domain is operated upon only by a single
+task, in which case it can be avoided by declaring the domain's type with
+``parSafe=false`` or without an explicit ``parSafe`` setting.
+
+Note that the ``parSafe=true`` mode is currently unstable for associative
+domains. Its availability and behavior may change in the future.
 
 As with any other domain type, it is not safe to access an
 associative array while its domain is changing, regardless of

--- a/doc/rst/language/spec/domains.rst
+++ b/doc/rst/language/spec/domains.rst
@@ -98,19 +98,24 @@ may make concurrent queries and iterations on a domain as long as
 another task is not simultaneously modifying the domain's index
 set.
 
-By default, associative domains permit multiple tasks
-to modify their index sets concurrently.  This adds some amount of
-overhead to these operations.  If the user knows that all such
-modifications will be done serially or in a parallel-safe context,
-the overheads can be avoided by setting ``parSafe`` to ``false`` in
-the domain's type declaration.  For example, the following
-declaration creates an associative domain of strings where the
-implementation will do nothing to ensure that simultaneous
-modifications to the domain are parallel-safe:
+By default, associative domains do not permit multiple tasks
+to modify their index sets concurrently without race conditions.
+This setting is controlled by the ``parSafe`` parameter of the domain type,
+which defaults to ``false``. This is because ``parSafe`` uses locking on
+the underlying data structure each time the domain is modified. This
+overhead is unnecessary, for example, when the domain is operated upon by a
+single task.
+
+Setting ``parSafe`` to ``true`` allows multiple tasks to modify the index set
+of an associative domain concurrently. This might be useful when the domain is
+operated upon by multiple tasks. However, it is the user's responsibility to
+ensure that the domain is not accessed while its index set is being modified.
+The following example demonstrates how to create a parallel-safe associative
+domain of strings:
 
   .. code-block:: chapel
 
-    var D: domain(string, parSafe=false);
+    var D: domain(string, parSafe=true);
 
 As with any other domain type, it is not safe to access an
 associative array while its domain is changing, regardless of
@@ -317,15 +322,6 @@ type and can be used to describe sets or to create dictionary-style
 arrays (hash tables). The type of indices of an associative domain, or
 its ``idxType``, can be any primitive type except ``void`` or any class
 type.
-
-
-   .. warning::
-
-      Associative domains and arrays are currently unstable.
-      Their functionality is likely to change in the future.
-      Chapel provides stable `map` and `set` data types
-      [see modules :mod:`Set` and :mod:`Map`]
-      that can be used instead in many cases.
 
 
 .. _Associative_Domain_Types:

--- a/test/release/examples/primers/associative.chpl
+++ b/test/release/examples/primers/associative.chpl
@@ -8,13 +8,6 @@
   :ref:`domains.chpl <primers-domains>` primers before proceeding if you're not
   already familiar with Chapel's domains and arrays.
 
-  .. warning::
-
-    Associative domains and arrays are currently unstable.
-    Their functionality is likely to change in the future.
-    Chapel provides stable `map` and `set` data types
-    [see modules :mod:`Set` and :mod:`Map`]
-    that can be used instead in many cases.
 
 */
 
@@ -65,6 +58,7 @@
 
       Associative domain types written without parSafe=false cause a
       transitory warning, which will be removed in a future release.
+      See :ref:`the Parallel Safety section for domains <Domain_and_Array_Parallel_Safety>`.
 
 */
 var Names: domain(string, parSafe=false);


### PR DESCRIPTION
This PR adds documentation related to the stabilization of associative domains:
1. Adds an entry to language evolution describing in detail the changes made to parSafety for associative domains and all the different flags, options, and what they do.
2. Edits the note about Parallel Safety for Associative Domains and Arrays to reflect the new default for associative domains being parSafe=false
3. Adds links to the above from a few different places which mention parSafe.
4. Remove messages about associative domains being unstable.