### PR TITLE
Fixes Zarr Failure for Linux32 Config

### DIFF
--- a/modules/packages/Zarr.chpl
+++ b/modules/packages/Zarr.chpl
@@ -303,7 +303,7 @@ module Zarr {
     // Compress the chunk's data
     if zarrProfiling then s.restart();
     var bytesCompressed = blosc_compress_ctx(_bloscLevel, 0, c_sizeof(t),
-                                             copyOut.size*c_sizeof(t), c_ptrTo(copyOut),
+                                             (copyOut.size*c_sizeof(t)) : c_size_t, c_ptrTo(copyOut),
                                              compressedBuffer, ((copyOut.size + 16) * c_sizeof(t)) : c_size_t,
                                              "blosclz", 0 : c_size_t, 1 : c_size_t);
     if bytesCompressed == 0 then

--- a/modules/packages/Zarr.chpl
+++ b/modules/packages/Zarr.chpl
@@ -297,7 +297,7 @@ module Zarr {
 
     // Create buffer for compressed bytes
     if zarrProfiling then s.restart();
-    var compressedBuffer = allocate(t, copyOut.size + 16);
+    var compressedBuffer = allocate(t, (copyOut.size + 16): c_size_t );
     if zarrProfiling then times["Creating Compressed Buffer"].add(s.elapsed());
 
     // Compress the chunk's data

--- a/modules/packages/Zarr.chpl
+++ b/modules/packages/Zarr.chpl
@@ -241,7 +241,7 @@ module Zarr {
     if zarrProfiling then times["Initializing copyIn"].add(s.elapsed());
 
     if zarrProfiling then s.restart();
-    var numRead = blosc_decompress_ctx(compressedChunk.c_str(), c_ptrTo(copyIn), copyIn.size*c_sizeof(t), 1);
+    var numRead = blosc_decompress_ctx(compressedChunk.c_str(), c_ptrTo(copyIn), copyIn.size*c_sizeof(t) : c_size_t, 1: c_int);
     if numRead <= 0 {
       throw new Error("Failed to decompress data from %?. Blosc error code: %?".format(chunkPath, numRead));
     }
@@ -304,8 +304,8 @@ module Zarr {
     if zarrProfiling then s.restart();
     var bytesCompressed = blosc_compress_ctx(_bloscLevel, 0, c_sizeof(t),
                                              copyOut.size*c_sizeof(t), c_ptrTo(copyOut),
-                                             compressedBuffer, (copyOut.size + 16) * c_sizeof(t),
-                                             "blosclz", 0, 1);
+                                             compressedBuffer, (copyOut.size + 16) * c_sizeof(t) : c_size_t,
+                                             "blosclz", 0 : c_size_t, 1 : c_size_t);
     if bytesCompressed == 0 then
       throw new Error("Failed to compress bytes");
     if zarrProfiling then times["Compression"].add(s.elapsed());

--- a/modules/packages/Zarr.chpl
+++ b/modules/packages/Zarr.chpl
@@ -297,7 +297,7 @@ module Zarr {
 
     // Create buffer for compressed bytes
     if zarrProfiling then s.restart();
-    var compressedBuffer = allocate(t, (copyOut.size + 16): c_size_t );
+    var compressedBuffer = allocate(t, (copyOut.size + 16): c_size_t);
     if zarrProfiling then times["Creating Compressed Buffer"].add(s.elapsed());
 
     // Compress the chunk's data

--- a/modules/packages/Zarr.chpl
+++ b/modules/packages/Zarr.chpl
@@ -241,7 +241,7 @@ module Zarr {
     if zarrProfiling then times["Initializing copyIn"].add(s.elapsed());
 
     if zarrProfiling then s.restart();
-    var numRead = blosc_decompress_ctx(compressedChunk.c_str(), c_ptrTo(copyIn), copyIn.size*c_sizeof(t) : c_size_t, 1: c_int);
+    var numRead = blosc_decompress_ctx(compressedChunk.c_str(), c_ptrTo(copyIn), (copyIn.size*c_sizeof(t)) : c_size_t, 1: c_int);
     if numRead <= 0 {
       throw new Error("Failed to decompress data from %?. Blosc error code: %?".format(chunkPath, numRead));
     }
@@ -304,7 +304,7 @@ module Zarr {
     if zarrProfiling then s.restart();
     var bytesCompressed = blosc_compress_ctx(_bloscLevel, 0, c_sizeof(t),
                                              copyOut.size*c_sizeof(t), c_ptrTo(copyOut),
-                                             compressedBuffer, (copyOut.size + 16) * c_sizeof(t) : c_size_t,
+                                             compressedBuffer, ((copyOut.size + 16) * c_sizeof(t)) : c_size_t,
                                              "blosclz", 0 : c_size_t, 1 : c_size_t);
     if bytesCompressed == 0 then
       throw new Error("Failed to compress bytes");


### PR DESCRIPTION
There are some lingering failures on linux32 configurations because the arguments to the blosc library functions weren't at the right bit width. This PR adds the necessary casts to resolve this failure.

Tested on linux32 machine and locally

Reviewed by: