### PR TITLE
Fix incorrect error with some parenless calls

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -2909,7 +2909,7 @@ void resolveCall(CallExpr* call) {
     if (resolveFunctionPointerCall(call))
       return;
 
-    if (call->isNamed("chpl__coerceCopy")) {
+    if (call->isNamedAstr(astr_coerceCopy)) {
       resolveCoerceCopyMove(call);
       return;
     }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -12852,7 +12852,8 @@ static void insertReturnTemps() {
       if (call->list == NULL && isForallRecIterHelper(call))
         continue;
       if (FnSymbol* fn = call->resolvedOrVirtualFunction()) {
-        if (fn->retType != dtVoid && fn->retTag != RET_TYPE) {
+        if (fn->retType != dtVoid && fn->retType != dtUnknown &&
+            fn->retTag != RET_TYPE) {
           ContextCallExpr* contextCall = toContextCallExpr(call->parentExpr);
           Expr*            contextCallOrCall; // insert before, remove it
 

--- a/test/functions/ferguson/parenless-call-bug.chpl
+++ b/test/functions/ferguson/parenless-call-bug.chpl
@@ -1,0 +1,33 @@
+// Bug reproducer from issue #25266
+// This code is based upon the test
+//  parallel/forall/may-vs-must-par/promo-use-standalone.chpl
+
+config const ni = 2;
+const RNGi = 1..ni;
+
+proc inc1i { }
+
+iter iter1par() {
+  writeln("iter1par serial");
+  for idx in RNGi do
+    yield idx;
+}
+iter iter1par(param tag) where tag == iterKind.standalone {
+  writeln("iter1par standalone");
+  for idx in RNGi.these(tag) do
+    yield idx;
+}
+iter iter1par(param tag) where tag == iterKind.leader {
+  writeln("iter1par leader");
+  for idx in RNGi.these(tag) do
+    yield idx;
+}
+iter iter1par(param tag, followThis) where tag == iterKind.follower {
+  inc1i;
+  for idx in RNGi.these(tag, followThis) do
+    yield idx;
+}
+
+proc multiply(arg1: int, arg2: int)   { writeln("mul=", arg1*arg2); }
+
+multiply([ IND in iter1par() ] IND, 0);

--- a/test/functions/ferguson/parenless-call-bug.good
+++ b/test/functions/ferguson/parenless-call-bug.good
@@ -1,0 +1,3 @@
+iter1par leader
+mul=0
+mul=0


### PR DESCRIPTION
This PR fixes #25266 and adds the problematic program from that issue as a test case.

The bug fix is to ignore unresolved functions within `insertReturnTemps`. For certain cases with parenless procs, `call->resolvedOrVirtualFunction()` can return a function that isn't resolved yet & has return type `dtUnknown`. We don't know yet that it needs a return temp in that case & it's equivalent to an unresolved `Call` (and return temps for unresolved calls must be handled somewhere else). So, this change arranges for `insertReturnTemps` to ignore calls in this situation, just as it ignores unresolved calls.

Reviewed by @lydia-duncan - thanks!

- [x] full comm=none testing
- [x] primers pass with `-valgrindexe`