### PR TITLE
Add basic correctness testing of Linux packages to nightly tests

### DIFF
--- a/util/cron/create_release_aptrpm.bash
+++ b/util/cron/create_release_aptrpm.bash
@@ -47,3 +47,6 @@ else
   log_info "Building $PACKAGE_NAME $PACKAGE_TYPE package on $OS"
   __build_native_package $PACKAGE_TYPE $OS $PACKAGE_NAME $CHPL_VERSION $PACKAGE_VERSION $DOCKER_DIR_NAME $PARALLEL
 fi
+
+log_info "Testing $PACKAGE_NAME"
+__test_all_packages

--- a/util/packaging/apt/test/Dockerfile.template
+++ b/util/packaging/apt/test/Dockerfile.template
@@ -1,15 +1,14 @@
 FROM @@{OS_BASE_IMAGE}
 
+@@{INJECT_BEFORE_DEPS}
+
+@@{TEST_ENV}
+
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y vim sudo
 
-RUN useradd -ms /bin/bash user && \
-    usermod -aG sudo user && \
-    echo "user:password" | chpasswd
-
-USER user
-WORKDIR /home/user
+@@{USER_CREATION}
 
 COPY --chown=user @@{HOST_PACKAGE_PATH}/@@{PACKAGE_NAME} /home/user/@@{PACKAGE_NAME}
 

--- a/util/packaging/common/build_helpers.sh
+++ b/util/packaging/common/build_helpers.sh
@@ -125,7 +125,7 @@ __run_container() {
 }
 
 __test_package() {
-  python3 $chpl_home/util/packaging/common/test_package.py $1
+  python3 $chpl_home/util/packaging/common/test_package.py $@
 }
 __test_all_packages() {
   for deb in util/packaging/apt/build/*/*/*.deb; do

--- a/util/packaging/common/build_helpers.sh
+++ b/util/packaging/common/build_helpers.sh
@@ -123,3 +123,15 @@ __run_container() {
 
   docker run -it --rm $__docker_tag
 }
+
+__test_package() {
+  python3 $chpl_home/util/packaging/common/test_package.py $1
+}
+__test_all_packages() {
+  for deb in util/packaging/apt/build/*/*/*.deb; do
+    __test_package $deb
+  done
+  for rpm in util/packaging/rpm/build/*/*/*.rpm; do
+    __test_package $rpm
+  done
+}

--- a/util/packaging/common/test_package.py
+++ b/util/packaging/common/test_package.py
@@ -45,7 +45,7 @@ def infer_docker_os(package):
         "fc38": "fedora:38",
         "fc39": "fedora:39",
         "fc40": "fedora:40",
-        "ubuntu22": "ubuntu:20.04",
+        "ubuntu22": "ubuntu:22.04",
         "ubuntu24": "ubuntu:24.04",
         "debian11": "debian:bullseye",
         "debian12": "debian:bookworm",

--- a/util/packaging/rpm/common/fill_docker_template.py
+++ b/util/packaging/rpm/common/fill_docker_template.py
@@ -107,14 +107,6 @@ COPY --chown=user ./common/fixpaths.py /home/user/fixpaths.py
 USER root
 RUN python3 fixpaths.py $BASENAME $CHAPEL_VERSION $PACKAGE_VERSION $OS_NAME $TARGETARCH
 USER user
-
-
-# hot fixes for rpm, can be removed in 2.1
-USER root
-RUN short_version=$(python3 package_name.py --short-version $BASENAME $CHAPEL_VERSION $PACKAGE_VERSION $OS_NAME $TARGETARCH) && \
-    sed -i 's|#!/usr/bin/env python|#!/usr/bin/env python3|' /usr/share/chapel/${short_version}/util/config/compileline.py && \
-    unset short_version
-USER user
 """
 
 substitutions[

--- a/util/packaging/rpm/test/Dockerfile.template
+++ b/util/packaging/rpm/test/Dockerfile.template
@@ -1,19 +1,17 @@
 FROM @@{OS_BASE_IMAGE}
 
-RUN dnf upgrade -y && dnf install -y sudo vim which
+@@{INJECT_BEFORE_DEPS}
 
-RUN useradd -ms /bin/bash user && \
-    usermod -aG wheel user && \
-    echo "user:password" | chpasswd && \
-    sed -i 's/%wheel[ \t]\{1,\}ALL=(ALL)[ \t]\{1,\}ALL/%wheel ALL=(ALL) NOPASSWD: ALL/g' /etc/sudoers
+@@{TEST_ENV}
 
-USER user
-WORKDIR /home/user
+RUN dnf upgrade -y && dnf install -y --allowerasing sudo vim which
+
+@@{USER_CREATION}
 
 COPY --chown=user @@{HOST_PACKAGE_PATH}/@@{PACKAGE_NAME} /home/user/@@{PACKAGE_NAME}
 
 USER root
-RUN dnf install -y ./@@{PACKAGE_NAME}
+RUN dnf install -y --allowerasing ./@@{PACKAGE_NAME}
 USER user
 WORKDIR /home/user
 


### PR DESCRIPTION
Adds basic correctness testing of Linux packages to nightly tests. This improves upon the unused `util/packaging/common/test_package.py` script and actually begins using in the nightly build script. This should validate the packages and catch mistakes when making changes to the package configs

Tested that `__test_package` works with existing packages.

[Reviewed by @jhh67]