### PR TITLE
Update prereqs to require Python 3.5 rather than 2.7

### DIFF
--- a/doc/rst/usingchapel/prereqs.rst
+++ b/doc/rst/usingchapel/prereqs.rst
@@ -16,7 +16,7 @@ for using Chapel:
   * You have a Bourne shell available at ``/bin/sh`` and ``env`` available at
     ``/usr/bin/env``.
 
-  * You have Python 2.7 or newer available as either ``python3`` or
+  * You have Python 3.5 or newer available as either ``python3`` or
     ``python`` and that ``env`` can locate it.
 
   * You have access to ``gmake`` or a GNU-compatible version of ``make``.


### PR DESCRIPTION
Since we have disabled testing for Python 2.7, this PR updates prereqs.rst to use Python 3.5 as the minimum version required. That is the oldest version that we test.