### PR TITLE
Build chapel-py-venv in Arkouda testing

### DIFF
--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -54,6 +54,7 @@ fi
 # install frontend python bindings
 (cd $CHPL_HOME && make frontend-shared)
 (cd $CHPL_HOME/tools/chapel-py && python -m pip install .)
+(cd $CHPL_HOME && make chapel-py-venv)
 
 # Compile Arkouda
 if [ "${CHPL_TEST_ARKOUDA_PERF}" = "true" ] ; then


### PR DESCRIPTION
Arkouda requires chapel-py to build servers with a non-default configuration. Eventually we'd like to make it a requirement for any Arkouda build.

To move in that direction, all of our nightly testing configurations should be able to build Arkouda using chapel-py (some configurations are currently resorting to a fallback build mode). This PR update's Arkouda's sub_test script to `make chapel-py-venv` before attempting to build Arkouda.