### PR TITLE
Avoid PIP timeouts in nightly testing

### DIFF
--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -78,7 +78,7 @@ if [ ${CHPL_TEST_ARKOUDA_STOP_AFTER_BUILD} = "false" ]; then
   export PYTHONUSERBASE=$ARKOUDA_HOME/python-deps
   # If Arkouda deps use any of our test deps, try to use the versions we want
   AK_PIP_CONTRAINTS="--constraint $CHPL_HOME/third-party/chpl-venv/test-requirements.txt"
-  if ! python3 -m pip install --timeout 60 $AK_PIP_CONTRAINTS -e .[dev] --user ; then
+  if ! python3 -m pip install --force-install --timeout 60 $AK_PIP_CONTRAINTS -e .[dev] --user ; then
     log_fatal_error "installing arkouda"
   fi
 

--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -78,7 +78,7 @@ if [ ${CHPL_TEST_ARKOUDA_STOP_AFTER_BUILD} = "false" ]; then
   export PYTHONUSERBASE=$ARKOUDA_HOME/python-deps
   # If Arkouda deps use any of our test deps, try to use the versions we want
   AK_PIP_CONTRAINTS="--constraint $CHPL_HOME/third-party/chpl-venv/test-requirements.txt"
-  if ! python3 -m pip install --force-reinstall --upgrade --no-cache-dir $AK_PIP_CONTRAINTS -e .[dev] --user ; then
+  if ! python3 -m pip install --timeout 60 $AK_PIP_CONTRAINTS -e .[dev] --user ; then
     log_fatal_error "installing arkouda"
   fi
 


### PR DESCRIPTION
Avoid PIP timeouts in nightly testing by utilizing the default pip caching behavior and increasing the network timeout.

[Reviewed by @bmcdonald3]