### PR TITLE
update WSL docs with example installation

### DIFF
--- a/doc/rst/platforms/macosx.rst
+++ b/doc/rst/platforms/macosx.rst
@@ -10,7 +10,7 @@ There are two main approaches for using Chapel on Mac OS X:
    quickest way to get up and running, but it results in a copy of
    Chapel that only supports shared-memory (single-locale) executions.
 
-2) Build Chapel from source, as with any other UN*X
+2) Build Chapel from source, as with any other UNIX
    system.  This is slightly more involved, but supports Chapel's full
    feature set.
 

--- a/doc/rst/platforms/windows.rst
+++ b/doc/rst/platforms/windows.rst
@@ -25,7 +25,7 @@ Microsoft Store. We recommend using Ubuntu, but others will likely work.
 
 This example shows how to install WSL and Ubuntu on Windows 10/11::
 
-    # Open PowerShell
+    # From PowerShell, run the following command to enable WSL
     wsl --install -d Ubuntu
 
 
@@ -43,12 +43,10 @@ There are two main approaches for using Chapel on WSL:
 
 For option 1, see the following example of how to install Chapel on WSL::
 
-    # Download the Chapel package
     # From the Ubuntu terminal, use the following command to download the Chapel package.
     wget https://github.com/chapel-lang/chapel/releases/download/2.1.0/chapel-2.1.0-1.ubuntu22.amd64.deb
 
-    # Verify that the package is official by checking the shasum 256 against the known good value:
-
+    # Verify the package by checking the shasum 256 against the known good value:
     echo "5928c31bb1ffe704356a86c52006b7bd3c8115190bc4a833abc6a6040c07b368 *chapel-2.1.0-1.ubuntu22.amd64.deb" | shasum -a 256 -c
 
     # Install Chapel

--- a/doc/rst/platforms/windows.rst
+++ b/doc/rst/platforms/windows.rst
@@ -36,7 +36,7 @@ There are two main approaches for using Chapel on WSL:
    only supports shared-memory (single-locale) executions. See the list of available
    packages released on the `Chapel GitHub page <https://github.com/chapel-lang/chapel/releases>`_.
 
-2) Build Chapel from source, as with any other UN*X system. This is slightly
+2) Build Chapel from source, as with any other UNIX system. This is slightly
    more involved, but supports Chapel's full feature set. See the list of prerequisites
    for your distribution from :ref:`readme-prereqs`
 

--- a/doc/rst/platforms/windows.rst
+++ b/doc/rst/platforms/windows.rst
@@ -22,9 +22,43 @@ variety of Linux distributions. For more information on WSL, see the
 
 To use Chapel on WSL, you will need to install a Linux distribution from the
 Microsoft Store. We recommend using Ubuntu, but others will likely work.
-Once you have installed your distribution, get the list of prerequisites
-from :ref:`readme-prereqs` and install Chapel as you would on a native Linux
-system. There are no platform-specific settings for Chapel on WSL at this time.
+
+This example shows how to install WSL and Ubuntu on Windows 10/11::
+
+    # Open PowerShell
+    wsl --install -d Ubuntu
+
+
+There are two main approaches for using Chapel on WSL:
+
+1) Install via a prebuilt Chapel package. This is the quickest way to get up
+   and running, but it results in a copy of Chapel without GPU support and that
+   only supports shared-memory (single-locale) executions. See the list of available
+   packages released on the `Chapel GitHub page <https://github.com/chapel-lang/chapel/releases>`_.
+
+2) Build Chapel from source, as with any other UN*X system. This is slightly
+   more involved, but supports Chapel's full feature set. See the list of prerequisites
+   for your distribution from :ref:`readme-prereqs`
+
+
+For option 1, see the following example of how to install Chapel on WSL::
+
+    # Download the Chapel package
+    # From the Ubuntu terminal, use the following command to download the Chapel package.
+    wget https://github.com/chapel-lang/chapel/releases/download/2.1.0/chapel-2.1.0-1.ubuntu22.amd64.deb
+
+    # Verify that the package is official by checking the shasum 256 against the known good value:
+
+    echo "5928c31bb1ffe704356a86c52006b7bd3c8115190bc4a833abc6a6040c07b368 *chapel-2.1.0-1.ubuntu22.amd64.deb" | shasum -a 256 -c
+
+    # Install Chapel
+    sudo apt-get update
+    sudo apt-get install ./chapel-2.1.0-1.ubuntu22.amd64.deb
+
+    # Test that chpl is available
+    chpl --version
+
+There are no platform-specific settings for Chapel on WSL at this time.
 
   .. note::
 

--- a/doc/rst/platforms/windows.rst
+++ b/doc/rst/platforms/windows.rst
@@ -43,15 +43,19 @@ There are two main approaches for using Chapel on WSL:
 
 For option 1, see the following example of how to install Chapel on WSL::
 
-    # From the Ubuntu terminal, use the following command to download the Chapel package.
-    wget https://github.com/chapel-lang/chapel/releases/download/2.1.0/chapel-2.1.0-1.ubuntu22.amd64.deb
+    # From the Ubuntu terminal, use wget to download the Chapel package,
+    # replacing <chapel_version> and <package_file_name> with the appropriate values
+    wget https://github.com/chapel-lang/chapel/releases/download/<chapel_version>/<package_file_name>
 
     # Verify the package by checking the shasum 256 against the known good value:
-    echo "5928c31bb1ffe704356a86c52006b7bd3c8115190bc4a833abc6a6040c07b368 *chapel-2.1.0-1.ubuntu22.amd64.deb" | shasum -a 256 -c
+    # see https://github.com/chapel-lang/chapel/releases for a list of packages and known good sha256 values
+    # if you get the following error:
+    # `shasum: standard input: no properly formatted SHA checksum lines found`
+    # check that you have 2 spaces between the sha256 value and the filename
 
-    # Install Chapel
+    # Install Chapel, replacing <package_file_name> with the appropriate value
     sudo apt-get update
-    sudo apt-get install ./chapel-2.1.0-1.ubuntu22.amd64.deb
+    sudo apt-get install <package_file_name>
 
     # Test that chpl is available
     chpl --version


### PR DESCRIPTION
Adds to the WSL documentation by explaining two main ways to get Chapel on WSL. The change also includes the commands to get WSL installed and an example that shows the commands to install Chapel with the package management system in Ubuntu.

[reviewed by @mppf - thanks!]