### PR TITLE
Fix test failures from #25454

### DIFF
--- a/test/library/packages/Curl/COMPOPTS
+++ b/test/library/packages/Curl/COMPOPTS
@@ -1,1 +1,0 @@
--sOpenReaderLockingDefault=false


### PR DESCRIPTION
Removes `-sOpenReaderLockingDefault=false` compopts from curl package tests as OpenReaderLockingDefault is now deprecated.