### PR TITLE
Produce better error message if partition doesn't exist

### DIFF
--- a/runtime/src/chpl-launcher-common.c
+++ b/runtime/src/chpl-launcher-common.c
@@ -219,7 +219,7 @@ chpl_run_utility1K(const char *command, char *const argv[], char *outbuf, int ou
       snprintf(buf, sizeof(buf), "Unable to run '%s' (no bytes read)",
                command);
       chpl_warning(buf, 0, 0);
-      return -1;
+      return 0;
     }
 
     // NOTE: We don't do a waitpid() here, so the program may keep running.

--- a/runtime/src/launch/slurm-srun/launch-slurm-srun.c
+++ b/runtime/src/launch/slurm-srun/launch-slurm-srun.c
@@ -147,8 +147,8 @@ static int getCoresPerLocale(int nomultithread, int32_t localesPerNode) {
       // not exist.
       char msg[2048];
       snprintf(msg, sizeof(msg),
-               "\"sinfo\" produced no output. Verify that partition "
-               "\"%s\" exists.", partition);
+               "'sinfo' produced no output. Verify that partition "
+               "'%s' exists.", partition);
 
       chpl_error(msg, 0, 0);
     } else if (rc <= 0) {

--- a/runtime/src/launch/slurm-srun/launch-slurm-srun.c
+++ b/runtime/src/launch/slurm-srun/launch-slurm-srun.c
@@ -138,18 +138,31 @@ static int getCoresPerLocale(int nomultithread, int32_t localesPerNode) {
     argv[6] = NULL;
   }
 
-  memset(buf, 0, buflen);
-  if (chpl_run_utility1K("sinfo", argv, buf, buflen) <= 0) {
-    chpl_error("Error trying to determine number of cores per node", 0, 0);
-  }
+  // We may have to run sinfo twice -- once with %i and once without
+  for (int i = 0; i < 2; i++) {
+    memset(buf, 0, buflen);
+    int rc = chpl_run_utility1K("sinfo", argv, buf, buflen);
+    if ((rc == 0) && partition) {
+      // if sinfo produced no output it might be because the partition does
+      // not exist.
+      char msg[2048];
+      snprintf(msg, sizeof(msg),
+               "\"sinfo\" produced no output. Verify that partition "
+               "\"%s\" exists.", partition);
 
-  if (strstr(buf, "Invalid node format specification: i")) {
-    // older versions of sinfo don't support the %i format. Try again
-    // without it. We won't be able to exclude reservations, but there's
-    // not much we can do about that.
-    argv[2] = (char *)  "--format=%c %Z";
-    if (chpl_run_utility1K("sinfo", argv, buf, buflen) <= 0) {
-      chpl_error("Error trying to determine number of cores per node", 0, 0);
+      chpl_error(msg, 0, 0);
+    } else if (rc <= 0) {
+        chpl_error("Error trying to determine number of cores per node", 0, 0);
+    }
+
+    if (strstr(buf, "Invalid node format specification: i")) {
+      // older versions of sinfo don't support the %i format. Try again
+      // without it. We won't be able to exclude reservations, but there's
+      // not much we can do about that.
+      argv[2] = (char *)  "--format=%c %Z";
+    } else {
+      // sinfo produced non-error output
+      break;
     }
   }
 


### PR DESCRIPTION
If `sinfo` produces no output it could be because the specified partition does not exist.

Resolves https://github.com/Cray/chapel-private/issues/4101.

Signed-off-by: John H. Hartman <jhh67@users.noreply.github.com>