### PR TITLE
Stop manually building `chapel-py` in Arkouda nightly testing

### DIFF
--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -52,8 +52,6 @@ if [ -n "${CHPL_TEST_ARKOUDA_DISABLE_MODULES}" ] ; then
 fi
 
 # install frontend python bindings
-(cd $CHPL_HOME && make frontend-shared)
-(cd $CHPL_HOME/tools/chapel-py && python -m pip install .)
 (cd $CHPL_HOME && make chapel-py-venv)
 
 # Compile Arkouda


### PR DESCRIPTION
Remove manual build of chapel-py from arkouda's sub_test s.t. tests only rely on `make chapel-py-venv`.

All of our nightly configs appear to be working with the `chapel-py` install in chpl-venv, so manually building it should no longer be necessary.