### PR TITLE
Add Ubuntu Noble to apptainer testing

### DIFF
--- a/util/devel/test/apptainer/current/ubuntu-noble-nollvm/image.def
+++ b/util/devel/test/apptainer/current/ubuntu-noble-nollvm/image.def
@@ -1,0 +1,11 @@
+BootStrap: docker
+From: ubuntu:noble
+
+%files
+    ../../provision-scripts/* /provision-scripts/
+
+%post
+    /provision-scripts/apt-get-deps.sh
+
+%runscript
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/ubuntu-noble/image.def
+++ b/util/devel/test/apptainer/current/ubuntu-noble/image.def
@@ -1,0 +1,13 @@
+BootStrap: docker
+From: ubuntu:noble
+
+%files
+    ../../provision-scripts/* /provision-scripts/
+
+%post
+    /provision-scripts/apt-get-deps.sh
+    # installs LLVM 18
+    /provision-scripts/apt-get-llvm.sh
+
+%runscript
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/extract-docs.py
+++ b/util/devel/test/apptainer/extract-docs.py
@@ -57,6 +57,8 @@ def title(name):
         name = '23.04 "Lunar Lobster"'
     if name == "Mantic":
         name = '23.10 "Mantic Minotaur"'
+    if name == "Noble":
+        name = '24.04 "Noble Numbat"'
     return name
 
 def fixname(subdir):
@@ -84,7 +86,7 @@ def fixname(subdir):
             tmp = part[:part.find("linux")]
             adj.append(title(tmp))
             adj.append("Linux")
-        elif re.search('\d$', part):
+        elif re.search('\\d$', part):
             sections = re.split('([0-9.]+)', part)
             for s in sections:
                 s = s.strip()

--- a/util/devel/test/vagrant/README-distro-timelines.txt
+++ b/util/devel/test/vagrant/README-distro-timelines.txt
@@ -149,6 +149,7 @@ x 16.04 "Xenial Xerus"      LTS until Apr 2021, EOL Apr 2026
   18.04 "Bionic Beaver"     LTS until Jun 2023, EOL Apr 2028
   20.04 "Focal Fossa"       LTS until Apr 2025, EOL Apr 2030
   22.04 "Jammy Jellyfish"   LTS until Jun 2027, EOL Apr 2032
+  24.04 "Noble Numbat"      LTS until Jun 2024, EOL Apr 2036
 
 non-LTS:
 x 14.10 "Utopic Unicorn"    EOL July 2015


### PR DESCRIPTION
This PR adds Ubuntu Noble to the apptainer testing and fixes an incompatibility with recent Python 3 versions for extract-docs.py.

This is a test change only.

Reviewed by @arezaii - thanks!