### PR TITLE
Fix creal and cimag support for gpus

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1403,12 +1403,14 @@ module ChapelBase {
   inline proc chpl_anycomplex.re {
     if this.type == complex(128) {
       pragma "fn synchronization free"
-      extern proc creal(x:complex(128)): real(64);
-      return creal(this);
+      pragma "codegen for CPU and GPU"
+      extern proc chpl_creal(x:complex(128)): real(64);
+      return chpl_creal(this);
     } else {
       pragma "fn synchronization free"
-      extern proc crealf(x:complex(64)): real(32);
-      return crealf(this);
+      pragma "codegen for CPU and GPU"
+      extern proc chpl_crealf(x:complex(64)): real(32);
+      return chpl_crealf(this);
     }
   }
   inline proc ref chpl_anycomplex.im ref {
@@ -1420,12 +1422,14 @@ module ChapelBase {
   inline proc chpl_anycomplex.im {
     if this.type == complex(128) {
       pragma "fn synchronization free"
-      extern proc cimag(x:complex(128)): real(64);
-      return cimag(this);
+      pragma "codegen for CPU and GPU"
+      extern proc chpl_cimag(x:complex(128)): real(64);
+      return chpl_cimag(this);
     } else {
       pragma "fn synchronization free"
-      extern proc cimagf(x:complex(64)): real(32);
-      return cimagf(this);
+      pragma "codegen for CPU and GPU"
+      extern proc chpl_cimagf(x:complex(64)): real(32);
+      return chpl_cimagf(this);
     }
   }
 

--- a/runtime/include/chplmath.h
+++ b/runtime/include/chplmath.h
@@ -34,6 +34,20 @@ MAYBE_GPU static inline int chpl_macro_float_isnan(float x) { return isnan(x); }
 MAYBE_GPU static inline int chpl_macro_double_signbit(double x) { return signbit(x); }
 MAYBE_GPU static inline int chpl_macro_float_signbit(float x) { return signbit(x); }
 
+
+#ifdef __cplusplus
+// workaround for C++ lacking C99 complex support
+MAYBE_GPU static inline double chpl_creal(_complex128 x) { return __builtin_creal(x); }
+MAYBE_GPU static inline float  chpl_crealf(_complex64 x) { return __builtin_crealf(x); }
+MAYBE_GPU static inline _imag64 chpl_cimag(_complex128 x) { return __builtin_cimag(x); }
+MAYBE_GPU static inline _imag32 chpl_cimagf(_complex64 x) { return __builtin_cimagf(x); }
+#else
+MAYBE_GPU static inline double chpl_creal(_complex128 x) { return creal(x); }
+MAYBE_GPU static inline float  chpl_crealf(_complex64 x) { return crealf(x); }
+MAYBE_GPU static inline _imag64 chpl_cimag(_complex128 x) { return cimag(x); }
+MAYBE_GPU static inline _imag32 chpl_cimagf(_complex64 x) { return cimagf(x); }
+#endif
+
 MAYBE_GPU static inline double chpl_sqrt64(double x) { return sqrt(x);  }
 MAYBE_GPU static inline float  chpl_sqrt32(float x)  { return sqrtf(x); }
 MAYBE_GPU static inline double chpl_fabs64(double x) { return fabs(x);  }


### PR DESCRIPTION
Fixes an issue in nightly where definitions for creal and cimag could not be found when the runtime is built with a C++ compiler (for gpus). This was technically an existing problem that was hidden by rewriting these functions to use builtins, but that was removed for newer LLVM versions in https://github.com/chapel-lang/chapel/pull/25019.

Tested that GPU tests work on system with GPUs and LLVM 17

[Reviewed by @vasslitvinov]