### PR TITLE
Add support for qualified interface access

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -2955,7 +2955,7 @@ void AggregateType::addClassToHierarchy(std::set<AggregateType*>& localSeen) {
       }
 
       auto ifcActuals = new CallExpr(PRIM_ACTUALS_LIST, new SymExpr(implementFor));
-      auto istmt = ImplementsStmt::build(isym->name, ifcActuals, nullptr);
+      auto istmt = ImplementsStmt::build(isym, ifcActuals, nullptr);
       getEnclosingBlockForImplements(this->symbol)->insertAtTail(istmt);
 
       expr->remove();

--- a/compiler/AST/interfaces.cpp
+++ b/compiler/AST/interfaces.cpp
@@ -290,6 +290,13 @@ void IfcConstraint::prettyPrint(std::ostream* o) {
 
 Symbol* gDummyWitness = NULL;
 
+ImplementsStmt* ImplementsStmt::build(InterfaceSymbol* isym, CallExpr* actuals,
+                                      BlockStmt* body) {
+ if (body == NULL) body = new BlockStmt();
+ IfcConstraint* icon = IfcConstraint::build(isym, actuals);
+ return new ImplementsStmt(icon, body);
+}
+
 ImplementsStmt* ImplementsStmt::build(const char* name, CallExpr* actuals,
                                       BlockStmt* body) {
  if (body == NULL) body = new BlockStmt();

--- a/compiler/include/stmt.h
+++ b/compiler/include/stmt.h
@@ -317,6 +317,9 @@ struct Witnesses {
 
 class ImplementsStmt final : public Stmt {
 public:
+  static ImplementsStmt* build(InterfaceSymbol* isym,
+                               CallExpr* actuals,
+                               BlockStmt* body);
   static ImplementsStmt* build(const char* name,
                                CallExpr* actuals,
                                BlockStmt* body);

--- a/test/constrained-generics/basic/qualified-interface-constraint.chpl
+++ b/test/constrained-generics/basic/qualified-interface-constraint.chpl
@@ -1,0 +1,12 @@
+module Other {
+  class CC {}
+  interface II {}
+}
+
+module M {
+  import Other;
+  class C: Other.CC {}
+  record R: Other.II {}
+
+  proc main() {}
+}


### PR DESCRIPTION
Closes https://github.com/chapel-lang/chapel/issues/25829.

Strangely, even though we have an `isym` when building the class hierarchy, I chose to use the symbol's name to construct an `implements` statement. This works when the name is available in scope without qualification, but not when qualified access is used. The principled solution is to allow interface statements to be constructed using a known interface symbol. This PR does that, and switches the class hierarchy logic to avoid using a name.

Reviewed by @jabraham17 -- thanks!

## Testing
- [x] paratest