### PR TITLE
Bind progress thread to locale's PUs with COMM=ofi

### DIFF
--- a/runtime/include/chpl-topo.h
+++ b/runtime/include/chpl-topo.h
@@ -83,9 +83,9 @@ int chpl_topo_reserveCPUPhysical(void);
 //
 int chpl_topo_bindCPU(int id);
 
-// Binds the current thread to the logical accessible CPUs. This restricts the
-// thread to the locale's CPUs (e.g., if the locale is running in a socket
-// its progress thread should also run in that socket).
+// Binds the current thread to the accessible logical CPUs (PUs). This
+// restricts the thread to the locale's PUs (i.e., the progress thread should
+// use the same PUs as the locale).
 //
 // Returns 0 on success, 1 otherwise
 //

--- a/runtime/include/chpl-topo.h
+++ b/runtime/include/chpl-topo.h
@@ -83,6 +83,14 @@ int chpl_topo_reserveCPUPhysical(void);
 //
 int chpl_topo_bindCPU(int id);
 
+// Binds the current thread to the logical accessible CPUs. This restricts the
+// thread to the locale's CPUs (e.g., if the locale is running in a socket
+// its progress thread should also run in that socket).
+//
+// Returns 0 on success, 1 otherwise
+//
+int chpl_topo_bindLogAccCPUs(void);
+
 //
 // how many NUMA domains are there?
 //

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -841,6 +841,14 @@ static void *comm_task_wrapper(void *arg)
             chpl_warning(msg, 0, 0);
         }
         _DBG_P("comm task bound to CPU %d", rarg->cpu);
+    } else {
+        int rc = chpl_topo_bindLogAccCPUs();
+        if (rc) {
+            chpl_warning(
+                "binding comm task to accessible PUs failed",
+                0, 0);
+        }
+        _DBG_P("comm task bound to accessible PUs");
     }
     (*(chpl_fn_p)(rarg->fn))(rarg->arg);
     return 0;

--- a/runtime/src/topo/hwloc/topo-hwloc.c
+++ b/runtime/src/topo/hwloc/topo-hwloc.c
@@ -1168,9 +1168,9 @@ int chpl_topo_bindCPU(int id) {
 }
 
 //
-// Binds the current thread to the logical accessible CPUs. This restricts the
-// thread to the locale's CPUs (e.g., if the locale is running in a socket
-// its progress thread should also run in that socket).
+// Binds the current thread to the accessible logical CPUs (PUs). This
+// restricts the thread to the locale's PUs (i.e., the progress thread should
+// use the same PUs as the locale).
 //
 // Returns 0 on success, 1 otherwise
 //

--- a/runtime/src/topo/hwloc/topo-hwloc.c
+++ b/runtime/src/topo/hwloc/topo-hwloc.c
@@ -1167,6 +1167,28 @@ int chpl_topo_bindCPU(int id) {
   return status;
 }
 
+//
+// Binds the current thread to the logical accessible CPUs. This restricts the
+// thread to the locale's CPUs (e.g., if the locale is running in a socket
+// its progress thread should also run in that socket).
+//
+// Returns 0 on success, 1 otherwise
+//
+int chpl_topo_bindLogAccCPUs(void) {
+  int status = 1;
+  if (topoSupport->cpubind->set_thisthread_cpubind) {
+    int flags = HWLOC_CPUBIND_THREAD | HWLOC_CPUBIND_STRICT;
+    CHK_ERR_ERRNO(hwloc_set_cpubind(topology, logAccSet, flags) == 0);
+    status = 0;
+  }
+  if (debug) {
+    char buf[1024];
+    hwloc_bitmap_list_snprintf(buf, sizeof(buf), logAccSet);
+    _DBG_P("chpl_topo_bindLogAccCPUs %s status: %d", buf, status);
+  }
+  return status;
+}
+
 chpl_bool chpl_topo_isOversubscribed(void) {
   _DBG_P("oversubscribed = %s", oversubscribed ? "True" : "False");
   return oversubscribed;

--- a/runtime/src/topo/none/topo-none.c
+++ b/runtime/src/topo/none/topo-none.c
@@ -66,6 +66,10 @@ int chpl_topo_bindCPU(int id) {
   return 1;
 }
 
+int chpl_topo_bindLogAccCPUs(void) {
+  return 1;
+}
+
 
 int chpl_topo_getNumNumaDomains(void) {
   return 1;


### PR DESCRIPTION
Bind the progress thread to the locale's PUs with COMM=ofi. Otherwise, when there are co-locales the progress thread may migrate to PUs used by another co-locale, or not used at all. This can lead to incorrect performance measurements.