### PR TITLE
Turn off this test due to it occasionally encountering a sporadic failure

### DIFF
--- a/test/library/draft/DistributedMap/v3/staticMemManager.chpl
+++ b/test/library/draft/DistributedMap/v3/staticMemManager.chpl
@@ -1,3 +1,5 @@
+// WARNING: this test has some race in it.  Please find it before re-enabling
+// the test!
 use DistributedMap;
 
 const n = 200;


### PR DESCRIPTION
There's probably a race in the test or the context manager it relies on, but given that this is a proof-of-concept rather than a piece of code we want people to rely on, just avoid the problem for now by turning the test off and leave a note warning about the race.

I wasn't able to observe the sporadic failure on OSX, but I was seeing it very rarely on linux - in 5 out of 2200 runs.  Running the other tests in the directory around 1000 times didn't reveal any sporadic behavior for them, so don't turn them off.

Ran a fresh checkout of the directory to verify that the test no longer runs