### PR TITLE
Co-locale tests don't require PCI to be enabled

### DIFF
--- a/test/runtime/jhh/colocales/colocales.py
+++ b/test/runtime/jhh/colocales/colocales.py
@@ -326,7 +326,6 @@ class Ex2Tests(TestCases.TestCase):
         output = self.runCmd("./colocales -r 0 -n 17")
         self.assertIn("warning: 9 cores are unused\n", output);
 
-@unittest.skip("requires --enable-pci")
 class Ex3Tests(TestCases.TestCase):
     """
     HPE Cray EX. One sockets, four NUMA domains per socket, 64 cores per


### PR DESCRIPTION
PCI must be enabled for `hwloc` to detect PCI devices, but it's not required when using `hwloc` topologies from XML files.