### PR TITLE
Emit more error messages from `genGraphs`

### DIFF
--- a/util/test/genGraphs.py
+++ b/util/test/genGraphs.py
@@ -1093,7 +1093,8 @@ def main():
         except (CouldNotReadGraphFile):
             pass  # do not increment numGraphfiles
         except (ValueError, IOError, OSError):
-            return -1
+            print("Error generating graph", graph)
+            raise
 
 
     # Copy the index.html and support css and js files

--- a/util/test/genGraphs.py
+++ b/util/test/genGraphs.py
@@ -1027,10 +1027,7 @@ def main():
     graphInfo = GraphStuff(options.name, options.testdir, perfdir, outdir,
         startdate, enddate, options.g_reduce, options.g_display_bounds,
         alttitle, annotation_file)
-    try:
-        graphInfo.init()
-    except (IOError, OSError):
-        return -1
+    graphInfo.init()
 
     # get the list of .graph files
     lines = list()


### PR DESCRIPTION
Adds error message emission (via just allowing exceptions to bubble out) in `util/test/genGraphs.py`, including for the error silently occurring in https://chapel.discourse.group/t/test-chapcs-perf-test-perf-chapcs/35404/7.

[reviewer info placeholder]

Testing:
- [x] error and traceback now emitted for manual run of `genGraphs`