### PR TITLE
add `;` to list of shell escaped chars in `sub_test.py`

### DIFF
--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -231,11 +231,11 @@ def LauncherTimeoutArgs(seconds):
 
 # Escape all special characters
 def ShellEscape(arg):
-    return re.sub(r'([\\!@#$%^&*()?\'"|<>[\]{} ])', r'\\\1', arg)
+    return re.sub(r'([\\!@#$%^&*()?;\'"|<>[\]{} ])', r'\\\1', arg)
 
 # Escape all special characters but leave spaces alone
 def ShellEscapeCommand(arg):
-    return re.sub(r'([\\!@#$%^&*()?\'"|<>[\]{}])', r'\\\1', arg)
+    return re.sub(r'([\\!@#$%^&*()?;\'"|<>[\]{}])', r'\\\1', arg)
 
 
 # Grabs the start and end of the output and replaces non-printable chars with ~
@@ -812,7 +812,7 @@ def get_util_dir():
 def get_config_dir(util_dir):
     return os.path.join(util_dir, 'config')
 
-def main(): 
+def main():
     # Start of sub_test proper
     #
     global utildir, chpl_base, chpl_home, machine, envCompopts, platform


### PR DESCRIPTION
This adds the semicolon character to the list of special escaped characters in two functions we use for preparing test command strings in `sub_test.py`. 

It was needed to accommodate HPO testing where the `execopts` expect to pass a `;` as the delimiter between arguments for the `hpo-example.chpl` blog article. I found that when `start_test` was used the program was not seeing any arguments after the first `;` in the `argsString` argument. Manually escaping the character did not work, but adding the `;` to the list of escaped characters in these `ShellEscape` and `ShellEscapeCommand` did.

TESTING:

- [x] paratest `[Summary: #Successes = 17653 | #Failures = 0 | #Futures = 0]`
- [x] paratest w/gasnet `[Summary: #Successes = 17835 | #Failures = 0 | #Futures = 0]`

[reviewed by @jabraham17 - thanks!]