### PR TITLE
Update the docs button to reflect that the current docs are 2.0

### DIFF
--- a/doc/util/versionButton.php
+++ b/doc/util/versionButton.php
@@ -87,8 +87,8 @@ if (pagePath == "") {
   pagePath = "index";
 }
 function dropSetup() {
-  var currentRelease = "1.33"; // what does the public have?
-  var stagedRelease = "2.0";  // is there a release staged but not yet public?
+  var currentRelease = "2.0"; // what does the public have?
+  var stagedRelease = "2.1";  // is there a release staged but not yet public?
   var nextRelease = "2.1";    // what's the next release? (on docs/main)
   var button = document.getElementById("versionButton");
   // Uses unicode down-pointing triangle


### PR DESCRIPTION
This is the update to the docs pull-down menu corresponding to the 2.0 docs going live (staged, but not yet pushed at the time of opening this PR).