### PR TITLE
Add missing variable in `chpl-language-server`

### DIFF
--- a/doc/rst/tools/chpl-language-server/chpl-language-server.rst
+++ b/doc/rst/tools/chpl-language-server/chpl-language-server.rst
@@ -79,7 +79,7 @@ syntax highlighting in Emacs):
 
   (with-eval-after-load 'eglot
     (add-to-list 'eglot-server-programs
-                 '(chpl-mode . ("chpl-language-server", "--chplcheck"))))
+                 '(chpl-mode . ("chpl-language-server" "--chplcheck"))))
 
 This will enable using the language server with a particular ``.chpl`` file by
 calling ``M-x eglot``.

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -173,6 +173,10 @@ class ChplcheckProxy:
             error("CHPL_HOME not set")
             return None
 
+        chplcheck_path = os.path.join(chpl_home, "tools", "chplcheck", "src")
+        # Add chplcheck to the path, but load via importlib
+        sys.path.append(chplcheck_path)
+
         def load_module(module_name: str) -> Optional[ModuleType]:
             file_path = os.path.join(chplcheck_path, module_name + ".py")
             spec = importlib.util.spec_from_file_location(

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -194,7 +194,7 @@ class ChplcheckProxy:
             return module
 
         mods = []
-        for mod in ["main", "config", "lsp", "driver", "rules"]:
+        for mod in ["chplcheck", "config", "lsp", "driver", "rules"]:
             m = load_module(mod)
             if m is None:
                 return None


### PR DESCRIPTION
Followup to https://github.com/chapel-lang/chapel/pull/25214, fixes a missing variable forgotten when applying reviewer feedback

Tested with `make test-cls`

[Reviewed by @DanilaFe and @lydia-duncan ]