### PR TITLE
Fix issue with promotion cache that caused incorrect type inference

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -71,6 +71,7 @@ Symbol *gTimer = NULL;
 Symbol *gTaskID = NULL;
 Symbol *gSyncVarAuxFields = NULL;
 Symbol *gSingleVarAuxFields = NULL;
+Symbol *gIgnoredPromotionToken = NULL;
 
 VarSymbol *gTrue = NULL;
 VarSymbol *gFalse = NULL;

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -1288,6 +1288,8 @@ void initPrimitiveTypes() {
   CREATE_DEFAULT_SYMBOL(dtUninstantiated, gUninstantiated, "?");
   gUninstantiated->addFlag(FLAG_PARAM);
 
+  CREATE_DEFAULT_SYMBOL(dtVoid, gIgnoredPromotionToken, "_ignoredPromotionToken");
+
   // set up the well-known types, including setting up dummy types
   // for dtString / _string and a few others
   initializeWellKnown();

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -924,6 +924,8 @@ extern Symbol *gDummyWitness;
 extern Symbol *gDummyRef;
 // used in convert-uast to mark a SymExpr needing future adjustment
 extern Symbol *gFixupRequiredToken;
+extern Symbol *gIgnoredPromotionToken;
+
 extern VarSymbol *gTrue;
 extern VarSymbol *gFalse;
 extern VarSymbol *gIteratorBreakToken;

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -2512,6 +2512,14 @@ PromotionInfo::PromotionInfo(FnSymbol* fn,
     }
   }
 
+  // Ensure that the substitutions for ignored promoted functions are different
+  // from used promoted functions. This is needed because promoted functions
+  // whose results are ignored may not yield (see insertAndSaveWrapCall),
+  // but those that are not ignored do. We don't want them to be confused
+  // when consulting the promotion cache.
+  if (!resultIsUsed) {
+    this->subs.put(gIgnoredPromotionToken, gIgnoredPromotionToken);
+  }
 
   for_formals(formal, fn) {
     TypeSymbol* promotedType = NULL;

--- a/test/library/standard/Reflection/canResolvePromoReturn.chpl
+++ b/test/library/standard/Reflection/canResolvePromoReturn.chpl
@@ -1,0 +1,16 @@
+proc printHelper(expr) {
+  writeln(expr);
+  writeln(expr.type : string);
+  writeln(iteratorToArrayElementType(expr.type) : string);
+  for x in expr do writeln(x);
+}
+
+use Reflection;
+var x = [0,2,5];
+var y = [0,2,5];
+
+writeln(canResolve("==",x,y));
+printHelper(x==y);
+
+printHelper(x!=y);
+writeln(canResolve("!=",x,y));

--- a/test/library/standard/Reflection/canResolvePromoReturn.good
+++ b/test/library/standard/Reflection/canResolvePromoReturn.good
@@ -1,0 +1,14 @@
+true
+true true true
+iterator
+bool
+true
+true
+true
+false false false
+iterator
+bool
+false
+false
+false
+true


### PR DESCRIPTION
This PR fixes https://github.com/chapel-lang/chapel/issues/13160.

The issue was caused by the fact that for unused promoted expressions, we elide the `yield`s (since nothing needs to be returned, and the side effects are presumably the only thing we care about). 

https://github.com/chapel-lang/chapel/blob/adc72107e038052bff389f27595675d47fe84131/compiler/resolution/wrappers.cpp#L2588-L2596

However, if a promoted result is used in one place and ignored in another, we store one of these (yielding or non-yielding) versions into the cache, and re-use it. As a result, depending on the other, either both don't yield, or both yield; in either case, this is problematic. #13160 triggers this because the promoted expression in `canResolve` is resolved "standalone", and looks like a statement; as a result, it's "ignored". Then, when we resolve the same promotion again while printing it, we get the cached result, which has a `nothing` return type.

This PR fixes the issue by adding a new sentinel to the substitutions for a promotion when it's ignored. The substitutions are used to disambiguate the cache, and as a result, the promoted and non-promoted versions are stored separately.

Reviewed by @dlongnecke-cray -- thanks!

## Testing
- [x] paratest