### PR TITLE
dyno: Add initial support for `_` and de-tupled loop index variables

### DIFF
--- a/frontend/include/chpl/resolution/can-pass.h
+++ b/frontend/include/chpl/resolution/can-pass.h
@@ -234,6 +234,9 @@ class KindProperties {
   /* Set the paramness property to the given one. */
   void setParam(bool isParam);
 
+  /* Set the constness property to the given one. */
+  void setConst(bool isConst);
+
   /* Combine two sets of kind properties into this one. The resulting
      set of properties is compatible with both arguments (e.g. ref + val = val,
      since values can't be made into references).

--- a/frontend/include/chpl/resolution/can-pass.h
+++ b/frontend/include/chpl/resolution/can-pass.h
@@ -204,6 +204,8 @@ CanPassResult canPass(Context* context,
    ref-ness, etc) each of which are processed independently from
    the others. */
 class KindProperties {
+ public:
+  using Kind = types::QualifiedType::Kind;
  private:
   bool isConst = false;
   bool isRef = false;
@@ -226,7 +228,7 @@ class KindProperties {
 
  public:
   /* Decompose a qualified type kind into its properties. */
-  static KindProperties fromKind(types::QualifiedType::Kind kind);
+  static KindProperties fromKind(Kind kind);
 
   /* Set the refness property to the given one. */
   void setRef(bool isRef);
@@ -256,12 +258,16 @@ class KindProperties {
   void strictCombineWith(const KindProperties& other);
 
   /* Combine the properties of two kinds, returning the result as a kind. */
-  static types::QualifiedType::Kind combineKindsMeet(
-      types::QualifiedType::Kind kind1,
-      types::QualifiedType::Kind kind2);
+  static types::QualifiedType::Kind combineKindsMeet(Kind kind1, Kind kind2);
 
   /* Convert the set of kind properties back into a kind. */
   types::QualifiedType::Kind toKind() const;
+
+  /* Add constness to the given kind. */
+  static Kind addConstness(Kind kind);
+
+  /* Add refness to the given kind. */
+  static Kind addRefness(Kind kind);
 
   bool valid() const { return isValid; }
 };

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -2087,8 +2087,13 @@ class ResolvedExpression {
   /** set the toId */
   void setToId(ID toId) { toId_ = toId; }
 
-  /** set the type */
+  /** set the qualified type */
   void setType(const types::QualifiedType& type) { type_ = type; }
+
+  /** set the kind of the qualified type */
+  void setKind(types::QualifiedType::Kind kind) {
+    type_ = { kind, type_.type(), type_.param() };
+  }
 
   /** set the most specific */
   void setMostSpecific(const MostSpecificCandidates& mostSpecific) {

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -4646,6 +4646,9 @@ bool Resolver::enter(const IndexableLoop* loop) {
   if (const Decl* idx = loop->index()) {
     ResolvedExpression& re = byPostorder.byAst(idx);
     re.setType(idxType);
+    if (auto tup = idx->toTupleDecl()) {
+      resolveTupleUnpackDecl(tup, idxType);
+    }
   }
 
   if (auto with = loop->withClause()) {

--- a/frontend/lib/resolution/Resolver.h
+++ b/frontend/lib/resolution/Resolver.h
@@ -442,18 +442,18 @@ struct Resolver {
 
   // e.g. (a, b) = mytuple
   // checks that tuple size matches and that the elements are assignable
-  // saves any '=' called into r.associatedFns
-  void resolveTupleUnpackAssign(ResolvedExpression& r,
+  // saves any '=' called for tuple components as associated actions in
+  // their respective resolved expressions
+  void resolveTupleUnpackAssign(const uast::Tuple* lhsTuple,
                                 const uast::AstNode* astForErr,
-                                const uast::Tuple* lhsTuple,
-                                types::QualifiedType lhsType,
-                                types::QualifiedType rhsType);
+                                const types::QualifiedType& lhsType,
+                                const types::QualifiedType& rhsType);
 
   // helper for resolveTupleDecl
   // e.g. var (a, b) = mytuple
   // checks that tuple size matches and establishes types for a and b
   void resolveTupleUnpackDecl(const uast::TupleDecl* lhsTuple,
-                              types::QualifiedType rhsType);
+                              const types::QualifiedType& rhsType);
 
   // e.g. var (a, b) = mytuple
   void resolveTupleDecl(const uast::TupleDecl* td);

--- a/frontend/lib/resolution/Resolver.h
+++ b/frontend/lib/resolution/Resolver.h
@@ -456,8 +456,9 @@ struct Resolver {
                               types::QualifiedType rhsType);
 
   // e.g. var (a, b) = mytuple
+  void resolveTupleDecl(const uast::TupleDecl* td);
   void resolveTupleDecl(const uast::TupleDecl* td,
-                        const types::Type* useType);
+                        types::QualifiedType useType);
 
   void validateAndSetToId(ResolvedExpression& r,
                           const uast::AstNode* exr,

--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -1174,6 +1174,20 @@ types::QualifiedType::Kind KindProperties::combineKindsMeet(
   return kp1.toKind();
 }
 
+QualifiedType::Kind
+KindProperties::addConstness(QualifiedType::Kind kind) {
+  auto kp = KindProperties::fromKind(kind);
+  kp.setConst(true);
+  return kp.toKind();
+}
+
+QualifiedType::Kind
+KindProperties::addRefness(QualifiedType::Kind kind) {
+  auto kp = KindProperties::fromKind(kind);
+  kp.setRef(true);
+  return kp.toKind();
+}
+
 QualifiedType::Kind KindProperties::toKind() const {
   if (!isValid) return QualifiedType::UNKNOWN;
   if (isType) return QualifiedType::TYPE;

--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -1116,6 +1116,10 @@ void KindProperties::setParam(bool isParam) {
   this->isParam = isParam;
 }
 
+void KindProperties::setConst(bool isConst) {
+  this->isConst = isConst;
+}
+
 bool KindProperties::checkValidCombine(const KindProperties& other) const {
   if (!isValid || !other.isValid) {
     return false;

--- a/frontend/lib/resolution/scope-types.cpp
+++ b/frontend/lib/resolution/scope-types.cpp
@@ -278,10 +278,6 @@ Scope::Scope(Context* context,
   if (isMethodScope) {         flags |= METHOD_SCOPE; }
   if (containsExternBlock) {   flags |= CONTAINS_EXTERN_BLOCK; }
   flags_ = flags;
-
-  // Remove the 'throwaway' variable '_' from any scope that contains it.
-  auto it = declared_.find(USTR("_"));
-  if (it != declared_.end()) declared_.erase(it);
 }
 
 void Scope::addBuiltin(UniqueString name) {

--- a/frontend/lib/resolution/scope-types.cpp
+++ b/frontend/lib/resolution/scope-types.cpp
@@ -278,6 +278,10 @@ Scope::Scope(Context* context,
   if (isMethodScope) {         flags |= METHOD_SCOPE; }
   if (containsExternBlock) {   flags |= CONTAINS_EXTERN_BLOCK; }
   flags_ = flags;
+
+  // Remove the 'throwaway' variable '_' from any scope that contains it.
+  auto it = declared_.find(USTR("_"));
+  if (it != declared_.end()) declared_.erase(it);
 }
 
 void Scope::addBuiltin(UniqueString name) {

--- a/frontend/test/resolution/testTuples.cpp
+++ b/frontend/test/resolution/testTuples.cpp
@@ -900,9 +900,9 @@ static void test23() {
 
   auto m = resolveTypesOfVariables(context, program, { "x", "y" });
   assert(!guard.realizeErrors());
-  assert(m["x"].kind() == QualifiedType::INDEX);
+  assert(m["x"].kind() == QualifiedType::CONST_VAR);
   assert(m["x"].type()->isIntType());
-  assert(m["y"].kind() == QualifiedType::INDEX);
+  assert(m["y"].kind() == QualifiedType::CONST_VAR);
   assert(m["y"].type()->isRecordType());
 }
 
@@ -921,7 +921,7 @@ static void test24() {
 
   auto qt = resolveTypeOfVariable(context, program, "x");
   assert(!guard.realizeErrors());
-  assert(qt.kind() == QualifiedType::INDEX);
+  assert(qt.kind() == QualifiedType::CONST_VAR);
   assert(qt.type()->isIntType());
 }
 
@@ -946,9 +946,9 @@ static void test25() {
 
   auto m = resolveTypesOfVariables(context, program, { "i", "j", "z" });
   assert(!guard.realizeErrors());
-  assert(m["i"].kind() == QualifiedType::INDEX);
+  assert(m["i"].kind() == QualifiedType::CONST_VAR);
   assert(m["i"].type()->isIntType());
-  assert(m["j"].kind() == QualifiedType::INDEX);
+  assert(m["j"].kind() == QualifiedType::CONST_VAR);
   assert(m["j"].type()->isIntType());
   assert(m["z"].kind() == QualifiedType::VAR);
   assert(m["z"].type()->isIntType());

--- a/frontend/test/resolution/testTuples.cpp
+++ b/frontend/test/resolution/testTuples.cpp
@@ -846,7 +846,7 @@ static void testTupleGeneric() {
 }
 
 static void test21() {
-  printf("test21\n");
+  printf("%s\n", __FUNCTION__);
   Context ctx;
   auto context = &ctx;
   ErrorGuard guard(context);
@@ -860,14 +860,23 @@ static void test21() {
     (x, _) = foo();
     )"""";
 
-  auto qt = resolveQualifiedTypeOfX(context, program);
+  auto xQt = resolveQualifiedTypeOfX(context, program);
   assert(!guard.realizeErrors());
-  assert(qt.kind() == QualifiedType::VAR);
-  assert(qt.type()->isRealType());
+  assert(xQt.kind() == QualifiedType::VAR);
+  assert(xQt.type()->isRealType());
+
+  // Get the type of the '(x, _)' tuple itself.
+  auto mod = parseModule(context, program);
+  auto& rr = resolveModule(context, mod->id());
+  auto astTup = mod->stmt(4)->toCall()->actual(0);
+  assert(astTup->isTuple());
+  auto& qtTup = rr.byAst(astTup).type();
+  assert(qtTup.kind() == QualifiedType::CONST_VAR);
+  assert(qtTup.type()->isTupleType());
 }
 
 static void test22() {
-  printf("test22\n");
+  printf("%s\n", __FUNCTION__);
   Context ctx;
   auto context = &ctx;
   ErrorGuard guard(context);
@@ -886,7 +895,7 @@ static void test22() {
 }
 
 static void test23() {
-  printf("test23\n");
+  printf("%s\n", __FUNCTION__);
   Context ctx;
   auto context = &ctx;
   ErrorGuard guard(context);
@@ -904,10 +913,18 @@ static void test23() {
   assert(m["x"].type()->isIntType());
   assert(m["y"].kind() == QualifiedType::CONST_VAR);
   assert(m["y"].type()->isRecordType());
+
+  auto mod = parseModule(context, program);
+  auto& rr = resolveModule(context, mod->id());
+  auto astTup = mod->stmt(2)->toIndexableLoop()->index();
+  assert(astTup->isTupleDecl());
+  auto& qtTup = rr.byAst(astTup).type();
+  assert(qtTup.kind() == QualifiedType::CONST_VAR);
+  assert(qtTup.type()->isTupleType());
 }
 
 static void test24() {
-  printf("test24\n");
+  printf("%s\n", __FUNCTION__);
   Context ctx;
   auto context = &ctx;
   ErrorGuard guard(context);
@@ -927,7 +944,7 @@ static void test24() {
 
 // This is private issue #6382.
 static void test25() {
-  printf("test25\n");
+  printf("%s\n", __FUNCTION__);
   Context ctx;
   auto context = &ctx;
   ErrorGuard guard(context);
@@ -952,6 +969,136 @@ static void test25() {
   assert(m["j"].type()->isIntType());
   assert(m["z"].kind() == QualifiedType::VAR);
   assert(m["z"].type()->isIntType());
+}
+
+static void test26() {
+  printf("%s\n", __FUNCTION__);
+  Context ctx;
+  auto context = &ctx;
+  ErrorGuard guard(context);
+
+  std::string program =
+    R""""(
+    var g: (int, int);
+    iter myIter() ref: (int, int) { yield g; }
+
+    for (i, j) in myIter() {
+      var z = i;
+    }
+    )"""";
+
+  // The entire tuple (i, j) is itself a 'REF' tuple.
+  auto mod = parseModule(context, program);
+  auto& rr = resolveModule(context, mod->id());
+  auto astTup = mod->stmt(2)->toIndexableLoop()->index();
+  assert(astTup->isTupleDecl());
+  auto& qtTup = rr.byAst(astTup).type();
+  assert(qtTup.kind() == QualifiedType::REF);
+  assert(qtTup.type()->isTupleType());
+
+  // The de-tupled components still maintain their 'REF'ness.
+  auto m = resolveTypesOfVariables(context, program, { "i", "j", "z" });
+  assert(!guard.realizeErrors());
+  assert(m["i"].kind() == QualifiedType::REF);
+  assert(m["i"].type()->isIntType());
+  assert(m["j"].kind() == QualifiedType::REF);
+  assert(m["j"].type()->isIntType());
+  assert(m["z"].kind() == QualifiedType::VAR);
+  assert(m["z"].type()->isIntType());
+}
+
+static void test27() {
+  printf("%s\n", __FUNCTION__);
+  Context ctx;
+  auto context = &ctx;
+  ErrorGuard guard(context);
+
+  std::string program =
+    R""""(
+    var g: (int, int);
+    iter myIter() const ref: (int, int) { yield g; }
+
+    for (i, j) in myIter() {
+      var z = i;
+    }
+    )"""";
+
+  // The entire tuple (i, j) is itself a 'REF' tuple.
+  auto mod = parseModule(context, program);
+  auto& rr = resolveModule(context, mod->id());
+  auto astTup = mod->stmt(2)->toIndexableLoop()->index();
+  assert(astTup->isTupleDecl());
+  auto& qtTup = rr.byAst(astTup).type();
+  assert(qtTup.kind() == QualifiedType::CONST_REF);
+  assert(qtTup.type()->isTupleType());
+
+  // The de-tupled components still maintain their 'REF'ness.
+  auto m = resolveTypesOfVariables(context, program, { "i", "j", "z" });
+  assert(!guard.realizeErrors());
+  assert(m["i"].kind() == QualifiedType::CONST_REF);
+  assert(m["i"].type()->isIntType());
+  assert(m["j"].kind() == QualifiedType::CONST_REF);
+  assert(m["j"].type()->isIntType());
+  assert(m["z"].kind() == QualifiedType::VAR);
+  assert(m["z"].type()->isIntType());
+}
+
+static void test28() {
+  printf("%s\n", __FUNCTION__);
+  Context ctx;
+  auto context = &ctx;
+  ErrorGuard guard(context);
+
+  std::string program =
+    R""""(
+    var g: (int, int);
+    ref (a, b) = g;
+    )"""";
+
+  // The entire tuple (i, j) is itself a 'REF' tuple.
+  auto mod = parseModule(context, program);
+  auto& rr = resolveModule(context, mod->id());
+  auto astTup = mod->stmt(1);
+  assert(astTup->isTupleDecl());
+  auto& qtTup = rr.byAst(astTup).type();
+  assert(qtTup.kind() == QualifiedType::REF);
+  assert(qtTup.type()->isTupleType());
+
+  // The de-tupled components still maintain their 'REF'ness.
+  auto m = resolveTypesOfVariables(context, program, { "a", "b" });
+  assert(!guard.realizeErrors());
+  assert(m["a"].kind() == QualifiedType::REF);
+  assert(m["a"].type()->isIntType());
+  assert(m["b"].kind() == QualifiedType::REF);
+  assert(m["b"].type()->isIntType());
+}
+
+static void test29() {
+  printf("%s\n", __FUNCTION__);
+  Context ctx;
+  auto context = &ctx;
+  ErrorGuard guard(context);
+
+  std::string program =
+    R""""(
+    var g: (int, int);
+    const ref (a, b) = g;
+    )"""";
+
+  auto mod = parseModule(context, program);
+  auto& rr = resolveModule(context, mod->id());
+  auto astTup = mod->stmt(1);
+  assert(astTup->isTupleDecl());
+  auto& qtTup = rr.byAst(astTup).type();
+  assert(qtTup.kind() == QualifiedType::CONST_REF);
+  assert(qtTup.type()->isTupleType());
+
+  auto m = resolveTypesOfVariables(context, program, { "a", "b" });
+  assert(!guard.realizeErrors());
+  assert(m["a"].kind() == QualifiedType::CONST_REF);
+  assert(m["a"].type()->isIntType());
+  assert(m["b"].kind() == QualifiedType::CONST_REF);
+  assert(m["b"].type()->isIntType());
 }
 
 int main() {
@@ -982,6 +1129,10 @@ int main() {
   test23();
   test24();
   test25();
+  test26();
+  test27();
+  test28();
+  test29();
 
   return 0;
 }

--- a/frontend/test/test-resolution.cpp
+++ b/frontend/test/test-resolution.cpp
@@ -244,6 +244,13 @@ resolveTypesOfVariablesInit(Context* context,
   return toReturn;
 }
 
+QualifiedType resolveTypeOfVariable(Context* context, std::string program,
+                                    const std::string& variable) {
+  auto m = resolveTypesOfVariables(context, std::move(program), { variable });
+  // If there is no key for 'variable', this constructs an empty value.
+  return m[variable];
+}
+
 void ensureParamInt(const QualifiedType& type, int64_t expectedValue) {
   assert(type.kind() == QualifiedType::PARAM);
   assert(type.type() != nullptr);

--- a/frontend/test/test-resolution.cpp
+++ b/frontend/test/test-resolution.cpp
@@ -45,9 +45,17 @@ QualifiedType
 resolveQualifiedTypeOfX(Context* context, std::string program) {
   auto m = parseModule(context, std::move(program));
   assert(m->numStmts() > 0);
-  const Variable* x = m->stmt(m->numStmts()-1)->toVariable();
+  // Walk backwards and find the first variable named 'x'.
+  const Variable* x = nullptr;
+  for (int i = m->numStmts() - 1; i >= 0; i--) {
+    if (auto v = m->stmt(i)->toVariable()) {
+      if (v->name() == "x") {
+        x = v;
+        break;
+      }
+    }
+  }
   assert(x);
-  assert(x->name() == "x");
 
   const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
 

--- a/frontend/test/test-resolution.h
+++ b/frontend/test/test-resolution.h
@@ -66,6 +66,9 @@ const Variable* findVariable(const ModuleVec& vec, const char* name);
 std::unordered_map<std::string, QualifiedType>
 resolveTypesOfVariables(Context* context, std::string program, const std::vector<std::string>& variables);
 
+QualifiedType resolveTypeOfVariable(Context* context, std::string program,
+                                    const std::string& variable);
+
 std::unordered_map<std::string, QualifiedType>
 resolveTypesOfVariablesInit(Context* context, std::string program, const std::vector<std::string>& variables);
 


### PR DESCRIPTION
This PR adds support for `_` throwaway variables, de-tupled loop index variables e.g., `for (i, _) in foo() do;`, and `ref` tuples.