### PR TITLE
Fix allocator tests when running on linux32

### DIFF
--- a/test/library/standard/Allocators/bumpAlignment.chpl
+++ b/test/library/standard/Allocators/bumpAlignment.chpl
@@ -9,7 +9,7 @@ proc test(param alignment) {
   var pool = new bumpPtrMemPool(10_000, alignment=alignment);
   for 1..10 {
     var p = newWithAllocator(pool, unmanaged C);
-    assert(c_ptrTo(p):int % alignment == 0);
+    assert(c_ptrTo(p):c_intptr % alignment:c_intptr == 0);
   }
 }
 
@@ -18,7 +18,7 @@ proc testParallel(param alignment) {
   var pool = new bumpPtrMemPool(100_000, alignment=alignment, parSafe=true);
   coforall 1..30 {
     var p = newWithAllocator(pool, unmanaged C);
-    assert(c_ptrTo(p):int % alignment == 0);
+    assert(c_ptrTo(p):c_intptr % alignment:c_intptr == 0);
   }
 }
 

--- a/test/library/standard/Allocators/customAllocator.32.good
+++ b/test/library/standard/Allocators/customAllocator.32.good
@@ -1,0 +1,5 @@
+allocated n=12
+allocated n=12
+{x = 1} {x = 2}
+deallocated
+deallocated

--- a/test/library/standard/Allocators/customAllocator.execopts
+++ b/test/library/standard/Allocators/customAllocator.execopts
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+tgt_platform=$($CHPL_HOME/env/printchplenv --value --only CHPL_TARGET_PLATFORM)
+
+# if linux32, use the linux32 good file
+if [ "$tgt_platform" == "linux32" ]; then
+  echo " # customAllocator.32.good"
+else
+  echo " # customAllocator.good"
+fi

--- a/test/library/standard/Allocators/customAllocatorClass.32.good
+++ b/test/library/standard/Allocators/customAllocatorClass.32.good
@@ -1,0 +1,5 @@
+allocated n=12
+allocated n=12
+{x = 1} {x = 2}
+deallocated
+deallocated

--- a/test/library/standard/Allocators/customAllocatorClass.execopts
+++ b/test/library/standard/Allocators/customAllocatorClass.execopts
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+tgt_platform=$($CHPL_HOME/env/printchplenv --value --only CHPL_TARGET_PLATFORM)
+
+# if linux32, use the linux32 good file
+if [ "$tgt_platform" == "linux32" ]; then
+  echo " # customAllocatorClass.32.good"
+else
+  echo " # customAllocatorClass.good"
+fi

--- a/test/studies/shootout/binary-trees/binarytrees-pool.chpl
+++ b/test/studies/shootout/binary-trees/binarytrees-pool.chpl
@@ -9,7 +9,7 @@
 use Allocators;
 
 config const n = 10,         // the maximum tree depth
-             globalPoolSize = 2 ** 32,
+             globalPoolSize = (2 ** 31)-1,
              localPoolSize = globalPoolSize;
 
 var globalPool = new bumpPtrMemPool(globalPoolSize, alignment=0);


### PR DESCRIPTION
Fixes tests for custom allocators to be compatible for linux32 as well.

- [x] Validated test changes

[Reviewed by @mppf]