### PR TITLE
Add support for building AmazonLinux2023 OS packages

### DIFF
--- a/util/packaging/common/test_package.py
+++ b/util/packaging/common/test_package.py
@@ -45,6 +45,7 @@ def infer_docker_os(package):
         "fc38": "fedora:38",
         "fc39": "fedora:39",
         "fc40": "fedora:40",
+        "amzn2023": "amazonlinux:2023",
         "ubuntu22": "ubuntu:22.04",
         "ubuntu24": "ubuntu:24.04",
         "debian11": "debian:bullseye",

--- a/util/packaging/rpm/amzn2023-gasnet-udp/Dockerfile.template
+++ b/util/packaging/rpm/amzn2023-gasnet-udp/Dockerfile.template
@@ -1,0 +1,25 @@
+FROM amazonlinux:2023 as build
+
+@@{ARGUMENTS}
+
+@@{INJECT_BEFORE_DEPS}
+
+RUN dnf upgrade -y && \
+    dnf install -y --allowerasing \
+      gcc gcc-c++ m4 perl python3 python3-devel bash make gawk git cmake \
+      which diffutils wget vim sudo \
+      llvm-devel clang clang-devel \
+      rpm-build rpm-devel rpmlint coreutils patch rpmdevtools chrpath
+
+@@{USER_CREATION}
+
+@@{GET_CHAPEL}
+
+@@{BUILD_DEFAULT}
+@@{BUILD_GASNET_UDP}
+
+@@{INSTALL}
+
+@@{PACKAGE_SETUP}
+
+@@{PACKAGE_BUILD}

--- a/util/packaging/rpm/amzn2023-gasnet-udp/spec.template
+++ b/util/packaging/rpm/amzn2023-gasnet-udp/spec.template
@@ -1,0 +1,49 @@
+Name: @@{BASENAME}
+Version: @@{CHAPEL_VERSION}
+Release: @@{PACKAGE_VERSION}%{?dist}
+ExclusiveArch: %{_arch}
+Summary: Chapel
+
+License: Apache-2.0
+Source0: chapel-%{version}.tar.gz
+
+Requires: bash perl git llvm-devel clang clang-devel python3 python3-devel make
+
+%description
+Chapel Programming Language
+
+%global debug_package %{nil}
+
+%prep
+%setup -q -n chapel-%{version}
+
+%build
+
+%install
+rm -rf %{buildroot}
+mkdir -p %{buildroot}/%{_prefix}
+mkdir -p %{buildroot}/%{_prefix}/bin
+mkdir -p %{buildroot}/%{_prefix}/lib
+mkdir -p %{buildroot}/%{_prefix}/share
+
+# Binaries
+cp %{_prefix}/bin/chpl %{buildroot}/%{_prefix}/bin/chpl
+cp %{_prefix}/bin/chpldoc %{buildroot}/%{_prefix}/bin/chpldoc
+cp %{_prefix}/bin/mason %{buildroot}/%{_prefix}/bin/mason
+cp %{_prefix}/bin/chplcheck %{buildroot}/%{_prefix}/bin/chplcheck
+cp %{_prefix}/bin/chpl-language-server %{buildroot}/%{_prefix}/bin/chpl-language-server
+# Libraries
+cp -r %{_prefix}/lib/chapel %{buildroot}/%{_prefix}/lib/chapel
+# CHPL_HOME
+cp -r %{_prefix}/share/chapel %{buildroot}/%{_prefix}/share/chapel
+
+%files
+%{_prefix}/bin/chpl
+%{_prefix}/bin/chpldoc
+%{_prefix}/bin/mason
+%{_prefix}/bin/chplcheck
+%{_prefix}/bin/chpl-language-server
+%{_prefix}/lib/chapel/*
+%{_prefix}/share/chapel/*
+
+%changelog

--- a/util/packaging/rpm/amzn2023-ofi-slurm/Dockerfile.template
+++ b/util/packaging/rpm/amzn2023-ofi-slurm/Dockerfile.template
@@ -1,0 +1,25 @@
+FROM amazonlinux:2023 as build
+
+@@{ARGUMENTS}
+
+@@{INJECT_BEFORE_DEPS}
+
+RUN dnf upgrade -y && \
+    dnf install -y --allowerasing \
+      gcc gcc-c++ m4 perl python3 python3-devel bash make gawk git cmake \
+      which diffutils wget vim sudo \
+      llvm-devel clang clang-devel \
+      rpm-build rpm-devel rpmlint coreutils patch rpmdevtools chrpath
+
+@@{USER_CREATION}
+
+@@{GET_CHAPEL}
+
+@@{BUILD_DEFAULT}
+@@{BUILD_OFI_SLURM}
+
+@@{INSTALL}
+
+@@{PACKAGE_SETUP}
+
+@@{PACKAGE_BUILD}

--- a/util/packaging/rpm/amzn2023-ofi-slurm/spec.template
+++ b/util/packaging/rpm/amzn2023-ofi-slurm/spec.template
@@ -1,0 +1,49 @@
+Name: @@{BASENAME}
+Version: @@{CHAPEL_VERSION}
+Release: @@{PACKAGE_VERSION}%{?dist}
+ExclusiveArch: %{_arch}
+Summary: Chapel
+
+License: Apache-2.0
+Source0: chapel-%{version}.tar.gz
+
+Requires: bash perl git llvm-devel clang clang-devel python3 python3-devel make pmix-devel slurm-devel
+
+%description
+Chapel Programming Language
+
+%global debug_package %{nil}
+
+%prep
+%setup -q -n chapel-%{version}
+
+%build
+
+%install
+rm -rf %{buildroot}
+mkdir -p %{buildroot}/%{_prefix}
+mkdir -p %{buildroot}/%{_prefix}/bin
+mkdir -p %{buildroot}/%{_prefix}/lib
+mkdir -p %{buildroot}/%{_prefix}/share
+
+# Binaries
+cp %{_prefix}/bin/chpl %{buildroot}/%{_prefix}/bin/chpl
+cp %{_prefix}/bin/chpldoc %{buildroot}/%{_prefix}/bin/chpldoc
+cp %{_prefix}/bin/mason %{buildroot}/%{_prefix}/bin/mason
+cp %{_prefix}/bin/chplcheck %{buildroot}/%{_prefix}/bin/chplcheck
+cp %{_prefix}/bin/chpl-language-server %{buildroot}/%{_prefix}/bin/chpl-language-server
+# Libraries
+cp -r %{_prefix}/lib/chapel %{buildroot}/%{_prefix}/lib/chapel
+# CHPL_HOME
+cp -r %{_prefix}/share/chapel %{buildroot}/%{_prefix}/share/chapel
+
+%files
+%{_prefix}/bin/chpl
+%{_prefix}/bin/chpldoc
+%{_prefix}/bin/mason
+%{_prefix}/bin/chplcheck
+%{_prefix}/bin/chpl-language-server
+%{_prefix}/lib/chapel/*
+%{_prefix}/share/chapel/*
+
+%changelog

--- a/util/packaging/rpm/amzn2023/Dockerfile.template
+++ b/util/packaging/rpm/amzn2023/Dockerfile.template
@@ -1,0 +1,24 @@
+FROM amazonlinux:2023 as build
+
+@@{ARGUMENTS}
+
+@@{INJECT_BEFORE_DEPS}
+
+RUN dnf upgrade -y && \
+    dnf install -y --allowerasing \
+      gcc gcc-c++ m4 perl python3 python3-devel bash make gawk git cmake \
+      which diffutils wget vim sudo \
+      llvm-devel clang clang-devel \
+      rpm-build rpm-devel rpmlint coreutils patch rpmdevtools chrpath
+
+@@{USER_CREATION}
+
+@@{GET_CHAPEL}
+
+@@{BUILD_DEFAULT}
+
+@@{INSTALL}
+
+@@{PACKAGE_SETUP}
+
+@@{PACKAGE_BUILD}

--- a/util/packaging/rpm/amzn2023/spec.template
+++ b/util/packaging/rpm/amzn2023/spec.template
@@ -1,0 +1,49 @@
+Name: @@{BASENAME}
+Version: @@{CHAPEL_VERSION}
+Release: @@{PACKAGE_VERSION}%{?dist}
+ExclusiveArch: %{_arch}
+Summary: Chapel
+
+License: Apache-2.0
+Source0: chapel-%{version}.tar.gz
+
+Requires: bash perl git llvm-devel clang clang-devel python3 python3-devel make
+
+%description
+Chapel Programming Language
+
+%global debug_package %{nil}
+
+%prep
+%setup -q -n chapel-%{version}
+
+%build
+
+%install
+rm -rf %{buildroot}
+mkdir -p %{buildroot}/%{_prefix}
+mkdir -p %{buildroot}/%{_prefix}/bin
+mkdir -p %{buildroot}/%{_prefix}/lib
+mkdir -p %{buildroot}/%{_prefix}/share
+
+# Binaries
+cp %{_prefix}/bin/chpl %{buildroot}/%{_prefix}/bin/chpl
+cp %{_prefix}/bin/chpldoc %{buildroot}/%{_prefix}/bin/chpldoc
+cp %{_prefix}/bin/mason %{buildroot}/%{_prefix}/bin/mason
+cp %{_prefix}/bin/chplcheck %{buildroot}/%{_prefix}/bin/chplcheck
+cp %{_prefix}/bin/chpl-language-server %{buildroot}/%{_prefix}/bin/chpl-language-server
+# Libraries
+cp -r %{_prefix}/lib/chapel %{buildroot}/%{_prefix}/lib/chapel
+# CHPL_HOME
+cp -r %{_prefix}/share/chapel %{buildroot}/%{_prefix}/share/chapel
+
+%files
+%{_prefix}/bin/chpl
+%{_prefix}/bin/chpldoc
+%{_prefix}/bin/mason
+%{_prefix}/bin/chplcheck
+%{_prefix}/bin/chpl-language-server
+%{_prefix}/lib/chapel/*
+%{_prefix}/share/chapel/*
+
+%changelog

--- a/util/packaging/rpm/common/fill_docker_template.py
+++ b/util/packaging/rpm/common/fill_docker_template.py
@@ -99,7 +99,7 @@ RUN python3 make_spec.py $BASENAME $CHAPEL_VERSION $PACKAGE_VERSION $OS_NAME $TA
 COPY --chown=user ./rpm/common/rpmlintrc /home/user/.rpmlintrc
 RUN rpmdev-setuptree && \\
     cp chapel-$CHAPEL_VERSION.tar.gz $(rpm --eval '%{_sourcedir}') && \\
-    ignore_unused=$([[ "$(rpm --eval '%{?dist}')" == ".el9" ]] && echo "" || echo "--ignore-unused-rpmlintrc") && \\
+    ignore_unused=$([[ "$(rpm --eval '%{fc#}')" == "1" ]] && echo "--ignore-unused-rpmlintrc") || echo "" && \\
     rpmlint $ignore_unused --file .rpmlintrc $BASENAME.spec && \\
     unset ignore_unused && \\
     spectool -g -R $BASENAME.spec

--- a/util/packaging/rpm/common/fill_docker_template.py
+++ b/util/packaging/rpm/common/fill_docker_template.py
@@ -99,7 +99,7 @@ RUN python3 make_spec.py $BASENAME $CHAPEL_VERSION $PACKAGE_VERSION $OS_NAME $TA
 COPY --chown=user ./rpm/common/rpmlintrc /home/user/.rpmlintrc
 RUN rpmdev-setuptree && \\
     cp chapel-$CHAPEL_VERSION.tar.gz $(rpm --eval '%{_sourcedir}') && \\
-    ignore_unused=$([[ "$(rpm --eval '%{fc#}')" == "1" ]] && echo "--ignore-unused-rpmlintrc") || echo "" && \\
+    ignore_unused=$([[ "$(rpm --eval '%{dist_name}')" == "Fedora Linux" ]] && echo "--ignore-unused-rpmlintrc") || echo "" && \\
     rpmlint $ignore_unused --file .rpmlintrc $BASENAME.spec && \\
     unset ignore_unused && \\
     spectool -g -R $BASENAME.spec

--- a/util/packaging/rpm/test/Dockerfile.template
+++ b/util/packaging/rpm/test/Dockerfile.template
@@ -4,7 +4,7 @@ FROM @@{OS_BASE_IMAGE}
 
 @@{TEST_ENV}
 
-RUN dnf upgrade -y && dnf install -y --allowerasing sudo vim which
+RUN dnf upgrade -y && dnf install -y --allowerasing sudo vim which shadow-utils
 
 @@{USER_CREATION}
 


### PR DESCRIPTION
Add new configs for AmazonLinux2023 for COMM=none, COMM=gasnet, COMM=ofi

Testing:
- [x] Tested `util/packaging/rpm/amzn2023`
- [x] Tested `util/packaging/rpm/amzn2023-gasnet-udp`
- [x] Tested `util/packaging/rpm/amzn2023-ofi-slurm`
- [x] Tested `util/packaging/rpm/el9`
- [x] Tested `util/packaging/rpm/fc40`

[Reviewed by @jhh67]