### PR TITLE
Be more selective in terms of clang version when using a flag in CUB compilation

### DIFF
--- a/runtime/src/gpu/nvidia/Makefile.share
+++ b/runtime/src/gpu/nvidia/Makefile.share
@@ -32,10 +32,13 @@ RUNTIME_CXXFLAGS += -x cuda -Wno-unknown-cuda-version \
 
 # With cuda 11, cub headers have unused typedefs
 RUNTIME_CXXFLAGS += -Wno-error=unused-local-typedef
-#
-# With cuda 11, cub headers have deprecated builtins
-RUNTIME_CXXFLAGS += -Wno-error=deprecated-builtins -Wno-error=unknown-pragmas \
-		    -Wno-error=unknown-warning-option
+
+
+ifeq ($(shell test $(CHPL_MAKE_LLVM_VERSION) -ge 15; echo "$$?"),0)
+	# With cuda 11, cub headers have deprecated builtins
+	RUNTIME_CXXFLAGS += -Wno-error=deprecated-builtins \
+			    -Wno-error=unknown-pragmas
+endif
 
 $(RUNTIME_OBJ_DIR)/gpu-nvidia-cub.o: gpu-nvidia-cub.cc \
                                          $(RUNTIME_OBJ_DIR_STAMP)

--- a/runtime/src/gpu/nvidia/Makefile.share
+++ b/runtime/src/gpu/nvidia/Makefile.share
@@ -34,7 +34,8 @@ RUNTIME_CXXFLAGS += -x cuda -Wno-unknown-cuda-version \
 RUNTIME_CXXFLAGS += -Wno-error=unused-local-typedef
 #
 # With cuda 11, cub headers have deprecated builtins
-RUNTIME_CXXFLAGS += -Wno-error=deprecated-builtins -Wno-error=unknown-pragmas
+RUNTIME_CXXFLAGS += -Wno-error=deprecated-builtins -Wno-error=unknown-pragmas \
+		    -Wno-error=unknown-warning-option
 
 $(RUNTIME_OBJ_DIR)/gpu-nvidia-cub.o: gpu-nvidia-cub.cc \
                                          $(RUNTIME_OBJ_DIR_STAMP)


### PR DESCRIPTION
https://github.com/chapel-lang/chapel/pull/25918 added `-Wno-error=deprecated-builtins` when compiling the runtime's CUB wrappers. However, that flag is not supported in some older clangs. Specifically, we added that to enable builds with clang 18, but clang 14 doesn't have that flag. This PR adds the problematic flag only if the clang version supports it.


Test:
- [x] build proceeds on a system with the same issue