### PR TITLE
Dial the version numbers on the man pages down to just major.minor

### DIFF
--- a/man/confchpl.rst
+++ b/man/confchpl.rst
@@ -1,5 +1,5 @@
 
-:Version: 2.1.0 pre-release
+:Version: 2.1 pre-release
 :Manual section: 1
 :Title: \\fBchpl\\fP
 :Subtitle: Compiler for the Chapel Programming Language

--- a/man/confchpldoc.rst
+++ b/man/confchpldoc.rst
@@ -1,5 +1,5 @@
 
-:Version: 2.1.0 pre-release
+:Version: 2.1 pre-release
 :Manual section: 1
 :Title: \\fBchpldoc\\fP
 :Subtitle: the Chapel Documentation Tool


### PR DESCRIPTION
Rationale: man pages shouldn't need to be updated in major ways with updates to minor releases, and having them reflect those numbers suggests they do while also introducing overhead when such releases need to be made.
