### PR TITLE
Dyno: Fix serialize/deserialize generation for classes

### DIFF
--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -426,7 +426,19 @@ generateDeSerialize(Context* context, const CompositeType* compType,
       UntypedFnSignature::FormalDetail(USTR("this"),
                                        UntypedFnSignature::DK_NO_DEFAULT,
                                        nullptr));
-  formalTypes.push_back(QualifiedType(QualifiedType::CONST_REF, compType));
+
+  QualifiedType thisType;
+  if (compType->isBasicClassType()) {
+    const Type* manager = nullptr;
+    auto borrowedNonnilDecor =
+        ClassTypeDecorator(ClassTypeDecorator::BORROWED_NONNIL);
+    auto receiverType =
+        ClassType::get(context, compType->toBasicClassType(), manager, borrowedNonnilDecor);
+    thisType = QualifiedType(QualifiedType::CONST_IN, receiverType);
+  } else {
+    thisType =QualifiedType(QualifiedType::CONST_REF, compType);
+  }
+  formalTypes.push_back(thisType);
 
   // TODO: Add constraints to these arguments
   ufsFormals.push_back(

--- a/frontend/test/resolution/testLibrary.cpp
+++ b/frontend/test/resolution/testLibrary.cpp
@@ -48,7 +48,7 @@ static void testHelloWorld() {
   assert(guard.numErrors() == 0);
 }
 
-static void testRecordSerialize() {
+static void testSerialize() {
   auto config = getConfigWithHome();
   Context ctx(config);
   Context* context = &ctx;
@@ -61,11 +61,21 @@ static void testRecordSerialize() {
     record R {
       var x : int;
     }
+    class C {
+      var x : int;
+    }
 
     proc main() {
       var writer : fileWriter(false);
       var r : R;
       r.serialize(writer, writer.serializer);
+
+      var o = new owned C(5);
+      o.serialize(writer, writer.serializer);
+      var s = new shared C(5);
+      s.serialize(writer, writer.serializer);
+      var u = new unmanaged C(5);
+      u.serialize(writer, writer.serializer);
     }
     )""";
 
@@ -75,7 +85,7 @@ static void testRecordSerialize() {
   assert(guard.numErrors() == 0);
 }
 
-static void testRecordDeserialize() {
+static void testDeserialize() {
   auto config = getConfigWithHome();
   Context ctx(config);
   Context* context = &ctx;
@@ -88,11 +98,21 @@ static void testRecordDeserialize() {
     record R {
       var x : int;
     }
+    class C {
+      var x : int;
+    }
 
     proc main() {
       var reader : fileReader(false);
       var r : R;
       r.deserialize(reader, reader.deserializer);
+
+      var o = new owned C(5);
+      o.deserialize(reader, reader.deserializer);
+      var s = new shared C(5);
+      s.deserialize(reader, reader.deserializer);
+      var u = new unmanaged C(5);
+      u.deserialize(reader, reader.deserializer);
     }
     )""";
 
@@ -104,8 +124,8 @@ static void testRecordDeserialize() {
 
 int main() {
   testHelloWorld();
-  testRecordSerialize();
-  testRecordDeserialize();
+  testSerialize();
+  testDeserialize();
 
   return 0;
 }


### PR DESCRIPTION
This PR updates serialize/deserialize signature generation for classes to use a borrowed non-nil receiver type, instead of using a managed type.

Testing:
- [x] test-dyno