### PR TITLE
Remove compiler code for LLVM 10 and below

### DIFF
--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -2769,11 +2769,7 @@ static GenRet codegenCallExprInner(GenRet genFn, std::vector<GenRet>& args,
 
     // Emit the indirect call.
     llvm::CallInst* c = nullptr;
-    #if HAVE_LLVM_VER >= 90
     c = info->irBuilder->CreateCall(fnType, val, llArgs);
-    #else
-    c = info->irBuilder->CreateCall(val, llArgs);
-    #endif
 
     ret.val = c;
 
@@ -3120,11 +3116,7 @@ static GenRet codegenCallExprInner(GenRet function,
       c = info->irBuilder->CreateCall(func, llArgs);
     } else {
       if (!fnType) INT_FATAL("Could not compute called function type");
-#if HAVE_LLVM_VER >= 90
       c = info->irBuilder->CreateCall(fnType, val, llArgs);
-#else
-      c = info->irBuilder->CreateCall(val, llArgs);
-#endif
     }
 
     if (func) {
@@ -3517,7 +3509,6 @@ void codegenCallMemcpy(GenRet dest, GenRet src, GenRet size,
     llvm::Function *func = llvm::Intrinsic::getDeclaration(info->module, llvm::Intrinsic::memcpy, types);
     //llvm::FunctionType *fnType = func->getFunctionType();
 
-#if HAVE_LLVM_VER >= 70
     // LLVM 7 and later: memcpy has no alignment argument
     llvm::Value* llArgs[4];
 
@@ -3528,21 +3519,6 @@ void codegenCallMemcpy(GenRet dest, GenRet src, GenRet size,
     // LLVM memcpy intrinsic has additional argument isvolatile
     // isVolatile?
     llArgs[3] = llvm::ConstantInt::get(llvm::Type::getInt1Ty(info->module->getContext()), 0, false);
-
-#else
-    // LLVM 6 and earlier: memcpy had alignment argument
-    llvm::Value* llArgs[5];
-
-    llArgs[0] = convertValueToType(dest.val, types[0], false);
-    llArgs[1] = convertValueToType(src.val, types[1], false);
-    llArgs[2] = convertValueToType(size.val, types[2], false);
-
-    // LLVM memcpy intrinsic has additional arguments alignment, isvolatile
-    // alignment
-    llArgs[3] = llvm::ConstantInt::get(llvm::Type::getInt32Ty(info->module->getContext()), 0, false);
-    // isVolatile?
-    llArgs[4] = llvm::ConstantInt::get(llvm::Type::getInt1Ty(info->module->getContext()), 0, false);
-#endif
 
     // We can't use IRBuilder::CreateMemCpy because that adds
     //  a cast to i8 (in address space 0).

--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -1008,14 +1008,7 @@ void VarSymbol::codegenDef() {
       info->lvt->addGlobalValue(cname, globalValue, GEN_VAL, ! is_signed(type), type);
     }
 
-#if HAVE_LLVM_VER >= 100
-    llvm::MaybeAlign alignment;
-#else
-    unsigned alignment = 0;
-#endif
-
-    alignment = getAlignment(type);
-
+    llvm::MaybeAlign alignment = getAlignment(type);
     llvm::Type *varType = type->codegen().type;
     llvm::AllocaInst *varAlloca = createVarLLVM(varType, cname);
 
@@ -2097,11 +2090,7 @@ codegenFunctionTypeLLVM(FnSymbol* fn, llvm::AttributeList& attrs,
           if (argInfo->getInReg()) b.addAttribute(llvm::Attribute::InReg);
 
           if (argInfo->getIndirectByVal()) {
-          #if HAVE_LLVM_VER >= 90
             b.addByValAttr(argTy);
-          #else
-            b.addAttribute(llvm::Attribute::ByVal);
-          #endif
           }
 
           clang::CharUnits align = argInfo->getIndirectAlign();
@@ -2903,17 +2892,9 @@ void FnSymbol::codegenDef() {
             //
             if (srcSize > dstSize) {
               irBuilder->CreateMemCpy(ptr,
-#if HAVE_LLVM_VER >= 100
                                       llvm::MaybeAlign(),
-#else
-                                      0,
-#endif
                                       storeAdr,
-#if HAVE_LLVM_VER >= 100
                                       llvm::MaybeAlign(),
-#else
-                                      0,
-#endif
                                       dstSize);
             }
 

--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -2891,11 +2891,8 @@ void FnSymbol::codegenDef() {
             // if we allocated a temporary, memcpy from it to the main var
             //
             if (srcSize > dstSize) {
-              irBuilder->CreateMemCpy(ptr,
-                                      llvm::MaybeAlign(),
-                                      storeAdr,
-                                      llvm::MaybeAlign(),
-                                      dstSize);
+              irBuilder->CreateMemCpy(ptr, llvm::MaybeAlign(),
+                                      storeAdr, llvm::MaybeAlign(), dstSize);
             }
 
             info->lvt->addValue(arg->cname, tmp.val,

--- a/compiler/codegen/cg-type.cpp
+++ b/compiler/codegen/cg-type.cpp
@@ -377,11 +377,7 @@ void AggregateType::codegenDef() {
 #ifdef HAVE_LLVM
       int paramID = 0;
       std::vector<llvm::Type*> params;
-#if HAVE_LLVM_VER >= 100
       std::vector<llvm::MaybeAlign> aligns;
-#else
-      std::vector<unsigned> aligns;
-#endif
 
       if ((symbol->hasFlag(FLAG_OBJECT_CLASS) && aggregateTag == AGGREGATE_CLASS)) {
         llvm::Type* cidType = info->lvt->getType("chpl__class_id");
@@ -518,11 +514,7 @@ void AggregateType::codegenDef() {
         if (aligns.size() == params.size()) {
           for (size_t i = 0; i < params.size(); i++) {
             unsigned offset = info->module->getDataLayout().getStructLayout(stype)->getElementOffset(i);
-#if HAVE_LLVM_VER >= 100
             unsigned align = 1 << Log2(aligns[i].valueOrOne());
-#else
-            unsigned align = aligns[i];
-#endif
             if ((offset % align) != 0) {
               // Not aligned. Issue an error. In the future, we expect to add
               // padding to make it aligned.

--- a/compiler/include/clangUtil.h
+++ b/compiler/include/clangUtil.h
@@ -30,10 +30,7 @@
 // a bunch of clang stuff.
 #include "LayeredValueTable.h"
 #include "llvmUtil.h"
-
-#if HAVE_LLVM_VER >= 100
 #include "llvm/Support/Alignment.h"
-#endif
 
 // forward declare some llvm and clang things
 namespace llvm {
@@ -80,18 +77,10 @@ int getCRecordMemberGEP(const char* typeName, const char* fieldName, bool& isCAr
 
 bool isCTypeUnion(const char* name);
 
-#if HAVE_LLVM_VER >= 100
 llvm::MaybeAlign getPointerAlign(int addrSpace);
 llvm::MaybeAlign getCTypeAlignment(const clang::TypeDecl* td);
 llvm::MaybeAlign getCTypeAlignment(const clang::QualType &qt);
 llvm::MaybeAlign getAlignment(Type* type);
-#else
-uint64_t getPointerAlign(int addrSpace);
-unsigned getCTypeAlignment(const clang::TypeDecl* td);
-unsigned getCTypeAlignment(const clang::QualType &qt);
-unsigned getAlignment(Type* type);
-#endif
-
 
 const clang::CodeGen::CGFunctionInfo& getClangABIInfoFD(clang::FunctionDecl* FD);
 const clang::CodeGen::CGFunctionInfo& getClangABIInfo(FnSymbol* fn);

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -4547,8 +4547,7 @@ void setupForGlobalToWide(void) {
   llvm::Type* retType = llvm::Type::getInt8PtrTy(ginfo->module->getContext());
   llvm::Type* argType = llvm::Type::getInt64Ty(ginfo->module->getContext());
   llvm::Value* fval = ginfo->module->getOrInsertFunction(
-                          dummy, retType, argType
-                          ).getCallee();
+                        dummy, retType, argType).getCallee();
   llvm::Function* fn = llvm::dyn_cast<llvm::Function>(fval);
 
   // Mark the function as external so that it will not be removed
@@ -5224,10 +5223,8 @@ static void llvmEmitObjectFile(void) {
         emitPM.add(createTargetTransformInfoWrapperPass(
                    info->targetMachine->getTargetIRAnalysis()));
 
-        info->targetMachine->addPassesToEmitFile(emitPM, outputOfile,
-                                                 nullptr,
-                                                 FileType,
-                                                 disableVerify);
+        info->targetMachine->addPassesToEmitFile(emitPM, outputOfile, nullptr,
+                                                 FileType, disableVerify);
 
         emitPM.run(*info->module);
 

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -78,6 +78,7 @@
 #else
 #include "llvm/Support/Host.h"
 #endif
+#include "llvm/Support/CodeGen.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/TargetSelect.h"
@@ -98,10 +99,6 @@ using LlvmOptimizationLevel = llvm::OptimizationLevel;
 #else
 #include "llvm/Support/TargetRegistry.h"
 using LlvmOptimizationLevel = llvm::PassBuilder::OptimizationLevel;
-#endif
-
-#if HAVE_LLVM_VER >= 90
-#include "llvm/Support/CodeGen.h"
 #endif
 
 #ifdef HAVE_LLVM_RV
@@ -1753,17 +1750,10 @@ void setupClang(GenInfo* info, std::string mainFile)
   //CompilerInvocation* CI =
   //  createInvocationFromCommandLine(clangArgs, clangInfo->Diags);
 
-#if HAVE_LLVM_VER >= 100
   bool success = CompilerInvocation::CreateFromArgs(
             Clang->getInvocation(),
             job->getArguments(),
             *clangDiags);
-#else
-  bool success = CompilerInvocation::CreateFromArgs(
-            Clang->getInvocation(),
-            &job->getArguments().front(), (&job->getArguments().back())+1,
-            *clangDiags);
-#endif
 
   CompilerInvocation* CI = &Clang->getInvocation();
 
@@ -1951,7 +1941,7 @@ static llvm::TargetOptions getTargetOptions(
 
   Options.FunctionSections = CodeGenOpts.FunctionSections;
   Options.DataSections = CodeGenOpts.DataSections;
-#if LLVM_VERSION_MAJOR == 120
+#if LLVM_VERSION_MAJOR == 12
   // clang::CodeGenOptions::IgnoreXCOFFVisibility first appeared in
   // LLVM version 12 and then went away in version 13.
   Options.IgnoreXCOFFVisibility = CodeGenOpts.IgnoreXCOFFVisibility;
@@ -2439,11 +2429,7 @@ void configurePMBuilder(PassManagerBuilder &PMBuilder, bool forFunctionPasses, i
   PMBuilder.LoopsInterleaved = CodeGenOpts.UnrollLoops;
   PMBuilder.MergeFunctions = CodeGenOpts.MergeFunctions;
 #if HAVE_LLVM_VER < 150
-#if HAVE_LLVM_VER > 60
   PMBuilder.PrepareForThinLTO = CodeGenOpts.PrepareForThinLTO;
-#else
-  PMBuilder.PrepareForThinLTO = CodeGenOpts.EmitSummaryIndex;
-#endif
   PMBuilder.PrepareForLTO = CodeGenOpts.PrepareForLTO;
 #endif
 
@@ -3937,11 +3923,7 @@ const clang::CodeGen::CGFunctionInfo& getClangABIInfoFD(clang::FunctionDecl* FD)
 
   clang::CanQual<clang::FunctionProtoType> proto =
              FTy.getAs<clang::FunctionProtoType>();
-#if HAVE_LLVM_VER >= 90
   return clang::CodeGen::arrangeFreeFunctionType(CGM, proto);
-#else
-  return clang::CodeGen::arrangeFreeFunctionType(CGM, proto, FD);
-#endif
 }
 
 
@@ -4016,23 +3998,8 @@ getCGArgInfo(const clang::CodeGen::CGFunctionInfo* CGI, int curCArg,
     }
   }
 
-  const clang::CodeGen::ABIArgInfo* argInfo = NULL;
-#if HAVE_LLVM_VER >= 100
   llvm::ArrayRef<clang::CodeGen::CGFunctionInfoArgInfo> a=CGI->arguments();
-  argInfo = &a[curCArg].info;
-
-#else
-  int i = 0;
-  for (auto &ii : CGI->arguments()) {
-    if (i == curCArg) {
-      argInfo = &ii.info;
-      break;
-    }
-    i++;
-  }
-#endif
-
-  return argInfo;
+  return &a[curCArg].info;
 }
 
 //
@@ -4190,7 +4157,6 @@ bool isCTypeUnion(const char* name) {
   return false;
 }
 
-#if HAVE_LLVM_VER >= 100
 llvm::MaybeAlign getPointerAlign(int addrSpace) {
   GenInfo* info = gGenInfo;
   INT_ASSERT(info);
@@ -4229,28 +4195,6 @@ llvm::MaybeAlign getAlignment(::Type* type) {
     return llvm::MaybeAlign();
   }
 }
-
-#else
-uint64_t getPointerAlign(int addrSpace) {
-  GenInfo* info = gGenInfo;
-  INT_ASSERT(info);
-  ClangInfo* clangInfo = info->clangInfo;
-  INT_ASSERT(clangInfo);
-
-  uint64_t align = clangInfo->Clang->getTarget().getPointerAlign(0);
-  return align;
-}
-unsigned getCTypeAlignment(const clang::TypeDecl* td) {
-  return helpGetCTypeAlignment(td);
-}
-unsigned getCTypeAlignment(const clang::QualType& qt) {
-  return helpGetCTypeAlignment(qt);
-}
-unsigned getAlignment(::Type* type) {
-  return helpGetAlignment(type);
-}
-#endif
-
 
 bool isBuiltinExternCFunction(const char* cname)
 {
@@ -4604,11 +4548,7 @@ void setupForGlobalToWide(void) {
   llvm::Type* argType = llvm::Type::getInt64Ty(ginfo->module->getContext());
   llvm::Value* fval = ginfo->module->getOrInsertFunction(
                           dummy, retType, argType
-#if HAVE_LLVM_VER < 90
-                          );
-#else
                           ).getCallee();
-#endif
   llvm::Function* fn = llvm::dyn_cast<llvm::Function>(fval);
 
   // Mark the function as external so that it will not be removed
@@ -5276,12 +5216,7 @@ static void llvmEmitObjectFile(void) {
       if (error || outputOfile.has_error())
         USR_FATAL("Could not open output file %s", filenames->moduleFilename.c_str());
 
-#if HAVE_LLVM_VER >= 100
       llvm::CodeGenFileType FileType = llvm::CGFT_ObjectFile;
-#else
-      llvm::TargetMachine::CodeGenFileType FileType =
-        llvm::TargetMachine::CGFT_ObjectFile;
-#endif
 
       {
         llvm::legacy::PassManager emitPM;
@@ -5289,16 +5224,10 @@ static void llvmEmitObjectFile(void) {
         emitPM.add(createTargetTransformInfoWrapperPass(
                    info->targetMachine->getTargetIRAnalysis()));
 
-#if HAVE_LLVM_VER > 60
         info->targetMachine->addPassesToEmitFile(emitPM, outputOfile,
                                                  nullptr,
                                                  FileType,
                                                  disableVerify);
-#else
-        info->targetMachine->addPassesToEmitFile(emitPM, outputOfile,
-                                                 FileType,
-                                                 disableVerify);
-#endif
 
         emitPM.run(*info->module);
 

--- a/compiler/llvm/llvmAggregateGlobalOps.cpp
+++ b/compiler/llvm/llvmAggregateGlobalOps.cpp
@@ -58,20 +58,14 @@
 #include "llvm/ADT/Statistic.h"
 
 #include "llvm/IR/BasicBlock.h"
+#include "llvm/IR/GetElementPtrTypeIterator.h"
 #include "llvm/IR/InstIterator.h"
-
-#if HAVE_LLVM_VER < 90
-#include "llvm/IR/CallSite.h"
-#endif
-
 #include "llvm/IR/Verifier.h"
 
 #include "llvm/Analysis/CallGraph.h"
 #include "llvm/Analysis/LazyCallGraph.h"
 #include "llvm/Analysis/ValueTracking.h"
 #include "llvm/Transforms/Utils/ValueMapper.h"
-
-#include "llvm/IR/GetElementPtrTypeIterator.h"
 
 #include <cstdio>
 #include <list>
@@ -207,94 +201,6 @@ Instruction* postponeDependentInstructions(
 // The next several fns are stolen almost totally unmodified from MemCpyOptimizer.
 // modified code areas say CUSTOM.
 
-#if HAVE_LLVM_VER < 100
-
-static int64_t GetOffsetFromIndex(const GEPOperator *GEP,
-                                  unsigned Idx,
-                                  bool &VariableIdxFound,
-                                  const DataLayout &DL){
-  // Skip over the first indices.
-  gep_type_iterator GTI = gep_type_begin(GEP);
-  for (unsigned i = 1; i != Idx; ++i, ++GTI)
-    /*skip along*/;
-
-  // Compute the offset implied by the rest of the indices.
-  int64_t Offset = 0;
-  for (unsigned i = Idx, e = GEP->getNumOperands(); i != e; ++i, ++GTI) {
-    ConstantInt *OpC = dyn_cast<ConstantInt>(GEP->getOperand(i));
-    if (!OpC)
-      return VariableIdxFound = true;
-    if (OpC->isZero()) continue;  // No offset.
-
-    // Handle struct indices, which add their field offset to the pointer.
-    if (StructType *STy = GTI.getStructTypeOrNull())
-    {
-      Offset += DL.getStructLayout(STy)->getElementOffset(OpC->getZExtValue());
-      continue;
-    }
-
-    // Otherwise, we have a sequential type like an array or vector.  Multiply
-    // the index by the ElementSize.
-    uint64_t Size = DL.getTypeAllocSize(GTI.getIndexedType());
-    Offset += Size*OpC->getSExtValue();
-  }
-
-  return Offset;
-}
-/// IsPointerOffset - Return true if Ptr1 is provably equal to Ptr2 plus a
-/// constant offset, and return that constant offset.  For example, Ptr1 might
-/// be &A[42], and Ptr2 might be &A[40].  In this case offset would be -8.
-static bool IsPointerOffset(Value *Ptr1, Value *Ptr2, int64_t &Offset,
-                            const DataLayout &DL) {
-  Ptr1 = Ptr1->stripPointerCasts();
-  Ptr2 = Ptr2->stripPointerCasts();
-
-  // Handle the trivial case first.
-  if (Ptr1 == Ptr2) {
-    Offset = 0;
-    return true;
-  }
-
-  GEPOperator *GEP1 = dyn_cast<GEPOperator>(Ptr1);
-  GEPOperator *GEP2 = dyn_cast<GEPOperator>(Ptr2);
-
-  bool VariableIdxFound = false;
-
-  // If one pointer is a GEP and the other isn't, then see if the GEP is a
-  // constant offset from the base, as in "P" and "gep P, 1".
-  if (GEP1 && !GEP2 && GEP1->getOperand(0)->stripPointerCasts() == Ptr2) {
-    Offset = -GetOffsetFromIndex(GEP1, 1, VariableIdxFound, DL);
-    return !VariableIdxFound;
-  }
-
-  if (GEP2 && !GEP1 && GEP2->getOperand(0)->stripPointerCasts() == Ptr1) {
-    Offset = GetOffsetFromIndex(GEP2, 1, VariableIdxFound, DL);
-    return !VariableIdxFound;
-  }
-
-  // Right now we handle the case when Ptr1/Ptr2 are both GEPs with an identical
-  // base.  After that base, they may have some number of common (and
-  // potentially variable) indices.  After that they handle some constant
-  // offset, which determines their offset from each other.  At this point, we
-  // handle no other case.
-  if (!GEP1 || !GEP2 || GEP1->getOperand(0) != GEP2->getOperand(0))
-    return false;
-
-  // Skip any common indices and track the GEP types.
-  unsigned Idx = 1;
-  for (; Idx != GEP1->getNumOperands() && Idx != GEP2->getNumOperands(); ++Idx)
-    if (GEP1->getOperand(Idx) != GEP2->getOperand(Idx))
-      break;
-
-  int64_t Offset1 = GetOffsetFromIndex(GEP1, Idx, VariableIdxFound, DL);
-  int64_t Offset2 = GetOffsetFromIndex(GEP2, Idx, VariableIdxFound, DL);
-  if (VariableIdxFound) return false;
-
-  Offset = Offset2-Offset1;
-  return true;
-}
-
-#endif
 
 static chpl::optional<int64_t> getPointerOffset(Value *Ptr1,
                                                Value *Ptr2,
@@ -302,12 +208,8 @@ static chpl::optional<int64_t> getPointerOffset(Value *Ptr1,
   chpl::optional<int64_t> optOffset;
 #if HAVE_LLVM_VER >= 170
   optOffset = Ptr2->getPointerOffsetFrom(Ptr1, DL);
-#elif HAVE_LLVM_VER >= 100
-  optOffset = isPointerOffset(Ptr1, Ptr2, DL);
 #else
-  int64_t Offset;
-  if (IsPointerOffset(Ptr1, Ptr2, Offset, DL))
-    optOffset = Offset;
+  optOffset = isPointerOffset(Ptr1, Ptr2, DL);
 #endif
   return optOffset;
 }
@@ -748,11 +650,7 @@ Instruction *AggregateGlobalOpsOpt::tryAggregating(Instruction *StartInst, Value
 
         StoreInst* newStore =
           irBuilder.CreateStore(oldStore->getValueOperand(), Dst);
-#if HAVE_LLVM_VER >= 100
         newStore->setAlignment(oldStore->getAlign());
-#else
-        newStore->setAlignment(oldStore->getAlignment());
-#endif
         newStore->takeName(oldStore);
       }
     }
@@ -776,13 +674,8 @@ Instruction *AggregateGlobalOpsOpt::tryAggregating(Instruction *StartInst, Value
 
     Function *func = Intrinsic::getDeclaration(M, Intrinsic::memcpy, types);
 
-#if HAVE_LLVM_VER >= 70
     // LLVM 7 and later: memcpy has no alignment argument
     Value* args[4]; // dst src len isvolatile
-#else
-    // LLVM 6 and earlier: memcpy had alignment argument
-    Value* args[5]; // dst src len alignment isvolatile
-#endif
 
     if( isStore ) {
       // it's a store (ie put)
@@ -795,19 +688,10 @@ Instruction *AggregateGlobalOpsOpt::tryAggregating(Instruction *StartInst, Value
     }
     args[2] = len;
 
-#if HAVE_LLVM_VER >= 70
     // LLVM 7 and later: memcpy has no alignment argument
 
     // isvolatile
     args[3] = ConstantInt::get(Type::getInt1Ty(Context), 0, false);
-#else
-    // LLVM 6 and earlier: memcpy had alignment argument
-
-    // alignment
-    args[3] = ConstantInt::get(Type::getInt32Ty(Context), 0, false);
-    // isvolatile
-    args[4] = ConstantInt::get(Type::getInt1Ty(Context), 0, false);
-#endif
 
     Instruction* aMemCpy = irBuilder.CreateCall(func, args);
 
@@ -845,11 +729,7 @@ Instruction *AggregateGlobalOpsOpt::tryAggregating(Instruction *StartInst, Value
 
         LoadInst* newLoad = irBuilder.CreateLoad(LoadType, Src);
 
-#if HAVE_LLVM_VER >= 100
         newLoad->setAlignment(oldLoad->getAlign());
-#else
-        newLoad->setAlignment(oldLoad->getAlignment());
-#endif
         oldLoad->replaceAllUsesWith(newLoad);
         newLoad->takeName(oldLoad);
         lastAddedInsn = newLoad;

--- a/compiler/llvm/llvmDebug.cpp
+++ b/compiler/llvm/llvmDebug.cpp
@@ -561,7 +561,6 @@ llvm::DISubprogram* debug_data::construct_function(FnSymbol *function)
 
   llvm::DISubroutineType* function_type = get_function_type(function);
 
-#if HAVE_LLVM_VER >= 80
   llvm::DISubprogram::DISPFlags SPFlags = llvm::DISubprogram::SPFlagDefinition;
   if (!function->hasFlag(FLAG_EXPORT))
     SPFlags |= llvm::DISubprogram::SPFlagLocalToUnit;
@@ -577,21 +576,6 @@ llvm::DISubprogram* debug_data::construct_function(FnSymbol *function)
     llvm::DINode::FlagZero, /* flags */
     SPFlags /* subprogram flags */
     );
-#else
-  llvm::DISubprogram* ret = this->dibuilder.createFunction(
-    module, /* scope */
-    name, /* name */
-    cname, /* linkage name */
-    file, line_number, function_type,
-    !function->hasFlag(FLAG_EXPORT), /* is local to unit */
-    true, /* is definition */
-    line_number, /* beginning of scope we start */
-    llvm::DINode::FlagZero, /* flags */
-    optimized /* isOptimized */
-    // TODO - in 3.8, do we need to pass Decl?
-    );
-
-#endif
   return ret;
 }
 

--- a/compiler/llvm/llvmExtractIR.cpp
+++ b/compiler/llvm/llvmExtractIR.cpp
@@ -53,15 +53,9 @@ std::unique_ptr<Module> extractLLVM(const llvm::Module* fromModule,
   ValueToValueMapTy VMap;
   // Create a new module containing only the definition of the function
   // and using external declarations for everything else
-#if HAVE_LLVM_VER < 70
-  auto ownedM = CloneModule(fromModule, VMap,
-                            [&](const GlobalValue *GV) {
-                                       return gvs.count(GV) > 0; });
-#else
   auto ownedM = CloneModule(*fromModule, VMap,
                             [&](const GlobalValue *GV) {
                                        return gvs.count(GV) > 0; });
-#endif
   Module& M = *ownedM.get();
 
   // collect names for the next step

--- a/compiler/llvm/llvmGlobalToWide.cpp
+++ b/compiler/llvm/llvmGlobalToWide.cpp
@@ -50,10 +50,6 @@
 #include "llvm/IR/AttributeMask.h"
 #endif
 
-#if HAVE_LLVM_VER < 90
-#include "llvm/IR/CallSite.h"
-#endif
-
 #include "llvm/IR/InstIterator.h"
 #include "llvm/IR/Intrinsics.h"
 #include "llvm/IR/IntrinsicInst.h"
@@ -722,21 +718,13 @@ namespace {
                                              oldLoad->getSyncScopeID()
                                              );
 
-#if HAVE_LLVM_VER >= 90
             Value* call = CallInst::Create(getFnType, getFn, args, "", oldLoad);
-#else
-            Value* call = CallInst::Create(getFn, args, "", oldLoad);
-#endif
             if (call == nullptr) assert(false && "failure creating call");
 
             // Now load from the alloc'd area.
             Instruction* loadedWide = new LoadInst(wLoadedTy, alloc, "",
                                        oldLoad->isVolatile(),
-#if HAVE_LLVM_VER >= 100
                                        oldLoad->getAlign(),
-#else
-                                       oldLoad->getAlignment(),
-#endif
                                        oldLoad->getOrdering(),
                                        oldLoad->getSyncScopeID(),
                                        oldLoad);
@@ -772,11 +760,7 @@ namespace {
             // Now store to the alloc'd area
             Instruction* st = new StoreInst(wValueOp, alloc,
                                             oldStore->isVolatile(),
-#if HAVE_LLVM_VER >= 100
                                             oldStore->getAlign(),
-#else
-                                            oldStore->getAlignment(),
-#endif
                                             oldStore->getOrdering(),
                                             oldStore->getSyncScopeID(),
                                             oldStore);
@@ -802,11 +786,7 @@ namespace {
                                              oldStore->getSyncScopeID()
                                              );
 
-#if HAVE_LLVM_VER >= 90
             Instruction* put = CallInst::Create(putFnType, putFn, args, "", oldStore);
-#else
-            Instruction* put = CallInst::Create(putFn, args, "", oldStore);
-#endif
             myReplaceInstWithInst(oldStore, put);
           }
           break; }
@@ -958,11 +938,7 @@ namespace {
                 args[3] = n;
                 args[4] = ctl;
 
-#if HAVE_LLVM_VER >= 90
                 putget = CallInst::Create(putFnType, putFn, args, "", call);
-#else
-                putget = CallInst::Create(putFn, args, "", call);
-#endif
               } else if( srcSpace == info->globalSpace &&
                          dstSpace != info->globalSpace ) {
                 // It's a GET
@@ -973,11 +949,7 @@ namespace {
                 args[3] = n;
                 args[4] = ctl;
 
-#if HAVE_LLVM_VER >= 90
                 putget = CallInst::Create(getFnType, getFn, args, "", call);
-#else
-                putget = CallInst::Create(getFn, args, "", call);
-#endif
               } else {
                 Value* args[5];
                 args[0] = createRnode(info, wDst, call);
@@ -987,11 +959,7 @@ namespace {
                 args[4] = n;
 
                 assert(getPutFn && "Missing get-put-function for global-to-global memcpy");
-#if HAVE_LLVM_VER >= 90
                 putget = CallInst::Create(getPutFnType, getPutFn, args, "", call);
-#else
-                putget = CallInst::Create(getPutFn, args, "", call);
-#endif
               }
 
               myReplaceInstWithInst(call, putget);
@@ -1016,11 +984,7 @@ namespace {
               args[2] = c;
               args[3] = n;
               assert(memsetFn && "Missing memset-function for global memset");
-#if HAVE_LLVM_VER >= 90
               mset = CallInst::Create(memsetFnType, memsetFn, args, "", call);
-#else
-              mset = CallInst::Create(memsetFn, args, "", call);
-#endif
               myReplaceInstWithInst(call, mset);
             } else {
               assert(false && "Unknown intrinsic call with global pointer");
@@ -1408,13 +1372,10 @@ bool GlobalToWide::run(Module &M) {
       assert(info->putFn);
       assert(info->getPutFn);
       assert(info->memsetFn);
-#if HAVE_LLVM_VER >= 90
       assert(info->getFnType);
       assert(info->putFnType);
       assert(info->getPutFnType);
       assert(info->memsetFnType);
-#endif
-
       assert(info->globalSpace > 0);
       assert(info->localeIdType);
       assert(info->nodeIdType);
@@ -1580,28 +1541,16 @@ bool GlobalToWide::run(Module &M) {
           Use &U = *UI;
           User *Old = U.getUser();
           ++UI;
-#if HAVE_LLVM_VER >= 90
           if (auto *CB = dyn_cast<CallBase>(Old)) {
             assert(CB->getCalledFunction() == F);
             Instruction *Call = CB;
-#else
-          CallSite CS(Old);
-          if (CS.getInstruction()) {
-            assert(CS.getCalledFunction() == F);
-            Instruction *Call = CS.getInstruction();
-#endif
 
             // Loop over the operands, inserting globalToWide function calls in
             // the caller as appropriate.
             unsigned ArgIndex = 1;
 
-#if HAVE_LLVM_VER >= 90
             for(User::op_iterator AE = CB->arg_end(), AI = CB->arg_begin();
                 AI != AE; ++AI, ++ArgIndex) {
-#else
-            for(CallSite::arg_iterator AE = CS.arg_end(), AI = CS.arg_begin();
-                AI != AE; ++AI, ++ArgIndex) {
-#endif
 
               if(!containsGlobalPointers(info, AI->get()->getType())) {
                 // unmodified argument
@@ -1620,22 +1569,12 @@ bool GlobalToWide::run(Module &M) {
             if (InvokeInst *II = dyn_cast<InvokeInst>(Call)) {
               New = InvokeInst::Create(NF, II->getNormalDest(), II->getUnwindDest(),
                                        Args, "", Call);
-#if HAVE_LLVM_VER >= 90
               cast<InvokeInst>(New)->setCallingConv(CB->getCallingConv());
               cast<InvokeInst>(New)->setAttributes(CB->getAttributes());
-#else
-              cast<InvokeInst>(New)->setCallingConv(CS.getCallingConv());
-              cast<InvokeInst>(New)->setAttributes(CS.getAttributes());
-#endif
             } else {
               New = CallInst::Create(NF, Args, "", Call);
-#if HAVE_LLVM_VER >= 90
               cast<CallInst>(New)->setCallingConv(CB->getCallingConv());
               cast<CallInst>(New)->setAttributes(CB->getAttributes());
-#else
-              cast<CallInst>(New)->setCallingConv(CS.getCallingConv());
-              cast<CallInst>(New)->setAttributes(CS.getAttributes());
-#endif
               if (cast<CallInst>(Call)->isTailCall())
                 cast<CallInst>(New)->setTailCall();
             }

--- a/compiler/llvm/llvmGlobalToWide.cpp
+++ b/compiler/llvm/llvmGlobalToWide.cpp
@@ -1376,6 +1376,7 @@ bool GlobalToWide::run(Module &M) {
       assert(info->putFnType);
       assert(info->getPutFnType);
       assert(info->memsetFnType);
+
       assert(info->globalSpace > 0);
       assert(info->localeIdType);
       assert(info->nodeIdType);

--- a/compiler/llvm/llvmUtil.cpp
+++ b/compiler/llvm/llvmUtil.cpp
@@ -61,17 +61,10 @@ llvm::AllocaInst* makeAlloca(llvm::Type* type,
 
   if( insertBefore ) {
     if (align != 0) {
-#if HAVE_LLVM_VER >= 100
       tempVar = new llvm::AllocaInst(type,
                                      DL.getAllocaAddrSpace(),
                                      size, llvm::Align(align),
                                      name, insertBefore);
-#else
-      tempVar = new llvm::AllocaInst(type,
-                                     DL.getAllocaAddrSpace(),
-                                     size, align,
-                                     name, insertBefore);
-#endif
     } else {
       tempVar = new llvm::AllocaInst(type,
                                      DL.getAllocaAddrSpace(),
@@ -79,17 +72,10 @@ llvm::AllocaInst* makeAlloca(llvm::Type* type,
     }
   } else {
     if (align != 0) {
-#if HAVE_LLVM_VER >= 100
       tempVar = new llvm::AllocaInst(type,
                                      DL.getAllocaAddrSpace(),
                                      size, llvm::Align(align),
                                      name, entryBlock);
-#else
-      tempVar = new llvm::AllocaInst(type,
-                                     DL.getAllocaAddrSpace(),
-                                     size, align,
-                                     name, entryBlock);
-#endif
     } else {
       tempVar = new llvm::AllocaInst(type,
                                      DL.getAllocaAddrSpace(),


### PR DESCRIPTION
Given that we no longer support LLVM versions <= 10, this PR removes compiler code guarded by `#if` conditionals that will never be used.

While there, fix a bug in checking for LLVM 12 and reorder a couple of lines.

Motivation: get some obsolete code out of my way for an upcoming PR.

Testing: standard and gasnet paratest, using LLVM 15.