### PR TITLE
Fix usage of `-Wno-nan-infinity-disabled`

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2940,8 +2940,10 @@ static void helpComputeClangArgs(std::string& clangCC,
   // of cabs but it appears to slow down simple complex multiplication.
   if (ffloatOpt > 0) { // --no-ieee-float
     clangCCArgs.push_back("-ffast-math");
-    // turn off inf warnings
+#if HAVE_LLVM_VER >= 180
+    // turn off inf warnings, added in clang 18
     clangCCArgs.push_back("-Wno-nan-infinity-disabled");
+#endif
   } else {
     if (ffloatOpt < 0) { // --ieee-float
       clangCCArgs.push_back("-fno-fast-math"); // -fno-fast-math


### PR DESCRIPTION
Removes a usage of `-Wno-nan-infinity-disabled`, which is only enabled in Clang/LLVM 18+

[Reviewed by @mppf]