### PR TITLE
Make `chplcheck` available from `chpl-language-server`

### DIFF
--- a/doc/rst/tools/chpl-language-server/chpl-language-server.rst
+++ b/doc/rst/tools/chpl-language-server/chpl-language-server.rst
@@ -62,6 +62,8 @@ VSCode
 Install the ``chapel`` extension from the `Visual Studio Code marketplace
 <https://marketplace.visualstudio.com/items?itemName=chpl-hpe.chapel-vscode>`_.
 
+.. _chpl-language-server-emacs:
+
 Emacs
 ^^^^^
 
@@ -191,10 +193,10 @@ The following features are extra visual aids:
 Using ``chplcheck`` from ``CLS``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Although ``chplcheck`` is a separate tool from ``CLS``, it can be used from
-``CLS`` to provide additional diagnostics. This is done by enabling the
-``--chplcheck`` flag. This will incorporate the diagnostics and fixits from
-``chplcheck``.
+Although :ref:`chplcheck <readme-chplcheck>` is a separate tool from ``CLS``,
+it can be used from ``CLS`` to provide additional diagnostics. This is done by
+enabling the ``--chplcheck`` flag. This will incorporate the diagnostics and
+fixits from ``chplcheck``.
 
 You can also still pass many of the same ``chplcheck`` flags to ``CLS``, just
 prefixed with ``--chplcheck-``. For example, the following command runs the

--- a/doc/rst/tools/chpl-language-server/chpl-language-server.rst
+++ b/doc/rst/tools/chpl-language-server/chpl-language-server.rst
@@ -77,7 +77,7 @@ syntax highlighting in Emacs):
 
   (with-eval-after-load 'eglot
     (add-to-list 'eglot-server-programs
-                 '(chpl-mode . ("chpl-language-server"))))
+                 '(chpl-mode . ("chpl-language-server", "--chplcheck"))))
 
 This will enable using the language server with a particular ``.chpl`` file by
 calling ``M-x eglot``.
@@ -91,11 +91,8 @@ additionally add the following to your ``.emacs`` file:
 
 .. note::
 
-   There is currently a limitation with Eglot that only one language server can
-   be registered per language.  We are investigating merging the support for
-   :ref:`readme-chplcheck` such that both can be used in Emacs at the same time,
-   stay tuned!
-
+   The above uses the ``--chplcheck`` flag to enable additional diagnostics from
+   ``chplcheck``. If you do not want to use ``chplcheck``, you can remove this.
 
 Supported Features
 ------------------
@@ -190,6 +187,25 @@ The following features are extra visual aids:
 | Generic        | ``CLS`` can show the various               | No flag, on by default                |
 | Instantiations | instantiations of a generic function.      |                                       |
 +----------------+--------------------------------------------+---------------------------------------+
+
+Using ``chplcheck`` from ``CLS``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Although ``chplcheck`` is a separate tool from ``CLS``, it can be used from
+``CLS`` to provide additional diagnostics. This is done by enabling the
+``--chplcheck`` flag. This will incorporate the diagnostics and fixits from
+``chplcheck``.
+
+You can also still pass many of the same ``chplcheck`` flags to ``CLS``, just
+prefixed with ``--chplcheck-``. For example, the following command runs the
+language server with linting enabled various ``chplcheck`` flags:
+
+.. code-block:: bash
+
+   chpl-language-server --chplcheck \
+     --chplcheck-enable-rule UseExplicitModules \
+     --chplcheck-disable-rule UnusedLoopIndex \
+     --chplcheck-add-rules path/to/my/myrules.py
 
 Configuring Chapel Projects
 ---------------------------

--- a/doc/rst/tools/chplcheck/chplcheck.rst
+++ b/doc/rst/tools/chplcheck/chplcheck.rst
@@ -168,13 +168,6 @@ additionally add the following to your ``.emacs`` file:
 
    (add-hook 'chpl-mode-hook 'eglot-ensure)
 
-.. note::
-
-   There is currently a limitation with Eglot that only one language server can
-   be registered per language.  We are investigating merging the support for
-   :ref:`readme-chpl-language-server` such that both can be used in Emacs at the
-   same time, stay tuned!
-
 
 
 Writing New Rules

--- a/doc/rst/tools/chplcheck/chplcheck.rst
+++ b/doc/rst/tools/chplcheck/chplcheck.rst
@@ -168,12 +168,17 @@ additionally add the following to your ``.emacs`` file:
 
    (add-hook 'chpl-mode-hook 'eglot-ensure)
 
+.. note::
 
+   There is currently a limitation with Eglot that only one language server can
+   be registered per language. To use ``chplcheck`` and ``chapel-language-server``
+   at the same time, see the
+   :ref:`Emacs documentation for chapel-language-server <chpl-language-server-emacs>`.
 
 Writing New Rules
 -----------------
 
-Rules are written using the :ref:`Python bindings for Chapel's compiler frontend<readme-chapel-py>`. In
+Rules are written using the :ref:`Python bindings for Chapel's compiler frontend <readme-chapel-py>`. In
 essence, a rule is a Python function that is used to detect issues with the
 AST. When registered with ``chplcheck``, the name of the function becomes the name
 of the rule (which can be used to enable and disable the rule, as per the

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -147,13 +147,19 @@ import configargparse
 
 class ChplcheckProxy:
 
-    def __init__(self, main: ModuleType, config: ModuleType, lsp: ModuleType, driver: ModuleType, rules: ModuleType):
+    def __init__(
+        self,
+        main: ModuleType,
+        config: ModuleType,
+        lsp: ModuleType,
+        driver: ModuleType,
+        rules: ModuleType,
+    ):
         self.main = main
         self.config = config
         self.lsp = lsp
         self.driver = driver
         self.rules = rules
-
 
     @classmethod
     def get(cls) -> Optional["ChplcheckProxy"]:
@@ -169,7 +175,9 @@ class ChplcheckProxy:
 
         def load_module(module_name: str) -> Optional[ModuleType]:
             file_path = os.path.join(chplcheck_path, module_name + ".py")
-            spec = importlib.util.spec_from_file_location(module_name, file_path)
+            spec = importlib.util.spec_from_file_location(
+                module_name, file_path
+            )
             if spec is None:
                 error(f"Could not load module from {file_path}")
                 return None
@@ -190,6 +198,7 @@ class ChplcheckProxy:
         proxy = ChplcheckProxy(*mods)
 
         return proxy
+
 
 chplcheck = ChplcheckProxy.get()
 

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -152,6 +152,7 @@ try:
     chplcheck_path = os.path.join(chpl_home, "tools", "chplcheck", "src")
     # Add chplcheck to the path, but load via importlib
     sys.path.append(chplcheck_path)
+
     def load_module(module_name: str):
         file_path = os.path.join(chplcheck_path, module_name + ".py")
         spec = importlib.util.spec_from_file_location(module_name, file_path)
@@ -163,6 +164,7 @@ try:
             raise ValueError(f"Could not load module from {file_path}")
         spec.loader.exec_module(module)
         return module
+
     chplcheck = load_module("chplcheck")
     chplcheck_lsp = load_module("lsp")
     chplcheck_config = load_module("config")
@@ -992,7 +994,6 @@ class CLSConfig:
         if chplcheck_config:
             chplcheck_config.Config.add_arguments(self.parser, "chplcheck-")
 
-
     def _parse_end_markers(self):
         self.args["end_markers"] = [
             a.strip() for a in self.args["end_markers"].split(",")
@@ -1069,7 +1070,14 @@ class ChapelLanguageServer(LanguageServer):
         """
         Setup the linter, if it is enabled
         """
-        if not (self.do_linting and chplcheck and chplcheck_lsp and chplcheck_config and chplcheck_driver and chplcheck_rules):
+        if not (
+            self.do_linting
+            and chplcheck
+            and chplcheck_lsp
+            and chplcheck_config
+            and chplcheck_driver
+            and chplcheck_rules
+        ):
             return
 
         config = chplcheck_config.Config.from_args(clsConfig.args)
@@ -1082,7 +1090,6 @@ class ChapelLanguageServer(LanguageServer):
 
         self.lint_driver.disable_rules(*config.disabled_rules)
         self.lint_driver.enable_rules(*config.enabled_rules)
-
 
     def get_deprecation_replacement(
         self, text: str
@@ -1197,7 +1204,9 @@ class ChapelLanguageServer(LanguageServer):
         # get lint diagnostics if applicable
         if self.lint_driver:
             assert chplcheck_lsp
-            lint_diagnostics = chplcheck_lsp.get_lint_diagnostics(fi.context.context, self.lint_driver, fi.get_asts())
+            lint_diagnostics = chplcheck_lsp.get_lint_diagnostics(
+                fi.context.context, self.lint_driver, fi.get_asts()
+            )
             diagnostics.extend(lint_diagnostics)
 
         return diagnostics
@@ -1758,7 +1767,9 @@ def run_lsp():
         # get lint fixits if applicable
         if ls.lint_driver:
             assert chplcheck_lsp
-            lint_actions = chplcheck_lsp.get_lint_actions(params.context.diagnostics)
+            lint_actions = chplcheck_lsp.get_lint_actions(
+                params.context.diagnostics
+            )
             actions.extend(lint_actions)
 
         return actions

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -988,7 +988,7 @@ class CLSConfig:
         self.parser.add_argument("--end-markers", default="none")
         self.parser.add_argument("--end-marker-threshold", type=int, default=10)
 
-        add_bool_flag("lint", "do_linting", False)
+        add_bool_flag("chplcheck", "do_linting", False)
         if chplcheck_config:
             chplcheck_config.Config.add_arguments(self.parser, "chplcheck-")
 

--- a/tools/chpl-language-server/test/linting.py
+++ b/tools/chpl-language-server/test/linting.py
@@ -57,14 +57,19 @@ async def test_lint_fixits(client: LanguageClient):
         assert len(client.diagnostics[doc.uri]) == 1
 
         diagnostics = client.diagnostics[doc.uri]
-        actions = await client.text_document_code_action_async(CodeActionParams(doc, rng((0, 0), endpos(file)), CodeActionContext(diagnostics)))
+        actions = await client.text_document_code_action_async(
+            CodeActionParams(
+                doc, rng((0, 0), endpos(file)), CodeActionContext(diagnostics)
+            )
+        )
         assert actions is not None
         # there should 2 actions, one to fixit and one to ignore. make sure that both exists
         # TODO: check that the fixits are valid and what we expect for a given input string
         # TODO: this should also be made into a helper function
         assert len(actions) == 2
-        assert "Apply Fix for" in actions[0].title and "Ignore" not in actions[0].title
+        assert (
+            "Apply Fix for" in actions[0].title
+            and "Ignore" not in actions[0].title
+        )
         assert "Ignore" in actions[1].title
         # TODO: check that applying the fixits actually resolves the warning
-
-

--- a/tools/chpl-language-server/test/linting.py
+++ b/tools/chpl-language-server/test/linting.py
@@ -1,0 +1,70 @@
+"""
+Test that the linter is working properly from CLS. These tests are not meant to be exhaustive of the linter's capabilities, rather they are meant to ensure that the integration between CLS and chplcheck is working properly.
+"""
+
+import sys
+
+from lsprotocol.types import ClientCapabilities
+from lsprotocol.types import InitializeParams
+from lsprotocol.types import CodeActionParams, CodeActionContext
+import pytest
+import pytest_lsp
+from pytest_lsp import ClientServerConfig, LanguageClient
+
+from util.utils import *
+from util.config import CLS_PATH
+
+
+@pytest_lsp.fixture(
+    config=ClientServerConfig(
+        server_command=[sys.executable, CLS_PATH(), "--chplcheck"],
+        client_factory=get_base_client,
+    )
+)
+async def client(lsp_client: LanguageClient):
+    # Setup
+    params = InitializeParams(capabilities=ClientCapabilities())
+    await lsp_client.initialize_session(params)
+
+    yield
+
+    # Teardown
+    await lsp_client.shutdown_session()
+
+
+@pytest.mark.asyncio
+async def test_lint_warnings(client: LanguageClient):
+    """
+    Test that lint warnings are reported properly
+    """
+    file = """
+            for i in {1..10} do { }
+           """
+    async with source_file(client, file, 3) as doc:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_lint_fixits(client: LanguageClient):
+    """
+    Test that fixits work properly
+    """
+    file = """
+            for i in {1..10} { i; }
+           """
+    async with source_file(client, file, None) as doc:
+        await save_file(client, doc)
+        assert len(client.diagnostics[doc.uri]) == 1
+
+        diagnostics = client.diagnostics[doc.uri]
+        actions = await client.text_document_code_action_async(CodeActionParams(doc, rng((0, 0), endpos(file)), CodeActionContext(diagnostics)))
+        assert actions is not None
+        # there should 2 actions, one to fixit and one to ignore. make sure that both exists
+        # TODO: check that the fixits are valid and what we expect for a given input string
+        # TODO: this should also be made into a helper function
+        assert len(actions) == 2
+        assert "Apply Fix for" in actions[0].title and "Ignore" not in actions[0].title
+        assert "Ignore" in actions[1].title
+        # TODO: check that applying the fixits actually resolves the warning
+
+

--- a/tools/chplcheck/src/config.py
+++ b/tools/chplcheck/src/config.py
@@ -1,3 +1,22 @@
+#
+# Copyright 2023-2024 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 from dataclasses import dataclass
 from typing import List, Union, Dict, Any
 import argparse
@@ -22,14 +41,14 @@ class Config:
             action="append",
             dest="chplcheck_disabled_rules",
             default=[],
-            help="Disable a lint rule by name"
+            help="Disable a lint rule by name",
         )
         parser.add_argument(
             f"--{prefix}enable-rule",
             action="append",
             dest="chplcheck_enabled_rules",
             default=[],
-            help="Enable a lint rule by name"
+            help="Enable a lint rule by name",
         )
         parser.add_argument(
             f"--{prefix}skip-unstable",

--- a/tools/chplcheck/src/config.py
+++ b/tools/chplcheck/src/config.py
@@ -74,19 +74,11 @@ class Config:
 
     @classmethod
     def from_args(cls, args: Union[argparse.Namespace, Dict[str, Any]]):
-        if isinstance(args, argparse.Namespace):
-            return cls(
-                disabled_rules=args.chplcheck_disabled_rules,
-                enabled_rules=args.chplcheck_enabled_rules,
-                skip_unstable=args.chplcheck_skip_unstable,
-                internal_prefixes=args.chplcheck_internal_prefixes,
-                add_rules=args.chplcheck_add_rules,
-            )
-        else:
-            return cls(
-                disabled_rules=args["chplcheck_disabled_rules"],
-                enabled_rules=args["chplcheck_enabled_rules"],
-                skip_unstable=args["chplcheck_skip_unstable"],
-                internal_prefixes=args["chplcheck_internal_prefixes"],
-                add_rules=args["chplcheck_add_rules"],
-            )
+        args = vars(args) if isinstance(args, argparse.Namespace) else args
+        return cls(
+            disabled_rules=args["chplcheck_disabled_rules"],
+            enabled_rules=args["chplcheck_enabled_rules"],
+            skip_unstable=args["chplcheck_skip_unstable"],
+            internal_prefixes=args["chplcheck_internal_prefixes"],
+            add_rules=args["chplcheck_add_rules"],
+        )

--- a/tools/chplcheck/src/config.py
+++ b/tools/chplcheck/src/config.py
@@ -1,0 +1,73 @@
+from dataclasses import dataclass
+from typing import List, Union, Dict, Any
+import argparse
+
+
+@dataclass
+class Config:
+    """
+    Configuration options that are specific to linting, not the CLI
+    """
+
+    disabled_rules: List[str]
+    enabled_rules: List[str]
+    skip_unstable: bool
+    internal_prefixes: List[str]
+    add_rules: List[str]
+
+    @classmethod
+    def add_arguments(cls, parser: argparse.ArgumentParser, prefix: str = ""):
+        parser.add_argument(
+            f"--{prefix}disable-rule",
+            action="append",
+            dest="chplcheck_disabled_rules",
+            default=[],
+            help="Disable a lint rule by name"
+        )
+        parser.add_argument(
+            f"--{prefix}enable-rule",
+            action="append",
+            dest="chplcheck_enabled_rules",
+            default=[],
+            help="Enable a lint rule by name"
+        )
+        parser.add_argument(
+            f"--{prefix}skip-unstable",
+            action="store_true",
+            dest="chplcheck_skip_unstable",
+            default=False,
+            help="Skip unstable rules when linting",
+        )
+        parser.add_argument(
+            f"--{prefix}internal-prefix",
+            action="append",
+            dest="chplcheck_internal_prefixes",
+            default=[],
+            help="Add a prefix to the list of internal prefixes used when linting",
+        )
+        parser.add_argument(
+            f"--{prefix}add-rules",
+            action="append",
+            dest="chplcheck_add_rules",
+            default=[],
+            help="Add a custom rule file for chplcheck",
+        )
+
+    @classmethod
+    def from_args(cls, args: Union[argparse.Namespace, Dict[str, Any]]):
+        if isinstance(args, argparse.Namespace):
+            return cls(
+                disabled_rules=args.chplcheck_disabled_rules,
+                enabled_rules=args.chplcheck_enabled_rules,
+                skip_unstable=args.chplcheck_skip_unstable,
+                internal_prefixes=args.chplcheck_internal_prefixes,
+                add_rules=args.chplcheck_add_rules,
+            )
+        else:
+            return cls(
+                disabled_rules=args["chplcheck_disabled_rules"],
+                enabled_rules=args["chplcheck_enabled_rules"],
+                skip_unstable=args["chplcheck_skip_unstable"],
+                internal_prefixes=args["chplcheck_internal_prefixes"],
+                add_rules=args["chplcheck_add_rules"],
+            )

--- a/tools/chplcheck/src/driver.py
+++ b/tools/chplcheck/src/driver.py
@@ -109,7 +109,9 @@ class LintDriver:
     def _has_internal_name(self, node: chapel.AstNode):
         if not hasattr(node, "name"):
             return False
-        return any(node.name().startswith(p) for p in self.config.internal_prefixes)
+        return any(
+            node.name().startswith(p) for p in self.config.internal_prefixes
+        )
 
     @staticmethod
     def _is_unstable_module(node: chapel.AstNode):
@@ -202,7 +204,9 @@ class LintDriver:
             # so we can't stop it from going into unstable modules. Instead,
             # once the rule emits a warning, check by traversing the AST
             # if the warning target should be skipped.
-            if self.config.skip_unstable and LintDriver._in_unstable_module(node):
+            if self.config.skip_unstable and LintDriver._in_unstable_module(
+                node
+            ):
                 continue
 
             yield (node, name, fixits)

--- a/tools/chplcheck/src/lsp.py
+++ b/tools/chplcheck/src/lsp.py
@@ -43,7 +43,10 @@ def _get_location(node: chapel.AstNode):
     else:
         return chapel.lsp.location_to_range(node.location())
 
-def get_lint_diagnostics(context: chapel.Context, driver: LintDriver, asts: List[chapel.AstNode]) -> List[Diagnostic]:
+
+def get_lint_diagnostics(
+    context: chapel.Context, driver: LintDriver, asts: List[chapel.AstNode]
+) -> List[Diagnostic]:
     """
     Run the linter rules on the Chapel ASTs and return them as LSP diagnostics.
     """
@@ -62,6 +65,7 @@ def get_lint_diagnostics(context: chapel.Context, driver: LintDriver, asts: List
                 diagnostic.data = {"rule": rule, "fixits": fixits}
             diagnostics.append(diagnostic)
     return diagnostics
+
 
 def get_lint_actions(diagnostics: List[Diagnostic]) -> List[CodeAction]:
     """
@@ -89,9 +93,7 @@ def get_lint_actions(diagnostics: List[Diagnostic]) -> List[CodeAction]:
                 start = e.start
                 end = e.end
                 rng = Range(
-                    start=Position(
-                        max(start[0] - 1, 0), max(start[1] - 1, 0)
-                    ),
+                    start=Position(max(start[0] - 1, 0), max(start[1] - 1, 0)),
                     end=Position(max(end[0] - 1, 0), max(end[1] - 1, 0)),
                 )
                 edit = TextEdit(range=rng, new_text=e.text)
@@ -109,6 +111,7 @@ def get_lint_actions(diagnostics: List[Diagnostic]) -> List[CodeAction]:
             )
             actions.append(action)
     return actions
+
 
 def run_lsp(driver: LintDriver):
     """

--- a/tools/chplcheck/src/lsp.py
+++ b/tools/chplcheck/src/lsp.py
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-from typing import Union
+from typing import Union, List
 import chapel
 import chapel.lsp
 from pygls.server import LanguageServer
@@ -35,6 +35,80 @@ from lsprotocol.types import Diagnostic, Range, Position, DiagnosticSeverity
 from fixits import Fixit, Edit
 from driver import LintDriver
 
+
+def _get_location(node: chapel.AstNode):
+    """Helper to get the location of a node"""
+    if isinstance(node, chapel.NamedDecl):
+        return chapel.lsp.location_to_range(node.name_location())
+    else:
+        return chapel.lsp.location_to_range(node.location())
+
+def get_lint_diagnostics(context: chapel.Context, driver: LintDriver, asts: List[chapel.AstNode]) -> List[Diagnostic]:
+    """
+    Run the linter rules on the Chapel ASTs and return them as LSP diagnostics.
+    """
+    diagnostics = []
+    # Silence errors from scope resolution etc., especially since they
+    # may be emitted from other files (dependencies).
+    with context.track_errors() as _:
+        for node, rule, fixits in driver.run_checks(context, asts):
+            diagnostic = Diagnostic(
+                range=_get_location(node),
+                message="Lint: rule [{}] violated".format(rule),
+                severity=DiagnosticSeverity.Warning,
+            )
+            if fixits:
+                fixits = [Fixit.to_dict(f) for f in fixits]
+                diagnostic.data = {"rule": rule, "fixits": fixits}
+            diagnostics.append(diagnostic)
+    return diagnostics
+
+def get_lint_actions(diagnostics: List[Diagnostic]) -> List[CodeAction]:
+    """
+    Return LSP code actions for the given diagnostics.
+    """
+    actions = []
+    for d in diagnostics:
+        if not d.data:
+            continue
+        name = d.data.get("rule", None)
+        if not name:
+            continue
+        if "fixits" not in d.data:
+            continue
+        fixits = [Fixit.from_dict(f) for f in d.data["fixits"]]
+        if not fixits:
+            continue
+
+        for f in fixits:
+            if not f:
+                continue
+            changes = dict()
+            for e in f.edits:
+                uri = "file://" + e.path
+                start = e.start
+                end = e.end
+                rng = Range(
+                    start=Position(
+                        max(start[0] - 1, 0), max(start[1] - 1, 0)
+                    ),
+                    end=Position(max(end[0] - 1, 0), max(end[1] - 1, 0)),
+                )
+                edit = TextEdit(range=rng, new_text=e.text)
+                if uri not in changes:
+                    changes[uri] = []
+                changes[uri].append(edit)
+            title = "Apply Fix for {}".format(name)
+            if f.description:
+                title += " ({})".format(f.description)
+            action = CodeAction(
+                title=title,
+                kind=CodeActionKind.QuickFix,
+                diagnostics=[d],
+                edit=WorkspaceEdit(changes=changes),
+            )
+            actions.append(action)
+    return actions
 
 def run_lsp(driver: LintDriver):
     """
@@ -80,12 +154,6 @@ def run_lsp(driver: LintDriver):
 
         return context.parse(uri[len("file://") :])
 
-    def get_location(node: chapel.AstNode):
-        if isinstance(node, chapel.NamedDecl):
-            return chapel.lsp.location_to_range(node.name_location())
-        else:
-            return chapel.lsp.location_to_range(node.location())
-
     def build_diagnostics(uri: str):
         """
         Parse a file at a particular URI, run the linter rules on the resulting
@@ -96,20 +164,7 @@ def run_lsp(driver: LintDriver):
         with context.track_errors() as errors:
             asts = parse_file(context, uri)
 
-        # Silence errors from scope resolution etc., especially since they
-        # may be emitted from other files (dependencies).
-        with context.track_errors() as _:
-            diagnostics = []
-            for node, rule, fixits in driver.run_checks(context, asts):
-                diagnostic = Diagnostic(
-                    range=get_location(node),
-                    message="Lint: rule [{}] violated".format(rule),
-                    severity=DiagnosticSeverity.Warning,
-                )
-                if fixits:
-                    fixits = [Fixit.to_dict(f) for f in fixits]
-                    diagnostic.data = {"rule": rule, "fixits": fixits}
-                diagnostics.append(diagnostic)
+        diagnostics = get_lint_diagnostics(context, driver, asts)
 
         # process the errors from syntax/scope resolution
         # TODO: should chplcheck still do this?
@@ -130,47 +185,7 @@ def run_lsp(driver: LintDriver):
     @server.feature(TEXT_DOCUMENT_CODE_ACTION)
     async def code_action(ls: LanguageServer, params: CodeActionParams):
         diagnostics = params.context.diagnostics
-        actions = []
-        for d in diagnostics:
-            if not d.data:
-                continue
-            name = d.data.get("rule", None)
-            if not name:
-                continue
-            if "fixits" not in d.data:
-                continue
-            fixits = [Fixit.from_dict(f) for f in d.data["fixits"]]
-            if not fixits:
-                continue
-
-            for f in fixits:
-                if not f:
-                    continue
-                changes = dict()
-                for e in f.edits:
-                    uri = "file://" + e.path
-                    start = e.start
-                    end = e.end
-                    rng = Range(
-                        start=Position(
-                            max(start[0] - 1, 0), max(start[1] - 1, 0)
-                        ),
-                        end=Position(max(end[0] - 1, 0), max(end[1] - 1, 0)),
-                    )
-                    edit = TextEdit(range=rng, new_text=e.text)
-                    if uri not in changes:
-                        changes[uri] = []
-                    changes[uri].append(edit)
-                title = "Apply Fix for {}".format(name)
-                if f.description:
-                    title += " ({})".format(f.description)
-                action = CodeAction(
-                    title=title,
-                    kind=CodeActionKind.QuickFix,
-                    diagnostics=[d],
-                    edit=WorkspaceEdit(changes=changes),
-                )
-                actions.append(action)
+        actions = get_lint_actions(diagnostics)
         return actions
 
     server.start_io()


### PR DESCRIPTION
This makes it possible for `chpl-language-server` to supply linting diagnostics, without users needing to use `chplcheck` directly.

Although using `chplcheck` standalone is the preferred config, some editors only allow one language server per language (like emacs). So this provides a workaround for those editors.

This PR also adds some limited `chplcheck` integration testing with `chpl-language-server`

[Reviewed by @DanilaFe and @lydia-duncan]

