### PR TITLE
Deprecate Sort's defaultComparator variable

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -739,6 +739,13 @@ module ChapelArray {
     return true;
   }
 
+  // This alternative usage of Sort.DefaultComparator
+  // prevents transitive use of module Sort.
+  proc chpl_defaultComparator() {
+    use Sort;
+    return new DefaultComparator();
+  }
+
   @chpldoc.nodoc
   proc shouldReturnRvalueByValue(type t) param {
     if !PODValAccess then return false;

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -739,13 +739,6 @@ module ChapelArray {
     return true;
   }
 
-  // This alternative declaration of Sort.defaultComparator
-  // prevents transitive use of module Sort.
-  proc chpl_defaultComparator() {
-    use Sort;
-    return defaultComparator;
-  }
-
   @chpldoc.nodoc
   proc shouldReturnRvalueByValue(type t) param {
     if !PODValAccess then return false;

--- a/modules/internal/DefaultSparse.chpl
+++ b/modules/internal/DefaultSparse.chpl
@@ -273,7 +273,8 @@ module DefaultSparse {
         }
       }
 
-      bulkAdd_prepareInds(inds, dataSorted, isUnique, Sort.defaultComparator);
+      bulkAdd_prepareInds(inds, dataSorted, isUnique,
+                          new Sort.DefaultComparator());
 
       if _nnz == 0 {
 

--- a/modules/layouts/LayoutCS.chpl
+++ b/modules/layouts/LayoutCS.chpl
@@ -434,7 +434,8 @@ class CSDom: BaseSparseDomImpl(?) {
     }
 
     if this.compressRows then
-      bulkAdd_prepareInds(inds, dataSorted, isUnique, cmp=Sort.defaultComparator);
+      bulkAdd_prepareInds(inds, dataSorted, isUnique,
+                          cmp = new Sort.DefaultComparator());
     else
       bulkAdd_prepareInds(inds, dataSorted, isUnique, cmp=_columnComparator);
 

--- a/modules/packages/Search.chpl
+++ b/modules/packages/Search.chpl
@@ -25,6 +25,8 @@ module Search {
                        reverseComparator, ReverseComparator;
   private use Sort;
 
+  @deprecated("The variable 'defaultComparator' is deprecated, please use a new instance of the :record:`DefaultComparator` type instead.")
+  var defaultComparator = new DefaultComparator();
 
 /*
   A note about lo/hi arguments:

--- a/modules/packages/Search.chpl
+++ b/modules/packages/Search.chpl
@@ -69,8 +69,8 @@ module Search {
       been if it was not found.
    :rtype: (`bool`, `Dom.idxType`)
  */
-proc search(Data:[?Dom], val, comparator:?rec= new DefaultComparator(),
-            lo=Dom.low, hi=Dom.high, sorted=false) {
+proc search(Data:[?Dom], val, comparator:?rec = new DefaultComparator(),
+            lo = Dom.low, hi = Dom.high, sorted = false) {
   if sorted then
     return binarySearch(Data, val, comparator, lo, hi);
   else
@@ -80,8 +80,8 @@ proc search(Data:[?Dom], val, comparator:?rec= new DefaultComparator(),
 
 @chpldoc.nodoc
 /* Error message for multi-dimension arrays */
-proc search(Data:[?Dom], val, comparator:?rec= new DefaultComparator(),
-            lo=Dom.low, hi=Dom.high, sorted=false)
+proc search(Data:[?Dom], val, comparator:?rec = new DefaultComparator(),
+            lo = Dom.low, hi = Dom.high, sorted = false)
   where Dom.rank != 1 {
     compilerError("search() requires 1-D array");
 }
@@ -128,8 +128,8 @@ proc linearSearch(Data:[?Dom], val, comparator:?rec = new DefaultComparator(),
 
 @chpldoc.nodoc
 /* Error message for multi-dimension arrays */
-proc linearSearch(Data:[?Dom], val, comparator:?rec= new DefaultComparator(),
-                  lo=Dom.low, hi=Dom.high)
+proc linearSearch(Data:[?Dom], val, comparator:?rec = new DefaultComparator(),
+                  lo = Dom.low, hi = Dom.high)
   where Dom.rank != 1 {
     compilerError("linearSearch() requires 1-D array");
 }

--- a/modules/packages/Search.chpl
+++ b/modules/packages/Search.chpl
@@ -106,7 +106,8 @@ proc search(Data:[?Dom], val, comparator:?rec= new DefaultComparator(),
    :rtype: (`bool`, `Dom.idxType`)
 
  */
-proc linearSearch(Data:[?Dom], val, comparator:?rec=defaultComparator, lo=Dom.low, hi=Dom.high) {
+proc linearSearch(Data:[?Dom], val, comparator:?rec = new DefaultComparator(),
+                   lo = Dom.low, hi = Dom.high) {
 
  chpl_check_comparator(comparator, Data.eltType);
 
@@ -153,7 +154,8 @@ proc linearSearch(Data:[?Dom], val, comparator:?rec=defaultComparator, lo=Dom.lo
    :rtype: (`bool`, `Dom.idxType`)
 
  */
-proc binarySearch(Data:[?Dom], val, comparator:?rec=defaultComparator, in lo=Dom.low, in hi=Dom.high) {
+proc binarySearch(Data:[?Dom], val, comparator:?rec = new DefaultComparator(),
+                  in lo=Dom.low, in hi=Dom.high) {
   chpl_check_comparator(comparator, Data.eltType);
   if Dom.rank != 1 then compilerError("binarySearch() requires 1-D array");
 
@@ -178,7 +180,8 @@ proc binarySearch(Data:[?Dom], val, comparator:?rec=defaultComparator, in lo=Dom
 
 @chpldoc.nodoc
 /* Non-stridable binarySearch */
-proc binarySearch(Data:[?Dom], val, comparator:?rec=defaultComparator, in lo=Dom.low, in hi=Dom.high)
+proc binarySearch(Data:[?Dom], val, comparator:?rec = new DefaultComparator(),
+                  in lo = Dom.low, in hi = Dom.high)
   where Dom.hasUnitStride()
 {
   chpl_check_comparator(comparator, Data.eltType);

--- a/modules/packages/Search.chpl
+++ b/modules/packages/Search.chpl
@@ -21,7 +21,7 @@
 /* Support for standard search routines on 1D arrays.
  */
 module Search {
-  public use Sort only defaultComparator, DefaultComparator,
+  public use Sort only DefaultComparator,
                        reverseComparator, ReverseComparator;
   private use Sort;
 
@@ -64,7 +64,8 @@ module Search {
       been if it was not found.
    :rtype: (`bool`, `Dom.idxType`)
  */
-proc search(Data:[?Dom], val, comparator:?rec=defaultComparator, lo=Dom.low, hi=Dom.high, sorted=false) {
+proc search(Data:[?Dom], val, comparator:?rec= new DefaultComparator(),
+            lo=Dom.low, hi=Dom.high, sorted=false) {
   if sorted then
     return binarySearch(Data, val, comparator, lo, hi);
   else
@@ -74,7 +75,8 @@ proc search(Data:[?Dom], val, comparator:?rec=defaultComparator, lo=Dom.low, hi=
 
 @chpldoc.nodoc
 /* Error message for multi-dimension arrays */
-proc search(Data:[?Dom], val, comparator:?rec=defaultComparator, lo=Dom.low, hi=Dom.high, sorted=false)
+proc search(Data:[?Dom], val, comparator:?rec= new DefaultComparator(),
+            lo=Dom.low, hi=Dom.high, sorted=false)
   where Dom.rank != 1 {
     compilerError("search() requires 1-D array");
 }

--- a/modules/packages/Search.chpl
+++ b/modules/packages/Search.chpl
@@ -19,14 +19,17 @@
  */
 
 /* Support for standard search routines on 1D arrays.
+
+   .. note::
+
+      Due to implementation constraints, this module currently exposes symbols
+      from the Sort module.  Please only rely on the re-exported versions of
+      :record:`~Sort.DefaultComparator` and :record:`~Sort.ReverseComparator`,
+      all other re-exported symbols should be considered unstable when obtained
+      from Search and will be removed in the future.
  */
 module Search {
-  public use Sort only DefaultComparator,
-                       reverseComparator, ReverseComparator;
-  private use Sort;
-
-  @deprecated("The variable 'defaultComparator' is deprecated, please use a new instance of the :record:`DefaultComparator` type instead.")
-  var defaultComparator = new DefaultComparator();
+  public use Sort;
 
 /*
   A note about lo/hi arguments:

--- a/modules/packages/Search.chpl
+++ b/modules/packages/Search.chpl
@@ -123,7 +123,8 @@ proc linearSearch(Data:[?Dom], val, comparator:?rec = new DefaultComparator(),
 
 @chpldoc.nodoc
 /* Error message for multi-dimension arrays */
-proc linearSearch(Data:[?Dom], val, comparator:?rec=defaultComparator, lo=Dom.low, hi=Dom.high)
+proc linearSearch(Data:[?Dom], val, comparator:?rec= new DefaultComparator(),
+                  lo=Dom.low, hi=Dom.high)
   where Dom.rank != 1 {
     compilerError("linearSearch() requires 1-D array");
 }

--- a/modules/packages/SortedMap.chpl
+++ b/modules/packages/SortedMap.chpl
@@ -32,7 +32,10 @@ module SortedMap {
   private use HaltWrappers;
   private use SortedSet;
   private use IO;
-  public use Sort only defaultComparator;
+  public use Sort only DefaultComparator;
+
+  @deprecated("The variable 'defaultComparator' is deprecated, please use a new instance of the :record:`DefaultComparator` type instead.")
+  var defaultComparator = new DefaultComparator();
 
   // Lock code lifted from modules/standard/List.chpl.
   @chpldoc.nodoc
@@ -96,7 +99,7 @@ module SortedMap {
     param parSafe = false;
 
     /* The comparator used to compare keys */
-    var comparator: record = defaultComparator;
+    var comparator: record = new DefaultComparator();
 
     // TODO: Maybe we want something like record optional for this?
     @chpldoc.nodoc
@@ -141,7 +144,7 @@ module SortedMap {
       :arg comparator: The comparator used to compare keys.
     */
     proc init(type keyType, type valType, param parSafe = false,
-              comparator: record = defaultComparator) {
+              comparator: record = new DefaultComparator()) {
       _checkKeyType(keyType);
       _checkValType(valType);
 

--- a/modules/packages/SortedMap.chpl
+++ b/modules/packages/SortedMap.chpl
@@ -32,10 +32,7 @@ module SortedMap {
   private use HaltWrappers;
   private use SortedSet;
   private use IO;
-  public use Sort only DefaultComparator;
-
-  @deprecated("The variable 'defaultComparator' is deprecated, please use a new instance of the :record:`DefaultComparator` type instead.")
-  var defaultComparator = new DefaultComparator();
+  public use Sort;
 
   // Lock code lifted from modules/standard/List.chpl.
   @chpldoc.nodoc

--- a/modules/packages/SortedMap.chpl
+++ b/modules/packages/SortedMap.chpl
@@ -26,6 +26,14 @@
   the parallel safety mode of its originating sortedMap.
 
   SortedMap supports searching for a certain key, insertion and deletion in O(logN).
+
+   .. note::
+
+      Due to implementation constraints, this module currently exposes symbols
+      from the Sort module.  Please only rely on the re-exported version of
+      :record:`~Sort.DefaultComparator`, all other re-exported symbols should be
+      considered unstable when obtained from SortedMap and will be removed in
+      the future.
 */
 module SortedMap {
   import ChapelLocks;

--- a/modules/packages/SortedMap.chpl
+++ b/modules/packages/SortedMap.chpl
@@ -25,7 +25,7 @@
   constructed from another sortedMap, the new sortedMap will inherit
   the parallel safety mode of its originating sortedMap.
 
-  SortedSet supports searching for a certain key, insertion and deletion in O(logN).
+  SortedMap supports searching for a certain key, insertion and deletion in O(logN).
 */
 module SortedMap {
   import ChapelLocks;

--- a/modules/packages/SortedSet.chpl
+++ b/modules/packages/SortedSet.chpl
@@ -35,6 +35,13 @@
   ``sortedSet`` will inherit the parallel safety mode of its originating
   ``sortedSet``.
 
+   .. note::
+
+      Due to implementation constraints, this module currently exposes symbols
+      from the Sort module.  Please only rely on the re-exported version of
+      :record:`~Sort.DefaultComparator`, all other re-exported symbols should be
+      considered unstable when obtained from SortedSet and will be removed in
+      the future.
 */
 module SortedSet {
   include module Treap;

--- a/modules/packages/SortedSet.chpl
+++ b/modules/packages/SortedSet.chpl
@@ -41,7 +41,10 @@ module SortedSet {
   private use Treap;
   private use Reflection;
   private use IO;
-  public use Sort only defaultComparator;
+  public use Sort only DefaultComparator;
+
+  @deprecated("The variable 'defaultComparator' is deprecated, please use a new instance of the :record:`DefaultComparator` type instead.")
+  var defaultComparator = new DefaultComparator();
 
   record sortedSet : writeSerializable {
     /* The type of the elements contained in this sortedSet. */
@@ -50,7 +53,7 @@ module SortedSet {
     /* If `true`, this sortedSet will perform parallel safe operations. */
     param parSafe = false;
 
-    type comparatorType = defaultComparator.type;
+    type comparatorType = DefaultComparator;
 
     /* The underlying implementation */
     @chpldoc.nodoc
@@ -64,7 +67,7 @@ module SortedSet {
       :arg comparatorType: The comparator type
     */
     proc init(type eltType, param parSafe = false,
-              type comparatorType = defaultComparator.type) {
+              type comparatorType = DefaultComparator) {
       this.eltType = eltType;
       this.parSafe = parSafe;
       this.comparatorType = comparatorType;
@@ -100,7 +103,7 @@ module SortedSet {
       :arg comparator: The comparator used to compare elements.
     */
     proc init(type eltType, iterable, param parSafe=false,
-              comparator: record = defaultComparator)
+              comparator: record = new DefaultComparator())
     where canResolveMethod(iterable, "these") lifetime this < iterable {
       this.eltType = eltType;
       this.parSafe = parSafe;

--- a/modules/packages/SortedSet.chpl
+++ b/modules/packages/SortedSet.chpl
@@ -41,10 +41,7 @@ module SortedSet {
   private use Treap;
   private use Reflection;
   private use IO;
-  public use Sort only DefaultComparator;
-
-  @deprecated("The variable 'defaultComparator' is deprecated, please use a new instance of the :record:`DefaultComparator` type instead.")
-  var defaultComparator = new DefaultComparator();
+  public use Sort;
 
   record sortedSet : writeSerializable {
     /* The type of the elements contained in this sortedSet. */

--- a/modules/packages/SortedSet/Treap.chpl
+++ b/modules/packages/SortedSet/Treap.chpl
@@ -193,7 +193,8 @@ module Treap {
       :arg parSafe: If `true`, this sortedSet will use parallel safe operations.
       :arg comparator: The comparator used to compare elements.
     */
-    proc init(type eltType, param parSafe = false, comparator: record = defaultComparator) {
+    proc init(type eltType, param parSafe = false,
+              comparator: record = new DefaultComparator()) {
       _checkType(eltType);
       this.eltType = eltType;
       this.parSafe = parSafe;
@@ -210,7 +211,8 @@ module Treap {
       :arg parSafe: If `true`, this sortedSet will use parallel safe operations.
       :arg comparator: The comparator used to compare elements.
     */
-    proc init(type eltType, iterable, param parSafe = false, comparator: record = defaultComparator)
+    proc init(type eltType, iterable, param parSafe = false,
+              comparator: record = new DefaultComparator())
     where canResolveMethod(iterable, "these") lifetime this < iterable {
       _checkType(eltType);
 

--- a/modules/standard/Heap.chpl
+++ b/modules/standard/Heap.chpl
@@ -28,10 +28,10 @@
   * Querying the top element is O(1).
   * Initialization from an array is O(N).
 
-  The heap accepts a :ref:`comparator <comparators>` to determine how
-  elements are compared. The default comparator is `defaultComparator` and makes
-  a max-heap. In this case, ``top`` will return the greatest element in the
-  heap.
+  The heap accepts a :ref:`comparator <comparators>` to determine how elements
+  are compared. The default comparator is an instance of `DefaultComparator` and
+  makes a max-heap. In this case, ``top`` will return the greatest element in
+  the heap.
 
   If a ``reverseComparator`` is passed to ``init``,
   ``top`` will return the minimal element.
@@ -44,9 +44,7 @@ module Heap {
   private use List;
   private use IO;
 
-  public use Sort only defaultComparator, DefaultComparator,
-                       reverseComparator, ReverseComparator;
-  private use Sort;
+  public use Sort;
 
   // The locker is borrowed from List.chpl
   //
@@ -137,7 +135,8 @@ module Heap {
 
       :arg comparator: The comparator to use
     */
-    proc init(type eltType, param parSafe = false, comparator: record = defaultComparator) {
+    proc init(type eltType, param parSafe = false,
+              comparator: record = new DefaultComparator()) {
       _checkType(eltType);
       this.eltType = eltType;
       this.parSafe = parSafe;
@@ -408,7 +407,8 @@ module Heap {
 
     :rtype: heap(t, comparator)
   */
-  proc createHeap(const ref x: list(?t), param parSafe: bool = false, comparator = defaultComparator) {
+  proc createHeap(const ref x: list(?t), param parSafe: bool = false,
+                  comparator = new DefaultComparator()) {
     var h = new heap(t, parSafe, comparator);
     h._commonInitFromIterable(x);
     return h;
@@ -427,7 +427,8 @@ module Heap {
 
     :rtype: heap(t, comparator)
   */
-  proc createHeap(const ref x: [?d] ?t, param parSafe: bool = false, comparator = defaultComparator) {
+  proc createHeap(const ref x: [?d] ?t, param parSafe: bool = false,
+                  comparator = new DefaultComparator()) {
     var h = new heap(t, parSafe, comparator);
     h._commonInitFromIterable(x);
     return h;

--- a/modules/standard/Heap.chpl
+++ b/modules/standard/Heap.chpl
@@ -36,6 +36,14 @@
   If a ``reverseComparator`` is passed to ``init``,
   ``top`` will return the minimal element.
 
+   .. note::
+
+      Due to implementation constraints, this module currently exposes symbols
+      from the Sort module.  Please only rely on the re-exported versions of
+      :record:`~Sort.DefaultComparator` and :record:`~Sort.ReverseComparator`,
+      all other re-exported symbols should be considered unstable when obtained
+      from Heap and will be removed in the future.
+
 */
 @unstable("The 'Heap' module is unstable")
 module Heap {

--- a/modules/standard/Heap.chpl
+++ b/modules/standard/Heap.chpl
@@ -29,9 +29,9 @@
   * Initialization from an array is O(N).
 
   The heap accepts a :ref:`comparator <comparators>` to determine how elements
-  are compared. The default comparator is an instance of `DefaultComparator` and
-  makes a max-heap. In this case, ``top`` will return the greatest element in
-  the heap.
+  are compared. The default comparator is an instance of
+  :record:`~Sort.DefaultComparator` and makes a max-heap. In this case, ``top``
+  will return the greatest element in the heap.
 
   If a ``reverseComparator`` is passed to ``init``,
   ``top`` will return the minimal element.

--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -1548,7 +1548,7 @@ module List {
       :arg comparator: A comparator used to sort this list.
     */
     @unstable("'list.sort' is unstable and may be replaced or modified in a future release")
-    proc ref sort(comparator: ?rec=Sort.defaultComparator) {
+    proc ref sort(comparator: ?rec= new Sort.DefaultComparator()) {
       on this {
         _enter();
 

--- a/modules/standard/Sort.chpl
+++ b/modules/standard/Sort.chpl
@@ -851,7 +851,7 @@ module InsertionSort {
 
    */
   proc insertionSort(ref Data: [?Dom] ?eltType,
-                     comparator:?rec= new DefaultComparator(), lo:int=Dom.low,
+                     comparator:?rec = new DefaultComparator(), lo:int=Dom.low,
                      hi:int=Dom.high) {
     chpl_check_comparator(comparator, eltType);
 
@@ -882,7 +882,7 @@ module InsertionSort {
   }
 
   proc insertionSortMoveElts(ref Data: [?Dom] ?eltType,
-                             comparator:?rec= new DefaultComparator(),
+                             comparator:?rec = new DefaultComparator(),
                              lo:int=Dom.low, hi:int=Dom.high) {
     chpl_check_comparator(comparator, eltType);
 

--- a/modules/standard/Sort.chpl
+++ b/modules/standard/Sort.chpl
@@ -848,7 +848,9 @@ module InsertionSort {
       data is sorted.
 
    */
-  proc insertionSort(ref Data: [?Dom] ?eltType, comparator:?rec=defaultComparator, lo:int=Dom.low, hi:int=Dom.high) {
+  proc insertionSort(ref Data: [?Dom] ?eltType,
+                     comparator:?rec= new DefaultComparator(), lo:int=Dom.low,
+                     hi:int=Dom.high) {
     chpl_check_comparator(comparator, eltType);
 
     if Dom.rank != 1 {
@@ -877,7 +879,9 @@ module InsertionSort {
     }
   }
 
-  proc insertionSortMoveElts(ref Data: [?Dom] ?eltType, comparator:?rec=defaultComparator, lo:int=Dom.low, hi:int=Dom.high) {
+  proc insertionSortMoveElts(ref Data: [?Dom] ?eltType,
+                             comparator:?rec= new DefaultComparator(),
+                             lo:int=Dom.low, hi:int=Dom.high) {
     chpl_check_comparator(comparator, eltType);
 
     if Dom.rank != 1 {
@@ -1399,9 +1403,9 @@ module QuickSort {
 
  /* Use quickSort to sort Data */
  proc quickSort(ref Data: [?Dom] ?eltType,
-                minlen=16,
-                comparator:?rec=defaultComparator,
-                region:range(?)=Data.domain.dim(0)) {
+                minlen = 16,
+                comparator:?rec = new DefaultComparator(),
+                region:range(?) = Data.domain.dim(0)) {
 
     chpl_check_comparator(comparator, eltType);
 
@@ -1425,7 +1429,7 @@ module QuickSort {
   /* Non-stridable quickSort to sort Data[start..end] */
   proc quickSortImpl(ref Data: [?Dom] ?eltType,
                      minlen=16,
-                     comparator:?rec=defaultComparator,
+                     comparator:?rec = new DefaultComparator(),
                      start:int = Dom.low, end:int = Dom.high) {
     import Sort.InsertionSort;
 
@@ -1532,8 +1536,9 @@ module SelectionSort {
 @chpldoc.nodoc
 module ShellSort {
   private use Sort;
-  proc shellSort(ref Data: [?Dom] ?eltType, comparator:?rec=defaultComparator,
-                 start=Dom.low, end=Dom.high)
+  proc shellSort(ref Data: [?Dom] ?eltType,
+                 comparator:?rec = new DefaultComparator(), start = Dom.low,
+                 end = Dom.high)
   {
     chpl_check_comparator(comparator, eltType);
 
@@ -1575,7 +1580,7 @@ module ShellSort {
   // Like the shell sort above, but this version uses
   // ShallowCopy to move elements instead of assigning them.
   proc shellSortMoveElts(ref Data: [?Dom] ?eltType,
-                         comparator:?rec = defaultComparator,
+                         comparator:?rec = new DefaultComparator(),
                          start: Data.idxType = Dom.low,
                          end: Data.idxType = Dom.high)
   {
@@ -1623,7 +1628,7 @@ module ShellSort {
   // this version takes int start and end and casts to Data.idxType
   // to make it more convenient to call from the radix sorting code
   proc shellSortMoveEltsIntIdx(ref Data: [?Dom] ?eltType,
-                               comparator:?rec = defaultComparator,
+                               comparator:?rec = new DefaultComparator(),
                                start:int = Dom.low,
                                end:int = Dom.high)
   {
@@ -1967,7 +1972,7 @@ module RadixSortHelp {
     } else if canResolveMethod(criterion, "key", a) {
       // Try to use the default comparator to get a keyPart.
       return binForRecordKeyPart(criterion.key(a),
-                                 defaultComparator,
+                                 new DefaultComparator(),
                                  startbit);
     } else {
       compilerError("Bad comparator for radix sort ", criterion.type:string,
@@ -4158,7 +4163,7 @@ record ReverseComparator {
    reverses the sort order of the default comparator.
    */
   proc init() {
-    this.comparator = defaultComparator;
+    this.comparator = new DefaultComparator();
   }
 
   /*
@@ -4223,7 +4228,7 @@ record ReverseComparator {
     if canResolveMethod(this.comparator, "key", a) {
       var key:comparator.key(a).type;
       // Does the defaultComparator have a keyPart for this?
-      return canResolveMethod(defaultComparator, "keyPart", key, 0);
+      return canResolveMethod(new DefaultComparator(), "keyPart", key, 0);
     }
     return false;
   }
@@ -4237,7 +4242,7 @@ record ReverseComparator {
     if canResolveMethod(this.comparator, "key", a) {
       var key:comparator.key(a).type;
       // Does the defaultComparator have a compare for this?
-      return canResolveMethod(defaultComparator, "compare", key, key);
+      return canResolveMethod(new DefaultComparator(), "compare", key, key);
     }
     return false;
   }
@@ -4263,7 +4268,7 @@ record ReverseComparator {
     chpl_check_comparator(this.comparator, a.type);
 
     if hasKeyPartFromKey(a) {
-      return getKeyPart(defaultComparator, this.comparator.key(a), i);
+      return getKeyPart(new DefaultComparator(), this.comparator.key(a), i);
     } else {
       return getKeyPart(this.comparator, a, i);
     }
@@ -4285,7 +4290,7 @@ record ReverseComparator {
     chpl_check_comparator(this.comparator, a.type);
 
     if hasCompareFromKey(a) {
-      return doCompare(defaultComparator,
+      return doCompare(new DefaultComparator(),
                        this.comparator.key(a),
                        this.comparator.key(b));
     } else {

--- a/modules/standard/Sort.chpl
+++ b/modules/standard/Sort.chpl
@@ -305,10 +305,10 @@ proc compareByPart(a:?t, b:t, comparator:?rec) {
 /*
    Base compare method of all sort functions.
 
-   By default, it returns the value of defaultComparator.compare(a, b).
+   By default, it returns the value of DefaultComparator.compare(a, b).
 
    If a comparator with a key method is passed, it will return the value of
-   defaultComparator(comparator.key(a), comparator.key(b)).
+   DefaultComparator(comparator.key(a), comparator.key(b)).
 
    If a comparator with a compare method is passed, it will return the value of
    comparator.compare(a, b).
@@ -729,7 +729,7 @@ iter sorted(x, comparator:? = new DefaultComparator()) {
 // but, it is stable and in-place
 @chpldoc.nodoc
 module BubbleSort {
-  import Sort.{defaultComparator, chpl_check_comparator, chpl_compare};
+  import Sort.{DefaultComparator, chpl_check_comparator, chpl_compare};
 
   /*
    Sort the 1D array `Data` in-place using a sequential bubble sort algorithm.
@@ -740,7 +740,8 @@ module BubbleSort {
       data is sorted.
 
    */
-  proc bubbleSort(ref Data: [?Dom] ?eltType, comparator:?rec=defaultComparator) {
+  proc bubbleSort(ref Data: [?Dom] ?eltType,
+                  comparator:?rec = new DefaultComparator()) {
     chpl_check_comparator(comparator, eltType);
 
     if Dom.rank != 1 {
@@ -769,7 +770,7 @@ module BubbleSort {
 // it is in-place but not stable.
 @chpldoc.nodoc
 module HeapSort {
-  import Sort.{defaultComparator, chpl_check_comparator, chpl_compare};
+  import Sort.{DefaultComparator, chpl_check_comparator, chpl_compare};
   /*
 
    Sort the 1D array `Data` in-place using a sequential heap sort algorithm.
@@ -780,7 +781,8 @@ module HeapSort {
       data is sorted.
 
    */
-  proc heapSort(ref Data: [?Dom] ?eltType, comparator:?rec=defaultComparator) {
+  proc heapSort(ref Data: [?Dom] ?eltType,
+                comparator:?rec = new DefaultComparator()) {
     chpl_check_comparator(comparator, eltType);
 
     if Dom.rank != 1 {
@@ -810,7 +812,7 @@ module HeapSort {
       SiftDown(low, end, comparator);
     }
 
-    proc SiftDown(start, end, comparator:?rec=defaultComparator) {
+    proc SiftDown(start, end, comparator:?rec = new DefaultComparator()) {
       var root = start;
       while ((2*root - low + stride) <= end) {
         const child = 2*root - low + stride;
@@ -929,7 +931,8 @@ module BinaryInsertionSort {
     :arg comparator: :ref:`Comparator <comparators>` record that defines how the
        data is sorted.
    */
-  proc binaryInsertionSort(ref Data: [?Dom] ?eltType, comparator:?rec=defaultComparator) {
+  proc binaryInsertionSort(ref Data: [?Dom] ?eltType,
+                           comparator:?rec = new DefaultComparator()) {
     chpl_check_comparator(comparator, eltType);
 
     if Dom.rank != 1 {
@@ -962,7 +965,10 @@ module BinaryInsertionSort {
     If `val` is not in `Data`, the index that it should be inserted at is returned.
     Does not check for a valid comparator.
   */
-  private proc _binarySearchForLastOccurrence(Data: [?Dom], val, comparator:?rec=defaultComparator, in lo=Dom.low, in hi=Dom.high) {
+  private
+  proc _binarySearchForLastOccurrence(Data: [?Dom], val,
+                                      comparator:?rec = new DefaultComparator(),
+                                      in lo=Dom.low, in hi=Dom.high) {
     const stride = abs(Dom.stride): Dom.idxType;
 
     var loc = -1;                                        // index of the last occurrence of val in Data
@@ -1005,7 +1011,8 @@ module TimSort {
 
    */
 
-  proc timSort(ref Data: [?Dom] ?eltType, blockSize=16, comparator:?rec=defaultComparator) {
+  proc timSort(ref Data: [?Dom] ?eltType, blockSize=16,
+               comparator:?rec = new DefaultComparator()) {
     chpl_check_comparator(comparator, eltType);
 
     if Dom.rank != 1 {
@@ -1015,7 +1022,8 @@ module TimSort {
     _TimSort(Data, Dom.low, Dom.high, blockSize, comparator);
   }
 
-  private proc _TimSort(ref Data: [?Dom], lo:int, hi:int, blockSize=16, comparator:?rec=defaultComparator) {
+  private proc _TimSort(ref Data: [?Dom], lo:int, hi:int, blockSize=16,
+                        comparator:?rec = new DefaultComparator()) {
     import Sort.InsertionSort;
 
     /*Parallelly apply insertionSort on each block of size `blockSize`
@@ -1056,7 +1064,8 @@ module TimSort {
    TimSort._Merge() creates a copy of the segments to be merged and
    stores the results back into the original memory.
   */
-  private proc _Merge(ref Dst: [?Dom] ?eltType, lo:int, mid:int, hi:int, comparator:?rec=defaultComparator) {
+  private proc _Merge(ref Dst: [?Dom] ?eltType, lo:int, mid:int, hi:int,
+                      comparator:?rec = new DefaultComparator()) {
     /* Data[lo..mid by stride] is much slower than Data[lo..mid] when
      * Dom is unstrided.  So specify the latter explicitly when possible. */
     if mid >= hi {
@@ -1121,7 +1130,8 @@ module MergeSort {
        data is sorted.
 
    */
-  proc mergeSort(ref Data: [?Dom] ?eltType, minlen=16, comparator:?rec=defaultComparator) {
+  proc mergeSort(ref Data: [?Dom] ?eltType, minlen=16,
+                 comparator:?rec = new DefaultComparator()) {
     chpl_check_comparator(comparator, eltType);
 
     if Dom.rank != 1 {
@@ -1147,7 +1157,9 @@ module MergeSort {
    * The data stays in Data "all they way down" until the first
    * _Merge(), then is moved back and forth as we return up the chain.
    */
-  private proc _MergeSort(ref Data: [?Dom], ref Scratch: [], lo:int, hi:int, minlen=16, comparator:?rec=defaultComparator, depth: int)
+  private proc _MergeSort(ref Data: [?Dom], ref Scratch: [], lo:int, hi:int,
+                          minlen=16, comparator:?rec = new DefaultComparator(),
+                          depth: int)
     where Dom.rank == 1 {
     import Sort.InsertionSort;
 
@@ -1198,7 +1210,8 @@ module MergeSort {
     }
   }
 
-  private proc _Merge(ref Dst: [?Dom] ?eltType, Src: [], lo:int, mid:int, hi:int, comparator:?rec=defaultComparator) {
+  private proc _Merge(ref Dst: [?Dom] ?eltType, Src: [], lo:int, mid:int,
+                      hi:int, comparator:?rec = new DefaultComparator()) {
     /* Data[lo..mid by stride] is much slower than Data[lo..mid] when
      * Dom is unstrided.  So specify the latter explicitly when possible. */
     const stride = abs(Dom.stride): Dom.idxType;
@@ -1509,7 +1522,8 @@ module SelectionSort {
        data is sorted.
 
    */
-  proc selectionSort(ref Data: [?Dom] ?eltType, comparator:?rec=defaultComparator) {
+  proc selectionSort(ref Data: [?Dom] ?eltType,
+                     comparator:?rec = new DefaultComparator()) {
     // note: selection sort is not a stable sort
 
     if Dom.rank != 1 {
@@ -3588,13 +3602,13 @@ module TwoArrayRadixSort {
 
 @chpldoc.nodoc
 module TwoArrayDistributedRadixSort {
-  import Sort.defaultComparator;
+  import Sort.DefaultComparator;
   private use super.TwoArrayDistributedPartitioning;
   private use super.RadixSortHelp;
   private use super.TwoArrayRadixSort;
 
   proc twoArrayDistributedRadixSort(ref Data:[],
-                                    comparator:?rec=defaultComparator) {
+                                    comparator:?rec = new DefaultComparator()) {
 
     // just run the local version if Data isn't distributed
     if Data._instance.isDefaultRectangular() {
@@ -3645,14 +3659,15 @@ module TwoArrayDistributedRadixSort {
 
 @chpldoc.nodoc
 module TwoArraySampleSort {
-  import Sort.defaultComparator;
+  import Sort.DefaultComparator;
   private use super.TwoArrayPartitioning;
   private use super.SampleSortHelp;
   private use super.RadixSortHelp;
 
   private use CTypes;
 
-  proc twoArraySampleSort(ref Data:[], comparator:?rec=defaultComparator) {
+  proc twoArraySampleSort(ref Data:[],
+                          comparator:?rec = new DefaultComparator()) {
 
     var baseCaseSize=16;
     var distributedBaseCaseSize=1024;
@@ -3681,7 +3696,7 @@ module TwoArraySampleSort {
 
 @chpldoc.nodoc
 module TwoArrayDistributedSampleSort {
-  import Sort.defaultComparator;
+  import Sort.DefaultComparator;
   private use super.TwoArrayPartitioning;
   private use super.SampleSortHelp;
   private use super.RadixSortHelp;
@@ -3690,7 +3705,7 @@ module TwoArrayDistributedSampleSort {
   private use CTypes;
 
   proc twoArrayDistributedSampleSort(ref Data:[],
-                                     comparator:?rec=defaultComparator) {
+                                     comparator:?rec = new DefaultComparator()) {
 
     // just run the local version if Data isn't distributed
     if Data._instance.isDefaultRectangular() {

--- a/modules/standard/Sort.chpl
+++ b/modules/standard/Sort.chpl
@@ -264,8 +264,7 @@ module Sort {
   argument when no comparator is passed to a sort function
 */
 @deprecated("The variable 'defaultComparator' is now deprecated, please create a new instance of the :record:`DefaultComparator` type instead.")
-const defaultComparator: DefaultComparator;
-defaultComparator = new DefaultComparator();
+const defaultComparator: DefaultComparator = new DefaultComparator();
 
 
 /*
@@ -329,7 +328,8 @@ inline proc chpl_compare(a:?t, b:t, comparator:?rec) {
   // Compare results of comparator.key(a) if is defined by user
   if canResolveMethod(comparator, "key", a) {
     // Use the default comparator to compare the integer keys
-    return defaultComparator.compare(comparator.key(a), comparator.key(b));
+    return (new DefaultComparator()).compare(comparator.key(a),
+                                             comparator.key(b));
   // Use comparator.compare(a, b) if is defined by user
   } else if canResolveMethod(comparator, "compare", a, b) {
     return comparator.compare(a ,b);
@@ -417,7 +417,7 @@ proc radixSortOkAndStrideOne(Data: [] ?eltType,
     } else if canResolveMethod(comparator, "key", tmp) {
       var key:comparator.key(tmp).type;
       // Does the defaultComparator have a keyPart for this?
-      if canResolveMethod(defaultComparator, "keyPart", key, 0) then
+      if canResolveMethod(new DefaultComparator(), "keyPart", key, 0) then
         return true;
     }
   }
@@ -3536,11 +3536,12 @@ module TwoArrayDistributedPartitioning {
 
 @chpldoc.nodoc
 module TwoArrayRadixSort {
-  import Sort.defaultComparator;
+  import Sort.DefaultComparator;
   private use super.TwoArrayPartitioning;
   private use super.RadixSortHelp;
 
-  proc twoArrayRadixSort(ref Data:[], comparator:?rec=defaultComparator,
+  proc twoArrayRadixSort(ref Data:[],
+                         comparator:?rec = new DefaultComparator(),
                          region:range(?) = Data.domain.dim(0)) {
 
     if !chpl_domainDistIsLayout(Data.domain) {
@@ -3736,7 +3737,7 @@ module InPlacePartitioning {
 // it is not stable and not fully parallel
 @chpldoc.nodoc
 module MSBRadixSort {
-  import Sort.{defaultComparator, ShellSort};
+  import Sort.{DefaultComparator, ShellSort};
   private use super.RadixSortHelp;
   private use OS.POSIX;
 
@@ -3751,7 +3752,7 @@ module MSBRadixSort {
     const maxTasks = here.maxTaskPar;//;here.numPUs(logical=true); // maximum number of tasks to make
   }
 
-  proc msbRadixSort(ref Data:[], comparator:?rec=defaultComparator,
+  proc msbRadixSort(ref Data:[], comparator:?rec = new DefaultComparator(),
                     region:range(?)=Data.domain.dim(0)) {
 
     var endbit:int;

--- a/modules/standard/Sort.chpl
+++ b/modules/standard/Sort.chpl
@@ -263,6 +263,7 @@ module Sort {
   Instance of :record:`DefaultComparator` used as default ``comparator=``
   argument when no comparator is passed to a sort function
 */
+@deprecated("The variable 'defaultComparator' is now deprecated, please create a new instance of the :record:`DefaultComparator` type instead.")
 const defaultComparator: DefaultComparator;
 defaultComparator = new DefaultComparator();
 

--- a/test/deprecated/Heap/depGlobal.chpl
+++ b/test/deprecated/Heap/depGlobal.chpl
@@ -1,0 +1,6 @@
+use Heap;
+
+var h = new heap(string, false, defaultComparator);
+
+h.push("foo");
+writeln(h.top());

--- a/test/deprecated/Heap/depGlobal.good
+++ b/test/deprecated/Heap/depGlobal.good
@@ -1,0 +1,2 @@
+depGlobal.chpl:3: warning: The variable 'defaultComparator' is now deprecated, please create a new instance of the DefaultComparator type instead.
+foo

--- a/test/deprecated/Search/depGlobals.chpl
+++ b/test/deprecated/Search/depGlobals.chpl
@@ -1,0 +1,5 @@
+use Search;
+
+var arr1: [0..5] int = [1, 3, 2, 4, 6, 5];
+writeln(search(arr1, 5, defaultComparator));
+

--- a/test/deprecated/Search/depGlobals.good
+++ b/test/deprecated/Search/depGlobals.good
@@ -1,2 +1,2 @@
-depGlobals.chpl:4: warning: The variable 'defaultComparator' is deprecated, please use a new instance of the DefaultComparator type instead.
+depGlobals.chpl:4: warning: The variable 'defaultComparator' is now deprecated, please create a new instance of the DefaultComparator type instead.
 (true, 5)

--- a/test/deprecated/Search/depGlobals.good
+++ b/test/deprecated/Search/depGlobals.good
@@ -1,0 +1,2 @@
+depGlobals.chpl:4: warning: The variable 'defaultComparator' is deprecated, please use a new instance of the DefaultComparator type instead.
+(true, 5)

--- a/test/deprecated/Sort/depGlobals.chpl
+++ b/test/deprecated/Sort/depGlobals.chpl
@@ -1,0 +1,5 @@
+use Sort;
+
+var arr1: [0..5] int = [1, 3, 2, 4, 6, 5];
+sort(arr1, defaultComparator);
+writeln(arr1);

--- a/test/deprecated/Sort/depGlobals.good
+++ b/test/deprecated/Sort/depGlobals.good
@@ -1,0 +1,2 @@
+depGlobals.chpl:4: warning: The variable 'defaultComparator' is now deprecated, please create a new instance of the DefaultComparator type instead.
+1 2 3 4 5 6

--- a/test/deprecated/SortedMap/depGlobal.chpl
+++ b/test/deprecated/SortedMap/depGlobal.chpl
@@ -1,0 +1,6 @@
+use SortedMap;
+
+var m = new sortedMap(string, string, false, defaultComparator);
+
+m["abc"] = "one two three";
+writeln(m.contains("abc"));

--- a/test/deprecated/SortedMap/depGlobal.good
+++ b/test/deprecated/SortedMap/depGlobal.good
@@ -1,0 +1,2 @@
+depGlobal.chpl:3: warning: The variable 'defaultComparator' is deprecated, please use a new instance of the DefaultComparator type instead.
+true

--- a/test/deprecated/SortedMap/depGlobal.good
+++ b/test/deprecated/SortedMap/depGlobal.good
@@ -1,2 +1,2 @@
-depGlobal.chpl:3: warning: The variable 'defaultComparator' is deprecated, please use a new instance of the DefaultComparator type instead.
+depGlobal.chpl:3: warning: The variable 'defaultComparator' is now deprecated, please create a new instance of the DefaultComparator type instead.
 true

--- a/test/deprecated/SortedSet/depGlobal.chpl
+++ b/test/deprecated/SortedSet/depGlobal.chpl
@@ -1,0 +1,6 @@
+use SortedSet;
+
+var s = new sortedSet(string, false, defaultComparator);
+
+s.add("foo");
+writeln(s.contains("foo"));

--- a/test/deprecated/SortedSet/depGlobal.good
+++ b/test/deprecated/SortedSet/depGlobal.good
@@ -1,0 +1,2 @@
+depGlobal.chpl:3: warning: The variable 'defaultComparator' is deprecated, please use a new instance of the DefaultComparator type instead.
+true

--- a/test/deprecated/SortedSet/depGlobal.good
+++ b/test/deprecated/SortedSet/depGlobal.good
@@ -1,2 +1,2 @@
-depGlobal.chpl:3: warning: The variable 'defaultComparator' is deprecated, please use a new instance of the DefaultComparator type instead.
+depGlobal.chpl:3: warning: The variable 'defaultComparator' is now deprecated, please create a new instance of the DefaultComparator type instead.
 true

--- a/test/library/draft/Vector/Vector.chpl
+++ b/test/library/draft/Vector/Vector.chpl
@@ -929,7 +929,7 @@ module Vector {
 
       :arg comparator: A comparator used to sort this vector.
     */
-    proc ref sort(comparator: ?rec=Sort.defaultComparator) {
+    proc ref sort(comparator: ?rec = new Sort.DefaultComparator()) {
       on this {
         _enter();
 

--- a/test/library/packages/Search/correctness.chpl
+++ b/test/library/packages/Search/correctness.chpl
@@ -92,7 +92,8 @@ proc main() {
 
 
 /* Checks array and resets values -- any output results in failure */
-proc checkSearch(result, expected, arr, searchProc:string, cmp=defaultComparator) {
+proc checkSearch(result, expected, arr, searchProc:string,
+                 cmp = new DefaultComparator()) {
   if result != expected {
     writeln(searchProc, '() function failed');
     writeln('eltType:    ', arr.eltType:string);

--- a/test/library/packages/Sort/RadixSort/distributedRadixSort.chpl
+++ b/test/library/packages/Sort/RadixSort/distributedRadixSort.chpl
@@ -20,7 +20,8 @@ proc simpletestcore(input:[]) {
     writef("input %xt\n", input);
   }
 
- TwoArrayDistributedRadixSort.twoArrayDistributedRadixSort(A, defaultComparator);
+  TwoArrayDistributedRadixSort.twoArrayDistributedRadixSort(A,
+                                     new DefaultComparator());
 
   if debug {
     writef("output %xt\n", A);
@@ -80,7 +81,8 @@ proc randomtest(n:int) {
 
   var timer:stopwatch;
   timer.start();
-  TwoArrayDistributedRadixSort.twoArrayDistributedRadixSort(A, defaultComparator);
+  TwoArrayDistributedRadixSort.twoArrayDistributedRadixSort(A,
+                                              new DefaultComparator());
   timer.stop();
 
   if comms {

--- a/test/library/packages/Sort/correctness/SortTypes.chpl
+++ b/test/library/packages/Sort/correctness/SortTypes.chpl
@@ -19,7 +19,7 @@ record UselessKeyPartComparator {
         return (-1, 0:tt);
 
     } else if x.type == string {
-      return defaultComparator.keyPart(x, i);
+      return (new DefaultComparator()).keyPart(x, i);
     } else if isNumericType(x.type) {
       if i == 0 then
         return (0, x);

--- a/test/library/packages/Sort/correctness/SortTypesStrided.chpl
+++ b/test/library/packages/Sort/correctness/SortTypesStrided.chpl
@@ -19,7 +19,7 @@ record UselessKeyPartComparator {
         return (-1, 0:tt);
 
     } else if x.type == string {
-      return defaultComparator.keyPart(x, i);
+      return (new DefaultComparator()).keyPart(x, i);
     } else if isNumericType(x.type) {
       if i == 0 then
         return (0, x);

--- a/test/library/packages/Sort/correctness/correctness.chpl
+++ b/test/library/packages/Sort/correctness/correctness.chpl
@@ -45,13 +45,13 @@ proc main() {
   // Pre-sorted arrays paired with comparators to test
   var tests = (
                 // Testing A.eltType
-                ([-4, -1, 2, 3], defaultComparator),
-                (['Brad', 'anthony', 'ben', 'david'], defaultComparator),
+                ([-4, -1, 2, 3], new DefaultComparator()),
+                (['Brad', 'anthony', 'ben', 'david'], new DefaultComparator()),
 
                 // Testing D.idxType / D.dims()
-                (largeA, defaultComparator),
-                (strideA, defaultComparator),
-                (strideAlignA, defaultComparator),
+                (largeA, new DefaultComparator()),
+                (strideA, new DefaultComparator()),
+                (strideAlignA, new DefaultComparator()),
                 (strideRevA, reverseComparator),
 
                 // Testing comparators

--- a/test/library/packages/Sort/correctness/test-radix-bucketizer.chpl
+++ b/test/library/packages/Sort/correctness/test-radix-bucketizer.chpl
@@ -26,7 +26,7 @@ proc testBucketizer() {
                     0x11,
                     0x00];
 
-  var criterion = defaultComparator;
+  var criterion = new DefaultComparator();
   var ASorted = A;
   sort(ASorted, criterion);
   assert(isSorted(ASorted));
@@ -161,7 +161,7 @@ proc testBucketizerRandomized(nelts:int, seed:int) {
   Random.fillRandom(A, seed=seed);
 
   var b = new RadixBucketizer();
-  var criterion = defaultComparator;
+  var criterion = new DefaultComparator();
 
   var ASorted = A;
   sort(ASorted, criterion);

--- a/test/library/packages/Sort/correctness/test-sample-bucketizer.chpl
+++ b/test/library/packages/Sort/correctness/test-sample-bucketizer.chpl
@@ -60,7 +60,7 @@ proc testBucketizer(nBuckets:int, equalBuckets:bool) {
                      0x2222222222222222:uint,
                      0xffffffffffffffff:uint];
 
-  var criterion = defaultComparator;
+  var criterion = new DefaultComparator();
 
   if debug then
     writeln("nBuckets=", nBuckets,
@@ -169,7 +169,7 @@ proc testBucketizerRandomized(nelts:int, nBuckets:int, equalBuckets:bool) {
   var A:[0..#nelts] uint;
   Random.fillRandom(A);
 
-  var criterion = defaultComparator;
+  var criterion = new DefaultComparator();
   var b = makeBucketizerTest(nBuckets, equalBuckets, A, criterion);
 
   var src = A;

--- a/test/library/packages/Sort/performance/sort-performance-explorer.chpl
+++ b/test/library/packages/Sort/performance/sort-performance-explorer.chpl
@@ -193,7 +193,8 @@ proc testsize(size:int) {
   }
 
   for m in methods {
-    const ref cmp = if reverse then reverseComparator else defaultComparator;
+    const ref cmp = if reverse then reverseComparator else
+                                      new DefaultComparator();
     var t: stopwatch;
     for i in 1..ntrials {
       input = makeInput(array, inputStrings);

--- a/test/library/packages/SortedMap/addOrReplace/testAddOrSet.chpl
+++ b/test/library/packages/SortedMap/addOrReplace/testAddOrSet.chpl
@@ -2,7 +2,7 @@ use SortedMap;
 
 
 
-var m = new sortedMap(int, int, false, defaultComparator);
+var m = new sortedMap(int, int, false, new DefaultComparator());
 for i in 1..10 {
   m.addOrReplace(i, i);
 }

--- a/test/library/packages/SortedMap/addSet/testAddSet.chpl
+++ b/test/library/packages/SortedMap/addSet/testAddSet.chpl
@@ -2,7 +2,7 @@ use SortedMap;
 
 
 
-var m = new sortedMap(int, int, false, defaultComparator);
+var m = new sortedMap(int, int, false, new DefaultComparator());
 
 var ret:bool = m.add(1, -1);
 assert(ret);

--- a/test/library/packages/SortedMap/clear/testClear.chpl
+++ b/test/library/packages/SortedMap/clear/testClear.chpl
@@ -3,7 +3,7 @@ use utilFunctions;
 
 
 
-var m = new sortedMap(string, int, false, defaultComparator);
+var m = new sortedMap(string, int, false, new DefaultComparator());
 
 for i in 1..99 by 3 {
   m[intToEnglish(i)] = i;

--- a/test/library/packages/SortedMap/contains/testContains.chpl
+++ b/test/library/packages/SortedMap/contains/testContains.chpl
@@ -3,7 +3,7 @@ use utilFunctions;
 
 
 
-var m = new sortedMap(string, string, false, defaultComparator);
+var m = new sortedMap(string, string, false, new DefaultComparator());
 
 for i in 1..99 by 3 {
   var number = intToEnglish(i);

--- a/test/library/packages/SortedMap/getAndRemove/testGetRemove.chpl
+++ b/test/library/packages/SortedMap/getAndRemove/testGetRemove.chpl
@@ -6,7 +6,7 @@ class C {
   var i: int;
 }
 
-var m = new sortedMap(string, shared C, false, defaultComparator);
+var m = new sortedMap(string, shared C, false, new DefaultComparator());
 m.add("one", new shared C(1));
 m.add("two", new shared C(2));
 

--- a/test/library/packages/SortedMap/getBorrowed/testGetBorrowed.chpl
+++ b/test/library/packages/SortedMap/getBorrowed/testGetBorrowed.chpl
@@ -6,7 +6,7 @@ class C {
   var i: int;
 }
 
-var m = new sortedMap(string, shared C, false, defaultComparator);
+var m = new sortedMap(string, shared C, false, new DefaultComparator());
 
 m.add("one", new shared C(1));
 m.add("two", new shared C(2));

--- a/test/library/packages/SortedMap/getReference/testGetReference.chpl
+++ b/test/library/packages/SortedMap/getReference/testGetReference.chpl
@@ -6,7 +6,7 @@ class C {
   var i: int;
 }
 
-var m = new sortedMap(string, shared C?, false, defaultComparator);
+var m = new sortedMap(string, shared C?, false, new DefaultComparator());
 
 m.add("one", new shared C?(1));
 m.add("two", new shared C?(2));

--- a/test/library/packages/SortedMap/getReference/testGetReferenceRecord.chpl
+++ b/test/library/packages/SortedMap/getReference/testGetReferenceRecord.chpl
@@ -4,7 +4,7 @@ record C {
   var i: int;
 }
 
-var m = new sortedMap(string, C, false, defaultComparator);
+var m = new sortedMap(string, C, false, new DefaultComparator());
 
 m.add("one", new C(1));
 m.add("two", new C(2));

--- a/test/library/packages/SortedMap/getValue/testGetValue.chpl
+++ b/test/library/packages/SortedMap/getValue/testGetValue.chpl
@@ -7,7 +7,7 @@ class C {
 }
 
 proc test() {
-  var m = new sortedMap(string, shared C, false, defaultComparator);
+  var m = new sortedMap(string, shared C, false, new DefaultComparator());
 
   m.add("one", new shared C(1));
   m.add("two", new shared C(2));

--- a/test/library/packages/SortedMap/getValue/testGetValueOwned.chpl
+++ b/test/library/packages/SortedMap/getValue/testGetValueOwned.chpl
@@ -7,7 +7,7 @@ class C {
 }
 
 proc test() {
-  var m = new sortedMap(string, owned C, false, defaultComparator);
+  var m = new sortedMap(string, owned C, false, new DefaultComparator());
 
   m.add("one", new owned C(1));
   m.add("two", new owned C(2));

--- a/test/library/packages/SortedMap/getValue/testGetValueRecord.chpl
+++ b/test/library/packages/SortedMap/getValue/testGetValueRecord.chpl
@@ -6,7 +6,7 @@ record C {
 }
 
 proc test() {
-  var m = new sortedMap(string, C, false, defaultComparator);
+  var m = new sortedMap(string, C, false, new DefaultComparator());
 
   m.add("one", new C(1));
   m.add("two", new C(2));

--- a/test/library/packages/SortedMap/init/testInit.chpl
+++ b/test/library/packages/SortedMap/init/testInit.chpl
@@ -3,7 +3,7 @@ use SortedMap;
 
 
 {
-  var m = new sortedMap(string, int, false, defaultComparator);
+  var m = new sortedMap(string, int, false, new DefaultComparator());
   m["one"] = 1;
   writeln(m);
 }

--- a/test/library/packages/SortedMap/isEmpty/testIsEmpty.chpl
+++ b/test/library/packages/SortedMap/isEmpty/testIsEmpty.chpl
@@ -2,7 +2,7 @@ use SortedMap;
 
 
 
-var m = new sortedMap(int, int, false, defaultComparator);
+var m = new sortedMap(int, int, false, new DefaultComparator());
 assert(m.isEmpty());
 
 for i in 1..3 do

--- a/test/library/packages/SortedMap/iterators/testIterators.chpl
+++ b/test/library/packages/SortedMap/iterators/testIterators.chpl
@@ -35,7 +35,7 @@ operator FacInt.>(a: FacInt, b: FacInt) {
   return a.n > b.n;
 }
 
-var fac = new sortedMap(int, FacInt, false, defaultComparator);
+var fac = new sortedMap(int, FacInt, false, new DefaultComparator());
 
 for i in 1..15 {
   fac[i] = new FacInt(i: uint);

--- a/test/library/packages/SortedMap/operators/testEquality.chpl
+++ b/test/library/packages/SortedMap/operators/testEquality.chpl
@@ -2,8 +2,8 @@ use SortedMap;
 
 
 
-var m1 = new sortedMap(int, int, false, defaultComparator),
-    m2 = new sortedMap(int, int, false, defaultComparator);
+var m1 = new sortedMap(int, int, false, new DefaultComparator()),
+    m2 = new sortedMap(int, int, false, new DefaultComparator());
 
 for i in 1..10 {
   m1[i] = -i;

--- a/test/library/packages/SortedMap/operators/testSetAssignOps.chpl
+++ b/test/library/packages/SortedMap/operators/testSetAssignOps.chpl
@@ -2,9 +2,9 @@ use SortedMap;
 
 
 
-var m0 = new sortedMap(int, int, false, defaultComparator);
-var m1 = new sortedMap(int, int, false, defaultComparator);
-var m2 = new sortedMap(int, int, false, defaultComparator);
+var m0 = new sortedMap(int, int, false, new DefaultComparator());
+var m1 = new sortedMap(int, int, false, new DefaultComparator());
+var m2 = new sortedMap(int, int, false, new DefaultComparator());
 
 m0[1] = 1;
 m0[2] = 2;

--- a/test/library/packages/SortedMap/operators/testSetOps.chpl
+++ b/test/library/packages/SortedMap/operators/testSetOps.chpl
@@ -2,8 +2,8 @@ use SortedMap;
 
 
 
-var m1 = new sortedMap(int, int, false, defaultComparator);
-var m2 = new sortedMap(int, int, false, defaultComparator);
+var m1 = new sortedMap(int, int, false, new DefaultComparator());
+var m2 = new sortedMap(int, int, false, new DefaultComparator());
 
 m1[1] = 1;
 m1[2] = 2;

--- a/test/library/packages/SortedMap/remove/testRemove.chpl
+++ b/test/library/packages/SortedMap/remove/testRemove.chpl
@@ -2,7 +2,7 @@ use SortedMap;
 
 
 
-var m = new sortedMap(int, int, false, defaultComparator);
+var m = new sortedMap(int, int, false, new DefaultComparator());
 
 for i in 1..10 {
   m.add(i, i);

--- a/test/library/packages/SortedMap/size/testSize.chpl
+++ b/test/library/packages/SortedMap/size/testSize.chpl
@@ -3,7 +3,7 @@ use utilFunctions;
 
 
 
-var m = new sortedMap(string, real, false, defaultComparator);
+var m = new sortedMap(string, real, false, new DefaultComparator());
 
 writeln(m.isEmpty());
 writeln(m.size);

--- a/test/library/packages/SortedMap/this/testThis.chpl
+++ b/test/library/packages/SortedMap/this/testThis.chpl
@@ -3,7 +3,7 @@ use utilFunctions;
 
 
 
-var m = new sortedMap(string, int, false, defaultComparator);
+var m = new sortedMap(string, int, false, new DefaultComparator());
 
 for i in 1..10 {
   m[intToEnglish(i)] = i;

--- a/test/library/packages/SortedMap/toArray/testToArray.chpl
+++ b/test/library/packages/SortedMap/toArray/testToArray.chpl
@@ -2,7 +2,7 @@ use SortedMap;
 
 
 
-var m = new sortedMap(int, int, false, defaultComparator);
+var m = new sortedMap(int, int, false, new DefaultComparator());
 
 for i in -10..10 do
   m[i] = -i + 100;

--- a/test/library/packages/SortedMap/types/MapTest.chpl
+++ b/test/library/packages/SortedMap/types/MapTest.chpl
@@ -1,8 +1,8 @@
 import SortedMap.sortedMap;
-import SortedMap.defaultComparator;
+import SortedMap.DefaultComparator;
 
 proc testMap(type t) where isTupleType(t) {
-  var m = new sortedMap(int, t, false, defaultComparator);
+  var m = new sortedMap(int, t, false, new DefaultComparator());
 
   var x: t = (new t[0](1), new t[1](2));
 
@@ -22,7 +22,7 @@ proc testMap(type t) where isTupleType(t) {
 }
 
 proc testMap(type t) where isBorrowedClass(t) {
-  var m = new sortedMap(int, t, false, defaultComparator);
+  var m = new sortedMap(int, t, false, new DefaultComparator());
 
   // create values with 'owned' if t is a borrowed class type
   // (the map will still store borrowed)
@@ -46,7 +46,7 @@ proc testMap(type t) where isBorrowedClass(t) {
 }
 
 proc testMap(type t) {
-  var m = new sortedMap(int, t, false, defaultComparator);
+  var m = new sortedMap(int, t, false, new DefaultComparator());
 
   var x: t = new t(1);
 

--- a/test/library/packages/SortedMap/types/mapOfArray.chpl
+++ b/test/library/packages/SortedMap/types/mapOfArray.chpl
@@ -2,7 +2,7 @@ use SortedMap;
 
 
 
-var m = new sortedMap(int, [1..2] int, false, defaultComparator);
+var m = new sortedMap(int, [1..2] int, false, new DefaultComparator());
 
 var A: [1..2] int = 1..2;
 m.add(1, A);

--- a/test/library/packages/SortedMap/types/testBorrowed2.chpl
+++ b/test/library/packages/SortedMap/types/testBorrowed2.chpl
@@ -9,7 +9,7 @@ class C {
 var e1 = new shared C(1);
 var e2 = new shared C(2);
 
-var m = new sortedMap(string, borrowed C, false, defaultComparator);
+var m = new sortedMap(string, borrowed C, false, new DefaultComparator());
 
 m.add("one", e1);
 m.add("two", e2);

--- a/test/library/packages/SortedMap/types/testNilableBorrowed.chpl
+++ b/test/library/packages/SortedMap/types/testNilableBorrowed.chpl
@@ -6,7 +6,7 @@ class T {
   var value = 0;
 }
 
-var m = new sortedMap(int, borrowed T?, false, defaultComparator);
+var m = new sortedMap(int, borrowed T?, false, new DefaultComparator());
 
 var a = new T(1);
 var b: borrowed T? = a.borrow();

--- a/test/library/packages/SortedMap/types/testShared2.chpl
+++ b/test/library/packages/SortedMap/types/testShared2.chpl
@@ -6,7 +6,7 @@ class C {
   var i: int;
 }
 
-var m = new sortedMap(string, shared C, false, defaultComparator);
+var m = new sortedMap(string, shared C, false, new DefaultComparator());
 
 m.add("one", new shared C(1));
 m.add("two", new shared C(2));

--- a/test/library/packages/SortedMap/update/testUpdate.chpl
+++ b/test/library/packages/SortedMap/update/testUpdate.chpl
@@ -2,8 +2,8 @@ use Sort;
 use SortedMap;
 use utilFunctions;
 
-var m1 = new sortedMap(string, int, true, defaultComparator);
-var m2 = new sortedMap(string, int, true, defaultComparator);
+var m1 = new sortedMap(string, int, true, new DefaultComparator());
+var m2 = new sortedMap(string, int, true, new DefaultComparator());
 
 forall i in 1..20 with (ref m1) do
   m1[intToEnglish(i)] = i;

--- a/test/library/packages/SortedSet/general/add/sSetAdd.chpl
+++ b/test/library/packages/SortedSet/general/add/sSetAdd.chpl
@@ -3,7 +3,7 @@ use Random;
 use Sort;
 
 config param testIters = 137;
-var oset = new sortedSet(int, false, defaultComparator);
+var oset = new sortedSet(int, false, new DefaultComparator());
 var a: [0..#testIters] int;
 fillRandom(a);
 for x in a {

--- a/test/library/packages/SortedSet/general/assign/sSetAssign.chpl
+++ b/test/library/packages/SortedSet/general/assign/sSetAssign.chpl
@@ -6,9 +6,9 @@ use OsetTest;
 config const testIters = 8;
 
 proc doTest(type eltType) {
-  var s1 = new sortedSet(eltType, false, defaultComparator);
-  var s2 = new sortedSet(eltType, false, defaultComparator);
-  var s3 = new sortedSet(eltType, false, defaultComparator);
+  var s1 = new sortedSet(eltType, false, new DefaultComparator());
+  var s2 = new sortedSet(eltType, false, new DefaultComparator());
+  var s3 = new sortedSet(eltType, false, new DefaultComparator());
 
   assert(s1.size == s2.size && s2.size == s3.size && s3.size == 0);
 

--- a/test/library/packages/SortedSet/general/clear/sSetClear.chpl
+++ b/test/library/packages/SortedSet/general/clear/sSetClear.chpl
@@ -6,9 +6,9 @@ use OsetTest;
 config const testIters = 8;
 
 proc doTest(type eltType) {
-  var s1 = new sortedSet(eltType, false, defaultComparator);
-  var s2 = new sortedSet(eltType, false, defaultComparator);
-  var s3 = new sortedSet(eltType, false, defaultComparator);
+  var s1 = new sortedSet(eltType, false, new DefaultComparator());
+  var s2 = new sortedSet(eltType, false, new DefaultComparator());
+  var s3 = new sortedSet(eltType, false, new DefaultComparator());
 
   for i in 1..testIters {
     var x = i:eltType;

--- a/test/library/packages/SortedSet/general/contains/sSetContains.chpl
+++ b/test/library/packages/SortedSet/general/contains/sSetContains.chpl
@@ -6,9 +6,9 @@ use OsetTest;
 config const testIters = 8;
 
 proc doTest(type eltType) {
-  var s1 = new sortedSet(eltType, false, defaultComparator);
-  var s2 = new sortedSet(eltType, false, defaultComparator);
-  var s3 = new sortedSet(eltType, false, defaultComparator);
+  var s1 = new sortedSet(eltType, false, new DefaultComparator());
+  var s2 = new sortedSet(eltType, false, new DefaultComparator());
+  var s3 = new sortedSet(eltType, false, new DefaultComparator());
 
   assert(s1.size == s2.size && s2.size == s3.size && s3.size == 0);
 

--- a/test/library/packages/SortedSet/general/difference/sSetDifference.chpl
+++ b/test/library/packages/SortedSet/general/difference/sSetDifference.chpl
@@ -5,9 +5,9 @@ use OsetTest;
 config const testIters = 8;
 
 proc doTest(type eltType) {
-  var s1 = new sortedSet(eltType, false, defaultComparator);
-  var s2 = new sortedSet(eltType, false, defaultComparator);
-  var s3 = new sortedSet(eltType, false, defaultComparator);
+  var s1 = new sortedSet(eltType, false, new DefaultComparator());
+  var s2 = new sortedSet(eltType, false, new DefaultComparator());
+  var s3 = new sortedSet(eltType, false, new DefaultComparator());
 
   assert(s1.size == s2.size && s2.size == s3.size && s3.size == 0);
 

--- a/test/library/packages/SortedSet/general/equality/sSetEquality.chpl
+++ b/test/library/packages/SortedSet/general/equality/sSetEquality.chpl
@@ -5,9 +5,9 @@ use OsetTest;
 config const testIters = 8;
 
 proc doTest(type eltType) {
-  var s1 = new sortedSet(eltType, false, defaultComparator);
-  var s2 = new sortedSet(eltType, false, defaultComparator);
-  var s3 = new sortedSet(eltType, false, defaultComparator);
+  var s1 = new sortedSet(eltType, false, new DefaultComparator());
+  var s2 = new sortedSet(eltType, false, new DefaultComparator());
+  var s3 = new sortedSet(eltType, false, new DefaultComparator());
 
   assert(s1 == s2 && s2 == s3);
 

--- a/test/library/packages/SortedSet/general/init/sSetInit.chpl
+++ b/test/library/packages/SortedSet/general/init/sSetInit.chpl
@@ -3,10 +3,10 @@ use OsetTest;
 
 
 
-var s1 = new sortedSet(int, false, defaultComparator);
-var s2 = new sortedSet(testRecord, false, defaultComparator);
-var s3 = new sortedSet(borrowed testClass, false, defaultComparator);
-var s4 = new sortedSet(int, 1..10, false, defaultComparator);
+var s1 = new sortedSet(int, false, new DefaultComparator());
+var s2 = new sortedSet(testRecord, false, new DefaultComparator());
+var s3 = new sortedSet(borrowed testClass, false, new DefaultComparator());
+var s4 = new sortedSet(int, 1..10, false, new DefaultComparator());
 
 assert(s1.size == 0);
 assert(s2.size == 0);

--- a/test/library/packages/SortedSet/general/initEquals/setInitEquals.chpl
+++ b/test/library/packages/SortedSet/general/initEquals/setInitEquals.chpl
@@ -5,7 +5,7 @@ use OsetTest;
 config const testIters = 8;
 
 proc doTest(type eltType) {
-  var s1 = new sortedSet(eltType, false, defaultComparator);
+  var s1 = new sortedSet(eltType, false, new DefaultComparator());
 
   for i in 1..testIters {
     var x = i:eltType;

--- a/test/library/packages/SortedSet/general/intersection/sSetIntersection.chpl
+++ b/test/library/packages/SortedSet/general/intersection/sSetIntersection.chpl
@@ -5,10 +5,10 @@ use OsetTest;
 config const testIters = 8;
 
 proc doTest(type eltType) {
-  var s1 = new sortedSet(eltType, false, defaultComparator);
-  var s2 = new sortedSet(eltType, false, defaultComparator);
-  var s3 = new sortedSet(eltType, false, defaultComparator);
-  var s4 = new sortedSet(eltType, false, defaultComparator);
+  var s1 = new sortedSet(eltType, false, new DefaultComparator());
+  var s2 = new sortedSet(eltType, false, new DefaultComparator());
+  var s3 = new sortedSet(eltType, false, new DefaultComparator());
+  var s4 = new sortedSet(eltType, false, new DefaultComparator());
 
   assert(s1.size == s2.size && s2.size == s3.size && s3.size == 0);
 

--- a/test/library/packages/SortedSet/general/isDisjoint/sSetIsDisjoint.chpl
+++ b/test/library/packages/SortedSet/general/isDisjoint/sSetIsDisjoint.chpl
@@ -5,8 +5,8 @@ use OsetTest;
 config const testIters = 8;
 
 proc doTest(type eltType) {
-  var s1 = new sortedSet(eltType, false, defaultComparator);
-  var s2 = new sortedSet(eltType, false, defaultComparator);
+  var s1 = new sortedSet(eltType, false, new DefaultComparator());
+  var s2 = new sortedSet(eltType, false, new DefaultComparator());
 
   assert(s1.isDisjoint(s2));
   assert(s2.isDisjoint(s1));

--- a/test/library/packages/SortedSet/general/isEmpty/sSetIsEmpty.chpl
+++ b/test/library/packages/SortedSet/general/isEmpty/sSetIsEmpty.chpl
@@ -1,6 +1,6 @@
 use SortedSet;
 
-var oset = new sortedSet(int, false, defaultComparator);
+var oset = new sortedSet(int, false, new DefaultComparator());
 writeln(oset.isEmpty());
 oset.add(1);
 writeln(oset.isEmpty());

--- a/test/library/packages/SortedSet/general/isIntersecting/sSetIsIntersecting.chpl
+++ b/test/library/packages/SortedSet/general/isIntersecting/sSetIsIntersecting.chpl
@@ -5,8 +5,8 @@ use OsetTest;
 config const testIters = 8;
 
 proc doTest(type eltType) {
-  var s1 = new sortedSet(eltType, false, defaultComparator);
-  var s2 = new sortedSet(eltType, false, defaultComparator);
+  var s1 = new sortedSet(eltType, false, new DefaultComparator());
+  var s2 = new sortedSet(eltType, false, new DefaultComparator());
 
   assert(!s1.isIntersecting(s2));
   assert(!s2.isIntersecting(s1));

--- a/test/library/packages/SortedSet/general/kth/noDefaultValue.chpl
+++ b/test/library/packages/SortedSet/general/kth/noDefaultValue.chpl
@@ -18,7 +18,7 @@ class Foo {
   }
 }
 
-var s1 = new sortedSet(shared Foo, false, defaultComparator);
+var s1 = new sortedSet(shared Foo, false, new DefaultComparator());
 s1.add(new shared Foo(11));
 s1.add(new shared Foo(5));
 s1.add(new shared Foo(16));

--- a/test/library/packages/SortedSet/general/kth/noDefaultValue.good
+++ b/test/library/packages/SortedSet/general/kth/noDefaultValue.good
@@ -1,4 +1,4 @@
-$CHPL_HOME/modules/packages/SortedSet.chpl:275: In method 'kth':
-$CHPL_HOME/modules/packages/SortedSet.chpl:276: error: kth is not available on types that can't be 
+$CHPL_HOME/modules/packages/SortedSet.chpl:282: In method 'kth':
+$CHPL_HOME/modules/packages/SortedSet.chpl:283: error: kth is not available on types that can't be 
                       default-initialized, here: shared Foo
   noDefaultValue.chpl:30: called as (sortedSet(shared Foo,false,DefaultComparator)).kth(k: int(64))

--- a/test/library/packages/SortedSet/general/kth/sSetKth.chpl
+++ b/test/library/packages/SortedSet/general/kth/sSetKth.chpl
@@ -6,7 +6,7 @@ use Sort;
 config const testIters = 128;
 
 proc doTest(ref arr: [?d] int) {
-  var s1 = new sortedSet(int, false, defaultComparator);
+  var s1 = new sortedSet(int, false, new DefaultComparator());
 
   for x in arr {
     s1.add(x);

--- a/test/library/packages/SortedSet/general/kth/yesDefaultValue.chpl
+++ b/test/library/packages/SortedSet/general/kth/yesDefaultValue.chpl
@@ -14,7 +14,7 @@ class Foo {
   }
 }
 
-var s1 = new sortedSet(shared Foo?, false, defaultComparator);
+var s1 = new sortedSet(shared Foo?, false, new DefaultComparator());
 s1.add(new shared Foo(11));
 s1.add(new shared Foo(5));
 s1.add(new shared Foo(16));

--- a/test/library/packages/SortedSet/general/lowerBound/sSetLowerbound.chpl
+++ b/test/library/packages/SortedSet/general/lowerBound/sSetLowerbound.chpl
@@ -16,7 +16,7 @@ proc lowerBound(arr: [?d] int, target: int, out result:int ): bool {
 }
 
 proc doTest(ref arr: [?d] int) {
-  var s1 = new sortedSet(int, false, defaultComparator);
+  var s1 = new sortedSet(int, false, new DefaultComparator());
 
   for x in arr {
     s1.add(x);

--- a/test/library/packages/SortedSet/general/memleaks/sSetCheckMemLeaks.chpl
+++ b/test/library/packages/SortedSet/general/memleaks/sSetCheckMemLeaks.chpl
@@ -15,7 +15,7 @@ const hi = 128;
 
 proc test() {
   var arr: [0..#hi] shared C?;
-  var s = new sortedSet(shared C?, false, defaultComparator);
+  var s = new sortedSet(shared C?, false, new DefaultComparator());
 
   for i in 0..#hi do arr[i] = new shared C(i);
   for x in arr do s.add(x);

--- a/test/library/packages/SortedSet/general/neighbours/sSetNeighbours.chpl
+++ b/test/library/packages/SortedSet/general/neighbours/sSetNeighbours.chpl
@@ -6,7 +6,7 @@ use Sort;
 config const testIters = 128;
 
 proc doTest(ref arr: [?d] int) {
-  var s1 = new sortedSet(int, false, defaultComparator);
+  var s1 = new sortedSet(int, false, new DefaultComparator());
 
   for x in arr {
     s1.add(x);

--- a/test/library/packages/SortedSet/general/properSubset/sSetProperSubset.chpl
+++ b/test/library/packages/SortedSet/general/properSubset/sSetProperSubset.chpl
@@ -7,8 +7,8 @@ config const testIters = 8;
 
 
 proc doTest(type eltType) {
-  var s1 = new sortedSet(eltType, false, defaultComparator);
-  var s2 = new sortedSet(eltType, false, defaultComparator);
+  var s1 = new sortedSet(eltType, false, new DefaultComparator());
+  var s2 = new sortedSet(eltType, false, new DefaultComparator());
 
   assert(!(s1 < s2));
   assert(!(s2 < s1));

--- a/test/library/packages/SortedSet/general/properSuperset/sSetProperSuperset.chpl
+++ b/test/library/packages/SortedSet/general/properSuperset/sSetProperSuperset.chpl
@@ -7,8 +7,8 @@ config const testIters = 8;
 
 
 proc doTest(type eltType) {
-  var s1 = new sortedSet(eltType, false, defaultComparator);
-  var s2 = new sortedSet(eltType, false, defaultComparator);
+  var s1 = new sortedSet(eltType, false, new DefaultComparator());
+  var s2 = new sortedSet(eltType, false, new DefaultComparator());
 
   assert(!(s1 > s2));
   assert(!(s2 > s1));

--- a/test/library/packages/SortedSet/general/remove/sSetRemove.chpl
+++ b/test/library/packages/SortedSet/general/remove/sSetRemove.chpl
@@ -6,8 +6,8 @@ use OsetTest;
 config const testIters = 8;
 
 proc doTest(type eltType) {
-  var s1 = new sortedSet(eltType, false, defaultComparator);
-  var s2 = new sortedSet(eltType, false, defaultComparator);
+  var s1 = new sortedSet(eltType, false, new DefaultComparator());
+  var s2 = new sortedSet(eltType, false, new DefaultComparator());
 
   assert(s1.size == s2.size && s1.size == 0);
 

--- a/test/library/packages/SortedSet/general/size/sSetSize.chpl
+++ b/test/library/packages/SortedSet/general/size/sSetSize.chpl
@@ -1,6 +1,6 @@
 use SortedSet;
 
-var oset = new sortedSet(int, false, defaultComparator);
+var oset = new sortedSet(int, false, new DefaultComparator());
 for i in 1..10 {
   oset.add(i);
   writeln(oset.size);

--- a/test/library/packages/SortedSet/general/subset/sSetSubset.chpl
+++ b/test/library/packages/SortedSet/general/subset/sSetSubset.chpl
@@ -7,8 +7,8 @@ config const testIters = 8;
 
 
 proc doTest(type eltType) {
-  var s1 = new sortedSet(eltType, false, defaultComparator);
-  var s2 = new sortedSet(eltType, false, defaultComparator);
+  var s1 = new sortedSet(eltType, false, new DefaultComparator());
+  var s2 = new sortedSet(eltType, false, new DefaultComparator());
 
   assert(s1 <= s2);
   assert(s2 <= s1);

--- a/test/library/packages/SortedSet/general/superset/sSetSuperset.chpl
+++ b/test/library/packages/SortedSet/general/superset/sSetSuperset.chpl
@@ -7,8 +7,8 @@ config const testIters = 8;
 
 
 proc doTest(type eltType) {
-  var s1 = new sortedSet(eltType, false, defaultComparator);
-  var s2 = new sortedSet(eltType, false, defaultComparator);
+  var s1 = new sortedSet(eltType, false, new DefaultComparator());
+  var s2 = new sortedSet(eltType, false, new DefaultComparator());
 
   assert(s1 >= s2);
   assert(s2 >= s1);

--- a/test/library/packages/SortedSet/general/symmetricDifference/sSetSymmetricDifference.chpl
+++ b/test/library/packages/SortedSet/general/symmetricDifference/sSetSymmetricDifference.chpl
@@ -5,9 +5,9 @@ use OsetTest;
 config const testIters = 8;
 
 proc doTest(type eltType) {
-  var s1 = new sortedSet(eltType, false, defaultComparator);
-  var s2 = new sortedSet(eltType, false, defaultComparator);
-  var s3 = new sortedSet(eltType, false, defaultComparator);
+  var s1 = new sortedSet(eltType, false, new DefaultComparator());
+  var s2 = new sortedSet(eltType, false, new DefaultComparator());
+  var s3 = new sortedSet(eltType, false, new DefaultComparator());
 
   assert(s1.size == s2.size && s2.size == s3.size && s3.size == 0);
 

--- a/test/library/packages/SortedSet/general/these/sSetThese.chpl
+++ b/test/library/packages/SortedSet/general/these/sSetThese.chpl
@@ -5,7 +5,7 @@ use OsetTest;
 config const testIters = 8;
 
 proc doTest(type eltType) {
-  var s1 = new sortedSet(eltType, false, defaultComparator);
+  var s1 = new sortedSet(eltType, false, new DefaultComparator());
 
   var count = 0;
 

--- a/test/library/packages/SortedSet/general/toArray/sSetToArray.chpl
+++ b/test/library/packages/SortedSet/general/toArray/sSetToArray.chpl
@@ -5,7 +5,7 @@ use OsetTest;
 config const testIters = 8;
 
 proc doTest(type eltType) {
-  var s1 = new sortedSet(eltType, false, defaultComparator);
+  var s1 = new sortedSet(eltType, false, new DefaultComparator());
 
   assert(s1.size == 0 && s1.isEmpty());
 

--- a/test/library/packages/SortedSet/general/types/OsetTypeTest.chpl
+++ b/test/library/packages/SortedSet/general/types/OsetTypeTest.chpl
@@ -3,7 +3,7 @@ use SortedSet;
 
 
 proc testSet(type t) where isTuple(t) {
-  var s = new sortedSet(t, false, defaultComparator);
+  var s = new sortedSet(t, false, new DefaultComparator());
 
   var x = (new t[0](1), new t[1](2));
 
@@ -19,7 +19,7 @@ proc testSet(type t) where isTuple(t) {
 }
 
 proc testSet(type t) where isBorrowedClass(t) {
-  var s = new sortedSet(t, false, defaultComparator);
+  var s = new sortedSet(t, false, new DefaultComparator());
 
   // create values with 'owned' if t is a borrowed class type
   // (the set will still store borrowed)
@@ -35,7 +35,7 @@ proc testSet(type t) where isBorrowedClass(t) {
 }
 
 proc testSet(type t) {
-  var s = new sortedSet(t, false, defaultComparator);
+  var s = new sortedSet(t, false, new DefaultComparator());
 
   var x = new t(1);
 

--- a/test/library/packages/SortedSet/general/types/testNilableBorrowed.chpl
+++ b/test/library/packages/SortedSet/general/types/testNilableBorrowed.chpl
@@ -12,7 +12,7 @@ operator T.<(lhs: borrowed T?, rhs: borrowed T?) {
   return lhs!.dummy < rhs!.dummy;
 }
 
-var s = new sortedSet(borrowed T?, false, defaultComparator);
+var s = new sortedSet(borrowed T?, false, new DefaultComparator());
 
 var a = new T();
 var b: borrowed T? = a.borrow();

--- a/test/library/packages/SortedSet/general/union/sSetUnion.chpl
+++ b/test/library/packages/SortedSet/general/union/sSetUnion.chpl
@@ -7,10 +7,10 @@ config const testIters = 8;
 
 
 proc doTest(type eltType) {
-  var s1 = new sortedSet(eltType, false, defaultComparator);
-  var s2 = new sortedSet(eltType, false, defaultComparator);
-  var s3 = new sortedSet(eltType, false, defaultComparator);
-  var s4 = new sortedSet(eltType, false, defaultComparator);
+  var s1 = new sortedSet(eltType, false, new DefaultComparator());
+  var s2 = new sortedSet(eltType, false, new DefaultComparator());
+  var s3 = new sortedSet(eltType, false, new DefaultComparator());
+  var s4 = new sortedSet(eltType, false, new DefaultComparator());
 
   assert(s1.size == s2.size && s2.size == s3.size && s3.size == 0);
 

--- a/test/library/packages/SortedSet/general/upperBound/sSetUpperbound.chpl
+++ b/test/library/packages/SortedSet/general/upperBound/sSetUpperbound.chpl
@@ -17,7 +17,7 @@ proc upperBound(arr: [?d] int, target: int, out result:int): bool {
 }
 
 proc doTest(ref arr: [?d] int) {
-  var s1 = new sortedSet(int, false, defaultComparator);
+  var s1 = new sortedSet(int, false, new DefaultComparator());
 
   for x in arr {
     s1.add(x);

--- a/test/library/packages/SortedSet/general/writeThis/sSetWriteThis.chpl
+++ b/test/library/packages/SortedSet/general/writeThis/sSetWriteThis.chpl
@@ -1,6 +1,6 @@
 use SortedSet;
 
-var oset = new sortedSet(int, false, defaultComparator);
+var oset = new sortedSet(int, false, new DefaultComparator());
 for i in 1..3 {
   oset.add(i);
   writeln(oset);

--- a/test/library/standard/Heap/push/heapPush.chpl
+++ b/test/library/standard/Heap/push/heapPush.chpl
@@ -17,5 +17,5 @@ proc rangeTest(comparator) {
   }
 }
 
-rangeTest(defaultComparator);
+rangeTest(new DefaultComparator());
 rangeTest(reverseComparator);

--- a/test/unstable/sortRegion.chpl
+++ b/test/unstable/sortRegion.chpl
@@ -2,5 +2,5 @@ use Sort;
 
 var A:[1..10] int = 1..10 by -1;
 
-sort(A, defaultComparator, 2..5);
+sort(A, new DefaultComparator(), 2..5);
 assert(&& reduce (A == [10, 6, 7, 8, 9, 5, 4, 3, 2, 1]));


### PR DESCRIPTION
Related to #25552 

As part of stabilizing the Sort module, we've decided to deprecate the module-scoped variable `defaultComparator`, in part due to a desire to use its name for the name of the type.  This PR implements that decision.

Replaces all references to the deprecated variable with the creation of new instances of the `DefaultComparator` type.

There were four modules that re-exported this symbol, and as such were encountering deprecation messages on their `use` statement:
- Heap
- Search
- SortedSet
- SortedMap

For now, replace those limited use statements with a more broad `use` of the module, and add a note to their documentation indicating which re-exported symbols can be relied on and which will be removed again once the deprecation is removed.

Additionally, makes some references into links and fixes a typo in the SortedMap documentation while I was here.

Adds a test of the deprecation warning for the symbol in Sort, as well as for the re-exported access of it from the aforementioned modules.

Updates various tests to avoid the deprecation warnings.

Passed a full paratest with futures, and spot checked the documentation and documentation links for some of the changes made.