### PR TITLE
Add distributed Game of Life example

### DIFF
--- a/test/exercises/life.compopts
+++ b/test/exercises/life.compopts
@@ -1,0 +1,3 @@
+-sdist=distType.na
+-sdist=distType.block
+-sdist=distType.stencil


### PR DESCRIPTION
Expands `test/exercises/life.chpl` to have distributed examples using `BlockDist` and `StencilDist`.

Tested locally

[Reviewed by @jeremiah-corrado]