### PR TITLE
LSP: use globally visible symbols (including via auto modules) to suggest autocompletion

### DIFF
--- a/frontend/include/chpl/resolution/scope-queries.h
+++ b/frontend/include/chpl/resolution/scope-queries.h
@@ -103,6 +103,10 @@ namespace resolution {
                            LookupConfig config,
                            CheckedScopes& visited);
 
+  std::map<UniqueString, BorrowedIdsWithName>
+  getSymbolsExportedFromScope(Context* context,
+                            const Scope* scope);
+
   /**
     Returns true if all of checkScope is visible from fromScope
     due to scope containment or whole-module use statements.

--- a/frontend/include/chpl/resolution/scope-queries.h
+++ b/frontend/include/chpl/resolution/scope-queries.h
@@ -103,6 +103,15 @@ namespace resolution {
                            LookupConfig config,
                            CheckedScopes& visited);
 
+  /**
+    Collect all symbols that are available in this scope, including ones
+    brought in through visibility statements. This function follows the
+    same rules as lookupNameInScope, except it collects all symbols instead
+    of one with a specific name.
+
+    Currently, this is only intended for tool support; the resolver itself
+    should rely on lookupNameInScope.
+   */
   std::map<UniqueString, BorrowedIdsWithName>
   getSymbolsAvailableInScope(Context* context,
                             const Scope* scope);

--- a/frontend/include/chpl/resolution/scope-queries.h
+++ b/frontend/include/chpl/resolution/scope-queries.h
@@ -104,7 +104,7 @@ namespace resolution {
                            CheckedScopes& visited);
 
   std::map<UniqueString, BorrowedIdsWithName>
-  getSymbolsExportedFromScope(Context* context,
+  getSymbolsAvailableInScope(Context* context,
                             const Scope* scope);
 
   /**

--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -640,6 +640,8 @@ class Scope {
 
   UniqueString name() const { return name_; }
 
+  const DeclMap& declared() const { return declared_; }
+
   /** Returns 'true' if this Scope directly contains use or import statements
       including the automatic 'use' for the standard library. */
   bool containsUseImport() const {

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -1647,11 +1647,11 @@ getSymbolsAvailableInScopeQuery(Context* context,
 
       bool anyMatches = false;
       for (auto& namePair : namePairs) {
-        if (namePair.first != name) continue;
-
-        anyMatches = true;
-        renameTo = namePair.second;
-        break;
+        if (namePair.first == name) {
+          anyMatches = true;
+          renameTo = namePair.second;
+          break;
+        }
       }
 
       return kind == VisibilitySymbols::CONTENTS_EXCEPT ? !anyMatches : anyMatches;
@@ -1664,11 +1664,11 @@ getSymbolsAvailableInScopeQuery(Context* context,
     UniqueString renameTo;
     if (!allowedByVisibility(decl.first, renameTo)) continue;
 
-    auto flagSet = 0;
-    if (inVisibilitySymbols) flagSet |= IdAndFlags::PUBLIC;
+    auto flags = 0;
+    if (inVisibilitySymbols) flags |= IdAndFlags::PUBLIC;
 
     auto exclude = IdAndFlags::FlagSet::empty();
-    if (auto borrowed = decl.second.borrow(flagSet, exclude)) {
+    if (auto borrowed = decl.second.borrow(flags, exclude)) {
       toReturn.try_emplace(renameTo, *borrowed);
     }
   }

--- a/tools/chapel-py/src/core-types.h
+++ b/tools/chapel-py/src/core-types.h
@@ -56,6 +56,8 @@ struct ScopeObject : public PythonClassWithObject<ScopeObject, const chpl::resol
   static constexpr const char* DocStr = "A scope in the Chapel program, such as a block.";
 };
 
+using VisibileSymbols = std::vector<std::tuple<chpl::UniqueString, std::vector<const chpl::uast::AstNode*>>>;
+
 struct AstNodeObject : public PythonClassWithObject<AstNodeObject, const chpl::uast::AstNode*> {
   static constexpr const char* Name = "AstNode";
   static constexpr const char* DocStr = "The base type of Chapel AST nodes";

--- a/tools/chapel-py/src/core-types.h
+++ b/tools/chapel-py/src/core-types.h
@@ -56,7 +56,7 @@ struct ScopeObject : public PythonClassWithObject<ScopeObject, const chpl::resol
   static constexpr const char* DocStr = "A scope in the Chapel program, such as a block.";
 };
 
-using VisibileSymbols = std::vector<std::tuple<chpl::UniqueString, std::vector<const chpl::uast::AstNode*>>>;
+using VisibleSymbol = std::tuple<chpl::UniqueString, std::vector<const chpl::uast::AstNode*>>;
 
 struct AstNodeObject : public PythonClassWithObject<AstNodeObject, const chpl::uast::AstNode*> {
   static constexpr const char* Name = "AstNode";

--- a/tools/chapel-py/src/method-tables/core-methods.h
+++ b/tools/chapel-py/src/method-tables/core-methods.h
@@ -91,6 +91,24 @@ CLASS_BEGIN(Scope)
                  toReturn.push_back(mod);
                }
                return toReturn)
+  PLAIN_GETTER(Scope, parent_scope, "Get the parent (outer) scope of this scope",
+               Nilable<const chpl::resolution::Scope*>, return node->parentScope())
+  PLAIN_GETTER(Scope, visible_nodes, "Get the nodes corresponding to declarations exported from this scope",
+               VisibileSymbols,
+               VisibileSymbols toReturn;
+               for (auto& pair : getSymbolsExportedFromScope(context, node)) {
+                 std::vector<const chpl::uast::AstNode*> into;
+                 for (auto id : pair.second) {
+                    if (id.isEmpty()) continue;
+                    into.push_back(parsing::idToAst(context, id));
+                 }
+
+                 if (!into.empty()) {
+                   toReturn.emplace_back(pair.first, std::move(into));
+                 }
+               }
+
+               return toReturn)
 CLASS_END(Scope)
 
 CLASS_BEGIN(Error)

--- a/tools/chapel-py/src/method-tables/core-methods.h
+++ b/tools/chapel-py/src/method-tables/core-methods.h
@@ -94,8 +94,8 @@ CLASS_BEGIN(Scope)
   PLAIN_GETTER(Scope, parent_scope, "Get the parent (outer) scope of this scope",
                Nilable<const chpl::resolution::Scope*>, return node->parentScope())
   PLAIN_GETTER(Scope, visible_nodes, "Get the nodes corresponding to declarations exported from this scope",
-               VisibileSymbols,
-               VisibileSymbols toReturn;
+               std::vector<VisibleSymbol>,
+               std::vector<VisibleSymbol> toReturn;
                for (auto& pair : getSymbolsAvailableInScope(context, node)) {
                  std::vector<const chpl::uast::AstNode*> into;
                  for (auto id : pair.second) {

--- a/tools/chapel-py/src/method-tables/core-methods.h
+++ b/tools/chapel-py/src/method-tables/core-methods.h
@@ -96,7 +96,7 @@ CLASS_BEGIN(Scope)
   PLAIN_GETTER(Scope, visible_nodes, "Get the nodes corresponding to declarations exported from this scope",
                VisibileSymbols,
                VisibileSymbols toReturn;
-               for (auto& pair : getSymbolsExportedFromScope(context, node)) {
+               for (auto& pair : getSymbolsAvailableInScope(context, node)) {
                  std::vector<const chpl::uast::AstNode*> into;
                  for (auto id : pair.second) {
                     if (id.isEmpty()) continue;

--- a/tools/chapel-py/src/python-types.h
+++ b/tools/chapel-py/src/python-types.h
@@ -246,6 +246,7 @@ DEFINE_INOUT_TYPE(const chpl::types::Param*, "Param", wrapGeneratedType(CONTEXT,
 DEFINE_INOUT_TYPE(chpl::Location, "Location", (PyObject*) LocationObject::create(TO_WRAP), ((LocationObject*) TO_UNWRAP)->value_);
 DEFINE_INOUT_TYPE(IterAdapterBase*, "typing.Iterator[AstNode]", wrapIterAdapter(CONTEXT, TO_WRAP), ((AstIterObject*) TO_UNWRAP)->iterAdapter);
 DEFINE_INOUT_TYPE(PyObject*, "typing.Any", TO_WRAP, TO_UNWRAP);
+DEFINE_INOUT_TYPE(const chpl::resolution::Scope*, "Scope", (PyObject*) ScopeObject::create(CONTEXT, TO_WRAP), ((ScopeObject*) TO_UNWRAP)->value_);
 
 template <typename T>
 T_DEFINE_INOUT_TYPE(T*, T::Name, (PyObject*) TO_WRAP, (T*) TO_UNWRAP);

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -605,7 +605,18 @@ class FileInfo:
             if not scope:
                 continue
 
+            file = ast.location().path()
+            in_bundled_module = self.context.context.is_bundled_path(file)
+
             for name, nodes in scope.visible_nodes():
+                # Don't show internal symbols to the user, even if they
+                # are technically in scope. The exception is if we're currently
+                # editing a standard file.
+                skip_prefixes = ["chpl_", "chpldev_", "_"]
+                if any(name.startswith(prefix) for prefix in skip_prefixes):
+                    if not in_bundled_module:
+                        continue
+
                 # Just take the first value to avoid showing N entries for
                 # overloaded functions.
                 self.visible_decls.append((name, nodes[0]))

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -210,11 +210,12 @@ def completion_item_for_decl(
     if kind == SymbolKind.Method:
         return None
 
+    name_to_use = override_name if override_name else decl.name()
     return CompletionItem(
-        label=override_name if override_name else decl.name(),
+        label=name_to_use,
         kind=decl_kind_to_completion_kind(kind),
-        insert_text=decl.name(),
-        sort_text=decl.name(),
+        insert_text=name_to_use,
+        sort_text=name_to_use,
     )
 
 

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -600,7 +600,9 @@ class FileInfo:
                 continue
 
             for name, nodes in scope.visible_nodes():
-                self.visible_decls.extend((name, node) for node in nodes)
+                # Just take the first value to avoid showing N entries for
+                # overloaded functions.
+                self.visible_decls.append((name, nodes[0]))
 
     def _search_instantiations(
         self,

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -601,6 +601,9 @@ class FileInfo:
     def _collect_possibly_visible_decls(self, asts: List[chapel.AstNode]):
         self.visible_decls = []
         for ast in asts:
+            if isinstance(ast, chapel.Comment):
+                continue
+
             scope = ast.scope()
             if not scope:
                 continue

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -205,6 +205,11 @@ def completion_item_for_decl(
     if not kind:
         return None
 
+    # For now, we show completion for global symbols (not x.<complete>),
+    # so it seems like we ought to rule out methods.
+    if kind == SymbolKind.Method:
+        return None
+
     return CompletionItem(
         label=override_name if override_name else decl.name(),
         kind=decl_kind_to_completion_kind(kind),

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -1549,11 +1549,9 @@ def run_lsp():
         fi, _ = ls.get_file_info(text_doc.uri)
 
         items = []
-        items.extend(
-            completion_item_for_decl(decl, override_name=name)
-            for (name, decl) in fi.visible_decls
-            if isinstance(decl, chapel.NamedDecl)
-        )
+        for (name, decl) in fi.visible_decls:
+            if isinstance(decl, chapel.NamedDecl):
+                items.append(completion_item_for_decl(decl, override_name=name))
         items.extend(completion_item_for_decl(mod) for mod in fi.used_modules)
 
         items = [item for item in items if item]


### PR DESCRIPTION
Should fix #24743.

This PR beefs up CLS's ability to find symbols in imported modules. It does so by:

* Transitively searching for visible symbols instead when modules are imported. This means that if module `A` re-exports variables from module `B`, importing `A` will make `B`'s variables appear in completions.
* Ensuring that auto modules, in addition to regular modules, are considered for auto-completion. These are the modules that bring in `Locale`, `here`, and all others.

Prior to this, Dyno did not have a way to collect _all_ visible symbols (opting instead for per-symbol lookups). Thus, this PR adds the corresponding Dyno query (memoization and all).

This PR does _not_ address the `Locales.size` aspect of #24743, as this relies on parser improvements and type resolution (the former being not-yet-started, the latter being experimental and unstable). Only completions for global variables such as `Locales` are present. 

Reviewed by @jabraham17 -- thanks!