### PR TITLE
Fix symbol-not-found errors when checking imports due to module order

### DIFF
--- a/compiler/passes/ResolveScope.cpp
+++ b/compiler/passes/ResolveScope.cpp
@@ -696,6 +696,35 @@ void ResolveScope::firstImportedModuleName(Expr* expr,
   }
 }
 
+static void scopeResolveVisibilityStmtsIfNeeded(const ResolveScope* in,
+                                                const ResolveScope* toResolve) {
+  if (toResolve->progress == IUP_NOT_STARTED) {
+    // Don't go into the unprocessed uses and imports now if the scope is in
+    // progress - this should only happen if we're currently in the scope
+    // being processed, or if there's a circular dependency.
+    //
+    // Otherwise, traverse this scope and trigger the resolution of the
+    // uses and imports now
+    for_alist(expr, toResolve->asBlockStmt()->body) {
+      if (UseStmt* useStmt = toUseStmt(expr)) {
+        BaseAST* astScope = getScope(useStmt);
+        ResolveScope* useScope = in->getScopeFor(astScope);
+        useStmt->scopeResolve(useScope);
+
+      } else if (ImportStmt* importStmt = toImportStmt(expr)) {
+        BaseAST* astScope = getScope(importStmt);
+        ResolveScope* importScope = in->getScopeFor(astScope);
+        importStmt->scopeResolve(importScope);
+      }
+      if (toResolve->progress == IUP_COMPLETED) {
+        // Don't bother continuing to traverse the block's stmts if we've
+        // found all the uses or imports we know about.
+        break;
+      }
+    }
+  }
+}
+
 SymAndReferencedName ResolveScope::lookupForImport(Expr* expr,
                                                    bool isUse) const {
   Symbol* retval = NULL;
@@ -838,31 +867,7 @@ SymAndReferencedName ResolveScope::lookupForImport(Expr* expr,
       retval = symbol;
 
     } else {
-      if (scope->progress == IUP_NOT_STARTED) {
-        // Don't go into the unprocessed uses and imports now if the scope is in
-        // progress - this should only happen if we're currently in the scope
-        // being processed, or if there's a circular dependency.
-        //
-        // Otherwise, traverse this scope and trigger the resolution of the
-        // uses and imports now
-        for_alist(expr, scope->asBlockStmt()->body) {
-          if (UseStmt* useStmt = toUseStmt(expr)) {
-            BaseAST* astScope = getScope(useStmt);
-            ResolveScope* useScope = getScopeFor(astScope);
-            useStmt->scopeResolve(useScope);
-
-          } else if (ImportStmt* importStmt = toImportStmt(expr)) {
-            BaseAST* astScope = getScope(importStmt);
-            ResolveScope* importScope = getScopeFor(astScope);
-            importStmt->scopeResolve(importScope);
-          }
-          if (scope->progress == IUP_COMPLETED) {
-            // Don't bother continuing to traverse the block's stmts if we've
-            // found all the uses or imports we know about.
-            break;
-          }
-        }
-      }
+      scopeResolveVisibilityStmtsIfNeeded(this, scope);
       if (Symbol* symbol = scope->lookupPublicVisStmts(rhsName)) {
         retval = symbol;
       } else if (Symbol *symbol =
@@ -1357,6 +1362,8 @@ bool ResolveScope::getFieldsWithUses(const char* fieldName,
     symbols.push_back(sym);
 
   } else {
+    scopeResolveVisibilityStmtsIfNeeded(this, this);
+
     if (mUseImportList.size() > 0) {
       std::vector<VisibilityStmt*> useImportList = mUseImportList;
 

--- a/test/modules/use/issue-25172-abc.chpl
+++ b/test/modules/use/issue-25172-abc.chpl
@@ -1,0 +1,16 @@
+module A {
+  proc main() {
+    use C;
+    import B.{foo};
+    foo();
+  }
+}
+module B {
+  public use C;
+}
+
+module C {
+  proc foo() {
+    writeln("Just chilling");
+  }
+}

--- a/test/modules/use/issue-25172-abc.good
+++ b/test/modules/use/issue-25172-abc.good
@@ -1,0 +1,1 @@
+Just chilling

--- a/test/modules/use/issue-25172-math.chpl
+++ b/test/modules/use/issue-25172-math.chpl
@@ -1,0 +1,1 @@
+import Math.{sqrt};


### PR DESCRIPTION
Closes https://github.com/chapel-lang/chapel/issues/25172.

The problem is simple; it's due to the order in which modules are searched. It's possible to reproduce it in a single file, and the bug effectively has to do with the `public use` having not been resolved at the time that a module is searched. Here' a reproducer based on Shreyas' original example.

```Chapel
module A {
  proc main() {
    use C;
    import B.{foo};
    foo();
  }
}
module B {
  public use C;
}

module C {
  proc foo() {
    writeln("Just chilling");
  }
}
```

Produces

```
shreyasrepro.chpl:2: In function 'main':
shreyasrepro.chpl:4: error: Bad identifier, no known 'foo' defined in 'B'
```

The sequence is as follows:

1. A, B, C are constructed and added to the global module list, in that order.
2. A is scope-resolved. To verify the import from B, it needs to look for fields in variables scope and use statements.
3. Because B hasn't been scope-resolved yet, its use statements haven't been processed, so the lookup fails.

The solution I think is to make use of the logic that @lydia-duncan introduced in https://github.com/chapel-lang/chapel/pull/16021.

Reviewed by @lydia-duncan -- thanks!

## Testing
- [x] paratest