### PR TITLE
Warn when using CHPL_ATOMICS=intrinsics

### DIFF
--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -593,6 +593,10 @@ CHPL_ATOMICS
    operations in Chapel or :ref:`readme-atomics` for more information about the
    runtime implementation.
 
+   .. warning::
+
+     Using ``CHPL_ATOMICS=intrinsics`` is a known performance issue. Please consider using ``CHPL_ATOMICS=cstdlib`` or ``CHPL_ATOMICS=locks`` for better performance, if possible. If not, please open an issue on GitHub.
+
 .. _readme-chplenv.CHPL_TIMERS:
 
 CHPL_TIMERS

--- a/util/chplenv/chpl_atomics.py
+++ b/util/chplenv/chpl_atomics.py
@@ -4,7 +4,7 @@ import sys
 
 import chpl_comm, chpl_compiler, chpl_platform, overrides
 from compiler_utils import CompVersion, get_compiler_version, has_std_atomics
-from utils import error, memoize
+from utils import error, memoize, warning
 
 
 @memoize
@@ -19,6 +19,8 @@ def get(flag='target'):
                 atomics_val = 'none'
     elif flag == 'target':
         atomics_val = overrides.get('CHPL_ATOMICS')
+        is_user_specified = atomics_val is not None
+        is_intel = False
         if not atomics_val:
             compiler_val = chpl_compiler.get('target')
             platform_val = chpl_platform.get('target')
@@ -42,6 +44,8 @@ def get(flag='target'):
             #
             # For pgi or 32-bit platforms with an older gcc, we fall back to
             # locks
+
+            is_intel = compiler_val == 'intel' or compiler_val == 'cray-prgenv-intel'
             if compiler_val in ['gnu', 'cray-prgenv-gnu', 'mpi-gnu']:
                 version = get_compiler_version(flag)
                 if version >= CompVersion('5.0'):
@@ -50,7 +54,7 @@ def get(flag='target'):
                     atomics_val = 'intrinsics'
                 elif version >= CompVersion('4.1') and not platform_val.endswith('32'):
                     atomics_val = 'intrinsics'
-            elif compiler_val == 'intel' or compiler_val == 'cray-prgenv-intel':
+            elif is_intel:
                 atomics_val = 'intrinsics'
             elif compiler_val == 'cray-prgenv-cray':
                 atomics_val = 'cstdlib'
@@ -69,6 +73,15 @@ def get(flag='target'):
                 atomics_val = 'locks'
     else:
         error("Invalid flag: '{0}'".format(flag), ValueError)
+
+    if flag == 'target' and atomics_val == 'intrinsics':
+        msg = "Using CHPL_ATOMICS=intrinsics is a known performance issue"
+        if is_intel:
+            msg += " but is required for portability with Intel compilers for the time being"
+        elif is_user_specified:
+            msg += ": please consider using CHPL_ATOMICS=cstdlib"
+        warning(msg)
+
     return atomics_val
 
 


### PR DESCRIPTION
Using `CHPL_ATOMICS=intrinsics` is only available to provide maximum portability, but is a killer for performance (see https://github.com/chapel-lang/chapel/issues/10996). This PR adds documentation to that effect and a `printchplenv` warning when `CHPL_ATOMICS=intrinsics`.

Closes https://github.com/chapel-lang/chapel/issues/10996, which has been left open to document the performance issue. Now that this will be documented in our actual docs, this issue can be closed.

Note: this is related to https://github.com/chapel-lang/chapel/issues/11029, which is about making the default for `CHPL_ATOMICS` cstdlib on all platforms. But `CHPL_ATOMICS=intrinsics` is important for portability with the intel compiler

[Reviewed by @jhh67]