### PR TITLE
Switch aggregation-based bale benchmarks to use Block by default

### DIFF
--- a/test/studies/bale/aggregation/histo.chpl
+++ b/test/studies/bale/aggregation/histo.chpl
@@ -13,7 +13,7 @@ config const M = 10000; // number of entries in the table per task
 const numUpdates = N * numTasks;
 const tableSize = M * numTasks;
 
-config param useBlockArr = false;
+config param useBlockArr = true;
 
 var t: stopwatch;
 proc startTimer() {

--- a/test/studies/bale/aggregation/ig-readme.md
+++ b/test/studies/bale/aggregation/ig-readme.md
@@ -99,7 +99,7 @@ Chapel:
 ---
 
 ```
-chpl ig.chpl --fast
+chpl ig.chpl --fast -suseBlockArr=false
 
 ./ig -nl 16 --N=10000000
        AGP:     6.987 seconds   0.824 GB/s/node
@@ -110,7 +110,7 @@ chpl ig.chpl --fast
        AGG:     4.138 seconds   1.392 GB/s/node
 
 
-chpl ig.chpl --fast -suseBlockArr -o ig-block
+chpl ig.chpl --fast -o ig-block
 
 ./ig-block -nl 16 --N=10000000
        AGP:     6.823 seconds   0.844 GB/s/node
@@ -121,7 +121,7 @@ chpl ig.chpl --fast -suseBlockArr -o ig-block
        AGG:     3.003 seconds   1.918 GB/s/node
 
 
-chpl ig.chpl --fast -suseBlockArr -sdefaultDisableLazyRADOpt -o ig-block-rad
+chpl ig.chpl --fast -sdefaultDisableLazyRADOpt -o ig-block-rad
 
 ./ig-block-rad -nl 16 --N=10000000
        AGP:     6.820 seconds   0.845 GB/s/node

--- a/test/studies/bale/aggregation/ig.chpl
+++ b/test/studies/bale/aggregation/ig.chpl
@@ -13,11 +13,12 @@ config const M = 10000; // number of entries in the table per task
 const numUpdates = N * numTasks;
 const tableSize = M * numTasks;
 
-// Block array access is faster than Cyclic currently. We hadn't optimized
-// these before because the comm overhead dominated, but that's no longer true
-// with aggregation. `-suseBlockArr` and/or `-sdefaultDisableLazyRADOpt` will
-// help indexing speed until we optimize them.
-config param useBlockArr = false;
+// Block array access is faster than Cyclic currently. We hadn't
+// optimized these before because the comm overhead dominated, but
+// that's no longer true with aggregation. `-suseBlockArr` (the
+// default) and/or `-sdefaultDisableLazyRADOpt` will help indexing
+// speed until we optimize them.
+config param useBlockArr = true;
 
 var t: stopwatch;
 proc startTimer() {


### PR DESCRIPTION
These benchmarks were originally written to use Cyclic by default in order to more closely mimic the reference versions that they were based upon.  In our performance runs and work, we've definitely focused on Block in recent runs and years, so here I'm switching the default to indicate that preference without removing the ability to switch back to Cyclic.  Updated the README by flipping the flags specified on the 'chpl' command lines.
