### PR TITLE
Un-future fact-linenum stack trace test as it is now working

### DIFF
--- a/test/runtime/stacktrace/fact-linenum.bad
+++ b/test/runtime/stacktrace/fact-linenum.bad
@@ -1,8 +1,0 @@
-fact-linenum.chpl:2: error: halt reached
-Stacktrace
-
-halt() at $CHPL_HOME/modules/standard/Errors.chpl:nnnn
-fact() at fact-linenum.chpl:1
-fact() at fact-linenum.chpl:1
-fact() at fact-linenum.chpl:1
-chpl__init_fact-linenum() at fact-linenum.chpl:1

--- a/test/runtime/stacktrace/fact-linenum.future
+++ b/test/runtime/stacktrace/fact-linenum.future
@@ -1,2 +1,0 @@
-feature request: Get call site lines in unwind
-#2610


### PR DESCRIPTION
This PR un-futures the test

    test/runtime/stacktrace/fact-linenum.chpl 

as it is now working as expected according to nightly testing.

Resolves https://github.com/Cray/chapel-private/issues/2610 .

Test change only -- not reviewed.

I checked that this test works correctly in the following configs on an Ubuntu 24.04 system:
- [x] quickstart with CHPL_UNWIND=bundled
- [x] quickstart with CHPL_UNWIND=bundled and CHPL_LLVM=none
- [x] quickstart with CHPL_UNWIND=bundled and CHPL_COMM=gasnet
- [x] default config with CHPL_UNWIND=bundled
- [x] default config with CHPL_UNWIND=bundled and CHPL_COMM=gasnet