### PR TITLE
Fix typos

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -2304,7 +2304,7 @@ static chpl::CompilerGlobals dynoBuildCompilerGlobals() {
     .overloadSetsChecking = fOverloadSetsChecks,
     .divByZeroChecking = !fNoDivZeroChecks,
     .cacheRemote = fCacheRemote,
-    // We need privitization if we are doing a non-local compilation, or using
+    // We need privatization if we are doing a non-local compilation, or using
     // GPUs
     // TODO can we remove `--no-privatization` flag?
     .privatization = (!fNoPrivatization && !fLocal) ||

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -200,7 +200,7 @@ struct LoopAttributeInfo {
     }
   }
 
-  void readNativeGpuAtrributes(const uast::AttributeGroup* attrs) {
+  void readNativeGpuAttributes(const uast::AttributeGroup* attrs) {
     this->assertOnGpuAttr = attrs->getAttributeNamed(USTR("assertOnGpu"));
     this->blockSizeAttr = attrs->getAttributeNamed(USTR("gpu.blockSize"));
   }
@@ -213,7 +213,7 @@ struct LoopAttributeInfo {
 
     LoopAttributeInfo into;
     into.readLlvmAttributes(context, attrs);
-    into.readNativeGpuAtrributes(attrs);
+    into.readNativeGpuAttributes(attrs);
 
     return into;
   }
@@ -225,7 +225,7 @@ struct LoopAttributeInfo {
 
     // Do not bother parsing LLVM attributes, since they don't apply to loops.
     LoopAttributeInfo into;
-    into.readNativeGpuAtrributes(attrs);
+    into.readNativeGpuAttributes(attrs);
 
     return into;
   }
@@ -453,7 +453,7 @@ struct Converter {
     return nullptr;
   }
 
-  void readNativeGpuAtrributes(LoopAttributeInfo& into,
+  void readNativeGpuAttributes(LoopAttributeInfo& into,
                                const uast::AttributeGroup* attrs) {
     into.assertOnGpuAttr = attrs->getAttributeNamed(USTR("assertOnGpu"));
     into.blockSizeAttr = attrs->getAttributeNamed(USTR("gpu.blockSize"));
@@ -3814,7 +3814,7 @@ struct Converter {
 
     /**
       Helper for code that calls 'convertVariable' but doesn't expect to handle
-      blocks with additional primitives, which can be introuced by that call
+      blocks with additional primitives, which can be introduced by that call
       for GPU attributes that need to be propagated to init expressions.
      */
     Expr* requireDefOnly() const {
@@ -3923,7 +3923,7 @@ struct Converter {
 
     auto def = new DefExpr(varSym, initExpr, typeExpr);
     VariableDefInfo ret = { def, /* entireExpr */ nullptr };
-    // Note: entierExpr is set below depending on if there are any attributes.
+    // Note: entireExpr is set below depending on if there are any attributes.
 
     auto loopFlags = LoopAttributeInfo::fromVariableDeclaration(context, node);
     if (!loopFlags.empty()) {

--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -996,7 +996,7 @@ static ShadowVarSymbol* createSVforFieldAccess(LoopWithShadowVarsInterface* fs, 
 {
   bool isConst = ovar->isConstant() || field->isConstant();
 
-  // with --baseline, we have to be careful where we insert the initializtion of
+  // with --baseline, we have to be careful where we insert the initialization of
   // the new ref we are creating. With foreach loops that accesses a field of a
   // symbol that has implicit ref intent, the initialization has to be in the
   // loop body.

--- a/compiler/resolution/lowerLoopContexts.cpp
+++ b/compiler/resolution/lowerLoopContexts.cpp
@@ -252,7 +252,7 @@ class IteratorContext: public Context {
  public:
   void setInnerLoop(CForLoop* loop) { innerLoop_ = loop; }
   void setCallToInner(CallExpr* expr) { callToInner_ = expr; }
-  void setInnermostLooop(CForLoop* loop) { innermostLoop_ = loop; }
+  void setInnermostLoop(CForLoop* loop) { innermostLoop_ = loop; }
 
   CoforallOnContext* toCoforallOnContext() {
     if (kind_ == Kind::CoforallOn) return (CoforallOnContext*) this;
@@ -453,7 +453,7 @@ class ContextHandler {
             CONTEXT_DEBUG(debugDepth, "found a candidate vectorized loop", cfl);
 
             auto outerCtx = std::make_unique<VectorizedLoopContext>(cfl);
-            outerCtx->setInnermostLooop(plainLoop);
+            outerCtx->setInnermostLoop(plainLoop);
             outerCtx->setCallToInner(callToCurCtx);
             outerCtx->setInnerLoop(findInnermostLoop(callToCurCtx));
             outerCtx->findLoopContextHandle();
@@ -480,7 +480,7 @@ class ContextHandler {
         CONTEXT_DEBUG(debugDepth, "found a candidate parent fn", parentFn);
 
         auto outerCtx = std::make_unique<CoforallOnContext>(parentFn);
-        outerCtx->setInnermostLooop(plainLoop);
+        outerCtx->setInnermostLoop(plainLoop);
         outerCtx->setCallToInner(callToCurCtx);
         outerCtx->setInnerLoop(findInnermostLoop(callToCurCtx));
         outerCtx->findLoopContextHandle();

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -909,7 +909,7 @@ class TypedFnSignature {
   /// \endcond DO_NOT_DOCUMENT
 };
 
-// Container for resolution candidates and (if applicable) their correponding
+// Container for resolution candidates and (if applicable) their corresponding
 // forwarding-to types.
 struct CandidatesAndForwardingInfo {
  private:

--- a/frontend/lib/framework/Context.cpp
+++ b/frontend/lib/framework/Context.cpp
@@ -560,7 +560,7 @@ void Context::gatherRecursionTrace(const querydetail::QueryMapResultBase* root,
                                    const querydetail::QueryMapResultBase* result,
                                    std::vector<TraceElement>& trace) const {
   // Note: do not collect the result, but only its dependency. The reason
-  // is that this is initally called with result=root, and including
+  // is that this is initially called with result=root, and including
   // the root in the trace seems unhelpful since it will issue a proper error
   // message.
 

--- a/frontend/lib/parsing/parser-error-classes-list.cpp
+++ b/frontend/lib/parsing/parser-error-classes-list.cpp
@@ -226,7 +226,7 @@ void ErrorNonAssociativeComparison::write(ErrorWriterBase& wr) const {
     wr.message("    ", oss.str());
     wr.message("");
   } else {
-    wr.message("If you wanted to perform elementwise comaprison, please use "
+    wr.message("If you wanted to perform elementwise comparison, please use "
                "'&&' to combine operations.");
   }
 

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -1563,7 +1563,7 @@ const chpl::optional<QualifiedType>& computeUnderlyingTypeOfEnum(Context* contex
   chpl::optional<QualifiedType> result;
   auto numericValues = computeNumericValuesOfEnumElements(context, element);
 
-  // Find the first non-unknown value, and return its type. As a fallack,
+  // Find the first non-unknown value, and return its type. As a fallback,
   // return either the default unknown value or, if we've encountered an error,
   // the erroneous type.
   for (auto& pair : numericValues) {

--- a/frontend/lib/uast/post-parse-checks.cpp
+++ b/frontend/lib/uast/post-parse-checks.cpp
@@ -1397,7 +1397,7 @@ void Visitor::checkAttributeNameRecognizedOrToolSpaced(const Attribute* node) {
   // then a USTR() on the attribute name will work or not work
 
   if (node->name() == USTR("functionStatic")) {
-    // Recognized but instable.
+    // Recognized but unstable.
     if (shouldEmitUnstableWarning(node)) {
       warn(node, "function-static variables using @functionStatic are unstable.");
     }

--- a/modules/internal/ChapelDomain.chpl
+++ b/modules/internal/ChapelDomain.chpl
@@ -792,7 +792,7 @@ module ChapelDomain {
           a.add(b(ind));
         }
       else
-        // unroll in the source code to allow heterogenous tuple elements
+        // unroll in the source code to allow heterogeneous tuple elements
         for ind in b {
           chpl__checkTupIrregDomAssign(a, ind, "containing ");
           a.add(ind);

--- a/test/errors/parsing/compareAssoc.2.good
+++ b/test/errors/parsing/compareAssoc.2.good
@@ -36,7 +36,7 @@
     14 | var x2 = a > b <= c;
        |
   Comparisons in the form 'x op y op z' are not supported.
-  If you wanted to perform elementwise comaprison, please use '&&' to combine operations.
+  If you wanted to perform elementwise comparison, please use '&&' to combine operations.
   If you wanted to use the result of a comparison as an operand in another comparison, consider using parentheses in a subexpression to disambiguate:
        |
     14 | var x2 = a > b <= c;
@@ -49,7 +49,7 @@
     18 | var x3 = a == b == c;
        |
   Comparisons in the form 'x op y op z' are not supported.
-  If you wanted to perform elementwise comaprison, please use '&&' to combine operations.
+  If you wanted to perform elementwise comparison, please use '&&' to combine operations.
   If you wanted to use the result of a comparison as an operand in another comparison, consider using parentheses in a subexpression to disambiguate:
        |
     18 | var x3 = a == b == c;
@@ -62,7 +62,7 @@
     22 | var x4 = a != b != c;
        |
   Comparisons in the form 'x op y op z' are not supported.
-  If you wanted to perform elementwise comaprison, please use '&&' to combine operations.
+  If you wanted to perform elementwise comparison, please use '&&' to combine operations.
   If you wanted to use the result of a comparison as an operand in another comparison, consider using parentheses in a subexpression to disambiguate:
        |
     22 | var x4 = a != b != c;

--- a/test/release/examples/primers/fileIO.chpl
+++ b/test/release/examples/primers/fileIO.chpl
@@ -169,8 +169,8 @@ if example == 0 || example == 2 {
 
 /* .. code-block:: sh
 
-      time ./fielIOv2 --example=2
-      time ./fielIOv2 --example=3
+      $ time ./fileIO --example=2
+      $ time ./fileIO --example=3
 */
 
 if example == 0 || example == 3 {


### PR DESCRIPTION
Fix typos in

driver.cpp, convert-uast.cpp, implementForallIntents.cpp,
lowerLoopContexts.cpp, resolution-types.h, Context.cpp,
parser-error-classes-list.cpp and a good file,
resolution-queries.cpp, post-parse-checks.cpp,
ChapelDomain.chpl, and primers/fileIO.chpl