### PR TITLE
Add missing .comm-none.good file

### DIFF
--- a/test/distributions/block/checkLocalizeConstBlockDom.comm-none.good
+++ b/test/distributions/block/checkLocalizeConstBlockDom.comm-none.good
@@ -1,0 +1,2 @@
+In initCopy(definedConst=false), domain definedConst: true; taking normal path
+0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0


### PR DESCRIPTION
In my earlier PR today, I'd been testing almost exclusively locally and then with GASNet in a paratest setting, so missed that I'd forgotten to 'git add' the comm-none .good file that I'd been testing against. This adds it.
