### PR TITLE
Tidying up Zarr IO Module Documentation

### DIFF
--- a/modules/packages/Zarr.chpl
+++ b/modules/packages/Zarr.chpl
@@ -37,6 +37,7 @@ module Zarr {
   require "blosc.h";
   require "-lblosc";
 
+  @chpldoc.nodoc
   module Blosc {
     use CTypes;
     extern proc blosc_init();
@@ -66,6 +67,7 @@ module Zarr {
     var dimension_names: list(string);
   };
 
+  @chpldoc.nodoc
   proc dtypeString(type dtype) throws {
     select dtype {
       when real(32) do return "f4";
@@ -76,6 +78,7 @@ module Zarr {
     throw Error("Unexpected data type, only real and int types are supported.");
   }
 
+  @chpldoc.nodoc
   proc getMetadata(directoryPath: string) throws {
     var metadataPath = joinPath(directoryPath, ".zarray");
     var r = openReader(metadataPath, deserializer = new jsonDeserializer(), locking=false);
@@ -84,6 +87,7 @@ module Zarr {
     return md;
   }
 
+  @chpldoc.nodoc
   proc validateMetadata(metadata: zarrMetadataV2, type dtype, param dimCount) throws {
     //dimensionality matches
     if dimCount != metadata.shape.size then
@@ -114,16 +118,18 @@ module Zarr {
   }
 
 
-
+  @chpldoc.nodoc
   proc buildChunkPath(directoryPath: string, delimiter: string, const chunkIndices: ?dimCount * int) {
     var indexStrings: dimCount*string;
     for i in 0..<dimCount do indexStrings[i] = chunkIndices[i] : string;
     return joinPath(directoryPath, delimiter.join(indexStrings));
   }
+  @chpldoc.nodoc
   proc buildChunkPath(directoryPath: string, delimiter: string, chunkIndex: int) {
     return joinPath(directoryPath, chunkIndex:string);
   }
 
+  @chpldoc.nodoc
   proc getLocalChunks(D: domain(?), localD: domain(?), chunkShape: ?dimCount*int): domain(dimCount) {
 
     const totalShape = D.shape;
@@ -155,6 +161,7 @@ module Zarr {
     const thisChunkDomain: domain(dimCount) = thisChunkRange;
     return thisChunkDomain;
   }
+  @chpldoc.nodoc
   proc getChunkDomain(chunkShape: ?dimCount*int, chunkIndices: int) {
     return getChunkDomain(chunkShape, (chunkIndices,));
   }

--- a/modules/packages/Zarr.chpl
+++ b/modules/packages/Zarr.chpl
@@ -37,8 +37,7 @@ module Zarr {
   require "blosc.h";
   require "-lblosc";
 
-  @chpldoc.nodoc
-  module Blosc {
+  private module Blosc {
     use CTypes;
     extern proc blosc_init();
     extern proc blosc_compress(clevel: c_int, doshuffle: c_int, typesize: c_size_t,
@@ -58,7 +57,7 @@ module Zarr {
     var shape: list(int);
   };
 
-  // Unused until support is added for v3.0 stores
+  /* Unused until support is added for v3.0 stores */
   record zarrMetadataV3 {
     var zarr_format: int;
     var node_type: string;
@@ -67,8 +66,7 @@ module Zarr {
     var dimension_names: list(string);
   };
 
-  @chpldoc.nodoc
-  proc dtypeString(type dtype) throws {
+  private proc dtypeString(type dtype) throws {
     select dtype {
       when real(32) do return "f4";
       when real(64) do return "f8";
@@ -78,8 +76,7 @@ module Zarr {
     throw Error("Unexpected data type, only real and int types are supported.");
   }
 
-  @chpldoc.nodoc
-  proc getMetadata(directoryPath: string) throws {
+  private proc getMetadata(directoryPath: string) throws {
     var metadataPath = joinPath(directoryPath, ".zarray");
     var r = openReader(metadataPath, deserializer = new jsonDeserializer(), locking=false);
     var md: zarrMetadataV2;
@@ -87,8 +84,7 @@ module Zarr {
     return md;
   }
 
-  @chpldoc.nodoc
-  proc validateMetadata(metadata: zarrMetadataV2, type dtype, param dimCount) throws {
+  private proc validateMetadata(metadata: zarrMetadataV2, type dtype, param dimCount) throws {
     //dimensionality matches
     if dimCount != metadata.shape.size then
       throw new Error("Expected metadata shape field to have %i dimensions: %?".format(dimCount, metadata.shape));
@@ -118,19 +114,16 @@ module Zarr {
   }
 
 
-  @chpldoc.nodoc
-  proc buildChunkPath(directoryPath: string, delimiter: string, const chunkIndices: ?dimCount * int) {
+  private proc buildChunkPath(directoryPath: string, delimiter: string, const chunkIndices: ?dimCount * int) {
     var indexStrings: dimCount*string;
     for i in 0..<dimCount do indexStrings[i] = chunkIndices[i] : string;
     return joinPath(directoryPath, delimiter.join(indexStrings));
   }
-  @chpldoc.nodoc
-  proc buildChunkPath(directoryPath: string, delimiter: string, chunkIndex: int) {
+  private proc buildChunkPath(directoryPath: string, delimiter: string, chunkIndex: int) {
     return joinPath(directoryPath, chunkIndex:string);
   }
 
-  @chpldoc.nodoc
-  proc getLocalChunks(D: domain(?), localD: domain(?), chunkShape: ?dimCount*int): domain(dimCount) {
+  private proc getLocalChunks(D: domain(?), localD: domain(?), chunkShape: ?dimCount*int): domain(dimCount) {
 
     const totalShape = D.shape;
     var chunkCounts: dimCount*int;
@@ -152,7 +145,7 @@ module Zarr {
 
 
   /* Returns the domain of the `chunkIndices`-th chunk for chunks of size `chunkShape` */
-  proc getChunkDomain(chunkShape: ?dimCount*int, chunkIndices: dimCount*int) {
+  private proc getChunkDomain(chunkShape: ?dimCount*int, chunkIndices: dimCount*int) {
     var thisChunkRange: dimCount*range(int);
     for i in 0..<dimCount {
       const start = chunkIndices[i] * chunkShape[i];
@@ -161,8 +154,7 @@ module Zarr {
     const thisChunkDomain: domain(dimCount) = thisChunkRange;
     return thisChunkDomain;
   }
-  @chpldoc.nodoc
-  proc getChunkDomain(chunkShape: ?dimCount*int, chunkIndices: int) {
+  private proc getChunkDomain(chunkShape: ?dimCount*int, chunkIndices: int) {
     return getChunkDomain(chunkShape, (chunkIndices,));
   }
 


### PR DESCRIPTION
Small PR to remove documentation of private helper methods and modules from the Zarr IO module. This will make the documentation for the module more comprehensible for users. 