### PR TITLE
Enable shared-memory bypass comms for co-locales on InfiniBand

### DIFF
--- a/third-party/gasnet/Makefile
+++ b/third-party/gasnet/Makefile
@@ -17,12 +17,9 @@ endif
 
 # PSHM (inter-Process SHared Memory) provide a mechanism for gasnet instances
 # on the same node to communicate through shared memory instead of the real
-# conduit. In "production" we only run a single gasnet client per node so this
-# doesn't help, but for smp it's required, and we've noticed faster testing
-# times since we do local spawning, which will result in multiple gasnet
-# clients on the same node. Note that pshm only works with segment fast/large.
-SUB_SEG = $(CHPL_MAKE_COMM_SUBSTRATE)-$(CHPL_MAKE_COMM_SEGMENT)
-ifneq (,$(findstring $(SUB_SEG), udp-fast udp-large smp-fast smp-large))
+# conduit. This is critical to communication performance for co-locales.
+# Note that pshm only works with segment fast/large.
+ifneq (,$(findstring $(CHPL_MAKE_COMM_SEGMENT), fast large))
 CHPL_GASNET_CFG_OPTIONS += --enable-pshm
 else
 CHPL_GASNET_CFG_OPTIONS += --disable-pshm


### PR DESCRIPTION
### Overview
This PR enables GASNet-level shared-memory bypass communication for all GASNet conduits (in fast/large segment modes), which should notably greatly accelerate co-locale communication for `CHPL_COMM=gasnet CHPL_COMM_SUBSTRATE=ibv`.

This fixes the defect acknowledged in the original PR #13473 regarding use of PSHM with `CHPL_COMM_SUBSTRATE=ibv`.

### TODO:

1. This PR has **not yet been tested for correctness or performance, and thus should be considered a proof-of-concept**.
2. The PR currently only modifies the GASNet-EX backend (i.e. `CHPL_GASNET_VERSION=ex`). Assuming it proves valuable there, then an analogous change probably must be back-ported to the legacy GASNet-1 backend, to avoid breaking it in the presence of co-locales.

CC: @PHHargrove , @ronawho , @jhh67 