### PR TITLE
Dyno: Fix scope resolution bug for type constructors and private-use

### DIFF
--- a/frontend/include/chpl/uast/Builder.h
+++ b/frontend/include/chpl/uast/Builder.h
@@ -77,7 +77,7 @@ class Builder final {
   // These are removed in the astToLocation_ map.
   AstLocMap notedLocations_;
 
-  bool generatedCode_ = false;
+  ID generatedFrom_;
 
   // These map AST to additional locations while the builder is building.
   // This is an equivalent to notedLocations for the additional locations.
@@ -91,10 +91,12 @@ class Builder final {
 
   Builder(Context* context, UniqueString filePath,
           UniqueString startingSymbolPath,
-          const libraries::LibraryFile* lib)
+          const libraries::LibraryFile* lib,
+          ID generatedFrom = ID())
     : context_(context),
       startingSymbolPath_(startingSymbolPath),
-      br(filePath, lib)
+      br(filePath, lib, generatedFrom),
+      generatedFrom_(generatedFrom)
   {
   }
 
@@ -108,6 +110,8 @@ class Builder final {
   void tryNoteAdditionalLocation(AstLocMap& m, AstNode* ast, Location loc);
   void copyAdditionalLocation(AstLocMap& m, const AstNode* from, const AstNode* to);
   void deleteAdditionalLocation(AstLocMap& m, const AstNode* ast);
+
+  bool isGenerated() { return !generatedFrom_.isEmpty(); }
 
  public:
   /** Construct a Builder for parsing a top-level module */
@@ -124,6 +128,7 @@ class Builder final {
 
   static owned<Builder> createForGeneratedCode(Context* context,
                                                const char* filepath,
+                                               ID generatedFrom,
                                                UniqueString parentSymbolPath);
 
   /** Construct a Builder for use when reading uAST from a library file. */

--- a/frontend/include/chpl/uast/BuilderResult.h
+++ b/frontend/include/chpl/uast/BuilderResult.h
@@ -142,6 +142,8 @@ class BuilderResult final {
   // but only for modules & symbols stored in the symbol table
   llvm::DenseMap<ID, std::pair<int,int>> libraryFileSymbols_;
 
+  ID generatedFrom_;
+
   // For use with library files.
   // Returns the module index & symbol index for the symbol
   // containing the passed ID.
@@ -159,10 +161,14 @@ class BuilderResult final {
  public:
   /** Construct an empty BuilderResult */
   BuilderResult();
-  /** Construct a BuilderResult that records a particular file path,
-      and optionally refers to a LibraryFile. */
+  /** Construct a BuilderResult that records a particular file path.
+      Optional arguments include:
+        - a LibraryFile to refer to in place of a file
+        - an ID from which this uAST was generated
+      */
   BuilderResult(UniqueString filePath,
-                const libraries::LibraryFile* lib = nullptr);
+                const libraries::LibraryFile* lib = nullptr,
+                ID generatedFrom = ID());
 
   /** Return the file path this result refers to */
   UniqueString filePath() const {

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -1446,22 +1446,8 @@ buildTypeConstructor(Context* context, const CompositeType* t,
                      std::vector<const Variable*>& fieldAsts) {
   auto parentMod = parsing::idToParentModule(context, id);
   auto modName = "chpl__generated_" + parentMod.symbolName(context).str() + "_" + name.str();
-  auto builder = Builder::createForGeneratedCode(context, modName.c_str(), parentMod.symbolPath());
+  auto builder = Builder::createForGeneratedCode(context, modName.c_str(), parentMod, parentMod.symbolPath());
   auto dummyLoc = parsing::locateId(context, id);
-
-  // Add a top-level 'use' of the module containing the type being constructed.
-  // This exists to support fields that reference other types in that module.
-  {
-    auto useName = parentMod.symbolName(context);
-    auto ident = Identifier::build(builder.get(), dummyLoc, useName);
-    auto vis = VisibilityClause::build(builder.get(), dummyLoc, std::move(ident));
-
-    AstList alist;
-    alist.push_back(std::move(vis));
-    auto useStmt = Use::build(builder.get(), dummyLoc,
-                              Decl::DEFAULT_VISIBILITY, std::move(alist));
-    builder->addToplevelExpression(std::move(useStmt));
-  }
 
   // Build formals of type constructor
   AstList formalAst;

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -1384,7 +1384,10 @@ bool LookupHelper::doLookupInScope(const Scope* scope,
            cur != nullptr;
            cur = nextHigherScope(context, cur)) {
 
-        if (asttags::isModule(cur->tag()) && !goPastModules) {
+        // Allow searching past compiler-generated modules, to pretend like
+        // they are children of the module from which they originated.
+        if (asttags::isModule(cur->tag()) && !goPastModules &&
+            !cur->id().isFabricatedId()) {
           reachedModule = true;
           break;
         }

--- a/frontend/lib/uast/Builder.cpp
+++ b/frontend/lib/uast/Builder.cpp
@@ -121,11 +121,12 @@ owned<Builder> Builder::createForIncludedModule(Context* context,
 
 owned<Builder> Builder::createForGeneratedCode(Context* context,
                                                const char* filepath,
+                                               ID generatedFrom,
                                                UniqueString parentSymbolPath) {
   auto uniqueFilename = UniqueString::get(context, filepath);
   auto b = new Builder(context, uniqueFilename, parentSymbolPath,
-                       /* LibraryFile */ nullptr);
-  b->generatedCode_ = true;
+                       /* LibraryFile */ nullptr,
+                       generatedFrom);
   return toOwned(b);
 }
 
@@ -488,7 +489,7 @@ void Builder::doAssignIDs(AstNode* ast, UniqueString symbolPath, int& i,
     }
 
     int numContainedIds = freshId;
-    int postOrderId = this->generatedCode_ ? -3 : -1;
+    int postOrderId = this->isGenerated() ? -3 : -1;
     ast->setID(ID(newSymbolPath, postOrderId, numContainedIds));
 
     // Note: when creating a new symbol (e.g. fn), we're not incrementing i.
@@ -510,7 +511,7 @@ void Builder::doAssignIDs(AstNode* ast, UniqueString symbolPath, int& i,
     }
 
     int afterChildID = i;
-    int myID = this->generatedCode_ ? -4 - afterChildID : afterChildID;
+    int myID = this->isGenerated() ? -4 - afterChildID : afterChildID;
     i++; // count the ID for the node we are currently visiting
     int numContainedIDs = afterChildID - firstChildID;
     ast->setID(ID(symbolPath, myID, numContainedIDs));

--- a/frontend/lib/uast/BuilderResult.cpp
+++ b/frontend/lib/uast/BuilderResult.cpp
@@ -120,6 +120,11 @@ bool BuilderResult::update(BuilderResult& keep, BuilderResult& addin) {
     computeIdMaps(ast.get(), nullptr, newIdToAst, newIdToParent);
   }
 
+  if (!addin.generatedFrom_.isEmpty()) {
+    // Assumption: single top-level expression that is a module
+    newIdToParent[keep.topLevelExpression(0)->id()] = addin.generatedFrom_;
+  }
+
   // now update the ID and Locations maps in keep
   changed |= defaultUpdate(keep.idToAst_, newIdToAst);
   changed |= defaultUpdate(keep.idToParentId_, newIdToParent);

--- a/frontend/lib/uast/BuilderResult.cpp
+++ b/frontend/lib/uast/BuilderResult.cpp
@@ -44,8 +44,9 @@ BuilderResult::BuilderResult()
 
 
 BuilderResult::BuilderResult(UniqueString filePath,
-                             const libraries::LibraryFile* lib)
-  : filePath_(filePath), libraryFile_(lib)
+                             const libraries::LibraryFile* lib,
+                             ID generatedFrom)
+  : filePath_(filePath), libraryFile_(lib), generatedFrom_(generatedFrom)
 {
 }
 
@@ -98,6 +99,7 @@ void BuilderResult::swap(BuilderResult& other) {
 
   std::swap(libraryFile_, other.libraryFile_);
   libraryFileSymbols_.swap(other.libraryFileSymbols_);
+  generatedFrom_.swap(other.generatedFrom_);
 }
 
 bool BuilderResult::update(BuilderResult& keep, BuilderResult& addin) {
@@ -136,6 +138,7 @@ bool BuilderResult::update(BuilderResult& keep, BuilderResult& addin) {
                            addin.commentIdToLocation_);
   changed |= defaultUpdateBasic(keep.libraryFile_, addin.libraryFile_);
   changed |= defaultUpdate(keep.libraryFileSymbols_, addin.libraryFileSymbols_);
+  changed |= defaultUpdate(keep.generatedFrom_, addin.generatedFrom_);
 
   return changed;
 }
@@ -184,6 +187,8 @@ void BuilderResult::mark(Context* context) const {
 
   // libraryFileSymbols_ only has IDs that should have been marked above
   (void) libraryFileSymbols_;
+
+  generatedFrom_.mark(context);
 
   // update the filePathForModuleName query
   BuilderResult::updateFilePaths(context, *this);


### PR DESCRIPTION
Modifies the idToParentId map of a BuilderResult to point to the module ID from which the compiler-generated module was created.

In the scope query logic, we then reject a compiler-generated module as a boundary for lookups, and allow the logic to proceed as though the compiler-generated module lived within the original code.

The implementation of Builder/BuilderResult is updated to better support these changes.

Also, a new test is added to lock in the correct behavior.

Testing:
- [x] test-dyno