### PR TITLE
Add future for bug when applying `forwarding` to badly formatted variable declaration

### DIFF
--- a/test/classes/forwarding/forwardToNonVar.bad
+++ b/test/classes/forwarding/forwardToNonVar.bad
@@ -1,0 +1,6 @@
+internal error: UTI-MIS-1041 chpl version 2.1.0 pre-release (c783ceba8b)
+
+Internal errors indicate a bug in the Chapel compiler,
+and we're sorry for the hassle.  We would appreciate your reporting this bug --
+please see https://chapel-lang.org/bugs.html for instructions.
+

--- a/test/classes/forwarding/forwardToNonVar.chpl
+++ b/test/classes/forwarding/forwardToNonVar.chpl
@@ -1,0 +1,8 @@
+use Map;
+
+class C {
+  forwarding var map(int, real);
+}
+
+var myC = new C();
+myC.add(1, 2.3);

--- a/test/classes/forwarding/forwardToNonVar.future
+++ b/test/classes/forwarding/forwardToNonVar.future
@@ -1,0 +1,3 @@
+bug: forwarding to a badly-formed variable declaration causes internal error
+
+#25067


### PR DESCRIPTION
Adding a future for #25067