### PR TITLE
add regression test for partial generic instantation

### DIFF
--- a/test/types/partial/issue-18005.chpl
+++ b/test/types/partial/issue-18005.chpl
@@ -1,0 +1,16 @@
+use Map;
+
+class B {
+  var name:string;
+}
+
+record R {
+  var bar: map(string, B);
+}
+
+var x = new R();
+writeln(x);
+
+/*
+  warn of partial instantiation, see github.com/chapel-lang/chapel/issues/18005
+*/

--- a/test/types/partial/issue-18005.good
+++ b/test/types/partial/issue-18005.good
@@ -1,0 +1,11 @@
+issue-18005.chpl:8: warning: partial instantiation without '?' argument
+issue-18005.chpl:8: note: opt in to partial instantiation explicitly with a trailing '?' argument
+issue-18005.chpl:8: note: or, add arguments to instantiate the following fields in generic type 'map(string,B,false)':
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: note:   generic type field 'valType'
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: note:   generic field 'resizeThreshold'
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: note:   generic field '_lock'
+issue-18005.chpl:8: warning: unstable type construction with some generic defaults
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: note: this type construction might ignore field defaults in the type declared here but that may change
+issue-18005.chpl:8: warning: unstable type construction with some generic defaults
+$CHPL_HOME/modules/standard/Map.chpl:nnnn: note: this type construction might ignore field defaults in the type declared here but that may change
+issue-18005.chpl:11: error: initialization requires an argument for bar

--- a/test/types/partial/issue-18005.prediff
+++ b/test/types/partial/issue-18005.prediff
@@ -1,0 +1,1 @@
+../../functions/operatorOverloads/operatorMethods/nestedMethodBad.prediff


### PR DESCRIPTION
Adds a test for partial instantiation of a generic to serve as a regression test against #18005.

TESTING:

- [x] paratest `[Summary: #Successes = 17375 | #Failures = 0 | #Futures = 921]`
- [x] paratest gasnet `[Summary: #Successes = 17556 | #Failures = 0 | #Futures = 927]`

[reviewed by @DanilaFe - thanks!]