### PR TITLE
Enhance User Guidance Docs: Clarify When to Use Mason

### DIFF
--- a/doc/rst/tools/mason/mason.rst
+++ b/doc/rst/tools/mason/mason.rst
@@ -16,9 +16,9 @@ Chapel programs.
 When to Leverage Mason for Chapel Builds
 ----------------------------------------
 
-Mason simplifies the build process for Chapel applications, but it's
-not currently a one-size-fits-all solution. Here's a breakdown of
-when Mason shines and when alternative approaches might be better suited.
+Mason simplifies the build process for Chapel applications. Here's a
+breakdown of when Mason shines and when alternative approaches might
+be better suited.
 
 **Ideal Use Cases for Mason:**
 
@@ -37,7 +37,7 @@ when Mason shines and when alternative approaches might be better suited.
    compilation steps beyond what the Chapel compiler offers, Mason might not
    be the most suitable choice. Consider alternatives like `Make` for greater
    flexibility in crafting intricate build commands. As an example, the
-   Arkouda project, a prominent open-source Chapel application, utilizes
+   Arkouda project, a prominent open-source Chapel application, uses
    `Make` to run preparatory Python scripts before the final binary compilation.
 
 **Combining Mason with Make:**

--- a/doc/rst/tools/mason/mason.rst
+++ b/doc/rst/tools/mason/mason.rst
@@ -13,17 +13,39 @@ that be to create a library to contribute to the community, use an
 existing package, or just to help with the process of building your
 Chapel programs.
 
-.. note::
+When to Leverage Mason for Chapel Builds
+----------------------------------------
 
-   **Pardon Our Dust**
+Mason simplifies the build process for Chapel applications, but it's
+not a one-size-fits-all solution. Here's a breakdown of when Mason
+shines and when alternative approaches might be better suited.
 
-   This mason guide is a work-in-progress as mason development itself
-   is still a work-in-progress.  If you're not already using the `main
-   branch <https://chapel-lang.org/docs/main/mason-packages/>`_ of the
-   documentation (which tracks real-time GitHub development), you may
-   find that it contains a more complete set of sections.  We welcome
-   feedback and requests on the guide as we go.
+**Ideal Use Cases for Mason:**
 
+1. Pure Chapel Projects
+   - Mason excels at managing the build process for applications written
+     entirely in Chapel. If your program relies solely on Chapel
+     dependencies and compiles directly from Chapel modules, Mason is the
+     perfect tool.
+2. External Dependencies with `Spack` or `pkg-config`
+   - Mason integrates seamlessly with external dependencies managed by
+     `Spack` or `pkg-config`.
+   - If your project uses such dependencies, Mason can handle them efficiently.
+
+**Considering Alternatives:**
+
+1. Complex Compilation Needs Beyond `chpl`
+   - For Chapel programs requiring compilation steps beyond what the Chapel
+     compiler offers, Mason might not be the most suitable choice. Consider
+     alternatives like `Make` for greater flexibility in crafting intricate build commands.
+   - Example: The Arkouda project, a prominent open-source Chapel application,
+     utilizes Make to run preparatory Python scripts before the final binary compilation.
+
+**Combining Mason with Make:**
+
+Mason and Make can co-exist effectively. You can leverage Mason for its dependency
+management capabilities while employing Make for broader build commands requiring
+more control.
 
 Quick Start Instructions
 ------------------------

--- a/doc/rst/tools/mason/mason.rst
+++ b/doc/rst/tools/mason/mason.rst
@@ -22,25 +22,23 @@ when Mason shines and when alternative approaches might be better suited.
 
 **Ideal Use Cases for Mason:**
 
-1. Pure Chapel Projects
-   a. Mason excels at managing the build process for applications written
-      entirely in Chapel.
-   b. If your program relies solely on Chapel
-      dependencies and compiles directly from Chapel modules, Mason is the
-      perfect tool.
-2. External Dependencies with `Spack` or `pkg-config`
-   a. Mason integrates seamlessly with external dependencies managed by
-      `Spack` or `pkg-config`. If your project uses such dependencies,
-      Mason can handle them efficiently.
+1. Pure Chapel Projects: Mason excels at managing the build process for
+   applications written entirely in Chapel. If your program relies solely
+   on Chapel dependencies and compiles directly from Chapel modules, Mason
+   is the perfect tool.
+2. External Dependencies with `Spack` or `pkg-config`: Mason integrates
+   seamlessly with external dependencies managed by `Spack` or
+   `pkg-config`. If your project uses such dependencies, Mason can handle
+   them efficiently.
 
 **Considering Alternatives:**
 
-1. Complex Compilation Needs Beyond `chpl`
-   a. For Chapel programs requiring compilation steps beyond what the Chapel
-     compiler offers, Mason might not be the most suitable choice. Consider
-     alternatives like `Make` for greater flexibility in crafting intricate build commands.
-   b. Example: The Arkouda project, a prominent open-source Chapel application,
-     utilizes Make to run preparatory Python scripts before the final binary compilation.
+1. Complex Compilation Needs Beyond `chpl`: For Chapel programs requiring
+   compilation steps beyond what the Chapel compiler offers, Mason might not
+   be the most suitable choice. Consider alternatives like `Make` for greater
+   flexibility in crafting intricate build commands. As an example, the
+   Arkouda project, a prominent open-source Chapel application, utilizes
+   `Make` to run preparatory Python scripts before the final binary compilation.
 
 **Combining Mason with Make:**
 

--- a/doc/rst/tools/mason/mason.rst
+++ b/doc/rst/tools/mason/mason.rst
@@ -23,22 +23,23 @@ when Mason shines and when alternative approaches might be better suited.
 **Ideal Use Cases for Mason:**
 
 1. Pure Chapel Projects
-   - Mason excels at managing the build process for applications written
-     entirely in Chapel. If your program relies solely on Chapel
-     dependencies and compiles directly from Chapel modules, Mason is the
-     perfect tool.
+   a. Mason excels at managing the build process for applications written
+      entirely in Chapel.
+   b. If your program relies solely on Chapel
+      dependencies and compiles directly from Chapel modules, Mason is the
+      perfect tool.
 2. External Dependencies with `Spack` or `pkg-config`
-   - Mason integrates seamlessly with external dependencies managed by
-     `Spack` or `pkg-config`.
-   - If your project uses such dependencies, Mason can handle them efficiently.
+   a. Mason integrates seamlessly with external dependencies managed by
+      `Spack` or `pkg-config`. If your project uses such dependencies,
+      Mason can handle them efficiently.
 
 **Considering Alternatives:**
 
 1. Complex Compilation Needs Beyond `chpl`
-   - For Chapel programs requiring compilation steps beyond what the Chapel
+   a. For Chapel programs requiring compilation steps beyond what the Chapel
      compiler offers, Mason might not be the most suitable choice. Consider
      alternatives like `Make` for greater flexibility in crafting intricate build commands.
-   - Example: The Arkouda project, a prominent open-source Chapel application,
+   b. Example: The Arkouda project, a prominent open-source Chapel application,
      utilizes Make to run preparatory Python scripts before the final binary compilation.
 
 **Combining Mason with Make:**

--- a/doc/rst/tools/mason/mason.rst
+++ b/doc/rst/tools/mason/mason.rst
@@ -17,8 +17,8 @@ When to Leverage Mason for Chapel Builds
 ----------------------------------------
 
 Mason simplifies the build process for Chapel applications, but it's
-not a one-size-fits-all solution. Here's a breakdown of when Mason
-shines and when alternative approaches might be better suited.
+not currently a one-size-fits-all solution. Here's a breakdown of
+when Mason shines and when alternative approaches might be better suited.
 
 **Ideal Use Cases for Mason:**
 


### PR DESCRIPTION
This pull request introduces new documentation that clarifies when to leverage Mason for building Chapel applications and when alternative approaches might be more suitable.

The new documentation provides a breakdown of ideal use cases for Mason, including:

- Pure Chapel Applications: Mason excels at managing the build process for projects written entirely in Chapel.
- External Dependencies with Spack or pkg-config: Mason integrates seamlessly with external dependencies managed by these popular package managers.

Additionally, the documentation highlights scenarios where alternative build tools like Make might be better suited, such as:

- Complex Compilation Needs: When a Chapel program requires intricate build commands beyond the capabilities of the Chapel compiler, tools like Make offer greater flexibility.

This improved guidance empowers users to make informed decisions about which build tool best aligns with their specific project requirements.