### PR TITLE
Dependency Access Issue on XC from HPCDC Move

### DIFF
--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -30,15 +30,11 @@ if ! git clone --depth=1 ${ARKOUDA_URL} --branch=${ARKOUDA_BRANCH} ; then
 fi
 cd ${ARKOUDA_HOME}
 
-# Install dependencies if needed
-if make check-deps 2>/dev/null ; then
-  export ARKOUDA_SKIP_CHECK_DEPS=true
-else
-  if ! nice make -j $($CHPL_HOME/util/buildRelease/chpl-make-cpu_count) install-deps ; then
-    log_fatal_error "installing dependencies"
-  fi
-  export "PATH=${ARKOUDA_HOME}/dep/hdf5-install/bin:$PATH"
+# Install dependencies
+if ! nice make -j $($CHPL_HOME/util/buildRelease/chpl-make-cpu_count) install-deps ; then
+  log_fatal_error "installing dependencies"
 fi
+export "PATH=${ARKOUDA_HOME}/dep/hdf5-install/bin:$PATH"
 
 # CHPL_TEST_ARKOUDA_DISABLE_MODULES is a colon separated list of modules to
 # disable.  Disable these modules by commenting them out in ServerModules.cfg

--- a/util/cron/common-arkouda.bash
+++ b/util/cron/common-arkouda.bash
@@ -26,16 +26,16 @@ export CHPL_NIGHTLY_TEST_DIRS=studies/arkouda/
 export CHPL_TEST_ARKOUDA=true
 
 # Temporary bandaid, revert after hpcdc issues resolved
+# HPCDC doesn't seem to be accessible to compute nodes at the moment
 # ARKOUDA_DEP_DIR=$COMMON_DIR/arkouda-deps
-ARKOUDA_DEP_DIR=/cray/css/users/chapelu/arkouda-deps
-if [ -d "$ARKOUDA_DEP_DIR" ]; then
-  export ARKOUDA_ARROW_PATH=${ARKOUDA_ARROW_PATH:-$ARKOUDA_DEP_DIR/arrow-install}
-  export ARKOUDA_ZMQ_PATH=${ARKOUDA_ZMQ_PATH:-$ARKOUDA_DEP_DIR/zeromq-install}
-  export ARKOUDA_HDF5_PATH=${ARKOUDA_HDF5_PATH:-$ARKOUDA_DEP_DIR/hdf5-install}
-  export ARKOUDA_ICONV_PATH=${ARKOUDA_ICONV_PATH:-$ARKOUDA_DEP_DIR/iconv-install}
-  export ARKOUDA_IDN2_PATH=${ARKOUDA_IDN2_PATH:-$ARKOUDA_DEP_DIR/idn2-install}
-  export PATH="$ARKOUDA_HDF5_PATH/bin:$PATH"
-fi
+# if [ -d "$ARKOUDA_DEP_DIR" ]; then
+#   export ARKOUDA_ARROW_PATH=${ARKOUDA_ARROW_PATH:-$ARKOUDA_DEP_DIR/arrow-install}
+#   export ARKOUDA_ZMQ_PATH=${ARKOUDA_ZMQ_PATH:-$ARKOUDA_DEP_DIR/zeromq-install}
+#   export ARKOUDA_HDF5_PATH=${ARKOUDA_HDF5_PATH:-$ARKOUDA_DEP_DIR/hdf5-install}
+#   export ARKOUDA_ICONV_PATH=${ARKOUDA_ICONV_PATH:-$ARKOUDA_DEP_DIR/iconv-install}
+#   export ARKOUDA_IDN2_PATH=${ARKOUDA_IDN2_PATH:-$ARKOUDA_DEP_DIR/idn2-install}
+#   export PATH="$ARKOUDA_HDF5_PATH/bin:$PATH"
+# fi
 
 # enable arrow/parquet support
 export ARKOUDA_SERVER_PARQUET_SUPPORT=true


### PR DESCRIPTION
After migrating to the new HPCDC location, compute nodes on our XC testing are unable to access shared libraries containing required dependencies. While tests execute successfully on the login node (`CHPL_LAUNCHER=none`), they fail when launched on compute nodes using `CHPL_LAUNCHER=slurm-srun`.

This PR implements a workaround by installing dependencies directly within the clone for each test run. This approach is expected to increase test runtime by approximately 2 minutes. We will investigate the root cause of the dependency access issue in a subsequent PR.