### PR TITLE
lock in error for use of _ in when clause

### DIFF
--- a/test/errors/parsing/underscores.1.good
+++ b/test/errors/parsing/underscores.1.good
@@ -16,7 +16,8 @@ underscores.chpl:16: error: Throwaway variable '_' is not allowed in this contex
 underscores.chpl:16: error: Throwaway variable '_' is not allowed in this context
 underscores.chpl:17: error: Throwaway variable '_' is not allowed in this context
 underscores.chpl:21: error: Throwaway variable '_' is not allowed in this context
-underscores.chpl:22: error: Throwaway variable '_' is not allowed in this context
-underscores.chpl:25: error: Throwaway variable '_' is not allowed in this context
-underscores.chpl:32: In function 'f':
-underscores.chpl:32: error: formals in a procedure definition must be named
+underscores.chpl:26: error: Throwaway variable '_' is not allowed in this context
+underscores.chpl:27: error: Throwaway variable '_' is not allowed in this context
+underscores.chpl:30: error: Throwaway variable '_' is not allowed in this context
+underscores.chpl:37: In function 'f':
+underscores.chpl:37: error: formals in a procedure definition must be named

--- a/test/errors/parsing/underscores.2.good
+++ b/test/errors/parsing/underscores.2.good
@@ -154,33 +154,42 @@
   Throwaway variable '_' is not allowed in this context.
   The throwaway variable is used here:
        |
-    21 | import this.A as _;
+    21 |  when (8, _) { writeln("Got 8"); }
+       |           ⎺
+       |
+  Throwaway variables are only allowed on the left-hand side of tuple unpacking, in function formal names, and when renaming the target of a 'use' statement.
+
+─── error in underscores.chpl:26 [InvalidThrowaway] ───
+  Throwaway variable '_' is not allowed in this context.
+  The throwaway variable is used here:
+       |
+    26 | import this.A as _;
        |                  ⎺
        |
   Throwaway variables are only allowed on the left-hand side of tuple unpacking, in function formal names, and when renaming the target of a 'use' statement.
 
-─── error in underscores.chpl:22 [InvalidThrowaway] ───
+─── error in underscores.chpl:27 [InvalidThrowaway] ───
   Throwaway variable '_' is not allowed in this context.
   The throwaway variable is used here:
        |
-    22 | import this.A.{dummy as _};
+    27 | import this.A.{dummy as _};
        |                         ⎺
        |
   Throwaway variables are only allowed on the left-hand side of tuple unpacking, in function formal names, and when renaming the target of a 'use' statement.
 
-─── error in underscores.chpl:25 [InvalidThrowaway] ───
+─── error in underscores.chpl:30 [InvalidThrowaway] ───
   Throwaway variable '_' is not allowed in this context.
   The throwaway variable is used here:
        |
-    25 | use A only dummy as _;
+    30 | use A only dummy as _;
        |                     ⎺
        |
   Throwaway variables are only allowed on the left-hand side of tuple unpacking, in function formal names, and when renaming the target of a 'use' statement.
 
-─── error in underscores.chpl:32 [ProcDefExplicitAnonFormal] ───
+─── error in underscores.chpl:37 [ProcDefExplicitAnonFormal] ───
   Formals in a procedure definition must be named
        |
-    32 | proc f(_: int) {}
+    37 | proc f(_: int) {}
        |        ⎺⎺⎺⎺⎺⎺⎺
        |
 

--- a/test/errors/parsing/underscores.chpl
+++ b/test/errors/parsing/underscores.chpl
@@ -16,6 +16,11 @@ foreach _ in 1..10 {}
 forall _ in 1..10 with (var _ = 42, + reduce _) {}
 coforall _ in 1..10 {}
 
+// can't capture into _ in a when
+select (8, 9) {
+ when (8, _) { writeln("Got 8"); }
+}
+
 // Imports can't rename to '_'
 module A { var dummy: int; }
 import this.A as _;


### PR DESCRIPTION
Lock in that a when clause with a tuple value can't use an underscore to ignore part of the match.

Resolves #24102 