### PR TITLE
Fix variable name mismatch in `nightly` script

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -841,7 +841,7 @@ if ($runtests == 0) {
                 $splice = "$utildir/devel/test/spliceDat";
                 $spliceCommand = "$splice -from_a $today -to_a $today $svnPerfDir/$datName $historicalFile> $tmpDatDir/$datName";
                 $spliceDatMessage = "Attempting to splice historical data $historicalFile with nightly data $svnPerfDir/$datName";
-                mysystem($spliceCommand, $spliceMessage, $ignoreError, 1);
+                mysystem($spliceCommand, $spliceMessage, $ignoreErrors, 1);
                 `cp $svnPerfDir/$datName $tmpNightlyDatDir/$datName`;
             }
 

--- a/util/cron/nightlysubs.pm
+++ b/util/cron/nightlysubs.pm
@@ -16,10 +16,10 @@ unlink($file);
 # be one of three values.
 #
 # * $exitOnError (aka <exit on error>): exit the script if the command fails
-# * $ignoreError (aka <ignore error>): silently allow the error to fail
+# * $ignoreErrors (aka <ignore errors>): silently allow the error to fail
 # * a path to a file: write the error to that file and continue
 $exitOnError = "<exit on error>";
-$ignoreError = "<ignore error>";
+$ignoreErrors = "<ignore errors>";
 sub mysystem {
     $command = $_[0];
     $errorname = $_[1];
@@ -36,7 +36,7 @@ sub mysystem {
         print "Error $errorname: $status\n";
         if ($onerror eq $exitOnError) {
             exit 1;
-        } elsif ($onerror eq $ignoreError) {
+        } elsif ($onerror eq $ignoreErrors) {
             # Do nothing
         } else {
             open(my $SF, '>>', $onerror) or die "Could not open file '$onerror' $!";


### PR DESCRIPTION
`nightlysubs` defines `$ignoreError`, but the `nightly` script uses `$ignoreErrors`. I renamed the former to the latter, because it reads nicer.

Reviewed by @lydia-duncan -- thanks!

## Testing
- [x] `nightly` with deliberately broken `chpldoc` does not send email