### PR TITLE
update homebrew formula for main

### DIFF
--- a/util/cron/test-homebrew.bash
+++ b/util/cron/test-homebrew.bash
@@ -50,25 +50,25 @@ cd ${CHPL_HOME}/util/packaging/homebrew
 location="${CHPL_HOME}/tar/chapel-${version}.tar.gz"
 log_info $location
 
-# Replace the url and sha236 in chapel.rb with the location of the tarball and sha256 of the tarball generated.
-# create sed -i '' -e for macOS 
+# Replace the url and sha256 in chapel.rb with the location of the tarball and sha256 of the tarball generated.
+# create sed -i '' -e for macOS
 sed_command="sed -i '' -e"
-$sed_command "s#url.*#url \"file\:///$location\"#" chapel.rb 
+$sed_command "s#url.*#url \"file\:///$location\"#" chapel.rb
 sha=($(shasum -a 256 $location))
 sha256=${sha[0]}
 log_info $sha256
 $sed_command  "1s/sha256.*/sha256 \"$sha256\"/;t" -e "1,/sha256.*/s//sha256 \"$sha256\"/" chapel.rb
 
 # Test if homebrew install using the chapel formula works.
-brew upgrade 
+brew upgrade
 brew uninstall --force chapel
 # Remove the cached chapel tar file before running brew install --build-from-source chapel.rb
 rm /Users/chapelu/Library/Caches/Homebrew/downloads/*.tar.gz
-brew install --build-from-source chapel.rb
+HOMEBREW_NO_INSTALL_FROM_API=1 brew install -v --build-from-source chapel.rb
 INSTALL_STATUS=$?
     if [ $INSTALL_STATUS -ne 0 ]
     then
-      log_error "brew install --build-from-source chapel.rb failed" 
+      log_error "brew install --build-from-source chapel.rb failed"
       exit 1
       else
       log_info "brew install --build-from-source chapel.rb succeeded"
@@ -77,7 +77,7 @@ chpl --version
 CHPL_INSTALL=$?
     if [ $CHPL_INSTALL -ne 0 ]
     then
-      log_error "chpl --version failed" 
+      log_error "chpl --version failed"
       exit 1
     else
       log_info "chpl --version succeeded"
@@ -86,21 +86,21 @@ CHPL_INSTALL=$?
 # Run pidigits and see if it works
 cd ${CHPL_HOME}/examples/benchmarks/shootout
 chpl pidigits.chpl
-   if [ $? -ne 0 ] 
+   if [ $? -ne 0 ]
    then
-     log_error "chpl pidigits.chpl failed to compile" 
+     log_error "chpl pidigits.chpl failed to compile"
      exit 1
    else
-     log_info "Compiled pidigits.chpl"  
-   fi   
+     log_info "Compiled pidigits.chpl"
+   fi
 ./pidigits
-  if [ $? -ne 0 ] 
+  if [ $? -ne 0 ]
    then
-     log_error "./pidigits failed" 
+     log_error "./pidigits failed"
      exit 1
    else
-     log_info "./pidigits succeeded"  
-   fi 
+     log_info "./pidigits succeeded"
+   fi
 
 #To mimic home-bre CI. Run home-brew chpl install inside a container.
 # check if docker desktop is installed in mac if not fail the test.
@@ -110,8 +110,8 @@ start_docker
 # This will test homebrew installation inside ubuntu VM using the lastest chapel.rb using the tarball built
 cd ${CHPL_HOME}/util/packaging/homebrew
 
-# Replace the tarball location in the container where the tarball is copied over 
-$sed_command "s#url.*#url \"file\:////home/linuxbrew/chapel-${version}.tar.gz\"#" chapel.rb 
+# Replace the tarball location in the container where the tarball is copied over
+$sed_command "s#url.*#url \"file\:////home/linuxbrew/chapel-${version}.tar.gz\"#" chapel.rb
 
 cp ${CHPL_HOME}/util/packaging/homebrew/chapel.rb  ${CHPL_HOME}/util/packaging/docker/test
 cp $location ${CHPL_HOME}/util/packaging/docker/test

--- a/util/cron/test-homebrew.bash
+++ b/util/cron/test-homebrew.bash
@@ -63,7 +63,7 @@ $sed_command  "1s/sha256.*/sha256 \"$sha256\"/;t" -e "1,/sha256.*/s//sha256 \"$s
 brew upgrade
 brew uninstall --force chapel
 # Remove the cached chapel tar file before running brew install --build-from-source chapel.rb
-rm /Users/chapelu/Library/Caches/Homebrew/downloads/*.tar.gz
+rm $HOME/Library/Caches/Homebrew/downloads/*--chapel-${version}.tar.gz
 HOMEBREW_NO_INSTALL_FROM_API=1 brew install -v --build-from-source chapel.rb
 INSTALL_STATUS=$?
     if [ $INSTALL_STATUS -ne 0 ]
@@ -102,7 +102,7 @@ chpl pidigits.chpl
      log_info "./pidigits succeeded"
    fi
 
-#To mimic home-bre CI. Run home-brew chpl install inside a container.
+#To mimic home-brew CI. Run home-brew chpl install inside a container.
 # check if docker desktop is installed in mac if not fail the test.
 source ${CHPL_HOME}/util/cron/docker.bash
 start_docker
@@ -116,7 +116,7 @@ $sed_command "s#url.*#url \"file\:////home/linuxbrew/chapel-${version}.tar.gz\"#
 cp ${CHPL_HOME}/util/packaging/homebrew/chapel.rb  ${CHPL_HOME}/util/packaging/docker/test
 cp $location ${CHPL_HOME}/util/packaging/docker/test
 
-#This will start a docker container that is similar to the one used by homebrew-ci snd tests homebrew installation inside it.
+#This will start a docker container that is similar to the one used by homebrew-ci and test the homebrew installation inside it.
 source ${CHPL_HOME}/util/packaging/docker/test/homebrew_ci.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="homebrew"

--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -39,6 +39,9 @@ class Chapel < Formula
     # Chapel uses this ENV to work out where to install.
     ENV["CHPL_HOME"] = libexec
     ENV["CHPL_GMP"] = "system"
+    # This ENV avoids a problem where cmake cache is invalidated by subsequent make calls
+    ENV["CHPL_CMAKE_USE_CC_CXX"] = "1"
+
     # don't try to set CHPL_LLVM_GCC_PREFIX since the llvm
     # package should be configured to use a reasonable GCC
     (libexec/"chplconfig").write <<~EOS
@@ -58,19 +61,10 @@ class Chapel < Formula
         system "make"
       end
       with_env(CHPL_LLVM: "system") do
-        cd "compiler" do
-          system "make", "clean-cmakecache"
-        end
         system "make"
       end
       with_env(CHPL_PIP_FROM_SOURCE: "1") do
-        cd "compiler" do
-          system "make", "clean-cmakecache"
-        end
         system "make", "chpldoc"
-        cd "compiler" do
-          system "make", "clean-cmakecache"
-        end
         system "make", "chplcheck"
         system "make", "chpl-language-server"
       end

--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -68,6 +68,9 @@ class Chapel < Formula
           system "make", "clean-cmakecache"
         end
         system "make", "chpldoc"
+        cd "compiler" do
+          system "make", "clean-cmakecache"
+        end
         system "make", "chplcheck"
         system "make", "chpl-language-server"
       end
@@ -112,5 +115,10 @@ class Chapel < Formula
     system bin/"chpl", "--print-passes", "--print-commands", libexec/"examples/hello.chpl"
     system bin/"chpldoc", "--version"
     system bin/"mason", "--version"
+
+    # Test chplcheck, if it works CLS probably does too.
+    # chpl-language-server will hang indefinitely waiting for a LSP client
+    system bin/"chplcheck", "--list-rules"
+    system bin/"chplcheck", libexec/"examples/hello.chpl"
   end
 end

--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -68,12 +68,10 @@ class Chapel < Formula
           system "make", "clean-cmakecache"
         end
         system "make", "chpldoc"
-      end
-      system "make", "mason"
-      with_env(CHPL_PIP_FROM_SOURCE: "1") do
         system "make", "chplcheck"
         system "make", "chpl-language-server"
       end
+      system "make", "mason"
       system "make", "cleanall"
 
       rm_rf("third-party/llvm/llvm-src/")


### PR DESCRIPTION
Makes small updates to homebrew formula that we keep up to date so that it can build the latest main. Fixes a problem in homebrew builds where we were having to reset the cmake cache between calls to make, or we'd see an error during the build about how the cmake variables for `CMAKE_C_COMPILER` and `CMAKE_CXX_COMPILER` were being reset. In this and other packages, we just want to use the CC and CXX values that the packager is providing, so by setting `CHPL_CMAKE_USE_CC_CXX` we avoid problems.

Previously, the `brew install` was failing and moving the new builds of the `chapel-language-server` and `chplcheck` in with `chpldoc` fixes it. While here, remove code that was temporarily introduced to work around bugs with python 3.12 and also code to add a `clean-cmakecache` target on the fly, since it is no longer needed.

TESTING:

- [x] can run `util/cron/test-homebrew.bash`
- [x] manually updating chapel formula with `brew edit chapel` installs all built targets (e.g., `chpl`, `chpldoc`, `chplcheck`, etc.)

[reviewed by @jabraham17 - thanks!]