### PR TITLE
support ref intent on gpuized forall w/ AMD

### DIFF
--- a/runtime/include/chpl-gpu-impl.h
+++ b/runtime/include/chpl-gpu-impl.h
@@ -76,7 +76,7 @@ void chpl_gpu_impl_stream_synchronize(void* stream);
 bool chpl_gpu_impl_can_reduce(void);
 bool chpl_gpu_impl_can_sort(void);
 
-void chpl_gpu_impl_host_register(void* var, size_t size);
+void* chpl_gpu_impl_host_register(void* var, size_t size);
 void chpl_gpu_impl_host_unregister(void* var);
 
 #define DECL_ONE_REDUCE_IMPL(chpl_kind, data_type) \

--- a/runtime/src/gpu/amd/gpu-amd.c
+++ b/runtime/src/gpu/amd/gpu-amd.c
@@ -394,12 +394,12 @@ bool chpl_gpu_impl_can_sort(void){
 void* chpl_gpu_impl_host_register(void* var, size_t size) {
   hipHostRegister(var, size, hipHostRegisterPortable);
   void *dev_var;
-  hipHostGetDevicePointer(&dev_var, var, 0);
+  ROCM_CALL(hipHostGetDevicePointer(&dev_var, var, 0));
   return dev_var;
 }
 
 void chpl_gpu_impl_host_unregister(void* var) {
-  hipHostUnregister(var);
+  ROCM_CALL(hipHostUnregister(var));
 }
 
 

--- a/runtime/src/gpu/amd/gpu-amd.c
+++ b/runtime/src/gpu/amd/gpu-amd.c
@@ -391,15 +391,15 @@ bool chpl_gpu_impl_can_sort(void){
   return chpl_gpu_impl_can_reduce();
 }
 
-void chpl_gpu_impl_host_register(void* var, size_t size) {
-  // To do this we also need to get a device pointer using
-  // `hipHostGetDevicePointer` and pass the launched kernel
-
-  // hipHostRegister(var, size, hipHostRegisterPortable);
+void* chpl_gpu_impl_host_register(void* var, size_t size) {
+  hipHostRegister(var, size, hipHostRegisterPortable);
+  void *dev_var;
+  hipHostGetDevicePointer(&dev_var, var, 0);
+  return dev_var;
 }
 
 void chpl_gpu_impl_host_unregister(void* var) {
-  // hipHostUnregister(var);
+  hipHostUnregister(var);
 }
 
 

--- a/runtime/src/gpu/nvidia/gpu-nvidia.c
+++ b/runtime/src/gpu/nvidia/gpu-nvidia.c
@@ -379,8 +379,11 @@ bool chpl_gpu_impl_can_sort(void){
   return true;
 }
 
-void chpl_gpu_impl_host_register(void* var, size_t size) {
+void* chpl_gpu_impl_host_register(void* var, size_t size) {
   cuMemHostRegister(var, size, CU_MEMHOSTREGISTER_PORTABLE);
+  void **dev_var = chpl_malloc(sizeof(void*));
+  *dev_var = var;
+  return dev_var;
 }
 
 void chpl_gpu_impl_host_unregister(void* var) {

--- a/runtime/src/gpu/nvidia/gpu-nvidia.c
+++ b/runtime/src/gpu/nvidia/gpu-nvidia.c
@@ -381,9 +381,7 @@ bool chpl_gpu_impl_can_sort(void){
 
 void* chpl_gpu_impl_host_register(void* var, size_t size) {
   cuMemHostRegister(var, size, CU_MEMHOSTREGISTER_PORTABLE);
-  void **dev_var = chpl_malloc(sizeof(void*));
-  *dev_var = var;
-  return dev_var;
+  return var;
 }
 
 void chpl_gpu_impl_host_unregister(void* var) {

--- a/runtime/src/gpu/nvidia/gpu-nvidia.c
+++ b/runtime/src/gpu/nvidia/gpu-nvidia.c
@@ -380,12 +380,12 @@ bool chpl_gpu_impl_can_sort(void){
 }
 
 void* chpl_gpu_impl_host_register(void* var, size_t size) {
-  cuMemHostRegister(var, size, CU_MEMHOSTREGISTER_PORTABLE);
+  CUDA_CALL(cuMemHostRegister(var, size, CU_MEMHOSTREGISTER_PORTABLE));
   return var;
 }
 
 void chpl_gpu_impl_host_unregister(void* var) {
-  cuMemHostUnregister(var);
+  CUDA_CALL(cuMemHostUnregister(var));
 }
 
 #endif // HAS_GPU_LOCALE

--- a/test/gpu/native/intents/forall_refIntentScalar.skipif
+++ b/test/gpu/native/intents/forall_refIntentScalar.skipif
@@ -1,1 +1,0 @@
-CHPL_GPU == amd


### PR DESCRIPTION
This PR extends the work from #25594 so that `ref` intent scalars will work with `forall` loops on AMD GPUs (the prior PR got it to work for NVIDIA).

Since AMD GPUs (or at least the ones we're using today) don't have universal addressing we need to convert the host pointer to the `ref` intent'd parameter into a "device pointer" before it can be used by the device. This PR performs this step.

Notes to reviewers:

For reasons I don't fully understand, in order to get this to work the thing I pass to the `cfg_add_direct_param` function (to add the ref intent'd param as a kernel argument) needs to be a double pointer (with the pointee being the aforementioned device pointer). To get this all to work I create an array of void pointers and then a second array where each element is a pointer to each element in the first. This lets us avoid malloc'ing each double pointer individually but, as can be seen, the code has a bit of pointer juggling. I'm not totally convinced my approach here is the most optimal thing to do but it seems to work.