### PR TITLE
Dyno: Silence dead variable errors for builtin/primitive types

### DIFF
--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -938,7 +938,9 @@ void CallInitDeinit::handleInFormal(const FnCall* ast, const AstNode* actual,
   QualifiedType actualType = rv.byAst(actual).type();
 
   // is the copy for 'in' elided?
-  if (elidedCopyFromIds.count(actual->id()) > 0 && isValue(actualType.kind())) {
+  if (elidedCopyFromIds.count(actual->id()) > 0 &&
+      isValue(actualType.kind()) &&
+      typeNeedsInitDeinitCall(actualType.type())) {
     // it is move initialization
     resolveMoveInit(actual, actual, formalType, actualType, rv);
 

--- a/frontend/test/resolution/testCallInitDeinit.cpp
+++ b/frontend/test/resolution/testCallInitDeinit.cpp
@@ -1611,6 +1611,30 @@ static void test20c() {
     });
 }
 
+static void test21() {
+  // Make sure primitive/builtin types don't trigger dead-variable tracking
+  testActions("test21",
+      R"""(
+      module M {
+        proc take(arg: int) {
+          return 5;
+        }
+        proc take2(arg: int) {
+          return 5;
+        }
+
+        proc test() {
+          var cond = true;
+          var arg : int;
+
+          var ret : int;
+          if cond then ret = take(arg);
+          else ret = take2(arg);
+        }
+      }
+      )""", {} );
+}
+
 // calling function with 'out' intent formal
 
 // calling functions with 'inout' intent formal
@@ -1696,6 +1720,8 @@ int main() {
   test20a();
   /* test20b(); */
   test20c();
+
+  test21();
 
   return 0;
 }


### PR DESCRIPTION
Skips CallInitDeinit::handleInFormal for builtin/primitive types to avoid dead variable errors related to passing such types to formals with the ``in`` intent.