### PR TITLE
Minor cleanups to the subprocess record

### DIFF
--- a/modules/standard/Subprocess.chpl
+++ b/modules/standard/Subprocess.chpl
@@ -210,7 +210,6 @@ module Subprocess {
      generally not needed since the channels will be closed when the
      subprocess record is automatically destroyed.
    */
-  pragma "ignore deprecated use"
   record subprocess {
     /* used to create the types for any channels that are necessary. */
     param locking:bool;

--- a/modules/standard/Subprocess.chpl
+++ b/modules/standard/Subprocess.chpl
@@ -211,7 +211,8 @@ module Subprocess {
      subprocess record is automatically destroyed.
    */
   record subprocess {
-    /* used to create the types for any channels that are necessary. */
+    /* used to create the types for any fileReaders/fileWriters that are
+       necessary. */
     param locking:bool;
 
     @chpldoc.nodoc


### PR DESCRIPTION
Removes an old pragma and updates a reference to `channel` to be `fileReader`/`fileWriter` instead.

It looks like the pragma was added when the `kind` field was getting deprecated, but we forgot to remove it when the deprecated field was removed.  Rectify that oversight so we don't accidentally sweep future issues under the rug

Passed a full paratest with futures