### PR TITLE
Add suppressif for complex/imag test on cygwin

### DIFF
--- a/test/library/standard/Math/trigImagFunctions.suppressif
+++ b/test/library/standard/Math/trigImagFunctions.suppressif
@@ -1,0 +1,2 @@
+# the floating point comparisons on cygwin are not handled right for this test
+CHPL_TARGET_PLATFORM <= cygwin


### PR DESCRIPTION
Adds suppressif to a test checking that the `complex` and `imag` versions of a function return the same value. The comparison in the test does not seem to work on cygwin.

[Not reviewed, trivial]