### PR TITLE
Add knucleotide4 to the README in the submitted shootouts directory

### DIFF
--- a/test/studies/shootout/submitted/README.md
+++ b/test/studies/shootout/submitted/README.md
@@ -31,6 +31,7 @@ that have been submitted across time to the website. For Chapel versions that ar
   [fasta5.chpl](https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/fasta-chapel-5.html)
     * Generates and writes random DNA sequences.
 * [knucleotide3.chpl](https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/knucleotide-chapel-3.html)
+* [knucleotide4.chpl](https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/knucleotide-chapel-4.html)
     * Count the frequencies of specific nucleotide sequences.
 * [mandelbrot.chpl](https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/mandelbrot-chapel-1.html) |
   [mandelbrot3.chpl](https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/mandelbrot-chapel-3.html)


### PR DESCRIPTION
Looks like we missed adding that version to the README when we added it, so do so now