### PR TITLE
Fix CPU-fallback for GPU-based reduction functions

### DIFF
--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -641,6 +641,13 @@ void chpl_gpu_arg_pass(void* _cfg, void* arg) {
 
 void chpl_gpu_arg_reduce(void* _cfg, void* arg, size_t elem_size,
                          reduce_wrapper_fn_t wrapper) {
+#ifndef GPU_RUNTIME_CPU
+  if (!chpl_gpu_can_reduce()) {
+    chpl_internal_error("The runtime is built with a software stack that does "
+                        "not support reductions (e.g. ROCm 4.x). `reduce` "
+                        "expressions and intents are not supported");
+  }
+#endif
   kernel_cfg* cfg = (kernel_cfg*)_cfg;
   if (cfg_can_reduce(cfg)) {
     // pass the argument normally

--- a/test/gpu/native/reduction/basic.compopts
+++ b/test/gpu/native/reduction/basic.compopts
@@ -1,0 +1,2 @@
+-sgpuAlwaysFallBackToCpuReduce=false
+-sgpuAlwaysFallBackToCpuReduce=true


### PR DESCRIPTION
This PR fixes an issue reported by @milthorpe. https://github.com/chapel-lang/chapel/pull/25314 is the key part for solving his case, but the lack of it caused the CPU fall back on `gpu*Reduce` functions to fire. Which turns out is untested and faulty.

The root cause is `here.parent` on a GPU sublocale doesn't return a correctly-setup parent. It does look like a CPU locale, which is nice, but its sublocale is still the same as the GPU sublocale from which it was called. I started to track the issue down, but I don't have a good solution for it yet. I'll create an issue for it.

Until that's fixed, this PR avoids `here.parent` in the fallback logic and implements a low-level "on" statement.

While there, this also adds a flag to test the CPU fallback and modifies a test to use it.

While there. this also adds a runtime error for using `reduce` expressions and intents on unsupported software, e.g. ROCm 4. In the next release cycle, I hope to remove ROCm 4 support, the CPU fall back and all the logic that wires it up. For now, this is a band-aid to keep 2.1 working correctly.

Test:
- [x] nvidia
- [x] amd
- [x] cpu