### PR TITLE
Add skipif for new gpu library test

### DIFF
--- a/test/gpu/native/interop/gpuLibrary/SKIPIF
+++ b/test/gpu/native/interop/gpuLibrary/SKIPIF
@@ -1,4 +1,4 @@
-// CHapel's library support does not work for comm!=none and launcher!=none
+# Chapel's library support does not work for comm!=none and launcher!=none
 CHPL_COMM != none
 COMPOPTS <= --no-local
 CHPL_LAUNCHER != none

--- a/test/gpu/native/interop/gpuLibrary/SKIPIF
+++ b/test/gpu/native/interop/gpuLibrary/SKIPIF
@@ -1,0 +1,4 @@
+// CHapel's library support does not work for comm!=none and launcher!=none
+CHPL_COMM != none
+COMPOPTS <= --no-local
+CHPL_LAUNCHER != none


### PR DESCRIPTION
Adds a skipif for a new gpu library test (from https://github.com/chapel-lang/chapel/pull/25538), which will not work for multi-locale or systems which require launchers

[Not reviewed - trivial]