### PR TITLE
Improve test cleanup for these tests

### DIFF
--- a/test/interop/C/cmakelists/targetToChpl/CLEANFILES
+++ b/test/interop/C/cmakelists/targetToChpl/CLEANFILES
@@ -1,3 +1,3 @@
 lib/*
-build/*
+build
 cmakeTest

--- a/test/interop/C/cmakelists/targetToLibToChpl/CLEANFILES
+++ b/test/interop/C/cmakelists/targetToLibToChpl/CLEANFILES
@@ -1,3 +1,3 @@
 lib/*
-build/*
+build
 cmakeTest


### PR DESCRIPTION
These tests were cleaning up old files, but not cleaning up the directory they lived in.  Which is fine, but it led to errors in their prediff along the lines of "Cannot create directory 'build': File exists" when the tests were re-run. These did not cause the test to fail or anything, but it seemed like a good idea to stop putting the tests in a situation where their prediff would do that.

Verified that the tests ran okay after this change and that the prediff error was gone.