### PR TITLE
Revert blog test

### DIFF
--- a/util/cron/test-darwin-m1.bash
+++ b/util/cron/test-darwin-m1.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Test full suite and blog posts for default configuration on M1 darwin
+# Test full suite for default configuration on M1 darwin
 
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common.bash
@@ -9,4 +9,4 @@ source $CWD/common-localnode-paratest.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="darwin-m1"
 
-$CWD/nightly -cron -blog $(get_nightly_paratest_args)
+$CWD/nightly -cron $(get_nightly_paratest_args)

--- a/util/cron/test-linux64.bash
+++ b/util/cron/test-linux64.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Test default configuration on full suite and blog posts.
+# Test default configuration on full suite.
 
 CWD=$(cd $(dirname $0) ; pwd)
 
@@ -9,4 +9,4 @@ source $CWD/common-localnode-paratest.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64"
 
-$CWD/nightly -cron -mason -protobuf -futures -blog ${nightly_args} $(get_nightly_paratest_args 8)
+$CWD/nightly -cron -mason -protobuf -futures ${nightly_args} $(get_nightly_paratest_args 8)


### PR DESCRIPTION
Reverts commits from PR #24690 because cloning the blog from github.com in the nightly script failed on the test machines, so undoing for now. 

Error reported is 
```
Cloning into 'chapel-blog'...
fatal: could not read Username for 'https://github.com': Device not configured
Error cloning blog repo: 128
```
which I think is a configuration issue with git

[reviewed by @DanilaFe - thanks!]