### PR TITLE
Add graph of binarytrees-pool

### DIFF
--- a/test/studies/shootout/binary-trees/binary-trees.graph
+++ b/test/studies/shootout/binary-trees/binary-trees.graph
@@ -1,6 +1,6 @@
-perfkeys: real, real, real, real, real, real, real
-graphkeys: Casey version, Casey iterator version, release, free while adding version, blc study version, free while adding (with exponent), parallel inner loop version
-files: binary-trees.dat, binary-trees_iter.dat, binarytrees.dat, binarytrees-freeWhileAdding.dat, binarytrees-blc.dat, binarytrees-freeWhileAdding-exp.dat, binarytrees-inner.dat
+perfkeys: real, real, real, real, real, real, real, real
+graphkeys: Casey version, Casey iterator version, release, free while adding version, blc study version, free while adding (with exponent), parallel inner loop version, allocate with pool
+files: binary-trees.dat, binary-trees_iter.dat, binarytrees.dat, binarytrees-freeWhileAdding.dat, binarytrees-blc.dat, binarytrees-freeWhileAdding-exp.dat, binarytrees-inner.dat, binarytrees-pool.dat
 graphtitle: Binary Trees Shootout Benchmark (n=21)
 ylabel: Time (seconds)
 graphname: binary-trees.21


### PR DESCRIPTION
Adds existing performance test `binarytrees-pool` to the existing binarytrees `.graph` file

[Reviewed by @jeremiah-corrado]