### PR TITLE
Fix index variable leak when forall body is empty

### DIFF
--- a/compiler/resolution/AutoDestroyScope.cpp
+++ b/compiler/resolution/AutoDestroyScope.cpp
@@ -167,6 +167,11 @@ void AutoDestroyScope::addEarlyDeinit(VarSymbol* var) {
   INT_FATAL("could not find scope declaring var");
 }
 
+
+size_t AutoDestroyScope::numLocalsAndDefers() const {
+  return mLocalsAndDefers.size();
+}
+
 VarSymbol* AutoDestroyScope::findVariableUsedBeforeInitialized(Expr* stmt) {
 
   if (CallExpr* call = toCallExpr(stmt)) {

--- a/compiler/resolution/AutoDestroyScope.h
+++ b/compiler/resolution/AutoDestroyScope.h
@@ -44,6 +44,9 @@ public:
 
   void                     addEarlyDeinit(VarSymbol* var);
 
+  // Counts how many declarations exists
+  size_t                   numLocalsAndDefers() const;
+
   VarSymbol*               findVariableUsedBeforeInitialized(Expr* stmt);
 
   // Forget about initializations for outer variables initialized

--- a/test/functions/iterators/bugs/stmt-iter-memory-leak.chpl
+++ b/test/functions/iterators/bugs/stmt-iter-memory-leak.chpl
@@ -1,0 +1,24 @@
+class C {
+  proc deinit() {
+    writeln("deinit C");
+  }
+}
+
+record R {
+  proc deinit() {
+    writeln("deinit R");
+  }
+}
+
+iter foo() {
+  yield new C();
+  yield new C();
+}
+
+iter bar() {
+  yield new R();
+  yield new R();
+}
+
+foo();
+bar();

--- a/test/functions/iterators/bugs/stmt-iter-memory-leak.good
+++ b/test/functions/iterators/bugs/stmt-iter-memory-leak.good
@@ -1,0 +1,4 @@
+deinit C
+deinit C
+deinit R
+deinit R

--- a/test/library/standard/Sort/errors/sortDomainArray.assoc7.good
+++ b/test/library/standard/Sort/errors/sortDomainArray.assoc7.good
@@ -1,1 +1,4 @@
 sortDomainArray.chpl:55: warning: It is recommended to use 'Sort.sorted' instead of this method. Compile with '-snoSortedWarnings' to suppress this warning.
+sortDomainArray.chpl:55: warning: It is recommended to use 'Sort.sorted' instead of this method. Compile with '-snoSortedWarnings' to suppress this warning.
+Note: This source location is a guess.
+sortDomainArray.chpl:55: warning: It is recommended to use 'Sort.sorted' instead of this method. Compile with '-snoSortedWarnings' to suppress this warning.

--- a/test/library/standard/Sort/errors/sortDomainArray.chpl
+++ b/test/library/standard/Sort/errors/sortDomainArray.chpl
@@ -32,11 +32,11 @@ var SpsA: [SpsD] real;
 
 if sparse1 then sort(SpsD); // should be an error
 if sparse2 then isSorted(SpsD); // should be an error
-if sparse3 then var x = sorted(SpsD); // should be an error
+if sparse3 then sorted(SpsD); // should be an error
 if sparse4 then sort(SpsA); // should be an error
 if sparse5 then isSorted(SpsA); // should be an error
-if sparse6 then var x = sorted(SpsA); // should be an error
-if sparse7 then var x = SpsD.sorted(); // should be an error
+if sparse6 then sorted(SpsA); // should be an error
+if sparse7 then SpsD.sorted(); // should be an error
 
 
 //
@@ -48,11 +48,11 @@ var AssocA = [1 => "one", 10 => "ten", 3 => "three", 16 => "sixteen"];
 
 if assoc1 then sort(AssocD); // should be an error
 if assoc2 then isSorted(AssocD); // should be an error
-if assoc3 then var x = sorted(AssocD);
+if assoc3 then sorted(AssocD);
 if assoc4 then sort(AssocA); // should be an error
 if assoc5 then isSorted(AssocA); // should be an error
-if assoc6 then var x = sorted(AssocA);
-if assoc7 then var x = AssocD.sorted(); // not an error, but warns
+if assoc6 then sorted(AssocA);
+if assoc7 then AssocD.sorted(); // not an error, but warns
 
 
 //
@@ -64,8 +64,8 @@ var RectA: [RectD] real;
 
 if rect1 then sort(RectD); // should be an error
 if rect2 then isSorted(RectD); // should be an error
-if rect3 then var x = sorted(RectD); // should be an error
+if rect3 then sorted(RectD); // should be an error
 if rect4 then sort(RectA);
 if rect5 then isSorted(RectA);
-if rect6 then var x = sorted(RectA);
-if rect7 then var x = RectD.sorted(); // should be an error
+if rect6 then sorted(RectA);
+if rect7 then RectD.sorted(); // should be an error


### PR DESCRIPTION
Closes https://github.com/chapel-lang/chapel/issues/25893, reverts https://github.com/chapel-lang/chapel/pull/25894.

I was happy to find logic that notes down loop index variables as something that needs to be auto-destroyed in a scope. However, while stepping through in the debugger, I noticed that the cleanup only happens "per statement", which means that loops with empty bodies over iterators do not have their bounds cleaned up:

```Chapel
[var in myiter()] ;; // does not clean up var
```

One of the reasons was that an "anchor statement" was needed to know where to put all the auto-destroys. This PR fixes the problem by detecting the situation (empty block statement but need to clean up variables), inserting a dummy `noop`, and using that as anchor.

## Testing
- [x] paratest