### PR TITLE
dyno: Fix a bug that skipped resolution of zip actuals

### DIFF
--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -4510,6 +4510,11 @@ resolveZipExpression(Resolver& rv, const IndexableLoop* loop, const Zip* zip) {
   bool loopRequiresParallel = loop->isForall();
   bool loopPrefersParallel = loopRequiresParallel || loop->isBracketLoop();
 
+  if (rv.scopeResolveOnly) {
+    zip->traverse(rv);
+    return {};
+  }
+
   // We build up tuple element types by resolving all the zip actuals.
   std::vector<QualifiedType> eltTypes;
 

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -4567,8 +4567,8 @@ resolveZipExpression(Resolver& rv, const IndexableLoop* loop, const Zip* zip) {
     }
   }
 
-  // This 'TupleType' builder preserves references for index types.
   if (!ret.isErroneousType()) {
+    // This 'TupleType' builder preserves references for index types.
     auto type = TupleType::getQualifiedTuple(context, std::move(eltTypes));
     ret = { kind, type };
   }

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -4509,11 +4509,7 @@ resolveZipExpression(Resolver& rv, const IndexableLoop* loop, const Zip* zip) {
   Context* context = rv.context;
   bool loopRequiresParallel = loop->isForall();
   bool loopPrefersParallel = loopRequiresParallel || loop->isBracketLoop();
-
-  if (rv.scopeResolveOnly) {
-    zip->traverse(rv);
-    return {};
-  }
+  QualifiedType ret;
 
   // We build up tuple element types by resolving all the zip actuals.
   std::vector<QualifiedType> eltTypes;
@@ -4534,22 +4530,23 @@ resolveZipExpression(Resolver& rv, const IndexableLoop* loop, const Zip* zip) {
     // Resolve the leader iterator.
     auto dt = resolveIterDetails(rv, leader, leader, {}, m);
 
+    eltTypes.push_back(dt.idxType);
+
     // Configure what followers should do using the iterator details.
     if (dt.succeededAt == IterDetails::LEADER_FOLLOWER) {
       followerPolicy = IterDetails::FOLLOWER;
       leaderYieldType = dt.leaderYieldType;
-      eltTypes.push_back(dt.idxType);
     } else if (dt.succeededAt == IterDetails::SERIAL) {
       followerPolicy = IterDetails::SERIAL;
-      eltTypes.push_back(dt.idxType);
     } else {
-      return { QualifiedType::UNKNOWN, ErroneousType::get(context) };
+      ret = { QualifiedType::UNKNOWN, ErroneousType::get(context) };
     }
   }
 
-  CHPL_ASSERT(followerPolicy != IterDetails::NONE);
-
   // Resolve the follower iterator or serial iterator for all followers.
+  // It is possible for the follower policy to be 'NONE', in which case
+  // no iterators will be resolved, but the follower iterands will be
+  // resolved.
   for (int i = 1; i < zip->numActuals(); i++) {
     auto actual = zip->actual(i);
     auto dt = resolveIterDetails(rv, actual, actual, leaderYieldType,
@@ -4569,8 +4566,10 @@ resolveZipExpression(Resolver& rv, const IndexableLoop* loop, const Zip* zip) {
   }
 
   // This 'TupleType' builder preserves references for index types.
-  auto type = TupleType::getQualifiedTuple(context, std::move(eltTypes));
-  QualifiedType ret = { kind, type };
+  if (!ret.isErroneousType()) {
+    auto type = TupleType::getQualifiedTuple(context, std::move(eltTypes));
+    ret = { kind, type };
+  }
 
   auto& reZip = rv.byPostorder.byAst(zip);
   reZip.setType(ret);

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -4539,6 +4539,8 @@ resolveZipExpression(Resolver& rv, const IndexableLoop* loop, const Zip* zip) {
     } else if (dt.succeededAt == IterDetails::SERIAL) {
       followerPolicy = IterDetails::SERIAL;
     } else {
+      // TODO: Emit an error here informing the user that a usable leader
+      // iterator wasn't found. Might be some test failure(s) to fix.
       ret = { QualifiedType::UNKNOWN, ErroneousType::get(context) };
     }
   }

--- a/frontend/test/resolution/testLoopIndexVars.cpp
+++ b/frontend/test/resolution/testLoopIndexVars.cpp
@@ -483,14 +483,9 @@ static void testIndexScope1() {
   Context* context = &ctx;
   ErrorGuard guard(context);
 
-  //
-  // Ensure that the loop iterand is scope-resolved 'outside' of the loop,
-  // such that the argument 'i' doesn't refer to the loop index variable 'i'.
-  //
-
+  // Ensure that each mention of 'i' refers to the correct index variable.
   auto iterText = R""""(
                   iter foo() { yield 0; }
-
                   for i in zip(foo(), for i in zip(foo(), foo()) do i) do i;
                   )"""";
 

--- a/frontend/test/resolution/testLoopIndexVars.cpp
+++ b/frontend/test/resolution/testLoopIndexVars.cpp
@@ -446,8 +446,8 @@ static void testNestedParamFor() {
   assert(resolvedVals == pc.resolvedVals);
 }
 
-static void testIndexScope() {
-  printf("testIndexScope\n");
+static void testIndexScope0() {
+  printf("testIndexScope0\n");
   Context ctx;
   Context* context = &ctx;
   ErrorGuard guard(context);
@@ -475,6 +475,36 @@ static void testIndexScope() {
   auto argRes = rr.byAst(arg);
   assert(argRes.toId() == m->stmt(1)->id());
   assert(!guard.realizeErrors());
+}
+
+static void testIndexScope1() {
+  printf("testIndexScope1\n");
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  //
+  // Ensure that the loop iterand is scope-resolved 'outside' of the loop,
+  // such that the argument 'i' doesn't refer to the loop index variable 'i'.
+  //
+
+  auto iterText = R""""(
+                  iter foo() { yield 0; }
+
+                  for i in zip(foo(), for i in zip(foo(), foo()) do i) do i;
+                  )"""";
+
+  const Module* m = parseModule(context, iterText);
+  auto loop = m->stmt(1)->toFor();
+
+  const ResolutionResultByPostorderID& rr = scopeResolveModule(context, m->id());
+  assert(!guard.realizeErrors());
+  auto idx1 = loop->index();
+  auto use1 = loop->body()->stmt(0);
+  auto idx2 = loop->iterand()->toZip()->actual(1)->toFor()->index();
+  auto use2 = loop->iterand()->toZip()->actual(1)->toFor()->body()->stmt(0);
+  assert(rr.byAst(use1).toId() == idx1->id());
+  assert(rr.byAst(use2).toId() == idx2->id());
 }
 
 static void testIterSigDetection(Context* context) {
@@ -824,7 +854,8 @@ int main() {
   testCForLoop();
   testParamFor();
   testNestedParamFor();
-  testIndexScope();
+  testIndexScope0();
+  testIndexScope1();
 
   // Use a single context instance to avoid re-resolving internal modules.
   auto ctx = buildStdContext();


### PR DESCRIPTION
This PR fixes a failing `chplcheck` test by adjusting the dyno resolver so that it always resolves zip actuals.

Faulty logic in `resolveZipExpression` caused the resolver to exit resolution of a `zip(...)` early if the leader could not be resolved. I've adjusted things so that all actuals are resolved (though _iterators_ for each actual may not be resolved if the leader is unusable).

Reviewed by @DanilaFe. Thanks!