### PR TITLE
Reduce overhead in BaseAST::typeInfo()

### DIFF
--- a/compiler/AST/baseAST.cpp
+++ b/compiler/AST/baseAST.cpp
@@ -411,11 +411,6 @@ ModuleSymbol* BaseAST::getModule() {
   return retval;
 }
 
-Type* BaseAST::typeInfo() {
-  QualifiedType qt = this->qualType();
-  return qt.type();
-}
-
 bool BaseAST::isRef() {
   return this->qualType().isRef();
 }

--- a/compiler/include/baseAST.h
+++ b/compiler/include/baseAST.h
@@ -251,6 +251,7 @@ public:
   virtual GenRet    codegen()                                          = 0;
   virtual bool      inTree()                                           = 0;
   virtual QualifiedType qualType()                                     = 0;
+  virtual Type*     typeInfo()                                         = 0;
   virtual void      verify()                                           = 0;
   virtual void      accept(AstVisitor* visitor)                        = 0;
 
@@ -258,7 +259,6 @@ public:
   int               linenum()                                    const;
   const char*       stringLoc()                                  const;
 
-  Type*             typeInfo(); // note: calls qualType
   bool              isRef();
   bool              isWideRef();
   bool              isRefOrWideRef();

--- a/compiler/include/expr-class-def.h
+++ b/compiler/include/expr-class-def.h
@@ -30,6 +30,7 @@ public:
           bool    inTree()                                        override;
   virtual bool    isStmt()                                           const;
           QualifiedType qualType()                                override;
+          Type*   typeInfo()                                      override;
           void    verify()                                        override;
 
   void verify(AstTag expectedTag); // ensure tag is as expected, then verify()

--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -270,6 +270,11 @@ inline bool Expr::inTree() {
   return parentSymbol != nullptr;
 }
 
+inline Type* Expr::typeInfo() {
+  QualifiedType qt = this->qualType();
+  return qt.type();
+}
+
 // Determines whether a node is in the AST (vs. has been removed
 // from the AST). Used e.g. by cleanAst().
 //

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -89,6 +89,7 @@ public:
   GenRet         codegen()   override;
   bool           inTree()    override;
   QualifiedType  qualType()  override;
+  Type*          typeInfo()  override { return type; }
   void           verify()    override;
 
   // Note: copy may add copied Symbols to the supplied map

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -71,6 +71,7 @@ public:
   GenRet         codegen()   override;
   bool           inTree()    override;
   QualifiedType  qualType()  override;
+  Type*          typeInfo()  override { return this; }
   void           verify()    override;
 
   virtual void           codegenDef();


### PR DESCRIPTION
This PR removes some overhead in `typeInfo()` in the compiler by "inlining" its prior implementation for `Type` and `Symbol`. Doing this for `Expr` is more involved and is left for another day. No user-visible changes.

### Rationale

The implementation of `typeInfo()` prior to this PR was introduced at the time we introduced `QualifiedType`. The expectation was that we would switch from using `Type*` to using`QualifiedType` in most cases throughout the compiler, so it was natural to derive a `Type*` from  a `QualifiedType`. This aspiration has not come to life so far. If/when it does, this PR can be reverted.

Testing: standard and gasnet paratests.