### PR TITLE
Revert change to always use hwloc with pci

### DIFF
--- a/test/runtime/jhh/colocales/colocales.py
+++ b/test/runtime/jhh/colocales/colocales.py
@@ -326,6 +326,7 @@ class Ex2Tests(TestCases.TestCase):
         output = self.runCmd("./colocales -r 0 -n 17")
         self.assertIn("warning: 9 cores are unused\n", output);
 
+@unittest.skip("requires --enable-pci")
 class Ex3Tests(TestCases.TestCase):
     """
     HPE Cray EX. One sockets, four NUMA domains per socket, 64 cores per

--- a/third-party/hwloc/Makefile
+++ b/third-party/hwloc/Makefile
@@ -26,6 +26,13 @@ CHPL_HWLOC_CFG_OPTIONS += --enable-static \
                           --disable-gl \
                           --disable-rsmi
 
+# TODO: this is also needed for colocales with GPUs
+# PCI support is needed for NIC selection, which currently is only supported
+# with the ofi comm layer
+ifneq ($(CHPL_MAKE_COMM), ofi)
+	CHPL_HWLOC_CFG_OPTIONS += --disable-pci
+endif
+
 ifdef CHPL_HWLOC_PREFIX
    CHPL_HWLOC_CFG_OPTIONS += --with-hwloc-symbol-prefix=$(CHPL_HWLOC_PREFIX)
 endif


### PR DESCRIPTION
Reverts a small piece of https://github.com/chapel-lang/chapel/pull/25734. By unconditionally enabling pci support with hwloc, this caused issues with chplenv and reading the hwloc dependencies

Specifically, `printchplenv --internal` would print:
```
Warning: Simple pkg-config parser does not handle Requires.private
Warning: in $CHPL_HOME/third-party/hwloc/install/...../lib/pkgconfig/hwloc.pc
```

This broke some nightly tests, so I am reverting this temporarily. Enabling PCI support is required eventually for full colocales+GPUs support

[Reviewed by @ShreyasKhandekar]
