### PR TITLE
Fix `fillRandom`'s wrong overload being selected

### DIFF
--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -234,15 +234,13 @@ module Random {
     rs.fill(arr, min, max);
   }
 
-  pragma "last resort"
   @chpldoc.nodoc
-  proc fillRandom(ref arr: [], min, max, seed: int) {
+  proc fillRandom(ref arr: [] ?t, min: t, max: t, seed: int) {
     compilerError("'fillRandom' does not support non-rectangular arrays");
   }
 
-  pragma "last resort"
   @chpldoc.nodoc
-  proc fillRandom(ref arr: [], min, max) {
+  proc fillRandom(ref arr: [] ?t, min: t, max: t) {
     compilerError("'fillRandom' does not support non-rectangular arrays");
   }
 

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -234,11 +234,13 @@ module Random {
     rs.fill(arr, min, max);
   }
 
+  pragma "last resort"
   @chpldoc.nodoc
   proc fillRandom(ref arr: [], min, max, seed: int) {
     compilerError("'fillRandom' does not support non-rectangular arrays");
   }
 
+  pragma "last resort"
   @chpldoc.nodoc
   proc fillRandom(ref arr: [], min, max) {
     compilerError("'fillRandom' does not support non-rectangular arrays");

--- a/test/library/standard/Random/fillRandom.chpl
+++ b/test/library/standard/Random/fillRandom.chpl
@@ -1,0 +1,19 @@
+use Random;
+
+var a : [0..<10] int;
+var b : [0..<10] real;
+var c : [0..<10] real(32);
+var d : [0..<10] uint;
+
+// Correct types, no coercion
+fillRandom(a, min=-1, max=1);
+fillRandom(b, min=-1.0, max=1.0);
+
+// Coercion
+fillRandom(b, min=-1, max=1);
+fillRandom(c, min=-1, max=1);
+fillRandom(d, min=-1, max=1);
+
+
+// Illegal
+// fillRandom(a, min=-1.0, max=1.0);


### PR DESCRIPTION
For filling random values for `real` arrays within a specified `min` and `max` where these values are `int`s, the overload which results in a compiler error was being selected.

For example:

```chapel
use Random;

var a : [0..<10] real;
fillRandom(a, min=-1, max=1);
```

would give us the following error:

```console
random.chpl:4: error: 'fillRandom' does not support non-rectangular arrays
```

This is because we expect the types of the `min` and `max` arguments to match the `eltType` of the array. However, the headers of the overload which results in the `compilerError` does not have the types enforced. This means that before trying to coerce the types (which should be done in this case), the compiler simply chooses the overload and results in an unhelpful error.

Based on the discussion in this issue, I've added the `?t` to the headers where appropriate and added a test to lock in the behavior.