### PR TITLE
Add the missing reduce helper decl in AMD runtime, too

### DIFF
--- a/runtime/include/gpu/amd/chpl-gpu-dev-reduce.h
+++ b/runtime/include/gpu/amd/chpl-gpu-dev-reduce.h
@@ -44,6 +44,7 @@
   MACRO(impl_kind, chpl_kind, data_type, 1024) \
 
 #define GPU_DEV_REDUCE(MACRO, impl_kind, chpl_kind) \
+  GPU_DEV_REDUCE_SPECS(MACRO, impl_kind, chpl_kind, chpl_bool) \
   GPU_DEV_REDUCE_SPECS(MACRO, impl_kind, chpl_kind, int8_t) \
   GPU_DEV_REDUCE_SPECS(MACRO, impl_kind, chpl_kind, int16_t)  \
   GPU_DEV_REDUCE_SPECS(MACRO, impl_kind, chpl_kind, int32_t)  \


### PR DESCRIPTION
This is a small patch symmetric to the one I added here: https://github.com/chapel-lang/chapel/pull/25108/files#diff-fd9cac0eea147dc210859903e7107766edc1abaeb335360064f415f1ba1f0571. I missed the AMD side as our typical manual test system doesn't have the correct ROCm version and the reduction tests are skipped.

Test:
- [x] `gpu/native/reductions/basic` on AMD