### PR TITLE
fix size_t and unused var errors in dyno tests

### DIFF
--- a/frontend/test/parsing/testParseBegin.cpp
+++ b/frontend/test/parsing/testParseBegin.cpp
@@ -136,7 +136,7 @@ static void test3(Parser* parser) {
       "begin with () { }\n"
       "begin with ref A { }\n");
   auto numErrors = 5;
-  assert(guard.errors().size() == numErrors);
+  assert(guard.errors().size() == (size_t) numErrors);
   assert("invalid intent expression in 'with' clause" == guard.error(1)->message());
   assert("'with' clause cannot be empty" == guard.error(2)->message());
   assert("missing parentheses around 'with' clause intents" == guard.error(4)->message());

--- a/frontend/test/parsing/testParseCobegin.cpp
+++ b/frontend/test/parsing/testParseCobegin.cpp
@@ -114,7 +114,7 @@ static void test2(Parser* parser) {
       "cobegin with ref A {;;}\n"
 );
   auto numErrors = 5;
-  assert(guard.errors().size() == numErrors);
+  assert(guard.errors().size() == (size_t) numErrors);
   assert("invalid intent expression in 'with' clause" == guard.error(1)->message());
   assert("'with' clause cannot be empty" == guard.error(2)->message());
   assert("missing parentheses around 'with' clause intents" == guard.error(4)->message());

--- a/frontend/test/parsing/testParseCoforall.cpp
+++ b/frontend/test/parsing/testParseCoforall.cpp
@@ -214,7 +214,7 @@ static void test5(Parser* parser) {
       "coforall i in 1..10 with () { }\n"
       "coforall i in 1..10 with ref A { }\n");
   auto numErrors = 5;
-  assert(guard.errors().size() == numErrors);
+  assert(guard.errors().size() == (size_t) numErrors);
   assert("invalid intent expression in 'with' clause" == guard.error(1)->message());
   assert("'with' clause cannot be empty" == guard.error(2)->message());
   assert("missing parentheses around 'with' clause intents" == guard.error(4)->message());

--- a/frontend/test/parsing/testParseFor.cpp
+++ b/frontend/test/parsing/testParseFor.cpp
@@ -176,7 +176,7 @@ static void test5(Parser* parser) {
   auto parseResult = parseStringAndReportErrors(parser, "test5.chpl",
       "for i in 1..10 with (ref A) { }");
   auto numErrors = 1;
-  assert(guard.errors().size() == numErrors);
+  assert(guard.errors().size() == (size_t) numErrors);
   assert("'with' clauses are not supported on 'for' loops" == guard.error(0)->message());
   assert(guard.realizeErrors() == numErrors);
 }
@@ -188,7 +188,7 @@ static void test6(Parser* parser) {
       "for i in 1..10 with () { }\n"
       "for i in 1..10 with ref A { }\n");
   auto numErrors = 7;
-  assert(guard.errors().size() == numErrors);
+  assert(guard.errors().size() == (size_t)numErrors);
   assert("invalid intent expression in 'with' clause" == guard.error(1)->message());
   assert("'with' clauses are not supported on 'for' loops" == guard.error(2)->message());
   assert("'with' clause cannot be empty" == guard.error(3)->message());

--- a/frontend/test/parsing/testParseForall.cpp
+++ b/frontend/test/parsing/testParseForall.cpp
@@ -252,7 +252,7 @@ static void test6(Parser* parser) {
       "forall i in 1..10 with () { }\n"
       "forall i in 1..10 with ref A { }\n");
   auto numErrors = 5;
-  assert(guard.errors().size() == numErrors);
+  assert(guard.errors().size() == (size_t) numErrors);
   assert("invalid intent expression in 'with' clause" == guard.error(1)->message());
   assert("'with' clause cannot be empty" == guard.error(2)->message());
   assert("missing parentheses around 'with' clause intents" == guard.error(4)->message());

--- a/frontend/test/parsing/testParseForeach.cpp
+++ b/frontend/test/parsing/testParseForeach.cpp
@@ -246,7 +246,7 @@ static void test6(Parser* parser) {
       "foreach i in 1..10 with () { }\n"
       "foreach i in 1..10 with ref A { }\n");
   auto numErrors = 5;
-  assert(guard.errors().size() == numErrors);
+  assert(guard.errors().size() == (size_t) numErrors);
   assert("invalid intent expression in 'with' clause" == guard.error(1)->message());
   assert("'with' clause cannot be empty" == guard.error(2)->message());
   assert("missing parentheses around 'with' clause intents" == guard.error(4)->message());

--- a/frontend/test/resolution/testLoopIndexVars.cpp
+++ b/frontend/test/resolution/testLoopIndexVars.cpp
@@ -640,12 +640,12 @@ assertLoopMatches(Context* context, const std::string& program,
   auto& rr = resolveModule(context, m->id());
   auto& reIterand = rr.byAst(iterand);
 
-  if (auto zip = iterand->toZip()) {
+  if (iterand->toZip()) {
     assert(false && "Zip iterands not handled in this test yet!");
     return;
   } else {
     int numExpectedActions = (needLeader || needFollower) ? 2 : 1;
-    assert(reIterand.associatedActions().size() == numExpectedActions);
+    assert(reIterand.associatedActions().size() == (size_t) numExpectedActions);
 
     auto& aa1 = reIterand.associatedActions()[0];
     assertIterIsCorrect(context, aa1, iterKindStr);


### PR DESCRIPTION
Adds `size_t` casting to `int` vars to fix warning about unsigned to signed comparisons, removes an unused `auto` var.

These fixes were needed to allow `make test-dyno` to proceed without failure - unsure how the original PRs made it passed the dyno-test CI stage.

TESTING:

- [x] local `make test-dyno` works again

[reviewed by @jabraham17 - thanks!]