### PR TITLE
Preserve -x with "-o LogLevel=Error"

### DIFF
--- a/doc/rst/platforms/udp.rst
+++ b/doc/rst/platforms/udp.rst
@@ -119,11 +119,12 @@ I'm seeing login banners mixed with my program's output
 
 If you are using SSH to launch jobs, you might get a
 login banner printed out along with your program's output. We have
-found the following setting useful to disable such printing:
+found the following setting useful to disable such printing (where
+``-x`` is retained from the instructions above):
 
 .. code-block:: bash
 
-   export GASNET_SSH_OPTIONS="-o LogLevel=Error"
+   export GASNET_SSH_OPTIONS="-x -o LogLevel=Error"
 
 My console output seems to be jumbled or missing
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Prior to this commit, the recommended environment setting to silence ssh login banners set `GASNET_SSH_OPTIONS` to a value which discarded the `-x` recommended earlier to disable X11 forwarding.  So, this commit updates the recommendation in a way that retains the `-x`.