### PR TITLE
Expand completion support for language server

### DIFF
--- a/tools/chapel-py/src/method-tables/uast-methods.h
+++ b/tools/chapel-py/src/method-tables/uast-methods.h
@@ -66,6 +66,8 @@ CLASS_BEGIN(AstNode)
                std::optional<ScopeObject*>,
 
                return ScopeObject::tryCreate(contextObject, resolution::scopeForId(context, node->id())))
+  PLAIN_GETTER(AstNode, creates_scope, "Returns true if this AST node creates a scope",
+               bool, return chpl::resolution::createsScope(node->tag()))
   PLAIN_GETTER(AstNode, type, "Get the type of this AST node, as a 3-tuple of (kind, type, param).",
                std::optional<QualifiedTypeTuple>,
 

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -702,9 +702,9 @@ class FileInfo:
     @enter
     def _enter_NamedDecl(self, node: chapel.NamedDecl):
         self.def_segments.append(NodeAndRange(node))
-        # s = ScopedNodeAndRange.create(node)
-        # if s:
-        #     self.scope_segments.append(s)
+        s = ScopedNodeAndRange.create(node)
+        if s:
+            self.scope_segments.append(s)
 
     def get_visible_nodes(
         self, pos: Position

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -781,11 +781,11 @@ class FileInfo:
                             d += int(
                                 self.context.context.is_bundled_path(
                                     visible_path
-                                ))
+                                )
+                            )
                             # if not explicitly used, increase the depth by 1
                             d += int(
-                                visible_path
-                                not in files_named_in_use_or_import
+                                visible_path not in files_named_in_use_or_import
                             )
 
                         visible_nodes.append(

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -774,16 +774,17 @@ class FileInfo:
                     if visible_node:
                         d = depth
                         visible_path = visible_node[1].location().path()
-
                         if visible_path != file:
                             # if from a different file, increase the depth by 1
                             d += 1
-                            # if from a bundled path and not explicitly imported, increase the depth by 1
+                            # if from a bundled path increase the depth by 1
                             d += int(
                                 self.context.context.is_bundled_path(
                                     visible_path
-                                )
-                                and visible_path
+                                ))
+                            # if not explicitly used, increase the depth by 1
+                            d += int(
+                                visible_path
                                 not in files_named_in_use_or_import
                             )
 

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -844,11 +844,7 @@ class FileInfo:
         self.use_segments.clear()
         self.def_segments.clear()
         self.scope_segments.clear()
-        import time
-        start_time = time.time()
         self.visit(asts)
-        end_time = time.time()
-        log(f"Rebuilt index for {self.uri} in {end_time - start_time} seconds")
         self.use_segments.sort()
         self.def_segments.sort()
 
@@ -1819,10 +1815,7 @@ def run_lsp():
 
         names = set()
         items = []
-        import time
-        start_time = time.time()
         for name, node, depth in fi.get_visible_nodes(params.position):
-            # log(node)
             if not isinstance(node, chapel.NamedDecl):
                 continue
             # if name is already suggested, skip it
@@ -1836,8 +1829,6 @@ def run_lsp():
             if item:
                 items.append(item)
                 names.add(name)
-        end_time = time.time()
-        log(f"Completion took {end_time - start_time} seconds")
 
         return CompletionList(is_incomplete=False, items=items)
 

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -1807,6 +1807,10 @@ def run_lsp():
         content = MarkupContent(MarkupKind.Markdown, text)
         return Hover(content, range=segment.get_location().range)
 
+    # TODO: can we make use of 'trigger_character' to provide completions?
+    # since we can't parse 'foo.', can we use the presence of a trigger '.' to
+    # read a identifier from the file buffer, lookup the scope for that name,
+    # and provide completions based on that scope?
     @server.feature(TEXT_DOCUMENT_COMPLETION, CompletionOptions())
     async def complete(ls: ChapelLanguageServer, params: CompletionParams):
         text_doc = ls.workspace.get_text_document(params.text_document.uri)

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -711,6 +711,7 @@ class FileInfo:
         """
         Returns the visible nodes at a given position.
         """
+
         def visible_nodes_for_scope(
             name: str, nodes: List[chapel.AstNode], in_bundled_module: bool
         ) -> Optional[Tuple[str, chapel.AstNode]]:

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -756,7 +756,9 @@ class FileInfo:
             # overloaded functions.
             return name, documented_nodes[0]
 
-        def visible_nodes_for_scopes(node: chapel.AstNode, scopes: List[chapel.Scope]):
+        def visible_nodes_for_scopes(
+            node: chapel.AstNode, scopes: List[chapel.Scope]
+        ):
             visible_nodes = []
             file = node.location().path()
             in_bundled_module = self.context.context.is_bundled_path(file)
@@ -778,11 +780,16 @@ class FileInfo:
                             d += 1
                             # if from a bundled path and not explicitly imported, increase the depth by 1
                             d += int(
-                                self.context.context.is_bundled_path(visible_path)
-                                and visible_path not in files_named_in_use_or_import
+                                self.context.context.is_bundled_path(
+                                    visible_path
+                                )
+                                and visible_path
+                                not in files_named_in_use_or_import
                             )
 
-                        visible_nodes.append((visible_node[0], visible_node[1], d))
+                        visible_nodes.append(
+                            (visible_node[0], visible_node[1], d)
+                        )
             return visible_nodes
 
         visible_nodes = []
@@ -790,7 +797,9 @@ class FileInfo:
 
         # node_and_scopes: List[Tuple[chapel.AstNode, List[chapel.Scope]]] = []
         if segment:
-            visible_nodes.extend(visible_nodes_for_scopes(segment.node, segment.scopes))
+            visible_nodes.extend(
+                visible_nodes_for_scopes(segment.node, segment.scopes)
+            )
         else:
             # no segment found, use the top level nodes
             for a in self.get_asts():
@@ -947,7 +956,9 @@ class FileInfo:
 
         return None
 
-    def scope_at_position(self, position: Position) -> Optional[ScopedNodeAndRange]:
+    def scope_at_position(
+        self, position: Position
+    ) -> Optional[ScopedNodeAndRange]:
         """
         Given a position, return the scope that contains it.
         """
@@ -958,8 +969,6 @@ class FileInfo:
             if s.rng.start > position:
                 break
         return found
-
-
 
     def file_lines(self) -> List[str]:
         file_text = self.context.context.get_file_text(

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -942,9 +942,14 @@ class FileInfo:
         """
         Given a position, return the scope that contains it.
         """
+        found = None
         for s in self.scope_segments.elts:
             if s.rng.start <= position <= s.rng.end:
-                return s
+                found = s
+            if s.rng.start > position:
+                break
+        return found
+
 
 
     def file_lines(self) -> List[str]:

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -448,7 +448,6 @@ class ScopedNodeAndRange:
         return ScopedNodeAndRange(node, scopes)
 
     @property
-    @functools.cache
     def rng(self):
         return location_to_range(self.node.location())
 

--- a/tools/chpl-language-server/test/completion.py
+++ b/tools/chpl-language-server/test/completion.py
@@ -1,0 +1,196 @@
+"""
+Test that completion works properly
+"""
+
+import sys
+
+from lsprotocol.types import ClientCapabilities
+from lsprotocol.types import Position, TextDocumentIdentifier
+from lsprotocol.types import CompletionItem, CompletionList, CompletionParams
+from lsprotocol.types import InitializeParams
+import pytest
+import pytest_lsp
+from pytest_lsp import ClientServerConfig, LanguageClient
+
+from util.utils import *
+from util.config import CLS_PATH
+
+
+@pytest_lsp.fixture(
+    config=ClientServerConfig(
+        server_command=[sys.executable, CLS_PATH()],
+        client_factory=get_base_client,
+    )
+)
+async def client(lsp_client: LanguageClient):
+    # Setup
+    params = InitializeParams(capabilities=ClientCapabilities())
+    await lsp_client.initialize_session(params)
+
+    yield
+
+    # Teardown
+    await lsp_client.shutdown_session()
+
+
+async def check_completion_items(
+    client: LanguageClient,
+    doc: TextDocumentIdentifier,
+    pos: Position,
+    expected: typing.List[str],
+) -> typing.List[CompletionItem]:
+    """
+    Check that the names returned by the completion items match what is expected.
+
+    Expected is a list strings of length N that should match the first N completion items.
+    """
+    items = await client.text_document_completion_async(
+        params=CompletionParams(text_document=doc, position=pos)
+    )
+    assert items is not None
+    items = items.items if isinstance(items, CompletionList) else items
+    assert len(items) >= len(expected)
+
+    sorted_items = sorted(items, key=lambda x: (x.sort_text or x.label).lower())
+    print("     ")
+    for expect, item in zip(expected, sorted_items):
+        print(f"Expected: {expect}, Actual: {item.label}")
+        assert item.label == expect
+    return sorted_items
+
+
+@pytest.mark.asyncio
+async def test_empty(client: LanguageClient):
+    """
+    Test that an empty file returns something
+    """
+    test = ";"
+    async with source_file(client, test) as doc:
+        items = await check_completion_items(client, doc, pos((0, 0)), [])
+        assert len(items) > 0
+
+
+@pytest.mark.asyncio
+async def test_basic_completion(client: LanguageClient):
+    """
+    Test basic features
+    """
+    file = """
+            var myGlobal: int;
+            record R {
+              var abc: int;
+              proc foo() { }
+              proc bar(myFormal) {
+                var localVar = 2;
+                forall myIndex in 1..10
+                  with (var myTaskPrivate = abc, var myGlobal = 1) {
+
+                }
+                begin {
+
+                }
+              }
+            }
+            var a = new R();
+            """
+
+    async with source_file(client, file) as doc:
+        global_scope = (pos((0, 0)), ["a", "myGlobal", "R"])
+        r_scope = (pos((2, 0)), ["abc", "bar", "foo"] + global_scope[1])
+        bar_scope = (pos((5, 0)), ["localVar", "myFormal", "this"] + r_scope[1])
+
+        # forall_scope changes where myGlobal is
+        forall_parent_scope_elms = bar_scope[1].copy()
+        forall_parent_scope_elms.remove("myGlobal")
+        forall_scope = (
+            pos((8, 0)),
+            ["myGlobal", "myIndex", "myTaskPrivate"] + forall_parent_scope_elms,
+        )
+
+        begin_scope = (pos((11, 0)), bar_scope[1])
+
+        expected = [global_scope, r_scope, bar_scope, forall_scope, begin_scope]
+        for p, exp in expected:
+            await check_completion_items(client, doc, p, exp)
+
+
+@pytest.mark.asyncio
+async def test_std_lib(client: LanguageClient):
+    """
+    Test that modules can be imported and used
+    """
+    A = """
+        use IO;
+        use B;
+        var mySymbol = 1;
+        """
+    B = """
+        proc foo() { }
+        """
+
+    async with source_files(client, A=A, B=B) as docs:
+        a_scope = (pos((0, 0)), ["mySymbol", "foo"])
+        b_scope = (pos((1, 0)), ["foo"])
+
+        a_completion = await check_completion_items(
+            client, docs("A"), a_scope[0], a_scope[1]
+        )
+        # a should have IO and writef somewhere in the list
+        assert any(
+            [x.label == "IO" or x.label == "writef" for x in a_completion]
+        )
+
+        await check_completion_items(client, docs("B"), b_scope[0], b_scope[1])
+
+        await save_file(client, docs("A"), docs("B"))
+        assert len(client.diagnostics[docs("A").uri]) == 0
+        assert len(client.diagnostics[docs("B").uri]) == 0
+
+
+@pytest.mark.asyncio
+async def test_use_in_module(client: LanguageClient):
+    """
+    Test that modules can be imported and used inside of a module
+    """
+
+    file = """
+            module file {
+              var mySymbol = 1;
+              module M {
+                use Random;
+              }
+            }
+            """
+
+    async with source_file(client, file) as doc:
+        file_scope = (pos((0, 0)), ["M", "mySymbol"])
+        m_scope = (pos((3, 0)), ["M", "mySymbol"])
+
+        await check_completion_items(client, doc, file_scope[0], file_scope[1])
+        m_scope_items = await check_completion_items(
+            client, doc, m_scope[0], m_scope[1]
+        )
+        assert any([x.label == "Random" for x in m_scope_items])
+
+
+@pytest.mark.asyncio
+async def test_use_in_scope(client: LanguageClient):
+    """
+    Test that modules can be imported and used inside of an arbitrary scope
+    """
+
+    file = """
+            proc bar() {
+              use Sort;
+            }
+            ;
+            """
+
+    async with source_file(client, file) as doc:
+        # bar and Sort are at the same "depth", so we can't rely on ordering
+        items = await check_completion_items(client, doc, pos((0, 0)), [])
+        assert any([x.label == "bar" or x.label == "sort" for x in items])
+
+        # outside of the scope, we should only see bar
+        items = await check_completion_items(client, doc, pos((3, 0)), ["bar"])
+        assert all([x.label != "sort" for x in items])


### PR DESCRIPTION
This PR expands upon our existing completion support to be location specific. Prior to this PR, only the module level scope was used to provide completion symbols. This PR changes that, so that visible symbols are computed based upon the users cursor.


With this PR, users will get an auto-complete suggestion of 'myVariable' when 'myV' is typed.
```chapel
record myRecord {
  var  myVariable = 1;
  proc foo() {
    myV
  }
}
```

Implementation details

This PR uses the fact that the FileInfo visits nodes in order when building segments. So in the above example, the scope for `myRecord` is visited before `foo`. As each scope is entered, we keep track of the location, its Scope object, and the parent scopes. This is precomputed before a user ever requests a completion, so that when that occurs it is just a simple lookup.

[Reviewed by @DanilaFe]
