### PR TITLE
Remove NUMA locale model from the docs

### DIFF
--- a/doc/rst/users-guide/TODO
+++ b/doc/rst/users-guide/TODO
@@ -85,10 +85,3 @@ Second pass
 -----------
 * Replace 'layer' with something else for runtime options?  Or embrace
   layer?
-
-Future
-------
-* As numa locale model comes on line introduce hierarchical locales
-  into the locality section (currently, the localesInChapel.rst file
-  brushes them off).  And/or as we have better written material
-  describing hierarchical locales, point to that.

--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -415,8 +415,6 @@ CHPL_LOCALE_MODEL
         Value    Description
         ======== =============================================
         flat     top-level locales are not further subdivided
-        numa     top-level locales are further subdivided into
-                 sublocales, each one a NUMA domain
         gpu      enable gpu sublocales
         ======== =============================================
 
@@ -425,9 +423,6 @@ CHPL_LOCALE_MODEL
    To enable GPU support, the value must be set to ``gpu``. See :ref:`readme-gpu` for more information.
 
    .. warning:: GPU support is under active development and settings may change.
-
-   .. warning:: The NUMA locale model is deprecated and will be removed
-      in a future release.
 
 
 .. _readme-chplenv.CHPL_TASKS:


### PR DESCRIPTION
Since the `numa` locale model has been deprecated for a while, we should remove it from the docs.
There are other docs which mention numa domains using the `-nl NxLt` syntax, which still works and is unstable today so we keep those.

There are also other mentions of NUMA locale model in `rst/developer/chips/inactive/18.rst` but since it is inactive, I left it as is.