### PR TITLE
Avoid internal error when returning a reference to a value of a different type

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -9483,11 +9483,11 @@ static void resolveMoveForRhsSymExpr(CallExpr* call, SymExpr* rhs) {
   }
 
   bool shouldCheckMoveToRef =
-    lhsSym->hasFlag(FLAG_REF_VAR) ||
+    (lhsSym->hasFlag(FLAG_REF_VAR) &&
+     ! lhsSym->hasEitherFlag(FLAG_TEMP, FLAG_EXPR_TEMP)) ||
     (lhsSym->hasFlag(FLAG_RVV) &&
      lhsSym->typeInfo() && lhsSym->typeInfo()->isRef());
   if (shouldCheckMoveToRef                                &&
-      ! lhsSym->hasEitherFlag(FLAG_TEMP, FLAG_EXPR_TEMP)  &&
       call->isPrimitive(PRIM_MOVE)                         )  {
     checkAndAdjustLhsRefType(call, lhsSym, rhsSym->type);
   }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -9482,7 +9482,11 @@ static void resolveMoveForRhsSymExpr(CallExpr* call, SymExpr* rhs) {
     if (lhsSym->qual == QUAL_CONST_REF) checkMoveSymToCRefYVV(call, rhsSym);
   }
 
-  if (lhsSym->hasFlag(FLAG_REF_VAR)                       &&
+  bool shouldCheckMoveToRef =
+    lhsSym->hasFlag(FLAG_REF_VAR) ||
+    (lhsSym->hasFlag(FLAG_RVV) &&
+     lhsSym->typeInfo() && lhsSym->typeInfo()->isRef());
+  if (shouldCheckMoveToRef                                &&
       ! lhsSym->hasEitherFlag(FLAG_TEMP, FLAG_EXPR_TEMP)  &&
       call->isPrimitive(PRIM_MOVE)                         )  {
     checkAndAdjustLhsRefType(call, lhsSym, rhsSym->type);

--- a/test/variables/ref/errors-type-mismatch-fn-1.chpl
+++ b/test/variables/ref/errors-type-mismatch-fn-1.chpl
@@ -1,0 +1,12 @@
+var global: int;
+
+record rec {
+  var A: int;
+
+  proc this() ref : real {
+    return global;
+  }
+}
+
+var r = new rec();
+writeln(r());

--- a/test/variables/ref/errors-type-mismatch-fn-1.good
+++ b/test/variables/ref/errors-type-mismatch-fn-1.good
@@ -1,0 +1,4 @@
+errors-type-mismatch-fn-1.chpl:6: In method 'this':
+errors-type-mismatch-fn-1.chpl:7: error: Initializing a reference with another type
+errors-type-mismatch-fn-1.chpl:6: note: Reference has type real(64)
+errors-type-mismatch-fn-1.chpl:7: note: Initializing with type int(64)

--- a/test/variables/ref/errors-type-mismatch-fn-2.chpl
+++ b/test/variables/ref/errors-type-mismatch-fn-2.chpl
@@ -1,4 +1,3 @@
-var global: int;
 var A: [1..10] int;
 
 record rec {

--- a/test/variables/ref/errors-type-mismatch-fn-2.chpl
+++ b/test/variables/ref/errors-type-mismatch-fn-2.chpl
@@ -1,0 +1,11 @@
+var global: int;
+var A: [1..10] int;
+
+record rec {
+  proc this() ref : real {
+    return A[1];
+  }
+}
+
+var r = new rec();
+writeln(r());

--- a/test/variables/ref/errors-type-mismatch-fn-2.good
+++ b/test/variables/ref/errors-type-mismatch-fn-2.good
@@ -1,4 +1,4 @@
-errors-type-mismatch-fn-2.chpl:5: In method 'this':
-errors-type-mismatch-fn-2.chpl:6: error: Initializing a reference with another type
-errors-type-mismatch-fn-2.chpl:5: note: Reference has type real(64)
-errors-type-mismatch-fn-2.chpl:6: note: Initializing with type int(64)
+errors-type-mismatch-fn-2.chpl:4: In method 'this':
+errors-type-mismatch-fn-2.chpl:5: error: Initializing a reference with another type
+errors-type-mismatch-fn-2.chpl:4: note: Reference has type real(64)
+errors-type-mismatch-fn-2.chpl:5: note: Initializing with type int(64)

--- a/test/variables/ref/errors-type-mismatch-fn-2.good
+++ b/test/variables/ref/errors-type-mismatch-fn-2.good
@@ -1,0 +1,4 @@
+errors-type-mismatch-fn-2.chpl:5: In method 'this':
+errors-type-mismatch-fn-2.chpl:6: error: Initializing a reference with another type
+errors-type-mismatch-fn-2.chpl:5: note: Reference has type real(64)
+errors-type-mismatch-fn-2.chpl:6: note: Initializing with type int(64)


### PR DESCRIPTION
Closes https://github.com/chapel-lang/chapel/issues/25596.

This PR fixes a bug in which the reference compatibility checking is skipped. In particular, this happens when assigning to the return symbol (with flag `RVV`) from a symbol expression (_not_ an `ADDR_OF` call). Because an error is never emitted, a later assertion that requires compatibility between reference assignments is triggered and compilation fails.

This PR adjusts the condition to also fire off a reference compatibility check for return symbols.

Reviewed by @lydia-duncan -- thanks! 

## Testing
- [x] paratest