### PR TITLE
Fix mason CI check that was failing for packages with sub-modules

### DIFF
--- a/doc/rst/tools/mason/guide/buildinglargerpackages.rst
+++ b/doc/rst/tools/mason/guide/buildinglargerpackages.rst
@@ -6,14 +6,40 @@ Building Larger Packages
 For packages that span multiple files, the main module is designated by the module that
 shares the name with the package directory and the name field in the ``Mason.toml`` file.
 
-While not recommended with mason libraries that are going to be added to the mason registry,
-passing a ``-- -M`` as outlined below can make building your mason application easier, but,
-for mason libraries, submodules should be used to avoid conflicting namespaces for users
-of your library (see :ref:`readme-module_include`).
+If a ``main`` procedure is used as the program's entry point, it should be located in the
+main module. If no main procedure is present in the main module, program execution will
+begin at the first line of the main module.
 
-For packages that span multiple sub-directories within ``src``, sub-directories must be passed
-to mason with the ``-- -M  <src/subdirectory>`` flag. Note the ``--`` which tells mason to
-forward all remaining flags directly to the chapel compiler. For example, lets say
+While not recommended with mason libraries that are going to be added to the mason registry,
+passing an ``-- -M`` compilation argument, as outlined below, can make building your mason
+application easier.
+
+Alternatively, for mason libraries, submodules should be used to avoid conflicting namespaces
+for users of your library. A submodule can be included in a mason project by adding a directory
+with the same name as the parent module, and placing source files for submodules in that
+directory. For example, in the directory structure below, the submodule ``subMod`` can be
+included in the main module ``myPackage`` by using ``include module SubMod;`` in the main
+module's source file (see :ref:`readme-module_include` for more)::
+
+  MyPackage/
+   │
+   ├── Mason.lock
+   ├── Mason.toml
+   ├── example/
+   ├── src/
+   │   ├── myPackage.chpl
+   │   └── myPackage/
+   │       └── SubMod.chpl
+   ├── target/
+   │   ├── debug/
+   │   │   └── myPackage
+   │   ├── example/
+   │   └── test/
+   └── test/
+
+To use modules located in sub-directories (without using submodules), all sub-directory paths
+must be passed to mason with the ``-- -M <src/subdirectory>`` flag. Note the ``--`` which tells
+mason to forward all remaining flags directly to the Chapel Compiler. For example, lets say
 MyPackage's structure is as follows::
 
   MyPackage/
@@ -32,10 +58,6 @@ MyPackage's structure is as follows::
    │   └── test/
    └── test/
 
-
-If MyPackage needs multiple files in different directories like the example above,
-then call ``mason build`` with the ``-- -M`` flag followed by the local dependencies.
-A full command of this example would be::
+The following command would be used to build MyPackage with the myPackageUtils module::
 
   mason build -- -M src/util/MyPackageUtils.chpl
-

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -504,10 +504,10 @@ proc check(username : string, path : string, trueIfLocal : bool, ci : bool) thro
   if package {
     writeln('Main Module Check:');
     if moduleCheck(projectCheckHome) {
-      writeln('   Your package has a main module whose name matches the package name. (PASSED)');
+      writeln('   Your package has one main module whose name matches the package name. (PASSED)');
     }
     else {
-      writeln('   Packages must have a main module whose name matches the package name. (FAILED)');
+      writeln('   Packages must have a single main module whose name matches the package name. (FAILED)');
       moduleTest = false;
     }
     writeln(spacer);
@@ -781,11 +781,10 @@ private proc ensureMasonProject(cwd : string, tomlName="Mason.toml") : string {
 
  */
 private proc moduleCheck(projectHome : string) throws {
-  const mainModuleName = getPackageName() + '.chpl';
-  for fileName in listDir(projectHome + '/src', dirs=false) {
-    if fileName == mainModuleName then return true;
-  }
-  return false;
+  const modules = listDir(projectHome + '/src', dirs=false);
+  if modules.size != 1 then return false;
+  if modules[0] != getPackageName() + '.chpl' then return false;
+  return true;
 }
 
 /* Checks package for examples */

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -504,10 +504,10 @@ proc check(username : string, path : string, trueIfLocal : bool, ci : bool) thro
   if package {
     writeln('Main Module Check:');
     if moduleCheck(projectCheckHome) {
-      writeln('   Your package has only one main module, can be published to a registry. (PASSED)');
+      writeln('   Your package has a main module whose name matches the package name. (PASSED)');
     }
     else {
-      writeln('   Packages with more than one modules cannot be published. (FAILED)');
+      writeln('   Packages must have a main module whose name matches the package name. (FAILED)');
       moduleTest = false;
     }
     writeln(spacer);
@@ -766,12 +766,26 @@ private proc ensureMasonProject(cwd : string, tomlName="Mason.toml") : string {
   return ensureMasonProject(dirname, tomlName);
 }
 
-/* Checks to make sure the package only has one main module
+/*Checks to make sure the package has a main module
+
+  The source file for the main module should have the same name as the package.
+  For example, `foo.chpl` is a valid main module for the following package:
+
+    foo/
+      Mason.toml
+      src/
+        foo.chpl  # module foo { include module bar; use bar; proc main() { ... } }
+        foo/
+          bar.chpl
+      ...
+
  */
 private proc moduleCheck(projectHome : string) throws {
-  const subModules = listDir(projectHome + '/src');
-  if subModules.size > 1 then return false;
-  else return true;
+  const mainModuleName = getPackageName() + '.chpl';
+  for fileName in listDir(projectHome + '/src', dirs=false) {
+    if fileName == mainModuleName then return true;
+  }
+  return false;
 }
 
 /* Checks package for examples */


### PR DESCRIPTION
Fix the bug in Mason's main-module check, outlined in [this issue](https://github.com/chapel-lang/chapel/issues/25064), that prevents packages that use sub-modules from being accepted in the mason registry.