### PR TITLE
dyno: handle parenless overloads based on 'where' clauses

### DIFF
--- a/frontend/lib/resolution/InitResolver.cpp
+++ b/frontend/lib/resolution/InitResolver.cpp
@@ -641,7 +641,7 @@ ID InitResolver::solveNameConflictByIgnoringField(const NameVec& vec) {
 }
 
 bool InitResolver::handleResolvingFieldAccess(const Identifier* node) {
-  auto parenlessInfo = Resolver::ParenlessOverloadInfo::notOverloaded();
+  auto parenlessInfo = Resolver::ParenlessOverloadInfo();
   auto scope = initResolver_.methodReceiverScopes();
   auto vec = initResolver_.lookupIdentifier(node, scope, parenlessInfo);
 

--- a/frontend/lib/resolution/InitResolver.cpp
+++ b/frontend/lib/resolution/InitResolver.cpp
@@ -641,9 +641,9 @@ ID InitResolver::solveNameConflictByIgnoringField(const NameVec& vec) {
 }
 
 bool InitResolver::handleResolvingFieldAccess(const Identifier* node) {
-  bool outIsOverloadedParenless;
+  auto parenlessInfo = Resolver::ParenlessOverloadInfo::notOverloaded();
   auto scope = initResolver_.methodReceiverScopes();
-  auto vec = initResolver_.lookupIdentifier(node, scope, outIsOverloadedParenless);
+  auto vec = initResolver_.lookupIdentifier(node, scope, parenlessInfo);
 
   // Handle and exit early if there were no ambiguities.
   if (vec.size() == 1 && vec[0].numIds() == 1) {

--- a/frontend/lib/resolution/InitResolver.cpp
+++ b/frontend/lib/resolution/InitResolver.cpp
@@ -641,8 +641,9 @@ ID InitResolver::solveNameConflictByIgnoringField(const NameVec& vec) {
 }
 
 bool InitResolver::handleResolvingFieldAccess(const Identifier* node) {
+  bool outIsOverloadedParenless;
   auto scope = initResolver_.methodReceiverScopes();
-  auto vec = initResolver_.lookupIdentifier(node, scope);
+  auto vec = initResolver_.lookupIdentifier(node, scope, outIsOverloadedParenless);
 
   // Handle and exit early if there were no ambiguities.
   if (vec.size() == 1 && vec[0].numIds() == 1) {

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2854,6 +2854,10 @@ void Resolver::tryResolveParenlessCall(const ParenlessOverloadInfo& info,
                !cMethod.mostSpecific().foundCandidates()) {
       // Only found a valid non-method call.
       handleResolvedCall(r, ident, ci, cNonMethod);
+    } else if (cMethod.mostSpecific().isEmpty() && cNonMethod.mostSpecific().isEmpty()) {
+      // Found neither; lots of candidates, but none worked! Use handleResolvedCall
+      // on cMethod to issue an error and record the result.
+      handleResolvedCall(r, ident, ci, cMethod);
     } else {
       // Found both, it's an ambiguity after all. Issue the ambiguity error
       // late, for which we need to recover some context.

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -114,11 +114,6 @@ struct GatherFieldsOrFormals {
 
 
 Resolver::ParenlessOverloadInfo
-Resolver::ParenlessOverloadInfo::notOverloaded() {
-  return Resolver::ParenlessOverloadInfo {};
-}
-
-Resolver::ParenlessOverloadInfo
 Resolver::ParenlessOverloadInfo::fromBorrowedIds(Context* context,
                                                  const std::vector<BorrowedIdsWithName>& bids) {
   bool anyMethodOrField = false;
@@ -133,7 +128,7 @@ Resolver::ParenlessOverloadInfo::fromBorrowedIds(Context* context,
       }
 
       if (!parsing::idIsParenlessFunction(context, idIt.curIdAndFlags().id())) {
-        return notOverloaded();
+        return {};
       }
     }
   }
@@ -2612,7 +2607,7 @@ Resolver::lookupIdentifier(const Identifier* ident,
                            ParenlessOverloadInfo& outParenlessOverloadInfo) {
   CHPL_ASSERT(scopeStack.size() > 0);
   const Scope* scope = scopeStack.back();
-  outParenlessOverloadInfo = ParenlessOverloadInfo::notOverloaded();
+  outParenlessOverloadInfo = ParenlessOverloadInfo();
 
   bool resolvingCalledIdent = nearestCalledExpression() == ident;
 
@@ -2868,7 +2863,8 @@ void Resolver::tryResolveParenlessCall(const ParenlessOverloadInfo& info,
 
       issueAmbiguityErrorIfNeeded(ident, inScope, receiverScopes, config);
       auto& rr = byPostorder.byAst(ident);
-      rr.setType(QualifiedType());
+      rr.setType(QualifiedType(QualifiedType::UNKNOWN,
+                               ErroneousType::get(context)));
 
     }
   } else if (info.hasMethodCandidates()) {
@@ -2907,7 +2903,7 @@ void Resolver::resolveIdentifier(const Identifier* ident,
   }
 
   // lookupIdentifier reports any errors that are needed
-  auto parenlessInfo = ParenlessOverloadInfo::notOverloaded();
+  auto parenlessInfo = ParenlessOverloadInfo();
   auto vec = lookupIdentifier(ident, receiverScopes, parenlessInfo);
 
   if (parenlessInfo.areCandidatesOnlyParenlessProcs() && !scopeResolveOnly) {

--- a/frontend/lib/resolution/Resolver.h
+++ b/frontend/lib/resolution/Resolver.h
@@ -488,7 +488,11 @@ struct Resolver {
 
   std::vector<BorrowedIdsWithName>
   lookupIdentifier(const uast::Identifier* ident,
-                   llvm::ArrayRef<const Scope*> receiverScopes);
+                   llvm::ArrayRef<const Scope*> receiverScopes,
+                   bool& outIsOverloadedParenless);
+
+
+  void tryResolveParenlessCall(const uast::Identifier* ident, bool considerMethodScopes);
 
   void resolveIdentifier(const uast::Identifier* ident,
                          llvm::ArrayRef<const Scope*> receiverScopes);

--- a/frontend/lib/resolution/Resolver.h
+++ b/frontend/lib/resolution/Resolver.h
@@ -508,6 +508,14 @@ struct Resolver {
 
   bool identHasMoreMentions(const uast::Identifier* ident);
 
+  // When an identifier is ambiguous, try issuing an error, but only if
+  // one hasn't been issued before. In doing so, re-run scope search to
+  // figure out how each candidate was found.
+  void issueAmbiguityErrorIfNeeded(const chpl::uast::Identifier* ident,
+                                   const Scope* scope,
+                                   llvm::ArrayRef<const Scope*> receiverScopes,
+                                   LookupConfig prevConfig);
+
   std::vector<BorrowedIdsWithName>
   lookupIdentifier(const uast::Identifier* ident,
                    llvm::ArrayRef<const Scope*> receiverScopes,
@@ -516,7 +524,7 @@ struct Resolver {
 
   void tryResolveParenlessCall(const ParenlessOverloadInfo& info,
                                const uast::Identifier* ident,
-                               bool considerMethodScopes);
+                               llvm::ArrayRef<const Scope*> receiverScopes);
 
   void resolveIdentifier(const uast::Identifier* ident,
                          llvm::ArrayRef<const Scope*> receiverScopes);

--- a/frontend/test/resolution/testMethodFieldAccess.cpp
+++ b/frontend/test/resolution/testMethodFieldAccess.cpp
@@ -1057,6 +1057,104 @@ static void testExample20() {
            "" /* ambiguity error */);
 }
 
+static void testExample21() {
+  testCall("example21.chpl",
+           R""""(
+              module M {
+                record r {
+                  proc x where true do return 1;
+                  proc x where false do return 0;
+                }
+
+                proc main() {
+                  var rr: r;
+                  rr.x;
+                }
+              }
+           )"""",
+           "M.main",
+           "M.main@3",
+           "M.r.x");
+}
+
+static void testExample22() {
+  testCall("example22.chpl",
+           R""""(
+              module M {
+                record r {
+                  proc x do return 1;
+                  proc x where false do return 0;
+                }
+
+                proc main() {
+                  var rr: r;
+                  rr.x;
+                }
+              }
+           )"""",
+           "M.main",
+           "M.main@3",
+           "M.r.x");
+}
+
+static void testExample23() {
+  testCall("example23.chpl",
+           R""""(
+              module M {
+                record r {
+                  proc x where true do return 1;
+                  proc x where true do return 0;
+                }
+
+                proc main() {
+                  var rr: r;
+                  rr.x;
+                }
+              }
+           )"""",
+           "M.main",
+           "M.main@3",
+           "" /* ambiguity error */);
+}
+
+static void testExample24() {
+  testCall("example24.chpl",
+           R""""(
+              module M {
+                proc x where false do return 1;
+                record r {
+                  proc x where true do return 0;
+                }
+
+                proc r.fn() {
+                  return x;
+                }
+              }
+           )"""",
+           "M.fn",
+           "M.fn@2",
+           "M.r.x");
+}
+
+static void testExample25() {
+  testCall("example25.chpl",
+           R""""(
+              module M {
+                proc x where true do return 1;
+                record r {
+                  proc x where false do return 0;
+                }
+
+                proc r.fn() {
+                  return x;
+                }
+              }
+           )"""",
+           "M.fn",
+           "M.fn@2",
+           "M.x");
+}
+
 int main() {
   test1r();
   test1c();
@@ -1112,6 +1210,11 @@ int main() {
   testExample18();
   testExample19();
   testExample20();
+  testExample21();
+  testExample22();
+  testExample23();
+  testExample24();
+  testExample25();
 
   return 0;
 }

--- a/frontend/test/resolution/testMethodFieldAccess.cpp
+++ b/frontend/test/resolution/testMethodFieldAccess.cpp
@@ -1152,6 +1152,44 @@ static void testExample25() {
            "M.x");
 }
 
+static void testExample26() {
+  testCall("example26.chpl",
+           R""""(
+              module M {
+                record r {
+                  proc x where false do return 1;
+                  proc x where false do return 0;
+                }
+
+                proc r.fn() {
+                  return x;
+                }
+              }
+           )"""",
+           "M.fn",
+           "M.fn@2",
+           "" /* both false; no matches. */);
+}
+
+static void testExample27() {
+  testCall("example27.chpl",
+           R""""(
+              module M {
+                proc x where false do return 1;
+                record r {
+                  proc x where false do return 0;
+                }
+
+                proc r.fn() {
+                  return x;
+                }
+              }
+           )"""",
+           "M.fn",
+           "M.fn@2",
+           "" /* both false; no matches. */);
+}
+
 int main() {
   test1r();
   test1c();
@@ -1212,6 +1250,8 @@ int main() {
   testExample23();
   testExample24();
   testExample25();
+  testExample26();
+  testExample27();
 
   return 0;
 }

--- a/frontend/test/resolution/testMethodFieldAccess.cpp
+++ b/frontend/test/resolution/testMethodFieldAccess.cpp
@@ -1066,14 +1066,13 @@ static void testExample21() {
                   proc x where false do return 0;
                 }
 
-                proc main() {
-                  var rr: r;
-                  rr.x;
+                proc r.fn() {
+                  return x;
                 }
               }
            )"""",
-           "M.main",
-           "M.main@3",
+           "M.fn",
+           "M.fn@2",
            "M.r.x");
 }
 
@@ -1086,14 +1085,13 @@ static void testExample22() {
                   proc x where false do return 0;
                 }
 
-                proc main() {
-                  var rr: r;
-                  rr.x;
+                proc r.fn() {
+                  return x;
                 }
               }
            )"""",
-           "M.main",
-           "M.main@3",
+           "M.fn",
+           "M.fn@2",
            "M.r.x");
 }
 
@@ -1106,14 +1104,13 @@ static void testExample23() {
                   proc x where true do return 0;
                 }
 
-                proc main() {
-                  var rr: r;
-                  rr.x;
+                proc r.fn() {
+                  return x;
                 }
               }
            )"""",
-           "M.main",
-           "M.main@3",
+           "M.fn",
+           "M.fn@2",
            "" /* ambiguity error */);
 }
 


### PR DESCRIPTION
Resolves https://github.com/Cray/chapel-private/issues/6076.

This PR adjusts Dyno's resolver to support selecting a parenless procedure from an overload set.

To make this work, I had to adjust the `lookupIdentifier` method on the `Resolver` to not immediately issue ambiguity errors even if multiple candiadte IDs were found. Instead, it now uses an out-parameter to return a `ParenlessOverloadInfo` struct. This struct has a public boolean property for calling code to check if all candidates were parenless functions; if this is the case (whether there were multiple candidates or one), we run call resolution. 

To match Dyno's existing behavior (which makes ambiguity between method and non-method parenless procedures an error), we actually run call resolution twice: one with a method receiver, and once without. If we find a candiadate for both, we issue that same ambiguity error that we would've issued prior to this PR. To make this work (and reuse the existing ambiguity-issuing logic), this PR adds a new helper method to the resolver to issue ambiguity errors. 

Reviewed by @riftEmber -- thanks!

## Testing
- [x] paratest
