### PR TITLE
Dyno: Type constructors for inheriting generic classes

### DIFF
--- a/frontend/include/chpl/framework/ID.h
+++ b/frontend/include/chpl/framework/ID.h
@@ -101,7 +101,13 @@ class ID final {
     of a symbol's nodes. When the AST node defines a new ID symbol scope,
     (as with Function or Module) this will return -1.
    */
-  int postOrderId() const { return postOrderId_; }
+  int postOrderId() const {
+    if (postOrderId_ < -1) {
+      return (postOrderId_ * -1) - 2;
+    } else {
+      return postOrderId_;
+    }
+  }
 
   /**
     Returns 'true' if this symbol has a 'postOrderId()' value of == -1,

--- a/frontend/include/chpl/framework/ID.h
+++ b/frontend/include/chpl/framework/ID.h
@@ -26,6 +26,7 @@
 namespace chpl {
 class Context;
 
+#define ID_GEN_START -3
 
 /**
   This class represents an ID for an AST node.
@@ -38,6 +39,7 @@ class ID final {
   enum FabricatedIdKind {
     // all of these need to be <= -2
     ExternBlockElement = -2,
+    Generated = ID_GEN_START,
   };
 
  private:
@@ -102,8 +104,14 @@ class ID final {
     (as with Function or Module) this will return -1.
    */
   int postOrderId() const {
-    if (postOrderId_ < -1) {
-      return (postOrderId_ * -1) - 2;
+    if (postOrderId_ < -2) {
+      if (postOrderId_ == ID_GEN_START) {
+        // generated symbol
+        return -1;
+      } else {
+        // generated uAST nodes
+        return (postOrderId_ * -1) - ID_GEN_START - 1;
+      }
     } else {
       return postOrderId_;
     }
@@ -114,7 +122,8 @@ class ID final {
     which means this is an ID for something that defines a new symbol
     scope.
    */
-   inline bool isSymbolDefiningScope() const { return postOrderId_ == -1; }
+   inline bool isSymbolDefiningScope() const { return postOrderId_ == -1 ||
+                                                      postOrderId_ == ID_GEN_START; }
 
   /**
     Some IDs are introduced during compilation and don't represent
@@ -125,7 +134,11 @@ class ID final {
 
   FabricatedIdKind fabricatedIdKind() const {
     CHPL_ASSERT(isFabricatedId());
-    return (FabricatedIdKind) postOrderId_;
+    if (postOrderId_ <= ID_GEN_START) {
+      return FabricatedIdKind::Generated;
+    } else {
+      return (FabricatedIdKind) postOrderId_;
+    }
   }
 
   /**

--- a/frontend/include/chpl/parsing/parsing-queries.h
+++ b/frontend/include/chpl/parsing/parsing-queries.h
@@ -111,6 +111,20 @@ const uast::BuilderResult*
 parseFileContainingIdToBuilderResult(Context* context, ID id);
 
 /**
+  Fetch the BuilderResult storing compiler-generated uAST based on the given
+  symbolPath.
+ */
+const uast::BuilderResult&
+getCompilerGeneratedBuilder(Context* context, UniqueString symbolPath);
+
+/**
+  Set the BuilderResult storing compiler-generated uAST based on the given
+  symbolPath.
+ */
+void setCompilerGeneratedBuilder(Context* context, UniqueString symbolPath,
+                                 uast::BuilderResult result);
+
+/**
   A function for counting the tokens when parsing
 */
 void countTokens(Context* context, UniqueString path, ParserStats* parseStats);

--- a/frontend/include/chpl/resolution/resolution-queries.h
+++ b/frontend/include/chpl/resolution/resolution-queries.h
@@ -508,10 +508,10 @@ const std::vector<const uast::Function*>& getTestsGatheredViaPrimitive(Context* 
 /**
   Returns the field in 'ad' (or its parent) that matches 'name'.
 */
-const uast::Decl* findFieldIDByName(Context* context,
-                              const uast::AggregateDecl* ad,
-                              const types::CompositeType* ct,
-                              UniqueString name);
+const uast::Decl* findFieldByName(Context* context,
+                                  const uast::AggregateDecl* ad,
+                                  const types::CompositeType* ct,
+                                  UniqueString name);
 
 
 

--- a/frontend/include/chpl/resolution/resolution-queries.h
+++ b/frontend/include/chpl/resolution/resolution-queries.h
@@ -505,6 +505,15 @@ reportInvalidMultipleInheritance(Context* context,
  */
 const std::vector<const uast::Function*>& getTestsGatheredViaPrimitive(Context* context);
 
+/**
+  Returns the field in 'ad' (or its parent) that matches 'name'.
+*/
+const uast::Decl* findFieldIDByName(Context* context,
+                              const uast::AggregateDecl* ad,
+                              const types::CompositeType* ct,
+                              UniqueString name);
+
+
 
 } // end namespace resolution
 } // end namespace chpl

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -161,6 +161,9 @@ class UntypedFnSignature {
   // this will not be present for compiler-generated functions
   const uast::AstNode* whereClause_;
 
+  // The ID that this compiler-generated function is based on
+  ID compilerGeneratedOrigin_;
+
   UntypedFnSignature(ID id,
                      UniqueString name,
                      bool isMethod,
@@ -170,7 +173,8 @@ class UntypedFnSignature {
                      uast::asttags::AstTag idTag,
                      uast::Function::Kind kind,
                      std::vector<FormalDetail> formals,
-                     const uast::AstNode* whereClause)
+                     const uast::AstNode* whereClause,
+                     ID compilerGeneratedOrigin = ID())
     : id_(id),
       name_(name),
       isMethod_(isMethod),
@@ -180,7 +184,8 @@ class UntypedFnSignature {
       idTag_(idTag),
       kind_(kind),
       formals_(std::move(formals)),
-      whereClause_(whereClause) {
+      whereClause_(whereClause),
+      compilerGeneratedOrigin_(compilerGeneratedOrigin) {
     CHPL_ASSERT(idTag == uast::asttags::Function ||
            idTag == uast::asttags::Class    ||
            idTag == uast::asttags::Record   ||
@@ -200,7 +205,8 @@ class UntypedFnSignature {
                         uast::asttags::AstTag idTag,
                         uast::Function::Kind kind,
                         std::vector<FormalDetail> formals,
-                        const uast::AstNode* whereClause);
+                        const uast::AstNode* whereClause,
+                        ID compilerGeneratedOrigin = ID());
 
  public:
   /** Get the unique UntypedFnSignature containing these components */
@@ -213,7 +219,8 @@ class UntypedFnSignature {
                                        uast::asttags::AstTag idTag,
                                        uast::Function::Kind kind,
                                        std::vector<FormalDetail> formals,
-                                       const uast::AstNode* whereClause);
+                                       const uast::AstNode* whereClause,
+                                       ID compilerGeneratedOrigin = ID());
 
   /** Get the unique UntypedFnSignature representing a Function's
       signature from a Function uAST pointer. */
@@ -234,7 +241,8 @@ class UntypedFnSignature {
            idTag_ == other.idTag_ &&
            kind_ == other.kind_ &&
            formals_ == other.formals_ &&
-           whereClause_ == other.whereClause_;
+           whereClause_ == other.whereClause_ &&
+           compilerGeneratedOrigin_ == other.compilerGeneratedOrigin_;
   }
   bool operator!=(const UntypedFnSignature& other) const {
     return !(*this == other);
@@ -251,6 +259,7 @@ class UntypedFnSignature {
       context->markPointer(elt.decl);
     }
     context->markPointer(whereClause_);
+    compilerGeneratedOrigin_.mark(context);
   }
 
 
@@ -273,6 +282,10 @@ class UntypedFnSignature {
   /** Returns true if this compiler generated */
   bool isCompilerGenerated() const {
     return isCompilerGenerated_;
+  }
+
+  ID compilerGeneratedOrigin() const {
+    return compilerGeneratedOrigin_;
   }
 
   /** Returns true if id() refers to a Function */

--- a/frontend/include/chpl/uast/AstNode.h
+++ b/frontend/include/chpl/uast/AstNode.h
@@ -138,6 +138,14 @@ class AstNode {
       deserialize the AstNode fields other than the children */
   AstNode(AstTag tag, Deserializer& des);
 
+  AstNode(const AstNode& node) {
+    this->tag_ = node.tag_;
+    this->attributeGroupChildNum_ = node.attributeGroupChildNum_;
+    for (auto child : node.children()) {
+      children_.push_back(child->copy());
+    }
+  }
+
   /** Completes the deserialization process for an AstNode
       by deserializing the children. */
   void deserializeChildren(Deserializer& des);
@@ -554,6 +562,8 @@ class AstNode {
       #undef CASE_OTHER
     }
   }
+
+  owned<AstNode> copy() const;
 };
 } // end namespace uast
 

--- a/frontend/include/chpl/uast/Builder.h
+++ b/frontend/include/chpl/uast/Builder.h
@@ -77,6 +77,8 @@ class Builder final {
   // These are removed in the astToLocation_ map.
   AstLocMap notedLocations_;
 
+  bool generatedCode_ = false;
+
   // These map AST to additional locations while the builder is building.
   // This is an equivalent to notedLocations for the additional locations.
   // The key type is just 'AstNode' so that we can use generic functions.
@@ -119,6 +121,10 @@ class Builder final {
   static owned<Builder> createForIncludedModule(Context* context,
                                                 const char* filepath,
                                                 UniqueString parentSymbolPath);
+
+  static owned<Builder> createForGeneratedCode(Context* context,
+                                               const char* filepath,
+                                               UniqueString parentSymbolPath);
 
   /** Construct a Builder for use when reading uAST from a library file. */
   static owned<Builder> createForLibraryFileModule(

--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -192,6 +192,15 @@ introspectParsedFiles(Context* context) {
   return toReturn;
 }
 
+static const BuilderResult&
+compilerGeneratedBuilderQuery(Context* context, UniqueString symbolPath) {
+  QUERY_BEGIN(compilerGeneratedBuilderQuery, context, symbolPath);
+
+  BuilderResult ret;
+
+  return QUERY_END(ret);
+}
+
 // parses whatever file exists that contains the passed ID and returns it
 const BuilderResult*
 parseFileContainingIdToBuilderResult(Context* context, ID id) {
@@ -205,6 +214,16 @@ parseFileContainingIdToBuilderResult(Context* context, ID id) {
   }
 
   return nullptr;
+}
+
+const BuilderResult&
+getCompilerGeneratedBuilder(Context* context, UniqueString symbolPath) {
+  return compilerGeneratedBuilderQuery(context, symbolPath);
+}
+
+void setCompilerGeneratedBuilder(Context* context, UniqueString symbolPath,
+                                 BuilderResult result) {
+  QUERY_STORE_RESULT(compilerGeneratedBuilderQuery, context, result, symbolPath);
 }
 
 void countTokens(Context* context, UniqueString path, ParserStats* parseStats) {

--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -204,6 +204,20 @@ compilerGeneratedBuilderQuery(Context* context, UniqueString symbolPath) {
 // parses whatever file exists that contains the passed ID and returns it
 const BuilderResult*
 parseFileContainingIdToBuilderResult(Context* context, ID id) {
+  {
+    UniqueString symbolPath = id.symbolPath();
+
+    while (!symbolPath.isEmpty()) {
+      auto tupleOfArgs = std::make_tuple(symbolPath);
+      auto got = context->hasCurrentResultForQuery(compilerGeneratedBuilderQuery, tupleOfArgs);
+      if (got) {
+        const BuilderResult& p = getCompilerGeneratedBuilder(context, symbolPath);
+        return &p;
+      }
+      symbolPath = ID::parentSymbolPath(context, symbolPath);
+    }
+  }
+
   UniqueString path;
   UniqueString parentSymbolPath;
   bool found = context->filePathForId(id, path, parentSymbolPath);

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1019,7 +1019,7 @@ void Resolver::resolveTypeQueries(const AstNode* formalTypeExpr,
         auto formal = fa->formal()->toNamedDecl();
         const SubstitutionsMap& subs = actualCt->substitutions();
         auto ad = parsing::idToAst(context, actualCt->id())->toAggregateDecl();
-        auto field = findFieldIDByName(context, ad, actualCt, formal->name());
+        auto field = findFieldByName(context, ad, actualCt, formal->name());
         auto search = subs.find(field->id());
         if (search != subs.end()) {
           QualifiedType fieldType = search->second;

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2390,11 +2390,13 @@ QualifiedType Resolver::typeForId(const ID& id, bool localGenericToUnknown) {
 
   if (id.isFabricatedId()) {
     switch (id.fabricatedIdKind()) {
-      case ID::ExternBlockElement:
-      // TODO: resolve types for extern block
-      // (will need the Identifier name for that)
-      auto unknownType = UnknownType::get(context);
-      return QualifiedType(QualifiedType::UNKNOWN, unknownType);
+      case ID::ExternBlockElement: {
+        // TODO: resolve types for extern block
+        // (will need the Identifier name for that)
+        auto unknownType = UnknownType::get(context);
+        return QualifiedType(QualifiedType::UNKNOWN, unknownType);
+      }
+      case ID::Generated: break;
     }
   }
 

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -81,16 +81,18 @@ UntypedFnSignature::getUntypedFnSignature(Context* context, ID id,
                                           asttags::AstTag idTag,
                                           uast::Function::Kind kind,
                                           std::vector<FormalDetail> formals,
-                                          const AstNode* whereClause) {
+                                          const AstNode* whereClause,
+                                          ID compilerGeneratedOrigin) {
   QUERY_BEGIN(getUntypedFnSignature, context,
               id, name, isMethod, isTypeConstructor, isCompilerGenerated,
-               throws, idTag, kind, formals, whereClause);
+               throws, idTag, kind, formals, whereClause, compilerGeneratedOrigin);
 
   owned<UntypedFnSignature> result =
     toOwned(new UntypedFnSignature(id, name,
                                    isMethod, isTypeConstructor,
                                    isCompilerGenerated, throws, idTag, kind,
-                                   std::move(formals), whereClause));
+                                   std::move(formals), whereClause,
+                                   compilerGeneratedOrigin));
 
   return QUERY_END(result);
 }
@@ -105,11 +107,13 @@ UntypedFnSignature::get(Context* context, ID id,
                         asttags::AstTag idTag,
                         uast::Function::Kind kind,
                         std::vector<FormalDetail> formals,
-                        const uast::AstNode* whereClause) {
+                        const uast::AstNode* whereClause,
+                        ID compilerGeneratedOrigin) {
   return getUntypedFnSignature(context, id, name,
                                isMethod, isTypeConstructor,
                                isCompilerGenerated, throws, idTag, kind,
-                               std::move(formals), whereClause).get();
+                               std::move(formals), whereClause,
+                               compilerGeneratedOrigin).get();
 }
 
 static const UntypedFnSignature*

--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -646,7 +646,7 @@ returnTypeForTypeCtorQuery(Context* context,
     if (instantiatedFrom != nullptr) {
       int nFormals = sig->numFormals();
       for (int i = 0; i < nFormals; i++) {
-        auto field = findFieldIDByName(context, ad, instantiatedFrom, untyped->formalName(i));
+        auto field = findFieldByName(context, ad, instantiatedFrom, untyped->formalName(i));
         const QualifiedType& formalType = sig->formalType(i);
         // Note that the formalDecl should already be a fieldDecl
         // based on typeConstructorInitialQuery.

--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -606,7 +606,6 @@ void ReturnTypeInferrer::exit(const AstNode* ast, RV& rv) {
   exitScope(ast);
 }
 
-
 // For a class type construction, returns a BasicClassType
 static const Type* const&
 returnTypeForTypeCtorQuery(Context* context,
@@ -621,7 +620,7 @@ returnTypeForTypeCtorQuery(Context* context,
   // handle type construction
   const AggregateDecl* ad = nullptr;
   if (!untyped->id().isEmpty())
-    if (auto ast = parsing::idToAst(context, untyped->id()))
+    if (auto ast = parsing::idToAst(context, untyped->compilerGeneratedOrigin()))
       ad = ast->toAggregateDecl();
 
   if (ad) {
@@ -647,13 +646,13 @@ returnTypeForTypeCtorQuery(Context* context,
     if (instantiatedFrom != nullptr) {
       int nFormals = sig->numFormals();
       for (int i = 0; i < nFormals; i++) {
-        const Decl* formalDecl = untyped->formalDecl(i);
+        auto field = findFieldIDByName(context, ad, instantiatedFrom, untyped->formalName(i));
         const QualifiedType& formalType = sig->formalType(i);
         // Note that the formalDecl should already be a fieldDecl
         // based on typeConstructorInitialQuery.
         auto useKind = formalType.kind();
         bool hasInitExpression = false;
-        if (auto vd = formalDecl->toVarLikeDecl()) {
+        if (auto vd = field->toVarLikeDecl()) {
           // Substitute with the kind of the underlying field corresponding to
           // the formal. For example, if we substitute in a type for a generic
           // VAR decl, the type we construct will need to be inited with a VAR
@@ -679,7 +678,7 @@ returnTypeForTypeCtorQuery(Context* context,
         } else {
           auto useQt =
               QualifiedType(useKind, formalType.type(), formalType.param());
-          subs.insert({formalDecl->id(), useQt});
+          subs.insert({field->id(), useQt});
         }
       }
     }

--- a/frontend/lib/types/CompositeType.cpp
+++ b/frontend/lib/types/CompositeType.cpp
@@ -99,6 +99,16 @@ void CompositeType::stringify(std::ostream& ss,
   bool printSupertype =
     superType != nullptr && stringKind != StringifyKind::CHPL_SYNTAX;
 
+  // Prepend parent substitutions to 'sorted' list
+  if (!printSupertype && superType != nullptr) {
+    auto cur = superType->toBasicClassType();
+    while (cur != nullptr) {
+      auto parentSubs = cur->getCompositeType()->sortedSubstitutions();
+      sorted.insert(sorted.begin(), parentSubs.begin(), parentSubs.end());
+      cur = cur->parentClassType();
+    }
+  }
+
   if (printSupertype || !sorted.empty()) {
     bool emittedField = false;
     ss << "(";

--- a/frontend/lib/uast/Builder.cpp
+++ b/frontend/lib/uast/Builder.cpp
@@ -119,6 +119,16 @@ owned<Builder> Builder::createForIncludedModule(Context* context,
   return toOwned(b);
 }
 
+owned<Builder> Builder::createForGeneratedCode(Context* context,
+                                               const char* filepath,
+                                               UniqueString parentSymbolPath) {
+  auto uniqueFilename = UniqueString::get(context, filepath);
+  auto b = new Builder(context, uniqueFilename, parentSymbolPath,
+                       /* LibraryFile */ nullptr);
+  b->generatedCode_ = true;
+  return toOwned(b);
+}
+
 owned<Builder> Builder::createForLibraryFileModule(
                                         Context* context,
                                         UniqueString filePath,
@@ -499,7 +509,7 @@ void Builder::doAssignIDs(AstNode* ast, UniqueString symbolPath, int& i,
     }
 
     int afterChildID = i;
-    int myID = afterChildID;
+    int myID = this->generatedCode_ ? -2 - afterChildID : afterChildID;
     i++; // count the ID for the node we are currently visiting
     int numContainedIDs = afterChildID - firstChildID;
     ast->setID(ID(symbolPath, myID, numContainedIDs));

--- a/frontend/lib/uast/Builder.cpp
+++ b/frontend/lib/uast/Builder.cpp
@@ -488,7 +488,8 @@ void Builder::doAssignIDs(AstNode* ast, UniqueString symbolPath, int& i,
     }
 
     int numContainedIds = freshId;
-    ast->setID(ID(newSymbolPath, -1, numContainedIds));
+    int postOrderId = this->generatedCode_ ? -3 : -1;
+    ast->setID(ID(newSymbolPath, postOrderId, numContainedIds));
 
     // Note: when creating a new symbol (e.g. fn), we're not incrementing i.
     // The new symbol ID has the updated path (e.g. function name)
@@ -509,7 +510,7 @@ void Builder::doAssignIDs(AstNode* ast, UniqueString symbolPath, int& i,
     }
 
     int afterChildID = i;
-    int myID = this->generatedCode_ ? -2 - afterChildID : afterChildID;
+    int myID = this->generatedCode_ ? -4 - afterChildID : afterChildID;
     i++; // count the ID for the node we are currently visiting
     int numContainedIDs = afterChildID - firstChildID;
     ast->setID(ID(symbolPath, myID, numContainedIDs));

--- a/frontend/test/resolution/testTypeConstruction.cpp
+++ b/frontend/test/resolution/testTypeConstruction.cpp
@@ -1458,6 +1458,40 @@ static void testRecursiveTypeConstructorMutual() {
   assert(fieldsB.fieldType(2).type()->toClassType()->basicClassType() == ctA->basicClassType());
 }
 
+static void test43() {
+  printf("test43\n");
+  Context ctx;
+  Context* context = &ctx;
+  auto p = parseTypeAndFieldsOfX(context,
+                        R""""(
+                        class A {
+                          type TX;
+                          var x : TX;
+                        }
+
+                        class B : A {
+                          type TY;
+                          var y : TY;
+                        }
+
+                        var x : unmanaged B(int, real)?;
+                        )"""");
+
+  auto rt = p.first->toClassType();
+  assert(rt);
+  assert(rt->decorator().isUnmanaged());
+
+  auto fields = p.second;
+  assert(fields);
+  assert(fields->numFields() == 2);
+  assert(fields->fieldType(0).type()->isRealType());
+
+  auto parent = rt->basicClassType()->parentClassType();
+  auto pf = parent->substitutions();
+  assert(pf.size() == 1);
+  assert(pf.begin()->second.type()->isIntType());
+}
+
 
 int main() {
   test1();
@@ -1509,6 +1543,7 @@ int main() {
   testRecursiveTypeConstructorAlias();
   testRecursiveTypeConstructorGeneric();
   testRecursiveTypeConstructorMutual();
+  test43();
 
   return 0;
 }


### PR DESCRIPTION
This PR implements type constructors for inheriting generic classes, which requires some substantial changes to the way type constructors are implemented in dyno.

Prior to this PR, we used a compiler-generated signature that re-used the uAST and IDs for fields in place of real formals. This breaks down when inheriting classes are involved because the parent fields will have different symbol paths from the child's fields, which can confuse the rest of dyno's infrastructure. This especially causes issues for the way we store resolution results, which cannot account for IDs from different symbol paths.

This PR addresses this problem by generating dedicated uAST for the type constructor, rather than trying to fake formals with the uAST of fields. Generating uAST on the fly like this is new for dyno, and has required some additional infrastructure. The notable changes are as follows:
- Ability to copy uAST
- Adds ``ID::FabricatedKind::Generated`` to indicate non-specific compiler-generated IDs
- Storing/fetching a BuilderResult for compiler-generated uAST based on a symbol path of a compiler-generated module
- Updating "id to ast" code to handle compiler-generated IDs

With these capabilities in place, typeConstructorInitialQuery now builds a small module to store a uAST Function that serves as the type constructor for a given type. This module pretends to be an included module living under the module in which the type was declared. For example, if a type 'R' was defined in module 'foo', the generated module would have the symbol path of ``foo.chpl__internal_foo_R``.

This module also includes a 'use' statement for the original module, which is necessary in the event that fields' type/init expressions refer to other symbols.

Once finished building the uAST, we store the BuilderResult based on the module path.

This PR updates the implementation of IDs to treat postOrderId values less than ``-2`` as compiler-generated IDs, but returning said IDs as a positive 0-based value so as not to confuse the rest of resolution. Internally, a value of ``-3`` represents a compiler-generated symbol, and anything less than ``-3`` is a child of a compiler-generated symbol, and will have its value translated into the proper positive value upon a call to ``ID::postOrderId()``. This change was made to more easily support id-to-ast lookups in which we want to quickly determine whether an ID has an actual file behind it, or if it requires special handling because it was compiler-generated.

Other changes:
- Updated CompositeType::stringify to print generic parent substitutions
- A new resolution query ``findFieldIDByName`` is added to support these changes

Testing:
- [x] test-dyno