### PR TITLE
Default to blocking when not using OFI injection

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -4647,6 +4647,8 @@ void amReqFn_msgOrdFence(c_nodeid_t node,
       && reqSize <= ofi_info->tx_attr->inject_size
       && envInjectAM) {
     flags = FI_INJECT;
+  } else {
+    blocking = true;
   }
   if (havePutsOut || haveAmosOut) {
     //
@@ -4721,6 +4723,8 @@ void amReqFn_msgOrd(c_nodeid_t node,
     // wait for it to get done on the target anyway.)
     //
     flags = FI_INJECT;
+  } else {
+    blocking = true;
   }
   ctx = TX_CTX_INIT(tcip, blocking, &txnDone);
   (void) wrap_fi_sendmsg(node, req, reqSize, mrDesc, ctx, flags, tcip);
@@ -4758,6 +4762,8 @@ void amReqFn_dlvrCmplt(c_nodeid_t node,
     anyway.)
     */
     flags = FI_INJECT;
+  } else {
+    blocking = true;
   }
 
   ctx = TX_CTX_INIT(tcip, blocking, &txnDone);
@@ -6029,6 +6035,8 @@ chpl_comm_nb_handle_t rmaPutFn_msgOrdFence(void* myAddr, void* mrDesc,
     // memory visibility until later.
     //
     flags = FI_INJECT;
+  } else {
+    blocking = true;
   }
   if (bitmapTest(tcip->amoVisBitmap, node)) {
     //
@@ -6093,6 +6101,8 @@ chpl_comm_nb_handle_t rmaPutFn_msgOrd(void* myAddr, void* mrDesc,
     // and we have a bound tx context so we can delay forcing the
     // memory visibility until later.
     flags = FI_INJECT;
+  } else {
+    blocking = true;
   }
   ctx = TX_CTX_INIT(tcip, blocking, &txnDone);
   (void) wrap_fi_writemsg(myAddr, mrDesc, node, mrRaddr, mrKey, size,
@@ -6914,6 +6924,8 @@ chpl_comm_nb_handle_t amoFn_msgOrd(struct amoBundle_t *ab,
       && ab->size <= ofi_info->tx_attr->inject_size
       && envInjectAMO) {
     flags = FI_INJECT;
+  } else {
+    famo = true;
   }
 
   //


### PR DESCRIPTION
Changes OFI active messages and puts to be blocking when not using `FI_INJECT`.

This partially fixes a bug introduced by https://github.com/chapel-lang/chapel/pull/25483 where code would never get a response to a put/am. This affected HPE EX machines and AWS with EFA.

This PR should fully fix the issue by default on HPE EX machines and AWS with EFA. However, the AWS with EFA case is still broken when using `CHPL_RT_COMM_OFI_INJECT_AM=true` which requires future work to fix.

Tested that the failing tests on HPE EX and AWS no longer fail by default. Also checked that with `CHPL_RT_COMM_OFI_INJECT_AM=true` HPE EX does not fail.

[Reviewed by @DanilaFe]