### PR TITLE
Fix a class/struct mismatch causing build failure on clang

### DIFF
--- a/compiler/include/convert-uast.h
+++ b/compiler/include/convert-uast.h
@@ -30,7 +30,7 @@
 #include "chpl/uast/BuilderResult.h"
 #include "chpl/uast/Module.h"
 
-class Converter;
+struct Converter;
 
 class UastConverter {
  private:


### PR DESCRIPTION
This PR fixes a compilation failure for frontend/ when compiling with clang.

Follow-up to PR #25946.

Reviewed by @jabraham17 - thanks!

- [x] full comm=none testing