### PR TITLE
Avoid compiler crash under --baseline

### DIFF
--- a/compiler/codegen/cg-type.cpp
+++ b/compiler/codegen/cg-type.cpp
@@ -65,8 +65,15 @@ void PrimitiveType::codegenDef() {
   } else {
 #ifdef HAVE_LLVM
     llvm::Type* llvmType = info->lvt->getType(this->symbol->cname);
-    if (llvmType == nullptr && (this == dtVoid || this == dtNothing)) {
-      llvmType = llvm::Type::getVoidTy(gContext->llvmContext());
+    if (llvmType == nullptr) {
+      if (this == dtVoid || this == dtNothing) {
+        llvmType = llvm::Type::getVoidTy(gContext->llvmContext());
+      } else {
+        USR_FATAL_CONT(this, "could not find C type for %s",
+                       this->symbol->cname);
+        // fake it so we can continue and report more errors, if present
+        llvmType = llvm::Type::getInt8Ty(gContext->llvmContext());
+      }
       // cf. int64_t is added to lvt in addGlobalCDecl()
       info->lvt->addGlobalType(this->symbol->cname, llvmType, false);
     }

--- a/test/types/integral/integral-alias-baseline.bad
+++ b/test/types/integral/integral-alias-baseline.bad
@@ -1,1 +1,1 @@
-error: Could not find C type for integral_chpl
+error: could not find C type for integral_chpl

--- a/test/types/integral/integral-alias-baseline.skipif
+++ b/test/types/integral/integral-alias-baseline.skipif
@@ -1,2 +1,8 @@
 # bug is specific to --baseline
 COMPOPTS >= --baseline
+
+# The output will be different for C codegen.
+# Skip these configurations to avoid .bad mismatches.
+# Once the bag is fixed, the program should work in all configurations.
+CHPL_LLVM == none
+CHPL_TARGET_COMPILER != llvm


### PR DESCRIPTION
This replaces an internal compiler error introduced in #25215 with a user error message. This is for the test that illustrates #24113.

### Details

The test `types/integral/integral-alias-baseline` when compiled with --baseline propagates the Chapel type `integral` all the way into codegen. Since `integral` is a generic type, it means that codegen receives invalid AST. Prior to #25215 the compiler reported a user error message, after that PR it failed an assertion. The latter is reasonable because the compiler indeed ends up with something invalid due to its own fault, not user's. However, this PR restores this scenario to a user-facing error just because it looks nicer.

* [x] testing: standard and gasnet paratests
