### PR TITLE
update chapel homebrew formula with upstream changes

### DIFF
--- a/util/packaging/docker/test/brew_install.bash
+++ b/util/packaging/docker/test/brew_install.bash
@@ -41,10 +41,10 @@ brew update
 # fi
 
 # This is the bulk of the testing and the same command that Homebrew CI runs
-brew test-bot --only-formulae --junit --only-json-tab --skip-dependents --testing-formulae="chapel" --added-formulae="" --deleted-formulae=""
+brew test-bot  --skip-online-checks --only-formulae --junit --only-json-tab --skip-dependents --testing-formulae="chapel" --added-formulae="" --deleted-formulae=""
 if [ $? -ne 0 ]; then
-      echo "brew test-bot --only-formulae --junit --only-json-tab --skip-dependents --testing-formulae="chapel" --added-formulae="" --deleted-formulae="" failed"
+      echo "brew test-bot --skip-online-checks --only-formulae --junit --only-json-tab --skip-dependents --testing-formulae="chapel" --added-formulae="" --deleted-formulae="" failed"
       exit 1
 else
-      echo "brew test-bot --only-formulae --junit --only-json-tab --skip-dependents --testing-formulae="chapel" --added-formulae="" --deleted-formulae="" succeeded"
+      echo "brew test-bot --skip-online-checks --only-formulae --junit --only-json-tab --skip-dependents --testing-formulae="chapel" --added-formulae="" --deleted-formulae="" succeeded"
 fi

--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -69,13 +69,13 @@ class Chapel < Formula
       system "make", "mason"
       system "make", "cleanall"
 
-      rm_rf("third-party/llvm/llvm-src/")
-      rm_rf("third-party/gasnet/gasnet-src")
-      rm_rf("third-party/libfabric/libfabric-src")
-      rm_rf("third-party/fltk/fltk-1.3.5-source.tar.gz")
-      rm_rf("third-party/libunwind/libunwind-1.1.tar.gz")
-      rm_rf("third-party/gmp/gmp-src/")
-      rm_rf("third-party/qthread/qthread-src/installed")
+      rm_r("third-party/llvm/llvm-src/")
+      rm_r("third-party/gasnet/gasnet-src")
+      rm_r("third-party/libfabric/libfabric-src")
+      rm_r("third-party/fltk/fltk-1.3.8-source.tar.gz")
+      rm_r("third-party/libunwind/libunwind-src")
+      rm_r("third-party/gmp/gmp-src/")
+      rm_r("third-party/qthread/qthread-src/installed")
     end
 
     # Install chpl and other binaries (e.g. chpldoc) into bin/ as exec scripts.

--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -75,7 +75,7 @@ class Chapel < Formula
       rm_r("third-party/fltk/fltk-1.3.8-source.tar.gz")
       rm_r("third-party/libunwind/libunwind-src")
       rm_r("third-party/gmp/gmp-src/")
-      rm_r("third-party/qthread/qthread-src/installed")
+      rm_r("third-party/qthread/qthread-src/")
     end
 
     # Install chpl and other binaries (e.g. chpldoc) into bin/ as exec scripts.

--- a/util/packaging/homebrew/chapel-release.rb
+++ b/util/packaging/homebrew/chapel-release.rb
@@ -81,13 +81,11 @@ class Chapel < Formula
       system "make", "mason"
       system "make", "cleanall"
 
-      rm_rf("third-party/llvm/llvm-src/")
-      rm_rf("third-party/gasnet/gasnet-src")
-      rm_rf("third-party/libfabric/libfabric-src")
-      rm_rf("third-party/fltk/fltk-1.3.5-source.tar.gz")
-      rm_rf("third-party/libunwind/libunwind-1.1.tar.gz")
-      rm_rf("third-party/gmp/gmp-src/")
-      rm_rf("third-party/qthread/qthread-src/installed")
+      rm_r("third-party/llvm/llvm-src/")
+      rm_r("third-party/gasnet/gasnet-src")
+      rm_r("third-party/libfabric/libfabric-src")
+      rm_r("third-party/gmp/gmp-src/")
+      rm_r("third-party/qthread/qthread-src")
     end
 
     # Install chpl and other binaries (e.g. chpldoc) into bin/ as exec scripts.


### PR DESCRIPTION
Update `chapel-release.rb` to match changes made to the published formula on `homebrew-core`, merge changes into `chapel-main.rb` so we're prepared for the next release.

Changes revealed some errors in our existing formula where we try to remove directories that don't exist so I updated the paths in the case of `qthread` and `fltk`.

I also added the `--skip-online-checks` flag to `brew test-bot` because our tests aren't concerned about reaching `chapel-lang.org` or other liveness checks.

[reviewed by @mppf - thanks!]

TESTING:

- [x] `util/cron/test-homebrew.bash` passes locally 