### PR TITLE
Dyno: Improve initializers on classes that inherit

### DIFF
--- a/frontend/lib/resolution/InitResolver.cpp
+++ b/frontend/lib/resolution/InitResolver.cpp
@@ -734,7 +734,9 @@ bool InitResolver::handleAssignmentToField(const OpCall* node) {
 
   // TODO: Is 'field' or 'this.field' too strict of a pattern?
   auto [fieldId, isSuperField] = fieldIdFromPossibleMentionOfField(lhs);
-  if (fieldId.isEmpty()) return false;
+
+  // parent fields already evaluated by 'handleUseOfField'
+  if (fieldId.isEmpty() || isSuperField) return false;
 
   auto state = fieldStateFromId(fieldId);
   CHPL_ASSERT(state);

--- a/frontend/lib/resolution/InitResolver.cpp
+++ b/frontend/lib/resolution/InitResolver.cpp
@@ -623,19 +623,12 @@ bool InitResolver::handleCallToSuperInit(const FnCall* node,
 
 void InitResolver::updateSuperType(const CallResolutionResult* c) {
   auto& msc = c->mostSpecific().only();
-  auto superThis = msc.formalActualMap().byFormalIdx(0).formalType();
+  auto superThis = msc.formalActualMap().byFormalIdx(0).formalType().type();
 
-  const BasicClassType* superType = nullptr;
-  if (auto ct = superThis.type()->toClassType()) {
-    superType = ct->basicClassType();
-  } else {
-    superType = superThis.type()->toBasicClassType();
-  }
-
-  this->superType_ = superType;
+  this->superType_ = superThis->getCompositeType()->toBasicClassType();
 
   // Only update the current receiver if the parent was generic.
-  if (superType->instantiatedFromCompositeType() != nullptr) {
+  if (superType_->instantiatedFromCompositeType() != nullptr) {
     updateResolverVisibleReceiverType();
   }
 

--- a/frontend/lib/resolution/InitResolver.cpp
+++ b/frontend/lib/resolution/InitResolver.cpp
@@ -139,7 +139,7 @@ void InitResolver::doSetupInitialState(void) {
   phase_ = isCallToSuperInitRequired() ? PHASE_NEED_SUPER_INIT
                                        : PHASE_NEED_COMPLETE;
 
-  std::ignore = setupFromType(currentRecvType_);
+  std::ignore = setupFromType(initialRecvType_);
 }
 
 void InitResolver::markComplete() {
@@ -542,10 +542,9 @@ std::pair<ID,bool> InitResolver::fieldIdFromPossibleMentionOfField(const AstNode
       if (dot->field() != "init" &&
           (ident->name() == "this" || ident->name() == "super")) {
         auto ct = currentRecvType_->getCompositeType();
-        auto ad = parsing::idToAst(ctx_, ct->id())->toAggregateDecl();
 
-        if (auto decl = findFieldByName(ctx_, ad, ct, dot->field())) {
-          return {decl->id(), !ad->id().contains(decl->id())};
+        if (auto decl = findFieldByName(ctx_, aggregateDecl_, ct, dot->field())) {
+          return {decl->id(), !aggregateDecl_->id().contains(decl->id())};
         }
       }
     }
@@ -556,9 +555,7 @@ std::pair<ID,bool> InitResolver::fieldIdFromPossibleMentionOfField(const AstNode
     // Note: Assumes an Identifier resolving to a field is a reliable
     // indication that the field belongs to the type being initialized.
     if (!fieldID.isEmpty() && parsing::idIsField(ctx_, fieldID)) {
-      auto ct = currentRecvType_->getCompositeType();
-      auto ad = parsing::idToAst(ctx_, ct->id())->toAggregateDecl();
-      return {fieldID, !ad->id().contains(fieldID)};
+      return {fieldID, !aggregateDecl_->id().contains(fieldID)};
     }
   }
 

--- a/frontend/lib/resolution/InitResolver.h
+++ b/frontend/lib/resolution/InitResolver.h
@@ -55,6 +55,7 @@ class InitResolver {
   Resolver& initResolver_;
   const uast::Function* fn_;
   const types::Type* initialRecvType_;
+  const uast::AggregateDecl* aggregateDecl_;
 
   std::map<ID, FieldInitState> fieldToInitState_;
   std::vector<ID> fieldIdsByOrdinal_;
@@ -79,6 +80,8 @@ class InitResolver {
         initResolver_(visitor),
         fn_(fn),
         initialRecvType_(recvType) {
+    auto typeID = initialRecvType_->getCompositeType()->id();
+    aggregateDecl_ = parsing::idToAst(ctx_, typeID)->toAggregateDecl();
     return;
   }
 

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -3947,6 +3947,9 @@ void Resolver::handleCallExpr(const uast::Call* call) {
     // To resolve this problem, manually compute the fully-generic type that
     // is being initialized and reset the receiver.
     //
+    // Note: erroneous field accesses will be handled by invoking
+    // ``InitResolver::handleResolvedCall`` below.
+    //
     // TODO: Move this logic into InitResolver.cpp - but where?
     if (initResolver && ci.name() == USTR("init")) {
       auto gt = ci.isMethodCall() ? ci.calledType() : receiverType;

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -3273,6 +3273,16 @@ void Resolver::resolveIdentifier(const Identifier* ident) {
       return;
     }
 
+    validateAndSetToId(result, ident, id);
+
+    // Before computing the type, handle field use inside an initializer.
+    //
+    // NB: this is important for parent fields, which may result in an
+    //   implicit 'super.init()' call, which may instantiate a generic field.
+    if (initResolver) {
+      std::ignore = initResolver->handleUseOfField(ident);
+    }
+
     // Attempt to lookup an outer variable.
     if (!lookupOuterVariable(type, ident, id)) {
 
@@ -3327,7 +3337,7 @@ void Resolver::resolveIdentifier(const Identifier* ident) {
       // have `this` inserted, as well as whether or not to turn this
       // into a parenless call.
 
-      // Fall through to validateAndSetToId
+      // Fall through
     } else if (scopeResolveOnly &&
                type.kind() == QualifiedType::FUNCTION) {
       // Possibly a "compatibility hack" with production: we haven't checked
@@ -3335,10 +3345,9 @@ void Resolver::resolveIdentifier(const Identifier* ident) {
       // care and assumes `ident` points to this function. Setting
       // the toId also helps determine if this is a method call
 
-      // Fall through to validateAndSetToId
+      // Fall through
     }
 
-    validateAndSetToId(result, ident, id);
     result.setType(type);
     // if there are multiple ids we should have gotten
     // a multiple definition error at the declarations.
@@ -3346,13 +3355,8 @@ void Resolver::resolveIdentifier(const Identifier* ident) {
 }
 
 bool Resolver::enter(const Identifier* ident) {
-  if (initResolver && initResolver->handleResolvingFieldAccess(ident)) {
-    std::ignore = initResolver->handleUseOfField(ident);
-    return false;
-  } else {
-    resolveIdentifier(ident);
-    return false;
-  }
+  resolveIdentifier(ident);
+  return false;
 }
 
 void Resolver::exit(const Identifier* ident) {
@@ -3792,9 +3796,17 @@ void Resolver::prepareCallInfoActuals(const Call* call,
 
 static const Type* getGenericType(Context* context, const Type* recv) {
   const Type* gen = nullptr;
-  if (auto cur = recv->toCompositeType()) {
+  if (auto cur = recv->toRecordType()) {
     gen = cur->instantiatedFromCompositeType();
     if (gen == nullptr) gen = cur;
+  } else if (auto bct = recv->toBasicClassType()) {
+    if (bct->parentClassType()->instantiatedFromCompositeType()) {
+      auto pt = getGenericType(context, bct->parentClassType())->toBasicClassType();
+      bct = BasicClassType::get(context, bct->id(), bct->name(), pt, bct->instantiatedFrom(), bct->substitutions());
+    }
+
+    gen = bct->instantiatedFromCompositeType();
+    if (gen == nullptr) gen = bct;
   } else if (auto cur = recv->toClassType()) {
     auto m = getGenericType(context, cur->manageableType());
     gen = ClassType::get(context, m->toManageableType(),
@@ -3928,21 +3940,22 @@ void Resolver::handleCallExpr(const uast::Call* call) {
   if (!skip) {
     QualifiedType receiverType = methodReceiverType();
 
-    // Calling initializer without qualifier, e.g., `init(a, b, c);``
-    //
     // If the user has mistakenly instantiated a field of the type before
     // calling ``init``, then the receiver type will either be fully or
     // partially instantiated. This will cause a failure to resolve the
     // ``init`` call, and result in a confusing and unhelpful error message.
+    // To resolve this problem, manually compute the fully-generic type that
+    // is being initialized and reset the receiver.
     //
-    // Instead, whenever we see this kind of 'init' call, we will set the
-    // receiver type to be fully-generic as if the user had not instantiated
-    // any fields. This matches the behavior when calling ``this.init(...)``,
-    // where ``this`` is treated as fully-generic.
-    if (initResolver &&
-        ci.name() == USTR("init") && ci.isMethodCall() == false) {
-      auto gen = getGenericType(context, receiverType.type());
+    // TODO: Move this logic into InitResolver.cpp - but where?
+    if (initResolver && ci.name() == USTR("init")) {
+      auto gt = ci.isMethodCall() ? ci.calledType() : receiverType;
+      auto gen = getGenericType(context, gt.type());
       receiverType = QualifiedType(QualifiedType::INIT_RECEIVER, gen);
+
+      if (ci.isMethodCall()) {
+        ci = CallInfo::createWithReceiver(ci, receiverType);
+      }
     }
 
     std::vector<ApplicabilityResult>* rejected = nullptr;
@@ -3980,8 +3993,12 @@ void Resolver::exit(const Call* call) {
 }
 
 bool Resolver::enter(const Dot* dot) {
-  if (initResolver && initResolver->handleResolvingFieldAccess(dot))
-    return false;
+  // Need to handle fields before the compiler-generated accessor, in case
+  // an implicit super.init() instantiates a generic field.
+  if (initResolver) {
+    initResolver->handleUseOfField(dot);
+  }
+
   return true;
 }
 
@@ -4061,8 +4078,6 @@ QualifiedType Resolver::typeForEnumElement(const EnumType* enumType,
 }
 
 void Resolver::exit(const Dot* dot) {
-  if (initResolver && initResolver->handleUseOfField(dot)) return;
-
   ResolvedExpression& receiver = byPostorder.byAst(dot->receiver());
 
   bool deferToFunctionResolution = false;
@@ -4219,6 +4234,8 @@ void Resolver::exit(const Dot* dot) {
 
   if (scopeResolveOnly || deferToFunctionResolution)
     return;
+
+  // TODO: Unique error for user-defined field accessor
 
   // resolve a.x where a is a record/class and x is a field or parenless method
   std::vector<CallInfoActual> actuals;

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -5337,7 +5337,7 @@ const Decl* findFieldByName(Context* context,
   const Decl* ret = nullptr;
 
   for (auto decl : ad->children()) {
-    if (auto named = decl->toNamedDecl()) {
+    if (auto named = decl->toVarLikeDecl()) {
       if (named->name() == name) {
         ret = named;
         break;
@@ -5364,8 +5364,10 @@ const Decl* findFieldByName(Context* context,
   if (ret == nullptr && ct != nullptr) {
     if (auto bct = ct->toBasicClassType()) {
       if (auto parent = bct->parentClassType()) {
-        auto parentAD = parsing::idToAst(context, parent->id())->toAggregateDecl();
-        ret = findFieldByName(context, parentAD, parent, name);
+        if (parent->isObjectType() == false) {
+          auto parentAD = parsing::idToAst(context, parent->id())->toAggregateDecl();
+          ret = findFieldByName(context, parentAD, parent, name);
+        }
       }
     }
   }

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -454,8 +454,15 @@ CallInfo CallInfo::createWithReceiver(const CallInfo& ci,
                                       UniqueString rename) {
   std::vector<CallInfoActual> newActuals;
   newActuals.push_back(CallInfoActual(receiverType, USTR("this")));
+
+  // Replace existing 'this' in 'ci'
+  int off = 0;
+  if (ci.isMethodCall() && ci.actual(0).byName() == "this") {
+    off = 1;
+  }
+
   // append the other actuals
-  newActuals.insert(newActuals.end(), ci.actuals_.begin(), ci.actuals_.end());
+  newActuals.insert(newActuals.end(), ci.actuals_.begin() + off, ci.actuals_.end());
 
   if (ci.name() == USTR("init")) {
     // For calls to 'init', tag the receiver with a special intent to


### PR DESCRIPTION
This PR improves support for initializers on classes that inherit. With this commit dyno now supports:
- implicit 'super.init' calls
- errors for accessing parent fields before 'super.init'
- usage of initialized fields part-way through initializing the whole type

This PR updates the Resolver to rely somewhat less on 'InitResolver' for explicitly handling ``Identifier`` and ``Dot`` uAST nodes. Instead we continue to rely on established Resolver mechanisms and selectively invoke the ``InitResolver`` when appropriate.

This PR also improves a fix within 'handleCallExpr' originally meant to support receiver-less 'init' calls. Instead, this fix is adapted to any 'init' call within an initializer, and will replace or create the receiver using a fully-generic type. This is done in case the user has erroneously initialized fields prior to the explicit 'init' call. I plan on moving this behavior into ``InitResolver`` in the future.

------------------

The ``fieldIdFromPossibleMentionOfField`` helper method is updated to return a field ID (if found) and whether that field is a parent field.

Some logic from ``handleCallToSuperInit`` is split off into a new ``updateSuperType`` method to better support the implicit 'super.init' case.

Minor fixes to ``findFieldByName``
- Use ``VarLikeDecl`` instead, as ``NamedDecl`` can match primary methods.
- Do not continue searching upwards if the parent class is the root class.

Lastly, this commit adds tests for newly supported initializer behavior.

- [x] test-dyno