### PR TITLE
Fix incremented module count.

### DIFF
--- a/test/optimizations/deadCodeElimination/elliot/countDeadModules.good
+++ b/test/optimizations/deadCodeElimination/elliot/countDeadModules.good
@@ -1,1 +1,1 @@
-Removed 33 dead modules.
+Removed 34 dead modules.


### PR DESCRIPTION
Jade also incremented this number for an unrelated reason in 0e429a932a6e1d72205921d018255b89c216b544 and Git thought we meant to change the code the same way. We didn't; we needed two increments.

Trivial, will not be reviewed.

## Testing

- [x] paratest