### PR TITLE
Remove special logic in `smokeTest` script for `CC` env var

### DIFF
--- a/util/buildRelease/smokeTest
+++ b/util/buildRelease/smokeTest
@@ -73,23 +73,6 @@ fi
 
 echo "Running with MASON=$MASON DOCS=$DOCS CHPL=$CHPL LINT=$LINT QUICKSTART=$QUICKSTART"
 
-# Ensure CC is respected, since it is typically ignored by chplenv/.
-if [ -n "${CC}" ] ; then
-    case $CC in
-        gcc)
-            # Deal with a frequent chapel stumbling block...
-            echo "Setting CHPL_HOST_COMPILER and CHPL_TARGET_COMPILER to: gnu"
-            export CHPL_HOST_COMPILER=gnu
-            export CHPL_TARGET_COMPILER=gnu
-            ;;
-        *)
-            echo "Setting CHPL_HOST_COMPILER and CHPL_TARGET_COMPILER to: ${CC}"
-            export CHPL_HOST_COMPILER=$CC
-            export CHPL_TARGET_COMPILER=$CC
-            ;;
-    esac
-fi
-
 # Ensure environment is correctly configured to run chpl.
 export CHPL_HOME=$(cd "$CWD/../.." ; pwd)
 


### PR DESCRIPTION
Remove logic in the `smokeTest` script which sets `CHPL_HOST_COMPILER` and `CHPL_TARGET_COMPILER` based on the `CC` environment variable, as it is no longer needed and can cause issues in some cases (https://github.com/Cray/chapel-private/issues/6320#issue-2306414633).

Resolves https://github.com/Cray/chapel-private/issues/6320.

[reviewer info placeholder]

Testing:
- [x] manual run of `util/buildRelease/smokeTest`