### PR TITLE
Lock in error message for bad cast to record

### DIFF
--- a/test/types/records/casts/castToNonType.chpl
+++ b/test/types/records/casts/castToNonType.chpl
@@ -1,0 +1,3 @@
+record R { }
+
+var a = 1:R;

--- a/test/types/records/casts/castToNonType.good
+++ b/test/types/records/casts/castToNonType.good
@@ -1,0 +1,1 @@
+castToNonType.chpl:3: error: illegal cast from int(64) to R


### PR DESCRIPTION
Locks in the nicer error message when casting a value to a record type

Resolves https://github.com/chapel-lang/chapel/issues/11368

[Not reviewed - trivial test added]