### PR TITLE
Warn for standalone function capture

### DIFF
--- a/compiler/include/fcf-support.h
+++ b/compiler/include/fcf-support.h
@@ -125,6 +125,9 @@ const ClosureEnv& computeOuterVariables(FnSymbol* fn);
 /*** Use to ensure a clean error for failed capture without other context. */
 VarSymbol* errorSink(FunctionType::Kind);
 
+/*** When a function is being captured but it's a statement in and of itself, warn. */
+void emitWarningForStandaloneCapture(Expr* expr, const char* name);
+
 } // end namespace 'fcfs'
 
 #endif

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -33,6 +33,7 @@
 #include "ForLoop.h"
 #include "IfExpr.h"
 #include "ImportStmt.h"
+#include "fcf-support.h"
 #include "initializerRules.h"
 #include "LoopExpr.h"
 #include "LoopStmt.h"
@@ -1038,6 +1039,7 @@ static void resolveUnresolvedSymExpr(UnresolvedSymExpr* usymExpr,
       // not reporting the correct number of lookups for overloaded
       // function symbols.
       prim = new CallExpr(PRIM_CAPTURE_FN, usymExpr->copy());
+      fcfs::emitWarningForStandaloneCapture(usymExpr, usymExpr->unresolved);
 
       // This business is necessary because of normalizing. If we are the
       // child of a "c_ptrTo" call, we need to know to do some pattern

--- a/compiler/resolution/fcf-support.cpp
+++ b/compiler/resolution/fcf-support.cpp
@@ -1180,6 +1180,16 @@ void emitWarningForStandaloneCapture(Expr* expr, const char* name) {
   //
   // This is likely wrong; the user probably meant to call it.
   if (expr->getStmtExpr() == expr) {
+    if (auto parent = expr->parentExpr) {
+      if (auto block = toBlockStmt(parent)) {
+        if (block->blockTag == BLOCK_TYPE) {
+          // When used in a type expression, it's not really standalone.
+          return;
+        }
+      }
+    }
+
+
     USR_WARN(expr, "function '%s' is mentioned but not called, so it is being "
              "captured as a first-class function", name);
     USR_PRINT(expr, "'%s' is a parenful function, so it needs '(...)' to be called", name);

--- a/compiler/resolution/fcf-support.cpp
+++ b/compiler/resolution/fcf-support.cpp
@@ -1180,12 +1180,10 @@ void emitWarningForStandaloneCapture(Expr* expr, const char* name) {
   //
   // This is likely wrong; the user probably meant to call it.
   if (expr->getStmtExpr() == expr) {
-    if (auto parent = expr->parentExpr) {
-      if (auto block = toBlockStmt(parent)) {
-        if (block->blockTag == BLOCK_TYPE) {
-          // When used in a type expression, it's not really standalone.
-          return;
-        }
+    if (auto block = toBlockStmt(expr->parentExpr)) {
+      if (block->blockTag == BLOCK_TYPE) {
+        // When used in a type expression, it's not really standalone.
+        return;
       }
     }
 

--- a/compiler/resolution/fcf-support.cpp
+++ b/compiler/resolution/fcf-support.cpp
@@ -1173,4 +1173,17 @@ VarSymbol* errorSink(FunctionType::Kind kind) {
   return ret;
 }
 
+void emitWarningForStandaloneCapture(Expr* expr, const char* name) {
+  // The mention is literally:
+  //
+  //   fn;
+  //
+  // This is likely wrong; the user probably meant to call it.
+  if (expr->getStmtExpr() == expr) {
+    USR_WARN(expr, "function '%s' is mentioned but not called, so it is being "
+             "captured as a first-class function", name);
+    USR_PRINT(expr, "'%s' is a parenful function, so it needs '(...)' to be called", name);
+  }
+}
+
 } // end namespace 'fcfs'

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -10911,6 +10911,7 @@ Expr* resolveExpr(Expr* expr) {
       }
       retval = resolveExprPhase2(expr, fn, expr);
     } else if (isMentionOfFnTriggeringCapture(se)) {
+      fcfs::emitWarningForStandaloneCapture(se, se->symbol()->name);
       auto fn = toFnSymbol(se->symbol());
       INT_ASSERT(fn);
 

--- a/test/exits/albrecht/exitWithNoCall.good
+++ b/test/exits/albrecht/exitWithNoCall.good
@@ -1,1 +1,4 @@
+exitWithNoCall.chpl:1: In function 'main':
+exitWithNoCall.chpl:3: warning: function 'exit' is mentioned but not called, so it is being captured as a first-class function
+exitWithNoCall.chpl:3: note: 'exit' is a parenful function, so it needs '(...)' to be called
 Compiling this shouldn't give an internal error

--- a/test/exits/sungeun/exitWithNoParensNoArgs.good
+++ b/test/exits/sungeun/exitWithNoParensNoArgs.good
@@ -1,1 +1,3 @@
+exitWithNoParensNoArgs.chpl:2: warning: function 'exit' is mentioned but not called, so it is being captured as a first-class function
+exitWithNoParensNoArgs.chpl:2: note: 'exit' is a parenful function, so it needs '(...)' to be called
 Hello, world

--- a/test/functions/fcf/standalone-capture-late.chpl
+++ b/test/functions/fcf/standalone-capture-late.chpl
@@ -1,0 +1,16 @@
+module A {
+  module B {
+    proc myFun() {
+      writeln("executing inner myFun()");
+    }
+  }
+  use B;
+
+  proc myFun() {
+    writeln("executing outer myFun()");
+  }
+
+  proc main() {
+    myFun;   // expecting to print "executing myFun()"
+  }
+}

--- a/test/functions/fcf/standalone-capture-late.good
+++ b/test/functions/fcf/standalone-capture-late.good
@@ -1,0 +1,6 @@
+standalone-capture-late.chpl:13: In function 'main':
+standalone-capture-late.chpl:14: warning: function 'myFun' is mentioned but not called, so it is being captured as a first-class function
+standalone-capture-late.chpl:14: note: 'myFun' is a parenful function, so it needs '(...)' to be called
+standalone-capture-late.chpl:14: error: cannot capture routine with name 'myFun' because it is overloaded
+standalone-capture-late.chpl:9: note: declared here
+standalone-capture-late.chpl:3: note: declared here

--- a/test/functions/fcf/standalone-capture.chpl
+++ b/test/functions/fcf/standalone-capture.chpl
@@ -1,0 +1,5 @@
+proc myFun() {
+  writeln("executing myFun()");
+}
+
+myFun;   // expecting to print "executing myFun()"

--- a/test/functions/fcf/standalone-capture.good
+++ b/test/functions/fcf/standalone-capture.good
@@ -1,0 +1,2 @@
+standalone-capture.chpl:5: warning: function 'myFun' is mentioned but not called, so it is being captured as a first-class function
+standalone-capture.chpl:5: note: 'myFun' is a parenful function, so it needs '(...)' to be called


### PR DESCRIPTION
Closes https://github.com/chapel-lang/chapel/issues/14484.

This PR ensures that a function that was referenced but not called (due to a lack of parentheses) gets warned about, since it's likely a mistake.

```Chapel
proc myFun() {
  writeln("executing myFun()");
}

myFun;
```

Produces:
```
standalone-capture.chpl:5: warning: function 'myFun' is mentioned but not called, so it is being captured as a first-class function
standalone-capture.chpl:5: note: 'myFun' is a parenful function, so it needs '(...)' to be called
```

Reviewed by @dlongnecke-cray -- thanks!

## Testing
- [x] paratest