### PR TITLE
Skip future for ARCH=x86

### DIFF
--- a/test/functions/generic/type-func-return-generic.skipif
+++ b/test/functions/generic/type-func-return-generic.skipif
@@ -1,2 +1,3 @@
-# this works fine on linux64
-CHPL_TARGET_PLATFORM==linux64
+# this only crashes on x86 due to use-after-free in the compiler
+CHPL_TARGET_ARCH==x86_64
+CHPL_TARGET_ARCH==x86


### PR DESCRIPTION
Skip a future for all x86 architectures (64 bit and 32 bit). This future passes on x86, but continues to fail on ARM

[Reviewed by @stonea]