### PR TITLE
Prevent misuse of `resolveFunction` in chpl-language-server

### DIFF
--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -649,7 +649,7 @@ class FileInfo:
 
             sig = candidate.function()
             fn = sig.ast()
-            if not fn:
+            if not fn or not isinstance(fn, chapel.Function):
                 continue
 
             # Even if we don't descend into it (and even if it's not an


### PR DESCRIPTION
Fixes an issue where chpl-language-server would incorrectly call `resolveFunction` on a non-function by adding a missing check in `_search_instantiations`

Tested locally

[Reviewed by @DanilaFe]