### PR TITLE
Add skipif to only run test on MacOS

### DIFF
--- a/test/chplenv/errors/noLocksOnDarwin.skipif
+++ b/test/chplenv/errors/noLocksOnDarwin.skipif
@@ -1,0 +1,1 @@
+CHPL_TARGET_PLATFORM!=darwin


### PR DESCRIPTION
Adds a skipif to only run new printchplenv test on MacOS

[Not reviewed - trivial]