### PR TITLE
Add perf annotation for `unset CHPL_TARGET_CPU`

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -570,6 +570,9 @@ all:
   05/01/24:
     - text: upgrade default LLVM to LLVM 17
       config: chapcs
+  06/03/24:
+    - text: Stop setting CHPL_TARGET_CPU (#25161)
+      config: chapcs
 
 # End all
 


### PR DESCRIPTION
Adds an perf annotation for a change to the perf testing infrastructure for chapcs, #25161

[Reviewed by @stonea]