### PR TITLE
Fix mason spack branch

### DIFF
--- a/test/mason/mason-help-tests/masonHelpTests.good
+++ b/test/mason/mason-help-tests/masonHelpTests.good
@@ -1,6 +1,7 @@
 $ mason new -h
 Usage:
     mason new [options] <project name>
+    mason new                    Starts an interactive session
 
 Options:
     -h, --help                   Display this message

--- a/tools/mason/MasonExternal.chpl
+++ b/tools/mason/MasonExternal.chpl
@@ -24,6 +24,7 @@ const major = spackVersion.major:string;
 const minor = spackVersion.minor:string;
 const spackBranch = 'releases/v' + '.'.join(major, minor);
 const spackDefaultPath = MASON_HOME + "/spack";
+const latestSpackRelease = "v0.22";
 
 use ArgumentParser;
 use FileSystem;
@@ -184,7 +185,7 @@ proc setupSpack() throws {
   const destCLI = MASON_HOME + "/spack/";
   const spackLatestBranch = ' --branch v' + spackVersion.str() + ' ';
   const destPackages = MASON_HOME + "/spack-registry";
-  const spackMasterBranch = ' --branch releases/latest ';
+  const spackMasterBranch = ' --branch releases/' + latestSpackRelease + ' ';
   const statusCLI = cloneSpackRepository(spackLatestBranch, destCLI);
   const statusPackages = cloneSpackRepository(spackMasterBranch, destPackages);
   generateYAML();


### PR DESCRIPTION
Mason's Spack support relied on being able to clone the `releases/latest` branch from[ spack's repo](https://github.com/spack/spack/), but it appears to have been removed with the latest spack release yesterday.

This PR hardcodes the branch to `releases/v0.22` to avoid test failures caused by this problem.

It's possible that the spack developers will reintroduce a `releases/latest` branch soon (not sure if this is something that happened intentionally, or was just missed in their recent release), in which case I will revert this PR.

- [x] mason tests passing