### PR TITLE
Remove incorrect assert for missing comm threads

### DIFF
--- a/runtime/include/tasks/qthreads/chpl-tasks-impl-fns.h
+++ b/runtime/include/tasks/qthreads/chpl-tasks-impl-fns.h
@@ -92,6 +92,7 @@ static inline chpl_qthread_tls_t* chpl_qthread_get_tasklocal(void)
                qthread_get_tasklocal(sizeof(chpl_qthread_tls_t));
         if (tls == NULL) {
             pthread_t me = pthread_self();
+            // if not process or comm thread, ok to return NULL
             if (pthread_equal(me, chpl_qthread_process_pthread)) {
                 tls = &chpl_qthread_process_tls;
             } else {

--- a/runtime/include/tasks/qthreads/chpl-tasks-impl-fns.h
+++ b/runtime/include/tasks/qthreads/chpl-tasks-impl-fns.h
@@ -95,7 +95,6 @@ static inline chpl_qthread_tls_t* chpl_qthread_get_tasklocal(void)
             if (pthread_equal(me, chpl_qthread_process_pthread)) {
                 tls = &chpl_qthread_process_tls;
             } else {
-                assert(chpl_qthread_comm_pthreads != NULL);
                 for (int i = 0; i < chpl_qthread_comm_num_pthreads; i++) {
                     if (pthread_equal(me, chpl_qthread_comm_pthreads[i])) {
                         tls = &chpl_qthread_comm_task_tls[i];


### PR DESCRIPTION
Removes an incorrect assertion in `chpl_qthread_get_tasklocal`. 

This was added in #25140, but because `chpl_qthread_comm_pthreads` always had at least 1 thread this wasn't a problem. However, after #25317 it was now possible (and the default) to have 0 `chpl_qthread_comm_pthreads`.

Removing the assert is sufficient, as the loop itself will already check for `chpl_qthread_comm_num_pthreads` and prevent a null pointer dereference. And it is not an error for `pthread_t me` to not be the process thread or one of the comm threads.

This assert causes issues with out nightly tests, but should not affect users who compile without asserts (which is the default).

Testing
- Tested `start_test test/gpu/native` with gasnet and `CHPL_GPU=nvidia` with cuda 11

[Reviewed by @e-kayrakli]