### PR TITLE
Enable UnusedFormal linter rule by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,6 +208,7 @@ lint-standard-modules: chplcheck FORCE
 		--internal-prefix "_" \
 		--internal-prefix "chpl_" \
 		--disable-rule "ControlFlowParentheses" \
+		--disable-rule "UnusedFormal" \
 		$(MODULES_TO_LINT)
 
 compile-util-python: FORCE

--- a/doc/rst/tools/chplcheck/chplcheck.rst
+++ b/doc/rst/tools/chplcheck/chplcheck.rst
@@ -202,7 +202,7 @@ checking for unused formals.
 
 .. code-block:: python
 
-   @driver.advanced_rule(default=False)
+   @driver.advanced_rule
    def UnusedFormal(context, root):
        formals = dict()
        uses = set()

--- a/test/chplcheck/PREDIFF
+++ b/test/chplcheck/PREDIFF
@@ -3,7 +3,6 @@
 FLAGS="--enable-rule ConsecutiveDecls"\
 " --enable-rule BoolLitInCondStatement"\
 " --enable-rule UseExplicitModules"\
-" --enable-rule UnusedFormal"\
 " --enable-rule CamelOrPascalCaseVariables"\
 " --enable-rule NestedCoforalls"\
 " --internal-prefix myprefix_ --internal-prefix _"\

--- a/test/chplcheck/Unused.chpl
+++ b/test/chplcheck/Unused.chpl
@@ -33,4 +33,9 @@ module Unused {
 
   myProc(1,2);
   myProcIgnored(1,2);
+
+  var Outer: [1..10] int;
+  proc foo(Outer) {
+    Outer[1] = 2;
+  }
 }

--- a/test/chplcheck/allrules.good
+++ b/test/chplcheck/allrules.good
@@ -17,7 +17,7 @@ Available rules (default rules marked with *):
   * PascalCaseClasses            Warn for classes that are not 'PascalCase'.
   * PascalCaseModules            Warn for modules that are not 'PascalCase'.
   * SimpleDomainAsRange          Warn for simple domains in loops that can be ranges.
-    UnusedFormal                 Warn for unused formals in functions.
+  * UnusedFormal                 Warn for unused formals in functions.
   * UnusedLoopIndex              Warn for unused index variables in loops.
   * UnusedTupleUnpack            Warn for unused tuple unpacking, such as '(_, _)'.
     UseExplicitModules           Warn for code that relies on auto-inserted implicit modules.

--- a/test/chplcheck/fixit-interactive/PREDIFF
+++ b/test/chplcheck/fixit-interactive/PREDIFF
@@ -3,7 +3,6 @@
 $CHPL_HOME/tools/chplcheck/chplcheck --enable-rule ConsecutiveDecls \
   --enable-rule BoolLitInCondStatement \
   --enable-rule UseExplicitModules \
-  --enable-rule UnusedFormal \
   --enable-rule CamelOrPascalCaseVariables \
   --enable-rule NestedCoforalls \
   --internal-prefix "myprefix_" --internal-prefix "_" \

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -586,7 +586,7 @@ def register_rules(driver: LintDriver):
             fixit = Fixit.build(Edit(loc.path(), line_start, loc.end(), text))
         return [fixit] if fixit else []
 
-    @driver.advanced_rule(default=False)
+    @driver.advanced_rule
     def UnusedFormal(context: Context, root: AstNode):
         """
         Warn for unused formals in functions.


### PR DESCRIPTION
Enables the UnusedFormal linter rule by default, which was turned off due to confusing bugs.

@riftEmber resolved the known bugs with this rule in https://github.com/chapel-lang/chapel/pull/25954, so this rule can be reenabled by default. 

[Reviewed by @riftEmber]