### PR TITLE
LSP: Display notes from error messages as part of the error message

### DIFF
--- a/frontend/include/chpl/framework/ErrorBase.h
+++ b/frontend/include/chpl/framework/ErrorBase.h
@@ -52,7 +52,8 @@ namespace chpl {
 
 class ErrorWriterBase;
 
-using Note = std::tuple<IdOrLocation, std::string>;
+using ErrorNote = std::tuple<IdOrLocation, std::string>;
+using ErrorCodeSnippet = std::tuple<Location, std::vector<Location>>;
 
 /** Enum representing the different types of errors in Dyno. */
 enum ErrorType {
@@ -163,12 +164,12 @@ class BasicError : public ErrorBase {
   /** The error's message. */
   std::string message_;
   /** Additional notes / details attached to the error. */
-  std::vector<Note> notes_;
+  std::vector<ErrorNote> notes_;
 
  protected:
   BasicError(Kind kind, ErrorType type, IdOrLocation idOrLoc,
              std::string message,
-             std::vector<Note> notes) :
+             std::vector<ErrorNote> notes) :
     ErrorBase(kind, type), idOrLoc_(std::move(idOrLoc)),
     message_(std::move(message)), notes_(std::move(notes)) {}
 
@@ -191,7 +192,7 @@ class GeneralError : public BasicError {
  protected:
   GeneralError(const GeneralError& other) = default;
   GeneralError(ErrorBase::Kind kind, IdOrLocation idOrLoc,
-               std::string message, std::vector<Note> notes)
+               std::string message, std::vector<ErrorNote> notes)
     : BasicError(kind, General, std::move(idOrLoc),
                  std::move(message), std::move(notes)) {}
 

--- a/frontend/include/chpl/framework/ErrorWriter.h
+++ b/frontend/include/chpl/framework/ErrorWriter.h
@@ -434,6 +434,91 @@ class ErrorWriter : public ErrorWriterBase {
   void writeNewline();
 };
 
+/**
+  Implementation of ErrorWriterBase that records calls
+  to the various API functions in order to retrieve information
+  from ErrorMessages.
+ */
+class CompatibilityWriter : public ErrorWriterBase {
+ private:
+  IdOrLocation idOrLoc_;
+  /** The computed location (derived from the ::id_ or ::loc_) */
+  Location computedLoc_;
+  /** The error's brief message */
+  std::string message_;
+  /** A list of notes associated with this error (aka details) */
+  std::vector<ErrorNote> notes_;
+  std::vector<ErrorCodeSnippet> codeSnippets_;
+
+ public:
+  CompatibilityWriter(Context* context)
+    : ErrorWriterBase(context, OutputFormat::BRIEF) {}
+
+  void writeHeading(ErrorBase::Kind kind, ErrorType type,
+                    IdOrLocation idOrLoc, const std::string& message) override {
+    // We may not have a context e.g. if we are just figuring out the error
+    // message text. Trust that `computedLoc_` is not important for that.
+    if (context_) this->computedLoc_ = errordetail::locate(context_, idOrLoc);
+    this->idOrLoc_ = std::move(idOrLoc);
+    this->message_ = message;
+  }
+
+  void writeMessage(const std::string& message) override {}
+
+  void writeCode(const Location& loc,
+                 const std::vector<Location>& hl) override {
+    this->codeSnippets_.push_back(std::make_tuple(loc, hl));
+  }
+
+  void writeNote(IdOrLocation loc, const std::string& message) override {
+    this->notes_.push_back(std::make_tuple(std::move(loc), message));
+  }
+
+  /**
+    Get the error's ID (could be empty in favor of the location).
+
+    This only works after ErrorBase::write was invoked with this
+    CompatibilityWriter.
+   */
+  inline ID id() const { return idOrLoc_.id(); }
+  /**
+    Get the error's location (could be empty in favor of the ID)
+
+    This only works after ErrorBase::write was invoked with this
+    CompatibilityWriter.
+   */
+  inline Location location() const { return idOrLoc_.location(); }
+  /**
+    Return the location that should be reported to the user.
+
+    This only works after ErrorBase::write was invoked with this
+    CompatibilityWriter.
+   */
+  inline Location computedLocation() const { return computedLoc_; }
+  /**
+    Return the error's brief message.
+
+    This only works after ErrorBase::write was invoked with this
+    CompatibilityWriter.
+   */
+  inline const std::string& message() const { return message_; }
+  /**
+    Return the error's notes / details.
+
+    This only works after ErrorBase::write was invoked with this
+    CompatibilityWriter.
+   */
+  const std::vector<ErrorNote>& notes() const { return notes_; }
+  /**
+    Return the error's code snippets.
+
+    This only works after ErrorBase::write was invoked with this
+    CompatibilityWriter.
+   */
+  const std::vector<ErrorCodeSnippet>& codeSnippets() const { return codeSnippets_; }
+};
+
+
 } // end namespace chpl
 
 #endif

--- a/frontend/lib/framework/ErrorBase.cpp
+++ b/frontend/lib/framework/ErrorBase.cpp
@@ -45,79 +45,6 @@ const char* ErrorBase::getTypeName(ErrorType type) {
   }
 }
 
-/**
-  Implementation of ErrorWriterBase that records calls
-  to the various API functions in order to convert ErrorBase
-  subclasses into backwards-compatible ErrorMessage instances.
- */
-class CompatibilityWriter : public ErrorWriterBase {
- private:
-  IdOrLocation idOrLoc_;
-  /** The computed location (derived from the ::id_ or ::loc_) */
-  Location computedLoc_;
-  /** The error's brief message */
-  std::string message_;
-  /** A list of notes associated with this error (aka details) */
-  std::vector<Note> notes_;
-
- public:
-  CompatibilityWriter(Context* context)
-    : ErrorWriterBase(context, OutputFormat::BRIEF) {}
-
-  void writeHeading(ErrorBase::Kind kind, ErrorType type,
-                    IdOrLocation idOrLoc, const std::string& message) override {
-    // We may not have a context e.g. if we are just figuring out the error
-    // message text. Trust that `computedLoc_` is not important for that.
-    if (context_) this->computedLoc_ = errordetail::locate(context_, idOrLoc);
-    this->idOrLoc_ = std::move(idOrLoc);
-    this->message_ = message;
-  }
-
-  void writeMessage(const std::string& message) override {}
-  void writeCode(const Location& loc,
-                 const std::vector<Location>& hl) override {}
-
-  void writeNote(IdOrLocation loc, const std::string& message) override {
-    this->notes_.push_back(std::make_tuple(std::move(loc), message));
-  }
-
-  /**
-    Get the error's ID (could be empty in favor of the location).
-
-    This only works after ErrorBase::write was invoked with this
-    CompatibilityWriter.
-   */
-  inline ID id() const { return idOrLoc_.id(); }
-  /**
-    Get the error's location (could be empty in favor of the ID)
-
-    This only works after ErrorBase::write was invoked with this
-    CompatibilityWriter.
-   */
-  inline Location location() const { return idOrLoc_.location(); }
-  /**
-    Return the location that should be reported to the user.
-
-    This only works after ErrorBase::write was invoked with this
-    CompatibilityWriter.
-   */
-  inline Location computedLocation() const { return computedLoc_; }
-  /**
-    Return the error's brief message.
-
-    This only works after ErrorBase::write was invoked with this
-    CompatibilityWriter.
-   */
-  inline const std::string& message() const { return message_; }
-  /**
-    Return the error's notes / details.
-
-    This only works after ErrorBase::write was invoked with this
-    CompatibilityWriter.
-   */
-  const std::vector<Note>& notes() const { return notes_; }
-};
-
 std::string ErrorBase::message() const {
   std::ostringstream oss;
   CompatibilityWriter ew(/* context */ nullptr);
@@ -168,7 +95,7 @@ void BasicError::write(ErrorWriterBase& wr) const {
 }
 
 void BasicError::mark(Context* context) const {
-  chpl::mark<Note> marker;
+  chpl::mark<ErrorNote> marker;
   idOrLoc_.mark(context);
   for (auto& note : notes_) {
     marker(context, note);

--- a/tools/chapel-py/src/core-types-gen.cpp
+++ b/tools/chapel-py/src/core-types-gen.cpp
@@ -22,6 +22,7 @@
 #include "chpl/uast/all-uast.h"
 #include "python-types.h"
 #include "chpl/framework/query-impl.h"
+#include "chpl/framework/ErrorWriter.h"
 #include "chpl/parsing/parsing-queries.h"
 #include "chpl/resolution/resolution-queries.h"
 #include "chpl/resolution/scope-queries.h"

--- a/tools/chapel-py/src/error-tracker.h
+++ b/tools/chapel-py/src/error-tracker.h
@@ -32,6 +32,8 @@ struct ErrorObject : public PythonClassWithObject<ErrorObject, chpl::owned<chpl:
   static constexpr const char* DocStr = "An error that occurred as part of processing a file with the Chapel compiler frontend";
 };
 
+using LocationAndNote = std::tuple<chpl::Location, std::string>;
+
 struct ErrorManagerObject : public PythonClassWithObject<ErrorManagerObject, std::tuple<>> {
   static constexpr const char* Name = "ErrorManager";
   static constexpr const char* DocStr = "A wrapper container to help track the errors from a Context.";

--- a/tools/chapel-py/src/method-tables/core-methods.h
+++ b/tools/chapel-py/src/method-tables/core-methods.h
@@ -94,10 +94,27 @@ CLASS_BEGIN(Scope)
 CLASS_END(Scope)
 
 CLASS_BEGIN(Error)
+  PLAIN_GETTER(Error, code_snippets, "Get the locations of code snippets printed by this error",
+               std::vector<chpl::ErrorCodeSnippet>,
+
+               CompatibilityWriter writer(context);
+               node->write(writer);
+               return writer.codeSnippets())
   PLAIN_GETTER(Error, location, "Get the location at which this error occurred",
                chpl::Location, return node->location(context))
   PLAIN_GETTER(Error, message, "Retrieve the contents of this error message",
                std::string, return node->message())
+  PLAIN_GETTER(Error, notes, "Get the locations and text of additional notes printed by this error",
+               std::vector<LocationAndNote>,
+
+               std::vector<LocationAndNote> toReturn;
+               CompatibilityWriter writer(context);
+               node->write(writer);
+               for (auto& note : writer.notes()) {
+                 toReturn.push_back(std::make_tuple(std::get<0>(note).computeLocation(context),
+                                                    std::get<1>(note)));
+               }
+               return toReturn)
   PLAIN_GETTER(Error, kind, "Retrieve the kind ('error', 'warning') of this type of error",
                const char*, return chpl::ErrorBase::getKindName(node->kind()))
   PLAIN_GETTER(Error, type, "Retrieve the unique name of this type of error",


### PR DESCRIPTION
This makes them clickable and goto-able :)

The functionality requires _locations_, which `chapel-py` itself does not currently concern itself with. So, the functionality is in CLS, which makes additional assumptions about files and their URLs right now. In other words, `chplcheck` doesn't benefit -- but barely any errors that `chplcheck` can report have additional notes anyway.

![image](https://github.com/chapel-lang/chapel/assets/4361282/ddaa1df6-9f29-443b-a215-3a29bda33356)

Reviewed by @jabraham17 -- thanks!
