### PR TITLE
Load deps from new Spack install on Atlas

### DIFF
--- a/util/cron/load-base-deps.bash
+++ b/util/cron/load-base-deps.bash
@@ -11,6 +11,10 @@ elif [ "$(hostname -s)" == "osprey" ]; then
   if [ -f /cray/css/users/chapelu/chpl-deps/load_chpl_deps.bash ] ; then
     source /cray/css/users/chapelu/chpl-deps/load_chpl_deps.bash
   fi
+elif [ "$(hostname -s)" == "atlas" ]; then
+  if [ -f /lus/scratch/chapelu/chpl-deps/$(hostname -s)/load_chpl_deps.bash ] ; then
+    source /lus/scratch/chapelu/chpl-deps/$(hostname -s)/load_chpl_deps.bash
+  fi
 else
   # For our internal testing, this is necessary to get the latest version of gcc
   # on the system.


### PR DESCRIPTION
Switch dependency loading on Atlas to use the new Spack install.

This is part of https://github.com/Cray/chapel-private/issues/6116, but I don't believe any jobs running on Atlas actually use this script so it doesn't need to get merged on its own to make progress. I just want to have it for completeness alongside the change on the internal code repo copy (https://github.hpe.com/hpe/hpc-chapel-code/pull/586).

Backing issue: https://github.com/Cray/chapel-private/issues/6116

[trivial, not reviewed]