### PR TITLE
Remove the unused and deprecated config `fileOffsetWithoutLocking`

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -4952,10 +4952,6 @@ inline proc fileWriter.unlock() {
   }
 }
 
-@chpldoc.nodoc
-@deprecated("'fileReader.offset' and 'fileWriter.offset' will not automatically acquire a lock, this config no longer impacts code and will be removed in a future release")
-config param fileOffsetWithoutLocking = false;
-
 /*
    Return the current offset of a :record:`fileReader`.
 

--- a/test/deprecated/IO/offsetWithLocking.chpl
+++ b/test/deprecated/IO/offsetWithLocking.chpl
@@ -1,2 +1,0 @@
-// deprecated by jade in 1.33
-use IO;

--- a/test/deprecated/IO/offsetWithLocking.compopts
+++ b/test/deprecated/IO/offsetWithLocking.compopts
@@ -1,2 +1,0 @@
--sfileOffsetWithoutLocking=true
--sfileOffsetWithoutLocking=false

--- a/test/deprecated/IO/offsetWithLocking.good
+++ b/test/deprecated/IO/offsetWithLocking.good
@@ -1,2 +1,0 @@
-warning: 'fileReader.offset' and 'fileWriter.offset' will not automatically acquire a lock, this config no longer impacts code and will be removed in a future release
-note: 'fileOffsetWithoutLocking' was set via a compiler flag


### PR DESCRIPTION
Removes the transitional config `fileOffsetWithoutLocking`, which has been unused and deprecated for a few releases now.

[Reviewed by @jeremiah-corrado]