### PR TITLE
dyno: make the 'synthetic' `getRangeType` be called `_range` to match standard library.

### DIFF
--- a/frontend/lib/types/CompositeType.cpp
+++ b/frontend/lib/types/CompositeType.cpp
@@ -145,7 +145,7 @@ const RecordType* CompositeType::getStringType(Context* context) {
 
 const RecordType* CompositeType::getRangeType(Context* context) {
   auto symbolPath = UniqueString::get(context, "ChapelRange._range");
-  auto name = UniqueString::get(context, "range");
+  auto name = UniqueString::get(context, "_range");
   auto id = ID(symbolPath, -1, 0);
   return RecordType::get(context, id, name,
                          /* instantiatedFrom */ nullptr,

--- a/frontend/test/resolution/testRanges.cpp
+++ b/frontend/test/resolution/testRanges.cpp
@@ -165,6 +165,21 @@ static void test6(Context* context) {
   assert(idxTypeInt->bitwidth() == 64);
 }
 
+static void test7(Context* context) {
+  // test range without bound
+  ErrorGuard guard(context);
+  context->advanceToNextRevision(false);
+  setupModuleSearchPaths(context, false, false, {}, {});
+  QualifiedType qt =  resolveTypeOfXInit(context,
+                         R""""(
+                         proc f(r: range(?)) do return 42;
+                         var x = f(1..10);
+                         )"""", true);
+  assert(qt.type() != nullptr);
+  assert(qt.type()->isIntType());
+  assert(qt.type()->toIntType()->isDefaultWidth());
+}
+
 int main() {
   // first test runs without environment and stdlib.
   test1();
@@ -178,5 +193,6 @@ int main() {
   test4(ctx);
   test5(ctx);
   test6(ctx);
+  test7(ctx);
   return 0;
 }

--- a/frontend/test/resolution/testRanges.cpp
+++ b/frontend/test/resolution/testRanges.cpp
@@ -29,7 +29,7 @@
 #include "chpl/uast/Variable.h"
 
 static QualifiedType getRangeIndexType(Context* context, const RecordType* r, const std::string& ensureBoundedType) {
-  assert(r->name() == "range");
+  assert(r->name() == "_range");
   auto fields = fieldsForTypeDecl(context, r, DefaultsPolicy::IGNORE_DEFAULTS);
 
   assert(fields.fieldName(0) == "idxType");


### PR DESCRIPTION
Today on `main`, trying to feed a range literal into a function that accepts a `range(?)` reports the following error:

```
─── error in poundrangeparam.chpl:3 [NoMatchingCandidates] ───
  Unable to resolve call to 'myProc': no matching candidates.
      |
    3 | myProc(1..10);
      |

  The following candidate didn't match because an actual couldn't be passed to a formal:
      |
    1 | proc myProc(x: range(?)) {}
      |             ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
      |
[frontend/lib/types/CompositeType.cpp:126 in stringify] Unimplemented: attempting to stringify odd type representation as Chapel syntax
  The formal 'x' expects a value of type '_range', but the actual was a value of type 'range(<const-var> int(64), ChapelRange.boundKind@2, ChapelRange.strideKind@2)'.
      |
    3 | myProc(1..10);
      |        ⎺⎺⎺⎺⎺
      |
```

The reason for this is that the internal type for range literals uses the name 'range', while the Chapel type uses '_range'. The two don't compare to be equal, and thus, aren't considered related. This PR changes the name to fix that.

Reviewed by @mppf -- thanks!

## Testing
- [x] dyno tests (local and via CI)
- [x] paratest