### PR TITLE
Improve errors when clang version doesn't match llvm

### DIFF
--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -396,12 +396,29 @@ def validate_llvm_config():
             error("Could not find clang++ with the same version as "
                   "CHPL_LLVM_CONFIG={}. Please try setting CHPL_TARGET_CXX.".format(llvm_config))
 
+        def print_clang_version_error(clang, name="clang"):
+            clang_version = get_clang_version(clang)
+            llvm_version = str(get_llvm_config_version(llvm_config)).strip()
+            if clang_version is None:
+                error(f"Could not determine version of {name} at '{clang}'")
+            elif llvm_version not in clang_version:
+                error(
+                    f"Version of {name} at '{clang}' does not match version of" +
+                    f" LLVM at '{llvm_config}'\n" +
+                    f"LLVM version: {llvm_version}\n" +
+                    f"{name} version: {clang_version}"
+                )
+            else:
+                error(
+                    f"Missing or wrong version for {name} at '{clang}'" +
+                    f" (using LLVM at {llvm_config})"
+                )
+
+
         if not is_system_clang_version_ok(clang_c):
-            error("Missing or wrong version for clang at {0}".format(
-                  clang_c))
+            print_clang_version_error(clang_c)
         if not is_system_clang_version_ok(clang_cxx):
-            error("Missing or wrong version for clang++ at {0}".format(
-                  clang_cxx))
+            print_clang_version_error(clang_cxx, name="clang++")
 
 
 @memoize


### PR DESCRIPTION
Improves the errors when the version of CHPL_TARGET_CC does not match the version of CHPL_LLVM_CONFIG. The error will now distinguish between "can't find CHPL_TARGET_CC" and "the versions don't match". The error will also print out what versions are and what value was used for those environment variables.

Based on suggestions in https://github.com/chapel-lang/chapel/issues/24669

[Reviewed by @ShreyasKhandekar]