### PR TITLE
Improve task intent errors for tuples

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -7755,6 +7755,17 @@ static Symbol* maybeGetBaseSymHelper(SymExpr* def) {
             }
             return baseSym;
           }
+        } else if (maybeMethodCall->isPrimitive(PRIM_GET_MEMBER)) {
+          // handle tuples
+          if (auto baseExpr = toSymExpr(maybeMethodCall->get(1))) {
+            auto baseSym = baseExpr->symbol();
+            if (baseSym->hasFlag(FLAG_TEMP)) {
+              if(auto sym = maybeGetBaseSym(baseSym)) {
+                return sym;
+              }
+            }
+            return baseSym;
+          }
         }
       }
     }

--- a/test/parallel/taskPar/taskIntents/errorAccessTuple.1.good
+++ b/test/parallel/taskPar/taskIntents/errorAccessTuple.1.good
@@ -1,0 +1,6 @@
+errorAccessTuple.chpl:13: error: cannot assign to const variable
+errorAccessTuple.chpl:11: note: The shadow variable 'r' is constant due to task intents in this begin statement
+errorAccessTuple.chpl:14: error: cannot assign to const variable
+errorAccessTuple.chpl:11: note: The shadow variable 'r' is constant due to task intents in this begin statement
+errorAccessTuple.chpl:15: error: cannot assign to const variable
+errorAccessTuple.chpl:11: note: The shadow variable 'a' is constant due to task intents in this begin statement

--- a/test/parallel/taskPar/taskIntents/errorAccessTuple.2.good
+++ b/test/parallel/taskPar/taskIntents/errorAccessTuple.2.good
@@ -1,0 +1,3 @@
+errorAccessTuple.chpl:18: error: const actual is passed to 'ref' formal 'a' of =
+note: to formal of type int(64)
+errorAccessTuple.chpl:11: note: The shadow variable 'a' is constant due to task intents in this begin statement

--- a/test/parallel/taskPar/taskIntents/errorAccessTuple.chpl
+++ b/test/parallel/taskPar/taskIntents/errorAccessTuple.chpl
@@ -1,0 +1,20 @@
+record R {
+  var x: 2*int;
+}
+
+var r: R;
+var a = (1,2);
+
+// need to toggle between the cases, as the error messages won't all appear at once
+config param test = 1;
+
+begin {
+  if test == 1 {
+    r.x(1) += 1;
+    r.x = (1,1);
+    a = (2,3);
+  }
+  else {
+    a(1) = 1;
+  }
+}

--- a/test/parallel/taskPar/taskIntents/errorAccessTuple.compopts
+++ b/test/parallel/taskPar/taskIntents/errorAccessTuple.compopts
@@ -1,0 +1,2 @@
+-stest=1 # errorAccessTuple.1.good
+-stest=2 # errorAccessTuple.2.good


### PR DESCRIPTION
This PR builds on #24089 to improve task intent errors for tuples.

After #24089 and prior to this PR, the error for tuples would look like:
```
error: cannot assign to const variable
note: The shadow variable 'call_temp' is constant due to task intents in this begin statement
```

However, `call_temp` is a compiler temporary, so this is not a useful error. This PR improves this so that the error message refers to the tuple variable in user code.

Tested with a full paratest with/without comm.

[Reviewed by @vasslitvinov]