### PR TITLE
Update docs menu to reflect that 'main' is now 2.2 pre-release

### DIFF
--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -82,13 +82,13 @@ master_doc = 'index'
 # 'version' adds a redundant version number onto the top of the sidebar
 # automatically (rtd-theme). We also don't use |version| anywhere in rst
 
-chplversion = '2.1'                  # TODO -- parse from `chpl --version`
+chplversion = '2.2'                  # TODO -- parse from `chpl --version`
 shortversion = chplversion.replace('-', '&#8209') # prevent line-break at hyphen, if any
 html_context = {"chplversion":chplversion}
 
 # The full version, including alpha/beta/rc tags.
-#release = '2.1.0 (pre-release)'
-release = '2.1.0'
+release = '2.2.0 (pre-release)'
+#release = '2.2.0'
 
 # General information about the project.
 project = u'Chapel Documentation'

--- a/doc/util/versionButton.php
+++ b/doc/util/versionButton.php
@@ -89,7 +89,7 @@ if (pagePath == "") {
 function dropSetup() {
   var currentRelease = "2.0"; // what does the public have?
   var stagedRelease = "2.1";  // is there a release staged but not yet public?
-  var nextRelease = "2.1";    // what's the next release? (on docs/main)
+  var nextRelease = "2.2";    // what's the next release? (on docs/main)
   var button = document.getElementById("versionButton");
   // Uses unicode down-pointing triangle
   var arrow = " &#9660;";


### PR DESCRIPTION
This is the standard update we make after cutting the release branch and releasing the new version.
