### PR TITLE
Restore default `-lgmp` on Cray X* systems

### DIFF
--- a/third-party/Makefile
+++ b/third-party/Makefile
@@ -112,14 +112,12 @@ $(GASNET_INSTALL_DIR): $(GASNET_DEPEND)
 
 try-gmp: FORCE
   ifneq ($(CHPL_MAKE_GMP_IS_OVERRIDDEN), True)
-  ifneq ($(CHPL_MAKE_GMP), system)
     ifeq ($(wildcard $(GMP_BUILD_DIR)),)
 	@echo "Speculatively attempting to build gmp"
 	-@$(MAKE) GMP_SPECULATIVE=yes gmp
     else ifeq ($(wildcard $(GMP_H_FILE)),)
 	$(info Speculative build of gmp squashed due to previous failures.)
     endif
-  endif
   endif
 
 gmp: $(GMP_H_FILE)

--- a/util/chplenv/chpl_gmp.py
+++ b/util/chplenv/chpl_gmp.py
@@ -50,6 +50,10 @@ def get_compile_args():
     if gmp_val == 'bundled':
          return third_party_utils.get_bundled_compile_args('gmp')
     elif gmp_val == 'system':
+        # On cray-x* systems, gmp should be in the system library path
+        if chpl_platform.get('target').startswith('cray-x'):
+            return ([], [])
+
         # try pkg-config
         args = third_party_utils.pkgconfig_get_system_compile_args('gmp')
         if args != (None, None):
@@ -68,6 +72,10 @@ def get_link_args():
          return third_party_utils.pkgconfig_get_bundled_link_args('gmp')
 
     elif gmp_val == 'system':
+        # On cray-x* systems, gmp should be in the system library path
+        if chpl_platform.get('target').startswith('cray-x'):
+            return ([], ["-lgmp"])
+
         # try pkg-config
         args = third_party_utils.pkgconfig_get_system_link_args('gmp')
         if args != (None, None):

--- a/util/chplenv/third_party_utils.py
+++ b/util/chplenv/third_party_utils.py
@@ -435,4 +435,4 @@ def could_not_find_pkgconfig_pkg(pkg, envname):
         error("{0} is installed via homebrew, but pkg-config is not installed. Please install pkg-config with `brew install pkg-config`.".format(pkg))
     else:
         install_str = " with `brew install {0}`".format(pkg) if homebrew_utils.homebrew_exists() else ""
-        error("Could not find a suitable {0} installation. Please install {0}{1} or set {2}=bundled`.".format(pkg, install_str, envname))
+        error("Could not find a suitable {0} installation. Please install {0}{1} or set {2}=bundled.".format(pkg, install_str, envname))

--- a/util/chplenv/third_party_utils.py
+++ b/util/chplenv/third_party_utils.py
@@ -434,5 +434,5 @@ def could_not_find_pkgconfig_pkg(pkg, envname):
         # tell user to install pkg-config as well
         error("{0} is installed via homebrew, but pkg-config is not installed. Please install pkg-config with `brew install pkg-config`.".format(pkg))
     else:
-        install_str = " with `brew install {0}` ".format(pkg) if homebrew_utils.homebrew_exists() else ""
-        error("Could not find a suitable {0} installation. Please install {0}{1}or set {2}=bundled`.".format(pkg, install_str, envname))
+        install_str = " with `brew install {0}`".format(pkg) if homebrew_utils.homebrew_exists() else ""
+        error("Could not find a suitable {0} installation. Please install {0}{1} or set {2}=bundled`.".format(pkg, install_str, envname))


### PR DESCRIPTION
On Cray X* systems, gmp should be in the default library search and does not require `pkg-config`

Restores the behavior prior to https://github.com/chapel-lang/chapel/pull/25184

Tested that this change allows a system gmp to be used on a Cray XC without pkg-config

Note: We could also do something like `$CHPL_TARGET_COMPILER --print-file-name=libgmp.so` to check if a shared library is available in PATH, rather than special casing for platforms. But that has the potential to cause problems, so this close to a release I just restored the previous behavior.

[Reviewed by @jhh67]