### PR TITLE
Revert "Require FI_ORDER_RMA_WAW with message-order-fence MCM"

### DIFF
--- a/runtime/src/comm/ofi/README.md
+++ b/runtime/src/comm/ofi/README.md
@@ -510,7 +510,6 @@ capabilities:
 and the following message orderings:
 
     FI_ORDER_ATOMIC_WAW
-    FI_ORDER_RMA_WAW
     FI_ORDER_SAS
 
 Note that there is no explicitly asserted ordering here between RMA and
@@ -524,10 +523,15 @@ this on an as-needed basis across the same transmit-receive endpoint
 pair, but in any other case we have to do it immediately after the
 operation that may create the dangling store.
 
-FI_ORDER_RMA_WAW is needed to ensure that multiple writes by a single task to
-the same memory address occur in program order. Note that this is a stronger
-guarantee than is necessary to enforce the MCM because it ensures that all
-writes by a task occur in program order, independent of memory address.
+The MCM requires that writes by a single task be performed in program order.
+However, satisfying this requirement does not require FI_ORDER_RMA_WAW
+because the compiler does not issue non-blocking PUTs, so there is no
+opportunity for writes by a single task to be performed out of order. The
+remote cache does perform non-blocking writes, but has internal
+synchronization to wait for previous conflicting writes to complete before
+issuing a new write. This ensures writes by a single task are performed in
+program order. FI_ORDER_RMA_WAW has signficant performance implications, so
+it should be avoided if possible.
 
 To force prior operations to be visible, the FI_DELIVERY_COMPLETE flag is
 required in addition to the FI_FENCE flag. Otherwise, the FI_FENCE merely

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1762,11 +1762,9 @@ struct fi_info* setCheckMsgOrderFenceProv(struct fi_info* info,
   //
   // Note: we don't ask for FI_ORDER_ATOMIC_RAW because the some providers
   // doesn't support it.  FI_ORDER_ATOMIC_WAR ordering is enforced by the
-  // MCM. We need FI_ORDER_RMA_WAW to ensure sequential consistency of
-  // writes.
+  // MCM.
   //
   uint64_t need_msg_orders =   FI_ORDER_ATOMIC_WAW
-                             | FI_ORDER_RMA_WAW
                              | FI_ORDER_SAS;
   if (set) {
     // Only use this mode if the tasking layer has a fixed number of threads.


### PR DESCRIPTION
This reverts commit 9575c8567aa72e65af46f7c6364c76f1a11f4981.

`FI_ORDER_RMA_WAW` is not required in message-order-fence because the compiler does not issue non-blocking PUTs, and even it if did `chpl_comm_put_nb` is currently implemented using blocking PUTs. So there is no opportunity for PUTs by a single task to be re-ordered.