### PR TITLE
Avoid redefining stdatomic symbols in Chapel runtime

### DIFF
--- a/modules/internal/Atomics.chpl
+++ b/modules/internal/Atomics.chpl
@@ -167,20 +167,20 @@ module Atomics {
   // Compute the C/Runtime type from the Chapel type
   // TODO support extern type renaming?
   private proc externT(type valType) type {
-    extern type atomic_bool;
+    extern "chpl_atomic_bool" type atomic_bool;
 
-    extern type atomic_int_least8_t;
-    extern type atomic_int_least16_t;
-    extern type atomic_int_least32_t;
-    extern type atomic_int_least64_t;
+    extern "chpl_atomic_int_least8_t" type atomic_int_least8_t;
+    extern "chpl_atomic_int_least16_t" type atomic_int_least16_t;
+    extern "chpl_atomic_int_least32_t" type atomic_int_least32_t;
+    extern "chpl_atomic_int_least64_t" type atomic_int_least64_t;
 
-    extern type atomic_uint_least8_t;
-    extern type atomic_uint_least16_t;
-    extern type atomic_uint_least32_t;
-    extern type atomic_uint_least64_t;
+    extern "chpl_atomic_uint_least8_t" type atomic_uint_least8_t;
+    extern "chpl_atomic_uint_least16_t" type atomic_uint_least16_t;
+    extern "chpl_atomic_uint_least32_t" type atomic_uint_least32_t;
+    extern "chpl_atomic_uint_least64_t" type atomic_uint_least64_t;
 
-    extern type atomic__real64;
-    extern type atomic__real32;
+    extern "chpl_atomic__real64" type atomic__real64;
+    extern "chpl_atomic__real32" type atomic__real32;
 
     select valType {
       when bool     do return atomic_bool;

--- a/modules/internal/MemConsistency.chpl
+++ b/modules/internal/MemConsistency.chpl
@@ -20,7 +20,7 @@
 
 module MemConsistency {
   pragma "c memory order type"
-  extern type memory_order;
+  extern "chpl_memory_order" type memory_order;
 
   // When I finish removing PRIM_INIT before initialization to a known
   // value, then this method should work.  Until then, my stopgap will be
@@ -65,12 +65,12 @@ module MemConsistency {
       writer.write("memory_order_unknown");
   }
 
-  extern const memory_order_relaxed:memory_order;
-  extern const memory_order_consume:memory_order;
-  extern const memory_order_acquire:memory_order;
-  extern const memory_order_release:memory_order;
-  extern const memory_order_acq_rel:memory_order;
-  extern const memory_order_seq_cst:memory_order;
+  extern "chpl_memory_order_relaxed" const memory_order_relaxed:memory_order;
+  extern "chpl_memory_order_consume" const memory_order_consume:memory_order;
+  extern "chpl_memory_order_acquire" const memory_order_acquire:memory_order;
+  extern "chpl_memory_order_release" const memory_order_release:memory_order;
+  extern "chpl_memory_order_acq_rel" const memory_order_acq_rel:memory_order;
+  extern "chpl_memory_order_seq_cst" const memory_order_seq_cst:memory_order;
 
   pragma "memory order type"
   enum memoryOrder {seqCst, acqRel, release, acquire, relaxed}

--- a/modules/packages/AtomicObjects.chpl
+++ b/modules/packages/AtomicObjects.chpl
@@ -248,7 +248,7 @@ prototype module AtomicObjects {
   }
 
   @chpldoc.nodoc
-  extern type atomic_uint_least64_t;
+  extern "chpl_atomic_uint_least64_t" type atomic_uint_least64_t;
 
   @chpldoc.nodoc
   extern type wide_ptr_t;

--- a/modules/packages/AtomicObjects.chpl
+++ b/modules/packages/AtomicObjects.chpl
@@ -29,6 +29,7 @@
       - The implementation relies on using either ``GCC`` style inline assembly
         (for x86-64) or a GCC/clang builtin, and so is restricted to a
         ``CHPL_TARGET_COMPILER`` value of ``gnu``, ``clang``, or ``llvm``.
+      - The implementation does not work with ``CHPL_ATOMICS=locks``.
 
   This module provides support for performing atomic operations on pointers
   to  ``unmanaged`` classes, which can be thought of as building blocks for

--- a/modules/packages/ConcurrentMap.chpl
+++ b/modules/packages/ConcurrentMap.chpl
@@ -30,6 +30,7 @@
       - The implementation relies on using either ``GCC`` style inline assembly
         (for x86-64) or a GCC/clang builtin, and so is restricted to a
         ``CHPL_TARGET_COMPILER`` value of ``gnu``, ``clang``, or ``llvm``.
+      - The implementation does not work with ``CHPL_ATOMICS=locks``.
 
   This module was
   inspired by the Interlocked Hash Table [#]_. It allows large critical

--- a/modules/packages/EpochManager.chpl
+++ b/modules/packages/EpochManager.chpl
@@ -30,6 +30,7 @@
       - The implementation relies on using either ``GCC`` style inline assembly
         (for x86-64) or a GCC/clang builtin, and so is restricted to a
         ``CHPL_TARGET_COMPILER`` value of ``gnu``, ``clang``, or ``llvm``.
+      - The implementation does not work with ``CHPL_ATOMICS=locks``.
 
   Epoch-Based Memory Reclamation
   ------------------------------

--- a/modules/packages/LockFreeQueue.chpl
+++ b/modules/packages/LockFreeQueue.chpl
@@ -30,6 +30,7 @@
       - The implementation relies on using either ``GCC`` style inline assembly
         (for x86-64) or a GCC/clang builtin, and so is restricted to a
         ``CHPL_TARGET_COMPILER`` value of ``gnu``, ``clang``, or ``llvm``.
+      - The implementation does not work with ``CHPL_ATOMICS=locks``.
 
   An implementation of the Michael & Scott [#]_, a lock-free queue. Concurrent safe
   memory reclamation is handled by an internal :record:`EpochManager`. Usage of the

--- a/modules/packages/LockFreeStack.chpl
+++ b/modules/packages/LockFreeStack.chpl
@@ -31,6 +31,7 @@
       - The implementation relies on using either ``GCC`` style inline assembly
         (for x86-64) or a GCC/clang builtin, and so is restricted to a
         ``CHPL_TARGET_COMPILER`` value of ``gnu``, ``clang``, or ``llvm``.
+      - The implementation does not work with ``CHPL_ATOMICS=locks``.
 
   An implementation of the Treiber Stack [#]_, a lock-free stack. Concurrent safe
   memory reclamation is handled by an internal :record:`EpochManager`. Usage of the

--- a/runtime/include/atomics/README
+++ b/runtime/include/atomics/README
@@ -1,4 +1,4 @@
-The Chapel runtime atomics interface is modelled after the
+The Chapel runtime atomics interface is modeled after the
 C11 standard. See: http://en.cppreference.com/w/c/atomic
 
 Currently we have a cstdlib, an intrinsics, and a locks

--- a/runtime/include/atomics/cstdlib/chpl-atomics.h
+++ b/runtime/include/atomics/cstdlib/chpl-atomics.h
@@ -84,12 +84,12 @@ typedef Atomic(_real32) chpl_atomic__real32;
 typedef chpl_atomic_bool chpl_atomic_spinlock_t;
 
 typedef memory_order chpl_memory_order;
-chpl_memory_order chpl_memory_order_relaxed = memory_order_relaxed;
-chpl_memory_order chpl_memory_order_consume = memory_order_consume;
-chpl_memory_order chpl_memory_order_acquire = memory_order_acquire;
-chpl_memory_order chpl_memory_order_release = memory_order_release;
-chpl_memory_order chpl_memory_order_acq_rel = memory_order_acq_rel;
-chpl_memory_order chpl_memory_order_seq_cst = memory_order_seq_cst;
+#define chpl_memory_order_relaxed memory_order_relaxed
+#define chpl_memory_order_consume memory_order_consume
+#define chpl_memory_order_acquire memory_order_acquire
+#define chpl_memory_order_release memory_order_release
+#define chpl_memory_order_acq_rel memory_order_acq_rel
+#define chpl_memory_order_seq_cst memory_order_seq_cst
 
 
 static inline chpl_memory_order _defaultOfMemoryOrder(void) {

--- a/runtime/include/atomics/cstdlib/chpl-atomics.h
+++ b/runtime/include/atomics/cstdlib/chpl-atomics.h
@@ -66,20 +66,41 @@
 extern "C" {
 #endif
 
-typedef Atomic(_real64) atomic__real64;
-typedef Atomic(_real32) atomic__real32;
 
-typedef atomic_bool atomic_spinlock_t;
+typedef atomic_int_least8_t chpl_atomic_int_least8_t;
+typedef atomic_int_least16_t chpl_atomic_int_least16_t;
+typedef atomic_int_least32_t chpl_atomic_int_least32_t;
+typedef atomic_int_least64_t chpl_atomic_int_least64_t;
+typedef atomic_uint_least8_t chpl_atomic_uint_least8_t;
+typedef atomic_uint_least16_t chpl_atomic_uint_least16_t;
+typedef atomic_uint_least32_t chpl_atomic_uint_least32_t;
+typedef atomic_uint_least64_t chpl_atomic_uint_least64_t;
+typedef atomic_uintptr_t chpl_atomic_uintptr_t;
+typedef atomic_bool chpl_atomic_bool;
 
-static inline memory_order _defaultOfMemoryOrder(void) {
-  return memory_order_seq_cst;
+typedef Atomic(_real64) chpl_atomic__real64;
+typedef Atomic(_real32) chpl_atomic__real32;
+
+typedef chpl_atomic_bool chpl_atomic_spinlock_t;
+
+typedef memory_order chpl_memory_order;
+chpl_memory_order chpl_memory_order_relaxed = memory_order_relaxed;
+chpl_memory_order chpl_memory_order_consume = memory_order_consume;
+chpl_memory_order chpl_memory_order_acquire = memory_order_acquire;
+chpl_memory_order chpl_memory_order_release = memory_order_release;
+chpl_memory_order chpl_memory_order_acq_rel = memory_order_acq_rel;
+chpl_memory_order chpl_memory_order_seq_cst = memory_order_seq_cst;
+
+
+static inline chpl_memory_order _defaultOfMemoryOrder(void) {
+  return chpl_memory_order_seq_cst;
 }
 
-static inline void chpl_atomic_thread_fence(memory_order order)
+static inline void chpl_atomic_thread_fence(chpl_memory_order order)
 {
   atomic_thread_fence(order);
 }
-static inline void chpl_atomic_signal_fence(memory_order order)
+static inline void chpl_atomic_signal_fence(chpl_memory_order order)
 {
   atomic_signal_fence(order);
 }
@@ -89,24 +110,24 @@ static inline void chpl_atomic_signal_fence(memory_order order)
 ////                      START OF ATOMICS BASE                           ////
 //////////////////////////////////////////////////////////////////////////////
 #define DECLARE_ATOMICS_BASE(type, basetype) \
-static inline chpl_bool atomic_is_lock_free_ ## type(atomic_ ## type * obj) { \
+static inline chpl_bool atomic_is_lock_free_ ## type(chpl_atomic_ ## type * obj) { \
   return atomic_is_lock_free(obj); \
 } \
-static inline void atomic_init_ ## type(atomic_ ## type * obj, basetype value) { \
+static inline void atomic_init_ ## type(chpl_atomic_ ## type * obj, basetype value) { \
   atomic_init(obj, value); \
 } \
-static inline void atomic_destroy_ ## type(atomic_ ## type * obj) { \
+static inline void atomic_destroy_ ## type(chpl_atomic_ ## type * obj) { \
 } \
-static inline void atomic_store_explicit_ ## type(atomic_ ## type * obj, basetype value, memory_order order) { \
+static inline void atomic_store_explicit_ ## type(chpl_atomic_ ## type * obj, basetype value, chpl_memory_order order) { \
   atomic_store_explicit(obj, value, order); \
 } \
-static inline void atomic_store_ ## type(atomic_ ## type * obj, basetype value) { \
+static inline void atomic_store_ ## type(chpl_atomic_ ## type * obj, basetype value) { \
   atomic_store(obj, value); \
 } \
-static inline basetype atomic_load_explicit_ ## type(atomic_ ## type * obj, memory_order order) { \
+static inline basetype atomic_load_explicit_ ## type(chpl_atomic_ ## type * obj, chpl_memory_order order) { \
   return atomic_load_explicit(obj, order); \
 } \
-static inline basetype atomic_load_ ## type(atomic_ ## type * obj) { \
+static inline basetype atomic_load_ ## type(chpl_atomic_ ## type * obj) { \
   return atomic_load(obj); \
 }
 
@@ -115,22 +136,22 @@ static inline basetype atomic_load_ ## type(atomic_ ## type * obj) { \
 ////                 START OF ATOMIC EXCHANGE OPS                         ////
 //////////////////////////////////////////////////////////////////////////////
 #define DECLARE_ATOMICS_EXCHANGE_OPS(type, basetype) \
-static inline basetype atomic_exchange_explicit_ ## type(atomic_ ## type * obj, basetype value, memory_order order) { \
+static inline basetype atomic_exchange_explicit_ ## type(chpl_atomic_ ## type * obj, basetype value, chpl_memory_order order) { \
   return atomic_exchange_explicit(obj, value, order); \
 } \
-static inline basetype atomic_exchange_ ## type(atomic_ ## type * obj, basetype value) { \
+static inline basetype atomic_exchange_ ## type(chpl_atomic_ ## type * obj, basetype value) { \
   return atomic_exchange(obj, value); \
 } \
-static inline chpl_bool atomic_compare_exchange_strong_explicit_ ## type(atomic_ ## type * obj, basetype * expected, basetype desired, memory_order succ, memory_order fail) { \
+static inline chpl_bool atomic_compare_exchange_strong_explicit_ ## type(chpl_atomic_ ## type * obj, basetype * expected, basetype desired, chpl_memory_order succ, chpl_memory_order fail) { \
   return atomic_compare_exchange_strong_explicit(obj, expected, desired, succ, fail); \
 } \
-static inline chpl_bool atomic_compare_exchange_strong_ ## type(atomic_ ## type * obj, basetype * expected, basetype desired) { \
+static inline chpl_bool atomic_compare_exchange_strong_ ## type(chpl_atomic_ ## type * obj, basetype * expected, basetype desired) { \
   return atomic_compare_exchange_strong(obj, expected, desired); \
 } \
-static inline chpl_bool atomic_compare_exchange_weak_explicit_ ## type(atomic_ ## type * obj, basetype * expected, basetype desired, memory_order succ, memory_order fail) { \
+static inline chpl_bool atomic_compare_exchange_weak_explicit_ ## type(chpl_atomic_ ## type * obj, basetype * expected, basetype desired, chpl_memory_order succ, chpl_memory_order fail) { \
   return atomic_compare_exchange_weak_explicit(obj, expected, desired, succ, fail); \
 } \
-static inline chpl_bool atomic_compare_exchange_weak_ ## type(atomic_ ## type * obj, basetype * expected, basetype desired) { \
+static inline chpl_bool atomic_compare_exchange_weak_ ## type(chpl_atomic_ ## type * obj, basetype * expected, basetype desired) { \
   return atomic_compare_exchange_weak(obj, expected, desired); \
 }
 
@@ -139,34 +160,34 @@ static inline chpl_bool atomic_compare_exchange_weak_ ## type(atomic_ ## type * 
 ////              START OF INTEGER ATOMIC FETCH OPERATIONS                ////
 //////////////////////////////////////////////////////////////////////////////
 #define DECLARE_ATOMICS_FETCH_OPS(type) \
-static inline type atomic_fetch_add_explicit_ ## type(atomic_ ## type * obj, type operand, memory_order order) { \
+static inline type atomic_fetch_add_explicit_ ## type(chpl_atomic_ ## type * obj, type operand, chpl_memory_order order) { \
   return atomic_fetch_add_explicit(obj, operand, order); \
 } \
-static inline type atomic_fetch_add_ ## type(atomic_ ## type * obj, type operand) { \
+static inline type atomic_fetch_add_ ## type(chpl_atomic_ ## type * obj, type operand) { \
   return atomic_fetch_add(obj, operand); \
 } \
-static inline type atomic_fetch_sub_explicit_ ## type(atomic_ ## type * obj, type operand, memory_order order) { \
+static inline type atomic_fetch_sub_explicit_ ## type(chpl_atomic_ ## type * obj, type operand, chpl_memory_order order) { \
   return atomic_fetch_sub_explicit(obj, operand, order); \
 } \
-static inline type atomic_fetch_sub_ ## type(atomic_ ## type * obj, type operand) { \
+static inline type atomic_fetch_sub_ ## type(chpl_atomic_ ## type * obj, type operand) { \
   return atomic_fetch_sub(obj, operand); \
 } \
-static inline type atomic_fetch_or_explicit_ ## type(atomic_ ## type * obj, type operand, memory_order order) { \
+static inline type atomic_fetch_or_explicit_ ## type(chpl_atomic_ ## type * obj, type operand, chpl_memory_order order) { \
   return atomic_fetch_or_explicit(obj, operand, order); \
 } \
-static inline type atomic_fetch_or_ ## type(atomic_ ## type * obj, type operand) { \
+static inline type atomic_fetch_or_ ## type(chpl_atomic_ ## type * obj, type operand) { \
   return atomic_fetch_or(obj, operand); \
 } \
-static inline type atomic_fetch_and_explicit_ ## type(atomic_ ## type * obj, type operand, memory_order order) { \
+static inline type atomic_fetch_and_explicit_ ## type(chpl_atomic_ ## type * obj, type operand, chpl_memory_order order) { \
   return atomic_fetch_and_explicit(obj, operand, order); \
 } \
-static inline type atomic_fetch_and_ ## type(atomic_ ## type * obj, type operand) { \
+static inline type atomic_fetch_and_ ## type(chpl_atomic_ ## type * obj, type operand) { \
   return atomic_fetch_and(obj, operand); \
 } \
-static inline type atomic_fetch_xor_explicit_ ## type(atomic_ ## type * obj, type operand, memory_order order) { \
+static inline type atomic_fetch_xor_explicit_ ## type(chpl_atomic_ ## type * obj, type operand, chpl_memory_order order) { \
   return atomic_fetch_xor_explicit(obj, operand, order); \
 } \
-static inline type atomic_fetch_xor_ ## type(atomic_ ## type * obj, type operand) { \
+static inline type atomic_fetch_xor_ ## type(chpl_atomic_ ## type * obj, type operand) { \
   return atomic_fetch_xor(obj, operand); \
 }
 
@@ -191,8 +212,8 @@ static inline type atomic_fetch_xor_ ## type(atomic_ ## type * obj, type operand
 ////                   START OF REAL ATOMICS FETCH OPS                    ////
 //////////////////////////////////////////////////////////////////////////////
 #define DECLARE_REAL_ATOMICS_FETCH_OPS(type) \
-static inline type atomic_fetch_add_explicit_ ## type(atomic_ ## type * obj, type operand, memory_order order) { \
-  memory_order ld_exp_order = GET_READABLE_ORDER(order); \
+static inline type atomic_fetch_add_explicit_ ## type(chpl_atomic_ ## type * obj, type operand, chpl_memory_order order) { \
+  chpl_memory_order ld_exp_order = GET_READABLE_ORDER(order); \
   type old_val = atomic_load_explicit(obj, ld_exp_order); \
   type new_val; \
   do { \
@@ -200,11 +221,11 @@ static inline type atomic_fetch_add_explicit_ ## type(atomic_ ## type * obj, typ
   } while (!atomic_compare_exchange_weak_explicit(obj, &old_val, new_val, order, ld_exp_order)); \
   return old_val; \
 } \
-static inline type atomic_fetch_add_ ## type(atomic_ ## type * obj, type operand) { \
+static inline type atomic_fetch_add_ ## type(chpl_atomic_ ## type * obj, type operand) { \
   return atomic_fetch_add_explicit_ ## type(obj, operand, memory_order_seq_cst); \
 } \
-static inline type atomic_fetch_sub_explicit_ ## type(atomic_ ## type * obj, type operand, memory_order order) { \
-  memory_order ld_exp_order = GET_READABLE_ORDER(order); \
+static inline type atomic_fetch_sub_explicit_ ## type(chpl_atomic_ ## type * obj, type operand, chpl_memory_order order) { \
+  chpl_memory_order ld_exp_order = GET_READABLE_ORDER(order); \
   type old_val = atomic_load_explicit(obj, ld_exp_order); \
   type new_val; \
   do { \
@@ -212,7 +233,7 @@ static inline type atomic_fetch_sub_explicit_ ## type(atomic_ ## type * obj, typ
   } while (!atomic_compare_exchange_weak_explicit(obj, &old_val, new_val, order, ld_exp_order)); \
   return old_val; \
 } \
-static inline type atomic_fetch_sub_ ## type(atomic_ ## type * obj, type operand) { \
+static inline type atomic_fetch_sub_ ## type(chpl_atomic_ ## type * obj, type operand) { \
   return atomic_fetch_sub_explicit_ ## type(obj, operand, memory_order_seq_cst); \
 }
 
@@ -258,23 +279,23 @@ DECLARE_REAL_ATOMICS(_real64);
 #undef DECLARE_ATOMICS
 #undef DECLARE_REAL_ATOMICS
 
-static inline void atomic_init_spinlock_t(atomic_spinlock_t* lock) {
+static inline void atomic_init_spinlock_t(chpl_atomic_spinlock_t* lock) {
   atomic_init(lock, false);
 }
 
-static inline void atomic_destroy_spinlock_t(atomic_spinlock_t* lock) { }
+static inline void atomic_destroy_spinlock_t(chpl_atomic_spinlock_t* lock) { }
 
-static inline chpl_bool atomic_try_lock_spinlock_t(atomic_spinlock_t* lock) {
+static inline chpl_bool atomic_try_lock_spinlock_t(chpl_atomic_spinlock_t* lock) {
   return !atomic_load(lock) && !atomic_exchange_explicit(lock, true, memory_order_acquire);
 }
 
-static inline void atomic_lock_spinlock_t(atomic_spinlock_t* lock) {
+static inline void atomic_lock_spinlock_t(chpl_atomic_spinlock_t* lock) {
   while(!atomic_try_lock_spinlock_t(lock)) {
     chpl_task_yield();
   }
 }
 
-static inline void atomic_unlock_spinlock_t(atomic_spinlock_t* lock) {
+static inline void atomic_unlock_spinlock_t(chpl_atomic_spinlock_t* lock) {
   atomic_store_explicit(lock, false, memory_order_release);
 }
 

--- a/runtime/include/atomics/intrinsics/chpl-atomics.h
+++ b/runtime/include/atomics/intrinsics/chpl-atomics.h
@@ -42,41 +42,41 @@ extern "C" {
 //
 #define SIZE_ALIGN_TYPE(t) __attribute__ ((aligned (sizeof(t)))) t
 
-typedef int_least8_t atomic_int_least8_t;
-typedef int_least16_t atomic_int_least16_t;
-typedef int_least32_t atomic_int_least32_t;
-typedef SIZE_ALIGN_TYPE(int_least64_t) atomic_int_least64_t;
-typedef uint_least8_t atomic_uint_least8_t;
-typedef uint_least16_t atomic_uint_least16_t;
-typedef uint_least32_t atomic_uint_least32_t;
-typedef SIZE_ALIGN_TYPE(uint_least64_t) atomic_uint_least64_t;
-typedef uintptr_t atomic_uintptr_t;
-typedef chpl_bool atomic_bool;
-typedef SIZE_ALIGN_TYPE(uint64_t) atomic__real64;
-typedef uint32_t atomic__real32;
+typedef int_least8_t chpl_atomic_int_least8_t;
+typedef int_least16_t chpl_atomic_int_least16_t;
+typedef int_least32_t chpl_atomic_int_least32_t;
+typedef SIZE_ALIGN_TYPE(int_least64_t) chpl_atomic_int_least64_t;
+typedef uint_least8_t chpl_atomic_uint_least8_t;
+typedef uint_least16_t chpl_atomic_uint_least16_t;
+typedef uint_least32_t chpl_atomic_uint_least32_t;
+typedef SIZE_ALIGN_TYPE(uint_least64_t) chpl_atomic_uint_least64_t;
+typedef uintptr_t chpl_atomic_uintptr_t;
+typedef chpl_bool chpl_atomic_bool;
+typedef SIZE_ALIGN_TYPE(uint64_t) chpl_atomic__real64;
+typedef uint32_t chpl_atomic__real32;
 
-typedef volatile uint8_t atomic_spinlock_t;
+typedef volatile uint8_t chpl_atomic_spinlock_t;
 
 #undef SIZE_ALIGN_TYPE
 
 typedef enum {
- memory_order_relaxed,
- memory_order_consume,
- memory_order_acquire,
- memory_order_release,
- memory_order_acq_rel,
- memory_order_seq_cst
-} memory_order;
+ chpl_memory_order_relaxed,
+ chpl_memory_order_consume,
+ chpl_memory_order_acquire,
+ chpl_memory_order_release,
+ chpl_memory_order_acq_rel,
+ chpl_memory_order_seq_cst
+} chpl_memory_order;
 
-static inline memory_order _defaultOfMemoryOrder(void) {
-  return memory_order_seq_cst;
+static inline chpl_memory_order _defaultOfMemoryOrder(void) {
+  return chpl_memory_order_seq_cst;
 }
 
-static inline void chpl_atomic_thread_fence(memory_order order)
+static inline void chpl_atomic_thread_fence(chpl_memory_order order)
 {
   __sync_synchronize();
 }
-static inline void chpl_atomic_signal_fence(memory_order order)
+static inline void chpl_atomic_signal_fence(chpl_memory_order order)
 {
   __sync_synchronize();
 }
@@ -90,15 +90,15 @@ static inline void chpl_atomic_signal_fence(memory_order order)
 // They must be implemented with atomic primitives to ensure consistent
 // visibility of the results.
 #define DECLARE_ATOMICS_BASE(type, basetype) \
-static inline chpl_bool atomic_is_lock_free_ ## type(atomic_ ## type * obj) { \
+static inline chpl_bool atomic_is_lock_free_ ## type(chpl_atomic_ ## type * obj) { \
   return true; \
 } \
-static inline void atomic_init_ ## type(atomic_ ## type * obj, basetype value) { \
+static inline void atomic_init_ ## type(chpl_atomic_ ## type * obj, basetype value) { \
   *obj = value; \
 } \
-static inline void atomic_destroy_ ## type(atomic_ ## type * obj) { \
+static inline void atomic_destroy_ ## type(chpl_atomic_ ## type * obj) { \
 } \
-static inline void atomic_store_explicit_ ## type(atomic_ ## type * obj, basetype value, memory_order order) { \
+static inline void atomic_store_explicit_ ## type(chpl_atomic_ ## type * obj, basetype value, chpl_memory_order order) { \
   basetype ret = *obj; \
   basetype old_val; \
   do { \
@@ -106,14 +106,14 @@ static inline void atomic_store_explicit_ ## type(atomic_ ## type * obj, basetyp
     ret = __sync_val_compare_and_swap(obj, old_val, value); \
   } while (ret != old_val); \
 } \
-static inline void atomic_store_ ## type(atomic_ ## type * obj, basetype value) { \
-  atomic_store_explicit_ ## type(obj, value, memory_order_seq_cst); \
+static inline void atomic_store_ ## type(chpl_atomic_ ## type * obj, basetype value) { \
+  atomic_store_explicit_ ## type(obj, value, chpl_memory_order_seq_cst); \
 } \
-static inline basetype atomic_load_explicit_ ## type(atomic_ ## type * obj, memory_order order) { \
+static inline basetype atomic_load_explicit_ ## type(chpl_atomic_ ## type * obj, chpl_memory_order order) { \
   return __sync_val_compare_and_swap(obj, (basetype)0, (basetype)0); \
 } \
-static inline basetype atomic_load_ ## type(atomic_ ## type * obj) { \
-  return atomic_load_explicit_ ## type(obj, memory_order_seq_cst); \
+static inline basetype atomic_load_ ## type(chpl_atomic_ ## type * obj) { \
+  return atomic_load_explicit_ ## type(obj, chpl_memory_order_seq_cst); \
 }
 
 
@@ -121,7 +121,7 @@ static inline basetype atomic_load_ ## type(atomic_ ## type * obj) { \
 ////                 START OF INTEGER ATOMIC EXCHANGE OPS                 ////
 //////////////////////////////////////////////////////////////////////////////
 #define DECLARE_ATOMICS_EXCHANGE_OPS(type, basetype) \
-static inline basetype atomic_exchange_explicit_ ## type(atomic_ ## type * obj, basetype value, memory_order order) { \
+static inline basetype atomic_exchange_explicit_ ## type(chpl_atomic_ ## type * obj, basetype value, chpl_memory_order order) { \
   basetype ret = *obj; \
   basetype old_val; \
   do { \
@@ -130,10 +130,10 @@ static inline basetype atomic_exchange_explicit_ ## type(atomic_ ## type * obj, 
   } while(ret != old_val); \
   return ret; \
 } \
-static inline basetype atomic_exchange_ ## type(atomic_ ## type * obj, basetype value) { \
-  return atomic_exchange_explicit_ ## type(obj, value, memory_order_seq_cst); \
+static inline basetype atomic_exchange_ ## type(chpl_atomic_ ## type * obj, basetype value) { \
+  return atomic_exchange_explicit_ ## type(obj, value, chpl_memory_order_seq_cst); \
 } \
-static inline chpl_bool atomic_compare_exchange_strong_explicit_ ## type(atomic_ ## type * obj, basetype * expected, basetype desired, memory_order succ, memory_order fail) { \
+static inline chpl_bool atomic_compare_exchange_strong_explicit_ ## type(chpl_atomic_ ## type * obj, basetype * expected, basetype desired, chpl_memory_order succ, chpl_memory_order fail) { \
   basetype old_value; \
   basetype old_expected = *expected; \
   chpl_bool ret; \
@@ -142,14 +142,14 @@ static inline chpl_bool atomic_compare_exchange_strong_explicit_ ## type(atomic_
   if (!ret) *expected = old_value; \
   return ret; \
 } \
-static inline chpl_bool atomic_compare_exchange_strong_ ## type(atomic_ ## type * obj, basetype * expected, basetype desired) { \
-  return atomic_compare_exchange_strong_explicit_ ## type(obj, expected, desired, memory_order_seq_cst, memory_order_seq_cst); \
+static inline chpl_bool atomic_compare_exchange_strong_ ## type(chpl_atomic_ ## type * obj, basetype * expected, basetype desired) { \
+  return atomic_compare_exchange_strong_explicit_ ## type(obj, expected, desired, chpl_memory_order_seq_cst, chpl_memory_order_seq_cst); \
 } \
-static inline chpl_bool atomic_compare_exchange_weak_explicit_ ## type(atomic_ ## type * obj, basetype * expected, basetype desired, memory_order succ, memory_order fail) { \
+static inline chpl_bool atomic_compare_exchange_weak_explicit_ ## type(chpl_atomic_ ## type * obj, basetype * expected, basetype desired, chpl_memory_order succ, chpl_memory_order fail) { \
   return atomic_compare_exchange_strong_explicit_ ## type(obj, expected, desired, succ, fail); \
 } \
-static inline chpl_bool atomic_compare_exchange_weak_ ## type(atomic_ ## type * obj, basetype * expected, basetype desired) { \
-  return atomic_compare_exchange_weak_explicit_ ## type(obj, expected, desired, memory_order_seq_cst, memory_order_seq_cst); \
+static inline chpl_bool atomic_compare_exchange_weak_ ## type(chpl_atomic_ ## type * obj, basetype * expected, basetype desired) { \
+  return atomic_compare_exchange_weak_explicit_ ## type(obj, expected, desired, chpl_memory_order_seq_cst, chpl_memory_order_seq_cst); \
 }
 
 
@@ -157,35 +157,35 @@ static inline chpl_bool atomic_compare_exchange_weak_ ## type(atomic_ ## type * 
 ////              START OF INTEGER ATOMIC FETCH OPERATIONS                ////
 //////////////////////////////////////////////////////////////////////////////
 #define DECLARE_ATOMICS_FETCH_OPS(type) \
-static inline type atomic_fetch_add_explicit_ ## type(atomic_ ## type * obj, type operand, memory_order order) { \
+static inline type atomic_fetch_add_explicit_ ## type(chpl_atomic_ ## type * obj, type operand, chpl_memory_order order) { \
   return __sync_fetch_and_add(obj, operand); \
 } \
-static inline type atomic_fetch_add_ ## type(atomic_ ## type * obj, type operand) { \
-  return atomic_fetch_add_explicit_ ## type(obj, operand, memory_order_seq_cst); \
+static inline type atomic_fetch_add_ ## type(chpl_atomic_ ## type * obj, type operand) { \
+  return atomic_fetch_add_explicit_ ## type(obj, operand, chpl_memory_order_seq_cst); \
 } \
-static inline type atomic_fetch_sub_explicit_ ## type(atomic_ ## type * obj, type operand, memory_order order) { \
+static inline type atomic_fetch_sub_explicit_ ## type(chpl_atomic_ ## type * obj, type operand, chpl_memory_order order) { \
   return __sync_fetch_and_sub(obj, operand); \
 } \
-static inline type atomic_fetch_sub_ ## type(atomic_ ## type * obj, type operand) { \
-  return atomic_fetch_sub_explicit_ ## type(obj, operand, memory_order_seq_cst); \
+static inline type atomic_fetch_sub_ ## type(chpl_atomic_ ## type * obj, type operand) { \
+  return atomic_fetch_sub_explicit_ ## type(obj, operand, chpl_memory_order_seq_cst); \
 } \
-static inline type atomic_fetch_or_explicit_ ## type(atomic_ ## type * obj, type operand, memory_order order) { \
+static inline type atomic_fetch_or_explicit_ ## type(chpl_atomic_ ## type * obj, type operand, chpl_memory_order order) { \
   return __sync_fetch_and_or(obj, operand); \
 } \
-static inline type atomic_fetch_or_ ## type(atomic_ ## type * obj, type operand) { \
-  return atomic_fetch_or_explicit_ ## type(obj, operand, memory_order_seq_cst); \
+static inline type atomic_fetch_or_ ## type(chpl_atomic_ ## type * obj, type operand) { \
+  return atomic_fetch_or_explicit_ ## type(obj, operand, chpl_memory_order_seq_cst); \
 } \
-static inline type atomic_fetch_and_explicit_ ## type(atomic_ ## type * obj, type operand, memory_order order) { \
+static inline type atomic_fetch_and_explicit_ ## type(chpl_atomic_ ## type * obj, type operand, chpl_memory_order order) { \
   return __sync_fetch_and_and(obj, operand); \
 } \
-static inline type atomic_fetch_and_ ## type(atomic_ ## type * obj, type operand) { \
-  return atomic_fetch_and_explicit_ ## type(obj, operand, memory_order_seq_cst); \
+static inline type atomic_fetch_and_ ## type(chpl_atomic_ ## type * obj, type operand) { \
+  return atomic_fetch_and_explicit_ ## type(obj, operand, chpl_memory_order_seq_cst); \
 } \
-static inline type atomic_fetch_xor_explicit_ ## type(atomic_ ## type * obj, type operand, memory_order order) { \
+static inline type atomic_fetch_xor_explicit_ ## type(chpl_atomic_ ## type * obj, type operand, chpl_memory_order order) { \
   return __sync_fetch_and_xor(obj, operand); \
 } \
-static inline type atomic_fetch_xor_ ## type(atomic_ ## type * obj, type operand) { \
-  return atomic_fetch_xor_explicit_ ## type(obj, operand, memory_order_seq_cst); \
+static inline type atomic_fetch_xor_ ## type(chpl_atomic_ ## type * obj, type operand) { \
+  return atomic_fetch_xor_explicit_ ## type(obj, operand, chpl_memory_order_seq_cst); \
 }
 
 
@@ -197,16 +197,16 @@ static inline type atomic_fetch_xor_ ## type(atomic_ ## type * obj, type operand
 // They must be implemented with atomic primitives to ensure consistent
 // visibility of the results.
 #define DECLARE_REAL_ATOMICS_BASE(type, uinttype) \
-static inline chpl_bool atomic_is_lock_free_ ## type(atomic_ ## type * obj) { \
+static inline chpl_bool atomic_is_lock_free_ ## type(chpl_atomic_ ## type * obj) { \
   return true; \
 } \
-static inline void atomic_init_ ## type(atomic_ ## type * obj, type value) { \
+static inline void atomic_init_ ## type(chpl_atomic_ ## type * obj, type value) { \
   assert(sizeof(type) == sizeof(uinttype)); \
   memcpy(obj, &value, sizeof(*obj)); \
 } \
-static inline void atomic_destroy_ ## type(atomic_ ## type * obj) { \
+static inline void atomic_destroy_ ## type(chpl_atomic_ ## type * obj) { \
 } \
-static inline void atomic_store_explicit_ ## type(atomic_ ## type * obj, type value, memory_order order) { \
+static inline void atomic_store_explicit_ ## type(chpl_atomic_ ## type * obj, type value, chpl_memory_order order) { \
   uinttype ret_uint = *obj; \
   uinttype val_uint; \
   uinttype old_uint; \
@@ -216,17 +216,17 @@ static inline void atomic_store_explicit_ ## type(atomic_ ## type * obj, type va
     ret_uint = __sync_val_compare_and_swap(obj, old_uint, val_uint); \
   } while (ret_uint != old_uint); \
 } \
-static inline void atomic_store_ ## type(atomic_ ## type * obj, type value) { \
-  atomic_store_explicit_ ## type(obj, value, memory_order_seq_cst); \
+static inline void atomic_store_ ## type(chpl_atomic_ ## type * obj, type value) { \
+  atomic_store_explicit_ ## type(obj, value, chpl_memory_order_seq_cst); \
 } \
-static inline type atomic_load_explicit_ ## type(atomic_ ## type * obj, memory_order order) { \
+static inline type atomic_load_explicit_ ## type(chpl_atomic_ ## type * obj, chpl_memory_order order) { \
   type ret; \
   uinttype ret_uint = __sync_val_compare_and_swap(obj, (uinttype)0, (uinttype)0); \
   memcpy(&ret, &ret_uint, sizeof(ret)); \
   return ret; \
 } \
-static inline type atomic_load_ ## type(atomic_ ## type * obj) { \
-  return atomic_load_explicit_ ## type(obj, memory_order_seq_cst); \
+static inline type atomic_load_ ## type(chpl_atomic_ ## type * obj) { \
+  return atomic_load_explicit_ ## type(obj, chpl_memory_order_seq_cst); \
 }
 
 
@@ -234,7 +234,7 @@ static inline type atomic_load_ ## type(atomic_ ## type * obj) { \
 ////                START OF REAL ATOMICS EXCHANGE OPS                    ////
 //////////////////////////////////////////////////////////////////////////////
 #define DECLARE_REAL_ATOMICS_EXCHANGE_OPS(type, uinttype) \
-static inline type atomic_exchange_explicit_ ## type(atomic_ ## type * obj, type value, memory_order order) { \
+static inline type atomic_exchange_explicit_ ## type(chpl_atomic_ ## type * obj, type value, chpl_memory_order order) { \
   type ret; \
   uinttype value_as_uint; \
   uinttype ret_as_uint = *obj; \
@@ -247,10 +247,10 @@ static inline type atomic_exchange_explicit_ ## type(atomic_ ## type * obj, type
   memcpy(&ret, &ret_as_uint, sizeof(ret)); \
   return ret; \
 } \
-static inline type atomic_exchange_ ## type(atomic_ ## type * obj, type value) { \
-  return atomic_exchange_explicit_ ## type(obj, value, memory_order_seq_cst); \
+static inline type atomic_exchange_ ## type(chpl_atomic_ ## type * obj, type value) { \
+  return atomic_exchange_explicit_ ## type(obj, value, chpl_memory_order_seq_cst); \
 } \
-static inline chpl_bool atomic_compare_exchange_strong_explicit_ ## type(atomic_ ## type * obj, type * expected, type desired, memory_order succ, memory_order fail) { \
+static inline chpl_bool atomic_compare_exchange_strong_explicit_ ## type(chpl_atomic_ ## type * obj, type * expected, type desired, chpl_memory_order succ, chpl_memory_order fail) { \
   uinttype old_value_as_uint; \
   uinttype old_expected_as_uint; \
   uinttype desired_as_uint; \
@@ -262,14 +262,14 @@ static inline chpl_bool atomic_compare_exchange_strong_explicit_ ## type(atomic_
   if (!ret) memcpy(expected, &old_value_as_uint, sizeof(old_value_as_uint)); \
   return ret; \
 } \
-static inline chpl_bool atomic_compare_exchange_strong_ ## type(atomic_ ## type * obj, type * expected, type desired) { \
-  return atomic_compare_exchange_strong_explicit_ ## type(obj, expected, desired, memory_order_seq_cst, memory_order_seq_cst); \
+static inline chpl_bool atomic_compare_exchange_strong_ ## type(chpl_atomic_ ## type * obj, type * expected, type desired) { \
+  return atomic_compare_exchange_strong_explicit_ ## type(obj, expected, desired, chpl_memory_order_seq_cst, chpl_memory_order_seq_cst); \
 } \
-static inline chpl_bool atomic_compare_exchange_weak_explicit_ ## type(atomic_ ## type * obj, type * expected, type desired, memory_order succ, memory_order fail) { \
+static inline chpl_bool atomic_compare_exchange_weak_explicit_ ## type(chpl_atomic_ ## type * obj, type * expected, type desired, chpl_memory_order succ, chpl_memory_order fail) { \
   return atomic_compare_exchange_strong_explicit_ ## type(obj, expected, desired, succ, fail); \
 } \
-static inline chpl_bool atomic_compare_exchange_weak_ ## type(atomic_ ## type * obj, type * expected, type desired) { \
-  return atomic_compare_exchange_weak_explicit_ ## type(obj, expected, desired, memory_order_seq_cst, memory_order_seq_cst); \
+static inline chpl_bool atomic_compare_exchange_weak_ ## type(chpl_atomic_ ## type * obj, type * expected, type desired) { \
+  return atomic_compare_exchange_weak_explicit_ ## type(obj, expected, desired, chpl_memory_order_seq_cst, chpl_memory_order_seq_cst); \
 }
 
 
@@ -277,7 +277,7 @@ static inline chpl_bool atomic_compare_exchange_weak_ ## type(atomic_ ## type * 
 ////                   START OF REAL ATOMICS FETCH OPS                    ////
 //////////////////////////////////////////////////////////////////////////////
 #define DECLARE_REAL_ATOMICS_FETCH_OPS(type, uinttype) \
-static inline type atomic_fetch_add_explicit_ ## type(atomic_ ## type * obj, type operand, memory_order order) { \
+static inline type atomic_fetch_add_explicit_ ## type(chpl_atomic_ ## type * obj, type operand, chpl_memory_order order) { \
   type ret; \
   type old; \
   type desired; \
@@ -294,10 +294,10 @@ static inline type atomic_fetch_add_explicit_ ## type(atomic_ ## type * obj, typ
   memcpy(&ret, &ret_as_uint, sizeof(ret)); \
   return ret; \
 } \
-static inline type atomic_fetch_add_ ## type(atomic_ ## type * obj, type operand) { \
-  return atomic_fetch_add_explicit_ ## type(obj, operand, memory_order_seq_cst); \
+static inline type atomic_fetch_add_ ## type(chpl_atomic_ ## type * obj, type operand) { \
+  return atomic_fetch_add_explicit_ ## type(obj, operand, chpl_memory_order_seq_cst); \
 } \
-static inline type atomic_fetch_sub_explicit_ ## type(atomic_ ## type * obj, type operand, memory_order order) { \
+static inline type atomic_fetch_sub_explicit_ ## type(chpl_atomic_ ## type * obj, type operand, chpl_memory_order order) { \
   type ret; \
   type old; \
   type desired; \
@@ -314,8 +314,8 @@ static inline type atomic_fetch_sub_explicit_ ## type(atomic_ ## type * obj, typ
   memcpy(&ret, &ret_as_uint, sizeof(ret)); \
   return ret; \
 } \
-static inline type atomic_fetch_sub_ ## type(atomic_ ## type * obj, type operand) { \
-  return atomic_fetch_sub_explicit_ ## type(obj, operand, memory_order_seq_cst); \
+static inline type atomic_fetch_sub_ ## type(chpl_atomic_ ## type * obj, type operand) { \
+  return atomic_fetch_sub_explicit_ ## type(obj, operand, chpl_memory_order_seq_cst); \
 } \
 
 
@@ -363,23 +363,23 @@ DECLARE_REAL_ATOMICS(_real64, uint64_t);
 #undef DECLARE_REAL_ATOMICS
 
 
-static inline void atomic_init_spinlock_t(atomic_spinlock_t* lock) {
+static inline void atomic_init_spinlock_t(chpl_atomic_spinlock_t* lock) {
   *lock = 0;
 }
 
-static inline void atomic_destroy_spinlock_t(atomic_spinlock_t* lock) { }
+static inline void atomic_destroy_spinlock_t(chpl_atomic_spinlock_t* lock) { }
 
-static inline chpl_bool atomic_try_lock_spinlock_t(atomic_spinlock_t* lock) {
+static inline chpl_bool atomic_try_lock_spinlock_t(chpl_atomic_spinlock_t* lock) {
   return !*lock && !__sync_lock_test_and_set(lock, 1);
 }
 
-static inline void atomic_lock_spinlock_t(atomic_spinlock_t* lock) {
+static inline void atomic_lock_spinlock_t(chpl_atomic_spinlock_t* lock) {
   while(!atomic_try_lock_spinlock_t(lock)) {
     chpl_task_yield();
   }
 }
 
-static inline void atomic_unlock_spinlock_t(atomic_spinlock_t* lock) {
+static inline void atomic_unlock_spinlock_t(chpl_atomic_spinlock_t* lock) {
   __sync_lock_release(lock);
 }
 

--- a/runtime/include/atomics/locks/chpl-atomics.h
+++ b/runtime/include/atomics/locks/chpl-atomics.h
@@ -52,114 +52,114 @@ extern "C" {
 typedef struct atomic_int_least8_s {
   pthread_mutex_t lock;
   int_least8_t v;
-} atomic_int_least8_t;
+} chpl_atomic_int_least8_t;
 typedef struct atomic_int_least16_s {
   pthread_mutex_t lock;
   int_least16_t v;
-} atomic_int_least16_t;
+} chpl_atomic_int_least16_t;
 typedef struct atomic_int_least32_s {
   pthread_mutex_t lock;
   int_least32_t v;
-} atomic_int_least32_t;
+} chpl_atomic_int_least32_t;
 typedef struct atomic_int_least64_s {
   pthread_mutex_t lock;
   int_least64_t v;
-} atomic_int_least64_t;
+} chpl_atomic_int_least64_t;
 typedef struct atomic_uint_least8_s {
   pthread_mutex_t lock;
   uint_least8_t v;
-} atomic_uint_least8_t;
+} chpl_atomic_uint_least8_t;
 typedef struct atomic_uint_least16_s {
   pthread_mutex_t lock;
   uint_least16_t v;
-} atomic_uint_least16_t;
+} chpl_atomic_uint_least16_t;
 typedef struct atomic_uint_least32_s {
   pthread_mutex_t lock;
   uint_least32_t v;
-} atomic_uint_least32_t;
+} chpl_atomic_uint_least32_t;
 typedef struct atomic_uint_least64_s {
   pthread_mutex_t lock;
   uint_least64_t v;
-} atomic_uint_least64_t;
+} chpl_atomic_uint_least64_t;
 typedef struct atomic_uintptr_s {
   pthread_mutex_t lock;
   uintptr_t v;
-} atomic_uintptr_t;
+} chpl_atomic_uintptr_t;
 
 typedef struct atomic_bool_s {
   pthread_mutex_t lock;
   chpl_bool v;
-} atomic_bool;
+} chpl_atomic_bool;
 
 typedef struct atomic__real32_s {
   pthread_mutex_t lock;
   _real32 v;
-} atomic__real32;
+} chpl_atomic__real32;
 
 typedef struct atomic__real64_s {
   pthread_mutex_t lock;
   _real64 v;
-} atomic__real64;
+} chpl_atomic__real64;
 
-typedef pthread_spinlock_t atomic_spinlock_t;
+typedef pthread_spinlock_t chpl_atomic_spinlock_t;
 
 typedef enum {
- memory_order_relaxed,
- memory_order_consume,
- memory_order_acquire,
- memory_order_release,
- memory_order_acq_rel,
- memory_order_seq_cst
-} memory_order;
+ chpl_memory_order_relaxed,
+ chpl_memory_order_consume,
+ chpl_memory_order_acquire,
+ chpl_memory_order_release,
+ chpl_memory_order_acq_rel,
+ chpl_memory_order_seq_cst
+} chpl_memory_order;
 
-static inline memory_order _defaultOfMemoryOrder(void) {
-  return memory_order_seq_cst;
+static inline chpl_memory_order _defaultOfMemoryOrder(void) {
+  return chpl_memory_order_seq_cst;
 }
 
 static inline
-void chpl_atomic_thread_fence(memory_order order)
+void chpl_atomic_thread_fence(chpl_memory_order order)
 {
   // No idea!
 }
 static inline
-void chpl_atomic_signal_fence(memory_order order)
+void chpl_atomic_signal_fence(chpl_memory_order order)
 {
   // No idea!
 }
 
 #define DECLARE_ATOMICS_BASE(type, basetype) \
-static inline chpl_bool atomic_is_lock_free_ ## type(atomic_ ## type * obj) { \
+static inline chpl_bool atomic_is_lock_free_ ## type(chpl_atomic_ ## type * obj) { \
   return false; \
 } \
-static inline void atomic_init_ ## type(atomic_ ## type * obj, basetype value) { \
+static inline void atomic_init_ ## type(chpl_atomic_ ## type * obj, basetype value) { \
   obj->v = value; \
   (void) pthread_mutex_init(&obj->lock, NULL); \
 } \
-static inline void atomic_destroy_ ## type(atomic_ ## type * obj) { \
+static inline void atomic_destroy_ ## type(chpl_atomic_ ## type * obj) { \
   (void) pthread_mutex_destroy(&obj->lock); \
 } \
 static MAYBE_INLINE void \
-atomic_store_explicit_ ## type(atomic_ ## type * obj, basetype value, memory_order order) { \
+atomic_store_explicit_ ## type(chpl_atomic_ ## type * obj, basetype value, chpl_memory_order order) { \
   (void) pthread_mutex_lock(&obj->lock); \
   obj->v = value; \
   (void) pthread_mutex_unlock(&obj->lock); \
 } \
-static inline void atomic_store_ ## type(atomic_ ## type * obj, basetype value) { \
-  atomic_store_explicit_ ## type(obj, value, memory_order_seq_cst); \
+static inline void atomic_store_ ## type(chpl_atomic_ ## type * obj, basetype value) { \
+  atomic_store_explicit_ ## type(obj, value, chpl_memory_order_seq_cst); \
 } \
 static MAYBE_INLINE basetype \
-atomic_load_explicit_ ## type(atomic_ ## type * obj, memory_order order) { \
+atomic_load_explicit_ ## type(chpl_atomic_ ## type * obj, chpl_memory_order order) { \
   basetype ret; \
   (void) pthread_mutex_lock(&obj->lock); \
   ret = obj->v; \
   (void) pthread_mutex_unlock(&obj->lock); \
   return ret; \
 } \
-static inline basetype atomic_load_ ## type(atomic_ ## type * obj) { \
-  return atomic_load_explicit_ ## type(obj, memory_order_seq_cst); \
+static inline basetype atomic_load_ ## type(chpl_atomic_ ## type * obj) { \
+  return atomic_load_explicit_ ## type(obj, chpl_memory_order_seq_cst); \
 } \
 static MAYBE_INLINE basetype \
-atomic_exchange_explicit_ ## type(atomic_ ## type * obj, basetype value, memory_order order) { \
+atomic_exchange_explicit_ ## type(chpl_atomic_ ## type * obj, basetype value, chpl_memory_order order) { \
   basetype ret; \
   (void) pthread_mutex_lock(&obj->lock); \
   ret = obj->v; \
@@ -167,11 +167,11 @@ atomic_exchange_explicit_ ## type(atomic_ ## type * obj, basetype value, memory_
   (void) pthread_mutex_unlock(&obj->lock); \
   return ret; \
 } \
-static inline basetype atomic_exchange_ ## type(atomic_ ## type * obj, basetype value) { \
-  return atomic_exchange_explicit_ ## type(obj, value, memory_order_seq_cst); \
+static inline basetype atomic_exchange_ ## type(chpl_atomic_ ## type * obj, basetype value) { \
+  return atomic_exchange_explicit_ ## type(obj, value, chpl_memory_order_seq_cst); \
 } \
 static MAYBE_INLINE chpl_bool \
-atomic_compare_exchange_strong_explicit_ ## type(atomic_ ## type * obj, basetype * expected, basetype desired, memory_order succ, memory_order fail) { \
+atomic_compare_exchange_strong_explicit_ ## type(chpl_atomic_ ## type * obj, basetype * expected, basetype desired, chpl_memory_order succ, chpl_memory_order fail) { \
   basetype ret; \
   (void) pthread_mutex_lock(&obj->lock); \
   if( obj->v == *expected ) { \
@@ -184,19 +184,19 @@ atomic_compare_exchange_strong_explicit_ ## type(atomic_ ## type * obj, basetype
   (void) pthread_mutex_unlock(&obj->lock); \
   return ret; \
 } \
-static inline chpl_bool atomic_compare_exchange_strong_ ## type(atomic_ ## type * obj, basetype * expected, basetype desired) { \
-  return atomic_compare_exchange_strong_explicit_ ## type(obj, expected, desired, memory_order_seq_cst, memory_order_seq_cst); \
+static inline chpl_bool atomic_compare_exchange_strong_ ## type(chpl_atomic_ ## type * obj, basetype * expected, basetype desired) { \
+  return atomic_compare_exchange_strong_explicit_ ## type(obj, expected, desired, chpl_memory_order_seq_cst, chpl_memory_order_seq_cst); \
 } \
-static inline chpl_bool atomic_compare_exchange_weak_explicit_ ## type(atomic_ ## type * obj, basetype * expected, basetype desired, memory_order succ, memory_order fail) { \
+static inline chpl_bool atomic_compare_exchange_weak_explicit_ ## type(chpl_atomic_ ## type * obj, basetype * expected, basetype desired, chpl_memory_order succ, chpl_memory_order fail) { \
   return atomic_compare_exchange_strong_explicit_ ## type(obj, expected, desired, succ, fail); \
 } \
-static inline chpl_bool atomic_compare_exchange_weak_ ## type(atomic_ ## type * obj, basetype * expected, basetype desired) { \
-  return atomic_compare_exchange_weak_explicit_ ## type(obj, expected, desired, memory_order_seq_cst, memory_order_seq_cst); \
+static inline chpl_bool atomic_compare_exchange_weak_ ## type(chpl_atomic_ ## type * obj, basetype * expected, basetype desired) { \
+  return atomic_compare_exchange_weak_explicit_ ## type(obj, expected, desired, chpl_memory_order_seq_cst, chpl_memory_order_seq_cst); \
 }
 
 #define DECLARE_ATOMICS_FETCH_OPS(type) \
 static MAYBE_INLINE type \
-atomic_fetch_add_explicit_ ## type(atomic_ ## type * obj, type operand, memory_order order) { \
+atomic_fetch_add_explicit_ ## type(chpl_atomic_ ## type * obj, type operand, chpl_memory_order order) { \
   type ret; \
   (void) pthread_mutex_lock(&obj->lock); \
   ret = obj->v; \
@@ -204,11 +204,11 @@ atomic_fetch_add_explicit_ ## type(atomic_ ## type * obj, type operand, memory_o
   (void) pthread_mutex_unlock(&obj->lock); \
   return ret; \
 } \
-static inline type atomic_fetch_add_ ## type(atomic_ ## type * obj, type operand) { \
-  return atomic_fetch_add_explicit_ ## type(obj, operand, memory_order_seq_cst); \
+static inline type atomic_fetch_add_ ## type(chpl_atomic_ ## type * obj, type operand) { \
+  return atomic_fetch_add_explicit_ ## type(obj, operand, chpl_memory_order_seq_cst); \
 } \
 static MAYBE_INLINE type \
-atomic_fetch_sub_explicit_ ## type(atomic_ ## type * obj, type operand, memory_order order) { \
+atomic_fetch_sub_explicit_ ## type(chpl_atomic_ ## type * obj, type operand, chpl_memory_order order) { \
   type ret; \
   (void) pthread_mutex_lock(&obj->lock); \
   ret = obj->v; \
@@ -216,11 +216,11 @@ atomic_fetch_sub_explicit_ ## type(atomic_ ## type * obj, type operand, memory_o
   (void) pthread_mutex_unlock(&obj->lock); \
   return ret; \
 } \
-static inline type atomic_fetch_sub_ ## type(atomic_ ## type * obj, type operand) { \
-  return atomic_fetch_sub_explicit_ ## type(obj, operand, memory_order_seq_cst); \
+static inline type atomic_fetch_sub_ ## type(chpl_atomic_ ## type * obj, type operand) { \
+  return atomic_fetch_sub_explicit_ ## type(obj, operand, chpl_memory_order_seq_cst); \
 } \
 static MAYBE_INLINE type \
-atomic_fetch_or_explicit_ ## type(atomic_ ## type * obj, type operand, memory_order order) { \
+atomic_fetch_or_explicit_ ## type(chpl_atomic_ ## type * obj, type operand, chpl_memory_order order) { \
   type ret; \
   (void) pthread_mutex_lock(&obj->lock); \
   ret = obj->v; \
@@ -228,11 +228,11 @@ atomic_fetch_or_explicit_ ## type(atomic_ ## type * obj, type operand, memory_or
   (void) pthread_mutex_unlock(&obj->lock); \
   return ret; \
 } \
-static inline type atomic_fetch_or_ ## type(atomic_ ## type * obj, type operand) { \
-  return atomic_fetch_or_explicit_ ## type(obj, operand, memory_order_seq_cst); \
+static inline type atomic_fetch_or_ ## type(chpl_atomic_ ## type * obj, type operand) { \
+  return atomic_fetch_or_explicit_ ## type(obj, operand, chpl_memory_order_seq_cst); \
 } \
 static MAYBE_INLINE type \
-atomic_fetch_and_explicit_ ## type(atomic_ ## type * obj, type operand, memory_order order) { \
+atomic_fetch_and_explicit_ ## type(chpl_atomic_ ## type * obj, type operand, chpl_memory_order order) { \
   type ret; \
   (void) pthread_mutex_lock(&obj->lock); \
   ret = obj->v; \
@@ -240,11 +240,11 @@ atomic_fetch_and_explicit_ ## type(atomic_ ## type * obj, type operand, memory_o
   (void) pthread_mutex_unlock(&obj->lock); \
   return ret; \
 } \
-static inline type atomic_fetch_and_ ## type(atomic_ ## type * obj, type operand) { \
-  return atomic_fetch_and_explicit_ ## type(obj, operand, memory_order_seq_cst); \
+static inline type atomic_fetch_and_ ## type(chpl_atomic_ ## type * obj, type operand) { \
+  return atomic_fetch_and_explicit_ ## type(obj, operand, chpl_memory_order_seq_cst); \
 } \
 static MAYBE_INLINE type \
-atomic_fetch_xor_explicit_ ## type(atomic_ ## type * obj, type operand, memory_order order) { \
+atomic_fetch_xor_explicit_ ## type(chpl_atomic_ ## type * obj, type operand, chpl_memory_order order) { \
   type ret; \
   (void) pthread_mutex_lock(&obj->lock); \
   ret = obj->v; \
@@ -252,13 +252,13 @@ atomic_fetch_xor_explicit_ ## type(atomic_ ## type * obj, type operand, memory_o
   (void) pthread_mutex_unlock(&obj->lock); \
   return ret; \
 } \
-static inline type atomic_fetch_xor_ ## type(atomic_ ## type * obj, type operand) { \
-  return atomic_fetch_xor_explicit_ ## type(obj, operand, memory_order_seq_cst); \
+static inline type atomic_fetch_xor_ ## type(chpl_atomic_ ## type * obj, type operand) { \
+  return atomic_fetch_xor_explicit_ ## type(obj, operand, chpl_memory_order_seq_cst); \
 }
 
 #define DECLARE_REAL_ATOMICS_FETCH_OPS(type) \
 static MAYBE_INLINE type \
-atomic_fetch_add_explicit_ ## type(atomic_ ## type * obj, type operand, memory_order order) { \
+atomic_fetch_add_explicit_ ## type(chpl_atomic_ ## type * obj, type operand, chpl_memory_order order) { \
   type ret; \
   (void) pthread_mutex_lock(&obj->lock); \
   ret = obj->v; \
@@ -266,11 +266,11 @@ atomic_fetch_add_explicit_ ## type(atomic_ ## type * obj, type operand, memory_o
   (void) pthread_mutex_unlock(&obj->lock); \
   return ret; \
 } \
-static inline type atomic_fetch_add_ ## type(atomic_ ## type * obj, type operand) { \
-  return atomic_fetch_add_explicit_ ## type(obj, operand, memory_order_seq_cst); \
+static inline type atomic_fetch_add_ ## type(chpl_atomic_ ## type * obj, type operand) { \
+  return atomic_fetch_add_explicit_ ## type(obj, operand, chpl_memory_order_seq_cst); \
 } \
 static MAYBE_INLINE type \
-atomic_fetch_sub_explicit_ ## type(atomic_ ## type * obj, type operand, memory_order order) { \
+atomic_fetch_sub_explicit_ ## type(chpl_atomic_ ## type * obj, type operand, chpl_memory_order order) { \
   type ret; \
   (void) pthread_mutex_lock(&obj->lock); \
   ret = obj->v; \
@@ -278,8 +278,8 @@ atomic_fetch_sub_explicit_ ## type(atomic_ ## type * obj, type operand, memory_o
   (void) pthread_mutex_unlock(&obj->lock); \
   return ret; \
 } \
-static inline type atomic_fetch_sub_ ## type(atomic_ ## type * obj, type operand) { \
-  return atomic_fetch_sub_explicit_ ## type(obj, operand, memory_order_seq_cst); \
+static inline type atomic_fetch_sub_ ## type(chpl_atomic_ ## type * obj, type operand) { \
+  return atomic_fetch_sub_explicit_ ## type(obj, operand, chpl_memory_order_seq_cst); \
 }
 
 DECLARE_ATOMICS_BASE(bool, chpl_bool);

--- a/runtime/include/atomics/locks/chpl-atomics.h
+++ b/runtime/include/atomics/locks/chpl-atomics.h
@@ -313,25 +313,25 @@ DECLARE_REAL_ATOMICS(_real64);
 #undef DECLARE_ATOMICS
 #undef MAYBE_INLINE
 
-static inline void atomic_init_spinlock_t(atomic_spinlock_t* lock) {
+static inline void atomic_init_spinlock_t(chpl_atomic_spinlock_t* lock) {
   pthread_spin_init(lock, PTHREAD_PROCESS_PRIVATE);
 }
 
-static inline void atomic_destroy_spinlock_t(atomic_spinlock_t* lock) {
+static inline void atomic_destroy_spinlock_t(chpl_atomic_spinlock_t* lock) {
   pthread_spin_destroy(lock);
 }
 
-static inline chpl_bool atomic_try_lock_spinlock_t(atomic_spinlock_t* lock) {
+static inline chpl_bool atomic_try_lock_spinlock_t(chpl_atomic_spinlock_t* lock) {
   return pthread_spin_trylock(lock) == 0;
 }
 
-static inline void atomic_lock_spinlock_t(atomic_spinlock_t* lock) {
+static inline void atomic_lock_spinlock_t(chpl_atomic_spinlock_t* lock) {
   while(!atomic_try_lock_spinlock_t(lock)) {
     chpl_task_yield();
   }
 }
 
-static inline void atomic_unlock_spinlock_t(atomic_spinlock_t* lock) {
+static inline void atomic_unlock_spinlock_t(chpl_atomic_spinlock_t* lock) {
   pthread_spin_unlock(lock);
 }
 

--- a/runtime/include/chpl-comm-diags.h
+++ b/runtime/include/chpl-comm-diags.h
@@ -90,7 +90,7 @@ void chpl_comm_getDiagnosticsHere(chpl_commDiagnostics *cd);
 // Private
 //
 typedef struct _chpl_atomic_commDiagnostics {
-#define _COMM_DIAGS_DECL_ATOMIC(cdv) atomic_uint_least64_t cdv;
+#define _COMM_DIAGS_DECL_ATOMIC(cdv) chpl_atomic_uint_least64_t cdv;
   CHPL_COMM_DIAGS_VARS_ALL(_COMM_DIAGS_DECL_ATOMIC)
 #undef _COMM_DIAGS_DECL_ATOMIC
 } chpl_atomic_commDiagnostics;
@@ -174,9 +174,9 @@ extern chpl_bool chpl_task_getCommDiagsTemporarilyDisabled(void);
   do {                                                                       \
     if (chpl_comm_diagnostics &&                                             \
         !chpl_task_getCommDiagsTemporarilyDisabled()) {                      \
-      atomic_uint_least64_t* ctrAddr = &chpl_comm_diags_counters._ctr;       \
+      chpl_atomic_uint_least64_t* ctrAddr = &chpl_comm_diags_counters._ctr;       \
       (void) atomic_fetch_add_explicit_uint_least64_t(ctrAddr, 1,            \
-                                                      memory_order_relaxed); \
+                                                      chpl_memory_order_relaxed); \
     }                                                                        \
   } while(0)
 

--- a/runtime/include/chpl-comm-native-atomics.h
+++ b/runtime/include/chpl-comm-native-atomics.h
@@ -47,7 +47,7 @@ extern "C" {
 #define DECL_CHPL_COMM_ATOMIC_WRITE(type)                               \
   void chpl_comm_atomic_write_ ## type                                  \
          (void* desired, c_nodeid_t node, void* object,                 \
-          memory_order order, int ln, int32_t fn);
+          chpl_memory_order order, int ln, int32_t fn);
 
 DECL_CHPL_COMM_ATOMIC_WRITE(int32)
 DECL_CHPL_COMM_ATOMIC_WRITE(int64)
@@ -66,7 +66,7 @@ DECL_CHPL_COMM_ATOMIC_WRITE(real64)
 #define DECL_CHPL_COMM_ATOMIC_READ(type)                                \
   void chpl_comm_atomic_read_ ## type                                   \
          (void* result, c_nodeid_t node, void* object,                  \
-          memory_order order, int ln, int32_t fn);
+          chpl_memory_order order, int ln, int32_t fn);
 
 DECL_CHPL_COMM_ATOMIC_READ(int32)
 DECL_CHPL_COMM_ATOMIC_READ(int64)
@@ -84,7 +84,7 @@ DECL_CHPL_COMM_ATOMIC_READ(real64)
 #define DECL_CHPL_COMM_ATOMIC_XCHG(type)                                \
   void chpl_comm_atomic_xchg_ ## type                                   \
          (void* desired, c_nodeid_t node, void* object, void* result,   \
-          memory_order order, int ln, int32_t fn);
+          chpl_memory_order order, int ln, int32_t fn);
 
 DECL_CHPL_COMM_ATOMIC_XCHG(int32)
 DECL_CHPL_COMM_ATOMIC_XCHG(int64)
@@ -104,7 +104,7 @@ DECL_CHPL_COMM_ATOMIC_XCHG(real64)
 #define DECL_CHPL_COMM_ATOMIC_CMPXCHG(type)                             \
   void chpl_comm_atomic_cmpxchg_ ## type                                \
          (void* expected, void* desired, c_nodeid_t node, void* object, \
-          chpl_bool32* result, memory_order succ, memory_order fail,    \
+          chpl_bool32* result, chpl_memory_order succ, chpl_memory_order fail,    \
           int ln, int32_t fn);
 
 DECL_CHPL_COMM_ATOMIC_CMPXCHG(int32)
@@ -127,7 +127,7 @@ DECL_CHPL_COMM_ATOMIC_CMPXCHG(real64)
 #define DECL_CHPL_COMM_ATOMIC_NONFETCH_BINARY(op, type)                 \
   void chpl_comm_atomic_ ## op ## _ ## type                             \
          (void* operand, c_nodeid_t node, void* object,                 \
-          memory_order order, int ln, int32_t fn);
+          chpl_memory_order order, int ln, int32_t fn);
 #define DECL_CHPL_COMM_ATOMIC_NONFETCH_UNORDERED_BINARY(op, type)       \
   void chpl_comm_atomic_ ## op ## _unordered_ ## type                   \
          (void* operand, c_nodeid_t node, void* object,                 \
@@ -135,7 +135,7 @@ DECL_CHPL_COMM_ATOMIC_CMPXCHG(real64)
 #define DECL_CHPL_COMM_ATOMIC_FETCH_BINARY(op, type)                    \
   void chpl_comm_atomic_fetch_ ## op ## _ ## type                       \
          (void* operand, c_nodeid_t node, void* object, void* result,   \
-          memory_order order, int ln, int32_t fn);
+          chpl_memory_order order, int ln, int32_t fn);
 #define DECL_CHPL_COMM_ATOMIC_BINARY(op, type)                          \
   DECL_CHPL_COMM_ATOMIC_NONFETCH_BINARY(op, type)                       \
   DECL_CHPL_COMM_ATOMIC_NONFETCH_UNORDERED_BINARY(op, type)             \

--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -423,7 +423,7 @@ static inline void chpl_comm_barrier(const char *msg) {
     return;
   }
 
-  chpl_rmem_consist_fence(memory_order_seq_cst, 0, 0);
+  chpl_rmem_consist_fence(chpl_memory_order_seq_cst, 0, 0);
   chpl_comm_impl_barrier(msg);
 }
 

--- a/runtime/include/chpl-gpu-diags.h
+++ b/runtime/include/chpl-gpu-diags.h
@@ -73,13 +73,13 @@ void chpl_gpu_getDiagnosticsHere(chpl_gpuDiagnostics *cd);
 // Private
 //
 typedef struct _chpl_atomic_gpuDiagnostics {
-#define _GPU_DIAGS_DECL_ATOMIC(cdv) atomic_uint_least64_t cdv;
+#define _GPU_DIAGS_DECL_ATOMIC(cdv) chpl_atomic_uint_least64_t cdv;
   CHPL_GPU_DIAGS_VARS_ALL(_GPU_DIAGS_DECL_ATOMIC)
 #undef _GPU_DIAGS_DECL_ATOMIC
 } chpl_atomic_gpuDiagnostics;
 
 extern chpl_atomic_gpuDiagnostics chpl_gpu_diags_counters;
-extern atomic_int_least16_t chpl_gpu_diags_disable_flag;
+extern chpl_atomic_int_least16_t chpl_gpu_diags_disable_flag;
 
 static inline
 void chpl_gpu_diags_init(void) {
@@ -168,9 +168,9 @@ int chpl_gpu_diags_is_enabled(void) {
 #define chpl_gpu_diags_incr(_ctr)                                           \
   do {                                                                       \
     if (chpl_gpu_diagnostics && chpl_gpu_diags_is_enabled()) {             \
-      atomic_uint_least64_t* ctrAddr = &chpl_gpu_diags_counters._ctr;       \
+      chpl_atomic_uint_least64_t* ctrAddr = &chpl_gpu_diags_counters._ctr;       \
       (void) atomic_fetch_add_explicit_uint_least64_t(ctrAddr, 1,            \
-                                                      memory_order_relaxed); \
+                                                      chpl_memory_order_relaxed); \
     }                                                                        \
   } while(0)
 

--- a/runtime/include/chpl-mem-consistency.h
+++ b/runtime/include/chpl-mem-consistency.h
@@ -21,7 +21,7 @@
 #ifndef _chpl_mem_consistency_h_
 #define _chpl_mem_consistency_h_
 
-#include "chpl-atomics.h" // for memory_order
+#include "chpl-atomics.h" // for chpl_memory_order
 
 #include "chpl-cache.h" // for chpl_cache_release, chpl_cache_acquire
 
@@ -92,9 +92,9 @@ void chpl_rmem_consist_acquire(int ln, int32_t fn)
 // operations/fences.
 
 static inline
-//void chpl_atomic_rmem_fence_pre(memory_order order, int ln, int32_t fn) {
-void chpl_rmem_consist_maybe_release(memory_order order, int ln, int32_t fn) {
-  if(order==memory_order_acquire || order==memory_order_relaxed) {
+//void chpl_atomic_rmem_fence_pre(chpl_memory_order order, int ln, int32_t fn) {
+void chpl_rmem_consist_maybe_release(chpl_memory_order order, int ln, int32_t fn) {
+  if(order==chpl_memory_order_acquire || order==chpl_memory_order_relaxed) {
     // do nothing
   } else {
     // for release or sequentially consistent, flush pending writes
@@ -102,9 +102,9 @@ void chpl_rmem_consist_maybe_release(memory_order order, int ln, int32_t fn) {
   }
 }
 static inline
-//void chpl_atomic_rmem_fence_post(memory_order order, int ln, int32_t fn) {
-void chpl_rmem_consist_maybe_acquire(memory_order order, int ln, int32_t fn) {
-  if(order==memory_order_release || order==memory_order_relaxed) {
+//void chpl_atomic_rmem_fence_post(chpl_memory_order order, int ln, int32_t fn) {
+void chpl_rmem_consist_maybe_acquire(chpl_memory_order order, int ln, int32_t fn) {
+  if(order==chpl_memory_order_release || order==chpl_memory_order_relaxed) {
     // do nothing
   } else {
     // for acquire or sequentially consistent, do not reuse any cached values
@@ -113,14 +113,14 @@ void chpl_rmem_consist_maybe_acquire(memory_order order, int ln, int32_t fn) {
 }
 
 static inline
-//void chpl_atomic_rmem_fence(memory_order order, int ln, int32_t fn) {
-void chpl_rmem_consist_fence(memory_order order, int ln, int32_t fn) {
-  if(order==memory_order_relaxed) {
+//void chpl_atomic_rmem_fence(chpl_memory_order order, int ln, int32_t fn) {
+void chpl_rmem_consist_fence(chpl_memory_order order, int ln, int32_t fn) {
+  if(order==chpl_memory_order_relaxed) {
     // do nothing
   } else {
     int acquire = 1;
     int release = 1;
-    if( order == memory_order_acquire ) {
+    if( order == chpl_memory_order_acquire ) {
       release = 0;
     } else if( order == memory_order_release ) {
       acquire = 0;

--- a/runtime/include/qio/qbuffer.h
+++ b/runtime/include/qio/qbuffer.h
@@ -50,7 +50,7 @@ typedef std::atomic<qb_refcnt_base_t> qbytes_refcnt_t;
 #define ATOMIC_DEST(a)
 #else
 #include "chpl-atomics.h"
-typedef atomic_uint_least64_t qbytes_refcnt_t;
+typedef chpl_atomic_uint_least64_t qbytes_refcnt_t;
 #define ATOMIC_INIT(a, val) atomic_init_uint_least64_t(&a, val)
 #define ATOMIC_LOAD(a) atomic_load_uint_least64_t(&a)
 #define ATOMIC_INCR(a) atomic_fetch_add_uint_least64_t(&a, 1)

--- a/runtime/include/qio/qio.h
+++ b/runtime/include/qio/qio.h
@@ -99,7 +99,7 @@ typedef qio_fdflag_t fdflag_t;
 
 // make a re-entrant lock.
 typedef struct {
-  atomic_spinlock_t lock;
+  chpl_atomic_spinlock_t lock;
   chpl_taskID_t owner; // task ID of owner.
   uint64_t count; // how many times owner has locked.
 } qio_lock_t;

--- a/runtime/src/chpl-gpu-diags.c
+++ b/runtime/src/chpl-gpu-diags.c
@@ -41,7 +41,7 @@ int chpl_verbose_gpu_stacktrace = 0;
 int chpl_gpu_diagnostics = 0;
 int chpl_gpu_diags_print_unstable = 0;
 
-atomic_int_least16_t chpl_gpu_diags_disable_flag;
+chpl_atomic_int_least16_t chpl_gpu_diags_disable_flag;
 chpl_atomic_gpuDiagnostics chpl_gpu_diags_counters;
 
 static pthread_once_t bcastPrintUnstable_once = PTHREAD_ONCE_INIT;

--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -50,7 +50,7 @@ bool chpl_gpu_use_stream_per_task = true;
 
 #include <inttypes.h>
 
-static atomic_spinlock_t* priv_table_lock = NULL;
+static chpl_atomic_spinlock_t* priv_table_lock = NULL;
 
 void chpl_gpu_init(void) {
   chpl_gpu_impl_init(&chpl_gpu_num_devices);
@@ -92,7 +92,7 @@ void chpl_gpu_init(void) {
 
   // TODO these should be freed
   priv_table_lock = chpl_mem_alloc(chpl_gpu_num_devices *
-                                   sizeof(atomic_spinlock_t),
+                                   sizeof(chpl_atomic_spinlock_t),
                                    CHPL_RT_MD_GPU_UTIL, 0, 0);
 
   for (int i=0 ; i<chpl_gpu_num_devices ; i++) {
@@ -548,7 +548,7 @@ static void cfg_finalize_priv_table(kernel_cfg *cfg) {
 
   CHPL_GPU_DEBUG("Global for the device table: %p\n", dev_global);
 
-  atomic_spinlock_t* lock = &(priv_table_lock[cfg->dev]);
+  chpl_atomic_spinlock_t* lock = &(priv_table_lock[cfg->dev]);
   while(!atomic_try_lock_spinlock_t(lock)) {
     chpl_task_yield();
   }

--- a/runtime/src/chpl-privatization.c
+++ b/runtime/src/chpl-privatization.c
@@ -24,7 +24,7 @@
 #include "chpl-atomics.h"
 
 static int64_t chpl_capPrivateObjects = 0;
-static atomic_spinlock_t lock;
+static chpl_atomic_spinlock_t lock;
 
 chpl_privateObject_t* chpl_privateObjects = NULL;
 

--- a/runtime/src/chplmemtrack.c
+++ b/runtime/src/chplmemtrack.c
@@ -185,9 +185,9 @@ void chpl_setMemFlags(void) {
     hashSizeIndex = 0;
     hashSize = hashSizes[hashSizeIndex];
     memTable = sys_calloc(hashSize, sizeof(memTableEntry*));
-    chpl_atomic_thread_fence(memory_order_release);
+    chpl_atomic_thread_fence(chpl_memory_order_release);
     chpl_memTrack = local_memTrack;
-    chpl_atomic_thread_fence(memory_order_release);
+    chpl_atomic_thread_fence(chpl_memory_order_release);
   }
 }
 

--- a/runtime/src/comm/gasnet/comm-gasnet-ex.c
+++ b/runtime/src/comm/gasnet/comm-gasnet-ex.c
@@ -147,9 +147,9 @@ void* get_ptr_from_args(gasnet_handlerarg_t a0, gasnet_handlerarg_t a1 )
 // of an AM handler.)
 //
 typedef struct {
-  atomic_uint_least32_t count;
-  uint_least32_t        target;
-  volatile int          flag;
+  chpl_atomic_uint_least32_t count;
+  uint_least32_t             target;
+  volatile int               flag;
 } done_t;
 
 //
@@ -501,7 +501,7 @@ static void AM_signal(gasnet_token_t token, gasnet_handlerarg_t a0, gasnet_handl
   done_t* done = (done_t*) get_ptr_from_args(a0, a1);
   uint_least32_t prev;
   prev = atomic_fetch_add_explicit_uint_least32_t(&done->count, 1,
-                                                  memory_order_seq_cst);
+                                                  chpl_memory_order_seq_cst);
   if (prev + 1 == done->target)
     done->flag = 1;
 }
@@ -511,7 +511,7 @@ static void AM_signal_long(gasnet_token_t token, void *buf, size_t nbytes,
   done_t* done = (done_t*) get_ptr_from_args(a0, a1);
   uint_least32_t prev;
   prev = atomic_fetch_add_explicit_uint_least32_t(&done->count, 1,
-                                                  memory_order_seq_cst);
+                                                  chpl_memory_order_seq_cst);
   if (prev + 1 == done->target)
     done->flag = 1;
 }
@@ -728,7 +728,7 @@ int32_t chpl_comm_getMaxThreads(void) {
 static volatile int pollingRunning;
 static volatile int pollingQuit;
 static chpl_bool pollingRequired = false;
-static atomic_spinlock_t pollingLock;
+static chpl_atomic_spinlock_t pollingLock;
 static chpl_bool pshmInUse = false;
 static chpl_bool haveSendThread = false;
 static chpl_bool haveReceiveThread = false;

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -138,9 +138,9 @@ void* get_ptr_from_args(gasnet_handlerarg_t a0, gasnet_handlerarg_t a1 )
 // of an AM handler.)
 //
 typedef struct {
-  atomic_uint_least32_t count;
-  uint_least32_t        target;
-  volatile int          flag;
+  chpl_atomic_uint_least32_t count;
+  uint_least32_t             target;
+  volatile int               flag;
 } done_t;
 
 //
@@ -493,7 +493,7 @@ static void AM_signal(gasnet_token_t token, gasnet_handlerarg_t a0, gasnet_handl
   done_t* done = (done_t*) get_ptr_from_args(a0, a1);
   uint_least32_t prev;
   prev = atomic_fetch_add_explicit_uint_least32_t(&done->count, 1,
-                                                  memory_order_seq_cst);
+                                                  chpl_memory_order_seq_cst);
   if (prev + 1 == done->target)
     done->flag = 1;
 }
@@ -503,7 +503,7 @@ static void AM_signal_long(gasnet_token_t token, void *buf, size_t nbytes,
   done_t* done = (done_t*) get_ptr_from_args(a0, a1);
   uint_least32_t prev;
   prev = atomic_fetch_add_explicit_uint_least32_t(&done->count, 1,
-                                                  memory_order_seq_cst);
+                                                  chpl_memory_order_seq_cst);
   if (prev + 1 == done->target)
     done->flag = 1;
 }
@@ -728,7 +728,7 @@ int32_t chpl_comm_getMaxThreads(void) {
 static volatile int pollingRunning;
 static volatile int pollingQuit;
 static chpl_bool pollingRequired;
-static atomic_spinlock_t pollingLock;
+static chpl_atomic_spinlock_t pollingLock;
 
 static inline void am_poll_try(void) {
   // Serialize polling for IBV, UCX, Aries, and OFI. Concurrent polling causes

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -7766,10 +7766,10 @@ void doCpuAMO(void* obj,
 #define CPU_INT_ARITH_AMO(_o, _t, _m)                                   \
   do {                                                                  \
     if (result == NULL) {                                               \
-      (void) atomic_fetch_##_o##_##_t((atomic_##_t*) obj,               \
+      (void) atomic_fetch_##_o##_##_t((chpl_atomic_##_t*) obj,               \
                                       myOpnd->_m);                      \
     } else {                                                            \
-      *(_t*) result = atomic_fetch_##_o##_##_t((atomic_##_t*) obj,      \
+      *(_t*) result = atomic_fetch_##_o##_##_t((chpl_atomic_##_t*) obj,      \
                                                myOpnd->_m);             \
     }                                                                   \
   } while (0)

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -129,7 +129,7 @@ static chpl_bool debug_exiting = false;
 static pthread_t proc_thread_id;
 
 static __thread uint32_t thread_idx      = ~(uint32_t) 0;
-static atomic_uint_least32_t next_thread_idx;
+static chpl_atomic_uint_least32_t next_thread_idx;
 #define _DBG_NEXT_THREAD_IDX() \
         atomic_fetch_add_uint_least32_t(&next_thread_idx, 1)
 
@@ -347,7 +347,7 @@ chpl_comm_pstats_t chpl_comm_pstats;
 #define PERFSTATS_LD(cnt)         _PSV_LD_FUNC(&_PSV_VAR(cnt))
 #define PERFSTATS_ST(cnt, val)    _PSV_ST_FUNC(&_PSV_VAR(cnt), val)
 #define PERFSTATS_STZ(cnt)        PERFSTATS_ST(cnt, 0)
-#define PERFSTATS_ADD(cnt, val)   (void) _PSV_ADD_FUNC_E(&_PSV_VAR(cnt), val, memory_order_relaxed)
+#define PERFSTATS_ADD(cnt, val)   (void) _PSV_ADD_FUNC_E(&_PSV_VAR(cnt), val, chpl_memory_order_relaxed)
 #define PERFSTATS_INC(cnt)        PERFSTATS_ADD(cnt, 1)
 
 #include <time.h>
@@ -570,7 +570,7 @@ static int max_mem_regions;
 static size_t mem_regions_size;
 
 static mem_region_table_t* mem_regions;
-static atomic_int_least32_t mreg_free_cnt;
+static chpl_atomic_int_least32_t mreg_free_cnt;
 static uint32_t mreg_cnt_max;
 
 static mem_region_table_t* mem_regions_all;
@@ -638,7 +638,7 @@ static mem_region_t* gnr_mreg_map;
 // fault-in failures, and reporting out-of-memory in response.
 //
 static struct sigaction previous_SIGBUS_sigact;
-static atomic_bool SIGBUS_gate;
+static chpl_atomic_bool SIGBUS_gate;
 
 struct mregs_supp {
   chpl_mem_descInt_t desc;
@@ -714,7 +714,7 @@ mpool_idx_base_t mpool_idx_finc(mpool_idx_t* pvar) {
 #define CD_ACTIVE_TRANS_MAX 128     // Max transactions in flight, per cd
 
 typedef uint32_t cq_cnt_t;
-typedef atomic_uint_least32_t cq_cnt_atomic_t;
+typedef chpl_atomic_uint_least32_t cq_cnt_atomic_t;
 
 #define CQ_CNT_INIT(cd, val) \
         atomic_init_uint_least32_t(&(cd)->cq_cnt_curr, val)
@@ -743,13 +743,13 @@ typedef atomic_uint_least32_t cq_cnt_atomic_t;
 // is the only one with cheap atomic reads.)
 
 typedef struct {
-  atomic_spinlock_t  busy CACHE_LINE_ALIGN;
-  cq_cnt_atomic_t    cq_cnt_curr CACHE_LINE_ALIGN;
-  chpl_bool          firmly_bound;
-  gni_nic_handle_t   nih;
-  gni_ep_handle_t*   remote_eps;
-  gni_cq_handle_t    cqh;
-  cq_cnt_t           cq_cnt_max;
+  chpl_atomic_spinlock_t  busy CACHE_LINE_ALIGN;
+  cq_cnt_atomic_t         cq_cnt_curr CACHE_LINE_ALIGN;
+  chpl_bool               firmly_bound;
+  gni_nic_handle_t        nih;
+  gni_ep_handle_t*        remote_eps;
+  gni_cq_handle_t         cqh;
+  cq_cnt_t                cq_cnt_max;
 #ifdef DEBUG_STATS
   uint64_t           acqs;
   uint64_t           acqs_looks;
@@ -768,7 +768,7 @@ static uint32_t     comm_dom_cnt_max;
 
 static comm_dom_t*  comm_doms;
 
-static atomic_int_least32_t global_init_cdi;
+static chpl_atomic_int_least32_t global_init_cdi;
 static __thread int comm_dom_free_idx = -1;
 static __thread comm_dom_t* cd = NULL;
 static __thread int cd_idx = -1;
@@ -834,7 +834,7 @@ static size_t rdma_threshold = DEFAULT_RDMA_THRESHOLD;
 
 typedef struct {
   gni_post_descriptor_t post_desc;  // POST descriptor for an NB transaction
-  atomic_bool done;                 // transaction has completed?
+  chpl_atomic_bool done;                 // transaction has completed?
   int cdi;                          // index of comm domain used for post
   mpool_idx_base_t next;            // free list index
 } nb_desc_t;
@@ -886,7 +886,7 @@ typedef mpool_idx_base_t rf_done_pool_t;
 
 static rf_done_pool_t (*rf_done_pool)[RF_DONE_NUM_PER_POOL];
 static mpool_idx_t rf_done_pool_head[RF_DONE_NUM_POOLS];
-static atomic_bool rf_done_pool_lock[RF_DONE_NUM_POOLS];
+static chpl_atomic_bool rf_done_pool_lock[RF_DONE_NUM_POOLS];
 
 static mpool_idx_t rf_done_pool_i;
 
@@ -1231,7 +1231,7 @@ static gni_fma_cmd_type_t nic_amos_ari[]        // Aries, non-fetching
         static const int gbp_##size##_num_per_pool = nPerPool;          \
         static int64_t* gbp_##size;                                     \
         static mpool_idx_t gbp_##size##_head[nPools];                   \
-        static atomic_bool gbp_##size##_lock[nPools];                   \
+        static chpl_atomic_bool gbp_##size##_lock[nPools];                   \
         static mpool_idx_t gbp_##size##_pool_i;                         \
         static inline                                                   \
         mpool_idx_base_t gbp_##size##_next_pool_i(void)                 \
@@ -1285,7 +1285,7 @@ static const int gbp_max_size = 4096;
 
 static fork_amo_data_t (*amo_res_pool)[AMO_RES_NUM_PER_POOL];
 static mpool_idx_t amo_res_pool_head[AMO_RES_NUM_POOLS];
-static atomic_bool amo_res_pool_lock[AMO_RES_NUM_POOLS];
+static chpl_atomic_bool amo_res_pool_lock[AMO_RES_NUM_POOLS];
 
 static mpool_idx_t amo_res_pool_i;
 
@@ -1550,7 +1550,7 @@ static const char* fork_op_name(fork_op_t op)
 }
 
 
-static atomic_uint_least64_t dbg_fork_seq;
+static chpl_atomic_uint_least64_t dbg_fork_seq;
 #define DBG_SET_SEQ(s) (s = atomic_fetch_add_uint_least64_t(&dbg_fork_seq, 1))
 
 
@@ -2643,7 +2643,7 @@ void register_memory(void)
   }
 
   can_register_memory = true;
-  chpl_atomic_thread_fence(memory_order_release);
+  chpl_atomic_thread_fence(chpl_memory_order_release);
 }
 
 
@@ -3247,7 +3247,7 @@ void SIGBUS_handler(int signo, siginfo_t *info, void *context)
       // Only say this once per node.
       //
       while (atomic_exchange_explicit_bool(&SIGBUS_gate, true,
-                                           memory_order_acquire)) {
+                                           chpl_memory_order_acquire)) {
         sleep(1); // listed as safe in a handler (sched_yield() isn't)
       }
 
@@ -4391,19 +4391,19 @@ size_t do_amo_on_cpu(fork_amo_cmd_t cmd,
   //
   switch (cmd) {
   case put_32:
-    atomic_store_int_least32_t((atomic_int_least32_t*) obj,
+    atomic_store_int_least32_t((chpl_atomic_int_least32_t*) obj,
                                *(int_least32_t*) opnd1);
     break;
 
   case put_64:
-    atomic_store_int_least64_t((atomic_int_least64_t*) obj,
+    atomic_store_int_least64_t((chpl_atomic_int_least64_t*) obj,
                                *(int_least64_t*) opnd1);
     break;
 
   case get_32:
     {
       int_least32_t my_res;
-      my_res = atomic_load_int_least32_t((atomic_int_least32_t*) obj);
+      my_res = atomic_load_int_least32_t((chpl_atomic_int_least32_t*) obj);
       memcpy(res, &my_res, sizeof(my_res));
       res_size = sizeof(my_res);
     }
@@ -4412,7 +4412,7 @@ size_t do_amo_on_cpu(fork_amo_cmd_t cmd,
   case get_64:
     {
       int_least64_t my_res;
-      my_res = atomic_load_int_least64_t((atomic_int_least64_t*) obj);
+      my_res = atomic_load_int_least64_t((chpl_atomic_int_least64_t*) obj);
       memcpy(res, &my_res, sizeof(my_res));
       res_size = sizeof(my_res);
     }
@@ -4421,7 +4421,7 @@ size_t do_amo_on_cpu(fork_amo_cmd_t cmd,
   case swap_32:
     {
       int_least32_t my_res;
-      my_res = atomic_exchange_int_least32_t((atomic_int_least32_t*) obj,
+      my_res = atomic_exchange_int_least32_t((chpl_atomic_int_least32_t*) obj,
                                              *(int_least32_t*) opnd1);
       memcpy(res, &my_res, sizeof(my_res));
       res_size = sizeof(my_res);
@@ -4431,7 +4431,7 @@ size_t do_amo_on_cpu(fork_amo_cmd_t cmd,
   case swap_64:
     {
       int_least64_t my_res;
-      my_res = atomic_exchange_int_least64_t((atomic_int_least64_t*) obj,
+      my_res = atomic_exchange_int_least64_t((chpl_atomic_int_least64_t*) obj,
                                              *(int_least64_t*) opnd1);
       memcpy(res, &my_res, sizeof(my_res));
       res_size = sizeof(my_res);
@@ -4442,7 +4442,7 @@ size_t do_amo_on_cpu(fork_amo_cmd_t cmd,
     {
       int_least32_t opnd1Val = *(int_least32_t*) opnd1;
       (void) atomic_compare_exchange_strong_int_least32_t
-               ((atomic_int_least32_t*) obj,
+               ((chpl_atomic_int_least32_t*) obj,
                 &opnd1Val,
                 *(int_least32_t*) opnd2);
       memcpy(res, &opnd1Val, sizeof(opnd1Val));
@@ -4454,7 +4454,7 @@ size_t do_amo_on_cpu(fork_amo_cmd_t cmd,
     {
       int_least64_t opnd1Val = *(int_least64_t*) opnd1;
       (void) atomic_compare_exchange_strong_int_least64_t
-               ((atomic_int_least64_t*) obj,
+               ((chpl_atomic_int_least64_t*) obj,
                 &opnd1Val,
                 *(int_least64_t*) opnd2);
       memcpy(res, &opnd1Val, sizeof(opnd1Val));
@@ -4508,7 +4508,7 @@ size_t do_amo_on_cpu(fork_amo_cmd_t cmd,
     {
       mem_region_t* mr;
 
-      if ((mr = mreg_for_local_addr(obj, sizeof(atomic__real64))) == NULL) {
+      if ((mr = mreg_for_local_addr(obj, sizeof(chpl_atomic__real64))) == NULL) {
         CPU_INT_ARITH_AMO(add, _real64);
       } else {
         int_least64_t expected;
@@ -4817,7 +4817,7 @@ void get_buf_pre_init(void)
 static
 inline
 void get_buf_N_init(int size, int nPools, int nPerPool, int64_t **gbp,
-                    mpool_idx_t gbp_head[], atomic_bool gbp_lock[],
+                    mpool_idx_t gbp_head[], chpl_atomic_bool gbp_lock[],
                     mpool_idx_t *p_gbp_pool_i)
 {
   const int pElemSize = size / sizeof(**gbp);
@@ -4861,7 +4861,7 @@ void get_buf_init(void)
 static
 inline
 void* get_buf_N_alloc(int size, int nPools, int nPerPool, int64_t gbp[],
-                      mpool_idx_t gbp_head[], atomic_bool gbp_lock[],
+                      mpool_idx_t gbp_head[], chpl_atomic_bool gbp_lock[],
                       mpool_idx_base_t gbp_next_pool_i)
 {
   const int pElemSize = size / sizeof(gbp[0]);
@@ -4923,7 +4923,7 @@ static
 inline
 chpl_bool get_buf_N_free(int64_t* p,
                          int size, int nPools, int nPerPool, int64_t gbp[],
-                         mpool_idx_t gbp_head[], atomic_bool gbp_lock[])
+                         mpool_idx_t gbp_head[], chpl_atomic_bool gbp_lock[])
 {
   const int pElemSize = size / sizeof(gbp[0]);
 
@@ -5080,7 +5080,7 @@ void consume_all_outstanding_cq_events(int cdi)
         // post_id is the pointer to the "done" flag the initiating task
         // is waiting on.
         //
-        atomic_store_bool((atomic_bool*) (intptr_t) post_desc->post_id, true);
+        atomic_store_bool((chpl_atomic_bool*) (intptr_t) post_desc->post_id, true);
       }
       CQ_CNT_DEC(cd);
     }
@@ -6266,7 +6266,7 @@ int chpl_comm_addr_gettable(c_nodeid_t node, void* start, size_t len)
         void chpl_comm_atomic_write_##_f(void* val,                     \
                                        int32_t loc,                     \
                                        void* obj,                       \
-                                       memory_order order,              \
+                                       chpl_memory_order order,         \
                                        int ln, int32_t fn)              \
         {                                                               \
           mem_region_t* remote_mr;                                      \
@@ -6311,7 +6311,7 @@ DEFINE_CHPL_COMM_ATOMIC_WRITE(real64, put_64, int_least64_t)
         void chpl_comm_atomic_read_##_f(void* res,                      \
                                        int32_t loc,                     \
                                        void* obj,                       \
-                                       memory_order order,              \
+                                       chpl_memory_order order,              \
                                        int ln, int32_t fn)              \
         {                                                               \
           mem_region_t* remote_mr;                                      \
@@ -6360,7 +6360,7 @@ DEFINE_CHPL_COMM_ATOMIC_READ(real64, get_64, int_least64_t)
                                         int32_t loc,                    \
                                         void* obj,                      \
                                         void* res,                      \
-                                        memory_order order,             \
+                                        chpl_memory_order order,             \
                                         int ln, int32_t fn)             \
         {                                                               \
           mem_region_t* remote_mr;                                      \
@@ -6407,8 +6407,8 @@ DEFINE_CHPL_COMM_ATOMIC_XCHG(real64, swap_64, int_least64_t)
                                            int32_t loc,                 \
                                            void* obj,                   \
                                            chpl_bool32* res,            \
-                                           memory_order succ,           \
-                                           memory_order fail,           \
+                                           chpl_memory_order succ,           \
+                                           chpl_memory_order fail,           \
                                            int ln, int32_t fn)          \
         {                                                               \
           mem_region_t* remote_mr;                                      \
@@ -6461,7 +6461,7 @@ DEFINE_CHPL_COMM_ATOMIC_CMPXCHG(real64, cswap_64, int_least64_t)
         void chpl_comm_atomic_##_o##_##_f(void* opnd,                   \
                                           int32_t loc,                  \
                                           void* obj,                    \
-                                          memory_order order,           \
+                                          chpl_memory_order order,           \
                                           int ln, int32_t fn)           \
         {                                                               \
           mem_region_t* remote_mr;                                      \
@@ -6515,7 +6515,7 @@ DEFINE_CHPL_COMM_ATOMIC_CMPXCHG(real64, cswap_64, int_least64_t)
                                                 int32_t loc,            \
                                                 void* obj,              \
                                                 void* res,              \
-                                                memory_order order,     \
+                                                chpl_memory_order order,     \
                                                 int ln, int32_t fn)     \
         {                                                               \
           mem_region_t* remote_mr;                                      \
@@ -6577,7 +6577,7 @@ DEFINE_CHPL_COMM_ATOMIC_INT_OP(uint64, add, add_i64, uint_least64_t)
         void chpl_comm_atomic_add_##_f(void* opnd,                      \
                                        int32_t loc,                     \
                                        void* obj,                       \
-                                       memory_order order,              \
+                                       chpl_memory_order order,              \
                                        int ln, int32_t fn)              \
         {                                                               \
           mem_region_t* remote_mr;                                      \
@@ -6631,7 +6631,7 @@ DEFINE_CHPL_COMM_ATOMIC_INT_OP(uint64, add, add_i64, uint_least64_t)
                                              int32_t loc,               \
                                              void* obj,                 \
                                              void* res,                 \
-                                             memory_order order,        \
+                                             chpl_memory_order order,        \
                                              int ln, int32_t fn)        \
         {                                                               \
           mem_region_t* remote_mr;                                      \
@@ -6671,7 +6671,7 @@ DEFINE_CHPL_COMM_ATOMIC_REAL_OP(real64, add_r64, _real64)
         void chpl_comm_atomic_sub_##_f(void* opnd,                      \
                                        int32_t loc,                     \
                                        void* obj,                       \
-                                       memory_order order,              \
+                                       chpl_memory_order order,              \
                                        int ln, int32_t fn)              \
         {                                                               \
           _t nopnd = _negate(*(_t*) opnd);                              \
@@ -6705,7 +6705,7 @@ DEFINE_CHPL_COMM_ATOMIC_REAL_OP(real64, add_r64, _real64)
                                              int32_t loc,               \
                                              void* obj,                 \
                                              void* res,                 \
-                                             memory_order order,        \
+                                             chpl_memory_order order,        \
                                              int ln, int32_t fn)        \
         {                                                               \
           _t nopnd = _negate(*(_t*) opnd);                              \
@@ -7294,7 +7294,7 @@ void do_fork_post(c_nodeid_t locale,
       *p_rf_done_addr = rf_done_alloc();
     }
     **p_rf_done_addr = 0;
-    chpl_atomic_thread_fence(memory_order_release);
+    chpl_atomic_thread_fence(chpl_memory_order_release);
 
     stack_post_desc = (gni_post_descriptor_t) { 0 };
     post_desc_p = &stack_post_desc;
@@ -7411,10 +7411,10 @@ void do_fork_post(c_nodeid_t locale,
 
           nb_desc = &nb_fork[i].nb_desc;
 
-          done = atomic_load_explicit_bool(&nb_desc->done, memory_order_acquire);
+          done = atomic_load_explicit_bool(&nb_desc->done, chpl_memory_order_acquire);
           if (!done) {
             consume_all_outstanding_cq_events(nb_desc->cdi);
-            done = atomic_load_explicit_bool(&nb_desc->done, memory_order_acquire);
+            done = atomic_load_explicit_bool(&nb_desc->done, chpl_memory_order_acquire);
           }
           if (done) {
             retired_any = true;
@@ -7681,7 +7681,7 @@ void post_fma_and_wait(c_nodeid_t locale, gni_post_descriptor_t* post_desc,
                        chpl_bool do_yield)
 {
   int cdi;
-  atomic_bool post_done;
+  chpl_atomic_bool post_done;
   uint64_t iters = 0;
 
   do_yield = should_yield_during_comm(do_yield);
@@ -7704,7 +7704,7 @@ void post_fma_and_wait(c_nodeid_t locale, gni_post_descriptor_t* post_desc,
     }
     consume_all_outstanding_cq_events(cdi);
     iters++;
-  } while (!atomic_load_explicit_bool(&post_done, memory_order_acquire));
+  } while (!atomic_load_explicit_bool(&post_done, chpl_memory_order_acquire));
 }
 
 #if HAVE_GNI_FMA_CHAIN_TRANSACTIONS
@@ -7762,7 +7762,7 @@ void post_fma_ct_and_wait(c_nodeid_t* locale_v,
                           gni_post_descriptor_t* post_desc)
 {
   int cdi;
-  atomic_bool post_done;
+  chpl_atomic_bool post_done;
 
   chpl_bool do_yield = should_yield_during_comm(true);
 
@@ -7781,7 +7781,7 @@ void post_fma_ct_and_wait(c_nodeid_t* locale_v,
       local_yield();
     }
     consume_all_outstanding_cq_events(cdi);
-  } while (!atomic_load_explicit_bool(&post_done, memory_order_acquire));
+  } while (!atomic_load_explicit_bool(&post_done, chpl_memory_order_acquire));
 }
 
 #endif
@@ -7813,7 +7813,7 @@ void post_rdma_and_wait(c_nodeid_t locale, gni_post_descriptor_t* post_desc,
                         chpl_bool do_yield)
 {
   int cdi;
-  atomic_bool post_done;
+  chpl_atomic_bool post_done;
 
   do_yield = should_yield_during_comm(do_yield);
 
@@ -7832,7 +7832,7 @@ void post_rdma_and_wait(c_nodeid_t locale, gni_post_descriptor_t* post_desc,
       local_yield();
     }
     consume_all_outstanding_cq_events(cdi);
-  } while (!atomic_load_explicit_bool(&post_done, memory_order_acquire));
+  } while (!atomic_load_explicit_bool(&post_done, chpl_memory_order_acquire));
 }
 
 

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -4372,12 +4372,12 @@ size_t do_amo_on_cpu(fork_amo_cmd_t cmd,
 #define CPU_INT_ARITH_AMO(_o, _t)                                       \
         do {                                                            \
           if (res == NULL) {                                            \
-            (void) atomic_fetch_##_o##_##_t((atomic_##_t*) obj,         \
+            (void) atomic_fetch_##_o##_##_t((chpl_atomic_##_t*) obj,         \
                                             *(_t*) opnd1);              \
           }                                                             \
           else {                                                        \
             _t my_res;                                                  \
-            my_res = atomic_fetch_##_o##_##_t((atomic_##_t*) obj,       \
+            my_res = atomic_fetch_##_o##_##_t((chpl_atomic_##_t*) obj,       \
                                               *(_t*) opnd1);            \
             memcpy(res, &my_res, sizeof(my_res));                       \
             res_size = sizeof(my_res);                                  \

--- a/runtime/src/error.c
+++ b/runtime/src/error.c
@@ -330,7 +330,7 @@ void chpl_warning_explicit(const char *message, int32_t lineno,
 }
 
 #ifndef LAUNCHER
-static atomic_bool thisLocaleAlreadyExiting;
+static chpl_atomic_bool thisLocaleAlreadyExiting;
 void chpl_error_init(void) {
   atomic_init_bool(&thisLocaleAlreadyExiting, false);
 }

--- a/test/functions/generic/withExternType.bad
+++ b/test/functions/generic/withExternType.bad
@@ -14,7 +14,7 @@ withExternType.chpl:27: warning: t4==t5 false
 withExternType.chpl:27: warning: t4==t6 false
 withExternType.chpl:27: warning: t5==t6 false
 withExternType.chpl:27: In function 'main':
-withExternType.chpl:52: error: unresolved call 'callAB(atomic_bool)'
+withExternType.chpl:52: error: unresolved call 'callAB(chpl_atomic_bool)'
 withExternType.chpl:19: note: this candidate did not match: callAB(arg: makeAB(int))
-withExternType.chpl:52: note: because actual argument #1 with type 'atomic_bool'
-withExternType.chpl:19: note: is passed to formal 'arg: atomic_bool'
+withExternType.chpl:52: note: because actual argument #1 with type 'chpl_atomic_bool'
+withExternType.chpl:19: note: is passed to formal 'arg: chpl_atomic_bool'

--- a/test/functions/generic/withExternType.chpl
+++ b/test/functions/generic/withExternType.chpl
@@ -4,24 +4,24 @@ module withExternType {
 
   // a generic function - can have multiple instantiations
   proc makeAB(type tt) type {
-    extern type atomic_bool;
-    return atomic_bool;
+    extern type chpl_atomic_bool;
+    return chpl_atomic_bool;
   }
 
   // a concrete function
   proc makeAB() type {
-    extern type atomic_bool;
-    return atomic_bool;
+    extern type chpl_atomic_bool;
+    return chpl_atomic_bool;
   }
 
-  extern type atomic_bool;
+  extern type chpl_atomic_bool;
 
   proc callAB(arg: makeAB(int)) {
     compilerError("success");
   }
 
   module aModule {
-    extern type atomic_bool;
+    extern type chpl_atomic_bool;
   }
 
   proc main {
@@ -30,8 +30,8 @@ module withExternType {
     type t2 = makeAB(int); // another call to the same instantiation
     type t3 = makeAB(bool);
     type t4 = makeAB();
-    type t5 = aModule.atomic_bool;
-    type t6 = atomic_bool;
+    type t5 = aModule.chpl_atomic_bool;
+    type t6 = chpl_atomic_bool;
     compilerWarning("t1==t2 ", (t1==t2):string);
     compilerWarning("t1==t3 ", (t1==t3):string);
     compilerWarning("t1==t4 ", (t1==t4):string);

--- a/test/parallel/taskCompare/elliot/endCount.h
+++ b/test/parallel/taskCompare/elliot/endCount.h
@@ -2,7 +2,7 @@
 #include "chpl-mem.h"
 
 typedef struct _EndCount {
-  atomic_int_least64_t runningTasks;
+  chpl_atomic_int_least64_t runningTasks;
 } EndCount;
 
 static EndCount* constructEndCount(void) {

--- a/test/runtime/ferguson/testatomics.test.c
+++ b/test/runtime/ferguson/testatomics.test.c
@@ -54,18 +54,18 @@
 
 int main(int argc, char** argv)
 {
-  atomic_bool flag;
+  chpl_atomic_bool flag;
 
   atomic_init_bool(&flag, true);
   atomic_store_bool(&flag, false);
   assert( false == atomic_exchange_bool(&flag, true) );
   assert( true == atomic_exchange_bool(&flag, true) );
 
-  chpl_atomic_thread_fence(memory_order_seq_cst);
-  chpl_atomic_signal_fence(memory_order_seq_cst);
+  chpl_atomic_thread_fence(chpl_memory_order_seq_cst);
+  chpl_atomic_signal_fence(chpl_memory_order_seq_cst);
 
   {
-    atomic_uint_least8_t tmp;
+    chpl_atomic_uint_least8_t tmp;
     atomic_load_uint_least8_t(&tmp);
   }
 

--- a/third-party/qthread/README
+++ b/third-party/qthread/README
@@ -2,7 +2,7 @@
 Qthreads README for Chapel
 ==========================
 
-This copy of Qthreads 1.19 is being released with Chapel for
+This copy of Qthreads 1.20 is being released with Chapel for
 convenience and was obtained from:
 
   https://github.com/sandialabs/qthreads

--- a/util/test/prediff-for-incremental-warning
+++ b/util/test/prediff-for-incremental-warning
@@ -17,7 +17,7 @@ incrementalTests = ["time_iterate", "time_access", "optimizeOnClauses_basic", "o
                     "access2d", "access3d", "ri-4-arrdom", "ri-4-arrdom.replicated", "ri-3-stress", "ri-3-stress-coforall", "assign",
                     "assign_across_locales", "copy_to_local", "dgemm", "init", "reductions-stress-fast", "sparse-iter-performance",
                     "externMethodCallPerf", "forVersusWhilePerf", "test_cholesky_performance", "mandelbrot-error-works",
-                    "mandelbrot-error", "atomic_bool", "atomic_vars", "ontest","uts_deq", "uts_rec", "dequeue", "sudoku-simple",
+                    "mandelbrot-error", "chpl_atomic_bool", "atomic_vars", "ontest","uts_deq", "uts_rec", "dequeue", "sudoku-simple",
                     "sudoku-simpler", "sudoku-smart", "sudoku", "leadFollowOpt", "ra-cleanloop", "ra-atomics", "ra", "test_for2d",
                     "test_cgapb", "test_cgapb_loop", "cg-sparse-timecomp", "fft-timecomp", "ManyThreads", "ft-serial", "cg-sparse",
                     "cg-printa", "cg-makea1-sparse-sort", "enumerated-array2", "enumerated-array", "formalDomainChecks3",


### PR DESCRIPTION
Avoid redefining stdatomic symbols in the Chapel runtime in some of our `CHPL_ATOMICS` portability layers.

Issues with redefinition can occur when stdatomic is used and `CHPL_ATOMICS=intrinsics` or `locks`, because those layers redefine stdatomic symbols. This is primarily an issue with qthreads 1.20, which now causes `stdatomic` to be used in all builds that use qthreads. The solution is to rewrite our runtime and standard library to use names with a prefix (`chpl_`) so we are defining our own symbols.

Testing
- [x] paratest with/without comm (gasnet) with `CHPL_ATOMICS=cstdlib`
- [x] paratest with/without comm (gasnet) with `CHPL_ATOMICS=intrinsics`
- [x] paratest with/without comm (gasnet) with `CHPL_ATOMICS=locks`
  - most tests passed except for some prior issues: see https://github.com/chapel-lang/chapel/issues/25760
- [x] build with `CHPL_COMM=ofi` with `CHPL_ATOMICS=cstdlib` and `CHPL_ATOMICS=intrinsics`
- [x] `start_test test/gpu/native` with `CHPL_GPU=cpu`

[Reviewed by @jhh67]

