### PR TITLE
Fix regex test failures on linux32 after advanceThrough fixes

### DIFF
--- a/runtime/src/qio/qio.c
+++ b/runtime/src/qio/qio.c
@@ -3974,7 +3974,8 @@ qioerr qio_channel_advance_unlocked(qio_channel_t* ch, int64_t nbytes)
   if( nbytes < 0 ) nbytes = 0;
 
   // Fast path: all data is available in the cached area.
-  if( qio_space_in_ptr_diff(nbytes, ch->cached_end, ch->cached_cur) ) {
+  if( nbytes < INTPTR_MAX &&
+      qio_space_in_ptr_diff(nbytes, ch->cached_end, ch->cached_cur) ) {
     ch->cached_cur = qio_ptr_add(ch->cached_cur, nbytes);
     return 0;
   }


### PR DESCRIPTION
Follow-up to PR #24849.

This PR fixes test failures for `regex/empty-channel-matches` and `regex/ferguson/rechan` in linux32 testing after that PR.

The switch to using `qio_channel_advance` instead of `qio_channel_advance_past_byte` to advance to the end of a fileReader in certain regular expression searching scenarios revealed a bug in `qio_channel_advance_unlocked`. It used `qio_space_in_ptr_diff`, which accepts an `intptr_t`, but it passed in an `int64_t`. On 64-bit systems, this is not an issue, because `intptr_t` and `int64_t` are both 64-bit. But, on a 32-bit system, `intptr_t` is 32 bits, and the resulting implicit conversion led to overflow, causing the comparison to have an unexpected result.

- [x] full comm=none testing

Reviewed by @mstrout - thanks!