### PR TITLE
Extend Standard Module Style Guide

### DIFF
--- a/doc/rst/developer/bestPractices/StandardModuleStyle.rst
+++ b/doc/rst/developer/bestPractices/StandardModuleStyle.rst
@@ -135,10 +135,34 @@ Accessor methods will avoid using "get" in their name.  E.g., instead of
 
 Methods that are not accessors are still allowed to use "get" in their name.
 
+Formals
++++++++
+
+Formal names should be camelCase.  Descriptive names are recommended, within
+reason.  Encoding the type name into a formal name is generally avoided when
+multiple types are supported, as doing so makes it harder to support generic
+functions.
+
+Some commonly used names are:
+
+- idx for an index
+
+- x and y for general pairs of formals
+
+- src and dst/dest (source and destination) for directional pairs of formals
+
+  - lhs and rhs (left hand side and right hand side) may also be used
+
+- eltType for the type of elements stored in a collection (also used as a field
+  name)
+
+- obj for a general object instance (as opposed to formals that can also be
+  primitive types)
+
 Other Identifiers
 -----------------
 
-Variables, fields, and argument names should be camelCase or PascalCase.
+Variables and fields should be camelCase or PascalCase.
 
 Handling Failure
 ----------------

--- a/doc/rst/developer/bestPractices/StandardModuleStyle.rst
+++ b/doc/rst/developer/bestPractices/StandardModuleStyle.rst
@@ -139,3 +139,22 @@ Other Identifiers
 -----------------
 
 Variables, fields, and argument names should be camelCase or PascalCase.
+
+Handling Failure
+----------------
+
+In general, when code in a library encounters erroneous behavior, an appropriate
+Error should be thrown.  This will enable users of the library to potentially
+recover from the bad behavior without having to restart their program.
+
+There are some known exceptions to this recommendation:
+
+- When division by zero is encountered, libraries will halt (unless the check
+  for division by zero has been disabled, see the flag's
+  :ref:`man page entry <man-div-by-zero-checks>`).
+- When accesses are made outside of the known bounds of a container type,
+  libraries will halt (unless bounds checking has been disabled, see the flag's
+  :ref:`man page entry <man-bounds-checks>`).
+- Other checks controlled by flags that are listed when running ``chpl -h``.
+- When the program runs out of memory and the function in question does not
+  already throw other types of errors, the library will halt.

--- a/doc/rst/developer/bestPractices/StandardModuleStyle.rst
+++ b/doc/rst/developer/bestPractices/StandardModuleStyle.rst
@@ -179,9 +179,12 @@ There are some known exceptions to this recommendation:
 - When division by zero is encountered, libraries will halt (unless the check
   for division by zero has been disabled, see the flag's
   :ref:`man page entry <man-div-by-zero-checks>`).
+
 - When accesses are made outside of the known bounds of a container type,
   libraries will halt (unless bounds checking has been disabled, see the flag's
   :ref:`man page entry <man-bounds-checks>`).
+
 - Other checks controlled by flags that are listed when running ``chpl -h``.
+
 - When the program runs out of memory and the function in question does not
   already throw other types of errors, the library will halt.

--- a/doc/rst/developer/bestPractices/StandardModuleStyle.rst
+++ b/doc/rst/developer/bestPractices/StandardModuleStyle.rst
@@ -145,18 +145,19 @@ functions.
 
 Some commonly used names are:
 
-- idx for an index
+- ``idx`` for an index
 
-- x and y for general pairs of formals
+- ``x`` and ``y`` for general pairs of formals
 
-- src and dst/dest (source and destination) for directional pairs of formals
+- ``src`` and ``dst``/``dest`` (source and destination) for directional pairs of
+  formals
 
-  - lhs and rhs (left hand side and right hand side) may also be used
+  - ``lhs`` and ``rhs`` (left hand side and right hand side) may also be used
 
-- eltType for the type of elements stored in a collection (also used as a field
-  name)
+- ``eltType`` for the type of elements stored in a collection (also used as a
+  field name)
 
-- obj for a general object instance (as opposed to formals that can also be
+- ``obj`` for a general object instance (as opposed to formals that can also be
   primitive types)
 
 Other Identifiers
@@ -168,8 +169,10 @@ Handling Failure
 ----------------
 
 In general, when code in a library encounters erroneous behavior, an appropriate
-Error should be thrown.  This will enable users of the library to potentially
-recover from the bad behavior without having to restart their program.
+Error should be thrown (see the :ref:`spec description <Chapter-Error_Handling>`
+for error handling in general and :mod:`Errors` for a list of some potential
+errors to throw).  This will enable users of the library to potentially recover
+from the bad behavior without having to restart their program.
 
 There are some known exceptions to this recommendation:
 

--- a/doc/rst/developer/bestPractices/StandardModuleStyle.rst
+++ b/doc/rst/developer/bestPractices/StandardModuleStyle.rst
@@ -169,10 +169,10 @@ Handling Failure
 ----------------
 
 In general, when code in a library encounters erroneous behavior, an appropriate
-Error should be thrown (see the :ref:`spec description <Chapter-Error_Handling>`
-for error handling in general and :mod:`Errors` for a list of some potential
-errors to throw).  This will enable users of the library to potentially recover
-from the bad behavior without having to restart their program.
+:class:`~Errors.Error` should be thrown (see the :ref:`spec description
+<Chapter-Error_Handling>` for error handling in general).  This will enable
+users of the library to potentially recover from the bad behavior without having
+to restart their program.
 
 There are some known exceptions to this recommendation:
 

--- a/doc/rst/developer/bestPractices/StandardModuleStyle.rst
+++ b/doc/rst/developer/bestPractices/StandardModuleStyle.rst
@@ -87,6 +87,11 @@ Many paren-ful methods take some notable action. Try to make these
 methods method names be a verb. In particular, a method that modifies an
 argument in-place should be a verb.
 
+When possible, functions and methods that return should declare their return
+type explicitly.  When not possible, such functions and methods should use the
+``:returns:`` documentation field (as described in
+:ref:`chpldoc-arg-return-yield-types`).
+
 Factory Functions and Methods
 +++++++++++++++++++++++++++++
 

--- a/doc/rst/tools/chpldoc/chpldoc.rst
+++ b/doc/rst/tools/chpldoc/chpldoc.rst
@@ -100,6 +100,7 @@ looking output. For example:
    module Buffers {
      ...
 
+.. _chpldoc-arg-return-yield-types:
 
 Argument and return/yield types
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Resolves #25122 

Add more information about the following decisions made during the 2.0 stabilization process, so that future module stabilization can rely on the document:

- documenting/declaring return types for functions
- when to use error handling versus halting
- formal names

Verified the built docs looked okay and that I could follow all the links