### PR TITLE
Generate custom per-locale cleanup code to avoid memory leak in per-locale static variables

### DIFF
--- a/compiler/include/passes.h
+++ b/compiler/include/passes.h
@@ -107,6 +107,9 @@ void initForTaskIntents();
 void removeTiMarks();
 bool isTiMark(Symbol* sym);
 
+// callDestructors.cpp
+void ensureModuleDeinitFnAnchor(ModuleSymbol* mod, Expr*& anchor);
+
 // deadCodeElimination.cpp
 void deadBlockElimination();
 

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -358,6 +358,7 @@ static void preNormalizeHandleStaticVars() {
                                               wrapperVar, initVarTemp));
       wrapperBlock->insertAtTail(new CallExpr(PRIM_DEFAULT_INIT_VAR, wrapperVar, wrapperTypeTemp));
 
+      bool needsCleanup = false;
       if (call->numActuals() > 0) {
         // The actual specifies the sharing kind.
         auto sharingKind = toSymExpr(call->get(1));
@@ -376,10 +377,53 @@ static void preNormalizeHandleStaticVars() {
           // Do nothing, that's the default behavior.
         } else if (sharingKind->symbol()->name == astr("computePerLocale")) {
           wrapperVar->addFlag(FLAG_LOCALE_PRIVATE);
+          needsCleanup = true;
         } else {
           USR_FATAL(call, "invalid argument to @functionStatic attribute");
         }
       }
+
+      // If we're a per-locale variable, we'll need to clean it up
+      // on every locale, since LOCALE_PRIVATE does not do this for us.
+      // Build the cleanup function now, so that it's resolved
+      // as normal as part of the resolution process.
+      //
+      // { scopeless
+      //   proc cleanupStaticWrapper() {}
+      // }
+      // myStaticVar.reset();
+      // { scopeless
+      //   chpl__executeStaticWrapperCleanupEverywhere(cleanupStaticWrapper);
+      // }
+      //
+      // Don't put the reset call into the function body right away because
+      // at this time, myStaticVar is a non-global variable, so the function
+      // is capturing it. We use the function as an FCF argument to
+      // 'executeStaticWraperCleanup', and capturing FCFs do not work. The
+      // relocation of the reset call will happen after the static variable has
+      // been hoisted to the module level.
+      //
+      // The proc def is wrapped in a block because creating an FCF introduces
+      // a whole bunch of additional functions into the same scope as the
+      // original function, and we need an easy way to get a handle on all
+      // of that.
+      //
+      // The 'executeStaticWrapperCleanup' call is wrapped in a block for a
+      // similar reason, but the things we want to relocate are call temps etc.
+      if (needsCleanup) {
+        auto cleanupBlock = new BlockStmt(BLOCK_SCOPELESS);
+        auto cleanupFnBlock = new BlockStmt(BLOCK_SCOPELESS);
+        auto cleanupCallBlock = new BlockStmt(BLOCK_SCOPELESS);
+        auto cleanupFn = new FnSymbol("cleanupStaticWrapper");
+        cleanupFnBlock->insertAtTail(new DefExpr(cleanupFn));
+        cleanupBlock->insertAtTail(cleanupFnBlock);
+        cleanupBlock->insertAtTail(
+            new CallExpr(new CallExpr(".", wrapperVar, new_CStringSymbol("reset"))));
+        cleanupCallBlock->insertAtTail(new CallExpr("chpl__executeStaticWrapperCleanupEverywhere", cleanupFn));
+        cleanupBlock->insertAtTail(cleanupCallBlock);
+        wrapperBlock->insertAtTail(cleanupBlock);
+      }
+
 
       anchor->insertBefore(initVarBlock);
       anchor->insertBefore(wrapperBlock);

--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -972,7 +972,7 @@ void FixupDestructors::process(FnSymbol* fn) {
   }
 }
 
-static void ensureModuleDeinitFnAnchor(ModuleSymbol* mod, Expr*& anchor) {
+void ensureModuleDeinitFnAnchor(ModuleSymbol* mod, Expr*& anchor) {
   if (anchor)
     return;
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -11734,6 +11734,7 @@ static void postResolveLiftStaticVars() {
   forv_Vec(CallExpr, call, gCallExprs) {
     if (call->isPrimitive(PRIM_STATIC_FUNCTION_VAR_WRAPPER)) {
       if (!call->inTree()) continue;
+      auto targetMod = call->getModule();
 
       auto wrapperSym = toSymExpr(call->get(1))->symbol();
       auto initDummySym = toSymExpr(call->get(2))->symbol();
@@ -11746,14 +11747,54 @@ static void postResolveLiftStaticVars() {
       // Move the definition point of the wrapper into the module scope.
       // But first, keep a handle on the block to be able to move it later.
       auto wrapperBlock = toBlockStmt(wrapperSym->defPoint->parentExpr);
-      INT_ASSERT(wrapperBlock);
-      call->getModule()->block->insertAtHead(wrapperSym->defPoint->remove());
+      targetMod->block->insertAtHead(wrapperSym->defPoint->remove());
+
+      // If we created some cleanup code to run in the per-locale case,
+      // retrieve it now.
+      BlockStmt* cleanupBlock = nullptr;
+      if (wrapperSym->hasFlag(FLAG_LOCALE_PRIVATE)) {
+        cleanupBlock = toBlockStmt(wrapperBlock->body.tail->remove());
+        INT_ASSERT(wrapperBlock);
+      }
 
       // Now move the initialization code into the module init function.
       // The last statement is the 'return void', which we keep.
-      call->getModule()->initFn->body->insertAtHead(wrapperBlock->remove());
+      targetMod->initFn->body->insertAtHead(wrapperBlock->remove());
       wrapperBlock->flattenAndRemove();
       call->remove();
+
+      // In some cases, we need to do cleanup. See the comment
+      // in normalize.cpp's preNormalizeHandleStaticVars for the
+      // structure of the cleanup block.
+      if (!cleanupBlock) continue;
+      SET_LINENO(wrapperSym);
+
+      auto cleanupFnDefBlock = toBlockStmt(cleanupBlock->body.head->remove());
+      INT_ASSERT1(cleanupFnDefBlock);
+      auto cleanupCall = toBlockStmt(cleanupBlock->body.tail->remove());
+      INT_ASSERT(cleanupCall);
+
+      auto cleanupFnDef = toDefExpr(cleanupFnDefBlock->body.tail);
+      INT_ASSERT(cleanupFnDef);
+      auto cleanupFn = toFnSymbol(cleanupFnDef->sym);
+      INT_ASSERT(cleanupFn);
+
+      // Relocate the .reset() call into the function; it's no longer
+      // a captured variable, but a global one.
+      cleanupFn->body->insertAtHead(cleanupBlock);
+      cleanupBlock->flattenAndRemove();
+
+      // Relocate the definition of the cleanup function for the new
+      // global static wrapper into the same module where the variable
+      // itself lives.
+      targetMod->block->insertAtHead(cleanupFnDefBlock);
+      cleanupFnDefBlock->flattenAndRemove();
+
+      // Insert a call to the cleanup code in the module's deinit function.
+      Expr* deinitAnchor = nullptr;
+      ensureModuleDeinitFnAnchor(targetMod, deinitAnchor);
+      deinitAnchor->insertAfter(cleanupCall);
+      cleanupCall->flattenAndRemove();
     }
   }
 }

--- a/modules/internal/ChapelStaticVars.chpl
+++ b/modules/internal/ChapelStaticVars.chpl
@@ -21,6 +21,7 @@
 module ChapelStaticVars {
   use OwnedObject;
   use Atomics;
+  use ChapelLocale;
 
   pragma "sharing kind enum"
   enum sharingKind {
@@ -73,8 +74,17 @@ module ChapelStaticVars {
       var expected = 0;
       return this.inited.compareExchange(expected, 1);
     }
+
+    proc ref reset() do {
+      this.container = nil;
+    }
   }
 
   proc chpl__functionStaticVariableWrapperType(type valueType) type
     do return _staticWrapper(valueType);
+
+  proc chpl__executeStaticWrapperCleanupEverywhere(fn: proc(): void) {
+    for loc in Locales do on loc do fn();
+  }
+
 }


### PR DESCRIPTION
This PR fixes a memory leak in `test/variables/static/multilocale`. The reason for the memory leak is that variables that are made per-locale using the `FLAG_LOCALE_PRIVATE` do not have their destructors invoked on every locale. As a result, the container that I use to contain the value of the static variable is not deallocated.

This PR invokes a custom `.reset()` function on locale-private static variables, across all locales. It does so in lieu of implementing per-locale deallocation for all locale private variables, since that might have broader-reaching consequences and would likely be more complicated.

There are some challenges with invoking `.reset()` across all locales. The main challenge is that most ways to invoke the destructor from user code create wide references to the per-locale variable, causing it to be reset only on the original locale from which the call occurs. The "workaround" to this is to, instead of passing the per-locale wrapper as a reference to some method or function, refer to it as a global variable:

```Chapel
pragma "locale private"
var wrapper: ...;

proc cleanupWrapper() {
  wrapper.reset();
}
```

This does _not_ end up creating a wide reference, and thus invokes the reset method on the copy of `wrapper` corresponding to the locale on which the cleanup function is executed.

The next challenge is invoking this function across all locales; building a `coforall` loop is quite involved, and difficult to do late in compilation. As a workaround, I use `cleanupWrapper` as an FCF argument to a standard module cleanup function, which iterates over all locales and invokes the FCF.

```Chapel
  proc chpl__executeStaticWrapperCleanupEverywhere(fn: proc(): void) {
    for loc in Locales do on loc do fn();
  }
```

## Testing
- [x] no memory leaks in `test/variables/static
- [ ] paratest
- [ ] gasnet paratest