### PR TITLE
Small fixes for UGNI builds with bundled LLVM

### DIFF
--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -18,6 +18,12 @@
  * limitations under the License.
  */
 
+#ifdef __STRICT_ANSI__
+// For builds with NVIDIA we define this, but this source is not compatible with
+// it. So, undefine if it was defined
+#undef __STRICT_ANSI__
+#endif
+
 //
 // GNI-based implementation of Chapel communication interface.
 //
@@ -3899,7 +3905,7 @@ void regMemBroadcast(int mr_i, int mr_cnt, chpl_bool send_mreg_cnt)
 }
 
 
-wide_ptr_t* chpl_comm_broadcast_global_vars_helper() {
+wide_ptr_t* chpl_comm_broadcast_global_vars_helper(void) {
   //
   // Gather the global variables' wide pointers on node 0 into a
   // buffer, and broadcast the address of that buffer to the other


### PR DESCRIPTION
This PR has two minor fixes for building the ugni layer with bundled LLVM.

1. On `flat` locale model, we get strict prototype errors because of a missing `void` in a function with 0 formals

2. On `gpu` locale model with `nvidia`, we use `-D__STRICT_ANSI__` while building the runtime. `comm-ugni.c` has some non-compliant code, so this PR undefines that if it is defined.

Resolves a bug reported by @ninivert  on [gitter](https://matrix.to/#/!PBYDSerrfYujeStENM:gitter.im/$-qXpYCwU3SWps1_izeV9aCr1PbqREN5A8EuQYwNvzQE?via=gitter.im&via=matrix.org&via=envs.net). 

Test:
- [x] gpu/native/jacobi/jacobi on ugni
- [x] flat "hello" on ugni