### PR TITLE
Remove suppressif for LCALS

### DIFF
--- a/test/studies/lcals/LCALSMain.suppressif
+++ b/test/studies/lcals/LCALSMain.suppressif
@@ -1,2 +1,0 @@
-# suppress timeouts with --no-local
-COMPOPTS <= --no-local


### PR DESCRIPTION
Removes suppressif added for LCALS timeouts, which https://github.com/chapel-lang/chapel/pull/25278 fixed

[Not Reviewed - trivial]