### PR TITLE
Skip rather than fail on git timeout for chop and minibude testing

### DIFF
--- a/test/gpu/native/studies/chop/chplGPU.skipif
+++ b/test/gpu/native/studies/chop/chplGPU.skipif
@@ -11,11 +11,14 @@ CHOP_BRANCH=main
 CHOP_URL=${CHOP_URL:-https://github.com/tcarneirop/ChOp.git}
 CHOP_BRANCH=${CHOP_BRANCH:-main}
 
-# Clone ChOp, skipif clone failed, add extra output to fail nightly job
+# Clone ChOp, skipif clone failed. Timeouts are frequent enough we don't want
+# to cause a failure.  It would be nice to add extra output to the log to
+# explain why it skipped but any output beyond "True" or "False" (even if sent
+# to stderr) will cause the skipif itself to fail.
 rm -rf ChOp
 if ! git clone ${CHOP_URL} --branch=${CHOP_BRANCH} --depth=1 2>gitClone.out; then
-  echo "git clone failed; output:" >&2
-  cat gitClone.out >&2
+  #echo "git clone failed; output:" >&2
+  #cat gitClone.out >&2
   echo "True"
   exit
 fi

--- a/test/gpu/native/studies/minibude/SKIPIF
+++ b/test/gpu/native/studies/minibude/SKIPIF
@@ -13,11 +13,14 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 MINIBUDE_URL=${MINIBUDE_URL:-https://github.com/milthorpe/miniBUDE.git}
 MINIBUDE_BRANCH=${MINIBUDE_BRANCH:-v2}
 
-# Clone miniBUDE, skipif clone failed, add extra output to fail nightly job
+# Clone miniBUDE, skipif clone failed. Timeouts are frequent enough we don't
+# want to cause a failure.  It would be nice to add extra output to the log to
+# explain why it skipped but any output beyond "True" or "False" (even if sent
+# to stderr) will cause the skipif itself to fail.
 rm -rf miniBUDE
 if ! git clone ${MINIBUDE_URL} --branch=${MINIBUDE_BRANCH} --depth=1 2>gitClone.out; then
-  echo "git clone failed; output:" >&2
-  cat gitClone.out >&2
+  #echo "git clone failed; output:" >&2
+  #cat gitClone.out >&2
   echo "True"
   exit
 fi


### PR DESCRIPTION
Git timeouts are frequent enough that for some tests that rely on doing a `git clone` it might make more sense to skip the test rather than fail it.

It looks like the nightly tests for chop and minibude were meant to do that but our extra logging output was causing the `skipif` to fail. This test comments out this extra output for the time being.

Ultimately, it would be preferable to modify our test infrastructure to not fail a skipif with extra output (and only process if the last line of output is "True" or "False"). Or at least we should only process output from `stdout` rather than `stderr`.