### PR TITLE
Remove note about formal names redeclared as nested procs

### DIFF
--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2970,7 +2970,6 @@ void Resolver::resolveIdentifier(const Identifier* ident,
       auto c = resolveGeneratedCall(context, ident, ci, inScopes);
       // Ensure we error out for redeclarations within the method itself,
       // which resolution with an implicit 'this' currently does not catch.
-      // TODO: Also catch redeclarations of formal names.
       std::vector<BorrowedIdsWithName> redeclarations;
       inScope->lookupInScope(ident->name(), redeclarations, IdAndFlags::Flags(),
                              IdAndFlags::FlagSet());


### PR DESCRIPTION
Added in https://github.com/chapel-lang/chapel/pull/25231 for https://github.com/chapel-lang/chapel/issues/25376, which turns out to not be a bug.