### PR TITLE
Fix a line no propagation bug with `--gpu-specialization`

### DIFF
--- a/compiler/passes/insertLineNumbers.cpp
+++ b/compiler/passes/insertLineNumbers.cpp
@@ -303,6 +303,9 @@ LineAndFile InsertLineNumbers::getLineAndFileForFn(FnSymbol *fn) {
     DefExpr* bundleArg = toDefExpr(fn->formals.tail);
     AggregateType* bundleType = toAggregateType(bundleArg->sym->typeInfo());
 
+    // lineField could have been created already. Today we see this only with
+    // --gpu-specialization, which can clone `coforall_fn`s while using the same
+    // arg bundle for both clones. We want to create lineField only once.
     VarSymbol* lineField = getOrCreateField(bundleType, "_ln",
                                             dtInt[INT_SIZE_DEFAULT]);
     VarSymbol* lineLocal = newTemp("_ln", dtInt[INT_SIZE_DEFAULT]);
@@ -313,6 +316,7 @@ LineAndFile InsertLineNumbers::getLineAndFileForFn(FnSymbol *fn) {
 
     // Same thing, just for the filename index now.
 
+    // See the comment above lineField.
     VarSymbol* fileField = getOrCreateField(bundleType, "_fn",
                                             dtInt[INT_SIZE_32]);
     VarSymbol* fileLocal = newTemp("_fn", dtInt[INT_SIZE_32]);


### PR DESCRIPTION
With https://github.com/chapel-lang/chapel/pull/24511 merged, we started to propagate line/file numbers for kernels correctly. But that exposed an issue that occurs with `--gpu-specialization` which showed up as junk source code location with verbose GPU.

The problem is a bit complicated. When calling `coforall_fn`s and other similar task functions, we bundle arguments into structs. We call these "arg bundles". Historically, (and currently by default) we have an arg bundle per `coforall_fn`. The pass insertLineNumbers (ILN) relies on this fact when propagating line/file numbers. That means when it starts processing a `coforall_fn`, it first adds `_ln` and `_fn` fields to that function's arg bundle. This works fine because ILN doesn't visit the same function twice.

With `--gpu-specialization` we can clone `coforall_fn`s. In which case, we don't clone their arg bundle types. This makes sense, however, breaks the assumption above. So, when ILN visits a gpu-specialized coforall_fn clone for the first time, it adds `_ln` and `_fn` fields blindly. However, non-specialized version has already been visited at this point and the arg bundle already contains `_ln` and `_fn` fields. Furthermore, it uses this newly added fields in the specialized `coforall_fn`s body, whereas it uses `getField("_ln")` to find fields before calling the function, which happens to return the first field with the given name, which is _not_ the same as the new one that's just added and used by the coforall_fn. In short, we end up having redundant fields, and use different copies in different places.

This PR makes ILN check for `_ln` and `_fn` fields before creating them.

Test:
- [x] standard linux64
- [x] nvidia
- [x] amd with `--gpu-specialization`