### PR TITLE
Improve the templates when the user doesn't have CHPL_HOME set

### DIFF
--- a/.github/ISSUE_TEMPLATE/00-bug.md
+++ b/.github/ISSUE_TEMPLATE/00-bug.md
@@ -50,5 +50,9 @@ e.g. [`test/path/to/foo.chpl`](
 
 - Output of `chpl --version`:
 - Output of `$CHPL_HOME/util/printchplenv --anonymize`:
+  <!--
+  When `$CHPL_HOME` is not set, you can use `chpl --print-chpl-settings`
+  instead, though be aware that this does not anonymize the output (yet)
+  -->
 - Back-end compiler and version, e.g. `gcc --version` or `clang --version`:
 - (For Cray systems only) Output of `module list`:

--- a/.github/ISSUE_TEMPLATE/00-bug.md
+++ b/.github/ISSUE_TEMPLATE/00-bug.md
@@ -52,7 +52,7 @@ e.g. [`test/path/to/foo.chpl`](
 - Output of `$CHPL_HOME/util/printchplenv --anonymize`:
   <!--
   When `$CHPL_HOME` is not set, you can use `chpl --print-chpl-settings`
-  instead, though be aware that this does not anonymize the output (yet)
+  instead, though be aware that this does not anonymize the output
   -->
 - Back-end compiler and version, e.g. `gcc --version` or `clang --version`:
 - (For Cray systems only) Output of `module list`:

--- a/.github/ISSUE_TEMPLATE/03-documentation.md
+++ b/.github/ISSUE_TEMPLATE/03-documentation.md
@@ -44,5 +44,9 @@ e.g. [`test/path/to/foo.chpl`](
 
 - Output of `chpldoc --version`:
 - Output of `$CHPL_HOME/util/printchplenv --anonymize`:
+  <!--
+  When `$CHPL_HOME` is not set, you can use `chpl --print-chpl-settings`
+  instead, though be aware that this does not anonymize the output (yet)
+  -->
 - Back-end compiler and version, e.g. `gcc --version` or `clang --version`:
 - (For Cray systems only) Output of `module list`:

--- a/.github/ISSUE_TEMPLATE/03-documentation.md
+++ b/.github/ISSUE_TEMPLATE/03-documentation.md
@@ -46,7 +46,7 @@ e.g. [`test/path/to/foo.chpl`](
 - Output of `$CHPL_HOME/util/printchplenv --anonymize`:
   <!--
   When `$CHPL_HOME` is not set, you can use `chpl --print-chpl-settings`
-  instead, though be aware that this does not anonymize the output (yet)
+  instead, though be aware that this does not anonymize the output
   -->
 - Back-end compiler and version, e.g. `gcc --version` or `clang --version`:
 - (For Cray systems only) Output of `module list`:


### PR DESCRIPTION
Michelle discovered that when a user installs using homebrew, `$CHPL_HOME/util/printchplenv --anonymize` doesn't work because `$CHPL_HOME` is not set.  List the alternative option Jade mentioned, though it does not anonymize the output (being explicit that that is the case so it doesn't surprise users).

Only the bug report and documentation report templates needed to be updated, the others do not include the command in question

I think this works based on looking at how the file displays in Github, but would need to make a test repository to fully check - if my reviewer is okay with it, I would like to check how it displays by merging and following up with tweaks as needed.