### PR TITLE
add annotations for stencil 2d graph

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -1005,8 +1005,14 @@ ft-a:
 heat_2d_dist.ml-time:
   08/31/23:
     - Optimize swap operation for Cyclic and Stencil distributions (#23019)
+  08/13/24:
+    - Expand auto local access optimization to support basic offsets (#25712)
+  08/19/24:
+    - Stencil Distribution performance improvments (#25701)
   09/04/24:
     - Extend array view elision to Block, Cyclic and Stencil (#25869)
+  09/11/24:
+    - Prevent offset access with block arrays to thwart dynamic ALA (#25933)
 
 hpl:
   12/11/15:


### PR DESCRIPTION
This adds the folllowing annotations to the stencil 2d graph (would be nice to put in release notes):

- https://github.com/chapel-lang/chapel/pull/25712 went in on 8/13 which caused the StencilDist line to meet the StencilDist_localAccess line
- https://github.com/chapel-lang/chapel/pull/25701 went in on 8/19 which improved the performance of both StencilDist versions
- https://github.com/chapel-lang/chapel/pull/25933 when in on 9/11, fixing the slight performance regression in the BlockDist version
