### PR TITLE
Print "constant due to task intents" in more cases

### DIFF
--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -592,7 +592,8 @@ static ShadowVarSymbol* create_IN_Parentvar(LoopWithShadowVarsInterface* fs,
 }
 
 static void constDueToTFI(ShadowVarSymbol* svar, Symbol* ovar) {
-  if (!ovar->isConstant())
+  if (!ovar->isConstant() ||
+      ovar->hasFlag(FLAG_CONST_DUE_TO_TASK_FORALL_INTENT))
     svar->addFlag(FLAG_CONST_DUE_TO_TASK_FORALL_INTENT);
 }
 

--- a/test/parallel/forall/vass/other/const-errors-due-to-intents.chpl
+++ b/test/parallel/forall/vass/other/const-errors-due-to-intents.chpl
@@ -16,3 +16,12 @@ forall a in A with (const i2, const in i3, const ref i4) {
   useit(i3);
   useit(i4);
 }
+
+forall a1 in A do
+  forall a2 in A do
+    forall a3 in A with (ref i1) do  // illegal: 'i1' is const in 'forall a2'
+      i1 = 8;
+
+forall a1 in A do
+  forall a2 in A do
+    i2 = 8;  // illegal: 'i2' is const in 'forall a2'

--- a/test/parallel/forall/vass/other/const-errors-due-to-intents.good
+++ b/test/parallel/forall/vass/other/const-errors-due-to-intents.good
@@ -14,3 +14,7 @@ const-errors-due-to-intents.chpl:16: error: const actual is passed to 'ref' form
 const-errors-due-to-intents.chpl:9: note: The shadow variable 'i3' is constant due to task intents in this loop
 const-errors-due-to-intents.chpl:17: error: const actual is passed to 'ref' formal 'arg' of useit()
 const-errors-due-to-intents.chpl:9: note: The shadow variable 'i4' is constant due to task intents in this loop
+const-errors-due-to-intents.chpl:23: error: cannot assign to const variable
+const-errors-due-to-intents.chpl:21: note: The shadow variable 'i1' is constant due to task intents in this loop
+const-errors-due-to-intents.chpl:27: error: cannot assign to const variable
+const-errors-due-to-intents.chpl:26: note: The shadow variable 'i2' is constant due to task intents in this loop


### PR DESCRIPTION
Prints the note "The shadow variable 'xyz' is constant due to task intents in this loop" in more cases, see test additions. For example:

```chpl
var i: int;
forall ... do
  forall ... do
    i = 8;     // error here due to an (implicit) task intent
               // in the forall loop on the previous line
```

Somewhat of an aside, consider this example, which came from a  user and motivated this change:
```chpl
var path: ...;
forall ... do
  forall ... do
    forall ... with (ref path) do
      // use 'path' here
```

I consider the `ref path` intent in the inner-most forall loop to be an error already. This is because `path` is a shadow variable in the enclosing loop that is constant and so cannot be passed by the non-const `ref` intent. However, the compiler, due to an implementation quirk, does not check ref intents. Instead it checks uses of the shadow variable in the loop body. If there is a use requiring the shadow var to be non-const, it issues an error. If there are no such uses, there is no error.

Testing: standard and gasnet paratests.