### PR TITLE
Fix internal error when `out` intent is used with a default value and no type.

### DIFF
--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -1053,7 +1053,7 @@ static void defaultedFormalApplyDefault(ArgSymbol* formal,
                                         VarSymbol* temp,
                                         Expr* fromExpr) {
   Symbol* typeTmp = NULL;
-  if (formal->typeExpr != NULL) {
+  if (formal->typeExpr != NULL && !formal->typeExprFromDefaultExpr) {
     typeTmp = newTemp("_formal_type");
     typeTmp->addFlag(FLAG_TYPE_VARIABLE);
     body->insertAtTail(new DefExpr(typeTmp));

--- a/test/functions/default-arguments/default-argument-out.bad
+++ b/test/functions/default-arguments/default-argument-out.bad
@@ -1,1 +1,1 @@
-default-argument-out.chpl:1: error: illegal assignment of value to type
+17


### PR DESCRIPTION
Closes https://github.com/chapel-lang/chapel/issues/7924, leaving design discussion up to https://github.com/chapel-lang/chapel/issues/25526.

The error was caused due to trying to coerce the default value to the default value's type. However, since no type is explicitly specified, the default value's expression is used. The resulting coercion / move ends up assigning a value to a type. The fix was simply to observe that the type expression was already used to infer the formal's type, so that can be used instead.

Reviewed by @jabraham17 -- thanks!

## Testing
- [x] paratest