### PR TITLE
Make debugging Mac caveat more obvious

### DIFF
--- a/doc/rst/usingchapel/debugging.rst
+++ b/doc/rst/usingchapel/debugging.rst
@@ -84,6 +84,8 @@ executable. This can be done in two steps.
    .. code-block:: bash
 
         chpl -g --target-compiler=gnu --savec <dir> --preserve-inlined-line-numbers --no-munge-user-idents --no-return-by-ref --no-inline <source_file>
+        # On MacOS
+        # chpl -g --target-compiler=clang --savec <dir> --preserve-inlined-line-numbers --no-munge-user-idents --no-return-by-ref --no-inline <source_file>
 
 For more details on these settings, read the rest of this section.
 

--- a/doc/rst/usingchapel/debugging.rst
+++ b/doc/rst/usingchapel/debugging.rst
@@ -70,7 +70,8 @@ The current best practice for debugging Chapel source code is to use the C
 backend and use a series of flags to improve the debuggability of the generated
 executable. This can be done in two steps.
 
-1) Build the compiler with ``CHPL_TARGET_COMPILER`` set to ``gnu``:
+1) Build the compiler with ``CHPL_TARGET_COMPILER`` set to ``gnu``
+   (or ``clang`` if on Mac):
 
    .. code-block:: bash
 

--- a/doc/rst/usingchapel/debugging.rst
+++ b/doc/rst/usingchapel/debugging.rst
@@ -76,6 +76,8 @@ executable. This can be done in two steps.
    .. code-block:: bash
 
         CHPL_TARGET_COMPILER=gnu make
+        # On MacOS
+        # CHPL_TARGET_COMPILER=clang make
 
 2) Build the executable from Chapel source code:
 


### PR DESCRIPTION
Makes the caveat about `CHPL_TARGET_COMPILER` for Macs more obvious

[Rveiewed by @DanilaFe]