### PR TITLE
Shorten module description for `PrecisionSerializer`

### DIFF
--- a/modules/packages/PrecisionSerializer.chpl
+++ b/modules/packages/PrecisionSerializer.chpl
@@ -19,9 +19,11 @@
  */
 
 /*
-  This module contains the ``precisionSerializer`` type which provides
-  formatting like the :record:`~IO.defaultSerializer`, but with finer control
-  over the precision and padding of numerical values.
+  Support for controlling I/O precision and padding.
+
+  Provides the ``precisionSerializer`` type, whose formatting is identical to
+  the :record:`~IO.defaultSerializer`, except numbers are printed with the
+  specified precision and padding.
 */
 module PrecisionSerializer {
   use IO;


### PR DESCRIPTION
The description for `PrecisionSerializer` was too long to fit in one line on the [module index page](https://chapel-lang.org/docs/chpl-modindex.html), so only part of the text was rendered (see: https://github.com/chapel-lang/chapel/issues/25667). This PR shortens the text to fit on one line.

- [x] inspected built docs