### PR TITLE
Deprecate defaultComparator.compare and reverseComparator.compare argument names

### DIFF
--- a/modules/standard/Sort.chpl
+++ b/modules/standard/Sort.chpl
@@ -3286,7 +3286,7 @@ record DefaultComparator {
     return compare(x=a, y=b);
   }
 
-    /*
+  /*
    Default compare method used in sort functions.
    Uses the `<` operator to compute the ordering between ``x`` and ``y``.
    See also `The .compare method`_.

--- a/modules/standard/Sort.chpl
+++ b/modules/standard/Sort.chpl
@@ -3279,10 +3279,26 @@ record DefaultComparator {
    :returns: 0 if ``a == b``
    :returns: -1 if ``a < b``
    */
+  pragma "last resort"
+  @deprecated("compare with 'a' and 'b' arguments is deprecated, please use compare with 'x' and 'y' arguments instead")
   inline
   proc compare(a, b) {
-    if a < b { return -1; }
-    else if b < a { return 1; }
+    return compare(x=a, y=b);
+  }
+
+    /*
+   Default compare method used in sort functions.
+   Uses the `<` operator to compute the ordering between ``x`` and ``y``.
+   See also `The .compare method`_.
+
+   :returns: 1 if ``y < x``
+   :returns: 0 if ``x == y``
+   :returns: -1 if ``x < y``
+   */
+  inline
+  proc compare(x, y: x.type) {
+    if x < y { return -1; }
+    else if y < x { return 1; }
     else return 0;
   }
 
@@ -3548,17 +3564,27 @@ record ReverseComparator {
   /*
    Reverses ``comparator.compare``. See also `The .compare method`_.
    */
+  pragma "last resort"
+  @deprecated("compare with 'a' and 'b' arguments is deprecated, please use compare with 'x' and 'y' arguments instead")
   inline
   proc compare(a, b) where hasCompare(a, b) || hasCompareFromKey(a) {
+    return compare(x=a, y=b);
+  }
 
-    chpl_check_comparator(this.comparator, a.type);
+  /*
+   Reverses ``comparator.compare``. See also `The .compare method`_.
+   */
+  inline
+  proc compare(x, y: x.type) where hasCompare(x, y) || hasCompareFromKey(x) {
 
-    if hasCompareFromKey(a) {
+    chpl_check_comparator(this.comparator, x.type);
+
+    if hasCompareFromKey(x) {
       return doCompare(new DefaultComparator(),
-                       this.comparator.key(a),
-                       this.comparator.key(b));
+                       this.comparator.key(x),
+                       this.comparator.key(y));
     } else {
-      return doCompare(this.comparator, a, b);
+      return doCompare(this.comparator, x, y);
     }
   }
 }

--- a/test/deprecated/Sort/comparatorArgs.chpl
+++ b/test/deprecated/Sort/comparatorArgs.chpl
@@ -1,0 +1,7 @@
+use Sort;
+
+var myDefComp = new DefaultComparator();
+writeln(myDefComp.compare(a=3, b=4));
+
+var myRevComp = new ReverseComparator();
+writeln(myDefComp.compare(a=3, b=4));

--- a/test/deprecated/Sort/comparatorArgs.good
+++ b/test/deprecated/Sort/comparatorArgs.good
@@ -1,0 +1,4 @@
+comparatorArgs.chpl:4: warning: compare with 'a' and 'b' arguments is deprecated, please use compare with 'x' and 'y' arguments instead
+comparatorArgs.chpl:7: warning: compare with 'a' and 'b' arguments is deprecated, please use compare with 'x' and 'y' arguments instead
+-1
+-1


### PR DESCRIPTION
Continues progress for #25552 

`a` and `b` argument names do not match the style of other standard modules, so
replace them with `x` and `y`.  This should not have much impact for user code,
as the compare method is mostly used by the sort implementation itself and the
number and position of arguments is the same.

Additionally, specify that the type of the y argument is expected to be the same
as that of the x argument

Add a test locking in the deprecation messages for the old arguments.

Passed a full paratest with futures