### PR TITLE
Fix a portability problem in a new test

### DIFF
--- a/test/library/standard/IO/readAll/readStringInvalid.chpl
+++ b/test/library/standard/IO/readAll/readStringInvalid.chpl
@@ -1,10 +1,15 @@
 use IO;
+use CTypes;
+import OS.POSIX.EILSEQ;
 
 var f = openMemFile();
 f.writer(locking=false).write(b"\xff" * 500);
 try {
   var s = f.reader(locking=false).readAll(string);
-} catch e {
-  writeln("caught expected error ", e);
+} catch e:SystemError {
+  assert(e.err == EILSEQ);
+  writeln("caught expected error");
+} catch {
+  writeln("caught unexpected error");
 }
 

--- a/test/library/standard/IO/readAll/readStringInvalid.good
+++ b/test/library/standard/IO/readAll/readStringInvalid.good
@@ -1,1 +1,1 @@
-caught expected error SystemError: Invalid or incomplete multibyte or wide character:  (in fileReader.readAll(ref s: string) with path "unknown" offset 1)
+caught expected error


### PR DESCRIPTION
Follow-up to PR #24783.

This PR fixes a portability problem in the new test readStringInvalid.chpl. The error prints out differently on Mac OS X vs Linux.

Test change only - not reviewed.