### PR TITLE
GPU: allow `@gpu.blockSize` attribute to contain GPU-ineligible expressions

### DIFF
--- a/compiler/AST/astutil.cpp
+++ b/compiler/AST/astutil.cpp
@@ -115,6 +115,18 @@ void collectCallExprs(BaseAST* ast, std::vector<CallExpr*>& callExprs) {
     callExprs.push_back(callExpr);
 }
 
+void collectCallExprsExceptInGpuBlock(BaseAST* ast, std::vector<CallExpr*>& callExprs) {
+  if (auto blk = toBlockStmt(ast)) {
+    if (blk->isGpuPrimitivesBlock()) {
+      return;
+    }
+  }
+
+  AST_CHILDREN_CALL(ast, collectCallExprsExceptInGpuBlock, callExprs);
+  if (CallExpr* callExpr = toCallExpr(ast))
+    callExprs.push_back(callExpr);
+}
+
 void collectBlockStmts(BaseAST* ast, std::vector<BlockStmt*>& blockStmts) {
   AST_CHILDREN_CALL(ast, collectBlockStmts, blockStmts);
   if (BlockStmt* blockStmt = toBlockStmt(ast))

--- a/compiler/include/astutil.h
+++ b/compiler/include/astutil.h
@@ -75,6 +75,7 @@ void collectDefExprs(BaseAST* ast, llvm::SmallVectorImpl<DefExpr*>& defExprs);
 void collectForallStmts(BaseAST* ast, std::vector<ForallStmt*>& forallStmts);
 void collectCForLoopStmtsPreorder(BaseAST* ast, std::vector<CForLoop*>& cforloopStmts);
 void collectCallExprs(BaseAST* ast, std::vector<CallExpr*>& callExprs);
+void collectCallExprsExceptInGpuBlock(BaseAST* ast, std::vector<CallExpr*>& callExprs);
 void collectBlockStmts(BaseAST* ast, std::vector<BlockStmt*>& blockStmts);
 void collectForLoops(BaseAST* ast, std::vector<ForLoop*>& forLoops);
 void collectMyCallExprs(BaseAST* ast,

--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -1010,6 +1010,7 @@ struct KernelActual {
 // ----------------------------------------------------------------------------
 
 static bool isCallToPrimitiveWeShouldNotCopyIntoKernel(CallExpr *call);
+static bool isCallToPrimitiveWithHostRuntimeEffect(CallExpr *call);
 
 // Given a GpuizableLoop that was determined to be "eligible" we generate an
 // outlined function
@@ -1246,6 +1247,12 @@ bool isCallToPrimitiveWeShouldNotCopyIntoKernel(CallExpr *call) {
   return call->isPrimitive(PRIM_ASSERT_ON_GPU) ||
          call->isPrimitive(PRIM_GPU_SET_BLOCKSIZE) ||
          call->isPrimitive(PRIM_GPU_PRIMITIVE_BLOCK);
+}
+
+bool isCallToPrimitiveWithHostRuntimeEffect(CallExpr *call) {
+  if (!call) return false;
+
+  return call->isPrimitive(PRIM_ASSERT_ON_GPU);
 }
 
 void GpuKernel::populateBody(FnSymbol *outlinedFunction) {
@@ -1487,12 +1494,23 @@ class CpuBoundLoopCleanup {
 
   static void doit(CForLoop *loop) {
     // 'gpu primitive blocks' contain several GPU primitives as well as
-    // any temporaries used for computing their arguments. We know for sure
-    // they don't need to go into the CPU loop.
+    // any temporaries used for computing their arguments. Some of these
+    // attributes are not meant for the host loop (e.g., they're meant
+    // for configuring the GPU loop), but others are (e.g., assertOnGpu
+    // should run on the CPU and cause a runtime error).
+    //
+    // Remove the 'gpu primitives block' as a whole, but preserve the
+    // individual GPU primitives that are meant for the host loop.
     std::vector<BlockStmt*> blocksInBody;
     collectBlockStmts(loop, blocksInBody);
     for (auto block : blocksInBody) {
       if (block->isGpuPrimitivesBlock()) {
+        for_alist(blockExpr, block->body) {
+          if (isCallToPrimitiveWithHostRuntimeEffect(toCallExpr(blockExpr))) {
+            block->insertBefore(blockExpr->remove());
+          }
+        }
+
         block->remove();
       }
     }

--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -38,6 +38,7 @@
 #include "timer.h"
 #include "misc.h"
 #include "view.h"
+#include "expr.h"
 
 #include "global-ast-vecs.h"
 
@@ -854,7 +855,8 @@ bool GpuizableLoop::callsInBodyAreGpuizableHelp(BlockStmt* blk,
   visitedFns.insert(blk->getFunction());
 
   std::vector<CallExpr*> calls;
-  collectCallExprs(blk, calls);
+
+  collectCallExprsExceptInGpuBlock(blk, calls);
 
   for_vector(CallExpr, call, calls) {
     if (call->primitive) {

--- a/test/gpu/native/assertOnGpuVarRuntime.chpl
+++ b/test/gpu/native/assertOnGpuVarRuntime.chpl
@@ -1,0 +1,5 @@
+@assertOnGpu
+var A = foreach i in 1..100 do i;
+
+writeln("!!! This message should not be displayed unless there's a bug in");
+writeln("    assertOnGpu.");

--- a/test/gpu/native/assertOnGpuVarRuntime.good
+++ b/test/gpu/native/assertOnGpuVarRuntime.good
@@ -1,0 +1,1 @@
+assertOnGpuVarRuntime.chpl:2: error: assertOnGpu() failed

--- a/test/gpu/native/ineligibleBlockSizeExpr.chpl
+++ b/test/gpu/native/ineligibleBlockSizeExpr.chpl
@@ -6,13 +6,13 @@ use GpuDiagnostics;
 startVerboseGpu();
 
 pragma "no gpu codegen"
-proc computeDomainSize(input: int) {
+proc computeBlockSize(input: int) {
   return input;
 }
 
 on here.gpus[0] {
   for size in [128, 256,512] {
-    @gpu.blockSize(computeDomainSize(size))
+    @gpu.blockSize(computeBlockSize(size))
     @assertOnGpu
     foreach 1..1024 {}
   }

--- a/test/gpu/native/ineligibleBlockSizeExpr.chpl
+++ b/test/gpu/native/ineligibleBlockSizeExpr.chpl
@@ -1,0 +1,19 @@
+// This test demonstrates that the blockSize of a loop can contain GPU-ineligible
+// code, since the blockSize is computed on the CPU before the kernel launch.
+
+use GpuDiagnostics;
+
+startVerboseGpu();
+
+pragma "no gpu codegen"
+proc computeDomainSize(input: int) {
+  return input;
+}
+
+on here.gpus[0] {
+  for size in [128, 256,512] {
+    @gpu.blockSize(computeDomainSize(size))
+    @assertOnGpu
+    foreach 1..1024 {}
+  }
+}

--- a/test/gpu/native/ineligibleBlockSizeExpr.chpl
+++ b/test/gpu/native/ineligibleBlockSizeExpr.chpl
@@ -11,9 +11,15 @@ proc computeBlockSize(input: int) {
 }
 
 on here.gpus[0] {
-  for size in [128, 256,512] {
-    @gpu.blockSize(computeBlockSize(size))
+    @gpu.blockSize(computeBlockSize(128))
     @assertOnGpu
     foreach 1..1024 {}
-  }
+
+    @gpu.blockSize(computeBlockSize(256))
+    @assertOnGpu
+    foreach 1..1024 {}
+
+    @gpu.blockSize(computeBlockSize(512))
+    @assertOnGpu
+    foreach 1..1024 {}
 }

--- a/test/gpu/native/ineligibleBlockSizeExpr.good
+++ b/test/gpu/native/ineligibleBlockSizeExpr.good
@@ -1,3 +1,3 @@
-0 (gpu 0): ineligibleBlockSizeExpr.chpl:17: kernel launch (block size: 128x1x1)
-0 (gpu 0): ineligibleBlockSizeExpr.chpl:17: kernel launch (block size: 256x1x1)
-0 (gpu 0): ineligibleBlockSizeExpr.chpl:17: kernel launch (block size: 512x1x1)
+0 (gpu 0): ineligibleBlockSizeExpr.chpl:16: kernel launch (block size: 128x1x1)
+0 (gpu 0): ineligibleBlockSizeExpr.chpl:20: kernel launch (block size: 256x1x1)
+0 (gpu 0): ineligibleBlockSizeExpr.chpl:24: kernel launch (block size: 512x1x1)

--- a/test/gpu/native/ineligibleBlockSizeExpr.good
+++ b/test/gpu/native/ineligibleBlockSizeExpr.good
@@ -1,0 +1,3 @@
+0 (gpu 0): ineligibleBlockSizeExpr.chpl:17: kernel launch (block size: 128x1x1)
+0 (gpu 0): ineligibleBlockSizeExpr.chpl:17: kernel launch (block size: 256x1x1)
+0 (gpu 0): ineligibleBlockSizeExpr.chpl:17: kernel launch (block size: 512x1x1)


### PR DESCRIPTION
Fixes https://github.com/chapel-lang/chapel/issues/24611.

Prior to this PR, it wasn't possible to set GPU block size to an expression that isn't GPU eligible. This was because the GPU attribute and function call end up as primitives _inside the loop body_, and get picked up by the ineligibility detector. 

To make this work, we need to fence off GPU primitives as "special", so that the ineligibility detector can skip them. Fortunately, there's already a feature for this -- the `gpu primitives block` attribute + "block type". Until now, this block was only used GPU attributes on variables (to make the primitives easy to copy and relocate into loop expressions). However, by making plain loops with attributes also use this block, we can create a "barrier" between the ineligibility detector and and non-loop code inside the body of a GPU-bound loop, allowing code like the following:

```Chapel
pragma "no gpu codegen"
proc computeBlockSize(input: int) {
  return input;
}

on here.gpus[0] {
  @gpu.blockSize(computeBlockSize(128))
  @assertOnGpu
  foreach 1..1024 {}
}

```

Reviewed by @e-kayrakli -- thanks!

## Testing
- [x] paratest
- [x] `gpu/native` test