### PR TITLE
Fix `CHPL_TARGET_CPU=unknown` warning with linux packages

### DIFF
--- a/util/packaging/apt/common/fill_docker_template.py
+++ b/util/packaging/apt/common/fill_docker_template.py
@@ -49,6 +49,7 @@ substitutions[
 WORKDIR /home/user/chapel-$CHAPEL_VERSION
 RUN export CHPL_HOME=/home/user/chapel-$CHAPEL_VERSION && \\
     rm -f $CHPL_HOME/chplconfig && touch $CHPL_HOME/chplconfig && \\
+    echo "CHPL_TARGET_CPU=none" >> $CHPL_HOME/chplconfig && \\
     ./configure --prefix=/usr && \\
     nice make all chpldoc mason chplcheck chpl-language-server -j$PARALLEL && \\
     unset CHPL_HOME
@@ -58,23 +59,22 @@ substitutions["BUILD_GASNET_UDP"] = """
 RUN export CHPL_HOME=/home/user/chapel-$CHAPEL_VERSION && \\
     rm -f $CHPL_HOME/chplconfig && touch $CHPL_HOME/chplconfig && \\
     echo "CHPL_COMM=gasnet" >> $CHPL_HOME/chplconfig && \\
+    echo "CHPL_TARGET_CPU=none" >> $CHPL_HOME/chplconfig && \\
     ./configure --prefix=/usr && \\
     nice make all chpldoc mason chplcheck chpl-language-server -j$PARALLEL && \\
     unset CHPL_HOME
 """
 
-# TODO: remove `export CHPL_COMM_OFI_OOB=pmi2` when https://github.com/chapel-lang/chapel/issues/25236 is resolved
 substitutions["BUILD_OFI_SLURM"] = """
 RUN export CHPL_HOME=/home/user/chapel-$CHAPEL_VERSION && \\
-    export CHPL_COMM_OFI_OOB=pmi2 && \\
     rm -f $CHPL_HOME/chplconfig && touch $CHPL_HOME/chplconfig && \\
     echo "CHPL_COMM=ofi" >> $CHPL_HOME/chplconfig && \\
     echo "CHPL_LAUNCHER=slurm-srun" >> $CHPL_HOME/chplconfig && \\
-    echo "CHPL_COMM_OFI_OOB=pmi2" >> $CHPL_HOME/chplconfig && \\
     echo "CHPL_LIBFABRIC=bundled" >> $CHPL_HOME/chplconfig && \\
+    echo "CHPL_TARGET_CPU=none" >> $CHPL_HOME/chplconfig && \\
     ./configure --prefix=/usr && \\
     nice make all chpldoc mason chplcheck chpl-language-server -j$PARALLEL && \\
-    unset CHPL_HOME && unset CHPL_COMM_OFI_OOB
+    unset CHPL_HOME
 """
 
 substitutions[

--- a/util/packaging/apt/common/fill_docker_template.py
+++ b/util/packaging/apt/common/fill_docker_template.py
@@ -70,6 +70,7 @@ RUN export CHPL_HOME=/home/user/chapel-$CHAPEL_VERSION && \\
     rm -f $CHPL_HOME/chplconfig && touch $CHPL_HOME/chplconfig && \\
     echo "CHPL_COMM=ofi" >> $CHPL_HOME/chplconfig && \\
     echo "CHPL_LAUNCHER=slurm-srun" >> $CHPL_HOME/chplconfig && \\
+    echo "CHPL_COMM_OFI_OOB=pmi2" >> $CHPL_HOME/chplconfig && \\
     echo "CHPL_LIBFABRIC=bundled" >> $CHPL_HOME/chplconfig && \\
     echo "CHPL_TARGET_CPU=none" >> $CHPL_HOME/chplconfig && \\
     ./configure --prefix=/usr && \\

--- a/util/packaging/apt/test/Dockerfile.template
+++ b/util/packaging/apt/test/Dockerfile.template
@@ -21,5 +21,5 @@ RUN mason new MyPackage
 WORKDIR /home/user/MyPackage
 RUN chplcheck src/*.chpl
 RUN mason build
-RUN mason run
+RUN mason run -- -nl 1
 WORKDIR /home/user

--- a/util/packaging/common/build_helpers.sh
+++ b/util/packaging/common/build_helpers.sh
@@ -128,10 +128,10 @@ __test_package() {
   python3 $chpl_home/util/packaging/common/test_package.py $@
 }
 __test_all_packages() {
-  for deb in util/packaging/apt/build/*/*/*.deb; do
+  for deb in $(find util/packaging/apt/build -name '*.deb'); do
     __test_package $deb
   done
-  for rpm in util/packaging/rpm/build/*/*/*.rpm; do
+  for rpm in $(find util/packaging/rpm/build -name '*.deb'); do
     __test_package $rpm
   done
 }

--- a/util/packaging/common/build_helpers.sh
+++ b/util/packaging/common/build_helpers.sh
@@ -131,7 +131,7 @@ __test_all_packages() {
   for deb in $(find util/packaging/apt/build -name '*.deb'); do
     __test_package $deb
   done
-  for rpm in $(find util/packaging/rpm/build -name '*.deb'); do
+  for rpm in $(find util/packaging/rpm/build -name '*.rpm'); do
     __test_package $rpm
   done
 }

--- a/util/packaging/common/test_package.py
+++ b/util/packaging/common/test_package.py
@@ -175,6 +175,11 @@ def main():
     test_dir = os.path.join(chpl_home, "util", "packaging", pkg_type, "test")
     test_dir = os.path.abspath(test_dir)
 
+    # TODO: need to figure out how to test the ofi-slurm package automatically
+    if "ofi-slurm" in package:
+        print("Skipping ofi-slurm package")
+        return
+
     docker_os = args.dockeros
     if docker_os is None:
         docker_os = infer_docker_os(package)

--- a/util/packaging/rpm/common/fill_docker_template.py
+++ b/util/packaging/rpm/common/fill_docker_template.py
@@ -72,6 +72,7 @@ RUN export CHPL_HOME=/home/user/chapel-$CHAPEL_VERSION && \\
     rm -f $CHPL_HOME/chplconfig && touch $CHPL_HOME/chplconfig && \\
     echo "CHPL_COMM=ofi" >> $CHPL_HOME/chplconfig && \\
     echo "CHPL_LAUNCHER=slurm-srun" >> $CHPL_HOME/chplconfig && \\
+    echo "CHPL_COMM_OFI_OOB=pmi2" >> $CHPL_HOME/chplconfig && \\
     echo "CHPL_LIBFABRIC=bundled" >> $CHPL_HOME/chplconfig && \\
     echo "CHPL_TARGET_CPU=none" >> $CHPL_HOME/chplconfig && \\
     ./configure --prefix=/usr && \\

--- a/util/packaging/rpm/common/fill_docker_template.py
+++ b/util/packaging/rpm/common/fill_docker_template.py
@@ -51,6 +51,7 @@ substitutions[
 WORKDIR /home/user/chapel-$CHAPEL_VERSION
 RUN export CHPL_HOME=/home/user/chapel-$CHAPEL_VERSION && \\
     rm -f $CHPL_HOME/chplconfig && touch $CHPL_HOME/chplconfig && \\
+    echo "CHPL_TARGET_CPU=none" >> $CHPL_HOME/chplconfig && \\
     ./configure --prefix=/usr && \\
     nice make all chpldoc mason chplcheck chpl-language-server -j$PARALLEL && \\
     unset CHPL_HOME
@@ -60,23 +61,22 @@ substitutions["BUILD_GASNET_UDP"] = """
 RUN export CHPL_HOME=/home/user/chapel-$CHAPEL_VERSION && \\
     rm -f $CHPL_HOME/chplconfig && touch $CHPL_HOME/chplconfig && \\
     echo "CHPL_COMM=gasnet" >> $CHPL_HOME/chplconfig && \\
+    echo "CHPL_TARGET_CPU=none" >> $CHPL_HOME/chplconfig && \\
     ./configure --prefix=/usr && \\
     nice make all chpldoc mason chplcheck chpl-language-server -j$PARALLEL && \\
     unset CHPL_HOME
 """
 
-# TODO: remove `export CHPL_COMM_OFI_OOB=pmi2` when https://github.com/chapel-lang/chapel/issues/25236 is resolved
 substitutions["BUILD_OFI_SLURM"] = """
 RUN export CHPL_HOME=/home/user/chapel-$CHAPEL_VERSION && \\
-    export CHPL_COMM_OFI_OOB=pmi2 && \\
-    rm -f $CHPL_HOME/chplconfig && \\
+    rm -f $CHPL_HOME/chplconfig && touch $CHPL_HOME/chplconfig && \\
     echo "CHPL_COMM=ofi" >> $CHPL_HOME/chplconfig && \\
     echo "CHPL_LAUNCHER=slurm-srun" >> $CHPL_HOME/chplconfig && \\
-    echo "CHPL_COMM_OFI_OOB=pmi2" >> $CHPL_HOME/chplconfig && \\
     echo "CHPL_LIBFABRIC=bundled" >> $CHPL_HOME/chplconfig && \\
+    echo "CHPL_TARGET_CPU=none" >> $CHPL_HOME/chplconfig && \\
     ./configure --prefix=/usr && \\
     nice make all chpldoc mason chplcheck chpl-language-server -j$PARALLEL && \\
-    unset CHPL_HOME && unset CHPL_COMM_OFI_OOB
+    unset CHPL_HOME
 """
 
 substitutions[

--- a/util/packaging/rpm/test/Dockerfile.template
+++ b/util/packaging/rpm/test/Dockerfile.template
@@ -19,5 +19,5 @@ RUN mason new MyPackage
 WORKDIR /home/user/MyPackage
 RUN chplcheck src/*.chpl
 RUN mason build
-RUN mason run
+RUN mason run -- -nl 1
 WORKDIR /home/user


### PR DESCRIPTION
Fixes an issue where the Linux packages built for multi-locale would warn about `CHPL_TARGET_CPU=unknown`. This is just a warning that users could ignore, but after this PR it won't show anyways.

The also fixes an issue where the packages used the default of `CHPL_TARGET_CPU=native` for `COMM=none` builds. This only really worked by happenstance and we should not continue to rely on it. `native` specializes builds for the current microarchitecture the compiler is being run on, this is not correct for packages that need to be distributed to other microarchitectures. However, we got away with it because the docker builds where already the "lowest denominator" platforms. This change does mean we no longer get user code specialization, but that is a [separate issue](https://github.com/chapel-lang/chapel/issues/25419).

Also, this PR resolves a TODO about `CHPL_COMM_OFI_OOB` and fixes some of the test commands for the packages.

Note to reviewer - this PR cherry-picks a few changes from https://github.com/chapel-lang/chapel/pull/25340 so that these changes make it into the 2.2 release, as that PR is too big to get in at this point.

Testing
- [x] ubuntu22 COMM=none package build locally and ran `__test_package`
- [x] fc40 COMM=none package build locally and ran `__test_package`
- [x] el9 COMM=ofi package build locally and tested package on aws cluster
- [x] debian12 COMM=gasnet  package build locally and ran `__test_package`

[Reviewed by @jhh67]