### PR TITLE
Add tests and futures motivated by HPO's use of these features

### DIFF
--- a/test/hash/throwingHash.chpl
+++ b/test/hash/throwingHash.chpl
@@ -1,0 +1,22 @@
+record myRec: hashable {
+  var x: int;
+
+  proc hash(salt = 0): uint throws {
+    // This is not meant to be a good hash function, just to test throwing
+    if (salt == 0) then throw new IllegalArgumentError("salt too obvious!");
+    else return x*salt;
+  }
+}
+
+proc main() {
+  var myR = new myRec(15);
+  try {
+    var hash1 = myR.hash();
+  } catch e: IllegalArgumentError {
+    writeln(e.message());
+    var hash2 = myR.hash(3);
+    writeln(hash2);
+  } catch e {
+    halt(e.message());
+  }
+}

--- a/test/hash/throwingHash.good
+++ b/test/hash/throwingHash.good
@@ -1,0 +1,2 @@
+salt too obvious!
+45

--- a/test/hash/throwingHashCallsRef.bad
+++ b/test/hash/throwingHashCallsRef.bad
@@ -1,0 +1,4 @@
+throwingHashCallsRef.chpl:11: warning: inferring a default intent to be 'ref' is deprecated - please use an explicit 'ref' this-intent for the method 'hash'
+throwingHashCallsRef.chpl:3: warning: inferring a default intent to be 'ref' is deprecated - please use an explicit 'ref' this-intent for the method 'hash'
+salt too obvious!
+45

--- a/test/hash/throwingHashCallsRef.chpl
+++ b/test/hash/throwingHashCallsRef.chpl
@@ -1,0 +1,30 @@
+// Trying to nail down why HPO was generating a warning on the type when we are
+// declaring a hash function explicitly
+record myRec: hashable {
+  var x: int;
+
+  proc ref getAndSetX() ref {
+    return x;
+  }
+
+  // This should warn - it's calling a `ref` thing but its intent isn't `ref`.
+  proc hash(salt = 0): uint throws {
+    // This is not meant to be a good hash function, just to test throwing and
+    // ref
+    if (salt == 0) then throw new IllegalArgumentError("salt too obvious!");
+    else return getAndSetX()*salt;
+  }
+}
+
+proc main() {
+  var myR = new myRec(15);
+  try {
+    var hash1 = myR.hash();
+  } catch e: IllegalArgumentError {
+    writeln(e.message());
+    var hash2 = myR.hash(3);
+    writeln(hash2);
+  } catch e {
+    halt(e.message());
+  }
+}

--- a/test/hash/throwingHashCallsRef.future
+++ b/test/hash/throwingHashCallsRef.future
@@ -1,0 +1,2 @@
+[bug] ref hash function generating an extra unsilenceable warning
+#24881

--- a/test/hash/throwingHashCallsRef.good
+++ b/test/hash/throwingHashCallsRef.good
@@ -1,0 +1,3 @@
+throwingHashCallsRef.chpl:11: warning: inferring a default intent to be 'ref' is deprecated - please use an explicit 'ref' this-intent for the method 'hash'
+salt too obvious!
+45

--- a/test/hash/throwingHashInModule.bad
+++ b/test/hash/throwingHashInModule.bad
@@ -1,0 +1,3 @@
+throwingHashInModule.chpl:2: In function 'hash':
+throwingHashInModule.chpl:2: error: call to throwing function hash without throws, try, or try! (relaxed mode)
+throwingHashInModule.chpl:5: note: throwing function hash defined here

--- a/test/hash/throwingHashInModule.chpl
+++ b/test/hash/throwingHashInModule.chpl
@@ -1,0 +1,24 @@
+module throwingHashInModule { // module decl essential to exhibit the problem
+  record myRec: hashable {
+    var x: int;
+
+    proc hash(salt = 0): uint throws {
+      // This is not meant to be a good hash function, just to test throwing
+      if (salt == 0) then throw new IllegalArgumentError("salt too obvious!");
+      else return x*salt;
+    }
+  }
+
+  proc main() {
+    var myR = new myRec(15);
+    try {
+      var hash1 = myR.hash();
+    } catch e: IllegalArgumentError {
+      writeln(e.message());
+      var hash2 = try! myR.hash(3);
+      writeln(hash2);
+    } catch e {
+      halt(e.message());
+    }
+  }
+}

--- a/test/hash/throwingHashInModule.future
+++ b/test/hash/throwingHashInModule.future
@@ -1,0 +1,2 @@
+[bug] throwing hash function generating an unavoidable error
+#24882

--- a/test/hash/throwingHashInModule.good
+++ b/test/hash/throwingHashInModule.good
@@ -1,0 +1,2 @@
+salt too obvious!
+45

--- a/test/hash/throwingHashIndirect.chpl
+++ b/test/hash/throwingHashIndirect.chpl
@@ -1,0 +1,28 @@
+// Trying to nail down why HPO was generating a warning on the type when we are
+// declaring a hash function explicitly
+record myRec: hashable {
+  var x: int;
+
+  proc checkSaltArg(salt) throws {
+    if (salt == 0) then throw new IllegalArgumentError("salt too obvious!");
+  }
+
+  proc hash(salt = 0): uint throws {
+    // This is not meant to be a good hash function, just to test throwing
+    checkSaltArg(salt);
+    return x*salt;
+  }
+}
+
+proc main() {
+  var myR = new myRec(15);
+  try {
+    var hash1 = myR.hash();
+  } catch e: IllegalArgumentError {
+    writeln(e.message());
+    var hash2 = myR.hash(3);
+    writeln(hash2);
+  } catch e {
+    halt(e.message());
+  }
+}

--- a/test/hash/throwingHashIndirect.good
+++ b/test/hash/throwingHashIndirect.good
@@ -1,0 +1,2 @@
+salt too obvious!
+45

--- a/test/hash/throwingHashRef.bad
+++ b/test/hash/throwingHashRef.bad
@@ -1,0 +1,3 @@
+throwingHashRef.chpl:3: warning: inferring a default intent to be 'ref' is deprecated - please use an explicit 'ref' this-intent for the method 'hash'
+salt too obvious!
+45

--- a/test/hash/throwingHashRef.chpl
+++ b/test/hash/throwingHashRef.chpl
@@ -1,0 +1,29 @@
+// Trying to nail down why HPO was generating a warning on the type when we are
+// declaring a hash function explicitly
+record myRec: hashable {
+  var x: int;
+
+  proc ref getAndSetX() ref {
+    return x;
+  }
+
+  proc ref hash(salt = 0): uint throws {
+    // This is not meant to be a good hash function, just to test throwing and
+    // ref
+    if (salt == 0) then throw new IllegalArgumentError("salt too obvious!");
+    else return getAndSetX()*salt;
+  }
+}
+
+proc main() {
+  var myR = new myRec(15);
+  try {
+    var hash1 = myR.hash();
+  } catch e: IllegalArgumentError {
+    writeln(e.message());
+    var hash2 = myR.hash(3);
+    writeln(hash2);
+  } catch e {
+    halt(e.message());
+  }
+}

--- a/test/hash/throwingHashRef.future
+++ b/test/hash/throwingHashRef.future
@@ -1,0 +1,2 @@
+[bug] ref hash function generating an extra unsilenceable warning
+#24881

--- a/test/hash/throwingHashRef.good
+++ b/test/hash/throwingHashRef.good
@@ -1,0 +1,2 @@
+salt too obvious!
+45

--- a/test/interop/python/cptrConstCharArrays.bad
+++ b/test/interop/python/cptrConstCharArrays.bad
@@ -1,0 +1,1 @@
+cptrConstCharArrays.chpl:10: error: Array return types must include an explicit element type for Python compilation

--- a/test/interop/python/cptrConstCharArrays.chpl
+++ b/test/interop/python/cptrConstCharArrays.chpl
@@ -1,0 +1,13 @@
+use CTypes;
+
+export proc takesArray(in x: [] c_ptrConst(c_char)) {
+  for str in x {
+    // Note: this assumes x will have initial contents
+    writeln(string.createCopyingBuffer(str));
+  }
+}
+
+export proc returnsArray(): [0..3] c_ptrConst(c_char) {
+  var x: [0..3] c_ptrConst(c_char) = ["guess", "this", "could", "work?"];
+  return x;
+}

--- a/test/interop/python/cptrConstCharArrays.future
+++ b/test/interop/python/cptrConstCharArrays.future
@@ -1,0 +1,2 @@
+[bug] restore ability to export functions with arrays of C style strings
+#24874

--- a/test/interop/python/cptrConstCharArrays.good
+++ b/test/interop/python/cptrConstCharArrays.good
@@ -1,0 +1,9 @@
+guess
+this
+could
+work?
+maybe
+this
+also
+works
+too?

--- a/test/interop/python/cptrConstCharArrays.prediff
+++ b/test/interop/python/cptrConstCharArrays.prediff
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+sed '/from cptrConstCharArrays.c:[0-9]*/d' $2 > $2.tmp
+sed '/^ *$/d' $2.tmp > $2
+rm $2.tmp
+export PYTHONPATH=lib/
+python3 use_cptrConstCharArrays.py >> $2

--- a/test/interop/python/stringArrayArg.chpl
+++ b/test/interop/python/stringArrayArg.chpl
@@ -1,0 +1,5 @@
+export proc takesStrArray(in x: [] string) {
+  for str in x {
+    writeln(str);
+  }
+}

--- a/test/interop/python/stringArrayArg.future
+++ b/test/interop/python/stringArrayArg.future
@@ -1,0 +1,2 @@
+[feature request] arrays of string arguments in exported functions
+#24877

--- a/test/interop/python/stringArrayArg.good
+++ b/test/interop/python/stringArrayArg.good
@@ -1,0 +1,5 @@
+let's
+see
+if
+this
+works

--- a/test/interop/python/stringArrayArg.prediff
+++ b/test/interop/python/stringArrayArg.prediff
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+sed '/from stringArrayArg.c:[0-9]*/d' $2 > $2.tmp
+sed '/^ *$/d' $2.tmp > $2
+rm $2.tmp
+export PYTHONPATH=lib/
+python3 use_stringArrayArg.py >> $2

--- a/test/interop/python/use_cptrConstCharArrays.py
+++ b/test/interop/python/use_cptrConstCharArrays.py
@@ -1,0 +1,8 @@
+import cptrConstCharArrays
+
+cptrConstCharArrays.chpl_setup()
+x = cptrConstCharArrays.returnsArray()
+cptrConstCharArrays.takesArray(x)
+y = [b"maybe", b"this", b"also", b"works", b"too?"]
+cptrConstCharArrays.takesArray(y)
+cptrConstCharArrays.chpl_cleanup()

--- a/test/interop/python/use_stringArrayArg.py
+++ b/test/interop/python/use_stringArrayArg.py
@@ -1,0 +1,8 @@
+import stringArrayArg
+
+# note: would be nice to merge with use_retStringArray.py when this works,
+# so it can test sending the returned array back like the other array tests do
+stringArrayArg.chpl_setup()
+x = ["let's", "see", "if", "this", "works"]
+stringArrayArg.takesStrArray(x)
+stringArrayArg.chpl_cleanup()


### PR DESCRIPTION
Covers:
- taking and returning arrays of `c_ptrConst(c_char)` in exported functions
- accepting arguments of arrays of strings in exported functions
- throwing from hash functions in script-like .chpl files
- throwing from hash functions in script-like .chpl files due to calling functions that throw
- calling functions with `ref` intent for the `this` argument from hash functions
- explicitly declaring the hash function to have `ref` intent for its `this` argument
- throwing from hash functions in explicit modules

Checked a fresh checkout of the hash tests behaved as expected.  The Python
interop tests worked locally