### PR TITLE
Hide the documentation for the remaining `ioerror` overloads

### DIFF
--- a/modules/standard/OS.chpl
+++ b/modules/standard/OS.chpl
@@ -1728,6 +1728,7 @@ module OS {
  */
   pragma "insert line file info"
   pragma "always propagate line file info"
+  @chpldoc.nodoc
   proc ioerror(error:errorCode, msg:string, path:string, offset:int(64)) throws
   {
     if error {
@@ -1770,6 +1771,7 @@ module OS {
    */
   pragma "insert line file info"
   pragma "always propagate line file info"
+  @chpldoc.nodoc
   proc ioerror(errstr:string, msg:string, path:string, offset:int(64)) throws
   {
     const quotedpath = quote_string(path, path.numBytes:c_ssize_t);


### PR DESCRIPTION
We'd decided to do this when initially reviewing the SysError module but somehow forgot to do it.  Oops.  We weren't going to make them private anyways, since they're also used in the IO module, so this shouldn't break anyone's code either.  They're also fairly specialized to the IO use case, so it's unlikely anyone is actually using them (unless they're also doing IO stuff).

Maybe some day in the future we'll add a developer-tools documentation category and we can list them there (maybe tweaking `@chpldoc.nodoc` to accept an argument and filter based on whether people want to see those symbols?  Just brainstorming).  But until then, they don't belong in the user documentation

Verifying the locally built docs look fine and don't break.