### PR TITLE
Require `setupModuleSearchPaths` be called before any other queries

### DIFF
--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -587,6 +587,9 @@ void setupModuleSearchPaths(
                   const std::vector<std::string>& prependStandardModulePaths,
                   const std::vector<std::string>& cmdLinePaths,
                   const std::vector<std::string>& inputFilenames) {
+  CHPL_ASSERT(
+      context->numQueriesRunThisRevision() == 0 &&
+      "setupModuleSearchPaths should be called before any queries are run");
 
   std::string modRoot;
   if (!minimalModules) {

--- a/frontend/test/resolution/testInteractive.cpp
+++ b/frontend/test/resolution/testInteractive.cpp
@@ -290,6 +290,7 @@ int main(int argc, char** argv) {
 
     // Run this query first to make the other output more understandable
     ctx->setDebugTraceFlag(false);
+    setupSearchPaths(ctx, enableStdLib, cmdLinePaths, files);
     typeForBuiltin(ctx, UniqueString::get(ctx, "int"));
     ctx->setDebugTraceFlag(trace);
     if (timing) ctx->beginQueryTimingTrace(timing);
@@ -297,8 +298,6 @@ int main(int argc, char** argv) {
     CompilerFlags flags;
     flags.set(CompilerFlags::WARN_UNSTABLE, warnUnstable);
     setCompilerFlags(ctx, std::move(flags));
-
-    setupSearchPaths(ctx, enableStdLib, cmdLinePaths, files);
 
     std::set<const ResolvedFunction*> calledFns;
 

--- a/tools/chplcheck/src/chplcheck.py
+++ b/tools/chplcheck/src/chplcheck.py
@@ -263,7 +263,7 @@ def main():
 
     printed_warning = False
 
-    for filename, context in chapel.files_with_contexts(args.filenames):
+    for filename, context in chapel.files_with_stdlib_contexts(args.filenames):
         context.set_module_paths([], [])
 
         # Silence errors, warnings etc. -- we're just linting.

--- a/tools/chplcheck/src/chplcheck.py
+++ b/tools/chplcheck/src/chplcheck.py
@@ -263,13 +263,8 @@ def main():
 
     printed_warning = False
 
-    prev_context = None
     for filename, context in chapel.files_with_contexts(args.filenames):
-        # Avoid re-setting module paths on already-used contexts, due to
-        # bucketing from files_with_contexts.
-        if context is not prev_context:
-            context.set_module_paths([], [])
-        prev_context = context
+        context.set_module_paths([], [])
 
         # Silence errors, warnings etc. -- we're just linting.
         with context.track_errors() as _:

--- a/tools/chplcheck/src/chplcheck.py
+++ b/tools/chplcheck/src/chplcheck.py
@@ -263,8 +263,13 @@ def main():
 
     printed_warning = False
 
+    prev_context = None
     for filename, context in chapel.files_with_contexts(args.filenames):
-        context.set_module_paths([], [])
+        # Avoid re-setting module paths on already-used contexts, due to
+        # bucketing from files_with_contexts.
+        if context is not prev_context:
+            context.set_module_paths([], [])
+        prev_context = context
 
         # Silence errors, warnings etc. -- we're just linting.
         with context.track_errors() as _:

--- a/tools/chplcheck/src/chplcheck.py
+++ b/tools/chplcheck/src/chplcheck.py
@@ -264,8 +264,6 @@ def main():
     printed_warning = False
 
     for filename, context in chapel.files_with_stdlib_contexts(args.filenames):
-        context.set_module_paths([], [])
-
         # Silence errors, warnings etc. -- we're just linting.
         with context.track_errors() as _:
             asts = context.parse(filename)


### PR DESCRIPTION
Require that setting the module search path occurs before any other queries in the Context revision, if at all. This is to prevent unexpected results from its default empty value being used before it is set, as many queries rely on it. Implemented as an assertion that it is the first query run in the revision.

Also change `testInteractive` to setup module search path earlier to be in line with this requirement. This fixes buggy behavior with `testInteractive --std`, in which we might not find standard module types, that was incidentally introduced in https://github.com/chapel-lang/chapel/pull/25190.

Depends on https://github.com/chapel-lang/chapel/pull/25326 which should be merged first.

[reviewer info placeholder]

Testing:
- [x] paratest
- [x] dyno tests
- [x] `testInteractive` with basic program
- [x] `chpl --dyno` with basic program