### PR TITLE
Update CUDA versions for the EX testing system upgrade

### DIFF
--- a/util/cron/test-gpu-ex-cuda-11.bash
+++ b/util/cron/test-gpu-ex-cuda-11.bash
@@ -6,7 +6,7 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-native-gpu.bash
 source $CWD/common-hpe-cray-ex.bash
 
-module load cudatoolkit/23.3_11.8 # pin to CUDA 11
+module load cudatoolkit/23.9_11.8
 
 # the module loaded above doesn't wire symlinks correctly. I've created a ticket
 # for that, but until that's fixed, we are setting this environment explicitly

--- a/util/cron/test-gpu-ex-cuda-12.bash
+++ b/util/cron/test-gpu-ex-cuda-12.bash
@@ -6,7 +6,7 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-native-gpu.bash
 source $CWD/common-hpe-cray-ex.bash
 
-module load cudatoolkit/23.3_12.0  # this is the default on this system
+module load cudatoolkit  # default is CUDA 12
 
 export CHPL_LLVM=bundled  # CUDA 12 is only supported with bundled LLVM
 export CHPL_COMM=none

--- a/util/cron/test-gpu-ex-cuda-12.ofi.bash
+++ b/util/cron/test-gpu-ex-cuda-12.ofi.bash
@@ -6,7 +6,7 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-native-gpu.bash
 source $CWD/common-hpe-cray-ex.bash
 
-module load cudatoolkit/23.3_12.0  # this is the default on this system
+module load cudatoolkit  # default is CUDA 12
 
 export CHPL_LLVM=bundled  # CUDA 12 is only supported with bundled LLVM
 export CHPL_COMM=ofi

--- a/util/cron/test-perf.gpu-ex-cuda-12.bash
+++ b/util/cron/test-perf.gpu-ex-cuda-12.bash
@@ -6,7 +6,7 @@ CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common-native-gpu.bash
 source $CWD/common-hpe-cray-ex.bash
 
-module load cudatoolkit/23.3_12.0  # this is the default on this system
+module load cudatoolkit  # default is CUDA 12
 
 export CHPL_LLVM=bundled  # CUDA 12 is only supported with bundled LLVM
 export CHPL_COMM=none


### PR DESCRIPTION
Updates `cudatoolkit` module versions after the system on which we run these tests got upgraded.

- For versions where we pin 11, we still use the explicit version.
- For versions where we use 12, we just rely on it being the default CUDA version.

This PR changes 4 configs, I tested one by manually launching the job.