### PR TITLE
Remove old skipif left over from when this test was a future

### DIFF
--- a/test/expressions/ferguson/if-expr/range-field-ifexpr.skipif
+++ b/test/expressions/ferguson/if-expr/range-field-ifexpr.skipif
@@ -1,2 +1,0 @@
-# returns pointer to local argument, skip everywhere except valgrind
-CHPL_TEST_VGRND_EXE!=on


### PR DESCRIPTION
This test was originally made to only run under valgrind because it ran into issues.  When the test was resolved, we didn't notice it had a skipif so didn't also remove it then.  Remove the skipif now

Verified a fresh checkout behaved as expected