### PR TITLE
add blog dirs to nightly testdirs more generally

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -640,10 +640,11 @@ if (!($dist eq "")) {
     $testdirs .= " distributions/robust/arithmetic";
 }
 
-# add blog directory to 'testdirs' if '-blog' was used and 'testdirs' is being
-# used to specify test directories as opposed to everything in '$CHPL_HOME/test/'
+# add blog directory to 'testdirs' if '-blogonly' was used
+# OR if '-blog' was used and 'testdirs' is being used to specify test directories
+# as opposed to testing everything in '$CHPL_HOME/test/'
 # to make blog testing work with new flags, make sure they modify 'testdirs' before here
-if ($testblog == 1 && $testdirs ne "") {
+if ($blogonly == 1 || ($testblog == 1 && $testdirs ne "")) {
     $testdirs .= " $testdir/copied-chapel-blog/";
 }
 

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -409,7 +409,7 @@ if ($testblog == 1) {
             exit 1;
         }
     }
-    
+
     # copy the relevant blog source files into the test directory so they'll be
     # ran alongside all the other tests and the results will truncate $CHPL_HOME
     # from the test file paths when reporting errors. Copying specific subdirectories
@@ -419,7 +419,6 @@ if ($testblog == 1) {
     mysystem("cp -r $blogdir/chpl-src $testdir/copied-chapel-blog/", "copying chapel-blog/chpl-src", $exitOnError, 1);
     mysystem("cp -r $blogdir/scripts $testdir/copied-chapel-blog/", "copying chapel-blog/scripts", $exitOnError, 1);
     mysystem("cp -r $blogdir/content/posts $testdir/copied-chapel-blog/content/", "copying chapel-blog/content", $exitOnError, 1);
-    
 }
 
 # Determine which make to use.
@@ -633,16 +632,19 @@ if ($examples == 1) {
     $testdirs .= " release/examples";
 }
 
-if ($blogonly == 1 || ($testblog == 1 && $examples == 1)) {
-    $testdirs .= " $testdir/copied-chapel-blog/";
-}
-
 if ($chplcheckonly == 1) {
     $testdirs .= " chplcheck";
 }
 
 if (!($dist eq "")) {
     $testdirs .= " distributions/robust/arithmetic";
+}
+
+# add blog directory to 'testdirs' if '-blog' was used and 'testdirs' is being
+# used to specify test directories as opposed to everything in '$CHPL_HOME/test/'
+# to make blog testing work with new flags, make sure they modify 'testdirs' before here
+if ($testblog == 1 && $testdirs ne "") {
+    $testdirs .= " $testdir/copied-chapel-blog/";
 }
 
 # After this point, changes to $testdirs are only reflected in the automailer, and


### PR DESCRIPTION
This expands the cases when we add the blog directories to the list of directories to test. The change is to stop using the presence of `-examples` with `-blog` to selectively add the blog directories, and instead just add them whenever `-blog` is used and the `testdirs` var already has some values in it. It should avoid the problem found in GPU tests and other configs that just populate `CHPL_NIGHTLY_TEST_DIRS` rather than calling `nightly` with a specific set of flags.

[reviewed by @riftEmber - thanks!]