### PR TITLE
Push and pull 'nightly' tag Docker images in nightly test job

### DIFF
--- a/util/cron/test-docker.bash
+++ b/util/cron/test-docker.bash
@@ -34,7 +34,8 @@ build_image() {
   fi
 }
 
-# Patch the Dockerfile to build FROM the nightly image instead of latest
+# Patch the Dockerfile to build FROM the nightly image instead of latest.
+# Assumes the Dockerfile is available at ./Dockerfile.
 dockerfile_nightly_patch() {
   local nightlypatch="
 1c1
@@ -42,7 +43,7 @@ dockerfile_nightly_patch() {
 ---
 > FROM chapel/chapel:nightly
 "
-  patch Dockerfile << EOF
+  patch ./Dockerfile << EOF
 $nightlypatch
 EOF
 }

--- a/util/cron/test-docker.bash
+++ b/util/cron/test-docker.bash
@@ -36,14 +36,14 @@ build_image() {
 
 # Patch the Dockerfile to build FROM the nightly image instead of latest
 dockerfile_nightly_patch() {
-  local patch="
+  local nightlypatch="
 1c1
 < FROM chapel/chapel:latest
 ---
 > FROM chapel/chapel:nightly
 "
   patch Dockerfile << EOF
-$dockerfile_nightly_patch
+$nightlypatch
 EOF
 }
 

--- a/util/cron/test-docker.bash
+++ b/util/cron/test-docker.bash
@@ -17,7 +17,15 @@ build_image() {
   local script="$2"
   # Remove any existing image with the tag before building docker image
   docker image rm --force $imageName
+
   docker build --push . -t $imageName
+  BUILD_RESULT=$?
+  if [ $BUILD_RESULT -ne 0 ]
+  then
+        echo "docker build failed for $imageName image"
+        exit 1
+  fi
+
   containerid= docker image ls | grep $imageName | awk '{print$3}'
   cd ${CHPL_HOME}/util/cron
   echo 'writeln("Hello, world!");' > hello.chpl

--- a/util/cron/test-docker.bash
+++ b/util/cron/test-docker.bash
@@ -54,10 +54,10 @@ build_image chapel/chapel:nightly  ${CHPL_HOME}/util/cron/docker-chapel.bash
 
 cd $CHPL_HOME/util/packaging/docker/gasnet
 dockerfile_nightly_patch
-build_image chapel/chapel_gasnet:nightly ${CHPL_HOME}/util/cron/docker-gasnet.bash
+build_image chapel/chapel-gasnet:nightly ${CHPL_HOME}/util/cron/docker-gasnet.bash
 
 cd $CHPL_HOME/util/packaging/docker/gasnet-smp
 dockerfile_nightly_patch
-build_image chapel/chapel_gasnet_smp:nightly ${CHPL_HOME}/util/cron/docker-gasnet.bash
+build_image chapel/chapel-gasnet-smp:nightly ${CHPL_HOME}/util/cron/docker-gasnet.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="docker"


### PR DESCRIPTION
Adjust the nightly Docker testing script to push (and pull) `nightly` tags of the images.

This incidentally makes the chapel-gasnet and chapel-gasnet-smp images build off of the just-built Chapel base image. Previously it was building off of the `latest` tag from the last release, not accessing the local copy of `latest` due to [behavior of the buildx builder](https://github.com/docker/buildx/issues/847).

While here, adjust formatting of `util/cron/test-docker.bash` script for clarity.

Resolves https://github.com/Cray/chapel-private/issues/6436.

[reviewer info placeholder]

Testing:
- [x] manual run succeeds and pushes `nightly` images on chapelmac-m1
- [x] build exits with error if Chapel base image can't build
- [x] (pre-merge reminder) update Dockerhub page to note the meaning of the `nightly` tag