### PR TITLE
Improve compilation commands for LAPACK and LinearAlgebra

### DIFF
--- a/modules/packages/LAPACK.chpl
+++ b/modules/packages/LAPACK.chpl
@@ -91,9 +91,9 @@ Once the details are worked out, compiling is quite simple and nearly identical 
 
 .. code-block:: sh
 
-  chpl -I$PATH_TO_LAPACKE_INCLUDE_DIR \
-       -L$PATH_TO_LIBGFORTRAN -lgfortran \
-       -L$PATH_TO_LAPACK_BINARIES -llapacke -llapack -lrefblas \
+  chpl -I/path/to/lapack/header/file \
+       -L/path/to/gfortran/library/file -lgfortran \
+       -L/path/to/lapack/library/files  -llapacke -llapack -lrefblas \
        source.chpl
 
 As an example,

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -81,9 +81,9 @@ on the system and specified with the following compilation flags:
 .. code-block:: bash
 
   # Building with LAPACK dependency
-  chpl -I$PATH_TO_LAPACKE_INCLUDE_DIR \
-       -L$PATH_TO_LIBGFORTRAN -lgfortran \
-       -L$PATH_TO_LAPACK_BINARIES -llapacke -llapack -lrefblas \
+  chpl -I/path/to/lapack/header/file \
+       -L/path/to/gfortran/library/file -lgfortran \
+       -L/path/to/lapack/library/files  -llapacke -llapack -lrefblas \
        example2.chpl
 
 **Building programs with optional dependencies**


### PR DESCRIPTION
Improves the compilation commands in the docs for LAPACK and LinearAlgebra to not use undefined environment variables.

This PR just implements the suggestion in https://github.com/chapel-lang/chapel/issues/16433#issuecomment-697036608

Resolves https://github.com/chapel-lang/chapel/issues/16433

[Reviewed by @DanilaFe]