### PR TITLE
Fenced operations in message-order-fence mode must be delivery-complete

### DIFF
--- a/runtime/src/comm/ofi/README.md
+++ b/runtime/src/comm/ofi/README.md
@@ -529,10 +529,10 @@ the same memory address occur in program order. Note that this is a stronger
 guarantee than is necessary to enforce the MCM because it ensures that all
 writes by a task occur in program order, independent of memory address.
 
-To force prior operations to be visible requires the FI_DELIVERY_COMPLETE flag
-in addition to the FI_FENCE flag. Otherwise, the FI_FENCE merely causes the
-prior operations to be transmit-compete, but they may not be visible in
-memory. See the fi_cq man page for more details.
+To force prior operations to be visible, the FI_DELIVERY_COMPLETE flag is
+required in addition to the FI_FENCE flag. Otherwise, the FI_FENCE merely
+causes the prior operations to be transmit-compete, they may not be visible
+in memory. See the fi_cq man page for more details.
 
 #### Message-order MCM Mode
 

--- a/runtime/src/comm/ofi/README.md
+++ b/runtime/src/comm/ofi/README.md
@@ -529,6 +529,11 @@ the same memory address occur in program order. Note that this is a stronger
 guarantee than is necessary to enforce the MCM because it ensures that all
 writes by a task occur in program order, independent of memory address.
 
+To force prior operations to be visible requires the FI_DELIVERY_COMPLETE flag
+in addition to the FI_FENCE flag. Otherwise, the FI_FENCE merely causes the
+prior operations to be transmit-compete, but they may not be visible in
+memory. See the fi_cq man page for more details.
+
 #### Message-order MCM Mode
 
 In message-order mode the comm layer also takes the provider's default

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -3892,7 +3892,7 @@ void mcmReleaseOneNode(c_nodeid_t node, struct perTxCtxInfo_t* tcip,
              "dummy GET from %d for %s ordering",
              (int) node, dbgOrderStr);
   uint64_t flags = (mcmMode == mcmm_msgOrdFence) ?
-                      FI_FENCE | FI_DELIVERY_COMPLETE : 0;
+                      (FI_FENCE | FI_DELIVERY_COMPLETE) : 0;
   atomic_bool txnDone;
   void *ctx = txCtxInit(tcip, __LINE__, &txnDone);
   ofi_get_lowLevel(orderDummy, orderDummyMRDesc, node,

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -3891,7 +3891,8 @@ void mcmReleaseOneNode(c_nodeid_t node, struct perTxCtxInfo_t* tcip,
   DBG_PRINTF(DBG_ORDER,
              "dummy GET from %d for %s ordering",
              (int) node, dbgOrderStr);
-  uint64_t flags = (mcmMode == mcmm_msgOrdFence) ? FI_FENCE : 0;
+  uint64_t flags = (mcmMode == mcmm_msgOrdFence) ?
+                      FI_FENCE | FI_DELIVERY_COMPLETE : 0;
   atomic_bool txnDone;
   void *ctx = txCtxInit(tcip, __LINE__, &txnDone);
   ofi_get_lowLevel(orderDummy, orderDummyMRDesc, node,
@@ -4577,12 +4578,12 @@ void amReqFn_msgOrdFence(c_nodeid_t node,
         && reqSize <= ofi_info->tx_attr->inject_size
         && envInjectAM) {
       void* ctx = txnTrkEncodeId(__LINE__);
-      uint64_t flags = FI_FENCE | FI_INJECT;
+      uint64_t flags = FI_FENCE | FI_DELIVERY_COMPLETE | FI_INJECT;
       (void) wrap_fi_sendmsg(node, req, reqSize, mrDesc, ctx, flags, tcip);
     } else {
       atomic_bool txnDone;
       void *ctx = txCtxInit(tcip, __LINE__, &txnDone);
-      uint64_t flags = FI_FENCE;
+      uint64_t flags = FI_FENCE | FI_DELIVERY_COMPLETE;
       (void) wrap_fi_sendmsg(node, req, reqSize, mrDesc, ctx, flags, tcip);
       waitForTxnComplete(tcip, ctx);
       txCtxCleanup(ctx);
@@ -5997,7 +5998,7 @@ chpl_comm_nb_handle_t rmaPutFn_msgOrdFence(void* myAddr, void* mrDesc,
       // PUT to force the AMO to complete before this PUT.  We may still
       // be able to inject the PUT, though.
       //
-      uint64_t flags = FI_FENCE;
+      uint64_t flags = FI_FENCE | FI_DELIVERY_COMPLETE;
       if (size <= ofi_info->tx_attr->inject_size
           && envInjectRMA) {
         flags |= FI_INJECT;
@@ -6437,7 +6438,7 @@ chpl_comm_nb_handle_t rmaGetFn_msgOrdFence(void* myAddr, void* mrDesc,
     // that visibility.
     //
     (void) wrap_fi_readmsg(myAddr, mrDesc, node, mrRaddr, mrKey, size, ctx,
-                           FI_FENCE, tcip);
+                           FI_FENCE | FI_DELIVERY_COMPLETE, tcip);
     if (havePutsOut) {
       bitmapClear(tcip->putVisBitmap, node);
     }
@@ -6850,7 +6851,7 @@ chpl_comm_nb_handle_t amoFn_msgOrdFence(struct amoBundle_t *ab,
     if (havePutsOut ||
        (famo && haveAmosOut &&
           !(ofi_info->tx_attr->msg_order & FI_ORDER_ATOMIC_RAW))) {
-      flags |= FI_FENCE;
+      flags |= FI_FENCE | FI_DELIVERY_COMPLETE;
     }
     if (havePutsOut) {
       bitmapClear(tcip->putVisBitmap, ab->node);


### PR DESCRIPTION
Fenced operations in `message-order-fence` MCM mode in `COMM=ofi `are used to
force visibility of previous operations. Previously, we did not also specify
`FI_DELIVERY_COMPLETE`, and as a result the fence only forced previous
operations to be transmit-complete, meaning they were transmitted but might
not be visible in memory. Specifying `FI_DELIVERY_COMPLETE` along with `FI_FENCE`
causes the previous operations to be visible.

Resolves https://github.com/Cray/chapel-private/issues/6169.