### PR TITLE
Switch to using default LLVM version in valgrind tests

### DIFF
--- a/util/cron/test-valgrind.bash
+++ b/util/cron/test-valgrind.bash
@@ -7,9 +7,6 @@ source $CWD/common.bash
 source $CWD/common-valgrind.bash
 source $CWD/common-localnode-paratest.bash
 
-# Use LLVM-13 to work around https://github.com/Cray/chapel-private/issues/3373
-source /data/cf/chapel/setup_system_llvm.bash 13
-
 # valgrind serializes execution, so don't limit to one executable at a time
 unset CHPL_TEST_LIMIT_RUNNING_EXECUTABLES
 

--- a/util/cron/test-valgrindexe.bash
+++ b/util/cron/test-valgrindexe.bash
@@ -7,9 +7,6 @@ source $CWD/common.bash
 source $CWD/common-valgrind.bash
 source $CWD/common-localnode-paratest.bash
 
-# Use LLVM-13 to work around https://github.com/Cray/chapel-private/issues/3373
-source /data/cf/chapel/setup_system_llvm.bash 13
-
 # valgrind serializes execution, so don't limit to one executable at a time
 unset CHPL_TEST_LIMIT_RUNNING_EXECUTABLES
 


### PR DESCRIPTION
Remove workaround setting use of LLVM 13 in Valgrind nightly test configs, as it is no longer needed and causing [other problems](https://chapel.discourse.group/t/test-chapcs-correctness-test-valgrindexe/33620/3).

Resolves https://github.com/Cray/chapel-private/issues/3373.

[merging without review for expediency as the test is broken now anyways)