### PR TITLE
Improve search behavior for specific keywords

### DIFF
--- a/doc/rst/language/spec/classes.rst
+++ b/doc/rst/language/spec/classes.rst
@@ -722,6 +722,7 @@ Methods without parentheses are not candidates for dynamic dispatch.
 .. index::
    pair: new; classes
    single: new
+   pair: keywords; new
 .. _Class_New:
 
 Class New

--- a/doc/rst/language/spec/data-parallelism.rst
+++ b/doc/rst/language/spec/data-parallelism.rst
@@ -323,10 +323,13 @@ variable, the resulting array has a 0-based one-dimensional domain.
       {0..4}
 
 .. index::
+   single: keywords; with (forall intent)
+   single: with; forall intent
    single: forall intents
    single: shadow variables
    single: data parallelism; forall intents
    single: data parallelism; shadow variables
+
 .. _Forall_Intents:
 
 Forall Intents

--- a/doc/rst/language/spec/iterators.rst
+++ b/doc/rst/language/spec/iterators.rst
@@ -72,6 +72,7 @@ declaration, with some key differences:
 
 .. index::
    single: yield
+   pair: keywords; yield
    single: iterators;yield
 .. _The_Yield_Statement:
 

--- a/doc/rst/language/spec/ranges.rst
+++ b/doc/rst/language/spec/ranges.rst
@@ -631,6 +631,8 @@ of functions that operate on ranges. They are described in
      sliced-range-expression
 
 .. index::
+   single: by
+   pair: keywords; by
    single: ranges; strided
    single: by; on ranges
    single: operators; by (range)
@@ -823,6 +825,7 @@ use the method :proc:`~ChapelRange.range.offset`.
 
 .. index::
    single: ranges; count operator
+   single: #
    single: ranges; #
    single: operators; # (range)
 .. _Count_Operator:

--- a/doc/rst/language/spec/records.rst
+++ b/doc/rst/language/spec/records.rst
@@ -23,6 +23,10 @@ contains all and only the fields defined by that type
 (:ref:`Record_Types`). Value semantics imply that the type of a
 record variable is known at compile time (i.e. it is statically typed).
 
+
+.. index::
+   pair: keywords; new
+
 A record can be created using the ``new`` operator, which allocates
 storage, initializes it via a call to a record initializer, and returns
 it. A record is also created upon a variable declaration of a record

--- a/doc/rst/language/spec/statements.rst
+++ b/doc/rst/language/spec/statements.rst
@@ -623,6 +623,8 @@ a parenthesized expression-list, the listed expressions must support
 zippered iteration.
 
 .. index::
+   single: zip
+   pair: keywords; zip
    single: zippered iteration
    single: iteration; zippered
 .. _Zippered_Iteration:

--- a/doc/rst/language/spec/task-parallelism-and-synchronization.rst
+++ b/doc/rst/language/spec/task-parallelism-and-synchronization.rst
@@ -487,6 +487,8 @@ statements may not be used to exit a coforall block.
    line until all of the tasks have completed.
 
 .. index::
+   single: keywords; with (task intent)
+   single: with; task intent
    single: task intents
    single: task parallelism; task functions
    single: task parallelism; task intents

--- a/doc/rst/technotes/local.rst
+++ b/doc/rst/technotes/local.rst
@@ -1,3 +1,7 @@
+.. index::
+    single: local
+    pair: keywords; local
+
 .. _readme-local:
 
 ===================

--- a/test/release/examples/primers/forallLoops.chpl
+++ b/test/release/examples/primers/forallLoops.chpl
@@ -29,6 +29,9 @@ As with for-loops, the body of a forall statement is a statement
 or a block statement, whereas the body of a forall expression is
 an expression. Both kinds are shown in the following sections.
 
+.. index::
+   single: forall (statement)
+
 "Must-parallel" forall statement
 --------------------------------
 
@@ -52,6 +55,9 @@ If ``A`` were a distributed array (:ref:`primers-distributions`),
 each loop iteration would typically be executed on the locale where
 the corresponding array element resides.
 
+.. index::
+   single: forall (expression)
+
 "Must-parallel" forall expression
 ---------------------------------
 
@@ -66,6 +72,10 @@ writeln(B);
 writeln();
 
 /*
+
+.. index::
+    single: forall; zip
+
 .. _primers-forallLoops-must-parallel-zippered:
 
 Zippered "must-parallel" forall statement
@@ -95,6 +105,10 @@ writeln();
 /*
 The leader iterable in this example is ``A``. Since this array is not
 distributed, all loop iterations will be executed on the current locale.
+
+.. index::
+    single: [] loop
+    single: bracket loop
 
 .. _primers-forallLoops-may-parallel:
 
@@ -128,6 +142,11 @@ if onlySerial() does not have any parallel overloads:
       forall i in onlySerial(n) { // error: a parallel iterator is not found
         writeln("in iteration #", i);
       }
+
+
+.. index::
+    single: [] loop expression
+    single: bracket loop expression
 
 "May-parallel" forall expression
 --------------------------------
@@ -226,6 +245,11 @@ writeln("outerAtomicVariable is: ", outerAtomicVariable.read());
 writeln();
 
 /*
+
+.. index::
+    single: forall; with
+.. _primers-forallLoops-with:
+
 The task intents ``in``, ``const in``, ``ref``, ``const ref``,
 and ``reduce`` can be specified explicitly using a ``with`` clause.
 
@@ -253,6 +277,11 @@ writeln("outerRealVariable is: ", outerRealVariable);
 writeln();
 
 /*
+
+.. index::
+    single: forall; reduce
+.. _primers-forallLoops-reduce:
+
 A reduce intent can be used to compute reductions.
 The value of each reduce-intent shadow variable at the end of its task
 is combined into its outer variable according to the specified reduction

--- a/test/release/examples/primers/taskParallel.chpl
+++ b/test/release/examples/primers/taskParallel.chpl
@@ -6,12 +6,17 @@
 
 config const n = 10; // Used for the coforall loop
 
-// .. _primers-taskparallel-begin:
-//
-// Begin Statements
-// ----------------
-// The ``begin`` statement spawns a thread of execution that is independent
-// of the current (main) thread of execution.
+/*
+.. index::
+    single: begin
+
+.. _primers-taskparallel-begin:
+
+Begin Statements
+----------------
+The ``begin`` statement spawns a thread of execution that is independent
+of the current (main) thread of execution.
+*/
 writeln("1: ### The begin statement ###");
 
 begin writeln("1: output from spawned task");
@@ -21,15 +26,18 @@ begin writeln("1: output from spawned task");
 writeln("1: output from main task");
 
 
+/*
+.. index::
+   single: cobegin
+.. _primers-taskparallel-cobegin:
 
-// .. _primers-taskparallel-cobegin:
-//
-// Cobegin Statements
-// ------------------
-// For more structured behavior, the ``cobegin`` statement can be used to
-// spawn a block of tasks, one for each statement.  Control continues
-// after the ``cobegin`` block, but only after all the tasks within the
-// ``cobegin`` block have completed.
+Cobegin Statements
+------------------
+For more structured behavior, the ``cobegin`` statement can be used to
+spawn a block of tasks, one for each statement.  Control continues
+after the ``cobegin`` block, but only after all the tasks within the
+``cobegin`` block have completed.
+*/
 writeln("2: ### The cobegin statement ###");
 
 cobegin {
@@ -59,16 +67,19 @@ cobegin {
 writeln("3: output from main task");
 
 
+/*
+.. index::
+   single: coforall
+.. _primers-taskparallel-coforall:
 
-// .. _primers-taskparallel-coforall:
-//
-// Coforall Loops
-// --------------
-// Another more structured form of task parallelism is the
-// ``coforall`` loop.  This loop form is like a ``for`` loop in which
-// each iteration of the loop is executed by a distinct task.  Similar
-// to the ``cobegin`` statement, the main thread of execution does not
-// continue until the tasks created for each iteration have completed.
+Coforall Loops
+--------------
+Another more structured form of task parallelism is the
+``coforall`` loop.  This loop form is like a ``for`` loop in which
+each iteration of the loop is executed by a distinct task.  Similar
+to the ``cobegin`` statement, the main thread of execution does not
+continue until the tasks created for each iteration have completed.
+*/
 writeln("4: ### The coforall loop ###");
 
 coforall i in 1..n {
@@ -97,6 +108,8 @@ coforall i in 1..n {
 writeln("5: output from main task");
 
 /*
+.. index::
+   single: with; task intent
 .. _primers-taskparallel-task-intents:
 
 Task Intents


### PR DESCRIPTION
This PR improves the documentation search results for specific searches:
 * new
 * with
 * by
 * zip
 * local

In order to do so, it adds `.. index::` entries to the forallLoops.chpl and taskParallel.chpl primers. I added index entries for other sections present there, while there. To get these `.. index::` entries to work, I needed to update `literate_chapel.py` because it was de-indenting the lines following `.. index::` which lead to invalid RST.

This PR also has a minor impact on the Chapel blog rendering (since the blog uses `chpl2rst.py` which this PR modifies to support `.. index::`). Now whitespace is more accurately respected within the .rst comments.

Reviewed by @DanilaFe - thanks!

- [x] full comm=none testing