### PR TITLE
Extend symbol signature to work FnCall

### DIFF
--- a/tools/chpl-language-server/src/symbol_signature.py
+++ b/tools/chpl-language-server/src/symbol_signature.py
@@ -142,6 +142,8 @@ def _get_symbol_signature(node: chapel.AstNode) -> List[Component]:
         return _var_to_string(node)
     elif isinstance(node, chapel.Function):
         return _proc_to_string(node)
+    elif isinstance(node, chapel.TypeQuery):
+        return [_wrap_str(f"?{node.name()}")]
 
     return [_wrap_str(node.name())]
 
@@ -171,6 +173,8 @@ def _node_to_string(node: chapel.AstNode) -> List[Component]:
         return [_wrap_str('"' + node.value() + '"')]
     elif isinstance(node, chapel.CStringLiteral):
         return [_wrap_str('c"' + node.value() + '"')]
+    elif isinstance(node, chapel.FnCall):
+        return _fncall_to_string(node)
     return [Component(ComponentTag.PLACEHOLDER, None)]
 
 
@@ -300,3 +304,20 @@ def _intent_to_string(intent: Optional[str]) -> str:
     }
     # use 'intent' as the default, so if no remap no work done
     return remap.get(intent, intent) if intent else ""
+
+def _fncall_to_string(call: chapel.FnCall) -> List[Component]:
+    """
+    Convert a call to a string
+    """
+    comps = []
+
+    comps.extend(_node_to_string(call.called_expression()))
+    comps.append(_wrap_str("[" if call.used_square_brackets() else "("))
+    sep = ""
+    for a in call.actuals():
+        comps.append(_wrap_str(sep))
+        sep = ", "
+        comps.extend(_node_to_string(a))
+    comps.append(_wrap_str("]" if call.used_square_brackets() else ")"))
+
+    return comps

--- a/tools/chpl-language-server/src/symbol_signature.py
+++ b/tools/chpl-language-server/src/symbol_signature.py
@@ -317,7 +317,13 @@ def _fncall_to_string(call: chapel.FnCall) -> List[Component]:
     for a in call.actuals():
         comps.append(_wrap_str(sep))
         sep = ", "
-        comps.extend(_node_to_string(a))
+        if isinstance(a, tuple):
+            comps.append(_wrap_str(a[0]))
+            comps.append(_wrap_str(" = "))
+            comps.extend(_node_to_string(a[1]))
+        else:
+            assert(isinstance(a, chapel.AstNode))
+            comps.extend(_node_to_string(a))
     comps.append(_wrap_str("]" if call.used_square_brackets() else ")"))
 
     return comps

--- a/tools/chpl-language-server/src/symbol_signature.py
+++ b/tools/chpl-language-server/src/symbol_signature.py
@@ -305,6 +305,7 @@ def _intent_to_string(intent: Optional[str]) -> str:
     # use 'intent' as the default, so if no remap no work done
     return remap.get(intent, intent) if intent else ""
 
+
 def _fncall_to_string(call: chapel.FnCall) -> List[Component]:
     """
     Convert a call to a string
@@ -312,7 +313,8 @@ def _fncall_to_string(call: chapel.FnCall) -> List[Component]:
     comps = []
 
     comps.extend(_node_to_string(call.called_expression()))
-    comps.append(_wrap_str("[" if call.used_square_brackets() else "("))
+    openbr, closebr = ("[", "]") if call.used_square_brackets() else ("(", ")")
+    comps.append(_wrap_str(openbr))
     sep = ""
     for a in call.actuals():
         comps.append(_wrap_str(sep))
@@ -322,8 +324,8 @@ def _fncall_to_string(call: chapel.FnCall) -> List[Component]:
             comps.append(_wrap_str(" = "))
             comps.extend(_node_to_string(a[1]))
         else:
-            assert(isinstance(a, chapel.AstNode))
+            assert isinstance(a, chapel.AstNode)
             comps.extend(_node_to_string(a))
-    comps.append(_wrap_str("]" if call.used_square_brackets() else ")"))
+    comps.append(_wrap_str(closebr))
 
     return comps


### PR DESCRIPTION
Extends symbol signature to be able to print out FnCalls. This is important for function signatures like `proc foo(a: int(?w), b: real(32))`

Tested locally

[Reviewed by @DanilaFe]