### PR TITLE
Fix `chpl_gmp` and `chpl_hwloc` to not print python arrays

### DIFF
--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -40,7 +40,7 @@ ifneq ($(CHPL_MAKE_HWLOC),none)
     # don't bother checking if we can link against hwloc
     CHPL_QTHREAD_CFG_OPTIONS += --disable-hwloc-configure-checks
   else ifeq ($(CHPL_MAKE_HWLOC),system)
-		CHPL_QTHREAD_CFG_OPTIONS += --with-hwloc=$(shell $(CHPL_MAKE_PYTHON) $(CHPL_MAKE_HOME)/util/chplenv/chpl_hwloc.py --prefix)
+    CHPL_QTHREAD_CFG_OPTIONS += --with-hwloc=$(shell $(CHPL_MAKE_PYTHON) $(CHPL_MAKE_HOME)/util/chplenv/chpl_hwloc.py --prefix)
     CHPL_QTHREAD_CFG_OPTIONS += --disable-hwloc-configure-checks
   endif
 endif

--- a/util/chplenv/chpl_gmp.py
+++ b/util/chplenv/chpl_gmp.py
@@ -92,9 +92,11 @@ def _main():
     (options, args) = parser.parse_args()
 
     if options.action == 'compile':
-        sys.stdout.write("{0}\n".format(get_compile_args()))
+        bundled, system = get_compile_args()
+        sys.stdout.write("{0}\n".format(' '.join(bundled + system)))
     elif options.action == 'link':
-        sys.stdout.write("{0}\n".format(get_link_args()))
+        bundled, system = get_link_args()
+        sys.stdout.write("{0}\n".format(' '.join(bundled + system)))
     else:
         sys.stdout.write("{0}\n".format(gmp_val))
 

--- a/util/chplenv/chpl_hwloc.py
+++ b/util/chplenv/chpl_hwloc.py
@@ -103,9 +103,11 @@ def _main():
     if options.action == 'prefix':
         sys.stdout.write("{0}\n".format(get_prefix()))
     elif options.action == 'compile':
-        sys.stdout.write("{0}\n".format(get_compile_args()))
+        bundled, system = get_compile_args()
+        sys.stdout.write("{0}\n".format(' '.join(bundled + system)))
     elif options.action == 'link':
-        sys.stdout.write("{0}\n".format(get_link_args()))
+        bundled, system = get_link_args()
+        sys.stdout.write("{0}\n".format(' '.join(bundled + system)))
     else:
         sys.stdout.write("{0}\n".format(hwloc_val))
 


### PR DESCRIPTION
Fixes 2 scripts added in https://github.com/chapel-lang/chapel/pull/25184 and https://github.com/chapel-lang/chapel/pull/25145 to print strings, instead of python tuples and arrays. This caused strange build failures 

I also fixed a whitespace oddity in a Makefile

Thank you @bonachea for pointing this out!

[Reviewed by @DanilaFe]