### PR TITLE
Add `-no-warnings` flag to `nightly` test script

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -33,6 +33,7 @@ $interpret = 0;
 $printusage = 1;
 $debug = 1;
 $asserts = 0;
+$warnings = 1;
 $runtests = 1;
 $buildruntime = 1;
 $hello = 0;
@@ -163,6 +164,8 @@ while (@ARGV) {
         $junit_xml = 1;
     } elsif ($flag eq "-asserts") {
         $asserts = 1;
+    } elsif ($flag eq "-no-warnings") {
+        $warnings = 0;
     } elsif ($flag eq "-mason") {
         $mason_build = 1;
     } elsif ($flag eq "-protobuf") {
@@ -491,7 +494,7 @@ if ($python2 == 0) {
   $hostcompiler = `$utildir/chplenv/chpl_compiler.py --host`; chomp($hostcompiler);
 
   # Setup variables to pass to all make calls.
-  $make_vars_no_opt = "DEBUG=0 WARNINGS=1 ASSERTS=$asserts";
+  $make_vars_no_opt = "DEBUG=0 WARNINGS=$warnings ASSERTS=$asserts";
 
   # Add OPTIMIZE=1 for most environments. If using the cray programming
   # environment, disable optimizations when building the compiler. This is an

--- a/util/cron/test-perf.chapcs.arkouda.release.bash
+++ b/util/cron/test-perf.chapcs.arkouda.release.bash
@@ -27,5 +27,7 @@ else
   exit 1
 fi
 
+nightly_args="${nightly_args} -no-warnings"
+
 test_release
 sync_graphs


### PR DESCRIPTION
This PR adds a `-no-warnings` flag to `util/cron/nightly`, allowing nightly test configs to flip the default for building Chapel (similar to `-asserts`). This PR then uses that flag in `util/cron/test-perf.chapcs.arkouda.release.bash`

[Reviewed by @tzinsky]