### PR TITLE
Change the default for COMM_OFI_INJECT_* to false to workaround runtime bug

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1018,9 +1018,12 @@ void chpl_comm_init(int *argc_p, char ***argv_p) {
 
   envUseCxiHybridMR = chpl_env_rt_get_bool("COMM_OFI_CXI_HYBRID_MR", true);
 
-  envInjectRMA = chpl_env_rt_get_bool("COMM_OFI_INJECT_RMA", true);
-  envInjectAMO = chpl_env_rt_get_bool("COMM_OFI_INJECT_AMO", true);
-  envInjectAM = chpl_env_rt_get_bool("COMM_OFI_INJECT_AM", true);
+  // TODO: default to false to workaround non-blocking ofi issue
+  // these should be changed back to true when that is fixed
+  envInjectRMA = chpl_env_rt_get_bool("COMM_OFI_INJECT_RMA", false);
+  envInjectAMO = chpl_env_rt_get_bool("COMM_OFI_INJECT_AMO", false);
+  envInjectAM = chpl_env_rt_get_bool("COMM_OFI_INJECT_AM", false);
+
   envUseDedicatedAmhCores = chpl_env_rt_get_bool(
                                   "COMM_OFI_DEDICATED_AMH_CORES", false);
   envExpectedProvider = chpl_env_rt_get("COMM_OFI_EXPECTED_PROVIDER", NULL);


### PR DESCRIPTION
This changes the default for the `CHPL_RT_COMM_OFI_INJECT_*` environment variables. This works around a bug in our runtime using OFI with non-blocking operations.

https://github.com/chapel-lang/chapel/issues/24972 is a symptom of this, and this PR restores correctness for this issue. I do not consider the issue resolved as this is more of a workaround.

Environment variables changed
- CHPL_RT_COMM_OFI_INJECT_AM
- CHPL_RT_COMM_OFI_INJECT_AMO
- CHPL_RT_COMM_OFI_INJECT_RMA

Tested using COMM=ofi and the EFA provider using `test/users/bachman/Beta_Diversity/main.chpl` (from #24972) and `test/release/examples/benchmarks/hpcc/ra-atomics.chpl` (which has the same problem), and validated that these tests do not hang with this patch

[Reviewed  by @jhh67] 