### PR TITLE
Make uninitialized memory errors non-fatal for GCC 13

### DIFF
--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -289,8 +289,9 @@ endif
 # (should be fixed in LLVM 15 though).
 # We would like to know when this occurs, though, so don't turn off
 # the warning; just don't let it abort the build.
+# Observed in GCC 13 as well as of May 2024.
 #
-ifeq ($(shell test $(GNU_GPP_MAJOR_VERSION) -eq 12; echo "$$?"),0)
+ifeq ($(shell test $(GNU_GPP_MAJOR_VERSION) -ge 12; echo "$$?"),0)
 WARN_CXXFLAGS += -Wno-error=uninitialized
 endif
 


### PR DESCRIPTION
Set `-Wno-error=uninitialized` for GCC >= 12 (rather than just == 12) after observing the suppressed error with GCC 13 as well.

This is to work around a true instance of the errors in LLVM <= 14 headers.

[reviewer info placeholder]

Testing:
- [x] resolves observed issue from nightly in reproducer configuration