### PR TITLE
Disallow CHPL_ATOMICS=locks on MacOS

### DIFF
--- a/test/chplenv/errors/noLocksOnDarwin.chpl
+++ b/test/chplenv/errors/noLocksOnDarwin.chpl
@@ -1,0 +1,2 @@
+// dummy file, the real test is done in the prediff
+;

--- a/test/chplenv/errors/noLocksOnDarwin.good
+++ b/test/chplenv/errors/noLocksOnDarwin.good
@@ -1,0 +1,2 @@
+
+Error: CHPL_ATOMICS=locks is not supported on MacOS

--- a/test/chplenv/errors/noLocksOnDarwin.prediff
+++ b/test/chplenv/errors/noLocksOnDarwin.prediff
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+CHPL_ATOMICS=locks \
+  CHPL_TARGET_PLATFORM=darwin \
+  $CHPL_HOME/util/printchplenv &>$2

--- a/util/chplenv/chpl_atomics.py
+++ b/util/chplenv/chpl_atomics.py
@@ -85,6 +85,11 @@ def get(flag='target'):
             msg += ": please consider using CHPL_ATOMICS=cstdlib"
         warning(msg)
 
+    if flag == 'target' and atomics_val == 'locks':
+        platform_val = chpl_platform.get('target')
+        if platform_val == 'darwin':
+            error("CHPL_ATOMICS=locks is not supported on MacOS")
+
     return atomics_val
 
 


### PR DESCRIPTION
Explicitly disallow `CHPL_ATOMICS=locks` on MacOS.

This was already unsupported, as the runtime would fail to build. The `CHPL_ATOMICS=locks` implementation uses `pthread_spinlock_t`, which is not supported on MacOS. This PR just makes it clearer to the user that this is not supported, rather than some strange build error.

Tested that `CHPL_ATOMICS=locks printchplenv` on MacOS gets the correct error.

[Reviewed by @lydia-duncan]