### PR TITLE
move homebrew chapel-release diff check to its own test

### DIFF
--- a/util/cron/test-compare-homebrew-release.bash
+++ b/util/cron/test-compare-homebrew-release.bash
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# This script is to test that the current homebrew formula on homebrew-core master
+# matches with the copy we keep in chapel-release.rb.
+
+# This script will clone the home-brew repository and do a diff with the our version.
+
+# !IMPORTANT! Make sure BREW_CORE_REPO_PATH is set to where the homebrew-core repository should go
+# before running this script, or it will fail on the step where it diffs the current
+# formula with the copy we store in chapel-release.rb
+
+CWD=$(cd $(dirname $0) ; pwd)
+source $CWD/functions.bash
+
+export CHPL_HOME=$(cd $CWD/../.. ; pwd)
+log_info "Setting CHPL_HOME to: ${CHPL_HOME}"
+
+log_info "Moving to ${CHPL_HOME}"
+cd $CHPL_HOME
+
+# This will clone the home-brew repository to BREW_CORE_REPO_PATH and compare the chapel-release.rb repo under
+# util/packaging/homebrew
+git clone --branch master --depth 1 git@github.com:Homebrew/homebrew-core ${BREW_CORE_REPO_PATH}/homebrew-core 2> /dev/null || (cd ${BREW_CORE_REPO_PATH:-/missing}/homebrew-core; git pull origin master)
+
+# compare the chapel.rb in homebrew-core with the one in our repository (chapel-release.rb)
+# to catch any changes homebrew makes to the formuala without telling us (might happen when they update deps, etc)
+diff ${BREW_CORE_REPO_PATH:-/missing}/homebrew-core/Formula/c/chapel.rb ${CHPL_HOME}/util/packaging/homebrew/chapel-release.rb 2> /dev/null
+FORMULA_CHANGED=$?
+if [ $FORMULA_CHANGED -ne 0 ]
+then
+  log_error "homebrew released formula updated and does not match chapel-release.rb! Verify chapel formula in homebrew-core!"
+  exit 1
+  else
+  log_info "homebrew released formula matches chapel-release.rb, good!"
+fi

--- a/util/cron/test-compare-homebrew-release.bash
+++ b/util/cron/test-compare-homebrew-release.bash
@@ -3,11 +3,11 @@
 # This script is to test that the current homebrew formula on homebrew-core master
 # matches with the copy we keep in chapel-release.rb.
 
-# This script will clone the home-brew repository and do a diff with the our version.
+# This script will clone the homebrew-core repository and do a diff with the our version
+# and the published version of the chapel formula.
 
-# !IMPORTANT! Make sure BREW_CORE_REPO_PATH is set to where the homebrew-core repository should go
-# before running this script, or it will fail on the step where it diffs the current
-# formula with the copy we store in chapel-release.rb
+# !IMPORTANT! Make sure BREW_CORE_REPO_PATH is set to where the homebrew-core
+# repository should go before running this script
 
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/functions.bash

--- a/util/cron/test-compare-homebrew-release.bash
+++ b/util/cron/test-compare-homebrew-release.bash
@@ -20,16 +20,17 @@ cd $CHPL_HOME
 
 # This will clone the home-brew repository to BREW_CORE_REPO_PATH and compare the chapel-release.rb repo under
 # util/packaging/homebrew
+log_info "Cloning homebrew-core repository into ${BREW_CORE_REPO_PATH}/homebrew-core"
 git clone --branch master --depth 1 git@github.com:Homebrew/homebrew-core ${BREW_CORE_REPO_PATH}/homebrew-core 2> /dev/null || (cd ${BREW_CORE_REPO_PATH:-/missing}/homebrew-core; git pull origin master)
 
 # compare the chapel.rb in homebrew-core with the one in our repository (chapel-release.rb)
-# to catch any changes homebrew makes to the formuala without telling us (might happen when they update deps, etc)
-diff ${BREW_CORE_REPO_PATH:-/missing}/homebrew-core/Formula/c/chapel.rb ${CHPL_HOME}/util/packaging/homebrew/chapel-release.rb 2> /dev/null
+# to catch any changes homebrew makes to the formula without telling us (might happen when they update deps, etc)
+diff ${BREW_CORE_REPO_PATH:-/missing}/homebrew-core/Formula/c/chapel.rb ${CHPL_HOME}/util/packaging/homebrew/chapel-release.rb
 FORMULA_CHANGED=$?
 if [ $FORMULA_CHANGED -ne 0 ]
 then
-  log_error "homebrew released formula updated and does not match chapel-release.rb! Verify chapel formula in homebrew-core!"
+  log_error "Chapel formula in homebrew-core has been updated and does not match chapel-release.rb! Verify chapel formula in homebrew-core"
   exit 1
   else
-  log_info "homebrew released formula matches chapel-release.rb, good!"
+  log_info "Chapel formula in homebrew-core matches chapel-release.rb, good"
 fi

--- a/util/cron/test-homebrew.bash
+++ b/util/cron/test-homebrew.bash
@@ -36,24 +36,9 @@ version="${short_version}"
 log_info "Moving to ${CHPL_HOME}"
 cd $CHPL_HOME
 
-# This will clone the home-brew repository under test and copies the chapel formula in chapel-lang repo under
-# util/packaging/home-brew
+# This will copy the chapel formula in chapel-lang repo under util/packaging/home-brew
 # replace the url and sha in the chapel formula with the url pointing to the tarball created and sha of the tarball.
 # run home-brew scripts to install chapel.
-
-git clone git@github.com:Homebrew/homebrew-core ${REPO_PATH}/homebrew-core 2> /dev/null || (cd ${REPO_PATH:-/missing}/homebrew-core; git pull origin master)
-
-# compare the chapel.rb in homebrew-core with the one in our repository (chapel-release.rb)
-# to catch any changes homebrew makes to the formuala without telling us (might happen when they update deps, etc)
-diff ${REPO_PATH:-/missing}/homebrew-core/Formula/c/chapel.rb ${CHPL_HOME}/util/packaging/homebrew/chapel-release.rb 2> /dev/null
-FORMULA_CHANGED=$?
-if [ $FORMULA_CHANGED -ne 0 ]
-then
-  log_error "homebrew released formula updated and does not match chapel-release.rb! Verify chapel formula in homebrew-core!"
-  exit 1
-  else
-  log_info "homebrew released formula matches chapel-release.rb, good!"
-fi
 
 log_info "Building tarball with version: ${version}"
 ./util/buildRelease/gen_release ${version}


### PR DESCRIPTION
Moves the check that makes sure we are notified of changes to the Chapel formula published in homebrew-core to its own test. 

This creates a new test configuration for checking that the version of the homebrew formula we cache in our Chapel tree is consistent with the version published by homebrew. Separating this test because it's a quick test to run and isolating it means we'll get specific failure messages for it, instead of generic homebrew test failures that could currently be caused by three different failure modes. Also since it's such a short test we could run this more than just once per week.

the companion PR for CI changes is https://github.hpe.com/hpe/hpc-chapel-ci-config/pull/1252

Updates the original hombrew-test script to no longer need a to clone the homebrew-core repository

[reviewed by @tzinsky  - thanks!]