### PR TITLE
Remote variables: execute initialization expression on the target locale

### DIFF
--- a/compiler/AST/LoopExpr.cpp
+++ b/compiler/AST/LoopExpr.cpp
@@ -719,9 +719,8 @@ static void adjustIndexDefPoints(FnSymbol* xifn, AList* indexDefs) {
     forLoop->insertAtHead(expr->remove());
 }*/
 
-void scopeResolveAndNormalizeGeneratedLoweringFn(FnSymbol* fn) {
+void normalizeGeneratedLoweringFn(FnSymbol* fn) {
   TransformLogicalShortCircuit vis;
-  addToSymbolTable(fn);
   fn->accept(&vis);
   resolveUnresolvedSymExprs(fn);
   normalize(fn);
@@ -891,20 +890,20 @@ static CallExpr* buildLoopExprFunctions(LoopExpr* loopExpr) {
       fn->insertAtHead(new DefExpr(fifn));
     }
 
-    scopeResolveAndNormalizeGeneratedLoweringFn(fn);
+    normalizeGeneratedLoweringFn(fn);
   } else {
     fn->defPoint->insertBefore(new DefExpr(sifn));
-    scopeResolveAndNormalizeGeneratedLoweringFn(sifn);
+    normalizeGeneratedLoweringFn(sifn);
 
     if (forall) {
       fn->defPoint->insertBefore(new DefExpr(lifn));
-      scopeResolveAndNormalizeGeneratedLoweringFn(lifn);
+      normalizeGeneratedLoweringFn(lifn);
 
       fn->defPoint->insertBefore(new DefExpr(fifn));
-      scopeResolveAndNormalizeGeneratedLoweringFn(fifn);
+      normalizeGeneratedLoweringFn(fifn);
     }
 
-    scopeResolveAndNormalizeGeneratedLoweringFn(fn);
+    normalizeGeneratedLoweringFn(fn);
   }
 
 

--- a/compiler/AST/stmt.cpp
+++ b/compiler/AST/stmt.cpp
@@ -647,7 +647,13 @@ BlockStmt* findEnclosingGpuAttributeBlock(Expr* search) {
     if (auto block = toBlockStmt(search)) {
       if (block->isGpuAttributeBlock()) return block;
     }
-    search = search->parentExpr;
+    if (search->parentExpr) {
+      search = search->parentExpr;
+    } else if (search->parentSymbol) {
+      search = search->parentSymbol->defPoint;
+    } else {
+      break;
+    }
   }
   return nullptr;
 }

--- a/compiler/AST/thunks.cpp
+++ b/compiler/AST/thunks.cpp
@@ -91,7 +91,7 @@ static CallExpr* buildThunkPrimFunctions(CallExpr* node) {
   }
   update_symbols(thunkFn, &map);
 
-  scopeResolveAndNormalizeGeneratedLoweringFn(thunkFn);
+  normalizeGeneratedLoweringFn(thunkFn);
 
   return thunkCall;
 }

--- a/compiler/AST/thunks.cpp
+++ b/compiler/AST/thunks.cpp
@@ -51,7 +51,7 @@ static void collectThunkOuterVars(Expr* expr, std::set<Symbol*>& outerVars) {
   collectSymExprs(expr, uses);
   for (auto use : uses) {
     Symbol* sym = use->symbol();
-    if (considerForOuter(sym))
+    if (considerForOuter(sym) && isOuterVarLoop(sym, expr))
       outerVars.insert(sym);
   }
 }

--- a/compiler/include/LoopExpr.h
+++ b/compiler/include/LoopExpr.h
@@ -94,7 +94,7 @@ bool considerForOuter(Symbol* sym);
   for an example of the sort of transformations this supports.
  */
 ArgSymbol* newOuterVarArg(Symbol* sym);
-void scopeResolveAndNormalizeGeneratedLoweringFn(FnSymbol* fn);
+void normalizeGeneratedLoweringFn(FnSymbol* fn);
 
 void lowerLoopExprs(BaseAST* ast);
 

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -3984,7 +3984,7 @@ struct Converter {
       auto wrapperCall = new CallExpr("chpl__buildRemoteWrapper");
       wrapperCall->insertAtTail(destinationExpr);
       if (typeExpr) wrapperCall->insertAtTail(typeExpr);
-      if (initExpr) wrapperCall->insertAtTail(initExpr);
+      if (initExpr) wrapperCall->insertAtTail(new CallExpr(PRIM_CREATE_THUNK, initExpr));
       auto wrapperDef = new DefExpr(wrapper, wrapperCall);
 
       auto wrapperGet = new CallExpr(".", new SymExpr(wrapper), new_CStringSymbol("get"));

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -830,12 +830,11 @@ static void normalizeBase(BaseAST* base, bool addEndOfStatements) {
     }
   }
 
+  lowerThunkPrims(base);
+
   lowerIfExprs(base);
 
   lowerLoopExprs(base);
-
-  lowerThunkPrims(base);
-
 
   //
   // Phase 4

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -830,11 +830,11 @@ static void normalizeBase(BaseAST* base, bool addEndOfStatements) {
     }
   }
 
+  lowerThunkPrims(base);
+
   lowerIfExprs(base);
 
   lowerLoopExprs(base);
-
-  lowerThunkPrims(base);
 
 
   //

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -830,11 +830,11 @@ static void normalizeBase(BaseAST* base, bool addEndOfStatements) {
     }
   }
 
-  lowerThunkPrims(base);
-
   lowerIfExprs(base);
 
   lowerLoopExprs(base);
+
+  lowerThunkPrims(base);
 
 
   //

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -11745,7 +11745,7 @@ static void applyGpuAttributesToIterableExprs() {
     int numUsers = primCall->numActuals();
 
     if (numUsers == 0) {
-      USR_FATAL(block, "Found GPU attributes on a variable declaration, but no subexpression to apply them to");
+      USR_FATAL_CONT(block, "Found GPU attributes on a variable declaration, but no subexpression to apply them to");
       USR_PRINT(block, "GPU attributes on variable declarations are applied to loop expressions and promoted function calls in the variable's initializer");
       USR_STOP();
     }

--- a/modules/internal/ChapelRemoteVars.chpl
+++ b/modules/internal/ChapelRemoteVars.chpl
@@ -39,37 +39,26 @@ module ChapelRemoteVars {
     }
   }
 
+  inline proc __defaultValueForType(type inType) {
+    var default: inType;
+    return default;
+  }
+
   @unstable("remote variables are unstable")
   inline proc chpl__buildRemoteWrapper(loc: locale, type inType) {
-    var default: inType;
-    return chpl__buildRemoteWrapper(loc, inType, default);
+    return chpl__buildRemoteWrapper(loc, inType, __primitive("create thunk", __defaultValueForType(inType)));
   }
 
   @unstable("remote variables are unstable")
-  inline proc chpl__buildRemoteWrapper(loc: locale, in value: ?t) {
-    return chpl__buildRemoteWrapper(loc, t, value);
+  inline proc chpl__buildRemoteWrapper(loc: locale, in tr: _thunkRecord) {
+    return chpl__buildRemoteWrapper(loc, thunkToReturnType(tr.type), tr);
   }
 
   @unstable("remote variables are unstable")
-  inline proc chpl__buildRemoteWrapper(loc: locale, type inType, in value: inType) {
+  inline proc chpl__buildRemoteWrapper(loc: locale, type inType, in tr: _thunkRecord) {
     var c: owned _remoteVarContainer(inType)?;
-    on loc do c = new _remoteVarContainer(value);
+    on loc do c = new _remoteVarContainer(__primitive("force thunk", tr));
     return new _remoteVarWrapper(try! c : owned _remoteVarContainer(inType));
-  }
-
-  private proc remoteWrapperTypeForIR(value) type {
-    var arr = value;
-    return owned _remoteVarContainer(arr.type);
-  }
-
-  @unstable("remote variables are unstable")
-  inline proc chpl__buildRemoteWrapper(loc: locale, value: _iteratorRecord) {
-    type wrapperType = remoteWrapperTypeForIR(value);
-    var c: wrapperType?;
-    on loc {
-      c = new _remoteVarContainer(value);
-    }
-    return new _remoteVarWrapper(try! c : wrapperType);
   }
 
 }

--- a/test/gpu/native/errors/assertOnGpuNoLoops.good
+++ b/test/gpu/native/errors/assertOnGpuNoLoops.good
@@ -1,1 +1,2 @@
 assertOnGpuNoLoops.chpl:3: error: Found GPU attributes on a variable declaration, but no subexpression to apply them to
+assertOnGpuNoLoops.chpl:3: note: GPU attributes on variable declarations are applied to loop expressions and promoted function calls in the variable's initializer

--- a/test/variables/remote/init-on-target.chpl
+++ b/test/variables/remote/init-on-target.chpl
@@ -1,0 +1,31 @@
+class C { var x: int; }
+
+proc doSomethingOwnedC() {
+  writeln("Am I running on the last locale? ", here == Locales.last);
+  return new owned C(42);
+}
+
+proc doSomethingSharedC() {
+  writeln("Am I running on the last locale? ", here == Locales.last);
+  return new shared C(42);
+}
+
+proc doSomethingInt() {
+  writeln("Am I running on the last locale? ", here == Locales.last);
+  return 42;
+}
+
+on Locales.last var myOwnedClassVar = doSomethingOwnedC();
+writeln(myOwnedClassVar);
+writeln(myOwnedClassVar.locale == Locales.last);
+
+// perform a copy to make sure that the actual heap value in the shared
+// wrapper is on the last locale
+on Locales.last var mySharedClassVar = doSomethingSharedC();
+writeln(mySharedClassVar);
+var copy = mySharedClassVar;
+writeln(copy.locale == Locales.last);
+
+on Locales.last var myIntVar = doSomethingInt();
+writeln(myIntVar);
+writeln(myIntVar.locale == Locales.last);

--- a/test/variables/remote/init-on-target.good
+++ b/test/variables/remote/init-on-target.good
@@ -1,0 +1,9 @@
+Am I running on the last locale? true
+{x = 42}
+true
+Am I running on the last locale? true
+{x = 42}
+true
+Am I running on the last locale? true
+42
+true

--- a/test/variables/remote/on-non-locale.bad
+++ b/test/variables/remote/on-non-locale.bad
@@ -1,8 +1,7 @@
-on-non-locale.chpl:2: error: unresolved call 'chpl__buildRemoteWrapper(int(64), 42)'
+on-non-locale.chpl:2: error: unresolved call 'chpl__buildRemoteWrapper(int(64), _tr_chpl__thunk3)'
 $CHPL_HOME/modules/internal/ChapelRemoteVars.chpl:nnnn: note: this candidate did not match: chpl__buildRemoteWrapper(loc: locale, type inType)
 on-non-locale.chpl:2: note: because actual argument #1 with type 'int(64)'
 $CHPL_HOME/modules/internal/ChapelRemoteVars.chpl:nnnn: note: is passed to formal 'loc: locale'
 on-non-locale.chpl:2: note: other candidates are:
-$CHPL_HOME/modules/internal/ChapelRemoteVars.chpl:nnnn: note:   chpl__buildRemoteWrapper(loc: locale, in value: ?t)
-$CHPL_HOME/modules/internal/ChapelRemoteVars.chpl:nnnn: note:   chpl__buildRemoteWrapper(loc: locale, value: _iteratorRecord)
-$CHPL_HOME/modules/internal/ChapelRemoteVars.chpl:nnnn: note:   chpl__buildRemoteWrapper(loc: locale, type inType, in value: inType)
+$CHPL_HOME/modules/internal/ChapelRemoteVars.chpl:nnnn: note:   chpl__buildRemoteWrapper(loc: locale, in tr: _thunkRecord)
+$CHPL_HOME/modules/internal/ChapelRemoteVars.chpl:nnnn: note:   chpl__buildRemoteWrapper(loc: locale, type inType, in tr: _thunkRecord)


### PR DESCRIPTION
This PR builds (and depends on) on top of my thunks PR (https://github.com/chapel-lang/chapel/pull/25387) to ensure that initialization of remote variables occurs on the target locale. Thus:

```Chapel
class C{}

proc doStuff() {
  writeln("On locale: ", here);
  return new C();
}

on Locales[1] var myVar = doStuff();
```

Will print `On locale: LOCALE1` and allocate `C` on `Locales[1]` as well. This makes the behavior match the loop expression case, and closes https://github.com/chapel-lang/chapel/issues/25298.

This PR adds test for non-array arguments executing on the target locale, whereas existing GPU tests (which were previously exercising a special case) will serve to continue testing that loop expressions etc. execute on the target locale.

Reviewed by @brandon-neth -- thanks!

## Testing
- [x] paratest
- [x] `test/gpu/native`