### PR TITLE
GPU technote updates for 2.2

### DIFF
--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -5,10 +5,16 @@
 GPU Programming
 ===============
 
-Chapel can be used to program GPUs. The `GPU Programming in Chapel series
-<https://chapel-lang.org/blog/series/gpu-programming-in-chapel/>`_ is a good
-resource for getting started with GPU programming in Chapel. This technote has
-some examples, but it is closer to a reference manual than a tutorial.
+Chapel enables developers to use parallelism at different levels: from
+intra-node multicore parallelism, to cross-node distributed parallelism, to
+GPUs. This technote serves as a reference on how to use Chapel to program GPUs.
+Specifically, it gives a quick overview of GPU programming, includes a handful
+of examples, discusses system requirements and current limitations for GPU
+support, and delves into more details on some specific GPU-related features.
+
+Readers preferring a more tutorial-like introduction to Chapel's GPU support,
+may also wish to look at our `GPU Programming in Chapel
+<https://chapel-lang.org/blog/series/gpu-programming-in-chapel/>`_ blog series.
 
 .. warning::
 

--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -163,9 +163,7 @@ The following are further requirements for GPU support:
     installations come with LLVM. Setting ``CHPL_LLVM=system`` will allow you to
     use that LLVM.
 
-  * For ROCm 6.x, only ``CHPL_LLVM=bundled`` is supported. The bundled LLVM is
-    version 18 with a patch to support ROCm 6. Said patch is in LLVM 19, as such
-    we expect to support system LLVM 19+ with ROCm 6 in the upcoming releases.
+  * For ROCm 6.x, only ``CHPL_LLVM=bundled`` is supported.
 
 * Specifically for using the `CPU-as-Device mode`_:
 

--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -666,6 +666,10 @@ for more information on using Chapel with WSL.
 
 Further Information
 -------------------
+* The `GPU Programming in Chapel series
+  <https://chapel-lang.org/blog/series/gpu-programming-in-chapel/>`_ is a good
+  resource for getting started with GPU programming in Chapel.
+
 * Please refer to issues with `GPU Support label
   <https://github.com/chapel-lang/chapel/labels/area%3A%20GPU%20Support>`_ for
   other known limitations and issues.


### PR DESCRIPTION
Some changes to call out here:

- More confident tone, where Intel limitation is removed from the first paragraph and replaced with a link to the blog series
- Replacing the focus on `foreach`/`forall` with order-independent statements to cover promotion and reduction
- Highlight `reduce` expressions more than the standalone functions
- Massaging the language around ROCm 6 and LLVM versions