### PR TITLE
Unload cce prior to loading PrgEnv-gnu

### DIFF
--- a/util/build_configs/cray-internal/setenv-hpe-cray-ex-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-hpe-cray-ex-x86_64.bash
@@ -319,6 +319,9 @@ else
         local target_compiler="gcc"
         #local target_version=$gen_version_gcc
 
+        # unload cce, let the PrgEnv module load it if necessary
+        unload_module_re cce
+
         # unload any existing PrgEnv
         unload_module_re PrgEnv-
 


### PR DESCRIPTION
The `cce` module appears to cause a problem when used with the `PrgEnv-gnu` and `libfabric` modules loaded, as the `hwloc` configuration fails because` -lfabric` is not found. Unload the `cce` module prior to loading the `PrgEnv-gnu`  module and let it reload `cce` should it want to, but this way `cce` isn't loaded if `PrgEnv-gnu` doesn't need it.