### PR TITLE
Update AWS docs to suggest binary distributions

### DIFF
--- a/doc/rst/platforms/aws.rst
+++ b/doc/rst/platforms/aws.rst
@@ -245,8 +245,8 @@ using the AWS session manager.
 Getting Chapel
 --------------
 
-If you are using an OS that has a pre-built binary for Chapel, you can download
-and install it using the system package manager.
+If you are using an OS that has a pre-built libfabric+slurm binary for Chapel,
+you can download and install it using the system package manager.
 For example, to install Chapel 2.2 on Ubuntu 22.04:
 
 .. code-block:: bash

--- a/doc/rst/platforms/aws.rst
+++ b/doc/rst/platforms/aws.rst
@@ -245,6 +245,7 @@ using the AWS session manager.
 Getting Chapel
 --------------
 
+Once connected to the instance via ssh, you need to install Chapel.
 If you are using an OS that has a pre-built libfabric+slurm binary for Chapel,
 you can download and install it using the system package manager.
 For example, to install Chapel 2.2 on Ubuntu 22.04:
@@ -257,9 +258,9 @@ For example, to install Chapel 2.2 on Ubuntu 22.04:
 If there is no pre-built binary for your OS, you can build Chapel from source.
 
 Building Chapel from Source
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+***************************
 
-Once connected to the instance via ssh, do the following:
+To build Chapel from source for use on the cluster, follow these steps:
 
 * Install the dependencies as shown on the :ref:`readme-prereqs-installation` page.
 
@@ -297,7 +298,8 @@ Running Chapel Programs
 
 A few final steps are left to configure the environment to run Chapel programs.
 These are required regardless of whether Chapel was installed from a package or
-built from source. This can be done by adding the following to your ``.bashrc``:
+built from source. These environment variables should be set before running any
+Chapel code. Users may wish to add this to their ``.bashrc``:
 
 .. code-block:: bash
 

--- a/doc/rst/platforms/aws.rst
+++ b/doc/rst/platforms/aws.rst
@@ -258,7 +258,7 @@ For example, to install Chapel 2.2 on Ubuntu 22.04:
 If there is no pre-built binary for your OS, you can build Chapel from source.
 
 Building Chapel from Source
-***************************
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To build Chapel from source for use on the cluster, follow these steps:
 

--- a/doc/rst/platforms/aws.rst
+++ b/doc/rst/platforms/aws.rst
@@ -242,8 +242,22 @@ using the AWS session manager.
    user (for Ubuntu, use ``sudo su ubuntu``). Then run ``cd`` to go to the home
    directory.
 
-Building Chapel
----------------
+Getting Chapel
+--------------
+
+If you are using an OS that has a pre-built binary for Chapel, you can download
+and install it using the system package manager.
+For example, to install Chapel 2.2 on Ubuntu 22.04:
+
+.. code-block:: bash
+
+    wget https://github.com/chapel-lang/chapel/releases/download/2.2.0/chapel-ofi-slurm-2.2.0-1.ubuntu22.amd64.deb
+    sudo apt install ./chapel-ofi-slurm-2.2.0-1.ubuntu22.amd64.deb
+
+If there is no pre-built binary for your OS, you can build Chapel from source.
+
+Building Chapel from Source
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Once connected to the instance via ssh, do the following:
 
@@ -265,49 +279,10 @@ Once connected to the instance via ssh, do the following:
       export CHPL_COMM=ofi
       export CHPL_LAUNCHER=slurm-srun
       export CHPL_COMM_OFI_OOB=pmi2
-      export SLURM_MPI_TYPE=pmi2
-
-      # if using a cluster without EFA, use FI_PROVIDER=tcp instead
-      export FI_PROVIDER=efa
 
       export CHPL_LIBFABRIC=system
       export PKG_CONFIG_PATH=/opt/amazon/efa/lib64/pkgconfig/
       export CHPL_LD_FLAGS="-L/opt/slurm/lib/ -Wl,-rpath,/opt/slurm/lib/"
-
-      export CHPL_RT_COMM_OFI_DEDICATED_AMH_CORES=true
-      export CHPL_RT_COMM_OFI_CONNECT_EAGERLY=true
-
-   Due to limitations in the number of pages that can be registered with EFA,
-   by default Chapel will try and use transparent huge pages. Make sure your
-   cluster has transparent huge pages enabled and has enough huge pages.
-
-   .. code-block:: bash
-
-      NUM_NODES=<max number of nodes in your cluster>
-      NUM_PAGES=<number of pages to use>
-      echo always | srun --nodes $NUM_NODES sudo tee /sys/kernel/mm/transparent_hugepage/enabled >/dev/null
-      echo $NUM_PAGES | srun --nodes $NUM_NODES sudo tee /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages >/dev/null
-
-   .. note::
-
-       Setting more huge pages than there is memory on the system can cause the
-       system to hang. Make sure to set the number of huge pages to a value
-       that is less than the total memory on the system (you can query this
-       with ``srun lsmem``). If you set it too low, you may get out of memory
-       errors when running Chapel programs. Try increasing the number of huge
-       pages or set a max heap size with ``CHPL_RT_MAX_HEAP_SIZE``.
-
-   If you wish to not use transparent huge pages, set ``export
-   CHPL_RT_COMM_OFI_THP_HINT=0``. Depending on your system, you my also need to
-   set ``CHPL_RT_MAX_HEAP_SIZE`` to a value less than ``96G``.
-
-   For best performance, users should also set ``export
-   FI_EFA_USE_DEVICE_RDMA=1``. This enables higher network performance by using
-   the RDMA capabilities of EFA, but it is only available on newer instances.
-   If you are unsure if your instance supports this, try setting it and running
-   a Chapel program. If the program fails with an error about
-   ``FI_EFA_USE_DEVICE_RDMA``, then your instance does not support this
-   feature.
 
    If using a GPU instance, use the following in addition to the above:
 
@@ -319,6 +294,54 @@ Once connected to the instance via ssh, do the following:
 
 Running Chapel Programs
 -----------------------
+
+A few final steps are left to configure the environment to run Chapel programs.
+These are required regardless of whether Chapel was installed from a package or
+built from source. This can be done by adding the following to your ``.bashrc``:
+
+.. code-block:: bash
+
+   export SLURM_MPI_TYPE=pmi2
+   # if using a cluster without EFA, use FI_PROVIDER=tcp instead
+   export FI_PROVIDER=efa
+
+   # these are not required, but can improve performance
+   export CHPL_RT_COMM_OFI_DEDICATED_AMH_CORES=true
+   export CHPL_RT_COMM_OFI_CONNECT_EAGERLY=true
+
+
+For best performance, users should also set ``export
+FI_EFA_USE_DEVICE_RDMA=1``. This enables higher network performance by using
+the RDMA capabilities of EFA, but it is only available on newer instances.
+If you are unsure if your instance supports this, try setting it and running
+a Chapel program. If the program fails with an error about
+``FI_EFA_USE_DEVICE_RDMA``, then your instance does not support this
+feature.
+
+Lastly, due to limitations in the number of pages that can be registered with EFA,
+by default Chapel will try and use transparent huge pages. Make sure your
+cluster has transparent huge pages enabled and has enough huge pages.
+
+.. code-block:: bash
+
+  NUM_NODES=<max number of nodes in your cluster>
+  NUM_PAGES=<number of pages to use>
+  echo always | srun --nodes $NUM_NODES sudo tee /sys/kernel/mm/transparent_hugepage/enabled >/dev/null
+  echo $NUM_PAGES | srun --nodes $NUM_NODES sudo tee /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages >/dev/null
+
+.. note::
+
+    Setting more huge pages than there is memory on the system can cause the
+    system to hang. Make sure to set the number of huge pages to a value
+    that is less than the total memory on the system (you can query this
+    with ``srun lsmem``). If you set it too low, you may get out of memory
+    errors when running Chapel programs. Try increasing the number of huge
+    pages or set a max heap size with ``CHPL_RT_MAX_HEAP_SIZE``.
+
+If you wish to not use transparent huge pages, set ``export
+CHPL_RT_COMM_OFI_THP_HINT=0``. Depending on your system, you my also need to
+set ``CHPL_RT_MAX_HEAP_SIZE`` to a value less than ``96G``.
+
 
 If all of the above steps have been completed successfully, you should be able
 to use your cluster to run Chapel programs. If you have a cluster with 4 or


### PR DESCRIPTION
Update the AWS docs to suggest to users that they use binary distributions when they are available.

Also restructured the docs to separate buildtime env vars and runtime env vars

[Reviewed by @jhh67]