### PR TITLE
Shorten `DistributedBag` module description for module index

### DIFF
--- a/modules/packages/DistributedBag.chpl
+++ b/modules/packages/DistributedBag.chpl
@@ -76,8 +76,8 @@
 */
 
 /*
-  Implements a highly parallel segmented multi-pool specialized for depth-first
-  search (DFS), sometimes referenced as ``DistBag_DFS``.
+  Implements a parallel segmented multi-pool for depth-first tree-search.
+  The data structure is sometimes referred to as ``DistBag_DFS``.
 
   Summary
   _______


### PR DESCRIPTION
Fix `DistributedBag` description in module index.
Related to #25667.