### PR TITLE
Restore skipif for ConcurrentMap and EpochManager

### DIFF
--- a/test/library/packages/ConcurrentMap.skipif
+++ b/test/library/packages/ConcurrentMap.skipif
@@ -1,0 +1,10 @@
+
+# AtomicObjects uses extern blocks
+CHPL_LLVM==none
+# AtomicObjects uses GCC inline assembly (for x86) or a compiler builtin
+# (for arm), so only test it on gcc/clang (which we know support this builtin)
+CHPL_TARGET_COMPILER==cray-prgenv-pgi
+CHPL_TARGET_COMPILER==pgi
+CHPL_TARGET_COMPILER==cray-prgenv-cray
+CHPL_TARGET_COMPILER==intel
+CHPL_TARGET_COMPILER==cray-prgenv-intel

--- a/test/library/packages/EpochManager.skipif
+++ b/test/library/packages/EpochManager.skipif
@@ -1,0 +1,9 @@
+# AtomicObjects uses extern blocks
+CHPL_LLVM==none
+# Depending on architecture, AtomicObjects either uses GCC inline assembly
+# or builtins, so only test it on gcc/clang
+CHPL_TARGET_COMPILER==cray-prgenv-pgi
+CHPL_TARGET_COMPILER==pgi
+CHPL_TARGET_COMPILER==cray-prgenv-cray
+CHPL_TARGET_COMPILER==intel
+CHPL_TARGET_COMPILER==cray-prgenv-intel


### PR DESCRIPTION
Restores skipifs removed in https://github.com/chapel-lang/chapel/pull/25928, only 1 line from the skipif should have been removed

[Reviewed by @stonea]