### PR TITLE
annotations for updating Arkouda release

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -2430,7 +2430,11 @@ arkouda: &arkouda-base
     - Closes 2873 Short strings optimization for multicol groupby (Bears-R-Us/arkouda#2877)
   01/07/24:
     - Array API infrastructure and partial implementation (Bears-R-Us/arkouda#2865)
-
+  02/07/24:
+    - Update Arkouda release testing from 1.32 to 1.33 (#24355)
+  03/28/24:
+    - Update Arkouda release testing from 1.33 to 2.0 (#24704)
+ 
 
 arkouda-string:
   <<: *arkouda-base


### PR DESCRIPTION
Add annotations to nightly perf graphs for Arkouda indicating when we updating to 1.33 and 2.0 release.