### PR TITLE
Add missing flag to bash complete script

### DIFF
--- a/util/chpl-completion.bash
+++ b/util/chpl-completion.bash
@@ -145,6 +145,7 @@ _chpl ()
 --live-analysis \
 --lldb \
 --llvm-print-ir \
+--llvm-print-ir-file \
 --llvm-print-ir-stage \
 --llvm-print-passes \
 --llvm-remarks \


### PR DESCRIPTION
Adds `--llvm-print-ir-file` to `util/chpl-completion.bash`. This was missed in https://github.com/chapel-lang/chapel/pull/25201

[Not reviewed - trivial]