### PR TITLE
GPU: Restore workaround in gpu-amd.c

### DIFF
--- a/runtime/src/gpu/amd/gpu-amd.c
+++ b/runtime/src/gpu/amd/gpu-amd.c
@@ -96,7 +96,16 @@ static void chpl_gpu_impl_set_globals(c_sublocid_t dev_id, hipModule_t module) {
 
   if (ptr) {
     assert(glob_size == sizeof(c_nodeid_t));
-    chpl_gpu_impl_copy_host_to_device((void*)ptr, &chpl_nodeID, glob_size, NULL);
+
+    // chpl_gpu_impl_copy_host_to_device performs a validation using
+    // hipPointerGetAttributes. However, apparently, that's not something you
+    // should call on pointers returned from hipModuleGetGlobal. Just perform
+    // the copy directly.
+    //
+    // The validation only happens when built with assertions (commonly
+    // enabled by CHPL_DEVELOPER), and chpl_gpu_impl_copy_host_to_device
+    // only causes issues in that case.
+    ROCM_CALL(hipMemcpyDtoD(ptr, (void*)&chpl_nodeID, glob_size));
   }
 }
 


### PR DESCRIPTION
Accidentally reverted by https://github.com/chapel-lang/chapel/commit/48b9f2750d346493f8abb43ab97de2a3a6b19ee9. 

Reviewed by @e-kayrakli -- thanks!

## Testing

- [x] `test/gpu/native`