### PR TITLE
Dyno: Clean up usage of postOrderId numbers

### DIFF
--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -1261,9 +1261,8 @@ AstTag idToTag(Context* context, ID id) {
 }
 
 bool idIsModule(Context* context, ID id) {
-  if (id.postOrderId() >= 0) {
-    // it can't possibly be a module if it's got a positive post-order ID
-    // since all modules have post-order ID -1
+  if (!id.isSymbolDefiningScope()) {
+    // it can't possibly be a module if it doesn't define a scope
     return false;
   }
   AstTag tag = idToTag(context, id);
@@ -1304,7 +1303,7 @@ bool idIsFunction(Context* context, ID id) {
   // Functions always have their own ID symbol scope,
   // and if it's not a function, we can return false
   // without doing further work.
-  if (id.postOrderId() != -1) {
+  if (!id.isSymbolDefiningScope()) {
     return false;
   }
 

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1804,7 +1804,7 @@ void Resolver::adjustTypesForSplitInit(ID id,
   // what variable does the LHS refer to? is it within the purview of this
   // Resolver?
   bool useLocalResult = (id.symbolPath() == symbol->id().symbolPath() &&
-                         id.postOrderId() >= 0);
+                         !id.isSymbolDefiningScope());
 
   // if the the lhs variable has not been initialized and
   // the type of LHS is generic or unknown, update it based on the RHS type.
@@ -2329,7 +2329,7 @@ QualifiedType Resolver::typeForId(const ID& id, bool localGenericToUnknown) {
   }
 
   bool useLocalResult = (id.symbolPath() == symbol->id().symbolPath() &&
-                         id.postOrderId() >= 0);
+                         !id.isSymbolDefiningScope());
   bool error = false;
   if (useLocalResult && curStmt != nullptr) {
     if (curStmt->id().contains(id)) {
@@ -3301,7 +3301,7 @@ static bool shouldUseGenericTypeForTypeExpr(const NamedDecl* decl) {
 
 bool Resolver::enter(const NamedDecl* decl) {
 
-  if (decl->id().postOrderId() < 0) {
+  if (decl->id().isSymbolDefiningScope()) {
     // It's a symbol with a different path, e.g. a Function.
     // Don't try to resolve it now in this
     // traversal. Instead, resolve it e.g. when the function is called.

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -65,7 +65,7 @@ const ResolutionResultByPostorderID& resolveModuleStmt(Context* context,
     return std::make_pair(std::get<0>(args), "resolving this module statement");
   );
 
-  CHPL_ASSERT(id.postOrderId() >= 0);
+  CHPL_ASSERT(!id.isSymbolDefiningScope());
 
   ResolutionResultByPostorderID result;
 
@@ -89,7 +89,7 @@ static const ResolutionResultByPostorderID&
 scopeResolveModuleStmt(Context* context, ID id) {
   QUERY_BEGIN(scopeResolveModuleStmt, context, id);
 
-  CHPL_ASSERT(id.postOrderId() >= 0);
+  CHPL_ASSERT(!id.isSymbolDefiningScope());
 
   // TODO: can we save space better here by having
   // the ResolutionResultByPostorderID have a different offset
@@ -250,8 +250,7 @@ const QualifiedType& typeForModuleLevelSymbol(Context* context, ID id,
 
   QualifiedType result;
 
-  int postOrderId = id.postOrderId();
-  if (postOrderId >= 0) {
+  if (!id.isSymbolDefiningScope()) {
     // 'typeForModuleLevelSymbol' can be called with an 'id' corresponding to a
     // variable declared as part of a MultiDecl or TupleDecl. Using that 'id'
     // with 'resolveModuleStmt' will return a bogus result because that 'id'


### PR DESCRIPTION
Do not compare postOrderIds to specific integer values. Instead, use the method ``ID::isSymbolDefiningScope()``.

Testing:
- [x] test-dyno