### PR TITLE
Use newer path for Spack install on Osprey

### DIFF
--- a/util/cron/load-base-deps.bash
+++ b/util/cron/load-base-deps.bash
@@ -8,8 +8,8 @@ if [ -f /data/cf/chapel/chpl-deps/setup_chpl_deps.bash ] ; then
   source /data/cf/chapel/chpl-deps/setup_chpl_deps.bash
 elif [ "$(hostname -s)" == "osprey" ]; then
   # ditto for osprey
-  if [ -f /cray/css/users/chapelu/chpl-deps/load_chpl_deps.bash ] ; then
-    source /cray/css/users/chapelu/chpl-deps/load_chpl_deps.bash
+  if [ -f /lus/scratch/chapelu/chpl-deps/osprey/load_chpl_deps.bash ] ; then
+    source /lus/scratch/chapelu/chpl-deps/osprey/load_chpl_deps.bash
   fi
 else
   # For our internal testing, this is necessary to get the latest version of gcc


### PR DESCRIPTION
Update `util/cron/load-base-deps.bash` to use the path of a newer Spack install for loading dependencies on Osprey.

Tested manually with one Osprey job that this still works.

Follow up to https://github.com/chapel-lang/chapel/pull/24271.

[trivial change unlikely to cause problems review can catch, not reviewed]