### PR TITLE
Require FI_ORDER_RMA_WAW with message-order-fence MCM

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1694,9 +1694,11 @@ struct fi_info* setCheckMsgOrderFenceProv(struct fi_info* info,
   //
   // Note: we don't ask for FI_ORDER_ATOMIC_RAW because the some providers
   // doesn't support it.  FI_ORDER_ATOMIC_WAR ordering is enforced by the
-  // MCM.
+  // MCM. We need FI_ORDER_RMA_WAW to ensure sequential consistency of
+  // writes.
   //
   uint64_t need_msg_orders =   FI_ORDER_ATOMIC_WAW
+                             | FI_ORDER_RMA_WAW
                              | FI_ORDER_SAS;
   if (set) {
     // Only use this mode if the tasking layer has a fixed number of threads.


### PR DESCRIPTION
Sequential consistency requires that multiple writes to the same memory address occur in program order. This requires `FI_ORDER_RMA_WAW` ordering guarantees when in the `message-order-fence` MCM mode.