### PR TITLE
Specify that it's okay for formal names to be PascalCase as well in the Standard Module Style guide

### DIFF
--- a/doc/rst/developer/bestPractices/StandardModuleStyle.rst
+++ b/doc/rst/developer/bestPractices/StandardModuleStyle.rst
@@ -138,10 +138,10 @@ Methods that are not accessors are still allowed to use "get" in their name.
 Formals
 +++++++
 
-Formal names should be camelCase.  Descriptive names are recommended, within
-reason.  Encoding the type name into a formal name is generally avoided when
-multiple types are supported, as doing so makes it harder to support generic
-functions.
+Formal names should be camelCase or PascalCase.  Descriptive names are
+recommended, within reason.  Encoding the type name into a formal name is
+generally avoided when multiple types are supported, as doing so makes it harder
+to support generic functions.
 
 Some commonly used names are:
 


### PR DESCRIPTION
This was in the original wording but I wasn't sure why it was there because I didn't recall any discussion about it.  But there also wasn't discussion that they had to be camelCase only, either, just that we don't want snake_case at all.  So restore the wording allowing PascalCase to those names

Pointed out by Brad when I merged the previous style guide PR.

Double checked the built docs