### PR TITLE
Test blog in a few correctness configs

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -630,7 +630,7 @@ if ($examples == 1) {
     $testdirs .= " release/examples";
 }
 
-if ($blogonly == 1) {
+if ($blogonly == 1 || ($testblog == 1 && $examples == 1)) {
     # test the sub-directories explicitly to avoid a bunch of skipped directories,
     # and also avoid the problem of testing the archetypes directory
     $testdirs .= " $blogdir/chpl-src/ $blogdir/content/posts";

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -383,6 +383,11 @@ if ($memleakslog ne "") {
     }
 }
 
+#
+# directory variables
+#
+$testdir = "$chplhomedir/test";
+print "\$chplhomedir = $chplhomedir\n";
 
 $testbindirname = dirname($0);
 $utildir = "$testbindirname/../../util";
@@ -450,11 +455,7 @@ unlink($mysystemlog); # the file gets appended to, so clear it first.
 ensureMysystemlogExists($mysystemlog); # empty (vs nonexistent) file is easier to compare against
 $prevmysystemlog = "$cronlogdir/last-mysystemerrs-$config_name.txt";
 
-#
-# directory variables
-#
-$testdir = "$chplhomedir/test";
-print "\$chplhomedir = $chplhomedir\n";
+
 
 
 $launchcmd = "$ENV{'CHPL_TEST_LAUNCHCMD'}";

--- a/util/cron/test-darwin.bash
+++ b/util/cron/test-darwin.bash
@@ -8,4 +8,4 @@ source $CWD/common-darwin.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="darwin"
 
-$CWD/nightly -cron -examples
+$CWD/nightly -cron -examples -blog

--- a/util/cron/test-linux64-clang.bash
+++ b/util/cron/test-linux64-clang.bash
@@ -15,4 +15,4 @@ export CHPL_TARGET_COMPILER=clang
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-clang"
 
-$CWD/nightly -cron -examples ${nightly_args}
+$CWD/nightly -cron -examples -blog ${nightly_args}

--- a/util/cron/test-linux64-gcc112.bash
+++ b/util/cron/test-linux64-gcc112.bash
@@ -27,4 +27,4 @@ fi
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-gcc112"
 
-$CWD/nightly -cron -examples ${nightly_args}
+$CWD/nightly -cron -examples -blog ${nightly_args}

--- a/util/cron/test-linux64-llvm16.bash
+++ b/util/cron/test-linux64-llvm16.bash
@@ -17,4 +17,4 @@ fi
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-llvm16"
 
-$CWD/nightly -cron -examples ${nightly_args}
+$CWD/nightly -cron -examples -blog ${nightly_args}


### PR DESCRIPTION
This adds blog testing to nightly correctness tests on `linux64-clang`, `linux64-gcc112`, `linux64-llvm16`, and `darwin` configs. It has a required CI companion PR https://github.hpe.com/hpe/hpc-chapel-ci-config/pull/1271 that enables cloning of the chapel-blog repo in these configs. 

[reviewed by @riftEmber - thanks!]