### PR TITLE
Add default case to switch to fix build error

### DIFF
--- a/tools/chapel-py/src/core-types-gen.cpp
+++ b/tools/chapel-py/src/core-types-gen.cpp
@@ -55,6 +55,7 @@ static const char* blockStyleToString(BlockStyle blockStyle) {
     case BlockStyle::EXPLICIT: return "explicit";
     case BlockStyle::IMPLICIT: return "implicit";
     case BlockStyle::UNNECESSARY_KEYWORD_AND_BLOCK: return "unnecessary";
+    default: return "";
   }
 }
 


### PR DESCRIPTION
Add a default case return to fix a build error in Chapel-Py.
@jabraham17 

Solves #25054 