### PR TITLE
Adjust the foreach technote for the recent changes in intents

### DIFF
--- a/doc/rst/technotes/foreach.rst
+++ b/doc/rst/technotes/foreach.rst
@@ -44,5 +44,5 @@ Status and Future Work
 - The current implementation does not make full use of vectorization hinting.
   We hope to expand the coverage especially to vectorize outer loops.
 
-- We intend to add ``with`` clauses to ``foreach`` loops to support
-  vector-lane-private variables.
+- ``foreach`` loops support ``with`` clauses. However, the behavior for vector-
+  or GPU-based execution for shadow variables may change in the future.


### PR DESCRIPTION
This PR makes a small adjustment in the `foreach` technote to mention that `with` clauses work but that their behavior may change in vector- or GPU-based executions.