### PR TITLE
Switch to using the GASNet EX API as the default

### DIFF
--- a/util/chplenv/chpl_gasnet.py
+++ b/util/chplenv/chpl_gasnet.py
@@ -7,7 +7,7 @@ import os
 def get_version():
     version = overrides.get('CHPL_GASNET_VERSION')
     if not version:
-        version = '1'
+        version = 'ex'
     if version not in ("1", "ex"):
         error("CHPL_GASNET_VERSION must be '1' or 'ex'")
     return version

--- a/util/cron/test-gasnet-1-everything.bash
+++ b/util/cron/test-gasnet-1-everything.bash
@@ -13,7 +13,7 @@ export GASNET_QUIET=Y
 # Test a GASNet compile using the default segment (everything for linux64)
 export CHPL_GASNET_SEGMENT=everything
 
-# Test GASNet EX
-export CHPL_GASNET_VERSION=ex
+# Test GASNet 1
+export CHPL_GASNET_VERSION=1
 
 $CWD/nightly -cron $(get_nightly_paratest_args 8)

--- a/util/cron/test-gasnet-1-everything.bash
+++ b/util/cron/test-gasnet-1-everything.bash
@@ -6,7 +6,7 @@ CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common-gasnet.bash
 source $CWD/common-localnode-paratest.bash
 
-export CHPL_NIGHTLY_TEST_CONFIG_NAME="gasnet-ex-everything"
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="gasnet-1-everything"
 
 export GASNET_QUIET=Y
 

--- a/util/cron/test-perf.hpe-apollo-hdr.gasnet-1-ibv.large.bash
+++ b/util/cron/test-perf.hpe-apollo-hdr.gasnet-1-ibv.large.bash
@@ -17,8 +17,8 @@ perf_hpe_apollo_args="-performance-configs gn-ibv-large:v,gn-ex-ibv-large:v -per
 
 export GASNET_PHYSMEM_MAX="0.90"
 
-# Test GASNet EX
-export CHPL_GASNET_VERSION=ex
+# Test GASNet 1
+export CHPL_GASNET_VERSION=1
 
 nightly_args="${nightly_args} -no-buildcheck"
 perf_args="-performance-description gn-ex-ibv-large -numtrials 1 -sync-dir-suffix gex"

--- a/util/cron/test-perf.hpe-apollo-hdr.gasnet-1-ibv.large.bash
+++ b/util/cron/test-perf.hpe-apollo-hdr.gasnet-1-ibv.large.bash
@@ -13,7 +13,7 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.hpe-apollo-hdr.gasnet-1-ibv.large"
 
 source $CWD/common-hpe-apollo.bash
 source $CWD/common-perf-hpe-apollo-hdr.bash
-perf_hpe_apollo_args="-performance-configs gn-ibv-large:v,gn-ex-ibv-large:v -perflabel ml- -startdate 08/28/23"
+perf_hpe_apollo_args="-performance-configs gn-ibv-large:v,gn-1-ibv-large:v -perflabel ml- -startdate 08/28/23"
 
 export GASNET_PHYSMEM_MAX="0.90"
 
@@ -21,6 +21,6 @@ export GASNET_PHYSMEM_MAX="0.90"
 export CHPL_GASNET_VERSION=1
 
 nightly_args="${nightly_args} -no-buildcheck"
-perf_args="-performance-description gn-ex-ibv-large -numtrials 1 -sync-dir-suffix gex"
+perf_args="-performance-description gn-1-ibv-large -numtrials 1 -sync-dir-suffix g1"
 
 $CWD/nightly -cron ${perf_args} ${perf_hpe_apollo_args} ${nightly_args}

--- a/util/cron/test-perf.hpe-apollo-hdr.gasnet-1-ibv.large.bash
+++ b/util/cron/test-perf.hpe-apollo-hdr.gasnet-1-ibv.large.bash
@@ -9,7 +9,7 @@ export CHPL_TEST_PERF_CONFIG_NAME='16-node-apollo-hdr'
 
 source $CWD/common-perf.bash
 
-export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.hpe-apollo-hdr.gasnet-ex-ibv.large"
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.hpe-apollo-hdr.gasnet-1-ibv.large"
 
 source $CWD/common-hpe-apollo.bash
 source $CWD/common-perf-hpe-apollo-hdr.bash

--- a/util/cron/test-slurm-gasnet-1-ibv.c-backend.bash
+++ b/util/cron/test-slurm-gasnet-1-ibv.c-backend.bash
@@ -13,7 +13,7 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="slurm-gasnet-ex-ibv.c-backend"
 
 export CHPL_COMM_SUBSTRATE=ibv
 
-# Test GASNet EX
-export CHPL_GASNET_VERSION=ex
+# Test GASNet 1
+export CHPL_GASNET_VERSION=1
 
 $CWD/nightly -cron -examples ${nightly_args} < /dev/null

--- a/util/cron/test-slurm-gasnet-1-ibv.c-backend.bash
+++ b/util/cron/test-slurm-gasnet-1-ibv.c-backend.bash
@@ -9,7 +9,7 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-slurm-gasnet-cray-cs.bash
 source $CWD/common-c-backend.bash
 
-export CHPL_NIGHTLY_TEST_CONFIG_NAME="slurm-gasnet-ex-ibv.c-backend"
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="slurm-gasnet-1-ibv.c-backend"
 
 export CHPL_COMM_SUBSTRATE=ibv
 

--- a/util/cron/test-slurm-gasnet-1-ibv.c-backend.bash
+++ b/util/cron/test-slurm-gasnet-1-ibv.c-backend.bash
@@ -2,7 +2,7 @@
 #
 # Multi-node, multi-locale testing on a cray-cs with slurm-gasnetrun_ibv
 # launcher:
-# test gasnet-ex configuration with CHPL_LLVM=none & CHPL_TARGET_COMPILER=gnu
+# test gasnet configuration with CHPL_LLVM=none & CHPL_TARGET_COMPILER=gnu
 # test against "examples"
 
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)

--- a/util/cron/test-slurm-gasnet-1-ibv.fast.bash
+++ b/util/cron/test-slurm-gasnet-1-ibv.fast.bash
@@ -7,7 +7,7 @@
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-slurm-gasnet-cray-cs.bash
 
-export CHPL_NIGHTLY_TEST_CONFIG_NAME="slurm-gasnet-ex-ibv.fast"
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="slurm-gasnet-1-ibv.fast"
 
 export CHPL_COMM_SUBSTRATE=ibv
 

--- a/util/cron/test-slurm-gasnet-1-ibv.fast.bash
+++ b/util/cron/test-slurm-gasnet-1-ibv.fast.bash
@@ -2,19 +2,19 @@
 #
 # Multi-node, multi-locale testing on a cray-cs cluster with slurm-gasnetrun_ibv
 # launcher:
-# test gasnet-ex (segment large) against "examples"
+# test gasnet-ex (segment fast) against "examples"
 
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-slurm-gasnet-cray-cs.bash
 
-export CHPL_NIGHTLY_TEST_CONFIG_NAME="slurm-gasnet-ex-ibv.large"
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="slurm-gasnet-ex-ibv.fast"
 
 export CHPL_COMM_SUBSTRATE=ibv
 
-# Test a GASNet compile using the large segment
-export CHPL_GASNET_SEGMENT=large
+# Test a GASNet compile using the fast segment
+export CHPL_GASNET_SEGMENT=fast
 
-# Test GASNet EX
-export CHPL_GASNET_VERSION=ex
+# Test GASNet 1
+export CHPL_GASNET_VERSION=1
 
 $CWD/nightly -cron -examples ${nightly_args} < /dev/null

--- a/util/cron/test-slurm-gasnet-1-ibv.fast.bash
+++ b/util/cron/test-slurm-gasnet-1-ibv.fast.bash
@@ -2,7 +2,7 @@
 #
 # Multi-node, multi-locale testing on a cray-cs cluster with slurm-gasnetrun_ibv
 # launcher:
-# test gasnet-ex (segment fast) against "examples"
+# test gasnet (segment fast) against "examples"
 
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-slurm-gasnet-cray-cs.bash

--- a/util/cron/test-slurm-gasnet-1-ibv.large.bash
+++ b/util/cron/test-slurm-gasnet-1-ibv.large.bash
@@ -7,7 +7,7 @@
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-slurm-gasnet-cray-cs.bash
 
-export CHPL_NIGHTLY_TEST_CONFIG_NAME="slurm-gasnet-ex-ibv.large"
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="slurm-gasnet-1-ibv.large"
 
 export CHPL_COMM_SUBSTRATE=ibv
 

--- a/util/cron/test-slurm-gasnet-1-ibv.large.bash
+++ b/util/cron/test-slurm-gasnet-1-ibv.large.bash
@@ -2,19 +2,19 @@
 #
 # Multi-node, multi-locale testing on a cray-cs cluster with slurm-gasnetrun_ibv
 # launcher:
-# test gasnet-ex (segment fast) against "examples"
+# test gasnet-ex (segment large) against "examples"
 
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-slurm-gasnet-cray-cs.bash
 
-export CHPL_NIGHTLY_TEST_CONFIG_NAME="slurm-gasnet-ex-ibv.fast"
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="slurm-gasnet-ex-ibv.large"
 
 export CHPL_COMM_SUBSTRATE=ibv
 
-# Test a GASNet compile using the fast segment
-export CHPL_GASNET_SEGMENT=fast
+# Test a GASNet compile using the large segment
+export CHPL_GASNET_SEGMENT=large
 
-# Test GASNet EX
-export CHPL_GASNET_VERSION=ex
+# Test GASNet 1
+export CHPL_GASNET_VERSION=1
 
 $CWD/nightly -cron -examples ${nightly_args} < /dev/null

--- a/util/cron/test-slurm-gasnet-1-ibv.large.bash
+++ b/util/cron/test-slurm-gasnet-1-ibv.large.bash
@@ -2,7 +2,7 @@
 #
 # Multi-node, multi-locale testing on a cray-cs cluster with slurm-gasnetrun_ibv
 # launcher:
-# test gasnet-ex (segment large) against "examples"
+# test gasnet (segment large) against "examples"
 
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-slurm-gasnet-cray-cs.bash

--- a/util/cron/test-slurm-gasnet-1-mpi.bash
+++ b/util/cron/test-slurm-gasnet-1-mpi.bash
@@ -11,7 +11,7 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="slurm-gasnet-ex-mpi"
 module load openmpi/gcc
 export CHPL_COMM_SUBSTRATE=mpi
 
-# Test GASNet EX
-export CHPL_GASNET_VERSION=ex
+# Test GASNet 1
+export CHPL_GASNET_VERSION=1
 
 $CWD/nightly -cron -hellos ${nightly_args}

--- a/util/cron/test-slurm-gasnet-1-mpi.bash
+++ b/util/cron/test-slurm-gasnet-1-mpi.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Test gasnet-ex mpi against hellos on cray-cs.
+# Test gasnet mpi against hellos on cray-cs.
 
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common-slurm-gasnet-cray-cs.bash

--- a/util/cron/test-slurm-gasnet-1-mpi.bash
+++ b/util/cron/test-slurm-gasnet-1-mpi.bash
@@ -5,7 +5,7 @@
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common-slurm-gasnet-cray-cs.bash
 
-export CHPL_NIGHTLY_TEST_CONFIG_NAME="slurm-gasnet-ex-mpi"
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="slurm-gasnet-1-mpi"
 
 # setup for mpi
 module load openmpi/gcc


### PR DESCRIPTION
Make `comm-gasnet-ex.c` the default GASNet shim instead of `comm-gasnet.c`.  This will facilitate future development using the GASNet-EX API. As a result of this change, the standard `gasnet` tests in `util/cron` will use GASNet-EX, so the `*gasnet-ex*` tests scripts have been renamed to `*gasnet-1*` and modified to use the GASNet-1 shim. Eventually these tests will be removed when the GASNet-1 shim is deprecated.

Resolves https://github.com/Cray/chapel-private/issues/6356.