### PR TITLE
Include interoperability commands when compiling with `--print-commands`

### DIFF
--- a/compiler/codegen/library.cpp
+++ b/compiler/codegen/library.cpp
@@ -109,7 +109,9 @@ static std::string getCompilelineOption(std::string option) {
   }
   fullCommand += "$CHPL_HOME/util/config/compileline --" + option;
   fullCommand += "> cmd.out.tmp";
-  runCommand(fullCommand);
+
+  std::string description = "Get compileline option " + option;
+  runCommand(fullCommand, description);
 
   std::string replace = "$CHPL_HOME/util/config/replace-paths.py ";
 
@@ -118,9 +120,10 @@ static std::string getCompilelineOption(std::string option) {
   replace += "--fixpath '$(CHPL_THIRD_PARTY)' $CHPL_THIRD_PARTY ";
   replace += "--fixpath '$(CHPL_HOME)' $CHPL_HOME < cmd.out.tmp";
 
-  std::string res = runCommand(replace);
+  std::string replaceDesc = "Replace paths in compileline option " + option;
+  std::string res = runCommand(replace, replaceDesc);
   std::string cleanup = "rm cmd.out.tmp";
-  runCommand(cleanup);
+  runCommand(cleanup, "Cleanup output file");
   return res;
 }
 
@@ -964,28 +967,28 @@ void codegen_make_python_module() {
                " source files");
     }
     std::string getCrayComp = "$CHPL_HOME/util/config/compileline --compiler";
-    crayCompiler = runCommand(getCrayComp);
+    crayCompiler = runCommand(getCrayComp, "Get Cray compiler");
     // Erase the trailing \n from getting the cFlags
     crayCompiler.erase(crayCompiler.length() - 1);
     std::string getCLink = "$CHPL_HOME/util/config/compileline --linkershared";
-    crayLinker = runCommand(getCLink);
+    crayLinker = runCommand(getCLink, "Get Cray linker information");
     crayLinker.erase(crayLinker.length() - 1);
   }
 
   std::string getCFlags = "$CHPL_HOME/util/config/compileline --cflags";
-  std::string cFlags = runCommand(getCFlags);
+  std::string cFlags = runCommand(getCFlags, "Get C flags");
   // Erase the trailing \n from getting the cFlags
   cFlags.erase(cFlags.length() - 1);
   std::string requireIncludes = getRequireIncludes();
   std::string getIncludes =
     "$CHPL_HOME/util/config/compileline --includes-and-defines";
-  std::string includes = runCommand(getIncludes);
+  std::string includes = runCommand(getIncludes, "Get includes and defines");
   // Erase the trailing \n from getting the includes
   includes.erase(includes.length() - 1);
 
   std::string requireLibraries = getRequireLibraries();
   std::string getLibraries = "$CHPL_HOME/util/config/compileline --libraries";
-  std::string libraries = runCommand(getLibraries);
+  std::string libraries = runCommand(getLibraries, "Get libraries");
   // Erase the trailing \n from getting the libraries
   libraries.erase(libraries.length() - 1);
 
@@ -994,7 +997,7 @@ void codegen_make_python_module() {
     std::string cmd = "$CHPL_HOME/util/config/compileline";
     cmd += " --multilocale-lib-deps";
     libraries += " ";
-    libraries += runCommand(cmd);
+    libraries += runCommand(cmd, "Get multilocale-specific dependencies");
     libraries.erase(libraries.length() - 1);
   }
 
@@ -1029,7 +1032,7 @@ void codegen_make_python_module() {
   chdirIn += libDir;
   chdirIn += "; ";
   std::string fullCommand = chdirIn + fullCythonCall;
-  runCommand(fullCommand);
+  runCommand(fullCommand, "Run Cython");
 }
 
 // Skip this function if it is defined in an internal module, or if it is

--- a/compiler/include/files.h
+++ b/compiler/include/files.h
@@ -129,7 +129,8 @@ const char* createDebuggerFile(const char* debugger, int argc, char* argv[]);
 
 std::string getChplDepsApp();
 bool compilingWithPrgEnv();
-std::string runCommand(const std::string& command);
+std::string runCommand(const std::string& command,
+                       const std::string& description);
 
 const char* filenameToModulename(const char* filename);
 

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -5008,7 +5008,8 @@ void makeBinaryLLVM(void) {
     if (fMultiLocaleInterop) {
       std::string cmd = std::string(CHPL_HOME);
       cmd += "/util/config/compileline --multilocale-lib-deps";
-      std::string libs = runCommand(cmd);
+      std::string libs = runCommand(cmd,
+                                    "Get multilocale-specific dependencies");
       // Erase trailing newline.
       libs.erase(libs.size() - 1);
       clangLDArgs.push_back(libs);

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -620,7 +620,7 @@ std::string getChplDepsApp() {
   std::string command = "CHPLENV_SUPPRESS_WARNINGS=true CHPL_HOME=" + std::string(CHPL_HOME) + " python3 ";
   command += std::string(CHPL_HOME) + "/util/chplenv/chpl_home_utils.py --chpldeps";
 
-  std::string venvDir = runCommand(command);
+  std::string venvDir = runCommand(command, "Get dependencies");
   venvDir.erase(venvDir.find_last_not_of("\n\r")+1);
 
   return venvDir;
@@ -630,7 +630,13 @@ bool compilingWithPrgEnv() {
   return 0 != strcmp(CHPL_TARGET_COMPILER_PRGENV, "none");
 }
 
-std::string runCommand(const std::string& command) {
+std::string runCommand(const std::string& command,
+                       const std::string& description) {
+  if (printSystemCommands) {
+    printf("\n# %s\n", description.c_str());
+    printf("%s\n", command.c_str());
+  }
+
   auto commandOutput = chpl::getCommandOutput(command);
   if (auto err = commandOutput.getError()) {
     USR_FATAL("failed to run '%s', error: %s",


### PR DESCRIPTION
Resolves #14269 

Prior to this change, `--library-python` compilation with `--print-commands` would not include the Cython command used to make the Python library.  Including the Cython command (and other helpful commands along the way) would allow faster debugging and experimentation when the Cython command fails.

In more details, library compilation was using `runCommand` instead of the usual `mysystem` commands that checked for `printSystemCommands`, due to wanting a string result.  This commit made `runCommand` also check that boolean.

Ran python interop testing on my Mac.  Also ran with `--print-commands` explicitly and it looked good. No failures with a standard paratest on linux (though that location was not set up for python interoperability testing)