### PR TITLE
Dyno: Fix erroneous error when resolving forwarded method on class value

### DIFF
--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -944,6 +944,12 @@ void CallInitDeinit::handleInFormal(const FnCall* ast, const AstNode* actual,
   // check for use of deinited variables
   processMentions(actual, rv);
 
+  if (auto t = formalType.type()) {
+    if (auto ct = t->toClassType()) {
+      if (ct->decorator().isBorrowed()) return;
+    }
+  }
+
   // compute the actual type
   QualifiedType actualType = rv.byAst(actual).type();
 

--- a/frontend/test/resolution/testCallInitDeinit.cpp
+++ b/frontend/test/resolution/testCallInitDeinit.cpp
@@ -1667,6 +1667,46 @@ static void test21() {
       )""", {} );
 }
 
+static void test22() {
+  // Make sure that call-init-deinit doesn't try to process an initialization
+  // by mistakenly passing 'R' to 'helper' instead of passing the forwarded
+  // value 'R.c'
+  testActions("test22",
+      R"""(
+      module M {
+        // call-init-deinit wants this to transmute R.c into the reciever of C.helper
+        operator =(ref lhs: borrowed C, rhs: unmanaged C) {
+        }
+
+        class C {
+          var x : int;
+
+          proc helper() {
+            return x;
+          }
+        }
+
+        record R {
+          var c = new unmanaged C(5);
+
+          forwarding c;
+
+          proc wrapper() {
+            return this.helper();
+          }
+        }
+
+        proc test() {
+          var r : R;
+          var x = r.wrapper();
+        }
+      }
+      )""", {
+        {AssociatedAction::DEFAULT_INIT, "r",          ""},
+        {AssociatedAction::DEINIT,       "M.test@6",   "r"}
+      });
+}
+
 // calling function with 'out' intent formal
 
 // calling functions with 'inout' intent formal
@@ -1755,6 +1795,8 @@ int main() {
   test20c();
 
   test21();
+
+  test22();
 
   return 0;
 }


### PR DESCRIPTION
Previously, CallInitDeinit::handleInFormal would attempt to resolve an assignment function even if the receiver was a borrowed class. This resulted in a failure when trying to resolve a forwarded call when the corresponding actual was not a class. For example, in the following program:

```chpl

class C {
  var x : int;

  proc helper() {
    return x;
  }
}

record R {
  var c = new unmanaged C(5);

  forwarding c;

  proc wrapper() {
    return this.helper(); // HERE!
  }
}

proc main() {
  var r : R;
  var x = r.wrapper();
}
```

We would encounter the error:

```
─── error in bar.chpl:16 [NoMatchingCandidates] ───
  Unable to resolve call to '=': no matching candidates.
       |
    16 |     return this.helper();
       |
```

This was because CallInitDeinit was incorrectly trying to resolve assignment between ``R`` and a ``borrowed C``.