### PR TITLE
Mark the Sort module as stable

### DIFF
--- a/modules/standard/Sort.chpl
+++ b/modules/standard/Sort.chpl
@@ -240,7 +240,6 @@ comparator to the initializer of the module-defined
   writeln(Array);
 
  */
-@unstable("The Sort module interface is unstable")
 module Sort {
 
   private use List;
@@ -3542,6 +3541,7 @@ private proc comparatorImplementsRelative(cmp) param do
 interface sortComparator { }
 
 /* Default comparator used in sort functions.*/
+@unstable("'DefaultComparator' is unstable and will have its name changed in the future")
 record DefaultComparator: keyPartComparator {
 
   /*
@@ -3856,6 +3856,7 @@ record DefaultComparator: keyPartComparator {
 }
 
 /* Reverse comparator built from another comparator.*/
+@unstable("'ReverseComparator' is unstable and will have its name changed in the future")
 record ReverseComparator: keyPartComparator {
 
   /* Generic comparator defined in initializer.*/

--- a/test/unstable/sortInterfaces.good
+++ b/test/unstable/sortInterfaces.good
@@ -1,4 +1,3 @@
-sortInterfaces.chpl:1: warning: The Sort module interface is unstable
 sortInterfaces.chpl:5: warning: keyPartComparator is not yet stable
 sortInterfaces.chpl:8: warning: sortComparator is not yet stable
 sortInterfaces.chpl:2: warning: relativeComparator is not yet stable

--- a/test/unstable/sortModule.chpl
+++ b/test/unstable/sortModule.chpl
@@ -1,1 +1,3 @@
 use Sort;
+Sort.DefaultComparator;
+Sort.ReverseComparator;

--- a/test/unstable/sortModule.good
+++ b/test/unstable/sortModule.good
@@ -1,1 +1,2 @@
-sortModule.chpl:1: warning: The Sort module interface is unstable
+sortModule.chpl:2: warning: 'DefaultComparator' is unstable and will have its name changed in the future
+sortModule.chpl:3: warning: 'ReverseComparator' is unstable and will have its name changed in the future

--- a/test/unstable/sortRegion.good
+++ b/test/unstable/sortRegion.good
@@ -1,2 +1,2 @@
-sortRegion.chpl:1: warning: The Sort module interface is unstable
+sortRegion.chpl:5: warning: 'DefaultComparator' is unstable and will have its name changed in the future
 sortRegion.chpl:5: warning: sort with a region argument is unstable


### PR DESCRIPTION
This PR marks the Sort module as a whole as stable. Any publicly visible symbols inside of the module are now considered stable, unless otherwise specified.

- [x] Tested with a full paratest with/without

[Reviewed by @lydia-duncan]