### PR TITLE
Build frontend shared library before building arkouda in nightly testing

### DIFF
--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -52,7 +52,8 @@ if [ -n "${CHPL_TEST_ARKOUDA_DISABLE_MODULES}" ] ; then
 fi
 
 # install frontend python bindings
-(cd $CHPL_HOME/tools/chapel-py && python -m pip install . --no-deps)
+(cd $CHPL_HOME && make frontend-shared)
+(cd $CHPL_HOME/tools/chapel-py && python -m pip install .)
 
 # Compile Arkouda
 if [ "${CHPL_TEST_ARKOUDA_PERF}" = "true" ] ; then


### PR DESCRIPTION
This will prevent warnings about `-lChplFrontendShared` not being available when building arkouda in nightly testing.