### PR TITLE
add file to README

### DIFF
--- a/test/release/examples/gpu/README
+++ b/test/release/examples/gpu/README
@@ -7,3 +7,5 @@ these examples, Chapel must be built with GPU support enabled, which can be
 done by setting CHPL_LOCALE_MODEL=gpu and rebuilding Chapel.  For more
 information about installing and using Chapel with gpu support see the
 following technical note: https://chapel-lang.org/docs/technotes/gpu.html
+
+hello-gpu.chpl : performs an example computation on use every gpu in system


### PR DESCRIPTION
Looks like we have a script that checks README files under dirs under `test/release/examples/`. This script requires that the README mention every `.chpl` file under that dir.

In #25562 I added this README but didn't mention the `hello-gpu.chpl` file I added. This PR should fix that.