### PR TITLE
dyno: Fix bugs that were breaking chpl-language-server tests

### DIFF
--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -1046,10 +1046,11 @@ static bool helpComputeCompilerGeneratedReturnType(Context* context,
 
 // returns 'true' if it was a case handled here & sets 'result' in that case
 // returns 'false' if it needs to be computed with a ResolvedVisitor traversal
-static bool helpComputeReturnType(Context* context,
+static bool helpComputeReturnType(ResolutionContext* rc,
                                   const TypedFnSignature* sig,
                                   const PoiScope* poiScope,
                                   QualifiedType& result) {
+  Context* context = rc->context();
   const UntypedFnSignature* untyped = sig->untyped();
 
   // TODO: Optimize the order of this case and the isCompilerGenerated case
@@ -1074,8 +1075,7 @@ static bool helpComputeReturnType(Context* context,
 
       // resolve the return type
       ResolutionResultByPostorderID resolutionById;
-      ResolutionContext rc(context);
-      auto visitor = Resolver::createForFunction(&rc, fn, poiScope, sig,
+      auto visitor = Resolver::createForFunction(rc, fn, poiScope, sig,
                                                  resolutionById);
       retType->traverse(visitor);
       result = resolutionById.byAst(retType).type();
@@ -1146,7 +1146,7 @@ static const QualifiedType& returnTypeQuery(ResolutionContext* rc,
   const UntypedFnSignature* untyped = sig->untyped();
   QualifiedType result;
 
-  bool computed = helpComputeReturnType(context, sig, poiScope, result);
+  bool computed = helpComputeReturnType(rc, sig, poiScope, result);
   if (!computed) {
     const AstNode* ast = parsing::idToAst(context, untyped->id());
     const Function* fn = ast->toFunction();
@@ -1232,7 +1232,7 @@ const TypedFnSignature* inferOutFormals(ResolutionContext* rc,
 
 void computeReturnType(Resolver& resolver) {
   QualifiedType returnType;
-  bool computed = helpComputeReturnType(resolver.context,
+  bool computed = helpComputeReturnType(resolver.rc,
                                         resolver.typedSignature,
                                         resolver.poiScope,
                                         returnType);

--- a/frontend/test/resolution/testResolve.cpp
+++ b/frontend/test/resolution/testResolve.cpp
@@ -1688,6 +1688,26 @@ static void test26() {
   }
 }
 
+// Make sure that 'extern' functions still have 'ResolvedFunction' entries.
+static void test27() {
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  // 'this' qualified, type field
+  std::string prog =
+    R"""(
+      extern proc foo(): int;
+    )""";
+
+  auto m = parseModule(context, prog);
+  auto f = m->stmt(0)->toFunction();
+  assert(f && f->linkage() == Decl::EXTERN);
+  auto rf = resolveConcreteFunction(context, f->id());
+  assert(rf->returnType().type()->isIntType());
+  assert(guard.realizeErrors() == 0);
+}
+
 int main() {
   test1();
   test2();
@@ -1715,6 +1735,7 @@ int main() {
   test24();
   test25();
   test26();
+  test27();
 
   return 0;
 }


### PR DESCRIPTION
This PR fixes bugs that were causing test failures in `chpl-language-server`.

Make sure to skip resolving function bodies in `resolveFunction` if the function does not have one (e.g., for `extern` functions).

If `typedSignatureInitial` is called on a nested function and parent frames are not present, emit a warning and continue if the parent(s) are generic instead of returning `nullptr`. Future work should make `typedSignatureInitial` take the parent function signature instead.

Reviewed by @mppf. Thanks!

TESTING

- [x] `linux64`, `standard`
- [x] `test-chpl-language-server`