### PR TITLE
Fix config names for darwin-arm tests

### DIFF
--- a/util/cron/test-darwin-arm.bash
+++ b/util/cron/test-darwin-arm.bash
@@ -7,6 +7,6 @@ source $CWD/common.bash
 source $CWD/common-darwin.bash
 source $CWD/common-localnode-paratest.bash
 
-export CHPL_NIGHTLY_TEST_CONFIG_NAME="darwin-m1"
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="darwin-arm"
 
 $CWD/nightly -cron $(get_nightly_paratest_args)

--- a/util/cron/test-darwin-arm.bash
+++ b/util/cron/test-darwin-arm.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Test full suite for default configuration on M1 darwin
+# Test full suite for default configuration on ARM darwin
 
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common.bash

--- a/util/cron/test-gasnet.darwin-arm.bash
+++ b/util/cron/test-gasnet.darwin-arm.bash
@@ -7,6 +7,6 @@ source $CWD/common-gasnet.bash
 source $CWD/common-darwin.bash
 source $CWD/common-localnode-paratest.bash
 
-export CHPL_NIGHTLY_TEST_CONFIG_NAME="gasnet.darwin-m1"
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="gasnet.darwin-arm"
 
 $CWD/nightly -cron -multilocale $(get_nightly_paratest_args)

--- a/util/cron/test-gasnet.darwin-arm.bash
+++ b/util/cron/test-gasnet.darwin-arm.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Test gasnet (segment everything) against multilocale tests
+# Test gasnet (segment everything) against multilocale tests on ARM Darwin
 
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common-gasnet.bash


### PR DESCRIPTION
Follow up to https://github.com/chapel-lang/chapel/pull/25835 in which I forgot to update the config names 🤦 .

[trivial fix, not reviewed]