### PR TITLE
Add pointer in the man page to documentation on values for environment variables

### DIFF
--- a/man/chpl.rst
+++ b/man/chpl.rst
@@ -851,6 +851,11 @@ OPTIONS
 
 *Compiler Configuration Options*
 
+Note that the flags in this section all have corresponding environment
+variables.  Details on those environment variables, including potential values
+for them, can be found at
+https://chapel-lang.org/docs/latest/usingchapel/chplenv.html .
+
 .. _man-home:
 
 **\--home <path>**

--- a/man/chpl.rst
+++ b/man/chpl.rst
@@ -854,7 +854,8 @@ OPTIONS
 Note that the flags in this section all have corresponding environment
 variables.  Details on those environment variables, including potential values
 for them, can be found at
-https://chapel-lang.org/docs/latest/usingchapel/chplenv.html .
+https://chapel-lang.org/docs/latest/usingchapel/chplenv.html or at
+doc/rst/usingchapel/chplenv.rst in your Chapel installation.
 
 .. _man-home:
 


### PR DESCRIPTION
Anna pointed out in #25514 that it was difficult to know what values were valid for the new flag I added, but also that this was a general problem with the flags in the compiler configuration options section.  The `--help` output seemed generally more barebones, so didn't seem like a good place to add additional information.  But the man page tends to have more information, so it seemed reasonable to refer to the online documentation for the general category.

Note that this will not help if someone jumps to the flag they care about, but it seemed annoying and repetitive to add the link to every single flag in the section.  I'm open to suggestions on how to draw attention to the section header, though

Passed full paratest with futures