### PR TITLE
Build multiarch image in test-docker.bash

### DIFF
--- a/util/cron/test-docker.bash
+++ b/util/cron/test-docker.bash
@@ -15,7 +15,7 @@ build_image() {
   # Remove any existing image with the tag before building docker image
   docker image rm --force $imageName
 
-  docker build --push . -t $imageName
+  docker buildx build --platform=linux/amd64,linux/arm64 . --push -t $imageName
   BUILD_RESULT=$?
   if [ $BUILD_RESULT -ne 0 ]
   then


### PR DESCRIPTION
Build `linux/amd64` platform image in addition to system default `linux/arm64` in the nightly Docker test script.

In addition to improving test coverage, this will cause our `nightly` image tag to be multi-arch going forward.

To be merged after https://github.hpe.com/hpe/hpc-chapel-ci-config/pull/1280 adjusts this job to run on our test machine that supports multi-arch build.

Implements https://github.com/Cray/chapel-private/issues/6563.

[reviewer info placeholder]

Testing:
- [x] manual run on M1 testing mac