### PR TITLE
fix dyno resolution of multi-decls as fields 

### DIFF
--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -1076,13 +1076,12 @@ idToContainingMultiDeclIdQuery(Context* context, ID id) {
   QUERY_BEGIN(idToContainingMultiDeclIdQuery, context, id);
 
   ID cur = id;
-  AstTag myTag = idToTag(context, id);
-  // TODO: do we need this assert? We should be able to normalize pretty much
-  // anything here, no?
-  CHPL_ASSERT(isVariable(myTag)  ||
-              isMultiDecl(myTag) ||
-              isTupleDecl(myTag) ||
-              isForwardingDecl(myTag));
+  AstTag tagForId = idToTag(context, id);
+  // TODO: do we really need this assert? In which cases do we arrive here unexpectedly?
+  CHPL_ASSERT(isVariable(tagForId)  ||
+              isMultiDecl(tagForId) ||
+              isTupleDecl(tagForId) ||
+              isForwardingDecl(tagForId));
 
   while (true) {
     ID parent = idToParentId(context, cur);

--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -1076,7 +1076,13 @@ idToContainingMultiDeclIdQuery(Context* context, ID id) {
   QUERY_BEGIN(idToContainingMultiDeclIdQuery, context, id);
 
   ID cur = id;
-  CHPL_ASSERT(isVariable(idToTag(context, id)));
+  AstTag myTag = idToTag(context, id);
+  // TODO: do we need this assert? We should be able to normalize pretty much
+  // anything here, no?
+  CHPL_ASSERT(isVariable(myTag)  ||
+              isMultiDecl(myTag) ||
+              isTupleDecl(myTag) ||
+              isForwardingDecl(myTag));
 
   while (true) {
     ID parent = idToParentId(context, cur);

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -648,7 +648,11 @@ const ResolvedFields& resolveFieldDecl(Context* context,
     CHPL_ASSERT(typeAst && typeAst->isAggregateDecl());
     auto ad = typeAst->toAggregateDecl();
 
-    auto fieldAst = parsing::idToAst(context, fieldId);
+    // normalize ids in the case they are contained within another decl
+    // this is so we don't try to resolve the type of an individual element without
+    // the context of its container
+    auto stmtId = parsing::idToContainingMultiDeclId(context, fieldId);
+    auto fieldAst = parsing::idToAst(context, stmtId);
     CHPL_ASSERT(fieldAst);
 
     if (ct->instantiatedFromCompositeType() == nullptr) {

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -651,6 +651,11 @@ const ResolvedFields& resolveFieldDecl(Context* context,
     // normalize ids in the case they are contained within another decl
     // this is so we don't try to resolve the type of an individual element without
     // the context of its container
+    // TODO: This could become a performance concern as it gets called for each
+    // element of a multiDecl and the way multiDecl elements are resolved involves
+    // resolving all of the elements of the multiDecl each time, resulting in
+    // quadratic time complexity.  We should consider a more efficient way to
+    // resolve elements of a multiDecl
     auto stmtId = parsing::idToContainingMultiDeclId(context, fieldId);
     auto fieldAst = parsing::idToAst(context, stmtId);
     CHPL_ASSERT(fieldAst);

--- a/frontend/test/resolution/testClasses.cpp
+++ b/frontend/test/resolution/testClasses.cpp
@@ -127,9 +127,39 @@ static void test2() {
   assert(qt.type()->toRecordType()->id() == rec->id());
 }
 
+// test that we can resolve the type of multi-decl fields properly when they
+// they are later used as a return type of a method
+static void test3() {
+  printf("test3\n");
+
+  std::string program = R"""(
+    class C {
+      var a, b : int;
+    }
+
+    proc C.getA() {
+      return a;
+    }
+
+    var foo = new C(40, 2);
+    var x = foo.getA();
+    )""";
+  Context ctx;
+  auto context = &ctx;
+  ErrorGuard guard(context);
+  auto m = parseModule(context, program);
+  auto results = resolveModule(context, m->id());
+  auto var = findVariable(m, "x");
+  auto qt = results.byAst(var).type();
+  assert(qt.type()->isIntType());
+  assert(qt.type()->toIntType()->bitwidth() == 64);
+}
+
+
 int main() {
   test1();
   test2();
+  test3();
 
   return 0;
 }


### PR DESCRIPTION
Updates the resolution of symbols in the body of a method to properly resolve the type of fields that are part of a multi-decl. 

The following reproducer would not resolve properly with `--dyno`:
```

class C {
  var a, b : int;
}

proc C.getA() {
  return a;
}

var foo = new C(40, 2);
var x = foo.getA();
```

because the type of `a`, although previously identified to be `int`, would be `unknown` when evaluating the return type of `getA()` and make `x` erroneous. 

This was happening because in this specific case we were not normalizing the symbol for the possibility it was an element of a multi-decl or tupledecl or other type of decl that is more like a container for other decls. We were attempting to resolve the type of `a` without the information about its multi-decl parent. 


TESTING:
- [x] new test to make sure the reproducer is fixed
- [x] compiling example with `--dyno` only produces errors in `convert-uast`


[reviewed by @DanilaFe - thank you!]
