### PR TITLE
dyno: adjust functions that return pre-determined IDs to parse the modules these IDs come from.

### DIFF
--- a/frontend/include/chpl/parsing/parsing-queries.h
+++ b/frontend/include/chpl/parsing/parsing-queries.h
@@ -361,6 +361,16 @@ filePathIsInBundledModule(Context* context, UniqueString filePath);
 const uast::Module* getToplevelModule(Context* context, UniqueString name);
 
 /**
+ Given a particular (presumably standard) module, return the ID of a symbol
+ with the given name in that module. Beyond creating the ID, this also ensures
+ that the standard module is parsed, and thus, that 'idToAst' on the returned
+ ID will return a non-null value.
+ */
+ID getSymbolFromTopLevelModule(Context* context,
+                               const char* modName,
+                               const char* symName);
+
+/**
  This query parses a submodule for 'include submodule'.
  Returns nullptr if no such file can be found.
  */

--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -841,6 +841,24 @@ const Module* getToplevelModule(Context* context, UniqueString name) {
   return getToplevelModuleQuery(context, name);
 }
 
+ID getSymbolFromTopLevelModule(Context* context,
+                               const char* modName,
+                               const char* symName) {
+  std::ignore = getToplevelModule(context, UniqueString::get(context, modName));
+
+  // Performance: this has to concatenate the two strings at runtime.
+  // This presumably has an overhead over writing something like Symbol.symname
+  // explicitly. If this becomes a performance issue, we can switch to
+  // a different format of this function, either accepting a full path as
+  // a second argument, or by using templates to concatenate the strings at
+  // compile time.
+  std::string fullPath = modName;
+  fullPath += ".";
+  fullPath += symName;
+
+  return ID(UniqueString::get(context, fullPath), -1, 0);
+}
+
 static const Module* const&
 getIncludedSubmoduleQuery(Context* context, ID includeModuleId) {
   QUERY_BEGIN(getIncludedSubmoduleQuery, context, includeModuleId);

--- a/frontend/lib/types/ArrayType.cpp
+++ b/frontend/lib/types/ArrayType.cpp
@@ -20,6 +20,7 @@
 #include "chpl/types/ArrayType.h"
 
 #include "chpl/framework/query-impl.h"
+#include "chpl/parsing/parsing-queries.h"
 #include "chpl/resolution/intents.h"
 #include "chpl/types/Param.h"
 
@@ -45,8 +46,7 @@ void ArrayType::stringify(std::ostream& ss,
 }
 
 static ID getArrayID(Context* context) {
-  auto symbolPath = UniqueString::get(context, "ChapelArray._array");
-  return ID(symbolPath, -1, 0);
+  return parsing::getSymbolFromTopLevelModule(context, "ChapelArray", "_array");
 }
 
 const owned<ArrayType>&

--- a/frontend/lib/types/BasicClassType.cpp
+++ b/frontend/lib/types/BasicClassType.cpp
@@ -65,9 +65,8 @@ BasicClassType::getRootClassType(Context* context) {
 
 const BasicClassType*
 BasicClassType::getReduceScanOpType(Context* context) {
-  auto symbolPath = UniqueString::get(context, "ChapelReduce.ReduceScanOp");
   auto name = UniqueString::get(context, "ReduceScanOp");
-  auto id = ID(symbolPath, -1, 0);
+  auto id = parsing::getSymbolFromTopLevelModule(context, "ChapelReduce", "ReduceScanOp");
   auto objectType = getRootClassType(context);
 
   return getBasicClassType(context, id, name,

--- a/frontend/lib/types/CPtrType.cpp
+++ b/frontend/lib/types/CPtrType.cpp
@@ -20,6 +20,7 @@
 #include "chpl/types/CPtrType.h"
 
 #include "chpl/framework/query-impl.h"
+#include "chpl/parsing/parsing-queries.h"
 #include "chpl/resolution/intents.h"
 #include "chpl/types/Param.h"
 #include "chpl/types/VoidType.h"
@@ -81,8 +82,7 @@ const CPtrType* CPtrType::getCVoidPtrType(Context* context) {
 
 const ID& CPtrType::getId(Context* context) {
   QUERY_BEGIN(getId, context);
-  UniqueString path = UniqueString::get(context, "CTypes.c_ptr");
-  ID result { path, -1, 0 };
+  ID result = parsing::getSymbolFromTopLevelModule(context, "CTypes", "c_ptr");
   return QUERY_END(result);
 }
 
@@ -97,8 +97,7 @@ const CPtrType* CPtrType::withoutConst(Context* context) const {
 
 const ID& CPtrType::getConstId(Context* context) {
   QUERY_BEGIN(getConstId, context);
-  UniqueString path = UniqueString::get(context, "CTypes.c_ptrConst");
-  ID result { path, -1, 0 };
+  ID result = parsing::getSymbolFromTopLevelModule(context, "CTypes", "c_ptrConst");
   return QUERY_END(result);
 }
 

--- a/frontend/lib/types/CompositeType.cpp
+++ b/frontend/lib/types/CompositeType.cpp
@@ -135,36 +135,32 @@ void CompositeType::stringify(std::ostream& ss,
 }
 
 const RecordType* CompositeType::getStringType(Context* context) {
-  auto symbolPath = UniqueString::get(context, "String._string");
   auto name = UniqueString::get(context, "string");
-  auto id = ID(symbolPath, -1, 0);
+  auto id = parsing::getSymbolFromTopLevelModule(context, "String", "_string");
   return RecordType::get(context, id, name,
                          /* instantiatedFrom */ nullptr,
                          SubstitutionsMap());
 }
 
 const RecordType* CompositeType::getRangeType(Context* context) {
-  auto symbolPath = UniqueString::get(context, "ChapelRange._range");
   auto name = UniqueString::get(context, "_range");
-  auto id = ID(symbolPath, -1, 0);
+  auto id = parsing::getSymbolFromTopLevelModule(context, "ChapelRange", "_range");
   return RecordType::get(context, id, name,
                          /* instantiatedFrom */ nullptr,
                          SubstitutionsMap());
 }
 
 const RecordType* CompositeType::getBytesType(Context* context) {
-  auto symbolPath = UniqueString::get(context, "Bytes._bytes");
   auto name = UniqueString::get(context, "bytes");
-  auto id = ID(symbolPath, -1, 0);
+  auto id = parsing::getSymbolFromTopLevelModule(context, "Bytes", "_bytes");
   return RecordType::get(context, id, name,
                          /* instantiatedFrom */ nullptr,
                          SubstitutionsMap());
 }
 
 const RecordType* CompositeType::getLocaleType(Context* context) {
-  auto symbolPath = UniqueString::get(context, "ChapelLocale._locale");
   auto name = UniqueString::get(context, "locale");
-  auto id = ID(symbolPath, -1, 0);
+  auto id = parsing::getSymbolFromTopLevelModule(context, "ChapelLocale", "_locale");
   return RecordType::get(context, id, name,
                          /* instantiatedFrom */ nullptr,
                          SubstitutionsMap());
@@ -209,9 +205,8 @@ bool CompositeType::isMissingBundledClassType(Context* context, ID id) {
 }
 
 const ClassType* CompositeType::getErrorType(Context* context) {
-  auto symbolPath = UniqueString::get(context, "Errors.Error");
   auto name = UniqueString::get(context, "Error");
-  auto id = ID(symbolPath, -1, 0);
+  auto id = parsing::getSymbolFromTopLevelModule(context, "Errors", "Error");
   auto dec = ClassTypeDecorator(ClassTypeDecorator::GENERIC_NONNIL);
   auto bct = BasicClassType::get(context, id,
                                 name,

--- a/frontend/lib/types/DomainType.cpp
+++ b/frontend/lib/types/DomainType.cpp
@@ -20,6 +20,7 @@
 #include "chpl/types/DomainType.h"
 
 #include "chpl/framework/query-impl.h"
+#include "chpl/parsing/parsing-queries.h"
 #include "chpl/resolution/intents.h"
 #include "chpl/types/Param.h"
 #include "chpl/types/TupleType.h"
@@ -52,8 +53,7 @@ void DomainType::stringify(std::ostream& ss,
 }
 
 static ID getDomainID(Context* context) {
-  auto symbolPath = UniqueString::get(context, "ChapelDomain._domain");
-  return ID(symbolPath, -1, 0);
+  return parsing::getSymbolFromTopLevelModule(context, "ChapelDomain", "_domain");
 }
 
 const owned<DomainType>&

--- a/frontend/lib/types/EnumType.cpp
+++ b/frontend/lib/types/EnumType.cpp
@@ -59,9 +59,8 @@ const EnumType* EnumType::get(Context* context, ID id, UniqueString name) {
 }
 
 const EnumType* EnumType::getBoundKindType(Context* context) {
-  auto symbolPath = UniqueString::get(context, "ChapelRange.boundKind");
   auto name = UniqueString::get(context, "boundKind");
-  auto id = ID(symbolPath, -1, 0);
+  auto id = parsing::getSymbolFromTopLevelModule(context, "ChapelRange", "boundKind");
   return EnumType::get(context, id, name);
 }
 


### PR DESCRIPTION
Normally, IDs are only assigned to ASTs once they've been parsed, so `idToAst` is safe to assume that it should just find the AST that corresponds to a given ID in the existing list of parsing results. However, some of our code expects IDs for certain modules to exist, and returns those. However, this means that sometimes the modules haven't been parsed, and `idToAst` lookups will fail. This PR adds a wrapper for this "return expected ID" pattern that forced the parsing of the module in question.

Reviewed by @riftEmber -- thanks!

## Testing
- [x] paratest
- [x] `make test-cls`