### PR TITLE
fix homebrew test failure, add --load to docker run

### DIFF
--- a/util/packaging/docker/test/homebrew_ci.bash
+++ b/util/packaging/docker/test/homebrew_ci.bash
@@ -5,9 +5,9 @@ export CHPL_HOME=$(cd $CWD/../.. ; pwd)
 
 cd ${CHPL_HOME}/packaging/docker/test
 
-# Remove image with name homebrew_ci before creating a fresh image to avoid failures. 
+# Remove image with name homebrew_ci before creating a fresh image to avoid failures.
 docker image rm --force homebrew_ci
-docker build . -t homebrew_ci
+docker build . --load -t homebrew_ci
 containerid= docker image ls | grep 'homebrew_ci' | awk '{print$3}'
 
 # Start the container and run a script to check homebrew install inside the running container
@@ -15,7 +15,7 @@ docker run --rm -i homebrew_ci /bin/bash < ${CHPL_HOME}/packaging/docker/test/br
 CONTAINER_RUN=$?
     if [ $CONTAINER_RUN -ne 0 ]
     then
-      echo "brew test bot commands failed inside ubuntu container" 
+      echo "brew test bot commands failed inside ubuntu container"
       exit 1
       else
       echo "brew test bot commands succeeded inside ubuntu container"


### PR DESCRIPTION
This PR adds the `--load` flag to the docker build command in `homebrew_ci`. A previous change to delete the images immediately after use made it so docker could no longer locate the image. 

In #24562 we fixed some test scripts to properly remove old docker images and this ~~brought up~~ exposed an issue with docker tests that was fixed in #24658, but the fix wasn't also made to the homebrew CI testing script that also uses docker and was updated the same way in #24562. 

The result was that running the homebrew test script would fail when it tried to load the homebrew_ci image that the script had built in a previous step, resulting in the following output:
```
WARNING: No output specified with docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load
Unable to find image 'homebrew_ci:latest' locally
docker: Error response from daemon: pull access denied for homebrew_ci, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
See 'docker run --help'.
```

TESTING:

- [x] homebrew test no longer fails with above error 

[reviewed by @riftEmber - thank you!]