### PR TITLE
Fix ChapelIO links

### DIFF
--- a/doc/rst/language/spec/input-and-output.rst
+++ b/doc/rst/language/spec/input-and-output.rst
@@ -11,4 +11,4 @@ See Library Documentation
 
 Chapel includes an extensive library for input and output that is
 documented in the standard library documentation. See
-the :mod:`ChapelIO` and :mod:`IO` module documentation.
+the :mod:`IO` module documentation.

--- a/modules/standard/Errors.chpl
+++ b/modules/standard/Errors.chpl
@@ -631,7 +631,7 @@ module Errors {
   /*
     Assert that a boolean condition is true.  If it is false, prints
     'assert failed - ' followed by all subsequent arguments, as though
-    printed using :proc:`~ChapelIO.write()`.
+    printed using :proc:`~IO.write()`.
 
     .. note :: In the current implementation, this assert never becomes a no-op.
                That is, using it will always incur execution-time checks.

--- a/modules/standard/GPU.chpl
+++ b/modules/standard/GPU.chpl
@@ -92,7 +92,7 @@ module GPU
      This function is intended to be called from within a GPU kernel and is
      useful for debugging purposes.
 
-     Currently using :proc:`~ChapelIO.write` to send output to ``stdout`` will
+     Currently using :proc:`~IO.write` to send output to ``stdout`` will
      make a loop ineligible for GPU execution; use :proc:`gpuWrite` instead.
 
      Currently this function will only work if values of type


### PR DESCRIPTION
After https://github.com/chapel-lang/chapel/pull/24542, any reference to ChapelIO in the docs will result in a broken link. This PR fixes that oversight.

[Reviewed by @lydia-duncan]