### PR TITLE
Always use `python3` in bash env shebang

### DIFF
--- a/util/config/compileline.py
+++ b/util/config/compileline.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import optparse
 import os


### PR DESCRIPTION
Removes `#!usr/bin/env python` from `compileline.py`, as this causes issues when building RPMs.

Now that we no longer support python2, it can just always be `#!usr/bin/env python3`

[Reviewed by @mppf and @riftEmber]