### PR TITLE
Use proper nightly flag for chplcheck-cls-only test

### DIFF
--- a/util/cron/test-linux64-chplcheck-cls-only.bash
+++ b/util/cron/test-linux64-chplcheck-cls-only.bash
@@ -9,4 +9,4 @@ source $CWD/common-localnode-paratest.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-chplcheck-cls-only"
 
-$CWD/nightly -cron -assertions -chplcheckonly -chpl-language-server ${nightly_args} $(get_nightly_paratest_args 8)
+$CWD/nightly -cron -asserts -chplcheckonly -chpl-language-server ${nightly_args} $(get_nightly_paratest_args 8)


### PR DESCRIPTION
No idea how `-assertions` got in there instead of `-asserts`.

Reviewed by @tzinsky -- thanks!