### PR TITLE
Avoid re-sending emails for the same bash errors

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -441,6 +441,8 @@ if (exists($ENV{'CHPL_NIGHTLY_TEST_CONFIG_NAME'})) {
 $mysystemlog = "$basetmpdir/mysystemerrs-$config_name.txt";
 $emailOnError = $mysystemlog;
 unlink($mysystemlog); # the file gets appended to, so clear it first.
+`touch $mysystemlog`; # now create an empty file (to make it easier to compare with another file)
+$prevmysystemlog = "$cronlogdir/last-mysystemerrs-$config_name.txt";
 
 #
 # directory variables
@@ -866,7 +868,7 @@ if ($runtests == 0) {
 # FIXME: Pass correct args here!
      # `$chplhomedir/util/cron/nightly_email.pl $status "$rawsummary" "$sortedsummary" "$prevsummary" "$mailer" "$nochangerecipient" "$recipient" "$subjectid" "$config_name" "$revision" "$rawlog" "$starttime" "$endtime" "$crontab" "$testdirs" $debug`;
      # Write the test results to the summary log.
-     writeFile($status, "$rawsummary", "$sortedsummary", "$prevsummary", "$mysystemlog", "", "$nochangerecipient", "$recipient", "$subjectid", "$config_name", "$revision", "$rawlog", "$starttime", "$endtime", "$crontab", "$testdirs", $debug);
+     writeFile($status, "$rawsummary", "$sortedsummary", "$prevsummary", "$mysystemlog", "$prevmysystemlog", "", "$nochangerecipient", "$recipient", "$subjectid", "$config_name", "$revision", "$rawlog", "$starttime", "$endtime", "$crontab", "$testdirs", $debug);
 #
 # analyze memory leaks tests
 #

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -441,7 +441,7 @@ if (exists($ENV{'CHPL_NIGHTLY_TEST_CONFIG_NAME'})) {
 $mysystemlog = "$basetmpdir/mysystemerrs-$config_name.txt";
 $emailOnError = $mysystemlog;
 unlink($mysystemlog); # the file gets appended to, so clear it first.
-`touch $mysystemlog`; # now create an empty file (to make it easier to compare with another file)
+ensureMysystemlogExists($mysystemlog); # empty (vs nonexistent) file is easier to compare against
 $prevmysystemlog = "$cronlogdir/last-mysystemerrs-$config_name.txt";
 
 #

--- a/util/cron/nightly_email.pm
+++ b/util/cron/nightly_email.pm
@@ -36,6 +36,10 @@ sub writeFile{
     $testdirs = $_[16];
     $debug = $_[17];
 
+    # Nothing sorts the system log for us; do that now, so that 'comm' is
+    # given a lexically sorted input as it expects.
+    $sortedmysystemlog = $mysystemlog . ".sorted";
+    `LC_ALL=C sort $mysystemlog > $sortedmysystemlog`;
 
     # Ensure the "previous" summary exists, e.g. if this is the first run of the
     # configuration they won't.
@@ -107,8 +111,8 @@ sub writeFile{
         $passingsuppresss = `grep "$suppressmarker" $sortedsummary | grep "\\[Success" | wc -l`; chomp($passingsuppresss);
         $newfailures += 0;
 
-        $newsystemerrors = `LC_ALL=C comm -13 $prevmysystemlog $mysystemlog | wc -l`; chomp($newsystemerrors);
-        $resolvedsystemerrors = `LC_ALL=C comm -23 $prevmysystemlog $mysystemlog | wc -l`; chomp($resolvedsystemerrors);
+        $newsystemerrors = `LC_ALL=C comm -13 $prevmysystemlog $sortedmysystemlog | wc -l`; chomp($newsystemerrors);
+        $resolvedsystemerrors = `LC_ALL=C comm -23 $prevmysystemlog $sortedmysystemlog | wc -l`; chomp($resolvedsystemerrors);
     }
 
     if ($newfailures == 0 && $newresolved == 0 && $newpassingfutures == 0 && $newpassingsuppress == 0 && $newsystemerrors == 0 && $resolvedsystemerrors == 0) {
@@ -131,7 +135,7 @@ sub writeFile{
              $summary ,
              $prevsummary ,
              $sortedsummary ,
-             $mysystemlog ,
+             $sortedmysystemlog ,
              $prevmysystemlog);
         }
     } else {
@@ -144,7 +148,7 @@ sub writeFile{
     if ($debug == 0) {
         if ($status == 0) {
             system("cp -pv $sortedsummary $prevsummary");
-            system("cp -pv $mysystemlog $prevmysystemlog");
+            system("cp -pv $sortedmysystemlog $prevmysystemlog");
         }
     }
 

--- a/util/cron/nightly_email.pm
+++ b/util/cron/nightly_email.pm
@@ -8,37 +8,39 @@ use nightlysubs;
 sub writeFile{
     $num_args = @_;
 
-    if ($num_args != 17) {
+    if ($num_args != 18) {
         print "usage: nightly_email.pm \$status \$rawsummary \$sortedsummary \n";
-        print "         \$prevsummary \$mysystemlog \$mailer \$nochangerecipient \$recipient \n";
+        print "         \$prevsummary \$mysystemlog \$prevmysystemlog \$mailer \$nochangerecipient \$recipient \n";
         print "         \$subjectid \$config_name \$revision \$rawlog \$starttime \n";
         print "         \$endtime \$crontab \$testdirs \$debug\n";
         exit 1;
     }
-    my ($status, $rawsummary, $sortedsummary, ,$prevsummary, $mysystemlog, $mailer, $nochangerecipient, $recipient, $subjectid, $config_name, $revision, $rawlog, $starttime, $endtime, $crontab, $testdirs, $debug)=@_;
+    my ($status, $rawsummary, $sortedsummary, ,$prevsummary, $mysystemlog, $prevmysystemlog, $mailer, $nochangerecipient, $recipient, $subjectid, $config_name, $revision, $rawlog, $starttime, $endtime, $crontab, $testdirs, $debug)=@_;
 
     $status = $_[0];
     $rawsummary = $_[1];
     $sortedsummary = $_[2];
     $prevsummary = $_[3];
     $mysystemlog = $_[4];
-    $mailer = $_[5];
-    $nochangerecipient = $_[6];
-    $recipient = $_[7];
-    $subjectid = $_[8];
-    $config_name = $_[9];
-    $revision = $_[10];
-    $rawlog = $_[11];
-    $starttime = $_[12];
-    $endtime = $_[13];
-    $crontab = $_[14];
-    $testdirs = $_[15];
-    $debug = $_[16];
+    $prevmysystemlog = $_[5];
+    $mailer = $_[6];
+    $nochangerecipient = $_[7];
+    $recipient = $_[8];
+    $subjectid = $_[9];
+    $config_name = $_[10];
+    $revision = $_[11];
+    $rawlog = $_[12];
+    $starttime = $_[13];
+    $endtime = $_[14];
+    $crontab = $_[15];
+    $testdirs = $_[16];
+    $debug = $_[17];
 
 
     # Ensure the "previous" summary exists, e.g. if this is the first run of the
     # configuration they won't.
     ensureSummaryExists($prevsummary);
+    ensureMysystemlogExists($prevmysystemlog);
 
 
     #
@@ -104,11 +106,12 @@ sub writeFile{
         $newpassingsuppress = `LC_ALL=C comm -13 $prevsummary $sortedsummary | grep -v "^.Summary:" | grep "$suppressmarker" | grep "\\[Success" | wc -l`; chomp($newpassingsuppresss);
         $passingsuppresss = `grep "$suppressmarker" $sortedsummary | grep "\\[Success" | wc -l`; chomp($passingsuppresss);
         $newfailures += 0;
+
+        $newsystemerrors = `LC_ALL=C comm -13 $prevmysystemlog $mysystemlog | wc -l`; chomp($newsystemerrors);
+        $resolvedsystemerrors = `LC_ALL=C comm -23 $prevmysystemlog $mysystemlog | wc -l`; chomp($resolvedsystemerrors);
     }
 
-    if (-f $mysystemlog && -s $mysystemlog) {
-        # Even if no errors occurred etc., the build failed, so send an email.
-    } elsif ($newfailures == 0 && $newresolved == 0 && $newpassingfutures == 0 && $newpassingsuppress == 0) {
+    if ($newfailures == 0 && $newresolved == 0 && $newpassingfutures == 0 && $newpassingsuppress == 0 && $newsystemerrors == 0 && $resolvedsystemerrors == 0) {
         $email=0;
         $recipient = $nochangerecipient;
     }
@@ -128,7 +131,8 @@ sub writeFile{
              $summary ,
              $prevsummary ,
              $sortedsummary ,
-             $mysystemlog);
+             $mysystemlog ,
+             $prevmysystemlog);
         }
     } else {
         print "CHPL_TEST_NOMAIL: No $mailcommand\n";
@@ -140,6 +144,7 @@ sub writeFile{
     if ($debug == 0) {
         if ($status == 0) {
             system("cp -pv $sortedsummary $prevsummary");
+            system("cp -pv $mysystemlog $prevmysystemlog");
         }
     }
 

--- a/util/cron/nightlysubs.pm
+++ b/util/cron/nightlysubs.pm
@@ -153,7 +153,7 @@ sub writeEmail {
     my $summary = $_[6];
     my $prevsummary = $_[7];
     my $sortedsummary = $_[8];
-    my $mysystemlog = $_[9];
+    my $sortedmysystemlog = $_[9];
     my $prevmysystemlog = $_[10];
 
     #Create a file "email.txt" in the chapel homedir. This file will be used by Jenkins to attach the test results in the email body
@@ -198,15 +198,15 @@ sub writeEmail {
         print $SF "\n";
 
         print $SF "--- New Errors in Bash Commands ------------------\n";
-        print $SF `LC_ALL=C comm -13 $prevmysystemlog $mysystemlog`;
+        print $SF `LC_ALL=C comm -13 $prevmysystemlog $sortedmysystemlog`;
         print $SF "\n";
 
         print $SF "--- Unresolved Errors in Bash Commands ------------------\n";
-        print $SF `LC_ALL=C comm -12 $prevmysystemlog $mysystemlog`;
+        print $SF `LC_ALL=C comm -12 $prevmysystemlog $sortedmysystemlog`;
         print $SF "\n";
 
         print $SF "--- Resolved Errors in Bash Commands ------------------\n";
-        print $SF `LC_ALL=C comm -23 $prevmysystemlog $mysystemlog`;
+        print $SF `LC_ALL=C comm -23 $prevmysystemlog $sortedmysystemlog`;
         print $SF "\n";
     print $SF;
     print $SF endMailChplenv();

--- a/util/cron/nightlysubs.pm
+++ b/util/cron/nightlysubs.pm
@@ -90,6 +90,14 @@ sub ensureSummaryExists {
     }
 }
 
+sub ensureMysystemlogExists {
+    $mysystemlog = $_[0];
+    if (! -r $mysystemlog) {
+        print "Creating $mysystemlog\n";
+        `touch $mysystemlog`
+    }
+}
+
 sub startMailHeader {
     my $revision = $_[0];
     my $logfile = $_[1];
@@ -146,6 +154,7 @@ sub writeEmail {
     my $prevsummary = $_[7];
     my $sortedsummary = $_[8];
     my $mysystemlog = $_[9];
+    my $prevmysystemlog = $_[10];
 
     #Create a file "email.txt" in the chapel homedir. This file will be used by Jenkins to attach the test results in the email body
     my $filename = "$chplhomedir/email.txt";
@@ -188,11 +197,17 @@ sub writeEmail {
         print $SF `LC_ALL=C comm -13 $prevsummary $sortedsummary | grep -v "^.Summary:" | grep "$futuremarker" | grep "\\[Error"`;
         print $SF "\n";
 
-        if (-f $mysystemlog && -s $mysystemlog) {
-            print $SF "--- Errors in Bash Commands ------------------\n";
-            print $SF `cat $mysystemlog`;
-            print $SF "\n";
-        }
+        print $SF "--- New Errors in Bash Commands ------------------\n";
+        print $SF `LC_ALL=C comm -13 $prevmysystemlog $mysystemlog`;
+        print $SF "\n";
+
+        print $SF "--- Unresolved Errors in Bash Commands ------------------\n";
+        print $SF `LC_ALL=C comm -12 $prevmysystemlog $mysystemlog`;
+        print $SF "\n";
+
+        print $SF "--- Resolved Errors in Bash Commands ------------------\n";
+        print $SF `LC_ALL=C comm -23 $prevmysystemlog $mysystemlog`;
+        print $SF "\n";
     print $SF;
     print $SF endMailChplenv();
     close($SF);


### PR DESCRIPTION
Builds upon https://github.com/chapel-lang/chapel/pull/25149.

The prior PR added support for sending emails about non-fatal system / bash errors in `nightly`. However, it did not add logic to only send emails when the bash failures change. Thus, each night that a particular bash command fails, a new email is sent out.

This PR adjusts this by only sending an email if a new bash command fails, or if a previously-failing bash command resolves. This avoid redundant emails for failures that last several days. When an email is sent, it also includes the currently-failing bash commands (but an email won't be sent _just_ for existing failures).

Reviewed by @riftEmber -- thanks!

## Testing
- [x] manually invoked `nightly` a bunch of times, breaking various Makefile targets that lie on non-fatal paths.