### PR TITLE
Remove extraneous debugger breakpoint in testCPtr

### DIFF
--- a/frontend/test/resolution/testCPtr.cpp
+++ b/frontend/test/resolution/testCPtr.cpp
@@ -75,7 +75,6 @@ void testCPtrArg(const char* formalType, const char* actualType, F&& test) {
   auto& modResResult = resolveModule(context, mainMod->id());
   auto& rr = modResResult.byAst(fCallVar->toVariable()->initExpression());
 
-  debuggerBreakHere();
   auto fn = rr.mostSpecific().only().fn();
 
   const types::CPtrType* formalTypePtr = nullptr;


### PR DESCRIPTION
This appears to have been left in accidentally in https://github.com/chapel-lang/chapel/pull/22654 (https://github.com/chapel-lang/chapel/pull/22654/files#diff-2c0c215b3271a5265835dc847315a79c13df3b1db4df5a25d9b0d01352c67984R69).

[reviewer info placeholder]