### PR TITLE
Expand Image module with new functions

### DIFF
--- a/modules/packages/Image.chpl
+++ b/modules/packages/Image.chpl
@@ -434,7 +434,7 @@ module Image {
           (idx[1]-radius1)..#(d1.dim(1).size)
         };
       }
-      otherwise do halt("unsupported corner type");
+      otherwise do halt("unsupported cornerType");
     }
 
     select merge {
@@ -444,7 +444,7 @@ module Image {
       when mergeMethod.add {
         base[pasteDom] = other | base[pasteDom];
       }
-      otherwise do halt("unsupported merge method");
+      otherwise do halt("unknown mergeMethod");
     }
 
   }


### PR DESCRIPTION
Adds new functions to the Image module to support more use cases for users.

Changes and improvements to this PR:
- adds a `shuffleColors` to rearrange an array of colors
- adds a `concatImage` to concat two images to make one bigger image
- adds a `pasteInto` to add two images together
- improves error messages from `mediaPipe` and reduces its verbosity
- adds bounds checking to `scale`


TODO: add missing doc strings
TODO: add tests for new features

[Reviewed by @]