### PR TITLE
Fix Image module compilation on 32 bit systems

### DIFF
--- a/modules/packages/Image.chpl
+++ b/modules/packages/Image.chpl
@@ -553,7 +553,7 @@ module Image {
       const width = cols;
       const height = rows;
       const nBytes = width * height * mode;
-      var data = allocate(uint(8), nBytes);
+      var data = allocate(uint(8), nBytes.safeCast(c_size_t));
       forall idx in 0..<(rows*cols) {
         const (i,j) = dom.orderToIndex(idx);
         const offset = idx * mode;


### PR DESCRIPTION
Fixes a issue where the Image module failed to compile on 32 bit systems due to a type mismatch

Spot checked `test/library/packages/Image/downSample.chpl` and `test/library/packages/Image/basicJpg.chpl` on a 32 bit system

[Reviewed by @DanilaFe]