### PR TITLE
Fix chapel-py builds for ASAN config

### DIFF
--- a/tools/chapel-py/setup.py
+++ b/tools/chapel-py/setup.py
@@ -70,8 +70,18 @@ LDFLAGS += [
 ]
 
 if str(chpl_variables.get("CHPL_SANITIZE")) == "address":
+    if str(chpl_variables.get("CHPL_HOST_PLATFORM")) == "darwin":
+        sys.exit(
+            "Cannot use chapel-py on Mac OS when address sanitization is enabled; " +
+            "please unset 'CHPL_SANITIZE' then rebuild Chapel"
+        )
+
     CXXFLAGS += ["-fsanitize=address"]
     LDFLAGS += ["-fsanitize=address"]
+
+    if str(chpl_variables.get("CHPL_TARGET_COMPILER")) == "clang":
+        CXXFLAGS += ["-shared-libasan"]
+        LDFLAGS += ["-shared-libasan"]
 
 os.environ["CC"] = host_cc
 os.environ["CXX"] = host_cxx

--- a/tools/chapel-py/setup.py
+++ b/tools/chapel-py/setup.py
@@ -79,7 +79,7 @@ if str(chpl_variables.get("CHPL_SANITIZE")) == "address":
     CXXFLAGS += ["-fsanitize=address"]
     LDFLAGS += ["-fsanitize=address"]
 
-    if "clang" in str(chpl_variables.get("CHPL_TARGET_COMPILER")):
+    if "clang" in host_cc:
         CXXFLAGS += ["-shared-libasan"]
         LDFLAGS += ["-shared-libasan"]
 

--- a/tools/chapel-py/setup.py
+++ b/tools/chapel-py/setup.py
@@ -69,6 +69,10 @@ LDFLAGS += [
     chpl_lib_path,
 ]
 
+if str(chpl_variables.get("CHPL_SANITIZE")) == "address":
+    CXXFLAGS += ["-fsanitize=address"]
+    LDFLAGS += ["-fsanitize=address"]
+
 os.environ["CC"] = host_cc
 os.environ["CXX"] = host_cxx
 setup(

--- a/tools/chapel-py/setup.py
+++ b/tools/chapel-py/setup.py
@@ -72,8 +72,8 @@ LDFLAGS += [
 if str(chpl_variables.get("CHPL_SANITIZE")) == "address":
     if str(chpl_variables.get("CHPL_HOST_PLATFORM")) == "darwin":
         sys.exit(
-            "Cannot use chapel-py on Mac OS when address sanitization is enabled; " +
-            "please unset 'CHPL_SANITIZE' then rebuild Chapel"
+            "Cannot use chapel-py on Mac OS when address sanitization is enabled; "
+            + "please unset 'CHPL_SANITIZE' then rebuild Chapel"
         )
 
     CXXFLAGS += ["-fsanitize=address"]

--- a/tools/chapel-py/setup.py
+++ b/tools/chapel-py/setup.py
@@ -79,7 +79,7 @@ if str(chpl_variables.get("CHPL_SANITIZE")) == "address":
     CXXFLAGS += ["-fsanitize=address"]
     LDFLAGS += ["-fsanitize=address"]
 
-    if str(chpl_variables.get("CHPL_TARGET_COMPILER")) == "clang":
+    if "clang" in str(chpl_variables.get("CHPL_TARGET_COMPILER")):
         CXXFLAGS += ["-shared-libasan"]
         LDFLAGS += ["-shared-libasan"]
 

--- a/util/config/run-in-venv-with-python-bindings.bash
+++ b/util/config/run-in-venv-with-python-bindings.bash
@@ -26,7 +26,7 @@ if [ $("$python" "$CHPL_HOME/util/chplenv/chpl_sanitizers.py") == "address" ]; t
     exit 1
   fi
 
-  if [ "$CC" == "clang" ]; then
+  if [ "$CC" == *"clang"* ]; then
     export LD_PRELOAD=$($CC -print-file-name=libclang_rt.asan.so)
   else
     export LD_PRELOAD=$($CC -print-file-name=libasan.so)

--- a/util/config/run-in-venv-with-python-bindings.bash
+++ b/util/config/run-in-venv-with-python-bindings.bash
@@ -17,4 +17,8 @@ if [ ! -d "$chpl_frontend_py_deps/chapel" ]; then
   exit 1
 fi
 
+if [ "$CHPL_SANITIZE" == "address" ]; then
+  export LD_PRELOAD=$(gcc -print-file-name=libasan.so)
+fi
+
 exec "$1" "${@:2}"


### PR DESCRIPTION
Adjust build scripts s.t. `chapel-py` can be built when Chapel is configured for Address sanitization.

Note: this currently works only on Linux, as Mac OS has a limitation where `DYLD_INSERT_LIBRARIES` cannot be passed to a child process — which would be needed to specify the path for `libclang_rt.asan.so` to chapel-py's setup script.

Resolves: https://github.com/Cray/chapel-private/issues/6766

Testing:
---

`CHPL_SANITIZE=address`:
| host-cc \ platform | Linux | Mac |
| :--- | :--- | :--- | 
| clang | ✅ | ⚠️ |
| gcc | ✅ | ❓ |

`CHPL_SANITIZE=none`:
|  host-cc \ platform | Linux | Mac |
| :--- | :--- | :--- | 
| clang | ✅ | ✅ |
| gcc | ✅ | ❓ |

✅ = chapel-py builds and works successfully
❓ = couldn't build chpl in this config
⚠️ = fails gracefully