### PR TITLE
Make more fixes to `test-docker.bash`

### DIFF
--- a/util/cron/test-docker.bash
+++ b/util/cron/test-docker.bash
@@ -38,12 +38,12 @@ fi
 
 # Build chapel docker image. 
 cd $CHPL_HOME
-build_image chapel  ${CHPL_HOME}/util/cron/docker-chapel.bash
+build_image chapel/chapel  ${CHPL_HOME}/util/cron/docker-chapel.bash
 
 cd $CHPL_HOME/util/packaging/docker/gasnet
-build_image chapel_gasnet ${CHPL_HOME}/util/cron/docker-gasnet.bash
+build_image chapel/chapel_gasnet ${CHPL_HOME}/util/cron/docker-gasnet.bash
 
 cd $CHPL_HOME/util/packaging/docker/gasnet-smp
-build_image chapel_gasnet_smp ${CHPL_HOME}/util/cron/docker-gasnet.bash
+build_image chapel/chapel_gasnet_smp ${CHPL_HOME}/util/cron/docker-gasnet.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="docker"

--- a/util/cron/test-docker.bash
+++ b/util/cron/test-docker.bash
@@ -18,7 +18,7 @@ local imageName="$1"
 local script="$2" 
 # Remove any existing image with the tag before building docker image
 docker image rm --force $imageName
-docker build . -t $imageName
+docker build --load . -t $imageName
 containerid= docker image ls | grep $imageName | awk '{print$3}'
 cd ${CHPL_HOME}/util/cron
 echo 'writeln("Hello, world!");' > hello.chpl


### PR DESCRIPTION
Includes:
- Adding `--load` to the Docker build command. For reasons unknown to me (perhaps an update, or something I did unintentionally while doing https://github.com/chapel-lang/chapel/pull/24562) the build is now trying to use the `docker-container` (BuildKit) driver rather than Colima, which needs `--load` to export the image from the building container to Docker. I think it should be fine to just adjust this in response.
- Changing the image names we build to include their repository name (`chapel/`) prefixes. This means that the gasnet and gasnet-smp builds, whose Dockerfiles contain `FROM chapel/chapel`, will now build off of the newly-built chapel image. Previously it appears they unintentionally were built based off of the latest `chapel/chapel` that exists in Dockerhub -- from the previous release.

[test fix attempt, not reviewed]