### PR TITLE
Fixes for Arkouda following GPU-based reduction

### DIFF
--- a/compiler/optimizations/noAliasSets.cpp
+++ b/compiler/optimizations/noAliasSets.cpp
@@ -657,7 +657,7 @@ void computeNoAliasSets() {
 
   {
     int id = 1;
-    forv_Vec(VarSymbol, var, gVarSymbols) {
+    for_alive_in_Vec(VarSymbol, var, gVarSymbols) {
       if (isGlobal(var) &&
           !var->isRef() &&
           isAddrTaken(var)) {
@@ -675,7 +675,7 @@ void computeNoAliasSets() {
 
   // Compute the starting point for the sets,
   // don't worry about transitivity/propagating yet.
-  forv_Vec(FnSymbol, fn, gFnSymbols) {
+  for_alive_in_Vec(FnSymbol, fn, gFnSymbols) {
     if (fnHasRefFormal(fn)) {
       if (fn->hasFlag(FLAG_EXPORT)) {
         // Assume exported functions can have formals aliasing each other
@@ -727,7 +727,7 @@ void computeNoAliasSets() {
 
   std::map<ArgSymbol*, std::set<ArgSymbol*> > bindingGraph;
 
-  forv_Vec(FnSymbol, p, gFnSymbols) {
+  for_alive_in_Vec(FnSymbol, p, gFnSymbols) {
     if (fnHasRefFormal(p)) {
       calls.clear();
       collectVirtualAndFnCalls(p, calls);
@@ -817,7 +817,7 @@ void computeNoAliasSets() {
 
   // Compute the maximum number of formals
   int maxFormals = 1;
-  forv_Vec(FnSymbol, fn, gFnSymbols) {
+  for_alive_in_Vec(FnSymbol, fn, gFnSymbols) {
     int nFormals = fn->numFormals();
     if (nFormals > maxFormals) {
       // If there are too many formals, don't do anything
@@ -856,7 +856,7 @@ void computeNoAliasSets() {
 
   // for each alias introduction site, e.g. f(X, X),
   // insert the resulting formal pair in fpairs and worklist
-  forv_Vec(FnSymbol, fn, gFnSymbols) {
+  for_alive_in_Vec(FnSymbol, fn, gFnSymbols) {
     if (fnHasRefFormal(fn)) {
       // Consider call sites to the function to propagate alias information
       for_SymbolSymExprs(se, fn) {
@@ -982,7 +982,7 @@ void computeNoAliasSets() {
 
   std::vector<ArgSymbol*> noAliasArgs;
 
-  forv_Vec(FnSymbol, p, gFnSymbols) {
+  for_alive_in_Vec(FnSymbol, p, gFnSymbols) {
     if (fnHasRefFormal(p)) {
       // Are the formals independent? Do they alias each other?
       int formalIdx1 = 1;
@@ -1041,7 +1041,7 @@ void computeNoAliasSets() {
 
 
   // Lastly, construct alias sets for local array variables.
-  forv_Vec(FnSymbol, fn, gFnSymbols) {
+  for_alive_in_Vec(FnSymbol, fn, gFnSymbols) {
     addNoAliasSetsInFn(fn);  // map from ArgSymbol -> BitVecs of size nAddrTakenGlobals
   }
 }

--- a/modules/standard/GPU.chpl
+++ b/modules/standard/GPU.chpl
@@ -451,7 +451,8 @@ module GPU
       compilerError("Unexpected reduction kind in doGpuReduce: ", op);
     }
 
-    param cTypeName = if      t==int(8)   then "int8_t"
+    param cTypeName = if      t==bool     then "chpl_bool"
+                      else if t==int(8)   then "int8_t"
                       else if t==int(16)  then "int16_t"
                       else if t==int(32)  then "int32_t"
                       else if t==int(64)  then "int64_t"
@@ -468,9 +469,14 @@ module GPU
                     " elements cannot be reduced with gpu*Reduce functions");
     }
 
+    proc valType(param op: string, const ref A: [] ?t) type {
+      if t==bool && op == "sum" then return int;
+      else return t;
+    }
+
     proc retType(param op: string, const ref A: [] ?t) type {
-      if isValReduce(op) then return A.eltType;
-      if isValIdxReduce(op) then return (A.eltType, int);
+      if isValReduce(op) then return valType(op, A);
+      if isValIdxReduce(op) then return (valType(op, A), int);
       compilerError("Unknown reduction operation: ", op);
     }
 
@@ -487,17 +493,17 @@ module GPU
     }
 
     proc doCpuReduce(param op: string, const ref A: [] ?t) {
+      var res: retType(op, A);
       if CHPL_GPU=="cpu" {
-        return doCpuReduceHelp(op, A);
+        res = doCpuReduceHelp(op, A): res.type;
       }
       else {
-        var res: retType(op, A);
         on here.parent {
           var HostArr = A;
-          res = doCpuReduceHelp(op, HostArr);
+          res = doCpuReduceHelp(op, HostArr): res.type;
         }
-        return res;
       }
+      return res;
     }
 
     proc getExternFuncName(param op: string, type t) param: string {
@@ -575,18 +581,14 @@ module GPU
     extern externFunc proc reduce_fn(data, size, ref val, ref idx);
 
     // initialize the return value
-    var ret;
+    var ret: retType(op, A);;
     if isValReduce(op) {
-      var retTmp: t;
-      if op == "min" then retTmp = max(t);
-      else if op == "max" then retTmp = min(t);
-      ret = retTmp;
+      if op == "min" then ret = max(t);
+      else if op == "max" then ret = min(t);
     }
     else if isValIdxReduce(op) {
-      var retTmp: (t, int);
-      if op == "minloc" then retTmp[0] = max(t);
-      else if op == "maxloc" then retTmp[0] = min(t);
-      ret = retTmp;
+      if op == "minloc" then ret[0] = max(t);
+      else if op == "maxloc" then ret[0] = min(t);
     }
     else {
       compilerError("Unknown reduction operation: ", op);
@@ -597,11 +599,12 @@ module GPU
     const basePtr = c_ptrToConst(A);
     for (offset,size) in offsetsThatCanFitIn32Bits(A.size) {
       var curIdx: int(32) = -1; // should remain -1 for sum, min, max
-      var curVal: t;
+      var curVal: valType(op, A);
       reduce_fn(basePtr+offset, size, curVal, curIdx);
       subReduceValIdx(op, offset, ret, (curVal, curIdx));
       if gpuDebugReduce then
-        writef(" (curVal=%i curIdx=%i ret=%?)\n", curVal, curIdx, ret);
+        writef(" (%s curVal=%i curIdx=%i ret=%?)\n", externFunc, curVal, curIdx,
+               ret);
     }
 
     if isValIdxReduce(op) then

--- a/runtime/include/gpu/chpl-gpu-reduce-util.h
+++ b/runtime/include/gpu/chpl-gpu-reduce-util.h
@@ -20,6 +20,7 @@
 #ifdef HAS_GPU_LOCALE
 
 #define GPU_DEV_CUB_WRAP(MACRO, impl_kind, chpl_kind) \
+  MACRO(impl_kind, chpl_kind, chpl_bool)  \
   MACRO(impl_kind, chpl_kind, int8_t)  \
   MACRO(impl_kind, chpl_kind, int16_t)  \
   MACRO(impl_kind, chpl_kind, int32_t)  \
@@ -32,6 +33,7 @@
   MACRO(impl_kind, chpl_kind, _real64);
 
 #define GPU_CUB_WRAP(MACRO, chpl_kind) \
+  MACRO(chpl_kind, chpl_bool)  \
   MACRO(chpl_kind, int8_t)  \
   MACRO(chpl_kind, int16_t)  \
   MACRO(chpl_kind, int32_t)  \

--- a/runtime/include/gpu/nvidia/chpl-gpu-dev-reduce.h
+++ b/runtime/include/gpu/nvidia/chpl-gpu-dev-reduce.h
@@ -35,6 +35,7 @@
   MACRO(impl_kind, chpl_kind, data_type, 1024) \
 
 #define GPU_DEV_REDUCE(MACRO, impl_kind, chpl_kind) \
+  GPU_DEV_REDUCE_SPECS(MACRO, impl_kind, chpl_kind, chpl_bool) \
   GPU_DEV_REDUCE_SPECS(MACRO, impl_kind, chpl_kind, int8_t) \
   GPU_DEV_REDUCE_SPECS(MACRO, impl_kind, chpl_kind, int16_t)  \
   GPU_DEV_REDUCE_SPECS(MACRO, impl_kind, chpl_kind, int32_t)  \

--- a/test/gpu/native/reduction/basic.chpl
+++ b/test/gpu/native/reduction/basic.chpl
@@ -34,7 +34,8 @@ proc testType(type t) {
       }
 
       // we cast to `t` to paper over the difference between the integral values
-      // returned from two different ways of sum-reducing bool arrays
+      // returned from two different ways (`gpuSumReduce` and `+ reduce`) of
+      // sum-reducing bool arrays
       writeln(op, ": ", if isTuple(res) then res:(t,int) else res:t);
     }
   }

--- a/test/gpu/native/reduction/basic.chpl
+++ b/test/gpu/native/reduction/basic.chpl
@@ -1,4 +1,5 @@
 use GPU;
+use GpuDiagnostics;
 use ChplConfig;
 
 config const useExpr = true;
@@ -32,7 +33,9 @@ proc testType(type t) {
         when "maxloc" do res=gpuMaxLocReduce(Arr);
       }
 
-      writeln(op, ": ", res);
+      // we cast to `t` to paper over the difference between the integral values
+      // returned from two different ways of sum-reducing bool arrays
+      writeln(op, ": ", if isTuple(res) then res:(t,int) else res:t);
     }
   }
 
@@ -45,6 +48,7 @@ proc testType(type t) {
   writeln();
 }
 
+testType(bool);
 testType(int(8));
 testType(int(16));
 testType(int(32));

--- a/test/gpu/native/reduction/basic.good
+++ b/test/gpu/native/reduction/basic.good
@@ -1,3 +1,10 @@
+Testing type bool
+sum: true
+min: false
+max: true
+minloc: (false, 0)
+maxloc: (true, 1)
+
 Testing type int(8)
 sum: 86
 min: 0


### PR DESCRIPTION
Arkouda+GPU compilation testing suffered as fallout from https://github.com/chapel-lang/chapel/pull/24787. The issues were twofold:

- Compiler segfault: In Arkouda, some order-independent loops are subject to what we call "late gpuization failure". In such cases, we generate a kernel, but then remove it from the AST. Removing a function from AST doesn't remove it from `gFnSymbols`. Scrubbing `gFnSymbols` et al. happens in between passes and removes such functions. However, `gpuTransforms` are technically part of LICM. After `gpuTransfroms` there are some LICM operations (that also seem unrelated to LICM, unfortunately) that iterate over `gFnSymbols`. One such operation would get the removed function from the AST that would cause segfaults down the road. As a solution, this PR uses `for_alive_in_Vec` in the problematic section of the code to avoid the issue. Note that I couldn't reproduce this issue outside of Arkouda.

- Linkage issues: fixing that exposed other linkage issues b/c Arkouda uses reductions on bools. It felt safe to just support those. So, this PR adds the ability to do reduction on bools.


#### Test:
- [x] arkouda compiles locally (well, there is another issue, but that needs to be fixed on Arkouda side. See https://github.com/Bears-R-Us/arkouda/pull/3236)
- [x] nvidia
- [x] amd
- [x] standard linux64