### PR TITLE
Add missing parts of packaging scripts

### DIFF
--- a/util/packaging/apt/debian11/Dockerfile
+++ b/util/packaging/apt/debian11/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM debian:bullseye as build
 
 ARG BASENAME=chapel
 ARG CHAPEL_VERSION=2.0.0

--- a/util/packaging/apt/debian12/Dockerfile
+++ b/util/packaging/apt/debian12/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm
+FROM debian:bookworm as build
 
 ARG BASENAME=chapel
 ARG CHAPEL_VERSION=2.0.0

--- a/util/packaging/apt/ubuntu20/Dockerfile
+++ b/util/packaging/apt/ubuntu20/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:20.04 as build
 
 ARG BASENAME=chapel
 ARG CHAPEL_VERSION=2.0.0

--- a/util/packaging/rpm/fc37/Dockerfile
+++ b/util/packaging/rpm/fc37/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:37
+FROM fedora:37 as build
 
 ARG BASENAME=chapel
 ARG CHAPEL_VERSION=2.0.0

--- a/util/packaging/rpm/fc38/Dockerfile
+++ b/util/packaging/rpm/fc38/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:38
+FROM fedora:38 as build
 
 ARG BASENAME=chapel
 ARG CHAPEL_VERSION=2.0.0

--- a/util/packaging/rpm/fc39/Dockerfile
+++ b/util/packaging/rpm/fc39/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:39
+FROM fedora:39 as build
 
 ARG BASENAME=chapel
 ARG CHAPEL_VERSION=2.0.0


### PR DESCRIPTION
This PR adds a few missing parts to some of the packaging scripts used to build OS packages.

These are currently error-prone, as there is a lot of duplicated code between scripts. This PR serves as a stop gap measure until [this PR is ready](https://github.com/chapel-lang/chapel/pull/25076).

[Reviewed by @jhh67]