### PR TITLE
Fix error with certain `include module` patterns

### DIFF
--- a/frontend/include/chpl/parsing/parsing-queries.h
+++ b/frontend/include/chpl/parsing/parsing-queries.h
@@ -107,9 +107,13 @@ introspectParsedFiles(Context* context);
 /**
   Like parseFileToBuilderResult but parses whatever file contained 'id'.
   Useful for projection queries.
+
+  If setParentSymbolPath is not nullptr, sets it to the parentSymbolPath used
+  when creating the BuilderResult.
  */
 const uast::BuilderResult*
-parseFileContainingIdToBuilderResult(Context* context, ID id);
+parseFileContainingIdToBuilderResult(Context* context, ID id,
+                                     UniqueString* setParentSymbolPath=nullptr);
 
 /**
   Fetch the BuilderResult storing compiler-generated uAST based on the given

--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -1444,10 +1444,9 @@ const ID& idToParentId(Context* context, ID id) {
     // Detect that and return the parent module in that case.
     if (result.isEmpty() && !parentSymbolPath.isEmpty()) {
       ID parentSymbolId = id.parentSymbolId(context);
-      if (!parentSymbolId.isEmpty()) {
-        CHPL_ASSERT(parentSymbolId.symbolPath() == parentSymbolPath);
-        result = parentSymbolId;
-      }
+      CHPL_ASSERT(!parentSymbolId.isEmpty());
+      CHPL_ASSERT(parentSymbolId.symbolPath() == parentSymbolPath);
+      result = parentSymbolId;
     }
   }
 

--- a/test/visibility/submodule-in-file/Recursive.chpl
+++ b/test/visibility/submodule-in-file/Recursive.chpl
@@ -1,0 +1,13 @@
+// This (and SubModule) were created as a reproducer for issue #25569
+
+module Recursive {
+  config param EXTRA_CHECKS = 42;
+
+  include public module SubModule;
+
+  use this.SubModule;
+
+  writeln("in Recursive, EXTRA_CHECKS=", EXTRA_CHECKS);
+
+  foo();
+}

--- a/test/visibility/submodule-in-file/Recursive/SubModule.chpl
+++ b/test/visibility/submodule-in-file/Recursive/SubModule.chpl
@@ -1,0 +1,5 @@
+module SubModule {
+  import super.EXTRA_CHECKS;
+
+  proc foo() { writeln("in SubModule.foo, EXTRA_CHECKS=", EXTRA_CHECKS); }
+}

--- a/test/visibility/submodule-in-file/test-Recursive.chpl
+++ b/test/visibility/submodule-in-file/test-Recursive.chpl
@@ -1,0 +1,3 @@
+use Recursive;
+
+proc main() { }

--- a/test/visibility/submodule-in-file/test-Recursive.good
+++ b/test/visibility/submodule-in-file/test-Recursive.good
@@ -1,0 +1,2 @@
+in Recursive, EXTRA_CHECKS=42
+in SubModule.foo, EXTRA_CHECKS=42


### PR DESCRIPTION
Resolves #25569

This PR fixes a problem with using `import super.something` from within a submodule that was stored in a different file using `include module`.

Reviewed by @DanilaFe - thanks!

- [x] full comm=none testing