### PR TITLE
chapel-py: Apply black to chapel-py and its derivative files.

### DIFF
--- a/tools/chapel-py/setup.py
+++ b/tools/chapel-py/setup.py
@@ -24,9 +24,16 @@ import os
 import sys
 import glob
 
-chpl_home = str(os.getenv('CHPL_HOME'))
+chpl_home = str(os.getenv("CHPL_HOME"))
 chpl_printchplenv = os.path.join(chpl_home, "util", "printchplenv")
-chpl_variables_lines = subprocess.check_output([chpl_printchplenv, "--internal", "--all", " --anonymize", "--simple"]).decode(sys.stdout.encoding).strip().splitlines()
+chpl_variables_lines = (
+    subprocess.check_output(
+        [chpl_printchplenv, "--internal", "--all", " --anonymize", "--simple"]
+    )
+    .decode(sys.stdout.encoding)
+    .strip()
+    .splitlines()
+)
 chpl_variables = dict()
 for line in chpl_variables_lines:
     elms = line.split("=", maxsplit=1)
@@ -44,11 +51,21 @@ if have_llvm:
     CXXFLAGS += ["-DHAVE_LLVM"]
 
 CXXFLAGS += ["-Wno-c99-designator"]
-CXXFLAGS += subprocess.check_output([llvm_config, "--cxxflags"]).decode(sys.stdout.encoding).strip().split()
+CXXFLAGS += (
+    subprocess.check_output([llvm_config, "--cxxflags"])
+    .decode(sys.stdout.encoding)
+    .strip()
+    .split()
+)
 CXXFLAGS += ["-std=c++17", "-I{}/frontend/include".format(chpl_home)]
 
 LDFLAGS = []
-LDFLAGS += ["-L{}".format(chpl_lib_path), "-lChplFrontendShared", "-Wl,-rpath", chpl_lib_path]
+LDFLAGS += [
+    "-L{}".format(chpl_lib_path),
+    "-lChplFrontendShared",
+    "-Wl,-rpath",
+    chpl_lib_path,
+]
 
 setup(
     name="chapel",
@@ -59,7 +76,7 @@ setup(
         Extension(
             "chapel.core",
             glob.glob("src/*.cpp"),
-            depends = glob.glob("src/**/*.h", recursive=True),
+            depends=glob.glob("src/**/*.h", recursive=True),
             extra_compile_args=CXXFLAGS,
             extra_link_args=LDFLAGS,
         )

--- a/tools/chapel-py/src/chapel/__init__.py
+++ b/tools/chapel-py/src/chapel/__init__.py
@@ -27,6 +27,7 @@ from . import visitor
 
 QualifiedType = typing.Tuple[str, Optional[ChapelType], Optional[Param]]
 
+
 def preorder(node):
     """
     Recursively visit the given AST node, going in pre-order (parent-then-children)
@@ -356,6 +357,7 @@ def files_with_contexts(files):
         for filename in to_yield:
             yield (filename, ctx)
 
+
 def range_to_tokens(
     rng: Location, lines: List[str]
 ) -> List[typing.Tuple[int, int, int]]:
@@ -396,11 +398,13 @@ def range_to_lines(rng: Location, lines: List[str]) -> List[str]:
         text.append(lines[line][column : column + length])
     return text
 
+
 def range_to_text(rng: Location, lines: List[str]) -> str:
     """
     Convert a Chapel location to a single string
     """
     return "\n".join(range_to_lines(rng, lines))
+
 
 def get_file_lines(context: Context, node: AstNode) -> typing.List[str]:
     """

--- a/tools/chapel-py/src/chapel/lsp/__init__.py
+++ b/tools/chapel-py/src/chapel/lsp/__init__.py
@@ -33,6 +33,7 @@ def location_to_range(location) -> Range:
         end=Position(max(0, end[0] - 1), max(end[1] - 1, 0)),
     )
 
+
 def error_to_diagnostic(error) -> Diagnostic:
     """
     Convert a Chapel error into a lsprotocol.types Diagnostic

--- a/tools/chapel-py/src/chapel/visitor/__init__.py
+++ b/tools/chapel-py/src/chapel/visitor/__init__.py
@@ -23,6 +23,7 @@ import chapel.core
 from collections import defaultdict
 from inspect import signature
 
+
 def _try_call(dispatch_table, visitor, node, method_type):
     """
     Not every AST node in the dispatch table has an entry, unless the user
@@ -56,6 +57,7 @@ def _try_call(dispatch_table, visitor, node, method_type):
         node_type = node_type.__base__
     return None
 
+
 def _visitor_visit(dispatch_table):
     def _do_visit(self, node):
         if isinstance(node, list):
@@ -67,7 +69,9 @@ def _visitor_visit(dispatch_table):
             for child in node:
                 _do_visit(self, child)
         _try_call(dispatch_table, self, node, "exit")
+
     return _do_visit
+
 
 def enter(method):
     """
@@ -84,6 +88,7 @@ def enter(method):
     method.__chapel_visitor_method__ = "enter"
     return method
 
+
 def exit(method):
     """
     Annotates a class method as being an 'exit' function. An 'exit'
@@ -92,6 +97,7 @@ def exit(method):
     """
     method.__chapel_visitor_method__ = "exit"
     return method
+
 
 def visitor(clazz):
     """
@@ -112,22 +118,26 @@ def visitor(clazz):
 
     # Detect all visitor-like methods.
     for name, var in vars(clazz).items():
-        if not callable(var): continue
-        if not hasattr(var, "__chapel_visitor_method__"): continue
+        if not callable(var):
+            continue
+        if not hasattr(var, "__chapel_visitor_method__"):
+            continue
 
         sig = signature(var)
-        if 'self' not in sig.parameters: continue
-        if len(sig.parameters) != 2: continue
+        if "self" not in sig.parameters:
+            continue
+        if len(sig.parameters) != 2:
+            continue
 
         # Detect the type of the second argument. It's an OrderedDict
         # so we can use numbers.
         arg = list(sig.parameters.values())[1]
 
         # Check if the type is a subtype of AstNode
-        if not issubclass(arg.annotation, chapel.core.AstNode): continue
+        if not issubclass(arg.annotation, chapel.core.AstNode):
+            continue
 
         dispatch_table[arg.annotation][var.__chapel_visitor_method__] = var
 
     clazz.visit = _visitor_visit(dispatch_table)
     return clazz
-

--- a/tools/chpl-language-server/src/bisect_compat.py
+++ b/tools/chpl-language-server/src/bisect_compat.py
@@ -19,8 +19,9 @@
 
 from typing import Callable, Sequence, Optional
 
+
 # reimplement bisect with a key, since the parameter wasn't added until python 3.10+
-def bisect_right(a: Sequence, x, key: Optional[Callable]=None):
+def bisect_right(a: Sequence, x, key: Optional[Callable] = None):
     lo = 0
     hi = len(a)
 
@@ -35,7 +36,8 @@ def bisect_right(a: Sequence, x, key: Optional[Callable]=None):
             lo = mid + 1
     return lo
 
-def bisect_left(a: Sequence, x, key: Optional[Callable]=None):
+
+def bisect_left(a: Sequence, x, key: Optional[Callable] = None):
     lo = 0
     hi = len(a)
 

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -198,8 +198,7 @@ def decl_kind_to_completion_kind(kind: SymbolKind) -> CompletionItemKind:
 
 
 def completion_item_for_decl(
-    decl: chapel.NamedDecl,
-    override_name: Optional[str] = None
+    decl: chapel.NamedDecl, override_name: Optional[str] = None
 ) -> Optional[CompletionItem]:
     kind = decl_kind(decl)
     if not kind:
@@ -1510,7 +1509,7 @@ def run_lsp():
         fi, _ = ls.get_file_info(text_doc.uri)
 
         items = []
-        for (name, decl) in fi.visible_decls:
+        for name, decl in fi.visible_decls:
             if isinstance(decl, chapel.NamedDecl):
                 items.append(completion_item_for_decl(decl, override_name=name))
         items.extend(completion_item_for_decl(mod) for mod in fi.used_modules)

--- a/tools/chpl-language-server/src/chpl-shim.py
+++ b/tools/chpl-language-server/src/chpl-shim.py
@@ -28,6 +28,7 @@ from collections import defaultdict
 from chapel import *
 from chapel.core import *
 
+
 def list_parsed_files(files, module_paths):
     ctx = Context()
     ctx.set_module_paths(module_paths, files)
@@ -56,7 +57,11 @@ def run_toplevel():
     os.symlink(__file__, wrapper)
 
     # Modify path to include the wrapper script at the front
-    chpl = subprocess.check_output(["which", "chpl"]).decode(sys.stdout.encoding).strip()
+    chpl = (
+        subprocess.check_output(["which", "chpl"])
+        .decode(sys.stdout.encoding)
+        .strip()
+    )
     newpath = os.pathsep.join([tempdir.name, os.environ["PATH"]])
 
     newenv = os.environ.copy()
@@ -89,8 +94,10 @@ def run_chpl_shim():
     tmpfile_path = os.environ["CHPL_SHIM_TARGET_PATH"]
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('filename', nargs='*')
-    parser.add_argument('-M', '--module-dir', action='append', dest="module_dirs", default=[])
+    parser.add_argument("filename", nargs="*")
+    parser.add_argument(
+        "-M", "--module-dir", action="append", dest="module_dirs", default=[]
+    )
 
     args, _ = parser.parse_known_args()
     files = args.filename
@@ -109,12 +116,16 @@ def run_chpl_shim():
     for file in files:
         invocation = " ".join(sys.argv).replace(__file__, real_compiler)
         commands[file] = {
-        #   "invocation": invocation,
-            "module_dirs": [os.path.abspath(mod_dir) for mod_dir in args.module_dirs],
+            #   "invocation": invocation,
+            "module_dirs": [
+                os.path.abspath(mod_dir) for mod_dir in args.module_dirs
+            ],
             "files": files,
         }
 
-    tmpfile = tempfile.NamedTemporaryFile(mode="w", delete=False, dir=tmpfile_path, suffix=".json")
+    tmpfile = tempfile.NamedTemporaryFile(
+        mode="w", delete=False, dir=tmpfile_path, suffix=".json"
+    )
 
     # Convert to json
     with tmpfile as f:

--- a/tools/chpl-language-server/src/symbol_signature.py
+++ b/tools/chpl-language-server/src/symbol_signature.py
@@ -256,11 +256,12 @@ def _proc_to_string(node: chapel.Function) -> List[Component]:
     if node.is_inline():
         comps.append(_wrap_str("inline "))
 
-
     comps.append(_wrap_str(f"{node.kind()} "))
     # if it has a this-formal, check for this intent
     if node.this_formal() and _intent_to_string(node.this_formal().intent()):
-        comps.append(_wrap_str(f"{_intent_to_string(node.this_formal().intent())} "))
+        comps.append(
+            _wrap_str(f"{_intent_to_string(node.this_formal().intent())} ")
+        )
     comps.append(_wrap_str(node.name()))
 
     if not node.is_parenless():

--- a/tools/chplcheck/src/chplcheck.py
+++ b/tools/chplcheck/src/chplcheck.py
@@ -67,8 +67,20 @@ def load_module(driver: LintDriver, file_path: str):
 
 
 def int_to_nth(n: int) -> str:
-    d = {1: "first", 2: "second", 3: "third", 4: "fourth", 5: "fifth", 6: "sixth", 7: "seventh", 8: "eighth", 9: "ninth", 10: "tenth"}
+    d = {
+        1: "first",
+        2: "second",
+        3: "third",
+        4: "fourth",
+        5: "fifth",
+        6: "sixth",
+        7: "seventh",
+        8: "eighth",
+        9: "ninth",
+        10: "tenth",
+    }
     return d.get(n, f"{n}th")
+
 
 def apply_fixits(
     violations: List[Tuple[chapel.AstNode, str, Optional[List[Fixit]]]],
@@ -114,7 +126,9 @@ def apply_fixits(
                         edits_to_apply.extend(fixit.edits)
                         done = True
                     except (ValueError, IndexError):
-                        print("Please enter a number corresponding to an option")
+                        print(
+                            "Please enter a number corresponding to an option"
+                        )
             except KeyboardInterrupt:
                 # apply no edits, return the original violations
                 return violations
@@ -183,19 +197,60 @@ def print_rules(driver: LintDriver, show_all=True):
 
 
 def main():
-    parser = argparse.ArgumentParser(prog="chplcheck", description="A linter for the Chapel language")
+    parser = argparse.ArgumentParser(
+        prog="chplcheck", description="A linter for the Chapel language"
+    )
     parser.add_argument("filenames", nargs="*")
-    parser.add_argument("--disable-rule", action="append", dest="disabled_rules", default=[])
-    parser.add_argument("--enable-rule", action="append", dest="enabled_rules", default=[])
+    parser.add_argument(
+        "--disable-rule", action="append", dest="disabled_rules", default=[]
+    )
+    parser.add_argument(
+        "--enable-rule", action="append", dest="enabled_rules", default=[]
+    )
     parser.add_argument("--lsp", action="store_true", default=False)
     parser.add_argument("--skip-unstable", action="store_true", default=False)
-    parser.add_argument("--internal-prefix", action="append", dest="internal_prefixes", default=[])
-    parser.add_argument("--add-rules", action="append", default=[], help="Add a custom rule file")
-    parser.add_argument("--list-rules", action="store_true", default=False, help="List all available rules")
-    parser.add_argument("--list-active-rules", action="store_true", default=False,  help="List all currently enabled rules")
-    parser.add_argument("--fixit", action="store_true", default=False, help="Apply fixits for the relevant rules")
-    parser.add_argument("--fixit-suffix", default=None, help="Suffix to append to the original file name when applying fixits. If not set (the default), the original file will be overwritten.")
-    parser.add_argument("--interactive", "-i", action="store_true", default=False, help="Apply fixits interactively, requires --fixit")
+    parser.add_argument(
+        "--internal-prefix",
+        action="append",
+        dest="internal_prefixes",
+        default=[],
+    )
+    parser.add_argument(
+        "--add-rules",
+        action="append",
+        default=[],
+        help="Add a custom rule file",
+    )
+    parser.add_argument(
+        "--list-rules",
+        action="store_true",
+        default=False,
+        help="List all available rules",
+    )
+    parser.add_argument(
+        "--list-active-rules",
+        action="store_true",
+        default=False,
+        help="List all currently enabled rules",
+    )
+    parser.add_argument(
+        "--fixit",
+        action="store_true",
+        default=False,
+        help="Apply fixits for the relevant rules",
+    )
+    parser.add_argument(
+        "--fixit-suffix",
+        default=None,
+        help="Suffix to append to the original file name when applying fixits. If not set (the default), the original file will be overwritten.",
+    )
+    parser.add_argument(
+        "--interactive",
+        "-i",
+        action="store_true",
+        default=False,
+        help="Apply fixits interactively, requires --fixit",
+    )
     args = parser.parse_args()
 
     driver = LintDriver(
@@ -238,7 +293,9 @@ def main():
             violations.sort(key=lambda f: f[0].location().start()[0])
 
             if args.fixit:
-                violations = apply_fixits(violations, args.fixit_suffix, args.interactive)
+                violations = apply_fixits(
+                    violations, args.fixit_suffix, args.interactive
+                )
 
             for node, rule, _ in violations:
                 print_violation(node, rule)

--- a/tools/chplcheck/src/fixits.py
+++ b/tools/chplcheck/src/fixits.py
@@ -35,9 +35,7 @@ class Edit:
 
     @classmethod
     def build(cls, location: chapel.Location, text: str) -> "Edit":
-        return Edit(
-            location.path(), location.start(), location.end(), text
-        )
+        return Edit(location.path(), location.start(), location.end(), text)
 
     @classmethod
     def to_dict(cls, fixit: "Edit") -> typing.Dict:

--- a/tools/chplcheck/src/lsp.py
+++ b/tools/chplcheck/src/lsp.py
@@ -152,7 +152,9 @@ def run_lsp(driver: LintDriver):
                     start = e.start
                     end = e.end
                     rng = Range(
-                        start=Position(max(start[0] - 1, 0), max(start[1] - 1, 0)),
+                        start=Position(
+                            max(start[0] - 1, 0), max(start[1] - 1, 0)
+                        ),
                         end=Position(max(end[0] - 1, 0), max(end[1] - 1, 0)),
                     )
                     edit = TextEdit(range=rng, new_text=e.text)

--- a/tools/chplcheck/src/rule_types.py
+++ b/tools/chplcheck/src/rule_types.py
@@ -22,23 +22,33 @@ import typing
 import chapel
 from fixits import Fixit, Edit
 
-def _build_ignore_fixit(anchor: chapel.AstNode, lines: typing.List[str], rule_name: str) -> Fixit:
+
+def _build_ignore_fixit(
+    anchor: chapel.AstNode, lines: typing.List[str], rule_name: str
+) -> Fixit:
     # TODO: how should this handle multiple ignores?
     loc = anchor.location()
     text = chapel.range_to_text(loc, lines)
     indent_amount = max(loc.start()[1] - 1, 0)
-    indent = " "* indent_amount
+    indent = " " * indent_amount
     text = f'@chplcheck.ignore("{rule_name}")\n' + indent + text
     ignore = Fixit.build(Edit.build(loc, text))
     ignore.description = "Ignore this warning"
     return ignore
+
 
 class BasicRuleResult:
     """
     Result type for basic rules. Rules can also return a plain boolean to
     represent a simple pass/fail result, with no fixit.
     """
-    def __init__(self, node: chapel.AstNode, ignorable: bool = False, fixits: typing.Optional[typing.Union[Fixit, typing.List[Fixit]]] = None):
+
+    def __init__(
+        self,
+        node: chapel.AstNode,
+        ignorable: bool = False,
+        fixits: typing.Optional[typing.Union[Fixit, typing.List[Fixit]]] = None,
+    ):
         self.node = node
         self.ignorable = ignorable
         if fixits is None:
@@ -60,7 +70,6 @@ class BasicRuleResult:
         return to_return
 
 
-
 _BasicRuleResult = typing.Union[bool, BasicRuleResult]
 """Internal type for basic rule results"""
 BasicRule = typing.Callable[[chapel.Context, chapel.AstNode], _BasicRuleResult]
@@ -72,7 +81,13 @@ class AdvancedRuleResult:
     Result type for advanced rules. Advanced rules can also return a plain
     boolean to represent a simple pass/fail result, with no fixit. Having an anchor implies that it is ignorable
     """
-    def __init__(self, node: chapel.AstNode, anchor: typing.Optional[chapel.AstNode] = None, fixits: typing.Optional[typing.Union[Fixit, typing.List[Fixit]]] = None):
+
+    def __init__(
+        self,
+        node: chapel.AstNode,
+        anchor: typing.Optional[chapel.AstNode] = None,
+        fixits: typing.Optional[typing.Union[Fixit, typing.List[Fixit]]] = None,
+    ):
         self.node = node
         self.anchor = anchor
         if fixits is None:

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -26,6 +26,7 @@ from driver import LintDriver
 from fixits import Fixit, Edit
 from rule_types import BasicRuleResult, AdvancedRuleResult
 
+
 def variables(node: AstNode):
     if isinstance(node, Variable):
         if node.name() != "_":
@@ -34,7 +35,12 @@ def variables(node: AstNode):
         for child in node:
             yield from variables(child)
 
-def fixit_remove_unused_node(node: AstNode, lines: Optional[List[str]] = None, context: Optional[Context] = None) -> Optional[Fixit]:
+
+def fixit_remove_unused_node(
+    node: AstNode,
+    lines: Optional[List[str]] = None,
+    context: Optional[Context] = None,
+) -> Optional[Fixit]:
     """
     Given an unused variable that's either a child of a TupleDecl or an
     iterand in a loop, construct a Fixit that removes it or replaces it
@@ -67,6 +73,7 @@ def fixit_remove_unused_node(node: AstNode, lines: Optional[List[str]] = None, c
         return Fixit.build(Edit.build(loc, before_lines + after_lines))
     return None
 
+
 def name_for_linting(context: Context, node: NamedDecl) -> str:
     name = node.name()
 
@@ -88,6 +95,7 @@ def check_pascal_case(context: Context, node: NamedDecl):
     return re.fullmatch(
         r"(([A-Z][a-z]*|\d+)+|[A-Z]+)?", name_for_linting(context, node)
     )
+
 
 def register_rules(driver: LintDriver):
     @driver.basic_rule(VarLikeDecl, default=False)
@@ -232,7 +240,9 @@ def register_rules(driver: LintDriver):
         # should be set in all branches
         assert text is not None
 
-        return BasicRuleResult(node, fixits=Fixit.build(Edit.build(node.location(), text)))
+        return BasicRuleResult(
+            node, fixits=Fixit.build(Edit.build(node.location(), text))
+        )
 
     @driver.basic_rule(NamedDecl)
     def ChplPrefixReserved(context: Context, node: NamedDecl):
@@ -270,7 +280,9 @@ def register_rules(driver: LintDriver):
             # dont warn if the EmptyStmt is the only statement in a block
             return True
 
-        return BasicRuleResult(node, fixits=Fixit.build(Edit.build(node.location(), "")))
+        return BasicRuleResult(
+            node, fixits=Fixit.build(Edit.build(node.location(), ""))
+        )
 
     @driver.basic_rule(TupleDecl)
     def UnusedTupleUnpack(context: Context, node: TupleDecl):
@@ -280,7 +292,7 @@ def register_rules(driver: LintDriver):
 
         varset = set(variables(node))
         if len(varset) == 0:
-            fixit = fixit_remove_unused_node(node, context = context)
+            fixit = fixit_remove_unused_node(node, context=context)
             if fixit is not None:
                 return BasicRuleResult(node, fixits=fixit)
             return False
@@ -563,7 +575,7 @@ def register_rules(driver: LintDriver):
                 Interface,
                 Union,
                 Enum,
-                Cobegin
+                Cobegin,
             )
             return isinstance(node, classes)
 
@@ -603,7 +615,10 @@ def register_rules(driver: LintDriver):
         # For implicit modules, proper code will technically be on the same
         # line as the module's body. But we don't want to warn about that,
         # since we don't want to ask all code to be indented one level deeper.
-        elif not (isinstance(parent_for_indentation, Module) and parent_for_indentation.kind() == "implicit"):
+        elif not (
+            isinstance(parent_for_indentation, Module)
+            and parent_for_indentation.kind() == "implicit"
+        ):
             parent_depth = parent_for_indentation.location().start()[1]
 
         prev = None
@@ -619,7 +634,8 @@ def register_rules(driver: LintDriver):
             iterable = root.stmts()
 
         for child in iterable:
-            if isinstance(child, Comment): continue
+            if isinstance(child, Comment):
+                continue
 
             # some NamedDecl nodes currently use the name as the location, which
             # does not indicate their actual indentation.
@@ -653,7 +669,11 @@ def register_rules(driver: LintDriver):
             elif prev_depth and depth != prev_depth:
                 # Special case, slightly coarse: avoid double-warning with
                 # MisleadingIndentation
-                if not(prev and isinstance(prev, Loop) and prev.block_style() == "implicit"):
+                if not (
+                    prev
+                    and isinstance(prev, Loop)
+                    and prev.block_style() == "implicit"
+                ):
                     yield child
 
                 # Do not update 'prev_depth'; use original prev_depth as


### PR DESCRIPTION
We've done this before on files such as `chpl-language-server.py` or `chplcheck.py` or `rules.py`. This PR just does that again, but also applies it to other, less-often formatted files.

Reviewed by @jabraham17 -- thanks!

## Testing
- [x] validated using the new CI check