### PR TITLE
Update a chpl-language-server test for additional warning

### DIFF
--- a/tools/chpl-language-server/test/diagnostics.py
+++ b/tools/chpl-language-server/test/diagnostics.py
@@ -53,11 +53,22 @@ async def test_incorrect_cross_file_diagnostics(client: LanguageClient):
     async with source_files(client, A=fileA, B=fileB) as docs:
         await save_file(client, docs("B"), docs("A"))
         assert len(client.diagnostics[docs("A").uri]) == 0
-        assert len(client.diagnostics[docs("B").uri]) == 1
-        assert (
-            "an implicit module named 'B' is being introduced to contain file-scope code"
-            in client.diagnostics[docs("B").uri][0].message
-        )
+        assert len(client.diagnostics[docs("B").uri]) >= 1
+
+        # check if the expected warnings are present
+        foundImplicitModule = False
+        foundSameName = False
+        for d in client.diagnostics[docs("B").uri]:
+            if 'ImplicitFileModule' in d.message:
+                # Warning: [ImplicitFileModule]: an implicit module named 'B'
+                # is being introduced to contain file-scope code
+                foundImplicitModule = True
+            if 'ImplicitModuleSameName' in d.message:
+                # Warning: [ImplicitModuleSameName]: module 'B' has
+                # the same name as the implicit file module
+                foundSameName = True
+
+        assert foundImplicitModule and foundSameName
 
 
 @pytest.mark.asyncio

--- a/tools/chpl-language-server/test/diagnostics.py
+++ b/tools/chpl-language-server/test/diagnostics.py
@@ -53,17 +53,17 @@ async def test_incorrect_cross_file_diagnostics(client: LanguageClient):
     async with source_files(client, A=fileA, B=fileB) as docs:
         await save_file(client, docs("B"), docs("A"))
         assert len(client.diagnostics[docs("A").uri]) == 0
-        assert len(client.diagnostics[docs("B").uri]) >= 1
+        assert len(client.diagnostics[docs("B").uri]) == 2
 
         # check if the expected warnings are present
         foundImplicitModule = False
         foundSameName = False
         for d in client.diagnostics[docs("B").uri]:
-            if 'ImplicitFileModule' in d.message:
+            if "ImplicitFileModule" in d.message:
                 # Warning: [ImplicitFileModule]: an implicit module named 'B'
                 # is being introduced to contain file-scope code
                 foundImplicitModule = True
-            if 'ImplicitModuleSameName' in d.message:
+            if "ImplicitModuleSameName" in d.message:
                 # Warning: [ImplicitModuleSameName]: module 'B' has
                 # the same name as the implicit file module
                 foundSameName = True


### PR DESCRIPTION
Follow-up to PR #25125.

That PR moved "same name as the implicit file module" warning to dyno, so it's now present in the warning output for chpl-language-server. Update the test to reflect that.

Reviewed by @DanilaFe - thanks!

- [x] make test-cls now passes