### PR TITLE
Fix tests broken by PR that disallowed `x.init()`

### DIFF
--- a/frontend/lib/uast/post-parse-checks.cpp
+++ b/frontend/lib/uast/post-parse-checks.cpp
@@ -668,7 +668,7 @@ void Visitor::checkExplicitDeinitCalls(const FnCall* node) {
     if (fn->name() == "chpl__delete") return;
   }
 
-  error(node, "direct calls to deinit() are not allowed.");
+  error(node, "explicit calls to deinit() are not allowed.");
 }
 
 void Visitor::checkNewBorrowed(const FnCall* node) {

--- a/frontend/test/parsing/testParseChecks.cpp
+++ b/frontend/test/parsing/testParseChecks.cpp
@@ -143,11 +143,11 @@ static void test3(void) {
   assert(guard.numErrors() == 3);
   displayErrors(ctx, guard);
   assertErrorMatches(ctx, guard, 0, "test3.chpl", 2,
-                     "direct calls to deinit() are not allowed");
+                     "explicit calls to deinit() are not allowed");
   assertErrorMatches(ctx, guard, 1, "test3.chpl", 3,
-                     "direct calls to deinit() are not allowed");
+                     "explicit calls to deinit() are not allowed");
   assertErrorMatches(ctx, guard, 2, "test3.chpl", 4,
-                     "direct calls to deinit() are not allowed");
+                     "explicit calls to deinit() are not allowed");
   guard.clearErrors();
 }
 

--- a/test/arrays/methods/specialMethodKeywords.chpl
+++ b/test/arrays/methods/specialMethodKeywords.chpl
@@ -24,13 +24,11 @@ proc C2.postinit() { }
 // deinit can also be used to deinitialize the module
 proc deinit() { }
 
-// Init and postinit can be explicitly called:
+// postinit can be explicitly called, but not init and deinit
 var obj = new C();
-obj.init();
+obj.init();         // [error: explicit calls to init() on anything other than 'this' or 'super' are not allowed]
 obj.postinit();
-
-// Not so much for deinit:
-obj.deinit();   // [error: Direct calls are disallowed]
+obj.deinit();       // [error: explicit calls to deinit() are not allowed]
 
 // Using these reserved words as variables names is not OK:
 var init = 42;      // [error: attempt to redefine reserved word 'init']

--- a/test/arrays/methods/specialMethodKeywords.good
+++ b/test/arrays/methods/specialMethodKeywords.good
@@ -1,10 +1,11 @@
-specialMethodKeywords.chpl:33: error: direct calls to deinit() are not allowed
-specialMethodKeywords.chpl:36: error: attempt to redefine reserved word 'init'
-specialMethodKeywords.chpl:37: error: attempt to redefine reserved word 'deinit'
-specialMethodKeywords.chpl:38: error: attempt to redefine reserved word 'postinit'
-specialMethodKeywords.chpl:41: error: attempt to redefine reserved word 'init'
-specialMethodKeywords.chpl:42: error: attempt to redefine reserved word 'postinit'
-specialMethodKeywords.chpl:71: In method 'deinit':
-specialMethodKeywords.chpl:71: error: 'return' statements with values are not allowed in deinit
-specialMethodKeywords.chpl:72: In method 'postinit':
-specialMethodKeywords.chpl:72: error: 'return' statements with values are not allowed in postinit
+specialMethodKeywords.chpl:29: error: explicit calls to init() on anything other than 'this' or 'super' are not allowed
+specialMethodKeywords.chpl:31: error: explicit calls to deinit() are not allowed
+specialMethodKeywords.chpl:34: error: attempt to redefine reserved word 'init'
+specialMethodKeywords.chpl:35: error: attempt to redefine reserved word 'deinit'
+specialMethodKeywords.chpl:36: error: attempt to redefine reserved word 'postinit'
+specialMethodKeywords.chpl:39: error: attempt to redefine reserved word 'init'
+specialMethodKeywords.chpl:40: error: attempt to redefine reserved word 'postinit'
+specialMethodKeywords.chpl:69: In method 'deinit':
+specialMethodKeywords.chpl:69: error: 'return' statements with values are not allowed in deinit
+specialMethodKeywords.chpl:70: In method 'postinit':
+specialMethodKeywords.chpl:70: error: 'return' statements with values are not allowed in postinit

--- a/test/classes/deinitializers/deinitExplicitCall.good
+++ b/test/classes/deinitializers/deinitExplicitCall.good
@@ -1,7 +1,7 @@
-deinitExplicitCall.chpl:6: error: direct calls to deinit() are not allowed
-deinitExplicitCall.chpl:10: error: direct calls to deinit() are not allowed
-deinitExplicitCall.chpl:12: error: direct calls to deinit() are not allowed
-deinitExplicitCall.chpl:13: error: direct calls to deinit() are not allowed
+deinitExplicitCall.chpl:6: error: explicit calls to deinit() are not allowed
+deinitExplicitCall.chpl:10: error: explicit calls to deinit() are not allowed
+deinitExplicitCall.chpl:12: error: explicit calls to deinit() are not allowed
+deinitExplicitCall.chpl:13: error: explicit calls to deinit() are not allowed
 deinitExplicitCall.chpl:15: In method 'something':
-deinitExplicitCall.chpl:16: error: direct calls to deinit() are not allowed
-deinitExplicitCall.chpl:17: error: direct calls to deinit() are not allowed
+deinitExplicitCall.chpl:16: error: explicit calls to deinit() are not allowed
+deinitExplicitCall.chpl:17: error: explicit calls to deinit() are not allowed

--- a/test/types/records/init/init-post-postinit.bad
+++ b/test/types/records/init/init-post-postinit.bad
@@ -1,3 +1,1 @@
-R.postinit() x: 0
-R.postinit() x: 1
-R.postinit() x: 0
+init-post-postinit.chpl:13: error: explicit calls to init() on anything other than 'this' or 'super' are not allowed


### PR DESCRIPTION
I somehow missed these in a paratest.

Reviewed by @arezaii -- thanks!

## Testing
- [x] paratest