### PR TITLE
Update QUICKSTART.rst

### DIFF
--- a/doc/rst/usingchapel/QUICKSTART.rst
+++ b/doc/rst/usingchapel/QUICKSTART.rst
@@ -40,7 +40,9 @@ to :ref:`using-a-more-full-featured-chapel` below.
 
          cd chapel-2.0.0
 
-   c. Set up your environment for Chapel's Quickstart mode.
+   c. Make sure you are doing the install on a machine with > 4GB of memory.
+
+   d. Set up your environment for Chapel's Quickstart mode.
       If you are using a shell other than ``bash`` or ``zsh``,
       see :ref:`quickstart-with-other-shells` below.
 
@@ -48,7 +50,7 @@ to :ref:`using-a-more-full-featured-chapel` below.
 
          source util/quickstart/setchplenv.bash
 
-   d. Use GNU make to build Chapel.  On some systems, you may have to
+   e. Use GNU make to build Chapel.  On some systems, you may have to
       use ``gmake`` if ``make`` is not a GNU version.
 
       .. code-block:: bash

--- a/doc/rst/usingchapel/building.rst
+++ b/doc/rst/usingchapel/building.rst
@@ -4,6 +4,9 @@
 Building Chapel
 ===============
 
+Before getting started, be sure you are building Chapel on a machine
+that has more than 4GB of memory.
+
 To build the Chapel compiler, set up your environment as described in
 :ref:`readme-chplenv`, cd to ``$CHPL_HOME`` (the root directory of
 your unpacked Chapel release), and run GNU make.  This will build the


### PR DESCRIPTION
Update QUICKSTART.rst to include memory requirement for installation. Install fails on a machine with < 4GB of memory.

---
Signed-off-by: Bonnie Hurwitz <bhurwitz@arizona.edu>