### PR TITLE
dyno: use declaration site of extern types to compute method scopes

### DIFF
--- a/frontend/include/chpl/types/ExternType.h
+++ b/frontend/include/chpl/types/ExternType.h
@@ -29,17 +29,20 @@ namespace types {
 class ExternType final : public Type {
  private:
   UniqueString linkageName_;
+  ID id_;
 
-  ExternType(UniqueString linkageName)
-    : Type(typetags::ExternType), linkageName_(linkageName) {}
+  ExternType(UniqueString linkageName, ID id)
+    : Type(typetags::ExternType), linkageName_(linkageName), id_(std::move(id)) {}
 
   bool contentsMatchInner(const Type* other) const override {
     const ExternType* rhs = (const ExternType*) other;
-    return linkageName_ == rhs->linkageName_;
+    return linkageName_ == rhs->linkageName_ &&
+           id_ == rhs->id_;
   }
 
   void markUniqueStringsInner(Context* context) const override {
     linkageName_.mark(context);
+    id_.mark(context);
   }
 
   Genericity genericity() const override {
@@ -47,7 +50,8 @@ class ExternType final : public Type {
   }
 
   static const owned<ExternType>& getExternType(Context* context,
-                                                UniqueString linkageName);
+                                                UniqueString linkageName,
+                                                ID id);
 
  public:
   virtual void stringify(std::ostream& ss,
@@ -55,7 +59,9 @@ class ExternType final : public Type {
 
   inline UniqueString linkageName() const { return linkageName_; }
 
-  static const ExternType* get(Context* context, UniqueString linkageName);
+  inline const ID& id() const { return id_; }
+
+  static const ExternType* get(Context* context, UniqueString linkageName, ID id);
 };
 
 } // end namespace types

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1373,7 +1373,7 @@ void Resolver::resolveNamedDecl(const NamedDecl* decl, const Type* useType) {
         linkageName = linkageNameNode->toStringLiteral()->value();
       }
       qtKind = QualifiedType::TYPE;
-      typePtr = ExternType::get(context, linkageName);
+      typePtr = ExternType::get(context, linkageName, var->id());
       paramPtr = nullptr;
     } else if (!typeExprT.hasTypePtr() && useType != nullptr) {
       // use type from argument to resolveNamedDecl

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -3514,6 +3514,8 @@ lookupCalledExpr(Context* context,
           Resolver::gatherReceiverAndParentScopesForType(context, compType);
       } else if (auto cptr = t->toCPtrType()) {
         receiverScopes.push_back(scopeForId(context, cptr->id(context)));
+      } else if (const ExternType* et = t->toExternType()) {
+        receiverScopes.push_back(scopeForId(context, et->id()));
       }
     }
   }

--- a/frontend/lib/types/ExternType.cpp
+++ b/frontend/lib/types/ExternType.cpp
@@ -24,9 +24,10 @@ namespace chpl {
 namespace types {
 
 const owned<ExternType>& ExternType::getExternType(Context* context,
-                                                   UniqueString name) {
-  QUERY_BEGIN(getExternType, context, name);
-  auto result = toOwned(new ExternType(name));
+                                                   UniqueString name,
+                                                   ID id) {
+  QUERY_BEGIN(getExternType, context, name, id);
+  auto result = toOwned(new ExternType(name, id));
   return QUERY_END(result);
 }
 
@@ -38,8 +39,8 @@ void ExternType::stringify(std::ostream& ss,
   linkageName().stringify(ss, stringKind);
 }
 
-const ExternType* ExternType::get(Context* context, UniqueString linkageName) {
-  return getExternType(context, linkageName).get();
+const ExternType* ExternType::get(Context* context, UniqueString linkageName, ID id) {
+  return getExternType(context, linkageName, std::move(id)).get();
 }
 
 } // end namespace types

--- a/frontend/test/resolution/testOpaqueExternTypes.cpp
+++ b/frontend/test/resolution/testOpaqueExternTypes.cpp
@@ -94,7 +94,7 @@ static void test2() {
   assert(anotherType.type()->isExternType());
   assert(anotherType.type()->toExternType()->linkageName() == "mytype");
 
-  assert(types.at("differentTypes").isParamTrue());
+  assert(types.at("differentTypes").isParamFalse());
 }
 
 // Make sure name similarity doesn't affect linkage-based equality.
@@ -118,15 +118,15 @@ static void test3() {
       return anotherType;
     }
 
-    param shouldBeTrue = f1() == f2();
-    param shouldBeFalse = f3() == f2();
+    param shouldBeFalse1 = f1() == f2();
+    param shouldBeFalse2 = f3() == f2();
     )""";
 
 
-  auto types = resolveTypesOfVariables(context, program, { "shouldBeTrue", "shouldBeFalse" });
+  auto types = resolveTypesOfVariables(context, program, { "shouldBeFalse1", "shouldBeFalse2" });
 
-  assert(types.at("shouldBeTrue").isParamTrue());
-  assert(types.at("shouldBeFalse").isParamFalse());
+  assert(types.at("shouldBeFalse1").isParamFalse());
+  assert(types.at("shouldBeFalse2").isParamFalse());
 }
 
 // Thorough test of externT from Atomics.chpl, but using if-then instead


### PR DESCRIPTION
Fixes https://github.com/Cray/chapel-private/issues/6096, implementing the proposal to make `==` report 'false' on two types with the same `extern` name if they're declared in different scopes.

The fix really is quite easy: bundling the ID of the variable that declares the extern type (much like a composite type declaration does) makes this fall out quite naturally.

Reviewed by @mppf -- thanks!

## Testing
- [x] dyno tests
- [x] paratest