### PR TITLE
Add an option to `nightly` to do nothing upon being executed

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -191,6 +191,13 @@ while (@ARGV) {
 
 print localtime() . "  host: " . hostname . "\n";
 
+# If we're being told to not do anything, just exit. This is useful for
+# "dry-running" test configurations that figure out some environment
+# variables then exit.
+if (exists($ENV{"CHPL_NIGHTLY_DO_NOTHING"})) {
+  exit 0;
+}
+
 # If this is running in jenkins, link to the job in the email.
 $crontab = "Unknown origin for this job...";
 if (exists($ENV{"BUILD_URL"})) {

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -188,15 +188,14 @@ while (@ARGV) {
     }
 }
 
-
-print localtime() . "  host: " . hostname . "\n";
-
 # If we're being told to not do anything, just exit. This is useful for
 # "dry-running" test configurations that figure out some environment
 # variables then exit.
 if (exists($ENV{"CHPL_NIGHTLY_DO_NOTHING"})) {
   exit 0;
 }
+
+print localtime() . "  host: " . hostname . "\n";
 
 # If this is running in jenkins, link to the job in the email.
 $crontab = "Unknown origin for this job...";


### PR DESCRIPTION
This PR adds a `CHPL_NIGHTLY_DO_NOTHING` environment variable that causes `nightly` to exit instead of doing any work (such as running tests, cloning repos, etc).

The reason to do this is to make it easier to reproduce nightly testing configurations locally, for trying to diagnose failures. Most of our testing configs execute a bash script in the `util/cron` directory. The scripts there set a variety of environment variables -- sometimes dynamically depending on the system. Having set these environment variables, they execute `nightly`, which takes care of cloning, building, and executing the Chapel compiler on the selected tests.

When I want to replicate the environment of a particular job, the way to do this most precisely is to connect to the machine that executed the job, and execute everything in the `util/cron` script _except_ the `nightly` command (since I have my own clone of Chapel, perhaps with a patch, that I am testing). Today, I do this by commenting out the call to `nightly`. With this PR, I can instead simply set the `CHPL_NIGHTLY_DO_NOTHING` and execute the bash script as-is, without introducing any diff or ephemeral change. With this, I get a faithful reproduction of the job's environment in one command.

In my `bashrc` on one of our systems, I have the following functions:

```Bash
        function _nvidia() {
                CHPL_NIGHTLY_DO_NOTHING=true source util/cron/test-gpu-ex-cuda-12.bash
        }

        function _amd() {
                CHPL_NIGHTLY_DO_NOTHING=true source util/cron/test-gpu-ex-rocm-54.bash
        }
```

By just executing `_nvidia`, I get the exact environment of the `ex-cuda-12` config to build Chapel and run tests.

Reviewed by @ShreyasKhandekar and @riftEmber -- thanks!