### PR TITLE
Improve error message for generic anonymous functions

### DIFF
--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -2304,6 +2304,9 @@ llvm::SmallVector<std::string, 2> explainGeneric(Type* t) {
       return {"'" + std::string(t->name()) + "' has generic lifetime management"};
     }
   }
+  if (t->symbol->hasFlag(FLAG_ARRAY)) {
+    return {"'" + std::string(t->name()) + "' is an array, which is considered generic due to runtime type information"};
+  }
   if (auto at = toAggregateType(t)) {
     if (at->isGeneric()) {
     llvm::SmallVector<std::string, 2> reasons;

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -2305,7 +2305,7 @@ llvm::SmallVector<std::string, 2> explainGeneric(Type* t) {
     }
   }
   if (t->symbol->hasFlag(FLAG_ARRAY)) {
-    return {"'" + std::string(t->name()) + "' is an array, which is considered generic due to runtime type information"};
+    return {"arrays are considered generic due to runtime type information"};
   }
   if (auto at = toAggregateType(t)) {
     if (at->isGeneric()) {

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -2301,11 +2301,11 @@ const Immediate& getDefaultImmediate(Type* t) {
 llvm::SmallVector<std::string, 2> explainGeneric(Type* t) {
   if (auto clsType = toDecoratedClassType(t)) {
     if (isDecoratorUnknownManagement(clsType->getDecorator())) {
-      return {"'" + std::string(t->name()) + "' has generic lifetime management"};
+      return {"'" + std::string(t->name()) + "' is a class with unknown management"};
     }
   }
   if (t->symbol->hasFlag(FLAG_ARRAY)) {
-    return {"arrays are considered generic due to runtime type information"};
+    return {"it is an array with runtime type information"};
   }
   if (auto at = toAggregateType(t)) {
     if (at->isGeneric()) {

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -2298,6 +2298,30 @@ const Immediate& getDefaultImmediate(Type* t) {
   return *defaultVar->immediate;
 }
 
+llvm::SmallVector<std::string, 2> explainGeneric(Type* t) {
+  if (auto clsType = toDecoratedClassType(t)) {
+    if (isDecoratorUnknownManagement(clsType->getDecorator())) {
+      return {"'" + std::string(t->name()) + "' has generic lifetime management"};
+    }
+  }
+  if (auto at = toAggregateType(t)) {
+    if (at->isGeneric()) {
+    llvm::SmallVector<std::string, 2> reasons;
+      for (auto i = 1; i <= at->numFields(); i++) {
+        auto fieldType = at->getField(i)->type;
+        if (fieldType->symbol && fieldType->symbol->hasFlag(FLAG_GENERIC)) {
+          auto moreReasons = explainGeneric(fieldType);
+          reasons.append(moreReasons.begin(), moreReasons.end());
+        }
+      }
+      if (!reasons.empty()) {
+        return reasons;
+      }
+    }
+  }
+  return {};
+}
+
 // Returns 'true' for types that are the type of numeric literals.
 // e.g. 1 is an 'int', so this function returns 'true' for 'int'.
 // e.g. 0.0 is a 'real', so this function returns 'true' for 'real'.

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -697,6 +697,9 @@ GenRet codegenImmediate(Immediate* i);
 
 const Immediate& getDefaultImmediate(Type* t);
 
+// Returns strings explaining why a type is generic
+llvm::SmallVector<std::string, 2> explainGeneric(Type* t);
+
 
 #define CLASS_ID_TYPE dtInt[INT_SIZE_32]
 #define UNION_ID_TYPE dtInt[INT_SIZE_64]

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -10646,6 +10646,21 @@ static Expr* resolveFunctionCapture(FnSymbol* fn, Expr* use,
                      fn->name);
     }
 
+    for(auto i = 0; i < ft->numFormals(); i++) {
+      auto formal = ft->formal(i);
+      if (formal->isGeneric()) {
+        std::string reason;
+        auto reasons = explainGeneric(formal->type);
+        if (reasons.empty()) {
+          USR_PRINT(use, "the formal '%s' is generic", formal->name);
+        } else {
+          for (auto& r : reasons) {
+            USR_PRINT(use, "the formal '%s' is generic because %s", formal->name, r.c_str());
+          }
+        }
+      }
+    }
+
     // Return a "sink" to handle any "illegal access" errors later.
     return swapInErrorSinkForCapture(ft->kind(), use);
   }

--- a/test/functions/fcf/ErrorArray.chpl
+++ b/test/functions/fcf/ErrorArray.chpl
@@ -1,0 +1,5 @@
+
+var x = proc(x : [1..10] int) : void {
+
+};
+compilerWarning(x.type : string);

--- a/test/functions/fcf/ErrorArray.good
+++ b/test/functions/fcf/ErrorArray.good
@@ -1,3 +1,3 @@
 ErrorArray.chpl:2: error: anonymous proc is generic and cannot be captured
-ErrorArray.chpl:2: note: the formal 'x' is generic because arrays are considered generic due to runtime type information
+ErrorArray.chpl:2: note: the formal 'x' is generic because it is an array with runtime type information
 ErrorArray.chpl:5: warning: proc

--- a/test/functions/fcf/ErrorArray.good
+++ b/test/functions/fcf/ErrorArray.good
@@ -1,0 +1,3 @@
+ErrorArray.chpl:2: error: anonymous proc is generic and cannot be captured
+ErrorArray.chpl:2: note: the formal 'x' is generic because '_array' is an array, which is considered generic due to runtime type information
+ErrorArray.chpl:5: warning: proc

--- a/test/functions/fcf/ErrorArray.good
+++ b/test/functions/fcf/ErrorArray.good
@@ -1,3 +1,3 @@
 ErrorArray.chpl:2: error: anonymous proc is generic and cannot be captured
-ErrorArray.chpl:2: note: the formal 'x' is generic because '_array' is an array, which is considered generic due to runtime type information
+ErrorArray.chpl:2: note: the formal 'x' is generic because arrays are considered generic due to runtime type information
 ErrorArray.chpl:5: warning: proc

--- a/test/functions/fcf/ErrorCaptureGeneric.good
+++ b/test/functions/fcf/ErrorCaptureGeneric.good
@@ -1,5 +1,10 @@
 ErrorCaptureGeneric.chpl:28: error: the proc 'f1' is generic and cannot be captured
+ErrorCaptureGeneric.chpl:28: note: the formal 'x' is generic
 ErrorCaptureGeneric.chpl:29: error: the proc 'f2' is generic and cannot be captured
+ErrorCaptureGeneric.chpl:29: note: the formal 'x' is generic
 ErrorCaptureGeneric.chpl:30: error: the proc 'f3' is generic and cannot be captured
+ErrorCaptureGeneric.chpl:30: note: the formal 'x' is generic
 ErrorCaptureGeneric.chpl:31: error: the proc 'f4' is generic and cannot be captured
+ErrorCaptureGeneric.chpl:31: note: the formal 'A' is generic
+ErrorCaptureGeneric.chpl:31: note: the formal 'B' is generic
 ErrorCaptureGeneric.chpl:33: error: illegal access of procedure

--- a/test/functions/fcf/ErrorGenericClass.chpl
+++ b/test/functions/fcf/ErrorGenericClass.chpl
@@ -1,0 +1,6 @@
+record R {
+	var x : RootClass; // generic 'lifetime'
+}
+
+var x = proc(r : R, x: RootClass) : void { };
+compilerWarning(x.type : string);

--- a/test/functions/fcf/ErrorGenericClass.good
+++ b/test/functions/fcf/ErrorGenericClass.good
@@ -1,0 +1,5 @@
+ErrorGenericClass.chpl:5: warning: need '(?)' on the type 'R' of the formal 'r' because this type is generic
+ErrorGenericClass.chpl:5: error: anonymous proc is generic and cannot be captured
+ErrorGenericClass.chpl:5: note: the formal 'r' is generic because 'RootClass' has generic lifetime management
+ErrorGenericClass.chpl:5: note: the formal 'x' is generic because 'RootClass' has generic lifetime management
+ErrorGenericClass.chpl:6: warning: proc

--- a/test/functions/fcf/ErrorGenericClass.good
+++ b/test/functions/fcf/ErrorGenericClass.good
@@ -1,5 +1,5 @@
 ErrorGenericClass.chpl:5: warning: need '(?)' on the type 'R' of the formal 'r' because this type is generic
 ErrorGenericClass.chpl:5: error: anonymous proc is generic and cannot be captured
-ErrorGenericClass.chpl:5: note: the formal 'r' is generic because 'RootClass' has generic lifetime management
-ErrorGenericClass.chpl:5: note: the formal 'x' is generic because 'RootClass' has generic lifetime management
+ErrorGenericClass.chpl:5: note: the formal 'r' is generic because 'RootClass' is a class with unknown management
+ErrorGenericClass.chpl:5: note: the formal 'x' is generic because 'RootClass' is a class with unknown management
 ErrorGenericClass.chpl:6: warning: proc

--- a/test/functions/jturner/first-class-generic-function.good
+++ b/test/functions/jturner/first-class-generic-function.good
@@ -1,5 +1,5 @@
 first-class-generic-function.chpl:329: In function 'main':
 first-class-generic-function.chpl:389: error: the proc 'scalar_outer_product_cholesky' is generic and cannot be captured
-first-class-generic-function.chpl:389: note: the formal 'A' is generic because arrays are considered generic due to runtime type information
+first-class-generic-function.chpl:389: note: the formal 'A' is generic because it is an array with runtime type information
 first-class-generic-function.chpl:329: In function 'main':
 first-class-generic-function.chpl:416: error: illegal access of procedure

--- a/test/functions/jturner/first-class-generic-function.good
+++ b/test/functions/jturner/first-class-generic-function.good
@@ -1,4 +1,5 @@
 first-class-generic-function.chpl:329: In function 'main':
 first-class-generic-function.chpl:389: error: the proc 'scalar_outer_product_cholesky' is generic and cannot be captured
+first-class-generic-function.chpl:389: note: the formal 'A' is generic because arrays are considered generic due to runtime type information
 first-class-generic-function.chpl:329: In function 'main':
 first-class-generic-function.chpl:416: error: illegal access of procedure

--- a/test/functions/lambda/captureGenericFn.good
+++ b/test/functions/lambda/captureGenericFn.good
@@ -1,5 +1,10 @@
 captureGenericFn.chpl:23: error: the proc 'f1' is generic and cannot be captured
+captureGenericFn.chpl:23: note: the formal 'x' is generic
 captureGenericFn.chpl:24: error: the proc 'f2' is generic and cannot be captured
+captureGenericFn.chpl:24: note: the formal 'x' is generic
 captureGenericFn.chpl:25: error: the proc 'f3' is generic and cannot be captured
+captureGenericFn.chpl:25: note: the formal 'x' is generic
 captureGenericFn.chpl:26: error: the proc 'f4' is generic and cannot be captured
+captureGenericFn.chpl:26: note: the formal 'A' is generic
+captureGenericFn.chpl:26: note: the formal 'B' is generic
 captureGenericFn.chpl:28: error: illegal access of procedure

--- a/test/io/sungeun/funcPtr6.good
+++ b/test/io/sungeun/funcPtr6.good
@@ -1,1 +1,2 @@
 funcPtr6.chpl:5: error: the proc 'foo' is generic and cannot be captured
+funcPtr6.chpl:5: note: the formal 'x' is generic


### PR DESCRIPTION
Chapel does not yet support using generic anonymous functions. Although we currently have errors that tell users this, it can be confusing why a given function is generic.

This PR adds some additional logic in function resolution to print why a specific anonymous function is generic. Specifically, 2 cases can trip users up.

1. A class without specific lifetime (e.g. `borrowed` or `unmanaged`)
2. An array (generic due to runtime type)

Tested with a full paratest with/without comm.

Resolves #14202

[Reviewed by @dlongnecke-cray]