### PR TITLE
Add support for GASNet PSHM and send progress thread

### DIFF
--- a/runtime/include/tasks/qthreads/chpl-tasks-impl-fns.h
+++ b/runtime/include/tasks/qthreads/chpl-tasks-impl-fns.h
@@ -76,10 +76,11 @@ typedef struct chpl_qthread_tls_s {
 } chpl_qthread_tls_t;
 
 extern pthread_t chpl_qthread_process_pthread;
-extern pthread_t chpl_qthread_comm_pthread;
+extern int chpl_qthread_comm_num_pthreads;
+extern pthread_t *chpl_qthread_comm_pthreads;
 
 extern chpl_qthread_tls_t chpl_qthread_process_tls;
-extern chpl_qthread_tls_t chpl_qthread_comm_task_tls;
+extern chpl_qthread_tls_t *chpl_qthread_comm_task_tls;
 
 // Wrap qthread_get_tasklocal().
 static inline chpl_qthread_tls_t* chpl_qthread_get_tasklocal(void)
@@ -91,10 +92,17 @@ static inline chpl_qthread_tls_t* chpl_qthread_get_tasklocal(void)
                qthread_get_tasklocal(sizeof(chpl_qthread_tls_t));
         if (tls == NULL) {
             pthread_t me = pthread_self();
-            if (pthread_equal(me, chpl_qthread_comm_pthread))
-                tls = &chpl_qthread_comm_task_tls;
-            else if (pthread_equal(me, chpl_qthread_process_pthread))
+            if (pthread_equal(me, chpl_qthread_process_pthread)) {
                 tls = &chpl_qthread_process_tls;
+            } else {
+                assert(chpl_qthread_comm_pthreads != NULL);
+                for (int i = 0; i < chpl_qthread_comm_num_pthreads; i++) {
+                    if (pthread_equal(me, chpl_qthread_comm_pthreads[i])) {
+                        tls = &chpl_qthread_comm_task_tls[i];
+                        break;
+                    }
+                }
+            }
         }
     }
     else

--- a/runtime/src/comm/gasnet/comm-gasnet-ex.c
+++ b/runtime/src/comm/gasnet/comm-gasnet-ex.c
@@ -1015,6 +1015,11 @@ void chpl_comm_post_task_init(void) {
 #if defined(GASNET_CONDUIT_IBV)
   if ((verbosity >= 2) && (chpl_nodeID == 0)) {
     printf("PSHM is %s.\n", pshmInUse? "enabled" : "disabled");
+    chpl_bool enabled = chpl_env_str_to_bool("GASNET_SND_THREAD",
+                                             getenv("GASNET_SND_THREAD"),
+                                             false);
+    printf("GASNet send progress thread is %s.\n", enabled ? "enabled" :
+          "disabled");
   }
 #endif
 }

--- a/runtime/src/comm/gasnet/comm-gasnet-ex.c
+++ b/runtime/src/comm/gasnet/comm-gasnet-ex.c
@@ -897,7 +897,7 @@ void chpl_comm_init(int *argc_p, char ***argv_p) {
   if (!usePSHM) {
     // Setting this to 1 will disable PSHM even if it was enabled during
     // GASNet configuration.
-    chpl_env_set("GASNET_SUPERNODE_MAXSIZE", "1", 1);
+    chpl_env_set("GASNET_SUPERNODE_MAXSIZE", "1", 0);
   }
 
   setup_polling_pre_init();

--- a/runtime/src/comm/gasnet/comm-gasnet-ex.c
+++ b/runtime/src/comm/gasnet/comm-gasnet-ex.c
@@ -766,7 +766,7 @@ static void setup_polling_pre_init(void) {
 
   // If there is a send thread give it exclusive access to the NIC. This
   // has no effect if there isn't a send thread.
-  chpl_env_set("GASNET_SND_THREAD_POLL_MODE", "exclusive", 1 /*overwrite*/);
+  chpl_env_set("GASNET_SND_THREAD_POLL_MODE", "exclusive", 0 /*overwrite*/);
 #endif
 }
 

--- a/runtime/src/comm/gasnet/comm-gasnet-ex.c
+++ b/runtime/src/comm/gasnet/comm-gasnet-ex.c
@@ -52,6 +52,8 @@
 #include <assert.h>
 #include <time.h>
 
+static int reservedCore = -1;
+
 #define GEX_NO_FLAGS 0
 
 static gasnet_seginfo_t* seginfo_table = NULL;
@@ -723,7 +725,7 @@ int32_t chpl_comm_getMaxThreads(void) {
 //
 static volatile int pollingRunning;
 static volatile int pollingQuit;
-static chpl_bool pollingRequired;
+static chpl_bool pollingRequired = false;
 static atomic_spinlock_t pollingLock;
 
 static inline void am_poll_try(void) {
@@ -751,11 +753,31 @@ static void polling(void* x) {
   pollingRunning = 0;
 }
 
-static void setup_polling(void) {
+static void setup_polling_pre_init(void) {
   atomic_init_spinlock_t(&pollingLock);
 #if defined(GASNET_CONDUIT_IBV)
-  pollingRequired = false;
-  chpl_env_set("GASNET_RCV_THREAD", "1", 1);
+  // We might want a GASNet receive progress thread. Note that in
+  // start_gasnet_progress_threads we may decide not to create it.
+  chpl_env_set("GASNET_RCV_THREAD", "1", 1 /*overwrite*/);
+
+  // By default we want a GASNet send progress thread. Note that we do
+  // not override any existing value, so the user can disable it if desired.
+  chpl_env_set("GASNET_SND_THREAD", "1", 0 /*overwrite*/);
+
+  // If there is a send thread give it exclusive access to the NIC. This
+  // has no effect if there isn't a send thread.
+  chpl_env_set("GASNET_SND_THREAD_POLL_MODE", "exclusive", 1 /*overwrite*/);
+#endif
+}
+
+static void setup_polling_post_init(void) {
+#if defined(GASNET_CONDUIT_IBV)
+
+  // Co-locales use PSHM to communicate, which requires an external progress
+  // thread.
+  gex_Rank_t numColocales;
+  gex_System_QueryNbrhdInfo(NULL, &numColocales, NULL);
+  pollingRequired = numColocales > 1;
 #else
   pollingRequired = true;
 #endif
@@ -767,8 +789,8 @@ static void start_polling(void) {
   pollingRunning = 0;
   pollingQuit = 0;
 
-  if (chpl_task_createCommTask(polling, NULL, -1)) {
-    chpl_internal_error("unable to start polling task for gasnet");
+  if (chpl_task_createCommTask(polling, NULL, reservedCore)) {
+    chpl_internal_error("unable to start external GASNet progress thread");
   }
 
   while (!pollingRunning) {
@@ -862,20 +884,27 @@ void chpl_comm_init(int *argc_p, char ***argv_p) {
   set_max_segsize();
   set_num_comm_domains();
   setup_ibv();
-  setup_polling();
+  setup_polling_pre_init();
+  GASNET_Safe(gex_Client_Init(&myclient, &myep, &myteam, "chapel",
+                              argc_p, argv_p,
+                              GEX_FLAG_USES_GASNET1 |
+                              GEX_FLAG_DEFER_THREADS));
 
-  GASNET_Safe(gex_Client_Init(&myclient, &myep, &myteam, "chapel", argc_p, argv_p, GEX_FLAG_USES_GASNET1));
-
+  setup_polling_post_init();
   chpl_nodeID = gasnet_mynode();
   chpl_numNodes = gasnet_nodes();
 
-  // get information about locales on the same node
+  // get information about co-locales
   gex_System_QueryHostInfo(NULL, &infoCount, &myIndex);
   chpl_set_num_locales_on_node((int32_t) infoCount);
   chpl_set_local_rank(myIndex);
 }
 
 void chpl_comm_pre_mem_init(void) {
+
+  if (chpl_env_rt_get_bool("COMM_GASNET_DEDICATED_PROGRESS_CORE", false)) {
+    reservedCore = chpl_topo_reserveCPUPhysical();
+  }
   GASNET_Safe(gex_Segment_Attach(&mysegment, myteam, gasnet_getMaxLocalSegmentSize()));
   GASNET_Safe(gex_EP_RegisterHandlers(myep, ftable, sizeof(ftable)/sizeof(gex_AM_Entry_t)));
 
@@ -924,7 +953,6 @@ void chpl_comm_pre_mem_init(void) {
   gex_Event_Wait(gex_Coll_BroadcastNB(myteam, 0, seginfo_table, seginfo_table, sizeof(gasnet_seginfo_t), GEX_NO_FLAGS));
   chpl_comm_barrier("making sure everyone's done with the broadcast");
 #endif
-
   gasnet_set_waitmode(GASNET_WAIT_BLOCK);
 }
 
@@ -946,8 +974,27 @@ int chpl_comm_run_in_lldb(int argc, char* argv[], int lldbArgnum, int* status) {
   return 0;
 }
 
+static void start_gasnet_progress_threads(void) {
+  unsigned int count;
+  const gex_ProgressThreadInfo_t *info;
+  GASNET_Safe(gex_System_QueryProgressThreads(myclient, &count, &info, 0) );
+  for (int i = 0; i < count; i++) {
+
+    // Don't create an internal receive thread if there is an external one
+    if (pollingRequired &&
+        (info[i].gex_thread_roles == GEX_THREAD_ROLE_RCV)) {
+      continue;
+    }
+    if (chpl_task_createCommTask((chpl_fn_p) info[i].gex_progress_fn,
+                                 info[i].gex_progress_arg, reservedCore)) {
+      chpl_internal_error("unable to start internal GASNet progress thread");
+    }
+  }
+}
+
 void chpl_comm_post_task_init(void) {
   start_polling();
+  start_gasnet_progress_threads();
 }
 
 void chpl_comm_rollcall(void) {

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -868,6 +868,11 @@ void chpl_comm_init(int *argc_p, char ***argv_p) {
   setup_ibv();
   setup_polling();
 
+  // Setting this to 1 will disable PSHM even if it was enabled during
+  // configuration. PSHM requires an external progress thread, which this
+  // shim doesn't create.
+  chpl_env_set("GASNET_SUPERNODE_MAXSIZE", "1", 1);
+
   assert(sizeof(gasnet_handlerarg_t)==sizeof(uint32_t));
 
   gasnet_init(argc_p, argv_p);

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -876,11 +876,6 @@ void chpl_comm_init(int *argc_p, char ***argv_p) {
     chpl_env_set("GASNET_SUPERNODE_MAXSIZE", "1", 0);
   }
 
-  // Setting this to 1 will disable PSHM even if it was enabled during
-  // configuration. PSHM requires an external progress thread, which this
-  // shim doesn't create.
-  chpl_env_set("GASNET_SUPERNODE_MAXSIZE", "1", 1);
-
   assert(sizeof(gasnet_handlerarg_t)==sizeof(uint32_t));
 
   gasnet_init(argc_p, argv_p);

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -868,6 +868,14 @@ void chpl_comm_init(int *argc_p, char ***argv_p) {
   setup_ibv();
   setup_polling();
 
+  // PSHM needs an external progress thread to guarantee AM handlers make
+  // progress in the absence of other GASNet calls, so if we've disabled our
+  // external progress thread then we should disable PSHM
+  if (!pollingRequired) {
+    // disable PSHM even if it was enabled during configuration.
+    chpl_env_set("GASNET_SUPERNODE_MAXSIZE", "1", 0);
+  }
+
   // Setting this to 1 will disable PSHM even if it was enabled during
   // configuration. PSHM requires an external progress thread, which this
   // shim doesn't create.

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -904,7 +904,10 @@ static void *comm_task_trampoline(void *arg)
                      "binding comm task to CPU %d failed", rarg->cpu);
             chpl_warning(msg, 0, 0);
         }
-        _DBG_P("comm task bound to CPU %d", rarg->cpu);
+        if (verbosity >= 2) {
+            // TODO: it would be better if only locales on node 0 printed this
+            printf("comm task bound to CPU %d\n", rarg->cpu);
+        }
     } else {
         int rc = chpl_topo_bindLogAccCPUs();
         if (rc) {
@@ -912,7 +915,9 @@ static void *comm_task_trampoline(void *arg)
                 "binding comm task to accessible PUs failed",
                 0, 0);
         }
-        _DBG_P("comm task bound to accessible PUs");
+        if ((verbosity >= 2) && (chpl_nodeID == 0)) {
+            printf("comm task bound to accessible PUs\n");
+        }
     }
     int rc = pthread_create(rarg->thread, NULL, comm_task_wrapper, rarg);
     if (rc) {

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -154,7 +154,10 @@ static aligned_t next_task_id = 1;
 static pthread_t initer;
 
 pthread_t chpl_qthread_process_pthread;
-pthread_t chpl_qthread_comm_pthread;
+
+int chpl_qthread_comm_num_pthreads = 0;
+int chpl_qthread_comm_max_pthreads = 0;
+pthread_t *chpl_qthread_comm_pthreads = NULL;
 
 chpl_task_bundle_t chpl_qthread_process_bundle = {
                                    .kind = CHPL_ARG_BUNDLE_KIND_TASK,
@@ -166,7 +169,7 @@ chpl_task_bundle_t chpl_qthread_process_bundle = {
                                    .requested_fn = NULL,
                                    .id = chpl_nullTaskID };
 
-chpl_task_bundle_t chpl_qthread_comm_task_bundle = {
+chpl_task_bundle_t chpl_qthread_comm_task_bundle_template = {
                                    .kind = CHPL_ARG_BUNDLE_KIND_TASK,
                                    .is_executeOn = false,
                                    .lineno = 0,
@@ -176,11 +179,12 @@ chpl_task_bundle_t chpl_qthread_comm_task_bundle = {
                                    .requested_fn = NULL,
                                    .id = chpl_nullTaskID };
 
+chpl_task_bundle_t *chpl_qthread_comm_task_bundles = NULL;
+
 chpl_qthread_tls_t chpl_qthread_process_tls = {
                                .bundle = &chpl_qthread_process_bundle };
 
-chpl_qthread_tls_t chpl_qthread_comm_task_tls = {
-                               .bundle = &chpl_qthread_comm_task_bundle };
+chpl_qthread_tls_t *chpl_qthread_comm_task_tls = NULL;
 
 //
 // chpl_qthread_get_tasklocal() is in chpl-tasks-impl.h
@@ -729,6 +733,43 @@ static void setupAffinity(void) {
   }
 }
 
+static pthread_t *allocate_comm_task(void) {
+    int newMax;
+    int oldMax = chpl_qthread_comm_max_pthreads;
+
+    if (chpl_qthread_comm_num_pthreads ==
+        chpl_qthread_comm_max_pthreads) {
+        newMax = (oldMax == 0) ? 1 : oldMax * 2;
+        size_t newSize = newMax * sizeof(*chpl_qthread_comm_pthreads);
+        chpl_qthread_comm_pthreads = chpl_realloc(chpl_qthread_comm_pthreads,
+                                                  newSize);
+
+        newSize = newMax * sizeof(*chpl_qthread_comm_task_bundles);
+        chpl_qthread_comm_task_bundles =
+            chpl_realloc(chpl_qthread_comm_task_bundles, newSize);
+
+        newSize = newMax * sizeof(*chpl_qthread_comm_task_tls);
+        chpl_free(chpl_qthread_comm_task_tls);
+        chpl_qthread_comm_task_tls = (chpl_qthread_tls_t *)
+                                        chpl_malloc(newSize);
+        for(int i = 0; i < chpl_qthread_comm_num_pthreads; i++) {
+            chpl_qthread_comm_task_tls[i].bundle =
+                    &chpl_qthread_comm_task_bundles[i];
+        }
+        chpl_qthread_comm_max_pthreads = newMax;
+    }
+    int i = chpl_qthread_comm_num_pthreads++;
+    assert(i < chpl_qthread_comm_max_pthreads);
+    chpl_qthread_comm_task_bundles[i] =
+            chpl_qthread_comm_task_bundle_template;
+    chpl_qthread_comm_task_tls[i].bundle =
+                    &chpl_qthread_comm_task_bundles[i];
+    return &chpl_qthread_comm_pthreads[i];
+}
+
+
+
+
 void chpl_task_init(void)
 {
     int32_t   commMaxThreads;
@@ -827,11 +868,34 @@ typedef struct {
     chpl_fn_p fn;
     void *arg;
     int cpu;
+    pthread_t *thread;
 } comm_task_wrapper_info_t;
 
 static void *comm_task_wrapper(void *arg)
 {
     comm_task_wrapper_info_t *rarg = arg;
+
+    void *targ = rarg->arg;
+    chpl_fn_p fn = rarg->fn;
+    chpl_free(rarg);
+    (*(chpl_fn_p)(fn))(targ);
+    return NULL;
+}
+
+// Communication threads indirect through this function to set CPU and
+// memory affinity properly. chpl_task_createCommTask creates a thread
+// running this function. This thread binds itself to the proper CPU(s),
+// but before it does that it has been using its stack and as a result its
+// stack may be in a NUMA domain not associated with the CPU(s). So this
+// thread creates another thread which inherits this thread's CPU affinity
+// so its stack is in the proper NUMA domain(s). This thread then exits
+// and the new thread calls comm_task_wrapper to invoke communication
+// function.
+
+static void *comm_task_trampoline(void *arg)
+{
+    comm_task_wrapper_info_t *rarg = arg;
+
     if (rarg->cpu >= 0) {
         int rc = chpl_topo_bindCPU(rarg->cpu);
         if (rc) {
@@ -850,8 +914,11 @@ static void *comm_task_wrapper(void *arg)
         }
         _DBG_P("comm task bound to accessible PUs");
     }
-    (*(chpl_fn_p)(rarg->fn))(rarg->arg);
-    return 0;
+    int rc = pthread_create(rarg->thread, NULL, comm_task_wrapper, rarg);
+    if (rc) {
+        chpl_error("pthread_create of comm_task_wrapper failed", 0, 0);
+    }
+    return NULL;
 }
 
 // Start the main task.
@@ -886,18 +953,14 @@ int chpl_task_createCommTask(chpl_fn_p fn,
                              void     *arg,
                              int      cpu)
 {
-    //
-    // The wrapper info must be static because it won't be referred to
-    // until the new pthread calls comm_task_wrapper().  And, it is
-    // safe for it to be static because we will be called at most once
-    // on each node.
-    //
-    static comm_task_wrapper_info_t wrapper_info;
-    wrapper_info.fn = fn;
-    wrapper_info.arg = arg;
-    wrapper_info.cpu = cpu;
-    return pthread_create(&chpl_qthread_comm_pthread,
-                          NULL, comm_task_wrapper, &wrapper_info);
+    comm_task_wrapper_info_t *wrapper_info;
+    wrapper_info = chpl_malloc(sizeof(*wrapper_info));
+    wrapper_info->fn = fn;
+    wrapper_info->arg = arg;
+    wrapper_info->cpu = cpu;
+    wrapper_info->thread = allocate_comm_task();
+    pthread_t dummy;
+    return pthread_create(&dummy, NULL, comm_task_trampoline, wrapper_info);
 }
 
 void chpl_task_addTask(chpl_fn_int_t       fid,

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -960,7 +960,14 @@ int chpl_task_createCommTask(chpl_fn_p fn,
     wrapper_info->cpu = cpu;
     wrapper_info->thread = allocate_comm_task();
     pthread_t dummy;
-    return pthread_create(&dummy, NULL, comm_task_trampoline, wrapper_info);
+    int rc = pthread_create(&dummy, NULL, comm_task_trampoline, wrapper_info);
+    if (rc == 0) {
+        rc = pthread_detach(dummy);
+        if (rc) {
+            chpl_error("pthread_detach of comm_task_trampoline failed", 0, 0);
+        }
+    }
+    return rc;
 }
 
 void chpl_task_addTask(chpl_fn_int_t       fid,

--- a/runtime/src/topo/hwloc/topo-hwloc.c
+++ b/runtime/src/topo/hwloc/topo-hwloc.c
@@ -785,7 +785,7 @@ int getCPUs(hwloc_cpuset_t cpuset, int *cpus, int size) {
 //
 int chpl_topo_getCPUs(chpl_bool physical, int *cpus, int count) {
   // Initializes CPU information.
-    cantReserveCPU = "chpl_topo_getCPUs called";
+  cantReserveCPU = "chpl_topo_getCPUs called";
   return getCPUs(physical ? physAccSet : logAccSet, cpus, count);
 }
 

--- a/runtime/src/topo/hwloc/topo-hwloc.c
+++ b/runtime/src/topo/hwloc/topo-hwloc.c
@@ -114,7 +114,7 @@ static void chpl_topo_setMemLocalityByPages(unsigned char*, size_t,
 
 // CPU reservation must happen before CPU information is returned to other
 // layers.
-static chpl_bool okToReserveCPU = true;
+static const char *cantReserveCPU = NULL;
 
 static chpl_bool oversubscribed = false;
 
@@ -297,7 +297,7 @@ static int numCPUsLogAcc  = -1;
 static int numCPUsLogAll  = -1;
 
 int chpl_topo_getNumCPUsPhysical(chpl_bool accessible_only) {
-  okToReserveCPU = false;
+  cantReserveCPU = "chpl_topo_getNumCPUsPhysical called";
   int cpus = (accessible_only) ? numCPUsPhysAcc : numCPUsPhysAll;
   if (cpus == -1) {
     chpl_error("number of cpus is uninitialized", 0, 0);
@@ -307,7 +307,7 @@ int chpl_topo_getNumCPUsPhysical(chpl_bool accessible_only) {
 
 
 int chpl_topo_getNumCPUsLogical(chpl_bool accessible_only) {
-  okToReserveCPU = false;
+  cantReserveCPU = "chpl_topo_getNumCPUsLogical called";
   int cpus = (accessible_only) ? numCPUsLogAcc : numCPUsLogAll;
   if (cpus == -1) {
     chpl_error("number of cpus is uninitialized", 0, 0);
@@ -785,7 +785,7 @@ int getCPUs(hwloc_cpuset_t cpuset, int *cpus, int size) {
 //
 int chpl_topo_getCPUs(chpl_bool physical, int *cpus, int count) {
   // Initializes CPU information.
-  okToReserveCPU = false;
+    cantReserveCPU = "chpl_topo_getCPUs called";
   return getCPUs(physical ? physAccSet : logAccSet, cpus, count);
 }
 
@@ -1105,7 +1105,7 @@ chpl_topo_reserveCPUPhysical(void) {
   _DBG_P("topoSupport->cpubind->set_thisthread_cpubind: %d",
          topoSupport->cpubind->set_thisthread_cpubind);
   _DBG_P("numCPUsPhysAcc: %d", numCPUsPhysAcc);
-  if (okToReserveCPU) {
+  if (!cantReserveCPU) {
     if ((topoSupport->cpubind->set_thisthread_cpubind) &&
         (numCPUsPhysAcc > 1)) {
 
@@ -1144,7 +1144,7 @@ chpl_topo_reserveCPUPhysical(void) {
       }
     }
   } else {
-    _DBG_P("okToReserveCPU is false");
+    _DBG_P("cantReserveCPU: %s", cantReserveCPU);
   }
 
   if (debug) {

--- a/third-party/gasnet/Makefile
+++ b/third-party/gasnet/Makefile
@@ -17,12 +17,9 @@ endif
 
 # PSHM (inter-Process SHared Memory) provide a mechanism for gasnet instances
 # on the same node to communicate through shared memory instead of the real
-# conduit. In "production" we only run a single gasnet client per node so this
-# doesn't help, but for smp it's required, and we've noticed faster testing
-# times since we do local spawning, which will result in multiple gasnet
-# clients on the same node. Note that pshm only works with segment fast/large.
-SUB_SEG = $(CHPL_MAKE_COMM_SUBSTRATE)-$(CHPL_MAKE_COMM_SEGMENT)
-ifneq (,$(findstring $(SUB_SEG), udp-fast udp-large smp-fast smp-large))
+# conduit. This is critical to communication performance for co-locales.
+# Note that pshm only works with segment fast/large.
+ifneq (,$(findstring $(CHPL_MAKE_COMM_SEGMENT), fast large))
 CHPL_GASNET_CFG_OPTIONS += --enable-pshm
 else
 CHPL_GASNET_CFG_OPTIONS += --disable-pshm


### PR DESCRIPTION
This PR makes several changes to add support for GASNet PSHM (shared-memory bypass) for co-locales, and to improve RDMA performance via a send progress thread. These are related because the both require changes to how GASNet progress threads are implemented. The changes include:

- Modify the communication task functionality in `tasks-qthreads.c` to support more than one progress thread.
-  When there are co-locales, create an external GASNet progress thread to progress PSHM.
- When there is an external GASNet progress thread, do not create an internal RCV thread because it is redundant.
-  By default, set `GASNET_SND_THREAD` to create an internal GASNet thread that progresses send operations. This can be overridden by setting `GASNET_SND_THREAD=false` in the environment.
- Set `GASNET_SND_THREAD_POLL_MODE=exclusive`, which gives the GASNet send progress thread exclusive access to the NIC.
- If `CHPL_RT_COMM_GASNET_DEDICATED_PROGRESS_CORE=true`, reserve one core for internal and external GASNet progress threads and bind those threads to the core.
- If `CHPL_RT_COMM_GASNET_DEDICATED_PROGRESS_CORE=false`, bind the internal and external GASNet progress threads to the locale's accessible cores.
- In the `gasnet` shim, set `GASNET_SUPERNODE_MAXSIZE=1 `if there are no-colocales. This will prevent the use of PSHM, which cannot be used because the `gasnet` shim does not create an external GASNet progress thread.
- Interpose `comm_task_trampoline` between `chpl_task_createCommTask` and `chpl_task_wrapper`. `chpl_task_createCommTask` creates a thread that  invokes `comm_task_trampoline` which binds itself to the proper core(s) before creating another thread that invokes `chpl_task_wrapper`. This  ensures that the second thread is bound to the proper core(s) and its stack has the proper NUMA affinity. The thread created by `chpl_task_createCommTask` exits.

Closes https://github.com/Cray/chapel-private/issues/6369.
Closes https://github.com/Cray/chapel-private/issues/6368.
Closes https://github.com/Cray/chapel-private/issues/6228.