### PR TITLE
Set CHPL_RT_LOCALES_PER_NODE correctly in the launcher

### DIFF
--- a/runtime/src/arg.c
+++ b/runtime/src/arg.c
@@ -291,9 +291,7 @@ void parseNumLocales(const char* numPtr, int32_t lineno, int32_t filename) {
       if (_argNumLocalesPerNode < 1) {
         chpl_error("Number of locales per node must be > 0.",
                    lineno, filename);
-      } else if ((_argNumLocalesPerNode > 1) || t) {
-        // We have co-locales if there is more then one locale per node or if
-        // the locale is bound to an architectural feature.
+      } else {
         chpl_env_set_uint("CHPL_RT_LOCALES_PER_NODE",
                           (uint64_t)_argNumLocalesPerNode, 1);
       }

--- a/runtime/src/topo/hwloc/topo-hwloc.c
+++ b/runtime/src/topo/hwloc/topo-hwloc.c
@@ -516,6 +516,7 @@ static void cpuInfoInit(void) {
 static const char *objTypeString(hwloc_obj_type_t t) {
   const char *str = NULL;
   switch(t) {
+    case HWLOC_OBJ_MACHINE: str = "machine"; break;
     case HWLOC_OBJ_PACKAGE: str = "socket"; break;
     case HWLOC_OBJ_NUMANODE: str = "NUMA domain"; break;
     case HWLOC_OBJ_CORE: str = "core"; break;
@@ -592,7 +593,8 @@ static void partitionResources(void) {
       if (myRootType == HWLOC_OBJ_TYPE_MAX) {
         // Chose a root object if the number of them matches the number of
         // locales.
-        hwloc_obj_type_t rootTypes[] = {HWLOC_OBJ_PACKAGE, HWLOC_OBJ_NUMANODE,
+        hwloc_obj_type_t rootTypes[] = {HWLOC_OBJ_MACHINE, HWLOC_OBJ_PACKAGE,
+                                        HWLOC_OBJ_NUMANODE,
                                         HWLOC_OBJ_L5CACHE, HWLOC_OBJ_L4CACHE,
                                         HWLOC_OBJ_L3CACHE, HWLOC_OBJ_L2CACHE,
                                         HWLOC_OBJ_L1CACHE, HWLOC_OBJ_CORE,
@@ -750,7 +752,7 @@ void chpl_topo_post_args_init(void) {
   if (verbosity >= 2) {
     hwloc_bitmap_list_snprintf(buf, sizeof(buf), physAccSet);
     printf("%d: using core(s) %s", chpl_nodeID, buf);
-    if (myRoot) {
+    if (myRoot && (myRoot->type != HWLOC_OBJ_MACHINE)) {
       printf(" in %s %d\n", objTypeString(myRoot->type),
              myRoot->logical_index);
     } else {

--- a/test/runtime/configMatters/launch/jhh/co-locales/co-locales.py
+++ b/test/runtime/configMatters/launch/jhh/co-locales/co-locales.py
@@ -89,7 +89,7 @@ class ColocaleArgs(unittest.TestCase):
         output = self.runCmd("./hello -nl 1x1 -v --dry-run")
         self.assertTrue('--nodes=1 ' in output or '-N 1 ' in output)
         self.assertIn('--ntasks=1 ', output)
-        self.assertNotIn("CHPL_RT_LOCALES_PER_NODE", output)
+        self.assertIn("CHPL_RT_LOCALES_PER_NODE=1 ", output)
         self.assertNotIn("CHPL_RT_COLOCALE_OBJ_TYPE", output)
 
     def test_02_3x2(self):
@@ -232,6 +232,15 @@ class ColocaleArgs(unittest.TestCase):
             output = self.runCmd("./hello -nl -3xs -v --dry-run")
         self.assertEqual(cm.exception.stdout.strip(),
             '<command-line arg>:1: error: "s" is not a valid number of co-locales.')
+
+    def test_20_env_override(self):
+        """Arg Mx1 overrides CHPL_RT_LOCALES_PER_NODE"""
+        self.env['CHPL_RT_LOCALES_PER_NODE'] = '2'
+        output = self.runCmd("./hello -nl 3x1 -v --dry-run")
+        self.assertTrue('--nodes=3 ' in output or '-N 3 ' in output)
+        self.assertIn('--ntasks=3 ', output)
+        self.assertIn("CHPL_RT_LOCALES_PER_NODE=1 ", output)
+        self.assertNotIn("CHPL_RT_COLOCALE_OBJ_TYPE", output)
 
 # copied from sub_test.py
 # report an error message and exit


### PR DESCRIPTION
The argument -nl Mx1 did not cause the launcher to set CHPL_RT_LOCALES_PER_NODE because one locale per node is implied. However, if this variable was already set in the environment it would be passed along to the runtime, causing an inconsistency between the launcher and the runtime. By setting it to 1 both the launcher and runtime agree on the number of co-locales.

Signed-off-by: John H. Hartman <jhh67@users.noreply.github.com>