### PR TITLE
Dyno: Fix confusing errors when incorrectly setting fields before 'init' calls

### DIFF
--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -3528,6 +3528,19 @@ void Resolver::prepareCallInfoActuals(const Call* call,
                            /* actualAsts */ nullptr);
 }
 
+static const Type* getGenericType(Context* context, const Type* recv) {
+  const Type* gen = nullptr;
+  if (auto cur = recv->toCompositeType()) {
+    gen = cur->instantiatedFromCompositeType();
+    if (gen == nullptr) gen = cur;
+  } else if (auto cur = recv->toClassType()) {
+    auto m = getGenericType(context, cur->manageableType());
+    gen = ClassType::get(context, m->toManageableType(),
+                         cur->manager(), cur->decorator());
+  }
+  return gen;
+}
+
 void Resolver::handleCallExpr(const uast::Call* call) {
   if (scopeResolveOnly) {
     return;
@@ -3635,7 +3648,25 @@ void Resolver::handleCallExpr(const uast::Call* call) {
   }
 
   if (!skip) {
-    auto receiverType = methodReceiverType();
+    QualifiedType receiverType = methodReceiverType();
+
+    // Calling initializer without qualifier, e.g., `init(a, b, c);``
+    //
+    // If the user has mistakenly instantiated a field of the type before
+    // calling ``init``, then the receiver type will either be fully or
+    // partially instantiated. This will cause a failure to resolve the
+    // ``init`` call, and result in a confusing and unhelpful error message.
+    //
+    // Instead, whenever we see this kind of 'init' call, we will set the
+    // receiver type to be fully-generic as if the user had not instantiated
+    // any fields. This matches the behavior when calling ``this.init(...)``,
+    // where ``this`` is treated as fully-generic.
+    if (initResolver &&
+        ci.name() == USTR("init") && ci.isMethodCall() == false) {
+      auto gen = getGenericType(context, receiverType.type());
+      receiverType = QualifiedType(QualifiedType::INIT_RECEIVER, gen);
+    }
+
     CallResolutionResult c
       = resolveCallInMethod(context, call, ci, inScopes, receiverType);
 

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -4305,7 +4305,9 @@ CallResolutionResult resolveFnCall(Context* context,
     CHPL_ASSERT(isTfsForInitializer(candidateFn));
 
     // TODO: Can we move this into the 'InitVisitor'?
-    if (!candidateFn->untyped()->isCompilerGenerated()) {
+    // Note: resolveInitializer is already called during instantiation
+    if (!candidateFn->untyped()->isCompilerGenerated() &&
+        candidateFn->instantiatedFrom() == nullptr) {
       std::ignore = resolveInitializer(context, candidateFn, inScopes.poiScope());
     }
   }

--- a/frontend/test/resolution/testInitSemantics.cpp
+++ b/frontend/test/resolution/testInitSemantics.cpp
@@ -802,7 +802,7 @@ static std::vector<std::string> getVersionsWithTypes(const std::string& prog,
 static std::vector<std::string> getAllVersions(const std::string& prog) {
   // Note, const checker currently balks at non-'this' calls to 'init'.
   std::vector<std::string> initProgs =
-    getVersionsWithTypes(prog, "INIT", { "this.init" });
+    getVersionsWithTypes(prog, "INIT", { "this.init", "init" });
 
   std::vector<std::string> allProgs;
   for (auto initProg : initProgs) {

--- a/frontend/test/resolution/testInitSemantics.cpp
+++ b/frontend/test/resolution/testInitSemantics.cpp
@@ -1120,7 +1120,7 @@ static void testAssignThenInit(void) {
     //  https://github.com/chapel-lang/chapel/issues/24900
     //
     // The errors are currently issued twice.
-    assert(guard.realizeErrors() == 2);
+    assert(guard.realizeErrors() == 1);
   }
 }
 


### PR DESCRIPTION
This PR updates the frontend to improve the error messages for the case in which we initialize a generic type field before calling ``init`` (without ``this``). For example:

```chpl
record pair {
  type fst;
  type snd;

  proc init(type fst, type snd) {
    this.fst = fst;
    this.snd = snd;
  }

  proc init(type both) {
    this.fst = both; // error!
    init(both, both); // also error!?
  }
}

var x = new pair(int);
```

Prior to this PR the user would encounter potentially-confusing error messages claiming that the ``init`` call could not be resolved. This resolution failure was caused by the the initialization of ``fst``, which in turn partially instantiated ``this``. When resolving the ``init`` call we rejected the partially instantiated ``this`` because initializers can only take concrete or fully generic receivers. The ``this.init`` case does not encounter this problem due to the way we happen to resolve the type of ``this`` early on, and do not update it until after initialization is complete.

The solution is to manually set a generic receiver type in the case that we call ``init`` instead of ``this.init``.

Testing:
- [x] test-dyno
- [x] local paratest