### PR TITLE
Fix homebrew for CLS and chplcheck

### DIFF
--- a/util/cron/test-homebrew.bash
+++ b/util/cron/test-homebrew.bash
@@ -35,15 +35,10 @@ cd $CHPL_HOME
 log_info "Building tarball with version: ${version}"
 ./util/buildRelease/gen_release ${version}
 
-# This will clone the home-brew repository under test and copies the chapel formula in chapel-lang repo under
-# util/packaging/home-brew
-# replace the url and sha in the chapel formula with the url pointing to the tarball created and sha of the tarball.
-# run home-brew scripts to install chapel.
+# This will replace the url and sha in the chapel formula with the url pointing
+# to the tarball created and sha of the tarball and then run home-brew scripts
+# to install chapel.
 
-mkdir -p $HOME/test
-git clone --reference-if-able "${REPO_CACHE_PATH:-/missing}/homebrew-core.git" git@github.com:Homebrew/homebrew-core.git 2> /dev/null || (cd $HOME/test/homebrew-core; git pull)
-#cp $HOME/test/homebrew-core/Formula/c/chapel.rb  ${CHPL_HOME}/util/packaging/homebrew/chapel.rb
-# fix to make the home-brew working. After 1.32 release uncomment the above line
 cp ${CHPL_HOME}/util/packaging/homebrew/chapel-main.rb  ${CHPL_HOME}/util/packaging/homebrew/chapel.rb
 cd ${CHPL_HOME}/util/packaging/homebrew
 # Get the tarball from the root tar/ directory and replace the url in chapel.rb with the tarball location
@@ -51,16 +46,16 @@ location="${CHPL_HOME}/tar/chapel-${version}.tar.gz"
 log_info $location
 
 # Replace the url and sha236 in chapel.rb with the location of the tarball and sha256 of the tarball generated.
-# create sed -i '' -e for macOS 
+# create sed -i '' -e for macOS
 sed_command="sed -i '' -e"
-$sed_command "s#url.*#url \"file\:///$location\"#" chapel.rb 
+$sed_command "s#url.*#url \"file\:///$location\"#" chapel.rb
 sha=($(shasum -a 256 $location))
 sha256=${sha[0]}
 log_info $sha256
 $sed_command  "1s/sha256.*/sha256 \"$sha256\"/;t" -e "1,/sha256.*/s//sha256 \"$sha256\"/" chapel.rb
 
 # Test if homebrew install using the chapel formula works.
-brew upgrade 
+brew upgrade
 brew uninstall --force chapel
 # Remove the cached chapel tar file before running brew install --build-from-source chapel.rb
 rm /Users/chapelu/Library/Caches/Homebrew/downloads/*.tar.gz

--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -84,6 +84,9 @@ class Chapel < Formula
       end
       system "make", "mason"
       with_env(CHPL_PIP_FROM_SOURCE: "1") do
+        cd "compiler" do
+          system "make", "clean-cmakecache"
+        end
         system "make", "chplcheck"
         system "make", "chpl-language-server"
       end
@@ -127,6 +130,11 @@ class Chapel < Formula
     system bin/"chpl", "--print-passes", "--print-commands", libexec/"examples/hello.chpl"
     system bin/"chpldoc", "--version"
     system bin/"mason", "--version"
+
+    # Test chplcheck, if it works CLS probably does too.
+    # chpl-language-server will hang indefinitely waiting for a LSP client
+    system bin/"chplcheck", "--list-rules"
+    system bin/"chplcheck", libexec/"examples/hello.chpl"
   end
 end
 


### PR DESCRIPTION
Adjusts the homebrew install for CLS and chplcheck to `make clean-cmakecache` from #24670 and #24827.

This PR also cleans up some of the homebrew nightly test logic

TO BE MERGED AFTER https://github.com/chapel-lang/chapel/pull/24670

Tested homebrew build locally

[Reviewed by @]