### PR TITLE
Enable using receiver scope info in param loop resolution

### DIFF
--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -503,7 +503,6 @@ Resolver::paramLoopResolver(Resolver& parent,
   ret.declStack = parent.declStack;
   ret.byPostorder.setupForParamLoop(loop, parent.byPostorder);
   ret.typedSignature = parent.typedSignature;
-  ret.allowReceiverScopes = parent.allowReceiverScopes;
 
   return ret;
 }
@@ -650,15 +649,15 @@ bool Resolver::getMethodReceiver(QualifiedType* outType, ID* outId) {
 }
 
 const ReceiverScopeHelper* Resolver::getMethodReceiverScopeHelper() {
+  auto fn = symbol->toFunction();
+  if (!fn && parentResolver)
+    return parentResolver->getMethodReceiverScopeHelper();
+
   if (!allowReceiverScopes) {
     // can't use receiver scopes yet
     // (e.g. we are computing the type of 'this' & otherwise that would recurse)
     return nullptr;
   }
-
-  auto fn = symbol->toFunction();
-  if (!fn && parentResolver)
-    return parentResolver->getMethodReceiverScopeHelper();
 
   if (!receiverScopesComputed) {
     receiverScopeHelper = nullptr;

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -503,13 +503,7 @@ Resolver::paramLoopResolver(Resolver& parent,
   ret.declStack = parent.declStack;
   ret.byPostorder.setupForParamLoop(loop, parent.byPostorder);
   ret.typedSignature = parent.typedSignature;
-
-  // Copy method receiver information
   ret.allowReceiverScopes = parent.allowReceiverScopes;
-  ret.receiverScopesComputed = parent.receiverScopesComputed;
-  ret.methodHelperComputed = parent.methodHelperComputed;
-  ret.receiverScopeHelper = parent.receiverScopeHelper;
-  ret.methodLookupHelper = parent.methodLookupHelper;
 
   return ret;
 }
@@ -666,6 +660,7 @@ const ReceiverScopeHelper* Resolver::getMethodReceiverScopeHelper() {
     receiverScopeHelper = nullptr;
 
     auto fn = symbol->toFunction();
+    if (!fn && parentResolver) fn = parentResolver->symbol->toFunction();
     if (fn && fn->isMethod()) {
       if (!scopeResolveOnly) {
         if (typedSignature != nullptr) {

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -504,6 +504,13 @@ Resolver::paramLoopResolver(Resolver& parent,
   ret.byPostorder.setupForParamLoop(loop, parent.byPostorder);
   ret.typedSignature = parent.typedSignature;
 
+  // Copy method receiver information
+  ret.allowReceiverScopes = parent.allowReceiverScopes;
+  ret.receiverScopesComputed = parent.receiverScopesComputed;
+  ret.methodHelperComputed = parent.methodHelperComputed;
+  ret.receiverScopeHelper = parent.receiverScopeHelper;
+  ret.methodLookupHelper = parent.methodLookupHelper;
+
   return ret;
 }
 

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -656,11 +656,13 @@ const ReceiverScopeHelper* Resolver::getMethodReceiverScopeHelper() {
     return nullptr;
   }
 
+  auto fn = symbol->toFunction();
+  if (!fn && parentResolver)
+    return parentResolver->getMethodReceiverScopeHelper();
+
   if (!receiverScopesComputed) {
     receiverScopeHelper = nullptr;
 
-    auto fn = symbol->toFunction();
-    if (!fn && parentResolver) fn = parentResolver->symbol->toFunction();
     if (fn && fn->isMethod()) {
       if (!scopeResolveOnly) {
         if (typedSignature != nullptr) {

--- a/frontend/test/resolution/testMethodCalls.cpp
+++ b/frontend/test/resolution/testMethodCalls.cpp
@@ -823,30 +823,61 @@ static void test16() {
 }
 
 static void test17() {
-  // Test resolving parenless calls from within param for loop.
-  Context ctx;
-  Context* context = &ctx;
-  ErrorGuard guard(context);
+  // Test resolving method calls from within param for loop.
 
-  std::string program = R"""(
-      class Foo {
-        proc asdf do return 3;
+  // Parenful
+  {
+    Context ctx;
+    Context* context = &ctx;
+    ErrorGuard guard(context);
 
-        proc doSomething() {
-          for param i in 0..2 do
-            return asdf;
+    std::string program = R"""(
+        class Foo {
+          proc asdf() do return 3;
+
+          proc doSomething() {
+            for param i in 0..2 do
+              return asdf();
+          }
         }
-      }
 
-      var f = new Foo();
-      var x = f.doSomething();
-      )""";
+        var f = new Foo();
+        var x = f.doSomething();
+        )""";
 
-  QualifiedType initType = resolveTypeOfXInit(context, program);
-  assert(initType.type());
-  assert(initType.type()->isIntType());
+    QualifiedType initType = resolveTypeOfXInit(context, program);
+    assert(initType.type());
+    assert(initType.type()->isIntType());
 
-  assert(guard.realizeErrors() == 0);
+    assert(guard.realizeErrors() == 0);
+  }
+
+  // Parenless
+  {
+    Context ctx;
+    Context* context = &ctx;
+    ErrorGuard guard(context);
+
+    std::string program = R"""(
+        class Foo {
+          proc asdf do return 3;
+
+          proc doSomething() {
+            for param i in 0..2 do
+              return asdf;
+          }
+        }
+
+        var f = new Foo();
+        var x = f.doSomething();
+        )""";
+
+    QualifiedType initType = resolveTypeOfXInit(context, program);
+    assert(initType.type());
+    assert(initType.type()->isIntType());
+
+    assert(guard.realizeErrors() == 0);
+  }
 }
 
 int main() {

--- a/frontend/test/resolution/testMethodCalls.cpp
+++ b/frontend/test/resolution/testMethodCalls.cpp
@@ -822,6 +822,33 @@ static void test16() {
   }
 }
 
+static void test17() {
+  // Test resolving parenless calls from within param for loop.
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  std::string program = R"""(
+      class Foo {
+        proc asdf do return 3;
+
+        proc doSomething() {
+          for param i in 0..2 do
+            return asdf;
+        }
+      }
+
+      var f = new Foo();
+      var x = f.doSomething();
+      )""";
+
+  QualifiedType initType = resolveTypeOfXInit(context, program);
+  assert(initType.type());
+  assert(initType.type()->isIntType());
+
+  assert(guard.realizeErrors() == 0);
+}
+
 int main() {
   test1();
   test2();
@@ -840,6 +867,7 @@ int main() {
   test14b();
   test15();
   test16();
+  test17();
 
   return 0;
 }


### PR DESCRIPTION
Fix a bug preventing Dyno resolving parenless method calls from within a param for loop in a method.

Fixed by adjusting receiver scope info calculation in the param loop child resolver to defer to (and trigger calculation of) the parent's results.

Resolves https://github.com/Cray/chapel-private/issues/6718.

[reviewer info placeholder]

Testing:
- [x] paratest
- [x] dyno tests