### PR TITLE
Fix dyno resolving `type` fields in method signatures

### DIFF
--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -3021,7 +3021,12 @@ void Resolver::resolveIdentifier(const Identifier* ident) {
   // and probably a few other features.
   bool emitLookupErrors = !resolvingCalledIdent && !scopeResolveOnly;
 
-  if (parenlessInfo.areCandidatesOnlyParenlessProcs() && !scopeResolveOnly) {
+  if (parenlessInfo.hasMethodCandidates() &&
+      getTypeGenericity(context, methodReceiverType()) != Type::CONCRETE) {
+    // Can't establish type yet, defer until receiver is instantiated.
+    result.setType(QualifiedType());
+  } else if (parenlessInfo.areCandidatesOnlyParenlessProcs() &&
+             !scopeResolveOnly) {
     // Ambiguous, but a special case: there are many parenless functions.
     // This might be fine, if their 'where' clauses leave only one.
     //

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -4058,6 +4058,12 @@ void Resolver::exit(const Dot* dot) {
     return;
   }
 
+  // Handle generic receiver type later in function resolution,
+  // once we have an instantiation.
+  if (getTypeGenericity(context, receiver.type()) != Type::CONCRETE) {
+    deferToFunctionResolution = true;
+  }
+
   if (scopeResolveOnly || deferToFunctionResolution)
     return;
 

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -235,7 +235,7 @@ Resolver::createForInitialSignature(Context* context, const Function* fn,
     fn->thisFormal()->traverse(ret);
     auto receiverType = ret.byPostorder.byAst(fn->thisFormal()).type();
     if (receiverType.hasTypePtr()) {
-      if (auto ct = receiverType.type()->toCompositeType()) {
+      if (auto ct = receiverType.type()->getCompositeType()) {
         ret.inCompositeType = ct;
       }
       ret.allowReceiverScopes = true;

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2289,7 +2289,7 @@ ApplicabilityResult instantiateSignature(Context* context,
         //
         // Also recompute receiver scopes based on the instantiated type so
         // that we correctly resolve the types of field identifiers.
-        visitor.setCompositeType(formalType.type()->toCompositeType());
+        visitor.setCompositeType(formalType.type()->getCompositeType());
         visitor.receiverScopesComputed = false;
       }
     }

--- a/frontend/test/resolution/testInitSemantics.cpp
+++ b/frontend/test/resolution/testInitSemantics.cpp
@@ -1453,7 +1453,7 @@ static void testInitGenericAfterConcrete() {
     auto t = resolveTypeOfX(context, program);
 
     assert(t);
-    assert(t->isAnyType());
+    assert(t->isUnknownType());
 
     assert(guard.errors().size() == 2);
     assert(guard.error(0)->message() ==

--- a/frontend/test/resolution/testResolve.cpp
+++ b/frontend/test/resolution/testResolve.cpp
@@ -1558,6 +1558,94 @@ static void test25() {
   }
 }
 
+static void test26() {
+  // Test resolving a generic type field usage in a method signature.
+
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  {
+    // 'this' qualified, type field
+    std::string prog =
+      R"""(
+        class Foo {
+          type myType = string;
+          proc doSomething(x : this.myType) param do return 1;
+        }
+
+        var myFoo = new Foo(int);
+        var x = myFoo.doSomething(1);
+      )""";
+
+    auto t = resolveTypeOfXInit(context, prog);
+    ensureParamInt(t, 1);
+    assert(guard.realizeErrors() == 0);
+
+    context->advanceToNextRevision(false);
+  }
+
+  {
+    // unqualified, type field
+    std::string prog =
+      R"""(
+        class Foo {
+          type myType = string;
+          proc doSomething(x : myType) param do return 1;
+        }
+
+        var myFoo = new Foo(int);
+        var x = myFoo.doSomething(1);
+      )""";
+
+    auto t = resolveTypeOfXInit(context, prog);
+    ensureParamInt(t, 1);
+    assert(guard.realizeErrors() == 0);
+
+    context->advanceToNextRevision(false);
+  }
+
+  {
+    // 'this' qualified, type parenless proc
+    std::string prog =
+      R"""(
+        class Foo {
+          proc myType type do return int;
+          proc doSomething(x : this.myType) param do return 1;
+        }
+
+        var myFoo = new Foo();
+        var x = myFoo.doSomething(1);
+      )""";
+
+    auto t = resolveTypeOfXInit(context, prog);
+    ensureParamInt(t, 1);
+    assert(guard.realizeErrors() == 0);
+
+    context->advanceToNextRevision(false);
+  }
+
+  {
+    // unqualified, type parenless proc
+    std::string prog =
+      R"""(
+        class Foo {
+          proc myType type do return int;
+          proc doSomething(x : myType) param do return 1;
+        }
+
+        var myFoo = new Foo();
+        var x = myFoo.doSomething(1);
+      )""";
+
+    auto t = resolveTypeOfXInit(context, prog);
+    ensureParamInt(t, 1);
+    assert(guard.realizeErrors() == 0);
+
+    context->advanceToNextRevision(false);
+  }
+}
+
 int main() {
   test1();
   test2();
@@ -1584,6 +1672,7 @@ int main() {
   test23();
   test24();
   test25();
+  test26();
 
   return 0;
 }

--- a/frontend/test/resolution/testResolve.cpp
+++ b/frontend/test/resolution/testResolve.cpp
@@ -1606,7 +1606,7 @@ static void test26() {
   }
 
   {
-    // 'this' qualified, type parenless proc
+    // 'this' qualified, type parenless proc, concrete receiver
     std::string prog =
       R"""(
         class Foo {
@@ -1626,7 +1626,7 @@ static void test26() {
   }
 
   {
-    // unqualified, type parenless proc
+    // unqualified, type parenless proc, concrete receiver
     std::string prog =
       R"""(
         class Foo {
@@ -1635,6 +1635,48 @@ static void test26() {
         }
 
         var myFoo = new Foo();
+        var x = myFoo.doSomething(1);
+      )""";
+
+    auto t = resolveTypeOfXInit(context, prog);
+    ensureParamInt(t, 1);
+    assert(guard.realizeErrors() == 0);
+
+    context->advanceToNextRevision(false);
+  }
+
+  {
+    // 'this' qualified, type parenless proc, generic receiver
+    std::string prog =
+      R"""(
+        class Foo {
+          type idxType;
+          proc myType type do return idxType;
+          proc doSomething(x : this.myType) param do return 1;
+        }
+
+        var myFoo = new Foo(int);
+        var x = myFoo.doSomething(1);
+      )""";
+
+    auto t = resolveTypeOfXInit(context, prog);
+    ensureParamInt(t, 1);
+    assert(guard.realizeErrors() == 0);
+
+    context->advanceToNextRevision(false);
+  }
+
+  {
+    // unqualified, type parenless proc, generic receiver
+    std::string prog =
+      R"""(
+        class Foo {
+          type idxType;
+          proc myType type do return idxType;
+          proc doSomething(x : myType) param do return 1;
+        }
+
+        var myFoo = new Foo(int);
         var x = myFoo.doSomething(1);
       )""";
 


### PR DESCRIPTION
Fix a bug preventing dyno from resolving unqualified uses of `type` fields or parenless procs in method signatures.

Resolved by setting `Resolver::inCompositeType` in more cases where it appears to have been accidentally omitted, and by delaying resolution of parenless procs on generic receivers until later when they are instantiated.

Also adds dyno tests for the fixed cases.

Note this PR includes one incidental test change in `testInitSemantics`, due to now resolving an incompletely-specified generic type's generic field as `UnknownType` rather than `AnyType`. I believe this is equally or more correct as the generic type is not initialized properly and in fact errors on initialization.

Resolves https://github.com/Cray/chapel-private/issues/6689.

[reviewer info placeholder]

Testing:
- [x] dyno tests
- [x] paratest