### PR TITLE
Avoid string copies by implementing replace with match

### DIFF
--- a/runtime/include/qio/qio_regex.h
+++ b/runtime/include/qio/qio_regex.h
@@ -127,7 +127,7 @@ qio_regex_string_piece_isnull(qio_regex_string_piece_t* sp)
 // Returns true if we matched.
 qio_bool qio_regex_match(qio_regex_t* regex, const char* str, int64_t str_len, int64_t startpos, int64_t endpos, int anchor, qio_regex_string_piece_t* submatch, int64_t nsubmatch);
 
-int64_t qio_regex_replace(qio_regex_t* regex, const char* repl, int64_t repl_len, const char* str, int64_t str_len, int64_t startpos, int64_t endpos, qio_bool global, const char** str_out, int64_t* len_out);
+int64_t qio_regex_replace(qio_regex_t* regex, const char* repl, int64_t repl_len, const char* str, int64_t str_len, int64_t maxreplace, const char** str_out, int64_t* len_out);
 
 
 // Returns ENOERR if we matched, EFORMAT if we did not, or an IO error.

--- a/runtime/src/qio/regex/bundled/re2-interface.cc
+++ b/runtime/src/qio/regex/bundled/re2-interface.cc
@@ -20,8 +20,8 @@
 
 #include <limits>
 #include <pthread.h>
-#include <stdlib.h>
-#include <stdio.h>
+#include <cstdlib>
+#include <cstdio>
 
 // We have run into issues when using our chpl-atomics.h file from C++ code
 // under CHPL_ATOMICS=cstdlib. As a workaround, just use std::atomic and avoid
@@ -372,7 +372,7 @@ static bool append_rewrite(char*& buf, // buffer
       continue;
     }
     s++;
-    int c = (s < end) ? *s : -1;
+    int c = (s < end) ? *s : EOF;
     if (isdigit(c)) {
       int n = (c - '0');
       if (n >= veclen) {
@@ -392,7 +392,7 @@ static bool append_rewrite(char*& buf, // buffer
 }
 
 static int free_and_return_error(char* buf) {
-  if (buf != NULL) qio_free((void*)buf);
+  qio_free((void*)buf);
   return -1;
 }
 
@@ -445,11 +445,11 @@ static int replace(const RE2& re, const StringPiece& rewrite,
       //
       if (re.options().encoding() == RE2::Options::EncodingUTF8) {
         // append the character
-        int bad;
         int nbytes = 0;
         int32_t chr = 0;
-        bad = chpl_enc_decode_char_buf_utf8(&chr, &nbytes, p, ep - p, false);
-        if (bad == 0) {
+        int failed =
+          chpl_enc_decode_char_buf_utf8(&chr, &nbytes, p, ep - p, false);
+        if (failed == 0) {
           if (!append(buf, buf_sz, buf_len, p, nbytes))
             return free_and_return_error(buf);
           p += nbytes;

--- a/runtime/src/qio/regex/bundled/re2-interface.cc
+++ b/runtime/src/qio/regex/bundled/re2-interface.cc
@@ -335,8 +335,8 @@ static bool append(char*& buf, // buffer
   if (buf == NULL || buf_len + data_len > buf_sz) {
     // reallocate buf
     int64_t new_sz = buf_sz * 2;
-    if (new_sz < data_len) {
-      new_sz = data_len + 32;
+    if (new_sz < buf_len + data_len) {
+      new_sz = buf_len + data_len + 32;
     }
     if (new_sz < 64) {
       new_sz = 64;

--- a/runtime/src/qio/regex/bundled/re2-interface.cc
+++ b/runtime/src/qio/regex/bundled/re2-interface.cc
@@ -400,57 +400,7 @@ static int free_and_return_error(char* buf) {
 static const int kMaxArgs = 16;
 static const int kVecSize = 1+kMaxArgs;
 
-
-// returns the number of replacements made or -1 for an error
-/*
-static int replace_first(const RE2& re, const StringPiece& rewrite,
-                         const StringPiece& str,
-                         const char** str_out, int64_t* len_out) {
-  StringPiece vec[kVecSize];
-  int nvec = 1 + RE2::MaxSubmatch(rewrite);
-  if (nvec > 1 + re.NumberOfCapturingGroups())
-    return -1;
-  if (nvec > static_cast<int>(sizeof(vec)/sizeof(StringPiece)))
-    return -1;
-  if (!re.Match(str, 0, str.size(), RE2::UNANCHORED, vec, nvec))
-    return 0;
-
-  // check that vec[0] makes sense
-  assert(vec[0].data() >= str.data());
-  assert(vec[0].data() + vec[0].size() <= str.data() + str.size());
-
-  char* buf = NULL;
-  int64_t buf_sz = 0;
-  int64_t buf_len = 0;
-  int64_t matchStart = vec[0].data() - str.data();
-
-  // copy any data from before the first match
-  if (!append(buf, buf_sz, buf_len, str.data(), matchStart))
-    return free_and_return_error(buf);
-
-  // copy the replacement instead of the first match
-  if (nvec == 1) {
-    // if there are no submatch replacements e.g. \\1, just copy the replacement
-    if (!append(buf, buf_sz, buf_len, rewrite.data(), rewrite.size()))
-      return free_and_return_error(buf);
-  } else {
-    if (!append_rewrite(buf, buf_sz, buf_len, rewrite, vec, nvec))
-      return free_and_return_error(buf);
-  }
-
-  int64_t matchEnd = matchStart + vec[0].size();
-
-  // then copy anything after the first match
-  if (str.size() > matchEnd)
-    if (!append(buf, buf_sz, buf_len,
-                str.data() + matchEnd, str.size() - matchEnd))
-      return free_and_return_error(buf);
-
-  // done
-  return 1;
-}
-*/
-
+// this function is loosly based upon RE2::GlobalReplace
 static int replace(const RE2& re, const StringPiece& rewrite,
                    const StringPiece& str,
                    int maxreplace,
@@ -529,9 +479,6 @@ static int replace(const RE2& re, const StringPiece& rewrite,
     if (count == maxreplace)
       break;
   }
-
-  // if (count == 0)
-  //  return 0;
 
   // append anything after the last match
   if (p < ep)

--- a/runtime/src/qio/regex/bundled/re2-interface.cc
+++ b/runtime/src/qio/regex/bundled/re2-interface.cc
@@ -320,32 +320,238 @@ qio_bool qio_regex_match(qio_regex_t* regex, const char* text, int64_t text_len,
   return ret;
 }
 
-int64_t qio_regex_replace(qio_regex_t* regex, const char* repl, int64_t repl_len, const char* str, int64_t str_len, int64_t startpos, int64_t endpos, qio_bool global, const char** str_out, int64_t* len_out)
-{
-  // This could make fewer copies of everything...
-  // ... but it will work for the moment and this is the
-  //     expedient way.
-  StringPiece rewrite(repl, repl_len);
-  std::string s(str, str_len);
-  int64_t ret = 0;
-  if (RE2* re = (RE2*) regex->regex) {
-    char* output = NULL;
-    if( global ) {
-      ret = RE2::GlobalReplace(&s, *re, rewrite);
-    } else {
-      if( RE2::Replace(&s, *re, rewrite) ) {
-        ret = 1;
-      } else {
-        ret = 0;
-      }
+
+// returns true for OK
+static bool append(char*& buf, // buffer
+                   int64_t& buf_sz, // allocated size
+                   int64_t& buf_len, // amount used
+                   const char* data, // to append
+                   int64_t data_len) {
+  if (data_len == 0)
+    return true; // nothing else to do
+
+  if (data_len < 0)
+    return false;
+
+  if (buf == NULL || buf_len + data_len > buf_sz) {
+    // reallocate buf
+    int64_t new_sz = buf_sz * 2;
+    if (new_sz < data_len) {
+      new_sz = data_len + 32;
     }
-    output = (char*) qio_malloc(s.length()+1);
-    memcpy(output, s.data(), s.length());
-    output[s.length()] = '\0';
-    *str_out = output;
-    *len_out = s.length();
+    if (new_sz < 64) {
+      new_sz = 64;
+    }
+    char* new_buf = (char*) qio_realloc((void*)buf, new_sz);
+    if (new_buf == NULL) return false; // failure to allocate
+    // record the new buffer and size for the caller
+    buf = new_buf;
+    buf_sz = new_sz;
   }
-  return ret;
+
+  // append the data
+  assert(buf_len >= 0 && data_len >= 0 && buf_sz >= 0);
+  assert(buf_len + data_len <= buf_sz);
+  memcpy(buf + buf_len, data, data_len);
+  buf_len += data_len;
+
+  return true; // everything is OK
+}
+
+static bool append_rewrite(char*& buf, // buffer
+                           int64_t& buf_sz, // allocated size
+                           int64_t& buf_len, // amount used
+                           const StringPiece& rewrite,
+                           const StringPiece* vec,
+                           int veclen) {
+  for (const char *s = rewrite.data(), *end = s + rewrite.size();
+       s < end;
+       s++) {
+    if (*s != '\\') {
+      // append 1 byte
+      append(buf, buf_sz, buf_len, s, 1);
+      continue;
+    }
+    s++;
+    int c = (s < end) ? *s : -1;
+    if (isdigit(c)) {
+      int n = (c - '0');
+      if (n >= veclen) {
+        return false;
+      }
+      StringPiece snip = vec[n];
+      if (!snip.empty())
+        append(buf, buf_sz, buf_len, snip.data(), snip.size());
+    } else if (c == '\\') {
+      const char* backslash = "\\";
+      append(buf, buf_sz, buf_len, backslash, 1);
+    } else {
+      return false;
+    }
+  }
+  return true;
+}
+
+static int free_and_return_error(char* buf) {
+  if (buf != NULL) qio_free((void*)buf);
+  return -1;
+}
+
+// these should match re2.cc
+static const int kMaxArgs = 16;
+static const int kVecSize = 1+kMaxArgs;
+
+
+// returns the number of replacements made or -1 for an error
+/*
+static int replace_first(const RE2& re, const StringPiece& rewrite,
+                         const StringPiece& str,
+                         const char** str_out, int64_t* len_out) {
+  StringPiece vec[kVecSize];
+  int nvec = 1 + RE2::MaxSubmatch(rewrite);
+  if (nvec > 1 + re.NumberOfCapturingGroups())
+    return -1;
+  if (nvec > static_cast<int>(sizeof(vec)/sizeof(StringPiece)))
+    return -1;
+  if (!re.Match(str, 0, str.size(), RE2::UNANCHORED, vec, nvec))
+    return 0;
+
+  // check that vec[0] makes sense
+  assert(vec[0].data() >= str.data());
+  assert(vec[0].data() + vec[0].size() <= str.data() + str.size());
+
+  char* buf = NULL;
+  int64_t buf_sz = 0;
+  int64_t buf_len = 0;
+  int64_t matchStart = vec[0].data() - str.data();
+
+  // copy any data from before the first match
+  if (!append(buf, buf_sz, buf_len, str.data(), matchStart))
+    return free_and_return_error(buf);
+
+  // copy the replacement instead of the first match
+  if (nvec == 1) {
+    // if there are no submatch replacements e.g. \\1, just copy the replacement
+    if (!append(buf, buf_sz, buf_len, rewrite.data(), rewrite.size()))
+      return free_and_return_error(buf);
+  } else {
+    if (!append_rewrite(buf, buf_sz, buf_len, rewrite, vec, nvec))
+      return free_and_return_error(buf);
+  }
+
+  int64_t matchEnd = matchStart + vec[0].size();
+
+  // then copy anything after the first match
+  if (str.size() > matchEnd)
+    if (!append(buf, buf_sz, buf_len,
+                str.data() + matchEnd, str.size() - matchEnd))
+      return free_and_return_error(buf);
+
+  // done
+  return 1;
+}
+*/
+
+static int replace(const RE2& re, const StringPiece& rewrite,
+                   const StringPiece& str,
+                   int maxreplace,
+                   const char** str_out, int64_t* len_out) {
+  StringPiece vec[kVecSize];
+  int nvec = 1 + RE2::MaxSubmatch(rewrite);
+  if (nvec > 1 + re.NumberOfCapturingGroups())
+    return -1;
+  if (nvec > static_cast<int>(sizeof(vec)/sizeof(StringPiece)))
+    return -1;
+
+  const char* p = str.data();
+  const char* ep = p + str.size();
+  const char* lastend = NULL;
+
+  char* buf = NULL;
+  int64_t buf_sz = 0;
+  int64_t buf_len = 0;
+
+  int count = 0;
+  while (p <= ep) {
+    if (!re.Match(str, static_cast<size_t>(p - str.data()),
+                  str.size(), RE2::UNANCHORED, vec, nvec))
+      break;
+
+    // append the data before the match
+    if (p < vec[0].data())
+      if (!append(buf, buf_sz, buf_len, p, vec[0].data() - p))
+        return free_and_return_error(buf);
+
+    if (vec[0].data() == lastend && vec[0].empty()) {
+      // Disallow empty match at end of last match: skip ahead.
+      //
+      if (re.options().encoding() == RE2::Options::EncodingUTF8) {
+        // append the character
+        int bad;
+        int nbytes = 0;
+        int32_t chr = 0;
+        bad = chpl_enc_decode_char_buf_utf8(&chr, &nbytes, p, ep - p, false);
+        if (bad == 0) {
+          if (!append(buf, buf_sz, buf_len, p, nbytes))
+            return free_and_return_error(buf);
+          p += nbytes;
+          continue;
+        }
+      }
+      // append a character; either not in UTF-8 mode or there
+      // is some UTF-8 encoding issue
+      if (p < ep)
+        if (!append(buf, buf_sz, buf_len, p, 1))
+          return free_and_return_error(buf);
+
+      p++;
+      continue;
+    }
+
+    // append the rewrite
+    if (!append_rewrite(buf, buf_sz, buf_len, rewrite, vec, nvec))
+      return free_and_return_error(buf);
+
+    // continue with just after the match
+    p = vec[0].data() + vec[0].size();
+    lastend = p;
+    count++;
+
+    // stop if we have replaced too many
+    if (count == maxreplace)
+      break;
+  }
+
+  // if (count == 0)
+  //  return 0;
+
+  // append anything after the last match
+  if (p < ep)
+    if (!append(buf, buf_sz, buf_len, p, ep - p))
+      return free_and_return_error(buf);
+
+  // append a null byte
+  const char* empty = "";
+  if (!append(buf, buf_sz, buf_len, empty, 1))
+    return free_and_return_error(buf);
+
+  // return buffer to caller
+  *str_out = buf;
+  *len_out = buf_len;
+
+  return count;
+}
+
+int64_t qio_regex_replace(qio_regex_t* regex, const char* repl, int64_t repl_len, const char* str, int64_t str_len, int64_t maxreplace, const char** str_out, int64_t* len_out)
+{
+  if (RE2* re = (RE2*) regex->regex) {
+    StringPiece rewrite(repl, repl_len);
+    StringPiece s(str, str_len);
+    return replace(*re, rewrite, s,
+                   maxreplace,
+                   str_out, len_out);
+  }
+  return 0;
 }
 
 int qio_regex_channel_read_byte(qio_channel_s* ch);

--- a/runtime/src/qio/regex/none/fail-regex.c
+++ b/runtime/src/qio/regex/none/fail-regex.c
@@ -79,7 +79,7 @@ bool qio_regex_match(qio_regex_t* regex, const char* text, int64_t str_len, int6
   return false;
 }
 
-int64_t qio_regex_replace(qio_regex_t* regex, const char* repl, int64_t repl_len, const char* str, int64_t str_len, int64_t startpos, int64_t endpos, qio_bool global, const char** str_out, int64_t* len_out)
+int64_t qio_regex_replace(qio_regex_t* regex, const char* repl, int64_t repl_len, const char* str, int64_t str_len, int64_t maxreplace, const char** str_out, int64_t* len_out)
 {
   chpl_internal_error("No Regex Support");
   return 0;

--- a/test/regex/replaceTricky.chpl
+++ b/test/regex/replaceTricky.chpl
@@ -1,0 +1,23 @@
+use Regex;
+
+proc test(re) {
+  writeln("bb".replace(re, "a"));
+  writeln("bb".replaceAndCount(re, "a"));
+  writeln("count=0 ", "bb".replaceAndCount(re, "a", count=0));
+  writeln("count=1 ", "bb".replaceAndCount(re, "a", count=1));
+  writeln("count=2 ", "bb".replaceAndCount(re, "a", count=2));
+  writeln("count=3 ", "bb".replaceAndCount(re, "a", count=3));
+  writeln("count=4 ", "bb".replaceAndCount(re, "a", count=4));
+}
+
+writeln("replacing bb b->a"); // python re.sub(r'b', 'a', "bb") -> aa
+test(new regex("b"));
+
+writeln("replacing bb ''->a"); // python re.sub(r'', 'a', "bb") -> ababa
+test(new regex(""));
+
+writeln("replacing bb b|->a"); // re.sub(r'b|', 'a', "bb") -> aaa
+test(new regex("b|"));
+
+writeln("replacing bb |b->a"); // re.sub(r'|b', 'a', "bb") -> aaaaa
+test(new regex("|b"));

--- a/test/regex/replaceTricky.good
+++ b/test/regex/replaceTricky.good
@@ -1,0 +1,32 @@
+replacing bb b->a
+aa
+(aa, 2)
+count=0 (bb, 0)
+count=1 (ab, 1)
+count=2 (aa, 2)
+count=3 (aa, 2)
+count=4 (aa, 2)
+replacing bb ''->a
+ababa
+(ababa, 3)
+count=0 (bb, 0)
+count=1 (abb, 1)
+count=2 (abab, 2)
+count=3 (ababa, 3)
+count=4 (ababa, 3)
+replacing bb b|->a
+aa
+(aa, 2)
+count=0 (bb, 0)
+count=1 (ab, 1)
+count=2 (aa, 2)
+count=3 (aa, 2)
+count=4 (aa, 2)
+replacing bb |b->a
+aa
+(aa, 2)
+count=0 (bb, 0)
+count=1 (ab, 1)
+count=2 (aa, 2)
+count=3 (aa, 2)
+count=4 (aa, 2)


### PR DESCRIPTION
This PR optimizes the 'replace' methods in Regex. It avoids string copies that were coming from moving the data to and from a `std::string` when calling RE2's Replace/GlobalReplace.  It does so by using our own implementation of Replace by calling RE2's Match function in the re2-interface.cc code so that we can construct a result buffer by repeatedly doubling & then provide that when constructing a Chapel string.

While there, this removes the need for doReplaceAndCountSlow, since now that we have our own implementation of the replace function, we can handle a maximum number of matches right there. While here, I noticed a bug in the old implementation, which this change fixes.

The bug:

``` chapel
use Regex;

writeln("bb".replace(new regex(""), "a"); // ababa
writeln("bb".replace(new regex(""), "a", count=5)); // was aaaaabb but now ababa
```

Work on this PR also revealed another bug described in #24788. Fixing that is left as future work.

How does it affect performance? These measurements were collected on my PC with `start_test -performance test/studies/shootout/submitted/regexredux*.chpl --numtrials 4`.

| Benchmark    | main   | this PR | speedup    |
| ------------ | ------ | ------- | ---------- |
| regexredux2  | 1.89 s | 1.55 s  | 22% faster |
| regexredux3  | 1.64 s | 1.29 s  | 25% faster |

Reviewed by @DanilaFe - thanks!

- [x] full comm=none testing
- [x] valgrind testing for test/regex