### PR TITLE
Fix how Dyno prints param booleans

### DIFF
--- a/frontend/include/chpl/types/Param.h
+++ b/frontend/include/chpl/types/Param.h
@@ -117,6 +117,9 @@ class Param {
   static std::string valueToString(ID id) {
     return id.str();
   }
+  static std::string valueToString(bool v) {
+    return v ? "true" : "false";
+  }
   template<typename T> static std::string valueToString(T v) {
     return std::to_string(v);
   }

--- a/tools/chpl-language-server/test/param_inlays.py
+++ b/tools/chpl-language-server/test/param_inlays.py
@@ -57,6 +57,9 @@ async def test_param_inlays_prim(client: LanguageClient):
             param e = if foo(string) then 1 else 10;
 
             param f = "hello";
+
+            param g = false;
+            param h = true;
            """
 
     inlays = [
@@ -66,6 +69,8 @@ async def test_param_inlays_prim(client: LanguageClient):
         (pos((7, 7)), "1"),
         (pos((8, 7)), "10"),
         (pos((10, 7)), '"hello"'),
+        (pos((12, 7)), "false"),
+        (pos((13, 7)), "true"),
     ]
 
     async with source_file(client, file) as doc:

--- a/tools/chpl-language-server/test/show_generic.py
+++ b/tools/chpl-language-server/test/show_generic.py
@@ -89,7 +89,7 @@ async def test_lenses_switch(client: LanguageClient):
     generic_inlays = [(pos((5, 13)), "p = ", None)]
     R_real_inlays = [
         (pos((2, 15)), ": R(real(64))", None),
-        (pos((2, 24)), "param value is 0", None),
+        (pos((2, 24)), "param value is false", None),
         (pos((2, 24)), ": bool", None),
         (pos((5, 13)), "p = ", None),
     ]


### PR DESCRIPTION
Fix how Dyno prints booleans, prior to this PR they were printed as `0` and `1` for `false` and `true`, respectively.

This effects how chpl-language-server prints param values.

```chapel
record R {
  param P: bool;
}
// prior to this PR
var a /*: R(1)*/ = new R(true);
// after this PR
var b /*: R(true)*/ = new R(true);
```

Note that this makes dyno printing match the production compiler.

```chapel
compilerWarning(b.type:string); // prints 'R(true)'

param p = false;
compilerWarning(p:string); // prints 'false'
```

Testing
- `make test-cls`

[Reviewed by @DanilaFe]