### PR TITLE
Add skipif for valgrind for gitErrors test

### DIFF
--- a/test/mason/gitErrors.skipif
+++ b/test/mason/gitErrors.skipif
@@ -1,0 +1,2 @@
+# valgrind duplicates the output of a program when a subprocess has an error and captures it with `pipeStyle.pipe`
+CHPL_TEST_VGRND_EX==on


### PR DESCRIPTION
Skip this test for valgrind testing only, as valgrind interacts strangely with subprocesses that capture stdout/stderr (https://github.com/chapel-lang/chapel/issues/25130).

[Not reviewed - trivial]