### PR TITLE
Rename the argument for TwoArrayDistSortPerBucketTaskStartComparator.key()

### DIFF
--- a/modules/standard/Sort.chpl
+++ b/modules/standard/Sort.chpl
@@ -2233,8 +2233,8 @@ module TwoArrayDistributedPartitioning {
   private param debugDist = false;
 
   record TwoArrayDistSortPerBucketTaskStartComparator {
-    proc key(arg: TwoArrayDistSortPerBucketTask) {
-      return arg.start;
+    proc key(elt: TwoArrayDistSortPerBucketTask) {
+      return elt.start;
     }
   }
 


### PR DESCRIPTION
Continues #25552 

Does not require a deprecation due to being an implementation detail.  Also, it's a single argument function, so it is highly unlikely anyone is actually using named argument passing for it

Passed a standard paratest with futures, and the test/library/standard/Sort directory with gasnet