### PR TITLE
Update Mac OS X instructions with non-homebrew option

### DIFF
--- a/doc/rst/platforms/macosx.rst
+++ b/doc/rst/platforms/macosx.rst
@@ -10,10 +10,9 @@ There are two main approaches for using Chapel on Mac OS X:
    quickest way to get up and running, but it results in a copy of
    Chapel that only supports shared-memory (single-locale) executions.
 
-2) Install and build Chapel from source, as with any other UN*X
+2) Build Chapel from source, as with any other UN*X
    system.  This is slightly more involved, but supports Chapel's full
-   feature set.  Refer to the :ref:`chapelhome-quickstart` for more
-   information.
+   feature set.
 
 --------
 Homebrew
@@ -38,7 +37,7 @@ Compile and run a test program::
 If you're new to Chapel, refer to the `What's Next?
 <https://chapel-lang.org/docs/usingchapel/QUICKSTART.html#what-s-next>`_
 section of :ref:`chapelhome-quickstart` for next steps.
-    
+
 .. note::
 
    The Homebrew installation provides a minimal installation of Chapel
@@ -57,3 +56,48 @@ section of :ref:`chapelhome-quickstart` for next steps.
 
 
 .. _Homebrew: https://brew.sh/
+
+
+--------------------
+Building from Source
+--------------------
+
+If you are not using the Homebrew package, it will be necessary to
+install a few development tools in order build Chapel. The instructions
+below show one way of getting a working development environment.
+
+First, install XCode_ or the developer Command Line Tools. XCode can be
+installed from the App store.
+
+Once this is done, open up a new Terminal window to verify that ``clang``
+and ``python3`` programs can be found and have a suitable version (see
+also :ref:`readme-prereqs`) by running the following commands::
+
+    clang --version
+    python3 --version
+
+After this step, you should have a working C/C++ compiler, ``make`` support,
+and a working installation of Python 3.
+
+Next, install CMake_. Since XCode installation does not include CMake,
+and it's required to build Chapel, it's necessary to install it
+separately. You can install it using a source or binary release from the
+CMake_ website. At the time of this writing, the CMake binary release
+includes a graphical CMake.app but does not install the command-line
+tool.  If you have CMake.app installed in your Applications folder, you
+can ask it to install the command-line tool with the following command::
+
+    sudo /Applications/CMake.app/Contents/bin/cmake-gui --install
+
+Once this is done, open up a new Terminal window to verify that
+``cmake`` is available and has a suitable version (see
+:ref:`readme-prereqs`)::
+
+    cmake --version
+
+From here, follow the main documentation for building from source at
+:ref:`chapelhome-quickstart`.
+
+.. _Xcode: https://developer.apple.com/xcode/
+
+.. _CMake: https://cmake.org/download/

--- a/doc/rst/platforms/macosx.rst
+++ b/doc/rst/platforms/macosx.rst
@@ -67,11 +67,15 @@ install a few development tools in order build Chapel. The instructions
 below show one way of getting a working development environment.
 
 First, install XCode_ or the developer Command Line Tools. XCode can be
-installed from the App store.
+installed from the App store. Or, you can install the developer Command
+Line Tools by opening a Terminal window and running::
 
-Once this is done, open up a new Terminal window to verify that ``clang``
-and ``python3`` programs can be found and have a suitable version (see
-also :ref:`readme-prereqs`) by running the following commands::
+    xcode-select --install
+
+Once this is done, open up a new Terminal window to verify that the
+``clang`` and ``python3`` programs can be found and have a suitable
+version (see also :ref:`readme-prereqs`) by running the following
+commands::
 
     clang --version
     python3 --version


### PR DESCRIPTION
This PR updates the Mac OS X platform README with details about how to install the required prerequisite tools without using Homebrew. This is based on my experience working with a user that didn't want to install Homebrew.

Reviewed by @DanilaFe - thanks!