### PR TITLE
Workaround for overloading in qthreads

### DIFF
--- a/runtime/etc/rtmain.c
+++ b/runtime/etc/rtmain.c
@@ -21,6 +21,11 @@
 // This file is used in LLVM backend compiles to compile the header
 // declarations for the Chapel runtime into an LLVM module.
 
+// Reduce our exposure to overloads of symbols with the same name
+// when parsing runtime headers in C++ mode during our LLVM codegen.
+// https://github.com/chapel-lang/chapel/issues/25506
+#define CHPL_AVOID_CPP_CODE 1
+
 #include "stdchpl.h"
 
 #include "chpl-gen-includes.h"

--- a/third-party/qthread/README
+++ b/third-party/qthread/README
@@ -19,3 +19,6 @@ as follows:
 
 * Pulled in an upstream fix for build issues on Alpine linux
   https://github.com/sandialabs/qthreads/pull/179
+
+* Do not #include "qthread.hpp" ifdef CHPL_AVOID_CPP_CODE
+  https://github.com/chapel-lang/chapel/pull/25507

--- a/third-party/qthread/qthread-src/include/qthread/qthread.h
+++ b/third-party/qthread/qthread-src/include/qthread/qthread.h
@@ -1707,7 +1707,7 @@ static QINLINE void *qthread_cas_ptr_(void **addr,
 
 Q_ENDCXX /* */
 
-#ifndef __cplusplus
+#if !defined __cplusplus || defined CHPL_AVOID_CPP_CODE
 
 # if defined(QTHREAD_ATOMIC_INCR) && !defined(QTHREAD_MUTEX_INCREMENT)
 #  define qthread_incr(ADDR, INCVAL) \


### PR DESCRIPTION
This resolves the failure in the test `gpu/native/examples/releaseNotes/tasks/begin` in the configuration "gpu-xc-cuda.ugni", which uses the bundled LLVM 18 and CUDA 12 (not sure though). It is a workaround for the problem of handling C++ overloading while parsing the runtime headers during our LLVM codegen, see #25506. The above test failure was triggered by, unlikely caused by, the PR #25215.

### Details

[The change is a simple two-liner. Read on for the rationale.]

Prior to this change, qthreads headers defined two overloads of qthread_fill: `qthread_fill(const aligned_t *dest)` in qthread.h and `qthread_fill(syncvar *const dest)` in qthread.hpp. Calls from ChapelSyncvar.chpl intended to invoke the former instead invoked the latter. Given that qthread's `syncvar` is a virtual class due to the presence of a virtual destructor, class instances occupy two 8-byte words whereas in Chapel the `aligned_t` variables are assume to occupy only one 8-byte word. The incorrect `qthread_fill` accessed the second word, which is garbage memory. The failure mentioned above is the only symptom of this problem that we have seen.

This change simply hides some of qthread's C++ headers, which removes the incorrect overload of `qthread_fill`, when qthreads are parsed in the C++ mode. Therefore the calls from ChapelSyncvar.chpl invoke the intended overload now.

As a mismatch to the C++ trouble, when we build qthreads as part of building the Chapel tree, we compile its sources in C mode.

This solution was proposed by @mppf - thank you!

Testing:
* [x] standard and gasnet paratest with locale_model=flat
* [x] spot-checks in the configuration where we observed the failure