### PR TITLE
add ROCM_PATH/include as a system include path for AMD GPU

### DIFF
--- a/util/chplenv/compile_link_args_utils.py
+++ b/util/chplenv/compile_link_args_utils.py
@@ -70,6 +70,7 @@ def get_runtime_includes_and_defines():
 
         elif gpu_type == "amd":
             # -isystem instead of -I silences warnings from inside these includes.
+            system.append("-isystem" + os.path.join(sdk_path, "include"))
             system.append("-isystem" + os.path.join(sdk_path, "hip", "include"))
             system.append("-isystem" + os.path.join(sdk_path, "hsa", "include"))
 


### PR DESCRIPTION
A standard ROCm module installation has key headers under ROCM_PATH/include - so this should be added as a system include for AMD GPU compilation.