### PR TITLE
Fix check for GPU sdk path when not using GPU support

### DIFF
--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -166,7 +166,7 @@ def get_sdk_path(for_gpu, sdk_type='bitcode'):
     gpu_type = get()
 
     # No SDK path if GPU is not being used.
-    if gpu_type == 'cpu':
+    if gpu_type in ('cpu', 'none'):
         return 'none'
 
     # Check vendor-specific environment variable for SDK path


### PR DESCRIPTION
Fixes a check for the GPU sdk path that was incorrectly giving errors when not using the GPU locale model

[Reviewed by @stonea]