### PR TITLE
Update hardcoded home path in syncPerfGraphs.py

### DIFF
--- a/util/cron/syncPerfGraphs.py
+++ b/util/cron/syncPerfGraphs.py
@@ -65,7 +65,7 @@ def syncToCrayWebhost(dirToSync, destDir, logFile, numRetries):
     # Assumes correct username and authentication for iad1-shared-b8-21.dreamhost.com is
     # configured for the current system.
     webHost = 'chapcs11.us.cray.com'
-    perfBaseDir = '/users/chapelu/public_html/perf'
+    perfBaseDir = '/hpcdc/data/users/chapelu/public_html/perf'
     perfDir = posixpath.join(perfBaseDir, destDir)
 
     rsyncDesc = 'rsync perf graphs to internal webhost'


### PR DESCRIPTION
Update a hardcoded home path from the soon-to-be decommissioned `/users/chapelu` to `/hpcdc/data/users/chapelu`.

The path is still hardcoded as this script is meant to be run from a system other than the one where the path exists. We could use a `~` for `$HOME` to be expanded on the destination system but I feel less confident in that being portable, and not getting expanded on the source system side.

[urgent test fix, not reviewed]