### PR TITLE
Do not use ---minimal-modules for `named-field-q-2.chpl`

### DIFF
--- a/test/types/records/generic/named-field-q-2.compopts
+++ b/test/types/records/generic/named-field-q-2.compopts
@@ -1,2 +1,0 @@
-# compile with --minimal-modules just because we can
---minimal-modules


### PR DESCRIPTION
Rationale: --minimal-modules does not work with several configurations, see
```
test/compflags/bradc/minimalModules/SKIPIF
```

To reduce the risk of testing noise, do not use this option on this test.

Not reviewed.