### PR TITLE
Fix: Get PTRANS.valgrind.chpl working again without auto -o flag

### DIFF
--- a/test/studies/hpcc/PTRANS/old/PTRANS.valgrind.compopts
+++ b/test/studies/hpcc/PTRANS/old/PTRANS.valgrind.compopts
@@ -1,1 +1,1 @@
-PTRANS.chpl
+PTRANS.chpl -o PTRANS.valgrind


### PR DESCRIPTION
This is a fix to #25772 which needed an explicit -o flag due to its use of modules, but wasn't caught in my testing due to being a valgrind-only test.
