### PR TITLE
Use raw strings for regex patterns in some of our Python scripts

### DIFF
--- a/util/test/convert_start_test_log_to_junit_xml.py
+++ b/util/test/convert_start_test_log_to_junit_xml.py
@@ -268,7 +268,7 @@ def _get_test_name(test_case_lines):
     :rtype: (str, str)
     :returns: tuple with classname and test name
     """
-    pattern = re.compile('\[test: (?P<test_name>[^\]]+)\]')
+    pattern = re.compile(r'\[test: (?P<test_name>[^\]]+)\]')
     match = pattern.search(test_case_lines[0])
     if match is None:
         raise ValueError('Could not find test name in: {0}'.format(
@@ -304,7 +304,7 @@ def _get_test_time(test_case_lines):
             raise ValueError(msg)
     time_line = test_case_lines[time_line_idx]
 
-    pattern = re.compile(' - (?P<time>-?\d+\.\d+) seconds\]$')
+    pattern = re.compile(r' - (?P<time>-?\d+\.\d+) seconds\]$')
     match = pattern.search(time_line)
     if match:
         time = match.group('time')
@@ -327,8 +327,8 @@ def _get_test_error(test_case_lines):
     :rtype: dict
     :returns: error dict with 'message' and 'content' keys, None if no errors
     """
-    error_pattern = re.compile('^\[Error.*$', re.IGNORECASE | re.MULTILINE)
-    warn_pattern = re.compile('^\[Warning.*$', re.IGNORECASE | re.MULTILINE)
+    error_pattern = re.compile(r'^\[Error.*$', re.IGNORECASE | re.MULTILINE)
+    warn_pattern = re.compile(r'^\[Warning.*$', re.IGNORECASE | re.MULTILINE)
 
     whole_test = ''.join(test_case_lines)
     errors = error_pattern.findall(whole_test)

--- a/util/test/find_slow_tests.py
+++ b/util/test/find_slow_tests.py
@@ -25,9 +25,9 @@ def create_parser():
 def get_pattern(mode):
     ''' Get regex pattern used to extract (test/dir, time) data '''
     if mode =='directory':
-        pattern = re.compile('\[Finished subtest "(.*)" - (.*) seconds')
+        pattern = re.compile(r'\[Finished subtest "(.*)" - (.*) seconds')
     else:
-        pattern = re.compile('\[Elapsed {} time for "(.*)" - (.*) seconds'.format(mode))
+        pattern = re.compile(r'\[Elapsed {} time for "(.*)" - (.*) seconds'.format(mode))
     return pattern
 
 


### PR DESCRIPTION
Needed to avoid `SyntaxWarning: invalid escape sequence` in Python 3.12.

See [Python 3.12 release notes](https://www.python.org/downloads/release/python-3120/):
> Invalid backslash escape sequences in strings now warn with SyntaxWarning instead of DeprecationWarning, making them more visible. (They will become syntax errors in the future.)

Warning observed in https://chapel-ci.us.cray.com/job/correctness-test-darwin-m1/651/consoleFull and many other runs.

See similar PR https://github.com/chapel-lang/chapel/pull/24664.

[reviewer info placeholder]