### PR TITLE
Remove FI_DELIVERY_COMPLETE in message-order-fence mode

### DIFF
--- a/runtime/src/comm/ofi/README.md
+++ b/runtime/src/comm/ofi/README.md
@@ -529,11 +529,6 @@ the same memory address occur in program order. Note that this is a stronger
 guarantee than is necessary to enforce the MCM because it ensures that all
 writes by a task occur in program order, independent of memory address.
 
-To force prior operations to be visible, the FI_DELIVERY_COMPLETE flag is
-required in addition to the FI_FENCE flag. Otherwise, the FI_FENCE merely
-causes the prior operations to be transmit-compete, they may not be visible
-in memory. See the fi_cq man page for more details.
-
 #### Message-order MCM Mode
 
 In message-order mode the comm layer also takes the provider's default

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -3975,8 +3975,7 @@ void mcmReleaseOneNode(c_nodeid_t node, struct perTxCtxInfo_t* tcip,
   DBG_PRINTF(DBG_ORDER,
              "dummy GET from %d for %s ordering",
              (int) node, dbgOrderStr);
-  uint64_t flags = (mcmMode == mcmm_msgOrdFence) ?
-                      (FI_FENCE | FI_DELIVERY_COMPLETE) : 0;
+  uint64_t flags = (mcmMode == mcmm_msgOrdFence) ? FI_FENCE : 0;
   chpl_atomic_bool txnDone;
   void *ctx = TX_CTX_INIT(tcip, true /*blocking*/, &txnDone);
   ofi_get_lowLevel(orderDummy, orderDummyMRDesc, node,
@@ -4662,7 +4661,7 @@ void amReqFn_msgOrdFence(c_nodeid_t node,
     // Special case: Do a fenced send if we need it for ordering with
     // respect to some prior operation(s).
     //
-    flags |= FI_FENCE | FI_DELIVERY_COMPLETE;
+    flags |= FI_FENCE;
   }
   ctx = TX_CTX_INIT(tcip, blocking, &txnDone);
   (void) wrap_fi_sendmsg(node, req, reqSize, mrDesc, ctx, flags, tcip);
@@ -6050,7 +6049,7 @@ chpl_comm_nb_handle_t rmaPutFn_msgOrdFence(void* myAddr, void* mrDesc,
     // Special case: If our last operation was an AMO  then we need to do a
     // fenced PUT to force the AMO to complete before this PUT.
     //
-    flags |= FI_FENCE | FI_DELIVERY_COMPLETE;
+    flags |= FI_FENCE;
   }
   ctx = TX_CTX_INIT(tcip, blocking, &txnDone);
   (void) wrap_fi_writemsg(myAddr, mrDesc, node, mrRaddr, mrKey, size,
@@ -6467,7 +6466,7 @@ chpl_comm_nb_handle_t rmaGetFn_msgOrdFence(void* myAddr, void* mrDesc,
     // that visibility.
     //
     (void) wrap_fi_readmsg(myAddr, mrDesc, node, mrRaddr, mrKey, size, ctx,
-                           FI_FENCE | FI_DELIVERY_COMPLETE, tcip);
+                           FI_FENCE, tcip);
     if (havePutsOut) {
       bitmapClear(tcip->putVisBitmap, node);
     }
@@ -6876,7 +6875,7 @@ chpl_comm_nb_handle_t amoFn_msgOrdFence(struct amoBundle_t *ab,
     if (havePutsOut ||
        (famo && haveAmosOut &&
           !(ofi_info->tx_attr->msg_order & FI_ORDER_ATOMIC_RAW))) {
-      flags |= FI_FENCE | FI_DELIVERY_COMPLETE;
+      flags |= FI_FENCE;
     }
     if (havePutsOut) {
       bitmapClear(tcip->putVisBitmap, ab->node);


### PR DESCRIPTION
The Cassini-1 NIC does not support `FI_DELIVERY_COMPLETE` and specifying it can cause hangs. See Cray/chapel-private#1661 and Cray/chapel-private#6677 for details.

Signed-off-by: John H. Hartman <jhh67@users.noreply.github.com>