### PR TITLE
  Suppress LCALS nightly test timeouts

### DIFF
--- a/test/studies/lcals/LCALSMain.skipif
+++ b/test/studies/lcals/LCALSMain.skipif
@@ -1,3 +1,3 @@
-# Takes to long under valgrind
+# Takes too long under valgrind
 CHPL_TEST_VGRND_EXE == on
 COMPOPTS <= --baseline

--- a/test/studies/lcals/LCALSMain.suppressif
+++ b/test/studies/lcals/LCALSMain.suppressif
@@ -1,0 +1,2 @@
+# suppress timeouts with --no-local
+COMPOPTS <= --no-local


### PR DESCRIPTION
A recent upgrade on a test system to LLVM 17 has caused LCALS to timeout when compiled with `--no-local`. This PR adds a suppressif for this case to reduce nighty test noise while I investigate the issue

[Not reviewed, trivial]