### PR TITLE
Switch CLBG non-locking stdin/stdout to use new idioms and names

### DIFF
--- a/test/studies/shootout/submitted/fasta3.chpl
+++ b/test/studies/shootout/submitted/fasta3.chpl
@@ -77,16 +77,16 @@ proc sumProbs(ref alphabet: []) {
 }
 
 //
-// Redefine stdout to use lock-free binary I/O and capture a newline
+// Redefine stdout to use lock-free I/O
 //
 use IO;
-const stdout = (new file(1)).writer(locking=false);
+const consoleOut = stdout.getFile().writer(locking=false);
 
 //
 // Repeat sequence "alu" for n characters
 //
 proc repeatMake(desc, alu, n) {
-  stdout.writef("%s", desc);
+  consoleOut.writef("%s", desc);
 
   const r = alu.size,
         s = [i in 0..r+lineLength] alu[i % r]: int(8);
@@ -94,8 +94,8 @@ proc repeatMake(desc, alu, n) {
   for i in 0..n by lineLength {
     const lo = i % r,
           len = min(lineLength, n-i);
-    stdout.writeBinary(s[lo..#len]);
-    stdout.writeln();
+    consoleOut.writeBinary(s[lo..#len]);
+    consoleOut.writeln();
   }
 }
 
@@ -105,7 +105,7 @@ proc repeatMake(desc, alu, n) {
 proc randomMake(desc, a, n) {
   var line_buff: [0..lineLength] int(8);
 
-  stdout.writef("%s", desc);
+  consoleOut.writef("%s", desc);
   for i in 1..n by lineLength do
     addLine(min(lineLength, n-i+1));
 
@@ -134,7 +134,7 @@ proc randomMake(desc, a, n) {
     }
     line_buff[numBytes] = "\n".toByte();
 
-    stdout.writeBinary(line_buff[0..numBytes]);
+    consoleOut.writeBinary(line_buff[0..numBytes]);
   }
 }
 

--- a/test/studies/shootout/submitted/fasta5.chpl
+++ b/test/studies/shootout/submitted/fasta5.chpl
@@ -75,8 +75,7 @@ proc main() {
 // Redefine stdout to use lock-free binary I/O and capture a newline
 //
 use IO;
-const stdout = (new file(1)).writer(locking=false);
-param newline = "\n".toByte();
+const consoleOut = stdout.getFile().writer(locking=false);
 
 //
 // Repeat 'alu' to generate a sequence of length 'n'
@@ -110,6 +109,7 @@ proc randomMake(desc, nuclInfo: [?nuclInds], n) {
     cp = 1 + (p*IM): randType;
   }
 
+  param newline = "\n".toByte();
   // guard when tasks can access the random numbers or output stream
   var randGo, outGo: [0..#numTasks] atomic int;
 

--- a/test/studies/shootout/submitted/fasta6.chpl
+++ b/test/studies/shootout/submitted/fasta6.chpl
@@ -38,18 +38,17 @@ const IUB = [("a", 0.27), ("c", 0.12), ("g", 0.12), ("t", 0.27),
                      ("g", 0.1975473066391),
                      ("t", 0.3015094502008)],
 
-      // Redefine stdout to use lock-free binary I/O
-      stdout = (new file(1)).writer(locking=false);
+      consoleOut = stdout.getFile().writer(locking=false);
 
 
 proc main() {
-  stdout.writeln(">ONE Homo sapiens alu");
+  consoleOut.writeln(">ONE Homo sapiens alu");
   repeatMake(ALU, 2*n);
 
-  stdout.writeln(">TWO IUB ambiguity codes");
+  consoleOut.writeln(">TWO IUB ambiguity codes");
   randomMake(IUB, 3*n);
 
-  stdout.writeln(">THREE Homo sapiens frequency");
+  consoleOut.writeln(">THREE Homo sapiens frequency");
   randomMake(HomoSapiens, 5*n);
 }
 
@@ -69,15 +68,15 @@ proc repeatMake(param alu, n) {
 
   const wholeBuffers = n / (len*lineLen);
   for i in 0..<wholeBuffers {
-    stdout.write(buffer);
+    consoleOut.write(buffer);
   }
 
   var extra = n - wholeBuffers*len*lineLen;
   extra += extra/lineLen;
-  stdout.writeBinary(buffer[..<extra]);
+  consoleOut.writeBinary(buffer[..<extra]);
 
   if n % lineLen != 0 {
-    stdout.writeln();
+    consoleOut.writeln();
   }
 }
 
@@ -118,7 +117,7 @@ proc randomMake(nuclInfo, n) {
         buffer[j*bytesPerLine + k] = hash[getNextRand()];
       }
     }
-    stdout.writeBinary(buffer);
+    consoleOut.writeBinary(buffer);
   }
 
   // compute number of complete lines remaining and fill them in
@@ -138,11 +137,11 @@ proc randomMake(nuclInfo, n) {
     buffer[offset + k] = hash[getNextRand()];
   }
 
-  stdout.writeBinary(buffer[0..<offset+extra]);
+  consoleOut.writeBinary(buffer[0..<offset+extra]);
 
   // add a final linefeed if needed
   if (extra != 0) {
-    stdout.writeln();
+    consoleOut.writeln();
   }
 
 }

--- a/test/studies/shootout/submitted/knucleotide3.chpl
+++ b/test/studies/shootout/submitted/knucleotide3.chpl
@@ -13,9 +13,8 @@ config param tableSize = 2**16,
 
 proc main(args: [] string) {
   // Open stdin and a binary reader channel
-  const consoleIn = new file(0),
-        fileLen = consoleIn.size,
-        stdinNoLock = consoleIn.reader(locking=false);
+  const fileLen = stdin.getFile().size,
+        consoleIn = stdin.getFile().reader(locking=false);
 
   // Read line-by-line until we see a line beginning with '>TH'
   var buff: [1..columns] uint(8),
@@ -23,7 +22,7 @@ proc main(args: [] string) {
       numRead = 0;
 
   do {
-    lineSize = stdinNoLock.readLine(buff);
+    lineSize = consoleIn.readLine(buff);
     numRead += lineSize;
   } while lineSize > 0 && !startsWithThree(buff);
 
@@ -33,7 +32,7 @@ proc main(args: [] string) {
       idx = 1;
 
   do {
-    lineSize = stdinNoLock.readLine(data[idx..]);
+    lineSize = consoleIn.readLine(data[idx..]);
     idx += lineSize - 1;
   } while lineSize > 0;
 

--- a/test/studies/shootout/submitted/knucleotide4.chpl
+++ b/test/studies/shootout/submitted/knucleotide4.chpl
@@ -12,9 +12,8 @@ config param columns = 61;
 
 proc main(args: [] string) {
   // Open stdin and a binary reader channel
-  const consoleIn = new file(0),
-        fileLen = consoleIn.size,
-        stdinNoLock = consoleIn.reader(locking=false);
+  const fileLen = stdin.getFile().size,
+        consoleIn = stdin.getFile().reader(locking=false);
 
   // Read line-by-line until we see a line beginning with '>TH'
   var buff: [1..columns] uint(8),
@@ -22,7 +21,7 @@ proc main(args: [] string) {
       numRead = 0;
 
   do {
-    lineSize = stdinNoLock.readLine(buff);
+    lineSize = consoleIn.readLine(buff);
     numRead += lineSize;
   } while lineSize > 0 && !startsWithThree(buff);
 
@@ -32,7 +31,7 @@ proc main(args: [] string) {
       idx = 1;
 
   do {
-    lineSize = stdinNoLock.readLine(data[idx..]);
+    lineSize = consoleIn.readLine(data[idx..]);
     idx += lineSize - 1;
   } while lineSize > 0;
 

--- a/test/studies/shootout/submitted/revcomp3.chpl
+++ b/test/studies/shootout/submitted/revcomp3.chpl
@@ -12,7 +12,7 @@ const table = createTable();    // create the table of code complements
 
 proc main(args: [] string) {
   use IO;
-  const stdin = (new file(0)).reader(locking=false);
+  const consoleIn = stdin.getFile().reader(locking=false);
 
   // read in the data using an incrementally growing buffer
   var bufLen = 8 * 1024,
@@ -21,14 +21,14 @@ proc main(args: [] string) {
       end = 0;
 
   do {
-    const more = stdin.readBinary(buf[end..]);
+    const more = consoleIn.readBinary(buf[end..]);
     if more {
       end = bufLen;
       bufLen += min(1024**2, bufLen);
       bufDom = {0..<bufLen};
     }
   } while more;
-  end = stdin.offset()-1;
+  end = consoleIn.offset()-1;
 
   // process the buffer a sequence at a time, working from the end
   var hi = end;

--- a/test/studies/shootout/submitted/revcomp5.chpl
+++ b/test/studies/shootout/submitted/revcomp5.chpl
@@ -19,20 +19,20 @@ param eol = '\n'.toByte(),  // end-of-line, as an integer
 
 
 proc main(args: [] string) {
-  var stdin  = (new file(0)).reader(locking=false),
-      stdout = (new file(1)).writer(locking=false),
+  var consoleIn  = stdin.getFile().reader(locking=false),
+      consoleOut = stdout.getFile().writer(locking=false),
       bufLen = 8 * 1024,
       bufDom = {0..<bufLen},
       buf: [bufDom] uint(8),
       end = 0;
 
   // read in the data using an incrementally growing buffer
-  while stdin.readBinary(buf[end..]) {
+  while consoleIn.readBinary(buf[end..]) {
     end = bufLen;
     bufLen += min(1024**2, bufLen);
     bufDom = {0..<bufLen};
   }
-  end = stdin.offset()-1;
+  end = consoleIn.offset()-1;
 
   // process the buffer a sequence at a time, working from the end
   var hi = end;
@@ -55,7 +55,7 @@ proc main(args: [] string) {
   }
 
   // write out the transformed buffer
-  stdout.writeBinary(buf[..end]);
+  consoleOut.writeBinary(buf[..end]);
 }
 
 

--- a/test/studies/shootout/submitted/revcomp8.chpl
+++ b/test/studies/shootout/submitted/revcomp8.chpl
@@ -25,8 +25,9 @@ param eol = '\n'.toByte(),  // end-of-line, as an integer
 var pairCmpl: [0..<join(maxChars, maxChars)] uint(16);
 
 // channels for doing efficient console I/O
-var stdinBin  = (new file(0)).reader(locking=false),
-    stdoutBin = (new file(1)).writer(locking=false);
+
+var consoleIn  = stdin.getFile().reader(locking=false),
+    consoleOut = stdout.getFile().writer(locking=false);
 
 proc main(args: [] string) {
   // set up the 'pairCmpl' map
@@ -42,7 +43,7 @@ proc main(args: [] string) {
 
   do {
     // read 'readSize' new characters
-    var newChars = stdinBin.readBinary(c_ptrTo(buff[readPos]), readSize),
+    var newChars = consoleIn.readBinary(c_ptrTo(buff[readPos]), readSize),
         nextSeqStart: int;
 
     // if the new characters contain the start of the next sequence,
@@ -85,7 +86,7 @@ proc revcomp(ref seq, size) {
   }
 
   // write out the header
-  stdoutBin.writeBinary(c_ptrTo(seq[0]), headerSize);
+  consoleOut.writeBinary(c_ptrTo(seq[0]), headerSize);
 
   // set up the atomic variables we'll use to coordinate between tasks
   var charsLeft, charsWritten: atomic int = size - (headerSize + 1);
@@ -132,7 +133,7 @@ proc revcomp(ref seq, size) {
 
       // take turns writing out our chunks
       charsWritten.waitFor(myStartChar);
-      stdoutBin.writeBinary(c_ptrTo(myBuff[0]), myChunkSize);
+      consoleOut.writeBinary(c_ptrTo(myBuff[0]), myChunkSize);
       charsWritten.write(myStartChar - myChunkSize);
 
       // grab the next chunk of work


### PR DESCRIPTION
After some discussion with the performance team, we decided we like this way better of creating non-locking stdin/stdout channels -- essentially cloning the default ones and renaming them.

(That said, we'd also like either built-in unlocked stdin/stdout or a simpler .getNonLocking() method that could be applied to clone any such channel).
