### PR TITLE
Add nightly test script for bundled LLVM

### DIFF
--- a/util/cron/test-linux64-llvm-bundled.bash
+++ b/util/cron/test-linux64-llvm-bundled.bash
@@ -6,6 +6,8 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common.bash
 
 export CHPL_LLVM=bundled
+# To avoid warning about this being ignored with bundled LLVM
+unset CHPL_LLVM_CONFIG
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-llvm-bundled"
 

--- a/util/cron/test-linux64-llvm-bundled.bash
+++ b/util/cron/test-linux64-llvm-bundled.bash
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# Test default configuration on examples only, on linux64, with bundled llvm
+
+CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+source $CWD/common.bash
+
+export CHPL_LLVM=bundled
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-llvm-bundled"
+
+$CWD/nightly -cron -examples ${nightly_args}


### PR DESCRIPTION
Add a nightly test script which tests examples on linux64 using the bundled LLVM.

To be merged with https://github.hpe.com/hpe/hpc-chapel-ci-config/pull/1247 which sets up a test config using this script.

Resolves https://github.com/Cray/chapel-private/issues/4937.

[reviewer info placeholder]

Testing:
- [x] manual run