### PR TITLE
undefine C complex I macro which conflicts with ROCm

### DIFF
--- a/runtime/include/chpltypes.h
+++ b/runtime/include/chpltypes.h
@@ -39,6 +39,8 @@ typedef double _Complex       _complex128;
 #ifndef _Complex_I
 static const _complex64 _Complex_I = {0.0f, 1.0f};
 #endif
+// C's complex I macro conflicts with some template parameters in e.g. rocPRIM
+#undef I
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
This PR aims to fix issue #25245.
Some rocPRIM template definitions use capital I, which conflicts with the macro 'I' defined in the C header <complex.h>. 
For example: https://github.com/ROCm/rocPRIM/blob/release/rocm-rel-5.4.3.1/rocprim/include/rocprim/types/tuple.hpp#L92 

As the C macro is not used elsewhere in Chapel runtime code, it can simply be undefined after <complex.h> is included.