### PR TITLE
--explain-call to report multiple best candidates

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4115,6 +4115,21 @@ static void reportHijackingError(CallExpr* call,
   USR_STOP();
 }
 
+static void explainOne(ResolutionCandidate* best, ResolutionCandidate* cur,
+                       const char* kind) {
+  if (cur != nullptr && cur != best)
+      USR_PRINT(cur->fn,   "%10s overload: %s", kind, toString(cur->fn));
+}
+static void explainCallCandidates(ResolutionCandidate* best,
+                                  ResolutionCandidate* bestRef,
+                                  ResolutionCandidate* bestValue,
+                                  ResolutionCandidate* bestConstRef) {
+    USR_PRINT(best->fn, "best candidates are: %s", toString(best->fn));
+    explainOne(best, bestRef,      "ref");
+    explainOne(best, bestValue,    "value");
+    explainOne(best, bestConstRef, "const ref");
+}
+
 static bool overloadSetsOK(CallExpr* call,
                            BlockStmt* searchScope,
                            check_state_t checkState,
@@ -4396,7 +4411,7 @@ static FnSymbol* resolveNormalCall(CallInfo&            info,
   }
 
   if (explainCallLine != 0 && explainCallMatch(call) == true) {
-    USR_PRINT(best->fn, "best candidate is: %s", toString(best->fn));
+    explainCallCandidates(best, bestRef, bestValue, bestConstRef);
   }
 
   if (call->partialTag                  == true &&

--- a/test/functions/ferguson/ref-pair/explain-call.chpl
+++ b/test/functions/ferguson/ref-pair/explain-call.chpl
@@ -1,0 +1,15 @@
+
+var global1 = 1;
+
+proc test(x:int) ref       { writeln("ref1"); return global1; }
+proc test(x:int)           { writeln("val1"); return 123; }
+proc test(x:int) const ref { writeln("cr1");  return global1; }
+
+proc test() ref       { writeln("ref2"); return global1; }
+proc test() const ref { writeln("cr2");  return global1; }
+
+var x1 = test(5);       // 3 "best candidates"
+writeln(x1);
+
+const ref x2 = test();  // 2 "best candidates"
+writeln(x2);

--- a/test/functions/ferguson/ref-pair/explain-call.compopts
+++ b/test/functions/ferguson/ref-pair/explain-call.compopts
@@ -1,0 +1,1 @@
+--explain-call test

--- a/test/functions/ferguson/ref-pair/explain-call.good
+++ b/test/functions/ferguson/ref-pair/explain-call.good
@@ -1,0 +1,26 @@
+explain-call.chpl:11: note: call: test(5)
+explain-call.chpl:4: note: visible functions are: test(x: int)
+explain-call.chpl:5: note:                        test(x: int)
+explain-call.chpl:6: note:                        test(x: int)
+explain-call.chpl:8: note:                        test()
+explain-call.chpl:9: note:                        test()
+explain-call.chpl:4: note: candidates are: test(x: int)
+explain-call.chpl:5: note:                 test(x: int)
+explain-call.chpl:6: note:                 test(x: int)
+explain-call.chpl:4: note: best candidates are: test(x: int)
+explain-call.chpl:5: note:      value overload: test(x: int)
+explain-call.chpl:6: note:  const ref overload: test(x: int)
+explain-call.chpl:14: note: call: test()
+explain-call.chpl:4: note: visible functions are: test(x: int)
+explain-call.chpl:5: note:                        test(x: int)
+explain-call.chpl:6: note:                        test(x: int)
+explain-call.chpl:8: note:                        test()
+explain-call.chpl:9: note:                        test()
+explain-call.chpl:8: note: candidates are: test()
+explain-call.chpl:9: note:                 test()
+explain-call.chpl:8: note: best candidates are: test()
+explain-call.chpl:9: note:  const ref overload: test()
+val1
+123
+cr2
+1


### PR DESCRIPTION
This PR makes `--explain-call` option show all "best" candidates being considered in the case of return intent overloads. This may be useful when the user is expecting one overload to be invoked and does not realize that another overload is also being considered because of return intent overload.

Testing: standard and gasnet paratests.