### PR TITLE
LSP: skip undocumented names when providing autocompletion

### DIFF
--- a/tools/chapel-py/src/method-tables/uast-methods.h
+++ b/tools/chapel-py/src/method-tables/uast-methods.h
@@ -131,6 +131,9 @@ CLASS_BEGIN(Attribute)
 CLASS_END(Attribute)
 
 CLASS_BEGIN(AttributeGroup)
+  METHOD(AttributeGroup, get_attribute_named, "Get the attribute with a particular name, if any",
+         Nilable<const chpl::uast::AstNode*>(chpl::UniqueString),
+         return node->getAttributeNamed(std::get<0>(args)))
   PLAIN_GETTER(AttributeGroup, is_unstable, "Check if this AttributeGroup contains the 'unstable' attribute",
                bool, return node->isUnstable())
   PLAIN_GETTER(AttributeGroup, is_deprecated, "Check if this AttributeGroup contains the 'deprecated' attribute",

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -588,6 +588,12 @@ class FileInfo:
                 # about standard files applies here too.
                 documented_nodes = []
                 for node in nodes:
+                    # apply aforementioned exception
+                    if in_bundled_module:
+                        documented_nodes.append(node)
+                        continue
+
+                    # avoid nodes with nodoc attribute.
                     ag = node.attribute_group()
                     if not ag or not ag.get_attribute_named("chpldoc.nodoc"):
                         documented_nodes.append(node)

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -584,9 +584,20 @@ class FileInfo:
                     if not in_bundled_module:
                         continue
 
+                # Only show nodes without @chpldoc.nodoc. The exception
+                # about standard files applies here too.
+                documented_nodes = []
+                for node in nodes:
+                    ag = node.attribute_group()
+                    if not ag or not ag.get_attribute_named("chpldoc.nodoc"):
+                        documented_nodes.append(node)
+
+                if len(documented_nodes) == 0:
+                    continue
+
                 # Just take the first value to avoid showing N entries for
                 # overloaded functions.
-                self.visible_decls.append((name, nodes[0]))
+                self.visible_decls.append((name, documented_nodes[0]))
 
     def _search_instantiations(
         self,

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -607,7 +607,9 @@ class FileInfo:
                         # we will not show them if they're @chpldoc.nodoc,
                         # since they're not special.
                         decl_file = node.location().path()
-                        is_standard_decl = self.context.context.is_bundled_path(decl_file)
+                        is_standard_decl = self.context.context.is_bundled_path(
+                            decl_file
+                        )
                         show = is_standard_decl
 
                     if show:


### PR DESCRIPTION
As of #24776, CLS does a proper traversal of included symbols -- including `ChapelStandard` -- to find autocompletion suggestions. However, this means it picks up internal symbols from `ChapelStandard`, ones that weren't meant for the users' eyes. To solve (part of) this problem, this PR configures CLS to skip symbols that have `@chpldoc.nodoc` on them: if they aren't meant for public-facing documentation, they likely aren't meant for the user. 

This exception does not apply when editing standard module files, since the implication there is that the user is a developer.

Reviewed by @jabraham17. Tested locally.