### PR TITLE
Fix warning that was unfixable by users

### DIFF
--- a/modules/standard/Types.chpl
+++ b/modules/standard/Types.chpl
@@ -25,9 +25,11 @@ pragma "module included by default"
 module Types {
   import HaltWrappers;
 
+pragma "suppress generic actual warning"
 @chpldoc.nodoc // joint documentation with the next one
 proc isType(type t) param do return true;
 /* Returns ``true`` if the argument is a type. */
+pragma "suppress generic actual warning"
 proc isType(e) param do return false;
 
 @chpldoc.nodoc // joint documentation with the next one

--- a/test/functions/generic/genericActual-isType.chpl
+++ b/test/functions/generic/genericActual-isType.chpl
@@ -1,0 +1,24 @@
+// a test that eventually calls `isType` should not have warnings about `(?)`
+// from https://github.com/chapel-lang/chapel/issues/25492
+use Sort only DefaultComparator, ReverseComparator;
+config param copyinit = false;
+
+record heap {
+    type eltType;
+    type comparator = DefaultComparator; 
+
+    proc init(type eltType, type comparator=DefaultComparator) {
+      this.eltType = eltType;
+      this.comparator = comparator;
+    }
+
+    proc init=(other: this.type) where copyinit {
+      this.eltType = this.type.eltType;
+      this.comparator = this.type.comparator;
+    }
+}
+
+var h1;
+h1 = new heap(int, ReverseComparator(?));
+writeln(h1.type:string);
+writeln(h1);

--- a/test/functions/generic/genericActual-isType.good
+++ b/test/functions/generic/genericActual-isType.good
@@ -1,0 +1,2 @@
+heap(int(64),ReverseComparator)
+()


### PR DESCRIPTION
Patches `Types.chpl` to fix a warning that could not be fixed in user code.

Resolves https://github.com/chapel-lang/chapel/issues/25492

[Reviewed by @mppf]