### PR TITLE
use chapel-blog sources inside chapel/test

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -409,14 +409,14 @@ if ($testblog == 1) {
             exit 1;
         }
     }
-    if ($blogonly == 0) {
-        # copy the relevant blog source files into the test directory so they'll be
-        # ran alongside all the other tests
-        mysystem("mkdir -p $testdir/copied-chapel-blog/content", "making chpl-src directory", $exitOnError, 1);
-        mysystem("cp -r $blogdir/chpl-src $testdir/copied-chapel-blog/", "copying chapel-blog/chpl-src", $exitOnError, 1);
-        mysystem("cp -r $blogdir/scripts $testdir/copied-chapel-blog/", "copying chapel-blog/scripts", $exitOnError, 1);
-        mysystem("cp -r $blogdir/content/posts $testdir/copied-chapel-blog/content/", "copying chapel-blog/content", $exitOnError, 1);
-    }
+    
+    # copy the relevant blog source files into the test directory so they'll be
+    # ran alongside all the other tests
+    mysystem("mkdir -p $testdir/copied-chapel-blog/content", "making chpl-src directory", $exitOnError, 1);
+    mysystem("cp -r $blogdir/chpl-src $testdir/copied-chapel-blog/", "copying chapel-blog/chpl-src", $exitOnError, 1);
+    mysystem("cp -r $blogdir/scripts $testdir/copied-chapel-blog/", "copying chapel-blog/scripts", $exitOnError, 1);
+    mysystem("cp -r $blogdir/content/posts $testdir/copied-chapel-blog/content/", "copying chapel-blog/content", $exitOnError, 1);
+    
 }
 
 # Determine which make to use.
@@ -633,7 +633,7 @@ if ($examples == 1) {
 if ($blogonly == 1 || ($testblog == 1 && $examples == 1)) {
     # test the sub-directories explicitly to avoid a bunch of skipped directories,
     # and also avoid the problem of testing the archetypes directory
-    $testdirs .= " $blogdir/chpl-src/ $blogdir/content/posts";
+    $testdirs .= " $testdir/copied-chapel-blog/";
 }
 
 if ($chplcheckonly == 1) {

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -411,7 +411,10 @@ if ($testblog == 1) {
     }
     
     # copy the relevant blog source files into the test directory so they'll be
-    # ran alongside all the other tests
+    # ran alongside all the other tests and the results will truncate $CHPL_HOME
+    # from the test file paths when reporting errors. Copying specific subdirectories
+    # this way avoids a bunch of skipped directories and the problem of testing
+    # the archetypes blog directory.
     mysystem("mkdir -p $testdir/copied-chapel-blog/content", "making chpl-src directory", $exitOnError, 1);
     mysystem("cp -r $blogdir/chpl-src $testdir/copied-chapel-blog/", "copying chapel-blog/chpl-src", $exitOnError, 1);
     mysystem("cp -r $blogdir/scripts $testdir/copied-chapel-blog/", "copying chapel-blog/scripts", $exitOnError, 1);
@@ -631,8 +634,6 @@ if ($examples == 1) {
 }
 
 if ($blogonly == 1 || ($testblog == 1 && $examples == 1)) {
-    # test the sub-directories explicitly to avoid a bunch of skipped directories,
-    # and also avoid the problem of testing the archetypes directory
     $testdirs .= " $testdir/copied-chapel-blog/";
 }
 


### PR DESCRIPTION
This makes a minor change to the nightly script when testing the chapel-blog. Instead of testing from a directory external to `$CHPL_HOME`, now the relevant blog sub directories will be copied into `$CHPL_HOME/test/copied-chapel-blog/` so that reports on failures will not include the full path, which was exposing test machine directory structure.

TESTING:

- [x] local testing of `test-linux64-llvm16.bash`

[reviewed by @riftEmber - thanks!]