### PR TITLE
make moduleCheck more robust

### DIFF
--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -782,7 +782,7 @@ private proc ensureMasonProject(cwd : string, tomlName="Mason.toml") : string {
  */
 private proc moduleCheck(projectHome : string) throws {
   const files = listDir(projectHome + '/src', dirs=false),
-	modules = for f in files do if f.endsWith('.chpl') then f;
+        modules = for f in files do if f.endsWith('.chpl') then f;
   if modules.size != 1 then return false;
   if modules[0] != getPackageName() + '.chpl' then return false;
   return true;

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -781,7 +781,8 @@ private proc ensureMasonProject(cwd : string, tomlName="Mason.toml") : string {
 
  */
 private proc moduleCheck(projectHome : string) throws {
-  const modules = listDir(projectHome + '/src', dirs=false);
+  const files = listDir(projectHome + '/src', dirs=false),
+	modules = for f in files do if f.endsWith('.chpl') then f;
   if modules.size != 1 then return false;
   if modules[0] != getPackageName() + '.chpl' then return false;
   return true;


### PR DESCRIPTION
Follow-up of https://github.com/chapel-lang/chapel/pull/25084, make sure that `moduleCheck` only considers `.chpl` files, otherwise the following case

```
myPkg/
   src/
       myPkg.chpl
       notes.txt
```

would lead the check to fail