### PR TITLE
Add scripts to test Chapel apt/rpm packages

### DIFF
--- a/util/packaging/apt/test/.gitignore
+++ b/util/packaging/apt/test/.gitignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/util/packaging/apt/test/Dockerfile.template
+++ b/util/packaging/apt/test/Dockerfile.template
@@ -23,3 +23,4 @@ WORKDIR /home/user/MyPackage
 RUN chplcheck src/*.chpl
 RUN mason build
 RUN mason run
+WORKDIR /home/user

--- a/util/packaging/apt/test/Dockerfile.template
+++ b/util/packaging/apt/test/Dockerfile.template
@@ -1,0 +1,25 @@
+FROM @@{OS_BASE_IMAGE}
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y vim sudo
+
+RUN useradd -ms /bin/bash user && \
+    usermod -aG sudo user && \
+    echo "user:password" | chpasswd
+
+USER user
+WORKDIR /home/user
+
+COPY --chown=user @@{HOST_PACKAGE_PATH}/@@{PACKAGE_NAME} /home/user/@@{PACKAGE_NAME}
+
+USER root
+RUN apt-get install -y ./@@{PACKAGE_NAME}
+USER user
+WORKDIR /home/user
+
+RUN mason new MyPackage
+WORKDIR /home/user/MyPackage
+RUN chplcheck src/*.chpl
+RUN mason build
+RUN mason run

--- a/util/packaging/common/README.md
+++ b/util/packaging/common/README.md
@@ -1,0 +1,3 @@
+# Packaging Common
+
+This directory contains common scripts and utilities for packaging

--- a/util/packaging/common/test_package.py
+++ b/util/packaging/common/test_package.py
@@ -61,6 +61,7 @@ def docker_build_image(
     test_dir, package, docker_os, imagetag="chapel-test-image"
 ):
     context = os.path.join(test_dir, "..")
+    context = os.path.abspath(context)
     dockerfile = os.path.join(test_dir, "Dockerfile")
 
     # check that the package is in the context directory
@@ -119,8 +120,17 @@ def main():
     global verbose
     verbose = args.verbose
 
+    chpl_home = os.environ.get("CHPL_HOME", "")
     package = os.path.abspath(os.path.expanduser(args.package))
-    test_dir = os.path.join(os.path.dirname(package), "..", "test")
+    test_dir = os.path.join(chpl_home, "util", "packaging")
+    if package.endswith(".deb"):
+        test_dir = os.path.join(test_dir, "apt")
+    elif package.endswith(".rpm"):
+        test_dir = os.path.join(test_dir, "rpm")
+    else:
+        print(f"Package {package} is not a .deb or .rpm file")
+        sys.exit(1)
+    test_dir = os.path.join(test_dir, "test")
     test_dir = os.path.abspath(test_dir)
     docker_os = args.dockeros
 

--- a/util/packaging/rpm/test/.gitignore
+++ b/util/packaging/rpm/test/.gitignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/util/packaging/rpm/test/Dockerfile.template
+++ b/util/packaging/rpm/test/Dockerfile.template
@@ -17,8 +17,8 @@ RUN dnf install -y ./@@{PACKAGE_NAME}
 USER user
 WORKDIR /home/user
 
-RUN mkdir MyPackage
+RUN mason new MyPackage
 WORKDIR /home/user/MyPackage
-RUN mason init
 RUN chplcheck src/*.chpl
 RUN mason build
+RUN mason run

--- a/util/packaging/rpm/test/Dockerfile.template
+++ b/util/packaging/rpm/test/Dockerfile.template
@@ -1,0 +1,24 @@
+FROM @@{OS_BASE_IMAGE}
+
+RUN dnf upgrade -y && dnf install -y sudo vim which
+
+RUN useradd -ms /bin/bash user && \
+    usermod -aG wheel user && \
+    echo "user:password" | chpasswd && \
+    sed -i 's/%wheel[ \t]\{1,\}ALL=(ALL)[ \t]\{1,\}ALL/%wheel ALL=(ALL) NOPASSWD: ALL/g' /etc/sudoers
+
+USER user
+WORKDIR /home/user
+
+COPY --chown=user @@{HOST_PACKAGE_PATH}/@@{PACKAGE_NAME} /home/user/@@{PACKAGE_NAME}
+
+USER root
+RUN dnf install -y ./@@{PACKAGE_NAME}
+USER user
+WORKDIR /home/user
+
+RUN mkdir MyPackage
+WORKDIR /home/user/MyPackage
+RUN mason init
+RUN chplcheck src/*.chpl
+RUN mason build

--- a/util/packaging/rpm/test/Dockerfile.template
+++ b/util/packaging/rpm/test/Dockerfile.template
@@ -22,3 +22,4 @@ WORKDIR /home/user/MyPackage
 RUN chplcheck src/*.chpl
 RUN mason build
 RUN mason run
+WORKDIR /home/user

--- a/util/packaging/rpm/test/test_package.py
+++ b/util/packaging/rpm/test/test_package.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""
+Run tests on build packages
+"""
+import sys
+import argparse
+import os
+import subprocess as sp
+from string import Template
+
+
+class MyTemplate(Template):
+    delimiter = "@@"
+
+global verbose
+verbose = False
+
+def run_command(cmd, **kwargs):
+    if verbose:
+        print(f"Running command: \"{' '.join(cmd)}\"")
+    return sp.check_call(cmd, **kwargs)
+
+
+def build_docker(package_path, package_name, docker_os):
+    template = ""
+    template_file = os.path.join(os.path.dirname(__file__), "Dockerfile.template")
+    with open(template_file, "r") as f:
+        template = f.read()
+
+    substitutions = {
+        "OS_BASE_IMAGE": docker_os,
+        "HOST_PACKAGE_PATH": package_path,
+        "PACKAGE_NAME": package_name,
+    }
+
+    src = MyTemplate(template)
+    result = src.substitute(substitutions)
+
+    output_file = os.path.join(os.path.dirname(__file__), "Dockerfile")
+    with open(output_file, "w") as f:
+        f.write(result)
+
+
+def determine_arch(package):
+    # if the arch is aarch64 or arm64, return arm64
+    # if the arch is x86_64 or amd64, return amd64
+    # otherwise return the components just before the suffix
+
+    arch = os.path.basename(package).split(".")[-2]
+    if arch in ["aarch64", "arm64"]:
+        return "arm64"
+    elif arch in ["x86_64", "amd64"]:
+        return "amd64"
+    else:
+        return arch
+
+def docker_build_image(package, docker_os, imagetag="chapel-test-image"):
+    test_dir = os.path.dirname(__file__)
+    context = os.path.join(test_dir, "..")
+    dockerfile = os.path.join(test_dir, "Dockerfile")
+
+    # check that the package is in the context directory
+    rel = os.path.relpath(package, context)
+    if rel.startswith(".."):
+        print(f"Package {package} is not in the context directory {context}")
+        sys.exit(1)
+
+    build_docker(os.path.dirname(rel), os.path.basename(rel), docker_os)
+
+    platform = f"linux/{determine_arch(package)}"
+
+    cmd = ["docker", "buildx", "build", "--platform", platform, "-t", imagetag, "-f", dockerfile, context]
+    run_command(cmd)
+
+    return imagetag
+
+def docker_run_container(imagetag):
+    cmd = ["docker", "run", "--rm", "-it", imagetag]
+    run_command(cmd)
+
+def cleanup(imagetag):
+    cmd = ["docker", "image", "rm", imagetag]
+    run_command(cmd)
+    os.remove(os.path.join(os.path.dirname(__file__), "Dockerfile"))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run tests on build packages")
+    parser.add_argument(
+        "package",
+        type=str,
+        help="The package to test"
+    )
+    parser.add_argument(
+        "dockeros",
+        type=str,
+        help="The docker image to use"
+    )
+    parser.add_argument(
+        "--run",
+        action="store_true",
+        help="Run the container after building the image")
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print verbose output")
+    args = parser.parse_args()
+    global verbose
+    verbose = args.verbose
+
+
+    package = os.path.abspath(os.path.expanduser(args.package))
+    docker_os = args.dockeros
+
+    imagetag = docker_build_image(package, docker_os)
+    if args.run:
+        docker_run_container(imagetag)
+    cleanup(imagetag)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a few scripts and Docker templates to test chapel packages built for various OSes in apt/rpm formats

Followup to https://github.com/chapel-lang/chapel/pull/25051

[Reviewed by @arezaii]