### PR TITLE
Patch build system to allow building with CHPL_TARGET_JEMALLOC=system

### DIFF
--- a/runtime/src/mem/jemalloc/mem-jemalloc.c
+++ b/runtime/src/mem/jemalloc/mem-jemalloc.c
@@ -64,6 +64,7 @@ static struct shared_heap {
 } heap;
 
 
+#ifdef USE_JE_CHUNK_HOOKS
 // compute aligned index into our shared heap, alignment must be a power of 2
 static inline void* alignHelper(void* base_ptr, size_t offset, size_t alignment) {
   uintptr_t p;
@@ -73,6 +74,7 @@ static inline void* alignHelper(void* base_ptr, size_t offset, size_t alignment)
   p = (p + alignment - 1) & ~(alignment - 1);
   return(void*) p;
 }
+#endif
 
 
 // *** Chunk hook replacements *** //

--- a/runtime/src/mem/jemalloc/mem-jemalloc.c
+++ b/runtime/src/mem/jemalloc/mem-jemalloc.c
@@ -47,10 +47,8 @@ unsigned CHPL_JE_LG_ARENA;
 // Decide whether or not to try to use jemalloc's chunk hooks interface
 //   jemalloc < 4.0 didn't support chunk_hooks_t
 //   jemalloc 4.1 changed opt.nareas from size_t to unsigned
-// .. so we use chunk hooks interface for jemalloc >= 4.1
-#if JEMALLOC_VERSION_MAJOR > 4
-#define USE_JE_CHUNK_HOOKS
-#endif
+//   jemalloc 5.x migrated to an extent API
+// .. so we use chunk hooks interface for jemalloc >= 4.1 and < 5.0
 #if (JEMALLOC_VERSION_MAJOR == 4) && (JEMALLOC_VERSION_MINOR >= 1)
 #define USE_JE_CHUNK_HOOKS
 #endif
@@ -302,7 +300,7 @@ static void replaceChunkHooks(void) {
     }
   }
 #else
-    chpl_internal_error("cannot init multi-locale heap: please rebuild with jemalloc >= 4.1");
+    chpl_internal_error("cannot init multi-locale heap: please rebuild with jemalloc >= 4.1 and < 5.0");
 #endif
 
 }

--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -76,8 +76,8 @@ ifeq ($(CFLAGS_NEEDS_RT_INCLUDES), y)
   # seems to cause Chapel programs built with the result to hang during
   # exit when shutting down Qthreads.
   #
-	# We also need to provide paths to system hwloc if its enabled
-  # since it might not be in default compiler search paths.
+	# We also need to provide paths to system hwloc and jemalloc if they are
+  # enabled, since it might not be in default compiler search paths.
 	#
   # Note that we call compileline with CHPL_MAKE_COMM=none. Under
   # CHPL_MAKE_COMM=gasnet, compileline will fail if gasnet is not built,
@@ -91,6 +91,9 @@ ifeq ($(CFLAGS_NEEDS_RT_INCLUDES), y)
   #
  	ifeq ($(CHPL_MAKE_HWLOC),system)
 		SYSTEM_INCS_DEFS := $(SYSTEM_INCS_DEFS)\|hwloc
+  endif
+	ifeq ($(CHPL_MAKE_TARGET_JEMALLOC),system)
+	SYSTEM_INCS_DEFS := $(SYSTEM_INCS_DEFS)\|jemalloc
   endif
 
   COMPILELINE_STDERR_REDIRECT=2> /dev/null

--- a/util/chplenv/compile_link_args_utils.py
+++ b/util/chplenv/compile_link_args_utils.py
@@ -73,7 +73,7 @@ def get_runtime_includes_and_defines():
             system.append("-isystem" + os.path.join(sdk_path, "hip", "include"))
             system.append("-isystem" + os.path.join(sdk_path, "hsa", "include"))
 
-    if mem == "jemalloc":
+    if mem == "jemalloc" and chpl_jemalloc.get('target') == "bundled":
         # set -DCHPL_JEMALLOC_PREFIX=chpl_je_
         # this is needed since it affects code inside of headers
         bundled.append("-DCHPL_JEMALLOC_PREFIX=chpl_je_")

--- a/util/chplenv/third-party-pkgs
+++ b/util/chplenv/third-party-pkgs
@@ -45,6 +45,8 @@ def generate_subdir_map():
     pkg_aliases['CHPL_GMP-bundled'] = 'gmp'
     pkg_aliases['CHPL_HWLOC-bundled'] = 'hwloc'
     pkg_aliases['CHPL_JEMALLOC-bundled'] = 'jemalloc'
+    pkg_aliases['CHPL_TARGET_JEMALLOC-bundled'] = 'jemalloc'
+    pkg_aliases['CHPL_HOST_JEMALLOC-bundled'] = 'jemalloc'
     pkg_aliases['CHPL_LIBFABRIC-bundled'] = 'libfabric'
     pkg_aliases['CHPL_LLVM-bundled'] = 'llvm'
     pkg_aliases['CHPL_UNWIND-bundled'] = 'libunwind'
@@ -71,7 +73,10 @@ def compute_required_pkgs():
             (var, val) = var.strip(), val.strip()
             # Ignore platform variables
             # Ignore CHPL_MEM (use CHPL_JEMALLOC)
-            if not (var.endswith('_PLATFORM') or var == 'CHPL_MEM'):
+            # Ignore CHPL_HOST_MEM (use CHPL_JEMALLOC)
+            # Ignore CHPL_TARGET_MEM (use CHPL_JEMALLOC)
+            ignore_vars = ['CHPL_MEM', 'CHPL_HOST_MEM', 'CHPL_TARGET_MEM']
+            if not (var.endswith('_PLATFORM') or var in ignore_vars):
                 if val in get_all_pkgs():
                     req_pkgs.add(val)
                 elif var + '-' + val in pkg_aliases:


### PR DESCRIPTION
This PR patches some of our build configuration scripts to be able to use `CHPL_TARGET_JEMALLOC=system`. This allows us to use our preferred configuration for performance (`CHPL_MEM=jemalloc`) in situations where we cannot build the bundled jemalloc (i.e. for packaging)

When using a system jemalloc 5.x, we have to turn off chunk hooks (jemalloc 5.x does not support it)

Testing:
- [x] `start_test test/release/examples` with `CHPL_MEM=jemalloc` and `CHPL_TARGET_JEMALLOC` on Mac

Notes:
- Builds on top of https://github.com/chapel-lang/chapel/pull/25145
- Fully unblocks https://github.com/chapel-lang/chapel/issues/24931 and https://github.com/chapel-lang/chapel/issues/24655, and enables homebrew to use the preferred config (https://github.com/chapel-lang/chapel/pull/25148)
- Uses diffs from https://github.com/chapel-lang/chapel/pull/23409

[Reviewed by @jhh67]