### PR TITLE
Force a build script error when a subcommand fails in packaging builds

### DIFF
--- a/util/cron/create_release_aptrpm.bash
+++ b/util/cron/create_release_aptrpm.bash
@@ -31,6 +31,9 @@ source $CWD/functions.bash
 export CHPL_HOME=$(cd $CWD/../.. ; pwd)
 log_info "Setting CHPL_HOME to: ${CHPL_HOME}"
 
+# if any errors occur, this script should fail
+set -e
+
 source $CHPL_HOME/util/packaging/common/build_helpers.sh
 
 # if using a local tarball, copy it to the expected location

--- a/util/packaging/common/build_helpers.sh
+++ b/util/packaging/common/build_helpers.sh
@@ -128,10 +128,10 @@ __test_package() {
   python3 $CHPL_HOME/util/packaging/common/test_package.py $@
 }
 __test_all_packages() {
-  for deb in $(find $CHPL_HOME/util/packaging/apt/build -name '*.deb'); do
+  for deb in $(set +e && find $CHPL_HOME/util/packaging/apt/build -name '*.deb'); do
     __test_package $deb
   done
-  for rpm in $(find $CHPL_HOME/util/packaging/rpm/build -name '*.rpm'); do
+  for rpm in $(set +e && find $CHPL_HOME/util/packaging/rpm/build -name '*.rpm'); do
     __test_package $rpm
   done
 }

--- a/util/packaging/common/test_package.py
+++ b/util/packaging/common/test_package.py
@@ -128,6 +128,7 @@ def docker_build_image(
         "docker",
         "buildx",
         "build",
+        "--load",
         "--platform",
         platform,
         "-t",


### PR DESCRIPTION
Forces the packaging builds to exit with an error if an error occurs in one of the invoked scripts.

This also adds a missing flag to the test package script.

[Reviewed by @tzinsky]