### PR TITLE
Skip new test in multilocale compilations

### DIFF
--- a/test/functions/export/exportArrProc.skipif
+++ b/test/functions/export/exportArrProc.skipif
@@ -1,0 +1,2 @@
+CHPL_COMM != none
+COMPOPTS <= --no-local


### PR DESCRIPTION
I had forgotten that we generate an error when passing arrays by 'ref' to 'export' proces in multilocale programs, and didn't think to test this new test in that setting.  This skips it in those settings since the point of the test is independent of that question.
