### PR TITLE
add annotation that impacted algorithm used in Akrouda sort tests

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -2540,7 +2540,7 @@ arkouda-array_create:
 arkouda-sort-cases:
   <<: *arkouda-base
   08/07/24:
-    - Closes 3526: refactor argsortMsg to remove registerND annotation (Bears-R-Us/#3602)
+    - Closes 3526 refactor argsortMsg to remove registerND annotation (Bears-R-Us/#3602)
 
 shoc-triad-all-lg:
   11/10/22:

--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -2537,6 +2537,11 @@ arkouda-array_create:
   04/05/24:
     - Closes 3071 Add permutation to our generators (Bears-R-Us/arkouda#3078)
 
+arkouda-sort-cases:
+  <<: *arkouda-base
+  08/07/24:
+    - Closes 3526: refactor argsortMsg to remove registerND annotation (Bears-R-Us/#3602)
+
 shoc-triad-all-lg:
   11/10/22:
     - Ensure we time mem transfer in SHOC Triad (#20961)


### PR DESCRIPTION
This PR adds an annotation to a couple of the Arkouda graphs.

(noted by @jeremiah-corrado): For the sorting tests, the historical behavior was buggy (i.e., for real-valued arrays we were completely ignoring the algorithm argument and always used the LSD algorithm). After https://github.com/Bears-R-Us/arkouda/pull/3602 (merged on 8/7), we are now using the algorithm argument, so the LSD and MSD lines have different performance.
