### PR TITLE
Allow ref-intent functions to not return anything if they halt

### DIFF
--- a/compiler/passes/checkGeneratedAst.cpp
+++ b/compiler/passes/checkGeneratedAst.cpp
@@ -429,11 +429,6 @@ checkFunction(FnSymbol* fn) {
 
   if (numVoidReturns != 0 && numNonVoidReturns != 0)
     USR_FATAL_CONT(fn, "Not all returns in this function return a value");
-  if (!isIterator && !fn->hasFlag(FLAG_NO_FN_BODY) &&
-      fn->returnsRefOrConstRef() &&
-      numNonVoidReturns == 0) {
-    USR_FATAL_CONT(fn, "function declared 'ref' but does not return anything");
-  }
 
   if (isIterator) {
     for_formals(formal, fn) {

--- a/compiler/passes/checkResolved.cpp
+++ b/compiler/passes/checkResolved.cpp
@@ -551,13 +551,19 @@ checkReturnPaths(FnSymbol* fn) {
       fn->hasFlag(FLAG_THUNK_BUILDER) ||
       !strcmp(fn->name, "=") || // TODO: Remove this to enforce new signature.
       !strcmp(fn->name, "chpl__buildArrayRuntimeType") ||
-      fn->retType == dtVoid ||
       fn->retTag == RET_TYPE ||
       fn->hasFlag(FLAG_EXTERN) ||
       fn->hasFlag(FLAG_INIT_TUPLE) ||
       fn->hasFlag(FLAG_AUTO_II) ||
       fn->hasFlag(FLAG_THUNK_INVOKE))
     return; // No.
+
+  if (fn->retType == dtVoid) {
+    if (fn->returnsRefOrConstRef()) {
+      USR_FATAL_CONT(fn, "function declared 'ref' but does not return anything");
+    }
+    return; // Doesn't return a value, no need to look for returns.
+  }
 
   // Check to see if the returned value is initialized.
   Symbol* ret = fn->getReturnSymbol();

--- a/test/functions/bradc/varFns/declVarRetHalt.chpl
+++ b/test/functions/bradc/varFns/declVarRetHalt.chpl
@@ -1,0 +1,4 @@
+proc p() ref : int {
+   halt();
+}
+p();

--- a/test/functions/bradc/varFns/declVarRetHalt.good
+++ b/test/functions/bradc/varFns/declVarRetHalt.good
@@ -1,0 +1,1 @@
+declVarRetHalt.chpl:2: error: halt reached

--- a/test/functions/bradc/varFns/declVarRetNothing.chpl
+++ b/test/functions/bradc/varFns/declVarRetNothing.chpl
@@ -2,7 +2,7 @@ proc testit(i) ref {
   writeln("I'm in testit, but not returning anything");
 }
 
-proc testit(i) ref {
+proc testit2(i) ref {
   writeln("I'm in testit, but not returning anything");
   return;
 }

--- a/test/functions/bradc/varFns/declVarRetNothingFromNonVoidFn.chpl
+++ b/test/functions/bradc/varFns/declVarRetNothingFromNonVoidFn.chpl
@@ -1,0 +1,4 @@
+proc p() ref : int {
+
+}
+p();

--- a/test/functions/bradc/varFns/declVarRetNothingFromNonVoidFn.good
+++ b/test/functions/bradc/varFns/declVarRetNothingFromNonVoidFn.good
@@ -1,0 +1,2 @@
+declVarRetNothingFromNonVoidFn.chpl:1: In function 'p':
+declVarRetNothingFromNonVoidFn.chpl:1: error: control reaches end of function that returns a value

--- a/test/functions/bradc/varFns/declVarRetVoidFromRefFn.chpl
+++ b/test/functions/bradc/varFns/declVarRetVoidFromRefFn.chpl
@@ -1,0 +1,4 @@
+proc p() ref : int {
+    return;
+}
+p();

--- a/test/functions/bradc/varFns/declVarRetVoidFromRefFn.good
+++ b/test/functions/bradc/varFns/declVarRetVoidFromRefFn.good
@@ -1,0 +1,1 @@
+declVarRetVoidFromRefFn.chpl:1: error: function declared 'ref' but does not return anything

--- a/test/functions/bradc/varFns/declVarUsedRetHalt.chpl
+++ b/test/functions/bradc/varFns/declVarUsedRetHalt.chpl
@@ -1,0 +1,4 @@
+proc p() ref : int {
+   halt();
+}
+ref q = p();

--- a/test/functions/bradc/varFns/declVarUsedRetHalt.good
+++ b/test/functions/bradc/varFns/declVarUsedRetHalt.good
@@ -1,0 +1,1 @@
+declVarUsedRetHalt.chpl:2: error: halt reached


### PR DESCRIPTION
This PR defers a check that causes https://github.com/chapel-lang/chapel/issues/10936 (thus, it closes https://github.com/chapel-lang/chapel/issues/10936).

The error message / check is only intend for cases where the function has no `return`, or has a non-value returning statement (`return;`). If even one value return exists -- even if it's not always reached -- the check will not trigger. Instead, the post-resolution control-flow return checking would catch the issue. However, this check accidentally captures the case when a value is claimed to be returned, but a halt is present. Normally, this case is handled by the aforementioned before-resolution control flow checking.

This PR defers the check for "returning nothing by ref" to the control-flow sensitive stage as well, and narrows it specifically for `void` functions, instead of all functions that have no returns. The existing logic takes care of missing or `void` returns for non-`void` functions.

Reviewed by @vasslitvinov -- thanks!

## Testing
- [x] paratest