### PR TITLE
CLS: Support inlay end markers for Select and When

### DIFF
--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -446,6 +446,8 @@ class EndMarkerPattern:
                         chapel.Sync,
                         chapel.Local,
                         chapel.Manage,
+                        chapel.Select,
+                        chapel.When,
                     ]
                 ),
                 header_location=lambda node: (


### PR DESCRIPTION
Extends the existing support for end marker inlay hints to include Select and When.

![Screenshot 2024-04-12 at 1 30 20 PM](https://github.com/chapel-lang/chapel/assets/15747900/3efeb5bd-09f9-4c2a-9d8f-68c30746649a)

Tested locally

[Reviewed by @DanilaFe]