### PR TITLE
Fix syntax warning in checkManPages with python3.12

### DIFF
--- a/test/man/checkManPages
+++ b/test/man/checkManPages
@@ -100,7 +100,7 @@ def check_man_page(bin_name, additional_args=None):
     for mline in [l.strip() for l in manpage if len(l.strip()) > 2]:
 
         # Line is flag
-        if (mline[0:5] == "**\--" or mline[4:5] == "," or mline[0:3] == "**-") and mline[-2:] == '**' and currentsection:
+        if (mline[0:5] == "**\\--" or mline[4:5] == "," or mline[0:3] == "**-") and mline[-2:] == '**' and currentsection:
 
             mflags = _get_flags(mline)
 


### PR DESCRIPTION
Fixes a syntax warning that would show in `test/man/checkManPages` when the test system was run with python3.12. Similar to https://github.com/chapel-lang/chapel/pull/24643 and https://github.com/chapel-lang/chapel/pull/24664

Not reviewed - trivial