### PR TITLE
Nightly test failure fix: allow pruning nonscalar ref syms on foreach loop

### DIFF
--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -779,13 +779,14 @@ static void resolveShadowVarTypeIntent(LoopWithShadowVarsInterface* fs,
 
   // Prune, as discussed in the above comment.
   //
-  // However, for foreach, we do not want to prune (replace a ref intent'd
-  // shadow variable with its definition outside the loop) because if the loop
-  // is gpuized we need to pass that variable by pointer. We do special
-  // processing to handle this case in iterator lowering and gpu transforms and
-  // as such do not want to prematurely prune it.
-  if (intent == TFI_REF && fs->isForallStmt())
+  // However, for scalars passed to foreach, we do not want to prune (replace a
+  // ref intent'd shadow variable with its definition outside the loop) because
+  // if the loop is gpuized we need to pass that variable by pointer. We do
+  // special processing to handle this case in iterator lowering and gpu
+  // transforms and as such do not want to prematurely prune it.
+  if (intent == TFI_REF && (fs->isForallStmt() || !isPrimitiveScalar(type))) {
     prune = true;
+  }
 }
 
 /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
After merging https://github.com/chapel-lang/chapel/pull/25704 we're seeing failures on `functions/deitz/iterators.test_var_iter_in_iter` and `functions/iterators/diten.arrEltIter` as well as several tests under `performance/ferguson/...`. (I ran gpu paratests but failed to run non-gpu paratests so didn't catch this earlier).

If I undo a change from that PR to re-enable pruning of `ref` intent'd shadow variables the tests pass again. For these particular tests the variables of interest are non-scalar, and for the purposes of processing ref intent'd variables with gpuized loops I only need these shadow variables to remain for scalars.

That being the case, I've tighten the exemption to pruning to only apply to ref intent'd shadow variables on non forall loops that are scalar.

**TODO**:
- [ ] Paratest
- [ ] Paratest gasnet
- [ ] Paratest NVIDIA
- [ ] Paratest AMD