### PR TITLE
GASNet: disable GEX_FLAG_DEFER_THREADS by default

### DIFF
--- a/runtime/src/comm/gasnet/comm-gasnet-ex.c
+++ b/runtime/src/comm/gasnet/comm-gasnet-ex.c
@@ -56,7 +56,7 @@ static int reservedCore = -1;
 
 #define GEX_NO_FLAGS 0
 
-static chpl_bool defer_gasnet_progress_threads = 0;
+static chpl_bool defer_gasnet_progress_threads = false;
 
 static gasnet_seginfo_t* seginfo_table = NULL;
 static gex_Client_t      myclient;

--- a/runtime/src/comm/gasnet/comm-gasnet-ex.c
+++ b/runtime/src/comm/gasnet/comm-gasnet-ex.c
@@ -56,7 +56,7 @@ static int reservedCore = -1;
 
 #define GEX_NO_FLAGS 0
 
-static int defer_gasnet_progress_threads = 0;
+static chpl_bool defer_gasnet_progress_threads = 0;
 
 static gasnet_seginfo_t* seginfo_table = NULL;
 static gex_Client_t      myclient;
@@ -897,11 +897,12 @@ void chpl_comm_init(int *argc_p, char ***argv_p) {
 
   defer_gasnet_progress_threads = chpl_env_rt_get_bool("COMM_GASNET_DEFER_PROGRESS_THREADS", false);
 
+  gex_Flags_t flags = GEX_FLAG_USES_GASNET1 |
+                      (defer_gasnet_progress_threads ? GEX_FLAG_DEFER_THREADS : 0);
+
   GASNET_Safe(gex_Client_Init(&myclient, &myep, &myteam, "chapel",
                               argc_p, argv_p,
-                              GEX_FLAG_USES_GASNET1 |
-                              (defer_gasnet_progress_threads ?
-                               GEX_FLAG_DEFER_THREADS : 0)));
+                              flags));
 
   setup_polling_post_init();
   chpl_nodeID = gasnet_mynode();


### PR DESCRIPTION
This commit partially reverts the behavioral changes introduced in 8ecfa22, by making the use of `GEX_FLAG_DEFER_THREADS` at GASNet initialization time optional.  The optional behavior is controlled by a new environment variable
`CHPL_RT_COMM_GASNET_DEFER_PROGRESS_THREADS`, which defaults to False.

The net impact of this change is to restore the behavior prior to PR#25140 in which GASNet launches the ibv-conduit receive thread, while allowing the end-user to opt-in to the alternative behavior in which Chapel creates the thread.

As a side-effect of this change, by default ibv-conduit's internal receive thread is *not* impacted by the setting of `CHPL_RT_COMM_GASNET_DEDICATED_PROGRESS_CORE`, nor does GASNet do any pinning of this thread.