### PR TITLE
Make chapel-py rebuild on changes to header files

### DIFF
--- a/tools/chapel-py/setup.py
+++ b/tools/chapel-py/setup.py
@@ -50,9 +50,18 @@ CXXFLAGS += ["-std=c++17", "-I{}/frontend/include".format(chpl_home)]
 LDFLAGS = []
 LDFLAGS += ["-L{}".format(chpl_lib_path), "-lChplFrontendShared", "-Wl,-rpath", chpl_lib_path]
 
-setup(name = "chapel",
-      version = "0.1",
-      package_dir = {'': 'src'},
-      packages = ['chapel', 'chapel.replace', 'chapel.visitor', 'chapel.lsp'],
-      ext_modules = [Extension("chapel.core", glob.glob("src/*.cpp"), extra_compile_args = CXXFLAGS, extra_link_args=LDFLAGS)]
-      )
+setup(
+    name="chapel",
+    version="0.1",
+    package_dir={"": "src"},
+    packages=["chapel", "chapel.replace", "chapel.visitor", "chapel.lsp"],
+    ext_modules=[
+        Extension(
+            "chapel.core",
+            glob.glob("src/*.cpp"),
+            depends=glob.glob("src/*.h"),
+            extra_compile_args=CXXFLAGS,
+            extra_link_args=LDFLAGS,
+        )
+    ],
+)

--- a/tools/chapel-py/setup.py
+++ b/tools/chapel-py/setup.py
@@ -59,7 +59,7 @@ setup(
         Extension(
             "chapel.core",
             glob.glob("src/*.cpp"),
-            depends=glob.glob("src/*.h"),
+            depends = glob.glob("src/**/*.h", recursive=True),
             extra_compile_args=CXXFLAGS,
             extra_link_args=LDFLAGS,
         )


### PR DESCRIPTION
Prior to this PR, if a developer changed the a header file in the python bindings, it would not trigger a rebuild of the C++ sources. This PR fixes that by making `setup.py` depend on the header files

[Reviewed by @DanilaFe]