### PR TITLE
Improve serializer module documentation

### DIFF
--- a/modules/packages/ChplFormat.chpl
+++ b/modules/packages/ChplFormat.chpl
@@ -17,9 +17,9 @@
  * limitations under the License.
  */
 
-/*
- The ChplFormat module provides a chplSerializer and chplDeserializer that
- aim to read and write data in a format similar to that of Chapel's syntax.
+/* Provides serialization in a format similar to Chapel's syntax.
+
+Intended for use with :ref:`IO support for serializers and deserializers <serialize-deserialize>`.
  */
 @unstable("ChplFormat module is considered unstable pending naming changes")
 module ChplFormat {

--- a/modules/packages/ObjectSerialization.chpl
+++ b/modules/packages/ObjectSerialization.chpl
@@ -17,9 +17,9 @@
  * limitations under the License.
  */
 
-/*
- The ObjectSerialization module provides an objectSerializer and
- objectDeserializer that implement a simple binary IO format.
+/* Provides serialization for Chapel data types in a binary format.
+
+Intended for use with :ref:`IO support for serializers and deserializers <serialize-deserialize>`.
  */
 @unstable("The ObjectSerialization module is unstable. The module's name, its types, and serialization format are subject to change.")
 module ObjectSerialization {

--- a/modules/standard/JSON.chpl
+++ b/modules/standard/JSON.chpl
@@ -17,9 +17,9 @@
  * limitations under the License.
  */
 
-/*
- The Json module provides a ``jsonSerializer`` and ``jsonDeserializer`` that
- allow for reading and writing data in the JSON format.
+/* Provides serialization in the JSON format.
+
+Intended for use with :ref:`IO support for serializers and deserializers <serialize-deserialize>`.
  */
 module JSON {
   private use IO;


### PR DESCRIPTION
Updates the first line of documentation to fit into the rendered module index list.

Also adds a link to the IO module's high-level serialization documentation.