### PR TITLE
Change docs/latest/ to docs/ in man page

### DIFF
--- a/man/chpl.rst
+++ b/man/chpl.rst
@@ -862,7 +862,7 @@ OPTIONS
 Note that the flags in this section all have corresponding environment
 variables.  Details on those environment variables, including potential values
 for them, can be found at
-https://chapel-lang.org/docs/latest/usingchapel/chplenv.html or at
+https://chapel-lang.org/docs/usingchapel/chplenv.html or at
 doc/rst/usingchapel/chplenv.rst in your Chapel installation.
 
 .. _man-home:


### PR DESCRIPTION
We used to require docs/latest to get to the latest docs online, but haven't for some time, and prefer using the non-latest/ URLs from the perspectives of simplicity and SEO.

[I've got updates to other files in another branch, but those are in code / not user-facing, so I'm saving those until after 2.2]

