### PR TITLE
update homebrew formulas after 2.0.1 release

### DIFF
--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -1,24 +1,24 @@
 class Chapel < Formula
   desc "Programming language for productive parallel computing at scale"
   homepage "https://chapel-lang.org/"
-  url "https://github.com/chapel-lang/chapel/releases/download/1.33.0/chapel-1.33.0.tar.gz"
-  sha256 "9dfd9bbab3eb1acf10242db909ccf17c1b07634452ca6ba8b238e69788d82883"
+  url "https://github.com/chapel-lang/chapel/releases/download/2.0.0/chapel-2.0.0.tar.gz"
+  sha256 "b5387e9d37b214328f422961e2249f2687453c2702b2633b7d6a678e544b9a02"
   license "Apache-2.0"
   head "https://github.com/chapel-lang/chapel.git", branch: "main"
 
   bottle do
-    sha256 arm64_sonoma:   "bf48565f37d29f78919cdc53c05e23e5e610e915e82ede08573b06d4a9746d40"
-    sha256 arm64_ventura:  "ac622257bbef56945f8241d87a63982dae2311fa803f3233788c4a2d85af6b0b"
-    sha256 arm64_monterey: "03757fe09bfdbc1651aaa6b6ffbc54b14022ff13e19d62ca3abfe778de11371a"
-    sha256 sonoma:         "1a16b40a4a13bca828f12a497c521cbbd6d0add7c819a47583c4273769e921b8"
-    sha256 ventura:        "ad445bd4da02eca77f983c75d098716251df6af33e992627800bc4167b8b5947"
-    sha256 monterey:       "984f5634eb6875a9c4b311044305d6fea01a4c04e768d2e3e20dc617e7d91d27"
-    sha256 x86_64_linux:   "2e9f4c854f3bf0b2aa571c489e62ab7f398b1dfcb7ce87c12dc48930d94e6fac"
+    sha256 arm64_sonoma:   "e7ea9cadf5ba880d79b9aee5e82756faae156717bf4fcbf08edf2a6730beef78"
+    sha256 arm64_ventura:  "e7f3fa3355572f34be363ba6ad9832770e88326f598dd017e8b270e79499a5b1"
+    sha256 arm64_monterey: "96f19eb98b6323aa5405722ff4460ef41a287ae579656cacfebad903bf596413"
+    sha256 sonoma:         "49cfd27778bdf6d3e994a1ec7e343ef8893feb4b7c13043437f44f534b819e60"
+    sha256 ventura:        "1dc143ee5c62f2df2a62eaf4b0664489860790f68bec53b145ed35d0e14b7d31"
+    sha256 monterey:       "a5d7b507a654b3b40ffe22254e7c925a6aab5f740b9b66ab6dcc51d4d41f8daa"
+    sha256 x86_64_linux:   "eca86d0e17808b7e346ea8edbb5d95ec917b347e25f67bdf8fe27037b6b21914"
   end
 
   depends_on "cmake"
   depends_on "gmp"
-  depends_on "llvm@15"
+  depends_on "llvm"
   depends_on "python@3.11"
 
   # LLVM is built with gcc11 and we will fail on linux with gcc version 5.xx
@@ -49,11 +49,6 @@ class Chapel < Formula
       CHPL_LLVM_CONFIG=#{llvm.opt_bin}/llvm-config
       CHPL_LLVM_GCC_PREFIX=none
     EOS
-    # CHPL_MEM and CHPL_TASKS are currently being set this way due
-    # to this PR: https://github.com/chapel-lang/chapel/pull/23415.
-    # This is a workaround for an issue where the bundled jemalloc
-    # makefile is being run and failing when we are supposed to use
-    # the system jemalloc.
 
     # Must be built from within CHPL_HOME to prevent build bugs.
     # https://github.com/Homebrew/legacy-homebrew/pull/35166
@@ -68,6 +63,8 @@ class Chapel < Formula
       with_env(CHPL_LLVM: "system") do
         system "make"
       end
+      # TODO: a bug (in the formula?) is causing chpldoc to not be installed
+      # see https://github.com/chapel-lang/chapel/issues/24639
       with_env(CHPL_PIP_FROM_SOURCE: "1") do
         system "make", "chpldoc"
       end
@@ -102,11 +99,16 @@ class Chapel < Formula
     cd libexec do
       with_env(CHPL_LLVM: "system") do
         system "util/test/checkChplInstall"
+        # TODO: enable when bug affecting chpldoc install is resolved
+        # system "util/test/checkChplDoc"
       end
       with_env(CHPL_LLVM: "none") do
         system "util/test/checkChplInstall"
+        # TODO: enable when bug affecting chpldoc install is resolved
+        # system "util/test/checkChplDoc"
       end
     end
     system bin/"chpl", "--print-passes", "--print-commands", libexec/"examples/hello.chpl"
+    system bin/"mason", "--version"
   end
 end

--- a/util/packaging/homebrew/chapel-release.rb
+++ b/util/packaging/homebrew/chapel-release.rb
@@ -1,8 +1,8 @@
 class Chapel < Formula
   desc "Programming language for productive parallel computing at scale"
   homepage "https://chapel-lang.org/"
-  url "https://github.com/chapel-lang/chapel/releases/download/1.32.0/chapel-1.32.0.tar.gz"
-  sha256 "9fb139756ebb63ab722856273457673fc7368b26d9a9483333650510506c0a96"
+  url "https://github.com/chapel-lang/chapel/releases/download/1.33.0/chapel-1.33.0.tar.gz"
+  sha256 "9dfd9bbab3eb1acf10242db909ccf17c1b07634452ca6ba8b238e69788d82883"
   license "Apache-2.0"
   head "https://github.com/chapel-lang/chapel.git", branch: "main"
 
@@ -44,13 +44,16 @@ class Chapel < Formula
     (libexec/"chplconfig").write <<~EOS
       CHPL_RE2=bundled
       CHPL_GMP=system
-    # These lines are added as part of this PR: https://github.com/chapel-lang/chapel/pull/23415.
-    # This is a workaround for an issue where the 
       CHPL_MEM=cstdlib
       CHPL_TASKS=fifo
       CHPL_LLVM_CONFIG=#{llvm.opt_bin}/llvm-config
       CHPL_LLVM_GCC_PREFIX=none
     EOS
+    # CHPL_MEM and CHPL_TASKS are currently being set this way due
+    # to this PR: https://github.com/chapel-lang/chapel/pull/23415.
+    # This is a workaround for an issue where the bundled jemalloc
+    # makefile is being run and failing when we are supposed to use
+    # the system jemalloc.
 
     # Must be built from within CHPL_HOME to prevent build bugs.
     # https://github.com/Homebrew/legacy-homebrew/pull/35166

--- a/util/packaging/homebrew/chapel-release.rb
+++ b/util/packaging/homebrew/chapel-release.rb
@@ -1,25 +1,25 @@
 class Chapel < Formula
   desc "Programming language for productive parallel computing at scale"
   homepage "https://chapel-lang.org/"
-  url "https://github.com/chapel-lang/chapel/releases/download/1.33.0/chapel-1.33.0.tar.gz"
-  sha256 "9dfd9bbab3eb1acf10242db909ccf17c1b07634452ca6ba8b238e69788d82883"
+  url "https://github.com/chapel-lang/chapel/releases/download/2.0.1/chapel-2.0.1.tar.gz"
+  sha256 "19ebcd88d829712468cfef10c634c3e975acdf78dd1a57671d11657574636053"
   license "Apache-2.0"
   head "https://github.com/chapel-lang/chapel.git", branch: "main"
 
   bottle do
-    sha256 arm64_sonoma:   "bf48565f37d29f78919cdc53c05e23e5e610e915e82ede08573b06d4a9746d40"
-    sha256 arm64_ventura:  "ac622257bbef56945f8241d87a63982dae2311fa803f3233788c4a2d85af6b0b"
-    sha256 arm64_monterey: "03757fe09bfdbc1651aaa6b6ffbc54b14022ff13e19d62ca3abfe778de11371a"
-    sha256 sonoma:         "1a16b40a4a13bca828f12a497c521cbbd6d0add7c819a47583c4273769e921b8"
-    sha256 ventura:        "ad445bd4da02eca77f983c75d098716251df6af33e992627800bc4167b8b5947"
-    sha256 monterey:       "984f5634eb6875a9c4b311044305d6fea01a4c04e768d2e3e20dc617e7d91d27"
-    sha256 x86_64_linux:   "2e9f4c854f3bf0b2aa571c489e62ab7f398b1dfcb7ce87c12dc48930d94e6fac"
+    sha256 arm64_sonoma:   "e75b261ff8378a1a86db49794ca9cc4419d8eadc7e7a4ce9a17430a5757bb778"
+    sha256 arm64_ventura:  "7ff7abdf3c8301727e52d65b15837b8974d7d3be52bcac72601b181bf426e444"
+    sha256 arm64_monterey: "a11ed899b3ccf9d8eac11910226d1f86a39f19a7d07c5e8d3f35d5785089eebc"
+    sha256 sonoma:         "e5edf9340b6bfb94bcf39f930406db9db9b2801dd378da85e489a6bd78a676b2"
+    sha256 ventura:        "ad9c9e354207c9926d25f513c1a3b7b6db0936dc1e27998f5859dd4d9cc7155b"
+    sha256 monterey:       "cbc79ae37aa099e744ff21b5654d7fdb364c012a02eb27a0e5d73e0783c2a999"
+    sha256 x86_64_linux:   "961ad1d420eeeac018098fba19f05ff207edcd279b8c98d5439838d9928f61de"
   end
 
   depends_on "cmake"
   depends_on "gmp"
-  depends_on "llvm@15"
-  depends_on "python@3.11"
+  depends_on "llvm@17"
+  depends_on "python@3.12"
 
   # LLVM is built with gcc11 and we will fail on linux with gcc version 5.xx
   fails_with gcc: "5"
@@ -28,12 +28,25 @@ class Chapel < Formula
     deps.map(&:to_formula).find { |f| f.name.match? "^llvm" }
   end
 
+  # Fixes: SyntaxWarning: invalid escape sequence '\d'
+  # Remove when merged: https://github.com/chapel-lang/chapel/pull/24643
+  patch :DATA
+
   def install
     # Always detect Python used as dependency rather than needing aliased Python formula
-    python = "python3.11"
-    # It should be noted that this will expand to: 'for cmd in python3.11 python3 python python2; do'
+    python = "python3.12"
+    # It should be noted that this will expand to: 'for cmd in python3.12 python3 python python2; do'
     # in our find-python.sh script.
     inreplace "util/config/find-python.sh", /^(for cmd in )(python3 )/, "\\1#{python} \\2"
+
+    # TEMPORARY adds clean-cmakecache target to prevent issues where only
+    #           the first make target gets written to the proper CMAKE_RUNTIME_OUTPUT_DIRECTORY
+    #           cmake detects a change in compilers (although the values are the same?) and
+    #           reruns configure, losing the output directory we set at configure time
+    inreplace "compiler/Makefile",
+              "all: $(PRETARGETS) $(MAKEALLSUBDIRS) echocompilerdir $(TARGETS)\n",
+              "all: $(PRETARGETS) $(MAKEALLSUBDIRS) echocompilerdir $(TARGETS)\n\n
+              clean-cmakecache: FORCE\n\trm -f $(COMPILER_BUILD)/CMakeCache.txt\n\n"
 
     libexec.install Dir["*"]
     # Chapel uses this ENV to work out where to install.
@@ -49,26 +62,24 @@ class Chapel < Formula
       CHPL_LLVM_CONFIG=#{llvm.opt_bin}/llvm-config
       CHPL_LLVM_GCC_PREFIX=none
     EOS
-    # CHPL_MEM and CHPL_TASKS are currently being set this way due
-    # to this PR: https://github.com/chapel-lang/chapel/pull/23415.
-    # This is a workaround for an issue where the bundled jemalloc
-    # makefile is being run and failing when we are supposed to use
-    # the system jemalloc.
 
     # Must be built from within CHPL_HOME to prevent build bugs.
     # https://github.com/Homebrew/legacy-homebrew/pull/35166
     cd libexec do
       system "./util/printchplenv", "--all"
-      with_env(CHPL_PIP_FROM_SOURCE: "1") do
-        system "make", "test-venv"
-      end
       with_env(CHPL_LLVM: "none") do
         system "make"
       end
       with_env(CHPL_LLVM: "system") do
+        cd "compiler" do
+          system "make", "clean-cmakecache"
+        end
         system "make"
       end
       with_env(CHPL_PIP_FROM_SOURCE: "1") do
+        cd "compiler" do
+          system "make", "clean-cmakecache"
+        end
         system "make", "chpldoc"
       end
       system "make", "mason"
@@ -102,11 +113,30 @@ class Chapel < Formula
     cd libexec do
       with_env(CHPL_LLVM: "system") do
         system "util/test/checkChplInstall"
+        system "util/test/checkChplDoc"
       end
       with_env(CHPL_LLVM: "none") do
         system "util/test/checkChplInstall"
+        system "util/test/checkChplDoc"
       end
     end
     system bin/"chpl", "--print-passes", "--print-commands", libexec/"examples/hello.chpl"
+    system bin/"chpldoc", "--version"
+    system bin/"mason", "--version"
   end
 end
+
+__END__
+diff --git a/util/chplenv/compiler_utils.py b/util/chplenv/compiler_utils.py
+index c4d683830f4c..1d1be1d55521 100644
+--- a/util/chplenv/compiler_utils.py
++++ b/util/chplenv/compiler_utils.py
+@@ -32,7 +32,7 @@ def CompVersion(version_string):
+     are not specified, 0 will be used for their value(s)
+     """
+     CompVersionT = namedtuple('CompVersion', ['major', 'minor', 'revision', 'build'])
+-    match = re.search(u'(\d+)(\.(\d+))?(\.(\d+))?(\.(\d+))?', version_string)
++    match = re.search(u"(\\d+)(\\.(\\d+))?(\\.(\\d+))?(\\.(\\d+))?", version_string)
+     if match:
+         major    = int(match.group(1))
+         minor    = int(match.group(3) or 0)

--- a/util/packaging/homebrew/readme.md
+++ b/util/packaging/homebrew/readme.md
@@ -1,20 +1,25 @@
 
-This folder contains a copy of the shipping homebrew formula `chapel-release.rb`, 
-and the modified formula that would be used in the next chapel release as 
-`chapel-main.rb`.  These are stored here to allow the Chapel team test upcoming changes without 
-impacting the Homebrew core project formula: (https://github.com/Homebrew/homebrew-core/blob/master/Formula/chapel.rb).   
-## Tracking changes
-The homebrew team will update formulas under some circumstances and this mostly when a formula
-has not specified a version for a dependency.  For example, the `chapel.rb` formula refers to the 
-most recent version of `llvm` via this line `depends_on "llvm"`.  If the `llvm` project updates their 
-formula, the homebrew team will modify dependencies by specifying a version such as `depends_on "llvm@13"`.
-They will also indicate the formula changed via the addtion of a revision value such as `revision 1` as seen
-in the 1.25.1 update:  https://github.com/Homebrew/homebrew-core/blob/c63259777f760d8cebdce758c3e91778e58b55a5/Formula/chapel.rb. 
+This folder contains a copy of the shipping homebrew formula `chapel-release.rb`,
+and the modified formula that would be used in the next chapel release as
+`chapel-main.rb`.  These are stored here to allow the Chapel team test upcoming changes without
+impacting the Homebrew core project formula: (https://github.com/Homebrew/homebrew-core/blob/master/Formula/chapel.rb).
 
-## How to release the formula 
-The homebrew docs explain how to issue a pull request here:  
-https://docs.brew.sh/How-To-Open-a-Homebrew-Pull-Request.  Before issuing the request itself, 
-the following commands should be run before submitting the PR: 
+## Tracking changes
+The homebrew team will update formulas under some circumstances without notifying
+us. This can happen if a dependency of ours, like llvm, gets updated and the
+latest version causes our formula to stop building.  For example, the `chapel.rb`
+formula refers to the most recent version of `llvm` via this line `depends_on "llvm"`.
+If the `llvm` project updates their formula, the homebrew team will modify dependencies
+by specifying a version such as `depends_on "llvm@13"`.
+They will also indicate the formula changed via the addition of a revision value such as `revision 1` as seen
+in the 1.25.1 update:  https://github.com/Homebrew/homebrew-core/blob/c63259777f760d8cebdce758c3e91778e58b55a5/Formula/chapel.rb.
+When we make a point release they might also update a formula without telling us, as in
+the 2.0.1 release: https://github.com/Homebrew/homebrew-core/commit/33e634c62ef8f5f6c7273cec442d661f92610aa5
+
+## How to release the formula
+The homebrew docs explain how to issue a pull request here:
+https://docs.brew.sh/How-To-Open-a-Homebrew-Pull-Request.  Before issuing the request itself,
+the following commands should be run before submitting the PR:
 ```
 brew tests
 brew install --build-from-source <CHANGED_FORMULA>
@@ -22,48 +27,48 @@ brew test <CHANGED_FORMULA>
 brew audit --strict --online <CHANGED_FORMULA>`
 ```
 
-These steps confirm that the formula will build within your local homebrew environment and 
+These steps confirm that the formula will build within your local homebrew environment and
 that the formula itself is properly formatted.  No trailing whitespace or extraneous characters
-thhat would cause the homebrew CI process to fail. 
+thhat would cause the homebrew CI process to fail.
 
-### Linuxbrew testing 
-The Ubuntu CI is run on a docker container per the instructions on their contribution documentation: 
+### Linuxbrew testing
+The Ubuntu CI is run on a docker container per the instructions on their contribution documentation:
 https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md
 
-The container is executed using the following instructions: 
+The container is executed using the following instructions:
 ```
 docker run --interactive --tty --rm --pull always homebrew/ubuntu22.04:latest /bin/bash
 ```
 
-Formulas can be copied to the container using the following command: 
+Formulas can be copied to the container using the following command:
 ```
 docker cp chapel.rb <container name or container ID>:/home/linuxbrew/chapel.rb
 ```
 
 ## How to test formula changes
-With the most recent release of Chapel, the formula has been updated to support 
-testing of the main trunk of the source tree.  This approach will clone the Chapel 
-repository locally and build from source.   The instructions for this approach
-are listed below: 
+With the most recent release of Chapel, the formula has been updated to support
+testing of the main trunk of the source tree. This approach will clone the Chapel
+repository locally and build from source.  The instructions for this approach
+are listed below:
 
  - Rename `chapel-main.rb` to `chapel.rb`
- - Run the following command: 
-   - `brew  install --HEAD chapel.rb` 
- - Validate the build by running: 
+ - Run the following command:
+   - `brew  install --HEAD chapel.rb`
+ - Validate the build by running:
    - `chpl --version`
    - Compile and run pidigits
 
 Alternatively, local testing can also be performed using a tarball, and the instructions
-for creating that artifact and building the homebrew package are listed below: 
+for creating that artifact and building the homebrew package are listed below:
 
- - Clone Chapel source 
+ - Clone Chapel source
  - Build the tarball via `./util/cron/create_tarball.bash`
  - Run `shasum -a 256 "url for the tarball"`
- - Verify the permissions on the tarball - it should be set to `644` if you are attempting to use a web location. 
- - Rename `chapel-main.rb` to `chapel.rb` 
+ - Verify the permissions on the tarball - it should be set to `644` if you are attempting to use a web location.
+ - Rename `chapel-main.rb` to `chapel.rb`
  - Modify the `chapel.rb` file to include the tarball URL (this can be a network location or a local file) and sha256 value
- - Then the following command can be run to build and install: 
+ - Then the following command can be run to build and install:
    - `brew install --build-from-source chapel.rb`
- - Finally, the install can be validated by running: 
+ - Finally, the install can be validated by running:
    - `chpl --version`
    - Compile and run pidigits


### PR DESCRIPTION
This PR updates `chapel-main.rb` to match the currently released formula for 2.0 and updates `chapel-release.rb` to contain the previous 1.33 released formula.

I skipped this step during the release process, it should have happened earlier. It probably needs to be called out as a separate step because it's not really part of the homebrew PR itself. 

[reviewed by @tzinsky - thanks!]