### PR TITLE
small edits to the `chpl` manpage

### DIFF
--- a/man/chpl.rst
+++ b/man/chpl.rst
@@ -18,11 +18,7 @@ DESCRIPTION
 -----------
 
 The **chpl** command invokes the Chapel compiler. **chpl** converts one
-or more Chapel source files into an executable. It does this by
-compiling Chapel code to C99 code and then invoking the target
-platform's C compiler to create the executable. However, most users will
-not need to be aware of the use of C as an intermediate format during
-compilation.
+or more Chapel source files into an executable.
 
 SOURCE FILES
 ------------

--- a/man/chpl.rst
+++ b/man/chpl.rst
@@ -27,21 +27,19 @@ Chapel recognizes four source file types: **.chpl**, .c, .h, and .o.
 
 **foo.chpl**
 
-    Chapel sources are compiled by the Chapel compiler into C intermediate
-    code, which is then passed to the target compiler to be compiled into
-    object code.
+    Chapel source file.
 
 **foo.c**
 
-    C source files are passed directly to the target C compiler.
+    C source file.
 
 **foo.h**
 
-    C header files are included in the generated C code.
+    C header file.
 
 **foo.o**
 
-    Object files are passed directly to the target linker.
+    Object file.
 
 OPTIONS
 -------

--- a/man/chpl.rst
+++ b/man/chpl.rst
@@ -18,9 +18,9 @@ DESCRIPTION
 -----------
 
 The **chpl** command invokes the Chapel compiler. **chpl** converts one
-or more Chapel source files into an executable. **chpl** produces object files
-using either LLVM (preferred, default) or C. See LLVM Code Generation Options
-or C Code Generation Options below.
+or more Chapel source files into an executable. **chpl** can be configured to
+produce object files using either LLVM or a C compiler. See LLVM Code Generation
+Options or C Code Generation Options below.
 
 SOURCE FILES
 ------------

--- a/man/chpl.rst
+++ b/man/chpl.rst
@@ -18,7 +18,9 @@ DESCRIPTION
 -----------
 
 The **chpl** command invokes the Chapel compiler. **chpl** converts one
-or more Chapel source files into an executable.
+or more Chapel source files into an executable. **chpl** produces object files
+using either LLVM (preferred, default) or C. See LLVM Code Generation Options
+or C Code Generation Options below.
 
 SOURCE FILES
 ------------


### PR DESCRIPTION
Updates the wording in the description of `chpl` to remove references to `C99`, removes some details about source files and intermediate steps of compilation.

[reviewed by @mppf - thanks!]

