### PR TITLE
Calculate the numBytes correctly

### DIFF
--- a/test/gpu/native/studies/sort/gpu-sort-performance-explorer.chpl
+++ b/test/gpu/native/studies/sort/gpu-sort-performance-explorer.chpl
@@ -112,7 +112,7 @@ proc testsize(size:int) {
 
   var array = generateArray(size);
 
-  var nBytes = size*8;
+  var nBytes = size*numBytes(eltType);
   var kibibytes = nBytes/1024.0;
   var mibibytes = kibibytes/1024.0;
   var sizestr = nBytes:string + " bytes";

--- a/test/library/packages/Sort/performance/sort-performance-explorer.chpl
+++ b/test/library/packages/Sort/performance/sort-performance-explorer.chpl
@@ -168,7 +168,7 @@ proc testsize(size:int) {
     inputStrings = forall a in array do a:string;
   }
 
-  var nBytes = size*8;
+  var nBytes = size*numBytes(eltType);
   var kibibytes = nBytes/1024.0;
   var mibibytes = kibibytes/1024.0;
   var sizestr = nBytes:string + " bytes";


### PR DESCRIPTION
In the sort performance explorers for CPU and GPU sorting, number of bytes was hard-coded to be `8`. This was resulting in incorrect calculation for the MiB/s (sort speed) for types which were not 64 bits. Replaced `8` with `numBytes(eltType)` to fix this issue.

- [x] gpu paratest