### PR TITLE
Add environment variables to always build chapel-py and CLS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,9 @@ comprt: FORCE
 	@$(MAKE) third-party-try-opt
 	@$(MAKE) always-build-test-venv
 	@$(MAKE) always-build-chpldoc
+	@$(MAKE) always-build-chapel-py
 	@$(MAKE) always-build-chplcheck
+	@$(MAKE) always-build-cls
 	@$(MAKE) runtime
 	@$(MAKE) modules
 
@@ -159,9 +161,19 @@ always-build-chpldoc: FORCE
 	$(MAKE) chpldoc; \
 	fi
 
+always-build-chapel-py: FORCE
+	-@if [ -n "$$CHPL_ALWAYS_BUILD_CHAPEL_PY" ]; then \
+	$(MAKE) chapel-py-venv; \
+	fi
+
 always-build-chplcheck: FORCE
 	-@if [ -n "$$CHPL_ALWAYS_BUILD_CHPLCHECK" ]; then \
 	$(MAKE) chplcheck; \
+	fi
+
+always-build-cls: FORCE
+	-@if [ -n "$$CHPL_ALWAYS_BUILD_CHPL_LANGUAGE_SERVER" ]; then \
+	$(MAKE) chpl-language-server; \
 	fi
 
 chplvis: compiler third-party-fltk FORCE


### PR DESCRIPTION
Fixes https://github.com/chapel-lang/chapel/issues/24871.

This PR adds two more environment variables, `CHPL_ALWAYS_BUILD_CHAPEL_PY` and `CHPL_ALWAYS_BUILD_LANGUAGE_SERVER`, to build `chapel-py` and `chpl-language-server` on `make -j32`. This will help in situations such as setting off `paratests`: simply running `make -j32` will be enough to make sure that Python environment is up to date, ensuring that `chplcheck` (etc.) tests run. This should help catch `chplcheck` bugs as they come up.