### PR TITLE
Dyno: Default initializers for classes that inherit

### DIFF
--- a/frontend/lib/framework/ID.cpp
+++ b/frontend/lib/framework/ID.cpp
@@ -141,8 +141,13 @@ ID ID::parentSymbolId(Context* context) const {
     return ID();
   }
 
-  // Otherwise, construct an ID for the parent symbol
-  return ID(parentSymPath, -1, 0);
+  if (this->isFabricatedId() &&
+      this->fabricatedIdKind() == FabricatedIdKind::Generated) {
+    return ID(parentSymPath, ID_GEN_START, 0);
+  } else {
+    // Otherwise, construct an ID for the parent symbol
+    return ID(parentSymPath, -1, 0);
+  }
 }
 
 UniqueString ID::symbolName(Context* context) const {

--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -214,6 +214,7 @@ parseFileContainingIdToBuilderResult(Context* context,
       symbolPath = id.symbolPath();
     } else {
       symbolPath = ID::parentSymbolPath(context, id.symbolPath());
+      if (symbolPath.isEmpty()) return nullptr;
 
       // Assumption: The generated module goes only one symbol deep.
       CHPL_ASSERT(ID::innermostSymbolName(context, symbolPath).startsWith("chpl__generated"));
@@ -1246,7 +1247,8 @@ static const AstTag& idToTagQuery(Context* context, ID id) {
 
   AstTag result = asttags::AST_TAG_UNKNOWN;
 
-  if (!id.isFabricatedId()) {
+  if (!id.isFabricatedId() ||
+      id.fabricatedIdKind() == ID::FabricatedIdKind::Generated) {
     const AstNode* ast = astForIdQuery(context, id);
     if (ast != nullptr) {
       result = ast->tag();

--- a/frontend/lib/resolution/InitResolver.cpp
+++ b/frontend/lib/resolution/InitResolver.cpp
@@ -764,8 +764,12 @@ bool InitResolver::handleAssignmentToField(const OpCall* node) {
 
     // TODO: Anything to do if the opposite is true?
     if (!isAlreadyInitialized) {
-      auto& reRhs = initResolver_.byPostorder.byAst(rhs);
-      state->qt = reRhs.type();
+      auto rhsType = initResolver_.byPostorder.byAst(rhs).type();
+
+      auto param = state->qt.kind() == QualifiedType::PARAM ? rhsType.param() : nullptr;
+      auto qt = QualifiedType(state->qt.kind(), rhsType.type(), param);
+      state->qt = qt;
+
       state->initPointId = node->id();
       state->isInitialized = true;
 

--- a/frontend/lib/resolution/InitResolver.cpp
+++ b/frontend/lib/resolution/InitResolver.cpp
@@ -419,6 +419,8 @@ InitResolver::computeTypedSignature(const Type* newRecvType) {
 
   formalsInstantiated.resize(ufs->numFormals());
 
+  bool needsInstantiation = false;
+
   for (int i = 0; i < tfs->numFormals(); i++) {
     if (i == 0) {
       auto qt = QualifiedType(determineReceiverIntent(), newRecvType);
@@ -427,12 +429,15 @@ InitResolver::computeTypedSignature(const Type* newRecvType) {
     } else {
       formalTypes.push_back(tfs->formalType(i));
       formalsInstantiated.setBit(i, tfs->formalIsInstantiated(i));
+      if (tfs->formalType(i).genericity() == Type::Genericity::GENERIC) {
+        needsInstantiation = true;
+      }
     }
   }
 
   ret = TypedFnSignature::get(ctx_, ufs, formalTypes,
                               tfs->whereClauseResult(),
-                              /* needsInstantiation */ false,
+                              needsInstantiation,
                               tfs->instantiatedFrom(),
                               tfs->parentFn(),
                               formalsInstantiated,

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -296,11 +296,7 @@ static void buildInitArgs(Context* context,
 
 static void collectFields(const AstNode* ast,
                           std::vector<const VarLikeDecl*>& fields) {
-  if (auto decl = ast->toAggregateDecl()) {
-    for (auto d : decl->decls()) {
-      collectFields(d, fields);
-    }
-  } else if (auto var = ast->toVarLikeDecl()) {
+  if (auto var = ast->toVarLikeDecl()) {
     fields.push_back(var);
   } else if (auto multi = ast->toMultiDecl()) {
     for (auto d : multi->decls()) {
@@ -355,7 +351,9 @@ static void initHelper(Context* context,
   }
 
   std::vector<const VarLikeDecl*> fields;
-  collectFields(typeDecl, fields);
+  for (auto d : typeDecl->decls()) {
+    collectFields(d, fields);
+  }
 
   for (auto field : fields) {
     Formal::Intent kind;

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -26,6 +26,7 @@
 #include "chpl/resolution/resolution-queries.h"
 #include "chpl/resolution/scope-queries.h"
 #include "chpl/types/all-types.h"
+#include "chpl/uast/AstTag.h"
 #include "chpl/uast/all-uast.h"
 
 #include "Resolver.h"
@@ -293,40 +294,209 @@ static void buildInitArgs(Context* context,
   }
 }
 
+static void collectFields(const AstNode* ast,
+                          std::vector<const VarLikeDecl*>& fields) {
+  if (auto decl = ast->toAggregateDecl()) {
+    for (auto d : decl->decls()) {
+      collectFields(d, fields);
+    }
+  } else if (auto var = ast->toVarLikeDecl()) {
+    fields.push_back(var);
+  } else if (auto multi = ast->toMultiDecl()) {
+    for (auto d : multi->decls()) {
+      collectFields(d, fields);
+    }
+  } else if (auto tup = ast->toTupleDecl()) {
+    for (auto d : tup->decls()) {
+      collectFields(d, fields);
+    }
+  } else if (auto fwd = ast->toForwardingDecl()) {
+    if (fwd->isDecl()) {
+      collectFields(fwd->expr(), fields);
+    }
+  }
+}
+
+static void initHelper(Context* context,
+                       Builder* builder,
+                       const AggregateDecl* typeDecl,
+                       const Location& dummyLoc,
+                       AstList& formals, AstList& superArgs, AstList& stmts,
+                       bool isChild = true) {
+  if (auto cls = typeDecl->toClass()) {
+    if (cls->numInheritExprs() == 1) {
+      ResolutionResultByPostorderID r;
+      auto visitor = Resolver::createForParentClass(context, typeDecl,
+                                                    {}, nullptr, r);
+      cls->inheritExpr(0)->traverse(visitor);
+      auto res = r.byAst(cls->inheritExpr(0));
+      if (auto parentType = res.type().type()) {
+        if (auto pct = parentType->getCompositeType()) {
+          const Type* manager = nullptr;
+          auto borrowedNonnilDecor =
+              ClassTypeDecorator(ClassTypeDecorator::BORROWED_NONNIL);
+          auto parentReceiver =
+            ClassType::get(context, pct->toBasicClassType(), manager, borrowedNonnilDecor);
+
+          // Do not add formals if the parent has a user-defined initializer
+          // TODO: It would be nice to be able to generate a nice error message
+          //   for the user if they try and pass arguments for the parent in
+          //   this case.
+          if (!areOverloadsPresentInDefiningScope(context, parentReceiver, QualifiedType::INIT_RECEIVER, USTR("init"))) {
+            auto parentAst = parsing::idToAst(context, pct->id());
+            if (auto parentDecl = parentAst->toAggregateDecl()) {
+              initHelper(context, builder, parentDecl, dummyLoc,
+                         formals, superArgs, stmts, /*isChild=*/false);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  std::vector<const VarLikeDecl*> fields;
+  collectFields(typeDecl, fields);
+
+  for (auto field : fields) {
+    Formal::Intent kind;
+    // for types & param, use the field kind, for values use 'in' intent
+    if (field->storageKind() == Qualifier::TYPE ||
+        field->storageKind() == Qualifier::PARAM) {
+      kind = (Formal::Intent)field->storageKind();
+    } else {
+      kind = Formal::Intent::IN;
+    }
+
+    auto typeExpr = field->typeExpression();
+    auto initExpr = field->initExpression();
+
+    owned<AstNode> formal = Formal::build(builder, dummyLoc,
+                                          /*attributeGroup=*/nullptr,
+                                          field->name(), kind,
+                                          typeExpr ? typeExpr->copy() : nullptr,
+                                          initExpr ? initExpr->copy() : nullptr);
+
+    if (isChild) {
+      // Create 'this.field = arg;' statement
+      owned<AstNode> lhs = Dot::build(builder, dummyLoc,
+                                      Identifier::build(builder, dummyLoc, USTR("this")),
+                                      field->name());
+      owned<AstNode> rhs = Identifier::build(builder, dummyLoc, field->name());
+      owned<AstNode> assign = OpCall::build(builder, dummyLoc, USTR("="),
+                                            std::move(lhs), std::move(rhs));
+      stmts.push_back(std::move(assign));
+    } else {
+      // collect arguments for super.init(...)
+      owned<AstNode> arg = Identifier::build(builder, dummyLoc, field->name());
+      superArgs.push_back(std::move(arg));
+    }
+
+    formals.push_back(std::move(formal));
+  }
+}
+
+static const BuilderResult& buildInitializer(Context* context, ID typeID) {
+  auto typeDecl = parsing::idToAst(context, typeID)->toAggregateDecl();
+  auto parentMod = parsing::idToParentModule(context, typeID);
+  auto modName = "chpl__generated_" + parentMod.symbolName(context).str() + "_" + typeDecl->name().str() + "_init";
+  auto bld = Builder::createForGeneratedCode(context, modName.c_str(), parentMod, parentMod.symbolPath());
+  auto builder = bld.get();
+  auto dummyLoc = parsing::locateId(context, typeID);
+
+  auto thisType = Identifier::build(builder, dummyLoc, typeDecl->name());
+  auto thisFormal = Formal::build(builder, dummyLoc, nullptr,
+                                  USTR("this"), Formal::DEFAULT_INTENT,
+                                  std::move(thisType), nullptr);
+
+  AstList formals;
+  AstList stmts;
+  AstList superArgs;
+  initHelper(context, builder, typeDecl, dummyLoc, formals, superArgs, stmts);
+
+  if (auto cls = typeDecl->toClass()) {
+    if (cls->numInheritExprs() > 0) {
+      owned<AstNode> dot = Dot::build(builder, dummyLoc, Identifier::build(builder, dummyLoc, USTR("super")), USTR("init"));
+      owned<AstNode> call = FnCall::build(builder, dummyLoc, std::move(dot), std::move(superArgs), false);
+      stmts.insert(stmts.begin(), std::move(call));
+    }
+  }
+
+  auto body = Block::build(builder, dummyLoc, std::move(stmts));
+  auto genFn = Function::build(builder,
+                               dummyLoc, {},
+                               Decl::Visibility::PUBLIC,
+                               Decl::Linkage::DEFAULT_LINKAGE,
+                               /*linkageName=*/{},
+                               USTR("init"),
+                               /*inline=*/false, /*override=*/false,
+                               Function::Kind::PROC,
+                               /*receiver=*/std::move(thisFormal),
+                               Function::ReturnIntent::DEFAULT_RETURN_INTENT,
+                               // throws, primaryMethod, parenless
+                               false, false, false,
+                               std::move(formals),
+                               // returnType, where, lifetime, body
+                               {}, {}, {}, std::move(body));
+
+  builder->noteChildrenLocations(genFn.get(), dummyLoc);
+  builder->addToplevelExpression(std::move(genFn));
+
+  auto result = builder->result();
+
+  auto modPath = result.topLevelExpression(0)->id().symbolPath();
+  parsing::setCompilerGeneratedBuilder(context, modPath, std::move(result));
+
+  auto& br = parsing::getCompilerGeneratedBuilder(context, modPath);
+
+  return br;
+}
+
 static const TypedFnSignature*
 generateInitSignature(Context* context, const CompositeType* inCompType) {
-  const CompositeType* compType = nullptr;
-  std::vector<UntypedFnSignature::FormalDetail> ufsFormals;
-  std::vector<QualifiedType> formalTypes;
+  const TypedFnSignature* result;
 
-  generateInitParts(context, inCompType, compType,
-                    ufsFormals, formalTypes, /*useGeneric*/ true);
+  if (auto ct = inCompType->getCompositeType()->toBasicClassType()) {
+    if (ct->isObjectType()) {
+      return nullptr;
+    }
+  }
 
-  // consult the fields to build up the remaining untyped formals
-  const DefaultsPolicy defaultsPolicy = DefaultsPolicy::IGNORE_DEFAULTS;
-  auto& rf = fieldsForTypeDecl(context, compType, defaultsPolicy);
+  // Old-style default function placeholder for certain types when the standard
+  // library isn't available.
+  if (CompositeType::isMissingBundledType(context, inCompType->id())) {
+    const CompositeType* compType = nullptr;
+    std::vector<UntypedFnSignature::FormalDetail> ufsFormals;
+    std::vector<QualifiedType> formalTypes;
+    AstList formals;
 
-  // Add field-based arguments to initializer, including those of parent class
-  // if present.
-  buildInitArgs(context, compType, rf, ufsFormals, formalTypes);
+    generateInitParts(context, inCompType, compType,
+                      ufsFormals, formalTypes, /*useGeneric*/ true);
+    // consult the fields to build up the remaining untyped formals
+    const DefaultsPolicy defaultsPolicy = DefaultsPolicy::IGNORE_DEFAULTS;
+    auto& rf = fieldsForTypeDecl(context, compType, defaultsPolicy);
 
-  // build the untyped signature
-  auto ufs = UntypedFnSignature::get(context,
-                        /*id*/ compType->id(),
-                        /*name*/ USTR("init"),
-                        /*isMethod*/ true,
-                        /*isTypeConstructor*/ false,
-                        /*isCompilerGenerated*/ true,
-                        /*throws*/ false,
-                        /*idTag*/ parsing::idToTag(context, compType->id()),
-                        /*kind*/ uast::Function::Kind::PROC,
-                        /*formals*/ std::move(ufsFormals),
-                        /*whereClause*/ nullptr);
+    // Add field-based arguments to initializer, including those of parent class
+    // if present.
+    buildInitArgs(context, compType, rf, ufsFormals, formalTypes);
 
-  // now build the other pieces of the typed signature
-  bool needsInstantiation = rf.isGeneric();
+    // build the untyped signature
+    auto ufs = UntypedFnSignature::get(context,
+                          /*id*/ inCompType->id(),
+                          /*name*/ USTR("init"),
+                          /*isMethod*/ true,
+                          /*isTypeConstructor*/ false,
+                          /*isCompilerGenerated*/ true,
+                          /*throws*/ false,
+                          /*idTag*/ parsing::idToTag(context, compType->id()),
+                          /*kind*/ uast::Function::Kind::PROC,
+                          /*formals*/ std::move(ufsFormals),
+                          /*whereClause*/ nullptr,
+                          /*compilerGeneratedOrigin=*/compType->id());
 
-  auto ret = TypedFnSignature::get(context,
+    // now build the other pieces of the typed signature
+    bool needsInstantiation = rf.isGeneric();
+
+    result = TypedFnSignature::get(context,
                                    ufs,
                                    std::move(formalTypes),
                                    TypedFnSignature::WHERE_NONE,
@@ -335,8 +505,57 @@ generateInitSignature(Context* context, const CompositeType* inCompType) {
                                    /* parentFn */ nullptr,
                                    /* formalsInstantiated */ Bitmap(),
                                    /* outerVariables */ {});
+  } else {
+    auto& br = buildInitializer(context, inCompType->id());
 
-  return ret;
+    const Module* genMod = br.topLevelExpression(0)->toModule();
+    auto initFn = genMod->child(genMod->numChildren()-1)->toFunction();
+
+    // compute the FormalDetails manually so that we can set the default-kind
+    // appropriately.
+    //
+    // TODO: give the Formals proper init-expressions so that we can rely on
+    // pre-existing code to create the UntypedFnSignature.
+    std::vector<UntypedFnSignature::FormalDetail> formals;
+    for (auto decl : initFn->formals()) {
+      UniqueString name;
+      bool hasDefault = false;
+      if (auto formal = decl->toFormal()) {
+        name = formal->name();
+        hasDefault = formal->initExpression() != nullptr;
+        if (decl != initFn->thisFormal()) {
+          if (formal->intent() != Formal::Intent::TYPE &&
+              formal->intent() != Formal::Intent::PARAM) {
+            if (formal->typeExpression() != nullptr) {
+              hasDefault = true;
+            }
+          }
+        }
+      }
+
+      auto defaultKind = hasDefault ? UntypedFnSignature::DK_DEFAULT
+                                    : UntypedFnSignature::DK_NO_DEFAULT;
+      auto fd = UntypedFnSignature::FormalDetail(name, defaultKind,
+                                                 decl, decl->isVarArgFormal());
+      formals.push_back(fd);
+    }
+
+    // find the unique-ified untyped signature
+    auto uSig = UntypedFnSignature::get(context, initFn->id(), initFn->name(),
+                                     true,
+                                     /* isTypeConstructor */ false,
+                                     /* isCompilerGenerated */ true,
+                                     /* throws */ false,
+                                     /* idTag */ asttags::Function,
+                                     uast::Function::Kind::PROC,
+                                     std::move(formals), nullptr,
+                                     inCompType->id());
+
+    ResolutionContext rcval(context);
+    result = typedSignatureInitial(&rcval, uSig);
+  }
+
+  return result;
 }
 
 static const TypedFnSignature*

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2530,7 +2530,7 @@ ApplicabilityResult instantiateSignature(ResolutionContext* rc,
                                       sig->outerVariables());
 
   // May need to resolve the body at this point to compute final TFS.
-  if (result->isInitializer() && !result->isCompilerGenerated()) {
+  if (result->isInitializer()) {
     auto rf = resolveFunction(rc, result, poiScope);
     result = rf->signature();
   }

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -525,7 +525,9 @@ static const Scope* const& scopeForIdQuery(Context* context, ID idIn) {
     // TODO: would it be beneficial to use idToTag in most cases here?
     const uast::AstNode* ast = parsing::idToAst(context, id);
     if (ast == nullptr) {
-      if (CompositeType::isMissingBundledType(context, id)) {
+      if (CompositeType::isMissingBundledType(context, id) ||
+          (id.isFabricatedId() &&
+          id.fabricatedIdKind() == ID::FabricatedIdKind::Generated)) {
         // if there are no bundled modules selected,
         // to enable testing, just return the top-level scope for these
         // built-in types

--- a/frontend/test/resolution/testCanPass.cpp
+++ b/frontend/test/resolution/testCanPass.cpp
@@ -606,12 +606,14 @@ static void test9() {
         var x;
       }
 
-      var a : Bar(int);
+      type t = Bar(int);
       var b = new Bar(3);
-      )""", {"a", "b"});
+      )""", {"t", "b"});
 
   CanPassResult r;
-  r = canPass(context, vars.at("b"), vars.at("a")); assert(passesAsIs(r));
+  QualifiedType t = vars.at("t");
+  auto formal = QualifiedType(QualifiedType::IN, t.type());
+  r = canPass(context, vars.at("b"), formal); assert(passesAsIs(r));
 }
 
 int main() {

--- a/frontend/test/resolution/testConstChecking.cpp
+++ b/frontend/test/resolution/testConstChecking.cpp
@@ -294,24 +294,18 @@ static void test6a() {
   testConstChecking("test6a",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) { }
-
         proc test() {
           const x: int = 0;
           x = 34;
         }
       }
     )"""",
-    {8});
+    {5});
 }
 static void test6b() {
   testConstChecking("test6b",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) { }
-
         proc test() {
           const x: int = 0;
           const ref y = x;
@@ -319,15 +313,12 @@ static void test6b() {
         }
       }
     )"""",
-    {9});
+    {6});
 }
 static void test6c() {
   testConstChecking("test6c",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) { }
-
         proc test() {
           const x: int = 0;
           ref y = x;
@@ -335,7 +326,7 @@ static void test6c() {
         }
       }
     )"""",
-    {8});
+    {5});
 }
 
 static void test7a() {

--- a/frontend/test/resolution/testCopyElision.cpp
+++ b/frontend/test/resolution/testCopyElision.cpp
@@ -133,10 +133,6 @@ static void test1() {
   testCopyElision("test1",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
 
         proc test() {
           var x:int = 0;
@@ -150,10 +146,6 @@ static void test2() {
   testCopyElision("test2",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
 
         proc test() {
           var x;
@@ -182,10 +174,6 @@ static void test4() {
   testCopyElision("test4",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
 
         proc test() {
           var x:int;
@@ -306,10 +294,6 @@ static void test12() {
   testCopyElision("test12",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
 
         proc test() {
           var x:int;
@@ -326,10 +310,6 @@ static void test13() {
   testCopyElision("test13",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
 
         proc test(cond: bool) {
           var x:int;
@@ -397,10 +377,6 @@ static void test17() {
   testCopyElision("test17",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
 
         proc test() {
           var x:int;
@@ -419,10 +395,6 @@ static void test18() {
   testCopyElision("test18",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
 
         proc test() {
           var x:int;
@@ -460,10 +432,6 @@ static void test20() {
   testCopyElision("test20",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
 
         proc test() {
           var x:int;
@@ -483,10 +451,6 @@ static void test21() {
   testCopyElision("test21",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
 
         proc test() {
           var x:int;
@@ -521,10 +485,6 @@ static void test23() {
   testCopyElision("test23",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
         record R {
           var field: int;
         }
@@ -541,10 +501,6 @@ static void test24() {
   testCopyElision("test24",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
         var x: int;
         var y = x;
       }
@@ -558,10 +514,6 @@ static void test25() {
   testCopyElision("test25",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
         var x: int;
         proc test() {
           var y = x;
@@ -577,10 +529,6 @@ static void test26() {
   testCopyElision("test26",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
 
         proc test() {
           var x: int;
@@ -598,10 +546,6 @@ static void test27() {
   testCopyElision("test27",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
 
         proc test() {
           var x: int;
@@ -621,10 +565,6 @@ static void test28() {
   testCopyElision("test28",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
 
         config const cond = true;
 
@@ -648,10 +588,6 @@ static void test29() {
   testCopyElision("test29",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
 
         config const cond = true;
 
@@ -676,10 +612,6 @@ static void test30() {
   testCopyElision("test30",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
         proc test(out x: int) {
           var y = x;
           return;
@@ -692,10 +624,6 @@ static void test31() {
   testCopyElision("test31",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
         proc test(out x: int) {
           var y = x;
         }
@@ -707,10 +635,6 @@ static void test32() {
   testCopyElision("test32",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
         proc test(inout x: int) {
           var y = x;
           return;
@@ -723,10 +647,6 @@ static void test33() {
   testCopyElision("test33",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
         proc test(inout x: int) {
           var y = x;
         }
@@ -739,10 +659,6 @@ static void test34() {
   testCopyElision("test34",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
 
         config const cond = true;
 
@@ -766,10 +682,6 @@ static void test35() {
   testCopyElision("test35a1",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
         config const cond = true;
         proc test() {
           var x: int = 0;
@@ -783,10 +695,6 @@ static void test35() {
   testCopyElision("test35a2",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
         config const cond = true;
         proc test() {
           var x: int = 0;
@@ -805,10 +713,6 @@ static void test35() {
   testCopyElision("test35a",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
 
         proc test() {
           var x: int = 0;
@@ -826,10 +730,6 @@ static void test35() {
   testCopyElision("test35b",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
 
         proc test() {
           var x: int = 0;
@@ -850,10 +750,6 @@ static void test36() {
   testCopyElision("test36a",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
 
         proc test() {
           var x: int = 0;
@@ -869,10 +765,6 @@ static void test36() {
   testCopyElision("test36b",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
 
         proc test() {
           var x: int = 0;
@@ -888,10 +780,6 @@ static void test36() {
   testCopyElision("test36c",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
 
         proc test() {
           var x: int = 0;
@@ -907,10 +795,6 @@ static void test36() {
   testCopyElision("test36d",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
 
         proc test() {
           var x: int = 0;
@@ -929,10 +813,6 @@ static void test37() {
   testCopyElision("test37a",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
 
         proc test() {
           var x: int = 0;
@@ -950,10 +830,6 @@ static void test37() {
   testCopyElision("test37b",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
 
         proc test() {
           var x: int = 0;
@@ -971,10 +847,6 @@ static void test37() {
   testCopyElision("test37c",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
 
         proc test() {
           var x: int = 0;
@@ -995,10 +867,6 @@ static void test38() {
   testCopyElision("test38a",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
 
         proc test() {
           var x: int = 0;
@@ -1015,10 +883,6 @@ static void test38() {
   testCopyElision("test38b",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
 
         proc test() {
           var x: int = 0;
@@ -1035,10 +899,6 @@ static void test38() {
   testCopyElision("test38c",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
 
         proc test() {
           var x: int = 0;
@@ -1058,10 +918,6 @@ static void test39() {
   testCopyElision("test39a",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
 
         proc test() {
           var x: int = 0;
@@ -1081,10 +937,6 @@ static void test39() {
   testCopyElision("test39b",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
 
         proc test() {
           var x: int = 0;
@@ -1104,10 +956,6 @@ static void test39() {
   testCopyElision("test39c",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
         config const cond = true;
         proc test() {
           var x: int = 0;
@@ -1133,10 +981,6 @@ static void test39() {
   testCopyElision("test39d",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
         config const cond = true;
         proc test() {
           var x: int = 0;
@@ -1165,10 +1009,6 @@ static void test40() {
   testCopyElision("test40a",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
 
         proc test() {
           var x: int = 0;
@@ -1185,10 +1025,6 @@ static void test40() {
   testCopyElision("test40b",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
 
         proc test() {
           var x: int = 0;
@@ -1207,10 +1043,6 @@ static void test40() {
   testCopyElision("test40c",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
 
         proc test() {
           var x: int = 0;
@@ -1223,7 +1055,6 @@ static void test40() {
             return;
           }
 
-          
         }
       }
     )"""",
@@ -1231,10 +1062,6 @@ static void test40() {
   testCopyElision("test40d",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
 
         proc test() {
           var x: int = 0;
@@ -1245,8 +1072,6 @@ static void test40() {
             x;
             return;
           }
-
-          
         }
       }
     )"""",
@@ -1254,10 +1079,6 @@ static void test40() {
   testCopyElision("test40e",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
 
         proc test() {
           var x: int = 0;
@@ -1268,7 +1089,6 @@ static void test40() {
             x;
           }
 
-          
         }
       }
     )"""",
@@ -1276,10 +1096,6 @@ static void test40() {
   testCopyElision("test40e",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
 
         proc test() {
           var x: int = 0;
@@ -1290,7 +1106,6 @@ static void test40() {
             return;
           }
 
-          
         }
       }
     )"""",
@@ -1298,10 +1113,6 @@ static void test40() {
   testCopyElision("test40f",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
 
         proc test() {
           var x: int = 0;
@@ -1312,8 +1123,7 @@ static void test40() {
             return;
           }
           x;
-          
-        }
+          }
       }
     )"""",
     {});
@@ -1323,10 +1133,6 @@ static void test41() {
   testCopyElision("test41a",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
         operator ==(ref lhs: int, rhs: int) {
           __primitive("==", lhs, rhs);
         }
@@ -1350,10 +1156,6 @@ static void test41() {
   testCopyElision("test41b",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
         operator ==(ref lhs: int, rhs: int) {
           __primitive("==", lhs, rhs);
         }
@@ -1383,10 +1185,6 @@ static void test42() {
   testCopyElision("test42a",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
         operator ==(ref lhs: int, rhs: int) {
           __primitive("==", lhs, rhs);
         }
@@ -1410,10 +1208,6 @@ static void test42() {
   testCopyElision("test42b",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
         operator ==(ref lhs: int, rhs: int) {
           __primitive("==", lhs, rhs);
         }
@@ -1440,10 +1234,6 @@ static void test43() {
   testCopyElision("test43a",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
         operator ==(ref lhs: int, rhs: int) {
           __primitive("==", lhs, rhs);
         }
@@ -1467,10 +1257,6 @@ static void test43() {
   testCopyElision("test43b",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
         operator ==(ref lhs: int, rhs: int) {
           __primitive("==", lhs, rhs);
         }

--- a/frontend/test/resolution/testForwarding.cpp
+++ b/frontend/test/resolution/testForwarding.cpp
@@ -133,7 +133,6 @@ static void test4() {
   const char* contents =
     R""""(
     module M {
-      operator =(ref lhs: int, rhs: int) { }
       operator +=(ref lhs: int, rhs: int) { }
       record Inner {
         var i: int;
@@ -168,7 +167,6 @@ static void test5a() {
   const char* contents =
     R""""(
     module M {
-      operator =(ref lhs: int, rhs: int) { }
       operator +=(ref lhs: int, rhs: int) { }
       record Inner1 {
         var i: int;
@@ -207,7 +205,6 @@ static void test5b() {
   const char* contents =
     R""""(
     module M {
-      operator =(ref lhs: int, rhs: int) { }
       operator +=(ref lhs: int, rhs: int) { }
       record Inner1 {
         var i: int;
@@ -256,7 +253,6 @@ static void test6a() {
   const char* contents =
     R""""(
     module M {
-      operator =(ref lhs: int, rhs: int) { }
       operator +=(ref lhs: int, rhs: int) { }
       record Inner1 {
         var i: int;
@@ -309,7 +305,6 @@ static void test6b() {
   const char* contents =
     R""""(
     module M {
-      operator =(ref lhs: int, rhs: int) { }
       operator +=(ref lhs: int, rhs: int) { }
       record Inner1 {
         var i: int;

--- a/frontend/test/resolution/testInitSemantics.cpp
+++ b/frontend/test/resolution/testInitSemantics.cpp
@@ -1509,6 +1509,32 @@ static void testInheritance() {
     x.type()->stringify(ss, chpl::StringifyKind::CHPL_SYNTAX);
     assert(ss.str() == "owned Child(int(64))");
   }
+
+  // Default initializer
+  {
+    Context ctx;
+    Context* context = &ctx;
+    ErrorGuard guard(context);
+
+    std::string program = R"""(
+      class A {
+        type TA;
+        var a : TA;
+      }
+      class B : A(?) {
+        type TB;
+        var b : TB;
+      }
+
+      var x = new B(int, 1, real, 42.0);
+      )""";
+
+    auto xt = resolveTypeOfX(context, program);
+
+    std::stringstream ss;
+    xt->stringify(ss, chpl::StringifyKind::CHPL_SYNTAX);
+    assert(ss.str() == "owned B(int(64), real(64))");
+  }
 }
 
 static void testImplicitSuperInit() {

--- a/frontend/test/resolution/testInitSemantics.cpp
+++ b/frontend/test/resolution/testInitSemantics.cpp
@@ -27,12 +27,6 @@
 
 #define TEST_NAME(ctx__) TEST_NAME_FROM_FN_NAME(ctx__)
 
-std::string opEquals = R"""(
-    operator =(ref lhs: int, rhs: int) {
-      __primitive("=", lhs, rhs);
-    }
-    )""";
-
 std::string otherOps = R"""(
     operator >(ref lhs: int, rhs: int) {
       return __primitive(">", lhs, rhs);
@@ -45,7 +39,7 @@ static void testFieldUseBeforeInit1(void) {
   ErrorGuard guard(ctx);
 
   auto path = TEST_NAME(ctx);
-  std::string contents = opEquals + R""""(
+  std::string contents = R""""(
     record r {
       var x: int;
     }
@@ -79,7 +73,7 @@ static void testFieldUseBeforeInit1(void) {
   // Check the first error to see if it lines up.
   auto& msg = guard.errors()[0];
   assert(msg->message() == "'x' is used before it is initialized");
-  assert(msg->location(ctx).firstLine() == 11);
+  assert(msg->location(ctx).firstLine() == 7);
   assert(guard.realizeErrors());
 }
 
@@ -89,7 +83,7 @@ static void testInitReturnVoid(void) {
   ErrorGuard guard(ctx);
 
   auto path = TEST_NAME(ctx);
-  std::string contents = opEquals + R""""(
+  std::string contents = R""""(
     record r {
       var x: int;
     }
@@ -117,7 +111,7 @@ static void testInitReturnVoid(void) {
   // Check the error (which comes last) to see if it lines up.
   auto& msg = guard.errors().back();
   assert(msg->message() == "initializers can only return 'void'");
-  assert(msg->location(ctx).firstLine() == 12);
+  assert(msg->location(ctx).firstLine() == 8);
   assert(guard.realizeErrors());
 }
 
@@ -127,7 +121,7 @@ static void testInitReturnEarly(void) {
   ErrorGuard guard(ctx);
 
   auto path = TEST_NAME(ctx);
-  std::string contents = opEquals + R""""(
+  std::string contents = R""""(
     record r {
       var x: int;
     }
@@ -155,7 +149,7 @@ static void testInitReturnEarly(void) {
   // Check the first error to see if it lines up.
   auto& msg = guard.errors()[0];
   assert(msg->message() == "cannot return from initializer before initialization is complete");
-  assert(msg->location(ctx).firstLine() == 11);
+  assert(msg->location(ctx).firstLine() == 7);
   assert(guard.realizeErrors());
 }
 
@@ -165,7 +159,7 @@ static void testInitThrow(void) {
   ErrorGuard guard(ctx);
 
   auto path = TEST_NAME(ctx);
-  std::string contents = opEquals + R""""(
+  std::string contents = R""""(
     record r {
       var x: int;
     }
@@ -193,7 +187,7 @@ static void testInitThrow(void) {
   // Check the first error to see if it lines up.
   auto& msg = guard.errors()[0];
   assert(msg->message() == "initializers are not yet allowed to throw errors");
-  assert(msg->location(ctx).firstLine() == 12);
+  assert(msg->location(ctx).firstLine() == 8);
   assert(guard.realizeErrors());
 }
 
@@ -203,7 +197,7 @@ static void testInitTryBang(void) {
   ErrorGuard guard(ctx);
 
   auto path = TEST_NAME(ctx);
-  std::string contents = opEquals + R""""(
+  std::string contents = R""""(
     record r {
       var x: int;
     }
@@ -232,7 +226,7 @@ static void testInitTryBang(void) {
   // Check the first error to see if it lines up.
   auto& msg = guard.errors()[0];
   assert(msg->message() == "Only catch-less try! statements are allowed in initializers for now");
-  assert(msg->location(ctx).firstLine() == 12);
+  assert(msg->location(ctx).firstLine() == 8);
   assert(guard.realizeErrors());
 }
 
@@ -261,7 +255,7 @@ static void testInitInsideLoops(void) {
     ErrorGuard guard(ctx);
 
     auto path = TEST_NAME(ctx);
-    std::string contents = opEquals + R""""(
+    std::string contents = R""""(
       record r {
         var x: int;
       }
@@ -288,7 +282,7 @@ static void testInitInsideLoops(void) {
     // Check the error (which comes last) to see if it lines up.
     auto& msg = guard.errors().back();
     assert(msg->message() == message);
-    assert(msg->location(ctx).firstLine() == 11);
+    assert(msg->location(ctx).firstLine() == 7);
     assert(guard.realizeErrors());
   }
 }
@@ -299,7 +293,7 @@ static void testThisComplete(void) {
   ErrorGuard guard(ctx);
 
   auto path = TEST_NAME(ctx);
-  std::string contents = opEquals + R""""(
+  std::string contents = R""""(
     record r {
       var x: int;
       var y : int;
@@ -333,7 +327,7 @@ static void testSecondAssign(void) {
   ErrorGuard guard(ctx);
 
   auto path = TEST_NAME(ctx);
-  std::string contents = opEquals + R""""(
+  std::string contents = R""""(
     record r {
       var x: int;
     }
@@ -364,7 +358,7 @@ static void testOutOfOrder(void) {
   ErrorGuard guard(ctx);
 
   auto path = TEST_NAME(ctx);
-  std::string contents = opEquals + R""""(
+  std::string contents = R""""(
     record r {
       var x, y, z: int;
     }
@@ -390,7 +384,7 @@ static void testOutOfOrder(void) {
 
   auto& msg = guard.errors()[0];
   assert(msg->message() == "Field \"x\" initialized out of order");
-  assert(msg->location(ctx).firstLine() == 11);
+  assert(msg->location(ctx).firstLine() == 7);
   assert(guard.realizeErrors());
 }
 
@@ -400,7 +394,7 @@ static void testInitCondBasic(void) {
   ErrorGuard guard(ctx);
 
   auto path = TEST_NAME(ctx);
-  std::string contents = opEquals + R""""(
+  std::string contents = R""""(
     record r {
       var x: int;
       var y : int;
@@ -439,7 +433,7 @@ static void testInitCondBadOrder(void) {
   ErrorGuard guard(ctx);
 
   auto path = TEST_NAME(ctx);
-  std::string contents = opEquals + R""""(
+  std::string contents = R""""(
     record r {
       var x: int;
       var y : int;
@@ -472,12 +466,12 @@ static void testInitCondBadOrder(void) {
   {
     auto& msg = guard.errors()[0];
     assert(msg->message() == "Field \"x\" initialized out of order");
-    assert(msg->location(ctx).firstLine() == 14);
+    assert(msg->location(ctx).firstLine() == 10);
   }
   {
     auto& msg = guard.errors()[1];
     assert(msg->message() == "Field \"y\" initialized out of order");
-    assert(msg->location(ctx).firstLine() == 16);
+    assert(msg->location(ctx).firstLine() == 12);
   }
   assert(guard.realizeErrors());
 }
@@ -488,7 +482,7 @@ static void testInitCondGenericDiff(void) {
   ErrorGuard guard(ctx);
 
   auto path = TEST_NAME(ctx);
-  std::string contents = opEquals + R""""(
+  std::string contents = R""""(
     operator >(const lhs : int, const rhs : int) {
       return __primitive(">", lhs, rhs);
     }
@@ -528,7 +522,7 @@ static void testInitCondGenericDiff(void) {
   // Check the first error to see if it lines up.
   auto& msg = guard.errors()[0];
   assert(msg->message() == "Initializer must compute the same type in each branch");
-  assert(msg->location(ctx).firstLine() == 14);
+  assert(msg->location(ctx).firstLine() == 10);
   assert(guard.realizeErrors());
 }
 
@@ -538,7 +532,7 @@ static void testInitCondGeneric(void) {
   ErrorGuard guard(ctx);
 
   auto path = TEST_NAME(ctx);
-  std::string contents = opEquals + R""""(
+  std::string contents = R""""(
     operator >(const lhs : int, const rhs : int) {
       return __primitive(">", lhs, rhs);
     }
@@ -582,7 +576,7 @@ static void testInitParamCondGeneric(void) {
   ErrorGuard guard(ctx);
 
   auto path = UniqueString::get(ctx, "mod");
-  std::string contents = opEquals + R""""(
+  std::string contents = R""""(
     operator >(const lhs : int, const rhs : int) {
       return __primitive(">", lhs, rhs);
     }
@@ -624,16 +618,16 @@ static void testInitParamCondGeneric(void) {
   assert(guard.errors().size() == 0);
 
   {
-    auto t = mod->stmt(3)->toVariable();
+    auto t = mod->stmt(2)->toVariable();
     auto tType = rr.byAst(t).type();
-    auto X = mod->stmt(5)->toVariable();
+    auto X = mod->stmt(4)->toVariable();
     auto XType = rr.byAst(X).type();
     assert(tType.type() == XType.type());
   }
   {
-    auto f = mod->stmt(4)->toVariable();
+    auto f = mod->stmt(3)->toVariable();
     auto fType = rr.byAst(f).type();
-    auto Y = mod->stmt(6)->toVariable();
+    auto Y = mod->stmt(5)->toVariable();
     auto YType = rr.byAst(Y).type();
     assert(fType.type() == YType.type());
   }
@@ -645,7 +639,7 @@ static void testNotThisDot(void) {
   ErrorGuard guard(ctx);
 
   auto path = TEST_NAME(ctx);
-  std::string contents = opEquals + otherOps + R""""(
+  std::string contents = otherOps + R""""(
     record X {
       proc type foo() {
         return 5;
@@ -695,11 +689,7 @@ static void testRelevantInit(void) {
   //
 
   auto path = TEST_NAME(ctx);
-  std::string contents = opEquals + otherOps + R""""(
-    operator =(ref lhs: int, const rhs: int) {
-      __primitive("=", lhs, rhs);
-    }
-
+  std::string contents = otherOps + R""""(
     record X {
       var val : int;
     }
@@ -743,7 +733,7 @@ static void testOwnedUserInit(void) {
   // class doesn't make it a candidate.
 
   auto path = TEST_NAME(ctx);
-  std::string contents = opEquals + otherOps + R""""(
+  std::string contents = otherOps + R""""(
     class Parent {
       proc init() {}
     }
@@ -1131,8 +1121,6 @@ static void testUseAfterInit() {
       return ret;
     }
 
-    operator =(ref lhs: real, const rhs: real) { __primitive("=", lhs, rhs); }
-
     class PointDoubleX {
       var a, b : real;
 
@@ -1163,9 +1151,6 @@ static void testInitEqOther(void) {
   ErrorGuard guard(ctx);
 
   std::string program = R"""(
-    operator =(ref lhs: numeric, const in rhs: numeric) {
-      __primitive("=", lhs, rhs);
-    }
     record R {
       type T;
       var field : T;
@@ -1341,9 +1326,6 @@ static void testInheritance() {
       operator *(const lhs: int, rhs: real) : real {
         return __primitive("*", lhs, rhs);
       }
-      operator =(ref lhs: real, const rhs: real) : void {
-        __primitive("=", lhs, rhs);
-      }
 
       proc Child.init() {
         this.y = x * 42.0;
@@ -1368,8 +1350,6 @@ static void testInheritance() {
       operator *(const lhs: int, rhs: real) : real {
         return __primitive("*", lhs, rhs);
       }
-      operator =(ref lhs: real, const rhs: real) : void {}
-      operator =(ref lhs: int, const rhs: int) : void {}
 
       proc Child.init() {
         this.x = 42;

--- a/frontend/test/resolution/testMaybeConst.cpp
+++ b/frontend/test/resolution/testMaybeConst.cpp
@@ -278,9 +278,6 @@ static void test3h() {
   testMaybeRef("test3h",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) { }
-
         var global: int;
         proc foo() ref { return global; }         // M.foo
         proc foo() const ref { return global; }   // M.foo#1
@@ -298,9 +295,6 @@ static void test3i() {
   testMaybeRef("test3i",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) { }
-
         var global: int;
         proc foo() ref { return global; }         // M.foo
         proc foo() const ref { return global; }   // M.foo#1
@@ -434,9 +428,6 @@ static void test4h() {
   testMaybeRef("test4h",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) { }
-
         var global: int;
         proc foo() ref { return global; }         // M.foo
         proc foo() { return global; }             // M.foo#1
@@ -454,9 +445,6 @@ static void test4i() {
   testMaybeRef("test4i",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) { }
-
         var global: int;
         proc foo() ref { return global; }         // M.foo
         proc foo() { return global; }             // M.foo#1
@@ -751,9 +739,6 @@ static void test6h() {
   testMaybeRef("test6h",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) { }
-
         var global: int;
         proc foo() const ref { return global; }     // M.foo
         proc foo() { return global; }               // M.foo#1
@@ -772,9 +757,6 @@ static void test6i() {
   testMaybeRef("test6i",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) { }
-
         var global: int;
         proc foo() ref { return global; }        // M.foo
         proc foo() const ref { return global; }  // M.foo#1

--- a/frontend/test/resolution/testNew.cpp
+++ b/frontend/test/resolution/testNew.cpp
@@ -148,7 +148,7 @@ static void testEmptyRecordCompilerGenInit() {
   auto& associatedActions = reNewCall.associatedActions();
   assert(associatedActions.size() == 1);
   auto initTfs = associatedActions[0].fn();
-  assert(initTfs->id() == r->id());
+  assert(initTfs->untyped()->compilerGeneratedOrigin() == r->id());
   assert(initTfs->numFormals() == 1);
   assert(initTfs->formalName(0) == "this");
 
@@ -241,8 +241,7 @@ static void testTertMethodCallCrossModule() {
   assert(tfsInit);
   auto ufsInit = tfsInit->untyped();
   assert(ufsInit);
-  assert(!tfsInit->id().isEmpty());
-  assert(tfsInit->id().symbolPath() == "A.C");
+  assert(tfsInit->untyped()->compilerGeneratedOrigin().symbolPath() == "A.C");
   assert(ufsInit->isCompilerGenerated());
   assert(tfsInit->numFormals() == 1);
   assert(tfsInit->formalName(0) == "this");

--- a/frontend/test/resolution/testSplitInit.cpp
+++ b/frontend/test/resolution/testSplitInit.cpp
@@ -121,11 +121,6 @@ static void test1() {
   testSplitInit("test1",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test() {
           var x:int = 0;
         }
@@ -138,11 +133,6 @@ static void test2() {
   testSplitInit("test2",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test() {
           var yes1;
           yes1 = 1;
@@ -156,11 +146,6 @@ static void test3() {
   testSplitInit("test3",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test() {
           var yes1:int;
           yes1 = 1;
@@ -175,11 +160,6 @@ static void test4() {
   testSplitInit("test4",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test() {
           var x:int = 0;
           var yes2;
@@ -197,11 +177,6 @@ static void test5() {
   testSplitInit("test5",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test(cond: bool) {
           var x:int = 0;
           var yes3;
@@ -230,11 +205,6 @@ static void test6() {
   testSplitInit("test6",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test(cond: bool, otherCond: bool) {
           var yes5;
           if cond {
@@ -254,11 +224,6 @@ static void test7() {
   testSplitInit("test7",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test() {
           var no1 = 4;
           no1 = 5;
@@ -272,11 +237,6 @@ static void test8() {
   testSplitInit("test8",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test() {
           {
             var no2:int;
@@ -293,11 +253,6 @@ static void test9() {
   testSplitInit("test9",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test() {
           {
             var no3:int;
@@ -314,11 +269,6 @@ static void test10() {
   testSplitInit("test10",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test(cond: bool) {
           var x;
           if cond then
@@ -334,11 +284,6 @@ static void test11() {
   testSplitInit("test11",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test(cond: bool) throws {
           var x;
           if cond then
@@ -354,11 +299,6 @@ static void test12() {
   testSplitInit("test12",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test() {
           var x:int;
           try {
@@ -378,11 +318,6 @@ static void test13() {
   testSplitInit("test13",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test() {
           var x:int;
           try {
@@ -401,11 +336,6 @@ static void test14() {
   testSplitInit("test14",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test() {
           var x:int;
           try {
@@ -425,11 +355,6 @@ static void test15() {
   testSplitInit("test15",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test() {
           var x:int;
           try {
@@ -446,11 +371,6 @@ static void test16() {
   testSplitInit("test16",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test(out formal: int) {
           formal = 4;
         }
@@ -463,11 +383,6 @@ static void test17() {
   testSplitInit("test17",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc fOut(out formal: int) { formal = 4; }
         proc test() {
           var x:int;
@@ -482,11 +397,6 @@ static void test18() {
   testSplitInit("test18",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc fOut(out formal: int) { formal = 4; }
         proc test() {
           var x;
@@ -501,11 +411,6 @@ static void test19() {
   testSplitInit("test19",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc int.fOut(out formal: int) { formal = 4; }
         proc test() {
           var myInt = 4;
@@ -522,13 +427,6 @@ static void test20() {
   testSplitInit("test20",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-        operator =(ref lhs: (int,), rhs: (int,)) {
-        }
-
         proc fOut(out formals:int...) {
           formals = (4,);
         }
@@ -545,13 +443,6 @@ static void test21() {
   testSplitInit("test21",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-        operator =(ref lhs: (int,int), rhs: (int,int)) {
-        }
-
         proc fOut(out formals:int...) {
           formals = (4,5);
         }
@@ -571,13 +462,6 @@ static void test22() {
   testSplitInit("test22",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-        operator =(ref lhs: (int,), rhs: (int,)) {
-        }
-
         proc fOut(out formals...) {
           formals = (4,);
         }
@@ -594,13 +478,6 @@ static void test23() {
   testSplitInit("test23",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-        operator =(ref lhs: (int,int), rhs: (int,int)) {
-        }
-
         proc fOut(out formals...) {
           formals = (4,5);
         }
@@ -618,13 +495,6 @@ static void test24() {
   testSplitInit("test24",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-        operator =(ref lhs: (int,), rhs: (int,)) {
-        }
-
         proc fOut(out formals...) {
           formals = (4,);
         }
@@ -640,13 +510,6 @@ static void test25() {
   testSplitInit("test25",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-        operator =(ref lhs: (int,int), rhs: (int,int)) {
-        }
-
         proc fOut(out formals...) {
           formals = (4,5);
         }
@@ -664,10 +527,6 @@ static void test26a() {
   testSplitInit("test26a",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
         proc test(r: bool) {
           var x;
           if r {
@@ -685,17 +544,6 @@ static void test26b() {
   testSplitInit("test26b",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-        operator =(ref lhs: real, rhs: real) {
-          __primitive("=", lhs, rhs);
-        }
-        operator =(ref lhs: int(8), rhs: int(8)) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test(r: bool) {
           var x;
           if r {
@@ -713,14 +561,6 @@ static void test26c() {
   testSplitInit("test26c",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-        operator =(ref lhs: int(8), rhs: int(8)) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test(r: bool) {
           var x;
           if r {
@@ -739,11 +579,6 @@ static void test27() {
   testSplitInit("test27",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test(ref arg: int) {
           var x:int;
           on arg {
@@ -759,11 +594,6 @@ static void test28() {
   testSplitInit("test28",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test() {
           var x:int;
           local {
@@ -779,11 +609,6 @@ static void test29() {
   testSplitInit("test29",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test() {
           var x:int;
           serial {
@@ -799,14 +624,6 @@ static void test30() {
   testSplitInit("test30",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-        operator =(ref lhs: int(8), rhs: int(8)) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test(r: bool) {
           var x, y;
           if r {
@@ -827,11 +644,6 @@ static void test31() {
   testSplitInit("test31",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test() {
           var x: int;
           inner1();
@@ -849,11 +661,6 @@ static void test32() {
   testSplitInit("test32",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test() {
           var x: int;
           proc inner1() {
@@ -871,11 +678,6 @@ static void test33() {
   testSplitInit("test33",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test() {
           var x: int;
           inner1();
@@ -893,11 +695,6 @@ static void test34() {
   testSplitInit("test34",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test() {
           var x: int;
           proc inner1() {
@@ -917,11 +714,6 @@ static void test35() {
   testSplitInit("test35",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         var g: int;
         proc f(out x: int) const ref { return g; }
         proc f(    x: int)       ref { return g; }
@@ -938,11 +730,6 @@ static void test36() {
   testSplitInit("test36",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         var g: int;
         proc f(out x: int,     y: int) const ref { return g; }
         proc f(    x: int, out y: int)       ref { return g; }
@@ -960,11 +747,6 @@ static void test37() {
   testSplitInit("test37",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test(cond: bool) {
           var x;
           if cond then
@@ -980,11 +762,6 @@ static void test38() {
   testSplitInit("test38",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test() {
           var x:int;
           if x {
@@ -1002,11 +779,6 @@ static void test39() {
   testSplitInit("test39",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test() {
           var x:int;
           var y = x;
@@ -1021,11 +793,6 @@ static void test40() {
   testSplitInit("test40",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test(cond: bool) {
           var x:int;
           if cond {
@@ -1042,11 +809,6 @@ static void test41() {
   testSplitInit("test41",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test() {
           var x:int;
           {
@@ -1063,11 +825,6 @@ static void test42() {
   testSplitInit("test42",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test() throws {
           var x:int;
           try {
@@ -1084,11 +841,6 @@ static void test43() {
   testSplitInit("test43",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test() {
           var x:int;
           try {
@@ -1106,11 +858,6 @@ static void test44() {
   testSplitInit("test44",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test(cond: bool) {
           var x:int;
           if cond {
@@ -1132,11 +879,6 @@ static void test45() {
   testSplitInit("test45",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test(cond: bool) {
           var x:int;
           if cond {
@@ -1156,11 +898,6 @@ static void test46() {
   testSplitInit("test46",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test(cond: bool) {
           var x:int;
           if cond {
@@ -1186,11 +923,6 @@ static void test47() {
   testSplitInit("test47",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         config var cond = true;
 
         proc test(out x: int) {
@@ -1210,11 +942,6 @@ static void test48() {
   testSplitInit("test48",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test(out x: int) {
           try {
           } catch {
@@ -1230,11 +957,6 @@ static void test49() {
   testSplitInit("test49",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test(out x: int) {
           return;
           x = 23;
@@ -1253,11 +975,6 @@ static void test50() {
   testSplitInit("test50",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         config var cond = false;
 
         proc test(out x: int) throws {
@@ -1275,11 +992,6 @@ static void test51() {
   testSplitInit("test51",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test(out x: int) throws {
           try {
             x = 5;
@@ -1296,11 +1008,6 @@ static void test52() {
   testSplitInit("test52",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test(out x: int) throws {
           throw nil;
           x = 23;
@@ -1314,11 +1021,6 @@ static void test53() {
   testSplitInit("test53",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         config var cond = false;
 
         proc test() throws {
@@ -1339,11 +1041,6 @@ static void test54() {
   testSplitInit("test54",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test() {
           var x;
           if true then
@@ -1359,11 +1056,6 @@ static void test55() {
   testSplitInit("test55",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test() {
           var x;
           if false then
@@ -1379,11 +1071,6 @@ static void test56() {
   testSplitInit("test56",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test() {
           type T = int;
           var x;
@@ -1400,11 +1087,6 @@ static void test57() {
   testSplitInit("test57",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test() {
           var x;
           if false then
@@ -1421,11 +1103,6 @@ static void test58() {
   testSplitInit("test58",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test() {
           var x;
           if true then
@@ -1444,11 +1121,6 @@ static void test59() {
   testSplitInit("test59",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test() {
           var x;
           if false then
@@ -1467,10 +1139,6 @@ static void test60() {
   testSplitInit("test60",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
         config const cond: bool = true;
         proc test() {
           var x;
@@ -1490,10 +1158,6 @@ static void test61() {
   testSplitInit("test61",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
         config const cond: bool = true;
         proc test() {
           var x;
@@ -1513,16 +1177,11 @@ static void test62() {
   testSplitInit("test62",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
         operator ==(ref lhs: int, rhs: int) {
           __primitive("==", lhs, rhs);
         }
 
         proc test(i: int) {
-          
           var x;
           select i {
             when 0 {
@@ -1546,16 +1205,11 @@ static void test63() {
   testSplitInit("test63",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
         operator ==(ref lhs: int, rhs: int) {
           __primitive("==", lhs, rhs);
         }
 
         proc test(i: int) {
-          
           var x;
           select i {
             when 0 {
@@ -1576,16 +1230,11 @@ static void test64() {
   testSplitInit("test64",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
         operator ==(ref lhs: int, rhs: int) {
           __primitive("==", lhs, rhs);
         }
 
         proc test(i: int) {
-          
           var x;
           select i {
             when 0 {
@@ -1610,17 +1259,12 @@ static void test65() {
   testSplitInit("test65",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
         operator ==(ref lhs: int, rhs: int) {
           __primitive("==", lhs, rhs);
         }
 
         config const i: int;
         proc test(i: int) {
-          
           var x;
           select i {
             when 0 {
@@ -1643,24 +1287,18 @@ static void test66() {
   testSplitInit("test66",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
         operator ==(ref lhs: int, rhs: int) {
           __primitive("==", lhs, rhs);
         }
 
         config const i: int;
         proc test(i: int) {
-          
           var x;
           select i {
             when 0 {
               x = 11;
             }
             when 1 {
-              
             }
             otherwise {
               x = 13;
@@ -1678,17 +1316,12 @@ static void test67() {
   testSplitInit("test67a",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
         operator ==(ref lhs: int, rhs: int) {
           __primitive("==", lhs, rhs);
         }
 
         config const i: int;
         proc test(i: int) {
-          
           var x, y;
           select i {
             when 1 { x = 1; y = 2; }
@@ -1702,17 +1335,12 @@ static void test67() {
   testSplitInit("test67b",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
         operator ==(ref lhs: int, rhs: int) {
           __primitive("==", lhs, rhs);
         }
 
         config const i: int;
         proc test(i: int) {
-          
           var x, y, z;
           select i {
             when 1 { z = 0; return; }
@@ -1726,17 +1354,12 @@ static void test67() {
   testSplitInit("test67c",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
         operator ==(ref lhs: int, rhs: int) {
           __primitive("==", lhs, rhs);
         }
 
         config const i: int;
         proc test(i: int) {
-          
           var x, y, z;
           select i {
             when 1 { z = 0; return; }
@@ -1750,17 +1373,12 @@ static void test67() {
   testSplitInit("test67d",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
         operator ==(ref lhs: int, rhs: int) {
           __primitive("==", lhs, rhs);
         }
 
         config const i: int;
         proc test(i: int) {
-          
           var x,y,z;
           select i {
             when 1 { z = 0; y = 1; return;}
@@ -1778,11 +1396,6 @@ static void testParamTrueWhen() {
   testSplitInit("testFirstParamTrueWhenNoOtherwise",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test() {
           type T = int;
           var x;
@@ -1794,7 +1407,6 @@ static void testParamTrueWhen() {
 
             }
           }
-          
         }
       }
     )"""",
@@ -1802,11 +1414,6 @@ static void testParamTrueWhen() {
     testSplitInit("testSecondParamTrueWhenNoOtherwise",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test() {
           type T = real;
           var x: int;
@@ -1815,7 +1422,6 @@ static void testParamTrueWhen() {
               x = 11;
             }
             when real {
-              
             }
           }
         }
@@ -1825,11 +1431,6 @@ static void testParamTrueWhen() {
     testSplitInit("testNoParamTrueWhenNoOtherwise",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test() {
           type T = string;
           var x: int;
@@ -1838,7 +1439,6 @@ static void testParamTrueWhen() {
               x = 11;
             }
             when real {
-              
             }
           }
           x = 3;
@@ -1849,20 +1449,13 @@ static void testParamTrueWhen() {
     testSplitInit("testNoParamTrueWhenYesOtherwise",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test() {
           type T = string;
           var x: int;
           select T {
             when int {
-              
             }
             when real {
-              
             }
             otherwise {
               x = 2;
@@ -1878,10 +1471,6 @@ static void test64a() {
   testSplitInit("test64a_passing",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
         operator ==(ref lhs: int, rhs: int) {
           __primitive("==", lhs, rhs);
         }
@@ -1905,10 +1494,6 @@ static void test64a() {
     testSplitInit("test64a",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
         operator ==(ref lhs: int, rhs: int) {
           __primitive("==", lhs, rhs);
         }
@@ -1936,11 +1521,6 @@ static void test65a() {
   testSplitInit("test65a",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test() {
           type T = int;
           var x;
@@ -1963,11 +1543,6 @@ static void test68() {
   testSplitInit("test68",
     R""""(
       module M {
-        // this would be in the standard library...
-        operator =(ref lhs: int, rhs: int) {
-          __primitive("=", lhs, rhs);
-        }
-
         proc test() {
           param x:int;
           x = 5;


### PR DESCRIPTION
This PR changes the frontend to start generating uAST for default initializers, which allows us to support default initializers on classes that inherit. 

This PR replaces the current signature-based implementation for default initializers with uAST for a Function. This Function's body contains the suitable statements to initialize each field, as well as a "super.init" call if applicable. This code currently lacks suitable init-expressions for default-initializable formals, which is left as future work.

An UntypedFnSignature is built manually so that we can force resolution to accept non-existent default values for each formal, regardless of whether it has an init-expression or not.

The resulting TypedFnSignature is created with `typedSignatureInitial`. This might be overkill, but it keeps the code cleaner for the time being.

-----

Now that default initializers have actual bodies, the frontend is attempting to resolve various assignment operators only defined in the internal/standard modules. This was initially a problem for the dedicated frontend tests, which do not generally load the internal modules in which basic assignment operators are implemented. This PR updates the frontend to generate assignment operators for primitive types, tuples, and classes when the standard library is not available.

Testing:
- [x] test-dyno