### PR TITLE
Add an explicit initialzer to LayoutCS to avoid confusion / close memory leak

### DIFF
--- a/modules/layouts/LayoutCS.chpl
+++ b/modules/layouts/LayoutCS.chpl
@@ -89,9 +89,15 @@ or for a specific domain by passing ``sortedIndices=false`` as an argument
 to the ``CS()`` initializer.
 */
 class CS: BaseDist {
-  param compressRows: bool = true;
-  param sortedIndices: bool = LayoutCSDefaultToSorted;
+  param compressRows: bool;
+  param sortedIndices: bool;
 
+  proc init(param compressRows: bool = true,
+            param sortedIndices: bool = LayoutCSDefaultToSorted) {
+    this.compressRows = compressRows;
+    this.sortedIndices = sortedIndices;
+  }
+  
   override proc dsiNewSparseDom(param rank: int, type idxType, dom: domain) {
     return new unmanaged CSDom(rank, idxType, this.compressRows, this.sortedIndices, dom.strides, _to_unmanaged(this), dom);
   }

--- a/modules/layouts/LayoutCS.chpl
+++ b/modules/layouts/LayoutCS.chpl
@@ -89,8 +89,8 @@ or for a specific domain by passing ``sortedIndices=false`` as an argument
 to the ``CS()`` initializer.
 */
 class CS: BaseDist {
-  param compressRows: bool;
-  param sortedIndices: bool;
+  param compressRows: bool = true;
+  param sortedIndices: bool = LayoutCSDefaultToSorted;
 
   proc init(param compressRows: bool = true,
             param sortedIndices: bool = LayoutCSDefaultToSorted) {


### PR DESCRIPTION
This adds an initializer to 'LayoutCS', taking the two bools that characterize it.  This is motivated by my new compressRows-cs.chpl in which I did not use named arguments, assumed that 'compressRows' was the first argument (it is the first field in the 'CS' class, and ended up (a) not testing what I intended to and (b) introducing a mysterious memory leak, due to setting some bool other than the one I thought I was.  While name-based argument passing would be the obvious/safe/self-documenting thing to do (and the thing all our existing tests of CS that pass arguments happen to do), it also seems like we don't really want users setting fields in the abstract sparse base classes.  So this PR introduces a new initializer taking the two param bools saying whether to compress the rows or columns and whether to store the indices in sorted order or not.
