### PR TITLE
Improve errorrs when casting abstract enums to numeric types

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4753,12 +4753,12 @@ void printResolutionErrorUnresolved(CallInfo&       info,
         EnumType* srcEnumType = toEnumType(srcType);
         if (srcEnumType && srcEnumType->isAbstract()) {
           USR_FATAL_CONT(call,
-                         "can't cast from an abstract enum ('%s') to %s",
+                         "cannot cast abstract enum type '%s' to '%s'",
                          toString(srcType),
                          toString(dstType));
         } else if (dstEnumType && dstEnumType->isAbstract()) {
           USR_FATAL_CONT(call,
-                         "can't cast from %s to an abstract enum type ('%s')",
+                         "cannot cast '%s' to abstract enum type '%s'",
                          toString(srcType),
                          toString(dstType));
         } else {

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -2234,8 +2234,16 @@ module ChapelBase {
   inline operator :(x:chpl_anyreal, type t:chpl_anyreal) do
     return __primitive("cast", t, x);
 
+  proc chpl_checkCastAbstractEnumError(type enumType, type dstType) param do
+    if isAbstractEnumType(enumType) then
+      compilerError("can't cast from an abstract enum ('" +
+                    enumType:string +
+                    "') to " +
+                    dstType:string);
+
   @unstable("enum-to-bool casts are likely to be deprecated in the future")
   inline operator :(x: enum, type t:bool) throws {
+    chpl_checkCastAbstractEnumError(x.type, t);
     return x: int: bool;
   }
   // operator :(x: enum, type t:integral)
@@ -2245,6 +2253,7 @@ module ChapelBase {
 
   @unstable("enum-to-float casts are likely to be deprecated in the future")
   inline operator :(x: enum, type t:chpl_anyreal) throws {
+    chpl_checkCastAbstractEnumError(x.type, t);
     return x: int: real;
   }
 
@@ -2431,8 +2440,10 @@ module ChapelBase {
     return (x.re, x.im):t;
 
   @unstable("enum-to-float casts are likely to be deprecated in the future")
-  inline operator :(x: enum, type t:chpl_anycomplex) throws do
+  inline operator :(x: enum, type t:chpl_anycomplex) throws {
+    chpl_checkCastAbstractEnumError(x.type, t);
     return (x:real, 0):t;
+  }
 
   //
   // casts to imag
@@ -2453,8 +2464,10 @@ module ChapelBase {
     return __primitive("cast", t, x.im);
 
   @unstable("enum-to-float casts are likely to be deprecated in the future")
-  inline operator :(x: enum, type t:chpl_anyimag)  throws do
+  inline operator :(x: enum, type t:chpl_anyimag)  throws {
+    chpl_checkCastAbstractEnumError(x.type, t);
     return x:real:imag;
+  }
 
   //
   // casts from complex

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -2236,10 +2236,11 @@ module ChapelBase {
 
   proc chpl_checkCastAbstractEnumError(type enumType, type dstType) param do
     if isAbstractEnumType(enumType) then
-      compilerError("can't cast from an abstract enum ('" +
+      compilerError("cannot cast abstract enum type '" +
                     enumType:string +
-                    "') to " +
-                    dstType:string);
+                    "' to '" +
+                    dstType:string +
+                    "'");
 
   @unstable("enum-to-bool casts are likely to be deprecated in the future")
   inline operator :(x: enum, type t:bool) throws {

--- a/test/expressions/casts/enumCastErrors-10.good
+++ b/test/expressions/casts/enumCastErrors-10.good
@@ -1,1 +1,1 @@
-enumCastErrors.chpl:49: error: cannot cast 'int(64)' to an abstract enum type 'color3'
+enumCastErrors.chpl:49: error: cannot cast 'int(64)' to abstract enum type 'color3'

--- a/test/expressions/casts/enumCastErrors-10.good
+++ b/test/expressions/casts/enumCastErrors-10.good
@@ -1,1 +1,1 @@
-enumCastErrors.chpl:49: error: can't cast from int(64) to an abstract enum type ('color3')
+enumCastErrors.chpl:49: error: cannot cast 'int(64)' to an abstract enum type 'color3'

--- a/test/expressions/casts/enumCastErrors-9.good
+++ b/test/expressions/casts/enumCastErrors-9.good
@@ -1,1 +1,1 @@
-enumCastErrors.chpl:45: error: cannot cast abstract enum type 'int(64)' to abstract enum type 'color3'
+enumCastErrors.chpl:45: error: cannot cast 'int(64)' to abstract enum type 'color3'

--- a/test/expressions/casts/enumCastErrors-9.good
+++ b/test/expressions/casts/enumCastErrors-9.good
@@ -1,1 +1,1 @@
-enumCastErrors.chpl:45: error: can't cast from int(64) to an abstract enum type ('color3')
+enumCastErrors.chpl:45: error: cannot cast abstract enum type 'int(64)' to abstract enum type 'color3'

--- a/test/types/enum/bad-cast-to-bool.good
+++ b/test/types/enum/bad-cast-to-bool.good
@@ -1,1 +1,1 @@
-bad-cast-to-type.chpl:3: error: can't cast from an abstract enum ('E') to bool
+bad-cast-to-type.chpl:3: error: cannot cast abstract enum type 'E' to 'bool'

--- a/test/types/enum/bad-cast-to-bool.good
+++ b/test/types/enum/bad-cast-to-bool.good
@@ -1,0 +1,1 @@
+bad-cast-to-type.chpl:3: error: can't cast from an abstract enum ('E') to bool

--- a/test/types/enum/bad-cast-to-complex.good
+++ b/test/types/enum/bad-cast-to-complex.good
@@ -1,1 +1,1 @@
-bad-cast-to-type.chpl:3: error: can't cast from an abstract enum ('E') to complex(128)
+bad-cast-to-type.chpl:3: error: cannot cast abstract enum type 'E' to 'complex(128)'

--- a/test/types/enum/bad-cast-to-complex.good
+++ b/test/types/enum/bad-cast-to-complex.good
@@ -1,0 +1,1 @@
+bad-cast-to-type.chpl:3: error: can't cast from an abstract enum ('E') to complex(128)

--- a/test/types/enum/bad-cast-to-imag.good
+++ b/test/types/enum/bad-cast-to-imag.good
@@ -1,0 +1,1 @@
+bad-cast-to-type.chpl:3: error: can't cast from an abstract enum ('E') to imag(64)

--- a/test/types/enum/bad-cast-to-imag.good
+++ b/test/types/enum/bad-cast-to-imag.good
@@ -1,1 +1,1 @@
-bad-cast-to-type.chpl:3: error: can't cast from an abstract enum ('E') to imag(64)
+bad-cast-to-type.chpl:3: error: cannot cast abstract enum type 'E' to 'imag(64)'

--- a/test/types/enum/bad-cast-to-real.bad
+++ b/test/types/enum/bad-cast-to-real.bad
@@ -1,1 +1,0 @@
-bad-cast-to-real.chpl:3: error: can't cast from an abstract enum ('E') to int(64)

--- a/test/types/enum/bad-cast-to-real.chpl
+++ b/test/types/enum/bad-cast-to-real.chpl
@@ -1,3 +1,0 @@
-enum E { R,G,B };
-
-writeln(E.B:real);

--- a/test/types/enum/bad-cast-to-real.future
+++ b/test/types/enum/bad-cast-to-real.future
@@ -1,2 +1,0 @@
-error message: bad cast of enum to real reports failure to cast to int
-#10385

--- a/test/types/enum/bad-cast-to-real.good
+++ b/test/types/enum/bad-cast-to-real.good
@@ -1,1 +1,1 @@
-bad-cast-to-type.chpl:3: error: can't cast from an abstract enum ('E') to real(64)
+bad-cast-to-type.chpl:3: error: cannot cast abstract enum type 'E' to 'real(64)'

--- a/test/types/enum/bad-cast-to-real.good
+++ b/test/types/enum/bad-cast-to-real.good
@@ -1,1 +1,1 @@
-bad-cast-to-real.chpl:3: error: can't cast from an abstract enum ('E') to real(64)
+bad-cast-to-type.chpl:3: error: can't cast from an abstract enum ('E') to real(64)

--- a/test/types/enum/bad-cast-to-type.chpl
+++ b/test/types/enum/bad-cast-to-type.chpl
@@ -1,0 +1,3 @@
+enum E { R,G,B };
+config type T = real;
+writeln(E.B:T);

--- a/test/types/enum/bad-cast-to-type.compopts
+++ b/test/types/enum/bad-cast-to-type.compopts
@@ -1,0 +1,4 @@
+-sT=real # bad-cast-to-real.good
+-sT=bool # bad-cast-to-bool.good
+-sT=imag # bad-cast-to-imag.good
+-sT=complex # bad-cast-to-complex.good

--- a/test/types/enum/bad-cast-to-type.good
+++ b/test/types/enum/bad-cast-to-type.good
@@ -1,0 +1,1 @@
+bad-cast-to-real.chpl:3: error: can't cast from an abstract enum ('E') to real(64)

--- a/test/types/enum/bad-cast-to-type.good
+++ b/test/types/enum/bad-cast-to-type.good
@@ -1,1 +1,1 @@
-bad-cast-to-real.chpl:3: error: can't cast from an abstract enum ('E') to real(64)
+bad-cast-to-real.chpl:3: error: cannot cast abstract enum type 'E' to 'real(64)'

--- a/test/types/enum/diten/paramEnumOutOfBounds2.good
+++ b/test/types/enum/diten/paramEnumOutOfBounds2.good
@@ -1,1 +1,1 @@
-paramEnumOutOfBounds2.chpl:3: error: can't cast from int(64) to an abstract enum type ('enumt')
+paramEnumOutOfBounds2.chpl:3: error: cannot cast 'int(64)' to abstract enum type 'enumt'

--- a/test/types/enum/enumCast-abstract-nonparam-toenum.good
+++ b/test/types/enum/enumCast-abstract-nonparam-toenum.good
@@ -1,1 +1,1 @@
-enumCast-abstract-nonparam.chpl:9: error: can't cast from int(64) to an abstract enum type ('color')
+enumCast-abstract-nonparam.chpl:9: error: cannot cast 'int(64)' to abstract enum type 'color'

--- a/test/types/enum/enumCast-abstract-nonparam.good
+++ b/test/types/enum/enumCast-abstract-nonparam.good
@@ -1,1 +1,1 @@
-enumCast-abstract-nonparam.chpl:7: error: cannot cast abstract enum 'color' to 'int(64)'
+enumCast-abstract-nonparam.chpl:7: error: cannot cast abstract enum type 'color' to 'int(64)'

--- a/test/types/enum/enumCast-abstract-nonparam.good
+++ b/test/types/enum/enumCast-abstract-nonparam.good
@@ -1,1 +1,1 @@
-enumCast-abstract-nonparam.chpl:7: error: can't cast from an abstract enum ('color') to int(64)
+enumCast-abstract-nonparam.chpl:7: error: cannot cast abstract enum 'color' to 'int(64)'

--- a/test/types/enum/paramEnumCast.good
+++ b/test/types/enum/paramEnumCast.good
@@ -7,5 +7,5 @@ paramEnumCast.chpl:23: error: Initializing parameter 'e3' to value not known at 
   paramEnumCast.chpl:41: called as testEnum(type t = gender, param e = gender.decline, param expectStr = "decline", param expectVal = 0)
 paramEnumCast.chpl:41: warning: int->enum cast was a surprise for decline
 paramEnumCast.chpl:6: In function 'testEnum':
-paramEnumCast.chpl:19: error: cannot cast abstract enum 'color' to 'int(64)'
+paramEnumCast.chpl:19: error: cannot cast abstract enum type 'color' to 'int(64)'
   paramEnumCast.chpl:42: called as testEnum(type t = color, param e = color.red, param expectStr = "red", param expectVal = 1)

--- a/test/types/enum/paramEnumCast.good
+++ b/test/types/enum/paramEnumCast.good
@@ -7,5 +7,5 @@ paramEnumCast.chpl:23: error: Initializing parameter 'e3' to value not known at 
   paramEnumCast.chpl:41: called as testEnum(type t = gender, param e = gender.decline, param expectStr = "decline", param expectVal = 0)
 paramEnumCast.chpl:41: warning: int->enum cast was a surprise for decline
 paramEnumCast.chpl:6: In function 'testEnum':
-paramEnumCast.chpl:19: error: can't cast from an abstract enum ('color') to int(64)
+paramEnumCast.chpl:19: error: cannot cast abstract enum 'color' to 'int(64)'
   paramEnumCast.chpl:42: called as testEnum(type t = color, param e = color.red, param expectStr = "red", param expectVal = 1)

--- a/test/types/range/enum/castEnumRange2.good
+++ b/test/types/range/enum/castEnumRange2.good
@@ -1,2 +1,2 @@
 castEnumRange2.chpl:4: warning: Casts between ranges involving 'enum' indices are currently unstable (see issue #22406); consider performing the conversion manually
-castEnumRange2.chpl:4: error: cannot cast abstract enum 'color' to 'int(64)'
+castEnumRange2.chpl:4: error: cannot cast abstract enum type 'color' to 'int(64)'

--- a/test/types/range/enum/castEnumRange2.good
+++ b/test/types/range/enum/castEnumRange2.good
@@ -1,2 +1,2 @@
 castEnumRange2.chpl:4: warning: Casts between ranges involving 'enum' indices are currently unstable (see issue #22406); consider performing the conversion manually
-castEnumRange2.chpl:4: error: can't cast from an abstract enum ('color') to int(64)
+castEnumRange2.chpl:4: error: cannot cast abstract enum 'color' to 'int(64)'


### PR DESCRIPTION
Specializes the error message when casting an abstract enum to a non-intergal numeric type.

For example, prior to this PR the following code would report an error about casting to int. Now it properly errors with a message about real
```chapel
enum E { R,G,B };
writeln(E.B:real);
```

Resolves https://github.com/chapel-lang/chapel/issues/10385. This issue only talks about `real` being a problem, but other types suffered from this same issue. Namely, `bool`, `imag`, and `complex`. This PR improves the error message for all of them.

Tested with a full paratest with/without comm

[Reviewed by @dlongnecke-cray]