### PR TITLE
Remove .bad file for segfaulting list future

### DIFF
--- a/test/library/standard/List/initEquals/listInitEqualsArrayBug.bad
+++ b/test/library/standard/List/initEquals/listInitEqualsArrayBug.bad
@@ -1,1 +1,0 @@
-listInitEqualsArrayBug.chpl:5: error: attempt to dereference nil


### PR DESCRIPTION
The future I "re-added" for #24305 is still sometimes failing with a segfault under gasnet. Because of this, just remove the `.bad` file for now.

Reviewed by @arezaii. Thanks!