### PR TITLE
LSP: another hot fix for runtime crashes

### DIFF
--- a/tools/chapel-py/src/method-tables/uast-methods.h
+++ b/tools/chapel-py/src/method-tables/uast-methods.h
@@ -87,6 +87,8 @@ CLASS_BEGIN(AstNode)
 
          auto sigObj = std::get<0>(args);
          auto resolvedFn = resolution::resolveFunction(context, sigObj->value_.signature, sigObj->value_.poiScope);
+         if (!resolvedFn) return {};
+
          auto r = resolvedFn->byAstOrNull(node);
          return ResolvedExpressionObject::tryCreate(contextObject, r))
   PLAIN_GETTER(AstNode, block_header, "Get the header Location of this block-like AstNode node",


### PR DESCRIPTION
Depends on https://github.com/chapel-lang/chapel/pull/24878.

This PR fixes a segmentation fault that occurs when we try to resolve the type of an expression in a particular instantiated function. Resolving concrete functions can fail (e.g., due to recursion), and return null. We didn't handle that. This PR fixes that.

Reviewed by @jabraham17 -- thanks!