### PR TITLE
Disable 'sync nothing' (because it doesn't currently work)

### DIFF
--- a/modules/internal/ChapelSyncvar.chpl
+++ b/modules/internal/ChapelSyncvar.chpl
@@ -52,8 +52,7 @@ module ChapelSyncvar {
   //
 
   private proc isSupported(type t) param do
-    return isNothingType(t)       ||
-           isBoolType(t)          ||
+    return isBoolType(t)          ||
            isIntegralType(t)      ||
            isRealType(t)          ||
            isImagType(t)          ||

--- a/test/types/sync/syncNothing.chpl
+++ b/test/types/sync/syncNothing.chpl
@@ -1,0 +1,14 @@
+use Time;
+
+config const N = 2;
+
+var s : sync nothing;
+begin {
+  writeln("Here I am in a separate task");
+  sleep(N);
+  s.writeEF(none);
+}
+
+writeln("Here I am before the barrier");
+s.readFE();
+writeln("Here I am after the barrier");

--- a/test/types/sync/syncNothing.good
+++ b/test/types/sync/syncNothing.good
@@ -1,0 +1,1 @@
+syncNothing.chpl:5: error: sync types cannot contain type 'nothing'


### PR DESCRIPTION
This is a simple fix to disable support for `sync nothing` similar to how we recently have for `sync void`.  From what I've been able to tell, I don't believe we've ever supported either, and think that this was a case of lack of sufficient testing/forethought to realize that both should've been made illegal when `none`/`nothing` were introduced.

The approach here was to simply remove `isNothingType` from the list of types that support `sync` variables in module code.  I also added the test from #20929 to lock it in.

Resolves #20929

Note that there's an ongoing desire to support a value-less full/empty bit using `sync void` or `sync nothing` in #9370
