### PR TITLE
Skip math GPU perf test on cray-cs

### DIFF
--- a/test/gpu/native/studies/math/mathKernels.chpl
+++ b/test/gpu/native/studies/math/mathKernels.chpl
@@ -2,7 +2,7 @@ use Math;
 import Time.stopwatch;
 use Random;
 
-config const size:uint(32) = 10_000_000;
+config const size:uint(32) = 100_000_000;
 config const iterations:int(32) = 1;
 config const printTime = true;
 config const correctness = false;

--- a/test/gpu/native/studies/math/mathKernels.cu
+++ b/test/gpu/native/studies/math/mathKernels.cu
@@ -21,7 +21,7 @@
 #endif
 
 #ifndef mk_SIZE
-#define mk_SIZE 10'000'000
+#define mk_SIZE 100'000'000
 #endif
 
 #define mk_FUNC_NAME_inner2(a, b) a ## b

--- a/test/gpu/native/studies/math/mathKernels.suppressif
+++ b/test/gpu/native/studies/math/mathKernels.suppressif
@@ -1,0 +1,2 @@
+# doing cuda interop on a cray-cs hangs the whole program
+CHPL_TARGET_PLATFORM=cray-cs


### PR DESCRIPTION
Skips testing of `mathKernel.chpl` perf test on cray-cs, as doing CUDA interop seems to cause hangs.

I observed that running the perf test without any interop, the test finished in a matter of seconds. But as soon as the CUDA version was linked the program would hang (before running any kernels). I was unable to diagnose this further due to network issues, but given that cray-cs is an older, unsupported hardware I don't think its the important.

Also reverts the change in https://github.com/chapel-lang/chapel/pull/25781, as its no longer needed. 

[Reviewed by @ShreyasKhandekar]