### PR TITLE
update regex pattern in chplenv scipt to raw string

### DIFF
--- a/util/chplenv/compiler_utils.py
+++ b/util/chplenv/compiler_utils.py
@@ -32,7 +32,7 @@ def CompVersion(version_string):
     are not specified, 0 will be used for their value(s)
     """
     CompVersionT = namedtuple('CompVersion', ['major', 'minor', 'revision', 'build'])
-    match = re.search(u'(\d+)(\.(\d+))?(\.(\d+))?(\.(\d+))?', version_string)
+    match = re.search(r"(\d+)(\.(\d+))?(\.(\d+))?(\.(\d+))?", version_string)
     if match:
         major    = int(match.group(1))
         minor    = int(match.group(3) or 0)


### PR DESCRIPTION
This PR fixes an issue encountered with python 3.12 that is causing out updated Chapel formula to fail CI checks in homebrew. 

A warning about invalid escape sequences is emitted, essentially causing `make check` to fail.

```
/opt/homebrew/Cellar/chapel/2.0/libexec/util/chplenv/compiler_utils.py:35: SyntaxWarning: invalid escape sequence '\d'
  match = re.search(u'(\d+)(\.(\d+))?(\.(\d+))?(\.(\d+))?', version_string)
```

This is caused by python 3.12 upgrading what was previously a silent DeprecationWarning to a SyntaxWarning (printed by default).