### PR TITLE
Make semantics (of when to call init=) for 'in' intents more consistent between forall and foreach loops 

### DIFF
--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -1816,11 +1816,12 @@ static void cleanupTaskIndependentCapturePrimitive(CallExpr *call) {
 // intent variables to gpu lowering.
 //
 //   (given an 'in' intent for a variable 'x'):
-//     const capturedX = copy-of(x);
-//     var taskIndX = PRIM_TASK_IND_CAPTURE_OF(copy-of(capturedX));
+//     var taskIndX = PRIM_TASK_IND_CAPTURE_OF(copy-of(x));
 //
-// Once we're done with gpu lowering we no longer need this primitive and so we
-// remove it.
+// For gpuized loops GPU lowering rewrites this as needed to ensure each thread
+// has an indpendent copy-of x, loops that are not gpuized will have remaining
+// uses of the primitive, which we process by removing the primitive but keeping
+// the copy.
 static void cleanupTaskIndependentCapturePrimitives() {
   for_alive_in_Vec(CallExpr, callExpr, gCallExprs)
     if(callExpr->isPrimitive(PRIM_TASK_PRIVATE_SVAR_CAPTURE))

--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -1541,6 +1541,7 @@ static void markLoopProperties(ForLoop* forLoop, BlockStmt* ibody,
 // While processing these update a symbol map that we'll use to map shadow
 // variables to whatever they should be mapped to in the expanded loop.
 static void processShadowVariables(ForLoop* forLoop, SymbolMap *map) {
+  SET_LINENO(forLoop);
   for_shadow_vars (svar, temp, forLoop) {
     switch (svar->intent) {
       case TFI_DEFAULT:
@@ -1550,28 +1551,25 @@ static void processShadowVariables(ForLoop* forLoop, SymbolMap *map) {
       case TFI_CONST_IN:
       case TFI_IN:
         {
-        // If we have a variable with an 'in' intent for a foreach loop we'll
-        // want to capture its value before we start executing the loop. We'll
-        // use this copied version to give an initial value to thread-private
-        // versions of the variable.  How many thread private variables we
-        // should have and how to initialize them is something handled by later
-        // passes since at this point we don't know if this loop will be
-        // vectorized or gpuized, so in the meantime we model this as an
-        // assignment to a primitive and leave it to future passes (like
-        // gpuTransforms) to rewrite things as appropriate.
-        // IOW: coming out of this case we'll add something that looks like this:
+        // If we have a variable with an 'in' intent for a foreach loop we
+        // need to create task private copies of the variable. We assume
+        // that the user will not introduce a race condition involving modifying
+        // the outside variable while we create these copies.
+        // 
+        // The exact way to create these task private copies will depend on if
+        // the loop is vectorized or gpuized or not so rather than deal with
+        // this during iterator lowering we wrap a piece of code demonstrating
+        // how to copy the in intent'd variable in a primitive like this:
         //
-        //   var capX = x;
-        //   var taskIndX = PRIM_TASK_PRIVATE_SVAR_CAPTURE(capX);
-        //   # note: there's also a flag on taskIndX marking it as being a "task"-independent variable
+        //   var taskIndX = PRIM_TASK_PRIVATE_SVAR_CAPTURE(x);
+        //   # note: there's also a flag on taskIndX marking it as being a
+        //   "task"-independent variable
 
-        SET_LINENO(forLoop);
-
-        VarSymbol* capturedSvar = new VarSymbol(astr("cap_", svar->name), svar->type);
-        forLoop->insertBefore(new DefExpr(capturedSvar));
-
-        // Shadow variables have an "initBlock", we want to use this block to
-        // get a copy of the variable. An example of svar->initBlock() might
+        // In reality, the way we copy a variable may be more complicated than
+        // a simple assignment (for example if the variable is an object).
+        //
+        // Shadow variables have an "initBlock", we can use this to figure out
+        // how to copy of the variable. An example of svar->initBlock() might
         // look like this:
         //
         //  (BlockStmt
@@ -1581,40 +1579,66 @@ static void processShadowVariables(ForLoop* forLoop, SymbolMap *map) {
         //          (SymExpr 'fn chpl__initCopy')
         //          (SymExpr 'const-val INP_this')))
         //
-        // But we rather than getting a copy of INP_this we want to get a copy of
+        // But rather than getting a copy of INP_this we want to get a copy of
         // the outer variable that the shadow variable is shadowing (i.e.
         // outerVarSE).
-        //
         CallExpr *initMove = toCallExpr(svar->initBlock()->body.first());
-        SymbolMap map1;
-        Symbol* outerVarSym = svar->outerVarSE->symbol();
+        if(initMove->isPrimitive(PRIM_MOVE)) {
+          Symbol* outerVarSym = svar->outerVarSE->symbol();
 
-        // When the shadow variable is owned/shared, we may have created a
-        // borrow for it. In that case, we'll need to find that borrow as the
-        // outerVar
-        if (DefExpr* prevDef = toDefExpr(svar->defPoint->prev)) {
-          if (ShadowVarSymbol* castTemp = toShadowVarSymbol(prevDef->sym)) {
-            if (castTemp->isCompilerAdded()) {
-              Symbol* castOuter = castTemp->outerVarSE->symbol();
-              if (castOuter->hasFlag(FLAG_TFI_BORROW_TEMP)) {
-                outerVarSym = castOuter;
+          // When the shadow variable is owned/shared, we may have created a
+          // borrow for it. In that case, we'll need to find that borrow as the
+          // outerVar
+          if (DefExpr* prevDef = toDefExpr(svar->defPoint->prev)) {
+            if (ShadowVarSymbol* castTemp = toShadowVarSymbol(prevDef->sym)) {
+              if (castTemp->isCompilerAdded()) {
+                Symbol* castOuter = castTemp->outerVarSE->symbol();
+                if (castOuter->hasFlag(FLAG_TFI_BORROW_TEMP)) {
+                  outerVarSym = castOuter;
+                }
               }
             }
           }
+
+          SymbolMap mapForInitCopy;
+          mapForInitCopy.put(svar->ParentvarForIN(), outerVarSym);
+          Expr *copiedInitialization = initMove->get(2)->copy(&mapForInitCopy);
+          VarSymbol* taskIndVar = new VarSymbol(astr("taskInd_", svar->name), svar->type);
+          taskIndVar->addFlag(FLAG_TASK_PRIVATE_VARIABLE);
+          forLoop->insertBefore(new DefExpr(taskIndVar));
+          forLoop->insertBefore(new CallExpr(
+              PRIM_MOVE, taskIndVar,
+              new CallExpr(PRIM_TASK_PRIVATE_SVAR_CAPTURE, copiedInitialization)));
+
+          map->put(svar, taskIndVar);
+        } else {
+          // If the initialization block doesn't use a MOVE expression but rather
+          // calls an init function directly (passing the to-be initialized object
+          // in by ref) then we process that differently.
+          //
+          // IOW we are given:
+          //   (CallExpr
+          //      (fn init =)
+          //      (val x)
+          //      (INP_x))
+          //
+          // And we want:
+          // 
+          //   PRIM_TASK_PRIVATE_SVAR_CAPTURE(init=(taskInd_x, capX));
+          VarSymbol* taskIndVar = new VarSymbol(astr("taskInd_", svar->name), svar->type);
+          taskIndVar->addFlag(FLAG_TASK_PRIVATE_VARIABLE);
+          forLoop->insertBefore(new DefExpr(taskIndVar));
+
+          SymbolMap mapForInitCopy;
+          Symbol* outerVarSym = svar->outerVarSE->symbol();
+          mapForInitCopy.put(svar->ParentvarForIN(), outerVarSym);
+          mapForInitCopy.put(svar, taskIndVar);
+          Expr *copiedInitialization = initMove->copy(&mapForInitCopy);
+          forLoop->insertBefore(
+              new CallExpr(PRIM_TASK_PRIVATE_SVAR_CAPTURE, copiedInitialization));
+
+          map->put(svar, taskIndVar);
         }
-
-        map1.put(svar->ParentvarForIN(), outerVarSym);
-        Expr *copiedInitialization = initMove->get(2)->copy(&map1);
-        forLoop->insertBefore(new CallExpr(PRIM_MOVE, capturedSvar, copiedInitialization));
-
-        VarSymbol* taskIndVar = new VarSymbol(astr("taskInd_", svar->name), svar->type);
-        taskIndVar->addFlag(FLAG_TASK_PRIVATE_VARIABLE);
-        forLoop->insertBefore(new DefExpr(taskIndVar));
-        forLoop->insertBefore(new CallExpr(
-            PRIM_MOVE, taskIndVar,
-            new CallExpr(PRIM_TASK_PRIVATE_SVAR_CAPTURE, copiedInitialization->copy())));
-
-        map->put(svar, taskIndVar);
         }
         break;
 

--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -1559,7 +1559,7 @@ static void processShadowVariables(ForLoop* forLoop, SymbolMap *map) {
           // The exact way to create these task private copies will depend on
           // if the loop is vectorized or gpuized or not so rather than deal
           // with this during iterator lowering we wrap a piece of code
-          // demonstrating how to copy the in intent'd variable in a primitive 
+          // demonstrating how to copy the in intent'd variable in a primitive
           // like this:
           //
           //   var taskIndX = PRIM_TASK_PRIVATE_SVAR_CAPTURE(x);

--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -1551,96 +1551,102 @@ static void processShadowVariables(ForLoop* forLoop, SymbolMap *map) {
       case TFI_CONST_IN:
       case TFI_IN:
         {
-        // If we have a variable with an 'in' intent for a foreach loop we
-        // need to create task private copies of the variable. We assume
-        // that the user will not introduce a race condition involving modifying
-        // the outside variable while we create these copies.
-        //
-        // The exact way to create these task private copies will depend on if
-        // the loop is vectorized or gpuized or not so rather than deal with
-        // this during iterator lowering we wrap a piece of code demonstrating
-        // how to copy the in intent'd variable in a primitive like this:
-        //
-        //   var taskIndX = PRIM_TASK_PRIVATE_SVAR_CAPTURE(x);
-        //   # note: there's also a flag on taskIndX marking it as being a
-        //   "task"-independent variable
+          // If we have a variable with an 'in' intent for a foreach loop we
+          // need to create task private copies of the variable. We assume
+          // that the user will not introduce a race condition involving
+          // modifying the outside variable while we create these copies.
+          //
+          // The exact way to create these task private copies will depend on
+          // if the loop is vectorized or gpuized or not so rather than deal
+          // with this during iterator lowering we wrap a piece of code
+          // demonstrating how to copy the in intent'd variable in a primitive 
+          // like this:
+          //
+          //   var taskIndX = PRIM_TASK_PRIVATE_SVAR_CAPTURE(x);
+          //   # note: there's also a flag on taskIndX marking it as being a
+          //   "task"-independent variable
 
-        // In reality, the way we copy a variable may be more complicated than
-        // a simple assignment (for example if the variable is an object).
-        //
-        // Shadow variables have an "initBlock", we can use this to figure out
-        // how to copy of the variable. An example of svar->initBlock() might
-        // look like this:
-        //
-        //  (BlockStmt
-        //    (CallExpr move
-        //      (SymExpr 'const-val this')
-        //        (CallExpr
-        //          (SymExpr 'fn chpl__initCopy')
-        //          (SymExpr 'const-val INP_this')))
-        //
-        // But rather than getting a copy of INP_this we want to get a copy of
-        // the outer variable that the shadow variable is shadowing (i.e.
-        // outerVarSE).
-        CallExpr *initMove = toCallExpr(svar->initBlock()->body.first());
-        if(initMove->isPrimitive(PRIM_MOVE)) {
-          Symbol* outerVarSym = svar->outerVarSE->symbol();
+          // In reality, the way we copy a variable may be more complicated
+          // than a simple assignment (for example if the variable is an
+          // object).
+          //
+          // Shadow variables have an "initBlock", we can use this to figure
+          // out how to copy of the variable. An example of svar->initBlock()
+          // might look like this:
+          //
+          //  (BlockStmt
+          //    (CallExpr move
+          //      (SymExpr 'const-val this')
+          //        (CallExpr
+          //          (SymExpr 'fn chpl__initCopy')
+          //          (SymExpr 'const-val INP_this')))
+          //
+          // But rather than getting a copy of INP_this we want to get a copy
+          // of the outer variable that the shadow variable is shadowing (i.e.
+          // outerVarSE).
+          CallExpr *initMove = toCallExpr(svar->initBlock()->body.first());
+          if(initMove->isPrimitive(PRIM_MOVE)) {
+            Symbol* outerVarSym = svar->outerVarSE->symbol();
 
-          // When the shadow variable is owned/shared, we may have created a
-          // borrow for it. In that case, we'll need to find that borrow as the
-          // outerVar
-          if (DefExpr* prevDef = toDefExpr(svar->defPoint->prev)) {
-            if (ShadowVarSymbol* castTemp = toShadowVarSymbol(prevDef->sym)) {
-              if (castTemp->isCompilerAdded()) {
-                Symbol* castOuter = castTemp->outerVarSE->symbol();
-                if (castOuter->hasFlag(FLAG_TFI_BORROW_TEMP)) {
-                  outerVarSym = castOuter;
+            // When the shadow variable is owned/shared, we may have created a
+            // borrow for it. In that case, we'll need to find that borrow as
+            // the outerVar
+            if (DefExpr* prevDef = toDefExpr(svar->defPoint->prev)) {
+              if (ShadowVarSymbol* castTemp=toShadowVarSymbol(prevDef->sym)) {
+                if (castTemp->isCompilerAdded()) {
+                  Symbol* castOuter = castTemp->outerVarSE->symbol();
+                  if (castOuter->hasFlag(FLAG_TFI_BORROW_TEMP)) {
+                    outerVarSym = castOuter;
+                  }
                 }
               }
             }
-          }
 
-          SymbolMap mapForInitCopy;
-          mapForInitCopy.put(svar->ParentvarForIN(), outerVarSym);
-          Expr *copiedInitialization = initMove->get(2)->copy(&mapForInitCopy);
-          VarSymbol* taskIndVar = new VarSymbol(astr("taskInd_", svar->name), svar->type);
-          taskIndVar->addFlag(FLAG_TASK_PRIVATE_VARIABLE);
-          forLoop->insertBefore(new DefExpr(taskIndVar));
-          forLoop->insertBefore(new CallExpr(
+            SymbolMap mapForInitCopy;
+            mapForInitCopy.put(svar->ParentvarForIN(), outerVarSym);
+            Expr *copiedInitialization =
+              initMove->get(2)->copy(&mapForInitCopy);
+            VarSymbol* taskIndVar = new VarSymbol(
+              astr("taskInd_", svar->name), svar->type);
+            taskIndVar->addFlag(FLAG_TASK_PRIVATE_VARIABLE);
+            forLoop->insertBefore(new DefExpr(taskIndVar));
+            forLoop->insertBefore(new CallExpr(
               PRIM_MOVE, taskIndVar,
-              new CallExpr(PRIM_TASK_PRIVATE_SVAR_CAPTURE, copiedInitialization)));
+              new CallExpr(PRIM_TASK_PRIVATE_SVAR_CAPTURE,
+                copiedInitialization)));
 
-          map->put(svar, taskIndVar);
-        } else {
-          // If the initialization block doesn't use a MOVE expression but rather
-          // calls an init function directly (passing the to-be initialized object
-          // in by ref) then we process that differently.
-          //
-          // IOW we are given:
-          //   (CallExpr
-          //      (fn init =)
-          //      (val x)
-          //      (INP_x))
-          //
-          // And we want:
-          //
-          //   PRIM_TASK_PRIVATE_SVAR_CAPTURE(init=(taskInd_x, capX));
-          VarSymbol* taskIndVar = new VarSymbol(astr("taskInd_", svar->name), svar->type);
-          taskIndVar->addFlag(FLAG_TASK_PRIVATE_VARIABLE);
-          forLoop->insertBefore(new DefExpr(taskIndVar));
+            map->put(svar, taskIndVar);
+          } else {
+            // If the initialization block doesn't use a MOVE expression but
+            // rather calls an init function directly (passing the to-be
+            // initialized object in by ref) then we process that differently.
+            //
+            // IOW we are given:
+            //   (CallExpr
+            //      (fn init =)
+            //      (val x)
+            //      (INP_x))
+            //
+            // And we want:
+            //
+            //   PRIM_TASK_PRIVATE_SVAR_CAPTURE(init=(taskInd_x, capX));
+            VarSymbol* taskIndVar = new VarSymbol(
+              astr("taskInd_", svar->name), svar->type);
+            taskIndVar->addFlag(FLAG_TASK_PRIVATE_VARIABLE);
+            forLoop->insertBefore(new DefExpr(taskIndVar));
 
-          SymbolMap mapForInitCopy;
-          Symbol* outerVarSym = svar->outerVarSE->symbol();
-          mapForInitCopy.put(svar->ParentvarForIN(), outerVarSym);
-          mapForInitCopy.put(svar, taskIndVar);
-          Expr *copiedInitialization = initMove->copy(&mapForInitCopy);
-          forLoop->insertBefore(
-              new CallExpr(PRIM_TASK_PRIVATE_SVAR_CAPTURE, copiedInitialization));
+            SymbolMap mapForInitCopy;
+            Symbol* outerVarSym = svar->outerVarSE->symbol();
+            mapForInitCopy.put(svar->ParentvarForIN(), outerVarSym);
+            mapForInitCopy.put(svar, taskIndVar);
+            Expr *copiedInitialization = initMove->copy(&mapForInitCopy);
+            forLoop->insertBefore(
+              new CallExpr(PRIM_TASK_PRIVATE_SVAR_CAPTURE,
+                copiedInitialization));
 
-          map->put(svar, taskIndVar);
-        }
-        }
-        break;
+            map->put(svar, taskIndVar);
+          }
+        }break;
 
       case TFI_IN_PARENT:
       case TFI_REF:

--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -1555,7 +1555,7 @@ static void processShadowVariables(ForLoop* forLoop, SymbolMap *map) {
         // need to create task private copies of the variable. We assume
         // that the user will not introduce a race condition involving modifying
         // the outside variable while we create these copies.
-        // 
+        //
         // The exact way to create these task private copies will depend on if
         // the loop is vectorized or gpuized or not so rather than deal with
         // this during iterator lowering we wrap a piece of code demonstrating
@@ -1623,7 +1623,7 @@ static void processShadowVariables(ForLoop* forLoop, SymbolMap *map) {
           //      (INP_x))
           //
           // And we want:
-          // 
+          //
           //   PRIM_TASK_PRIVATE_SVAR_CAPTURE(init=(taskInd_x, capX));
           VarSymbol* taskIndVar = new VarSymbol(astr("taskInd_", svar->name), svar->type);
           taskIndVar->addFlag(FLAG_TASK_PRIVATE_VARIABLE);

--- a/test/statements/foreach/inIntentToRecordWithConstructor.chpl
+++ b/test/statements/foreach/inIntentToRecordWithConstructor.chpl
@@ -1,0 +1,20 @@
+record myR {
+  var x = 10;
+  proc init() do writeln("init");
+  proc init=(other) {
+    this.x = other.x;
+    writeln("init=");
+  }
+
+}
+var rInstance: myR;
+var sum = 0;
+writeln("Is this 10? ", rInstance.x);  // yes
+
+foreach i in 1..10 with (ref sum, in rInstance) {  // ignore racy `ref sum`
+  rInstance.x = 5;
+  sum += rInstance.x;
+}
+
+writeln("Is this 10? ", rInstance.x);  // yes
+writeln("Is this 50? ", sum);  // yes

--- a/test/statements/foreach/inIntentToRecordWithConstructor.good
+++ b/test/statements/foreach/inIntentToRecordWithConstructor.good
@@ -1,0 +1,5 @@
+init
+Is this 10? 10
+init=
+Is this 10? 10
+Is this 50? 50


### PR DESCRIPTION
We would like consistent semantics for task intents between `forall` and `foreach` loops.

When using an `in` intent on a record that defines `init=` in a `forall` loop we will see that `init=` gets called once per task. Previously, in a `foreach` loop we wouldn't do this (instead we would create copies but would do so doing something akin to a strict field-by-field rather than calling the user-defined `init=` method). This was a bug that is now fixed in this PR.

This PR also modifies things so the only copies we create are the task-private copies (in a non-vectorized, non-gpuized loop). Previously, we would first create a "captured" copy of the `in` intent'd variable and then make copies from that. This would ensure all tasks would have the same copy; a safer thing to do in case there's a race condition where some other task modifies the shadowed variable. Nevertheless, despite the safety concerns doing so adds overhead, doesn't seem like something users are likely to encounter, and isn't the current behavior for `forall` loops. For `forall` it seems to have something of a consensus that this is acceptable (https://github.com/Cray/chapel-private/issues/6066#issuecomment-2007938176). Anyway, in the interest of making things more consistent I now avoid creating this "captured" copy.

### Testing:
- [x] non-gasnet paratests
- [x] gpu nvidia paratests 