### PR TITLE
Skip bulk transfer tests on ROCm 4

### DIFF
--- a/test/gpu/native/remote-bulk-transfers-par.skipif
+++ b/test/gpu/native/remote-bulk-transfers-par.skipif
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+if $CHPL_HOME/util/printchplenv --simple | grep -q "CHPL_GPU=amd"; then
+  if hipcc --version | head -n1 | grep -q "HIP version: 4"; then
+    echo 1
+  else
+    echo 0
+  fi
+else
+  echo 0
+fi

--- a/test/gpu/native/remote-bulk-transfers.skipif
+++ b/test/gpu/native/remote-bulk-transfers.skipif
@@ -1,0 +1,1 @@
+remote-bulk-transfers-par.skipif


### PR DESCRIPTION
These are affected by odd sporadic memory corruption which we believe to be due to the ROCm driver more so than the actual GPU implementation, so skip them to avoid polluting nightly testing. 

Reviewed by @e-kayrakli -- thanks!

## Testing
- [x] tests now skipped on osprey