### PR TITLE
Correctly emit error for ambiguity between local var and parenless method

### DIFF
--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2673,7 +2673,6 @@ std::vector<BorrowedIdsWithName> Resolver::lookupIdentifier(
   }
 
   bool resolvingCalledIdent = nearestCalledExpression() == ident;
-
   LookupConfig config = IDENTIFIER_LOOKUP_CONFIG;
   if (!resolvingCalledIdent) config |= LOOKUP_INNERMOST;
 
@@ -2975,8 +2974,10 @@ void Resolver::resolveIdentifier(const Identifier* ident,
       inScope->lookupInScope(ident->name(), redeclarations, IdAndFlags::Flags(),
                              IdAndFlags::FlagSet());
       if (!redeclarations.empty()) {
-        context->error(ident, "parenless proc redeclares the field '%s'",
-                       ident->name().c_str());
+        bool resolvingCalledIdent = nearestCalledExpression() == ident;
+        LookupConfig config = IDENTIFIER_LOOKUP_CONFIG;
+        if (!resolvingCalledIdent) config |= LOOKUP_INNERMOST;
+        issueAmbiguityErrorIfNeeded(ident, inScope, receiverScopes, config);
       } else {
         // Save result if successful
         if (handleResolvedCallWithoutError(result, ident, ci, c) &&

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2971,7 +2971,6 @@ void Resolver::resolveIdentifier(const Identifier* ident,
       auto c = resolveGeneratedCall(context, ident, ci, inScopes);
       // Ensure we error out for redeclarations within the method itself,
       // which resolution with an implicit 'this' currently does not catch.
-      // TODO: Also catch redeclarations of formal names.
       std::vector<BorrowedIdsWithName> redeclarations;
       inScope->lookupInScope(ident->name(), redeclarations, IdAndFlags::Flags(),
                              IdAndFlags::FlagSet());

--- a/frontend/test/resolution/testMethodFieldAccess.cpp
+++ b/frontend/test/resolution/testMethodFieldAccess.cpp
@@ -749,7 +749,7 @@ static void testExample5a() {
     std::ignore = resolveConcreteFunction(context, methodId);
 
     assert(guard.numErrors() == 1);
-    assert(guard.error(0)->message() == "'foo' is ambiguous");
+    assert(guard.error(0)->type() == ErrorType::AmbiguousIdentifier);
 
     guard.clearErrors();
   }


### PR DESCRIPTION
Correctly emit an ambiguity error (rather than redeclaration error) in the case of ambiguity between a local variable and a parenless method declared within a method.

Also adds a test that an ambiguity error is emitted.

Follow up to https://github.com/chapel-lang/chapel/pull/25231 which incorrectly made this a redeclaration. Per explanation in https://github.com/chapel-lang/chapel/issues/25376#issuecomment-2197428093.

[reviewer info placeholder]

Testing:
- [x] dyno tests