### PR TITLE
Add tests of default intent varargs and the types whose default intent is ref

### DIFF
--- a/test/functions/varargs/varargsModArray.bad
+++ b/test/functions/varargs/varargsModArray.bad
@@ -1,0 +1,4 @@
+varargsModArray.chpl:2: In function 'myPrintln':
+varargsModArray.chpl:7: error: cannot assign to const variable
+  varargsModArray.chpl:13: called as myPrintln(args(0): [domain(1,int(64),one)] int(64), args(1): real(64), args(2): string)
+note: generic instantiations are underlined in the above callstack

--- a/test/functions/varargs/varargsModArray.chpl
+++ b/test/functions/varargs/varargsModArray.chpl
@@ -1,0 +1,13 @@
+// Taken from https://github.com/chapel-lang/chapel/issues/25858
+proc myPrintln(args...)
+{
+  writeln("args.type     = ", args.type:string);
+  writeln("args (before) = ", args);
+
+  args[0][0] *= 10;  // modify tuple (just for test)
+
+  writeln("args (after) = ", args);
+}
+
+var arr: [0..2] int = [1, 2, 3];
+myPrintln(arr, 2.3, "four");

--- a/test/functions/varargs/varargsModArray.future
+++ b/test/functions/varargs/varargsModArray.future
@@ -1,0 +1,2 @@
+bug: can't modify array passed as part of vararg with default intent
+#25903

--- a/test/functions/varargs/varargsModArray.good
+++ b/test/functions/varargs/varargsModArray.good
@@ -1,0 +1,4 @@
+varargsModArray.chpl:2: warning: inferring a default intent to be 'ref' is deprecated - please use an explicit 'ref' intent for the argument 'args'
+args.type     = ([domain(1,int(64),one)] int(64),real(64),string)
+args (before) = (1 2 3, 2.3, four)
+args (after) = (10 2 3, 2.3, four)

--- a/test/functions/varargs/varargsModAtomic.chpl
+++ b/test/functions/varargs/varargsModAtomic.chpl
@@ -1,0 +1,13 @@
+// Taken from https://github.com/chapel-lang/chapel/issues/25858
+proc myPrintln(args...)
+{
+  writeln("args.type     = ", args.type:string);
+  writeln("args (before) = ", args);
+
+  args[0].fetchAdd(10);  // modify tuple (just for test)
+
+  writeln("args (after) = ", args);
+}
+
+var atomInt: atomic int = 1;
+myPrintln(atomInt, 2.3, "four");

--- a/test/functions/varargs/varargsModAtomic.good
+++ b/test/functions/varargs/varargsModAtomic.good
@@ -1,0 +1,3 @@
+args.type     = (atomic int(64),real(64),string)
+args (before) = (1, 2.3, four)
+args (after) = (11, 2.3, four)

--- a/test/functions/varargs/varargsModSync.chpl
+++ b/test/functions/varargs/varargsModSync.chpl
@@ -1,0 +1,15 @@
+// Taken from https://github.com/chapel-lang/chapel/issues/25858
+proc myPrintln(args...)
+{
+  writeln("args.type     = ", args.type:string);
+  writeln("args (before) = (", args[0].readFF(), ", ", args[1], ", ", args[2],
+          ")");
+
+  args[0].writeFF(10);  // modify tuple (just for test)
+
+  writeln("args (after) = (", args[0].readFF(), ", ", args[1], ", ", args[2],
+          ")");
+}
+
+var syncInt: sync int = 1;
+myPrintln(syncInt, 2.3, "four");

--- a/test/functions/varargs/varargsModSync.good
+++ b/test/functions/varargs/varargsModSync.good
@@ -1,0 +1,3 @@
+args.type     = (sync int(64),real(64),string)
+args (before) = (1, 2.3, four)
+args (after) = (10, 2.3, four)


### PR DESCRIPTION
Atomics and syncs are modifiable even after #25887.  However, the change there does mean that arrays are not modifiable (though the deprecation message indicates that maybe that's going to stop being the case soon, too?)

Anyways, add tests locking in that behavior today, since I've written them.  I made the arrays case a future, but if the deprecation message means it's changing then maybe all of them actually pass.

Running a fresh checkout of the tests now