### PR TITLE
Update my study version of nbody to be like nbody#2, but using foreach loops

### DIFF
--- a/test/studies/shootout/nbody/bradc/nbody-blc.chpl
+++ b/test/studies/shootout/nbody/bradc/nbody-blc.chpl
@@ -1,8 +1,8 @@
 /* The Computer Language Benchmarks Game
    https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
-   contributed by Brad Chamberlain
-   derived from the Chapel version by Albert Sidelnik and myself
+   contributed by Albert Sidelnik and Brad Chamberlain, modernized by Brad
+   derived from the Java version by Mark C. Lewis and Chad Whipkey
 */
 
 use Math;                     // to get access to 'pi'
@@ -24,9 +24,9 @@ record body {
 }
 
 //
-// the bodies that we'll be simulating
+// the array of bodies that we'll be simulating
 //
-var bodies = (/* sun */
+var bodies = [/* sun */
               new body(mass = solarMass),
 
               /* jupiter */
@@ -64,9 +64,9 @@ var bodies = (/* sun */
                                1.62824170038242295e-03 * daysPerYear,
                               -9.51592254519715870e-05 * daysPerYear),
                       mass =   5.15138902046611451e-05 * solarMass)
-              );
+              ];
 
-param numBodies = bodies.size;    // the number of bodies being simulated
+const numBodies = bodies.size;    // the number of bodies being simulated
 
 proc main() {
   initSun();                      // initialize the sun's velocity
@@ -91,18 +91,21 @@ proc initSun() {
 // advance the positions and velocities of all the bodies
 //
 proc advance(dt) {
-  foreach i in 0..<numBodies with (ref bodies) {
-    foreach j in i+1..<numBodies with (ref bodies) {
-      const dpos = bodies[i].pos - bodies[j].pos,
+  foreach i in 0..<numBodies {
+    foreach j in i+1..<numBodies {
+      ref b1 = bodies[i],
+          b2 = bodies[j];
+
+      const dpos = b1.pos - b2.pos,
             mag = dt / sqrt(sumOfSquares(dpos))**3;
 
-      bodies[i].vel -= dpos * bodies[j].mass * mag;
-      bodies[j].vel += dpos * bodies[i].mass * mag;
+      b1.vel -= dpos * b2.mass * mag;
+      b2.vel += dpos * b1.mass * mag;
     }
   }
 
-  foreach i in 0..<numBodies with (ref bodies) do
-    bodies[i].pos += dt * bodies[i].vel;
+  foreach b in bodies do
+    b.pos += dt * b.vel;
 }
 
 //
@@ -112,10 +115,14 @@ proc energy() {
   var e = 0.0;
 
   for i in 0..<numBodies {
-    e += 0.5 * bodies[i].mass * sumOfSquares(bodies[i].vel);
+    const b1 = bodies[i];
+
+    e += 0.5 * b1.mass * sumOfSquares(b1.vel);
+
     for j in i+1..<numBodies {
-      e -= (bodies[i].mass * bodies[j].mass)
-           / sqrt(sumOfSquares(bodies[i].pos - bodies[j].pos));
+      const b2 = bodies[j];
+
+      e -= (b1.mass * b2.mass) / sqrt(sumOfSquares(b1.pos - b2.pos));
     }
   }
 


### PR DESCRIPTION
A recent CLBG update kicked out our version of nbody that was both most compact and almost-best-performing, making our nbody#2 version the most compact, but a significant bit slower.  I'd been meaning to submit a modernized version using 'foreach' loops rather than 'for param' loops, so this updates my study version to be based on version 2, but using foreach loops.  I also took the approach of getting 'pi' from the math library rather than defining it manually.