### PR TITLE
Print CHPL_LLVM_SUPPORT when CHPL_LLVM is none

### DIFF
--- a/util/chplenv/printchplenv.py
+++ b/util/chplenv/printchplenv.py
@@ -128,7 +128,7 @@ CHPL_ENVS = [
     ChapelEnv('CHPL_RE2', RUNTIME | DEFAULT, 're2'),
     ChapelEnv('  CHPL_RE2_IS_OVERRIDDEN', INTERNAL),
     ChapelEnv('CHPL_LLVM', COMPILER | DEFAULT, 'llvm'),
-    ChapelEnv('  CHPL_LLVM_SUPPORT', COMPILER | NOPATH, 'llvm'),
+    ChapelEnv('  CHPL_LLVM_SUPPORT', COMPILER | DEFAULT | NOPATH, 'llvm'),
     ChapelEnv('  CHPL_LLVM_CONFIG', COMPILER | NOPATH),
     ChapelEnv('  CHPL_LLVM_VERSION', COMPILER),
     ChapelEnv('  CHPL_LLVM_CLANG_C', INTERNAL),
@@ -351,6 +351,8 @@ def filter_tidy(chpl_env):
         return comm == 'ofi'
     elif chpl_env.name == '  CHPL_NETWORK_ATOMICS':
         return comm != 'none'
+    elif chpl_env.name == '  CHPL_LLVM_SUPPORT':
+        return llvm == 'none'
     elif chpl_env.name == '  CHPL_GPU':
         return locale == 'gpu'
     elif chpl_env.name == '  CHPL_GPU_MEM_STRATEGY':


### PR DESCRIPTION
Adds `CHPL_LLVM_SUPPORT` to the default `printchplenv` output when `CHPL_LLVM=none`. This should make it more clear to users that Chapel will still use LLVM, even if `CHPL_LLVM=none`.

Tested that `CHPL_LLVM_SUPPORT` is printed when `CHPL_LLVM=none`, and not printed otherwise.

TODO: make sure it is still printed when `--all` or `--compiler` is passed

[Reviewed by @]