### PR TITLE
Deprecate old Sort functions and replace with new argument lists

### DIFF
--- a/modules/standard/Sort.chpl
+++ b/modules/standard/Sort.chpl
@@ -600,6 +600,36 @@ proc sort(ref Data: [?Dom] ?eltType, comparator:?rec=defaultComparator)
     compilerError("sort() is currently only supported for 1D rectangular arrays");
 }
 
+/*
+   Check if array `x` is in sorted order
+
+   :arg x: The array to verify
+   :type x: an array
+   :arg comparator: :ref:`Comparator <comparators>` record that defines how the
+      data is sorted.
+   :returns: ``true`` if array is sorted
+   :rtype: `bool`
+ */
+proc isSorted(x: [], comparator:? = new DefaultComparator()): bool {
+  chpl_check_comparator(comparator, x.eltType);
+
+  const stride = abs(x.domain.stride): x.domain.idxType;
+  var sorted = true;
+  forall (element, i) in zip(x, x.domain) with (&& reduce sorted) {
+    if i > x.domain.low {
+      sorted &&= (chpl_compare(x[i-stride], element, comparator) <= 0);
+    }
+  }
+  return sorted;
+}
+
+
+@chpldoc.nodoc
+/* Error message for multi-dimension arrays */
+proc isSorted(x: [], comparator:? =new DefaultComparator())
+  where x.domain.rank != 1 {
+    compilerError("isSorted() requires 1-D array");
+}
 
 /*
    Check if array `Data` is in sorted order
@@ -611,22 +641,17 @@ proc sort(ref Data: [?Dom] ?eltType, comparator:?rec=defaultComparator)
    :returns: ``true`` if array is sorted
    :rtype: `bool`
  */
+pragma "last resort"
+@deprecated("'isSorted' with the argument name 'Data' is deprecated, please use the version with the argument name 'x' instead")
 proc isSorted(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator): bool {
-  chpl_check_comparator(comparator, eltType);
-
-  const stride = abs(Dom.stride): Dom.idxType;
-  var sorted = true;
-  forall (element, i) in zip(Data, Dom) with (&& reduce sorted) {
-    if i > Dom.low {
-      sorted &&= (chpl_compare(Data[i-stride], element, comparator) <= 0);
-    }
-  }
-  return sorted;
+  return isSorted(x=Data, comparator);
 }
 
 
+pragma "last resort"
 @chpldoc.nodoc
 /* Error message for multi-dimension arrays */
+@deprecated("'isSorted' with the argument name 'Data' is deprecated, please use the version with the argument name 'x' instead")
 proc isSorted(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator)
   where Dom.rank != 1 {
     compilerError("isSorted() requires 1-D array");

--- a/modules/standard/Sort.chpl
+++ b/modules/standard/Sort.chpl
@@ -460,7 +460,7 @@ The choice of sorting algorithm used is made by the implementation.
     * ``c_string``
 
 :arg x: The array to be sorted
-:type x: an array
+:type x: `array`
 :arg comparator: :ref:`Comparator <comparators>` record that defines how the
   data is sorted.
 :arg stable: Defaults to ``false``. If it is ``false``, the implementation
@@ -604,7 +604,7 @@ proc sort(ref Data: [?Dom] ?eltType, comparator:?rec=defaultComparator)
    Check if array `x` is in sorted order
 
    :arg x: The array to verify
-   :type x: an array
+   :type x: `array`
    :arg comparator: :ref:`Comparator <comparators>` record that defines how the
       data is sorted.
    :returns: ``true`` if array is sorted

--- a/modules/standard/Sort.chpl
+++ b/modules/standard/Sort.chpl
@@ -471,7 +471,9 @@ proc sort(ref x: [], comparator:? = new DefaultComparator(),
           param stable:bool = false) {
   chpl_check_comparator(comparator, x.eltType);
 
-  if x.domain.low >= x.domain.high then
+  const D = x.domain;
+
+  if D.low >= D.high then
     return;
 
   if stable {
@@ -485,7 +487,7 @@ proc sort(ref x: [], comparator:? = new DefaultComparator(),
       // randomness, according to some heuristic
 
       var simplerSortSize=50_000;
-      if x.domain.size < simplerSortSize {
+      if D.size < simplerSortSize {
         // TODO: use quicksort instead in these small cases
         MSBRadixSort.msbRadixSort(x, comparator=comparator);
         return;
@@ -613,10 +615,12 @@ proc sort(ref Data: [?Dom] ?eltType, comparator:?rec=defaultComparator)
 proc isSorted(x: [], comparator:? = new DefaultComparator()): bool {
   chpl_check_comparator(comparator, x.eltType);
 
-  const stride = abs(x.domain.stride): x.domain.idxType;
+  const D = x.domain;
+
+  const stride = abs(D.stride): D.idxType;
   var sorted = true;
-  forall (element, i) in zip(x, x.domain) with (&& reduce sorted) {
-    if i > x.domain.low {
+  forall (element, i) in zip(x, D) with (&& reduce sorted) {
+    if i > D.low {
       sorted &&= (chpl_compare(x[i-stride], element, comparator) <= 0);
     }
   }
@@ -626,7 +630,7 @@ proc isSorted(x: [], comparator:? = new DefaultComparator()): bool {
 
 @chpldoc.nodoc
 /* Error message for multi-dimension arrays */
-proc isSorted(x: [], comparator:? =new DefaultComparator())
+proc isSorted(x: [], comparator:? = new DefaultComparator())
   where x.domain.rank != 1 {
     compilerError("isSorted() requires 1-D array");
 }
@@ -645,16 +649,6 @@ pragma "last resort"
 @deprecated("'isSorted' with the argument name 'Data' is deprecated, please use the version with the argument name 'x' instead")
 proc isSorted(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator): bool {
   return isSorted(x=Data, comparator);
-}
-
-
-pragma "last resort"
-@chpldoc.nodoc
-/* Error message for multi-dimension arrays */
-@deprecated("'isSorted' with the argument name 'Data' is deprecated, please use the version with the argument name 'x' instead")
-proc isSorted(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator)
-  where Dom.rank != 1 {
-    compilerError("isSorted() requires 1-D array");
 }
 
 @chpldoc.nodoc

--- a/modules/standard/Sort.chpl
+++ b/modules/standard/Sort.chpl
@@ -597,8 +597,8 @@ proc sort(ref Data: [?Dom] ?eltType, comparator:?rec=defaultComparator,
 
 @chpldoc.nodoc
 /* Error message for multi-dimension arrays */
-proc sort(ref Data: [?Dom] ?eltType, comparator:?rec=defaultComparator)
-  where Dom.rank != 1 || !Data.isRectangular() {
+proc sort(ref x: [?Dom] , comparator:? = new DefaultComparator())
+  where Dom.rank != 1 || !x.isRectangular() {
     compilerError("sort() is currently only supported for 1D rectangular arrays");
 }
 

--- a/modules/standard/Sort.chpl
+++ b/modules/standard/Sort.chpl
@@ -551,7 +551,7 @@ proc isSorted(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator)
 }
 
 @chpldoc.nodoc
-iter sorted(x : domain, comparator:?rec=defaultComparator) {
+iter sorted(x : domain, comparator:? = new DefaultComparator()) {
   for i in x._value.dsiSorted(comparator) {
     yield i;
   }
@@ -588,7 +588,7 @@ iter sorted(x : domain, comparator:?rec=defaultComparator) {
    :ytype: x's element type
 
  */
-iter sorted(x, comparator:?rec=defaultComparator) {
+iter sorted(x, comparator:? = new DefaultComparator()) {
   if isArrayValue(x) && Reflection.canResolveMethod(x._value, "dsiSorted", comparator)
   {
     // As far as I know this branch is only encountered for associative arrays

--- a/test/deprecated/Sort/depSortInPlace.chpl
+++ b/test/deprecated/Sort/depSortInPlace.chpl
@@ -1,0 +1,16 @@
+use Sort;
+
+var arr: [0..15] int =
+  [3, 2, 15, 2, 23, 5, 8, -2, 9, 3, 34, 100000, 26, 61, -1, 0];
+sort(arr, inPlaceAlgorithm=true);
+writeln(arr);
+
+var arr2: [0..15] int =
+  [3, 2, 15, 2, 23, 5, 8, -2, 9, 3, 34, 100000, 26, 61, -1, 0];
+sort(arr2, new DefaultComparator(), false, true);
+writeln(arr2);
+
+var arr3: [0..15] int =
+  [3, 2, 15, 2, 23, 5, 8, -2, 9, 3, 34, 100000, 26, 61, -1, 0];
+sort(Data=arr3);
+writeln(arr3);

--- a/test/deprecated/Sort/depSortInPlace.good
+++ b/test/deprecated/Sort/depSortInPlace.good
@@ -1,0 +1,6 @@
+depSortInPlace.chpl:5: warning: The 'sort' function with 'Data' and 'inPlaceAlgorithm' arguments has been deprecated, please use the 'sort' function with an 'x' argument instead
+depSortInPlace.chpl:10: warning: The 'sort' function with 'Data' and 'inPlaceAlgorithm' arguments has been deprecated, please use the 'sort' function with an 'x' argument instead
+depSortInPlace.chpl:15: warning: The 'sort' function with 'Data' and 'inPlaceAlgorithm' arguments has been deprecated, please use the 'sort' function with an 'x' argument instead
+-2 -1 0 2 2 3 3 5 8 9 15 23 26 34 61 100000
+-2 -1 0 2 2 3 3 5 8 9 15 23 26 34 61 100000
+-2 -1 0 2 2 3 3 5 8 9 15 23 26 34 61 100000

--- a/test/deprecated/Sort/isSortedDep.chpl
+++ b/test/deprecated/Sort/isSortedDep.chpl
@@ -1,0 +1,4 @@
+use Sort;
+
+var x: [0..<5] int = [0, 1, 2, 3, 4];
+writeln(isSorted(Data=x));

--- a/test/deprecated/Sort/isSortedDep.good
+++ b/test/deprecated/Sort/isSortedDep.good
@@ -1,0 +1,2 @@
+isSortedDep.chpl:4: warning: 'isSorted' with the argument name 'Data' is deprecated, please use the version with the argument name 'x' instead
+true


### PR DESCRIPTION
Resolves #25544 

Implements the decisions reached by the Sort discussion team.  Updates the argument lists for:
- `sort` by renaming the array argument and removing the `inPlaceAlgorithm` argument (which was confusing), and removing the queries.  Also uses `new DefaultComparator()` instead of the module-scoped variable.
- `isSorted` by renaming the array argument, removing the queries and using `new DefaultComparator()` instead of the module-scoped variable.
- and the `sorted` iterator by removing the queries and using `new DefaultComparator()` instead of the module-scoped variable.

The sorted iterator did not need a deprecation for this change.

Adds tests locking in the deprecation messages for `sort` and `isSorted`.

Passed a full paratest with futures