### PR TITLE
Add auto-fixit for MisleadingIndent lint rule

### DIFF
--- a/test/chplcheck/MisleadingIndentation.chpl
+++ b/test/chplcheck/MisleadingIndentation.chpl
@@ -7,4 +7,20 @@ module Indentation {
   for i in 1..10 do
     writeln(i);
     writeln("second thing");
+
+  for i in 1..10 do
+writeln(i);
+writeln("second thing");
+
+  // the only fixit is ignore, cant apply fixit to the multiline
+  for i in 1..10 do
+    writeln(i);
+    writeln
+    ("second thing");
+
+  // the only fixit here is ignore, don't know the indentation level
+  for i in 1..10 do
+  writeln(i);
+  writeln("second thing");
+
 }

--- a/test/chplcheck/MisleadingIndentation.good
+++ b/test/chplcheck/MisleadingIndentation.good
@@ -1,2 +1,6 @@
 MisleadingIndentation.chpl:4: node violates rule MisleadingIndentation
+MisleadingIndentation.chpl:13: node violates rule MisleadingIndentation
+MisleadingIndentation.chpl:18: node violates rule MisleadingIndentation
+MisleadingIndentation.chpl:23: node violates rule IncorrectIndentation
+MisleadingIndentation.chpl:24: node violates rule MisleadingIndentation
 [Success matching fixit for MisleadingIndentation]

--- a/test/chplcheck/MisleadingIndentation.good-fixit
+++ b/test/chplcheck/MisleadingIndentation.good-fixit
@@ -7,4 +7,22 @@ module Indentation {
   for i in 1..10 do
     writeln(i);
     writeln("second thing");
+
+  for i in 1..10 do
+writeln(i);
+  writeln("second thing");
+
+  // the only fixit is ignore, cant apply fixit to the multiline
+  @chplcheck.ignore("MisleadingIndentation")
+  for i in 1..10 do
+    writeln(i);
+    writeln
+    ("second thing");
+
+  // the only fixit here is ignore, don't know the indentation level
+  @chplcheck.ignore("MisleadingIndentation")
+  for i in 1..10 do
+  writeln(i);
+  writeln("second thing");
+
 }

--- a/test/chplcheck/MisleadingIndentation.good-fixit
+++ b/test/chplcheck/MisleadingIndentation.good-fixit
@@ -1,8 +1,7 @@
 module Indentation {
-  @chplcheck.ignore("MisleadingIndentation")
   for i in 1..10 do
     writeln(i);
-    writeln("second thing");
+  writeln("second thing");
 
   @chplcheck.ignore("MisleadingIndentation")
   for i in 1..10 do


### PR DESCRIPTION
This PR adds a fixit to chplcheck for MisleadingIndent. This lets users auto-fix and improve their code.

![Screenshot 2024-04-19 at 3 41 36 PM](https://github.com/chapel-lang/chapel/assets/15747900/4d290f72-0a5a-44ec-aeae-1339dccd9369)

Tested locally

[Reviewed by @DanilaFe]