### PR TITLE
Add a suppressif for an ALA test

### DIFF
--- a/test/optimizations/autoLocalAccess/stencil/unsupportedCases.suppressif
+++ b/test/optimizations/autoLocalAccess/stencil/unsupportedCases.suppressif
@@ -1,0 +1,1 @@
+COMPOPTS<=--baseline


### PR DESCRIPTION
The test in question generates slightly different output with `--baseline --report-auto-local-access`. There is no behavioral difference at execution time. This PR adds a suppressif for this test with `--baseline`.

Tested locally with `--respect-skipifs`