### PR TITLE
Fix CLS bugs bundle

### DIFF
--- a/tools/chapel-py/src/chapel/lsp/__init__.py
+++ b/tools/chapel-py/src/chapel/lsp/__init__.py
@@ -45,11 +45,16 @@ def error_to_diagnostic(error) -> Diagnostic:
         "warning": DiagnosticSeverity.Warning,
     }
 
+    type_ = error.type()
+    if type_ is not None:
+        message = "{}: [{}]: {}".format(
+            error.kind().capitalize(), type_, error.message()
+        )
+    else:
+        message = "{}: {}".format(error.kind().capitalize(), error.message())
     diagnostic = Diagnostic(
         range=location_to_range(error.location()),
-        message="{}: [{}]: {}".format(
-            error.kind().capitalize(), error.type(), error.message()
-        ),
+        message=message,
         severity=kind_to_severity[error.kind()],
     )
     return diagnostic

--- a/tools/chapel-py/src/method-tables/core-methods.h
+++ b/tools/chapel-py/src/method-tables/core-methods.h
@@ -143,7 +143,10 @@ CLASS_BEGIN(Error)
   PLAIN_GETTER(Error, kind, "Retrieve the kind ('error', 'warning') of this type of error",
                const char*, return chpl::ErrorBase::getKindName(node->kind()))
   PLAIN_GETTER(Error, type, "Retrieve the unique name of this type of error",
-               const char*, return chpl::ErrorBase::getTypeName(node->type()))
+               std::optional<const char*>,
+               const char* name = chpl::ErrorBase::getTypeName(node->type());
+               return name ? std::optional(name) : std::nullopt;
+               )
 CLASS_END(Error)
 
 CLASS_BEGIN(ErrorManager)

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -690,7 +690,10 @@ class FileInfo:
         self._collect_possibly_visible_decls(asts)
 
         if self.use_resolver:
-            self._search_instantiations(asts)
+            # TODO: suppress resolution errors due to false-positives
+            # this should be removed once the resolver is finished
+            with self.context.context.track_errors() as _:
+                self._search_instantiations(asts)
 
     def called_function_at_position(
         self, position: Position

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -688,8 +688,7 @@ class FileInfo:
         self._collect_possibly_visible_decls(asts)
 
         if self.use_resolver:
-            with self.context.context.track_errors() as _:
-                self._search_instantiations(asts)
+            self._search_instantiations(asts)
 
     def called_function_at_position(
         self, position: Position

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -258,6 +258,8 @@ def encode_deltas(
     to it: each line is encoded as a delta from the previous line, and each
     column is encoded as a delta from the previous column.
 
+    `tokens` must be sorted by line number, and then by column number within
+
     Returns tokens with type token_type, and modifiers token_modifiers.
     """
 
@@ -1852,6 +1854,8 @@ def run_lsp():
                     ls.get_dead_code_tokens(ast, fi.file_lines(), instantiation)
                 )
 
+        # sort tokens by line number, and then by column number
+        tokens.sort(key=lambda x: (x[0], x[1]))
         return SemanticTokens(data=encode_deltas(tokens, 0, 0))
 
     @server.feature(TEXT_DOCUMENT_PREPARE_CALL_HIERARCHY)


### PR DESCRIPTION
This PR fixes several CLS issues as a bundle, as they are all small changes

Bugs fixed:
- Dead code for `if; else if; else` was not displayed correctly
- Errors like "Cannot establish type for call expression" that have no custom error type displayed strangely

[Reviewed by @DanilaFe]