### PR TITLE
Add local .good file for variables/static/multilocale-deinit.chpl

### DIFF
--- a/test/variables/static/multilocale-deinit.comm-none.good
+++ b/test/variables/static/multilocale-deinit.comm-none.good
@@ -1,0 +1,1 @@
+deinit of record with value 3


### PR DESCRIPTION
This test (which is multi-locale), introduced by https://github.com/chapel-lang/chapel/pull/25320 did not have a `.good` output for local executions.

Trivial, will not be reviewed.