### PR TITLE
fix failing test (introduced in prior PR): add FLAG_REV_VAR to ref made for ref'd foreach intents

### DIFF
--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -1665,6 +1665,7 @@ static void processShadowVariables(ForLoop* forLoop, SymbolMap *map) {
           VarSymbol* refVar = new VarSymbol(
             astr("ref_", svar->name), svar->type->getRefType());
           refVar->addFlag(FLAG_EXEMPT_REF_PROPAGATION);
+          refVar->addFlag(FLAG_REF_VAR);
           forLoop->insertBefore(new DefExpr(refVar));
           forLoop->insertBefore(new CallExpr(
             PRIM_MOVE, refVar, new CallExpr(


### PR DESCRIPTION
#25704 introduced a bug where under the following:

- Doing a non COMM=none build
- `--no-live-analysis` passed at compile time
- Passing `--memTrack` at runtime

We would see any Chapel program fail at runtime. For our nightly tests this occurs with `library/standard/MemMove/setRTTypeBaseline` but I can repro with a simple "hello world" Chapel program.

Investigating I discovered:

- #25704 introduces a new `ref` variable for `ref` intent'd variables passed to `foreach` loop.
- It looks like when passing `--memTrack` we have such a foreach loop (really the `chpl_bytes` iterator in `String`) and when passing `--no-liveness-analysis`
- In `Iterator.cpp` there's a pass that collects the local variables in some iterator (I guess to package them in a record?) and the way this is conducted depends on whether or not liveness analysis is enabled.
- If liveness analysis is disabled then during this collection process we do not collect a variable who's type has `FLAG_REF` unless the variable of the type also has `FLAG_REF_VAR`.
- The lack of this collection happening for the `ref` we introduce in the first bullet is causing our runtime segfault.

I'm confused by this last point. But nevertheless it seems like the right thing to do is make the `ref` introduced for a `ref` intent'd `foreach` variable have the `FLAG_REF_VAR` flag. If I do that the bug seems to go away.

I have no idea why this bug seems to only occur w/ gasnet builds.

**TODO**
- [x] Paratest
- [x] Paratest gasnet
- [x] Paratest NVIDIA
- [x] Paratest AMD