### PR TITLE
support ref intent on scalars for gpuized foreach loops

### DIFF
--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -1319,7 +1319,10 @@ KernelArg::KernelArg(Symbol* symInLoop, GpuKernel* kernel, bool isCompilerGenera
 
   if (isRefIntentScalarArg)
   {
-    this->kind_ = GpuArgKind::ADDROF | GpuArgKind::HOST_REGISTER;
+    this->kind_ = GpuArgKind::HOST_REGISTER;
+    if(!symInLoop->isRef()) {
+      this->kind_ |= GpuArgKind::ADDROF;
+    }
     kernel->incNumHostRegisteredVars();
   } else if (isClass(symValType) ||
       (!symInLoop->isRef() && !isAggregateType(symValType))) {

--- a/compiler/optimizations/refPropagation.cpp
+++ b/compiler/optimizations/refPropagation.cpp
@@ -269,6 +269,10 @@ size_t singleAssignmentRefPropagation(FnSymbol* fn) {
   for_vector(BaseAST, ast, asts) {
     if (VarSymbol* var = toVarSymbol(ast)) {
       if (var->isRef()) {
+        if(var->hasFlag(FLAG_EXEMPT_REF_PROPAGATION)) {
+          continue;
+        }
+
         refVec.add(var);
         refSet.set_add(var);
       }

--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -778,7 +778,7 @@ static void resolveShadowVarTypeIntent(LoopWithShadowVarsInterface* fs,
   }
 
   // Prune, as discussed in the above comment.
-  if (intent == TFI_REF)
+  if (intent == TFI_REF && fs->isForallStmt())
     prune = true;
 }
 

--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -778,6 +778,12 @@ static void resolveShadowVarTypeIntent(LoopWithShadowVarsInterface* fs,
   }
 
   // Prune, as discussed in the above comment.
+  //
+  // However, for foreach, we do not want to prune (replace a ref intent'd
+  // shadow variable with its definition outside the loop) because if the loop
+  // is gpuized we need to pass that variable by pointer. We do special
+  // processing to handle this case in iterator lowering and gpu transforms and
+  // as such do not want to prematurely prune it.
   if (intent == TFI_REF && fs->isForallStmt())
     prune = true;
 }

--- a/frontend/include/chpl/uast/PragmaList.h
+++ b/frontend/include/chpl/uast/PragmaList.h
@@ -654,6 +654,7 @@ PRAGMA(COMPUTE_UNIFIED_TYPE_HELP, ypr, "compute unified type helper", "identify 
 PRAGMA(DO_NOT_RESOLVE_UNLESS_CALLED, npr, "do not resolve unless called", "do not resolve this function unless it is called (e.g. if it contains only compilerError)")
 PRAGMA(TASK_PRIVATE_VARIABLE, npr, "task private variable", ncm)
 PRAGMA(TFI_BORROW_TEMP, npr, "temporary for storing borrow of a shadow var", ncm)
+PRAGMA(EXEMPT_REF_PROPAGATION, npr, "exempt variable from ref propagation", ncm)
 
 #undef ypr
 #undef npr

--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -715,10 +715,10 @@ void chpl_gpu_arg_reduce(void* _cfg, void* arg, size_t elem_size,
 void chpl_gpu_arg_host_register(void* _cfg, void* arg, size_t size) {
   kernel_cfg* cfg = (kernel_cfg*)_cfg;
 
-  void *dev_arg = chpl_gpu_impl_host_register(*((void**)arg), size);
+  void *dev_arg = chpl_gpu_impl_host_register(arg, size);
   *(cfg->host_registered_vars[cfg->cur_host_registered_var]) = dev_arg;
   cfg_add_direct_param(cfg, cfg->host_registered_vars[cfg->cur_host_registered_var]);
-  cfg->host_registered_vars_host_ptrs[cfg->cur_host_registered_var] = *((void**)arg);
+  cfg->host_registered_vars_host_ptrs[cfg->cur_host_registered_var] = arg;
   cfg->cur_host_registered_var += 1;
   CHPL_GPU_DEBUG("\tAdded ref intent param (at %d): %p\n", cfg->cur_param,  dev_arg);
 }

--- a/test/gpu/native/intents/foreach_refIntentScalar.future
+++ b/test/gpu/native/intents/foreach_refIntentScalar.future
@@ -1,2 +1,0 @@
-bug
-ref intent'd scalars should be host registered and passed to gpu kernel by ref


### PR DESCRIPTION
This PR enables the following future to work:

```chpl
on here.gpus[0] {
  var x = 1;
  writeln("Before loop x = ", x);
  @assertOnGpu
  foreach 0..0 with (ref x) do x = 2;
  writeln("After loop x = ", x);
}
```

It now print `After loop x = 2` where before it printed `x = 1`.

As far as implementation:

The gpuized loop needs to have `x` passed in as a pointer so we can do a direct-memory-access from the GPU to RAM. To ensure this happens when we outline the loop body, we rewrite `ref` intents passed to foreach like this during iterator lowering:

```chpl
foreach 0..0 with (ref x) do x = 2;
```

To:

```chpl
ref ref_x = x;
foreach 0..0 with (ref ref_x) do ref_x = 2;
```

**TODO**
- [x] Paratest nvidia
- [x] Paratest AMD