### PR TITLE
Unset CHPL_LLVM_CONFIG variable for GPU tests

### DIFF
--- a/util/cron/common-native-gpu.bash
+++ b/util/cron/common-native-gpu.bash
@@ -6,6 +6,9 @@ source $CWD/common.bash
 # number as a parameter to the script.
 # source /cray/css/users/chapelu/setup_system_llvm.bash
 
+# Prevent which LLVM from being set by this variable, so it can be overridden
+# later to use ROCM LLVM.
+unset CHPL_LLVM_CONFIG
 export CHPL_LLVM=system
 export CHPL_LOCALE_MODEL=gpu
 export CHPL_TEST_GPU=true

--- a/util/cron/common-native-gpu.bash
+++ b/util/cron/common-native-gpu.bash
@@ -6,9 +6,6 @@ source $CWD/common.bash
 # number as a parameter to the script.
 # source /cray/css/users/chapelu/setup_system_llvm.bash
 
-# Prevent which LLVM from being set by this variable, so it can be overridden
-# later to use ROCM LLVM.
-unset CHPL_LLVM_CONFIG
 export CHPL_LLVM=system
 export CHPL_LOCALE_MODEL=gpu
 export CHPL_TEST_GPU=true

--- a/util/cron/test-gpu-rocm.bash
+++ b/util/cron/test-gpu-rocm.bash
@@ -6,6 +6,9 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-slurm-gasnet-cray-cs.bash
 source $CWD/common-native-gpu.bash
 
+# Prevent which LLVM from being set by this variable, so it can be overridden
+# # later to use ROCM LLVM.
+unset CHPL_LLVM_CONFIG
 export CHPL_GPU=amd
 export CHPL_GPU_ARCH=gfx906
 export CHPL_LLVM=system

--- a/util/cron/test-gpu-rocm.gasnet.bash
+++ b/util/cron/test-gpu-rocm.gasnet.bash
@@ -6,6 +6,9 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-slurm-gasnet-cray-cs.bash
 source $CWD/common-native-gpu.bash
 
+# Prevent which LLVM from being set by this variable, so it can be overridden
+# # later to use ROCM LLVM.
+unset CHPL_LLVM_CONFIG
 export CHPL_GPU=amd
 export CHPL_GPU_ARCH=gfx906
 export CHPL_LLVM=system

--- a/util/cron/test-perf.gpu-rocm.bash
+++ b/util/cron/test-perf.gpu-rocm.bash
@@ -6,6 +6,9 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-slurm-gasnet-cray-cs.bash
 source $CWD/common-native-gpu.bash
 
+# Prevent which LLVM from being set by this variable, so it can be overridden
+# # later to use ROCM LLVM.
+unset CHPL_LLVM_CONFIG
 export CHPL_GPU=amd
 export CHPL_LAUNCHER_PARTITION=amdMI60
 export CHPL_GPU_ARCH=gfx906


### PR DESCRIPTION
Unset the `CHPL_LLVM_CONFIG` environment variable for GPU tests.

This variable is set by the new Spack install, and prevents the test scripts from overriding with another LLVM such as ROCM LLVM when necessary. Unsetting it is a temporary solution; it should be possible to change the Spack install to never set it in the first place in all configurations, but we want to minimize potential fallout leading up to release.

See discussion at https://cray.slack.com/archives/GDP57GWNS/p1718226256981199?thread_ts=1718211492.378619&cid=GDP57GWNS.

[reviewer info placeholder]