### PR TITLE
annotations for release-over-release 2.2 triage

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -582,6 +582,12 @@ all:
   06/17/24:
     - text: Revert to default GASNET_SND_THREAD=0 (#25307)
       config: 16-node-apollo-hdr
+  08/12/24:
+    - Update bundled qthreads to 1.20 (#25210)
+      config: chapcs
+  08/28/24:
+    - Qthreads Adjust Fences To Fix Perf Regression (#25833)
+      config: chapcs
 
 # End all
 
@@ -901,7 +907,6 @@ empty-chpl-barrier.ml-time:
   06/26/21:
     - Optimize allLocalesBarrier by reducing communication (#17978)
 
-
 exchange:
   04/18/19:
     - Enable bulk-transfer for BlockDist by default (#12797)
@@ -909,6 +914,8 @@ exchange:
     - Fix some issues with constant domain optimization (#16397)
   09/29/20:
     - Remove an unneeded assignment from array view slice initializer (#16477)
+  09/04/24:
+    - Extend array view elision to Block, Cyclic and Stencil (#25869)
 
 fannkuch-redux:
   07/22/14:
@@ -998,6 +1005,8 @@ ft-a:
 heat_2d_dist.ml-time:
   08/31/23:
     - Optimize swap operation for Cyclic and Stencil distributions (#23019)
+  09/04/24:
+    - Extend array view elision to Block, Cyclic and Stencil (#25869)
 
 hpl:
   12/11/15:
@@ -1572,6 +1581,8 @@ mg: &mg-base
 
 mg-b:
   <<: *mg-base
+  08/19/24:
+    - Stencil Distribution performance improvments (#25701)
 
 mg.ml-time:
   05/11/17:
@@ -1606,6 +1617,9 @@ miniMD:
     - Enable bulk-transfer for BlockDist by default (#12797)
   03/13/20:
     -  Reallocate 1D arrays in place, when possible (#15177)
+  07/08/24:
+    - Implement array view elision (#24390)
+
 
 miniMD.ml-time:
   09/14/17:
@@ -1844,6 +1858,9 @@ return-array-8: &return-array-base
     - remove unnecessary return from array-return tests (#5486)
   05/01/18:
     - Enable variables declared with generic type (#9355)
+  09/10/24:
+    - Avoid array allocation for moving to equal domain (#25896)
+
 return-array-20000000:
   <<: *return-array-base
 return-array-40000000:
@@ -2094,16 +2111,6 @@ thread-ring:
     - Prevent serialization from qthread sync vars (#9737)
   08/30/18:
     - Reduce hugepage waste from call stacks (#10254)
-  08/12/24:
-    - Update bundled qthreads to 1.20 (#25210)
-  08/28/24:
-    - Qthreads Adjust Fences To Fix Perf Regression (#25833)
-
-twopt-buildtrees:
-  08/12/24:
-    - Update bundled qthreads to 1.20 (#25210)
-  08/28/24:
-    - Qthreads Adjust Fences To Fix Perf Regression (#25833)
 
 time_array_vs_ddata:
   05/31/14:

--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -583,10 +583,10 @@ all:
     - text: Revert to default GASNET_SND_THREAD=0 (#25307)
       config: 16-node-apollo-hdr
   08/12/24:
-    - Update bundled qthreads to 1.20 (#25210)
+    - text: Update bundled qthreads to 1.20 (#25210)
       config: chapcs
   08/28/24:
-    - Qthreads Adjust Fences To Fix Perf Regression (#25833)
+    - text: Qthreads Adjust Fences To Fix Perf Regression (#25833)
       config: chapcs
 
 # End all


### PR DESCRIPTION
- moved qthreads update/patch annotations to apply to all chapcs graphs (since they seem to impact a slew of graphs and not just the 2 I previously had annotated).
- annotation for "Avoid array allocation for moving to equal domain" to "array return performance" graph
- annotation for AVE to apply to miniMD graph
- annotation for AVE on "2D Heat Solver" graph
- annotation for "Stencil Distribution performance improvments" to NPB MG Time Size B
