### PR TITLE
Make mason missing command errors more portable

### DIFF
--- a/test/mason/gitErrors.good
+++ b/test/mason/gitErrors.good
@@ -1,6 +1,1 @@
-git: 'ini' is not a git command. See 'git --help'.
-
-The most similar commands are
-	init
-	init-db
 MasonError: Command not found: 'git init'

--- a/test/mason/gitErrors.good
+++ b/test/mason/gitErrors.good
@@ -1,1 +1,1 @@
-MasonError: Command not found: 'git init'
+MasonError: Command failed: 'git init'

--- a/test/mason/gitErrors.good
+++ b/test/mason/gitErrors.good
@@ -1,2 +1,2 @@
-MasonError: Command failed: 'git init'
+MasonError: Command failed: 'git ini'
 MasonError: Command failed: 'git init'

--- a/test/mason/gitErrors.good
+++ b/test/mason/gitErrors.good
@@ -1,1 +1,2 @@
 MasonError: Command failed: 'git init'
+MasonError: Command failed: 'git init'

--- a/test/mason/gitErrors.prediff
+++ b/test/mason/gitErrors.prediff
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# prediff out anything thats not `MasonError`
+# the other messages are not portable to other systems
+
+cat $2 | grep "^MasonError:" > $2.prediff.tmp
+mv $2.prediff.tmp $2

--- a/test/mason/gitErrors.prediff
+++ b/test/mason/gitErrors.prediff
@@ -2,6 +2,9 @@
 
 # prediff out anything thats not `MasonError`
 # the other messages are not portable to other systems
-
 cat $2 | grep "^MasonError:" > $2.prediff.tmp
+mv $2.prediff.tmp $2
+
+# depending on the platform, the error message may be different
+cat $2 | sed 's/Command not found:/Command failed:/' > $2.prediff.tmp
 mv $2.prediff.tmp $2

--- a/test/mason/masonInit/masonInitTest3.good
+++ b/test/mason/masonInit/masonInitTest3.good
@@ -1,1 +1,1 @@
-Command not found: 'git init -q /path/to/masonInit'
+Command failed: 'git init -q /path/to/masonInit'

--- a/test/mason/masonInit/masonInitTest3.prediff
+++ b/test/mason/masonInit/masonInitTest3.prediff
@@ -3,3 +3,7 @@
 # remove the path after 'git init -q '
 cat $2 | sed 's|git init -q .*/masonInit|git init -q /path/to/masonInit|' > $2.prediff.tmp
 mv $2.prediff.tmp $2
+
+# depending on the platform, the error message may be different
+cat $2 | sed 's/Command not found:/Command failed:/' > $2.prediff.tmp
+mv $2.prediff.tmp $2

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -344,8 +344,12 @@ proc cloneMasonReg(username: string, safeDir : string, registryPath : string) th
 /* Checks to see if 'git config --get remote.origin.url' exists
  */
 proc doesGitOriginExist() {
-  var urlExists = runCommand("git config --get remote.origin.url", true);
-  return !urlExists.isEmpty();
+  try {
+    var urlExists = runCommand("git config --get remote.origin.url", true);
+    return !urlExists.isEmpty();
+  } catch {
+    return false;
+  }
 }
 
 
@@ -378,8 +382,12 @@ private proc getUsername() {
 /* Procedure that returns the url of the git remote origin
  */
 private proc gitUrl() {
-  var url = runCommand("git config --get remote.origin.url", true);
-  return url;
+  try {
+    var url = runCommand("git config --get remote.origin.url", true);
+    return url;
+  } catch {
+    return "";
+  }
 }
 
 /* Takes the git username and creates a new branch of the mason registry users fork,

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -115,6 +115,9 @@ proc runCommand(cmd, quiet=false) : string throws {
       while process.stderr.readLine(line) do write(line);
     }
     process.wait();
+    if process.exitCode != 0 {
+      throw new owned MasonError("Command failed: '" + cmd + "'");
+    }
   } catch e: FileNotFoundError {
     throw new owned MasonError("Command not found: '" + cmd + "'");
   } catch {

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -120,6 +120,8 @@ proc runCommand(cmd, quiet=false) : string throws {
     }
   } catch e: FileNotFoundError {
     throw new owned MasonError("Command not found: '" + cmd + "'");
+  } catch e: MasonError {
+    throw e;
   } catch {
     throw new owned MasonError("Internal mason error");
   }


### PR DESCRIPTION
This PR expands on the work in https://github.com/chapel-lang/chapel/pull/25069 to improve mason errors when dependencies (specifically git) are missing. This PR adds additional logic to account for portability issues exposed by nightly testing

Testing
- Tested the two tests added in #25069 pass on a Mac
- Tested `start_test test/mason` passes on linux x86
- Tested `start_test test/mason` passes on the nightly test machine (a slightly different linux x86)

[Reviewed by @benharsh]