### PR TITLE
Clarify the issue templates w.r.t. workarounds and if the issue is blocking

### DIFF
--- a/.github/ISSUE_TEMPLATE/00-bug.md
+++ b/.github/ISSUE_TEMPLATE/00-bug.md
@@ -11,9 +11,10 @@ labels: 'type: Bug'
 <!--
 What behavior did you observe when encountering this issue?
 What behavior did you expect to observe?
+Describe any work-arounds you've considered, if any.
 -->
 
-**Is this a blocking issue with no known work-arounds?**
+**Is this issue currently blocking your progress?**
 <!-- Answer 'yes', 'no' or 'I don't know'. -->
 
 ### Steps to Reproduce

--- a/.github/ISSUE_TEMPLATE/00-bug.md
+++ b/.github/ISSUE_TEMPLATE/00-bug.md
@@ -11,11 +11,11 @@ labels: 'type: Bug'
 <!--
 What behavior did you observe when encountering this issue?
 What behavior did you expect to observe?
-Describe any work-arounds you've considered, if any.
+Describe the workarounds you've tried, if any.
 -->
 
 **Is this issue currently blocking your progress?**
-<!-- Answer 'yes', 'no' or 'I don't know'. -->
+<!-- Answer 'yes', 'no' or feel free to provide additional detail. -->
 
 ### Steps to Reproduce
 

--- a/.github/ISSUE_TEMPLATE/01-feature_request.md
+++ b/.github/ISSUE_TEMPLATE/01-feature_request.md
@@ -11,10 +11,10 @@ labels: 'type: Feature Request'
 <!--
 Is your feature request related to an issue? Please describe.
 Describe the solution you'd like.
-Describe any work-arounds you've considered.
+Describe any work-arounds you've considered, if any.
 -->
 
-**Is this a blocking issue with no known work-arounds?**
+**Is this issue currently blocking your progress?**
 <!-- Answer 'yes', 'no' or 'I don't know'. -->
 
 ### Code Sample

--- a/.github/ISSUE_TEMPLATE/01-feature_request.md
+++ b/.github/ISSUE_TEMPLATE/01-feature_request.md
@@ -11,11 +11,11 @@ labels: 'type: Feature Request'
 <!--
 Is your feature request related to an issue? Please describe.
 Describe the solution you'd like.
-Describe any work-arounds you've considered, if any.
+Describe the workarounds you've tried, if any.
 -->
 
 **Is this issue currently blocking your progress?**
-<!-- Answer 'yes', 'no' or 'I don't know'. -->
+<!-- Answer 'yes', 'no' or feel free to provide additional detail. -->
 
 ### Code Sample
 

--- a/.github/ISSUE_TEMPLATE/02-performance.md
+++ b/.github/ISSUE_TEMPLATE/02-performance.md
@@ -11,11 +11,11 @@ labels: 'type: Performance'
 <!--
 What behavior did you observe when encountering this issue?
 What behavior did you expect to observe?
-Describe any work-arounds you've considered, if any.
+Describe the workarounds you've tried, if any.
 -->
 
 **Is this issue currently blocking your progress?**
-<!-- Answer 'yes', 'no' or 'I don't know'. -->
+<!-- Answer 'yes', 'no' or feel free to provide additional detail. -->
 
 ### Steps to Reproduce
 

--- a/.github/ISSUE_TEMPLATE/02-performance.md
+++ b/.github/ISSUE_TEMPLATE/02-performance.md
@@ -11,9 +11,10 @@ labels: 'type: Performance'
 <!--
 What behavior did you observe when encountering this issue?
 What behavior did you expect to observe?
+Describe any work-arounds you've considered, if any.
 -->
 
-**Is this a blocking issue with no known work-arounds?**
+**Is this issue currently blocking your progress?**
 <!-- Answer 'yes', 'no' or 'I don't know'. -->
 
 ### Steps to Reproduce


### PR DESCRIPTION
We had a user recently seem confused whether calling the issue "blocking" was talking about the state of the project or their personal experience.  In response, it seemed like a good idea to adjust the request a bit.

Based on the structure of the feature request template, make the other two templates talk about potential work-arounds in the "Description" section, and make the request say "if any", so the user doesn't feel like they have to have looked into work-arounds themselves.

Transform the question about if it is blocking to not mention work-arounds and be more explicit about who is being blocked ("you", the person filing the request, though I would expect Chapel developers filing such issues to use their "user hat" and answer based on if they can accomplish what they are trying to do when they encountered the issue)