### PR TITLE
Further improve readAll(string) performance

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -8201,7 +8201,7 @@ proc computeGuessReadSize(ch: fileReader, maxChars: c_ssize_t, pos: int): c_ssiz
   var fileLen:int(64) = -1;
   if fp {
     if maxChars == max(c_ssize_t) {
-      // try to find the file size with seek etc when doing readAll
+      // try to find the file size with stat etc when doing readAll
       var err:errorCode = qio_file_length(fp, fileLen);
       // if there was an error, ignore it, but don't use the file length
       if err then fileLen = 0;
@@ -8344,7 +8344,7 @@ private proc readStringImpl(ch: fileReader, ref out_var: string, len: int(64)) :
         var requestSz = 2*buffSz;
         // make sure to at least request 16 bytes
         if requestSz < n + 16 then requestSz = n + 16;
-        // but don't ever ask for more bytes than maxBytes + 1
+        // but don't ever ask for more bytes than maxBytes + 5
         if maxBytes < max(c_ssize_t) && requestSz > maxBytes + 5 then
           requestSz = maxBytes + 5;
         (buff, buffSz) = bufferEnsureSize(buff, buffSz, requestSz);

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -8336,8 +8336,6 @@ private proc readStringImpl(ch: fileReader, ref out_var: string, len: int(64)) :
     var nChars:c_ssize_t = 0; // how many codepoints have we read?
     (buff, buffSz) = bufferAlloc(guessReadSize);
 
-    //writeln("starting with buffSz ", buffSz);
-
     // then try to read repeatedly until we have read 'maxChars' or reach EOF
     while nChars < maxChars {
       var locErr:errorCode = 0;
@@ -8351,7 +8349,6 @@ private proc readStringImpl(ch: fileReader, ref out_var: string, len: int(64)) :
           requestSz = maxBytes + 5;
         (buff, buffSz) = bufferEnsureSize(buff, buffSz, requestSz);
         assert(n + 5 < buffSz);
-        //writeln("reallocated buffSz ", buffSz);
       }
 
       const bytesRemaining = buffSz - n;
@@ -8360,10 +8357,6 @@ private proc readStringImpl(ch: fileReader, ref out_var: string, len: int(64)) :
                              else max(c_ssize_t);
       var readCodepoints:c_ssize_t = 0;
       var readBytes:c_ssize_t = 0;
-      //writeln("n ", n);
-      //writeln("nChars ", nChars);
-      //writeln("bytesRemaining ", bytesRemaining);
-      //writeln("charsRemaining ", charsRemaining);
       locErr = qio_channel_read_chars(false, ch._channel_internal,
                                       buff[n], // store starting here
                                       bytesRemaining,
@@ -8371,8 +8364,6 @@ private proc readStringImpl(ch: fileReader, ref out_var: string, len: int(64)) :
                                       readBytes,
                                       readCodepoints);
 
-      ////writeln("readBytes ", readBytes);
-      //writeln("readCodepoints ", readCodepoints);
       nChars += readCodepoints;
       n += readBytes;
 

--- a/runtime/include/qio/qio_error.h
+++ b/runtime/include/qio/qio_error.h
@@ -166,6 +166,7 @@ qioerr qio_mkerror_errno(void);
 #define QIO_ENOMEM (qio_int_to_err(ENOMEM))
 #define QIO_ESHORT (qio_int_to_err(ESHORT))
 #define QIO_EEOF (qio_int_to_err(EEOF))
+#define QIO_EILSEQ (qio_int_to_err(EILSEQ))
 
 
 // This could be done optionally only under Chapel.

--- a/runtime/include/qio/qio_formatted.h
+++ b/runtime/include/qio/qio_formatted.h
@@ -476,6 +476,9 @@ qioerr qio_channel_read_char(const int threadsafe, qio_channel_t* restrict ch, i
   return err;
 }
 
+// read as many UTF-8 characters as fit into maxBytes / maxCodepoints
+qioerr qio_channel_read_chars(const int threadsafe, qio_channel_t* restrict ch, char* restrict buf, ssize_t maxBytes, ssize_t maxCodepoints, ssize_t* readBytes, ssize_t* readCodepoints);
+
 // Return the number of bytes used in encoding chr,
 // or 0 if it's an invalid character.
 static inline

--- a/runtime/src/qio/qio_formatted.c
+++ b/runtime/src/qio/qio_formatted.c
@@ -4453,6 +4453,128 @@ qioerr _qio_channel_read_char_slow_unlocked(qio_channel_t* restrict ch, int32_t*
   return err;
 }
 
+static qioerr qio_channel_read_chars_impl(qio_channel_t* restrict ch, char* restrict buf, ssize_t maxBytes, ssize_t maxCodepoints, ssize_t* readBytes, ssize_t* readCodepoints) {
+  qioerr err = 0;
+  ssize_t nBytes = 0;
+  ssize_t nCodepoints = 0;
+  uint32_t codepoint = 0;
+  uint32_t state = 0;
+  uint8_t byte = 0;
+  ssize_t amt_read = 0;
+  int32_t chr = 0;
+  ssize_t codepoint_sz = 0;
+
+  while (nBytes < maxBytes && nCodepoints < maxCodepoints) {
+    // decode as many full codepoints as are present in ch->cached
+    while (nBytes+4 <= maxBytes && nCodepoints < maxCodepoints &&
+           qio_space_in_ptr_diff(4, ch->cached_end, ch->cached_cur)) {
+      // read, save, and decode one byte
+      byte = *(unsigned char*)ch->cached_cur;
+      buf[nBytes++] = byte;
+      chpl_enc_utf8_decode(&state, &codepoint, byte);
+      ch->cached_cur = qio_ptr_add(ch->cached_cur,1);
+      if (state == UTF8_ACCEPT) {
+        // reset state and codepoint
+        state = 0;
+        codepoint = 0;
+        nCodepoints++;
+        // keep going
+      } else if (state == UTF8_REJECT) {
+        err = QIO_EILSEQ;
+        goto done;
+      }
+    }
+
+    if (nCodepoints >= maxCodepoints) {
+      // stop if we have read the requested number of codepoints
+      break;
+    }
+
+    // read the rest of the codepoint if we are partway through one
+    while (state > 1 && nBytes < maxBytes) {
+      amt_read = 0;
+      byte = 0;
+      err = qio_channel_read(false, ch, &byte, 1, &amt_read);
+      if (err) {
+        goto done;
+      } else if (amt_read != 1) {
+        err = QIO_ESHORT;
+        goto done;
+      }
+      // save and decode that byte
+      buf[nBytes++] = byte;
+      chpl_enc_utf8_decode(&state, &codepoint, byte);
+      if (state == UTF8_ACCEPT) {
+        // reset state and codepoint and stop
+        state = 0;
+        codepoint = 0;
+        nCodepoints++;
+        break;
+      } else if (state == UTF8_REJECT) {
+        err = QIO_EILSEQ;
+        goto done;
+      }
+    }
+
+    // mark, and then try to read a whole codepoint
+    err = qio_channel_mark(false, ch);
+    if (err) {
+      return err;
+    }
+
+    chr = 0;
+    err = qio_channel_read_char(false, ch, &chr);
+    if (err) {
+      // commit so we advance the channel position as normal for
+      // invalid UTF-8
+      qio_channel_commit_unlocked(ch);
+      goto done;
+    }
+    codepoint_sz = qio_nbytes_char(chr);
+    if (nBytes + codepoint_sz > maxBytes) {
+      // time to stop, no more room for the next codepoint sequence
+      qio_channel_revert_unlocked(ch);
+      err = 0;
+      goto done;
+    }
+
+    // otherwise, store the codepoint and continue
+    qio_encode_char_buf(buf + nBytes, chr);
+    nBytes += codepoint_sz;
+    nCodepoints++;
+    qio_channel_commit_unlocked(ch);
+  }
+
+  if (state != UTF8_ACCEPT) {
+    err = QIO_EILSEQ;
+  }
+
+done:
+  *readBytes = nBytes;
+  *readCodepoints = nCodepoints;
+  return err;
+}
+
+qioerr qio_channel_read_chars(const int threadsafe, qio_channel_t* restrict ch, char* restrict buf, ssize_t maxBytes, ssize_t maxCodepoints, ssize_t* readBytes, ssize_t* readCodepoints) {
+  qioerr err;
+
+  if( threadsafe ) {
+    err = qio_lock(&ch->lock);
+    if( err ) return err;
+  }
+
+  err = qio_channel_read_chars_impl(ch, buf, maxBytes, maxCodepoints,
+                                    readBytes, readCodepoints);
+
+  _qio_channel_set_error_unlocked(ch, err);
+  if( threadsafe ) {
+    qio_unlock(&ch->lock);
+  }
+
+  return err;
+}
+
+
 c_string qio_encode_to_string(int32_t chr)
 {
   int nbytes;

--- a/runtime/src/qio/qio_formatted.c
+++ b/runtime/src/qio/qio_formatted.c
@@ -4516,6 +4516,11 @@ static qioerr qio_channel_read_chars_impl(qio_channel_t* restrict ch, char* rest
       }
     }
 
+    if (nCodepoints >= maxCodepoints) {
+      // stop if we have read the requested number of codepoints
+      break;
+    }
+
     // mark, and then try to read a whole codepoint
     err = qio_channel_mark(false, ch);
     if (err) {


### PR DESCRIPTION
Follow-up to PR #24783.

This PR is intended to improve the performance of `readAll(string)` and other functions using `readStringImpl`. It adds `qio_channel_read_chars` which is similar to `qio_channel_read_char`, but can read many codepoints at once, and then uses it in `readStringImpl`.

How does it affect performance? These measurements were collected on my PC with `start_test -performance test/studies/shootout/submitted/regexredux2.chpl --numtrials 4` (and note that `main` here includes #24783). Please note that the performance gain for `readAll` itself will be a larger percentage (since it is not most of the benchmark time). The speed gain for `readAll(string)` specifically within the benchmark is about 2x.


| Benchmark    | main   | this PR | speedup    |
| ------------ | ------ | ------- | ---------- |
| regexredux2  | 1.42 s | 1.37 s  |  5% faster |


Reviewed by @jeremiah-corrado - thanks!

- [x] full comm=none testing