### PR TITLE
Add assert for non-null pointer inside loop

### DIFF
--- a/runtime/include/tasks/qthreads/chpl-tasks-impl-fns.h
+++ b/runtime/include/tasks/qthreads/chpl-tasks-impl-fns.h
@@ -97,6 +97,7 @@ static inline chpl_qthread_tls_t* chpl_qthread_get_tasklocal(void)
                 tls = &chpl_qthread_process_tls;
             } else {
                 for (int i = 0; i < chpl_qthread_comm_num_pthreads; i++) {
+                    assert(chpl_qthread_comm_pthreads != NULL);
                     if (pthread_equal(me, chpl_qthread_comm_pthreads[i])) {
                         tls = &chpl_qthread_comm_task_tls[i];
                         break;


### PR DESCRIPTION
Adds an assert for `chpl_qthread_comm_pthreads != NULL` inside a loop prior to dereferencing it.

This adds back the assertion removed in https://github.com/chapel-lang/chapel/pull/25325, but puts it into the correct location. This has no behavior or user-facing change, rather it just more direcrtly encodes the invariant that at this stage in the code `chpl_qthread_comm_pthreads` must have a value, implied by `chpl_qthread_comm_num_pthreads>0`.

I expect this have no testing change, but sanity checked with `start_test test/gpu/native` with GASNet+CUDA+IBV.

[Reviewed by @jhh67 and @bonachea]