### PR TITLE
Fix userDefReduceSlim by updating test and .good file

### DIFF
--- a/test/users/csep524/userDefReduceSlim.chpl
+++ b/test/users/csep524/userDefReduceSlim.chpl
@@ -17,7 +17,7 @@ class mostFrequent: ReduceScanOp {
     mySet += inputval;
   }
 
-  proc combine(partner: mostFrequent) {
+  proc combine(partner: mostFrequent(?)) {
     // This is a user-submitted bug where 'mostFrequent' was mistakenly used
     // and caused an internal compiler error.
     forall i in mostFrequent.mySet {

--- a/test/users/csep524/userDefReduceSlim.good
+++ b/test/users/csep524/userDefReduceSlim.good
@@ -3,5 +3,5 @@ userDefReduceSlim.chpl:23: error: unresolved call 'type mostFrequent.mySet'
 userDefReduceSlim.chpl:9: note: this candidate did not match: mostFrequent.mySet
 userDefReduceSlim.chpl:23: note: because method call receiver is a type
 userDefReduceSlim.chpl:9: note: but is passed to non-type formal 'this: borrowed mostFrequent'
-  $CHPL_HOME/modules/internal/ChapelReduce.chpl:65: called as (mostFrequent(int(64))).combine(partner: owned mostFrequent(int(64)))
+  $CHPL_HOME/modules/internal/ChapelReduce.chpl:67: called as (mostFrequent(int(64))).combine(partner: owned mostFrequent(int(64)))
   within internal functions (use --print-callstack-on-error to see)

--- a/test/users/csep524/userDefReduceSlim.good
+++ b/test/users/csep524/userDefReduceSlim.good
@@ -3,5 +3,5 @@ userDefReduceSlim.chpl:23: error: unresolved call 'type mostFrequent.mySet'
 userDefReduceSlim.chpl:9: note: this candidate did not match: mostFrequent.mySet
 userDefReduceSlim.chpl:23: note: because method call receiver is a type
 userDefReduceSlim.chpl:9: note: but is passed to non-type formal 'this: borrowed mostFrequent'
-  $CHPL_HOME/modules/internal/ChapelReduce.chpl:67: called as (mostFrequent(int(64))).combine(partner: owned mostFrequent(int(64)))
+  $CHPL_HOME/modules/internal/ChapelReduce.chpl:nnnn: called as (mostFrequent(int(64))).combine(partner: owned mostFrequent(int(64)))
   within internal functions (use --print-callstack-on-error to see)

--- a/test/users/csep524/userDefReduceSlim.prediff
+++ b/test/users/csep524/userDefReduceSlim.prediff
@@ -1,0 +1,1 @@
+../../../util/test/prediff-obscure-module-linenos


### PR DESCRIPTION
Updates the test to use '?' and avoid the warning, and updates the .good file with the correct line number.