### PR TITLE
Fix chapel-py related Arkouda build failures in nightly testing

### DIFF
--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -51,6 +51,9 @@ if [ -n "${CHPL_TEST_ARKOUDA_DISABLE_MODULES}" ] ; then
   unset IFS
 fi
 
+# install frontend python bindings
+(cd $CHPL_HOME/tools/chapel-py && python -m pip install . --no-deps)
+
 # Compile Arkouda
 if [ "${CHPL_TEST_ARKOUDA_PERF}" = "true" ] ; then
   PERF_SUB_DIR="$CHPL_TEST_PERF_DIR/$CHPL_TEST_PERF_DESCRIPTION"

--- a/util/cron/common-arkouda.bash
+++ b/util/cron/common-arkouda.bash
@@ -44,9 +44,6 @@ if [ -f "$SETUP_PYTHON" ]; then
   source $SETUP_PYTHON
 fi
 
-# install frontend python bindings
-(cd $CHPL_HOME/tools/chapel-py && python -m pip install .)
-
 export CHPL_WHICH_RELEASE_FOR_ARKOUDA="2.1.0"
 # test against Chapel release (checking out current test/cron directories)
 function test_release() {


### PR DESCRIPTION
Install chapel-py in arkouda's `sub_test` script instead of the `common-arkouda` script. This way, chapel will have been built by that point and can be used to build the frontend bindings.