### PR TITLE
Fix two bugs in CLS

### DIFF
--- a/tools/chapel-py/src/method-tables/core-methods.h
+++ b/tools/chapel-py/src/method-tables/core-methods.h
@@ -93,9 +93,7 @@ CLASS_BEGIN(Scope)
                  auto& id = moduleIds[i];
                  if (!reportedIds.insert(id).second) continue;
                  auto ast = parsing::idToAst(context, id);
-                 auto mod = ast->toModule();
-                 CHPL_ASSERT(mod != nullptr);
-                 toReturn.push_back(mod);
+                 if (auto mod = ast->toModule()) toReturn.push_back(mod);
                }
                return toReturn)
   PLAIN_GETTER(Scope, parent_scope, "Get the parent (outer) scope of this scope",

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -1635,19 +1635,16 @@ def run_lsp():
         if not node_and_loc:
             return None
 
-        # only add highlights for the current document
-        should_add = lambda x: x.get_uri() == text_doc_uri
-
         # todo: it would be nice if this differentiated between read and write
         highlights = []
-        if should_add(node_and_loc):
+        # only highlight the declaration if it is in the current document
+        if node_and_loc.get_uri() == text_doc_uri:
             dh = DocumentHighlight(node_and_loc.rng, DocumentHighlightKind.Text)
             highlights.append(dh)
         uses = fi.uses_here.get(node_and_loc.node.unique_id(), [])
         highlights += [
             DocumentHighlight(use.rng, DocumentHighlightKind.Text)
             for use in uses
-            if should_add(use)
         ]
 
         return highlights


### PR DESCRIPTION
Fixes two different bugs in CLS

1. CLS would crash with the following code (#24843)
    ```chapel
    enum myEnum {a, b, c};
    use myEnum;
    ```

2. Visual glitch with symbol highlighting. Locations from other modules where incorrectly being applied to the current document

Tested locally

[Reviewed by @DanilaFe]

resolves #24843