### PR TITLE
Add linter fixit for EmptyStmts

### DIFF
--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -224,7 +224,7 @@ def register_rules(driver: LintDriver):
         """
         Warn for empty statements (i.e., unnecessary semicolons).
         """
-        return False
+        return BasicRuleResult(Fixit.build(Edit.build(node.location(), "")))
 
     # Five things have to match between consecutive decls for this to warn:
     # 1. same type

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -220,10 +220,15 @@ def register_rules(driver: LintDriver):
         return True
 
     @driver.basic_rule(EmptyStmt)
-    def EmptyStmts(context, node):
+    def EmptyStmts(_, node: EmptyStmt):
         """
         Warn for empty statements (i.e., unnecessary semicolons).
         """
+        p = node.parent()
+        if p and isinstance(p, SimpleBlockLike) and len(list(p.stmts())) == 1:
+            # dont warn if the EmptyStmt is the only statement in a block
+            return True
+
         return BasicRuleResult(Fixit.build(Edit.build(node.location(), "")))
 
     # Five things have to match between consecutive decls for this to warn:


### PR DESCRIPTION
Adds an fixit for the chplcheck rule `EmptyStmts`. This allows users to automatically fix their code.

This also fixes an issue where the lint rule would warn in places where it was syntactically invalid to remove the `;`, for example `if a then ; else b;`

To be merged after #24744

[Reviewed by @DanilaFe]