### PR TITLE
chplcheck: improve the 'bad indentation' rule, and add rule for ';;;'.

### DIFF
--- a/frontend/include/chpl/uast/uast-classes-list.h
+++ b/frontend/include/chpl/uast/uast-classes-list.h
@@ -78,6 +78,7 @@
   AST_NODE(Try)                        // old AST: TryStmt
   AST_NODE(Use)                        // old AST: UseStmt
   AST_NODE(VisibilityClause)           //
+  AST_NODE(When)                       //
   AST_NODE(WithClause)                 //
   AST_NODE(Yield)                      //
 
@@ -90,7 +91,6 @@
     AST_NODE(On)                       //
     AST_NODE(Serial)                   //
     AST_NODE(Sync)                     //
-    AST_NODE(When)                     //
   AST_END_SUBCLASSES(SimpleBlockLike)
 
   AST_BEGIN_SUBCLASSES(Loop)           // old AST: LoopExpr / LoopStmt

--- a/test/chplcheck/CaseRules.chpl
+++ b/test/chplcheck/CaseRules.chpl
@@ -42,7 +42,7 @@ module CaseRules {
   var snake_CapVar: real;
   const snake_Var: string;
 
-  record R {};
+  record R {}
 
   var _privateVar: int;
 

--- a/test/chplcheck/IncorrectIndentation.chpl
+++ b/test/chplcheck/IncorrectIndentation.chpl
@@ -303,3 +303,23 @@ union u5 {
 
   proc firstProc() {} proc secondProc() {}
 }
+
+enum color { red, green, blue }; // semicolon warning does not issue bad indentation
+
+// Since locations are incorrectly reported with 'public' and 'private',
+// these shouldn't warn.
+module M7 {
+  proc f1 {}
+    proc g1 {}
+  public proc f2 {}
+    public proc g2 {}
+  private proc f3 {}
+    private proc g3 {}
+
+  use super.M1;
+    use super.M1;
+  public use super.M2;
+    public use super.M2;
+  private use super.M2;
+    private use super.M2;
+}

--- a/test/chplcheck/IncorrectIndentation.good
+++ b/test/chplcheck/IncorrectIndentation.good
@@ -57,3 +57,6 @@ IncorrectIndentation.chpl:285: node violates rule IncorrectIndentation
 IncorrectIndentation.chpl:291: node violates rule IncorrectIndentation
 IncorrectIndentation.chpl:298: node violates rule IncorrectIndentation
 IncorrectIndentation.chpl:304: node violates rule IncorrectIndentation
+IncorrectIndentation.chpl:307: node violates rule EmptyStmts
+IncorrectIndentation.chpl:313: node violates rule IncorrectIndentation
+IncorrectIndentation.chpl:320: node violates rule IncorrectIndentation

--- a/test/chplcheck/activerules.good
+++ b/test/chplcheck/activerules.good
@@ -5,6 +5,7 @@ Active rules:
   CamelCaseRecords             Warn for records that are not 'camelCase'.
   ChplPrefixReserved           Warn for user-defined names that start with the 'chpl_' reserved prefix.
   DoKeywordAndBlock            Warn for redundant 'do' keyword before a curly brace '{'.
+  EmptyStmts                   Warn for empty statements (i.e., unnecessary semicolons).
   IncorrectIndentation         Warn for inconsistent or missing indentation
   MethodsAfterFields           Warn for classes or records that mix field and method definitions.
   MisleadingIndentation        Warn for single-statement blocks that look like they might be multi-statement blocks.

--- a/test/chplcheck/activerules.good
+++ b/test/chplcheck/activerules.good
@@ -11,4 +11,5 @@ Active rules:
   MisleadingIndentation        Warn for single-statement blocks that look like they might be multi-statement blocks.
   PascalCaseClasses            Warn for classes that are not 'PascalCase'.
   PascalCaseModules            Warn for modules that are not 'PascalCase'.
+  SimpleDomainAsRange          Warn for simple domains in loops that can be ranges.
   UnusedLoopIndex              Warn for unused index variables in loops.

--- a/test/chplcheck/allrules.good
+++ b/test/chplcheck/allrules.good
@@ -7,6 +7,7 @@ Available rules (default rules marked with *):
   * ChplPrefixReserved           Warn for user-defined names that start with the 'chpl_' reserved prefix.
     ConsecutiveDecls             Warn for consecutive variable declarations that can be combined.
   * DoKeywordAndBlock            Warn for redundant 'do' keyword before a curly brace '{'.
+  * EmptyStmts                   Warn for empty statements (i.e., unnecessary semicolons).
   * IncorrectIndentation         Warn for inconsistent or missing indentation
   * MethodsAfterFields           Warn for classes or records that mix field and method definitions.
   * MisleadingIndentation        Warn for single-statement blocks that look like they might be multi-statement blocks.

--- a/test/chplcheck/allrules.good
+++ b/test/chplcheck/allrules.good
@@ -14,6 +14,7 @@ Available rules (default rules marked with *):
     NestedCoforalls              Warn for nested 'coforall' loops, which could lead to performance hits.
   * PascalCaseClasses            Warn for classes that are not 'PascalCase'.
   * PascalCaseModules            Warn for modules that are not 'PascalCase'.
+  * SimpleDomainAsRange          Warn for simple domains in loops that can be ranges.
     UnusedFormal                 Warn for unused formals in functions.
   * UnusedLoopIndex              Warn for unused index variables in loops.
     UseExplicitModules           Warn for code that relies on auto-inserted implicit modules.

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -149,6 +149,14 @@ def register_rules(driver):
                 method_seen = True
         return True
 
+    @driver.basic_rule(EmptyStmt)
+    def EmptyStmts(context, node):
+        """
+        Warn for empty statements (i.e., unnecessary semicolons).
+        """
+
+        return False
+
     #Five things have to match between consecutive decls for this to warn:
     # 1. same type
     # 2. same kind
@@ -448,6 +456,9 @@ def register_rules(driver):
             # some NamedDecl nodes currently use the name as the location, which
             # does not indicate their actual indentation.
             if isinstance(child, (VarLikeDecl, TupleDecl, ForwardingDecl)):
+                continue
+            # Empty statements get their own warnings, no need to warn here.
+            elif isinstance(child, EmptyStmt):
                 continue
             # private function locations are bugged and don't include the 'private'
             # keyword.

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -464,7 +464,10 @@ def register_rules(driver):
             # keyword.
             #
             # https://github.com/chapel-lang/chapel/issues/24818
-            if isinstance(child, Function) and child.visibility() == "private":
+            elif (
+                isinstance(child, (Function, Use, Import))
+                and child.visibility() != ""
+            ):
                 continue
 
             line, depth = child.location().start()


### PR DESCRIPTION
This PR does a few things.

1. Fixes a small bug in which `When` was listed to inherit from `SimpleBlockLike`, but didn't. This led to some segmentation faults / memory issues when iterating over 'statements' of 'SimpleBlockLike' nodes.
2. Adjusts the `IncorrectIndentation` rule to skip all private and public things, because visibility modifiers' locations are not correctly reported by the parser (https://github.com/chapel-lang/chapel/issues/24818).
3. Adds a new rule for cases like this:
   ```Chapel
   enum {};
   ```
   Previously, `;` (which is unnecessary here and creates a new statement), would count as a same-line sibling to `enum`, resulting in a warning for `IncorrectIndentation`. However, the trouble isn't that `;` is improperly indented, but that it exists at all. Thus, the PR adds a new linter rule for `;`s where they aren't needed.

Reviewed by @jabraham17 -- thanks!