### PR TITLE
Allow Chapel programs with COMM=ofi to use explicit transparent huge pages

### DIFF
--- a/doc/rst/platforms/aws.rst
+++ b/doc/rst/platforms/aws.rst
@@ -272,13 +272,32 @@ Once connected to the instance via ssh, do the following:
       export CHPL_COMM_OFI_OOB=pmi2
       PMI2_DIR=/opt/slurm/lib/
       export CHPL_LD_FLAGS="-L$PMI2_DIR -Wl,-rpath,$PMI2_DIR"
-      export SLURM_MPI_TYPE=pmi2
       export CHPL_RT_COMM_OFI_DEDICATED_AMH_CORES=true
       export CHPL_RT_COMM_OFI_CONNECT_EAGERLY=true
 
-      # Set this based on the max amount of memory available per-instance
-      # Note that EFA currently prevents the use of a heap larger than 96G
-      export CHPL_RT_MAX_HEAP_SIZE=75%
+   Due to limitations in the number of pages that can be registered with EFA,
+   by default Chapel will try and use transparent huge pages. Make sure your
+   cluster has transparent huge pages enabled and has enough huge pages.
+
+   .. code-block:: bash
+
+      NUM_NODES=<max number of nodes in your cluster>
+      NUM_PAGES=<number of pages to use>
+      srun --nodes $NUM_NODES echo always | sudo tee /sys/kernel/mm/transparent_hugepage/enabled >/dev/null
+      srun --nodes $NUM_NODES echo $NUM_PAGES | sudo tee /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages >/dev/null
+
+   .. note::
+
+       Setting more huge pages than there is memory on the system can cause the
+       system to hang. Make sure to set the number of huge pages to a value
+       that is less than the total memory on the system (you can query this
+       with ``srun lsmem``). If you set it too low, you may get out of memory
+       errors when running Chapel programs. Try increasing the number of huge
+       pages or set a max heap size with ``CHPL_RT_MAX_HEAP_SIZE``.
+
+   If you wish to not use transparent huge pages, set ``export
+   CHPL_RT_COMM_OFI_THP_HINT=0``. Depending on your system, you my also need to
+   set ``CHPL_RT_MAX_HEAP_SIZE`` to a value less than ``96G``.
 
    For best performance, users should also set ``export
    FI_EFA_USE_DEVICE_RDMA=1``. This enables higher network performance by using

--- a/runtime/src/comm/ofi/comm-ofi-internal.h
+++ b/runtime/src/comm/ofi/comm-ofi-internal.h
@@ -236,6 +236,15 @@ extern int chpl_comm_ofi_abort_on_error;
       }                                                                 \
     } while (0)
 
+#define CHK_SYS_MMAP(p, sz, prot, flags, fd, off)                              \
+    do {                                                                       \
+      if((p = mmap(NULL, (sz), (prot), (flags), (fd), (off))) == MAP_FAILED) { \
+        INTERNAL_ERROR_V("mmap(NULL, %#zx, %#zx, %#zx, %d, %d): %s",           \
+                         (size_t)(sz), (size_t)(prot), (size_t)(flags),        \
+                         (int)(fd), (int)(off), strerror(errno));              \
+      }                                                                        \
+    } while (0)
+
 #define CHK_SYS_FREE(p)                                                 \
   do {                                                                  \
     sys_free(p);                                                        \

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -3628,13 +3628,9 @@ void init_fixedHeap(void) {
       if (!useTHP) {
         CHK_SYS_MEMALIGN(start, page_size, size);
       } else {
-        start = mmap(NULL, size,
-                     PROT_READ | PROT_WRITE,
-                     MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB,
-                     -1, 0);
-        if (start == MAP_FAILED) {
-          INTERNAL_ERROR_V("mmap failed: %s", strerror(errno));
-        }
+        CHK_SYS_MMAP(start, size, PROT_READ | PROT_WRITE,
+                                  MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB,
+                                  -1, 0);
       }
       } while (start == NULL && size > decrement);
 


### PR DESCRIPTION
This PR adds a new runtime variable, `CHPL_RT_COMM_OFI_THP_HINT`, which controls if the OFI comm layer will use transparent huge pages to allocate memory. The default value is false, except when the provider being used is EFA. The default is true for EFA, since EFA is severely limited in the number of pages it can register.

This PR also updates the docs for using Chapel on AWS to explain how to enable and use transparent huge pages.

This PR requires https://github.com/chapel-lang/chapel/pull/24969 to be merged first

Tested on AWS

[Reviewed by @jhh67]