### PR TITLE
Work around a GCC 13 error

### DIFF
--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -3664,13 +3664,14 @@ emitMultipleDefinedSymbolErrorsQuery(Context* context, const Scope* scope) {
     if (error) {
       // emit a multiply-defined symbol error
       std::vector<ResultVisibilityTrace> traceResult;
-      v = lookupNameInScopeTracing(context, scope,
-                                   /* methodLookupHelper */ nullptr,
-                                   /* receiverScopeHelper */ nullptr,
-                                   name, config,
-                                   traceResult);
+      MatchingIdsWithName v2 =
+        lookupNameInScopeTracing(context, scope,
+                                 /* methodLookupHelper */ nullptr,
+                                 /* receiverScopeHelper */ nullptr,
+                                 name, config,
+                                 traceResult);
 
-      CHPL_REPORT(context, Redefinition, scope->id(), name, v, traceResult);
+      CHPL_REPORT(context, Redefinition, scope->id(), name, v2, traceResult);
 
       result = true;
     }


### PR DESCRIPTION
Follow-up to #25853. This PR avoids errors from GCC 13 when building with `make DEBUG=0 WARNINGS=1 ASSERTS=0 OPTIMIZE=1 compiler`. The warnings look like this:

```
/usr/include/c++/13/bits/stl_algobase.h:437:30: error: ‘void* __builtin_memmove(void*, const void*, long unsigned int)’ forming offset 40 is out of the bounds [0, 40] of object ‘<anonymous>’ with type ‘chpl::resolution::MatchingIdsWithName’ [-Werror=array-bounds=]
  437 |             __builtin_memmove(__result, __first, sizeof(_Tp) * _Num);
      |             ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/mppf/w/main/frontend/lib/resolution/scope-queries.cpp: In function ‘const bool& chpl::resolution::emitMultipleDefinedSymbolErrorsQuery(chpl::Context*, const Scope*)’:
/home/mppf/w/main/frontend/lib/resolution/scope-queries.cpp:3585:35: note: ‘<anonymous>’ declared here
 3585 |       v = lookupNameInScopeTracing(context, scope, { }, name, config,
      |           ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 3586 |                                    traceResult);
      |                                    ~~~~~~~~~~~~
```

It is currently unclear to me if the error is a false positive. However, I figured out a workaround by introducing a new variable to store the result of `lookupNameInScopeTracing` here.

Trivial and not reviewed.

- [x] full comm=none testing