### PR TITLE
chplcheck: add ways to list rules

### DIFF
--- a/test/chplcheck/activerules.chpl
+++ b/test/chplcheck/activerules.chpl
@@ -1,0 +1,1 @@
+writeln("Hello, world!");

--- a/test/chplcheck/activerules.good
+++ b/test/chplcheck/activerules.good
@@ -1,0 +1,12 @@
+activerules.chpl:1: node violates rule UseExplicitModules
+Active rules:
+  BoolLitInCondStmt            Warn for boolean literals like 'true' in a conditional statement.
+  CamelCaseFunctions           Warn for functions that are not 'camelCase'.
+  CamelCaseRecords             Warn for records that are not 'camelCase'.
+  ChplPrefixReserved           Warn for user-defined names that start with the 'chpl_' reserved prefix.
+  DoKeywordAndBlock            Warn for redundant 'do' keyword before a curly brace '{'.
+  MethodsAfterFields           Warn for classes or records that mix field and method definitions.
+  MisleadingIndentation        Warn for single-statement blocks that look like they might be multi-statement blocks.
+  PascalCaseClasses            Warn for classes that are not 'PascalCase'.
+  PascalCaseModules            Warn for modules that are not 'PascalCase'.
+  UnusedLoopIndex              Warn for unused index variables in loops.

--- a/test/chplcheck/activerules.prediff
+++ b/test/chplcheck/activerules.prediff
@@ -1,0 +1,5 @@
+#!/bin/bash
+$CHPL_HOME/tools/chplcheck/chplcheck --list-active-rules $1.chpl >> $2
+if sed "s#$(pwd)/##" $2 >$2.tmp; then
+    mv $2.tmp $2
+fi

--- a/test/chplcheck/allrules.chpl
+++ b/test/chplcheck/allrules.chpl
@@ -1,0 +1,1 @@
+writeln("Hello, world!");

--- a/test/chplcheck/allrules.good
+++ b/test/chplcheck/allrules.good
@@ -1,0 +1,17 @@
+allrules.chpl:1: node violates rule UseExplicitModules
+Available rules (default rules marked with *):
+  * BoolLitInCondStmt            Warn for boolean literals like 'true' in a conditional statement.
+  * CamelCaseFunctions           Warn for functions that are not 'camelCase'.
+  * CamelCaseRecords             Warn for records that are not 'camelCase'.
+    CamelOrPascalCaseVariables   Warn for variables that are not 'camelCase' or 'PascalCase'.
+  * ChplPrefixReserved           Warn for user-defined names that start with the 'chpl_' reserved prefix.
+    ConsecutiveDecls             Warn for consecutive variable declarations that can be combined.
+  * DoKeywordAndBlock            Warn for redundant 'do' keyword before a curly brace '{'.
+  * MethodsAfterFields           Warn for classes or records that mix field and method definitions.
+  * MisleadingIndentation        Warn for single-statement blocks that look like they might be multi-statement blocks.
+    NestedCoforalls              Warn for nested 'coforall' loops, which could lead to performance hits.
+  * PascalCaseClasses            Warn for classes that are not 'PascalCase'.
+  * PascalCaseModules            Warn for modules that are not 'PascalCase'.
+    UnusedFormal                 Warn for unused formals in functions.
+  * UnusedLoopIndex              Warn for unused index variables in loops.
+    UseExplicitModules           Warn for code that relies on auto-inserted implicit modules.

--- a/test/chplcheck/allrules.prediff
+++ b/test/chplcheck/allrules.prediff
@@ -1,0 +1,5 @@
+#!/bin/bash
+$CHPL_HOME/tools/chplcheck/chplcheck --list-rules $1.chpl >> $2
+if sed "s#$(pwd)/##" $2 >$2.tmp; then
+    mv $2.tmp $2
+fi

--- a/tools/chplcheck/src/driver.py
+++ b/tools/chplcheck/src/driver.py
@@ -58,6 +58,20 @@ class LintDriver:
         self.skip_unstable = skip_unstable
         self.internal_prefixes = internal_prefixes
 
+    def rules_and_descriptions(self):
+        # Use a dict in case a rule is registered multiple times.
+        to_return = {}
+
+        for rule in self.BasicRules:
+            to_return[rule[0]] = rule[2].__doc__
+
+        for rule in self.AdvancedRules:
+            to_return[rule[0]] = rule[1].__doc__
+
+        to_return = list(to_return.items())
+        to_return.sort()
+        return to_return
+
     def disable_rules(self, *rules):
         """
         Tell the driver to silence / skip warning for the given rules.

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -38,16 +38,28 @@ def check_pascal_case(node):
 def register_rules(driver):
     @driver.basic_rule(VarLikeDecl, default=False)
     def CamelOrPascalCaseVariables(context, node):
+        """
+        Warn for variables that are not 'camelCase' or 'PascalCase'.
+        """
+
         if node.name() == "_": return True
         if node.linkage() == 'extern': return True
         return check_camel_case(node) or check_pascal_case(node)
 
     @driver.basic_rule(Record)
     def CamelCaseRecords(context, node):
+        """
+        Warn for records that are not 'camelCase'.
+        """
+
         return check_camel_case(node)
 
     @driver.basic_rule(Function)
     def CamelCaseFunctions(context, node):
+        """
+        Warn for functions that are not 'camelCase'.
+        """
+
         # Override functions / methods can't control the name, that's up
         # to the parent.
         if node.is_override(): return True
@@ -60,22 +72,42 @@ def register_rules(driver):
 
     @driver.basic_rule(Class)
     def PascalCaseClasses(context, node):
+        """
+        Warn for classes that are not 'PascalCase'.
+        """
+
         return check_pascal_case(node)
 
     @driver.basic_rule(Module)
     def PascalCaseModules(context, node):
+        """
+        Warn for modules that are not 'PascalCase'.
+        """
+
         return node.kind() == "implicit" or check_pascal_case(node)
 
     @driver.basic_rule(Module, default=False)
     def UseExplicitModules(context, node):
+        """
+        Warn for code that relies on auto-inserted implicit modules.
+        """
+
         return node.kind() != "implicit"
 
     @driver.basic_rule(Loop)
     def DoKeywordAndBlock(context, node):
+        """
+        Warn for redundant 'do' keyword before a curly brace '{'.
+        """
+
         return node.block_style() != "unnecessary"
 
     @driver.basic_rule(Coforall, default=False)
     def NestedCoforalls(context, node):
+        """
+        Warn for nested 'coforall' loops, which could lead to performance hits.
+        """
+
         parent = node.parent()
         while parent is not None:
             if isinstance(parent, Coforall):
@@ -85,10 +117,18 @@ def register_rules(driver):
 
     @driver.basic_rule([Conditional, BoolLiteral, chapel.rest])
     def BoolLitInCondStmt(context, node):
+        """
+        Warn for boolean literals like 'true' in a conditional statement.
+        """
+
         return False
 
     @driver.basic_rule(NamedDecl)
     def ChplPrefixReserved(context, node):
+        """
+        Warn for user-defined names that start with the 'chpl_' reserved prefix.
+        """
+
         if node.name().startswith("chpl_"):
             path = node.location().path()
             return context.is_bundled_path(path)
@@ -97,6 +137,10 @@ def register_rules(driver):
     @driver.basic_rule(Record)
     @driver.basic_rule(Class)
     def MethodsAfterFields(context, node):
+        """
+        Warn for classes or records that mix field and method definitions.
+        """
+
         method_seen = False
         for child in node:
             if isinstance(child, VarLikeDecl) and method_seen:
@@ -113,6 +157,10 @@ def register_rules(driver):
     # 5. same pragmas
     @driver.advanced_rule(default=False)
     def ConsecutiveDecls(context, root):
+        """
+        Warn for consecutive variable declarations that can be combined.
+        """
+
         def is_relevant_decl(node):
             var_node = None
             if isinstance(node, MultiDecl):
@@ -191,6 +239,10 @@ def register_rules(driver):
 
     @driver.advanced_rule
     def MisleadingIndentation(context, root):
+        """
+        Warn for single-statement blocks that look like they might be multi-statement blocks.
+        """
+
         prev, prevloop = None, None
         for child in root:
             if isinstance(child, Comment): continue
@@ -212,6 +264,10 @@ def register_rules(driver):
 
     @driver.advanced_rule(default=False)
     def UnusedFormal(context, root):
+        """
+        Warn for unused formals in functions.
+        """
+
         formals = dict()
         uses = set()
 
@@ -238,6 +294,10 @@ def register_rules(driver):
 
     @driver.advanced_rule
     def UnusedLoopIndex(context, root):
+        """
+        Warn for unused index variables in loops.
+        """
+
         indices = dict()
         uses = set()
 


### PR DESCRIPTION
This PR adds two flags to `chplcheck`:

* `--list-rules`
  This flag simply prints all the registered rules. Rules that are enabled by default are marked with a '*'. The documentation for the rule comes from the Python implementation's docstring.
  <img width="858" alt="Screen Shot 2024-03-27 at 1 18 34 PM
" src="https://github.com/chapel-lang/chapel/assets/4361282/1b699fe7-ccc1-4f1d-9d93-3d5eb316d392">

* `--list-active-rules`
  This flag prints only the rules that are currently enabled by the user, taking into account which rules were explicitly enabled/disabled using `--enable-rule` and `--disable-rule`.
  <img width="945" alt="Screen Shot 2024-03-27 at 1 19 33 PM" src="https://github.com/chapel-lang/chapel/assets/4361282/da534670-65fc-4c10-9015-86c5ede10580">


Reviewed by @jabraham17 -- thanks!

## Testing
- [x] `test/chplcheck`