### PR TITLE
Fix dyno CI testing when standard modules are required

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -78,8 +78,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: make test-dyno-with-asserts
+      # 'make modules' so the ChapelSysCTypes module is available
       run: |
-        CHPL_HOME=$PWD make DYNO_ENABLE_ASSERTIONS=1 test-dyno -j`util/buildRelease/chpl-make-cpu_count`
+        CHPL_HOME=$PWD make modules && make DYNO_ENABLE_ASSERTIONS=1 test-dyno -j`util/buildRelease/chpl-make-cpu_count`
     - name: run dyno linters
       run: |
         CHPL_HOME=$PWD CHPL_HOST_CC=clang-13 CHPL_HOST_CXX=clang++-13 make run-dyno-linters


### PR DESCRIPTION
This PR fixes dyno CI testing involving standard modules by building the ChapelSysCTypes module ahead of testing. Prior to this change we could get errors due to an inability to find the module.