### PR TITLE
Add an ID constructor overload taking only `symbolPath`

### DIFF
--- a/frontend/include/chpl/framework/ID.h
+++ b/frontend/include/chpl/framework/ID.h
@@ -75,7 +75,7 @@ class ID final {
     Construct an ID with specified symbol path, and default postorder traversal
     number.
    */
-  ID(UniqueString symbolPath) : symbolPath_(symbolPath) {}
+  explicit ID(UniqueString symbolPath) : symbolPath_(symbolPath) {}
 
   /**
     Return a path to the ID symbol scope. For example, a function 'foo'

--- a/frontend/include/chpl/framework/ID.h
+++ b/frontend/include/chpl/framework/ID.h
@@ -72,6 +72,12 @@ class ID final {
   }
 
   /**
+    Construct an ID with specified symbol path, and default postorder traversal
+    number.
+   */
+  ID(UniqueString symbolPath) : symbolPath_(symbolPath) {}
+
+  /**
     Return a path to the ID symbol scope. For example, a function 'foo'
     declared in a module M would have symbolPath M.foo.
 

--- a/frontend/include/chpl/uast/BuilderResult.h
+++ b/frontend/include/chpl/uast/BuilderResult.h
@@ -65,11 +65,11 @@ namespace llvm {
     }
 
     static const chpl::ID getEmptyKey() {
-      return chpl::ID(USTR("<empty>"), -1, 0);
+      return chpl::ID(USTR("<empty>"));
     }
 
     static const chpl::ID getTombstoneKey() {
-      return chpl::ID(USTR("<tombstone>"), -1, 0);
+      return chpl::ID(USTR("<tombstone>"));
     }
   };
 }

--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -772,7 +772,7 @@ static const Module* const& getToplevelModuleQuery(Context* context,
 
   const Module* result = nullptr;
 
-  auto searchId = ID(name, -1, 0);
+  auto searchId = ID(name);
   UniqueString path;
   UniqueString parentSymbolPath;
   bool found = context->filePathForId(searchId, path, parentSymbolPath);
@@ -856,7 +856,7 @@ ID getSymbolFromTopLevelModule(Context* context,
   fullPath += ".";
   fullPath += symName;
 
-  return ID(UniqueString::get(context, fullPath), -1, 0);
+  return ID(UniqueString::get(context, fullPath));
 }
 
 static const Module* const&

--- a/frontend/test/framework/testIds.cpp
+++ b/frontend/test/framework/testIds.cpp
@@ -31,9 +31,11 @@ static void test1() {
   Context ctx;
   Context* context = &ctx;
 
-  auto t1 = ID(UniqueString::get(context, "\\#\\#\\#\\.\\.\\."), -1, 0);
-  auto t2 = ID(UniqueString::get(context, "\\#\\#\\#\\.\\.\\."), -1, 0);
+  auto t1 = ID(UniqueString::get(context, "\\#\\#\\#\\.\\.\\."));
+  auto t2 = ID(UniqueString::get(context, "\\#\\#\\#\\.\\.\\."));
+  auto t3 = ID(UniqueString::get(context, "\\#\\#\\#\\.\\.\\."), -1, 0);
   assert(0 == t1.compare(t2));
+  assert(0 == t1.compare(t3));
 
   auto t1Parent = t1.parentSymbolId(context);
   assert(t1Parent.isEmpty());
@@ -45,26 +47,26 @@ static void test1() {
   assert(exp1[0].first == "\\#\\#\\#\\.\\.\\.");
   assert(exp1[0].second == 0);
 
-  auto t3 = ID(UniqueString::get(context, "ChapelRange.\\#"), -1, 0);
-  auto t3Parent = t3.parentSymbolId(context);
-  assert(t3Parent.symbolPath() == "ChapelRange");
-  auto t3name = t3.symbolName(context);
-  assert(t3name == "#");
+  auto t4 = ID(UniqueString::get(context, "ChapelRange.\\#"));
+  auto t4Parent = t4.parentSymbolId(context);
+  assert(t4Parent.symbolPath() == "ChapelRange");
+  auto t4name = t4.symbolName(context);
+  assert(t4name == "#");
 
-  auto exp3 = ID::expandSymbolPath(context, t3.symbolPath());
+  auto exp3 = ID::expandSymbolPath(context, t4.symbolPath());
   assert(exp3.size() == 2);
   assert(exp3[0].first == "ChapelRange");
   assert(exp3[0].second == 0);
   assert(exp3[1].first == "\\#");
   assert(exp3[1].second == 0);
 
-  auto t4 = ID(UniqueString::get(context, "file\\.name\\#.submodule.x#3"),-1,0);
-  auto t4Parent = t4.parentSymbolId(context);
-  assert(t4Parent.symbolPath() == "file\\.name\\#.submodule");
-  auto t4name = t4.symbolName(context);
-  assert(t4name == "x");
+  auto t5 = ID(UniqueString::get(context, "file\\.name\\#.submodule.x#3"));
+  auto t5Parent = t5.parentSymbolId(context);
+  assert(t5Parent.symbolPath() == "file\\.name\\#.submodule");
+  auto t5name = t5.symbolName(context);
+  assert(t5name == "x");
 
-  auto exp4 = ID::expandSymbolPath(context, t4.symbolPath());
+  auto exp4 = ID::expandSymbolPath(context, t5.symbolPath());
   assert(exp4.size() == 3);
   assert(exp4[0].first == "file\\.name\\#");
   assert(exp4[0].second == 0);
@@ -96,7 +98,7 @@ static void test2() {
   }
 
   auto escSub = esc + ".x#3";
-  ID eltId = ID(UniqueString::get(context, escSub), -1, 0);
+  ID eltId = ID(UniqueString::get(context, escSub));
   ID eltId1 = ID(UniqueString::get(context, escSub), 1, 0);
 
   assert(eltId.parentSymbolId(context).symbolPath() == esc.c_str());
@@ -116,7 +118,7 @@ static void test2() {
 
   const char* subFname = "weird-file##.name/Submodule.chpl";
   auto escSubMod = esc + ".Submodule#4";
-  ID subModId = ID(UniqueString::get(context, escSubMod), -1, 0);
+  ID subModId = ID(UniqueString::get(context, escSubMod));
 
   assert(subModId.parentSymbolId(context).symbolPath() == esc.c_str());
   assert(subModId.symbolName(context) == "Submodule");
@@ -134,7 +136,7 @@ static void test2() {
   }
 
   auto escSubElt = escSubMod + ".y#5";
-  ID subEltId = ID(UniqueString::get(context, escSubElt), -1, 0);
+  ID subEltId = ID(UniqueString::get(context, escSubElt));
 
   assert(subEltId.parentSymbolId(context).symbolPath()==subModId.symbolPath());
   assert(subEltId.symbolName(context) == "y");

--- a/frontend/test/resolution/testCanPass.cpp
+++ b/frontend/test/resolution/testCanPass.cpp
@@ -587,7 +587,7 @@ static void test8() {
   auto anyEnumType = QualifiedType(QualifiedType::VAR, AnyEnumType::get(c));
   auto anEnum = QualifiedType(QualifiedType::VAR,
       EnumType::get(context,
-                   ID(UniqueString::get(c, "someModule"), -1, 0),
+                   ID(UniqueString::get(c, "someModule")),
                    UniqueString::get(c, "someEnum")));
 
   // test passing an enum type to `enum` works fine


### PR DESCRIPTION
Add an overload of the ID constructor that takes only `symbolPath`, leaving default values for postorder traversal number and number of children.

This lets us remove some instances of the default values being hardcoded.

Resolves https://github.com/Cray/chapel-private/issues/4346.

[reviewer info placeholder]

Testing:
- [x] dyno tests