### PR TITLE
Dyno: Fix init= for generic types initialized from different types

### DIFF
--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -5001,7 +5001,8 @@ void ConvertedSymbolsMap::applyFixups(chpl::Context* context,
 
     FnSymbol* fn = findConvertedFn(target, /* trace */ false);
     if (fn == nullptr) {
-      context->error(inAst, "could not find target function for call fixup %s within %s",
+      auto idForErr = inAst ? inAst->id() : target->id();
+      context->error(idForErr, "could not find target function for call fixup %s within %s",
                  target->untyped()->name().c_str(),
                  inSymbolId.str().c_str());
     }

--- a/frontend/test/resolution/testCallInitDeinit.cpp
+++ b/frontend/test/resolution/testCallInitDeinit.cpp
@@ -546,6 +546,38 @@ static void test5c() {
     });
 }
 
+static void test5d() {
+  testActions("test5d",
+    R""""(
+      module M {
+        operator =(ref lhs: numeric, const in rhs: numeric) {
+          __primitive("=", lhs, rhs);
+        }
+        record R { type T; var field : T; }
+        proc R.init(type T, field = 0) {
+          this.T = T;
+          this.field = field;
+        }
+        proc R.init=(other: ?) {
+          this.T = other.type;
+          this.field = other;
+        }
+        proc R.deinit() { }
+        proc test() {
+          var i = 4;
+          var x:R(?) = i;
+          var y:R(?) = 42.0;
+        }
+      }
+    )"""",
+    {
+      {AssociatedAction::INIT_OTHER,   "x",        ""},
+      {AssociatedAction::INIT_OTHER,   "y",        ""},
+      {AssociatedAction::DEINIT,       "M.test@12", "y"},
+      {AssociatedAction::DEINIT,       "M.test@12", "x"},
+    });
+}
+
 
 // test cross-type variable init from another record
 static void test6a() {
@@ -1662,6 +1694,7 @@ int main() {
   test5a();
   test5b();
   test5c();
+  test5d();
 
   test6a();
   test6b();


### PR DESCRIPTION
This PR updates the ``init=`` implementation to correctly instantiate the declaration when a record is initialized from a type other than that record. For example, something like ``var x : MyWrapperType(?) = 42;``.

There are two parts to this PR:

1) Updating InitResolver to call ``updateResolverVisibleReceiverType`` for each field. This will account for any potential substitutions needed to fully instantiate the type, including fields like ``var x : T;``.

2) In ``Resolver::getTypeForDecl``, using the computed instantiated type from the ``init=`` to set the type of the declaration.

A couple of tests are added to lock in this behavior.

Testing:
- [x] test-dyno
- [x] full local