### PR TITLE
Fix typo in error message for nvvm

### DIFF
--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -200,10 +200,11 @@ def get_cuda_libdevice_path():
         # sure how realistic that is, nor I see multiple instances in the systems I
         # have access to. They are always named `libdevice.10.bc`, but I just want
         # to be sure here.
-        libdevices = glob.glob(chpl_cuda_path+"/nvvm/libdevice/libdevice*.bc")
+        path_part = "/nvvm/libdevice/libdevice*.bc"
+        libdevices = glob.glob(chpl_cuda_path+path_part)
         if len(libdevices) == 0:
             _reportMissingGpuReq("Can't find libdevice. Please make sure your CHPL_CUDA_PATH is "
-                  "set such that CHPL_CUDA_PATH/nvmm/libdevice/libdevice*.bc exists.")
+                  "set such that CHPL_CUDA_PATH{} exists.".format(path_part))
             return 'error'
         else:
             return libdevices[0]


### PR DESCRIPTION
Fixes an error message when chplenv cannot find a path in `CUDA/nvvm/...`.

Resolves https://github.com/chapel-lang/chapel/issues/25402

[Reviewed by @e-kayrakli]