### PR TITLE
Dyno: Improvements to tuple-grouped formals

### DIFF
--- a/frontend/include/chpl/uast/TupleDecl.h
+++ b/frontend/include/chpl/uast/TupleDecl.h
@@ -76,6 +76,7 @@ class TupleDecl final : public Decl {
   int numElements_;
   int typeExpressionChildNum_;
   int initExpressionChildNum_;
+  bool isTupleDeclFormal_;
 
   TupleDecl(AstList children, int attributeGroupChildNum, Decl::Visibility vis,
             Decl::Linkage linkage,
@@ -93,6 +94,14 @@ class TupleDecl final : public Decl {
       initExpressionChildNum_(initExpressionChildNum) {
 
     CHPL_ASSERT(assertAcceptableTupleDecl());
+
+    isTupleDeclFormal_ = false;
+    for (auto decl : decls()) {
+      if (decl->isFormal()) {
+        isTupleDeclFormal_ = true;
+        break;
+      }
+    }
   }
 
   void serializeInner(Serializer& ser) const override {
@@ -101,6 +110,7 @@ class TupleDecl final : public Decl {
     ser.writeVInt(numElements_);
     ser.writeVInt(typeExpressionChildNum_);
     ser.writeVInt(initExpressionChildNum_);
+    ser.write(isTupleDeclFormal_);
   }
 
   explicit TupleDecl(Deserializer& des)
@@ -109,6 +119,7 @@ class TupleDecl final : public Decl {
     numElements_ = des.readVInt();
     typeExpressionChildNum_ = des.readVInt();
     initExpressionChildNum_ = des.readVInt();
+    isTupleDeclFormal_ = des.read<bool>();
   }
 
   bool assertAcceptableTupleDecl();
@@ -120,7 +131,8 @@ class TupleDecl final : public Decl {
            lhs->intentOrKind_ == rhs->intentOrKind_ &&
            lhs->numElements_ == rhs->numElements_ &&
            lhs->typeExpressionChildNum_ == rhs->typeExpressionChildNum_ &&
-           lhs->initExpressionChildNum_ == rhs->initExpressionChildNum_;
+           lhs->initExpressionChildNum_ == rhs->initExpressionChildNum_ &&
+           lhs->isTupleDeclFormal_ == rhs->isTupleDeclFormal_;
   }
 
   void markUniqueStringsInner(Context* context) const override {
@@ -210,6 +222,13 @@ class TupleDecl final : public Decl {
     Returns a string describing the passed intentOrKind.
    */
   static const char* intentOrKindToString(IntentOrKind kind);
+
+  /**
+    Returns 'true' if this TupleDecl is a formal in a procedure.
+   */
+  const bool isTupleDeclFormal() const {
+    return isTupleDeclFormal_;
+  }
 };
 
 

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1921,7 +1921,6 @@ void Resolver::resolveTupleDecl(const TupleDecl* td,
     useT = QualifiedType(declKind, useType);
   } else if (substitutions != nullptr &&
              substitutions->count(td->id()) != 0) {
-    // TODO: should this be referential or value?
     auto sub = substitutions->find(td->id())->second;
     auto subTup = sub.hasTypePtr() ? sub.type()->toTupleType() : nullptr;
 

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1914,6 +1914,18 @@ void Resolver::resolveTupleDecl(const TupleDecl* td,
   // Figure out the type to use for this tuple
   if (useType != nullptr) {
     useT = QualifiedType(declKind, useType);
+  } else if (substitutions != nullptr &&
+             substitutions->count(td->id()) != 0) {
+    // TODO: should this be referential or value?
+    auto sub = substitutions->find(td->id())->second;
+    auto subTup = sub.hasTypePtr() ? sub.type()->toTupleType() : nullptr;
+
+    if (subTup == nullptr) {
+      // Rely on hasTypePtr check below to recognize error
+      useT = QualifiedType();
+    } else {
+      useT = sub;
+    }
   } else {
     QualifiedType typeExprT;
     QualifiedType initExprT;

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1904,6 +1904,13 @@ void Resolver::resolveTupleDecl(const TupleDecl* td,
   QualifiedType::Kind declKind = (Qualifier) td->intentOrKind();
   QualifiedType useT;
 
+  if (td->isTupleDeclFormal() && declKind != QualifiedType::DEFAULT_INTENT) {
+    useT = QualifiedType(declKind, ErroneousType::get(context));
+    ResolvedExpression& result = byPostorder.byAst(td);
+    result.setType(useT);
+    return;
+  }
+
   // Figure out the type to use for this tuple
   if (useType != nullptr) {
     useT = QualifiedType(declKind, useType);

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1904,6 +1904,11 @@ void Resolver::resolveTupleDecl(const TupleDecl* td,
   QualifiedType::Kind declKind = (Qualifier) td->intentOrKind();
   QualifiedType useT;
 
+  // Non-default intents are currently not allowed for tuple-grouped formals.
+  //
+  // Note: This doesn't apply to nested TupleDecls like ``(a, b)`` in the
+  // formal ``((a, b), c)``. Such nested formals should be handled by
+  // ``resolveTupleUnpackDecl``.
   if (td->isTupleDeclFormal() && declKind != QualifiedType::DEFAULT_INTENT) {
     useT = QualifiedType(declKind, ErroneousType::get(context));
     ResolvedExpression& result = byPostorder.byAst(td);

--- a/frontend/test/resolution/testTuples.cpp
+++ b/frontend/test/resolution/testTuples.cpp
@@ -599,6 +599,44 @@ static void test14() {
     assert(vars["varB"].type()->isRealType());
     assert(vars["varC"].type()->isStringType());
   }
+  {
+    Context ctx;
+    Context* context = &ctx;
+    ErrorGuard guard(context);
+
+    auto vars = resolveTypesOfVariables(context,
+                  R""""(
+                  proc baz(((a, b), c, d), param which : int) {
+                    if which == 0 then return a;
+                    else if which == 1 then return b;
+                    else if which == 2 then return c;
+                    else if which == 3 then return d;
+                    else return none;
+                  }
+
+                  var litA = baz(((1, 2.0), "test", 4:uint), 0);
+                  var litB = baz(((1, 2.0), "test", 4:uint), 1);
+                  var litC = baz(((1, 2.0), "test", 4:uint), 2);
+                  var litD = baz(((1, 2.0), "test", 4:uint), 3);
+
+                  var arg = ((1, 2.0), "test", 4:uint);
+                  var varA = baz(arg, 0);
+                  var varB = baz(arg, 1);
+                  var varC = baz(arg, 2);
+                  var varD = baz(arg, 3);
+                  )"""",
+                  {"litA", "litB", "litC", "litD",
+                   "varA", "varB", "varC", "varD"});
+    assert(vars["litA"].type()->isIntType());
+    assert(vars["litB"].type()->isRealType());
+    assert(vars["litC"].type()->isStringType());
+    assert(vars["litD"].type()->isUintType());
+
+    assert(vars["varA"].type()->isIntType());
+    assert(vars["varB"].type()->isRealType());
+    assert(vars["varC"].type()->isStringType());
+    assert(vars["varD"].type()->isUintType());
+  }
 }
 
 static void test15() {

--- a/frontend/test/resolution/testTuples.cpp
+++ b/frontend/test/resolution/testTuples.cpp
@@ -537,8 +537,8 @@ static void test14() {
                     var retTwo = foo((a, b, c));
                   )"""",
                   {"retOne", "retTwo"});
-    assert(!vars["retOne"].isUnknown());
-    assert(!vars["retTwo"].isUnknown());
+    assert(vars["retOne"].type()->isIntType());
+    assert(vars["retTwo"].type()->isIntType());
   }
   {
     Context ctx;

--- a/frontend/test/resolution/testTuples.cpp
+++ b/frontend/test/resolution/testTuples.cpp
@@ -491,26 +491,114 @@ static void test13() {
   assert(vt == tt);
 }
 
+// TupleDecl formals
 static void test14() {
   printf("test14\n");
-  Context ctx;
-  Context* context = &ctx;
 
-  auto qt = resolveTypeOfXInit(context,
-                R""""(
-                  proc f(x: int, (y, z): (real, int)) { return (x, y, z); }
-                  var x = f( 1, (2.0, 3) );
-                )"""");
+  {
+    Context ctx;
+    Context* context = &ctx;
+    ErrorGuard guard(context);
 
-  assert(qt.kind() == QualifiedType::CONST_VAR);
-  assert(qt.type()->isTupleType());
-  auto tt = qt.type()->toTupleType();
+    auto qt = resolveTypeOfXInit(context,
+                  R""""(
+                    proc f(x: int, (y, z): (real, int)) { return (x, y, z); }
+                    var x = f( 1, (2.0, 3) );
+                  )"""");
 
-  assert(tt->numElements() == 3);
-  assert(!tt->isStarTuple());
-  assert(tt->elementType(0).type()->isIntType());
-  assert(tt->elementType(1).type()->isRealType());
-  assert(tt->elementType(2).type()->isIntType());
+    assert(qt.kind() == QualifiedType::CONST_VAR);
+    assert(qt.type()->isTupleType());
+    auto tt = qt.type()->toTupleType();
+
+    assert(tt->numElements() == 3);
+    assert(!tt->isStarTuple());
+    assert(tt->elementType(0).type()->isIntType());
+    assert(tt->elementType(1).type()->isRealType());
+    assert(tt->elementType(2).type()->isIntType());
+  }
+
+  {
+    Context ctx;
+    Context* context = &ctx;
+    ErrorGuard guard(context);
+
+    // Using a homogeneous tuple type expression
+    auto vars = resolveTypesOfVariables(context,
+                  R""""(
+                    proc foo((x, y, z): 3*int) {
+                      return x;
+                    }
+
+                    var three = (1, 2, 3);
+                    var retOne = foo(three);
+
+                    var a, b, c : int;
+
+                    var retTwo = foo((a, b, c));
+                  )"""",
+                  {"retOne", "retTwo"});
+    assert(!vars["retOne"].isUnknown());
+    assert(!vars["retTwo"].isUnknown());
+  }
+  {
+    Context ctx;
+    Context* context = &ctx;
+    ErrorGuard guard(context);
+
+    auto qt = resolveTypeOfXInit(context,
+                  R""""(
+                  proc blah(type (a, b, c)) {
+                    var ret : a;
+                    return ret;
+                  }
+
+                  var x = blah((int, real, string));
+
+                  )"""");
+
+    assert(qt.isErroneousType());
+    assert(guard.numErrors() == 2);
+
+    // From post-parse-checks
+    auto& err = guard.error(0);
+    assert(err->message() == "intents on tuple-grouped arguments are not yet supported");
+
+    assert(guard.error(1)->type() == ErrorType::NoMatchingCandidates);
+
+    guard.realizeErrors();
+  }
+  {
+    Context ctx;
+    Context* context = &ctx;
+    ErrorGuard guard(context);
+
+    auto vars = resolveTypesOfVariables(context,
+                  R""""(
+                  proc baz((x, y, z), param which : int) {
+                    if which == 0 then return x;
+                    else if which == 1 then return y;
+                    else if which == 2 then return z;
+                    else return none;
+                  }
+
+                  var litA = baz((1, 2.0, "test"), 0);
+                  var litB = baz((1, 2.0, "test"), 1);
+                  var litC = baz((1, 2.0, "test"), 2);
+
+                  var three = (1, 2.0, "test");
+                  var varA = baz(three, 0);
+                  var varB = baz(three, 1);
+                  var varC = baz(three, 2);
+                  )"""",
+                  {"litA", "litB", "litC", "varA", "varB", "varC"});
+    assert(vars["litA"].type()->isIntType());
+    assert(vars["litB"].type()->isRealType());
+    assert(vars["litC"].type()->isStringType());
+
+    assert(vars["varA"].type()->isIntType());
+    assert(vars["varB"].type()->isRealType());
+    assert(vars["varC"].type()->isStringType());
+  }
 }
 
 static void test15() {

--- a/test/types/tuple/bharshbarg/intentTupleGroup.good
+++ b/test/types/tuple/bharshbarg/intentTupleGroup.good
@@ -1,1 +1,2 @@
+intentTupleGroup.chpl:1: In function 'foo':
 intentTupleGroup.chpl:1: error: intents on tuple-grouped arguments are not yet supported


### PR DESCRIPTION
This PR makes several improvements to the resolution of tuple-grouped formals in the frontend. After this PR, the following cases are now functional:
- tuple-grouped formal with a star-tuple type expression
- generic tuple-grouped formals (flat and nested)

This PR also adds an error for tuple-grouped formals with a non-default formal intent. This matches the production compiler's behavior.

Technical details:
- ``resolveTupleUnpackDecl`` is improved to better handle unknown or erroneous types
- ``TupleDecl::isTupleDeclFormal()`` has been added to aid in distinguishing such formals from variable declarations
- To allow generics, substitutions and star-tuples of ``AnyType`` were required

Testing:
- [x] test-dyno
- [x] local paratest