### PR TITLE
Add documentation on how to install the language server and linter in emacs

### DIFF
--- a/doc/rst/tools/chpl-language-server/chpl-language-server.rst
+++ b/doc/rst/tools/chpl-language-server/chpl-language-server.rst
@@ -62,6 +62,39 @@ VSCode
 Install the ``chapel`` extension from the `Visual Studio Code marketplace
 <https://marketplace.visualstudio.com/items?itemName=chpl-hpe.chapel-vscode>`_.
 
+Emacs
+^^^^^
+
+With Emacs 29.1, support has been added for language server protocols via `Eglot
+<https://www.gnu.org/software/emacs/manual/html_mono/eglot.html>`_
+
+To utilize the Chapel language server with Eglot, add the following to your
+``.emacs`` file:
+
+.. code-block:: lisp
+
+  (with-eval-after-load 'eglot
+    (add-to-list 'eglot-server-programs
+                 '(chpl-mode . ("chpl-language-server"))))
+
+This will enable using the language server with a particular ``.chpl`` file by
+calling ``M-x eglot``.
+
+To automatically use Eglot and the language server with every ``.chpl`` file,
+additionally add the following to your ``.emacs`` file:
+
+.. code-block:: lisp
+
+   (add-hook 'chpl-mode-hook 'eglot-ensure)
+
+.. note::
+
+   There is currently a limitation with Eglot that only one language server can
+   be registered per language.  We are investigating merging the support for
+   :ref:`readme-chplcheck` such that both can be used in Emacs at the same time,
+   stay tuned!
+
+
 Supported Features
 ------------------
 

--- a/doc/rst/tools/chpl-language-server/chpl-language-server.rst
+++ b/doc/rst/tools/chpl-language-server/chpl-language-server.rst
@@ -71,7 +71,7 @@ With Emacs 29.1, support has been added for language server protocols via `Eglot
 To utilize the Chapel language server with Eglot, add the following to your
 ``.emacs`` file (note that this assumes you have already followed the
 instructions in ``$CHPL_HOME/highlight/emacs/README.rst`` to install Chapel
-syntax highlighting in emacs):
+syntax highlighting in Emacs):
 
 .. code-block:: lisp
 

--- a/doc/rst/tools/chpl-language-server/chpl-language-server.rst
+++ b/doc/rst/tools/chpl-language-server/chpl-language-server.rst
@@ -69,7 +69,9 @@ With Emacs 29.1, support has been added for language server protocols via `Eglot
 <https://www.gnu.org/software/emacs/manual/html_mono/eglot.html>`_
 
 To utilize the Chapel language server with Eglot, add the following to your
-``.emacs`` file:
+``.emacs`` file (note that this assumes you have already followed the
+instructions in ``$CHPL_HOME/highlight/emacs/README.rst`` to install Chapel
+syntax highlighting in emacs):
 
 .. code-block:: lisp
 

--- a/doc/rst/tools/chplcheck/chplcheck.rst
+++ b/doc/rst/tools/chplcheck/chplcheck.rst
@@ -147,7 +147,10 @@ Emacs
 With Emacs 29.1, support has been added for language server protocols via `Eglot
 <https://www.gnu.org/software/emacs/manual/html_mono/eglot.html>`_
 
-To utilize the linter via Eglot, add the following to your ``.emacs`` file:
+To utilize the linter via Eglot, add the following to your ``.emacs`` file (note
+that this assumes you have already followed the instructions in
+``$CHPL_HOME/highlight/emacs/README.rst`` to install Chapel syntax highlighting
+in Emacs):
 
 .. code-block:: lisp
 

--- a/doc/rst/tools/chplcheck/chplcheck.rst
+++ b/doc/rst/tools/chplcheck/chplcheck.rst
@@ -141,6 +141,39 @@ VSCode
 Install the ``chapel`` extension from the `Visual Studio Code marketplace
 <https://marketplace.visualstudio.com/items?itemName=chpl-hpe.chapel-vscode>`_.
 
+Emacs
+~~~~~
+
+With Emacs 29.1, support has been added for language server protocols via `Eglot
+<https://www.gnu.org/software/emacs/manual/html_mono/eglot.html>`_
+
+To utilize the linter via Eglot, add the following to your ``.emacs`` file:
+
+.. code-block:: lisp
+
+   (with-eval-after-load 'eglot
+     (add-to-list 'eglot-server-programs
+                  '(chpl-mode . ("chplcheck" "--lsp"))))
+
+This will enable using the linter with a particular ``.chpl`` file by calling
+``M-x eglot``.
+
+To automatically use Eglot and the linter with every ``.chpl`` file,
+additionally add the following to your ``.emacs`` file:
+
+.. code-block:: lisp
+
+   (add-hook 'chpl-mode-hook 'eglot-ensure)
+
+.. note::
+
+   There is currently a limitation with Eglot that only one language server can
+   be registered per language.  We are investigating merging the support for
+   :ref:`readme-chpl-language-server` such that both can be used in Emacs at the
+   same time, stay tuned!
+
+
+
 Writing New Rules
 -----------------
 


### PR DESCRIPTION
Resolves Cray/chapel-private#6378

Currently both can't be used at the same time so note that for the time being.

Verified the built docs looked nice