### PR TITLE
Add special handling for map.parSafe and set.parSafe unstable warnings

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -14165,7 +14165,7 @@ static CallExpr* createGenericRecordVarDefaultInitCall(Symbol* val,
         - var m: map(int, int);
         - var s: set(int);
         an unstable warning won't be generated (this is necessary because the
-        initializer with a parSafe argument is marked unstable).
+        initializer with a parSafe formal is marked unstable).
 
         This conditional can be removed if/when the unstable warning is removed
         from map and set's 'parSafe' fields.

--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -91,6 +91,22 @@ module Map {
     /* Type of map values. */
     type valType;
 
+    // NOTE: the compiler has some special handling for unstable warnings
+    // associated with map's parSafe field:
+    // * AggregateType::generateType -> ensures that specifying 'parSafe' in a type
+    //    expression for 'map' will generate a warning
+    // * functionResolution.createGenericRecordVarDefaultInitCall -> ensures that
+    //    the stable initializer is called when the compiler generates initializer
+    //     calls for variable declarations that don't specify 'parSafe' (or set it to false)
+    //
+    // This results in the following behavior:
+    //  - 'var m: map(int, int)' doesn't generate an unstable warning
+    //  - 'type t = map(int, int, false)' generates an unstable warning
+    //  - 'var m: map(int, int, parSafe=true)' generates two unstable warnings (one
+    //    for the type expression and one for the initializer call)
+    //  - 'var m: map(int, int, parSafe=false)' generates one unstable warning for
+    //    the type expression
+
     /* If `true`, this map will perform parallel safe operations. */
     @unstable("'map.parSafe' is unstable and is expected to be replaced by a separate map type in the future")
     param parSafe = false;

--- a/modules/standard/Set.chpl
+++ b/modules/standard/Set.chpl
@@ -150,6 +150,22 @@ module Set {
     /* The type of the elements contained in this set. */
     type eltType;
 
+    // NOTE: the compiler has some special handling for unstable warnings
+    // associated with set's parSafe field:
+    // * AggregateType::generateType -> ensures that specifying 'parSafe' in a type
+    //    expression for 'set' will generate a warning
+    // * functionResolution.createGenericRecordVarDefaultInitCall -> ensures that
+    //    the stable initializer is called when the compiler generates initializer
+    //     calls for variable declarations that don't specify 'parSafe' (or set it to false)
+    //
+    // This results in the following behavior:
+    //  - 'var m: set(int)' doesn't generate an unstable warning
+    //  - 'type t = set(int, false)' generates an unstable warning
+    //  - 'var m: set(int, parSafe=true)' generates two unstable warnings (one
+    //    for the type expression and one for the initializer call)
+    //  - 'var m: set(int, parSafe=false)' generates one unstable warning for
+    //    the type expression
+
     /* If `true`, this set will perform parallel safe operations. */
     @unstable("'set.parSafe' is unstable and is expected to be replaced by a separate set type in the future")
     param parSafe = false;
@@ -202,6 +218,7 @@ module Set {
                                       initialCapacity);
     }
 
+    pragma "last resort"
     @unstable("'set.parSafe' is unstable and is expected to be replaced by a separate set type in the future")
     proc init(type eltType, param parSafe,
               resizeThreshold=defaultHashTableResizeThreshold,

--- a/modules/standard/Set.chpl
+++ b/modules/standard/Set.chpl
@@ -218,7 +218,6 @@ module Set {
                                       initialCapacity);
     }
 
-    pragma "last resort"
     @unstable("'set.parSafe' is unstable and is expected to be replaced by a separate set type in the future")
     proc init(type eltType, param parSafe,
               resizeThreshold=defaultHashTableResizeThreshold,

--- a/test/unstable/Map/parSafe.chpl
+++ b/test/unstable/Map/parSafe.chpl
@@ -18,3 +18,10 @@ var m8 = new map(string,int,parSafe=false);
 m7.addOrReplace("a",1);
 m8["a"] = 1;
 writeln(m7.parSafe == true);
+
+var m9: map(int, int);
+var m10: map(int, int, true);
+var m11: map(int, int, parSafe=false);
+
+type a = map(int, int);
+type b = map(int, int, false);

--- a/test/unstable/Map/parSafe.good
+++ b/test/unstable/Map/parSafe.good
@@ -5,4 +5,8 @@ parSafe.chpl:13: warning: 'map.parSafe' is unstable and is expected to be replac
 parSafe.chpl:15: warning: 'map.parSafe' is unstable and is expected to be replaced by a separate map type in the future
 parSafe.chpl:16: warning: 'map.parSafe' is unstable and is expected to be replaced by a separate map type in the future
 parSafe.chpl:20: warning: 'map.parSafe' is unstable and is expected to be replaced by a separate map type in the future
+parSafe.chpl:23: warning: 'map.parSafe' is unstable and is expected to be replaced by a separate map type in the future
+parSafe.chpl:24: warning: 'map.parSafe' is unstable and is expected to be replaced by a separate map type in the future
+parSafe.chpl:27: warning: 'map.parSafe' is unstable and is expected to be replaced by a separate map type in the future
+parSafe.chpl:23: warning: 'map.parSafe' is unstable and is expected to be replaced by a separate map type in the future
 true

--- a/test/unstable/Set/parSafe.chpl
+++ b/test/unstable/Set/parSafe.chpl
@@ -24,3 +24,10 @@ var v = new Values();
 var s7 = new set(int, v, parSafe=true);
 var s8 = new set(int, v, parSafe=false);
 writeln(s7.parSafe == true);
+
+var s9: set(int);
+var s10: set(int, parSafe=true);
+var s11: set(int, false);
+
+type a = set(int);
+type b = set(int, parSafe=true);

--- a/test/unstable/Set/parSafe.good
+++ b/test/unstable/Set/parSafe.good
@@ -5,4 +5,8 @@ parSafe.chpl:13: warning: 'set.parSafe' is unstable and is expected to be replac
 parSafe.chpl:24: warning: 'set.parSafe' is unstable and is expected to be replaced by a separate set type in the future
 parSafe.chpl:25: warning: 'set.parSafe' is unstable and is expected to be replaced by a separate set type in the future
 parSafe.chpl:26: warning: 'set.parSafe' is unstable and is expected to be replaced by a separate set type in the future
+parSafe.chpl:29: warning: 'set.parSafe' is unstable and is expected to be replaced by a separate set type in the future
+parSafe.chpl:30: warning: 'set.parSafe' is unstable and is expected to be replaced by a separate set type in the future
+parSafe.chpl:33: warning: 'set.parSafe' is unstable and is expected to be replaced by a separate set type in the future
+parSafe.chpl:29: warning: 'set.parSafe' is unstable and is expected to be replaced by a separate set type in the future
 true


### PR DESCRIPTION
Add special logic to the compiler to prevent the following `map` and `set` initializations from emitting unstable warnings for their `parSafe` field:

```chpl
var m: map(int, int);
var s: set(int);
```

Also add logic to emit unstable warnings when specifying the `map` or `set` types with a value for `parSafe`:
```chpl
type mt = map(int, int, false);
type st = set(int, parSafe=true);
```

- [x] local paratest
- [x] gasnet paratest