### PR TITLE
Fix module index text for Image, Debugger, OS, and POSIX

### DIFF
--- a/modules/packages/Image.chpl
+++ b/modules/packages/Image.chpl
@@ -17,8 +17,7 @@
  * limitations under the License.
  */
 
-/*
-The Image module provides a way to write arrays of pixels to an output image format.
+/* Provides a way to write arrays of pixels to an output image format.
 
 For example, the following code creates a 3x3 array of pixels and writes it to
 a BMP file. The array is then scaled by a factor of 2 (creating a 9x9 image)

--- a/modules/standard/Debugger.chpl
+++ b/modules/standard/Debugger.chpl
@@ -18,8 +18,11 @@
  * limitations under the License.
  */
 
-/*
-  The Debugger module provides a collection of useful debugging utilities
+/* Provides a collection of useful debugging utilities.
+
+The Debugger module currently only provides a single function,
+:proc:`breakpoint`. This function can be used to set a breakpoint in the code
+that will be hit when the program is run under a debugger.
 */
 @unstable(category="experimental", reason="The Debugger module is unstable due to its experimental behavior")
 module Debugger {

--- a/modules/standard/OS.chpl
+++ b/modules/standard/OS.chpl
@@ -18,9 +18,7 @@
  * limitations under the License.
  */
 
-/*
-   The ``OS`` module provides definitions matching operating system
-   interfaces.
+/* The ``OS`` module provides definitions matching operating system interfaces.
 
    This module provides Chapel declarations for the constants, types,
    and functions defined by various operating systems' programmatic
@@ -34,9 +32,9 @@
 
  */
 module OS {
-  /*
-     The ``OS.POSIX`` module provides definitions matching the POSIX
-     programming interface, specifically POSIX.1-2017.  That standard
+  /* This module provides definitions matching the POSIX programming interface.
+
+     The ``OS.POSIX`` modudle specifically provides POSIX.1-2017.  That standard
      can be found at <https://pubs.opengroup.org/onlinepubs/9699919799/>.
 
      There is one unavoidable difference between POSIX and ``OS.POSIX``.


### PR DESCRIPTION
Fixes the module index for the Image, Debugger, OS, and POSIX modules.

These were identified in https://github.com/chapel-lang/chapel/issues/25667

Prior to this they were not rendered correctly because an extra line existed after `/*` for the doc strings

- [x] build docs and validated formatting and that the module index was correct

[Reviewed by @jeremiah-corrado]