### PR TITLE
Suppress readHDF5Df.chpl test always

### DIFF
--- a/test/library/draft/DataFrames/diten/readHDF5Df.suppressif
+++ b/test/library/draft/DataFrames/diten/readHDF5Df.suppressif
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+
+# This test wasn't run for a while and fell behind language changes, so it's
+# failing. See https://github.com/Cray/chapel-private/issues/6322 for
+# discussion.
+
+print(True)


### PR DESCRIPTION
Suppress this newly-running failing test pending further discussion, to end a few days of noise in multiple configs.

See https://github.com/Cray/chapel-private/issues/6322 for explanation and discussion.

[reviewer info placeholder]