### PR TITLE
Dyno: syntactically determine the genericity of fields for building type constructors

### DIFF
--- a/frontend/include/chpl/framework/mark-functions.h
+++ b/frontend/include/chpl/framework/mark-functions.h
@@ -31,7 +31,6 @@
 #include <vector>
 
 #include "chpl/framework/Context.h"
-#include "chpl/types/QualifiedType.h"
 #include "chpl/util/memory.h"
 
 namespace chpl {
@@ -157,13 +156,6 @@ void mark_tuple_impl(Context* context, const Tuple& tuple, std::index_sequence<I
 template<typename ... Ts> struct mark<std::tuple<Ts...>> {
   void operator()(Context* context, const std::tuple<Ts...>& keep) const {
     mark_tuple_impl(context, keep, std::index_sequence_for<Ts...>());
-  }
-};
-
-template <>
-struct mark<types::QualifiedType::Kind> {
-  void operator()(Context* context, types::QualifiedType::Kind t) {
-    // No need to mark enums
   }
 };
 

--- a/frontend/include/chpl/resolution/resolution-error-classes-list.h
+++ b/frontend/include/chpl/resolution/resolution-error-classes-list.h
@@ -85,6 +85,7 @@ ERROR_CLASS(ReductionInvalidName, const uast::AstNode*, UniqueString, types::Qua
 ERROR_CLASS(ReductionNotReduceScanOp, const uast::AstNode*, types::QualifiedType)
 ERROR_CLASS(SplitInitMismatchedConditionalTypes, const uast::Variable*, const uast::AstNode*, const types::QualifiedType, const types::QualifiedType, const int, const int)
 ERROR_CLASS(SuperFromTopLevelModule, const uast::AstNode*, const uast::Module*, resolution::VisibilityStmtKind)
+ERROR_CLASS(SyntacticGenericityMismatch, const uast::Decl*, const types::Type::Genericity, const types::Type::Genericity, types::QualifiedType)
 WARNING_CLASS(TertiaryUseImportUnstable, UniqueString, const uast::AstNode*, const uast::VisibilityClause*, const resolution::Scope*, resolution::VisibilityStmtKind)
 ERROR_CLASS(TupleDeclMismatchedElems, const uast::TupleDecl*, const types::TupleType*)
 ERROR_CLASS(TupleDeclNotTuple, const uast::TupleDecl*, const types::Type*)

--- a/frontend/include/chpl/resolution/resolution-error-classes-list.h
+++ b/frontend/include/chpl/resolution/resolution-error-classes-list.h
@@ -60,6 +60,7 @@ ERROR_CLASS(InvalidParamCast, const uast::AstNode*, types::QualifiedType, types:
 ERROR_CLASS(InvalidSuper, const uast::Identifier*, types::QualifiedType)
 ERROR_CLASS(MemManagementNonClass, const uast::New*, const types::Type*)
 ERROR_CLASS(MissingInclude, const uast::Include*, std::string)
+ERROR_CLASS(MissingFormalInstantiation, const uast::AstNode*, std::vector<std::tuple<const uast::Decl*, types::QualifiedType>>)
 ERROR_CLASS(ModuleAsVariable, const uast::AstNode*, const uast::AstNode*, const uast::Module*)
 ERROR_CLASS(MultipleEnumElems, const uast::AstNode*, chpl::UniqueString, const uast::Enum*, std::vector<ID>)
 ERROR_CLASS(MultipleInheritance, const uast::Class*, const uast::AstNode*, const uast::AstNode*)

--- a/frontend/include/chpl/resolution/resolution-queries.h
+++ b/frontend/include/chpl/resolution/resolution-queries.h
@@ -129,14 +129,14 @@ const types::Type* initialTypeForTypeDecl(Context* context, ID declId);
   fieldsForTypeDecl should be used instead unless there
   is a reason that one-at-a-time resolution is important.
 
-  If ignoreTypes is set, computes basic information (field order, IDs)
+  If syntaxOnly is set, computes basic information (field order, IDs)
   but does not compute types.
  */
 const ResolvedFields& resolveFieldDecl(Context* context,
                                        const types::CompositeType* ct,
                                        ID fieldId,
                                        DefaultsPolicy defaultsPolicy,
-                                       bool ignoreTypes = false);
+                                       bool syntaxOnly = false);
 
 /**
   Compute the fields and their types for a CompositeType
@@ -154,13 +154,13 @@ const ResolvedFields& resolveFieldDecl(Context* context,
 
   The returned fields do not include any parent class fields.
 
-  If ignoreTypes is set, computes basic information (field order, IDs)
+  If syntaxOnly is set, computes basic information (field order, IDs)
   but does not compute types.
  */
 const ResolvedFields& fieldsForTypeDecl(Context* context,
                                         const types::CompositeType* ct,
                                         DefaultsPolicy defaultsPolicy,
-                                        bool ignoreTypes = false);
+                                        bool syntaxOnly = false);
 
 /**
   If 'name' is the name of a field for type 't', returns a non-null pointer;

--- a/frontend/include/chpl/resolution/resolution-queries.h
+++ b/frontend/include/chpl/resolution/resolution-queries.h
@@ -128,14 +128,18 @@ const types::Type* initialTypeForTypeDecl(Context* context, ID declId);
   The result will not have summary information computed.
   fieldsForTypeDecl should be used instead unless there
   is a reason that one-at-a-time resolution is important.
+
+  If ignoreTypes is set, computes basic information (field order, IDs)
+  but does not compute types.
  */
 const ResolvedFields& resolveFieldDecl(Context* context,
                                        const types::CompositeType* ct,
                                        ID fieldId,
-                                       DefaultsPolicy defaultsPolicy);
+                                       DefaultsPolicy defaultsPolicy,
+                                       bool ignoreTypes = false);
 
 /**
-  Compute the types of the fields for a CompositeType
+  Compute the fields and their types for a CompositeType
   (such as one returned by initialTypeForTypeDecl).
 
   If useGenericFormalDefaults is true, a generic field like
@@ -149,10 +153,14 @@ const ResolvedFields& resolveFieldDecl(Context* context,
   the field already has a substitution in the CompositeType.
 
   The returned fields do not include any parent class fields.
+
+  If ignoreTypes is set, computes basic information (field order, IDs)
+  but does not compute types.
  */
 const ResolvedFields& fieldsForTypeDecl(Context* context,
                                         const types::CompositeType* ct,
-                                        DefaultsPolicy defaultsPolicy);
+                                        DefaultsPolicy defaultsPolicy,
+                                        bool ignoreTypes = false);
 
 /**
   If 'name' is the name of a field for type 't', returns a non-null pointer;

--- a/frontend/include/chpl/resolution/resolution-queries.h
+++ b/frontend/include/chpl/resolution/resolution-queries.h
@@ -217,6 +217,10 @@ types::Type::Genericity getTypeGenericity(Context* context,
                                           types::QualifiedType qt);
 
 
+bool isFieldSyntacticallyGeneric(Context* context,
+                                 const ID& field,
+                                 types::QualifiedType* formalType = nullptr);
+
 /**
   Returns true if the field should be included in the type constructor.
   In that event, also sets formalType to the type the formal should use.

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -2426,6 +2426,8 @@ class ResolvedFields {
     }
   }
 
+  void validateFieldGenericity(Context* context, const types::CompositeType* fieldsOfType) const;
+
   void finalizeFields(Context* context, bool syntaxOnly);
 
   /** Returns true if this is a generic type */

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -2426,7 +2426,7 @@ class ResolvedFields {
     }
   }
 
-  void finalizeFields(Context* context);
+  void finalizeFields(Context* context, bool syntaxOnly);
 
   /** Returns true if this is a generic type */
   bool isGeneric() const { return isGeneric_; }

--- a/frontend/include/chpl/resolution/scope-queries.h
+++ b/frontend/include/chpl/resolution/scope-queries.h
@@ -44,6 +44,9 @@ namespace resolution {
    */
   const Scope* scopeForModule(Context* context, ID moduleId);
 
+
+  const bool& isNameBuiltinGenericType(Context* context, UniqueString name);
+
   /**
     The configuration used to look up a plain identifier in a scope
     when resolving expressions.

--- a/frontend/include/chpl/types/QualifiedType.h
+++ b/frontend/include/chpl/types/QualifiedType.h
@@ -270,6 +270,13 @@ struct stringify<types::QualifiedType::Kind> {
 // docs are turned off for this as a workaround for breathe errors
 /// \cond DO_NOT_DOCUMENT
 
+template <>
+struct mark<types::QualifiedType::Kind> {
+  void operator()(Context* context, types::QualifiedType::Kind t) {
+    // No need to mark enums
+  }
+};
+
 
 /// \endcond
 

--- a/frontend/include/chpl/types/Type.h
+++ b/frontend/include/chpl/types/Type.h
@@ -22,6 +22,7 @@
 
 #include "chpl/framework/Context.h"
 #include "chpl/framework/update-functions.h"
+#include "chpl/framework/mark-functions.h"
 #include "chpl/types/TypeTag.h"
 #include "chpl/uast/Pragma.h"
 
@@ -371,6 +372,23 @@ namespace detail {
 
 } // end namespace types
 
+/// \cond DO_NOT_DOCUMENT
+
+template<> struct update<types::Type::Genericity> {
+  bool operator()(types::Type::Genericity& keep,
+                  types::Type::Genericity& addin) const {
+    return defaultUpdateBasic(keep, addin);
+  }
+};
+
+template<> struct mark<types::Type::Genericity> {
+  void operator()(Context* context,
+                  const types::Type::Genericity& keep) const {
+    // nothing to do for enum
+  }
+};
+
+/// \endcond DO_NOT_DOCUMENT
 
 } // end namespace chpl
 

--- a/frontend/lib/resolution/InitResolver.cpp
+++ b/frontend/lib/resolution/InitResolver.cpp
@@ -311,7 +311,7 @@ const Type* InitResolver::computeReceiverTypeConsideringState(void) {
 
     if (isInitiallyConcrete) continue;
 
-    if (!shouldIncludeFieldInTypeConstructor(ctx_, id, qtInitial)) continue;
+    if (!isFieldSyntacticallyGeneric(ctx_, id)) continue;
 
     // TODO: Will need to relax this as we go.
     if (isValidQtForSubstitutions(state->qt)) {

--- a/frontend/lib/resolution/resolution-error-classes-list.cpp
+++ b/frontend/lib/resolution/resolution-error-classes-list.cpp
@@ -742,7 +742,6 @@ void ErrorMissingInclude::write(ErrorWriterBase& wr) const {
 }
 
 void ErrorMissingFormalInstantiation::write(ErrorWriterBase& wr) const {
-  // ERROR_CLASS(MissingFormalInstantiation, const uast::AstNode*, std::vector<std::tuple<const uast::Decl*, types::QualifiedType>>)
   auto call = std::get<0>(info_);
   auto& genericFormals = std::get<1>(info_);
 

--- a/frontend/lib/resolution/resolution-error-classes-list.cpp
+++ b/frontend/lib/resolution/resolution-error-classes-list.cpp
@@ -741,6 +741,27 @@ void ErrorMissingInclude::write(ErrorWriterBase& wr) const {
   wr.note(moduleInclude, "expected file at path '", filePath, "'");
 }
 
+void ErrorMissingFormalInstantiation::write(ErrorWriterBase& wr) const {
+  // ERROR_CLASS(MissingFormalInstantiation, const uast::AstNode*, std::vector<std::tuple<const uast::Decl*, types::QualifiedType>>)
+  auto call = std::get<0>(info_);
+  auto& genericFormals = std::get<1>(info_);
+
+  wr.heading(kind_, type_, call, "call does not provide enough type information for a complete instantiation.");
+  wr.code(call, {call});
+  for (auto& formal : genericFormals) {
+    auto decl = std::get<0>(formal);
+    auto qt = std::get<1>(formal);
+
+    if (auto named = decl->toNamedDecl()) {
+      wr.note(call, "formal '", named->name(), "' has generic type '", qt.type(), "', but is expected to have a concrete type.");
+    } else {
+      wr.note(call, "formal has generic type '", qt.type(), "', but is expected to have a concrete type.");
+    }
+    wr.codeForDef(decl);
+    wr.message("");
+  }
+}
+
 void ErrorModuleAsVariable::write(ErrorWriterBase& wr) const {
   auto node = std::get<0>(info_);
   auto parent = std::get<1>(info_);

--- a/frontend/lib/resolution/resolution-error-classes-list.cpp
+++ b/frontend/lib/resolution/resolution-error-classes-list.cpp
@@ -1468,6 +1468,37 @@ void ErrorSuperFromTopLevelModule::write(ErrorWriterBase& wr) const {
   wr.codeForLocation(mod);
 }
 
+static const char* genericityToString(types::Type::Genericity genericity) {
+  switch (genericity) {
+    case types::Type::GENERIC:
+      return "generic";
+    case types::Type::GENERIC_WITH_DEFAULTS:
+      return "generic with defaults";
+    case types::Type::MAYBE_GENERIC:
+      return "maybe generic";
+    case types::Type::CONCRETE:
+      return "concrete";
+    default:
+      CHPL_ASSERT(false && "shouldn't happen");
+      return "";
+  }
+}
+
+void ErrorSyntacticGenericityMismatch::write(ErrorWriterBase& wr) const {
+  auto decl = std::get<const uast::Decl*>(info_);
+  auto actualGenericity = std::get<1>(info_);
+  auto syntacticGenericity = std::get<2>(info_);
+  auto& type = std::get<types::QualifiedType>(info_);
+
+  CHPL_ASSERT(decl->isVarLikeDecl());
+  auto var = decl->toVarLikeDecl();
+
+  wr.heading(kind_, type_, decl, "field '", var->name(), "' appears to be ",
+             genericityToString(syntacticGenericity), " in the program's syntax, but it has been inferred to be ",
+             type, ", which is ", genericityToString(actualGenericity), ".");
+  wr.codeForLocation(decl);
+}
+
 void ErrorTertiaryUseImportUnstable::write(ErrorWriterBase& wr) const {
   auto name = std::get<UniqueString>(info_);
   auto node = std::get<const uast::AstNode*>(info_);

--- a/frontend/lib/resolution/resolution-error-classes-list.cpp
+++ b/frontend/lib/resolution/resolution-error-classes-list.cpp
@@ -764,11 +764,9 @@ void ErrorMissingFormalInstantiation::write(ErrorWriterBase& wr) const {
 
     if (qt.type()) {
       if (auto ct = qt.type()->toClassType()) {
-        if (auto bt = ct->basicClassType()) {
-          if (ct->decorator().isUnknownManagement()) {
-            wr.note(decl, "one reason that ", formalName, " is generic is that it doesn't have a specified memory management strategy like 'owned', 'shared' or 'unmanaged'.");
-            wr.message("Consider explicitly specifying a memory management strategy, or adding a new type parameter to explicitly make the formal generic.");
-          }
+        if (ct->decorator().isUnknownManagement() && ct->basicClassType()) {
+          wr.note(decl, "one reason that ", formalName, " is generic is that it doesn't have a specified memory management strategy like 'owned', 'shared' or 'unmanaged'.");
+          wr.message("Consider explicitly specifying a memory management strategy, or adding a new type parameter to explicitly make the formal generic.");
         }
       }
     }

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -1231,25 +1231,6 @@ Type::Genericity getTypeGenericity(Context* context, QualifiedType qt) {
   return getTypeGenericityViaQualifiedTypeQuery(context, qt);
 }
 
-static bool isBuiltinGenericIdentifier(UniqueString id) {
-  static const std::unordered_set<std::string> builtinGenericTypeNames = {
-    /* "complex", "imag", "real", */
-
-    /* the above are listed in the production compiler's list, but they have
-       default values (imag == imag(64)), so they are not considered generic. */
-
-    "enum",
-    "numeric", "integral",
-    "_iteratorRecord", "_iteratorClass",
-    "_thunkRecord",
-    "POD",
-    "owned", "_owned", "shared", "_shared",
-    "_anyRecord", "_tuple",
-    "_singlevar", "_syncvar"
-  };
-  return builtinGenericTypeNames.count(id.c_str()) > 0;
-}
-
 /**
   Written primarily to support multi-decls, though the logic is the same
   as for single declarations. Sets 'outIsGeneric' with the genericity of the
@@ -1294,7 +1275,7 @@ static bool isVariableDeclWithClearGenericity(Context* context,
   // concrete. The only "generic" form is a call with a "(?)" actual.
 
   if (auto ident = var->typeExpression()->toIdentifier()) {
-    outIsGeneric = isBuiltinGenericIdentifier(ident->name());
+    outIsGeneric = isNameBuiltinGenericType(context, ident->name());
     return true;
   } else if (auto call = var->typeExpression()->toFnCall()) {
     for (auto actual : call->actuals()) {

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -1231,6 +1231,25 @@ Type::Genericity getTypeGenericity(Context* context, QualifiedType qt) {
   return getTypeGenericityViaQualifiedTypeQuery(context, qt);
 }
 
+static bool isBuiltinGenericIdentifier(UniqueString id) {
+  static const std::unordered_set<std::string> builtinGenericTypeNames = {
+    /* "complex", "imag", "real", */
+
+    /* the above are listed in the production compiler's list, but they have
+       default values (imag == imag(64)), so they are not considered generic. */
+
+    "enum",
+    "numeric", "integral",
+    "_iteratorRecord", "_iteratorClass",
+    "_thunkRecord",
+    "POD",
+    "owned", "_owned", "shared", "_shared",
+    "_anyRecord", "_tuple",
+    "_singlevar", "_syncvar"
+  };
+  return builtinGenericTypeNames.count(id.c_str()) > 0;
+}
+
 /**
   Written primarily to support multi-decls, though the logic is the same
   as for single declarations. Sets 'outIsGeneric' with the genericity of the
@@ -1274,7 +1293,10 @@ static bool isVariableDeclWithClearGenericity(Context* context,
   // of the type expression determines if we guess it to be generic or
   // concrete. The only "generic" form is a call with a "(?)" actual.
 
-  if (auto call = var->typeExpression()->toFnCall()) {
+  if (auto ident = var->typeExpression()->toIdentifier()) {
+    outIsGeneric = isBuiltinGenericIdentifier(ident->name());
+    return true;
+  } else if (auto call = var->typeExpression()->toFnCall()) {
     for (auto actual : call->actuals()) {
       if (auto ident = actual->toIdentifier()) {
         if (ident->name() == "?") {

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -1282,10 +1282,14 @@ bool isFieldSyntacticallyGeneric(Context* context,
   auto var = parsing::idToAst(context, fieldId)->toVariable();
   CHPL_ASSERT(var);
 
-  bool isGeneric;
+  bool isGeneric = false;
   if (isVariableDeclWithClearGenericity(context, var, isGeneric, formalType)) {
     return isGeneric;
   }
+
+  // Today, in situations when the genericity is not clear, without further
+  // information we assume the field is generic.
+  CHPL_ASSERT(isGeneric == true);
 
   // Genericity isn't clear; if we're in a multi-decl, try searching
   // to the right.
@@ -2279,7 +2283,6 @@ ApplicabilityResult instantiateSignature(Context* context,
                                           fieldType.param()));
 
       if (isFieldSyntacticallyGeneric(context, fieldDecl->id())){
-        // TODO
         newSubstitutions.insert({fieldDecl->id(), fieldType});
       }
     }

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -1204,14 +1204,30 @@ Type::Genericity getTypeGenericityIgnoring(Context* context, QualifiedType qt,
    return g;
 }
 
-Type::Genericity getTypeGenericity(Context* context, const Type* t) {
+static const Type::Genericity& getTypeGenericityViaPtrQuery(Context* context, const Type* t) {
+  QUERY_BEGIN(getTypeGenericityViaPtrQuery, context, t);
+
   std::set<const Type*> ignore;
-  return getTypeGenericityIgnoring(context, t, ignore);
+  auto result = getTypeGenericityIgnoring(context, t, ignore);
+
+  return QUERY_END(result);
+}
+
+Type::Genericity getTypeGenericity(Context* context, const Type* t) {
+  return getTypeGenericityViaPtrQuery(context, t);
+}
+
+static const Type::Genericity& getTypeGenericityViaQualifiedTypeQuery(Context* context, QualifiedType qt) {
+  QUERY_BEGIN(getTypeGenericityViaQualifiedTypeQuery, context, qt);
+
+  std::set<const Type*> ignore;
+  auto result = getTypeGenericityIgnoring(context, qt, ignore);
+
+  return QUERY_END(result);
 }
 
 Type::Genericity getTypeGenericity(Context* context, QualifiedType qt) {
-  std::set<const Type*> ignore;
-  return getTypeGenericityIgnoring(context, qt, ignore);
+  return getTypeGenericityViaQualifiedTypeQuery(context, qt);
 }
 
 /**

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2157,8 +2157,16 @@ ApplicabilityResult instantiateSignature(Context* context,
     if (!sig->untyped()->isTypeConstructor()) {
       // We've visited the rest of the formals and figured out their types.
       // Time to backfill the 'this' formal.
-      auto newType = helpGetTypeForDecl(context, ad, newSubstitutions,
-                                        poiScope, sig->formalType(0).type());
+      const Type* newType = helpGetTypeForDecl(context, ad, newSubstitutions,
+                                               poiScope, sig->formalType(0).type());
+
+      // If the original formal is a class type (with management etc.), ensure
+      // that the management etc. is preserved.
+      if (auto sigCt = sig->formalType(0).type()->toClassType()) {
+        if (auto mt = newType->toManageableType()) {
+          newType = ClassType::get(context, mt, sigCt->manager(), sigCt->decorator());
+        }
+      }
 
       formalTypes[0] = QualifiedType(sig->formalType(0).kind(), newType);
     }

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -737,6 +737,7 @@ const ResolvedFields& resolveFieldDecl(Context* context,
     }
   }
 
+  if (!syntaxOnly) result.validateFieldGenericity(context, ct);
 
   return QUERY_END(result);
 }

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2246,15 +2246,9 @@ ApplicabilityResult instantiateSignature(Context* context,
       }
     }
 
-    // visit the field declarations
-    for (auto child: ad->children()) {
-      if (child->isVariable() ||
-          child->isMultiDecl() ||
-          child->isTupleDecl() ||
-          child->isForwardingDecl()) {
-        child->traverse(visitor);
-      }
-    }
+    // do not visit the field declarations directly; only visit those
+    // that are relevant for computing the types of the formals. This
+    // happens below.
 
     // add formals according to the parent class type
 
@@ -2277,6 +2271,7 @@ ApplicabilityResult instantiateSignature(Context* context,
 
     for (; formalIdx < nFormals; formalIdx++) {
       const Decl* fieldDecl = untypedSignature->formalDecl(formalIdx);
+      fieldDecl->traverse(visitor);
       const ResolvedExpression& e = r.byAst(fieldDecl);
       QualifiedType fieldType = e.type();
       QualifiedType sigType = sig->formalType(formalIdx);

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -750,8 +750,18 @@ void ResolvedFields::finalizeFields(Context* context, bool syntaxOnly) {
     Type::Genericity g;
 
     if (syntaxOnly) {
-      g = isFieldSyntacticallyGeneric(context, field.declId, nullptr) ?
-          Type::GENERIC : Type::CONCRETE;
+      if (!isFieldSyntacticallyGeneric(context, field.declId, nullptr)) {
+        g = Type::CONCRETE;
+      } else {
+        // In syntaxOnly mode, the field type is only set from substitutions;
+        // if there are none, it's left unknown, which, if the field is
+        // syntactically generic, means it's generic.
+        if (field.type.isUnknownKindOrType()) {
+          g = Type::GENERIC;
+        } else {
+          g = getTypeGenericityIgnoring(context, field.type, ignore);
+        }
+      }
     } else {
       g = getTypeGenericityIgnoring(context, field.type, ignore);
     }

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -737,7 +737,7 @@ bool FormalActualMap::computeAlignment(const UntypedFnSignature* untyped,
   return true;
 }
 
-void ResolvedFields::finalizeFields(Context* context) {
+void ResolvedFields::finalizeFields(Context* context, bool syntaxOnly) {
   bool anyGeneric = false ;
   bool allGenHaveDefault = true; // all generic fields have default init
                                  // -- vacuously true if there are no generic
@@ -747,7 +747,15 @@ void ResolvedFields::finalizeFields(Context* context) {
 
   // look at the fields and compute the summary information
   for (const auto& field : fields_) {
-    auto g = getTypeGenericityIgnoring(context, field.type, ignore);
+    Type::Genericity g;
+
+    if (syntaxOnly) {
+      g = isFieldSyntacticallyGeneric(context, field.declId, nullptr) ?
+          Type::GENERIC : Type::CONCRETE;
+    } else {
+      g = getTypeGenericityIgnoring(context, field.type, ignore);
+    }
+
     if (g != Type::CONCRETE) {
       if (!field.hasDefaultValue) {
         allGenHaveDefault = false;

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -1974,6 +1974,18 @@ static const bool& isNameBuiltinType(Context* context, UniqueString name) {
   return QUERY_END(toReturn);
 }
 
+const bool& isNameBuiltinGenericType(Context* context, UniqueString name) {
+  QUERY_BEGIN(isNameBuiltinGenericType, context, name);
+  bool result = false;
+  std::unordered_map<UniqueString,const Type*> typeMap;
+  Type::gatherBuiltins(context, typeMap);
+  auto it = typeMap.find(name);
+  if (it != typeMap.end()) {
+    result = it->second->genericity() == Type::GENERIC;
+  }
+  return QUERY_END(result);
+}
+
 // if it's the first time encountering a particular module (and if it is
 // indeed a module, and not an enum or other type of declaration), add
 // it to the ResolvedVisibilityScope as a module named in a use/import

--- a/frontend/test/resolution/testNew.cpp
+++ b/frontend/test/resolution/testNew.cpp
@@ -790,7 +790,9 @@ static void testCompilerGeneratedGenericNewWithDefaultInitClass() {
 
 
   {
-    auto ct = vars.at("x1").type()->toCompositeType();
+    auto clt = vars.at("x1").type()->toClassType();
+    assert(clt);
+    auto ct = clt->basicClassType();
     assert(ct);
     assert(ct->name() == "C");
 
@@ -808,7 +810,9 @@ static void testCompilerGeneratedGenericNewWithDefaultInitClass() {
   }
 
   {
-    auto ct = vars.at("x2").type()->toCompositeType();
+    auto clt = vars.at("x2").type()->toClassType();
+    assert(clt);
+    auto ct = clt->basicClassType();
     assert(ct);
     assert(ct->name() == "C");
 
@@ -846,9 +850,10 @@ static void testCompilerGeneratedGenericNewClass() {
 
 
   {
-    auto ct = vars.at("x1").type()->toCompositeType();
+    auto clt = vars.at("x1").type()->toClassType();
+    assert(clt);
+    auto ct = clt->basicClassType();
     assert(ct);
-    assert(ct->name() == "C");
 
     // It should already be instantiated, no need to use defaults.
     auto fields = fieldsForTypeDecl(context, ct, DefaultsPolicy::IGNORE_DEFAULTS);
@@ -864,9 +869,10 @@ static void testCompilerGeneratedGenericNewClass() {
   }
 
   {
-    auto ct = vars.at("x2").type()->toCompositeType();
+    auto clt = vars.at("x2").type()->toClassType();
+    assert(clt);
+    auto ct = clt->basicClassType();
     assert(ct);
-    assert(ct->name() == "C");
 
     // It should already be instantiated, no need to use defaults.
     auto fields = fieldsForTypeDecl(context, ct, DefaultsPolicy::IGNORE_DEFAULTS);
@@ -887,9 +893,10 @@ static void testCompilerGeneratedGenericNewClass() {
   }
 
   {
-    auto ct = vars.at("x4").type()->toCompositeType();
+    auto clt = vars.at("x4").type()->toClassType();
+    assert(clt);
+    auto ct = clt->basicClassType();
     assert(ct);
-    assert(ct->name() == "C");
 
     // It should already be instantiated, no need to use defaults.
     auto fields = fieldsForTypeDecl(context, ct, DefaultsPolicy::IGNORE_DEFAULTS);

--- a/frontend/test/resolution/testTypeConstruction.cpp
+++ b/frontend/test/resolution/testTypeConstruction.cpp
@@ -1362,6 +1362,102 @@ static void testRecursiveTypeConstructorAlias() {
   assert(fields->fieldType(2).type()->toClassType()->basicClassType() == ct->basicClassType());
 }
 
+static void testRecursiveTypeConstructorGeneric() {
+  printf("testRecursiveTypeConstructorGeneric\n");
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  std::ignore = resolveTypeOfXInit(context,
+      R"""(
+      class Node {
+          type eltType = int;
+          var data: eltType;
+          var next: Node(eltType)?;
+      }
+      var x = new unmanaged Node(int, 314);
+      )""", /* requireTypeKnown */ false);
+
+  bool foundError = false;
+  for (auto& err : guard.errors()) {
+    if (err->type() == ErrorType::MissingFormalInstantiation) {
+      foundError = true;
+      break;
+    }
+  }
+  assert(foundError);
+  assert(guard.realizeErrors() > 0);
+}
+
+static void testRecursiveTypeConstructorMutual() {
+  printf("testRecursiveTypeConstructor\n");
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  auto p = parseTypeAndFieldsOfX(context,
+      R"""(
+      class MutA {
+        type eltType;
+        var data: eltType;
+        var next: owned MutB(eltType)?;
+      }
+
+      class MutB {
+        type eltType;
+        var data: eltType;
+        var next: owned MutA(eltType)?;
+      }
+
+      var x = new MutA(real, 3.14, new MutB(real, 2.71));
+      )""");
+
+  auto ctA = p.first->toClassType();
+  assert(ctA);
+  assert(ctA->basicClassType());
+  assert(ctA->basicClassType()->instantiatedFrom());
+
+  auto fieldsA = p.second;
+  assert(fieldsA);
+  assert(fieldsA->numFields() == 3);
+  assert(fieldsA->fieldName(0) == "eltType");
+  assert(fieldsA->fieldHasDefaultValue(0) == false);
+  assert(fieldsA->fieldType(0).kind() == QualifiedType::TYPE);
+  assert(fieldsA->fieldType(0).type() == RealType::get(context, 0));
+  assert(fieldsA->fieldName(1) == "data");
+  assert(fieldsA->fieldHasDefaultValue(1) == false);
+  assert(fieldsA->fieldType(1).kind() == QualifiedType::VAR);
+  assert(fieldsA->fieldType(1).type() == RealType::get(context, 0));
+  assert(fieldsA->fieldName(2) == "next");
+  assert(fieldsA->fieldHasDefaultValue(2) == false);
+  assert(fieldsA->fieldType(2).kind() == QualifiedType::VAR);
+  assert(fieldsA->fieldType(2).type()->toClassType());
+
+  auto ctB = fieldsA->fieldType(2).type()->toClassType();
+  assert(ctB);
+  assert(ctB->basicClassType());
+  assert(ctB->basicClassType()->instantiatedFrom());
+
+  auto defaultsPolicy = DefaultsPolicy::IGNORE_DEFAULTS;
+  const ResolvedFields& fieldsB = fieldsForTypeDecl(context, ctB->basicClassType(),
+                                                    defaultsPolicy);
+
+  assert(fieldsB.numFields() == 3);
+  assert(fieldsB.fieldName(0) == "eltType");
+  assert(fieldsB.fieldHasDefaultValue(0) == false);
+  assert(fieldsB.fieldType(0).kind() == QualifiedType::TYPE);
+  assert(fieldsB.fieldType(0).type() == RealType::get(context, 0));
+  assert(fieldsB.fieldName(1) == "data");
+  assert(fieldsB.fieldHasDefaultValue(1) == false);
+  assert(fieldsB.fieldType(1).kind() == QualifiedType::VAR);
+  assert(fieldsB.fieldType(1).type() == RealType::get(context, 0));
+  assert(fieldsB.fieldName(2) == "next");
+  assert(fieldsB.fieldHasDefaultValue(2) == false);
+  assert(fieldsB.fieldType(2).kind() == QualifiedType::VAR);
+  assert(fieldsB.fieldType(2).type()->toClassType());
+  assert(fieldsB.fieldType(2).type()->toClassType()->basicClassType() == ctA->basicClassType());
+}
+
 
 int main() {
   test1();
@@ -1411,6 +1507,8 @@ int main() {
   test42();
   testRecursiveTypeConstructor();
   testRecursiveTypeConstructorAlias();
+  testRecursiveTypeConstructorGeneric();
+  testRecursiveTypeConstructorMutual();
 
   return 0;
 }

--- a/frontend/test/resolution/testTypePropertyPrimitives.cpp
+++ b/frontend/test/resolution/testTypePropertyPrimitives.cpp
@@ -594,7 +594,7 @@ static void test12() {
             record r9 { type T; var x: T; }
             class c1 { var x: int; }
             record r10 { var x: owned c1?; }
-            record r11 { var x: r9; }
+            record r11 { var x: r9(?); }
             )""",
     /* primitive */ chpl::uast::primtags::PRIM_IS_POD,
     /* calls */ {


### PR DESCRIPTION
Closes https://github.com/Cray/chapel-private/issues/6281.

Up to this point, Dyno used the types of a record's fields to determine whether or not said fields need to be included in the type constructor. The trickiest cases were something like the following:

```Chapel
class C {}
record myRec {
  var myField: C; // Need to know that C is a class;
                  // Classes without a memory management strategy are generic
                  // Records don't have memory management and so would be concrete 
}
```

```Chapel
record myRec {
  var myField: someFunction(args); // If someFunction produces a generic type, myField is generic.
}
```

The problem with the approach of resolving the fields to build the type constructor is that the type expression of a field may invoke the type constructor. An example is the following code:

```Chapel
class Node {
  type eltType;
  var data: eltType;
  var next: unmanaged Node(eltType)?;
}
var n: unmanaged Node(real) = new unmanaged Node(real, 3.14);
```

This makes the type constructor depend on itself, which in the naive implementation leads to infinite recursion. A non-naive solution might be to detect recursive calls like this, and skip resolving them (or do some other workarounds). Though a simple "is call to `Node`?" check would solve this particular case, type constructor dependence can span several types if mutual recursion is in use:

```Chapel
class MutA {
  type eltType;
  var data: eltType;
  var next: owned MutB(eltType)?;
}

class MutB {
  type eltType;
  var data: eltType;
  var next: owned MutA(eltType)?;
}
```
A robust approach that is type-aware would somehow construct the field dependence map of various types, and use this information to ignore certain problematic type constructor invocations. However, this is very complicated, particularly since arbitrary functions (and thus modules, types, etc.) can be used as type expressions, which could in one way or another invoke type constructors of other types.

## A Simpler Approach
Instead of building out a robust type-based type constructor generator, this PR switches to a purely syntactic decision procedure for including fields in type constructors. The reason is simple; the only case that requires any sort of type reasoning is `var x: expr`. This is because:

1. `type t`, in any form, belongs in the type constructor (even if it has a default)
2. `param p` is generic for the same reason as `type t`
3. `var x = ...` is not generic because the initialization expression will produce a concrete type
4. `var x: expr = ...` is not generic for the same reason as the previous case

Thus, only in the `var x: expr` case do we need type reasoning. If we make a simplifying assumption -- that generic fields are marked with `(?)` -- we can determine the genericity syntactically too. The production compiler already warns for generic fields without `(?)`, and considers them unstable, so this assumption is reasonable. This PR makes that change, and other tweaks that preclude the need for infinite recursion while resolving type constructors like `Node` and `MutA`.

The undecorated class case is broken by these changes (`var c: C` is considered concrete, but turns out to be generic; the type constructor doesn't get enough type arguments, and `var c: C` becomes generic). This PR adds nicer error messages for when this is the case.

In making this change, the PR also adjusts the logic for computing a type's genericity to use the syntax-driven approach. This helps remove the (error-prone) stateful checking of "is query running", which we previously used to detect recursion.

### Additional Checking
Since there are now two sources of truth for whether a field is generic or not (its syntactic definition and its final resolved type), we need to ensure consistency between the two. To this end, I've added logic to check if the syntactic and "true" genericity don't match up. Originally, after a discussion with @mppf, I planned to add this to `fieldsForTypeDecl`. However, this function is called relatively rarely by the resolution process, which prefers instead to resolve individual fields as necessary. As a result, this PR modifies `resolveFieldDecl`, which is more granular, to emit the error. This makes it possible to emit the error in more cases where it should be emitted, at the expense of some additional logic to make sense of other fields _not_ in the given declaration (e.g., if `resolveFieldDecl` is called on the fourth field, some handling will be done on the preceding three fields to support emitting the error). 

Reviewed by @mppf -- thanks!

## Testing
- [x] dyno tests, including new ones of the cases here
- [x] paratest