### PR TITLE
Use ROCm LLVM in GPU perf test config

### DIFF
--- a/util/cron/test-perf.gpu-rocm.bash
+++ b/util/cron/test-perf.gpu-rocm.bash
@@ -6,9 +6,6 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-slurm-gasnet-cray-cs.bash
 source $CWD/common-native-gpu.bash
 
-# Prevent which LLVM from being set by this variable, so it can be overridden
-# # later to use ROCM LLVM.
-unset CHPL_LLVM_CONFIG
 export CHPL_GPU=amd
 export CHPL_LAUNCHER_PARTITION=amdMI60
 export CHPL_GPU_ARCH=gfx906
@@ -22,6 +19,10 @@ source $CWD/common-native-gpu-perf.bash
 # CONFIG_NAME
 source $CWD/common-perf.bash
 export CHPL_TARGET_CPU=native
+
+# Prevent which LLVM from being set by this variable, so it can be overridden
+# # later to use ROCM LLVM.
+unset CHPL_LLVM_CONFIG
 
 # everything we source above will end up sourcing `common.bash` which will then
 # source `load-base-deps.bash`. In the system we run this config,


### PR DESCRIPTION
Moves `unset CHPL_LLVM_CONFIG` lower in a perf config script so that it comes after `common-perf.bash`, which sets `CHPL_LLVM_CONFIG`

[Not reviewed, will get a post-merge review]