### PR TITLE
Fix graphs for multi-locale playground

### DIFF
--- a/util/cron/test-perf.hpe-apollo-hdr.gasnet-ibv.playground.bash
+++ b/util/cron/test-perf.hpe-apollo-hdr.gasnet-ibv.playground.bash
@@ -47,4 +47,4 @@ perf_args="-performance-description $SHORT_NAME -perflabel ml-"
 perf_args="${perf_args} -performance-configs gn-ibv-large:v,gn-ibv-fast:v,$SHORT_NAME:v -sync-dir-suffix $SHORT_NAME"
 perf_args="${perf_args} -numtrials 1 -startdate $START_DATE"
 
-$CWD/nightly -cron ${perf_args} ${perf_hpe_apollo_args} ${nightly_args}
+$CWD/nightly -cron ${perf_args} ${nightly_args}


### PR DESCRIPTION
Fix the generated graphs from the multi-locale playground to use the correct configs.

Removed perf_hpe_apollo_args, which should not be in the arg list

[Not reviewed - trivial]