### PR TITLE
Explicitly set SLURM_MPI_TYPE when using OFI_OOB=pmi

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi-launch.c
+++ b/runtime/src/comm/ofi/comm-ofi-launch.c
@@ -19,7 +19,7 @@
  */
 
 //
-// Launch assistance for the uGNI communication interface.
+// Launch assistance for the OFI communication interface.
 //
 
 #include <inttypes.h>
@@ -59,6 +59,12 @@ void chpl_comm_preLaunch(int32_t numLocales) {
       chpl_env_set(evName, buf, 1);
     }
   }
+
+  // when using PMI and SLURM_MPI_TYPE is not set, set it to pmi2
+  // this isn't strictly required on all systems, but it is on some (AWS)
+  // and is it much easier to just set it than to figure out if its required
+  chpl_env_set("SLURM_MPI_TYPE", "pmi2", 0);
+
 #endif
 
   if (chpl_env_rt_get_bool("OVERSUBSCRIBED", false)) {


### PR DESCRIPTION
This PR explicitly sets `SLURM_MPI_TYPE` when using `CHPL_COMM_OFI_OOB=pmi[x|2]`. This reduces the number of environment variables required to be set on some platforms, notably AWS, making it easier for users to use chapel.

Tested on AWS that explicitly setting `SLURM_MPI_TYPE` was no longer required.

This PR is based on https://github.com/chapel-lang/chapel/issues/18975. Some discussion there suggested determining when it is actually required to set `SLURM_MPI_TYPE`. This PR takes the simpler approach of always setting it, but only when using pmi.

[Reviewed by @jhh67]