### PR TITLE
Fix some futures with --fast

### DIFF
--- a/test/arrays/lydia/defaultValue.compopts
+++ b/test/arrays/lydia/defaultValue.compopts
@@ -1,0 +1,2 @@
+# the test relies on --checks
+--checks

--- a/test/domains/vass/domain-and-subdomain-args.compopts
+++ b/test/domains/vass/domain-and-subdomain-args.compopts
@@ -1,0 +1,2 @@
+# the test relies on --checks
+--checks

--- a/test/errhandling/iterators/non-equal-lengths-error-array-init.compopts
+++ b/test/errhandling/iterators/non-equal-lengths-error-array-init.compopts
@@ -1,0 +1,2 @@
+# the test relies on --checks
+--checks

--- a/test/errhandling/iterators/non-equal-lengths-error.compopts
+++ b/test/errhandling/iterators/non-equal-lengths-error.compopts
@@ -1,0 +1,2 @@
+# the test relies on --checks
+--checks

--- a/test/functions/default-arguments/runtime-type-1.compopts
+++ b/test/functions/default-arguments/runtime-type-1.compopts
@@ -1,0 +1,2 @@
+# the test relies on --checks
+--checks

--- a/test/library/packages/Collection/insertArrayInBag1.compopts
+++ b/test/library/packages/Collection/insertArrayInBag1.compopts
@@ -1,0 +1,2 @@
+# the test relies on --checks
+--checks

--- a/test/library/packages/Collection/insertArrayInBag2.compopts
+++ b/test/library/packages/Collection/insertArrayInBag2.compopts
@@ -1,0 +1,2 @@
+# the test relies on --checks
+--checks

--- a/test/users/bguarraci/const_locale.compopts
+++ b/test/users/bguarraci/const_locale.compopts
@@ -1,0 +1,2 @@
+# the test relies on --checks
+--checks


### PR DESCRIPTION
Fixes a handful of futures that change behavior due to `--fast`. All of them are because `--checks` is being tested, so adding a compopts with `--checks` fixes this.

Tested locally with the following command
```
start_test --compopts --fast --respect-skipifs \
  test/functions/default-arguments/runtime-type-1.chpl \
  test/domains/vass/domain-arg-query-expr.chpl \
  test/library/packages/Collection/insertArrayInBag1.chpl \
  test/library/packages/Collection/insertArrayInBag2.chpl \
  test/arrays/lydia/defaultValue.chpl \
  test/types/range/unbounded/slices \
  test/errhandling/iterators/non-equal-lengths-error-array-init.chpl \
  test/errhandling/iterators/non-equal-lengths-error.chpl \
  test/users/bguarraci/const_locale.chpl
```

resolves https://github.com/Cray/chapel-private/issues/4539

[Reviewed by @]