### PR TITLE
Add baseline suppressifs for new c_addrOf tests

### DIFF
--- a/test/library/standard/CTypes/cAddrOfDistArr.suppressif
+++ b/test/library/standard/CTypes/cAddrOfDistArr.suppressif
@@ -1,0 +1,1 @@
+COMPOPTS <= --baseline

--- a/test/library/standard/CTypes/cAddrOfDistArrLocaleCheck.suppressif
+++ b/test/library/standard/CTypes/cAddrOfDistArrLocaleCheck.suppressif
@@ -1,0 +1,1 @@
+COMPOPTS <= --baseline


### PR DESCRIPTION
The idiom `c_addrOf(DistributedArray)` doesn't compile with `--baseline` with some codegen assertions. The root cause or the solution wasn't immediately clear to me. So, this PR adds suppressifs for relevant tests for `--baseline`.