### PR TITLE
Fix scripts for perf tests

### DIFF
--- a/util/cron/common-perf.bash
+++ b/util/cron/common-perf.bash
@@ -3,8 +3,9 @@
 # Configure environment for performance testing. This should be sourced by other
 # scripts that wish to make use of the variables set here.
 
-source $(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)/common.bash
-source $(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)/common-fast.bash
+CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+source $CWD/common.bash
+source $CWD/common-fast.bash
 
 # It is tempting to use hostname --short, but macs only support the short form
 # of the argument.

--- a/util/cron/common-quickstart.bash
+++ b/util/cron/common-quickstart.bash
@@ -3,7 +3,8 @@
 # Configure environment for quickstart testing. This should be sourced by other
 # scripts that wish to make use of the variables set here.
 
-source $(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)/common.bash
+CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+source $CWD/common.bash
 source ${CHPL_HOME}/util/quickstart/setchplenv.bash
 
 # Skip $CHPL_HOME/test/regex/elliot/I-fail-without-re2


### PR DESCRIPTION
This fixes an issue without `util/cron/common-perf.bash` where `comm-fast.bash` was never being loaded into the environment, meaning that `unset CHPL_TARGET_CPU` was never being run. This was causing the confusing behavior of nightly tests running with `CHPL_TARGET_CPU=none` when they should not have.

The root cause was calling `$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)` twice in the same `.bash` file, instead of having `CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)`.

In an effort to future proof other test scripts, I also changed `common-quickstart` even though it wasn't currently an issue.

[Reviewed by @bradcray]
