### PR TITLE
Update the skipifs for these futures to only run with valgrind testing

### DIFF
--- a/test/types/string/ternaryPlain.skipif
+++ b/test/types/string/ternaryPlain.skipif
@@ -1,1 +1,2 @@
-CHPL_COMM != none
+# encounters memory issues, skip everywhere except valgrind
+CHPL_TEST_VGRND_EXE != on

--- a/test/types/string/ternaryPlainRef.skipif
+++ b/test/types/string/ternaryPlainRef.skipif
@@ -1,1 +1,2 @@
-CHPL_COMM != none
+# encounters memory issues, skip everywhere except valgrind
+CHPL_TEST_VGRND_EXE != on

--- a/test/types/string/ternaryReturn.skipif
+++ b/test/types/string/ternaryReturn.skipif
@@ -1,1 +1,2 @@
-CHPL_COMM != none
+# encounters memory issues, skip everywhere except valgrind
+CHPL_TEST_VGRND_EXE != on


### PR DESCRIPTION
The behavior with this test is inconsistent across platforms due to the memory issues encountered, so limit it to only situations where the failure is guaranteed.

Checked the behavior with and without using valgrind