### PR TITLE
Avoid ambiguity warning for bundled modules

### DIFF
--- a/frontend/include/chpl/util/filesystem.h
+++ b/frontend/include/chpl/util/filesystem.h
@@ -20,6 +20,8 @@
 #ifndef CHPL_UTIL_FILESYSTEM_H
 #define CHPL_UTIL_FILESYSTEM_H
 
+#include "chpl/framework/UniqueString.h"
+
 #include "llvm/Config/llvm-config.h"
 
 #include "llvm/Support/ErrorOr.h"
@@ -133,6 +135,17 @@ deduplicateSamePaths(const std::vector<std::string>& paths);
   Removes any number of leading ./ from 'path'.
  */
 std::string cleanLocalPath(std::string path);
+
+/**
+  Returns 'true' if 'filepath' refers to a file contained in 'dir'.
+  If dirPath is "", returns false. Use "." for the current dir.
+ */
+bool filePathInDirPath(llvm::StringRef filePath, llvm::StringRef dirPath);
+/**
+  Returns 'true' if 'filepath' refers to a file contained in 'dir'
+  If dirPath is "", returns false. Use "." for the current dir.
+ */
+bool filePathInDirPath(UniqueString filePath, UniqueString dirPath);
 
 #if LLVM_VERSION_MAJOR >= 13
 /**

--- a/frontend/include/chpl/util/filesystem.h
+++ b/frontend/include/chpl/util/filesystem.h
@@ -118,8 +118,10 @@ std::string getExecutablePath(const char* argv0, void* MainExecAddr);
 /**
   Compare two paths to see if they point to the same filesystem object.
   Utilizes llvm::sys::fs:equivalent to do the comparison.
+
+  Returns false if either path is "" and both paths are not "".
 */
-bool isSameFile(const llvm::Twine& path1, const llvm::Twine& path2);
+bool isSameFile(llvm::StringRef path1, llvm::StringRef path2);
 
 /**
   Remove duplicate files/directories from a vector of paths.

--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -741,25 +741,25 @@ filePathIsInInternalModule(Context* context, UniqueString filePath) {
   // the command line flag --prepend-internal-module-dir
   auto& prependedPaths = prependedInternalModulePath(context);
   for (auto& path : prependedPaths) {
-    if (filePath.startsWith(path)) return true;
+    if (filePathInDirPath(filePath, path)) return true;
   }
 
   UniqueString prefix = internalModulePath(context);
   if (prefix.isEmpty()) return false;
-  return filePath.startsWith(prefix);
+  return filePathInDirPath(filePath, prefix);
 }
 
 bool
 filePathIsInBundledModule(Context* context, UniqueString filePath) {
   UniqueString prefix = bundledModulePath(context);
-  if (!prefix.isEmpty() && filePath.startsWith(prefix))
+  if (!prefix.isEmpty() && filePathInDirPath(filePath, prefix))
     return true;
 
   for (auto& path : prependedInternalModulePath(context))
-    if (filePath.startsWith(path)) return true;
+    if (filePathInDirPath(filePath, path)) return true;
 
   for (auto& path : prependedStandardModulePath(context))
-    if (filePath.startsWith(path)) return true;
+    if (filePathInDirPath(filePath, path)) return true;
 
   return false;
 }
@@ -770,11 +770,11 @@ filePathIsInStandardModule(Context* context, UniqueString filePath) {
   // the command line flag --prepend-standard-module-dir
   auto& prependedPaths = prependedStandardModulePath(context);
   for (auto& path : prependedPaths) {
-    if (filePath.startsWith(path)) return true;
+    if (filePathInDirPath(filePath, path)) return true;
   }
 
   UniqueString bundled = bundledModulePath(context);
-  if (bundled.isEmpty() || !filePath.startsWith(bundled)) {
+  if (bundled.isEmpty() || !filePathInDirPath(filePath, bundled)) {
     // not a bundled module & not in --prepend-standard-module-dir paths
     return false;
   }
@@ -788,7 +788,8 @@ filePathIsInStandardModule(Context* context, UniqueString filePath) {
   // is a standard module
   auto internal = UniqueString::getConcat(context, bundled.c_str(), "internal");
   auto packages = UniqueString::getConcat(context, bundled.c_str(), "packages");
-  if (filePath.startsWith(internal) || filePath.startsWith(packages)) {
+  if (filePathInDirPath(filePath, internal) ||
+      filePathInDirPath(filePath, packages)) {
     return false;
   }
 

--- a/frontend/lib/util/filesystem.cpp
+++ b/frontend/lib/util/filesystem.cpp
@@ -346,10 +346,8 @@ static bool filePathInDirPath(const char* filePathPtr, size_t filePathLen,
     return false; // documented behavior; use "." for the current dir.
 
   // create SmallVectors for the relevant paths so we can use LLVM Path stuff
-  auto path =
-    llvm::SmallVector<char>(llvm::ArrayRef(filePathPtr, filePathLen));
-  auto dirPath =
-    llvm::SmallVector<char>(llvm::ArrayRef(dirPathPtr, dirPathLen));
+  auto path = llvm::SmallVector<char>(filePathPtr, filePathPtr+filePathLen);
+  auto dirPath = llvm::SmallVector<char>(dirPathPtr, dirPathPtr+dirPathLen);
 
   // set 'path' to filePath without the filename (i.e. the directory)
   auto style = llvm::sys::path::Style::posix;

--- a/frontend/test/util/CMakeLists.txt
+++ b/frontend/test/util/CMakeLists.txt
@@ -18,6 +18,7 @@
 comp_unit_test(testAssertions)
 comp_unit_test(testIteratorAdapters)
 comp_unit_test(testLLVMsupport)
+comp_unit_test(testPathUtils)
 comp_unit_test(testQueryTimingAndTrace)
 comp_unit_test(testQuoteStrings)
 comp_unit_test(testShaFile)

--- a/frontend/test/util/testPathUtils.cpp
+++ b/frontend/test/util/testPathUtils.cpp
@@ -31,10 +31,14 @@ static void testCleanLocalPath() {
   assert(cleanLocalPath("./foo.chpl") == "foo.chpl");
   assert(cleanLocalPath("/foo.chpl") == "/foo.chpl");
   assert(cleanLocalPath("../foo.chpl") == "../foo.chpl");
+  assert(cleanLocalPath(".") == ".");
+  assert(cleanLocalPath("/") == "/");
+  assert(cleanLocalPath("") == "");
 }
 
 static void testPathInDirPath() {
   assert(filePathInDirPath("foo.chpl", ".") == true);
+  assert(filePathInDirPath("foo.chpl", "") == false); // documented
   assert(filePathInDirPath("./foo.chpl", ".") == true);
   assert(filePathInDirPath("./foo.chpl", "./") == true);
   assert(filePathInDirPath("foo.chpl", "/") == false);
@@ -62,6 +66,15 @@ static void testIsSameFile() {
   assert(isSameFile("foo", "./././foo") == true);
   assert(isSameFile("foo", "bar") == false);
   assert(isSameFile("../bar/../baz", "../baz") == true);
+  assert(isSameFile("testPathUtils", "") == false);
+  assert(isSameFile("foo", "") == false);
+  assert(isSameFile("", ".") == false);
+  assert(isSameFile(".", "") == false);
+  assert(isSameFile("", "") == true);
+  assert(isSameFile("/bin", "") == false);
+  assert(isSameFile("/usr/bin", "/usr/bin") == true);
+  assert(isSameFile("/usr/bin", "") == false);
+  assert(isSameFile("/usr/bin", "") == false);
 }
 
 static void checkDeduplicate(std::vector<std::string> input,

--- a/frontend/test/util/testPathUtils.cpp
+++ b/frontend/test/util/testPathUtils.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "chpl/framework/Context.h"
+#include "chpl/util/filesystem.h"
+
+#include <cstring>
+#include <cstdio>
+
+using namespace chpl;
+
+
+static void testCleanLocalPath() {
+  assert(cleanLocalPath("foo.chpl") == "foo.chpl");
+  assert(cleanLocalPath("./foo.chpl") == "foo.chpl");
+  assert(cleanLocalPath("/foo.chpl") == "/foo.chpl");
+  assert(cleanLocalPath("../foo.chpl") == "../foo.chpl");
+}
+
+static void testPathInDirPath() {
+  assert(filePathInDirPath("foo.chpl", ".") == true);
+  assert(filePathInDirPath("./foo.chpl", ".") == true);
+  assert(filePathInDirPath("./foo.chpl", "./") == true);
+  assert(filePathInDirPath("foo.chpl", "/") == false);
+  assert(filePathInDirPath("/foo.chpl", "/") == true);
+  assert(filePathInDirPath("../foo.chpl", "/") == false);
+  assert(filePathInDirPath("../foo.chpl", ".") == false);
+  assert(filePathInDirPath("../foo.chpl", "./") == false);
+  assert(filePathInDirPath("../foo.chpl", "..") == true);
+  assert(filePathInDirPath("../foo.chpl", "../") == true);
+  assert(filePathInDirPath("/dir/foo.chpl", "/dir") == true);
+  assert(filePathInDirPath("/dir/foo.chpl", "/dir/") == true);
+}
+
+static void testIsSameFile() {
+  assert(isSameFile("testPathUtils", "testPathUtils") == true);
+  assert(isSameFile("testPathUtils", "../util/testPathUtils") == true);
+  // also test behavior with files that don't exist
+  assert(isSameFile("foo", "testPathUtils") == false);
+  assert(isSameFile("foo", "foo") == true);
+  assert(isSameFile("foo", "../util/foo") == true);
+  assert(isSameFile("foo", "./././foo") == true);
+  assert(isSameFile("foo", "bar") == false);
+  assert(isSameFile("../bar/../baz", "../baz") == true);
+}
+
+static void checkDeduplicate(std::vector<std::string> input,
+                             std::vector<std::string> expect) {
+  std::vector<std::string> got = deduplicateSamePaths(input);
+
+  if (expect.size() != got.size()) {
+    printf("size mismatch\n");
+    assert(expect.size() == got.size());
+    return;
+  }
+
+  for (size_t i = 0; i < expect.size(); i++) {
+    if (expect[i] != got[i]) {
+      printf("mismatch, expected %s but got %s\n",
+             expect[i].c_str(), got[i].c_str());
+      assert(expect[i] == got[i]);
+    }
+  }
+}
+
+static void testDeduplicateSamePaths() {
+  checkDeduplicate({"foo", "bar", "baz", "foo"}, {"foo", "bar", "baz"});
+  checkDeduplicate({"testPathUtils", "../util/testPathUtils", "foo"},
+                   {"testPathUtils", "foo"});
+  checkDeduplicate({"../baz", "../bar/../baz"},
+                   {"../baz"});
+}
+
+
+int main(int argc, char** argv) {
+  testCleanLocalPath();
+  testPathInDirPath();
+  testIsSameFile();
+  testDeduplicateSamePaths();
+
+  return 0;
+}

--- a/frontend/test/util/testPathUtils.cpp
+++ b/frontend/test/util/testPathUtils.cpp
@@ -46,6 +46,10 @@ static void testPathInDirPath() {
   assert(filePathInDirPath("../foo.chpl", "../") == true);
   assert(filePathInDirPath("/dir/foo.chpl", "/dir") == true);
   assert(filePathInDirPath("/dir/foo.chpl", "/dir/") == true);
+  assert(filePathInDirPath("/a/b/c/d.chpl", "/a") == true);
+  assert(filePathInDirPath("/a/b/c/d.chpl", "/a/") == true);
+  assert(filePathInDirPath("/a/b/c/d.chpl", "/a/b/c/") == true);
+  assert(filePathInDirPath("/aa/foo.chpl", "/a") == false);
 }
 
 static void testIsSameFile() {

--- a/frontend/test/util/testShaFile.cpp
+++ b/frontend/test/util/testShaFile.cpp
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-// TODO: move this file to the util tests
 #include "chpl/framework/Context.h"
 #include "chpl/util/filesystem.h"
 

--- a/test/modules/vass/userInsteadOfStandard/ChapelIO.chpl
+++ b/test/modules/vass/userInsteadOfStandard/ChapelIO.chpl
@@ -53,5 +53,6 @@ use IO;
 
 // function to test if this was the ChapelIO that got used
 proc testchapelio() {
+  compilerWarning("test warning", errorDepth=0);
   writeln("In my ChapelIO!");
 }

--- a/test/modules/vass/userInsteadOfStandard/foo2.good
+++ b/test/modules/vass/userInsteadOfStandard/foo2.good
@@ -1,3 +1,3 @@
-ChapelIO.chpl:11: In function 'serializeDefaultImpl':
-ChapelIO.chpl:11: warning: need '(?)' on the type 'fileWriter' of the formal 'writer' because this type is generic
-foo2.chpl:11: error: done
+ChapelIO.chpl:55: In function 'testchapelio':
+ChapelIO.chpl:56: warning: test warning
+foo2.chpl:1: error: done


### PR DESCRIPTION
Follow-up to PR #25125.

Adjusts getExistingFileInModuleSearchPath to avoid issuing an ambiguity warning for CHPL_LOCALE_MODEL=gpu where it is intentional that

    modules/internal/localeModels/gpu/ChapelGpuSupport.chpl

is used instead of the fallback

    modules/internal/ChapelGpuSupport.chpl

It does that by fixing getExistingFileInModuleSearchPath to avoid the warning if both are bundled modules. However, for this to work in a straightforward manner, I needed also to improve some of the related code, which was not handling cases such as "." being a module search path (because it was using prefix checks rather than something file-path aware).

Reviewed by @dlongnecke-cray - thanks!

- [x] ambiguity warning no longer issued when compiling with CHPL_LOCALE_MODEL=gpu
- [x] full comm=none testing