### PR TITLE
Suppress ICC const discarding warning

### DIFF
--- a/make/compiler/Makefile.intel
+++ b/make/compiler/Makefile.intel
@@ -128,11 +128,12 @@ IEEE_FLOAT_GEN_CFLAGS = -fp-model precise -fp-model source
 #  174  : warns about expressions that have no effect
 #  177  : warns about unused variable declarations
 #  556  : warns about type X being assigned to entity of type Y
+#  2332 : warns about discarded const qualifier (https://github.com/chapel-lang/chapel/issues/24894)
 
 WARN_CXXFLAGS = -Wall -Werror -diag-disable remark -wr279,304,593,810,869,981,1572,1599 -diag-warning 1292,3924
 WARN_CFLAGS = $(WARN_CXXFLAGS)
 WARN_GEN_CFLAGS = $(WARN_CFLAGS)
-SQUASH_WARN_GEN_CFLAGS = -wr111,167,174,177,556
+SQUASH_WARN_GEN_CFLAGS = -wr111,167,174,177,556,2332
 
 #
 # Don't warn for signed pointer issues (ex. c_ptr(c_char) )


### PR DESCRIPTION
Due to an apparent difference in how ICC interprets `const` pointer `typedef`s to arrays, suppress "discarding qualifiers" warnings in ICC.

See issue https://github.com/chapel-lang/chapel/issues/24894 for more information.

Follow up to https://github.com/chapel-lang/chapel/pull/24809.

[reviewer info placeholder]

Testing:
- [x] succeeds in reproducer configuration
- [x] paratest