### PR TITLE
Workaround GCC 8.1 and LLVM bug

### DIFF
--- a/third-party/llvm/README
+++ b/third-party/llvm/README
@@ -52,6 +52,24 @@ option(LLVM_INCLUDE_TESTS "Generate build targets for the LLVM unit tests." OFF)
   llvm-src/CMakeLists.txt looks like the following:
 option(LLVM_INCLUDE_BENCHMARKS "Generate benchmark targets. If OFF, benchmarks can't be built." OFF)
 
+* Patched `lib/Support/APFloat.cpp` to workaround https://github.com/llvm/llvm-project/issues/81013
+```
+--- a/third-party/llvm/llvm-src/lib/Support/APFloat.cpp
++++ b/third-party/llvm/llvm-src/lib/Support/APFloat.cpp
+@@ -112,9 +112,9 @@ struct fltSemantics {
+   /* Number of bits actually used in the semantics. */
+   unsigned int sizeInBits;
+ 
+-  fltNonfiniteBehavior nonFiniteBehavior = fltNonfiniteBehavior::IEEE754;
++  fltNonfiniteBehavior nonFiniteBehavior = fltNonfiniteBehavior(int(fltNonfiniteBehavior::IEEE754));
+ 
+-  fltNanEncoding nanEncoding = fltNanEncoding::IEEE;
++  fltNanEncoding nanEncoding = fltNanEncoding(int(fltNanEncoding::IEEE));
+   // Returns true if any number described by this semantics can be precisely
+   // represented by the specified semantics. Does not take into account
+   // the value of fltNonfiniteBehavior.
+```
+
 Upgrading LLVM versions
 =======================
 

--- a/third-party/llvm/llvm-src/lib/Support/APFloat.cpp
+++ b/third-party/llvm/llvm-src/lib/Support/APFloat.cpp
@@ -112,9 +112,9 @@ struct fltSemantics {
   /* Number of bits actually used in the semantics. */
   unsigned int sizeInBits;
 
-  fltNonfiniteBehavior nonFiniteBehavior = fltNonfiniteBehavior::IEEE754;
+  fltNonfiniteBehavior nonFiniteBehavior = fltNonfiniteBehavior(int(fltNonfiniteBehavior::IEEE754));
 
-  fltNanEncoding nanEncoding = fltNanEncoding::IEEE;
+  fltNanEncoding nanEncoding = fltNanEncoding(int(fltNanEncoding::IEEE));
   // Returns true if any number described by this semantics can be precisely
   // represented by the specified semantics. Does not take into account
   // the value of fltNonfiniteBehavior.


### PR DESCRIPTION
Patches our bundled LLVM (similar to #24354) to workaround an [LLVM bug](https://github.com/llvm/llvm-project/issues/81013) that prevents the LLVM support library from being built with GCC 8.1

Tested that Chapel builds with `CHPL_LLVM=none` and `CHPL_LLVM_SUPPORT=bundled` with gcc 8.1

[Reviewed by @mppf]