### PR TITLE
Dyno: Fix resolution of module-scope MultiDecl and TupleDecl

### DIFF
--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -252,11 +252,16 @@ const QualifiedType& typeForModuleLevelSymbol(Context* context, ID id,
 
   int postOrderId = id.postOrderId();
   if (postOrderId >= 0) {
-    const auto& resolvedStmt = resolveModuleStmt(context, id);
+    // 'typeForModuleLevelSymbol' can be called with an 'id' corresponding to a
+    // variable declared as part of a MultiDecl or TupleDecl. Using that 'id'
+    // with 'resolveModuleStmt' will return a bogus result because that 'id'
+    // is not at the statement level.
+    auto stmtId = parsing::idToContainingMultiDeclId(context, id);
+    const auto& resolvedStmt = resolveModuleStmt(context, stmtId);
     if (resolvedStmt.hasId(id)) {
       result = resolvedStmt.byId(id).type();
       if (result.needsSplitInitTypeInfo(context) && !isCurrentModule) {
-        ID moduleId = parsing::idToParentId(context, id);
+        ID moduleId = parsing::idToParentId(context, stmtId);
         const auto& resolvedModule = resolveModule(context, moduleId);
         assert(resolvedModule.hasId(id));
         result = resolvedModule.byId(id).type();

--- a/frontend/test/resolution/testMultiDecl.cpp
+++ b/frontend/test/resolution/testMultiDecl.cpp
@@ -234,12 +234,29 @@ static void test5() {
   assert(dQt.type() == RealType::get(context, 0));
 }
 
+static void test6() {
+  printf("test6\n");
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  std::string program = R"""(
+    var a, b : int;
+
+    var x = a;
+    )""";
+
+  auto xt = resolveTypeOfX(context, program);
+  assert(xt->isIntType());
+}
+
 int main() {
   test1();
   test2();
   test3();
   test4();
   test5();
+  test6();
 
   return 0;
 }


### PR DESCRIPTION
This commit fixes a bug in which module-scope MultiDecl or TupleDecl variables had an UnknownType outside of their declarations. The problem was that ``typeForModuleLevelSymbol`` was trying to fetch the previously resolved variable with ``resolveModuleStmt`` using the ID of the variable. This didn't work because the ID of a MultiDecl or TupleDecl entry is not at the statement level and so a previous query result did not exist.

The solution is to add a helper that walks up the tree to find the correct module statement ID.

Testing:
- [x] test-dyno