### PR TITLE
dyno: changes to improve `--dyno-scope-bundled` performance

### DIFF
--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -169,6 +169,7 @@ extern bool fDriverCompilationPhase;
 extern bool fDriverMakeBinaryPhase;
 extern char driverTmpDir[FILENAME_MAX];
 // end compiler driver control flags
+extern bool fExitLeaks;
 extern bool fPrintAllCandidates;
 extern bool fPrintCallGraph;
 extern bool fPrintCallStackOnError;

--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -323,6 +323,7 @@ extern bool fDynoScopeResolve;
 extern bool fDynoScopeProduction;
 extern bool fDynoScopeBundled;
 extern bool fDynoDebugTrace;
+extern bool fDynoDebugPrintParsedFiles;
 extern bool fDynoVerifySerialization;
 extern bool fDynoGenLib;
 extern bool fDynoGenStdLib;

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -376,6 +376,7 @@ bool fDynoScopeResolve = true;
 bool fDynoScopeProduction = true;
 bool fDynoScopeBundled = false;
 bool fDynoDebugTrace = false;
+bool fDynoDebugPrintParsedFiles = false;
 bool fDynoVerifySerialization = false;
 bool fDynoGenLib = false;
 bool fDynoGenStdLib = false;
@@ -1510,6 +1511,7 @@ static ArgumentDescription arg_desc[] = {
  {"dyno-scope-production", ' ', NULL, "Enable [disable] using both dyno and production scope resolution", "N", &fDynoScopeProduction, "CHPL_DYNO_SCOPE_PRODUCTION", NULL},
  {"dyno-scope-bundled", ' ', NULL, "Enable [disable] using dyno to scope resolve bundled modules", "N", &fDynoScopeBundled, "CHPL_DYNO_SCOPE_BUNDLED", NULL},
  {"dyno-debug-trace", ' ', NULL, "Enable [disable] debug-trace output when using dyno compiler library", "N", &fDynoDebugTrace, "CHPL_DYNO_DEBUG_TRACE", NULL},
+ {"dyno-debug-print-parsed-files", ' ', NULL, "Enable [disable] printing all files that were parsed by Dyno", "N", &fDynoDebugPrintParsedFiles, "CHPL_DYNO_DEBUG_PRINT_PARSED_FILES", NULL},
  {"dyno-break-on-hash", ' ' , NULL, "Break when query with given hash value is executed when using dyno compiler library", "X", &fDynoBreakOnHash, "CHPL_DYNO_BREAK_ON_HASH", NULL},
  {"dyno-gen-lib", ' ', "<path>", "Specify files named on the command line should be saved into a .dyno library", "P", NULL, NULL, addDynoGenLib},
  {"dyno-gen-std", ' ', NULL, "Generate a .dyno library file for the standard library", "F", &fDynoGenStdLib, NULL, setDynoGenStdLib},

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -151,6 +151,7 @@ bool fDriverDoMonolithic = false;
 bool driverDebugPhaseSpecified = false;
 // Tmp dir path managed by compiler driver
 char driverTmpDir[FILENAME_MAX] = "";
+bool fExitLeaks = true;
 bool fLibraryCompile = false;
 bool fLibraryFortran = false;
 bool fLibraryMakefile = false;
@@ -1439,6 +1440,7 @@ static ArgumentDescription arg_desc[] = {
  {"driver-compilation-phase", ' ', NULL, "Run driver compilation phase (internal use flag)", "F", &fDriverCompilationPhase, NULL, setSubInvocation},
  {"driver-makebinary-phase", ' ', NULL, "Run driver makeBinary phase (internal use flag)", "F", &fDriverMakeBinaryPhase, NULL, setSubInvocation},
  {"driver-debug-phase", ' ', "<phase>", "Specify driver phase to run when debugging: compilation, makeBinary, all", "S", NULL, NULL, setDriverDebugPhase},
+ {"exit-leaks", ' ', NULL, "[Don't] leak memory on exit", "N", &fExitLeaks, NULL, NULL},
  {"gdb", ' ', NULL, "Run compiler in gdb", "F", &fRungdb, NULL, NULL},
  {"lldb", ' ', NULL, "Run compiler in lldb", "F", &fRunlldb, NULL, NULL},
  {"interprocedural-alias-analysis", ' ', NULL, "Enable [disable] interprocedural alias analysis", "n", &fNoInterproceduralAliasAnalysis, NULL, NULL},

--- a/compiler/passes/parseAndConvert.cpp
+++ b/compiler/passes/parseAndConvert.cpp
@@ -1439,5 +1439,15 @@ void parseAndConvertUast() {
   // Revert to using the default error handler now.
   gContext->installErrorHandler(nullptr);
 
+  if (fDynoDebugPrintParsedFiles) {
+    std::set<std::string> files;
+    auto filesUstr = chpl::parsing::introspectParsedFiles(gContext);
+    for (auto ustr : filesUstr) {
+      files.insert(ustr.str());
+    }
+    for (auto file : files) {
+      fprintf(stderr, "Parsed file: %s\n", file.c_str());
+    }
+  }
   parsed = true;
 }

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -1117,7 +1117,9 @@ void clean_exit(int status) {
 
   cleanup_for_exit();
 
-  delete gContext;
+  // The context's destructor takes a while, and we're about to exit anyway,
+  // so deliberately leak it.
+  // delete gContext;
   gContext = nullptr;
 
   if (gGenInfo) {

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -1117,9 +1117,12 @@ void clean_exit(int status) {
 
   cleanup_for_exit();
 
-  // The context's destructor takes a while, and we're about to exit anyway,
-  // so deliberately leak it.
-  // delete gContext;
+  if (fExitLeaks) {
+    // The context's destructor takes a while, and we're about to exit anyway,
+    // so deliberately leak it.
+  } else {
+    delete gContext;
+  }
   gContext = nullptr;
 
   if (gGenInfo) {

--- a/frontend/include/chpl/framework/query-impl.h
+++ b/frontend/include/chpl/framework/query-impl.h
@@ -27,7 +27,7 @@
 #include "chpl/framework/stringify-functions.h"
 
 #ifndef CHPL_QUERY_TIMING_AND_TRACE_ENABLED
-#define CHPL_QUERY_TIMING_AND_TRACE_ENABLED 1
+#define CHPL_QUERY_TIMING_AND_TRACE_ENABLED 0
 #endif
 
 /**
@@ -617,7 +617,7 @@ Context::querySetterUpdateResult(
 
 #else
 
-#define QUERY_BEGIN_TIMING()
+#define QUERY_BEGIN_TIMING(context__)
 
 #endif
 

--- a/frontend/include/chpl/framework/query-impl.h
+++ b/frontend/include/chpl/framework/query-impl.h
@@ -27,7 +27,13 @@
 #include "chpl/framework/stringify-functions.h"
 
 #ifndef CHPL_QUERY_TIMING_AND_TRACE_ENABLED
+#ifdef NDEBUG
+// release mode
 #define CHPL_QUERY_TIMING_AND_TRACE_ENABLED 0
+#else
+// debug mode
+#define CHPL_QUERY_TIMING_AND_TRACE_ENABLED 1
+#endif
 #endif
 
 /**

--- a/frontend/include/chpl/resolution/scope-queries.h
+++ b/frontend/include/chpl/resolution/scope-queries.h
@@ -168,9 +168,12 @@ namespace resolution {
 
   /**
     Resolve the uses and imports in a given scope.
+
+    If 'skipPrivate' is set, avoids resolving visibility statements that
+    only expose scope-private symbols. This helps avoid unnecessary work.
   */
   const ResolvedVisibilityScope*
-  resolveVisibilityStmts(Context* context, const Scope* scope);
+  resolveVisibilityStmts(Context* context, const Scope* scope, bool skipPrivate = false);
 
   /**
     Return the scope for the automatically included 'ChapelStandard' module,

--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -1439,9 +1439,15 @@ const uast::AttributeGroup*
 astToAttributeGroup(Context* context, const uast::AstNode* ast) {
   const uast::AttributeGroup* ret = nullptr;
   if (ast) {
+    // If we find an attribute group on the AST, return it.
+    if (auto ag = ast->attributeGroup()) return ag;
+
+    // Multi-decls aren't nested, so no need to check parents for a group.
+    if (ast->isMultiDecl()) return nullptr;
+
+    // handle nesting: what if we're a Variable inside a MultiDecl?
     auto parent = parentAst(context, ast);
-    bool done = ast->isMultiDecl() || !parent ||
-                (!parent->isTupleDecl() && !parent->isMultiDecl());
+    bool done = !parent || (!parent->isTupleDecl() && !parent->isMultiDecl());
     // recurse if not done
     return done
            ? ast->attributeGroup()

--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -1442,10 +1442,11 @@ astToAttributeGroup(Context* context, const uast::AstNode* ast) {
     // If we find an attribute group on the AST, return it.
     if (auto ag = ast->attributeGroup()) return ag;
 
-    // Multi-decls aren't nested, so no need to check parents for a group.
-    if (ast->isMultiDecl()) return nullptr;
+    // Right now, only Variables and TupleDecls can inherit attributes
+    // from enclosing MultiDecls or TupleDecls.
+    if (!ast->isVariable() && !ast->isTupleDecl()) return nullptr;
 
-    // handle nesting: what if we're a Variable inside a MultiDecl?
+    // handle nesting: what if we're a Variable inside a MultiDecl or TupleDecl?
     auto parent = parentAst(context, ast);
     bool done = !parent || (!parent->isTupleDecl() && !parent->isMultiDecl());
     // recurse if not done

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -1064,6 +1064,7 @@ static bool isReservedIdentifier(UniqueString name) {
     USTR("int"),
     USTR("uint"),
     USTR("real"),
+    USTR("string"),
   };
   return reserved.count(name);
 }

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -1062,9 +1062,11 @@ static bool isReservedIdentifier(UniqueString name) {
     USTR("complex"),
     USTR("domain"),
     USTR("int"),
+    USTR("nil"),
     USTR("uint"),
     USTR("real"),
     USTR("string"),
+    USTR("void"),
   };
   return reserved.count(name);
 }

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -1056,6 +1056,11 @@ static const Scope* nextHigherScope(Context* context, const Scope* scope) {
 // Performance: ideally this could be a SmallPtrSet, but we're getting
 // different .c_str() pointers for USTR("int") and strings we get from the
 // parser. Seems fixable.
+//
+// Other reserved identifiers (bytes, imag) could be added here, but in
+// my performance benchmarks they didn't occur frequently so were not
+// worth the additional checking by this function. This list is not intended
+// to be complete; rather, it is intended to cover the most common cases.
 static bool isReservedIdentifier(UniqueString name) {
   static std::unordered_set<UniqueString> reserved = {
     USTR("bool"),

--- a/frontend/test/resolution/testSuper.cpp
+++ b/frontend/test/resolution/testSuper.cpp
@@ -181,15 +181,15 @@ static void superTest6() {
               }
 
               class Child : Parent {
-                proc foo(super: owned Other) {
+                proc foo() {
                   return super.bar();
                 }
               }
             }
          )"""",
          "M.Child.foo",
-         "M.Child.foo@7",
-         "M.Other.bar");
+         "M.Child.foo@3",
+         "M.Parent.bar");
 }
 
 int main() {

--- a/test/separate_compilation/serialization/buildAll.compopts
+++ b/test/separate_compilation/serialization/buildAll.compopts
@@ -1,1 +1,1 @@
-testGenLib.dyno MyMod.dyno OtherMod.dyno chpl_standard.dyno --main-module testGenLib --dyno-debug-trace
+testGenLib.dyno MyMod.dyno OtherMod.dyno chpl_standard.dyno --main-module testGenLib --dyno-debug-print-parsed-files

--- a/test/separate_compilation/serialization/buildAll.good
+++ b/test/separate_compilation/serialization/buildAll.good
@@ -1,3 +1,3 @@
-2 { fileTextQuery ("buildAll.chpl") 
+Parsed file: buildAll.chpl
 MYPREFIX: doMyM-doMyM-doMyM
 MYPREFIX: doMrehtO-doMrehtO-doMrehtO

--- a/test/separate_compilation/serialization/testGenLib.MyMod.good
+++ b/test/separate_compilation/serialization/testGenLib.MyMod.good
@@ -1,98 +1,98 @@
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelBase.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelStandard.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/PrintModuleInitOrder.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/standard/gen/.../ChapelSysCTypes.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/standard/Errors.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelTaskData.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/startInitCommDiags.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/CString.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/Bytes.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/String.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/OwnedObject.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/SharedObject.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/Atomics.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/NetworkAtomics.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/NetworkAtomicTypes.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/AtomicsCommon.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelIteratorSupport.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelThreads.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelTuple.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelRange.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelReduce.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelSyncvar.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelTaskDataHelp.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/localeModels/flat/LocaleModel.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelLocale.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelPrivatization.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/DefaultRectangular.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/LocalesArray.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelArray.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelDistribution.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelAutoLocalAccess.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelIOSerialize.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelHashing.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/DefaultAssociative.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/DefaultSparse.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelTaskID.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/tasktable/off/ChapelTaskTable.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/MemTracking.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelUtil.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelSerializedBroadcast.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ExportWrappers.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelAutoAggregation.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelGpuSupport.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelContext.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelStaticVars.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/stopInitCommDiags.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelLocks.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ByteBufferHelpers.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/BytesStringCommon.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/BytesCasts.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/StringCasts.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/MemConsistency.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelDebugPrint.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/LocaleModelHelpFlat.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/LocaleModelHelpMem.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ExternalArray.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ArrayViewSlice.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ArrayViewRankChange.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ArrayViewReindex.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelDomain.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelHashtable.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelIOStringifyHelper.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/LocaleModelHelpSetup.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/LocaleModelHelpRuntime.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelNumLocales.chpl") 
-2 { fileTextQuery ("testGenLib.chpl") 
-8 { fileTextQuery ("$CHPL_HOME/modules/standard/CTypes.chpl") 
-9 { fileTextQuery ("$CHPL_HOME/modules/standard/HaltWrappers.chpl") 
-8 { fileTextQuery ("$CHPL_HOME/modules/standard/ChplConfig.chpl") 
-7 { fileTextQuery ("$CHPL_HOME/modules/standard/CommDiagnostics.chpl") 
-8 { fileTextQuery ("$CHPL_HOME/modules/standard/OS.chpl") 
-7 { fileTextQuery ("$CHPL_HOME/modules/standard/WeakPointer.chpl") 
-7 { fileTextQuery ("$CHPL_HOME/modules/standard/Reflection.chpl") 
-7 { fileTextQuery ("$CHPL_HOME/modules/dists/DSIUtil.chpl") 
-7 { fileTextQuery ("$CHPL_HOME/modules/standard/AutoMath.chpl") 
-a { fileTextQuery ("$CHPL_HOME/modules/standard/IO.chpl") 
-b { fileTextQuery ("$CHPL_HOME/modules/standard/ChapelIO.chpl") 
-b { fileTextQuery ("$CHPL_HOME/modules/standard/Regex.chpl") 
-b { fileTextQuery ("$CHPL_HOME/modules/packages/RangeChunk.chpl") 
-c { fileTextQuery ("$CHPL_HOME/modules/standard/Math.chpl") 
-7 { fileTextQuery ("$CHPL_HOME/modules/packages/CopyAggregation.chpl") 
-6 { fileTextQuery ("$CHPL_HOME/modules/standard/Types.chpl") 
-7 { fileTextQuery ("OtherMod.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/packages/Sort.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/packages/Search.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/standard/Communication.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/standard/MemMove.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/standard/List.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/standard/Random.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/dists/BlockDist.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/packages/NPBRandom.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/standard/Time.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/layouts/LayoutCS.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/dists/SparseBlockDist.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/standard/JSON.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/standard/Map.chpl") 
+Parsed file: $CHPL_HOME/modules/dists/BlockDist.chpl
+Parsed file: $CHPL_HOME/modules/dists/DSIUtil.chpl
+Parsed file: $CHPL_HOME/modules/dists/SparseBlockDist.chpl
+Parsed file: $CHPL_HOME/modules/internal/ArrayViewRankChange.chpl
+Parsed file: $CHPL_HOME/modules/internal/ArrayViewReindex.chpl
+Parsed file: $CHPL_HOME/modules/internal/ArrayViewSlice.chpl
+Parsed file: $CHPL_HOME/modules/internal/Atomics.chpl
+Parsed file: $CHPL_HOME/modules/internal/AtomicsCommon.chpl
+Parsed file: $CHPL_HOME/modules/internal/ByteBufferHelpers.chpl
+Parsed file: $CHPL_HOME/modules/internal/Bytes.chpl
+Parsed file: $CHPL_HOME/modules/internal/BytesCasts.chpl
+Parsed file: $CHPL_HOME/modules/internal/BytesStringCommon.chpl
+Parsed file: $CHPL_HOME/modules/internal/CString.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelArray.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelAutoAggregation.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelAutoLocalAccess.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelBase.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelContext.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelDebugPrint.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelDistribution.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelDomain.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelGpuSupport.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelHashing.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelHashtable.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelIOSerialize.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelIOStringifyHelper.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelIteratorSupport.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelLocale.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelLocks.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelNumLocales.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelPrivatization.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelRange.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelReduce.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelSerializedBroadcast.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelStandard.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelStaticVars.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelSyncvar.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelTaskData.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelTaskDataHelp.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelTaskID.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelThreads.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelTuple.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelUtil.chpl
+Parsed file: $CHPL_HOME/modules/internal/DefaultAssociative.chpl
+Parsed file: $CHPL_HOME/modules/internal/DefaultRectangular.chpl
+Parsed file: $CHPL_HOME/modules/internal/DefaultSparse.chpl
+Parsed file: $CHPL_HOME/modules/internal/ExportWrappers.chpl
+Parsed file: $CHPL_HOME/modules/internal/ExternalArray.chpl
+Parsed file: $CHPL_HOME/modules/internal/LocaleModelHelpFlat.chpl
+Parsed file: $CHPL_HOME/modules/internal/LocaleModelHelpMem.chpl
+Parsed file: $CHPL_HOME/modules/internal/LocaleModelHelpRuntime.chpl
+Parsed file: $CHPL_HOME/modules/internal/LocaleModelHelpSetup.chpl
+Parsed file: $CHPL_HOME/modules/internal/LocalesArray.chpl
+Parsed file: $CHPL_HOME/modules/internal/MemConsistency.chpl
+Parsed file: $CHPL_HOME/modules/internal/MemTracking.chpl
+Parsed file: $CHPL_HOME/modules/internal/NetworkAtomicTypes.chpl
+Parsed file: $CHPL_HOME/modules/internal/NetworkAtomics.chpl
+Parsed file: $CHPL_HOME/modules/internal/OwnedObject.chpl
+Parsed file: $CHPL_HOME/modules/internal/PrintModuleInitOrder.chpl
+Parsed file: $CHPL_HOME/modules/internal/SharedObject.chpl
+Parsed file: $CHPL_HOME/modules/internal/String.chpl
+Parsed file: $CHPL_HOME/modules/internal/StringCasts.chpl
+Parsed file: $CHPL_HOME/modules/internal/localeModels/flat/LocaleModel.chpl
+Parsed file: $CHPL_HOME/modules/internal/startInitCommDiags.chpl
+Parsed file: $CHPL_HOME/modules/internal/stopInitCommDiags.chpl
+Parsed file: $CHPL_HOME/modules/internal/tasktable/off/ChapelTaskTable.chpl
+Parsed file: $CHPL_HOME/modules/layouts/LayoutCS.chpl
+Parsed file: $CHPL_HOME/modules/packages/CopyAggregation.chpl
+Parsed file: $CHPL_HOME/modules/packages/NPBRandom.chpl
+Parsed file: $CHPL_HOME/modules/packages/RangeChunk.chpl
+Parsed file: $CHPL_HOME/modules/packages/Search.chpl
+Parsed file: $CHPL_HOME/modules/packages/Sort.chpl
+Parsed file: $CHPL_HOME/modules/standard/AutoMath.chpl
+Parsed file: $CHPL_HOME/modules/standard/CTypes.chpl
+Parsed file: $CHPL_HOME/modules/standard/ChapelIO.chpl
+Parsed file: $CHPL_HOME/modules/standard/ChplConfig.chpl
+Parsed file: $CHPL_HOME/modules/standard/CommDiagnostics.chpl
+Parsed file: $CHPL_HOME/modules/standard/Communication.chpl
+Parsed file: $CHPL_HOME/modules/standard/Errors.chpl
+Parsed file: $CHPL_HOME/modules/standard/HaltWrappers.chpl
+Parsed file: $CHPL_HOME/modules/standard/IO.chpl
+Parsed file: $CHPL_HOME/modules/standard/JSON.chpl
+Parsed file: $CHPL_HOME/modules/standard/List.chpl
+Parsed file: $CHPL_HOME/modules/standard/Map.chpl
+Parsed file: $CHPL_HOME/modules/standard/Math.chpl
+Parsed file: $CHPL_HOME/modules/standard/MemMove.chpl
+Parsed file: $CHPL_HOME/modules/standard/OS.chpl
+Parsed file: $CHPL_HOME/modules/standard/Random.chpl
+Parsed file: $CHPL_HOME/modules/standard/Reflection.chpl
+Parsed file: $CHPL_HOME/modules/standard/Regex.chpl
+Parsed file: $CHPL_HOME/modules/standard/Time.chpl
+Parsed file: $CHPL_HOME/modules/standard/Types.chpl
+Parsed file: $CHPL_HOME/modules/standard/WeakPointer.chpl
+Parsed file: $CHPL_HOME/modules/standard/gen/.../ChapelSysCTypes.chpl
+Parsed file: OtherMod.chpl
+Parsed file: testGenLib.chpl
 MYPREFIX: doMyM-doMyM-doMyM
 MYPREFIX: OtherMod OtherMod OtherMod

--- a/test/separate_compilation/serialization/testGenLib.OtherMod.good
+++ b/test/separate_compilation/serialization/testGenLib.OtherMod.good
@@ -1,98 +1,98 @@
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelBase.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelStandard.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/PrintModuleInitOrder.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/standard/gen/.../ChapelSysCTypes.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/standard/Errors.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelTaskData.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/startInitCommDiags.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/CString.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/Bytes.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/String.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/OwnedObject.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/SharedObject.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/Atomics.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/NetworkAtomics.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/NetworkAtomicTypes.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/AtomicsCommon.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelIteratorSupport.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelThreads.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelTuple.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelRange.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelReduce.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelSyncvar.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelTaskDataHelp.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/localeModels/flat/LocaleModel.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelLocale.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelPrivatization.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/DefaultRectangular.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/LocalesArray.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelArray.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelDistribution.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelAutoLocalAccess.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelIOSerialize.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelHashing.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/DefaultAssociative.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/DefaultSparse.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelTaskID.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/tasktable/off/ChapelTaskTable.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/MemTracking.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelUtil.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelSerializedBroadcast.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ExportWrappers.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelAutoAggregation.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelGpuSupport.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelContext.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelStaticVars.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/stopInitCommDiags.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelLocks.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ByteBufferHelpers.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/BytesStringCommon.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/BytesCasts.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/StringCasts.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/MemConsistency.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelDebugPrint.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/LocaleModelHelpFlat.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/LocaleModelHelpMem.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ExternalArray.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ArrayViewSlice.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ArrayViewRankChange.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ArrayViewReindex.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelDomain.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelHashtable.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelIOStringifyHelper.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/LocaleModelHelpSetup.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/LocaleModelHelpRuntime.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelNumLocales.chpl") 
-2 { fileTextQuery ("testGenLib.chpl") 
-8 { fileTextQuery ("$CHPL_HOME/modules/standard/CTypes.chpl") 
-9 { fileTextQuery ("$CHPL_HOME/modules/standard/HaltWrappers.chpl") 
-8 { fileTextQuery ("$CHPL_HOME/modules/standard/ChplConfig.chpl") 
-7 { fileTextQuery ("$CHPL_HOME/modules/standard/CommDiagnostics.chpl") 
-8 { fileTextQuery ("$CHPL_HOME/modules/standard/OS.chpl") 
-7 { fileTextQuery ("$CHPL_HOME/modules/standard/WeakPointer.chpl") 
-7 { fileTextQuery ("$CHPL_HOME/modules/standard/Reflection.chpl") 
-7 { fileTextQuery ("$CHPL_HOME/modules/dists/DSIUtil.chpl") 
-7 { fileTextQuery ("$CHPL_HOME/modules/standard/AutoMath.chpl") 
-a { fileTextQuery ("$CHPL_HOME/modules/standard/IO.chpl") 
-b { fileTextQuery ("$CHPL_HOME/modules/standard/ChapelIO.chpl") 
-b { fileTextQuery ("$CHPL_HOME/modules/standard/Regex.chpl") 
-b { fileTextQuery ("$CHPL_HOME/modules/packages/RangeChunk.chpl") 
-c { fileTextQuery ("$CHPL_HOME/modules/standard/Math.chpl") 
-7 { fileTextQuery ("$CHPL_HOME/modules/packages/CopyAggregation.chpl") 
-6 { fileTextQuery ("$CHPL_HOME/modules/standard/Types.chpl") 
-7 { fileTextQuery ("MyMod.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/packages/Sort.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/packages/Search.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/standard/Communication.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/standard/MemMove.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/standard/List.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/standard/Random.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/dists/BlockDist.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/packages/NPBRandom.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/standard/Time.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/layouts/LayoutCS.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/dists/SparseBlockDist.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/standard/JSON.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/standard/Map.chpl") 
+Parsed file: $CHPL_HOME/modules/dists/BlockDist.chpl
+Parsed file: $CHPL_HOME/modules/dists/DSIUtil.chpl
+Parsed file: $CHPL_HOME/modules/dists/SparseBlockDist.chpl
+Parsed file: $CHPL_HOME/modules/internal/ArrayViewRankChange.chpl
+Parsed file: $CHPL_HOME/modules/internal/ArrayViewReindex.chpl
+Parsed file: $CHPL_HOME/modules/internal/ArrayViewSlice.chpl
+Parsed file: $CHPL_HOME/modules/internal/Atomics.chpl
+Parsed file: $CHPL_HOME/modules/internal/AtomicsCommon.chpl
+Parsed file: $CHPL_HOME/modules/internal/ByteBufferHelpers.chpl
+Parsed file: $CHPL_HOME/modules/internal/Bytes.chpl
+Parsed file: $CHPL_HOME/modules/internal/BytesCasts.chpl
+Parsed file: $CHPL_HOME/modules/internal/BytesStringCommon.chpl
+Parsed file: $CHPL_HOME/modules/internal/CString.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelArray.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelAutoAggregation.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelAutoLocalAccess.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelBase.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelContext.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelDebugPrint.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelDistribution.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelDomain.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelGpuSupport.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelHashing.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelHashtable.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelIOSerialize.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelIOStringifyHelper.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelIteratorSupport.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelLocale.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelLocks.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelNumLocales.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelPrivatization.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelRange.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelReduce.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelSerializedBroadcast.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelStandard.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelStaticVars.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelSyncvar.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelTaskData.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelTaskDataHelp.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelTaskID.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelThreads.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelTuple.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelUtil.chpl
+Parsed file: $CHPL_HOME/modules/internal/DefaultAssociative.chpl
+Parsed file: $CHPL_HOME/modules/internal/DefaultRectangular.chpl
+Parsed file: $CHPL_HOME/modules/internal/DefaultSparse.chpl
+Parsed file: $CHPL_HOME/modules/internal/ExportWrappers.chpl
+Parsed file: $CHPL_HOME/modules/internal/ExternalArray.chpl
+Parsed file: $CHPL_HOME/modules/internal/LocaleModelHelpFlat.chpl
+Parsed file: $CHPL_HOME/modules/internal/LocaleModelHelpMem.chpl
+Parsed file: $CHPL_HOME/modules/internal/LocaleModelHelpRuntime.chpl
+Parsed file: $CHPL_HOME/modules/internal/LocaleModelHelpSetup.chpl
+Parsed file: $CHPL_HOME/modules/internal/LocalesArray.chpl
+Parsed file: $CHPL_HOME/modules/internal/MemConsistency.chpl
+Parsed file: $CHPL_HOME/modules/internal/MemTracking.chpl
+Parsed file: $CHPL_HOME/modules/internal/NetworkAtomicTypes.chpl
+Parsed file: $CHPL_HOME/modules/internal/NetworkAtomics.chpl
+Parsed file: $CHPL_HOME/modules/internal/OwnedObject.chpl
+Parsed file: $CHPL_HOME/modules/internal/PrintModuleInitOrder.chpl
+Parsed file: $CHPL_HOME/modules/internal/SharedObject.chpl
+Parsed file: $CHPL_HOME/modules/internal/String.chpl
+Parsed file: $CHPL_HOME/modules/internal/StringCasts.chpl
+Parsed file: $CHPL_HOME/modules/internal/localeModels/flat/LocaleModel.chpl
+Parsed file: $CHPL_HOME/modules/internal/startInitCommDiags.chpl
+Parsed file: $CHPL_HOME/modules/internal/stopInitCommDiags.chpl
+Parsed file: $CHPL_HOME/modules/internal/tasktable/off/ChapelTaskTable.chpl
+Parsed file: $CHPL_HOME/modules/layouts/LayoutCS.chpl
+Parsed file: $CHPL_HOME/modules/packages/CopyAggregation.chpl
+Parsed file: $CHPL_HOME/modules/packages/NPBRandom.chpl
+Parsed file: $CHPL_HOME/modules/packages/RangeChunk.chpl
+Parsed file: $CHPL_HOME/modules/packages/Search.chpl
+Parsed file: $CHPL_HOME/modules/packages/Sort.chpl
+Parsed file: $CHPL_HOME/modules/standard/AutoMath.chpl
+Parsed file: $CHPL_HOME/modules/standard/CTypes.chpl
+Parsed file: $CHPL_HOME/modules/standard/ChapelIO.chpl
+Parsed file: $CHPL_HOME/modules/standard/ChplConfig.chpl
+Parsed file: $CHPL_HOME/modules/standard/CommDiagnostics.chpl
+Parsed file: $CHPL_HOME/modules/standard/Communication.chpl
+Parsed file: $CHPL_HOME/modules/standard/Errors.chpl
+Parsed file: $CHPL_HOME/modules/standard/HaltWrappers.chpl
+Parsed file: $CHPL_HOME/modules/standard/IO.chpl
+Parsed file: $CHPL_HOME/modules/standard/JSON.chpl
+Parsed file: $CHPL_HOME/modules/standard/List.chpl
+Parsed file: $CHPL_HOME/modules/standard/Map.chpl
+Parsed file: $CHPL_HOME/modules/standard/Math.chpl
+Parsed file: $CHPL_HOME/modules/standard/MemMove.chpl
+Parsed file: $CHPL_HOME/modules/standard/OS.chpl
+Parsed file: $CHPL_HOME/modules/standard/Random.chpl
+Parsed file: $CHPL_HOME/modules/standard/Reflection.chpl
+Parsed file: $CHPL_HOME/modules/standard/Regex.chpl
+Parsed file: $CHPL_HOME/modules/standard/Time.chpl
+Parsed file: $CHPL_HOME/modules/standard/Types.chpl
+Parsed file: $CHPL_HOME/modules/standard/WeakPointer.chpl
+Parsed file: $CHPL_HOME/modules/standard/gen/.../ChapelSysCTypes.chpl
+Parsed file: MyMod.chpl
+Parsed file: testGenLib.chpl
 MYPREFIX: MyMod MyMod MyMod
 MYPREFIX: doMrehtO-doMrehtO-doMrehtO

--- a/test/separate_compilation/serialization/testGenLib.both.good
+++ b/test/separate_compilation/serialization/testGenLib.both.good
@@ -1,97 +1,97 @@
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelBase.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelStandard.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/PrintModuleInitOrder.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/standard/gen/.../ChapelSysCTypes.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/standard/Errors.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelTaskData.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/startInitCommDiags.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/CString.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/Bytes.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/String.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/OwnedObject.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/SharedObject.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/Atomics.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/NetworkAtomics.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/NetworkAtomicTypes.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/AtomicsCommon.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelIteratorSupport.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelThreads.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelTuple.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelRange.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelReduce.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelSyncvar.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelTaskDataHelp.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/localeModels/flat/LocaleModel.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelLocale.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelPrivatization.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/DefaultRectangular.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/LocalesArray.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelArray.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelDistribution.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelAutoLocalAccess.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelIOSerialize.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelHashing.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/DefaultAssociative.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/DefaultSparse.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelTaskID.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/tasktable/off/ChapelTaskTable.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/MemTracking.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelUtil.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelSerializedBroadcast.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ExportWrappers.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelAutoAggregation.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelGpuSupport.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelContext.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelStaticVars.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/stopInitCommDiags.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelLocks.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ByteBufferHelpers.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/BytesStringCommon.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/BytesCasts.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/StringCasts.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/MemConsistency.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelDebugPrint.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/LocaleModelHelpFlat.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/LocaleModelHelpMem.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ExternalArray.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ArrayViewSlice.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ArrayViewRankChange.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ArrayViewReindex.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelDomain.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelHashtable.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelIOStringifyHelper.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/LocaleModelHelpSetup.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/LocaleModelHelpRuntime.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/internal/ChapelNumLocales.chpl") 
-2 { fileTextQuery ("testGenLib.chpl") 
-8 { fileTextQuery ("$CHPL_HOME/modules/standard/CTypes.chpl") 
-9 { fileTextQuery ("$CHPL_HOME/modules/standard/HaltWrappers.chpl") 
-8 { fileTextQuery ("$CHPL_HOME/modules/standard/ChplConfig.chpl") 
-7 { fileTextQuery ("$CHPL_HOME/modules/standard/CommDiagnostics.chpl") 
-8 { fileTextQuery ("$CHPL_HOME/modules/standard/OS.chpl") 
-7 { fileTextQuery ("$CHPL_HOME/modules/standard/WeakPointer.chpl") 
-7 { fileTextQuery ("$CHPL_HOME/modules/standard/Reflection.chpl") 
-7 { fileTextQuery ("$CHPL_HOME/modules/dists/DSIUtil.chpl") 
-7 { fileTextQuery ("$CHPL_HOME/modules/standard/AutoMath.chpl") 
-a { fileTextQuery ("$CHPL_HOME/modules/standard/IO.chpl") 
-b { fileTextQuery ("$CHPL_HOME/modules/standard/ChapelIO.chpl") 
-b { fileTextQuery ("$CHPL_HOME/modules/standard/Regex.chpl") 
-b { fileTextQuery ("$CHPL_HOME/modules/packages/RangeChunk.chpl") 
-c { fileTextQuery ("$CHPL_HOME/modules/standard/Math.chpl") 
-7 { fileTextQuery ("$CHPL_HOME/modules/packages/CopyAggregation.chpl") 
-6 { fileTextQuery ("$CHPL_HOME/modules/standard/Types.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/packages/Sort.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/packages/Search.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/standard/Communication.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/standard/MemMove.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/standard/List.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/standard/Random.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/dists/BlockDist.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/packages/NPBRandom.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/standard/Time.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/layouts/LayoutCS.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/dists/SparseBlockDist.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/standard/JSON.chpl") 
-2 { fileTextQuery ("$CHPL_HOME/modules/standard/Map.chpl") 
+Parsed file: $CHPL_HOME/modules/dists/BlockDist.chpl
+Parsed file: $CHPL_HOME/modules/dists/DSIUtil.chpl
+Parsed file: $CHPL_HOME/modules/dists/SparseBlockDist.chpl
+Parsed file: $CHPL_HOME/modules/internal/ArrayViewRankChange.chpl
+Parsed file: $CHPL_HOME/modules/internal/ArrayViewReindex.chpl
+Parsed file: $CHPL_HOME/modules/internal/ArrayViewSlice.chpl
+Parsed file: $CHPL_HOME/modules/internal/Atomics.chpl
+Parsed file: $CHPL_HOME/modules/internal/AtomicsCommon.chpl
+Parsed file: $CHPL_HOME/modules/internal/ByteBufferHelpers.chpl
+Parsed file: $CHPL_HOME/modules/internal/Bytes.chpl
+Parsed file: $CHPL_HOME/modules/internal/BytesCasts.chpl
+Parsed file: $CHPL_HOME/modules/internal/BytesStringCommon.chpl
+Parsed file: $CHPL_HOME/modules/internal/CString.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelArray.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelAutoAggregation.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelAutoLocalAccess.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelBase.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelContext.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelDebugPrint.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelDistribution.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelDomain.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelGpuSupport.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelHashing.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelHashtable.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelIOSerialize.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelIOStringifyHelper.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelIteratorSupport.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelLocale.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelLocks.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelNumLocales.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelPrivatization.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelRange.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelReduce.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelSerializedBroadcast.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelStandard.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelStaticVars.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelSyncvar.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelTaskData.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelTaskDataHelp.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelTaskID.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelThreads.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelTuple.chpl
+Parsed file: $CHPL_HOME/modules/internal/ChapelUtil.chpl
+Parsed file: $CHPL_HOME/modules/internal/DefaultAssociative.chpl
+Parsed file: $CHPL_HOME/modules/internal/DefaultRectangular.chpl
+Parsed file: $CHPL_HOME/modules/internal/DefaultSparse.chpl
+Parsed file: $CHPL_HOME/modules/internal/ExportWrappers.chpl
+Parsed file: $CHPL_HOME/modules/internal/ExternalArray.chpl
+Parsed file: $CHPL_HOME/modules/internal/LocaleModelHelpFlat.chpl
+Parsed file: $CHPL_HOME/modules/internal/LocaleModelHelpMem.chpl
+Parsed file: $CHPL_HOME/modules/internal/LocaleModelHelpRuntime.chpl
+Parsed file: $CHPL_HOME/modules/internal/LocaleModelHelpSetup.chpl
+Parsed file: $CHPL_HOME/modules/internal/LocalesArray.chpl
+Parsed file: $CHPL_HOME/modules/internal/MemConsistency.chpl
+Parsed file: $CHPL_HOME/modules/internal/MemTracking.chpl
+Parsed file: $CHPL_HOME/modules/internal/NetworkAtomicTypes.chpl
+Parsed file: $CHPL_HOME/modules/internal/NetworkAtomics.chpl
+Parsed file: $CHPL_HOME/modules/internal/OwnedObject.chpl
+Parsed file: $CHPL_HOME/modules/internal/PrintModuleInitOrder.chpl
+Parsed file: $CHPL_HOME/modules/internal/SharedObject.chpl
+Parsed file: $CHPL_HOME/modules/internal/String.chpl
+Parsed file: $CHPL_HOME/modules/internal/StringCasts.chpl
+Parsed file: $CHPL_HOME/modules/internal/localeModels/flat/LocaleModel.chpl
+Parsed file: $CHPL_HOME/modules/internal/startInitCommDiags.chpl
+Parsed file: $CHPL_HOME/modules/internal/stopInitCommDiags.chpl
+Parsed file: $CHPL_HOME/modules/internal/tasktable/off/ChapelTaskTable.chpl
+Parsed file: $CHPL_HOME/modules/layouts/LayoutCS.chpl
+Parsed file: $CHPL_HOME/modules/packages/CopyAggregation.chpl
+Parsed file: $CHPL_HOME/modules/packages/NPBRandom.chpl
+Parsed file: $CHPL_HOME/modules/packages/RangeChunk.chpl
+Parsed file: $CHPL_HOME/modules/packages/Search.chpl
+Parsed file: $CHPL_HOME/modules/packages/Sort.chpl
+Parsed file: $CHPL_HOME/modules/standard/AutoMath.chpl
+Parsed file: $CHPL_HOME/modules/standard/CTypes.chpl
+Parsed file: $CHPL_HOME/modules/standard/ChapelIO.chpl
+Parsed file: $CHPL_HOME/modules/standard/ChplConfig.chpl
+Parsed file: $CHPL_HOME/modules/standard/CommDiagnostics.chpl
+Parsed file: $CHPL_HOME/modules/standard/Communication.chpl
+Parsed file: $CHPL_HOME/modules/standard/Errors.chpl
+Parsed file: $CHPL_HOME/modules/standard/HaltWrappers.chpl
+Parsed file: $CHPL_HOME/modules/standard/IO.chpl
+Parsed file: $CHPL_HOME/modules/standard/JSON.chpl
+Parsed file: $CHPL_HOME/modules/standard/List.chpl
+Parsed file: $CHPL_HOME/modules/standard/Map.chpl
+Parsed file: $CHPL_HOME/modules/standard/Math.chpl
+Parsed file: $CHPL_HOME/modules/standard/MemMove.chpl
+Parsed file: $CHPL_HOME/modules/standard/OS.chpl
+Parsed file: $CHPL_HOME/modules/standard/Random.chpl
+Parsed file: $CHPL_HOME/modules/standard/Reflection.chpl
+Parsed file: $CHPL_HOME/modules/standard/Regex.chpl
+Parsed file: $CHPL_HOME/modules/standard/Time.chpl
+Parsed file: $CHPL_HOME/modules/standard/Types.chpl
+Parsed file: $CHPL_HOME/modules/standard/WeakPointer.chpl
+Parsed file: $CHPL_HOME/modules/standard/gen/.../ChapelSysCTypes.chpl
+Parsed file: testGenLib.chpl
 MYPREFIX: doMyM-doMyM-doMyM
 MYPREFIX: doMrehtO-doMrehtO-doMrehtO

--- a/test/separate_compilation/serialization/testGenLib.compopts
+++ b/test/separate_compilation/serialization/testGenLib.compopts
@@ -1,4 +1,4 @@
-MyMod.dyno --dyno-debug-trace # testGenLib.MyMod.good
-OtherMod.dyno --dyno-debug-trace # testGenLib.OtherMod.good
-MyMod.dyno OtherMod.dyno --dyno-debug-trace # testGenLib.both.good
-MyMod.dyno OtherMod.dyno chpl_standard.dyno --dyno-debug-trace # testGenLib.standard.good
+MyMod.dyno --dyno-debug-print-parsed-files # testGenLib.MyMod.good
+OtherMod.dyno --dyno-debug-print-parsed-files # testGenLib.OtherMod.good
+MyMod.dyno OtherMod.dyno --dyno-debug-print-parsed-files # testGenLib.both.good
+MyMod.dyno OtherMod.dyno chpl_standard.dyno --dyno-debug-print-parsed-files # testGenLib.standard.good

--- a/test/separate_compilation/serialization/testGenLib.prediff
+++ b/test/separate_compilation/serialization/testGenLib.prediff
@@ -1,10 +1,7 @@
 #!/bin/bash
 
-grep "fileTextQuery (\|^MYPREFIX" $2 > $2.tmp
+grep "Parsed file:\|^MYPREFIX" $2 > $2.tmp
 
-cat $2.tmp | sed 's/hash: .*$//g' > $2
-
-mv $2 $2.tmp
 cat $2.tmp | sed "s|${CHPL_HOME}|\$CHPL_HOME|g" > $2
 
 mv $2 $2.tmp

--- a/test/separate_compilation/serialization/testGenLib.standard.good
+++ b/test/separate_compilation/serialization/testGenLib.standard.good
@@ -1,3 +1,3 @@
-2 { fileTextQuery ("testGenLib.chpl") 
+Parsed file: testGenLib.chpl
 MYPREFIX: doMyM-doMyM-doMyM
 MYPREFIX: doMrehtO-doMrehtO-doMrehtO

--- a/util/chpl-completion.bash
+++ b/util/chpl-completion.bash
@@ -75,6 +75,7 @@ _chpl ()
 --dyno-scope-resolve \
 --dyno-verify-serialization \
 --early-deinit \
+--exit-leaks \
 --explain-call \
 --explain-call-id \
 --explain-instantiation \
@@ -203,6 +204,7 @@ _chpl ()
 --no-dyno-scope-resolve \
 --no-dyno-verify-serialization \
 --no-early-deinit \
+--no-exit-leaks \
 --no-explain-verbose \
 --no-fast-followers \
 --no-force-vectorize \

--- a/util/chpl-completion.bash
+++ b/util/chpl-completion.bash
@@ -67,6 +67,7 @@ _chpl ()
 --dyno \
 --dyno-break-error \
 --dyno-break-on-hash \
+--dyno-debug-print-parsed-files \
 --dyno-debug-trace \
 --dyno-gen-lib \
 --dyno-gen-std \
@@ -198,6 +199,7 @@ _chpl ()
 --no-dynamic-auto-local-access \
 --no-dyno \
 --no-dyno-break-error \
+--no-dyno-debug-print-parsed-files \
 --no-dyno-debug-trace \
 --no-dyno-scope-bundled \
 --no-dyno-scope-production \


### PR DESCRIPTION
This PR makes a number of changes that serve to improve the performance of `chpl` under `--dyno-scope-bundled.` They are as follows:

* Disable query tracing. This is currently done system-wide while this PR is a draft, but a merge-ready version of this PR should have some kind of build switch or configuration to disable query tracing when a release build is being created.
* Deliberately leak the memory associated with the Dyno context. This one might be a bit controversial. The Dyno context's destruct -- thanks to all the memoized queries -- takes 0.1s to run. We only ever `delete` it on `clean_exit`, which means that the OS is about to reclaim memory anyway.
* Reduce usage of `parentAst` in identifier lookups (specifically, the logic that checks for, and silences, warnings about nodes-in-calls (which are handled by call resolution). We already track if we're in the called expression of a call, so we can re-use that. This saves the -- costly -- `parentAst` lookups.
* Adjust logic in `validateAndSetToId` to use 'ID::parentSymbolId` instead of the `idToParentId` query; the former does not require any AST knowledge, which also reduces the reliance on `idToAst`. It also helps skip some intermediate (non-scope) IDs while traversing.
* Slightly re-order the checks in `astToAttributeGroup` to avoid as many `parentAst` lookups as possible. 
* Remove the logic that looks up `super` in scopes, since `super` is a reserved keyword with special meaning.
* In certain eligible conditions, skip checking scopes in favor of returning a ("found") ID() when looking up a well-known reserved name. E.g., looking up `int` cannot result in matches anywhere but the global scope (since `int` is a reserved keyword), so there's no reason to look it up in user modules.
* Rewrite the computation for transitively finding method receivers from inheritance chains to be recursive and re-use previous results.

The net result is that the following invocation:

```
chpl --no-compiler-driver --dyno-scope-bundled examples/hello.chpl --stop-after-pass=parseAndConvertUast 
```

Went from 1.3 seconds to 0.9 seconds on my local machine. This is a step forward, but is far from the 0.4s of the `--no-dyno-scope-resolve --stop-after-pass=scopeResolve` version of this command.

## Other notes
* Unsurprisingly, most of the time (900ms / 1.3s of the original execution) is spent in `doLookupInScope`
* From there, `scopeResolveFunction` takes 75% of the total execution time of `parseAndConvertUast`
* According to query timings, the `resolveVisibilityStmtsQuery` is still among the slowest self-queries we have (i.e., excluding child execution times). This might be unsurprising since it runs the non-query `doLookupInScope`.
* Noticed some minor overheads from constructing QueryMapResults. Tried switching them to use small pointer sets and small vectors, but that hurt instead of helping.

At this point, it seems like we might need some sort of lookup cache, since identifiers are looked up within modules many times. This is complicated by the fact that instead of "checked module for X", we have "checked module for X given the following filter flags", which makes it harder to detect when we can be sure that a symbol doesn't exist in a scope.

Reviewed by @mppf -- thanks!

## Testing
- [x] paratest