### PR TITLE
Remove explicit `SLURM_MPI_TYPE=pmi2`

### DIFF
--- a/doc/rst/platforms/aws.rst
+++ b/doc/rst/platforms/aws.rst
@@ -263,15 +263,17 @@ Once connected to the instance via ssh, do the following:
       . ~/chapel/util/setchplenv.bash
 
       export CHPL_COMM=ofi
+      export CHPL_LAUNCHER=slurm-srun
+      export CHPL_COMM_OFI_OOB=pmi2
+      export SLURM_MPI_TYPE=pmi2
+
       # if using a cluster without EFA, use FI_PROVIDER=tcp instead
       export FI_PROVIDER=efa
 
-      export CHPL_LAUNCHER=slurm-srun
       export CHPL_LIBFABRIC=system
       export PKG_CONFIG_PATH=/opt/amazon/efa/lib64/pkgconfig/
-      export CHPL_COMM_OFI_OOB=pmi2
-      PMI2_DIR=/opt/slurm/lib/
-      export CHPL_LD_FLAGS="-L$PMI2_DIR -Wl,-rpath,$PMI2_DIR"
+      export CHPL_LD_FLAGS="-L/opt/slurm/lib/ -Wl,-rpath,/opt/slurm/lib/"
+
       export CHPL_RT_COMM_OFI_DEDICATED_AMH_CORES=true
       export CHPL_RT_COMM_OFI_CONNECT_EAGERLY=true
 
@@ -283,8 +285,8 @@ Once connected to the instance via ssh, do the following:
 
       NUM_NODES=<max number of nodes in your cluster>
       NUM_PAGES=<number of pages to use>
-      srun --nodes $NUM_NODES echo always | sudo tee /sys/kernel/mm/transparent_hugepage/enabled >/dev/null
-      srun --nodes $NUM_NODES echo $NUM_PAGES | sudo tee /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages >/dev/null
+      echo always | srun --nodes $NUM_NODES sudo tee /sys/kernel/mm/transparent_hugepage/enabled >/dev/null
+      echo $NUM_PAGES | srun --nodes $NUM_NODES sudo tee /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages >/dev/null
 
    .. note::
 

--- a/doc/rst/platforms/libfabric.rst
+++ b/doc/rst/platforms/libfabric.rst
@@ -123,7 +123,7 @@ ___________________
 Libfabric defines an abstract network and operations on it, and
 so-called *providers* within libfabric define the concrete instances of
 the network and operations.  The provider used by a program is selected
-at execution time.  The ofi communication layer has been tested with 3
+at execution time.  The ofi communication layer has been tested with 4
 different providers:
 
   gni
@@ -143,6 +143,11 @@ different providers:
     functional, indeed to the extent libfabric has a reference provider
     the tcp provider is it, but its emphasis is definitely
     functionality rather than performance.
+
+  efa
+    The ``efa`` provider works on AWS EC2 instances with Elastic Fabric
+    Adapter (EFA) support. This is the default provider on AWS EC2 instances
+    with EFA support.
 
   verbs
     The ``verbs`` provider works on any system with verbs-based network

--- a/runtime/src/comm/ofi/comm-ofi-launch.c
+++ b/runtime/src/comm/ofi/comm-ofi-launch.c
@@ -59,12 +59,6 @@ void chpl_comm_preLaunch(int32_t numLocales) {
       chpl_env_set(evName, buf, 1);
     }
   }
-
-  // when using PMI and SLURM_MPI_TYPE is not set, set it to pmi2
-  // this isn't strictly required on all systems, but it is on some (AWS)
-  // and is it much easier to just set it than to figure out if its required
-  chpl_env_set("SLURM_MPI_TYPE", "pmi2", 0);
-
 #endif
 
   if (chpl_env_rt_get_bool("OVERSUBSCRIBED", false)) {


### PR DESCRIPTION
Removes always setting `SLURM_MPI_TYPE=pmi2` when `OFI_OOB=pmi2`. This was an improvement for AWS, but negatively impacted other platforms.

Also added more AWS and EFA documentation

This reverts https://github.com/chapel-lang/chapel/pull/24959.

[Reviewed by @]