### PR TITLE
Avoid using `head` for skipif for hipcc.

### DIFF
--- a/test/gpu/native/distArray/SKIPIF
+++ b/test/gpu/native/distArray/SKIPIF
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if $CHPL_HOME/util/printchplenv --simple | grep -q "CHPL_GPU=amd"; then
-  if hipcc --version | head -n1 | grep -q "HIP version: 4"; then
+  if hipcc --version | grep -q "HIP version: 4"; then
     echo 1
   else
     echo 0

--- a/test/gpu/native/reduction/SKIPIF
+++ b/test/gpu/native/reduction/SKIPIF
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if $CHPL_HOME/util/printchplenv --simple | grep -q "CHPL_GPU=amd"; then
-  if hipcc --version | head -n1 | grep -q "HIP version: 4"; then
+  if hipcc --version | grep -q "HIP version: 4"; then
     echo 1
   else
     echo 0

--- a/test/gpu/native/remote-bulk-transfers-par.skipif
+++ b/test/gpu/native/remote-bulk-transfers-par.skipif
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if $CHPL_HOME/util/printchplenv --simple | grep -q "CHPL_GPU=amd"; then
-  if hipcc --version | head -n1 | grep -q "HIP version: 4"; then
+  if hipcc --version | grep -q "HIP version: 4"; then
     echo 1
   else
     echo 0


### PR DESCRIPTION
Apparently, hipcc behaves oddly when its output is piped into `head`. Piping the output into grep -- which should still work -- should still work, and doesn't cause the same odd hipcc error.

Trivial, will not be reviewed.

## Testing
- [x] skipif works on machine with ROCm 5
- [x] skipif works on machine with ROCm 4