### PR TITLE
Avoid race in multilocale static variable test

### DIFF
--- a/test/variables/static/multilocale.chpl
+++ b/test/variables/static/multilocale.chpl
@@ -6,7 +6,7 @@ proc add(arg) {
   return counter;
 }
 
-forall loc in Locales do on loc {
+for loc in Locales do on loc {
   add(1);
   add(2);
   add(3);


### PR DESCRIPTION
I made the loop `forall` instead of `for`, which makes the `on` statements sometime execute out of order. This isn't important for the test, so instead, use a `for` loop.

Reviewed by @benharsh -- thanks!