### PR TITLE
Minor fix to `chapel-py`'s run-in-venv script

### DIFF
--- a/util/config/run-in-venv-with-python-bindings.bash
+++ b/util/config/run-in-venv-with-python-bindings.bash
@@ -26,7 +26,7 @@ if [ $("$python" "$CHPL_HOME/util/chplenv/chpl_sanitizers.py") == "address" ]; t
     exit 1
   fi
 
-  if [ "$CC" == *"clang"* ]; then
+  if [[ "$CC" == *"clang"* ]]; then
     export LD_PRELOAD=$($CC -print-file-name=libclang_rt.asan.so)
   else
     export LD_PRELOAD=$($CC -print-file-name=libasan.so)


### PR DESCRIPTION
Follow on to: https://github.com/chapel-lang/chapel/pull/26050 that adds some missing double braces to `chapel-py`'s run-in-venv script (forgot to add this last commit before merging).