### PR TITLE
Fix CUDA interop tests for newer LLVM versions

### DIFF
--- a/test/gpu/interop/cuBLAS/c_cublas.compile.sh
+++ b/test/gpu/interop/cuBLAS/c_cublas.compile.sh
@@ -1,3 +1,14 @@
 #!/usr/bin/env bash
 
-nvcc -c c_cublas.c -lcublas
+chpl=$1
+
+chpl_home=$($chpl --print-chpl-home)
+llvm_version=$($chpl_home/util/printchplenv --all --simple | grep CHPL_LLVM_VERSION | sed 's/CHPL_LLVM_VERSION=//')
+
+NVCC_FLAGS=""
+if [[ "$llvm_version" -ge 15 ]]; then
+  # LLVM 15 and later require default to -fPIE, so streamKernel.cu needs to be compiled with -fPIE
+  NVCC_FLAGS="--compiler-options -fPIE"
+fi
+
+nvcc -c c_cublas.c -lcublas $NVCC_FLAGS

--- a/test/gpu/interop/cuBLAS/level1/PRECOMP
+++ b/test/gpu/interop/cuBLAS/level1/PRECOMP
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
-cd ../ && ./c_cublas.compile.sh
+chpl=$3
+cd ../ && ./c_cublas.compile.sh $chpl

--- a/test/gpu/interop/stream/streamChpl.precomp
+++ b/test/gpu/interop/stream/streamChpl.precomp
@@ -1,5 +1,15 @@
 #!/bin/bash
 
-nvcc -O3 -c streamKernel.cu -o streamKernel.o 
+chpl=$3
+chpl_home=$($chpl --print-chpl-home)
+llvm_version=$($chpl_home/util/printchplenv --all --simple | grep CHPL_LLVM_VERSION | sed 's/CHPL_LLVM_VERSION=//')
+
+NVCC_FLAGS=""
+if [[ "$llvm_version" -ge 15 ]]; then
+  # LLVM 15 and later require default to -fPIE, so streamKernel.cu needs to be compiled with -fPIE
+  NVCC_FLAGS="--compiler-options -fPIE"
+fi
+
+nvcc -O3 -c streamKernel.cu -o streamKernel.o $NVCC_FLAGS
 nvcc -O3 streamKernel.o -o streamKernelDlinked.o -dlink
 


### PR DESCRIPTION
This adds extra `nvcc` compilation flags required when doing CUDA interop with Chapel code compiled with LLVM 15+.

The problem with this test was exposed by a test system upgrade to LLVM 18.

Tested that `start_test test/gpu/interop/cuBLAS/ test/gpu/interop/stream/` works with LLVM 18

[Reviewed by @stonea]