### PR TITLE
Update Sort module documentation

### DIFF
--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -40,6 +40,12 @@
       - clear
       - sort
 
+      .. warning::
+
+        :proc:`list.sort<List.list.sort>` is deprecated - please use the
+        :proc:`sort(x: list)<Sort.sort>` procedure from the
+        :mod:`Sort` module instead
+
   Additionally, all references to list elements are invalidated when the list
   is deinitialized.
 


### PR DESCRIPTION
Update the sort module documentation based on the work done in the sort module stabilization subteam.

On a high level
- Added a short intro with a few examples of using `proc sort`, before this change it was a bit wierd to just see Comparators as the first thing in the sort module docs.
- Edited the comparators section to mention the new prescribed way to create and use custom comparators using the newly created interfaces.
- Went over the rest of the doc to update other things that have changed like argument names