### PR TITLE
Add a new environment variable to pass `--gpus-per-node` to slurm

### DIFF
--- a/runtime/src/launch/slurm-srun/launch-slurm-srun.c
+++ b/runtime/src/launch/slurm-srun/launch-slurm-srun.c
@@ -399,7 +399,7 @@ static char* chpl_launch_create_command(int argc, char* argv[],
       fprintf(slurmFile, "#SBATCH --account=%s\n", account);
     }
 
-    // set the account name if one was provided
+    // set gpus-per-node if one was provided
     if (gpusPerNode && strlen(gpusPerNode) > 0) {
       fprintf(slurmFile, "#SBATCH --gpus-per-node=%s\n", gpusPerNode);
     }
@@ -548,7 +548,7 @@ static char* chpl_launch_create_command(int argc, char* argv[],
       len += snprintf(iCom+len, sizeof(iCom)-len, "--account=%s ", account);
     }
 
-    // set the account name if one was provided
+    // set gpus-per-node if one was provided
     if (gpusPerNode && strlen(gpusPerNode) > 0) {
       len += snprintf(iCom+len, sizeof(iCom)-len, "--gpus-per-node=%s ", gpusPerNode);
     }

--- a/runtime/src/launch/slurm-srun/launch-slurm-srun.c
+++ b/runtime/src/launch/slurm-srun/launch-slurm-srun.c
@@ -216,6 +216,7 @@ static char* chpl_launch_create_command(int argc, char* argv[],
   char* outputfn = getenv("CHPL_LAUNCHER_SLURM_OUTPUT_FILENAME");
   char* errorfn = getenv("CHPL_LAUNCHER_SLURM_ERROR_FILENAME");
   char* nodeAccessEnv = getenv("CHPL_LAUNCHER_NODE_ACCESS");
+  char* gpusPerNode = getenv("CHPL_LAUNCHER_GPUS_PER_NODE");
   char* memEnv = getenv("CHPL_LAUNCHER_MEM");
   const char* nodeAccessStr = NULL;
   const char* memStr = NULL;
@@ -398,6 +399,11 @@ static char* chpl_launch_create_command(int argc, char* argv[],
       fprintf(slurmFile, "#SBATCH --account=%s\n", account);
     }
 
+    // set the account name if one was provided
+    if (gpusPerNode && strlen(gpusPerNode) > 0) {
+      fprintf(slurmFile, "#SBATCH --gpus-per-node=%s\n", gpusPerNode);
+    }
+
     // set the output file name to either the user specified
     // name or to the binaryName.<jobID>.out if none specified
     if (outputfn != NULL) {
@@ -540,6 +546,11 @@ static char* chpl_launch_create_command(int argc, char* argv[],
     // set the account name if one was provided
     if (account && strlen(account) > 0) {
       len += snprintf(iCom+len, sizeof(iCom)-len, "--account=%s ", account);
+    }
+
+    // set the account name if one was provided
+    if (gpusPerNode && strlen(gpusPerNode) > 0) {
+      len += snprintf(iCom+len, sizeof(iCom)-len, "--gpus-per-node=%s ", gpusPerNode);
     }
 
     // add the (possibly wrapped) binary name


### PR DESCRIPTION
`--gpus-per-node` or the like are required to be able to use GPU nodes on some systems. I noticed this requirement on Perlmutter. However, we don't have the ability to pass that flag through the launcher executable we generate. This PR adds `CHPL_LAUNCHER_GPUS_PER_NODE` environment flag to add that ability.