### PR TITLE
reorder depends_on statements in brew formula per style guide

### DIFF
--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -16,13 +16,13 @@ class Chapel < Formula
     sha256 x86_64_linux:   "961ad1d420eeeac018098fba19f05ff207edcd279b8c98d5439838d9928f61de"
   end
 
+  depends_on "pkg-config" => :build
   depends_on "cmake"
   depends_on "gmp"
   depends_on "hwloc"
   depends_on "jemalloc"
   depends_on "llvm@17"
   depends_on "python@3.12"
-  depends_on "pkg-config" => :build
 
   # LLVM is built with gcc11 and we will fail on linux with gcc version 5.xx
   fails_with gcc: "5"


### PR DESCRIPTION
Fix the order of `depends_on` statements to put `"pkg-config" => :build` at the top of the dependency list. It seems `brew style` will fail if it finds this dependency anywhere else in the dependency list.

[reviewed by @jabraham17 - thanks!]