### PR TITLE
Cherry-pick GASNet bug4723 fix : ssh-spawner failures with tcsh

### DIFF
--- a/third-party/gasnet/README
+++ b/third-party/gasnet/README
@@ -34,4 +34,4 @@ Chapel modifications to GASNet
 The modifications that we have made to the official GASNet release are
 as follows:
 
-* None
+* Cherry-picked 76c8a6a39 - Address bug 4723 in which ssh-spawner chokes tcsh

--- a/third-party/gasnet/gasnet-src/other/spawner/gasnetrun.pl
+++ b/third-party/gasnet/gasnet-src/other/spawner/gasnetrun.pl
@@ -192,6 +192,11 @@ sub fullpath($)
 # Implement -E for ssh, if required, as a wrapper (processed below)
     if (($spawner eq 'SSH') && defined $envlist) {
         foreach (split(',', $envlist)) {
+            # Screen both variable names and values for "bad" ones.
+            # See Bug 4723 for the motivation.
+            next if ($ENV{$_} =~ m/\n/); # skip value with newline(s), which we cannot portably quote
+            next unless ($_ =~ m/^[A-Za-z_][A-Za-z0-9_]*$/); # skip invalid variable name
+
             unshift @ARGV, "$_=$ENV{$_}";
         }
         unshift @ARGV, $ENV{'GASNET_ENVCMD'};


### PR DESCRIPTION
Cherry-pick [GASNet fix](https://bitbucket.org/berkeleylab/gasnet/commits/76c8a6a3904d10fe3e9a6d2f3442cf810d00c5a5) to [bug 4723](https://gasnet-bugs.lbl.gov/bugzilla/show_bug.cgi?id=4723), which resolves ssh-spawner failures when using tcsh.

Problem was reproduced on JLSE cascade, and fix confirmed using the patched Chapel build tree.

Demonstration:
```
ac.dbonachea@cascade12> echo $SHELL
/bin/tcsh
ac.dbonachea@cascade12> ps
  PID TTY          TIME CMD
 2715 pts/0    00:00:00 ps
35195 pts/0    00:00:00 tcsh
65107 pts/0    00:00:00 bash
ac.dbonachea@cascade12> env | grep -A30 BASH                
BASH_FUNC_module%%=() {  local _mlredir=0;
 if [ -n "${MODULES_REDIRECT_OUTPUT+x}" ]; then
 if [ "$MODULES_REDIRECT_OUTPUT" = '0' ]; then
 _mlredir=0;
 else
 if [ "$MODULES_REDIRECT_OUTPUT" = '1' ]; then
 _mlredir=1;
 fi;
 fi;
 fi;
 case " $@ " in 
 *' --no-redirect '*)
 _mlredir=0
 ;;
 *' --redirect '*)
 _mlredir=1
 ;;
 esac;
 if [ $_mlredir -eq 0 ]; then
 _module_raw "$@";
 else
 _module_raw "$@" 2>&1;
 fi
}
BASH_FUNC__module_raw%%=() {  eval "$(/usr/bin/tclsh /usr/lib64/Modules/modulecmd.tcl bash "$@")";
 _mlstatus=$?;
 return $_mlstatus
}
BASH_FUNC_mc%%=() {  . /usr/share/mc/mc-wrapper.sh
}
BASH_FUNC_ml%%=() {  module ml "$@"
}
_=/usr/bin/env
ac.dbonachea@cascade12> ./hello6-taskpar-dist -nl 2 -v -v -v
<redacted>/chapel/third-party/gasnet/install/linux64-x86_64-unknown-llvm-none/substrate-ibv/seg-large/bin/gasnetrun_ibv -n 2 -N 2 -c 0 -E SPACK_USER_CONFIG_PATH,LC_ALL,LD_LIBRARY_PATH,CSHRCREAD,HOSTTYPE,PRCS_DIFF_OPTIONS,SSH_CONNECTION,LESSCLOSE,XKEYSYMDB,MYPWD,LANG,WINDOWMANAGER,LESS,DISABLE_LIMIT,HOSTNAME,IPPROOT,USE_MACHTYPE,CSHEDIT,EDITOR,GPG_TTY,LESS_ADVANCED_PREPROCESSOR,GASNET_OFI_SPAWNER,COLORTERM,VENDOR,MACHTYPE,BIN_LS,CVSROOT,FI_PROVIDER_PATH,SSH_AUTH_SOCK,GASNET_SSH_NODEFILE,PRCS_LOGQUERY,MINICOM,TCBUILD_FLAGS,INTEL_PYTHONHOME,OSTYPE,CLASSPATH,XDG_SESSION_ID,MODULES_CMD,USER,MODULES_SET_SHELL_STARTUP,PAGER,MPI_CC,COBALT_JOBID,GASNET_BOOTSTRAP_CONFIRM,MORE,GROUP,PWD,TCBUILD_FLAGS_SUFFIX,INTEL_SCRIPT,SSH_STARTED,HOME,LPDEST,HOST,SSH_CLIENT,LANGVAR,SHORTHOST,XNLSPATH,CPATH,MODULE_AVAIL,XDG_SESSION_TYPE,https_proxy,LOGHOME,XDG_DATA_DIRS,http_proxy,NLSPATH,LIBGL_DEBUG,YPDOMAIN,COBALT_NODEFILE,__MODULES_LMALTNAME,PROFILEREAD,TMPDIR,SPACK_HOST,LIBRARY_PATH,UPC_PTHREADS_PER_PROC,LOADEDMODULES,DAALROOT,no_proxy,arch,INTEL_LICENSE_FILE,SSH_TTY,NO_PROXY,COLUMNS,MAIL,SOCKS_PROXY,RELPATH,HOSTALIASES,VISUAL,UPC_SHARED_HEAP_SIZE,LESSKEY,TERM,SHELL,XDG_SESSION_CLASS,PRCS_REPOSITORY,SSH_SERVERS,socks_proxy,PLATFORM,__MODULES_LMCONFLICT,TMOUT,SHLVL,G_FILENAME_ENCODING,PRINTER,GASNET_PSM_SPAWNER,GASNET_SPAWNFN,MANPATH,SOCKS5_SERVER,gopher_proxy,MODULEPATH,LOGNAME,DBUS_SESSION_BUS_ADDRESS,XDG_RUNTIME_DIR,MYVI,MKLROOT,PSTLROOT,TI_SPAWNFN,INITIAL_CWDCMD,XDG_CONFIG_DIRS,PATH,TBBROOT,_LMFILES_,GASNET_PHYSMEM_MAX,MODULESHOME,PKG_CONFIG_PATH,INFOPATH,RSYNC_RSH,G_BROKEN_FILENAMES,I_MPI_ROOT,MPIRUN_CMD,HISTSIZE,TI_THREADS,ftp_proxy,PSM2_MQ_RNDV_HFI_WINDOW,CPU,SSH_SENDS_LOCALE,GCC_COLORS,CVS_RSH,BASH_FUNC_module%%,BASH_FUNC__module_raw%%,BASH_FUNC_mc%%,BASH_FUNC_ml%%,_ <redacted>/chapel/hello6-taskpar-dist_real -nl 2 -v -v -v
0: using core(s) 0-31
oversubscribed = False
QTHREADS: Using 32 Shepherds
QTHREADS: Using 1 Workers per Shepherd
QTHREADS: Guard Pages Enabled
QTHREADS: Using 8376320 byte stack size.
1: using core(s) 0-31
QTHREADS: Using 32 Shepherds
QTHREADS: Using 1 Workers per Shepherd
QTHREADS: Guard Pages Enabled
QTHREADS: Using 8376320 byte stack size.
executing locale 1 of 2 on node 'cascade13'
PSHM is disabled.
GASNet receive progress thread is enabled.
GASNet send progress thread is disabled.
executing locale 0 of 2 on node 'cascade12'
comm task bound to accessible PUs
Hello, world! (from locale 0 of 2 named cascade12)
Hello, world! (from locale 1 of 2 named cascade13)
```