### PR TITLE
Make the `static typeof` primitive actually static (ensure it has no side effects)

### DIFF
--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -1764,7 +1764,9 @@ Expr* partOfNonNormalizableExpr(Expr* expr) {
   for (Expr* node = expr; node; node = node->parentExpr) {
     if (CallExpr* call = toCallExpr(node)) {
       Expr* root = nullptr;
-      if (call->isPrimitive(PRIM_RESOLVES) || call->isPrimitive(PRIM_STATIC_TYPEOF)) root = call;
+      if (call->isPrimitive(PRIM_RESOLVES) ||
+          call->isPrimitive(PRIM_STATIC_TYPEOF) ||
+          call->isPrimitive(PRIM_STATIC_FIELD_TYPE)) root = call;
       if (root) return root;
     }
   }

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -1765,6 +1765,13 @@ Expr* partOfNonNormalizableExpr(Expr* expr) {
     if (CallExpr* call = toCallExpr(node)) {
       Expr* root = nullptr;
       if (call->isPrimitive(PRIM_RESOLVES) ||
+
+          // Static resolution calls are not normalizeable so that they
+          // don't "spill" their call temps outside of the primitive call.
+          // If they are "spilled", replacing the primitive with its result
+          // will still leave behind the temps; normally these would be
+          // cleaned up (via dead code elimination), but under --baseline
+          // or --no-dead-code-elimination they would not be.
           call->isPrimitive(PRIM_STATIC_TYPEOF) ||
           call->isPrimitive(PRIM_STATIC_FIELD_TYPE)) root = call;
       if (root) return root;

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -1764,7 +1764,7 @@ Expr* partOfNonNormalizableExpr(Expr* expr) {
   for (Expr* node = expr; node; node = node->parentExpr) {
     if (CallExpr* call = toCallExpr(node)) {
       Expr* root = nullptr;
-      if (call->isPrimitive(PRIM_RESOLVES)) root = call;
+      if (call->isPrimitive(PRIM_RESOLVES) || call->isPrimitive(PRIM_STATIC_TYPEOF)) root = call;
       if (root) return root;
     }
   }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -10372,7 +10372,7 @@ static Expr* handleNonNormalizableExpr(Expr* expr) {
 
       // Prefolding will completely replace PRIM_RESOLVES calls, so
       // further action is not needed here.
-      if (call->isPrimitive(PRIM_RESOLVES)) {
+      if (call->isPrimitive(PRIM_RESOLVES) || call->isPrimitive(PRIM_STATIC_TYPEOF)) {
         ret = preFold(call);
       } else {
         INT_FATAL("Not handled!");

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -10372,7 +10372,9 @@ static Expr* handleNonNormalizableExpr(Expr* expr) {
 
       // Prefolding will completely replace PRIM_RESOLVES calls, so
       // further action is not needed here.
-      if (call->isPrimitive(PRIM_RESOLVES) || call->isPrimitive(PRIM_STATIC_TYPEOF)) {
+      if (call->isPrimitive(PRIM_RESOLVES) ||
+          call->isPrimitive(PRIM_STATIC_TYPEOF) ||
+          call->isPrimitive(PRIM_STATIC_FIELD_TYPE)) {
         ret = preFold(call);
       } else {
         INT_FATAL("Not handled!");

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -2085,6 +2085,7 @@ static Expr* preFoldPrimOp(CallExpr* call) {
     break;
   }
 
+  case PRIM_STATIC_FIELD_TYPE:
   case PRIM_STATIC_TYPEOF: {
     auto exprToResolve = call->get(1);
 
@@ -2117,7 +2118,6 @@ static Expr* preFoldPrimOp(CallExpr* call) {
   }
 
 
-  case PRIM_STATIC_FIELD_TYPE:
   case PRIM_THUNK_RESULT_TYPE:
   case PRIM_SCALAR_PROMOTION_TYPE: {
 

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -2121,7 +2121,7 @@ static Expr* preFoldPrimOp(CallExpr* call) {
   case PRIM_THUNK_RESULT_TYPE:
   case PRIM_SCALAR_PROMOTION_TYPE: {
 
-    // Replace the type query call with a SymExpr of the type symbol
+    // Replace the type query call with a SymExpr of the type symbol.
     // call->typeInfo() will request the type from the primitive
     Type* type = call->typeInfo();
     retval = new SymExpr(type->symbol);


### PR DESCRIPTION
This fixes some niche compilation errors to do with `chpl_getStandInRTT` under `--baseline` (specifically `--no-dead-code-elimination`).

## The Problem
Consider the following comment:

https://github.com/chapel-lang/chapel/blob/ad1bbdf6a8b32d09186fdb901643d683ca6eccd2/modules/internal/ChapelIteratorSupport.chpl#L209-L216

Here, we rely on the fact that `static typeof` gets only static type information. That's because `instanceObj` is null (default-initialized).

The code above is eventually normalized to something like this:
```Chapel
var call_tmp = instanceObj.eltType;
type instanceEltType = __primitive("static typeof", call_tmp);
```

The normal resolution process replaces the primitive with its result:

```Chapel
var call_tmp = instanceObj.eltType;
type instanceEltType = int; // e.g.
```

Later, dead code elimination removes the unused `call_tmp`:

```Chapel
type instanceEltType = int; // e.g.
```

However, under `--baseline`, the last step doesn't happen. Which means that `instanceObj.eltType` is actually executed. As a result, we end up with a `nil` deference error.

Thus, any piece of code that triggers this overload of `chpl_getStandInRTT` will crash at runtime.

## The Solution

The solution is to avoid normalizing `static typeof` (and `static field type`). Instead, at resolution time, these expressions are placed into a temporary block, resolved there, and the block is then removed. The result is that no temporaries are left behind, and no side effects occur even under `--baseline`.

This implementation piggybacks on `PRIM_RESOLVE`'s, since both of them avoid normalization through "normal" means.

The alternative solution would have been to manually trace and remove temporaries as they are created, but that seemed more brittle and involved.

Reviewed by @benharsh -- thanks!

## Testing
- [x] paratest
- [x] paratest (baseline)
- [x] paratest (GASNet)