### PR TITLE
Only show LSP errors that pertain to the current file

### DIFF
--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -1044,7 +1044,8 @@ class ChapelLanguageServer(LanguageServer):
             self.file_infos[uri] = file_info
 
         # filter out errors that are not related to the file
-        errors = [e for e in errors if e.location().path() == uri[len("file://") :]]
+        cur_path = uri[len("file://") :]
+        errors = [e for e in errors if e.location().path() == cur_path]
 
         return (file_info, errors)
 

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -1043,6 +1043,9 @@ class ChapelLanguageServer(LanguageServer):
             )
             self.file_infos[uri] = file_info
 
+        # filter out errors that are not related to the file
+        errors = [e for e in errors if e.location().path() == uri[len("file://") :]]
+
         return (file_info, errors)
 
     def build_diagnostics(self, uri: str) -> List[Diagnostic]:


### PR DESCRIPTION
Fixes an issue where errors from other files were shown in the file that had window focus.

tested locally

[Reviewed by @DanilaFe]