### PR TITLE
Add a config error for invalid locale model setting

### DIFF
--- a/util/chplenv/chpl_locale_model.py
+++ b/util/chplenv/chpl_locale_model.py
@@ -9,7 +9,7 @@ from utils import memoize, error
 def get():
     locale_model_val = overrides.get('CHPL_LOCALE_MODEL', 'flat')
 
-    if locale_model_val != 'flat' and locale_model_val != 'gpu':
+    if locale_model_val not in ['flat', 'gpu']:
         error('{} is not a valid value for CHPL_LOCALE_MODEL. '
               'It can only be "flat" or "gpu".'.format(locale_model_val))
 

--- a/util/chplenv/chpl_locale_model.py
+++ b/util/chplenv/chpl_locale_model.py
@@ -2,12 +2,17 @@
 import sys
 
 import overrides
-from utils import memoize
+from utils import memoize, error
 
 
 @memoize
 def get():
     locale_model_val = overrides.get('CHPL_LOCALE_MODEL', 'flat')
+
+    if locale_model_val != 'flat' and locale_model_val != 'gpu':
+        error('{} is not a valid value for CHPL_LOCALE_MODEL. '
+              'It can only be "flat" or "gpu".'.format(locale_model_val))
+
     return locale_model_val
 
 


### PR DESCRIPTION
It appears that we don't check the value of `CHPL_LOCALE_MODEL` in our environment scripts. I have no idea what we build if it was set to something invalid, but we build _something_. That's pretty bad. This PR adds an error message when `CHPL_LOCALE_MODEL` is set to something other than `flat` or `gpu`.

Tested locally with different settings including leaving it unset.