### PR TITLE
chapel-py: scope resolve uses and imports

### DIFF
--- a/doc/util/nitpick_ignore
+++ b/doc/util/nitpick_ignore
@@ -72,3 +72,8 @@ cpp:identifier VIS_USE
 cpp:identifier T
 cpp:identifier Deserializer
 cpp:identifier Serializer
+# For some reason, 'LOOKUP_' symbols in headers are not found.
+cpp:identifier LOOKUP_DECLS
+cpp:identifier LOOKUP_IMPORT_AND_USE
+cpp:identifier LOOKUP_PARENTS
+cpp:identifier LOOKUP_EXTERN_BLOCKS

--- a/frontend/include/chpl/resolution/scope-queries.h
+++ b/frontend/include/chpl/resolution/scope-queries.h
@@ -44,6 +44,15 @@ namespace resolution {
   const Scope* scopeForModule(Context* context, ID moduleId);
 
   /**
+    The configuration used to look up a plain identifier in a scope
+    when resolving expressions.
+   */
+  const LookupConfig IDENTIFIER_LOOKUP_CONFIG = LOOKUP_DECLS |
+                                                LOOKUP_IMPORT_AND_USE |
+                                                LOOKUP_PARENTS |
+                                                LOOKUP_EXTERN_BLOCKS;
+
+  /**
     Find what a name might refer to.
 
     'scope' is the context in which the name occurs (e.g. as an Identifier)

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2591,12 +2591,6 @@ bool Resolver::identHasMoreMentions(const Identifier* ident) {
   return false;
 }
 
-static const LookupConfig identifierLookupConfig = LOOKUP_DECLS |
-                                                   LOOKUP_IMPORT_AND_USE |
-                                                   LOOKUP_PARENTS |
-                                                   LOOKUP_EXTERN_BLOCKS;
-
-
 void Resolver::issueAmbiguityErrorIfNeeded(const Identifier* ident,
                                            const Scope* scope,
                                            llvm::ArrayRef<const Scope*> receiverScopes,
@@ -2627,7 +2621,7 @@ Resolver::lookupIdentifier(const Identifier* ident,
 
   bool resolvingCalledIdent = nearestCalledExpression() == ident;
 
-  LookupConfig config = identifierLookupConfig;
+  LookupConfig config = IDENTIFIER_LOOKUP_CONFIG;
   if (!resolvingCalledIdent) config |= LOOKUP_INNERMOST;
 
   auto vec = lookupNameInScopeWithWarnings(context, scope, receiverScopes,
@@ -2877,7 +2871,7 @@ void Resolver::tryResolveParenlessCall(const ParenlessOverloadInfo& info,
       // Found both, it's an ambiguity after all. Issue the ambiguity error
       // late, for which we need to recover some context.
 
-      LookupConfig config = identifierLookupConfig;
+      LookupConfig config = IDENTIFIER_LOOKUP_CONFIG;
       bool resolvingCalledIdent = nearestCalledExpression() == ident;
       if (!resolvingCalledIdent) config |= LOOKUP_INNERMOST;
 

--- a/tools/chapel-py/src/resolution.cpp
+++ b/tools/chapel-py/src/resolution.cpp
@@ -60,11 +60,13 @@ static const ID scopeResolveViaVisibilityStmt(Context* context, const AstNode* v
           }
 
           if (identToLookUp) {
+            auto config = chpl::resolution::IDENTIFIER_LOOKUP_CONFIG |
+                          resolution::LOOKUP_SKIP_PRIVATE_VIS;
             auto ids =
               resolution::lookupNameInScope(context, visCla.scope(),
                                             /* receiverScopes */ {},
                                             identToLookUp->name(),
-                                            chpl::resolution::IDENTIFIER_LOOKUP_CONFIG);
+                                            config);
 
             if (ids.empty()) return ID();
             toReturn = ids[0].firstId();


### PR DESCRIPTION
Fixes https://github.com/chapel-lang/chapel/issues/24905.

This PR beefs up the logic for scope resolving identifiers that occur in the use / rename list of a node. When the node-to-be-resolved is part of a visibility clause such as the 'x' in `use M only x` or the `b` in `import M.{a as b}` etc, the new logic performs a proper scope search of the module being accessed. Thus, when the user hovers over 'fillRandom', which is a visibility clause, the scope resolution process now finds a 'fillRandom' overload.

![image](https://github.com/chapel-lang/chapel/assets/4361282/c1398c62-3e6f-4c39-95dc-ccb70c9ad2f0)

Reviewed by @jabraham17 -- thanks!

## Testing
- [x] dyno tests