### PR TITLE
Fix a bug with varargs and const checking

### DIFF
--- a/compiler/resolution/expandVarArgs.cpp
+++ b/compiler/resolution/expandVarArgs.cpp
@@ -473,6 +473,10 @@ static void expandVarArgsBody(FnSymbol*      fn,
     needTuple = true;
   }
 
+  if (formal->intent == INTENT_CONST) {
+    var->addFlag(FLAG_CONST);
+  }
+
   if (needTuple == true) {
     CallExpr* tupleCall = NULL;
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -11557,7 +11557,7 @@ proc fileReader._read_complex(width:uint(32), out t:complex, i:int)
 // arguments from writef. This way, we can use the same code for an `arg` type
 // for which we have already created and instantiation of this.
 @chpldoc.nodoc
-proc fileWriter._writefOne(fmtStr, ref arg, i: int,
+proc fileWriter._writefOne(fmtStr, const ref arg, i: int,
                            ref cur: c_size_t, ref j: int,
                            argType: c_ptr(c_int), argTypeLen: int,
                            ref conv: qio_conv_t, ref gotConv: bool,

--- a/test/functions/constVarargs.chpl
+++ b/test/functions/constVarargs.chpl
@@ -1,0 +1,12 @@
+// Taken from https://github.com/chapel-lang/chapel/issues/25858
+proc myPrintln(const args...)
+{
+  writeln("args.type     = ", args.type:string);
+  writeln("args (before) = ", args);
+
+  args[0] *= 10;  // should not be allowed
+
+  writeln("args (after) = ", args);
+}
+
+myPrintln(1, 2.3, "four");

--- a/test/functions/constVarargs.good
+++ b/test/functions/constVarargs.good
@@ -1,0 +1,3 @@
+constVarargs.chpl:2: In function 'myPrintln':
+constVarargs.chpl:7: error: cannot assign to const variable
+  constVarargs.chpl:12: called as myPrintln(args(0): int(64), args(1): real(64), args(2): string)

--- a/test/functions/constVarargsQuery.chpl
+++ b/test/functions/constVarargsQuery.chpl
@@ -1,0 +1,12 @@
+// Taken from https://github.com/chapel-lang/chapel/issues/25858, modified
+proc myPrintln(const args...?k)
+{
+  writeln("args.type     = ", args.type:string);
+  writeln("args (before) = ", args);
+
+  args[0] *= 10;  // should not be allowed
+
+  writeln("args (after) = ", args);
+}
+
+myPrintln(1, 2.3, "four");

--- a/test/functions/constVarargsQuery.good
+++ b/test/functions/constVarargsQuery.good
@@ -1,0 +1,3 @@
+constVarargsQuery.chpl:2: In function 'myPrintln':
+constVarargsQuery.chpl:7: error: cannot assign to const variable
+  constVarargsQuery.chpl:12: called as myPrintln(args(0): int(64), args(1): real(64), args(2): string)


### PR DESCRIPTION
Resolves #25858 

When expanding a varargs function, we were accidentally dropping the constness of the argument on the floor.  Rectify that mistake.

Fix a varargs function in the IO module that was taking advantage of this bug by making the function it calls with the contents of the varargs also accept a const.

Adds two tests of this bug, covering queried and non-queried sizes for the varargs.

Passed a full paratest with futures
