### PR TITLE
dyno: improve initializers for generic types with (some, all) defaults

### DIFF
--- a/frontend/lib/resolution/InitResolver.cpp
+++ b/frontend/lib/resolution/InitResolver.cpp
@@ -233,18 +233,57 @@ bool InitResolver::isFinalReceiverStateValid(void) {
   return ret;
 }
 
+static const Type* ctFromSubs(Context* context,
+                              const Type* receiverType,
+                              const CompositeType* compositeType,
+                              const CompositeType::SubstitutionsMap& subs) {
+  auto root = compositeType->instantiatedFromCompositeType() ?
+              compositeType->instantiatedFromCompositeType() :
+              compositeType;
+
+  const Type* ret = nullptr;
+
+  if (auto rec = receiverType->toRecordType()) {
+    ret = RecordType::get(context, rec->id(), rec->name(),
+                          root->toRecordType(),
+                          subs);
+  } else if (auto cls = receiverType->toClassType()) {
+    auto oldBasic = cls->basicClassType();
+    CHPL_ASSERT(oldBasic && "Not handled!");
+
+    auto basic = BasicClassType::get(context, oldBasic->id(),
+                                     oldBasic->name(),
+                                     oldBasic->parentClassType(),
+                                     root->toBasicClassType(),
+                                     subs);
+    auto manager = AnyOwnedType::get(context);
+    auto dec = ClassTypeDecorator(ClassTypeDecorator::BORROWED_NONNIL);
+    ret = ClassType::get(context, basic, manager, dec);
+  } else {
+    CHPL_ASSERT(false && "Not handled!");
+  }
+
+  return ret;
+}
+
 const Type* InitResolver::computeReceiverTypeConsideringState(void) {
   auto ctInitial = typeToCompType(initialRecvType_);
-  auto& rfInitial = fieldsForTypeDecl(ctx_, ctInitial,
-                                      DefaultsPolicy::USE_DEFAULTS);
+
+  // The non-default fields are used to determine if we need to create
+  // substitutions. I.e., if a field is concrete even if we ignore defaults,
+  // no reason to add a substitution.
+  auto& rfNoDefaults = fieldsForTypeDecl(ctx_, ctInitial,
+                                        DefaultsPolicy::IGNORE_DEFAULTS);
+  auto& rfDefaults = fieldsForTypeDecl(ctx_, ctInitial,
+                                       DefaultsPolicy::IGNORE_DEFAULTS);
   CompositeType::SubstitutionsMap subs;
 
-  if (!rfInitial.isGeneric()) return currentRecvType_;
+  if (!rfNoDefaults.isGeneric()) return currentRecvType_;
 
-  for (int i = 0; i < rfInitial.numFields(); i++) {
-    auto id = rfInitial.fieldDeclId(i);
+  for (int i = 0; i < rfNoDefaults.numFields(); i++) {
+    auto id = rfNoDefaults.fieldDeclId(i);
     auto state = fieldStateFromId(id);
-    auto qtInitial = rfInitial.fieldType(i);
+    auto qtInitial = rfNoDefaults.fieldType(i);
     bool isInitiallyConcrete = qtInitial.genericity() == Type::CONCRETE;
 
     if (isInitiallyConcrete) continue;
@@ -252,9 +291,33 @@ const Type* InitResolver::computeReceiverTypeConsideringState(void) {
     // TODO: Will need to relax this as we go.
     // TODO: 'isGenericOrUnknown' isn't the right test here - e.g. if we have
     // a type field set to 'string'
-    if (state->qt.isType() || state->qt.isParam())
-      if (!state->qt.isGenericOrUnknown())
-        subs.insert({id, state->qt});
+    if ((state->qt.isType() || state->qt.isParam()) &&
+        !state->qt.isGenericOrUnknown()) {
+      subs.insert({id, state->qt});
+    } else {
+      // generic field without a substitution form the initializer.
+      // Perhaps we can use a default?
+
+      // First, try a default from the original (base) type.
+      QualifiedType qtForSub = rfDefaults.fieldType(i);
+
+      if (qtForSub.isGenericOrUnknown() && !subs.empty()) {
+        // There's no default value in the base type. But we already have
+        // substitutions from previous fields. If the composite type is
+        // dependently typed, we might be able to compute defaults that
+        // depend on these prior substitutions.
+        auto ctIntermediate = ctFromSubs(ctx_, initialRecvType_, ctInitial, subs);
+        auto& rfIntermediate = fieldsForTypeDecl(ctx_, typeToCompType(ctIntermediate),
+                                                 DefaultsPolicy::USE_DEFAULTS);
+
+        qtForSub = rfIntermediate.fieldType(i);
+      }
+
+      if ((qtForSub.isType() || qtForSub.isParam()) &&
+          !qtForSub.isGenericOrUnknown()) {
+        subs.insert({id, qtForSub});
+      }
+    }
   }
 
   if (subs.size() == 0) {
@@ -262,31 +325,7 @@ const Type* InitResolver::computeReceiverTypeConsideringState(void) {
     return currentRecvType_;
   }
 
-  const Type* ret = nullptr;
-  auto initCompType = typeToCompType(initialRecvType_);
-  auto root = initCompType->instantiatedFromCompositeType() ?
-              initCompType->instantiatedFromCompositeType() :
-              initCompType;
-
-  if (auto rec = initialRecvType_->toRecordType()) {
-    ret = RecordType::get(ctx_, rec->id(), rec->name(),
-                          root->toRecordType(),
-                          subs);
-  } else if (auto cls = initialRecvType_->toClassType()) {
-    auto oldBasic = cls->basicClassType();
-    CHPL_ASSERT(oldBasic && "Not handled!");
-
-    auto basic = BasicClassType::get(ctx_, oldBasic->id(),
-                                     oldBasic->name(),
-                                     oldBasic->parentClassType(),
-                                     root->toBasicClassType(),
-                                     subs);
-    auto manager = AnyOwnedType::get(ctx_);
-    auto dec = ClassTypeDecorator(ClassTypeDecorator::BORROWED_NONNIL);
-    ret = ClassType::get(ctx_, basic, manager, dec);
-  } else {
-    CHPL_ASSERT(false && "Not handled!");
-  }
+  const Type* ret = ctFromSubs(ctx_, initialRecvType_, ctInitial, subs);
 
   CHPL_ASSERT(ret);
 

--- a/frontend/test/resolution/testRanges.cpp
+++ b/frontend/test/resolution/testRanges.cpp
@@ -180,6 +180,23 @@ static void test7(Context* context) {
   assert(qt.type()->toIntType()->isDefaultWidth());
 }
 
+static void test8(Context* context) {
+  // test range without bound
+  ErrorGuard guard(context);
+  context->advanceToNextRevision(false);
+  setupModuleSearchPaths(context, false, false, {}, {});
+  QualifiedType qt =  resolveTypeOfXInit(context,
+                         R""""(
+                         var x = new range(int, 0, 10);
+                         )"""", true);
+  auto rangeType = qt.type()->toRecordType();
+  assert(rangeType != nullptr);
+  auto idxType = getRangeIndexType(context, rangeType, "both");
+  assert(idxType.type() != nullptr);
+  auto idxTypeInt = idxType.type()->toIntType();
+  assert(idxTypeInt->bitwidth() == 64);
+}
+
 int main() {
   // first test runs without environment and stdlib.
   test1();
@@ -194,5 +211,6 @@ int main() {
   test5(ctx);
   test6(ctx);
   test7(ctx);
+  test8(ctx);
   return 0;
 }


### PR DESCRIPTION
This PR improves initializers for generic types with initializers. The core issue it's trying to address is the fact that, prior to this PR, calling `new range` resulted in an assertion error (turned into a regular error on `main` by #24790):

https://github.com/chapel-lang/chapel/blob/2d130287495a49f5f91555faab0b1787e5368d0f/frontend/lib/resolution/resolution-queries.cpp#L2113

This was caused by the fact that `range` is generic-with-defaults. Since its fields, when defaults are used, are thus all concrete, the `InitResolver` skipped re-assigning them. However, this is obviously incorrect, since the record being constructed is (at the time of initialization) fully generic, so the default values of its fields should have no say in whether we can assign to them. This PR changes the logic to avoid skipping generic-with-default types in this manner.

The next hurdle is computing 'remaining types' -- after some type fields have been set, ensuring that others are left as default. E.g., if a `range` constructor sets `idxType` but not `strideKind`, the former should be user-provided, while the latter should use the default value. This PR implements this as well, by falling back to default substitutions if one is not stored in the initializer state (i.e., not written by the user).

These changes fix `_range`, but are not sufficient in general. In particular, if the record is dependent, we might need to be computing defaults based on the intermediate substitution state:

```Chapel
proc typeConstructor(type t) type { ... }

record dependentPair {
  type t1;
  type t2 = typeConstructor(t1);
}

proc dependentPair.new(type t1) {
  this.t1 = t1;
  // At this point, 'this' should have type 'dependentPair(t1, typeConstructor(t1))`.
}
```

The PR thus adjusts the `InitResolver` logic to fall back to the 'intermediate representation' for computing field types if a default value cannot be computed without prior instantiations. While there, I noticed that fields instantiated with `tuple(x, y)` are considered 'unknown', and aren't used in substitutions. This is because the (fast / conservative) `Type::genericity()` method returns `MAYBE_GENERIC` for tuples (and many other types). In the `InitResolver`, I adjusted logic to use `getTypeGenericity`, which ensures that tuples-as-field-substitutions work. 

Finally, I noted that some logic explicitly rules out computing the types of type-fields-with-defaults as a TODO. It was unclear to me what made that need to be a special case; removing the special-case logic, all tests still pass, and generic-with-some-default types are resolved as expected.

Reviewed by @benharsh -- thanks!

## Testing
- [x] dyno tests
- [x] paratest