### PR TITLE
Adjust flags to suppress/disable warnings from CUB 11 with newer Clangs

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2895,12 +2895,11 @@ static void helpComputeClangArgs(std::string& clangCC,
     clangCCArgs.push_back(clangRequiredWarningFlags[i]);
   }
 
-  if (usingGpuLocaleModel()) {
-    if (getGpuCodegenType() == GpuCodegenType::GPU_CG_NVIDIA_CUDA) {
-      // this is necessary for CUB 11. Once we drop CUDA 11 support, we can
-      // probably remove this
-      clangCCArgs.push_back("-Wno-deprecated-builtins");
-    }
+  if (usingGpuLocaleModel() &&
+      getGpuCodegenType() == GpuCodegenType::GPU_CG_NVIDIA_CUDA) {
+    // this is necessary for CUB 11. Once we drop CUDA 11 support, we can
+    // probably remove this
+    clangCCArgs.push_back("-Wno-deprecated-builtins");
   }
 
   // Add debug flags

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2895,6 +2895,14 @@ static void helpComputeClangArgs(std::string& clangCC,
     clangCCArgs.push_back(clangRequiredWarningFlags[i]);
   }
 
+  if (usingGpuLocaleModel()) {
+    if (getGpuCodegenType() == GpuCodegenType::GPU_CG_NVIDIA_CUDA) {
+      // this is necessary for CUB 11. Once we drop CUDA 11 support, we can
+      // probably remove this
+      clangCCArgs.push_back("-Wno-deprecated-builtins");
+    }
+  }
+
   // Add debug flags
   if (debugCCode) {
     clangCCArgs.push_back("-g");

--- a/runtime/src/gpu/nvidia/Makefile.share
+++ b/runtime/src/gpu/nvidia/Makefile.share
@@ -32,6 +32,9 @@ RUNTIME_CXXFLAGS += -x cuda -Wno-unknown-cuda-version \
 
 # With cuda 11, cub headers have unused typedefs
 RUNTIME_CXXFLAGS += -Wno-error=unused-local-typedef
+#
+# With cuda 11, cub headers have deprecated builtins
+RUNTIME_CXXFLAGS += -Wno-error=deprecated-builtins -Wno-error=unknown-pragmas
 
 $(RUNTIME_OBJ_DIR)/gpu-nvidia-cub.o: gpu-nvidia-cub.cc \
                                          $(RUNTIME_OBJ_DIR_STAMP)


### PR DESCRIPTION
This PR suppresses some warnings coming from CUB 11. We discovered these when on one of the test machines was upgraded from clang 14 to 18. I am not sure at which clang version we start to see the warnings in question. So, the changes do not check for the clang version. It'd be great if we could check for the CUDA version, but unfortunately that's not wired in right now.

Test:
- [x] clean build in a local environment where I was able to repro the issue
- [x] standard
- [x] nvidia
- [x] amd