### PR TITLE
Dyno: Improve resolution of where-clauses on generic methods

### DIFF
--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -781,12 +781,12 @@ bool CanPassResult::canInstantiateBuiltin(Context* context,
     return true;
 
   if (formalT->isAnyIteratorClassType()) {
-    CHPL_UNIMPL("iterator classes"); // TODO: represent iterators
+    // TODO: represent iterators
     return false;
   }
 
   if (formalT->isAnyIteratorRecordType()) {
-    CHPL_UNIMPL("iterator records"); // TODO: represent iterators
+    // TODO: represent iterators
     return false;
   }
 

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -1972,7 +1972,13 @@ ApplicabilityResult instantiateSignature(Context* context,
       }
 
       if (fn != nullptr && fn->isMethod() && fn->thisFormal() == formal) {
-        visitor.setCompositeType(qFormalType.type()->toCompositeType());
+        // Set the visitor's 'inCompositeType' property to the final
+        // instantiation of 'this' so that we can correctly resolve methods.
+        //
+        // Also recompute receiver scopes based on the instantiated type so
+        // that we correctly resolve the types of field identifiers.
+        visitor.setCompositeType(formalType.type()->toCompositeType());
+        visitor.receiverScopesComputed = false;
       }
     }
   }

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -344,6 +344,8 @@ CallInfo CallInfo::create(Context* context,
       name = calledIdent->name();
     } else if (auto calledDot = called->toDot()) {
       name = calledDot->field();
+    } else if (auto op = called->toOpCall()) {
+      name = op->op();
     } else {
       CHPL_UNIMPL("CallInfo without a name");
     }


### PR DESCRIPTION
This PR updates the implementation of instantiating a signature in dyno to correctly set the type of ``this`` while resolving the non-formal elements of a secondary method. Prior to this PR, we were potentially setting the type of ``this`` to be the fully-generic type, rather than the instantiation we had just computed. For example, for a method like ``R.foo()`` we would use ``R`` instead of something like ``R(int)``.

While in the area, I also observed and fixed a related issue when referencing fields of a generic type while within an instantiated secondary method. The solution was to simply reset the Resolver's "computed receiver scopes" flag so that they would be appropriately recomputed.

This PR also includes a couple of minor cleanups to avoid generating some false "unimplemented" warnings during resolution.