### PR TITLE
Prevent offset access with block arrays to thwart dynamic ALA

### DIFF
--- a/compiler/optimizations/forallOptimizations.cpp
+++ b/compiler/optimizations/forallOptimizations.cpp
@@ -1261,6 +1261,10 @@ static void generateDynamicCheckForAccess(ALACandidate& candidate,
       offsetCheck->insertAtTail(e->copy());
     }
 
+    CallExpr *staticOverride = new CallExpr(PRIM_UNARY_LNOT,
+        new SymExpr(staticCheckSymMap[baseSym]));
+    offsetCheck = new CallExpr("||", staticOverride, offsetCheck);
+
     CallExpr* newCheck = new CallExpr("&&", offsetCheck); // we'll add curCheck
     curCheck->replace(newCheck);
     newCheck->insertAtTail(curCheck);

--- a/test/optimizations/autoLocalAccess/blockWithOffset.chpl
+++ b/test/optimizations/autoLocalAccess/blockWithOffset.chpl
@@ -1,0 +1,21 @@
+use BlockDist;
+
+
+var Arr = blockDist.createArray(1..10, int);
+
+const Inner = Arr.domain.expand(-1);
+
+forall i in Arr.domain { // this should make Arr[i] a static candidate
+  if i<10 then
+    Arr[i] =  // this must be a local access (9 total)
+      Arr[i+1];  // this must be a default access (9 total)
+}
+
+writeln(Arr);
+
+forall i in Inner { // this should make Arr[i] a dynamic candidate
+    Arr[i] =  // this must be a local access (8 total) <- this was buggy
+      Arr[i+1];  // this must be a default access (8 total)
+}
+
+writeln(Arr);

--- a/test/optimizations/autoLocalAccess/blockWithOffset.compopts
+++ b/test/optimizations/autoLocalAccess/blockWithOffset.compopts
@@ -1,0 +1,1 @@
+-slogDistArrEltAccess=true

--- a/test/optimizations/autoLocalAccess/blockWithOffset.good
+++ b/test/optimizations/autoLocalAccess/blockWithOffset.good
@@ -1,0 +1,42 @@
+
+Start analyzing forall (blockWithOffset.chpl:8)
+| Found loop domain (blockWithOffset.chpl:4)
+| Will attempt static and dynamic optimizations (blockWithOffset.chpl:8)
+|
+|  Start analyzing call (blockWithOffset.chpl:10)
+|   Can optimize: Access base is the iterator's base (blockWithOffset.chpl:10)
+|  This call is a static optimization candidate (blockWithOffset.chpl:10)
+|
+|  Start analyzing call (blockWithOffset.chpl:11)
+|   Call has offset(s), this will require dynamic check (blockWithOffset.chpl:11)
+|   Can optimize: Access base is the iterator's base (blockWithOffset.chpl:11)
+|  This call is a static optimization candidate (blockWithOffset.chpl:11)
+|
+End analyzing forall (blockWithOffset.chpl:8)
+
+
+Start analyzing forall (blockWithOffset.chpl:16)
+| Found loop domain (blockWithOffset.chpl:6)
+| Will attempt static and dynamic optimizations (blockWithOffset.chpl:16)
+|
+|  Start analyzing call (blockWithOffset.chpl:17)
+|   Can't determine the domain of access base (blockWithOffset.chpl:4)
+|  This call is a dynamic optimization candidate (blockWithOffset.chpl:17)
+|
+|  Start analyzing call (blockWithOffset.chpl:18)
+|   Call has offset(s), this will require dynamic check (blockWithOffset.chpl:18)
+|   Can't determine the domain of access base (blockWithOffset.chpl:4)
+|  This call is a dynamic optimization candidate (blockWithOffset.chpl:18)
+|
+End analyzing forall (blockWithOffset.chpl:16)
+
+Static check successful. Using localAccess [static only ALA clone]  (blockWithOffset.chpl:10)
+Static check failed. Reverting optimization [static only ALA clone]  (blockWithOffset.chpl:11)
+Static check successful. Using localAccess with dynamic check (blockWithOffset.chpl:17)
+Static check failed. Reverting optimization [static and dynamic ALA clone]  (blockWithOffset.chpl:18)
+0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0
+
+Numbers collected by prediff:
+	localAccess was called 17 times
+	this was called 17 times

--- a/test/optimizations/autoLocalAccess/blockWithOffset.prediff
+++ b/test/optimizations/autoLocalAccess/blockWithOffset.prediff
@@ -1,0 +1,1 @@
+PREDIFF-filter-accessors


### PR DESCRIPTION
This PR makes sure that ALA is applicable for:

```chpl
var A = blockDist.createArray(...)
const InnerDomain = A.domain.expand(-1);

forall i in InnerDomain {
  A[i] = A[i-1];
}
```

Things of note:

- this is a dynamically optimized loop, because the compiler can't statically determine that `InnerDomain` and `A.domain` are aligned.
- the body contains both regular (`A[i]`) and offset (`A[i-1]`) access, where the latter is not optimizable for a block-distributed array

The problem is, https://github.com/chapel-lang/chapel/pull/25712 modified the dynamic checks in scenarios like this. After that PR, the generated optimization looked like

```chpl
param staticRegularFlag = alaStaticallySupported(A);  // added for A[i] (true)
param staticOffsetFlag = alaOffsetStaticallySupported(A);  // added for A[i-1] (false)

if ( (!staticRegularFlag || alaDynamicallySupported(A)) &&
                            alaOffsetCheck(A, 1)) {
  // optimized loop
}
else {
  // unoptimized loop
}
```

Note that ALA has static override (`!staticRegularFlag ||` part) which allows optimization and the dynamic checks to be reverted in case a static check fails. This allows some accesses to be optimized while some others fails. However, the same override is not there for the offset check. This PR adds a similar `!staticOffsetFlag ||` for similar purposes. This allows `A[i]` to be optimized as before while `A[i-1]` is not.

Test:
- [x] performance goes back to where we were before
- [x] gasnet 
- [x] linux64
