### PR TITLE
Temporary hpcdc rollback due to Arkouda test instability

### DIFF
--- a/util/cron/common-arkouda.bash
+++ b/util/cron/common-arkouda.bash
@@ -4,9 +4,7 @@
 
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 
-# COMMON_DIR=/hpcdc/project/chapel
-# This is a temporary bandaid
-COMMON_DIR=/cray/css/users/chapelu
+COMMON_DIR=/hpcdc/project/chapel
 if [ ! -d "$COMMON_DIR" ]; then
   COMMON_DIR=/cy/users/chapelu
 fi
@@ -27,7 +25,9 @@ fi
 export CHPL_NIGHTLY_TEST_DIRS=studies/arkouda/
 export CHPL_TEST_ARKOUDA=true
 
-ARKOUDA_DEP_DIR=$COMMON_DIR/arkouda-deps
+# Temporary bandaid, revert after hpcdc issues resolved
+# ARKOUDA_DEP_DIR=$COMMON_DIR/arkouda-deps
+ARKOUDA_DEP_DIR=/cray/css/users/chapelu/arkouda-deps
 if [ -d "$ARKOUDA_DEP_DIR" ]; then
   export ARKOUDA_ARROW_PATH=${ARKOUDA_ARROW_PATH:-$ARKOUDA_DEP_DIR/arrow-install}
   export ARKOUDA_ZMQ_PATH=${ARKOUDA_ZMQ_PATH:-$ARKOUDA_DEP_DIR/zeromq-install}

--- a/util/cron/common-arkouda.bash
+++ b/util/cron/common-arkouda.bash
@@ -4,7 +4,9 @@
 
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 
-COMMON_DIR=/hpcdc/project/chapel
+# COMMON_DIR=/hpcdc/project/chapel
+# This is a temporary bandaid
+COMMON_DIR=/cray/css/users/chapelu
 if [ ! -d "$COMMON_DIR" ]; then
   COMMON_DIR=/cy/users/chapelu
 fi


### PR DESCRIPTION
Arkouda nightly tests have been unstable for roughly a month. To address recent test failures attributed to hpcdc changes, this PR reverts the hpcdc directory to its previous configuration. This rollback will allow for continued testing while we diagnose and resolve the compatibility issues.