### PR TITLE
Revert some recent changes to --debugGpu output

### DIFF
--- a/runtime/include/chpl-gpu.h
+++ b/runtime/include/chpl-gpu.h
@@ -42,17 +42,12 @@ extern bool chpl_gpu_use_stream_per_task;
 
 #ifdef HAS_GPU_LOCALE
 
-extern int chpl_nodeID;
-
 __attribute__ ((format (printf, 1, 2)))
 static inline void CHPL_GPU_DEBUG(const char *str, ...) {
   if (chpl_gpu_debug) {
     va_list args;
     va_start(args, str);
-    const char* base_fmt = "(%3d:%3d) %s";
-    char fmt[128];
-    snprintf(fmt, 128, base_fmt, chpl_nodeID, chpl_task_getRequestedSubloc(), str);
-    vfprintf(stdout, fmt, args);
+    vfprintf(stdout, str, args);
     va_end(args);
     fflush(stdout);
   }


### PR DESCRIPTION
https://github.com/chapel-lang/chapel/pull/23913 made some changes to the `--debugGpu` output. I wasn't expecting/remembering that some tests use that flag to lock in behavior. Taking a look at the changes in question, I think they are more noise than signal in most common use cases of `--debugGpu` to me. So, this PR just reverts those changes.

Test
- [x] nvidia
- [x] amd