### PR TITLE
Fix `preadc` tests

### DIFF
--- a/test/io/ferguson/preadc/preadvpwritev_sys.skipif
+++ b/test/io/ferguson/preadc/preadvpwritev_sys.skipif
@@ -1,1 +1,1 @@
-CHPL_ATOMICS!=intrinsics
+CHPL_ATOMICS==locks

--- a/test/io/ferguson/preadc/preadvpwritev_sys.test.c
+++ b/test/io/ferguson/preadc/preadvpwritev_sys.test.c
@@ -20,7 +20,7 @@ int main() {
   int datalen = strlen(data);
   int fd;
   ssize_t got;
-  err_t err;
+  qio_err_t err;
 
   buf = malloc(buflen);
   assert(buf);
@@ -30,7 +30,7 @@ int main() {
   // open file
   fd = open("tmp.data", O_RDWR | O_CREAT, S_IRWXU);
   assert(fd>=0);
-  
+
   // copy data to buf
   memset(buf, 0, buflen);
   memcpy(buf, data, datalen);
@@ -41,7 +41,7 @@ int main() {
   //got = pwrite(fd, buf, datalen, 0);
   assert(!err);
   assert(got == datalen);
- 
+
   // clear buf
   memset(buf, 0, buflen);
   // read data
@@ -53,7 +53,7 @@ int main() {
   assert(got == datalen);
   // check data
   assert(0 == memcmp(data, buf, datalen));
- 
+
   close(fd);
   unlink("tmp.data");
 

--- a/test/io/ferguson/preadc/preadwrite_sys.skipif
+++ b/test/io/ferguson/preadc/preadwrite_sys.skipif
@@ -1,1 +1,1 @@
-CHPL_ATOMICS!=intrinsics
+CHPL_ATOMICS==locks

--- a/test/io/ferguson/preadc/preadwrite_sys.test.c
+++ b/test/io/ferguson/preadc/preadwrite_sys.test.c
@@ -19,7 +19,7 @@ int main() {
   int datalen = strlen(data);
   int fd;
   ssize_t got;
-  err_t err;
+  qio_err_t err;
 
   buf = malloc(buflen);
   assert(buf);
@@ -27,7 +27,7 @@ int main() {
   // open file
   fd = open("tmp.data", O_RDWR | O_CREAT, S_IRWXU);
   assert(fd>=0);
-  
+
   // copy data to buf
   memset(buf, 0, buflen);
   memcpy(buf, data, datalen);
@@ -35,7 +35,7 @@ int main() {
   err = sys_pwrite(fd, buf, datalen, 0, &got);
   assert(!err);
   assert(got == datalen);
- 
+
   // clear buf
   memset(buf, 0, buflen);
   // read data
@@ -44,7 +44,7 @@ int main() {
   assert(got == datalen);
   // check data
   assert(0 == memcmp(data, buf, datalen));
- 
+
   close(fd);
   unlink("tmp.data");
 


### PR DESCRIPTION
Fixes two broken `preadc` tests that had regressed after renaming `err_t` to `qio_err_t`. Since these tests were not run in the default configuration, they were missed in nightly testing. This PR also changes the skipif for these tests to let them run in the default configuration.

Tested manually locally on MacOS

[Reviewed by @mppf]