### PR TITLE
ROCm < 5.0.0 doesn't support PCI domain attribute

### DIFF
--- a/runtime/src/gpu/amd/gpu-amd.c
+++ b/runtime/src/gpu/amd/gpu-amd.c
@@ -154,6 +154,7 @@ void chpl_gpu_impl_init(int* num_devices) {
     ROCM_CALL(hipDeviceGet(&allDevices[i], i));
 #endif
     int domain, bus, device;
+#if ROCM_VERSION_MAJOR >= 5
     int rc = hipDeviceGetAttribute(&domain, hipDeviceAttributePciDomainID,
                                     allDevices[i]);
     if (rc == hipErrorInvalidValue) {
@@ -163,6 +164,10 @@ void chpl_gpu_impl_init(int* num_devices) {
     } else {
       ROCM_CALL(rc);
     }
+#else
+    // Earlier versions of ROCm don't support this attribute.
+    domain = 0;
+#endif
     ROCM_CALL(hipDeviceGetAttribute(&bus, hipDeviceAttributePciBusId,
                                     allDevices[i]));
     ROCM_CALL(hipDeviceGetAttribute(&device, hipDeviceAttributePciDeviceId,


### PR DESCRIPTION
You can't query the PCI domain on ROCm < 5.0.0, so assume it's zero.