### PR TITLE
resolve failing tests in nightly cray ex perf job by updating max heap size

### DIFF
--- a/util/cron/test-perf.hpe-cray-ex.ofi.bash
+++ b/util/cron/test-perf.hpe-cray-ex.ofi.bash
@@ -16,7 +16,7 @@ source $CWD/common-ofi.bash || \
 source $CWD/common-hpe-cray-ex.bash
 
 export CHPL_RT_COMM_OFI_EXPECTED_PROVIDER="cxi"
-export CHPL_RT_MAX_HEAP_SIZE=16g
+export CHPL_RT_MAX_HEAP_SIZE="50%"
 
 nightly_args="${nightly_args} -no-buildcheck"
 perf_args="-performance -perflabel ml- -numtrials 1"


### PR DESCRIPTION
See (https://github.com/Cray/chapel-private/issues/6710). We have several tests in our `hpe-cray-ex-performance-test-perf.hpe-cray-ex.ofi` job failing because they're running out of memory.  This PR updates `CHPL_RT_MAX_HEAP_SIZE` to 50%.

This is what we have it set to in `./common-hpe-cray-ex.bash` so this seems like it should be fine to do.

I haven't manually verified that this resolves all the failing tests, but given that we've had these failures going for a while (and I'm on triage) I don't mind pushing this out as an experimental update and dealing with any fallout that occurs tomorrow.