### PR TITLE
Add deprecation warning to `chpl_compare`

### DIFF
--- a/modules/packages/SortedMap.chpl
+++ b/modules/packages/SortedMap.chpl
@@ -32,6 +32,7 @@ module SortedMap {
   private use HaltWrappers;
   private use SortedSet;
   private use IO;
+  import Sort.{relativeComparator};
   public use Sort only DefaultComparator;
 
   // TODO: remove this module and its public use when the deprecations have been
@@ -133,7 +134,7 @@ module SortedMap {
     }
 
     @chpldoc.nodoc
-    record _keyComparator {
+    record _keyComparator: relativeComparator {
       var comparator: record;
       proc compare(a, b) {
         return comparator.compare(a[0], b[0]);

--- a/modules/standard/Sort.chpl
+++ b/modules/standard/Sort.chpl
@@ -331,8 +331,10 @@ proc compareByPart(a:?t, b:t, comparator:?rec) {
      a == b: returns 0
 */
 inline proc chpl_compare(a:?t, b:t, comparator:?rec) {
-  // TODO: this should also check interfaces for deprecation because it gets
-  // used in things like Search, Heap, treap, SortedSet, SortedMap, etc.
+  // this is an internal proc, but other stdlib consumers like Search may call it
+  // TODO: this can probably be removed when the logic here uses interfaces
+  //       instead of duck typing
+  chpl_check_comparator(comparator, t);
   // TODO -- In cases where values are larger than keys, it may be faster to
   //         key data once and sort the keyed data, mirroring swaps in data.
   // Compare results of comparator.key(a) if is defined by user
@@ -347,8 +349,11 @@ inline proc chpl_compare(a:?t, b:t, comparator:?rec) {
             canResolveMethod(comparator, "keyPart", a, 0) {
     return compareByPart(a, b, comparator);
   } else {
-    // TODO: this should talk about interfaces
-    compilerError("The comparator " + comparator.type:string + " requires a 'key(a)', 'compare(a, b)', or 'keyPart(a, i)' method");
+    // this case should not occur, since chpl_check_comparator should catch it
+    compilerError(
+      "The comparator ", comparator.type:string,
+      " must implement either 'keyComparator', 'keyPartComparator', or ",
+      "'relativeComparator' for ", t:string);
   }
 }
 

--- a/test/deprecated/Sort/internalCompare.chpl
+++ b/test/deprecated/Sort/internalCompare.chpl
@@ -2,10 +2,19 @@
 
 use Sort;
 
-record R {}
-proc R.key(x) do return x;
+record R1 {}
+proc R1.key(x) do return x;
+writeln(chpl_compare(1, 2, comparator=new R1()));
 
+record R2 {}
+proc R2.compare(x, y) do return if x < y then -1 else 1;
+writeln(chpl_compare(3, 4, comparator=new R2()));
 
-writeln(chpl_compare(1, 2, comparator=new R()));
+record R3 {}
+proc R3.compare(x, y) do return if x < y then -1 else 1;
+proc R3.keyPart(elt, i) do return (keyPartStatus.returned, elt);
+writeln(chpl_compare(5, 6, comparator=new R3()));
 
-
+record R4 {}
+proc R4.keyPart(elt, i) do return (keyPartStatus.returned, elt);
+writeln(chpl_compare(7, 8, comparator=new R4()));

--- a/test/deprecated/Sort/internalCompare.chpl
+++ b/test/deprecated/Sort/internalCompare.chpl
@@ -1,0 +1,11 @@
+// the internal chpl_compare function may have external users, so it gets a deprecation warning
+
+use Sort;
+
+record R {}
+proc R.key(x) do return x;
+
+
+writeln(chpl_compare(1, 2, comparator=new R()));
+
+

--- a/test/deprecated/Sort/internalCompare.chpl
+++ b/test/deprecated/Sort/internalCompare.chpl
@@ -16,5 +16,5 @@ proc R3.keyPart(elt, i) do return (keyPartStatus.returned, elt);
 writeln(chpl_compare(5, 6, comparator=new R3()));
 
 record R4 {}
-proc R4.keyPart(elt, i) do return (keyPartStatus.returned, elt);
+proc R4.keyPart(elt, i) do return (0, elt);
 writeln(chpl_compare(7, 8, comparator=new R4()));

--- a/test/deprecated/Sort/internalCompare.good
+++ b/test/deprecated/Sort/internalCompare.good
@@ -1,1 +1,2 @@
 internalCompare.chpl:9: warning: Defining a comparator with a 'key' method without implementing the keyComparator interface is deprecated. Please implement the keyComparator interface (i.e. 'record R: keyComparator').
+-1

--- a/test/deprecated/Sort/internalCompare.good
+++ b/test/deprecated/Sort/internalCompare.good
@@ -2,3 +2,7 @@ internalCompare.chpl:7: warning: Defining a comparator with a 'key' method witho
 internalCompare.chpl:11: warning: Defining a comparator with a 'compare' method without implementing the relativeComparator interface is deprecated. Please implement the relativeComparator interface (i.e. 'record R2: relativeComparator').
 internalCompare.chpl:16: warning: Defining a comparator with both a 'compare' method and a 'keyPart' without implementing the keyPartComparator interface is deprecated. Please implement the keyPartComparator interface (i.e. 'record R3: relativeComparator').
 internalCompare.chpl:20: warning: Defining a comparator with a 'keyPart' method without implementing the keyPartComparator interface is deprecated. Please implement the keyPartComparator interface (i.e. 'record R4: keyPartComparator').
+-1
+-1
+-1
+-1

--- a/test/deprecated/Sort/internalCompare.good
+++ b/test/deprecated/Sort/internalCompare.good
@@ -1,2 +1,4 @@
-internalCompare.chpl:9: warning: Defining a comparator with a 'key' method without implementing the keyComparator interface is deprecated. Please implement the keyComparator interface (i.e. 'record R: keyComparator').
--1
+internalCompare.chpl:7: warning: Defining a comparator with a 'key' method without implementing the keyComparator interface is deprecated. Please implement the keyComparator interface (i.e. 'record R1: keyComparator').
+internalCompare.chpl:11: warning: Defining a comparator with a 'compare' method without implementing the relativeComparator interface is deprecated. Please implement the relativeComparator interface (i.e. 'record R2: relativeComparator').
+internalCompare.chpl:16: warning: Defining a comparator with both a 'compare' method and a 'keyPart' without implementing the keyPartComparator interface is deprecated. Please implement the keyPartComparator interface (i.e. 'record R3: relativeComparator').
+internalCompare.chpl:20: warning: Defining a comparator with a 'keyPart' method without implementing the keyPartComparator interface is deprecated. Please implement the keyPartComparator interface (i.e. 'record R4: keyPartComparator').

--- a/test/deprecated/Sort/internalCompare.good
+++ b/test/deprecated/Sort/internalCompare.good
@@ -1,0 +1,1 @@
+internalCompare.chpl:9: warning: Defining a comparator with a 'key' method without implementing the keyComparator interface is deprecated. Please implement the keyComparator interface (i.e. 'record R: keyComparator').

--- a/test/library/packages/SortedSet/partialGenericFieldWorkaround.chpl
+++ b/test/library/packages/SortedSet/partialGenericFieldWorkaround.chpl
@@ -1,11 +1,11 @@
 // This is from issue https://github.com/chapel-lang/chapel/issues/18656
 
-use SortedSet;
+use SortedSet; use Sort;
 
 enum E { A = 0, B, C, D, };
 
-record R1 { proc key(a) do return  a:int; };
-record R2 { proc key(a) do return -a:int; };
+record R1: keyComparator { proc key(a) do return  a:int; };
+record R2: keyComparator { proc key(a) do return -a:int; };
 
 const comp1: R1, comp2: R2;
 


### PR DESCRIPTION
Adds a deprecation warning to `chpl_compare` for deprecated usages of comparators. While this is technically an internal function and as such shouldn't need deprecations, it is used by other Chapel standard modules and by some users, so this PR gives a warning instead of code potentially breaking down the road.

- [x] tested with a full paratest with/without comm

[Reviewed by @lydia-duncan]