### PR TITLE
Default to cstdlib atomics when CHPL_LLVM=bundled

### DIFF
--- a/util/chplenv/chpl_atomics.py
+++ b/util/chplenv/chpl_atomics.py
@@ -57,7 +57,10 @@ def get(flag='target'):
             elif compiler_val in ['allinea', 'cray-prgenv-allinea']:
                 atomics_val = 'cstdlib'
             elif compiler_val == 'clang':
-                if has_std_atomics():
+                # if using bundled LLVM, we can use cstdlib atomics
+                import chpl_llvm
+                has_llvm = chpl_llvm.get()
+                if has_llvm == "bundled" or has_std_atomics():
                     atomics_val = 'cstdlib'
                 else:
                     atomics_val = 'intrinsics'


### PR DESCRIPTION
When using `CHPL_TARGET_COMPILER=clang` and the bundled LLVM, we can assume `clang` supports cstdlib atomics.

Resolves https://github.com/chapel-lang/chapel/issues/18806