### PR TITLE
Revert "add blog tests to default darwin-m1 nightly test"

### DIFF
--- a/util/cron/test-darwin-m1.bash
+++ b/util/cron/test-darwin-m1.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Test full suite and blog posts for default configuration on M1 darwin
+# Test full suite for default configuration on M1 darwin
 
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common.bash
@@ -9,4 +9,4 @@ source $CWD/common-localnode-paratest.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="darwin-m1"
 
-$CWD/nightly -cron -blog $(get_nightly_paratest_args)
+$CWD/nightly -cron $(get_nightly_paratest_args)


### PR DESCRIPTION
This reverts commit `08165c52f5d9948af6aca8b8cab7c6bae661c8c0`, PR #24690 

cloning the blog from `github.com` fails in this script on the test machines, so undoing for now.