### PR TITLE
Improve chapel-py errors when python versions are mismatched

### DIFF
--- a/test/chplcheck/SKIPIF
+++ b/test/chplcheck/SKIPIF
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-source $CHPL_HOME/util/config/run-in-venv-common.bash
-
-if python3 -c "import chapel" 2> /dev/null; then
+if $CHPL_HOME/util/config/run-in-venv-with-python-bindings.bash python3 -c "import chapel" 2> /dev/null; then
     echo "False"
 else
     echo "True"

--- a/test/chplcheck/fixit-interactive/SKIPIF
+++ b/test/chplcheck/fixit-interactive/SKIPIF
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-source $CHPL_HOME/util/config/run-in-venv-common.bash
-
-if python3 -c "import chapel" 2> /dev/null; then
+if $CHPL_HOME/util/config/run-in-venv-with-python-bindings.bash python3 -c "import chapel" 2> /dev/null; then
     echo "False"
 else
     echo "True"

--- a/third-party/chpl-venv/Makefile
+++ b/third-party/chpl-venv/Makefile
@@ -105,13 +105,13 @@ c2chapel-venv: install-chpldeps
 # like ok1/ok2.
 chapel-py-venv: FORCE $(CHPL_VENV_VIRTUALENV_DIR_OK)
 	@# Install chapel-py's Python package into the Python Application
-	@# directory structure at $(CHPL_VENV_CHPLDEPS_VERSIONED)
+	@# directory structure at $(CHPL_VENV_CHPL_FRONTEND_PY_DEPS)
 	@# this is python version specific
 	export PATH="$(CHPL_VENV_VIRTUALENV_BIN):$$PATH" && \
 	export VIRTUAL_ENV=$(CHPL_VENV_VIRTUALENV_DIR) && \
 	CHPL_HOME=$(CHPL_MAKE_HOME) $(PIP) install --upgrade \
 	  $(CHPL_PIP_INSTALL_PARAMS) $(LOCAL_PIP_FLAGS) \
-	  --target $(CHPL_VENV_CHPLDEPS_VERSIONED) \
+	  --target $(CHPL_VENV_CHPL_FRONTEND_PY_DEPS) \
 	  $(CHPL_MAKE_HOME)/tools/chapel-py \
 	  -r $(CHPL_VENV_CHAPEL_PY_REQUIREMENTS_FILE)
 	mkdir -p $(CHPL_MAKE_HOME)/tools/chapel-py/src/chapel/core

--- a/third-party/chpl-venv/Makefile
+++ b/third-party/chpl-venv/Makefile
@@ -105,12 +105,13 @@ c2chapel-venv: install-chpldeps
 # like ok1/ok2.
 chapel-py-venv: FORCE $(CHPL_VENV_VIRTUALENV_DIR_OK)
 	@# Install chapel-py's Python package into the Python Application
-	@# directory structure at $(CHPL_VENV_CHPLDEPS)
+	@# directory structure at $(CHPL_VENV_CHPLDEPS_VERSIONED)
+	@# this is python version specific
 	export PATH="$(CHPL_VENV_VIRTUALENV_BIN):$$PATH" && \
 	export VIRTUAL_ENV=$(CHPL_VENV_VIRTUALENV_DIR) && \
 	CHPL_HOME=$(CHPL_MAKE_HOME) $(PIP) install --upgrade \
 	  $(CHPL_PIP_INSTALL_PARAMS) $(LOCAL_PIP_FLAGS) \
-	  --target $(CHPL_VENV_CHPLDEPS) \
+	  --target $(CHPL_VENV_CHPLDEPS_VERSIONED) \
 	  $(CHPL_MAKE_HOME)/tools/chapel-py \
 	  -r $(CHPL_VENV_CHAPEL_PY_REQUIREMENTS_FILE)
 	mkdir -p $(CHPL_MAKE_HOME)/tools/chapel-py/src/chapel/core

--- a/third-party/chpl-venv/Makefile.include
+++ b/third-party/chpl-venv/Makefile.include
@@ -32,4 +32,5 @@ CHPL_VENV_VIRTUALENV_DIR_DEPS2_OK=$(CHPL_VENV_BUILD)/build-venv/ok2
 CHPL_VENV_VIRTUALENV_BIN=$(CHPL_VENV_VIRTUALENV_DIR)/bin
 CHPL_VENV_INSTALL=$(CHPL_VENV_DIR)/install
 CHPL_VENV_CHPLDEPS=$(CHPL_VENV_INSTALL)/chpldeps
+CHPL_VENV_CHPLDEPS_VERSIONED=$(CHPL_VENV_INSTALL)/chpldeps-py$(shell $(PYTHON) -c 'import sys; print(str(sys.version_info.major) + str(sys.version_info.minor))')
 CHPL_VENV_CHPLDEPS_MAIN=$(CHPL_VENV_CHPLDEPS)/__main__.py

--- a/third-party/chpl-venv/Makefile.include
+++ b/third-party/chpl-venv/Makefile.include
@@ -32,5 +32,5 @@ CHPL_VENV_VIRTUALENV_DIR_DEPS2_OK=$(CHPL_VENV_BUILD)/build-venv/ok2
 CHPL_VENV_VIRTUALENV_BIN=$(CHPL_VENV_VIRTUALENV_DIR)/bin
 CHPL_VENV_INSTALL=$(CHPL_VENV_DIR)/install
 CHPL_VENV_CHPLDEPS=$(CHPL_VENV_INSTALL)/chpldeps
-CHPL_VENV_CHPLDEPS_VERSIONED=$(CHPL_VENV_INSTALL)/chpldeps-py$(shell $(PYTHON) -c 'import sys; print(str(sys.version_info.major) + str(sys.version_info.minor))')
+CHPL_VENV_CHPL_FRONTEND_PY_DEPS=$(CHPL_VENV_INSTALL)/chpl-frontend-py-deps-py$(shell $(PYTHON) -c 'import sys; print(str(sys.version_info.major) + str(sys.version_info.minor))')
 CHPL_VENV_CHPLDEPS_MAIN=$(CHPL_VENV_CHPLDEPS)/__main__.py

--- a/util/chplenv/chpl_home_utils.py
+++ b/util/chplenv/chpl_home_utils.py
@@ -4,7 +4,6 @@ import optparse
 import os
 import re
 import sys
-import glob
 
 import chpl_bin_subdir, chpl_python_version, overrides
 from utils import memoize

--- a/util/chplenv/chpl_home_utils.py
+++ b/util/chplenv/chpl_home_utils.py
@@ -93,7 +93,7 @@ def get_chpldeps(version=None):
     if version is None:
         chpl_venv = os.path.join(base, "chpldeps")
     else:
-        chpl_venv = os.path.join(base, "chpldeps-py" + str(version))
+        chpl_venv = os.path.join(base, "chpl-frontend-py-deps-py" + str(version))
     return chpl_venv
 
 @memoize

--- a/util/chplenv/chpl_home_utils.py
+++ b/util/chplenv/chpl_home_utils.py
@@ -4,6 +4,7 @@ import optparse
 import os
 import re
 import sys
+import glob
 
 import chpl_bin_subdir, chpl_python_version, overrides
 from utils import memoize
@@ -88,9 +89,12 @@ def add_vars_to_paths(s):
 # Get the chpl-venv install directory:
 # $CHPL_HOME/third-party/chpl-venv/install/chpldeps
 @memoize
-def get_chpldeps():
-    chpl_venv = os.path.join(get_chpl_third_party(), 'chpl-venv',
-                             'install', 'chpldeps')
+def get_chpldeps(version=None):
+    base = os.path.join(get_chpl_third_party(), "chpl-venv", "install")
+    if version is None:
+        chpl_venv = os.path.join(base, "chpldeps")
+    else:
+        chpl_venv = os.path.join(base, "chpldeps-py" + str(version))
     return chpl_venv
 
 @memoize
@@ -110,6 +114,14 @@ def _main():
                       dest='func', const=get_chpl_third_party)
     parser.add_option('--chpldeps', action='store_const',
                       dest='func', const=get_chpldeps)
+    parser.add_option(
+        "--chpldeps-version",
+        action="store_const",
+        dest="func",
+        const=lambda: get_chpldeps(
+            str(sys.version_info.major) + str(sys.version_info.minor)
+        ),
+    )
     parser.add_option('--using-module', action='store_const',
                       dest='func', const=using_chapel_module)
     (options, args) = parser.parse_args()

--- a/util/config/run-in-venv-common.bash
+++ b/util/config/run-in-venv-common.bash
@@ -11,7 +11,7 @@ python=$($CHPL_HOME/util/config/find-python.sh)
 chpldeps=$("$python" "$CHPL_HOME/util/chplenv/chpl_home_utils.py" --chpldeps)
 
 if [ ! -e "$chpldeps" ]; then
-  echo "chpl dependencies are missing - try make test-venv or make chapel-py-venv" 1>&2
+  echo "chpl dependencies are missing - try make test-venv" 1>&2
   exit 1
 fi
 

--- a/util/config/run-in-venv-common.bash
+++ b/util/config/run-in-venv-common.bash
@@ -10,10 +10,5 @@ fi
 python=$($CHPL_HOME/util/config/find-python.sh)
 chpldeps=$("$python" "$CHPL_HOME/util/chplenv/chpl_home_utils.py" --chpldeps)
 
-if [ ! -e "$chpldeps" ]; then
-  echo "chpl dependencies are missing - try make test-venv" 1>&2
-  exit 1
-fi
-
 # include the dependencies
 export PYTHONPATH="$chpldeps":$PYTHONPATH

--- a/util/config/run-in-venv-with-python-bindings.bash
+++ b/util/config/run-in-venv-with-python-bindings.bash
@@ -7,8 +7,13 @@ CWD=$(cd $(dirname $0) ; pwd)
 # Perform checks and set up environment variables for virtual env.
 source $CWD/run-in-venv-common.bash
 
-if [ ! -d "$chpldeps/chapel" ]; then
-  echo "chapel python bindings not built - try make chapel-py-venv " 1>&2
+chpldeps_version=$("$python" "$CHPL_HOME/util/chplenv/chpl_home_utils.py" --chpldeps-version)
+export PYTHONPATH="$chpldeps_version":$PYTHONPATH
+
+if [ ! -d "$chpldeps_version/chapel" ]; then
+  python_version=$("$python" -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')
+  echo "chapel python bindings are not built for python ${python_version}" 1>&2
+  echo "make sure your current python version matches the one used to build chapel" 1>&2
   exit 1
 fi
 

--- a/util/config/run-in-venv-with-python-bindings.bash
+++ b/util/config/run-in-venv-with-python-bindings.bash
@@ -7,10 +7,10 @@ CWD=$(cd $(dirname $0) ; pwd)
 # Perform checks and set up environment variables for virtual env.
 source $CWD/run-in-venv-common.bash
 
-chpldeps_version=$("$python" "$CHPL_HOME/util/chplenv/chpl_home_utils.py" --chpldeps-version)
-export PYTHONPATH="$chpldeps_version":$PYTHONPATH
+chpl_frontend_py_deps=$("$python" "$CHPL_HOME/util/chplenv/chpl_home_utils.py" --chpldeps-version)
+export PYTHONPATH="$chpl_frontend_py_deps":$PYTHONPATH
 
-if [ ! -d "$chpldeps_version/chapel" ]; then
+if [ ! -d "$chpl_frontend_py_deps/chapel" ]; then
   python_version=$("$python" -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')
   echo "chapel python bindings are not built for python ${python_version}" 1>&2
   echo "make sure your current python version matches the one used to build chapel" 1>&2


### PR DESCRIPTION
This PR significantly improves the errors users get when they try and use a chapel-py based tool with mismatched python versions.

This PR splits the chpldeps install directory into general dependencies and python version specific dependencies. This allows the `run-in-venv-with-python-bindings` script to be able to easily distinguish python versions. This also allows builds for multiple python versions to live side-by-side, without needing to `make clobber`.

Resolves https://github.com/chapel-lang/chapel/issues/24892

Tested locally, switching between python3.11 and python3.12

[Reviewed by @mppf and @DanilaFe]
