### PR TITLE
Install `chplconfig` to `CHPL_HOME` in prefix installs

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -548,7 +548,7 @@ static void setupChplHome(const char* argv0) {
       // Set an extra default CHPL_CONFIG directory
       rc = snprintf(CHPL_CONFIG, FILENAME_MAX, "%s/%s/%s",
                     get_configured_prefix(), // e.g. /usr
-                    "/lib/chapel",
+                    "share/chapel",
                     majMinorVers);
       if ( rc >= FILENAME_MAX ) USR_FATAL("Installed pathname too long");
 

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -516,19 +516,19 @@ static void setupChplHome(const char* argv0) {
     // E.g. /usr/lib/chapel/1.16/runtime/lib
     rc = snprintf(CHPL_RUNTIME_LIB, FILENAME_MAX, "%s/%s/%s/%s",
                   get_configured_prefix(), // e.g. /usr
-                  "/lib/chapel",
+                  "lib/chapel",
                   majMinorVers,
                   "runtime/lib");
     if ( rc >= FILENAME_MAX ) USR_FATAL("Installed pathname too long");
     rc = snprintf(CHPL_RUNTIME_INCL, FILENAME_MAX, "%s/%s/%s/%s",
                   get_configured_prefix(), // e.g. /usr
-                  "/lib/chapel",
+                  "lib/chapel",
                   majMinorVers,
                   "runtime/include");
     if ( rc >= FILENAME_MAX ) USR_FATAL("Installed pathname too long");
     rc = snprintf(CHPL_THIRD_PARTY, FILENAME_MAX, "%s/%s/%s/%s",
                   get_configured_prefix(), // e.g. /usr
-                  "/lib/chapel",
+                  "lib/chapel",
                   majMinorVers,
                   "third-party");
     if ( rc >= FILENAME_MAX ) USR_FATAL("Installed pathname too long");

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -539,25 +539,7 @@ static void setupChplHome(const char* argv0) {
   }
 
   // and setenv the derived enviro vars for use by called scripts/Makefiles
-  {
-    int rc;
-    saveChplHomeDerivedInEnv();
-
-    if (installed) {
-      char CHPL_CONFIG[FILENAME_MAX+1] = "";
-      // Set an extra default CHPL_CONFIG directory
-      rc = snprintf(CHPL_CONFIG, FILENAME_MAX, "%s/%s/%s",
-                    get_configured_prefix(), // e.g. /usr
-                    "share/chapel",
-                    majMinorVers);
-      if ( rc >= FILENAME_MAX ) USR_FATAL("Installed pathname too long");
-
-      // Don't overwrite CHPL_CONFIG so that a user-specified
-      // one would be left alone.
-      rc = setenv("CHPL_CONFIG", CHPL_CONFIG, 0);
-      if( rc ) USR_FATAL("Could not setenv CHPL_CONFIG");
-    }
-  }
+  saveChplHomeDerivedInEnv();
 }
 
 // If the compiler was built without LLVM and CHPL_LLVM is not set in

--- a/util/buildRelease/install.sh
+++ b/util/buildRelease/install.sh
@@ -402,12 +402,7 @@ fi
 # copy chplconfig
 if [ -f chplconfig ]
 then
-  if [ ! -z "$PREFIX" ]
-  then
-    myinstallfileto chplconfig "$PREFIX/lib/chapel/$VERS/chplconfig"
-  else
-    myinstallfileto chplconfig "$DEST_CHPL_HOME/chplconfig"
-  fi
+  myinstallfileto chplconfig "$DEST_CHPL_HOME/chplconfig"
 fi
 
 # Clean up: remove any .pyc files

--- a/util/chplenv/chpl_home_utils.py
+++ b/util/chplenv/chpl_home_utils.py
@@ -11,11 +11,7 @@ from utils import memoize
 
 @memoize
 def get_chpl_home():
-    chpl_home = overrides.get('CHPL_HOME', '')
-    if not chpl_home:
-        dirname = os.path.dirname
-        chpl_home = dirname(dirname(dirname(os.path.realpath(__file__))))
-    return chpl_home
+    return overrides.get_chpl_home(overrides)
 
 @memoize
 def get_chpl_runtime_incl():

--- a/util/chplenv/overrides.py
+++ b/util/chplenv/overrides.py
@@ -83,6 +83,14 @@ chplvars = [
            ]
 
 
+# this has to be defined here to prevent circular imports with chpl_home_utils
+def get_chpl_home(source):
+    chpl_home = source.get('CHPL_HOME', '')
+    if not chpl_home:
+        dirname = os.path.dirname
+        chpl_home = dirname(dirname(dirname(os.path.realpath(__file__))))
+    return chpl_home
+
 class ChapelConfig(object):
     """ Class for parsing chplconfig file and providing 'get' interface """
     def __init__(self):
@@ -120,7 +128,7 @@ class ChapelConfig(object):
         # Places to look for a chplconfig file, in order of priority
         chpl_config = os.environ.get('CHPL_CONFIG')
         home = os.path.expanduser('~')
-        chpl_home = os.environ.get('CHPL_HOME')
+        chpl_home = get_chpl_home(os.environ)
 
         if self.chplconfig_found(chpl_config, 'CHPL_CONFIG'):
             return


### PR DESCRIPTION
Changes `install.sh` to install `chplconfig` to `CHPL_HOME` in prefix-based installs, so that `chpl` and `printchplenv` agree on the default environment variables and location of `chplconfig`.

This also adjusts `util/chplenv/chpl_home_utils.py` and `util/chplenv/overrides.py` so the correct CHPL_HOME value is used when looking for `chplconfig`, regardless of the environment variables.

[Reviewed by @mppf]