### PR TITLE
Deprecate `chpl_comm_array_get` and `chpl_comm_array_put`

### DIFF
--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -5621,7 +5621,7 @@ static void codegenPutGet(CallExpr* call, GenRet &ret) {
     curArg = call->get(curArgIdx++);
     INT_ASSERT(curArg, LOCALE_ID_TYPE);
 
-    GenRet locale = codegenValueMaybeDeref(curArg);;
+    GenRet locale = codegenValueMaybeDeref(curArg);
     args.push_back(locale);
 
 

--- a/frontend/lib/uast/post-parse-checks.cpp
+++ b/frontend/lib/uast/post-parse-checks.cpp
@@ -691,8 +691,8 @@ void Visitor::checkSparseKeyword(const FnCall* node) {
                " their behavior is likely to change in the future.");
 }
 
-// TODO: remove this check and warning after 2.0?
 void Visitor::checkPrimCallInUserCode(const PrimCall* node) {
+  // TODO: remove this check and warning after 2.0?
   // suppress this warning from chpldoc
   if (isUserCode())
     if ((node->prim() == PrimitiveTag::PRIM_CHPL_COMM_GET ||
@@ -701,6 +701,12 @@ void Visitor::checkPrimCallInUserCode(const PrimCall* node) {
           warn(node, "the primitives 'chpl_comm_get' and 'chpl_comm_put',"
                " have changed behavior in Chapel 1.32. Please use"
                " the 'Communication' module's 'get' and 'put' procedures"
+               " as replacements for calling the primitives directly");
+  if (node->prim() == PrimitiveTag::PRIM_CHPL_COMM_ARRAY_GET ||
+      node->prim() == PrimitiveTag::PRIM_CHPL_COMM_ARRAY_PUT)
+    warn(node, "the primitives 'chpl_comm_array_get' and"
+               " 'chpl_comm_array_put' are deprecated. Please use the"
+               " 'Communication' module's 'get' and 'put' procedures"
                " as replacements for calling the primitives directly");
 }
 

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -662,11 +662,11 @@ module ChapelLocale {
       // We must directly implement a bulk copy here, as the mechanisms
       // for doing so via a whole array assignment are not initialized
       // yet and copying element-by-element via a for loop is costly.
-      __primitive("chpl_comm_array_get",
+      __primitive("chpl_comm_get",
                   __primitive("array_get", newRL, 0),
                   0 /* locale 0 */,
                   __primitive("array_get", origRL, 0),
-                  numLocales:c_size_t);
+                  (numLocales * c_sizeof(locale)):c_size_t);
       // Set the rootLocale to the local copy
       rootLocale._instance = newRootLocale;
     }

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -34,7 +34,7 @@ module DefaultRectangular {
 
   use DSIUtil;
   public use ChapelArray;
-  use ChapelDistribution, ChapelRange, OS, CTypes, CTypes;
+  use ChapelDistribution, ChapelRange, OS, CTypes;
   use ChapelDebugPrint, ChapelLocks, OwnedObject, IO;
   use DefaultSparse, DefaultAssociative;
   public use ExternalArray; // OK: currently expected to be available by
@@ -2151,20 +2151,20 @@ module DefaultRectangular {
       if debugDefaultDistBulkTransfer then
         chpl_debug_writeln("\tlocal get() from ", Blocid);
 
-      __primitive("chpl_comm_array_get", dstRef, Blocid, Bsublocid,
-                  srcRef, len);
+      __primitive("chpl_comm_get", dstRef, Blocid, Bsublocid,
+                  srcRef, len * c_sizeof(A.eltType));
     } else if Blocid==here.id {
       if debugDefaultDistBulkTransfer then
         chpl_debug_writeln("\tlocal put() to ", Alocid);
 
-      __primitive("chpl_comm_array_put", srcRef, Alocid, Asublocid,
-                  dstRef, len);
+      __primitive("chpl_comm_put", srcRef, Alocid, Asublocid,
+                  dstRef, len * c_sizeof(A.eltType));
     } else on Adata.locale {
       if debugDefaultDistBulkTransfer then
         chpl_debug_writeln("\tremote get() on ", here.id, " from ", Blocid);
 
-      __primitive("chpl_comm_array_get", dstRef, Blocid, Bsublocid,
-                  srcRef, len);
+      __primitive("chpl_comm_get", dstRef, Blocid, Bsublocid,
+                  srcRef, len * c_sizeof(A.eltType));
     }
   }
 

--- a/modules/packages/DistributedBagDeprecated.chpl
+++ b/modules/packages/DistributedBagDeprecated.chpl
@@ -607,7 +607,7 @@ module DistributedBagDeprecated {
               if bufferOffset + block!.size > bufferSz {
                 halt("DistributedBagDeprecated Internal Error: Snapshot attempt with bufferSz(", bufferSz, ") with offset bufferOffset(", bufferOffset + block!.size, ")");
               }
-              __primitive("chpl_comm_array_put", block!.elems[0], here.id, buffer[bufferOffset], block!.size);
+              __primitive("chpl_comm_put", block!.elems[0], here.id, buffer[bufferOffset], block!.size * numBytes(eltType));
               bufferOffset += block!.size;
               block = block!.next;
             }
@@ -799,12 +799,12 @@ module DistributedBagDeprecated {
         if len > need {
           srcOffset = len - need;
           headBlock!.size = srcOffset;
-          __primitive("chpl_comm_array_put", headBlock!.elems[srcOffset], locId, destPtr[destOffset], need);
+          __primitive("chpl_comm_put", headBlock!.elems[srcOffset], locId, destPtr[destOffset], need * numBytes(eltType));
           destOffset = destOffset + need;
         } else {
           srcOffset = 0;
           headBlock!.size = 0;
-          __primitive("chpl_comm_array_put", headBlock!.elems[srcOffset], locId, destPtr[destOffset], len);
+          __primitive("chpl_comm_put", headBlock!.elems[srcOffset], locId, destPtr[destOffset], len * numBytes(eltType));
           destOffset = destOffset + len;
         }
 
@@ -842,7 +842,7 @@ module DistributedBagDeprecated {
         var nLeft = n - offset;
         var nSpace = block!.cap - block!.size;
         var nFill = min(nLeft, nSpace);
-        __primitive("chpl_comm_array_get", block!.elems[block!.size], locId, ptr[offset], nFill);
+        __primitive("chpl_comm_get", block!.elems[block!.size], locId, ptr[offset], nFill * numBytes(eltType));
         block!.size = block!.size + nFill;
         offset = offset + nFill;
       }

--- a/test/deprecated/chplCommGetPut.chpl
+++ b/test/deprecated/chplCommGetPut.chpl
@@ -11,3 +11,16 @@ inline proc GET(addr, node, rAddr, size) {
 inline proc PUT(addr, node, rAddr, size) {
   __primitive("chpl_comm_put", addr, node, rAddr, size);
 }
+
+/*
+ Test for depreacting chpl_comm_array_* primitives
+*/
+
+inline proc GETARR(addr, node, rAddr, size) {
+  __primitive("chpl_comm_array_get", addr, node, rAddr, size);
+}
+
+
+inline proc PUTARR(addr, node, rAddr, size) {
+  __primitive("chpl_comm_array_put", addr, node, rAddr, size);
+}

--- a/test/deprecated/chplCommGetPut.good
+++ b/test/deprecated/chplCommGetPut.good
@@ -2,3 +2,7 @@ chplCommGetPut.chpl:7: In function 'GET':
 chplCommGetPut.chpl:8: warning: the primitives 'chpl_comm_get' and 'chpl_comm_put', have changed behavior in Chapel 1.32. Please use the 'Communication' module's 'get' and 'put' procedures as replacements for calling the primitives directly
 chplCommGetPut.chpl:11: In function 'PUT':
 chplCommGetPut.chpl:12: warning: the primitives 'chpl_comm_get' and 'chpl_comm_put', have changed behavior in Chapel 1.32. Please use the 'Communication' module's 'get' and 'put' procedures as replacements for calling the primitives directly
+chplCommGetPut.chpl:19: In function 'GETARR':
+chplCommGetPut.chpl:20: warning: the primitives 'chpl_comm_array_get' and 'chpl_comm_array_put' are deprecated. Please use the 'Communication' module's 'get' and 'put' procedures as replacements for calling the primitives directly
+chplCommGetPut.chpl:24: In function 'PUTARR':
+chplCommGetPut.chpl:25: warning: the primitives 'chpl_comm_array_get' and 'chpl_comm_array_put' are deprecated. Please use the 'Communication' module's 'get' and 'put' procedures as replacements for calling the primitives directly

--- a/test/optimizations/sungeun/bulk_transfer/chpl_comm_get.chpl
+++ b/test/optimizations/sungeun/bulk_transfer/chpl_comm_get.chpl
@@ -5,13 +5,13 @@ var A: [1..n] int = 777;
 var B: [1..n] int = -1;
 var Ad = A._value.theData;
 var Bd = B._value.theData;
-__primitive("chpl_comm_array_get",
+__primitive("chpl_comm_get",
             __primitive("array_get", Bd,
                         B._value.getDataIndex(1)),
             0,
             __primitive("array_get", Ad,
                         A._value.getDataIndex(1)),
-            n);
+            n * numBytes(A.eltType));
 if printOutput then writeln(B);
 for i in B.domain do
   if A(i) != B(i) then
@@ -20,13 +20,13 @@ for i in B.domain do
 on Locales(numLocales-1) {
   var C: [1..n] int = -1;
   var Cd = C._value.theData;
-  __primitive("chpl_comm_array_get",
+  __primitive("chpl_comm_get",
               __primitive("array_get", Cd,
                           C._value.getDataIndex(1)),
               0,
               __primitive("array_get", Ad,
                           A._value.getDataIndex(1)),
-              n);
+              n * numBytes(C.eltType));
   if printOutput then writeln(C);
   for i in C.domain do
     if A(i) != C(i) then
@@ -40,13 +40,13 @@ on Locales(numLocales-1) {
   on Locales(0) {
     var E: [1..n] int = -1;
     var Ed = E._value.theData;
-    __primitive("chpl_comm_array_get",
+    __primitive("chpl_comm_get",
                 __primitive("array_get", Ed,
                             E._value.getDataIndex(1)),
                 numLocales-1,
                 __primitive("array_get", Dd,
                             D._value.getDataIndex(1)),
-                n);
+                n * numBytes(D.eltType));
     if printOutput then writeln(E);
     for i in E.domain do
       if D(i) != E(i) then

--- a/test/optimizations/sungeun/bulk_transfer/chpl_comm_put.chpl
+++ b/test/optimizations/sungeun/bulk_transfer/chpl_comm_put.chpl
@@ -5,13 +5,13 @@ var A: [1..n] int = 777;
 var B: [1..n] int = -1;
 var Ad = A._value.theData;
 var Bd = B._value.theData;
-__primitive("chpl_comm_array_put",
+__primitive("chpl_comm_put",
             __primitive("array_get", Ad,
                         A._value.getDataIndex(1)),
             0,
             __primitive("array_get", Bd,
                         B._value.getDataIndex(1)),
-            n);
+            n * numBytes(A.eltType));
 if printOutput then writeln(B);
 for i in B.domain do
   if A(i) != B(i) then
@@ -21,13 +21,13 @@ on Locales(numLocales-1) {
   var C: [1..n] int = -1;
   var Cd = C._value.theData;
   on Locales(0) {
-    __primitive("chpl_comm_array_put",
+    __primitive("chpl_comm_put",
                 __primitive("array_get", Ad,
                             A._value.getDataIndex(1)),
                 numLocales-1,
                 __primitive("array_get", Cd,
                             C._value.getDataIndex(1)),
-                n);
+                n * numBytes(C.eltType));
   }
   if printOutput then writeln(C);
   for i in C.domain do
@@ -43,13 +43,13 @@ on Locales(numLocales-1) {
     var E: [1..n] int = -1;
     var Ed = E._value.theData;
     on Locales(numLocales-1) {
-      __primitive("chpl_comm_array_put",
+      __primitive("chpl_comm_put",
                   __primitive("array_get", Dd,
                               D._value.getDataIndex(1)),
                   0,
                   __primitive("array_get", Ed,
                               E._value.getDataIndex(1)),
-                  n);
+                  n * numBytes(D.eltType));
     }
     if printOutput then writeln(E);
     for i in E.domain do

--- a/test/studies/isx/isx-hand-optimized.chpl
+++ b/test/studies/isx/isx-hand-optimized.chpl
@@ -300,7 +300,7 @@ proc exchangeKeys(taskID, sendOffsets, bucketSizes, myBucketedKeys) {
     // perturb the destination locale by our ID to avoid bottlenecks
     //
     const dstlocid = (locid+taskID) % numTasks;
-    const transferSize = bucketSizes[dstlocid] * numBytes(keyType);
+    const transferSize = bucketSizes[dstlocid];
     const dstOffset = recvOffset[dstlocid].fetchAdd(transferSize);
     const srcOffset = sendOffsets[dstlocid];
 
@@ -312,7 +312,10 @@ proc exchangeKeys(taskID, sendOffsets, bucketSizes, myBucketedKeys) {
 
     var Ridx = myBucketedKeys._instance.getDataIndex(srcOffset);
     var Rdata = _ddata_shift(keyType, myBucketedKeys._instance.theData, Ridx);
-    put(c_addrOf(Ldata[0]), c_addrOf(Rdata[0]), Ldata.locale.id, transferSize);
+    __primitive("chpl_comm_put", Rdata[0], Ldata.locale.id, Ldata[0], transferSize * numBytes(keyType));
+    // We run into issues about locality w.r.t.c pointers which can be avoided by changing
+    // the interface of the communcations module
+    // put(c_addrOf(Ldata[0]), c_addrOf(Rdata[0]), Ldata.locale.id, transferSize);
   }
 
 }

--- a/test/studies/isx/isx-hand-optimized.chpl
+++ b/test/studies/isx/isx-hand-optimized.chpl
@@ -293,12 +293,14 @@ proc countLocalBucketSizes(myKeys, ref bucketSizes) {
 
 
 proc exchangeKeys(taskID, sendOffsets, bucketSizes, myBucketedKeys) {
+  use Communication only put;
+  use CTypes only c_addrOf;
   for locid in 0..#numTasks {
     //
     // perturb the destination locale by our ID to avoid bottlenecks
     //
     const dstlocid = (locid+taskID) % numTasks;
-    const transferSize = bucketSizes[dstlocid];
+    const transferSize = bucketSizes[dstlocid] * numBytes(keyType);
     const dstOffset = recvOffset[dstlocid].fetchAdd(transferSize);
     const srcOffset = sendOffsets[dstlocid];
 
@@ -310,7 +312,7 @@ proc exchangeKeys(taskID, sendOffsets, bucketSizes, myBucketedKeys) {
 
     var Ridx = myBucketedKeys._instance.getDataIndex(srcOffset);
     var Rdata = _ddata_shift(keyType, myBucketedKeys._instance.theData, Ridx);
-    __primitive("chpl_comm_array_put", Rdata[0], Ldata.locale.id, Ldata[0], transferSize);
+    put(c_addrOf(Ldata[0]), c_addrOf(Rdata[0]), Ldata.locale.id, transferSize);
   }
 
 }


### PR DESCRIPTION
Based on the discussion from https://github.com/Cray/chapel-private/issues/5493. This PR implements part (1) of the proposal there. Follow up PR's will implement the other points in the linked issue.

As part of this PR we have deprecated the `chpl_comm_array_get` and `chpl_comm_array_put` primitives and only want to use `chpl_comm_get` and `chpl_comm_put` going forward for our own needs. 
Users should not be using either of these, but we're deprecating instead of removing these out of an abundance of caution.



- [ ] gasnet paratest