### PR TITLE
Fix `start_test` not suppressing timeout errors

### DIFF
--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -2481,7 +2481,7 @@ def main():
                                 sys.stdout.write(']\n')
                         # only notify for a failed execution if launching the test was successful
                         elif (not launcher_error):
-                            sys.stdout.write('[Error execution failed for %s]\n'%(test_name))
+                            sys.stdout.write('%s[Error execution failed for %s]\n'%(futuretest,test_name))
 
                         if exectimeout or status != 0 or exec_status != 0:
                             break


### PR DESCRIPTION
Fixes an issue were `start_test` would not suppress timeout errors properly. Adjusted `sub_test` to add the appropriate future line.

[Review by @jeremiah-corrado]