### PR TITLE
Fix incorrect warning with chapel-py tools and CHPL_LLVM=none

### DIFF
--- a/tools/chapel-py/setup.py
+++ b/tools/chapel-py/setup.py
@@ -47,7 +47,7 @@ host_bin_subdir = str(chpl_variables.get("CHPL_HOST_BIN_SUBDIR"))
 chpl_lib_path = os.path.join(chpl_home, "lib", "compiler", host_bin_subdir)
 
 CXXFLAGS = []
-if have_llvm:
+if have_llvm and have_llvm != "none":
     CXXFLAGS += ["-DHAVE_LLVM"]
 
 CXXFLAGS += ["-Wno-c99-designator"]


### PR DESCRIPTION
Fixes an issue where users would get a misconfiguration warning erroneously.

With CHPL_LLVM=none, users would receive the following warning. This was a configuration issue with how chapel-py was being built.
```
Misconfiguration of the C++ Chapel compiler library
  headers in use with HAVE_LLVM defined
  .cpp files compiled without HAVE_LLVM defined
```

[Reviewed by @mppf]