### PR TITLE
Support for configurable compression algorithm in Zarr IO 

### DIFF
--- a/modules/packages/Zarr.chpl
+++ b/modules/packages/Zarr.chpl
@@ -144,7 +144,11 @@ module Zarr {
 
   private proc validateCompressor(compressor) throws {
     const supportedCompressors = ["blosclz", "lz4", "lz4hc", "zlib", "zstd"];
-    if supportedCompressors.find(compressor) == -1 then throw new Error("Unsupported compressor: %s".format(compressor));
+    if supportedCompressors.find(compressor) == -1 {
+      throw new IllegalArgumentError("Unsupported compressor: %s.".format(compressor) +
+                                     " Supported compressors are: blosclz, lz4, lz4hc, zlib, and zstd.");
+    }
+      
   }
 
   private proc buildChunkPath(directoryPath: string, delimiter: string, const chunkIndex: ?dimCount * int) {

--- a/modules/packages/Zarr.chpl
+++ b/modules/packages/Zarr.chpl
@@ -17,11 +17,11 @@
  * limitations under the License.
  */
 
-/*
-  Support for distributed reading and writing of Zarr stores. Support is
-  limited to v2 Zarr arrays stored on local filesystems. NFS is not supported.
-  The module uses c-blosc to compress and decompress chunks. Zarr
-  specification: https://zarr-specs.readthedocs.io/en/latest/v2/v2.0.html
+/* Support for reading and writing of Zarr stores.
+
+  Support is limited to v2 Zarr arrays stored on local filesystems. NFS
+  is not supported. The module uses c-blosc to compress and decompress chunks.
+  Zarr specification: https://zarr-specs.readthedocs.io/en/latest/v2/v2.0.html
 */
 module Zarr {
   use IO;

--- a/modules/packages/Zarr.chpl
+++ b/modules/packages/Zarr.chpl
@@ -148,7 +148,6 @@ module Zarr {
       throw new IllegalArgumentError("Unsupported compressor: %s.".format(compressor) +
                                      " Supported compressors are: blosclz, lz4, lz4hc, zlib, and zstd.");
     }
-      
   }
 
   private proc buildChunkPath(directoryPath: string, delimiter: string, const chunkIndex: ?dimCount * int) {

--- a/test/library/packages/Zarr/ZarrCompressors.chpl
+++ b/test/library/packages/Zarr/ZarrCompressors.chpl
@@ -1,0 +1,66 @@
+use Zarr;
+use IO;
+use FileSystem;
+use BlockDist;
+use Random;
+
+proc localTest(compressor: string) {
+  const N = 20;
+  const D: domain(2) = {0..<N, 0..<2*N};
+  var A: [D] real(32);
+  fillRandom(A);
+
+  if (exists("TestLocal")) then rmTree("TestLocal");
+  writeZarrArrayLocal("TestLocal", A, (7,18), compressor=compressor);
+
+  var B = readZarrArrayLocal("TestLocal", real(32), 2);
+  assert(A.domain == B.domain, "Domain mismatch: %? %?".format(A.domain, B.domain));
+  forall i in A.domain do 
+    assert(A[i] == B[i], "Mismatch for real data on indices: %?.\nWritten: %?\nRead: %?".format(i, A[i], B[i]));
+  rmTree("TestLocal");
+}
+
+proc distributedTest(compressor: string) {
+  const N = 20;
+  const D: domain(2) dmapped new blockDist({0..N, 0..<2*N}) = {0..<N, 0..<2*N};
+  var A: [D] real(32);
+  fillRandom(A);
+
+  if (exists("TestDistributed")) then rmTree("TestDistributed");
+  writeZarrArray("TestDistributed", A, (7,18), compressor=compressor);
+
+  var B = readZarrArray("TestDistributed", real(32), 2);
+  assert(A.domain == B.domain, "Domain mismatch: %? %?".format(A.domain, B.domain));
+  forall i in A.domain do 
+    assert(A[i] == B[i], "Mismatch for real data on indices: %?.\nWritten: %?\nRead: %?".format(i, A[i], B[i]));
+  rmTree("TestDistributed");
+}
+
+proc testUnsupportedCompressor() {
+  var A: [1..10] real(32);
+  try {
+    writeZarrArrayLocal("TestUnsupportedCompressor", A, (7,), compressor="unsupported");
+    assert(false, "Expected an error for unsupported compressor");
+  } catch e {
+    assert(e.message() == "Unsupported compressor: unsupported");
+  }
+  try {
+    writeZarrArray("TestUnsupportedCompressor", A, (7,), compressor="unsupported");
+    assert(false, "Expected an error for unsupported compressor");
+  } catch e {
+    assert(e.message() == "Unsupported compressor: unsupported");
+  }
+  
+}
+
+
+proc main() {
+  var compressors = ["blosclz", "lz4", "lz4hc", "zlib", "zstd"];
+  for compressor in compressors {
+    writeln("Testing ", compressor);
+    localTest(compressor);
+    distributedTest(compressor);
+  }
+  testUnsupportedCompressor();
+  writeln("Pass");
+}

--- a/test/library/packages/Zarr/ZarrCompressors.chpl
+++ b/test/library/packages/Zarr/ZarrCompressors.chpl
@@ -42,13 +42,13 @@ proc testUnsupportedCompressor() {
     writeZarrArrayLocal("TestUnsupportedCompressor", A, (7,), compressor="unsupported");
     assert(false, "Expected an error for unsupported compressor");
   } catch e {
-    assert(e.message() == "Unsupported compressor: unsupported");
+    assert(e.message() == "Unsupported compressor: unsupported. Supported compressors are: blosclz, lz4, lz4hc, zlib, and zstd.", e.message());
   }
   try {
     writeZarrArray("TestUnsupportedCompressor", A, (7,), compressor="unsupported");
     assert(false, "Expected an error for unsupported compressor");
   } catch e {
-    assert(e.message() == "Unsupported compressor: unsupported");
+    assert(e.message() == "Unsupported compressor: unsupported. Supported compressors are: blosclz, lz4, lz4hc, zlib, and zstd.", e.message());
   }
   
 }

--- a/test/library/packages/Zarr/ZarrCompressors.good
+++ b/test/library/packages/Zarr/ZarrCompressors.good
@@ -1,0 +1,6 @@
+Testing blosclz
+Testing lz4
+Testing lz4hc
+Testing zlib
+Testing zstd
+Pass


### PR DESCRIPTION
This PR adds support for selecting between different compression algorithms when writing Zarr stores. Supported options are `blosclz`, `lz4`, `lz4hc`, `zlib`, and `zstd`. This PR also includes tests for these options. Resolves https://github.com/Cray/chapel-private/issues/6588.

Zarr tests run locally, paratest passes on ChapDL

Reviewed by: 