### PR TITLE
Resolve some chplcheck warnings in modules

### DIFF
--- a/modules/packages/AllLocalesBarriers.chpl
+++ b/modules/packages/AllLocalesBarriers.chpl
@@ -69,7 +69,7 @@ module AllLocalesBarriers {
   use BlockDist, Collectives;
 
   private const BarrierSpace = LocaleSpace dmapped new blockDist(LocaleSpace);
-  private var globalBarrier = [b in BarrierSpace] new unmanaged aBarrier(1, reusable=true, procAtomics=true, hackIntoCommBarrier=true);
+  private var globalBarrier = [BarrierSpace] new unmanaged aBarrier(1, reusable=true, procAtomics=true, hackIntoCommBarrier=true);
   private proc deinit() { [b in globalBarrier] delete b; }
 
   @chpldoc.nodoc

--- a/modules/packages/ArgumentParser.chpl
+++ b/modules/packages/ArgumentParser.chpl
@@ -258,7 +258,7 @@ module ArgumentParser {
   // TODO: Add public github issue when available
 
   @chpldoc.nodoc
-  enum argKind { positional, subcommand, option, flag, passthrough };
+  enum argKind { positional, subcommand, option, flag, passthrough }
 
   // stores an argument definition
   @chpldoc.nodoc

--- a/modules/packages/BLAS.chpl
+++ b/modules/packages/BLAS.chpl
@@ -171,7 +171,7 @@ in memory.
 module BLAS {
 
   /* Available BLAS implementations for ``blasImpl`` */
-  enum BlasImpl {blas, mkl, off};
+  enum BlasImpl {blas, mkl, off}
   use BlasImpl;
 
   /* Specifies which header filename to include, based on the BLAS
@@ -214,19 +214,19 @@ module BLAS {
   }
 
   /* Define row or column order */
-  enum Order {Row=101: c_int, Col};
+  enum Order {Row=101: c_int, Col}
 
   /* Operation of matrix : none, transpose, or adjoint */
-  enum Op {N=111 : c_int, T, H}; // NoTranspose, Transpose, Adjoint
+  enum Op {N=111 : c_int, T, H} // NoTranspose, Transpose, Adjoint
 
   /* Storage for symmetric matrices */
-  enum Uplo {Upper=121 : c_int, Lower};
+  enum Uplo {Upper=121 : c_int, Lower}
 
   /* Assume a unit or non-unit diagonal */
-  enum Diag {NonUnit=131 : c_int, Unit};
+  enum Diag {NonUnit=131 : c_int, Unit}
 
   /* Operate on the left or right side */
-  enum Side {Left=141 : c_int, Right};
+  enum Side {Left=141 : c_int, Right}
 
   /* Level 3 BLAS */
 
@@ -1773,10 +1773,10 @@ module BLAS {
   proc rotg(ref a : ?eltType, ref b : eltType, ref c : eltType, ref s : eltType) {
     require header;
     select eltType {
-      when real(32) do{
+      when real(32) {
         cblas_srotg (c_ptrTo(a), c_ptrTo(b), c_ptrTo(c), c_ptrTo(s));
       }
-      when real(64) do{
+      when real(64) {
         cblas_drotg (c_ptrTo(a), c_ptrTo(b), c_ptrTo(c), c_ptrTo(s));
       }
       otherwise {
@@ -1836,10 +1836,10 @@ module BLAS {
       throw new owned IllegalArgumentError("illegal argument 'P': must consist of 5 elements, passed to rotmg");
 
     select eltType {
-      when real(32) do{
+      when real(32) {
         cblas_srotmg(c_ptrTo(d1),c_ptrTo(d2),c_ptrTo(b1),b2,P);
       }
-      when real(64) do{
+      when real(64) {
         cblas_drotmg(c_ptrTo(d1),c_ptrTo(d2),c_ptrTo(b1),b2,P);
       }
       otherwise {
@@ -1880,10 +1880,10 @@ module BLAS {
     const N = D.size: c_int;
 
     select eltType {
-      when real(32) do{
+      when real(32) {
         cblas_srot(N, X, incX, Y, incY, c, s);
       }
-      when real(64) do{
+      when real(64) {
         cblas_drot(N, X, incX, Y, incY, c, s);
       }
       otherwise {
@@ -1944,10 +1944,10 @@ module BLAS {
     const N = D.size: c_int;
 
     select eltType {
-      when real(32) do{
+      when real(32) {
         cblas_srotm(N, X, incX, Y, incY,  P);
       }
-      when real(64) do{
+      when real(64) {
         cblas_drotm(N, X, incX, Y, incY, P);
       }
       otherwise {
@@ -1983,16 +1983,16 @@ module BLAS {
     const N = D.size: c_int;
 
     select eltType {
-      when real(32) do{
+      when real(32) {
         cblas_sswap (N, X, incX, Y, incY);
       }
-      when real(64) do{
+      when real(64) {
         cblas_dswap (N, X, incX, Y, incY);
       }
-      when complex(64) do{
+      when complex(64) {
         cblas_cswap (N, X, incX, Y, incY);
       }
-      when complex(128) do{
+      when complex(128) {
         cblas_zswap (N, X, incX, Y, incY);
       }
       otherwise {
@@ -2026,16 +2026,16 @@ module BLAS {
     const N = D.size: c_int;
 
     select eltType {
-      when real(32) do{
+      when real(32) {
         cblas_sscal (N, alpha, X, incX);
       }
-      when real(64) do{
+      when real(64) {
         cblas_dscal (N, alpha, X, incX);
       }
-      when complex(64) do{
+      when complex(64) {
         cblas_cscal (N, c_ptrToConst(alpha), X, incX);
       }
-      when complex(128) do{
+      when complex(128) {
         cblas_zscal (N, c_ptrToConst(alpha), X, incX);
       }
       otherwise {
@@ -2071,16 +2071,16 @@ module BLAS {
     const N = D.size: c_int;
 
     select eltType {
-      when real(32) do{
+      when real(32) {
         cblas_scopy (N, X, incX, Y, incY);
       }
-      when real(64) do{
+      when real(64) {
         cblas_dcopy (N, X, incX, Y, incY);
       }
-      when complex(64) do{
+      when complex(64) {
         cblas_ccopy (N, X, incX, Y, incY);
       }
-      when complex(128) do{
+      when complex(128) {
         cblas_zcopy (N, X, incX, Y, incY);
       }
       otherwise {
@@ -2117,16 +2117,16 @@ module BLAS {
 
     const N = D.size: c_int;
     select eltType {
-      when real(32) do{
+      when real(32) {
         cblas_saxpy (N, alpha, X, incX, Y, incY);
       }
-      when real(64) do{
+      when real(64) {
         cblas_daxpy (N, alpha, X, incX, Y, incY);
       }
-      when complex(64) do{
+      when complex(64) {
         cblas_caxpy (N, c_ptrToConst(alpha), X, incX, Y, incY);
       }
-      when complex(128) do{
+      when complex(128) {
         cblas_zaxpy (N, c_ptrToConst(alpha), X, incX, Y, incY);
       }
       otherwise {
@@ -2157,10 +2157,10 @@ module BLAS {
     const N = xD.size: c_int;
 
     select eltType {
-      when real(32) do{
+      when real(32) {
         return cblas_sdot (N, X, incX, Y, incY);
       }
-      when real(64) do{
+      when real(64) {
        return cblas_ddot (N,X, incX, Y, incY);
       }
       otherwise {
@@ -2194,10 +2194,10 @@ module BLAS {
     var res: eltType;
 
     select eltType {
-      when complex(64) do{
+      when complex(64) {
         cblas_cdotu_sub (N, X, incX, Y, incY, c_ptrTo(res));
       }
-      when complex(128) do{
+      when complex(128) {
         cblas_zdotu_sub (N, X, incX, Y, incY, c_ptrTo(res));
       }
       otherwise {
@@ -2233,10 +2233,10 @@ module BLAS {
     var res: eltType;
 
     select eltType {
-      when complex(64) do{
+      when complex(64) {
         cblas_cdotc_sub (N, X, incX, Y, incY, c_ptrTo(res));
       }
-      when complex(128) do{
+      when complex(128) {
         cblas_zdotc_sub (N, X, incX, Y, incY, c_ptrTo(res));
       }
       otherwise {
@@ -2316,16 +2316,16 @@ module BLAS {
     const N = D.size: c_int;
 
     select eltType {
-     when real(32) do{
+     when real(32) {
         return cblas_snrm2 (N,  X, incX);
       }
-      when real(64) do{
+      when real(64) {
         return cblas_dnrm2 (N, X, incX);
       }
-      when complex(64) do{
+      when complex(64) {
         return cblas_scnrm2 (N, X, incX);
       }
-      when complex(128) do{
+      when complex(128) {
         return cblas_dznrm2 (N, X, incX);
       }
       otherwise {
@@ -2355,16 +2355,16 @@ module BLAS {
     const N = D.size: c_int;
 
     select eltType {
-     when real(32) do{
+     when real(32) {
         return cblas_sasum(N, X, incX);
       }
-     when real(64) do{
+     when real(64) {
         return cblas_dasum(N, X, incX);
       }
-     when complex(64) do{
+     when complex(64) {
         return cblas_scasum(N, X, incX);
       }
-      when complex(128) do{
+      when complex(128) {
         return cblas_dzasum(N, X, incX);
       }
       otherwise {
@@ -2394,16 +2394,16 @@ module BLAS {
     const r = D.dim(0);
 
     select eltType {
-     when real(32) do{
+     when real(32) {
         return r.orderToIndex(cblas_isamax(N, X, incX));
       }
-     when real(64) do{
+     when real(64) {
         return r.orderToIndex(cblas_idamax(N, X, incX));
       }
-     when complex(64) do{
+     when complex(64) {
         return r.orderToIndex(cblas_icamax(N, X, incX));
       }
-      when complex(128) do{
+      when complex(128) {
         return r.orderToIndex(cblas_izamax(N, X, incX));
       }
       otherwise {

--- a/modules/packages/ConcurrentMap.chpl
+++ b/modules/packages/ConcurrentMap.chpl
@@ -571,7 +571,7 @@ module ConcurrentMap {
       :yields: A copy of one of the keys contained in this map.
     */
     iter keys() : keyType {
-      for (key, val) in this {
+      for (key, _) in this {
         yield key;
       }
     }
@@ -582,7 +582,7 @@ module ConcurrentMap {
       :yields: A copy of one of the values contained in this map.
     */
     iter values() : valType {
-      for (key, val) in this {
+      for (_, val) in this {
         yield val;
       }
     }
@@ -623,7 +623,7 @@ module ConcurrentMap {
         }
       }
 
-      coforall tid in 1..here.maxTaskPar {
+      coforall 1..here.maxTaskPar {
         var workListTok : owned TokenWrapper = workList.getToken();
         var deferredListTok : owned TokenWrapper = deferredList.getToken();
         while (true) {
@@ -695,7 +695,7 @@ module ConcurrentMap {
       :yields: A copy of one of the keys contained in this map.
     */
     iter keys(param tag:iterKind) where tag == iterKind.standalone {
-      forall (key, val) in this {
+      forall (key, _) in this {
         yield key;
       }
     }
@@ -706,7 +706,7 @@ module ConcurrentMap {
       :yields: A copy of one of the values contained in this map.
     */
     iter values(param tag:iterKind) where tag == iterKind.standalone {
-      forall (key, val) in this {
+      forall (_, val) in this {
         yield val;
       }
     }
@@ -1031,7 +1031,7 @@ module ConcurrentMap {
     */
     proc keysToArray(): [] keyType throws {
       var stack = new Stack(keyType);
-      for (key, val) in this {
+      for (key, _) in this {
         stack.push(key);
       }
 
@@ -1054,7 +1054,7 @@ module ConcurrentMap {
     */
     proc valuesToArray(): [] valType throws {
       var stack = new Stack(valType);
-      for (key, val) in this {
+      for (_, val) in this {
         stack.push(val);
       }
 

--- a/modules/packages/CopyAggregation.chpl
+++ b/modules/packages/CopyAggregation.chpl
@@ -392,7 +392,7 @@ module AggregationPrimitives {
     proc ref cachedAlloc(): c_ptr(elemType) {
       if data == nil {
         const rvf_size = size.safeCast(c_size_t);
-        on Locales[loc] do {
+        on Locales[loc] {
           data = allocate(elemType, rvf_size);
         }
       }

--- a/modules/packages/Crypto.chpl
+++ b/modules/packages/Crypto.chpl
@@ -181,7 +181,7 @@ module Crypto {
         halt("Enter an array with size greater than 0 in order to create a buffer");
       }
       this.buffDomain = s.domain;
-      for i in this.buffDomain do {
+      for i in this.buffDomain {
         this.buff[i] = s[i];
       }
     }
@@ -225,7 +225,7 @@ module Crypto {
     */
     proc toHex() throws {
       var buffHex: [this.buffDomain] string;
-      for i in this.buffDomain do {
+      for i in this.buffDomain {
         const byte = this.buff[i];
         const nib1 = convertNibble((byte>>4)&0xf, uppercase=false);
         const nib2 = convertNibble(byte&0xf, uppercase=false);
@@ -243,7 +243,7 @@ module Crypto {
     */
     proc toHexString() throws {
       var buffHexString: string;
-      for i in this.buffDomain do {
+      for i in this.buffDomain {
         const byte = this.buff[i];
         const nib1 = convertNibble((byte>>4)&0xf, uppercase=false);
         const nib2 = convertNibble(byte&0xf, uppercase=false);
@@ -340,7 +340,7 @@ module Crypto {
     proc init(iv: owned CryptoBuffer, encSymmKey: [] owned CryptoBuffer, encSymmValue: owned CryptoBuffer) {
       init this;
       this.keyDomain = encSymmKey.domain;
-      for i in this.keyDomain do {
+      for i in this.keyDomain {
         this.keys[i] = encSymmKey[i];
       }
       this.iv = iv;
@@ -406,7 +406,7 @@ module Crypto {
 
     var ctx = CHPL_EVP_MD_CTX_new();
 
-    var hash: [0..#hashLen] uint(8); ;
+    var hash: [0..#hashLen] uint(8);
     var retHashLen: c_uint = 0;
 
     var md: CONST_EVP_MD_PTR;
@@ -1047,7 +1047,7 @@ proc bfEncrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer, cip
       EVP_CIPHER_CTX_init(ctx); // TODO
 
       var numKeys = keys.size;
-      for i in keys.domain do {
+      for i in keys.domain {
         var keySize = EVP_PKEY_size(keys[i].getKeyPair());
         var dummyMalloc: [1..((keySize): int(64))] uint(8);
         encSymmKeys[i] = new unmanaged CryptoBuffer(dummyMalloc);
@@ -1055,12 +1055,12 @@ proc bfEncrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer, cip
 
       var encSymmKeysPtr: [keys.domain] c_ptr(uint(8));
       var encryptedSymKeyLen: c_int = 0;
-      for i in keys.domain do {
+      for i in keys.domain {
         encSymmKeysPtr[i] = encSymmKeys[i].getBuffPtr();
       }
 
       var keyObjs: [keys.domain] EVP_PKEY_PTR;
-      for i in keys.domain do {
+      for i in keys.domain {
         keyObjs[i] = keys[i].getKeyPair();
       }
 
@@ -1098,7 +1098,7 @@ proc bfEncrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer, cip
       var numEncKeys = encKeys.size;
       var openErrCode = 0;
 
-      for i in encKeys.domain do {
+      for i in encKeys.domain {
         openErrCode = EVP_OpenInit(ctx,
                                   EVP_aes_256_cbc(),
                                   encKeys[i].getBuffPtr(),

--- a/modules/packages/Curl.chpl
+++ b/modules/packages/Curl.chpl
@@ -611,7 +611,7 @@ module Curl {
       var offset:c_size_t;       // offset that we want to skip to
                                // (in the case where we cannot request byteranges)
       var curr:c_int;          // the index of the current buffer
-    };
+    }
 
     // userdata, is a curl_iovec_t. This is set to be passed into this function,
     // when we

--- a/modules/packages/DistributedBagDeprecated.chpl
+++ b/modules/packages/DistributedBagDeprecated.chpl
@@ -1028,7 +1028,7 @@ module DistributedBagDeprecated {
             while true {
               select segment.currentStatus {
                 // Quick acquire...
-                when STATUS_UNLOCKED do {
+                when STATUS_UNLOCKED {
                   if segment.acquireWithStatus(STATUS_ADD) {
                     segment.addElements(elt);
                     segment.releaseStatus();

--- a/modules/packages/EpochManager.chpl
+++ b/modules/packages/EpochManager.chpl
@@ -575,12 +575,12 @@ module EpochManager {
     proc init() {
       allocated_list = new unmanaged LockFreeLinkedList(unmanaged _token);
       free_list = new unmanaged LockFreeQueue(unmanaged _token, false);
-      limbo_list = for i in 1..EBR_EPOCHS do new unmanaged LimboList();
+      limbo_list = for 1..EBR_EPOCHS do new unmanaged LimboList();
       init this;
 
       // Initialise the free list pool with here.maxTaskPar tokens
       // Do we want this to be a 'coforall' ?
-      forall i in 0..#here.maxTaskPar {
+      forall 0..#here.maxTaskPar {
         var tok = new unmanaged _token();
         allocated_list.append(tok);
         free_list.enqueue(tok);
@@ -894,7 +894,7 @@ module EpochManager {
     // Initialise the free list pool with here.maxTaskPar tokens and other members
     @chpldoc.nodoc
     proc initializeMembers() {
-      forall i in 0..#here.maxTaskPar {
+      forall 0..#here.maxTaskPar {
         var tok = new unmanaged _token();
         this.allocated_list.append(tok);
         this.free_list.enqueue(tok);
@@ -981,7 +981,7 @@ module EpochManager {
       if (global_epoch.is_setting_epoch.testAndSet()) {
         is_setting_epoch.clear();
         return;
-      };
+      }
 
       // TODO: Right now we do not utilize all 3 epochs; in the future,
       // I need to check how crossbeam does it and go from there.

--- a/modules/packages/FFTW.chpl
+++ b/modules/packages/FFTW.chpl
@@ -651,7 +651,7 @@ module FFTW {
   */
   proc init_FFTW_MT() {
     coforall loc in Locales {
-      on loc do {
+      on loc {
         if (C_FFTW.fftw_init_threads() == 0) then
           halt("Failed to properly initialize FFTW threads on locale ",
                here.id);
@@ -676,7 +676,7 @@ module FFTW {
   */
   proc plan_with_nthreads(nthreads: int = 0) {
     coforall loc in Locales {
-      on loc do {
+      on loc {
         const myNThreads = if nthreads < 1 then here.maxTaskPar else nthreads;
         C_FFTW.fftw_plan_with_nthreads(myNThreads.safeCast(c_int));
       }
@@ -689,7 +689,7 @@ module FFTW {
   */
   proc cleanup_threads() {
     coforall loc in Locales {
-      on loc do {
+      on loc {
         C_FFTW.fftw_cleanup_threads();
       }
     }

--- a/modules/packages/HDF5.chpl
+++ b/modules/packages/HDF5.chpl
@@ -3669,7 +3669,7 @@ module HDF5 {
      clear the contents of an existing file.  `Append` will add to a file
      that already exists.  Both will open a new empty file.
    */
-  enum Hdf5OpenMode { Truncate, Append };
+  enum Hdf5OpenMode { Truncate, Append }
 
   /* Write the arrays from the :record:`ArrayWrapper` records stored in
      the `data` argument to the corresponding filename in the

--- a/modules/packages/LAPACK.chpl
+++ b/modules/packages/LAPACK.chpl
@@ -125,7 +125,7 @@ We anticipate the following additions:
 module LAPACK {
 
   /* Available LAPACK implementations for ``lapackImpl`` */
-  enum LapackImpl {lapack, mkl, off};
+  enum LapackImpl {lapack, mkl, off}
   use LapackImpl;
   use CTypes;
 
@@ -208,7 +208,7 @@ extern const LAPACK_TRANSPOSE_MEMORY_ERROR : c_int ;
 
 The enum values values are the same as the const value such that ``lapack_memory_order.row_major == LAPACK_ROW_MAJOR`` and ``lapack_memory_order.column_major == LAPACK_COL_MAJOR``, allowing the enum to be used with pure LAPACK procedures.
  */
-enum lapack_memory_order{row_major = 101 : c_int, column_major = 102 : c_int};
+enum lapack_memory_order{row_major = 101 : c_int, column_major = 102 : c_int}
 
 
 @chpldoc.nodoc

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -664,12 +664,12 @@ proc Matrix(const Arrays ...?n, type eltType) {
   var M: [{dim1, dim2}] eltType;
 
   if (isHomogeneousTuple(Arrays)) {
-    forall i in dim1 with (ref Arrays) do {
+    forall i in dim1 with (ref Arrays) {
       if Arrays(i).size != Arrays(0).size then halt("Matrix() expected arrays of equal length");
       M[i, ..] = Arrays(i): eltType;
     }
   } else {
-    for param i in 0..<n do {
+    for param i in 0..<n {
       if Arrays(i).size != Arrays(0).size then halt("Matrix() expected arrays of equal length");
       M[i, ..] = Arrays(i): eltType;
     }
@@ -1750,7 +1750,7 @@ enum normType {
     Frobenius norm
   */
   normFrob
-};
+}
 
 /*
   Compute the norm indicated by `p` on the 1D array `x`.
@@ -2497,7 +2497,7 @@ proc expm(A: [], param useExactOneNorm=true) throws {
   var V = mat[1];
   var X = solvePQ(U, V);
   // According to the paper X = r_13(A)^(2^s): achieved by repeated squaring.
-  for i in 1..s {
+  for 1..s {
     X = dot(X, X);
   }
   return X;
@@ -3450,7 +3450,7 @@ module Sparse {
         end = D.shape(0);
       }
       var indices : [start..end] (D.idxType, D.idxType);
-      forall ind in {start..end} with (ref indices) {
+      forall ind in start..end with (ref indices) {
         indices[ind] = (ind, ind+k);
       }
       D.bulkAdd(indices, dataSorted=true, isUnique=true, preserveInds=false);

--- a/modules/packages/LinearAlgebraJama.chpl
+++ b/modules/packages/LinearAlgebraJama.chpl
@@ -1592,7 +1592,7 @@ class Matrix {
       this.aDom = {1..m, 1..n};
       init this;
 
-      for i in 1..m {
+      for 1..m {
          if (this.aDom.high(1) != n) {
             assert((this.aDom.high(1) != n), "All rows must have the same length.");
          }

--- a/modules/packages/LockFreeQueue.chpl
+++ b/modules/packages/LockFreeQueue.chpl
@@ -208,7 +208,7 @@ module LockFreeQueue {
     }
 
     iter drain(param tag : iterKind) : objTypeOpt where tag == iterKind.standalone {
-      coforall tid in 1..here.maxTaskPar {
+      coforall 1..here.maxTaskPar {
         var tok = getToken();
         var (hasElt, elt) = dequeue(tok);
         while hasElt {

--- a/modules/packages/LockFreeStack.chpl
+++ b/modules/packages/LockFreeStack.chpl
@@ -187,7 +187,7 @@ module LockFreeStack {
     }
 
     iter drain(param tag : iterKind) : objTypeOpt where tag == iterKind.standalone {
-      coforall tid in 1..here.maxTaskPar {
+      coforall 1..here.maxTaskPar {
         var tok = getToken();
         var (hasElt, elt) = pop(tok);
         while hasElt {

--- a/modules/packages/NPBRandom.chpl
+++ b/modules/packages/NPBRandom.chpl
@@ -485,7 +485,7 @@
     iter NPBRandomPrivate_iterate(type resultType, D: domain, seed: int(64),
                          start: int(64)) {
       var cursor = randlc_skipto(seed, start);
-      for i in D do
+      for D do
         yield randlc(resultType, cursor);
     }
 
@@ -515,7 +515,7 @@
           myStart += multiplier * ZD.indexOrder(innerRange.lowBound).safeCast(int(64));
         if innerRange.hasUnitStride() {
           cursor = randlc_skipto(seed, myStart);
-          for i in innerRange do
+          for innerRange do
             yield randlc(resultType, cursor);
         } else {
           myStart -= innerRange.lowBound.safeCast(int(64));

--- a/modules/packages/Socket.chpl
+++ b/modules/packages/Socket.chpl
@@ -332,9 +332,9 @@ proc tcpConn.serialize(writer, ref serializer) throws {
 private extern proc sizeof(e): c_size_t;
 
 @chpldoc.nodoc
-extern "struct event_base" record event_base {};
+extern "struct event_base" record event_base {}
 @chpldoc.nodoc
-extern "struct event" record event {};
+extern "struct event" record event {}
 @chpldoc.nodoc
 extern type pthread_t;
 @chpldoc.nodoc

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -1714,7 +1714,7 @@ module SampleSortHelp {
     var arrayIndex = start_n + sampleStep - 1;
     var splitterIndex = 0;
     splitters[splitterIndex] = A[arrayIndex:idxType];
-    for i in 2..numBuckets-1 {
+    for 2..numBuckets-1 {
       arrayIndex += sampleStep;
       // Skip duplicates
       if chpl_compare(splitters[splitterIndex], A[arrayIndex:idxType], criterion)!=0 {
@@ -1735,7 +1735,7 @@ module SampleSortHelp {
     // Fill the array to the next power of two
     var logBuckets = log2(uniqueSplitters) + 1;
     numBuckets = 1 << logBuckets;
-    for i in uniqueSplitters+1 .. numBuckets-1 {
+    for uniqueSplitters+1 .. numBuckets-1 {
       splitterIndex += 1;
       splitters[splitterIndex] = A[arrayIndex];
     }
@@ -2195,7 +2195,7 @@ module SequentialInPlacePartitioning {
         end = end_n;
       }
 
-      for (i,bin) in bucketizer.classify(A, start, end, criterion, startbit) {
+      for (_,bin) in bucketizer.classify(A, start, end, criterion, startbit) {
         counts[bin] += 1;
       }
     }
@@ -2421,7 +2421,7 @@ module TwoArrayPartitioning {
       for bin in 0..#nBuckets {
         counts[bin] = 0;
       }
-      for (i,bin) in state.bucketizer.classify(src, start, end,
+      for (_,bin) in state.bucketizer.classify(src, start, end,
                                                criterion, startbit) {
         counts[bin] += 1;
       }
@@ -3082,13 +3082,13 @@ module TwoArrayDistributedPartitioning {
         for t in distTask.tasks {
           if !t.isEmpty() {
             if t.useSecondState {
-              for (loc, tid) in t.localeAndIds(A) {
+              for (_, tid) in t.localeAndIds(A) {
                 assert(!usedLocales2[tid]); // means race condition would occur
                 usedLocales2[tid] = true;
               }
 
             } else {
-              for (loc, tid) in t.localeAndIds(A) {
+              for (_, tid) in t.localeAndIds(A) {
                 assert(!usedLocales1[tid]); // means race condition would occur
                 usedLocales1[tid] = true;
               }
@@ -3850,7 +3850,7 @@ module MSBRadixSort {
         }
       }
 
-      forall (bin,(bin_start,bin_end)) in zip(0..#nbigsubs,bigsubs) with (ref A) {
+      forall (_,(bin_start,bin_end)) in zip(0..#nbigsubs,bigsubs) with (ref A) {
         msbRadixSort(A, bin_start, bin_end, criterion, subbits, endbit, settings);
       }
     } else {

--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -458,7 +458,7 @@ module TomlParser {
    fieldEmpty,
    fieldDate,
    fieldTime,
-   fieldDateTime };
+   fieldDateTime }
  private use fieldtag;
 
  @chpldoc.nodoc

--- a/modules/packages/UnrolledLinkedList.chpl
+++ b/modules/packages/UnrolledLinkedList.chpl
@@ -108,7 +108,7 @@ module UnrolledLinkedList {
       data[size] = x;
       size += 1;
     }
-  };
+  }
 
   record unrolledLinkedList : writeSerializable {
 

--- a/modules/packages/VisualDebug.chpl
+++ b/modules/packages/VisualDebug.chpl
@@ -77,7 +77,7 @@ module VisualDebug
 */
 
 @chpldoc.nodoc
-  enum vis_op {v_start, v_stop, v_tag, v_pause};
+  enum vis_op {v_start, v_stop, v_tag, v_pause}
 
 private iter hc_id2com ( id: int, off: int ) {
    var offset = off;

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -1883,7 +1883,7 @@ module BigInteger {
     maybePrime,
     /* Indicates that the number is a prime. */
     isPrime
-  };
+  }
 
   /*
     Determine whether ``this`` is prime.  Returns one of the :enum:`primality`

--- a/modules/standard/ChplConfig.chpl
+++ b/modules/standard/ChplConfig.chpl
@@ -129,7 +129,7 @@ module ChplConfig {
   CHPL_MEM = __primitive("get compiler variable", "CHPL_MEM");
 
   /* See :ref:`readme-chplenv.CHPL_MAKE` for more information. */
-  @unstable("'ChplConfig.CHPL_MAKE' is unstable and may be replaced with a different way to access this information in the future");
+  @unstable("'ChplConfig.CHPL_MAKE' is unstable and may be replaced with a different way to access this information in the future")
   param CHPL_MAKE:string;
   CHPL_MAKE = __primitive("get compiler variable", "CHPL_MAKE");
 

--- a/modules/standard/CommDiagnostics.chpl
+++ b/modules/standard/CommDiagnostics.chpl
@@ -334,7 +334,7 @@ module CommDiagnostics
       if first then writer.write("<no communication>");
       writer.write(")");
     }
-  };
+  }
 
   /*
     The Chapel record type inherits the comm layer definition of it.

--- a/modules/standard/DynamicIters.chpl
+++ b/modules/standard/DynamicIters.chpl
@@ -165,7 +165,7 @@ where tag == iterKind.follower
   const current:rType=unDensify(followThis(0),c);
   if debugDynamicIters then
     writeln("Follower received range ", followThis, " ; shifting to ", current);
-  for i in current do {
+  for i in current {
     yield i;
   }
 }
@@ -307,7 +307,7 @@ where tag == iterKind.leader
     const factor=nTasks;
     var lock: chpl_LocalSpinlock;
 
-    coforall tid in 0..#nTasks with (ref remain) do {
+    coforall tid in 0..#nTasks with (ref remain) {
       while undone.read() do {
         // There is local work in remain(tid)
         const current:rType=adaptSplit(remain, factor, undone, lock);
@@ -331,7 +331,7 @@ where tag == iterKind.follower
   const current:rType=unDensify(followThis(0),c);
   if debugDynamicIters then
     writeln("Follower received range ", followThis, " ; shifting to ", current);
-  for i in current do {
+  for i in current {
     yield i;
   }
 }
@@ -413,7 +413,7 @@ iter guided(param tag:iterKind, c:domain, numTasks:int, parDim:int, followThis)
 where tag == iterKind.follower
 {
   // Invoke the default rectangular domain follower iterator.
-  for i in c.these(tag=iterKind.follower, followThis=followThis) do {
+  for i in c.these(tag=iterKind.follower, followThis=followThis) {
     yield i;
   }
 }
@@ -476,7 +476,7 @@ enum Method {
     in the victim range is performed from its tail.
   */
   WholeTail = 2
-};
+}
 
 /*
   Used to select the adaptive stealing method.
@@ -541,7 +541,7 @@ where tag == iterKind.leader
 
       // Step 2: While there is work at tid, do splitting
 
-      while moreLocalWork[tid] do {
+      while moreLocalWork[tid] {
         // There is local work
         // The current range we get after splitting locally
         const zeroBasedIters:rType=adaptSplit(localWork[tid], factorSteal, moreLocalWork[tid], locks[tid]);
@@ -558,7 +558,7 @@ where tag == iterKind.leader
       var victim=(tid+1) % nTasks;
       var stealFailed:bool=false;
 
-      while moreWork.read() do {
+      while moreWork.read() {
         if debugDynamicIters then
           writeln("Entering at Stealing phase in tid ", tid," with victim ", victim, " using method of Stealing ", methodStealing);
 
@@ -620,7 +620,7 @@ where tag == iterKind.follower
   var current:rType=unDensify(followThis(0),c);
   if debugDynamicIters then
     writeln("Follower received range ", followThis, " ; shifting to ", current);
-  for i in current do {
+  for i in current {
     yield i;
   }
 }
@@ -703,7 +703,7 @@ iter adaptive(param tag:iterKind, c:domain, numTasks:int, parDim:int, followThis
 where tag == iterKind.follower
 {
   // Invoke the default rectangular domain follower iterator.
-  for i in c.these(tag=iterKind.follower, followThis=followThis) do {
+  for i in c.these(tag=iterKind.follower, followThis=followThis) {
     yield i;
   }
 }

--- a/modules/standard/Errors.chpl
+++ b/modules/standard/Errors.chpl
@@ -248,7 +248,7 @@ module Errors {
         var curnext = curr._next;
         if const asTaskErr = curr: unmanaged TaskErrors? {
           on asTaskErr do
-            for e in asTaskErr do
+            for asTaskErr do
               n += 1;
         } else {
           n += 1;
@@ -433,7 +433,7 @@ module Errors {
     /* Returns `true` if this :class:`TaskErrors` contains an error
        of the given type or a subclass of that type. */
     proc contains(type t) {
-      for e in filter(t) {
+      for filter(t) {
         return true;
       }
       return false;

--- a/modules/standard/GpuDiagnostics.chpl
+++ b/modules/standard/GpuDiagnostics.chpl
@@ -56,7 +56,7 @@ module GpuDiagnostics
     var host_to_device: uint(64);
     var device_to_host: uint(64);
     var device_to_device: uint(64);
-  };
+  }
 
   /*
     The Chapel record type inherits the runtime definition of it.

--- a/modules/standard/Heap.chpl
+++ b/modules/standard/Heap.chpl
@@ -298,7 +298,7 @@ module Heap {
     */
     proc push(const ref x: list(eltType)) {
       _enter();
-      for e in x do
+      for x do
         _push(x);
       _leave();
     }

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1003,7 +1003,7 @@ extern const QIO_HINT_OWNED:c_int;
 
 // can be left opaque, but we need the correct C type name
 @chpldoc.nodoc
-extern record qio_file_t {};
+extern record qio_file_t {}
 @chpldoc.nodoc
 extern type qio_file_ptr_t = c_ptr(qio_file_t);
 private extern const QIO_FILE_PTR_NULL:qio_file_ptr_t;
@@ -1017,7 +1017,7 @@ extern record qiovec_t {
 
 // opaque like qio_file_t
 @chpldoc.nodoc
-extern record qio_channel_t {};
+extern record qio_channel_t {}
 @chpldoc.nodoc
 extern type qio_channel_ptr_t = c_ptr(qio_channel_t);
 private extern const QIO_CHANNEL_PTR_NULL:qio_channel_ptr_t;
@@ -9227,7 +9227,7 @@ proc fileReader.readBinary(ref data: [?d] ?t, param endian = endianness.native):
         numRead /= c_sizeof(t): numRead.type;  // convert from #bytes to #elts
       } // else no-op, reading a 0-element array reads nothing
     } else {
-      for (i, b) in zip(data.domain, data) {
+      for (_, b) in zip(data.domain, data) {
         e = try _read_binary_internal(this._channel_internal,
                                       endianToIoKind(endian), b);
 

--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -160,7 +160,7 @@ module List {
     type eltType;
 
     /*If `true`, this list will perform parallel safe operations.*/
-    @unstable("'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future");
+    @unstable("'list.parSafe' is unstable and is expected to be replaced by a separate list type in the future")
     param parSafe = false;
 
     @chpldoc.nodoc

--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -92,7 +92,7 @@ module Map {
     type valType;
 
     /* If `true`, this map will perform parallel safe operations. */
-    @unstable("'map.parSafe' is unstable and is expected to be replaced by a separate map type in the future");
+    @unstable("'map.parSafe' is unstable and is expected to be replaced by a separate map type in the future")
     param parSafe = false;
 
     /*

--- a/modules/standard/MemDiagnostics.chpl
+++ b/modules/standard/MemDiagnostics.chpl
@@ -103,7 +103,7 @@ private extern proc chpl_memoryUsed(): uint(64);
   be expressed either as individual bytes or as chunks of 2**10,
   2**20, or 2**30 bytes.
  */
-enum MemUnits {Bytes, KB, MB, GB};
+enum MemUnits {Bytes, KB, MB, GB}
 
 /*
   How much physical memory is present on this locale?

--- a/modules/standard/OS.chpl
+++ b/modules/standard/OS.chpl
@@ -808,7 +808,7 @@ module OS {
     extern const FD_SETSIZE:c_int;
 
     /* Contains a fixed amount of file descriptors. */
-    extern record fd_set {};
+    extern record fd_set {}
 
     /* Clears the bit for the file descriptor ``fd`` in ``fdset``. */
     proc FD_CLR(fd:c_int, fdset:c_ptr(fd_set)) {
@@ -998,7 +998,7 @@ module OS {
       var tz_minuteswest:c_int;
       /* Type of DST correction */
       var tz_dsttime:c_int;
-    };
+    }
 
     /*
       Get the date and time, based on the timezone in ``tzp``.
@@ -1030,7 +1030,7 @@ module OS {
       var tm_yday:c_int;
       /* Daylight Savings flag */
       var tm_isdst:c_int;
-    };
+    }
 
     /* Get the date and time as a string. */
     extern proc asctime(timeptr:c_ptr(struct_tm)):c_ptr(c_char);

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -215,7 +215,7 @@ proc commonPath(paths: string ...?n): string {
   var pos = prefixList.size;   // rightmost index of common prefix
   var minPathLength = prefixList.size;
 
-  for i in 1..n-1 do {
+  for i in 1..n-1 {
 
     var tempList = new list(string);
     for x in paths(i).split(pathSep, -1, false) do
@@ -296,7 +296,7 @@ proc commonPath(paths: []): string {
   var pos = prefixList.size;   // rightmost index of common prefix
   var minPathLength = prefixList.size;
 
-  for i in (start+1)..end do {
+  for i in (start+1)..end {
 
     var tempList = new list(string);
     for x in paths[i].split(delimiter, -1, false) do
@@ -681,7 +681,7 @@ proc relPath(path: string, start:string=curDir): string throws {
 
   // Append up-levels until we reach the point where the paths diverge.
   var outComps = new list(string);
-  for i in 1..(startComps.size - prefixLen) do
+  for 1..(startComps.size - prefixLen) do
     outComps.pushBack(parentDir);
 
   // Append the portion of path following the common prefix.

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -1992,7 +1992,7 @@ module Random {
             var (found, indexChosen) = Search.binarySearch(cumulativeArr, randNum);
             if !indicesChosen.contains(indexChosen) {
               indicesChosen += indexChosen;
-              samples[i] = X.dim(0).orderToIndex(indexChosen);;
+              samples[i] = X.dim(0).orderToIndex(indexChosen);
               i += 1;
             }
             P[indexChosen] = 0;
@@ -3277,7 +3277,7 @@ module Random {
     iter PCGRandomPrivate_iterate(type resultType, D: domain, seed: int(64),
                                   start: int(64)) {
       var cursor = randlc_skipto(resultType, seed, start);
-      for i in D do
+      for D do
         yield randlc(resultType, cursor);
     }
 
@@ -3306,7 +3306,7 @@ module Random {
           myStart += multiplier * ZD.indexOrder(innerRange.lowBound).safeCast(int(64));
         if innerRange.hasUnitStride() {
           var cursor = randlc_skipto(resultType, seed, myStart);
-          for i in innerRange do
+          for innerRange do
             yield randlc(resultType, cursor);
         } else {
           myStart -= innerRange.lowBound.safeCast(int(64));
@@ -3324,7 +3324,7 @@ module Random {
                                           min: resultType, max: resultType) {
       var cursor = randlc_skipto(resultType, seed, start);
       var count = start;
-      for i in D {
+      for D {
         yield randlc_bounded(resultType, cursor, seed, count, min, max);
         count += 1;
       }
@@ -3360,7 +3360,7 @@ module Random {
         if innerRange.hasUnitStride() {
           var cursor = randlc_skipto(resultType, seed, myStart);
           var count = myStart;
-          for i in innerRange {
+          for innerRange {
             yield randlc_bounded(resultType, cursor, seed, count, min, max);
             count += 1;
           }

--- a/modules/standard/Time.chpl
+++ b/modules/standard/Time.chpl
@@ -1286,7 +1286,7 @@ module Time {
   operator dateTime.:(x: dateTime, type t: string) {
     proc zeroPad(nDigits: int, i: int) {
       var numStr = i: string;
-      for i in 1..nDigits-numStr.size {
+      for 1..nDigits-numStr.size {
         numStr = "0" + numStr;
       }
       return numStr;
@@ -1861,7 +1861,7 @@ module Time {
     if microseconds != 0 {
       str += ".";
       const usLog10 = Math.log10(microseconds): int;
-      for i in 1..(5-usLog10) {
+      for 1..(5-usLog10) {
         str += "0";
       }
 


### PR DESCRIPTION
This PR uses the new `--fixit` functionality of `chplcheck` to auto-detect and auto-fix code to be Chapeltastic. All of the code was checked by hand after the fixits were applied to ensure only correct code was emitted.

Testing
- [x] paratest
- [x] paratest with gasnet

[Reviewed by @DanilaFe]