### PR TITLE
Dyno: resolve `foo()` to `foo(standalone)` if serial version of the iterator is not available.

### DIFF
--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -1913,7 +1913,8 @@ class CallResolutionResult {
     return mostSpecific_ == other.mostSpecific_ &&
            exprType_ == other.exprType_ &&
            PoiInfo::updateEquals(poiInfo_, other.poiInfo_) &&
-           speciallyHandled_ == other.speciallyHandled_;
+           speciallyHandled_ == other.speciallyHandled_ &&
+           rejectedPossibleIteratorCandidates_ == other.rejectedPossibleIteratorCandidates_;
   }
   bool operator!=(const CallResolutionResult& other) const {
     return !(*this == other);
@@ -1923,6 +1924,8 @@ class CallResolutionResult {
     exprType_.swap(other.exprType_);
     poiInfo_.swap(other.poiInfo_);
     std::swap(speciallyHandled_, other.speciallyHandled_);
+    std::swap(rejectedPossibleIteratorCandidates_,
+              other.rejectedPossibleIteratorCandidates_);
   }
 
   void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const;

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -1865,6 +1865,7 @@ class CallResolutionResult {
   // whether the resolution result was handled using some compiler-level logic,
   // which does not correspond to a TypedSignature or AST.
   bool speciallyHandled_ = false;
+  bool rejectedPossibleIteratorCandidates_ = false;
 
  public:
   CallResolutionResult() {}
@@ -1877,13 +1878,15 @@ class CallResolutionResult {
   }
 
   CallResolutionResult(MostSpecificCandidates mostSpecific,
+                       bool rejectedPossibleIteratorCandidates,
                        types::QualifiedType exprType,
                        PoiInfo poiInfo,
                        bool speciallyHandled = false)
     : mostSpecific_(std::move(mostSpecific)),
       exprType_(std::move(exprType)),
       poiInfo_(std::move(poiInfo)),
-      speciallyHandled_(speciallyHandled)
+      speciallyHandled_(speciallyHandled),
+      rejectedPossibleIteratorCandidates_(rejectedPossibleIteratorCandidates)
   {
   }
 
@@ -1898,6 +1901,13 @@ class CallResolutionResult {
 
   /** whether the resolution result was handled using some compiler-level logic */
   bool speciallyHandled() const { return speciallyHandled_; }
+
+  /** whether we rejected candidates because they expected a tag or followThis.
+      This might indicate that we need to re-resolve with tag to find parallel
+      iterators. */
+  bool rejectedPossibleIteratorCandidates() const {
+    return rejectedPossibleIteratorCandidates_;
+  }
 
   bool operator==(const CallResolutionResult& other) const {
     return mostSpecific_ == other.mostSpecific_ &&

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -1484,7 +1484,8 @@ class FormalActualMap {
            actualIdxToFormalIdx_ == other.actualIdxToFormalIdx_ &&
            mappingIsValid_ == other.mappingIsValid_ &&
            failingActualIdx_ == other.failingActualIdx_ &&
-           failingFormalIdx_ == other.failingFormalIdx_;
+           failingFormalIdx_ == other.failingFormalIdx_ &&
+           missingIteratorActuals_ == other.missingIteratorActuals_;
   }
 
   bool operator!=(const FormalActualMap& other) const {
@@ -1499,11 +1500,13 @@ class FormalActualMap {
     (void) mappingIsValid_; // nothing to mark
     (void) failingActualIdx_; // nothing to mark
     (void) failingFormalIdx_; // nothing to mark
+    (void) missingIteratorActuals_; // nothing to mark
   }
 
   size_t hash() const {
     return chpl::hash(byFormalIdx_, actualIdxToFormalIdx_, mappingIsValid_,
-                      failingActualIdx_, failingFormalIdx_);
+                      failingActualIdx_, failingFormalIdx_,
+                      missingIteratorActuals_);
   }
 
   /** check if mapping is valid */

--- a/frontend/lib/resolution/intents.cpp
+++ b/frontend/lib/resolution/intents.cpp
@@ -77,7 +77,8 @@ static QualifiedType::Kind defaultIntentForType(const Type* t,
     return QualifiedType::CONST_IN;
 
   if (t->isStringType() || t->isBytesType() ||
-      t->isRecordType() || t->isUnionType() || t->isTupleType()) {
+      t->isRecordType() || t->isUnionType() || t->isTupleType() ||
+      t->isIteratorType()) {
     if (isThis) {
       if (isInit)
         return QualifiedType::REF;

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -1118,7 +1118,9 @@ CallResolutionResult resolvePrimCall(ResolutionContext* rc,
     } else {
       CHPL_ASSERT(false && "unsupported param folding");
     }
-    return CallResolutionResult(candidates, type, poi, /* specially handled */ true);
+    return CallResolutionResult(candidates,
+                                /* rejectedPossibleIteratorCandidates */ false,
+                                type, poi, /* specially handled */ true);
   }
 
   // otherwise, handle each primitive individually
@@ -1816,7 +1818,9 @@ CallResolutionResult resolvePrimCall(ResolutionContext* rc,
     type = QualifiedType(QualifiedType::UNKNOWN, ErroneousType::get(context));
   }
 
-  return CallResolutionResult(candidates, type, poi, /* specially handled */ true);
+  return CallResolutionResult(candidates,
+                              /* rejectedPossibleIteratorCandidates */ false,
+                              type, poi, /* specially handled */ true);
 }
 
 

--- a/frontend/test/resolution/testLoopIndexVars.cpp
+++ b/frontend/test/resolution/testLoopIndexVars.cpp
@@ -794,22 +794,18 @@ static void testForallStandaloneThese(Context* context) {
   assert(!guard.realizeErrors());
 }
 
-// Daniel 07/19/24: Disabling this deliberately. Production requires a
-//                  serial iteartor even when a standalone iterator is
-//                  available and would be preferred.
-//
-// static void testForallStandaloneRedirect(Context* context) {
-//   printf("%s\n", __FUNCTION__);
-//   ErrorGuard guard(context);
-// 
-//   ADVANCE_PRESERVING_STANDARD_MODULES_(context);
-//   auto program = R""""(
-//                   iter foo(param tag: iterKind) where tag == iterKind.standalone do yield 0;
-//                   forall i in foo() do i;
-//                   )"""";
-//   assertLoopMatches(context, program, "standalone", 1, 0);
-//   assert(!guard.realizeErrors());
-// }
+static void testForallStandaloneRedirect(Context* context) {
+  printf("%s\n", __FUNCTION__);
+  ErrorGuard guard(context);
+
+  ADVANCE_PRESERVING_STANDARD_MODULES_(context);
+  auto program = R""""(
+                  iter foo(param tag: iterKind) where tag == iterKind.standalone do yield 0;
+                  forall i in foo() do i;
+                  )"""";
+  assertLoopMatches(context, program, "standalone", 1, 0);
+  assert(!guard.realizeErrors());
+}
 
 static void testForallLeaderFollowerThese(Context* context) {
   printf("%s\n", __FUNCTION__);
@@ -828,23 +824,19 @@ static void testForallLeaderFollowerThese(Context* context) {
   assert(!guard.realizeErrors());
 }
 
-// Daniel 07/19/24: Disabling this deliberately. Production requires a
-//                  serial iteartor even when a leader/follower pair is
-//                  available and would be preferred.
-//
-// static void testForallLeaderFollowerRedirect(Context* context) {
-//   printf("%s\n", __FUNCTION__);
-//   ErrorGuard guard(context);
-// 
-//   ADVANCE_PRESERVING_STANDARD_MODULES_(context);
-//   auto program = R""""(
-//                   iter foo(param tag: iterKind) where tag == iterKind.leader do yield (0, 0);
-//                   iter foo(param tag: iterKind, followThis) where tag == iterKind.follower do yield 0;
-//                   forall i in foo() do i;
-//                   )"""";
-//   assertLoopMatches(context, program, "leader", 2, 0, 1);
-//   assert(!guard.realizeErrors());
-// }
+static void testForallLeaderFollowerRedirect(Context* context) {
+  printf("%s\n", __FUNCTION__);
+  ErrorGuard guard(context);
+
+  ADVANCE_PRESERVING_STANDARD_MODULES_(context);
+  auto program = R""""(
+                  iter foo(param tag: iterKind) where tag == iterKind.leader do yield (0, 0);
+                  iter foo(param tag: iterKind, followThis) where tag == iterKind.follower do yield 0;
+                  forall i in foo() do i;
+                  )"""";
+  assertLoopMatches(context, program, "leader", 2, 0, 1);
+  assert(!guard.realizeErrors());
+}
 
 // Invoke an iterator in a loop expression, yielding a tuple of the iterator's
 // yield values, then invoke the loop expression in a regular loop and ensure
@@ -1060,9 +1052,9 @@ int main() {
   testSerialZip(context);
   testParallelZip(context);
   testForallStandaloneThese(context);
-  // testForallStandaloneRedirect(context);
+  testForallStandaloneRedirect(context);
   testForallLeaderFollowerThese(context);
-  // testForallLeaderFollowerRedirect(context);
+  testForallLeaderFollowerRedirect(context);
 
   testForLoopExpression(context);
   testForallLoopExpressionStandalone(context);

--- a/frontend/test/resolution/testLoopIndexVars.cpp
+++ b/frontend/test/resolution/testLoopIndexVars.cpp
@@ -34,12 +34,6 @@
 
 #include <map>
 
-#define ADVANCE_PRESERVING_STANDARD_MODULES_(ctx__) \
-  do { \
-    ctx__->advanceToNextRevision(false); \
-    setupModuleSearchPaths(ctx__, false, false, {}, {}); \
-  } while (0)
-
 static auto myiter = std::string(R""""(
 iter myiter() {
   yield 1;

--- a/frontend/test/resolution/testLoopIndexVars.cpp
+++ b/frontend/test/resolution/testLoopIndexVars.cpp
@@ -579,18 +579,22 @@ static void testExplicitTaggedIter(Context* context) {
     assert(!guard.realizeErrors());
 
     auto aLoop = parentAst(context, findVariable(mod, "a"))->toIndexableLoop();
+    assert(rr.byAst(aLoop->iterand()).associatedActions().empty());
     auto aSig1 = rr.byAst(aLoop->iterand()).mostSpecific().only().fn();
     assert(aSig1->isSerialIterator(context));
 
     auto bLoop = parentAst(context, findVariable(mod, "b"))->toIndexableLoop();
+    assert(rr.byAst(bLoop->iterand()).associatedActions().empty());
     auto bSig1 = rr.byAst(bLoop->iterand()).mostSpecific().only().fn();
     assert(bSig1->isParallelStandaloneIterator(context));
 
     auto cLoop = parentAst(context, findVariable(mod, "c"))->toIndexableLoop();
+    assert(rr.byAst(cLoop->iterand()).associatedActions().empty());
     auto cSig1 = rr.byAst(cLoop->iterand()).mostSpecific().only().fn();
     assert(cSig1->isParallelLeaderIterator(context));
 
     auto dLoop = parentAst(context, findVariable(mod, "d"))->toIndexableLoop();
+    assert(rr.byAst(dLoop->iterand()).associatedActions().empty());
     auto dSig1 = rr.byAst(dLoop->iterand()).mostSpecific().only().fn();
     assert(dSig1->isParallelFollowerIterator(context));
 

--- a/frontend/test/resolution/testLoopIndexVars.cpp
+++ b/frontend/test/resolution/testLoopIndexVars.cpp
@@ -555,6 +555,57 @@ static void testIterSigDetection(Context* context) {
     assert(m["d"].type()->isStringType());
 }
 
+static void testExplicitTaggedIter(Context* context) {
+  printf("%s\n", __FUNCTION__);
+  ErrorGuard guard(context);
+
+  ADVANCE_PRESERVING_STANDARD_MODULES_(context);
+  std::string program =
+    R""""(
+
+    iter i1() { yield 0.0; }
+    iter i1(param tag: iterKind) where tag == iterKind.standalone { yield 0; }
+    iter i1(param tag: iterKind) where tag == iterKind.leader { yield (0.0,0.0); }
+    iter i1(param tag: iterKind, followThis) where tag == iterKind.follower { yield ""; }
+
+    for a in i1() do;
+    for b in i1(tag=iterKind.standalone) do;
+    for c in i1(tag=iterKind.leader) do;
+    for d in i1(tag=iterKind.follower, followThis="") do;
+    )"""";
+
+    auto mod = parseModule(context, program);
+    auto& rr = resolveModule(context, mod->id());
+    assert(!guard.realizeErrors());
+
+    auto aLoop = parentAst(context, findVariable(mod, "a"))->toIndexableLoop();
+    auto aSig1 = rr.byAst(aLoop->iterand()).mostSpecific().only().fn();
+    assert(aSig1->isSerialIterator(context));
+
+    auto bLoop = parentAst(context, findVariable(mod, "b"))->toIndexableLoop();
+    auto bSig1 = rr.byAst(bLoop->iterand()).mostSpecific().only().fn();
+    assert(bSig1->isParallelStandaloneIterator(context));
+
+    auto cLoop = parentAst(context, findVariable(mod, "c"))->toIndexableLoop();
+    auto cSig1 = rr.byAst(cLoop->iterand()).mostSpecific().only().fn();
+    assert(cSig1->isParallelLeaderIterator(context));
+
+    auto dLoop = parentAst(context, findVariable(mod, "d"))->toIndexableLoop();
+    auto dSig1 = rr.byAst(dLoop->iterand()).mostSpecific().only().fn();
+    assert(dSig1->isParallelFollowerIterator(context));
+
+    auto m = resolveTypesOfVariables(context, program, { "a", "b", "c", "d"});
+    assert(!guard.realizeErrors());
+    assert(m["a"].kind() == QualifiedType::CONST_VAR);
+    assert(m["a"].type()->isRealType());
+    assert(m["b"].kind() == QualifiedType::CONST_VAR);
+    assert(m["b"].type()->isIntType());
+    assert(m["c"].kind() == QualifiedType::CONST_VAR);
+    assert(m["c"].type()->isTupleType());
+    assert(m["d"].kind() == QualifiedType::CONST_VAR);
+    assert(m["d"].type()->isStringType());
+}
+
 static void
 unpackIterKindStrToBool(const std::string& str,
                         bool* needSerial=nullptr,
@@ -1043,6 +1094,7 @@ int main() {
   auto ctx = buildStdContext();
   Context* context = ctx.get();
   testIterSigDetection(context);
+  testExplicitTaggedIter(context);
   testSerialZip(context);
   testParallelZip(context);
   testForallStandaloneThese(context);

--- a/frontend/test/resolution/testResolverVerboseErrors.cpp
+++ b/frontend/test/resolution/testResolverVerboseErrors.cpp
@@ -264,7 +264,7 @@ static const char* errorBasic = R"""(
     3 | f(a=42);
       |
   
-  The following candidate didn't match:
+  The following candidate didn't match because the provided actuals could not be mapped to its formals:
       |
     1 | proc f(x: int) {}
       |

--- a/frontend/test/test-resolution.h
+++ b/frontend/test/test-resolution.h
@@ -24,6 +24,12 @@
 
 #include "chpl/resolution/resolution-types.h"
 
+#define ADVANCE_PRESERVING_STANDARD_MODULES_(ctx__) \
+  do { \
+    ctx__->advanceToNextRevision(false); \
+    setupModuleSearchPaths(ctx__, false, false, {}, {}); \
+  } while (0)
+
 // forward declare classes and namespaces
 namespace chpl {
   namespace resolution {


### PR DESCRIPTION
Closes https://github.com/Cray/chapel-private/issues/6720 by rolling in a minor fix (see 8320546803e3b3cba9e367991ed5a5bf60d4ef46)

This PR intends to address a longstanding concern with the leader/follower API design in which to use a parallel iterator, you need to define a serial iterator as well. Thus, you can't iterate over `foo()` if only `foo(standalone)` or `foo(leader)/foo(follower)` are defined. This PR implements this, detecting calls to iterators that were discarded only because of the `tag`/`followThis` arguments, and re-trying them with the tags in priority order.

The key observation is that the formal-actual map, when it's checking alignment, is actually very well positioned to determine if a call is valid with the exception of missing a `tag` argument: it iterates over all formals of a potential candidate, and checks if they have a corresponding actual. Thus, if the following conditions are met, we have candidate that was rejected by may constitute a parallel version of the current call:

* The candidate is an iterator
* The only formals that are missing are `tag` and `followThis`

If this situation is detected, I store the candidate in a separate list of "rejected iterator candidates". This is intended for future optimization opportunities; see the "Optimization Opportunities" section below. The presence of rejected candidates is propagated to the `CallResolutionResult`. Other code (currently, the `Call*` handling in the resolver) can check the `CallResolutionResult`, and attempt to re-run resolution with `iterKind.standalone` if it failed before. I added logic that does this, storing the repeated resolution attempts as associated actions.

The fact that all call handling uniformily approaches re-resolving with `tag` means that parallel iterators are invoked in other contexts than `for` loops; returning a `foo()` from a function, or storing it in a variable, is still an acceptable way to invoke a `standalone`-only version of `foo`.

## Optimization Opportunities
The call resolution process has a lot of steps, including handling last resort candidates, forwarding, and POI scopes. In my opinion, the re-written (`foo()` -> `foo(standalone)`) calls should still obey the same rules as all other calls for overloading and candidate selection (meaning they should respect last-resort candidates, "distance", forwarding order etc.). My original intention was to simply treat "fallback" iterator functions as another kind of last resort candidate, and thus have `resolveCall` succeed for `foo()` by rewriting the call to `foo(standalone)` where appropriate. However, this would effectively require a duplication of all handling for last-resort candidates (we'd need "last resort groups" and "last-resort groups of fallback iterators", for example), and generally seems to increase complexity dramatically.

As a result, I went with the "set a flag on CallResolutionResult" approach. Calling code can re-invoke `resolveCall` with the necessary tag arguments, and call resolution would take care (as it normally does) of precedence, forwarding, receivers, etc. The disadvantage here is that there is likely a lot of overlap when collecting candidates (into a vector of IDs), and that this work is likely performed multiple times in such a case. The `rejectedIteratorsMissingTag` field is intended as a stub that can be grown if we choose to re-attempt the approach from the previous paragraph, and handle the fallback iterator functions in a single pass.

Reviewed by @dlongnecke-cray -- thanks!

## Testing
- [x] dyno tests
   - [x] @dlongnecke-cray's original tests and new tests outside a loop context
   - [x] @riftEmber's tests for iterator forwarding