### PR TITLE
Updates to Subprocess w.r.t. throwing (documentation and behavior)

### DIFF
--- a/modules/standard/Subprocess.chpl
+++ b/modules/standard/Subprocess.chpl
@@ -476,6 +476,19 @@ module Subprocess {
                arguments.
 
      :throws IllegalArgumentError: Thrown when ``args`` is an empty array.
+
+     Some errors at process creation may be deferred until later method calls
+     are made.  These include:
+
+     - :class:`~OS.BlockingIoError`: If there weren't enough system resources
+       when the subprocess was created to create it.
+
+     - :class:`~OS.PermissionError`: If there were permission issues when
+       setting up the subprocess.
+
+     - :class:`~OS.SystemError`: If there were other problems when initially
+       setting up the subprocess.
+
      */
   proc spawn(args:[] string, env:[] string=Subprocess.empty_env, executable="",
              stdin:?t = pipeStyle.forward, stdout:?u = pipeStyle.forward,
@@ -711,6 +724,9 @@ module Subprocess {
      :returns: a :record:`subprocess` locking set according to the arguments.
 
      :throws IllegalArgumentError: Thrown when ``command`` is an empty string.
+
+     Some errors at process creation may be deferred until later method calls
+     are made, see :proc:`spawn` for these errors.
   */
   proc spawnshell(command:string, env:[] string=Subprocess.empty_env,
                   stdin:?t = pipeStyle.forward, stdout:?u = pipeStyle.forward,
@@ -1035,19 +1051,17 @@ module Subprocess {
 
     :arg signal: the signal to send
 
-    :throws BlockingIoError: If there weren't enough system resources when the
-                             subprocess was created to create it.
     :throws PermissionError: If the program did not have permission to send that
-                             signal to the target subprocess, or if there were
-                             permission issues when setting up the subprocess.
+                             signal to the target subprocess.
     :throws IllegalArgumentError: If an invalid signal was specified.
-    :throws SystemError: If there were other problems when initially setting up
-                         the subprocess.
     :throws ProcessLookupError: If the subprocess's pid or process group does
                                 not exist.  This can also happen if the
                                 subprocess is a zombie (a process that has
                                 already committed termination but has not yet
                                 been waited for).
+
+    In addition, some errors that occurred when the process was created may be
+    thrown when this method is called, see the documentation for :proc:`spawn`.
    */
   proc subprocess.sendPosixSignal(signal:int) throws {
     try _throw_on_launch_error();
@@ -1069,19 +1083,6 @@ module Subprocess {
     Request an abnormal termination of the child process.  The
     associated signal, `SIGABRT`, may be caught and handled by
     the child process. See :proc:`subprocess.sendPosixSignal`.
-
-    :throws BlockingIoError: If there weren't enough system resources when the
-                             subprocess was created to create it.
-    :throws PermissionError: If the program did not have permission to send that
-                             signal to the target subprocess, or if there were
-                             permission issues when setting up the subprocess.
-    :throws SystemError: If there were other problems when initially setting up
-                         the subprocess.
-    :throws ProcessLookupError: If the subprocess's pid or process group does
-                                not exist.  This can also happen if the
-                                subprocess is a zombie (a process that has
-                                already committed termination but has not yet
-                                been waited for).
    */
   proc subprocess.abort() throws {
     try _throw_on_launch_error();
@@ -1091,19 +1092,6 @@ module Subprocess {
   /* Send the child process an alarm signal. The associated signal,
      `SIGALRM`, may be caught and handled by the child process. See
      :proc:`subprocess.sendPosixSignal`.
-
-    :throws BlockingIoError: If there weren't enough system resources when the
-                             subprocess was created to create it.
-    :throws PermissionError: If the program did not have permission to send that
-                             signal to the target subprocess, or if there were
-                             permission issues when setting up the subprocess.
-    :throws SystemError: If there were other problems when initially setting up
-                         the subprocess.
-    :throws ProcessLookupError: If the subprocess's pid or process group does
-                                not exist.  This can also happen if the
-                                subprocess is a zombie (a process that has
-                                already committed termination but has not yet
-                                been waited for).
    */
   proc subprocess.alarm() throws {
     try _throw_on_launch_error();
@@ -1114,19 +1102,6 @@ module Subprocess {
     Unconditionally kill the child process.  The associated signal,
     `SIGKILL`, cannot be caught by the child process. See
     :proc:`subprocess.sendPosixSignal`.
-
-    :throws BlockingIoError: If there weren't enough system resources when the
-                             subprocess was created to create it.
-    :throws PermissionError: If the program did not have permission to send that
-                             signal to the target subprocess, or if there were
-                             permission issues when setting up the subprocess.
-    :throws SystemError: If there were other problems when initially setting up
-                         the subprocess.
-    :throws ProcessLookupError: If the subprocess's pid or process group does
-                                not exist.  This can also happen if the
-                                subprocess is a zombie (a process that has
-                                already committed termination but has not yet
-                                been waited for).
    */
   proc subprocess.kill() throws {
     try _throw_on_launch_error();
@@ -1137,19 +1112,6 @@ module Subprocess {
     Request termination of the child process.  The associated signal,
     `SIGTERM`, may be caught and handled by the child process. See
     :proc:`subprocess.sendPosixSignal`.
-
-    :throws BlockingIoError: If there weren't enough system resources when the
-                             subprocess was created to create it.
-    :throws PermissionError: If the program did not have permission to send that
-                             signal to the target subprocess, or if there were
-                             permission issues when setting up the subprocess.
-    :throws SystemError: If there were other problems when initially setting up
-                         the subprocess.
-    :throws ProcessLookupError: If the subprocess's pid or process group does
-                                not exist.  This can also happen if the
-                                subprocess is a zombie (a process that has
-                                already committed termination but has not yet
-                                been waited for).
    */
   proc subprocess.terminate() throws {
     try _throw_on_launch_error();

--- a/modules/standard/Subprocess.chpl
+++ b/modules/standard/Subprocess.chpl
@@ -1040,9 +1040,9 @@ module Subprocess {
     :throws PermissionError: If the program did not have permission to send that
                              signal to the target subprocess, or if there were
                              permission issues when setting up the subprocess.
-    :throws SystemError: If an invalid signal was specified or if there were
-                         other problems when initially setting up the
-                         subprocess.
+    :throws IllegalArgumentError: If an invalid signal was specified.
+    :throws SystemError: If there were other problems when initially setting up
+                         the subprocess.
     :throws ProcessLookupError: If the subprocess's pid or process group does
                                 not exist.  This can also happen if the
                                 subprocess is a zombie (a process that has
@@ -1056,7 +1056,13 @@ module Subprocess {
     on home {
       err = qio_send_signal(pid, signal:c_int);
     }
-    if err then try ioerror(err, "in subprocess.sendPosixSignal, with signal " + signal:string);
+    if (err == EINVAL) {
+      throw new IllegalArgumentError("Signal " + signal: string +
+                                     " is not a valid POSIX signal");
+    } else if err {
+      try ioerror(err, "in subprocess.sendPosixSignal, with signal " +
+                  signal:string);
+    }
   }
 
   /*

--- a/modules/standard/Subprocess.chpl
+++ b/modules/standard/Subprocess.chpl
@@ -965,6 +965,9 @@ module Subprocess {
     function does not wait for the subprocess to complete.  Note that it is
     generally not necessary to call this function since these channels will be
     closed when the subprocess record goes out of scope.
+
+    :throws SystemError: If the subprocess's stdin, stdout, or stderr were not
+                         successfully closed.
    */
   proc ref subprocess.close() throws {
     // TODO: see subprocess.wait() for more on this error handling approach
@@ -1031,6 +1034,20 @@ module Subprocess {
 
 
     :arg signal: the signal to send
+
+    :throws BlockingIoError: If there weren't enough system resources when the
+                             subprocess was created to create it.
+    :throws PermissionError: If the program did not have permission to send that
+                             signal to the target subprocess, or if there were
+                             permission issues when setting up the subprocess.
+    :throws SystemError: If an invalid signal was specified or if there were
+                         other problems when initially setting up the
+                         subprocess.
+    :throws ProcessLookupError: If the subprocess's pid or process group does
+                                not exist.  This can also happen if the
+                                subprocess is a zombie (a process that has
+                                already committed termination but has not yet
+                                been waited for).
    */
   proc subprocess.sendPosixSignal(signal:int) throws {
     try _throw_on_launch_error();
@@ -1046,6 +1063,19 @@ module Subprocess {
     Request an abnormal termination of the child process.  The
     associated signal, `SIGABRT`, may be caught and handled by
     the child process. See :proc:`subprocess.sendPosixSignal`.
+
+    :throws BlockingIoError: If there weren't enough system resources when the
+                             subprocess was created to create it.
+    :throws PermissionError: If the program did not have permission to send that
+                             signal to the target subprocess, or if there were
+                             permission issues when setting up the subprocess.
+    :throws SystemError: If there were other problems when initially setting up
+                         the subprocess.
+    :throws ProcessLookupError: If the subprocess's pid or process group does
+                                not exist.  This can also happen if the
+                                subprocess is a zombie (a process that has
+                                already committed termination but has not yet
+                                been waited for).
    */
   proc subprocess.abort() throws {
     try _throw_on_launch_error();
@@ -1055,6 +1085,19 @@ module Subprocess {
   /* Send the child process an alarm signal. The associated signal,
      `SIGALRM`, may be caught and handled by the child process. See
      :proc:`subprocess.sendPosixSignal`.
+
+    :throws BlockingIoError: If there weren't enough system resources when the
+                             subprocess was created to create it.
+    :throws PermissionError: If the program did not have permission to send that
+                             signal to the target subprocess, or if there were
+                             permission issues when setting up the subprocess.
+    :throws SystemError: If there were other problems when initially setting up
+                         the subprocess.
+    :throws ProcessLookupError: If the subprocess's pid or process group does
+                                not exist.  This can also happen if the
+                                subprocess is a zombie (a process that has
+                                already committed termination but has not yet
+                                been waited for).
    */
   proc subprocess.alarm() throws {
     try _throw_on_launch_error();
@@ -1065,6 +1108,19 @@ module Subprocess {
     Unconditionally kill the child process.  The associated signal,
     `SIGKILL`, cannot be caught by the child process. See
     :proc:`subprocess.sendPosixSignal`.
+
+    :throws BlockingIoError: If there weren't enough system resources when the
+                             subprocess was created to create it.
+    :throws PermissionError: If the program did not have permission to send that
+                             signal to the target subprocess, or if there were
+                             permission issues when setting up the subprocess.
+    :throws SystemError: If there were other problems when initially setting up
+                         the subprocess.
+    :throws ProcessLookupError: If the subprocess's pid or process group does
+                                not exist.  This can also happen if the
+                                subprocess is a zombie (a process that has
+                                already committed termination but has not yet
+                                been waited for).
    */
   proc subprocess.kill() throws {
     try _throw_on_launch_error();
@@ -1075,6 +1131,19 @@ module Subprocess {
     Request termination of the child process.  The associated signal,
     `SIGTERM`, may be caught and handled by the child process. See
     :proc:`subprocess.sendPosixSignal`.
+
+    :throws BlockingIoError: If there weren't enough system resources when the
+                             subprocess was created to create it.
+    :throws PermissionError: If the program did not have permission to send that
+                             signal to the target subprocess, or if there were
+                             permission issues when setting up the subprocess.
+    :throws SystemError: If there were other problems when initially setting up
+                         the subprocess.
+    :throws ProcessLookupError: If the subprocess's pid or process group does
+                                not exist.  This can also happen if the
+                                subprocess is a zombie (a process that has
+                                already committed termination but has not yet
+                                been waited for).
    */
   proc subprocess.terminate() throws {
     try _throw_on_launch_error();

--- a/modules/standard/Subprocess.chpl
+++ b/modules/standard/Subprocess.chpl
@@ -1082,7 +1082,8 @@ module Subprocess {
   /*
     Request an abnormal termination of the child process.  The
     associated signal, `SIGABRT`, may be caught and handled by
-    the child process. See :proc:`subprocess.sendPosixSignal`.
+    the child process. See :proc:`subprocess.sendPosixSignal` for details,
+    including what errors can be thrown.
    */
   proc subprocess.abort() throws {
     try _throw_on_launch_error();
@@ -1091,7 +1092,8 @@ module Subprocess {
 
   /* Send the child process an alarm signal. The associated signal,
      `SIGALRM`, may be caught and handled by the child process. See
-     :proc:`subprocess.sendPosixSignal`.
+     :proc:`subprocess.sendPosixSignal` for details, including what errors can
+     be thrown.
    */
   proc subprocess.alarm() throws {
     try _throw_on_launch_error();
@@ -1101,7 +1103,8 @@ module Subprocess {
   /*
     Unconditionally kill the child process.  The associated signal,
     `SIGKILL`, cannot be caught by the child process. See
-    :proc:`subprocess.sendPosixSignal`.
+    :proc:`subprocess.sendPosixSignal` for details, including what errors can be
+    thrown.
    */
   proc subprocess.kill() throws {
     try _throw_on_launch_error();
@@ -1111,7 +1114,8 @@ module Subprocess {
   /*
     Request termination of the child process.  The associated signal,
     `SIGTERM`, may be caught and handled by the child process. See
-    :proc:`subprocess.sendPosixSignal`.
+    :proc:`subprocess.sendPosixSignal` for details, including what errors can be
+    thrown.
    */
   proc subprocess.terminate() throws {
     try _throw_on_launch_error();

--- a/test/library/standard/Spawn/chpl_signal.h
+++ b/test/library/standard/Spawn/chpl_signal.h
@@ -1,0 +1,8 @@
+#include <signal.h>
+
+int chpl_SIGRTMAX(void);
+
+// Allow us to call the SIGRTMAX macro from Chapel code
+int chpl_SIGRTMAX(void) {
+  return SIGRTMAX;
+}

--- a/test/library/standard/Spawn/sendBadSignal.chpl
+++ b/test/library/standard/Spawn/sendBadSignal.chpl
@@ -1,0 +1,21 @@
+use Subprocess;
+use CTypes;
+
+extern proc chpl_SIGRTMAX(): c_int;
+
+// Make sure the subprocess stays around long enough for us to potentially
+// interact with it
+var subproc = spawn(["sleep", "60"]);
+
+try {
+  subproc.sendPosixSignal(chpl_SIGRTMAX() + 1);
+} catch e: IllegalArgumentError {
+  // This is the intended behavior
+  writeln("Caught IllegalArgumentError for too large signal");
+} catch {
+  // Catchall in case something else happened
+  writeln("oops, didn't catch too large signal");
+}
+
+// Ensure the subprocess completes
+subproc.wait();

--- a/test/library/standard/Spawn/sendBadSignal.compopts
+++ b/test/library/standard/Spawn/sendBadSignal.compopts
@@ -1,0 +1,1 @@
+chpl_signal.h

--- a/test/library/standard/Spawn/sendBadSignal.good
+++ b/test/library/standard/Spawn/sendBadSignal.good
@@ -1,0 +1,1 @@
+Caught IllegalArgumentError for too large signal

--- a/test/library/standard/Spawn/sendBadSignal.skipif
+++ b/test/library/standard/Spawn/sendBadSignal.skipif
@@ -1,0 +1,1 @@
+CHPL_TARGET_PLATFORM != linux64


### PR DESCRIPTION
Resolves #12162 

The following functions could throw errors, but did not tell users what errors could be thrown, making it more difficult for users to catch those errors and adjust their programs if possible.  Add documentation of what errors could be thrown to:
- subprocess.close()
- subprocess.sendPosixSignal()

Some of the errors thrown by sendPosixSignal and friends were a result of deferring errors from spawn/spawnshell.  Note those errors in spawn/spawnshell and refer back to them.

While here, I updated `sendPosixSignal` to throw an `IllegalArgumentError` if a bad signal was sent to the method.  The method was previously just throwing a `SystemError`, but that would be indistinguishable from the `SystemError`s that could be thrown if there was something wrong as a result of creating the subprocess in the first place.

Added a test to lock the behavior of sendPosixSignal in with bad signals.  Limited the test to only run on linux64 due to portability concerns (I was having some difficulty getting my Mac to find the POSIX-defined `SIGRTMAX` macro that seemed like a good way to guarantee checking a signal that didn't exist, so decided not to spend too much time on it).

Double checked the built documentation.  Passed a paratest with futures