### PR TITLE
Use the correct environment to detect the backend in CHAMPS testing

### DIFF
--- a/test/studies/champs/sub_test
+++ b/test/studies/champs/sub_test
@@ -97,7 +97,7 @@ if [ -z "$CHAMPS_QUICKSTART" ] || [ ! -z "$CHAMPS_COMPILE_ALL_EXECS" ] ; then
   # we are seeing OOM issues with the C backend that we attribute to a
   # system/backend issue. Until we figure out what's going wrong, stop testing
   # this executable with the C backend
-  if [ "${CHPL_LLVM}" != "none" ] ; then
+  if [ "${CHPL_TARGET_COMPILER}" != "gnu" ] ; then
     test_compile post
   fi
 


### PR DESCRIPTION
CHAMPS uses `CHPL_TARGET_COMPILER` to set the actual backend. To my surprise, it runs with `CHPL_LLVM=system` even with the C backend. I am not sure if it has any implications. In any case, this PR adjusts the recent fix to skip a problematic example to use the correct environment variable.