### PR TITLE
Fix nl argument parsing

### DIFF
--- a/runtime/src/arg.c
+++ b/runtime/src/arg.c
@@ -291,9 +291,12 @@ void parseNumLocales(const char* numPtr, int32_t lineno, int32_t filename) {
       if (_argNumLocalesPerNode < 1) {
         chpl_error("Number of locales per node must be > 0.",
                    lineno, filename);
-      }
-      if (_argNumLocalesPerNode > 1) {
-        chpl_env_set("CHPL_RT_LOCALES_PER_NODE", lpn, 1);
+      } else if ((_argNumLocalesPerNode > 1) || t) {
+        // We have co-locales if there is more then one locale per node or if
+        // the locale is bound to an architectural feature.
+        char buf[32];
+        snprintf(buf, sizeof(buf), "%d", _argNumLocalesPerNode);
+        chpl_env_set("CHPL_RT_LOCALES_PER_NODE", buf, 1);
       }
     } else {
 
@@ -307,6 +310,8 @@ void parseNumLocales(const char* numPtr, int32_t lineno, int32_t filename) {
       if (_argNumLocalesPerNode < 1) {
         chpl_error("CHPL_RT_LOCALES_PER_NODE must be > 0.", lineno, filename);
       }
+
+      // TODO: allow for a suffix w/out L
     }
 
     int32_t numNodes = c_string_to_int32_t_precise(expr, &invalid,

--- a/test/runtime/configMatters/launch/jhh/co-locales/co-locales.py
+++ b/test/runtime/configMatters/launch/jhh/co-locales/co-locales.py
@@ -79,41 +79,53 @@ class ColocaleArgs(unittest.TestCase):
     def test_00_base(self):
         """One locale per node"""
         output = self.runCmd("./hello -nl 4 -v --dry-run")
-        self.assertTrue('--nodes=4' in output or '-N 4' in output)
-        self.assertIn('--ntasks=4', output)
+        self.assertTrue('--nodes=4 ' in output or '-N 4 ' in output)
+        self.assertIn('--ntasks=4 ', output)
+        self.assertNotIn("CHPL_RT_LOCALES_PER_NODE", output)
+        self.assertNotIn("CHPL_RT_COLOCALE_OBJ_TYPE", output)
 
     def test_01_1x1(self):
         """Still one locale per node"""
         output = self.runCmd("./hello -nl 1x1 -v --dry-run")
-        self.assertTrue('--nodes=1' in output or '-N 1' in output)
-        self.assertIn('--ntasks=1', output)
+        self.assertTrue('--nodes=1 ' in output or '-N 1 ' in output)
+        self.assertIn('--ntasks=1 ', output)
+        self.assertNotIn("CHPL_RT_LOCALES_PER_NODE", output)
+        self.assertNotIn("CHPL_RT_COLOCALE_OBJ_TYPE", output)
 
     def test_02_3x2(self):
         """Three nodes, two locales per node"""
         output = self.runCmd("./hello -nl 3x2 -v --dry-run")
-        self.assertTrue('--nodes=3' in output or '-N 3' in output)
-        self.assertIn('--ntasks=6', output)
+        self.assertTrue('--nodes=3 ' in output or '-N 3 ' in output)
+        self.assertIn('--ntasks=6 ', output)
+        self.assertIn("CHPL_RT_LOCALES_PER_NODE=2 ", output)
+        self.assertNotIn("CHPL_RT_COLOCALE_OBJ_TYPE", output)
 
     def test_03_1xd1(self):
         """One node, locales-per-node defaults to 1"""
         self.env['CHPL_RT_LOCALES_PER_NODE'] = '1'
         output = self.runCmd("./hello -nl 1x -v --dry-run")
-        self.assertTrue('--nodes=1' in output or '-N 1' in output)
-        self.assertIn('--ntasks=1', output)
+        self.assertTrue('--nodes=1 ' in output or '-N 1 ' in output)
+        self.assertIn('--ntasks=1 ', output)
+        self.assertNotIn("CHPL_RT_LOCALES_PER_NODE", output)
+        self.assertNotIn("CHPL_RT_COLOCALE_OBJ_TYPE", output)
 
     def test_04_3xd1(self):
         """Three nodes, locales-per-node defaults to 1"""
         self.env['CHPL_RT_LOCALES_PER_NODE'] = '1'
         output = self.runCmd("./hello -nl 3x -v --dry-run")
-        self.assertTrue('--nodes=3' in output or '-N 3' in output)
-        self.assertIn('--ntasks=3', output)
+        self.assertTrue('--nodes=3 ' in output or '-N 3 ' in output)
+        self.assertIn('--ntasks=3 ', output)
+        self.assertNotIn("CHPL_RT_LOCALES_PER_NODE", output)
+        self.assertNotIn("CHPL_RT_COLOCALE_OBJ_TYPE", output)
 
     def test_05_3xd2(self):
         """Three nodes, locales-per-node defaults to 2"""
         self.env['CHPL_RT_LOCALES_PER_NODE'] = '2'
         output = self.runCmd("./hello -nl 3x -v --dry-run")
-        self.assertTrue('--nodes=3' in output or '-N 3' in output)
-        self.assertIn('--ntasks=6', output)
+        self.assertTrue('--nodes=3 ' in output or '-N 3 ' in output)
+        self.assertIn('--ntasks=6 ', output)
+        self.assertNotIn("CHPL_RT_LOCALES_PER_NODE", output)
+        self.assertNotIn("CHPL_RT_COLOCALE_OBJ_TYPE", output)
 
     def test_06_3xd_1(self):
         """Three nodes, locales-per-node is negative"""
@@ -183,16 +195,22 @@ class ColocaleArgs(unittest.TestCase):
         """Arg overrides CHPL_RT_LOCALES_PER_NODE"""
         self.env['CHPL_RT_LOCALES_PER_NODE'] = '4'
         output = self.runCmd("./hello -nl 3x2 -v --dry-run")
-        self.assertTrue('--nodes=3' in output or '-N 3' in output)
-        self.assertIn('--ntasks=6', output)
+        self.assertTrue('--nodes=3 ' in output or '-N 3 ' in output)
+        self.assertIn('--ntasks=6 ', output)
+        self.assertIn("CHPL_RT_LOCALES_PER_NODE=2 ", output)
+        self.assertNotIn("CHPL_RT_COLOCALE_OBJ_TYPE", output)
 
     def test_16_valid_suffixes(self):
         """Allow valid suffixes"""
-        for s in ['s', 'socket', 'numa', 'llc', 'c', 'core']:
-            with self.subTest(s=s):
+        suffixes = {'s':'socket', 'socket':'socket', 'numa':'numa',
+                    'llc':'cache', 'c':'core', 'core':'core'}
+        for (s, t) in suffixes.items():
+            with self.subTest(s=s, t=t):
                 output=self.runCmd("./hello -nl 3x2%s -v --dry-run" % s)
-                self.assertTrue('--nodes=3' in output or '-N 3' in output)
-                self.assertIn('--ntasks=6', output)
+                self.assertTrue('--nodes=3 ' in output or '-N 3 ' in output)
+                self.assertIn('--ntasks=6 ', output)
+                self.assertIn("CHPL_RT_LOCALES_PER_NODE=2 ", output)
+                self.assertIn('CHPL_RT_COLOCALE_OBJ_TYPE=%s ' % t, output)
 
     def test_17_invalid_suffix(self):
         """Reject invalid suffix"""


### PR DESCRIPTION
`CHPL_RT_LOCALES_PER_NODE` should be set if there is a single locale per node that is bound to an architectural feature. Otherwise the runtime will not partition resources correctly. Updated the test cases to test for this, and to be more rigorous about when this and other environment variables should be set and not set.