### PR TITLE
Allow mason to use a license reference repo, to fix testing timeouts

### DIFF
--- a/test/mason/EXECENV
+++ b/test/mason/EXECENV
@@ -12,7 +12,7 @@ print('MASON_HOME=$PWD/mason_home')
 
 print('MASON_REGISTRY=registry|https://github.com/chapel-lang/mason-registry')
 print('MASON_OFFLINE=false')
-print('SPACK_ROOT=$MASON_HOME/spack')
+print('SPACK_ROOT=$PWD/mason_home/spack')
 
 cachePath = os.getenv('REPO_CACHE_PATH', default='')
 if cachePath != '':

--- a/test/mason/EXECENV
+++ b/test/mason/EXECENV
@@ -1,9 +1,19 @@
+#!/usr/bin/env python3
+
+import os
+
 # Ensure mason in PATH
-PATH=$CHPL_HOME/bin/$CHPL_HOST_BIN_SUBDIR:$PATH
+print('PATH=$CHPL_HOME/bin/$CHPL_HOST_BIN_SUBDIR:$PATH')
 
 # Mason envs
-MASON_HOME=$PWD/mason_home
+print('MASON_HOME=$PWD/mason_home')
+
 # Note, this registry should only ever be used by mason update tests
-MASON_REGISTRY=registry|https://github.com/chapel-lang/mason-registry
-MASON_OFFLINE=false
-SPACK_ROOT=$PWD/mason_home/spack
+
+print('MASON_REGISTRY=registry|https://github.com/chapel-lang/mason-registry')
+print('MASON_OFFLINE=false')
+print('SPACK_ROOT=$MASON_HOME/spack')
+
+cachePath = os.getenv('REPO_CACHE_PATH', default='')
+if cachePath != '':
+   print('MASON_LICENSE_CACHE_PATH=' + cachePath)

--- a/tools/mason/MasonEnv.chpl
+++ b/tools/mason/MasonEnv.chpl
@@ -112,6 +112,16 @@ proc MASON_REGISTRY {
   return registries;
 }
 
+/* Returns the path to use when caching the list of licenses, if provided by the
+   user.  This is useful for systems where internet connectivity can be erratic
+   or slow.
+ */
+proc MASON_LICENSE_CACHE_PATH: string {
+  const licenseCache = getEnv("MASON_LICENSE_CACHE_PATH");
+
+  return licenseCache;
+}
+
 proc masonEnv(args) {
 
   var parser = new argumentParser(helpHandler=new MasonEnvHelpHandler());

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -690,7 +690,8 @@ proc refreshLicenseList(overwrite=false) throws {
   const branch = '--branch main ';
   const depth = '--depth 1 ';
   const url = 'https://github.com/spdx/license-list-data.git ';
-  const referIfAble = " --reference-if-able " + dest;
+  const referIfAble = if MASON_LICENSE_CACHE_PATH != "" then
+    " --reference-if-able " + MASON_LICENSE_CACHE_PATH + "/spdx" else "";
   const command = 'git clone -q ' + branch + depth + url + dest + referIfAble;
   if !isDir(dest) {
     runCommand(command);

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -690,7 +690,8 @@ proc refreshLicenseList(overwrite=false) throws {
   const branch = '--branch main ';
   const depth = '--depth 1 ';
   const url = 'https://github.com/spdx/license-list-data.git ';
-  const command = 'git clone -q ' + branch + depth + url + dest;
+  const referIfAble = " --reference-if-able " + dest;
+  const command = 'git clone -q ' + branch + depth + url + dest + referIfAble;
   if !isDir(dest) {
     runCommand(command);
   } else if overwrite {

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -691,7 +691,8 @@ proc refreshLicenseList(overwrite=false) throws {
   const depth = '--depth 1 ';
   const url = 'https://github.com/spdx/license-list-data.git ';
   const referIfAble = if MASON_LICENSE_CACHE_PATH != "" then
-    " --reference-if-able " + MASON_LICENSE_CACHE_PATH + "/spdx" else "";
+    " --reference-if-able " + MASON_LICENSE_CACHE_PATH +
+      "/license-list-data.git" else "";
   const command = 'git clone -q ' + branch + depth + url + dest + referIfAble;
   if !isDir(dest) {
     runCommand(command);


### PR DESCRIPTION
We've been experiencing some sporadic failures to get the license information for Mason's `--refresh-license` flag.  This is likely due to connection issues.

Adds an environment variable to mason called `MASON_LICENSE_CACHE_PATH` that when present will indicate that the specified cache location should be used for the license repository, if needed.  Updates the `EXECENV` for the tests that were having problems to conditionally set this new environment variable to `REPO_CACHE_PATH` when it is set, which we already use for other cached repos.

Passed a full paratest with futures, and verified that the test passed both with and without `REPO_CACHE_PATH` defined