### PR TITLE
Use smaller size for GPU perf test

### DIFF
--- a/test/gpu/native/studies/math/mathKernels.chpl
+++ b/test/gpu/native/studies/math/mathKernels.chpl
@@ -2,7 +2,7 @@ use Math;
 import Time.stopwatch;
 use Random;
 
-config const size:uint(32) = 100_000_000;
+config const size:uint(32) = 10_000_000;
 config const iterations:int(32) = 1;
 config const printTime = true;
 config const correctness = false;

--- a/test/gpu/native/studies/math/mathKernels.cu
+++ b/test/gpu/native/studies/math/mathKernels.cu
@@ -21,7 +21,7 @@
 #endif
 
 #ifndef mk_SIZE
-#define mk_SIZE 100'000'000
+#define mk_SIZE 10'000'000
 #endif
 
 #define mk_FUNC_NAME_inner2(a, b) a ## b


### PR DESCRIPTION
Use a smaller problem size for `mathKernels`, so that perf testing on older hardware does not take too long

[Reviewed by @ShreyasKhandekar]