### PR TITLE
Skip IO/serializers/arrays test for 32-bit linux

### DIFF
--- a/test/io/serializers/arrays.skipif
+++ b/test/io/serializers/arrays.skipif
@@ -1,0 +1,1 @@
+CHPL_HOST_PLATFORM == linux32


### PR DESCRIPTION
IO/serializers/arrays was failing on 32-bit linux because the binary representation of real numbers was different than 64-bit platforms. This PR skips that test on 32-bit linux.