### PR TITLE
Fix baseline bug for iteration over heterogeneous tuples

### DIFF
--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -2520,14 +2520,16 @@ static Expr* unrollHetTupleLoop(CallExpr* call, Expr* tupExpr, Type* iterType) {
     VarSymbol* tmp = newTemp(astr("tupleTemp"));
     tmp->addFlag(FLAG_REF_VAR);
 
+    auto field = tupType->getField(i);
+    auto prim = field->isRef() ? PRIM_GET_MEMBER_VALUE : PRIM_GET_MEMBER;
     // create the AST for 'tupleTemp = tuple.field'
     //
-    VarSymbol* field = new_CStringSymbol(tupType->getField(i)->name);
+    VarSymbol* fieldName = new_CStringSymbol(field->name);
     noop->insertBefore(new DefExpr(tmp));
     noop->insertBefore(new CallExpr(PRIM_MOVE, tmp,
-                                    new CallExpr(PRIM_GET_MEMBER,
+                                    new CallExpr(prim,
                                                  tupExpr->copy(),
-                                                 field)));
+                                                 fieldName)));
 
     // clone the body; subtract 2 from i to number unrollings from 0
     //

--- a/test/types/tuple/these/iterHetTupleArg.bad
+++ b/test/types/tuple/these/iterHetTupleArg.bad
@@ -1,8 +1,8 @@
-iterHetTupleArg.chpl:14: internal error: COD-CG--XPR-5708 chpl version 1.24.0 pre-release (a721b8db24)
-Note: This source location is a guess.
-
-Internal errors indicate a bug in the Chapel compiler,
-and we're sorry for the hassle.  We would appreciate your reporting this bug --
-please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-
+iterHetTupleArg.chpl:13: In function 'byDefaultIntent':
+iterHetTupleArg.chpl:13: error: tuple formal 'tupArg' of 'byDefaultIntent' is const and cannot be modified
+note: tuple element #0 of type R
+iterHetTupleArg.chpl:14: note: possibly set here
+iterHetTupleArg.chpl:13: error: tuple formal 'tupArg' of 'byDefaultIntent' is const and cannot be modified
+note: tuple element #1 of type S
+iterHetTupleArg.chpl:14: note: possibly set here
+  iterHetTupleArg.chpl:11: called as byDefaultIntent(tupArg: (R,S))


### PR DESCRIPTION
This bug was caused by an incorrect usage of PRIM_GET_MEMBER for tuple components that are references. Instead, use PRIM_GET_MEMBER_VALUE. We don't see this in normal production configurations because optimizations eliminated the tuple literal entirely.

Testing:
- [x] full local
- [x] full gasnet