### PR TITLE
chplcheck: Add a rule for writing complex number literals in the wrong order

### DIFF
--- a/test/chplcheck/ComplexLiteralOrder.chpl
+++ b/test/chplcheck/ComplexLiteralOrder.chpl
@@ -1,0 +1,9 @@
+var a = 10 + 1i;
+var b = -11 + 2i;
+var c = 12 - 3i;
+var d = -13 - 4i;
+
+var e = 10i + 1;
+var f = -11i + 2;
+var g = 12i - 3;
+var h = -13i - 4;

--- a/test/chplcheck/ComplexLiteralOrder.good
+++ b/test/chplcheck/ComplexLiteralOrder.good
@@ -1,0 +1,6 @@
+ComplexLiteralOrder.chpl:1: node violates rule UseExplicitModules
+ComplexLiteralOrder.chpl:2: node violates rule ConsecutiveDecls
+ComplexLiteralOrder.chpl:6: node violates rule ComplexLiteralOrder
+ComplexLiteralOrder.chpl:7: node violates rule ComplexLiteralOrder
+ComplexLiteralOrder.chpl:8: node violates rule ComplexLiteralOrder
+ComplexLiteralOrder.chpl:9: node violates rule ComplexLiteralOrder

--- a/test/chplcheck/activerules.good
+++ b/test/chplcheck/activerules.good
@@ -4,6 +4,7 @@ Active rules:
   CamelCaseFunctions           Warn for functions that are not 'camelCase'.
   CamelCaseRecords             Warn for records that are not 'camelCase'.
   ChplPrefixReserved           Warn for user-defined names that start with the 'chpl_' reserved prefix.
+  ComplexLiteralOrder          Warn for complex literals that are not in a consistent order.
   DoKeywordAndBlock            Warn for redundant 'do' keyword before a curly brace '{'.
   EmptyStmts                   Warn for empty statements (i.e., unnecessary semicolons).
   IncorrectIndentation         Warn for inconsistent or missing indentation

--- a/test/chplcheck/allrules.good
+++ b/test/chplcheck/allrules.good
@@ -5,6 +5,7 @@ Available rules (default rules marked with *):
   * CamelCaseRecords             Warn for records that are not 'camelCase'.
     CamelOrPascalCaseVariables   Warn for variables that are not 'camelCase' or 'PascalCase'.
   * ChplPrefixReserved           Warn for user-defined names that start with the 'chpl_' reserved prefix.
+  * ComplexLiteralOrder          Warn for complex literals that are not in a consistent order.
     ConsecutiveDecls             Warn for consecutive variable declarations that can be combined.
   * DoKeywordAndBlock            Warn for redundant 'do' keyword before a curly brace '{'.
   * EmptyStmts                   Warn for empty statements (i.e., unnecessary semicolons).

--- a/tools/chapel-py/src/chapel/__init__.py
+++ b/tools/chapel-py/src/chapel/__init__.py
@@ -467,6 +467,13 @@ def is_basic_literal_like(node: AstNode) -> Optional[Literal]:
 def is_complex_literal(
     node: AstNode
 ) -> Optional[typing.Tuple[Literal, Literal]]:
+    """
+    Check for complex number literals: 1+2i, -42-3i, etc.
+    Returns a tuple of the "underlying" literals, removing surrounding AST
+    ((1, 2i), (42, 3i), etc.). This helps do type comparisons in more complex
+    checks. If the node is not a complex literal, returns None.
+    """
+
     if not isinstance(node, OpCall):
         return None
 
@@ -491,6 +498,12 @@ def is_complex_literal(
 
 
 def is_literal_like(node: AstNode) -> bool:
+    """
+    Returns true if the node is a literal-like node: either a "true" literal
+    (1, "hello", etc.) or something that isn't a literal in the AST,
+    but is a literal mathematically (-10, 10 + 2i).
+    """
+
     if is_basic_literal_like(node):
         return True
 

--- a/tools/chapel-py/src/chapel/__init__.py
+++ b/tools/chapel-py/src/chapel/__init__.py
@@ -465,7 +465,7 @@ def is_basic_literal_like(node: AstNode) -> Optional[Literal]:
 
 
 def is_complex_literal(
-    node: AstNode
+    node: AstNode,
 ) -> Optional[typing.Tuple[Literal, Literal]]:
     """
     Check for complex number literals: 1+2i, -42-3i, etc.

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -377,6 +377,24 @@ def register_rules(driver: LintDriver):
             return False
         return True
 
+    @driver.basic_rule(OpCall)
+    def ComplexLiteralOrder(context: Context, node: OpCall):
+        """
+        Warn for complex literals that are not in a consistent order.
+        """
+
+        complex_lit = chapel.is_complex_literal(node)
+        if not complex_lit:
+            return True
+
+        # If the first element is not the imaginary literal, then we have
+        # 10+2i, which is the correct order.
+        if not isinstance(complex_lit[0], ImagLiteral):
+            return True
+
+        # Eventually, auto-fixit will go here. For now, just warn.
+        return False
+
     # Five things have to match between consecutive decls for this to warn:
     # 1. same type
     # 2. same kind


### PR DESCRIPTION
This PR adds a rule for complex number literals that are written with the imaginary number first. Conventionally, imaginary number literals are written with the real part first (i.e., `1 + 2i`, not `2i + 1`).

To re-use some code, this PR moves the complex number detection logic out of `chpl-language-server.py` and into the `chapel` module provided by `chapel-py`. In doing so, it also adds comments.

Reviewed by @jabraham17 -- thanks!

## Testing

- [x] `make test-cls`
- [x] `start_test test/chplcheck`