### PR TITLE
Fix various segfaults and crashes in frontend

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1529,7 +1529,7 @@ static ArgumentDescription arg_desc[] = {
  {"dyno-gen-lib", ' ', "<path>", "Specify files named on the command line should be saved into a .dyno library", "P", NULL, NULL, addDynoGenLib},
  {"dyno-gen-std", ' ', NULL, "Generate a .dyno library file for the standard library", "F", &fDynoGenStdLib, NULL, setDynoGenStdLib},
  {"dyno-verify-serialization", ' ', NULL, "Enable [disable] verification of serialization", "N", &fDynoVerifySerialization, NULL, NULL},
- {"dyno-no-break-error", ' ', NULL, "Disable breakpoint for user errors from the frontend", "N", &fDynoNoBreakError, NULL, NULL},
+ {"dyno-break-error", ' ', NULL, "Enable breakpoint for user errors from the frontend", "n", &fDynoNoBreakError, NULL, NULL},
  {"resolve-concrete-fns", ' ', NULL, "Enable [disable] resolving concrete functions",  "N", &fResolveConcreteFns, NULL, NULL},
 
  {"io-gen-serialization", ' ', NULL, "Enable [disable] generation of IO serialization methods", "n", &fNoIOGenSerialization, "CHPL_IO_GEN_SERIALIZATION", NULL},

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -382,6 +382,7 @@ bool fDynoGenLib = false;
 bool fDynoGenStdLib = false;
 bool fDynoLibGenOrUse = false; // .dyno file or --dyno-gen-lib/std
 size_t fDynoBreakOnHash = 0;
+bool fDynoNoBreakError = false;
 
 bool fResolveConcreteFns = false;
 bool fIdBasedMunging = false;
@@ -1528,6 +1529,7 @@ static ArgumentDescription arg_desc[] = {
  {"dyno-gen-lib", ' ', "<path>", "Specify files named on the command line should be saved into a .dyno library", "P", NULL, NULL, addDynoGenLib},
  {"dyno-gen-std", ' ', NULL, "Generate a .dyno library file for the standard library", "F", &fDynoGenStdLib, NULL, setDynoGenStdLib},
  {"dyno-verify-serialization", ' ', NULL, "Enable [disable] verification of serialization", "N", &fDynoVerifySerialization, NULL, NULL},
+ {"dyno-no-break-error", ' ', NULL, "Disable breakpoint for user errors from the frontend", "N", &fDynoNoBreakError, NULL, NULL},
  {"resolve-concrete-fns", ' ', NULL, "Enable [disable] resolving concrete functions",  "N", &fResolveConcreteFns, NULL, NULL},
 
  {"io-gen-serialization", ' ', NULL, "Enable [disable] generation of IO serialization methods", "n", &fNoIOGenSerialization, "CHPL_IO_GEN_SERIALIZATION", NULL},
@@ -2373,6 +2375,10 @@ static void dynoConfigureContext(std::string chpl_module_path) {
 
   // comments do not need to be preserved for the compiler
   config.includeComments = false;
+
+  if (fDynoNoBreakError) {
+    config.disableErrorBreakpoints = true;
+  }
 
   // Replace the current gContext with one using the new configuration.
   auto oldContext = gContext;

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -736,7 +736,7 @@ struct Converter {
             ret = new CallExpr(se);
           }
           if (isFieldAccess) {
-            INT_FATAL("resolving field access call not yet implemented");
+            CHPL_UNIMPL("resolving field access call not yet implemented");
             // TODO: convert it to a call to the field accessor
             // using the resolved TypedFnSignature from rr
           }
@@ -847,7 +847,7 @@ struct Converter {
       astlocMarker markAstLoc(stmt->id());
       Expr* e = convertAST(stmt);
       if (!e) continue;
-      if (ret) INT_FATAL("implicit block with multiple statements");
+      if (ret) CHPL_UNIMPL("implicit block with multiple statements");
       ret = isBlockStmt(e) ? toBlockStmt(e) : buildChapelStmt(e);
     }
 
@@ -1255,7 +1255,7 @@ struct Converter {
       case uast::New::SHARED: symManager = dtShared->symbol; break;
       case uast::New::UNMANAGED: symManager = dtUnmanaged->symbol; break;
       case uast::New::BORROWED: symManager = dtBorrowed->symbol; break;
-      default: INT_FATAL("Not handled!"); break;
+      default: CHPL_UNIMPL("Unhandled new expression"); break;
     }
 
     INT_ASSERT(symManager);
@@ -1463,7 +1463,7 @@ struct Converter {
         Expr* riExpr = convertScanReduceOp(rd->op());
         svs = ShadowVarSymbol::buildFromReduceIntent(ovar, riExpr);
       } else {
-        INT_FATAL("Not handled!");
+        CHPL_UNIMPL("Unhandled with clause");
       }
 
       INT_ASSERT(svs != nullptr);
@@ -1812,7 +1812,7 @@ struct Converter {
 
     // Else it's something that we haven't seen yet.
     } else {
-      INT_FATAL("Not handled yet!");
+      CHPL_UNIMPL("Unhandled Decl");
       return nullptr;
     }
   }
@@ -2071,7 +2071,7 @@ struct Converter {
           actualList->insertAtTail(rhs);
           hasConvertedThisIter = true;
         } else {
-          if (isAssociativeList) INT_FATAL("Not possible!");
+          if (isAssociativeList) CHPL_UNIMPL("Invalid associative list");
         }
       }
 
@@ -2475,7 +2475,8 @@ struct Converter {
         } else if (call->numActuals() == 1) {
           child = call->get(1);
         } else {
-          INT_FATAL(call, "unexpected form for new expression (no actuals)");
+          CHPL_UNIMPL("unexpected form for new expression (no actuals)");
+          return nullptr;
         }
         child->remove();
         auto toNilable = new CallExpr(PRIM_TO_NILABLE_CLASS_CHECKED, child);
@@ -2875,7 +2876,7 @@ struct Converter {
         return RET_TYPE;
     }
 
-    INT_FATAL("case not handled");
+    CHPL_UNIMPL("return intent case not handled");
     return RET_VALUE;
   }
 
@@ -2973,7 +2974,7 @@ struct Converter {
 
     } else {
       // should not arrive here, or else we missed something
-      INT_FATAL("should not be reached");
+      CHPL_UNIMPL("Unhandled lifetime clause");
       return nullptr;
     }
   }
@@ -3115,7 +3116,7 @@ struct Converter {
           conv = buildTupleArgDefExpr(tag, tuple, type, init);
           INT_ASSERT(conv);
         } else {
-          INT_FATAL("Not handled yet!");
+          CHPL_UNIMPL("Unhandled formal");
         }
 
         // Attaches def to function's formal list.
@@ -3304,7 +3305,7 @@ struct Converter {
           conv = toDefExpr(convertAST(anon));
           INT_ASSERT(conv);
         } else {
-          INT_FATAL("Not handled yet!");
+          INT_FATAL("Unhandled formal in function signature");
         }
 
         // Attaches def to function's formal list.
@@ -3545,7 +3546,7 @@ struct Converter {
         return INTENT_TYPE;
     }
 
-    INT_FATAL("case not handled");
+    CHPL_UNIMPL("Unhandled formal intent");
     return INTENT_BLANK;
   }
 
@@ -4220,7 +4221,7 @@ void Converter::setResolvedCall(const uast::FnCall* call, CallExpr* expr) {
       if (nBest == 0) {
         // nothing to do
       } else if (nBest > 1) {
-        INT_FATAL("return intent overloading not yet handled");
+        CHPL_UNIMPL("return intent overloading not yet handled");
       } else if (nBest == 1) {
         const resolution::TypedFnSignature* sig = candidates.only().fn();
         Symbol* fn = findConvertedFn(sig);
@@ -4359,27 +4360,27 @@ Type* Converter::convertClassType(const types::QualifiedType qt) {
     }
   }
 
-  INT_FATAL("not implemented yet");
+  CHPL_UNIMPL("Unhandled class type");
   return nullptr;
 }
 
 Type* Converter::convertEnumType(const types::QualifiedType qt) {
-  INT_FATAL("not implemented yet");
+  CHPL_UNIMPL("Unhandled enum type");
   return nullptr;
 }
 
 Type* Converter::convertExternType(const types::QualifiedType qt) {
-  INT_FATAL("not implemented yet");
+  CHPL_UNIMPL("Unhandled extern type");
   return nullptr;
 }
 
 Type* Converter::convertFunctionType(const types::QualifiedType qt) {
-  INT_FATAL("not implemented yet");
+  CHPL_UNIMPL("Unhandled function type");
   return nullptr;
 }
 
 Type* Converter::convertBasicClassType(const types::QualifiedType qt) {
-  INT_FATAL("not implemented yet");
+  CHPL_UNIMPL("Unhandled basic class type");
   return nullptr;
 }
 
@@ -4391,17 +4392,17 @@ Type* Converter::convertRecordType(const types::QualifiedType qt) {
     return dtBytes;
   }
 
-  INT_FATAL("not implemented yet");
+  CHPL_UNIMPL("unhandled record type");
   return nullptr;
 }
 
 Type* Converter::convertTupleType(const types::QualifiedType qt) {
-  INT_FATAL("not implemented yet");
+  CHPL_UNIMPL("Unhandled tuple type");
   return nullptr;
 }
 
 Type* Converter::convertUnionType(const types::QualifiedType qt) {
-  INT_FATAL("not implemented yet");
+  CHPL_UNIMPL("Unhandled union type");
   return nullptr;
 }
 
@@ -4937,7 +4938,7 @@ void ConvertedSymbolsMap::applyFixups(chpl::Context* context,
 
     Symbol* sym = findConvertedSym(target, /* trace */ false);
     if (isTemporaryConversionSymbol(sym)) {
-      INT_FATAL("could not find target symbol for sym fixup for %s within %s",
+      context->error(inAst, "could not find target symbol for sym fixup for %s within %s",
                 target.str().c_str(), inSymbolId.str().c_str());
     }
 
@@ -4966,7 +4967,7 @@ void ConvertedSymbolsMap::applyFixups(chpl::Context* context,
     Symbol* sym = findConvertedSym(target, /* trace */ false);
     auto usedM = toModuleSymbol(sym);
     if (!usedM) {
-      INT_FATAL("could not find target symbol for module fixup for %s within %s",
+      context->error(inAst, "could not find target symbol for module fixup for %s within %s",
                 target.str().c_str(), inSymbolId.str().c_str());
     }
 
@@ -4983,7 +4984,7 @@ void ConvertedSymbolsMap::applyFixups(chpl::Context* context,
 
     FnSymbol* fn = findConvertedFn(target, /* trace */ false);
     if (fn == nullptr) {
-      INT_FATAL("could not find target function for call fixup %s within %s",
+      context->error(inAst, "could not find target function for call fixup %s within %s",
                  target->untyped()->name().c_str(),
                  inSymbolId.str().c_str());
     }

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -3305,7 +3305,7 @@ struct Converter {
           conv = toDefExpr(convertAST(anon));
           INT_ASSERT(conv);
         } else {
-          INT_FATAL("Unhandled formal in function signature");
+          CHPL_UNIMPL("Unhandled formal in function signature");
         }
 
         // Attaches def to function's formal list.

--- a/frontend/include/chpl/framework/Context.h
+++ b/frontend/include/chpl/framework/Context.h
@@ -120,6 +120,11 @@ class Context {
      */
     bool includeComments = true;
 
+    /**
+      Disable breakpoint in Context::report.
+     */
+    bool disableErrorBreakpoints = false;
+
     void swap(Configuration& other);
   };
 

--- a/frontend/include/chpl/resolution/ResolvedVisitor.h
+++ b/frontend/include/chpl/resolution/ResolvedVisitor.h
@@ -41,6 +41,8 @@ static bool resolvedVisitorEnterFor(ResolvedVisitorImpl& v,
       const ResolvedExpression& rr = v.byAst(loop);
       const ResolvedParamLoop* resolvedLoop = rr.paramLoop();
 
+      if (resolvedLoop == nullptr) return false;
+
       const AstNode* iterand = loop->iterand();
       iterand->traverse(v);
 

--- a/frontend/lib/framework/Context.cpp
+++ b/frontend/lib/framework/Context.cpp
@@ -66,6 +66,7 @@ void Context::Configuration::swap(Context::Configuration& other) {
   std::swap(keepTmpDir, other.keepTmpDir);
   std::swap(toolName, other.toolName);
   std::swap(includeComments, other.includeComments);
+  std::swap(disableErrorBreakpoints, other.disableErrorBreakpoints);
 }
 
 void Context::setupGlobalStrings() {
@@ -875,7 +876,9 @@ void Context::collectGarbage() {
 }
 
 void Context::report(owned<ErrorBase> error) {
-  gdbShouldBreakHere();
+  if (!config_.disableErrorBreakpoints) {
+    gdbShouldBreakHere();
+  }
 
   // If errorCollectionStack is not empty, errors are being collected, and
   // thus not reported to the handler. Stash the error in the top (back) of the

--- a/frontend/lib/resolution/InitResolver.cpp
+++ b/frontend/lib/resolution/InitResolver.cpp
@@ -225,7 +225,7 @@ bool InitResolver::isFinalReceiverStateValid(void) {
     }
 
     if (state->qt.genericity() == Type::GENERIC) {
-      CHPL_ASSERT(false && "Not handled yet!");
+      CHPL_UNIMPL("Unhandled generic initializer state");
       ret = false;
     }
   }
@@ -255,6 +255,11 @@ const Type* InitResolver::computeReceiverTypeConsideringState(void) {
     if (state->qt.isType() || state->qt.isParam())
       if (!state->qt.isGenericOrUnknown())
         subs.insert({id, state->qt});
+  }
+
+  if (subs.size() == 0) {
+    ctx_->error(ctInitial->id(), "unable to instantiate generic type from initializer");
+    return currentRecvType_;
   }
 
   const Type* ret = nullptr;

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -4044,11 +4044,15 @@ bool Resolver::enter(const IndexableLoop* loop) {
       const Range* rng = iterand->toRange();
       ResolvedExpression& lowRE = byPostorder.byAst(rng->lowerBound());
       ResolvedExpression& hiRE = byPostorder.byAst(rng->upperBound());
-      auto low = lowRE.type().param()->toIntParam();
-      auto hi = hiRE.type().param()->toIntParam();
+      // TODO: Simplify once we no longer use nullptr for param()
+      auto lowParam = lowRE.type().param();
+      auto hiParam = hiRE.type().param();
+      auto low = lowParam ? lowParam->toIntParam() : nullptr;
+      auto hi = hiParam ? hiParam->toIntParam() : nullptr;
 
       if (low == nullptr || hi == nullptr) {
         context->error(loop, "param loops may only iterate over range literals with integer bounds");
+        return false;
       }
 
       std::vector<ResolutionResultByPostorderID> loopResults;

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -122,6 +122,8 @@ static bool isBuiltinTypeOperator(UniqueString name) {
 bool
 needCompilerGeneratedMethod(Context* context, const Type* type,
                             UniqueString name, bool parenless) {
+  if (type == nullptr) return false;
+
   if (isNameOfCompilerGeneratedMethod(name) ||
       (type->isRecordType() && !isBuiltinTypeOperator(name))) {
     if (!areOverloadsPresentInDefiningScope(context, type, name)) {

--- a/frontend/lib/resolution/disambiguation.cpp
+++ b/frontend/lib/resolution/disambiguation.cpp
@@ -1183,6 +1183,7 @@ static void computeConversionInfo(const DisambiguationContext& dctx,
       // Initializer work-around: Skip 'this' for generic initializers
       continue;
     }
+    if (!fa1->actualType().hasTypePtr()) continue;
 
     // if (fa1->formalType().kind() == uast::Qualifier::OUT) {
       // continue; // type comes from call site so ignore it here
@@ -1433,6 +1434,8 @@ static int testArgMapping(const DisambiguationContext& dctx,
   QualifiedType f2Type = fa2->formalType();
   QualifiedType actualType = fa1->actualType();
   CHPL_ASSERT(actualType == fa2->actualType());
+
+  if (!actualType.hasTypePtr()) return -1;
 
   // Give up early for out intent arguments
   // (these don't impact candidate selection)

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -882,7 +882,6 @@ static QualifiedType primIsRecordType(Context* context, const CallInfo& ci) {
 }
 
 static QualifiedType primIsFcfType(Context* context, const CallInfo& ci) {
-  CHPL_UNIMPL("PRIM_IS_FCF_TYPE");
   return makeParamBool(context, false);
 }
 

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -882,6 +882,7 @@ static QualifiedType primIsRecordType(Context* context, const CallInfo& ci) {
 }
 
 static QualifiedType primIsFcfType(Context* context, const CallInfo& ci) {
+  CHPL_UNIMPL("PRIM_IS_FCF_TYPE");
   return makeParamBool(context, false);
 }
 

--- a/frontend/lib/resolution/resolution-error-classes-list.cpp
+++ b/frontend/lib/resolution/resolution-error-classes-list.cpp
@@ -831,7 +831,7 @@ void ErrorNoMatchingCandidates::write(ErrorWriterBase& wr) const {
       auto fn = candidate.initialForErr();
       resolution::FormalActualMap fa(fn, ci);
       auto badPass = fa.byFormalIdx(candidate.formalIdx());
-      auto formalDecl = badPass.formal()->toNamedDecl();
+      auto formalDecl = badPass.formal();
       const uast::AstNode* actualExpr = nullptr;
       if (call && 0 <= badPass.actualIdx() && badPass.actualIdx() < call->numActuals()) {
         actualExpr = call->actual(badPass.actualIdx());
@@ -840,7 +840,13 @@ void ErrorNoMatchingCandidates::write(ErrorWriterBase& wr) const {
       wr.note(fn->id(), "the following candidate didn't match because an actual couldn't be passed to a formal:");
       wr.code(fn->id(), { formalDecl });
 
-      wr.message("The formal '", formalDecl->name(), "' expects ", badPass.formalType(), ", but the actual was ", badPass.actualType(), ".");
+      std::string formalName;
+      if (auto named = formalDecl->toNamedDecl()) {
+        formalName = "'" + named->name().str() + "'";
+      } else if (formalDecl->isTupleDecl()) {
+        // TODO: should we do anything fancy here?
+      }
+      wr.message("The formal ", formalName, " expects ", badPass.formalType(), ", but the actual was ", badPass.actualType(), ".");
       if (actualExpr) {
         wr.code(actualExpr, { actualExpr });
       }

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -994,8 +994,7 @@ static Type::Genericity getFieldsGenericity(Context* context,
     int n = tt->numElements();
     for (int i = 0; i < n; i++) {
       auto g = getTypeGenericityIgnoring(context, tt->elementType(i), ignore);
-      CHPL_ASSERT(g != Type::MAYBE_GENERIC);
-      if (g == Type::GENERIC) {
+      if (g == Type::GENERIC || g == Type::MAYBE_GENERIC) {
         combined = g;
       } else if (g == Type::GENERIC_WITH_DEFAULTS &&
                  combined == Type::CONCRETE) {
@@ -2110,8 +2109,11 @@ ApplicabilityResult instantiateSignature(Context* context,
       if (isTfsForInitializer(result)) {
         auto resolvedFn = resolveInitializer(context, result, poiScope);
         auto newTfs = resolvedFn->signature();
-        CHPL_ASSERT(!newTfs->needsInstantiation());
-        result = newTfs;
+        if (newTfs->needsInstantiation()) {
+          context->error(newTfs->id(), "Failure to resolve initializer");
+        } else {
+          result = newTfs;
+        }
       } else {
         CHPL_ASSERT(false && "Not handled yet!");
         std::ignore = resolveFunction(context, result, poiScope);
@@ -2684,18 +2686,24 @@ doIsCandidateApplicableInitial(Context* context,
   if (isVariable(tag)) {
     if (ci.isParenless() && ci.isMethodCall() && ci.numActuals() == 1) {
       // calling a field accessor
-      auto ct = ci.actual(0).type().type()->getCompositeType();
-      CHPL_ASSERT(ct);
-      auto containingType = isNameOfField(context, ci.name(), ct);
-      CHPL_ASSERT(containingType != nullptr);
-      return ApplicabilityResult::success(fieldAccessor(context, containingType, ci.name()));
-    } else {
-      // not a candidate
-      return ApplicabilityResult::failure(candidateId, /* TODO */ FAIL_CANDIDATE_OTHER);
+      //
+      // TODO: This doesn't have anything to do with this candidate. Shouldn't
+      // we be handling this somewhere else?
+      if (auto ct = ci.actual(0).type().type()->getCompositeType()) {
+        if (auto containingType = isNameOfField(context, ci.name(), ct)) {
+          auto ret = fieldAccessor(context, containingType, ci.name());
+          return ApplicabilityResult::success(ret);
+        }
+      }
     }
+    // not a candidate
+    return ApplicabilityResult::failure(candidateId, /* TODO */ FAIL_CANDIDATE_OTHER);
   }
 
-  CHPL_ASSERT(isFunction(tag) && "expected fn case only by this point");
+  if (!isFunction(tag)) {
+    context->error(candidateId, "Found non-function where function was expected");
+    return ApplicabilityResult::failure(candidateId, /* TODO */ FAIL_CANDIDATE_OTHER);
+  }
 
   if (ci.isMethodCall() && (ci.name() == "init" || ci.name() == "init=")) {
     // TODO: test when record has defaults for type/param fields
@@ -3489,8 +3497,10 @@ considerCompilerGeneratedCandidates(Context* context,
                                                            tfs,
                                                            ci,
                                                            poi);
-  CHPL_ASSERT(instantiated.success());
-  CHPL_ASSERT(instantiated.candidate()->instantiatedFrom());
+  if (!instantiated.success() ||
+      instantiated.candidate()->needsInstantiation()) {
+    context->error(tfs->id(), "invalid instantiation of compiler-generated method");
+  }
 
   candidates.addCandidate(instantiated.candidate());
 }
@@ -4323,7 +4333,13 @@ CallResolutionResult resolveCall(Context* context,
     return resolveTupleExpr(context, tuple, ci, inScope, inPoiScope);
   }
 
-  CHPL_ASSERT(false && "should not be reached");
+  if (call) {
+    std::string msg = "resolveCall cannot handle tag: ";
+    msg += asttags::tagToString(call->tag());
+    CHPL_UNIMPL(msg.c_str());
+  } else {
+    CHPL_UNIMPL("resolveCall with null Call*");
+  }
   MostSpecificCandidates emptyCandidates;
   QualifiedType emptyType;
   PoiInfo emptyPoi;

--- a/frontend/lib/util/assertions.cpp
+++ b/frontend/lib/util/assertions.cpp
@@ -66,9 +66,13 @@ void assertion(bool expr, const char* filename, const char* func,
 void chpl_unimpl(const char* filename, const char* func, int lineno,
                  const char* msg) {
   std::string fname(filename);
-  auto front = fname.substr(fname.find("frontend"), std::string::npos);
-  fprintf(stderr, "[%s:%d in %s] Unimplemented: %s\n", front.c_str(), lineno,
-          func, msg);
+  std::string shortName = fname;
+  auto frontPos = fname.find("frontend");
+  if (frontPos != std::string::npos) {
+    shortName = fname.substr(frontPos, std::string::npos);
+  }
+  fprintf(stderr, "[%s:%d in %s] Unimplemented: %s\n",
+                  shortName.c_str(), lineno, func, msg);
 };
 
 

--- a/util/chpl-completion.bash
+++ b/util/chpl-completion.bash
@@ -69,6 +69,7 @@ _chpl ()
 --dyno-debug-trace \
 --dyno-gen-lib \
 --dyno-gen-std \
+--dyno-no-break-error \
 --dyno-scope-bundled \
 --dyno-scope-production \
 --dyno-scope-resolve \
@@ -197,6 +198,7 @@ _chpl ()
 --no-dynamic-auto-local-access \
 --no-dyno \
 --no-dyno-debug-trace \
+--no-dyno-no-break-error \
 --no-dyno-scope-bundled \
 --no-dyno-scope-production \
 --no-dyno-scope-resolve \


### PR DESCRIPTION
This PR addresses a variety of segfaults and crashes encountered while running the primers with ``--dyno``.

Some other changes:
- Adds ``--dyno-no-break-error`` to disable the breakpoint in ``Context::report``. This is useful when trying to avoid a breakpoint for every single error during compilation (which, right now, is quite a few).
- ``ErrorNoMatchingCandidates`` is updated to account for TupleDecls

Testing:
- [x] full local