### PR TITLE
Dyno: Fixes to c_ptr representation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -80,7 +80,8 @@ jobs:
     - name: make test-dyno-with-asserts
       # 'make modules' so the ChapelSysCTypes module is available
       run: |
-        CHPL_HOME=$PWD make modules && make DYNO_ENABLE_ASSERTIONS=1 test-dyno -j`util/buildRelease/chpl-make-cpu_count`
+        CHPL_HOME=$PWD make modules
+        CHPL_HOME=$PWD make DYNO_ENABLE_ASSERTIONS=1 test-dyno -j`util/buildRelease/chpl-make-cpu_count`
     - name: run dyno linters
       run: |
         CHPL_HOME=$PWD CHPL_HOST_CC=clang-13 CHPL_HOST_CXX=clang++-13 make run-dyno-linters

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -78,8 +78,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: make test-dyno-with-asserts
+      # 'make modules' so the ChapelSysCTypes module is available
       run: |
-        CHPL_HOME=$PWD make DYNO_ENABLE_ASSERTIONS=1 test-dyno -j`util/buildRelease/chpl-make-cpu_count`
+        CHPL_HOME=$PWD make modules && make DYNO_ENABLE_ASSERTIONS=1 test-dyno -j`util/buildRelease/chpl-make-cpu_count`
     - name: run dyno linters
       run: |
         CHPL_HOME=$PWD CHPL_HOST_CC=clang-13 CHPL_HOST_CXX=clang++-13 make run-dyno-linters

--- a/frontend/include/chpl/types/CPtrType.h
+++ b/frontend/include/chpl/types/CPtrType.h
@@ -82,6 +82,10 @@ class CPtrType final : public Type {
   static const ID& getId(Context* context);
   static const ID& getConstId(Context* context);
 
+  const ID& id(Context* context) const {
+    return isConst() ? getConstId(context) : getId(context);
+  }
+
   const Type* eltType() const {
     return eltType_;
   }

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -723,8 +723,6 @@ generateCPtrMethod(Context* context, QualifiedType receiverType,
   return result;
 }
 
-// TODO: Is the use of a QualifiedType for 'receiverType' going to result in
-// too many queries differentiated by the kind?
 static const TypedFnSignature* const&
 getCompilerGeneratedMethodQuery(Context* context, QualifiedType receiverType,
                                 UniqueString name, bool parenless) {
@@ -866,7 +864,15 @@ generateCastToEnum(Context* context,
 const TypedFnSignature*
 getCompilerGeneratedMethod(Context* context, const QualifiedType receiverType,
                            UniqueString name, bool parenless) {
-  return getCompilerGeneratedMethodQuery(context, receiverType, name, parenless);
+  // Normalize recieverType to allow TYPE methods on c_ptr, and to otherwise
+  // use the VAR Kind. The Param* value is also stripped away to reduce
+  // queries.
+  auto qt = receiverType;
+  bool isCPtr = qt.hasTypePtr() ? qt.type()->isCPtrType() : false;
+  if (!(qt.isType() && isCPtr)) {
+    qt = QualifiedType(QualifiedType::VAR, qt.type());
+  }
+  return getCompilerGeneratedMethodQuery(context, qt, name, parenless);
 }
 
 static const TypedFnSignature* const&

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -685,24 +685,27 @@ generateRecordComparison(Context* context, const CompositeType* lhsType) {
 }
 
 static const TypedFnSignature*
-generateCPtrMethod(Context* context, const CPtrType * cpt, UniqueString name) {
+generateCPtrMethod(Context* context, QualifiedType receiverType,
+                   UniqueString name) {
   // Build a basic function signature for methods on a cptr
   // TODO: we should really have a way to just set the return type here
+  const CPtrType* cpt = receiverType.type()->toCPtrType();
   const TypedFnSignature* result = nullptr;
   std::vector<UntypedFnSignature::FormalDetail> formals;
   std::vector<QualifiedType> formalTypes;
 
   formals.push_back(UntypedFnSignature::FormalDetail(USTR("this"), false, nullptr));
-  formalTypes.push_back(QualifiedType(QualifiedType::CONST_REF, cpt));
+  auto qual = receiverType.isType() ? QualifiedType::TYPE : QualifiedType::CONST_REF;
+  formalTypes.push_back(QualifiedType(qual, cpt));
 
   auto ufs = UntypedFnSignature::get(context,
-                        /*id*/ cpt->getId(context),
+                        /*id*/ cpt->id(context),
                         /*name*/ name,
                         /*isMethod*/ true,
                         /*isTypeConstructor*/ false,
                         /*isCompilerGenerated*/ true,
                         /*throws*/ false,
-                        /*idTag*/ parsing::idToTag(context, cpt->getId(context)),
+                        /*idTag*/ asttags::Record, /*parsing::idToTag(context, cpt->getId(context)),*/
                         /*kind*/ uast::Function::Kind::PROC,
                         /*formals*/ std::move(formals),
                         /*whereClause*/ nullptr);
@@ -719,9 +722,11 @@ generateCPtrMethod(Context* context, const CPtrType * cpt, UniqueString name) {
 }
 
 static const TypedFnSignature* const&
-getCompilerGeneratedMethodQuery(Context* context, const Type* type,
+getCompilerGeneratedMethodQuery(Context* context, QualifiedType receiverType,
                                 UniqueString name, bool parenless) {
-  QUERY_BEGIN(getCompilerGeneratedMethodQuery, context, type, name, parenless);
+  QUERY_BEGIN(getCompilerGeneratedMethodQuery, context, receiverType, name, parenless);
+
+  const Type* type = receiverType.type();
 
   const TypedFnSignature* result = nullptr;
 
@@ -749,8 +754,8 @@ getCompilerGeneratedMethodQuery(Context* context, const Type* type,
       } else {
         CHPL_UNIMPL("record method not implemented yet!");
       }
-    } else if (auto cPtrType = type->toCPtrType()) {
-      result = generateCPtrMethod(context, cPtrType, name);
+    } else if (type->isCPtrType()) {
+      result = generateCPtrMethod(context, receiverType, name);
     } else {
       CHPL_UNIMPL("should not be reachable");
     }
@@ -855,9 +860,9 @@ generateCastToEnum(Context* context,
   If no method was generated, returns nullptr.
 */
 const TypedFnSignature*
-getCompilerGeneratedMethod(Context* context, const Type* type,
+getCompilerGeneratedMethod(Context* context, const QualifiedType receiverType,
                            UniqueString name, bool parenless) {
-  return getCompilerGeneratedMethodQuery(context, type, name, parenless);
+  return getCompilerGeneratedMethodQuery(context, receiverType, name, parenless);
 }
 
 static const TypedFnSignature* const&

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -707,7 +707,7 @@ generateCPtrMethod(Context* context, QualifiedType receiverType,
                         /*isTypeConstructor*/ false,
                         /*isCompilerGenerated*/ true,
                         /*throws*/ false,
-                        /*idTag*/ asttags::Record,
+                        /*idTag*/ asttags::Class,
                         /*kind*/ uast::Function::Kind::PROC,
                         /*formals*/ std::move(formals),
                         /*whereClause*/ nullptr);

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -695,6 +695,8 @@ generateCPtrMethod(Context* context, QualifiedType receiverType,
   std::vector<QualifiedType> formalTypes;
 
   formals.push_back(UntypedFnSignature::FormalDetail(USTR("this"), false, nullptr));
+
+  // Allow calling 'eltType' on either a type or value
   auto qual = receiverType.isType() ? QualifiedType::TYPE : QualifiedType::CONST_REF;
   formalTypes.push_back(QualifiedType(qual, cpt));
 
@@ -705,7 +707,7 @@ generateCPtrMethod(Context* context, QualifiedType receiverType,
                         /*isTypeConstructor*/ false,
                         /*isCompilerGenerated*/ true,
                         /*throws*/ false,
-                        /*idTag*/ asttags::Record, /*parsing::idToTag(context, cpt->getId(context)),*/
+                        /*idTag*/ asttags::Record,
                         /*kind*/ uast::Function::Kind::PROC,
                         /*formals*/ std::move(formals),
                         /*whereClause*/ nullptr);
@@ -721,6 +723,8 @@ generateCPtrMethod(Context* context, QualifiedType receiverType,
   return result;
 }
 
+// TODO: Is the use of a QualifiedType for 'receiverType' going to result in
+// too many queries differentiated by the kind?
 static const TypedFnSignature* const&
 getCompilerGeneratedMethodQuery(Context* context, QualifiedType receiverType,
                                 UniqueString name, bool parenless) {

--- a/frontend/lib/resolution/default-functions.h
+++ b/frontend/lib/resolution/default-functions.h
@@ -54,7 +54,8 @@ bool needCompilerGeneratedMethod(Context* context, const types::Type* type,
   If no method was generated, returns nullptr.
 */
 const TypedFnSignature*
-getCompilerGeneratedMethod(Context* context, const types::Type* type,
+getCompilerGeneratedMethod(Context* context,
+                           const types::QualifiedType receiverType,
                            UniqueString name, bool parenless);
 
 /**

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -1641,10 +1641,25 @@ CallResolutionResult resolvePrimCall(Context* context,
       type = QualifiedType(QualifiedType::CONST_VAR,
                            CompositeType::getLocaleIDType(context));
       break;
+
+    case PRIM_ARRAY_GET: {
+        if (ci.numActuals() == 2 && ci.actual(0).type().hasTypePtr()) {
+          auto index = ci.actual(1).type();
+          if (index.hasTypePtr() && index.type()->isIntegralType()) {
+            auto act = ci.actual(0).type();
+            if (auto ptr = act.type()->toCPtrType()) {
+              type = QualifiedType(QualifiedType::REF, ptr->eltType());
+            }
+          } else {
+            context->error(call, "bad call to primitive \"%s\": second argument must be an integral type", primTagToName(prim));
+          }
+        }
+      }
+      break;
+
     case PRIM_USED_MODULES_LIST:
     case PRIM_REFERENCED_MODULES_LIST:
     case PRIM_TUPLE_EXPAND:
-    case PRIM_ARRAY_GET:
     case PRIM_MAYBE_LOCAL_THIS:
     case PRIM_MAYBE_LOCAL_ARR_ELEM:
     case PRIM_MAYBE_AGGREGATE_ASSIGN:

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -1332,7 +1332,8 @@ CallResolutionResult resolvePrimCall(Context* context,
           break;
         } else if (actualType.type()->isStringType() ||
                    actualType.type()->isBytesType() ||
-                   actualType.type()->isCStringType()) {
+                   actualType.type()->isCStringType() ||
+                   actualType.type()->isCPtrType()) {
           // for non-param string/bytes, the return type is just a default int
           type = QualifiedType(QualifiedType::CONST_VAR,
                                IntType::get(context, 0));

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2676,15 +2676,6 @@ doIsCandidateApplicableInitial(Context* context,
     return ApplicabilityResult::failure(candidateId, /* TODO */ FAIL_CANDIDATE_OTHER);
   }
 
-  // Ignore the 'eltType' declaration in the fake c_ptr[Const] classes. A
-  // compiler-generated function will handle it since we're representing the
-  // type entirely within the frontend.
-  if ((candidateId.symbolPath() == CPtrType::getId(context).symbolPath() ||
-      candidateId.symbolPath() == CPtrType::getConstId(context).symbolPath()) &&
-      ci.name() == "eltType") {
-    return ApplicabilityResult::failure(candidateId, /* TODO */ FAIL_CANDIDATE_OTHER);
-  }
-
   if (isVariable(tag)) {
     if (ci.isParenless() && ci.isMethodCall() && ci.numActuals() == 1) {
       // calling a field accessor

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -4066,7 +4066,9 @@ findMostSpecificAndCheck(Context* context,
   }
 
   // note any most-specific candidates from POI in poiInfo.
-  {
+  // TODO: This can be the case for generated calls, but is skipping the POI
+  // accumulation safe?
+  if (call != nullptr) {
     size_t n = candidates.size();
     for (size_t i = firstPoiCandidate; i < n; i++) {
       for (const MostSpecificCandidate& candidate : mostSpecific) {

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -3413,7 +3413,7 @@ considerCompilerGeneratedMethods(Context* context,
   }
 
   // get the compiler-generated function, may be generic
-  auto tfs = getCompilerGeneratedMethod(context, receiverType, ci.name(),
+  auto tfs = getCompilerGeneratedMethod(context, receiver.type(), ci.name(),
                                         ci.isParenless());
   return tfs;
 }

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -3409,17 +3409,16 @@ considerCompilerGeneratedMethods(Context* context,
   // fetch the receiver type info
   CHPL_ASSERT(ci.numActuals() >= 1);
   auto& receiver = ci.actual(0);
-  // TODO: This should be the QualifiedType in case of type methods
-  auto receiverType = receiver.type().type();
+  auto receiverType = receiver.type();
 
   // if not compiler-generated, then nothing to do
-  if (!needCompilerGeneratedMethod(context, receiverType, ci.name(),
+  if (!needCompilerGeneratedMethod(context, receiverType.type(), ci.name(),
                                    ci.isParenless())) {
     return nullptr;
   }
 
   // get the compiler-generated function, may be generic
-  auto tfs = getCompilerGeneratedMethod(context, receiver.type(), ci.name(),
+  auto tfs = getCompilerGeneratedMethod(context, receiverType, ci.name(),
                                         ci.isParenless());
   return tfs;
 }

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -160,11 +160,6 @@ struct GatherDecls {
       // since dyno handles tuple types directly rather
       // than through a record.
       skip = true;
-    } else if (d->isClass() &&
-        d->attributeGroup() != nullptr &&
-        d->attributeGroup()->hasPragma(uast::pragmatags::PRAGMA_C_PTR_CLASS) &&
-        (d->name() == "c_ptr" || d->name() == "c_ptrConst")) {
-      skip = true;
     }
 
     if (skip == false) {

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -160,6 +160,15 @@ struct GatherDecls {
       // since dyno handles tuple types directly rather
       // than through a record.
       skip = true;
+    } else if (d->name() == "eltType" &&
+               atFieldLevel && tagParent == asttags::Class &&
+               (d->id().symbolPath().startsWith("CTypes.c_ptr") ||
+                d->id().symbolPath().startsWith("Ctypes.c_ptrConst"))) {
+      // skip gathering the 'eltType' field of the dummy c_ptr[Const] classes,
+      // since we're representing those types entirely within the frontend.
+      //
+      // TODO: Remove this once we have replaced those classes.
+      skip = true;
     }
 
     if (skip == false) {

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -160,6 +160,11 @@ struct GatherDecls {
       // since dyno handles tuple types directly rather
       // than through a record.
       skip = true;
+    } else if (d->isClass() &&
+        d->attributeGroup() != nullptr &&
+        d->attributeGroup()->hasPragma(uast::pragmatags::PRAGMA_C_PTR_CLASS) &&
+        (d->name() == "c_ptr" || d->name() == "c_ptrConst")) {
+      skip = true;
     }
 
     if (skip == false) {

--- a/frontend/lib/types/CompositeType.cpp
+++ b/frontend/lib/types/CompositeType.cpp
@@ -201,7 +201,8 @@ bool CompositeType::isMissingBundledClassType(Context* context, ID id) {
     auto path = id.symbolPath();
     return path == "ChapelReduce.ReduceScanOp" ||
            path == "Errors.Error" || 
-           path == "CTypes.c_ptr";
+           path == "CTypes.c_ptr" ||
+           path == "CTypes.c_ptrConst";
   }
 
   return false;

--- a/frontend/lib/types/Type.cpp
+++ b/frontend/lib/types/Type.cpp
@@ -135,10 +135,6 @@ void Type::gatherBuiltins(Context* context,
   auto genericUnmanaged = ClassType::get(context, AnyClassType::get(context), nullptr, ClassTypeDecorator(ClassTypeDecorator::UNMANAGED));
   gatherType(context, map, "unmanaged", genericUnmanaged);
 
-  gatherType(context, map, "c_ptr", CPtrType::get(context));
-
-  gatherType(context, map, "c_ptrConst", CPtrType::getConst(context));
-
   BuiltinType::gatherBuiltins(context, map);
 }
 

--- a/frontend/test/resolution/testCPtr.cpp
+++ b/frontend/test/resolution/testCPtr.cpp
@@ -310,6 +310,32 @@ static void test22() {
   });
 }
 
+static void test23() {
+  ErrorGuard guard(context);
+
+  std::string program = R"""(
+  module M{
+    module X {
+      proc foo() {
+        use CTypes;
+
+        var ret : c_ptr(int);
+        return ret;
+      }
+    }
+
+    use X;
+
+    var ptr = foo();
+    var x = ptr[0];
+  }
+  )""";
+
+  auto vars = resolveTypesOfVariables(context, program, {"ptr", "x"});
+  assert(vars["ptr"].type()->isCPtrType());
+  assert(vars["x"].type()->isIntType());
+}
+
 int main() {
   setupContext();
 
@@ -335,6 +361,8 @@ int main() {
   test20();
   test21();
   test22();
+
+  test23();
 
   delete context;
 

--- a/frontend/test/resolution/testCPtr.cpp
+++ b/frontend/test/resolution/testCPtr.cpp
@@ -32,14 +32,31 @@
 
 #include <sstream>
 
+static Context* context;
+
+// Use a single context with revisions to get this test running faster.
+static void setupContext() {
+  std::string chpl_home;
+  if (const char* chpl_home_env = getenv("CHPL_HOME")) {
+    chpl_home = chpl_home_env;
+  } else {
+    printf("CHPL_HOME must be set");
+    exit(1);
+  }
+  Context::Configuration config;
+  config.chplHome = chpl_home;
+  context = new Context(config);
+}
+
 template <typename F>
 void testCPtrArg(const char* formalType, const char* actualType, F&& test) {
-  Context ctx;
-  Context* context = &ctx;
+  context->advanceToNextRevision(false);
+  setupModuleSearchPaths(context, false, false, {}, {});
   ErrorGuard guard(context);
 
   std::stringstream ss;
 
+  ss << "use CTypes;" << std::endl;
   ss << "record rec { type someType; }" << std::endl;
   ss << "proc f(x: " << formalType << ") {}" << std::endl;
   ss << "var arg: " << actualType << ";" << std::endl;
@@ -53,14 +70,14 @@ void testCPtrArg(const char* formalType, const char* actualType, F&& test) {
 
   assert(modules.size() == 1);
   auto mainMod = modules[0];
-  assert(mainMod->numStmts() == 4);
+  assert(mainMod->numStmts() == 5);
 
-  auto fChild = mainMod->child(1);
+  auto fChild = mainMod->child(2);
   assert(fChild->isFunction());
   auto fFn = fChild->toFunction();
   assert(fFn->name() == "f");
 
-  auto fCallVar = mainMod->child(3);
+  auto fCallVar = mainMod->child(4);
   assert(fCallVar->isVariable());
 
   auto& modResResult = resolveModule(context, mainMod->id());
@@ -294,6 +311,8 @@ static void test22() {
 }
 
 int main() {
+  setupContext();
+
   test1();
   test2();
   test3();
@@ -316,6 +335,8 @@ int main() {
   test20();
   test21();
   test22();
+
+  delete context;
 
   return 0;
 }

--- a/frontend/test/resolution/testReturnTypes.cpp
+++ b/frontend/test/resolution/testReturnTypes.cpp
@@ -1095,15 +1095,26 @@ static void testSelectParams() {
 }
 
 static void testCPtrEltType() {
+  std::string chpl_home;
+  if (const char* chpl_home_env = getenv("CHPL_HOME")) {
+    chpl_home = chpl_home_env;
+  } else {
+    printf("CHPL_HOME must be set");
+    exit(1);
+  }
+  Context::Configuration config;
+  config.chplHome = chpl_home;
   { 
     //works for c_ptr
     std::string program = ops + R"""(
+    use CTypes;
     var y: c_ptr(uint(8));
     type x = y.eltType;
     )""";
 
-    Context ctx;
+    Context ctx(config);
     Context* context = &ctx;
+    setupModuleSearchPaths(context, false, false, {}, {});
     ErrorGuard guard(context);
     auto qt = resolveTypeOfXInit(context, program);
     assert(qt.type()->isUintType());
@@ -1113,6 +1124,7 @@ static void testCPtrEltType() {
   { 
     //works for user-defined class 
     std::string program = ops + R"""(
+    use CTypes;
     class c_ptr2 {
       type eltType;
     }
@@ -1120,8 +1132,9 @@ static void testCPtrEltType() {
     type x = y.eltType;
     )""";
 
-    Context ctx;
+    Context ctx(config);
     Context* context = &ctx;
+    setupModuleSearchPaths(context, false, false, {}, {});
     ErrorGuard guard(context);
     auto qt = resolveTypeOfXInit(context, program);
     assert(qt.type()->isUintType());


### PR DESCRIPTION
This PR contains various improvements to the representation of ``c_ptr`` and ``c_ptrConst`` in the frontend.

The most significant change is to stop treating ``c_ptr[Const]`` as a builtin and instead rely on the ``c_ptr`` and ``c_ptrConst`` classes in ``CTypes``. This allows us to use a real ID as a point of reference to find methods on ``c_ptr`` when ``CTypes`` is not in scope. Tests have also been updated to now use ``CTypes``.

Another notable change is to allow ``eltType`` to be called on both types and values of ``c_ptr``. This is achieved by updating ``getCompilerGeneratedMethodQuery`` to take a ``QualifiedType`` instead of a ``Type*``, so that we can preserve the relevant ``Kind``.

Other changes:
- implement PRIM_ARRAY_GET for ``c_ptr``
- allow ``c_ptr`` in PRIM_STRING_LENGTH_BYTES

Testing:
- [x] test-dyno
- [x] local paratest
