### PR TITLE
Allow bundled libfabric to be built with newer clang

### DIFF
--- a/third-party/libfabric/Makefile
+++ b/third-party/libfabric/Makefile
@@ -29,6 +29,19 @@ ifeq ($(CHPL_LIB_PIC),pic)
 CFLAGS += $(SHARED_LIB_CFLAGS)
 endif
 
+
+CLANG_VER := $(shell echo __clang_major__ | $(CXX) -E -x c++ - | sed -e '/^\#/d' -e 's/L$$//')
+
+#
+# Use -Wno-error=int-conversion for clang 15+
+#
+CFLAGS += $(shell test $(CLANG_VER) -ge 15 && echo -Wno-error=int-conversion)
+
+#
+# use -Wno-error=incompatible-function-pointer-types for clang 16+
+#
+CFLAGS += $(shell test $(CLANG_VER) -ge 16 && echo -Wno-error=incompatible-function-pointer-types)
+
 CHPL_LIBFABRIC_CFG_OPTIONS += $(CHPL_LIBFABRIC_MORE_CFG_OPTIONS)
 
 default: all


### PR DESCRIPTION
This PR adds a few warning opt outs when building the bundled libfabric with specific versions of clang.

Testing
- [x] built with CHPL_COMM=ofi, CHPL_LIBFABRIC=bundled, and CHPL_DEVELOPER=1 with clang 14, 15, 16, 17, and 18.

[Reviewed by @jhh67]