### PR TITLE
Remove default arguments from syncWarp impl

### DIFF
--- a/runtime/include/gpu/amd/chpl-gpu-gen-includes.h
+++ b/runtime/include/gpu/amd/chpl-gpu-gen-includes.h
@@ -60,13 +60,12 @@ __device__ static inline void chpl_gpu_force_sync() {
   __builtin_amdgcn_s_barrier();
 }
 
-__device__ static inline void chpl_gpu_force_warp_sync(unsigned mask=0xffffffff) {
+__device__ static inline void chpl_gpu_force_warp_sync(unsigned mask) {
   // no-op
   // AMD gpu's have no architectures which need a syncWarp operation
   // This is because as of the time of writing, HIP guarantees that all
   // threads within a warp will be executed in lockstep
 }
-
 
 __device__ static inline uint32_t chpl_gpu_getThreadIdxX() { return __builtin_amdgcn_workitem_id_x(); }
 __device__ static inline uint32_t chpl_gpu_getThreadIdxY() { return __builtin_amdgcn_workitem_id_y(); }

--- a/runtime/include/gpu/nvidia/chpl-gpu-gen-includes.h
+++ b/runtime/include/gpu/nvidia/chpl-gpu-gen-includes.h
@@ -60,7 +60,7 @@ __device__ static inline void chpl_gpu_force_sync() {
   asm volatile("bar.sync 0;" : : : "memory");
 }
 
-__device__ static inline void chpl_gpu_force_warp_sync(unsigned mask=0xffffffff) {
+__device__ static inline void chpl_gpu_force_warp_sync(unsigned mask) {
   // Call nvidia's syncwarp
   __syncwarp(mask);
 }


### PR DESCRIPTION
These default arguments are not supported in C. They were redundant anyway so we are not losing anything here; the module version of syncWarp already has the default arguments so it doesn't matter if the implementation has that.
Fixes some nightly test failures.