### PR TITLE
Cleanup stdlib parentheses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,6 @@ lint-standard-modules: chplcheck FORCE
 	tools/chplcheck/chplcheck --skip-unstable \
 		--internal-prefix "_" \
 		--internal-prefix "chpl_" \
-		--disable-rule "RedundantParentheses" \
 		$(MODULES_TO_LINT)
 
 compile-util-python: FORCE

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -461,7 +461,7 @@ record blockDist : writeSerializable {
 
   @chpldoc.nodoc
   inline operator ==(d1: blockDist(?), d2: blockDist(?)) {
-    if (d1._value == d2._value) then
+    if d1._value == d2._value then
       return true;
     return d1._value.dsiEqualDMaps(d2._value);
   }
@@ -754,8 +754,8 @@ proc BlockImpl.redistribute(const in newBbox) {
 
 
 proc BlockImpl.dsiAssign(other: this.type) {
-  if (this.targetLocDom != other.targetLocDom ||
-      || reduce (this.targetLocales != other.targetLocales)) {
+  if this.targetLocDom != other.targetLocDom ||
+     || reduce (this.targetLocales != other.targetLocales) {
     halt("'blockDist' assignments currently require the target locale arrays to match");
   }
 
@@ -1868,7 +1868,7 @@ proc BlockImpl.dsiTargetLocales() const ref {
 
 proc BlockImpl.chpl__locToLocIdx(loc: locale) {
   for locIdx in targetLocDom do
-    if (targetLocales[locIdx] == loc) then
+    if targetLocales[locIdx] == loc then
       return (true, locIdx);
   return (false, targetLocDom.first);
 }
@@ -1881,7 +1881,7 @@ proc BlockDom.dsiHasSingleLocalSubdomain() param do return !allowDuplicateTarget
 // returns the current locale's subdomain
 
 proc BlockArr.dsiLocalSubdomain(loc: locale) {
-  if (loc == here) {
+  if loc == here {
     // quick solution if we have a local array
     if const myLocArrNN = myLocArr then
       return myLocArrNN.locDom.myBlock;
@@ -1894,7 +1894,7 @@ proc BlockArr.dsiLocalSubdomain(loc: locale) {
 }
 proc BlockDom.dsiLocalSubdomain(loc: locale) {
   const (gotit, locid) = dist.chpl__locToLocIdx(loc);
-  if (gotit) {
+  if gotit {
     if loc == here {
       // If we're doing the common case of just querying our own ownership,
       // return the local, pre-computed value
@@ -1983,7 +1983,7 @@ proc BlockArr.canDoOptimizedSwap(other) {
 proc BlockArr.doiOptimizedSwap(other: this.type)
   where this.strides == other.strides {
 
-  if(canDoOptimizedSwap(other)) {
+  if canDoOptimizedSwap(other) {
     if debugOptimizedSwap {
       writeln("BlockArr doing optimized swap. Domains: ",
               this.dom.whole, " ", other.dom.whole, " Bounding boxes: ",
@@ -2226,7 +2226,7 @@ proc BlockArr.doiScan(op, dom) where (rank == 1) &&
 
       // the "first" locale scans the per-locale contributions as they
       // become ready
-      if (locid == firstLoc) then on elemPerLoc {
+      if locid == firstLoc then on elemPerLoc {
         const metaop = op.clone();
 
         var next: resType = metaop.identity;

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -322,7 +322,7 @@ record cyclicDist : writeSerializable {
 
   @chpldoc.nodoc
   inline operator ==(d1: cyclicDist(?), d2: cyclicDist(?)) {
-    if (d1._value == d2._value) then
+    if d1._value == d2._value then
       return true;
     return d1._value.dsiEqualDMaps(d2._value);
   }
@@ -472,7 +472,7 @@ class CyclicImpl: BaseDist, writeSerializable {
 
 proc CyclicImpl.chpl__locToLocIdx(loc: locale) {
   for locIdx in targetLocDom do
-    if (targetLocs[locIdx] == loc) then
+    if targetLocs[locIdx] == loc then
       return (true, locIdx);
   return (false, targetLocDom.first);
 }
@@ -1583,7 +1583,7 @@ proc CyclicArr.dsiHasSingleLocalSubdomain() param do return !allowDuplicateTarge
 proc CyclicDom.dsiHasSingleLocalSubdomain() param do return !allowDuplicateTargetLocales;
 
 proc CyclicArr.dsiLocalSubdomain(loc: locale) {
-  if (loc == here) {
+  if loc == here {
     // quick solution if we have a local array
     if const myLocArrNN = myLocArr then
       return myLocArrNN.locDom.myBlock;
@@ -1596,7 +1596,7 @@ proc CyclicArr.dsiLocalSubdomain(loc: locale) {
 }
 proc CyclicDom.dsiLocalSubdomain(loc: locale) {
   const (gotit, locid) = dist.chpl__locToLocIdx(loc);
-  if (gotit) {
+  if gotit {
     return whole[(...(chpl__computeCyclic(idxType, locid, dist.targetLocDom.dims(), dist.startIdx)))] : myBlockType(rank, idxType);
   } else {
     var d: myBlockType(rank, idxType);
@@ -1631,7 +1631,7 @@ proc CyclicArr.canDoOptimizedSwap(other) {
 proc CyclicArr.doiOptimizedSwap(other: this.type)
   where this.strides == other.strides {
 
-  if(canDoOptimizedSwap(other)) {
+  if canDoOptimizedSwap(other) {
     if debugOptimizedSwap {
       writeln("CyclicArr doing optimized swap. Domains: ",
               this.dom.whole, " ", other.dom.whole, " Bounding boxes: ",

--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -229,11 +229,11 @@ class SparseBlockDom: BaseSparseDomImpl(?) {
   // output domain
   //
   proc dsiSerialWrite(f) {
-    if (rank == 1) {
+    if rank == 1 {
       f.write("{");
       for locdom in locDoms {
         // on locdom do {
-        if (locdom!.dsiNumIndices) {
+        if locdom!.dsiNumIndices {
             f.write(" ");
             locdom!.dsiSerialWrite(f);
           }
@@ -825,11 +825,11 @@ proc LocSparseBlockArr.this(i) ref {
 // output array
 //
 proc SparseBlockArr.dsiSerialWrite(f) {
-  if (rank == 1) {
+  if rank == 1 {
     f.write("[");
     for locarr in locArr {
       // on locdom do {
-      if (locarr!.locDom.dsiNumIndices) {
+      if locarr!.locDom.dsiNumIndices {
         f.write(" ");
         locarr!.dsiSerialWrite(f);
       }


### PR DESCRIPTION
This PR removes parentheses that trigger the `RedundantParentheses` linter rule. The rule advises rewriting logic like this:

```Chapel
if (bla) {

}
```

Into the following:

```Chapel
if bla {

}
```

Even though both are valid, the parentheses are not needed.