### PR TITLE
Fix memory leak when writing JPG and PNG images

### DIFF
--- a/modules/packages/Image.chpl
+++ b/modules/packages/Image.chpl
@@ -575,12 +575,14 @@ module Image {
       const (writeFunc, context, width, height, mode, data) = writeCommon(outfile, pixels);
       const stride = width * mode;
       stbi_write_png_to_func(writeFunc, context, width, height, mode, data, stride);
+      deallocate(data);
     }
 
     proc writeJpg(const ref outfile: fileWriter(?), pixels: [?dom]) throws {
       const (writeFunc, context, width, height, mode, data) = writeCommon(outfile, pixels);
       const quality: c_int = 100;
       stbi_write_jpg_to_func(writeFunc, context, width, height, mode, data, quality);
+      deallocate(data);
     }
 
 


### PR DESCRIPTION
Fixes a memory leak when calling `writeImage` for JPG or PNG, caused by missing calls to `deallocate`

Tested `start_test --memLeaks test/library/packages/Image` locally.

[Reviewed by @DanilaFe]