### PR TITLE
Fix graph file for lsu-heat perf tests

### DIFF
--- a/test/studies/lsuHeat/heat.graph
+++ b/test/studies/lsuHeat/heat.graph
@@ -1,4 +1,4 @@
-perfKeys: elapsed:, elapsed:, elapsed:, elapsed:
+perfkeys: elapsed:, elapsed:, elapsed:, elapsed:
 files: heat.dat, heat_barrier_sync.dat, heat_ghost_sync.dat, heat_queue_sync.dat
 graphkeys: forall, coforall global array, coforall task-local arrays, coforall task-local arrays (with queues)
 ylabel: Time (seconds)


### PR DESCRIPTION
Fix the `perfkeys` line in the graph file added [here](https://github.com/chapel-lang/chapel/pull/22391/files#diff-d3f1a3dc82d01de8002362c04c50731962a2d6c2987b7142ce60249fa64e4bab), which was incorrectly camel-cased.