### PR TITLE
Skip testing a CHAMPS executable with the C backend

### DIFF
--- a/test/studies/champs/sub_test
+++ b/test/studies/champs/sub_test
@@ -93,7 +93,14 @@ if [ -z "$CHAMPS_QUICKSTART" ] || [ ! -z "$CHAMPS_COMPILE_ALL_EXECS" ] ; then
   test_compile geo
   test_compile thermo
   test_compile postLink
-  test_compile post
+
+  # we are seeing OOM issues with the C backend that we attribute to a
+  # system/backend issue. Until we figure out what's going wrong, stop testing
+  # this executable with the C backend
+  if [ "${CHPL_LLVM}" != "none" ] ; then
+    test_compile post
+  fi
+
   test_compile stochasticIcing
   test_compile octree
   test_compile eigenSolvePost


### PR DESCRIPTION
We are seeing OOM issues with the C backend that we attribute to a
system/backend issue. Until we figure out what's going wrong, stop testing
a CHAMPS executable with the C backend.