### PR TITLE
Add a no-local.good file for this test

### DIFF
--- a/test/distributions/block/checkLocalizeConstBlockDom.chpl
+++ b/test/distributions/block/checkLocalizeConstBlockDom.chpl
@@ -1,6 +1,6 @@
 use BlockDist;
 
-const D = {1..10} dmapped new blockDist({1..100});
+const D = {1..10} dmapped new blockDist({1..10});
 
 var A: [D] real;
 

--- a/test/distributions/block/checkLocalizeConstBlockDom.no-local.good
+++ b/test/distributions/block/checkLocalizeConstBlockDom.no-local.good
@@ -1,0 +1,5 @@
+In initCopy(definedConst=false), domain definedConst: false; taking normal path
+In initCopy(definedConst=false), domain definedConst: false; taking normal path
+In initCopy(definedConst=false), domain definedConst: true; taking normal path
+In initCopy(definedConst=false), domain definedConst: false; taking normal path
+0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0


### PR DESCRIPTION
I hadn't thought about how this test would behave in a no-local setting, and am not sure I would've guessed the behavior would match the multilocale .good file even if I had.  This adds a no-local.good file to lock in the current behavior.

While here, I also noticed that I accidentally changed the problem size of the domain without also changing the bbox in the blockDist argument, and didn't mean for them not to match; it doesn't seem to impact how the test works, but seemed worth updating to avoid suggesting I was trying to do anything clever or unusual—I wasn't.
