### PR TITLE
Install python frontend bindings before building arkouda

### DIFF
--- a/util/cron/common-arkouda.bash
+++ b/util/cron/common-arkouda.bash
@@ -44,6 +44,9 @@ if [ -f "$SETUP_PYTHON" ]; then
   source $SETUP_PYTHON
 fi
 
+# install frontend python bindings
+(cd $CHPL_HOME/tools/chapel-py && python -m pip install .)
+
 export CHPL_WHICH_RELEASE_FOR_ARKOUDA="2.1.0"
 # test against Chapel release (checking out current test/cron directories)
 function test_release() {


### PR DESCRIPTION
As of https://github.com/Bears-R-Us/arkouda/pull/3477, the Chapel frontend bindings are required to build Arkouda. This is needed to support a build script that handles the new `registerCommand` and `instantiateAndRegister` annotations added in https://github.com/Bears-R-Us/arkouda/pull/3371.

This PR adds a step to `pip install` the frontend bindings as a part of the nightly testing setup for arkouda.