### PR TITLE
Remove uses of variable length arrays from compiler

### DIFF
--- a/compiler/codegen/library.cpp
+++ b/compiler/codegen/library.cpp
@@ -849,11 +849,11 @@ static void makePYFile() {
       libraries += getCompilelineOption("multilocale-lib-deps");
     }
 
-    char copyOfLib[libraries.length() + 1];
-    libraries.copy(copyOfLib, libraries.length(), 0);
+    auto copyOfLib = std::make_unique<char[]>(libraries.length() + 1);
+    libraries.copy(copyOfLib.get(), libraries.length(), 0);
     copyOfLib[libraries.length()] = '\0';
     int prefixLen = strlen("-l");
-    char* curSection = strtok(copyOfLib, " \n");
+    char* curSection = strtok(copyOfLib.get(), " \n");
     // Get the libraries from compileline --libraries, taking the `name`
     // portion from all `-lname` parts of that command's output
     while (curSection != NULL) {

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -585,8 +585,8 @@ static void recordCodeGenStrings(int argc, char* argv[]) {
     char *arg = argv[i];
     // Handle " and \" in strings
     while (char *dq = strchr(arg, '"')) {
-      char targ[strlen(argv[i])+4];
-      memcpy(targ, arg, dq-arg);
+      auto targ = std::make_unique<char[]>(strlen(argv[i])+4);
+      memcpy(targ.get(), arg, dq-arg);
       if ((dq==argv[i]) || ((dq!=argv[i]) && (*(dq-1)!='\\'))) {
         targ[dq-arg] = '\\';
         targ[dq-arg+1] = '"';
@@ -596,7 +596,7 @@ static void recordCodeGenStrings(int argc, char* argv[]) {
         targ[dq-arg+1] = '\0';
       }
       arg = dq+1;
-      compileCommand = astr(compileCommand, targ);
+      compileCommand = astr(compileCommand, targ.get());
       if (arg == NULL) break;
     }
     if (arg)


### PR DESCRIPTION
Replaces uses of nonstandard variable length arrays with smart pointers

Tested by building compiler

[Reviewed by @DanilaFe]