### PR TITLE
Fix bug resolving constrained, dependently typed, type constructor formals

### DIFF
--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -3723,8 +3723,7 @@ void Resolver::handleCallExpr(const uast::Call* call) {
   // EXCEPT, type construction can work with unknown or generic types
   // EXCEPT, tuple type construction also works with unknown/generic types
 
-  if (!ci.calledType().isType() &&
-      !call->isTuple()) {
+  if (!call->isTuple()) {
     int actualIdx = 0;
     for (const auto& actual : ci.actuals()) {
       ID toId; // does the actual refer directly to a particular variable?
@@ -3749,6 +3748,8 @@ void Resolver::handleCallExpr(const uast::Call* call) {
                  qt.isRef() == false) {
         // don't skip because it could be initialized with 'out' intent,
         // but not for non-out formals because they can't be split-initialized.
+      } else if (actualAst->isTypeQuery() && ci.calledType().isType()) {
+        // don't skip for type queries in type constructors
       } else {
         if (qt.isParam() && qt.param() == nullptr) {
           skip = UNKNOWN_PARAM;
@@ -3784,6 +3785,13 @@ void Resolver::handleCallExpr(const uast::Call* call) {
     // Do not skip primitive calls that accept a generic type, since they
     // may be valid.
     skip = NONE;
+  }
+
+  // Don't skip for type constructors, except due to unknown params.
+  if (skip != NONE && ci.calledType().isType()) {
+    if (skip != UNKNOWN_PARAM) {
+      skip = NONE;
+    }
   }
 
   if (!skip) {

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -3770,6 +3770,11 @@ void Resolver::handleCallExpr(const uast::Call* call) {
           }
         }
       }
+      // Don't skip for type constructors, except due to unknown params.
+      if (skip != UNKNOWN_PARAM && ci.calledType().isType()) {
+        skip = NONE;
+      }
+
       if (skip) {
         break;
       }
@@ -3785,13 +3790,6 @@ void Resolver::handleCallExpr(const uast::Call* call) {
     // Do not skip primitive calls that accept a generic type, since they
     // may be valid.
     skip = NONE;
-  }
-
-  // Don't skip for type constructors, except due to unknown params.
-  if (skip != NONE && ci.calledType().isType()) {
-    if (skip != UNKNOWN_PARAM) {
-      skip = NONE;
-    }
   }
 
   if (!skip) {

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -3770,8 +3770,15 @@ void Resolver::handleCallExpr(const uast::Call* call) {
           }
         }
       }
+
       // Don't skip for type constructors, except due to unknown params.
       if (skip != UNKNOWN_PARAM && ci.calledType().isType()) {
+        skip = NONE;
+      }
+
+      // Do not skip primitive calls that accept a generic type, since they
+      // may be valid.
+      if (skip == GENERIC_TYPE && call->toPrimCall()) {
         skip = NONE;
       }
 
@@ -3784,12 +3791,6 @@ void Resolver::handleCallExpr(const uast::Call* call) {
   // Don't try to resolve calls to '=' until later
   if (ci.isOpCall() && ci.name() == USTR("=")) {
     skip = OTHER_REASON;
-  }
-
-  if (skip == GENERIC_TYPE && call->toPrimCall()) {
-    // Do not skip primitive calls that accept a generic type, since they
-    // may be valid.
-    skip = NONE;
   }
 
   if (!skip) {

--- a/frontend/test/resolution/testFunctionCalls.cpp
+++ b/frontend/test/resolution/testFunctionCalls.cpp
@@ -132,11 +132,87 @@ static void test3b() {
   helpTest3(theFunction);
 }
 
+// Test calling dependently typed type constructor, for type with param field
+static void test4() {
+  Context ctx;
+  auto context = &ctx;
+
+  // With param field type declared
+  {
+    printf("part 1\n");
+    context->advanceToNextRevision(true);
+
+    const std::string program =
+      R""""(
+      record Foo {
+        param fooStrides : int;
+      }
+      proc bar(param strides = 1, other: Foo(strides)) {
+        return other.fooStrides;
+      }
+      var x = bar(1, new Foo(1));
+      )"""";
+
+    auto qt = resolveTypeOfXInit(context, program);
+    assert(qt.type() != nullptr);
+    assert(qt.type()->isIntType());
+
+    context->collectGarbage();
+  }
+
+  // Param field of generic type
+  {
+    printf("part 2\n");
+    context->advanceToNextRevision(true);
+
+    const std::string program =
+      R""""(
+      record Foo {
+        param fooStrides;
+      }
+      proc bar(param strides = 1, other: Foo(strides)) {
+        return other.fooStrides;
+      }
+      var x = bar(1, new Foo(1));
+      )"""";
+
+    auto qt = resolveTypeOfXInit(context, program);
+    assert(qt.type() != nullptr);
+    assert(qt.type()->isIntType());
+
+    context->collectGarbage();
+  }
+
+  // With param formal type declared
+  {
+    printf("part 3\n");
+    context->advanceToNextRevision(true);
+
+    const std::string program =
+      R""""(
+      record Foo {
+        param fooStrides : int;
+      }
+      proc bar(param strides : int, other: Foo(strides)) {
+        return other.fooStrides;
+      }
+      var x = bar(1, new Foo(1));
+      )"""";
+
+    auto qt = resolveTypeOfXInit(context, program);
+    assert(qt.type() != nullptr);
+    assert(qt.type()->isIntType());
+
+    context->collectGarbage();
+  }
+}
+
 int main() {
   test1();
   test2();
   test3a();
   test3b();
+  test4();
 
   return 0;
 }


### PR DESCRIPTION
Fix a dyno bug in resolving a dependently typed type constructor call used as the type of a formal, when the type constructor has a constrained generic formal.

Example:
```
record Foo
{
  param fooStrides : int;
  // param fooStrides; // always worked
}
proc bar(param strides = 1, other: Foo(strides)) {}
// proc bar(param strides : int, other: Foo(strides)) {} // always worked
bar(1, new Foo(1));
```

Previously, `Foo(strides)` would fail to resolve; we attempted to resolve it in `Resolver::handleCallExpr` which occurs prior to instantiation, at which point `strides` is an unknown param and therefore cannot be passed to the `int` param required by `Foo`'s type constructor. This is resolved by extending `handleCallExpr`'s skip-until-later logic to also allow skipping type constructors, in the case of unknown params that aren't type queries.

Encountered on https://github.com/Cray/chapel-private/issues/6604#issuecomment-2291717556.

While here, also move the special case for primitive calls that accept a generic type into the loop checking through each actual, to prevent masking later formals that might provide a different reason to skip.

Thanks @DanilaFe for the help debugging this.

[reviewer info placeholder]

Testing:
- [x] dyno tests
- [x] original reproducer now succeeds
- [x] non-matching call to `bar` (`bar(1, new Foo(2))`) is still correctly rejected
- [x] paratest