### PR TITLE
dyno: adjust `stringify` on types to actually produce Chapel syntax

### DIFF
--- a/frontend/include/chpl/types/CStringType.h
+++ b/frontend/include/chpl/types/CStringType.h
@@ -50,6 +50,8 @@ class CStringType final : public Type {
   ~CStringType() = default;
 
   static const CStringType* get(Context* context);
+
+  void stringify(std::ostream& ss, StringifyKind stringKind) const override;
 };
 
 

--- a/frontend/include/chpl/types/NilType.h
+++ b/frontend/include/chpl/types/NilType.h
@@ -50,6 +50,8 @@ class NilType final : public Type {
   ~NilType() = default;
 
   static const NilType* get(Context* context);
+
+  void stringify(std::ostream& ss, StringifyKind stringKind) const override;
 };
 
 

--- a/frontend/include/chpl/types/Param.h
+++ b/frontend/include/chpl/types/Param.h
@@ -106,7 +106,7 @@ class Param {
 
   // helper function to convert a value to a string
   static std::string valueToString(UniqueString v) {
-    return v.str();
+    return std::string("\"") + v.str() + std::string("\"");
   }
   static std::string valueToString(ComplexDouble v) {
     return std::to_string(v.re) + "+" + std::to_string(v.im) + "i";

--- a/frontend/include/chpl/types/VoidType.h
+++ b/frontend/include/chpl/types/VoidType.h
@@ -50,6 +50,8 @@ class VoidType final : public Type {
   ~VoidType() = default;
 
   static const VoidType* get(Context* context);
+
+  void stringify(std::ostream& ss, StringifyKind stringKind) const override;
 };
 
 

--- a/frontend/lib/types/CStringType.cpp
+++ b/frontend/lib/types/CStringType.cpp
@@ -36,6 +36,10 @@ const CStringType* CStringType::get(Context* context) {
   return getCStringType(context).get();
 }
 
+void CStringType::stringify(std::ostream& ss, StringifyKind stringKind) const {
+  ss << "c_string";
+}
+
 
 } // end namespace types
 } // end namespace chpl

--- a/frontend/lib/types/ClassType.cpp
+++ b/frontend/lib/types/ClassType.cpp
@@ -84,7 +84,8 @@ void ClassType::stringify(std::ostream& ss,
   // emit ? if nilable
   if (decorator_.isNilable()) {
     ss << "?";
-  } else if (decorator_.isUnknownNilability()) {
+  } else if (decorator_.isUnknownNilability() &&
+             stringKind != StringifyKind::CHPL_SYNTAX) {
     ss << " <unknown-nilability>";
   }
 }

--- a/frontend/lib/types/CompositeType.cpp
+++ b/frontend/lib/types/CompositeType.cpp
@@ -96,11 +96,14 @@ void CompositeType::stringify(std::ostream& ss,
 
   auto sorted = sortedSubstitutions();
 
-  if (superType || !sorted.empty()) {
+  bool printSupertype =
+    superType != nullptr && stringKind != StringifyKind::CHPL_SYNTAX;
+
+  if (printSupertype || !sorted.empty()) {
     bool emittedField = false;
     ss << "(";
 
-    if (superType != nullptr && stringKind != StringifyKind::CHPL_SYNTAX) {
+    if (printSupertype) {
       ss << "super:";
       superType->stringify(ss, stringKind);
       emittedField = true;
@@ -108,9 +111,23 @@ void CompositeType::stringify(std::ostream& ss,
 
     for (const auto& sub : sorted) {
       if (emittedField) ss << ", ";
-      sub.first.stringify(ss, stringKind);
-      ss << ":";
-      sub.second.stringify(ss, stringKind);
+
+      if (stringKind != StringifyKind::CHPL_SYNTAX) {
+        sub.first.stringify(ss, stringKind);
+        ss << ":";
+        sub.second.stringify(ss, stringKind);
+      } else {
+        if (sub.second.isType() || (sub.second.isParam() && sub.second.param() == nullptr)) {
+          sub.second.type()->stringify(ss, stringKind);
+        } else if (sub.second.isParam()) {
+          sub.second.param()->stringify(ss, stringKind);
+        } else {
+          // Some odd configuration; fall back to printing the qualified type.
+          CHPL_UNIMPL("attempting to stringify odd type representation as Chapel syntax");
+          sub.second.stringify(ss, stringKind);
+        }
+      }
+
       emittedField = true;
     }
     ss << ")";

--- a/frontend/lib/types/ExternType.cpp
+++ b/frontend/lib/types/ExternType.cpp
@@ -32,7 +32,9 @@ const owned<ExternType>& ExternType::getExternType(Context* context,
 
 void ExternType::stringify(std::ostream& ss,
                            chpl::StringifyKind stringKind) const {
-  ss << "extern type ";
+  if (stringKind != StringifyKind::CHPL_SYNTAX) {
+    ss << "extern type ";
+  }
   linkageName().stringify(ss, stringKind);
 }
 

--- a/frontend/lib/types/NilType.cpp
+++ b/frontend/lib/types/NilType.cpp
@@ -36,6 +36,10 @@ const NilType* NilType::get(Context* context) {
   return getNilType(context).get();
 }
 
+void NilType::stringify(std::ostream& ss, StringifyKind stringKind) const {
+  ss << "_nilType";
+}
+
 
 } // end namespace types
 } // end namespace chpl

--- a/frontend/lib/types/Type.cpp
+++ b/frontend/lib/types/Type.cpp
@@ -159,7 +159,9 @@ void Type::stringify(std::ostream& ss, chpl::StringifyKind stringKind) const {
   for (int i = 0; i < leadingSpaces; i++) {
     ss << "  ";
   }
-  ss << "type ";
+  if (stringKind != chpl::StringifyKind::CHPL_SYNTAX) {
+    ss << "type ";
+  }
   ss << typetags::tagToString(this->tag());
 }
 

--- a/frontend/lib/types/VoidType.cpp
+++ b/frontend/lib/types/VoidType.cpp
@@ -36,6 +36,10 @@ const VoidType* VoidType::get(Context* context) {
   return getVoidType(context).get();
 }
 
+void VoidType::stringify(std::ostream& ss, StringifyKind stringKind) const {
+  ss << "void";
+}
+
 
 } // end namespace types
 } // end namespace chpl

--- a/frontend/test/resolution/testResolverVerboseErrors.cpp
+++ b/frontend/test/resolution/testResolverVerboseErrors.cpp
@@ -65,7 +65,7 @@ static const char* errorExactMatch = R"""(
     4 | proc f(ref x: owned Parent) {}
       |        ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
       |
-  The formal 'x' expects a value of type 'owned Parent()', but the actual was a value of type 'owned Child()'.
+  The formal 'x' expects a value of type 'owned Parent', but the actual was a value of type 'owned Child'.
       |
     7 | f(x);
       |   ⎺
@@ -120,7 +120,7 @@ static const char* errorIncompatibleMgr = R"""(
     3 | proc f(x: owned C) {}
       |        ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
       |
-  The formal 'x' expects a value of type 'owned C()', but the actual was a value of type 'shared C()'.
+  The formal 'x' expects a value of type 'owned C', but the actual was a value of type 'shared C'.
       |
     6 | f(x);
       |   ⎺
@@ -149,7 +149,7 @@ static const char* errorIncompatibleNilability = R"""(
     3 | proc f(x: owned C) {}
       |        ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
       |
-  The formal 'x' expects a value of type 'owned C()', but the actual was a value of type 'owned C()?'.
+  The formal 'x' expects a value of type 'owned C', but the actual was a value of type 'owned C?'.
       |
     6 | f(arg);
       |   ⎺⎺⎺


### PR DESCRIPTION
This PR adjusts the `stringify` function to properly support generating Chapel syntax, and not a Dyno approximation of it. Fixes https://github.com/chapel-lang/chapel/issues/24481.

The most changes were made to `CompositeType`, but other types (`Void`, `CString`, and `Nil`) were also adjusted. The PR also adjusted the stringification of string params to quote the strings, so that it prints `param x = "hello"` and not `param x = hello`, which looks like an identifier access.

Reviewed by @benharsh -- thanks!

## Testing
- [x] paratest