### PR TITLE
Make chpl-shim available in PATH

### DIFF
--- a/tools/chpl-language-server/Makefile
+++ b/tools/chpl-language-server/Makefile
@@ -28,6 +28,7 @@ include $(CHPL_MAKE_HOME)/third-party/chpl-venv/Makefile.include
 
 bdir=$(CHPL_BIN_DIR)
 link=$(bdir)/chpl-language-server
+link-shim=$(bdir)/chpl-shim
 
 all: chpl-language-server install
 
@@ -36,20 +37,34 @@ chpl-language-server-venv:
 
 chpl-language-server: chpl-language-server-venv
 
-clean:
+clean: clean-link clean-link-shim
+
+cleanall: clean
+
+clobber: clean
+
+clean-link:
 ifneq ($(wildcard $(link)),)
 	@echo "Removing old symbolic link..."
 	rm -f $(link)
 	@echo
 endif
 
-cleanall: clean
+clean-link-shim:
+ifneq ($(wildcard $(link-shim)),)
+	@echo "Removing old symbolic link..."
+	rm -f $(link-shim)
+	@echo
+endif
 
-clobber: clean
-
-$(link): clean
+$(link): clean-link
 	@echo "Installing chpl-language-server symbolic link..."
 	mkdir -p $(bdir)
 	ln -s $(shell pwd)/chpl-language-server $(link)
 
-install: chpl-language-server $(link)
+$(link-shim): clean-link-shim
+	@echo "Installing chpl-shim symbolic link..."
+	mkdir -p $(bdir)
+	ln -s $(shell pwd)/chpl-shim $(link-shim)
+
+install: chpl-language-server $(link) $(link-shim)

--- a/tools/chpl-language-server/chpl-shim
+++ b/tools/chpl-language-server/chpl-shim
@@ -20,8 +20,14 @@
 #
 
 if [ -z "$CHPL_HOME" ]; then
-  echo "Error: CHPL_HOME is not set"
-  exit 1
+  # We need CHPL_HOME to find run-in-venv.bash. Try falling back to a
+  # compiler in PATH.
+  if output=$(chpl --print-bootstrap-commands); then
+    eval "$output"
+  else
+    echo "Error: CHPL_HOME is not set" 1>&2
+    exit 1
+  fi
 fi
 
 exec $CHPL_HOME/util/config/run-in-venv-with-python-bindings.bash \

--- a/util/buildRelease/install.sh
+++ b/util/buildRelease/install.sh
@@ -381,18 +381,23 @@ then
 fi
 
 CHPL_LANGUAGE_SERVER="bin/$CHPL_BIN_SUBDIR"/chpl-language-server
+# comes with chpl-language-serverh
+CHPL_SHIM="bin/$CHPL_BIN_SUBDIR"/chpl-shim
 
 # copy chpl-language-server
 if [ -f "$CHPL_LANGUAGE_SERVER" ]
 then
   myinstallfile "tools/chpl-language-server/chpl-language-server" "$DEST_CHPL_HOME/tools/chpl-language-server"
+  myinstallfile "tools/chpl-language-server/chpl-shim" "$DEST_CHPL_HOME/tools/chpl-language-server"
   myinstalldir "tools/chpl-language-server/src" "$DEST_CHPL_HOME/tools/chpl-language-server/src"
 
   if [ ! -z "$PREFIX" ]
   then
     ln -s "$DEST_CHPL_HOME/tools/chpl-language-server/chpl-language-server" "$PREFIX/bin"/chpl-language-server
+    ln -s "$DEST_CHPL_HOME/tools/chpl-language-server/chpl-shim" "$PREFIX/bin"/chpl-shim
   else
     ln -s "$DEST_CHPL_HOME/tools/chpl-language-server/chpl-language-server" "$DEST_DIR/bin/$CHPL_BIN_SUBDIR"/chpl-language-server
+    ln -s "$DEST_CHPL_HOME/tools/chpl-language-server/chpl-shim" "$DEST_DIR/bin/$CHPL_BIN_SUBDIR"/chpl-shim
   fi
 fi
 

--- a/util/buildRelease/install.sh
+++ b/util/buildRelease/install.sh
@@ -381,7 +381,7 @@ then
 fi
 
 CHPL_LANGUAGE_SERVER="bin/$CHPL_BIN_SUBDIR"/chpl-language-server
-# comes with chpl-language-serverh
+# comes with chpl-language-server
 CHPL_SHIM="bin/$CHPL_BIN_SUBDIR"/chpl-shim
 
 # copy chpl-language-server

--- a/util/buildRelease/install.sh
+++ b/util/buildRelease/install.sh
@@ -381,8 +381,6 @@ then
 fi
 
 CHPL_LANGUAGE_SERVER="bin/$CHPL_BIN_SUBDIR"/chpl-language-server
-# comes with chpl-language-server
-CHPL_SHIM="bin/$CHPL_BIN_SUBDIR"/chpl-shim
 
 # copy chpl-language-server
 if [ -f "$CHPL_LANGUAGE_SERVER" ]


### PR DESCRIPTION
Adds a Makefile target for chpl-shim so that it gets put in `bin` and picked up by `make install`

[Reviewed by @DanilaFe]