### PR TITLE
Switch perf playground to main

### DIFF
--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -25,10 +25,10 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground"
 # 4) Update START_DATE to be today, using the format mm/dd/yy
 #
 
-GITHUB_USER=jabraham17
-GITHUB_BRANCH=new-pm-perf
-SHORT_NAME=new-llvm-pm
-START_DATE=05/29/24
+GITHUB_USER=chapel-lang
+GITHUB_BRANCH=main
+SHORT_NAME=main
+START_DATE=06/17/24
 
 git branch -D $GITHUB_USER-$GITHUB_BRANCH
 git checkout -b $GITHUB_USER-$GITHUB_BRANCH


### PR DESCRIPTION
Switch perf playground to main as it is not being used right now and testing main will reduce nightly noise.

[Not reviewed - trivial]