### PR TITLE
Two tiny cleanups to convert-uast

### DIFF
--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -403,8 +403,7 @@ struct Converter {
 
   bool shouldScopeResolve(ID symbolId) {
     if (canScopeResolve) {
-      return fDynoScopeBundled ||
-             !chpl::parsing::idIsInBundledModule(context, symbolId);
+      return fDynoScopeBundled || topLevelModTag == MOD_USER;
     }
 
     return false;
@@ -418,7 +417,7 @@ struct Converter {
   }
   bool shouldResolve(ID symbolId) {
     if (fDynoCompilerLibrary) {
-      return !chpl::parsing::idIsInBundledModule(context, symbolId);
+      return topLevelModTag == MOD_USER;
     } else {
       return shouldResolve(symbolId.symbolPath());
     }

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -458,15 +458,6 @@ struct Converter {
     return FLAG_UNKNOWN;
   }
 
-  static bool isBlockComment(const uast::Comment* node) {
-    const auto& str = node->str();
-    if (str.size() < 4) return false;
-    if (str[0] != '/' || str[1] != '*') return false;
-    INT_ASSERT(str[str.size()-1] == '/');
-    INT_ASSERT(str[str.size()-2] == '*');
-    return true;
-  }
-
   Expr* visit(const uast::Comment* node) {
     return nullptr;
   }


### PR DESCRIPTION
This PR makes two tiny changes to convert-uast.cpp:
 1. It removes an unused function that is local to this file.
 2. It switches from using a query to decide if scope resolution should be attempted to checking the current `modTag`. (Note: we are currently using `MOD_STANDARD` for package modules, and as a result, only `MOD_USER` code is not in a bundled module. See also this code that sets `modTag` https://github.com/chapel-lang/chapel/blob/08f4df28ccbc1428b35d1b96b3cbe79fb997947e/compiler/passes/parseAndConvert.cpp#L299-L309

No behavior changes in this PR.

Reviewed by @arezaii - thanks!

- [x] full comm=none testing