### PR TITLE
Add `keyPartComparator` interface for `Sort`

### DIFF
--- a/modules/standard/Sort.chpl
+++ b/modules/standard/Sort.chpl
@@ -356,6 +356,7 @@ inline proc chpl_compare(a:?t, b:t, comparator:?rec) {
             canResolveMethod(comparator, "keyPart", a, 0) {
     return compareByPart(a, b, comparator);
   } else {
+    // TODO: this should talk about interfaces
     compilerError("The comparator " + comparator.type:string + " requires a 'key(a)', 'compare(a, b)', or 'keyPart(a, i)' method");
   }
 }
@@ -385,12 +386,14 @@ proc chpl_check_comparator(comparator,
   }
   // Check for valid comparator methods
   else if canResolveMethod(comparator, "key", data) {
+    // TODO: check for keyComparator
     // Check return type of key
     const keydata = comparator.key(data);
     type keytype = keydata.type;
     if !(canResolve("<", keydata, keydata)) then
       compilerError(errorDepth=errorDepth, "The key method in ", comparator.type:string, " must return an object that supports the '<' function when used with ", eltType:string, " elements");
 
+    // TODO: this should check that multiple interfaces are not implemented as well
     // Check that there isn't also a compare or keyPart
     if canResolveMethod(comparator, "compare", data, data) {
       compilerError(errorDepth=errorDepth, comparator.type:string, " contains both a key method and a compare method");
@@ -400,6 +403,7 @@ proc chpl_check_comparator(comparator,
     }
   }
   else if canResolveMethod(comparator, "compare", data, data) {
+    // TODO: check for keyPartComparator or relativeComparator
     // Check return type of compare
     type comparetype = comparator.compare(data, data).type;
     if !(isNumericType(comparetype)) then
@@ -450,6 +454,7 @@ proc chpl_check_comparator(comparator,
     }
   }
   else {
+    // TODO: this error should talk about interfaces
     // If we make it this far, the passed comparator was defined incorrectly
     compilerError(errorDepth=errorDepth, "The comparator " + comparator.type:string + " requires a 'key(a)', 'compare(a, b)', or 'keyPart(a, i)' method " + " for element type " + eltType:string );
   }

--- a/modules/standard/Sort.chpl
+++ b/modules/standard/Sort.chpl
@@ -158,8 +158,8 @@ strings. It accepts two arguments:
 A ``keyPart`` method should return a tuple consisting of *section* and a *part*.
 
  * The *section* must be of type :type:`keyPartStatus`. It indicates when the
- end of ``elt`` has been reached and in that event how it should be sorted
- relative to other array elements.
+   end of ``elt`` has been reached and in that event how it should be sorted
+   relative to other array elements.
 
  * The *part* can be any signed or unsigned integral type and can contain any
    value. The *part* will be ignored unless the *section* returned is

--- a/modules/standard/Sort.chpl
+++ b/modules/standard/Sort.chpl
@@ -713,7 +713,7 @@ proc sort(ref Data: [?Dom] ?eltType, comparator:?rec=defaultComparator,
 
 @chpldoc.nodoc
 /* Error message for multi-dimension arrays */
-proc sort(ref x: [?Dom] , comparator:? = new DefaultComparator())
+proc sort(ref x: [?Dom] , comparator:? = new DefaultComparator(), param stable:bool = false)
   where Dom.rank != 1 || !x.isRectangular() {
     compilerError("sort() is currently only supported for 1D rectangular arrays");
 }

--- a/modules/standard/Sort.chpl
+++ b/modules/standard/Sort.chpl
@@ -19,6 +19,8 @@
  */
 
 
+// TODO: rewrite these docs to describe the interfaces
+
 // TODO -- performance test sort routines and optimize (see other TODO's)
 /*
 
@@ -146,31 +148,29 @@ implemented with a compare method:
 The .keyPart method
 ~~~~~~~~~~~~~~~~~~~
 
-A ``keyPart(a, i)`` method returns *parts* of key value at a time. This
+A ``keyPart(elt, i)`` method returns *parts* of key value at a time. This
 interface supports radix sorting for variable length data types, such as
 strings. It accepts two arguments:
 
- * ``a`` is the element being sorted
+ * ``elt`` is the element being sorted
  * ``i`` is the part number of the key requested, starting from 0
 
 A ``keyPart`` method should return a tuple consisting of *section* and a *part*.
 
- * The *section* can be any signed integral type and should have the value `-1`,
-   `0`, or `1`. It indicates when the end of the ``a`` has been reached
-   and in that event how it should be sorted relative to other array elements.
+ * The *section* must be of type ``keyPartStatus``. It indicates when the end of ``elt`` has been reached and in that event how it should be sorted relative to other array elements.
 
-   ================ ====================================
-   Returned section Interpretation
-   ================ ====================================
-   ``-1``           no more key parts for ``a``,
-                    sort it before those with more parts
+   ============================= ===========================================
+   Returned section              Interpretation
+   ============================= ===========================================
+   ``keyPartStatus.pre``          no more key parts for ``elt``,
+                                  sort it before those with more parts
 
-   ``0``            a key part for ``a`` is returned in
-                    the second tuple element
+   ``keyPartStatus.returned``     a key part for ``elt`` is returned in
+                                  the second tuple element
 
-   ``1``            no more key parts for ``a``,
-                    sort it after those with more parts
-   ================ ====================================
+   ``keyPartStatus.post``         no more key parts for ``elt``,
+                                  sort it after those with more parts
+   ============================= ===========================================
 
  * The *part* can be any signed or unsigned integral type and can contain any
    value. The *part* will be ignored unless the *section* returned is ``0``.
@@ -184,11 +184,11 @@ This ``keyPart`` method supports sorting tuples of 2 integers:
 
 .. code-block:: chapel
 
-  proc keyPart(x:2*int, i:int) {
+  proc keyPart(elt: 2*int, i: int) {
     if i > 1 then
       return (-1, 0);
 
-    return (0, x(i));
+    return (keyPartStatus.returned, elt(i));
   }
 
 
@@ -196,10 +196,10 @@ Here is a ``keyPart`` to support sorting of strings:
 
 .. code-block:: chapel
 
-  proc keyPart(x:string, i:int):(int(8), uint(8)) {
+  proc keyPart(x: string, i: int): (keyPartStatus, uint(8)) {
     var len = x.numBytes;
-    var section = if i < len then 0:int(8)  else -1:int(8);
-    var part =    if i < len then x.byte(i) else  0:uint(8);
+    var section = if i < len then keyPartStatus.returned  else keyPartStatus.pre;
+    var part =    if i < len then x.byte(i)               else 0:uint(8);
     return (section, part);
   }
 
@@ -283,20 +283,38 @@ const reverseComparator: ReverseComparator(DefaultComparator) =
 private inline
 proc compareByPart(a:?t, b:t, comparator:?rec) {
   var curPart = 0;
-  while true {
-    var (aSection, aPart) = comparator.keyPart(a, curPart);
-    var (bSection, bPart) = comparator.keyPart(b, curPart);
-    if aSection != 0 || bSection != 0 {
-      return aSection - bSection;
-    }
-    if aPart < bPart {
-      return -1;
-    }
-    if aPart > bPart {
-      return 1;
-    }
+  if canResolveMethod(comparator, "chpl_keyPartInternal", a, 0) {
+    while true {
+      var (aSection, aPart) = comparator.chpl_keyPartInternal(a, curPart);
+      var (bSection, bPart) = comparator.chpl_keyPartInternal(b, curPart);
+      if aSection:int != 0 || bSection:int != 0 {
+        return aSection:int - bSection:int;
+      }
+      if aPart < bPart {
+        return -1;
+      }
+      if aPart > bPart {
+        return 1;
+      }
 
-    curPart += 1;
+      curPart += 1;
+    }
+  } else {
+    while true {
+      var (aSection, aPart) = comparator.keyPart(a, curPart);
+      var (bSection, bPart) = comparator.keyPart(b, curPart);
+      if aSection:int != 0 || bSection:int != 0 {
+        return aSection:int - bSection:int;
+      }
+      if aPart < bPart {
+        return -1;
+      }
+      if aPart > bPart {
+        return 1;
+      }
+
+      curPart += 1;
+    }
   }
 
   // This is never reached. The return below is a workaround for issue #10447.
@@ -334,7 +352,8 @@ inline proc chpl_compare(a:?t, b:t, comparator:?rec) {
   // Use comparator.compare(a, b) if is defined by user
   } else if canResolveMethod(comparator, "compare", a, b) {
     return comparator.compare(a ,b);
-  } else if canResolveMethod(comparator, "keyPart", a, 0) {
+  } else if canResolveMethod(comparator, "chpl_keyPartInternal", a, 0) ||
+            canResolveMethod(comparator, "keyPart", a, 0) {
     return compareByPart(a, b, comparator);
   } else {
     compilerError("The comparator " + comparator.type:string + " requires a 'key(a)', 'compare(a, b)', or 'keyPart(a, i)' method");
@@ -352,14 +371,18 @@ pragma "unsafe" // due to 'data' default-initialized to nil for class types
       data is sorted.
 
  */
-proc chpl_check_comparator(comparator, type eltType) param {
+proc chpl_check_comparator(comparator,
+                           type eltType,
+                           param errorDepth = 2,
+                           param doDeprecationCheck = true) param {
   // Dummy data for checking method resolution
   // This may need updating when constructors support non-default args
   const data: eltType;
 
-  param errorDepth = 2;
-
   if comparator.type == DefaultComparator {}
+  else if isSubtype(comparator.type, ReverseComparator) {
+    return chpl_check_comparator(comparator.comparator, eltType, errorDepth+1, false);
+  }
   // Check for valid comparator methods
   else if canResolveMethod(comparator, "key", data) {
     // Check return type of key
@@ -382,18 +405,49 @@ proc chpl_check_comparator(comparator, type eltType) param {
     if !(isNumericType(comparetype)) then
       compilerError(errorDepth=errorDepth, "The compare method in ", comparator.type:string, " must return a numeric type when used with ", eltType:string, " elements");
   }
-  else if canResolveMethod(comparator, "keyPart", data, 0) {
+  else if canResolveMethod(comparator, "chpl_keyPartInternal") {
     var idx: int = 0;
-    type partType = comparator.keyPart(data, idx).type;
+    type partType = comparator.chpl_keyPartInternal(data, idx).type;
     if !isTupleType(partType) then
       compilerError(errorDepth=errorDepth, "The keyPart method in ", comparator.type:string, " must return a tuple when used with ", eltType:string, " elements");
     var tmp: partType;
-    var expectInt = tmp(0);
+    var expectKeyPartStatus = tmp(0);
     var expectIntUint = tmp(1);
-    if !isInt(expectInt.type) then
-      compilerError(errorDepth=errorDepth, "The keyPart method in ", comparator.type:string, " must return a tuple with element 0 of type int(?) when used with ", eltType:string, " elements");
+    if expectKeyPartStatus.type != keyPartStatus then
+      compilerError(errorDepth=errorDepth, "The keyPart method in ", comparator.type:string, " must return a tuple with element 0 of type keyPartStatus when used with ", eltType:string, " elements");
     if !(isInt(expectIntUint) || isUint(expectIntUint)) then
-      compilerError(errorDepth=errorDepth, "The keyPart method in ", comparator.type:string, " must return a tuple with element 1 of type  int(?) or uint(?) when used with ", eltType:string, " elements");
+      compilerError(errorDepth=errorDepth, "The keyPart method in ", comparator.type:string, " must return a tuple with element 1 of type int(?) or uint(?) when used with ", eltType:string, " elements");
+    // no need to check the interface,'chpl_keyPartInternal' is internal
+  }
+  else if canResolveMethod(comparator, "keyPart", data, 0) {
+    if comparatorImplementsKeyPart(comparator) {
+      var idx: int = 0;
+      type partType = comparator.keyPart(data, idx).type;
+      if !isTupleType(partType) then
+        compilerError(errorDepth=errorDepth, "The keyPart method in ", comparator.type:string, " must return a tuple when used with ", eltType:string, " elements");
+      var tmp: partType;
+      var expectKeyPartStatus = tmp(0);
+      var expectIntUint = tmp(1);
+      if expectKeyPartStatus.type != keyPartStatus then
+        compilerError(errorDepth=errorDepth, "The keyPart method in ", comparator.type:string, " must return a tuple with element 0 of type keyPartStatus when used with ", eltType:string, " elements");
+      if !(isInt(expectIntUint) || isUint(expectIntUint)) then
+        compilerError(errorDepth=errorDepth, "The keyPart method in ", comparator.type:string, " must return a tuple with element 1 of type int(?) or uint(?) when used with ", eltType:string, " elements");
+    } else {
+      if doDeprecationCheck then
+        compilerWarning(errorDepth=errorDepth, "Defining a comparator with a 'keyPart' method without implementing the keyPartComparator interface is deprecated. Please implement the keyPartComparator interface (i.e. 'record "+ comparator.type:string + ": keyPartComparator').");
+
+      var idx: int = 0;
+      type partType = comparator.keyPart(data, idx).type;
+      if !isTupleType(partType) then
+        compilerError(errorDepth=errorDepth, "The keyPart method in ", comparator.type:string, " must return a tuple when used with ", eltType:string, " elements");
+      var tmp: partType;
+      var expectInt = tmp(0);
+      var expectIntUint = tmp(1);
+      if !isInt(expectInt.type) then
+        compilerError(errorDepth=errorDepth, "The keyPart method in ", comparator.type:string, " must return a tuple with element 0 of type int(?) when used with ", eltType:string, " elements");
+      if !(isInt(expectIntUint) || isUint(expectIntUint)) then
+        compilerError(errorDepth=errorDepth, "The keyPart method in ", comparator.type:string, " must return a tuple with element 1 of type int(?) or uint(?) when used with ", eltType:string, " elements");
+    }
   }
   else {
     // If we make it this far, the passed comparator was defined incorrectly
@@ -413,12 +467,14 @@ proc radixSortOkAndStrideOne(Data: [] ?eltType,
                              region: range(?)) param {
   if region.strides == strideKind.one {
     var tmp:Data[Data.domain.low].type;
-    if canResolveMethod(comparator, "keyPart", tmp, 0) {
+    if canResolveMethod(comparator, "chpl_keyPartInternal", tmp, 0) ||
+       canResolveMethod(comparator, "keyPart", tmp, 0) {
       return true;
     } else if canResolveMethod(comparator, "key", tmp) {
       var key:comparator.key(tmp).type;
       // Does the defaultComparator have a keyPart for this?
-      if canResolveMethod(new DefaultComparator(), "keyPart", key, 0) then
+      if canResolveMethod(new DefaultComparator(), "chpl_keyPartInternal", key, 0) ||
+         canResolveMethod(new DefaultComparator(), "keyPart", key, 0) then
         return true;
     }
   }
@@ -1389,40 +1445,77 @@ module RadixSortHelp {
   inline
   proc binForRecordKeyPart(a, criterion, startbit:int)
   {
-    // We have keyPart(element, start):(section:int(8), part:int/uint)
-    const testRet: criterion.keyPart(a, 1).type;
-    const testPart = testRet(1);
-    param bitsPerPart = numBits(testPart.type);
-    param bitsPerPartModRadixBits = bitsPerPart % RADIX_BITS;
-    if bitsPerPartModRadixBits != 0 then
-      compilerError("part size must be a multiple of radix bits");
-      // or else the implementation below would have to handle crossing parts
+    if canResolveMethod(criterion, "chpl_keyPartInternal", a, 0) {
+      // We have keyPart(element, start):(section:int(8), part:int/uint)
+      const testRet: criterion.chpl_keyPartInternal(a, 1).type;
+      const testPart = testRet(1);
+      param bitsPerPart = numBits(testPart.type);
+      param bitsPerPartModRadixBits = bitsPerPart % RADIX_BITS;
+      if bitsPerPartModRadixBits != 0 then
+        compilerError("part size must be a multiple of radix bits");
+        // or else the implementation below would have to handle crossing parts
 
-    // startbit must be a multiple of RADIX_BITS because the radix
-    // sort operates RADIX_BITS at a time.
+      // startbit must be a multiple of RADIX_BITS because the radix
+      // sort operates RADIX_BITS at a time.
 
-    // startbit might be partway through a part (e.g. 16 bits into a uint(64))
-    const whichpart = startbit / bitsPerPart;
-    const bitsinpart = startbit % bitsPerPart;
+      // startbit might be partway through a part (e.g. 16 bits into a uint(64))
+      const whichpart = startbit / bitsPerPart;
+      const bitsinpart = startbit % bitsPerPart;
 
-    const (section, part) = criterion.keyPart(a, whichpart);
-    var ubits = part:uint(bitsPerPart);
-    // If the number is signed, invert the top bit, so that
-    // the negative numbers sort below the positive numbers
-    if isInt(part) {
-      const one:ubits.type = 1;
-      ubits = ubits ^ (one << (bitsPerPart - 1));
+      const (section, part) = criterion.chpl_keyPartInternal(a, whichpart);
+      var ubits = part:uint(bitsPerPart);
+      // If the number is signed, invert the top bit, so that
+      // the negative numbers sort below the positive numbers
+      if isInt(part) {
+        const one:ubits.type = 1;
+        ubits = ubits ^ (one << (bitsPerPart - 1));
+      }
+      param mask:uint = (1 << RADIX_BITS) - 1;
+      const ubin = (ubits >> (bitsPerPart - bitsinpart - RADIX_BITS)) & mask;
+
+      if section:int == 0 then
+        return (ubin:int + 1, ubits);
+      else if section:int < 0 then
+        return (0, ubits);
+      else
+        return ((1 << RADIX_BITS) + 1, ubits);
+    } else {
+      // We have keyPart(element, start):(section:int(8), part:int/uint)
+      const testRet: criterion.keyPart(a, 1).type;
+      const testPart = testRet(1);
+      param bitsPerPart = numBits(testPart.type);
+      param bitsPerPartModRadixBits = bitsPerPart % RADIX_BITS;
+      if bitsPerPartModRadixBits != 0 then
+        compilerError("part size must be a multiple of radix bits");
+        // or else the implementation below would have to handle crossing parts
+
+      // startbit must be a multiple of RADIX_BITS because the radix
+      // sort operates RADIX_BITS at a time.
+
+      // startbit might be partway through a part (e.g. 16 bits into a uint(64))
+      const whichpart = startbit / bitsPerPart;
+      const bitsinpart = startbit % bitsPerPart;
+
+      const (section, part) = criterion.keyPart(a, whichpart);
+      var ubits = part:uint(bitsPerPart);
+      // If the number is signed, invert the top bit, so that
+      // the negative numbers sort below the positive numbers
+      if isInt(part) {
+        const one:ubits.type = 1;
+        ubits = ubits ^ (one << (bitsPerPart - 1));
+      }
+      param mask:uint = (1 << RADIX_BITS) - 1;
+      const ubin = (ubits >> (bitsPerPart - bitsinpart - RADIX_BITS)) & mask;
+
+      if section:int == 0 then
+        return (ubin:int + 1, ubits);
+      else if section:int < 0 then
+        return (0, ubits);
+      else
+        return ((1 << RADIX_BITS) + 1, ubits);
     }
-    param mask:uint = (1 << RADIX_BITS) - 1;
-    const ubin = (ubits >> (bitsPerPart - bitsinpart - RADIX_BITS)) & mask;
-
-    if section == 0 then
-      return (ubin:int + 1, ubits);
-    else if section < 0 then
-      return (0, ubits);
-    else
-      return ((1 << RADIX_BITS) + 1, ubits);
   }
+
 
   // Get the bin for a record with criterion.key or criterion.keyPart
   //
@@ -1430,7 +1523,8 @@ module RadixSortHelp {
   inline
   proc binForRecord(a, criterion, startbit:int)
   {
-    if canResolveMethod(criterion, "keyPart", a, 0) {
+    if canResolveMethod(criterion, "chpl_keyPartInternal", a, 0) ||
+       canResolveMethod(criterion, "keyPart", a, 0) {
       return binForRecordKeyPart(a, criterion, startbit);
     } else if canResolveMethod(criterion, "key", a) {
       // Try to use the default comparator to get a keyPart.
@@ -3267,8 +3361,46 @@ module MSBRadixSort {
 
 /* Comparators */
 
+
+// This is documented in the blurb at the top of the file
+/*
+  Indicates when the end of an element has been reached and in that event how
+  it should be sorted relative to other array elements.
+*/
+@chpldoc.nodoc
+enum keyPartStatus {
+  /* No more key parts for element, sort it before those with more parts */
+  pre = -1,
+  /* A key part for element is being returned */
+  returned = 0,
+  /* No more key parts for element, sort it after those with more parts */
+  post = 1
+}
+
+private inline proc reverseKeyPartStatus(status: keyPartStatus): keyPartStatus do
+  return try! (status:int * -1): keyPartStatus;
+private inline proc reverseKeyPartStatus(status) do
+  return -status;
+
+// TODO: this is a hack to workaround issues with interfaces
+interface keyPartComparator {
+  /*
+  proc Self.keyPart(elt, i: int): (keyPartStatus, integral);
+  proc Self.compare(x, y: x.type): int {
+    if x < y      then return -1;
+    else if y < x then return 1;
+    else          return 0;
+  }
+  */
+}
+private proc comparatorImplementsKeyPart(cmp) param do
+  return __primitive("implements interface", cmp, keyPartComparator) != 2;
+
+@chpldoc.nodoc
+config param useKeyPartStatus = false;
+
 /* Default comparator used in sort functions.*/
-record DefaultComparator {
+record DefaultComparator: keyPartComparator {
 
   /*
    Default compare method used in sort functions.
@@ -3302,41 +3434,51 @@ record DefaultComparator {
     else return 0;
   }
 
-  /*
-   Default ``keyPart`` method for integral values.
-   See also `The .keyPart method`_.
-
-   :arg x: the `int` or `uint` of any size to sort
-   :arg i: the part number requested
-
-   :returns: ``(0, x)`` if ``i==0``, or ``(-1, x)`` otherwise
-   */
-  inline
-  proc keyPart(x: integral, i:int):(int(8), x.type) {
-    var section:int(8) = if i > 0 then -1:int(8) else 0:int(8);
-    return (section, x);
+  // TODO: remove and inline into `keyPart` when `useKeyPartStatus` is deprecated
+  @chpldoc.nodoc
+  inline proc chpl_keyPartInternal(elt: integral, i: int): (keyPartStatus, elt.type) {
+    var section = if i > 0 then keyPartStatus.pre else keyPartStatus.returned;
+    return (section, elt);
   }
 
   /*
-   Default ``keyPart`` method for `real` values.
-   See also `The .keyPart method`_.
+    Default ``keyPart`` method for integral values.
+    See also `The .keyPart method`_.
 
-   :arg x: the `real` of any width to sort
-   :arg i: the part number requested
+    :arg elt: the `int` or `uint` of any size to sort
+    :arg i: the part number requested
 
-   :returns: ``(0, u)`` if ``i==0``, or ``(-1, u)`` otherwise,
-             where `u` is a `uint` storing the bits of the `real`
-             but with some transformations applied to produce the
-             correct sort order.
+    :returns: ``(keyPartStatus.pre, x)`` if ``i==0``, or ``(keyPartStatus.returned, x)`` otherwise
    */
-  inline
-  proc keyPart(x: chpl_anyreal, i:int):(int(8), uint(numBits(x.type))) {
-    import OS.POSIX.memcpy;
-    var section:int(8) = if i > 0 then -1:int(8) else 0:int(8);
+  inline proc keyPart(elt: integral, i: int): (keyPartStatus, elt.type)
+    where useKeyPartStatus {
+    return chpl_keyPartInternal(elt, i);
+  }
+  /*
+    Default ``keyPart`` method for integral values.
+    See also `The .keyPart method`_.
 
-    param nbits = numBits(x.type);
+    :arg x: the `int` or `uint` of any size to sort
+    :arg i: the part number requested
+
+    :returns: ``(0, x)`` if ``i==0``, or ``(-1, x)`` otherwise
+   */
+  @deprecated("Using :proc:`keyPart` without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary")
+  inline proc keyPart(x: integral, i: int): (int(8), x.type)
+    where !useKeyPartStatus {
+    var (section, part) = chpl_keyPartInternal(x, i);
+    return (section:int(8), part);
+  }
+
+  // TODO: remove and inline into `keyPart` when `useKeyPartStatus` is deprecated
+  @chpldoc.nodoc
+  inline proc chpl_keyPartInternal(elt: real(?), i:int): (keyPartStatus, uint(numBits(elt.type))) {
+    import OS.POSIX.memcpy;
+    var section = if i > 0 then keyPartStatus.pre else keyPartStatus.returned;
+
+    param nbits = numBits(elt.type);
     // Convert the real bits to a uint
-    var src = x;
+    var src = elt;
     var dst: uint(nbits);
     memcpy(c_ptrTo(dst), c_ptrTo(src), c_sizeof(src.type));
 
@@ -3350,90 +3492,228 @@ record DefaultComparator {
     }
     return (section, dst);
   }
+
   /*
-   Default ``keyPart`` method for `imag` values.
-   See also `The .keyPart method`_.
+    Default ``keyPart`` method for `real` values.
+    See also `The .keyPart method`_.
 
-   This method works by calling keyPart with the corresponding `real` value.
-   */
+    :arg elt: the `real` of any width to sort
+    :arg i: the part number requested
 
-  inline
-  proc keyPart(x: chpl_anyimag, i:int):(int(8), uint(numBits(x.type))) {
-    return keyPart(x:real(numBits(x.type)), i);
+    :returns: ``(keyPartStatus.returned, u)`` if ``i==0``, or
+              ``(keyPartStatus.pre, u)`` otherwise,
+              where `u` is a `uint` storing the bits of the `real`
+              but with some transformations applied to produce the
+              correct sort order.
+  */
+  inline proc keyPart(elt: real(?), i:int): (keyPartStatus, uint(numBits(elt.type)))
+    where useKeyPartStatus {
+    return chpl_keyPartInternal(elt, i);
   }
 
   /*
-   Default ``keyPart`` method for tuples of `int`, `uint`, `real`, or `imag`
-   values.
-   See also `The .keyPart method`_.
+    Default ``keyPart`` method for `real` values.
+    See also `The .keyPart method`_.
 
-   :arg x: homogeneous tuple of the numeric type (of any bit width) to sort
-   :arg i: the part number requested
+    :arg x: the `real` of any width to sort
+    :arg i: the part number requested
 
-   :returns: For `int` and `uint`, returns
-             ``(0, x(i))`` if ``i < x.size``, or ``(-1, 0)`` otherwise.
-             For `real` and `imag`, uses ``keyPart`` to find the `uint`
-             to provide the sorting order.
-   */
-  inline
-  proc keyPart(x: _tuple, i:int) where isHomogeneousTuple(x) &&
+    :returns: ``(0, u)`` if ``i==0``, or ``(-1, u)`` otherwise,
+              where `u` is a `uint` storing the bits of the `real`
+              but with some transformations applied to produce the
+              correct sort order.
+  */
+  @deprecated("Using :proc:`keyPart` without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary")
+  inline proc keyPart(x: chpl_anyreal, i:int): (int(8), uint(numBits(x.type)))
+    where !useKeyPartStatus {
+    var (section, part) = chpl_keyPartInternal(x, i);
+    return (section:int(8), part);
+  }
+
+  // TODO: remove and inline into `keyPart` when `useKeyPartStatus` is deprecated
+  @chpldoc.nodoc
+  inline proc chpl_keyPartInternal(elt: imag(?), i: int): (keyPartStatus, uint(numBits(elt.type))) {
+    return chpl_keyPartInternal(elt:real(numBits(elt.type)), i);
+  }
+  /*
+    Default ``keyPart`` method for `imag` values.
+    See also `The .keyPart method`_.
+
+    This method works by calling keyPart with the corresponding `real` value.
+  */
+  inline proc keyPart(elt: imag(?), i: int): (keyPartStatus, uint(numBits(elt.type)))
+    where useKeyPartStatus {
+    return chpl_keyPartInternal(elt, i);
+  }
+
+  /*
+    Default ``keyPart`` method for `imag` values.
+    See also `The .keyPart method`_.
+
+    This method works by calling keyPart with the corresponding `real` value.
+  */
+  @deprecated("Using :proc:`keyPart` without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary")
+  inline proc keyPart(x: chpl_anyimag, i:int):(int(8), uint(numBits(x.type)))
+    where !useKeyPartStatus {
+    var (section, part) = chpl_keyPartInternal(x, i);
+    return (section:int(8), part);
+  }
+
+  // TODO: remove and inline into `keyPart` when `useKeyPartStatus` is deprecated
+  @chpldoc.nodoc
+  inline proc chpl_keyPartInternal(elt: _tuple, i: int) where
+                                        isHomogeneousTuple(elt) &&
+                                       (isInt(elt(0)) || isUint(elt(0)) ||
+                                        isReal(elt(0)) || isImag(elt(0))) {
+    // Re-use the keyPart for imag, real
+    const (_,part) = this.chpl_keyPartInternal(elt(i), 1);
+    if i >= elt.size then
+      return (keyPartStatus.pre, 0:part.type);
+    else
+      return (keyPartStatus.returned, part);
+  }
+
+
+  /*
+    Default ``keyPart`` method for tuples of `int`, `uint`, `real`, or `imag`
+    values.
+    See also `The .keyPart method`_.
+
+    :arg elt: homogeneous tuple of the numeric type (of any bit width) to sort
+    :arg i: the part number requested
+
+    :returns: For `int` and `uint`, returns
+              ``(keyPartStatus.pre, elt(i))`` if ``i < elt.size``,
+              or ``(keyPartStatus.returned, 0)`` otherwise.
+              For `real` and `imag`, uses ``keyPart`` to find the `uint`
+              to provide the sorting order.
+  */
+  inline proc keyPart(elt: _tuple, i: int) where useKeyPartStatus &&
+                                        isHomogeneousTuple(elt) &&
+                                       (isInt(elt(0)) || isUint(elt(0)) ||
+                                        isReal(elt(0)) || isImag(elt(0))) {
+    return chpl_keyPartInternal(elt, i);
+  }
+
+  /*
+    Default ``keyPart`` method for tuples of `int`, `uint`, `real`, or `imag`
+    values.
+    See also `The .keyPart method`_.
+
+    :arg x: homogeneous tuple of the numeric type (of any bit width) to sort
+    :arg i: the part number requested
+
+    :returns: For `int` and `uint`, returns
+              ``(0, x(i))`` if ``i < x.size``, or ``(-1, 0)`` otherwise.
+              For `real` and `imag`, uses ``keyPart`` to find the `uint`
+              to provide the sorting order.
+  */
+  @deprecated("Using :proc:`keyPart` without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary")
+  inline proc keyPart(x: _tuple, i:int) where !useKeyPartStatus &&
+                                        isHomogeneousTuple(x) &&
                                        (isInt(x(0)) || isUint(x(0)) ||
                                         isReal(x(0)) || isImag(x(0))) {
-    // Re-use the keyPart for imag, real
-    const (_,part) = this.keyPart(x(i), 1);
-    if i >= x.size then
-      return (-1, 0:part.type);
-    else
-      return (0, part);
+    var (section, part) = chpl_keyPartInternal(x, i);
+    return (section:int(8), part);
   }
 
-  /*
-   Default ``keyPart`` method for sorting strings.
-   See also `The .keyPart method`_.
-
-   .. note::
-     Currently assumes that the string is local.
-
-   :arg x: the string to sort
-   :arg i: the part number requested
-
-   :returns: ``(0, byte i of string)`` or ``(-1, 0)`` if ``i > x.size``
-   */
-  inline
-  proc keyPart(x:string, i:int):(int(8), uint(8)) {
+  // TODO: remove and inline into `keyPart` when `useKeyPartStatus` is deprecated
+  @chpldoc.nodoc
+  inline proc chpl_keyPartInternal(elt: string, i: int): (keyPartStatus, uint(8)) {
     // This assumes that the string is local, which should
     // be OK for the sort module (because the array containing
     // the string must currently be local).
     // In the future it should use bytes access into the string.
     if boundsChecking then
-      assert(x.locale_id == here.id);
+      assert(elt.locale_id == here.id);
 
-    var ptr = x.c_str():c_ptr(uint(8));
-    var len = x.numBytes;
-    var section = if i < len then 0:int(8) else -1:int(8);
-    var part =    if i < len then ptr[i] else  0:uint(8);
+    var ptr = elt.c_str():c_ptr(uint(8));
+    var len = elt.numBytes;
+    var section = if i < len then keyPartStatus.returned else keyPartStatus.pre;
+    var part =    if i < len then ptr[i]                 else 0:uint(8);
+    return (section, part);
+  }
+
+
+  /*
+    Default ``keyPart`` method for sorting strings.
+    See also `The .keyPart method`_.
+
+    .. note::
+      Currently assumes that the string is local.
+
+    :arg elt: the string to sort
+    :arg i: the part number requested
+
+    :returns: ``(keyPartStatus.returned, byte i of string)`` or
+              ``(keyPartStatus.pre, 0)`` if ``i > elt.size``
+  */
+  inline proc keyPart(elt: string, i: int): (keyPartStatus, uint(8))
+    where useKeyPartStatus {
+    return chpl_keyPartInternal(elt, i);
+  }
+
+  /*
+    Default ``keyPart`` method for sorting strings.
+    See also `The .keyPart method`_.
+
+    .. note::
+      Currently assumes that the string is local.
+
+    :arg x: the string to sort
+    :arg i: the part number requested
+
+    :returns: ``(0, byte i of string)`` or ``(-1, 0)`` if ``i > x.size``
+  */
+  @deprecated("Using :proc:`keyPart` without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary")
+  inline proc keyPart(x:string, i:int): (int(8), uint(8))
+    where !useKeyPartStatus {
+    var (section, part) = chpl_keyPartInternal(x, i);
+    return (section:int(8), part);
+  }
+
+  // TODO: remove and inline into `keyPart` when `useKeyPartStatus` is deprecated
+  @chpldoc.nodoc
+  inline proc chpl_keyPartInternal(elt: c_ptrConst(c_char), i: int): (keyPartStatus, uint(8)) {
+    var ptr = elt:c_ptr(uint(8));
+    var byte = ptr[i];
+    var section = if byte != 0 then keyPartStatus.returned else keyPartStatus.pre;
+    var part = byte;
     return (section, part);
   }
 
   /*
-   Default ``keyPart`` method for sorting `c_ptrConst(c_char)`.
-   See also `The .keyPart method`_.
-   :arg x: the `c_ptrConst(c_char)` to sort
-   :arg i: the part number requested
-   :returns: ``(0, byte i of string)`` or ``(-1, 0)`` if byte ``i`` is ``0``
-   */
-  inline
-  proc keyPart(x:c_ptrConst(c_char), i:int):(int(8), uint(8)) {
-    var ptr = x:c_ptr(uint(8));
-    var byte = ptr[i];
-    var section = if byte != 0 then 0:int(8) else -1:int(8);
-    var part = byte;
-    return (section, part);
+    Default ``keyPart`` method for sorting `c_ptrConst(c_char)`.
+    See also `The .keyPart method`_.
+
+    :arg elt: the `c_ptrConst(c_char)` to sort
+    :arg i: the part number requested
+
+    :returns: ``(keyPartStatus.returned, byte i of string)`` or
+              ``(keyPartStatus.pre, 0)`` if byte ``i`` is ``0``
+  */
+  inline proc keyPart(elt: c_ptrConst(c_char), i: int): (keyPartStatus, uint(8))
+    where useKeyPartStatus {
+    return chpl_keyPartInternal(elt, i);
+  }
+
+  /*
+    Default ``keyPart`` method for sorting `c_ptrConst(c_char)`.
+    See also `The .keyPart method`_.
+    :arg x: the `c_ptrConst(c_char)` to sort
+    :arg i: the part number requested
+    :returns: ``(0, byte i of string)`` or ``(-1, 0)`` if byte ``i`` is ``0``
+  */
+  @deprecated("Using :proc:`keyPart` without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary")
+  inline proc keyPart(x:c_ptrConst(c_char), i:int):(int(8), uint(8))
+    where !useKeyPartStatus {
+    var (section, part) = chpl_keyPartInternal(x, i);
+    return (section:int(8), part);
   }
 }
 
 /* Reverse comparator built from another comparator.*/
-record ReverseComparator {
+record ReverseComparator: keyPartComparator {
 
   /* Generic comparator defined in initializer.*/
   var comparator;
@@ -3456,6 +3736,8 @@ record ReverseComparator {
    */
   proc init(comparator) {
     this.comparator = comparator;
+    if !comparatorImplementsKeyPart(this.comparator) then
+      compilerWarning("Defining a comparator with a 'keyPart' method without implementing the keyPartComparator interface is deprecated. Please implement the keyPartComparator interface (i.e. 'record "+ this.comparator.type:string + ": keyPartComparator').");
   }
 
   /*
@@ -3501,14 +3783,16 @@ record ReverseComparator {
 
   @chpldoc.nodoc
   proc hasKeyPart(a) param {
-    return canResolveMethod(this.comparator, "keyPart", a, 0);
+    return canResolveMethod(this.comparator, "chpl_keyPartInternal", a, 0) ||
+           canResolveMethod(this.comparator, "keyPart", a, 0);
   }
   @chpldoc.nodoc
   proc hasKeyPartFromKey(a) param {
     if canResolveMethod(this.comparator, "key", a) {
       var key:comparator.key(a).type;
       // Does the defaultComparator have a keyPart for this?
-      return canResolveMethod(new DefaultComparator(), "keyPart", key, 0);
+      return canResolveMethod(new DefaultComparator(), "chpl_keyPartInternal", key, 0) ||
+             canResolveMethod(new DefaultComparator(), "keyPart", key, 0);
     }
     return false;
   }
@@ -3528,31 +3812,57 @@ record ReverseComparator {
   }
 
   @chpldoc.nodoc
-  inline
-  proc getKeyPart(cmp, a, i) {
-    var (section, part) = cmp.keyPart(a, i);
-    if typeIsBitReversible(part.type) {
-      return (-section, ~part);
-    } else if typeIsNegateReversible(part.type) {
-      return (-section, -part);
+  inline proc getKeyPart(cmp, elt, i) {
+    if canResolveMethod(cmp, "chpl_keyPartInternal", elt, 0) {
+      var (section, part) = cmp.chpl_keyPartInternal(elt, i);
+      if typeIsBitReversible(part.type) {
+        return (reverseKeyPartStatus(section), ~part);
+      } else if typeIsNegateReversible(part.type) {
+        return (reverseKeyPartStatus(section), -part);
+      } else {
+        compilerError("keyPart must return int or uint");
+      }
     } else {
-      compilerError("keyPart must return int or uint");
+      var (section, part) = cmp.keyPart(elt, i);
+      if typeIsBitReversible(part.type) {
+        return (reverseKeyPartStatus(section), ~part);
+      } else if typeIsNegateReversible(part.type) {
+        return (reverseKeyPartStatus(section), -part);
+      } else {
+        compilerError("keyPart must return int or uint");
+      }
+    }
+  }
+
+  // TODO: remove and inline into `keyPart` when `useKeyPartStatus` is deprecated
+  @chpldoc.nodoc
+  inline proc chpl_keyPartInternal(elt, i)
+    where (hasKeyPart(elt) || hasKeyPartFromKey(elt)) {
+    chpl_check_comparator(this.comparator, elt.type, doDeprecationCheck=false);
+    if hasKeyPartFromKey(elt) {
+      return getKeyPart(new DefaultComparator(), this.comparator.key(elt), i);
+    } else {
+      return getKeyPart(this.comparator, elt, i);
     }
   }
 
   /*
-   Reverses ``comparator.keyPart``. See also `The .keyPart method`_.
-   */
-  inline
-  proc keyPart(a, i) where hasKeyPart(a) || hasKeyPartFromKey(a) {
-    chpl_check_comparator(this.comparator, a.type);
+    Reverses ``comparator.keyPart``. See also `The .keyPart method`_.
+  */
+  inline proc keyPart(elt, i) where useKeyPartStatus &&
+                                    (hasKeyPart(elt) ||
+                                     hasKeyPartFromKey(elt)) {
+    return chpl_keyPartInternal(elt, i);
+  }
 
-    if hasKeyPartFromKey(a) {
-      return getKeyPart(new DefaultComparator(), this.comparator.key(a), i);
-    } else {
-      return getKeyPart(this.comparator, a, i);
-    }
-
+  /*
+    Reverses ``comparator.keyPart``. See also `The .keyPart method`_.
+  */
+  @deprecated("Using :proc:`keyPart` without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary")
+  inline proc keyPart(a, i) where !useKeyPartStatus &&
+                                  (hasKeyPart(a) || hasKeyPartFromKey(a)) {
+    var (section, part) = chpl_keyPartInternal(a, i);
+    return (section:int(8), part);
   }
 
   @chpldoc.nodoc
@@ -3577,7 +3887,7 @@ record ReverseComparator {
   inline
   proc compare(x, y: x.type) where hasCompare(x, y) || hasCompareFromKey(x) {
 
-    chpl_check_comparator(this.comparator, x.type);
+    chpl_check_comparator(this.comparator, x.type, doDeprecationCheck=false);
 
     if hasCompareFromKey(x) {
       return doCompare(new DefaultComparator(),

--- a/modules/standard/Sort.chpl
+++ b/modules/standard/Sort.chpl
@@ -157,7 +157,9 @@ strings. It accepts two arguments:
 
 A ``keyPart`` method should return a tuple consisting of *section* and a *part*.
 
- * The *section* must be of type :type:`keyPartStatus`. It indicates when the end of ``elt`` has been reached and in that event how it should be sorted relative to other array elements.
+ * The *section* must be of type :type:`keyPartStatus`. It indicates when the
+ end of ``elt`` has been reached and in that event how it should be sorted
+ relative to other array elements.
 
  * The *part* can be any signed or unsigned integral type and can contain any
    value. The *part* will be ignored unless the *section* returned is
@@ -3449,7 +3451,8 @@ record DefaultComparator: keyPartComparator {
     :arg elt: the `int` or `uint` of any size to sort
     :arg i: the part number requested
 
-    :returns: ``(keyPartStatus.pre, x)`` if ``i==0``, or ``(keyPartStatus.returned, x)`` otherwise
+    :returns: ``(keyPartStatus.returned, x)`` if ``i==0``, or
+              ``(keyPartStatus.pre, x)`` otherwise
    */
   inline proc keyPart(elt: integral, i: int): (keyPartStatus, elt.type)
     where useKeyPartStatus {

--- a/modules/standard/Sort.chpl
+++ b/modules/standard/Sort.chpl
@@ -157,28 +157,16 @@ strings. It accepts two arguments:
 
 A ``keyPart`` method should return a tuple consisting of *section* and a *part*.
 
- * The *section* must be of type ``keyPartStatus``. It indicates when the end of ``elt`` has been reached and in that event how it should be sorted relative to other array elements.
-
-   ============================= ===========================================
-   Returned section              Interpretation
-   ============================= ===========================================
-   ``keyPartStatus.pre``          no more key parts for ``elt``,
-                                  sort it before those with more parts
-
-   ``keyPartStatus.returned``     a key part for ``elt`` is returned in
-                                  the second tuple element
-
-   ``keyPartStatus.post``         no more key parts for ``elt``,
-                                  sort it after those with more parts
-   ============================= ===========================================
+ * The *section* must be of type :type:`keyPartStatus`. It indicates when the end of ``elt`` has been reached and in that event how it should be sorted relative to other array elements.
 
  * The *part* can be any signed or unsigned integral type and can contain any
-   value. The *part* will be ignored unless the *section* returned is ``0``.
+   value. The *part* will be ignored unless the *section* returned is
+   :enumconstant:`keyPartStatus.returned`.
 
 
 Let's consider several example ``keyPart`` methods. All of these are
 simplifications of ``keyPart`` methods already available in the
-``DefaultComparator``.
+:type:`DefaultComparator`.
 
 This ``keyPart`` method supports sorting tuples of 2 integers:
 
@@ -3374,12 +3362,10 @@ module MSBRadixSort {
 /* Comparators */
 
 
-// This is documented in the blurb at the top of the file
 /*
   Indicates when the end of an element has been reached and in that event how
   it should be sorted relative to other array elements.
 */
-@chpldoc.nodoc
 enum keyPartStatus {
   /* No more key parts for element, sort it before those with more parts */
   pre = -1,
@@ -3394,6 +3380,7 @@ private inline proc reverseKeyPartStatus(status: keyPartStatus): keyPartStatus d
 private inline proc reverseKeyPartStatus(status) do
   return -status;
 
+// TODO: chpldoc will not render this yet :(
 // TODO: this is a hack to workaround issues with interfaces
 interface keyPartComparator {
   /*

--- a/test/deprecated/Sort/keyPartInt-resolved.good
+++ b/test/deprecated/Sort/keyPartInt-resolved.good
@@ -1,0 +1,24 @@
+Comparing with DefaultComparator
+(returned, 1)
+(returned, 2)
+(returned, 13835058055282163712)
+(returned, 13835058055282163712)
+(returned, 4)
+(returned, 13835058055282163712)
+(returned, 102)
+(returned, 98)
+Comparing with ReverseComparator
+(returned, -2)
+(returned, 18446744073709551613)
+(returned, 4611686018427387903)
+(returned, 4611686018427387903)
+(returned, -5)
+(returned, 4611686018427387903)
+(returned, 153)
+(returned, 157)
+isSorted before false
+isSorted after true
+isSorted before false
+isSorted after true
+isSorted before false
+isSorted after true

--- a/test/deprecated/Sort/keyPartInt.chpl
+++ b/test/deprecated/Sort/keyPartInt.chpl
@@ -1,0 +1,87 @@
+use Sort, CTypes;
+
+//
+// Static usage, a user tries to call `keyPart` from DefaultComparator or
+// ReverseComparator without `-suseKeyPartStatus`
+//
+
+var comparators = (new DefaultComparator(), new ReverseComparator());
+var titles = ("Default", "Reverse");
+
+for param i in 0..#comparators.size {
+  writeln("Comparing with ", titles[i], "Comparator");
+  var d = comparators[i];
+  // integral
+  writeln(d.keyPart(1, 0));
+  writeln(d.keyPart(2:uint, 0));
+  // real(?)
+  writeln(d.keyPart(2.0, 0));
+  // imag(?)
+  writeln(d.keyPart(2.0i, 0));
+  // _tuple
+  writeln(d.keyPart((4, 2), 0));
+  writeln(d.keyPart((2.0, 8.0), 0));
+  // string
+  writeln(d.keyPart("foo", 0));
+  // c_ptrConst(c_char)
+  writeln(d.keyPart("bar".c_str(), 0));
+}
+
+//
+// Dynamic usage deprecation warnings, for when a user has defined a custom comparator and uses it in `sort` or `isSorted`
+//
+
+
+// This is a simple comparator for integers
+// It is identical to the Sort module for normal sorting
+// To make sure we get all the deprecation warnings, we need to use a unique comparator type for each call
+
+record myCmp1 { proc keyPart(elt, i) do return (if i > 0 then -1 else 0, elt); }
+record myCmp2 { proc keyPart(elt, i) do return (if i > 0 then -1 else 0, elt); }
+record myCmp3 { proc keyPart(elt, i) do return (if i > 0 then -1 else 0, elt); }
+record myCmp4 { proc keyPart(elt, i) do return (if i > 0 then -1 else 0, elt); }
+record myCmp5 { proc keyPart(elt, i) do return (if i > 0 then -1 else 0, elt); }
+record myCmp6 { proc keyPart(elt, i) do return (if i > 0 then -1 else 0, elt); }
+record myCmp7 { proc keyPart(elt, i) do return (if i > 0 then -1 else 0, elt); }
+record myCmp8 { proc keyPart(elt, i) do return (if i > 0 then -1 else 0, elt); }
+record myCmp9 { proc keyPart(elt, i) do return (if i > 0 then -1 else 0, elt); }
+
+record myCmpResolveDeps: keyPartComparator {
+  proc keyPart(elt, i) do
+    return (if i > 0 then keyPartStatus.pre else keyPartStatus.returned, elt);
+}
+
+proc getComparator(param i: int) type {
+  if Sort.useKeyPartStatus then return myCmpResolveDeps;
+  else select i {
+    when 1 do return myCmp1;
+    when 2 do return myCmp2;
+    when 3 do return myCmp3;
+    when 4 do return myCmp4;
+    when 5 do return myCmp5;
+    when 6 do return myCmp6;
+    when 7 do return myCmp7;
+    when 8 do return myCmp8;
+    when 9 do return myCmp9;
+  }
+  compilerError("");
+}
+
+use Random;
+var arr: [1..1000] int;
+
+// there should be 9 deprecations here
+fillRandom(arr);
+writeln("isSorted before ", isSorted(arr, comparator=new (getComparator(1))()));
+sort(arr, comparator=new (getComparator(2))());
+writeln("isSorted after ", isSorted(arr, comparator=new (getComparator(3))()));
+
+fillRandom(arr);
+writeln("isSorted before ", isSorted(arr, comparator=new ReverseComparator(new (getComparator(4))())));
+sort(arr, comparator=new ReverseComparator(new (getComparator(5))()));
+writeln("isSorted after ", isSorted(arr, comparator=new ReverseComparator(new (getComparator(6))())));
+
+fillRandom(arr);
+writeln("isSorted before ", isSorted(arr, comparator=new (getComparator(7))()));
+var temp = sorted(arr, comparator=new (getComparator(8))());
+writeln("isSorted after ", isSorted(temp, comparator=new (getComparator(9))()));

--- a/test/deprecated/Sort/keyPartInt.compopts
+++ b/test/deprecated/Sort/keyPartInt.compopts
@@ -1,0 +1,4 @@
+                         # keyPartInt.good
+-suseKeyPartStatus=false # keyPartInt.good
+-suseKeyPartStatus       # keyPartInt-resolved.good
+-suseKeyPartStatus=true  # keyPartInt-resolved.good

--- a/test/deprecated/Sort/keyPartInt.good
+++ b/test/deprecated/Sort/keyPartInt.good
@@ -1,48 +1,48 @@
-test/deprecated/Sort/keyPartInt.chpl:15: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
-test/deprecated/Sort/keyPartInt.chpl:16: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
-test/deprecated/Sort/keyPartInt.chpl:18: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
-test/deprecated/Sort/keyPartInt.chpl:20: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
-test/deprecated/Sort/keyPartInt.chpl:22: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
-test/deprecated/Sort/keyPartInt.chpl:23: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
-test/deprecated/Sort/keyPartInt.chpl:25: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
-test/deprecated/Sort/keyPartInt.chpl:27: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
-test/deprecated/Sort/keyPartInt.chpl:15: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
-test/deprecated/Sort/keyPartInt.chpl:16: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
-test/deprecated/Sort/keyPartInt.chpl:18: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
-test/deprecated/Sort/keyPartInt.chpl:20: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
-test/deprecated/Sort/keyPartInt.chpl:22: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
-test/deprecated/Sort/keyPartInt.chpl:23: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
-test/deprecated/Sort/keyPartInt.chpl:25: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
-test/deprecated/Sort/keyPartInt.chpl:27: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
-test/deprecated/Sort/keyPartInt.chpl:75: warning: Defining a comparator with a 'keyPart' method without implementing the keyPartComparator interface is deprecated. Please implement the keyPartComparator interface (i.e. 'record myCmp1: keyPartComparator').
-test/deprecated/Sort/keyPartInt.chpl:76: warning: Defining a comparator with a 'keyPart' method without implementing the keyPartComparator interface is deprecated. Please implement the keyPartComparator interface (i.e. 'record myCmp2: keyPartComparator').
-test/deprecated/Sort/keyPartInt.chpl:77: warning: Defining a comparator with a 'keyPart' method without implementing the keyPartComparator interface is deprecated. Please implement the keyPartComparator interface (i.e. 'record myCmp3: keyPartComparator').
-test/deprecated/Sort/keyPartInt.chpl:80: warning: Defining a comparator with a 'keyPart' method without implementing the keyPartComparator interface is deprecated. Please implement the keyPartComparator interface (i.e. 'record myCmp4: keyPartComparator').
-test/deprecated/Sort/keyPartInt.chpl:81: warning: Defining a comparator with a 'keyPart' method without implementing the keyPartComparator interface is deprecated. Please implement the keyPartComparator interface (i.e. 'record myCmp5: keyPartComparator').
-test/deprecated/Sort/keyPartInt.chpl:82: warning: Defining a comparator with a 'keyPart' method without implementing the keyPartComparator interface is deprecated. Please implement the keyPartComparator interface (i.e. 'record myCmp6: keyPartComparator').
-test/deprecated/Sort/keyPartInt.chpl:85: warning: Defining a comparator with a 'keyPart' method without implementing the keyPartComparator interface is deprecated. Please implement the keyPartComparator interface (i.e. 'record myCmp7: keyPartComparator').
-$CHPL_HOME/modules/standard/Sort.chpl:835: In iterator 'sorted':
-$CHPL_HOME/modules/standard/Sort.chpl:848: warning: Defining a comparator with a 'keyPart' method without implementing the keyPartComparator interface is deprecated. Please implement the keyPartComparator interface (i.e. 'record myCmp8: keyPartComparator').
-  test/deprecated/Sort/keyPartInt.chpl:86: called as sorted(x: [domain(1,int(64),one)] int(64), comparator: myCmp8)
-test/deprecated/Sort/keyPartInt.chpl:87: warning: Defining a comparator with a 'keyPart' method without implementing the keyPartComparator interface is deprecated. Please implement the keyPartComparator interface (i.e. 'record myCmp9: keyPartComparator').
+keyPartInt.chpl:15: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+keyPartInt.chpl:16: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+keyPartInt.chpl:18: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+keyPartInt.chpl:20: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+keyPartInt.chpl:22: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+keyPartInt.chpl:23: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+keyPartInt.chpl:25: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+keyPartInt.chpl:27: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+keyPartInt.chpl:15: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+keyPartInt.chpl:16: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+keyPartInt.chpl:18: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+keyPartInt.chpl:20: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+keyPartInt.chpl:22: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+keyPartInt.chpl:23: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+keyPartInt.chpl:25: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+keyPartInt.chpl:27: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+keyPartInt.chpl:75: warning: Defining a comparator with a 'keyPart' method without implementing the keyPartComparator interface is deprecated. Please implement the keyPartComparator interface (i.e. 'record myCmp1: keyPartComparator').
+keyPartInt.chpl:76: warning: Defining a comparator with a 'keyPart' method without implementing the keyPartComparator interface is deprecated. Please implement the keyPartComparator interface (i.e. 'record myCmp2: keyPartComparator').
+keyPartInt.chpl:77: warning: Defining a comparator with a 'keyPart' method without implementing the keyPartComparator interface is deprecated. Please implement the keyPartComparator interface (i.e. 'record myCmp3: keyPartComparator').
+keyPartInt.chpl:80: warning: Defining a comparator with a 'keyPart' method without implementing the keyPartComparator interface is deprecated. Please implement the keyPartComparator interface (i.e. 'record myCmp4: keyPartComparator').
+keyPartInt.chpl:81: warning: Defining a comparator with a 'keyPart' method without implementing the keyPartComparator interface is deprecated. Please implement the keyPartComparator interface (i.e. 'record myCmp5: keyPartComparator').
+keyPartInt.chpl:82: warning: Defining a comparator with a 'keyPart' method without implementing the keyPartComparator interface is deprecated. Please implement the keyPartComparator interface (i.e. 'record myCmp6: keyPartComparator').
+keyPartInt.chpl:85: warning: Defining a comparator with a 'keyPart' method without implementing the keyPartComparator interface is deprecated. Please implement the keyPartComparator interface (i.e. 'record myCmp7: keyPartComparator').
+$CHPL_HOME/modules/standard/Sort.chpl:nnnn: In iterator 'sorted':
+$CHPL_HOME/modules/standard/Sort.chpl:nnnn: warning: Defining a comparator with a 'keyPart' method without implementing the keyPartComparator interface is deprecated. Please implement the keyPartComparator interface (i.e. 'record myCmp8: keyPartComparator').
+  keyPartInt.chpl:86: called as sorted(x: [domain(1,int(64),one)] int(64), comparator: myCmp8)
+keyPartInt.chpl:87: warning: Defining a comparator with a 'keyPart' method without implementing the keyPartComparator interface is deprecated. Please implement the keyPartComparator interface (i.e. 'record myCmp9: keyPartComparator').
 Comparing with DefaultComparator
-(returned, 1)
-(returned, 2)
-(returned, 13835058055282163712)
-(returned, 13835058055282163712)
-(returned, 4)
-(returned, 13835058055282163712)
-(returned, 102)
-(returned, 98)
+(0, 1)
+(0, 2)
+(0, 13835058055282163712)
+(0, 13835058055282163712)
+(0, 4)
+(0, 13835058055282163712)
+(0, 102)
+(0, 98)
 Comparing with ReverseComparator
-(returned, -2)
-(returned, 18446744073709551613)
-(returned, 4611686018427387903)
-(returned, 4611686018427387903)
-(returned, -5)
-(returned, 4611686018427387903)
-(returned, 153)
-(returned, 157)
+(0, -2)
+(0, 18446744073709551613)
+(0, 4611686018427387903)
+(0, 4611686018427387903)
+(0, -5)
+(0, 4611686018427387903)
+(0, 153)
+(0, 157)
 isSorted before false
 isSorted after true
 isSorted before false

--- a/test/deprecated/Sort/keyPartInt.good
+++ b/test/deprecated/Sort/keyPartInt.good
@@ -1,0 +1,51 @@
+test/deprecated/Sort/keyPartInt.chpl:15: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+test/deprecated/Sort/keyPartInt.chpl:16: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+test/deprecated/Sort/keyPartInt.chpl:18: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+test/deprecated/Sort/keyPartInt.chpl:20: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+test/deprecated/Sort/keyPartInt.chpl:22: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+test/deprecated/Sort/keyPartInt.chpl:23: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+test/deprecated/Sort/keyPartInt.chpl:25: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+test/deprecated/Sort/keyPartInt.chpl:27: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+test/deprecated/Sort/keyPartInt.chpl:15: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+test/deprecated/Sort/keyPartInt.chpl:16: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+test/deprecated/Sort/keyPartInt.chpl:18: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+test/deprecated/Sort/keyPartInt.chpl:20: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+test/deprecated/Sort/keyPartInt.chpl:22: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+test/deprecated/Sort/keyPartInt.chpl:23: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+test/deprecated/Sort/keyPartInt.chpl:25: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+test/deprecated/Sort/keyPartInt.chpl:27: warning: Using keyPart without 'keyPartStatus' is deprecated, compile with '-suseKeyPartStatus' and update your types if necessary
+test/deprecated/Sort/keyPartInt.chpl:75: warning: Defining a comparator with a 'keyPart' method without implementing the keyPartComparator interface is deprecated. Please implement the keyPartComparator interface (i.e. 'record myCmp1: keyPartComparator').
+test/deprecated/Sort/keyPartInt.chpl:76: warning: Defining a comparator with a 'keyPart' method without implementing the keyPartComparator interface is deprecated. Please implement the keyPartComparator interface (i.e. 'record myCmp2: keyPartComparator').
+test/deprecated/Sort/keyPartInt.chpl:77: warning: Defining a comparator with a 'keyPart' method without implementing the keyPartComparator interface is deprecated. Please implement the keyPartComparator interface (i.e. 'record myCmp3: keyPartComparator').
+test/deprecated/Sort/keyPartInt.chpl:80: warning: Defining a comparator with a 'keyPart' method without implementing the keyPartComparator interface is deprecated. Please implement the keyPartComparator interface (i.e. 'record myCmp4: keyPartComparator').
+test/deprecated/Sort/keyPartInt.chpl:81: warning: Defining a comparator with a 'keyPart' method without implementing the keyPartComparator interface is deprecated. Please implement the keyPartComparator interface (i.e. 'record myCmp5: keyPartComparator').
+test/deprecated/Sort/keyPartInt.chpl:82: warning: Defining a comparator with a 'keyPart' method without implementing the keyPartComparator interface is deprecated. Please implement the keyPartComparator interface (i.e. 'record myCmp6: keyPartComparator').
+test/deprecated/Sort/keyPartInt.chpl:85: warning: Defining a comparator with a 'keyPart' method without implementing the keyPartComparator interface is deprecated. Please implement the keyPartComparator interface (i.e. 'record myCmp7: keyPartComparator').
+$CHPL_HOME/modules/standard/Sort.chpl:835: In iterator 'sorted':
+$CHPL_HOME/modules/standard/Sort.chpl:848: warning: Defining a comparator with a 'keyPart' method without implementing the keyPartComparator interface is deprecated. Please implement the keyPartComparator interface (i.e. 'record myCmp8: keyPartComparator').
+  test/deprecated/Sort/keyPartInt.chpl:86: called as sorted(x: [domain(1,int(64),one)] int(64), comparator: myCmp8)
+test/deprecated/Sort/keyPartInt.chpl:87: warning: Defining a comparator with a 'keyPart' method without implementing the keyPartComparator interface is deprecated. Please implement the keyPartComparator interface (i.e. 'record myCmp9: keyPartComparator').
+Comparing with DefaultComparator
+(returned, 1)
+(returned, 2)
+(returned, 13835058055282163712)
+(returned, 13835058055282163712)
+(returned, 4)
+(returned, 13835058055282163712)
+(returned, 102)
+(returned, 98)
+Comparing with ReverseComparator
+(returned, -2)
+(returned, 18446744073709551613)
+(returned, 4611686018427387903)
+(returned, 4611686018427387903)
+(returned, -5)
+(returned, 4611686018427387903)
+(returned, 153)
+(returned, 157)
+isSorted before false
+isSorted after true
+isSorted before false
+isSorted after true
+isSorted before false
+isSorted after true

--- a/test/deprecated/Sort/keyPartInt.prediff
+++ b/test/deprecated/Sort/keyPartInt.prediff
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# prediff out line numbers from Sort module
+sed -e 's/Sort.chpl:[0-9][0-9]*:/Sort.chpl:nnn/' $2 > $2.tmp
+mv $2.tmp $2

--- a/test/deprecated/Sort/keyPartInt.prediff
+++ b/test/deprecated/Sort/keyPartInt.prediff
@@ -1,5 +1,3 @@
 #!/usr/bin/env bash
 
-# prediff out line numbers from Sort module
-sed -e 's/Sort.chpl:[0-9][0-9]*:/Sort.chpl:nnn/' $2 > $2.tmp
-mv $2.tmp $2
+$CHPL_HOME/util/test/prediff-obscure-module-linenos $@

--- a/test/library/standard/Sort/correctness/SortTypes.chpl
+++ b/test/library/standard/Sort/correctness/SortTypes.chpl
@@ -9,22 +9,22 @@ record UselessKeyComparator {
   }
 }
 
-record UselessKeyPartComparator {
+record UselessKeyPartComparator: keyPartComparator {
   proc keyPart(x, i:int) {
     if isTuple(x) {
       type tt = x(0).type;
       if i < x.size then
-        return (0, x(i));
+        return (keyPartStatus.returned, x(i));
       else
-        return (-1, 0:tt);
+        return (keyPartStatus.pre, 0:tt);
 
     } else if x.type == string {
       return (new DefaultComparator()).keyPart(x, i);
     } else if isNumericType(x.type) {
       if i == 0 then
-        return (0, x);
+        return (keyPartStatus.returned, x);
       else
-        return (-1, x);
+        return (keyPartStatus.pre, x);
     } else {
       compilerError("not handled");
     }

--- a/test/library/standard/Sort/correctness/SortTypesStrided.chpl
+++ b/test/library/standard/Sort/correctness/SortTypesStrided.chpl
@@ -9,22 +9,22 @@ record UselessKeyComparator {
   }
 }
 
-record UselessKeyPartComparator {
+record UselessKeyPartComparator: keyPartComparator {
   proc keyPart(x, i:int) {
     if isTuple(x) {
       type tt = x(0).type;
       if i < x.size then
-        return (0, x(i));
+        return (keyPartStatus.returned, x(i));
       else
-        return (-1, 0:tt);
+        return (keyPartStatus.pre, 0:tt);
 
     } else if x.type == string {
       return (new DefaultComparator()).keyPart(x, i);
     } else if isNumericType(x.type) {
       if i == 0 then
-        return (0, x);
+        return (keyPartStatus.returned, x);
       else
-        return (-1, x);
+        return (keyPartStatus.pre, x);
     } else {
       compilerError("not handled");
     }

--- a/test/library/standard/Sort/correctness/keyPartEnding.chpl
+++ b/test/library/standard/Sort/correctness/keyPartEnding.chpl
@@ -42,15 +42,15 @@ proc stringToTwoRepeated(arg:string) {
   }
 }
 
-record MyComparator {
+record MyComparator: keyPartComparator {
   proc keyPart(arg:TwoRepeated, i:int) {
     var sum = arg.nFirst + arg.nSecond;
     if i < arg.nFirst then
-      return (0, arg.first);
+      return (keyPartStatus.returned, arg.first);
     else if i < sum then
-      return (0, arg.second);
+      return (keyPartStatus.returned, arg.second);
     else
-      return (-1, 0);
+      return (keyPartStatus.pre, 0);
   }
 }
 

--- a/test/library/standard/Sort/correctness/sortStrings.compopts
+++ b/test/library/standard/Sort/correctness/sortStrings.compopts
@@ -1,0 +1,1 @@
+-suseKeyPartStatus

--- a/test/library/standard/Sort/correctness/testMsbRadixSort.chpl
+++ b/test/library/standard/Sort/correctness/testMsbRadixSort.chpl
@@ -11,67 +11,67 @@ use BitOps;
 
  var chplout = stdout.withSerializer(chplSerializer);
 
- record uintCriterion8 {
+ record uintCriterion8: keyPartComparator {
    inline
-   proc keyPart(x, start:int):(int(8),uint(8)) {
-     if start >= 8 then return (-1:int(8), 0:uint(8));
+   proc keyPart(x, start:int):(keyPartStatus,uint(8)) {
+     if start >= 8 then return (keyPartStatus.pre, 0:uint(8));
      var key:uint = (x:uint) >> (64 - 8*(start+1));
      //writef("in keyPart8(%016xu, %u)\n", x, start);
-     return (0:int(8), (key & 0xff):uint(8));
+     return (keyPartStatus.returned, (key & 0xff):uint(8));
    }
  }
- record uintCriterion16 {
+ record uintCriterion16: keyPartComparator {
    inline
-   proc keyPart(x, start:int):(int(8),uint(16)) {
-     if start >= 4 then return (-1:int(8), 0:uint(8));
+   proc keyPart(x, start:int):(keyPartStatus,uint(16)) {
+     if start >= 4 then return (keyPartStatus.pre, 0:uint(8));
      var key:uint = (x:uint) >> (64 - 16*(start+1));
      //writef("in keyPart16(%016xu, %u)\n", x, start);
-     return (0:int(8), (key & 0xffff):uint(16));
+     return (keyPartStatus.returned, (key & 0xffff):uint(16));
    }
  }
- record uintCriterion32 {
+ record uintCriterion32: keyPartComparator {
    inline
-   proc keyPart(x, start:int):(int, uint(32)) {
-     if start >= 2 then return (-1:int, 0:uint(32));
+   proc keyPart(x, start:int):(keyPartStatus, uint(32)) {
+     if start >= 2 then return (keyPartStatus.pre, 0:uint(32));
      var key:uint = (x:uint) >> (64 - 32*(start+1));
      //writef("in keyPart32(%016xu, %u)\n", x, start);
-     return (0:int, (key & 0xffffffff):uint(32));
+     return (keyPartStatus.returned, (key & 0xffffffff):uint(32));
    }
  }
- record uintCriterion64 {
+ record uintCriterion64: keyPartComparator {
    inline
-   proc keyPart(x, start:int):(int(8), uint(64)) {
-     if start >= 1 then return (-1:int(8), 0:uint(64));
+   proc keyPart(x, start:int):(keyPartStatus, uint(64)) {
+     if start >= 1 then return (keyPartStatus.pre, 0:uint(64));
      var key:uint = x:uint;
      //writef("in keyPart64(%016xu, %u)\n", x, start);
-     return (0:int(8), key);
+     return (keyPartStatus.returned, key);
    }
  }
- record intCriterion {
+ record intCriterion: keyPartComparator {
    inline
-   proc keyPart(x, start:int):(int, int) {
-     if start >= 1 then return (-1:int, 0:int);
+   proc keyPart(x, start:int):(keyPartStatus, int) {
+     if start >= 1 then return (keyPartStatus.pre, 0:int);
      //writef("in intCriterion64(%016xu, %u)\n", x, start);
-     return (0:int, x);
+     return (keyPartStatus.returned, x);
    }
  }
- record intTupleCriterion {
+ record intTupleCriterion: keyPartComparator {
    inline
-   proc keyPart(x:2*int, start:int):(int, int) {
+   proc keyPart(x:2*int, start:int):(keyPartStatus, int) {
      if start >= 2 then
-       return (-1, 0);
+       return (keyPartStatus.pre, 0);
 
      //writef("in intTupleCriterion(%016xu %016xu %u)\n", x(1), x(2), start);
-     return (0, x(start));
+     return (keyPartStatus.returned, x(start));
    }
  }
- record stringCriterion {
+ record stringCriterion: keyPartComparator {
    inline
-   proc keyPart(x:string, start:int):(int(8), uint(8)) {
+   proc keyPart(x:string, start:int):(keyPartStatus, uint(8)) {
      var ptr = x.c_str():c_ptr(uint(8));
      var len = x.numBytes;
-     var section = if start < len then 0:int(8)     else -1:int(8);
-     var part =    if start < len then ptr[start]   else  0:uint(8);
+     var section = if start < len then keyPartStatus.returned else keyPartStatus.pre;
+     var part =    if start < len then ptr[start]             else 0:uint(8);
      return (section, part);
    }
  }

--- a/test/library/standard/Sort/errors/errors-keyPart.chpl
+++ b/test/library/standard/Sort/errors/errors-keyPart.chpl
@@ -22,26 +22,43 @@ proc main() {
 /* Broken keyPart */
 
 record str { }
+str implements keyPartComparator;
 
 proc str.keyPart(a, i) {
   return 'foobar';
 }
 
 
+record tStrStrDep { }
+
+proc tStrStrDep.keyPart(a, b) {
+  return ("a", "b");
+}
+
 record tStrStr { }
+tStrStr implements keyPartComparator;
 
 proc tStrStr.keyPart(a, b) {
   return ("a", "b");
 }
 
+// deprecation warning and error about uint instead of int
+record tUintIntDep { }
+
+proc tUintIntDep.keyPart(a, b) {
+  return (0:uint, 0);
+}
+
 record tUintInt { }
+tUintInt implements keyPartComparator;
 
 proc tUintInt.keyPart(a, b) {
   return (0:uint, 0);
 }
 
 record tIntReal { }
+tIntReal implements keyPartComparator;
 
 proc tIntReal.keyPart(a, b) {
-  return (0, 0.0);
+  return (keyPartStatus.returned, 0.0);
 }

--- a/test/library/standard/Sort/errors/errors-keyPart.compopts
+++ b/test/library/standard/Sort/errors/errors-keyPart.compopts
@@ -1,4 +1,6 @@
--scomparator=str      # errors-keyPart.str.good
--scomparator=tIntReal # errors-keyPart.tIntReal.good
--scomparator=tStrStr  # errors-keyPart.tStrStr.good
--scomparator=tUintInt # errors-keyPart.tUintInt.good
+-scomparator=str         # errors-keyPart.str.good
+-scomparator=tIntReal    # errors-keyPart.tIntReal.good
+-scomparator=tStrStr     # errors-keyPart.tStrStr.good
+-scomparator=tStrStrDep  # errors-keyPart.tStrStrDep.good
+-scomparator=tUintInt    # errors-keyPart.tUintInt.good
+-scomparator=tUintIntDep # errors-keyPart.tUintIntDep.good

--- a/test/library/standard/Sort/errors/errors-keyPart.tIntReal.good
+++ b/test/library/standard/Sort/errors/errors-keyPart.tIntReal.good
@@ -1,2 +1,2 @@
 errors-keyPart.chpl:9: In function 'main':
-errors-keyPart.chpl:17: error: The keyPart method in tIntReal must return a tuple with element 1 of type  int(?) or uint(?) when used with int(64) elements
+errors-keyPart.chpl:17: error: The keyPart method in tIntReal must return a tuple with element 1 of type int(?) or uint(?) when used with int(64) elements

--- a/test/library/standard/Sort/errors/errors-keyPart.tStrStr.good
+++ b/test/library/standard/Sort/errors/errors-keyPart.tStrStr.good
@@ -1,2 +1,2 @@
 errors-keyPart.chpl:9: In function 'main':
-errors-keyPart.chpl:17: error: The keyPart method in tStrStr must return a tuple with element 0 of type int(?) when used with int(64) elements
+errors-keyPart.chpl:17: error: The keyPart method in tStrStr must return a tuple with element 0 of type keyPartStatus when used with int(64) elements

--- a/test/library/standard/Sort/errors/errors-keyPart.tStrStrDep.good
+++ b/test/library/standard/Sort/errors/errors-keyPart.tStrStrDep.good
@@ -1,0 +1,3 @@
+errors-keyPart.chpl:9: In function 'main':
+errors-keyPart.chpl:17: warning: Defining a comparator with a 'keyPart' method without implementing the keyPartComparator interface is deprecated. Please implement the keyPartComparator interface (i.e. 'record tStrStrDep: keyPartComparator').
+errors-keyPart.chpl:17: error: The keyPart method in tStrStrDep must return a tuple with element 0 of type int(?) when used with int(64) elements

--- a/test/library/standard/Sort/errors/errors-keyPart.tUintInt.good
+++ b/test/library/standard/Sort/errors/errors-keyPart.tUintInt.good
@@ -1,2 +1,2 @@
 errors-keyPart.chpl:9: In function 'main':
-errors-keyPart.chpl:17: error: The keyPart method in tUintInt must return a tuple with element 0 of type int(?) when used with int(64) elements
+errors-keyPart.chpl:17: error: The keyPart method in tUintInt must return a tuple with element 0 of type keyPartStatus when used with int(64) elements

--- a/test/library/standard/Sort/errors/errors-keyPart.tUintIntDep.good
+++ b/test/library/standard/Sort/errors/errors-keyPart.tUintIntDep.good
@@ -1,0 +1,3 @@
+errors-keyPart.chpl:9: In function 'main':
+errors-keyPart.chpl:17: warning: Defining a comparator with a 'keyPart' method without implementing the keyPartComparator interface is deprecated. Please implement the keyPartComparator interface (i.e. 'record tUintIntDep: keyPartComparator').
+errors-keyPart.chpl:17: error: The keyPart method in tUintIntDep must return a tuple with element 0 of type int(?) when used with int(64) elements


### PR DESCRIPTION
Adds the `keyPartComparator` interface, which requires users to implement `proc keyPart` and optionally implement `proc compare`. Also adds the `keyPartStatus` enum, which replaces the 0th element of the tuple returned from `keyPart`

Adds `keyPartStatus` from https://github.com/chapel-lang/chapel/issues/25552
Implements `keyPartComparator` from https://github.com/chapel-lang/chapel/issues/25553

Testing
- [x] built and check docs
- [x] paratest with/without comm

Future work:
- this PR adds a number of TODOs that should be resolved when `relativeComparator` and `keyComparator` are added

[Reviewed by @lydia-duncan]