### PR TITLE
Improve sync deprecation message with `<=>`

### DIFF
--- a/modules/internal/ChapelSyncvar.chpl
+++ b/modules/internal/ChapelSyncvar.chpl
@@ -422,26 +422,25 @@ module ChapelSyncvar {
 
   proc chpl__readXX(const ref x : _syncvar(?)) do return x.readXX();
 
-  @chpldoc.nodoc
-  operator <=>(lhs : _syncvar, ref rhs) {
-    const tmp = lhs;
-
-    lhs = rhs;
-    rhs = tmp;
-  }
-
-  @chpldoc.nodoc
-  operator <=>(ref lhs, rhs : _syncvar) {
-    const tmp = lhs;
-
-    lhs = rhs;
+    @chpldoc.nodoc
+  @deprecated(notes="Swapping 'sync' variables is deprecated; perform the swap manually using explicit '.read??'/'.write??' methods")
+  operator <=>(ref lhs : _syncvar, ref rhs) {
+    const tmp = lhs.readFE();
+    lhs.writeEF(rhs);
     rhs = tmp;
   }
 
   @chpldoc.nodoc
   @deprecated(notes="Swapping 'sync' variables is deprecated; perform the swap manually using explicit '.read??'/'.write??' methods")
-  operator <=>(lhs : _syncvar, rhs : _syncvar) {
+  operator <=>(ref lhs, ref rhs : _syncvar) {
+    const tmp = lhs;
+    lhs = rhs.readFE();
+    rhs.writeEF(tmp);
+  }
 
+  @chpldoc.nodoc
+  @deprecated(notes="Swapping 'sync' variables is deprecated; perform the swap manually using explicit '.read??'/'.write??' methods")
+  operator <=>(ref lhs : _syncvar, ref rhs : _syncvar) {
     const tmp = lhs.readFE();
     lhs.writeEF(rhs.readFE());
     rhs.writeEF(tmp);

--- a/test/deprecated/swapSync.chpl
+++ b/test/deprecated/swapSync.chpl
@@ -1,0 +1,18 @@
+{
+  var a: int = 1;
+  var b: sync int = 2;
+  a <=> b;
+  writeln((a, b.readFF()));
+}
+{
+  var a: sync int = 1;
+  var b: int = 2;
+  a <=> b;
+  writeln((a.readFF(), b));
+}
+{
+  var a: sync int = 1;
+  var b: sync int = 2;
+  a <=> b;
+  writeln((a.readFF(), b.readFF()));
+}

--- a/test/deprecated/swapSync.good
+++ b/test/deprecated/swapSync.good
@@ -1,0 +1,6 @@
+swapSync.chpl:4: warning: Swapping 'sync' variables is deprecated; perform the swap manually using explicit '.read??'/'.write??' methods
+swapSync.chpl:10: warning: Swapping 'sync' variables is deprecated; perform the swap manually using explicit '.read??'/'.write??' methods
+swapSync.chpl:16: warning: Swapping 'sync' variables is deprecated; perform the swap manually using explicit '.read??'/'.write??' methods
+(2, 1)
+(2, 1)
+(2, 1)


### PR DESCRIPTION
Improves the deprecation message when users used `<=>` on a sync and a non-sync type.

Prior to this PR, users would get deprecation warnings from the implementation of `<=>`, now they get the correct deprecation warning about `<=>`

- [ ] test with a full paratest with/without comm