### PR TITLE
Switch test to only run with valgrind

### DIFF
--- a/test/library/standard/List/initEquals/listInitEqualsArrayBug.skipif
+++ b/test/library/standard/List/initEquals/listInitEqualsArrayBug.skipif
@@ -1,2 +1,1 @@
-CHPL_COMM == none
-CHPL_TEST_VGRND_EXE == on
+CHPL_TEST_VGRND_EXE != on


### PR DESCRIPTION
Switches `test/library/standard/List/initEquals/listInitEqualsArrayBug.chpl` to only run with valgrind, as this is the only config we can reliably assume it will fail in.

Tested that `start_test test/library/standard/List/initEquals/listInitEqualsArrayBug.chpl -respect-skipifs -valgrindexe` is a future and that `start_test test/library/standard/List/initEquals/listInitEqualsArrayBug.chpl -respect-skipifs` skips the test

[Not reviewed - will get a post-merge review]