### PR TITLE
Fix typo: 'pgicc' -> 'pgcc'

### DIFF
--- a/util/chplenv/chpl_compiler.py
+++ b/util/chplenv/chpl_compiler.py
@@ -256,7 +256,7 @@ COMPILERS = [('gnu', 'gcc', 'g++'),
              ('clang', 'clang', 'clang++'),
              ('ibm', 'xlc', 'xlC'),
              ('intel', 'icc', 'icpc'),
-             ('pgi', 'pgicc', 'pgc++')]
+             ('pgi', 'pgcc', 'pgc++')]
 
 # given a compiler command string, (e.g. "gcc" or "/path/to/clang++"),
 # figure out the compiler family (e.g. gnu or clang),


### PR DESCRIPTION
This fixes a typo in our scripts that Paul Hargrove pointed out, which also serves as an indication that we haven't done much w.r.t. testing against PGI in recent years.