### PR TITLE
Revert to default GASNET_SND_THREAD=0

### DIFF
--- a/runtime/src/comm/gasnet/comm-gasnet-ex.c
+++ b/runtime/src/comm/gasnet/comm-gasnet-ex.c
@@ -765,7 +765,9 @@ static void setup_polling_pre_init(void) {
 
   // By default we want a GASNet send progress thread. Note that we do
   // not override any existing value, so the user can disable it if desired.
-  chpl_env_set("GASNET_SND_THREAD", "1", 0 /*overwrite*/);
+  // Currently off by default because it was observed to reduce performance
+  // when running one locale-per-node on a multi-socket system without binding
+  chpl_env_set("GASNET_SND_THREAD", "0", 0 /*overwrite*/);
 
   // If there is a send thread give it exclusive access to the NIC. This
   // has no effect if there isn't a send thread.


### PR DESCRIPTION
This commit partially reverts the effects of 8ecfa22, by restoring the GASNet default of GASNET_SND_THREAD=0 which disables creation of the internal progress thread used to reap send completions.

Users still have the ability to enable the send thread by setting envvar GASNET_SND_THREAD=1 (confirmed through manual testing).

Example:
```
cascade11$ ./hello6-taskpar-dist -nl 2 -v -v -v
<redacted>/chapel/third-party/gasnet/install/linux64-x86_64-unknown-llvm-none/substrate-ibv/seg-large/bin/gasnetrun_ibv -n 2 -N 2 -c 0 -E LC_ALL,LANG,COBALT_JOBID,COBALT_NODEFILE,USER,LOGNAME,HOME,PATH,SHELL,TERM,SSH_AUTH_SOCK,XDG_SESSION_ID,XDG_RUNTIME_DIR,DBUS_SESSION_BUS_ADDRESS,XDG_SESSION_TYPE,XDG_SESSION_CLASS,SSH_CLIENT,SSH_CONNECTION,SSH_TTY,HOSTTYPE,VENDOR,OSTYPE,MACHTYPE,SHLVL,PWD,GROUP,HOST,CSHEDIT,MAIL,CPU,HOSTNAME,LESS,LESSCLOSE,LESS_ADVANCED_PREPROCESSOR,LESSKEY,PAGER,MORE,MINICOM,MANPATH,XKEYSYMDB,XNLSPATH,COLORTERM,SSH_SENDS_LOCALE,LIBGL_DEBUG,MODULES_SET_SHELL_STARTUP,MODULES_CMD,MODULESHOME,LOADEDMODULES,MODULEPATH,http_proxy,https_proxy,ftp_proxy,gopher_proxy,socks_proxy,SOCKS_PROXY,SOCKS5_SERVER,no_proxy,WINDOWMANAGER,XDG_DATA_DIRS,XDG_CONFIG_DIRS,G_BROKEN_FILENAMES,G_FILENAME_ENCODING,CSHRCREAD,GPG_TTY,MODULE_AVAIL,DISABLE_LIMIT,INTEL_SCRIPT,DAALROOT,CPATH,LIBRARY_PATH,LD_LIBRARY_PATH,CLASSPATH,NLSPATH,INFOPATH,INTEL_PYTHONHOME,TBBROOT,PSTLROOT,MKLROOT,PKG_CONFIG_PATH,IPPROOT,arch,I_MPI_ROOT,FI_PROVIDER_PATH,INTEL_LICENSE_FILE,GASNET_SSH_NODEFILE,MPIRUN_CMD,MPI_CC,USE_MACHTYPE,GASNET_OFI_SPAWNER,GASNET_PSM_SPAWNER,PSM2_MQ_RNDV_HFI_WINDOW,UPC_SHARED_HEAP_SIZE,UPC_PTHREADS_PER_PROC,GASNET_SPAWNFN,GASNET_BOOTSTRAP_CONFIRM,TI_SPAWNFN,TI_THREADS,SSH_SERVERS,LOGHOME,YPDOMAIN,PLATFORM,SHORTHOST,RELPATH,INITIAL_CWDCMD,SSH_STARTED,HOSTALIASES,LPDEST,PRINTER,MYVI,EDITOR,VISUAL,TMPDIR,RSYNC_RSH,LANGVAR,PRCS_REPOSITORY,PRCS_LOGQUERY,PRCS_DIFF_OPTIONS,TCBUILD_FLAGS_SUFFIX,TCBUILD_FLAGS,MYPWD,BIN_LS,CVSROOT,CVS_RSH,GCC_COLORS,SPACK_HOST,SPACK_USER_CONFIG_PATH,GASNET_PHYSMEM_MAX <redacted>/chapel/hello6-taskpar-dist_real -nl 2 -v -v -v
0: using core(s) 0-31
oversubscribed = False
QTHREADS: Using 32 Shepherds
QTHREADS: Using 1 Workers per Shepherd
QTHREADS: Guard Pages Enabled
QTHREADS: Using 8376320 byte stack size.
1: using core(s) 0-31
QTHREADS: Using 32 Shepherds
QTHREADS: Using 1 Workers per Shepherd
QTHREADS: Guard Pages Enabled
QTHREADS: Using 8376320 byte stack size.
executing locale 1 of 2 on node 'cascade12'
PSHM is disabled.
GASNet receive progress thread is enabled.
GASNet send progress thread is disabled.
executing locale 0 of 2 on node 'cascade11'
comm task bound to accessible PUs
Hello, world! (from locale 0 of 2 named cascade11)
Hello, world! (from locale 1 of 2 named cascade12)
```

The line `GASNet send progress thread is disabled.` confirms the setting has been applied as intended, also confirmed using `GASNET_VERBOSEENV=1`.