### PR TITLE
Fixed injection in message-order MCM mode

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -4656,7 +4656,7 @@ void amReqFn_msgOrdFence(c_nodeid_t node,
     flags |= FI_FENCE | FI_DELIVERY_COMPLETE;
   }
   ctx = TX_CTX_INIT(tcip, blocking, &txnDone);
-  (void) wrap_fi_sendmsg(node, req, reqSize, mrDesc, ctx, flags, tcip); 
+  (void) wrap_fi_sendmsg(node, req, reqSize, mrDesc, ctx, flags, tcip);
   if (blocking) {
     waitForTxnComplete(tcip, ctx);
     txCtxCleanup(ctx);

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -351,7 +351,6 @@ static const char* mcmModeNames[] = { "undefined",
 // transmit-complete. However, in general we don't know whether a given
 // operation is the last. For this reason we can't use the fi_inject*
 // functions.
-// TODO: remove calls to fi_inject* from the code
 //
 
 


### PR DESCRIPTION
Modified message-order MCM mode to not use fi_inject* functions as they do not generate a completion event. See
the comment in` comm-ofi.c` for details. Also cleaned up transmit context initialization and refactored several
functions to have similar control flow. 

Signed-off-by: John H. Hartman <jhh67@users.noreply.github.com>