### PR TITLE
Rename checkUast to checkGeneratedAst

### DIFF
--- a/compiler/include/checks.h
+++ b/compiler/include/checks.h
@@ -24,7 +24,7 @@
 
 // These are the entry points for per-pass checks.
 void check_parseAndConvertUast();
-void check_checkUast();
+void check_checkGeneratedAst();
 void check_readExternC();
 void check_expandExternArrayCalls();
 void check_cleanup();

--- a/compiler/include/passes.h
+++ b/compiler/include/passes.h
@@ -44,7 +44,7 @@ void bulkCopyRecords();
 void callDestructors();
 void checkNormalized();
 void checkResolved();
-void checkUast();
+void checkGeneratedAst();
 void cleanup();
 void codegen();
 void copyPropagation();

--- a/compiler/main/checks.cpp
+++ b/compiler/main/checks.cpp
@@ -78,7 +78,7 @@ void check_parseAndConvertUast()
   check_afterEveryPass();
 }
 
-void check_checkUast()
+void check_checkGeneratedAst()
 {
   // checkIsIterator() will crash if there were certain USR_FATAL_CONT()
   // e.g. functions/vass/proc-iter/error-yield-in-proc-*
@@ -649,7 +649,7 @@ static void checkIsIterator() {
   forv_Vec(CallExpr, call, gCallExprs) {
     if (call->isPrimitive(PRIM_YIELD)) {
       FnSymbol* fn = toFnSymbol(call->parentSymbol);
-      // Violations should have caused USR_FATAL_CONT in checkUast().
+      // Violations should have caused USR_FATAL_CONT in checkGeneratedAst().
       INT_ASSERT(fn && fn->isIterator());
     }
   }

--- a/compiler/main/runpasses.cpp
+++ b/compiler/main/runpasses.cpp
@@ -41,7 +41,7 @@ struct PassInfo {
 
 // These entries should be kept in the same order as those in the pass list
 #define LOG_parseAndConvertUast                'p'
-#define LOG_checkUast                          LOG_NEVER
+#define LOG_checkGeneratedAst                  LOG_NEVER
 #define LOG_readExternC                        LOG_NO_SHORT
 #define LOG_cleanup                            LOG_NO_SHORT
 #define LOG_scopeResolve                       's'
@@ -89,8 +89,8 @@ struct PassInfo {
 //
 static PassInfo sPassList[] = {
   // Chapel to AST
-  RUN(parseAndConvertUast),     // parse files and create AST
-  RUN(checkUast),               // checks semantics of parsed AST
+  RUN(parseAndConvertUast),     // parse files and generate AST
+  RUN(checkGeneratedAst),       // checks semantics of generated AST
 
   // Read in runtime and included C header file types/prototypes
   RUN(readExternC),
@@ -162,7 +162,7 @@ static void setupStopAfterPass() {
     if (stopAfterPass[0]) {
       USR_FATAL("cannot provide both parse-only and stop after pass flags");
     }
-    strcpy(stopAfterPass, "checkUast");
+    strcpy(stopAfterPass, "checkGeneratedAst");
   }
 
   // ensure pass to stop after exists

--- a/compiler/passes/CMakeLists.txt
+++ b/compiler/passes/CMakeLists.txt
@@ -19,7 +19,7 @@ set(SRCS
     buildDefaultFunctions.cpp
     checkNormalized.cpp
     checkResolved.cpp
-    checkUast.cpp
+    checkGeneratedAst.cpp
     cleanup.cpp
     convert-uast.cpp
     createTaskFunctions.cpp

--- a/compiler/passes/Makefile.share
+++ b/compiler/passes/Makefile.share
@@ -24,7 +24,7 @@ PASSES_SRCS =                                              \
         buildDefaultFunctions.cpp                          \
         checkNormalized.cpp                                \
         checkResolved.cpp                                  \
-        checkUast.cpp                                      \
+        checkGeneratedAst.cpp                              \
         cleanup.cpp                                        \
         convert-uast.cpp                                   \
         createTaskFunctions.cpp                            \

--- a/compiler/passes/checkGeneratedAst.cpp
+++ b/compiler/passes/checkGeneratedAst.cpp
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-// checkUast.cpp
+// checkGeneratedAst.cpp
 
 // this file contains AST checks that occur after converting
 // from uAST to AST.
@@ -49,7 +49,7 @@ static void checkOperator(FnSymbol* fn);
 static void checkUseStmt(UseStmt* use);
 
 void
-checkUast() {
+checkGeneratedAst() {
   setupForCheckExplicitDeinitCalls();
 
   forv_Vec(CallExpr, call, gCallExprs) {

--- a/test/compflags/stopEarly/parseOnly.good
+++ b/test/compflags/stopEarly/parseOnly.good
@@ -1,4 +1,4 @@
 init
 parseAndConvertUast
-checkUast
+checkGeneratedAst
 driverCleanup

--- a/test/parsing/ferguson/var-decl-keyword-type.compopts
+++ b/test/parsing/ferguson/var-decl-keyword-type.compopts
@@ -1,1 +1,1 @@
---stop-after-pass checkUast
+--stop-after-pass checkGeneratedAst


### PR DESCRIPTION
This PR renames `compiler/passes/checkUast.cpp` to `compiler/passes/checkGeneratedAst.cpp`.  It also renames the related pass. The name `checkUast` is confusing because it might be interpreted as checking the uAST. However it is checking the AST that is generated from the uAST, just after it is created.

- [x] full comm=none testing

Reviewed by @dlongnecke-cray - thanks!