### PR TITLE
Adjust `test-dyno` Makefile to allow parallel on macOS

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -182,7 +182,7 @@ frontend-shared: FORCE $(CHPL_CONFIG_CHECK) $(COMPILER_BUILD)
 
 test-frontend: FORCE frontend-tests $(CHPL_CONFIG_CHECK) $(COMPILER_BUILD)
 	@echo "Running the frontend tests..."
-	JOBSFLAG=`echo "$$MAKEFLAGS" | sed -n 's/.*\(-j\|--jobs=\) *\([0-9][0-9]*\).*/-j\2/p'` ; \
+	JOBSFLAG=`echo "$$MAKEFLAGS" | sed -n -E 's/.*(-j|--jobs=) *([0-9][0-9]*).*/-j\2/p'` ; \
 	  cd $(COMPILER_BUILD)/frontend/test && ctest $$JOBSFLAG . ;
 
 frontend-tests: $(CHPL_CONFIG_CHECK) $(COMPILER_BUILD)


### PR DESCRIPTION
Adjust the Dyno tests Makefile target to correctly use concurrency (as specified in `make` invocation) on macOS.

The problem was due to different syntax for capture groups and "or" on macOS `sed`. Fixed by adjusting the `sed` invocation to work on either macOS or GNU sed.

Getting a parallel run working also requires using GNU Make 4.x, which isn't the default on macOS -- see [backing issue](https://github.com/Cray/chapel-private/issues/6770).

[reviewer info placeholder]

Resolves https://github.com/Cray/chapel-private/issues/6770.

Testing:
- [x] `make -jN test-dyno` on my mac
- [x] `make -jN test-dyno` on chapdl
- [x] paratest cuz changing Makefiles is scary