### PR TITLE
Fix bash error in `checkChplInstall`

### DIFF
--- a/util/test/checkChplInstall
+++ b/util/test/checkChplInstall
@@ -136,6 +136,15 @@ function cleanup_tmp_dir()
 }
 trap cleanup_tmp_dir EXIT
 
+# Compute python interperet to use for helpers
+chpl_py="$($CHPL_HOME/util/config/find-python.sh)"
+
+# Collect comm protocol environment variables (lowercase to avoid conflicts)
+chpl_comm="$($chpl_py $CHPL_HOME/util/chplenv/chpl_comm.py)"
+chpl_launcher="$($chpl_py $CHPL_HOME/util/chplenv/chpl_launcher.py)"
+chpl_compiler="$($chpl_py $CHPL_HOME/util/chplenv/chpl_compiler.py --target)"
+chpl_locale_model="$($chpl_py $CHPL_HOME/util/chplenv/chpl_locale_model.py)"
+
 # Location of test job
 if [ -d ${CHPL_HOME}/test/release/examples ] ; then
     TEST_DIR=${CHPL_HOME}/test/release/examples
@@ -150,7 +159,7 @@ else
 fi
 
 TEST_JOB=${TEST_JOB_BASENAME}
-if [ ${CHPL_LOCALE_MODEL} == "gpu" ]; then
+if [ "${chpl_locale_model}" == "gpu" ]; then
   TEST_DIR="${TEST_DIR}/gpu"
   REL_TEST_DIR="${REL_TEST_DIR}/gpu"
   TEST_JOB="hello-gpu"
@@ -164,14 +173,6 @@ fi
 if [[ -e ${TEST_DIR}/${TEST_JOB}.compopts ]]; then
   COMP_FLAGS="$(cat ${TEST_DIR}/${TEST_JOB}.compopts)"
 fi
-
-# Compute python interperet to use for helpers
-chpl_py="$($CHPL_HOME/util/config/find-python.sh)"
-
-# Collect comm protocol environment variables (lowercase to avoid conflicts)
-chpl_comm="$($chpl_py $CHPL_HOME/util/chplenv/chpl_comm.py)"
-chpl_launcher="$($chpl_py $CHPL_HOME/util/chplenv/chpl_launcher.py)"
-chpl_compiler="$($chpl_py $CHPL_HOME/util/chplenv/chpl_compiler.py --target)"
 
 # Compile test job into temporary directory
 log_info "Compiling \$CHPL_HOME/${REL_TEST_DIR}/${TEST_JOB}.chpl"


### PR DESCRIPTION
Fixes a bash error in `checkChplInstall`, caused by `CHPL_LOCALE_MODEL` not always being a set environment variable.

The error I saw was `util/test/checkChplInstall: line 153: [: ==: unary operator expected` and the simple fix was to wrap `CHPL_LOCALE_MODEL` in quotes, but I also switched this line to query the `chplenv` scripts (in case `CHPL_LOCALE_MODEL` comes from a .chplconfig file, or similar).

[Reviewed by @stonea] 