### PR TITLE
update cpu-as-device mode for prior PR on ref intent scalars

### DIFF
--- a/runtime/src/gpu/cpu/gpu-cpu.c
+++ b/runtime/src/gpu/cpu/gpu-cpu.c
@@ -197,7 +197,7 @@ void chpl_gpu_impl_sort_##chpl_kind##_##data_type(data_type* data_in, \
 
 GPU_DEV_CUB_WRAP(DEF_ONE_SORT, SortKeys, keys)
 
-void chpl_gpu_impl_host_register(void* var, size_t size) { }
+void* chpl_gpu_impl_host_register(void* var, size_t size) { return NULL; }
 void chpl_gpu_impl_host_unregister(void* var) { }
 
 #undef DEF_ONE_SORT

--- a/runtime/src/gpu/cpu/gpu-cpu.c
+++ b/runtime/src/gpu/cpu/gpu-cpu.c
@@ -197,7 +197,7 @@ void chpl_gpu_impl_sort_##chpl_kind##_##data_type(data_type* data_in, \
 
 GPU_DEV_CUB_WRAP(DEF_ONE_SORT, SortKeys, keys)
 
-void* chpl_gpu_impl_host_register(void* var, size_t size) { return NULL; }
+void* chpl_gpu_impl_host_register(void* var, size_t size) { return var; }
 void chpl_gpu_impl_host_unregister(void* var) { }
 
 #undef DEF_ONE_SORT


### PR DESCRIPTION
This should have been done as part of #25647 (which made updates so we could have ref intents to scalars in gpuized loops work on AMD). Anyway, that PR updated the signature of `chpl_gpu_impl_host_register` (to have it return the device pointer for the thing you're ref intent'ing) but I forgot to update it in the `cpu-as-device` implementation. This PR does that update.This should have been done as part of #25647 (which made updates so we could have ref intents to scalars in gpuized loops work on AMD). Anyway, that PR updated the signature of `chpl_gpu_impl_host_register` (to have it return the device pointer for the thing you're ref intent'ing) but I forgot to update it in the `cpu-as-device` implementation. This PR does that update.