### PR TITLE
update homebrew release formula to match release version

### DIFF
--- a/util/packaging/homebrew/chapel-release.rb
+++ b/util/packaging/homebrew/chapel-release.rb
@@ -1,19 +1,18 @@
 class Chapel < Formula
   desc "Programming language for productive parallel computing at scale"
   homepage "https://chapel-lang.org/"
-  url "https://github.com/chapel-lang/chapel/releases/download/2.1.0/chapel-2.1.0.tar.gz"
-  sha256 "72593c037505dd76e8b5989358b7580a3fdb213051a406adb26a487d26c68c60"
+  url "https://github.com/chapel-lang/chapel/releases/download/2.2.0/chapel-2.2.0.tar.gz"
+  sha256 "bb16952a87127028031fd2b56781bea01ab4de7c3466f7b6a378c4d8895754b6"
   license "Apache-2.0"
-  revision 3
   head "https://github.com/chapel-lang/chapel.git", branch: "main"
 
   bottle do
-    sha256 arm64_sequoia: "2d501f1424bc9f21bfad56bcfc556cf8712e524db4fcbf57ee2cb18b59673be4"
-    sha256 arm64_sonoma:  "c16920ce4c25f8d530ad0fb9612c8d7caaafa53246b2a747dbf5e3115c46dfe8"
-    sha256 arm64_ventura: "cc1f389cfd794bac980e53a42ca8e9c0255c9f73c6986adbd94722a27fe55733"
-    sha256 sonoma:        "8cbef3e52afed90588890167c3be772a33511faaf83ff2bdde68335b657167bf"
-    sha256 ventura:       "5e50cc8ad9a26b24125f4b725038a5a312068f7cd05273cbe01dcc56b5d50c4a"
-    sha256 x86_64_linux:  "67c2451db78969ab1a7031ed8b6758b02da7ca728ae11ca41b8d7ff3321d2ed6"
+    sha256 arm64_sequoia: "bf699c9806375fabf1b6287cd9a5f95d2f207893b6e13715449f039974b23f64"
+    sha256 arm64_sonoma:  "b7d3d45beff719677abe1837743c7c49be92e0f1a9f76b3dcfa976e85b64fc01"
+    sha256 arm64_ventura: "aaa552f946f72c9455ca9ecda1be4f8cdaf1c8e41cb5dadcbae35e86d5e36fc5"
+    sha256 sonoma:        "7e131ad39120b86823f32d442a2c2e6f7f5d8c1d0b3552b2baf519b94f798a9d"
+    sha256 ventura:       "54975ba802a1d47a2be81d43506d04c6de12625f0b2894be5cf300e28433e622"
+    sha256 x86_64_linux:  "b5c76ea840dd2cf224576761c821db3c8fafcf9fd50315ee11f8367024a7f853"
   end
 
   depends_on "cmake"
@@ -30,11 +29,6 @@ class Chapel < Formula
   def llvm
     deps.map(&:to_formula).find { |f| f.name.match? "^llvm" }
   end
-
-  # This fixes an issue when using jemalloc and hwloc from the system (homebrew)
-  # provided installation. Remove in Chapel 2.2 release, after
-  # https://github.com/chapel-lang/chapel/pull/25354 is merged
-  patch :DATA
 
   def install
     # Always detect Python used as dependency rather than needing aliased Python formula
@@ -81,10 +75,12 @@ class Chapel < Formula
       system "make", "cleanall"
 
       rm_r("third-party/llvm/llvm-src/")
-      rm_r("third-party/gasnet/gasnet-src")
-      rm_r("third-party/libfabric/libfabric-src")
+      rm_r("third-party/gasnet/gasnet-src/")
+      rm_r("third-party/libfabric/libfabric-src/")
+      rm_r("third-party/fltk/fltk-1.3.8-source.tar.gz")
+      rm_r("third-party/libunwind/libunwind-src/")
       rm_r("third-party/gmp/gmp-src/")
-      rm_r("third-party/qthread/qthread-src")
+      rm_r("third-party/qthread/qthread-src/")
     end
 
     # Install chpl and other binaries (e.g. chpldoc) into bin/ as exec scripts.
@@ -123,106 +119,3 @@ class Chapel < Formula
     system bin/"chplcheck", libexec/"examples/hello.chpl"
   end
 end
-
-__END__
-diff --git a/third-party/jemalloc/Makefile.target.include b/third-party/jemalloc/Makefile.target.include
-deleted file mode 100644
-index 217a500dfb..0000000000
---- a/third-party/jemalloc/Makefile.target.include
-+++ /dev/null
-@@ -1,12 +0,0 @@
--JEMALLOC_DIR=$(THIRD_PARTY_DIR)/jemalloc
--JEMALLOC_SUBDIR = $(JEMALLOC_DIR)/jemalloc-src
--JEMALLOC_BUILD_SUBDIR=build/$(CHPL_MAKE_TARGET_JEMALLOC_UNIQ_CFG_PATH)
--JEMALLOC_BUILD_DIR=$(JEMALLOC_DIR)/$(JEMALLOC_BUILD_SUBDIR)
--JEMALLOC_INSTALL_SUBDIR=install/$(CHPL_MAKE_TARGET_JEMALLOC_UNIQ_CFG_PATH)
--JEMALLOC_INSTALL_DIR=$(JEMALLOC_DIR)/$(JEMALLOC_INSTALL_SUBDIR)
--JEMALLOC_INCLUDE_DIR = $(JEMALLOC_INSTALL_DIR)/include
--JEMALLOC_LIB_DIR = $(JEMALLOC_INSTALL_DIR)/lib
--JEMALLOC_BIN_DIR = $(JEMALLOC_INSTALL_DIR)/bin
--JEMALLOC_TARGET = --target
--
--CHPL_JEMALLOC_PREFIX=$(CHPL_JEMALLOC_TARGET_PREFIX)
-diff --git a/make/Makefile.base b/make/Makefile.base
-index bcbda0a9cf..1120057d47 100644
---- a/make/Makefile.base
-+++ b/make/Makefile.base
-@@ -194,7 +194,7 @@ include $(THIRD_PARTY_DIR)/jemalloc/Makefile.common.include
- ifeq ($(strip $(CHPL_MAKE_HOST_TARGET)),--host)
- include $(THIRD_PARTY_DIR)/jemalloc/Makefile.host.include-$(CHPL_MAKE_HOST_JEMALLOC)
- else
--include $(THIRD_PARTY_DIR)/jemalloc/Makefile.target.include
-+include $(THIRD_PARTY_DIR)/jemalloc/Makefile.target.include-$(CHPL_MAKE_TARGET_JEMALLOC)
- endif
- include $(THIRD_PARTY_DIR)/gmp/Makefile.include
- include $(THIRD_PARTY_DIR)/hwloc/Makefile.include
-diff --git a/third-party/jemalloc/Makefile.target.include-bundled b/third-party/jemalloc/Makefile.target.include-bundled
-new file mode 100644
-index 0000000000..217a500dfb
---- /dev/null
-+++ b/third-party/jemalloc/Makefile.target.include-bundled
-@@ -0,0 +1,12 @@
-+JEMALLOC_DIR=$(THIRD_PARTY_DIR)/jemalloc
-+JEMALLOC_SUBDIR = $(JEMALLOC_DIR)/jemalloc-src
-+JEMALLOC_BUILD_SUBDIR=build/$(CHPL_MAKE_TARGET_JEMALLOC_UNIQ_CFG_PATH)
-+JEMALLOC_BUILD_DIR=$(JEMALLOC_DIR)/$(JEMALLOC_BUILD_SUBDIR)
-+JEMALLOC_INSTALL_SUBDIR=install/$(CHPL_MAKE_TARGET_JEMALLOC_UNIQ_CFG_PATH)
-+JEMALLOC_INSTALL_DIR=$(JEMALLOC_DIR)/$(JEMALLOC_INSTALL_SUBDIR)
-+JEMALLOC_INCLUDE_DIR = $(JEMALLOC_INSTALL_DIR)/include
-+JEMALLOC_LIB_DIR = $(JEMALLOC_INSTALL_DIR)/lib
-+JEMALLOC_BIN_DIR = $(JEMALLOC_INSTALL_DIR)/bin
-+JEMALLOC_TARGET = --target
-+
-+CHPL_JEMALLOC_PREFIX=$(CHPL_JEMALLOC_TARGET_PREFIX)
-diff --git a/third-party/jemalloc/Makefile.target.include-none b/third-party/jemalloc/Makefile.target.include-none
-new file mode 100644
-index 0000000000..e69de29bb2
---- /dev/null
-+++ b/third-party/jemalloc/Makefile.target.include-none
-@@ -0,0 +1 @@
-+
-diff --git a/third-party/jemalloc/Makefile.target.include-system b/third-party/jemalloc/Makefile.target.include-system
-new file mode 100644
-index 0000000000..e69de29bb2
---- /dev/null
-+++ b/third-party/jemalloc/Makefile.target.include-system
-@@ -0,0 +1 @@
-+
-diff --git a/util/chplenv/chpl_hwloc.py b/util/chplenv/chpl_hwloc.py
-index cda5ed6bc0..9dc7f0355d 100755
---- a/util/chplenv/chpl_hwloc.py
-+++ b/util/chplenv/chpl_hwloc.py
-@@ -61,7 +61,13 @@ def get_link_args():
-             if exists and retcode != 0:
-                 error("CHPL_HWLOC=system requires hwloc >= 2.1", ValueError)
-
--            return third_party_utils.pkgconfig_get_system_link_args('hwloc')
-+            _, pclibs = third_party_utils.pkgconfig_get_system_link_args('hwloc', static=False)
-+            libs = []
-+            for pcl in pclibs:
-+                libs.append(pcl)
-+                if pcl.startswith('-L'):
-+                    libs.append(pcl.replace('-L', '-Wl,-rpath,', 1))
-+            return ([ ], libs)
-         else:
-             third_party_utils.could_not_find_pkgconfig_pkg("hwloc", "CHPL_HWLOC")
-
-diff --git a/util/chplenv/chpl_jemalloc.py b/util/chplenv/chpl_jemalloc.py
-index 3d665fa56b..78761c1c6e 100644
---- a/util/chplenv/chpl_jemalloc.py
-+++ b/util/chplenv/chpl_jemalloc.py
-@@ -129,7 +129,13 @@ def get_link_args(flag):
-         # try pkg-config
-         args = third_party_utils.pkgconfig_get_system_link_args('jemalloc')
-         if args != (None, None):
--            return args
-+            pclibs = args[1]
-+            libs = []
-+            for pcl in pclibs:
-+                libs.append(pcl)
-+                if pcl.startswith('-L'):
-+                    libs.append(pcl.replace('-L', '-Wl,-rpath,', 1))
-+            return (args[0], libs)
-         else:
-             envname = "CHPL_TARGET_JEMALLOC" if flag == "target" else "CHPL_HOST_JEMALLOC"
-             third_party_utils.could_not_find_pkgconfig_pkg("jemalloc", envname)


### PR DESCRIPTION
This updates the homebrew release formula that we capture to catch changes to the published formula. The update matches our version to the version for 2.2 recently released in Homebrew.

trivial test file change only, not reviewed