### PR TITLE
Minor documentation cleanup for the Types module

### DIFF
--- a/modules/standard/Types.chpl
+++ b/modules/standard/Types.chpl
@@ -709,8 +709,7 @@ proc toNilableIfClassType(type arg) type {
 // joint documentation, for user convenience
 /*
 Returns the number of bits used to store the values of type ``t``.
-This is available for all numeric types and fixed-width ``bool`` types.
-It is not available for default-width ``bool``.
+This is available for all numeric types.
 */
 pragma "no where doc"
 proc numBits(type t) param where t == bool {
@@ -754,8 +753,7 @@ param bitsPerByte = 8;
 
 /*
 Returns the number of bytes used to store the values of type ``t``.
-This is available for all numeric types and fixed-width ``bool`` types.
-It is not available for default-width ``bool``.
+This is available for all numeric types.
 */
 proc numBytes(type t) param do return numBits(t)/8;
 

--- a/modules/standard/Types.chpl
+++ b/modules/standard/Types.chpl
@@ -712,6 +712,7 @@ Returns the number of bits used to store the values of type ``t``.
 This is available for all numeric types and fixed-width ``bool`` types.
 It is not available for default-width ``bool``.
 */
+pragma "no where doc"
 proc numBits(type t) param where t == bool {
   compilerError("default-width 'bool' does not have a well-defined size");
 }
@@ -767,6 +768,7 @@ When ``t`` is a ``bool`` type, it returns ``false``.
 When ``t`` is ``real``, ``imag``, or ``complex`` type,
 it is a non-``param`` function.
 */
+pragma "no where doc"
 proc min(type t) param  where isBool(t) do      return false: t;
 
 @chpldoc.nodoc
@@ -805,6 +807,7 @@ When ``t`` is a ``bool`` type, it returns ``true``.
 When ``t`` is a ``real``, ``imag``, or ``complex`` type,
 it is a non-``param`` function.
 */
+pragma "no where doc"
 proc max(type t) param  where isBool(t) do      return true: t;
 
 @chpldoc.nodoc


### PR DESCRIPTION
- Hide the where clauses for `numBits()`, `min()` and `max()`

The documentation speaks generally, but the where clauses are for one of the
specific cases (because we have several overloads and only wanted to document
it generally).  Hide the where clause so that the documentation is not confusing

- Remove some out-of-date mention of "fixed-width bool types"

We removed support for fixed-width bool types a while ago, but it looks like we
missed updating this documentation to not mention them.  Since the default width
bool (which is all that remains) is not supported, just remove mentions of bools
from these entirely.  Note that I left the overload for numBits, because it seemed
like a reasonable enough error message.

Double checked the built documentation.  Running a paratest (even though I don't
expect any surprises)