### PR TITLE
Add spec index entries based on .tex index entries

### DIFF
--- a/doc/rst/language/spec/arrays.rst
+++ b/doc/rst/language/spec/arrays.rst
@@ -23,8 +23,9 @@ concurrently from distinct tasks. For more information see
 :ref:`the Parallel Safety section for domains <Domain_and_Array_Parallel_Safety>`.
 
 .. index::
-   single: arrays;types
-   single: arrays;element type
+   single: arrays; types
+   single: arrays; domain type
+   single: arrays; element type
 .. _Array_Types:
 
 Array Types
@@ -122,10 +123,10 @@ An array’s element type can be referred to using the member symbol
       real(64)
 
 .. index::
-   single: arrays;values
-   single: arrays;initialization
-   single: initialization;arrays
-   single: arrays;literals
+   single: arrays; values
+   single: arrays; initialization
+   single: initialization; arrays
+   single: arrays; literals
 .. _Array_Values:
 
 Array Values
@@ -152,9 +153,8 @@ corresponding to the underlying domain which defines its indices.
      associative-array-literal
 
 .. index::
-   single: rectangular array literals
-   single: arrays;rectangular;literals
-   single: arrays;rectangular;default values
+   pair: rectangular arrays; literals
+   seealso: arrays; rectangular arrays
 .. _Rectangular_Array_Literals:
 
 Rectangular Array Literals
@@ -244,12 +244,16 @@ procedure with an implicit return type (see
    arrays whose elements are themselves 1D arrays.
 
 
+.. index::
+   single: rectangular arrays; default values
+
 A rectangular array’s default value is an array in which each element
 is initialized to the default value of the element type.
 
 .. index::
-   single: associative array literals
-   single: arrays;associative;literals
+   pair: associative arrays; literals
+   seealso: arrays; associative arrays
+
 .. _Associative_Array_Literals:
 
 Associative Array Literals
@@ -317,8 +321,7 @@ of values in the listing also match. A trailing comma is allowed.
       (3, three)
 
 .. index::
-   single: arrays;runtime representation
-   single: arrays;domain maps
+   single: arrays; runtime representation
 .. _Array_Runtime_Representation:
 
 Runtime Representation of Array Values
@@ -330,8 +333,7 @@ control the runtime representation of an array’s elements. See
  :ref:`Chapter-Domain_Maps` for more details.
 
 .. index::
-   single: arrays;indexing
-   single: indexing;arrays
+   pair: arrays; indexing
 .. _Array_Indexing:
 
 Array Indexing
@@ -377,8 +379,7 @@ that is not part of its domain’s index set, the reference is considered
 out-of-bounds and a runtime error will occur, halting the program.
 
 .. index::
-   single: indexing;rectangular arrays
-   single: rectangular arrays;indexing
+   pair: rectangular arrays; indexing
 .. _Rectangular_Array_Indexing:
 
 Rectangular Array Indexing
@@ -469,8 +470,7 @@ the array.
    indexed into by 1-tuples.
 
 .. index::
-   single: indexing;associative arrays
-   single: associative arrays;indexing
+   pair: associative arrays; indexing
 .. _Associative_Array_Indexing:
 
 Associative Array Indexing
@@ -506,8 +506,7 @@ Indices can be added to associative arrays through the array’s domain.
       var x = A["a"];
 
 .. index::
-   single: arrays;iteration
-   single: iteration;array
+   pair: arrays; iteration
 .. _Iteration_over_Arrays:
 
 Iteration over Arrays
@@ -537,8 +536,7 @@ The iterator variable for an array iteration is a reference to the array
 element type.
 
 .. index::
-   single: arrays;assignment
-   single: assignment;array
+   pair: arrays; assignment
 .. _Array_Assignment:
 
 Array Assignment
@@ -689,8 +687,7 @@ array of booleans.  To get a single result use the ``equals`` method instead.
 
 
 .. index::
-   single: arrays;slicing
-   single: slicing;array
+   pair: arrays; slicing
 .. _Array_Slicing:
 
 Array Slicing
@@ -757,8 +754,8 @@ corresponding to the slicing domain’s index set.
    interior of ``A``.
 
 .. index::
-   single: arrays;slicing;rectangular
-   single: slicing;arrays;rectangular
+   single: arrays; slicing
+   pair: slicing; rectangular arrays
 .. _Rectangular_Array_Slicing:
 
 Rectangular Array Slicing
@@ -780,7 +777,7 @@ in :ref:`Array_Slicing` and then using that subdomain to slice
 the array.
 
 .. index::
-   single: arrays;slicing;rectangular;rank change
+   pair: arrays; rank change slicing
 .. _Rectangular_Array_Slicing_With_Rank_Change:
 
 Rectangular Array Slicing with a Rank Change
@@ -825,7 +822,7 @@ passed in to take the slice.
    are the first column of ``A``.
 
 .. index::
-   single: arrays;count operator
+   pair: arrays; count operator
    single: operators;# (on arrays)
 .. _Count_Operator_Arrays:
 
@@ -838,6 +835,9 @@ an integer in the case of a 1D array). The operator is equivalent to
 applying the ``#`` operator to the array’s domain and using the result
 to slice the array as described in Section :ref:`Rectangular_Array_Slicing`.
 
+.. index::
+   pair: arrays; swap operator
+   single: operators;<=> (on arrays)
 .. _Array_Swap_Operator:
 
 Swap operator ``<=>``
@@ -846,8 +846,7 @@ The ``<=>`` operator can be used to swap the contents of two arrays
 with the same shape.
 
 .. index::
-   single: arrays;actual arguments
-   single: arguments;array
+   pair: arrays; arguments
 .. _Array_Arguments_To_Functions:
 
 Array Arguments to Functions
@@ -868,8 +867,7 @@ index set. If the formal array’s domain was declared using an explicit
 distribution, the actual array’s domain must use an equivalent distribution.
 
 .. index::
-   single: arrays;promotion
-   single: promotion;arrays
+   pair: arrays; promotion
 .. _Array_Promotion_of_Scalar_Functions:
 
 Array Promotion of Scalar Functions
@@ -913,8 +911,7 @@ function as defined in :ref:`Promotion`.
    in ``A`` the element-wise sum of the elements in ``B`` and ``C``.
 
 .. index::
-   single: arrays;returning
-   single: returning;array
+   pair: arrays; returning
 .. _Returning_Arrays_from_Functions:
 
 Returning Arrays from Functions
@@ -927,7 +924,7 @@ Similarly to array arguments, the element type and/or domain of an array
 return type can be omitted.
 
 .. index::
-   single: arrays;sparse
+   single: arrays; sparse
 .. _Sparse_Arrays:
 
 Sparse Arrays
@@ -995,8 +992,8 @@ element type by assigning to a pseudo-field named ``IRV`` in the array.
       sparse-error.chpl:9: error: halt reached - attempting to assign a 'zero' value in a sparse array at index (1, 5)
 
 .. index::
-   single: domains;association with arrays
-   single: arrays;association with domains
+   single: domains; association with arrays
+   single: arrays; association with domains
 .. _Association_of_Arrays_to_Domains:
 
 Association of Arrays to Domains
@@ -1087,9 +1084,8 @@ For the ``+=`` and ``|=`` operators, the value from ``B`` will overwrite
 the existing value in ``A`` when indices overlap.
 
 .. index::
-   single: arrays;predefined functions
-   single: predefined functions;arrays
-   single: functions;arrays;predefined
+   pair: arrays; predefined functions
+   seealso: functions; predefined functions
 .. _Predefined_Functions_and_Methods_on_Arrays:
 
 Predefined Routines on Arrays

--- a/doc/rst/language/spec/arrays.rst
+++ b/doc/rst/language/spec/arrays.rst
@@ -1,5 +1,7 @@
 .. default-domain:: chpl
 
+.. index::
+   single: arrays
 .. _Chapter-Arrays:
 
 ======
@@ -20,6 +22,9 @@ Users must take care when applying operations to arrays and domains
 concurrently from distinct tasks. For more information see
 :ref:`the Parallel Safety section for domains <Domain_and_Array_Parallel_Safety>`.
 
+.. index::
+   single: arrays;types
+   single: arrays;element type
 .. _Array_Types:
 
 Array Types
@@ -116,6 +121,11 @@ An array’s element type can be referred to using the member symbol
       real(64)
       real(64)
 
+.. index::
+   single: arrays;values
+   single: arrays;initialization
+   single: initialization;arrays
+   single: arrays;literals
 .. _Array_Values:
 
 Array Values
@@ -141,6 +151,10 @@ corresponding to the underlying domain which defines its indices.
      rectangular-array-literal
      associative-array-literal
 
+.. index::
+   single: rectangular array literals
+   single: arrays;rectangular;literals
+   single: arrays;rectangular;default values
 .. _Rectangular_Array_Literals:
 
 Rectangular Array Literals
@@ -233,6 +247,9 @@ procedure with an implicit return type (see
 A rectangular array’s default value is an array in which each element
 is initialized to the default value of the element type.
 
+.. index::
+   single: associative array literals
+   single: arrays;associative;literals
 .. _Associative_Array_Literals:
 
 Associative Array Literals
@@ -299,6 +316,9 @@ of values in the listing also match. A trailing comma is allowed.
       (16, sixteen)
       (3, three)
 
+.. index::
+   single: arrays;runtime representation
+   single: arrays;domain maps
 .. _Array_Runtime_Representation:
 
 Runtime Representation of Array Values
@@ -309,6 +329,9 @@ domain’s distribution. Through this mechanism, users can reason about and
 control the runtime representation of an array’s elements. See
  :ref:`Chapter-Domain_Maps` for more details.
 
+.. index::
+   single: arrays;indexing
+   single: indexing;arrays
 .. _Array_Indexing:
 
 Array Indexing
@@ -353,6 +376,9 @@ Except for associative arrays, if an array is indexed using an index
 that is not part of its domain’s index set, the reference is considered
 out-of-bounds and a runtime error will occur, halting the program.
 
+.. index::
+   single: indexing;rectangular arrays
+   single: rectangular arrays;indexing
 .. _Rectangular_Array_Indexing:
 
 Rectangular Array Indexing
@@ -442,6 +468,9 @@ the array.
    even for one-dimensional arrays because one-dimensional arrays can be
    indexed into by 1-tuples.
 
+.. index::
+   single: indexing;associative arrays
+   single: associative arrays;indexing
 .. _Associative_Array_Indexing:
 
 Associative Array Indexing
@@ -476,6 +505,9 @@ Indices can be added to associative arrays through the array’s domain.
       A["b"] = 2;
       var x = A["a"];
 
+.. index::
+   single: arrays;iteration
+   single: iteration;array
 .. _Iteration_over_Arrays:
 
 Iteration over Arrays
@@ -504,6 +536,9 @@ is semantically equivalent to:
 The iterator variable for an array iteration is a reference to the array
 element type.
 
+.. index::
+   single: arrays;assignment
+   single: assignment;array
 .. _Array_Assignment:
 
 Array Assignment
@@ -653,6 +688,9 @@ array of booleans.  To get a single result use the ``equals`` method instead.
   arr1.equals(arr2) // compare entire arrays resulting in a single boolean
 
 
+.. index::
+   single: arrays;slicing
+   single: slicing;array
 .. _Array_Slicing:
 
 Array Slicing
@@ -718,6 +756,9 @@ corresponding to the slicing domain’s index set.
    assigns the elements in the interior of ``B`` to the elements in the
    interior of ``A``.
 
+.. index::
+   single: arrays;slicing;rectangular
+   single: slicing;arrays;rectangular
 .. _Rectangular_Array_Slicing:
 
 Rectangular Array Slicing
@@ -738,6 +779,8 @@ domain by the specified ranges to create a subdomain as described
 in :ref:`Array_Slicing` and then using that subdomain to slice
 the array.
 
+.. index::
+   single: arrays;slicing;rectangular;rank change
 .. _Rectangular_Array_Slicing_With_Rank_Change:
 
 Rectangular Array Slicing with a Rank Change
@@ -781,6 +824,9 @@ passed in to take the slice.
    the slice ``A[1..n, 1]`` is a one-dimensional array whose elements
    are the first column of ``A``.
 
+.. index::
+   single: arrays;count operator
+   single: operators;# (on arrays)
 .. _Count_Operator_Arrays:
 
 Count Operator
@@ -799,6 +845,9 @@ Swap operator ``<=>``
 The ``<=>`` operator can be used to swap the contents of two arrays
 with the same shape.
 
+.. index::
+   single: arrays;actual arguments
+   single: arguments;array
 .. _Array_Arguments_To_Functions:
 
 Array Arguments to Functions
@@ -818,6 +867,9 @@ signature, the domain of the actual argument must represent the same
 index set. If the formal array’s domain was declared using an explicit
 distribution, the actual array’s domain must use an equivalent distribution.
 
+.. index::
+   single: arrays;promotion
+   single: promotion;arrays
 .. _Array_Promotion_of_Scalar_Functions:
 
 Array Promotion of Scalar Functions
@@ -860,6 +912,9 @@ function as defined in :ref:`Promotion`.
    if ``A``, ``B``, and ``C`` are arrays, this code assigns each element
    in ``A`` the element-wise sum of the elements in ``B`` and ``C``.
 
+.. index::
+   single: arrays;returning
+   single: returning;array
 .. _Returning_Arrays_from_Functions:
 
 Returning Arrays from Functions
@@ -871,6 +926,8 @@ intents can be used to return a reference to an array.
 Similarly to array arguments, the element type and/or domain of an array
 return type can be omitted.
 
+.. index::
+   single: arrays;sparse
 .. _Sparse_Arrays:
 
 Sparse Arrays
@@ -937,6 +994,9 @@ element type by assigning to a pseudo-field named ``IRV`` in the array.
 
       sparse-error.chpl:9: error: halt reached - attempting to assign a 'zero' value in a sparse array at index (1, 5)
 
+.. index::
+   single: domains;association with arrays
+   single: arrays;association with domains
 .. _Association_of_Arrays_to_Domains:
 
 Association of Arrays to Domains
@@ -1026,6 +1086,10 @@ will halt with an error message.
 For the ``+=`` and ``|=`` operators, the value from ``B`` will overwrite
 the existing value in ``A`` when indices overlap.
 
+.. index::
+   single: arrays;predefined functions
+   single: predefined functions;arrays
+   single: functions;arrays;predefined
 .. _Predefined_Functions_and_Methods_on_Arrays:
 
 Predefined Routines on Arrays

--- a/doc/rst/language/spec/bytes.rst
+++ b/doc/rst/language/spec/bytes.rst
@@ -1,6 +1,9 @@
 
 .. default-domain:: chpl
 
+.. index::
+   single: bytes
+   single: types; bytes
 .. _Chapter-Bytes:
 
 =====

--- a/doc/rst/language/spec/classes.rst
+++ b/doc/rst/language/spec/classes.rst
@@ -1,5 +1,8 @@
 .. default-domain:: chpl
 
+.. index::
+   single: classes
+   single: classes;instances
 .. _Chapter-Classes:
 
 =======
@@ -26,6 +29,9 @@ A class is generic if it has generic fields. A class can also be generic
 if it inherits from a generic class. Generic classes and fields are
 discussed in :ref:`Generic_Types`.
 
+.. index::
+   single: classes;declarations
+   single: class
 .. _Class_Declarations:
 
 Class Declarations
@@ -73,6 +79,11 @@ Generic classes are described in :ref:`Generic_Types`.
       as discussion is needed regarding its impact on inheritance, for
       instance.
 
+.. index::
+   single: classes;lifetime
+   single: classes;borrows
+   single: class lifetime
+   single: borrow
 .. _Class_Lifetime_and_Borrows:
 
 Class Lifetime and Borrows
@@ -156,6 +167,9 @@ it refers to.
       Additional syntax to specify the lifetimes of function returns will
       probably be needed.
 
+.. index::
+   single: classes;types
+   single: class type
 .. _Class_Types:
 
 Class Types
@@ -331,6 +345,9 @@ expression of a class type ``C``. It will return ``borrowed C`` for any
 non-nilable ``C`` type (e.g. ``owned C``). It will return
 ``borrowed C?`` for any nilable ``C`` type (e.g. ``C?``).
 
+.. index::
+   single: classes;values
+   single: class value
 .. _Class_Values:
 
 Class Values
@@ -378,6 +395,9 @@ non-nilable classes are not currently supported.
    implicitly from the initialization expression. Finally, an object
    of type ``owned D`` is created and assigned to ``c``.
 
+.. index::
+   single: classes;nil
+   single: nil
 .. _Class_nil_value:
 
 The *nil* Value
@@ -395,6 +415,9 @@ formal/variable/field is non-nilable or generic, including generic
 memory management.
 
 
+.. index::
+   single: classes;fields
+   single: fields;class
 .. _Class_Fields:
 
 Class Fields
@@ -434,6 +457,13 @@ Field access is described in :ref:`Class_Field_Accesses`.
       declarations with ``ref`` or ``const ref`` keywords, are an area of
       future work.
 
+.. index::
+   single: classes;methods
+   single: methods;classes
+   single: methods;primary
+   single: methods;secondary
+   single: primary methods
+   single: secondary methods
 .. _Class_Methods:
 
 Class Methods
@@ -549,6 +579,9 @@ management. See also :ref:`Methods_without_Parentheses`.
       owned C?
 
 
+.. index::
+   single: classes;nested classes
+   single: nested classes
 .. _Nested_Classes:
 
 Nested Classes
@@ -558,6 +591,11 @@ A class defined within another class or record is a nested class. A
 nested class can be referenced only within its immediately enclosing
 class or record.
 
+.. index::
+   single: inheritance
+   single: classes;inheritance
+   single: derived class
+   single: classes;derived
 .. _Inheritance:
 
 Inheritance
@@ -578,6 +616,9 @@ will have type constructor arguments based upon generic fields in the
 fully specified ``C`` will be a subclass of a corresponding fully
 specified ``ParentC``.
 
+.. index::
+   single: RootClass
+   single: classes;RootClass
 .. _The_Root_Class:
 
 The Root Class
@@ -590,6 +631,9 @@ directly or indirectly. If a class declaration does not contain a
 indirectly through the class it inherits from. A variable of type
 ``RootClass`` can hold a reference to an object of any class type.
 
+.. index::
+   single: classes;base;field access
+   single: classes;field access;base class
 .. _Accessing_Base_Class_Fields:
 
 Accessing Base Class Fields
@@ -601,6 +645,8 @@ accessed in their base class unless a getter method is overridden in the
 derived class, as discussed
 in :ref:`Overriding_Base_Class_Methods`.
 
+.. index::
+   single: shadowing;base class fields
 .. _Shadowing_Base_Class_Fields:
 
 Shadowing Base Class Fields
@@ -609,6 +655,9 @@ Shadowing Base Class Fields
 A field in a derived class declared with the same name as a field in a
 base class will cause a compilation error.
 
+.. index::
+   single: dynamic dispatch
+   single: methods;base class;overriding
 .. _Overriding_Base_Class_Methods:
 
 Overriding Base Class Methods
@@ -660,6 +709,10 @@ Methods without parentheses are not candidates for dynamic dispatch.
    access a base field within a base method should that field be
    shadowed by a subclass.
 
+.. index::
+   single: new;classes
+   single: new
+   single: classes;new
 .. _Class_New:
 
 Class New
@@ -713,6 +766,9 @@ a ``type-expression`` that results in a class type. Then:
 See also :ref:`Class_Lifetime_and_Borrows` and
 :ref:`Class_Types`.
 
+.. index::
+   single: classes;initializers
+   single: initializers
 .. _Class_Initializers:
 
 Class Initializers
@@ -729,6 +785,15 @@ If the program declares no initializers for a class, the compiler must
 generate an initializer for that class based on the types and
 initialization expressions of fields defined by that class.
 
+.. index::
+   single: classes;initializers;user-defined
+   single: user-defined initializers
+   single: initializers;user-defined
+   single: classes;initializers;user-defined;init-vs-assign
+   single: classes;initializers;user-defined;omitting
+   single: classes;initializers;user-defined;complete
+   single: classes;initializers;user-defined;other-initializers
+   single: classes;initializers;user-defined;conditionals
 .. _User_Defined_Initializers:
 
 User-Defined Initializers
@@ -1265,6 +1330,10 @@ Miscellaneous Field Initialization Rules
 Fields may not be initialized within loop statements or parallel
 statements.
 
+.. index::
+   single: classes;initializers;compiler-generated
+   single: initializers;compiler-generated
+   single: compiler-generated initializers
 .. _The_Compiler_Generated_Initializer:
 
 The Compiler-Generated Initializer
@@ -1333,6 +1402,8 @@ value of the corresponding actual argument.
    -  The call ``new C(0,0.0,"")`` specifies the initial values for all
       fields explicitly.
 
+.. index::
+   single: classes;initializers;postinit
 .. _The_postinit_Method:
 
 The postinit Method
@@ -1393,6 +1464,13 @@ For classes that inherit, the user may invoke the parent’s ``postinit``
 method or let the compiler insert a call automatically
 (:ref:`The_postinit_Method_for_Inheriting_Classes`).
 
+.. index::
+   single: classes;initializers;initializer-inheritance
+   single: initializers;initializer-inheritance
+   single: initializer-inheritance
+   single: classes;initializers;initializer-inheritance;dynamic-this
+   single: classes;initializers;initializer-inheritance;compiler-generated
+   single: classes;initializers;initializer-inheritance;postinit
 .. _Initializing_Inherited:
 
 Initializing Inherited Classes
@@ -1684,6 +1762,11 @@ parent’s ``postinit`` method.
       Parent.postinit: 1.0, 2.0
       Child.postinit: 3.0, 4.0
 
+.. index::
+   single: classes;field access
+   single: field access;class
+   single: classes;receiver
+   single: receiver;class
 .. _Class_Field_Accesses:
 
 Field Accesses
@@ -1764,6 +1847,10 @@ instantiated class type itself.
    and assigns the field ``age`` in the object ``anActor`` the value
    ``27``.
 
+.. index::
+   single: classes;getter method
+   single: getter method;class
+   single: methods;class;getter
 .. _Getter_Methods:
 
 Field Getter Methods
@@ -1773,6 +1860,9 @@ The compiler implements field access as calls to a compiler-generated
 methods without parentheses that have the same name as the field. See
 also :ref:`Methods_without_Parentheses`.
 
+.. index::
+   single: classes;method calls
+   single: methods;calling
 .. _Class_Method_Calls:
 
 Class Method Calls
@@ -1792,6 +1882,9 @@ method receivers.
 Common Operations
 -----------------
 
+.. index::
+   single: classes;assignment
+   single: assignment;class
 .. _Class_Assignment:
 
 Class Assignment
@@ -1843,6 +1936,10 @@ different memory management strategies are disallowed:
    the source and the destination would appear responsible for deleting
    the instance
 
+.. index::
+   single: classes;delete
+   single: delete;class unmanaged instances
+   single: deallocation;unmanaged class instances
 .. _Class_Delete:
 
 Deleting Unmanaged Class Instances
@@ -1909,6 +2006,9 @@ behavior is undefined.
 
       DONE
 
+.. index::
+   single: classes;deinitializer
+   single: deinitializer;classes
 .. _Class_Deinitializer:
 
 Class Deinitializer

--- a/doc/rst/language/spec/classes.rst
+++ b/doc/rst/language/spec/classes.rst
@@ -2,7 +2,11 @@
 
 .. index::
    single: classes
-   single: classes;instances
+   single: classes; instances
+   seealso: classes; owned classes
+   seealso: classes; shared classes
+   seealso: classes; borrowed classes
+   seealso: classes; unmanaged classes
 .. _Chapter-Classes:
 
 =======
@@ -30,7 +34,7 @@ if it inherits from a generic class. Generic classes and fields are
 discussed in :ref:`Generic_Types`.
 
 .. index::
-   single: classes;declarations
+   single: classes; declarations
    single: class
 .. _Class_Declarations:
 
@@ -80,10 +84,12 @@ Generic classes are described in :ref:`Generic_Types`.
       instance.
 
 .. index::
-   single: classes;lifetime
-   single: classes;borrows
-   single: class lifetime
-   single: borrow
+   pair: classes; lifetime
+   single: classes; borrows
+   pair: owned classes; lifetime
+   pair: shared classes; lifetime
+   pair: unmanaged classes; lifetime
+   pair: borrowed classes; lifetime
 .. _Class_Lifetime_and_Borrows:
 
 Class Lifetime and Borrows
@@ -168,8 +174,11 @@ it refers to.
       probably be needed.
 
 .. index::
-   single: classes;types
-   single: class type
+   single: classes; types
+   pair: owned classes; types
+   pair: shared classes; types
+   pair: unmanaged classes; types
+   pair: borrowed classes; types
 .. _Class_Types:
 
 Class Types
@@ -278,6 +287,8 @@ available for this purpose (see :ref:`Explicit_Class_Conversions`).
       borrowed C
       owned C
 
+.. index::
+   pair: classes; nilable
 .. _Nilable_Classes:
 
 Nilable Class Types
@@ -346,8 +357,7 @@ non-nilable ``C`` type (e.g. ``owned C``). It will return
 ``borrowed C?`` for any nilable ``C`` type (e.g. ``C?``).
 
 .. index::
-   single: classes;values
-   single: class value
+   single: classes; values
 .. _Class_Values:
 
 Class Values
@@ -396,7 +406,7 @@ non-nilable classes are not currently supported.
    of type ``owned D`` is created and assigned to ``c``.
 
 .. index::
-   single: classes;nil
+   single: classes; nil
    single: nil
 .. _Class_nil_value:
 
@@ -416,8 +426,7 @@ memory management.
 
 
 .. index::
-   single: classes;fields
-   single: fields;class
+   pair: classes; fields
 .. _Class_Fields:
 
 Class Fields
@@ -458,12 +467,12 @@ Field access is described in :ref:`Class_Field_Accesses`.
       future work.
 
 .. index::
-   single: classes;methods
-   single: methods;classes
-   single: methods;primary
-   single: methods;secondary
+   pair: classes; methods
+   single: methods; primary
+   single: methods; secondary
    single: primary methods
    single: secondary methods
+   single: methods; this
 .. _Class_Methods:
 
 Class Methods
@@ -580,7 +589,7 @@ management. See also :ref:`Methods_without_Parentheses`.
 
 
 .. index::
-   single: classes;nested classes
+   single: classes; nested classes
    single: nested classes
 .. _Nested_Classes:
 
@@ -593,9 +602,9 @@ class or record.
 
 .. index::
    single: inheritance
-   single: classes;inheritance
+   single: classes; inheritance
    single: derived class
-   single: classes;derived
+   single: classes; derived
 .. _Inheritance:
 
 Inheritance
@@ -618,7 +627,7 @@ specified ``ParentC``.
 
 .. index::
    single: RootClass
-   single: classes;RootClass
+   single: classes; RootClass
 .. _The_Root_Class:
 
 The Root Class
@@ -632,8 +641,8 @@ indirectly through the class it inherits from. A variable of type
 ``RootClass`` can hold a reference to an object of any class type.
 
 .. index::
-   single: classes;base;field access
-   single: classes;field access;base class
+   single: classes; accessing inherited fields
+   single: inheritance; accessing fields
 .. _Accessing_Base_Class_Fields:
 
 Accessing Base Class Fields
@@ -646,7 +655,7 @@ derived class, as discussed
 in :ref:`Overriding_Base_Class_Methods`.
 
 .. index::
-   single: shadowing;base class fields
+   single: shadowing; inherited class fields
 .. _Shadowing_Base_Class_Fields:
 
 Shadowing Base Class Fields
@@ -657,7 +666,8 @@ base class will cause a compilation error.
 
 .. index::
    single: dynamic dispatch
-   single: methods;base class;overriding
+   single: methods; overriding inherited methods
+   single: override
 .. _Overriding_Base_Class_Methods:
 
 Overriding Base Class Methods
@@ -710,9 +720,8 @@ Methods without parentheses are not candidates for dynamic dispatch.
    shadowed by a subclass.
 
 .. index::
-   single: new;classes
+   pair: new; classes
    single: new
-   single: classes;new
 .. _Class_New:
 
 Class New
@@ -767,8 +776,7 @@ See also :ref:`Class_Lifetime_and_Borrows` and
 :ref:`Class_Types`.
 
 .. index::
-   single: classes;initializers
-   single: initializers
+   pair: classes; initializers
 .. _Class_Initializers:
 
 Class Initializers
@@ -786,14 +794,10 @@ generate an initializer for that class based on the types and
 initialization expressions of fields defined by that class.
 
 .. index::
-   single: classes;initializers;user-defined
-   single: user-defined initializers
-   single: initializers;user-defined
-   single: classes;initializers;user-defined;init-vs-assign
-   single: classes;initializers;user-defined;omitting
-   single: classes;initializers;user-defined;complete
-   single: classes;initializers;user-defined;other-initializers
-   single: classes;initializers;user-defined;conditionals
+   pair: classes; user-defined initializers
+   seealso: initializers; user-defined initializers
+   single: user-defined initializers; complete
+   single: user-defined initializers; conditionals
 .. _User_Defined_Initializers:
 
 User-Defined Initializers
@@ -861,6 +865,8 @@ Section :ref:`Generic_User_Initializers` for details.
    and the second initializer lets the user specify the initial message
    when creating a MessagePoint.
 
+.. index::
+   single: user-defined initializers; field initialization vs assignment
 .. _Field_Initialization_Versus_Assignment:
 
 Field Initialization Versus Assignment
@@ -942,6 +948,8 @@ be issued.
       usedBeforeInitialized.chpl:4: In initializer:
       usedBeforeInitialized.chpl:5: error: field "x" used before it is initialized
 
+.. index::
+   single: user-defined initializers; omitting fields
 .. _Omitting_Field_Initializations:
 
 Omitting Field Initializations
@@ -1058,6 +1066,9 @@ initialized out of order, a compile-time error will be issued.
    confusing and surprising, and is avoided by requiring fields to be
    initialized in field declaration order.
 
+.. index::
+   single: user-defined initializers; limitations
+   single: user-defined initializers; init this
 .. _Limitations_on_Instance_Usage_in_Initializers:
 
 Limitations on Instance Usage in Initializers
@@ -1168,6 +1179,8 @@ compiler will insert it at the end of the initializer.
    ``init this`` statement is used. If the second initializer tried to
    invoke the ``verify`` method, a compile-time error would be issued.
 
+.. index::
+   single: user-defined initializers; invoking other initializers
 .. _Invoking_Other_Initializers:
 
 Invoking Other Initializers
@@ -1215,6 +1228,8 @@ after such a call to ``init``.
    fully initialized, the ``init this`` statement has been used, and so
    ``this`` can be passed to the ``writeln`` function.
 
+.. index::
+   single: user-defined initializers; conditionals
 .. _Initializing_Fields_in_Conditional_Statements:
 
 Initializing Fields in Conditional Statements
@@ -1324,6 +1339,9 @@ at the end of the conditional statement.
    of the if-branch in order to match the state at the end of the
    else-branch.
 
+.. index::
+   single: user-defined initializers; limitations
+
 Miscellaneous Field Initialization Rules
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -1331,9 +1349,8 @@ Fields may not be initialized within loop statements or parallel
 statements.
 
 .. index::
-   single: classes;initializers;compiler-generated
-   single: initializers;compiler-generated
-   single: compiler-generated initializers
+   pair: classes;compiler-generated initializers
+   seealso: initializers; compiler-generated initializers
 .. _The_Compiler_Generated_Initializer:
 
 The Compiler-Generated Initializer
@@ -1403,7 +1420,7 @@ value of the corresponding actual argument.
       fields explicitly.
 
 .. index::
-   single: classes;initializers;postinit
+   single: user-defined initializers; postinit for classes
 .. _The_postinit_Method:
 
 The postinit Method
@@ -1465,12 +1482,9 @@ method or let the compiler insert a call automatically
 (:ref:`The_postinit_Method_for_Inheriting_Classes`).
 
 .. index::
-   single: classes;initializers;initializer-inheritance
-   single: initializers;initializer-inheritance
-   single: initializer-inheritance
-   single: classes;initializers;initializer-inheritance;dynamic-this
-   single: classes;initializers;initializer-inheritance;compiler-generated
-   single: classes;initializers;initializer-inheritance;postinit
+   single: initializers; initializers and inheritance
+   single: inheritance; initializers
+   single: user-defined initializers; initializers and inheritance
 .. _Initializing_Inherited:
 
 Initializing Inherited Classes
@@ -1596,6 +1610,8 @@ be accessed before explicit calls to ``init``.
    parent’s initializer because it explicitly invokes another
    initializer.
 
+.. index::
+   single: user-defined initializers; methods and inheritance
 .. _Calling_Methods_on_Parent_Classes:
 
 Calling Methods on Parent Classes
@@ -1668,6 +1684,8 @@ functions as though it were of the parent type.
       Child.foo
       {x = 1.0, y = 2.0, z = 3.0}
 
+.. index::
+   single: compiler-generated initializers; initializers and inheritance
 .. _The_Compiler_Generated_Initializer_for_Inheriting_Classes:
 
 The Compiler Generated Initializer for Inheriting Classes
@@ -1715,6 +1733,8 @@ formals for the child type.
    initializer with three formals named ``x``, ``y``, and ``z`` that all
    have default values based on their types.
 
+.. index::
+   single: user-defined initializers; postinit for classes
 .. _The_postinit_Method_for_Inheriting_Classes:
 
 The postinit Method for Inheriting Classes
@@ -1763,10 +1783,8 @@ parent’s ``postinit`` method.
       Child.postinit: 3.0, 4.0
 
 .. index::
-   single: classes;field access
-   single: field access;class
-   single: classes;receiver
-   single: receiver;class
+   pair: classes; field access
+   pair: classes; receiver
 .. _Class_Field_Accesses:
 
 Field Accesses
@@ -1848,9 +1866,8 @@ instantiated class type itself.
    ``27``.
 
 .. index::
-   single: classes;getter method
-   single: getter method;class
-   single: methods;class;getter
+   pair: classes; getter method
+   single: methods; field getter
 .. _Getter_Methods:
 
 Field Getter Methods
@@ -1861,8 +1878,8 @@ methods without parentheses that have the same name as the field. See
 also :ref:`Methods_without_Parentheses`.
 
 .. index::
-   single: classes;method calls
-   single: methods;calling
+   single: classes; method calls
+   single: methods; calling
 .. _Class_Method_Calls:
 
 Class Method Calls
@@ -1883,8 +1900,7 @@ Common Operations
 -----------------
 
 .. index::
-   single: classes;assignment
-   single: assignment;class
+   pair: classes; assignment
 .. _Class_Assignment:
 
 Class Assignment
@@ -1937,9 +1953,9 @@ different memory management strategies are disallowed:
    the instance
 
 .. index::
-   single: classes;delete
-   single: delete;class unmanaged instances
-   single: deallocation;unmanaged class instances
+   single: classes; delete
+   single: delete; class unmanaged instances
+   single: deallocation; unmanaged class instances
 .. _Class_Delete:
 
 Deleting Unmanaged Class Instances
@@ -2007,8 +2023,7 @@ behavior is undefined.
       DONE
 
 .. index::
-   single: classes;deinitializer
-   single: deinitializer;classes
+   pair: classes; deinitializer
 .. _Class_Deinitializer:
 
 Class Deinitializer
@@ -2057,6 +2072,9 @@ the memory.
 
 
 
+.. index::
+   single: owned classes
+   pair: classes; owned
 .. _Owned_Objects:
 
 Owned Objects
@@ -2111,7 +2129,8 @@ and transfer the owned class instance to the other value.
 
  var emptyOwnedObject: owned MyClass;
 
-
+.. index::
+   single: owned classes; borrowing
 .. _about-owned-borrowing:
 
 Borrowing from `owned`
@@ -2136,6 +2155,8 @@ that could be deleted before the `borrow`. For example:
    // a is deleted here
  }
 
+.. index::
+   single: owned classes; implicit conversions
 .. _about-owned-coercions:
 
 Coercions for `owned`
@@ -2171,6 +2192,9 @@ For example:
  // myStudent containing nil.
 
 
+.. index::
+   single: owned classes; default intent
+
 `owned` Default Intent
 ~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -2178,6 +2202,9 @@ The default intent for :type:`~OwnedObject.owned` is ``const``. See more on
 argument intents in the :ref:`Procedures Primer <primers-procedures>` and see
 more on the default intent in the :ref:`Intents_for_owned_and_shared`.
 
+.. index::
+   single: owned classes; predefined methods
+   single: predefined functions; owned classes
 .. _Owned_Methods:
 
 Methods on `owned` Classes
@@ -2186,7 +2213,9 @@ Methods on `owned` Classes
 .. include:: /builtins/OwnedObject.rst
 
 
-
+.. index::
+   single: shared classes
+   pair: classes; shared
 .. _Shared_Objects:
 
 Shared Objects
@@ -2230,6 +2259,9 @@ will be deleted after all of these references go out of scope.
    // goes out of scope.
  }
 
+.. index::
+   single: shared classes; borrowing
+
 Borrowing from `shared`
 ~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -2241,6 +2273,9 @@ some checking for errors in this case. In these ways,
 
 See :ref:`about-owned-borrowing` for more details and examples.
 
+.. index::
+   single: shared classes; implicit conversions
+
 Coercions for `shared`
 ~~~~~~~~~~~~~~~~~~~~~~
 
@@ -2251,6 +2286,9 @@ subclass of ``U``.
 
 See :ref:`about-owned-coercions` for more details and examples.
 
+.. index::
+   single: shared classes; default intent
+
 `shared` Default Intent
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -2258,6 +2296,9 @@ The default intent for :type:`~SharedObject.shared` is ``const``. See more on
 argument intents in the :ref:`Procedures Primer <primers-procedures>` and see
 more on the default intent in the :ref:`Intents_for_owned_and_shared`.
 
+.. index::
+   single: shared classes; predefined methods
+   single: predefined functions; shared classes
 .. _Shared_Methods:
 
 Methods on `shared` Classes

--- a/doc/rst/language/spec/conversions.rst
+++ b/doc/rst/language/spec/conversions.rst
@@ -2,8 +2,8 @@
 
 .. index::
    single: conversions
-   single: conversions;source type
-   single: conversions;target type
+   single: conversions; source type
+   single: conversions; target type
 .. _Chapter-Conversions:
 
 ===========
@@ -18,9 +18,11 @@ implicit (:ref:`Implicit_Conversions`) or
 explicit (:ref:`Explicit_Conversions`).
 
 .. index::
-   single: conversions;implicit
-   single: conversions;implicit;occurs at
-   single: conversions;implicit;allowed types
+   single: conversions; implicit
+   single: implicit conversions
+   see: coercions; implicit conversions
+   single: implicit conversions; occurs at
+   single: implicit conversions; allowed types
 .. _Implicit_Conversions:
 
 Implicit Conversions
@@ -74,10 +76,13 @@ be defined for record types, as specified in
 :ref:`Implicit_Conversion_Init_Assign`.
 
 .. index::
-   single: conversions;numeric
-   single: conversions;implicit;numeric
-   single: conversions;boolean
-   single: conversions;implicit;boolean
+   single: implicit conversions; numeric
+   pair: implicit conversions; int
+   pair: implicit conversions; uint
+   pair: implicit conversions; real
+   pair: implicit conversions; imag
+   pair: implicit conversions; complex
+   pair: implicit conversions; bool
 .. _Implicit_NumBool_Conversions:
 
 Implicit Numeric and Bool Conversions
@@ -163,8 +168,8 @@ complex(\ :math:`s`)                                                            
 
 
 .. index::
-   single: conversions;numeric;parameter
-   single: conversions;implicit;parameter
+   pair: implicit conversions; literals
+   pair: implicit conversions; params
 .. _Implicit_Compile_Time_Constant_Conversions:
 
 Implicit Compile-Time Constant Conversions
@@ -192,6 +197,8 @@ implicitly convert:
  * to ``uint`` of matching or greater size or to ``real``
  * or, to ``complex`` of any size.
 
+.. index::
+   pair: implicit conversions; ranges
 .. _Implicit_Range_Conversions:
 
 Implicit Range Conversions
@@ -217,10 +224,9 @@ conversion is allowed when:
    and the ``strides`` of the source is ``negOne``.
 
 .. index::
-   single: conversions;implicit;class
-   single: conversions;implicit;nilable
-   single: conversions;implicit;borrow
-   single: classes;implicit conversion
+   pair: implicit conversions; classes
+   single: implicit conversions; nilability
+   single: implicit conversions; borrowing
 .. _Implicit_Class_Conversions:
 
 Implicit Class Conversions
@@ -257,8 +263,9 @@ See :ref:`Class_Lifetime_and_Borrows`.  For example:
 
 
 .. index::
-   single: conversions;implicit;type arguments
-   single: conversions;implicit;subtype
+   single: implicit conversions; type arguments
+   single: implicit conversions; subtype
+   single: subtype
 .. _Subtype:
 .. _Subtype_Arg_Conversions:
 .. _Implicit_Type_Arg_Conversions:
@@ -409,6 +416,9 @@ when one type is a subtype of another.
 
      true
 
+.. index::
+   pair: implicit conversions; assignment
+   pair: implicit conversions; initialization
 .. _Implicit_Conversion_Init_Assign:
 
 Implicit Conversions for Initialization and Assignment
@@ -516,6 +526,9 @@ without ``init=`` or to provide ``init=`` without ``=``.
       c is (intValue = 3) : myInteger
       d is (intValue = 4) : myInteger
 
+.. index::
+   single: implicit conversions; for calls
+   single: calls; implicit conversion
 .. _Implicit_Conversion_Call:
 
 Implicit Conversions for Function Calls
@@ -558,8 +571,8 @@ Implicit conversions are not applied for actual arguments passed to
    calls?  If so, how would the user define them?
 
 .. index::
-   single: conversions;boolean;in a statement
-   single: conversions;implicit;boolean
+   pair: implicit conversions; conditionals
+   single: implicit conversion; boolean
 .. _Implicit_Conversion_Conditionals:
 .. _Implicit_Statement_Bool_Conversions:
 
@@ -592,7 +605,10 @@ indicated in their documentation.
 
 
 .. index::
-   single: conversions;explicit
+   single: conversions; explicit
+   single: conversions; casts
+   single: casts
+   see: explicit conversions; casts
 .. _Explicit_Conversions:
 
 Explicit Conversions
@@ -629,8 +645,7 @@ type. Such a conversion does not change the value of the expression.
 
 
 .. index::
-   single: conversions;numeric
-   single: conversions;explicit;numeric
+   single: casts; numeric
 .. _Explicit_Numeric_Conversions:
 
 Explicit Numeric Conversions
@@ -715,8 +730,7 @@ Explicitly converting between ``real(k)`` and ``imag(k)`` will copy the
 represented number while changing whether or not it is imaginary.
 
 .. index::
-   single: conversions;tuple to complex
-   single: conversions;explicit;tuple to complex
+   single: casts; tuple to complex
 .. _Explicit_Tuple_to_Complex_Conversion:
 
 Explicit Tuple to Complex Conversion
@@ -731,8 +745,7 @@ resulting complex value; the second member of the tuple becomes the
 imaginary part of the resulting complex value.
 
 .. index::
-   single: conversions;enumeration
-   single: conversions;explicit;enumeration
+   single: casts; enums
 .. _Explicit_Enumeration_Conversions:
 
 Explicit Enumeration Conversions
@@ -778,9 +791,7 @@ the matching symbol.  If no symbol has the given integer value, an
 
 
 .. index::
-   single: conversions;class
-   single: conversions;explicit;class
-   single: classes;explicit conversion
+   pair: casts; classes
 .. _Explicit_Class_Conversions:
 
 Explicit Class Conversions
@@ -841,8 +852,7 @@ The conversions in this subsection apply when the source is either an
 expression or a type expression.
 
 .. index::
-   single: conversions;range
-   single: conversions;explicit;range
+   pair: casts; ranges
 .. _Explicit_Range_Conversions:
 
 Explicit Range Conversions
@@ -862,8 +872,7 @@ target's stride type or it is of the opposite sign than expected
 by the target's ``strides`` parameter.
 
 .. index::
-   single: conversions;domain
-   single: conversions;explicit;domain
+   pair: casts; domains
 .. _Explicit_Domain_Conversions:
 
 Explicit Domain Conversions
@@ -875,8 +884,7 @@ Such conversion is performed dimension-wise following the rules
 for explicit range conversions (see :ref:`Explicit_Range_Conversions`).
 
 .. index::
-   single: conversions;string to bytes
-   single: conversions;explicit;string to bytes
+   pair: casts; string to bytes
 .. _Explicit_String_to_Bytes_Conversions:
 
 Explicit String to Bytes Conversions
@@ -888,8 +896,7 @@ contain arbitrary bytes. Instead, ``bytes.decode()`` method should be
 used to produce a ``string`` from a ``bytes``.
 
 .. index::
-   single: conversions;type to string
-   single: conversions;explicit;type to string
+   single: casts; type to string
 .. _Explicit_Type_to_String_Conversions:
 
 Explicit Type to String Conversions
@@ -913,7 +920,8 @@ resultant ``string`` is the name of the type.
 
    This program will print out the string ``"real(64)"``.
 
-
+.. index::
+   single: casts; user-defined
 .. _User_Defined_Casts:
 
 User-Defined Casts

--- a/doc/rst/language/spec/conversions.rst
+++ b/doc/rst/language/spec/conversions.rst
@@ -1,5 +1,9 @@
 .. default-domain:: chpl
 
+.. index::
+   single: conversions
+   single: conversions;source type
+   single: conversions;target type
 .. _Chapter-Conversions:
 
 ===========
@@ -13,6 +17,10 @@ expression can be a type expression. We refer to these two types as the
 implicit (:ref:`Implicit_Conversions`) or
 explicit (:ref:`Explicit_Conversions`).
 
+.. index::
+   single: conversions;implicit
+   single: conversions;implicit;occurs at
+   single: conversions;implicit;allowed types
 .. _Implicit_Conversions:
 
 Implicit Conversions
@@ -65,6 +73,11 @@ Additionally, implicit conversions for initialization and assignment can
 be defined for record types, as specified in
 :ref:`Implicit_Conversion_Init_Assign`.
 
+.. index::
+   single: conversions;numeric
+   single: conversions;implicit;numeric
+   single: conversions;boolean
+   single: conversions;implicit;boolean
 .. _Implicit_NumBool_Conversions:
 
 Implicit Numeric and Bool Conversions
@@ -149,6 +162,9 @@ complex(\ :math:`s`)                                                            
 ==================== ================= ================ ================= ================= ====================
 
 
+.. index::
+   single: conversions;numeric;parameter
+   single: conversions;implicit;parameter
 .. _Implicit_Compile_Time_Constant_Conversions:
 
 Implicit Compile-Time Constant Conversions
@@ -200,6 +216,11 @@ conversion is allowed when:
  - the ``strides`` of the target is ``negative``
    and the ``strides`` of the source is ``negOne``.
 
+.. index::
+   single: conversions;implicit;class
+   single: conversions;implicit;nilable
+   single: conversions;implicit;borrow
+   single: classes;implicit conversion
 .. _Implicit_Class_Conversions:
 
 Implicit Class Conversions
@@ -235,6 +256,9 @@ See :ref:`Class_Lifetime_and_Borrows`.  For example:
       f(c); // equivalent to f(c.borrow())
 
 
+.. index::
+   single: conversions;implicit;type arguments
+   single: conversions;implicit;subtype
 .. _Subtype:
 .. _Subtype_Arg_Conversions:
 .. _Implicit_Type_Arg_Conversions:
@@ -533,6 +557,9 @@ Implicit conversions are not applied for actual arguments passed to
    Should Chapel allow user-defined implicit conversions for function
    calls?  If so, how would the user define them?
 
+.. index::
+   single: conversions;boolean;in a statement
+   single: conversions;implicit;boolean
 .. _Implicit_Conversion_Conditionals:
 .. _Implicit_Statement_Bool_Conversions:
 
@@ -564,6 +591,8 @@ indicated in their documentation.
    conditionals? If so, how would the user define them?
 
 
+.. index::
+   single: conversions;explicit
 .. _Explicit_Conversions:
 
 Explicit Conversions
@@ -599,6 +628,9 @@ An explicit conversion from a type to the same type is allowed for any
 type. Such a conversion does not change the value of the expression.
 
 
+.. index::
+   single: conversions;numeric
+   single: conversions;explicit;numeric
 .. _Explicit_Numeric_Conversions:
 
 Explicit Numeric Conversions
@@ -682,6 +714,9 @@ zero.
 Explicitly converting between ``real(k)`` and ``imag(k)`` will copy the
 represented number while changing whether or not it is imaginary.
 
+.. index::
+   single: conversions;tuple to complex
+   single: conversions;explicit;tuple to complex
 .. _Explicit_Tuple_to_Complex_Conversion:
 
 Explicit Tuple to Complex Conversion
@@ -695,6 +730,9 @@ is ``complex(64)``, each member of the two-tuple must be convertible to
 resulting complex value; the second member of the tuple becomes the
 imaginary part of the resulting complex value.
 
+.. index::
+   single: conversions;enumeration
+   single: conversions;explicit;enumeration
 .. _Explicit_Enumeration_Conversions:
 
 Explicit Enumeration Conversions
@@ -739,6 +777,10 @@ the matching symbol.  If no symbol has the given integer value, an
 ``IllegalArgumentError`` is thrown.
 
 
+.. index::
+   single: conversions;class
+   single: conversions;explicit;class
+   single: classes;explicit conversion
 .. _Explicit_Class_Conversions:
 
 Explicit Class Conversions
@@ -798,6 +840,9 @@ has different nilability or memory management strategy. Supposing that
 The conversions in this subsection apply when the source is either an
 expression or a type expression.
 
+.. index::
+   single: conversions;range
+   single: conversions;explicit;range
 .. _Explicit_Range_Conversions:
 
 Explicit Range Conversions
@@ -816,6 +861,9 @@ either because the source stride is not representable within the
 target's stride type or it is of the opposite sign than expected
 by the target's ``strides`` parameter.
 
+.. index::
+   single: conversions;domain
+   single: conversions;explicit;domain
 .. _Explicit_Domain_Conversions:
 
 Explicit Domain Conversions
@@ -826,6 +874,9 @@ to another rectangular domain type of the same ``rank``.
 Such conversion is performed dimension-wise following the rules
 for explicit range conversions (see :ref:`Explicit_Range_Conversions`).
 
+.. index::
+   single: conversions;string to bytes
+   single: conversions;explicit;string to bytes
 .. _Explicit_String_to_Bytes_Conversions:
 
 Explicit String to Bytes Conversions
@@ -836,6 +887,9 @@ An expression of ``string`` type can be explicitly converted to a
 contain arbitrary bytes. Instead, ``bytes.decode()`` method should be
 used to produce a ``string`` from a ``bytes``.
 
+.. index::
+   single: conversions;type to string
+   single: conversions;explicit;type to string
 .. _Explicit_Type_to_String_Conversions:
 
 Explicit Type to String Conversions

--- a/doc/rst/language/spec/data-parallelism.rst
+++ b/doc/rst/language/spec/data-parallelism.rst
@@ -1,5 +1,8 @@
 .. default-domain:: chpl
 
+.. index::
+   single: data parallelism
+   single: parallelism;data
 .. _Chapter-Data_Parallelism:
 
 ================
@@ -34,6 +37,11 @@ intents or forall intents, among others. Such accesses are subject to
 the Memory Consistency Model
 (:ref:`Chapter-Memory_Consistency_Model`).
 
+.. index::
+   single: forall
+   single: loops;forall
+   single: data parallelism;forall
+   single: statements;forall
 .. _Forall:
 
 The Forall Statement
@@ -42,6 +50,8 @@ The Forall Statement
 The forall statement is a concurrent variant of the for statement
 described in :ref:`The_For_Loop`.
 
+.. index::
+   single: statements;forall;syntax
 .. _forall_syntax:
 
 Syntax
@@ -72,6 +82,10 @@ The handling of the outer variables within the forall statement and the
 role of ``task-intent-clause`` are defined in
 :ref:`Forall_Intents`.
 
+.. index::
+   single: statements;forall;semantics
+   single: leading the execution of a loop
+   single: data parallelism;leader iterator
 .. _forall_semantics:
 
 Execution and Serializability
@@ -153,6 +167,8 @@ the current iteration of the forall loop.
 
       1 2 3 4 5
 
+.. index::
+   single: statements;forall;zipper iteration
 .. _forall_zipper:
 
 Zippered Iteration
@@ -162,6 +178,10 @@ Zippered iteration has the same semantics as described
 in :ref:`Zippered_Iteration`
 and :ref:`Parallel_Iterators` for parallel iteration.
 
+.. index::
+   single: data parallelism;forall expressions
+   single: forall expressions
+   single: expressions;forall
 .. _Forall_Expressions:
 
 The Forall Expression
@@ -170,6 +190,8 @@ The Forall Expression
 The forall expression is a concurrent variant of the for expression
 described in :ref:`For_Expressions`.
 
+.. index::
+   single: expressions;forall;syntax
 .. _forall_expr_syntax:
 
 Syntax
@@ -199,6 +221,8 @@ The handling of the outer variables within the forall expression and the
 role of ``task-intent-clause`` are defined in
 :ref:`Forall_Intents`.
 
+.. index::
+   single: expressions;forall;semantics
 .. _Forall_Expression_Execution:
 
 Execution
@@ -240,6 +264,9 @@ the zippered case :ref:`Zippered_Promotion`.
 The forall expression follows the semantics of the forall statement as
 described in :ref:`forall_semantics`.
 
+.. index::
+   single: expressions;forall;zipper iteration
+
 Zippered Iteration
 ~~~~~~~~~~~~~~~~~~
 
@@ -247,6 +274,9 @@ Forall expression also support zippered iteration semantics as described
 in :ref:`Zippered_Iteration`
 and :ref:`Parallel_Iterators` for parallel iteration.
 
+.. index::
+   single: expressions;forall;and conditional expressions
+   single: expressions;forall;filtering
 .. _Filtering_Predicates_Forall:
 
 Filtering Predicates in Forall Expressions
@@ -292,6 +322,13 @@ variable, the resulting array has a 0-based one-dimensional domain.
       1 3 5 7 9
       {0..4}
 
+.. index::
+   single: forall intents
+   single: shadow variables
+   single: data parallelism;forall intents
+   single: data parallelism;shadow variables
+   single: statements;forall;forall intents
+   single: statements;forall;shadow variables
 .. _Forall_Intents:
 
 Forall Intents
@@ -361,6 +398,13 @@ shadow variable for that task.
    that task intents :ref:`Task_Intents` affect the behavior of
    a task construct such as a ``coforall`` loop.
 
+.. index::
+   single: task-private variables
+   single: shadow variables
+   single: data parallelism;task-private variables
+   single: data parallelism;shadow variables
+   single: statements;forall;task-private variables
+   single: statements;forall;shadow variables
 .. _Task_Private_Variables:
 
 Task-Private Variables
@@ -463,6 +507,9 @@ destroyed.
       shadow var: 3  yield: inside coforall
       shadow var: 3  yield: inside coforall
 
+.. index::
+   single: promotion
+   single: data parallelism;promotion
 .. _Promotion:
 
 Promotion
@@ -590,6 +637,8 @@ iterator         0-based one-dimensional domain
       1.0 2.0 3.0 4.0 5.0
       (x = 1.0, y = 1.0) (x = 2.0, y = 1.0) (x = 3.0, y = 1.0) (x = 4.0, y = 1.0) (x = 5.0, y = 1.0)
 
+.. index::
+   single: promotion;default arguments
 .. _Promotion_Default_Arguments:
 
 Default Arguments
@@ -645,6 +694,8 @@ expression can be evaluated many times. For example:
 
       0 1 2 3 4
 
+.. index::
+   single: promotion;zipper iteration
 .. _Zippered_Promotion:
 
 Zippered Promotion
@@ -716,6 +767,12 @@ causes promotion. The rules are the same as in the non-zippered case.
 
       (1, 4) (2, 5) (3, 6)
 
+.. index::
+   single: whole array assignment
+   single: whole array operations
+   single: arrays;assignment
+   single: assignment;whole array
+   single: data parallelism;evaluation order
 .. _Whole_Array_Operations:
 
 Whole Array Operations and Evaluation Order
@@ -798,6 +855,11 @@ statement and the proper intents, for example:
 
    [b in B with (+ reduce A)] A[b] += 3;
 
+.. index::
+   single: reductions
+   single: scans
+   single: data parallelism;reductions
+   single: data parallelism;scans
 .. _Reductions_and_Scans:
 
 Reductions and Scans
@@ -813,6 +875,9 @@ operators, and also supports a mechanism for the user to define
 additional reductions and scans
 (:ref:`Chapter-User_Defined_Reductions_and_Scans`).
 
+.. index::
+   single: reduction expressions
+   single: expressions;reduction
 .. _reduce:
 
 Reduction Expressions
@@ -911,6 +976,9 @@ User-defined reductions are specified by preceding the keyword
 described
 in :ref:`Chapter-User_Defined_Reductions_and_Scans`.
 
+.. index::
+   single: scan expressions
+   single: expressions;scan
 .. _scan:
 
 Scan Expressions
@@ -962,6 +1030,12 @@ User-defined scans are specified by preceding the keyword ``scan`` by
 the class type that implements the scan interface as described
 in :ref:`Chapter-User_Defined_Reductions_and_Scans`.
 
+.. index::
+   single: data parallelism;knobs for default data parallelism
+   single: data parallelism;configuration constants
+   single: dataParTasksPerLocale
+   single: dataParIgnoreRunningTasks
+   single: dataParMinGranularity
 .. _data_parallel_knobs:
 
 Configuration Constants for Default Data Parallelism

--- a/doc/rst/language/spec/data-parallelism.rst
+++ b/doc/rst/language/spec/data-parallelism.rst
@@ -2,7 +2,7 @@
 
 .. index::
    single: data parallelism
-   single: parallelism;data
+   single: parallelism; data
 .. _Chapter-Data_Parallelism:
 
 ================
@@ -39,9 +39,9 @@ the Memory Consistency Model
 
 .. index::
    single: forall
-   single: loops;forall
-   single: data parallelism;forall
-   single: statements;forall
+   pair: forall; statements
+   single: loops; forall
+   single: data parallelism; forall
 .. _Forall:
 
 The Forall Statement
@@ -51,7 +51,7 @@ The forall statement is a concurrent variant of the for statement
 described in :ref:`The_For_Loop`.
 
 .. index::
-   single: statements;forall;syntax
+   single: forall; syntax
 .. _forall_syntax:
 
 Syntax
@@ -83,9 +83,10 @@ role of ``task-intent-clause`` are defined in
 :ref:`Forall_Intents`.
 
 .. index::
-   single: statements;forall;semantics
-   single: leading the execution of a loop
-   single: data parallelism;leader iterator
+   single: forall; semantics
+   single: forall; leader iterator
+   single: forall; follower iterator
+   single: data parallelism; leader iterator
 .. _forall_semantics:
 
 Execution and Serializability
@@ -168,7 +169,7 @@ the current iteration of the forall loop.
       1 2 3 4 5
 
 .. index::
-   single: statements;forall;zipper iteration
+   single: forall; zippered iteration
 .. _forall_zipper:
 
 Zippered Iteration
@@ -179,9 +180,8 @@ in :ref:`Zippered_Iteration`
 and :ref:`Parallel_Iterators` for parallel iteration.
 
 .. index::
-   single: data parallelism;forall expressions
-   single: forall expressions
-   single: expressions;forall
+   single: data parallelism; forall expressions
+   pair: forall; expressions
 .. _Forall_Expressions:
 
 The Forall Expression
@@ -191,7 +191,7 @@ The forall expression is a concurrent variant of the for expression
 described in :ref:`For_Expressions`.
 
 .. index::
-   single: expressions;forall;syntax
+   single: forall; syntax
 .. _forall_expr_syntax:
 
 Syntax
@@ -222,7 +222,7 @@ role of ``task-intent-clause`` are defined in
 :ref:`Forall_Intents`.
 
 .. index::
-   single: expressions;forall;semantics
+   single: forall; semantics
 .. _Forall_Expression_Execution:
 
 Execution
@@ -265,7 +265,7 @@ The forall expression follows the semantics of the forall statement as
 described in :ref:`forall_semantics`.
 
 .. index::
-   single: expressions;forall;zipper iteration
+   single: forall; zippered iteration
 
 Zippered Iteration
 ~~~~~~~~~~~~~~~~~~
@@ -275,8 +275,8 @@ in :ref:`Zippered_Iteration`
 and :ref:`Parallel_Iterators` for parallel iteration.
 
 .. index::
-   single: expressions;forall;and conditional expressions
-   single: expressions;forall;filtering
+   single: forall; forall expressions and conditional expressions
+   single: forall; filtering
 .. _Filtering_Predicates_Forall:
 
 Filtering Predicates in Forall Expressions
@@ -325,10 +325,8 @@ variable, the resulting array has a 0-based one-dimensional domain.
 .. index::
    single: forall intents
    single: shadow variables
-   single: data parallelism;forall intents
-   single: data parallelism;shadow variables
-   single: statements;forall;forall intents
-   single: statements;forall;shadow variables
+   single: data parallelism; forall intents
+   single: data parallelism; shadow variables
 .. _Forall_Intents:
 
 Forall Intents
@@ -401,10 +399,10 @@ shadow variable for that task.
 .. index::
    single: task-private variables
    single: shadow variables
-   single: data parallelism;task-private variables
-   single: data parallelism;shadow variables
-   single: statements;forall;task-private variables
-   single: statements;forall;shadow variables
+   single: data parallelism; task-private variables
+   single: data parallelism; shadow variables
+   single: forall; task-private variables
+   single: forall; shadow variables
 .. _Task_Private_Variables:
 
 Task-Private Variables
@@ -509,7 +507,7 @@ destroyed.
 
 .. index::
    single: promotion
-   single: data parallelism;promotion
+   single: data parallelism; promotion
 .. _Promotion:
 
 Promotion
@@ -638,7 +636,7 @@ iterator         0-based one-dimensional domain
       (x = 1.0, y = 1.0) (x = 2.0, y = 1.0) (x = 3.0, y = 1.0) (x = 4.0, y = 1.0) (x = 5.0, y = 1.0)
 
 .. index::
-   single: promotion;default arguments
+   single: promotion; default arguments
 .. _Promotion_Default_Arguments:
 
 Default Arguments
@@ -695,7 +693,7 @@ expression can be evaluated many times. For example:
       0 1 2 3 4
 
 .. index::
-   single: promotion;zipper iteration
+   single: promotion; zippered iteration
 .. _Zippered_Promotion:
 
 Zippered Promotion
@@ -770,9 +768,9 @@ causes promotion. The rules are the same as in the non-zippered case.
 .. index::
    single: whole array assignment
    single: whole array operations
-   single: arrays;assignment
-   single: assignment;whole array
-   single: data parallelism;evaluation order
+   single: arrays; assignment
+   single: assignment; whole array
+   single: data parallelism; evaluation order
 .. _Whole_Array_Operations:
 
 Whole Array Operations and Evaluation Order
@@ -820,6 +818,8 @@ side array expressions alias the left-hand side expression.
    are assigned to ``A`` may be read to compute the sum depending on the
    number of tasks used to implement the data parallel statement.
 
+.. index::
+   single: promotion; array indexing
 .. _Promoted_Array_Indexing:
 
 Promoted Array Indexing
@@ -858,8 +858,8 @@ statement and the proper intents, for example:
 .. index::
    single: reductions
    single: scans
-   single: data parallelism;reductions
-   single: data parallelism;scans
+   single: data parallelism; reductions
+   single: data parallelism; scans
 .. _Reductions_and_Scans:
 
 Reductions and Scans
@@ -876,8 +876,8 @@ additional reductions and scans
 (:ref:`Chapter-User_Defined_Reductions_and_Scans`).
 
 .. index::
-   single: reduction expressions
-   single: expressions;reduction
+   single: reduce
+   single: expressions; reduce
 .. _reduce:
 
 Reduction Expressions
@@ -977,8 +977,8 @@ described
 in :ref:`Chapter-User_Defined_Reductions_and_Scans`.
 
 .. index::
-   single: scan expressions
-   single: expressions;scan
+   single: scan
+   single: expressions; scan
 .. _scan:
 
 Scan Expressions
@@ -1031,8 +1031,8 @@ the class type that implements the scan interface as described
 in :ref:`Chapter-User_Defined_Reductions_and_Scans`.
 
 .. index::
-   single: data parallelism;knobs for default data parallelism
-   single: data parallelism;configuration constants
+   single: data parallelism; knobs for default data parallelism
+   single: data parallelism; configuration constants
    single: dataParTasksPerLocale
    single: dataParIgnoreRunningTasks
    single: dataParMinGranularity

--- a/doc/rst/language/spec/domain-maps.rst
+++ b/doc/rst/language/spec/domain-maps.rst
@@ -2,11 +2,11 @@
 
 .. index::
    single: domain maps
-   single: mapped;domain maps
+   single: mapped; domain maps
    single: layouts
    single: distributions
-   single: domain maps;layouts
-   single: domain maps;distributions
+   single: domain maps; layouts
+   single: domain maps; distributions
 .. _Chapter-Domain_Maps:
 
 =============
@@ -47,11 +47,11 @@ Distributions are presented as follows:
 
 .. index::
    single: domain maps for domain types
-   single: types;domains;domain maps for
+   single: domains; domain maps for
    single: dmap value
    single: dmapped clause
-   single: domain maps;dmap value
-   single: domain maps;dmapped clause
+   single: domain maps; dmap value
+   single: domain maps; dmapped clause
 .. _Domain_Maps_For_Types:
 
 Distributions for Domain Types
@@ -137,8 +137,7 @@ is considered to be an initialization expression as if preceded by
       type BlockDom = domain(2) dmapped new blockDist({1..5,1..6});
 
 .. index::
-   single: domain maps;for domain values
-   single: values;domains;domain maps for
+   single: domain maps; for domain values
 .. _Domain_Maps_For_Values:
 
 Distributions for Domain Values
@@ -186,8 +185,8 @@ clause, in the same way as a domain type's distribution.
    mapped using a Block distribution.
 
 .. index::
-   single: domain maps;for arrays
-   single: arrays;domain maps
+   single: domain maps; for arrays
+   single: arrays; domain maps
 .. _Domain_Maps_For_Arrays:
 
 Distributions for Arrays
@@ -210,9 +209,9 @@ array was declared.
    the type of ``Dom``.
 
 .. index::
-   single: domain maps;domain assignment
-   single: domains;assignment
-   single: assignment;domain
+   single: domain maps; domain assignment
+   single: domains; assignment
+   single: assignment; domain
 .. _Domain_Maps_Not_Assigned:
 
 Distributions Are Not Retained upon Domain Assignment

--- a/doc/rst/language/spec/domain-maps.rst
+++ b/doc/rst/language/spec/domain-maps.rst
@@ -1,5 +1,12 @@
 .. default-domain:: chpl
 
+.. index::
+   single: domain maps
+   single: mapped;domain maps
+   single: layouts
+   single: distributions
+   single: domain maps;layouts
+   single: domain maps;distributions
 .. _Chapter-Domain_Maps:
 
 =============
@@ -38,6 +45,13 @@ Distributions are presented as follows:
    refer to the
    :ref:`Domain Map Standard Interface technical note <readme-dsi>`
 
+.. index::
+   single: domain maps for domain types
+   single: types;domains;domain maps for
+   single: dmap value
+   single: dmapped clause
+   single: domain maps;dmap value
+   single: domain maps;dmapped clause
 .. _Domain_Maps_For_Types:
 
 Distributions for Domain Types
@@ -122,6 +136,9 @@ is considered to be an initialization expression as if preceded by
       use BlockDist;
       type BlockDom = domain(2) dmapped new blockDist({1..5,1..6});
 
+.. index::
+   single: domain maps;for domain values
+   single: values;domains;domain maps for
 .. _Domain_Maps_For_Values:
 
 Distributions for Domain Values
@@ -168,6 +185,9 @@ clause, in the same way as a domain type's distribution.
    both ``MyBlockedDomLiteral1`` and ``MyBlockedDomLiteral2`` will be
    mapped using a Block distribution.
 
+.. index::
+   single: domain maps;for arrays
+   single: arrays;domain maps
 .. _Domain_Maps_For_Arrays:
 
 Distributions for Arrays
@@ -189,6 +209,10 @@ array was declared.
    the distribution used for ``MyArray`` is the Block distribution from
    the type of ``Dom``.
 
+.. index::
+   single: domain maps;domain assignment
+   single: domains;assignment
+   single: assignment;domain
 .. _Domain_Maps_Not_Assigned:
 
 Distributions Are Not Retained upon Domain Assignment

--- a/doc/rst/language/spec/domains.rst
+++ b/doc/rst/language/spec/domains.rst
@@ -1,5 +1,7 @@
 .. default-domain:: chpl
 
+.. index::
+   single: domains
 .. _Chapter-Domains:
 
 Domains
@@ -26,6 +28,9 @@ discuss the types and values of sparse subdomains. The remaining
 sections describe the important manipulations that can be performed with
 domains, as well as the predefined operators and functions defined for
 domains.
+
+.. index::
+   single: domains;kinds
 
 Domain Overview
 ---------------
@@ -121,6 +126,8 @@ As with any other domain type, it is not safe to access an
 associative array while its domain is changing, regardless of
 whether ``parSafe`` is set to ``true`` or ``false``.
 
+.. index::
+   single: domains;types and values
 .. _Base_Domain_Types_and_Values:
 
 Base Domain Types and Values
@@ -142,6 +149,16 @@ subsections.
 The keyword ``domain``, when not followed by parentheses, refers to
 a generic type that can be instantiated with any domain type.
 This type may also be written as ``domain(?)``.
+
+.. index::
+   single: rectangular domains
+   single: domains;rectangular
+   single: domains;rectangular;types
+   single: types;rectangular domains
+   single: domains;values;rectangular
+   single: domains;rectangular;values
+   single: domains;rectangular;literals
+   single: domains;rectangular;default value
 
 Rectangular Domains
 ~~~~~~~~~~~~~~~~~~~
@@ -314,6 +331,19 @@ for type:
       8 9 10 11 12 13 14
       29 30 31 32 33 34 35
 
+.. index::
+   single: associative domains
+   single: types;associative domains
+   single: domains;associative
+   single: types;opaque domains
+   single: opaque domains;types
+   single: domains;opaque
+   single: domains;values;associative
+   single: domains;associative;values
+   single: domains;associative;literals
+   single: domains;associative;initialization
+   single: domains;associative;default values
+
 Associative Domains
 ~~~~~~~~~~~~~~~~~~~
 
@@ -415,6 +445,9 @@ empty index set.
 Indices can be added to or removed from an associative domain as
 described in :ref:`Adding_and_Removing_Domain_Indices`.
 
+.. index::
+   single: subdomains
+   single: subdomains;simple
 .. _Simple_Subdomain_Types_and_Values:
 
 Simple Subdomain Types and Values
@@ -447,6 +480,10 @@ subdomains, unless it is specifically distinguished as one or the other.
    of multiple domains; and to improve the compiler’s ability to prove
    away bounds checks for array accesses.
 
+.. index::
+   single: subdomains;simple;types
+   single: subdomains;types;simple
+   single: types;subdomains;simple
 .. _Simple_Subdomain_Types:
 
 Simple Subdomain Types
@@ -469,6 +506,11 @@ underlying representation as its base domain.
    property should be re-verified once its parent domain is reassigned
    and whether this should be done aggressively or lazily.
 
+.. index::
+   single: subdomains;simple;values
+   single: values;subdomains;simple
+   single: subdomains;simple;default values
+
 Simple Subdomain Values
 ~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -484,6 +526,9 @@ in the same way as its parent domain. It is an error to
 attempt to add an index to a subdomain that is not also a member of the
 parent domain.
 
+.. index::
+   single: domains;sparse
+   single: subdomains;sparse
 .. _Sparse_Subdomain_Types_and_Values:
 
 Sparse Subdomain Types and Values
@@ -510,6 +555,12 @@ index set and that of parent domain is the set of indices for which the
 sparse array will store this replicated value.
 See :ref:`Sparse_Arrays` for details about sparse arrays.
 
+.. index::
+   single: domains;sparse;types
+   single: subdomains;sparse;types
+   single: types;domains;sparse
+   single: types;subdomains;sparse
+
 Sparse Subdomain Types
 ~~~~~~~~~~~~~~~~~~~~~~
 
@@ -517,6 +568,17 @@ Each root domain type has a unique corresponding sparse subdomain type.
 Sparse subdomains whose parent domains are also sparse subdomains share
 the same type.
 
+.. index::
+   single: domains;sparse;values
+   single: subdomains;sparse;values
+   single: values;domains;sparse
+   single: values;subdomains;sparse
+   single: sparse domains;literals;lack thereof
+   single: sparse domains;initialization
+   single: domains;sparse;initialization
+   single: initialization;sparse domains
+   single: sparse domains;default value
+   single: domains;sparse;default value
 .. _Sparse_Domain_Values:
 
 Sparse Subdomain Values
@@ -548,6 +610,8 @@ The default value for a sparse subdomain value is the empty set.
       const D: domain(2) = {1..n, 1..n};
       var SpsD: sparse subdomain(D);
 
+.. index::
+   single: domains;index types
 .. _Index_Types:
 
 Domain Index Types
@@ -596,6 +660,9 @@ precise to use a variable of the domain’s index type.
    belong to constant or monotonically growing domains. But these
    semantics need to be defined nevertheless.
 
+.. index::
+   single: domains;iteration
+   single: iteration;domain
 .. _Iteration_over_Domains:
 
 Iteration Over Domains
@@ -609,6 +676,9 @@ indices, then the indices are visited in that order.
 The type of the iterator variable for an iteration over a domain named
 ``D`` is that domain’s index type, ``index(D)``.
 
+.. index::
+   single: domains;as arguments
+   single: argument passing;domains
 .. _Domain_Arguments:
 
 Domains as Arguments
@@ -624,6 +694,9 @@ When a domain value is passed to a formal argument of compatible domain
 type by default intent, it is passed by reference in order to preserve
 the domain’s identity.
 
+.. index::
+   single: domains;promotion
+   single: promotion;domain
 .. _Domain_Promotion_of_Scalar_Functions:
 
 Domain Promotion of Scalar Functions
@@ -688,6 +761,9 @@ subdomain.
    domain-name:
      identifier
 
+.. index::
+   single: domains;assignment
+   single: assignment;domain
 .. _Domain_Assignment:
 
 Domain Assignment
@@ -739,6 +815,10 @@ are equivalent or not:
      dom1 == dom2
      dom1 != dom2
 
+.. index::
+   single: domains;striding
+   single: by;on rectangular domains
+   single: operators;by (domain)
 .. _Domain_Striding:
 
 Domain Striding
@@ -764,6 +844,10 @@ by applying the ``by`` operator to the corresponding dimension
 of the operand domain and the stride value if it is an integer,
 or the corresponding component of the stride value if it is a tuple.
 
+.. index::
+   single: domains;alignment
+   single: align;on rectangular domains
+   single: operators;align (domain)
 .. _Domain_Alignment:
 
 Domain Alignment
@@ -786,6 +870,15 @@ by applying the ``align`` operator to the corresponding dimension
 of the operand domain and the alignment value if it is an integer,
 or the corresponding component of the alignment value if it is a tuple.
 
+.. index::
+   single: slicing;domains
+   single: domains;slicing
+   single: domain-based slicing
+   single: slicing;domain-based
+   single: slicing;range-based
+   single: range-based slicing
+   single: slicing;rank-change
+   single: rank-change slicing
 .. _Domain_Slicing:
 
 Domain Slicing
@@ -868,6 +961,11 @@ being sliced. The resulting subdomain’s type will be the same as the
 original domain, but with a ``rank`` equal to the number of dimensions
 that were sliced by ranges rather than integers.
 
+.. index::
+   single: domains;count operator
+   single: domains;#
+   single: # (domain)
+   single: operators;# (domain)
 .. _Count_Operator_Domains:
 
 Count Operator
@@ -879,6 +977,9 @@ an integer in the case of a 1D domain). The operator produces a new domain
 obtained by applying the ``#`` operator to each of the component ranges
 of the argument domain, with the same distribution as the argument.
 
+.. index::
+   single: domains;adding indices
+   single: domains;removing indices
 .. _Adding_and_Removing_Domain_Indices:
 
 Adding and Removing Domain Indices
@@ -914,6 +1015,9 @@ set manipulations.  The supported set operators are:
   \-       Difference
   ^        Symmetric Difference
   =======  ====================
+
+.. index::
+   single: domains;predefined functions
 
 Predefined Routines on Domains
 ------------------------------

--- a/doc/rst/language/spec/domains.rst
+++ b/doc/rst/language/spec/domains.rst
@@ -30,7 +30,7 @@ domains, as well as the predefined operators and functions defined for
 domains.
 
 .. index::
-   single: domains;kinds
+   single: domains; kinds
 
 Domain Overview
 ---------------
@@ -80,6 +80,9 @@ arrays (:ref:`Association_of_Arrays_to_Domains`).
 The runtime representation of a domain is controlled by its distribution,
 see :ref:`Distributions <Chapter-Domain_Maps>`.
 
+.. index::
+   single: domains; parallel safety
+   single: iterator invalidation
 .. _Domain_and_Array_Parallel_Safety:
 
 Parallel Safety with respect to Domains (and Arrays)
@@ -127,7 +130,8 @@ associative array while its domain is changing, regardless of
 whether ``parSafe`` is set to ``true`` or ``false``.
 
 .. index::
-   single: domains;types and values
+   single: domains; types
+   single: domains; values
 .. _Base_Domain_Types_and_Values:
 
 Base Domain Types and Values
@@ -152,13 +156,7 @@ This type may also be written as ``domain(?)``.
 
 .. index::
    single: rectangular domains
-   single: domains;rectangular
-   single: domains;rectangular;types
-   single: types;rectangular domains
-   single: domains;values;rectangular
-   single: domains;rectangular;values
-   single: domains;rectangular;literals
-   single: domains;rectangular;default value
+   single: domains; rectangular
 
 Rectangular Domains
 ~~~~~~~~~~~~~~~~~~~
@@ -168,6 +166,9 @@ They are characterized by a tensor product of ranges and represent
 indices that are tuples of an integral type. Because their index sets
 can be represented using ranges, regular domain values typically require
 only :math:`O(1)` space.
+
+.. index::
+   pair: rectangular domains; types
 
 Rectangular Domain Types
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -228,6 +229,9 @@ where ``named-expression-list`` allows specifying the values of ``rank``,
       {1..0, 1..0, 1..0}
       {1..0, 1..0, 1..0}
 
+.. index::
+   single: rectangular domains; values
+
 .. _Rectangular_Domain_Values:
 
 Rectangular Domain Values
@@ -248,6 +252,9 @@ This is also known as row-major ordering.
       *Future*
 
       Domains defined using unbounded ranges may be supported.
+
+.. index::
+   pair: rectangular domains; literals
 
 Literal rectangular domain values are represented by a comma-separated
 list of range expressions of matching ``idxType`` enclosed in curly
@@ -299,6 +306,9 @@ A domain expression may contain bounds which are evaluated at runtime.
    that :math:`i \in {1, 2, \ldots, n}` and
    :math:`j \in {1, 2, \ldots, n}`.
 
+.. index::
+   pair: rectangular domains; default value
+
 The default value of a domain type is the ``rank`` default range values
 for type:
 
@@ -313,7 +323,7 @@ for type:
    using the domain’s ``dim()`` method, and each element is filled with
    some value. Then the array is printed out.
 
-   Thus, the code 
+   Thus, the code
 
    .. code-block:: chapel
 
@@ -333,13 +343,7 @@ for type:
 
 .. index::
    single: associative domains
-   single: types;associative domains
-   single: domains;associative
-   single: types;opaque domains
-   single: opaque domains;types
-   single: domains;opaque
-   single: domains;values;associative
-   single: domains;associative;values
+   single: domains; associative
    single: domains;associative;literals
    single: domains;associative;initialization
    single: domains;associative;default values
@@ -354,6 +358,8 @@ its ``idxType``, can be any primitive type except ``void`` or any class
 type.
 
 
+.. index::
+   pair: associative domains; types
 .. _Associative_Domain_Types:
 
 Associative Domain Types
@@ -378,6 +384,8 @@ relation between the indices and the array elements can be thought of as
 a map between the values of the index set and the elements stored in the
 array.
 
+.. index::
+   single: associative domains; values
 .. _Associative_Domain_Values:
 
 Associative Domain Values
@@ -386,6 +394,9 @@ Associative Domain Values
 An associative domain’s value is simply the set of all index values that
 the domain describes. The iteration order over the indices of an
 associative domain is undefined.
+
+.. index::
+   single: associative domains; literals
 
 Specification of an associative domain literal value follows a similar
 syntax as rectangular domain literal values. What differentiates the two
@@ -439,6 +450,9 @@ the indices does not match a compiler error will be issued.
 
       {foo, bar}
 
+.. index::
+   single: associative domains; default value
+
 If uninitialized, the default value of an associative domain is the
 empty index set.
 
@@ -447,7 +461,10 @@ described in :ref:`Adding_and_Removing_Domain_Indices`.
 
 .. index::
    single: subdomains
-   single: subdomains;simple
+   single: subdomains; simple
+   single: simple subdomains
+   single: domains; simple subdomains
+   single: domains; subdomains
 .. _Simple_Subdomain_Types_and_Values:
 
 Simple Subdomain Types and Values
@@ -481,9 +498,7 @@ subdomains, unless it is specifically distinguished as one or the other.
    away bounds checks for array accesses.
 
 .. index::
-   single: subdomains;simple;types
-   single: subdomains;types;simple
-   single: types;subdomains;simple
+   pair: simple subdomains; types
 .. _Simple_Subdomain_Types:
 
 Simple Subdomain Types
@@ -507,9 +522,8 @@ underlying representation as its base domain.
    and whether this should be done aggressively or lazily.
 
 .. index::
-   single: subdomains;simple;values
-   single: values;subdomains;simple
-   single: subdomains;simple;default values
+   single: simple subdomains; values
+   single: simple subdomains; default value
 
 Simple Subdomain Values
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -527,8 +541,10 @@ attempt to add an index to a subdomain that is not also a member of the
 parent domain.
 
 .. index::
-   single: domains;sparse
-   single: subdomains;sparse
+   single: subdomains; sparse
+   single: sparse subdomains
+   see: sparse domains; sparse subdomains
+   single: domains; sparse subdomains
 .. _Sparse_Subdomain_Types_and_Values:
 
 Sparse Subdomain Types and Values
@@ -556,10 +572,7 @@ sparse array will store this replicated value.
 See :ref:`Sparse_Arrays` for details about sparse arrays.
 
 .. index::
-   single: domains;sparse;types
-   single: subdomains;sparse;types
-   single: types;domains;sparse
-   single: types;subdomains;sparse
+   pair: sparse subdomains; types
 
 Sparse Subdomain Types
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -569,16 +582,10 @@ Sparse subdomains whose parent domains are also sparse subdomains share
 the same type.
 
 .. index::
-   single: domains;sparse;values
-   single: subdomains;sparse;values
-   single: values;domains;sparse
-   single: values;subdomains;sparse
-   single: sparse domains;literals;lack thereof
-   single: sparse domains;initialization
-   single: domains;sparse;initialization
-   single: initialization;sparse domains
-   single: sparse domains;default value
-   single: domains;sparse;default value
+   single: sparse subdomains; values
+   single: sparse subdomains; lack of literals
+   pair: sparse subdomains; initialization
+   single: sparse subdomains; default value
 .. _Sparse_Domain_Values:
 
 Sparse Subdomain Values
@@ -603,7 +610,7 @@ The default value for a sparse subdomain value is the empty set.
    The following code declares a two-dimensional dense domain ``D``,
    followed by a two dimensional sparse subdomain of ``D`` named
    ``SpsD``. Since ``SpsD`` is uninitialized, it will initially describe
-   an empty set of indices from ``D``. 
+   an empty set of indices from ``D``.
 
    .. code-block:: chapel
 
@@ -611,7 +618,7 @@ The default value for a sparse subdomain value is the empty set.
       var SpsD: sparse subdomain(D);
 
 .. index::
-   single: domains;index types
+   single: domains; index types
 .. _Index_Types:
 
 Domain Index Types
@@ -661,8 +668,7 @@ precise to use a variable of the domain’s index type.
    semantics need to be defined nevertheless.
 
 .. index::
-   single: domains;iteration
-   single: iteration;domain
+   pair: domains; iteration
 .. _Iteration_over_Domains:
 
 Iteration Over Domains
@@ -677,7 +683,7 @@ The type of the iterator variable for an iteration over a domain named
 ``D`` is that domain’s index type, ``index(D)``.
 
 .. index::
-   single: domains;as arguments
+   single: domains; as arguments
    single: argument passing;domains
 .. _Domain_Arguments:
 
@@ -695,8 +701,8 @@ type by default intent, it is passed by reference in order to preserve
 the domain’s identity.
 
 .. index::
-   single: domains;promotion
-   single: promotion;domain
+   single: domains; promotion
+   single: promotion; domains
 .. _Domain_Promotion_of_Scalar_Functions:
 
 Domain Promotion of Scalar Functions
@@ -720,13 +726,13 @@ scalar function as defined in :ref:`Promotion`.
    Given an array ``A`` with element type ``int`` declared over a
    one-dimensional domain ``D`` with ``idxType`` ``int``, the array
    elements can be assigned their corresponding index values by writing:
-   
+
 
    .. code-block:: chapel
 
       A = D;
 
-   This is equivalent to: 
+   This is equivalent to:
 
    .. code-block:: chapel
 
@@ -762,8 +768,7 @@ subdomain.
      identifier
 
 .. index::
-   single: domains;assignment
-   single: assignment;domain
+   pair: domains; assignment
 .. _Domain_Assignment:
 
 Domain Assignment
@@ -796,13 +801,16 @@ assignment between the ranges in each dimension must be legal.
    ``(1,1)``\ :math:`\ldots`\ ``(n,n)``. The third invokes an iterator
    that is written to ``yield`` indices read from a file named
    “inds.dat”. Each of these assignments has the effect of replacing the
-   previous index set with a completely new set of values. 
+   previous index set with a completely new set of values.
 
    .. code-block:: chapel
 
       SpsD = ((1,1), (n,n));
       SpsD = [i in 1..n] (i,i);
       SpsD = readIndicesFromFile("inds.dat");
+
+.. index::
+   single: domains; comparison
 
 Domain Comparison
 ~~~~~~~~~~~~~~~~~
@@ -816,9 +824,9 @@ are equivalent or not:
      dom1 != dom2
 
 .. index::
-   single: domains;striding
-   single: by;on rectangular domains
-   single: operators;by (domain)
+   single: domains; striding
+   single: by; on rectangular domains
+   single: operators; by (domain)
 .. _Domain_Striding:
 
 Domain Striding
@@ -845,9 +853,9 @@ of the operand domain and the stride value if it is an integer,
 or the corresponding component of the stride value if it is a tuple.
 
 .. index::
-   single: domains;alignment
-   single: align;on rectangular domains
-   single: operators;align (domain)
+   single: domains; align
+   single: align; on rectangular domains
+   single: operators; align (domain)
 .. _Domain_Alignment:
 
 Domain Alignment
@@ -871,14 +879,7 @@ of the operand domain and the alignment value if it is an integer,
 or the corresponding component of the alignment value if it is a tuple.
 
 .. index::
-   single: slicing;domains
-   single: domains;slicing
-   single: domain-based slicing
-   single: slicing;domain-based
-   single: slicing;range-based
-   single: range-based slicing
-   single: slicing;rank-change
-   single: rank-change slicing
+   pair: slicing; domains
 .. _Domain_Slicing:
 
 Domain Slicing
@@ -906,6 +907,10 @@ match the domain being sliced.
 Slicing can also be performed on an array, resulting in aliasing a
 subset of the array’s elements (:ref:`Array_Slicing`).
 
+.. index::
+   single: domain-based slicing
+   single: slicing; domain-based
+
 Domain-based Slicing
 ^^^^^^^^^^^^^^^^^^^^
 
@@ -916,6 +921,9 @@ applied for slicing.
 
    Can we say that it is an alias in the case of sparse/associative?
 
+.. index::
+   single: slicing;range-based
+   single: range-based slicing
 .. _Range_Based_Slicing:
 
 Range-based Slicing
@@ -943,6 +951,9 @@ sets is applied for slicing.
             Col2OfD = D[.., 2..2],
             AllButLastRow = D[..n-1, ..];
 
+.. index::
+   single: slicing;rank-change
+   single: rank-change slicing
 .. _Rank_Change_Slicing:
 
 Rank-Change Slicing
@@ -962,10 +973,10 @@ original domain, but with a ``rank`` equal to the number of dimensions
 that were sliced by ranges rather than integers.
 
 .. index::
-   single: domains;count operator
+   single: domains; count operator
    single: domains;#
    single: # (domain)
-   single: operators;# (domain)
+   single: operators; # (domain)
 .. _Count_Operator_Domains:
 
 Count Operator
@@ -978,8 +989,12 @@ obtained by applying the ``#`` operator to each of the component ranges
 of the argument domain, with the same distribution as the argument.
 
 .. index::
-   single: domains;adding indices
-   single: domains;removing indices
+   single: domains; adding indices
+   single: domains; removing indices
+   single: associative domains; adding indices
+   single: associative domains; removing indices
+   single: sparse subdomains; adding indices
+   single: sparse subdomains; removing indices
 .. _Adding_and_Removing_Domain_Indices:
 
 Adding and Removing Domain Indices
@@ -1003,6 +1018,9 @@ As with normal domain assignments, arrays declared in terms of a domain
 being modified in this way will be reallocated as discussed
 in :ref:`Association_of_Arrays_to_Domains`.
 
+.. index::
+   single: associative domains; set operations
+
 Set Operations on Associative Domains
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -1017,7 +1035,7 @@ set manipulations.  The supported set operators are:
   =======  ====================
 
 .. index::
-   single: domains;predefined functions
+   pair: domains; predefined functions
 
 Predefined Routines on Domains
 ------------------------------

--- a/doc/rst/language/spec/domains.rst
+++ b/doc/rst/language/spec/domains.rst
@@ -344,9 +344,9 @@ for type:
 .. index::
    single: associative domains
    single: domains; associative
-   single: domains;associative;literals
-   single: domains;associative;initialization
-   single: domains;associative;default values
+   single: associative domains; literals
+   single: associative domains; initialization
+   single: associative domains; default values
 
 Associative Domains
 ~~~~~~~~~~~~~~~~~~~

--- a/doc/rst/language/spec/error-handling.rst
+++ b/doc/rst/language/spec/error-handling.rst
@@ -79,7 +79,7 @@ There are three ways to handle an error:
 -  Propagate the error out of the current function with ``throws``.
 
 .. index::
-   single: try!;
+   single: try!
    single: errors; try!
 .. _Halting_on_error_with_try_bang:
 

--- a/doc/rst/language/spec/error-handling.rst
+++ b/doc/rst/language/spec/error-handling.rst
@@ -1,5 +1,8 @@
 .. default-domain:: chpl
 
+.. index::
+   single: error handling
+   single: errors
 .. _Chapter-Error_Handling:
 
 ==============
@@ -18,6 +21,10 @@ a less-permissive mode intended for production code.
    defined here, is available in the
    :ref:`errorHandling technical note <readme-errorHandling>`
 
+.. index::
+   single: errors;throwing
+   single: throw
+   single: throws
 .. _Throwing_Errors:
 
 Throwing Errors
@@ -53,6 +60,8 @@ thrown.
         return 1;
       }
 
+.. index::
+   single: errors;handling
 .. _Handling_Errors:
 
 Handling Errors
@@ -66,6 +75,9 @@ There are three ways to handle an error:
 
 -  Propagate the error out of the current function with ``throws``.
 
+.. index::
+   single: try;
+   single: errors;try;
 .. _Halting_on_error_with_try_bang:
 
 Halting on error with try!
@@ -93,6 +105,10 @@ block or a ``try!`` expression prefix, the program halts.
         }
       }
 
+.. index::
+   single: catch
+   single: errors;catch
+   single: errors;try
 .. _Handling_an_error_with_catch:
 
 Handling an error with catch

--- a/doc/rst/language/spec/error-handling.rst
+++ b/doc/rst/language/spec/error-handling.rst
@@ -2,6 +2,7 @@
 
 .. index::
    single: error handling
+   seealso: error handling; errors
    single: errors
 .. _Chapter-Error_Handling:
 
@@ -22,7 +23,7 @@ a less-permissive mode intended for production code.
    :ref:`errorHandling technical note <readme-errorHandling>`
 
 .. index::
-   single: errors;throwing
+   single: errors; throwing
    single: throw
    single: throws
 .. _Throwing_Errors:
@@ -61,7 +62,9 @@ thrown.
       }
 
 .. index::
-   single: errors;handling
+   single: errors; handling
+   pair: statements; try
+   pair: statements; try!
 .. _Handling_Errors:
 
 Handling Errors
@@ -76,8 +79,8 @@ There are three ways to handle an error:
 -  Propagate the error out of the current function with ``throws``.
 
 .. index::
-   single: try;
-   single: errors;try;
+   single: try!;
+   single: errors; try!
 .. _Halting_on_error_with_try_bang:
 
 Halting on error with try!
@@ -107,8 +110,9 @@ block or a ``try!`` expression prefix, the program halts.
 
 .. index::
    single: catch
-   single: errors;catch
-   single: errors;try
+   single: errors; catch
+   single: errors; try
+   pair: catch; statements
 .. _Handling_an_error_with_catch:
 
 Handling an error with catch
@@ -235,6 +239,11 @@ enclosing ``try`` block, when present.
         return 1;
       }
 
+.. index::
+   single: throws
+   single: errors; throws
+   single: errors; propagating
+
 .. _Propagating_an_error_with_throws:
 
 Propagating an error with throws
@@ -269,6 +278,8 @@ error raised in a ``try`` block.
         // errors other than FileNotFoundError propagate
       }
 
+.. index::
+   single: try; without catch
 .. _catch_less_try:
 
 catch-less try
@@ -301,6 +312,9 @@ calls to clarify control flow.
         return try canThrow(0);
       }
 
+.. index::
+   pair: try; expressions
+   pair: try!; expressions
 .. _try_expressions:
 
 try expressions
@@ -323,6 +337,8 @@ flow at expression granularity. The expression form may not be used with
         return try canThrow(0);
       }
 
+.. index::
+   single: catch; complete handling
 .. _Complete_handling:
 
 Complete handling
@@ -367,6 +383,8 @@ ways:
            }
          }
 
+.. index::
+   pair: statements; defer
 .. _Errors_defer:
 
 Defer statement
@@ -403,6 +421,8 @@ handling context would be unclear.
 
 Errors also cannot be thrown by ``deinit()`` for similar reasons.
 
+.. index::
+   single: errors; and methods
 .. _Errors_Methods:
 
 Errors and Methods
@@ -431,6 +451,8 @@ throw if the overridden method does not throw.
         }
       }
 
+.. index::
+   single: errors; and multilocale
 .. _Errors_Multilocale:
 
 Errors and Multilocale
@@ -455,11 +477,16 @@ will be propagated out of the ``on`` statement.
         }
       }
 
+.. index::
+   single: errors; and parallelism
 .. _Errors_Parallelism:
 
 Errors and Parallelism
 ----------------------
 
+.. index::
+   single: TaskErrors
+   single: errors; TaskErrors
 .. _TaskErrors:
 
 TaskErrors
@@ -474,6 +501,8 @@ Nested ``coforall`` statements do not produce nested ``TaskErrors``.
 Instead, the nested errors are flattened into the ``TaskErrors`` error
 thrown by the outer loop.
 
+.. index::
+   single: errors; and begin
 .. _Errors_begin:
 
 Errors and begin
@@ -500,6 +529,8 @@ task.
         }
       }
 
+.. index::
+   single: errors; and cobegin
 .. _Errors_coforall_and_cobegin:
 
 Errors and coforall and cobegin
@@ -560,6 +591,8 @@ flattened ``TaskErrors`` error.
         }
       }
 
+.. index::
+   single: errors; and forall
 .. _Errors_forall:
 
 Errors and forall
@@ -591,6 +624,9 @@ may execute serially within a single task, it will always throw a
         }
       }
 
+.. index::
+   single: errors; Error subclasses
+   single: Error
 .. _Creating_New_Error_Types:
 
 Creating New Error Types
@@ -617,6 +653,8 @@ the module documentation for :mod:`OS`.
 
       class DemoSysError : SystemError { }
 
+.. index::
+   single: errors; error handling modes
 .. _Error_Handling_Modes:
 
 Error Handling Modes
@@ -633,6 +671,9 @@ Certain error handling details depend on the *error handling mode*:
 Code that is legal in the production mode is always legal in the
 prototype mode.
 
+.. index::
+   single: errors; prototype mode
+   single: prototype
 .. _Errors_Prototype_Mode:
 
 Prototype Mode
@@ -707,6 +748,8 @@ prototype mode applies here, too.
         }
       }
 
+.. index::
+   single: errors; production mode
 .. _Production_Mode_for_Explicit_Modules:
 
 Production Mode

--- a/doc/rst/language/spec/error-handling.rst
+++ b/doc/rst/language/spec/error-handling.rst
@@ -405,8 +405,8 @@ Errors also cannot be thrown by ``deinit()`` for similar reasons.
 
 .. _Errors_Methods:
 
-Methods
--------
+Errors and Methods
+------------------
 
 Errors can be thrown by methods, just as with any other function. An
 overriding method must throw if the overridden method throws, or not
@@ -433,8 +433,8 @@ throw if the overridden method does not throw.
 
 .. _Errors_Multilocale:
 
-Multilocale
------------
+Errors and Multilocale
+----------------------
 
 Errors can be thrown within ``on`` statements. In that event, the error
 will be propagated out of the ``on`` statement.
@@ -457,8 +457,8 @@ will be propagated out of the ``on`` statement.
 
 .. _Errors_Parallelism:
 
-Parallelism
------------
+Errors and Parallelism
+----------------------
 
 .. _TaskErrors:
 
@@ -476,8 +476,8 @@ thrown by the outer loop.
 
 .. _Errors_begin:
 
-begin
-~~~~~
+Errors and begin
+~~~~~~~~~~~~~~~~
 
 Errors can be thrown within a ``begin`` statement. In that event, the
 error will be propagated to the ``sync`` statement that waits for that
@@ -502,8 +502,8 @@ task.
 
 .. _Errors_coforall_and_cobegin:
 
-coforall and cobegin
-~~~~~~~~~~~~~~~~~~~~
+Errors and coforall and cobegin
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Errors can be thrown from ``coforall`` and ``cobegin`` statements and
 handled as ``TaskErrors``. The nested ``coforall`` loops will emit a
@@ -562,8 +562,8 @@ flattened ``TaskErrors`` error.
 
 .. _Errors_forall:
 
-forall
-~~~~~~
+Errors and forall
+~~~~~~~~~~~~~~~~~
 
 Errors can be thrown from ``forall`` loops, too. Although the ``forall``
 may execute serially within a single task, it will always throw a

--- a/doc/rst/language/spec/expressions.rst
+++ b/doc/rst/language/spec/expressions.rst
@@ -1,5 +1,7 @@
 .. default-domain:: chpl
 
+.. index::
+   single: expressions
 .. _Chapter-Expressions:
 
 ===========
@@ -58,6 +60,9 @@ additionally as follows:
 
 -  initializer calls :ref:`Class_New`
 
+.. index::
+   single: literal expressions
+   single: expressions;literal
 .. _Literal_Expressions:
 
 Literal Expressions
@@ -90,6 +95,8 @@ values for domains are described in
 are described in :ref:`Rectangular_Array_Literals` and
 :ref:`Associative_Array_Literals`.
 
+.. index::
+   single: expressions;variable
 .. _Variable_Expressions:
 
 Variable Expressions
@@ -104,6 +111,8 @@ an expression. The syntax of a variable expression is given by:
    variable-expression:
      identifier 
 
+.. index::
+   single: expressions;enumeration constant
 .. _Enumeration_Constant_Expression:
 
 Enumeration Constant Expression
@@ -121,6 +130,8 @@ enumeration constant expression is given by:
 For an example of using enumeration constants,
 see :ref:`Enumerated_Types`.
 
+.. index::
+   single: expressions;parenthesized
 .. _Parenthesized_Expressions:
 
 Parenthesized Expressions
@@ -137,6 +148,9 @@ parentheses as given by:
 Such an expression evaluates to the expression. The parentheses are
 ignored and have only a syntactical effect.
 
+.. index::
+   single: function calls
+   single: expressions;call
 .. _Call_Expressions:
 
 Call Expressions
@@ -145,6 +159,9 @@ Call Expressions
 Functions and function calls are defined
 in :ref:`Chapter-Procedures`.
 
+.. index::
+   single: indexing
+   single: expressions;indexing
 .. _Indexing_Expressions:
 
 Indexing Expressions
@@ -156,6 +173,9 @@ syntax as a call expression.
 Indexing is performed by an implicit invocation of the ``this`` method
 on the value being indexed, passing the indices as the actual arguments.
 
+.. index::
+   single: member access
+   single: expressions;member access
 .. _Member_Access_Expressions:
 
 Member Access Expressions
@@ -174,6 +194,10 @@ of an instance of a class, record, or union. They are defined in
      field-access-expression
      method-call-expression
 
+.. index::
+   single: expressions;type query
+   single: ? (type query)
+   single: operators;? (type query)
 .. _The_Query_Expression:
 
 The Query Expression
@@ -268,6 +292,11 @@ in :ref:`Formal_Arguments_of_Generic_Type`.
 There is an expectation that query expressions will be allowed in more
 places in the future.
 
+.. index::
+   single: casts
+   single: expressions;cast
+   single: : (cast)
+   single: operators;: (cast)
 .. _Casts:
 
 Casts
@@ -285,6 +314,9 @@ invokes the corresponding explicit
 conversion (:ref:`Explicit_Conversions`). A resolution error
 occurs if no such conversion exists.
 
+.. index::
+   single: lvalues
+   single: expressions;lvalue
 .. _LValue_Expressions:
 
 LValue Expressions
@@ -318,6 +350,11 @@ LValue expressions are given by the following syntax:
 The syntax is less restrictive than the definition above. For example,
 not all ``call-expression``\ s are lvalues.
 
+.. index::
+   single: operators;precedence
+   single: operators;associativity
+   single: expressions;precedence
+   single: expressions;associativity
 .. _Operator_Precedence_and_Associativity:
 
 Precedence and Associativity
@@ -512,6 +549,12 @@ precedence than those listed later.
    will learn of their error at compilation time because the resulting
    expression is not a scalar as expected.
 
+.. index::
+   single: expressions;operator
+   single: operators;unary
+   single: expressions;unary operator
+   single: operators;binary
+   single: expressions;binary operator
 .. _Unary_Expressions:
 .. _Binary_Expressions:
 
@@ -542,6 +585,8 @@ The syntax of a binary expression is given by:
 
 The operators are defined in subsequent sections.
 
+.. index::
+   single: operators;arithmetic
 .. _Arithmetic_Operators:
 
 Arithmetic Operators
@@ -557,6 +602,9 @@ listed, those listed earlier in the list being given preference. If no
 compatible implicit conversions exist, then a compile-time error occurs.
 In these cases, an explicit cast is required.
 
+.. index::
+   single: + (unary)
+   single: operators;+ (unary)
 .. _Unary_Plus_Operators:
 
 Unary Plus Operators
@@ -587,6 +635,10 @@ The unary plus operators are predefined as follows:
 
 For each of these definitions, the result is the value of the operand.
 
+.. index::
+   single: operators;negation
+   single: - (unary)
+   single: operators;- (unary)
 .. _Unary_Minus_Operators:
 
 Unary Minus Operators
@@ -619,6 +671,10 @@ corresponds to inverting the signs of both the real and imaginary parts.
 Negating a value of type ``uint`` or ``uint(w)`` for any width will
 result in a compilation error.
 
+.. index::
+   single: operators;addition
+   single: +
+   single: operators;+
 .. _Addition_Operators:
 
 Addition Operators
@@ -673,6 +729,10 @@ Addition over a value of real type and a value of imaginary type
 produces a value of complex type. Addition of values of complex type and
 either real or imaginary types also produces a value of complex type.
 
+.. index::
+   single: operators;subtraction
+   single: -
+   single: operators;-
 .. _Subtraction_Operators:
 
 Subtraction Operators
@@ -724,6 +784,10 @@ vice versa, produces a value of complex type. Subtraction of values of
 complex type from either real or imaginary types, and vice versa, also
 produces a value of complex type.
 
+.. index::
+   single: operators;multiplication
+   single: operators;*
+   single: *
 .. _Multiplication_Operators:
 
 Multiplication Operators
@@ -776,6 +840,10 @@ type produces a value of imaginary type. Multiplication of values of
 complex type and either real or imaginary types produces a value of
 complex type.
 
+.. index::
+   single: operators;division
+   single: /
+   single: operators;/
 .. _Division_Operators:
 
 Division Operators
@@ -834,6 +902,10 @@ and :math:`b * q2` are the two multiples of ``b`` closest to ``a``. The
 integer result :math:`q` is the candidate quotient which lies closest to
 zero.
 
+.. index::
+   single: operators;modulus
+   single: %
+   single: operators;%
 .. _Modulus_Operators:
 
 Modulus Operators
@@ -874,6 +946,10 @@ related by the following identity:
 There is an expectation that the predefined modulus operators will be
 extended to handle real, imaginary, and complex types in the future.
 
+.. index::
+   single: operators;exponentiation
+   single: **
+   single: operators;**
 .. _Exponentiation_Operators:
 
 Exponentiation Operators
@@ -902,6 +978,8 @@ value of the first operand raised to the power of the second operand.
 There is an expectation that the predefined exponentiation operators
 will be extended to handle imaginary and complex types in the future.
 
+.. index::
+   single: operators;bitwise
 .. _Bitwise_Operators:
 
 Bitwise Operators
@@ -911,6 +989,10 @@ This section describes the predefined bitwise operators. These operators
 can be redefined over different types using operator
 overloading (:ref:`Function_Overloading`).
 
+.. index::
+   single: operators;bitwise;complement
+   single: ~
+   single: operators;~
 .. _Bitwise_Complement_Operators:
 
 Bitwise Complement Operators
@@ -933,6 +1015,10 @@ The bitwise complement operators are predefined as follows:
 For each of these definitions, the result is the bitwise complement of
 the operand.
 
+.. index::
+   single: operators;bitwise;and
+   single: &
+   single: operators;&
 .. _Bitwise_And_Operators:
 
 Bitwise And Operators
@@ -968,6 +1054,10 @@ are performed.
    of unsigned over signed as the result type in the mixed case reflects
    the semantics of standard C.
 
+.. index::
+   single: operators;bitwise;or
+   single: |
+   single: operators;|
 .. _Bitwise_Or_Operators:
 
 Bitwise Or Operators
@@ -995,6 +1085,10 @@ apparent sign changes as the required conversions are performed.
 
    The same as for bitwise and (:ref:`Bitwise_And_Operators`).
 
+.. index::
+   single: operators;bitwise;exclusive or
+   single: ^
+   single: operators;^
 .. _Bitwise_Xor_Operators:
 
 Bitwise Xor Operators
@@ -1022,6 +1116,12 @@ changes as the required conversions are performed.
 
    The same as for bitwise and (:ref:`Bitwise_And_Operators`).
 
+.. index::
+   single: operators;shift
+   single: <<
+   single: operators;<<
+   single: >>
+   single: operators;>>
 .. _Shift_Operators:
 
 Shift Operators
@@ -1068,6 +1168,8 @@ The value of ``b`` must be non-negative.
 
 The value of ``b`` must be less than the number of bits in ``a``.
 
+.. index::
+   single: operators;logical
 .. _Logical_Operators:
 
 Logical Operators
@@ -1077,6 +1179,10 @@ This section describes the predefined logical operators. These operators
 can be redefined over different types using operator
 overloading (:ref:`Function_Overloading`).
 
+.. index::
+   single: operators;logical;not
+   single: !
+   single: operators;!
 .. _Logical_Negation_Operators:
 
 The Logical Negation Operator
@@ -1097,6 +1203,10 @@ For the boolean form, the result is the logical negation of the operand.
 For the integer forms, the result is true if the operand is zero and
 false otherwise.
 
+.. index::
+   single: operators;logical;and
+   single: &&
+   single: operators;&&
 .. _Logical_And_Operators:
 
 The Logical And Operator
@@ -1130,6 +1240,10 @@ The function ``isTrue`` is predefined over bool type as follows:
 Overloading the logical and operator over other types is accomplished by
 overloading the ``isTrue`` function over other types.
 
+.. index::
+   single: operators;logical;or
+   single: ||
+   single: operators;||
 .. _Logical_Or_Operators:
 
 The Logical Or Operator
@@ -1158,6 +1272,8 @@ in :ref:`Logical_And_Operators`. Overloading the logical or
 operator over other types is accomplished by overloading the ``isTrue``
 function over other types.
 
+.. index::
+   single: operators;relational
 .. _Relational_Operators:
 
 Relational Operators
@@ -1167,6 +1283,19 @@ This section describes the predefined relational operators. These
 operators can be redefined over different types using operator
 overloading (:ref:`Function_Overloading`).
 
+.. index::
+   single: operators;less than
+   single: <
+   single: operators;<
+   single: operators;greater than
+   single: >
+   single: operators;>
+   single: operators;less than or equal
+   single: <=
+   single: operators;<=
+   single: operators;greater than or equal
+   single: >=
+   single: operators;>=
 .. _Ordered_Comparison_Operators:
 
 Ordered Comparison Operators
@@ -1282,6 +1411,16 @@ Comparisons between strings are defined based on the ordering of the
 character set used to represent the string, which is applied elementwise
 to the string’s characters in order.
 
+.. index::
+   single: operators;equality
+   single: ==
+   single: operators;==
+   single: !=
+   single: operators;!=
+   single: == (string)
+   single: operators;== (string)
+   single: != (string)
+   single: operators;!= (string)
 .. _Equality_Comparison_Operators:
 
 Equality Comparison Operators
@@ -1393,6 +1532,10 @@ This section describes several miscellaneous operators. These operators
 can be redefined over different types using operator
 overloading (:ref:`Function_Overloading`).
 
+.. index::
+   single: operators;string concatenation
+   single: operators;concatenation;string
+   single: operators;+ (string)
 .. _The_String_Concatenation_Operator:
 
 The String Concatenation Operator
@@ -1435,6 +1578,9 @@ arguments:
    will cause ``z`` to be a new string containing the value
    ``"hi there"``.
 
+.. index::
+   single: by
+   single: operators;by
 .. _The_By_Operator:
 
 The By Operator
@@ -1444,6 +1590,9 @@ The operator ``by`` is predefined on ranges and rectangular domains. It
 is described in :ref:`By_Operator_For_Ranges` for ranges
 and :ref:`Domain_Striding` for domains.
 
+.. index::
+   single: align
+   single: operators;align
 .. _The_Align_Operator:
 
 The Align Operator
@@ -1453,6 +1602,10 @@ The operator ``align`` is predefined on ranges and rectangular domains.
 It is described in :ref:`Align_Operator_For_Ranges` for ranges
 and :ref:`Domain_Alignment` for domains.
 
+.. index::
+   single: operators;range;count
+   single: #
+   single: operators;#
 .. _The_Range_Count_Operator:
 
 The Range Count Operator
@@ -1461,6 +1614,9 @@ The Range Count Operator
 The operator ``#`` is predefined on ranges. It is described in
  :ref:`Count_Operator`.
 
+.. index::
+   single: let
+   single: operators;let
 .. _Let_Expressions:
 
 Let Expressions
@@ -1510,6 +1666,13 @@ The scope of the variables is the let-expression.
 
       0.0025
 
+.. index::
+   single: conditional expressions
+   single: expressions;conditional
+   single: expressions;if-then-else
+   single: if
+   single: then
+   single: else
 .. _Conditional_Expressions:
 
 Conditional Expressions
@@ -1561,6 +1724,9 @@ and :ref:`Filtering_Predicates_Forall`, respectively.
       Half of 21 is 11
       Half of 1000 is 500
 
+.. index::
+   single: for
+   single: expressions;for
 .. _For_Expressions:
 
 For Expressions
@@ -1590,6 +1756,9 @@ is defined by the ``iterable-expression`` following the same rules as
 for promotion, both in the regular case :ref:`Promotion` and in
 the zippered case :ref:`Zippered_Promotion`.
 
+.. index::
+   single: for;filtering predicates
+   single: expressions;for;filtering predicates
 .. _Filtering_Predicates_For:
 
 Filtering Predicates in For Expressions

--- a/doc/rst/language/spec/expressions.rst
+++ b/doc/rst/language/spec/expressions.rst
@@ -61,8 +61,8 @@ additionally as follows:
 -  initializer calls :ref:`Class_New`
 
 .. index::
-   single: literal expressions
-   single: expressions;literal
+   single: expressions; literals
+   single: literals
 .. _Literal_Expressions:
 
 Literal Expressions
@@ -96,7 +96,7 @@ are described in :ref:`Rectangular_Array_Literals` and
 :ref:`Associative_Array_Literals`.
 
 .. index::
-   single: expressions;variable
+   single: expressions; variable use
 .. _Variable_Expressions:
 
 Variable Expressions
@@ -112,7 +112,7 @@ an expression. The syntax of a variable expression is given by:
      identifier 
 
 .. index::
-   single: expressions;enumeration constant
+   single: expressions; enumeration constant use
 .. _Enumeration_Constant_Expression:
 
 Enumeration Constant Expression
@@ -131,7 +131,7 @@ For an example of using enumeration constants,
 see :ref:`Enumerated_Types`.
 
 .. index::
-   single: expressions;parenthesized
+   single: expressions; parenthesized
 .. _Parenthesized_Expressions:
 
 Parenthesized Expressions
@@ -149,8 +149,7 @@ Such an expression evaluates to the expression. The parentheses are
 ignored and have only a syntactical effect.
 
 .. index::
-   single: function calls
-   single: expressions;call
+   single: expressions; calls
 .. _Call_Expressions:
 
 Call Expressions
@@ -161,7 +160,7 @@ in :ref:`Chapter-Procedures`.
 
 .. index::
    single: indexing
-   single: expressions;indexing
+   single: expressions; indexing
 .. _Indexing_Expressions:
 
 Indexing Expressions
@@ -175,7 +174,7 @@ on the value being indexed, passing the indices as the actual arguments.
 
 .. index::
    single: member access
-   single: expressions;member access
+   single: expressions; member access
 .. _Member_Access_Expressions:
 
 Member Access Expressions
@@ -293,8 +292,8 @@ There is an expectation that query expressions will be allowed in more
 places in the future.
 
 .. index::
-   single: casts
-   single: expressions;cast
+   single: casts; syntax
+   single: expressions; cast
    single: : (cast)
    single: operators;: (cast)
 .. _Casts:
@@ -316,7 +315,7 @@ occurs if no such conversion exists.
 
 .. index::
    single: lvalues
-   single: expressions;lvalue
+   single: expressions; lvalue
 .. _LValue_Expressions:
 
 LValue Expressions
@@ -351,10 +350,11 @@ The syntax is less restrictive than the definition above. For example,
 not all ``call-expression``\ s are lvalues.
 
 .. index::
-   single: operators;precedence
-   single: operators;associativity
-   single: expressions;precedence
-   single: expressions;associativity
+   single: operators; precedence
+   single: operators; associativity
+   single: expressions; precedence
+   single: expressions; associativity
+   single: precedence table
 .. _Operator_Precedence_and_Associativity:
 
 Precedence and Associativity
@@ -550,11 +550,11 @@ precedence than those listed later.
    expression is not a scalar as expected.
 
 .. index::
-   single: expressions;operator
-   single: operators;unary
-   single: expressions;unary operator
-   single: operators;binary
-   single: expressions;binary operator
+   single: expressions; operator
+   single: operators; unary
+   single: expressions; unary operator
+   single: operators; binary
+   single: expressions; binary operator
 .. _Unary_Expressions:
 .. _Binary_Expressions:
 
@@ -636,9 +636,9 @@ The unary plus operators are predefined as follows:
 For each of these definitions, the result is the value of the operand.
 
 .. index::
-   single: operators;negation
+   single: operators; negation
    single: - (unary)
-   single: operators;- (unary)
+   single: operators; - (unary)
 .. _Unary_Minus_Operators:
 
 Unary Minus Operators
@@ -672,9 +672,9 @@ Negating a value of type ``uint`` or ``uint(w)`` for any width will
 result in a compilation error.
 
 .. index::
-   single: operators;addition
+   single: operators; addition
    single: +
-   single: operators;+
+   single: operators; +
 .. _Addition_Operators:
 
 Addition Operators
@@ -730,9 +730,9 @@ produces a value of complex type. Addition of values of complex type and
 either real or imaginary types also produces a value of complex type.
 
 .. index::
-   single: operators;subtraction
+   single: operators; subtraction
    single: -
-   single: operators;-
+   single: operators; -
 .. _Subtraction_Operators:
 
 Subtraction Operators
@@ -785,8 +785,8 @@ complex type from either real or imaginary types, and vice versa, also
 produces a value of complex type.
 
 .. index::
-   single: operators;multiplication
-   single: operators;*
+   single: operators; multiplication
+   single: operators; *
    single: *
 .. _Multiplication_Operators:
 
@@ -841,9 +841,9 @@ complex type and either real or imaginary types produces a value of
 complex type.
 
 .. index::
-   single: operators;division
+   single: operators; division
    single: /
-   single: operators;/
+   single: operators; /
 .. _Division_Operators:
 
 Division Operators
@@ -903,9 +903,9 @@ integer result :math:`q` is the candidate quotient which lies closest to
 zero.
 
 .. index::
-   single: operators;modulus
+   single: operators; modulus
    single: %
-   single: operators;%
+   single: operators; %
 .. _Modulus_Operators:
 
 Modulus Operators
@@ -947,9 +947,9 @@ There is an expectation that the predefined modulus operators will be
 extended to handle real, imaginary, and complex types in the future.
 
 .. index::
-   single: operators;exponentiation
+   single: operators; exponentiation
    single: **
-   single: operators;**
+   single: operators; **
 .. _Exponentiation_Operators:
 
 Exponentiation Operators
@@ -979,7 +979,7 @@ There is an expectation that the predefined exponentiation operators
 will be extended to handle imaginary and complex types in the future.
 
 .. index::
-   single: operators;bitwise
+   single: operators; bitwise
 .. _Bitwise_Operators:
 
 Bitwise Operators
@@ -990,9 +990,9 @@ can be redefined over different types using operator
 overloading (:ref:`Function_Overloading`).
 
 .. index::
-   single: operators;bitwise;complement
+   single: operators; bitwise complement
    single: ~
-   single: operators;~
+   single: operators; ~
 .. _Bitwise_Complement_Operators:
 
 Bitwise Complement Operators
@@ -1016,9 +1016,9 @@ For each of these definitions, the result is the bitwise complement of
 the operand.
 
 .. index::
-   single: operators;bitwise;and
+   single: operators; bitwise and
    single: &
-   single: operators;&
+   single: operators; &
 .. _Bitwise_And_Operators:
 
 Bitwise And Operators
@@ -1055,9 +1055,9 @@ are performed.
    the semantics of standard C.
 
 .. index::
-   single: operators;bitwise;or
+   single: operators; bitwise or
    single: |
-   single: operators;|
+   single: operators; |
 .. _Bitwise_Or_Operators:
 
 Bitwise Or Operators
@@ -1086,9 +1086,9 @@ apparent sign changes as the required conversions are performed.
    The same as for bitwise and (:ref:`Bitwise_And_Operators`).
 
 .. index::
-   single: operators;bitwise;exclusive or
+   single: operators; bitwise exclusive or
    single: ^
-   single: operators;^
+   single: operators; ^
 .. _Bitwise_Xor_Operators:
 
 Bitwise Xor Operators
@@ -1117,9 +1117,9 @@ changes as the required conversions are performed.
    The same as for bitwise and (:ref:`Bitwise_And_Operators`).
 
 .. index::
-   single: operators;shift
+   single: operators; shift
    single: <<
-   single: operators;<<
+   single: operators; <<
    single: >>
    single: operators;>>
 .. _Shift_Operators:
@@ -1169,7 +1169,7 @@ The value of ``b`` must be non-negative.
 The value of ``b`` must be less than the number of bits in ``a``.
 
 .. index::
-   single: operators;logical
+   single: operators; logical
 .. _Logical_Operators:
 
 Logical Operators
@@ -1180,9 +1180,9 @@ can be redefined over different types using operator
 overloading (:ref:`Function_Overloading`).
 
 .. index::
-   single: operators;logical;not
+   single: operators; logical not
    single: !
-   single: operators;!
+   single: operators; !
 .. _Logical_Negation_Operators:
 
 The Logical Negation Operator
@@ -1204,9 +1204,9 @@ For the integer forms, the result is true if the operand is zero and
 false otherwise.
 
 .. index::
-   single: operators;logical;and
+   single: operators; logical and
    single: &&
-   single: operators;&&
+   single: operators ;&&
 .. _Logical_And_Operators:
 
 The Logical And Operator
@@ -1241,9 +1241,9 @@ Overloading the logical and operator over other types is accomplished by
 overloading the ``isTrue`` function over other types.
 
 .. index::
-   single: operators;logical;or
+   single: operators; logical or
    single: ||
-   single: operators;||
+   single: operators; ||
 .. _Logical_Or_Operators:
 
 The Logical Or Operator
@@ -1273,7 +1273,8 @@ operator over other types is accomplished by overloading the ``isTrue``
 function over other types.
 
 .. index::
-   single: operators;relational
+   single: operators; relational
+   single: operators; comparison
 .. _Relational_Operators:
 
 Relational Operators
@@ -1284,18 +1285,18 @@ operators can be redefined over different types using operator
 overloading (:ref:`Function_Overloading`).
 
 .. index::
-   single: operators;less than
+   single: operators; less than
    single: <
-   single: operators;<
-   single: operators;greater than
+   single: operators; <
+   single: operators; greater than
    single: >
-   single: operators;>
-   single: operators;less than or equal
+   single: operators; >
+   single: operators; less than or equal
    single: <=
-   single: operators;<=
-   single: operators;greater than or equal
+   single: operators; <=
+   single: operators; greater than or equal
    single: >=
-   single: operators;>=
+   single: operators; >=
 .. _Ordered_Comparison_Operators:
 
 Ordered Comparison Operators
@@ -1412,15 +1413,16 @@ character set used to represent the string, which is applied elementwise
 to the string’s characters in order.
 
 .. index::
-   single: operators;equality
+   single: operators; equality
+   single: operators; inequality
    single: ==
-   single: operators;==
+   single: operators; ==
    single: !=
-   single: operators;!=
+   single: operators; !=
    single: == (string)
-   single: operators;== (string)
+   single: operators; == (string)
    single: != (string)
-   single: operators;!= (string)
+   single: operators; != (string)
 .. _Equality_Comparison_Operators:
 
 Equality Comparison Operators
@@ -1533,9 +1535,8 @@ can be redefined over different types using operator
 overloading (:ref:`Function_Overloading`).
 
 .. index::
-   single: operators;string concatenation
-   single: operators;concatenation;string
-   single: operators;+ (string)
+   single: operators; string concatenation
+   single: operators; + (string)
 .. _The_String_Concatenation_Operator:
 
 The String Concatenation Operator
@@ -1580,7 +1581,7 @@ arguments:
 
 .. index::
    single: by
-   single: operators;by
+   single: operators; by
 .. _The_By_Operator:
 
 The By Operator
@@ -1592,7 +1593,7 @@ and :ref:`Domain_Striding` for domains.
 
 .. index::
    single: align
-   single: operators;align
+   single: operators; align
 .. _The_Align_Operator:
 
 The Align Operator
@@ -1603,9 +1604,9 @@ It is described in :ref:`Align_Operator_For_Ranges` for ranges
 and :ref:`Domain_Alignment` for domains.
 
 .. index::
-   single: operators;range;count
+   single: operators; range count
    single: #
-   single: operators;#
+   single: operators; #
 .. _The_Range_Count_Operator:
 
 The Range Count Operator
@@ -1616,7 +1617,7 @@ The operator ``#`` is predefined on ranges. It is described in
 
 .. index::
    single: let
-   single: operators;let
+   single: expressions; let
 .. _Let_Expressions:
 
 Let Expressions
@@ -1668,8 +1669,8 @@ The scope of the variables is the let-expression.
 
 .. index::
    single: conditional expressions
-   single: expressions;conditional
-   single: expressions;if-then-else
+   single: expressions; conditional
+   single: expressions; if-then-else
    single: if
    single: then
    single: else
@@ -1726,7 +1727,7 @@ and :ref:`Filtering_Predicates_Forall`, respectively.
 
 .. index::
    single: for
-   single: expressions;for
+   single: expressions; for
 .. _For_Expressions:
 
 For Expressions
@@ -1757,8 +1758,8 @@ for promotion, both in the regular case :ref:`Promotion` and in
 the zippered case :ref:`Zippered_Promotion`.
 
 .. index::
-   single: for;filtering predicates
-   single: expressions;for;filtering predicates
+   single: for; filtering predicates
+   single: expressions; for with filtering predicate
 .. _Filtering_Predicates_For:
 
 Filtering Predicates in For Expressions

--- a/doc/rst/language/spec/generics.rst
+++ b/doc/rst/language/spec/generics.rst
@@ -13,8 +13,8 @@ over both types and parameters. The generic functions and types look
 similar to non-generic functions and types already discussed.
 
 .. index::
-   single: functions;generic
-   single: generics;functions
+   single: functions; generic
+   single: generics; functions
 .. _Generic_Functions:
 
 Generic Functions
@@ -39,7 +39,7 @@ A function is generic if any of the following conditions hold:
 These conditions are discussed in the next sections.
 
 .. index::
-   single: intents;type
+   single: intents; type
 .. _Formal_Type_Arguments:
 
 Formal Type Arguments
@@ -123,7 +123,7 @@ accepting type arguments that only apply to a specific group of types.
       real(64) 1.0
 
 .. index::
-   single: intents;param
+   single: intents; param
 .. _Formal_Parameter_Arguments:
 
 Formal Parameter Arguments
@@ -167,7 +167,7 @@ this function at a call site. The formal argument is a parameter.
    component contains the value ``3``.
 
 .. index::
-   single: formal arguments;without types
+   single: formal arguments; without types
 .. _Formal_Arguments_without_Types:
 
 Formal Arguments without Types
@@ -219,7 +219,7 @@ each unique actual type.
    ``(real, real, real)``.
 
 .. index::
-   single: formal arguments;with queried types
+   single: formal arguments; with queried types
 .. _Formal_Arguments_with_Queried_Types:
 
 Formal Arguments with Queried Types
@@ -291,7 +291,7 @@ semantics of a type alias.
       12.0
 
 .. index::
-   single: formal arguments;generic
+   single: formal arguments; with generic type
 .. _Formal_Arguments_of_Generic_Type:
 
 Formal Arguments of Generic Type
@@ -349,9 +349,9 @@ require a query to mark the argument as generic. See also
       }
 
 .. index::
-   single: formal arguments;partially concrete
-   single: formal arguments;partially generic
-   single: where;implicit
+   single: formal arguments; partially concrete
+   single: formal arguments; partially generic
+   single: where; implicit
 .. _Formal_Arguments_of_Partially_Generic_Type:
 
 Formal Arguments of Partially Generic Type
@@ -479,7 +479,7 @@ constrained.
       partially-concrete-tuple-ambiguity.chpl:5: error: ambiguous call 'f(2*real(64))'
 
 .. index::
-   single: formal arguments;array
+   single: formal arguments; array
 .. _Formal_Arguments_of_Generic_Array_Types:
 
 Formal Arguments of Generic Array Types
@@ -496,7 +496,7 @@ A queried domain may not be modified via the name to which it is bound
 (see :ref:`Association_of_Arrays_to_Domains` for rationale).
 
 .. index::
-   single: generics;function visibility
+   single: generics; function visibility
 .. _Function_Visibility_in_Generic_Functions:
 
 Function Visibility in Generic Functions
@@ -602,8 +602,8 @@ or instantiated (if the derived type is generic).
    discussion. Comments or questions are appreciated.
 
 .. index::
-   single: generics;types
-   single: types;generic
+   single: generics; types
+   single: types; generic
 .. _Generic_Types:
 
 Generic Types
@@ -618,6 +618,10 @@ generic records.
    single: enumerated (generic type)
    single: enum (generic type)
    single: class (generic type)
+   single: unmanaged (generic type)
+   single: owned (generic type)
+   single: shared (generic type)
+   single: borrowed (generic type)
    single: record (generic type)
 .. _Built_in_Generic_Types:
 
@@ -669,12 +673,12 @@ instantiated as follows:
    similarly to the above but with ``unmanaged`` management strategy.
 
  .. index::
-   single: generics;classes
-   single: classes;generic
-   single: generics;records
-   single: records;generic
-   single: generics;fields
-   single: fields;generic
+   single: generics; classes
+   single: classes; generic
+   single: generics; records
+   single: records; generic
+   single: generics; fields
+   single: fields; generic
 
 Generic Classes and Records
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -709,8 +713,8 @@ Correspondingly, the class or record is instantiated with a set of types
 and parameter values, one type or value per generic field.
 
 .. index::
-   single: type aliases;in classes or records
-   single: fields;type alias
+   single: type aliases; in classes or records
+   single: fields; type alias
 .. _Type_Aliases_in_Generic_Types:
 
 Type Aliases in Generic Types
@@ -780,8 +784,9 @@ instead.
    field of.
 
 .. index::
-   single: parameters;in classes or records
-   single: fields;parameter
+   single: parameters; in classes or records
+   single: fields; parameter
+   pair: fields; param
 .. _Parameters_in_Generic_Types:
 
 Parameters in Generic Types
@@ -881,9 +886,9 @@ instead.
    ``-sbig=false`` or no argument it will print out ``R(32)``.
 
 .. index::
-   single: fields;variable and constant, without types
-   single: variables;in classes or records
-   single: constants;in classes or records
+   single: fields; variable and constant, without types
+   single: variables; in classes or records
+   single: constants; in classes or records
 .. _Fields_without_Types:
 
 Fields without Types
@@ -993,9 +998,9 @@ The types for such fields must either be a built-in generic type (see
 
 
 .. index::
-   single: generics;type constructor
-   single: initializers;type constructors
-   single: generics;instantiated type
+   single: generics; type constructor
+   single: initializers; type constructors
+   single: generics; instantiated type
 .. _Type_Constructors:
 
 The Type Constructor
@@ -1112,8 +1117,8 @@ marked with ``(?)``:
    :ref:`Formal_Type_Arguments`)
 
 .. index::
-   single: generics;methods
-   single: methods;generic
+   single: generics; methods
+   single: methods; generic
 .. _Generic_Methods:
 
 Generic Methods
@@ -1124,8 +1129,8 @@ are generic over the implicit ``this`` argument. This is in addition to
 being generic over any other argument that is generic.
 
 .. index::
-   single: generics;initializers;compiler-generated
-   single: initializers;compiler-generated;for generic classes or records
+   single: generics; compiler-generated initializers
+   single: compiler-generated initializers;for generic classes or records
 .. _Generic_Compiler_Generated_Initializers:
 
 The Compiler-Generated Generic Initializer
@@ -1156,8 +1161,8 @@ have defaults, so the corresponding actual values must always be
 provided.
 
 .. index::
-   single: generics;initializers;user-defined
-   single: initializers;user-defined;for generic classes or records
+   single: generics; user-defined initializers
+   single: user-defined initializers; for generic classes or records
 .. _Generic_User_Initializers:
 
 User-Defined Initializers
@@ -1425,7 +1430,7 @@ implementation can still be a generic function. See also
 :ref:`Where_Clauses`.
 
 .. index::
-   single: generics;examples;stack
+   single: generics; stack example
 .. _Example_Generic_Stack:
 
 Example: A Generic Stack

--- a/doc/rst/language/spec/generics.rst
+++ b/doc/rst/language/spec/generics.rst
@@ -1,5 +1,7 @@
 .. default-domain:: chpl
 
+.. index::
+   single: generics
 .. _Chapter-Generics:
 
 ========
@@ -10,6 +12,9 @@ Chapel supports generic functions and types that are parameterizable
 over both types and parameters. The generic functions and types look
 similar to non-generic functions and types already discussed.
 
+.. index::
+   single: functions;generic
+   single: generics;functions
 .. _Generic_Functions:
 
 Generic Functions
@@ -33,6 +38,8 @@ A function is generic if any of the following conditions hold:
 
 These conditions are discussed in the next sections.
 
+.. index::
+   single: intents;type
 .. _Formal_Type_Arguments:
 
 Formal Type Arguments
@@ -115,6 +122,8 @@ accepting type arguments that only apply to a specific group of types.
       int(8) 1
       real(64) 1.0
 
+.. index::
+   single: intents;param
 .. _Formal_Parameter_Arguments:
 
 Formal Parameter Arguments
@@ -157,6 +166,8 @@ this function at a call site. The formal argument is a parameter.
    The function call ``fillTuple(3, 3)`` returns a 3-tuple where each
    component contains the value ``3``.
 
+.. index::
+   single: formal arguments;without types
 .. _Formal_Arguments_without_Types:
 
 Formal Arguments without Types
@@ -207,6 +218,8 @@ each unique actual type.
    3-tuple of real values ``(3.14, 3.14, 3.14)``. The return type is
    ``(real, real, real)``.
 
+.. index::
+   single: formal arguments;with queried types
 .. _Formal_Arguments_with_Queried_Types:
 
 Formal Arguments with Queried Types
@@ -277,6 +290,8 @@ semantics of a type alias.
       6
       12.0
 
+.. index::
+   single: formal arguments;generic
 .. _Formal_Arguments_of_Generic_Type:
 
 Formal Arguments of Generic Type
@@ -333,6 +348,10 @@ require a query to mark the argument as generic. See also
         // c.type may not be int
       }
 
+.. index::
+   single: formal arguments;partially concrete
+   single: formal arguments;partially generic
+   single: where;implicit
 .. _Formal_Arguments_of_Partially_Generic_Type:
 
 Formal Arguments of Partially Generic Type
@@ -459,6 +478,8 @@ constrained.
 
       partially-concrete-tuple-ambiguity.chpl:5: error: ambiguous call 'f(2*real(64))'
 
+.. index::
+   single: formal arguments;array
 .. _Formal_Arguments_of_Generic_Array_Types:
 
 Formal Arguments of Generic Array Types
@@ -474,6 +495,8 @@ formal argument is taken to be the domain of the actual argument.
 A queried domain may not be modified via the name to which it is bound
 (see :ref:`Association_of_Arrays_to_Domains` for rationale).
 
+.. index::
+   single: generics;function visibility
 .. _Function_Visibility_in_Generic_Functions:
 
 Function Visibility in Generic Functions
@@ -578,6 +601,9 @@ or instantiated (if the derived type is generic).
    Note that the Chapel lookup mechanism is still under development and
    discussion. Comments or questions are appreciated.
 
+.. index::
+   single: generics;types
+   single: types;generic
 .. _Generic_Types:
 
 Generic Types
@@ -586,6 +612,13 @@ Generic Types
 Generic types comprise built-in generic types, generic classes, and
 generic records.
 
+.. index::
+   single: integral (generic type)
+   single: numeric (generic type)
+   single: enumerated (generic type)
+   single: enum (generic type)
+   single: class (generic type)
+   single: record (generic type)
 .. _Built_in_Generic_Types:
 
 Built-in Generic Types
@@ -635,6 +668,14 @@ instantiated as follows:
 -  ``unmanaged``, ``unmanaged class``, ``unmanaged class?`` behave
    similarly to the above but with ``unmanaged`` management strategy.
 
+ .. index::
+   single: generics;classes
+   single: classes;generic
+   single: generics;records
+   single: records;generic
+   single: generics;fields
+   single: fields;generic
+
 Generic Classes and Records
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -667,6 +708,9 @@ For each generic field, the class or record is parameterized over:
 Correspondingly, the class or record is instantiated with a set of types
 and parameter values, one type or value per generic field.
 
+.. index::
+   single: type aliases;in classes or records
+   single: fields;type alias
 .. _Type_Aliases_in_Generic_Types:
 
 Type Aliases in Generic Types
@@ -735,6 +779,9 @@ instead.
    ``next`` is the same type as the type of the object that it is a
    field of.
 
+.. index::
+   single: parameters;in classes or records
+   single: fields;parameter
 .. _Parameters_in_Generic_Types:
 
 Parameters in Generic Types
@@ -833,6 +880,10 @@ instead.
    Running this example with ``-sbig=true`` will print out ``R(64)``, and with
    ``-sbig=false`` or no argument it will print out ``R(32)``.
 
+.. index::
+   single: fields;variable and constant, without types
+   single: variables;in classes or records
+   single: constants;in classes or records
 .. _Fields_without_Types:
 
 Fields without Types
@@ -941,6 +992,10 @@ The types for such fields must either be a built-in generic type (see
 
 
 
+.. index::
+   single: generics;type constructor
+   single: initializers;type constructors
+   single: generics;instantiated type
 .. _Type_Constructors:
 
 The Type Constructor
@@ -1056,6 +1111,9 @@ marked with ``(?)``:
  * generic types passed to a `type` formal argument (see
    :ref:`Formal_Type_Arguments`)
 
+.. index::
+   single: generics;methods
+   single: methods;generic
 .. _Generic_Methods:
 
 Generic Methods
@@ -1065,6 +1123,9 @@ All methods bound to generic classes or records, including initializers,
 are generic over the implicit ``this`` argument. This is in addition to
 being generic over any other argument that is generic.
 
+.. index::
+   single: generics;initializers;compiler-generated
+   single: initializers;compiler-generated;for generic classes or records
 .. _Generic_Compiler_Generated_Initializers:
 
 The Compiler-Generated Generic Initializer
@@ -1094,6 +1155,9 @@ corresponding to the generic ``var`` and ``const`` fields, if any, never
 have defaults, so the corresponding actual values must always be
 provided.
 
+.. index::
+   single: generics;initializers;user-defined
+   single: initializers;user-defined;for generic classes or records
 .. _Generic_User_Initializers:
 
 User-Defined Initializers
@@ -1183,6 +1247,12 @@ type.
    ``c1``, and ``v1``. Otherwise, field initializations may be omitted
    according to previously-described initializer semantics.
 
+.. index::
+   single: user-defined compiler diagnostics
+   single: user-defined compiler errors
+   single: user-defined compiler warnings
+   single: compilerError
+   single: compilerWarning
 .. _User_Defined_Compiler_Errors:
 
 User-Defined Compiler Diagnostics
@@ -1259,6 +1329,10 @@ continue after encountering a ``compilerWarning``.
       compilerDiagnostics.chpl:16: warning: 1-argument version of foo called with type: string
       compilerDiagnostics.chpl:20: error: foo() called with non-matching types: int(64) != real(64)
 
+.. index::
+   single: specific instantiations
+   single: generic specialization
+   single: generic functions and special versions
 .. _Creating_General_and_Specialized_Versions_of_a_Function:
 
 Creating General and Specialized Versions of a Function
@@ -1350,6 +1424,8 @@ that works with some set of types - in other words, the special
 implementation can still be a generic function. See also
 :ref:`Where_Clauses`.
 
+.. index::
+   single: generics;examples;stack
 .. _Example_Generic_Stack:
 
 Example: A Generic Stack

--- a/doc/rst/language/spec/interoperability.rst
+++ b/doc/rst/language/spec/interoperability.rst
@@ -1,5 +1,7 @@
 .. default-domain:: chpl
 
+.. index::
+   single: interoperability
 .. _Chapter-Interoperability:
 
 ================
@@ -37,6 +39,8 @@ and procedures are supplied in :ref:`Shared_Language_Elements`.
 The remainder of this chapter documents Chapel support of
 interoperability through the existing C-language backend.
 
+.. index::
+   single: interoperability;overview
 .. _Interop_Overview:
 
 Interoperability Overview
@@ -46,6 +50,8 @@ The following two subsections provide an overview of calling
 externally-defined (C) routines in Chapel, and setting up Chapel
 routines so they can be called from external (C) code.
 
+.. index::
+   single: interoperability;external functions;calling
 .. _Calling_External_Functions:
 
 Calling External Functions
@@ -124,6 +130,8 @@ static libraries (archives), dynamic libraries or both are supported.
 See the ``chpl`` man page for more information on how these file types
 are handled.
 
+.. index::
+   single: interoperability;Chapel functions;calling
 .. _Calling_Chapel_Functions:
 
 Calling Chapel Functions
@@ -183,6 +191,8 @@ example, the code below declares a function callable in C as
       function was to be instantiated with the given ``param`` values and
       argument types.
 
+.. index::
+   single: interoperability;sharing
 .. _Shared_Language_Elements:
 
 Shared Language Elements
@@ -191,6 +201,14 @@ Shared Language Elements
 This section provides details on how to share Chapel types, variables
 and procedures with external code. It is written assuming that the
 intermediate language is C.
+
+.. index::
+   single: interoperability;standard C types
+   single: interoperability;C types;standard
+   single: interoperability;external C types
+   single: interoperability;C types;external
+   single: interoperability;C structs;external
+   single: interoperability;opaque types
 
 Shared Types
 ~~~~~~~~~~~~
@@ -409,6 +427,8 @@ Like a ``void*`` in C, Chapel’s ``opaque`` carries no information
 regarding the underlying type. It therefore subverts type safety, and
 should be used with caution.
 
+.. index::
+   single: interoperability;shared data
 .. _Shared_Data:
 
 Shared Data
@@ -442,6 +462,9 @@ constants.
    the Chapel compiler does not necessarily parse C code, external
    params are not supported.
 
+.. index::
+   single: interoperability;shared procedures
+   single: interoperability;external functions;calling
 .. _Shared_Procedures:
 
 Shared Procedures
@@ -451,6 +474,8 @@ This subsection provides additional detail and examples for calling
 external procedures from Chapel and for exporting Chapel functions for
 external use.
 
+.. index::
+   single: interoperability;C procedures;calling
 .. _Calling_External_C_Functions:
 
 Calling External C Functions
@@ -526,6 +551,8 @@ prototyped in Chapel by declaring the argument as a type. For example:
 Calling such a routine with a Chapel type will cause the type identifier
 (e.g., ’int’) to be passed to the routine. [3]_
 
+.. index::
+   single: interoperability;Chapel procedures;calling
 .. _Calling_Chapel_Procedures_Externally:
 
 Calling Chapel Procedures Externally
@@ -555,6 +582,8 @@ name is also used externally.
 When a procedure is exported, all of the types and functions on which it
 depends are also exported. Iterators cannot be explicitly exported.
 
+.. index::
+   single: interoperability;argument passing
 .. _Interop_Argument_Passing:
 
 Argument Passing

--- a/doc/rst/language/spec/interoperability.rst
+++ b/doc/rst/language/spec/interoperability.rst
@@ -40,7 +40,7 @@ The remainder of this chapter documents Chapel support of
 interoperability through the existing C-language backend.
 
 .. index::
-   single: interoperability;overview
+   single: interoperability; overview
 .. _Interop_Overview:
 
 Interoperability Overview
@@ -51,7 +51,7 @@ externally-defined (C) routines in Chapel, and setting up Chapel
 routines so they can be called from external (C) code.
 
 .. index::
-   single: interoperability;external functions;calling
+   single: interoperability; calling external functions
 .. _Calling_External_Functions:
 
 Calling External Functions
@@ -131,7 +131,7 @@ See the ``chpl`` man page for more information on how these file types
 are handled.
 
 .. index::
-   single: interoperability;Chapel functions;calling
+   single: interoperability; calling Chapel functions
 .. _Calling_Chapel_Functions:
 
 Calling Chapel Functions
@@ -192,7 +192,7 @@ example, the code below declares a function callable in C as
       argument types.
 
 .. index::
-   single: interoperability;sharing
+   single: interoperability; sharing
 .. _Shared_Language_Elements:
 
 Shared Language Elements
@@ -203,12 +203,10 @@ and procedures with external code. It is written assuming that the
 intermediate language is C.
 
 .. index::
-   single: interoperability;standard C types
-   single: interoperability;C types;standard
-   single: interoperability;external C types
-   single: interoperability;C types;external
-   single: interoperability;C structs;external
-   single: interoperability;opaque types
+   single: interoperability; standard C types
+   single: interoperability; external C types
+   single: interoperability; C structs
+   single: interoperability; opaque types
 
 Shared Types
 ~~~~~~~~~~~~
@@ -428,7 +426,7 @@ regarding the underlying type. It therefore subverts type safety, and
 should be used with caution.
 
 .. index::
-   single: interoperability;shared data
+   single: interoperability; shared data
 .. _Shared_Data:
 
 Shared Data
@@ -463,8 +461,8 @@ constants.
    params are not supported.
 
 .. index::
-   single: interoperability;shared procedures
-   single: interoperability;external functions;calling
+   single: interoperability; shared procedures
+   single: interoperability; calling external functions
 .. _Shared_Procedures:
 
 Shared Procedures
@@ -475,7 +473,7 @@ external procedures from Chapel and for exporting Chapel functions for
 external use.
 
 .. index::
-   single: interoperability;C procedures;calling
+   single: interoperability; calling C procedures
 .. _Calling_External_C_Functions:
 
 Calling External C Functions
@@ -552,7 +550,7 @@ Calling such a routine with a Chapel type will cause the type identifier
 (e.g., ’int’) to be passed to the routine. [3]_
 
 .. index::
-   single: interoperability;Chapel procedures;calling
+   single: interoperability; calling Chapel procedures
 .. _Calling_Chapel_Procedures_Externally:
 
 Calling Chapel Procedures Externally
@@ -583,7 +581,7 @@ When a procedure is exported, all of the types and functions on which it
 depends are also exported. Iterators cannot be explicitly exported.
 
 .. index::
-   single: interoperability;argument passing
+   single: interoperability; argument passing
 .. _Interop_Argument_Passing:
 
 Argument Passing

--- a/doc/rst/language/spec/iterators.rst
+++ b/doc/rst/language/spec/iterators.rst
@@ -1,5 +1,8 @@
 .. default-domain:: chpl
 
+.. index::
+   single: functions;iterators
+   single: iterators
 .. _Chapter-Iterators:
 
 =========
@@ -14,6 +17,8 @@ values (consecutively or in parallel) via its yield statements.
    The parallel iterator story is under development. It is expected that
    the specification will be expanded regarding parallel iterators.
 
+.. index::
+   single: iterators;definition
 .. _Iterator_Function_Definitions:
 
 Iterator Definitions
@@ -65,6 +70,9 @@ declaration, with some key differences:
 
    Iterators that yield types or params are not currently supported.
 
+.. index::
+   single: yield
+   single: iterators;yield
 .. _The_Yield_Statement:
 
 The Yield Statement
@@ -107,6 +115,8 @@ are not permitted to have a return expression. An iterator also
 completes after the last statement in the iterator is executed. An
 iterator need not contain any yield statements.
 
+.. index::
+   single: iterators;calls
 .. _Iterator_Calls:
 
 Iterator Calls
@@ -127,6 +137,9 @@ in the :ref:`Procedures Chapter <Chapter-Procedures>`.
 However, the result of an iterator call depends upon its context, as
 described below.
 
+.. index::
+   single: iterators;in for loops
+   single: iterators;in forall loops
 .. _Iterators_in_For_and_Forall_Loops:
 
 Iterators in For and Forall Loops
@@ -137,6 +150,8 @@ evaluated alongside the loop body in an interleaved manner. For each
 iteration, the iterator yields a value or a reference
 and the loop body is executed.
 
+.. index::
+   single: iterators;and arrays
 .. _Iterators_as_Arrays:
 
 Iterators as Arrays
@@ -185,6 +200,8 @@ value.
 
       1 4 9 16 25
 
+.. index::
+   single: iterators;and generics
 .. _Iterators_and_Generics:
 
 Iterators and Generics
@@ -199,6 +216,8 @@ for loops. The arguments to the iterator call expression, if any, are
 evaluated at the call site, i.e. prior to passing the iterator to the
 generic function.
 
+.. index::
+   single: iterators;recursive
 .. _Recursive_Iterators:
 
 Recursive Iterators
@@ -268,6 +287,9 @@ typically made by iterating over it in a loop.
       Tree Data
       b d e c a
 
+.. index::
+   single: iterators;promotion
+   single: promotion;iterator
 .. _Iterator_Promotion_of_Scalar_Functions:
 
 Iterator Promotion of Scalar Functions
@@ -316,6 +338,9 @@ scalar function as described in :ref:`Promotion`.
       10
       11
 
+.. index::
+   single: parallel iterators
+   single: iterators;parallel
 .. _Parallel_Iterators:
 
 Parallel Iterators

--- a/doc/rst/language/spec/iterators.rst
+++ b/doc/rst/language/spec/iterators.rst
@@ -1,7 +1,7 @@
 .. default-domain:: chpl
 
 .. index::
-   single: functions;iterators
+   single: functions; iterators
    single: iterators
 .. _Chapter-Iterators:
 

--- a/doc/rst/language/spec/language-overview.rst
+++ b/doc/rst/language/spec/language-overview.rst
@@ -52,7 +52,7 @@ narrow the gulf between high-performance parallel programming languages
 and mainstream programming and scripting languages.
 
 .. index::
-   single: language principles;general parallel programming
+   single: language principles; general parallel programming
 .. _General_Parallel_Programming:
 
 General Parallel Programming
@@ -116,7 +116,7 @@ all of them. Naturally, Chapel programmers can tune their code to more
 closely match a particular machine’s characteristics.
 
 .. index::
-   single: language principles;locality-aware programming
+   single: language principles; locality-aware programming
 .. _Locality_Aware_Programming:
 
 Locality-Aware Programming
@@ -133,7 +133,7 @@ specified by the programmer on a process-by-process basis via the
 multiple cooperating program instances.
 
 .. index::
-   single: language principles;object-oriented programming
+   single: language principles; object-oriented programming
 .. _Object_Oriented_Programming:
 
 Object-Oriented Programming
@@ -152,7 +152,7 @@ reference-based classes as well as value classes that are assigned and
 passed by value.
 
 .. index::
-   single: language principles;generic programming
+   single: language principles; generic programming
 .. _Generic_Programming:
 
 Generic Programming
@@ -171,7 +171,6 @@ rather than by relying on dynamic typing which would result in
 unacceptable runtime overheads for the HPC community.
 
 .. index::
-   single: modules
    single: main
 .. _Getting_Started:
 

--- a/doc/rst/language/spec/language-overview.rst
+++ b/doc/rst/language/spec/language-overview.rst
@@ -1,5 +1,8 @@
 .. default-domain:: chpl
 
+.. index::
+   single: overview
+   single: language overview
 .. _Chapter-Language_Overview:
 
 =================
@@ -25,6 +28,8 @@ This section provides a brief overview of the Chapel language by
 discussing first the guiding principles behind the design of the
 language and second how to get started with Chapel.
 
+.. index::
+   single: language principles
 .. _Guiding_Principles:
 
 Guiding Principles
@@ -46,6 +51,8 @@ abstractions. The second two principles were motivated by a desire to
 narrow the gulf between high-performance parallel programming languages
 and mainstream programming and scripting languages.
 
+.. index::
+   single: language principles;general parallel programming
 .. _General_Parallel_Programming:
 
 General Parallel Programming
@@ -108,6 +115,8 @@ parallelism in an architecturally-neutral way to perform reasonably on
 all of them. Naturally, Chapel programmers can tune their code to more
 closely match a particular machine’s characteristics.
 
+.. index::
+   single: language principles;locality-aware programming
 .. _Locality_Aware_Programming:
 
 Locality-Aware Programming
@@ -123,6 +132,8 @@ SPMD-based programming models in which such details are explicitly
 specified by the programmer on a process-by-process basis via the
 multiple cooperating program instances.
 
+.. index::
+   single: language principles;object-oriented programming
 .. _Object_Oriented_Programming:
 
 Object-Oriented Programming
@@ -140,6 +151,8 @@ of the mainstream programming community. Chapel supports traditional
 reference-based classes as well as value classes that are assigned and
 passed by value.
 
+.. index::
+   single: language principles;generic programming
 .. _Generic_Programming:
 
 Generic Programming
@@ -157,6 +170,9 @@ compiler create versions of the code for each required type signature
 rather than by relying on dynamic typing which would result in
 unacceptable runtime overheads for the HPC community.
 
+.. index::
+   single: modules
+   single: main
 .. _Getting_Started:
 
 Getting Started

--- a/doc/rst/language/spec/lexical-structure.rst
+++ b/doc/rst/language/spec/lexical-structure.rst
@@ -1,15 +1,21 @@
 .. default-domain:: chpl
 
+.. index::
+   single: lexical structure
 .. _Chapter-Lexical_Structure:
 
 =================
 Lexical Structure
 =================
 
+
 This section describes the lexical components of Chapel programs. The
 purpose of lexical analysis is to separate the raw input stream into a
 sequence of tokens suitable for input to the parser.
 
+.. index::
+   single: comments
+   single: lexical structure;comments
 .. _Comments:
 
 Comments
@@ -41,6 +47,9 @@ not start a comment but rather are part of the bytes or string literal.
         writeln("hello, world"); // output greeting with new line
       }
 
+.. index::
+   single: white space
+   single: lexical structure;white space
 .. _White_Space:
 
 White Space
@@ -50,6 +59,9 @@ White-space characters are spaces, tabs, line feeds, form feeds, and
 carriage returns. Along with comments, they delimit tokens, but are
 otherwise ignored.
 
+.. index::
+   single: case sensitivity
+   single: lexical structure;case sensitivity
 .. _Case_Sensitivity:
 
 Case Sensitivity
@@ -62,6 +74,8 @@ Chapel is a case sensitive language.
    The following identifiers are considered distinct: ``chapel``,
    ``Chapel``, and ``CHAPEL``.
 
+.. index::
+   single: lexical structure;tokens
 .. _Tokens:
 
 Tokens
@@ -70,6 +84,9 @@ Tokens
 Tokens include identifiers, keywords, literals, operators, and
 punctuation.
 
+.. index::
+   single: identifiers
+   single: lexical structure;identifiers
 .. _Identifiers:
 
 Identifiers
@@ -112,6 +129,9 @@ following syntax:
    The following are legal identifiers: ``Cray1``, ``Cray$``,
    ``legalIdentifier``, and ``legal_identifier``.
 
+.. index::
+   single: keywords
+   single: lexical structure;keywords
 .. _Keywords:
 
 Keywords
@@ -239,6 +259,9 @@ The following identifiers are keywords reserved for future use:
    pragma
    primitive
 
+.. index::
+   single: lexical structure;literals
+   single: literals;primitive type
 .. _Literals:
 
 Literals
@@ -497,6 +520,10 @@ A bytes literal can be either interpreted or uninterpreted.
      interpreted-bytes-literal
      uninterpreted-bytes-literal
 
+.. index::
+   single: lexical structure;operator
+   single: operators;lexical structure
+   single: lexical structure;punctuation
 .. _Operators_and_Punctuation:
 
 Operators and Punctuation
@@ -527,6 +554,10 @@ language:
 ``"`` ``'``                                                                                         string delimiters
 =================================================================================================== =============================
 
+.. index::
+   single: lexical structure;braces
+   single: lexical structure;parentheses
+   single: lexical structure;brackets
 .. _Grouping_Tokens:
 
 Grouping Tokens

--- a/doc/rst/language/spec/locales.rst
+++ b/doc/rst/language/spec/locales.rst
@@ -1,5 +1,10 @@
 .. default-domain:: chpl
 
+.. index::
+   single: local
+   single: remote
+   single: locales;local
+   single: locales;remote
 .. _Chapter-Locales_Chapter:
 
 =======
@@ -18,6 +23,8 @@ any tasks running on this locale. The term *remote* will be used to
 describe another locale, the data on another locale, and the tasks
 running on another locale.
 
+.. index::
+   single: locales
 .. _Locales:
 
 Locales
@@ -31,6 +38,9 @@ the memories of other locales.  As an example, a single shared memory
 machine would be defined as a single locale. In contrast, a cluster of
 network-connected multicore nodes would have a locale for each node.
 
+.. index::
+   single: locale
+   single: types;locale
 .. _The_Locale_Type:
 
 Locale Types
@@ -41,6 +51,9 @@ Both data and tasks can be associated with a value of locale type.
 
 The default value for a variable with ``locale`` type is ``Locales[0]``.
 
+.. index::
+   single: locales;methods
+   single: predefined functions;locale
 .. _Locale_Methods:
 
 Locale Methods
@@ -50,6 +63,10 @@ The locale type supports the following methods:
 
 .. include:: /builtins/ChapelLocale.rst
 
+.. index::
+   single: Locales
+   single: numLocales
+   single: execution environment
 .. _Predefined_Locales_Array:
 
 The Predefined Locales Array
@@ -103,6 +120,9 @@ locale values and referring to it in place of the Locales array.
    ``Locales`` array. Each locale is added to the ``MyLocales`` array
    four times in a round-robin fashion.
 
+.. index::
+   single: here
+   single: locales;here
 .. _here:
 
 The *here* Locale
@@ -126,6 +146,9 @@ program. It refers to the locale that the current task is running on.
 
 The identifier ``here`` is not a keyword and can be overridden.
 
+.. index::
+   single: locale
+   single: .locale
 .. _Querying_the_Locale_of_an_Expression:
 
 Querying the Locale of an Expression
@@ -206,6 +229,9 @@ replicated across all locales.
 
    when running on 5 locales.
 
+.. index::
+   single: on
+   single: statements;on
 .. _On:
 
 The On Statement
@@ -238,6 +264,8 @@ tasks across the network-connected locales upon which the program is running:
     coforall loc in Locales { on loc { ... } }
 
 
+.. index::
+   single: variable declarations;remote
 .. _remote_variable_declarations:
 
 Remote Variable Declarations

--- a/doc/rst/language/spec/locales.rst
+++ b/doc/rst/language/spec/locales.rst
@@ -3,8 +3,8 @@
 .. index::
    single: local
    single: remote
-   single: locales;local
-   single: locales;remote
+   single: locales; local
+   single: locales; remote
 .. _Chapter-Locales_Chapter:
 
 =======
@@ -40,7 +40,7 @@ network-connected multicore nodes would have a locale for each node.
 
 .. index::
    single: locale
-   single: types;locale
+   single: types; locale
 .. _The_Locale_Type:
 
 Locale Types
@@ -52,8 +52,8 @@ Both data and tasks can be associated with a value of locale type.
 The default value for a variable with ``locale`` type is ``Locales[0]``.
 
 .. index::
-   single: locales;methods
-   single: predefined functions;locale
+   single: locales; methods
+   single: predefined functions; locale
 .. _Locale_Methods:
 
 Locale Methods
@@ -64,7 +64,7 @@ The locale type supports the following methods:
 .. include:: /builtins/ChapelLocale.rst
 
 .. index::
-   single: Locales
+   single: Locales array
    single: numLocales
    single: execution environment
 .. _Predefined_Locales_Array:
@@ -122,7 +122,7 @@ locale values and referring to it in place of the Locales array.
 
 .. index::
    single: here
-   single: locales;here
+   single: locales; here
 .. _here:
 
 The *here* Locale
@@ -231,7 +231,7 @@ replicated across all locales.
 
 .. index::
    single: on
-   single: statements;on
+   single: statements; on
 .. _On:
 
 The On Statement
@@ -265,7 +265,7 @@ tasks across the network-connected locales upon which the program is running:
 
 
 .. index::
-   single: variable declarations;remote
+   single: variable declarations; remote
 .. _remote_variable_declarations:
 
 Remote Variable Declarations

--- a/doc/rst/language/spec/memory-consistency-model.rst
+++ b/doc/rst/language/spec/memory-consistency-model.rst
@@ -63,7 +63,7 @@ This chapter will proceed in a manner inspired by the :math:`XC` memory
 model described there.
 
 .. index::
-   single: memory consistency model;sequential consistency for data-race-free programs
+   single: memory consistency model; sequential consistency for data-race-free programs
 .. _SC_for_DRF:
 
 Sequential Consistency for Data-Race-Free Programs
@@ -240,7 +240,7 @@ which preserve sequential program behavior:
 -  If :math:`S(a) <_p S'(a)` then :math:`S(a) <_m S'(a)`
 
 .. index::
-   single: memory consistency model;non-sequentially consisten atomic operations
+   single: memory consistency model; non-sequentially consistent atomic operations
 .. _non_sc_atomics:
 
 Non-Sequentially Consistent Atomic Operations
@@ -287,7 +287,7 @@ as ordinary loads or stores with two exceptions:
    for normal loads and stores.
 
 .. index::
-   single: memory consistency model;unordered memory operations
+   single: memory consistency model; unordered memory operations
 .. _unordered_operations:
 
 Unordered Memory Operations
@@ -404,7 +404,7 @@ move data between two arrays without requiring any ordering:
    }
 
 .. index::
-   single: memory consistency model;examples
+   single: memory consistency model; examples
 .. _MCM_examples:
 
 Examples

--- a/doc/rst/language/spec/memory-consistency-model.rst
+++ b/doc/rst/language/spec/memory-consistency-model.rst
@@ -1,5 +1,7 @@
 .. default-domain:: chpl
 
+.. index::
+   single: memory consistency model
 .. _Chapter-Memory_Consistency_Model:
 
 ========================
@@ -60,6 +62,8 @@ See *A Primer on Memory Consistency and Cache Coherence* by Sorin,
 This chapter will proceed in a manner inspired by the :math:`XC` memory
 model described there.
 
+.. index::
+   single: memory consistency model;sequential consistency for data-race-free programs
 .. _SC_for_DRF:
 
 Sequential Consistency for Data-Race-Free Programs
@@ -235,6 +239,8 @@ which preserve sequential program behavior:
 
 -  If :math:`S(a) <_p S'(a)` then :math:`S(a) <_m S'(a)`
 
+.. index::
+   single: memory consistency model;non-sequentially consisten atomic operations
 .. _non_sc_atomics:
 
 Non-Sequentially Consistent Atomic Operations
@@ -280,6 +286,8 @@ as ordinary loads or stores with two exceptions:
    eventually be visible to all other threads. This property is not true
    for normal loads and stores.
 
+.. index::
+   single: memory consistency model;unordered memory operations
 .. _unordered_operations:
 
 Unordered Memory Operations
@@ -395,6 +403,8 @@ move data between two arrays without requiring any ordering:
      unordered_store(B[P[i]], A[i]);
    }
 
+.. index::
+   single: memory consistency model;examples
 .. _MCM_examples:
 
 Examples

--- a/doc/rst/language/spec/methods.rst
+++ b/doc/rst/language/spec/methods.rst
@@ -2,8 +2,8 @@
 
 .. index::
    single: methods
-   single: methods;primary
-   single: methods;secondary
+   single: methods; primary
+   single: methods; secondary
    single: primary methods
    single: secondary methods
 .. _Chapter-Methods:
@@ -67,7 +67,8 @@ The use of ``this-intent`` is described in
 
 .. index::
    single: method calls
-   single: methods;calling
+   single: methods; calling
+   single: calls; methods
 .. _Method_Calls:
 
 Method Calls
@@ -147,14 +148,15 @@ a way that allows these methods to be called (see :ref:`Using_Modules` and
    discussion.
 
 .. index::
-   single: methods;receiver
+   single: methods; receiver
    single: this
-   single: classes;this
+   single: classes; this
+   single: records; this
    single: receiver
    single: type methods
    single: instance methods
-   single: methods;type
-   single: methods;instance
+   single: methods; type
+   single: methods; instance
 .. _Method_receiver_and_this:
 
 The Method Receiver and the *this* Argument
@@ -329,9 +331,9 @@ entirely, the receiver will be passed with a default intent. The default
    to ``4``.
 
 .. index::
-   single: methods;indexing
+   single: methods; indexing
    single: this
-   single: methods;this
+   single: methods; this
 .. _The_this_Method:
 
 The *this* Method
@@ -385,9 +387,9 @@ be declared with parentheses even if the argument list is empty.
       thisMethod.chpl:9: error: halt reached - ThreeArray index out of bounds: 4
 
 .. index::
-   single: methods;iterating
+   single: methods; iterating
    single: these
-   single: methods;these
+   single: methods; these
 .. _The_these_Method:
 
 The *these* Method

--- a/doc/rst/language/spec/methods.rst
+++ b/doc/rst/language/spec/methods.rst
@@ -1,5 +1,11 @@
 .. default-domain:: chpl
 
+.. index::
+   single: methods
+   single: methods;primary
+   single: methods;secondary
+   single: primary methods
+   single: secondary methods
 .. _Chapter-Methods:
 
 =======
@@ -59,6 +65,9 @@ Method calls are described in :ref:`Method_Calls`.
 The use of ``this-intent`` is described in
 :ref:`Method_receiver_and_this`.
 
+.. index::
+   single: method calls
+   single: methods;calling
 .. _Method_Calls:
 
 Method Calls
@@ -137,6 +146,15 @@ a way that allows these methods to be called (see :ref:`Using_Modules` and
    Future work: the semantics of privacy specifiers for methods are still under
    discussion.
 
+.. index::
+   single: methods;receiver
+   single: this
+   single: classes;this
+   single: receiver
+   single: type methods
+   single: instance methods
+   single: methods;type
+   single: methods;instance
 .. _Method_receiver_and_this:
 
 The Method Receiver and the *this* Argument
@@ -310,6 +328,10 @@ entirely, the receiver will be passed with a default intent. The default
    Given a variable ``x = 2``, a call to ``x.doubleMe()`` will set ``x``
    to ``4``.
 
+.. index::
+   single: methods;indexing
+   single: this
+   single: methods;this
 .. _The_this_Method:
 
 The *this* Method
@@ -362,6 +384,10 @@ be declared with parentheses even if the argument list is empty.
       3
       thisMethod.chpl:9: error: halt reached - ThreeArray index out of bounds: 4
 
+.. index::
+   single: methods;iterating
+   single: these
+   single: methods;these
 .. _The_these_Method:
 
 The *these* Method

--- a/doc/rst/language/spec/modules.rst
+++ b/doc/rst/language/spec/modules.rst
@@ -23,8 +23,8 @@ in :ref:`Program_Execution`.
 
 .. index::
    single: module
-   single: modules;definitions
-   single: modules;top-level
+   single: modules; definitions
+   single: modules; top-level
 .. _Module_Definitions:
 
 Module Definitions
@@ -62,7 +62,7 @@ creates a *top-level module*. Module declarations within other modules
 create nested modules (:ref:`Nested_Modules`).
 
 .. index::
-   single: modules;prototype
+   single: modules; prototype
 .. _Prototype_Modules:
 
 Prototype Modules
@@ -79,9 +79,9 @@ Implicit modules (:ref:`Implicit_Modules`) are implicitly considered
 ``prototype`` modules as well.
 
 .. index::
-   single: modules;and files
+   single: modules; and files
    single: implicit modules
-   single: modules;implicit
+   single: modules; implicit
 .. _Implicit_Modules:
 
 Files and Implicit Modules
@@ -179,8 +179,8 @@ identifier, it cannot be referenced in a use statement.
    printY.
 
 .. index::
-   single: modules;nested
-   single: modules;sub-modules
+   single: modules; nested
+   single: modules; sub-modules
 .. _Nested_Modules:
 
 Nested Modules
@@ -273,7 +273,7 @@ nested modules.
       0
 
 .. index::
-   single: modules;access
+   single: modules; access
 .. _Access_Of_Module_Contents:
 
 Access of Module Contents
@@ -287,7 +287,7 @@ statement (:ref:`Importing_Modules`) or qualified
 naming (:ref:`Explicit_Naming`).
 
 .. index::
-   single: modules;access
+   single: modules; access
 .. _Visibility_Of_A_Module:
 
 Visibility Of A Module
@@ -321,7 +321,7 @@ unless it has already been brought into scope by another ``use`` or ``import``
 statement.
 
 .. index::
-   single: modules;access
+   single: modules; symbol visibility
 .. _Visibility_Of_Symbols:
 
 Visibility Of A Module’s Symbols
@@ -338,8 +338,8 @@ statement (:ref:`Importing_Modules`), or qualified
 naming (:ref:`Explicit_Naming`).
 
 .. index::
-   single: modules;using
-   single: modules;importing
+   single: modules; using
+   single: modules; importing
 .. _Using_And_Importing:
 
 Using and Importing
@@ -838,7 +838,7 @@ access to certain symbols, that list will also limit which of the symbols from
 C1, C2, and C3 will be available to A.
 
 .. index::
-   single: modules;qualified naming
+   single: modules; qualified naming
 .. _Explicit_Naming:
 
 Qualified Naming of Module Symbols
@@ -1128,8 +1128,7 @@ modules.
 
 
 .. index::
-   single: modules;initialization
-   single: initialization;modules
+   pair: modules; initialization
 .. _Module_Initialization:
 
 Module Initialization
@@ -1176,8 +1175,7 @@ Module initialization order is discussed
 in :ref:`Module_Initialization_Order`.
 
 .. index::
-   single: modules;deinitialization
-   single: deinitialization;modules
+   pair: modules; deinitialization
 .. _Module_Deinitialization:
 
 Module Deinitialization
@@ -1288,7 +1286,7 @@ the following situations in order:
 
 .. index::
    single: main
-   single: functions;main
+   single: functions; main
    single: exploratory programming
 .. _The_main_Procedure:
 
@@ -1334,7 +1332,7 @@ procedure. The default main function is equivalent to:
    module is initialized.
 
 .. index::
-   single: modules;initialization order
+   single: modules; initialization order
 .. _Module_Initialization_Order:
 
 Module Initialization Order
@@ -1394,7 +1392,7 @@ uses are initialized before the nested module and its uses or imports.
    M2.M3. Finally M1 is initialized, and the main procedure is run.
 
 .. index::
-   single: modules;deinitialization order
+   single: modules; deinitialization order
 .. _Module_Deinitialization_Order:
 
 Module Deinitialization Order

--- a/doc/rst/language/spec/modules.rst
+++ b/doc/rst/language/spec/modules.rst
@@ -1,5 +1,7 @@
 .. default-domain:: chpl
 
+.. index::
+   single: modules
 .. _Chapter-Modules:
 
 =======
@@ -19,6 +21,10 @@ in :ref:`Visibility_Of_Symbols`. The execution of a program
 and module initialization/deinitialization are described
 in :ref:`Program_Execution`.
 
+.. index::
+   single: module
+   single: modules;definitions
+   single: modules;top-level
 .. _Module_Definitions:
 
 Module Definitions
@@ -55,6 +61,8 @@ Any module declaration that is not contained within another module
 creates a *top-level module*. Module declarations within other modules
 create nested modules (:ref:`Nested_Modules`).
 
+.. index::
+   single: modules;prototype
 .. _Prototype_Modules:
 
 Prototype Modules
@@ -70,6 +78,10 @@ errors that are not handled will terminate the program
 Implicit modules (:ref:`Implicit_Modules`) are implicitly considered
 ``prototype`` modules as well.
 
+.. index::
+   single: modules;and files
+   single: implicit modules
+   single: modules;implicit
 .. _Implicit_Modules:
 
 Files and Implicit Modules
@@ -166,6 +178,9 @@ identifier, it cannot be referenced in a use statement.
    Module implicit defines the module-scope symbols x, y, printX, and
    printY.
 
+.. index::
+   single: modules;nested
+   single: modules;sub-modules
 .. _Nested_Modules:
 
 Nested Modules
@@ -257,6 +272,8 @@ nested modules.
       0
       0
 
+.. index::
+   single: modules;access
 .. _Access_Of_Module_Contents:
 
 Access of Module Contents
@@ -269,6 +286,8 @@ done via the use statement (:ref:`Using_Modules`), the import
 statement (:ref:`Importing_Modules`) or qualified
 naming (:ref:`Explicit_Naming`).
 
+.. index::
+   single: modules;access
 .. _Visibility_Of_A_Module:
 
 Visibility Of A Module
@@ -301,6 +320,8 @@ imported with just its name, even from the scope in which the module is defined,
 unless it has already been brought into scope by another ``use`` or ``import``
 statement.
 
+.. index::
+   single: modules;access
 .. _Visibility_Of_Symbols:
 
 Visibility Of A Module’s Symbols
@@ -316,6 +337,9 @@ it contains are accessible via the use statement (:ref:`Using_Modules`), import
 statement (:ref:`Importing_Modules`), or qualified
 naming (:ref:`Explicit_Naming`).
 
+.. index::
+   single: modules;using
+   single: modules;importing
 .. _Using_And_Importing:
 
 Using and Importing
@@ -813,6 +837,8 @@ in the second example of re-exporting, if module A's import of B only allowed
 access to certain symbols, that list will also limit which of the symbols from
 C1, C2, and C3 will be available to A.
 
+.. index::
+   single: modules;qualified naming
 .. _Explicit_Naming:
 
 Qualified Naming of Module Symbols
@@ -1101,6 +1127,9 @@ modules.
       3
 
 
+.. index::
+   single: modules;initialization
+   single: initialization;modules
 .. _Module_Initialization:
 
 Module Initialization
@@ -1146,6 +1175,9 @@ module, other than function and type declarations, are executed.
 Module initialization order is discussed
 in :ref:`Module_Initialization_Order`.
 
+.. index::
+   single: modules;deinitialization
+   single: deinitialization;modules
 .. _Module_Deinitialization:
 
 Module Deinitialization
@@ -1163,6 +1195,9 @@ deinitialization:
 Module deinitialization order is discussed
 in :ref:`Module_Deinitialization_Order`.
 
+.. index::
+   single: program execution
+   single: program initialization
 .. _Program_Execution:
 
 Program Execution
@@ -1251,6 +1286,10 @@ the following situations in order:
    Notice that ``main`` is treated like just another procedure if it is not
    in the main module and can be called as such.
 
+.. index::
+   single: main
+   single: functions;main
+   single: exploratory programming
 .. _The_main_Procedure:
 
 The *main* Procedure
@@ -1294,6 +1333,8 @@ procedure. The default main function is equivalent to:
    The compiler adds an empty default ``main`` which runs after that
    module is initialized.
 
+.. index::
+   single: modules;initialization order
 .. _Module_Initialization_Order:
 
 Module Initialization Order
@@ -1352,6 +1393,8 @@ uses are initialized before the nested module and its uses or imports.
    M2) must be initialized first. M2 itself is initialized, followed by
    M2.M3. Finally M1 is initialized, and the main procedure is run.
 
+.. index::
+   single: modules;deinitialization order
 .. _Module_Deinitialization_Order:
 
 Module Deinitialization Order

--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -120,8 +120,8 @@ Calls to methods are defined in
 Section :ref:`Class_Method_Calls`.
 
 .. index::
-   single: functions;procedure definition
-   single: procedures;definition
+   single: functions; procedure definition
+   single: procedures; definition
    single: proc
 .. _Function_Definitions:
 
@@ -265,7 +265,7 @@ See the chapter on interoperability
 and imported functions.
 
 .. index::
-   single: functions;without parentheses
+   single: functions; without parentheses
 .. _Functions_without_Parentheses:
 
 Functions without Parentheses
@@ -305,8 +305,7 @@ be called without parentheses.
 
 .. index::
    single: formal arguments
-   single: functions;formal arguments
-   single: functions;arguments;formal
+   single: functions; formal arguments
 .. _Formal_Arguments:
 
 Formal Arguments
@@ -322,9 +321,8 @@ default value (e.g. ``arg = ""``).
 
 .. index::
    single: named arguments
-   single: functions;named arguments
-   single: functions;arguments;named
-   single: formal arguments;naming
+   single: functions; named arguments
+   single: formal arguments; naming
 .. _Named_Arguments:
 
 Named Arguments
@@ -363,8 +361,7 @@ compiler-checked documentation.
 
 .. index::
    single: default values
-   single: functions;default argument values
-   single: functions;arguments;defaults
+   single: functions; default argument values
    single: formal arguments;defaults
 .. _Default_Values:
 
@@ -456,8 +453,8 @@ from the default value expression.
 
 .. index::
    single: intents
-   single: argument;intents
-   single: functions;arguments;intents
+   pair: arguments; intents
+   single: functions; arguments intents
 .. _Argument_Intents:
 
 Argument Intents
@@ -520,7 +517,7 @@ See the sections on each intent for further details.
 
 .. index::
    single: in (intent)
-   single: intents;in
+   single: intents; in
 .. _The_In_Intent:
 
 The In Intent
@@ -604,7 +601,7 @@ but the code does not copy initialize:
 
 .. index::
    single: out (intent)
-   single: intents;out
+   single: intents; out
 .. _The_Out_Intent:
 
 The Out Intent
@@ -645,7 +642,7 @@ function body rather than from the call site.
 
 .. index::
    single: inout (intent)
-   single: intents;inout
+   single: intents; inout
 .. _The_Inout_Intent:
 
 The Inout Intent
@@ -666,7 +663,7 @@ modified within the function.
 
 .. index::
    single: ref (intent)
-   single: intents;ref
+   single: intents; ref
 .. _The_Ref_Intent:
 
 The Ref Intent
@@ -688,7 +685,7 @@ model.
 
 .. index::
    single: const in (intent)
-   single: intents;const in
+   single: intents; const in
 .. _The_Const_In_Intent:
 
 The Const In Intent
@@ -699,7 +696,7 @@ modifications to the formal argument are prohibited within the function.
 
 .. index::
    single: const ref (intent)
-   single: intents;const ref
+   single: intents; const ref
 .. _The_Const_Ref_Intent:
 
 The Const Ref Intent
@@ -736,7 +733,7 @@ The following example shows such modification by means other than the
       2
 
 .. index::
-   single: intents;const
+   single: intents; const
 .. _The_Const_Intent:
 
 The Const Intent
@@ -795,11 +792,7 @@ In the cases where these assumptions are not appropriate, code should use
 
 
 .. index::
-   single: intents;default
-   single: intents;array default
-   single: intents;record chpl{this} default
-   single: intents;default for owned
-   single: intents;default for shared
+   single: intents; default
 .. _The_Default_Intent:
 
 The Default Intent
@@ -863,8 +856,8 @@ actual argument is assumed to remain unchanged during the call and
 ownership transfer or ownership sharing will not occur.
 
 .. index::
-   single: functions;variable number of arguments
-   single: functions;varargs
+   single: functions; variable number of arguments
+   single: functions; varargs
 .. _Variable_Length_Argument_Lists:
 
 Variable Number of Arguments
@@ -985,8 +978,8 @@ homogeneous tuple, otherwise it will be a heterogeneous tuple.
    equivalent, as are the expressions ``tuple(1)`` and ``(1,)``.
 
 .. index::
-   single: functions;return intent
-   single: statements;return;return intent
+   single: functions; return intent
+   single: return; intent
 .. _Return_Intent:
 
 Return Intents
@@ -997,7 +990,7 @@ function and in what contexts that function is allowed to be used.
 The rules for returning tuples are specified in :ref:`Tuple_Return_Behavior`.
 
 .. index::
-   single: intents;default (return intent)
+   single: intents; default (return intent)
 .. _Default_Return_Intent:
 
 The Default Return Intent
@@ -1008,7 +1001,7 @@ a value in the same way as the ``out`` return intent,
 see :ref:`Out_Return_Intent`.
 
 .. index::
-   single: intents;out (return intent)
+   single: intents; out (return intent)
 .. _Out_Return_Intent:
 
 The Out Return Intent
@@ -1022,10 +1015,10 @@ see :ref:`Copy_and_Move_Initialization`.
 It is an error to return a ``sync`` or ``atomic`` by ``out`` intent.
 
 .. index::
-   single: functions;ref keyword
+   single: functions; ref keyword
    single: ref (return intent)
-   single: intents;ref (return intent)
-   single: functions;lvalues
+   single: intents; ref (return intent)
+   single: functions; lvalues
 .. _Ref_Return_Intent:
 
 The Ref Return Intent
@@ -1082,9 +1075,9 @@ exists outside of the function's scope.
       3
 
 .. index::
-   single: functions;const ref keyword
+   single: functions; const ref keyword
    single: const ref (return intent)
-   single: intents;const ref (return intent)
+   single: intents; const ref (return intent)
 .. _Const_Ref_Return_Intent:
 
 The Const Ref Return Intent
@@ -1096,7 +1089,7 @@ form of the ``ref`` return intent. Calls to functions marked with the
 
 .. index::
    single: const (return intent)
-   single: intents;const (return intent)
+   single: intents; const (return intent)
 .. _Const_Return_Intent:
 
 The Const Return Intent
@@ -1108,8 +1101,7 @@ the ``const`` return intent are not lvalue expressions.
 
 
 .. index::
-   single: functions;return intent overloads
-   single: functions;return intent overloads
+   single: functions; return intent overloads
 .. _Return_Intent_Overloads:
 
 Return Intent Overloads
@@ -1168,8 +1160,7 @@ context.
       ref-return-intent-pair.chpl:8: error: halt reached - cannot assign value to A(1) if A(0) <= 0
 
 .. index::
-   single: functions;as parameters
-   single: functions;parameter function
+   single: functions; param return intent
    single: parameter function
 .. _Param_Return_Intent:
 
@@ -1220,8 +1211,8 @@ loop :ref:`Parameter_For_Loops` and conditionals with a
 conditional expressions that is not a parameter.
 
 .. index::
-   single: functions;as types
-   single: functions;type functions
+   single: functions; type return intent
+   single: functions; type functions
 .. _Type_Return_Intent:
 
 The Type Return Intent
@@ -1290,7 +1281,7 @@ forms of control flow.
 
 .. index::
    single: return
-   single: statements;return
+   single: statements; return
 .. _The_Return_Statement:
 
 The Return Statement
@@ -1346,8 +1337,8 @@ The syntax of the return statement is given by
       6
 
 .. index::
-   single: statements;return;return type
-   single: functions;return types
+   single: return types
+   single: functions; return types
 .. _Return_Types:
 
 Return Types
@@ -1359,7 +1350,7 @@ inferred implicitly.
 
 .. index::
    single: explicit return type
-   single: functions;return types;explicit
+   single: return types; explicit
 .. _Explicit_Return_Types:
 
 Explicit Return Types
@@ -1374,9 +1365,9 @@ the type returned in all of the return statements exactly, when checked
 after generic instantiation and parameter folding (if applicable).
 
 .. index::
-   single: type inference;of return types
+   single: type inference; of return types
    single: implicit return type
-   single: functions;return types;implicit
+   single: return types; implicit
 .. _Implicit_Return_Types:
 
 Implicit Return Types
@@ -1399,7 +1390,7 @@ an error.
 
 .. index::
    single: where
-   single: functions;where
+   single: functions; where
 .. _Where_Clauses:
 
 Where Clauses
@@ -1440,7 +1431,7 @@ resolution.
    clause on the second function evaluates to false.
 
 .. index::
-   single: functions;nested
+   single: functions; nested
    single: nested function
 .. _Nested_Functions:
 
@@ -1461,8 +1452,8 @@ which they are nested.
    single: overloading
    single: overloading functions
    single: overloading operators
-   single: functions;overloading
-   single: operators;overloading
+   single: functions; overloading
+   single: operators; overloading
 .. _Function_Overloading:
 
 Function and Operator Overloading
@@ -1495,7 +1486,10 @@ resolution.
 Assignment overloads are not supported for class types.
 
 .. index::
-   single: functions;resolution
+   single: functions; resolution
+   single: functions; disambiguation
+   see: overload resolution; function resolution
+   single: function resolution
 .. _Function_Resolution:
 
 Function Resolution
@@ -1558,7 +1552,7 @@ This section uses the following notation:
   type :math:`T(Y_i)`.
 
 .. index::
-   single: functions;visible
+   single: functions; visible
 .. _Determining_Visible_Functions:
 
 Determining Visible Functions
@@ -1584,9 +1578,9 @@ function call and one of the following conditions is met:
   receiver type.
 
 .. index::
-   single: functions;candidates
-   single: functions;resolution;valid mapping
-   single: functions;resolution;legal argument mapping
+   single: functions; candidates
+   single: function resolution; valid mapping
+   single: function resolution; legal argument mapping
 .. _Determining_Candidate_Functions:
 
 Determining Candidate Functions
@@ -1671,8 +1665,7 @@ array of ``int`` and :math:`T(X_i)` is ``int``, then promotion occurs and
 the above rules will be checked with :math:`T(A_i)` == ``int``.
 
 .. index::
-   single: functions;most specific
-   single: functions;resolution;most specific
+   single: function resolution; most specific
 .. _Determining_More_Specific_Functions:
 .. _Determining_Most_Specific_Functions:
 
@@ -1843,7 +1836,7 @@ the following function(s) are selected as best functions:
 -  only those functions that have a ``where`` clause, otherwise.
 
 .. index::
-   single: functions;return intent overloads
+   single: functions; return intent overloads
 .. _Choosing_Return_Intent_Overload:
 
 Choosing Return Intent Overloads Based on Calling Context

--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -1,5 +1,18 @@
 .. default-domain:: chpl
 
+.. index::
+   single: functions
+   single: functions;call site
+   single: call site
+   single: functions;formal arguments
+   single: formal arguments
+   single: functions;actual arguments
+   single: actual arguments
+   single: functions;procedure
+   single: procedure
+   single: functions;operator
+   single: functions;method
+   single: operators;procedure
 .. _Chapter-Procedures:
 
 ==========
@@ -52,6 +65,11 @@ Functions are presented as follows:
    and operator overloading :ref:`Function_Overloading`,
    function resolution :ref:`Function_Resolution`
 
+.. index::
+   single: function calls
+   single: calls;function
+   single: actual arguments
+   single: functions;actual arguments
 .. _Function_Calls:
 
 Function Calls
@@ -101,6 +119,10 @@ in :ref:`Named_Arguments`.
 Calls to methods are defined in
 Section :ref:`Class_Method_Calls`.
 
+.. index::
+   single: functions;procedure definition
+   single: procedures;definition
+   single: proc
 .. _Function_Definitions:
 
 Procedure Definitions
@@ -242,6 +264,8 @@ See the chapter on interoperability
 (:ref:`Chapter-Interoperability`) for details on exported
 and imported functions.
 
+.. index::
+   single: functions;without parentheses
 .. _Functions_without_Parentheses:
 
 Functions without Parentheses
@@ -279,6 +303,10 @@ be called without parentheses.
    to use parentheses when calling ``foo`` or omit them when calling
    ``bar``.
 
+.. index::
+   single: formal arguments
+   single: functions;formal arguments
+   single: functions;arguments;formal
 .. _Formal_Arguments:
 
 Formal Arguments
@@ -292,6 +320,11 @@ applied, resulting in type-dependent behavior.
 A formal argument can include a type (e.g. ``arg: int``) and possibly a
 default value (e.g. ``arg = ""``).
 
+.. index::
+   single: named arguments
+   single: functions;named arguments
+   single: functions;arguments;named
+   single: formal arguments;naming
 .. _Named_Arguments:
 
 Named Arguments
@@ -328,6 +361,11 @@ arguments with default values. For a function that has many arguments,
 it is sometimes good practice to name the arguments at the call site for
 compiler-checked documentation.
 
+.. index::
+   single: default values
+   single: functions;default argument values
+   single: functions;arguments;defaults
+   single: formal arguments;defaults
 .. _Default_Values:
 
 Default Values
@@ -416,6 +454,10 @@ from the default value expression.
       {0..2}
 
 
+.. index::
+   single: intents
+   single: argument;intents
+   single: functions;arguments;intents
 .. _Argument_Intents:
 
 Argument Intents
@@ -476,6 +518,9 @@ local changes affect the actual? no     on return on return at once  N/A        
 
 See the sections on each intent for further details.
 
+.. index::
+   single: in (intent)
+   single: intents;in
 .. _The_In_Intent:
 
 The In Intent
@@ -557,6 +602,9 @@ but the code does not copy initialize:
       block ending
 
 
+.. index::
+   single: out (intent)
+   single: intents;out
 .. _The_Out_Intent:
 
 The Out Intent
@@ -595,6 +643,9 @@ function body rather than from the call site.
    call site. However this is not yet implemented, at the time of this
    writing.
 
+.. index::
+   single: inout (intent)
+   single: intents;inout
 .. _The_Inout_Intent:
 
 The Inout Intent
@@ -613,6 +664,9 @@ candidate (see :ref:`Function_Resolution`).
 The actual argument must be a valid lvalue. The formal argument can be
 modified within the function.
 
+.. index::
+   single: ref (intent)
+   single: intents;ref
 .. _The_Ref_Intent:
 
 The Ref Intent
@@ -632,6 +686,9 @@ concurrent modifications to the ``ref`` actual argument by other tasks
 may be visible within the function, subject to the memory consistency
 model.
 
+.. index::
+   single: const in (intent)
+   single: intents;const in
 .. _The_Const_In_Intent:
 
 The Const In Intent
@@ -640,6 +697,9 @@ The Const In Intent
 The ``const in`` intent is identical to the ``in`` intent, except that
 modifications to the formal argument are prohibited within the function.
 
+.. index::
+   single: const ref (intent)
+   single: intents;const ref
 .. _The_Const_Ref_Intent:
 
 The Const Ref Intent
@@ -675,6 +735,8 @@ The following example shows such modification by means other than the
       1
       2
 
+.. index::
+   single: intents;const
 .. _The_Const_Intent:
 
 The Const Intent
@@ -732,6 +794,12 @@ In the cases where these assumptions are not appropriate, code should use
      * for values of enumerated type
 
 
+.. index::
+   single: intents;default
+   single: intents;array default
+   single: intents;record chpl{this} default
+   single: intents;default for owned
+   single: intents;default for shared
 .. _The_Default_Intent:
 
 The Default Intent
@@ -794,6 +862,9 @@ If the default intent or ``const`` intent is used for an
 actual argument is assumed to remain unchanged during the call and
 ownership transfer or ownership sharing will not occur.
 
+.. index::
+   single: functions;variable number of arguments
+   single: functions;varargs
 .. _Variable_Length_Argument_Lists:
 
 Variable Number of Arguments
@@ -913,6 +984,9 @@ homogeneous tuple, otherwise it will be a heterogeneous tuple.
    Therefore the expressions ``tuple(1, 2)`` and ``(1,2)`` are
    equivalent, as are the expressions ``tuple(1)`` and ``(1,)``.
 
+.. index::
+   single: functions;return intent
+   single: statements;return;return intent
 .. _Return_Intent:
 
 Return Intents
@@ -922,6 +996,8 @@ The ``return-intent`` determines how the value is returned from a
 function and in what contexts that function is allowed to be used.
 The rules for returning tuples are specified in :ref:`Tuple_Return_Behavior`.
 
+.. index::
+   single: intents;default (return intent)
 .. _Default_Return_Intent:
 
 The Default Return Intent
@@ -931,6 +1007,8 @@ When no ``return-intent`` is specified explicitly, the function returns
 a value in the same way as the ``out`` return intent,
 see :ref:`Out_Return_Intent`.
 
+.. index::
+   single: intents;out (return intent)
 .. _Out_Return_Intent:
 
 The Out Return Intent
@@ -943,6 +1021,11 @@ see :ref:`Copy_and_Move_Initialization`.
 
 It is an error to return a ``sync`` or ``atomic`` by ``out`` intent.
 
+.. index::
+   single: functions;ref keyword
+   single: ref (return intent)
+   single: intents;ref (return intent)
+   single: functions;lvalues
 .. _Ref_Return_Intent:
 
 The Ref Return Intent
@@ -998,6 +1081,10 @@ exists outside of the function's scope.
 
       3
 
+.. index::
+   single: functions;const ref keyword
+   single: const ref (return intent)
+   single: intents;const ref (return intent)
 .. _Const_Ref_Return_Intent:
 
 The Const Ref Return Intent
@@ -1007,6 +1094,9 @@ The ``const ref`` return intent is also available. It is a restricted
 form of the ``ref`` return intent. Calls to functions marked with the
 ``const ref`` return intent are not lvalue expressions.
 
+.. index::
+   single: const (return intent)
+   single: intents;const (return intent)
 .. _Const_Return_Intent:
 
 The Const Return Intent
@@ -1017,6 +1107,9 @@ The ``const`` return intent makes it up to the implementation to return a
 the ``const`` return intent are not lvalue expressions.
 
 
+.. index::
+   single: functions;return intent overloads
+   single: functions;return intent overloads
 .. _Return_Intent_Overloads:
 
 Return Intent Overloads
@@ -1074,6 +1167,10 @@ context.
 
       ref-return-intent-pair.chpl:8: error: halt reached - cannot assign value to A(1) if A(0) <= 0
 
+.. index::
+   single: functions;as parameters
+   single: functions;parameter function
+   single: parameter function
 .. _Param_Return_Intent:
 
 The Param Return Intent
@@ -1122,6 +1219,9 @@ compile-time. This includes loops other than the parameter for
 loop :ref:`Parameter_For_Loops` and conditionals with a
 conditional expressions that is not a parameter.
 
+.. index::
+   single: functions;as types
+   single: functions;type functions
 .. _Type_Return_Intent:
 
 The Type Return Intent
@@ -1188,6 +1288,9 @@ used as a shorthand for defining the body instead, similar to other
 forms of control flow.
 
 
+.. index::
+   single: return
+   single: statements;return
 .. _The_Return_Statement:
 
 The Return Statement
@@ -1242,6 +1345,9 @@ The syntax of the return statement is given by
 
       6
 
+.. index::
+   single: statements;return;return type
+   single: functions;return types
 .. _Return_Types:
 
 Return Types
@@ -1251,6 +1357,9 @@ Every procedure has a return type. The return type is either specified
 explicitly via ``return-type`` in the procedure declaration, or is
 inferred implicitly.
 
+.. index::
+   single: explicit return type
+   single: functions;return types;explicit
 .. _Explicit_Return_Types:
 
 Explicit Return Types
@@ -1264,6 +1373,10 @@ intent (:ref:`Ref_Return_Intent`), the return type must match
 the type returned in all of the return statements exactly, when checked
 after generic instantiation and parameter folding (if applicable).
 
+.. index::
+   single: type inference;of return types
+   single: implicit return type
+   single: functions;return types;implicit
 .. _Implicit_Return_Types:
 
 Implicit Return Types
@@ -1284,6 +1397,9 @@ between every other type and that type, and that type becomes the
 inferred return type. If the above requirements are not satisfied, it is
 an error.
 
+.. index::
+   single: where
+   single: functions;where
 .. _Where_Clauses:
 
 Where Clauses
@@ -1323,6 +1439,9 @@ resolution.
    the call foo(3) resolves to the first definition because the where
    clause on the second function evaluates to false.
 
+.. index::
+   single: functions;nested
+   single: nested function
 .. _Nested_Functions:
 
 Nested Functions
@@ -1338,6 +1457,12 @@ scope in which they are defined.
 Nested functions may refer to variables defined in the function(s) in
 which they are nested.
 
+.. index::
+   single: overloading
+   single: overloading functions
+   single: overloading operators
+   single: functions;overloading
+   single: operators;overloading
 .. _Function_Overloading:
 
 Function and Operator Overloading
@@ -1369,6 +1494,8 @@ resolution.
 
 Assignment overloads are not supported for class types.
 
+.. index::
+   single: functions;resolution
 .. _Function_Resolution:
 
 Function Resolution
@@ -1430,6 +1557,8 @@ This section uses the following notation:
   consideration, where :math:`A_i` is passed to the formal :math:`Y_i` of
   type :math:`T(Y_i)`.
 
+.. index::
+   single: functions;visible
 .. _Determining_Visible_Functions:
 
 Determining Visible Functions
@@ -1454,6 +1583,10 @@ function call and one of the following conditions is met:
 - :math:`X` is a method and it is visible in the module that defines the
   receiver type.
 
+.. index::
+   single: functions;candidates
+   single: functions;resolution;valid mapping
+   single: functions;resolution;legal argument mapping
 .. _Determining_Candidate_Functions:
 
 Determining Candidate Functions
@@ -1537,8 +1670,10 @@ type, index type, or yielded type.  For example, if :math:`T(A_i)` is an
 array of ``int`` and :math:`T(X_i)` is ``int``, then promotion occurs and
 the above rules will be checked with :math:`T(A_i)` == ``int``.
 
+.. index::
+   single: functions;most specific
+   single: functions;resolution;most specific
 .. _Determining_More_Specific_Functions:
-
 .. _Determining_Most_Specific_Functions:
 
 Determining Most Specific Functions
@@ -1707,6 +1842,8 @@ the following function(s) are selected as best functions:
 
 -  only those functions that have a ``where`` clause, otherwise.
 
+.. index::
+   single: functions;return intent overloads
 .. _Choosing_Return_Intent_Overload:
 
 Choosing Return Intent Overloads Based on Calling Context

--- a/doc/rst/language/spec/procedures.rst
+++ b/doc/rst/language/spec/procedures.rst
@@ -2,17 +2,18 @@
 
 .. index::
    single: functions
-   single: functions;call site
+   see: routines; functions
+   see: subroutines; functions
+   single: functions; call site
+   single: functions; actual arguments
+   single: functions; procedure
+   single: functions; operators
+   single: functions; methods
+   single: procedures
+   single: operators; procedures
    single: call site
-   single: functions;formal arguments
    single: formal arguments
-   single: functions;actual arguments
    single: actual arguments
-   single: functions;procedure
-   single: procedure
-   single: functions;operator
-   single: functions;method
-   single: operators;procedure
 .. _Chapter-Procedures:
 
 ==========
@@ -66,10 +67,9 @@ Functions are presented as follows:
    function resolution :ref:`Function_Resolution`
 
 .. index::
-   single: function calls
-   single: calls;function
+   single: calls
+   see: function calls; calls
    single: actual arguments
-   single: functions;actual arguments
 .. _Function_Calls:
 
 Function Calls

--- a/doc/rst/language/spec/ranges.rst
+++ b/doc/rst/language/spec/ranges.rst
@@ -1,5 +1,7 @@
 .. default-domain:: chpl
 
+.. index::
+   single: ranges
 .. _Chapter-Ranges:
 
 Ranges
@@ -29,6 +31,26 @@ Ranges are presented as follows:
 -  predefined functions on ranges
    :ref:`Predefined_Range_Functions`
 
+.. index::
+   single: ranges;concepts
+   single: ranges;represented sequence
+   single: ranges;sequence
+   single: ranges;low bound
+   single: ranges;high bound
+   single: ranges;stride
+   single: ranges;alignment
+   single: ranges;alignment;ambiguous
+   single: ranges;represented sequence;increasing
+   single: ranges;represented sequence;decreasing
+   single: ranges;empty
+   single: ranges;aligned integer
+   single: ranges;alignment;ambiguous
+   single: ranges;first index
+   single: ranges;last index
+   single: ranges;aligned low bound
+   single: ranges;aligned high bound
+   single: ranges;alignment;natural
+   single: ranges;iterable
 .. _Range_Concepts:
 
 Range Concepts
@@ -135,6 +157,14 @@ Ranges have the following additional properties.
 -  The range is *iterable*, that is, it is legal to iterate over it, if
    it has a first index.
 
+.. index::
+   single: ranges;types
+   single: types;range
+   single: ranges;idxType
+   single: ranges;bounds
+   single: ranges;boundKind
+   single: ranges;strides
+   single: ranges;strideKind
 .. _Range_Types:
 
 Range Types
@@ -255,6 +285,8 @@ its parameters, i.e., ``range(int, boundKind.both, strideKind.one)``.
       1..0
       3..13 by 3 align 1
 
+.. index::
+   single: ranges;values
 .. _Range_Values:
 
 Range Values
@@ -264,6 +296,8 @@ A range value consists of the range’s four primary properties
 (:ref:`Range_Concepts`): low bound, high bound, stride and
 alignment.
 
+.. index::
+   single: ranges;literals
 .. _Range_Literals:
 
 Range Literals
@@ -335,6 +369,8 @@ The value of a range literal is as follows:
 
 -  The alignment is 0.
 
+.. index::
+   single: ranges;default values
 .. _Range_Default_Values:
 
 Default Values
@@ -379,6 +415,8 @@ querying the high bound to determine whether or not it is valid.
    ``boundKind.high`` is unstable w.r.t. the value of their
    finite bound.
 
+.. index::
+   single: ranges;operations
 .. _Ranges_Common_Operations:
 
 Common Operations
@@ -401,6 +439,8 @@ existing one. This supports a coding style in which all range values are
    These are the same arguments as were used to justify making strings
    immutable in Java and C#.
 
+.. index::
+   single: ranges;assignment
 .. _Range_Assignment:
 
 Range Assignment
@@ -424,6 +464,8 @@ Range assignment is legal when:
    The ability to assign between two unbounded ranges with
    incompatible idxTypes is deprecated.
 
+.. index::
+   single: ranges;comparisons
 .. _Range_Comparisons:
 
 Range Comparisons
@@ -447,6 +489,9 @@ Ranges can be compared using equality and inequality.
    Returns ``false`` if the two ranges have the same represented sequence or
    the same four primary properties, and ``true`` otherwise.
 
+.. index::
+   single: ranges;iteration
+   single: ranges;iteration;zippered
 .. _Iterating_over_Ranges:
 
 Iterating over Ranges
@@ -523,6 +568,9 @@ loop context, it is equivalent to a bounded range where the omitted
 low/high bound is taken to be the ``false``/``true`` for a ``bool``
 range or the type's initial/final value for an ``enum`` range.
 
+.. index::
+   single: ranges;promotion
+   single: promotion;range
 .. _Range_Promotion_of_Scalar_Functions:
 
 Range Promotion of Scalar Functions
@@ -562,6 +610,8 @@ scalar function as described in :ref:`Promotion`.
       forall (a, i) in zip(A, 1..10) do
         a = addOne(i);
 
+.. index::
+   single: ranges;operators
 .. _Range_Operators:
 
 Range Operators
@@ -582,6 +632,11 @@ of functions that operate on ranges. They are described in
      aligned-range-expression
      sliced-range-expression
 
+.. index::
+   single: ranges;strided
+   single: by;on ranges
+   single: operators;by (range)
+   single: ranges;by operator
 .. _By_Operator_For_Ranges:
 
 By Operator
@@ -681,6 +736,11 @@ following primary properties:
    and high bounds can be clearer when using ranges to slice
    arrays.
 
+.. index::
+   single: ranges;align
+   single: align;on ranges
+   single: operators;align (range)
+   single: ranges;align operator
 .. _Align_Operator_For_Ranges:
 
 Align Operator
@@ -763,6 +823,10 @@ When the stride is negative, the same indices are printed in reverse:
 To set the alignment relative to the range's ``first`` index,
 use the method :proc:`~ChapelRange.range.offset`.
 
+.. index::
+   single: ranges;count operator
+   single: ranges;#
+   single: operators;# (range)
 .. _Count_Operator:
 
 Count Operator
@@ -862,6 +926,9 @@ It is an error if the count is greater than the ``size`` of the range.
    as bounded on both ends regardless of their ``bounds`` parameters.
    This behavior is unstable and might change in the future.
 
+.. index::
+   single: ranges;arithmetic operators
+   single: operators;arithmetic;range
 .. _Range_Arithmetic:
 
 Arithmetic Operators
@@ -917,6 +984,8 @@ resulting range is also unaligned.
    These operators are unstable.
    They may be removed or change behavior in the future.
 
+.. index::
+   single: ranges;slicing
 .. _Range_Slicing:
 
 Range Slicing
@@ -984,11 +1053,18 @@ If the resulting sequence is empty and both operands are unbounded
 in the same direction, it is an error.
 
 
+.. index::
+   single: ranges;predefined functions
 .. _Predefined_Range_Functions:
 
 Predefined Routines on Ranges
 -----------------------------
 
+.. index::
+   single: ranges;type accessors
+   single: ranges;idxType
+   single: ranges;bounds
+   single: ranges;strides
 .. _Range_Type_Accessors:
 
 Range Type Queries

--- a/doc/rst/language/spec/ranges.rst
+++ b/doc/rst/language/spec/ranges.rst
@@ -32,25 +32,25 @@ Ranges are presented as follows:
    :ref:`Predefined_Range_Functions`
 
 .. index::
-   single: ranges;concepts
-   single: ranges;represented sequence
-   single: ranges;sequence
-   single: ranges;low bound
-   single: ranges;high bound
-   single: ranges;stride
-   single: ranges;alignment
-   single: ranges;alignment;ambiguous
-   single: ranges;represented sequence;increasing
-   single: ranges;represented sequence;decreasing
-   single: ranges;empty
-   single: ranges;aligned integer
-   single: ranges;alignment;ambiguous
-   single: ranges;first index
-   single: ranges;last index
-   single: ranges;aligned low bound
-   single: ranges;aligned high bound
-   single: ranges;alignment;natural
-   single: ranges;iterable
+   single: ranges; concepts
+   single: ranges; represented sequence
+   single: ranges; sequence
+   single: ranges; low bound
+   single: ranges; high bound
+   single: ranges; stride
+   single: ranges; alignment
+   single: ranges; alignment;ambiguous
+   single: ranges; represented sequence increasing
+   single: ranges; represented sequence ;decreasing
+   single: ranges; empty
+   single: ranges; aligned integer
+   single: ranges; ambiguous alignment
+   single: ranges; first index
+   single: ranges; last index
+   single: ranges; aligned low bound
+   single: ranges; aligned high bound
+   single: ranges; natural alignment
+   single: ranges; iterable
 .. _Range_Concepts:
 
 Range Concepts
@@ -158,13 +158,12 @@ Ranges have the following additional properties.
    it has a first index.
 
 .. index::
-   single: ranges;types
-   single: types;range
-   single: ranges;idxType
-   single: ranges;bounds
-   single: ranges;boundKind
-   single: ranges;strides
-   single: ranges;strideKind
+   pair: ranges; types
+   single: ranges; idxType
+   single: ranges; bounds
+   single: ranges; boundKind
+   single: ranges; strides
+   single: ranges; strideKind
 .. _Range_Types:
 
 Range Types
@@ -286,7 +285,7 @@ its parameters, i.e., ``range(int, boundKind.both, strideKind.one)``.
       3..13 by 3 align 1
 
 .. index::
-   single: ranges;values
+   single: ranges; values
 .. _Range_Values:
 
 Range Values
@@ -297,7 +296,7 @@ A range value consists of the range’s four primary properties
 alignment.
 
 .. index::
-   single: ranges;literals
+   single: ranges; literals
 .. _Range_Literals:
 
 Range Literals
@@ -370,7 +369,7 @@ The value of a range literal is as follows:
 -  The alignment is 0.
 
 .. index::
-   single: ranges;default values
+   single: ranges; default values
 .. _Range_Default_Values:
 
 Default Values
@@ -416,7 +415,7 @@ querying the high bound to determine whether or not it is valid.
    finite bound.
 
 .. index::
-   single: ranges;operations
+   single: ranges; operations
 .. _Ranges_Common_Operations:
 
 Common Operations
@@ -440,7 +439,7 @@ existing one. This supports a coding style in which all range values are
    immutable in Java and C#.
 
 .. index::
-   single: ranges;assignment
+   single: ranges; assignment
 .. _Range_Assignment:
 
 Range Assignment
@@ -465,7 +464,7 @@ Range assignment is legal when:
    incompatible idxTypes is deprecated.
 
 .. index::
-   single: ranges;comparisons
+   single: ranges; comparisons
 .. _Range_Comparisons:
 
 Range Comparisons
@@ -490,8 +489,8 @@ Ranges can be compared using equality and inequality.
    the same four primary properties, and ``true`` otherwise.
 
 .. index::
-   single: ranges;iteration
-   single: ranges;iteration;zippered
+   pair: ranges; iteration
+   pair: ranges; zippered iteration
 .. _Iterating_over_Ranges:
 
 Iterating over Ranges
@@ -569,8 +568,7 @@ low/high bound is taken to be the ``false``/``true`` for a ``bool``
 range or the type's initial/final value for an ``enum`` range.
 
 .. index::
-   single: ranges;promotion
-   single: promotion;range
+   pair: ranges;promotion
 .. _Range_Promotion_of_Scalar_Functions:
 
 Range Promotion of Scalar Functions
@@ -611,7 +609,7 @@ scalar function as described in :ref:`Promotion`.
         a = addOne(i);
 
 .. index::
-   single: ranges;operators
+   single: ranges; operators
 .. _Range_Operators:
 
 Range Operators
@@ -633,10 +631,10 @@ of functions that operate on ranges. They are described in
      sliced-range-expression
 
 .. index::
-   single: ranges;strided
-   single: by;on ranges
-   single: operators;by (range)
-   single: ranges;by operator
+   single: ranges; strided
+   single: by; on ranges
+   single: operators; by (range)
+   single: ranges; by operator
 .. _By_Operator_For_Ranges:
 
 By Operator
@@ -737,10 +735,10 @@ following primary properties:
    arrays.
 
 .. index::
-   single: ranges;align
-   single: align;on ranges
-   single: operators;align (range)
-   single: ranges;align operator
+   single: ranges; align
+   single: align; on ranges
+   single: operators; align (range)
+   single: ranges; align operator
 .. _Align_Operator_For_Ranges:
 
 Align Operator
@@ -824,9 +822,9 @@ To set the alignment relative to the range's ``first`` index,
 use the method :proc:`~ChapelRange.range.offset`.
 
 .. index::
-   single: ranges;count operator
-   single: ranges;#
-   single: operators;# (range)
+   single: ranges; count operator
+   single: ranges; #
+   single: operators; # (range)
 .. _Count_Operator:
 
 Count Operator
@@ -927,8 +925,8 @@ It is an error if the count is greater than the ``size`` of the range.
    This behavior is unstable and might change in the future.
 
 .. index::
-   single: ranges;arithmetic operators
-   single: operators;arithmetic;range
+   single: ranges; arithmetic operators
+   single: operators; arithmetic range operators
 .. _Range_Arithmetic:
 
 Arithmetic Operators
@@ -985,7 +983,7 @@ resulting range is also unaligned.
    They may be removed or change behavior in the future.
 
 .. index::
-   single: ranges;slicing
+   pair: ranges; slicing
 .. _Range_Slicing:
 
 Range Slicing
@@ -1054,17 +1052,17 @@ in the same direction, it is an error.
 
 
 .. index::
-   single: ranges;predefined functions
+   pair: ranges; predefined functions
 .. _Predefined_Range_Functions:
 
 Predefined Routines on Ranges
 -----------------------------
 
 .. index::
-   single: ranges;type accessors
-   single: ranges;idxType
-   single: ranges;bounds
-   single: ranges;strides
+   single: ranges; type accessors
+   single: ranges; idxType
+   single: ranges; bounds
+   single: ranges; strides
 .. _Range_Type_Accessors:
 
 Range Type Queries

--- a/doc/rst/language/spec/ranges.rst
+++ b/doc/rst/language/spec/ranges.rst
@@ -39,9 +39,9 @@ Ranges are presented as follows:
    single: ranges; high bound
    single: ranges; stride
    single: ranges; alignment
-   single: ranges; alignment;ambiguous
+   single: ranges; ambiguous alignment
    single: ranges; represented sequence increasing
-   single: ranges; represented sequence ;decreasing
+   single: ranges; represented sequence decreasing
    single: ranges; empty
    single: ranges; aligned integer
    single: ranges; ambiguous alignment

--- a/doc/rst/language/spec/records.rst
+++ b/doc/rst/language/spec/records.rst
@@ -747,7 +747,8 @@ like ``int``.
 
 
 .. index::
-   single: records;differences with classes
+   single: records; differences from classes
+   single: classes; differences from records
 .. _Class_and_Record_Differences:
 
 Differences between Classes and Records
@@ -755,8 +756,6 @@ Differences between Classes and Records
 
 The key differences between records and classes are listed below.
 
-.. index::
-   single: records;declarations;differences with classes
 .. _Declaration_Differences:
 
 Declarations
@@ -767,9 +766,6 @@ that they begin with the ``class`` and ``record`` keywords,
 respectively. In contrast to classes, records do not support
 inheritance.
 
-.. index::
-   single: classes;allocation
-   single: records;allocation
 .. _Storage_Allocation_Differences:
 
 Storage Allocation
@@ -787,9 +783,6 @@ associated with the fields in the class, is allocated and reclaimed
 separately from variables referencing that instance. The same class
 instance can be referenced by multiple class variables.
 
-.. index::
-   single: classes;assignment
-   single: records;assignment
 .. _Assignment_Differences:
 
 Assignment
@@ -809,9 +802,6 @@ target record have no effect upon the class instance.
 
 Assignment of a record to a class variable is not permitted.
 
-.. index::
-   single: classes;arguments
-   single: records;arguments
 .. _Argument_Differences:
 
 Arguments
@@ -828,9 +818,6 @@ Records do not provide a counterpart of the ``nil`` value. A variable of
 record type is associated with storage throughout its lifetime, so
 ``nil`` has no meaning with respect to records.
 
-.. index::
-   single: records;delete illegal
-   single: delete;illegal for records
 .. _Record_Delete_Illegal:
 
 The *delete* operator
@@ -838,9 +825,6 @@ The *delete* operator
 
 Calling ``delete`` on a record is illegal.
 
-.. index::
-   single: classes;comparison
-   single: records;comparison
 .. _Comparison_Operator_Differences:
 
 Default Comparison Operators

--- a/doc/rst/language/spec/records.rst
+++ b/doc/rst/language/spec/records.rst
@@ -31,6 +31,10 @@ type.
 A record type is generic if it contains generic fields. Generic record
 types are discussed in detail in :ref:`Generic_Types`.
 
+.. index::
+   single: records;declarations
+   single: declarations;records
+   single: record
 .. _Record_Declarations:
 
 Record Declarations
@@ -83,6 +87,10 @@ external records.
     as discussion is needed regarding its impact on inheritance, for
     instance.
 
+.. index::
+   single: records;record types
+   single: records;types
+   single: types;records
 .. _Record_Types:
 
 Record Types
@@ -105,6 +113,9 @@ specify the type. Generic records must be instantiated to serve as a
 fully-specified type, for example to declare a variable. This is done
 with type constructors, which are defined in Section :ref:`Type_Constructors`.
 
+.. index::
+   single: records;fields
+   single: fields;records
 .. _Record_Fields:
 
 Record Fields
@@ -132,6 +143,9 @@ storage associated with a record.
    contained by an instance of the ``Actor`` class defined in the
    preceding chapter :ref:`Class_Fields`.
 
+.. index::
+   single: records;methods
+   single: methods;records
 .. _Record_Methods:
 
 Record Methods
@@ -145,6 +159,9 @@ The receiver of a record method is passed by ``const`` intent by default.
 A method that modifies ``this`` must declare an explicit ``this-intent`` of
 ``ref``, see :ref:`Method_receiver_and_this`.
 
+.. index::
+   single: nested records
+   single: records;nested
 .. _Nested_Record_Types:
 
 Nested Record Types
@@ -154,6 +171,9 @@ A record defined within another class or record is a nested record. A
 nested record can be referenced only within its immediately enclosing
 class or record.
 
+.. index::
+   single: records;variable declarations
+   single: variables;records
 .. _Record_Variable_Declarations:
 
 Record Variable Declarations
@@ -174,6 +194,8 @@ record type. The record variable is initialized with a call to an
 initializer (:ref:`Class_Initializers`) that accepts zero actual
 arguments.
 
+.. index::
+   single: records;allocation
 .. _Record_Storage:
 
 Storage Allocation
@@ -194,6 +216,9 @@ elements elsewhere (see
 Record storage is reclaimed automatically. See :ref:`Variable_Lifetimes`
 for details on when a record becomes dead.
 
+.. index::
+   single: records;initialization
+   single: initialization;record
 .. _Record_Initialization:
 
 Record Initialization
@@ -272,6 +297,9 @@ As with classes, the user can provide their own initializers
 initializers are supplied, the default initializer cannot be called
 directly.
 
+.. index::
+   single: records;deinitializer
+   single: deinitializer;records
 .. _Record_Deinitializer:
 
 Record Deinitializer
@@ -323,6 +351,9 @@ out of scope and before its memory is reclaimed.
 
       --memLeaksByType
 
+.. index::
+   single: records;arguments
+   single: arguments;records
 .. _Record_Arguments:
 
 Record Arguments
@@ -374,6 +405,9 @@ by the record assignment function (:ref:`Record_Assignment`).
    by the assignment in ``modifyMyColor`` because the intent ``inout``
    is used.
 
+.. index::
+   single: records;field access
+   single: field access
 .. _Record_Field_Access:
 
 Record Field Access
@@ -388,6 +422,8 @@ Accessing a parameter or type field returns a parameter or type,
 respectively. Also, parameter and type fields can be accessed from an
 instantiated record type in addition to from a record value.
 
+.. index::
+   single: records;getters
 .. _Field_Getter_Methods:
 
 Field Getter Methods
@@ -398,6 +434,9 @@ As in classes, field accesses are performed via getter methods
 a reference to the specified field (so they can be written as well as
 read). The user may redefine these as needed.
 
+.. index::
+   single: records;method calls
+   single: method calls
 .. _Record_Method_Access:
 
 Record Method Calls
@@ -412,6 +451,8 @@ always resolved at compile time.
 Common Operations
 -----------------
 
+.. index::
+   single: records;copy initialization
 .. _Copy_Initialization_of_Records:
 
 Copy Initialization of Records
@@ -558,6 +599,8 @@ declaration:
   var A : Wrapper(int) = 4;
   var B : Wrapper(string) = "hello";
 
+.. index::
+   single: records;assignment
 .. _Record_Assignment:
 
 Record Assignment
@@ -621,6 +664,13 @@ The following example demonstrates record assignment.
    entities, rather than two references to the same object. Assigning
    ``3.14`` to ``C.x`` does not affect the ``x`` field in ``A``.
 
+.. index::
+   single: records;equality
+   single: records;inequality
+   single: records;==
+   single: records;!=
+   single: == (record)
+   single: != (record)
 .. _Record_Comparison_Operators:
 
 Default Comparison Operators
@@ -696,6 +746,8 @@ like ``int``.
 
 
 
+.. index::
+   single: records;differences with classes
 .. _Class_and_Record_Differences:
 
 Differences between Classes and Records
@@ -703,6 +755,8 @@ Differences between Classes and Records
 
 The key differences between records and classes are listed below.
 
+.. index::
+   single: records;declarations;differences with classes
 .. _Declaration_Differences:
 
 Declarations
@@ -713,6 +767,9 @@ that they begin with the ``class`` and ``record`` keywords,
 respectively. In contrast to classes, records do not support
 inheritance.
 
+.. index::
+   single: classes;allocation
+   single: records;allocation
 .. _Storage_Allocation_Differences:
 
 Storage Allocation
@@ -730,6 +787,9 @@ associated with the fields in the class, is allocated and reclaimed
 separately from variables referencing that instance. The same class
 instance can be referenced by multiple class variables.
 
+.. index::
+   single: classes;assignment
+   single: records;assignment
 .. _Assignment_Differences:
 
 Assignment
@@ -749,6 +809,9 @@ target record have no effect upon the class instance.
 
 Assignment of a record to a class variable is not permitted.
 
+.. index::
+   single: classes;arguments
+   single: records;arguments
 .. _Argument_Differences:
 
 Arguments
@@ -765,6 +828,9 @@ Records do not provide a counterpart of the ``nil`` value. A variable of
 record type is associated with storage throughout its lifetime, so
 ``nil`` has no meaning with respect to records.
 
+.. index::
+   single: records;delete illegal
+   single: delete;illegal for records
 .. _Record_Delete_Illegal:
 
 The *delete* operator
@@ -772,6 +838,9 @@ The *delete* operator
 
 Calling ``delete`` on a record is illegal.
 
+.. index::
+   single: classes;comparison
+   single: records;comparison
 .. _Comparison_Operator_Differences:
 
 Default Comparison Operators

--- a/doc/rst/language/spec/records.rst
+++ b/doc/rst/language/spec/records.rst
@@ -32,8 +32,8 @@ A record type is generic if it contains generic fields. Generic record
 types are discussed in detail in :ref:`Generic_Types`.
 
 .. index::
-   single: records;declarations
-   single: declarations;records
+   single: records; declarations
+   single: declarations; records
    single: record
 .. _Record_Declarations:
 
@@ -88,9 +88,8 @@ external records.
     instance.
 
 .. index::
-   single: records;record types
-   single: records;types
-   single: types;records
+   single: records; record types
+   pair: records; types
 .. _Record_Types:
 
 Record Types
@@ -114,8 +113,7 @@ fully-specified type, for example to declare a variable. This is done
 with type constructors, which are defined in Section :ref:`Type_Constructors`.
 
 .. index::
-   single: records;fields
-   single: fields;records
+   pair: records; fields
 .. _Record_Fields:
 
 Record Fields
@@ -144,8 +142,7 @@ storage associated with a record.
    preceding chapter :ref:`Class_Fields`.
 
 .. index::
-   single: records;methods
-   single: methods;records
+   pair: records; methods
 .. _Record_Methods:
 
 Record Methods
@@ -161,7 +158,7 @@ A method that modifies ``this`` must declare an explicit ``this-intent`` of
 
 .. index::
    single: nested records
-   single: records;nested
+   single: records; nested
 .. _Nested_Record_Types:
 
 Nested Record Types
@@ -172,8 +169,8 @@ nested record can be referenced only within its immediately enclosing
 class or record.
 
 .. index::
-   single: records;variable declarations
-   single: variables;records
+   single: records; variable declarations
+   single: variables; records
 .. _Record_Variable_Declarations:
 
 Record Variable Declarations
@@ -195,7 +192,7 @@ initializer (:ref:`Class_Initializers`) that accepts zero actual
 arguments.
 
 .. index::
-   single: records;allocation
+   single: records; allocation
 .. _Record_Storage:
 
 Storage Allocation
@@ -217,8 +214,8 @@ Record storage is reclaimed automatically. See :ref:`Variable_Lifetimes`
 for details on when a record becomes dead.
 
 .. index::
-   single: records;initialization
-   single: initialization;record
+   single: records; initialization
+   single: initialization; record
 .. _Record_Initialization:
 
 Record Initialization
@@ -298,8 +295,8 @@ initializers are supplied, the default initializer cannot be called
 directly.
 
 .. index::
-   single: records;deinitializer
-   single: deinitializer;records
+   single: records; deinitializer
+   single: deinitializer; records
 .. _Record_Deinitializer:
 
 Record Deinitializer
@@ -352,8 +349,8 @@ out of scope and before its memory is reclaimed.
       --memLeaksByType
 
 .. index::
-   single: records;arguments
-   single: arguments;records
+   single: records; arguments
+   single: arguments; records
 .. _Record_Arguments:
 
 Record Arguments
@@ -406,7 +403,7 @@ by the record assignment function (:ref:`Record_Assignment`).
    is used.
 
 .. index::
-   single: records;field access
+   single: records; field access
    single: field access
 .. _Record_Field_Access:
 
@@ -423,7 +420,7 @@ respectively. Also, parameter and type fields can be accessed from an
 instantiated record type in addition to from a record value.
 
 .. index::
-   single: records;getters
+   single: records; getters
 .. _Field_Getter_Methods:
 
 Field Getter Methods
@@ -435,7 +432,7 @@ a reference to the specified field (so they can be written as well as
 read). The user may redefine these as needed.
 
 .. index::
-   single: records;method calls
+   single: records; method calls
    single: method calls
 .. _Record_Method_Access:
 
@@ -452,7 +449,7 @@ Common Operations
 -----------------
 
 .. index::
-   single: records;copy initialization
+   pair: records; copy initialization
 .. _Copy_Initialization_of_Records:
 
 Copy Initialization of Records
@@ -600,7 +597,7 @@ declaration:
   var B : Wrapper(string) = "hello";
 
 .. index::
-   single: records;assignment
+   pair: records; assignment
 .. _Record_Assignment:
 
 Record Assignment
@@ -665,10 +662,10 @@ The following example demonstrates record assignment.
    ``3.14`` to ``C.x`` does not affect the ``x`` field in ``A``.
 
 .. index::
-   single: records;equality
-   single: records;inequality
-   single: records;==
-   single: records;!=
+   single: records; equality
+   single: records; inequality
+   single: records; ==
+   single: records; !=
    single: == (record)
    single: != (record)
 .. _Record_Comparison_Operators:

--- a/doc/rst/language/spec/statements.rst
+++ b/doc/rst/language/spec/statements.rst
@@ -1,5 +1,7 @@
 .. default-domain:: chpl
 
+.. index::
+   single: statement
 .. _Chapter-Statements:
 
 ==========
@@ -93,6 +95,8 @@ additionally as follows:
 
 -  manage :ref:`The_Manage_Statement`
 
+.. index::
+   single: block
 .. _Blocks:
 
 Blocks
@@ -116,6 +120,10 @@ variables (:ref:`Local_Variables`).
 The statements within a block are executed serially unless the block is
 in a cobegin statement (:ref:`Cobegin`).
 
+.. index::
+   single: expressions;statement
+   single: expression statement
+   single: statements;expression
 .. _Expression_Statements:
 
 Expression Statements
@@ -133,6 +141,28 @@ effects. The syntax for an expression statement is given by
      new-expression ;
      let-expression ;
 
+.. index::
+   single: assignment
+   single: statements;assignment
+   single: =
+   single: +=
+   single: -=
+   single: *=
+   single: /=
+   single: %=
+   single: **=
+   single: &=
+   single: |=
+   single: ^=
+   single: ||=
+   single: &&=
+   single: <<=
+   single: >>=
+   single: operators;assignment
+   single: operators;compound assignment
+   single: operators;assignment;compound
+   single: operators;simple assignment
+   single: operators;assignment;simple
 .. _Assignment_Statements:
 
 Assignment Statements
@@ -211,6 +241,12 @@ the left-hand side expression should have ``ref`` intent and be modified
 within the body of the function. The return type of the function should
 be ``void``.
 
+.. index::
+   single: swap;statement
+   single: statements;swap
+   single: swap;operator
+   single: operators;swap
+   single: <=>
 .. _The_Swap_Statement:
 
 The Swap Statement
@@ -254,6 +290,13 @@ as necessary.
       b = a;
       a = t;
 
+.. index::
+   single: statements;conditional
+   single: if
+   single: then
+   single: else
+   single: conditional statements
+   single: conditional statement;dangling else
 .. _The_Conditional_Statement:
 
 The Conditional Statement
@@ -351,6 +394,13 @@ statement, too.
       B,other
       A,other
 
+.. index::
+   single: select
+   single: when
+   single: otherwise
+   single: statements;select
+   single: statements;when
+   single: statements;otherwise
 .. _The_Select_Statement:
 
 The Select Statement
@@ -395,6 +445,10 @@ Each statement embedded in the *when-statement* or the
 *otherwise-statement* has its own scope whether or not an explicit block
 surrounds it.
 
+.. index::
+   single: while loops
+   single: while
+   single: statements;while
 .. _The_While_and_Do_While_Loops:
 
 The While Do and Do While Loops
@@ -527,6 +581,10 @@ Otherwise the variable stores a borrow of the expression's value
 The variable can be modified within the loop body if it is declared
 with the ``var`` keyword.
 
+.. index::
+   single: for loops
+   single: for
+   single: statements;for
 .. _The_For_Loop:
 
 The For Loop
@@ -566,6 +624,9 @@ If the iteratable-expression begins with the keyword ``zip`` followed by
 a parenthesized expression-list, the listed expressions must support
 zippered iteration.
 
+.. index::
+   single: zipper iteration
+   single: iteration;zipper
 .. _Zippered_Iteration:
 
 Zippered Iteration
@@ -604,6 +665,11 @@ support iteration over a 2D `m` x `n` space as well.
 
       1 4 2 5 3 6 
 
+.. index::
+   single: statements;param for
+   single: for loops;parameters
+   single: for
+   single: param
 .. _Parameter_For_Loops:
 
 Parameter For Loops
@@ -627,6 +693,14 @@ Parameter for loops are restricted to iteration over range literals with
 an optional by expression where the bounds and stride must be
 parameters. The loop is then unrolled for each iteration.
 
+.. index::
+   single: statements;jumps
+   single: label
+   single: break
+   single: continue
+   single: statements;label
+   single: statements;break
+   single: statements;continue
 .. _Label_Break_Continue:
 
 The Break, Continue and Label Statements
@@ -700,6 +774,9 @@ A ``break`` statement cannot be used to exit a parallel loop
         }
       }
 
+.. index::
+   single: require
+   single: statements;require
 .. _The_Require_statement:
 
 The Require Statement
@@ -770,6 +847,11 @@ depending on the value of *requireFoo*:
          require defaultHeader;
 
 
+.. index::
+   single: use
+   single: statements;use
+   single: modules;using
+   single: types;enumerated;using
 .. _The_Use_Statement:
 
 The Use Statement
@@ -805,6 +887,9 @@ within the scope.  For further information about ``import`` statements, see
 
 For more information on modules in general, please see :ref:`Chapter-Modules`.
 
+.. index::
+   single: defer
+   single: statements;defer
 .. _The_Defer_Statement:
 
 The Defer Statement
@@ -1012,6 +1097,8 @@ cleanup action run.
       Condition: true
       Inside if
 
+.. index::
+   single: statements;empty
 .. _The_Empty_Statement:
 
 The Empty Statement

--- a/doc/rst/language/spec/statements.rst
+++ b/doc/rst/language/spec/statements.rst
@@ -158,11 +158,9 @@ effects. The syntax for an expression statement is given by
    single: &&=
    single: <<=
    single: >>=
-   single: operators;assignment
-   single: operators;compound assignment
-   single: operators;assignment;compound
-   single: operators;simple assignment
-   single: operators;assignment;simple
+   single: operators; assignment
+   single: operators; compound assignment
+   single: operators; simple assignment
 .. _Assignment_Statements:
 
 Assignment Statements

--- a/doc/rst/language/spec/statements.rst
+++ b/doc/rst/language/spec/statements.rst
@@ -121,9 +121,9 @@ The statements within a block are executed serially unless the block is
 in a cobegin statement (:ref:`Cobegin`).
 
 .. index::
-   single: expressions;statement
+   single: expressions; statement
    single: expression statement
-   single: statements;expression
+   single: statements; expression
 .. _Expression_Statements:
 
 Expression Statements
@@ -143,7 +143,7 @@ effects. The syntax for an expression statement is given by
 
 .. index::
    single: assignment
-   single: statements;assignment
+   single: statements; assignment
    single: =
    single: +=
    single: -=
@@ -242,10 +242,10 @@ within the body of the function. The return type of the function should
 be ``void``.
 
 .. index::
-   single: swap;statement
-   single: statements;swap
-   single: swap;operator
-   single: operators;swap
+   single: swap; statement
+   single: statements; swap
+   single: swap; operator
+   single: operators; swap
    single: <=>
 .. _The_Swap_Statement:
 
@@ -291,12 +291,12 @@ as necessary.
       a = t;
 
 .. index::
-   single: statements;conditional
+   single: statements; conditional
    single: if
    single: then
    single: else
    single: conditional statements
-   single: conditional statement;dangling else
+   single: conditional statement; dangling else
 .. _The_Conditional_Statement:
 
 The Conditional Statement
@@ -398,9 +398,9 @@ statement, too.
    single: select
    single: when
    single: otherwise
-   single: statements;select
-   single: statements;when
-   single: statements;otherwise
+   single: statements; select
+   single: statements; when
+   single: statements; otherwise
 .. _The_Select_Statement:
 
 The Select Statement
@@ -448,7 +448,7 @@ surrounds it.
 .. index::
    single: while loops
    single: while
-   single: statements;while
+   single: statements; while
 .. _The_While_and_Do_While_Loops:
 
 The While Do and Do While Loops
@@ -584,7 +584,7 @@ with the ``var`` keyword.
 .. index::
    single: for loops
    single: for
-   single: statements;for
+   single: statements; for
 .. _The_For_Loop:
 
 The For Loop
@@ -625,8 +625,8 @@ a parenthesized expression-list, the listed expressions must support
 zippered iteration.
 
 .. index::
-   single: zipper iteration
-   single: iteration;zipper
+   single: zippered iteration
+   single: iteration; zippered
 .. _Zippered_Iteration:
 
 Zippered Iteration
@@ -666,10 +666,9 @@ support iteration over a 2D `m` x `n` space as well.
       1 4 2 5 3 6 
 
 .. index::
-   single: statements;param for
-   single: for loops;parameters
-   single: for
-   single: param
+   single: statements; param for
+   single: for loops; param
+   pair: for; param
 .. _Parameter_For_Loops:
 
 Parameter For Loops
@@ -694,13 +693,13 @@ an optional by expression where the bounds and stride must be
 parameters. The loop is then unrolled for each iteration.
 
 .. index::
-   single: statements;jumps
+   single: statements; jumps
    single: label
    single: break
    single: continue
-   single: statements;label
-   single: statements;break
-   single: statements;continue
+   single: statements; label
+   single: statements; break
+   single: statements; continue
 .. _Label_Break_Continue:
 
 The Break, Continue and Label Statements
@@ -776,7 +775,7 @@ A ``break`` statement cannot be used to exit a parallel loop
 
 .. index::
    single: require
-   single: statements;require
+   single: statements; require
 .. _The_Require_statement:
 
 The Require Statement
@@ -849,9 +848,9 @@ depending on the value of *requireFoo*:
 
 .. index::
    single: use
-   single: statements;use
-   single: modules;using
-   single: types;enumerated;using
+   single: statements; use
+   single: modules; using
+   single: enumerated types; using
 .. _The_Use_Statement:
 
 The Use Statement
@@ -869,6 +868,10 @@ see :ref:`Using_Modules`.  For more information on enumerated types, please
 see :ref:`Enumerated_Types`.  For more information on modules in general, please
 see :ref:`Chapter-Modules`.
 
+.. index::
+   single: import
+   single: statements; import
+   single: modules; importing
 .. _The_Import_Statement:
 
 The Import Statement
@@ -889,7 +892,7 @@ For more information on modules in general, please see :ref:`Chapter-Modules`.
 
 .. index::
    single: defer
-   single: statements;defer
+   single: statements; defer
 .. _The_Defer_Statement:
 
 The Defer Statement
@@ -1098,7 +1101,7 @@ cleanup action run.
       Inside if
 
 .. index::
-   single: statements;empty
+   single: statements; empty
 .. _The_Empty_Statement:
 
 The Empty Statement

--- a/doc/rst/language/spec/strings.rst
+++ b/doc/rst/language/spec/strings.rst
@@ -1,5 +1,8 @@
 .. default-domain:: chpl
 
+.. index::
+   single: string
+   single: types; string
 .. _Chapter-Strings:
 
 =======

--- a/doc/rst/language/spec/task-parallelism-and-synchronization.rst
+++ b/doc/rst/language/spec/task-parallelism-and-synchronization.rst
@@ -46,11 +46,12 @@ details task parallelism as follows:
 
 .. index::
    single: task parallelism
-   single: parallelism;task
-   single: task parallelism;task creation
+   single: parallelism; task
+   single: task parallelism; task creation
    single: task creation
    single: task function
-   single: task parallelism;task function
+   single: task parallelism; task function
+   single: tasks
 .. _Task_parallelism:
 
 Tasks and Task Parallelism
@@ -93,7 +94,7 @@ task intents, among others.
 
 .. index::
    single: begin
-   single: statements;begin
+   single: statements; begin
 .. _Begin:
 
 The Begin Statement
@@ -152,12 +153,11 @@ Yield and return statements are not allowed in begin blocks. Break and
 continue statements may not be used to exit a begin block.
 
 .. index::
-   single: synchronization variables;sync
-   single: synchronization variables;sync
    single: sync
    single: single
-   single: synchronization types;formal arguments
-   single: synchronization types;actual arguments
+   single: synchronization variables; sync
+   single: synchronization types; formal arguments
+   single: synchronization types; actual arguments
 .. _Synchronization_Variables:
 
 Synchronization Variables
@@ -306,6 +306,8 @@ state is not changed or waited on. The qualifier ``sync`` without the
 value type can be used to specify a generic formal argument that
 requires a ``sync`` actual.
 
+.. index::
+   pair: sync; predefined functions
 .. _Functions_on_Synchronization_Variables:
 
 Predefined Sync Methods
@@ -316,8 +318,9 @@ The following methods are defined for variables of ``sync`` type:
 .. include:: /builtins/ChapelSyncvar.rst
 
 .. index::
-   single: atomic variables;atomic
+   single: atomic variables; atomic
    single: atomic
+   pair: atomic; predefined functions
 .. _Atomic_Variables:
 .. _Functions_on_Atomic_Variables:
 
@@ -338,7 +341,7 @@ by the following syntax:
 
 .. index::
    single: cobegin
-   single: statements;cobegin
+   single: statements; cobegin
 .. _Cobegin:
 
 The Cobegin Statement
@@ -402,7 +405,7 @@ statements may not be used to exit a cobegin block.
 
 .. index::
    single: coforall
-   single: statements;coforall
+   single: statements; coforall
 .. _Coforall:
 
 The Coforall Loop
@@ -483,8 +486,8 @@ statements may not be used to exit a coforall block.
 
 .. index::
    single: task intents
-   single: task parallelism;task functions
-   single: task parallelism;task intents
+   single: task parallelism; task functions
+   single: task parallelism; task intents
 .. _Task_Intents:
 
 Task Intents
@@ -656,7 +659,7 @@ subject to such treatment within nested task constructs, if any.
 
 .. index::
    single: sync
-   single: statements;sync
+   single: statements; sync
 .. _Sync_Statement:
 
 The Sync Statement
@@ -747,7 +750,7 @@ continue statements may not be used to exit a sync statement block.
 
 .. index::
    single: serial
-   single: statements;serial
+   single: statements; serial
 .. _Serial:
 
 The Serial Statement

--- a/doc/rst/language/spec/task-parallelism-and-synchronization.rst
+++ b/doc/rst/language/spec/task-parallelism-and-synchronization.rst
@@ -1,5 +1,7 @@
 .. default-domain:: chpl
 
+.. index::
+   single: synchronization
 .. _Chapter-Task_Parallelism_and_Synchronization:
 
 ====================================
@@ -42,6 +44,13 @@ details task parallelism as follows:
     execution.
 
 
+.. index::
+   single: task parallelism
+   single: parallelism;task
+   single: task parallelism;task creation
+   single: task creation
+   single: task function
+   single: task parallelism;task function
 .. _Task_parallelism:
 
 Tasks and Task Parallelism
@@ -82,6 +91,9 @@ Memory Consistency Model
 accesses can result from aliasing due to ``ref`` argument intents or
 task intents, among others.
 
+.. index::
+   single: begin
+   single: statements;begin
 .. _Begin:
 
 The Begin Statement
@@ -139,6 +151,13 @@ task function and the role of ``task-intent-clause`` are defined in
 Yield and return statements are not allowed in begin blocks. Break and
 continue statements may not be used to exit a begin block.
 
+.. index::
+   single: synchronization variables;sync
+   single: synchronization variables;sync
+   single: sync
+   single: single
+   single: synchronization types;formal arguments
+   single: synchronization types;actual arguments
 .. _Synchronization_Variables:
 
 Synchronization Variables
@@ -296,6 +315,9 @@ The following methods are defined for variables of ``sync`` type:
 
 .. include:: /builtins/ChapelSyncvar.rst
 
+.. index::
+   single: atomic variables;atomic
+   single: atomic
 .. _Atomic_Variables:
 .. _Functions_on_Atomic_Variables:
 
@@ -314,6 +336,9 @@ by the following syntax:
 
 .. include:: /builtins/Atomics.rst
 
+.. index::
+   single: cobegin
+   single: statements;cobegin
 .. _Cobegin:
 
 The Cobegin Statement
@@ -375,6 +400,9 @@ statements may not be used to exit a cobegin block.
    continue past the final line above until each of the sync variables
    is written, thereby ensuring that each of the functions has finished.
 
+.. index::
+   single: coforall
+   single: statements;coforall
 .. _Coforall:
 
 The Coforall Loop
@@ -453,6 +481,10 @@ statements may not be used to exit a coforall block.
    tasks have completed. Thus control does not continue past the last
    line until all of the tasks have completed.
 
+.. index::
+   single: task intents
+   single: task parallelism;task functions
+   single: task parallelism;task intents
 .. _Task_Intents:
 
 Task Intents
@@ -622,6 +654,9 @@ subject to such treatment within nested task constructs, if any.
       which would apply the intent to all variables. An example of syntax
       for a blanket ``ref`` intent would be ``ref *``.
 
+.. index::
+   single: sync
+   single: statements;sync
 .. _Sync_Statement:
 
 The Sync Statement
@@ -710,6 +745,9 @@ continue statements may not be used to exit a sync statement block.
    wait for these begin statements to complete whereas the latter code
    will not.
 
+.. index::
+   single: serial
+   single: statements;serial
 .. _Serial:
 
 The Serial Statement

--- a/doc/rst/language/spec/tuples.rst
+++ b/doc/rst/language/spec/tuples.rst
@@ -1,5 +1,7 @@
 .. default-domain:: chpl
 
+.. index::
+   single: tuples
 .. _Chapter-Tuples:
 
 ======
@@ -13,6 +15,11 @@ addition to making it easy to return multiple values from a function,
 tuples help to support multidimensional indices, to group arguments to
 functions, and to specify mathematical concepts.
 
+.. index::
+   single: tuples;types
+   single: types;tuple
+   single: tuples;homogeneous
+   single: types;* (tuples)
 .. _Tuple_Types:
 
 Tuple Types
@@ -93,6 +100,9 @@ operator since every 1-tuple is trivially a homogeneous tuple.
    integers. The type ``3*3*int``, on the other hand, specifies a
    9-tuple of integers.
 
+.. index::
+   single: tuples;values
+   single: values;tuple
 .. _Tuple_Values:
 
 Tuple Values
@@ -179,6 +189,8 @@ When a tuple is passed as an argument to a function, it is passed as if
 it is a record type containing fields of the same type and in the same
 order as in the tuple.
 
+.. index::
+   single: tuples;indexing
 .. _Tuple_Indexing:
 
 Tuple Indexing
@@ -237,6 +249,9 @@ necessarily compile-time constants.
    Non-homogeneous tuples can only be accessed by compile-time constants
    since the type of an expression must be statically known.
 
+.. index::
+   single: tuples;iteration
+   single: iteration;tuple
 .. _Iteration_over_Tuples:
 
 Iteration over Tuples
@@ -301,6 +316,9 @@ equivalent to:
 Similarly, a `coforall` loop is equivalent to the `cobegin` statement
 whose body is the series of compound statements from the serial case.
 
+.. index::
+   single: assignment;tuple
+   single: tuples;assignment
 .. _Tuple_Assignment:
 
 Tuple Assignment
@@ -311,6 +329,8 @@ of the assignment operator are each assigned the components of the tuple
 on the right-hand side of the assignment. These assignments occur in
 component order (component zero followed by component one, etc.).
 
+.. index::
+   single: tuples;destructuring
 .. _Tuple_Destructuring:
 
 Tuple Destructuring
@@ -334,6 +354,9 @@ Tuples can be split into their components in the following ways:
    expressions where a tuple expression is expanded in place using the
    tuple expansion expression.
 
+.. index::
+   single: tuples;assignments grouped as
+   single: tuples;omitting components
 .. _Assignments_in_a_Tuple:
 
 Splitting a Tuple with Assignment
@@ -423,6 +446,9 @@ evaluated, but the omitted values will not be assigned to anything.
 
       1
 
+.. index::
+   single: tuples;variable declarations grouped as
+   single: tuples;omitting components
 .. _Variable_Declarations_in_a_Tuple:
 
 Splitting a Tuple in a Declaration
@@ -508,6 +534,9 @@ defined for the omitted components.
 
       1
 
+.. index::
+   single: tuples;indices grouped as
+   single: tuples;omitting components
 .. _Indices_in_a_Tuple:
 
 Splitting a Tuple into Multiple Indices of a Loop
@@ -551,6 +580,9 @@ present but invisible. This means that the loop body controlled by the
 iterator may be executed multiple times with the same set of (visible)
 indices.
 
+.. index::
+   single: tuples;formal arguments grouped as
+   single: tuples;omitting components
 .. _Formal_Argument_Declarations_in_a_Tuple:
 
 Splitting a Tuple into Multiple Formal Arguments in a Function Call
@@ -650,6 +682,9 @@ that are grouped using the tuple notation may be omitted. In this case,
 no names are associated with the omitted components. The call is
 evaluated as if an argument were defined.
 
+.. index::
+   single: ... (tuple expansion)
+   single: tuples;expanding in place
 .. _Tuple_Expansion:
 
 Splitting a Tuple via Tuple Expansion
@@ -1040,11 +1075,15 @@ An iterator with the default or ``const`` yield intent may yield
 using the semantics of either the ``out`` or ``const ref`` yield intent,
 in an implementation-defined manner.
 
+.. index::
+   single: tuples;operators
 .. _Tuple_Operators:
 
 Tuple Operators
 ---------------
 
+.. index::
+   single: operators;tuple;unary
 .. _Tuple_Unary_Operators:
 
 Unary Operators
@@ -1083,6 +1122,19 @@ element type is a user-defined type, it must supply an overloaded
 definition for the unary operator being used. Otherwise, a compile-time
 error will be issued.
 
+.. index::
+   single: operators;tuple;binary
+   single: +
+   single: -
+   single: *
+   single: /
+   single: %
+   single: **
+   single: &
+   single: |
+   single: ^
+   single: <<
+   single: >>
 .. _Tuple_Binary_Operators:
 
 Binary Operators
@@ -1124,6 +1176,14 @@ result.
 
       (3, 3.0, 12)
 
+.. index::
+   single: operators;tuple;relational
+   single: >
+   single: >=
+   single: <
+   single: <=
+   single: ==
+   single: !=
 .. _Tuple_Relational_Operators:
 
 Relational Operators
@@ -1167,6 +1227,20 @@ in the two operand tuples. Otherwise, a compile-time error will result.
 
       true
 
+.. index::
+   single: tuples;predefined functions
+   single: predefined functions;tuples
+   single: functions;tuples;predefined
+   single: tuples;isTuple
+   single: predefined functions;isTuple
+   single: tuples;isTupleType
+   single: predefined functions;isTupleType
+   single: tuples;max
+   single: predefined functions;max
+   single: tuples;min
+   single: predefined functions;min
+   single: tuples;size
+   single: predefined functions;size
 .. _Predefined_Functions_and_Methods_on_Tuples:
 
 Predefined Routines on Tuples

--- a/doc/rst/language/spec/tuples.rst
+++ b/doc/rst/language/spec/tuples.rst
@@ -16,10 +16,9 @@ tuples help to support multidimensional indices, to group arguments to
 functions, and to specify mathematical concepts.
 
 .. index::
-   single: tuples;types
-   single: types;tuple
-   single: tuples;homogeneous
-   single: types;* (tuples)
+   pair: tuples; types
+   single: tuples; homogeneous
+   single: types; * (tuples)
 .. _Tuple_Types:
 
 Tuple Types
@@ -101,8 +100,7 @@ operator since every 1-tuple is trivially a homogeneous tuple.
    9-tuple of integers.
 
 .. index::
-   single: tuples;values
-   single: values;tuple
+   pair: tuples;values
 .. _Tuple_Values:
 
 Tuple Values
@@ -190,7 +188,7 @@ it is a record type containing fields of the same type and in the same
 order as in the tuple.
 
 .. index::
-   single: tuples;indexing
+   pair: tuples; indexing
 .. _Tuple_Indexing:
 
 Tuple Indexing
@@ -250,8 +248,7 @@ necessarily compile-time constants.
    since the type of an expression must be statically known.
 
 .. index::
-   single: tuples;iteration
-   single: iteration;tuple
+   pair: tuples; iteration
 .. _Iteration_over_Tuples:
 
 Iteration over Tuples
@@ -317,8 +314,7 @@ Similarly, a `coforall` loop is equivalent to the `cobegin` statement
 whose body is the series of compound statements from the serial case.
 
 .. index::
-   single: assignment;tuple
-   single: tuples;assignment
+   pair: assignment; tuples
 .. _Tuple_Assignment:
 
 Tuple Assignment
@@ -330,7 +326,7 @@ on the right-hand side of the assignment. These assignments occur in
 component order (component zero followed by component one, etc.).
 
 .. index::
-   single: tuples;destructuring
+   single: tuples; destructuring
 .. _Tuple_Destructuring:
 
 Tuple Destructuring
@@ -355,8 +351,8 @@ Tuples can be split into their components in the following ways:
    tuple expansion expression.
 
 .. index::
-   single: tuples;assignments grouped as
-   single: tuples;omitting components
+   single: tuples; assignments grouped as
+   single: tuples; omitting components
 .. _Assignments_in_a_Tuple:
 
 Splitting a Tuple with Assignment
@@ -447,8 +443,8 @@ evaluated, but the omitted values will not be assigned to anything.
       1
 
 .. index::
-   single: tuples;variable declarations grouped as
-   single: tuples;omitting components
+   single: tuples; variable declarations grouped as
+   single: tuples; omitting components
 .. _Variable_Declarations_in_a_Tuple:
 
 Splitting a Tuple in a Declaration
@@ -535,8 +531,8 @@ defined for the omitted components.
       1
 
 .. index::
-   single: tuples;indices grouped as
-   single: tuples;omitting components
+   single: tuples; indices grouped as
+   single: tuples; omitting components
 .. _Indices_in_a_Tuple:
 
 Splitting a Tuple into Multiple Indices of a Loop
@@ -581,8 +577,8 @@ iterator may be executed multiple times with the same set of (visible)
 indices.
 
 .. index::
-   single: tuples;formal arguments grouped as
-   single: tuples;omitting components
+   single: tuples; formal arguments grouped as
+   single: tuples; omitting components
 .. _Formal_Argument_Declarations_in_a_Tuple:
 
 Splitting a Tuple into Multiple Formal Arguments in a Function Call
@@ -684,7 +680,7 @@ evaluated as if an argument were defined.
 
 .. index::
    single: ... (tuple expansion)
-   single: tuples;expanding in place
+   single: tuples; expanding in place
 .. _Tuple_Expansion:
 
 Splitting a Tuple via Tuple Expansion
@@ -1076,14 +1072,14 @@ using the semantics of either the ``out`` or ``const ref`` yield intent,
 in an implementation-defined manner.
 
 .. index::
-   single: tuples;operators
+   single: tuples; operators
 .. _Tuple_Operators:
 
 Tuple Operators
 ---------------
 
 .. index::
-   single: operators;tuple;unary
+   single: operators; unary tuple operators
 .. _Tuple_Unary_Operators:
 
 Unary Operators
@@ -1123,18 +1119,18 @@ definition for the unary operator being used. Otherwise, a compile-time
 error will be issued.
 
 .. index::
-   single: operators;tuple;binary
-   single: +
-   single: -
-   single: *
-   single: /
-   single: %
-   single: **
-   single: &
-   single: |
-   single: ^
-   single: <<
-   single: >>
+   single: operators; binary tuple operators
+   single: + (on tuples)
+   single: - (on tuples)
+   single: * (on tuples)
+   single: / (on tuples)
+   single: % (on tuples)
+   single: ** (on tuples)
+   single: & (on tuples)
+   single: | (on tuples)
+   single: ^ (on tuples)
+   single: << (on tuples)
+   single: >> (on tuples)
 .. _Tuple_Binary_Operators:
 
 Binary Operators
@@ -1177,13 +1173,13 @@ result.
       (3, 3.0, 12)
 
 .. index::
-   single: operators;tuple;relational
-   single: >
-   single: >=
-   single: <
-   single: <=
-   single: ==
-   single: !=
+   single: operators; relational operators on tuples
+   single: > (on tuples)
+   single: >= (on tuples)
+   single: < (on tuples)
+   single: <= (on tuples)
+   single: == (on tuples)
+   single: != (on tuples)
 .. _Tuple_Relational_Operators:
 
 Relational Operators
@@ -1228,19 +1224,17 @@ in the two operand tuples. Otherwise, a compile-time error will result.
       true
 
 .. index::
-   single: tuples;predefined functions
-   single: predefined functions;tuples
-   single: functions;tuples;predefined
-   single: tuples;isTuple
-   single: predefined functions;isTuple
-   single: tuples;isTupleType
-   single: predefined functions;isTupleType
-   single: tuples;max
-   single: predefined functions;max
-   single: tuples;min
-   single: predefined functions;min
-   single: tuples;size
-   single: predefined functions;size
+   pair: tuples; predefined functions
+   single: tuples; isTuple
+   single: predefined functions; isTuple
+   single: tuples; isTupleType
+   single: predefined functions; isTupleType
+   single: tuples; max
+   single: predefined functions; max
+   single: tuples; min
+   single: predefined functions; min
+   single: tuples; size
+   single: predefined functions; size
 .. _Predefined_Functions_and_Methods_on_Tuples:
 
 Predefined Routines on Tuples

--- a/doc/rst/language/spec/types.rst
+++ b/doc/rst/language/spec/types.rst
@@ -57,7 +57,7 @@ These statements are defined in Sections :ref:`Enumerated_Types`,
 respectively.
 
 .. index::
-   single: types;primitive
+   single: types; primitive
 .. _Primitive_Types:
 
 Primitive Types
@@ -111,7 +111,7 @@ See :ref:`Compile-Time_Constants`
 
 .. index::
    single: void
-   single: types;void
+   single: types; void
 .. _The_Void_Type:
 
 The Void Type
@@ -145,7 +145,7 @@ to a variable.
 
 .. index::
    single: nothing
-   single: types;nothing
+   single: types; nothing
 .. _The_Nothing_type:
 
 The Nothing Type
@@ -188,7 +188,7 @@ representation at run-time.
 
 .. index::
    single: bool
-   single: types;bool
+   single: types; bool
 .. _The_Bool_Type:
 
 The Bool Type
@@ -240,8 +240,8 @@ not initialized to something else (see also :ref:`Chapter-Variables`).
 .. index::
    single: uint
    single: int
-   single: types;uint
-   single: types;int
+   single: types; uint
+   single: types; int
 .. _Signed_and_Unsigned_Integral_Types:
 
 Signed and Unsigned Integral Types
@@ -326,7 +326,8 @@ will be discarded.
 
 .. index::
    single: real
-   single: types;real
+   single: types; real
+   single: types; floating point
 .. _Real_Types:
 
 Real Types
@@ -402,7 +403,8 @@ without an exponent (see :ref:`Literals` for details):
 
 .. index::
    single: imaginary
-   single: types;imaginary
+   single: types; imaginary
+   single: types; imag
 .. _Imaginary_Types:
 
 Imaginary Types
@@ -472,7 +474,7 @@ floating-point value while changing whether or not it is imaginary.
 
 .. index::
    single: complex
-   single: types;complex
+   single: types; complex
 .. _Complex_Types:
 
 Complex Types
@@ -527,7 +529,7 @@ See the :mod:`Math` module documentation.
 
 .. index::
    single: string
-   single: types;string
+   single: types; string
 .. _The_String_Type:
 
 The String Type
@@ -539,7 +541,7 @@ unbounded. Strings are defined in :ref:`Chapter-Strings`.
 
 .. index::
    single: bytes
-   single: types;bytes
+   single: types; bytes
 .. _The_Bytes_Type:
 
 The Bytes Type
@@ -551,13 +553,13 @@ unbounded. Bytes are defined in :ref:`Chapter-Bytes`.
 
 .. index::
    single: enumerated types
-   single: types;enumerated
-   single: enumerated types;abstract
-   single: enumerated types;concrete
-   single: enumerated types;semi-concrete
-   single: enumerated types;iterating
-   single: enumerated types;size
-   single: predefined functions;size (enum)
+   single: types; enumerated
+   single: enumerated types; abstract
+   single: enumerated types; concrete
+   single: enumerated types; semi-concrete
+   single: enumerated types; iterating
+   single: enumerated types; size
+   single: predefined functions; size (enum)
 .. _Enumerated_Types:
 
 Enumerated Types
@@ -678,7 +680,7 @@ available:
    Returns the last constant in the enumerated type.
 
 .. index::
-   single: types;structured
+   single: types; structured
 .. _Structured_Types:
 
 Structured Types
@@ -803,7 +805,7 @@ of any type. Domains, arrays, and their index types are defined in
 :ref:`Chapter-Domains` and :ref:`Chapter-Arrays`.
 
 .. index::
-   single: types;synchronization
+   single: types; synchronization
 .. _Synchronization_Types:
 
 Synchronization Types
@@ -824,7 +826,7 @@ The sync type is discussed in
 in :ref:`Atomic_Variables`.
 
 .. index::
-   single: types;aliases
+   single: types; aliases
 .. _Type_Aliases:
 
 Type Aliases

--- a/doc/rst/language/spec/types.rst
+++ b/doc/rst/language/spec/types.rst
@@ -760,7 +760,7 @@ fields. If all the fields are of the same type, the tuple is
 homogeneous. Tuples are defined in :ref:`Chapter-Tuples`.
 
 .. index::
-   single: types;dataparallel
+   single: types; data parallel
 .. _Data_Parallel_Types:
 
 Data Parallel Types

--- a/doc/rst/language/spec/types.rst
+++ b/doc/rst/language/spec/types.rst
@@ -1,5 +1,7 @@
 .. default-domain:: chpl
 
+.. index::
+   single: types
 .. _Chapter-Types:
 
 =====
@@ -54,6 +56,8 @@ These statements are defined in Sections :ref:`Enumerated_Types`,
 :ref:`Union_Declarations`, and :ref:`Type_Aliases`,
 respectively.
 
+.. index::
+   single: types;primitive
 .. _Primitive_Types:
 
 Primitive Types
@@ -105,6 +109,9 @@ See :ref:`Compile-Time_Constants`
    primitive types depending on a platform’s native support for those
    types.
 
+.. index::
+   single: void
+   single: types;void
 .. _The_Void_Type:
 
 The Void Type
@@ -136,6 +143,9 @@ primarily used to indicate that a function does not return anything.
 It is an error to assign the result of a function that returns ``void``
 to a variable.
 
+.. index::
+   single: nothing
+   single: types;nothing
 .. _The_Nothing_type:
 
 The Nothing Type
@@ -176,6 +186,9 @@ representation at run-time.
 
        1
 
+.. index::
+   single: bool
+   single: types;bool
 .. _The_Bool_Type:
 
 The Bool Type
@@ -224,6 +237,11 @@ not initialized to something else (see also :ref:`Chapter-Variables`).
       false
 
 
+.. index::
+   single: uint
+   single: int
+   single: types;uint
+   single: types;int
 .. _Signed_and_Unsigned_Integral_Types:
 
 Signed and Unsigned Integral Types
@@ -306,6 +324,9 @@ will be discarded.
 
 
 
+.. index::
+   single: real
+   single: types;real
 .. _Real_Types:
 
 Real Types
@@ -379,6 +400,9 @@ without an exponent (see :ref:`Literals` for details):
       5.18738
 
 
+.. index::
+   single: imaginary
+   single: types;imaginary
 .. _Imaginary_Types:
 
 Imaginary Types
@@ -446,6 +470,9 @@ floating-point value while changing whether or not it is imaginary.
       b = 10.25i : imag(64)
 
 
+.. index::
+   single: complex
+   single: types;complex
 .. _Complex_Types:
 
 Complex Types
@@ -498,6 +525,9 @@ The standard :mod:`Math` module provides more functions on complex types.
 See the :mod:`Math` module documentation.
 
 
+.. index::
+   single: string
+   single: types;string
 .. _The_String_Type:
 
 The String Type
@@ -507,6 +537,9 @@ Strings are a primitive type designated by the symbol ``string``
 comprised of Unicode characters in UTF-8 encoding. Their length is
 unbounded. Strings are defined in :ref:`Chapter-Strings`.
 
+.. index::
+   single: bytes
+   single: types;bytes
 .. _The_Bytes_Type:
 
 The Bytes Type
@@ -516,6 +549,15 @@ Bytes is a primitive type designated by the symbol ``bytes`` comprised
 of arbitrary bytes. Bytes are immutable in-place and their length is
 unbounded. Bytes are defined in :ref:`Chapter-Bytes`.
 
+.. index::
+   single: enumerated types
+   single: types;enumerated
+   single: enumerated types;abstract
+   single: enumerated types;concrete
+   single: enumerated types;semi-concrete
+   single: enumerated types;iterating
+   single: enumerated types;size
+   single: predefined functions;size (enum)
 .. _Enumerated_Types:
 
 Enumerated Types
@@ -635,6 +677,8 @@ available:
 
    Returns the last constant in the enumerated type.
 
+.. index::
+   single: types;structured
 .. _Structured_Types:
 
 Structured Types
@@ -715,6 +759,8 @@ A tuple is a light-weight record that consists of one or more anonymous
 fields. If all the fields are of the same type, the tuple is
 homogeneous. Tuples are defined in :ref:`Chapter-Tuples`.
 
+.. index::
+   single: types;dataparallel
 .. _Data_Parallel_Types:
 
 Data Parallel Types
@@ -756,6 +802,8 @@ that correspond to the indices in its domain. A domain’s indices can be
 of any type. Domains, arrays, and their index types are defined in
 :ref:`Chapter-Domains` and :ref:`Chapter-Arrays`.
 
+.. index::
+   single: types;synchronization
 .. _Synchronization_Types:
 
 Synchronization Types
@@ -775,6 +823,8 @@ The sync type is discussed in
 :ref:`Synchronization_Variables`. The atomic type is discussed
 in :ref:`Atomic_Variables`.
 
+.. index::
+   single: types;aliases
 .. _Type_Aliases:
 
 Type Aliases

--- a/doc/rst/language/spec/unions.rst
+++ b/doc/rst/language/spec/unions.rst
@@ -1,5 +1,7 @@
 .. default-domain:: chpl
 
+.. index::
+   single: unions
 .. _Chapter-Unions:
 
 ======
@@ -12,6 +14,9 @@ execution. Unions are safe so that an access to a field that does not
 contain data is a runtime error. When a union is initialized, it is in
 an unset state so that no field contains data.
 
+.. index::
+   single: types;unions
+   single: union types
 .. _Union_Types:
 
 Union Types
@@ -28,6 +33,9 @@ The union type is specified by the name of the union type. This
 simplification from class and record types is possible because generic
 unions are not supported.
 
+.. index::
+   single: union
+   single: declarations;union
 .. _Union_Declarations:
 
 Union Declarations
@@ -57,6 +65,8 @@ for type and field resolution, but no corresponding backend definition
 is generated. It is presumed that the definition of an external union
 type is supplied by a library or the execution environment.
 
+.. index::
+   single: unions;fields
 .. _Union_Fields:
 
 Union Fields
@@ -68,6 +78,8 @@ set.
 
 Union fields should not be specified with initialization expressions.
 
+.. index::
+   single: unions;assignment
 .. _Union_Assignment:
 
 Union Assignment

--- a/doc/rst/language/spec/unions.rst
+++ b/doc/rst/language/spec/unions.rst
@@ -15,7 +15,7 @@ contain data is a runtime error. When a union is initialized, it is in
 an unset state so that no field contains data.
 
 .. index::
-   single: types;unions
+   single: types; unions
    single: union types
 .. _Union_Types:
 
@@ -35,7 +35,7 @@ unions are not supported.
 
 .. index::
    single: union
-   single: declarations;union
+   single: declarations; union
 .. _Union_Declarations:
 
 Union Declarations
@@ -66,7 +66,7 @@ is generated. It is presumed that the definition of an external union
 type is supplied by a library or the execution environment.
 
 .. index::
-   single: unions;fields
+   single: unions; fields
 .. _Union_Fields:
 
 Union Fields
@@ -79,7 +79,7 @@ set.
 Union fields should not be specified with initialization expressions.
 
 .. index::
-   single: unions;assignment
+   single: unions; assignment
 .. _Union_Assignment:
 
 Union Assignment

--- a/doc/rst/language/spec/variables.rst
+++ b/doc/rst/language/spec/variables.rst
@@ -435,7 +435,7 @@ for an arbitrary expression ``e``.
 
 .. index::
    single: declarations; multiple variables
-   single: variables; multple variable declarations
+   single: variables; multiple variable declarations
 .. _Multiple_Variable_Declarations:
 
 Multiple Variable Declarations

--- a/doc/rst/language/spec/variables.rst
+++ b/doc/rst/language/spec/variables.rst
@@ -14,8 +14,8 @@ is known at compile-time and the compiler enforces that values assigned
 to the variable can be stored in that variable as specified by its type.
 
 .. index::
-   single: variables;declarations
-   single: declarations;variables
+   single: variables; declarations
+   single: declarations; variables
 .. _Variable_Declarations:
 
 Variable Declarations
@@ -126,7 +126,7 @@ Multiple variables can be grouped together using a tuple notation as
 described in :ref:`Variable_Declarations_in_a_Tuple`.
 
 .. index::
- single: split initialization
+   single: split initialization
 .. _Split_Initialization:
 
 Split Initialization
@@ -376,9 +376,9 @@ unconditionally return.
       2
 
 .. index::
-   single: default initialization;variables
-   single: variables;default initialization
-   single: variables;default values
+   single: default initialization; variables
+   single: variables; default initialization
+   single: variables; default values
 .. _Default_Values_For_Types:
 
 Default Initialization
@@ -411,7 +411,7 @@ atomic      base default value
 
 .. index::
    single: type inference
-   single: type inference;local
+   single: type inference; local
 .. _Local_Type_Inference:
 
 Local Type Inference
@@ -434,8 +434,8 @@ is equivalent to
 for an arbitrary expression ``e``.
 
 .. index::
-   single: declarations;variables;multiple
-   single: variables;declarations;multiple
+   single: declarations; multiple variables
+   single: variables; multple variable declarations
 .. _Multiple_Variable_Declarations:
 
 Multiple Variable Declarations
@@ -550,7 +550,7 @@ follows:
    *full*/*empty* state.
 
 .. index::
-   single: variables;module level
+   single: variables; module level
 .. _Module_Level_Variables:
 
 Module Level Variables
@@ -563,7 +563,7 @@ initialization of that variable. If they are public, they can also be
 accessed in other modules that use that module.
 
 .. index::
-   single: variables;local
+   single: variables; local
 .. _Local_Variables:
 
 Local Variables
@@ -594,7 +594,7 @@ the keyword ``param``, are compile-time constants and constants,
 specified with the keyword ``const``, are runtime constants.
 
 .. index::
-   single: constants;compile-time
+   single: constants; compile-time
    single: parameters
    single: param
 .. _Compile-Time_Constants:
@@ -641,7 +641,7 @@ Parameter expressions are restricted to the following constructs:
    See :ref:`Param_Return_Intent`.
 
 .. index::
-   single: constants;runtime
+   single: constants; runtime
    single: constants
    single: const
 .. _Runtime_Constants:
@@ -660,10 +660,10 @@ initialized to reference. However, the fields of that object are allowed
 to be modified.
 
 .. index::
-   single: variables;configuration
-   single: constants;configuration
+   single: variables; configuration
+   single: constants; configuration
+   single: parameters; configuration
    single: config
-   single: parameters;configuration
 .. _Configuration_Variables:
 
 Configuration Variables
@@ -713,8 +713,7 @@ overrides the default value appearing in the Chapel code.
    rank-independent code.
 
 .. index::
-   single: variables;ref
-   single: ref
+   pair: variables; ref
 .. _Ref_Variables:
 
 Ref Variables
@@ -801,6 +800,8 @@ Parameter constants and expressions cannot be aliased.
       myArr[3] = 73
       myConstRef = 52
 
+.. index::
+   single: variables; conflicts
 .. _Variable_Conflicts:
 
 Variable Conflicts
@@ -834,6 +835,9 @@ share a name with it.  While functions may share the same name (see
 :ref:`Function_Overloading`), a function sharing a name with a variable in the
 same scope will lead to conflicts.
 
+
+.. index::
+   pair: variables; lifetimes
 .. _Variable_Lifetimes:
 
 Variable Lifetimes
@@ -850,6 +854,9 @@ A variable's lifetime ends:
    :ref:`Copy_Elision`.
  * otherwise, at the variable's deinit point (see :ref:`Deinit_Points`)
 
+.. index::
+   single: variables; deinitialization points
+   single: deinitialization points
 .. _Deinit_Points:
 
 Deinit Points
@@ -958,6 +965,11 @@ are deinitialized at the end of the containing statement.
 
 
 
+.. index::
+   single: copy initialization
+   single: move initialization
+   single: initialization; copy
+   single: initialization; move
 .. _Copy_and_Move_Initialization:
 
 Copy and Move Initialization

--- a/doc/rst/language/spec/variables.rst
+++ b/doc/rst/language/spec/variables.rst
@@ -125,6 +125,8 @@ defined in :ref:`Multiple_Variable_Declarations`.
 Multiple variables can be grouped together using a tuple notation as
 described in :ref:`Variable_Declarations_in_a_Tuple`.
 
+.. index::
+ single: split initialization
 .. _Split_Initialization:
 
 Split Initialization
@@ -1063,6 +1065,8 @@ outer/ref
   function, or reference variable or argument
 
 
+.. index::
+   single: copy elision
 .. _Copy_Elision:
 
 Copy Elision

--- a/doc/rst/language/spec/variables.rst
+++ b/doc/rst/language/spec/variables.rst
@@ -1,5 +1,7 @@
 .. default-domain:: chpl
 
+.. index::
+   single: variables
 .. _Chapter-Variables:
 
 =========
@@ -11,6 +13,9 @@ statically-typed, type-safe language so every variable has a type that
 is known at compile-time and the compiler enforces that values assigned
 to the variable can be stored in that variable as specified by its type.
 
+.. index::
+   single: variables;declarations
+   single: declarations;variables
 .. _Variable_Declarations:
 
 Variable Declarations
@@ -368,6 +373,10 @@ unconditionally return.
 
       2
 
+.. index::
+   single: default initialization;variables
+   single: variables;default initialization
+   single: variables;default values
 .. _Default_Values_For_Types:
 
 Default Initialization
@@ -398,6 +407,9 @@ sync        base default value and *empty* status
 atomic      base default value
 =========== =======================================
 
+.. index::
+   single: type inference
+   single: type inference;local
 .. _Local_Type_Inference:
 
 Local Type Inference
@@ -419,6 +431,9 @@ is equivalent to
 
 for an arbitrary expression ``e``.
 
+.. index::
+   single: declarations;variables;multiple
+   single: variables;declarations;multiple
 .. _Multiple_Variable_Declarations:
 
 Multiple Variable Declarations
@@ -532,6 +547,8 @@ follows:
    careful handling to avoid unintentional changes to their
    *full*/*empty* state.
 
+.. index::
+   single: variables;module level
 .. _Module_Level_Variables:
 
 Module Level Variables
@@ -543,6 +560,8 @@ level variables can be accessed anywhere within that module after the
 initialization of that variable. If they are public, they can also be
 accessed in other modules that use that module.
 
+.. index::
+   single: variables;local
 .. _Local_Variables:
 
 Local Variables
@@ -561,6 +580,8 @@ Note that unlike most types, variables of ``unmanaged`` class type do not
 automatically reclaim the storage that they refer to. Such storage can be
 reclaimed as described in :ref:`Class_Delete`.
 
+.. index::
+   single: constants
 .. _Constants:
 
 Constants
@@ -570,6 +591,10 @@ Constants are divided into two categories: parameters, specified with
 the keyword ``param``, are compile-time constants and constants,
 specified with the keyword ``const``, are runtime constants.
 
+.. index::
+   single: constants;compile-time
+   single: parameters
+   single: param
 .. _Compile-Time_Constants:
 
 Compile-Time Constants
@@ -613,6 +638,10 @@ Parameter expressions are restricted to the following constructs:
 -  Call expressions of parameter functions.
    See :ref:`Param_Return_Intent`.
 
+.. index::
+   single: constants;runtime
+   single: constants
+   single: const
 .. _Runtime_Constants:
 
 Runtime Constants
@@ -628,6 +657,11 @@ That is, the variable always points to the object that it was
 initialized to reference. However, the fields of that object are allowed
 to be modified.
 
+.. index::
+   single: variables;configuration
+   single: constants;configuration
+   single: config
+   single: parameters;configuration
 .. _Configuration_Variables:
 
 Configuration Variables
@@ -676,6 +710,9 @@ overrides the default value appearing in the Chapel code.
    parameter. The ``rank`` configuration variable can be used to write
    rank-independent code.
 
+.. index::
+   single: variables;ref
+   single: ref
 .. _Ref_Variables:
 
 Ref Variables

--- a/doc/rst/technotes/noinit.rst
+++ b/doc/rst/technotes/noinit.rst
@@ -1,8 +1,8 @@
 
-.. _readme-noinit:
 .. index::
    single: noinit
    single: noinit;variables
+.. _readme-noinit:
 
 .. default-domain:: chpl
 

--- a/doc/rst/technotes/noinit.rst
+++ b/doc/rst/technotes/noinit.rst
@@ -1,5 +1,8 @@
 
 .. _readme-noinit:
+.. index::
+   single: noinit
+   single: noinit;variables
 
 .. default-domain:: chpl
 


### PR DESCRIPTION
This PR adds `.. index::` directives to the .rst language specification based upon `\index` entries that were present in the .tex version. All directives added here use the `single:` format.

Note that the sphinx index only supports 2-level nesting. That meant adjusting some of the more deeply nested cases that we had in the .tex version.

This PR also adds a few index entries that were noticeably absent from the .tex version (since the language specification had evolved since then).

See also [the sphinx documentation about index directives](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#index-generating-markup)

Reviewed by @lydia-duncan - thanks!

- [x] comm=none testing