### PR TITLE
Revert "Emit C `const` qualifier for `c_ptrConst` type"

### DIFF
--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -1435,15 +1435,6 @@ GenRet codegenElementPtr(GenRet base, GenRet index, bool ddataPtr=false) {
   if( info->cfile ) {
     base = codegenValue(base); // even for tuple, for style.
     ret.c = "(" + base.c + " + " + index.c + ")";
-    if (baseType->symbol->hasFlag(FLAG_C_PTRCONST_CLASS)) {
-      // For our const C pointer representation, we will codegen the type as
-      // const, but want to use it as non-const most places in the generated C.
-      // This is because the rest of code generation doesn't try to handle C
-      // constness, and we don't want to have to add that support everywhere.
-      // Here, we cast away the constness so this pointer can be assigned into
-      // a non-const call tmp without issue, for dereferencing or other use.
-      ret.c = "((void*)" + ret.c + ")";
-    }
   } else {
 #ifdef HAVE_LLVM
     unsigned AS = base.val->getType()->getPointerAddressSpace();

--- a/compiler/codegen/cg-type.cpp
+++ b/compiler/codegen/cg-type.cpp
@@ -313,10 +313,11 @@ void AggregateType::codegenDef() {
     TypeSymbol* base = getDataClassType(symbol);
     const char* baseType = base->cname;
     if( outfile ) {
-      const char* constness =
-          symbol->hasFlag(FLAG_C_PTRCONST_CLASS) ? "const " : "";
-      fprintf(outfile, "typedef %s%s *%s;\n", constness, baseType,
-              symbol->cname);
+      // TODO: add const qualifier for const pointers
+      // This would require properly using const qualifiers throughout generated C
+      // code, which we currently do not have. Otherwise we get warnings about
+      // discarding const qualification. Anna, 04-19-2023
+      fprintf(outfile, "typedef %s *%s;\n", baseType, symbol->cname);
     } else {
 #ifdef HAVE_LLVM
       llvm::Type* llBaseType;

--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -171,6 +171,16 @@ ifeq ($(shell test $(GNU_GPP_MAJOR_VERSION) -gt 5; echo "$$?"),0)
 WARN_CXXFLAGS += -Wsuggest-override -Wno-error=suggest-override
 endif
 
+# Don't warn about const qualifiers that are discarded on assignment
+# this is a temporary workaround to the issue that c_ptrConst types don't
+# currently include the const qualifier in generated code
+# see https://github.com/chapel-lang/chapel/pull/22122
+# which removed the const qualifiers
+# maybe added in gcc 4.6.0?
+ifeq ($(shell test $(GNU_GPP_MAJOR_VERSION) -ge 5; echo "$$?"),0)
+SQUASH_WARN_GEN_CFLAGS += -Wno-discarded-qualifiers
+endif
+
 #
 # Don't warn for signed pointer issues (ex. c_ptr(c_char) )
 #

--- a/make/compiler/Makefile.intel
+++ b/make/compiler/Makefile.intel
@@ -128,11 +128,12 @@ IEEE_FLOAT_GEN_CFLAGS = -fp-model precise -fp-model source
 #  174  : warns about expressions that have no effect
 #  177  : warns about unused variable declarations
 #  556  : warns about type X being assigned to entity of type Y
+#  2332 : warns about discarded const qualifier
 
 WARN_CXXFLAGS = -Wall -Werror -diag-disable remark -wr279,304,593,810,869,981,1572,1599 -diag-warning 1292,3924
 WARN_CFLAGS = $(WARN_CXXFLAGS)
 WARN_GEN_CFLAGS = $(WARN_CFLAGS)
-SQUASH_WARN_GEN_CFLAGS = -wr111,167,174,177,556
+SQUASH_WARN_GEN_CFLAGS = -wr111,167,174,177,556,2332
 
 #
 # Don't warn for signed pointer issues (ex. c_ptr(c_char) )

--- a/runtime/include/chpl-comm-compiler-macros.h
+++ b/runtime/include/chpl-comm-compiler-macros.h
@@ -277,7 +277,7 @@ void chpl_check_local(c_nodeid_t node, int32_t ln, int32_t file, const char* err
 }
 
 static inline
-void chpl_check_nil(const void* ptr, int32_t lineno, int32_t filename)
+void chpl_check_nil(void* ptr, int32_t lineno, int32_t filename)
 {
   if (ptr == nil)
     chpl_error("attempt to dereference nil", lineno, filename);

--- a/runtime/include/chplio.h
+++ b/runtime/include/chplio.h
@@ -50,7 +50,7 @@ static inline _cfile chpl_cnullfile(void) { return (_cfile) 0; }
 
 // These should be moved to chpl-string.h and eventually go away.
 // These return the Chapel idea of a (narrow) string.
-chpl_string chpl_refToString(const void* ref);
+chpl_string chpl_refToString(void* ref);
 chpl_string chpl_wideRefToString(c_nodeid_t node, void* addr);
 
 typedef FILE* c_file;

--- a/runtime/include/chpltypes.h
+++ b/runtime/include/chpltypes.h
@@ -77,7 +77,15 @@ typedef bool chpl_bool;
 #endif
 
 static inline void* c_pointer_return(void* x) { return x; }
-static inline const void* c_pointer_return_const(const void* x) { return x; }
+// TODO: Return a const void* and remove the const-discarding cast, here as well
+// as in the GPU runtime versions.
+// This is currently not possible as our C backend does not consistently respect
+// constness and would generate code that discards the const qualifier.
+// Constness is casted away here because we still need to accept a const
+// argument to get pointers to const Chapel variables; preventing mutation of
+// pointed-to const variables is enforced before this point.
+// Anna, April 2023.
+static inline void* c_pointer_return_const(const void* x) { return (void*)x; }
 static inline ptrdiff_t c_pointer_diff(void* a, void* b, ptrdiff_t eltSize) {
   return (((unsigned char*)a) - ((unsigned char*)b)) / eltSize;
 }

--- a/runtime/include/gpu/chpl-gpu-gen-common.h
+++ b/runtime/include/gpu/chpl-gpu-gen-common.h
@@ -38,8 +38,8 @@ __device__ static inline c_sublocid_t chpl_task_getRequestedSubloc(void)
 }
 
 __device__ static inline void* c_pointer_return(void* x) { return x; }
-__device__ static inline const void* c_pointer_return_const(const void* x) {
-  return x;
+__device__ static inline void* c_pointer_return_const(const void* x) {
+  return (void*)x;
 }
 
 __device__ static inline chpl_localeID_t chpl_rt_buildLocaleID(c_nodeid_t node,  c_sublocid_t subloc) {

--- a/runtime/src/chplio.c
+++ b/runtime/src/chplio.c
@@ -28,7 +28,7 @@
 #include <inttypes.h>
 
 // These should be moved to chpl-string.c and eventually go away.
-chpl_string chpl_refToString(const void* ref) {
+chpl_string chpl_refToString(void* ref) {
   char buff[32];
   (void) snprintf(buff, sizeof(buff), "%p", ref);
   return string_copy(buff, 0, 0);

--- a/test/extern/bradc/cprintarr.h
+++ b/test/extern/bradc/cprintarr.h
@@ -1,4 +1,4 @@
-static inline void cprintarr(const double* arr, int size) {
+static inline void cprintarr(double* arr, int size) {
   for (int i=0; i<size; i++) {
     printf("%lf ", arr[i]);
   }

--- a/test/extern/diten/testVoidExternFns.h
+++ b/test/extern/diten/testVoidExternFns.h
@@ -5,6 +5,6 @@ static void voidNoArray(int64_t n) {
   printf("%d\n", (int)n);
 }
 
-static void voidWithArray(const int64_t* A, int64_t n) {
+static void voidWithArray(int64_t* A, int64_t n) {
   printf("%d %d %d\n", (int)A[0], (int)A[1], (int)n);
 }

--- a/test/extern/kbrady/array_fns.h
+++ b/test/extern/kbrady/array_fns.h
@@ -1,6 +1,6 @@
 #include <stdio.h>
 
-static void printarr(const int* x, int n) {
+static void printarr(int* x, int n) {
   int i;
   printf("printme[0..%i] = ", n-1);
   for( i = 0; i < n; i++ ) {
@@ -9,7 +9,7 @@ static void printarr(const int* x, int n) {
   printf("\n");
 }
 
-static int sumarr(const int* x, int n) {
+static int sumarr(int* x, int n) {
   int i;
   int acc = 0;
   printf("sumarr[0..%i] = ", n-1);

--- a/test/extern/passArrays/passViewToExtern.h
+++ b/test/extern/passArrays/passViewToExtern.h
@@ -1,5 +1,5 @@
 #include <stdio.h>
 
-static inline void printThree(const double* ptr) {
+static inline void printThree(double* ptr) {
   printf("%lf %lf %lf\n", ptr[0], ptr[1], ptr[2]);
 }

--- a/test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-associative.chpl
+++ b/test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-associative.chpl
@@ -2,7 +2,7 @@ use IO;
 use Map;
 use Sort;
 
-extern proc memcpy(ref x : [], b:c_ptrConst(c_char) , len:int);
+extern proc memcpy(x : [], b:c_ptrConst(c_char) , len:int);
 
 config const tableSize = 1 << 16;
 config const lineSize = 61;

--- a/test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-chaining.chpl
+++ b/test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-chaining.chpl
@@ -1,7 +1,7 @@
 use IO;
 use Sort;
 
-extern proc memcpy(ref x : [], b:c_ptrConst(c_char), len:int);
+extern proc memcpy(x : [], b:c_ptrConst(c_char), len:int);
 
 config const tableSize = 1 << 16;
 config const lineSize = 61;

--- a/test/users/bugzilla/bug794131/bug794131.chpl
+++ b/test/users/bugzilla/bug794131/bug794131.chpl
@@ -9,7 +9,7 @@ record things {
 extern record data_set {
 }
 
-extern proc read_stuff(location: c_ptr(data_set), ref stuff: [] things,
+extern proc read_stuff(location: c_ptr(data_set), stuff: [] things,
                     start: uint(64), size: uint(64), count: uint(64)): int(64);
 
 proc get_stuff()

--- a/test/users/ibertolacc/void_extern_proc_array.chpl
+++ b/test/users/ibertolacc/void_extern_proc_array.chpl
@@ -2,7 +2,7 @@ require "void_extern_proc_array.h", "void_extern_proc_array.c";
 
 use CTypes;
 
-extern proc voidArrayFunction(ref array: [] c_int, elems : c_int): void;
+extern proc voidArrayFunction(array: [] c_int, elems : c_int): void;
 
 var array: [1..10] c_int;
 


### PR DESCRIPTION
Reverts chapel-lang/chapel#24746

Reverting as I accidentally merged this before a day off and checked in to find a lot of failures, which I don't want to resolve on my day off.

[reverting broken PR, not reviewed]