### PR TITLE
Prevent chpl-shim from overwriting files when unnecessary

### DIFF
--- a/tools/chpl-language-server/src/chpl-shim.py
+++ b/tools/chpl-language-server/src/chpl-shim.py
@@ -84,8 +84,12 @@ def run_toplevel():
                 for key, value in from_file.items():
                     commands[key].append(value)
 
-    with open(".cls-commands.json", "w") as f:
-        json.dump(commands, f)
+
+    # Skip if we would overwrite an existing file with empty commands
+    skip_cls = os.path.exists(".cls-commands.json") and len(commands.keys()) == 0
+    if not skip_cls:
+        with open(".cls-commands.json", "w") as f:
+            json.dump(commands, f)
 
 
 def run_chpl_shim():

--- a/tools/chpl-language-server/src/chpl-shim.py
+++ b/tools/chpl-language-server/src/chpl-shim.py
@@ -84,9 +84,10 @@ def run_toplevel():
                 for key, value in from_file.items():
                     commands[key].append(value)
 
-
     # Skip if we would overwrite an existing file with empty commands
-    skip_cls = os.path.exists(".cls-commands.json") and len(commands.keys()) == 0
+    skip_cls = (
+        os.path.exists(".cls-commands.json") and len(commands.keys()) == 0
+    )
     if not skip_cls:
         with open(".cls-commands.json", "w") as f:
             json.dump(commands, f)


### PR DESCRIPTION
Prevents chpl-shim from overwriting files when there is nothing to do. This can cause issues with `chpl-shim mason build` where `mason` doesn't rebuild without source modification. This results in `chpl-shim` writing an empty `.cls-commands.json` file.

Resolves https://github.com/chapel-lang/chapel/issues/25226

Tested that multiple `chpl-shim mason build` runs do not break `.cls-commands.json`

[Reviewed by @DanilaFe]