### PR TITLE
Add missing id check for `--break-on-codegen-id`

### DIFF
--- a/compiler/codegen/cg-CForLoop.cpp
+++ b/compiler/codegen/cg-CForLoop.cpp
@@ -265,6 +265,9 @@ static void addLoopMetadata(llvm::Instruction* instruction,
 
 GenRet CForLoop::codegen()
 {
+  if (id == breakOnCodegenID)
+    gdbShouldBreakHere();
+
   GenInfo* info    = gGenInfo;
   FILE*    outfile = info->cfile;
   GenRet   ret;


### PR DESCRIPTION
Adds a missing `if(id == ...)` for `--break-on-codegen-id`, a useful feature for debugging Chapel codegen.

[Not reviewed - trivial]