### PR TITLE
Update the EX build to not pin the GCC compiler.

### DIFF
--- a/util/build_configs/cray-internal/setenv-hpe-cray-ex-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-hpe-cray-ex-x86_64.bash
@@ -307,7 +307,7 @@ else
         list_loaded_modules
     fi
 
-    gen_version_gcc=10.3.0
+    #gen_version_gcc=10.3.0
     #[TODO] gen_version_intel=16.0.3.210
     #gen_version_cce=15.0.1
 
@@ -317,28 +317,28 @@ else
 
         local target_prgenv="PrgEnv-gnu"
         local target_compiler="gcc"
-        local target_version=$gen_version_gcc
+        #local target_version=$gen_version_gcc
 
         # unload any existing PrgEnv
         unload_module_re PrgEnv-
 
         # load target PrgEnv with compiler version
         load_module $target_prgenv
-        load_module_version $target_compiler $target_version
+        #load_module_version $target_compiler $target_version
     }
 
     function load_prgenv_intel() {
 
         local target_prgenv="PrgEnv-intel"
         local target_compiler="intel"
-        local target_version=$gen_version_intel
+        #local target_version=$gen_version_intel
 
         # unload any existing PrgEnv
         unload_module_re PrgEnv-
 
         # load target PrgEnv with compiler version
         load_module $target_prgenv
-        load_module_version $target_compiler $target_version
+        #load_module_version $target_compiler $target_version
     }
 
     function load_prgenv_cray() {


### PR DESCRIPTION
When building the EX modules, the build environment utilizes a set of configuration files and scripts that define the dependencies needed for the build.  This script was overriding those settings and pinning the gcc to 10.3.0 causing build errors.   This PR will remove the hard coded pin and resolves this error: 

libstdc++.so.6: version `GLIBCXX_3.4.30' not found (required by cmake)

The script in this PR will need additional updates that are considered out of scope for this error.   That is considered to be a TODO at this time. 