### PR TITLE
Fix some commcounts tests, add a flag to test utility module

### DIFF
--- a/test/performance/ferguson/CommUtil.chpl
+++ b/test/performance/ferguson/CommUtil.chpl
@@ -1,6 +1,7 @@
 use CommDiagnostics;
 use Time;
 
+config const verboseComm = false;
 config var printCounts = false;
 config var printAllCounts = false;
 
@@ -12,12 +13,14 @@ var timer:stopwatch;
 proc start() {
   resetCommDiagnostics();
   startCommDiagnostics();
+  if verboseComm then startVerboseComm();
   timer.clear();
   timer.start();
 }
 
 proc stop() {
   timer.stop();
+  if verboseComm then stopVerboseComm();
   stopCommDiagnostics();
 }
 

--- a/test/performance/ferguson/array/remote-array-write.chpl
+++ b/test/performance/ferguson/array/remote-array-write.chpl
@@ -17,4 +17,5 @@ stop();
 writeln(A[1]);
 writeln(A[n]);
 
-report(maxGets=3, maxOns=1);
+// LLVM backend generates 3 gets, C generates 4
+report(maxGets=4, maxOns=1, maxGetsToAdjust=3);

--- a/test/performance/ferguson/record/remote-record-write-copy.chpl
+++ b/test/performance/ferguson/record/remote-record-write-copy.chpl
@@ -26,4 +26,5 @@ stop();
 writeln(A[1]);
 writeln(A[n]);
 
-report(maxGets=3, maxOns=1);
+// LLVM backend generates 3 gets, C generates 4
+report(maxGets=4, maxOns=1, maxGetsToAdjust=3);

--- a/test/performance/ferguson/record/remote-record-write.chpl
+++ b/test/performance/ferguson/record/remote-record-write.chpl
@@ -27,4 +27,5 @@ stop();
 writeln(A[1]);
 writeln(A[n]);
 
-report(maxGets=3, maxOns=1);
+// LLVM backend generates 3 gets, C generates 4
+report(maxGets=4, maxOns=1, maxGetsToAdjust=3);

--- a/test/performance/ferguson/tuple/remote-tuple-write-copy.chpl
+++ b/test/performance/ferguson/tuple/remote-tuple-write-copy.chpl
@@ -22,4 +22,5 @@ stop();
 writeln(A[1]);
 writeln(A[n]);
 
-report(maxGets=3, maxOns=1);
+// LLVM backend generates 3 gets, C generates 4
+report(maxGets=4, maxOns=1, maxGetsToAdjust=3);

--- a/test/performance/ferguson/tuple/remote-tuple-write-small-copy.chpl
+++ b/test/performance/ferguson/tuple/remote-tuple-write-small-copy.chpl
@@ -22,4 +22,5 @@ stop();
 writeln(A[1]);
 writeln(A[n]);
 
-report(maxGets=3, maxOns=1);
+// LLVM backend generates 3 gets, C generates 4
+report(maxGets=4, maxOns=1, maxGetsToAdjust=3);

--- a/test/performance/ferguson/tuple/remote-tuple-write-small.chpl
+++ b/test/performance/ferguson/tuple/remote-tuple-write-small.chpl
@@ -20,4 +20,5 @@ stop();
 writeln(A[1]);
 writeln(A[n]);
 
-report(maxGets=3, maxOns=1);
+// LLVM backend generates 3 gets, C generates 4
+report(maxGets=4, maxOns=1, maxGetsToAdjust=3);

--- a/test/performance/ferguson/tuple/remote-tuple-write.chpl
+++ b/test/performance/ferguson/tuple/remote-tuple-write.chpl
@@ -20,4 +20,5 @@ stop();
 writeln(A[1]);
 writeln(A[n]);
 
-report(maxGets=3, maxOns=1);
+// LLVM backend generates 3 gets, C generates 4
+report(maxGets=4, maxOns=1, maxGetsToAdjust=3);


### PR DESCRIPTION
This is a follow up to https://github.com/chapel-lang/chapel/pull/24390.

It looks like the LLVM and C backends generate different number of gets when the remote cache is enabled in some tests. While the updates in that PR covered the changes in the LLVM backend for those tests, it didn't cover for the C backend's behavior. This PR adjusts comm counts checking in those tests.

Michael's theory for the difference between the backends is:

> The cache for remote data is sensitive to the memory layout used in the end. And this could vary between C and LLVM, in particular, how things are laid out in the stack memory.

which I find to be very reasonable.

While there, I also added a `config const verboseComm` flag to the relevant tests' utility module to help with debugging.

Test:
- [x] `performance/ferguson` with gasnet+udp+LLVM 
- [x] `performance/ferguson` with gasnet+udp+C 