### PR TITLE
Additional fixes for build warnings with LLVM 17

### DIFF
--- a/frontend/lib/types/Param.cpp
+++ b/frontend/lib/types/Param.cpp
@@ -147,7 +147,7 @@ optional<ParamTag> Param::tryGuessParamTagFromType(const Type* t) {
   } else if (t->isNothingType()) {
     return paramtags::NoneParam;
   }
-  return optional<ParamTag>({});
+  return empty;
 }
 
 static paramtags::ParamTag guessParamTagFromType(const Type* t) {

--- a/frontend/lib/types/Param.cpp
+++ b/frontend/lib/types/Param.cpp
@@ -147,7 +147,7 @@ optional<ParamTag> Param::tryGuessParamTagFromType(const Type* t) {
   } else if (t->isNothingType()) {
     return paramtags::NoneParam;
   }
-  return {};
+  return optional<ParamTag>({});
 }
 
 static paramtags::ParamTag guessParamTagFromType(const Type* t) {

--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -355,6 +355,14 @@ ifeq ($(shell test $(CHPL_MAKE_LLVM_VERSION) -eq 12; echo "$$?"),0)
 WARN_CXXFLAGS += -Wno-deprecated-declarations
 endif
 
+#
+# Don't error for -Wnonnull in llvm 17+ due to false positives in llvm headers
+#
+ifeq ($(shell test $(CHPL_MAKE_LLVM_VERSION) -ge 17; echo "$$?"),0)
+WARN_CXXFLAGS += -Wno-error=nonnull
+endif
+
+
 ifeq ($(GNU_GPP_SUPPORTS_MISSING_DECLS),1)
 WARN_CXXFLAGS += -Wmissing-declarations
 else

--- a/util/cron/test-linux64-gcc101.bash
+++ b/util/cron/test-linux64-gcc101.bash
@@ -8,13 +8,15 @@ source $CWD/common.bash
 # Use CHPL_LLVM=none to avoid using a system LLVM potentially linked
 # with a different and incompatible version of GCC
 export CHPL_LLVM=none
+export CHPL_LLVM_SUPPORT=bundled
+unset CHPL_LLVM_CONFIG
 
 source /data/cf/chapel/setup_gcc101.bash     # host-specific setup for target compiler
 
 # Set environment variables to nudge cmake towards GCC 10.1
 export CHPL_CMAKE_USE_CC_CXX=1
-export CC=gcc
-export CXX=g++
+export CC=$(which gcc)
+export CXX=$(which g++)
 
 gcc_version=$(gcc -dumpversion)
 if [ "$gcc_version" != "10.1.0" ]; then

--- a/util/cron/test-linux64-gcc112.bash
+++ b/util/cron/test-linux64-gcc112.bash
@@ -8,13 +8,15 @@ source $CWD/common.bash
 # Use CHPL_LLVM=none to avoid using a system LLVM potentially linked
 # with a different and incompatible version of GCC
 export CHPL_LLVM=none
+export CHPL_LLVM_SUPPORT=bundled
+unset CHPL_LLVM_CONFIG
 
 source /data/cf/chapel/setup_gcc112.bash     # host-specific setup for target compiler
 
 # Set environment variables to nudge cmake towards GCC 11.2
 export CHPL_CMAKE_USE_CC_CXX=1
-export CC=gcc
-export CXX=g++
+export CC=$(which gcc)
+export CXX=$(which g++)
 
 gcc_version=$(gcc -dumpversion)
 if [ "$gcc_version" != "11.2.0" ]; then

--- a/util/cron/test-linux64-gcc73.bash
+++ b/util/cron/test-linux64-gcc73.bash
@@ -8,13 +8,15 @@ source $CWD/common.bash
 # Use CHPL_LLVM=none to avoid using a system LLVM potentially linked
 # with a different and incompatible version of GCC
 export CHPL_LLVM=none
+export CHPL_LLVM_SUPPORT=bundled
+unset CHPL_LLVM_CONFIG
 
 source /data/cf/chapel/setup_gcc73.bash     # host-specific setup for target compiler
 
 # Set environment variables to nudge cmake towards GCC 7.3
 export CHPL_CMAKE_USE_CC_CXX=1
-export CC=gcc
-export CXX=g++
+export CC=$(which gcc)
+export CXX=$(which g++)
 
 gcc_version=$(gcc -dumpversion)
 if [ "$gcc_version" != "7.3.0" ]; then

--- a/util/cron/test-linux64-gcc91.bash
+++ b/util/cron/test-linux64-gcc91.bash
@@ -8,13 +8,15 @@ source $CWD/common.bash
 # Use CHPL_LLVM=none to avoid using a system LLVM potentially linked
 # with a different and incompatible version of GCC
 export CHPL_LLVM=none
+export CHPL_LLVM_SUPPORT=bundled
+unset CHPL_LLVM_CONFIG
 
 source /data/cf/chapel/setup_gcc91.bash     # host-specific setup for target compiler
 
 # Set environment variables to nudge cmake towards GCC 9.1
 export CHPL_CMAKE_USE_CC_CXX=1
-export CC=gcc
-export CXX=g++
+export CC=$(which gcc)
+export CXX=$(which g++)
 
 gcc_version=$(gcc -dumpversion)
 if [ "$gcc_version" != "9.1.0" ]; then


### PR DESCRIPTION
This PR applies a few fixes that resolve build issues with the compiler when built with newer llvm

- Opt out of -Wnonnull due to false positives in LLVM headers
- Patch `Param.cpp` to work around gcc 9 bug (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80635)
- Adjust test configs for older gcc versions to avoid linker/abi incompatibility issues

[Reviewed by @riftEmber]