### PR TITLE
Remove call to `setup_cmake_nightly.bash` in `setenv-xc-x86_64.bash`

### DIFF
--- a/util/build_configs/cray-internal/setenv-xc-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-x86_64.bash
@@ -104,11 +104,6 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
         $CHPL_HOME/util/printchplenv --all --no-tidy --anonymize || echo >&2 ignore error
     fi
 
-    # Load a more recent cmake version. Required for building LLVM 12 or newer.
-    if [ -f /hpcdc/project/chapel/setup_cmake_nightly.bash ] ; then
-      source /hpcdc/project/chapel/setup_cmake_nightly.bash
-    fi
-
     # NOTE: The --target-compiler values used in this setenv project will never be
     #       seen by Chapel make. They will be recognized (and discarded) in the
     #       setenv callback script in the lower section of this file.


### PR DESCRIPTION
`setup_cmake_nightly.bash` gives a non-working CMake on Atlas, where this script is used in nightly testing. But Atlas already loads a working CMake from the new Spack install setup, which is replaced by this one, so just stop replacing it.

[reviewer info placeholder]