### PR TITLE
Update C++ standard specified for protobuf build

### DIFF
--- a/tools/protoc-gen-chpl/Makefile
+++ b/tools/protoc-gen-chpl/Makefile
@@ -32,7 +32,7 @@ linkFile=$(bdir)/protoc-gen-chpl
 SOURCES=$(wildcard *.cpp)
 HEADERS=$(wildcard *.h)
 LDFLAGS = $(shell pkg-config --libs protobuf 2>/dev/null) -lprotobuf -lprotoc
-CPPFLAGS = $(shell pkg-config --cflags protobuf 2>/dev/null) -I.
+CPPFLAGS = $(shell pkg-config --cflags protobuf 2>/dev/null) -I. -std=c++17
 
 ifeq ($(CHPL_MAKE_PLATFORM),darwin)
 	PROTOC_LIB_LOC=$(dir $(shell which protoc))../lib

--- a/tools/protoc-gen-chpl/Makefile
+++ b/tools/protoc-gen-chpl/Makefile
@@ -32,7 +32,7 @@ linkFile=$(bdir)/protoc-gen-chpl
 SOURCES=$(wildcard *.cpp)
 HEADERS=$(wildcard *.h)
 LDFLAGS = $(shell pkg-config --libs protobuf 2>/dev/null) -lprotobuf -lprotoc
-CPPFLAGS = $(shell pkg-config --cflags protobuf 2>/dev/null) -I. -std=c++11
+CPPFLAGS = $(shell pkg-config --cflags protobuf 2>/dev/null) -I.
 
 ifeq ($(CHPL_MAKE_PLATFORM),darwin)
 	PROTOC_LIB_LOC=$(dir $(shell which protoc))../lib


### PR DESCRIPTION
Recent versions of protobuf [depend on abseil-cpp](https://protobuf.dev/news/2022-08-03/#abseil-dep), and abseil requires at least C++14. However, we specify the use of C++11 in the compile flags for our `protoc-gen-chpl` target. Update it to C++17 since that's what Chapel in general requires.

[`d1a649a` (#16817)](https://github.com/chapel-lang/chapel/pull/16817/commits/d1a649afd0308f55dba09bf71841a176ec62a63b) asserts the `-std` argument is required for building on Mac, which holds up on my Mac with Clang 15; however, it works with `-std=c++17` instead of 11.

[reviewer info placeholder]

Testing:
- [x] `make protoc-gen-chpl` succeeds with a protobuf requiring abseil, on Mac and Linux
  - not on the latest protobuf however, due to https://github.com/Cray/chapel-private/issues/6313, but that's a separate issue