### PR TITLE
Remove source of `~/.bashrc` in `load-base-deps.bash`

### DIFF
--- a/util/cron/load-base-deps.bash
+++ b/util/cron/load-base-deps.bash
@@ -18,13 +18,6 @@ elif [[ "$(hostname -s)" == "richter-login" ]]; then
 else
   # For systems not using a Spack install
 
-  # For our internal testing, this is necessary to get the latest version of gcc
-  # on the system.
-  if [ -z "${CHPL_SOURCED_BASHRC}" -a -f ~/.bashrc ] ; then
-      source ~/.bashrc
-      export CHPL_SOURCED_BASHRC=true
-  fi
-
   # load llvm
   if [ -f /hpcdc/project/chapel/setup_system_llvm.bash ] ; then
     source /hpcdc/project/chapel/setup_system_llvm.bash


### PR DESCRIPTION
This prevented users from sourcing `util/cron/load-base-deps.bash` in their `.bashrc` (directly or indirectly) on un-Spackified systems, due to an infinite loop.

Thanks @mppf for identifying this as the cause.

This source of `.bashrc` should no longer be necessary with Spackification; if anything breaks it should be replaced with a better solution.

[reviewer info placeholder]