### PR TITLE
Re-futurize test using runtime types for type fields

### DIFF
--- a/test/arrays/deitz/part5/test_array_type_field_type.future
+++ b/test/arrays/deitz/part5/test_array_type_field_type.future
@@ -1,0 +1,3 @@
+bug: memory errors for type field of array type
+
+#25502

--- a/test/arrays/deitz/part5/test_array_type_field_type.skipif
+++ b/test/arrays/deitz/part5/test_array_type_field_type.skipif
@@ -1,0 +1,1 @@
+CHPL_TEST_VGRND_EXE != on


### PR DESCRIPTION
In #22616 I retired this future because it had been relying on some very old syntax for domain literals. This test happened to pass on my mac, but fails in other configurations due to memory issues, so it needs to become a .future again.