### PR TITLE
skip memleaks job for ConcurrentMap/LockFreeQueue/LockFreeStack

### DIFF
--- a/test/library/packages/ConcurrentMap.skipif
+++ b/test/library/packages/ConcurrentMap.skipif
@@ -7,3 +7,9 @@ CHPL_TARGET_COMPILER==pgi
 CHPL_TARGET_COMPILER==cray-prgenv-cray
 CHPL_TARGET_COMPILER==intel
 CHPL_TARGET_COMPILER==cray-prgenv-intel
+
+# These tests have known memory leaks. To cover this, we have a subset of tests
+# where we explicitly pass '--memLeaks' as an execopt. For other correctness
+# tests, we don't want them to fail in our broader "memory leak" job so we skip
+# when we're running that job.
+CHPL_MEM_LEAK_TESTING==true

--- a/test/library/packages/EpochManager.skipif
+++ b/test/library/packages/EpochManager.skipif
@@ -7,3 +7,9 @@ CHPL_TARGET_COMPILER==pgi
 CHPL_TARGET_COMPILER==cray-prgenv-cray
 CHPL_TARGET_COMPILER==intel
 CHPL_TARGET_COMPILER==cray-prgenv-intel
+
+# These tests have known memory leaks. To cover this, we have a subset of tests
+# where we explicitly pass '--memLeaks' as an execopt. For other correctness
+# tests, we don't want them to fail in our broader "memory leak" job so we skip
+# when we're running that job.
+CHPL_MEM_LEAK_TESTING==true


### PR DESCRIPTION
PR #25392 replaced a set of futures that were locking down that (for ConcurrentMap, LockFreeQueue, and LockFreeStack) we failed with memory leaks (when passing '--memLeaks') with normal correctness tests. To lock down the known memory failures I also created a handful of other tests that lock down the "known leak" when passing in '--memLeaks' by execopt (this is the precedent we have for other known leaks as we have a script that detects such tests).

Anyway, we don't want the pure correctness tests to fail on our memleak job so we should skip them. This PR adjusts the skipif files to do that.