### PR TITLE
Dyno: Implement super.init for generic classes

### DIFF
--- a/frontend/lib/resolution/InitResolver.cpp
+++ b/frontend/lib/resolution/InitResolver.cpp
@@ -82,6 +82,12 @@ bool InitResolver::setupFromType(const Type* type) {
   fieldToInitState_.clear();
   fieldIdsByOrdinal_.clear();
 
+  if (auto ct = type->toClassType()) {
+    if (auto bct = ct->basicClassType()) {
+      superType_ = bct->parentClassType();
+    }
+  }
+
   auto ct = type->getCompositeType();
   auto& rf = fieldsForTypeDecl(ctx_, ct, DefaultsPolicy::USE_DEFAULTS);
 
@@ -131,6 +137,7 @@ void InitResolver::copyState(InitResolver& other) {
   thisCompleteIds_ = other.thisCompleteIds_;
   isDescendingIntoAssignment_ = other.isDescendingIntoAssignment_;
   currentRecvType_ = other.currentRecvType_;
+  superType_ = other.superType_;
 }
 
 InitResolver::Phase InitResolver::getMaxPhase(Phase A, Phase B) {
@@ -253,6 +260,7 @@ bool InitResolver::isFinalReceiverStateValid(void) {
 
 static const Type* ctFromSubs(Context* context,
                               const Type* receiverType,
+                              const BasicClassType* superType,
                               const CompositeType* compositeType,
                               const CompositeType::SubstitutionsMap& subs) {
   auto root = compositeType->instantiatedFromCompositeType() ?
@@ -262,17 +270,22 @@ static const Type* ctFromSubs(Context* context,
   const Type* ret = nullptr;
 
   if (auto rec = receiverType->toRecordType()) {
+    auto instantatiatedFrom = subs.size() == 0 ? nullptr :
+                                                 root->toRecordType();
     ret = RecordType::get(context, rec->id(), rec->name(),
-                          root->toRecordType(),
+                          instantatiatedFrom,
                           subs);
   } else if (auto cls = receiverType->toClassType()) {
     auto oldBasic = cls->basicClassType();
     CHPL_ASSERT(oldBasic && "Not handled!");
 
+    auto instantatiatedFrom = subs.size() == 0 ? nullptr :
+                                                 root->toBasicClassType();
+
     auto basic = BasicClassType::get(context, oldBasic->id(),
                                      oldBasic->name(),
-                                     oldBasic->parentClassType(),
-                                     root->toBasicClassType(),
+                                     superType,
+                                     instantatiatedFrom,
                                      subs);
     auto manager = AnyOwnedType::get(context);
     auto dec = ClassTypeDecorator(ClassTypeDecorator::BORROWED_NONNIL);
@@ -296,7 +309,17 @@ const Type* InitResolver::computeReceiverTypeConsideringState(void) {
                                        DefaultsPolicy::USE_DEFAULTS);
   CompositeType::SubstitutionsMap subs;
 
-  if (!rfNoDefaults.isGeneric()) return currentRecvType_;
+  bool genericParent = superType_ && superType_->substitutions().size() != 0;
+
+  if (!rfNoDefaults.isGeneric()) {
+    if (genericParent) {
+      // Might need to update the parent of the initial receiver type after
+      // a super.init call
+      return ctFromSubs(ctx_, initialRecvType_, superType_, ctInitial, subs);
+    } else {
+      return currentRecvType_;
+    }
+  }
 
   auto isValidQtForSubstitutions = [this](const QualifiedType qt) {
     if (qt.isUnknown()) return false;
@@ -328,7 +351,7 @@ const Type* InitResolver::computeReceiverTypeConsideringState(void) {
         // substitutions from previous fields. If the composite type is
         // dependently typed, we might be able to compute defaults that
         // depend on these prior substitutions.
-        auto ctIntermediate = ctFromSubs(ctx_, initialRecvType_, ctInitial, subs);
+        auto ctIntermediate = ctFromSubs(ctx_, initialRecvType_, superType_, ctInitial, subs);
         auto& rfIntermediate = fieldsForTypeDecl(ctx_, ctIntermediate->getCompositeType(),
                                                  DefaultsPolicy::USE_DEFAULTS);
 
@@ -341,14 +364,13 @@ const Type* InitResolver::computeReceiverTypeConsideringState(void) {
     }
   }
 
-  if (subs.size() == 0) {
-    return currentRecvType_;
-  } else {
-    const Type* ret = ctFromSubs(ctx_, initialRecvType_, ctInitial, subs);
+  if (subs.size() != 0 || genericParent) {
+    const Type* ret = ctFromSubs(ctx_, initialRecvType_, superType_, ctInitial, subs);
     CHPL_ASSERT(ret);
     return ret;
+  } else {
+    return currentRecvType_;
   }
-
 }
 
 QualifiedType::Kind InitResolver::determineReceiverIntent(void) {
@@ -551,9 +573,35 @@ bool InitResolver::handleCallToThisComplete(const FnCall* node) {
   return true;
 }
 
-// TODO: Detect calls to super.
 bool InitResolver::handleCallToSuperInit(const FnCall* node,
                                          const CallResolutionResult* c) {
+  if (auto dot = node->calledExpression()->toDot()) {
+    if (auto ident = dot->receiver()->toIdentifier()) {
+      if (ident->name() == "super" && dot->field() == "init") {
+        auto& msc = c->mostSpecific().only();
+        auto superThis = msc.formalActualMap().byFormalIdx(0).formalType();
+
+        const BasicClassType* superType = nullptr;
+        if (auto ct = superThis.type()->toClassType()) {
+          superType = ct->basicClassType();
+        } else {
+          superType = superThis.type()->toBasicClassType();
+        }
+
+        this->superType_ = superType;
+
+        // Only update the current receiver if the parent was generic.
+        if (superType->instantiatedFromCompositeType() != nullptr) {
+          updateResolverVisibleReceiverType();
+        }
+
+        phase_ = PHASE_NEED_COMPLETE;
+
+        return true;
+      }
+    }
+  }
+
   return false;
 }
 

--- a/frontend/lib/resolution/InitResolver.h
+++ b/frontend/lib/resolution/InitResolver.h
@@ -64,6 +64,7 @@ class InitResolver {
   std::vector<ID> thisCompleteIds_;
   bool isDescendingIntoAssignment_ = false;
   const types::Type* currentRecvType_ = initialRecvType_;
+  const types::BasicClassType* superType_ = nullptr;
 
   InitResolver(Context* ctx, Resolver& visitor,
                const uast::Function* fn,

--- a/frontend/test/resolution/testInitSemantics.cpp
+++ b/frontend/test/resolution/testInitSemantics.cpp
@@ -1313,17 +1313,23 @@ static void testInheritance() {
           super.init(A);
           this.B = B;
         }
+
+        proc helper() { return "test"; }
       }
 
       var x = new Child(int, string);
+      var y = x.helper();
     )""";
 
-    auto vars = resolveTypesOfVariables(context, program, {"x"});
+    auto vars = resolveTypesOfVariables(context, program, {"x", "y"});
     auto x = vars["x"];
+    auto y = vars["y"];
 
     std::stringstream ss;
     x.type()->stringify(ss, chpl::StringifyKind::CHPL_SYNTAX);
     assert(ss.str() == "owned Child(int(64), string)");
+
+    assert(y.type()->isStringType());
   }
 
   // Generic parent, concrete child

--- a/frontend/test/resolution/testInitSemantics.cpp
+++ b/frontend/test/resolution/testInitSemantics.cpp
@@ -1165,8 +1165,6 @@ static void testInitEqOther(void) {
 }
 
 static void testInheritance() {
-  // TODO: generics
-
   std::string parentChild = R"""(
     class Parent {
       var x : int;
@@ -1297,6 +1295,65 @@ static void testInheritance() {
     std::ignore = resolveModule(context, m->id());
   }
 
+  // Basic generic case
+  {
+    Context ctx;
+    Context* context = &ctx;
+    ErrorGuard guard(context);
+
+    std::string program = R"""(
+      class Parent {
+        type A;
+      }
+
+      class Child : Parent {
+        type B;
+
+        proc init(type A, type B) {
+          super.init(A);
+          this.B = B;
+        }
+      }
+
+      var x = new Child(int, string);
+    )""";
+
+    auto vars = resolveTypesOfVariables(context, program, {"x"});
+    auto x = vars["x"];
+
+    std::stringstream ss;
+    x.type()->stringify(ss, chpl::StringifyKind::CHPL_SYNTAX);
+    assert(ss.str() == "owned Child(int(64), string)");
+  }
+
+  // Generic parent, concrete child
+  {
+    Context ctx;
+    Context* context = &ctx;
+    ErrorGuard guard(context);
+
+    std::string program = R"""(
+      class Parent {
+        type A;
+      }
+
+      class Child : Parent {
+
+        proc init(type A) {
+          super.init(A);
+        }
+      }
+
+      var x = new Child(int);
+    )""";
+
+    auto vars = resolveTypesOfVariables(context, program, {"x"});
+    auto x = vars["x"];
+
+    std::stringstream ss;
+    x.type()->stringify(ss, chpl::StringifyKind::CHPL_SYNTAX);
+    assert(ss.str() == "owned Child(int(64))");
+  }
 }
 
 static void testInitGenericAfterConcrete() {


### PR DESCRIPTION
This PR improves the resolution of initializers to handle super.init calls involving generic classes. The core improvement is to have ``InitResolver`` store the parent's type, and update that type after a call to super.init. With an accurate parent type ``InitResolver`` can use that when it incrementally recomputes the current receiver type as fields are initialized.

Testing:
- [x] test-dyno