### PR TITLE
Exclude operators from completion suggestions in CLS

### DIFF
--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -209,6 +209,11 @@ def completion_item_for_decl(
     if kind == SymbolKind.Method:
         return None
 
+    # We don't want to show operators in completion lists, as they're
+    # not really useful to the user in this context.
+    if kind == SymbolKind.Operator:
+        return None
+
     name_to_use = override_name if override_name else decl.name()
     return CompletionItem(
         label=name_to_use,


### PR DESCRIPTION
Exclude operators from completion suggestions in CLS, as these show up first in some editors alphabetically and are not really that useful to users

Tested locally

[Reviewed by @DanilaFe]