### PR TITLE
Update `upload-artifact` Github CI action from v3->v4

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,7 +48,7 @@ jobs:
       run: |
         ./util/buildRelease/smokeTest quickstart docs
     - name: upload docs
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: documentation
         path: doc/html


### PR DESCRIPTION
Resolves https://github.com/Cray/chapel-private/issues/6340.

Testing:
- [x] `documentation.zip` artifact generated in CI run
- [x] deprecation warnings no longer come up