### PR TITLE
Fix typo in hip memcpy call

### DIFF
--- a/runtime/src/gpu/amd/gpu-amd.c
+++ b/runtime/src/gpu/amd/gpu-amd.c
@@ -105,7 +105,7 @@ static void chpl_gpu_impl_set_globals(c_sublocid_t dev_id, hipModule_t module) {
     // The validation only happens when built with assertions (commonly
     // enabled by CHPL_DEVELOPER), and chpl_gpu_impl_copy_host_to_device
     // only causes issues in that case.
-    ROCM_CALL(hipMemcpyDtoD(ptr, (void*)&chpl_nodeID, glob_size));
+    ROCM_CALL(hipMemcpyHtoD(ptr, (void*)&chpl_nodeID, glob_size));
   }
 }
 


### PR DESCRIPTION
Fixes a typo introduced in https://github.com/chapel-lang/chapel/pull/24706, where `chpl_gpu_impl_copy_host_to_device` was replaced with `hipMemcpyDtoD`, when it should have been replaced with `hipMemcpyHtoD`

- [x] Ran `start_test test/gpu/native` with rocm 5.4.3
- [x] Ran `start_test test/gpu/native` with rocm 6.2

[Reviewed by @DanilaFe]