### PR TITLE
Workaround asan bug with generic type names

### DIFF
--- a/test/unstable/sortModule.chpl
+++ b/test/unstable/sortModule.chpl
@@ -1,3 +1,3 @@
 use Sort;
-Sort.DefaultComparator;
-Sort.ReverseComparator;
+new Sort.DefaultComparator();
+new Sort.ReverseComparator();


### PR DESCRIPTION
Changes a test for unstable warnings to avoid https://github.com/chapel-lang/chapel/issues/25885

[Not reviewed - trivial]