### PR TITLE
Followup to Allocator linux32 fix

### DIFF
--- a/test/library/standard/Allocators/customAllocator.execopts
+++ b/test/library/standard/Allocators/customAllocator.execopts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-tgt_platform=$($CHPL_HOME/env/printchplenv --value --only CHPL_TARGET_PLATFORM)
+tgt_platform=$($CHPL_HOME/util/printchplenv --value --only CHPL_TARGET_PLATFORM)
 
 # if linux32, use the linux32 good file
 if [ "$tgt_platform" == "linux32" ]; then

--- a/test/library/standard/Allocators/customAllocatorClass.execopts
+++ b/test/library/standard/Allocators/customAllocatorClass.execopts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-tgt_platform=$($CHPL_HOME/env/printchplenv --value --only CHPL_TARGET_PLATFORM)
+tgt_platform=$($CHPL_HOME/util/printchplenv --value --only CHPL_TARGET_PLATFORM)
 
 # if linux32, use the linux32 good file
 if [ "$tgt_platform" == "linux32" ]; then

--- a/test/studies/shootout/binary-trees/binarytrees-pool.skipif
+++ b/test/studies/shootout/binary-trees/binarytrees-pool.skipif
@@ -1,0 +1,2 @@
+# program attempts to allocate and address more than 4GB of memory
+CHPL_TARGET_PLATFORM==linux32


### PR DESCRIPTION
Followup to https://github.com/chapel-lang/chapel/pull/25834

Fixes a typo in the execopts scripts and validated it works on a linux32 platform.

Skip `binarytrees-pool` on linux32 to avoid out-of-memory. The program attempts to allocate far more than a 32 bit program can address.

[Reviewed by @mppf]