### PR TITLE
[dyno] map sync to _syncvar record

### DIFF
--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -5182,6 +5182,10 @@ void Converter::postConvertApplyFixups() {
 
     INT_ASSERT(isTemporaryConversionSymbol(se->symbol()));
 
+    if (target->isCompilerGenerated()) {
+      continue;
+    }
+
     astlocMarker markAstLoc(target->id());
 
     Symbol* sym = findConvertedFn(target, /* neverTrace */ true);

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -3984,6 +3984,11 @@ static bool resolveFnCallSpecialType(Context* context,
     auto ctorCall = CallInfo::copyAndRename(ci, newName);
     result = resolveCall(rc, call, ctorCall, inScopes);
     return true;
+  } else if (ci.name() == "sync") {
+    auto newName = UniqueString::get(context, "_syncvar");
+    auto ctorCall = CallInfo::copyAndRename(ci, newName);
+    result = resolveCall(rc, call, ctorCall, inScopes);
+    return true;
   }
 
   return false;

--- a/frontend/test/resolution/testMethodCalls.cpp
+++ b/frontend/test/resolution/testMethodCalls.cpp
@@ -853,6 +853,30 @@ static void test17() {
   }
 }
 
+static void test18() {
+  // test sync var method call isFull
+  printf("test6\n");
+  auto config = getConfigWithHome();
+  Context ctx(config);
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+  setupModuleSearchPaths(context, false, false, {}, {});
+
+  std::string program = R"""(
+      var x : sync int;
+      var y = x.isFull;
+    )""";
+
+  auto m = parseModule(context, std::move(program));
+  auto results = resolveModule(context, m->id());
+  auto var = findVariable(m, "y");
+  auto init = var->initExpression();
+  assert(init);
+  auto qt = results.byAst(init).type();
+  assert(qt.type()->isBoolType());
+  assert(guard.numErrors() == 0);
+}
+
 int main() {
   test1();
   test2();
@@ -871,6 +895,7 @@ int main() {
   test14b();
   test16();
   test17();
+  test18();
 
   return 0;
 }


### PR DESCRIPTION
This moves us toward fully resolving the `sync` keyword to the `_syncvar` record type in dyno. Resolves https://github.com/Cray/chapel-private/issues/6741 and adds a dyno test to capture the fixed resolution issue.

TESTING:

- [x] test case passes
- [x] `release/examples/spec/Memory_Consistency_Model/syncSpinWait` now fails in `convert-uast` with: 
```
chapel/compiler/passes/convert-uast.cpp:4709 in convertRecordType] Unimplemented: unhandled record type: _syncvar
> syncSpinWait.chpl:11: internal error: PAS-CON-AST-5193 chpl version 2.3.0 pre-release (90c1cfa153)
```

[reviewed by @mppf - thanks!]