### PR TITLE
Dyno: Fix method resolution on string and bytes types

### DIFF
--- a/frontend/include/chpl/framework/all-global-strings.h
+++ b/frontend/include/chpl/framework/all-global-strings.h
@@ -171,5 +171,10 @@ X(llvmAssertVectorized, "llvm.assertVectorized")
 X(deprecated          , "deprecated")
 X(unstable            , "unstable")
 
+X(stringId            , "String._string")
+X(bytesId             , "Bytes._bytes")
+X(localeId            , "ChapelLocale._locale")
+X(rangeId             , "ChapelRange._range")
+
 /* A string too long is checked at compile time */
 /* X(somethingtoolong      , "somethingtoolongforthemacro") */

--- a/frontend/lib/types/CompositeType.cpp
+++ b/frontend/lib/types/CompositeType.cpp
@@ -93,8 +93,17 @@ void CompositeType::stringify(std::ostream& ss,
     superType = bct->parentClassType();
   }
 
-  //std::string ret = typetags::tagToString(tag());
-  name().stringify(ss, stringKind);
+  if (isStringType()) {
+    ss << "string";
+  } else if (isBytesType()) {
+    ss << "bytes";
+  } else if (isLocaleType()) {
+    ss << "locale";
+  } else if (id().symbolPath() == USTR("ChapelRange._range")) {
+    ss << "range";
+  } else {
+    name().stringify(ss, stringKind);
+  }
 
   auto sorted = sortedSubstitutions();
 
@@ -147,7 +156,7 @@ void CompositeType::stringify(std::ostream& ss,
 }
 
 const RecordType* CompositeType::getStringType(Context* context) {
-  auto name = UniqueString::get(context, "string");
+  auto name = UniqueString::get(context, "_string");
   auto id = parsing::getSymbolFromTopLevelModule(context, "String", "_string");
   return RecordType::get(context, id, name,
                          /* instantiatedFrom */ nullptr,
@@ -163,7 +172,7 @@ const RecordType* CompositeType::getRangeType(Context* context) {
 }
 
 const RecordType* CompositeType::getBytesType(Context* context) {
-  auto name = UniqueString::get(context, "bytes");
+  auto name = UniqueString::get(context, "_bytes");
   auto id = parsing::getSymbolFromTopLevelModule(context, "Bytes", "_bytes");
   return RecordType::get(context, id, name,
                          /* instantiatedFrom */ nullptr,
@@ -171,7 +180,7 @@ const RecordType* CompositeType::getBytesType(Context* context) {
 }
 
 const RecordType* CompositeType::getLocaleType(Context* context) {
-  auto name = UniqueString::get(context, "locale");
+  auto name = UniqueString::get(context, "_locale");
   auto id = parsing::getSymbolFromTopLevelModule(context, "ChapelLocale", "_locale");
   return RecordType::get(context, id, name,
                          /* instantiatedFrom */ nullptr,

--- a/frontend/lib/types/Type.cpp
+++ b/frontend/lib/types/Type.cpp
@@ -165,7 +165,7 @@ IMPLEMENT_DUMP(Type);
 
 bool Type::isStringType() const {
   if (auto rec = toRecordType()) {
-    if (rec->name() == USTR("string"))
+    if (rec->id().symbolPath() == USTR("String._string"))
       return true;
   }
   return false;
@@ -173,7 +173,7 @@ bool Type::isStringType() const {
 
 bool Type::isBytesType() const {
   if (auto rec = toRecordType()) {
-    if (rec->name() == USTR("bytes"))
+    if (rec->id().symbolPath() == USTR("Bytes._bytes"))
       return true;
   }
   return false;
@@ -181,7 +181,7 @@ bool Type::isBytesType() const {
 
 bool Type::isLocaleType() const {
   if (auto rec = toRecordType()) {
-    if (rec->name() == USTR("locale"))
+    if (rec->id().symbolPath() == USTR("ChapelLocale._locale"))
       return true;
   }
   return false;


### PR DESCRIPTION
Updates CompositeType to use the leading-underscore version of string, bytes, and locale types so that they match the records declared in module code. The 'is[String|Bytes|Locale]Type' methods are updated to instead check the ID of the type, rather than the name. Lastly, stringify is updated to print the proper reserved names for these types.

Note: The 'locale' type is not tested here due to a pre-existing recursive query bug.

Testing:
- [x] test-dyno