### PR TITLE
Add a user facing error message for export proc argument mismatch

### DIFF
--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -2938,7 +2938,7 @@ static GenRet codegenCallExprInner(GenRet function,
     for (size_t i = 0; i < args.size(); i++) {
       const clang::CodeGen::ABIArgInfo* argInfo = NULL;
       if (CGI) {
-        argInfo = getCGArgInfo(CGI, i);
+        argInfo = getCGArgInfo(CGI, i, fn);
       } else if (args[i].isLVPtr == GEN_VAL && useDarwinArmFix(args[i].chplType)) {
         argInfo = getSingleCGArgInfo(args[i].chplType);
       }

--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -2047,7 +2047,7 @@ codegenFunctionTypeLLVM(FnSymbol* fn, llvm::AttributeList& attrs,
   for_formals(formal, fn) {
     const clang::CodeGen::ABIArgInfo* argInfo = NULL;
     if (CGI) {
-      argInfo = getCGArgInfo(CGI, clangArgNum);
+      argInfo = getCGArgInfo(CGI, clangArgNum, fn);
     } else if (useDarwinArmFix(formal->type)) {
       argInfo = getSingleCGArgInfo(formal->type);
     }
@@ -2767,7 +2767,7 @@ void FnSymbol::codegenDef() {
     for_formals(arg, this) {
       const clang::CodeGen::ABIArgInfo* argInfo = NULL;
       if (CGI) {
-        argInfo = getCGArgInfo(CGI, clangArgNum);
+        argInfo = getCGArgInfo(CGI, clangArgNum, this);
       } else if (useDarwinArmFix(arg->type)) {
         argInfo = getSingleCGArgInfo(arg->type);
       }

--- a/compiler/include/clangUtil.h
+++ b/compiler/include/clangUtil.h
@@ -97,7 +97,8 @@ const clang::CodeGen::CGFunctionInfo& getClangABIInfoFD(clang::FunctionDecl* FD)
 const clang::CodeGen::CGFunctionInfo& getClangABIInfo(FnSymbol* fn);
 
 const clang::CodeGen::ABIArgInfo*
-getCGArgInfo(const clang::CodeGen::CGFunctionInfo* CGI, int curCArg);
+getCGArgInfo(const clang::CodeGen::CGFunctionInfo* CGI, int curCArg,
+             FnSymbol* fn=nullptr);
 
 const clang::CodeGen::ABIArgInfo*
 getSingleCGArgInfo(Type* type);

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -4002,17 +4002,25 @@ const clang::CodeGen::CGFunctionInfo& getClangABIInfo(FnSymbol* fn) {
 }
 
 const clang::CodeGen::ABIArgInfo*
-getCGArgInfo(const clang::CodeGen::CGFunctionInfo* CGI, int curCArg)
+getCGArgInfo(const clang::CodeGen::CGFunctionInfo* CGI, int curCArg,
+             FnSymbol* fn)
 {
 
   // Don't try to use the calling convention code for variadic args.
-  if ((unsigned) curCArg >= CGI->arg_size() && CGI->isVariadic())
-    return NULL;
+  if ((unsigned) curCArg >= CGI->arg_size()) {
+    if (CGI->isVariadic()) {
+      return NULL;
+    }
+    else {
+      USR_FATAL(fn, "Argument number mismatch in export proc");
+    }
+  }
 
   const clang::CodeGen::ABIArgInfo* argInfo = NULL;
 #if HAVE_LLVM_VER >= 100
   llvm::ArrayRef<clang::CodeGen::CGFunctionInfoArgInfo> a=CGI->arguments();
   argInfo = &a[curCArg].info;
+
 #else
   int i = 0;
   for (auto &ii : CGI->arguments()) {

--- a/test/interop/C/errorMessage/errorInArgNMismatch.chpl
+++ b/test/interop/C/errorMessage/errorInArgNMismatch.chpl
@@ -1,0 +1,4 @@
+require "errorInArgNMismatch.h";
+
+export proc foo(x : real) { }
+

--- a/test/interop/C/errorMessage/errorInArgNMismatch.good
+++ b/test/interop/C/errorMessage/errorInArgNMismatch.good
@@ -1,0 +1,1 @@
+errorInArgNMismatch.chpl:3: error: Argument number mismatch in export proc

--- a/test/interop/C/errorMessage/errorInArgNMismatch.h
+++ b/test/interop/C/errorMessage/errorInArgNMismatch.h
@@ -1,0 +1,4 @@
+#pragma once
+
+void foo(void);
+


### PR DESCRIPTION
This replaces a compiler assertion with a user-facing error message. Noted by @twesterhout on [gitter](https://matrix.to/#/!PBYDSerrfYujeStENM:gitter.im/$D4ys_1Xy9ZLD437uk64oeOPAXzVkPMdBMYYgGJtLA1I?via=gitter.im&via=matrix.org&via=envs.net).

The assertion was triggered when Chapel code exports a function with more number of arguments then there is in the C header that declares the function on C side.

Test:
- [x] linux64