### PR TITLE
Add notes about other ways to solve the Optimizers library argument problem

### DIFF
--- a/test/library/draft/Optimizers/Optimizers.chpl
+++ b/test/library/draft/Optimizers/Optimizers.chpl
@@ -68,6 +68,12 @@ module Optimizers {
     /* The current value the argument is using */
     proc value {
       // TODO: update when support multiple argument types
+      // Stamping out a bunch of fields per supported argument type is annoying
+      // but generics makes it kinda necessary if we want to store wrappers of
+      // different argument types in the same list.
+      // Arkouda gets around this by having a concrete parent type and generic
+      // subtype (iirc), I think we could do something similar here.  We could
+      // potentially also manage this with a union.
       return intValue;
     }
 


### PR DESCRIPTION
In talking to Jade and David during the user support/stabilization subteam meeting today, I remembered a way Arkouda handles the "support multiple argument types leading to genericness when I want to store things in the same data structure" issue that this library will encounter when it extends the argument types it supports.  Jade also reminded me of the existence of unions.  Note both of these possible solutions for the future so we don't forget again by the time we get back to this library

Checked the tests of the draft library locally, but didn't run testing otherwise - it's a comment update, it shouldn't impact anything else.