### PR TITLE
Remove note about VSCode extension in docs

### DIFF
--- a/doc/rst/tools/chpl-language-server/chpl-language-server.rst
+++ b/doc/rst/tools/chpl-language-server/chpl-language-server.rst
@@ -62,11 +62,6 @@ VSCode
 Install the ``chapel`` extension from the `Visual Studio Code marketplace
 <https://marketplace.visualstudio.com/items?itemName=chpl-hpe.chapel-vscode>`_.
 
-.. note::
-
-   The extension is not yet available at the time of writing and the above link
-   may not work until then. This section will be updated when it is available.
-
 Supported Features
 ------------------
 

--- a/doc/rst/tools/chplcheck/chplcheck.rst
+++ b/doc/rst/tools/chplcheck/chplcheck.rst
@@ -141,11 +141,6 @@ VSCode
 Install the ``chapel`` extension from the `Visual Studio Code marketplace
 <https://marketplace.visualstudio.com/items?itemName=chpl-hpe.chapel-vscode>`_.
 
-.. note::
-
-   The extension is not yet available at the time of writing and the above link
-   may not work until then. This section will be updated when it is available.
-
 Writing New Rules
 -----------------
 


### PR DESCRIPTION
Removes a small note in the docs about a possibly broken link, the link should now always work.

[Not Reviewed - trivial]