### PR TITLE
Unstable anon script for 2.2: special case & <command line>

### DIFF
--- a/test/unstableAnonScript/specialCases/search1.notest
+++ b/test/unstableAnonScript/specialCases/search1.notest
@@ -1,0 +1,1 @@
+// Copied from test/unstable/unstable-module-ambiguity/search1.notest

--- a/test/unstableAnonScript/specialCases/search1/MyModule.chpl
+++ b/test/unstableAnonScript/specialCases/search1/MyModule.chpl
@@ -1,0 +1,4 @@
+// Copied from test/unstable/unstable-module-ambiguity/search1/MyModule.chpl
+module MyModule {
+  writeln("In search1/MyModule.chpl");
+}

--- a/test/unstableAnonScript/specialCases/search2.notest
+++ b/test/unstableAnonScript/specialCases/search2.notest
@@ -1,0 +1,1 @@
+// Copied from test/unstable/unstable-module-ambiguity/search2.notest

--- a/test/unstableAnonScript/specialCases/search2/MyModule.chpl
+++ b/test/unstableAnonScript/specialCases/search2/MyModule.chpl
@@ -1,0 +1,4 @@
+// Copied from test/unstable/unstable-module-ambiguity/search2/MyModule.chpl
+module MyModule {
+  writeln("In search2/MyModule.chpl");
+}

--- a/test/unstableAnonScript/specialCases/unstable-module-ambiguity.chpl
+++ b/test/unstableAnonScript/specialCases/unstable-module-ambiguity.chpl
@@ -1,0 +1,2 @@
+// Copied from test/unstable/unstable-module-ambiguity/unstable-module-ambiguity.chpl
+use MyModule;

--- a/test/unstableAnonScript/specialCases/unstable-module-ambiguity.compopts
+++ b/test/unstableAnonScript/specialCases/unstable-module-ambiguity.compopts
@@ -1,0 +1,1 @@
+-M search1 -M search2

--- a/test/unstableAnonScript/specialCases/unstable-module-ambiguity.good
+++ b/test/unstableAnonScript/specialCases/unstable-module-ambiguity.good
@@ -1,0 +1,2 @@
+Hey, if you're modifying the output of this test, maybe it's time to remove this special case from the script?
+1 instance of "warning: ambiguous module source file; which module is chosen in this case is unstable"


### PR DESCRIPTION
This adds a few things to the unstable warning anonymizer script in order to update it for the 2.2 release.

- Add handling for a warning starting with the word `<command line>`: previously, we were assuming that a warning either starts with a Chapel file name (like `foo.chpl`) or with `<command-line arg>` but a new unstable warning was added this release which starts with `<command line>` and it also doesn't have a number following it (the other two have numbers following them which indicate a line number of argument number)
- Add special case handling for the ambiguous modules warning (which is what also required the change from the 1st bullet) since it exposes implementation details (module names), we scrub these names now.
- Add testing for the special case