### PR TITLE
Dyno: Fix some issues with implicit param coercions

### DIFF
--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1075,8 +1075,8 @@ QualifiedType Resolver::getTypeForDecl(const AstNode* declForErr,
   } else {
     // otherwise both declaredType and initExprType are provided.
     // check that they are compatible
-    auto got = canPass(context, initExprType,
-                       QualifiedType(declKind, declaredType.type()));
+    auto fullDeclType = QualifiedType(declKind, declaredType.type());
+    auto got = canPass(context, initExprType, fullDeclType);
     if (!got.passes()) {
       if (declaredType.type()->isExternType()) {
         auto varDT = QualifiedType(QualifiedType::VAR, declaredType.type());
@@ -1131,7 +1131,7 @@ QualifiedType Resolver::getTypeForDecl(const AstNode* declForErr,
         }
       } else {
         // get instantiation type
-        auto t = getInstantiationType(context, initExprType, declaredType);
+        auto t = getInstantiationType(context, initExprType, fullDeclType);
         typePtr = t.type();
         if (inferParam) {
           paramPtr = t.param();

--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -993,7 +993,7 @@ CanPassResult CanPassResult::canPass(Context* context,
     return fail(FAIL_UNKNOWN_FORMAL_TYPE); // unknown formal type, can't resolve
   }
 
-  if (isTypeGeneric(context, formalQT)) {
+  if (formalQT.isParam() == false && isTypeGeneric(context, formalQT)) {
     // Check to see if we should proceed with instantiation.
     // Further checking will occur after the instantiation occurs,
     // so checking here just rules out predictable situations.
@@ -1056,6 +1056,11 @@ CanPassResult CanPassResult::canPass(Context* context,
 
     case QualifiedType::PARAM:
       {
+        if (formalQT.hasParamPtr() == false &&
+            formalQT.type()->isAnyType()) {
+          return instantiate();
+        }
+
         auto got = canConvert(context, actualQT, formalQT);
         if (got.passes()) {
           // if the formal parameter value is unknown, we need

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -1384,6 +1384,9 @@ QualifiedType getInstantiationType(Context* context,
       auto pt = CPtrType::getConst(context, actualPt->eltType());
       return QualifiedType(formalType.kind(), pt);
     }
+  } else if (actualType.isParam() && formalType.isParam() &&
+             formalType.hasParamPtr() == false ) {
+    return Param::fold(context, nullptr, PrimitiveTag::PRIM_CAST, actualType, formalType);
   }
 
   // TODO: sync type -> value type?

--- a/frontend/test/resolution/testParams.cpp
+++ b/frontend/test/resolution/testParams.cpp
@@ -161,13 +161,18 @@ static void test6() {
     proc bar(param arg) param {
       return arg;
     }
+    proc gen(param arg: int(?w)) param {
+      return __primitive("+", arg, w);
+    }
+
 
     param fooval = foo(0xffff);
     param barval = bar(0);
+    param genval = gen(36);
 
     param p : int(32) = 0x1234;
   )""";
-  std::vector<std::string> names = {"fooval", "barval", "p"};
+  std::vector<std::string> names = {"fooval", "barval", "genval", "p"};
   auto vals = resolveTypesOfVariables(context, program, names);
 
   auto fooval = vals["fooval"];
@@ -177,6 +182,10 @@ static void test6() {
   auto barval = vals["barval"];
   ensureParamInt(barval, 0);
   assert(barval.type()->toIntType()->bitwidth() == 64);
+
+  auto genval = vals["genval"];
+  ensureParamInt(genval, 100);
+  assert(genval.type()->toIntType()->bitwidth() == 64);
 
   auto pval = vals["p"];
   ensureParamInt(pval, 0x1234);

--- a/frontend/test/resolution/testParams.cpp
+++ b/frontend/test/resolution/testParams.cpp
@@ -148,12 +148,48 @@ static void test5() {
   assert(qtBytes.param() == chpl::types::IntParam::get(&ctx, 7));
 }
 
+static void test6() {
+  printf("test6\n");
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  std::string program = R"""(
+    proc foo(param arg: int(32)) param {
+      return arg;
+    }
+    proc bar(param arg) param {
+      return arg;
+    }
+
+    param fooval = foo(0xffff);
+    param barval = bar(0);
+
+    param p : int(32) = 0x1234;
+  )""";
+  std::vector<std::string> names = {"fooval", "barval", "p"};
+  auto vals = resolveTypesOfVariables(context, program, names);
+
+  auto fooval = vals["fooval"];
+  ensureParamInt(fooval, 0xffff);
+  assert(fooval.type()->toIntType()->bitwidth() == 32);
+
+  auto barval = vals["barval"];
+  ensureParamInt(barval, 0);
+  assert(barval.type()->toIntType()->bitwidth() == 64);
+
+  auto pval = vals["p"];
+  ensureParamInt(pval, 0x1234);
+  assert(pval.type()->toIntType()->bitwidth() == 32);
+}
+
 int main() {
   test1();
   test2();
   test3();
   test4();
   test5();
+  test6();
 
   return 0;
 }


### PR DESCRIPTION
Prior to this PR dyno would fail to properly coerce params in the cases of param-var initialization or when passing to a formal:

```chpl
proc foo(param arg: int(32)) param {
  return arg;
}
// no matching candidate!
param fooval = foo(0xffff);

// initialization error complaining about type mismatch!
param p : int(32) = 0x1234;
```

These bugs were mainly caused by a failed result from ``canPass`` originating from a call to ``canInstantiate``. ``canInstantiate`` sees two concrete types that are different and returns a failure. In the case of failure, we should allow the switch statement below to try a conversion.

``getTypeForDecl`` is updated to use the correct Kind when calling ``getInstantiationType``, and ``getInstantiationType`` is updated to instantiate params.

Testing:
- [x] test-dyno