### PR TITLE
Start using lustre dependencies for Arkouda XC testing

### DIFF
--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -30,9 +30,13 @@ if ! git clone --depth=1 ${ARKOUDA_URL} --branch=${ARKOUDA_BRANCH} ; then
 fi
 cd ${ARKOUDA_HOME}
 
-# Install dependencies
-if ! nice make -j $($CHPL_HOME/util/buildRelease/chpl-make-cpu_count) install-deps ; then
+# Install dependencies if needed
+if make check-deps 2>/dev/null ; then
   export ARKOUDA_SKIP_CHECK_DEPS=true
+else
+  if ! nice make -j $($CHPL_HOME/util/buildRelease/chpl-make-cpu_count) install-deps ; then
+    log_fatal_error "installing dependencies"
+  fi
 fi
 export "PATH=${ARKOUDA_HOME}/dep/hdf5-install/bin:$PATH"
 

--- a/util/cron/common-arkouda.bash
+++ b/util/cron/common-arkouda.bash
@@ -25,9 +25,12 @@ fi
 export CHPL_NIGHTLY_TEST_DIRS=studies/arkouda/
 export CHPL_TEST_ARKOUDA=true
 
-# Temporary bandaid, revert after hpcdc issues resolved
 # HPCDC doesn't seem to be accessible to compute nodes at the moment
-ARKOUDA_DEP_DIR=$COMMON_DIR/arkouda-deps
+# so we made a mirror on lustre where compute nodes can access
+ARKOUDA_DEP_DIR=/lus/scratch/chapelu/arkouda-deps
+if [ ! -d "$COMMON_DIR" ]; then
+  ARKOUDA_DEP_DIR=$COMMON_DIR/arkouda-deps
+fi
 if [ -d "$ARKOUDA_DEP_DIR" ]; then
   export ARKOUDA_ARROW_PATH=${ARKOUDA_ARROW_PATH:-$ARKOUDA_DEP_DIR/arrow-install}
   export ARKOUDA_ZMQ_PATH=${ARKOUDA_ZMQ_PATH:-$ARKOUDA_DEP_DIR/zeromq-install}

--- a/util/cron/common-arkouda.bash
+++ b/util/cron/common-arkouda.bash
@@ -28,7 +28,7 @@ export CHPL_TEST_ARKOUDA=true
 # HPCDC doesn't seem to be accessible to compute nodes at the moment
 # so we made a mirror on lustre where compute nodes can access
 ARKOUDA_DEP_DIR=/lus/scratch/chapelu/arkouda-deps
-if [ ! -d "$COMMON_DIR" ]; then
+if [ ! -d "$ARKOUDA_DEP_DIR" ]; then
   ARKOUDA_DEP_DIR=$COMMON_DIR/arkouda-deps
 fi
 if [ -d "$ARKOUDA_DEP_DIR" ]; then


### PR DESCRIPTION
While we wait for HPCDC to be accessible via the XC compute nodes, we are working around that issue with a mirror of the dependencies installed on the lustre filesystem, which is accessible to the compute nodes. If the lustre filesystem doesn't exist, we will continue to use the old dependencies (for single-node testing).