### PR TITLE
Resolving nil assignments in record initialization

### DIFF
--- a/frontend/lib/resolution/InitResolver.cpp
+++ b/frontend/lib/resolution/InitResolver.cpp
@@ -760,6 +760,7 @@ bool InitResolver::handleAssignmentToField(const OpCall* node) {
     // TODO: Anything to do if the opposite is true?
     if (!isAlreadyInitialized) {
       auto& reRhs = initResolver_.byPostorder.byAst(rhs);
+      auto& reLhs = initResolver_.byPostorder.byId(lhs->id());
       state->qt = reRhs.type();
       state->initPointId = node->id();
       state->isInitialized = true;
@@ -769,7 +770,6 @@ bool InitResolver::handleAssignmentToField(const OpCall* node) {
       // field doesn't contribute to the receiver type.
       updateResolverVisibleReceiverType();
 
-      auto& reLhs = initResolver_.byPostorder.byId(lhs->id());
       auto lhsQt = reLhs.type();
       auto lhsKind = lhsQt.kind();
       if (lhsKind != QualifiedType::TYPE && lhsKind != QualifiedType::PARAM && isConstQualifier(lhsKind)) {
@@ -891,6 +891,10 @@ void InitResolver::checkEarlyReturn(const Return* ret) {
       (size_t)currentFieldIndex_ < fieldIdsByOrdinal_.size()) {
     ctx_->error(ret, "cannot return from initializer before initialization is complete");
   }
+}
+
+bool InitResolver::isInitPoint(const uast::AstNode* node) {
+  return initPoints.find(node) != initPoints.end();
 }
 
 } // end namespace resolution

--- a/frontend/lib/resolution/InitResolver.cpp
+++ b/frontend/lib/resolution/InitResolver.cpp
@@ -769,9 +769,8 @@ bool InitResolver::handleAssignmentToField(const OpCall* node) {
       // field doesn't contribute to the receiver type.
       updateResolverVisibleReceiverType();
 
-      auto reLhs = initResolver_.byPostorder.byId(lhs->id());
+      auto& reLhs = initResolver_.byPostorder.byId(lhs->id());
       auto lhsQt = reLhs.type();
-
       auto lhsKind = lhsQt.kind();
       if (lhsKind != QualifiedType::TYPE && lhsKind != QualifiedType::PARAM && isConstQualifier(lhsKind)) {
         // Regardless of the field's intent, it is mutable in this expression.

--- a/frontend/lib/resolution/InitResolver.cpp
+++ b/frontend/lib/resolution/InitResolver.cpp
@@ -769,13 +769,17 @@ bool InitResolver::handleAssignmentToField(const OpCall* node) {
       // field doesn't contribute to the receiver type.
       updateResolverVisibleReceiverType();
 
-      auto lhsKind = state->qt.kind();
-      if (lhsKind != QualifiedType::TYPE && lhsKind != QualifiedType::PARAM) {
+      auto reLhs = initResolver_.byPostorder.byId(lhs->id());
+      auto lhsQt = reLhs.type();
+
+      auto lhsKind = lhsQt.kind();
+      if (lhsKind != QualifiedType::TYPE && lhsKind != QualifiedType::PARAM && isConstQualifier(lhsKind)) {
         // Regardless of the field's intent, it is mutable in this expression.
         lhsKind = QualifiedType::REF;
       }
-      auto lhsType = QualifiedType(lhsKind, state->qt.type(), state->qt.param());
+      auto lhsType = QualifiedType(lhsKind, lhsQt.type(), lhsQt.param());
       initResolver_.byPostorder.byAst(lhs).setType(lhsType);
+      initPoints.insert(node);
 
     } else {
       CHPL_ASSERT(0 == "Not handled yet!");

--- a/frontend/lib/resolution/InitResolver.h
+++ b/frontend/lib/resolution/InitResolver.h
@@ -129,6 +129,9 @@ class InitResolver {
 
 public:
 
+  //initialization points to guide handling `=` operators 
+  std::set<const uast::AstNode*> initPoints;
+
   static owned<InitResolver>
   create(Context* context, Resolver& visitor, const uast::Function* fn);
 

--- a/frontend/lib/resolution/InitResolver.h
+++ b/frontend/lib/resolution/InitResolver.h
@@ -158,6 +158,9 @@ public:
   const TypedFnSignature* finalize(void);
 
   void checkEarlyReturn(const uast::Return* ret);
+
+  // Returns true if the AST node is an initialization point
+  bool isInitPoint(const uast::AstNode* node);
 };
 
 } // end namespace resolution

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -901,7 +901,7 @@ void CallInitDeinit::handleAssign(const OpCall* ast, RV& rv) {
   processMentions(ast, rv);
   
   bool isIniting = splitInited;
-  isIniting |= resolver.initResolver && resolver.initResolver->initPoints.count(ast) > 0;
+  isIniting |= resolver.initResolver && resolver.initResolver->isInitPoint(ast);
   if (lhsType.isType() || lhsType.isParam()) {
     // these are basically 'move' initialization
     resolveMoveInit(ast, rhsAst, lhsType, rhsType, rv);

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -900,7 +900,8 @@ void CallInitDeinit::handleAssign(const OpCall* ast, RV& rv) {
   // check for use of deinited variables
   processMentions(ast, rv);
   
-  bool isIniting = splitInited || resolver.initResolver->initPoints.count(ast) > 0;
+  bool isIniting = splitInited;
+  isIniting |= resolver.initResolver && resolver.initResolver->initPoints.count(ast) > 0;
   if (lhsType.isType() || lhsType.isParam()) {
     // these are basically 'move' initialization
     resolveMoveInit(ast, rhsAst, lhsType, rhsType, rv);

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -900,12 +900,10 @@ void CallInitDeinit::handleAssign(const OpCall* ast, RV& rv) {
   // check for use of deinited variables
   processMentions(ast, rv);
   
-  bool isIniting = resolver.initResolver->initPoints.count(ast) > 0;
+  bool isIniting = splitInited || resolver.initResolver->initPoints.count(ast) > 0;
   if (lhsType.isType() || lhsType.isParam()) {
     // these are basically 'move' initialization
     resolveMoveInit(ast, rhsAst, lhsType, rhsType, rv);
-  } else if (splitInited) {
-    processInit(frame, ast, lhsType, rhsType, rv);
   } else if (isIniting) {
     processInit(frame, ast, lhsType, rhsType, rv);
   } else {

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -899,11 +899,14 @@ void CallInitDeinit::handleAssign(const OpCall* ast, RV& rv) {
 
   // check for use of deinited variables
   processMentions(ast, rv);
-
+  
+  bool isIniting = resolver.initResolver->initPoints.count(ast) > 0;
   if (lhsType.isType() || lhsType.isParam()) {
     // these are basically 'move' initialization
     resolveMoveInit(ast, rhsAst, lhsType, rhsType, rv);
   } else if (splitInited) {
+    processInit(frame, ast, lhsType, rhsType, rv);
+  } else if (isIniting) {
     processInit(frame, ast, lhsType, rhsType, rv);
   } else {
     // it is assignment, so resolve the '=' call

--- a/frontend/test/resolution/testInitSemantics.cpp
+++ b/frontend/test/resolution/testInitSemantics.cpp
@@ -1627,6 +1627,28 @@ static void testInitGenericAfterConcrete() {
   }
 }
 
+static void testNilFieldInit() {
+  std::string program = R"""(
+    class C { var x: int; }
+
+    record R {
+      var x: unmanaged C?;
+      proc init() {
+        x = nil;
+      }
+    }
+ 
+    var x: R;
+  )""";
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+  auto t = resolveTypeOfX(context, program);
+  assert(t);
+  assert(t->isRecordType());
+
+  assert(guard.errors().size() == 0);
+};
 // TODO:
 // - test using defaults for types and params
 //   - also in conditionals
@@ -1673,6 +1695,7 @@ int main() {
 
   testInitGenericAfterConcrete();
 
+  testNilFieldInit();
   return 0;
 }
 

--- a/frontend/test/resolution/testInitSemantics.cpp
+++ b/frontend/test/resolution/testInitSemantics.cpp
@@ -1643,12 +1643,21 @@ static void testNilFieldInit() {
   Context ctx;
   Context* context = &ctx;
   ErrorGuard guard(context);
-  auto t = resolveTypeOfX(context, program);
-  assert(t);
-  assert(t->isRecordType());
+  ResolutionContext rcval(context);
+  auto rc = &rcval;
+  auto m = parseModule(context, std::move(program));
+  auto recordDecl = m->stmt(1)->toAggregateDecl();
+  auto initFunc = recordDecl->declOrComment(1)->toFunction();
+  assert(initFunc);
+
+  auto untyped = UntypedFnSignature::get(context, initFunc);
+  auto typed = typedSignatureInitial(rc, untyped);
+  auto inFn = resolveFunction(rc, typed, nullptr);
+  assert(inFn);
 
   assert(guard.errors().size() == 0);
 };
+
 // TODO:
 // - test using defaults for types and params
 //   - also in conditionals


### PR DESCRIPTION
Resolves https://github.com/Cray/chapel-private/issues/6660.

Adds support for resolving field initialization where the field is initialized to `nil`, as in
```
class C { var x : int; }

record R {
  var x : unmanaged C?;

  proc init() {
    x = nil;
  }
}

var r : R;
```

This involved 2 changes. First, changing the `InitResolver` to use the declared type of an LHS for the LHS rather than the type of the RHS expression. Second, adding an `initPoints` field to the `InitResolver` that tracks the initialization points of fields. Then, in `call-init-deinit`, assignments are handled as initializations if the assignment is one of the initialization points.