### PR TITLE
Prediff out LLDB test line for `--memLeaks` being set

### DIFF
--- a/test/execflags/lldbddash/declint.prediff
+++ b/test/execflags/lldbddash/declint.prediff
@@ -9,6 +9,9 @@ set tmpfile = $outfile.raw.tmp
 #
 mv $outfile $tmpfile
 grep -v "Breakpoint 1: where" $tmpfile | grep -v "target create" | grep -v "Current executable set to" | grep -v "b gdbShouldBreakHere" > $outfile
+# Also filter out line about memleaks arguments to executable
+mv $outfile $tmpfile
+grep -v 'settings set -- target.run-args  "--memLeaks"' $tmpfile > $outfile
 rm $tmpfile
 
 #


### PR DESCRIPTION
The test `test/execflags/lldbddash/declint.chpl` has been failing in `memleaks` configuration since LLDB became available to it and the test was no longer `skipif`'d. This is because LLDB prints out a line about arguments to the executable being set (`--memLeaks` and `--memLeaksLog`) which doesn't apply otherwise. Prediff out these lines so the test can pass.

[reviewer info placeholder]

Testing:
- [x] test now passes in reproducer configuration
- [x] test still passes in non-memleaks configuration