### PR TITLE
Fix paths in packaging scripts

### DIFF
--- a/util/packaging/common/build_helpers.sh
+++ b/util/packaging/common/build_helpers.sh
@@ -125,13 +125,13 @@ __run_container() {
 }
 
 __test_package() {
-  python3 $chpl_home/util/packaging/common/test_package.py $@
+  python3 $CHPL_HOME/util/packaging/common/test_package.py $@
 }
 __test_all_packages() {
-  for deb in $(find util/packaging/apt/build -name '*.deb'); do
+  for deb in $(find $CHPL_HOME/util/packaging/apt/build -name '*.deb'); do
     __test_package $deb
   done
-  for rpm in $(find util/packaging/rpm/build -name '*.rpm'); do
+  for rpm in $(find $CHPL_HOME/util/packaging/rpm/build -name '*.rpm'); do
     __test_package $rpm
   done
 }


### PR DESCRIPTION
Fixes paths to be absolute based on CHPL_HOME in the test scripts for the linux packages.

[Reviewed by @jhh67 and @tzinsky]