### PR TITLE
dyno: resolve module-qualified function calls.

### DIFF
--- a/frontend/include/chpl/resolution/resolution-queries.h
+++ b/frontend/include/chpl/resolution/resolution-queries.h
@@ -366,8 +366,7 @@ filterCandidatesInstantiating(Context* context,
 CallResolutionResult resolveCall(Context* context,
                                  const uast::Call* call,
                                  const CallInfo& ci,
-                                 const Scope* inScope,
-                                 const PoiScope* inPoiScope,
+                                 const CallScopeInfo& inScopes,
                                  std::vector<ApplicabilityResult>* rejected = nullptr);
 
 /**
@@ -381,8 +380,7 @@ CallResolutionResult resolveCall(Context* context,
 CallResolutionResult resolveCallInMethod(Context* context,
                                          const uast::Call* call,
                                          const CallInfo& ci,
-                                         const Scope* inScope,
-                                         const PoiScope* inPoiScope,
+                                         const CallScopeInfo& inScopes,
                                          types::QualifiedType implicitReceiver,
                                          std::vector<ApplicabilityResult>* rejected = nullptr);
 
@@ -395,8 +393,7 @@ CallResolutionResult resolveCallInMethod(Context* context,
 CallResolutionResult resolveGeneratedCall(Context* context,
                                           const uast::AstNode* astForErr,
                                           const CallInfo& ci,
-                                          const Scope* inScope,
-                                          const PoiScope* inPoiScope,
+                                          const CallScopeInfo& inScopes,
                                           std::vector<ApplicabilityResult>* rejected = nullptr);
 
 /**
@@ -412,8 +409,7 @@ CallResolutionResult
 resolveGeneratedCallInMethod(Context* context,
                              const uast::AstNode* astForErr,
                              const CallInfo& ci,
-                             const Scope* inScope,
-                             const PoiScope* inPoiScope,
+                             const CallScopeInfo& inScopes,
                              types::QualifiedType implicitReceiver);
 
 // tries to resolve an (unambiguous) init=

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -1857,6 +1857,39 @@ class CallResolutionResult {
   /// \endcond DO_NOT_DOCUMENT
 };
 
+/**
+
+  When resolving calls like f(), we need three scopes to search.
+  * The 'call scope', which becomes relevant if we're resolving a generic function.
+    When we resolve a generic function, and come across other calls,
+    this 'call scope' becomes the 'poi scope' for resolving those dependent calls.
+  * The 'lookup scope', which is used to restrict where we search for candidates.
+    For instance, when resolving `M.f()`, we don't want to look for `f` in
+    the current scope, only in the scope of `M`. The call scope is not
+    always the same as the 'lookup scope' because while resolving `M.f`,
+    we still want to use the 'scall scope' for POI.
+  * The 'POI scope', which is used when resolving calls in generic functions
+    as described in the first bullet.
+
+  This data structure bundles all three scopes for convenient threading through
+  the call resolution process.
+ */
+class CallScopeInfo {
+ private:
+  const Scope* callScope_;
+  const Scope* lookupScope_;
+  const PoiScope* poiScope_;
+
+ public:
+  CallScopeInfo(const Scope* callScope, const Scope* lookupScope, const PoiScope* poiScope)
+    : callScope_(callScope), lookupScope_(lookupScope), poiScope_(poiScope) {
+  }
+
+  const Scope* callScope() const { return callScope_; }
+  const Scope* lookupScope() const { return lookupScope_; }
+  const PoiScope* poiScope() const { return poiScope_; }
+};
+
 class ResolvedParamLoop;
 
 /**

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -617,6 +617,7 @@ class CallInfo {
                          const ResolutionResultByPostorderID& byPostorder,
                          bool raiseErrors = true,
                          std::vector<const uast::AstNode*>* actualAsts=nullptr,
+                         ID* moduleScopeId=nullptr,
                          UniqueString rename = UniqueString());
 
   /** Construct a CallInfo by adding a method receiver argument to

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -611,6 +611,11 @@ class CallInfo {
 
       If actualAsts is provided and not 'nullptr', it will be updated
       to contain the uAST pointers for each actual.
+
+      If moduleScopeId is provided and not 'nullptr', it will be updated
+      with the ID of the scope that should be searched for candidates.
+      That is, if the call expression is 'M.f(...)' for a module 'M', then
+      'moduleScopeId' will be set to the ID of the module 'M'.
    */
   static CallInfo create(Context* context,
                          const uast::Call* call,

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -1868,7 +1868,7 @@ class CallResolutionResult {
     For instance, when resolving `M.f()`, we don't want to look for `f` in
     the current scope, only in the scope of `M`. The call scope is not
     always the same as the 'lookup scope' because while resolving `M.f`,
-    we still want to use the 'scall scope' for POI.
+    we still want to use the 'call scope' for POI.
   * The 'POI scope', which is used when resolving calls in generic functions
     as described in the first bullet.
 

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -1881,10 +1881,14 @@ class CallScopeInfo {
   const Scope* lookupScope_;
   const PoiScope* poiScope_;
 
- public:
   CallScopeInfo(const Scope* callScope, const Scope* lookupScope, const PoiScope* poiScope)
     : callScope_(callScope), lookupScope_(lookupScope), poiScope_(poiScope) {
   }
+
+ public:
+  static CallScopeInfo forNormalCall(const Scope* scope, const PoiScope* poiScope);
+  static CallScopeInfo forQualifiedCall(Context* context, const ID& moduleId,
+                                        const Scope* scope, const PoiScope* poiScope);
 
   const Scope* callScope() const { return callScope_; }
   const Scope* lookupScope() const { return lookupScope_; }

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2101,6 +2101,7 @@ bool Resolver::resolveSpecialKeywordCall(const Call* call) {
       auto ci = CallInfo::create(context, call, byPostorder,
                                  /* raiseErrors */ true,
                                  /* actualAsts */ nullptr,
+                                 /* moduleScopeId */ nullptr,
                                  /* rename */ UniqueString::get(context, "chpl__buildIndexType"));
       auto scope = scopeStack.back();
       CallScopeInfo inScopes = { scope, scope, poiScope };

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -3504,7 +3504,6 @@ void Resolver::handleCallExpr(const uast::Call* call) {
 
   CHPL_ASSERT(scopeStack.size() > 0);
   const Scope* scope = scopeStack.back();
-  auto inScopes = CallScopeInfo::forNormalCall(scope, poiScope);
 
   // try to resolve it as a special call (e.g. Tuple assignment)
   if (resolveSpecialCall(call)) {
@@ -3517,6 +3516,10 @@ void Resolver::handleCallExpr(const uast::Call* call) {
                              /* raiseErrors */ true,
                              &actualAsts,
                              &moduleScopeId);
+  auto inScopes =
+    moduleScopeId.isEmpty() ?
+    CallScopeInfo::forNormalCall(scope, poiScope) :
+    CallScopeInfo::forQualifiedCall(context, moduleScopeId, scope, poiScope);
 
   // With some exceptions (see below), don't try to resolve a call that accepts:
   SkipCallResolutionReason skip = NONE;

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2843,6 +2843,9 @@ void Resolver::tryResolveParenlessCall(const ParenlessOverloadInfo& info,
                       actuals);
   CHPL_ASSERT(!scopeStack.empty());
   auto inScope = scopeStack.back();
+
+  // Note: this is only ever used from resolveIdentifier, so no qualifiers
+  // are needed; resolve as an unqualified call.
   auto inScopes = CallScopeInfo::forNormalCall(inScope, poiScope);
 
   // If some IDs were methods and some weren't, we have to resolve two

--- a/frontend/lib/resolution/Resolver.h
+++ b/frontend/lib/resolution/Resolver.h
@@ -409,8 +409,7 @@ struct Resolver {
   void handleResolvedCallPrintCandidates(ResolvedExpression& r,
                                          const uast::Call* call,
                                          const CallInfo& ci,
-                                         const Scope* scope,
-                                         const PoiScope* poiScope,
+                                         const CallScopeInfo& inScopes,
                                          const types::QualifiedType& receiverType,
                                          const CallResolutionResult& c);
   // like handleResolvedCall saves the call in associatedFns.

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -497,7 +497,7 @@ void CallInitDeinit::resolveDefaultInit(const VarLikeDecl* ast, RV& rv) {
                         /* isParenless */ false,
                         std::move(actuals));
     const Scope* scope = scopeForId(context, ast->id());
-    CallScopeInfo inScopes = { scope, scope, resolver.poiScope };
+    auto inScopes = CallScopeInfo::forNormalCall(scope, resolver.poiScope);
     auto c = resolveGeneratedCall(context, ast, ci, inScopes);
     ResolvedExpression& opR = rv.byAst(ast);
     resolver.handleResolvedAssociatedCall(opR, ast, ci, c,
@@ -533,7 +533,7 @@ void CallInitDeinit::resolveAssign(const AstNode* ast,
                       /* isParenless */ false,
                       actuals);
   const Scope* scope = scopeForId(context, ast->id());
-  CallScopeInfo inScopes = { scope, scope, resolver.poiScope };
+  auto inScopes = CallScopeInfo::forNormalCall(scope, resolver.poiScope);
   auto c = resolveGeneratedCall(context, ast, ci, inScopes);
   ResolvedExpression& opR = rv.byAst(ast);
 
@@ -570,7 +570,7 @@ void CallInitDeinit::resolveCopyInit(const AstNode* ast,
                       /* isParenless */ false,
                       actuals);
   const Scope* scope = scopeForId(context, ast->id());
-  CallScopeInfo inScopes = { scope, scope, resolver.poiScope };
+  auto inScopes = CallScopeInfo::forNormalCall(scope, resolver.poiScope);
   auto c = resolveGeneratedCall(context, ast, ci, inScopes);
 
   std::vector<const AstNode*> actualAsts;
@@ -762,7 +762,7 @@ void CallInitDeinit::resolveDeinit(const AstNode* ast,
                       /* isParenless */ false,
                       actuals);
   const Scope* scope = scopeForId(context, ast->id());
-  CallScopeInfo inScopes = { scope, scope, resolver.poiScope };
+  auto inScopes = CallScopeInfo::forNormalCall(scope, resolver.poiScope);
   auto c = resolveGeneratedCall(context, ast, ci, inScopes);
 
   // Should we associate it with the current statement or the current block?

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -497,7 +497,8 @@ void CallInitDeinit::resolveDefaultInit(const VarLikeDecl* ast, RV& rv) {
                         /* isParenless */ false,
                         std::move(actuals));
     const Scope* scope = scopeForId(context, ast->id());
-    auto c = resolveGeneratedCall(context, ast, ci, scope, resolver.poiScope);
+    CallScopeInfo inScopes = { scope, scope, resolver.poiScope };
+    auto c = resolveGeneratedCall(context, ast, ci, inScopes);
     ResolvedExpression& opR = rv.byAst(ast);
     resolver.handleResolvedAssociatedCall(opR, ast, ci, c,
                                           AssociatedAction::DEFAULT_INIT,
@@ -532,7 +533,8 @@ void CallInitDeinit::resolveAssign(const AstNode* ast,
                       /* isParenless */ false,
                       actuals);
   const Scope* scope = scopeForId(context, ast->id());
-  auto c = resolveGeneratedCall(context, ast, ci, scope, resolver.poiScope);
+  CallScopeInfo inScopes = { scope, scope, resolver.poiScope };
+  auto c = resolveGeneratedCall(context, ast, ci, inScopes);
   ResolvedExpression& opR = rv.byAst(ast);
 
   auto op = ast->toOpCall();
@@ -568,7 +570,8 @@ void CallInitDeinit::resolveCopyInit(const AstNode* ast,
                       /* isParenless */ false,
                       actuals);
   const Scope* scope = scopeForId(context, ast->id());
-  auto c = resolveGeneratedCall(context, ast, ci, scope, resolver.poiScope);
+  CallScopeInfo inScopes = { scope, scope, resolver.poiScope };
+  auto c = resolveGeneratedCall(context, ast, ci, inScopes);
 
   std::vector<const AstNode*> actualAsts;
   actualAsts.push_back(ast);
@@ -759,7 +762,8 @@ void CallInitDeinit::resolveDeinit(const AstNode* ast,
                       /* isParenless */ false,
                       actuals);
   const Scope* scope = scopeForId(context, ast->id());
-  auto c = resolveGeneratedCall(context, ast, ci, scope, resolver.poiScope);
+  CallScopeInfo inScopes = { scope, scope, resolver.poiScope };
+  auto c = resolveGeneratedCall(context, ast, ci, inScopes);
 
   // Should we associate it with the current statement or the current block?
   const AstNode* assocAst = currentStatement();

--- a/frontend/lib/resolution/copy-elision.cpp
+++ b/frontend/lib/resolution/copy-elision.cpp
@@ -136,7 +136,8 @@ bool FindElidedCopies::hasCrossTypeInitAssignWithIn(
                       /* isParenless */ false,
                       actuals);
   const Scope* scope = scopeForId(context, ast->id());
-  auto c = resolveGeneratedCall(context, ast, ci, scope, poiScope);
+  CallScopeInfo inScopes = { scope, scope, poiScope };
+  auto c = resolveGeneratedCall(context, ast, ci, inScopes);
   const MostSpecificCandidates& fns = c.mostSpecific();
   // return intent overloading should not be possible with an init=
   CHPL_ASSERT(fns.numBest() <= 1);

--- a/frontend/lib/resolution/copy-elision.cpp
+++ b/frontend/lib/resolution/copy-elision.cpp
@@ -136,7 +136,7 @@ bool FindElidedCopies::hasCrossTypeInitAssignWithIn(
                       /* isParenless */ false,
                       actuals);
   const Scope* scope = scopeForId(context, ast->id());
-  CallScopeInfo inScopes = { scope, scope, poiScope };
+  auto inScopes = CallScopeInfo::forNormalCall(scope, poiScope);
   auto c = resolveGeneratedCall(context, ast, ci, inScopes);
   const MostSpecificCandidates& fns = c.mostSpecific();
   // return intent overloading should not be possible with an init=

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -1209,7 +1209,7 @@ CallResolutionResult resolvePrimCall(Context* context,
         bool resolveFn = prim == PRIM_CALL_AND_FN_RESOLVES ||
                          prim == PRIM_METHOD_CALL_AND_FN_RESOLVES;
 
-        CallScopeInfo inScopes = { inScope, inScope, inPoiScope };
+        auto inScopes = CallScopeInfo::forNormalCall(inScope, inPoiScope);
         type = primCallResolves(context, ci, forMethod, resolveFn, call, inScopes);
       }
       break;

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -4409,7 +4409,8 @@ const TypedFnSignature* tryResolveInitEq(Context* context,
   const Scope* scope = nullptr;
   if (astForScopeOrErr) scope = scopeForId(context, astForScopeOrErr->id());
 
-  auto c = resolveGeneratedCall(context, astForScopeOrErr, ci, { scope, scope, poiScope });
+  auto c = resolveGeneratedCall(context, astForScopeOrErr, ci,
+                                CallScopeInfo::forNormalCall(scope, poiScope));
   return c.mostSpecific().only().fn();
 }
 
@@ -4433,7 +4434,8 @@ const TypedFnSignature* tryResolveDeinit(Context* context,
   const Scope* scope = nullptr;
   if (astForScopeOrErr) scope = scopeForId(context, astForScopeOrErr->id());
 
-  auto c = resolveGeneratedCall(context, astForScopeOrErr, ci, { scope, scope, poiScope });
+  auto c = resolveGeneratedCall(context, astForScopeOrErr, ci,
+                                CallScopeInfo::forNormalCall(scope, poiScope));
   return c.mostSpecific().only().fn();
 }
 
@@ -4463,7 +4465,7 @@ tryResolveAssignHelper(Context* context,
   const Scope* scope = nullptr;
   if (astForScopeOrErr) scope = scopeForId(context, astForScopeOrErr->id());
   auto c = resolveGeneratedCall(context, astForScopeOrErr, ci,
-                                { scope, scope, /* poiScope */ nullptr });
+                                CallScopeInfo::forNormalCall(scope, /* poiScope */ nullptr));
   return c.mostSpecific().only().fn();
 }
 

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -25,6 +25,7 @@
 #include "chpl/framework/query-impl.h"
 #include "chpl/framework/update-functions.h"
 #include "chpl/resolution/resolution-queries.h"
+#include "chpl/resolution/scope-queries.h"
 #include "chpl/types/TupleType.h"
 #include "chpl/uast/Builder.h"
 #include "chpl/uast/FnCall.h"
@@ -966,6 +967,15 @@ void CallResolutionResult::stringify(std::ostream& ss,
   exprType_.stringify(ss, stringKind);
 }
 
+CallScopeInfo CallScopeInfo::forNormalCall(const Scope* scope, const PoiScope* poiScope) {
+  return CallScopeInfo(scope, scope, poiScope);
+}
+
+CallScopeInfo CallScopeInfo::forQualifiedCall(Context* context, const ID& moduleId,
+                                      const Scope* scope, const PoiScope* poiScope) {
+  auto moduleScope = scopeForModule(context, moduleId);
+  return CallScopeInfo(scope, moduleScope, poiScope);
+}
 
 const char* AssociatedAction::kindToString(Action a) {
   switch (a) {

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -320,7 +320,7 @@ void CallInfo::prepareActuals(Context* context,
 }
 
 // returns true if values of this kind should be treated as 'functional':
-// if a call `x(args)` is being resolved, and `x` is a function value, then
+// if a call `x(args)` is being resolved, and `x` is a value, then
 // we should resolve `x.this(args)` instead.
 static bool isKindForFunctionalValue(QualifiedType::Kind kind) {
   return kind != QualifiedType::UNKNOWN &&

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -397,7 +397,8 @@ CallInfo CallInfo::create(Context* context,
     if (dotReceiverType && dotReceiverType->kind() == QualifiedType::MODULE) {
       // In calls like `M.f()`, where `M` is a module, we need to restrict
       // our search to `M`'s scope. Signal this by setting `moduleScopeId`.
-      if (moduleScopeId != nullptr) *moduleScopeId = dotReceiver->id();
+      if (moduleScopeId != nullptr)
+        *moduleScopeId = byPostorder.byAst(dotReceiver).toId();
     } else if (calledExprType && !calledExprType->isUnknown()) {
       calledType = *calledExprType;
 

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -323,6 +323,7 @@ CallInfo CallInfo::create(Context* context,
                           const ResolutionResultByPostorderID& byPostorder,
                           bool raiseErrors,
                           std::vector<const uast::AstNode*>* actualAsts,
+                          ID* moduleScopeId,
                           UniqueString rename) {
 
   // Pieces of the CallInfo we need to prepare.

--- a/frontend/test/ErrorGuard.h
+++ b/frontend/test/ErrorGuard.h
@@ -92,11 +92,17 @@ class ErrorGuard {
 
   /** Print the errors contained in this guard and then clear the guard
       of errors. Returns the number of errors. */
-  int realizeErrors() {
+  int realizeErrors(bool countWarnings = true) {
     assert(handler_);
     if (!handler_->errors().size()) return false;
     this->printErrors();
     int ret = (int) handler_->errors().size();
+
+    if (!countWarnings) {
+      for (auto& err : handler_->errors())
+        if (err->kind() == chpl::ErrorBase::WARNING) --ret;
+    }
+
     handler_->clear();
     return ret;
   }

--- a/frontend/test/resolution/testResolve.cpp
+++ b/frontend/test/resolution/testResolve.cpp
@@ -1408,6 +1408,115 @@ static void test23() {
   }
 }
 
+static void test24() {
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  {
+    // straightforward case for qualified module
+    std::string prog =
+      R"""(
+      module M {
+          proc fn() do return 42;
+      }
+      var x = M.fn();
+      )""";
+
+    auto t = resolveTypeOfXInit(context, prog);
+    assert(t.type());
+    assert(t.type()->isIntType());
+    assert(t.type()->toIntType()->isDefaultWidth());
+
+    // Ignore warnings for 'implicit module'.
+    assert(guard.realizeErrors(/* countWarnings */ false) == 0);
+  }
+
+  {
+    // qualified call when POI is involved. Make sure that although the
+    // current scope isn't searched for the function, it is still searched
+    // for POI functions when resolving the generic function's body.
+    context->advanceToNextRevision(false);
+    std::string prog =
+      R"""(
+      module M {
+        proc genericFn(x) {
+          return foo(x);
+        }
+      }
+
+      record myRecord {}
+      proc foo(r: myRecord) do return 42;
+
+      var x = M.genericFn(new myRecord());
+      )""";
+
+    auto t = resolveTypeOfXInit(context, prog);
+    assert(t.type());
+    assert(t.type()->isIntType());
+    assert(t.type()->toIntType()->isDefaultWidth());
+
+    // Ignore warnings for 'implicit module'.
+    assert(guard.realizeErrors(/* countWarnings */ false) == 0);
+  }
+  {
+    // another POI case, to make sure that the POI-based generic function
+    // we just wrote isn't defaulting to some return type.
+    context->advanceToNextRevision(false);
+    std::string prog =
+      R"""(
+      module M {
+        proc genericFn(x) {
+          return foo(x);
+        }
+      }
+
+      record myRecord1 {}
+      proc foo(r: myRecord1) do return 42;
+
+      record myRecord2 {}
+      proc foo(r: myRecord2) do return "hello";
+
+      var x = (M.genericFn(new myRecord1()), M.genericFn(new myRecord2()));
+      )""";
+
+    auto t = resolveTypeOfXInit(context, prog);
+    assert(t.type());
+    auto tt = t.type()->toTupleType();
+    assert(tt);
+    assert(tt->sortedSubstitutions().at(0).second.type()->isIntType());
+    assert(tt->sortedSubstitutions().at(1).second.type()->isStringType());
+
+    // Ignore warnings for 'implicit module'.
+    assert(guard.realizeErrors(/* countWarnings */ false) == 0);
+  }
+  {
+    // qualified call, but we're not calling a function. Rather, we're invoking
+    // an overloaded call operator on a value, which we retrieve from a module.
+    context->advanceToNextRevision(false);
+    std::string prog =
+      R"""(
+      module M {
+        record hasCallOperator {
+          proc this(arg: bool) do return 42;
+        }
+
+        var myKindaFn: hasCallOperator;
+      }
+
+      var x = M.myKindaFn(true);
+      )""";
+
+    auto t = resolveTypeOfXInit(context, prog);
+    assert(t.type());
+    assert(t.type()->isIntType());
+    assert(t.type()->toIntType()->isDefaultWidth());
+
+    // Ignore warnings for 'implicit module'.
+    assert(guard.realizeErrors(/* countWarnings */ false) == 0);
+  }
+}
+
 int main() {
   test1();
   test2();
@@ -1432,6 +1541,7 @@ int main() {
   test21();
   test22();
   test23();
+  test24();
 
   return 0;
 }

--- a/frontend/test/resolution/testResolve.cpp
+++ b/frontend/test/resolution/testResolve.cpp
@@ -1515,6 +1515,27 @@ static void test24() {
     // Ignore warnings for 'implicit module'.
     assert(guard.realizeErrors(/* countWarnings */ false) == 0);
   }
+
+  {
+    // nested module qualified access should work too.
+    std::string prog =
+      R"""(
+      module M {
+        module N {
+          proc fn() do return 42;
+        }
+      }
+      var x = M.N.fn();
+      )""";
+
+    auto t = resolveTypeOfXInit(context, prog);
+    assert(t.type());
+    assert(t.type()->isIntType());
+    assert(t.type()->toIntType()->isDefaultWidth());
+
+    // Ignore warnings for 'implicit module'.
+    assert(guard.realizeErrors(/* countWarnings */ false) == 0);
+  }
 }
 
 int main() {


### PR DESCRIPTION
Resolves https://github.com/Cray/chapel-private/issues/6100. 

This PR implements resolving function calls like `M.f()`, where `M` is a module. This effort is in two parts:

1. **Detecting when a module-qualified call occurs (i.e., distinguishing `myVar.f()` from `MyMod.f()`)**. Currently, `CallInfo::create` is responsible for doing this for other things (e.g., detecting method calls, detecting calls to `proc this`, etc). This PR adjusts `CallInfo::create` with another out-parameter to determine if a module was called.
   
   To achieve this, I flattened the logic in `CallInfo::create` a bit, so that the cases and order in which they are tried are more obvious. At present, they are as follows, in order of priority: call to _any_ value (including one retrieved from a module via `M.x`), call to module-scoped functions (e.g., `M.f`), calls to "anything" (any expression `e` that has been resolved), calls to methods `a.f`. For the most part, this order is as before, with the exception of introducing module-scoped functions between the first and third steps.
2. **Once a module call has been detected, ensuring that only candidates from the module are used for call resolution.** This is made particularly complicated by the following situation:
   
   ```Chapel
   module M {
     proc genericFn(x) {
       return foo(x);
     }
   }
   
   module N {
     record myRecord1 {}
     proc foo(r: myRecord1) do return 42;
   
     record myRecord2 {}
     proc foo(r: myRecord2) do return "hello";
   
     import M;
   
     proc main() {
       writeln(M.genericFn(new myRecord1()));
     }
   }
   ```
   According to Chapel's semantics, this should be type-correct, and print `42`. The reason this works, despite `foo` not being in scope of `genericFn`, is that the call to `genericFn` in `main` is used for computing a "point of instantiation scope", which is searched as a fallback when finding candidates.

   What this means is that we need to specify two scopes to call resolution for `genericFn`: the scope that is to be searched for methods (i.e., the scope of `M`), and the scope that is to be used for POI if the called function is generic. This is, of course, in addition to the pre-existing POI scope (if `main` were generic itself). As a consequence, to make this work, all call resolution functions need to be updated to take three scopes instead of two (new: the 'qualified scope'; call scope and POI scope remain as before). This is tedious. I handle the case by adding a new `CallScopeInfo` struct which contains the three scopes, making it easier to pass around.

   I adjusted the functions using a 'most conservative' strategy: I found all places where scopes were searched for candidates, and adjusted them to use an additional scope (by changing the arguments to accept a `CallScopeInfo`). I then updated callers of the adjusted functions, and so on. This ensures that all functions that accept a `CallScopeInfo` at some point use all three of its components. Other functions that only use the call and POI scopes (e.g., for instantiating already-found candidates) remain unchanged.

While there, I noticed that we don't properly handle the case of `M.x()`, where `M.x` is a value with a `proc this` overload, because we always fall back to trying to resolve `x(this = M)` (or perhaps just `x()`, since the `this = M` would be ill formed). Since this is very much in the spirit of qualified function calls --- and since the fix touched `CallInfo::create` --- I made this work, too.

I added tests to `testResolve` with all the cases described up to this point.

Compiling `hell.chpl` with `--dyno` on this branch leaves only one error:

```
warning: The prototype GPU support implies --no-checks. This may impact debuggability. To suppress this warning, compile with --no-checks explicitly
[frontend/lib/resolution/resolution-queries.cpp:293 in typeForModuleLevelSymbol] Unimplemented: interfaces
[frontend/lib/resolution/default-functions.cpp:239 in generateInitSignature] Unimplemented: initializers on inheriting classes
[frontend/lib/resolution/prims.cpp:884 in primIsFcfType] Unimplemented: PRIM_IS_FCF_TYPE
[frontend/lib/resolution/prims.cpp:884 in primIsFcfType] Unimplemented: PRIM_IS_FCF_TYPE
[frontend/lib/resolution/prims.cpp:884 in primIsFcfType] Unimplemented: PRIM_IS_FCF_TYPE
[frontend/lib/resolution/prims.cpp:884 in primIsFcfType] Unimplemented: PRIM_IS_FCF_TYPE
$CHPL_HOME/modules/internal/BytesStringCommon.chpl:109: In function 'decodeByteBuffer':
$CHPL_HOME/modules/internal/BytesStringCommon.chpl:139: error: unable to resolve call to '!=': no matching candidates
$CHPL_HOME/modules/internal/CString.chpl:26: In module 'CString':
$CHPL_HOME/modules/internal/CString.chpl:54: note: the following candidate didn't match because an actual couldn't be passed to a formal
$CHPL_HOME/modules/internal/Bytes.chpl:26: In module 'Bytes':
$CHPL_HOME/modules/internal/Bytes.chpl:1240: note: the following candidate didn't match because an actual couldn't be passed to a formal
$CHPL_HOME/modules/internal/BytesStringCommon.chpl:139: note: omitting 80 more candidates that didn't match
```

Reviewed by @benharsh and @mppf -- thanks!

## Testing
- [x] paratest
- [x] dyno tests -- locally and in CI
