### PR TITLE
Mark extern incomplete types as such and fail to default-init them.

### DIFF
--- a/compiler/passes/externCResolve.cpp
+++ b/compiler/passes/externCResolve.cpp
@@ -183,6 +183,8 @@ Expr* convertStructToChplType(ModuleSymbol* module,
   TypeSymbol* ts = new TypeSymbol(chpl_name, ct);
   ts->cname = cname;
   ts->addFlag(FLAG_EXTERN);
+  if (structType->isIncompleteType())
+    ts->addFlag(FLAG_INCOMPLETE);
   DefExpr* def = new DefExpr(ts);
 
   addCDef(module, def);

--- a/frontend/include/chpl/uast/PragmaList.h
+++ b/frontend/include/chpl/uast/PragmaList.h
@@ -311,6 +311,7 @@ PRAGMA(IF_EXPR_RESULT, npr, "if-expr result", ncm)
 PRAGMA(IMPLICIT_ALIAS_FIELD, npr, "implicit alias field", ncm)
 PRAGMA(IMPLICIT_MODULE, npr, "implicit top-level module", ncm)
 PRAGMA(INCLUDED_MODULE, npr, "included sub-module", ncm)
+PRAGMA(INCOMPLETE, npr, "incomplete", "an extern type that is incomplete in the C/C++ sense")
 PRAGMA(INDEX_VAR, npr, "index var", ncm)
 PRAGMA(INFER_CUSTOM_TYPE, ypr, "infer custom type", ncm)
 

--- a/test/extern/records/OpaqueStructUseError.bad
+++ b/test/extern/records/OpaqueStructUseError.bad
@@ -1,8 +1,0 @@
-OpaqueStructUseError.chpl:9: internal error: COD-CG--XPR-nnnn chpl version mmmm
-Note: This source location is a guess.
-
-Internal errors indicate a bug in the Chapel compiler,
-and we're sorry for the hassle.  We would appreciate your reporting this bug --
-please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-

--- a/test/extern/records/OpaqueStructUseError.future
+++ b/test/extern/records/OpaqueStructUseError.future
@@ -1,2 +1,0 @@
-bug: compiler crashes when using an opaque C struct
-#25191

--- a/test/extern/records/OpaqueStructUseError.good
+++ b/test/extern/records/OpaqueStructUseError.good
@@ -1,1 +1,1 @@
-OpaqueStructUseError.chpl:9: error: using an incomplete type 'mydata'
+OpaqueStructUseError.chpl:9: error: cannot default initialize incomplete 'extern' type 'mydata'


### PR DESCRIPTION
Prior to this, cg-expr would fail while trying to zero-initialize an incomplete type.

This change only affects the LLVM backend, but the test in this issue was already skipped for the C backend.

Resolves https://github.com/chapel-lang/chapel/issues/18061.

## Future work
Ensure that the behavior for the C backend is reasonable as well.

Reviewed by @mppf -- thanks!

## Testing
- [x] paratest