### PR TITLE
Improve `--no-local` codegen

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -2166,6 +2166,9 @@ const char* astr_coerceCopy = NULL;
 const char* astr_coerceMove = NULL;
 const char* astr_autoDestroy = NULL;
 
+const char* astr_gen_comm_get = NULL;
+const char* astr_gen_comm_put = NULL;
+
 void initAstrConsts() {
   astrSassign = astr("=");
   astrSdot    = astr(".");
@@ -2212,6 +2215,9 @@ void initAstrConsts() {
   astr_coerceMove = astr("chpl__coerceMove");
 
   astr_autoDestroy = astr("chpl__autoDestroy");
+
+  astr_gen_comm_get = astr("chpl_gen_comm_get");
+  astr_gen_comm_put = astr("chpl_gen_comm_put");
 }
 
 bool isAstrOpName(const char* name) {

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -846,6 +846,9 @@ extern const char* astr_coerceCopy;
 extern const char* astr_coerceMove;
 extern const char* astr_autoDestroy;
 
+extern const char* astr_gen_comm_get;
+extern const char* astr_gen_comm_put;
+
 bool isAstrOpName(const char* name);
 
 void initAstrConsts();

--- a/runtime/include/chpl-comm-compiler-macros.h
+++ b/runtime/include/chpl-comm-compiler-macros.h
@@ -53,7 +53,7 @@ void chpl_gen_comm_get(void *addr, c_nodeid_t node, void* raddr,
                        size_t size, int32_t commID, int ln, int32_t fn)
 {
   if (chpl_nodeID == node) {
-    chpl_memmove(addr, raddr, size);
+    memmove(addr, raddr, size);
 #ifdef HAS_CHPL_CACHE_FNS
   } else if( chpl_cache_enabled() ) {
     chpl_cache_comm_get(addr, node, raddr, size, commID, ln, fn);
@@ -117,7 +117,7 @@ void chpl_gen_comm_put(void* addr, c_nodeid_t node, void* raddr,
                        size_t size, int32_t commID, int ln, int32_t fn)
 {
   if (chpl_nodeID == node) {
-    chpl_memmove(raddr, addr, size);
+    memmove(raddr, addr, size);
 #ifdef HAS_CHPL_CACHE_FNS
   } else if( chpl_cache_enabled() ) {
     chpl_cache_comm_put(addr, node, raddr, size, commID, ln, fn);

--- a/test/llvm/inlining/no-get-put.chpl
+++ b/test/llvm/inlining/no-get-put.chpl
@@ -1,0 +1,57 @@
+//
+// This test is a simpler version of the kinds of patterns that can cause
+// performance issues in `test/studies/lcals/`. When compiled with
+// `--no-local`, GETS, PUTS, and memmove wreak havoc on performance. This test
+// is a regression test to make sure these are always inlined properly.
+//
+
+use Time;
+config const samples=15000;
+config const N = 171;
+config type T = real;
+
+const s_num_1D_Real_arrays = 16;
+const aligned_chunksize = 44256;
+
+class LoopData {
+  var RealArray_1D: [0..#s_num_1D_Real_arrays][0..#aligned_chunksize] real;
+}
+var loop_data = new LoopData();
+
+proc initData(ref ra: [] real, id: int) {
+  const factor: real = if id % 2 != 0 then 0.1 else 0.2;
+  for (r,j) in zip(ra, 0..) {
+    r = factor*(j + 1.1)/(j + 1.12345);
+  }
+}
+proc loopInit() {
+  for i in 1..5 {
+    initData(loop_data.RealArray_1D[i-1], i);
+  }
+}
+
+
+var s = new stopwatch();
+
+proc kernel(samples, len) {
+  ref out1 = loop_data.RealArray_1D[0];
+  ref out2 = loop_data.RealArray_1D[1];
+  ref out3 = loop_data.RealArray_1D[2];
+  ref in1  = loop_data.RealArray_1D[3];
+  ref in2  = loop_data.RealArray_1D[4];
+
+  s.start();
+  for 0..#samples do
+    for i in 0..#len {
+      out1[i] = in1[i] * in2[i];
+      out2[i] = in1[i] + in2[i];
+      out3[i] = in1[i] - in2[i];
+    }
+  s.stop();
+}
+
+proc main() {
+  loopInit();
+  kernel(samples, N);
+  writeln("Elapsed time: ", s.elapsed(), " seconds");
+}

--- a/test/llvm/inlining/no-get-put.compopts
+++ b/test/llvm/inlining/no-get-put.compopts
@@ -1,0 +1,1 @@
+--llvm-print-ir kernel --llvm-print-ir-stage full --fast --no-ieee-float --no-local

--- a/test/llvm/inlining/no-get-put.good
+++ b/test/llvm/inlining/no-get-put.good
@@ -1,0 +1,1 @@
+Success

--- a/test/llvm/inlining/no-get-put.prediff
+++ b/test/llvm/inlining/no-get-put.prediff
@@ -21,17 +21,6 @@ for e in exclude_list:
         if e in l:
             output.append('Error: found call to {} in {}'.format(e, outfilename))
 
-# there should be calls to chpl_comm_get, or chpl_comm_put, and llvm.memmove
-include_list = ['chpl_comm_get', 'chpl_comm_put', 'llvm.memmove']
-for i in include_list:
-    found = False
-    for l in call_lines:
-        if i in l:
-            found = True
-            break
-    if not found:
-        output.append('Error: did not find call to {} in {}'.format(i, outfilename))
-
 if len(output) > 0:
     with open(outfilename, 'w') as f:
         for o in output:

--- a/test/llvm/inlining/no-get-put.prediff
+++ b/test/llvm/inlining/no-get-put.prediff
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+
+import sys
+import re
+
+outfilename = sys.argv[2]
+
+lines = []
+with open(outfilename, 'r') as f:
+    lines = f.readlines()
+
+call_pat = re.compile(r'\bcall\b')
+call_lines = [l for l in lines if call_pat.search(l)]
+
+output = []
+
+# there should be no calls to chpl_gen_comm_get, or chpl_gen_comm_put, or chpl_memmove
+exclude_list = ['chpl_gen_comm_get', 'chpl_gen_comm_put', 'chpl_memmove']
+for e in exclude_list:
+    for l in call_lines:
+        if e in l:
+            output.append('Error: found call to {} in {}'.format(e, outfilename))
+
+# there should be calls to chpl_comm_get, or chpl_comm_put, and llvm.memmove
+include_list = ['chpl_comm_get', 'chpl_comm_put', 'llvm.memmove']
+for i in include_list:
+    found = False
+    for l in call_lines:
+        if i in l:
+            found = True
+            break
+    if not found:
+        output.append('Error: did not find call to {} in {}'.format(i, outfilename))
+
+if len(output) > 0:
+    with open(outfilename, 'w') as f:
+        for o in output:
+            f.write(o + '\n')
+else:
+    with open(outfilename, 'w') as f:
+        f.write('Success\n')


### PR DESCRIPTION
Improves Chapel codegen with `--fast` and `--no-local` by always inlining `chpl_gen_comm_get` and `chpl_gen_comm_put` and by directly calling `memmove` (instead of through a wrapper.).

Prior to LLVM 16, we used the legacy LLVM pass manager which had a much more aggressive inliner, and these functions would be inlined into performance critical code. With newer LLVMs, the legacy pass manager has been replaced, and the new inliner is much less aggressive. When functions are inlined, the LLVM optimizer has more to work with and can optimize better and perform various forms of LICM, which is important for potentially expensive operations like GET/PUT.

Additionally, when accessing a wide pointer on the same node, the Chapel runtime uses `memmove`. LLVM has a number of optimizations for memory functions like `memmove` and `memcpy`. However, the Chapel runtime wraps `memmove` in `chpl_memmove` and if the inliner is not aggressive enough to inline the call, then the LLVM optimizations will fail to fire.

The particular patterns that cause these performance issues is exemplified by LCALs, a vectorization test suite. However, the Chapel implementation (and presumable the C version as well) uses various indirections to reduce boiler-plate. This means for a given array access, there may be several wide pointers to go through for a single array access. I created a reproducer of this pattern in `test/llvm/inlining/no-get-put.chpl`. If you remove the class and nested arrays, this code fully vectorizes loop in `kernel()`. However, the class and nested arrays both introduce indirection which is codegened as a wide pointer. This means the loop doesn't vectorize and may be extremely slow if the pointer accesses are not LICMed out of the core loop. I consider improving the vectorization in the presence of wide pointers future work.

In summary, if `chpl_gen_comm_get`, `chpl_gen_comm_put`, and `chpl_memmove` are not inlined properly, performance suffers with `--no-local`. A simple example is `muladdsub` from LCALs, which takes a 6x performance regression

Testing:
- [x] tested that `LCALs` performance recovers to pre-LLVM 16 levels with `--no-local`
- [x] full correctness test with/without comm

[Reviewed by @mppf]
