### PR TITLE
Resolve list init= future test

### DIFF
--- a/test/library/standard/List/initEquals/listInitEqualsArrayBug.future
+++ b/test/library/standard/List/initEquals/listInitEqualsArrayBug.future
@@ -1,1 +1,0 @@
-#24305: List of arrays with specified runtime type breaks at runtime

--- a/test/library/standard/List/initEquals/listInitEqualsArrayBug.skipif
+++ b/test/library/standard/List/initEquals/listInitEqualsArrayBug.skipif
@@ -1,2 +1,0 @@
-CHPL_COMM == none
-CHPL_TEST_VGRND_EXE == on


### PR DESCRIPTION
Promotes the future test `test/library/standard/List/initEquals/listInitEqualsArrayBug` to a full test, as it is no longer failing on main

This seems to have been resolved by #25278, although I don't fully understand why.

Resolves https://github.com/chapel-lang/chapel/issues/24305