### PR TITLE
Resolve qualified inheritance expressions in classes

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -3041,7 +3041,10 @@ void AggregateType::discoverParentAndCheck(Expr* storesName,
 
   ts->maybeGenerateDeprecationWarning(storesName);
 
-  AggregateType* pt = toAggregateType(ts->type);
+  // When Dyno is handling the conversion, it automatically inserts
+  // 'anymanaged' into class references. What we want for inheritance is
+  // not 'anymanaged C' but 'C', so use `canonicalClassType`.
+  AggregateType* pt = toAggregateType(canonicalClassType(ts->type));
 
   if (pt == NULL) {
     USR_FATAL(storesName, "Illegal super class %s", ts->name);

--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -3039,12 +3039,17 @@ void AggregateType::discoverParentAndCheck(Expr* storesName,
     USR_FATAL(storesName, "Illegal super class");
   }
 
-  ts->maybeGenerateDeprecationWarning(storesName);
-
   // When Dyno is handling the conversion, it automatically inserts
   // 'anymanaged' into class references. What we want for inheritance is
   // not 'anymanaged C' but 'C', so use `canonicalClassType`.
-  AggregateType* pt = toAggregateType(canonicalClassType(ts->type));
+  Type* ct = canonicalClassType(ts->type);
+  bool dynoWasUsed = (ct != ts->type);
+  AggregateType* pt = toAggregateType(ct);
+
+  // Dyno would already have issued the deprecation warning
+  if (!dynoWasUsed) {
+    ts->maybeGenerateDeprecationWarning(storesName);
+  }
 
   if (pt == NULL) {
     USR_FATAL(storesName, "Illegal super class %s", ts->name);

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -4142,7 +4142,7 @@ struct Converter {
       // get the resolution results. Thus, instead of doing (. 'M' 'C')
       // just refer to 'C'.
       if (auto results = currentResolutionResult()) {
-        if (auto result = results->byAstOrNull(inheritExpr)) {
+        if (auto result = results->byAstOrNull(ident)) {
           auto toId = result->toId();
           if (!toId.isEmpty()) {
             if (auto converted = findConvertedSym(toId)) {

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -4139,8 +4139,9 @@ struct Converter {
       inheritMarkedGeneric |= thisInheritMarkedGeneric;
 
       // Don't convert the expression literally if we have a `toId`.
-      // get the resolution results. Thus, instead of doing (. 'M' 'C')
-      // just refer to 'C'.
+      // The production scope resolver doesnt't support M.C as a class
+      // inheritance expression, but we already know what it refers to.
+      // Thus, instead of doing (. 'M' 'C') we can just refer to 'C'.
       if (auto results = currentResolutionResult()) {
         if (auto result = results->byAstOrNull(ident)) {
           auto toId = result->toId();

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -4138,11 +4138,17 @@ struct Converter {
       // get the resolution results. Thus, instead of doing (. 'M' 'C')
       // just refer to 'C'.
       if (auto results = currentResolutionResult()) {
-        debuggerBreakHere();
         if (auto result = results->byAstOrNull(inheritExpr)) {
           auto toId = result->toId();
           if (!toId.isEmpty()) {
             if (auto converted = findConvertedSym(toId)) {
+              // Normally, findConvertedSym wraps classes in anymanaged.
+              // We don't want that for inherit exprs; instead, we want
+              // the canonical representation.
+              if (auto ts = toTypeSymbol(converted)) {
+                converted = canonicalClassType(ts->type)->symbol;
+              }
+
               inherits.push_back(new SymExpr(converted));
               continue;
             }

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -4132,6 +4132,10 @@ struct Converter {
       auto* ident =
         uast::Class::getUnwrappedInheritExpr(inheritExpr, thisInheritMarkedGeneric);
 
+      // Always convert the taraget expression so that we note used modules
+      // as needed. We won't necessarily use the resulting expression;
+      // see the comment below.
+      auto converted = convertExprOrNull(ident);
       inheritMarkedGeneric |= thisInheritMarkedGeneric;
 
       // Don't convert the expression literally if we have a `toId`.
@@ -4157,7 +4161,7 @@ struct Converter {
       }
 
       // Couldn't find the target, so translate it literally.
-      if (auto converted = convertExprOrNull(ident)) {
+      if (converted) {
         inherits.push_back(converted);
       }
     }

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -4147,13 +4147,6 @@ struct Converter {
           auto toId = result->toId();
           if (!toId.isEmpty()) {
             if (auto converted = findConvertedSym(toId)) {
-              // Normally, findConvertedSym wraps classes in anymanaged.
-              // We don't want that for inherit exprs; instead, we want
-              // the canonical representation.
-              if (auto ts = toTypeSymbol(converted)) {
-                converted = canonicalClassType(ts->type)->symbol;
-              }
-
               inherits.push_back(new SymExpr(converted));
               continue;
             }

--- a/frontend/include/chpl/uast/AggregateDecl.h
+++ b/frontend/include/chpl/uast/AggregateDecl.h
@@ -191,10 +191,10 @@ class AggregateDecl : public TypeDecl {
               children_.begin() + inheritExprChildNum_ + numInheritExprs_);
   }
 
-  /** Returns the inherited Identifier, including considering
+  /** Returns the inherited Identifier or Dot, including considering
       one marked generic with Superclass(?) */
-  static const Identifier* getInheritExprIdent(const AstNode* ast,
-                                               bool& markedGeneric);
+  static const AstNode* getUnwrappedInheritExpr(const AstNode* ast,
+                                            bool& markedGeneric);
   /** Returns true if the passed inherit expression is legal */
   static bool isAcceptableInheritExpr(const AstNode* ast);
 };

--- a/frontend/include/chpl/uast/AggregateDecl.h
+++ b/frontend/include/chpl/uast/AggregateDecl.h
@@ -91,11 +91,7 @@ class AggregateDecl : public TypeDecl {
                   elementsChildNum);
     }
 
-    if (inheritExprChildNum_ != NO_CHILD) {
-      for (int i = 0; i < numInheritExprs_; i++) {
-        CHPL_ASSERT(isAcceptableInheritExpr(child(inheritExprChildNum_ + i)));
-      }
-    }
+    // Don't validate inherit expressions here, they're checked post-parse.
 
     CHPL_ASSERT(validAggregateChildren(declOrComments()));
   }
@@ -195,8 +191,6 @@ class AggregateDecl : public TypeDecl {
       one marked generic with Superclass(?) */
   static const AstNode* getUnwrappedInheritExpr(const AstNode* ast,
                                             bool& markedGeneric);
-  /** Returns true if the passed inherit expression is legal */
-  static bool isAcceptableInheritExpr(const AstNode* ast);
 };
 
 

--- a/frontend/lib/parsing/ParserContextImpl.h
+++ b/frontend/lib/parsing/ParserContextImpl.h
@@ -2773,16 +2773,9 @@ ParserContext::buildAggregateTypeDecl(YYLTYPE location,
     if (optInherit->size() > 0) {
       for (size_t i = 0; i < optInherit->size(); i++) {
         AstNode* ast = (*optInherit)[i];
-        bool inheritOk =
-          chpl::uast::AggregateDecl::isAcceptableInheritExpr(ast);
 
-        if (inheritOk) {
-          inheritExprs.push_back(toOwned(ast));
-          (*optInherit)[i] = nullptr;
-        } else {
-          syntax(inheritLoc,
-                 "invalid parent class or interface; please specify a single class or interface name");
-        }
+        inheritExprs.push_back(toOwned(ast));
+        (*optInherit)[i] = nullptr;
       }
     }
     consumeList(optInherit); // just to delete it

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -597,12 +597,12 @@ gatherParentClassScopesForScopeResolving(Context* context, ID classDeclId) {
     // Uses the empty 'savecReceiverScopes' because the class expression
     // can't be a method anyways.
     bool ignoredMarkedGeneric = false;
-    auto ident = Class::getUnwrappedInheritExpr(inheritExpr,
+    auto inherit = Class::getUnwrappedInheritExpr(inheritExpr,
                                                 ignoredMarkedGeneric);
-    ident->traverse(visitor);
+    inherit->traverse(visitor);
 
 
-    ResolvedExpression& re = r.byAst(ident);
+    ResolvedExpression& re = r.byAst(inherit);
     if (re.toId().isEmpty()) {
       context->error(inheritExpr, "invalid parent class expression");
       encounteredError = true;

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -597,9 +597,9 @@ gatherParentClassScopesForScopeResolving(Context* context, ID classDeclId) {
     // Uses the empty 'savecReceiverScopes' because the class expression
     // can't be a method anyways.
     bool ignoredMarkedGeneric = false;
-    auto ident = Class::getInheritExprIdent(inheritExpr,
-                                            ignoredMarkedGeneric);
-    visitor.resolveIdentifier(ident, visitor.savedReceiverScopes);
+    auto ident = Class::getUnwrappedInheritExpr(inheritExpr,
+                                                ignoredMarkedGeneric);
+    ident->traverse(visitor);
 
 
     ResolvedExpression& re = r.byAst(ident);

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2613,6 +2613,12 @@ const ResolutionResultByPostorderID& scopeResolveAggregate(Context* context,
   ResolutionResultByPostorderID result;
 
   if (ad) {
+    // These are children, but are skipped by the is*Decl conditions below.
+    for (auto inheritExpr : ad->inheritExprs()) {
+      auto res = Resolver::createForScopeResolvingField(context, ad, inheritExpr, result);
+      inheritExpr->traverse(res);
+    }
+
     // TODO: Use some kind of "ad->fields()" iterator
     for (auto child : ad->children()) {
       if (child->isVarLikeDecl() ||

--- a/frontend/lib/uast/AggregateDecl.cpp
+++ b/frontend/lib/uast/AggregateDecl.cpp
@@ -60,23 +60,27 @@ std::string AggregateDecl::aggregateDeclDumpChildLabelInner(int i) const {
 AggregateDecl::~AggregateDecl() {
 }
 
-const Identifier* AggregateDecl::getInheritExprIdent(const AstNode* ast,
-                                                     bool& markedGeneric) {
+const AstNode* AggregateDecl::getUnwrappedInheritExpr(const AstNode* ast,
+                                                      bool& markedGeneric) {
+  // This doesn't do a deep check that e.g., the Dot expression is well-formed.
+  // This is expected to be done once during post-parse checks.
+
   if (ast != nullptr) {
-    if (ast->isIdentifier()) {
-      // inheriting from e.g. Parent is OK
+    if (ast->isIdentifier() || ast->isDot()) {
+      // inheriting from e.g. Parent or M.Parent is OK
       markedGeneric = false;
-      return ast->toIdentifier();
+      return ast;
     } else if (auto call = ast->toFnCall()) {
       const AstNode* calledExpr = call->calledExpression();
-      if (calledExpr != nullptr && calledExpr->isIdentifier() &&
+      if (calledExpr != nullptr &&
+          (calledExpr->isIdentifier() || calledExpr->isDot()) &&
           call->numActuals() == 1) {
         if (const AstNode* actual = call->actual(0)) {
           if (auto id = actual->toIdentifier()) {
             if (id->name() == USTR("?")) {
               // inheriting from e.g. Parent(?) is OK
               markedGeneric = true;
-              return calledExpr->toIdentifier();
+              return calledExpr;
             }
           }
         }
@@ -90,7 +94,7 @@ const Identifier* AggregateDecl::getInheritExprIdent(const AstNode* ast,
 
 bool AggregateDecl::isAcceptableInheritExpr(const AstNode* ast) {
   bool ignoredMarkedGeneric = false;
-  return getInheritExprIdent(ast, ignoredMarkedGeneric) != nullptr;
+  return getUnwrappedInheritExpr(ast, ignoredMarkedGeneric) != nullptr;
 }
 
 

--- a/frontend/lib/uast/AggregateDecl.cpp
+++ b/frontend/lib/uast/AggregateDecl.cpp
@@ -92,11 +92,6 @@ const AstNode* AggregateDecl::getUnwrappedInheritExpr(const AstNode* ast,
   return nullptr;
 }
 
-bool AggregateDecl::isAcceptableInheritExpr(const AstNode* ast) {
-  bool ignoredMarkedGeneric = false;
-  return getUnwrappedInheritExpr(ast, ignoredMarkedGeneric) != nullptr;
-}
-
 
 } // namespace uast
 } // namespace chpl

--- a/frontend/test/resolution/testModuleInitOrder.cpp
+++ b/frontend/test/resolution/testModuleInitOrder.cpp
@@ -249,6 +249,45 @@ static void testFindMention(void) {
   std::cout << std::endl;
 }
 
+static void testFindMentionInherit(void) {
+  Context::Configuration config;
+  config.chplHome = chplHome();
+  Context context(config);
+  Context* ctx = &context;
+  ErrorGuard guard(ctx);
+
+  auto path = TEST_NAME(ctx);
+  std::cout << path.c_str() << std::endl;
+
+  std::string contents =
+    R""""(
+    module M1 {
+      class Child : Sub1.Sub2.Parent {}
+      module Sub1 {
+        module Sub2 {
+          class Parent {}
+        }
+      }
+    }
+    )"""";
+
+  setFileText(ctx, path, contents);
+
+  // Get the module.
+  auto& br = parseAndReportErrors(ctx, path);
+  assert(br.numTopLevelExpressions() == 1);
+  auto m1 = br.topLevelExpression(0)->toModule();
+  assert(m1);
+
+  // check that we find the correct list of mentioned modules
+  checkMentionedModules(ctx, m1->id(), {"Sub1", "Sub2"});
+
+  std::cout << "---" << std::endl;
+
+  assert(!guard.realizeErrors());
+  std::cout << std::endl;
+}
+
 static void testFindMentionFields(void) {
   Context::Configuration config;
   config.chplHome = chplHome();
@@ -823,6 +862,7 @@ int main() {
   testFindUse();
   testFindImport();
   testFindMention();
+  testFindMentionInherit();
   testFindMentionFields();
   testFindMentionNotFields();
   testFindImportSubmoduleIncluded();

--- a/test/classes/ferguson/generic-inherit6.bad
+++ b/test/classes/ferguson/generic-inherit6.bad
@@ -1,1 +1,1 @@
-generic-inherit6.chpl:13: syntax error: invalid parent class or interface; please specify a single class or interface name
+generic-inherit6.chpl:13: error: invalid parent class or interface; please specify a single (possibly qualified) class or interface name

--- a/test/errors/parsing/bad-superclass.1.good
+++ b/test/errors/parsing/bad-superclass.1.good
@@ -1,0 +1,4 @@
+bad-superclass.chpl:11: error: invalid parent class or interface; please specify a single (possibly qualified) class or interface name
+bad-superclass.chpl:12: error: invalid parent class or interface; please specify a single (possibly qualified) class or interface name
+bad-superclass.chpl:13: error: invalid parent class or interface; please specify a single (possibly qualified) class or interface name
+bad-superclass.chpl:14: error: invalid parent class or interface; please specify a single (possibly qualified) class or interface name

--- a/test/errors/parsing/bad-superclass.2.good
+++ b/test/errors/parsing/bad-superclass.2.good
@@ -1,0 +1,12 @@
+─── error in bad-superclass.chpl:11 ───
+  Invalid parent class or interface; please specify a single (possibly qualified) class or interface name
+
+─── error in bad-superclass.chpl:12 ───
+  Invalid parent class or interface; please specify a single (possibly qualified) class or interface name
+
+─── error in bad-superclass.chpl:13 ───
+  Invalid parent class or interface; please specify a single (possibly qualified) class or interface name
+
+─── error in bad-superclass.chpl:14 ───
+  Invalid parent class or interface; please specify a single (possibly qualified) class or interface name
+

--- a/test/errors/parsing/bad-superclass.chpl
+++ b/test/errors/parsing/bad-superclass.chpl
@@ -1,0 +1,14 @@
+class Parent {
+
+}
+
+class Wrapper {
+  proc type wrapsType type do return Parent;
+}
+
+proc doNothing(type input) type do return input;
+
+class C : doNothing(Parent) {}
+class D : doNothing(Wrapper).wrapsType {}
+class E : (doNothing(Parent))(?) {}
+class F : (doNothing(Wrapper).wrapsType)(?) {}


### PR DESCRIPTION
Closes https://github.com/chapel-lang/chapel/issues/13086.

This PR adds support for module-qualified inheritance expressions in classes.

```Chapel
module ModuleA {
  class A { }
}

module ModuleB {
  import ModuleA;
  class B: ModuleA.A { }
}
```

Importantly, this __relies on the Dyno scope resolver__ to find the module references prior to converting the AST into the "classic" / old AST. Thus, unless `--dyno-scope-bundled` is used, the bundled modules __will not__ support this feature. It's much harder to get the production resolver to make this work, due to various ordering dependencies of when classes are constructed / unresolved expressions are resolved.

I think this is fine because:
1. The limitation only affects standard library developers. User code will get this feature, because the Dyno scope resolver has been on by default for many releases now. 
2. Dyno is meant to replace the production compiler in the near future (barring some performance issues with `--dyno-scope-bundled`), so this limitation will eventually go away.

The PR works by simply short-cutting the conversion of `M.N.Parent` directly into `Parent` in the production AST. As an implementation detail, a production AST representation of `M.N.Parent` is still created, which helps properly keep track of the fact that `M` and `N` were used by the module containing the child class. The production compiler thus sees the same thing it would see if the user wrote `use` and referenced the `Parent` expression directly.

Reviewed by @benharsh -- thanks!

## Testing
- [x] paratest