### PR TITLE
Improve errors for missue of `Sort` with arrays and domains

### DIFF
--- a/modules/internal/ChapelDomain.chpl
+++ b/modules/internal/ChapelDomain.chpl
@@ -2802,8 +2802,7 @@ module ChapelDomain {
         compilerWarning(
           "It is recommended to use 'Sort.sorted' instead of this method. ",
           "Compile with '-snoSortedWarnings' to suppress this warning.");
-      import Sort;
-      for x in Sort.sorted(this, comparator=comparator) do yield x;
+      for x in this._value.dsiSorted(comparator) do yield x;
     }
 
     @chpldoc.nodoc

--- a/modules/internal/ChapelDomain.chpl
+++ b/modules/internal/ChapelDomain.chpl
@@ -2794,7 +2794,15 @@ module ChapelDomain {
     }
 
     // associative array interface
-    /* Yields the domain indices in sorted order. */
+    /*
+      Yields the domain indices in sorted order. This method is only supported
+      on associative domains.
+
+      .. warning::
+
+         It is recommended to use :proc:`Sort.sorted` instead of this method.
+
+    */
     iter sorted(comparator:?t = chpl_defaultComparator()) {
       if !this.isAssociative() then
         compilerError("'.sorted()' is only supported on associative domains");

--- a/modules/internal/ChapelDomain.chpl
+++ b/modules/internal/ChapelDomain.chpl
@@ -2795,17 +2795,15 @@ module ChapelDomain {
 
     // associative array interface
     /* Yields the domain indices in sorted order. */
-    iter sorted(comparator:?t = chpl_defaultComparator()) where this.isAssociative() {
+    iter sorted(comparator:?t = chpl_defaultComparator()) {
+      if !this.isAssociative() then
+        compilerError("'.sorted()' is only supported on associative domains");
       if !noSortedWarnings then
         compilerWarning(
           "It is recommended to use 'Sort.sorted' instead of this method. ",
           "Compile with '-snoSortedWarnings' to suppress this warning.");
-      for i in _value.dsiSorted(comparator) {
-        yield i;
-      }
-    }
-    iter sorted(comparator:?t = chpl_defaultComparator()) where !this.isAssociative() {
-      compilerError("'.sorted()' is only supported on associative domains");
+      import Sort;
+      for x in Sort.sorted(this, comparator=comparator) do yield x;
     }
 
     @chpldoc.nodoc

--- a/modules/internal/ChapelDomain.chpl
+++ b/modules/internal/ChapelDomain.chpl
@@ -46,6 +46,9 @@ module ChapelDomain {
   @chpldoc.nodoc
   config param noNegativeStrideWarnings = false;
 
+  @chpldoc.nodoc
+  config param noSortedWarnings = false;
+
   pragma "no copy return"
   pragma "return not owned"
   proc _getDomain(value) {
@@ -2792,10 +2795,17 @@ module ChapelDomain {
 
     // associative array interface
     /* Yields the domain indices in sorted order. */
-    iter sorted(comparator:?t = chpl_defaultComparator()) {
+    iter sorted(comparator:?t = chpl_defaultComparator()) where this.isAssociative() {
+      if !noSortedWarnings then
+        compilerWarning(
+          "It is recommended to use 'Sort.sorted' instead of this method. ",
+          "Compile with '-snoSortedWarnings' to suppress this warning.");
       for i in _value.dsiSorted(comparator) {
         yield i;
       }
+    }
+    iter sorted(comparator:?t = chpl_defaultComparator()) where !this.isAssociative() {
+      compilerError("'.sorted()' is only supported on associative domains");
     }
 
     @chpldoc.nodoc

--- a/modules/packages/ReplicatedVar.chpl
+++ b/modules/packages/ReplicatedVar.chpl
@@ -146,7 +146,8 @@ proc rcCollect(replicatedVar: [?D] ?MYTYPE, ref collected: [?CD] MYTYPE): void
   var targetLocales = _rcTargetLocalesHelper(replicatedVar);
   assert(replicatedVar.domain == rcDomainBase);
   for idx in collected.domain do assert(targetLocales.domain.contains(idx));
-  coforall (idx, col) in zip(targetLocales.domain.sorted(), collected) do
+  import Sort;
+  coforall (idx, col) in zip(Sort.sorted(targetLocales.domain), collected) do
     on targetLocales[idx] do
       col = replicatedVar[rcDomainIx];
 }

--- a/modules/standard/Sort.chpl
+++ b/modules/standard/Sort.chpl
@@ -892,8 +892,8 @@ iter sorted(x : domain, comparator:? = new DefaultComparator()) {
 //
 // TODO - Make standalone or leader/follower parallel iterator
 /*
-   Yield the elements of argument `x` in sorted order, using sort
-   algorithm.
+   Yield the elements of argument `x` in sorted order, using the same algorithm
+   as :proc:`sort`.
 
    .. note:
 

--- a/modules/standard/Sort.chpl
+++ b/modules/standard/Sort.chpl
@@ -784,6 +784,11 @@ proc sort(ref x: [?Dom] , comparator:? = new DefaultComparator(), param stable:b
   where Dom.rank != 1 || !x.isRectangular() {
     compilerError("sort() is currently only supported for 1D rectangular arrays");
 }
+@chpldoc.nodoc
+proc sort(ref x: domain,
+          comparator:? = new DefaultComparator(),
+          param stable:bool = false) do
+  compilerError("sort() is not supported on domains");
 
 /*
    Check if array `x` is in sorted order
@@ -841,9 +846,12 @@ proc isSorted(x: list(?), comparator:? = new DefaultComparator()): bool {
 @chpldoc.nodoc
 /* Error message for multi-dimension arrays */
 proc isSorted(x: [], comparator:? = new DefaultComparator())
-  where x.domain.rank != 1 {
-    compilerError("isSorted() requires 1-D array");
+  where x.rank != 1 || !x.isRectangular() {
+    compilerError("isSorted() is currently only supported for 1D rectangular arrays");
 }
+@chpldoc.nodoc
+proc isSorted(x: domain, comparator:? = new DefaultComparator()) do
+  compilerError("isSorted() is not supported on domains");
 
 /*
    Check if array `Data` is in sorted order
@@ -862,11 +870,16 @@ proc isSorted(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator): bool {
 }
 
 @chpldoc.nodoc
-iter sorted(x : domain, comparator:? = new DefaultComparator()) {
+iter sorted(x : domain, comparator:? = new DefaultComparator())
+  where x.isAssociative() {
   for i in x._value.dsiSorted(comparator) {
     yield i;
   }
 }
+@chpldoc.nodoc
+iter sorted(x: domain, comparator:? = new DefaultComparator())
+  where !x.isAssociative() do
+  compilerError("sorted() is currently only supported on associative domains");
 
 //
 // This is a first draft "sorterator" which is designed to take some

--- a/modules/standard/Sort.chpl
+++ b/modules/standard/Sort.chpl
@@ -918,7 +918,10 @@ iter sorted(x, comparator:? = new DefaultComparator()) {
     }
   } else if isArrayValue(x) && Reflection.canResolveMethod(x._value, "dsiSorted") {
     compilerError(x._value.type:string + " does not support dsiSorted(comparator)");
-  } else {
+  } else if isArrayValue(x) && x.isSparse() {
+    compilerError("sorted() is not supported on sparse arrays");
+  }
+  else {
     var y = x; // need to do before isArrayValue test in case x is an iterable
     param iterable = isArrayValue(y) || isSubtype(y.type, List.list(?));
     if iterable {

--- a/modules/standard/Sort.chpl
+++ b/modules/standard/Sort.chpl
@@ -870,16 +870,13 @@ proc isSorted(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator): bool {
 }
 
 @chpldoc.nodoc
-iter sorted(x : domain, comparator:? = new DefaultComparator())
-  where x.isAssociative() {
+iter sorted(x : domain, comparator:? = new DefaultComparator()) {
+  if !x.isAssociative() then
+    compilerError("sorted() is currently only supported on associative domains");
   for i in x._value.dsiSorted(comparator) {
     yield i;
   }
 }
-@chpldoc.nodoc
-iter sorted(x: domain, comparator:? = new DefaultComparator())
-  where !x.isAssociative() do
-  compilerError("sorted() is currently only supported on associative domains");
 
 //
 // This is a first draft "sorterator" which is designed to take some

--- a/test/arrays/diten/enumArrayMethods.chpl
+++ b/test/arrays/diten/enumArrayMethods.chpl
@@ -1,20 +1,21 @@
+import Sort;
 enum E {a=1, b=0, c=2};
 
 var D: domain(E) = E.a..E.c;
 
-writeln(D.sorted());
+writeln(Sort.sorted(D));
 
 D -= E.a;
-writeln(D.sorted());
+writeln(Sort.sorted(D));
 
 D -= E.b;
-writeln(D.sorted());
+writeln(Sort.sorted(D));
 
 D += E.a;
-writeln(D.sorted());
+writeln(Sort.sorted(D));
 
 D += E.b;
-writeln(D.sorted());
+writeln(Sort.sorted(D));
 
 D.clear();
-writeln(D.sorted());
+writeln(Sort.sorted(D));

--- a/test/arrays/diten/nestSortedIter.chpl
+++ b/test/arrays/diten/nestSortedIter.chpl
@@ -1,7 +1,8 @@
+import Sort;
 var D: domain(int);
 D += 1; D += 2; D+=4; D += 3;
-for a in D.sorted() {
-  for b in D.sorted() {
+for a in Sort.sorted(D) {
+  for b in Sort.sorted(D) {
     writeln((a,b));
   }
 }

--- a/test/associative/bharshbarg/domains/recordWithRange.chpl
+++ b/test/associative/bharshbarg/domains/recordWithRange.chpl
@@ -1,3 +1,4 @@
+import Sort;
 use List;
 
 config const n = 100;
@@ -58,5 +59,5 @@ for 1..n {
   assert(D.size == recs.size);
 }
 
-for d in D.sorted() do
+for d in Sort.sorted(D) do
   writeln(d, " => ", A[d]);

--- a/test/associative/bradc/assocRecord.chpl
+++ b/test/associative/bradc/assocRecord.chpl
@@ -1,3 +1,4 @@
+import Sort;
 record Coord {
   var x: int;
   var y: int;
@@ -20,7 +21,7 @@ Name(c1) = "z basis coordinate";
 Name(c2) = "y basis coordinate";
 Name(c3) = "x basis coordinate";
 
-for coord in D.sorted() {
+for coord in Sort.sorted(D) {
   writeln("coord ", coord, " is called ", Name(coord));
 }
 

--- a/test/associative/deitz/arrays/test_indefinite4.chpl
+++ b/test/associative/deitz/arrays/test_indefinite4.chpl
@@ -1,3 +1,4 @@
+import Sort;
 use printHelp;
 
 var d : domain(int);
@@ -12,5 +13,5 @@ a(5) = 4;
 writelnSorted(d);
 writelnSortedByDom(a);
 
-for i in d.sorted() do
+for i in Sort.sorted(d) do
   writeln(i, " -> ", a(i));

--- a/test/associative/deitz/arrays/test_indefinite5.chpl
+++ b/test/associative/deitz/arrays/test_indefinite5.chpl
@@ -1,3 +1,4 @@
+import Sort;
 use printHelp;
 
 var d : domain(int);
@@ -12,5 +13,5 @@ a(0) = 4;
 writelnSorted(d);
 writelnSortedByDom(a);
 
-for i in d.sorted() do
+for i in Sort.sorted(d) do
   writeln(i, " -> ", a(i));

--- a/test/associative/deitz/arrays/test_indefinite6.chpl
+++ b/test/associative/deitz/arrays/test_indefinite6.chpl
@@ -1,3 +1,4 @@
+import Sort;
 use printHelp;
 
 var d : domain(int);
@@ -12,5 +13,5 @@ a(0) = 4;
 writelnSorted(d);
 writelnSortedByDom(a);
 
-for i in d.sorted() do
+for i in Sort.sorted(d) do
   writeln(i, " -> ", a(i));

--- a/test/associative/deitz/arrays/test_indefinite7.chpl
+++ b/test/associative/deitz/arrays/test_indefinite7.chpl
@@ -1,3 +1,4 @@
+import Sort;
 use printHelp;
 
 var d : domain(string);
@@ -12,5 +13,5 @@ a("zero") = 4;
 writelnSorted(d);
 writelnSortedByDom(a);
 
-for i in d.sorted() do
+for i in Sort.sorted(d) do
   writeln(i, " -> ", a(i));

--- a/test/associative/deitz/domains/test_indefinite_domain_of_tuple.chpl
+++ b/test/associative/deitz/domains/test_indefinite_domain_of_tuple.chpl
@@ -1,3 +1,4 @@
+import Sort;
 use printHelp;
 
 type t = (int, int);
@@ -8,5 +9,5 @@ writelnSorted(D);
 var A: [D] int;
 A((1, 2)) = 5;
 A((3, 4)) = 6;
-for i in D.sorted() do
+for i in Sort.sorted(D) do
   writeln((i, A(i)));

--- a/test/associative/ferguson/plus-reduce-assoc.chpl
+++ b/test/associative/ferguson/plus-reduce-assoc.chpl
@@ -1,3 +1,4 @@
+import Sort;
 // Can I use + reduce on associative domain?
 var D: domain(int);
 
@@ -9,8 +10,8 @@ proc makeD(x:int) {
 
 D = + reduce [i in 1..10] makeD(i);
 
-writeln(D.sorted());
+writeln(Sort.sorted(D));
 
 var D2 = + reduce for i in 1..10 do makeD(i);
 
-writeln(D2.sorted());
+writeln(Sort.sorted(D2));

--- a/test/associative/ferguson/plus-reduce-intent-assoc.chpl
+++ b/test/associative/ferguson/plus-reduce-intent-assoc.chpl
@@ -1,3 +1,4 @@
+import Sort;
 // Can use + reduce intent on associative domain?
 var D: domain(int);
 
@@ -5,4 +6,4 @@ forall x in 1..10 with (+ reduce D) {
   D += x;
 }
 
-writeln(D.sorted());
+writeln(Sort.sorted(D));

--- a/test/classes/bradc/arrayInClass/arrayOfArithInClass.chpl
+++ b/test/classes/bradc/arrayInClass/arrayOfArithInClass.chpl
@@ -1,3 +1,4 @@
+import Sort;
 // declare class types
 
 class ArithC {
@@ -22,7 +23,7 @@ class EnumC {
 }
 
 iter sortedAssoc(arr) {
-  for k in arr.domain.sorted() {
+  for k in Sort.sorted(arr.domain) {
     yield arr[k];
   }
 }
@@ -31,7 +32,7 @@ iter sortedAssoc(arr) {
 
 proc foo(C) {
   if (C.x.domain.isAssociative()) {
-    writeln("C.x.domain is: ", C.x.domain.sorted());
+    writeln("C.x.domain is: ", Sort.sorted(C.x.domain));
     writeln("x is: ", sortedAssoc(C.x));
   } else {
     writeln("C.x.domain is: ", C.x.domain);

--- a/test/classes/bradc/arrayInClass/genericArrayInClass-arith.chpl
+++ b/test/classes/bradc/arrayInClass/genericArrayInClass-arith.chpl
@@ -1,3 +1,4 @@
+import Sort;
 // declare class types
 
 class ArithC {
@@ -30,7 +31,7 @@ class EnumC {
 }
 
 iter sortedAssoc(arr) {
-  for k in arr.domain.sorted() {
+  for k in Sort.sorted(arr.domain) {
     yield arr[k];
   }
 }
@@ -39,7 +40,7 @@ iter sortedAssoc(arr) {
 
 proc foo(C) {
   if (C.x.domain.isAssociative()) {
-    writeln("C.x.domain is: ", C.x.domain.sorted());
+    writeln("C.x.domain is: ", Sort.sorted(C.x.domain));
     writeln("x is: ", sortedAssoc(C.x));
   } else {
     writeln("C.x.domain is: ", C.x.domain);

--- a/test/classes/bradc/arrayInClass/genericArrayInClass-otharrs.chpl
+++ b/test/classes/bradc/arrayInClass/genericArrayInClass-otharrs.chpl
@@ -1,3 +1,4 @@
+import Sort;
 // declare class types
 
 class ArithC {
@@ -31,7 +32,7 @@ class EnumC {
 
 /* We have to handle nested associative types */
 iter sortedOut(arr) {
-  const ks = if arr.domain.isAssociative() then arr.domain.sorted() else arr.domain;
+  const ks = if arr.domain.isAssociative() then Sort.sorted(arr.domain) else arr.domain;
   for k in ks {
     const x = arr[k];
     if isArrayType(x.type) && x.domain.isAssociative() {
@@ -47,7 +48,7 @@ iter sortedOut(arr) {
 
 proc foo(C) {
   if (C.x.domain.isAssociative()) {
-    writeln("C.x.domain is: ", C.x.domain.sorted());
+    writeln("C.x.domain is: ", Sort.sorted(C.x.domain));
     writeln("x is: ", sortedOut(C.x));
   } else {
     writeln("C.x.domain is: ", C.x.domain);

--- a/test/classes/bradc/arrayInClass/genericArrayInClass-real.chpl
+++ b/test/classes/bradc/arrayInClass/genericArrayInClass-real.chpl
@@ -1,3 +1,4 @@
+import Sort;
 // declare class types
 
 class ArithC {
@@ -30,7 +31,7 @@ class EnumC {
 }
 
 iter sortedAssoc(arr) {
-  for k in arr.domain.sorted() {
+  for k in Sort.sorted(arr.domain) {
     yield arr[k];
   }
 }
@@ -39,7 +40,7 @@ iter sortedAssoc(arr) {
 
 proc foo(C) {
   if (C.x.domain.isAssociative()) {
-    writeln("C.x.domain is: ", C.x.domain.sorted());
+    writeln("C.x.domain is: ", Sort.sorted(C.x.domain));
     writeln("x is: ", sortedAssoc(C.x));
   } else {
     writeln("C.x.domain is: ", C.x.domain);

--- a/test/classes/bradc/arrayInClass/genericClassArray-named.chpl
+++ b/test/classes/bradc/arrayInClass/genericClassArray-named.chpl
@@ -1,5 +1,6 @@
+import Sort;
 iter sortedAssoc(arr) {
-  for k in arr.domain.sorted() {
+  for k in Sort.sorted(arr.domain) {
     yield arr[k];
   }
 }
@@ -11,7 +12,7 @@ class C {
 
   proc foo() {
     if (x.domain.isAssociative()) {
-      writeln("x.domain is: ", x.domain.sorted());
+      writeln("x.domain is: ", Sort.sorted(x.domain));
       writeln("x is: ", sortedAssoc(x));
     } else {
       writeln("x.domain is: ", x.domain);

--- a/test/distributions/bradc/assoc/userAssoc-array-domain-zipper.chpl
+++ b/test/distributions/bradc/assoc/userAssoc-array-domain-zipper.chpl
@@ -1,3 +1,4 @@
+import Sort;
 use HashedDist;
 
 config const verbose = false;
@@ -20,7 +21,7 @@ D += 2.4;
 D += 3.5;
 
 writeln("D is:");
-for d in D.sorted() {
+for d in Sort.sorted(D) {
   writeln(d);
 }
 
@@ -31,7 +32,7 @@ A(2.4) = "two point four";
 A(3.5) = "three point five";
 
 writeln("A is:");
-for d in D.sorted() {
+for d in Sort.sorted(D) {
   writeln(A[d]);
   if verbose then
     writeln(A[d], " on locale ", A[d].locale);

--- a/test/distributions/bradc/assoc/userAssoc-basic-domain.chpl
+++ b/test/distributions/bradc/assoc/userAssoc-basic-domain.chpl
@@ -1,3 +1,4 @@
+import Sort;
 use HashedDist;
 
 record MyMapper {
@@ -37,7 +38,7 @@ D += 3.5;
 
 // check .sorted()
 writeln("D is:");
-for d in D.sorted() {
+for d in Sort.sorted(D) {
   writeln(d);
 }
 

--- a/test/distributions/bradc/assoc/userAssoc-dom-operations.chpl
+++ b/test/distributions/bradc/assoc/userAssoc-dom-operations.chpl
@@ -1,3 +1,4 @@
+import Sort;
 use HashedDist;
 
 config const verbose = false;
@@ -20,7 +21,7 @@ D += 8.8;
 D -= 3.5;
 
 writeln("D is:");
-for d in D.sorted() {
+for d in Sort.sorted(D) {
   writeln(d);
 }
 
@@ -40,7 +41,7 @@ A(7.7) = "seven point seven";
 A(8.8) = "eight point eight";
 
 writeln("A is:");
-for d in D.sorted() {
+for d in Sort.sorted(D) {
   writeln(d, ": ", A[d]);
   if verbose then
     writeln(A[d], " on locale ", A[d].locale);
@@ -49,7 +50,7 @@ writeln();
 
 D += 9.9;
 writeln("after adding 9.9 to D, A is:");
-for d in D.sorted() {
+for d in Sort.sorted(D) {
   writeln(d, ": ", A[d]);
   if verbose then
     writeln(A[d], " on locale ", A[d].locale);
@@ -61,7 +62,7 @@ D.clear();
 
 assert(!D.contains(9.9));
 writeln("after D.clear, A is:");
-for d in D.sorted() {
+for d in Sort.sorted(D) {
   writeln(A[d]);
   if verbose then
     writeln(A[d], " on locale ", A[d].locale);

--- a/test/distributions/robust/associative/basic/domain_write.chpl
+++ b/test/distributions/robust/associative/basic/domain_write.chpl
@@ -13,8 +13,8 @@ for i in D {
   DomStringType += s;
 }
 
-writeln(DomIntType.sorted());
-writeln(DomUintType.sorted());
-writeln(DomRealType.sorted());
-writeln(DomStringType.sorted());
+writeln(Sort.sorted(DomIntType));
+writeln(Sort.sorted(DomUintType));
+writeln(Sort.sorted(DomRealType));
+writeln(Sort.sorted(DomStringType));
 

--- a/test/distributions/robust/associative/basic/whole_domain_assign.chpl
+++ b/test/distributions/robust/associative/basic/whole_domain_assign.chpl
@@ -33,7 +33,7 @@ proc testWhole(DA) {
   DA2 = DA;
   if debug then writeln(DA2);
   var success = true;
-  for (ai, ai2) in zip(DA.sorted(), DA2.sorted()) {
+  for (ai, ai2) in zip(Sort.sorted(DA), Sort.sorted(DA2)) {
     if ai != ai2 {
       success = false;
       break;

--- a/test/domains/assoc/assocSorted.chpl
+++ b/test/domains/assoc/assocSorted.chpl
@@ -1,0 +1,6 @@
+// ensure that .sorted() continues to work on associative domains
+use Sort;
+var d: domain(int) = {4,3,5,6,2,1,1};
+writeln(d.type:string);
+writeln(d.sorted());
+writeln(d.sorted(new ReverseComparator()));

--- a/test/domains/assoc/assocSorted.compopts
+++ b/test/domains/assoc/assocSorted.compopts
@@ -1,1 +1,1 @@
--sassocParSafeDefault -snoParSafeWarning -snoSortedWarnings
+-sassocParSafeDefault=false -snoParSafeWarning -snoSortedWarnings

--- a/test/domains/assoc/assocSorted.compopts
+++ b/test/domains/assoc/assocSorted.compopts
@@ -1,0 +1,1 @@
+-sassocParSafeDefault -snoParSafeWarning -snoSortedWarnings

--- a/test/domains/assoc/assocSorted.good
+++ b/test/domains/assoc/assocSorted.good
@@ -1,0 +1,3 @@
+DefaultAssociativeDom(int(64),false)
+1 2 3 4 5 6
+6 5 4 3 2 1

--- a/test/domains/operators/domainAdd.chpl
+++ b/test/domains/operators/domainAdd.chpl
@@ -1,31 +1,32 @@
+import Sort;
 {
   var D1 : domain(int) = { 1..10 };
   var D2 : domain(int) = { 20..30 };
   var D3 : domain(int) = D1 + D2;
-  writeln(D1.sorted());
-  writeln(D2.sorted());
-  writeln(D3.sorted());
+  writeln(Sort.sorted(D1));
+  writeln(Sort.sorted(D2));
+  writeln(Sort.sorted(D3));
 }
 
 {
   var D1 : domain(int) = { 1..10 };
   var D2 : domain(int) = { 20..30 };
   var D3 : domain(int) = D2 + D1;
-  writeln(D1.sorted());
-  writeln(D2.sorted());
-  writeln(D3.sorted());
+  writeln(Sort.sorted(D1));
+  writeln(Sort.sorted(D2));
+  writeln(Sort.sorted(D3));
 }
 
 {
   var D1 : domain(int) = { 1..10 };
   var D3 : domain(int) = D1 + 50;
-  writeln(D1.sorted());
-  writeln(D3.sorted());
+  writeln(Sort.sorted(D1));
+  writeln(Sort.sorted(D3));
 }
 
 {
   var D1 : domain(int) = { 1..10 };
   var D3 : domain(int) = 50 + D1;
-  writeln(D1.sorted());
-  writeln(D3.sorted());
+  writeln(Sort.sorted(D1));
+  writeln(Sort.sorted(D3));
 }

--- a/test/domains/operators/domainSub.chpl
+++ b/test/domains/operators/domainSub.chpl
@@ -1,15 +1,16 @@
+import Sort;
 {
   var D1 : domain(int) = { 10..30 };
   var D2 : domain(int) = { 20..30 };
   var D3 : domain(int) = D1 - D2;
-  writeln(D1.sorted());
-  writeln(D2.sorted());
-  writeln(D3.sorted());
+  writeln(Sort.sorted(D1));
+  writeln(Sort.sorted(D2));
+  writeln(Sort.sorted(D3));
 }
 
 {
   var D1 : domain(int) = { 1..10 };
   var D3 : domain(int) = D1 - 5;
-  writeln(D1.sorted());
-  writeln(D3.sorted());
+  writeln(Sort.sorted(D1));
+  writeln(Sort.sorted(D3));
 }

--- a/test/domains/sungeun/assoc/clear.chpl
+++ b/test/domains/sungeun/assoc/clear.chpl
@@ -1,3 +1,4 @@
+import Sort;
 config const n = 10;
 
 var D: domain(int);
@@ -5,19 +6,19 @@ var A: [D] int;
 
 for i in 1..n do D += i;
 A = 1;
-for i in D.sorted() do write((i, A[i]));
+for i in Sort.sorted(D) do write((i, A[i]));
 writeln();
 
 for i in 1..n by 2 do D -= i;
-for i in D.sorted() do write((i, A[i]));
+for i in Sort.sorted(D) do write((i, A[i]));
 writeln();
 
 for i in 1..n do D += i;
 A += 1;
-for i in D.sorted() do write((i, A[i]));
+for i in Sort.sorted(D) do write((i, A[i]));
 writeln();
 
 D.clear();
 for i in 1..n do D += i;
-for i in D.sorted() do write((i, A[i]));
+for i in Sort.sorted(D) do write((i, A[i]));
 writeln();

--- a/test/domains/sungeun/assoc/equals_minus_1.chpl
+++ b/test/domains/sungeun/assoc/equals_minus_1.chpl
@@ -1,3 +1,4 @@
+import Sort;
 config param parSafe = true;
 config const n = 7;
 
@@ -7,14 +8,14 @@ D1 += n+1;
 D1 += n;
 D1 += n-1;
 D1 += n-2;
-writeln(D1.sorted());
+writeln(Sort.sorted(D1));
 
 var D2: domain(int, parSafe=parSafe);
 D2 += n;
 D2 += n+1;
 D2 += n+2;
-writeln(D2.sorted());
+writeln(Sort.sorted(D2));
 
 var D3 = D1 - D2;
-writeln(D3.sorted());
+writeln(Sort.sorted(D3));
 

--- a/test/domains/sungeun/assoc/equals_minus_2.chpl
+++ b/test/domains/sungeun/assoc/equals_minus_2.chpl
@@ -1,3 +1,4 @@
+import Sort;
 config param parSafe = true;
 config const n = 7;
 
@@ -5,8 +6,8 @@ var D1: domain(int, parSafe=parSafe);
 D1 += n;
 D1 += n-1;
 D1 += n-2;
-writeln(D1.sorted());
+writeln(Sort.sorted(D1));
 
 var D2 = D1 - n;
-writeln(D2.sorted());
+writeln(Sort.sorted(D2));
 

--- a/test/domains/sungeun/assoc/equals_plus_1.chpl
+++ b/test/domains/sungeun/assoc/equals_plus_1.chpl
@@ -1,3 +1,4 @@
+import Sort;
 config param parSafe = true;
 config const n = 7;
 
@@ -5,14 +6,14 @@ var D1: domain(int, parSafe=parSafe);
 D1 += n;
 D1 += n-1;
 D1 += n-2;
-writeln(D1.sorted());
+writeln(Sort.sorted(D1));
 
 var D2: domain(int, parSafe=parSafe);
 D2 += n;
 D2 += n+1;
 D2 += n+2;
-writeln(D2.sorted());
+writeln(Sort.sorted(D2));
 
 var D3 = D1 + D2;
-writeln(D3.sorted());
+writeln(Sort.sorted(D3));
 

--- a/test/domains/sungeun/assoc/equals_plus_2.chpl
+++ b/test/domains/sungeun/assoc/equals_plus_2.chpl
@@ -1,3 +1,4 @@
+import Sort;
 config param parSafe = true;
 config const n = 7;
 
@@ -6,8 +7,8 @@ D1 += n+2;
 D1 += n+1;
 D1 += n-1;
 D1 += n-2;
-writeln(D1.sorted());
+writeln(Sort.sorted(D1));
 
 var D2 = D1 + n;
-writeln(D2.sorted());
+writeln(Sort.sorted(D2));
 

--- a/test/domains/sungeun/assoc/forall.chpl
+++ b/test/domains/sungeun/assoc/forall.chpl
@@ -1,3 +1,4 @@
+import Sort;
 config param parSafe = true;
 config const n = 50000;
 
@@ -11,4 +12,4 @@ serial !parSafe {
     D1 -= max(int)-i;
 }
 
-writeln(D1.sorted());
+writeln(Sort.sorted(D1));

--- a/test/domains/sungeun/assoc/index_not_in_domain_1.chpl
+++ b/test/domains/sungeun/assoc/index_not_in_domain_1.chpl
@@ -1,3 +1,4 @@
+import Sort;
 config param parSafe = true;
 
 var D1: domain(int, parSafe=parSafe);
@@ -5,7 +6,7 @@ D1 += max(int);
 D1 += max(int)/2;
 D1 += max(int)/4;
 D1 += max(int)/8;
-writeln(D1.sorted());
+writeln(Sort.sorted(D1));
 
 var D2: domain(int, parSafe=parSafe);
 D2 += max(int);
@@ -13,8 +14,8 @@ D2 += max(int)/2;
 D2 += max(int)/4;
 D2 += max(int)/8;
 D2 += max(int)/16;
-writeln(D2.sorted());
+writeln(Sort.sorted(D2));
 
 D1 -= D2;
-writeln(D2.sorted());
+writeln(Sort.sorted(D2));
 

--- a/test/domains/sungeun/assoc/index_not_in_domain_2.chpl
+++ b/test/domains/sungeun/assoc/index_not_in_domain_2.chpl
@@ -1,3 +1,4 @@
+import Sort;
 config param parSafe = true;
 
 var D1: domain(int, parSafe=parSafe);
@@ -27,5 +28,5 @@ assert(retval == 0);
 
 proc printDomainSorted() {
   write("Indices in domain: ");
-  writeln(D1.sorted());
+  writeln(Sort.sorted(D1));
 }

--- a/test/domains/sungeun/assoc/minus_equals.chpl
+++ b/test/domains/sungeun/assoc/minus_equals.chpl
@@ -1,3 +1,4 @@
+import Sort;
 config param parSafe = true;
 
 var D1: domain(int, parSafe=parSafe);
@@ -5,7 +6,7 @@ D1 += max(int);
 D1 += max(int)/2;
 D1 += max(int)/4;
 D1 += max(int)/8;
-writeln(D1.sorted());
+writeln(Sort.sorted(D1));
 
 var D2: domain(int, parSafe=parSafe);
 D2 += max(int)/8;
@@ -15,7 +16,7 @@ D2 += max(int);
 D2 += max(int)/16;
 D2 += max(int)/32;
 D2 += max(int)/64;
-writeln(D2.sorted());
+writeln(Sort.sorted(D2));
 
 serial !parSafe do D2 -= D1;
-writeln(D2.sorted());
+writeln(Sort.sorted(D2));

--- a/test/domains/sungeun/assoc/plus_equals.chpl
+++ b/test/domains/sungeun/assoc/plus_equals.chpl
@@ -1,15 +1,16 @@
+import Sort;
 config param parSafe = true;
 config const n = 10;
 
 var D1: domain(int, parSafe=parSafe);
 for i in 0..n do
   D1 += max(int)-i;
-writeln(D1.sorted());
+writeln(Sort.sorted(D1));
 
 var D2: domain(int, parSafe=parSafe);
 for i in 0..n do
   D2 += min(int)+i;
-writeln(D2.sorted());
+writeln(Sort.sorted(D2));
 
 serial !parSafe do D2 += D1;
-writeln(D2.sorted());
+writeln(Sort.sorted(D2));

--- a/test/domains/sungeun/assoc/plus_minus_equals.chpl
+++ b/test/domains/sungeun/assoc/plus_minus_equals.chpl
@@ -1,3 +1,4 @@
+import Sort;
 config param parSafe = true;
 
 var D1: domain(int, parSafe=parSafe);
@@ -5,32 +6,32 @@ D1 += max(int);
 D1 += max(int)/2;
 D1 += max(int)/4;
 D1 += max(int)/8;
-writeln(D1.sorted());
+writeln(Sort.sorted(D1));
 
 D1 += 1;
-writeln(D1.sorted());
+writeln(Sort.sorted(D1));
 
 D1 -= max(int)/4;
-writeln(D1.sorted());
+writeln(Sort.sorted(D1));
 
 D1 += 1;
-writeln(D1.sorted());
+writeln(Sort.sorted(D1));
 
 D1 -= max(int);
-writeln(D1.sorted());
+writeln(Sort.sorted(D1));
 
 D1 += 1;
-writeln(D1.sorted());
+writeln(Sort.sorted(D1));
 
 D1 -= max(int)/8;
-writeln(D1.sorted());
+writeln(Sort.sorted(D1));
 
 D1 += 1;
-writeln(D1.sorted());
+writeln(Sort.sorted(D1));
 
 D1 -= max(int)/2;
-writeln(D1.sorted());
+writeln(Sort.sorted(D1));
 
 D1 += 1;
-writeln(D1.sorted());
+writeln(Sort.sorted(D1));
 

--- a/test/domains/sungeun/assoc/stress.chpl
+++ b/test/domains/sungeun/assoc/stress.chpl
@@ -1,3 +1,4 @@
+import Sort;
 config param parSafe = true;
 config const doSerial = false;
 
@@ -25,7 +26,7 @@ for p in 1..numSwapPasses {
   }
 }
 
-writeln(D.sorted());
+writeln(Sort.sorted(D));
 sync serial doSerial || (!doSerial && !parSafe) {
   writeln("Start adding..");
   begin with (ref D, ref inserted) forall i in 1..numAdds with (ref D, ref inserted) {
@@ -48,4 +49,4 @@ sync serial doSerial || (!doSerial && !parSafe) {
   }
 }
 
-writeln(D.sorted());
+writeln(Sort.sorted(D));

--- a/test/domains/sungeun/assoc/stress.numthr.chpl
+++ b/test/domains/sungeun/assoc/stress.numthr.chpl
@@ -1,3 +1,4 @@
+import Sort;
 config param parSafe = true;
 config const doSerial = false;
 
@@ -25,7 +26,7 @@ for p in 1..numSwapPasses {
   }
 }
 
-writeln(D.sorted());
+writeln(Sort.sorted(D));
 sync serial doSerial || (!doSerial && !parSafe) {
   writeln("Start adding..");
   begin with (ref D, ref inserted) forall i in 1..numAdds with (ref D, ref inserted) {
@@ -48,4 +49,4 @@ sync serial doSerial || (!doSerial && !parSafe) {
   }
 }
 
-writeln(D.sorted());
+writeln(Sort.sorted(D));

--- a/test/exercises/duplicates/duplicates-alt-assoc-reduce.chpl
+++ b/test/exercises/duplicates/duplicates-alt-assoc-reduce.chpl
@@ -132,10 +132,10 @@ proc main(args: [] string) {
   // stumbling block: associative array key+value iteration
   // stumbling block: associative array key+value iteration in sorted order
   writeln("Duplicate files found:");
-  for hash in hashesToPaths.keys.sorted() {
+  for hash in sorted(hashesToPaths.keys) {
     if hashesToPaths.values[hash].keys.size > 1 {
       writeln(hash);
-      for path in hashesToPaths.values[hash].keys.sorted() {
+      for path in sorted(hashesToPaths.values[hash].keys) {
         writeln("  ", path);
       }
     }

--- a/test/exercises/duplicates/duplicates-alt-assoc.chpl
+++ b/test/exercises/duplicates/duplicates-alt-assoc.chpl
@@ -60,10 +60,10 @@ proc main(args: [] string) {
   // stumbling block: associative array key+value iteration
   // stumbling block: associative array key+value iteration in sorted order
   writeln("Duplicate files found:");
-  for hash in hashes.sorted() {
+  for hash in sorted(hashes) {
     if hashesToPaths[hash].size > 1 {
       writeln(hash);
-      for path in hashesToPaths[hash].sorted() {
+      for path in sorted(hashesToPaths[hash]) {
         writeln("  ", path);
       }
     }

--- a/test/functions/deitz/iterators/leader_follower/test_neg_stride_range_leader_follower.chpl
+++ b/test/functions/deitz/iterators/leader_follower/test_neg_stride_range_leader_follower.chpl
@@ -1,3 +1,4 @@
+import Sort;
 var D: domain((int,int), parSafe=false);
 
 var lock: sync bool;
@@ -8,7 +9,7 @@ forall (i,j) in zip(1..7 by -1, 0..) with (ref D) {
   lock.readFE();
 }
 
-writeln(D.sorted());
+writeln(Sort.sorted(D));
 D.clear();
 
 forall (i,j) in zip(1..7 by -2, 0..) with (ref D) {
@@ -17,7 +18,7 @@ forall (i,j) in zip(1..7 by -2, 0..) with (ref D) {
   lock.readFE();
 }
 
-writeln(D.sorted());
+writeln(Sort.sorted(D));
 D.clear();
 
 forall (i,j) in zip(1..4, 1..7 by -2) with (ref D) {
@@ -26,7 +27,7 @@ forall (i,j) in zip(1..4, 1..7 by -2) with (ref D) {
   lock.readFE();
 }
 
-writeln(D.sorted());
+writeln(Sort.sorted(D));
 D.clear();
 
 forall (i,j) in zip({1..7 by -1}, 0..) with (ref D) {
@@ -35,7 +36,7 @@ forall (i,j) in zip({1..7 by -1}, 0..) with (ref D) {
   lock.readFE();
 }
 
-writeln(D.sorted());
+writeln(Sort.sorted(D));
 D.clear();
 
 forall (i,j) in zip({1..7 by -2}, 0..) with (ref D) {
@@ -44,7 +45,7 @@ forall (i,j) in zip({1..7 by -2}, 0..) with (ref D) {
   lock.readFE();
 }
 
-writeln(D.sorted());
+writeln(Sort.sorted(D));
 D.clear();
 
 forall (i,j) in zip({1..4}, {1..7 by -2}) with (ref D) {
@@ -53,4 +54,4 @@ forall (i,j) in zip({1..4}, {1..7 by -2}) with (ref D) {
   lock.readFE();
 }
 
-writeln(D.sorted());
+writeln(Sort.sorted(D));

--- a/test/io/ferguson/assoc-array-chpl.chpl
+++ b/test/io/ferguson/assoc-array-chpl.chpl
@@ -1,4 +1,4 @@
-use IO, ChplFormat;
+use IO, ChplFormat, Sort;
 
 proc main() {
   var tmp = openTempFile();
@@ -14,10 +14,10 @@ proc main() {
     tmp.reader(deserializer = new chplDeserializer(), locking=false).readf("%?\n", B);
   }
 
-  for key in A.domain.sorted() {
+  for key in Sort.sorted(A.domain) {
     writeln("A[", key, "]=", A[key]);
   }
-  for key in B.domain.sorted() {
+  for key in Sort.sorted(B.domain) {
     writeln("B[", key, "]=", B[key]);
   }
 }

--- a/test/io/ferguson/assoc-domains.chpl
+++ b/test/io/ferguson/assoc-domains.chpl
@@ -1,8 +1,9 @@
+import Sort;
 use IO;
 
 
 proc testText(ref seeds: domain(int)) {
-  writeln("in testText ", seeds.sorted());
+  writeln("in testText ", Sort.sorted(seeds));
   var lf = open('test.log' : string, ioMode.cwr);
   var delta: [seeds] real;
   var po: domain(int);
@@ -13,13 +14,13 @@ proc testText(ref seeds: domain(int)) {
   var z = lf.reader(locking=false);
   c.write(seeds);
   c.flush();
-  writeln("Wrote: ", seeds.sorted());
+  writeln("Wrote: ", Sort.sorted(seeds));
   var ok = z.read(po);
   assert(ok);
-  writeln("Read: ", po.sorted());
+  writeln("Read: ", Sort.sorted(po));
 }
 proc testBinary(ref seeds: domain(int)) {
-  writeln("in testBinary ", seeds.sorted());
+  writeln("in testBinary ", Sort.sorted(seeds));
   var lf = open('test.log' : string, ioMode.cwr);
   var delta: [seeds] real;
   var po: domain(int);
@@ -30,10 +31,10 @@ proc testBinary(ref seeds: domain(int)) {
   var z = lf.reader(deserializer=new binaryDeserializer(), locking=false);
   c.write(seeds);
   c.flush();
-  writeln("Wrote: ", seeds.sorted());
+  writeln("Wrote: ", Sort.sorted(seeds));
   var ok = z.read(po);
   assert(ok);
-  writeln("Read: ", po.sorted());
+  writeln("Read: ", Sort.sorted(po));
 }
 
 proc test(in seeds) {

--- a/test/library/draft/DataFrames/DataFrames.chpl
+++ b/test/library/draft/DataFrames/DataFrames.chpl
@@ -248,7 +248,7 @@ module DataFrames {
       var idxWidth = writeIdxWidth() + 1;
       for space in 1..idxWidth do
         f.write(" ");
-      const labelsSorted = d.labels.sorted();
+      const labelsSorted = sorted(d.labels);
       for lab in labelsSorted {
         f.write(lab + "   ");
       }
@@ -832,7 +832,7 @@ module DataFrames {
         var n = nrows();
         var nStr = n: string;
         var idxWidth = nStr.size + 1;
-        const labelsSorted = labels.sorted();
+        const labelsSorted = sorted(labels);
 
         for space in 1..idxWidth do
           writer.write(" ");

--- a/test/library/standard/Sort/errors/sortDomainArray.assoc1.good
+++ b/test/library/standard/Sort/errors/sortDomainArray.assoc1.good
@@ -1,0 +1,1 @@
+sortDomainArray.chpl:33: error: sort() is not supported on domains

--- a/test/library/standard/Sort/errors/sortDomainArray.assoc1.good
+++ b/test/library/standard/Sort/errors/sortDomainArray.assoc1.good
@@ -1,1 +1,1 @@
-sortDomainArray.chpl:33: error: sort() is not supported on domains
+sortDomainArray.chpl:49: error: sort() is not supported on domains

--- a/test/library/standard/Sort/errors/sortDomainArray.assoc2.good
+++ b/test/library/standard/Sort/errors/sortDomainArray.assoc2.good
@@ -1,0 +1,1 @@
+sortDomainArray.chpl:50: error: isSorted() is not supported on domains

--- a/test/library/standard/Sort/errors/sortDomainArray.assoc4.good
+++ b/test/library/standard/Sort/errors/sortDomainArray.assoc4.good
@@ -1,0 +1,1 @@
+sortDomainArray.chpl:52: error: sort() is currently only supported for 1D rectangular arrays

--- a/test/library/standard/Sort/errors/sortDomainArray.assoc5.good
+++ b/test/library/standard/Sort/errors/sortDomainArray.assoc5.good
@@ -1,1 +1,1 @@
-sortDomainArray.chpl:53: error: isSorted() is not supported on domains
+sortDomainArray.chpl:53: error: isSorted() is currently only supported for 1D rectangular arrays

--- a/test/library/standard/Sort/errors/sortDomainArray.assoc5.good
+++ b/test/library/standard/Sort/errors/sortDomainArray.assoc5.good
@@ -1,0 +1,1 @@
+sortDomainArray.chpl:53: error: isSorted() is not supported on domains

--- a/test/library/standard/Sort/errors/sortDomainArray.assoc7.good
+++ b/test/library/standard/Sort/errors/sortDomainArray.assoc7.good
@@ -1,0 +1,4 @@
+sortDomainArray.chpl:55: warning: It is recommended to use 'Sort.sorted' instead of this method. Compile with '-snoSortedWarnings' to suppress this warning.
+sortDomainArray.chpl:55: warning: It is recommended to use 'Sort.sorted' instead of this method. Compile with '-snoSortedWarnings' to suppress this warning.
+Note: This source location is a guess.
+sortDomainArray.chpl:55: warning: It is recommended to use 'Sort.sorted' instead of this method. Compile with '-snoSortedWarnings' to suppress this warning.

--- a/test/library/standard/Sort/errors/sortDomainArray.chpl
+++ b/test/library/standard/Sort/errors/sortDomainArray.chpl
@@ -36,7 +36,7 @@ if sparse3 then sorted(SpsD); // should be an error
 if sparse4 then sort(SpsA); // should be an error
 if sparse5 then isSorted(SpsA); // should be an error
 if sparse6 then sorted(SpsA); // should be an error
-/*TODO*/ if sparse7 then SpsD.sorted(); // should be an error
+if sparse7 then SpsD.sorted(); // should be an error
 
 
 //
@@ -52,7 +52,7 @@ if assoc3 then sorted(AssocD);
 if assoc4 then sort(AssocA); // should be an error
 if assoc5 then isSorted(AssocA); // should be an error
 if assoc6 then sorted(AssocA);
-/*TODO*/ if assoc7 then AssocD.sorted(); // not an error, but should it warn???? prefer `sorted(AssocD)`
+if assoc7 then AssocD.sorted(); // not an error, but warns
 
 
 //
@@ -68,4 +68,4 @@ if rect3 then sorted(RectD); // should be an error
 if rect4 then sort(RectA);
 if rect5 then isSorted(RectA);
 if rect6 then sorted(RectA);
-/*TODO*/ if rect7 then RectD.sorted(); // should be an error, see https://github.com/chapel-lang/chapel/issues/25109
+if rect7 then RectD.sorted(); // should be an error

--- a/test/library/standard/Sort/errors/sortDomainArray.chpl
+++ b/test/library/standard/Sort/errors/sortDomainArray.chpl
@@ -1,0 +1,71 @@
+use Sort;
+
+config param sparse1 = false,
+             sparse2 = false,
+             sparse3 = false,
+             sparse4 = false,
+             sparse5 = false,
+             sparse6 = false,
+             sparse7 = false;
+config param assoc1 = false,
+             assoc2 = false,
+             assoc3 = false,
+             assoc4 = false,
+             assoc5 = false,
+             assoc6 = false,
+             assoc7 = false;
+config param rect1 = false,
+             rect2 = false,
+             rect3 = false,
+             rect4 = false,
+             rect5 = false,
+             rect6 = false,
+             rect7 = false;
+
+
+//
+// Sparse
+//
+
+var SpsD: sparse subdomain({1..10});
+var SpsA: [SpsD] real;
+
+if sparse1 then sort(SpsD); // should be an error
+if sparse2 then isSorted(SpsD); // should be an error
+if sparse3 then sorted(SpsD); // should be an error
+if sparse4 then sort(SpsA); // should be an error
+if sparse5 then isSorted(SpsA); // should be an error
+if sparse6 then sorted(SpsA); // should be an error
+/*TODO*/ if sparse7 then SpsD.sorted(); // should be an error
+
+
+//
+// Associative
+//
+
+var AssocD: domain(string, parSafe=false) = {"bar", "foo"};
+var AssocA = [1 => "one", 10 => "ten", 3 => "three", 16 => "sixteen"];
+
+if assoc1 then sort(AssocD); // should be an error
+if assoc2 then isSorted(AssocD); // should be an error
+if assoc3 then sorted(AssocD);
+if assoc4 then sort(AssocA); // should be an error
+if assoc5 then isSorted(AssocA); // should be an error
+if assoc6 then sorted(AssocA);
+/*TODO*/ if assoc7 then AssocD.sorted(); // not an error, but should it warn???? prefer `sorted(AssocD)`
+
+
+//
+// Rectangular
+//
+
+var RectD = {1..10};
+var RectA: [RectD] real;
+
+if rect1 then sort(RectD); // should be an error
+if rect2 then isSorted(RectD); // should be an error
+if rect3 then sorted(RectD); // should be an error
+if rect4 then sort(RectA);
+if rect5 then isSorted(RectA);
+if rect6 then sorted(RectA);
+/*TODO*/ if rect7 then RectD.sorted(); // should be an error, see https://github.com/chapel-lang/chapel/issues/25109

--- a/test/library/standard/Sort/errors/sortDomainArray.compopts
+++ b/test/library/standard/Sort/errors/sortDomainArray.compopts
@@ -1,0 +1,20 @@
+# good case with no compiler errors
+-sassoc3 -sassoc6 -srect4 -srect5 -srect6 # sortDomainArray.good
+-sassoc7 # sortDomainArray.assoc7.good
+
+# the rest should be some form of compiler error
+-ssparse1   # sortDomainArray.sparse1.good
+-ssparse2   # sortDomainArray.sparse2.good
+-ssparse3   # sortDomainArray.sparse3.good
+-ssparse4   # sortDomainArray.sparse4.good
+-ssparse5   # sortDomainArray.sparse5.good
+-ssparse6   # sortDomainArray.sparse6.good
+-ssparse7   # sortDomainArray.sparse7.good
+-sassoc1    # sortDomainArray.assoc1.good
+-sassoc2    # sortDomainArray.assoc2.good
+-sassoc4    # sortDomainArray.assoc4.good
+-sassoc5    # sortDomainArray.assoc5.good
+-srect1     # sortDomainArray.rect1.good
+-srect2     # sortDomainArray.rect2.good
+-srect3     # sortDomainArray.rect3.good
+-srect7     # sortDomainArray.rect7.good

--- a/test/library/standard/Sort/errors/sortDomainArray.compopts
+++ b/test/library/standard/Sort/errors/sortDomainArray.compopts
@@ -1,6 +1,11 @@
 # good case with no compiler errors
 -sassoc3 -sassoc6 -srect4 -srect5 -srect6 # sortDomainArray.good
+
+# this case has warnings
 -sassoc7 # sortDomainArray.assoc7.good
+# disable the warnings with a compiler flag
+-sassoc7 -snoSortedWarnings # sortDomainArray.good
+
 
 # the rest should be some form of compiler error
 -ssparse1   # sortDomainArray.sparse1.good

--- a/test/library/standard/Sort/errors/sortDomainArray.rect1.good
+++ b/test/library/standard/Sort/errors/sortDomainArray.rect1.good
@@ -1,0 +1,1 @@
+sortDomainArray.chpl:33: error: sort() is not supported on domains

--- a/test/library/standard/Sort/errors/sortDomainArray.rect1.good
+++ b/test/library/standard/Sort/errors/sortDomainArray.rect1.good
@@ -1,1 +1,1 @@
-sortDomainArray.chpl:33: error: sort() is not supported on domains
+sortDomainArray.chpl:65: error: sort() is not supported on domains

--- a/test/library/standard/Sort/errors/sortDomainArray.rect2.good
+++ b/test/library/standard/Sort/errors/sortDomainArray.rect2.good
@@ -1,0 +1,1 @@
+sortDomainArray.chpl:66: error: isSorted() is not supported on domains

--- a/test/library/standard/Sort/errors/sortDomainArray.rect3.good
+++ b/test/library/standard/Sort/errors/sortDomainArray.rect3.good
@@ -1,0 +1,1 @@
+sortDomainArray.chpl:67: error: sorted() is currently only supported on associative domains

--- a/test/library/standard/Sort/errors/sortDomainArray.rect7.good
+++ b/test/library/standard/Sort/errors/sortDomainArray.rect7.good
@@ -1,6 +1,1 @@
-sortDomainArray.chpl:71: error: unresolved call 'unmanaged domain(1,int(64),one).dsiSorted(DefaultComparator)'
-$CHPL_HOME/modules/internal/DefaultAssociative.chpl:nnnn: note: this candidate did not match: DefaultAssociativeDom.dsiSorted(comparator)
-$CHPL_HOME/modules/internal/ChapelDomain.chpl:nnnn: note: because method call receiver with type 'unmanaged domain(1,int(64),one)'
-$CHPL_HOME/modules/internal/DefaultAssociative.chpl:nnnn: note: is passed to formal 'this: borrowed DefaultAssociativeDom'
-sortDomainArray.chpl:71: note: other candidates are:
-$CHPL_HOME/modules/internal/DefaultAssociative.chpl:nnnn: note:   DefaultAssociativeArr.dsiSorted(comparator)
+sortDomainArray.chpl:71: error: '.sorted()' is only supported on associative domains

--- a/test/library/standard/Sort/errors/sortDomainArray.rect7.good
+++ b/test/library/standard/Sort/errors/sortDomainArray.rect7.good
@@ -1,0 +1,6 @@
+sortDomainArray.chpl:71: error: unresolved call 'unmanaged domain(1,int(64),one).dsiSorted(DefaultComparator)'
+$CHPL_HOME/modules/internal/DefaultAssociative.chpl:nnnn: note: this candidate did not match: DefaultAssociativeDom.dsiSorted(comparator)
+$CHPL_HOME/modules/internal/ChapelDomain.chpl:nnnn: note: because method call receiver with type 'unmanaged domain(1,int(64),one)'
+$CHPL_HOME/modules/internal/DefaultAssociative.chpl:nnnn: note: is passed to formal 'this: borrowed DefaultAssociativeDom'
+sortDomainArray.chpl:71: note: other candidates are:
+$CHPL_HOME/modules/internal/DefaultAssociative.chpl:nnnn: note:   DefaultAssociativeArr.dsiSorted(comparator)

--- a/test/library/standard/Sort/errors/sortDomainArray.sparse1.good
+++ b/test/library/standard/Sort/errors/sortDomainArray.sparse1.good
@@ -1,0 +1,1 @@
+sortDomainArray.chpl:33: error: sort() is not supported on domains

--- a/test/library/standard/Sort/errors/sortDomainArray.sparse2.good
+++ b/test/library/standard/Sort/errors/sortDomainArray.sparse2.good
@@ -1,0 +1,1 @@
+sortDomainArray.chpl:34: error: isSorted() is not supported on domains

--- a/test/library/standard/Sort/errors/sortDomainArray.sparse3.good
+++ b/test/library/standard/Sort/errors/sortDomainArray.sparse3.good
@@ -1,0 +1,1 @@
+sortDomainArray.chpl:35: error: sorted() is currently only supported on associative domains

--- a/test/library/standard/Sort/errors/sortDomainArray.sparse4.good
+++ b/test/library/standard/Sort/errors/sortDomainArray.sparse4.good
@@ -1,0 +1,1 @@
+sortDomainArray.chpl:36: error: sort() is currently only supported for 1D rectangular arrays

--- a/test/library/standard/Sort/errors/sortDomainArray.sparse5.good
+++ b/test/library/standard/Sort/errors/sortDomainArray.sparse5.good
@@ -1,0 +1,1 @@
+sortDomainArray.chpl:37: error: isSorted() is currently only supported for 1D rectangular arrays

--- a/test/library/standard/Sort/errors/sortDomainArray.sparse6.good
+++ b/test/library/standard/Sort/errors/sortDomainArray.sparse6.good
@@ -1,0 +1,1 @@
+sortDomainArray.chpl:38: error: sorted() is currently only supported on associative domains

--- a/test/library/standard/Sort/errors/sortDomainArray.sparse6.good
+++ b/test/library/standard/Sort/errors/sortDomainArray.sparse6.good
@@ -1,1 +1,1 @@
-sortDomainArray.chpl:38: error: sorted() is currently only supported on associative domains
+sortDomainArray.chpl:38: error: sorted() is not supported on sparse arrays

--- a/test/library/standard/Sort/errors/sortDomainArray.sparse7.good
+++ b/test/library/standard/Sort/errors/sortDomainArray.sparse7.good
@@ -1,6 +1,1 @@
-sortDomainArray.chpl:39: error: unresolved call 'unmanaged DefaultSparseDom(1,int(64),domain(1,int(64),one)).dsiSorted(DefaultComparator)'
-$CHPL_HOME/modules/internal/DefaultAssociative.chpl:nnnn: note: this candidate did not match: DefaultAssociativeDom.dsiSorted(comparator)
-$CHPL_HOME/modules/internal/ChapelDomain.chpl:nnnn: note: because method call receiver with type 'unmanaged DefaultSparseDom(1,int(64),domain(1,int(64),one))'
-$CHPL_HOME/modules/internal/DefaultAssociative.chpl:nnnn: note: is passed to formal 'this: borrowed DefaultAssociativeDom'
-sortDomainArray.chpl:39: note: other candidates are:
-$CHPL_HOME/modules/internal/DefaultAssociative.chpl:nnnn: note:   DefaultAssociativeArr.dsiSorted(comparator)
+sortDomainArray.chpl:39: error: '.sorted()' is only supported on associative domains

--- a/test/library/standard/Sort/errors/sortDomainArray.sparse7.good
+++ b/test/library/standard/Sort/errors/sortDomainArray.sparse7.good
@@ -1,0 +1,6 @@
+sortDomainArray.chpl:39: error: unresolved call 'unmanaged DefaultSparseDom(1,int(64),domain(1,int(64),one)).dsiSorted(DefaultComparator)'
+$CHPL_HOME/modules/internal/DefaultAssociative.chpl:nnnn: note: this candidate did not match: DefaultAssociativeDom.dsiSorted(comparator)
+$CHPL_HOME/modules/internal/ChapelDomain.chpl:nnnn: note: because method call receiver with type 'unmanaged DefaultSparseDom(1,int(64),domain(1,int(64),one))'
+$CHPL_HOME/modules/internal/DefaultAssociative.chpl:nnnn: note: is passed to formal 'this: borrowed DefaultAssociativeDom'
+sortDomainArray.chpl:39: note: other candidates are:
+$CHPL_HOME/modules/internal/DefaultAssociative.chpl:nnnn: note:   DefaultAssociativeArr.dsiSorted(comparator)

--- a/test/release/examples/primers/associative.chpl
+++ b/test/release/examples/primers/associative.chpl
@@ -191,13 +191,14 @@ writeln("Our 'Scores' associative array: ", Scores);
 // Given an array, print in the following format:
 // [ idx => val, ... ]
 //
-// We'll use the ``sorted`` iterator to print in a consistent order. Otherwise,
+// We'll use the ``Sort`` module to print in a consistent order. Otherwise,
 // the order in which indices are yielded is nondeterministic.
 //
 proc prettyPrint(arr : [?dom]) {
   write("[ ");
   var first = true;
-  for k in dom.sorted() {
+  import Sort;
+  for k in Sort.sorted(dom) {
     if !first {
       write(", ", k, " => ", arr[k]);
     } else {

--- a/test/release/examples/primers/learnChapelInYMinutes.chpl
+++ b/test/release/examples/primers/learnChapelInYMinutes.chpl
@@ -377,7 +377,8 @@ stringSet += "b";
 stringSet += "c";
 stringSet += "a"; // Redundant add "a"
 stringSet -= "c"; // Remove "c"
-writeln(stringSet.sorted());
+import Sort;
+writeln(Sort.sorted(stringSet));
 
 // Associative domains can also have a literal syntax
 var intSet = {1, 2, 4, 5, 100};
@@ -447,7 +448,7 @@ writeln(rSum, "\n", realArray);
 var dictDomain: domain(string) = { "one", "two", "three"};
 var dict: [dictDomain] int = ["one" => 1, "two" => 2, "three" => 3];
 
-for key in dictDomain.sorted() do
+for key in Sort.sorted(dictDomain) do
   writeln(dict[key]);
 
 // Arrays can be assigned to each other in a few different ways.

--- a/test/studies/labelprop/labelprop-tweets.chpl
+++ b/test/studies/labelprop/labelprop-tweets.chpl
@@ -59,6 +59,7 @@ use HashedDist;
 use LinkedLists;
 use BlockDist;
 use JSON;
+use Sort;
 
 // packing twitter user IDs to numbers
 var total_tweets_processed : atomic int;
@@ -319,7 +320,7 @@ proc create_and_analyze_graph(ref Pairs)
 
   // reduction intent would help here to compute max node id
   // TODO -- bug: this loop is not working with a forall (compile error)
-  for (node, id) in zip(1..userIds.size, userIds.sorted()) {
+  for (node, id) in zip(1..userIds.size, Sort.sorted(userIds)) {
     idToNode[id] = node:int(32);
     nodeToId[node] = id;
   }

--- a/test/studies/madness/common/test_showboxes.chpl
+++ b/test/studies/madness/common/test_showboxes.chpl
@@ -1,3 +1,4 @@
+import Sort;
 use MRA;
 use MadAnalytics;
 
@@ -19,10 +20,10 @@ proc main() {
     F.evalNPT(npt);
 
     writeln("\nDumping the boxes at each level:");
-    
+
     for lvl in 0..F.max_level { 
         write("\n **",lvl,": ");
-        for (n, l) in F.sumC.indices.sorted() do
+        for (n, l) in Sort.sorted(F.sumC.indices) do
             if n == lvl then write(" [",n,", ",l,"]");
     }
     writeln();

--- a/test/studies/madness/dinan/mad_chapel/test_showboxes.chpl
+++ b/test/studies/madness/dinan/mad_chapel/test_showboxes.chpl
@@ -1,3 +1,4 @@
+import Sort;
 use MRA;
 use MadAnalytics;
 
@@ -22,7 +23,7 @@ proc main() {
     
     for lvl in 0..F.max_level { 
         write("\n **",lvl,": ");
-        for (n, l) in F.s.indices.sorted() do
+        for (n, l) in Sort.sorted(F.s.indices) do
             if n == lvl then write(" [",n,", ",l,"]");
     }
     writeln();

--- a/test/studies/ssca2/graphio/SSCA2_RMAT_graph_generator.chpl
+++ b/test/studies/ssca2/graphio/SSCA2_RMAT_graph_generator.chpl
@@ -25,7 +25,7 @@
 // +=========================================================================+
 
 use SSCA2_compilation_config_params;
-private use IO;
+private use IO, Sort;
 
 record directed_vertex_pair {
   var start = 1: int;
@@ -450,7 +450,7 @@ proc Writeout_RMAT_graph(G, snapshot_prefix:string, dstyle = "-"): void {
     if dEdge then writeln(dstyle, " vertex ", u);
     writeNum(sta, startIx);
 
-    for v in G.Neighbors(u).sorted() {
+    for v in sorted(G.Neighbors(u)) {
       const w = G.Row(u).Weight(v);
       if dRow then write((v, w));
       if dEdge then writeln(dstyle, " ", u, " ", v, " ", w);

--- a/test/types/enum/diten/enumDom.chpl
+++ b/test/types/enum/diten/enumDom.chpl
@@ -1,3 +1,4 @@
+import Sort;
 use LinkedLists;
 
 enum color { red, green, blue };
@@ -16,13 +17,13 @@ var b: [E] int = s;
 
 writeln("(a.domain, s)");
 
-for (i, j) in zip(a.domain.sorted(), s) {
+for (i, j) in zip(Sort.sorted(a.domain), s) {
   writeln(i, " ", j);
 }
 
 writeln("(s, a.domain)");
 
-for (j, i) in zip(s, a.domain.sorted()) {
+for (j, i) in zip(s, Sort.sorted(a.domain)) {
   writeln(i, " ", j);
 }
 

--- a/test/users/shetag/assoc.chpl
+++ b/test/users/shetag/assoc.chpl
@@ -1,3 +1,4 @@
+import Sort;
 type t = (int,int);
 var td : domain(t);
 
@@ -9,19 +10,19 @@ td.add(one);
 td.add(two);
 
 //The two outputs match
-writeln("A  ", td.sorted());
+writeln("A  ", Sort.sorted(td));
 for ind in td do
   writeln("A ", ind);
 
 td.remove(two);
 //The two outputs match
-writeln("B  ", td.sorted());
+writeln("B  ", Sort.sorted(td));
 for ind in td do
   writeln("B ", ind);
 
 td.remove(one);
 //The two outputs match
-writeln("C  ", td.sorted());
+writeln("C  ", Sort.sorted(td));
 for ind in td do
   writeln("C ", ind);
 //Scenario 1 ends
@@ -31,19 +32,19 @@ td.add(one);
 td.add(two);
 
 //The two outputs match
-writeln("D  ", td.sorted());
+writeln("D  ", Sort.sorted(td));
 for ind in td do
   writeln("D ", ind);
 
 td.remove(one);
 //The two outputs *do not* match
-writeln("E  ", td.sorted());
+writeln("E  ", Sort.sorted(td));
 for ind in td do
   writeln("E ", ind); 
 
 td.remove(two);
 //The two outputs match
-writeln("F  ", td.sorted());
+writeln("F  ", Sort.sorted(td));
 for ind in td do
   writeln("F ", ind);
 //Scenario 2 ends


### PR DESCRIPTION
Improves the errors thrown by the Sort module (and .sorted() method) when it is used incorrectly by passing unsupported array.domain types.

This PR also adds a warning to `assocDomain.sorted()`, but it does not deprecate it to maintain backwards compatibility.

- [x] tested with a full paratest with/without comm
- [x] checked that docs build and render properly

Resolves https://github.com/chapel-lang/chapel/issues/25109

[Reviewed by @ShreyasKhandekar]