### PR TITLE
Mark functions generated by `lowerLoopExprs` compiler generated

### DIFF
--- a/compiler/AST/LoopExpr.cpp
+++ b/compiler/AST/LoopExpr.cpp
@@ -305,6 +305,7 @@ handleArrayTypeCase(LoopExpr* loopExpr, FnSymbol* fn, Expr* indices,
   // removed
   //
   FnSymbol* isArrayTypeFn = new FnSymbol("_isArrayTypeFn");
+  isArrayTypeFn->addFlag(FLAG_COMPILER_GENERATED);
   isArrayTypeFn->addFlag(FLAG_INLINE);
   isArrayTypeFn->setGeneric(false);
   fn->insertAtTail(new DefExpr(isArrayTypeFn));

--- a/compiler/AST/LoopExpr.cpp
+++ b/compiler/AST/LoopExpr.cpp
@@ -404,6 +404,7 @@ static FnSymbol* buildSerialIteratorFn(const char* iteratorName,
   FnSymbol* sifn = new FnSymbol(iteratorName);
   sifn->addFlag(FLAG_ITERATOR_FN);
   sifn->addFlag(FLAG_DONT_UNREF_FOR_YIELDS);
+  sifn->addFlag(FLAG_COMPILER_GENERATED);
   sifn->setGeneric(true);
 
   ArgSymbol* sifnIterator = new ArgSymbol(INTENT_BLANK, "iterator", dtAny);
@@ -453,6 +454,7 @@ static FnSymbol* buildLeaderIteratorFn(const char* iteratorName,
 {
   FnSymbol* lifn = new FnSymbol(iteratorName);
   lifn->addFlag(FLAG_FN_RETURNS_ITERATOR);
+  lifn->addFlag(FLAG_COMPILER_GENERATED);
   lifn->setGeneric(true);
 
   Expr* tag = new SymExpr(gLeaderTag);
@@ -489,6 +491,7 @@ static FnSymbol* buildFollowerIteratorFn(const char* iteratorName,
   FnSymbol* fifn = new FnSymbol(iteratorName);
   fifn->addFlag(FLAG_ITERATOR_FN);
   fifn->addFlag(FLAG_DONT_UNREF_FOR_YIELDS);
+  fifn->addFlag(FLAG_COMPILER_GENERATED);
   fifn->setGeneric(true);
 
   Expr* tag = new SymExpr(gFollowerTag);

--- a/test/expressions/new-expr/field-init-missing-args-bug.bad
+++ b/test/expressions/new-expr/field-init-missing-args-bug.bad
@@ -1,4 +1,0 @@
-field-init-missing-args-bug.chpl:6: error: type in 'new' expression is missing its argument list
-field-init-missing-args-bug.chpl:18: error: type in 'new' expression is missing its argument list
-field-init-missing-args-bug.chpl:18: error: type in 'new' expression is missing its argument list
-field-init-missing-args-bug.chpl:18: error: type in 'new' expression is missing its argument list

--- a/test/expressions/new-expr/field-init-missing-args-bug.future
+++ b/test/expressions/new-expr/field-init-missing-args-bug.future
@@ -1,1 +1,0 @@
-bug: compiler complains of missing argument list in 'new' that is there


### PR DESCRIPTION
Closes https://github.com/chapel-lang/chapel/issues/15588.

The top-level issue is that we call `normalize` a second time while building the loop functions (`chpl__loopexpr`). However, the calls to `normalize` re-visit the calls to `new C`, and trigger double-normalization. This is a known issue that's already worked around by the compiler.

https://github.com/chapel-lang/chapel/blob/adc72107e038052bff389f27595675d47fe84131/compiler/passes/normalize.cpp#L1431-L1438

The check below the comment avoids the error for compiler-generated functions. However, for some reason, the loop lowering functions aren't marked compiler generated, so when they are encountered, the error is not skipped. I marked them as COMPILER_GENERATED, got a clean paratest, and this bug is fixed.

The more "pure" solution is to avoid re-running `normalize` when outlining the loop expression functions. I tried this first, but the iterator logic relies on a lot of the functionality provided by `normalize` (return normalization etc.), and I could not get it working without. 

Reviewed by @dlongnecke-cray -- thanks!

## Testing
- [x] paratest