### PR TITLE
Fix dyno bug resolving init of generic field after concrete field

### DIFF
--- a/frontend/lib/resolution/InitResolver.cpp
+++ b/frontend/lib/resolution/InitResolver.cpp
@@ -341,15 +341,13 @@ const Type* InitResolver::computeReceiverTypeConsideringState(void) {
   }
 
   if (subs.size() == 0) {
-    ctx_->error(ctInitial->id(), "unable to instantiate generic type from initializer");
     return currentRecvType_;
+  } else {
+    const Type* ret = ctFromSubs(ctx_, initialRecvType_, ctInitial, subs);
+    CHPL_ASSERT(ret);
+    return ret;
   }
 
-  const Type* ret = ctFromSubs(ctx_, initialRecvType_, ctInitial, subs);
-
-  CHPL_ASSERT(ret);
-
-  return ret;
 }
 
 QualifiedType::Kind InitResolver::determineReceiverIntent(void) {

--- a/frontend/lib/resolution/InitResolver.cpp
+++ b/frontend/lib/resolution/InitResolver.cpp
@@ -242,7 +242,8 @@ bool InitResolver::isFinalReceiverStateValid(void) {
     }
 
     if (state->qt.genericity() == Type::GENERIC) {
-      CHPL_UNIMPL("Unhandled generic initializer state");
+      ctx_->error(ctInitial->id(),
+                  "unable to instantiate generic type from initializer");
       ret = false;
     }
   }

--- a/frontend/test/resolution/testInitSemantics.cpp
+++ b/frontend/test/resolution/testInitSemantics.cpp
@@ -1299,6 +1299,29 @@ static void testInheritance() {
 
 }
 
+static void testInitGenericAfterConcrete() {
+  std::string program = R"""(
+      record Foo {
+        var a:int;
+        var b;
+        proc init() {
+          this.a = 1;
+          this.b = 2;
+        }
+      }
+
+      var myFoo = new Foo();
+      var x = myFoo.b;
+    )""";
+
+  Context ctx;
+  Context* context = &ctx;
+  auto t = resolveTypeOfX(context, program);
+
+  assert(t);
+  assert(t->isIntType());
+}
+
 // TODO:
 // - test using defaults for types and params
 //   - also in conditionals
@@ -1338,6 +1361,8 @@ int main() {
   testInitEqOther();
 
   testInheritance();
+
+  testInitGenericAfterConcrete();
 
   return 0;
 }


### PR DESCRIPTION
Fixes a dyno init resolver bug, where an error is emitted for an initializer that assigns to a generic field after a concrete field.

Thanks @DanilaFe for suggesting this solution.

Resolves https://github.com/Cray/chapel-private/issues/6522.

[reviewer info placeholder]

Testing:
- [x] dyno tests