### PR TITLE
Update fedora 40 package dependencies

### DIFF
--- a/util/packaging/rpm/fc40/Dockerfile.template
+++ b/util/packaging/rpm/fc40/Dockerfile.template
@@ -8,7 +8,7 @@ RUN dnf upgrade -y && \
     dnf install -y \
       gcc gcc-c++ m4 perl python3 python3-devel bash make gawk git cmake \
       which diffutils wget vim \
-      llvm17-devel clang17 clang17-devel \
+      llvm-devel clang clang-devel \
       rpm-build rpm-devel rpmlint coreutils patch rpmdevtools chrpath
 
 @@{USER_CREATION}

--- a/util/packaging/rpm/fc40/spec.template
+++ b/util/packaging/rpm/fc40/spec.template
@@ -7,7 +7,7 @@ Summary: Chapel
 License: Apache-2.0
 Source0: chapel-%{version}.tar.gz
 
-Requires: bash perl git llvm17-devel clang17 clang17-devel python3 python3-devel make
+Requires: bash perl git llvm-devel clang clang-devel python3 python3-devel make
 
 %description
 Chapel Programming Language


### PR DESCRIPTION
Update the dependencies for fedora 40 to not require LLVM 17, they can now use LLVM 18

[Reviewed by @jhh67]