### PR TITLE
Dyno: Improve super.init() calls in default initializers

### DIFF
--- a/frontend/lib/resolution/InitResolver.cpp
+++ b/frontend/lib/resolution/InitResolver.cpp
@@ -683,14 +683,15 @@ bool InitResolver::handleCallToSuperInit(const FnCall* node,
 }
 
 void InitResolver::updateSuperType(const CallResolutionResult* c) {
-  auto& msc = c->mostSpecific().only();
-  auto superThis = msc.formalActualMap().byFormalIdx(0).formalType().type();
+  if (auto& msc = c->mostSpecific().only()) {
+    auto superThis = msc.formalActualMap().byFormalIdx(0).formalType().type();
 
-  this->superType_ = superThis->getCompositeType()->toBasicClassType();
+    this->superType_ = superThis->getCompositeType()->toBasicClassType();
 
-  // Only update the current receiver if the parent was generic.
-  if (superType_->instantiatedFromCompositeType() != nullptr) {
-    updateResolverVisibleReceiverType();
+    // Only update the current receiver if the parent was generic.
+    if (superType_->instantiatedFromCompositeType() != nullptr) {
+      updateResolverVisibleReceiverType();
+    }
   }
 
   phase_ = PHASE_NEED_COMPLETE;

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -3971,9 +3971,11 @@ static const Type* getGenericType(Context* context, const Type* recv) {
     gen = cur->instantiatedFromCompositeType();
     if (gen == nullptr) gen = cur;
   } else if (auto bct = recv->toBasicClassType()) {
-    if (bct->parentClassType()->instantiatedFromCompositeType()) {
-      auto pt = getGenericType(context, bct->parentClassType())->toBasicClassType();
-      bct = BasicClassType::get(context, bct->id(), bct->name(), pt, bct->instantiatedFrom(), bct->substitutions());
+    if (auto pct = bct->parentClassType()) {
+      if (pct->instantiatedFromCompositeType()) {
+        auto pt = getGenericType(context, pct)->toBasicClassType();
+        bct = BasicClassType::get(context, bct->id(), bct->name(), pt, bct->instantiatedFrom(), bct->substitutions());
+      }
     }
 
     gen = bct->instantiatedFromCompositeType();

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -344,8 +344,6 @@ static bool initHelper(Context* context,
           }
         }
       }
-    } else {
-      addSuperInit = false;
     }
   }
 

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -193,6 +193,7 @@ const ResolutionResultByPostorderID& resolveModule(Context* context, ID id) {
             child->isTypeDecl() ||
             child->isFunction() ||
             child->isModule() ||
+            child->isInterface() ||
             child->isExternBlock()) {
             // Resolve use/import to find deprecation/unstable warnings.
             // child->isUse() ||

--- a/frontend/test/resolution/testInitSemantics.cpp
+++ b/frontend/test/resolution/testInitSemantics.cpp
@@ -1596,6 +1596,27 @@ static void testInheritance() {
     check(z2);
     check(z3);
   }
+
+  // Make sure that existence of an interface in the inherit-exprs list
+  // does not cause a super.init call to be generated.
+  {
+    Context ctx;
+    Context* context = &ctx;
+    ErrorGuard guard(context);
+
+    std::string program = R"""(
+      interface myInterface {}
+
+      class C : myInterface {
+        var x : string;
+      }
+
+      var c = new C();
+      )""";
+
+    auto m = parseModule(context, std::move(program));
+    std::ignore = resolveModule(context, m->id());
+  }
 }
 
 static void testImplicitSuperInit() {

--- a/frontend/test/resolution/testInitSemantics.cpp
+++ b/frontend/test/resolution/testInitSemantics.cpp
@@ -1515,6 +1515,87 @@ static void testInheritance() {
     xt->stringify(ss, chpl::StringifyKind::CHPL_SYNTAX);
     assert(ss.str() == "owned B(int(64), real(64))");
   }
+
+  // Default initializer when parent has user-defined initializer
+  {
+    Context ctx;
+    Context* context = &ctx;
+    ErrorGuard guard(context);
+
+    std::string program = R"""(
+      class A {
+        var x : int;
+
+        proc init(x: int = 0) {
+          this.x = x;
+        }
+      }
+
+      class B : A {
+        var y : string;
+      }
+
+      var b1 = new B();
+      var b2 = new B("test");
+      )""";
+
+    auto vars = resolveTypesOfVariables(context, program, {"b1", "b2"});
+    auto b1 = vars["b1"].type();
+    auto b2 = vars["b2"].type();
+
+    auto check = [] (const Type* type) {
+      std::stringstream ss;
+      type->stringify(ss, chpl::StringifyKind::CHPL_SYNTAX);
+      assert(ss.str() == "owned B");
+    };
+
+    check(b1);
+    check(b2);
+  }
+
+  // Default initializer when grandparent has user-defined initializer
+  {
+    Context ctx;
+    Context* context = &ctx;
+    ErrorGuard guard(context);
+
+    std::string program = R"""(
+      class X {
+        var one : int;
+
+        proc init(one: int = 0) {
+          this.one = one;
+        }
+      }
+
+      class Y : X {
+        var two : real;
+      }
+
+      class Z : Y {
+        var three : string;
+      }
+
+      var z1 = new Z();
+      var z2 = new Z(42.0);
+      var z3 = new Z(42.0, "test");
+      )""";
+
+    auto vars = resolveTypesOfVariables(context, program, {"z1", "z2", "z3"});
+    auto z1 = vars["z1"].type();
+    auto z2 = vars["z2"].type();
+    auto z3 = vars["z3"].type();
+
+    auto check = [] (const Type* type) {
+      std::stringstream ss;
+      type->stringify(ss, chpl::StringifyKind::CHPL_SYNTAX);
+      assert(ss.str() == "owned Z");
+    };
+
+    check(z1);
+    check(z2);
+    check(z3);
+  }
 }
 
 static void testImplicitSuperInit() {


### PR DESCRIPTION
This PR fixes an issue where super.init() calls were being generated
despite the lack of a parent class. This lead to resolution failures
when trying to resolve init on the root class.

This kind of error manifested itself when there was an interface in the
inherit-exprs list of the class. The 'initHelper' function was naively
ignoring the possibility of such expressions.

The bug is fixed by relying on ``initialTypeForTypeDecl`` to
compute the parent class rather than doing it manually inside
'initHelper'.

-----

While here, it was convenient to fix another super.init() related bug
when generating default initializers when a parent (or other ancestor
class) had a user-defined initializer. In such cases the compiler should
not be generating formals for classes that define their own initializer,
and should instead be invoking an empty 'super.init()' when such a class
is the direct parent.

A straightforward way to fix this issue was to abandon the recursive
nature of the 'initHelper' function and instead build the default
initializer for the parent class. With a correct parent initializer we
can simply copy the formals to the child class initializer and avoid
having to think recursively.

Lastly, 'initHelper' is modified to return a boolean indicating whether
a 'super.init()' call is needed, as opposed to examining the
inherit-exprs of the class.

Testing:
- [x] test-dyno
- [x] local paratest