### PR TITLE
Remove spack dep loading on horizon

### DIFF
--- a/util/cron/load-base-deps.bash
+++ b/util/cron/load-base-deps.bash
@@ -7,9 +7,7 @@ if [[ "${HOSTNAME:0:6}" == "chapcs" || "${HOSTNAME:0:6}" == "chapvm" ]]; then
   if [ -f /data/cf/chapel/chpl-deps/chapcs11/load_chpl_deps.bash ] ; then
     source /data/cf/chapel/chpl-deps/chapcs11/load_chpl_deps.bash
   fi
-elif [[ "$(hostname -s)" == "osprey" || "$(hostname -s)" == "atlas" ||
-        "$(hostname -s)" == "horizon" || "$(hostname -s)" == "horizon-elogin" ||
-        "$(hostname -s)" == "horizon-aarch" ]]; then
+elif [[ "$(hostname -s)" == "osprey" || "$(hostname -s)" == "atlas" ]]; then
   if [ -f /lus/scratch/chapelu/chpl-deps/$(hostname -s)/load_chpl_deps.bash ] ; then
     source /lus/scratch/chapelu/chpl-deps/$(hostname -s)/load_chpl_deps.bash
   fi


### PR DESCRIPTION
We don't want to load deps from Spack on Horizon as that's where we do module builds.

I thought that https://github.hpe.com/hpe/hpc-chapel-ci-config/commit/9db0ae56a63de443f6c58658e7817808d6564e25 made it so no Horizon tests used Spack deps anymore, but some apparently do, such as https://chapel-ci.us.cray.com/job/cray-xc-correctness-test-cray-xc-arkouda.release/200/consoleFull. This PR removes the code responsible.