### PR TITLE
Reorder documentation for "Tools"

### DIFF
--- a/doc/rst/tools/index.rst
+++ b/doc/rst/tools/index.rst
@@ -3,21 +3,44 @@
 Tools
 =====
 
-Contents:
+Documentation
+-------------
 
 .. toctree::
-   :hidden:
+   :maxdepth: 1
+   :glob:
+
+   chpldoc/chpldoc
+
+Development
+-----------
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   chpl-language-server/chpl-language-server
+   chplcheck/chplcheck
+   chplvis/chplvis
+   mason/mason
+
+Interoperability
+----------------
 
 .. toctree::
    :maxdepth: 1
    :glob:
 
    c2chapel/c2chapel
-   chpldoc/chpldoc
-   chplvis/chplvis
-   mason/mason
    protoc-gen-chpl/protoc-gen-chpl
-   unstableWarningAnonymizer/unstableWarningAnonymizer
+
+
+Other
+-----
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
    chapel-py/chapel-py
-   chplcheck/chplcheck
-   chpl-language-server/chpl-language-server
+   unstableWarningAnonymizer/unstableWarningAnonymizer


### PR DESCRIPTION
Reorders the documentation for the tools section of our docs


Built and checked the docs locally, they look like this:
![Screenshot 2024-03-15 at 11 03 14 AM](https://github.com/chapel-lang/chapel/assets/15747900/85126975-aef5-4fd0-bff5-17871106e16f)

[Reviewed by @DanilaFe]