### PR TITLE
Switch LLVM setup script used in Valgrind test configs

### DIFF
--- a/util/cron/test-valgrind.bash
+++ b/util/cron/test-valgrind.bash
@@ -8,7 +8,7 @@ source $CWD/common-valgrind.bash
 source $CWD/common-localnode-paratest.bash
 
 # Use LLVM-13 to work around https://github.com/Cray/chapel-private/issues/3373
-source /cray/css/users/chapelu/setup_system_llvm.bash 13
+source /data/cf/chapel/setup_system_llvm.bash 13
 
 # valgrind serializes execution, so don't limit to one executable at a time
 unset CHPL_TEST_LIMIT_RUNNING_EXECUTABLES

--- a/util/cron/test-valgrindexe.bash
+++ b/util/cron/test-valgrindexe.bash
@@ -8,7 +8,7 @@ source $CWD/common-valgrind.bash
 source $CWD/common-localnode-paratest.bash
 
 # Use LLVM-13 to work around https://github.com/Cray/chapel-private/issues/3373
-source /cray/css/users/chapelu/setup_system_llvm.bash 13
+source /data/cf/chapel/setup_system_llvm.bash 13
 
 # valgrind serializes execution, so don't limit to one executable at a time
 unset CHPL_TEST_LIMIT_RUNNING_EXECUTABLES


### PR DESCRIPTION
Switch the LLVM dependency setup script used in Valgrind nightly test configs.

We use LLVM 13 for our Valgrind testing due to https://github.com/Cray/chapel-private/issues/3373. These tests run on chapcs/chapvm systems which I recently switched to use a new Spack install, and as part of this I switched all LLVM dependencies to come from a Spack install. I adjusted the script `/data/cf/chapel/setup_system_llvm.bash` to load LLVMs from `/data/cf/chapel/chpl-deps/spack/`. However, the Valgrind test scripts apparently use a copy of this script at `/cray/css/users/chapelu/setup_system_llvm.bash`, which loads from manual LLVM installs and does not have a corresponding Spack install to use AFAIK.

Since I think this is the only remaining case in which we need to load an old LLVM, and we have a working way to do that, just go for the easy solution of sourcing the updated `/data/cf/chapel/setup_system_llvm.bash` script instead.