### PR TITLE
Add regression tests for #7840

### DIFF
--- a/test/classes/forwarding/typeVar.chpl
+++ b/test/classes/forwarding/typeVar.chpl
@@ -1,0 +1,16 @@
+module Main{
+  class A{
+    type selfType;
+    proc print(){
+      writeln("hi, from A");
+    }
+  }
+  class B{
+    forwarding var a: A;
+  }
+  proc main(){
+    var b = new B(new A(B));
+    b.print();
+    writeln("End");
+  }
+}

--- a/test/classes/forwarding/typeVar.good
+++ b/test/classes/forwarding/typeVar.good
@@ -1,0 +1,9 @@
+typeVar.chpl:11: In function 'main':
+typeVar.chpl:12: warning: please add '(?)' to type 'B' because it is generic
+typeVar.chpl:9: warning: field is declared with generic memory management
+note: consider adding 'owned', 'shared', or 'borrowed'
+note: if generic memory management is desired, use a 'type' field to store the class type
+typeVar.chpl:9: warning: please use '?' when declaring a field with generic type
+typeVar.chpl:9: note: for example with 'A(?)'
+hi, from A
+End

--- a/test/classes/forwarding/typeVarExplicitType.chpl
+++ b/test/classes/forwarding/typeVarExplicitType.chpl
@@ -1,0 +1,16 @@
+module Main{
+  class A{
+    type selfType;
+    proc print(){
+      writeln("hi, from A");
+    }
+  }
+  class B{
+    forwarding var a: owned A(owned B);// Chenged here
+  }
+  proc main(){
+    var b = new B(new A(owned B));
+    b.print();
+    writeln("End");
+  }
+}

--- a/test/classes/forwarding/typeVarExplicitType.good
+++ b/test/classes/forwarding/typeVarExplicitType.good
@@ -1,0 +1,2 @@
+hi, from A
+End


### PR DESCRIPTION
Closes #7840.

Forwarding with a class with a type field is no longer a problem. Certainly there's no forwarding-specific issue at play, though the second program in that issue does produce an internal compiler error -- and does so even without a forwarding statement. The remaining issue is https://github.com/chapel-lang/chapel/issues/20500, which is unrelated.

Trivial, will not be reviewed.

## Testing
- [x] new tests pass