### PR TITLE
Add 'const' qualifier to generated 'c_ptrConst' types in C code

### DIFF
--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -1105,7 +1105,10 @@ transformTypeForPointer(Type* type) {
   } else if (type->symbol->hasFlag(FLAG_C_PTR_CLASS)) {
     // TODO: add const qualifier for const pointers?
     Type* pointedTo = getDataClassType(type->symbol)->typeInfo();
-    return pointedTo->codegen().c + " *";
+    bool isConst = type->symbol->hasFlag(FLAG_C_PTRCONST_CLASS);
+    std::string ret = isConst ? "const " : "";
+    ret += pointedTo->codegen().c + " *";
+    return ret;
   }
   std::string typeName = type->codegen().c;
   return typeName;

--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -1103,7 +1103,6 @@ transformTypeForPointer(Type* type) {
     return referenced->codegen().c + " *";
 
   } else if (type->symbol->hasFlag(FLAG_C_PTR_CLASS)) {
-    // TODO: add const qualifier for const pointers?
     Type* pointedTo = getDataClassType(type->symbol)->typeInfo();
     bool isConst = type->symbol->hasFlag(FLAG_C_PTRCONST_CLASS);
     std::string ret = isConst ? "const " : "";

--- a/test/interop/C/PtrConstQualifier.chpl
+++ b/test/interop/C/PtrConstQualifier.chpl
@@ -1,6 +1,24 @@
 use CTypes;
 
+proc internalGenericProc(x) { x; }
+
+proc internalProc(x: c_ptrConst(int(32))) {
+  internalGenericProc(x);
+
+  // Test #0
+  var n1: int(32) = 8;
+  var p1 = c_ptrToConst(n1);
+  assert(p1 != x);
+  assert(p1.deref() == x.deref());
+
+  // Test #1
+  const n2: int(32) = 8;
+  var p2 = c_ptrToConst(n2);
+  assert(p2 != x && p2.deref() == x.deref());
+}
+
 export proc printAndReturn(x: c_ptrConst(int(32))) {
   writeln(x.deref():string);
+  internalProc(x);
   return x;
 }

--- a/test/interop/C/PtrConstQualifier.chpl
+++ b/test/interop/C/PtrConstQualifier.chpl
@@ -1,0 +1,6 @@
+use CTypes;
+
+export proc printAndReturn(x: c_ptrConst(int(32))) {
+  writeln(x.deref():string);
+  return x;
+}

--- a/test/interop/C/use_PtrConstQualifier.cleanfiles
+++ b/test/interop/C/use_PtrConstQualifier.cleanfiles
@@ -1,0 +1,2 @@
+lib/libPtrConstQualifier.a
+lib/PtrConstQualifier.h

--- a/test/interop/C/use_PtrConstQualifier.good
+++ b/test/interop/C/use_PtrConstQualifier.good
@@ -1,0 +1,2 @@
+8
+const int32_t * printAndReturn(const int32_t * x);

--- a/test/interop/C/use_PtrConstQualifier.lastcompopts
+++ b/test/interop/C/use_PtrConstQualifier.lastcompopts
@@ -1,0 +1,1 @@
+-Llib/ -lPtrConstQualifier `$CHPL_HOME/util/config/compileline --libraries` -lPtrConstQualifier

--- a/test/interop/C/use_PtrConstQualifier.prediff
+++ b/test/interop/C/use_PtrConstQualifier.prediff
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+grep printAndReturn lib/PtrConstQualifier.h >> $2

--- a/test/interop/C/use_PtrConstQualifier.test.c
+++ b/test/interop/C/use_PtrConstQualifier.test.c
@@ -1,0 +1,10 @@
+#include "lib/PtrConstQualifier.h"
+
+int main(int argc, char** argv) {
+  chpl_library_init(argc, argv);
+  const int n = 8;
+  const int* ptr = printAndReturn(&n);
+  assert(ptr == &n);
+  chpl_library_finalize();
+  return 0;
+}


### PR DESCRIPTION
Enable generation of `const` qualifiers for `c_ptrConst` types in exported routine signatures. Built on previous work by @riftEmber.

Addresses part of #24668.

TESTING

- [x] `linux64`, `standard`
- [x] `linux64`, `CHPL_LLVM=none`

Reviewed by @riftEmber. Thanks!