### PR TITLE
Fix printchplenv and printchplbuilds when installed with a prefix

### DIFF
--- a/util/chplenv/chpl_home_utils.py
+++ b/util/chplenv/chpl_home_utils.py
@@ -15,7 +15,7 @@ def get_chpl_home():
 
 @memoize
 def get_chpl_runtime_incl():
-    prefix = get_install_prefix()
+    prefix = get_prefix_install_prefix()
     if prefix is None:
         default = os.path.join(get_chpl_home(), 'runtime', 'include')
     else:
@@ -27,7 +27,7 @@ def get_chpl_runtime_incl():
 
 @memoize
 def get_chpl_runtime_lib():
-    prefix = get_install_prefix()
+    prefix = get_prefix_install_prefix()
     if prefix is None:
         default = os.path.join(get_chpl_home(), 'lib')
     else:
@@ -39,7 +39,7 @@ def get_chpl_runtime_lib():
 
 @memoize
 def get_chpl_third_party():
-    prefix = get_install_prefix()
+    prefix = get_prefix_install_prefix()
     if prefix is None:
         default = os.path.join(get_chpl_home(), 'third-party')
     else:
@@ -56,7 +56,7 @@ install_path_regex = re.compile(
 
 @memoize
 def get_chpl_version_from_install():
-    if get_install_prefix():
+    if get_prefix_install_prefix():
         chpl_home = get_chpl_home()
         m = install_path_regex.match(chpl_home)
         # if we are in an installed directory, this should always match
@@ -66,9 +66,11 @@ def get_chpl_version_from_install():
 
 
 @memoize
-def get_install_prefix():
+def get_prefix_install_prefix():
     """
-    gets the prefix where Chapel is installed, if not installed returns None
+    If Chapel is installed as a prefix install (with `./configure --prefix` etc)
+    then this function returns the prefix where it is installed.
+    If it's not installed or installed as a `--chpl-home` install, it returns `None`
     """
     chpl_home = get_chpl_home()
 

--- a/util/chplenv/chpl_home_utils.py
+++ b/util/chplenv/chpl_home_utils.py
@@ -71,13 +71,29 @@ def get_install_prefix():
     gets the prefix where Chapel is installed, if not installed returns None
     """
     chpl_home = get_chpl_home()
-    # if the last three parts of chpl_home are "share", "chapel", and a version number
-    # and there are no makefiles in the chpl_home directory,
-    # then we are in an installed directory
 
-    m = install_path_regex.match(chpl_home)
-    if m is None or os.path.exists(os.path.join(chpl_home, 'Makefile')):
+    frontend_path = os.path.join(chpl_home, 'frontend')
+    doc_path = os.path.join(chpl_home, 'doc')
+    has_frontend = os.path.exists(frontend_path) and os.path.isdir(frontend_path)
+    has_doc = os.path.exists(doc_path) and os.path.isdir(doc_path)
+    is_installed = has_frontend and has_doc
+    if not is_installed:
         return None
+
+    bin_path = os.path.join(chpl_home, 'bin')
+    lib_path = os.path.join(chpl_home, 'lib')
+    has_bin = os.path.exists(bin_path) and os.path.isdir(bin_path)
+    has_lib = os.path.exists(lib_path) and os.path.isdir(lib_path)
+    is_chpl_home_install = has_bin and has_lib
+    if is_chpl_home_install:
+        return None
+
+    # if we reach this point, we can be fairly confident that this is a prefix-install
+    # the regex should always match in this case
+    m = install_path_regex.match(chpl_home)
+    if m is None:
+        return None
+
     prefix = m.group(1)
     if prefix == "":
         prefix = os.path.sep

--- a/util/chplenv/chpl_home_utils.py
+++ b/util/chplenv/chpl_home_utils.py
@@ -76,8 +76,8 @@ def get_install_prefix():
     doc_path = os.path.join(chpl_home, 'doc')
     has_frontend = os.path.exists(frontend_path) and os.path.isdir(frontend_path)
     has_doc = os.path.exists(doc_path) and os.path.isdir(doc_path)
-    is_installed = has_frontend and has_doc
-    if not is_installed:
+    is_source_dir = has_frontend and has_doc
+    if is_source_dir:
         return None
 
     bin_path = os.path.join(chpl_home, 'bin')

--- a/util/chplenv/printchplbuilds.py
+++ b/util/chplenv/printchplbuilds.py
@@ -14,6 +14,7 @@ from pprint import pprint
 import datetime
 from enum import Enum, unique
 from collections import defaultdict
+import chpl_home_utils
 
 # Parsing the build directory path is implemented as a state machine. Some
 # of the components start with a prefix, some do not. The state machine
@@ -346,12 +347,8 @@ def main(argv):
         builds = [Parse(args.path.split(os.sep))]
     else:
         # gather the paths for all builds
-        home = os.getenv('CHPL_HOME')
-        if home is None:
-            print("Error: CHPL_HOME is not set", file=sys.stderr)
-            sys.exit(1)
+        base = chpl_home_utils.get_chpl_runtime_lib()
 
-        base = os.path.join(home, "lib")
         # "targets" is a list of all paths that contain a "libchpl.a" file
         targets = []
         for root, dirs, files in os.walk(base):


### PR DESCRIPTION
Fixes an issue where `chpl --print-chpl-settings` and `printchplenv` would give very different output in a prefix-based install.

This PR uses a heuristic to determine if Chapel is in a prefix-based install.
- if CHPL_HOME has a `frontend` and `doc` directory, its a from-source build
- if its not a from source build and CHPL_HOME has a `bin` and `lib` directory, its a CHPL_HOME install
- otherwise, its a prefix install. The actual path is also sanity checked that it ends with`share/chapel/VERMAJOR.VERMINOR`

Resolves https://github.com/chapel-lang/chapel/issues/25874

Tested by confirming that everything still works as expected in a from-source/CHPL_HOME-based build and that a prefix install is now correct.

[Reviewed by @mppf]