### PR TITLE
Fix a bug with default values in Python interoperability

### DIFF
--- a/compiler/resolution/fixupExports.cpp
+++ b/compiler/resolution/fixupExports.cpp
@@ -225,6 +225,14 @@ static void attemptFixups(FnSymbol* fn) {
   // If a wrapper hasn't been made yet, there's nothing to do.
   if (wrapper == NULL) { return; }
 
+  // Ensure we didn't break our exported formal default value tracking
+  for (int i = 1; i <= fn->numFormals(); i++) {
+    std::string storedDefault = exportedDefaultValues[fn->getFormal(i)];
+    if (storedDefault != "") {
+      exportedDefaultValues[wrapper->getFormal(i)] = storedDefault;
+    }
+  }
+
   insertUnwrappedCall(wrapper, fn, tmps);
 
   wrapperMap[wrapper] = fn;

--- a/test/interop/python/defaultValuesBug.chpl
+++ b/test/interop/python/defaultValuesBug.chpl
@@ -1,0 +1,4 @@
+export proc foo(in whatever: string, x: int = 5) {
+  writeln(whatever);
+  writeln(x);
+}

--- a/test/interop/python/defaultValuesBug.good
+++ b/test/interop/python/defaultValuesBug.good
@@ -1,0 +1,4 @@
+blah
+5
+blah blah
+3

--- a/test/interop/python/defaultValuesBug.prediff
+++ b/test/interop/python/defaultValuesBug.prediff
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+sed '/from defaultValuesBug.c:[0-9]*/d' $2 > $2.tmp
+sed '/^ *$/d' $2.tmp > $2
+rm $2.tmp
+export PYTHONPATH=lib/
+python3 use_defaultValuesBug.py >> $2

--- a/test/interop/python/use_defaultValuesBug.py
+++ b/test/interop/python/use_defaultValuesBug.py
@@ -1,0 +1,8 @@
+import defaultValuesBug
+
+defaultValuesBug.chpl_setup()
+
+defaultValuesBug.foo("blah")
+defaultValuesBug.foo("blah blah", 3)
+
+defaultValuesBug.chpl_cleanup()


### PR DESCRIPTION
Default values seemed to work just fine except when a string was used as one of
the other arguments.

Resolves #25670 

<details>

It turned out that the issue was because string arguments were causing us to
make a wrapper function and that wrapper function was what was getting exported.
Our default value tracking was assuming the argument stored wasn't going to get
replaced with another version after function resolution.

To fix, check for any formals that have a default value tracked in the old
function and insert a map entry for the new version of that function

</details>

Added a new test file to track the bug fix.

Passed a full paratest with futures, and a local run of python interoperability testing