### PR TITLE
Restore ': real' type constraints + therefore performance to spectralnorm2

### DIFF
--- a/test/studies/shootout/submitted/spectralnorm2.chpl
+++ b/test/studies/shootout/submitted/spectralnorm2.chpl
@@ -48,6 +48,6 @@ proc multiplyAtv(v: [?Dv], ref Atv: [?DAtv]) {
 //
 // Compute element i,j of the conceptually infinite matrix A
 //
-inline proc A(i, j) {
+inline proc A(i: real, j: real) {
   return 1.0 / ((((i+j) * (i+j+1)) / 2) + i + 1);
 }


### PR DESCRIPTION
Yesterday, in doing some code cleanups, I couldn't remember why this version of spectralnorm's 'A' routine took explicit ': real' arguments and the other took the generic (therefore 'int') arguments.  At the time, I was thinking it was a correctness issue, and seeing that things worked fine either way, removed the constraints for cleaner code.

Last night's performance testing reminded me that it's really a matter of performance, as the 'real' versions permit better vectorization to take place.

As a result, I'm restoring them here, to restore the performance.
