### PR TITLE
Optional compressor field for Zarr stores

### DIFF
--- a/modules/packages/Zarr.chpl
+++ b/modules/packages/Zarr.chpl
@@ -121,7 +121,7 @@ module Zarr {
     var r = openReader(metadataPath, deserializer = new jsonDeserializer(), locking=false);
     var mdRequired: zarrMetadataV2Required;
     r.readf("%?", mdRequired);
-    
+
     r.seek(0..);
     var mdOptional: zarrMetadataV2Optional;
     try {

--- a/modules/packages/Zarr.chpl
+++ b/modules/packages/Zarr.chpl
@@ -86,6 +86,17 @@ module Zarr {
     var compressor: string;
   }
 
+  record zarrMetadataV2Required {
+    var zarr_format: int;
+    var chunks: list(int);
+    var dtype: string;
+    var shape: list(int);
+  }
+
+  record zarrMetadataV2Optional {
+    var compressor: string;
+  }
+
   /* Unused until support is added for v3.0 stores */
   record zarrMetadataV3 {
     var zarr_format: int;
@@ -108,8 +119,18 @@ module Zarr {
   private proc getMetadata(directoryPath: string) throws {
     var metadataPath = joinPath(directoryPath, ".zarray");
     var r = openReader(metadataPath, deserializer = new jsonDeserializer(), locking=false);
-    var md: zarrMetadataV2;
-    r.readf("%?", md);
+    var mdRequired: zarrMetadataV2Required;
+    r.readf("%?", mdRequired);
+    
+    r.seek(0..);
+    var mdOptional: zarrMetadataV2Optional;
+    try {
+      r.readf("%?", mdOptional);
+    } catch {
+      mdOptional.compressor = "blosclz";
+    }
+
+    var md = new zarrMetadataV2(mdRequired.zarr_format, mdRequired.chunks, mdRequired.dtype, mdRequired.shape, mdOptional.compressor);
     return md;
   }
 

--- a/test/library/packages/Zarr/.gitignore
+++ b/test/library/packages/Zarr/.gitignore
@@ -9,4 +9,5 @@ c-blosc
 LocalIOStore_*
 TestLocal
 TestTargetLocale
+TestNoCompressorSpecified
 

--- a/test/library/packages/Zarr/CLEANFILES
+++ b/test/library/packages/Zarr/CLEANFILES
@@ -7,3 +7,4 @@ Test3D
 LocalIOStore_*
 TestLocal
 TestTargetLocale
+TestNoCompressorSpecified

--- a/test/library/packages/Zarr/ZarrCompressors.chpl
+++ b/test/library/packages/Zarr/ZarrCompressors.chpl
@@ -53,6 +53,27 @@ proc testUnsupportedCompressor() {
   
 }
 
+proc testNoCompressorSpecified() {
+  const configJson = '''
+    {
+      "zarr_format": 2,
+      "chunks": [5,8,12],
+      "shape": [10, 20, 30],
+      "dtype": "<f4"
+    }
+    ''';
+  
+  var A: [0..<10,0..<20,0..<30] real(32);
+  writeZarrArrayLocal("TestNoCompressorSpecified", A, (5,8,12));
+  var configFile = openWriter("TestNoCompressorSpecified/.zarray");
+  configFile.write(configJson);
+  configFile.close();
+
+  var B = readZarrArrayLocal("TestNoCompressorSpecified", real(32), 3);
+  forall i in A.domain do 
+    assert(A[i] == B[i], "Mismatch for real data on indices: %?.\nWritten: %?\nRead: %?".format(i, A[i], B[i]));
+}
+
 
 proc main() {
   var compressors = ["blosclz", "lz4", "lz4hc", "zlib", "zstd"];
@@ -62,5 +83,6 @@ proc main() {
     distributedTest(compressor);
   }
   testUnsupportedCompressor();
+  testNoCompressorSpecified();
   writeln("Pass");
 }


### PR DESCRIPTION
Removes the requirement that zarr metadata contain a "compressor" field. 

Tested locally and chapdl with comm none, locally with gasnet.

Reviewed by: