### PR TITLE
Fix #18050: Ensure GASNet can use hwloc

### DIFF
--- a/third-party/gasnet/Makefile
+++ b/third-party/gasnet/Makefile
@@ -91,8 +91,9 @@ GASNET_CFLAGS += $(SHARED_LIB_CFLAGS)
 MPI_CC += $(SHARED_LIB_CFLAGS)
 endif
 
-# Disable hwloc until https://github.com/chapel-lang/chapel/issues/18050
-CHPL_GASNET_CFG_OPTIONS += --disable-hwloc
+ifeq ($(CHPL_MAKE_HWLOC),bundled)
+CHPL_GASNET_CFG_OPTIONS += --with-hwloc-home=$(HWLOC_INSTALL_DIR)
+endif
 
 # Disable IBV ODP due to https://upc-bugs.lbl.gov/bugzilla/show_bug.cgi?id=4008
 CHPL_GASNET_CFG_OPTIONS += --disable-ibv-odp

--- a/third-party/gasnet/Makefile
+++ b/third-party/gasnet/Makefile
@@ -94,6 +94,12 @@ endif
 ifeq ($(CHPL_MAKE_HWLOC),bundled)
 CHPL_GASNET_CFG_OPTIONS += --with-hwloc-home=$(HWLOC_INSTALL_DIR)
 endif
+ifeq ($(CHPL_MAKE_HWLOC),system)
+CHPL_GASNET_CFG_OPTIONS += --with-hwloc-home=$(shell $(CHPL_MAKE_PYTHON) $(CHPL_MAKE_HOME)/util/chplenv/chpl_hwloc.py --prefix)
+endif
+ifeq ($(CHPL_MAKE_HWLOC),none)
+CHPL_GASNET_CFG_OPTIONS += --disable-hwloc
+endif
 
 # Disable IBV ODP due to https://upc-bugs.lbl.gov/bugzilla/show_bug.cgi?id=4008
 CHPL_GASNET_CFG_OPTIONS += --disable-ibv-odp


### PR DESCRIPTION
PR #18049 temporarily disabled GASNet's use of hwloc to work-around link failures arising from disparate versions of hwloc ending up in the same executable. Unfortunately this also hobbled GASNet's built-in support for toplogy-aware intelligent selection of network adapter on multi-NIC nodes, especially on InfiniBand multi-rail systems.

This commit restores GASNet's ability to detect hwloc, and ensures that it uses the same hwloc as the rest of the Chapel runtime.

I've tested this on the JLSE Cascade InfiniBand cluster using both `CHPL_HWLOC=bundled` and `CHPL_HWLOC=system`

[Contributed by @bonachea, reviewed and merged by @jabraham17]