### PR TITLE
Add a future for #7936

### DIFF
--- a/test/arrays/formals/promotedExprAsArrayActual.bad
+++ b/test/arrays/formals/promotedExprAsArrayActual.bad
@@ -1,0 +1,4 @@
+promotedExprAsArrayActual.chpl:3: error: unresolved call 'doSomething(promoted expression)'
+promotedExprAsArrayActual.chpl:1: note: this candidate did not match: doSomething(arg: [] int)
+promotedExprAsArrayActual.chpl:3: note: because actual argument #1 with type 'iterator'
+promotedExprAsArrayActual.chpl:1: note: is passed to formal 'arg: []'

--- a/test/arrays/formals/promotedExprAsArrayActual.chpl
+++ b/test/arrays/formals/promotedExprAsArrayActual.chpl
@@ -1,0 +1,3 @@
+proc doSomething(arg: [] int) {}
+var A, B: [1..10] int;
+doSomething(A + B);

--- a/test/arrays/formals/promotedExprAsArrayActual.future
+++ b/test/arrays/formals/promotedExprAsArrayActual.future
@@ -1,0 +1,2 @@
+feature: passing promoted expressions to array formals
+https://github.com/chapel-lang/chapel/issues/7936


### PR DESCRIPTION
One might expect that promoted expressions get coerced into arrays when giving to arary formals, but this does not happen, which is the underlying cause for the bug in https://github.com/chapel-lang/chapel/issues/7936. It would be nice to have that.

Trivial, will not be reviewed.

## Testing
- [x] new future is a "clean match against .bad file".