### PR TITLE
Expand error message for when fifo is used with GPU locale model

### DIFF
--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -361,9 +361,10 @@ def validate(chplLocaleModel):
     # (e.g. CUDA or ROCm)
     gpu.validate_sdk_version()
 
+    if chpl_tasks.get() == 'fifo':
+        error("The 'fifo' tasking model is not supported with GPU support")
+
     if get() == 'cpu':
-        if chpl_tasks.get() == 'fifo':
-            error("The 'fifo' tasking model is not supported with CPU-as-device mode")
         return True
 
     if chpl_compiler.get('target') != 'llvm':


### PR DESCRIPTION
With GPU support, we can't use the `fifo` tasking layer. We do have an error message for that, but for some reason it was just checking it for cpu-as-device mode. This PR fixes the error message to cover all GPU configs.

Resolves https://github.com/chapel-lang/chapel/issues/24619.