### PR TITLE
Revert ChOp back to using old perfkeys

### DIFF
--- a/test/gpu/native/studies/chop/main.gpu-keys
+++ b/test/gpu/native/studies/chop/main.gpu-keys
@@ -1,1 +1,1 @@
-Elapsed TOTAL:
+Elapsed time:

--- a/test/gpu/native/studies/chop/main.prediff
+++ b/test/gpu/native/studies/chop/main.prediff
@@ -5,6 +5,6 @@ cp $2 $2.bak
 grep "^[[:space:]]*Initial Tree size" $2 > $2.tmp
 grep "^[[:space:]]*Final Tree size" $2 >> $2.tmp
 grep "^[[:space:]]*TOTAL Tree size" $2 >> $2.tmp
-grep "^[[:space:]]*Elapsed TOTAL" $2 >> $2.tmp
+grep "^[[:space:]]*Elapsed time" $2 >> $2.tmp
 
 mv $2.tmp $2

--- a/test/gpu/native/studies/chop/patches/time.patch
+++ b/test/gpu/native/studies/chop/patches/time.patch
@@ -23,7 +23,7 @@ index 55d2e57..a30e77e 100644
 +          writef("\n\tElapsed Initial Search: %.3dr", initial.elapsed());
 +          writef("\n\tElapsed PGAS Data Distribution: %.3dr", distribution.elapsed());
 +          writef("\n\tElapsed Final Search: %.3dr",     final.elapsed());
-+          writef("\n\tElapsed TOTAL: %.3dr\n",  final.elapsed()+initial.elapsed()+distribution.elapsed());
++          writef("\n\tElapsed time: %.3dr\n",  final.elapsed()+initial.elapsed()+distribution.elapsed());
 +          writef("\n\tPGAS proportion: %.3dr\n", (distribution.elapsed())/(total_time)*100);
 +        }
  


### PR DESCRIPTION
Technically the output for the time measurement has changed in ChOp. But adapting to it would require changing our dat files for performance tracking, which is never fun. Instead this PR modifies the source to print out `Elapsed time:` as it used to. Also reverts some of the recent changes to go back to using `Elapsed time` as the key.