### PR TITLE
Add use for CHPL_COMM in UgniPerfStats Module

### DIFF
--- a/modules/packages/UgniPerfStats.chpl
+++ b/modules/packages/UgniPerfStats.chpl
@@ -32,7 +32,7 @@
     default to dynamic linking.
  */
 module UgniPerfStats {
-
+  private use ChplConfig only CHPL_COMM;
   /* Zero performance counters on the current locale */
   inline proc resetStatsHere() {
     if CHPL_COMM == "ugni" {


### PR DESCRIPTION
The UgniPerfStats module had this error since it used CHPL_COMM without
using or importing it first. I happened to come across it by chance.

No tests exist for this module in particular. It isn't used enough to
add tests.