### PR TITLE
add blogonly test script, adjust nightly script blog handling

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -72,6 +72,7 @@ $python2 = 0;
 $pythonDep = 0;
 $testblog = 0;
 $blogonly = 0;
+$blogdir = "";
 
 while (@ARGV) {
     $flag = shift @ARGV;
@@ -168,9 +169,11 @@ while (@ARGV) {
         $protobuf_build = 1;
     } elsif ($flag eq "-blog") {
         $testblog = 1;
+        $blogdir = shift @ARGV;
     } elsif ($flag eq "-blogonly") {
         $blogonly = 1;
         $testblog = 1;
+        $blogdir = shift @ARGV;
     } else {
         $printusage = 1;
         last;
@@ -209,8 +212,8 @@ if ($printusage == 1) {
     print "\t-debug                         : check out sources and run for individual user (default)\n";
     print "\t-cron                          : use for nightly cron runs only\n";
     print "\t-baseline                      : run testins using --baseline\n";
-    print "\t-blog                          : test the chapel blog with nightly tests\n";
-    print "\t-blogonly                      : only run the chapel blog tests\n";
+    print "\t-blog <blogdir>                : test the chapel blog at <blogdir> with nightly tests\n";
+    print "\t-blogonly <blogdir>            : only run the chapel blog tests. <blogdir> specifies root of blog repo\n";
     print "\t-componly                      : only run the compiler, not the generated binary\n";
     print "\t-compopts <opt>                : run tests with -compopts <opt>\n";
     print "\t-compperformance <description> : run tests with compiler performance tracking\n";
@@ -555,19 +558,23 @@ if ($multilocale == 1) {
 }
 
 #
-# clone blog repo if blog testing requested
+# check the blog repo dir if blog testing requested
 #
 if ($testblog == 1) {
-    print "Cloning blog repo\n";
-    mysystem("cd $basetmpdir && git clone git\@github.com:chapel-lang/chapel-blog", "cloning blog repo", 1, 1, 1);
-    mysystem("cd $basetmpdir/chapel-blog && git checkout main", "checking out branch", 1, 1, 1);
+    print "checking blog repo\n";
+    unless(-d $cronlogdir) {
+        print "Error: specified blog testing but blogdir ($blogdir) was not found\n";
+        exit 1;
+    }
+    # mysystem("cd $basetmpdir && git clone git\@github.com:chapel-lang/chapel-blog", "cloning blog repo", 1, 1, 1);
+    # mysystem("cd $basetmpdir/chapel-blog && git checkout main", "checking out branch", 1, 1, 1);
     if ($blogonly == 0) {
         # copy the relevant blog source files into the test directory so they'll be
         # ran alongside all the other tests
         mysystem("mkdir -p $testdir/copied-chapel-blog/content", "making chpl-src directory", 1, 1, 1);
-        mysystem("cp -r $basetmpdir/chapel-blog/chpl-src $testdir/copied-chapel-blog/", "copying chapel-blog/chpl-src", 1, 1, 1);
-        mysystem("cp -r $basetmpdir/chapel-blog/scripts $testdir/copied-chapel-blog/", "copying chapel-blog/scripts", 1, 1, 1);
-        mysystem("cp -r $basetmpdir/chapel-blog/content/posts $testdir/copied-chapel-blog/content/", "copying chapel-blog/content", 1, 1, 1);
+        mysystem("cp -r $blogdir/chpl-src $testdir/copied-chapel-blog/", "copying chapel-blog/chpl-src", 1, 1, 1);
+        mysystem("cp -r $blogdir/scripts $testdir/copied-chapel-blog/", "copying chapel-blog/scripts", 1, 1, 1);
+        mysystem("cp -r $blogdir/content/posts $testdir/copied-chapel-blog/content/", "copying chapel-blog/content", 1, 1, 1);
     }
 }
 
@@ -605,7 +612,7 @@ if (!($dist eq "")) {
 if ($blogonly == 1) {
     # test the sub-directories explicitly to avoid a bunch of skipped directories,
     # and also avoid the problem of testing the archetypes directory
-    $testflags = "$testflags $basetmpdir/chapel-blog/chpl-src/ $basetmpdir/chapel-blog/content/posts";
+    $testflags = "$testflags $blogdir/chpl-src/ $blogdir/content/posts";
 }
 
 if ($hello == 1) {

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -169,10 +169,10 @@ while (@ARGV) {
         $protobuf_build = 1;
     } elsif ($flag eq "-blog") {
         $testblog = 1;
-        $blogdir = shift @ARGV;
     } elsif ($flag eq "-blogonly") {
         $blogonly = 1;
         $testblog = 1;
+    } elsif ($flag eq "-blogdir") {
         $blogdir = shift @ARGV;
     } else {
         $printusage = 1;
@@ -212,8 +212,9 @@ if ($printusage == 1) {
     print "\t-debug                         : check out sources and run for individual user (default)\n";
     print "\t-cron                          : use for nightly cron runs only\n";
     print "\t-baseline                      : run testins using --baseline\n";
-    print "\t-blog <blogdir>                : test the chapel blog at <blogdir> with nightly tests. <blogdir> could alternatively be specified with CHPL_NIGHTLY_BLOGDIR\n";
-    print "\t-blogonly <blogdir>            : only run the chapel blog tests. <blogdir> specifies root of blog repo. <blogdir> could alternatively be specified with CHPL_NIGHTLY_BLOGDIR\n";
+    print "\t-blog                          : test the chapel blog with nightly tests. <blogdir> could be specified with CHPL_NIGHTLY_BLOGDIR or by passing -blogdir\n";
+    print "\t-blogonly <blogdir>            : only run the chapel blog tests. <blogdir> could be specified with CHPL_NIGHTLY_BLOGDIR or by passing -blogdir\n";
+    print "\t-blogdir <blogdir>             : specify the root of the chapel-blog repo to use with -blog or -blogonly";
     print "\t-componly                      : only run the compiler, not the generated binary\n";
     print "\t-compopts <opt>                : run tests with -compopts <opt>\n";
     print "\t-compperformance <description> : run tests with compiler performance tracking\n";

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -371,6 +371,26 @@ if ($memleakslog ne "") {
 $testbindirname = dirname($0);
 $utildir = "$testbindirname/../../util";
 
+#
+# check the blog repo dir if blog testing requested
+#
+if ($testblog == 1) {
+    print "checking blog repo\n";
+    unless(-d $blogdir) {
+        print "Error: specified blog testing but blogdir ($blogdir) was not found\n";
+        exit 1;
+    }
+    # mysystem("cd $basetmpdir && git clone git\@github.com:chapel-lang/chapel-blog", "cloning blog repo", 1, 1, 1);
+    # mysystem("cd $basetmpdir/chapel-blog && git checkout main", "checking out branch", 1, 1, 1);
+    if ($blogonly == 0) {
+        # copy the relevant blog source files into the test directory so they'll be
+        # ran alongside all the other tests
+        mysystem("mkdir -p $testdir/copied-chapel-blog/content", "making chpl-src directory", 1, 1, 1);
+        mysystem("cp -r $blogdir/chpl-src $testdir/copied-chapel-blog/", "copying chapel-blog/chpl-src", 1, 1, 1);
+        mysystem("cp -r $blogdir/scripts $testdir/copied-chapel-blog/", "copying chapel-blog/scripts", 1, 1, 1);
+        mysystem("cp -r $blogdir/content/posts $testdir/copied-chapel-blog/content/", "copying chapel-blog/content", 1, 1, 1);
+    }
+}
 
 # Determine which make to use.
 $make = "";
@@ -557,26 +577,6 @@ if ($multilocale == 1) {
     $testflags = "$testflags -multilocale-only";
 }
 
-#
-# check the blog repo dir if blog testing requested
-#
-if ($testblog == 1) {
-    print "checking blog repo\n";
-    unless(-d $blogdir) {
-        print "Error: specified blog testing but blogdir ($blogdir) was not found\n";
-        exit 1;
-    }
-    # mysystem("cd $basetmpdir && git clone git\@github.com:chapel-lang/chapel-blog", "cloning blog repo", 1, 1, 1);
-    # mysystem("cd $basetmpdir/chapel-blog && git checkout main", "checking out branch", 1, 1, 1);
-    if ($blogonly == 0) {
-        # copy the relevant blog source files into the test directory so they'll be
-        # ran alongside all the other tests
-        mysystem("mkdir -p $testdir/copied-chapel-blog/content", "making chpl-src directory", 1, 1, 1);
-        mysystem("cp -r $blogdir/chpl-src $testdir/copied-chapel-blog/", "copying chapel-blog/chpl-src", 1, 1, 1);
-        mysystem("cp -r $blogdir/scripts $testdir/copied-chapel-blog/", "copying chapel-blog/scripts", 1, 1, 1);
-        mysystem("cp -r $blogdir/content/posts $testdir/copied-chapel-blog/content/", "copying chapel-blog/content", 1, 1, 1);
-    }
-}
 
 #
 # don't bother making the spec tests if we're only testing hello, world programs;

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -559,7 +559,7 @@ if ($multilocale == 1) {
 #
 if ($testblog == 1) {
     print "Cloning blog repo\n";
-    mysystem("cd $basetmpdir && git clone https://github.com/chapel-lang/chapel-blog", "cloning blog repo", 1, 1, 1);
+    mysystem("cd $basetmpdir && git clone git\@github.com:chapel-lang/chapel-blog", "cloning blog repo", 1, 1, 1);
     mysystem("cd $basetmpdir/chapel-blog && git checkout main", "checking out branch", 1, 1, 1);
     if ($blogonly == 0) {
         # copy the relevant blog source files into the test directory so they'll be

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -562,7 +562,7 @@ if ($multilocale == 1) {
 #
 if ($testblog == 1) {
     print "checking blog repo\n";
-    unless(-d $cronlogdir) {
+    unless(-d $blogdir) {
         print "Error: specified blog testing but blogdir ($blogdir) was not found\n";
         exit 1;
     }

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -384,8 +384,6 @@ if ($testblog == 1) {
             exit 1;
         }
     }
-    # mysystem("cd $basetmpdir && git clone git\@github.com:chapel-lang/chapel-blog", "cloning blog repo", 1, 1, 1);
-    # mysystem("cd $basetmpdir/chapel-blog && git checkout main", "checking out branch", 1, 1, 1);
     if ($blogonly == 0) {
         # copy the relevant blog source files into the test directory so they'll be
         # ran alongside all the other tests

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -212,8 +212,8 @@ if ($printusage == 1) {
     print "\t-debug                         : check out sources and run for individual user (default)\n";
     print "\t-cron                          : use for nightly cron runs only\n";
     print "\t-baseline                      : run testins using --baseline\n";
-    print "\t-blog <blogdir>                : test the chapel blog at <blogdir> with nightly tests\n";
-    print "\t-blogonly <blogdir>            : only run the chapel blog tests. <blogdir> specifies root of blog repo\n";
+    print "\t-blog <blogdir>                : test the chapel blog at <blogdir> with nightly tests. <blogdir> could alternatively be specified with CHPL_NIGHTLY_BLOGDIR\n";
+    print "\t-blogonly <blogdir>            : only run the chapel blog tests. <blogdir> specifies root of blog repo. <blogdir> could alternatively be specified with CHPL_NIGHTLY_BLOGDIR\n";
     print "\t-componly                      : only run the compiler, not the generated binary\n";
     print "\t-compopts <opt>                : run tests with -compopts <opt>\n";
     print "\t-compperformance <description> : run tests with compiler performance tracking\n";
@@ -377,8 +377,11 @@ $utildir = "$testbindirname/../../util";
 if ($testblog == 1) {
     print "checking blog repo\n";
     unless(-d $blogdir) {
-        print "Error: specified blog testing but blogdir ($blogdir) was not found\n";
-        exit 1;
+        $blogdir = $ENV{'CHPL_NIGHTLY_BLOGDIR'};
+        unless(-d $blogdir) {
+            print "Error: specified blog testing but blogdir ($blogdir) was not found\n";
+            exit 1;
+        }
     }
     # mysystem("cd $basetmpdir && git clone git\@github.com:chapel-lang/chapel-blog", "cloning blog repo", 1, 1, 1);
     # mysystem("cd $basetmpdir/chapel-blog && git checkout main", "checking out branch", 1, 1, 1);

--- a/util/cron/test-linux64-blog-only.bash
+++ b/util/cron/test-linux64-blog-only.bash
@@ -7,6 +7,6 @@ CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common.bash
 source $CWD/common-localnode-paratest.bash
 
-export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64"
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-blog-only"
 
 $CWD/nightly -cron -blogonly ${nightly_args} $(get_nightly_paratest_args 8)

--- a/util/cron/test-linux64-blog-only.bash
+++ b/util/cron/test-linux64-blog-only.bash
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# Test default configuration on blog posts only
+
+CWD=$(cd $(dirname $0) ; pwd)
+
+source $CWD/common.bash
+source $CWD/common-localnode-paratest.bash
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64"
+
+$CWD/nightly -cron -blogonly ${nightly_args} $(get_nightly_paratest_args 8)


### PR DESCRIPTION
Adds a test script for testing only the chapel blog and adjusts blog arguments and handling in the `nightly` testing script. 

Changes the nightly script to no longer attempt to clone the chapel-blog repo, instead accepting the location of the repo as a separate argument `-blogdir` or through an environment variable, `CHPL_NIGHTLY_BLOGDIR`. 

These changes allow us to better support testing of the chapel-blog using our nightly test framework by moving the clone step outside of the nightly test and into the CI setup. 

Additionally, this PR adds a new script for testing the blog in Chapel's default `linux64` configuration.

[reviewed by @DanilaFe - thanks!]
