### PR TITLE
fix docker FROM-AS case mismatch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ WORKDIR $CHPL_HOME
 # Build stage: build Chapel from sources
 # ======================================
 
-FROM chapel-base as chapel-build
+FROM chapel-base AS chapel-build
 
 # acquire sources
 COPY . .
@@ -85,7 +85,7 @@ RUN rm -rf third-party/llvm/llvm-src
 # Final stage: copy build results, but omit large files.
 # ======================================
 
-FROM chapel-base as chapel
+FROM chapel-base AS chapel
 COPY --from=chapel-build $CHPL_HOME $CHPL_HOME
 
 ENV PATH="${PATH}:${CHPL_HOME}/bin:${CHPL_HOME}/util"


### PR DESCRIPTION
This fixes a warning from Docker about mismatched casing between `FROM` and `as` in two lines. Previously Docker would issue a warning about this like so:
```console
WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match
```

This just updates the casing to match and eliminate the warning.

TESTING:

- [x] `docker build .` no longer complains about case mismatch

[reviewed by @DanilaFe - thanks!]