### PR TITLE
user friendly error for var intent on foreach

### DIFF
--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -1655,16 +1655,16 @@ static void processShadowVariables(ForLoop* forLoop, SymbolMap *map) {
         continue;
 
      case TFI_REDUCE_OP:
-        // to be implemented
-        INT_ASSERT(false);
-        break;
-
       case TFI_REDUCE:
       case TFI_REDUCE_PARENT_AS:
       case TFI_REDUCE_PARENT_OP:
-      case TFI_TASK_PRIVATE:
-        // to be implemented
+        // to be implemented. Reduce intents should have given a user-friendly
+        // error message during parsing.
         INT_ASSERT(false);
+
+       case TFI_TASK_PRIVATE:
+        // to be implemented
+        USR_FATAL_CONT(forLoop, "var intents can not be used in foreach loops");
     }
   }
 }

--- a/test/statements/foreach/reduceIntent.chpl
+++ b/test/statements/foreach/reduceIntent.chpl
@@ -1,0 +1,2 @@
+var x = 0;
+foreach i in 0..10 with (+reduce x) do x += i;

--- a/test/statements/foreach/reduceIntent.good
+++ b/test/statements/foreach/reduceIntent.good
@@ -1,0 +1,1 @@
+reduceIntent.chpl:2: error: reduce intents can not be used in foreach loops

--- a/test/statements/foreach/varIntent.chpl
+++ b/test/statements/foreach/varIntent.chpl
@@ -1,0 +1,1 @@
+foreach i in 0..0 with (var x = 0) { }

--- a/test/statements/foreach/varIntent.good
+++ b/test/statements/foreach/varIntent.good
@@ -1,0 +1,1 @@
+varIntent.chpl:1: error: var intents can not be used in foreach loops


### PR DESCRIPTION
We don't currently support `var` intents on `foreach` loops. Previously, if users tried to do this we would assert and produce an "internal error". This PR makes things a little more user friendly by giving an error message. 

While there I also add a test locking down that we produce an error for reduce intents on `foreach` (which we also don't currently support)

See https://github.com/chapel-lang/chapel/issues/24764.

TODO:
* [x] paratests