### PR TITLE
Improve "Can't find nvidia/amd toolkit" error

### DIFF
--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -218,10 +218,10 @@ def get_sdk_path(for_gpu, sdk_type='bitcode'):
 
         return chpl_sdk_path
     elif gpu_type == for_gpu:
-        _reportMissingGpuReq("Can't find {} toolkit. Try setting {} to the " +
-                             "{} installation path.".format(get(),
-                                                            gpu.sdk_path_env,
-                                                            gpu.runtime_impl))
+        _reportMissingGpuReq(("Can't find {} toolkit. Try setting {} to the " +
+                              "{} installation path.").format(get(),
+                                                              gpu.sdk_path_env,
+                                                              gpu.runtime_impl))
         return 'error'
     else:
         return ''

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -218,7 +218,10 @@ def get_sdk_path(for_gpu, sdk_type='bitcode'):
 
         return chpl_sdk_path
     elif gpu_type == for_gpu:
-        _reportMissingGpuReq("Can't find {} toolkit.".format(get()))
+        _reportMissingGpuReq("Can't find {} toolkit. Try setting {} to the " +
+                             "{} installation path.".format(get(),
+                                                            gpu.sdk_path_env,
+                                                            gpu.runtime_impl))
         return 'error'
     else:
         return ''

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -219,7 +219,7 @@ def get_sdk_path(for_gpu, sdk_type='bitcode'):
         return chpl_sdk_path
     elif gpu_type == for_gpu:
         _reportMissingGpuReq(("Can't find {} toolkit. Try setting {} to the " +
-                              "{} installation path.").format(get(),
+                              "{} installation path.").format(gpu.runtime_impl,
                                                               gpu.sdk_path_env,
                                                               gpu.runtime_impl))
         return 'error'


### PR DESCRIPTION
1. Suggested by @mppf, this PR adds `Try setting CHPL_CUDA_PATH to the cuda installation path` to the error message. Before, `CHPL_CUDA_PATH` was not mentioned in the error message.
2. The error says "nvidia toolkit" or "amd toolkit". Those are not real things. We need "cuda toolkit" or "rocm toolkit". This PR adjusts for that. Capitalizations are still not perfect, but I don't want to wire a new variable in on these scripts at this point.


Tested on a system with no GPUs that:

```
> export CHPL_GPU=nvidia
> printchplenv

Error: Can't find cuda toolkit. Try setting CHPL_CUDA_PATH to the cuda installation path. To avoid this issue, you can have GPU code run on the CPU by setting 'CHPL_GPU=cpu'. To turn this error into a warning set CHPLENV_GPU_REQ_ERRS_AS_WARNINGS.

> export CHPL_GPU=amd
> printchplenv

Error: Can't find rocm toolkit. Try setting CHPL_ROCM_PATH to the rocm installation path. To avoid this issue, you can have GPU code run on the CPU by setting 'CHPL_GPU=cpu'. To turn this error into a warning set CHPLENV_GPU_REQ_ERRS_AS_WARNINGS.
```

Scripts continue to function normally on a system with a GPU.
