### PR TITLE
BTR: catch non-fatal, but failed `mysystem` commands in `nightly` script

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -296,7 +296,7 @@ if ($basetmpdir eq "") {
 # to a file. The $exitOnError variable tells it to exit immediately, while
 # $ignoreErrors tells it to continue without doing anything. $emailOnError,
 # which is the path of the error file, tells it to write the errors to a file.
-$mysystemlog = "$basetmpdir/mysystemerrs.txt";
+$mysystemlog = "$basetmpdir/mysystemerrs-$config_name.txt";
 $emailOnError = $mysystemlog;
 unlink($mysystemlog); # the file gets appended to, so clear it first.
 

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -298,6 +298,7 @@ if ($basetmpdir eq "") {
 # which is the path of the error file, tells it to write the errors to a file.
 $mysystemlog = "$basetmpdir/mysystemerrs.txt";
 $emailOnError = $mysystemlog;
+unlink($mysystemlog); # the file gets appended to, so clear it first.
 
 # Number of logical processes on current system. Will be used as number of jobs
 # when calling make with parallel execution.
@@ -835,7 +836,7 @@ if ($runtests == 0) {
 # FIXME: Pass correct args here!
      # `$chplhomedir/util/cron/nightly_email.pl $status "$rawsummary" "$sortedsummary" "$prevsummary" "$mailer" "$nochangerecipient" "$recipient" "$subjectid" "$config_name" "$revision" "$rawlog" "$starttime" "$endtime" "$crontab" "$testdirs" $debug`;
      # Write the test results to the summary log.
-     writeFile($status, "$rawsummary", "$sortedsummary", "$prevsummary", "", "$nochangerecipient", "$recipient", "$subjectid", "$config_name", "$revision", "$rawlog", "$starttime", "$endtime", "$crontab", "$testdirs", $debug);
+     writeFile($status, "$rawsummary", "$sortedsummary", "$prevsummary", "$mysystemlog", "", "$nochangerecipient", "$recipient", "$subjectid", "$config_name", "$revision", "$rawlog", "$starttime", "$endtime", "$crontab", "$testdirs", $debug);
 #
 # analyze memory leaks tests
 #

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -292,6 +292,12 @@ if ($basetmpdir eq "") {
     $basetmpdir = "/tmp";
 }
 
+# The 'mysystem' function either exits on errors, ignores them, or writes them
+# to a file. The $exitOnError variable tells it to exit immediately, while
+# $ignoreErrors tells it to continue without doing anything. $emailOnError,
+# which is the path of the error file, tells it to write the errors to a file.
+$mysystemlog = "$basetmpdir/mysystemerrs.txt";
+$emailOnError = $mysystemlog;
 
 # Number of logical processes on current system. Will be used as number of jobs
 # when calling make with parallel execution.
@@ -390,10 +396,10 @@ if ($testblog == 1) {
     if ($blogonly == 0) {
         # copy the relevant blog source files into the test directory so they'll be
         # ran alongside all the other tests
-        mysystem("mkdir -p $testdir/copied-chapel-blog/content", "making chpl-src directory", 1, 1, 1);
-        mysystem("cp -r $blogdir/chpl-src $testdir/copied-chapel-blog/", "copying chapel-blog/chpl-src", 1, 1, 1);
-        mysystem("cp -r $blogdir/scripts $testdir/copied-chapel-blog/", "copying chapel-blog/scripts", 1, 1, 1);
-        mysystem("cp -r $blogdir/content/posts $testdir/copied-chapel-blog/content/", "copying chapel-blog/content", 1, 1, 1);
+        mysystem("mkdir -p $testdir/copied-chapel-blog/content", "making chpl-src directory", $exitOnError, 1);
+        mysystem("cp -r $blogdir/chpl-src $testdir/copied-chapel-blog/", "copying chapel-blog/chpl-src", $exitOnError, 1);
+        mysystem("cp -r $blogdir/scripts $testdir/copied-chapel-blog/", "copying chapel-blog/scripts", $exitOnError, 1);
+        mysystem("cp -r $blogdir/content/posts $testdir/copied-chapel-blog/content/", "copying chapel-blog/content", $exitOnError, 1);
     }
 }
 
@@ -509,12 +515,12 @@ if ($python2 == 0) {
 
 
 print "Making $make_vars_opt compiler\n";
-$makestat = mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_opt compiler", "making chapel compiler", 1, 1);
+$makestat = mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_opt compiler", "making chapel compiler", $exitOnError);
 
 # Speculatively build a couple third-party libraries. This command should not
 # fail, even if it fails to build the libraries.
 print "Making $make_vars_opt third-party-try-opt\n";
-mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_opt third-party-try-opt", "make chapel third-party-try-opt", 1, 1);
+mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_opt third-party-try-opt", "make chapel third-party-try-opt", $exitOnError);
 
 # if we are using python2 or a deprecated version of python3, we cannot build
 # the test-venv and/or chpldoc
@@ -522,12 +528,12 @@ if ($python2 == 0 && $pythonDep == 0) {
   # Build chpldoc. Do not fail the build if it does not succeed. Do not send
   # mail either.
   print "Making $make_vars_opt chpldoc\n";
-  mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_opt chpldoc", "make chapel chpldoc", 0, 0);
+  mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_opt chpldoc", "make chapel chpldoc", $ignoreErrors);
 
   # Build test virtualenv. Fail if the build does not succeed as virtualenv is
   # needed for start_test. Send mail on failure
   print "Making $make_var_opt test-venv\n";
-  mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_opt test-venv", "make chapel test-venv", 1, 1);
+  mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_opt test-venv", "make chapel test-venv", $exitOnError);
 }
 
 if ($buildruntime == 0) {
@@ -536,21 +542,21 @@ if ($buildruntime == 0) {
 }
 
 print "Making $make_vars_opt runtime\n";
-$makestat = mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_opt runtime", "making chapel runtime", 1, 1);
+$makestat = mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_opt runtime", "making chapel runtime", $exitOnError);
 
 print "Making modules\n";
-$makestat = mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_opt modules", "making chapel modules", 1, 1);
+$makestat = mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_opt modules", "making chapel modules", $exitOnError);
 
 # Build mason
 if ($mason_build == 1) {
   print "Making mason\n";
-  mysystem("cd $chplhomedir && $make -j$num_procs mason", "making mason", 1, 1);
+  mysystem("cd $chplhomedir && $make -j$num_procs mason", "making mason", $exitOnError);
 }
 
 # Build the protobuf Chapel plugin
 if ($protobuf_build == 1) {
     print "Making the protobuf Chapel plugin\n";
-    mysystem("cd $chplhomedir && $make protoc-gen-chpl", "making protoc-gen-chpl", 1, 1);
+    mysystem("cd $chplhomedir && $make protoc-gen-chpl", "making protoc-gen-chpl", $exitOnError);
 }
 
 #
@@ -589,7 +595,7 @@ if ($multilocale == 1) {
 #
 if ($examples == 1) {
     print "Making spectests\n";
-    mysystem("cd $chplhomedir && $make spectests", "making spec tests", 0, 1);
+    mysystem("cd $chplhomedir && $make spectests", "making spec tests", $emailOnError);
     $testdirs .= " release/examples";
 }
 
@@ -610,7 +616,7 @@ if ($parnodefile eq "") {
 } else {
     if ($testdirs ne "") {
         mysystem("cd $testdir && find $testdirs -wholename \"*.svn\" -prune -o -type d > DIRFILE",
-                 "making directory file", 1, 1);
+                 "making directory file", $exitOnError);
         $testflags = "$testflags -dirfile DIRFILE";
     }
 }
@@ -624,7 +630,7 @@ if ($allhellos == 1) {
     if ($parnodefile eq "") {
         $testflags = "$testflags --no-recurse release/examples";
     } else {
-        mysystem("cd $testdir && echo $testdirs > DIRFILE", 1, 1);
+        mysystem("cd $testdir && echo $testdirs > DIRFILE", $exitOnError);
         $testflags = "$testflags -dirfile DIRFILE";
     }
 }
@@ -711,7 +717,7 @@ if ($runtests == 0) {
   $ENV{'CHPL_HOME'} = $chplhomedir;
 
   $buildcheckcommand = "cd $ENV{'CHPL_HOME'} && . util/setchplenv.sh && CHPL_CHECK_DEBUG=1 make check";
-  mysystem($buildcheckcommand, "running `make check`", 1, 1, 1);
+  mysystem($buildcheckcommand, "running `make check`", $exitOnError, 1);
 
 } else {
 
@@ -725,7 +731,7 @@ if ($runtests == 0) {
     # Confirm Chapel built correctly before start_test / paratest
     if ($buildcheck == 1) {
         $buildcheckcommand = "cd $ENV{'CHPL_HOME'} && . util/setchplenv.sh && CHPL_CHECK_DEBUG=1 make check";
-        mysystem($buildcheckcommand, "running `make check`", 1, 1, 1);
+        mysystem($buildcheckcommand, "running `make check`", $exitOnError, 1);
     }
 
     if ($parnodefile eq "") {
@@ -757,7 +763,7 @@ if ($runtests == 0) {
 # Restore graph sync once we find a solution to our network issues
         $rsyncCommand = "$chplhomedir/util/cron/syncPerfGraphs.py $svnPerfDir/$performancedescription/html/ $perfConfigName/$syncsuffix --logFile $logdir/$str.errors";
         $rsyncMessage = "syncing performance graph to dreamhost -- log file at $logdir/$str.errors";
-        mysystem($rsyncCommand, $rsyncMessage , 0, 1, 1);
+        mysystem($rsyncCommand, $rsyncMessage , $emailOnError, 1);
    }
 
 #
@@ -803,7 +809,7 @@ if ($runtests == 0) {
                 $splice = "$utildir/devel/test/spliceDat";
                 $spliceCommand = "$splice -from_a $today -to_a $today $svnPerfDir/$datName $historicalFile> $tmpDatDir/$datName";
                 $spliceDatMessage = "Attempting to splice historical data $historicalFile with nightly data $svnPerfDir/$datName";
-                mysystem($spliceCommand, $spliceMessage, 0, 0, 1);
+                mysystem($spliceCommand, $spliceMessage, $ignoreError, 1);
                 `cp $svnPerfDir/$datName $tmpNightlyDatDir/$datName`;
             }
 
@@ -813,7 +819,7 @@ if ($runtests == 0) {
             $genGraphs = "$utildir/test/genGraphs";
             $genGraphsCommand = "$genGraphs -p $tmpDatDir -o $svnReleasePerfDir/html/ -t $chplhomedir/test/ -a \"$altTitle\" -n $perfConfigName  -g $chplhomedir/test/GRAPHFILES -s $startdate -m default:v,nightly";
             $genGraphsMessage = "Generating release over release performance graphs";
-            mysystem($genGraphsCommand, $genGraphsMessage, 0, 1, 1);
+            mysystem($genGraphsCommand, $genGraphsMessage, $emailOnError, 1);
 
             # sync the perf graphs over to dreamhost
             my $str = "syncReleaseToDreamhost.$perfConfigName/releaseOverRelease/$syncsuffix";
@@ -822,7 +828,7 @@ if ($runtests == 0) {
 # Restore graph sync once we find a solution to our network issues
             $rsyncCommand = "$chplhomedir/util/cron/syncPerfGraphs.py $svnReleasePerfDir/html/ $perfConfigName/releaseOverRelease/$syncsuffix --logFile $logdir/$str.errors";
             $rsyncMessage = "syncing release performance graph to dreamhost -- log file at $logdir/$str.errors";
-            mysystem($rsyncCommand, $rsyncMessage , 0, 1, 1);
+            mysystem($rsyncCommand, $rsyncMessage , $emailOnError, 1);
         }
     }
 

--- a/util/cron/nightly_email.pm
+++ b/util/cron/nightly_email.pm
@@ -8,7 +8,7 @@ use nightlysubs;
 sub writeFile{
     $num_args = @_;
 
-    if ($num_args != 16) {
+    if ($num_args != 17) {
         print "usage: nightly_email.pl \$status \$rawsummary \$sortedsummary \n";
         print "         \$prevsummary \$mysystemlog \$mailer \$nochangerecipient \$recipient \n";
         print "         \$subjectid \$config_name \$revision \$rawlog \$starttime \n";

--- a/util/cron/nightly_email.pm
+++ b/util/cron/nightly_email.pm
@@ -10,29 +10,30 @@ sub writeFile{
 
     if ($num_args != 16) {
         print "usage: nightly_email.pl \$status \$rawsummary \$sortedsummary \n";
-        print "         \$prevsummary \$mailer \$nochangerecipient \$recipient \n";
+        print "         \$prevsummary \$mysystemlog \$mailer \$nochangerecipient \$recipient \n";
         print "         \$subjectid \$config_name \$revision \$rawlog \$starttime \n";
         print "         \$endtime \$crontab \$testdirs \$debug\n";
         exit 1;
     }
-    my ($status, $rawsummary, $sortedsummary, ,$prevsummary, $mailer, $nochangerecipient, $recipient, $subjectid, $config_name, $revision, $rawlog, $starttime, $endtime, $crontab, $testdirs, $debug)=@_;
+    my ($status, $rawsummary, $sortedsummary, ,$prevsummary, $mysystemlog, $mailer, $nochangerecipient, $recipient, $subjectid, $config_name, $revision, $rawlog, $starttime, $endtime, $crontab, $testdirs, $debug)=@_;
 
     $status = $_[0];
     $rawsummary = $_[1];
     $sortedsummary = $_[2];
     $prevsummary = $_[3];
-    $mailer = $_[4];
-    $nochangerecipient = $_[5];
-    $recipient = $_[6];
-    $subjectid = $_[7];
-    $config_name = $_[8];
-    $revision = $_[9];
-    $rawlog = $_[10];
-    $starttime = $_[11];
-    $endtime = $_[12];
-    $crontab = $_[13];
-    $testdirs = $_[14];
-    $debug = $_[15];
+    $mysystemlog = $_[4];
+    $mailer = $_[5];
+    $nochangerecipient = $_[6];
+    $recipient = $_[7];
+    $subjectid = $_[8];
+    $config_name = $_[9];
+    $revision = $_[10];
+    $rawlog = $_[11];
+    $starttime = $_[12];
+    $endtime = $_[13];
+    $crontab = $_[14];
+    $testdirs = $_[15];
+    $debug = $_[16];
 
 
     # Ensure the "previous" summary exists, e.g. if this is the first run of the
@@ -105,7 +106,9 @@ sub writeFile{
         $newfailures += 0;
     }
 
-    if ($newfailures == 0 && $newresolved == 0 && $newpassingfutures == 0 && $newpassingsuppress == 0) {
+    if (-f $mysystemlog && -s $mysystemlog) {
+        # Even if no errors occurred etc., the build failed, so send an email.
+    } elsif ($newfailures == 0 && $newresolved == 0 && $newpassingfutures == 0 && $newpassingsuppress == 0) {
         $email=0;
         $recipient = $nochangerecipient;
     }
@@ -124,7 +127,8 @@ sub writeFile{
              $numtestssummary ,
              $summary ,
              $prevsummary ,
-             $sortedsummary );
+             $sortedsummary ,
+             $mysystemlog);
         }
     } else {
         print "CHPL_TEST_NOMAIL: No $mailcommand\n";

--- a/util/cron/nightlysubs.pm
+++ b/util/cron/nightlysubs.pm
@@ -145,6 +145,8 @@ sub writeEmail {
     my $summary = $_[6];
     my $prevsummary = $_[7];
     my $sortedsummary = $_[8];
+    my $mysystemlog = $_[9];
+
     #Create a file "email.txt" in the chapel homedir. This file will be used by Jenkins to attach the test results in the email body
     my $filename = "$chplhomedir/email.txt";
     open(my $SF, '>', $filename) or die "Could not open file '$filename' $!";
@@ -185,6 +187,12 @@ sub writeEmail {
         print $SF "--- New Failing Future tests -----------------\n";
         print $SF `LC_ALL=C comm -13 $prevsummary $sortedsummary | grep -v "^.Summary:" | grep "$futuremarker" | grep "\\[Error"`;
         print $SF "\n";
+
+        if (-f $mysystemlog && -s $mysystemlog) {
+            print $SF "--- Errors in Bash Commands ------------------\n";
+            print $SF `cat $mysystemlog`;
+            print $SF "\n";
+        }
     print $SF;
     print $SF endMailChplenv();
     close($SF);

--- a/util/cron/nightlysubs.pm
+++ b/util/cron/nightlysubs.pm
@@ -34,9 +34,9 @@ sub mysystem {
         if($status != -1) {$status = $status / 256; }
 
         print "Error $errorname: $status\n";
-        if ($onerror == $exitOnError) {
+        if ($onerror eq $exitOnError) {
             exit 1;
-        } elsif ($onerror == $ignoreError) {
+        } elsif ($onerror eq $ignoreError) {
             # Do nothing
         } else {
             open(my $SF, '>>', $onerror) or die "Could not open file '$onerror' $!";

--- a/util/cron/nightlysubs.pm
+++ b/util/cron/nightlysubs.pm
@@ -12,12 +12,19 @@ $chplhomedir = abs_path("$cwd/../..");
 $file = "$chplhomedir/email.txt";
 unlink($file);
 
+# Special constants for 'mysystem'. The third argument of 'mysystem' should
+# be one of three values.
+#
+# * $exitOnError (aka <exit on error>): exit the script if the command fails
+# * $ignoreError (aka <ignore error>): silently allow the error to fail
+# * a path to a file: write the error to that file and continue
+$exitOnError = "<exit on error>";
+$ignoreError = "<ignore error>";
 sub mysystem {
     $command = $_[0];
     $errorname = $_[1];
-    $fatal = $_[2];
-    $mailmsg = $_[3];
-    $showcommand = $_[4];
+    $onerror = $_[2];
+    $showcommand = $_[3];
 
     if ($showcommand) { print "Executing $command\n"; }
     my $status = system($command);
@@ -25,9 +32,16 @@ sub mysystem {
         $endtime = localtime;
         $somethingfailed = 1;
         if($status != -1) {$status = $status / 256; }
+
         print "Error $errorname: $status\n";
-        if ($fatal != 0) {
+        if ($onerror == $exitOnError) {
             exit 1;
+        } elsif ($onerror == $ignoreError) {
+            # Do nothing
+        } else {
+            open(my $SF, '>>', $onerror) or die "Could not open file '$onerror' $!";
+            print $SF "Error $errorname: $status\n";
+            close($SF);
         }
     }
     $status;


### PR DESCRIPTION
 I noticed a relatively significant problem in our `nightly` script. We have two variables in `mysystem`: one that configures whether failing the command should be fatal, and one that configures whether an email should be sent. Most commands are either non-fatal non-email, or fatal and send-email. However, some commands (e.g., `make spectests`, `rsync`) are non-fatal send-email. Despite this, the code for sending an email (or doing any kind of error tracking) is lacking.

```Perl
sub mysystem {
    $command = $_[0];
    $errorname = $_[1];
    $fatal = $_[2];
    $mailmsg = $_[3]; # !!!! Not used anywhere?
    $showcommand = $_[4];

    if ($showcommand) { print "Executing $command\n"; }
    my $status = system($command);
    if ($status != 0) {
        $endtime = localtime;
        $somethingfailed = 1;
        if($status != -1) {$status = $status / 256; }
        print "Error $errorname: $status\n";
        if ($fatal != 0) {
            exit 1;
        }
    }
    $status;
}
```

Thus, we miss notifications for various errors and would, on `main`, also miss notifying the triager if a hypothetical `make chplcheck` fails. This PR addresses this by storing the non-fatal, do-email commands that fail into a new file, `mysystemlog.txt`, and adding its contents to the existing emailing functionality.

# Implementation
Currently, the `nightly` script itself doesn't send emails; only our Jenkins runner does this. The nightly script signals to Jenkins that an email should be sent by creating an `email.txt` file. If this file is present, Jenkins sends it. Thus, to signal existing errors from `mysystem`, we need to keep track of them and include them while generating `email.txt`. To do this, this PR adds a new file, `mysystemlog.txt` (specialized based on the nightly configuration name). It is given as an argument to `mysystem`, causing it to write failures to that file.

Fundamentally, the nature of `mysystem`'s error reporting is tri-state. There's no "fatal, do not email" calls. As a result, it's not well-represented using the two boolean variables I mentioned above. As a result of that, and of the need to path in a path to write errors to, I've switched it to accepting only one argument: a string that's either a path (for non-fatal, email) or a special value for fatal and non-fatal-non-email configs. As a result, the calls now look like this:

```Perl
# Non-fatal, no email
mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_opt chpldoc", "make chapel chpldoc", $ignoreErrors);

# Fatal
mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_opt compiler", "making chapel compiler", $exitOnError);

# Email on error
mysystem("cd $chplhomedir && $make spectests", "making spec tests", $emailOnError);
```

It reads nicer than `0, 1` arguments, and communicates more information. 

From here, I adjusted the emailer script to check for the existence of the error file, and send email if so.

Reviewed by @tzinsky -- thanks!
 