### PR TITLE
Fix missing `instantiatedFrom` on generic-inheriting class types

### DIFF
--- a/frontend/include/chpl/types/CompositeType.h
+++ b/frontend/include/chpl/types/CompositeType.h
@@ -117,8 +117,11 @@ class CompositeType : public Type {
     CHPL_ASSERT(instantiatedFrom_ == nullptr ||
            instantiatedFrom_->instantiatedFrom_ == nullptr);
 
-    // check that subs is consistent with instantiatedFrom
-    CHPL_ASSERT((instantiatedFrom_ == nullptr) == subs_.empty());
+    // check that subs is consistent with instantiatedFrom, except in the
+    // case of class types which can be generic with empty subs due to
+    // inheritance
+    CHPL_ASSERT(tag == typetags::BasicClassType ||
+                (instantiatedFrom_ == nullptr) == subs_.empty());
   }
 
   bool compositeTypeContentsMatchInner(const CompositeType* other) const {

--- a/frontend/lib/resolution/InitResolver.cpp
+++ b/frontend/lib/resolution/InitResolver.cpp
@@ -279,7 +279,8 @@ static const Type* ctFromSubs(Context* context,
     auto oldBasic = cls->basicClassType();
     CHPL_ASSERT(oldBasic && "Not handled!");
 
-    bool genericParent = superType && superType->substitutions().size() != 0;
+    bool genericParent =
+        superType && superType->instantiatedFromCompositeType() != nullptr;
     auto instantiatedFrom = (subs.size() == 0 && !genericParent)
                                   ? nullptr
                                   : root->toBasicClassType();
@@ -311,7 +312,8 @@ const Type* InitResolver::computeReceiverTypeConsideringState(void) {
                                        DefaultsPolicy::USE_DEFAULTS);
   CompositeType::SubstitutionsMap subs;
 
-  bool genericParent = superType_ && superType_->substitutions().size() != 0;
+  bool genericParent =
+      superType_ && superType_->instantiatedFromCompositeType() != nullptr;
 
   if (!rfNoDefaults.isGeneric()) {
     if (genericParent) {

--- a/frontend/lib/resolution/InitResolver.cpp
+++ b/frontend/lib/resolution/InitResolver.cpp
@@ -279,13 +279,15 @@ static const Type* ctFromSubs(Context* context,
     auto oldBasic = cls->basicClassType();
     CHPL_ASSERT(oldBasic && "Not handled!");
 
-    auto instantatiatedFrom = subs.size() == 0 ? nullptr :
-                                                 root->toBasicClassType();
+    bool genericParent = superType && superType->substitutions().size() != 0;
+    auto instantiatedFrom = (subs.size() == 0 && !genericParent)
+                                  ? nullptr
+                                  : root->toBasicClassType();
 
     auto basic = BasicClassType::get(context, oldBasic->id(),
                                      oldBasic->name(),
                                      superType,
-                                     instantatiatedFrom,
+                                     instantiatedFrom,
                                      subs);
     auto manager = AnyOwnedType::get(context);
     auto dec = ClassTypeDecorator(ClassTypeDecorator::BORROWED_NONNIL);

--- a/frontend/lib/resolution/InitResolver.cpp
+++ b/frontend/lib/resolution/InitResolver.cpp
@@ -270,8 +270,7 @@ static const Type* ctFromSubs(Context* context,
   const Type* ret = nullptr;
 
   if (auto rec = receiverType->toRecordType()) {
-    auto instantatiatedFrom = subs.size() == 0 ? nullptr :
-                                                 root->toRecordType();
+    auto instantatiatedFrom = subs.empty() ? nullptr : root->toRecordType();
     ret = RecordType::get(context, rec->id(), rec->name(),
                           instantatiatedFrom,
                           subs);
@@ -281,9 +280,8 @@ static const Type* ctFromSubs(Context* context,
 
     bool genericParent =
         superType && superType->instantiatedFromCompositeType() != nullptr;
-    auto instantiatedFrom = (subs.size() == 0 && !genericParent)
-                                  ? nullptr
-                                  : root->toBasicClassType();
+    auto instantiatedFrom =
+        (subs.empty() && !genericParent) ? nullptr : root->toBasicClassType();
 
     auto basic = BasicClassType::get(context, oldBasic->id(),
                                      oldBasic->name(),
@@ -368,7 +366,7 @@ const Type* InitResolver::computeReceiverTypeConsideringState(void) {
     }
   }
 
-  if (subs.size() != 0 || genericParent) {
+  if (!subs.empty() || genericParent) {
     const Type* ret = ctFromSubs(ctx_, initialRecvType_, superType_, ctInitial, subs);
     CHPL_ASSERT(ret);
     return ret;

--- a/frontend/test/resolution/testInitSemantics.cpp
+++ b/frontend/test/resolution/testInitSemantics.cpp
@@ -1348,9 +1348,14 @@ static void testInheritance() {
         proc init(type A) {
           super.init(A);
         }
+
+        proc doNothing() {}
       }
 
       var x = new Child(int);
+
+      // ensure we can call a method on this receiver type after init
+      x.doNothing();
     )""";
 
     auto vars = resolveTypesOfVariables(context, program, {"x"});

--- a/frontend/test/resolution/testInitSemantics.cpp
+++ b/frontend/test/resolution/testInitSemantics.cpp
@@ -1365,6 +1365,46 @@ static void testInheritance() {
     x.type()->stringify(ss, chpl::StringifyKind::CHPL_SYNTAX);
     assert(ss.str() == "owned Child(int(64))");
   }
+
+  // Generic grandparent, concrete parent, concrete child
+  {
+    Context ctx;
+    Context* context = &ctx;
+    ErrorGuard guard(context);
+
+    std::string program = R"""(
+      class Grandparent {
+        type A;
+      }
+
+      class Parent : Grandparent {
+        proc init(type A) {
+          super.init(A);
+        }
+      }
+
+      class Child : Parent {
+
+        proc init(type A) {
+          super.init(A);
+        }
+
+        proc doNothing() {}
+      }
+
+      var x = new Child(int);
+
+      // ensure we can call a method on this receiver type after init
+      x.doNothing();
+    )""";
+
+    auto vars = resolveTypesOfVariables(context, program, {"x"});
+    auto x = vars["x"];
+
+    std::stringstream ss;
+    x.type()->stringify(ss, chpl::StringifyKind::CHPL_SYNTAX);
+    assert(ss.str() == "owned Child(int(64))");
+  }
 }
 
 static void testInitGenericAfterConcrete() {


### PR DESCRIPTION
This prevented Dyno from resolving method calls on class types that are generic only by virtue of inheriting from a generic parent.

Fixed by relaxing the guard on setting `instantiatedFrom` in `ctFromSubs` to also allow it for class types with a generic parent. Along with this, relax the assertion in the `CompositeType` constructor requires no `instantiatedFrom` with empty substitutions, to not be enforced on class types.

Includes adding test coverage of the fixed case.

Resolves https://github.com/Cray/chapel-private/issues/6672.

[reviewer info placeholder]

Testing:
- [x] dyno tests