### PR TITLE
Switch homebrew to use system hwloc and jemalloc

### DIFF
--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -19,6 +19,7 @@ class Chapel < Formula
   depends_on "cmake"
   depends_on "gmp"
   depends_on "hwloc"
+  depends_on "jemalloc"
   depends_on "llvm@17"
   depends_on "python@3.12"
 
@@ -40,6 +41,7 @@ class Chapel < Formula
     # Chapel uses this ENV to work out where to install.
     ENV["CHPL_HOME"] = libexec
     ENV["CHPL_GMP"] = "system"
+    ENV["CHPL_TARGET_JEMALLOC"] = "system"
     # This ENV avoids a problem where cmake cache is invalidated by subsequent make calls
     ENV["CHPL_CMAKE_USE_CC_CXX"] = "1"
 
@@ -48,7 +50,7 @@ class Chapel < Formula
     (libexec/"chplconfig").write <<~EOS
       CHPL_RE2=bundled
       CHPL_GMP=system
-      CHPL_MEM=cstdlib
+      CHPL_MEM=jemalloc
       CHPL_HWLOC=system
       CHPL_LLVM_CONFIG=#{llvm.opt_bin}/llvm-config
       CHPL_LLVM_GCC_PREFIX=none

--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -41,7 +41,6 @@ class Chapel < Formula
     # Chapel uses this ENV to work out where to install.
     ENV["CHPL_HOME"] = libexec
     ENV["CHPL_GMP"] = "system"
-    ENV["CHPL_TARGET_JEMALLOC"] = "system"
     # This ENV avoids a problem where cmake cache is invalidated by subsequent make calls
     ENV["CHPL_CMAKE_USE_CC_CXX"] = "1"
 
@@ -51,6 +50,7 @@ class Chapel < Formula
       CHPL_RE2=bundled
       CHPL_GMP=system
       CHPL_MEM=jemalloc
+      CHPL_TARGET_JEMALLOC=system
       CHPL_HWLOC=system
       CHPL_LLVM_CONFIG=#{llvm.opt_bin}/llvm-config
       CHPL_LLVM_GCC_PREFIX=none

--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -18,6 +18,7 @@ class Chapel < Formula
 
   depends_on "cmake"
   depends_on "gmp"
+  depends_on "hwloc"
   depends_on "llvm@17"
   depends_on "python@3.12"
 
@@ -48,7 +49,7 @@ class Chapel < Formula
       CHPL_RE2=bundled
       CHPL_GMP=system
       CHPL_MEM=cstdlib
-      CHPL_TASKS=fifo
+      CHPL_HWLOC=system
       CHPL_LLVM_CONFIG=#{llvm.opt_bin}/llvm-config
       CHPL_LLVM_GCC_PREFIX=none
     EOS


### PR DESCRIPTION
Switches the homebrew formula in the chapel tree to use a system install of hwloc, which allows chapel to use qthreads. This results in better performance for users. This also uses a system install of jemalloc, which also increases performance.

- [x] Tested locally by install chapel from the homebrew formula and running `chpl examples/hello.chpl && ./hello`

To be merged after https://github.com/chapel-lang/chapel/pull/25145 and https://github.com/chapel-lang/chapel/pull/25158

Resolves https://github.com/chapel-lang/chapel/issues/24655
Resolves https://github.com/chapel-lang/chapel/issues/24931

[Reviewed by @stonea]