### PR TITLE
Work around bundled gmp build issue in Arkouda perf test

### DIFF
--- a/util/cron/test-perf.chapcs.arkouda.release.bash
+++ b/util/cron/test-perf.chapcs.arkouda.release.bash
@@ -15,6 +15,13 @@ if [ -n "$CHPL_WHICH_RELEASE_FOR_ARKOUDA" ]; then
   if [ "$CHPL_WHICH_RELEASE_FOR_ARKOUDA" = "2.0.0" ]; then
     # use LLVM 17, latest supported by 2.0.0
     if [ -f /data/cf/chapel/setup_system_llvm.bash ] ; then
+      # Hack to avoid build issues with GMP. Spack installed GMP is pulled in as
+      # a dependency of GDB. Then for some reason, it's (undesirably) linked
+      # against by the bundled GMP's self-tests, causing them to fail due to
+      # version mismatch. Avoid this by unloading GDB and therefore GMP.
+      # Anna 2024-06-17
+      module unload gdb
+
       source /data/cf/chapel/setup_system_llvm.bash 17
     fi
   else


### PR DESCRIPTION
Unload Spack-installed gdb (and transitively its dependency gmp) for Arkouda perf tests on chapcs, as its presence causes bundled GMP self-tests to link against the system GMP and encounter a version mismatch.

To resolve nightly issues from https://chapel.discourse.group/t/test-chapcs07-performance-test-perf-chapcs-arkouda-release/34288.

[reviewer info placeholder]

Testing:
- [x] manual run of `./util/cron/test-perf.chapcs.arkouda.release.bash` succeeds