### PR TITLE
Remove unused variable

### DIFF
--- a/frontend/lib/parsing/parser-error-classes-list.cpp
+++ b/frontend/lib/parsing/parser-error-classes-list.cpp
@@ -721,11 +721,9 @@ void ErrorAmbiguousMainModule::write(ErrorWriterBase& wr) const {
              "unknown main module due to multiple command line modules");
   wr.note(loc, "add a 'proc main' or use '--main-module'");
   wr.message("");
-  size_t i = 0;
   for (auto mod : modules) {
     wr.note(locationOnly(mod), "'module ", mod->name(), "' could be the main module");
     wr.codeForDef(mod);
-    i++;
   }
 }
 void ErrorUnknownMainModule::write(ErrorWriterBase& wr) const {


### PR DESCRIPTION
Follow-up to PR #25125 to remove an unused variable that causes problems when building the compiler with `clang`.

Reviewed by @riftEmber - thanks!