### PR TITLE
Fix revcomp perfkeys files that I accidentally broke in #24698

### DIFF
--- a/test/studies/shootout/submitted/revcomp3.perfkeys
+++ b/test/studies/shootout/submitted/revcomp3.perfkeys
@@ -1,1 +1,2 @@
+real
 verify:-4:AACATTACAGGTAATGATAA

--- a/test/studies/shootout/submitted/revcomp5.perfkeys
+++ b/test/studies/shootout/submitted/revcomp5.perfkeys
@@ -1,1 +1,2 @@
+real
 verify:-4:AACATTACAGGTAATGATAA


### PR DESCRIPTION
Somehow, as part of #24698, I broke the revcomp perfkeys files by removing the 'real' lines that are used to track the execution time. Worse, I saw this in my testing, but misinterpreted the warnings, thought it was just a sign that my perfdat files were out of sync with 'main' (not the first time that would've happened), deleted them, re-ran and saw that it was clean.  :facepalm:

I'm not sure quite what led me to remove the 'real' lines to begin with, but I've been working on this PR for 3-12 months, and I must've done it awhile ago for good or bad reasons and completely forgotten about it / overlooked it in reviewing the diff.  Sorry for the noise.
