### PR TITLE
Single-locale Zarr IO + single chunk updates

### DIFF
--- a/modules/packages/Zarr.chpl
+++ b/modules/packages/Zarr.chpl
@@ -543,9 +543,11 @@ module Zarr {
   }
 
   /* 
-    Updates a single chunk within a Zarr store with the data in `A`. It is assumed that the Zarr store and the associated metadata file already exists.
+    Updates a single chunk within a Zarr store with the data in `A`. The
+    Zarr store and the associated metadata file must already exist.
 
-    :arg directoryPath: Relative or absolute path to the root of the zarr store. This directory should exist and contain a '.zarray' metadata file.
+    :arg directoryPath: Relative or absolute path to the root of the zarr
+      store. This directory should exist and contain a '.zarray' metadata file.
 
     :arg A: The array to update the chunk with.
 

--- a/modules/packages/Zarr.chpl
+++ b/modules/packages/Zarr.chpl
@@ -480,12 +480,11 @@ module Zarr {
     return A;
   }
 
-  
   /*
     Writes an array to storage as a v2.0 zarr store using a single locale. The
     array metadata and chunks will be stored within the `directoryPath`
     directory, which is created if it does not yet exist. The chunks will
-    have the dimensions given in the`chunkShape` argument. 
+    have the dimensions given in the`chunkShape` argument.
 
     :arg directoryPath: Relative or absolute path to the root of the zarr store.
       The directory and all necessary parent directories will be created if it
@@ -542,7 +541,7 @@ module Zarr {
     blosc_destroy();
   }
 
-  /* 
+  /*
     Updates a single chunk within a Zarr store with the data in `A`. The
     Zarr store and the associated metadata file must already exist.
 

--- a/modules/packages/Zarr.chpl
+++ b/modules/packages/Zarr.chpl
@@ -579,7 +579,7 @@ module Zarr {
     blosc_destroy();
   }
 
-  proc updateZarrChunk(directoryPath: string, ref A: [?domainType] ?dtype, chunkIndex: int, bloscThreads=1) throws {
+  proc updateZarrChunk(directoryPath: string, ref A: [?domainType] ?dtype, chunkIndex: int, bloscThreads: int(32) = 1) throws {
     updateZarrChunk(directoryPath, A, (chunkIndex,), bloscThreads);
   }
 }

--- a/test/library/packages/Zarr/CLEANFILES
+++ b/test/library/packages/Zarr/CLEANFILES
@@ -4,3 +4,4 @@ ReindexStore
 Test1D
 Test2D
 Test3D
+LocalIOStore_*


### PR DESCRIPTION
This PR adds support for single-locale reading/writing of Zarr stores, which was a user request. It also adds an `updateZarrChunk` method to allow for writing individual chunks to storage rather than writing the whole array. This is in anticipation of adding more support for partial IO on Zarr stores. 

Testing: CHPL_COMM={none,gasnet} x machines={mac, horizon}

Reviewed by: 