### PR TITLE
Fixes to nightly EX perf testing script

### DIFF
--- a/util/cron/test-perf.hpe-cray-ex.ofi.bash
+++ b/util/cron/test-perf.hpe-cray-ex.ofi.bash
@@ -4,7 +4,13 @@
 
 CWD=$(cd $(dirname $0) ; pwd)
 
-source $CWD/common.bash
+export CHPL_TEST_PERF_SUBDIR="hpe-cray-ex"
+export CHPL_TEST_PERF_CONFIG_NAME='16-node-hpe-cray-ex'
+
+source $CWD/common-perf.bash
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.hpe-cray-ex.ofi"
+
 source $CWD/common-ofi.bash || \
   ( echo "Could not set up comm=ofi testing." && exit 1 )
 source $CWD/common-hpe-cray-ex.bash
@@ -12,12 +18,11 @@ source $CWD/common-hpe-cray-ex.bash
 export CHPL_RT_COMM_OFI_EXPECTED_PROVIDER="cxi"
 export CHPL_RT_MAX_HEAP_SIZE=16g
 
-export CHPL_TEST_PERF_SUBDIR="hpe-cray-ex"
-export CHPL_TEST_PERF_CONFIG_NAME='16-node-hpe-cray-ex'
-export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.hpe-cray-ex.ofi"
-
 nightly_args="${nightly_args} -no-buildcheck"
 perf_args="-numtrials 1"
 perf_hpe_cray_ex_args="-startdate 06/25/24"
+
+# To use while setting up job for testing
+export CHPL_NIGHTLY_TEST_DIRS="release/examples/benchmarks/hpcc"
 
 $CWD/nightly -cron ${perf_args} ${perf_hpe_cray_ex_args} ${nightly_args}

--- a/util/cron/test-perf.hpe-cray-ex.ofi.bash
+++ b/util/cron/test-perf.hpe-cray-ex.ofi.bash
@@ -19,7 +19,7 @@ export CHPL_RT_COMM_OFI_EXPECTED_PROVIDER="cxi"
 export CHPL_RT_MAX_HEAP_SIZE=16g
 
 nightly_args="${nightly_args} -no-buildcheck"
-perf_args="-numtrials 1"
+perf_args="-performance -numtrials 1"
 perf_hpe_cray_ex_args="-startdate 06/25/24"
 
 # To use while setting up job for testing

--- a/util/cron/test-perf.hpe-cray-ex.ofi.bash
+++ b/util/cron/test-perf.hpe-cray-ex.ofi.bash
@@ -22,7 +22,4 @@ nightly_args="${nightly_args} -no-buildcheck"
 perf_args="-performance -numtrials 1"
 perf_hpe_cray_ex_args="-startdate 06/25/24"
 
-# To use while setting up job for testing
-export CHPL_NIGHTLY_TEST_DIRS="release/examples/benchmarks/hpcc"
-
 $CWD/nightly -cron ${perf_args} ${perf_hpe_cray_ex_args} ${nightly_args}


### PR DESCRIPTION
There were a few issues with the previous PR to add nightly perf testing for an HPE Cray EX machine (#25375). This PR resolves them.  Specifically:

- Need to pass `--performance` to nightly
- Need to source `common-perf.bash` to set some environment variables.

Testing done: I've tried explicitly running this script by having the Jenkin's job pull from the branch on my repos and it appears to work.