### PR TITLE
Lock in behavior for promotion with defaults

### DIFF
--- a/test/functions/promotion/issue-22573.chpl
+++ b/test/functions/promotion/issue-22573.chpl
@@ -1,0 +1,24 @@
+config param testnum = 1;
+
+proc foo(x:int, y:int = 7) {
+  return x+y;
+}
+var A = [1,2,3,4,5,6,7,8,9];
+
+if testnum == 1 {
+  // promotion and not capturing the result
+  foo(A);
+}
+else if testnum == 2{
+  // promotion and capturing the result
+  var x = foo(A);
+}
+else if testnum == 3 {
+  // promotion and first capturing the result, then not capturing the result
+  var x = foo(A);
+  foo(A);
+}
+else if testnum == 4 {
+  // no promotion and not capturing the result
+  foo(7);
+}

--- a/test/functions/promotion/issue-22573.compopts
+++ b/test/functions/promotion/issue-22573.compopts
@@ -1,0 +1,4 @@
+-stestnum=1
+-stestnum=2
+-stestnum=3
+-stestnum=4


### PR DESCRIPTION
Adds a test for promotion with defaults to ensure it continues to compile and work. This was captured in https://github.com/chapel-lang/chapel/issues/22573 but it works on main today.

Not reviewed - trivial test change

Resolves https://github.com/chapel-lang/chapel/issues/22573