### PR TITLE
Add `Sort.keyComparator` for specifying a comparator with `key`

### DIFF
--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -38,6 +38,7 @@ private use BlockDist;
 private use RangeChunk;
 private use HaltWrappers;
 private use LayoutCS;
+import Sort.{keyComparator};
 
 //
 // These flags are used to output debug information and run extra
@@ -52,7 +53,7 @@ config param debugSparseBlockDistBulkTransfer = false;
 // just use Block.
 
 // Helper type for sorting locales
-record targetLocaleComparator {
+record targetLocaleComparator: keyComparator {
   param rank;
   type idxType;
   type sparseLayoutType;

--- a/modules/layouts/LayoutCS.chpl
+++ b/modules/layouts/LayoutCS.chpl
@@ -22,7 +22,7 @@
 
 @unstable("LayoutCS is unstable and may change in the future")
 prototype module LayoutCS {
-
+import Sort.{keyComparator};
 import RangeChunk;
 
 @chpldoc.nodoc
@@ -38,7 +38,7 @@ config param LayoutCSDefaultToSorted = true;
 
 @chpldoc.nodoc
 /* Comparator used for sorting by columns */
-record _ColumnComparator {
+record _ColumnComparator: keyComparator {
   proc key(idx: _tuple) { return (idx(1), idx(0));}
 }
 

--- a/modules/standard/Sort.chpl
+++ b/modules/standard/Sort.chpl
@@ -434,10 +434,9 @@ proc chpl_check_comparator(comparator,
                            type eltType,
                            param errorDepth = 2,
                            param doDeprecationCheck = true) param {
-
-  // TODO: add keyComparator
   // if more than 1 interface is implemented, error
-  if (comparatorImplementsKeyPart(comparator):int +
+  if (comparatorImplementsKey(comparator):int +
+      comparatorImplementsKeyPart(comparator):int +
       comparatorImplementsRelative(comparator):int) > 1 {
     compilerError(errorDepth=errorDepth, "The comparator " + comparator.type:string + " should only implement one sort comparator interface.");
   }
@@ -452,7 +451,15 @@ proc chpl_check_comparator(comparator,
   }
   // Check for valid comparator methods
   else if canResolveMethod(comparator, "key", data) {
-    // TODO: check for keyComparator
+    if doDeprecationCheck && !comparatorImplementsKey(comparator) {
+      param atType = if isRecord(comparator) then "record" else "class";
+      param fixString = "'" + atType + " " +
+                        comparator.type:string + ": keyComparator'";
+      compilerWarning(errorDepth=errorDepth,
+        "Defining a comparator with a 'key' method without " +
+        "implementing the keyComparator interface is deprecated. " +
+        "Please implement the keyComparator interface (i.e. " + fixString + ").");
+      }
     // Check return type of key
     const keydata = comparator.key(data);
     type keytype = keydata.type;
@@ -464,6 +471,8 @@ proc chpl_check_comparator(comparator,
         eltType:string,
         " elements");
 
+    // TODO: I think these can be removed once we enforce the interface in
+    //       the compiler and remove `canResolveMethod`
     // Check that there isn't also a compare or keyPart
     if canResolveMethod(comparator, "compare", data, data) {
       compilerError(errorDepth=errorDepth,
@@ -515,10 +524,8 @@ proc chpl_check_comparator(comparator,
     // the check and error are in chpl_check_comparator_keyPart
   }
   else {
-
-    // TODO: this error should talk about interfaces
     // If we make it this far, the passed comparator was defined incorrectly
-    compilerError(errorDepth=errorDepth, "The comparator " + comparator.type:string + " requires a 'key(a)', 'compare(a, b)', or 'keyPart(a, i)' method for element type " + eltType:string );
+    compilerError(errorDepth=errorDepth, "The comparator " + comparator.type:string + " must implement either 'keyComparator', 'keyPartComparator', or 'relativeComparator' for " + eltType:string);
   }
 
   return true;
@@ -2388,12 +2395,12 @@ module TwoArrayDistributedPartitioning {
   private use Math;
   public use List only list;
   import Sort.{ShellSort, MSBRadixSort, QuickSort};
-  import Sort.{RadixSortHelp, ShallowCopy};
+  import Sort.{RadixSortHelp, ShallowCopy, keyComparator};
   use MSBRadixSort;
 
   private param debugDist = false;
 
-  record TwoArrayDistSortPerBucketTaskStartComparator {
+  record TwoArrayDistSortPerBucketTaskStartComparator: keyComparator {
     proc key(elt: TwoArrayDistSortPerBucketTask) {
       return elt.start;
     }
@@ -3428,6 +3435,25 @@ module MSBRadixSort {
 
 /* Comparators */
 
+/*
+  The keyComparator interface defines how a comparator should sort elements by
+  returning a *key* for each element in the array.
+*/
+@unstable("keyComparator is not yet stable")
+interface keyComparator {
+  /*
+    Given an array element, returns a key element to sort by.
+
+    :arg elt: the array element being compared
+    :returns: a *key* element to sort by
+    :rtype: a type that support '<'
+  */
+  pragma "docs only"
+  proc Self.key(elt);// due to current limitations this signature is only for chpldoc
+}
+
+private proc comparatorImplementsKey(cmp) param do
+  return __primitive("implements interface", cmp, keyComparator) != 2;
 
 /*
   Indicates when the end of an element has been reached and in that event how

--- a/modules/standard/Sort.chpl
+++ b/modules/standard/Sort.chpl
@@ -525,7 +525,27 @@ proc chpl_check_comparator(comparator,
   }
   else {
     // If we make it this far, the passed comparator was defined incorrectly
-    compilerError(errorDepth=errorDepth, "The comparator " + comparator.type:string + " must implement either 'keyComparator', 'keyPartComparator', or 'relativeComparator' for " + eltType:string);
+    if comparatorImplementsKey(comparator) {
+      compilerError(errorDepth=errorDepth,
+        "The comparator ", comparator.type:string,
+        " implements 'keyComparator' but does not correctly provide a ",
+        "'key' method for ", eltType:string);
+    } else if comparatorImplementsKeyPart(comparator) {
+      compilerError(errorDepth=errorDepth,
+        "The comparator ", comparator.type:string,
+        " implements 'keyPartComparator' but does not correctly provide a ",
+        "'keyPart' method for ", eltType:string);
+    } else if comparatorImplementsRelative(comparator) {
+      compilerError(errorDepth=errorDepth,
+        "The comparator ", comparator.type:string,
+        " implements 'relativeComparator' but does not correctly provide a ",
+        "'compare' method for ", eltType:string);
+    } else {
+      compilerError(errorDepth=errorDepth,
+        "The comparator ", comparator.type:string,
+        " must implement either 'keyComparator', 'keyPartComparator', or ",
+        "'relativeComparator' for ", eltType:string);
+    }
   }
 
   return true;

--- a/modules/standard/Sort.chpl
+++ b/modules/standard/Sort.chpl
@@ -451,15 +451,6 @@ proc chpl_check_comparator(comparator,
   }
   // Check for valid comparator methods
   else if canResolveMethod(comparator, "key", data) {
-    if doDeprecationCheck && !comparatorImplementsKey(comparator) {
-      param atType = if isRecord(comparator) then "record" else "class";
-      param fixString = "'" + atType + " " +
-                        comparator.type:string + ": keyComparator'";
-      compilerWarning(errorDepth=errorDepth,
-        "Defining a comparator with a 'key' method without " +
-        "implementing the keyComparator interface is deprecated. " +
-        "Please implement the keyComparator interface (i.e. " + fixString + ").");
-      }
     // Check return type of key
     const keydata = comparator.key(data);
     type keytype = keydata.type;
@@ -483,6 +474,15 @@ proc chpl_check_comparator(comparator,
       compilerError(errorDepth=errorDepth,
         comparator.type:string,
         " contains both a key method and a keyPart method");
+    }
+    if doDeprecationCheck && !comparatorImplementsKey(comparator) {
+      param atType = if isRecord(comparator) then "record" else "class";
+      param fixString = "'" + atType + " " +
+                        comparator.type:string + ": keyComparator'";
+      compilerWarning(errorDepth=errorDepth,
+        "Defining a comparator with a 'key' method without " +
+        "implementing the keyComparator interface is deprecated. " +
+        "Please implement the keyComparator interface (i.e. " + fixString + ").");
     }
   }
   else if canResolveMethod(comparator, "compare", data, data) {

--- a/test/deprecated/Sort/usekeyComparator-resolved.good
+++ b/test/deprecated/Sort/usekeyComparator-resolved.good
@@ -1,0 +1,6 @@
+isSorted before false
+isSorted after true
+isSorted before false
+isSorted after true
+isSorted before false
+isSorted after true

--- a/test/deprecated/Sort/usekeyComparator.chpl
+++ b/test/deprecated/Sort/usekeyComparator.chpl
@@ -1,0 +1,55 @@
+use Sort;
+
+config param resolveDeps = false;
+
+// To make sure we get all the deprecation warnings, we need to use a unique comparator type for each call
+
+record myCmp1 { proc key(elt) do return elt; }
+record myCmp2 { proc key(elt) do return elt; }
+record myCmp3 { proc key(elt) do return elt; }
+record myCmp4 { proc key(elt) do return elt; }
+record myCmp5 { proc key(elt) do return elt; }
+record myCmp6 { proc key(elt) do return elt; }
+record myCmp7 { proc key(elt) do return elt; }
+record myCmp8 { proc key(elt) do return elt; }
+record myCmp9 { proc key(elt) do return elt; }
+
+record myCmpResolveDeps: keyComparator {
+  proc key(elt) do return elt;
+}
+
+proc getComparator(param i: int) type {
+  if resolveDeps then return myCmpResolveDeps;
+  else select i {
+    when 1 do return myCmp1;
+    when 2 do return myCmp2;
+    when 3 do return myCmp3;
+    when 4 do return myCmp4;
+    when 5 do return myCmp5;
+    when 6 do return myCmp6;
+    when 7 do return myCmp7;
+    when 8 do return myCmp8;
+    when 9 do return myCmp9;
+  }
+  compilerError("");
+}
+
+use Random;
+var arr: [1..1000] int;
+
+// there should be 9 deprecations here
+fillRandom(arr);
+writeln("isSorted before ", isSorted(arr, comparator=new (getComparator(1))()));
+sort(arr, comparator=new (getComparator(2))());
+writeln("isSorted after ", isSorted(arr, comparator=new (getComparator(3))()));
+
+fillRandom(arr);
+writeln("isSorted before ", isSorted(arr, comparator=new ReverseComparator(new (getComparator(4))())));
+sort(arr, comparator=new ReverseComparator(new (getComparator(5))()));
+writeln("isSorted after ", isSorted(arr, comparator=new ReverseComparator(new (getComparator(6))())));
+
+fillRandom(arr);
+writeln("isSorted before ", isSorted(arr, comparator=new (getComparator(7))()));
+var temp = sorted(arr, comparator=new (getComparator(8))());
+writeln("isSorted after ", isSorted(temp, comparator=new (getComparator(9))()));
+

--- a/test/deprecated/Sort/usekeyComparator.compopts
+++ b/test/deprecated/Sort/usekeyComparator.compopts
@@ -1,0 +1,4 @@
+                    # usekeyComparator.good
+-sresolveDeps=false # usekeyComparator.good
+-sresolveDeps       # usekeyComparator-resolved.good
+-sresolveDeps=true  # usekeyComparator-resolved.good

--- a/test/deprecated/Sort/usekeyComparator.good
+++ b/test/deprecated/Sort/usekeyComparator.good
@@ -1,0 +1,17 @@
+usekeyComparator.chpl:42: warning: Defining a comparator with a 'key' method without implementing the keyComparator interface is deprecated. Please implement the keyComparator interface (i.e. 'record myCmp1: keyComparator').
+usekeyComparator.chpl:43: warning: Defining a comparator with a 'key' method without implementing the keyComparator interface is deprecated. Please implement the keyComparator interface (i.e. 'record myCmp2: keyComparator').
+usekeyComparator.chpl:44: warning: Defining a comparator with a 'key' method without implementing the keyComparator interface is deprecated. Please implement the keyComparator interface (i.e. 'record myCmp3: keyComparator').
+usekeyComparator.chpl:47: warning: Defining a comparator with a 'key' method without implementing the keyComparator interface is deprecated. Please implement the keyComparator interface (i.e. 'record myCmp4: keyComparator').
+usekeyComparator.chpl:48: warning: Defining a comparator with a 'key' method without implementing the keyComparator interface is deprecated. Please implement the keyComparator interface (i.e. 'record myCmp5: keyComparator').
+usekeyComparator.chpl:49: warning: Defining a comparator with a 'key' method without implementing the keyComparator interface is deprecated. Please implement the keyComparator interface (i.e. 'record myCmp6: keyComparator').
+usekeyComparator.chpl:52: warning: Defining a comparator with a 'key' method without implementing the keyComparator interface is deprecated. Please implement the keyComparator interface (i.e. 'record myCmp7: keyComparator').
+$CHPL_HOME/modules/standard/Sort.chpl:nnnn: In iterator 'sorted':
+$CHPL_HOME/modules/standard/Sort.chpl:nnnn: warning: Defining a comparator with a 'key' method without implementing the keyComparator interface is deprecated. Please implement the keyComparator interface (i.e. 'record myCmp8: keyComparator').
+  usekeyComparator.chpl:53: called as sorted(x: [domain(1,int(64),one)] int(64), comparator: myCmp8)
+usekeyComparator.chpl:54: warning: Defining a comparator with a 'key' method without implementing the keyComparator interface is deprecated. Please implement the keyComparator interface (i.e. 'record myCmp9: keyComparator').
+isSorted before false
+isSorted after true
+isSorted before false
+isSorted after true
+isSorted before false
+isSorted after true

--- a/test/deprecated/Sort/usekeyComparator.prediff
+++ b/test/deprecated/Sort/usekeyComparator.prediff
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+$CHPL_HOME/util/test/prediff-obscure-module-linenos $@

--- a/test/domains/vass/arrays-of-domains.chpl
+++ b/test/domains/vass/arrays-of-domains.chpl
@@ -43,4 +43,4 @@ var AAB = makeDomain(2, rr);
 writeln("AAB.domain ", sorted(AAB.domain));
 writeln("AAB = ", sorted(AAB, new AAcomparator()));
 
-record AAcomparator { proc key(a) do return a.size; }
+record AAcomparator: keyComparator { proc key(a) do return a.size; }

--- a/test/library/packages/Search/correctness.chpl
+++ b/test/library/packages/Search/correctness.chpl
@@ -2,7 +2,7 @@
  *  Check correctness of search functions
  */
 
-use Search; use Sort only relativeComparator;
+use Search; use Sort only relativeComparator, keyComparator;
 
 proc main() {
 
@@ -117,7 +117,7 @@ proc ReverseComparator.name() { return 'ReverseComparator';}
 
 
 /* Key Sort by absolute value */
-record AbsKeyCmp {
+record AbsKeyCmp: keyComparator {
   proc key(a) { return abs(a); }
   proc name() { return 'AbsKeyCmp'; }
 }

--- a/test/library/standard/Sort/correctness/SortTypes.chpl
+++ b/test/library/standard/Sort/correctness/SortTypes.chpl
@@ -3,7 +3,7 @@ config const verbose = false;
 
 use Sort, Math;
 
-record UselessKeyComparator {
+record UselessKeyComparator: keyComparator {
   proc key(x) {
     return x;
   }

--- a/test/library/standard/Sort/correctness/SortTypesStrided.chpl
+++ b/test/library/standard/Sort/correctness/SortTypesStrided.chpl
@@ -3,7 +3,7 @@ config const verbose = false;
 
 use Sort;
 
-record UselessKeyComparator {
+record UselessKeyComparator: keyComparator {
   proc key(x) {
     return x;
   }

--- a/test/library/standard/Sort/correctness/correctness.chpl
+++ b/test/library/standard/Sort/correctness/correctness.chpl
@@ -225,11 +225,11 @@ proc ReverseComparator.name() { return 'ReverseComparator';}
 
 
 /* Key Sort by absolute value */
-record AbsKeyCmp {
+record AbsKeyCmp: keyComparator {
   proc key(a) { return abs(a); }
   proc name() { return 'AbsKeyCmp'; }
 }
-class AbsKeyCmpClass {
+class AbsKeyCmpClass: keyComparator {
   proc key(a) { return abs(a); }
   proc name() { return 'AbsKeyCmpClass'; }
 }
@@ -249,11 +249,11 @@ class AbsCompCmpClass: relativeComparator {
 
 
 /* Key method can return a non-numerical/string type, such as tuple */
-record TupleCmp {
+record TupleCmp: keyComparator {
   proc key(a) { return (a, a); }
   proc name() { return 'TupleCmp'; }
 }
-class TupleCmpClass {
+class TupleCmpClass: keyComparator {
   proc key(a) { return (a, a); }
   proc name() { return 'TupleCmpClass'; }
 }

--- a/test/library/standard/Sort/correctness/sort-array-of-owned.chpl
+++ b/test/library/standard/Sort/correctness/sort-array-of-owned.chpl
@@ -8,7 +8,7 @@ class Value {
 }
 
 
-record keyValueComparator {
+record keyValueComparator: keyComparator {
   proc key(v: Value?) {
     if v == nil then
       return 0;
@@ -58,7 +58,7 @@ operator Wrapper.=(ref lhs: Wrapper, ref rhs: Wrapper) {
   lhs.elt = rhs.elt;
 }
 
-record keyWrapperComparator {
+record keyWrapperComparator: keyComparator {
   proc key(v: Wrapper) {
     if v.elt == nil then
       return 0;
@@ -108,7 +108,7 @@ record ArrayWrapper {
     elts[1] = arg;
   }
 }
-record keyArrayWrapperComparator {
+record keyArrayWrapperComparator: keyComparator {
   proc key(v: ArrayWrapper) {
     if v.elts[1] == nil then
       return 0;
@@ -148,7 +148,7 @@ proc ArrayWrapperComparator type do
 
 // TEST 4: SORTING ARRAY CONTAINING ARRAY OF OWNED ELEMENTS
 
-record keyArrayComparator {
+record keyArrayComparator: keyComparator {
   proc key(v: [] owned Value?) {
     if v[1] == nil then
       return 0;

--- a/test/library/standard/Sort/correctness/sort-region.chpl
+++ b/test/library/standard/Sort/correctness/sort-region.chpl
@@ -4,7 +4,7 @@ record AbsCompCmp: relativeComparator {
   proc compare(a, b) { return abs(a) - abs(b); }
   proc name() { return 'AbsCompCmp'; }
 }
-record AbsKeyCmp {
+record AbsKeyCmp: keyComparator {
   proc key(a) { return abs(a); }
   proc name() { return 'AbsKeyCmp'; }
 }

--- a/test/library/standard/Sort/correctness/stableSort.chpl
+++ b/test/library/standard/Sort/correctness/stableSort.chpl
@@ -5,7 +5,7 @@ record myRec {
   var x: int;
   var creationIndex: int;
 }
-record myRecComparator {
+record myRecComparator: keyComparator {
   proc key(rec: myRec): int do
     return rec.x;
 }
@@ -16,7 +16,7 @@ proc factory(x: int): myRec {
   return new myRec(x, next);
 }
 
-record myRecComparatorByCreationIndex {
+record myRecComparatorByCreationIndex: keyComparator {
   proc key(rec: myRec): int do
     return rec.creationIndex;
 }

--- a/test/library/standard/Sort/errors/error-multiple-interfaces.1.good
+++ b/test/library/standard/Sort/errors/error-multiple-interfaces.1.good
@@ -1,1 +1,1 @@
-error-multiple-interfaces.chpl:32: error: The comparator R1 should only implement one sort comparator interface.
+error-multiple-interfaces.chpl:27: error: The comparator R1 should only implement one sort comparator interface.

--- a/test/library/standard/Sort/errors/error-multiple-interfaces.2.good
+++ b/test/library/standard/Sort/errors/error-multiple-interfaces.2.good
@@ -1,0 +1,1 @@
+error-multiple-interfaces.chpl:27: error: The comparator R2 should only implement one sort comparator interface.

--- a/test/library/standard/Sort/errors/error-multiple-interfaces.3.good
+++ b/test/library/standard/Sort/errors/error-multiple-interfaces.3.good
@@ -1,0 +1,1 @@
+error-multiple-interfaces.chpl:27: error: The comparator R3 should only implement one sort comparator interface.

--- a/test/library/standard/Sort/errors/error-multiple-interfaces.4.good
+++ b/test/library/standard/Sort/errors/error-multiple-interfaces.4.good
@@ -1,1 +1,1 @@
-error-multiple-interfaces.chpl:32: error: The comparator R4 should only implement one sort comparator interface.
+error-multiple-interfaces.chpl:27: error: The comparator R4 should only implement one sort comparator interface.

--- a/test/library/standard/Sort/errors/error-multiple-interfaces.chpl
+++ b/test/library/standard/Sort/errors/error-multiple-interfaces.chpl
@@ -2,12 +2,6 @@ use Sort;
 
 config type comparator;
 
-// TODO: when Sort.keyComparator is implemented, this should be removed
-// the test will fail and notify us when that occurs
-interface keyComparator { }
-
-var A = [1,2,3,4];
-
 record R1: keyPartComparator, relativeComparator {
   proc compare(a: int, b: int) {
     return a - b;
@@ -29,4 +23,5 @@ record R4: keyComparator, keyPartComparator, relativeComparator {
   }
 }
 
+var A = [1,2,3,4];
 sort(A, comparator=new comparator());

--- a/test/library/standard/Sort/errors/errors-comparator.chpl
+++ b/test/library/standard/Sort/errors/errors-comparator.chpl
@@ -51,7 +51,6 @@ proc keyPartArgs.keyPart(a) {
   return a;
 }
 
-// this should still get a deprecation warning
 // Both key and compare
 record keyAndCompare { }
 proc keyAndCompare.key(a) {
@@ -61,7 +60,6 @@ proc keyAndCompare.compare(a, b) {
   return 0;
 }
 
-// this should still get a deprecation warning
 // Both key and keyPart
 record keyAndKeyPart { }
 proc keyAndKeyPart.key(a) {

--- a/test/library/standard/Sort/errors/errors-comparator.chpl
+++ b/test/library/standard/Sort/errors/errors-comparator.chpl
@@ -25,28 +25,33 @@ record empty { }
 
 // Wrong function
 record wrong { }
+wrong implements keyComparator;
 proc wrong.Key(a) {
   return abs(a);
 }
 
 // Invalid key args -- should have 1 arg
-record keyargs{ }
+record keyargs { }
+keyargs implements keyComparator;
 proc keyargs.key(a, b) {
   return a - b;
 }
 
 // Invalid compareargs -- should have 2 args
 record compareargs { }
+compareargs implements relativeComparator;
 proc compareargs.compare(a) {
   return a;
 }
 
 // Bad keyPart args -- need 2 args
 record keyPartArgs { }
-proc keyAndCompare.keyPart(a) {
+keyPartArgs implements keyPartComparator;
+proc keyPartArgs.keyPart(a) {
   return a;
 }
 
+// this should still get a deprecation warning
 // Both key and compare
 record keyAndCompare { }
 proc keyAndCompare.key(a) {
@@ -56,6 +61,7 @@ proc keyAndCompare.compare(a, b) {
   return 0;
 }
 
+// this should still get a deprecation warning
 // Both key and keyPart
 record keyAndKeyPart { }
 proc keyAndKeyPart.key(a) {

--- a/test/library/standard/Sort/errors/errors-comparator.compareargs.good
+++ b/test/library/standard/Sort/errors/errors-comparator.compareargs.good
@@ -1,2 +1,2 @@
 errors-comparator.chpl:9: In function 'main':
-errors-comparator.chpl:17: error: The comparator compareargs must implement either 'keyComparator', 'keyPartComparator', or 'relativeComparator' for int(64)
+errors-comparator.chpl:17: error: The comparator compareargs implements 'relativeComparator' but does not correctly provide a 'compare' method for int(64)

--- a/test/library/standard/Sort/errors/errors-comparator.compareargs.good
+++ b/test/library/standard/Sort/errors/errors-comparator.compareargs.good
@@ -1,2 +1,2 @@
 errors-comparator.chpl:9: In function 'main':
-errors-comparator.chpl:17: error: The comparator compareargs requires a 'key(a)', 'compare(a, b)', or 'keyPart(a, i)' method for element type int(64)
+errors-comparator.chpl:17: error: The comparator compareargs must implement either 'keyComparator', 'keyPartComparator', or 'relativeComparator' for int(64)

--- a/test/library/standard/Sort/errors/errors-comparator.empty.good
+++ b/test/library/standard/Sort/errors/errors-comparator.empty.good
@@ -1,2 +1,2 @@
 errors-comparator.chpl:9: In function 'main':
-errors-comparator.chpl:17: error: The comparator empty requires a 'key(a)', 'compare(a, b)', or 'keyPart(a, i)' method for element type int(64)
+errors-comparator.chpl:17: error: The comparator empty must implement either 'keyComparator', 'keyPartComparator', or 'relativeComparator' for int(64)

--- a/test/library/standard/Sort/errors/errors-comparator.keyandcompare.good
+++ b/test/library/standard/Sort/errors/errors-comparator.keyandcompare.good
@@ -1,3 +1,2 @@
 errors-comparator.chpl:9: In function 'main':
-errors-comparator.chpl:17: warning: Defining a comparator with a 'key' method without implementing the keyComparator interface is deprecated. Please implement the keyComparator interface (i.e. 'record keyAndCompare: keyComparator').
 errors-comparator.chpl:17: error: keyAndCompare contains both a key method and a compare method

--- a/test/library/standard/Sort/errors/errors-comparator.keyandcompare.good
+++ b/test/library/standard/Sort/errors/errors-comparator.keyandcompare.good
@@ -1,2 +1,3 @@
 errors-comparator.chpl:9: In function 'main':
+errors-comparator.chpl:17: warning: Defining a comparator with a 'key' method without implementing the keyComparator interface is deprecated. Please implement the keyComparator interface (i.e. 'record keyAndCompare: keyComparator').
 errors-comparator.chpl:17: error: keyAndCompare contains both a key method and a compare method

--- a/test/library/standard/Sort/errors/errors-comparator.keyandkeypart.good
+++ b/test/library/standard/Sort/errors/errors-comparator.keyandkeypart.good
@@ -1,2 +1,3 @@
 errors-comparator.chpl:9: In function 'main':
+errors-comparator.chpl:17: warning: Defining a comparator with a 'key' method without implementing the keyComparator interface is deprecated. Please implement the keyComparator interface (i.e. 'record keyAndKeyPart: keyComparator').
 errors-comparator.chpl:17: error: keyAndKeyPart contains both a key method and a keyPart method

--- a/test/library/standard/Sort/errors/errors-comparator.keyandkeypart.good
+++ b/test/library/standard/Sort/errors/errors-comparator.keyandkeypart.good
@@ -1,3 +1,2 @@
 errors-comparator.chpl:9: In function 'main':
-errors-comparator.chpl:17: warning: Defining a comparator with a 'key' method without implementing the keyComparator interface is deprecated. Please implement the keyComparator interface (i.e. 'record keyAndKeyPart: keyComparator').
 errors-comparator.chpl:17: error: keyAndKeyPart contains both a key method and a keyPart method

--- a/test/library/standard/Sort/errors/errors-comparator.keyargs.good
+++ b/test/library/standard/Sort/errors/errors-comparator.keyargs.good
@@ -1,2 +1,2 @@
 errors-comparator.chpl:9: In function 'main':
-errors-comparator.chpl:17: error: The comparator keyargs requires a 'key(a)', 'compare(a, b)', or 'keyPart(a, i)' method for element type int(64)
+errors-comparator.chpl:17: error: The comparator keyargs must implement either 'keyComparator', 'keyPartComparator', or 'relativeComparator' for int(64)

--- a/test/library/standard/Sort/errors/errors-comparator.keyargs.good
+++ b/test/library/standard/Sort/errors/errors-comparator.keyargs.good
@@ -1,2 +1,2 @@
 errors-comparator.chpl:9: In function 'main':
-errors-comparator.chpl:17: error: The comparator keyargs must implement either 'keyComparator', 'keyPartComparator', or 'relativeComparator' for int(64)
+errors-comparator.chpl:17: error: The comparator keyargs implements 'keyComparator' but does not correctly provide a 'key' method for int(64)

--- a/test/library/standard/Sort/errors/errors-comparator.keypartargs.good
+++ b/test/library/standard/Sort/errors/errors-comparator.keypartargs.good
@@ -1,2 +1,2 @@
 errors-comparator.chpl:9: In function 'main':
-errors-comparator.chpl:17: error: The comparator keyPartArgs requires a 'key(a)', 'compare(a, b)', or 'keyPart(a, i)' method for element type int(64)
+errors-comparator.chpl:17: error: The comparator keyPartArgs must implement either 'keyComparator', 'keyPartComparator', or 'relativeComparator' for int(64)

--- a/test/library/standard/Sort/errors/errors-comparator.keypartargs.good
+++ b/test/library/standard/Sort/errors/errors-comparator.keypartargs.good
@@ -1,2 +1,2 @@
 errors-comparator.chpl:9: In function 'main':
-errors-comparator.chpl:17: error: The comparator keyPartArgs must implement either 'keyComparator', 'keyPartComparator', or 'relativeComparator' for int(64)
+errors-comparator.chpl:17: error: The comparator keyPartArgs implements 'keyPartComparator' but does not correctly provide a 'keyPart' method for int(64)

--- a/test/library/standard/Sort/errors/errors-comparator.wrong.good
+++ b/test/library/standard/Sort/errors/errors-comparator.wrong.good
@@ -1,2 +1,2 @@
 errors-comparator.chpl:9: In function 'main':
-errors-comparator.chpl:17: error: The comparator wrong must implement either 'keyComparator', 'keyPartComparator', or 'relativeComparator' for int(64)
+errors-comparator.chpl:17: error: The comparator wrong implements 'keyComparator' but does not correctly provide a 'key' method for int(64)

--- a/test/library/standard/Sort/errors/errors-comparator.wrong.good
+++ b/test/library/standard/Sort/errors/errors-comparator.wrong.good
@@ -1,2 +1,2 @@
 errors-comparator.chpl:9: In function 'main':
-errors-comparator.chpl:17: error: The comparator wrong requires a 'key(a)', 'compare(a, b)', or 'keyPart(a, i)' method for element type int(64)
+errors-comparator.chpl:17: error: The comparator wrong must implement either 'keyComparator', 'keyPartComparator', or 'relativeComparator' for int(64)

--- a/test/library/standard/Sort/errors/errors-key.chpl
+++ b/test/library/standard/Sort/errors/errors-key.chpl
@@ -22,6 +22,7 @@ proc main() {
 
 // Return class 'foobar'
 record rec { }
+rec implements keyComparator;
 class foobar { };
 
 proc rec.key(a) {

--- a/test/studies/1brc/concurrentMapVer.chpl
+++ b/test/studies/1brc/concurrentMapVer.chpl
@@ -67,5 +67,5 @@ record adder {
 }
 
 // used to sort tempData records by city name
-record comparator { }
+record comparator: keyComparator { }
 proc comparator.key(k: (bytes, tempData)) { return k[0]; }

--- a/test/unstable/sortInterfaces.chpl
+++ b/test/unstable/sortInterfaces.chpl
@@ -6,3 +6,5 @@ R2 implements keyPartComparator;
 
 record R3 { }
 R3 implements sortComparator;
+
+record R4: keyComparator { }

--- a/test/unstable/sortInterfaces.good
+++ b/test/unstable/sortInterfaces.good
@@ -1,3 +1,4 @@
 sortInterfaces.chpl:5: warning: keyPartComparator is not yet stable
 sortInterfaces.chpl:8: warning: sortComparator is not yet stable
 sortInterfaces.chpl:2: warning: relativeComparator is not yet stable
+sortInterfaces.chpl:10: warning: keyComparator is not yet stable

--- a/tools/unstableWarningAnonymizer/unstableAnonScript.chpl
+++ b/tools/unstableWarningAnonymizer/unstableAnonScript.chpl
@@ -65,7 +65,7 @@ import Set.set;
 import Sort;
 import Regex.regex;
 import ArgumentParser;
-use Sort only relativeComparator;
+use Sort only relativeComparator, keyComparator;
 
 proc countUniqueWarnings(ref warningsMap: map(string, ?t),
                          inputFileReader: IO.fileReader(?)
@@ -172,7 +172,7 @@ proc occurrenceComparator.compare(a: (string, int, int), b: (string, int, int)){
   return b[1] - a[1];  // Reverse sort
 }
 
-record warningComparator {}
+record warningComparator: keyComparator {}
 proc warningComparator.key(a: (string, int, int)) { return a[0]; }
 
 proc convertMapToArray(const m: map(string, ?t), sorted: bool, topX: int)


### PR DESCRIPTION
Adds the `keyComparator` interface to the Sort module. This deprecates the old way of defining comparators with `key` methods.

Implements part of https://github.com/chapel-lang/chapel/issues/25553

Testing
- [x] built and checked docs
- [x] paratest with/without comm

[Reviewed by @lydia-duncan]
