### PR TITLE
Remove use of vectorizeOnly

### DIFF
--- a/test/studies/lcals/LCALSConfiguration.chpl
+++ b/test/studies/lcals/LCALSConfiguration.chpl
@@ -80,7 +80,7 @@ module LCALSConfiguration {
   config const run_variantRawSPMD          = false; // off by default because
                                                     // short and medium loops
                                                     // take too long.
-  config const run_variantRawVectorizeOnly = false; // off by default because
+  config const run_variantRawVector = false;        // off by default because
                                                     // it currently behaves
                                                     // identically to the
                                                     // serial variant

--- a/test/studies/lcals/LCALSMain.chpl
+++ b/test/studies/lcals/LCALSMain.chpl
@@ -12,7 +12,7 @@ use RunBRawLoops;
 use RunCRawLoops;
 use RunParallelRawLoops;
 use RunSPMDRawLoops;
-use RunVectorizeOnlyRawLoops;
+use RunVectorRawLoops;
 
 use IO;
 
@@ -118,7 +118,7 @@ proc main {
     }
     run_variants[LoopVariantID.RAW_SPMD] = true;
   }
-  if run_variantRawVectorizeOnly then
+  if run_variantRawVector then
     run_variants[LoopVariantID.RAW_VECTOR_ONLY] = true;
 
 
@@ -617,7 +617,7 @@ proc runLoopVariant(lvid: LoopVariantID, run_loop:[] bool, ilength: LoopLength) 
       runSPMDRawLoops(loop_stats, run_loop, ilength);
     }
     when LoopVariantID.RAW_VECTOR_ONLY {
-      runVectorizeOnlyRawLoops(loop_stats, run_loop, ilength);
+      runVectorRawLoops(loop_stats, run_loop, ilength);
     }
 /*
     when LoopVariantID.FORALL_LAMBDA {

--- a/test/studies/lcals/LCALSMain.good
+++ b/test/studies/lcals/LCALSMain.good
@@ -1,4 +1,3 @@
-RunVectorizeOnlyRawLoops.chpl:4: warning: The 'VectorizingIterator' module has been deprecated; please use 'foreach' loops instead
 
  allocateLoopSuiteRunInfo...
 

--- a/test/studies/lcals/RunVectorRawLoops.chpl
+++ b/test/studies/lcals/RunVectorRawLoops.chpl
@@ -1,9 +1,9 @@
-module RunVectorizeOnlyRawLoops {
+module RunVectorRawLoops {
   use LCALSDataTypes;
   use Timer;
   private use Math;
 
-  proc runVectorizeOnlyRawLoops(loop_stats: [] shared LoopStat, run_loop:[] bool, ilength: LoopLength) {
+  proc runVectorRawLoops(loop_stats: [] shared LoopStat, run_loop:[] bool, ilength: LoopLength) {
     var loop_suite_run_info = getLoopSuiteRunInfo();
     var loop_data = getLoopData();
 

--- a/test/studies/lcals/RunVectorizeOnlyRawLoops.chpl
+++ b/test/studies/lcals/RunVectorizeOnlyRawLoops.chpl
@@ -1,7 +1,6 @@
 module RunVectorizeOnlyRawLoops {
   use LCALSDataTypes;
   use Timer;
-  use VectorizingIterator;
   private use Math;
 
   proc runVectorizeOnlyRawLoops(loop_stats: [] shared LoopStat, run_loop:[] bool, ilength: LoopLength) {
@@ -471,7 +470,8 @@ module RunVectorizeOnlyRawLoops {
             var val = 0.0;
             ltimer.start();
             for 0..#num_samples {
-              forall i in vectorizeOnly(0..(len-1):int(32)) with (+ reduce sumx) {
+              // TODO: this should have a reduce intent instead of a ref intent
+              foreach i in 0..(len-1):int(32) with (ref sumx) {
                 var x = x0 + i*h;
                 sumx += trap_int_func(x, y, xp, yp);
               }


### PR DESCRIPTION
Removes a use of `vectorizeOnly` in LCALS, which can now be replaced with `foreach`. Since the test now uses all `foreach`, the filenames and variables that use `vectorizeOnly` have also been renamed.

[Reviewed by @lydia-duncan]