### PR TITLE
Revert "gasnet/Makefile: --enable-pshm for all conduits"

### DIFF
--- a/third-party/gasnet/Makefile
+++ b/third-party/gasnet/Makefile
@@ -17,9 +17,12 @@ endif
 
 # PSHM (inter-Process SHared Memory) provide a mechanism for gasnet instances
 # on the same node to communicate through shared memory instead of the real
-# conduit. This is critical to communication performance for co-locales.
-# Note that pshm only works with segment fast/large.
-ifneq (,$(findstring $(CHPL_MAKE_COMM_SEGMENT), fast large))
+# conduit. In "production" we only run a single gasnet client per node so this
+# doesn't help, but for smp it's required, and we've noticed faster testing
+# times since we do local spawning, which will result in multiple gasnet
+# clients on the same node. Note that pshm only works with segment fast/large.
+SUB_SEG = $(CHPL_MAKE_COMM_SUBSTRATE)-$(CHPL_MAKE_COMM_SEGMENT)
+ifneq (,$(findstring $(SUB_SEG), udp-fast udp-large smp-fast smp-large))
 CHPL_GASNET_CFG_OPTIONS += --enable-pshm
 else
 CHPL_GASNET_CFG_OPTIONS += --disable-pshm


### PR DESCRIPTION
This reverts commit 9a2d0ba30fcab88241ab957276fa3dd50a9fe064.

Enabling PSHM causes a startup performance regression when `CHPL_GASNET_SEGMENT=fast` and perhaps other runtime performance regressions as well. The former can be observed via the `test/performance/elliot/no-op.chpl` test, which is about 9x slower on one platform. The hypothesis is that this because of differences in the way that the fixed heap is allocated with PSHM enabled vs. disabled. When PSHM is disabled the heap is mmapped, and it's thought that the kernel is mapping all pages at that time, so that `chpl_comm_regMemHeapTouch` isn't doing anything. When PSHM is enabled the heap is not mapped, but `chpl_comm_regMemHeapTouch` is only touching every 2MB so with a much smaller page size there are many pages to be faulted in either when the heap is registered or while the application runs. Either way, revert this change so that PSHM is disabled by default and performance is restored.