### PR TITLE
Add blog testing to some nightly scripts

### DIFF
--- a/util/cron/test-darwin-m1.bash
+++ b/util/cron/test-darwin-m1.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Test full suite for default configuration on M1 darwin
+# Test full suite and blog posts for default configuration on M1 darwin
 
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common.bash
@@ -9,4 +9,4 @@ source $CWD/common-localnode-paratest.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="darwin-m1"
 
-$CWD/nightly -cron $(get_nightly_paratest_args)
+$CWD/nightly -cron -blog $(get_nightly_paratest_args)

--- a/util/cron/test-linux64.bash
+++ b/util/cron/test-linux64.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Test default configuration on full suite.
+# Test default configuration on full suite and blog posts.
 
 CWD=$(cd $(dirname $0) ; pwd)
 
@@ -9,4 +9,4 @@ source $CWD/common-localnode-paratest.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64"
 
-$CWD/nightly -cron -mason -protobuf -futures ${nightly_args} $(get_nightly_paratest_args 8)
+$CWD/nightly -cron -mason -protobuf -futures -blog ${nightly_args} $(get_nightly_paratest_args 8)


### PR DESCRIPTION
Adds `-blog` to some nightly test scripts to begin testing our blog sources regularly. This is a follow-up to #24510 that added this flag to the `nightly` script. 

This PR only adds testing to two configurations (`linux64` and `darwin-m1`) to avoid blowing up nightly testing in the case there are any problems when it runs for the first time.

[reviewed by @DanilaFe - thanks!]