### PR TITLE
Add support for syncWarp

### DIFF
--- a/modules/standard/GPU.chpl
+++ b/modules/standard/GPU.chpl
@@ -216,6 +216,22 @@ module GPU
   }
 
   /*
+    Causes the executing thread to wait until all warp lanes named in mask
+    have executed a ``syncWarp()`` (with the same mask) before resuming
+    execution.
+    Each calling thread must have its own bit set in the mask and all
+    non-exited threads named in mask must execute a corresponding
+    ``syncWarp()`` with the same mask, or the result is undefined.
+  */
+  inline proc syncWarp(mask : uint(32) = 0xffffffff) {
+    pragma "codegen for GPU"
+    extern "chpl_gpu_force_warp_sync" proc chpl_syncWarp(mask);
+
+    __primitive("chpl_assert_on_gpu", false);
+    chpl_syncWarp(mask);
+  }
+
+  /*
     Allocate block shared memory, enough to store ``size`` elements of
     ``eltType``. Returns a :type:`CTypes.c_ptr` to the allocated array. Note that
     although every thread in a block calls this procedure, the same shared array

--- a/runtime/include/gpu/amd/chpl-gpu-gen-includes.h
+++ b/runtime/include/gpu/amd/chpl-gpu-gen-includes.h
@@ -60,6 +60,14 @@ __device__ static inline void chpl_gpu_force_sync() {
   __builtin_amdgcn_s_barrier();
 }
 
+__device__ static inline void chpl_gpu_force_warp_sync(unsigned mask=0xffffffff) {
+  // no-op
+  // AMD gpu's have no architectures which need a syncWarp operation
+  // This is because as of the time of writing, HIP guarantees that all
+  // threads within a warp will be executed in lockstep
+}
+
+
 __device__ static inline uint32_t chpl_gpu_getThreadIdxX() { return __builtin_amdgcn_workitem_id_x(); }
 __device__ static inline uint32_t chpl_gpu_getThreadIdxY() { return __builtin_amdgcn_workitem_id_y(); }
 __device__ static inline uint32_t chpl_gpu_getThreadIdxZ() { return __builtin_amdgcn_workitem_id_z(); }

--- a/runtime/include/gpu/chpl-gpu-gen-common.h
+++ b/runtime/include/gpu/chpl-gpu-gen-common.h
@@ -138,6 +138,11 @@ __host__ static inline void chpl_gpu_force_sync() {
   chpl_internal_error("chpl_gpu_force_sync called from host");
 }
 
+__host__ static inline void chpl_gpu_force_warp_sync(unsigned mask=0xffffffff) {
+  chpl_internal_error("chpl_gpu_force_warp_sync called from host");
+}
+
+
 __device__ static inline
 void chpl_gen_comm_get_from_subloc(void *addr, c_nodeid_t src_node,
                                    c_sublocid_t src_subloc, void* raddr,

--- a/runtime/include/gpu/cpu/chpl-gpu-gen-includes.h
+++ b/runtime/include/gpu/cpu/chpl-gpu-gen-includes.h
@@ -97,6 +97,13 @@ static inline void chpl_gpu_force_sync(void) {
   }
 }
 
+static inline void chpl_gpu_force_warp_sync(unsigned mask=0xffffffff) {
+  if (!chpl_gpu_no_cpu_mode_warning) {
+    chpl_warning("chpl_gpu_force_warp_sync was called", 0, 0);
+  }
+}
+
+
 #endif // HAS_GPU_LOCALE
 
 #endif // _CHPL_GPU_GEN_INCLUDES_H

--- a/runtime/include/gpu/nvidia/chpl-gpu-gen-includes.h
+++ b/runtime/include/gpu/nvidia/chpl-gpu-gen-includes.h
@@ -60,6 +60,11 @@ __device__ static inline void chpl_gpu_force_sync() {
   asm volatile("bar.sync 0;" : : : "memory");
 }
 
+__device__ static inline void chpl_gpu_force_warp_sync(unsigned mask=0xffffffff) {
+  // Call nvidia's syncwarp
+  __syncwarp(mask);
+}
+
 __device__ static inline uint32_t chpl_gpu_getThreadIdxX() { return __nvvm_read_ptx_sreg_tid_x(); }
 __device__ static inline uint32_t chpl_gpu_getThreadIdxY() { return __nvvm_read_ptx_sreg_tid_y(); }
 __device__ static inline uint32_t chpl_gpu_getThreadIdxZ() { return __nvvm_read_ptx_sreg_tid_z(); }

--- a/test/gpu/native/syncWarp.chpl
+++ b/test/gpu/native/syncWarp.chpl
@@ -1,0 +1,34 @@
+use GPU;
+config const n=1000;
+on here.gpus[0] {
+  var Arr: [0..<n] int;
+  var Dummy: [0..<n] int;
+  var CorrectResult: [0..<n] bool;
+  @assertOnGpu
+  foreach i in Arr.domain {
+    const warpIndex = i/32;
+
+    if i%32==0 {
+      for j in 0..<32 {
+        Arr[i+j] = warpIndex;
+      }
+      for i in 0..<n { // We do this to try and make the threads out of sync
+        Dummy[i] = i;
+      }
+    }
+    syncWarp();
+
+    CorrectResult[i] = Arr[i] == warpIndex;
+  }
+  // expect all `true`s in `CorrectResult` only if there's a syncWarp call
+  // It is out of our control whether a divergence in a warp really occurs
+  // on not; that is decided by the thread scheduler.
+  // So it is possible that a syncWarp will not be needed, so a passing test
+  // doesn't mean that the test is correct unfortunately
+  for i in CorrectResult.domain {
+    if(CorrectResult[i] == false) {
+      writeln("Incorrect result at index ", i);
+      break;
+    }
+  }
+}


### PR DESCRIPTION
For Nvidia GPUs, starting with Volta architectures and later, threads within a warp can diverge. For applications needing memory and synchronization barriers, calling `syncWarp` provides this functionality within warps. It is like `syncThreads`, but at a more granular level.

For AMD GPUs, threads within a warp are guaranteed to be executed in lockstep. Therefore `syncWarp` is a no-op in that case. This may change in the future as new AMD architectures emerge.

Resolves https://github.com/Cray/chapel-private/issues/5002, https://github.com/Cray/chapel-private/issues/5453