### PR TITLE
Tweak `binarytrees-pool` based on feedback

### DIFF
--- a/test/studies/shootout/binary-trees/binarytrees-pool.chpl
+++ b/test/studies/shootout/binary-trees/binarytrees-pool.chpl
@@ -8,35 +8,31 @@
 
 use Allocators;
 
-config const n = 10;                       // the maximum tree depth
+config const n = 10;                         // the maximum tree depth
 
 proc main() {
-  const minDepth = 4,                      // the shallowest tree
-        maxDepth = max(minDepth + 2, n),   // the deepest normal tree
-        strDepth = maxDepth + 1,           // the depth of the "stretch" tree
-        depths = minDepth..maxDepth by 2,  // the range of depths to create
-        nodeSize = 24;                     // the approximate size of a node
-  var stats: [depths] (int,int);           // stores statistics for the trees
-  const poolSize =
-    (((2**(maxDepth+2))-1)*nodeSize)*3;    // how much each pool allocates
-                                           // based on the deepest tree,
-                                           // with a factor of 3 for safety
-  var globalPool = new bumpPtrMemPool(poolSize, alignment=0);
+  const minDepth = 4,                        // the shallowest tree
+        maxDepth = max(minDepth + 2, n),     // the deepest normal tree
+        strDepth = maxDepth + 1,             // the depth of the "stretch" tree
+        depths = minDepth..maxDepth by 2,    // the range of depths to create
+        nodeSize = 24,                       // the approximate size of a node
+        poolSize = 2**(maxDepth+2)*nodeSize; // how much each pool allocates
+  var stats: [depths] (int,int);             // stores statistics for the trees
 
   //
   // Create the short-lived "stretch" tree, checksum it, and print its stats.
   //
   {
-    const strTree = newWithAllocator(globalPool,
-                                      unmanaged Tree, strDepth, globalPool);
+    var pool = new bumpPtrMemPool(poolSize, alignment=0);
+    const strTree = newWithAllocator(pool, unmanaged Tree, strDepth, pool);
     writeln("stretch tree of depth ", strDepth, "\t check: ", strTree.sum());
   }
 
   //
   // Build the long-lived tree.
   //
-  const llTree = newWithAllocator(globalPool,
-                                    unmanaged Tree, maxDepth, globalPool);
+  var pool = new bumpPtrMemPool(poolSize, alignment=0);
+  const llTree = newWithAllocator(pool, unmanaged Tree, maxDepth, pool);
 
   //
   // Iterate over the depths. At each depth, create the required trees in
@@ -48,8 +44,8 @@ proc main() {
 
     forall 1..iterations
       with (+ reduce sum,
-            var localPool = new bumpPtrMemPool(poolSize, alignment=0)) {
-      const t = newWithAllocator(localPool, unmanaged Tree, depth, localPool);
+            var pool = new bumpPtrMemPool(poolSize*8, alignment=0)) {
+      const t = newWithAllocator(pool, unmanaged Tree, depth, pool);
       sum += t.sum();
     }
     stats[depth] = (iterations, sum);

--- a/test/studies/shootout/binary-trees/binarytrees-pool.chpl
+++ b/test/studies/shootout/binary-trees/binarytrees-pool.chpl
@@ -15,7 +15,7 @@ proc main() {
         maxDepth = max(minDepth + 2, n),     // the deepest normal tree
         strDepth = maxDepth + 1,             // the depth of the "stretch" tree
         depths = minDepth..maxDepth by 2,    // the range of depths to create
-        nodeSize = 24,                       // the approximate size of a node
+        nodeSize = 24,                       // the size of a node
         poolSize = 2**(maxDepth+2)*nodeSize; // how much each pool allocates
   var stats: [depths] (int,int);             // stores statistics for the trees
 

--- a/test/studies/shootout/binary-trees/binarytrees-pool.chpl
+++ b/test/studies/shootout/binary-trees/binarytrees-pool.chpl
@@ -45,7 +45,7 @@ proc main() {
 
     forall 1..iterations
       with (+ reduce sum,
-            const pool = new bumpPtrMemPool(poolSize, alignment=0)) {
+            var pool = new bumpPtrMemPool(poolSize, alignment=0)) {
       const t = newWithAllocator(pool, unmanaged Tree, depth, pool);
       sum += t.sum();
     }

--- a/test/studies/shootout/binary-trees/binarytrees-pool.chpl
+++ b/test/studies/shootout/binary-trees/binarytrees-pool.chpl
@@ -6,7 +6,7 @@
      Brad Chamberlain
 */
 
-use Allocators;
+use Allocators, Math;
 
 config const n = 10;                         // the maximum tree depth
 
@@ -41,7 +41,7 @@ proc main() {
   //
   for depth in depths {
     const iterations = 2**(maxDepth - depth + minDepth),
-          ps = poolSize(depth, iterations/here.maxTaskPar);
+          ps = poolSize(depth, divCeilPos(iterations, here.maxTaskPar));
     var sum = 0;
 
     forall 1..iterations

--- a/test/studies/shootout/binary-trees/binarytrees-pool.execenv
+++ b/test/studies/shootout/binary-trees/binarytrees-pool.execenv
@@ -1,0 +1,2 @@
+# this value has been shown to cause the most problems for this test
+CHPL_RT_NUM_THREADS_PER_LOCALE=3


### PR DESCRIPTION
Tweak `binarytrees-pool` based on feedback. Many of the changes are cosmetic (changing how constants are written) and others improve the portability (making sure enough memory is available when running with limited cores) 

[Reviewed by @bradcray]