### PR TITLE
Add a workaround for issue #25381

### DIFF
--- a/util/chplenv/third_party_utils.py
+++ b/util/chplenv/third_party_utils.py
@@ -66,6 +66,13 @@ def filter_libs_skip_arg(arg):
         # and since Chapel programs always build with pthreads anyway
         return True
 
+    if arg == '-L/usr/lib':
+        # Ignore this flag since on some systems /usr/lib is 32-bit
+        # and /usr/lib64 is 64-bit, so we would normally want /usr/lib64.
+        # This is a workaround for building qthreads with CHPL_HWLOC=system
+        # on Gentoo systems.
+        return True
+
     return False
 
 # Given bundled_libs and system_libs lists, filters some

--- a/util/chplenv/third_party_utils.py
+++ b/util/chplenv/third_party_utils.py
@@ -94,6 +94,7 @@ def filter_libs(bundled_libs, system_libs):
             system_ret.append(arg)
         else:
             # otherwise include the flag in bundled
+            # TODO: this put something like -L/usr/lib into system_ret instead.
             bundled_ret.append(arg)
 
     for arg in system_libs:


### PR DESCRIPTION
Resolves #25381.

This PR adds a workaround to address #25381. The workaround is to filter out `-L/usr/lib` in `filter_libs_skip_arg` from `third_party_utils.py`. The justification for removing this is that it shouldn't be required since it's a system default (if/when it is appropriate).

Reviewed by @jabraham17 - thanks!

- [x] make check works on Ubuntu 24.0
- [x] works on Mac OS X
- [x] full comm=none testing