### PR TITLE
Allow declaring enums within classes.

### DIFF
--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -4082,6 +4082,12 @@ struct Converter {
   }
 
   Expr* visit(const uast::Enum* node) {
+    const resolution::ResolutionResultByPostorderID* resolved = nullptr;
+    if (shouldScopeResolve(node)) {
+      resolved = &resolution::scopeResolveEnum(context, node->id());
+    }
+    pushToSymStack(node, resolved);
+
     auto enumType = new EnumType();
 
     for (auto elem : node->enumElements()) {
@@ -4106,6 +4112,8 @@ struct Converter {
 
     // Note the enum type is converted so we can wire up SymExprs later
     noteConvertedSym(node, enumTypeSym);
+
+    popFromSymStack(node, enumTypeSym);
 
     return ret;
   }

--- a/compiler/passes/flattenClasses.cpp
+++ b/compiler/passes/flattenClasses.cpp
@@ -27,7 +27,7 @@
 
 void FlattenClasses::process(TypeSymbol* ts) {
   Type* t = ts->type;
-  if (isAggregateType(t) || isDecoratedClassType(t)) {
+  if (isAggregateType(t) || isDecoratedClassType(t) || isEnumType(t)) {
     if (toAggregateType(t->symbol->defPoint->parentSymbol->type)) {
       ModuleSymbol* mod = t->getModule();
       DefExpr* def = t->symbol->defPoint;

--- a/compiler/passes/flattenClasses.cpp
+++ b/compiler/passes/flattenClasses.cpp
@@ -29,6 +29,12 @@ void FlattenClasses::process(TypeSymbol* ts) {
   Type* t = ts->type;
   if (isAggregateType(t) || isDecoratedClassType(t) || isEnumType(t)) {
     if (toAggregateType(t->symbol->defPoint->parentSymbol->type)) {
+      if (isEnumType(t)) {
+        if (shouldWarnUnstableFor(t)) {
+          USR_WARN(t, "declaring en enumeration inside of a class or record is unstable");
+        }
+      }
+
       ModuleSymbol* mod = t->getModule();
       DefExpr* def = t->symbol->defPoint;
 

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1194,15 +1194,9 @@ static void insertFieldAccess(FnSymbol*          method,
 static int computeNestedDepth(const char* name, Type* type) {
   int retval = 0;
 
-  // enums can be nested within classes and they should not be allowed
-  // to access outer fields.
-  AggregateType* ct = toAggregateType(type);
-  if (auto et = toEnumType(type)) {
-    retval += 1;
-    ct = toAggregateType(et->symbol->defPoint->parentSymbol->type);
-  }
-
   if (isMethodName(name, type) == true) {
+    AggregateType* ct = toAggregateType(type);
+
     // count how many classes out from current depth that
     // this method is first defined in
     while (ct != NULL && isMethodNameLocal(name, ct) == false) {
@@ -1213,6 +1207,7 @@ static int computeNestedDepth(const char* name, Type* type) {
   } else {
     // count how many classes out from current depth that
     // this symbol is first defined in
+    AggregateType* ct = toAggregateType(type);
 
     while (ct != NULL) {
       if (ct->getField(name, false) != nullptr ||

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1194,9 +1194,15 @@ static void insertFieldAccess(FnSymbol*          method,
 static int computeNestedDepth(const char* name, Type* type) {
   int retval = 0;
 
-  if (isMethodName(name, type) == true) {
-    AggregateType* ct = toAggregateType(type);
+  // enums can be nested within classes and they should not be allowed
+  // to access outer fields.
+  AggregateType* ct = toAggregateType(type);
+  if (auto et = toEnumType(type)) {
+    retval += 1;
+    ct = toAggregateType(et->symbol->defPoint->parentSymbol->type);
+  }
 
+  if (isMethodName(name, type) == true) {
     // count how many classes out from current depth that
     // this method is first defined in
     while (ct != NULL && isMethodNameLocal(name, ct) == false) {
@@ -1207,7 +1213,6 @@ static int computeNestedDepth(const char* name, Type* type) {
   } else {
     // count how many classes out from current depth that
     // this symbol is first defined in
-    AggregateType* ct = toAggregateType(type);
 
     while (ct != NULL) {
       if (ct->getField(name, false) != nullptr ||

--- a/frontend/include/chpl/resolution/resolution-error-classes-list.h
+++ b/frontend/include/chpl/resolution/resolution-error-classes-list.h
@@ -64,7 +64,7 @@ ERROR_CLASS(ModuleAsVariable, const uast::AstNode*, const uast::AstNode*, const 
 ERROR_CLASS(MultipleEnumElems, const uast::AstNode*, chpl::UniqueString, const uast::Enum*, std::vector<ID>)
 ERROR_CLASS(MultipleInheritance, const uast::Class*, const uast::AstNode*, const uast::AstNode*)
 ERROR_CLASS(MultipleQuestionArgs, const uast::FnCall*, const uast::AstNode*, const uast::AstNode*)
-ERROR_CLASS(NestedClassFieldRef, const uast::AggregateDecl*, const uast::AggregateDecl*, const uast::AstNode*, ID)
+ERROR_CLASS(NestedClassFieldRef, const uast::TypeDecl*, const uast::TypeDecl*, const uast::AstNode*, ID)
 ERROR_CLASS(NoMatchingCandidates, const uast::AstNode*, resolution::CallInfo, std::vector<resolution::ApplicabilityResult>)
 ERROR_CLASS(NonIterable, const uast::AstNode*, const uast::AstNode*, types::QualifiedType)
 ERROR_CLASS(NoMatchingEnumValue, const uast::AstNode*, const types::EnumType*, types::QualifiedType)

--- a/frontend/include/chpl/resolution/resolution-queries.h
+++ b/frontend/include/chpl/resolution/resolution-queries.h
@@ -295,6 +295,12 @@ const OuterVariables* computeOuterVariables(Context* context, ID id);
 const ResolutionResultByPostorderID& scopeResolveAggregate(Context* context,
                                                           ID id);
 
+/*
+ * Scope-resolve an EnumDecl's constants
+ */
+const ResolutionResultByPostorderID& scopeResolveEnum(Context* context,
+                                                      ID id);
+
 /**
   Returns the ResolvedFunction called by a particular
   ResolvedExpression, if there was exactly one candidate.

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -3278,7 +3278,11 @@ bool Resolver::enter(const NamedDecl* decl) {
   CHPL_ASSERT(scopeStack.size() > 0);
   const Scope* scope = scopeStack.back();
 
-  emitMultipleDefinedSymbolErrors(context, scope);
+  // Silence redefinition warnings for enum elements because we have
+  // a special error (DuplicateEnumElement) for those.
+  if (!decl->isEnumElement()) {
+    emitMultipleDefinedSymbolErrors(context, scope);
+  }
 
   enterScope(decl);
 

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2803,12 +2803,12 @@ void Resolver::validateAndSetToId(ResolvedExpression& r,
         // We found the aggregate type in which the to-ID is declared,
         // so there's no nested class issues.
         break;
-      } else if (asttags::isAggregateDecl(parsing::idToTag(context, searchId))) {
+      } else if (asttags::isTypeDecl(parsing::idToTag(context, searchId))) {
         auto parentAst = parsing::idToAst(context, parentId);
         auto searchAst = parsing::idToAst(context, searchId);
-        auto searchAD = searchAst->toAggregateDecl();
+        auto searchAD = searchAst->toTypeDecl();
         // It's an error!
-        CHPL_REPORT(context, NestedClassFieldRef, parentAst->toAggregateDecl(),
+        CHPL_REPORT(context, NestedClassFieldRef, parentAst->toTypeDecl(),
                     searchAD, node, toId);
         break;
       }

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -377,6 +377,19 @@ Resolver::createForScopeResolvingField(Context* context,
   return ret;
 }
 
+Resolver
+Resolver::createForScopeResolvingEnumConstant(Context* context,
+                                       const uast::Enum* ed,
+                                       const uast::AstNode* fieldStmt,
+                                       ResolutionResultByPostorderID& byPostorder) {
+  auto ret = Resolver(context, ed, byPostorder, nullptr);
+  ret.scopeResolveOnly = true;
+  ret.curStmt = fieldStmt;
+  ret.byPostorder.setupForSymbol(ed);
+
+  return ret;
+}
+
 
 // set up Resolver to initially resolve field declaration types
 Resolver

--- a/frontend/lib/resolution/Resolver.h
+++ b/frontend/lib/resolution/Resolver.h
@@ -192,6 +192,11 @@ struct Resolver {
                                          const uast::AstNode* fieldStmt,
                                          ResolutionResultByPostorderID& byPostorder);
 
+  static Resolver createForScopeResolvingEnumConstant(Context* context,
+                                         const uast::Enum* ed,
+                                         const uast::AstNode* fieldStmt,
+                                         ResolutionResultByPostorderID& byPostorder);
+
   // set up Resolver to initially resolve field declaration types
   static Resolver
   createForInitialFieldStmt(Context* context,

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2628,6 +2628,23 @@ const ResolutionResultByPostorderID& scopeResolveAggregate(Context* context,
   return QUERY_END(result);
 }
 
+const ResolutionResultByPostorderID& scopeResolveEnum(Context* context,
+                                                      ID id) {
+  QUERY_BEGIN(scopeResolveEnum, context, id);
+
+  auto ed = parsing::idToAst(context, id)->toEnum();
+  ResolutionResultByPostorderID result;
+
+  if (ed) {
+    for (auto child : ed->enumElements()) {
+      auto res = Resolver::createForScopeResolvingEnumConstant(context, ed, child, result);
+      child->traverse(res);
+    }
+  }
+
+  return QUERY_END(result);
+}
+
 
 const ResolvedFunction* resolveOnlyCandidate(Context* context,
                                              const ResolvedExpression& r) {

--- a/test/attributes/stability/stability.set.good
+++ b/test/attributes/stability/stability.set.good
@@ -2,4 +2,6 @@ stability.chpl:21: In module 'U':
 stability.chpl:22: warning: this module is unstable
 stability.chpl:23: In function 'main':
 stability.chpl:24: warning: the API is not finalized
+stability.chpl:6: warning: declaring en enumeration inside of a class or record is unstable
+stability.chpl:8: warning: declaring en enumeration inside of a class or record is unstable
 stability.chpl:25: warning: does not support new enum

--- a/test/types/enum/lydia/declaredInClass-initializer.bad
+++ b/test/types/enum/lydia/declaredInClass-initializer.bad
@@ -1,8 +1,0 @@
-declaredInClass-initializer.chpl:21: internal error: UTI-MIS-0597 chpl version 1.19.0 pre-release (cfeb6592b3)
-Note: This source location is a guess.
-
-Internal errors indicate a bug in the Chapel compiler,
-and we're sorry for the hassle.  We would appreciate your reporting this bug --
-please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-

--- a/test/types/enum/lydia/declaredInClass-initializer.chpl
+++ b/test/types/enum/lydia/declaredInClass-initializer.chpl
@@ -5,12 +5,10 @@
 proc main() {
   var sampleBug = new Sample();
   writeln(sampleBug.tag);
-  delete sampleBug;
 }
 
 
 class Sample {
-
 
   enum classTag { field1,
                   field2};

--- a/test/types/enum/lydia/declaredInClass-initializer.future
+++ b/test/types/enum/lydia/declaredInClass-initializer.future
@@ -1,8 +1,0 @@
-bug: enums declared in class scope can't have fields use their type
-
-The spec says that it is legal to declare an enum within the top level scope of
-a class (as well as classes, records, and unions).  However, trying to use that
-enum runs into issues.
-
-This future covers omitted initialization of a field declared with that enum
-type as its type (and explicitly naming a constant to set it in Phase 2)

--- a/test/types/enum/lydia/declaredInClass-nestedRef-method.chpl
+++ b/test/types/enum/lydia/declaredInClass-nestedRef-method.chpl
@@ -1,0 +1,21 @@
+// According to the spec, it is legal to define an enum type within a class.
+// However, we seem to have issues with accessing its constant values in
+// practice.
+
+proc main() {
+  var sampleBug = new Sample();
+  writeln(sampleBug.tag);
+}
+
+
+class Sample {
+
+  proc doSomething() do return 10;
+
+  enum inner {
+    red = doSomething(), green, blue
+  }
+
+  // give it a value.. still error
+  var tag: inner = inner.red;
+}

--- a/test/types/enum/lydia/declaredInClass-nestedRef-method.good
+++ b/test/types/enum/lydia/declaredInClass-nestedRef-method.good
@@ -1,0 +1,4 @@
+declaredInClass-nestedRef-method.chpl:16: error: unresolved call 'doSomething()'
+declaredInClass-nestedRef-method.chpl:13: note: this candidate did not match: Sample.doSomething()
+declaredInClass-nestedRef-method.chpl:16: note: because call is not written as a method call
+declaredInClass-nestedRef-method.chpl:13: note: but candidate function is a method

--- a/test/types/enum/lydia/declaredInClass-nestedRef.chpl
+++ b/test/types/enum/lydia/declaredInClass-nestedRef.chpl
@@ -1,0 +1,21 @@
+// According to the spec, it is legal to define an enum type within a class.
+// However, we seem to have issues with accessing its constant values in
+// practice.
+
+proc main() {
+  var sampleBug = new Sample();
+  writeln(sampleBug.tag);
+}
+
+
+class Sample {
+
+  param x = 10;
+
+  enum inner {
+    red = x, green, blue
+  }
+
+  // give it a value.. still error
+  var tag: inner = inner.red;
+}

--- a/test/types/enum/lydia/declaredInClass-nestedRef.good
+++ b/test/types/enum/lydia/declaredInClass-nestedRef.good
@@ -1,0 +1,4 @@
+declaredInClass-nestedRef.chpl:16: error: illegal use of identifier 'x' from enclosing type
+declaredInClass-nestedRef.chpl:15: note: the identifier is used within enum 'inner', declared here
+declaredInClass-nestedRef.chpl:11: note: however, the identifier refers to a field of an enclosing class 'Sample', declared here
+declaredInClass-nestedRef.chpl:13: note: field declared here

--- a/test/unstable/enumInClass.chpl
+++ b/test/unstable/enumInClass.chpl
@@ -1,0 +1,22 @@
+// According to the spec, it is legal to define an enum type within a class.
+// However, we seem to have issues with accessing its constant values in
+// practice.
+
+proc main() {
+  var sampleBug = new Sample();
+  writeln(sampleBug.tag);
+}
+
+
+class Sample {
+
+  enum classTag { field1,
+                  field2};
+
+  // give it a value.. still error
+  var tag: classTag;
+
+  proc init() {
+    tag = classTag.field2;
+  }
+}

--- a/test/unstable/enumInClass.good
+++ b/test/unstable/enumInClass.good
@@ -1,0 +1,2 @@
+enumInClass.chpl:13: warning: declaring en enumeration inside of a class or record is unstable
+field2


### PR DESCRIPTION
Fixes https://github.com/chapel-lang/chapel/issues/6871.

This PR adds support for enums within classes. The internal error locked in by Lydia's test is due to the fact that an enum is interpreted as a "field" and used accordingly (but it isn't a field!). Instead, I took the same approach that we take for classes, and flattened declaration of nested enums to be alongside their parent class. To ensure that the flattening didn't "break any links", I extended Dyno's existing error for outer variable references to enums nested in classes (classes can't be nested in enums, so the change is "one-directional"). This made all the tests in #6871 pass.

Reviewed by @benharsh -- thanks!

## Testing
- [x] paratest