### PR TITLE
Link module index to global doc index

### DIFF
--- a/doc/rst/index.rst
+++ b/doc/rst/index.rst
@@ -37,9 +37,8 @@ Chapel Documentation
 
 
 
-Index
------
+Indexes
+-------
 
+* :ref:`Chapel Module Index <chpl-modindex>`
 * :ref:`Chapel Online Documentation Index <genindex>`
-
-.. COMMENT: clean this up before exposing:: * :chpl:chplref:`chplmodindex`


### PR DESCRIPTION
While the sidebar shows both module and doc indexes, the main page of the doc only shows the second one. This PR fixes this mismatch by linking the module index as well.

![mismatch](https://github.com/user-attachments/assets/9d7ef6f9-6e6f-45be-bd99-bc7263de3ac7)
