### PR TITLE
Add a suppressif for an ALA test

### DIFF
--- a/test/optimizations/autoLocalAccess/unalignedFollower.suppressif
+++ b/test/optimizations/autoLocalAccess/unalignedFollower.suppressif
@@ -1,0 +1,1 @@
+COMPOPTS<=--baseline


### PR DESCRIPTION
A newly added test was generating one less line of `--report-auto-local-access` output when compiling with `--baseline`. I believe this is due to the fact that with `--baseline` we disable fast followers. This results in one less loop body to report ALA information. This PR, adds a suppressif for the test in question.