### PR TITLE
Prevent chpl-language-server from providing type inserts for loops

### DIFF
--- a/tools/chpl-language-server/test/type_inlays.py
+++ b/tools/chpl-language-server/test/type_inlays.py
@@ -275,11 +275,11 @@ async def test_type_inlays_loops(client: LanguageClient):
            """
 
     inlays = [
-        (pos((0, 5)), "int(64)"),
-        (pos((1, 8)), "int(64)"),
-        (pos((2, 10)), "int(64)"),
-        (pos((3, 9)), "int(64)"),
-        (pos((4, 2)), "int(64)"),
+        (pos((0, 5)), "int(64)", False),
+        (pos((1, 8)), "int(64)", False),
+        (pos((2, 10)), "int(64)", False),
+        (pos((3, 9)), "int(64)", False),
+        (pos((4, 2)), "int(64)", False),
     ]
 
     async with source_file(client, file) as doc:
@@ -305,7 +305,7 @@ async def test_type_inlays_return(client: LanguageClient):
 
     inlays = [
         (pos((2, 5)), "owned C?"),
-        (pos((5, 5)), "int(64)"),
+        (pos((5, 5)), "int(64)", False),
     ]
 
     async with source_file(client, file) as doc:

--- a/tools/chpl-language-server/test/util/utils.py
+++ b/tools/chpl-language-server/test/util/utils.py
@@ -522,25 +522,41 @@ async def check_type_inlay_hints(
     client: LanguageClient,
     doc: TextDocumentIdentifier,
     rng: Range,
-    expected_inlays: Sequence[typing.Tuple[Position, str]],
+    expected_inlays: Sequence[
+        typing.Union[
+            typing.Tuple[Position, str], typing.Tuple[Position, str, bool]
+        ]
+    ],
 ) -> typing.List[InlayHint]:
     """
     Helper method for `check_inlay_hints`. Adds the `: ` prefix.
 
-    Also checks that inlays are insertable
+    `expected_inlays` is a list of tuples. The tuples can be either of length 2
+    or 3. If the tuple is of length 2, the first element is the expected
+    position and the second element is the expected text of the type. If the
+    tuple is of length 3, then the first two elements are the same. The third
+    element is a boolean that indicates whether the inlay hint is insertable.
     """
-    # we current do not make use of InlayHintKind.Type for type inlays in CLS
-    inlays = [(pos, f": {text}", None) for pos, text in expected_inlays]
-    actual_inlays = await check_inlay_hints(client, doc, rng, inlays)
+    # we currently do not make use of InlayHintKind.Type for type inlays in CLS
+    inlays_with_colon = [(i[0], f": {i[1]}", None) for i in expected_inlays]
+    inlays = [
+        (i[0], f": {i[1]}", i[2] if len(i) >= 3 else True) for i in expected_inlays
+    ]
+    actual_inlays = await check_inlay_hints(client, doc, rng, inlays_with_colon)
 
     # Check that the inlays are insertable
     for expected, actual in zip(inlays, actual_inlays):
-        # the list of inlay text edits should have one element and have the
-        # same text/range as the inlay
-        assert actual.text_edits is not None
-        assert len(actual.text_edits) == 1
-        assert actual.text_edits[0].range.start == expected[0]
-        assert actual.text_edits[0].new_text == expected[1]
+        print(expected, actual)
+        if expected[2]:
+            # the list of inlay text edits should have one element and have the
+            # same text/range as the inlay
+            assert actual.text_edits is not None
+            assert len(actual.text_edits) == 1
+            assert actual.text_edits[0].range.start == expected[0]
+            assert actual.text_edits[0].new_text == expected[1]
+        else:
+            # the inlay should not be insertable
+            assert actual.text_edits is None
 
     return actual_inlays
 

--- a/tools/chpl-language-server/test/util/utils.py
+++ b/tools/chpl-language-server/test/util/utils.py
@@ -532,10 +532,13 @@ async def check_type_inlay_hints(
     Helper method for `check_inlay_hints`. Adds the `: ` prefix.
 
     `expected_inlays` is a list of tuples. The tuples can be either of length 2
-    or 3. If the tuple is of length 2, the first element is the expected
-    position and the second element is the expected text of the type. If the
-    tuple is of length 3, then the first two elements are the same. The third
-    element is a boolean that indicates whether the inlay hint is insertable.
+    or 3.
+    - If the tuple is of length 2, the first element is the expected position
+      and the second element is the expected text of the type. This implies that
+      the inlay hint is insertable.
+    - If the tuple is of length 3, then the first two elements are the same as
+      the 2-tuple. The third element is a boolean that indicates whether the
+      inlay hint is insertable.
     """
     # we currently do not make use of InlayHintKind.Type for type inlays in CLS
     inlays_with_colon = [(i[0], f": {i[1]}", None) for i in expected_inlays]

--- a/tools/chpl-language-server/test/util/utils.py
+++ b/tools/chpl-language-server/test/util/utils.py
@@ -540,7 +540,8 @@ async def check_type_inlay_hints(
     # we currently do not make use of InlayHintKind.Type for type inlays in CLS
     inlays_with_colon = [(i[0], f": {i[1]}", None) for i in expected_inlays]
     inlays = [
-        (i[0], f": {i[1]}", i[2] if len(i) >= 3 else True) for i in expected_inlays
+        (i[0], f": {i[1]}", i[2] if len(i) >= 3 else True)
+        for i in expected_inlays
     ]
     actual_inlays = await check_inlay_hints(client, doc, rng, inlays_with_colon)
 

--- a/tools/chpl-language-server/test/util/utils.py
+++ b/tools/chpl-language-server/test/util/utils.py
@@ -547,7 +547,6 @@ async def check_type_inlay_hints(
 
     # Check that the inlays are insertable
     for expected, actual in zip(inlays, actual_inlays):
-        print(expected, actual)
         if expected[2]:
             # the list of inlay text edits should have one element and have the
             # same text/range as the inlay


### PR DESCRIPTION
This fixes an issue where `chpl-language-server` would add insertable type inlays for loops, even though thats not valid syntax. If a user tried to insert the type inlay, they would then get a syntax error. This PR prevents users from making that mistake by removing the insertable inlay. The inlay still shows, it is just not insertable.

Prior to this PR, users woild be able to insert the type as shown below
![Screenshot 2024-05-31 at 3 11 56 PM](https://github.com/chapel-lang/chapel/assets/15747900/135615e7-78c0-4a0b-93a3-6b39548ed304)

Inserting this type creates the following error
![Screenshot 2024-05-31 at 3 13 11 PM](https://github.com/chapel-lang/chapel/assets/15747900/e3a1256d-07b4-4dbb-beb1-e6c87ac17ae5)

This PR prevents this situation from occurring all together.

Tested locally with `make test-cls`

[Reviewed by @DanilaFe]