### PR TITLE
Progress non-blocking operations in OFI

### DIFF
--- a/modules/internal/Atomics.chpl
+++ b/modules/internal/Atomics.chpl
@@ -398,6 +398,7 @@ module Atomics {
       this.write(false, order);
     }
 
+    extern proc chpl_comm_ensure_progress(): void;
     /*
        Waits until the stored value is equal to `val`. The implementation may
        yield the running task while waiting.
@@ -405,6 +406,7 @@ module Atomics {
     inline proc const waitFor(val:bool, param order: memoryOrder = memoryOrder.seqCst): void {
       on this {
         while (this.read(order=memoryOrder.relaxed) != val) {
+          chpl_comm_ensure_progress();
           currentTask.yieldExecution();
         }
         chpl_atomic_thread_fence(c_memory_order(order));

--- a/modules/internal/Atomics.chpl
+++ b/modules/internal/Atomics.chpl
@@ -227,7 +227,7 @@ module Atomics {
       return chpl__networkAtomicType(valType);
     }
   }
-  
+
   extern proc chpl_comm_ensure_progress(): void;
 
   pragma "atomic type"

--- a/modules/internal/Atomics.chpl
+++ b/modules/internal/Atomics.chpl
@@ -227,6 +227,8 @@ module Atomics {
       return chpl__networkAtomicType(valType);
     }
   }
+  
+  extern proc chpl_comm_ensure_progress(): void;
 
   pragma "atomic type"
   pragma "ignore noinit"
@@ -398,7 +400,6 @@ module Atomics {
       this.write(false, order);
     }
 
-    extern proc chpl_comm_ensure_progress(): void;
     /*
        Waits until the stored value is equal to `val`. The implementation may
        yield the running task while waiting.

--- a/modules/internal/Atomics.chpl
+++ b/modules/internal/Atomics.chpl
@@ -749,6 +749,7 @@ module Atomics {
     inline proc const waitFor(val:valType, param order: memoryOrder = memoryOrder.seqCst): void {
       on this {
         while (this.read(order=memoryOrder.relaxed) != val) {
+          chpl_comm_ensure_progress();
           currentTask.yieldExecution();
         }
         chpl_atomic_thread_fence(c_memory_order(order));

--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -548,6 +548,12 @@ void chpl_comm_execute_on_fast(c_nodeid_t node, c_sublocid_t subloc,
                                int ln, int32_t fn);
 
 //
+// Ensure that the communication layer makes progress if there are any
+// outstanding non-blocking operations.
+//
+void chpl_comm_ensure_progress(void);
+
+//
 // Hook to ensure remote memory consistency after unordered operations.
 //
 #ifndef CHPL_COMM_IMPL_UNORDERED_TASK_FENCE

--- a/runtime/src/comm/gasnet/comm-gasnet-ex.c
+++ b/runtime/src/comm/gasnet/comm-gasnet-ex.c
@@ -1698,6 +1698,4 @@ void  chpl_comm_execute_on_fast(c_nodeid_t node, c_sublocid_t subloc,
   }
 }
 
-void chpl_comm_ensure_progress(void) {
-  am_poll_try();
-}
+void chpl_comm_ensure_progress(void) { }

--- a/runtime/src/comm/gasnet/comm-gasnet-ex.c
+++ b/runtime/src/comm/gasnet/comm-gasnet-ex.c
@@ -1697,3 +1697,7 @@ void  chpl_comm_execute_on_fast(c_nodeid_t node, c_sublocid_t subloc,
                       /*fast*/ true, /*blocking*/ true);
   }
 }
+
+void chpl_comm_ensure_progress(void) {
+  am_poll_try();
+}

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -1658,3 +1658,7 @@ void  chpl_comm_execute_on_fast(c_nodeid_t node, c_sublocid_t subloc,
                       /*fast*/ true, /*blocking*/ true);
   }
 }
+
+void chpl_comm_ensure_progress(void) {
+  am_poll_try();
+}

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -1659,6 +1659,4 @@ void  chpl_comm_execute_on_fast(c_nodeid_t node, c_sublocid_t subloc,
   }
 }
 
-void chpl_comm_ensure_progress(void) {
-  am_poll_try();
-}
+void chpl_comm_ensure_progress(void) { }

--- a/runtime/src/comm/none/comm-none.c
+++ b/runtime/src/comm/none/comm-none.c
@@ -262,3 +262,5 @@ void chpl_comm_execute_on_fast(c_nodeid_t node, c_sublocid_t subloc,
 
   chpl_ftable_call(fid, arg);
 }
+
+void chpl_comm_ensure_progress(void) { }

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -6231,11 +6231,12 @@ void ofi_put_lowLevel(const void* addr, void* mrDesc, c_nodeid_t node,
                       uint64_t mrRaddr, uint64_t mrKey, size_t size,
                       void* ctx, uint64_t flags,
                       struct perTxCtxInfo_t* tcip) {
-  if (flags == FI_INJECT
-      && size <= ofi_info->tx_attr->inject_size
-      && envInjectRMA) {
-    (void) wrap_fi_inject_write(addr, node, mrRaddr, mrKey, size, tcip);
-  } else if (flags == 0) {
+
+  // Can't inject a buffer that is too large 
+  if ((flags & FI_INJECT) && (size > ofi_info->tx_attr->inject_size)) {
+    flags &= ~FI_INJECT;
+  }
+  if (flags == 0) {
     (void) wrap_fi_write(addr, mrDesc, node, mrRaddr, mrKey, size, ctx, tcip);
   } else {
     (void) wrap_fi_writemsg(addr, mrDesc, node, mrRaddr, mrKey, size, ctx,

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -6033,19 +6033,18 @@ chpl_comm_nb_handle_t rmaPutFn_msgOrdFence(void* myAddr, void* mrDesc,
       && size <= ofi_info->tx_attr->inject_size
       && !blocking && envInjectRMA) {
     //
-    // Special case: write injection has the least latency.  We can use that
-    // if this PUT is non-blocking, its size doesn't exceed the injection
-    // size limit, and we have a bound tx context so we can delay forcing the
+    // Special case: write injection has the least latency.  We can use it if
+    // this PUT is non-blocking, its size doesn't exceed the injection size
+    // limit, and we have a bound tx context so we can delay forcing the
     // memory visibility until later.
     //
     flags = FI_INJECT;
   }
   if (tcip->bound && bitmapTest(tcip->amoVisBitmap, node)) {
     //
-    // Special case: If our last operation was an AMO (which can only
-    // be true with a bound tx context) then we need to do a fenced
-    // PUT to force the AMO to complete before this PUT.  We may still
-    // be able to inject the PUT, though.
+    // Special case: If our last operation was an AMO (which can only be true
+    // with a bound tx context) then we need to do a fenced PUT to force the
+    // AMO to complete before this PUT.
     //
     flags |= FI_FENCE | FI_DELIVERY_COMPLETE;
   }

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -5772,7 +5772,7 @@ void chpl_comm_getput_unordered_task_fence(void) {
 /*
  * Routine for ensuring the current thread's send endpoint is progressed. This
  * should be called when waiting outside the communication layer and there
- * may be outstanding non-blocking operations that are not yet transmitted. 
+ * may be outstanding non-blocking operations that are not yet transmitted.
  */
 void chpl_comm_ensure_progress(void) {
   struct perTxCtxInfo_t* tcip;
@@ -6274,7 +6274,7 @@ void ofi_put_lowLevel(const void* addr, void* mrDesc, c_nodeid_t node,
                       void* ctx, uint64_t flags,
                       struct perTxCtxInfo_t* tcip) {
 
-  // Can't inject a buffer that is too large 
+  // Can't inject a buffer that is too large
   if ((flags & FI_INJECT) && (size > ofi_info->tx_attr->inject_size)) {
     flags &= ~FI_INJECT;
   }

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1022,6 +1022,14 @@ void chpl_comm_init(int *argc_p, char ***argv_p) {
   envUseAmTxCntr = chpl_env_rt_get_bool("COMM_OFI_AM_TX_COUNTER", false);
   envUseAmRxCntr = chpl_env_rt_get_bool("COMM_OFI_AM_RX_COUNTER", false);
 
+  // Temporarily disable completion counters until non-blocking operations
+  // are implemented correctly.
+
+  if (envUseTxCntr || envUseAmTxCntr || envUseAmRxCntr) {
+    chpl_warning("OFI completion counters are currently disabled.", 0, 0);
+    envUseTxCntr = envUseAmTxCntr = envUseAmRxCntr = false;
+  }
+
   envUseCxiHybridMR = chpl_env_rt_get_bool("COMM_OFI_CXI_HYBRID_MR", true);
 
   // TODO: default to false to workaround non-blocking ofi issue

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -7947,3 +7947,5 @@ static void _psv_print(int li, chpl_comm_pstats_t* ps)
 #undef _PSV_PRINT
 }
 #endif
+
+void chpl_comm_ensure_progress(void) { }


### PR DESCRIPTION
Endpoints that have pending non-blocking operations must be progressed while waiting for the operations to complete. Consider non-blocking `on` statements such as those that occur as a result of the `for loc in Locales do on loc` idiom. The compiler-generated code loops through all locales, invokes a non-blocking `on` operation on each one, and issues the next `on` operation before the previous one completes. Upon completion, each `on` statement decrements an atomic counter, on which the main thread waits until the counter drops to zero. The problem is that the main thread does not progress the network stack while waiting on the atomic variable, and as a result the application may come to a halt waiting for the atomic variable to be decremented while there are `on` operations yet to be transmitted.

This PR adds the function `chpl_comm_ensure_progress` that must be called when a task is waiting on a condition outside of the comm layer (e.g., for an atomic counter to drop to zero) and that condition will be made true by a non-blocking communication operation (e.g., a non-blocking `on` statement). This function ensures that the endpoint associated with the task is progressed so that the non-blocking operation is transmitted successfully.

While implementing this PR I cleaned up the interface for non-blocking PUTs to allow them to be progressed once they are implemented properly (currently they are implemented as blocking PUTs, see the `chpl_comm_put_nb` implementation).

Note that this PR only affects the message-order-fence MCM mode using completion queues. I will fix the message-order MCM mode and completion counters in subsequent PRs to keep this one manageable. 

Resolves https://github.com/Cray/chapel-private/issues/6248 and resolves https://github.com/Cray/chapel-private/issues/6249.

Signed-off-by: John H. Hartman <jhh67@users.noreply.github.com>