### PR TITLE
update homebrew formulas and testing scripts

### DIFF
--- a/util/cron/test-homebrew.bash
+++ b/util/cron/test-homebrew.bash
@@ -42,6 +42,20 @@ log_info "Building tarball with version: ${version}"
 
 mkdir -p $HOME/test
 git clone --reference-if-able "${REPO_CACHE_PATH:-/missing}/homebrew-core.git" git@github.com:Homebrew/homebrew-core.git 2> /dev/null || (cd $HOME/test/homebrew-core; git pull)
+
+# we should do a step where we diff the chapel.rb in homebrew-core with
+# the one in our repository to catch any changes homebrew makes without telling us
+
+diff ${REPO_CACHE_PATH:-/missing}/homebrew-core/Formula/c/chapel.rb ${CHPL_HOME}/util/packaging/homebrew/chapel-release.rb 2> /dev/null
+FORMULA_CHANGED=$?
+if [ $FORMULA_CHANGED -ne 0 ]
+then
+  log_error "homebrew released formula updated and does not match chapel-release.rb! Verify chapel formula in homebrew-core!"
+  exit 1
+  else
+  log_info "homebrew released formula matches chapel-release.rb, good!"
+fi
+
 #cp $HOME/test/homebrew-core/Formula/c/chapel.rb  ${CHPL_HOME}/util/packaging/homebrew/chapel.rb
 # fix to make the home-brew working. After 1.32 release uncomment the above line
 cp ${CHPL_HOME}/util/packaging/homebrew/chapel-main.rb  ${CHPL_HOME}/util/packaging/homebrew/chapel.rb

--- a/util/cron/test-homebrew.bash
+++ b/util/cron/test-homebrew.bash
@@ -6,6 +6,10 @@
 # replace the url and sha in the chapel formula with the url pointing to the tarball created and sha of the tarball.
 # run home-brew scripts to install chapel.
 
+# !IMPORTANT! Make sure REPO_CACHE_PATH is set to where the homebrew-core repository should go
+# before running this script, or it will fail on the step where it diffs the current
+# formula with the copy we store in chapel-release.rb
+
 # Create a tarball from current repo.
 # The tarball is left in root of repo in tar/ directory.
 CWD=$(cd $(dirname $0) ; pwd)
@@ -32,9 +36,6 @@ version="${short_version}"
 log_info "Moving to ${CHPL_HOME}"
 cd $CHPL_HOME
 
-log_info "Building tarball with version: ${version}"
-./util/buildRelease/gen_release ${version}
-
 # This will clone the home-brew repository under test and copies the chapel formula in chapel-lang repo under
 # util/packaging/home-brew
 # replace the url and sha in the chapel formula with the url pointing to the tarball created and sha of the tarball.
@@ -43,10 +44,9 @@ log_info "Building tarball with version: ${version}"
 mkdir -p $HOME/test
 git clone --reference-if-able "${REPO_CACHE_PATH:-/missing}/homebrew-core.git" git@github.com:Homebrew/homebrew-core.git 2> /dev/null || (cd $HOME/test/homebrew-core; git pull)
 
-# we should do a step where we diff the chapel.rb in homebrew-core with
-# the one in our repository to catch any changes homebrew makes without telling us
-
-diff ${REPO_CACHE_PATH:-/missing}/homebrew-core/Formula/c/chapel.rb ${CHPL_HOME}/util/packaging/homebrew/chapel-release.rb 2> /dev/null
+# compare the chapel.rb in homebrew-core with the one in our repository (chapel-release.rb)
+# to catch any changes homebrew makes to the formuala without telling us (might happen when they update deps, etc)
+diff ${REPO_CACHE_PATH:-/missing}/Formula/c/chapel.rb ${CHPL_HOME}/util/packaging/homebrew/chapel-release.rb 2> /dev/null
 FORMULA_CHANGED=$?
 if [ $FORMULA_CHANGED -ne 0 ]
 then
@@ -55,6 +55,9 @@ then
   else
   log_info "homebrew released formula matches chapel-release.rb, good!"
 fi
+
+log_info "Building tarball with version: ${version}"
+./util/buildRelease/gen_release ${version}
 
 #cp $HOME/test/homebrew-core/Formula/c/chapel.rb  ${CHPL_HOME}/util/packaging/homebrew/chapel.rb
 # fix to make the home-brew working. After 1.32 release uncomment the above line

--- a/util/packaging/docker/test/Dockerfile
+++ b/util/packaging/docker/test/Dockerfile
@@ -1,10 +1,28 @@
-# This is a container used to run homebrew-ci 
+# This is a container used to run homebrew-ci
 
-# Get the homebrew ubuntu container
-FROM ghcr.io/homebrew/ubuntu22.04:master
+# Get the homebrew ubuntu container, set the platform to avoid warnings when on M1
+FROM --platform=linux/amd64 ghcr.io/homebrew/ubuntu22.04:master
+
+# Redundant to brew_install.bash butimporant for anyone working in this container
+ENV HOMEBREW_NO_AUTO_UPDATE=1
+ENV HOMEBREW_NO_INSTALL_FROM_API=1
+ENV HOMEBREW_DEVELOPER=1
 
 RUN mkdir -p /home/linuxbrew
+# only really needed for interactive debugging
+# RUN sudo apt-get update
+# RUN sudo apt-get install -y vim
+# ENV EDITOR=vim
 
-# COPY chapel.rb and chapel*.tar.gz inside the container to run homebrew install 
-COPY chapel.rb /home/linuxbrew/
+# necessary so that updated chapel.rb formula can be committed, which is only way it
+# will be tested
+RUN git config --global user.name "Chapel Tester"
+RUN git config --global user.email "chapeluser@nomail.com"
+
+# COPY chapel.rb and chapel*.tar.gz inside the container to run homebrew install
+COPY chapel.rb /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/c/chapel.rb
 COPY chapel*.tar.gz /home/linuxbrew/
+# must commit the change or brew doctor will complain
+WORKDIR /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/
+RUN git add Formula/c/chapel.rb && git commit -m "update chapel.rb for nightly testing"
+WORKDIR /home/linuxbrew/

--- a/util/packaging/docker/test/Dockerfile
+++ b/util/packaging/docker/test/Dockerfile
@@ -3,7 +3,8 @@
 # Get the homebrew ubuntu container, set the platform to avoid warnings when on M1
 FROM --platform=linux/amd64 ghcr.io/homebrew/ubuntu22.04:master
 
-# Redundant to brew_install.bash butimporant for anyone working in this container
+# Redundant to brew_install.bash but imporant for anyone working in this container
+# which can be ran without brew_install.bash
 ENV HOMEBREW_NO_AUTO_UPDATE=1
 ENV HOMEBREW_NO_INSTALL_FROM_API=1
 ENV HOMEBREW_DEVELOPER=1

--- a/util/packaging/docker/test/brew_install.bash
+++ b/util/packaging/docker/test/brew_install.bash
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
-export HOMEBREW_SIMULATE_MACOS_ON_LINUX=1
+# Important to set HOMEBREW_NO_INSTALL_FROM_API to actually test changes
+export HOMEBREW_NO_INSTALL_FROM_API=1
+# Might not be needed, but also doesn't hurt and matches homebrew CI
+export HOMEBREW_NO_AUTO_UPDATE=1
 #Update homebrew
-brew update 
+brew update
 
 #Script used in docker exec command to test homebrew formula
 brew test-bot --only-tap-syntax
 if [ $? -ne 0 ]; then
-      echo "brew test-bot --only-tap-syntax failed" 
+      echo "brew test-bot --only-tap-syntax failed"
       exit 1
 else
       echo "brew test-bot --only-tap-syntax succeeded"
@@ -15,7 +18,7 @@ fi
 # tests commands
 brew test-bot --only-cleanup-before
 if [ $? -ne 0 ]; then
-      echo "brew test-bot --only-cleanup-before failed" 
+      echo "brew test-bot --only-cleanup-before failed"
       exit 1
 else
       echo "brew test-bot --only-cleanup-before succeeded"
@@ -23,7 +26,7 @@ fi
 
 brew test-bot --only-setup
     if [ $? -ne 0 ]; then
-      echo "brew test-bot --only-setup failed" 
+      echo "brew test-bot --only-setup failed"
       exit 1
       else
       echo "brew test-bot --only-setup succeeded"
@@ -31,8 +34,17 @@ brew test-bot --only-setup
 
 brew test-bot --only-formulae-dependents --junit --testing-formulae=chapel --skipped-or-failed-formulae=chapel
 if [ $? -ne 0 ]; then
-      echo "brew test-bot --only-formulae-dependents --junit --testing-formulae=chapel --skipped-or-failed-formulae=chapel failed" 
+      echo "brew test-bot --only-formulae-dependents --junit --testing-formulae=chapel --skipped-or-failed-formulae=chapel failed"
       exit 1
 else
       echo "brew test-bot --only-formulae-dependents --junit --testing-formulae=chapel --skipped-or-failed-formulae=chapel succeeded"
+fi
+
+# This is the bulk of the testing and the same command that Homebrew CI runs
+brew test-bot --only-formulae --junit --only-json-tab --skip-dependents --testing-formulae="chapel" --added-formulae="" --deleted-formulae=""
+if [ $? -ne 0 ]; then
+      echo "brew test-bot --only-formulae --junit --only-json-tab --skip-dependents --testing-formulae="chapel" --added-formulae="" --deleted-formulae="" failed"
+      exit 1
+else
+      echo "brew test-bot --only-formulae --junit --only-json-tab --skip-dependents --testing-formulae="chapel" --added-formulae="" --deleted-formulae="" succeeded"
 fi

--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -16,12 +16,12 @@ class Chapel < Formula
     sha256 x86_64_linux:   "961ad1d420eeeac018098fba19f05ff207edcd279b8c98d5439838d9928f61de"
   end
 
-  depends_on "pkg-config" => :build
   depends_on "cmake"
   depends_on "gmp"
   depends_on "hwloc"
   depends_on "jemalloc"
-  depends_on "llvm@17"
+  depends_on "llvm"
+  depends_on "pkg-config"
   depends_on "python@3.12"
 
   # LLVM is built with gcc11 and we will fail on linux with gcc version 5.xx

--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -6,8 +6,9 @@ class Chapel < Formula
   license "Apache-2.0"
   head "https://github.com/chapel-lang/chapel.git", branch: "main"
 
-  # Let's try not including the bottle information deliberatley to test if that
-  # avoid accidentally pulling from the brew API
+  # Don't include the bottle information in chapel-main.rb deliberatley. The
+  # idea is that we don't want to accidentally use a published bottle in our testing,
+  # which would always report passing.
 
   depends_on "cmake"
   depends_on "gmp"

--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -6,15 +6,8 @@ class Chapel < Formula
   license "Apache-2.0"
   head "https://github.com/chapel-lang/chapel.git", branch: "main"
 
-  bottle do
-    sha256 arm64_sonoma:   "e75b261ff8378a1a86db49794ca9cc4419d8eadc7e7a4ce9a17430a5757bb778"
-    sha256 arm64_ventura:  "7ff7abdf3c8301727e52d65b15837b8974d7d3be52bcac72601b181bf426e444"
-    sha256 arm64_monterey: "a11ed899b3ccf9d8eac11910226d1f86a39f19a7d07c5e8d3f35d5785089eebc"
-    sha256 sonoma:         "e5edf9340b6bfb94bcf39f930406db9db9b2801dd378da85e489a6bd78a676b2"
-    sha256 ventura:        "ad9c9e354207c9926d25f513c1a3b7b6db0936dc1e27998f5859dd4d9cc7155b"
-    sha256 monterey:       "cbc79ae37aa099e744ff21b5654d7fdb364c012a02eb27a0e5d73e0783c2a999"
-    sha256 x86_64_linux:   "961ad1d420eeeac018098fba19f05ff207edcd279b8c98d5439838d9928f61de"
-  end
+  # Let's try not including the bottle information deliberatley to test if that
+  # avoid accidentally pulling from the brew API
 
   depends_on "cmake"
   depends_on "gmp"

--- a/util/packaging/homebrew/chapel-release.rb
+++ b/util/packaging/homebrew/chapel-release.rb
@@ -1,8 +1,8 @@
 class Chapel < Formula
   desc "Programming language for productive parallel computing at scale"
   homepage "https://chapel-lang.org/"
-  url "https://github.com/chapel-lang/chapel/releases/download/2.0.1/chapel-2.0.1.tar.gz"
-  sha256 "19ebcd88d829712468cfef10c634c3e975acdf78dd1a57671d11657574636053"
+  url "https://github.com/chapel-lang/chapel/releases/download/2.1.0/chapel-2.1.0.tar.gz"
+  sha256 "72593c037505dd76e8b5989358b7580a3fdb213051a406adb26a487d26c68c60"
   license "Apache-2.0"
   head "https://github.com/chapel-lang/chapel.git", branch: "main"
 
@@ -18,7 +18,10 @@ class Chapel < Formula
 
   depends_on "cmake"
   depends_on "gmp"
-  depends_on "llvm@17"
+  depends_on "hwloc"
+  depends_on "jemalloc"
+  depends_on "llvm"
+  depends_on "pkg-config"
   depends_on "python@3.12"
 
   # LLVM is built with gcc11 and we will fail on linux with gcc version 5.xx
@@ -28,8 +31,9 @@ class Chapel < Formula
     deps.map(&:to_formula).find { |f| f.name.match? "^llvm" }
   end
 
-  # Fixes: SyntaxWarning: invalid escape sequence '\d'
-  # Remove when merged: https://github.com/chapel-lang/chapel/pull/24643
+  # This fixes an issue when using jemalloc and hwloc from the system (homebrew)
+  # provided installation. Remove in Chapel 2.2 release, after
+  # https://github.com/chapel-lang/chapel/pull/25354 is merged
   patch :DATA
 
   def install
@@ -39,26 +43,21 @@ class Chapel < Formula
     # in our find-python.sh script.
     inreplace "util/config/find-python.sh", /^(for cmd in )(python3 )/, "\\1#{python} \\2"
 
-    # TEMPORARY adds clean-cmakecache target to prevent issues where only
-    #           the first make target gets written to the proper CMAKE_RUNTIME_OUTPUT_DIRECTORY
-    #           cmake detects a change in compilers (although the values are the same?) and
-    #           reruns configure, losing the output directory we set at configure time
-    inreplace "compiler/Makefile",
-              "all: $(PRETARGETS) $(MAKEALLSUBDIRS) echocompilerdir $(TARGETS)\n",
-              "all: $(PRETARGETS) $(MAKEALLSUBDIRS) echocompilerdir $(TARGETS)\n\n
-              clean-cmakecache: FORCE\n\trm -f $(COMPILER_BUILD)/CMakeCache.txt\n\n"
-
     libexec.install Dir["*"]
     # Chapel uses this ENV to work out where to install.
     ENV["CHPL_HOME"] = libexec
     ENV["CHPL_GMP"] = "system"
+    # This ENV avoids a problem where cmake cache is invalidated by subsequent make calls
+    ENV["CHPL_CMAKE_USE_CC_CXX"] = "1"
+
     # don't try to set CHPL_LLVM_GCC_PREFIX since the llvm
     # package should be configured to use a reasonable GCC
     (libexec/"chplconfig").write <<~EOS
       CHPL_RE2=bundled
       CHPL_GMP=system
-      CHPL_MEM=cstdlib
-      CHPL_TASKS=fifo
+      CHPL_MEM=jemalloc
+      CHPL_TARGET_JEMALLOC=system
+      CHPL_HWLOC=system
       CHPL_LLVM_CONFIG=#{llvm.opt_bin}/llvm-config
       CHPL_LLVM_GCC_PREFIX=none
     EOS
@@ -71,16 +70,12 @@ class Chapel < Formula
         system "make"
       end
       with_env(CHPL_LLVM: "system") do
-        cd "compiler" do
-          system "make", "clean-cmakecache"
-        end
         system "make"
       end
       with_env(CHPL_PIP_FROM_SOURCE: "1") do
-        cd "compiler" do
-          system "make", "clean-cmakecache"
-        end
         system "make", "chpldoc"
+        system "make", "chplcheck"
+        system "make", "chpl-language-server"
       end
       system "make", "mason"
       system "make", "cleanall"
@@ -123,20 +118,113 @@ class Chapel < Formula
     system bin/"chpl", "--print-passes", "--print-commands", libexec/"examples/hello.chpl"
     system bin/"chpldoc", "--version"
     system bin/"mason", "--version"
+
+    # Test chplcheck, if it works CLS probably does too.
+    # chpl-language-server will hang indefinitely waiting for a LSP client
+    system bin/"chplcheck", "--list-rules"
+    system bin/"chplcheck", libexec/"examples/hello.chpl"
   end
 end
 
 __END__
-diff --git a/util/chplenv/compiler_utils.py b/util/chplenv/compiler_utils.py
-index c4d683830f4c..1d1be1d55521 100644
---- a/util/chplenv/compiler_utils.py
-+++ b/util/chplenv/compiler_utils.py
-@@ -32,7 +32,7 @@ def CompVersion(version_string):
-     are not specified, 0 will be used for their value(s)
-     """
-     CompVersionT = namedtuple('CompVersion', ['major', 'minor', 'revision', 'build'])
--    match = re.search(u'(\d+)(\.(\d+))?(\.(\d+))?(\.(\d+))?', version_string)
-+    match = re.search(u"(\\d+)(\\.(\\d+))?(\\.(\\d+))?(\\.(\\d+))?", version_string)
-     if match:
-         major    = int(match.group(1))
-         minor    = int(match.group(3) or 0)
+diff --git a/third-party/jemalloc/Makefile.target.include b/third-party/jemalloc/Makefile.target.include
+deleted file mode 100644
+index 217a500dfb..0000000000
+--- a/third-party/jemalloc/Makefile.target.include
++++ /dev/null
+@@ -1,12 +0,0 @@
+-JEMALLOC_DIR=$(THIRD_PARTY_DIR)/jemalloc
+-JEMALLOC_SUBDIR = $(JEMALLOC_DIR)/jemalloc-src
+-JEMALLOC_BUILD_SUBDIR=build/$(CHPL_MAKE_TARGET_JEMALLOC_UNIQ_CFG_PATH)
+-JEMALLOC_BUILD_DIR=$(JEMALLOC_DIR)/$(JEMALLOC_BUILD_SUBDIR)
+-JEMALLOC_INSTALL_SUBDIR=install/$(CHPL_MAKE_TARGET_JEMALLOC_UNIQ_CFG_PATH)
+-JEMALLOC_INSTALL_DIR=$(JEMALLOC_DIR)/$(JEMALLOC_INSTALL_SUBDIR)
+-JEMALLOC_INCLUDE_DIR = $(JEMALLOC_INSTALL_DIR)/include
+-JEMALLOC_LIB_DIR = $(JEMALLOC_INSTALL_DIR)/lib
+-JEMALLOC_BIN_DIR = $(JEMALLOC_INSTALL_DIR)/bin
+-JEMALLOC_TARGET = --target
+-
+-CHPL_JEMALLOC_PREFIX=$(CHPL_JEMALLOC_TARGET_PREFIX)
+diff --git a/make/Makefile.base b/make/Makefile.base
+index bcbda0a9cf..1120057d47 100644
+--- a/make/Makefile.base
++++ b/make/Makefile.base
+@@ -194,7 +194,7 @@ include $(THIRD_PARTY_DIR)/jemalloc/Makefile.common.include
+ ifeq ($(strip $(CHPL_MAKE_HOST_TARGET)),--host)
+ include $(THIRD_PARTY_DIR)/jemalloc/Makefile.host.include-$(CHPL_MAKE_HOST_JEMALLOC)
+ else
+-include $(THIRD_PARTY_DIR)/jemalloc/Makefile.target.include
++include $(THIRD_PARTY_DIR)/jemalloc/Makefile.target.include-$(CHPL_MAKE_TARGET_JEMALLOC)
+ endif
+ include $(THIRD_PARTY_DIR)/gmp/Makefile.include
+ include $(THIRD_PARTY_DIR)/hwloc/Makefile.include
+diff --git a/third-party/jemalloc/Makefile.target.include-bundled b/third-party/jemalloc/Makefile.target.include-bundled
+new file mode 100644
+index 0000000000..217a500dfb
+--- /dev/null
++++ b/third-party/jemalloc/Makefile.target.include-bundled
+@@ -0,0 +1,12 @@
++JEMALLOC_DIR=$(THIRD_PARTY_DIR)/jemalloc
++JEMALLOC_SUBDIR = $(JEMALLOC_DIR)/jemalloc-src
++JEMALLOC_BUILD_SUBDIR=build/$(CHPL_MAKE_TARGET_JEMALLOC_UNIQ_CFG_PATH)
++JEMALLOC_BUILD_DIR=$(JEMALLOC_DIR)/$(JEMALLOC_BUILD_SUBDIR)
++JEMALLOC_INSTALL_SUBDIR=install/$(CHPL_MAKE_TARGET_JEMALLOC_UNIQ_CFG_PATH)
++JEMALLOC_INSTALL_DIR=$(JEMALLOC_DIR)/$(JEMALLOC_INSTALL_SUBDIR)
++JEMALLOC_INCLUDE_DIR = $(JEMALLOC_INSTALL_DIR)/include
++JEMALLOC_LIB_DIR = $(JEMALLOC_INSTALL_DIR)/lib
++JEMALLOC_BIN_DIR = $(JEMALLOC_INSTALL_DIR)/bin
++JEMALLOC_TARGET = --target
++
++CHPL_JEMALLOC_PREFIX=$(CHPL_JEMALLOC_TARGET_PREFIX)
+diff --git a/third-party/jemalloc/Makefile.target.include-none b/third-party/jemalloc/Makefile.target.include-none
+new file mode 100644
+index 0000000000..e69de29bb2
+--- /dev/null
++++ b/third-party/jemalloc/Makefile.target.include-none
+@@ -0,0 +1 @@
++
+diff --git a/third-party/jemalloc/Makefile.target.include-system b/third-party/jemalloc/Makefile.target.include-system
+new file mode 100644
+index 0000000000..e69de29bb2
+--- /dev/null
++++ b/third-party/jemalloc/Makefile.target.include-system
+@@ -0,0 +1 @@
++
+diff --git a/util/chplenv/chpl_hwloc.py b/util/chplenv/chpl_hwloc.py
+index cda5ed6bc0..9dc7f0355d 100755
+--- a/util/chplenv/chpl_hwloc.py
++++ b/util/chplenv/chpl_hwloc.py
+@@ -61,7 +61,13 @@ def get_link_args():
+             if exists and retcode != 0:
+                 error("CHPL_HWLOC=system requires hwloc >= 2.1", ValueError)
+
+-            return third_party_utils.pkgconfig_get_system_link_args('hwloc')
++            _, pclibs = third_party_utils.pkgconfig_get_system_link_args('hwloc', static=False)
++            libs = []
++            for pcl in pclibs:
++                libs.append(pcl)
++                if pcl.startswith('-L'):
++                    libs.append(pcl.replace('-L', '-Wl,-rpath,', 1))
++            return ([ ], libs)
+         else:
+             third_party_utils.could_not_find_pkgconfig_pkg("hwloc", "CHPL_HWLOC")
+
+diff --git a/util/chplenv/chpl_jemalloc.py b/util/chplenv/chpl_jemalloc.py
+index 3d665fa56b..78761c1c6e 100644
+--- a/util/chplenv/chpl_jemalloc.py
++++ b/util/chplenv/chpl_jemalloc.py
+@@ -129,7 +129,13 @@ def get_link_args(flag):
+         # try pkg-config
+         args = third_party_utils.pkgconfig_get_system_link_args('jemalloc')
+         if args != (None, None):
+-            return args
++            pclibs = args[1]
++            libs = []
++            for pcl in pclibs:
++                libs.append(pcl)
++                if pcl.startswith('-L'):
++                    libs.append(pcl.replace('-L', '-Wl,-rpath,', 1))
++            return (args[0], libs)
+         else:
+             envname = "CHPL_TARGET_JEMALLOC" if flag == "target" else "CHPL_HOST_JEMALLOC"
+             third_party_utils.could_not_find_pkgconfig_pkg("jemalloc", envname)

--- a/util/packaging/homebrew/chapel-release.rb
+++ b/util/packaging/homebrew/chapel-release.rb
@@ -7,13 +7,13 @@ class Chapel < Formula
   head "https://github.com/chapel-lang/chapel.git", branch: "main"
 
   bottle do
-    sha256 arm64_sonoma:   "e75b261ff8378a1a86db49794ca9cc4419d8eadc7e7a4ce9a17430a5757bb778"
-    sha256 arm64_ventura:  "7ff7abdf3c8301727e52d65b15837b8974d7d3be52bcac72601b181bf426e444"
-    sha256 arm64_monterey: "a11ed899b3ccf9d8eac11910226d1f86a39f19a7d07c5e8d3f35d5785089eebc"
-    sha256 sonoma:         "e5edf9340b6bfb94bcf39f930406db9db9b2801dd378da85e489a6bd78a676b2"
-    sha256 ventura:        "ad9c9e354207c9926d25f513c1a3b7b6db0936dc1e27998f5859dd4d9cc7155b"
-    sha256 monterey:       "cbc79ae37aa099e744ff21b5654d7fdb364c012a02eb27a0e5d73e0783c2a999"
-    sha256 x86_64_linux:   "961ad1d420eeeac018098fba19f05ff207edcd279b8c98d5439838d9928f61de"
+    sha256 arm64_sonoma:   "6270062d9c3472bc58f50509aa6277f94bbc74a8f0281ec63086a4d9d4730a1c"
+    sha256 arm64_ventura:  "e18e72fcd4fb23504c73b837b3e8f8024c461823b368b65a6948722113f85b9d"
+    sha256 arm64_monterey: "190788f344f7a5233f0916ff82e058b138a83bbc12ddcd2aa209b1bb7201d0e2"
+    sha256 sonoma:         "0cfba2be4769bedc8f9860a41fadeb7f96230498c64d4412b59a2aa074d6fa1b"
+    sha256 ventura:        "e23058da8ea803f51ca1279d8b80adf8f32dffa698740678341a95fcdc5fe30e"
+    sha256 monterey:       "f7eddcf9f7a47b6e03c977e799aaf61f5f2bbfef76c8553b1eff4e6853928af9"
+    sha256 x86_64_linux:   "1b16e11553762c1dcc82c59dc56e48f0a5ed6f644f0b3a1fdaab5570d5edffc4"
   end
 
   depends_on "cmake"


### PR DESCRIPTION
Updates the homebrew formulas for release (what homebrew has committed to homebrew-core) and main (what we use to test our latest changes against) and also updates the dockerfile and test script we use to install and test our package changes. 

This testing updates are necessary to ensure we are actually testing the current changes and not the formula that is currently released. Additionally, the changes include more robust testing that matches the command used (currently) by homebrew CI.

A new check is implemented to ensure that the if the published formula in `homebrew-core` gets updated that we will get a test failure for the homebrew tests. That should help us keep our `chapel-release.rb` formula up to date with what Homebrew has released in the wild. 

Removes `HOMEBREW_SIMULATE_MACOS_ON_LINUX` because it causes errors and is not set in Homebrew CI.

TESTING:

- [x] local run of util/cron/test-homebrew.bash `brew test bot commands succeeded inside ubuntu container`
- [x] paratest `[Summary: #Successes = 17477 | #Failures = 0 | #Futures = 935]`

[reviewed by @jabraham17 - thanks!]
