### PR TITLE
Remove default arguments from syncWarp impl part 2

### DIFF
--- a/runtime/include/gpu/chpl-gpu-gen-common.h
+++ b/runtime/include/gpu/chpl-gpu-gen-common.h
@@ -138,7 +138,7 @@ __host__ static inline void chpl_gpu_force_sync() {
   chpl_internal_error("chpl_gpu_force_sync called from host");
 }
 
-__host__ static inline void chpl_gpu_force_warp_sync(unsigned mask=0xffffffff) {
+__host__ static inline void chpl_gpu_force_warp_sync(unsigned mask) {
   chpl_internal_error("chpl_gpu_force_warp_sync called from host");
 }
 

--- a/runtime/include/gpu/cpu/chpl-gpu-gen-includes.h
+++ b/runtime/include/gpu/cpu/chpl-gpu-gen-includes.h
@@ -97,7 +97,7 @@ static inline void chpl_gpu_force_sync(void) {
   }
 }
 
-static inline void chpl_gpu_force_warp_sync(unsigned mask=0xffffffff) {
+static inline void chpl_gpu_force_warp_sync(unsigned mask) {
   if (!chpl_gpu_no_cpu_mode_warning) {
     chpl_warning("chpl_gpu_force_warp_sync was called", 0, 0);
   }


### PR DESCRIPTION
Follow up to #24751
These default arguments are not supported in C. They were redundant anyway so we are not losing anything here; the module version of syncWarp already has the default arguments so it doesn't matter if the implementation has that.
Fixes some nightly test failures.