### PR TITLE
Fix dyno resolving dependently-typed fields in method

### DIFF
--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -1632,13 +1632,11 @@ QualifiedType getInstantiationType(Context* context,
 
       // which BasicClassType to use?
       const BasicClassType* bct;
-      if (auto formalBct = formalCt->basicClassType()) {
+      auto formalBct = formalCt->basicClassType();
+      if (formalBct && getTypeGenericity(context, formalBct) == Type::CONCRETE) {
         bct = formalBct;
       } else {
         CHPL_ASSERT(formalCt->manageableType()->toManageableType());
-        bct = actualCt->basicClassType();
-      }
-      if (getTypeGenericity(context, bct) != Type::CONCRETE) {
         bct = actualCt->basicClassType();
       }
 

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -1638,9 +1638,8 @@ QualifiedType getInstantiationType(Context* context,
         CHPL_ASSERT(formalCt->manageableType()->toManageableType());
         bct = actualCt->basicClassType();
       }
-      auto g = getTypeGenericity(context, bct);
-      if (g != Type::CONCRETE) {
-        CHPL_UNIMPL("instantiate generic class formal");
+      if (getTypeGenericity(context, bct) != Type::CONCRETE) {
+        bct = actualCt->basicClassType();
       }
 
       // now construct the ClassType

--- a/frontend/test/resolution/testClasses.cpp
+++ b/frontend/test/resolution/testClasses.cpp
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "test-resolution.h"
+
 #include "chpl/parsing/parsing-queries.h"
 #include "chpl/resolution/resolution-queries.h"
 #include "chpl/types/BasicClassType.h"
@@ -29,7 +31,6 @@
 #include "chpl/uast/Identifier.h"
 #include "chpl/uast/Module.h"
 #include "chpl/uast/Variable.h"
-#include "test-resolution.h"
 
 static void test1() {
   printf("test1\n");
@@ -72,12 +73,12 @@ static void test1() {
   auto bct = it->getCompositeType()->toBasicClassType();
   assert(bct);
 
-  auto borrowedNonNil =
-      ClassType::get(context, bct, nullptr,
-                     ClassTypeDecorator(ClassTypeDecorator::BORROWED_NONNIL));
-  auto anyNonNil =
-      ClassType::get(context, bct, nullptr,
-                     ClassTypeDecorator(ClassTypeDecorator::GENERIC_NONNIL));
+  auto borrowedNonNil = ClassType::get(context, bct, nullptr,
+                                       ClassTypeDecorator(
+                                         ClassTypeDecorator::BORROWED_NONNIL));
+  auto anyNonNil = ClassType::get(context, bct, nullptr,
+                                  ClassTypeDecorator(
+                                    ClassTypeDecorator::GENERIC_NONNIL));
 
   assert(methodT->formalName(0) == "this");
   assert(methodT->formalType(0).kind() == QualifiedType::CONST_IN);


### PR DESCRIPTION
Enable dyno to type resolve usages of dependently-typed class fields, used within methods.

This wasn't working due to the method receiver type being left generic during instantiation. Fixed by using the actual `BasicClassType` to instantiate the formal when it's generic.

Resolves https://github.com/Cray/chapel-private/issues/6690.

[reviewer info placeholder]

Testing:
- [x] dyno tests
- [x] paratest