### PR TITLE
Strict memory management checks for non-classes

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -995,7 +995,7 @@ AggregateType* AggregateType::generateType(CallExpr* call,
 
     if (auto sub = toTypeSymbol(map.get(field))) {
       if (!isClassLike(sub->typeInfo())) {
-        USR_FATAL(call, "cannot use type non-class type '%s' with memory management specifiers",
+        USR_FATAL(call, "cannot use non-class type '%s' with memory management specifiers",
                   sub->name);
       }
     }

--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -986,6 +986,22 @@ AggregateType* AggregateType::generateType(CallExpr* call,
 
   INT_ASSERT(notNamed.size() == 0);
 
+  // Don't even allow creating an instantiation of something like
+  // 'owned' with a non-class.
+  bool isManagedPtrType = symbol->hasFlag(FLAG_MANAGED_POINTER);
+  if (isManagedPtrType && genericFields.size() > 0) {
+    // Assume first generic field is the underlying type.
+    auto field = genericFields[0];
+
+    if (auto sub = toTypeSymbol(map.get(field))) {
+      if (!isClassLike(sub->typeInfo())) {
+        USR_FATAL(call, "cannot use type non-class type '%s' with memory management specifiers",
+                  sub->name);
+      }
+    }
+  }
+
+
   ret = ret->generateType(map, call, callString, evalDefaults, getInstantiationPoint(call));
 
   if (ret != this) {

--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -55,6 +55,9 @@ module OwnedObject {
   pragma "leaves this nil"
   @chpldoc.nodoc // hide init/record impl details
   proc _owned.init(type chpl_t) {
+    // TODO: today, the compiler has a special check for a non-class type
+    // being used to instnatiate _owned, so this check is likely redundant and
+    // should be removed.
     if !isClass(chpl_t) then
       compilerError("owned only works with classes");
 

--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -55,9 +55,10 @@ module OwnedObject {
   pragma "leaves this nil"
   @chpldoc.nodoc // hide init/record impl details
   proc _owned.init(type chpl_t) {
-    // TODO: today, the compiler has a special check for a non-class type
+    // TODO: today (06/15/2024), the compiler has a special check for a non-class type
     // being used to instnatiate _owned, so this check is likely redundant and
-    // should be removed.
+    // should be removed. See other _shared.init methods for similar checks that
+    // are likely also redundant.
     if !isClass(chpl_t) then
       compilerError("owned only works with classes");
 

--- a/modules/internal/SharedObject.chpl
+++ b/modules/internal/SharedObject.chpl
@@ -137,7 +137,8 @@ module SharedObject {
   proc _shared.init(type chpl_t) {
     // TODO: today (06/15/2024), the compiler has a special check for a non-class type
     // being used to instnatiate _shared, so this check is likely redundant and
-    // should be removed.
+    // should be removed. See other _shared.init methods for similar checks that
+    // are likely also redundant.
     if !isClass(chpl_t) then
       compilerError("shared only works with classes");
 

--- a/modules/internal/SharedObject.chpl
+++ b/modules/internal/SharedObject.chpl
@@ -135,6 +135,9 @@ module SharedObject {
   pragma "leaves this nil"
   @chpldoc.nodoc // hide init/record impl details
   proc _shared.init(type chpl_t) {
+    // TODO: today (06/15/2024), the compiler has a special check for a non-class type
+    // being used to instnatiate _shared, so this check is likely redundant and
+    // should be removed.
     if !isClass(chpl_t) then
       compilerError("shared only works with classes");
 

--- a/test/classes/delete-free/error-owned-record-in-operator.chpl
+++ b/test/classes/delete-free/error-owned-record-in-operator.chpl
@@ -1,0 +1,8 @@
+record R { }
+
+var r1 = new R();
+var r2 = new R();
+
+r1 <=> r2;
+
+operator <=>(ref a: owned R, ref b: owned R) { }

--- a/test/classes/delete-free/error-owned-record-in-operator.good
+++ b/test/classes/delete-free/error-owned-record-in-operator.good
@@ -1,0 +1,2 @@
+error-owned-record-in-operator.chpl:8: In function '<=>':
+error-owned-record-in-operator.chpl:8: error: cannot use type non-class type 'R' with memory management specifiers

--- a/test/classes/delete-free/error-owned-record-in-operator.good
+++ b/test/classes/delete-free/error-owned-record-in-operator.good
@@ -1,2 +1,2 @@
 error-owned-record-in-operator.chpl:8: In function '<=>':
-error-owned-record-in-operator.chpl:8: error: cannot use type non-class type 'R' with memory management specifiers
+error-owned-record-in-operator.chpl:8: error: cannot use non-class type 'R' with memory management specifiers

--- a/test/classes/delete-free/error-owned-record.good
+++ b/test/classes/delete-free/error-owned-record.good
@@ -1,1 +1,1 @@
-error-owned-record.chpl:4: error: cannot use type non-class type 'R' with memory management specifiers
+error-owned-record.chpl:4: error: cannot use non-class type 'R' with memory management specifiers

--- a/test/classes/delete-free/error-owned-record.good
+++ b/test/classes/delete-free/error-owned-record.good
@@ -1,1 +1,1 @@
-error-owned-record.chpl:4: error: owned only works with classes
+error-owned-record.chpl:4: error: cannot use type non-class type 'R' with memory management specifiers

--- a/test/classes/delete-free/error-shared-record.good
+++ b/test/classes/delete-free/error-shared-record.good
@@ -1,1 +1,1 @@
-error-shared-record.chpl:4: error: shared only works with classes
+error-shared-record.chpl:4: error: cannot use type non-class type 'R' with memory management specifiers

--- a/test/classes/delete-free/error-shared-record.good
+++ b/test/classes/delete-free/error-shared-record.good
@@ -1,1 +1,1 @@
-error-shared-record.chpl:4: error: cannot use type non-class type 'R' with memory management specifiers
+error-shared-record.chpl:4: error: cannot use non-class type 'R' with memory management specifiers

--- a/test/classes/delete-free/owned-shared-on-record.future
+++ b/test/classes/delete-free/owned-shared-on-record.future
@@ -1,2 +1,0 @@
-bug: internal error when using `owned MyRecord` or `shared MyRecord`
-#25549

--- a/test/classes/delete-free/owned-shared-on-record.good
+++ b/test/classes/delete-free/owned-shared-on-record.good
@@ -1,0 +1,1 @@
+owned-shared-on-record.chpl:3: error: cannot use type non-class type 'C' with memory management specifiers

--- a/test/classes/delete-free/owned-shared-on-record.good
+++ b/test/classes/delete-free/owned-shared-on-record.good
@@ -1,1 +1,1 @@
-owned-shared-on-record.chpl:3: error: cannot use type non-class type 'C' with memory management specifiers
+owned-shared-on-record.chpl:3: error: cannot use non-class type 'C' with memory management specifiers

--- a/test/classes/delete-free/owned/errors/owned-int-type.bad
+++ b/test/classes/delete-free/owned/errors/owned-int-type.bad
@@ -1,3 +1,0 @@
-$CHPL_HOME/modules/internal/OwnedObject.chpl:417: error: ambiguous call 'owned.init(owned int(64))'
-$CHPL_HOME/modules/internal/OwnedObject.chpl:175: note: candidates are: owned.init(p: borrowed)
-$CHPL_HOME/modules/internal/OwnedObject.chpl:242: note:                 owned.init(src: owned)

--- a/test/classes/delete-free/owned/errors/owned-int-type.future
+++ b/test/classes/delete-free/owned/errors/owned-int-type.future
@@ -1,4 +1,0 @@
-error message: 'owned <non-class type>' results in confusing error messages
-
-This series of tests shows that when 'owned' is applied to something other
-than a class type, the resulting error messages are confusing.

--- a/test/classes/delete-free/owned/errors/owned-int-type.good
+++ b/test/classes/delete-free/owned/errors/owned-int-type.good
@@ -1,2 +1,1 @@
-owned-class-instance.chpl:1: error: 'owned' can only be applied to class types
-owned-class-instance.chpl:1: note: here it is applied to type 'int'
+owned-int-type.chpl:1: error: cannot use type non-class type 'int(64)' with memory management specifiers

--- a/test/classes/delete-free/owned/errors/owned-int-type.good
+++ b/test/classes/delete-free/owned/errors/owned-int-type.good
@@ -1,1 +1,1 @@
-owned-int-type.chpl:1: error: cannot use type non-class type 'int(64)' with memory management specifiers
+owned-int-type.chpl:1: error: cannot use non-class type 'int(64)' with memory management specifiers


### PR DESCRIPTION
Realized I forgot to open this during the day.

Closes https://github.com/chapel-lang/chapel/issues/14121. Closes https://github.com/chapel-lang/chapel/issues/25549.

This PR ensures that errors are thrown when non-class types are used with `shared` and `owned`. The previous error was limited to invocations of the initializers for `_owned` / `_shared`, which does not happen in certain cases, including when using type aliases and specifying formal types. This PR adds special-case logic for management types to the type instantiation code directly, which guarantees that it's run as soon as `owned(T)` is attempted. As a result, errors are now caught earlier and in more cases.

Reviewed by @jabraham17 -- thanks!

## Testing
- [x] paratest + new tests