### PR TITLE
Fix dyno range literal resolution bug

### DIFF
--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -3307,12 +3307,6 @@ void Resolver::exit(const Range* range) {
     return;
   }
 
-  // For the time being, we're resolving ranges by manually finding the record
-  // and instantiating it appropriately. However, long-term, range literals
-  // should be equivalent to a call to chpl_build_bounded_range. The resolver
-  // cannot handle this right now, but in the future, the below implementation
-  // should be replaced with one that resolves the call.
-
   const RecordType* rangeType = CompositeType::getRangeType(context);
   if (CompositeType::isMissingBundledRecordType(context, rangeType->id())) {
     // The range record is part of the standard library, but

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -3314,8 +3314,7 @@ void Resolver::exit(const Range* range) {
   // should be replaced with one that resolves the call.
 
   const RecordType* rangeType = CompositeType::getRangeType(context);
-  auto rangeAst = parsing::idToAst(context, rangeType->id());
-  if (!rangeAst) {
+  if (CompositeType::isMissingBundledRecordType(context, rangeType->id())) {
     // The range record is part of the standard library, but
     // it's possible to invoke the resolver without the stdlib.
     // In this case, mark ranges as UnknownType, but do not error.

--- a/frontend/lib/types/CompositeType.cpp
+++ b/frontend/lib/types/CompositeType.cpp
@@ -188,7 +188,7 @@ bool CompositeType::isMissingBundledRecordType(Context* context, ID id) {
   if (noLibrary) {
     auto path = id.symbolPath();
     return path == "String._string" ||
-           path == "ChapelRange.range" ||
+           path == "ChapelRange._range" ||
            path == "Bytes._bytes";
   }
 


### PR DESCRIPTION
Fix an error message observed in `testInteractive --std` for some codes that include a range literal.

This occurred due to the `Resolver` looking up the existence of `ChapelRange._range` AST as a way of checking if the standard library is available before proceeding with range resolution. However, this can get hit before the `ChapelRange` module is resolved, such as when a range is used as an argument to a method on another type (e.g., slicing). The `idToAstQuery` for `ChapelRange._range` fails, and that stored result is used later when the `_range` AST _does_ exist and we need to get it.

Fixed by replacing the AST existence check with a call to `CompositeType::isMissingBundledRecordType`, plus fixing the name of the type (`range`->`_range`) in that method. While there, also removed a TODO in `Resolver::exit(Range*)` to resolve a call to `chpl_build_*_range` rather than manually instantiating the `_range` record, which was done in https://github.com/chapel-lang/chapel/pull/24816.

Credit to @DanilaFe for the fix.

Resolves https://github.com/Cray/chapel-private/issues/6151.

[reviewer info placeholder]

Testing:
- [x] dyno tests
- [x] paratest