### PR TITLE
Remove mailing list variables from nightly test script

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -22,10 +22,6 @@ use lib "$FindBin::Bin";
 
 use nightlysubs;
 use nightly_email;
-# Mailing lists.
-$failuremail = "chapel+tests\@discoursemail.com";
-$allmail = "chapel-test-results-all\@lists.sourceforge.net";
-$replymail = "";
 
 $valgrind = 0;
 $valgrindexe = 0;


### PR DESCRIPTION
The `util/cron/nightly` test script is no longer responsible for any mailing, and these variables are not used anywhere including in internal repos.

Removes the last instance of a sourceforge address from scripts in this repo (https://github.com/Cray/chapel-private/issues/2950).

[reviewer info placeholder]

Testing:
- [ ] simple nightly test still works