### PR TITLE
Silence docker FromAsCasing warning

### DIFF
--- a/util/packaging/apt/common/fill_docker_template.py
+++ b/util/packaging/apt/common/fill_docker_template.py
@@ -108,10 +108,10 @@ substitutions[
 WORKDIR /home/user
 RUN dpkg-deb --build $(python3 package_name.py $BASENAME $CHAPEL_VERSION $PACKAGE_VERSION $OS_NAME $TARGETARCH)
 
-FROM scratch as artifact
+FROM scratch AS artifact
 COPY --from=build /home/user/*.deb /
 
-FROM build as release
+FROM build AS release
 """
 
 

--- a/util/packaging/apt/debian11/Dockerfile.template
+++ b/util/packaging/apt/debian11/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM debian:bullseye as build
+FROM debian:bullseye AS build
 
 @@{ARGUMENTS}
 

--- a/util/packaging/apt/debian12-gasnet-udp/Dockerfile.template
+++ b/util/packaging/apt/debian12-gasnet-udp/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM debian:bookworm as build
+FROM debian:bookworm AS build
 
 @@{ARGUMENTS}
 

--- a/util/packaging/apt/debian12/Dockerfile.template
+++ b/util/packaging/apt/debian12/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM debian:bookworm as build
+FROM debian:bookworm AS build
 
 @@{ARGUMENTS}
 

--- a/util/packaging/apt/ubuntu20/Dockerfile.template
+++ b/util/packaging/apt/ubuntu20/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 as build
+FROM ubuntu:20.04 AS build
 
 @@{ARGUMENTS}
 ARG DEBIAN_FRONTEND=noninteractive

--- a/util/packaging/apt/ubuntu22-gasnet-udp/Dockerfile.template
+++ b/util/packaging/apt/ubuntu22-gasnet-udp/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 as build
+FROM ubuntu:22.04 AS build
 
 @@{ARGUMENTS}
 ARG DEBIAN_FRONTEND=noninteractive

--- a/util/packaging/apt/ubuntu22-ofi-slurm/Dockerfile.template
+++ b/util/packaging/apt/ubuntu22-ofi-slurm/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 as build
+FROM ubuntu:22.04 AS build
 
 @@{ARGUMENTS}
 ARG DEBIAN_FRONTEND=noninteractive

--- a/util/packaging/apt/ubuntu22/Dockerfile.template
+++ b/util/packaging/apt/ubuntu22/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 as build
+FROM ubuntu:22.04 AS build
 
 @@{ARGUMENTS}
 ARG DEBIAN_FRONTEND=noninteractive

--- a/util/packaging/apt/ubuntu24/Dockerfile.template
+++ b/util/packaging/apt/ubuntu24/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04 as build
+FROM ubuntu:24.04 AS build
 
 @@{ARGUMENTS}
 ARG DEBIAN_FRONTEND=noninteractive

--- a/util/packaging/rpm/common/fill_docker_template.py
+++ b/util/packaging/rpm/common/fill_docker_template.py
@@ -123,10 +123,10 @@ substitutions[
 RUN rpmbuild -ba $BASENAME.spec && \\
     cp $(rpm --eval '%{_rpmdir}')/$(rpm --eval '%{_arch}')/*.rpm .
 
-FROM scratch as artifact
+FROM scratch AS artifact
 COPY --from=build /home/user/*.rpm /
 
-FROM build as release
+FROM build AS release
 """
 
 

--- a/util/packaging/rpm/el9-gasnet-udp/Dockerfile.template
+++ b/util/packaging/rpm/el9-gasnet-udp/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM rockylinux/rockylinux:9 as build
+FROM rockylinux/rockylinux:9 AS build
 
 @@{ARGUMENTS}
 

--- a/util/packaging/rpm/el9-ofi-slurm/Dockerfile.template
+++ b/util/packaging/rpm/el9-ofi-slurm/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM rockylinux/rockylinux:9 as build
+FROM rockylinux/rockylinux:9 AS build
 
 @@{ARGUMENTS}
 

--- a/util/packaging/rpm/el9/Dockerfile.template
+++ b/util/packaging/rpm/el9/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM rockylinux/rockylinux:9 as build
+FROM rockylinux/rockylinux:9 AS build
 
 @@{ARGUMENTS}
 

--- a/util/packaging/rpm/fc37/Dockerfile.template
+++ b/util/packaging/rpm/fc37/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM fedora:37 as build
+FROM fedora:37 AS build
 
 @@{ARGUMENTS}
 

--- a/util/packaging/rpm/fc38/Dockerfile.template
+++ b/util/packaging/rpm/fc38/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM fedora:38 as build
+FROM fedora:38 AS build
 
 @@{ARGUMENTS}
 

--- a/util/packaging/rpm/fc39/Dockerfile.template
+++ b/util/packaging/rpm/fc39/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM fedora:39 as build
+FROM fedora:39 AS build
 
 @@{ARGUMENTS}
 

--- a/util/packaging/rpm/fc40/Dockerfile.template
+++ b/util/packaging/rpm/fc40/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM fedora:40 as build
+FROM fedora:40 AS build
 
 @@{ARGUMENTS}
 


### PR DESCRIPTION
Fixes warnings from `docker build` about mismatched casing on `FROM` and `as`.

[Reviewed by @jhh67]

