### PR TITLE
add blog to gpu-cuda nightly config

### DIFF
--- a/util/cron/test-gpu-cuda.bash
+++ b/util/cron/test-gpu-cuda.bash
@@ -13,4 +13,4 @@ export CHPL_COMM=none
 export CHPL_LAUNCHER_PARTITION=stormP100
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-cuda"
-$CWD/nightly -cron ${nightly_args}
+$CWD/nightly -cron -blog ${nightly_args}


### PR DESCRIPTION
This adds blog testing to a single correctness test for GPU builds, `cray-cs-gpu-correctness-test-gpu-cuda`

It requires a companion PR in CI config https://github.hpe.com/hpe/hpc-chapel-ci-config/pull/1287

[reviewed by @riftEmber - thanks!]