### PR TITLE
Patch bundled gasnet to pull in bugfix for IBV

### DIFF
--- a/third-party/gasnet/gasnet-src/other/firehose/firehose_region.c
+++ b/third-party/gasnet/gasnet-src/other/firehose/firehose_region.c
@@ -704,7 +704,12 @@ GASNETI_INLINE(fhi_init_local_region)
 firehose_private_t *
 fhi_init_local_region(int local_ref, firehose_region_t *region)
 {
+#if GASNET_NDEBUG && PLATFORM_COMPILER_CLANG && PLATFORM_COMPILER_VERSION_GE(16,0,0)
+    // Work-around bug 4617 by inhibiting some optimization(s)
+    firehose_private_t * volatile priv;
+#else
     firehose_private_t *priv;
+#endif
 
     gasneti_assert(region != NULL);
     gasneti_assert((local_ref == 0) || (local_ref == 1));


### PR DESCRIPTION
This PR patches the bundled gasnet to pull in a fix for gasnet using the ibv-conduit with clang16+.

Gasnet bug: https://gasnet-bugs.lbl.gov/bugzilla/show_bug.cgi?id=4617
Gasnet patch: https://bitbucket.org/berkeleylab/gasnet/pull-requests/625

Resolves https://github.com/chapel-lang/chapel/issues/24779
Resolves https://github.com/chapel-lang/chapel/issues/22055

Tested by building with `CHPL_COMM=gasnet` and `CHPL_COMM_SUBSTRATE=ibv` and confirming that the correct codepath for the conditional compilation is taken

I was also able to reproduce the issue on an InfiniBand system without the patch, and confirmed that applying the patch  results in correct execution.

```
> chpl examples/hello6-taskpar-dist.chpl 
> ./hello6-taskpar-dist.chpl  -nl 4
SEGFAULT

> ...apply patch....
> chpl examples/hello6-taskpar-dist.chpl 
> ./hello6-taskpar-dist.chpl  -nl 4
Hello, world! .....
......
```

[Reviewed by @jhh67]