### PR TITLE
Add `keyPartStatus` as a return type for `keyPart`

### DIFF
--- a/test/deprecated/Sort/keyPartInt-resolved.good
+++ b/test/deprecated/Sort/keyPartInt-resolved.good
@@ -1,0 +1,24 @@
+Comparing with DefaultComparator
+(returned, 1)
+(returned, 2)
+(returned, 13835058055282163712)
+(returned, 13835058055282163712)
+(returned, 4)
+(returned, 13835058055282163712)
+(returned, 102)
+(returned, 98)
+Comparing with ReverseComparator
+(returned, -2)
+(returned, 18446744073709551613)
+(returned, 4611686018427387903)
+(returned, 4611686018427387903)
+(returned, -5)
+(returned, 4611686018427387903)
+(returned, 153)
+(returned, 157)
+isSorted before false
+isSorted after true
+isSorted before false
+isSorted after true
+isSorted before false
+isSorted after true

--- a/test/deprecated/Sort/keyPartInt.chpl
+++ b/test/deprecated/Sort/keyPartInt.chpl
@@ -1,0 +1,54 @@
+use Sort, CTypes;
+
+//
+// Static usage, a user tries to call `keyPart` from DefaultComparator or
+// ReverseComparator without `-suseKeyPartStatus`
+//
+
+var comparators = (new DefaultComparator(), new ReverseComparator());
+var titles = ("Default", "Reverse");
+
+for param i in 0..#comparators.size {
+  writeln("Comparing with ", titles[i], "Comparator");
+  var d = comparators[i];
+  // integral
+  writeln(d.keyPart(1, 0));
+  writeln(d.keyPart(2:uint, 0));
+  // real(?)
+  writeln(d.keyPart(2.0, 0));
+  // imag(?)
+  writeln(d.keyPart(2.0i, 0));
+  // _tuple
+  writeln(d.keyPart((4, 2), 0));
+  writeln(d.keyPart((2.0, 8.0), 0));
+  // string
+  writeln(d.keyPart("foo", 0));
+  // c_ptrConst(c_char)
+  writeln(d.keyPart("bar".c_str(), 0));
+}
+
+//
+// Dynamic usage deprecation warnings, for when a user has defined a custom comparator and uses it in `sort` or `isSorted`
+//
+
+record myCmp {
+  // this is a simple comparator for integers
+  // its identical to the Sort module for normal sorting
+  proc keyPart(elt, i) {
+    var section = if i > 0 then -1 else 0;
+    return (section, elt);
+  }
+}
+use Random;
+var arr: [1..1000] int;
+fillRandom(arr);
+
+// there should be 6 deprecations here
+sort(arr, comparator=new myCmp());
+writeln("isSorted ", isSorted(arr, comparator=new myCmp()));
+
+sort(arr, comparator=new ReverseComparator(new myCmp()));
+writeln("isSorted ", isSorted(arr, comparator=new ReverseComparator(new myCmp())));
+
+var temp = sorted(arr, comparator=new MyCmp());
+writeln("isSorted ", isSorted(temp, comparator=new myCmp()));

--- a/test/deprecated/Sort/keyPartInt.chpl
+++ b/test/deprecated/Sort/keyPartInt.chpl
@@ -31,29 +31,57 @@ for param i in 0..#comparators.size {
 // Dynamic usage deprecation warnings, for when a user has defined a custom comparator and uses it in `sort` or `isSorted`
 //
 
-record myCmp {
-  // this is a simple comparator for integers
-  // its identical to the Sort module for normal sorting
-  proc keyPart(elt, i) {
-    var section = if i > 0 then -1 else 0;
-    return (section, elt);
-  }
+
+// This is a simple comparator for integers
+// It is identical to the Sort module for normal sorting
+// To make sure we get all the deprecation warnings, we need to use a unique comparator type for each call
+
+record myCmp1 { proc keyPart(elt, i) do return (if i > 0 then -1 else 0, elt); }
+record myCmp2 { proc keyPart(elt, i) do return (if i > 0 then -1 else 0, elt); }
+record myCmp3 { proc keyPart(elt, i) do return (if i > 0 then -1 else 0, elt); }
+record myCmp4 { proc keyPart(elt, i) do return (if i > 0 then -1 else 0, elt); }
+record myCmp5 { proc keyPart(elt, i) do return (if i > 0 then -1 else 0, elt); }
+record myCmp6 { proc keyPart(elt, i) do return (if i > 0 then -1 else 0, elt); }
+record myCmp7 { proc keyPart(elt, i) do return (if i > 0 then -1 else 0, elt); }
+record myCmp8 { proc keyPart(elt, i) do return (if i > 0 then -1 else 0, elt); }
+record myCmp9 { proc keyPart(elt, i) do return (if i > 0 then -1 else 0, elt); }
+
+record myCmpResolveDeps {
+  proc keyPart(elt, i) do
+    return (if i > 0 then keyPartStatus.pre else keyPartStatus.returned, elt);
 }
+
+proc getComparator(param i: int) type {
+  if Sort.useKeyPartStatus then return myCmpResolveDeps;
+  else select i {
+    when 1 do return myCmp1;
+    when 2 do return myCmp2;
+    when 3 do return myCmp3;
+    when 4 do return myCmp4;
+    when 5 do return myCmp5;
+    when 6 do return myCmp6;
+    when 7 do return myCmp7;
+    when 8 do return myCmp8;
+    when 9 do return myCmp9;
+  }
+  compilerError("");
+}
+
 use Random;
 var arr: [1..1000] int;
 
 // there should be 9 deprecations here
 fillRandom(arr);
-writeln("isSorted before ", isSorted(arr, comparator=new myCmp()));
-sort(arr, comparator=new myCmp());
-writeln("isSorted after ", isSorted(arr, comparator=new myCmp()));
+writeln("isSorted before ", isSorted(arr, comparator=new (getComparator(1))()));
+sort(arr, comparator=new (getComparator(2))());
+writeln("isSorted after ", isSorted(arr, comparator=new (getComparator(3))()));
 
 fillRandom(arr);
-writeln("isSorted before ", isSorted(arr, comparator=new ReverseComparator(new myCmp())));
-sort(arr, comparator=new ReverseComparator(new myCmp()));
-writeln("isSorted after ", isSorted(arr, comparator=new ReverseComparator(new myCmp())));
+writeln("isSorted before ", isSorted(arr, comparator=new ReverseComparator(new (getComparator(4))())));
+sort(arr, comparator=new ReverseComparator(new (getComparator(5))()));
+writeln("isSorted after ", isSorted(arr, comparator=new ReverseComparator(new (getComparator(6))())));
 
 fillRandom(arr);
-writeln("isSorted before ", isSorted(arr, comparator=new myCmp()));
-var temp = sorted(arr, comparator=new myCmp());
-writeln("isSorted after ", isSorted(temp, comparator=new myCmp()));
+writeln("isSorted before ", isSorted(arr, comparator=new (getComparator(7))()));
+var temp = sorted(arr, comparator=new (getComparator(8))());
+writeln("isSorted after ", isSorted(temp, comparator=new (getComparator(9))()));

--- a/test/deprecated/Sort/keyPartInt.chpl
+++ b/test/deprecated/Sort/keyPartInt.chpl
@@ -41,14 +41,19 @@ record myCmp {
 }
 use Random;
 var arr: [1..1000] int;
+
+// there should be 9 deprecations here
 fillRandom(arr);
-
-// there should be 6 deprecations here
+writeln("isSorted before ", isSorted(arr, comparator=new myCmp()));
 sort(arr, comparator=new myCmp());
-writeln("isSorted ", isSorted(arr, comparator=new myCmp()));
+writeln("isSorted after ", isSorted(arr, comparator=new myCmp()));
 
+fillRandom(arr);
+writeln("isSorted before ", isSorted(arr, comparator=new ReverseComparator(new myCmp())));
 sort(arr, comparator=new ReverseComparator(new myCmp()));
-writeln("isSorted ", isSorted(arr, comparator=new ReverseComparator(new myCmp())));
+writeln("isSorted after ", isSorted(arr, comparator=new ReverseComparator(new myCmp())));
 
-var temp = sorted(arr, comparator=new MyCmp());
-writeln("isSorted ", isSorted(temp, comparator=new myCmp()));
+fillRandom(arr);
+writeln("isSorted before ", isSorted(arr, comparator=new myCmp()));
+var temp = sorted(arr, comparator=new myCmp());
+writeln("isSorted after ", isSorted(temp, comparator=new myCmp()));

--- a/test/deprecated/Sort/keyPartInt.compopts
+++ b/test/deprecated/Sort/keyPartInt.compopts
@@ -1,0 +1,4 @@
+                         # keyPartInt.good
+-suseKeyPartStatus=false # keyPartInt.good
+-suseKeyPartStatus       # keyPartInt-resolved.good
+-suseKeyPartStatus=true  # keyPartInt-resolved.good

--- a/test/deprecated/Sort/keyPartInt.good
+++ b/test/deprecated/Sort/keyPartInt.good
@@ -1,0 +1,44 @@
+keyPartInt.chpl:15: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+keyPartInt.chpl:16: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+keyPartInt.chpl:18: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+keyPartInt.chpl:20: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+keyPartInt.chpl:22: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+keyPartInt.chpl:23: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+keyPartInt.chpl:25: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+keyPartInt.chpl:27: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+keyPartInt.chpl:15: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+keyPartInt.chpl:16: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+keyPartInt.chpl:18: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+keyPartInt.chpl:20: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+keyPartInt.chpl:22: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+keyPartInt.chpl:23: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+keyPartInt.chpl:25: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+keyPartInt.chpl:27: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+keyPartInt.chpl:47: warning: Returning an int(?) as the first element of the tuple from `keyPart` is deprecated, please use 'keyPartStatus'
+keyPartInt.chpl:49: warning: Returning an int(?) as the first element of the tuple from `keyPart` is deprecated, please use 'keyPartStatus'
+keyPartInt.chpl:57: warning: Returning an int(?) as the first element of the tuple from `keyPart` is deprecated, please use 'keyPartStatus'
+keyPartInt.chpl:59: warning: Returning an int(?) as the first element of the tuple from `keyPart` is deprecated, please use 'keyPartStatus'
+Comparing with DefaultComparator
+(0, 1)
+(0, 2)
+(0, 13835058055282163712)
+(0, 13835058055282163712)
+(0, 4)
+(0, 13835058055282163712)
+(0, 102)
+(0, 98)
+Comparing with ReverseComparator
+(0, -2)
+(0, 18446744073709551613)
+(0, 4611686018427387903)
+(0, 4611686018427387903)
+(0, -5)
+(0, 4611686018427387903)
+(0, 153)
+(0, 157)
+isSorted before false
+isSorted after true
+isSorted before false
+isSorted after true
+isSorted before false
+isSorted after true

--- a/test/deprecated/Sort/keyPartInt.good
+++ b/test/deprecated/Sort/keyPartInt.good
@@ -14,10 +14,15 @@ keyPartInt.chpl:22: warning: Using keyPart without 'keyPartStatus' is deprecated
 keyPartInt.chpl:23: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
 keyPartInt.chpl:25: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
 keyPartInt.chpl:27: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
-keyPartInt.chpl:47: warning: Returning an int(?) as the first element of the tuple from `keyPart` is deprecated, please use 'keyPartStatus'
-keyPartInt.chpl:49: warning: Returning an int(?) as the first element of the tuple from `keyPart` is deprecated, please use 'keyPartStatus'
-keyPartInt.chpl:57: warning: Returning an int(?) as the first element of the tuple from `keyPart` is deprecated, please use 'keyPartStatus'
-keyPartInt.chpl:59: warning: Returning an int(?) as the first element of the tuple from `keyPart` is deprecated, please use 'keyPartStatus'
+keyPartInt.chpl:75: warning: Returning an int(?) as the first element of the tuple from `keyPart` is deprecated, please use 'keyPartStatus'
+keyPartInt.chpl:76: warning: Returning an int(?) as the first element of the tuple from `keyPart` is deprecated, please use 'keyPartStatus'
+keyPartInt.chpl:77: warning: Returning an int(?) as the first element of the tuple from `keyPart` is deprecated, please use 'keyPartStatus'
+keyPartInt.chpl:80: warning: Returning an int(?) as the first element of the tuple from `keyPart` is deprecated, please use 'keyPartStatus'
+keyPartInt.chpl:81: warning: Returning an int(?) as the first element of the tuple from `keyPart` is deprecated, please use 'keyPartStatus'
+keyPartInt.chpl:82: warning: Returning an int(?) as the first element of the tuple from `keyPart` is deprecated, please use 'keyPartStatus'
+keyPartInt.chpl:85: warning: Returning an int(?) as the first element of the tuple from `keyPart` is deprecated, please use 'keyPartStatus'
+keyPartInt.chpl:86: warning: Returning an int(?) as the first element of the tuple from `keyPart` is deprecated, please use 'keyPartStatus'
+keyPartInt.chpl:87: warning: Returning an int(?) as the first element of the tuple from `keyPart` is deprecated, please use 'keyPartStatus'
 Comparing with DefaultComparator
 (0, 1)
 (0, 2)

--- a/test/deprecated/Sort/keyPartInt.prediff
+++ b/test/deprecated/Sort/keyPartInt.prediff
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# prediff out line numbers from Sort module
+sed -e 's/Sort.chpl:[0-9][0-9]*:/Sort.chpl:nnn/' $2 > $2.tmp
+mv $2.tmp $2


### PR DESCRIPTION
Adds enum `keyPartStatus` to be used as the value in the 0th element for the tuple returned by `keyPart`. 

To support this new `keyPart`, this PR has two sets of deprecations.
- Deprecating when users call `DefaultComparator.keyPart` or `ReverseComparator.keyPart`, the return type now uses `keyPartStatus`. Users who call these functions themselves will get warnings until they recompile with `-suseKeyPartStatus`. This is a rare use case
- Deprecating allowing users to pass custom comparators with `keyPart` that returns 2 integers. This is the more common case, requiring users to return `(keyPartStatus, int)` instead.

Implements part of https://github.com/chapel-lang/chapel/issues/25552

TODO: Finish creating deprecation test `test/deprecated/Sort/keyPartInt.chpl`

- [ ] Ran a full paratest with/without comm
- [ ] Built and checked docs
