### PR TITLE
update version numbers to reflect pre-release status of Chapel 2.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,13 +36,13 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 # These values will be written to <build_dir>/frontend/include/chpl/config/config.h
 
 set(CHPL_MAJOR_VERSION 2)
-set(CHPL_MINOR_VERSION 0)
+set(CHPL_MINOR_VERSION 1)
 set(CHPL_PATCH_VERSION 0)
 set(CHPL_BUILD_VERSION 0)
 
 # Flip this to 'true' when we're ready to roll out a release; then back
 # after branching
-set(CHPL_OFFICIAL_RELEASE true)
+set(CHPL_OFFICIAL_RELEASE false)
 
 ### END config.h version value setting - configured_prefix set below ###
 

--- a/man/confchpl.rst
+++ b/man/confchpl.rst
@@ -1,5 +1,5 @@
 
-:Version: 2.0.0
+:Version: 2.1.0 pre-release
 :Manual section: 1
 :Title: \\fBchpl\\fP
 :Subtitle: Compiler for the Chapel Programming Language

--- a/man/confchpldoc.rst
+++ b/man/confchpldoc.rst
@@ -1,5 +1,5 @@
 
-:Version: 2.0.0
+:Version: 2.1.0 pre-release
 :Manual section: 1
 :Title: \\fBchpldoc\\fP
 :Subtitle: the Chapel Documentation Tool

--- a/test/chpldoc/compflags/combinations/versionhelp-chpldoc.sh
+++ b/test/chpldoc/compflags/combinations/versionhelp-chpldoc.sh
@@ -5,7 +5,7 @@ compiler=$3
 echo -n `basename $compiler`
 cat $CWD/../../../compflags/bradc/printstuff/version.goodstart
 # During pre-release mode
-# diff $CWD/../../../../compiler/main/BUILD_VERSION $CWD/zero.txt > /dev/null 2>&1 && echo "" || \
-#  { echo -n " pre-release (" && cat $CWD/../../../../compiler/main/BUILD_VERSION | tr -d \"\\n && echo ")" ; }
+diff $CWD/../../../../compiler/main/BUILD_VERSION $CWD/zero.txt > /dev/null 2>&1 && echo "" || \
+ { echo -n " pre-release (" && cat $CWD/../../../../compiler/main/BUILD_VERSION | tr -d \"\\n && echo ")" ; }
 # During release mode:
-echo ""
+# echo ""

--- a/test/compflags/bradc/printstuff/version.goodstart
+++ b/test/compflags/bradc/printstuff/version.goodstart
@@ -1,1 +1,1 @@
- version 2.0.0
+ version 2.1.0

--- a/test/compflags/bradc/printstuff/versionhelp.sh
+++ b/test/compflags/bradc/printstuff/versionhelp.sh
@@ -5,10 +5,10 @@ compiler=$3
 echo -n `basename $compiler`
 cat $CWD/version.goodstart
 # During pre-release mode
-# diff $CWD/../../../../compiler/main/BUILD_VERSION $CWD/zero.txt > /dev/null 2>&1 && echo "" || \
-#  { echo -n " pre-release (" && cat $CWD/../../../../compiler/main/BUILD_VERSION | tr -d \"\\n && echo ")" ; }
+diff $CWD/../../../../compiler/main/BUILD_VERSION $CWD/zero.txt > /dev/null 2>&1 && echo "" || \
+ { echo -n " pre-release (" && cat $CWD/../../../../compiler/main/BUILD_VERSION | tr -d \"\\n && echo ")" ; }
 # During release mode:
-echo ""
+# echo ""
 
 if [ "$CHPL_LLVM" != "none" ]
 then


### PR DESCRIPTION
This PR updates version numbers to 2.1 (pre-release) for `chpl`, `chpldoc`, and the website documentation. 

This is the corresponding update to the previous PRs that changed the status from pre-release to release:
- https://github.com/chapel-lang/chapel/pull/24588
- https://github.com/chapel-lang/chapel/pull/24533

Changes are compared against past PRs doing the same:  

- https://github.com/chapel-lang/chapel/pull/24061
~~- https://github.com/chapel-lang/chapel/pull/23530~~

TESTING:

- [x] paratest `[Summary: #Successes = 17162 | #Failures = 0 | #Futures = 919]`

[reviewed by @ShreyasKhandekar - thanks!]