### PR TITLE
Implement `PRIM_GET_SVEC_MEMBER*` in Dyno

### DIFF
--- a/frontend/include/chpl/resolution/can-pass.h
+++ b/frontend/include/chpl/resolution/can-pass.h
@@ -244,6 +244,11 @@ class KindProperties {
      checking is a separate pass. */
   void strictCombineWith(const KindProperties& other);
 
+  /* Combine the properties of two kinds, returning the result as a kind. */
+  static types::QualifiedType::Kind combineKinds(
+      types::QualifiedType::Kind kind1,
+      types::QualifiedType::Kind kind2);
+
   /* Convert the set of kind properties back into a kind. */
   types::QualifiedType::Kind toKind() const;
 

--- a/frontend/include/chpl/resolution/can-pass.h
+++ b/frontend/include/chpl/resolution/can-pass.h
@@ -221,6 +221,9 @@ class KindProperties {
  private:
   void invalidate();
 
+  /* Helper to check basic validity of combining two KindProperties. */
+  bool checkValidCombine(const KindProperties& other) const;
+
  public:
   /* Decompose a qualified type kind into its properties. */
   static KindProperties fromKind(types::QualifiedType::Kind kind);
@@ -233,8 +236,13 @@ class KindProperties {
 
   /* Combine two sets of kind properties into this one. The resulting
      set of properties is compatible with both arguments (e.g. ref + val = val,
-     since values can't be made into references). */
-  void combineWith(const KindProperties& other);
+     since values can't be made into references).
+     Takes the mathematical join with respect to constness (const + non-const = const). */
+  void combineWithJoin(const KindProperties& other);
+
+  /* Like combineWithJoin, but takes the mathematical meet with respect to
+     constness (const + non-const = non-const). */
+  void combineWithMeet(const KindProperties& other);
 
   /* Combine two sets of kind properties, strictly enforcing properties of
      the receiver (e.g. (receiver) param + (other) value = invalid, because
@@ -245,7 +253,7 @@ class KindProperties {
   void strictCombineWith(const KindProperties& other);
 
   /* Combine the properties of two kinds, returning the result as a kind. */
-  static types::QualifiedType::Kind combineKinds(
+  static types::QualifiedType::Kind combineKindsMeet(
       types::QualifiedType::Kind kind1,
       types::QualifiedType::Kind kind2);
 

--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -1118,6 +1118,14 @@ void KindProperties::strictCombineWith(const KindProperties& other) {
   // We could do some checking now, but that might be a bit premature.
 }
 
+types::QualifiedType::Kind KindProperties::combineKinds(
+    types::QualifiedType::Kind kind1, types::QualifiedType::Kind kind2) {
+  auto kp1 = KindProperties::fromKind(kind1);
+  auto kp2 = KindProperties::fromKind(kind2);
+  kp1.combineWith(kp2);
+  return kp1.toKind();
+}
+
 QualifiedType::Kind KindProperties::toKind() const {
   if (!isValid) return QualifiedType::UNKNOWN;
   if (isType) return QualifiedType::TYPE;

--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -1088,25 +1088,41 @@ void KindProperties::setParam(bool isParam) {
   this->isParam = isParam;
 }
 
-void KindProperties::combineWith(const KindProperties& other) {
-  if (!isValid) return;
-  if (!other.isValid || isType != other.isType) {
+bool KindProperties::checkValidCombine(const KindProperties& other) const {
+  if (!isValid || !other.isValid) {
+    return false;
+  }
+  if (isType != other.isType) {
     // Can't mix types and non-types.
+    return false;
+  }
+
+  return true;
+}
+
+void KindProperties::combineWithJoin(const KindProperties& other) {
+  if (!checkValidCombine(other)) {
     invalidate();
     return;
   }
+
   isConst = isConst || other.isConst;
   isRef = isRef && other.isRef;
   isParam = isParam && other.isParam;
 }
 
+void KindProperties::combineWithMeet(const KindProperties& other) {
+  bool bothConst = isConst && other.isConst;
+  combineWithJoin(other);
+  isConst = bothConst;
+}
+
 void KindProperties::strictCombineWith(const KindProperties& other) {
-  if (!isValid) return;
-  if (!other.isValid || isType != other.isType) {
-    // Can't mix types and non-types.
+  if (!checkValidCombine(other)) {
     invalidate();
     return;
   }
+
   if (isParam && !other.isParam) {
     // If a param is required, can't return a non-param.
     invalidate();
@@ -1118,11 +1134,11 @@ void KindProperties::strictCombineWith(const KindProperties& other) {
   // We could do some checking now, but that might be a bit premature.
 }
 
-types::QualifiedType::Kind KindProperties::combineKinds(
+types::QualifiedType::Kind KindProperties::combineKindsMeet(
     types::QualifiedType::Kind kind1, types::QualifiedType::Kind kind2) {
   auto kp1 = KindProperties::fromKind(kind1);
   auto kp2 = KindProperties::fromKind(kind2);
-  kp1.combineWith(kp2);
+  kp1.combineWithMeet(kp2);
   return kp1.toKind();
 }
 
@@ -1171,7 +1187,7 @@ commonType(Context* context,
     }
     auto kind = type.kind();
     auto typeProperties = KindProperties::fromKind(kind);
-    properties.combineWith(typeProperties);
+    properties.combineWithJoin(typeProperties);
   }
 
   if (requiredKind) {

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -384,8 +384,8 @@ static QualifiedType primGetSvecMember(Context* context, PrimitiveTag prim,
     if (index.hasTypePtr() && index.type()->isIntegralType()) {
       auto act = ci.actual(0).type();
       if (auto tup = act.type()->toTupleType()) {
-        auto eltType = tup->elementType(0);
         if (tup->isStarTuple()) {
+          auto eltType = tup->starType();
           QualifiedType::Kind retKind = eltType.kind();
           if (prim == PRIM_GET_SVEC_MEMBER_VALUE) {
             // Must return as value for _VALUE variant, but still maintain

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -308,7 +308,7 @@ static QualifiedType primAddrOf(Context* context, const CallInfo& ci) {
   // Combine the properties of the argument's kind with those of the 'REF'
   // kind. This should inherit const-ness, throw off param-ness, and result in
   // errors if the argument is a TYPE.
-  kp.combineWith(KindProperties::fromKind(QualifiedType::REF));
+  kp.combineWithJoin(KindProperties::fromKind(QualifiedType::REF));
   if (!kp.valid()) return QualifiedType();
 
   // 'combineWith' actually disables ref-ness if either argument is non-ref.
@@ -389,8 +389,8 @@ static QualifiedType primGetSvecMember(Context* context, PrimitiveTag prim,
           QualifiedType::Kind retKind = eltType.kind();
           if (prim == PRIM_GET_SVEC_MEMBER_VALUE) {
             // Return as value for _VALUE variant, maintaining constness.
-            // TODO: also maintain param-ness if we later support param tuples
-            retKind = KindProperties::combineKinds(retKind, QualifiedType::VAR);
+            retKind =
+                KindProperties::combineKindsMeet(retKind, QualifiedType::PARAM);
           }
           return QualifiedType(retKind, eltType.type());
         }

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -388,12 +388,9 @@ static QualifiedType primGetSvecMember(Context* context, PrimitiveTag prim,
           auto eltType = tup->starType();
           QualifiedType::Kind retKind = eltType.kind();
           if (prim == PRIM_GET_SVEC_MEMBER_VALUE) {
-            // Must return as value for _VALUE variant, but still maintain
-            // constness and param-ness as applicable.
-            if (!eltType.isParam()) {
-              retKind = (eltType.isConst() ? QualifiedType::CONST_VAR
-                                           : QualifiedType::VAR);
-            }
+            // Return as value for _VALUE variant, maintaining constness.
+            // TODO: also maintain param-ness if we later support param tuples
+            retKind = KindProperties::combineKinds(retKind, QualifiedType::VAR);
           }
           return QualifiedType(retKind, eltType.type());
         }

--- a/frontend/test/resolution/testTuples.cpp
+++ b/frontend/test/resolution/testTuples.cpp
@@ -617,40 +617,6 @@ static void argHelper(std::string formal, std::string actual,
   }
 }
 
-static void testTupleGeneric() {
-  printf("testTupleGeneric\n");
-
-  // Basic all-generic cases
-  argHelper("(?,)", "(5,)", true);
-  argHelper("(?,)", "('hello',)", true);
-  argHelper("(?,?)", "(5, 1.0)", true);
-  argHelper("(?,?)", "(5, 'hello')", true);
-  argHelper("(?,?,?)", "(5, 1.0,'hello')", true);
-
-  // Mixed concrete and generic, still expecting to pass
-  argHelper("(int, ?)", "(5, 1.0)", true);
-  argHelper("(int, ?)", "(5, 'hello')", true);
-  argHelper("(int, ?)", "('hello', 5)", false);
-
-  argHelper("(int, ?, string)", "(5, 42.0, 'hello')", true);
-  argHelper("(int, ?, string)", "(5, 5, 'hello')", true);
-  argHelper("(int, ?, string)", "(5, 'hi', 'hello')", true);
-  argHelper("(int, ?, string)", "('hi', 42.0, 'hello')", false);
-  argHelper("(int, ?, string)", "(5, 42.0, 5)", false);
-
-  // Passing a tuples of incorrect size
-  argHelper("(int, ?)", "(5,5,5)", false);
-  argHelper("(int, ?, ?)", "(5,5)", false);
-
-  // Some 'integral' and 'numeric' tests
-  argHelper("(integral, integral)", "(5, 5)", true);
-  argHelper("(integral, integral)", "(5, 'hello')", false);
-
-  argHelper("(numeric, numeric)", "(5, 5)", true);
-  argHelper("(numeric, numeric)", "(5, 42.0)", true);
-  argHelper("(numeric, numeric)", "(5, 'hi')", false);
-}
-
 static void test18() {
   printf("test18\n");
   Context ctx;
@@ -708,6 +674,41 @@ static void test19() {
 
   ensureParamBool(rr.byAst(a).type(), true);
   ensureParamBool(rr.byAst(b).type(), true);
+}
+
+
+static void testTupleGeneric() {
+  printf("testTupleGeneric\n");
+
+  // Basic all-generic cases
+  argHelper("(?,)", "(5,)", true);
+  argHelper("(?,)", "('hello',)", true);
+  argHelper("(?,?)", "(5, 1.0)", true);
+  argHelper("(?,?)", "(5, 'hello')", true);
+  argHelper("(?,?,?)", "(5, 1.0,'hello')", true);
+
+  // Mixed concrete and generic, still expecting to pass
+  argHelper("(int, ?)", "(5, 1.0)", true);
+  argHelper("(int, ?)", "(5, 'hello')", true);
+  argHelper("(int, ?)", "('hello', 5)", false);
+
+  argHelper("(int, ?, string)", "(5, 42.0, 'hello')", true);
+  argHelper("(int, ?, string)", "(5, 5, 'hello')", true);
+  argHelper("(int, ?, string)", "(5, 'hi', 'hello')", true);
+  argHelper("(int, ?, string)", "('hi', 42.0, 'hello')", false);
+  argHelper("(int, ?, string)", "(5, 42.0, 5)", false);
+
+  // Passing a tuples of incorrect size
+  argHelper("(int, ?)", "(5,5,5)", false);
+  argHelper("(int, ?, ?)", "(5,5)", false);
+
+  // Some 'integral' and 'numeric' tests
+  argHelper("(integral, integral)", "(5, 5)", true);
+  argHelper("(integral, integral)", "(5, 'hello')", false);
+
+  argHelper("(numeric, numeric)", "(5, 5)", true);
+  argHelper("(numeric, numeric)", "(5, 42.0)", true);
+  argHelper("(numeric, numeric)", "(5, 'hi')", false);
 }
 
 int main() {

--- a/frontend/test/resolution/testTuples.cpp
+++ b/frontend/test/resolution/testTuples.cpp
@@ -653,8 +653,8 @@ static void test19() {
                   var y = t(1);
                   var z = t(2);
 
-                  param a = __primitive("get svec member", t, 0).type == int;
-                  param b = __primitive("get svec member", t, 1).type == int;
+                  var a = __primitive("get svec member", t, 0);
+                  var b = __primitive("get svec member value", t, 0);
                 )"""";
 
   auto m = parseModule(context, std::move(program));
@@ -672,8 +672,13 @@ static void test19() {
   assert(rr.byAst(y).type().type()->isIntType());
   assert(rr.byAst(z).type().type()->isIntType());
 
-  ensureParamBool(rr.byAst(a).type(), true);
-  ensureParamBool(rr.byAst(b).type(), true);
+  auto aQt = rr.byAst(a).type();
+  auto bQt = rr.byAst(b).type();
+
+  assert(aQt.kind() == QualifiedType::VAR);
+  assert(aQt.type()->isIntType());
+  assert(aQt.kind() == QualifiedType::VAR);
+  assert(bQt.type()->isIntType());
 }
 
 

--- a/frontend/test/resolution/testTuples.cpp
+++ b/frontend/test/resolution/testTuples.cpp
@@ -665,39 +665,24 @@ static void test19() {
                   var d = __primitive("get svec member value", (myFoo, myFoo), 1);
                 )"""";
 
-  auto m = parseModule(context, std::move(program));
+  auto variables = resolveTypesOfVariablesInit(
+      context, program, {"x", "y", "z", "a", "b", "c", "d"});
 
-  auto x = findVariable(m, "x");
-  auto y = findVariable(m ,"y");
-  auto z = findVariable(m ,"z");
+  assert(variables.at("x").type()->isIntType());
+  assert(variables.at("y").type()->isIntType());
+  assert(variables.at("z").type()->isIntType());
 
-  auto aInit = findVariable(m ,"a")->initExpression();
-  auto bInit = findVariable(m ,"b")->initExpression();
-  auto cInit = findVariable(m ,"c")->initExpression();
-  auto dInit = findVariable(m ,"d")->initExpression();
+  assert(variables.at("a").kind() == QualifiedType::VAR);
+  assert(variables.at("a").type()->isIntType());
 
-  const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
+  assert(variables.at("b").kind() == QualifiedType::VAR);
+  assert(variables.at("b").type()->isIntType());
 
-  assert(rr.byAst(x).type().type()->isIntType());
-  assert(rr.byAst(y).type().type()->isIntType());
-  assert(rr.byAst(z).type().type()->isIntType());
+  assert(variables.at("c").kind() == QualifiedType::REF);
+  assert(variables.at("c").type()->isClassType());
 
-  auto aInitQt = rr.byAst(aInit).type();
-  auto bInitQt = rr.byAst(bInit).type();
-  auto cInitQt = rr.byAst(cInit).type();
-  auto dInitQt = rr.byAst(dInit).type();
-
-  assert(aInitQt.kind() == QualifiedType::VAR);
-  assert(aInitQt.type()->isIntType());
-
-  assert(bInitQt.kind() == QualifiedType::VAR);
-  assert(bInitQt.type()->isIntType());
-
-  assert(cInitQt.kind() == QualifiedType::REF);
-  assert(cInitQt.type()->isClassType());
-
-  assert(dInitQt.kind() == QualifiedType::VAR);
-  assert(dInitQt.type()->isClassType());
+  assert(variables.at("d").kind() == QualifiedType::VAR);
+  assert(variables.at("d").type()->isClassType());
 }
 
 

--- a/frontend/test/resolution/testTuples.cpp
+++ b/frontend/test/resolution/testTuples.cpp
@@ -676,6 +676,40 @@ static void test18() {
   assert(rr.byAst(z).type().type()->isRealType());
 }
 
+static void test19() {
+  printf("test19\n");
+  Context ctx;
+  Context* context = &ctx;
+
+  auto program = R""""(
+                  var t = (1, 2, 3);
+                  var x = t(0);
+                  var y = t(1);
+                  var z = t(2);
+
+                  param a = __primitive("get svec member", t, 0).type == int;
+                  param b = __primitive("get svec member", t, 1).type == int;
+                )"""";
+
+  auto m = parseModule(context, std::move(program));
+
+  auto x = findVariable(m, "x");
+  auto y = findVariable(m ,"y");
+  auto z = findVariable(m ,"z");
+
+  auto a = findVariable(m ,"a");
+  auto b = findVariable(m ,"b");
+
+  const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
+
+  assert(rr.byAst(x).type().type()->isIntType());
+  assert(rr.byAst(y).type().type()->isIntType());
+  assert(rr.byAst(z).type().type()->isIntType());
+
+  ensureParamBool(rr.byAst(a).type(), true);
+  ensureParamBool(rr.byAst(b).type(), true);
+}
+
 int main() {
   test1();
   test2();
@@ -697,6 +731,7 @@ int main() {
   test16();
   test17();
   test18();
+  test19();
 
   testTupleGeneric();
 

--- a/frontend/test/resolution/testTuples.cpp
+++ b/frontend/test/resolution/testTuples.cpp
@@ -642,6 +642,7 @@ static void test18() {
   assert(rr.byAst(z).type().type()->isRealType());
 }
 
+// Test "get svec member[ value]" primitives
 static void test19() {
   printf("test19\n");
   Context ctx;
@@ -653,8 +654,14 @@ static void test19() {
                   var y = t(1);
                   var z = t(2);
 
+                  class Foo {
+                    proc init() {}
+                  }
+
                   var a = __primitive("get svec member", t, 0);
                   var b = __primitive("get svec member value", t, 0);
+                  var c = __primitive("get svec member", (new Foo(), new Foo()), 1);
+                  var d = __primitive("get svec member value", (new Foo(), new Foo()), 1);
                 )"""";
 
   auto m = parseModule(context, std::move(program));
@@ -665,6 +672,8 @@ static void test19() {
 
   auto a = findVariable(m ,"a");
   auto b = findVariable(m ,"b");
+  auto c = findVariable(m ,"c");
+  auto d = findVariable(m ,"d");
 
   const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
 
@@ -674,11 +683,20 @@ static void test19() {
 
   auto aQt = rr.byAst(a).type();
   auto bQt = rr.byAst(b).type();
+  auto cQt = rr.byAst(c).type();
+  auto dQt = rr.byAst(d).type();
 
   assert(aQt.kind() == QualifiedType::VAR);
   assert(aQt.type()->isIntType());
-  assert(aQt.kind() == QualifiedType::VAR);
+
+  assert(bQt.kind() == QualifiedType::VAR);
   assert(bQt.type()->isIntType());
+
+  assert(cQt.kind() == QualifiedType::REF);
+  assert(cQt.type()->isClassType());
+
+  assert(dQt.kind() == QualifiedType::VAR);
+  assert(dQt.type()->isClassType());
 }
 
 

--- a/frontend/test/resolution/testTuples.cpp
+++ b/frontend/test/resolution/testTuples.cpp
@@ -657,11 +657,12 @@ static void test19() {
                   class Foo {
                     proc init() {}
                   }
+                  var myFoo = new owned Foo();
 
                   var a = __primitive("get svec member", t, 0);
                   var b = __primitive("get svec member value", t, 0);
-                  var c = __primitive("get svec member", (new Foo(), new Foo()), 1);
-                  var d = __primitive("get svec member value", (new Foo(), new Foo()), 1);
+                  var c = __primitive("get svec member", (myFoo, myFoo), 1);
+                  var d = __primitive("get svec member value", (myFoo, myFoo), 1);
                 )"""";
 
   auto m = parseModule(context, std::move(program));
@@ -670,10 +671,10 @@ static void test19() {
   auto y = findVariable(m ,"y");
   auto z = findVariable(m ,"z");
 
-  auto a = findVariable(m ,"a");
-  auto b = findVariable(m ,"b");
-  auto c = findVariable(m ,"c");
-  auto d = findVariable(m ,"d");
+  auto aInit = findVariable(m ,"a")->initExpression();
+  auto bInit = findVariable(m ,"b")->initExpression();
+  auto cInit = findVariable(m ,"c")->initExpression();
+  auto dInit = findVariable(m ,"d")->initExpression();
 
   const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
 
@@ -681,22 +682,22 @@ static void test19() {
   assert(rr.byAst(y).type().type()->isIntType());
   assert(rr.byAst(z).type().type()->isIntType());
 
-  auto aQt = rr.byAst(a).type();
-  auto bQt = rr.byAst(b).type();
-  auto cQt = rr.byAst(c).type();
-  auto dQt = rr.byAst(d).type();
+  auto aInitQt = rr.byAst(aInit).type();
+  auto bInitQt = rr.byAst(bInit).type();
+  auto cInitQt = rr.byAst(cInit).type();
+  auto dInitQt = rr.byAst(dInit).type();
 
-  assert(aQt.kind() == QualifiedType::VAR);
-  assert(aQt.type()->isIntType());
+  assert(aInitQt.kind() == QualifiedType::VAR);
+  assert(aInitQt.type()->isIntType());
 
-  assert(bQt.kind() == QualifiedType::VAR);
-  assert(bQt.type()->isIntType());
+  assert(bInitQt.kind() == QualifiedType::VAR);
+  assert(bInitQt.type()->isIntType());
 
-  assert(cQt.kind() == QualifiedType::REF);
-  assert(cQt.type()->isClassType());
+  assert(cInitQt.kind() == QualifiedType::REF);
+  assert(cInitQt.type()->isClassType());
 
-  assert(dQt.kind() == QualifiedType::VAR);
-  assert(dQt.type()->isClassType());
+  assert(dInitQt.kind() == QualifiedType::VAR);
+  assert(dInitQt.type()->isClassType());
 }
 
 


### PR DESCRIPTION
Implement `get svec member` and `get svec member value` primitives in Dyno and add some testing.

Along the way, split `KindProperties::combineWith` into `combineWithJoin` and `combineWithMeet` variations. These take the mathematical join and meet with respect to constness, considering `const > non-const`. `combineWithJoin` is equivalent to the previous version, whereas the new `combineWithMeet` is a "less strict" version used to remove ref-ness in the `get svec member value` primitive. Thanks @DanilaFe for the out-of-band suggestions on this.

Part of https://github.com/Cray/chapel-private/issues/5512 and https://github.com/Cray/chapel-private/issues/6104.

[reviewer info placeholder]

Testing:
- [x] dyno tests
- [x] paratest