### PR TITLE
Remove testUniqueString dependence on moby.txt test file

### DIFF
--- a/frontend/test/framework/CMakeLists.txt
+++ b/frontend/test/framework/CMakeLists.txt
@@ -22,7 +22,3 @@ comp_unit_test(testQueryEquivalence)
 comp_unit_test(testRecursionFails)
 comp_unit_test(testUniqueString)
 comp_unit_test(testVarint)
-
-# Copy the moby.txt to the binary dir for use by testUniqueString
-file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/../../../test/types/string/psahabu/perf/moby.txt
-     DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/frontend/test/framework/testUniqueString.cpp
+++ b/frontend/test/framework/testUniqueString.cpp
@@ -444,10 +444,6 @@ int main(int argc, char** argv) {
     else
       inputFile = argv[i];
   }
-  if (printTiming && !inputFile) {
-    std::cout << "Performance timing requested, but no input file specified" << std::endl;
-    exit(1);
-  }
 
   test0();
   test1();
@@ -461,6 +457,10 @@ int main(int argc, char** argv) {
   // Next, measure performance
   if (inputFile) {
     testPerformance(ctx, inputFile, printTiming);
+  } else if (printTiming) {
+    std::cout << "Performance timing requested, but no input file specified" << std::endl;
+    return 1;
   }
+
   return 0;
 }

--- a/frontend/test/framework/testUniqueString.cpp
+++ b/frontend/test/framework/testUniqueString.cpp
@@ -435,7 +435,7 @@ static void test4() {
 
 
 int main(int argc, char** argv) {
-  const char* inputFile = "moby.txt";
+  const char* inputFile = nullptr;
   std::string timingArg = "--timing";
   bool printTiming = false;
   for (int i = 1; i < argc; i++) {
@@ -443,6 +443,10 @@ int main(int argc, char** argv) {
       printTiming = true;
     else
       inputFile = argv[i];
+  }
+  if (printTiming && !inputFile) {
+    std::cout << "Performance timing requested, but no input file specified" << std::endl;
+    exit(1);
   }
 
   test0();
@@ -455,6 +459,8 @@ int main(int argc, char** argv) {
   Context* ctx = &context;
 
   // Next, measure performance
-  testPerformance(ctx, inputFile, printTiming);
+  if (inputFile) {
+    testPerformance(ctx, inputFile, printTiming);
+  }
   return 0;
 }


### PR DESCRIPTION
Modify dyno test `testUniqueString` to not rely on the `moby.txt` test data file being present.

Also adjust build system to not make a copy of this file from `test/types/string/psahabu/perf/moby.txt` to be used in this test.

This makes it possible to build and test the frontend without the production test dir existing.

Resolves https://github.com/Cray/chapel-private/issues/6437.

[reviewer info placeholder]

- [x] dyno tests
- [x] dyno tests with non-existent `$CHPL_HOME/test` dir
  - [x] fails on `main`
- [x] manual performance test with `testUniqueString [--timing] test/types/string/psahabu/perf/moby.txt` still works