### PR TITLE
separate 1-node and 16-node ex perf jobs

### DIFF
--- a/util/cron/test-perf.hpe-cray-ex-ofi.1node.bash
+++ b/util/cron/test-perf.hpe-cray-ex-ofi.1node.bash
@@ -9,7 +9,7 @@ export CHPL_TEST_PERF_CONFIG_NAME='1-node-hpe-cray-ex'
 
 source $CWD/common-perf.bash
 
-export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.hpe-cray-ex.ofi.1node"
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.hpe-cray-ex-ofi.1node"
 
 source $CWD/common-ofi.bash || \
   ( echo "Could not set up comm=ofi testing." && exit 1 )
@@ -20,6 +20,6 @@ export CHPL_RT_MAX_HEAP_SIZE=16g
 
 nightly_args="${nightly_args} -no-buildcheck"
 perf_args="-performance -perflabel perf -numtrials 1"
-perf_hpe_cray_ex_args="-startdate 09/10/24"
+perf_hpe_cray_ex_args="-startdate 06/25/24"
 
 $CWD/nightly -cron ${perf_args} ${perf_hpe_cray_ex_args} ${nightly_args}

--- a/util/cron/test-perf.hpe-cray-ex-ofi.1node.bash
+++ b/util/cron/test-perf.hpe-cray-ex-ofi.1node.bash
@@ -9,7 +9,7 @@ export CHPL_TEST_PERF_CONFIG_NAME='1-node-hpe-cray-ex'
 
 source $CWD/common-perf.bash
 
-export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.hpe-cray-ex.ofi"
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.hpe-cray-ex.ofi.1node"
 
 source $CWD/common-ofi.bash || \
   ( echo "Could not set up comm=ofi testing." && exit 1 )

--- a/util/cron/test-perf.hpe-cray-ex-ofi.1node.bash
+++ b/util/cron/test-perf.hpe-cray-ex-ofi.1node.bash
@@ -5,7 +5,7 @@
 CWD=$(cd $(dirname $0) ; pwd)
 
 export CHPL_TEST_PERF_SUBDIR="hpe-cray-ex"
-export CHPL_TEST_PERF_CONFIG_NAME='16-node-hpe-cray-ex'
+export CHPL_TEST_PERF_CONFIG_NAME='1-node-hpe-cray-ex'
 
 source $CWD/common-perf.bash
 
@@ -19,7 +19,7 @@ export CHPL_RT_COMM_OFI_EXPECTED_PROVIDER="cxi"
 export CHPL_RT_MAX_HEAP_SIZE=16g
 
 nightly_args="${nightly_args} -no-buildcheck"
-perf_args="-performance -perflabel ml- -numtrials 1"
-perf_hpe_cray_ex_args="-startdate 06/25/24"
+perf_args="-performance -perflabel perf -numtrials 1"
+perf_hpe_cray_ex_args="-startdate 09/10/24"
 
 $CWD/nightly -cron ${perf_args} ${perf_hpe_cray_ex_args} ${nightly_args}

--- a/util/cron/test-perf.hpe-cray-ex.ofi.1node.bash
+++ b/util/cron/test-perf.hpe-cray-ex.ofi.1node.bash
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
-# Run performance tests on an HPE Cray EX
+# Run performance tests on an HPE Cray EX (build for multilocale runs, but only
+# run single locale perf tests).
 
 CWD=$(cd $(dirname $0) ; pwd)
 

--- a/util/cron/test-perf.hpe-cray-ex.ofi.1node.bash
+++ b/util/cron/test-perf.hpe-cray-ex.ofi.1node.bash
@@ -9,7 +9,7 @@ export CHPL_TEST_PERF_CONFIG_NAME='1-node-hpe-cray-ex'
 
 source $CWD/common-perf.bash
 
-export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.hpe-cray-ex-ofi.1node"
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.hpe-cray-ex.ofi.1node"
 
 source $CWD/common-ofi.bash || \
   ( echo "Could not set up comm=ofi testing." && exit 1 )

--- a/util/cron/test-perf.hpe-cray-ex.ofi.bash
+++ b/util/cron/test-perf.hpe-cray-ex.ofi.bash
@@ -20,6 +20,6 @@ export CHPL_RT_MAX_HEAP_SIZE=16g
 
 nightly_args="${nightly_args} -no-buildcheck"
 perf_args="-performance -perflabel ml- -numtrials 1"
-perf_hpe_cray_ex_args="-startdate 06/25/24"
+perf_hpe_cray_ex_args="-startdate 09/10/24"
 
 $CWD/nightly -cron ${perf_args} ${perf_hpe_cray_ex_args} ${nightly_args}


### PR DESCRIPTION
Our currently nightly EX perf testing isn't passing -perflabel ml so even though we call it a "16 node" job, in actuality it's only running our single locale tests.

This PR fixes this so the job passes the perf label and we have another 1-node ex perf test.