### PR TITLE
Skip test that's not meant to work in CPU-as-device mode.

### DIFF
--- a/test/gpu/native/assertOnGpuVarRuntime.skipif
+++ b/test/gpu/native/assertOnGpuVarRuntime.skipif
@@ -1,0 +1,2 @@
+# This test covers features we don't support in cpu-as-device mode
+CHPL_GPU==cpu


### PR DESCRIPTION
The test for "assert on gpu's runtime component" is not meant to be executing in CPU-as-device mode, since that always skips the runtime error. That's because the CPU loops are always used, and the 'kernel launch' calls are only used to track launch counts.