### PR TITLE
Skip these futures when CHPL_COMM != none

### DIFF
--- a/test/types/string/ternaryPlain.future
+++ b/test/types/string/ternaryPlain.future
@@ -1,2 +1,4 @@
 bug: strings in ternary expressions will sometimes segfault
 #25032
+
+When this future is resolved, please remove the .skipif file

--- a/test/types/string/ternaryPlain.skipif
+++ b/test/types/string/ternaryPlain.skipif
@@ -1,0 +1,1 @@
+CHPL_COMM != none

--- a/test/types/string/ternaryPlainRef.future
+++ b/test/types/string/ternaryPlainRef.future
@@ -1,2 +1,4 @@
 bug: strings in ternary expressions will sometimes segfault
 #25032
+
+When this future is resolved, please remove the .skipif file

--- a/test/types/string/ternaryPlainRef.skipif
+++ b/test/types/string/ternaryPlainRef.skipif
@@ -1,0 +1,1 @@
+CHPL_COMM != none

--- a/test/types/string/ternaryReturn.future
+++ b/test/types/string/ternaryReturn.future
@@ -1,2 +1,4 @@
 bug: strings in ternary expressions will sometimes segfault
 #25032
+
+When this future is resolved, please remove the .skipif file

--- a/test/types/string/ternaryReturn.skipif
+++ b/test/types/string/ternaryReturn.skipif
@@ -1,0 +1,1 @@
+CHPL_COMM != none


### PR DESCRIPTION
They appear to not encounter memory issues in those circumstances, so only test them in the scenarios where they fail.

Also update the .future files to indicate that the skipifs should be removed when they are resolved

Verifying a fresh checkout of the tests behave as expected