### PR TITLE
dyno: resolve range literals using `chpl_build_*_range`.

### DIFF
--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2014,7 +2014,17 @@ ApplicabilityResult instantiateSignature(Context* context,
 
   // use the existing signature if there were no substitutions
   if (substitutions.size() == 0 && formalTypes.size() == 0) {
-    return ApplicabilityResult::success(sig);
+    // Even if no instantiations occurred due to formals, an initializer
+    // might end up creating substitutions when we resolve its body
+    // and process assignments like `this.someType = bla`. So, do not
+    // short-circuit in that case.
+    if (!isTfsForInitializer(sig)) {
+      return ApplicabilityResult::success(sig);
+    } else {
+      // normally we do this when we add a substitution, but we haven't
+      // added any substitutions yet.
+      formalsInstantiated.resize(sig->numFormals());
+    }
   }
 
   bool needsInstantiation = false;


### PR DESCRIPTION
Depends on https://github.com/chapel-lang/chapel/pull/24814. 

This PR switches our way of resolving range literals to use the (production) `chpl_build_*_range` functions. This was always planned, but until now, range constructors like `new range` didn't work. Since #24814 makes most range constructors work (I discovered plain `range()` didn't), we can now use the builders.

To view the diff without #24814, see here: https://github.com/chapel-lang/chapel/pull/24816/files/b648c39e05e8a072014a4bfe46f45654edc7e692..3b18d41c12bed27f0ef79c743a58e8583f33b61c

Reviewed by @benharsh -- thanks!

## Testing
- [x] dyno tests
- [x] paratest