### PR TITLE
Annotations from week of 6/27

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -573,6 +573,12 @@ all:
   06/03/24:
     - text: Stop setting CHPL_TARGET_CPU (#25161)
       config: chapcs
+  06/12/24:
+    - text: Add support for GASNet PSHM and send progress thread (#25140)
+      config: 16-node-apollo-hdr
+  06/17/24:
+    - text: Revert to default GASNET_SND_THREAD=0 (#25307)
+      config: 16-node-apollo-hdr
 
 # End all
 
@@ -2455,6 +2461,8 @@ arkouda: &arkouda-base
     - Closes 3089 Avoid OOM Crashes caused due to in intents on makeDistArray (Bears-R-Us/arkouda#3163)
   05/14/24:
     - Dataframe Indexing (Bears-R-Us/arkouda#3109)
+  06/14/24:
+    - Reverts DataFrame Indexing Changes (Bears-R-Us/arkouda#3323)
 
 arkouda-string:
   <<: *arkouda-base

--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -2464,7 +2464,7 @@ arkouda: &arkouda-base
   06/14/24:
     - Reverts DataFrame Indexing Changes (Bears-R-Us/arkouda#3323)
   6/25/24:
-    - Closes 3334, 3351: Simplify server side string code and added fixed length (Bears-R-Us/arkouda#3335)
+    - Closes 3334, 3351 Simplify server side string code and added fixed length (Bears-R-Us/arkouda#3335)
   6/27/24:
     - Remove number of files multiplication for IO benchmark (Bears-R-Us/arkouda#3368)
 

--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -2463,6 +2463,11 @@ arkouda: &arkouda-base
     - Dataframe Indexing (Bears-R-Us/arkouda#3109)
   06/14/24:
     - Reverts DataFrame Indexing Changes (Bears-R-Us/arkouda#3323)
+  6/25/24:
+    - Closes 3334, 3351: Simplify server side string code and added fixed length (Bears-R-Us/arkouda#3335)
+  6/27/24:
+    - Remove number of files multiplication for IO benchmark (Bears-R-Us/arkouda#3368)
+
 
 arkouda-string:
   <<: *arkouda-base

--- a/util/test/check_annotations.py
+++ b/util/test/check_annotations.py
@@ -92,7 +92,8 @@ def check_configs(ann_data):
     """Check that all the configs used in the annotation file are 'known'"""
     known_configs = {'shootout', 'chap03', 'chap04', 'bradc-lnx', 'chapcs',
                      '16-node-xc', '1-node-xc', '16-node-cs', '16-node-cs-hdr',
-                     'chapcs.comm-counts', '1-node-p100', '1-node-mi60'}
+                     'chapcs.comm-counts', '1-node-p100', '1-node-mi60',
+                     '16-node-apollo-hdr'}
     for graph in ann_data:
         for _, annotations in ann_data[graph].items():
             for ann in annotations:


### PR DESCRIPTION
Annotations ---

- (#25140) introduced shared-memory bypass behavior that caused several perf. regressions, (#25307) helped resolve that somewhat by reverting some behavior.

Arkouda annotations:

- (Bears-R-Us/arkouda#3323) reverted a prior PR that caused a perf regression a dataframe indexing test

- (Bears-R-Us/arkouda#3335) and (Bears-R-Us/arkouda#3368) Annotate for a PR (and the fixing) that incorrectly changed how the number of bytes were calculated for string IO benchmark.