### PR TITLE
Fix can-pass disambiguation bug for fully-generic class formals

### DIFF
--- a/frontend/include/chpl/resolution/can-pass.h
+++ b/frontend/include/chpl/resolution/can-pass.h
@@ -114,10 +114,6 @@ class CanPassResult {
                                          types::ClassTypeDecorator actual,
                                          types::ClassTypeDecorator formal);
 
-  static CanPassResult canPassClassTypes(Context* context,
-                                         const types::ClassType* actualCt,
-                                         const types::ClassType* formalCt);
-
   static CanPassResult canPassSubtypeOrBorrowing(Context* context,
                                                  const types::Type* actualT,
                                                  const types::Type* formalT);

--- a/frontend/include/chpl/resolution/can-pass.h
+++ b/frontend/include/chpl/resolution/can-pass.h
@@ -114,13 +114,13 @@ class CanPassResult {
                                          types::ClassTypeDecorator actual,
                                          types::ClassTypeDecorator formal);
 
+  static CanPassResult canPassSubtypeNonBorrowing(Context* context,
+                                      const types::Type* actualT,
+                                      const types::Type* formalT);
+
   static CanPassResult canPassSubtypeOrBorrowing(Context* context,
                                                  const types::Type* actualT,
                                                  const types::Type* formalT);
-
-  static CanPassResult canPassSubtype(Context* context,
-                                      const types::Type* actualT,
-                                      const types::Type* formalT);
 
   static CanPassResult canConvertTuples(Context* context,
                                         const types::TupleType* aT,

--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -516,6 +516,7 @@ CanPassResult CanPassResult::canPassSubtypeNonBorrowing(Context* context,
     if (auto formalCt = formalT->toClassType()) {
       // owned Child -> owned Parent
       // owned Child -> owned Parent?
+      // owned Child? -> owned Parent?
 
       // check decorators allow passing
       CanPassResult decResult = canPassDecorators(context,

--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -503,7 +503,7 @@ CanPassResult CanPassResult::canPassDecorators(Context* context,
 // kind of NONE or SUBTYPE.
 // It's returning CanPassResult in order to also reflect if instantiation
 // was necessary.
-CanPassResult CanPassResult::canPassSubtype(Context* context,
+CanPassResult CanPassResult::canPassSubtypeNonBorrowing(Context* context,
                                             const Type* actualT,
                                             const Type* formalT) {
   // nil -> pointers
@@ -578,7 +578,7 @@ CanPassResult CanPassResult::canPassSubtype(Context* context,
   return fail(FAIL_EXPECTED_SUBTYPE);
 }
 
-// Like canPassSubtype, but considers subtyping conversions and/or implicit
+// Like canPassSubtypeNonBorrowing, but considers subtyping conversions and/or implicit
 // borrowing conversions.
 // This function returns CanPassResult which always has
 // conversion kind of NONE, SUBTYPE, BORROWS, or BORROWS_SUBTYPE.
@@ -587,7 +587,7 @@ CanPassResult CanPassResult::canPassSubtypeOrBorrowing(Context* context,
                                                        const Type* formalT) {
   // First check if we can pass directly or with subtype conversion, ignoring
   // any borrowing that may be necessary.
-  auto result = canPassSubtype(context, actualT, formalT);
+  auto result = canPassSubtypeNonBorrowing(context, actualT, formalT);
   if (result.passes()) {
     const ConversionKind subtypingConversion = result.conversionKind_;
     CHPL_ASSERT(subtypingConversion == NONE || subtypingConversion == SUBTYPE);
@@ -1027,7 +1027,8 @@ CanPassResult CanPassResult::canPass(Context* context,
           }
         }
         // TODO: promotion
-        return canPassSubtype(context, actualT, formalT);
+
+        return canPassSubtypeNonBorrowing(context, actualT, formalT);
       }
 
     case QualifiedType::PARAM:

--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -490,6 +490,7 @@ CanPassResult CanPassResult::canPassDecorators(Context* context,
                        conversion);
 }
 
+// TODO: this doesn't need to be its own method
 CanPassResult CanPassResult::canPassClassTypes(Context* context,
                                                const ClassType* actualCt,
                                                const ClassType* formalCt) {
@@ -859,7 +860,7 @@ CanPassResult CanPassResult::canInstantiate(Context* context,
   if (auto actualCt = actualT->toClassType()) {
     // check for instantiating classes
     if (auto formalCt = formalT->toClassType()) {
-      CanPassResult got = canPassClassTypes(context, actualCt, formalCt);
+      CanPassResult got = canPassSubtypeOrBorrowing(context, actualCt, formalCt);
       if (got.passes() && got.instantiates()) {
         return got;
       }

--- a/frontend/test/resolution/testCanPass.cpp
+++ b/frontend/test/resolution/testCanPass.cpp
@@ -77,6 +77,14 @@ static bool passesInstantiates(CanPassResult r) {
          r.conversionKind() == CanPassResult::NONE;
 }
 
+static bool passesInstantiatesBorrowing(CanPassResult r) {
+  return r.passes() &&
+         r.instantiates() &&
+         !r.promotes() &&
+         r.converts() &&
+         r.conversionKind() == CanPassResult::BORROWS;
+}
+
 /*
 static bool passesOther(CanPassResult r) {
   return r.passes() &&
@@ -408,6 +416,13 @@ static void test7() {
                          ClassType::get(context, bctArg, mgmtArg, decArg));
   };
 
+  auto borrowedGenericRefQt = QualifiedType(
+      QualifiedType::REF,
+      ClassType::get(context, AnyClassType::get(context), nullptr, borrowedQ));
+  auto unmanagedGenericRefQt = QualifiedType(
+      QualifiedType::REF,
+      ClassType::get(context, AnyClassType::get(context), nullptr, unmanagedQ));
+
   auto ownedMgmt = AnyOwnedType::get(context);
 
   auto borrowedParent   = qt(basicParent, nullptr,   borrowed);
@@ -544,6 +559,11 @@ static void test7() {
   r = canPass(c, ownedChild,       unmanagedParentQ); assert(doesNotPass(r));
   r = canPass(c, ownedChildQ,      unmanagedParent);  assert(doesNotPass(r));
   r = canPass(c, ownedChildQ,      unmanagedParentQ); assert(doesNotPass(r));
+
+
+  // check passing to generic class type
+  r = canPass(c, unmanagedChildQ, unmanagedGenericRefQt); assert(passesInstantiates(r));
+  r = canPass(c, unmanagedChildQ, borrowedGenericRefQt); assert(passesInstantiatesBorrowing(r));
 }
 
 static void test8() {


### PR DESCRIPTION
Fix a bug causing disambiguation between `unmanaged` and `borrowed` fully-generic class formals to fail.

This bug was likely introduced in https://github.com/chapel-lang/chapel/pull/24207, when borrowing was added as a separate type of conversion. The problem was `canInstantiate`'s usage of `canPassClassTypes`, which after that PR only checked for subtype conversion. Switched to use `canPassSubtypeOrBorrowing` to preserve original intention.

This PR also includes:
- some `canPass` refactors, most significantly inlining `canPassClassTypes` into its one remaining call site in `canPassSubtypeNonBorrowing`
- added testing in `testCanPass` for the original bug

Resolves https://github.com/Cray/chapel-private/issues/6070.

[reviewer info placeholder]

Testing:
- [x] paratest
- [x] dyno tests
- [x] original reproducer now succeeds