### PR TITLE
Adjust 'underscores' test to actually lock down what it claims to

### DIFF
--- a/test/errors/parsing/underscores.chpl
+++ b/test/errors/parsing/underscores.chpl
@@ -27,7 +27,7 @@ use A only dummy as _;
 // Underscores ARE allowed in tuple declarations...
 var (_, _) = (42, 42);
 // .. tuple assignments
-(_, y) = (42, 42);
+(_, _) = (42, 42);
 // .. function formals (as far as our check is concerned; another check rules these out)
 proc f(_: int) {}
 // .. renames for use targets

--- a/test/errors/parsing/underscores.chpl
+++ b/test/errors/parsing/underscores.chpl
@@ -27,7 +27,7 @@ use A only dummy as _;
 // Underscores ARE allowed in tuple declarations...
 var (_, _) = (42, 42);
 // .. tuple assignments
-(x, y) = (42, 42);
+(_, y) = (42, 42);
 // .. function formals (as far as our check is concerned; another check rules these out)
 proc f(_: int) {}
 // .. renames for use targets


### PR DESCRIPTION
As @cassella pointed out in [this comment](https://github.com/chapel-lang/chapel/pull/25168#discussion_r1641277014), the test claims to test underscores in assignment positions, but doesn't actually use an underscore there. This PR fixes this oversight.

Trivial, not reviewed.

## Testing
- [x] `test/errors/parsing/underscores.chpl` still passes