### PR TITLE
Add linter warning for simple domains used in loops

### DIFF
--- a/test/chplcheck/SimpleDomainAsRange.chpl
+++ b/test/chplcheck/SimpleDomainAsRange.chpl
@@ -1,0 +1,59 @@
+module SimpleDomainAsRange {
+
+  //
+  // these cases should not warn
+  //
+
+  @chplcheck.ignore("UnusedLoopIndex")
+  for i in 1..10 {}
+
+  @chplcheck.ignore("UnusedLoopIndex")
+  for i in 1..<10 {}
+
+  @chplcheck.ignore("UnusedLoopIndex")
+  for i in 1..#10 {}
+
+  for 1..10 {}
+
+  for 1..<10 {}
+
+  for 1..#10 {}
+
+  @chplcheck.ignore("UnusedLoopIndex")
+  for (i, j) in {1..10, 1..10} {}
+
+  @chplcheck.ignore("UnusedLoopIndex")
+  for {1..10, 1..10} {}
+
+  var r: 2*range(int);
+  @chplcheck.ignore("UnusedLoopIndex")
+  for i in {(...r)} {}
+
+  @chplcheck.ignore("UnusedLoopIndex")
+  for {(...r)} {}
+
+  //
+  // These cases should warn
+  //
+
+  @chplcheck.ignore("UnusedLoopIndex")
+  for i in {1..10} {}
+
+  @chplcheck.ignore("UnusedLoopIndex")
+  for i in {1..<10} {}
+
+  @chplcheck.ignore("UnusedLoopIndex")
+  for i in {1..#10} {}
+
+  for {1..10} {}
+
+  for {1..<10} {}
+
+  for {1..#10} {}
+
+  for {1..#10 by 2} {}
+
+  for {1..#10 align 2} {}
+
+  for {1..#10 by 2 align 2} {}
+}

--- a/test/chplcheck/SimpleDomainAsRange.good
+++ b/test/chplcheck/SimpleDomainAsRange.good
@@ -1,0 +1,9 @@
+SimpleDomainAsRange.chpl:40: node violates rule SimpleDomainAsRange
+SimpleDomainAsRange.chpl:43: node violates rule SimpleDomainAsRange
+SimpleDomainAsRange.chpl:46: node violates rule SimpleDomainAsRange
+SimpleDomainAsRange.chpl:48: node violates rule SimpleDomainAsRange
+SimpleDomainAsRange.chpl:50: node violates rule SimpleDomainAsRange
+SimpleDomainAsRange.chpl:52: node violates rule SimpleDomainAsRange
+SimpleDomainAsRange.chpl:54: node violates rule SimpleDomainAsRange
+SimpleDomainAsRange.chpl:56: node violates rule SimpleDomainAsRange
+SimpleDomainAsRange.chpl:58: node violates rule SimpleDomainAsRange

--- a/tools/chapel-py/src/method-tables/uast-methods.h
+++ b/tools/chapel-py/src/method-tables/uast-methods.h
@@ -451,6 +451,11 @@ CLASS_END(StringLikeLiteral)
 CLASS_BEGIN(Call)
   PLAIN_GETTER(Call, actuals, "Get the arguments to this Call node",
                IterAdapterBase*, return mkIterPair(node->actuals()))
+  PLAIN_GETTER(Call, num_actuals, "Get the number of actuals for this Call node",
+               int, return node->numActuals())
+  METHOD(Call, actual, "Get the n'th actual of this Call node",
+         const chpl::uast::AstNode*(int),
+         return node->actual(std::get<0>(args)))
   PLAIN_GETTER(Call, called_expression, "Get the expression invoked by this Call node",
                const chpl::uast::AstNode*, return node->calledExpression())
   PLAIN_GETTER(Call, formal_actual_mapping, "Get the index of the function's formal for each of the call's actuals.",

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -348,7 +348,7 @@ def register_rules(driver):
                     or node.op() == "align"
                 )
             ):
-                return is_range_like(list(node.actuals())[0])
+                return is_range_like(node.actual(0))
             return False
 
         for loop, _ in chapel.each_matching(root, IndexableLoop):
@@ -362,4 +362,4 @@ def register_rules(driver):
             if not is_range_like(exprs[0]):
                 continue
 
-            yield iterand
+            yield iterand, loop

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -323,3 +323,43 @@ def register_rules(driver):
 
         for unused in indices.keys() - uses:
             yield indices[unused]
+
+    @driver.advanced_rule
+    def SimpleDomainAsRange(context: Context, root: AstNode):
+        """
+        Warn for simple domains in loops that can be ranges.
+        """
+
+        def is_range_like(node: AstNode):
+            """
+            a node is range like if its a range, a `count` expr with a
+            range-like on the lhs, a `by` expr with a range-like on the lhs, or
+            an `align` expr with a range-like on the lhs
+            """
+
+            if isinstance(node, Range):
+                return True
+            if (
+                isinstance(node, OpCall)
+                and node.is_binary_op()
+                and (
+                    node.op() == "#"
+                    or node.op() == "by"
+                    or node.op() == "align"
+                )
+            ):
+                return is_range_like(list(node.actuals())[0])
+            return False
+
+        for loop, _ in chapel.each_matching(root, IndexableLoop):
+            iterand = loop.iterand()
+            if not isinstance(iterand, Domain):
+                continue
+            exprs = list(iterand.exprs())
+            if len(exprs) != 1:
+                continue
+            # only warn for ranges or count operators
+            if not is_range_like(exprs[0]):
+                continue
+
+            yield iterand


### PR DESCRIPTION
Adds a linter warning for simple domains used in loops. Domain literals like `{1..10}` used as the iterand of a loop cause an unnecessary domain creation. Although this may be optimized away by the compiler, it is cleaner and possibly more performant to not have the domain literal.

![Screenshot 2024-04-04 at 9 31 08 AM](https://github.com/chapel-lang/chapel/assets/15747900/18307aeb-6b0d-4bd9-8587-8cf2919841ae)

[Reviewed by @DanilaFe]