### PR TITLE
Prevent infinite loop due to mutually recursive module init functions

### DIFF
--- a/compiler/util/astlocs.cpp
+++ b/compiler/util/astlocs.cpp
@@ -185,6 +185,9 @@ Expr* findLocationIgnoringInternalInlining(Expr* cur) {
         (startsWithChpl==false && inlined==false))
       return cur;
 
+    // If we're in a module init function, we can't go any further
+    if (curFn->hasFlag(FLAG_MODULE_INIT)) return cur;
+
     // Look for a call to that function
     CallExpr* anyCall = NULL;
     CallExpr* userCall = NULL;

--- a/test/modules/vass/userInsteadOfStandard/foo2.good
+++ b/test/modules/vass/userInsteadOfStandard/foo2.good
@@ -1,3 +1,3 @@
 ChapelIO.chpl:55: In function 'testchapelio':
 ChapelIO.chpl:56: warning: test warning
-foo2.chpl:1: error: done
+foo2.chpl:11: error: done


### PR DESCRIPTION
Prevents error handling code from getting into a cycle of following mutually recursive functions.

Resolves https://github.com/chapel-lang/chapel/issues/26029

Testing:
- [x] Tested that original issue is resolved
- [x] Full paratest with/without comm for a sanity check

[Reviewed by @e-kayrakli]