### PR TITLE
Change the CUDA module loaded in CUDA 11 EX tests

### DIFF
--- a/util/cron/test-gpu-ex-cuda-11.bash
+++ b/util/cron/test-gpu-ex-cuda-11.bash
@@ -6,7 +6,7 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-native-gpu.bash
 source $CWD/common-hpe-cray-ex.bash
 
-module load cudatoolkit/23.9_11.8
+module load cuda/11.8
 
 # the module loaded above doesn't wire symlinks correctly. I've created a ticket
 # for that, but until that's fixed, we are setting this environment explicitly


### PR DESCRIPTION
Since cudatoolkit is deprecated (and also 23.9 was not available anymore), this change switches to using the cuda/11.8 module instead.

Will fix nightly build failures.

- [x] GPU tests on pinoak