### PR TITLE
Skip new regex tests when no regex support

### DIFF
--- a/test/regex/flags/SKIPIF
+++ b/test/regex/flags/SKIPIF
@@ -1,0 +1,1 @@
+CHPL_RE2==none


### PR DESCRIPTION
Follow-up to PR #24935 to add a SKIPIF to skip the new tests in quickstart testing where they can't run.

Test change only, not reviewed.