### PR TITLE
LSP: fix "call hierarchy" across files

### DIFF
--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2150,8 +2150,8 @@ ApplicabilityResult instantiateSignature(ResolutionContext* rc,
   const TypedFnSignature* parentSignature = sig->parentFn();
   if (parentSignature) {
     for (auto up = parentSignature; up; up = up->parentFn()) {
-      CHPL_ASSERT(!up->needsInstantiation());
       if (up->needsInstantiation()) {
+        CHPL_UNIMPL("parent function needs instantiation");
         return ApplicabilityResult::failure(sig->id(), FAIL_CANDIDATE_OTHER);
       }
     }

--- a/tools/chapel-py/src/python-types.h
+++ b/tools/chapel-py/src/python-types.h
@@ -92,7 +92,7 @@ template <typename T>
 std::vector<T> unwrapVector(ContextObject* CONTEXT, PyObject* vec) {
   std::vector<T> toReturn(PyList_Size(vec));
   for (ssize_t i = 0; i < PyList_Size(vec); i++) {
-    toReturn.push_back(PythonReturnTypeInfo<T>::unwrap(CONTEXT, PyList_GetItem(vec, i)));
+    toReturn[i] = PythonReturnTypeInfo<T>::unwrap(CONTEXT, PyList_GetItem(vec, i));
   }
   return toReturn;
 }

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -1165,7 +1165,7 @@ class ChapelLanguageServer(LanguageServer):
         then the FileInfo's index is rebuilt even if it has already been
         computed. This is useful if the underlying file has changed.
 
-        Most of the tiem, we will create a new context for a given URI. When
+        Most of the time, we will create a new context for a given URI. When
         requested, however, context_id will be used to create a FileInfo
         for a specific context. This is useful if e.g., file A wants to display
         an instantiation in file B.
@@ -1493,7 +1493,7 @@ class ChapelLanguageServer(LanguageServer):
                 MessageType.Error,
             )
             return None
-        uid, idx, ctx = item.data
+        uid, inst_id, ctx = item.data
 
         fi, _ = self.get_file_info(item.uri, context_id=ctx)
 
@@ -1509,7 +1509,7 @@ class ChapelLanguageServer(LanguageServer):
             # We don't handle that here.
             return None
 
-        instantiation = fi.context.retrieve_signature(idx)
+        instantiation = fi.context.retrieve_signature(inst_id)
 
         return (fi, fn, instantiation)
 

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -1150,7 +1150,10 @@ class ChapelLanguageServer(LanguageServer):
                 self.get_file_info("file://" + file, do_update=False)
 
     def get_file_info(
-        self, uri: str, do_update: bool = False, context_id: Optional[str] = None
+        self,
+        uri: str,
+        do_update: bool = False,
+        context_id: Optional[str] = None,
     ) -> Tuple[FileInfo, List[Any]]:
         """
         The language server maintains a FileInfo object per file. The FileInfo
@@ -1178,13 +1181,11 @@ class ChapelLanguageServer(LanguageServer):
         else:
             if context_id:
                 context = self.retrieve_context(context_id)
-                assert(context)
+                assert context
             else:
                 context = self.get_context(uri)
 
-            file_info, errors = context.new_file_info(
-                uri, self.use_resolver
-            )
+            file_info, errors = context.new_file_info(uri, self.use_resolver)
             self.file_infos[fi_key] = file_info
 
             # Also make this the "default" context for this file in case we
@@ -2048,7 +2049,10 @@ def run_lsp():
 
         # Oddly, returning multiple here makes for no child nodes in the VSCode
         # UI. Just take one signature for now.
-        return next(([ls.fn_to_call_hierarchy_item(sig, fi.context)] for sig in sigs), [])
+        return next(
+            ([ls.fn_to_call_hierarchy_item(sig, fi.context)] for sig in sigs),
+            [],
+        )
 
     @server.feature(CALL_HIERARCHY_INCOMING_CALLS)
     async def call_hierarchy_incoming(

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -1446,7 +1446,7 @@ class ChapelLanguageServer(LanguageServer):
         """
         loc = location_to_location(sym.location())
 
-        inst_id = ""
+        inst_id = None
         context_id = None
 
         return CallHierarchyItem(
@@ -1484,8 +1484,8 @@ class ChapelLanguageServer(LanguageServer):
             item.data is None
             or not isinstance(item.data, list)
             or not isinstance(item.data[0], str)
-            or not isinstance(item.data[1], str)
-            or not isinstance(item.data[2], str)
+            or not isinstance(item.data[1], Optional[str])
+            or not isinstance(item.data[2], Optional[str])
         ):
             self.show_message(
                 "Call hierarchy item contains missing or invalid additional data",
@@ -1494,13 +1494,7 @@ class ChapelLanguageServer(LanguageServer):
             return None
         uid, idx, ctx = item.data
 
-        context_id = None
-        if ctx != "":
-            context_id = ctx
-
-        print(f"Context: {context_id}", file=sys.stderr)
-
-        fi, _ = self.get_file_info(item.uri, context_id=context_id)
+        fi, _ = self.get_file_info(item.uri, context_id=ctx)
 
         # TODO: Performance:
         # Once the Python bindings supports it, we can use the

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -1030,7 +1030,9 @@ class ChapelLanguageServer(LanguageServer):
         super().__init__("chpl-language-server", "v0.1")
 
         self.contexts: Dict[str, ContextContainer] = {}
-        self.file_infos: Dict[str, FileInfo] = {}
+        self.context_ids: Dict[ContextContainer, str] = {}
+        self.context_id_counter = 0
+        self.file_infos: Dict[Tuple[str, Optional[str]], FileInfo] = {}
         self.configurations: Dict[str, WorkspaceConfig] = {}
 
         self.use_resolver: bool = config.get("resolver")
@@ -1130,8 +1132,16 @@ class ChapelLanguageServer(LanguageServer):
         for file in context.file_paths:
             self.contexts[file] = context
         self.contexts[path] = context
+        self.context_id_counter += 1
+        self.context_ids[context] = str(self.context_id_counter)
 
         return context
+
+    def retrieve_context(self, context_id: str) -> Optional[ContextContainer]:
+        for ctx, cid in self.context_ids.items():
+            if cid == context_id:
+                return ctx
+        return None
 
     def eagerly_process_all_files(self, context: ContextContainer):
         cfg = context.config
@@ -1140,7 +1150,7 @@ class ChapelLanguageServer(LanguageServer):
                 self.get_file_info("file://" + file, do_update=False)
 
     def get_file_info(
-        self, uri: str, do_update: bool = False
+        self, uri: str, do_update: bool = False, context_id: Optional[str] = None
     ) -> Tuple[FileInfo, List[Any]]:
         """
         The language server maintains a FileInfo object per file. The FileInfo
@@ -1151,19 +1161,36 @@ class ChapelLanguageServer(LanguageServer):
         creating one if it doesn't exist. If do_update is set to True,
         then the FileInfo's index is rebuilt even if it has already been
         computed. This is useful if the underlying file has changed.
+
+        Most of the tiem, we will create a new context for a given URI. When
+        requested, however, context_id will be used to create a FileInfo
+        for a specific context. This is useful if e.g., file A wants to display
+        an instantiation in file B.
         """
 
         errors = []
 
-        if uri in self.file_infos:
-            file_info = self.file_infos[uri]
+        fi_key = (uri, context_id)
+        if fi_key in self.file_infos:
+            file_info = self.file_infos[fi_key]
             if do_update:
                 errors = file_info.context.advance()
         else:
-            file_info, errors = self.get_context(uri).new_file_info(
+            if context_id:
+                context = self.retrieve_context(context_id)
+                assert(context)
+            else:
+                context = self.get_context(uri)
+
+            file_info, errors = context.new_file_info(
                 uri, self.use_resolver
             )
-            self.file_infos[uri] = file_info
+            self.file_infos[fi_key] = file_info
+
+            # Also make this the "default" context for this file in case we
+            # open it.
+            if (uri, None) not in self.file_infos:
+                self.file_infos[(uri, None)] = file_info
 
         # filter out errors that are not related to the file
         cur_path = uri[len("file://") :]
@@ -1419,7 +1446,8 @@ class ChapelLanguageServer(LanguageServer):
         """
         loc = location_to_location(sym.location())
 
-        inst_idx = -1
+        inst_id = ""
+        context_id = None
 
         return CallHierarchyItem(
             name=sym.name(),
@@ -1428,11 +1456,11 @@ class ChapelLanguageServer(LanguageServer):
             uri=loc.uri,
             range=loc.range,
             selection_range=location_to_range(sym.name_location()),
-            data=[sym.unique_id(), inst_idx],
+            data=[sym.unique_id(), inst_id, context_id],
         )
 
     def fn_to_call_hierarchy_item(
-        self, sig: chapel.TypedSignature
+        self, sig: chapel.TypedSignature, caller_context: ContextContainer
     ) -> CallHierarchyItem:
         """
         Like sym_to_call_hierarchy_item, but for function instantiations.
@@ -1442,8 +1470,8 @@ class ChapelLanguageServer(LanguageServer):
         """
         fn: chapel.Function = sig.ast()
         item = self.sym_to_call_hierarchy_item(fn)
-        fi, _ = self.get_file_info(item.uri)
-        item.data[1] = fi.context.register_signature(sig)
+        item.data[1] = caller_context.register_signature(sig)
+        item.data[2] = self.context_ids[caller_context]
 
         return item
 
@@ -1457,15 +1485,22 @@ class ChapelLanguageServer(LanguageServer):
             or not isinstance(item.data, list)
             or not isinstance(item.data[0], str)
             or not isinstance(item.data[1], str)
+            or not isinstance(item.data[2], str)
         ):
             self.show_message(
                 "Call hierarchy item contains missing or invalid additional data",
                 MessageType.Error,
             )
             return None
-        uid, idx = item.data
+        uid, idx, ctx = item.data
 
-        fi, _ = self.get_file_info(item.uri)
+        context_id = None
+        if ctx != "":
+            context_id = ctx
+
+        print(f"Context: {context_id}", file=sys.stderr)
+
+        fi, _ = self.get_file_info(item.uri, context_id=context_id)
 
         # TODO: Performance:
         # Once the Python bindings supports it, we can use the
@@ -2019,7 +2054,7 @@ def run_lsp():
 
         # Oddly, returning multiple here makes for no child nodes in the VSCode
         # UI. Just take one signature for now.
-        return next(([ls.fn_to_call_hierarchy_item(sig)] for sig in sigs), [])
+        return next(([ls.fn_to_call_hierarchy_item(sig, fi.context)] for sig in sigs), [])
 
     @server.feature(CALL_HIERARCHY_INCOMING_CALLS)
     async def call_hierarchy_incoming(
@@ -2065,7 +2100,7 @@ def run_lsp():
             if isinstance(called_fn, str):
                 item = ls.sym_to_call_hierarchy_item(hack_id_to_node[called_fn])
             else:
-                item = ls.fn_to_call_hierarchy_item(called_fn)
+                item = ls.fn_to_call_hierarchy_item(called_fn, fi.context)
 
             to_return.append(
                 CallHierarchyIncomingCall(
@@ -2089,7 +2124,7 @@ def run_lsp():
         if unpacked is None:
             return None
 
-        _, fn, instantiation = unpacked
+        fi, fn, instantiation = unpacked
 
         outgoing_calls: Dict[chapel.TypedSignature, List[chapel.FnCall]] = (
             defaultdict(list)
@@ -2112,7 +2147,7 @@ def run_lsp():
 
         to_return = []
         for called_fn, calls in outgoing_calls.items():
-            item = ls.fn_to_call_hierarchy_item(called_fn)
+            item = ls.fn_to_call_hierarchy_item(called_fn, fi.context)
             to_return.append(
                 CallHierarchyOutgoingCall(
                     item,

--- a/tools/chpl-language-server/test/basic.py
+++ b/tools/chpl-language-server/test/basic.py
@@ -139,6 +139,7 @@ async def test_go_to_definition_use_standard(client: LanguageClient):
         await check_goto_decl_def_module(client, doc, pos((1, 10)), mod_Map)
         await check_goto_decl_def_module(client, doc, pos((2, 8)), mod_Time)
 
+
 @pytest.mark.asyncio
 async def test_go_to_definition_use_across_modules(client: LanguageClient):
     """
@@ -162,7 +163,9 @@ async def test_go_to_definition_use_across_modules(client: LanguageClient):
         docB = docs("B")
 
         await check_goto_decl_def_module(client, docB, pos((1, 6)), docA)
-        await check_goto_decl_def(client, docB, pos((2, 10)), (docA, pos((1, 6))))
+        await check_goto_decl_def(
+            client, docB, pos((2, 10)), (docA, pos((1, 6)))
+        )
 
     async with source_files(client, A=fileA, B=fileB) as docs:
         await check(docs)

--- a/tools/chpl-language-server/test/call_hierarchy.py
+++ b/tools/chpl-language-server/test/call_hierarchy.py
@@ -202,11 +202,13 @@ async def test_call_hierarchy_across_files(client: LanguageClient):
         await check_call_hierarchy(client, docs("C"), pos((3, 2)), expected_int)
         await check_call_hierarchy(client, docs("C"), pos((4, 2)), expected_real)
 
+    # Ensure that call hierarchy works without .cls-commands.json...
     async with unrelated_source_files(
         client, A=fileA, B=fileB, C=fileC
     ) as docs:
         await check(docs)
 
+    # ...and with .cls-commands.json
     async with source_files(
         client, A=fileA, B=fileB, C=fileC
     ) as docs:

--- a/tools/chpl-language-server/test/call_hierarchy.py
+++ b/tools/chpl-language-server/test/call_hierarchy.py
@@ -200,7 +200,9 @@ async def test_call_hierarchy_across_files(client: LanguageClient):
 
     async def check(docs):
         await check_call_hierarchy(client, docs("C"), pos((3, 2)), expected_int)
-        await check_call_hierarchy(client, docs("C"), pos((4, 2)), expected_real)
+        await check_call_hierarchy(
+            client, docs("C"), pos((4, 2)), expected_real
+        )
 
     # Ensure that call hierarchy works without .cls-commands.json...
     async with unrelated_source_files(
@@ -209,7 +211,5 @@ async def test_call_hierarchy_across_files(client: LanguageClient):
         await check(docs)
 
     # ...and with .cls-commands.json
-    async with source_files(
-        client, A=fileA, B=fileB, C=fileC
-    ) as docs:
+    async with source_files(client, A=fileA, B=fileB, C=fileC) as docs:
         await check(docs)

--- a/tools/chpl-language-server/test/call_hierarchy.py
+++ b/tools/chpl-language-server/test/call_hierarchy.py
@@ -1,0 +1,157 @@
+"""
+Tests basic functionality, including autocompletion, go-to-definition, hover,
+and references
+"""
+
+import sys
+
+from lsprotocol.types import ClientCapabilities
+from lsprotocol.types import CallHierarchyPrepareParams, CallHierarchyOutgoingCallsParams, CallHierarchyItem
+from lsprotocol.types import InitializeParams
+import pytest
+import pytest_lsp
+import typing
+from pytest_lsp import ClientServerConfig, LanguageClient
+
+from util.utils import *
+from util.config import CLS_PATH
+
+
+@pytest_lsp.fixture(
+    config=ClientServerConfig(
+        server_command=[
+            sys.executable,
+            CLS_PATH(),
+            "--resolver",
+        ],
+        client_factory=get_base_client,
+    )
+)
+async def client(lsp_client: LanguageClient):
+    # Setup
+    params = InitializeParams(capabilities=ClientCapabilities())
+    await lsp_client.initialize_session(params)
+
+    yield
+
+    # Teardown
+    await lsp_client.shutdown_session()
+
+class CallTree:
+    def __init__(self, item_id: str, children: typing.List["CallTree"]):
+        self.item_id = item_id
+        self.children = children
+
+async def collect_call_tree(client: LanguageClient, item: CallHierarchyItem, depth: int) -> typing.Optional[CallTree]:
+    if depth <= 0:
+        return None
+
+    assert(isinstance(item.data, list))
+    assert(len(item.data) == 3)
+    item_id = item.data[0]
+
+    children = []
+    outgoing = await client.call_hierarchy_outgoing_calls_async(CallHierarchyOutgoingCallsParams(item))
+    if outgoing is not None:
+        for outgoing_call in outgoing:
+            new_tree = await collect_call_tree(client, outgoing_call.to, depth - 1)
+            if new_tree is not None:
+                children.append(new_tree)
+
+    return CallTree(item_id, children)
+
+
+async def compute_call_hierarchy(client: LanguageClient, doc: TextDocumentIdentifier, position: Position, depth: int) -> typing.Optional[CallTree]:
+    items = await client.text_document_prepare_call_hierarchy_async(CallHierarchyPrepareParams(text_document=doc, position=position))
+    if items is None:
+        return None
+
+    assert(len(items) == 1)
+    return await collect_call_tree(client, items[0], depth)
+
+def verify_call_hierarchy(tree: CallTree, expected: CallTree):
+    assert(tree.item_id == expected.item_id)
+    assert(len(tree.children) == len(expected.children))
+    for i in range(len(tree.children)):
+        verify_call_hierarchy(tree.children[i], expected.children[i])
+
+async def check_call_hierarchy(client: LanguageClient, doc: TextDocumentIdentifier, position: Position, expected: CallTree, depth: int = 10) -> typing.Optional[CallTree]:
+    items = await client.text_document_prepare_call_hierarchy_async(CallHierarchyPrepareParams(text_document=doc, position=position))
+    assert(items is not None)
+    assert(len(items) == 1)
+    tree = await collect_call_tree(client, items[0], depth)
+    assert(tree is not None)
+    verify_call_hierarchy(tree, expected)
+    return tree
+
+@pytest.mark.asyncio
+async def test_call_hierarchy_basic(client: LanguageClient):
+    file = """
+           proc foo() {}
+           proc bar() do foo();
+           bar();
+           """
+
+    async with source_file(client, file) as doc:
+        expect = CallTree("main.bar", [ CallTree("main.foo", []) ])
+        await check_call_hierarchy(client, doc, pos((2, 0)), expect)
+
+@pytest.mark.asyncio
+async def test_call_hierarchy_overloads(client: LanguageClient):
+    file = """
+           proc foo(arg: int) {}
+           proc foo(arg: bool) {}
+           foo(1);
+           foo(true);
+           """
+
+    async with source_file(client, file) as doc:
+        expect_int = CallTree("main.foo", [])
+        await check_call_hierarchy(client, doc, pos((2, 0)), expect_int)
+        expect_bool = CallTree("main.foo#1", [])
+        await check_call_hierarchy(client, doc, pos((3, 0)), expect_bool)
+
+@pytest.mark.asyncio
+async def test_call_hierarchy_recursive(client: LanguageClient):
+    file = """
+           proc foo() do foo();
+           foo();
+           """
+
+    async with source_file(client, file) as doc:
+        expect = CallTree("main.foo", [ CallTree("main.foo", []) ])
+        await check_call_hierarchy(client, doc, pos((1, 0)), expect, depth=2)
+
+@pytest.mark.asyncio
+async def test_call_hierarchy_across_files(client: LanguageClient):
+    fileA = """
+            module A {
+              proc someImplementationDetail(arg: string) {}
+            }
+            """
+    fileB = """
+            module B {
+              use A;
+
+              proc toString(x: int): string do return "";
+              proc toString(x: real): string do return "";
+
+              proc doSomething(arg) {
+                someImplementationDetail(toString(arg));
+              }
+            }
+            """
+    fileC = """
+            module C {
+              use B;
+
+              doSomething(12);
+              doSomething(12.0);
+            }
+            """
+
+    async with unrelated_source_files(client, A=fileA, B=fileB, C=fileC) as docs:
+        expected_int = CallTree("B.doSomething", [ CallTree("A.someImplementationDetail", []), CallTree("B.toString", []) ])
+        await check_call_hierarchy(client, docs("C"), pos((3, 2)), expected_int)
+        expected_real = CallTree("B.doSomething", [ CallTree("A.someImplementationDetail", []), CallTree("B.toString#1", []) ])
+        await check_call_hierarchy(client, docs("C"), pos((4, 2)), expected_real)

--- a/tools/chpl-language-server/test/call_hierarchy.py
+++ b/tools/chpl-language-server/test/call_hierarchy.py
@@ -1,6 +1,5 @@
 """
-Tests basic functionality, including autocompletion, go-to-definition, hover,
-and references
+Test the call hierarchy feature, which computes calls between functions.
 """
 
 import sys

--- a/tools/chpl-language-server/test/util/utils.py
+++ b/tools/chpl-language-server/test/util/utils.py
@@ -73,7 +73,12 @@ def get_base_client() -> LanguageClient:
 
 
 class SourceFilesContext:
-    def __init__(self, client: LanguageClient, files: typing.Dict[str, str]):
+    def __init__(
+        self,
+        client: LanguageClient,
+        files: typing.Dict[str, str],
+        build_cls_commands: bool = True,
+    ):
         self.tempdir = tempfile.TemporaryDirectory()
         self.client = client
 
@@ -96,8 +101,9 @@ class SourceFilesContext:
             commands[filepath] = [{"module_dirs": [], "files": allfiles}]
 
         commandspath = os.path.join(self.tempdir.name, ".cls-commands.json")
-        with open(commandspath, "w") as f:
-            json.dump(commands, f)
+        if build_cls_commands:
+            with open(commandspath, "w") as f:
+                json.dump(commands, f)
 
     def _get_doc(self, name: str) -> TextDocumentIdentifier:
         return TextDocumentIdentifier(
@@ -157,6 +163,14 @@ def source_files(client: LanguageClient, **files: str):
     language server to connect the files together in the workspace.
     """
     return SourceFilesContext(client, files)
+
+
+def unrelated_source_files(client: LanguageClient, **files: str):
+    """
+    Same as 'source_files', but doesn't create a .cls-commands.json file that
+    would cause the files to be treated as "connected" and resolved together.
+    """
+    return SourceFilesContext(client, files, build_cls_commands=False)
 
 
 def source_file(


### PR DESCRIPTION
In the following program, trying to get the call hierarchy for `writeln` did not work on `main`.

```Chapel
writeln("Hello, world!");
```

There were a few issues with this. The first issue is that the the "index" that was fed through a `CallHierarchyItem` to LSP and back to `CLS` was an index into a single file's list of instantiations. Thus, if the function was instantiated in one place, but defined in another, the index would not be valid (or worse, be incorrect). This PR changes this by changing the way typed signatures are mapped to JSON-compatible identifiers; they are instead registered with a `ContextContainer` object, getting a unique ID. The unique ID is then used as JSON data, and can be used to access the same `TypedSignature` object when the JSON is being deserialized.

This, however, was not enough. The next problem was that we currently create a new `ContextContainer` per file (to handle the case in which multiple files with the same name / module name exist). As a result of this, `writeln` that is called in module `A` and defined in module `B` will have its instantiation computed using `A`'s context, but its AST and other information will use `B`'s context. This is troublesome. This PR adjusts the situation by changing the `file -> FileInfo` mapping to be a `(file, context id) -> FileInfo` mapping. This way, the same file can have several contexts (e.g., if a standard library file is loaded from two distinct files, but both named `A.chpl`). By default (e.g., when opening a file), the `(file, "None")` key is used (since no particular context was requested). However, if a file A needs to show an instantiation (via file info) from file B, we create a new mapping `(fileB, fileA.context.id) -> fileInfoB`, which is created from the same context. This ensures that there is a file information object for file B with the same context as that of file A.

When a call hierarchy item is constructed, it now specifies what context was used to create it. Thus, if other CallHierarchyItems point to other files, these other files are opened with the same context. To communicate the context over JSON, I employ the same approach as I did with typed signatures (register a context object with unique ID, use the ID to marshal the context to and from JSON).

~~To fix the case of `writeln` in particular, I had to relax an assertion from the `_owned`/`_shared_` resolution PR https://github.com/chapel-lang/chapel/pull/25617. This led to some simplified code in any case, which is great. I believe @arezaii is fine with this change.~~ This was separately merged in https://github.com/chapel-lang/chapel/pull/26078.

A bug that I'm surprised we didn't find prior to this, which is fixed in this PR, is that vector unmarshalling for Python interop allocates a vector of the Python list's size, then pushes _additional elements_ instead of setting the already-allocated locations. This ended up e.g., pushing an empty string for each "real" string a user passed in a list. This led to some odd interactions with Dyno's module searching (an empty string as an input file led to "." being added to the module search path, which we do not want).

Reviewed by @jabraham17 -- thanks!

## Testing
- [x] LSP tests
- [x] new call hierarchy tests
- [x] dyno tests