### PR TITLE
Re-enable Arkouda check-deps tests

### DIFF
--- a/util/cron/common-arkouda.bash
+++ b/util/cron/common-arkouda.bash
@@ -25,10 +25,6 @@ fi
 export CHPL_NIGHTLY_TEST_DIRS=studies/arkouda/
 export CHPL_TEST_ARKOUDA=true
 
-# Removing regex.compile caused smoke test failures. As a stopgap measure we are
-# skipping dependency check.
-export ARKOUDA_SKIP_CHECK_DEPS=1
-
 ARKOUDA_DEP_DIR=$COMMON_DIR/arkouda-deps
 if [ -d "$ARKOUDA_DEP_DIR" ]; then
   export ARKOUDA_ARROW_PATH=${ARKOUDA_ARROW_PATH:-$ARKOUDA_DEP_DIR/arrow-install}


### PR DESCRIPTION
In https://github.com/chapel-lang/chapel/pull/23402/, check-deps tests for Arkouda were temporarily disabled due to regex.compile failures.

This PR re-enables these tests to ensure Arkouda's dependency check tests keep working and to catch potential deprecations early on.