### PR TITLE
Fix rst rendering in `task-parallelism-and-synchronization`

### DIFF
--- a/doc/rst/language/spec/task-parallelism-and-synchronization.rst
+++ b/doc/rst/language/spec/task-parallelism-and-synchronization.rst
@@ -41,7 +41,7 @@ details task parallelism as follows:
    way to suppress parallelism.
 
 -  :ref:`Yield_Task_Execution` describes yielding the current tasks
-    execution.
+   execution.
 
 
 .. index::


### PR DESCRIPTION
Remove a whitespace to fix rst rendering in `task-parallelism-and-synchronization` language spec.

The old behavior causes the last item in the list to be bold, along with a line-break:

![rst_render](https://github.com/chapel-lang/chapel/assets/72358009/9900a8d6-8d7c-4cca-9be5-fdab5ebffc66)
