### PR TITLE
update mason test .good file to match help output after removing 'new'

### DIFF
--- a/test/mason/mason-help-tests/masonHelpTests.good
+++ b/test/mason/mason-help-tests/masonHelpTests.good
@@ -1,7 +1,6 @@
 $ mason new -h
 Usage:
     mason new [options] <project name>
-    mason new                    Starts an interactive session
 
 Options:
     -h, --help                   Display this message


### PR DESCRIPTION
Fixes a mason test `.good` file to match the output from `--help` since the documentation was updated in https://github.com/chapel-lang/chapel/pull/25099

TESTING:

- [x] `mason/mason-help-tests/masonHelpTests` passes


[trivial change to test `.good` file only, not reviewed]