### PR TITLE
dyno: Fix resolution of `locale.home`

### DIFF
--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -3682,6 +3682,8 @@ gatherAndFilterCandidatesForwarding(Context* context,
       // A more robust approach might split forwarding statement resolution
       // into individual queries, and skip the code below only if the current
       // forwarding statement is being used to resolve itself.
+      //
+      // https://github.com/chapel-lang/chapel/issues/24709
     } else {
       const ResolvedFields& exprs = resolveForwardingExprs(context, ct);
       if (fields.numForwards() > 0 ||

--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -1032,8 +1032,9 @@ const QualifiedType& returnType(Context* context,
     // resolve the function body
     // resolveFunction will arrange to call computeReturnType
     // and store the return type in the result.
-    const ResolvedFunction* rFn = resolveFunction(context, sig, poiScope);
-    result = rFn->returnType();
+    if (auto rFn = resolveFunction(context, sig, poiScope)) {
+      result = rFn->returnType();
+    }
   }
 
   return QUERY_END(result);
@@ -1050,17 +1051,17 @@ inferOutFormalsQuery(Context* context,
   std::vector<types::QualifiedType> formalTypes;
 
   // resolve the function body
-  const ResolvedFunction* rFn = resolveFunction(context, sig,
-                                                instantiationPoiScope);
-  const ResolutionResultByPostorderID& rr = rFn->resolutionById();
+  if (auto rFn = resolveFunction(context, sig, instantiationPoiScope)) {
+    const ResolutionResultByPostorderID& rr = rFn->resolutionById();
 
-  int numFormals = sig->numFormals();
-  for (int i = 0; i < numFormals; i++) {
-    const types::QualifiedType& ft = sig->formalType(i);
-    if (ft.kind() == QualifiedType::OUT && ft.isGenericOrUnknown()) {
-      formalTypes.push_back(rr.byAst(untyped->formalDecl(i)).type());
-    } else {
-      formalTypes.push_back(ft);
+    int numFormals = sig->numFormals();
+    for (int i = 0; i < numFormals; i++) {
+      const types::QualifiedType& ft = sig->formalType(i);
+      if (ft.kind() == QualifiedType::OUT && ft.isGenericOrUnknown()) {
+        formalTypes.push_back(rr.byAst(untyped->formalDecl(i)).type());
+      } else {
+        formalTypes.push_back(ft);
+      }
     }
   }
 


### PR DESCRIPTION
Closes https://github.com/Cray/chapel-private/issues/6030. 

This PR fixes a segmentation fault that occurs while resolving a call to `locale.home`:

```Chapel
var x : locale;
var y = x.home;
```

There are two layers to this issue:

* The segmentation fault (a symptom) is caused by the auto-handler for infinite recursive queries. This handler (introduced in https://github.com/chapel-lang/chapel/pull/24321) replaces the computed (bogus) result of an infinitely recursive query with its default type. In this case, the infinite recursion comes from forwarding statements (see next bullet), but poisons `resolveFunction`.
  
  Because `resolveFunction` is poisoned, it too returns `nullptr`. This makes code that relies on `resolveFunction` without checking for null break. The PR fixes this by adjusting all code that calls `resolveFunction` in Dyno proper to handle nulls. The PR does __not__ adjust tests, since if a test relies on the value of a function being non-null, a `null` return value will cause a crash and (correctly) trigger a test failure.
* An infinite recursion while resolving forwarding statements in `_locale`. This is caused by the fact that `value` (the thing-being-forwarded) is a parenless proc. To resolve the parenless proc, Dyno searches forwarding candidates, inevitably trying to resolve `forwarding value`. The PR fixes this by adding an `isQueryRunning(resolveForwardingStatements)` check. This fixes the issue, but is too coarse: I left https://github.com/chapel-lang/chapel/issues/24709 as a future work.

Reviewed by @benharsh -- thanks!

## Testing
- [x] paratest