### PR TITLE
Ensure tmp folder is deleted even if context is deliberately leaked

### DIFF
--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -1119,7 +1119,8 @@ void clean_exit(int status) {
 
   if (fExitLeaks) {
     // The context's destructor takes a while, and we're about to exit anyway,
-    // so deliberately leak it.
+    // so deliberately leak it. Still perform file-based cleanup, though.
+    gContext->cleanupTmpDirIfNeeded();
   } else {
     delete gContext;
   }


### PR DESCRIPTION
This was previously causing some pollution due an accumulation of temporary folders.

Fortunately, doing this does not make any difference in terms of performance improvements that came from leaking the context.

Reviewed by @riftEmber -- thanks!

## Testing
- [x] paratest