### PR TITLE
Add support for a `@fixit` decorator to `chplcheck`

### DIFF
--- a/tools/chapel-py/src/chapel/__init__.py
+++ b/tools/chapel-py/src/chapel/__init__.py
@@ -514,6 +514,10 @@ def is_literal_like(node: AstNode) -> bool:
 
 
 def is_unstable_module(node: AstNode):
+    """
+    Returns true if the given AST node is a module, and if it's explicitly
+    marked unstable.
+    """
     if isinstance(node, Module):
         attrs = node.attribute_group()
         if attrs:
@@ -523,6 +527,9 @@ def is_unstable_module(node: AstNode):
 
 
 def in_unstable_module(node: AstNode):
+    """
+    Returns true if the given AST node is inside a module marked as unstable.
+    """
     n = node
     while n is not None:
         if is_unstable_module(n):

--- a/tools/chapel-py/src/chapel/__init__.py
+++ b/tools/chapel-py/src/chapel/__init__.py
@@ -496,6 +496,8 @@ def is_complex_literal(
         if isinstance(left, imag_number) and isinstance(right, real_number):
             return (left, right)
 
+    return None
+
 
 def is_literal_like(node: AstNode) -> bool:
     """
@@ -510,4 +512,18 @@ def is_literal_like(node: AstNode) -> bool:
     if is_complex_literal(node):
         return True
 
+def is_unstable_module(node: AstNode):
+    if isinstance(node, Module):
+        attrs = node.attribute_group()
+        if attrs:
+            if attrs.is_unstable():
+                return True
+    return False
+
+def in_unstable_module(node: AstNode):
+    n = node
+    while n is not None:
+        if is_unstable_module(n):
+            return True
+        n = n.parent()
     return False

--- a/tools/chapel-py/src/chapel/__init__.py
+++ b/tools/chapel-py/src/chapel/__init__.py
@@ -512,6 +512,7 @@ def is_literal_like(node: AstNode) -> bool:
     if is_complex_literal(node):
         return True
 
+
 def is_unstable_module(node: AstNode):
     if isinstance(node, Module):
         attrs = node.attribute_group()
@@ -519,6 +520,7 @@ def is_unstable_module(node: AstNode):
             if attrs.is_unstable():
                 return True
     return False
+
 
 def in_unstable_module(node: AstNode):
     n = node

--- a/tools/chapel-py/src/chapel/__init__.py
+++ b/tools/chapel-py/src/chapel/__init__.py
@@ -520,9 +520,8 @@ def is_unstable_module(node: AstNode):
     """
     if isinstance(node, Module):
         attrs = node.attribute_group()
-        if attrs:
-            if attrs.is_unstable():
-                return True
+        if attrs and attrs.is_unstable():
+            return True
     return False
 
 

--- a/tools/chplcheck/src/driver.py
+++ b/tools/chplcheck/src/driver.py
@@ -63,7 +63,7 @@ class LintDriver:
     def __init__(self, config: Config):
         self.config: Config = config
         self.SilencedRules: List[str] = []
-        self.BasicRules: List[Tuple[str, Any, rule_types.BasicRule]] = []
+        self.BasicRules: List[rule_types.BasicRule] = []
         self.AdvancedRules: List[Tuple[str, rule_types.AdvancedRule]] = []
 
     def rules_and_descriptions(self):
@@ -71,7 +71,7 @@ class LintDriver:
         to_return = {}
 
         for rule in self.BasicRules:
-            to_return[rule[0]] = rule[2].__doc__
+            to_return[rule.name] = rule.check_func.__doc__
 
         for rule in self.AdvancedRules:
             to_return[rule[0]] = rule[1].__doc__
@@ -150,30 +150,48 @@ class LintDriver:
         self,
         context: chapel.Context,
         root: chapel.AstNode,
-        rule: Tuple[str, Any, rule_types.BasicRule],
+        rule: rule_types.BasicRule,
     ) -> Iterator[Tuple[chapel.AstNode, str, Optional[List[Fixit]]]]:
-        (name, nodetype, func) = rule
 
         # If we should ignore the rule no matter the node, no reason to run
         # a traversal and match the pattern.
-        if not self._should_check_rule(name):
+        if not self._should_check_rule(rule.name):
             return
 
         for node, _ in chapel.each_matching(
-            root, nodetype, iterator=self._preorder_skip_unstable_modules
+            root, rule.pattern, iterator=self._preorder_skip_unstable_modules
         ):
-            if not self._should_check_rule(name, node):
+            if not self._should_check_rule(rule.name, node):
                 continue
 
-            val = func(context, node)
-            check, fixit = None, []
-            if isinstance(val, rule_types.BasicRuleResult):
+            result = rule.check_func(context, node)
+            check, fixits = None, []
+            # unwrap the result from the check function
+            if isinstance(result, rule_types.BasicRuleResult):
                 check = False
-                fixit = val.fixits(context, name)
+                fixits = result.fixits(context, rule.name)
             else:
-                check = val
+                check = result
+                result = rule_types.BasicRuleResult(node)
+            # if we are going to warn, check for fixits from fixit hooks (in
+            # addition to the fixits in the rule itself)
             if not check:
-                yield (node, name, fixit)
+                fixits_from_hooks = []
+                for fixit_func in rule.fixit_funcs:
+                    extra_fixes = fixit_func(context, result)
+                    if extra_fixes is not None:
+                        if isinstance(extra_fixes, Fixit):
+                            if extra_fixes.description is None:
+                                extra_fixes.description = fixit_func.__doc__.strip()
+                            fixits_from_hooks.append(extra_fixes)
+                        else:
+                            for f in extra_fixes:
+                                if f.description is None:
+                                    f.description = fixit_func.__doc__.strip()
+                                fixits_from_hooks.append(f)
+                # add the fixits from the hooks to the fixits from the rule
+                fixits = fixits_from_hooks + fixits
+                yield (node, rule.name, fixits)
 
     def _check_advanced_rule(
         self,
@@ -223,7 +241,11 @@ class LintDriver:
         """
 
         def decorator_basic_rule(func):
-            self.BasicRules.append((func.__name__, pat, func))
+            self.BasicRules.append(
+                rule_types.BasicRule(
+                    name=func.__name__, pattern=pat, check_func=func
+                )
+            )
             if not default:
                 self.SilencedRules.append(func.__name__)
 
@@ -234,6 +256,26 @@ class LintDriver:
             return wrapper_basic_rule
 
         return decorator_basic_rule
+
+    def fixit(self, checkfunc):
+        def decorator_fixit(func):
+            if checkfunc.__name__ not in [
+                rule.name for rule in self.BasicRules
+            ]:
+                raise ValueError(
+                    f"Fixit decorator must be used on a basic rule"
+                )
+            for rule in self.BasicRules:
+                if rule.name == checkfunc.__name__:
+                    rule.fixit_funcs.append(func)
+
+            @functools.wraps(func)
+            def wrapper_basic_rule(*args, **kwargs):
+                return func(*args, **kwargs)
+
+            return wrapper_basic_rule
+
+        return decorator_fixit
 
     def advanced_rule(self, _func=None, *, default=True):
         """

--- a/tools/chplcheck/src/driver.py
+++ b/tools/chplcheck/src/driver.py
@@ -179,15 +179,12 @@ class LintDriver:
 
     def fixit(self, checkfunc):
         def decorator_fixit(func):
-            if checkfunc.__name__ not in [
-                rule.name for rule in self.BasicRules
-            ]:
-                raise ValueError(
-                    f"Fixit decorator must be used on a basic rule"
-                )
-            for rule in self.BasicRules:
+            for rule in itertools.chain(self.BasicRules, self.AdvancedRules):
                 if rule.name == checkfunc.__name__:
                     rule.fixit_funcs.append(func)
+                    break
+            else:
+                raise ValueError("Couldn't find rule {} to attach fixit {} to".format(checkfunc.__name__, func.__name__))
 
             @functools.wraps(func)
             def wrapper_basic_rule(*args, **kwargs):

--- a/tools/chplcheck/src/driver.py
+++ b/tools/chplcheck/src/driver.py
@@ -177,6 +177,14 @@ class LintDriver:
         return decorator_basic_rule
 
     def fixit(self, checkfunc):
+        """
+        Declare a fixit hook for a given rule. The hook function receives as
+        parameters the Dyno context object and the AdvancedRuleResult or
+        BasicRuleResult object that represents the rule violation.
+
+        The hook function should return a list of Fixit objects which will be
+        suggested to the user.
+        """
         def decorator_fixit(func):
             found = False
             for rule in itertools.chain(self.BasicRules, self.AdvancedRules):

--- a/tools/chplcheck/src/driver.py
+++ b/tools/chplcheck/src/driver.py
@@ -145,7 +145,6 @@ class LintDriver:
 
         yield from rule.check(context, root)
 
-
     def basic_rule(self, pat, default=True):
         """
         This method is a decorator factory for adding 'basic' rules to the
@@ -186,7 +185,11 @@ class LintDriver:
                     found = True
 
             if not found:
-                raise ValueError("Couldn't find rule {} to attach fixit {} to".format(checkfunc.__name__, func.__name__))
+                raise ValueError(
+                    "Couldn't find rule {} to attach fixit {} to".format(
+                        checkfunc.__name__, func.__name__
+                    )
+                )
 
             @functools.wraps(func)
             def wrapper_basic_rule(*args, **kwargs):

--- a/tools/chplcheck/src/driver.py
+++ b/tools/chplcheck/src/driver.py
@@ -179,11 +179,13 @@ class LintDriver:
 
     def fixit(self, checkfunc):
         def decorator_fixit(func):
+            found = False
             for rule in itertools.chain(self.BasicRules, self.AdvancedRules):
                 if rule.name == checkfunc.__name__:
                     rule.fixit_funcs.append(func)
-                    break
-            else:
+                    found = True
+
+            if not found:
                 raise ValueError("Couldn't find rule {} to attach fixit {} to".format(checkfunc.__name__, func.__name__))
 
             @functools.wraps(func)

--- a/tools/chplcheck/src/driver.py
+++ b/tools/chplcheck/src/driver.py
@@ -185,6 +185,7 @@ class LintDriver:
         The hook function should return a list of Fixit objects which will be
         suggested to the user.
         """
+
         def decorator_fixit(func):
             found = False
             for rule in itertools.chain(self.BasicRules, self.AdvancedRules):

--- a/tools/chplcheck/src/driver.py
+++ b/tools/chplcheck/src/driver.py
@@ -111,31 +111,13 @@ class LintDriver:
             node.name().startswith(p) for p in self.config.internal_prefixes
         )
 
-    @staticmethod
-    def _is_unstable_module(node: chapel.AstNode):
-        if isinstance(node, chapel.Module):
-            attrs = node.attribute_group()
-            if attrs:
-                if attrs.is_unstable():
-                    return True
-        return False
-
-    @staticmethod
-    def _in_unstable_module(node: chapel.AstNode):
-        n = node
-        while n is not None:
-            if LintDriver._is_unstable_module(n):
-                return True
-            n = n.parent()
-        return False
-
     def _preorder_skip_unstable_modules(self, node):
         if not self.config.skip_unstable:
             yield from chapel.preorder(node)
             return
 
         def recurse(node):
-            if LintDriver._is_unstable_module(node):
+            if chapel.is_unstable_module(node):
                 return
 
             yield node

--- a/tools/chplcheck/src/rule_types.py
+++ b/tools/chplcheck/src/rule_types.py
@@ -80,11 +80,13 @@ class BasicRuleResult:
 
 
 _BasicRuleResult = typing.Union[bool, BasicRuleResult]
-"""Internal type for basic rule results"""
+"""The type of values that can be returned by basic rule functions"""
+
+
 BasicRuleCheck = typing.Callable[
     [chapel.Context, chapel.AstNode], _BasicRuleResult
 ]
-"""Function type for basic rules; (context, node) -> bool or BasicRuleResult"""
+"""Function type for basic rules; (context, node) -> _BasicRuleResult"""
 
 
 class AdvancedRuleResult:
@@ -124,14 +126,19 @@ _AdvancedRuleResult = typing.Iterator[
     typing.Union[chapel.AstNode, AdvancedRuleResult]
 ]
 """Internal type for advanced rule results"""
-AdvancedRule = typing.Callable[
+
+
+AdvancedRuleCheck = typing.Callable[
     [chapel.Context, chapel.AstNode], _AdvancedRuleResult
 ]
 """Function type for advanced rules"""
 
+
 RuleResult = typing.Union[_BasicRuleResult, _AdvancedRuleResult]
 """Union type for all rule results"""
-Rule = typing.Union[BasicRuleCheck, AdvancedRule]
+
+
+Rule = typing.Union[BasicRuleCheck, AdvancedRuleCheck]
 """Union type for all rules"""
 
 
@@ -148,8 +155,18 @@ Function type for fixits; (context, data) -> None or Fixit or List[Fixit]
 @dataclass
 class BasicRule:
     """
-    Class containing all information for the driver about rules"""
+    Class containing all information for the driver about basic rules
+    """
     name: str
     pattern: typing.Any
     check_func: BasicRuleCheck
+    fixit_funcs: typing.List[FixitHook] = field(default_factory=list)
+
+@dataclass
+class AdvancedRule:
+    """
+    Class containing all information for the driver about advanced
+    """
+    name: str
+    check_func: AdvancedRuleCheck
     fixit_funcs: typing.List[FixitHook] = field(default_factory=list)

--- a/tools/chplcheck/src/rule_types.py
+++ b/tools/chplcheck/src/rule_types.py
@@ -21,6 +21,7 @@ from dataclasses import field
 import typing
 
 import chapel
+from abc import ABCMeta, abstractmethod
 from fixits import Fixit, Edit
 
 
@@ -151,7 +152,7 @@ Function type for fixits; (context, data) -> None or Fixit or List[Fixit]
 """
 
 
-class Rule(typing.Generic[VarResultType]):
+class Rule(typing.Generic[VarResultType], metaclass=ABCMeta):
     # can't specify type of driver due to circular import
     def __init__(self, driver, name: str) -> None:
         self.driver = driver
@@ -182,6 +183,12 @@ class Rule(typing.Generic[VarResultType]):
                 self._fixup_description_for_fixit(f, fixit_func)
                 fixits_from_hooks.append(f)
         return fixits_from_hooks
+
+    @abstractmethod
+    def check(
+        self, context: chapel.Context, root: chapel.AstNode
+    ) -> typing.Iterable[CheckResult]:
+        pass
 
 
 class BasicRule(Rule[BasicRuleResult]):

--- a/tools/chplcheck/src/rule_types.py
+++ b/tools/chplcheck/src/rule_types.py
@@ -17,7 +17,6 @@
 # limitations under the License.
 #
 
-from dataclasses import field
 import typing
 
 import chapel
@@ -101,6 +100,7 @@ class AdvancedRuleResult:
         node: chapel.AstNode,
         anchor: typing.Optional[chapel.AstNode] = None,
         fixits: typing.Optional[typing.Union[Fixit, typing.List[Fixit]]] = None,
+        data: typing.Optional[typing.Any] = None,
     ):
         self.node = node
         self.anchor = anchor
@@ -110,6 +110,7 @@ class AdvancedRuleResult:
             self._fixits = [fixits]
         else:
             self._fixits = fixits
+        self.data = data
 
     def fixits(self, context: chapel.Context, name: str) -> typing.List[Fixit]:
         """

--- a/tools/chplcheck/src/rule_types.py
+++ b/tools/chplcheck/src/rule_types.py
@@ -203,7 +203,7 @@ class BasicRule(Rule[BasicRuleResult]):
         self.pattern = pattern
         self.check_func = check_func
 
-    def check_single(
+    def _check_single(
         self, context: chapel.Context, node: chapel.AstNode
     ) -> typing.Optional[CheckResult]:
         result = self.check_func(context, node)
@@ -234,7 +234,7 @@ class BasicRule(Rule[BasicRuleResult]):
             if not self.driver.should_check_rule(self.name, node):
                 continue
 
-            checked = self.check_single(context, node)
+            checked = self._check_single(context, node)
             if checked is not None:
                 yield checked
 

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -301,7 +301,6 @@ def register_rules(driver: LintDriver):
 
         return [Fixit.build(Edit.build(paren_loc, new_text))]
 
-
     @driver.basic_rule(Coforall, default=False)
     def NestedCoforalls(context: Context, node: Coforall):
         """
@@ -327,7 +326,9 @@ def register_rules(driver: LintDriver):
     # that difficult. Blocks get built and rebuilt in the parser, making it
     # hard to tag the resulting block with curky braces locations.
     @driver.fixit(BoolLitInCondStmt)
-    def FixBoolLitInCondStmt_KeepBraces(context: Context, result: BasicRuleResult):
+    def FixBoolLitInCondStmt_KeepBraces(
+        context: Context, result: BasicRuleResult
+    ):
         """
         Remove the unused branch of a conditional statement, keeping the braces.
         """
@@ -567,11 +568,8 @@ def register_rules(driver: LintDriver):
             line_start = (loc.start()[0], 1)
             parent_indent = max(prevloop_loc.start()[1] - 1, 0)
             text = " " * parent_indent + range_to_text(loc, lines)
-            fixit = Fixit.build(
-                Edit(loc.path(), line_start, loc.end(), text)
-            )
+            fixit = Fixit.build(Edit(loc.path(), line_start, loc.end(), text))
         return [fixit] if fixit else []
-
 
     @driver.advanced_rule(default=False)
     def UnusedFormal(context: Context, root: AstNode):

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -551,6 +551,9 @@ def register_rules(driver: LintDriver):
 
     @driver.fixit(MisleadingIndentation)
     def FixMisleadingIndentation(context: Context, result: AdvancedRuleResult):
+        """
+        Align second statement to be outside of the loop.
+        """
         assert isinstance(result.anchor, AstNode)
         prevloop_loc = result.anchor.location()
         loc = result.node.location()


### PR DESCRIPTION
This PR builds on the work started by @jabraham17 before the release.

Jade's original work functioned by adding a new `fixit_funcs` field to the `BasicRule` data structure. Previously, `BasicRule` was only used as a convenient way to store the name, pattern, and checking function for basic rules. Then, at the time that basic rules were checked, Jade's implementation also executed the `fixit_funcs`, and added any fixits they produced to this list. This made it possible to mix and match fixit approach (some inline, some using hooks).

My PR builds on this work in the following ways:

* It converts the `BasicRule` data class into a class hierarchy; a parent `Rule` class is extended by `BasicRule` (the existing data structure) and `AdvancedRule` (a new class analogous to `BasicRule`, but containing the names and checking function of advanced rules).
  *  `Rule` is generic over the type of result its hooks expect. Thus, the fixit hooks for `BasicRule` expect a `BasicRuleResult`, and the fixit hooks for `AdvancedRule` accept an `AdvancedRuleResult`. The types of the fixit hooks are not currently checked when they are inserted into the `fixit_funcs` list (it requires some relatively advanced checking which is best left for a follow-up). 
* The logic for checking the AST according to a given rule is moved into the `BasicRule` and `AdvancedRule` subclasses. This helps in two ways:
  1. It helps standardize the interface between applying advanced and basic rules. Now they all take a context and an AST root, and provide an iterable of `CheckResult` (offending node, rule name, and suggested fixits).
  2. It helps move a bunch of special logic out of `driver.py` that handles how each rule should be applied, and to share this logic (namely, the fixit hook handling) between advanced and basic rules in a type-safe manner.
* Some advanced rules have their fixits converted into hook-based fixits. I left some rules alone because the inline fixits are very brief and unobtrusive.

I have some ideas on how to enforce type correctness of fixits and fixit hooks, but they are best left for a follow-up PR.

Reviewed by @jabraham17 -- thanks!

## Testing
- [x] `test/chplcheck`