### PR TITLE
Update LLVM's license to Apache 2.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -48,7 +48,7 @@ The Chapel implementation is composed of two categories of code:
      jemalloc         alternative memory allocator                 BSD-like
      libfabric        portable networking library                  BSD
      libunwind        used for runtime stack tracing               MIT
-     llvm             CLANG C parsing/optional back-end compiler   U of I/NCSA
+     llvm             CLANG C parsing/optional back-end compiler   Apache 2.0
      qthread          alternative lightweight tasking option       new BSD
      re2              optional regular expression parsing library  new BSD
      utf8-decoder     used for runtime UTF-8 string decoding       MIT


### PR DESCRIPTION
While reviewing some of our third-party licenses, I happened to notice that the copy of LLVM we redistribute is actually Apache 2.0 licensed, meaning our file was out of date.

The last release with UIUC license was LLVM 8 although some later releases have legacy licenses with UIUC.

The license was changed to Apache License v2.0 with LLVM Exceptions in llvm-project commit 469bdefd448b76c5adcdd67256e9a44fabf7e027 in Jan 2019.

Docs https://llvm.org/docs/DeveloperPolicy.html#legacy indicate some of LLVM still uses the old license but as far as we know, nothing that Chapel uses falls into that category.