### PR TITLE
Stencil Distribution performance improvments

### DIFF
--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -1973,17 +1973,16 @@ proc StencilArr.naiveUpdateFluff() {
 //    c) Copy elements from the local buffer into the cache
 //
 proc StencilArr._packedUpdate() {
+  const mypid = this.pid;
   coforall i in dom.dist.targetLocDom {
     on dom.dist.targetLocales(i) {
-      var myLocDom = locArr[i].locDom;
+      const privArr = if _privatization then chpl_getPrivatizedCopy(this.type, mypid) else this;
+      var myLocDom = privArr.locArr[i].locDom;
 
       proc translateIdx(idx) {
         return -1 * chpl__tuplify(idx);
       }
 
-      // BHARSH TODO: can we fuse these two foralls? My current concern is that
-      // by waiting we might prevent another iteration running and possibly
-      // find ourselves in a deadlock.
       forall (D, S, recvIdx, sendBufIdx) in zip(myLocDom.sendDest, myLocDom.sendSrc,
                                                 myLocDom.Neighs,
                                                 myLocDom.NeighDom) {
@@ -1995,19 +1994,18 @@ proc StencilArr._packedUpdate() {
             const recvBufIdx = translateIdx(sendBufIdx);
 
             // Pack the buffer
-            //
-            // TODO: Should we have a serialization helper for N-dimensional
-            // DefaultRectangulars into 1-dimension arrays?
-            ref src = locArr[i].myElems[S];
-            ref buf = locArr[i].sendBufs[sendBufIdx];
-            local do for (s, i) in zip(src, buf.domain.first..#src.sizeAs(int)) do buf[i] = s;
+            ref src = privArr.locArr[i].myElems;
+            ref buf = privArr.locArr[i].sendBufs[sendBufIdx];
+
+            // TODO: parallelize for larger buffers? Other forms for this loop?
+            local do for (si, i) in zip(S, buf.domain.first..#src.sizeAs(int)) do buf[i] = src[si];
 
             if debugStencilDist then
               writeln("Filled ", here, ".", S, " for ", dom.dist.targetLocales(recvIdx), "::", recvBufIdx);
-            locArr[recvIdx].sendRecvFlag[recvBufIdx].write(true);
+            privArr.locArr[recvIdx].sendRecvFlag[recvBufIdx].write(true);
           } else {
             // 'naive' update
-            locArr[recvIdx].myElems[D] = locArr[i].myElems[S];
+            privArr.locArr[recvIdx].myElems[D] = privArr.locArr[i].myElems[S];
           }
         }
       }
@@ -2023,14 +2021,17 @@ proc StencilArr._packedUpdate() {
           const srcBufIdx = translateIdx(recvBufIdx);
           if debugStencilDist then
             writeln(here, "::", recvBufIdx, " WAITING");
-          locArr[i].sendRecvFlag[recvBufIdx].waitFor(true); // Can we read yet?
-          locArr[i].sendRecvFlag[recvBufIdx].write(false);  // reset for next call
 
-          locArr[i].recvBufs[recvBufIdx][1..D.sizeAs(int)] = locArr[srcIdx].sendBufs[srcBufIdx][1..D.sizeAs(int)];
+          privArr.locArr[i].sendRecvFlag[recvBufIdx].waitFor(true); // Can we read yet?
+          privArr.locArr[i].sendRecvFlag[recvBufIdx].write(false);  // reset for next call
 
-          ref dest = locArr[i].myElems[D];
-          ref buf = locArr[i].recvBufs[recvBufIdx];
-          local do for (d, i) in zip(dest, buf.domain.first..#dest.sizeAs(int)) do d = buf[i];
+          privArr.locArr[i].recvBufs[recvBufIdx][1..D.sizeAs(int)] = privArr.locArr[srcIdx].sendBufs[srcBufIdx][1..D.sizeAs(int)];
+
+          // unpack buffer
+          ref dest = privArr.locArr[i].myElems;
+          ref buf = privArr.locArr[i].recvBufs[recvBufIdx];
+
+          local do for (di, i) in zip(D, buf.domain.first..#dest.sizeAs(int)) do dest[di] = buf[i];
         }
       }
     }
@@ -2281,8 +2282,12 @@ proc StencilArr.dsiLocalSubdomain(loc: locale) {
 proc StencilDom.dsiLocalSubdomain(loc: locale) {
   const (gotit, locid) = dist.chpl__locToLocIdx(loc);
   if (gotit) {
-    var inds = chpl__computeBlock(locid, dist.targetLocDom, dist.boundingBox);
-    return whole[(...inds)];
+    if loc == here {
+      return locDoms[locid].myBlock;
+    } else {
+      var inds = chpl__computeBlock(locid, dist.targetLocDom, dist.boundingBox);
+      return whole[(...inds)];
+    }
   } else {
     var d: domain(rank, idxType, strides);
     return d;

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -1994,11 +1994,11 @@ proc StencilArr._packedUpdate() {
             const recvBufIdx = translateIdx(sendBufIdx);
 
             // Pack the buffer
-            ref src = privArr.locArr[i].myElems;
+            ref src = privArr.locArr[i].myElems[S];
             ref buf = privArr.locArr[i].sendBufs[sendBufIdx];
 
             // TODO: parallelize for larger buffers? Other forms for this loop?
-            local do for (si, i) in zip(S, buf.domain.first..#src.sizeAs(int)) do buf[i] = src[si];
+            local do for (s, i) in zip(src, buf.domain.first..#src.sizeAs(int)) do buf[i] = s;
 
             if debugStencilDist then
               writeln("Filled ", here, ".", S, " for ", dom.dist.targetLocales(recvIdx), "::", recvBufIdx);
@@ -2028,10 +2028,10 @@ proc StencilArr._packedUpdate() {
           privArr.locArr[i].recvBufs[recvBufIdx][1..D.sizeAs(int)] = privArr.locArr[srcIdx].sendBufs[srcBufIdx][1..D.sizeAs(int)];
 
           // unpack buffer
-          ref dest = privArr.locArr[i].myElems;
+          ref dest = privArr.locArr[i].myElems[D];
           ref buf = privArr.locArr[i].recvBufs[recvBufIdx];
 
-          local do for (di, i) in zip(D, buf.domain.first..#dest.sizeAs(int)) do dest[di] = buf[i];
+          local do for (d, i) in zip(dest, buf.domain.first..#dest.sizeAs(int)) do d = buf[i];
         }
       }
     }


### PR DESCRIPTION
Reduce the amount of fine-grained communication incurred by `stencilArr.updateFluff` using privitization.

To give an idea of the performance benefits of this PR, the following table shows the runtime improvements on a navier-stokes simulation that uses the stencil distribution with a few different problem sizes:

| problem size | main (sec) | this branch (sec) |
| :--- | :--- | :--- |
| 1024^2 | 9.0031 | 8.23441 |
| 2048^2 | 11.3919 | 8.9551 |
| 4096^2 | 22.3191 | 19.6735 |

I also tested a few other changes to `updateFluff` on the same navier-stokes benchmark. All of these either hurt performance or didn't result in a noticeable improvement:
* using puts instead of gets for the buffer assignment
* using a barrier instead of atomic synchronization
* parallelizing the buffer packing/unpacking
* copying the entire buffers instead of a slice of the first `D` elements

- [x] gasnet paratest