### PR TITLE
chplcheck: Allow silencing advanced rules

### DIFF
--- a/test/chplcheck/COMPOPTS
+++ b/test/chplcheck/COMPOPTS
@@ -1,0 +1,1 @@
+ --using-attribute-toolname chplcheck

--- a/test/chplcheck/MisleadingIndentation.chpl
+++ b/test/chplcheck/MisleadingIndentation.chpl
@@ -2,4 +2,9 @@ module Indentation {
   for i in 1..10 do
     writeln(i);
     writeln("second thing");
+
+  @chplcheck.ignore("MisleadingIndentation")
+  for i in 1..10 do
+    writeln(i);
+    writeln("second thing");
 }

--- a/test/chplcheck/Unused.chpl
+++ b/test/chplcheck/Unused.chpl
@@ -14,6 +14,18 @@ module Unused {
         writeln(i);
       }
     }
+
+    // test with unrelated attribute; previously this (wrongly) silenced warnigns
+    @chplcheck.ignore("UnusedFormal")
+    for i in 1..10 {}
+
+    // silencing UnusedLoopIndex should definitely work, though.
+    @chplcheck.ignore("UnusedLoopIndex")
+    for i in 1..10 {}
+
+    @chplcheck.ignore("UnusedLoopIndex")
+    for (i,j) in {1..10,1..10} do
+      writeln(i);
   }
   myProc(1,2);
 }

--- a/test/chplcheck/Unused.chpl
+++ b/test/chplcheck/Unused.chpl
@@ -27,5 +27,10 @@ module Unused {
     for (i,j) in {1..10,1..10} do
       writeln(i);
   }
+
+  @chplcheck.ignore("UnusedFormal")
+  proc myProcIgnored(A, B) {}
+
   myProc(1,2);
+  myProcIgnored(1,2);
 }

--- a/test/chplcheck/Unused.good
+++ b/test/chplcheck/Unused.good
@@ -2,3 +2,4 @@ Unused.chpl:2: node violates rule UnusedFormal
 Unused.chpl:3: node violates rule UnusedLoopIndex
 Unused.chpl:5: node violates rule UnusedLoopIndex
 Unused.chpl:13: node violates rule UnusedLoopIndex
+Unused.chpl:20: node violates rule UnusedLoopIndex

--- a/tools/chplcheck/src/driver.py
+++ b/tools/chplcheck/src/driver.py
@@ -136,7 +136,14 @@ class LintDriver:
         if not self._should_check_rule(name):
             return
 
-        for node in func(context, root):
+        for result in func(context, root):
+            if isinstance(result, tuple):
+                node, anchor = result
+                if not self._should_check_rule(name, anchor):
+                    continue
+            else:
+                node = result
+
             # It's not clear how, if it all, advanced rules should be silenced
             # by attributes (i.e., where do you put the @chplcheck.ignore
             # attribute?). For now, do not silence them on a per-node basis.
@@ -178,6 +185,10 @@ class LintDriver:
         An advanced rule is a function that gets called on a root AST node,
         and is expected to traverse that AST to find places where warnings
         need to be emitted.
+
+        Advanced rules should yield either the node to be warned for, or
+        a tuple of (node, anchor). The anchor is checked for silencing,
+        making it possible to support @chplcheck.ignore for the advanced rule.
 
         The name of the decorated function is used as the name of the rule.
         """

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -191,22 +191,23 @@ def register_rules(driver):
 
     @driver.advanced_rule
     def MisleadingIndentation(context, root):
-        prev = None
+        prev, prevloop = None, None
         for child in root:
             if isinstance(child, Comment): continue
             yield from MisleadingIndentation(context, child)
 
             if prev is not None:
                 if child.location().start()[1] == prev.location().start()[1]:
-                    yield child
+                    yield (child, prevloop)
 
-            prev = None
+            prev, prevloop = None, None
             if isinstance(child, Loop) and child.block_style() == "implicit":
                 grandchildren = list(child)
                 # safe to access [-1], loops must have at least 1 child
                 for blockchild in reversed(list(grandchildren[-1])):
                     if isinstance(blockchild, Comment): continue
                     prev = blockchild
+                    prevloop = child
                     break
 
     @driver.advanced_rule(default=False)
@@ -233,7 +234,7 @@ def register_rules(driver):
                 uses.add(refersto.unique_id())
 
         for unused in formals.keys() - uses:
-            yield formals[unused]
+            yield (formals[unused], formals[unused].parent())
 
     @driver.advanced_rule
     def UnusedLoopIndex(context, root):

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -248,11 +248,13 @@ def register_rules(driver):
                 for child in node:
                     yield from variables(child)
 
-        for (_, match) in chapel.each_matching(root, [IndexableLoop, ("?decl", Decl), chapel.rest]):
-            node = match["decl"]
+        for (loop, match) in chapel.each_matching(root, IndexableLoop):
+            node = loop.index()
+            if node is None:
+                continue
 
             for index in variables(node):
-                indices[index.unique_id()] = index
+                indices[index.unique_id()] = (index, loop)
 
         for (use, _) in chapel.each_matching(root, Identifier):
             refersto = use.to_node()


### PR DESCRIPTION
This PR adjusts chplcheck's rule handling to support silencing advanced rules. Since advanced rules are full-scale AST traversals, they need to opt into being silencable by providing "anchors": nodes that can be marked with `@chplcheck.ignore` to skip warnings. This PR allows advanced rules to opt into silencing by yielding a tuple rather than a single node. The tuple is in the form `(node, anchor)`.

While there, I fixed a bug in `UnusedLoopIndex` that caused annotating a loop with _any_ attribute (including `chplcheck.ignore`, e.g.) to break the warning. This was due to an overly specific AST pattern, which I replaced with a plain getter. 

I also adjusted the tests to check the handling of `chplcheck.ignore`. This required tweaking `COMPOPTS` to allow through chplcheck attributes.

Reviewed by @brandon-neth -- thanks!

## Testing
- [x] `test/chplcheck`
- [x] paratest