### PR TITLE
Update memory requirements for building Chapel

### DIFF
--- a/doc/rst/usingchapel/QUICKSTART.rst
+++ b/doc/rst/usingchapel/QUICKSTART.rst
@@ -40,7 +40,7 @@ to :ref:`using-a-more-full-featured-chapel` below.
 
          cd chapel-2.0.0
 
-   c. Make sure you are doing the install on a machine with > 4GB of memory.
+   c. Make sure you are doing the install on a machine with > 2GB of memory.
 
    d. Set up your environment for Chapel's Quickstart mode.
       If you are using a shell other than ``bash`` or ``zsh``,

--- a/doc/rst/usingchapel/QUICKSTART.rst
+++ b/doc/rst/usingchapel/QUICKSTART.rst
@@ -40,9 +40,7 @@ to :ref:`using-a-more-full-featured-chapel` below.
 
          cd chapel-2.0.0
 
-   c. Make sure you are doing the install on a machine with > 2GB of memory.
-
-   d. Set up your environment for Chapel's Quickstart mode.
+   c. Set up your environment for Chapel's Quickstart mode.
       If you are using a shell other than ``bash`` or ``zsh``,
       see :ref:`quickstart-with-other-shells` below.
 
@@ -50,7 +48,7 @@ to :ref:`using-a-more-full-featured-chapel` below.
 
          source util/quickstart/setchplenv.bash
 
-   e. Use GNU make to build Chapel.  On some systems, you may have to
+   d. Use GNU make to build Chapel.  On some systems, you may have to
       use ``gmake`` if ``make`` is not a GNU version.
 
       .. code-block:: bash

--- a/doc/rst/usingchapel/building.rst
+++ b/doc/rst/usingchapel/building.rst
@@ -4,9 +4,6 @@
 Building Chapel
 ===============
 
-Before getting started, be sure you are building Chapel on a machine
-that has more than 4GB of memory.
-
 To build the Chapel compiler, set up your environment as described in
 :ref:`readme-chplenv`, cd to ``$CHPL_HOME`` (the root directory of
 your unpacked Chapel release), and run GNU make.  This will build the

--- a/doc/rst/usingchapel/prereqs.rst
+++ b/doc/rst/usingchapel/prereqs.rst
@@ -44,6 +44,14 @@ for using Chapel:
     use the bundled LLVM or disable LLVM support (see
     :ref:`readme-chplenv.CHPL_LLVM`).
 
+  * When using the LLVM installation bundled with Chapel
+    (``CHPL_LLVM=bundled``), make sure your machine has at least 4GB of memory
+    available before building Chapel. If you are using your system's LLVM
+    (``CHPL_LLVM=system``), Chapel can be built with at least 2GB of memory.
+    See :ref:`readme-chplenv.CHPL_LLVM` for more information about these
+    settings. Note that the memory requirements for building Chapel may vary
+    in other configurations or for parallel builds.
+
 In addition, several optional components have additional requirements:
 
   * Python 3.9 or newer is required if you want to use chpldoc, c2chapel,


### PR DESCRIPTION

Based on the conversation in #24411 we update the memory requirements for building Chapel as follows:

1. Quickstart config requires >2GB of memory
2. CHPL_LLVM=system requires >2GB of memory
3. CHPL_LLVM=bundled requires >4GB of memory
4. Makes clean that other configurations may vary in memory requirements