### PR TITLE
Dyno: implement specification of parenless `type`/`param` procs on nilable types

### DIFF
--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1431,7 +1431,7 @@ void Resolver::resolveNamedDecl(const NamedDecl* decl, const Type* useType) {
       bool isClassType = typeExprT.type() && typeExprT.type()->isClassType();
       if (isFormalThis && isClassType && identOrNoTypeExpr) {
         auto dec = ClassTypeDecorator(ClassTypeDecorator::BORROWED_NONNIL);
-        bool useFullyGenericDecorator = true;
+        bool useFullyGenericDecorator = false;
 
         if (auto varLikeDecl = decl->toVarLikeDecl()) {
           useFullyGenericDecorator |=

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1423,11 +1423,34 @@ void Resolver::resolveNamedDecl(const NamedDecl* decl, const Type* useType) {
       // for 'this' formals of class type, adjust them to be borrowed, so
       // e.g. proc C.foo() { } has 'this' of type 'borrowed C'.
       // This should not apply to parenthesized expressions.
+      //
+      // An exception to this is when we are looking at a type method or
+      // a parenless, type- or param returning method. In that case, the
+      // decorator is 'anymanaged any-nilable', not borrowed nonnil.
       bool identOrNoTypeExpr = !typeExpr || typeExpr->isIdentifier();
       bool isClassType = typeExprT.type() && typeExprT.type()->isClassType();
       if (isFormalThis && isClassType && identOrNoTypeExpr) {
-        auto ct = typeExprT.type()->toClassType();
         auto dec = ClassTypeDecorator(ClassTypeDecorator::BORROWED_NONNIL);
+        bool useFullyGenericDecorator = true;
+
+        if (auto varLikeDecl = decl->toVarLikeDecl()) {
+          useFullyGenericDecorator |=
+            varLikeDecl->storageKind() == QualifiedType::TYPE;
+        }
+
+        if (symbol && symbol->isFunction()) {
+          auto fn = symbol->toFunction();
+          useFullyGenericDecorator |=
+            (fn->returnIntent() == Function::TYPE ||
+             fn->returnIntent() == Function::PARAM) &&
+            fn->isParenless();
+        }
+
+        if (useFullyGenericDecorator) {
+          dec = ClassTypeDecorator(ClassTypeDecorator::GENERIC);
+        }
+
+        auto ct = typeExprT.type()->toClassType();
         typeExprT = QualifiedType(typeExprT.kind(),
                                   ct->withDecorator(context, dec),
                                   typeExprT.param());

--- a/frontend/test/resolution/testMethodCalls.cpp
+++ b/frontend/test/resolution/testMethodCalls.cpp
@@ -570,6 +570,65 @@ static void test10() {
   assert(t2.type()->isBoolType());
 }
 
+static void test11() {
+  // Type method calls are allowed on nilable classes; their receiver should
+  // be generic over nilability and management.
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  std::string program = R"""(
+    class C {
+      proc type typeMethod() {
+        return 42;
+      }
+    }
+    var x1 = (C).typeMethod();
+    var x2 = (owned C).typeMethod();
+    var x3 = (borrowed C?).typeMethod();
+  )""";
+
+  auto vars = resolveTypesOfVariables(context, program, { "x1", "x2", "x3" });
+  assert(!guard.realizeErrors());
+
+  for (auto& [name, var] : vars) {
+    assert(var.type());
+    assert(var.type()->isIntType());
+  }
+}
+
+static void test12() {
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  std::string program = R"""(
+    class C {
+      proc parenlessParam param {
+        return 42;
+      }
+      proc parenlessType type {
+        return this.type;
+      }
+    }
+
+    var x: owned C? = new owned C?();
+    param p1 = x.parenlessParam;
+    type t1 = x.parenlessType;
+  )""";
+
+  auto vars = resolveTypesOfVariables(context, program, {"p1", "t1"});
+  assert(!guard.realizeErrors());
+
+  ensureParamInt(vars["p1"], 42);
+
+  auto t1 = vars["t1"];
+  assert(t1.type());
+  assert(t1.type()->isClassType());
+  assert(t1.type()->toClassType()->decorator().isNilable());
+  assert(t1.type()->toClassType()->manager() == AnyOwnedType::get(context));
+}
+
 
 int main() {
   test1();
@@ -582,6 +641,8 @@ int main() {
   test8();
   test9();
   test10();
+  test11();
+  test12();
 
   return 0;
 }


### PR DESCRIPTION
Closes https://github.com/Cray/chapel-private/issues/6469.

In some cases for methods on classes, the receiver is not `in borrowed`, but a generic type; this is in particular true for `type` methods (like `MyClass.foo()`) and parenless procedures that return types or params. The [spec describes this here](https://chapel-lang.org/docs/language/spec/classes.html#class-methods). This PR implements that logic.

Reviewed by @riftEmber -- thanks!

## Testing
- [x] dyno tests (including new tests for this feature)
- [x] paratest