### PR TITLE
Add a missing 'override'

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -2400,7 +2400,7 @@ module DefaultRectangular {
   }
 
   override proc DefaultRectangularArr.isDefaultRectangular() param do return true;
-  proc type DefaultRectangularArr.isDefaultRectangular() param do return true;
+  override proc type DefaultRectangularArr.isDefaultRectangular() param do return true;
 
   config param debugDRScan = false;
 

--- a/test/functions/export/exportArrProc.chpl
+++ b/test/functions/export/exportArrProc.chpl
@@ -1,0 +1,11 @@
+const D = {1..3};
+
+export proc foo(ref ret: [D] real, const ref input: [D] real) {
+  writeln("In my exported routine");
+  ret = 2 * input;
+}
+
+var A, B: [1..3] real;
+A = 1..3;
+foo(B, A);
+writeln(B);

--- a/test/functions/export/exportArrProc.good
+++ b/test/functions/export/exportArrProc.good
@@ -1,0 +1,2 @@
+In my exported routine
+2.0 4.0 6.0


### PR DESCRIPTION
While sketching out some code involving 'export' declarations, I ran into an error pointing out that an internal method was missing its override keyword, which was accurate.  Fixing that here.
