### PR TITLE
Improve Mason Documentation

### DIFF
--- a/doc/rst/tools/mason/guide/submitting.rst
+++ b/doc/rst/tools/mason/guide/submitting.rst
@@ -5,11 +5,12 @@
 Submit a Package
 ================
 
-The mason registry will hold the manifest files for packages submitted by developers.
-To contribute a package to the mason-registry a chapel developer will need to host their
-package and submit a pull request to the mason-registry with the toml file pointing
-to their package. For a more detailed description follow the steps below. Publishing
-can be done with ``mason publish`` or manually.
+The `Mason-Registry <https://github.com/chapel-lang/mason-registry>`_ will hold
+the manifest files for packages submitted by developers. To contribute a
+package to the mason-registry a chapel developer will need to host their
+package and submit a pull request to the mason-registry with the toml file
+pointing to their package. For a more detailed description follow the steps
+below. Publishing can be done with ``mason publish`` or manually.
 
 ``mason publish`` Steps:
       1) Write a library or binary package in chapel using mason
@@ -90,4 +91,3 @@ The current resolution strategy for Mason 0.1.0 is the IVRS as described below:
        (ex. 1.4.3, 1.7.0 --> 1.7)
     3. If multiple major versions are present, mason will print an error.
        (ex. 1.13.0, 2.1.0 --> incompatible)
-

--- a/doc/rst/tools/mason/mason.rst
+++ b/doc/rst/tools/mason/mason.rst
@@ -25,7 +25,7 @@ Chapel programs.
    feedback and requests on the guide as we go.
 
 
-Quick start Instructions
+Quick Start Instructions
 ------------------------
 
 To install mason, run ``make mason`` from your Chapel home directory.

--- a/doc/rst/tools/mason/mason.rst
+++ b/doc/rst/tools/mason/mason.rst
@@ -46,7 +46,9 @@ within `MyAppName`.
 
 Or, to create a mason package that can be used as a dependency in other mason
 projects, run: ``mason new <MyPackageName> --lib``. This will create a similar
-file structure, except `MyPackageName.chpl` won't have a `main` function:
+file structure; however, the primary source file, `MyPackageName.chpl`, won't
+have a `main` routine because the library is not intended to be run as a
+standalone program:
 
 .. code-block:: none
 
@@ -55,11 +57,15 @@ file structure, except `MyPackageName.chpl` won't have a `main` function:
    │   └── MyPackageName.chpl
    └── Mason.toml
 
-For either type of mason project, you can add new dependencies with ``mason add
-<package name>``. This will add your dependency to the `toml` file. When your
-project is built, mason will download the dependency from the `Mason-Registry
-<https://github.com/chapel-lang/mason-registry>`_, allowing you to use it in
-your application or library.
+For either type of mason project, add new dependencies with ``mason add
+<package name>``. This will add the new dependency to the list in the `toml`
+file. When the project is built, mason will download source files for all
+Chapel dependencies using the `Mason-Registry
+<https://github.com/chapel-lang/mason-registry>`_, allowing them to be used
+in the application or library.
+
+Note that mason also supports numerous other features such as unit testing,
+examples, and documentation. See the sections below for more information.
 
 
 Getting Started with Mason

--- a/doc/rst/tools/mason/mason.rst
+++ b/doc/rst/tools/mason/mason.rst
@@ -25,15 +25,49 @@ Chapel programs.
    feedback and requests on the guide as we go.
 
 
-The Chapel Users Guide is divided into four main sections:
+Quick start Instructions
+------------------------
+
+To install mason, run ``make mason`` from your Chapel home directory.
+
+To create a new mason application run: ``mason new <MyAppName>``. This will
+create a mason project in a new directory `MyAppName` with the following
+structure:
+
+.. code-block:: none
+
+   MyAppName/
+   ├── src/
+   │   └── MyAppName.chpl
+   └── Mason.toml
+
+The app can be run by calling ``mason build`` followed by ``mason run`` from
+within `MyAppName`.
+
+Or, to create a mason package that can be used as a dependency in other mason
+projects, run: ``mason new <MyPackageName> --lib``. This will create a similar
+file structure, except `MyPackageName.chpl` won't have a `main` function:
+
+.. code-block:: none
+
+   MyPackageName/
+   ├── src/
+   │   └── MyPackageName.chpl
+   └── Mason.toml
+
+For either type of mason project, you can add new dependencies with ``mason add
+<package name>``. This will add your dependency to the `toml` file. When your
+project is built, mason will download the dependency from the `Mason-Registry
+<https://github.com/chapel-lang/mason-registry>`_, allowing you to use it in
+your application or library.
 
 
 Getting Started with Mason
 --------------------------
 
-In this section, you will find information on installing mason
-and a basic HelloWorld example to get you started using mason
-packages in your own code.
+In this section, you will find more detailed information about installing mason
+and a basic HelloWorld example to get you started using mason packages in your
+own code.
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
Adds a 'quickstart' section to the main mason documentation page. Intended to be helpful for people who are experienced with package managers and just need a few hints/reminders to get them going.

Adds a link to the mason-registry to the page about how to publish mason packages.

- [x] inspected built docs