### PR TITLE
indicate terminating null byte is optional on string/bytes buffers

### DIFF
--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -71,7 +71,8 @@ module Bytes {
     :type x: `c_ptr(int(8))` or `c_ptr(uint(8))`
 
     :arg length: Length of `x`, excluding the optional terminating null byte.
-                 Defaults to the number of bytes in `x` before the terminating null byte.
+                 Defaults to the number of bytes in `x` before the terminating
+                 null byte.
     :type length: `int`
 
     :returns: A new :type:`bytes`
@@ -92,7 +93,8 @@ module Bytes {
     :type x: `c_ptrConst(uint(8))` or `c_ptrConst(int(8))`
 
     :arg length: Length of `x`, excluding the optional terminating null byte.
-                 Defaults to the number of bytes in `x` before the terminating null byte.
+                 Defaults to the number of bytes in `x` before the terminating
+                 null byte.
     :type length: `int`
 
     :returns: A new :type:`bytes`
@@ -130,7 +132,8 @@ module Bytes {
      :arg x: Buffer to borrow
      :type x: `c_ptr(uint(8))` or `c_ptr(int(8))`
 
-     :arg length: Length of the buffer `x`, excluding the optional terminating null byte.
+     :arg length: Length of the buffer `x`, excluding the optional terminating
+                  null byte.
 
      :arg size: Size of memory allocated for `x` in bytes
 
@@ -155,8 +158,9 @@ module Bytes {
     :arg x: The `c_ptr` to take ownership of
     :type x: `c_ptr(uint(8))` or `c_ptr(int(8))`
 
-    :arg length: Length of buffer `x`, excluding the optional terminating null byte.
-                 Defaults to the number of bytes in `x` before the terminating null byte.
+    :arg length: Length of buffer `x`, excluding the optional terminating null
+                 byte. Defaults to the number of bytes in `x` before the
+                 terminating null byte.
     :type length: `int`
 
     :returns: A new :type:`bytes`
@@ -184,8 +188,9 @@ module Bytes {
     :arg x: The `c_ptrConst` to take ownership of
     :type x: `c_ptrConst(uint(8))` or `c_ptrConst(int(8))`
 
-    :arg length: Length of `x`'s buffer, excluding the optional terminating null byte.
-                 Defaults to the number of bytes in `x` before the terminating null byte.
+    :arg length: Length of `x`'s buffer, excluding the optional terminating null
+                 byte. Defaults to the number of bytes in `x` before the
+                 terminating null byte.
     :type length: `int`
 
     :returns: A new :type:`bytes`
@@ -204,7 +209,8 @@ module Bytes {
      :arg x: The buffer to take ownership of
      :type x: `c_ptr(uint(8))` or `c_ptr(int(8))`
 
-     :arg length: Length of the buffer `x`, excluding the optional terminating null byte.
+     :arg length: Length of the buffer `x`, excluding the optional terminating
+                  null byte.
 
      :arg size: Size of memory allocated for `x` in bytes
 
@@ -227,8 +233,9 @@ module Bytes {
     :arg x: The :class:`~CTypes.c_ptrConst` to copy
     :type x: `c_ptrConst(uint(8))` or `c_ptrConst(int(8))`
 
-    :arg length: Length of buffer `x`, excluding the optional terminating null byte.
-                 Defaults to the number of bytes in `x` before the terminating null byte.
+    :arg length: Length of buffer `x`, excluding the optional terminating null
+                 byte. Defaults to the number of bytes in `x` before the
+                 terminating null byte.
     :type length: `int`
 
     :returns: A new :type:`bytes`
@@ -254,8 +261,9 @@ module Bytes {
      :arg x: The buffer to copy
      :type x: `c_ptr(uint(8))` or `c_ptr(int(8))`
 
-     :arg length: Length of buffer `x`, excluding the optional terminating null byte.
-                  Defaults to the number of bytes in `x` before the terminating null byte.
+     :arg length: Length of buffer `x`, excluding the optional terminating null
+                  byte. Defaults to the number of bytes in `x` before the
+                  terminating null byte.
 
      :arg size: Size of memory allocated for `x` in bytes
 

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -70,7 +70,8 @@ module Bytes {
     :arg x: `c_ptr` to borrow as a buffer
     :type x: `c_ptr(int(8))` or `c_ptr(uint(8))`
 
-    :arg length: Length of `x`, excluding the optional terminating null byte. Defaults to the number of bytes in x before the optional terminating null byte.
+    :arg length: Length of `x`, excluding the optional terminating null byte.
+                 Defaults to the number of bytes in `x` before the terminating null byte.
     :type length: `int`
 
     :returns: A new :type:`bytes`
@@ -90,7 +91,8 @@ module Bytes {
     :arg x: `c_ptrConst` to borrow as a buffer
     :type x: `c_ptrConst(uint(8))` or `c_ptrConst(int(8))`
 
-    :arg length: Length of `x`, excluding the optional terminating null byte. Defaults to the number of bytes in x before the optional terminating null byte.
+    :arg length: Length of `x`, excluding the optional terminating null byte.
+                 Defaults to the number of bytes in `x` before the terminating null byte.
     :type length: `int`
 
     :returns: A new :type:`bytes`
@@ -153,7 +155,8 @@ module Bytes {
     :arg x: The `c_ptr` to take ownership of
     :type x: `c_ptr(uint(8))` or `c_ptr(int(8))`
 
-    :arg length: Length of buffer `x`, excluding the optional terminating null byte. Defaults to the number of bytes in x before the optional terminating null byte.
+    :arg length: Length of buffer `x`, excluding the optional terminating null byte.
+                 Defaults to the number of bytes in `x` before the terminating null byte.
     :type length: `int`
 
     :returns: A new :type:`bytes`
@@ -181,7 +184,8 @@ module Bytes {
     :arg x: The `c_ptrConst` to take ownership of
     :type x: `c_ptrConst(uint(8))` or `c_ptrConst(int(8))`
 
-    :arg length: Length of `x`'s buffer, excluding the optional terminating null byte. Defaults to the number of bytes in x before the optional terminating null byte.
+    :arg length: Length of `x`'s buffer, excluding the optional terminating null byte.
+                 Defaults to the number of bytes in `x` before the terminating null byte.
     :type length: `int`
 
     :returns: A new :type:`bytes`
@@ -223,7 +227,8 @@ module Bytes {
     :arg x: The :class:`~CTypes.c_ptrConst` to copy
     :type x: `c_ptrConst(uint(8))` or `c_ptrConst(int(8))`
 
-    :arg length: Length of buffer `x`, excluding the optional terminating null byte. Defaults to the number of bytes in x before the optional terminating null byte.
+    :arg length: Length of buffer `x`, excluding the optional terminating null byte.
+                 Defaults to the number of bytes in `x` before the terminating null byte.
     :type length: `int`
 
     :returns: A new :type:`bytes`
@@ -249,7 +254,8 @@ module Bytes {
      :arg x: The buffer to copy
      :type x: `c_ptr(uint(8))` or `c_ptr(int(8))`
 
-     :arg length: Length of buffer `x`, excluding the optional terminating null byte. Defaults to the number of bytes in x before the optional terminating null byte.
+     :arg length: Length of buffer `x`, excluding the optional terminating null byte.
+                  Defaults to the number of bytes in `x` before the terminating null byte.
 
      :arg size: Size of memory allocated for `x` in bytes
 

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -70,7 +70,7 @@ module Bytes {
     :arg x: `c_ptr` to borrow as a buffer
     :type x: `c_ptr(int(8))` or `c_ptr(uint(8))`
 
-    :arg length: Length of `x`, excluding the terminating null byte. Defaults to the number of bytes in x before the terminating null byte.
+    :arg length: Length of `x`, excluding the optional terminating null byte. Defaults to the number of bytes in x before the optional terminating null byte.
     :type length: `int`
 
     :returns: A new :type:`bytes`
@@ -90,7 +90,7 @@ module Bytes {
     :arg x: `c_ptrConst` to borrow as a buffer
     :type x: `c_ptrConst(uint(8))` or `c_ptrConst(int(8))`
 
-    :arg length: Length of `x`, excluding the terminating null byte. Defaults to the number of bytes in x before the terminating null byte.
+    :arg length: Length of `x`, excluding the optional terminating null byte. Defaults to the number of bytes in x before the optional terminating null byte.
     :type length: `int`
 
     :returns: A new :type:`bytes`
@@ -128,7 +128,7 @@ module Bytes {
      :arg x: Buffer to borrow
      :type x: `c_ptr(uint(8))` or `c_ptr(int(8))`
 
-     :arg length: Length of the buffer `x`, excluding the terminating null byte.
+     :arg length: Length of the buffer `x`, excluding the optional terminating null byte.
 
      :arg size: Size of memory allocated for `x` in bytes
 
@@ -153,7 +153,7 @@ module Bytes {
     :arg x: The `c_ptr` to take ownership of
     :type x: `c_ptr(uint(8))` or `c_ptr(int(8))`
 
-    :arg length: Length of buffer `x`, excluding the terminating null byte. Defaults to the number of bytes in x before the terminating null byte.
+    :arg length: Length of buffer `x`, excluding the optional terminating null byte. Defaults to the number of bytes in x before the optional terminating null byte.
     :type length: `int`
 
     :returns: A new :type:`bytes`
@@ -181,7 +181,7 @@ module Bytes {
     :arg x: The `c_ptrConst` to take ownership of
     :type x: `c_ptrConst(uint(8))` or `c_ptrConst(int(8))`
 
-    :arg length: Length of `x`'s buffer, excluding the terminating null byte. Defaults to the number of bytes in x before the terminating null byte.
+    :arg length: Length of `x`'s buffer, excluding the optional terminating null byte. Defaults to the number of bytes in x before the optional terminating null byte.
     :type length: `int`
 
     :returns: A new :type:`bytes`
@@ -200,7 +200,7 @@ module Bytes {
      :arg x: The buffer to take ownership of
      :type x: `c_ptr(uint(8))` or `c_ptr(int(8))`
 
-     :arg length: Length of the buffer `x`, excluding the terminating null byte.
+     :arg length: Length of the buffer `x`, excluding the optional terminating null byte.
 
      :arg size: Size of memory allocated for `x` in bytes
 
@@ -223,7 +223,7 @@ module Bytes {
     :arg x: The :class:`~CTypes.c_ptrConst` to copy
     :type x: `c_ptrConst(uint(8))` or `c_ptrConst(int(8))`
 
-    :arg length: Length of buffer `x`, excluding the terminating null byte. Defaults to the number of bytes in x before the terminating null byte.
+    :arg length: Length of buffer `x`, excluding the optional terminating null byte. Defaults to the number of bytes in x before the optional terminating null byte.
     :type length: `int`
 
     :returns: A new :type:`bytes`
@@ -249,7 +249,7 @@ module Bytes {
      :arg x: The buffer to copy
      :type x: `c_ptr(uint(8))` or `c_ptr(int(8))`
 
-     :arg length: Length of buffer `x`, excluding the terminating null byte. Defaults to the number of bytes in x before the terminating null byte.
+     :arg length: Length of buffer `x`, excluding the optional terminating null byte. Defaults to the number of bytes in x before the optional terminating null byte.
 
      :arg size: Size of memory allocated for `x` in bytes
 

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -392,7 +392,7 @@ module String {
     :arg x: The buffer to borrow from
     :type x: `c_ptr(uint(8))` or `c_ptr(int(8))`
 
-    :arg length: Length of the string stored in `x` in bytes, excluding the
+    :arg length: Length of the string stored in `x` in bytes, excluding the optional
                  terminating null byte.
     :type length: `int`
 
@@ -417,7 +417,7 @@ module String {
     :arg x: The buffer to borrow from
     :type x: `c_ptrConst(uint(8))` or `c_ptrConst(int(8))`
 
-    :arg length: Length of the string stored in `x` in bytes, excluding the
+    :arg length: Length of the string stored in `x` in bytes, excluding the optional
                  terminating null byte.
     :type length: `int`
 
@@ -466,7 +466,7 @@ module String {
      :type x: `c_ptr(uint(8))` or `c_ptr(int(8))`
 
      :arg length: Length of the string stored in `x` in bytes, excluding the
-                  terminating null byte.
+                  optional terminating null byte.
      :type length: `int`
 
      :arg size: Size of memory allocated for `x` in bytes
@@ -506,7 +506,7 @@ module String {
     :arg x: The buffer to take ownership of
     :type x: `c_ptr(uint(8))` or `c_ptr(int(8))`
 
-    :arg length: Length of the string stored in `x` in bytes, excluding the
+    :arg length: Length of the string stored in `x` in bytes, excluding the optional
                  terminating null byte.
     :type length: `int`
 
@@ -540,7 +540,7 @@ module String {
     :arg x: The buffer to take ownership of
     :type x: `c_ptrConst(uint(8))` or `c_ptrConst(int(8))`
 
-    :arg length: Length of the string stored in `x` in bytes, excluding the
+    :arg length: Length of the string stored in `x` in bytes, excluding the optional
                  terminating null byte.
     :type length: `int`
 
@@ -564,7 +564,7 @@ module String {
      :arg x: The buffer to take ownership of
      :type x: `c_ptr(uint(8))` or `c_ptr(int(8))`
 
-     :arg length: Length of the string stored in `x` in bytes, excluding the
+     :arg length: Length of the string stored in `x` in bytes, excluding the optional
                   terminating null byte.
      :type length: `int`
 
@@ -595,7 +595,7 @@ module String {
     :arg x: The buffer to copy
     :type x: `c_ptrConst(uint(8))` or `c_ptrConst(int(8))`
 
-    :arg length: Length of `x` in bytes, excluding the terminating null byte.
+    :arg length: Length of `x` in bytes, excluding the optional terminating null byte.
     :type length: `int`
 
     :arg policy: - `decodePolicy.strict` raises an error
@@ -626,7 +626,7 @@ module String {
      :arg x: The buffer to copy
      :type x: `c_ptr(uint(8))` or `c_ptr(int(8))`
 
-     :arg length: Length of the string stored in `x` in bytes, excluding the
+     :arg length: Length of the string stored in `x` in bytes, excluding the optional
                   terminating null byte.
      :type length: `int`
 

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -564,8 +564,8 @@ module String {
      :arg x: The buffer to take ownership of
      :type x: `c_ptr(uint(8))` or `c_ptr(int(8))`
 
-     :arg length: Length of the string stored in `x` in bytes, excluding the optional
-                  terminating null byte.
+     :arg length: Length of the string stored in `x` in bytes, excluding the
+                  optional terminating null byte.
      :type length: `int`
 
      :arg size: Size of memory allocated for `x` in bytes
@@ -626,8 +626,8 @@ module String {
      :arg x: The buffer to copy
      :type x: `c_ptr(uint(8))` or `c_ptr(int(8))`
 
-     :arg length: Length of the string stored in `x` in bytes, excluding the optional
-                  terminating null byte.
+     :arg length: Length of the string stored in `x` in bytes, excluding the
+                  optional terminating null byte.
      :type length: `int`
 
      :arg size: Size of memory allocated for `x` in bytes. This argument is


### PR DESCRIPTION
Update the docs for `string/bytes` methods to indicate that the terminating null byte in a buffer is optional, as requested in https://github.com/Cray/chapel-private/issues/4895#issuecomment-2119362267

TESTING:

- [x] built and manually reviewed docs in firefox browser

[reviewed by @vasslitvinov - thanks!]