### PR TITLE
Fix ref warnings on compiler generated interface wrapper functions

### DIFF
--- a/compiler/resolution/interfaceResolution.cpp
+++ b/compiler/resolution/interfaceResolution.cpp
@@ -1316,6 +1316,7 @@ static FnSymbol* finalizeHolder(ImplementsStmt* istm, FnSymbol*   reqFn,
   FnSymbol* wrapper = new FnSymbol(target->name);
   wrapper->addFlag(FLAG_INLINE);
   wrapper->addFlag(FLAG_INVISIBLE_FN);
+  wrapper->addFlag(FLAG_COMPILER_GENERATED);
   wrapperFnForImplementsStmt(istm)->defPoint->insertAfter(new DefExpr(wrapper));
 
   for (Symbol* dup: formalDups)

--- a/test/constrained-generics/hashable/ref-hash.chpl
+++ b/test/constrained-generics/hashable/ref-hash.chpl
@@ -1,0 +1,27 @@
+record myRec: hashable {
+  var x: int;
+
+  proc ref getAndSetX() ref {
+    return x;
+  }
+
+  proc ref hash(salt = 0): uint throws {
+    // This is not meant to be a good hash function, just to test throwing and
+    // ref
+    if (salt == 0) then throw new IllegalArgumentError("salt too obvious!");
+    else return getAndSetX()*salt;
+  }
+}
+
+proc main() {
+  var myR = new myRec(15);
+  try {
+    var hash1 = myR.hash();
+  } catch e: IllegalArgumentError {
+    writeln(e.message());
+    var hash2 = myR.hash(3);
+    writeln(hash2);
+  } catch e {
+    halt(e.message());
+  }
+}

--- a/test/constrained-generics/hashable/ref-hash.good
+++ b/test/constrained-generics/hashable/ref-hash.good
@@ -1,0 +1,2 @@
+salt too obvious!
+45


### PR DESCRIPTION
This PR ensures that compiler generated interface wrapper functions are marked as compiler generated. This fixes an issue where some warnings, like implicit ref deprecation warnings, would warn for cases where a user cannot respond to the warning.

Tested with a full paratest with/without gasnet

Resolves https://github.com/chapel-lang/chapel/issues/24881

[Reviewed by @]