### PR TITLE
Enable more floating point optimizations for `--no-ieee-float`

### DIFF
--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -2728,6 +2728,15 @@ void FnSymbol::codegenDef() {
       func->addFnAttr("target-cpu", TargetCPU);
       func->addFnAttr("target-features", TargetFeatures);
     }
+    if (ffloatOpt == 1) {
+      func->addFnAttr("unsafe-fp-math", "true");
+      func->addFnAttr("approx-func-fp-math", "true");
+      func->addFnAttr("denormal-fp-math", "preserve-sign,preserve-sign");
+      func->addFnAttr("no-infs-fp-math", "true");
+      func->addFnAttr("no-nans-fp-math", "true");
+      func->addFnAttr("no-signed-zeros-fp-math", "true");
+      func->addFnAttr("no-trapping-math", "true");
+    }
 
     llvm::BasicBlock *block =
       llvm::BasicBlock::Create(info->module->getContext(), "entry", func);


### PR DESCRIPTION
This adds a few extra flags and switches for `--no-ieee-float` to enable better backend optimization when compiling with `clang` for Chapel code.

This also adds some GPU specific flags, to better match the code that `nvcc` outputs with `--use_fast_math`

[Reviewed by @]