### PR TITLE
dyno: Make 'none' support param-ness.

### DIFF
--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -332,8 +332,9 @@ const QualifiedType& typeForBuiltin(Context* context,
     result = QualifiedType(QualifiedType::CONST_VAR,
                            NilType::get(context));
   } else if (name == USTR("none")) {
-    result = QualifiedType(QualifiedType::CONST_VAR,
-                           NothingType::get(context));
+    result = QualifiedType(QualifiedType::PARAM,
+                           NothingType::get(context),
+                           NoneParam::get(context, /* NoneValue */ {}));
   } else {
     // Could be a non-type builtin like 'index'
     result = QualifiedType();

--- a/frontend/test/resolution/testResolve.cpp
+++ b/frontend/test/resolution/testResolve.cpp
@@ -1551,6 +1551,9 @@ static void test25() {
     auto t = resolveTypeOfXInit(context, prog);
     assert(t.type());
     assert(t.type()->isNothingType());
+    assert(t.isParam());
+    assert(t.param());
+    assert(t.param()->isNoneParam());
     assert(guard.realizeErrors() == 0);
   }
 }


### PR DESCRIPTION
I didn't realize we had a `NoneParam` value for params of type `nothing`. I looked for a `NothingParam`, but obviously didn't find any. In reading some unrelated code today, I noticed that we _do_ have params of `nothing`; this PR adjusts the builtin type and the corresponding test to ensure that paramness is available. 

Reviewed by @mppf -- thanks!

## Testing
- [x] dyno tests
- [x] paratest