### PR TITLE
Use `--reference-if-able` for `git clone`s in scripts

### DIFF
--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -76,8 +76,13 @@ if (exists($ENV{"CHPL_GEN_RELEASE_NO_CLONE"})) {
         $git_branch = $ENV{'CHPL_GEN_RELEASE_BRANCH'};
     }
 
+    $repo_cache_path = "/missing";
+    if (exists($ENV{'REPO_CACHE_PATH'})) {
+        $repo_cache_path = $ENV{'REPO_CACHE_PATH'};
+    }
+
     print "[gen_release] Cloning the sources (repo: $git_url branch: $git_branch)...\n";
-    SystemOrDie("git clone --reference-if-able $ENV{'REPO_CACHE_PATH'}/chapel.git --branch $git_branch $git_url $rootdir");
+    SystemOrDie("git clone --reference-if-able \"$repo_cache_path/chapel.git\" --branch $git_branch $git_url $rootdir");
 
     if (exists($ENV{'CHPL_GEN_RELEASE_COMMIT'})) {
         $commit = $ENV{'CHPL_GEN_RELEASE_COMMIT'};

--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -77,8 +77,7 @@ if (exists($ENV{"CHPL_GEN_RELEASE_NO_CLONE"})) {
     }
 
     print "[gen_release] Cloning the sources (repo: $git_url branch: $git_branch)...\n";
-    $reference_repo = "/cray/css/users/chapelu/cached_repos/chapel.git";
-    SystemOrDie("git clone --reference-if-able $reference_repo --branch $git_branch $git_url $rootdir");
+    SystemOrDie("git clone --reference-if-able $ENV{'REPO_CACHE_PATH'}/chapel.git --branch $git_branch $git_url $rootdir");
 
     if (exists($ENV{'CHPL_GEN_RELEASE_COMMIT'})) {
         $commit = $ENV{'CHPL_GEN_RELEASE_COMMIT'};

--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -77,7 +77,8 @@ if (exists($ENV{"CHPL_GEN_RELEASE_NO_CLONE"})) {
     }
 
     print "[gen_release] Cloning the sources (repo: $git_url branch: $git_branch)...\n";
-    SystemOrDie("git clone --branch $git_branch $git_url $rootdir");
+    $reference_repo = "/cray/css/users/chapelu/cached_repos/chapel.git";
+    SystemOrDie("git clone --reference-if-able $reference_repo --branch $git_branch $git_url $rootdir");
 
     if (exists($ENV{'CHPL_GEN_RELEASE_COMMIT'})) {
         $commit = $ENV{'CHPL_GEN_RELEASE_COMMIT'};

--- a/util/cron/test-homebrew.bash
+++ b/util/cron/test-homebrew.bash
@@ -41,7 +41,8 @@ log_info "Building tarball with version: ${version}"
 # run home-brew scripts to install chapel.
 
 mkdir -p $HOME/test
-git clone git@github.com:Homebrew/homebrew-core.git 2> /dev/null || (cd $HOME/test/homebrew-core; git pull) 
+reference_repo=/cray/css/users/chapelu/cached_repos/homebrew-core.git
+git clone --reference-if-able $reference_repo git@github.com:Homebrew/homebrew-core.git 2> /dev/null || (cd $HOME/test/homebrew-core; git pull)
 #cp $HOME/test/homebrew-core/Formula/c/chapel.rb  ${CHPL_HOME}/util/packaging/homebrew/chapel.rb
 # fix to make the home-brew working. After 1.32 release uncomment the above line
 cp ${CHPL_HOME}/util/packaging/homebrew/chapel-main.rb  ${CHPL_HOME}/util/packaging/homebrew/chapel.rb

--- a/util/cron/test-homebrew.bash
+++ b/util/cron/test-homebrew.bash
@@ -41,8 +41,7 @@ log_info "Building tarball with version: ${version}"
 # run home-brew scripts to install chapel.
 
 mkdir -p $HOME/test
-reference_repo=/cray/css/users/chapelu/cached_repos/homebrew-core.git
-git clone --reference-if-able $reference_repo git@github.com:Homebrew/homebrew-core.git 2> /dev/null || (cd $HOME/test/homebrew-core; git pull)
+git clone --reference-if-able $REPO_CACHE_PATH/homebrew-core.git git@github.com:Homebrew/homebrew-core.git 2> /dev/null || (cd $HOME/test/homebrew-core; git pull)
 #cp $HOME/test/homebrew-core/Formula/c/chapel.rb  ${CHPL_HOME}/util/packaging/homebrew/chapel.rb
 # fix to make the home-brew working. After 1.32 release uncomment the above line
 cp ${CHPL_HOME}/util/packaging/homebrew/chapel-main.rb  ${CHPL_HOME}/util/packaging/homebrew/chapel.rb

--- a/util/cron/test-homebrew.bash
+++ b/util/cron/test-homebrew.bash
@@ -41,7 +41,7 @@ log_info "Building tarball with version: ${version}"
 # run home-brew scripts to install chapel.
 
 mkdir -p $HOME/test
-git clone --reference-if-able $REPO_CACHE_PATH/homebrew-core.git git@github.com:Homebrew/homebrew-core.git 2> /dev/null || (cd $HOME/test/homebrew-core; git pull)
+git clone --reference-if-able "${REPO_CACHE_PATH:-/missing}/homebrew-core.git" git@github.com:Homebrew/homebrew-core.git 2> /dev/null || (cd $HOME/test/homebrew-core; git pull)
 #cp $HOME/test/homebrew-core/Formula/c/chapel.rb  ${CHPL_HOME}/util/packaging/homebrew/chapel.rb
 # fix to make the home-brew working. After 1.32 release uncomment the above line
 cp ${CHPL_HOME}/util/packaging/homebrew/chapel-main.rb  ${CHPL_HOME}/util/packaging/homebrew/chapel.rb

--- a/util/devel/test/vagrant/provision-scripts/chapel-update.sh
+++ b/util/devel/test/vagrant/provision-scripts/chapel-update.sh
@@ -9,8 +9,7 @@ do
     cd chapel && git checkout main && git pull --ff-only && cd .. && echo UPDATED
   else
     echo cloning chapel
-    reference_repo=/cray/css/users/chapelu/cached_repos/chapel.git
-    git clone --reference-if-able $reference_repo --depth 1 https://github.com/chapel-lang/chapel && echo CLONED
+    git clone --reference-if-able $REPO_CACHE_PATH/chapel.git --depth 1 https://github.com/chapel-lang/chapel && echo CLONED
   fi
 
   if [ $? -eq 0 ]

--- a/util/devel/test/vagrant/provision-scripts/chapel-update.sh
+++ b/util/devel/test/vagrant/provision-scripts/chapel-update.sh
@@ -9,7 +9,8 @@ do
     cd chapel && git checkout main && git pull --ff-only && cd .. && echo UPDATED
   else
     echo cloning chapel
-    git clone https://github.com/chapel-lang/chapel && echo CLONED
+    reference_repo=/cray/css/users/chapelu/cached_repos/chapel.git
+    git clone --reference-if-able $reference_repo --depth 1 https://github.com/chapel-lang/chapel && echo CLONED
   fi
 
   if [ $? -eq 0 ]

--- a/util/devel/test/vagrant/provision-scripts/chapel-update.sh
+++ b/util/devel/test/vagrant/provision-scripts/chapel-update.sh
@@ -9,7 +9,7 @@ do
     cd chapel && git checkout main && git pull --ff-only && cd .. && echo UPDATED
   else
     echo cloning chapel
-    git clone --reference-if-able $REPO_CACHE_PATH/chapel.git --depth 1 https://github.com/chapel-lang/chapel && echo CLONED
+    git clone --reference-if-able "${REPO_CACHE_PATH:-/missing}/chapel.git" --depth 1 https://github.com/chapel-lang/chapel && echo CLONED
   fi
 
   if [ $? -eq 0 ]

--- a/util/devel/test/vagrant/provision-scripts/git-clone-chapel.sh
+++ b/util/devel/test/vagrant/provision-scripts/git-clone-chapel.sh
@@ -4,5 +4,6 @@ if [ -d chapel ]
 then
   echo WARNING: chapel directory already exists, not cloning
 else
-  git clone --depth 1 https://github.com/chapel-lang/chapel
+  reference_repo=/cray/css/users/chapelu/cached_repos/chapel.git
+  git clone --reference-if-able $reference_repo --depth 1 https://github.com/chapel-lang/chapel
 fi

--- a/util/devel/test/vagrant/provision-scripts/git-clone-chapel.sh
+++ b/util/devel/test/vagrant/provision-scripts/git-clone-chapel.sh
@@ -4,6 +4,5 @@ if [ -d chapel ]
 then
   echo WARNING: chapel directory already exists, not cloning
 else
-  reference_repo=/cray/css/users/chapelu/cached_repos/chapel.git
-  git clone --reference-if-able $reference_repo --depth 1 https://github.com/chapel-lang/chapel
+  git clone --reference-if-able $REPO_CACHE_PATH/chapel.git --depth 1 https://github.com/chapel-lang/chapel
 fi

--- a/util/devel/test/vagrant/provision-scripts/git-clone-chapel.sh
+++ b/util/devel/test/vagrant/provision-scripts/git-clone-chapel.sh
@@ -4,5 +4,5 @@ if [ -d chapel ]
 then
   echo WARNING: chapel directory already exists, not cloning
 else
-  git clone --reference-if-able $REPO_CACHE_PATH/chapel.git --depth 1 https://github.com/chapel-lang/chapel
+  git clone --reference-if-able "${REPO_CACHE_PATH:-/missing}/chapel.git" --depth 1 https://github.com/chapel-lang/chapel
 fi


### PR DESCRIPTION
Use `--reference-if-able` for all manual `git clone`s in our scripts under `util/`.

The path of the reference repo is assumed to be provided as an environment variable, either on the command line if used manually or from Jenkins as set in CI config for nightly runs. If the variable is missing we will use the path `/missing/{repo-name}` and get a warning that no such path exists.

To be merged with https://github.hpe.com/hpe/hpc-chapel-ci-config/pull/1155 which sets up the environment variables from the Jenkins side.

[reviewer info placeholder]