### PR TITLE
Add support for chplcheck testing to `nightly`

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -73,6 +73,8 @@ $pythonDep = 0;
 $testblog = 0;
 $blogonly = 0;
 $blogdir = "";
+$chplcheck = 0;
+$chplcheckonly = 0;
 
 while (@ARGV) {
     $flag = shift @ARGV;
@@ -173,6 +175,11 @@ while (@ARGV) {
         $testblog = 1;
     } elsif ($flag eq "-blogdir") {
         $blogdir = shift @ARGV;
+    } elsif ($flag eq "-chplcheck") {
+        $chplcheck = 1;
+    } elsif ($flag eq "-chplcheckonly") {
+        $chplcheck = 1;
+        $chplcheckonly = 1;
     } else {
         $printusage = 1;
         last;
@@ -214,6 +221,8 @@ if ($printusage == 1) {
     print "\t-blog                          : test the chapel blog with nightly tests. <blogdir> could be specified with CHPL_NIGHTLY_BLOGDIR or by passing -blogdir\n";
     print "\t-blogonly <blogdir>            : only run the chapel blog tests. <blogdir> could be specified with CHPL_NIGHTLY_BLOGDIR or by passing -blogdir\n";
     print "\t-blogdir <blogdir>             : specify the root of the chapel-blog repo to use with -blog or -blogonly";
+    print "\t-chplcheck                     : run the chplcheck tests\n";
+    print "\t-chpl-language-server          : run the Chapel Language Server tests\n";
     print "\t-componly                      : only run the compiler, not the generated binary\n";
     print "\t-compopts <opt>                : run tests with -compopts <opt>\n";
     print "\t-compperformance <description> : run tests with compiler performance tracking\n";
@@ -540,6 +549,15 @@ if ($python2 == 0 && $pythonDep == 0) {
 if ($buildruntime == 0) {
     print "Built compiler but not runtime, and did not run tests\n";
     exit 0;
+}
+
+if ($chplcheck == 1) {
+    # Build chplcheck if it's requested. If something is wrong with chapel-py,
+    # this can fail. It's not fatal, since it will only throw
+    # off the chplcheck-specific tests. However, we definitely want to send
+    # mail, since this indicates a problem with chplcheck.
+    print "Making chplcheck\n";
+    mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_opt chplcheck", "make chplcheck", $emailOnError);
 }
 
 print "Making $make_vars_opt runtime\n";

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -222,7 +222,7 @@ if ($printusage == 1) {
     print "\t-blogonly <blogdir>            : only run the chapel blog tests. <blogdir> could be specified with CHPL_NIGHTLY_BLOGDIR or by passing -blogdir\n";
     print "\t-blogdir <blogdir>             : specify the root of the chapel-blog repo to use with -blog or -blogonly";
     print "\t-chplcheck                     : run the chplcheck tests\n";
-    print "\t-chpl-language-server          : run the Chapel Language Server tests\n";
+    print "\t-chplcheckonly                 : only run the chplcheck tests\n";
     print "\t-componly                      : only run the compiler, not the generated binary\n";
     print "\t-compopts <opt>                : run tests with -compopts <opt>\n";
     print "\t-compperformance <description> : run tests with compiler performance tracking\n";

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -624,6 +624,10 @@ if ($blogonly == 1) {
     $testdirs .= " $blogdir/chpl-src/ $blogdir/content/posts";
 }
 
+if ($chplcheckonly == 1) {
+    $testdirs .= " chplcheck";
+}
+
 if (!($dist eq "")) {
     $testdirs .= " distributions/robust/arithmetic";
 }

--- a/util/cron/test-linux64-chplcheck-only.bash
+++ b/util/cron/test-linux64-chplcheck-only.bash
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# Test default configuration on chplcheck tests only
+
+CWD=$(cd $(dirname $0) ; pwd)
+
+source $CWD/common.bash
+source $CWD/common-localnode-paratest.bash
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-chplcheck-only"
+
+$CWD/nightly -cron -chplcheckonly ${nightly_args} $(get_nightly_paratest_args 8)


### PR DESCRIPTION
Closes https://github.com/chapel-lang/chapel/issues/24782 (except for the part about adding a new Jenkins job)

This PR builds on top of https://github.com/chapel-lang/chapel/pull/25149 to add support for `chplcheck` testing. It does so by adding a new flag, `chplcheck`, which is used to trigger `make chplcheck` during the build. As a consequence of `make chplcheck`, the Python bindings for Dyno are built. This enables existing tests in `test/chplcheck`, because their `SKIPIF` explicitly tries loading the `chapel-py` package from the virtual environment.

This PR depends on #25149 because it relies on the fixes in that PR to send emails on failure.

Reviewed by @arezaii -- thanks!