### PR TITLE
Use C linkage when compiling with `--library` for GPUs

### DIFF
--- a/compiler/codegen/library.cpp
+++ b/compiler/codegen/library.cpp
@@ -83,6 +83,10 @@ void codegen_library_header(std::vector<FnSymbol*> functions) {
       }
       // Maybe need something here to support LLVM extern blocks?
 
+      if (usingGpuLocaleModel()) {
+        fprintf(libhdrfile.fptr, "#ifdef __cplusplus\nextern \"C\" {\n#endif\n");
+      }
+
       // Print out the module initialization function headers and the exported
       // functions
       for_vector(FnSymbol, fn, functions) {
@@ -90,6 +94,10 @@ void codegen_library_header(std::vector<FnSymbol*> functions) {
             isUserRoutine(fn)) {
           fn->codegenPrototype();
         }
+      }
+
+      if (usingGpuLocaleModel()) {
+        fprintf(libhdrfile.fptr, "#ifdef __cplusplus\n}\n#endif\n");
       }
 
       gGenInfo->cfile = save_cfile;

--- a/runtime/etc/Makefile.include
+++ b/runtime/etc/Makefile.include
@@ -96,7 +96,8 @@ printcompileline:
 	@echo $(CC) \
 	      $(SANITIZER_CFLAGS) $(CHPL_MAKE_BASE_CFLAGS) $(COMP_GEN_CFLAGS) \
 	      $(CHPL_MAKE_TARGET_BUNDLED_COMPILE_ARGS) \
-	      -I.
+	      -I. \
+				$(CHPL_MAKE_TARGET_SYSTEM_COMPILE_ARGS)
 
 printcxxcompileline:
 	@echo $(CXX) $(SANITIZER_CFLAGS) $(CHPL_MAKE_BASE_CXXFLAGS) $(GEN_CXXFLAGS) $(COMP_GEN_CXXFLAGS) $(CHPL_RT_INC_DIR)

--- a/test/gpu/native/interop/gpuLibrary/CLEANFILES
+++ b/test/gpu/native/interop/gpuLibrary/CLEANFILES
@@ -1,0 +1,6 @@
+lib/*
+lib
+cmakeBuild/*
+cmakeBuild
+test_udf2_compileline
+test_udf2_make

--- a/test/gpu/native/interop/gpuLibrary/CMakeLists.txt
+++ b/test/gpu/native/interop/gpuLibrary/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.20)
+project(test_udf2_cmake CXX)
+set(CMAKE_CXX_STANDARD 11)
+include(lib/udf2.cmake)
+add_executable(test_udf2_cmake test_udf2.cpp)
+target_include_directories(test_udf2_cmake PRIVATE ${udf2_INCLUDE_DIRS})
+target_link_libraries(test_udf2_cmake PRIVATE ${udf2_LINK_LIBS})

--- a/test/gpu/native/interop/gpuLibrary/Makefile
+++ b/test/gpu/native/interop/gpuLibrary/Makefile
@@ -3,8 +3,8 @@ test_udf2_make_cpu: test_udf2.cpp lib/libudf2.a
 	@$(CHPL_COMPILER) -x c++ -lstdc++ $(CHPL_CFLAGS) -o test_udf2_make $< $(CHPL_LDFLAGS)
 
 test_udf2_make_nvidia: test_udf2.cpp lib/libudf2.a
-	@$(CHPL_COMPILER) -x cuda $(CHPL_CFLAGS) -o test_udf2_make $< $(CHPL_LDFLAGS)
+	@$(CHPL_COMPILER) -x cuda -lstdc++ $(CHPL_CFLAGS) -o test_udf2_make $< $(CHPL_LDFLAGS)
 
 test_udf2_make_amd: test_udf2.cpp lib/libudf2.a
-	@$(CHPL_COMPILER) -x hip $(CHPL_CFLAGS) -o test_udf2_make $< $(CHPL_LDFLAGS)
+	@$(CHPL_COMPILER) -x hip -lstdc++ $(CHPL_CFLAGS) -o test_udf2_make $< $(CHPL_LDFLAGS)
 

--- a/test/gpu/native/interop/gpuLibrary/Makefile
+++ b/test/gpu/native/interop/gpuLibrary/Makefile
@@ -1,3 +1,3 @@
 include lib/Makefile.udf2
 test_udf2_make: test_udf2.cpp lib/libudf2.a
-	@$(CHPL_COMPILER) $(CHPL_CFLAGS) -o $@ $^ $(CHPL_LDFLAGS)
+	@$(CHPL_COMPILER) -x c++ -lstdc++ $(CHPL_CFLAGS) -o $@ $< $(CHPL_LDFLAGS)

--- a/test/gpu/native/interop/gpuLibrary/Makefile
+++ b/test/gpu/native/interop/gpuLibrary/Makefile
@@ -1,3 +1,10 @@
 include lib/Makefile.udf2
-test_udf2_make: test_udf2.cpp lib/libudf2.a
-	@$(CHPL_COMPILER) -x c++ -lstdc++ $(CHPL_CFLAGS) -o $@ $< $(CHPL_LDFLAGS)
+test_udf2_make_cpu: test_udf2.cpp lib/libudf2.a
+	@$(CHPL_COMPILER) -x c++ -lstdc++ $(CHPL_CFLAGS) -o test_udf2_make $< $(CHPL_LDFLAGS)
+
+test_udf2_make_nvidia: test_udf2.cpp lib/libudf2.a
+	@$(CHPL_COMPILER) -x cuda $(CHPL_CFLAGS) -o test_udf2_make $< $(CHPL_LDFLAGS)
+
+test_udf2_make_amd: test_udf2.cpp lib/libudf2.a
+	@$(CHPL_COMPILER) -x hip $(CHPL_CFLAGS) -o test_udf2_make $< $(CHPL_LDFLAGS)
+

--- a/test/gpu/native/interop/gpuLibrary/Makefile
+++ b/test/gpu/native/interop/gpuLibrary/Makefile
@@ -1,0 +1,3 @@
+include lib/Makefile.udf2
+test_udf2_make: test_udf2.cpp lib/libudf2.a
+	@$(CHPL_COMPILER) $(CHPL_CFLAGS) -o $@ $^ $(CHPL_LDFLAGS)

--- a/test/gpu/native/interop/gpuLibrary/test_udf2.cpp
+++ b/test/gpu/native/interop/gpuLibrary/test_udf2.cpp
@@ -1,0 +1,25 @@
+#include <iostream>
+
+#include "udf2.h"
+
+int main(int argc, char **argv) {
+  chpl_library_init(argc, argv);
+  chpl__init_Foo(0, 0);
+
+  int32_t x[] = {5, 1, 4}; // these should be allocated on the GPU
+  int32_t y[] = {5, 7, 8}; // but that's irrelevant for the issue here
+  int32_t result[3];
+
+  chpl_external_array col_result{result, 3, nullptr};
+  chpl_external_array col_a{x, 3, nullptr};
+  chpl_external_array col_b{y, 3, nullptr};
+
+  add_int32(&col_result, &col_a, &col_b);
+
+  for (int i = 0; i < 3; i++) {
+    std::cout << "result[" << i << "] = " << result[i] << std::endl;
+  }
+
+  chpl_library_finalize();
+  return 0;
+}

--- a/test/gpu/native/interop/gpuLibrary/udf2.chpl
+++ b/test/gpu/native/interop/gpuLibrary/udf2.chpl
@@ -1,0 +1,17 @@
+module Foo {
+
+  extern proc chpl_task_getRequestedSubloc(): int(32);
+  extern proc printf(s...);
+
+  export proc add_int32(ref result: [] int(32), const ref a: [] int(32),
+                        const ref b: [] int(32)) {
+    printf("before on\n");
+    on here.gpus[0] { // `sync begin on` is needed
+      printf("subloc : %d\n", chpl_task_getRequestedSubloc()); // prints -2 without `sync begin on`
+      @assertOnGpu
+      foreach i in 0..2 {
+        result[i] = a[i] + b[i];
+      }
+    }
+  }
+} // Foo

--- a/test/gpu/native/interop/gpuLibrary/udf2.chpl
+++ b/test/gpu/native/interop/gpuLibrary/udf2.chpl
@@ -8,10 +8,13 @@ module Foo {
     printf("before on\n");
     sync begin on here.gpus[0] { // `sync begin on` is needed
       printf("subloc : %d\n", chpl_task_getRequestedSubloc()); // prints -2 without `sync begin on`
+      const a_gpu = a, b_gpu = b;
+      var result_gpu: result.type;
       @assertOnGpu
       foreach i in 0..2 {
-        result[i] = a[i] + b[i];
+        result_gpu[i] = a_gpu[i] + b_gpu[i];
       }
+      result = result_gpu;
     }
   }
 } // Foo

--- a/test/gpu/native/interop/gpuLibrary/udf2.chpl
+++ b/test/gpu/native/interop/gpuLibrary/udf2.chpl
@@ -6,7 +6,7 @@ module Foo {
   export proc add_int32(ref result: [] int(32), const ref a: [] int(32),
                         const ref b: [] int(32)) {
     printf("before on\n");
-    on here.gpus[0] { // `sync begin on` is needed
+    sync begin on here.gpus[0] { // `sync begin on` is needed
       printf("subloc : %d\n", chpl_task_getRequestedSubloc()); // prints -2 without `sync begin on`
       @assertOnGpu
       foreach i in 0..2 {

--- a/test/gpu/native/interop/gpuLibrary/udf2.compopts
+++ b/test/gpu/native/interop/gpuLibrary/udf2.compopts
@@ -1,0 +1,1 @@
+--library --library-cmakelists --library-makefile --library-dir lib

--- a/test/gpu/native/interop/gpuLibrary/udf2.good
+++ b/test/gpu/native/interop/gpuLibrary/udf2.good
@@ -1,0 +1,18 @@
+Running test_udf2_compileline
+before on
+subloc : -2
+result[0] = 10
+result[1] = 8
+result[2] = 12
+Running test_udf2_cmake
+before on
+subloc : -2
+result[0] = 10
+result[1] = 8
+result[2] = 12
+Running test_udf2_make
+before on
+subloc : -2
+result[0] = 10
+result[1] = 8
+result[2] = 12

--- a/test/gpu/native/interop/gpuLibrary/udf2.good
+++ b/test/gpu/native/interop/gpuLibrary/udf2.good
@@ -1,18 +1,18 @@
 Running test_udf2_compileline
 before on
-subloc : -2
+subloc : 0
 result[0] = 10
 result[1] = 8
 result[2] = 12
 Running test_udf2_cmake
 before on
-subloc : -2
+subloc : 0
 result[0] = 10
 result[1] = 8
 result[2] = 12
 Running test_udf2_make
 before on
-subloc : -2
+subloc : 0
 result[0] = 10
 result[1] = 8
 result[2] = 12

--- a/test/gpu/native/interop/gpuLibrary/udf2.noexec
+++ b/test/gpu/native/interop/gpuLibrary/udf2.noexec
@@ -1,0 +1,1 @@
+this is executed by the prediff

--- a/test/gpu/native/interop/gpuLibrary/udf2.prediff
+++ b/test/gpu/native/interop/gpuLibrary/udf2.prediff
@@ -2,16 +2,16 @@
 
 CHPL=$3
 OUTFILE=$2
-CHPL_HOME=`$CHPL --print-chpl-home`
-CHPL_GPU=$($chpl_home/util/printchplenv --all --simple | grep CHPL_GPU | sed 's/CHPL_GPU=//')
+chpl_home=`$CHPL --print-chpl-home`
+chpl_gpu=$(CHPL_HOME=$chpl_home $chpl_home/util/printchplenv --all --simple | grep CHPL_GPU | sed 's/CHPL_GPU=//')
 
 # build with compileline
-cxx=`$CHPL_HOME/util/config/compileline --compile-c++`
-libs=`$CHPL_HOME/util/config/compileline --libraries`
+cxx=`$chpl_home/util/config/compileline --compile-c++`
+libs=`$chpl_home/util/config/compileline --libraries`
 gpu_flags=""
-if [[ "$CHPL_GPU" == "nvidia" ]]; then
+if [[ "$chpl_gpu" == "nvidia" ]]; then
   gpu_flags="-x cuda"
-elif [[ "$CHPL_GPU" == "opencl" ]]; then
+elif [[ "$chpl_gpu" == "amd" ]]; then
   gpu_flags="-x hip"
 fi
 $cxx $gpu_flags test_udf2.cpp -Ilib -Llib/ -ludf2 $libs -o test_udf2_compileline

--- a/test/gpu/native/interop/gpuLibrary/udf2.prediff
+++ b/test/gpu/native/interop/gpuLibrary/udf2.prediff
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+CHPL=$3
+OUTFILE=$2
+CHPL_HOME=`$CHPL --print-chpl-home`
+
+
+# build with compileline
+cxx=`$CHPL_HOME/util/config/compileline --compile-c++`
+libs=`$CHPL_HOME/util/config/compileline --libraries`
+$cxx test_udf2.cpp -Ilib -Llib/ -ludf2 $libs -o test_udf2_compileline
+echo "Running test_udf2_compileline" >> $OUTFILE
+./test_udf2_compileline >> $OUTFILE
+
+# build with cmake
+mkdir cmakeBuild
+cmake -B cmakeBuild -S .
+cmake --build cmakeBuild --target test_udf2_cmake
+echo "Running test_udf2_cmake" >> $OUTFILE
+./cmakeBuild/test_udf2_cmake >> $OUTFILE
+
+# build with makefile
+make test_udf2_make
+echo "Running test_udf2_make" >> $OUTFILE
+./test_udf2_make >> $OUTFILE
+

--- a/test/gpu/native/interop/gpuLibrary/udf2.prediff
+++ b/test/gpu/native/interop/gpuLibrary/udf2.prediff
@@ -3,12 +3,18 @@
 CHPL=$3
 OUTFILE=$2
 CHPL_HOME=`$CHPL --print-chpl-home`
-
+CHPL_GPU=$($chpl_home/util/printchplenv --all --simple | grep CHPL_GPU | sed 's/CHPL_GPU=//')
 
 # build with compileline
 cxx=`$CHPL_HOME/util/config/compileline --compile-c++`
 libs=`$CHPL_HOME/util/config/compileline --libraries`
-$cxx test_udf2.cpp -Ilib -Llib/ -ludf2 $libs -o test_udf2_compileline
+gpu_flags=""
+if [[ "$CHPL_GPU" == "nvidia" ]]; then
+  gpu_flags="-x cuda"
+elif [[ "$CHPL_GPU" == "opencl" ]]; then
+  gpu_flags="-x hip"
+fi
+$cxx $gpu_flags test_udf2.cpp -Ilib -Llib/ -ludf2 $libs -o test_udf2_compileline
 echo "Running test_udf2_compileline" >> $OUTFILE
 ./test_udf2_compileline >> $OUTFILE
 
@@ -20,7 +26,7 @@ echo "Running test_udf2_cmake" >> $OUTFILE
 ./cmakeBuild/test_udf2_cmake >> $OUTFILE
 
 # build with makefile
-make test_udf2_make
+make test_udf2_make_$CHPL_GPU
 echo "Running test_udf2_make" >> $OUTFILE
 ./test_udf2_make >> $OUTFILE
 

--- a/test/gpu/native/interop/gpuLibrary/udf2.prediff
+++ b/test/gpu/native/interop/gpuLibrary/udf2.prediff
@@ -3,7 +3,7 @@
 CHPL=$3
 OUTFILE=$2
 chpl_home=`$CHPL --print-chpl-home`
-chpl_gpu=$(CHPL_HOME=$chpl_home $chpl_home/util/printchplenv --all --simple | grep CHPL_GPU | sed 's/CHPL_GPU=//')
+chpl_gpu=$(CHPL_HOME=$chpl_home $chpl_home/util/printchplenv --all --simple | grep 'CHPL_GPU=' | sed 's/CHPL_GPU=//')
 
 # build with compileline
 cxx=`$chpl_home/util/config/compileline --compile-c++`


### PR DESCRIPTION
Used C linkage in the generated header when compiling with `--library` with the GPU locale model. 

Implemented by adding `extern "C"` around all of the function prototypes.

While there, also fixed an issue with `compileline`, which was missing a line to libraries from the system like other commands.  This prevented using `--library` with systems installs of bundled libraries, like jemalloc.

Testing
- [x] local testing of new test with CHPL_GPU=cpu
- [x] tested new test with CHPL_GPU=nvidia
- [x] tested new test with CHPL_GPU=amd

Resolves https://github.com/chapel-lang/chapel/issues/25222

[Reviewed by @e-kayrakli]