### PR TITLE
Change param-based nbody to foreach-based

### DIFF
--- a/test/studies/shootout/nbody/bradc/nbody-blc.chpl
+++ b/test/studies/shootout/nbody/bradc/nbody-blc.chpl
@@ -91,8 +91,8 @@ proc initSun() {
 // advance the positions and velocities of all the bodies
 //
 proc advance(dt) {
-  for param i in 0..<numBodies {
-    for param j in i+1..<numBodies {
+  foreach i in 0..<numBodies with (ref bodies) {
+    foreach j in i+1..<numBodies with (ref bodies) {
       const dpos = bodies[i].pos - bodies[j].pos,
             mag = dt / sqrt(sumOfSquares(dpos))**3;
 
@@ -101,7 +101,7 @@ proc advance(dt) {
     }
   }
 
-  for param i in 0..<numBodies do
+  foreach i in 0..<numBodies with (ref bodies) do
     bodies[i].pos += dt * bodies[i].vel;
 }
 


### PR DESCRIPTION
While thinking about our fastest/smallest nbody entry on yesterday's CLBG results, I was wondering how a foreach-based version would compare to the for+param version in terms of performance these days. It will probably be less compact in terms of code size—particularly because we're using a tuple of records, which require a `with` clause to modify—but it also feels like a more intuitive use of the language features.  And since my study version has been in sync with the submitted nbody3.chpl, no need to keep timing it as it was.
