### PR TITLE
Add an index entry for init=

### DIFF
--- a/doc/rst/language/spec/records.rst
+++ b/doc/rst/language/spec/records.rst
@@ -454,6 +454,8 @@ Common Operations
 
 .. index::
    pair: records; copy initialization
+   single: init=
+
 .. _Copy_Initialization_of_Records:
 
 Copy Initialization of Records


### PR DESCRIPTION
@jeremiah-corrado pointed out that searching for `init=` does not lead to the appropriate spec section to describe the feature. This PR fixes that problem by adding an `.. index::` entry for `init=`.

Reviewed by @jeremiah-corrado - thanks!