### PR TITLE
Dyno: Implement param enum-to-string casts and fix param enum stringify

### DIFF
--- a/doc/util/nitpick_ignore
+++ b/doc/util/nitpick_ignore
@@ -55,6 +55,7 @@ cpp:identifier ParamTag
 cpp:identifier PragmaTag
 cpp:identifier TypeTag
 cpp:identifier PrimitiveTag
+cpp:identifier EnumParam
 cpp:identifier chpl::uast::PrimitiveTag
 cpp:identifier types::RealParam
 cpp:identifier types::IntParam

--- a/frontend/include/chpl/types/Param.h
+++ b/frontend/include/chpl/types/Param.h
@@ -77,7 +77,23 @@ class Param {
       return 0;
     }
   };
-  using EnumValue = std::pair<ID, std::string>;
+  struct EnumValue {
+    ID id;
+    std::string str;
+
+    EnumValue(ID id, std::string str)
+      : id(id), str(str)
+    { }
+    bool operator==(const EnumValue& other) const {
+      return this->id == other.id && this->str == other.str;
+    }
+    bool operator!=(const EnumValue& other) const {
+      return !(*this == other);
+    }
+    size_t hash() const {
+      return chpl::hash(id, str);
+    }
+  };
 
  private:
   ParamTag tag_;
@@ -116,7 +132,7 @@ class Param {
     return "none";
   }
   static std::string valueToString(EnumValue v) {
-    return v.second;
+    return v.str;
   }
   static std::string valueToString(bool v) {
     return v ? "true" : "false";
@@ -286,10 +302,10 @@ template<> struct stringify<chpl::types::Param::EnumValue> {
                   chpl::StringifyKind stringKind,
                   const chpl::types::Param::EnumValue& stringMe) const {
     if (stringKind == chpl::StringifyKind::CHPL_SYNTAX) {
-      streamOut << stringMe.second;
+      streamOut << stringMe.str;
     } else {
-      streamOut << stringMe.second;
-      streamOut << " (" << stringMe.first.str() << ")";
+      streamOut << stringMe.str;
+      streamOut << " (" << stringMe.id.str() << ")";
     }
   }
 };
@@ -323,8 +339,8 @@ template<> struct deserialize<types::Param::NoneValue> {
 
 template<> struct serialize<types::Param::EnumValue> {
   void operator()(Serializer& ser, types::Param::EnumValue val) const {
-    ser.write(val.first);
-    ser.write(val.second);
+    ser.write(val.id);
+    ser.write(val.str);
   }
 };
 
@@ -332,7 +348,7 @@ template<> struct deserialize<types::Param::EnumValue> {
   types::Param::EnumValue operator()(Deserializer& des) {
     auto id = des.read<ID>();
     auto str = des.read<std::string>();
-    return std::make_pair(id, str);
+    return types::Param::EnumValue(id, str);
   }
 };
 
@@ -349,6 +365,11 @@ namespace std {
   };
   template<> struct hash<chpl::types::Param::NoneValue> {
     size_t operator()(const chpl::types::Param::NoneValue key) const {
+      return key.hash();
+    }
+  };
+  template<> struct hash<chpl::types::Param::EnumValue> {
+    size_t operator()(const chpl::types::Param::EnumValue key) const {
       return key.hash();
     }
   };

--- a/frontend/include/chpl/types/param-classes-list.h
+++ b/frontend/include/chpl/types/param-classes-list.h
@@ -27,7 +27,7 @@
 
 PARAM_NODE(BoolParam, bool)
 PARAM_NODE(ComplexParam, ComplexDouble)
-PARAM_NODE(EnumParam, ID)
+PARAM_NODE(EnumParam, EnumValue)
 PARAM_NODE(IntParam, int64_t)
 PARAM_NODE(NoneParam, NoneValue)
 PARAM_NODE(RealParam, double)

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -4433,9 +4433,7 @@ resolveIterTypeWithTag(Resolver& rv,
     // The iterand is an unresolved call, or it is a resolved iterator but
     // not the one that we need. Regather existing actuals and reuse the
     // receiver if it is present.
-    } else {
-      auto call = iterand->toCall();
-      CHPL_ASSERT(call);
+    } else if (auto call = iterand->toCall()) {
 
       bool raiseErrors = false;
       auto tmp = CallInfo::create(context, call, rv.byPostorder, raiseErrors);
@@ -4445,6 +4443,9 @@ resolveIterTypeWithTag(Resolver& rv,
       callIsMethodCall = tmp.isMethodCall();
       callIsParenless = tmp.isParenless();
       for (auto& a : tmp.actuals()) callActuals.push_back(a);
+    } else {
+      CHPL_UNIMPL("unknown iterand");
+      return error;
     }
 
     if (!needSerial) {

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -3886,7 +3886,7 @@ Resolver::typeForScopeResolvedEnumElement(const EnumType* enumType,
                                           bool ambiguous) {
   if (!refersToId.isEmpty()) {
     // Found a single enum element, the type can be a param.
-    auto newParam = EnumParam::get(context, refersToId);
+    auto newParam = Param::getEnumParam(context, refersToId);
     return QualifiedType(QualifiedType::PARAM, enumType, newParam);
   } else if (ambiguous) {
     // multiple candidates. but the expression most likely has a type given by

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -3590,6 +3590,17 @@ static bool resolveFnCallSpecial(Context* context,
     if (isParamTypeCast) {
         auto srcEnumType = src.type()->toEnumType();
         auto dstEnumType = dst.type()->toEnumType();
+
+        if (srcEnumType && dst.type()->isStringType()) {
+          std::ostringstream oss;
+          src.param()->stringify(oss, chpl::StringifyKind::CHPL_SYNTAX);
+          auto ustr = UniqueString::get(context, oss.str());
+          exprTypeOut = QualifiedType(QualifiedType::PARAM,
+                                      RecordType::getStringType(context),
+                                      StringParam::get(context, ustr));
+          return true;
+        }
+
         if (srcEnumType && srcEnumType->isAbstract()) {
           exprTypeOut = CHPL_TYPE_ERROR(context, EnumAbstract, astForErr, "from", srcEnumType, dst.type());
           return true;

--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -884,7 +884,7 @@ static bool helpComputeOrderToEnumReturnType(Context* context,
     uint64_t counter = 0;
     for (auto elem : ast->enumElements()) {
       if (counter == whichValue) {
-        param = EnumParam::get(context, elem->id());
+        param = Param::getEnumParam(context, elem->id());
         break;
       }
       counter++;
@@ -920,7 +920,7 @@ static bool helpComputeEnumToOrderReturnType(Context* context,
       parsing::idToAst(context, et->id())->toEnum();
     int counter = 0;
     for (auto elem : ast->enumElements()) {
-      if (elem->id() == inputParam->value()) {
+      if (elem->id() == inputParam->value().first) {
         param = IntParam::get(context, counter);
         break;
       }

--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -920,7 +920,7 @@ static bool helpComputeEnumToOrderReturnType(Context* context,
       parsing::idToAst(context, et->id())->toEnum();
     int counter = 0;
     for (auto elem : ast->enumElements()) {
-      if (elem->id() == inputParam->value().first) {
+      if (elem->id() == inputParam->value().id) {
         param = IntParam::get(context, counter);
         break;
       }

--- a/frontend/lib/types/EnumType.cpp
+++ b/frontend/lib/types/EnumType.cpp
@@ -78,7 +78,7 @@ getParamConstantsMapQuery(Context* context, const EnumType* et) {
   auto ast = parsing::idToAst(context, et->id());
   if (auto e = ast->toEnum()) {
     for (auto elem : e->enumElements()) {
-      auto param = EnumParam::get(context, elem->id());
+      auto param = Param::getEnumParam(context, elem->id());
       auto k = UniqueString::get(context, elem->name().str());
       QualifiedType v(QualifiedType::PARAM, et, param);
       ret.insert({std::move(k), std::move(v)});

--- a/frontend/lib/types/Param.cpp
+++ b/frontend/lib/types/Param.cpp
@@ -212,10 +212,10 @@ optional<Immediate> paramToImmediate(Context* context,
 
         if (ep) {
           auto numericValueOpt =
-            computeNumericValueOfEnumElement(context, ep->value().first);
+            computeNumericValueOfEnumElement(context, ep->value().id);
 
           if (!numericValueOpt) {
-            auto eltAst = parsing::idToAst(context, ep->value().first)->toEnumElement();
+            auto eltAst = parsing::idToAst(context, ep->value().id)->toEnumElement();
             auto qt = CHPL_TYPE_ERROR(context, EnumValueAbstract, astForErr, et, eltAst);
 
             // In order to be able to compose multiple calls to this function,
@@ -948,7 +948,8 @@ IMPLEMENT_DUMP(Param);
 
 const EnumParam* Param::getEnumParam(Context* context, ID id) {
   auto ast = parsing::idToAst(context, id)->toEnumElement();
-  auto value = std::make_pair(id, ast->name().str());
+  CHPL_ASSERT(ast && "expecting EnumElement");
+  auto value = EnumValue(id, ast->name().str());
   return EnumParam::get(context, value);
 }
 

--- a/frontend/lib/types/Param.cpp
+++ b/frontend/lib/types/Param.cpp
@@ -212,10 +212,10 @@ optional<Immediate> paramToImmediate(Context* context,
 
         if (ep) {
           auto numericValueOpt =
-            computeNumericValueOfEnumElement(context, ep->value());
+            computeNumericValueOfEnumElement(context, ep->value().first);
 
           if (!numericValueOpt) {
-            auto eltAst = parsing::idToAst(context, ep->value())->toEnumElement();
+            auto eltAst = parsing::idToAst(context, ep->value().first)->toEnumElement();
             auto qt = CHPL_TYPE_ERROR(context, EnumValueAbstract, astForErr, et, eltAst);
 
             // In order to be able to compose multiple calls to this function,
@@ -482,7 +482,7 @@ static QualifiedType enumParamFromNumericValue(Context* context,
     if (elemId) {
       return QualifiedType(QualifiedType::PARAM,
                            enumType,
-                           EnumParam::get(context, elemId));
+                           Param::getEnumParam(context, elemId));
     } else {
       return CHPL_TYPE_ERROR(context, NoMatchingEnumValue,
                              astForErr, enumType, numericValue);
@@ -946,6 +946,11 @@ IMPLEMENT_DUMP(Param);
 // clear the macros
 #undef PARAM_NODE
 
+const EnumParam* Param::getEnumParam(Context* context, ID id) {
+  auto ast = parsing::idToAst(context, id)->toEnumElement();
+  auto value = std::make_pair(id, ast->name().str());
+  return EnumParam::get(context, value);
+}
 
 } // end namespace types
 } // end namespace chpl

--- a/frontend/test/resolution/testEnums.cpp
+++ b/frontend/test/resolution/testEnums.cpp
@@ -45,10 +45,10 @@ static void test1() {
 
   auto et = qt.type()->toEnumType();
   auto ep = qt.param()->toEnumParam();
-  assert(et->id().contains(ep->value().first));
+  assert(et->id().contains(ep->value().id));
   auto enumAst = parsing::idToAst(context, et->id());
   assert(enumAst && enumAst->isEnum());
-  auto elemAst = parsing::idToAst(context, ep->value().first);
+  auto elemAst = parsing::idToAst(context, ep->value().id);
   assert(elemAst && elemAst->isEnumElement());
 }
 
@@ -366,11 +366,11 @@ static void test11() {
 
   auto param0 = vars.at("a").param();
   assert(param0 && param0->isEnumParam());
-  assert(param0->toEnumParam()->value().first.postOrderId() == 1);
+  assert(param0->toEnumParam()->value().id.postOrderId() == 1);
 
   auto param1 = vars.at("b").param();
   assert(param1 && param1->isEnumParam());
-  assert(param1->toEnumParam()->value().first.postOrderId() == 5);
+  assert(param1->toEnumParam()->value().id.postOrderId() == 5);
 }
 
 static void test12() {
@@ -579,22 +579,22 @@ static void test17() {
   assert(vars.at("c").type()->isEnumType());
   assert(vars.at("c").param());
   assert(vars.at("c").param()->isEnumParam());
-  assert(vars.at("c").param()->toEnumParam()->value().first.postOrderId() == 0);
+  assert(vars.at("c").param()->toEnumParam()->value().id.postOrderId() == 0);
   assert(vars.at("d").type());
   assert(vars.at("d").type()->isEnumType());
   assert(vars.at("d").param());
   assert(vars.at("d").param()->isEnumParam());
-  assert(vars.at("d").param()->toEnumParam()->value().first.postOrderId() == 0);
+  assert(vars.at("d").param()->toEnumParam()->value().id.postOrderId() == 0);
   assert(vars.at("e").type());
   assert(vars.at("e").type()->isEnumType());
   assert(vars.at("e").param());
   assert(vars.at("e").param()->isEnumParam());
-  assert(vars.at("e").param()->toEnumParam()->value().first.postOrderId() == 1);
+  assert(vars.at("e").param()->toEnumParam()->value().id.postOrderId() == 1);
   assert(vars.at("f").type());
   assert(vars.at("f").type()->isEnumType());
   assert(vars.at("f").param());
   assert(vars.at("f").param()->isEnumParam());
-  assert(vars.at("f").param()->toEnumParam()->value().first.postOrderId() == 2);
+  assert(vars.at("f").param()->toEnumParam()->value().id.postOrderId() == 2);
 
   assert(guard.realizeErrors() == 1);
 }

--- a/frontend/test/resolution/testEnums.cpp
+++ b/frontend/test/resolution/testEnums.cpp
@@ -45,10 +45,10 @@ static void test1() {
 
   auto et = qt.type()->toEnumType();
   auto ep = qt.param()->toEnumParam();
-  assert(et->id().contains(ep->value()));
+  assert(et->id().contains(ep->value().first));
   auto enumAst = parsing::idToAst(context, et->id());
   assert(enumAst && enumAst->isEnum());
-  auto elemAst = parsing::idToAst(context, ep->value());
+  auto elemAst = parsing::idToAst(context, ep->value().first);
   assert(elemAst && elemAst->isEnumElement());
 }
 
@@ -366,11 +366,11 @@ static void test11() {
 
   auto param0 = vars.at("a").param();
   assert(param0 && param0->isEnumParam());
-  assert(param0->toEnumParam()->value().postOrderId() == 1);
+  assert(param0->toEnumParam()->value().first.postOrderId() == 1);
 
   auto param1 = vars.at("b").param();
   assert(param1 && param1->isEnumParam());
-  assert(param1->toEnumParam()->value().postOrderId() == 5);
+  assert(param1->toEnumParam()->value().first.postOrderId() == 5);
 }
 
 static void test12() {
@@ -579,22 +579,22 @@ static void test17() {
   assert(vars.at("c").type()->isEnumType());
   assert(vars.at("c").param());
   assert(vars.at("c").param()->isEnumParam());
-  assert(vars.at("c").param()->toEnumParam()->value().postOrderId() == 0);
+  assert(vars.at("c").param()->toEnumParam()->value().first.postOrderId() == 0);
   assert(vars.at("d").type());
   assert(vars.at("d").type()->isEnumType());
   assert(vars.at("d").param());
   assert(vars.at("d").param()->isEnumParam());
-  assert(vars.at("d").param()->toEnumParam()->value().postOrderId() == 0);
+  assert(vars.at("d").param()->toEnumParam()->value().first.postOrderId() == 0);
   assert(vars.at("e").type());
   assert(vars.at("e").type()->isEnumType());
   assert(vars.at("e").param());
   assert(vars.at("e").param()->isEnumParam());
-  assert(vars.at("e").param()->toEnumParam()->value().postOrderId() == 1);
+  assert(vars.at("e").param()->toEnumParam()->value().first.postOrderId() == 1);
   assert(vars.at("f").type());
   assert(vars.at("f").type()->isEnumType());
   assert(vars.at("f").param());
   assert(vars.at("f").param()->isEnumParam());
-  assert(vars.at("f").param()->toEnumParam()->value().postOrderId() == 2);
+  assert(vars.at("f").param()->toEnumParam()->value().first.postOrderId() == 2);
 
   assert(guard.realizeErrors() == 1);
 }

--- a/frontend/test/resolution/testParams.cpp
+++ b/frontend/test/resolution/testParams.cpp
@@ -121,7 +121,7 @@ static void test4() {
   assert(bestFn->formalType(0).isParam());
   assert(bestFn->formalName(0) == UniqueString::get(context, "this"));
   assert(bestFn->formalType(0).param()->isEnumParam());
-  assert(bestFn->formalType(0).param()->toEnumParam()->value() == greenEnum->id());
+  assert(bestFn->formalType(0).param()->toEnumParam()->value().first == greenEnum->id());
   const ResolvedFunction* rfn = scopeResolveFunction(context, isBlueFn->id());
   const auto tsi = typedSignatureInitial(context, rfn->signature()->untyped());
   assert(tsi->formalType(0).isParam());

--- a/frontend/test/resolution/testParams.cpp
+++ b/frontend/test/resolution/testParams.cpp
@@ -121,7 +121,7 @@ static void test4() {
   assert(bestFn->formalType(0).isParam());
   assert(bestFn->formalName(0) == UniqueString::get(context, "this"));
   assert(bestFn->formalType(0).param()->isEnumParam());
-  assert(bestFn->formalType(0).param()->toEnumParam()->value().first == greenEnum->id());
+  assert(bestFn->formalType(0).param()->toEnumParam()->value().id == greenEnum->id());
   const ResolvedFunction* rfn = scopeResolveFunction(context, isBlueFn->id());
   const auto tsi = typedSignatureInitial(context, rfn->signature()->untyped());
   assert(tsi->formalType(0).isParam());

--- a/frontend/test/resolution/testRanges.cpp
+++ b/frontend/test/resolution/testRanges.cpp
@@ -36,7 +36,7 @@ getRangeInfo(Context* context, const RecordType* r) {
   assert(bounded.type()->isEnumType());
   assert(bounded.param() != nullptr);
   auto boundedValue = bounded.param()->toEnumParam();
-  auto id = boundedValue->value();
+  auto id = boundedValue->value().first;
   auto astNode = idToAst(context, id)->toNamedDecl();
   assert(astNode != nullptr);
   std::string boundTypeStr = astNode->name().str();
@@ -46,7 +46,7 @@ getRangeInfo(Context* context, const RecordType* r) {
   assert(stridable.type()->isEnumType());
   assert(stridable.param() != nullptr);
   auto stridableValue = stridable.param()->toEnumParam();
-  auto idS = stridableValue->value();
+  auto idS = stridableValue->value().first;
   auto astNodeS = idToAst(context, idS)->toNamedDecl();
   assert(astNodeS != nullptr);
   std::string stridesStr = astNodeS->name().str();

--- a/frontend/test/resolution/testRanges.cpp
+++ b/frontend/test/resolution/testRanges.cpp
@@ -36,7 +36,7 @@ getRangeInfo(Context* context, const RecordType* r) {
   assert(bounded.type()->isEnumType());
   assert(bounded.param() != nullptr);
   auto boundedValue = bounded.param()->toEnumParam();
-  auto id = boundedValue->value().first;
+  auto id = boundedValue->value().id;
   auto astNode = idToAst(context, id)->toNamedDecl();
   assert(astNode != nullptr);
   std::string boundTypeStr = astNode->name().str();
@@ -46,7 +46,7 @@ getRangeInfo(Context* context, const RecordType* r) {
   assert(stridable.type()->isEnumType());
   assert(stridable.param() != nullptr);
   auto stridableValue = stridable.param()->toEnumParam();
-  auto idS = stridableValue->value().first;
+  auto idS = stridableValue->value().id;
   auto astNodeS = idToAst(context, idS)->toNamedDecl();
   assert(astNodeS != nullptr);
   std::string stridesStr = astNodeS->name().str();

--- a/frontend/test/resolution/testTypeConstruction.cpp
+++ b/frontend/test/resolution/testTypeConstruction.cpp
@@ -1540,14 +1540,14 @@ static void test44() {
   assert(pt.type()->isEnumType());
   assert(pt.param()->isEnumParam());
   auto param = pt.param()->toEnumParam();
-  assert(param->value().second == "x");
+  assert(param->value().str == "x");
 
 
   auto parent = xt->basicClassType()->parentClassType();
   auto pf = parent->substitutions();
   assert(pf.size() == 1);
   assert(pf.begin()->second.type()->isEnumType());
-  assert(pf.begin()->second.param()->toEnumParam()->value().second == "red");
+  assert(pf.begin()->second.param()->toEnumParam()->value().str == "red");
 }
 
 int main() {

--- a/frontend/test/resolution/testTypeConstruction.cpp
+++ b/frontend/test/resolution/testTypeConstruction.cpp
@@ -1540,15 +1540,14 @@ static void test44() {
   assert(pt.type()->isEnumType());
   assert(pt.param()->isEnumParam());
   auto param = pt.param()->toEnumParam();
-  // TODO: properly stringify enum params
-  assert(param->value().str() == "M.coords@0");
+  assert(param->value().second == "x");
 
 
   auto parent = xt->basicClassType()->parentClassType();
   auto pf = parent->substitutions();
   assert(pf.size() == 1);
   assert(pf.begin()->second.type()->isEnumType());
-  assert(pf.begin()->second.param()->toEnumParam()->value().str() == "M.Other.color@0");
+  assert(pf.begin()->second.param()->toEnumParam()->value().second == "red");
 }
 
 int main() {

--- a/tools/chapel-py/src/method-tables/param-methods.h
+++ b/tools/chapel-py/src/method-tables/param-methods.h
@@ -38,7 +38,7 @@ CLASS_END(BoolParam)
 
 CLASS_BEGIN(EnumParam)
   PLAIN_GETTER(EnumParam, value, "Get the value of this enum Param",
-               const chpl::uast::AstNode*, return parsing::idToAst(context, node->value()))
+               const chpl::uast::AstNode*, return parsing::idToAst(context, node->value().first))
 CLASS_END(EnumParam)
 
 CLASS_BEGIN(IntParam)

--- a/tools/chapel-py/src/method-tables/param-methods.h
+++ b/tools/chapel-py/src/method-tables/param-methods.h
@@ -38,7 +38,7 @@ CLASS_END(BoolParam)
 
 CLASS_BEGIN(EnumParam)
   PLAIN_GETTER(EnumParam, value, "Get the value of this enum Param",
-               const chpl::uast::AstNode*, return parsing::idToAst(context, node->value().first))
+               const chpl::uast::AstNode*, return parsing::idToAst(context, node->value().id))
 CLASS_END(EnumParam)
 
 CLASS_BEGIN(IntParam)


### PR DESCRIPTION
Prior to this change, param enums could not be stringified because EnumParam only stored an ID and the stringify signature lacks a ``Context*`` needed to map the ID to uAST. Without the uAST we cannot compute the original name of the enum element. Instead, store a pair of ``ID`` and ``string`` inside EnumParam and compute the element's name ahead of time.

``EnumParam::get`` is supplanted by ``Param::getEnumParam``, which is a helper that uses the provided context to fetch the enum element's name as a string, then builds the stored pair.

Using this capability, this PR easily implements param enum to string casts.

After this PR, we can now print types with param-enum fields more cleanly. Rather than ``R(mod.colors@0)`` we simply print, e.g., ``R(green)``.

Testing:
- [x] test-dyno