### PR TITLE
Add a 'black' check to verify formatting of Python files

### DIFF
--- a/.github/workflows/python-format-CI.yml
+++ b/.github/workflows/python-format-CI.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  pull_request:
+    paths:
+      - 'tools/chapel-py/**/*.py'
+      - 'tools/chplcheck/**/*.py'
+      - 'tools/chpl-language-server/**/*.py'
+  workflow_dispatch:
+
+jobs:
+  check-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: psf/black@stable
+        with:
+          options: "--check --verbose"
+          src: "tools/{chapel-py,chplcheck,chpl-language-server}/**/*.py"

--- a/.github/workflows/python-format-CI.yml
+++ b/.github/workflows/python-format-CI.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI Format Check
 
 on:
   pull_request:

--- a/.github/workflows/python-format-CI.yml
+++ b/.github/workflows/python-format-CI.yml
@@ -17,3 +17,4 @@ jobs:
         with:
           options: "--check --verbose"
           src: "tools/{chapel-py,chplcheck,chpl-language-server}/**/*.py"
+          version: "24.4.0"

--- a/.github/workflows/python-format-CI.yml
+++ b/.github/workflows/python-format-CI.yml
@@ -16,5 +16,5 @@ jobs:
       - uses: psf/black@stable
         with:
           options: "--check --verbose --line-length 80"
-          src: "./tools/{chapel-py,chplcheck,chpl-language-server}/**/*.py"
+          src: "./tools/chapel-py ./tools/chplcheck ./tools/chpl-language-server"
           version: "24.4.0"

--- a/.github/workflows/python-format-CI.yml
+++ b/.github/workflows/python-format-CI.yml
@@ -16,5 +16,5 @@ jobs:
       - uses: psf/black@stable
         with:
           options: "--check --verbose"
-          src: "tools/{chapel-py,chplcheck,chpl-language-server}/**/*.py"
+          src: "./tools/{chapel-py,chplcheck,chpl-language-server}/**/*.py"
           version: "24.4.0"

--- a/.github/workflows/python-format-CI.yml
+++ b/.github/workflows/python-format-CI.yml
@@ -15,6 +15,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: psf/black@stable
         with:
-          options: "--check --verbose"
+          options: "--check --verbose --line-length 80"
           src: "./tools/{chapel-py,chplcheck,chpl-language-server}/**/*.py"
           version: "24.4.0"


### PR DESCRIPTION
Only on chapel-py and its derivative projects.

This CI check only runs on PRs that touch files in `chapel-py`, `chplcheck`, or `chpl-language-server`.

Reviewed by @tzinsky -- thanks!