### PR TITLE
Support `ref` intent scalar on gpuized forall loop for NVIDIA

### DIFF
--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -5549,7 +5549,7 @@ DEFINE_PRIM(GPU_ARG) {
   Immediate* imm = getSymbolImmediate(kindSE->symbol());
   int8_t kind = imm->v_int8;
 
-  if ((kind & 1<<0) == GpuArgKind::ADDROF) {
+  if (kind & GpuArgKind::ADDROF) {
     args.push_back(codegenAddrOf(codegenValuePtr(call->get(2))));
   }
   else {
@@ -5557,7 +5557,7 @@ DEFINE_PRIM(GPU_ARG) {
   }
 
   const char* fnName;
-  if ((kind & 1<<1) == GpuArgKind::OFFLOAD) {
+  if (kind & GpuArgKind::OFFLOAD) {
     fnName = "chpl_gpu_arg_offload";
     args.push_back(codegenSizeof(call->get(2)->typeInfo()->getValType()));
 
@@ -5569,8 +5569,11 @@ DEFINE_PRIM(GPU_ARG) {
     args.push_back(codegenSizeof(call->get(2)->typeInfo()->getValType()));
     args.push_back(call->get(4)->codegen());
 
-  }
-  else {
+  } else if (kind & GpuArgKind::HOST_REGISTER) {
+    fnName = "chpl_gpu_arg_host_register";
+    args.push_back(codegenSizeof(call->get(2)->typeInfo()->getValType()));
+
+  } else {
     fnName = "chpl_gpu_arg_pass";
   }
 

--- a/compiler/include/misc.h
+++ b/compiler/include/misc.h
@@ -100,6 +100,7 @@ enum GpuArgKind {
                   // using the previous bit)
                   // otherwise, the variable is passed directly
   REDUCE = 1<<2,  // this is a reduction temp
+  HOST_REGISTER = 1<<3
 };
 
 

--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -1293,7 +1293,7 @@ FnSymbol* KernelArg::generateFinalReductionWrapper() {
   return ret;
 }
 
-KernelArg::KernelArg(Symbol* symInLoop, GpuKernel* kernel, bool isCompilerGeneratedArgcheckIntent) :
+KernelArg::KernelArg(Symbol* symInLoop, GpuKernel* kernel, bool isCompilerGeneratedArg) :
   actual_(symInLoop), kernel_(kernel) {
 
   Type* symType = symInLoop->typeInfo();
@@ -1302,7 +1302,7 @@ KernelArg::KernelArg(Symbol* symInLoop, GpuKernel* kernel, bool isCompilerGenera
   IntentTag intent = symInLoop->isRef() ? INTENT_REF : INTENT_IN;
   this->formal_ = new ArgSymbol(intent, symInLoop->name, symType);
 
-  if (!isCompilerGeneratedArgcheckIntent &&
+  if (!isCompilerGeneratedArg &&
       !isAggregateType(symInLoop->getValType()) &&
       !symInLoop->hasFlag(FLAG_TASK_PRIVATE_VARIABLE) &&
       !symInLoop->isConstValWillNotChange())

--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -1023,7 +1023,7 @@ class KernelArg {
     ReductionInfo redInfo_;
 
   public:
-    KernelArg(Symbol* symInLoop, GpuKernel* kernel);
+    KernelArg(Symbol* symInLoop, GpuKernel* kernel, bool isCompilerGeneratedArg);
     int8_t kind() const { return kind_; }
     ArgSymbol* formal() const { return formal_; }
     Type* getType() const { return actual_->typeInfo(); }
@@ -1070,6 +1070,7 @@ class GpuKernel {
   std::string name_;
 
   int nReductionBufs_ = 0;
+  int nHostRegisteredVars_ = 0;
 
   BlockStmt* userBody_; // where the loop's body goes
   BlockStmt* postBody_; // executed by all GPU threads (even if oob) at the end
@@ -1085,6 +1086,8 @@ class GpuKernel {
   BlockStmt* gpuPrimitivesBlock() const { return gpuPrimitivesBlock_; }
   Symbol* blockSize() const {return blockSize_; }
   int nReductionBufs() const {return nReductionBufs_; }
+  int nHostRegisteredVars() const {return nHostRegisteredVars_; }
+  void incNumHostRegisteredVars() { nHostRegisteredVars_ += 1; }
 
   private:
   void buildStubOutlinedFunction(DefExpr* insertionPoint);
@@ -1098,7 +1101,9 @@ class GpuKernel {
   void generateOobCond();
   void generatePostBody();
   void markGPUSubCalls(FnSymbol* fn);
-  Symbol* addKernelArgument(Symbol* symInLoop);
+  Symbol* addUserVarKernelArgument(Symbol* symInLoop);
+  Symbol* addCompilerGeneratedKernelArgument(Symbol* symInLoop);
+  Symbol* addKernelArgument(Symbol* symInLoop, bool isCompilerGenerated);
   Symbol* addLocalVariable(Symbol* symInLoop);
 
   void incReductionBufs() { nReductionBufs_ += 1; }
@@ -1288,7 +1293,7 @@ FnSymbol* KernelArg::generateFinalReductionWrapper() {
   return ret;
 }
 
-KernelArg::KernelArg(Symbol* symInLoop, GpuKernel* kernel) :
+KernelArg::KernelArg(Symbol* symInLoop, GpuKernel* kernel, bool isCompilerGeneratedArgcheckIntent) :
   actual_(symInLoop), kernel_(kernel) {
 
   Type* symType = symInLoop->typeInfo();
@@ -1297,8 +1302,14 @@ KernelArg::KernelArg(Symbol* symInLoop, GpuKernel* kernel) :
   IntentTag intent = symInLoop->isRef() ? INTENT_REF : INTENT_IN;
   this->formal_ = new ArgSymbol(intent, symInLoop->name, symType);
 
-
-  if (isClass(symValType) ||
+  if (!isCompilerGeneratedArgcheckIntent &&
+      !isAggregateType(symInLoop->getValType()) &&
+      !symInLoop->hasFlag(FLAG_TASK_PRIVATE_VARIABLE) &&
+      !symInLoop->isConstValWillNotChange())
+  {
+    this->kind_ = GpuArgKind::ADDROF | GpuArgKind::HOST_REGISTER;
+    kernel->incNumHostRegisteredVars();
+  } else if (isClass(symValType) ||
       (!symInLoop->isRef() && !isAggregateType(symValType))) {
     // class: must be on GPU memory
     // scalar: can be passed as an argument directly
@@ -1404,8 +1415,16 @@ CallExpr* KernelArg::generatePrimGpuBlockReduce(Symbol* blockSize) const {
   return nullptr;
 }
 
-Symbol* GpuKernel::addKernelArgument(Symbol* symInLoop) {
-  KernelArg arg(symInLoop, this);
+Symbol* GpuKernel::addUserVarKernelArgument(Symbol* symInLoop) {
+  return addKernelArgument(symInLoop, false);
+}
+
+Symbol* GpuKernel::addCompilerGeneratedKernelArgument(Symbol* symInLoop) {
+  return addKernelArgument(symInLoop, true);
+}
+
+Symbol* GpuKernel::addKernelArgument(Symbol* symInLoop, bool isCompilerGenerated) {
+  KernelArg arg(symInLoop, this, isCompilerGenerated);
 
   if (!arg.isEligible()) {
     this->gpuLoop.reportNotGpuizable(symInLoop, "unsupported reduction");
@@ -1489,7 +1508,7 @@ void GpuKernel::generateIndexComputation() {
       PRIM_ADD, tempVar, varThreadIdxX));
     fn_->insertAtTail(c2);
 
-    Symbol* startOffset = addKernelArgument(lowerBound);
+    Symbol* startOffset = addCompilerGeneratedKernelArgument(lowerBound);
     VarSymbol* index = insertNewVarAndDef(fn_->body, "chpl_simt_index",
                                           dtInt[INT_SIZE_64]);
     fn_->insertAtTail(new CallExpr(PRIM_MOVE, index, new CallExpr(
@@ -1513,7 +1532,7 @@ void GpuKernel::generateIndexComputation() {
  *
  */
 void GpuKernel::generateOobCond() {
-  Symbol* localUpperBound = addKernelArgument(gpuLoop.upperBound());
+  Symbol* localUpperBound = addCompilerGeneratedKernelArgument(gpuLoop.upperBound());
 
   VarSymbol* isInBounds = new VarSymbol("chpl_is_in_bounds", dtBool);
   fn_->insertAtTail(new DefExpr(isInBounds));
@@ -1669,18 +1688,18 @@ void GpuKernel::populateBody() {
               else if (symExpr == parent->get(1) ||
                 (parent->numActuals() >= 3 && symExpr == parent->get(3)))
               {
-                addKernelArgument(sym);
+                addUserVarKernelArgument(sym);
               }
               else {
                 this->setLateGpuizationFailure(true);
               }
             }
             else if (parent->isPrimitive()) {
-              addKernelArgument(sym);
+              addUserVarKernelArgument(sym);
             }
             else if (FnSymbol* calledFn = parent->resolvedFunction()) {
               if (!toFnSymbol(sym)) {
-                addKernelArgument(sym);
+                addUserVarKernelArgument(sym);
               }
 
               if (!calledFn->hasFlag(FLAG_GPU_AND_CPU_CODEGEN)) {
@@ -1693,7 +1712,7 @@ void GpuKernel::populateBody() {
           } else if (CondStmt* cond = toCondStmt(symExpr->parentExpr)) {
             // Parent is a conditional statement.
             if (symExpr == cond->condExpr) {
-              addKernelArgument(sym);
+              addUserVarKernelArgument(sym);
             }
           } else {
             this->setLateGpuizationFailure(true);
@@ -1960,6 +1979,7 @@ static void generateGPUKernelCall(const GpuizableLoop &gpuLoop,
   initCfgCall->insertAtTail(new_IntSymbol(kernel.kernelActuals().size()));
   initCfgCall->insertAtTail(new_IntSymbol(gpuLoop.pidGets().size()));
   initCfgCall->insertAtTail(new_IntSymbol(kernel.nReductionBufs()));
+  initCfgCall->insertAtTail(new_IntSymbol(kernel.nHostRegisteredVars()));
   gpuBlock->insertAtTail(new CallExpr(PRIM_MOVE, cfg, initCfgCall));
 
   // first, add pids

--- a/runtime/include/chpl-gpu-impl.h
+++ b/runtime/include/chpl-gpu-impl.h
@@ -76,6 +76,9 @@ void chpl_gpu_impl_stream_synchronize(void* stream);
 bool chpl_gpu_impl_can_reduce(void);
 bool chpl_gpu_impl_can_sort(void);
 
+void chpl_gpu_impl_host_register(void* var, size_t size);
+void chpl_gpu_impl_host_unregister(void* var);
+
 #define DECL_ONE_REDUCE_IMPL(chpl_kind, data_type) \
 void chpl_gpu_impl_##chpl_kind##_reduce_##data_type(data_type* data, int n,\
                                                     data_type* val, int* idx,\

--- a/runtime/include/chpl-gpu.h
+++ b/runtime/include/chpl-gpu.h
@@ -93,12 +93,13 @@ void chpl_gpu_support_module_finished_initializing(void);
 
 void* chpl_gpu_init_kernel_cfg(const char* fn_name, int64_t num_threads,
                                int blk_dim, int n_params, int n_pids,
-                               int n_redbufs, int ln, int32_t fn);
+                               int n_redbufs, int n_hostreg_vars, int ln,
+                               int32_t fn);
 void* chpl_gpu_init_kernel_cfg_3d(const char* fn_name,
                                   int grd_dim_x, int grd_dim_y, int grd_dim_z,
                                   int blk_dim_x, int blk_dim_y, int blk_dim_z,
                                   int n_params, int n_pids, int n_redbufs,
-                                  int ln, int32_t fn);
+                                  int n_hostreg_vars, int ln, int32_t fn);
 
 void chpl_gpu_deinit_kernel_cfg(void* cfg);
 void chpl_gpu_arg_offload(void* cfg, void* arg, size_t size);
@@ -106,6 +107,7 @@ void chpl_gpu_pid_offload(void* cfg, int64_t pid, size_t size);
 void chpl_gpu_arg_pass(void* cfg, void* arg);
 void chpl_gpu_arg_reduce(void* cfg, void* arg, size_t elem_size,
                          reduce_wrapper_fn_t wrapper);
+void chpl_gpu_arg_host_register(void* _cfg, void* arg, size_t size);
 void chpl_gpu_launch_kernel(void* cfg);
 
 void* chpl_gpu_mem_array_alloc(size_t size, chpl_mem_descInt_t description,

--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -255,6 +255,9 @@ typedef struct kernel_cfg_s {
   int n_params;
   int cur_param;
   void*** kernel_params;
+  int n_host_registered;
+  int cur_host_registered_var;
+  void** host_registered_vars;
 
   // Keep track of kernel parameters we dynamically allocate memory for so
   // later on we know what we need to free.
@@ -283,7 +286,7 @@ typedef struct kernel_cfg_s {
 
 static void cfg_init(kernel_cfg* cfg, const char* fn_name,
                      int n_params, int n_pids, int n_reduce_vars,
-                     int ln, int32_t fn) {
+                     int n_host_registered_vars, int ln, int32_t fn) {
 
   cfg->fn_name = fn_name;
 
@@ -301,7 +304,6 @@ static void cfg_init(kernel_cfg* cfg, const char* fn_name,
   cfg->kernel_params = chpl_mem_alloc(cfg->n_params * sizeof(void **),
                                       CHPL_RT_MD_GPU_KERNEL_PARAM_BUFF, ln, fn);
   assert(cfg->kernel_params);
-
 
   cfg->param_dyn_allocated = chpl_mem_alloc(cfg->n_params * sizeof(bool),
                                             CHPL_RT_MD_GPU_KERNEL_PARAM_META,
@@ -335,6 +337,12 @@ static void cfg_init(kernel_cfg* cfg, const char* fn_name,
 
   cfg->reduce_vars = chpl_mem_alloc(cfg->n_reduce_vars * sizeof(reduce_var),
                                     CHPL_RT_MD_GPU_KERNEL_PARAM_BUFF, ln, fn);
+
+  cfg->n_host_registered = n_host_registered_vars;
+  cfg->cur_host_registered_var = 0;
+  cfg->host_registered_vars = chpl_mem_alloc(
+    cfg->n_host_registered * sizeof(void*), CHPL_RT_MD_GPU_KERNEL_PARAM_BUFF,
+    ln, fn);
 }
 
 static void cfg_init_dims_1d(kernel_cfg* cfg, int64_t num_threads,
@@ -551,11 +559,13 @@ static void cfg_finalize_priv_table(kernel_cfg *cfg) {
 
 void* chpl_gpu_init_kernel_cfg(const char* fn_name, int64_t num_threads,
                                int blk_dim, int n_params, int n_pids,
-                               int n_reduce_vars, int ln, int32_t fn) {
+                               int n_reduce_vars, int n_host_registered_vars,
+                               int ln, int32_t fn) {
   void* ret = chpl_mem_alloc(sizeof(kernel_cfg),
                              CHPL_RT_MD_GPU_KERNEL_PARAM_META, ln, fn);
 
-  cfg_init((kernel_cfg*)ret, fn_name, n_params, n_pids, n_reduce_vars, ln, fn);
+  cfg_init((kernel_cfg*)ret, fn_name, n_params, n_pids, n_reduce_vars,
+           n_host_registered_vars, ln, fn);
   cfg_init_dims_1d((kernel_cfg*)ret, num_threads, blk_dim);
 
   CHPL_GPU_DEBUG("Initialized kernel config for %s. num_threads=%"PRId64" blk_dim=%d"
@@ -570,12 +580,14 @@ void* chpl_gpu_init_kernel_cfg_3d(const char* fn_name,
                                   int grd_dim_x, int grd_dim_y, int grd_dim_z,
                                   int blk_dim_x, int blk_dim_y, int blk_dim_z,
                                   int n_params, int n_pids, int n_reduce_vars,
-                                  int ln, int32_t fn) {
+                                  int n_host_registered_vars, int ln,
+                                  int32_t fn) {
 
   void* ret = chpl_mem_alloc(sizeof(kernel_cfg),
                              CHPL_RT_MD_GPU_KERNEL_PARAM_META, ln, fn);
 
-  cfg_init((kernel_cfg*)ret, fn_name, n_params, n_pids, n_reduce_vars, ln, fn);
+  cfg_init((kernel_cfg*)ret, fn_name, n_params, n_pids, n_reduce_vars,
+           n_host_registered_vars, ln, fn);
   cfg_init_dims_3d((kernel_cfg*)ret,
                    grd_dim_x, grd_dim_y, grd_dim_z,
                    blk_dim_x, blk_dim_y, blk_dim_z);
@@ -616,6 +628,11 @@ void chpl_gpu_deinit_kernel_cfg(void* _cfg) {
     chpl_gpu_mem_free(cfg->reduce_vars[i].buffer, cfg->ln, cfg->fn);
   }
   chpl_mem_free(cfg->reduce_vars, cfg->ln, cfg->fn);
+
+  for (int i=0 ; i<cfg->n_reduce_vars ; i++) {
+    chpl_gpu_impl_host_unregister(cfg->host_registered_vars[i]);
+  }
+  chpl_mem_free(cfg->host_registered_vars, cfg->ln, cfg->fn);
 
   chpl_mem_free(cfg, ((kernel_cfg*)cfg)->ln, ((kernel_cfg*)cfg)->fn);
   CHPL_GPU_DEBUG("Deinitialized kernel config\n");
@@ -679,6 +696,13 @@ void chpl_gpu_arg_reduce(void* _cfg, void* arg, size_t elem_size,
     chpl_internal_error("The runtime is not ready to do reductions with this"
                         " kernel configuration. Using multidimensional launch?\n");
   }
+}
+
+void chpl_gpu_arg_host_register(void* _cfg, void* arg, size_t size) {
+  kernel_cfg* cfg = (kernel_cfg*)_cfg;
+  cfg_add_direct_param(cfg, arg);
+  chpl_gpu_impl_host_register(*((void**)arg), sizeof(char)*8);
+  CHPL_GPU_DEBUG("\tAdded ref intent param (at %d): %p\n", cfg->cur_param,  arg);
 }
 
 static void cfg_finalize_reductions(kernel_cfg* cfg) {

--- a/runtime/src/gpu/amd/gpu-amd.c
+++ b/runtime/src/gpu/amd/gpu-amd.c
@@ -391,4 +391,16 @@ bool chpl_gpu_impl_can_sort(void){
   return chpl_gpu_impl_can_reduce();
 }
 
+void chpl_gpu_impl_host_register(void* var, size_t size) {
+  // To do this we also need to get a device pointer using
+  // `hipHostGetDevicePointer` and pass the launched kernel
+
+  // hipHostRegister(var, size, hipHostRegisterPortable);
+}
+
+void chpl_gpu_impl_host_unregister(void* var) {
+  // hipHostUnregister(var);
+}
+
+
 #endif // HAS_GPU_LOCALE

--- a/runtime/src/gpu/cpu/gpu-cpu.c
+++ b/runtime/src/gpu/cpu/gpu-cpu.c
@@ -197,5 +197,8 @@ void chpl_gpu_impl_sort_##chpl_kind##_##data_type(data_type* data_in, \
 
 GPU_DEV_CUB_WRAP(DEF_ONE_SORT, SortKeys, keys)
 
+void chpl_gpu_impl_host_register(void* var, size_t size) { }
+void chpl_gpu_impl_host_unregister(void* var) { }
+
 #undef DEF_ONE_SORT
 #endif // HAS_GPU_LOCALE

--- a/runtime/src/gpu/nvidia/gpu-nvidia.c
+++ b/runtime/src/gpu/nvidia/gpu-nvidia.c
@@ -379,4 +379,12 @@ bool chpl_gpu_impl_can_sort(void){
   return true;
 }
 
+void chpl_gpu_impl_host_register(void* var, size_t size) {
+  cuMemHostRegister(var, size, CU_MEMHOSTREGISTER_PORTABLE);
+}
+
+void chpl_gpu_impl_host_unregister(void* var) {
+  cuMemHostUnregister(var);
+}
+
 #endif // HAS_GPU_LOCALE

--- a/test/gpu/native/cudaOnly/gpuAddNums/gpuAddNums_primitive.chpl
+++ b/test/gpu/native/cudaOnly/gpuAddNums/gpuAddNums_primitive.chpl
@@ -60,7 +60,8 @@ on here.gpus[0] {
                         /*blockSize*/ 1,
                         /*args*/1,
                         /*pids*/0,
-                        /*reductions*/0);
+                        /*reductions*/0,
+                        /*hostRegVars*/0);
 
   // 1 is an enum value that says: "pass the address of this to the
   //   kernel_params, while not offloading anything". I am not entirely sure why

--- a/test/gpu/native/intents/forall_refIntentScalar.chpl
+++ b/test/gpu/native/intents/forall_refIntentScalar.chpl
@@ -1,0 +1,7 @@
+on here.gpus[0] {
+  var x = 1;
+  writeln("Before loop x = ", x);
+  @assertOnGpu
+  forall 0..0 with (ref x) do x = 2;
+  writeln("After loop x = ", x);
+}

--- a/test/gpu/native/intents/forall_refIntentScalar.good
+++ b/test/gpu/native/intents/forall_refIntentScalar.good
@@ -1,0 +1,2 @@
+Before loop x = 1
+After loop x = 2

--- a/test/gpu/native/intents/forall_refIntentScalar.skipif
+++ b/test/gpu/native/intents/forall_refIntentScalar.skipif
@@ -1,0 +1,1 @@
+CHPL_GPU == amd

--- a/test/gpu/native/intents/foreach_refIntentScalar.chpl
+++ b/test/gpu/native/intents/foreach_refIntentScalar.chpl
@@ -1,0 +1,7 @@
+on here.gpus[0] {
+  var x = 1;
+  writeln("Before loop x = ", x);
+  @assertOnGpu
+  foreach 0..0 with (ref x) do x = 2;
+  writeln("After loop x = ", x);
+}

--- a/test/gpu/native/intents/foreach_refIntentScalar.future
+++ b/test/gpu/native/intents/foreach_refIntentScalar.future
@@ -1,0 +1,2 @@
+bug
+ref intent'd scalars should be host registered and passed to gpu kernel by ref

--- a/test/gpu/native/intents/foreach_refIntentScalar.good
+++ b/test/gpu/native/intents/foreach_refIntentScalar.good
@@ -1,0 +1,2 @@
+Before loop x = 1
+After loop x = 2

--- a/test/gpu/native/studies/transpose/transpose.chpl
+++ b/test/gpu/native/studies/transpose/transpose.chpl
@@ -115,7 +115,8 @@ inline proc transposeLowLevel(original, ref output) {
                         /*blk_dims*/ blockSize, blockSize, 1,
                         /*args*/4,
                         /*pids*/0,
-                        /*reductions*/0);
+                        /*reductions*/0,
+                        /*host_reg_vars*/0);
 
   // 1 is an enum value that says: "pass the address of this to the
   //   kernel_params, while not offloading anything".

--- a/test/gpu/native/threadBlockAndGridPrimitives.chpl
+++ b/test/gpu/native/threadBlockAndGridPrimitives.chpl
@@ -57,7 +57,8 @@ proc runExample(gdimX, gdimY, gdimZ, bdimX, bdimY, bdimZ) {
                         /*blk_dims*/ bdimX, bdimY, bdimZ,
                         /*args*/1,
                         /*pids*/0,
-                        /*reductions*/0);
+                        /*reductions*/0,
+                        /*hostRegVars*/0);
 
 
   // 1 is an enum value that says: "pass the address of this to the


### PR DESCRIPTION
This PR enables using `ref` intent'd scalars on a `forall` loop by host registering the scalar before calling the kernel.

In other words, the following:

```chpl
on here.gpus[0] {
  var x = 1;
  writeln("Before loop x = ", x);
  @assertOnGpu
  foreach 0..0 with (ref x) do x = 2;
  writeln("After loop x = ", x);
}
```

now, correctly, results in `2` where previously it resulted in 1.

This PR will only work for `forall` loops and when using `CHPL_GPU=nvidia` or `CHPL_GPU=cpu`.  I believe it should be possible to get this to work for AMD and `foreach` loops as well but the work required is significant enough that I'd like to do that in a separate PR. More details on the followup work is in this comment: https://github.com/Cray/chapel-private/issues/6442#issuecomment-2234252037


Implementation details for reviewers:

- I add a new GpuArgKind called `HOST_REGISTER` to indicate arguments that should be "host registered".  Host registering a variable page-locks the memory so the gpu can safely do a direct memory access of it.

- When we construct "kernel arguments" in gpuTransforms, I now pass into the `KernelArg` constructor a flag indicating it the kernel argument is "compiler generated" (for example the variables we construct for loop bounds) or "user generated" (for example an outer variable accessed by the loop). This is necessary for my next bullet which is:

- To determine if a variable is a `ref` intent'd scalar I check if:
  - It's not compiler generated, and
  - It's not an in intent'd variable (checked by looking at flags), and
  - It's a scalar, and
  - It's not a constant

- The compiler now generates calls to `chpl_gpu_arg_host_register` for each `ref` intent'd scalar.  Our runtime calls a `chpl_gpu_impl_host_register` function to actually register these and stores an array of all these values in the kernel config. When we deconstruct the config we also unregister these variables.

- To our runtime I add `chpl_gpu_impl_host_register` and `chpl_gpu_impl_host_unregister` functions. For NVIDIA I call the `cuMemHostRegister` and `cuMemHostUnregister` functions.  For AMD I currently have commented out code because there's more work I'll need to do to support  this.  For cpu-as-device mode it's a no-op.
