### PR TITLE
Track llvm::Value objects during codegen

### DIFF
--- a/compiler/codegen/cg-CForLoop.cpp
+++ b/compiler/codegen/cg-CForLoop.cpp
@@ -25,6 +25,7 @@
 #include "build.h"
 #include "codegen.h"
 #include "driver.h"
+#include "llvmTracker.h"
 #include "llvmVer.h"
 #include "ForLoop.h"
 #include "LayeredValueTable.h"
@@ -329,6 +330,8 @@ GenRet CForLoop::codegen()
 
     blockStmtBody = llvm::BasicBlock::Create(info->module->getContext(), FNAME("blk_body"));
     blockStmtEnd  = llvm::BasicBlock::Create(info->module->getContext(), FNAME("blk_end"));
+    trackLLVMValue(blockStmtBody);
+    trackLLVMValue(blockStmtEnd);
 
     // In order to track more easily with the C backend and because mem2reg should optimize
     // all of these cases, we generate a for loop as the same as
@@ -342,6 +345,7 @@ GenRet CForLoop::codegen()
 
     // Create the init basic block
     blockStmtInit = llvm::BasicBlock::Create(info->module->getContext(), FNAME("blk_c_for_init"));
+    trackLLVMValue(blockStmtInit);
 
 #if HAVE_LLVM_VER >= 160
     func->insert(func->end(), blockStmtInit);
@@ -350,7 +354,8 @@ GenRet CForLoop::codegen()
 #endif
 
     // Insert an explicit branch from the current block to the init block
-    info->irBuilder->CreateBr(blockStmtInit);
+    llvm::BranchInst* toInit = info->irBuilder->CreateBr(blockStmtInit);
+    trackLLVMValue(toInit);
 
     // Now switch to the init block for code generation
     info->irBuilder->SetInsertPoint(blockStmtInit);
@@ -363,13 +368,16 @@ GenRet CForLoop::codegen()
     llvm::Value* condValue0 = test0.val;
 
     // Normalize it to boolean
-    if (condValue0->getType() != llvm::Type::getInt1Ty(info->module->getContext()))
+    if (condValue0->getType() != llvm::Type::getInt1Ty(info->module->getContext())) {
       condValue0 = info->irBuilder->CreateICmpNE(condValue0,
                                                llvm::ConstantInt::get(condValue0->getType(), 0),
                                                FNAME("condition"));
+      trackLLVMValue(condValue0);
+    }
 
     // Create the conditional branch
-    info->irBuilder->CreateCondBr(condValue0, blockStmtBody, blockStmtEnd);
+    llvm::BranchInst* condBr = info->irBuilder->CreateCondBr(condValue0, blockStmtBody, blockStmtEnd);
+    trackLLVMValue(condBr);
 
     // Now add the body.
 #if HAVE_LLVM_VER >= 160
@@ -405,13 +413,16 @@ GenRet CForLoop::codegen()
     llvm::Value* condValue1 = test1.val;
 
     // Normalize it to boolean
-    if (condValue1->getType() != llvm::Type::getInt1Ty(info->module->getContext()))
+    if (condValue1->getType() != llvm::Type::getInt1Ty(info->module->getContext())) {
       condValue1 = info->irBuilder->CreateICmpNE(condValue1,
                                                  llvm::ConstantInt::get(condValue1->getType(), 0),
                                                  FNAME("condition"));
+      trackLLVMValue(condValue1);
+    }
 
     // Create the conditional branch
     llvm::Instruction* endLoopBranch = info->irBuilder->CreateCondBr(condValue1, blockStmtBody, blockStmtEnd);
+    trackLLVMValue(endLoopBranch);
 
     if(loopMetadata)
       addLoopMetadata(endLoopBranch, loopMetadata, accessGroup);

--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -42,6 +42,7 @@
 
 #ifdef HAVE_LLVM
 #include "llvm/IR/Module.h"
+#include "llvmTracker.h"
 #include "llvmUtil.h"
 #include "llvm/IR/IntrinsicsNVPTX.h"
 #include "clang/CodeGen/CGFunctionInfo.h"
@@ -241,10 +242,12 @@ GenRet DefExpr::codegen() {
       if(!(blockLabel = info->lvt->getBlock(sym->cname))) {
         blockLabel = llvm::BasicBlock::Create(
             info->module->getContext(), sym->cname);
+        trackLLVMValue(blockLabel);
         info->lvt->addBlock(sym->cname, blockLabel);
       }
 
-      info->irBuilder->CreateBr(blockLabel);
+      llvm::BranchInst* brInst = info->irBuilder->CreateBr(blockLabel);
+      trackLLVMValue(brInst);
 
 #if HAVE_LLVM_VER >= 160
       func->insert(func->end(), blockLabel);
@@ -349,10 +352,13 @@ static llvm::Value* createInBoundsGEP(llvm::Type* gepType,
     }
   }
 #if HAVE_LLVM_VER >= 130
-  return info->irBuilder->CreateInBoundsGEP(gepType, ptr, idxList);
+  llvm::Value* gep = info->irBuilder->CreateInBoundsGEP(gepType, ptr, idxList);
+  trackLLVMValue(gep);
 #else
-  return info->irBuilder->CreateInBoundsGEP(ptr, idxList);
+  llvm::Value* gep = info->irBuilder->CreateInBoundsGEP(ptr, idxList);
+  trackLLVMValue(gep);
 #endif
+  return gep;
 }
 
 #endif
@@ -437,6 +443,8 @@ GenRet codegenWideAddr(GenRet locale, GenRet raddr, Type* wideType = NULL)
           gepTy, ret.val, WIDE_GEP_ADDR);
       llvm::Value* loc = info->irBuilder->CreateStructGEP(
           gepTy, ret.val, WIDE_GEP_LOC);
+      trackLLVMValue(adr);
+      trackLLVMValue(loc);
 
       llvm::Value* addrVal = raddr.val;
 
@@ -452,8 +460,10 @@ GenRet codegenWideAddr(GenRet locale, GenRet raddr, Type* wideType = NULL)
       INT_ASSERT(addrVal);
 #endif
 
-      info->irBuilder->CreateStore(addrVal, adr);
-      info->irBuilder->CreateStore(locale.val, loc);
+      llvm::StoreInst* st1 = info->irBuilder->CreateStore(addrVal, adr);
+      llvm::StoreInst* st2 = info->irBuilder->CreateStore(locale.val, loc);
+      trackLLVMValue(st1);
+      trackLLVMValue(st2);
 #endif
     }
     // Load whatever we stored...
@@ -486,7 +496,9 @@ GenRet codegenWideAddr(GenRet locale, GenRet raddr, Type* wideType = NULL)
     // we are supposed to have since null has type void*.
     llvm::Value* locAddr = raddr.val;
     locAddr = info->irBuilder->CreatePointerCast(locAddr, locAddrType);
+    trackLLVMValue(locAddr);
     ret.val = info->irBuilder->CreateCall(fn, {locale.val, locAddr});
+    trackLLVMValue(ret.val);
 #endif
   }
 
@@ -567,7 +579,8 @@ void codegenInvariantStart(llvm::Type *valType, llvm::Value *addr)
   llvm::ConstantInt *size = llvm::ConstantInt::getSigned(
       llvm::Type::getInt64Ty(gContext->llvmContext()), sizeInBytes);
 
-  info->irBuilder->CreateInvariantStart(addr, size);
+  llvm::CallInst* istart = info->irBuilder->CreateInvariantStart(addr, size);
+  trackLLVMValue(istart);
 }
 
 // Create an LLVM store instruction possibly adding
@@ -586,6 +599,7 @@ llvm::StoreInst* codegenStoreLLVM(llvm::Value* val,
 {
   GenInfo *info = gGenInfo;
   llvm::StoreInst* ret = info->irBuilder->CreateStore(val, ptr);
+  trackLLVMValue(ret);
   llvm::MDNode* tbaa = NULL;
   if (USE_TBAA && valType &&
       (isClass(valType) || !valType->symbol->llvmTbaaStructCopyNode)) {
@@ -665,6 +679,7 @@ llvm::LoadInst* codegenLoadLLVM(llvm::Value* ptr,
 
   llvm::Type* loadType = computePointerElementType(ptr, valType);
   llvm::LoadInst* ret = info->irBuilder->CreateLoad(loadType, ptr);
+  trackLLVMValue(ret);
 
   llvm::MDNode* tbaa = NULL;
   if (USE_TBAA && valType &&
@@ -937,9 +952,11 @@ static GenRet codegenWideThingField(GenRet ws, WideThingField field)
         INT_ASSERT(ty);
         ret.val = info->irBuilder->CreateConstInBoundsGEP2_32(
                                             ty, ws.val, 0, field);
+        trackLLVMValue(ret.val);
       } else {
         ret.isLVPtr = GEN_VAL;
         ret.val = info->irBuilder->CreateExtractValue(ws.val, field);
+        trackLLVMValue(ret.val);
       }
       assert(ret.val);
     } else {
@@ -990,6 +1007,7 @@ GenRet codegenRaddr(GenRet wide)
                                    addrType);
     INT_ASSERT(fn);
     ret.val = info->irBuilder->CreateCall(fn, wide.val);
+    trackLLVMValue(ret.val);
 #endif
     ret = codegenCast(type, ret);
   }
@@ -1018,6 +1036,7 @@ static GenRet codegenRlocale(GenRet wide)
     llvm::Function* fn = getLocFn(info->module, &info->globalToWideInfo, addrType);
     INT_ASSERT(fn);
     ret.val = info->irBuilder->CreateCall(fn, wide.val);
+    trackLLVMValue(ret.val);
 #endif
   }
   ret.chplType = type;
@@ -1063,6 +1082,7 @@ static GenRet codegenRnode(GenRet wide){
     llvm::Function* fn = getNodeFn(info->module, &info->globalToWideInfo, addrType);
     INT_ASSERT(fn);
     ret.val = info->irBuilder->CreateCall(fn, wide.val);
+    trackLLVMValue(ret.val);
 #endif
   }
 
@@ -1237,6 +1257,7 @@ GenRet doCodegenFieldPtr(
       bool unused;
       ret.val = info->irBuilder->CreateStructGEP(
           baseTy, baseValue, cBaseType->getMemberGEP("_u", unused));
+      trackLLVMValue(ret.val);
       auto addrSpace = baseValue->getType()->getPointerAddressSpace();
       llvm::PointerType* ty = llvm::PointerType::get(retType.type, addrSpace);
       // Now cast it to the right type.
@@ -1256,13 +1277,16 @@ GenRet doCodegenFieldPtr(
         llvm::Type* retTy = genEltType.type;
         INT_ASSERT(retTy);
         ret.val = info->irBuilder->CreateStructGEP(baseTy, baseValue, fieldno);
+        trackLLVMValue(ret.val);
         llvm::StructType* sTy = llvm::cast<llvm::StructType>(baseTy);
         INT_ASSERT(sTy);
         llvm::Type* eltTy = sTy->getElementType(fieldno);
         ret.val = info->irBuilder->CreateStructGEP(eltTy, ret.val, 0);
         ret.isLVPtr = GEN_VAL;
+        trackLLVMValue(ret.val);
       } else {
         ret.val = info->irBuilder->CreateStructGEP(baseTy, baseValue, fieldno);
+        trackLLVMValue(ret.val);
 
         if (isUnion(ct) ||
             // Workaround: since we don't store full function pointer types
@@ -1759,8 +1783,10 @@ GenRet codegenEquals(GenRet a, GenRet b)
    }
    if( av.val->getType()->isFPOrFPVectorTy() ) {
      ret.val = info->irBuilder->CreateFCmpOEQ(av.val, bv.val);
+     trackLLVMValue(ret.val);
    } else {
      ret.val = info->irBuilder->CreateICmpEQ(av.val, bv.val);
+     trackLLVMValue(ret.val);
    }
 #endif
   }
@@ -1787,8 +1813,10 @@ GenRet codegenNotEquals(GenRet a, GenRet b)
    }
    if( av.val->getType()->isFPOrFPVectorTy() ) {
      ret.val = info->irBuilder->CreateFCmpUNE(av.val, bv.val);
+     trackLLVMValue(ret.val);
    } else {
      ret.val = info->irBuilder->CreateICmpNE(av.val, bv.val);
+     trackLLVMValue(ret.val);
    }
 #endif
   }
@@ -1816,12 +1844,15 @@ GenRet codegenLessEquals(GenRet a, GenRet b)
 
     if (values.a->getType()->isFPOrFPVectorTy()) {
       ret.val = gGenInfo->irBuilder->CreateFCmpOLE(values.a, values.b);
+      trackLLVMValue(ret.val);
 
     } else if (!values.isSigned) {
       ret.val = gGenInfo->irBuilder->CreateICmpULE(values.a, values.b);
+      trackLLVMValue(ret.val);
 
     } else {
       ret.val = gGenInfo->irBuilder->CreateICmpSLE(values.a, values.b);
+      trackLLVMValue(ret.val);
     }
 #endif
   }
@@ -1844,6 +1875,7 @@ GenRet codegenLogicalOr(GenRet a, GenRet b)
 #ifdef HAVE_LLVM
     ret.val = info->irBuilder->CreateOr(info->irBuilder->CreateIsNotNull(av.val),
                                         info->irBuilder->CreateIsNotNull(bv.val));
+    trackLLVMValue(ret.val);
 #endif
   }
   return ret;
@@ -1863,6 +1895,7 @@ GenRet codegenLogicalAnd(GenRet a, GenRet b)
 #ifdef HAVE_LLVM
     ret.val = info->irBuilder->CreateAnd(info->irBuilder->CreateIsNotNull(av.val),
                                          info->irBuilder->CreateIsNotNull(bv.val));
+    trackLLVMValue(ret.val);
 #endif
   }
   return ret;
@@ -1919,11 +1952,13 @@ GenRet codegenAdd(GenRet a, GenRet b)
         convertValuesToLarger(av.val, bv.val, a_signed, b_signed);
       if(values.a->getType()->isFPOrFPVectorTy()) {
         ret.val = info->irBuilder->CreateFAdd(values.a, values.b);
+        trackLLVMValue(ret.val);
       } else {
         // Purpose of adding values.isSigned is to generate 'nsw' argument
         // to add instruction if addition happens to be between signed integers.
         // This causes overflowing on adding to be undefined behaviour as in C.
         ret.val = info->irBuilder->CreateAdd(values.a, values.b, "", false, values.isSigned);
+        trackLLVMValue(ret.val);
       }
       ret.isUnsigned = !values.isSigned;
     }
@@ -1960,14 +1995,17 @@ GenRet codegenSub(GenRet a, GenRet b)
       GenRet negbv;
       negbv.val = info->irBuilder->CreateNSWNeg(bv.val);
       negbv.isUnsigned = false;
+      trackLLVMValue(negbv.val);
       ret = codegenAdd(av, negbv);
     } else {
       PromotedPair values =
         convertValuesToLarger(av.val, bv.val, a_signed, b_signed);
       if(values.a->getType()->isFPOrFPVectorTy()) {
         ret.val = info->irBuilder->CreateFSub(values.a, values.b);
+        trackLLVMValue(ret.val);
       } else {
         ret.val = info->irBuilder->CreateSub(values.a, values.b, "", false, values.isSigned);
+        trackLLVMValue(ret.val);
       }
       ret.isUnsigned = !values.isSigned;
     }
@@ -1993,10 +2031,12 @@ GenRet codegenNeg(GenRet a)
       ret = codegenCallExpr("complexUnaryMinus128", av);
     } else if(value->getType()->isFPOrFPVectorTy()) {
       ret.val = info->irBuilder->CreateFNeg(value);
+      trackLLVMValue(ret.val);
     } else {
       bool av_signed = false;
       if(av.chplType) av_signed = is_signed(av.chplType);
       ret.val = info->irBuilder->CreateNeg(value, "", false, av_signed);
+      trackLLVMValue(ret.val);
     }
     ret.isUnsigned = false;
 #endif
@@ -2030,8 +2070,10 @@ GenRet codegenMul(GenRet a, GenRet b)
         convertValuesToLarger(av.val, bv.val, a_signed, b_signed);
       if(values.a->getType()->isFPOrFPVectorTy()) {
         ret.val = info->irBuilder->CreateFMul(values.a, values.b);
+        trackLLVMValue(ret.val);
       } else {
         ret.val = info->irBuilder->CreateMul(values.a, values.b, "", false, values.isSigned);
+        trackLLVMValue(ret.val);
       }
       ret.isUnsigned = !values.isSigned;
     }
@@ -2064,11 +2106,14 @@ GenRet codegenDiv(GenRet a, GenRet b)
                               is_signed(bv.chplType));
       if(values.a->getType()->isFPOrFPVectorTy()) {
         ret.val = info->irBuilder->CreateFDiv(values.a, values.b);
+        trackLLVMValue(ret.val);
       } else {
         if(!values.isSigned) {
           ret.val = info->irBuilder->CreateUDiv(values.a, values.b);
+          trackLLVMValue(ret.val);
         } else {
           ret.val = info->irBuilder->CreateSDiv(values.a, values.b);
+          trackLLVMValue(ret.val);
         }
       }
     }
@@ -2095,11 +2140,14 @@ GenRet codegenMod(GenRet a, GenRet b)
                             is_signed(bv.chplType));
     if(values.a->getType()->isFPOrFPVectorTy()) {
       ret.val = info->irBuilder->CreateFRem(values.a, values.b);
+      trackLLVMValue(ret.val);
     } else {
       if(!values.isSigned) {
         ret.val = info->irBuilder->CreateURem(values.a, values.b);
+        trackLLVMValue(ret.val);
       } else {
         ret.val = info->irBuilder->CreateSRem(values.a, values.b);
+        trackLLVMValue(ret.val);
       }
     }
 #endif
@@ -2136,6 +2184,7 @@ static GenRet emitFmaForLlvm(GenRet av, GenRet bv, GenRet cv) {
   std::vector<llvm::Type*> tys = { ty };
   std::vector<llvm::Value*> args = { av.val, bv.val, cv.val };
   ret.val = info->irBuilder->CreateIntrinsic(id, tys, args);
+  trackLLVMValue(ret.val);
 #endif
 
   return ret;
@@ -2194,6 +2243,7 @@ static GenRet emitSqrtLLVMIntrinsic(GenRet av) {
   std::vector<llvm::Type*> tys = { ty };
   std::vector<llvm::Value*> args = { av.val };
   ret.val = info->irBuilder->CreateIntrinsic(id, tys, args);
+  trackLLVMValue(ret.val);
 #endif
 
   return ret;
@@ -2240,6 +2290,7 @@ static GenRet emitAbsLLVMIntrinsic(GenRet av) {
   std::vector<llvm::Type*> tys = { ty };
   std::vector<llvm::Value*> args = { av.val };
   ret.val = info->irBuilder->CreateIntrinsic(id, tys, args);
+  trackLLVMValue(ret.val);
 #endif
 
   return ret;
@@ -2277,6 +2328,7 @@ GenRet codegenLsh(GenRet a, GenRet b)
     bool av_signed = false;
     if(av.chplType) av_signed = is_signed(av.chplType);
     ret.val = info->irBuilder->CreateShl(av.val, amt, "", false, av_signed);
+    trackLLVMValue(ret.val);
 #endif
   }
   return ret;
@@ -2299,8 +2351,10 @@ GenRet codegenRsh(GenRet a, GenRet b)
                                           is_signed(bv.chplType));
     if(!is_signed(a.chplType)) {
       ret.val = info->irBuilder->CreateLShr(av.val, amt);
+      trackLLVMValue(ret.val);
     } else {
       ret.val = info->irBuilder->CreateAShr(av.val, amt);
+      trackLLVMValue(ret.val);
     }
 #endif
   }
@@ -2324,6 +2378,7 @@ GenRet codegenAnd(GenRet a, GenRet b)
                             is_signed(av.chplType),
                             is_signed(bv.chplType));
     ret.val = info->irBuilder->CreateAnd(values.a, values.b);
+    trackLLVMValue(ret.val);
 #endif
   }
   return ret;
@@ -2346,6 +2401,7 @@ GenRet codegenOr(GenRet a, GenRet b)
                             is_signed(av.chplType),
                             is_signed(bv.chplType));
     ret.val = info->irBuilder->CreateOr(values.a, values.b);
+    trackLLVMValue(ret.val);
 #endif
   }
   return ret;
@@ -2368,6 +2424,7 @@ GenRet codegenXor(GenRet a, GenRet b)
                             is_signed(av.chplType),
                             is_signed(bv.chplType));
     ret.val = info->irBuilder->CreateXor(values.a, values.b);
+    trackLLVMValue(ret.val);
 #endif
   }
   return ret;
@@ -2402,6 +2459,9 @@ GenRet codegenTernary(GenRet cond, GenRet ifTrue, GenRet ifFalse)
         info->module->getContext(), "ternaryBlockIfFalse");
     llvm::BasicBlock *blockEnd = llvm::BasicBlock::Create(
         info->module->getContext(), "ternaryBlockEnd");
+    trackLLVMValue(blockIfTrue);
+    trackLLVMValue(blockIfFalse);
+    trackLLVMValue(blockEnd);
 
     GenRet ifTrueVal = codegenValue(ifTrue);
     GenRet ifFalseVal = codegenValue(ifFalse);
@@ -2413,8 +2473,9 @@ GenRet codegenTernary(GenRet cond, GenRet ifTrue, GenRet ifFalse)
 
     llvm::Value* tmp = createVarLLVM(values.a->getType(), name);
 
-    info->irBuilder->CreateCondBr(
+    llvm::BranchInst* condBr = info->irBuilder->CreateCondBr(
         codegenValue(cond).val, blockIfTrue, blockIfFalse);
+    trackLLVMValue(condBr);
 
 #if HAVE_LLVM_VER >= 160
     func->insert(func->end(), blockIfTrue);
@@ -2422,8 +2483,10 @@ GenRet codegenTernary(GenRet cond, GenRet ifTrue, GenRet ifFalse)
     func->getBasicBlockList().push_back(blockIfTrue);
 #endif
     info->irBuilder->SetInsertPoint(blockIfTrue);
-    info->irBuilder->CreateStore(values.a, tmp);
-    info->irBuilder->CreateBr(blockEnd);
+    llvm::StoreInst* store1 = info->irBuilder->CreateStore(values.a, tmp);
+    trackLLVMValue(store1);
+    llvm::BranchInst* toEnd1 = info->irBuilder->CreateBr(blockEnd);
+    trackLLVMValue(toEnd1);
 
 #if HAVE_LLVM_VER >= 160
     func->insert(func->end(), blockIfFalse);
@@ -2431,8 +2494,10 @@ GenRet codegenTernary(GenRet cond, GenRet ifTrue, GenRet ifFalse)
     func->getBasicBlockList().push_back(blockIfFalse);
 #endif
     info->irBuilder->SetInsertPoint(blockIfFalse);
-    info->irBuilder->CreateStore(values.b, tmp);
-    info->irBuilder->CreateBr(blockEnd);
+    llvm::StoreInst* store2 = info->irBuilder->CreateStore(values.b, tmp);
+    trackLLVMValue(store2);
+    llvm::BranchInst* toEnd2 = info->irBuilder->CreateBr(blockEnd);
+    trackLLVMValue(toEnd2);
 
 #if HAVE_LLVM_VER >= 160
     func->insert(func->end(), blockEnd);
@@ -2441,6 +2506,7 @@ GenRet codegenTernary(GenRet cond, GenRet ifTrue, GenRet ifFalse)
 #endif
     info->irBuilder->SetInsertPoint(blockEnd);
     ret.val = info->irBuilder->CreateLoad(ifTrue.chplType->symbol->getLLVMType(), tmp);
+    trackLLVMValue(ret.val);
 
     ret.isUnsigned = !values.isSigned;
 #endif
@@ -2462,6 +2528,7 @@ GenRet codegenIsZero(GenRet x)
     } else {
 #ifdef HAVE_LLVM
       ret.val = info->irBuilder->CreateIsNull(x.val);
+      trackLLVMValue(ret.val);
 #endif
     }
   } else {
@@ -2470,6 +2537,7 @@ GenRet codegenIsZero(GenRet x)
     else {
 #ifdef HAVE_LLVM
       ret.val = info->irBuilder->CreateIsNull(xv.val);
+      trackLLVMValue(ret.val);
 #endif
     }
   }
@@ -2491,6 +2559,7 @@ GenRet codegenIsNotZero(GenRet x)
     } else {
 #ifdef HAVE_LLVM
       ret.val = info->irBuilder->CreateIsNotNull(x.val);
+      trackLLVMValue(ret.val);
 #endif
     }
   } else {
@@ -2499,6 +2568,7 @@ GenRet codegenIsNotZero(GenRet x)
     else {
 #ifdef HAVE_LLVM
       ret.val = info->irBuilder->CreateIsNotNull(xv.val);
+      trackLLVMValue(ret.val);
 #endif
     }
   }
@@ -2540,8 +2610,10 @@ GenRet codegenGlobalArrayElement(const char* table_name,
 #if HAVE_LLVM_VER >= 130
     llvm::Instruction* element =
       info->irBuilder->CreateLoad(eltTy.type, elementPtr);
+    trackLLVMValue(element);
 #else
     llvm::Instruction* element = info->irBuilder->CreateLoad(elementPtr);
+    trackLLVMValue(element);
 #endif
 
     // I don't think it matters, but we could provide TBAA metadata
@@ -2779,6 +2851,7 @@ static GenRet codegenCallExprInner(GenRet genFn, std::vector<GenRet>& args,
     // Emit the indirect call.
     llvm::CallInst* c = nullptr;
     c = info->irBuilder->CreateCall(fnType, val, llArgs);
+    trackLLVMValue(c);
 
     ret.val = c;
 
@@ -3015,9 +3088,12 @@ static GenRet codegenCallExprInner(GenRet function,
                 // handle offset
                 if (unsigned offset = argInfo->getDirectOffset()) {
                   ptr = irBuilder->CreatePointerCast(ptr, i8PtrTy);
+                  trackLLVMValue(ptr);
                   ptr = irBuilder->CreateConstInBoundsGEP1_32(i8PtrTy, ptr, offset);
+                  trackLLVMValue(ptr);
                 }
                 ptr = irBuilder->CreatePointerCast(ptr, sTyPtrTy);
+                trackLLVMValue(ptr);
 
                 unsigned nElts = sTy->getNumElements();
                 for (unsigned i = 0; i < nElts; i++) {
@@ -3025,11 +3101,15 @@ static GenRet codegenCallExprInner(GenRet function,
 #if HAVE_LLVM_VER >= 130
                   llvm::Value* eltPtr =
                     irBuilder->CreateStructGEP(sTy, ptr, i);
+                  trackLLVMValue(eltPtr);
                   llvm::Value* loaded =
                     irBuilder->CreateLoad(sTy->getElementType(i), eltPtr);
+                  trackLLVMValue(loaded);
 #else
                   llvm::Value* eltPtr = irBuilder->CreateStructGEP(ptr, i);
+                  trackLLVMValue(eltPtr);
                   llvm::Value* loaded = irBuilder->CreateLoad(eltPtr);
+                  trackLLVMValue(loaded);
 #endif
                   llArgs.push_back(loaded);
                 }
@@ -3058,6 +3138,7 @@ static GenRet codegenCallExprInner(GenRet function,
 
             llvm::Type* sTyPtrTy = llvm::PointerType::get(sTy, stackSpace);
             llvm::Value* ptr = irBuilder->CreatePointerCast(tmp.val, sTyPtrTy);
+            trackLLVMValue(ptr);
 
             unsigned nElts = sTy->getNumElements();
             for (unsigned i = 0; i < nElts; i++) {
@@ -3067,13 +3148,15 @@ static GenRet codegenCallExprInner(GenRet function,
 
               // load to produce the next LLVM argument
 #if HAVE_LLVM_VER >= 130
-              llvm::Value* eltPtr =
-                irBuilder->CreateStructGEP(sTy, ptr, i);
-              llvm::Value* loaded =
-                irBuilder->CreateLoad(ty, eltPtr);
+              llvm::Value* eltPtr = irBuilder->CreateStructGEP(sTy, ptr, i);
+              trackLLVMValue(eltPtr);
+              llvm::Value* loaded = irBuilder->CreateLoad(ty, eltPtr);
+              trackLLVMValue(loaded);
 #else
               llvm::Value* eltPtr = irBuilder->CreateStructGEP(ptr, i);
+              trackLLVMValue(eltPtr);
               llvm::Value* loaded = irBuilder->CreateLoad(eltPtr);
+              trackLLVMValue(loaded);
 #endif
               llArgs.push_back(loaded);
             }
@@ -3123,9 +3206,11 @@ static GenRet codegenCallExprInner(GenRet function,
 
     if (func) {
       c = info->irBuilder->CreateCall(func, llArgs);
+      trackLLVMValue(c);
     } else {
       if (!fnType) INT_FATAL("Could not compute called function type");
       c = info->irBuilder->CreateCall(fnType, val, llArgs);
+      trackLLVMValue(c);
     }
 
     if (func) {
@@ -3534,6 +3619,7 @@ void codegenCallMemcpy(GenRet dest, GenRet src, GenRet size,
     // We can't use IRBuilder::CreateMemCpy because that adds
     //  a cast to i8 (in address space 0).
     llvm::CallInst* CI = info->irBuilder->CreateCall(func, llArgs);
+    trackLLVMValue(CI);
 
     llvm::MDNode* tbaaStructTag = NULL;
     if( pointedToType ) {
@@ -3824,6 +3910,7 @@ GenRet codegenCastPtrToInt(Type* toType, GenRet value)
     llvm::Type* castType = toType->codegen().type;
 
     ret.val = info->irBuilder->CreatePtrToInt(value.val, castType);
+    trackLLVMValue(ret.val);
     ret.isLVPtr = GEN_VAL;
     ret.chplType = toType;
     ret.isUnsigned = ! is_signed(toType);
@@ -4535,6 +4622,7 @@ DEFINE_PRIM(RETURN) {
 
     if (call->parentSymbol->hasFlag(FLAG_FUNCTION_TERMINATES_PROGRAM)) {
       returnInst = irBuilder->CreateUnreachable();
+      trackLLVMValue(returnInst);
     } else if (returnInfo) {
       // See CodeGenFunction::EmitFunctionEpilog
 
@@ -4542,6 +4630,7 @@ DEFINE_PRIM(RETURN) {
         case clang::CodeGen::ABIArgInfo::Kind::Ignore:
         {
           returnInst = irBuilder->CreateRetVoid();
+          trackLLVMValue(returnInst);
           break;
         }
 
@@ -4557,6 +4646,7 @@ DEFINE_PRIM(RETURN) {
             llvm::Value* arg = &*ii;
             llvm::Value* sret = irBuilder->CreateStructGEP(
                 nullptr, arg, returnInfo->getInAllocaFieldIndex());
+            trackLLVMValue(sret);
 
             auto align = getPointerAlign(0);
 #if HAVE_LLVM_VER >= 130
@@ -4564,14 +4654,18 @@ DEFINE_PRIM(RETURN) {
                                                           sret,
                                                           align,
                                                           "sret");
+            trackLLVMValue(v);
 #else
             llvm::Value* v = irBuilder->CreateAlignedLoad(sret,
                                                           align,
                                                           "sret");
+            trackLLVMValue(v);
 #endif
             returnInst = irBuilder->CreateRet(v);
+            trackLLVMValue(returnInst);
           } else {
             returnInst = irBuilder->CreateRetVoid();
+            trackLLVMValue(returnInst);
           }
           break;
         }
@@ -4596,6 +4690,7 @@ DEFINE_PRIM(RETURN) {
 
           codegenStoreLLVM(ret, ptr);
           returnInst = irBuilder->CreateRetVoid();
+          trackLLVMValue(returnInst);
           break;
         }
 
@@ -4605,6 +4700,7 @@ DEFINE_PRIM(RETURN) {
           if (returnInfo->getCoerceToType() == returnType &&
               returnInfo->getDirectOffset() == 0) {
             returnInst = irBuilder->CreateRet(ret.val);
+            trackLLVMValue(returnInst);
           } else {
             // offset might be nonzero... what does that mean?
             if (returnInfo->getDirectOffset() != 0)
@@ -4615,6 +4711,7 @@ DEFINE_PRIM(RETURN) {
                                                 !ret.isUnsigned,
                                                 /*force*/ true);
             returnInst = irBuilder->CreateRet(r);
+            trackLLVMValue(returnInst);
           }
           break;
         }
@@ -4636,12 +4733,14 @@ DEFINE_PRIM(RETURN) {
               continue;
 
             auto elt = irBuilder->CreateExtractValue(r, i);
+            trackLLVMValue(elt);
             results.push_back(elt);
           }
 
           // single result should be returned
           if (results.size() == 1) {
             returnInst = irBuilder->CreateRet(results[0]);
+            trackLLVMValue(returnInst);
 
           // Otherwise, form new aggregate without padding
           } else {
@@ -4651,8 +4750,10 @@ DEFINE_PRIM(RETURN) {
             unsigned nResults = results.size();
             for (unsigned i = 0; i < nResults; i++) {
               rv = irBuilder->CreateInsertValue(rv, results[i], i);
+              trackLLVMValue(rv);
             }
             returnInst = irBuilder->CreateRet(rv);
+            trackLLVMValue(returnInst);
           }
 
           break;
@@ -4668,9 +4769,11 @@ DEFINE_PRIM(RETURN) {
     } else {
       if (returnVoid) {
         returnInst = irBuilder->CreateRetVoid();
+        trackLLVMValue(returnInst);
       } else {
         ret = codegenCast(ret.chplType, ret);
         returnInst = irBuilder->CreateRet(ret.val);
+        trackLLVMValue(returnInst);
       }
     }
     ret.val = returnInst;
@@ -4703,6 +4806,7 @@ DEFINE_PRIM(UNARY_NOT) {
     } else {
 #ifdef HAVE_LLVM
       ret.val = gGenInfo->irBuilder->CreateNot(tmp.val);
+      trackLLVMValue(ret.val);
 #endif
     }
 }
@@ -4820,12 +4924,15 @@ DEFINE_PRIM(LESSOREQUAL) {
 
       if (values.a->getType()->isFPOrFPVectorTy()) {
         ret.val = gGenInfo->irBuilder->CreateFCmpOLE(values.a, values.b);
+        trackLLVMValue(ret.val);
 
       } else if (!values.isSigned) {
         ret.val = gGenInfo->irBuilder->CreateICmpULE(values.a, values.b);
+        trackLLVMValue(ret.val);
 
       } else {
         ret.val = gGenInfo->irBuilder->CreateICmpSLE(values.a, values.b);
+        trackLLVMValue(ret.val);
       }
 #endif
     }
@@ -4852,12 +4959,15 @@ DEFINE_PRIM(GREATEROREQUAL) {
 
       if (values.a->getType()->isFPOrFPVectorTy()) {
         ret.val = gGenInfo->irBuilder->CreateFCmpOGE(values.a, values.b);
+        trackLLVMValue(ret.val);
 
       } else if (!values.isSigned) {
         ret.val = gGenInfo->irBuilder->CreateICmpUGE(values.a, values.b);
+        trackLLVMValue(ret.val);
 
       } else {
         ret.val = gGenInfo->irBuilder->CreateICmpSGE(values.a, values.b);
+        trackLLVMValue(ret.val);
       }
 #endif
     }
@@ -4884,12 +4994,15 @@ DEFINE_PRIM(LESS) {
 
       if (values.a->getType()->isFPOrFPVectorTy()) {
         ret.val = gGenInfo->irBuilder->CreateFCmpOLT(values.a, values.b);
+        trackLLVMValue(ret.val);
 
       } else if (!values.isSigned) {
         ret.val = gGenInfo->irBuilder->CreateICmpULT(values.a, values.b);
+        trackLLVMValue(ret.val);
 
       } else {
         ret.val = gGenInfo->irBuilder->CreateICmpSLT(values.a, values.b);
+        trackLLVMValue(ret.val);
       }
 #endif
     }
@@ -4916,12 +5029,15 @@ DEFINE_PRIM(GREATER) {
 
       if (values.a->getType()->isFPOrFPVectorTy()) {
         ret.val = gGenInfo->irBuilder->CreateFCmpOGT(values.a, values.b);
+        trackLLVMValue(ret.val);
 
       } else if (!values.isSigned) {
         ret.val = gGenInfo->irBuilder->CreateICmpUGT(values.a, values.b);
+        trackLLVMValue(ret.val);
 
       } else {
         ret.val = gGenInfo->irBuilder->CreateICmpSGT(values.a, values.b);
+        trackLLVMValue(ret.val);
       }
 #endif
     }
@@ -5519,10 +5635,12 @@ DEFINE_PRIM(GPU_ALLOC_SHARED) {
       *info->module, arrayType, false, llvm::GlobalValue::InternalLinkage,
       llvm::UndefValue::get(arrayType), "gpuSharedMemory", nullptr,
       llvm::GlobalValue::NotThreadLocal, 3, false);
+  trackLLVMValue(sharedArray);
 
   // Get a void* pointer to the shared array.
   llvm::Type* voidPtrType = llvm::Type::getInt8PtrTy(gContext->llvmContext(), 3);
   llvm::Value* sharedArrayPtr = gGenInfo->irBuilder->CreateBitCast(sharedArray, voidPtrType, "sharedArrayPtr");
+  trackLLVMValue(sharedArrayPtr);
 
   ret.val = sharedArrayPtr;
   ret.isLVPtr = GEN_VAL;
@@ -5550,6 +5668,7 @@ DEFINE_PRIM(GPU_SYNC_THREADS) {
   llvm::Function *fun = llvm::Intrinsic::getDeclaration(gGenInfo->module,
     llvm::Intrinsic::nvvm_barrier0);
   ret.val = gGenInfo->irBuilder->CreateCall(fun);
+  trackLLVMValue(ret.val);
   ret.isLVPtr = GEN_VAL;
   ret.chplType = chplReturnType;*/
 
@@ -6018,7 +6137,8 @@ void codegenCallMemset(GenRet dest, Type* type) {
   } else {
 #ifdef HAVE_LLVM
     llvm::ConstantInt* zero = info->irBuilder->getIntN(8, 0);
-    info->irBuilder->CreateMemSet(dest.val, zero, size.val, llvm::Align(1));
+    llvm::CallInst* memset = info->irBuilder->CreateMemSet(dest.val, zero, size.val, llvm::Align(1));
+    trackLLVMValue(memset);
 #endif
   }
 }
@@ -6057,6 +6177,7 @@ DEFINE_PRIM(REGISTER_GLOBAL_VAR) {
       INT_ASSERT(fn);
 
       ptr_wide_ptr.val = gGenInfo->irBuilder->CreateCall(fn, ptr_wide_ptr.val);
+      trackLLVMValue(ptr_wide_ptr.val);
     }
 #endif
 
@@ -6202,8 +6323,10 @@ DEFINE_PRIM(FTABLE_CALL) {
                                      ftable.val, GEPLocs);
 #if HAVE_LLVM_VER >= 130
       fnPtr      = gGenInfo->irBuilder->CreateLoad(genericFnPtr, fnPtrPtr);
+      trackLLVMValue(fnPtr);
 #else
       fnPtr      = gGenInfo->irBuilder->CreateLoad(fnPtrPtr);
+      trackLLVMValue(fnPtr);
 #endif
 
       // Generate an LLVM function type based upon the arguments.
@@ -6235,6 +6358,7 @@ DEFINE_PRIM(FTABLE_CALL) {
       // OK, now cast to the fnTy.
       fngen.val = gGenInfo->irBuilder->CreateBitCast(fnPtr,
                                                      fnTy->getPointerTo());
+      trackLLVMValue(fngen.val);
 #endif
     }
 
@@ -6296,8 +6420,10 @@ DEFINE_PRIM(VIRTUAL_METHOD_CALL) {
 #if HAVE_LLVM_VER >= 130
       llvm::Instruction* fnPtrV =
         gGenInfo->irBuilder->CreateLoad(genericFnPtr, fnPtrPtr);
+      trackLLVMValue(fnPtrV);
 #else
       llvm::Instruction* fnPtrV = gGenInfo->irBuilder->CreateLoad(fnPtrPtr);
+      trackLLVMValue(fnPtrV);
 #endif
       fnPtr.val = fnPtrV;
 #endif
@@ -6435,6 +6561,7 @@ DEFINE_PRIM(BREAKPOINT) {
   else {
     #ifdef HAVE_LLVM
     ret.val = info->irBuilder->CreateIntrinsic(llvm::Intrinsic::debugtrap, {}, {});
+    trackLLVMValue(ret.val);
     #endif
   }
 }

--- a/compiler/codegen/cg-stmt.cpp
+++ b/compiler/codegen/cg-stmt.cpp
@@ -29,6 +29,7 @@
 #include "ImportStmt.h"
 #include "LayeredValueTable.h"
 #include "llvmDebug.h"
+#include "llvmTracker.h"
 #include "llvmVer.h"
 #include "misc.h"
 #include "passes.h"
@@ -152,8 +153,10 @@ GenRet BlockStmt::codegen() {
     getFunction()->codegenUniqueNum++;
 
     blockStmtBody = llvm::BasicBlock::Create(info->module->getContext(), FNAME("blk_body"));
+    trackLLVMValue(blockStmtBody);
 
-    info->irBuilder->CreateBr(blockStmtBody);
+    llvm::BranchInst* toBody = info->irBuilder->CreateBr(blockStmtBody);
+    trackLLVMValue(toBody);
 
     // Now add the body.
 #if HAVE_LLVM_VER >= 160
@@ -252,14 +255,20 @@ CondStmt::codegen() {
         info->module->getContext(),
         FNAME("cond_end"));
 
+    trackLLVMValue(condStmtIf);
+    trackLLVMValue(condStmtThen);
+    trackLLVMValue(condStmtEnd);
+
     if (elseStmt) {
       condStmtElse = llvm::BasicBlock::Create(info->module->getContext(),
                                               FNAME("cond_else"));
+      trackLLVMValue(condStmtElse);
     }
 
     info->lvt->addLayer();
 
-    info->irBuilder->CreateBr(condStmtIf);
+    llvm::BranchInst* toCond = info->irBuilder->CreateBr(condStmtIf);
+    trackLLVMValue(toCond);
 
 #if HAVE_LLVM_VER >= 160
     func->insert(func->end(), condStmtIf);
@@ -278,12 +287,14 @@ CondStmt::codegen() {
           condValue,
           llvm::ConstantInt::get(condValue->getType(), 0),
           FNAME("condition"));
+      trackLLVMValue(condValue);
     }
 
-    info->irBuilder->CreateCondBr(
+    llvm::BranchInst* condBr = info->irBuilder->CreateCondBr(
         condValue,
         condStmtThen,
         (elseStmt) ? condStmtElse : condStmtEnd);
+    trackLLVMValue(condBr);
 
 #if HAVE_LLVM_VER >= 160
     func->insert(func->end(), condStmtThen);
@@ -295,7 +306,8 @@ CondStmt::codegen() {
     info->lvt->addLayer();
     thenStmt->codegen();
 
-    info->irBuilder->CreateBr(condStmtEnd);
+    llvm::BranchInst* toEnd1 = info->irBuilder->CreateBr(condStmtEnd);
+    trackLLVMValue(toEnd1);
     info->lvt->removeLayer();
 
     if(elseStmt) {
@@ -308,7 +320,8 @@ CondStmt::codegen() {
 
       info->lvt->addLayer();
       elseStmt->codegen();
-      info->irBuilder->CreateBr(condStmtEnd);
+      llvm::BranchInst* toEnd2 = info->irBuilder->CreateBr(condStmtEnd);
+      trackLLVMValue(toEnd2);
       info->lvt->removeLayer();
     }
 
@@ -353,15 +366,18 @@ GenRet GotoStmt::codegen() {
     llvm::BasicBlock *blockLabel;
     if(!(blockLabel = info->lvt->getBlock(cname))) {
       blockLabel = llvm::BasicBlock::Create(info->module->getContext(), cname);
+      trackLLVMValue(blockLabel);
       info->lvt->addBlock(cname, blockLabel);
     }
 
-    info->irBuilder->CreateBr(blockLabel);
+    llvm::BranchInst* toLabel = info->irBuilder->CreateBr(blockLabel);
+    trackLLVMValue(toLabel);
 
     getFunction()->codegenUniqueNum++;
 
     llvm::BasicBlock *afterGoto = llvm::BasicBlock::Create(
         info->module->getContext(), FNAME("afterGoto"));
+    trackLLVMValue(afterGoto);
 #if HAVE_LLVM_VER >= 160
     func->insert(func->end(), afterGoto);
 #else

--- a/compiler/include/llvmTracker.h
+++ b/compiler/include/llvmTracker.h
@@ -24,7 +24,9 @@
 extern int breakOnLLVMID;
 
 ///*** set it to 1 to activate trackLLVMValue() ***///
+#ifndef TRACK_LLVM_VALUES
 #define TRACK_LLVM_VALUES 0
+#endif
 
 #ifdef HAVE_LLVM
 namespace llvm {

--- a/compiler/include/llvmTracker.h
+++ b/compiler/include/llvmTracker.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020-2024 Hewlett Packard Enterprise Development LP
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _LLVMTRACKER_H_
+#define _LLVMTRACKER_H_
+
+extern int breakOnLLVMID;
+
+///*** set it to 1 to activate trackLLVMValue() ***///
+#define TRACK_LLVM_VALUES 0
+
+#ifdef HAVE_LLVM
+namespace llvm {
+  class Value; class Function; class BasicBlock; class Instruction;
+}
+
+#if TRACK_LLVM_VALUES ///*** trackLLVMValue is active ***///
+
+// these are defined in llvmUtil.cpp; they return their argument
+const llvm::Value* trackLLVMValue(const llvm::Value* val);
+llvm::Value* trackLLVMValue(llvm::Value* val);
+
+#else //TRACK_LLVM_VALUES ///*** trackLLVMValue is no-op ***///
+
+static inline const llvm::Value* trackLLVMValue(const llvm::Value* val)
+{ return val; }
+
+static inline llvm::Value* trackLLVMValue(llvm::Value* val)
+{ return val; }
+
+#endif //TRACK_LLVM_VALUES
+#endif //HAVE_LLVM
+
+#endif //_LLVMTRACKER_H_

--- a/compiler/include/llvmTracker.h
+++ b/compiler/include/llvmTracker.h
@@ -29,17 +29,19 @@ extern int breakOnLLVMID;
 #endif
 
 #ifdef HAVE_LLVM
-namespace llvm {
-  class Value; class Function; class BasicBlock; class Instruction;
-}
+
+namespace llvm { class Value; }
 
 #if TRACK_LLVM_VALUES ///*** trackLLVMValue is active ***///
+
+#include "llvm/Transforms/Utils/ValueMapper.h"
+void trackClonedLLVMValues(llvm::ValueToValueMapTy& VMap);
 
 // these are defined in llvmUtil.cpp; they return their argument
 const llvm::Value* trackLLVMValue(const llvm::Value* val);
 llvm::Value* trackLLVMValue(llvm::Value* val);
 
-#else //TRACK_LLVM_VALUES ///*** trackLLVMValue is no-op ***///
+#else ///*** trackLLVMValue is no-op ***///
 
 static inline const llvm::Value* trackLLVMValue(const llvm::Value* val)
 { return val; }

--- a/compiler/include/llvmUtil.h
+++ b/compiler/include/llvmUtil.h
@@ -66,7 +66,16 @@ bool isTypeSizeSmallerThan(const llvm::DataLayout& layout, llvm::Type* ty, uint6
 void print_llvm(llvm::Type* t);
 void print_llvm(llvm::Value* v);
 void print_llvm(llvm::Module* m);
-// print_clang is also available in another file
+
+// print_clang() is available in clangUtil.h,cpp
+
+void list_view(const llvm::Type* t);
+void list_view(const llvm::Value* v);
+void list_view(const llvm::Module *m);
+
+void nprint_view(const llvm::Type* t);
+void nprint_view(const llvm::Value* v);
+void nprint_view(const llvm::Module *m);
 
 llvm::AttrBuilder llvmPrepareAttrBuilder(llvm::LLVMContext& ctx);
 

--- a/compiler/llvm/llvmExtractIR.cpp
+++ b/compiler/llvm/llvmExtractIR.cpp
@@ -23,7 +23,6 @@
 #ifdef HAVE_LLVM
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/Module.h"
-#include "llvm/IR/IRPrintingPasses.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/ToolOutputFile.h"
@@ -32,6 +31,7 @@
 #include "llvm/Transforms/Utils/ValueMapper.h"
 #include "llvm/IR/Verifier.h"
 
+#include "llvmTracker.h"
 #include "llvmUtil.h"
 
 #if HAVE_LLVM_VER >= 170
@@ -56,6 +56,9 @@ std::unique_ptr<Module> extractLLVM(const llvm::Module* fromModule,
   auto ownedM = CloneModule(*fromModule, VMap,
                             [&](const GlobalValue *GV) {
                                        return gvs.count(GV) > 0; });
+#if TRACK_LLVM_VALUES
+  trackClonedLLVMValues(VMap);
+#endif
   Module& M = *ownedM.get();
 
   // collect names for the next step
@@ -126,6 +129,33 @@ void removeUnreferencedLLVM(llvm::Module* mod) {
 #endif
 }
 
+//
+// class PrintModuleWithIDs is a slimmed-down version of
+// class PrintModulePassWrapper from lib/IR/IRPrintingPasses.cpp
+// It allows LLVM IDs, see TRACK_LLVM_VALUES / trackLLVMValue(),
+// to be included in the IR printout, when enabled.
+// Beware that --mllvm --filter-print-funcs are not honored
+// when using the class, ex. upon --llvm-print-ir
+//
+class PrintModuleWithIDs : public ModulePass {
+public:
+  static char ID;
+  PrintModuleWithIDs() : ModulePass(ID) {}
+
+  bool runOnModule(Module &M) override {
+    nprint_view(&M);
+    return false;
+  }
+
+  void getAnalysisUsage(AnalysisUsage &AU) const override {
+    AU.setPreservesAll();
+  }
+
+  StringRef getPassName() const override { return "Print Module IR with IDs"; }
+};
+
+char PrintModuleWithIDs::ID = 0;
+
 void extractAndPrintFunctionsLLVM(std::set<const GlobalValue*> *gvs) {
 
   if (gvs == NULL || gvs->size() == 0)
@@ -147,21 +177,10 @@ void extractAndPrintFunctionsLLVM(std::set<const GlobalValue*> *gvs) {
   std::unique_ptr<Module> ownedM = extractLLVM(funcModule, *gvs);
   Module& M = *ownedM.get();
 
-  std::error_code EC;
-  // note: could output to a file if we replace "-" with a filename
-#if HAVE_LLVM_VER >= 120
-  ToolOutputFile Out("-", EC, sys::fs::OF_None);
-#else
-  ToolOutputFile Out("-", EC, sys::fs::F_None);
-#endif
-  if (EC) {
-    errs() << EC.message() << '\n';
-    return;
-  }
-
   // TODO: use the new PassManager
   legacy::PassManager Passes;
-  Passes.add( createPrintModulePass(Out.os(), "", false));
+  Passes.add(new PrintModuleWithIDs());
+
   // note: could output bit code this way:
   //Passes.add(createBitcodeWriterPass(Out.os(), true));
 

--- a/compiler/llvm/llvmUtil.cpp
+++ b/compiler/llvm/llvmUtil.cpp
@@ -31,7 +31,7 @@
 
 #if TRACK_LLVM_VALUES
 #include "llvm/IR/AssemblyAnnotationWriter.h"
-#include <map>
+#include <unordered_map>
 #endif
 
 bool isArrayVecOrStruct(llvm::Type* t)
@@ -616,7 +616,7 @@ int breakOnLLVMID = 0;
 
 #if TRACK_LLVM_VALUES
 
-static std::map<const llvm::Value*, int> trackValIds;
+static std::unordered_map<const llvm::Value*, int> trackValIds;
 static int nextTrackId = 1;
 
 static void printLlvmId(const llvm::Value* val) {

--- a/compiler/llvm/llvmUtil.cpp
+++ b/compiler/llvm/llvmUtil.cpp
@@ -18,6 +18,8 @@
  * limitations under the License.
  */
 
+#include "chpl/util/break.h"
+#include "llvmTracker.h"
 #include "llvmUtil.h"
 
 #include <cstdio>
@@ -26,6 +28,11 @@
 #ifdef HAVE_LLVM
 
 #include "llvm/Support/Debug.h"
+
+#if TRACK_LLVM_VALUES
+#include "llvm/IR/AssemblyAnnotationWriter.h"
+#include <map>
+#endif
 
 bool isArrayVecOrStruct(llvm::Type* t)
 {
@@ -65,10 +72,12 @@ llvm::AllocaInst* makeAlloca(llvm::Type* type,
                                      DL.getAllocaAddrSpace(),
                                      size, llvm::Align(align),
                                      name, insertBefore);
+      trackLLVMValue(tempVar);
     } else {
       tempVar = new llvm::AllocaInst(type,
                                      DL.getAllocaAddrSpace(),
                                      size, name, insertBefore);
+      trackLLVMValue(tempVar);
     }
   } else {
     if (align != 0) {
@@ -76,10 +85,12 @@ llvm::AllocaInst* makeAlloca(llvm::Type* type,
                                      DL.getAllocaAddrSpace(),
                                      size, llvm::Align(align),
                                      name, entryBlock);
+      trackLLVMValue(tempVar);
     } else {
       tempVar = new llvm::AllocaInst(type,
                                      DL.getAllocaAddrSpace(),
                                      size, name, entryBlock);
+      trackLLVMValue(tempVar);
     }
   }
 
@@ -101,6 +112,7 @@ llvm::AllocaInst* createAllocaInFunctionEntry(llvm::IRBuilder<>* irBuilder,
   }
 
   llvm::AllocaInst *tempVar = irBuilder->CreateAlloca(type, nullptr, name);
+  trackLLVMValue(tempVar);
   irBuilder->SetInsertPoint(&func->back());
   return tempVar;
 }
@@ -157,33 +169,39 @@ PromotedPair convertValuesToLarger(
   //Floating point values
   if(type1->isFloatingPointTy() && type2->isFloatingPointTy()) {
     if(type1->getPrimitiveSizeInBits() > type2->getPrimitiveSizeInBits()) {
-      return PromotedPair(value1,
-                          irBuilder->CreateFPExt(value2, type1), true);
+      llvm::Value* fpe2 = irBuilder->CreateFPExt(value2, type1);
+      trackLLVMValue(fpe2);
+      return PromotedPair(value1, fpe2, true);
     } else {
-      return PromotedPair(irBuilder->CreateFPExt(value1, type2),
-                          value2, true);
+      llvm::Value* fpe1 = irBuilder->CreateFPExt(value1, type2);
+      trackLLVMValue(fpe1);
+      return PromotedPair(fpe1, value2, true);
     }
   }
 
   //Floating point / Integer values
   if(type1->isFloatingPointTy() && type2->isIntegerTy()) {
     if(isSigned2) {
-      return PromotedPair(value1,
-                          irBuilder->CreateSIToFP(value2, type1), true);
+      llvm::Value* stf = irBuilder->CreateSIToFP(value2, type1);
+      trackLLVMValue(stf);
+      return PromotedPair(value1, stf, true);
     } else {
-      return PromotedPair(value1,
-                          irBuilder->CreateUIToFP(value2, type1), true);
+      llvm::Value* utf = irBuilder->CreateUIToFP(value2, type1);
+      trackLLVMValue(utf);
+      return PromotedPair(value1, utf, true);
     }
   }
 
   //Integer / Floating point values
   if(type2->isFloatingPointTy() && type1->isIntegerTy()) {
     if(isSigned1) {
-      return PromotedPair(irBuilder->CreateSIToFP(value1, type2),
-                          value2, true);
+      llvm::Value* stf = irBuilder->CreateSIToFP(value1, type2);
+      trackLLVMValue(stf);
+      return PromotedPair(stf, value2, true);
     } else {
-      return PromotedPair(irBuilder->CreateUIToFP(value1, type2),
-                          value2, true);
+      llvm::Value* utf = irBuilder->CreateUIToFP(value1, type2);
+      trackLLVMValue(utf);
+      return PromotedPair(utf, value2, true);
     }
   }
 
@@ -193,24 +211,23 @@ PromotedPair convertValuesToLarger(
       // both are signed or both are unsigned.
       if(type1->getPrimitiveSizeInBits() > type2->getPrimitiveSizeInBits()) {
         if(isSigned2) {
-          return PromotedPair(value1,
-                        irBuilder->CreateSExtOrBitCast(value2, type1),
-                        true);
+          llvm::Value* cast2 = irBuilder->CreateSExtOrBitCast(value2, type1);
+          trackLLVMValue(cast2);
+          return PromotedPair(value1, cast2, true);
         } else {
-          return PromotedPair(
-                        value1,
-                        irBuilder->CreateZExtOrBitCast(value2, type1),
-                        false);
+          llvm::Value* cast2 = irBuilder->CreateZExtOrBitCast(value2, type1);
+          trackLLVMValue(cast2);
+          return PromotedPair(value1, cast2, false);
         }
       } else {
         if(isSigned1) {
-          return PromotedPair(
-                        irBuilder->CreateSExtOrBitCast(value1, type2),
-                        value2, true);
+          llvm::Value* cast1 = irBuilder->CreateSExtOrBitCast(value1, type2);
+          trackLLVMValue(cast1);
+          return PromotedPair(cast1, value2, true);
         } else {
-          return PromotedPair(
-                        irBuilder->CreateZExtOrBitCast(value1, type2),
-                        value2, false);
+          llvm::Value* cast1 = irBuilder->CreateZExtOrBitCast(value1, type2);
+          trackLLVMValue(cast1);
+          return PromotedPair(cast1, value2, false);
         }
       }
     } else {
@@ -220,15 +237,16 @@ PromotedPair convertValuesToLarger(
               type1->getPrimitiveSizeInBits() >=
               type2->getPrimitiveSizeInBits()) {
         // value1 is unsigned and >= bits; value2 is signed
-        return PromotedPair(value1,
-                            irBuilder->CreateSExtOrBitCast(value2, type1),
-                            false);
+        llvm::Value* cast2 = irBuilder->CreateSExtOrBitCast(value2, type1);
+        trackLLVMValue(cast2);
+        return PromotedPair(value1, cast2, false);
       } else if( !isSigned2 &&
                      type1->getPrimitiveSizeInBits() <=
                      type2->getPrimitiveSizeInBits() ) {
         // value2 is unsigned and >= bits; value1 is signed
-        return PromotedPair(irBuilder->CreateSExtOrBitCast(value1, type2),
-                            value2, false);
+        llvm::Value* cast1 = irBuilder->CreateSExtOrBitCast(value1, type2);
+        trackLLVMValue(cast1);
+        return PromotedPair(cast1, value2, false);
       } else {
         // Otherwise, if the type of the operand with signed integer
         // type can represent all of the values of the type of the operand
@@ -239,29 +257,29 @@ PromotedPair convertValuesToLarger(
                type1->getPrimitiveSizeInBits()-1 >=
                type2->getPrimitiveSizeInBits()) {
           // value1 is signed, value2 is not
-          return PromotedPair(value1,
-                        irBuilder->CreateZExtOrBitCast(value2, type1),
-                        true);
+          llvm::Value* cast2 = irBuilder->CreateZExtOrBitCast(value2, type1);
+          trackLLVMValue(cast2);
+          return PromotedPair(value1, cast2, true);
         } else if( isSigned2 &&
                       type1->getPrimitiveSizeInBits() <=
                       type2->getPrimitiveSizeInBits() - 1) {
-          return PromotedPair(
-                        irBuilder->CreateZExtOrBitCast(value1, type2),
-                        value2, true);
+          llvm::Value* cast1 = irBuilder->CreateZExtOrBitCast(value1, type2);
+          trackLLVMValue(cast1);
+          return PromotedPair(cast1, value2, true);
         } else {
           // otherwise, both operands are converted to the unsigned
           // integer type corresponding to the type of the operand
           // with signed integer type.
           if( isSigned1 ) {
             // convert both to unsigned type1
-            return PromotedPair(value1,
-                          irBuilder->CreateZExtOrBitCast(value2, type1),
-                          false);
+            llvm::Value* cast2 = irBuilder->CreateZExtOrBitCast(value2, type1);
+            trackLLVMValue(cast2);
+            return PromotedPair(value1, cast2, false);
           } else {
             // convert both to unsigned type2
-            return PromotedPair(
-                          irBuilder->CreateZExtOrBitCast(value1, type2),
-                          value2, false);
+            llvm::Value* cast1 = irBuilder->CreateZExtOrBitCast(value1, type2);
+            trackLLVMValue(cast1);
+            return PromotedPair(cast1, value2, false);
           }
         }
       }
@@ -292,9 +310,11 @@ PromotedPair convertValuesToLarger(
     }
 #endif
 
-    return PromotedPair(irBuilder->CreatePointerCast(value1, castTy),
-                        irBuilder->CreatePointerCast(value2, castTy),
-                        false);
+    llvm::Value* cast1 = irBuilder->CreatePointerCast(value1, castTy);
+    llvm::Value* cast2 = irBuilder->CreatePointerCast(value2, castTy);
+    trackLLVMValue(cast1);
+    trackLLVMValue(cast2);
+    return PromotedPair(cast1, cast2, false);
   }
 
   return PromotedPair(NULL, NULL, false);
@@ -409,50 +429,50 @@ llvm::Value *convertValueToType(llvm::IRBuilder<>* irBuilder,
     if(newType->getPrimitiveSizeInBits() > curType->getPrimitiveSizeInBits()) {
       // Sign extend if isSigned, but never sign extend single bits.
       if(isSigned && ! curType->isIntegerTy(1)) {
-        return irBuilder->CreateSExtOrBitCast(value, newType);
+        return trackLLVMValue(irBuilder->CreateSExtOrBitCast(value, newType));
       }
       else {
-        return irBuilder->CreateZExtOrBitCast(value, newType);
+        return trackLLVMValue(irBuilder->CreateZExtOrBitCast(value, newType));
       }
     }
     else {
-      return irBuilder->CreateTruncOrBitCast(value, newType);
+      return trackLLVMValue(irBuilder->CreateTruncOrBitCast(value, newType));
     }
   }
 
   //Floating point values
   if(newType->isFloatingPointTy() && curType->isFloatingPointTy()) {
     if(newType->getPrimitiveSizeInBits() > curType->getPrimitiveSizeInBits()) {
-      return irBuilder->CreateFPExt(value, newType);
+      return trackLLVMValue(irBuilder->CreateFPExt(value, newType));
     }
     else {
-      return irBuilder->CreateFPTrunc(value, newType);
+      return trackLLVMValue(irBuilder->CreateFPTrunc(value, newType));
     }
   }
 
   //Integer value to floating point value
   if(newType->isFloatingPointTy() && curType->isIntegerTy()) {
     if(isSigned) {
-      return irBuilder->CreateSIToFP(value, newType);
+      return trackLLVMValue(irBuilder->CreateSIToFP(value, newType));
     }
     else {
-      return irBuilder->CreateUIToFP(value, newType);
+      return trackLLVMValue(irBuilder->CreateUIToFP(value, newType));
     }
   }
 
   //Floating point value to integer value
   if(newType->isIntegerTy() && curType->isFloatingPointTy()) {
-    return irBuilder->CreateFPToSI(value, newType);
+    return trackLLVMValue(irBuilder->CreateFPToSI(value, newType));
   }
 
   //Integer to pointer
   if(newType->isPointerTy() && curType->isIntegerTy()) {
-    return irBuilder->CreateIntToPtr(value, newType);
+    return trackLLVMValue(irBuilder->CreateIntToPtr(value, newType));
   }
 
   //Pointer to integer
   if(newType->isIntegerTy() && curType->isPointerTy()) {
-    return irBuilder->CreatePtrToInt(value, newType);
+    return trackLLVMValue(irBuilder->CreatePtrToInt(value, newType));
   }
 
   //Pointers
@@ -467,7 +487,7 @@ llvm::Value *convertValueToType(llvm::IRBuilder<>* irBuilder,
     {
       assert( 0 && "Can't convert pointer to different address space");
     }
-    return irBuilder->CreatePointerCast(value, newType);
+    return trackLLVMValue(irBuilder->CreatePointerCast(value, newType));
   }
 
   // Structure types.
@@ -493,14 +513,18 @@ llvm::Value *convertValueToType(llvm::IRBuilder<>* irBuilder,
       llvm::Type* newPtrType = newType->getPointerTo();
       // Now get cast pointers
       llvm::Value* tmp_cur = irBuilder->CreatePointerCast(tmp_alloc, curPtrType);
+      trackLLVMValue(tmp_cur);
       llvm::Value* tmp_new = irBuilder->CreatePointerCast(tmp_alloc, newPtrType);
-      irBuilder->CreateStore(value, tmp_cur);
+      trackLLVMValue(tmp_new);
+      llvm::StoreInst* store_cur = irBuilder->CreateStore(value, tmp_cur);
+      trackLLVMValue(store_cur);
 #if HAVE_LLVM_VER >= 150
-      return irBuilder->CreateLoad(newType, tmp_new);
+      return trackLLVMValue(irBuilder->CreateLoad(newType, tmp_new));
 #elif HAVE_LLVM_VER >= 130
-      return irBuilder->CreateLoad(tmp_new->getType()->getPointerElementType(), tmp_new);
+      return trackLLVMValue(irBuilder->CreateLoad(
+                        tmp_new->getType()->getPointerElementType(), tmp_new));
 #else
-      return irBuilder->CreateLoad(tmp_new);
+      return trackLLVMValue(irBuilder->CreateLoad(tmp_new));
 #endif
     }
   }
@@ -557,6 +581,153 @@ void print_llvm(llvm::Module* m)
 
   fprintf(stderr, "\n");
 }
+
+// list_view() below do the same as print_llvm() above,
+// except list_view() are consistent with other list_views in view.cpp:
+//  - naming, for use with our debugger aliases nview, lview
+//  - output to stdout
+//
+// nprint_view() below do the same as list_view(),
+// except when TRACK_LLVM_VALUES=1 they also display LLVM IDs when available
+
+void list_view(const llvm::Type* arg) {
+  if (arg == NULL) printf("<NULL>");
+  else arg->print(llvm::outs(), true);
+  printf("\n");
+}
+
+void list_view(const llvm::Value* arg) {
+  if (arg == NULL) printf("<NULL>");
+  else arg->print(llvm::outs(), true);
+  printf("\n");
+}
+
+void list_view(const llvm::Module* arg) {
+  if (arg == NULL) printf("<NULL>");
+  else arg->print(llvm::outs(), nullptr, true, true);
+  printf("\n");
+}
+
+////////////////////
+// trackLLVMValue //
+////////////////////
+
+int breakOnLLVMID = 0;
+
+#if TRACK_LLVM_VALUES
+
+static std::map<const llvm::Value*, int> trackValIds;
+static int nextTrackId = 1;
+
+static void printLlvmId(const llvm::Value* val) {
+  auto search = trackValIds.find(val);
+  if (search != trackValIds.end())  printf("[%4d] ", search->second);
+  else                              printf("[%4s] ", "");
+  fflush(stdout);
+}
+
+// do not print anything if 'val' does not have an associated ID
+static void printLlvmIdIfFound(const llvm::Value* val, const char* msg) {
+  auto search = trackValIds.find(val);
+  if (search == trackValIds.end()) return;
+  printf("[%4d]%s", search->second, msg);
+  fflush(stdout);
+}
+
+static int addLlvmValue(const llvm::Value* val) {
+  int& insertedId = trackValIds[val];
+  // Some XXX::Create() and irBuilder->CreateYYY() may return
+  // a previously-created Value. Keep the existing ID for those.
+  if (insertedId == 0)
+    insertedId = nextTrackId++;
+  return insertedId;
+}
+
+const llvm::Value* trackLLVMValue(const llvm::Value* val) {
+  int newId = addLlvmValue(val);
+  if (newId == breakOnLLVMID) gdbShouldBreakHere();
+  return val;
+}
+
+llvm::Value* trackLLVMValue(llvm::Value* val) {
+  trackLLVMValue((const llvm::Value*) val);
+  return val;
+}
+
+class LLVMValueTracker : public llvm::AssemblyAnnotationWriter {
+public:
+   /// emit a string right before the start of a function
+   void emitFunctionAnnot(const llvm::Function *F,
+                          llvm::formatted_raw_ostream &s) {
+     printLlvmId(F);
+   }
+
+   /// emit a string right after the basic block label
+   void emitBasicBlockStartAnnot(const llvm::BasicBlock *BB,
+                                 llvm::formatted_raw_ostream &s) {
+     printLlvmIdIfFound(BB, "\n");
+   }
+
+   /// emit a string right after the basic block
+   void emitBasicBlockEndAnnot(const llvm::BasicBlock *BB,
+                               llvm::formatted_raw_ostream &s) {
+     // nothing
+   }
+
+   /// emit a string right before an instruction is emitted
+   void emitInstructionAnnot(const llvm::Instruction *I,
+                             llvm::formatted_raw_ostream &s) {
+     printLlvmId(I);
+   }
+
+   /// emit a comment to the right of an instruction or global value
+   void printInfoComment(const llvm::Value &val,
+                         llvm::formatted_raw_ostream &s) {
+     // nothing
+   }
+};
+
+static LLVMValueTracker llvmValueTracker;
+
+void nprint_view(const llvm::Value* arg) {
+  if (arg == NULL) {
+    printf("<NULL>");
+  }
+  else if (const llvm::Function* f = llvm::dyn_cast<llvm::Function>(arg)) {
+    f->print(llvm::outs(), &llvmValueTracker, true, true);
+  }
+  else if (const llvm::BasicBlock* bb = llvm::dyn_cast<llvm::BasicBlock>(arg)) {
+    bb->print(llvm::outs(), &llvmValueTracker, true, true);
+  }
+  else {
+    printLlvmId(arg);
+    // LLVM currently does not print Value* w/ AssemblyAnnotationWriter
+    arg->print(llvm::outs(), true);
+  }
+  printf("\n");
+}
+
+void nprint_view(const llvm::Type* arg) {
+  if (arg == NULL) printf("<NULL>");
+  else arg->print(llvm::outs(), true); // no tracking currently
+  printf("\n");
+}
+
+void nprint_view(const llvm::Module* arg) {
+  if (arg == NULL) printf("<NULL>");
+  else arg->print(llvm::outs(), &llvmValueTracker, true, true);
+  printf("\n");
+}
+
+#else // if TRACK_LLVM_VALUES
+
+// LLVM IDs are not tracked; nprint_view() is the same as list_view()
+
+void nprint_view(const llvm::Type* arg)   { list_view(arg); }
+void nprint_view(const llvm::Value* arg)  { list_view(arg); }
+void nprint_view(const llvm::Module* arg) { list_view(arg); }
+
+#endif // if TRACK_LLVM_VALUES
 
 llvm::AttrBuilder llvmPrepareAttrBuilder(llvm::LLVMContext& ctx) {
   #if HAVE_LLVM_VER >= 140

--- a/compiler/llvm/llvmUtil.cpp
+++ b/compiler/llvm/llvmUtil.cpp
@@ -654,6 +654,14 @@ llvm::Value* trackLLVMValue(llvm::Value* val) {
   return val;
 }
 
+void trackClonedLLVMValues(llvm::ValueToValueMapTy& VMap) {
+  for (auto Entry : VMap) {
+    auto it = trackValIds.find(Entry.first); // look up the clone's original
+    if (it != trackValIds.end())
+      trackValIds[Entry.second] = it->second; // map clone to original's ID
+  }
+}
+
 class LLVMValueTracker : public llvm::AssemblyAnnotationWriter {
 public:
    /// emit a string right before the start of a function


### PR DESCRIPTION
This PR introduces an opt-in support for breakpoints on creation of LLVM Value objects during codegen, as identified with what I will call "LLVM IDs". This is analogous to `breakOnID` for BaseAST objects. The implementation is different, however, in order to allow it to work with unmodified LLVMs, ex. when CHPL_LLVM==system.

To enable tracking LLVM IDs, set `TRACK_LLVM_VALUES` to 1 in `llvmTracker.h` or using `-D`, and rebuild the compiler.

This PR also adds overloads of the compiler's traditional helpers `list_view` and `nprint_view` for LLVM's Value, Type, and Module objects. This allows compiler developers to use their existing debugger aliases to examine these LLVM items. When tracking is enabled, `nprint_view` dislays the LLVM IDs when available.

The workflow may look like this:

```
# (a) start compilation
# break compilation during codegen
(gdb) nview func
[1499] define internal void @chpl_user_main() !chpl.ast.id !1 {
[72041]
[72042]   %1 = alloca %struct.EE1, align 8
[72043]   %2 = alloca %struct.EE2, align 8
[72044]   %3 = alloca %struct.EE3, align 8
[72045]   %4 = alloca %struct.EE4, align 8
[72046]   %5 = alloca %struct.EE5, align 8
[72047]   %6 = alloca %struct.EE6, align 8
[72048]   %7 = alloca %RR1, align 8
.....

# (b) restart compilation
(gdb) set breakOnLLVMID = 72043
(gdb) continue
# the debugger breaks in createAllocaInFunctionEntry()
# immediately after creating `%2 = alloca %struct.EE2`
```

### Implementation notes

I chose the following implementation approach in order to avoid modifications to LLVM, which would complicate building and packaging of Chapel:

* For each point in our codegen where an llvm Value is created, I added a call to `trackLLVMValue()` passing the newly-created object as an argument.

* This function assigns the object a new unique ID and adds it to a hashtable.

* If the ID matches `breakOnLLVMID`, `gdbShouldBreakHere()` is invoked, analogously to how `breakOnID` works.

* `nprint_view` passes a subclass of `llvm::AssemblyAnnotationWriter` to the `print()` method on an llvm::Function or llvm::BasicBlock, which prints the LLVM IDs obtained from the hashtable, or empty brackets for the objects that do not have their IDs in the hashtable.

This functionality is disabled by default to avoid increased compilation time.

To find all the places where an llvm::Value is created, I grepped the compiler for `irBuilder->Create` and for `::Create`. I surely missed some instances, we can add them as we come across them.

Early dev history: 3bb29e5d41..8858fe9bb6

I thank @jabraham17  for discussions about this project and for helping me generally with LLVM.
