### PR TITLE
Fix an issue with library compilation on Macs

### DIFF
--- a/compiler/codegen/library.cpp
+++ b/compiler/codegen/library.cpp
@@ -272,12 +272,8 @@ static void printMakefileLibraries(fileinfo makefile, std::string name) {
     fprintf(makefile.fptr, "%s", requires_.c_str());
   }
 
-  //
-  // Append the Chapel library as the last linker argument. We do this as a
-  // stopgap to make the GNU linker happy.
-  //
   removeTrailingNewlines(libraries);
-  fprintf(makefile.fptr, " %s %s\n\n", libraries.c_str(), libname.c_str());
+  fprintf(makefile.fptr, " %s\n\n", libraries.c_str());
 }
 
 // Helper to convert command lines flags from make syntax to CMake syntax

--- a/test/interop/C/exportArray/callArrayArg_queriedDomain.lastcompopts
+++ b/test/interop/C/exportArray/callArrayArg_queriedDomain.lastcompopts
@@ -1,1 +1,1 @@
--Llib/ -larrayArg_queriedDomain `$CHPL_HOME/util/config/compileline --libraries` -larrayArg_queriedDomain
+-Llib/ -larrayArg_queriedDomain `$CHPL_HOME/util/config/compileline --libraries`

--- a/test/interop/C/exportArray/callArrayOpaquePointer.lastcompopts
+++ b/test/interop/C/exportArray/callArrayOpaquePointer.lastcompopts
@@ -1,1 +1,1 @@
--Llib/ -larrayOpaquePointer `$CHPL_HOME/util/config/compileline --libraries` -larrayOpaquePointer
+-Llib/ -larrayOpaquePointer `$CHPL_HOME/util/config/compileline --libraries`

--- a/test/interop/C/exportArray/callCheckIfEmpty.lastcompopts
+++ b/test/interop/C/exportArray/callCheckIfEmpty.lastcompopts
@@ -1,1 +1,1 @@
--Llib/ -lcheckIfEmpty `$CHPL_HOME/util/config/compileline --libraries` -lcheckIfEmpty
+-Llib/ -lcheckIfEmpty `$CHPL_HOME/util/config/compileline --libraries`

--- a/test/interop/C/exportArray/callExported2Arg.lastcompopts
+++ b/test/interop/C/exportArray/callExported2Arg.lastcompopts
@@ -1,1 +1,1 @@
--Llib/ -lexportFuncWith1Arr1Not `$CHPL_HOME/util/config/compileline --libraries` -lexportFuncWith1Arr1Not
+-Llib/ -lexportFuncWith1Arr1Not `$CHPL_HOME/util/config/compileline --libraries`

--- a/test/interop/C/exportArray/callExported2ArgDiff.lastcompopts
+++ b/test/interop/C/exportArray/callExported2ArgDiff.lastcompopts
@@ -1,1 +1,1 @@
--Llib/ -lexportFuncWith1Not1Arr `$CHPL_HOME/util/config/compileline --libraries` -lexportFuncWith1Not1Arr
+-Llib/ -lexportFuncWith1Not1Arr `$CHPL_HOME/util/config/compileline --libraries`

--- a/test/interop/C/exportArray/callExported2Arrays.lastcompopts
+++ b/test/interop/C/exportArray/callExported2Arrays.lastcompopts
@@ -1,1 +1,1 @@
--Llib/ -lexportFuncWith2Arrays `$CHPL_HOME/util/config/compileline --libraries` -lexportFuncWith2Arrays
+-Llib/ -lexportFuncWith2Arrays `$CHPL_HOME/util/config/compileline --libraries`

--- a/test/interop/C/exportArray/callExportedArrayFunc.lastcompopts
+++ b/test/interop/C/exportArray/callExportedArrayFunc.lastcompopts
@@ -1,1 +1,1 @@
--Llib/ -lexportFuncWithArrayArg `$CHPL_HOME/util/config/compileline --libraries` -lexportFuncWithArrayArg
+-Llib/ -lexportFuncWithArrayArg `$CHPL_HOME/util/config/compileline --libraries`

--- a/test/interop/C/exportArray/callExportedExplicit.lastcompopts
+++ b/test/interop/C/exportArray/callExportedExplicit.lastcompopts
@@ -1,1 +1,1 @@
--Llib/ -lexportFuncWithExplicitVoidRet `$CHPL_HOME/util/config/compileline --libraries` -lexportFuncWithExplicitVoidRet
+-Llib/ -lexportFuncWithExplicitVoidRet `$CHPL_HOME/util/config/compileline --libraries`

--- a/test/interop/C/exportArray/callExportedRealArr.lastcompopts
+++ b/test/interop/C/exportArray/callExportedRealArr.lastcompopts
@@ -1,1 +1,1 @@
--Llib/ -lexportFuncWithRealArr `$CHPL_HOME/util/config/compileline --libraries` -lexportFuncWithRealArr
+-Llib/ -lexportFuncWithRealArr `$CHPL_HOME/util/config/compileline --libraries`

--- a/test/interop/C/exportArray/callExportedWithExternType.lastcompopts
+++ b/test/interop/C/exportArray/callExportedWithExternType.lastcompopts
@@ -1,1 +1,1 @@
--Llib/ -lexportFuncWithExternType `$CHPL_HOME/util/config/compileline --libraries` -lexportFuncWithExternType
+-Llib/ -lexportFuncWithExternType `$CHPL_HOME/util/config/compileline --libraries`

--- a/test/interop/C/exportArray/callExportedWithPtr.lastcompopts
+++ b/test/interop/C/exportArray/callExportedWithPtr.lastcompopts
@@ -1,1 +1,1 @@
--Llib/ -lexportFuncWithPtr `$CHPL_HOME/util/config/compileline --libraries` -lexportFuncWithPtr
+-Llib/ -lexportFuncWithPtr `$CHPL_HOME/util/config/compileline --libraries`

--- a/test/interop/C/exportArray/callFuncReturnsArray.lastcompopts
+++ b/test/interop/C/exportArray/callFuncReturnsArray.lastcompopts
@@ -1,1 +1,1 @@
--Llib/ -lreturnExternArray `$CHPL_HOME/util/config/compileline --libraries` -lreturnExternArray
+-Llib/ -lreturnExternArray `$CHPL_HOME/util/config/compileline --libraries`

--- a/test/interop/C/exportArray/callWrapArrayAsOpaque_global.lastcompopts
+++ b/test/interop/C/exportArray/callWrapArrayAsOpaque_global.lastcompopts
@@ -1,1 +1,1 @@
--Llib/ -lwrapArrayAsOpaque_global `$CHPL_HOME/util/config/compileline --libraries` -lwrapArrayAsOpaque_global
+-Llib/ -lwrapArrayAsOpaque_global `$CHPL_HOME/util/config/compileline --libraries`

--- a/test/interop/C/exportArray/callWrapArrayAsOpaque_moreComplex.lastcompopts
+++ b/test/interop/C/exportArray/callWrapArrayAsOpaque_moreComplex.lastcompopts
@@ -1,1 +1,1 @@
--Llib/ -lwrapArrayAsOpaque_moreComplex `$CHPL_HOME/util/config/compileline --libraries` -lwrapArrayAsOpaque_moreComplex
+-Llib/ -lwrapArrayAsOpaque_moreComplex `$CHPL_HOME/util/config/compileline --libraries`

--- a/test/interop/C/exportArray/returningArr/callExportedArrArgReturnInt.lastcompopts
+++ b/test/interop/C/exportArray/returningArr/callExportedArrArgReturnInt.lastcompopts
@@ -1,1 +1,1 @@
--Llib/ -lexportArrArgReturnInt `$CHPL_HOME/util/config/compileline --libraries` -lexportArrArgReturnInt
+-Llib/ -lexportArrArgReturnInt `$CHPL_HOME/util/config/compileline --libraries`

--- a/test/interop/C/exportArray/returningArr/callFuncReturnsArray.lastcompopts
+++ b/test/interop/C/exportArray/returningArr/callFuncReturnsArray.lastcompopts
@@ -1,1 +1,1 @@
--Llib/ -lreturnArray `$CHPL_HOME/util/config/compileline --libraries` -lreturnArray
+-Llib/ -lreturnArray `$CHPL_HOME/util/config/compileline --libraries`

--- a/test/interop/C/exportArray/returningArr/callFuncReturnsArrayGenericDecl.lastcompopts
+++ b/test/interop/C/exportArray/returningArr/callFuncReturnsArrayGenericDecl.lastcompopts
@@ -1,1 +1,1 @@
--Llib/ -lreturnArrayGenericDecl `$CHPL_HOME/util/config/compileline --libraries` -lreturnArrayGenericDecl
+-Llib/ -lreturnArrayGenericDecl `$CHPL_HOME/util/config/compileline --libraries`

--- a/test/interop/C/exportArray/returningArr/callFuncReturnsArrayGenericDecl2.lastcompopts
+++ b/test/interop/C/exportArray/returningArr/callFuncReturnsArrayGenericDecl2.lastcompopts
@@ -1,1 +1,1 @@
--Llib/ -lreturnArrayGenericDecl2 `$CHPL_HOME/util/config/compileline --libraries` -lreturnArrayGenericDecl2
+-Llib/ -lreturnArrayGenericDecl2 `$CHPL_HOME/util/config/compileline --libraries`

--- a/test/interop/C/exportArray/returningArr/callFuncReturnsArrayOfReals.lastcompopts
+++ b/test/interop/C/exportArray/returningArr/callFuncReturnsArrayOfReals.lastcompopts
@@ -1,1 +1,1 @@
--Llib/ -lreturnArrayOfReals `$CHPL_HOME/util/config/compileline --libraries` -lreturnArrayOfReals
+-Llib/ -lreturnArrayOfReals `$CHPL_HOME/util/config/compileline --libraries`

--- a/test/interop/C/exportArray/returningArr/callFuncReturnsArrayTakesArg.lastcompopts
+++ b/test/interop/C/exportArray/returningArr/callFuncReturnsArrayTakesArg.lastcompopts
@@ -1,1 +1,1 @@
--Llib/ -lreturnArrayTakesArg `$CHPL_HOME/util/config/compileline --libraries` -lreturnArrayTakesArg
+-Llib/ -lreturnArrayTakesArg `$CHPL_HOME/util/config/compileline --libraries`

--- a/test/interop/C/exportArray/returningArr/callFuncReturnsArrayTakesArg2.lastcompopts
+++ b/test/interop/C/exportArray/returningArr/callFuncReturnsArrayTakesArg2.lastcompopts
@@ -1,1 +1,1 @@
--Llib/ -lreturnArrayTakesArg2 `$CHPL_HOME/util/config/compileline --libraries` -lreturnArrayTakesArg2
+-Llib/ -lreturnArrayTakesArg2 `$CHPL_HOME/util/config/compileline --libraries`

--- a/test/interop/C/exportArray/returningArr/callFuncReturnsArrayTakesArrayArg.lastcompopts
+++ b/test/interop/C/exportArray/returningArr/callFuncReturnsArrayTakesArrayArg.lastcompopts
@@ -1,1 +1,1 @@
--Llib/ -lreturnArrayTakesArrayArg `$CHPL_HOME/util/config/compileline --libraries` -lreturnArrayTakesArrayArg
+-Llib/ -lreturnArrayTakesArrayArg `$CHPL_HOME/util/config/compileline --libraries`

--- a/test/interop/C/exportArray/returningArr/callFuncReturnsArrayTakesArrayArg2.lastcompopts
+++ b/test/interop/C/exportArray/returningArr/callFuncReturnsArrayTakesArrayArg2.lastcompopts
@@ -1,1 +1,1 @@
--Llib/ -lreturnArrayTakesArrayArg2 `$CHPL_HOME/util/config/compileline --libraries` -lreturnArrayTakesArrayArg2
+-Llib/ -lreturnArrayTakesArrayArg2 `$CHPL_HOME/util/config/compileline --libraries`

--- a/test/interop/C/exportArray/returningArr/callFuncReturnsArrayTakesArrayArg3.lastcompopts
+++ b/test/interop/C/exportArray/returningArr/callFuncReturnsArrayTakesArrayArg3.lastcompopts
@@ -1,1 +1,1 @@
--Llib/ -lreturnArrayTakesArrayArg3 `$CHPL_HOME/util/config/compileline --libraries` -lreturnArrayTakesArrayArg3
+-Llib/ -lreturnArrayTakesArrayArg3 `$CHPL_HOME/util/config/compileline --libraries`

--- a/test/interop/C/exportArray/returningArr/callFuncReturnsArrayTakesArrayArg4.lastcompopts
+++ b/test/interop/C/exportArray/returningArr/callFuncReturnsArrayTakesArrayArg4.lastcompopts
@@ -1,1 +1,1 @@
--Llib/ -lreturnArrayTakesArrayArg4 `$CHPL_HOME/util/config/compileline --libraries` -lreturnArrayTakesArrayArg4
+-Llib/ -lreturnArrayTakesArrayArg4 `$CHPL_HOME/util/config/compileline --libraries`

--- a/test/interop/C/exportArray/returningArr/callFuncReturnsBadArray.lastcompopts
+++ b/test/interop/C/exportArray/returningArr/callFuncReturnsBadArray.lastcompopts
@@ -1,1 +1,1 @@
--Llib/ -lreturnBadArray `$CHPL_HOME/util/config/compileline --libraries` -lreturnBadArray
+-Llib/ -lreturnBadArray `$CHPL_HOME/util/config/compileline --libraries`

--- a/test/interop/C/exportArray/returningArr/callFuncReturnsBadArray2.lastcompopts
+++ b/test/interop/C/exportArray/returningArr/callFuncReturnsBadArray2.lastcompopts
@@ -1,1 +1,1 @@
--Llib/ -lreturnBadArray2 `$CHPL_HOME/util/config/compileline --libraries` -lreturnBadArray2
+-Llib/ -lreturnBadArray2 `$CHPL_HOME/util/config/compileline --libraries`

--- a/test/interop/C/externRecords/sendExternRecord.lastcompopts
+++ b/test/interop/C/externRecords/sendExternRecord.lastcompopts
@@ -1,1 +1,1 @@
--Llib/ -lreceiveExternRecord `$CHPL_HOME/util/config/compileline --libraries` -lreceiveExternRecord
+-Llib/ -lreceiveExternRecord `$CHPL_HOME/util/config/compileline --libraries`

--- a/test/interop/C/globals/use_reliesOnGlobal-library-init.lastcompopts
+++ b/test/interop/C/globals/use_reliesOnGlobal-library-init.lastcompopts
@@ -1,1 +1,1 @@
--Llib/ -lreliesOnGlobal `$CHPL_HOME/util/config/compileline --libraries` -lreliesOnGlobal
+-Llib/ -lreliesOnGlobal `$CHPL_HOME/util/config/compileline --libraries`

--- a/test/interop/C/globals/use_reliesOnGlobal.lastcompopts
+++ b/test/interop/C/globals/use_reliesOnGlobal.lastcompopts
@@ -1,1 +1,1 @@
--Llib/ -lreliesOnGlobal `$CHPL_HOME/util/config/compileline --libraries` -lreliesOnGlobal
+-Llib/ -lreliesOnGlobal `$CHPL_HOME/util/config/compileline --libraries`

--- a/test/interop/C/noLibFlag/callDirSet.lastcompopts
+++ b/test/interop/C/noLibFlag/callDirSet.lastcompopts
@@ -1,1 +1,1 @@
--Lmydir/ -lsetDir `$CHPL_HOME/util/config/compileline --libraries` -lsetDir
+-Lmydir/ -lsetDir `$CHPL_HOME/util/config/compileline --libraries`

--- a/test/interop/C/use_PtrConstQualifier.lastcompopts
+++ b/test/interop/C/use_PtrConstQualifier.lastcompopts
@@ -1,1 +1,1 @@
--Llib/ -lPtrConstQualifier `$CHPL_HOME/util/config/compileline --libraries` -lPtrConstQualifier
+-Llib/ -lPtrConstQualifier `$CHPL_HOME/util/config/compileline --libraries`

--- a/test/interop/C/use_testing.lastcompopts
+++ b/test/interop/C/use_testing.lastcompopts
@@ -1,1 +1,1 @@
--Llib/ -ltesting `$CHPL_HOME/util/config/compileline --libraries` -ltesting
+-Llib/ -ltesting `$CHPL_HOME/util/config/compileline --libraries`


### PR DESCRIPTION
Library compilation on Macs has recently started generating the error:
```
ld: warning: ignoring duplicate libraries: '<library name>'
```

I believe we added this extra library specification for a reason (linking is annoyingly fragile), and it seems likely that reason is no longer necessary, so it should be safe to remove the extra library specification in general.  Experimentation with removing the extra library linking on linux makes this seem likely.

For many tests, this was part of the specified ".lastcompopts" file and so could be removed from the tests.  For the tests of generating Makefiles, we needed to modify the compiler to not add this extra use of the library.

Tested:
- the impacted tests locally on my Mac
- full paratest on Linux