### PR TITLE
map c2chapel FILE to c_FILE and add tests that use FILE type ptrs

### DIFF
--- a/test/c2chapel/testFunctions.c
+++ b/test/c2chapel/testFunctions.c
@@ -35,3 +35,11 @@ void test_array(int64_t* arr, int64_t len) {
 int64_t test_return(int64_t a) {
   return a + 1;
 }
+
+FILE* test_open(const char* path, const char* mode) {
+  return fopen(path, mode);
+}
+
+int test_close(FILE* file) {
+  return fclose(file);
+}

--- a/test/c2chapel/testFunctions.h
+++ b/test/c2chapel/testFunctions.h
@@ -13,3 +13,7 @@ void test_pointer(int64_t* a);
 void test_array(int64_t* arr, int64_t len);
 
 int64_t test_return(int64_t a);
+
+FILE* test_open(const char* path, const char* mode);
+
+int test_close(FILE* file);

--- a/tools/c2chapel/c2chapel.py
+++ b/tools/c2chapel/c2chapel.py
@@ -91,8 +91,8 @@ c2chapel["signed int"]         = "c_int"
 c2chapel["signed long long"]   = "c_longlong"
 c2chapel["signed long"]        = "c_long"
 
-# Note: this mapping is defined by the compiler, not the ChapelSysCTypes file
-c2chapel["FILE"] = "_file"
+# Note: this mapping is defined by CTypes, not the ChapelSysCTypes file
+c2chapel["FILE"] = "c_FILE"
 
 __temp = [k for k in c2chapel.keys()]
 for key in __temp:
@@ -511,7 +511,7 @@ def genTypeAlias(node):
             print("extern type " + alias + ";")
         else:
             print("extern type " + alias + " = " + typeName + ";")
-        foundTypes.add(alias);
+        foundTypes.add(alias)
         print()
 
 def isPointerToStruct(node):
@@ -590,7 +590,7 @@ def handleTypedefs(defs, ignores):
 # - bitshift constants (e.g. 1<<3)
 def emit_defines(fname):
     with open(fname, "r") as f:
-        pat = re.compile("^\s*#define\s+([_a-zA-Z0-9]+)\s+[0-9]+$")
+        pat = re.compile("^\\s*#define\\s+([_a-zA-Z0-9]+)\\s+[0-9]+$")
         first = True
         for line in f:
             res = pat.match(line)


### PR DESCRIPTION
Fixes a bug in `c2chapel` where signatures with `FILE` or `FILE*` types were incorrectly generated as `_FILE` in the corresponding Chapel source files. Also adds some tests for `c2chapel` that make use of signatures with `FILE` and `FILE*` types to catch changes in the behavior.

TESTING:

- [x] paratest `[Summary: #Successes = 17215 | #Failures = 0 | #Futures = 924]`
- [x] local testing of `test/c2chapel` dir

[reviewed by @mppf - thanks!]