### PR TITLE
Misleading indent var warn

### DIFF
--- a/test/chplcheck/MisleadingIndentation.chpl
+++ b/test/chplcheck/MisleadingIndentation.chpl
@@ -23,4 +23,9 @@ writeln("second thing");
   writeln(i);
   writeln("second thing");
 
+  proc f() {
+      for 1..10 do
+          writeln("Hello, world!");
+      var unrelated = "hi";
+  }
 }

--- a/test/chplcheck/MisleadingIndentation.good-fixit
+++ b/test/chplcheck/MisleadingIndentation.good-fixit
@@ -25,4 +25,9 @@ writeln(i);
   writeln(i);
   writeln("second thing");
 
+  proc f() {
+      for 1..10 do
+          writeln("Hello, world!");
+      var unrelated = "hi";
+  }
 }

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -46,6 +46,8 @@ def might_incorrectly_report_location(node: AstNode) -> bool:
 
     # some NamedDecl nodes currently use the name as the location, which
     # does not indicate their actual indentation.
+    #
+    # https://github.com/chapel-lang/chapel/issues/25208
     if isinstance(node, (VarLikeDecl, TupleDecl, ForwardingDecl)):
         return True
 

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -44,7 +44,6 @@ def might_incorrectly_report_location(node: AstNode) -> bool:
     indentation should leave these variables alone.
     """
 
-
     # some NamedDecl nodes currently use the name as the location, which
     # does not indicate their actual indentation.
     if isinstance(node, (VarLikeDecl, TupleDecl, ForwardingDecl)):
@@ -54,13 +53,11 @@ def might_incorrectly_report_location(node: AstNode) -> bool:
     # keyword.
     #
     # https://github.com/chapel-lang/chapel/issues/24818
-    elif (
-        isinstance(node, (Function, Use, Import))
-        and node.visibility() != ""
-    ):
+    elif isinstance(node, (Function, Use, Import)) and node.visibility() != "":
         return True
 
     return False
+
 
 def fixit_remove_unused_node(
     node: AstNode,


### PR DESCRIPTION
This was caused by the incorrect location reporting for variables. If the code above is 4-indented, and then location of the name is used, that name is also 4-indented, code flags as misleading.

As an example:
```Chapel
      for 1..10 do
          writeln("Hello, world!");
      var unrelated = "hi";
```

Note that `unrelated` and `writeln` happen to be aligned, which is sufficient for the false positive.

Reported by @alvaradoo -- thanks!

The solution is to steal the logic from IncorrectIndentation that avoids AST nodes that report their locations oddly.

Reviewed by @jabraham17 -- thanks!

## Testing
- [x] `start_test test/chplcheck`.