### PR TITLE
docs: Fix BigBlockSpace not sharing domain with BlockSpace in primer

### DIFF
--- a/test/release/examples/primers/distributions.chpl
+++ b/test/release/examples/primers/distributions.chpl
@@ -220,7 +220,7 @@ coforall L in Locales {
 // it.  For example, we can declare a larger domain than
 // ``BlockSpace`` as follows:
 
-const BigBlockSpace = blockDist.createDomain({0..n+1, 0..n+1});
+const BigBlockSpace = BlkDist.createDomain({0..n+1, 0..n+1});
 
 // In this case, the rows and columns numbered ``0`` and ``n+1`` fall
 // outside of the bounding box.  As a result, indices like ``(0, i)``


### PR DESCRIPTION
debug code:

```Chapel
// ...
const BigBlockSpace = blockDist.createDomain({0..n+1, 0..n+1});
var BigA: [BigBlockSpace] int;

forall biga in BigA do biga = here.id;

writeln("Big Block Array Ownership Map");
writeln(BigA);
writeln();
// ...
```

**before**

produces with `./distributions -nl 2 --n 3`

```
Block Array Ownership Map
0 0 1
2 2 3
4 4 5

// ...

Big Block Array Ownership Map
0 0 0 1 1
0 0 0 1 1
2 2 2 3 3
2 2 2 3 3
4 4 4 5 5
```

**with proposed changes**

produces with `./distributions -nl 2 --n 3`

```
Block Array Ownership Map
0 0 1
2 2 3
4 4 5

// ...

Big Block Array Ownership Map
0 0 0 1 1
0 0 0 1 1
2 2 2 3 3
4 4 4 5 5
4 4 4 5 5
```