### PR TITLE
Add proto testing for Arkouda nightly

### DIFF
--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -100,6 +100,14 @@ if [ ${CHPL_TEST_ARKOUDA_STOP_AFTER_BUILD} = "false" ]; then
   fi
   test_end
 
+  test_start "make test-proto"
+  if make test-proto ; then
+    log_success "make test-proto output"
+  else
+    log_error "running make test-proto"
+  fi
+  test_end
+
   # Run benchmarks
   if [ "${CHPL_TEST_ARKOUDA_PERF}" = "true" ] ; then
     benchmark_opts="--save-data --dat-dir $CHPL_TEST_PERF_DIR --gen-graphs --graph-dir $CHPL_TEST_PERF_DIR/html"


### PR DESCRIPTION
The Arkouda devs are planning to switch to a new set of unit tests, so we are starting to run those in nightly now before officially making that change on the Arkouda side of things.