### PR TITLE
Pin llvm version for arkouda release testing

### DIFF
--- a/util/cron/test-perf.chapcs.arkouda.release.bash
+++ b/util/cron/test-perf.chapcs.arkouda.release.bash
@@ -12,10 +12,10 @@ if [ -n "$CHPL_WHICH_RELEASE_FOR_ARKOUDA" ]; then
   # Note: Add more cases to the following 'if' whenever we need to test a
   # release that does not support our latest available LLVM. Cases can be
   # removed when we no longer care about testing against that release.
-  if [ "$CHPL_WHICH_RELEASE_FOR_ARKOUDA" = "1.30.0" ]; then
-    # use LLVM 15, latest supported by 1.31.0
+  if [ "$CHPL_WHICH_RELEASE_FOR_ARKOUDA" = "2.0.0" ]; then
+    # use LLVM 17, latest supported by 2.0.0
     if [ -f /data/cf/chapel/setup_system_llvm.bash ] ; then
-      source /data/cf/chapel/setup_system_llvm.bash 15
+      source /data/cf/chapel/setup_system_llvm.bash 17
     fi
   else
     # Default to using latest LLVM.


### PR DESCRIPTION
This PR fixes testing of Arkouda with the Chapel release after a system upgrade to LLVM 18.

[Reviewed by @riftEmber]