### PR TITLE
Avoid redundant query graph traversals when tracking errors

### DIFF
--- a/frontend/include/chpl/framework/Context-detail.h
+++ b/frontend/include/chpl/framework/Context-detail.h
@@ -266,6 +266,12 @@ class QueryMapResultBase {
   // Whether or not errors from this query result have been shown to the
   // user (they may not have been if some query checked for errors).
   mutable bool emittedErrors = false;
+  // Whether or not any errors were produced by this query or its dependencies.
+  // This is useful to short-circuit collecting errors (emitted or not)
+  // when they are being tracked and stored in a list.
+  //
+  // This is not too strongly connected to emittedErrors (which tracks whether
+  // errors --- if any --- were shown to the user for this query result only)
   mutable bool errorsPresentInSelfOrDependencies = false;
   mutable std::set<const QueryMapResultBase*> recursionErrors;
   mutable QueryErrorVec errors;

--- a/frontend/include/chpl/framework/Context-detail.h
+++ b/frontend/include/chpl/framework/Context-detail.h
@@ -266,6 +266,7 @@ class QueryMapResultBase {
   // Whether or not errors from this query result have been shown to the
   // user (they may not have been if some query checked for errors).
   mutable bool emittedErrors = false;
+  mutable bool errorsPresentInSelfOrDependencies = false;
   mutable std::set<const QueryMapResultBase*> recursionErrors;
   mutable QueryErrorVec errors;
 
@@ -274,6 +275,7 @@ class QueryMapResultBase {
   QueryMapResultBase(RevisionNumber lastChecked,
                      RevisionNumber lastChanged,
                      bool emittedErrors,
+                     bool errorsPresentInSelfOrDependencies,
                      std::set<const QueryMapResultBase*> recursionErrors,
                      QueryMapBase* parentQueryMap);
   virtual ~QueryMapResultBase() = 0; // this is an abstract base class
@@ -294,18 +296,20 @@ class QueryMapResult final : public QueryMapResultBase {
   //  * a default-constructed result
   QueryMapResult(QueryMap<ResultType, ArgTs...>* parentQueryMap,
                  std::tuple<ArgTs...> tupleOfArgs)
-    : QueryMapResultBase(-1, -1, false, {}, parentQueryMap),
+    : QueryMapResultBase(-1, -1, false, false, {}, parentQueryMap),
       tupleOfArgs(std::move(tupleOfArgs)),
       result() {
   }
   QueryMapResult(RevisionNumber lastChecked,
                  RevisionNumber lastChanged,
                  bool emittedErrors,
+                 bool errorsPresentInSelfOrDependencies,
                  std::set<const QueryMapResultBase*> recursionErrors,
                  QueryMap<ResultType, ArgTs...>* parentQueryMap,
                  std::tuple<ArgTs...> tupleOfArgs,
                  ResultType result)
     : QueryMapResultBase(lastChecked, lastChanged, emittedErrors,
+                         errorsPresentInSelfOrDependencies,
                          std::move(recursionErrors), parentQueryMap),
       tupleOfArgs(std::move(tupleOfArgs)),
       result(std::move(result)) {


### PR DESCRIPTION
@mppf observed that a disproportionate amount of time is being spent finding errors to add into the error collection vector when tracking is enabled. The thing is that most graph nodes don't have any errors to speak of, so the traversals are redundant. This PR adds a simple transitive counter that detects how many errors have occurred. This helps avoid traversing the query graph, and saves most of the overhead that Michael was seeing originally.

Reviewed by @mppf -- thanks!

## Testing
- [x] dyno tests