### PR TITLE
Switch from test proto to test for Arkouda testing

### DIFF
--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -96,11 +96,11 @@ if [ ${CHPL_TEST_ARKOUDA_STOP_AFTER_BUILD} = "false" ]; then
   test_end
 
   # Run Python unit tests
-  test_start "make test-python-proto"
-  if make test-proto ; then
-    log_success "make test-python-proto output"
+  test_start "make test-python"
+  if make test-python ; then
+    log_success "make test-python output"
   else
-    log_error "running make test-python-proto"
+    log_error "running make test-python"
   fi
   test_end
 


### PR DESCRIPTION
The Arkouda testing framework has been consolidated to a single testing library and with that consolidation there was a change in naming of how to run the unit tests from `make test-proto` to `make test-python`.