### PR TITLE
Improve location reporting for ControlFlowParentheses

### DIFF
--- a/tools/chplcheck/src/rule_types.py
+++ b/tools/chplcheck/src/rule_types.py
@@ -226,7 +226,7 @@ class BasicRule(Rule[BasicRuleResult]):
         # addition to the fixits in the result itself)
         # add the fixits from the hooks to the fixits from the rule
         fixits = self.run_fixit_hooks(context, result) + fixits
-        return (node, self.name, fixits)
+        return (result.node, self.name, fixits)
 
     def check(
         self, context: chapel.Context, root: chapel.AstNode

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -289,7 +289,7 @@ def register_rules(driver: LintDriver):
         paren_loc = subject.parenth_location()
         assert paren_loc
 
-        # If parentheeses span multiple lines, don't provide a fixit,
+        # If parentheses span multiple lines, don't provide a fixit,
         # since the indentation would need more thought.
         start_line, start_col = paren_loc.start()
         end_line, end_col = paren_loc.end()

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -279,7 +279,7 @@ def register_rules(driver: LintDriver):
 
         # Now, we should warn: there's a node in a conditional or
         # if/else, it has parentheses at the top level, but it doesn't need them.
-        return BasicRuleResult(node, data=subject)
+        return BasicRuleResult(subject, data=subject)
 
     @driver.fixit(ControlFlowParentheses)
     def RemoveControlFlowParentheses(context: Context, result: BasicRuleResult):


### PR DESCRIPTION
Improves the location reporting for ControlFlowParentheses to only report the location for the condition, not the full body.

[Reviewed by @DanilaFe]