### PR TITLE
Update version menu to reflect that default docs are about to become 2.1

### DIFF
--- a/doc/util/versionButton.php
+++ b/doc/util/versionButton.php
@@ -87,8 +87,8 @@ if (pagePath == "") {
   pagePath = "index";
 }
 function dropSetup() {
-  var currentRelease = "2.0"; // what does the public have?
-  var stagedRelease = "2.1";  // is there a release staged but not yet public?
+  var currentRelease = "2.1"; // what does the public have?
+  var stagedRelease = "2.2";  // is there a release staged but not yet public?
   var nextRelease = "2.2";    // what's the next release? (on docs/main)
   var button = document.getElementById("versionButton");
   // Uses unicode down-pointing triangle


### PR DESCRIPTION
This is our normal day-of-release bump to the docs version menu once the website updates have been made public.