### PR TITLE
Turn off warning for cuda 11

### DIFF
--- a/runtime/src/gpu/nvidia/Makefile.share
+++ b/runtime/src/gpu/nvidia/Makefile.share
@@ -30,6 +30,9 @@ RUNTIME_CXXFLAGS += -x cuda -Wno-unknown-cuda-version \
                     -Xclang -fcuda-allow-variadic-functions \
                     --offload-arch=$(CHPL_MAKE_GPU_ARCH)
 
+# With cuda 11, cub headers have unused typedefs
+RUNTIME_CXXFLAGS += -Wno-error=unused-local-typedef
+
 $(RUNTIME_OBJ_DIR)/gpu-nvidia-cub.o: gpu-nvidia-cub.cc \
                                          $(RUNTIME_OBJ_DIR_STAMP)
 	$(CXX) -c $(CXX11_STD) $(RUNTIME_CXXFLAGS) $(RUNTIME_INCLS) -o $@ $<


### PR DESCRIPTION
This fixes an issue that came up in our nightly testing with cuda 11, where new warnings in cub headers caused builds to fail.

Tested that chapel built on test system with cuda 11

[Reviewed by @ShreyasKhandekar]