### PR TITLE
Add method stub to register host memory with CHPL_GPU=cpu

### DIFF
--- a/runtime/src/gpu/cpu/gpu-cpu.c
+++ b/runtime/src/gpu/cpu/gpu-cpu.c
@@ -197,7 +197,7 @@ void chpl_gpu_impl_sort_##chpl_kind##_##data_type(data_type* data_in, \
 
 GPU_DEV_CUB_WRAP(DEF_ONE_SORT, SortKeys, keys)
 
-void chpl_gpu_impl_host_register(void* var, size_t size) { }
+void* chpl_gpu_impl_host_register(void* var, size_t size) { return var; }
 void chpl_gpu_impl_host_unregister(void* var) { }
 
 #undef DEF_ONE_SORT


### PR DESCRIPTION
Fixes an issue introduced by https://github.com/chapel-lang/chapel/pull/25647, which changed the signature of `chpl_gpu_impl_host_register` but did not update the `CHPL_GPU=cpu` code path.

[Reviewed by @e-kayrakli]