### PR TITLE
Remove outdated `chpl_defaultDistInitPrivate` workaround

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -143,15 +143,7 @@ module DefaultRectangular {
 
   proc chpl_defaultDistInitPrivate() {
     if defaultDist._value==nil {
-      // FIXME benharsh: Here's what we want to do:
-      //   defaultDist = new dmap(new DefaultDist());
-      // The problem is that the LHS of the "proc =" for _distributions
-      // loses its ref intent in the removeWrapRecords pass.
-      //
-      // The code below is copied from the contents of the "proc =".
-      const nd = new dmap(new unmanaged DefaultDist());
-      __primitive("move", defaultDist, chpl__autoCopy(nd.clone(),
-                                                      definedConst=false));
+      defaultDist = new dmap(new DefaultDist());
     }
   }
 


### PR DESCRIPTION
Remove a workaround for `ref`-intent issue with `_distribution`s that does not appear to exist anymore.

This workaround was implemented 9 years ago in https://github.com/chapel-lang/chapel/commit/3e1a5a339981ce803eedb622e0a76563366a889c (part of https://github.com/chapel-lang/chapel/pull/2178).

[reviewer info placeholder]

Testing:
- [x] paratest
- [x] gasnet paratest
- [x] C backend paratest
- [x] GPU tests