### PR TITLE
Extend array view elision to Block, Cyclic and Stencil

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -950,7 +950,7 @@ iter BlockImpl.activeTargetLocales(const space : domain = boundingBox) {
   // The subset {1..10 by 4} will involve locales 0, 1, and 3.
   foreach i in {(...dims)} {
     const chunk = chpl__computeBlock(i, targetLocDom, boundingBox, boundingBox.dims());
-    // TODO: Want 'contains' for a domain. Slicing is a workaround.
+    // TODO: Want 'overlaps' for a domain. Slicing is a workaround.
     if locSpace[(...chunk)].sizeAs(int) > 0 then
       yield i;
   }
@@ -974,7 +974,7 @@ iter BlockImpl.activeTargetLocales(const space : range(?)) {
   // The subset {1..10 by 4} will involve locales 0, 1, and 3.
   foreach i in dims {
     const chunk = chpl__computeBlock(i, targetLocDom, boundingBox, boundingBox.dims());
-    // TODO: Want 'contains' for a domain. Slicing is a workaround.
+    // TODO: Want 'overlaps' for a domain. Slicing is a workaround.
     if space[chunk[0]].sizeAs(int) > 0 then
       yield i;
   }

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -956,6 +956,31 @@ iter BlockImpl.activeTargetLocales(const space : domain = boundingBox) {
   }
 }
 
+iter BlockImpl.activeTargetLocales(const space : range(?)) {
+  compilerAssert(rank==1);
+  const dims = targetLocsIdx(space.first)..targetLocsIdx(space.last);
+
+  // In case 'space' is a strided domain we need to check that the locales
+  // in 'dims' actually contain indices in 'locSpace'.
+  //
+  // Note that we cannot use a simple stride here because it is not guaranteed
+  // that each locale contains the same number of indices. For example, the
+  // domain {1..10} over four locales will split like:
+  //   L0: -max(int)..3
+  //   L1: 4..5
+  //   L2: 6..8
+  //   L3: 9..max(int)
+  //
+  // The subset {1..10 by 4} will involve locales 0, 1, and 3.
+  foreach i in dims {
+    const chunk = chpl__computeBlock(i, targetLocDom, boundingBox, boundingBox.dims());
+    // TODO: Want 'contains' for a domain. Slicing is a workaround.
+    if space[chunk[0]].sizeAs(int) > 0 then
+      yield i;
+  }
+
+}
+
 // create a domain over an existing blockDist Distribution
 proc blockDist.createDomain(dom: domain(?)) {
   return dom dmapped this;

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -67,6 +67,7 @@ config param debugBlockDistBulkTransfer = false;
 config const disableAliasedBulkTransfer = true;
 
 config param disableBlockDistBulkTransfer = false;
+config param disableBlockDistArrayViewElision = false;
 
 config param sanityCheckDistribution = false;
 
@@ -1728,6 +1729,10 @@ inline proc LocBlockArr.this(i) ref {
 
 override proc BlockDom.dsiSupportsAutoLocalAccess() param {
   return true;
+}
+
+override proc BlockDom.dsiSupportsArrayViewElision() param {
+  return !disableBlockDistArrayViewElision;
 }
 
 ///// Privatization and serialization ///////////////////////////////////////

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -37,6 +37,7 @@ proc _determineIdxTypeFromStartIdx(startIdx) type {
 config param debugCyclicDist = false;
 config param verboseCyclicDistWriters = false;
 config param debugCyclicDistBulkTransfer = false;
+config param disableCyclicDistArrayViewElision = false;
 
 private config param allowDuplicateTargetLocales = false;
 //
@@ -499,6 +500,10 @@ override proc CyclicImpl.dsiDisplayRepresentation() {
 }
 
 override proc CyclicDom.dsiSupportsAutoLocalAccess() param { return true; }
+
+override proc CyclicDom.dsiSupportsArrayViewElision() param {
+  return !disableCyclicDistArrayViewElision;
+}
 
 proc CyclicImpl.init(other: CyclicImpl, privateData,
                  param rank = other.rank,

--- a/modules/dists/DSIUtil.chpl
+++ b/modules/dists/DSIUtil.chpl
@@ -659,9 +659,9 @@ proc bulkCommTranslateDomain(srcSlice : domain, srcView : range(?),
   param strides = chpl_strideUnion(targetView, srcSlice);
 
   const dense = densify(srcSlice.dim(0), srcView);
-  const rngs  = unDensify(dense, targetView);
+  const rng  = unDensify(dense, targetView);
 
-  return {rngs};
+  return {rng};
 }
 //
 // bulkCommConvertCoordinate() converts

--- a/modules/dists/DSIUtil.chpl
+++ b/modules/dists/DSIUtil.chpl
@@ -651,8 +651,8 @@ proc bulkCommTranslateDomain(srcSlice : domain, srcDom : domain, targetDom : dom
 // paths that comes from elided array views. We could consider using this
 // lighterweight implementation as a more general special case for 1D bulk
 // transfers.
-proc bulkCommTranslateDomain(srcSlice : domain, srcView : range,
-                             targetView : range) {
+proc bulkCommTranslateDomain(srcSlice : domain, srcView : range(?),
+                             targetView : range(?)) {
   if srcSlice.rank != 1 then
     compilerError("bulkCommTranslateDomain: source slice and source domain must have identical rank");
 

--- a/modules/dists/DSIUtil.chpl
+++ b/modules/dists/DSIUtil.chpl
@@ -701,6 +701,17 @@ proc bulkCommConvertCoordinate(ind, bView:domain, aView:domain)
   return result;
 }
 
+// this is a 1D, range-based version of the above. It is used by AVE, which
+// tries to avoid creating domains for views.
+proc bulkCommConvertCoordinate(ind, bView:range(?), aView:range(?))
+{
+  if boundsChecking then
+    assert(bView.contains(ind));
+
+  const result = aView.orderToIndex(bView.indexOrder(ind));
+  return (result,);
+}
+
 record chpl_PrivatizedDistHelper : writeSerializable {
 //  type instanceType;
   var _pid:int;  // only used when privatized

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -885,12 +885,7 @@ iter StencilImpl.activeTargetLocales(const space : domain = boundingBox) {
 
 iter StencilImpl.activeTargetLocales(const space : range(?)) {
   compilerAssert(rank==1);
-  const low = chpl__tuplify(targetLocsIdx(space.first));
-  const high = chpl__tuplify(targetLocsIdx(space.last));
-  var dims : rank*range(low(0).type);
-  for param i in 0..rank-1 {
-    dims(i) = low(i)..high(i);
-  }
+  const dims = targetLocsIdx(space.first)..targetLocsIdx(space.last);
 
   // In case 'locSpace' is a strided domain we need to check that the locales
   // in 'dims' actually contain indices in 'locSpace'.
@@ -907,7 +902,7 @@ iter StencilImpl.activeTargetLocales(const space : range(?)) {
   foreach i in dims {
     const chunk = chpl__computeBlock(i, targetLocDom, boundingBox);
     // TODO: Want 'contains' for a domain. Slicing is a workaround.
-    if locSpace[chunk].sizeAs(int) > 0 then
+    if space[chunk[0]].sizeAs(int) > 0 then
       yield i;
   }
 

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -60,6 +60,7 @@ config param debugStencilDistBulkTransfer = false;
 config param stencilDistAllowPackedUpdateFluff = true;
 
 config param disableStencilDistBulkTransfer = false;
+config param disableStencilDistArrayViewElision = false;
 
 private config param allowDuplicateTargetLocales = false;
 // Instructs the _packedUpdate method to only perform the optimized buffer
@@ -2123,6 +2124,10 @@ override proc StencilDom.dsiAutoLocalAccessOffsetCheck(offsets) {
     ret &&= fluff[i] >= abs(offsets[i]);
   }
   return ret;
+}
+
+override proc StencilDom.dsiSupportsArrayViewElision() param {
+  return !disableStencilDistArrayViewElision;
 }
 
 //

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -883,6 +883,36 @@ iter StencilImpl.activeTargetLocales(const space : domain = boundingBox) {
   }
 }
 
+iter StencilImpl.activeTargetLocales(const space : range(?)) {
+  compilerAssert(rank==1);
+  const low = chpl__tuplify(targetLocsIdx(space.first));
+  const high = chpl__tuplify(targetLocsIdx(space.last));
+  var dims : rank*range(low(0).type);
+  for param i in 0..rank-1 {
+    dims(i) = low(i)..high(i);
+  }
+
+  // In case 'locSpace' is a strided domain we need to check that the locales
+  // in 'dims' actually contain indices in 'locSpace'.
+  //
+  // Note that we cannot use a simple stride here because it is not guaranteed
+  // that each locale contains the same number of indices. For example, the
+  // domain {1..10} over four locales will split like:
+  //   L0: -max(int)..3
+  //   L1: 4..5
+  //   L2: 6..8
+  //   L3: 9..max(int)
+  //
+  // The subset {1..10 by 4} will involve locales 0, 1, and 3.
+  foreach i in dims {
+    const chunk = chpl__computeBlock(i, targetLocDom, boundingBox);
+    // TODO: Want 'contains' for a domain. Slicing is a workaround.
+    if locSpace[chunk].sizeAs(int) > 0 then
+      yield i;
+  }
+
+}
+
 // create a domain over an existing Stencil Distribution
 proc stencilDist.createDomain(dom: domain(?)) {
   return dom dmapped this;

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -887,7 +887,7 @@ iter StencilImpl.activeTargetLocales(const space : range(?)) {
   compilerAssert(rank==1);
   const dims = targetLocsIdx(space.first)..targetLocsIdx(space.last);
 
-  // In case 'locSpace' is a strided domain we need to check that the locales
+  // In case 'space' is a strided domain we need to check that the locales
   // in 'dims' actually contain indices in 'locSpace'.
   //
   // Note that we cannot use a simple stride here because it is not guaranteed

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -877,7 +877,7 @@ iter StencilImpl.activeTargetLocales(const space : domain = boundingBox) {
   // The subset {1..10 by 4} will involve locales 0, 1, and 3.
   foreach i in {(...dims)} {
     const chunk = chpl__computeBlock(i, targetLocDom, boundingBox);
-    // TODO: Want 'contains' for a domain. Slicing is a workaround.
+    // TODO: Want 'overlaps' for a domain. Slicing is a workaround.
     if locSpace[(...chunk)].sizeAs(int) > 0 then
       yield i;
   }
@@ -901,7 +901,7 @@ iter StencilImpl.activeTargetLocales(const space : range(?)) {
   // The subset {1..10 by 4} will involve locales 0, 1, and 3.
   foreach i in dims {
     const chunk = chpl__computeBlock(i, targetLocDom, boundingBox);
-    // TODO: Want 'contains' for a domain. Slicing is a workaround.
+    // TODO: Want 'overlaps' for a domain. Slicing is a workaround.
     if space[chunk[0]].sizeAs(int) > 0 then
       yield i;
   }

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2175,7 +2175,7 @@ module ChapelArray {
       eqVals = (a._value == b._value);
     }
     else if isProtoSlice(a) && isProtoSlice(b) {
-      eqVals = (a == b); // default record comparison should cover it
+      eqVals = (a == b);
     }
     else {
       compilerError("Internal error: cross-type assignments are not supported");

--- a/modules/internal/ChapelArrayViewElision.chpl
+++ b/modules/internal/ChapelArrayViewElision.chpl
@@ -76,21 +76,25 @@ module ChapelArrayViewElision {
 
   proc chpl__ave_protoSlicesSupportAssignment(a: chpl__protoSlice,
                                               b: chpl__protoSlice) param: bool {
-    if a.isRankChange != b.isRankChange then return false; //or assert?
+    // for now, only same array types on both sides are supported
+    if a.ptrToArr.type != b.ptrToArr.type then return false;
 
-    if !a.isRankChange then return true; // nothing else to check
+    // either both sides are rank-changes, or neither is
+    if a.isRankChange != b.isRankChange then return false;
 
-    // we want to check that if there are integrals in the original slicing
-    // expressions, they are at the same rank. In other words, if we are working
-    // with rank-changes, we want to make sure that the collapsed dims on both
-    // sides match
-    type aType = a.slicingExprType;
-    type bType = b.slicingExprType;
-    compilerAssert(a.slicingExprType.size == b.slicingExprType.size);
-    for param i in 0..<a.slicingExprType.size {
-      if ( ( isRangeType(aType[i]) && !isRangeType(bType[i])) ||
-           (!isRangeType(aType[i]) &&  isRangeType(bType[i])) ) {
-        return false;
+    if a.isRankChange {
+      // we want to check that if there are integrals in the original slicing
+      // expressions, they are at the same rank. In other words, if we are
+      // working with rank-changes, we want to make sure that the collapsed dims
+      // on both sides match
+      type aType = a.slicingExprType;
+      type bType = b.slicingExprType;
+      compilerAssert(a.slicingExprType.size == b.slicingExprType.size);
+      for param i in 0..<a.slicingExprType.size {
+        if ( ( isRangeType(aType[i]) && !isRangeType(bType[i])) ||
+             (!isRangeType(aType[i]) &&  isRangeType(bType[i])) ) {
+          return false;
+        }
       }
     }
 

--- a/modules/internal/ChapelArrayViewElision.chpl
+++ b/modules/internal/ChapelArrayViewElision.chpl
@@ -319,6 +319,10 @@ module ChapelArrayViewElision {
         yield arr[i];
       }
     }
+
+    proc supportsShortArrayTransfer() param {
+      return ptrToArr.deref().domain.supportsShortArrayTransfer();
+    }
   }
 
   // we need this as otherwise compiler-generated equality operator requires

--- a/modules/internal/ChapelArrayViewElision.chpl
+++ b/modules/internal/ChapelArrayViewElision.chpl
@@ -70,7 +70,8 @@ module ChapelArrayViewElision {
 
   proc chpl__ave_exprCanBeProtoSlice(base, idxExprs...) param: bool {
     return chpl__ave_baseTypeSupports(base) &&
-           chpl__ave_idxExprsSupport(base.idxType, (...idxExprs));
+           chpl__ave_idxExprsSupport(base.idxType, (...idxExprs)) &&
+           !chpl__ave_nonComplientSlice(base, (...idxExprs));
   }
 
   proc chpl__ave_protoSlicesSupportAssignment(a: chpl__protoSlice,
@@ -402,6 +403,17 @@ module ChapelArrayViewElision {
       return false;
     }
     return true;
+  }
+
+  private proc chpl__ave_nonComplientSlice(base, idxExprs: domain) param {
+    // distributed array sliced with a distributed domain is non-complient
+    // such slices imply "redistribution" of the data. Right now, let's ignore
+    // those
+    return !chpl__isDROrDRView(base) && !chpl__isDROrDRView(idxExprs);
+  }
+
+  private proc chpl__ave_nonComplientSlice(base, idxExprs...) param {
+    return false;
   }
 
   private proc chpl__ave_idxExprsSupport(type idxType,

--- a/modules/internal/ChapelArrayViewElision.chpl
+++ b/modules/internal/ChapelArrayViewElision.chpl
@@ -369,7 +369,7 @@ module ChapelArrayViewElision {
 
   private proc chpl__ave_baseTypeSupports(base) param: bool {
     import Reflection;
-    return isArray(base) && // also could be a view?
+    return isArray(base) && !chpl__isArrayView(base) && // we could allow views
            base.domain.supportsArrayViewElision() &&
            Reflection.canResolve("c_addrOf", base);
   }

--- a/modules/internal/ChapelArrayViewElision.chpl
+++ b/modules/internal/ChapelArrayViewElision.chpl
@@ -361,7 +361,7 @@ module ChapelArrayViewElision {
   private proc chpl__ave_baseTypeSupports(base) param: bool {
     import Reflection;
     return isArray(base) && // also could be a view?
-           isSubtype(base._instance.type, DefaultRectangularArr) &&
+           base.domain.supportsArrayViewElision() &&
            Reflection.canResolve("c_addrOf", base);
   }
 

--- a/modules/internal/ChapelArrayViewElision.chpl
+++ b/modules/internal/ChapelArrayViewElision.chpl
@@ -196,8 +196,12 @@ module ChapelArrayViewElision {
       halt("protoSlice copy initializer should never be called");
     }
 
+    // 1D always returns a range
     inline proc domOrRange where rank==1 {
-      return ranges; // doesn't matter whether it is a domain or a range
+      if isDomain(ranges) then
+        return ranges.dim[0];
+      else
+        return ranges;
     }
 
     inline proc domOrRange where rank>1 {

--- a/modules/internal/ChapelArrayViewElision.chpl
+++ b/modules/internal/ChapelArrayViewElision.chpl
@@ -77,7 +77,7 @@ module ChapelArrayViewElision {
   proc chpl__ave_protoSlicesSupportAssignment(a: chpl__protoSlice,
                                               b: chpl__protoSlice) param: bool {
     // for now, only same array types on both sides are supported
-    if a.ptrToArr.type != b.ptrToArr.type then return false;
+    if a.ptrToArr.deref().type != b.ptrToArr.deref().type then return false;
 
     // either both sides are rank-changes, or neither is
     if a.isRankChange != b.isRankChange then return false;

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -510,6 +510,10 @@ module ChapelDistribution {
       return false;
     }
 
+    proc dsiSupportsShortArrayTransfer() param {
+      return false;
+    }
+
     proc dsiIteratorYieldsLocalElements() param {
       return false;
     }

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -506,6 +506,10 @@ module ChapelDistribution {
       return false;
     }
 
+    proc dsiSupportsArrayViewElision() param {
+      return false;
+    }
+
     proc dsiIteratorYieldsLocalElements() param {
       return false;
     }

--- a/modules/internal/ChapelDomain.chpl
+++ b/modules/internal/ChapelDomain.chpl
@@ -2865,6 +2865,10 @@ module ChapelDomain {
     @chpldoc.nodoc
     proc autoLocalAccessOffsetCheck(offsets) {
       return _value.dsiAutoLocalAccessOffsetCheck(offsets);
+
+    @chpldoc.nodoc
+    proc supportsArrayViewElision() param {
+      return _value.dsiSupportsArrayViewElision();
     }
 
     @chpldoc.nodoc

--- a/modules/internal/ChapelDomain.chpl
+++ b/modules/internal/ChapelDomain.chpl
@@ -2872,6 +2872,11 @@ module ChapelDomain {
     }
 
     @chpldoc.nodoc
+    proc supportsShortArrayTransfer() param {
+      return _value.dsiSupportsShortArrayTransfer();
+    }
+
+    @chpldoc.nodoc
     proc iteratorYieldsLocalElements() param {
       return _value.dsiIteratorYieldsLocalElements();
     }

--- a/modules/internal/ChapelDomain.chpl
+++ b/modules/internal/ChapelDomain.chpl
@@ -2865,6 +2865,7 @@ module ChapelDomain {
     @chpldoc.nodoc
     proc autoLocalAccessOffsetCheck(offsets) {
       return _value.dsiAutoLocalAccessOffsetCheck(offsets);
+    }
 
     @chpldoc.nodoc
     proc supportsArrayViewElision() param {

--- a/modules/internal/ChapelShortArrayTransfer.chpl
+++ b/modules/internal/ChapelShortArrayTransfer.chpl
@@ -36,9 +36,10 @@ module ChapelShortArrayTransfer {
 
 
   proc chpl__staticCheckShortArrayTransfer(a, b) param {
-    // Engin: this is the case I'm focusing on in the initial PR. This can
-    // definitely be loosened up... by a lot.
-    return !disableShortArrayTransfer && isProtoSlice(a) && isProtoSlice(b);
+    // This can be loosened up as we expand SAT
+    return !disableShortArrayTransfer &&
+           isProtoSlice(a) && a.supportsShortArrayTransfer() &&
+           isProtoSlice(b) && b.supportsShortArrayTransfer();
   }
 
   inline proc chpl__dynamicCheckShortArrayTransfer(a, b) {

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1694,6 +1694,10 @@ module DefaultRectangular {
     for elem in chpl__serialViewIterHelper(arr, viewDom) do yield elem;
   }
 
+  iter chpl__serialViewIter1D(arr, viewDom) ref {
+    for elem in chpl__serialViewIterHelper(arr, viewDom) do yield elem;
+  }
+
   iter chpl__serialViewIterHelper(arr, viewDom) ref {
     foreach i in viewDom {
       const dataIdx = if arr.isReindexArrayView() then chpl_reindexConvertIdx(i, arr.dom, arr.downdom)

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1764,6 +1764,10 @@ module DefaultRectangular {
     return true;
   }
 
+  override proc DefaultRectangularDom.dsiSupportsShortArrayTransfer() param {
+    return true;
+  }
+
   // Why can the following two functions not be collapsed into one
   // where 'dom = arr.dom'?  Because this puts a type constraint on
   // what 'dom' can be passed that is too strict in some callchains

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1760,6 +1760,10 @@ module DefaultRectangular {
     return defaultRectangularSupportsAutoLocalAccess;
   }
 
+  override proc DefaultRectangularDom.dsiSupportsArrayViewElision() param {
+    return true;
+  }
+
   // Why can the following two functions not be collapsed into one
   // where 'dom = arr.dom'?  Because this puts a type constraint on
   // what 'dom' can be passed that is too strict in some callchains

--- a/test/optimizations/arrayViewElision/distributed.chpl
+++ b/test/optimizations/arrayViewElision/distributed.chpl
@@ -33,3 +33,16 @@ const Space = {1..10};
   A[3..5] = B[3..5];
   writeln(A);
 }
+
+{
+  use BlockDist;
+  use StencilDist;
+
+  const BD = Space dmapped new blockDist(Space);
+  const SD = Space dmapped new stencilDist(Space);
+  var A: [BD] int = 1;
+  var B: [SD] int = 2;
+
+  A[3..5] = B[3..5];
+  writeln(A);
+}

--- a/test/optimizations/arrayViewElision/distributed.chpl
+++ b/test/optimizations/arrayViewElision/distributed.chpl
@@ -22,3 +22,14 @@ const Space = {1..10};
   A[3..5] = B[3..5];
   writeln(A);
 }
+
+{
+  use StencilDist;
+
+  const D = Space dmapped new stencilDist(Space);
+  var A: [D] int = 1;
+  var B: [D] int = 2;
+
+  A[3..5] = B[3..5];
+  writeln(A);
+}

--- a/test/optimizations/arrayViewElision/distributed.comm-none.good
+++ b/test/optimizations/arrayViewElision/distributed.comm-none.good
@@ -1,0 +1,36 @@
+ArrayViewElision supported distributed.chpl:11
+	lhsBaseType: [BlockDom(1,int(64),one,unmanaged DefaultDist)] int(64)
+	lhsIndexingExprs: 
+		range(int(64),both,one)
+	rhsBaseType: [BlockDom(1,int(64),one,unmanaged DefaultDist)] int(64)
+	rhsIndexingExprs: 
+		range(int(64),both,one)
+
+ArrayViewElision supported distributed.chpl:22
+	lhsBaseType: [CyclicDom(1,int(64),one)] int(64)
+	lhsIndexingExprs: 
+		range(int(64),both,one)
+	rhsBaseType: [CyclicDom(1,int(64),one)] int(64)
+	rhsIndexingExprs: 
+		range(int(64),both,one)
+
+ArrayViewElision supported distributed.chpl:33
+	lhsBaseType: [StencilDom(1,int(64),one,false)] int(64)
+	lhsIndexingExprs: 
+		range(int(64),both,one)
+	rhsBaseType: [StencilDom(1,int(64),one,false)] int(64)
+	rhsIndexingExprs: 
+		range(int(64),both,one)
+
+ArrayViewElision not supported distributed.chpl:46
+	lhsBaseType: [BlockDom(1,int(64),one,unmanaged DefaultDist)] int(64)
+	lhsIndexingExprs: 
+		range(int(64),both,one)
+	rhsBaseType: [StencilDom(1,int(64),one,false)] int(64)
+	rhsIndexingExprs: 
+		range(int(64),both,one)
+
+1 1 2 2 2 1 1 1 1 1
+1 1 2 2 2 1 1 1 1 1
+1 1 2 2 2 1 1 1 1 1
+1 1 2 2 2 1 1 1 1 1

--- a/test/optimizations/arrayViewElision/distributed.good
+++ b/test/optimizations/arrayViewElision/distributed.good
@@ -1,16 +1,27 @@
-ArrayViewElision not supported distributed.chpl:11
+ArrayViewElision supported distributed.chpl:11
 	lhsBaseType: [BlockDom(1,int(64),one,unmanaged DefaultDist)] int(64)
 	lhsIndexingExprs: 
 		range(int(64),both,one)
-	rhsBaseType: 
+	rhsBaseType: [BlockDom(1,int(64),one,unmanaged DefaultDist)] int(64)
 	rhsIndexingExprs: 
+		range(int(64),both,one)
 
-ArrayViewElision not supported distributed.chpl:22
+ArrayViewElision supported distributed.chpl:22
 	lhsBaseType: [CyclicDom(1,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		range(int(64),both,one)
-	rhsBaseType: 
+	rhsBaseType: [CyclicDom(1,int(64),one)] int(64)
 	rhsIndexingExprs: 
+		range(int(64),both,one)
 
+ArrayViewElision supported distributed.chpl:33
+	lhsBaseType: [StencilDom(1,int(64),one,false)] int(64)
+	lhsIndexingExprs: 
+		range(int(64),both,one)
+	rhsBaseType: [StencilDom(1,int(64),one,false)] int(64)
+	rhsIndexingExprs: 
+		range(int(64),both,one)
+
+1 1 2 2 2 1 1 1 1 1
 1 1 2 2 2 1 1 1 1 1
 1 1 2 2 2 1 1 1 1 1

--- a/test/optimizations/arrayViewElision/distributed.good
+++ b/test/optimizations/arrayViewElision/distributed.good
@@ -22,6 +22,15 @@ ArrayViewElision supported distributed.chpl:33
 	rhsIndexingExprs: 
 		range(int(64),both,one)
 
+ArrayViewElision not supported distributed.chpl:46
+	lhsBaseType: [BlockDom(1,int(64),one,unmanaged DefaultDist)] int(64)
+	lhsIndexingExprs: 
+		range(int(64),both,one)
+	rhsBaseType: [StencilDom(1,int(64),one,false)] int(64)
+	rhsIndexingExprs: 
+		range(int(64),both,one)
+
+1 1 2 2 2 1 1 1 1 1
 1 1 2 2 2 1 1 1 1 1
 1 1 2 2 2 1 1 1 1 1
 1 1 2 2 2 1 1 1 1 1

--- a/test/optimizations/arrayViewElision/distributed.good
+++ b/test/optimizations/arrayViewElision/distributed.good
@@ -1,4 +1,4 @@
-ArrayViewElision supported distributed.chpl:11
+ArrayViewElision supported (dynamic locality check required) distributed.chpl:11
 	lhsBaseType: [BlockDom(1,int(64),one,unmanaged DefaultDist)] int(64)
 	lhsIndexingExprs: 
 		range(int(64),both,one)
@@ -6,7 +6,7 @@ ArrayViewElision supported distributed.chpl:11
 	rhsIndexingExprs: 
 		range(int(64),both,one)
 
-ArrayViewElision supported distributed.chpl:22
+ArrayViewElision supported (dynamic locality check required) distributed.chpl:22
 	lhsBaseType: [CyclicDom(1,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		range(int(64),both,one)
@@ -14,7 +14,7 @@ ArrayViewElision supported distributed.chpl:22
 	rhsIndexingExprs: 
 		range(int(64),both,one)
 
-ArrayViewElision supported distributed.chpl:33
+ArrayViewElision supported (dynamic locality check required) distributed.chpl:33
 	lhsBaseType: [StencilDom(1,int(64),one,false)] int(64)
 	lhsIndexingExprs: 
 		range(int(64),both,one)

--- a/test/optimizations/arrayViewElision/distributed.no-local.good
+++ b/test/optimizations/arrayViewElision/distributed.no-local.good
@@ -1,0 +1,1 @@
+distributed.good

--- a/test/optimizations/arrayViewElision/nonComplientSlice.chpl
+++ b/test/optimizations/arrayViewElision/nonComplientSlice.chpl
@@ -1,0 +1,18 @@
+// for now, we don't support distributed arrays sliced with distributed domains
+use BlockDist;
+
+config const n = 10;
+
+var dom = blockDist.createDomain(1..n);
+var innerDom = dom.expand(-1);
+
+var Arr: [dom] int;
+var Crr: [dom] int = 1;
+
+Arr[innerDom] = Crr[innerDom];
+
+writeln(Arr);
+
+
+
+

--- a/test/optimizations/arrayViewElision/nonComplientSlice.compopts
+++ b/test/optimizations/arrayViewElision/nonComplientSlice.compopts
@@ -1,0 +1,1 @@
+--array-view-elision --report-array-view-elision

--- a/test/optimizations/arrayViewElision/nonComplientSlice.good
+++ b/test/optimizations/arrayViewElision/nonComplientSlice.good
@@ -1,0 +1,8 @@
+ArrayViewElision not supported nonComplientSlice.chpl:12
+	lhsBaseType: [BlockDom(1,int(64),one,unmanaged DefaultDist)] int(64)
+	lhsIndexingExprs: 
+		BlockDom(1,int(64),one,unmanaged DefaultDist)
+	rhsBaseType: 
+	rhsIndexingExprs: 
+
+0 1 1 1 1 1 1 1 1 0

--- a/test/optimizations/arrayViewElision/rankChanges-no-sat.comm-none.good
+++ b/test/optimizations/arrayViewElision/rankChanges-no-sat.comm-none.good
@@ -46,32 +46,24 @@ ArrayViewElision not supported rankChanges.chpl:20
 		int(64)
 		range(int(64),both,one)
 
-<ShortArrayTransfer> Size: 3 Threshold: 60
-<ShortArrayTransfer> size qualifies
 1 1 1 1 1
 1 1 1 1 1
 2 2 2 1 1
 1 1 1 1 1
 1 1 1 1 1
 
-<ShortArrayTransfer> Size: 3 Threshold: 60
-<ShortArrayTransfer> size qualifies
 1 1 2 1 1
 1 1 2 1 1
 1 1 2 1 1
 1 1 1 1 1
 1 1 1 1 1
 
-<ShortArrayTransfer> Size: 5 Threshold: 60
-<ShortArrayTransfer> size qualifies
 1 1 1 1 1
 1 1 1 1 1
 2 2 2 2 2
 1 1 1 1 1
 1 1 1 1 1
 
-<ShortArrayTransfer> Size: 5 Threshold: 60
-<ShortArrayTransfer> size qualifies
 1 1 2 1 1
 1 1 2 1 1
 1 1 2 1 1

--- a/test/optimizations/arrayViewElision/rankChanges-no-sat.good
+++ b/test/optimizations/arrayViewElision/rankChanges-no-sat.good
@@ -46,36 +46,24 @@ ArrayViewElision not supported rankChanges.chpl:20
 		int(64)
 		range(int(64),both,one)
 
-<ShortArrayTransfer> Size: 3 Threshold: 60
-<ShortArrayTransfer> size qualifies
-<ShortArrayTransfer> locality qualifies
 1 1 1 1 1
 1 1 1 1 1
 2 2 2 1 1
 1 1 1 1 1
 1 1 1 1 1
 
-<ShortArrayTransfer> Size: 3 Threshold: 60
-<ShortArrayTransfer> size qualifies
-<ShortArrayTransfer> locality qualifies
 1 1 2 1 1
 1 1 2 1 1
 1 1 2 1 1
 1 1 1 1 1
 1 1 1 1 1
 
-<ShortArrayTransfer> Size: 5 Threshold: 60
-<ShortArrayTransfer> size qualifies
-<ShortArrayTransfer> locality qualifies
 1 1 1 1 1
 1 1 1 1 1
 2 2 2 2 2
 1 1 1 1 1
 1 1 1 1 1
 
-<ShortArrayTransfer> Size: 5 Threshold: 60
-<ShortArrayTransfer> size qualifies
-<ShortArrayTransfer> locality qualifies
 1 1 2 1 1
 1 1 2 1 1
 1 1 2 1 1

--- a/test/optimizations/arrayViewElision/rankChanges-no-sat.no-local.good
+++ b/test/optimizations/arrayViewElision/rankChanges-no-sat.no-local.good
@@ -1,0 +1,1 @@
+rankChanges-no-sat.good

--- a/test/optimizations/arrayViewElision/rankChanges.chpl
+++ b/test/optimizations/arrayViewElision/rankChanges.chpl
@@ -1,11 +1,11 @@
-var A: [1..5, 1..5] int = 1;
-var B: [1..5, 1..5] int = 2;
+config param dist = "stencil";
 
-proc testAndReset() {
-  writeln(A);
-  writeln();
-  A = 1;
-}
+param aVal = 1, bVal = 2;
+
+var arrRanges = (1..5, 1..5);
+
+var (A, B) = createArrays();
+
 
 // supported:
 A[3, 1..3] = B[3, 1..3]; testAndReset();
@@ -18,3 +18,46 @@ A[.., 3] = B[.., 3]; testAndReset();
 // unsupported:
 A[3, 1..3] = B[1..3, 3]; testAndReset();
 A[1..3, 3] = B[3, 1..3]; testAndReset();
+
+proc testAndReset() {
+  writeln(A);
+  writeln();
+  A = 1;
+}
+
+proc createArrays() {
+  select dist {
+    when "default" {
+      var A: [(...arrRanges)] int = aVal;
+      var B: [(...arrRanges)] int = bVal;
+      A = aVal;
+      B = bVal;
+      return (A, B);
+    }
+    when "block" {
+      use BlockDist;
+      var A = blockDist.createArray((...arrRanges), int);
+      var B = blockDist.createArray((...arrRanges), int);
+      A = aVal;
+      B = bVal;
+      return (A, B);
+    }
+    when "cyclic" {
+      use CyclicDist;
+      var A = cyclicDist.createArray((...arrRanges), int);
+      var B = cyclicDist.createArray((...arrRanges), int);
+      A = aVal;
+      B = bVal;
+      return (A, B);
+    }
+    when "stencil" {
+      use StencilDist;
+      var A = stencilDist.createArray((...arrRanges), int);
+      var B = stencilDist.createArray((...arrRanges), int);
+      A = aVal;
+      B = bVal;
+      return (A, B);
+    }
+  }
+}
+

--- a/test/optimizations/arrayViewElision/rankChanges.compopts
+++ b/test/optimizations/arrayViewElision/rankChanges.compopts
@@ -1,1 +1,4 @@
---report-array-view-elision -sdebugShortArrayTransfer
+--report-array-view-elision -sdist='"default"' -sdebugShortArrayTransfer=true # rankChanges
+--report-array-view-elision -sdist='"block"' -sdebugShortArrayTransfer=false # rankChanges-no-sat
+--report-array-view-elision -sdist='"stencil"' -sdebugShortArrayTransfer=false # rankChanges-no-sat
+--report-array-view-elision -sdist='"cyclic"' -sdebugShortArrayTransfer=false # rankChanges-no-sat

--- a/test/optimizations/arrayViewElision/rankChanges.prediff
+++ b/test/optimizations/arrayViewElision/rankChanges.prediff
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+grep -v BaseType $2 >$2.tmp
+mv $2.tmp $2

--- a/test/optimizations/arrayViewElision/slices-1d-domain-no-sat.comm-none.good
+++ b/test/optimizations/arrayViewElision/slices-1d-domain-no-sat.comm-none.good
@@ -1,0 +1,36 @@
+ArrayViewElision supported slices.chpl:24
+	lhsIndexingExprs: 
+		domain(1,int(64),one)
+	rhsIndexingExprs: 
+		domain(1,int(64),one)
+
+ArrayViewElision supported slices.chpl:24
+	lhsIndexingExprs: 
+		domain(1,int(64),one)
+	rhsIndexingExprs: 
+		domain(1,int(64),one)
+
+Set first two:
+Test 1
+2 2 1 1 1
+
+Test 2
+2 2 1 1 1
+
+-----------------
+Set last two:
+Test 3
+1 1 1 2 2
+
+Test 4
+1 1 1 2 2
+
+-----------------
+Set all:
+Test 5
+2 2 2 2 2
+
+Test 6
+2 2 2 2 2
+
+-----------------

--- a/test/optimizations/arrayViewElision/slices-1d-domain-no-sat.good
+++ b/test/optimizations/arrayViewElision/slices-1d-domain-no-sat.good
@@ -1,0 +1,36 @@
+ArrayViewElision supported (dynamic locality check required) slices.chpl:24
+	lhsIndexingExprs: 
+		domain(1,int(64),one)
+	rhsIndexingExprs: 
+		domain(1,int(64),one)
+
+ArrayViewElision supported (dynamic locality check required) slices.chpl:24
+	lhsIndexingExprs: 
+		domain(1,int(64),one)
+	rhsIndexingExprs: 
+		domain(1,int(64),one)
+
+Set first two:
+Test 1
+2 2 1 1 1
+
+Test 2
+2 2 1 1 1
+
+-----------------
+Set last two:
+Test 3
+1 1 1 2 2
+
+Test 4
+1 1 1 2 2
+
+-----------------
+Set all:
+Test 5
+2 2 2 2 2
+
+Test 6
+2 2 2 2 2
+
+-----------------

--- a/test/optimizations/arrayViewElision/slices-1d-domain-no-sat.no-local.good
+++ b/test/optimizations/arrayViewElision/slices-1d-domain-no-sat.no-local.good
@@ -1,0 +1,1 @@
+slices-1d-domain-no-sat.good

--- a/test/optimizations/arrayViewElision/slices-1d-domain.comm-none.good
+++ b/test/optimizations/arrayViewElision/slices-1d-domain.comm-none.good
@@ -1,16 +1,12 @@
 ArrayViewElision supported slices.chpl:24
-	lhsBaseType: [domain(1,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		domain(1,int(64),one)
-	rhsBaseType: [domain(1,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		domain(1,int(64),one)
 
 ArrayViewElision supported slices.chpl:24
-	lhsBaseType: [domain(1,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		domain(1,int(64),one)
-	rhsBaseType: [domain(1,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		domain(1,int(64),one)
 

--- a/test/optimizations/arrayViewElision/slices-1d-domain.good
+++ b/test/optimizations/arrayViewElision/slices-1d-domain.good
@@ -1,16 +1,12 @@
 ArrayViewElision supported (dynamic locality check required) slices.chpl:24
-	lhsBaseType: [domain(1,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		domain(1,int(64),one)
-	rhsBaseType: [domain(1,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		domain(1,int(64),one)
 
 ArrayViewElision supported (dynamic locality check required) slices.chpl:24
-	lhsBaseType: [domain(1,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		domain(1,int(64),one)
-	rhsBaseType: [domain(1,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		domain(1,int(64),one)
 

--- a/test/optimizations/arrayViewElision/slices-1d-range-no-sat.comm-none.good
+++ b/test/optimizations/arrayViewElision/slices-1d-range-no-sat.comm-none.good
@@ -1,0 +1,165 @@
+ArrayViewElision supported slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),both,one)
+	rhsIndexingExprs: 
+		range(int(64),both,one)
+
+ArrayViewElision supported slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),both,one)
+	rhsIndexingExprs: 
+		range(int(64),both,one)
+
+ArrayViewElision supported slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),both,one)
+	rhsIndexingExprs: 
+		range(int(64),both,one)
+
+ArrayViewElision supported slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),high,one)
+	rhsIndexingExprs: 
+		range(int(64),high,one)
+
+ArrayViewElision supported slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),high,one)
+	rhsIndexingExprs: 
+		range(int(64),high,one)
+
+ArrayViewElision supported slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),high,one)
+	rhsIndexingExprs: 
+		range(int(64),high,one)
+
+ArrayViewElision supported slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),low,one)
+	rhsIndexingExprs: 
+		range(int(64),low,one)
+
+ArrayViewElision supported slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),low,one)
+	rhsIndexingExprs: 
+		range(int(64),low,one)
+
+ArrayViewElision supported slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),low,one)
+	rhsIndexingExprs: 
+		range(int(64),low,one)
+
+ArrayViewElision supported slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),both,one)
+	rhsIndexingExprs: 
+		range(int(64),both,one)
+
+ArrayViewElision supported slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),low,one)
+	rhsIndexingExprs: 
+		range(int(64),low,one)
+
+ArrayViewElision supported slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),neither,one)
+	rhsIndexingExprs: 
+		range(int(64),neither,one)
+
+ArrayViewElision supported slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),neither,one)
+	rhsIndexingExprs: 
+		range(int(64),neither,one)
+
+ArrayViewElision supported slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),neither,one)
+	rhsIndexingExprs: 
+		range(int(64),neither,one)
+
+Set first two:
+Test 1
+2 2 1 1 1
+
+Test 2
+2 2 1 1 1
+
+Test 3
+2 2 1 1 1
+
+Test 4
+2 2 1 1 1
+
+Test 5
+2 2 1 1 1
+
+Test 6
+2 2 1 1 1
+
+Test 7
+2 2 1 1 1
+
+Test 8
+2 2 1 1 1
+
+-----------------
+Set last two:
+Test 9
+1 1 1 2 2
+
+Test 10
+1 1 1 2 2
+
+Test 11
+1 1 1 2 2
+
+Test 12
+1 1 1 2 2
+
+Test 13
+1 1 1 2 2
+
+Test 14
+1 1 1 2 2
+
+Test 15
+1 1 1 2 2
+
+Test 16
+1 1 1 2 2
+
+-----------------
+Set all:
+Test 17
+2 2 2 2 2
+
+Test 18
+2 2 2 2 2
+
+Test 19
+2 2 2 2 2
+
+Test 20
+2 2 2 2 2
+
+Test 21
+2 2 2 2 2
+
+Test 22
+2 2 2 2 2
+
+Test 23
+2 2 2 2 2
+
+Test 24
+2 2 2 2 2
+
+Test 25
+2 2 2 2 2
+
+-----------------

--- a/test/optimizations/arrayViewElision/slices-1d-range-no-sat.good
+++ b/test/optimizations/arrayViewElision/slices-1d-range-no-sat.good
@@ -1,0 +1,165 @@
+ArrayViewElision supported (dynamic locality check required) slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),both,one)
+	rhsIndexingExprs: 
+		range(int(64),both,one)
+
+ArrayViewElision supported (dynamic locality check required) slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),both,one)
+	rhsIndexingExprs: 
+		range(int(64),both,one)
+
+ArrayViewElision supported (dynamic locality check required) slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),both,one)
+	rhsIndexingExprs: 
+		range(int(64),both,one)
+
+ArrayViewElision supported (dynamic locality check required) slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),high,one)
+	rhsIndexingExprs: 
+		range(int(64),high,one)
+
+ArrayViewElision supported (dynamic locality check required) slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),high,one)
+	rhsIndexingExprs: 
+		range(int(64),high,one)
+
+ArrayViewElision supported (dynamic locality check required) slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),high,one)
+	rhsIndexingExprs: 
+		range(int(64),high,one)
+
+ArrayViewElision supported (dynamic locality check required) slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),low,one)
+	rhsIndexingExprs: 
+		range(int(64),low,one)
+
+ArrayViewElision supported (dynamic locality check required) slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),low,one)
+	rhsIndexingExprs: 
+		range(int(64),low,one)
+
+ArrayViewElision supported (dynamic locality check required) slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),low,one)
+	rhsIndexingExprs: 
+		range(int(64),low,one)
+
+ArrayViewElision supported (dynamic locality check required) slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),both,one)
+	rhsIndexingExprs: 
+		range(int(64),both,one)
+
+ArrayViewElision supported (dynamic locality check required) slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),low,one)
+	rhsIndexingExprs: 
+		range(int(64),low,one)
+
+ArrayViewElision supported (dynamic locality check required) slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),neither,one)
+	rhsIndexingExprs: 
+		range(int(64),neither,one)
+
+ArrayViewElision supported (dynamic locality check required) slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),neither,one)
+	rhsIndexingExprs: 
+		range(int(64),neither,one)
+
+ArrayViewElision supported (dynamic locality check required) slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),neither,one)
+	rhsIndexingExprs: 
+		range(int(64),neither,one)
+
+Set first two:
+Test 1
+2 2 1 1 1
+
+Test 2
+2 2 1 1 1
+
+Test 3
+2 2 1 1 1
+
+Test 4
+2 2 1 1 1
+
+Test 5
+2 2 1 1 1
+
+Test 6
+2 2 1 1 1
+
+Test 7
+2 2 1 1 1
+
+Test 8
+2 2 1 1 1
+
+-----------------
+Set last two:
+Test 9
+1 1 1 2 2
+
+Test 10
+1 1 1 2 2
+
+Test 11
+1 1 1 2 2
+
+Test 12
+1 1 1 2 2
+
+Test 13
+1 1 1 2 2
+
+Test 14
+1 1 1 2 2
+
+Test 15
+1 1 1 2 2
+
+Test 16
+1 1 1 2 2
+
+-----------------
+Set all:
+Test 17
+2 2 2 2 2
+
+Test 18
+2 2 2 2 2
+
+Test 19
+2 2 2 2 2
+
+Test 20
+2 2 2 2 2
+
+Test 21
+2 2 2 2 2
+
+Test 22
+2 2 2 2 2
+
+Test 23
+2 2 2 2 2
+
+Test 24
+2 2 2 2 2
+
+Test 25
+2 2 2 2 2
+
+-----------------

--- a/test/optimizations/arrayViewElision/slices-1d-range-no-sat.no-local.good
+++ b/test/optimizations/arrayViewElision/slices-1d-range-no-sat.no-local.good
@@ -1,0 +1,1 @@
+slices-1d-range-no-sat.good

--- a/test/optimizations/arrayViewElision/slices-1d-range.comm-none.good
+++ b/test/optimizations/arrayViewElision/slices-1d-range.comm-none.good
@@ -1,112 +1,84 @@
 ArrayViewElision supported slices.chpl:26
-	lhsBaseType: [domain(1,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		range(int(64),both,one)
-	rhsBaseType: [domain(1,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		range(int(64),both,one)
 
 ArrayViewElision supported slices.chpl:26
-	lhsBaseType: [domain(1,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		range(int(64),both,one)
-	rhsBaseType: [domain(1,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		range(int(64),both,one)
 
 ArrayViewElision supported slices.chpl:26
-	lhsBaseType: [domain(1,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		range(int(64),both,one)
-	rhsBaseType: [domain(1,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		range(int(64),both,one)
 
 ArrayViewElision supported slices.chpl:26
-	lhsBaseType: [domain(1,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		range(int(64),high,one)
-	rhsBaseType: [domain(1,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		range(int(64),high,one)
 
 ArrayViewElision supported slices.chpl:26
-	lhsBaseType: [domain(1,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		range(int(64),high,one)
-	rhsBaseType: [domain(1,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		range(int(64),high,one)
 
 ArrayViewElision supported slices.chpl:26
-	lhsBaseType: [domain(1,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		range(int(64),high,one)
-	rhsBaseType: [domain(1,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		range(int(64),high,one)
 
 ArrayViewElision supported slices.chpl:26
-	lhsBaseType: [domain(1,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		range(int(64),low,one)
-	rhsBaseType: [domain(1,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		range(int(64),low,one)
 
 ArrayViewElision supported slices.chpl:26
-	lhsBaseType: [domain(1,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		range(int(64),low,one)
-	rhsBaseType: [domain(1,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		range(int(64),low,one)
 
 ArrayViewElision supported slices.chpl:26
-	lhsBaseType: [domain(1,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		range(int(64),low,one)
-	rhsBaseType: [domain(1,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		range(int(64),low,one)
 
 ArrayViewElision supported slices.chpl:26
-	lhsBaseType: [domain(1,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		range(int(64),both,one)
-	rhsBaseType: [domain(1,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		range(int(64),both,one)
 
 ArrayViewElision supported slices.chpl:26
-	lhsBaseType: [domain(1,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		range(int(64),low,one)
-	rhsBaseType: [domain(1,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		range(int(64),low,one)
 
 ArrayViewElision supported slices.chpl:26
-	lhsBaseType: [domain(1,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		range(int(64),neither,one)
-	rhsBaseType: [domain(1,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		range(int(64),neither,one)
 
 ArrayViewElision supported slices.chpl:26
-	lhsBaseType: [domain(1,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		range(int(64),neither,one)
-	rhsBaseType: [domain(1,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		range(int(64),neither,one)
 
 ArrayViewElision supported slices.chpl:26
-	lhsBaseType: [domain(1,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		range(int(64),neither,one)
-	rhsBaseType: [domain(1,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		range(int(64),neither,one)
 

--- a/test/optimizations/arrayViewElision/slices-1d-range.good
+++ b/test/optimizations/arrayViewElision/slices-1d-range.good
@@ -1,112 +1,84 @@
 ArrayViewElision supported (dynamic locality check required) slices.chpl:26
-	lhsBaseType: [domain(1,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		range(int(64),both,one)
-	rhsBaseType: [domain(1,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		range(int(64),both,one)
 
 ArrayViewElision supported (dynamic locality check required) slices.chpl:26
-	lhsBaseType: [domain(1,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		range(int(64),both,one)
-	rhsBaseType: [domain(1,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		range(int(64),both,one)
 
 ArrayViewElision supported (dynamic locality check required) slices.chpl:26
-	lhsBaseType: [domain(1,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		range(int(64),both,one)
-	rhsBaseType: [domain(1,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		range(int(64),both,one)
 
 ArrayViewElision supported (dynamic locality check required) slices.chpl:26
-	lhsBaseType: [domain(1,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		range(int(64),high,one)
-	rhsBaseType: [domain(1,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		range(int(64),high,one)
 
 ArrayViewElision supported (dynamic locality check required) slices.chpl:26
-	lhsBaseType: [domain(1,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		range(int(64),high,one)
-	rhsBaseType: [domain(1,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		range(int(64),high,one)
 
 ArrayViewElision supported (dynamic locality check required) slices.chpl:26
-	lhsBaseType: [domain(1,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		range(int(64),high,one)
-	rhsBaseType: [domain(1,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		range(int(64),high,one)
 
 ArrayViewElision supported (dynamic locality check required) slices.chpl:26
-	lhsBaseType: [domain(1,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		range(int(64),low,one)
-	rhsBaseType: [domain(1,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		range(int(64),low,one)
 
 ArrayViewElision supported (dynamic locality check required) slices.chpl:26
-	lhsBaseType: [domain(1,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		range(int(64),low,one)
-	rhsBaseType: [domain(1,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		range(int(64),low,one)
 
 ArrayViewElision supported (dynamic locality check required) slices.chpl:26
-	lhsBaseType: [domain(1,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		range(int(64),low,one)
-	rhsBaseType: [domain(1,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		range(int(64),low,one)
 
 ArrayViewElision supported (dynamic locality check required) slices.chpl:26
-	lhsBaseType: [domain(1,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		range(int(64),both,one)
-	rhsBaseType: [domain(1,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		range(int(64),both,one)
 
 ArrayViewElision supported (dynamic locality check required) slices.chpl:26
-	lhsBaseType: [domain(1,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		range(int(64),low,one)
-	rhsBaseType: [domain(1,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		range(int(64),low,one)
 
 ArrayViewElision supported (dynamic locality check required) slices.chpl:26
-	lhsBaseType: [domain(1,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		range(int(64),neither,one)
-	rhsBaseType: [domain(1,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		range(int(64),neither,one)
 
 ArrayViewElision supported (dynamic locality check required) slices.chpl:26
-	lhsBaseType: [domain(1,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		range(int(64),neither,one)
-	rhsBaseType: [domain(1,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		range(int(64),neither,one)
 
 ArrayViewElision supported (dynamic locality check required) slices.chpl:26
-	lhsBaseType: [domain(1,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		range(int(64),neither,one)
-	rhsBaseType: [domain(1,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		range(int(64),neither,one)
 

--- a/test/optimizations/arrayViewElision/slices-2d-domain-no-sat.comm-none.good
+++ b/test/optimizations/arrayViewElision/slices-2d-domain-no-sat.comm-none.good
@@ -1,0 +1,60 @@
+ArrayViewElision supported slices.chpl:24
+	lhsIndexingExprs: 
+		domain(2,int(64),one)
+	rhsIndexingExprs: 
+		domain(2,int(64),one)
+
+ArrayViewElision supported slices.chpl:24
+	lhsIndexingExprs: 
+		domain(2,int(64),one)
+	rhsIndexingExprs: 
+		domain(2,int(64),one)
+
+Set first two:
+Test 1
+2 2 1 1 1
+2 2 1 1 1
+1 1 1 1 1
+1 1 1 1 1
+1 1 1 1 1
+
+Test 2
+2 2 1 1 1
+2 2 1 1 1
+1 1 1 1 1
+1 1 1 1 1
+1 1 1 1 1
+
+-----------------
+Set last two:
+Test 3
+1 1 1 1 1
+1 1 1 1 1
+1 1 1 1 1
+1 1 1 2 2
+1 1 1 2 2
+
+Test 4
+1 1 1 1 1
+1 1 1 1 1
+1 1 1 1 1
+1 1 1 2 2
+1 1 1 2 2
+
+-----------------
+Set all:
+Test 5
+2 2 2 2 2
+2 2 2 2 2
+2 2 2 2 2
+2 2 2 2 2
+2 2 2 2 2
+
+Test 6
+2 2 2 2 2
+2 2 2 2 2
+2 2 2 2 2
+2 2 2 2 2
+2 2 2 2 2
+
+-----------------

--- a/test/optimizations/arrayViewElision/slices-2d-domain-no-sat.good
+++ b/test/optimizations/arrayViewElision/slices-2d-domain-no-sat.good
@@ -1,18 +1,16 @@
-ArrayViewElision supported slices.chpl:24
+ArrayViewElision supported (dynamic locality check required) slices.chpl:24
 	lhsIndexingExprs: 
 		domain(2,int(64),one)
 	rhsIndexingExprs: 
 		domain(2,int(64),one)
 
-ArrayViewElision supported slices.chpl:24
+ArrayViewElision supported (dynamic locality check required) slices.chpl:24
 	lhsIndexingExprs: 
 		domain(2,int(64),one)
 	rhsIndexingExprs: 
 		domain(2,int(64),one)
 
 Set first two:
-<ShortArrayTransfer> Size: 4 Threshold: 60
-<ShortArrayTransfer> size qualifies
 Test 1
 2 2 1 1 1
 2 2 1 1 1
@@ -20,8 +18,6 @@ Test 1
 1 1 1 1 1
 1 1 1 1 1
 
-<ShortArrayTransfer> Size: 4 Threshold: 60
-<ShortArrayTransfer> size qualifies
 Test 2
 2 2 1 1 1
 2 2 1 1 1
@@ -31,8 +27,6 @@ Test 2
 
 -----------------
 Set last two:
-<ShortArrayTransfer> Size: 4 Threshold: 60
-<ShortArrayTransfer> size qualifies
 Test 3
 1 1 1 1 1
 1 1 1 1 1
@@ -40,8 +34,6 @@ Test 3
 1 1 1 2 2
 1 1 1 2 2
 
-<ShortArrayTransfer> Size: 4 Threshold: 60
-<ShortArrayTransfer> size qualifies
 Test 4
 1 1 1 1 1
 1 1 1 1 1
@@ -51,8 +43,6 @@ Test 4
 
 -----------------
 Set all:
-<ShortArrayTransfer> Size: 25 Threshold: 60
-<ShortArrayTransfer> size qualifies
 Test 5
 2 2 2 2 2
 2 2 2 2 2
@@ -60,8 +50,6 @@ Test 5
 2 2 2 2 2
 2 2 2 2 2
 
-<ShortArrayTransfer> Size: 25 Threshold: 60
-<ShortArrayTransfer> size qualifies
 Test 6
 2 2 2 2 2
 2 2 2 2 2

--- a/test/optimizations/arrayViewElision/slices-2d-domain-no-sat.no-local.good
+++ b/test/optimizations/arrayViewElision/slices-2d-domain-no-sat.no-local.good
@@ -1,0 +1,1 @@
+slices-2d-domain-no-sat.good

--- a/test/optimizations/arrayViewElision/slices-2d-domain.good
+++ b/test/optimizations/arrayViewElision/slices-2d-domain.good
@@ -1,16 +1,12 @@
 ArrayViewElision supported (dynamic locality check required) slices.chpl:24
-	lhsBaseType: [domain(2,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		domain(2,int(64),one)
-	rhsBaseType: [domain(2,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		domain(2,int(64),one)
 
 ArrayViewElision supported (dynamic locality check required) slices.chpl:24
-	lhsBaseType: [domain(2,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		domain(2,int(64),one)
-	rhsBaseType: [domain(2,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		domain(2,int(64),one)
 

--- a/test/optimizations/arrayViewElision/slices-2d-range-no-sat.comm-none.good
+++ b/test/optimizations/arrayViewElision/slices-2d-range-no-sat.comm-none.good
@@ -1,0 +1,293 @@
+ArrayViewElision supported slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),both,one)
+		range(int(64),both,one)
+	rhsIndexingExprs: 
+		range(int(64),both,one)
+		range(int(64),both,one)
+
+ArrayViewElision supported slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),both,one)
+		range(int(64),both,one)
+	rhsIndexingExprs: 
+		range(int(64),both,one)
+		range(int(64),both,one)
+
+ArrayViewElision supported slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),both,one)
+		range(int(64),both,one)
+	rhsIndexingExprs: 
+		range(int(64),both,one)
+		range(int(64),both,one)
+
+ArrayViewElision supported slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),high,one)
+		range(int(64),high,one)
+	rhsIndexingExprs: 
+		range(int(64),high,one)
+		range(int(64),high,one)
+
+ArrayViewElision supported slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),high,one)
+		range(int(64),high,one)
+	rhsIndexingExprs: 
+		range(int(64),high,one)
+		range(int(64),high,one)
+
+ArrayViewElision supported slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),high,one)
+		range(int(64),high,one)
+	rhsIndexingExprs: 
+		range(int(64),high,one)
+		range(int(64),high,one)
+
+ArrayViewElision supported slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),low,one)
+		range(int(64),low,one)
+	rhsIndexingExprs: 
+		range(int(64),low,one)
+		range(int(64),low,one)
+
+ArrayViewElision supported slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),low,one)
+		range(int(64),low,one)
+	rhsIndexingExprs: 
+		range(int(64),low,one)
+		range(int(64),low,one)
+
+ArrayViewElision supported slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),low,one)
+		range(int(64),low,one)
+	rhsIndexingExprs: 
+		range(int(64),low,one)
+		range(int(64),low,one)
+
+ArrayViewElision supported slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),both,one)
+		range(int(64),both,one)
+	rhsIndexingExprs: 
+		range(int(64),both,one)
+		range(int(64),both,one)
+
+ArrayViewElision supported slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),low,one)
+		range(int(64),low,one)
+	rhsIndexingExprs: 
+		range(int(64),low,one)
+		range(int(64),low,one)
+
+ArrayViewElision supported slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),neither,one)
+		range(int(64),neither,one)
+	rhsIndexingExprs: 
+		range(int(64),neither,one)
+		range(int(64),neither,one)
+
+ArrayViewElision supported slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),neither,one)
+		range(int(64),neither,one)
+	rhsIndexingExprs: 
+		range(int(64),neither,one)
+		range(int(64),neither,one)
+
+ArrayViewElision supported slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),neither,one)
+		range(int(64),neither,one)
+	rhsIndexingExprs: 
+		range(int(64),neither,one)
+		range(int(64),neither,one)
+
+Set first two:
+Test 1
+2 2 1 1 1
+2 2 1 1 1
+1 1 1 1 1
+1 1 1 1 1
+1 1 1 1 1
+
+Test 2
+2 2 1 1 1
+2 2 1 1 1
+1 1 1 1 1
+1 1 1 1 1
+1 1 1 1 1
+
+Test 3
+2 2 1 1 1
+2 2 1 1 1
+1 1 1 1 1
+1 1 1 1 1
+1 1 1 1 1
+
+Test 4
+2 2 1 1 1
+2 2 1 1 1
+1 1 1 1 1
+1 1 1 1 1
+1 1 1 1 1
+
+Test 5
+2 2 1 1 1
+2 2 1 1 1
+1 1 1 1 1
+1 1 1 1 1
+1 1 1 1 1
+
+Test 6
+2 2 1 1 1
+2 2 1 1 1
+1 1 1 1 1
+1 1 1 1 1
+1 1 1 1 1
+
+Test 7
+2 2 1 1 1
+2 2 1 1 1
+1 1 1 1 1
+1 1 1 1 1
+1 1 1 1 1
+
+Test 8
+2 2 1 1 1
+2 2 1 1 1
+1 1 1 1 1
+1 1 1 1 1
+1 1 1 1 1
+
+-----------------
+Set last two:
+Test 9
+1 1 1 1 1
+1 1 1 1 1
+1 1 1 1 1
+1 1 1 2 2
+1 1 1 2 2
+
+Test 10
+1 1 1 1 1
+1 1 1 1 1
+1 1 1 1 1
+1 1 1 2 2
+1 1 1 2 2
+
+Test 11
+1 1 1 1 1
+1 1 1 1 1
+1 1 1 1 1
+1 1 1 2 2
+1 1 1 2 2
+
+Test 12
+1 1 1 1 1
+1 1 1 1 1
+1 1 1 1 1
+1 1 1 2 2
+1 1 1 2 2
+
+Test 13
+1 1 1 1 1
+1 1 1 1 1
+1 1 1 1 1
+1 1 1 2 2
+1 1 1 2 2
+
+Test 14
+1 1 1 1 1
+1 1 1 1 1
+1 1 1 1 1
+1 1 1 2 2
+1 1 1 2 2
+
+Test 15
+1 1 1 1 1
+1 1 1 1 1
+1 1 1 1 1
+1 1 1 2 2
+1 1 1 2 2
+
+Test 16
+1 1 1 1 1
+1 1 1 1 1
+1 1 1 1 1
+1 1 1 2 2
+1 1 1 2 2
+
+-----------------
+Set all:
+Test 17
+2 2 2 2 2
+2 2 2 2 2
+2 2 2 2 2
+2 2 2 2 2
+2 2 2 2 2
+
+Test 18
+2 2 2 2 2
+2 2 2 2 2
+2 2 2 2 2
+2 2 2 2 2
+2 2 2 2 2
+
+Test 19
+2 2 2 2 2
+2 2 2 2 2
+2 2 2 2 2
+2 2 2 2 2
+2 2 2 2 2
+
+Test 20
+2 2 2 2 2
+2 2 2 2 2
+2 2 2 2 2
+2 2 2 2 2
+2 2 2 2 2
+
+Test 21
+2 2 2 2 2
+2 2 2 2 2
+2 2 2 2 2
+2 2 2 2 2
+2 2 2 2 2
+
+Test 22
+2 2 2 2 2
+2 2 2 2 2
+2 2 2 2 2
+2 2 2 2 2
+2 2 2 2 2
+
+Test 23
+2 2 2 2 2
+2 2 2 2 2
+2 2 2 2 2
+2 2 2 2 2
+2 2 2 2 2
+
+Test 24
+2 2 2 2 2
+2 2 2 2 2
+2 2 2 2 2
+2 2 2 2 2
+2 2 2 2 2
+
+Test 25
+2 2 2 2 2
+2 2 2 2 2
+2 2 2 2 2
+2 2 2 2 2
+2 2 2 2 2
+
+-----------------

--- a/test/optimizations/arrayViewElision/slices-2d-range-no-sat.good
+++ b/test/optimizations/arrayViewElision/slices-2d-range-no-sat.good
@@ -1,4 +1,4 @@
-ArrayViewElision supported slices.chpl:26
+ArrayViewElision supported (dynamic locality check required) slices.chpl:26
 	lhsIndexingExprs: 
 		range(int(64),both,one)
 		range(int(64),both,one)
@@ -6,7 +6,7 @@ ArrayViewElision supported slices.chpl:26
 		range(int(64),both,one)
 		range(int(64),both,one)
 
-ArrayViewElision supported slices.chpl:26
+ArrayViewElision supported (dynamic locality check required) slices.chpl:26
 	lhsIndexingExprs: 
 		range(int(64),both,one)
 		range(int(64),both,one)
@@ -14,7 +14,7 @@ ArrayViewElision supported slices.chpl:26
 		range(int(64),both,one)
 		range(int(64),both,one)
 
-ArrayViewElision supported slices.chpl:26
+ArrayViewElision supported (dynamic locality check required) slices.chpl:26
 	lhsIndexingExprs: 
 		range(int(64),both,one)
 		range(int(64),both,one)
@@ -22,7 +22,7 @@ ArrayViewElision supported slices.chpl:26
 		range(int(64),both,one)
 		range(int(64),both,one)
 
-ArrayViewElision supported slices.chpl:26
+ArrayViewElision supported (dynamic locality check required) slices.chpl:26
 	lhsIndexingExprs: 
 		range(int(64),high,one)
 		range(int(64),high,one)
@@ -30,7 +30,7 @@ ArrayViewElision supported slices.chpl:26
 		range(int(64),high,one)
 		range(int(64),high,one)
 
-ArrayViewElision supported slices.chpl:26
+ArrayViewElision supported (dynamic locality check required) slices.chpl:26
 	lhsIndexingExprs: 
 		range(int(64),high,one)
 		range(int(64),high,one)
@@ -38,7 +38,7 @@ ArrayViewElision supported slices.chpl:26
 		range(int(64),high,one)
 		range(int(64),high,one)
 
-ArrayViewElision supported slices.chpl:26
+ArrayViewElision supported (dynamic locality check required) slices.chpl:26
 	lhsIndexingExprs: 
 		range(int(64),high,one)
 		range(int(64),high,one)
@@ -46,7 +46,7 @@ ArrayViewElision supported slices.chpl:26
 		range(int(64),high,one)
 		range(int(64),high,one)
 
-ArrayViewElision supported slices.chpl:26
+ArrayViewElision supported (dynamic locality check required) slices.chpl:26
 	lhsIndexingExprs: 
 		range(int(64),low,one)
 		range(int(64),low,one)
@@ -54,7 +54,7 @@ ArrayViewElision supported slices.chpl:26
 		range(int(64),low,one)
 		range(int(64),low,one)
 
-ArrayViewElision supported slices.chpl:26
+ArrayViewElision supported (dynamic locality check required) slices.chpl:26
 	lhsIndexingExprs: 
 		range(int(64),low,one)
 		range(int(64),low,one)
@@ -62,7 +62,7 @@ ArrayViewElision supported slices.chpl:26
 		range(int(64),low,one)
 		range(int(64),low,one)
 
-ArrayViewElision supported slices.chpl:26
+ArrayViewElision supported (dynamic locality check required) slices.chpl:26
 	lhsIndexingExprs: 
 		range(int(64),low,one)
 		range(int(64),low,one)
@@ -70,7 +70,7 @@ ArrayViewElision supported slices.chpl:26
 		range(int(64),low,one)
 		range(int(64),low,one)
 
-ArrayViewElision supported slices.chpl:26
+ArrayViewElision supported (dynamic locality check required) slices.chpl:26
 	lhsIndexingExprs: 
 		range(int(64),both,one)
 		range(int(64),both,one)
@@ -78,7 +78,7 @@ ArrayViewElision supported slices.chpl:26
 		range(int(64),both,one)
 		range(int(64),both,one)
 
-ArrayViewElision supported slices.chpl:26
+ArrayViewElision supported (dynamic locality check required) slices.chpl:26
 	lhsIndexingExprs: 
 		range(int(64),low,one)
 		range(int(64),low,one)
@@ -86,7 +86,7 @@ ArrayViewElision supported slices.chpl:26
 		range(int(64),low,one)
 		range(int(64),low,one)
 
-ArrayViewElision supported slices.chpl:26
+ArrayViewElision supported (dynamic locality check required) slices.chpl:26
 	lhsIndexingExprs: 
 		range(int(64),neither,one)
 		range(int(64),neither,one)
@@ -94,7 +94,7 @@ ArrayViewElision supported slices.chpl:26
 		range(int(64),neither,one)
 		range(int(64),neither,one)
 
-ArrayViewElision supported slices.chpl:26
+ArrayViewElision supported (dynamic locality check required) slices.chpl:26
 	lhsIndexingExprs: 
 		range(int(64),neither,one)
 		range(int(64),neither,one)
@@ -102,7 +102,7 @@ ArrayViewElision supported slices.chpl:26
 		range(int(64),neither,one)
 		range(int(64),neither,one)
 
-ArrayViewElision supported slices.chpl:26
+ArrayViewElision supported (dynamic locality check required) slices.chpl:26
 	lhsIndexingExprs: 
 		range(int(64),neither,one)
 		range(int(64),neither,one)
@@ -111,8 +111,6 @@ ArrayViewElision supported slices.chpl:26
 		range(int(64),neither,one)
 
 Set first two:
-<ShortArrayTransfer> Size: 4 Threshold: 60
-<ShortArrayTransfer> size qualifies
 Test 1
 2 2 1 1 1
 2 2 1 1 1
@@ -120,8 +118,6 @@ Test 1
 1 1 1 1 1
 1 1 1 1 1
 
-<ShortArrayTransfer> Size: 4 Threshold: 60
-<ShortArrayTransfer> size qualifies
 Test 2
 2 2 1 1 1
 2 2 1 1 1
@@ -129,8 +125,6 @@ Test 2
 1 1 1 1 1
 1 1 1 1 1
 
-<ShortArrayTransfer> Size: 4 Threshold: 60
-<ShortArrayTransfer> size qualifies
 Test 3
 2 2 1 1 1
 2 2 1 1 1
@@ -138,8 +132,6 @@ Test 3
 1 1 1 1 1
 1 1 1 1 1
 
-<ShortArrayTransfer> Size: 4 Threshold: 60
-<ShortArrayTransfer> size qualifies
 Test 4
 2 2 1 1 1
 2 2 1 1 1
@@ -147,8 +139,6 @@ Test 4
 1 1 1 1 1
 1 1 1 1 1
 
-<ShortArrayTransfer> Size: 4 Threshold: 60
-<ShortArrayTransfer> size qualifies
 Test 5
 2 2 1 1 1
 2 2 1 1 1
@@ -156,8 +146,6 @@ Test 5
 1 1 1 1 1
 1 1 1 1 1
 
-<ShortArrayTransfer> Size: 4 Threshold: 60
-<ShortArrayTransfer> size qualifies
 Test 6
 2 2 1 1 1
 2 2 1 1 1
@@ -165,8 +153,6 @@ Test 6
 1 1 1 1 1
 1 1 1 1 1
 
-<ShortArrayTransfer> Size: 4 Threshold: 60
-<ShortArrayTransfer> size qualifies
 Test 7
 2 2 1 1 1
 2 2 1 1 1
@@ -174,8 +160,6 @@ Test 7
 1 1 1 1 1
 1 1 1 1 1
 
-<ShortArrayTransfer> Size: 4 Threshold: 60
-<ShortArrayTransfer> size qualifies
 Test 8
 2 2 1 1 1
 2 2 1 1 1
@@ -185,8 +169,6 @@ Test 8
 
 -----------------
 Set last two:
-<ShortArrayTransfer> Size: 4 Threshold: 60
-<ShortArrayTransfer> size qualifies
 Test 9
 1 1 1 1 1
 1 1 1 1 1
@@ -194,8 +176,6 @@ Test 9
 1 1 1 2 2
 1 1 1 2 2
 
-<ShortArrayTransfer> Size: 4 Threshold: 60
-<ShortArrayTransfer> size qualifies
 Test 10
 1 1 1 1 1
 1 1 1 1 1
@@ -203,8 +183,6 @@ Test 10
 1 1 1 2 2
 1 1 1 2 2
 
-<ShortArrayTransfer> Size: 4 Threshold: 60
-<ShortArrayTransfer> size qualifies
 Test 11
 1 1 1 1 1
 1 1 1 1 1
@@ -212,8 +190,6 @@ Test 11
 1 1 1 2 2
 1 1 1 2 2
 
-<ShortArrayTransfer> Size: 4 Threshold: 60
-<ShortArrayTransfer> size qualifies
 Test 12
 1 1 1 1 1
 1 1 1 1 1
@@ -221,8 +197,6 @@ Test 12
 1 1 1 2 2
 1 1 1 2 2
 
-<ShortArrayTransfer> Size: 4 Threshold: 60
-<ShortArrayTransfer> size qualifies
 Test 13
 1 1 1 1 1
 1 1 1 1 1
@@ -230,8 +204,6 @@ Test 13
 1 1 1 2 2
 1 1 1 2 2
 
-<ShortArrayTransfer> Size: 4 Threshold: 60
-<ShortArrayTransfer> size qualifies
 Test 14
 1 1 1 1 1
 1 1 1 1 1
@@ -239,8 +211,6 @@ Test 14
 1 1 1 2 2
 1 1 1 2 2
 
-<ShortArrayTransfer> Size: 4 Threshold: 60
-<ShortArrayTransfer> size qualifies
 Test 15
 1 1 1 1 1
 1 1 1 1 1
@@ -248,8 +218,6 @@ Test 15
 1 1 1 2 2
 1 1 1 2 2
 
-<ShortArrayTransfer> Size: 4 Threshold: 60
-<ShortArrayTransfer> size qualifies
 Test 16
 1 1 1 1 1
 1 1 1 1 1
@@ -259,8 +227,6 @@ Test 16
 
 -----------------
 Set all:
-<ShortArrayTransfer> Size: 25 Threshold: 60
-<ShortArrayTransfer> size qualifies
 Test 17
 2 2 2 2 2
 2 2 2 2 2
@@ -268,8 +234,6 @@ Test 17
 2 2 2 2 2
 2 2 2 2 2
 
-<ShortArrayTransfer> Size: 25 Threshold: 60
-<ShortArrayTransfer> size qualifies
 Test 18
 2 2 2 2 2
 2 2 2 2 2
@@ -277,8 +241,6 @@ Test 18
 2 2 2 2 2
 2 2 2 2 2
 
-<ShortArrayTransfer> Size: 25 Threshold: 60
-<ShortArrayTransfer> size qualifies
 Test 19
 2 2 2 2 2
 2 2 2 2 2
@@ -286,8 +248,6 @@ Test 19
 2 2 2 2 2
 2 2 2 2 2
 
-<ShortArrayTransfer> Size: 25 Threshold: 60
-<ShortArrayTransfer> size qualifies
 Test 20
 2 2 2 2 2
 2 2 2 2 2
@@ -295,8 +255,6 @@ Test 20
 2 2 2 2 2
 2 2 2 2 2
 
-<ShortArrayTransfer> Size: 25 Threshold: 60
-<ShortArrayTransfer> size qualifies
 Test 21
 2 2 2 2 2
 2 2 2 2 2
@@ -304,8 +262,6 @@ Test 21
 2 2 2 2 2
 2 2 2 2 2
 
-<ShortArrayTransfer> Size: 25 Threshold: 60
-<ShortArrayTransfer> size qualifies
 Test 22
 2 2 2 2 2
 2 2 2 2 2
@@ -313,8 +269,6 @@ Test 22
 2 2 2 2 2
 2 2 2 2 2
 
-<ShortArrayTransfer> Size: 25 Threshold: 60
-<ShortArrayTransfer> size qualifies
 Test 23
 2 2 2 2 2
 2 2 2 2 2
@@ -322,8 +276,6 @@ Test 23
 2 2 2 2 2
 2 2 2 2 2
 
-<ShortArrayTransfer> Size: 25 Threshold: 60
-<ShortArrayTransfer> size qualifies
 Test 24
 2 2 2 2 2
 2 2 2 2 2
@@ -331,8 +283,6 @@ Test 24
 2 2 2 2 2
 2 2 2 2 2
 
-<ShortArrayTransfer> Size: 25 Threshold: 60
-<ShortArrayTransfer> size qualifies
 Test 25
 2 2 2 2 2
 2 2 2 2 2

--- a/test/optimizations/arrayViewElision/slices-2d-range-no-sat.no-local.good
+++ b/test/optimizations/arrayViewElision/slices-2d-range-no-sat.no-local.good
@@ -1,0 +1,1 @@
+slices-2d-range-no-sat.good

--- a/test/optimizations/arrayViewElision/slices-2d-range.good
+++ b/test/optimizations/arrayViewElision/slices-2d-range.good
@@ -1,139 +1,111 @@
 ArrayViewElision supported (dynamic locality check required) slices.chpl:26
-	lhsBaseType: [domain(2,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		range(int(64),both,one)
 		range(int(64),both,one)
-	rhsBaseType: [domain(2,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		range(int(64),both,one)
 		range(int(64),both,one)
 
 ArrayViewElision supported (dynamic locality check required) slices.chpl:26
-	lhsBaseType: [domain(2,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		range(int(64),both,one)
 		range(int(64),both,one)
-	rhsBaseType: [domain(2,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		range(int(64),both,one)
 		range(int(64),both,one)
 
 ArrayViewElision supported (dynamic locality check required) slices.chpl:26
-	lhsBaseType: [domain(2,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		range(int(64),both,one)
 		range(int(64),both,one)
-	rhsBaseType: [domain(2,int(64),one)] int(64)
-	rhsIndexingExprs: 
-		range(int(64),both,one)
-		range(int(64),both,one)
-
-ArrayViewElision supported (dynamic locality check required) slices.chpl:26
-	lhsBaseType: [domain(2,int(64),one)] int(64)
-	lhsIndexingExprs: 
-		range(int(64),high,one)
-		range(int(64),high,one)
-	rhsBaseType: [domain(2,int(64),one)] int(64)
-	rhsIndexingExprs: 
-		range(int(64),high,one)
-		range(int(64),high,one)
-
-ArrayViewElision supported (dynamic locality check required) slices.chpl:26
-	lhsBaseType: [domain(2,int(64),one)] int(64)
-	lhsIndexingExprs: 
-		range(int(64),high,one)
-		range(int(64),high,one)
-	rhsBaseType: [domain(2,int(64),one)] int(64)
-	rhsIndexingExprs: 
-		range(int(64),high,one)
-		range(int(64),high,one)
-
-ArrayViewElision supported (dynamic locality check required) slices.chpl:26
-	lhsBaseType: [domain(2,int(64),one)] int(64)
-	lhsIndexingExprs: 
-		range(int(64),high,one)
-		range(int(64),high,one)
-	rhsBaseType: [domain(2,int(64),one)] int(64)
-	rhsIndexingExprs: 
-		range(int(64),high,one)
-		range(int(64),high,one)
-
-ArrayViewElision supported (dynamic locality check required) slices.chpl:26
-	lhsBaseType: [domain(2,int(64),one)] int(64)
-	lhsIndexingExprs: 
-		range(int(64),low,one)
-		range(int(64),low,one)
-	rhsBaseType: [domain(2,int(64),one)] int(64)
-	rhsIndexingExprs: 
-		range(int(64),low,one)
-		range(int(64),low,one)
-
-ArrayViewElision supported (dynamic locality check required) slices.chpl:26
-	lhsBaseType: [domain(2,int(64),one)] int(64)
-	lhsIndexingExprs: 
-		range(int(64),low,one)
-		range(int(64),low,one)
-	rhsBaseType: [domain(2,int(64),one)] int(64)
-	rhsIndexingExprs: 
-		range(int(64),low,one)
-		range(int(64),low,one)
-
-ArrayViewElision supported (dynamic locality check required) slices.chpl:26
-	lhsBaseType: [domain(2,int(64),one)] int(64)
-	lhsIndexingExprs: 
-		range(int(64),low,one)
-		range(int(64),low,one)
-	rhsBaseType: [domain(2,int(64),one)] int(64)
-	rhsIndexingExprs: 
-		range(int(64),low,one)
-		range(int(64),low,one)
-
-ArrayViewElision supported (dynamic locality check required) slices.chpl:26
-	lhsBaseType: [domain(2,int(64),one)] int(64)
-	lhsIndexingExprs: 
-		range(int(64),both,one)
-		range(int(64),both,one)
-	rhsBaseType: [domain(2,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		range(int(64),both,one)
 		range(int(64),both,one)
 
 ArrayViewElision supported (dynamic locality check required) slices.chpl:26
-	lhsBaseType: [domain(2,int(64),one)] int(64)
+	lhsIndexingExprs: 
+		range(int(64),high,one)
+		range(int(64),high,one)
+	rhsIndexingExprs: 
+		range(int(64),high,one)
+		range(int(64),high,one)
+
+ArrayViewElision supported (dynamic locality check required) slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),high,one)
+		range(int(64),high,one)
+	rhsIndexingExprs: 
+		range(int(64),high,one)
+		range(int(64),high,one)
+
+ArrayViewElision supported (dynamic locality check required) slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),high,one)
+		range(int(64),high,one)
+	rhsIndexingExprs: 
+		range(int(64),high,one)
+		range(int(64),high,one)
+
+ArrayViewElision supported (dynamic locality check required) slices.chpl:26
 	lhsIndexingExprs: 
 		range(int(64),low,one)
 		range(int(64),low,one)
-	rhsBaseType: [domain(2,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		range(int(64),low,one)
 		range(int(64),low,one)
 
 ArrayViewElision supported (dynamic locality check required) slices.chpl:26
-	lhsBaseType: [domain(2,int(64),one)] int(64)
+	lhsIndexingExprs: 
+		range(int(64),low,one)
+		range(int(64),low,one)
+	rhsIndexingExprs: 
+		range(int(64),low,one)
+		range(int(64),low,one)
+
+ArrayViewElision supported (dynamic locality check required) slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),low,one)
+		range(int(64),low,one)
+	rhsIndexingExprs: 
+		range(int(64),low,one)
+		range(int(64),low,one)
+
+ArrayViewElision supported (dynamic locality check required) slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),both,one)
+		range(int(64),both,one)
+	rhsIndexingExprs: 
+		range(int(64),both,one)
+		range(int(64),both,one)
+
+ArrayViewElision supported (dynamic locality check required) slices.chpl:26
+	lhsIndexingExprs: 
+		range(int(64),low,one)
+		range(int(64),low,one)
+	rhsIndexingExprs: 
+		range(int(64),low,one)
+		range(int(64),low,one)
+
+ArrayViewElision supported (dynamic locality check required) slices.chpl:26
 	lhsIndexingExprs: 
 		range(int(64),neither,one)
 		range(int(64),neither,one)
-	rhsBaseType: [domain(2,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		range(int(64),neither,one)
 		range(int(64),neither,one)
 
 ArrayViewElision supported (dynamic locality check required) slices.chpl:26
-	lhsBaseType: [domain(2,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		range(int(64),neither,one)
 		range(int(64),neither,one)
-	rhsBaseType: [domain(2,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		range(int(64),neither,one)
 		range(int(64),neither,one)
 
 ArrayViewElision supported (dynamic locality check required) slices.chpl:26
-	lhsBaseType: [domain(2,int(64),one)] int(64)
 	lhsIndexingExprs: 
 		range(int(64),neither,one)
 		range(int(64),neither,one)
-	rhsBaseType: [domain(2,int(64),one)] int(64)
 	rhsIndexingExprs: 
 		range(int(64),neither,one)
 		range(int(64),neither,one)

--- a/test/optimizations/arrayViewElision/slices.chpl
+++ b/test/optimizations/arrayViewElision/slices.chpl
@@ -1,4 +1,4 @@
-config param useDomain = false, rank = 1, dist = "stencil";
+config param useDomain = false, rank = 1, dist = "block";
 
 proc multuplify(param rank, x) {
   var ret: rank*x.type;

--- a/test/optimizations/arrayViewElision/slices.chpl
+++ b/test/optimizations/arrayViewElision/slices.chpl
@@ -1,4 +1,4 @@
-config param useDomain = true, rank = 1;
+config param useDomain = false, rank = 1;
 config param dist = "stencil";
 
 proc multuplify(param rank, x) {

--- a/test/optimizations/arrayViewElision/slices.chpl
+++ b/test/optimizations/arrayViewElision/slices.chpl
@@ -1,4 +1,4 @@
-config param useDomain = false, rank = 1, dist = "block";
+config param useDomain = false, rank = 1, dist = "default";
 
 proc multuplify(param rank, x) {
   var ret: rank*x.type;

--- a/test/optimizations/arrayViewElision/slices.chpl
+++ b/test/optimizations/arrayViewElision/slices.chpl
@@ -1,5 +1,4 @@
-config param useDomain = false, rank = 1;
-config param dist = "stencil";
+config param useDomain = false, rank = 1, dist = "stencil";
 
 proc multuplify(param rank, x) {
   var ret: rank*x.type;
@@ -12,42 +11,6 @@ proc multuplify(param rank, x) {
 var arrRanges = multuplify(rank, 1..5);
 
 param aVal = 1, bVal = 2;
-
-proc createArrays() {
-  select dist {
-    when "default" {
-      var A: [(...arrRanges)] int = aVal;
-      var B: [(...arrRanges)] int = bVal;
-      A = aVal;
-      B = bVal;
-      return (A, B);
-    }
-    when "block" {
-      use BlockDist;
-      var A = blockDist.createArray((...arrRanges), int);
-      var B = blockDist.createArray((...arrRanges), int);
-      A = aVal;
-      B = bVal;
-      return (A, B);
-    }
-    when "cyclic" {
-      use CyclicDist;
-      var A = cyclicDist.createArray((...arrRanges), int);
-      var B = cyclicDist.createArray((...arrRanges), int);
-      A = aVal;
-      B = bVal;
-      return (A, B);
-    }
-    when "stencil" {
-      use StencilDist;
-      var A = stencilDist.createArray((...arrRanges), int);
-      var B = stencilDist.createArray((...arrRanges), int);
-      A = aVal;
-      B = bVal;
-      return (A, B);
-    }
-  }
-}
 
 var (A, B) = createArrays();
 
@@ -117,3 +80,40 @@ if !useDomain {
   test(.., ..);
 }
 writeln("-----------------");
+
+proc createArrays() {
+  select dist {
+    when "default" {
+      var A: [(...arrRanges)] int = aVal;
+      var B: [(...arrRanges)] int = bVal;
+      A = aVal;
+      B = bVal;
+      return (A, B);
+    }
+    when "block" {
+      use BlockDist;
+      var A = blockDist.createArray((...arrRanges), int);
+      var B = blockDist.createArray((...arrRanges), int);
+      A = aVal;
+      B = bVal;
+      return (A, B);
+    }
+    when "cyclic" {
+      use CyclicDist;
+      var A = cyclicDist.createArray((...arrRanges), int);
+      var B = cyclicDist.createArray((...arrRanges), int);
+      A = aVal;
+      B = bVal;
+      return (A, B);
+    }
+    when "stencil" {
+      use StencilDist;
+      var A = stencilDist.createArray((...arrRanges), int);
+      var B = stencilDist.createArray((...arrRanges), int);
+      A = aVal;
+      B = bVal;
+      return (A, B);
+    }
+  }
+}
+

--- a/test/optimizations/arrayViewElision/slices.chpl
+++ b/test/optimizations/arrayViewElision/slices.chpl
@@ -1,5 +1,5 @@
 config param useDomain = true, rank = 1;
-config param dist = "block";
+config param dist = "stencil";
 
 proc multuplify(param rank, x) {
   var ret: rank*x.type;

--- a/test/optimizations/arrayViewElision/slices.compopts
+++ b/test/optimizations/arrayViewElision/slices.compopts
@@ -2,6 +2,10 @@
 --report-array-view-elision -sdist='"default"' -sdebugShortArrayTransfer=true -srank=2 -suseDomain=false # slices-2d-range
 --report-array-view-elision -sdist='"default"' -sdebugShortArrayTransfer=true -srank=1 -suseDomain=true # slices-1d-domain
 --report-array-view-elision -sdist='"default"' -sdebugShortArrayTransfer=true -srank=2 -suseDomain=true # slices-2d-domain
+--report-array-view-elision -sdist='"block"' -sdebugShortArrayTransfer=false -srank=1 -suseDomain=false # slices-1d-range-no-sat
+--report-array-view-elision -sdist='"block"' -sdebugShortArrayTransfer=false -srank=2 -suseDomain=false # slices-2d-range-no-sat
+--report-array-view-elision -sdist='"block"' -sdebugShortArrayTransfer=false -srank=1 -suseDomain=true # slices-1d-domain-no-sat
+--report-array-view-elision -sdist='"block"' -sdebugShortArrayTransfer=false -srank=2 -suseDomain=true # slices-2d-domain-no-sat
 --report-array-view-elision -sdist='"stencil"' -sdebugShortArrayTransfer=false -srank=1 -suseDomain=false # slices-1d-range-no-sat
 --report-array-view-elision -sdist='"stencil"' -sdebugShortArrayTransfer=false -srank=2 -suseDomain=false # slices-2d-range-no-sat
 --report-array-view-elision -sdist='"stencil"' -sdebugShortArrayTransfer=false -srank=1 -suseDomain=true # slices-1d-domain-no-sat

--- a/test/optimizations/arrayViewElision/slices.compopts
+++ b/test/optimizations/arrayViewElision/slices.compopts
@@ -10,3 +10,7 @@
 --report-array-view-elision -sdist='"stencil"' -sdebugShortArrayTransfer=false -srank=2 -suseDomain=false # slices-2d-range-no-sat
 --report-array-view-elision -sdist='"stencil"' -sdebugShortArrayTransfer=false -srank=1 -suseDomain=true # slices-1d-domain-no-sat
 --report-array-view-elision -sdist='"stencil"' -sdebugShortArrayTransfer=false -srank=2 -suseDomain=true # slices-2d-domain-no-sat
+--report-array-view-elision -sdist='"cyclic"' -sdebugShortArrayTransfer=false -srank=1 -suseDomain=false # slices-1d-range-no-sat
+--report-array-view-elision -sdist='"cyclic"' -sdebugShortArrayTransfer=false -srank=2 -suseDomain=false # slices-2d-range-no-sat
+--report-array-view-elision -sdist='"cyclic"' -sdebugShortArrayTransfer=false -srank=1 -suseDomain=true # slices-1d-domain-no-sat
+--report-array-view-elision -sdist='"cyclic"' -sdebugShortArrayTransfer=false -srank=2 -suseDomain=true # slices-2d-domain-no-sat

--- a/test/optimizations/arrayViewElision/slices.compopts
+++ b/test/optimizations/arrayViewElision/slices.compopts
@@ -1,4 +1,8 @@
---report-array-view-elision -sdebugShortArrayTransfer=true -srank=1 -suseDomain=false # slices-1d-range
---report-array-view-elision -sdebugShortArrayTransfer=true -srank=2 -suseDomain=false # slices-2d-range
---report-array-view-elision -sdebugShortArrayTransfer=true -srank=1 -suseDomain=true # slices-1d-domain
---report-array-view-elision -sdebugShortArrayTransfer=true -srank=2 -suseDomain=true # slices-2d-domain
+--report-array-view-elision -sdist='"default"' -sdebugShortArrayTransfer=true -srank=1 -suseDomain=false # slices-1d-range
+--report-array-view-elision -sdist='"default"' -sdebugShortArrayTransfer=true -srank=2 -suseDomain=false # slices-2d-range
+--report-array-view-elision -sdist='"default"' -sdebugShortArrayTransfer=true -srank=1 -suseDomain=true # slices-1d-domain
+--report-array-view-elision -sdist='"default"' -sdebugShortArrayTransfer=true -srank=2 -suseDomain=true # slices-2d-domain
+--report-array-view-elision -sdist='"stencil"' -sdebugShortArrayTransfer=false -srank=1 -suseDomain=false # slices-1d-range-no-sat
+--report-array-view-elision -sdist='"stencil"' -sdebugShortArrayTransfer=false -srank=2 -suseDomain=false # slices-2d-range-no-sat
+--report-array-view-elision -sdist='"stencil"' -sdebugShortArrayTransfer=false -srank=1 -suseDomain=true # slices-1d-domain-no-sat
+--report-array-view-elision -sdist='"stencil"' -sdebugShortArrayTransfer=false -srank=2 -suseDomain=true # slices-2d-domain-no-sat

--- a/test/optimizations/arrayViewElision/slices.prediff
+++ b/test/optimizations/arrayViewElision/slices.prediff
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+grep -v BaseType $2 >$2.tmp
+mv $2.tmp $2


### PR DESCRIPTION
This PR extends the array view elision (AVE) optimization added in https://github.com/chapel-lang/chapel/pull/24390 to Block, Cyclic and Stencil. Previously, AVE was only supported on DR.

Changes are relatively straightforward. They are roughly:

- Add some new `dsiSupports*` methods to signal AVE and SAT support (no meaningful change for SAT in this PR)
- Add `config param`s for controlling support for these newly supported types
- Add `range`-based helper functions. None has any notable new logic. They are just simplifications of already-existing, domain-based counterparts as these can assume 1D domains. These range-based versions are required by AVE, which wants to avoid domain creation for cases like `Arr[3..5]`.
  - `activeTargetLocales`
  - `bulkCommTranslateDomain`
  - `bulkCommConvertCoordinate`
- Expand `test/optimizations/arrayViewElision/{slices,rankChanges}` to cover new distributions.
  - `prediff` "lhsBaseType" and "rhsBaseType" from the output generated by `--report-array-view-elision` as now the reported types change based on `compopts`
  - add `createArrays` helper function to create arrays of given types
  - add a `config param` to control the array type
  - expand `compopts`: the distributed versions disable SAT reporting and have special good file variations. SAT doesn't fire for distributed arrays, yet.

The following are still not supported, but could be considered as future work as need arise:

- cross-type assignment
- views of views
- distributed-domain slices of distributed arrays

Test:
- [x] linux64
- [x] gasnet