### PR TITLE
Fix export procs with numeric in-intent formals

### DIFF
--- a/test/functions/export/in-intent-formals.chpl
+++ b/test/functions/export/in-intent-formals.chpl
@@ -1,0 +1,176 @@
+// ensure that in-intent formals are codegen-ed correctly, see #23419
+// for each arg type, this test has an 'export' proc with an in-intent formal
+// that (1) assigns into it then (2) calls another fn twice, passing the formal by ref
+
+/// bool ///
+
+proc updateBool(ref updateArg: bool) {
+  write(updateArg.type:string, " updateArg: ", updateArg);
+  updateArg = !updateArg;
+  writeln(" --> ", updateArg);
+}
+
+export proc exportBool(in exportArg: bool) {
+  exportArg = false;
+  updateBool(exportArg);
+  updateBool(exportArg);
+  writeln(exportArg.type:string, " finally:   ", exportArg);
+}
+
+/// int(64) ///
+
+proc updateInt64(ref updateArg: int(64)) {
+  write(updateArg.type:string, " updateArg: ", updateArg);
+  updateArg += 1000;
+  writeln(" --> ", updateArg);
+}
+
+export proc exportInt64(in exportArg: int(64)) {
+  exportArg = 1064;
+  updateInt64(exportArg);
+  updateInt64(exportArg);
+  writeln(exportArg.type:string, " finally:   ", exportArg);
+}
+
+/// uint(64) ///
+
+proc updateUint64(ref updateArg: uint(64)) {
+  write(updateArg.type:string, " updateArg: ", updateArg);
+  updateArg += 2000;
+  writeln(" --> ", updateArg);
+}
+
+export proc exportUint64(in exportArg: uint(64)) {
+  exportArg = 2064;
+  updateUint64(exportArg);
+  updateUint64(exportArg);
+  writeln(exportArg.type:string, " finally:   ", exportArg);
+}
+
+/// int16 ///
+
+proc updateInt16(ref updateArg: int(16)) {
+  write(updateArg.type:string, " updateArg: ", updateArg);
+  updateArg += 1002;
+  writeln(" --> ", updateArg);
+}
+
+export proc exportInt16(in exportArg: int(16)) {
+  exportArg = 1016;
+  updateInt16(exportArg);
+  updateInt16(exportArg);
+  writeln(exportArg.type:string, " finally:   ", exportArg);
+}
+
+/// uint8 ///
+
+proc updateUint8(ref updateArg: uint(8)) {
+  write(updateArg.type:string, " updateArg: ", updateArg);
+  updateArg += 100;
+  writeln(" --> ", updateArg);
+}
+
+export proc exportUint8(in exportArg: uint(8)) {
+  exportArg = 8;
+  updateUint8(exportArg);
+  updateUint8(exportArg);
+  writeln(exportArg.type:string, " finally:   ", exportArg);
+}
+
+
+/// real ///
+
+proc updateReal(ref updateArg: real) {
+  write(updateArg.type:string, " updateArg: ", updateArg);
+  updateArg += 1.1;
+  writeln(" --> ", updateArg);
+}
+
+export proc exportReal(in exportArg: real) {
+  exportArg = 10.64;
+  updateReal(exportArg);
+  updateReal(exportArg);
+  writeln(exportArg.type:string, " finally:   ", exportArg);
+}
+
+/// imag ///
+
+proc updateImag(ref updateArg: imag) {
+  write(updateArg.type:string, " updateArg: ", updateArg);
+  updateArg += 1.0i;
+  writeln(" --> ", updateArg);
+}
+
+export proc exportImag(in exportArg: imag) {
+  exportArg = 1.64i;
+  updateImag(exportArg);
+  updateImag(exportArg);
+  writeln(exportArg.type:string, " finally:   ", exportArg);
+}
+
+/// complex ///
+
+proc updateComplex(ref updateArg: complex) {
+  write(updateArg.type:string, " updateArg: ", updateArg);
+  updateArg += 1.1+2.01i;
+  writeln(" --> ", updateArg);
+}
+
+export proc exportComplex(in exportArg: complex) {
+  exportArg = 10+20i;
+  updateComplex(exportArg);
+  updateComplex(exportArg);
+  writeln(exportArg.type:string, " finally:   ", exportArg);
+}
+
+/// record ///
+
+import CTypes;
+
+extern record RR {
+  //we can hide this field: var i1: CTypes.c_int;
+  var i2: CTypes.c_int;
+}
+
+extern var externRecord: RR;
+var chapelRecord: RR;
+chapelRecord.i2 = 1023;
+
+proc updateRec(ref updateArg: RR) {
+  write(updateArg.type:string, " updateArg: ", updateArg);
+  updateArg.i2 += 1000;
+  writeln(" --> ", updateArg);
+}
+
+export proc exportRec(in exportArg: RR) {
+  exportArg = chapelRecord;
+  updateRec(exportArg);
+  updateRec(exportArg);
+  writeln(exportArg.type:string, " finally:   ", exportArg);
+}
+
+/// string ///
+
+proc updateString(ref updateArg: string) {
+  write(updateArg.type:string, " updateArg: ", updateArg);
+  updateArg += " there";
+  writeln(" --> ", updateArg);
+}
+
+export proc exportString(in exportArg: string) {
+  exportArg = "hi";
+  updateString(exportArg);
+  updateString(exportArg);
+  writeln(exportArg.type:string, " finally:   ", exportArg);
+}
+
+exportBool(true);
+exportInt64(4564);
+exportUint64(4654);
+exportInt16(616);
+exportUint8(88);
+exportReal(64.46);
+exportImag(64.64i);
+exportComplex(22+33i);
+exportRec(externRecord);
+exportString("a string");

--- a/test/functions/export/in-intent-formals.compopts
+++ b/test/functions/export/in-intent-formals.compopts
@@ -1,0 +1,1 @@
+in-intent-formals.h

--- a/test/functions/export/in-intent-formals.good
+++ b/test/functions/export/in-intent-formals.good
@@ -1,0 +1,30 @@
+bool updateArg: false --> true
+bool updateArg: true --> false
+bool finally:   false
+int(64) updateArg: 1064 --> 2064
+int(64) updateArg: 2064 --> 3064
+int(64) finally:   3064
+uint(64) updateArg: 2064 --> 4064
+uint(64) updateArg: 4064 --> 6064
+uint(64) finally:   6064
+int(16) updateArg: 1016 --> 2018
+int(16) updateArg: 2018 --> 3020
+int(16) finally:   3020
+uint(8) updateArg: 8 --> 108
+uint(8) updateArg: 108 --> 208
+uint(8) finally:   208
+real(64) updateArg: 10.64 --> 11.74
+real(64) updateArg: 11.74 --> 12.84
+real(64) finally:   12.84
+imag(64) updateArg: 1.64i --> 2.64i
+imag(64) updateArg: 2.64i --> 3.64i
+imag(64) finally:   3.64i
+complex(128) updateArg: 10.0 + 20.0i --> 11.1 + 22.01i
+complex(128) updateArg: 11.1 + 22.01i --> 12.2 + 24.02i
+complex(128) finally:   12.2 + 24.02i
+RR updateArg: (i2 = 1023) --> (i2 = 2023)
+RR updateArg: (i2 = 2023) --> (i2 = 3023)
+RR finally:   (i2 = 3023)
+string updateArg: hi --> hi there
+string updateArg: hi there --> hi there there
+string finally:   hi there there

--- a/test/functions/export/in-intent-formals.h
+++ b/test/functions/export/in-intent-formals.h
@@ -1,0 +1,2 @@
+typedef struct { int i1, i2; } RR;
+RR externRecord;


### PR DESCRIPTION
Resolves #23419.

This PR forces stack-allocation of numeric `in`-intent formals of `export` procs during codegen for LLVM. Before this PR such formals were not stack-allocated. As a result, passing such a formal to __primitive("=") for assignment crashed the codegen; passing it to a ref formal incorrectly passed a stack-allocated copy. In-intent formals in the other cases are already stack-allocated along different code paths. During codegen to C stack-allocation is not an issue, so it is not affected by this PR.

While there, add a gdbShouldBreakHere() for LLVM codegen of a formal with a given breakOnCodegenID and factor out some code.

Testing: standard and gasnet paratests.