### PR TITLE
Disable exit memory leaks by default

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -151,7 +151,7 @@ bool fDriverDoMonolithic = false;
 bool driverDebugPhaseSpecified = false;
 // Tmp dir path managed by compiler driver
 char driverTmpDir[FILENAME_MAX] = "";
-bool fExitLeaks = true;
+bool fExitLeaks = false;
 bool fLibraryCompile = false;
 bool fLibraryFortran = false;
 bool fLibraryMakefile = false;


### PR DESCRIPTION
Pending further discussion, I'll disable this feature for the release.

Reviewed by @jabraham17 -- thanks!

## Testing
- [x] paratest