### PR TITLE
Look for sinfo error message anywhere in its output

### DIFF
--- a/runtime/src/launch/slurm-srun/launch-slurm-srun.c
+++ b/runtime/src/launch/slurm-srun/launch-slurm-srun.c
@@ -143,8 +143,7 @@ static int getCoresPerLocale(int nomultithread, int32_t localesPerNode) {
     chpl_error("Error trying to determine number of cores per node", 0, 0);
   }
 
-  if (!strncmp("Invalid node format specification: i", buf,
-               strlen("Invalid node format specification: i"))) {
+  if (strstr(buf, "Invalid node format specification: i")) {
     // older versions of sinfo don't support the %i format. Try again
     // without it. We won't be able to exclude reservations, but there's
     // not much we can do about that.


### PR DESCRIPTION
It appears that sometimes the `sinfo` error message about an invalid format specification is not in the first line of output. Change to use `strstr` so we find it anywhere in the output.