### PR TITLE
skip ChAI testing on AMD

### DIFF
--- a/test/gpu/native/studies/chai/SKIPIF
+++ b/test/gpu/native/studies/chai/SKIPIF
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# skip for AMD GPUs (for now) - see: https://github.com/Cray/chapel-private/issues/6739
+if [ "$CHPL_GPU" = "amd" ]; then
+  echo "True"
+  exit
+fi
+
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 CHAI_BRANCH=main
 CHAI_URL=${CHAI_URL:-https://github.com/chapel-lang/ChAI.git}


### PR DESCRIPTION
Skip ChAI testing on AMD GPUs for now. One of ChAI's tests is failing on AMD with an esoteric error message — this needs to be investigated and fixed before AMD testing can be re-enabled.