### PR TITLE
Dyno: fix decls with tuple type expressions and initialization expressions

### DIFF
--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1265,6 +1265,42 @@ static const Type* computeVarArgTuple(Resolver& resolver,
   return typePtr;
 }
 
+
+static bool adjustTupleTypeIntentForDecl(Context* context,
+                                            const NamedDecl* decl,
+                                            QualifiedType::Kind declaredKind,
+                                            QualifiedType::Kind& qtKind,
+                                            const Type*& typePtr) {
+  // adjust tuple declarations for value / referential tuples
+  if (typePtr != nullptr && decl->isVarArgFormal() == false) {
+    if (auto tupleType = typePtr->toTupleType()) {
+      if (declaredKind == QualifiedType::DEFAULT_INTENT) {
+        typePtr = tupleType->toReferentialTuple(context);
+        qtKind = QualifiedType::CONST_REF;
+        return true;
+      } else if (declaredKind == QualifiedType::CONST_INTENT) {
+        typePtr = tupleType->toReferentialTuple(context, /* makeConst */ true);
+        qtKind = QualifiedType::CONST_REF;
+        return true;
+      } else if (qtKind == QualifiedType::CONST_IN ||
+                 qtKind == QualifiedType::CONST_REF) {
+        typePtr = tupleType->toValueTuple(context, /* makeConst */ true);
+        return true;
+      } else if (qtKind == QualifiedType::VAR ||
+                 qtKind == QualifiedType::CONST_VAR ||
+                 qtKind == QualifiedType::REF ||
+                 qtKind == QualifiedType::IN ||
+                 qtKind == QualifiedType::OUT ||
+                 qtKind == QualifiedType::INOUT ||
+                 qtKind == QualifiedType::TYPE) {
+        typePtr = tupleType->toValueTuple(context);
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 /* If the type is generic with defaults, computes the defaults of a type.
    Returns the original type if instantiating with defaults isn't necessary. */
 static QualifiedType computeTypeDefaults(Resolver& resolver,
@@ -1494,6 +1530,19 @@ void Resolver::resolveNamedDecl(const NamedDecl* decl, const Type* useType) {
           computeFormalIntent(decl, qtKind, typeExprT.type(), typeExprT.param());
         }
       }
+
+      // The type expression is a type-tuple (e.g., (type int, type bool)),
+      // but the actual value may be value-tuple (e.g., (int, bool)), or a ref
+      // tuple, etc. Need to adjust the intents so that getTypeForDecl (which
+      // runs canPass) doesn't balk at the mismatch.
+      auto adjustedQtKind = qtKind;
+      auto adjustedTypePtr = typeExprT.type();
+      if (adjustTupleTypeIntentForDecl(context, decl, qtKind,
+                                       adjustedQtKind, adjustedTypePtr)) {
+        typeExprT = QualifiedType(typeExprT.kind(), adjustedTypePtr, typeExprT.param());
+      }
+
+      //
       // Check that the initExpr type is compatible with declared type
       // Check kinds are OK
       // Handle any implicit conversions / instantiations
@@ -1525,29 +1574,7 @@ void Resolver::resolveNamedDecl(const NamedDecl* decl, const Type* useType) {
                                  qtKind, typePtr);
   }
 
-  // adjust tuple declarations for value / referential tuples
-  if (typePtr != nullptr && decl->isVarArgFormal() == false) {
-    if (auto tupleType = typePtr->toTupleType()) {
-      if (declaredKind == QualifiedType::DEFAULT_INTENT) {
-        typePtr = tupleType->toReferentialTuple(context);
-        qtKind = QualifiedType::CONST_REF;
-      } else if (declaredKind == QualifiedType::CONST_INTENT) {
-        typePtr = tupleType->toReferentialTuple(context, /* makeConst */ true);
-        qtKind = QualifiedType::CONST_REF;
-      } else if (qtKind == QualifiedType::CONST_IN ||
-                 qtKind == QualifiedType::CONST_REF) {
-        typePtr = tupleType->toValueTuple(context, /* makeConst */ true);
-      } else if (qtKind == QualifiedType::VAR ||
-                 qtKind == QualifiedType::CONST_VAR ||
-                 qtKind == QualifiedType::REF ||
-                 qtKind == QualifiedType::IN ||
-                 qtKind == QualifiedType::OUT ||
-                 qtKind == QualifiedType::INOUT ||
-                 qtKind == QualifiedType::TYPE) {
-        typePtr = tupleType->toValueTuple(context);
-      }
-    }
-  }
+  adjustTupleTypeIntentForDecl(context, decl, declaredKind, qtKind, typePtr);
 
   ResolvedExpression& result = byPostorder.byAst(decl);
   result.setType(QualifiedType(qtKind, typePtr, paramPtr));

--- a/frontend/test/resolution/testTuples.cpp
+++ b/frontend/test/resolution/testTuples.cpp
@@ -971,6 +971,32 @@ static void test20() {
   }
 }
 
+static void test21() {
+  // Ensure that (type int, type int) tuples in type expression are properly
+  // handled when they are specifying the type of var or const variable.
+
+  Context ctx;
+  Context* context = &ctx;
+  auto program = R"""(
+    var x: 2*int = (7,3);
+    const y: 2*int = (7,3);
+    var x2: 2*int;
+    const y2: 2*int;
+
+    param firstMatch = x.type == x2.type;
+    param secondMatch = y.type == y2.type;
+  )""";
+
+  auto vars = resolveTypesOfVariables(context, program,
+                                      {"x", "y", "x2", "y2", "firstMatch", "secondMatch"});
+  assert(vars["x"].type()->isTupleType());
+  assert(vars["y"].type()->isTupleType());
+  assert(vars["x2"].type()->isTupleType());
+  assert(vars["y2"].type()->isTupleType());
+  ensureParamBool(vars["firstMatch"], true);
+  ensureParamBool(vars["secondMatch"], true);
+}
+
 
 int main() {
   test1();
@@ -998,5 +1024,6 @@ int main() {
   testTupleGeneric();
 
   test20();
+  test21();
   return 0;
 }


### PR DESCRIPTION
Closes https://github.com/Cray/chapel-private/issues/6385; prior to this PR, the following program:

```Chapel
var x: 2*int = (7,3);
```

Produced an error:

```
─── error in onetuple.chpl:1 [IncompatibleTypeAndInit] ───
  Type mismatch between declared type of 'x' and initialization expression.
  In the following declaration:
      |
    1 | var x: 2*int = (7,3);
      |        ⎺⎺⎺⎺⎺   ⎺⎺⎺⎺⎺
      |
  the type specifier has type '(int(64), int(64))', while the initial value has type '(int(64), int(64))'.
```

The (chapel syntax) output is quite confusing in the error message, but the difference between the specified type and the actual type are the intents of the components. On the left hand site we have a 'type' tuple, but on the right we have a value tuple.

There is already logic on `main` to adjust the type of the declaration _at the end_ to mark the tuple components 'var' or 'ref', etc. However, the type-value mismatch happens while the type of the declaration is being inferred, before the final adjustment. The solution seems to be to adjust the type of the tuple's components using the same rules as "usual" (described, I believe, in the [specification here](https://chapel-lang.org/docs/language/spec/tuples.html#tuple-argument-intents)). So, this PR extracts the "adjustment" process, runs it once on the type expression to ensure it's compatible with the value, then again on the final type.

Reviewed by @benharsh -- thanks!

## Testing
- [x] dyno tests