### PR TITLE
Update test to avoid memory leak

### DIFF
--- a/test/multilocale/diten/localBlock/needMultiLocales/localBlock5.chpl
+++ b/test/multilocale/diten/localBlock/needMultiLocales/localBlock5.chpl
@@ -1,22 +1,22 @@
 class C {
   var a: int;
-  var next: unmanaged C?;
+  var next: shared C?;
 }
 
-var A: [1..5] unmanaged C?;
+var A: [1..5] shared C?;
 
 on Locales(1) {
-  [i in A.domain] A(i) = new unmanaged C(i);
+  [i in A.domain] A(i) = new shared C(i);
 }
 
-[i in A.domain] A(i)!.next = new unmanaged C(i+1);
+[i in A.domain] A(i)!.next = new shared C(i+1);
 
 var B = A!.next;
 local {
-  B!.next = new unmanaged C(B!.a + 1);
+  B!.next = new shared C(B!.a + 1);
 }
 
-proc foo(c: unmanaged C?) {
+proc foo(c: C?) {
   c!.a = c!.a - 3;
 }
 


### PR DESCRIPTION
This is a longstanding test, but it isn't one that worked (ran to completion) until I updated it to use a new optimization yesterday. It has leaked memory all along, but because it didn't complete, we didn't complain about it; now that it does, we started to.

Here, I'm changing the class types to use 'shared' (similar to what was already done in its sibling, localBlock6.chpl) to close the leak in a simple way without changing the point of the test (to see how local blocks and classes interact).

Note that neither of these tests used any memory management styles when originally written and that they were added later as we were changing the way classes were managed by default.
