### PR TITLE
fix tests broken by disallowing `x.init()`; disallow `x.postinit()` as well.

### DIFF
--- a/frontend/lib/uast/post-parse-checks.cpp
+++ b/frontend/lib/uast/post-parse-checks.cpp
@@ -115,6 +115,7 @@ struct Visitor {
   bool handleNestedDecoratorsInTypeConstructors(const FnCall* node);
   void checkForNestedClassDecorators(const FnCall* node);
   void checkExplicitInitCalls(const FnCall* node);
+  void checkExplicitPostinitCalls(const FnCall* node);
   void checkExplicitDeinitCalls(const FnCall* node);
   void checkNewBorrowed(const FnCall* node);
   void checkBorrowFromNew(const FnCall* node);
@@ -649,6 +650,13 @@ void Visitor::checkExplicitInitCalls(const FnCall* node) {
   }
   error(node, "explicit calls to init() on anything other than"
               " 'this' or 'super' are not allowed.");
+}
+
+void Visitor::checkExplicitPostinitCalls(const FnCall* node) {
+  auto calledExpr = isCallToMethodOrFnWithName(node, USTR("postinit"));
+  if (!calledExpr) return;
+
+  error(node, "explicit calls to postinit() are not allowed.");
 }
 
 void Visitor::checkExplicitDeinitCalls(const FnCall* node) {
@@ -1517,6 +1525,7 @@ void Visitor::visit(const FnCall* node) {
   checkNoDuplicateNamedArguments(node);
   checkForNestedClassDecorators(node);
   checkExplicitInitCalls(node);
+  checkExplicitPostinitCalls(node);
   checkExplicitDeinitCalls(node);
   checkNewBorrowed(node);
   checkBorrowFromNew(node);

--- a/frontend/lib/uast/post-parse-checks.cpp
+++ b/frontend/lib/uast/post-parse-checks.cpp
@@ -114,6 +114,7 @@ struct Visitor {
   bool handleNestedDecoratorsInNew(const FnCall* node);
   bool handleNestedDecoratorsInTypeConstructors(const FnCall* node);
   void checkForNestedClassDecorators(const FnCall* node);
+  void reportErrorForNonThisSuperCall(const FnCall* node, UniqueString method);
   void checkExplicitInitCalls(const FnCall* node);
   void checkExplicitPostinitCalls(const FnCall* node);
   void checkExplicitDeinitCalls(const FnCall* node);
@@ -633,13 +634,15 @@ static const AstNode* isCallToMethodOrFnWithName(const FnCall* call,
   return nullptr;
 }
 
-void Visitor::checkExplicitInitCalls(const FnCall* node) {
-  auto calledExpr = isCallToMethodOrFnWithName(node, USTR("init"));
+void Visitor::reportErrorForNonThisSuperCall(const FnCall* node, UniqueString method) {
+  auto calledExpr = isCallToMethodOrFnWithName(node, method);
   if (!calledExpr) return;
 
   if (auto dot = calledExpr->toDot()) {
     if (auto receiverIdent = dot->receiver()->toIdentifier()) {
-      // this.init(..) and super.init(..) are allowed.
+      // this.f(..) and super.f(..) are allowed, by definition of this method.
+      // That is because this method is used for 'init' and 'postinit' checking,
+      // where such code is valid.
       if (receiverIdent->name() == USTR("this") ||
           receiverIdent->name() == USTR("super"))
         return;
@@ -648,15 +651,16 @@ void Visitor::checkExplicitInitCalls(const FnCall* node) {
     // Standalone call; this is implicitly applied to 'this', so no problem.
     return;
   }
-  error(node, "explicit calls to init() on anything other than"
-              " 'this' or 'super' are not allowed.");
+  error(node, "explicit calls to %s() on anything other than"
+              " 'this' or 'super' are not allowed.", method.c_str());
+}
+
+void Visitor::checkExplicitInitCalls(const FnCall* node) {
+  reportErrorForNonThisSuperCall(node, USTR("init"));
 }
 
 void Visitor::checkExplicitPostinitCalls(const FnCall* node) {
-  auto calledExpr = isCallToMethodOrFnWithName(node, USTR("postinit"));
-  if (!calledExpr) return;
-
-  error(node, "explicit calls to postinit() are not allowed.");
+  reportErrorForNonThisSuperCall(node, USTR("postinit"));
 }
 
 void Visitor::checkExplicitDeinitCalls(const FnCall* node) {

--- a/frontend/lib/uast/post-parse-checks.cpp
+++ b/frontend/lib/uast/post-parse-checks.cpp
@@ -669,7 +669,7 @@ void Visitor::checkExplicitDeinitCalls(const FnCall* node) {
     if (fn->name() == "chpl__delete") return;
   }
 
-  error(node, "direct calls to deinit() are not allowed.");
+  error(node, "explicit calls to deinit() are not allowed.");
 }
 
 void Visitor::checkNewBorrowed(const FnCall* node) {

--- a/frontend/test/parsing/testParseChecks.cpp
+++ b/frontend/test/parsing/testParseChecks.cpp
@@ -143,11 +143,11 @@ static void test3(void) {
   assert(guard.numErrors() == 3);
   displayErrors(ctx, guard);
   assertErrorMatches(ctx, guard, 0, "test3.chpl", 2,
-                     "direct calls to deinit() are not allowed");
+                     "explicit calls to deinit() are not allowed");
   assertErrorMatches(ctx, guard, 1, "test3.chpl", 3,
-                     "direct calls to deinit() are not allowed");
+                     "explicit calls to deinit() are not allowed");
   assertErrorMatches(ctx, guard, 2, "test3.chpl", 4,
-                     "direct calls to deinit() are not allowed");
+                     "explicit calls to deinit() are not allowed");
   guard.clearErrors();
 }
 

--- a/test/arrays/methods/specialMethodKeywords.chpl
+++ b/test/arrays/methods/specialMethodKeywords.chpl
@@ -24,13 +24,11 @@ proc C2.postinit() { }
 // deinit can also be used to deinitialize the module
 proc deinit() { }
 
-// Init and postinit can be explicitly called:
+// init, postinit, and deinit cannot be explicitly called:
 var obj = new C();
-obj.init();
-obj.postinit();
-
-// Not so much for deinit:
-obj.deinit();   // [error: Direct calls are disallowed]
+obj.init();         // [error: explicit calls to init() on anything other than 'this' or 'super' are not allowed]
+obj.postinit();     // [error: explicit calls to postinit() are not allowed]
+obj.deinit();       // [error: explicit calls to deinit() are not allowed]
 
 // Using these reserved words as variables names is not OK:
 var init = 42;      // [error: attempt to redefine reserved word 'init']

--- a/test/arrays/methods/specialMethodKeywords.good
+++ b/test/arrays/methods/specialMethodKeywords.good
@@ -1,4 +1,6 @@
-specialMethodKeywords.chpl:33: error: direct calls to deinit() are not allowed
+specialMethodKeywords.chpl:29: error: explicit calls to init() on anything other than 'this' or 'super' are not allowed
+specialMethodKeywords.chpl:30: error: explicit calls to postinit() are not allowed
+specialMethodKeywords.chpl:33: error: explicit calls to deinit() are not allowed
 specialMethodKeywords.chpl:36: error: attempt to redefine reserved word 'init'
 specialMethodKeywords.chpl:37: error: attempt to redefine reserved word 'deinit'
 specialMethodKeywords.chpl:38: error: attempt to redefine reserved word 'postinit'

--- a/test/arrays/methods/specialMethodKeywords.good
+++ b/test/arrays/methods/specialMethodKeywords.good
@@ -1,12 +1,12 @@
 specialMethodKeywords.chpl:29: error: explicit calls to init() on anything other than 'this' or 'super' are not allowed
 specialMethodKeywords.chpl:30: error: explicit calls to postinit() are not allowed
-specialMethodKeywords.chpl:33: error: explicit calls to deinit() are not allowed
-specialMethodKeywords.chpl:36: error: attempt to redefine reserved word 'init'
-specialMethodKeywords.chpl:37: error: attempt to redefine reserved word 'deinit'
-specialMethodKeywords.chpl:38: error: attempt to redefine reserved word 'postinit'
-specialMethodKeywords.chpl:41: error: attempt to redefine reserved word 'init'
-specialMethodKeywords.chpl:42: error: attempt to redefine reserved word 'postinit'
-specialMethodKeywords.chpl:71: In method 'deinit':
-specialMethodKeywords.chpl:71: error: 'return' statements with values are not allowed in deinit
-specialMethodKeywords.chpl:72: In method 'postinit':
-specialMethodKeywords.chpl:72: error: 'return' statements with values are not allowed in postinit
+specialMethodKeywords.chpl:31: error: explicit calls to deinit() are not allowed
+specialMethodKeywords.chpl:34: error: attempt to redefine reserved word 'init'
+specialMethodKeywords.chpl:35: error: attempt to redefine reserved word 'deinit'
+specialMethodKeywords.chpl:36: error: attempt to redefine reserved word 'postinit'
+specialMethodKeywords.chpl:39: error: attempt to redefine reserved word 'init'
+specialMethodKeywords.chpl:40: error: attempt to redefine reserved word 'postinit'
+specialMethodKeywords.chpl:69: In method 'deinit':
+specialMethodKeywords.chpl:69: error: 'return' statements with values are not allowed in deinit
+specialMethodKeywords.chpl:70: In method 'postinit':
+specialMethodKeywords.chpl:70: error: 'return' statements with values are not allowed in postinit

--- a/test/arrays/methods/specialMethodKeywords.good
+++ b/test/arrays/methods/specialMethodKeywords.good
@@ -1,5 +1,5 @@
 specialMethodKeywords.chpl:29: error: explicit calls to init() on anything other than 'this' or 'super' are not allowed
-specialMethodKeywords.chpl:30: error: explicit calls to postinit() are not allowed
+specialMethodKeywords.chpl:30: error: explicit calls to postinit() on anything other than 'this' or 'super' are not allowed
 specialMethodKeywords.chpl:31: error: explicit calls to deinit() are not allowed
 specialMethodKeywords.chpl:34: error: attempt to redefine reserved word 'init'
 specialMethodKeywords.chpl:35: error: attempt to redefine reserved word 'deinit'

--- a/test/classes/deinitializers/deinitExplicitCall.good
+++ b/test/classes/deinitializers/deinitExplicitCall.good
@@ -1,7 +1,7 @@
-deinitExplicitCall.chpl:6: error: direct calls to deinit() are not allowed
-deinitExplicitCall.chpl:10: error: direct calls to deinit() are not allowed
-deinitExplicitCall.chpl:12: error: direct calls to deinit() are not allowed
-deinitExplicitCall.chpl:13: error: direct calls to deinit() are not allowed
+deinitExplicitCall.chpl:6: error: explicit calls to deinit() are not allowed
+deinitExplicitCall.chpl:10: error: explicit calls to deinit() are not allowed
+deinitExplicitCall.chpl:12: error: explicit calls to deinit() are not allowed
+deinitExplicitCall.chpl:13: error: explicit calls to deinit() are not allowed
 deinitExplicitCall.chpl:15: In method 'something':
-deinitExplicitCall.chpl:16: error: direct calls to deinit() are not allowed
-deinitExplicitCall.chpl:17: error: direct calls to deinit() are not allowed
+deinitExplicitCall.chpl:16: error: explicit calls to deinit() are not allowed
+deinitExplicitCall.chpl:17: error: explicit calls to deinit() are not allowed

--- a/test/classes/initializers/postInit/callPostInit.good
+++ b/test/classes/initializers/postInit/callPostInit.good
@@ -1,3 +1,1 @@
-C.init
-C.postinit
-C.postinit
+callPostInit.chpl:15: error: explicit calls to postinit() on anything other than 'this' or 'super' are not allowed

--- a/test/types/records/init/init-post-postinit.bad
+++ b/test/types/records/init/init-post-postinit.bad
@@ -1,3 +1,0 @@
-R.postinit() x: 0
-R.postinit() x: 1
-R.postinit() x: 0

--- a/test/types/records/init/init-post-postinit.future
+++ b/test/types/records/init/init-post-postinit.future
@@ -1,2 +1,0 @@
-bug: Explicit calls to .init and .postinit should not be allowed
-#8991

--- a/test/types/records/init/init-post-postinit.good
+++ b/test/types/records/init/init-post-postinit.good
@@ -1,3 +1,3 @@
-init-post-postinit.chpl:12: error: explicit calls to postinit() are not allowed
+init-post-postinit.chpl:12: error: explicit calls to postinit() on anything other than 'this' or 'super' are not allowed
 init-post-postinit.chpl:13: error: explicit calls to init() on anything other than 'this' or 'super' are not allowed
-init-post-postinit.chpl:14: error: explicit calls to postinit() are not allowed
+init-post-postinit.chpl:14: error: explicit calls to postinit() on anything other than 'this' or 'super' are not allowed

--- a/test/types/records/init/init-post-postinit.good
+++ b/test/types/records/init/init-post-postinit.good
@@ -1,3 +1,3 @@
-init-post-postinit.chpl:12: error: can't call postinit() here
-init-post-postinit.chpl:13: error: can't call init() here
-init-post-postinit.chpl:14: error: can't call postinit() here
+init-post-postinit.chpl:12: error: explicit calls to postinit() are not allowed
+init-post-postinit.chpl:13: error: explicit calls to init() on anything other than 'this' or 'super' are not allowed
+init-post-postinit.chpl:14: error: explicit calls to postinit() are not allowed


### PR DESCRIPTION
Closes #8991; fixes tests broken on `main`.

This PR adjusts some tests that seem to contradict each other on whether or not `x.init()` is allowed for arbitrary `x`. Based on discussion in #8991, it sounds like they should not be allowed. Ruling them out is a relatively simple post-parse check. 

While there, I noted that `x.postinit()` is in a similar spot, and disallowed it too.

Reviewed by @benharsh -- thanks!

## Testing
- [x] paratest