### PR TITLE
Rename a function to make it clearer that it returns non-module IDs

### DIFF
--- a/frontend/include/chpl/resolution/scope-queries.h
+++ b/frontend/include/chpl/resolution/scope-queries.h
@@ -144,12 +144,12 @@ namespace resolution {
 
 
   /**
-   * Given a scope, returns a list of IDs for all the modules that were either
-   * used or imported in that scope. May return an empty vector if no modules
-   * were used or imported in the scope.
+   * Given a scope, returns a list of IDs for all the modules and enums that
+   * were either used or imported in that scope. May return an empty vector if
+   * no modules were used or imported in the scope.
    */
-  const std::vector<ID> findUsedImportedModules(Context* context,
-                                                const Scope* scope);
+  const std::vector<ID> findUsedImportedIds(Context* context,
+                                            const Scope* scope);
 
   /**
     Resolve the uses and imports in a given scope.

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -2657,7 +2657,7 @@ const Scope* scopeForModule(Context* context, ID id) {
 
 
 const
-std::vector<ID> findUsedImportedModules(Context* context,
+std::vector<ID> findUsedImportedIds(Context* context,
                                         const Scope* scope) {
   auto result = resolveVisibilityStmts(context, scope);
   std::vector<ID> ids;

--- a/tools/chapel-py/src/method-tables/core-methods.h
+++ b/tools/chapel-py/src/method-tables/core-methods.h
@@ -86,7 +86,7 @@ CLASS_BEGIN(Scope)
   PLAIN_GETTER(Scope, used_imported_modules, "Get the modules that were used or imported in this scope",
                std::vector<const chpl::uast::Module*>,
 
-               auto& moduleIds = resolution::findUsedImportedModules(context, node);
+               auto& moduleIds = resolution::findUsedImportedIds(context, node);
                std::set<ID> reportedIds;
                std::vector<const chpl::uast::Module*> toReturn;
                for (size_t i = 0; i < moduleIds.size(); i++) {

--- a/tools/chpldoc/chpldoc.cpp
+++ b/tools/chpldoc/chpldoc.cpp
@@ -1867,7 +1867,7 @@ struct GatherModulesVisitor {
   void handleUseOrImport(const AstNode* node) {
     if (processUsedModules_) {
       auto scope = resolution::scopeForId(context_, node->id());
-      auto used = resolution::findUsedImportedModules(context_, scope);
+      auto used = resolution::findUsedImportedIds(context_, scope);
       for (auto id: used) {
         if (idIsInBundledModule(context_, id)) {
           continue;


### PR DESCRIPTION
The function `findUsedImportedModules` doesn't just return modules, it also returns enums. Thus, the name is misleading; I renamed the function to fit its actual purpose.

Reviewed by @mppf  -- thanks!

## Testing
- [x] dyno tests
- [x] paratest (including `chpldoc` and `chapel-py`)