### PR TITLE
Fix chplcheck bug with IncorrectIndentation and attributes

### DIFF
--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -632,6 +632,10 @@ def register_rules(driver: LintDriver):
             iterable = root.decls_or_comments()
         elif isinstance(root, SimpleBlockLike):
             iterable = root.stmts()
+        elif isinstance(root, Module) and root.attribute_group() is not None:
+            # attribute group is the first child, skip it
+            iterable = list(root)[1:]
+
 
         for child in iterable:
             if isinstance(child, Comment):

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -636,7 +636,6 @@ def register_rules(driver: LintDriver):
             # attribute group is the first child, skip it
             iterable = list(root)[1:]
 
-
         for child in iterable:
             if isinstance(child, Comment):
                 continue


### PR DESCRIPTION
Fixes an issue with the `IncorrectIndentation` lint rule where a module level attribute was treated as a child of the module

For example:
```chapel
@myAttribute() // Warning: IncorrectIndentation
module foo {
  ...
}
```

This is fixed by skipping the AttributeGroup, if it exists

Tested locally

[Reviewed by @DanilaFe]