### PR TITLE
Retire passing `chplcheck` `UnusedFormalBug` future

### DIFF
--- a/test/chplcheck/UnusedFormalBug.bad
+++ b/test/chplcheck/UnusedFormalBug.bad
@@ -1,1 +1,0 @@
-UnusedFormalBug.chpl:3: node violates rule UnusedFormal

--- a/test/chplcheck/UnusedFormalBug.chpl
+++ b/test/chplcheck/UnusedFormalBug.chpl
@@ -1,6 +1,0 @@
-module UnusedFormalBug {
-  var A: [1..10] int;
-  proc foo(A) {
-    A[1] = 2;
-  }
-}

--- a/test/chplcheck/UnusedFormalBug.future
+++ b/test/chplcheck/UnusedFormalBug.future
@@ -1,1 +1,0 @@
-bug: `A[...]` should resolve to the formal


### PR DESCRIPTION
Retire the future `test/chplcheck/UnusedFormalBug.chpl` which now passes.

The underlying bug was fixed in https://github.com/chapel-lang/chapel/pull/25954.

[trivial, not reviewed]

Testing:
- [x] `test/chplcheck` tests