### PR TITLE
Rework configuration of `CHPL_GPU` to improve clarity

### DIFF
--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -153,6 +153,8 @@ extern const char* CHPL_TARGET_BUNDLED_LINK_ARGS;
 extern const char* CHPL_TARGET_SYSTEM_LINK_ARGS;
 
 extern const char* CHPL_CUDA_LIBDEVICE_PATH;
+extern const char* CHPL_ROCM_LLVM_PATH;
+extern const char* CHPL_ROCM_LIBDEVICE_PATH;
 extern const char* CHPL_GPU;
 extern const char* CHPL_GPU_ARCH;
 

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -4450,7 +4450,7 @@ static void linkGpuDeviceLibraries() {
   } else {
     // See <https://github.com/RadeonOpenCompute/ROCm-Device-Libs> for details
     // on what these various libraries are.
-    auto libPath = gGpuSdkPath + std::string("/amdgcn/bitcode");
+    auto libPath = CHPL_ROCM_AMDGCN_PATH + std::string("/bitcode");
     linkBitCodeFile((libPath + "/hip.bc").c_str());
     linkBitCodeFile((libPath + "/ocml.bc").c_str());
     linkBitCodeFile((libPath + "/ockl.bc").c_str());
@@ -4821,11 +4821,7 @@ static void makeBinaryLLVMForHIP(const std::string& artifactFilename,
   std::string inputs = "-inputs=/dev/null";
   std::string outputs = "-outputs=" + fatbinFilename;
 #endif
-  auto sdkString = std::string(gGpuSdkPath);
-  // check file exists, maybe use alternate path (say if spack installed)
-  std::string lldBin = pathExists((sdkString + "/llvm/bin/lld").c_str()) ?
-                       sdkString + "/llvm/bin/lld"  :
-                       sdkString + "/bin/lld";
+  std::string lldBin = CHPL_ROCM_LLVM_PATH + std::string("/bin/lld");
   for (auto& gpuArch : gpuArches) {
     std::string gpuObject = gpuObjFilename + "_" + gpuArch + ".o";
     std::string gpuOut = outFilenamePrefix + "_" + gpuArch + ".out";
@@ -5051,7 +5047,8 @@ void makeBinaryLLVM(void) {
         gpuArgs += " -Wno-unknown-cuda-version";
       }
       else if (getGpuCodegenType() == GpuCodegenType::GPU_CG_AMD_HIP) {
-        curPath = addToPATH(gGpuSdkPath + std::string("/llvm/bin"));
+        // use the AMD LLVM path, use separate var
+        curPath = addToPATH(CHPL_ROCM_LLVM_PATH + std::string("/bin"));
       }
     }
 

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -130,6 +130,8 @@ const char* CHPL_TARGET_BUNDLED_LINK_ARGS = NULL;
 const char* CHPL_TARGET_SYSTEM_LINK_ARGS = NULL;
 
 const char* CHPL_CUDA_LIBDEVICE_PATH = NULL;
+const char* CHPL_ROCM_LLVM_PATH = NULL;
+const char* CHPL_ROCM_AMDGCN_PATH = NULL;
 const char* CHPL_GPU = NULL;
 const char* CHPL_GPU_ARCH = NULL;
 
@@ -1824,6 +1826,8 @@ static void setChapelEnvs() {
 
   if (usingGpuLocaleModel()) {
     CHPL_CUDA_LIBDEVICE_PATH = envMap["CHPL_CUDA_LIBDEVICE_PATH"];
+    CHPL_ROCM_LLVM_PATH = envMap["CHPL_ROCM_LLVM_PATH"];
+    CHPL_ROCM_AMDGCN_PATH = envMap["CHPL_ROCM_AMDGCN_PATH"];
     CHPL_GPU= envMap["CHPL_GPU"];
     CHPL_GPU_ARCH = envMap["CHPL_GPU_ARCH"];
     switch (getGpuCodegenType()) {

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1831,7 +1831,7 @@ static void setChapelEnvs() {
         gGpuSdkPath = envMap["CHPL_CUDA_PATH"];
         break;
       case GpuCodegenType::GPU_CG_AMD_HIP:
-        gGpuSdkPath = envMap["CHPL_ROCM_BITCODE_PATH"];
+        gGpuSdkPath = envMap["CHPL_ROCM_PATH"];
         break;
       case GpuCodegenType::GPU_CG_CPU:
         gGpuSdkPath = "";

--- a/modules/standard/ChplConfig.chpl
+++ b/modules/standard/ChplConfig.chpl
@@ -190,6 +190,12 @@ module ChplConfig {
   CHPL_GPU = __primitive("get compiler variable", "CHPL_GPU");
 
   @chpldoc.nodoc
+  @unstable("'ChplConfig.CHPL_GPU_SDK_VERSION' is unstable and may be replaced with a different way to access this information in the future")
+  param CHPL_GPU_SDK_VERSION:string;
+  CHPL_GPU_SDK_VERSION = __primitive("get compiler variable", "CHPL_GPU_SDK_VERSION");
+
+
+  @chpldoc.nodoc
   @unstable("'ChplConfig.CHPL_LIB_PIC' is unstable and may be replaced with a different way to access this information in the future")
   param CHPL_LIB_PIC: string;
   CHPL_LIB_PIC = __primitive("get compiler variable", "CHPL_LIB_PIC");

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -64,6 +64,19 @@ $(CHPL_ENV_HEADER): $(CHPL_MAKE_HOME)/util/printchplenv $(CHPL_MAKE_HOME)/util/c
 	  sed 's/^ *//;s/ *$$//' | \
 	  sed 's/[^0-9A-Za-z]/_/g' | \
 	  awk '{ print "#define " toupper($$1) }' >> $(CHPL_ENV_HEADER)
+	
+	@$(CHPL_MAKE_HOME)/util/printchplenv --only CHPL_GPU_SDK_VERSION --value | \
+		grep -q none && \
+			echo "#define CHPL_GPU_SDK_VERSION_MAJOR 0" >> $(CHPL_ENV_HEADER) && \
+			echo "#define CHPL_GPU_SDK_VERSION_MINOR 0" >> $(CHPL_ENV_HEADER) && \
+			echo "#define CHPL_GPU_SDK_VERSION_PATCH 0" >> $(CHPL_ENV_HEADER) \
+		|| \
+			$(CHPL_MAKE_HOME)/util/printchplenv --only CHPL_GPU_SDK_VERSION --value | \
+			sed 's/\./ /g' | \
+			awk '{ print "#define CHPL_GPU_SDK_VERSION_MAJOR " $$1; \
+						 print "#define CHPL_GPU_SDK_VERSION_MINOR " $$2; \
+						 print "#define CHPL_GPU_SDK_VERSION_PATCH " $$3 }' >> $(CHPL_ENV_HEADER)
+
 	@echo "#endif /* _CHPL_ENV_GEN_H_ */" >> $(CHPL_ENV_HEADER)
 
 THIRD_PARTY_PKGS = $(shell $(CHPL_MAKE_PYTHON) $(CHPL_MAKE_HOME)/util/chplenv/third-party-pkgs)

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -64,7 +64,6 @@ $(CHPL_ENV_HEADER): $(CHPL_MAKE_HOME)/util/printchplenv $(CHPL_MAKE_HOME)/util/c
 	  sed 's/^ *//;s/ *$$//' | \
 	  sed 's/[^0-9A-Za-z]/_/g' | \
 	  awk '{ print "#define " toupper($$1) }' >> $(CHPL_ENV_HEADER)
-	
 	@$(CHPL_MAKE_HOME)/util/printchplenv --only CHPL_GPU_SDK_VERSION --value | \
 		grep -q none && \
 			echo "#define CHPL_GPU_SDK_VERSION_MAJOR 0" >> $(CHPL_ENV_HEADER) && \
@@ -76,7 +75,6 @@ $(CHPL_ENV_HEADER): $(CHPL_MAKE_HOME)/util/printchplenv $(CHPL_MAKE_HOME)/util/c
 			awk '{ print "#define CHPL_GPU_SDK_VERSION_MAJOR " $$1; \
 						 print "#define CHPL_GPU_SDK_VERSION_MINOR " $$2; \
 						 print "#define CHPL_GPU_SDK_VERSION_PATCH " $$3 }' >> $(CHPL_ENV_HEADER)
-
 	@echo "#endif /* _CHPL_ENV_GEN_H_ */" >> $(CHPL_ENV_HEADER)
 
 THIRD_PARTY_PKGS = $(shell $(CHPL_MAKE_PYTHON) $(CHPL_MAKE_HOME)/util/chplenv/third-party-pkgs)

--- a/runtime/include/gpu/amd/rocm-version.h
+++ b/runtime/include/gpu/amd/rocm-version.h
@@ -21,20 +21,6 @@
 #ifndef __HIP_PLATFORM_AMD__
 #define __HIP_PLATFORM_AMD__
 #endif
-#include <hip/hip_common.h>
-#include <hip/hip_runtime.h>
 
-#if __has_include(<rocm-core/rocm_version.h>)  // 5.x wants this
-#include <rocm-core/rocm_version.h>
-#elif __has_include(<rocm/rocm_version.h>)  // 4.x wants this
-#include <rocm/rocm_version.h>
-#elif __has_include(<rocm_version.h>)  // Deprecated. 5.x used to want this
-#include <rocm_version.h>
-#endif
-
-// we should have found the correct header by now. But if not, we set
-// ROCM_VERSION_MAJOR to 4 as it is the lowest version we support and has fewer
-// runtime features enabled. So, it is a safer choice.
-#if !defined(ROCM_VERSION_MAJOR)
-#define ROCM_VERSION_MAJOR 4
-#endif
+// CHPL_GPU_SDK_VERSION_MAJOR is determined by printchplenv
+#define ROCM_VERSION_MAJOR CHPL_GPU_SDK_VERSION_MAJOR

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -19,7 +19,6 @@ class gpu_type:
     def __init__(self, sdk_path_env,
                         sdk_path_env_bitcode,
                         sdk_path_env_include,
-                        sdk_path_env_runtime,
                         compiler,
                         default_arch,
                         llvm_target,
@@ -29,7 +28,6 @@ class gpu_type:
         self.sdk_path_env = sdk_path_env
         self.sdk_path_env_bitcode = sdk_path_env_bitcode
         self.sdk_path_env_include = sdk_path_env_include
-        self.sdk_path_env_runtime = sdk_path_env_runtime
         self.compiler = compiler
         self.default_arch = default_arch
         self.llvm_target = llvm_target
@@ -54,7 +52,6 @@ GPU_TYPES = {
     "nvidia": gpu_type(sdk_path_env="CHPL_CUDA_PATH",
                        sdk_path_env_bitcode="CHPL_CUDA_PATH",
                        sdk_path_env_include="CHPL_CUDA_PATH",
-                       sdk_path_env_runtime="CHPL_CUDA_PATH",
                        compiler="nvcc",
                        default_arch="sm_60",
                        llvm_target="NVPTX",
@@ -64,7 +61,6 @@ GPU_TYPES = {
     "amd": gpu_type(sdk_path_env="CHPL_ROCM_PATH",
                     sdk_path_env_bitcode="CHPL_ROCM_BITCODE_PATH",
                     sdk_path_env_include="CHPL_ROCM_INCLUDE_PATH",
-                    sdk_path_env_runtime="CHPL_ROCM_RUNTIME_PATH",
                     compiler="hipcc",
                     default_arch="",
                     llvm_target="AMDGPU",
@@ -74,7 +70,6 @@ GPU_TYPES = {
     "cpu": gpu_type(sdk_path_env="",
                     sdk_path_env_bitcode="",
                     sdk_path_env_include="",
-                    sdk_path_env_runtime="",
                     compiler="",
                     default_arch="",
                     llvm_target="",
@@ -174,7 +169,6 @@ def get_sdk_path(for_gpu, sdk_type='bitcode'):
     sub_env_names = {
         "bitcode": gpu.sdk_path_env_bitcode,
         "include": gpu.sdk_path_env_include,
-        "runtime": gpu.sdk_path_env_runtime
     }
     assert sdk_type in sub_env_names
 

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -341,6 +341,7 @@ def _validate_cuda_version_impl():
     return True
 
 def get_sdk_version():
+    version = 'none'
     if get() == 'amd':
         chpl_rocm_path = get_sdk_path('amd', sdk_type='include')
         files_to_try = ['%s/.info/version-hiprt' % chpl_rocm_path,
@@ -366,7 +367,7 @@ def get_sdk_version():
                     match = re.search(r"llvm-amdgpu-([\d\.]+)", my_stdout)
                     if match:
                         rocm_version = match.group(1)
-        return rocm_version
+        version = rocm_version
     elif get() == 'nvidia':
         chpl_cuda_path = get_sdk_path('nvidia')
         version_file_json = '%s/version.json' % chpl_cuda_path
@@ -390,9 +391,9 @@ def get_sdk_version():
                 match = re.search(pattern, my_stdout)
                 if match:
                     cuda_version = match.group(1)
-        return cuda_version
-    else:
-        return 'none'
+        version = cuda_version
+    version = version.strip() if version is not None else 'none'
+    return version
 
 
 def _validate_rocm_version_impl():

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -19,23 +19,25 @@ def _validate_rocm_version():
 
 class gpu_type:
     def __init__(self, sdk_path_env,
-                        sdk_path_env_bitcode,
-                        sdk_path_env_include,
                         compiler,
                         default_arch,
                         llvm_target,
                         runtime_impl,
+                        find_sdk_path,
+                        find_version,
                         version_validator,
-                        llvm_validator):
+                        llvm_validator,
+                        real_gpu):
         self.sdk_path_env = sdk_path_env
-        self.sdk_path_env_bitcode = sdk_path_env_bitcode
-        self.sdk_path_env_include = sdk_path_env_include
         self.compiler = compiler
         self.default_arch = default_arch
         self.llvm_target = llvm_target
         self.runtime_impl = runtime_impl
+        self.find_sdk_path = find_sdk_path
+        self.find_version = find_version
         self.version_validator = version_validator
         self.llvm_validator = llvm_validator
+        self.real_gpu = real_gpu
 
     def validate_sdk_version(self):
         return self.version_validator()
@@ -50,7 +52,7 @@ def _validate_rocm_llvm_version(gpu: gpu_type):
     return _validate_rocm_llvm_version_impl(gpu)
 
 @memoize
-def _gpu_compiler_version_output(compiler: str, lang: str):
+def gpu_compiler_basic_compile(compiler: str, lang: str):
     dummy_main = "int main() { return 0; }"
     exists, returncode, stdout, _ = try_run_command([compiler, "-v", "-c", "-x", lang, "-", "-o", "/dev/null"], cmd_input=dummy_main, combine_output=True)
     if exists and returncode == 0 and stdout:
@@ -59,36 +61,77 @@ def _gpu_compiler_version_output(compiler: str, lang: str):
         return None
 
 def _find_cuda_sdk_path(compiler: str):
-    out = _gpu_compiler_version_output(compiler, "cu")
-    # #$ TOP=
+    out = gpu_compiler_basic_compile(compiler, "cu")
+    if not out:
+        return None
+    regex = r"^#\$ TOP=(.+)$"
+    match = re.search(regex, out, re.MULTILINE)
+    return match.group(1) if match else None
 
-    # find lib device: #$ NVVMIR_LIBRARY_DIR=
 
+def find_llvm_amd_bin_path(compiler: str):
+    out = gpu_compiler_basic_compile(compiler, "hip")
+    if not out:
+        return None
+    regex = r"^InstalledDir: (.+)$"
+    match = re.search(regex, out, re.MULTILINE)
+    return match.group(1) if match else None
 
-# LLVM AMD GPU
-def _find_rocm_sdk_path(compiler: str):
-    out = _gpu_compiler_version_output(compiler, "hip")
-    # InstalledDir
+def find_amdgcn_path(compiler: str):
+    out = gpu_compiler_basic_compile(compiler, "hip")
+    if not out:
+        return None
+    # find the builtin bitcode path
+    # this will likely appear many times, we just take the first occurrence
+    regex = r"-mlink-builtin-bitcode\s*(/.+?amdgcn/bitcode)"
+    match = re.search(regex, out)
+    if not match:
+        return None
+    full_path = match.group(1)
+    # strip the 'bitcode' part (and trailing '/')
+    return os.path.dirname(full_path)
 
-# HIP
-def _find_rocm_include_path(compiler: str):
-    # Found HIP installation
-    pass
+def _find_hip_sdk_path(compiler: str):
+    out = gpu_compiler_basic_compile(compiler, "hip")
+    if not out:
+        return None
+    regex = r"^Found HIP installation: (.+),"
+    match = re.search(regex, out, re.MULTILINE)
+    return match.group(1) if match else None
 
 def _find_cuda_version(compiler: str):
-    # cuda, we can run nvcc --version
+    # we can run 'nvcc --version'
     # 'Cuda compilation tools, release'
-    pass
+    regex = r"Cuda compilation tools, release ([\d\.]+)"
+
+    exists, returncode, out, _ = utils.try_run_command([compiler, "--version"])
+    if not (exists and returncode == 0):
+        return None
+    
+    match = re.search(regex, out)
+    return match.group(1) if match else None
 
 def _find_rocm_version(compiler: str):
-    # hip/amd sucks, we have to guess
-    # one of the following regexs in the compiler output, look in this order
-    ' roc-VERSION '
-    '/rocm-VERSION/'
-    '/hip-VERSION/'
-    '/llvm-amdgpu-VERSION/'
-    '/rocm/VERSION/'
-    pass
+    # hip/amd has less uniform version info, we have to guess
+    # use one of the following regexes in the compiler output in this order
+    sep = os.path.sep
+    regexes = [
+        r"\broc-([\d\.]+)\b",
+        sep+r"rocm-([\d\.]+)"+sep,
+        sep+r"hip-([\d\.]+)",
+        sep+r"llvm-amdgpu-([\d\.]+)",
+        sep+r"rocm"+sep+r"([\d\.]+)"+sep,
+    ]
+
+    out = gpu_compiler_basic_compile(compiler, "hip")
+    if not out:
+        return None
+
+    for regex in regexes:
+        match = re.search(regex, out)
+        if match:
+            return match.group(1)
+    return None
 
 GPU_TYPES = {
     "nvidia": gpu_type(sdk_path_env="CHPL_CUDA_PATH",
@@ -99,16 +142,18 @@ GPU_TYPES = {
                        find_sdk_path=_find_cuda_sdk_path,
                        find_version=_find_cuda_version,
                        version_validator=_validate_cuda_version,
-                       llvm_validator=_validate_cuda_llvm_version),
+                       llvm_validator=_validate_cuda_llvm_version,
+                       real_gpu=True),
     "amd": gpu_type(sdk_path_env="CHPL_ROCM_PATH",
                     compiler="hipcc",
                     default_arch="",
                     llvm_target="AMDGPU",
                     runtime_impl="rocm",
-                    find_sdk_path=_find_rocm_sdk_path,
+                    find_sdk_path=_find_hip_sdk_path,
                     find_version=_find_rocm_version,
                     version_validator=_validate_rocm_version,
-                    llvm_validator=_validate_rocm_llvm_version),
+                    llvm_validator=_validate_rocm_llvm_version,
+                    real_gpu=True),
     "cpu": gpu_type(sdk_path_env="",
                     compiler="",
                     default_arch="",
@@ -117,7 +162,18 @@ GPU_TYPES = {
                     find_sdk_path=lambda compiler: None,
                     find_version=lambda compiler: None,
                     version_validator=lambda: None,
-                    llvm_validator=lambda: None),
+                    llvm_validator=lambda: None,
+                    real_gpu=False),
+    "none": gpu_type(sdk_path_env="",
+                     compiler="",
+                     default_arch="",
+                     llvm_target="",
+                     runtime_impl="",
+                     find_sdk_path=lambda compiler: None,
+                     find_version=lambda compiler: None,
+                     version_validator=lambda: None,
+                     llvm_validator=lambda: None,
+                     real_gpu=False)
 }
 
 
@@ -150,7 +206,8 @@ def get_llvm_override():
     if get() == 'amd':
         major_version = get_sdk_version().split('.')[0]
         if major_version == '5':
-            return '{}/llvm/bin/llvm-config'.format(get_sdk_path('amd'))
+            llvm_path = find_llvm_amd_bin_path(get_gpu_compiler())
+            return '{}/llvm-config'.format(llvm_path)
         pass
     return 'none'
 
@@ -214,66 +271,38 @@ def get_gpu_compiler():
 
 
 @memoize
-def get_sdk_path(for_gpu, sdk_type='bitcode'):
-    gpu_type = get()
-
+def get_sdk_path(for_gpu):
     # No SDK path if GPU is not being used.
-    if gpu_type in ('cpu', 'none'):
+    if not GPU_TYPES[get()].real_gpu:
         return 'none'
-
-    # Check vendor-specific environment variable for SDK path
     gpu = GPU_TYPES[for_gpu]
-    sub_env_names = {
-        "bitcode": gpu.sdk_path_env_bitcode,
-        "include": gpu.sdk_path_env_include,
-    }
-    assert sdk_type in sub_env_names
 
-    # get the sub env if it exists
-    chpl_sdk_path = os.environ.get(sub_env_names[sdk_type])
-    if chpl_sdk_path:
-        return chpl_sdk_path
-    
-    # otherwise use the basic one
+    def validate_path(p):
+        # TODO: for now, just do a simple validation that checks if the path exists
+        return (os.path.exists(p) and os.path.isdir(p))
+
+    # use user specify if given
     chpl_sdk_path = os.environ.get(gpu.sdk_path_env)
     if chpl_sdk_path:
-        return chpl_sdk_path
-
-    # try to find the SDK by running `which` on a vendor-specific program.
-    exists, returncode, my_stdout, my_stderr = utils.try_run_command(["which",
-                                                                      gpu.compiler])
-
-    if exists and returncode == 0:
-        pass
-        # # Walk up from directories from the one containing the gpu compiler
-        # # (e.g.  `nvcc` or `hipcc`) until we find a directory that starts with
-        # # `runtime_impl` (e.g `cuda` or `rocm`)
-        # # TODO: this logic does not seem to work for spack
-        # real_path = os.path.realpath(my_stdout.strip()).strip()
-        # path_parts = real_path.split("/")
-        # chpl_sdk_path = "/"
-        # for part in path_parts:
-        #     if len(part) == 0: continue
-        #     chpl_sdk_path += part
-        #     if not part.startswith(gpu.runtime_impl):
-        #         chpl_sdk_path += "/"
-        #     else:
-        #         break
-        
-        # validate the SDK path found
-        if not (os.path.exists(chpl_sdk_path) and os.path.isdir(chpl_sdk_path)):
+        if for_gpu == get() and not validate_path(chpl_sdk_path):
             _reportMissingGpuReq(
-                "Can't infer {} toolkit from '{}'. Try setting {}."
-                .format(get(), real_path, gpu.sdk_path_env)
-            )
+                "CHPL_GPU={} specified but SDK path '{}' does not exist."
+                .format(for_gpu, chpl_sdk_path))
             return 'error'
-
         return chpl_sdk_path
-    elif gpu_type == for_gpu:
-        _reportMissingGpuReq(("Can't find {} toolkit. Try setting {} to the " +
-                              "{} installation path.").format(gpu.runtime_impl,
-                                                              gpu.sdk_path_env,
-                                                              gpu.runtime_impl))
+
+    # find the sdk path from the compiler based on the one in PATH
+    sdk_path = gpu.find_sdk_path(gpu.compiler)
+    if sdk_path:
+        if not validate_path(sdk_path):
+            _reportMissingGpuReq(
+                "Can't find {} SDK path from '{}'. Try setting {}."
+                .format(for_gpu, gpu.compiler, gpu.sdk_path_env))
+            return 'error'
+        return sdk_path
+    elif for_gpu == get():
+        _reportMissingGpuReq("Can't infer {} toolkit from '{}'. Try setting {}."
+              .format(gpu.runtime_impl, gpu.compiler, gpu.sdk_path_env))
         return 'error'
     else:
         return ''
@@ -295,7 +324,7 @@ def get_runtime_compile_args():
     system = []
 
     gpu_type = get()
-    sdk_path = get_sdk_path(gpu_type, sdk_type='include')
+    sdk_path = get_sdk_path(gpu_type)
     incl = chpl_home_utils.get_chpl_runtime_incl()
 
     # this -D is needed since it affects code inside of headers
@@ -325,7 +354,7 @@ def get_runtime_link_args():
     system = []
 
     gpu_type = get()
-    sdk_path = get_sdk_path(gpu_type, sdk_type='include')
+    sdk_path = get_sdk_path(gpu_type)
 
     if gpu_type == "nvidia":
         system.append("-L" + os.path.join(sdk_path, "lib64"))
@@ -344,29 +373,59 @@ def get_runtime_link_args():
 
     return bundled, system
 
-
-
-
-
 def get_cuda_libdevice_path():
     if get() == 'nvidia':
+        # TODO:  # find lib device: #$ NVVMIR_LIBRARY_DIR=
         # TODO this only makes sense when we are generating for nvidia
         chpl_cuda_path = get_sdk_path('nvidia')
-
+        print(chpl_cuda_path)
+        compiler = get_gpu_compiler()
+        out = gpu_compiler_basic_compile(compiler, "cu")
+        if not out:
+            _reportMissingGpuReq("Can't find libdevice. Please make sure your CHPL_CUDA_PATH is " "set such that CHPL_CUDA_PATH points to the CUDA installation.")
+            return "error"
+        regex = r"^#\$ NVVMIR_LIBRARY_DIR=(.+)$"
+        match = re.search(regex, out, re.MULTILINE)
+        if not match:
+            _reportMissingGpuReq("Can't find libdevice. Please make sure your CHPL_CUDA_PATH is "
+                  "set such that CHPL_CUDA_PATH points to the CUDA installation.")
+            return 'error' 
+        libdevice_path = match.group(1)
         # there can be multiple libdevices for multiple compute architectures. Not
         # sure how realistic that is, nor I see multiple instances in the systems I
         # have access to. They are always named `libdevice.10.bc`, but I just want
         # to be sure here.
-        path_part = "/nvvm/libdevice/libdevice*.bc"
-        libdevices = glob.glob(chpl_cuda_path+path_part)
+        libdevices = glob.glob(os.path.join(libdevice_path, "libdevice.*.bc"))
         if len(libdevices) == 0:
             _reportMissingGpuReq("Can't find libdevice. Please make sure your CHPL_CUDA_PATH is "
-                  "set such that CHPL_CUDA_PATH{} exists.".format(path_part))
+                  "set such that CHPL_CUDA_PATH{} exists.")
             return 'error'
         else:
             return libdevices[0]
 
     return "none"
+
+def get_rocm_llvm_path():
+    if get() == 'amd':
+        compiler = get_gpu_compiler()
+        llvm_path = find_llvm_amd_bin_path(compiler)
+        if not llvm_path:
+            _reportMissingGpuReq("Could not find llvm-amd in {}".format(compiler))
+            return 'error'
+        # strip bin path component (and trailing /)
+        return os.path.dirname(llvm_path)
+    return 'none'
+
+def get_rocm_amdgcn_path():
+    if get() == 'amd':
+        compiler = get_gpu_compiler()
+        amdgcn_path = find_amdgcn_path(compiler)
+        if not amdgcn_path:
+            _reportMissingGpuReq("Could not find amdgcn in {}".format(compiler))
+            return 'error'
+        return amdgcn_path
+    return 'none'
+
 
 def validateLlvmBuiltForTgt(expectedTgt):
     # If we're using the bundled LLVM, llvm-config may not have been built
@@ -452,57 +511,13 @@ def _validate_cuda_version_impl():
     return True
 
 def get_sdk_version():
-    version = 'none'
-    if get() == 'amd':
-        chpl_rocm_path = get_sdk_path('amd', sdk_type='include')
-        files_to_try = ['%s/.info/version-hiprt' % chpl_rocm_path,
-            '%s/.info/version-libs' % chpl_rocm_path]
 
-        version_filename = None
-        for fname in files_to_try:
-           if os.path.exists(fname):
-               version_filename = fname
-               break
+    gpu = GPU_TYPES[get()]
+    if not gpu.real_gpu:
+        return 'none'
+    version = gpu.find_version(get_gpu_compiler())
+    # TODO add validation for if the compiler matches what the user set CHPL_GPU_SDK_VERSION?
 
-        rocm_version = None
-        if version_filename is not None:
-            rocm_version = open(version_filename).read()
-        else:
-            exists, returncode, my_stdout, my_stderr = utils.try_run_command(
-                ["hipcc", "--version"])
-            if exists and returncode == 0:
-                match = re.search(r"rocm?-([\d\.]+)", my_stdout)
-                if match:
-                    rocm_version = match.group(1)
-                else:
-                    match = re.search(r"llvm-amdgpu-([\d\.]+)", my_stdout)
-                    if match:
-                        rocm_version = match.group(1)
-        version = rocm_version
-    elif get() == 'nvidia':
-        chpl_cuda_path = get_sdk_path('nvidia')
-        version_file_json = '%s/version.json' % chpl_cuda_path
-        version_file_txt = '%s/version.txt' % chpl_cuda_path
-        cuda_version = None
-        if os.path.exists(version_file_json):
-            f = open(version_file_json)
-            version_json = json.load(f)
-            f.close()
-            cuda_version = version_json["cuda"]["version"]
-        elif os.path.exists(version_file_txt):
-            txt = open(version_file_txt).read()
-            match = re.search(r'\d+\.\d+\.\d+', txt)
-            if match:
-                cuda_version = match.group()
-        if cuda_version is None:
-            exists, returncode, my_stdout, my_stderr = utils.try_run_command(
-                ["nvcc", "--version"])
-            if exists and returncode == 0:
-                pattern = r"Cuda compilation tools, release ([\d\.]+)"
-                match = re.search(pattern, my_stdout)
-                if match:
-                    cuda_version = match.group(1)
-        version = cuda_version
     version = version.strip() if version is not None else 'none'
     return version
 
@@ -517,7 +532,7 @@ def _validate_rocm_version_impl():
 
     rocm_version = get_sdk_version()
 
-    if rocm_version is None:
+    if rocm_version == 'none':
         _reportMissingGpuReq("Unable to determine ROCm version.")
         return False
 

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -367,8 +367,7 @@ def get_sdk_version():
                     if match:
                         rocm_version = match.group(1)
         return rocm_version
-
-    if get() == 'nvidia':
+    elif get() == 'nvidia':
         chpl_cuda_path = get_sdk_path('nvidia')
         version_file_json = '%s/version.json' % chpl_cuda_path
         version_file_txt = '%s/version.txt' % chpl_cuda_path
@@ -392,6 +391,8 @@ def get_sdk_version():
                 if match:
                     cuda_version = match.group(1)
         return cuda_version
+    else:
+        return 'none'
 
 
 def _validate_rocm_version_impl():

--- a/util/chplenv/compile_link_args_utils.py
+++ b/util/chplenv/compile_link_args_utils.py
@@ -50,7 +50,7 @@ def get_runtime_includes_and_defines():
         # this is needed since it affects code inside of headers
         bundled.append("-DCHPL_COMM_DEBUG")
 
-    gpu_bundled, gpu_system = chpl_gpu.get_runtime_includes_and_defines()
+    gpu_bundled, gpu_system = chpl_gpu.get_runtime_compile_args()
     bundled.extend(gpu_bundled)
     system.extend(gpu_system)
 

--- a/util/chplenv/compile_link_args_utils.py
+++ b/util/chplenv/compile_link_args_utils.py
@@ -50,29 +50,9 @@ def get_runtime_includes_and_defines():
         # this is needed since it affects code inside of headers
         bundled.append("-DCHPL_COMM_DEBUG")
 
-    if locale_model == "gpu":
-        # this -D is needed since it affects code inside of headers
-        bundled.append("-DHAS_GPU_LOCALE")
-        if chpl_gpu.get() == "cpu":
-            bundled.append("-DGPU_RUNTIME_CPU")
-        memtype = chpl_gpu.get_gpu_mem_strategy()
-
-        # If compiling for GPU locales, add CUDA runtime headers to include path
-        gpu_type = chpl_gpu.get()
-        sdk_path = chpl_gpu.get_sdk_path(gpu_type, sdk_type='include')
-
-        bundled.append("-I" + os.path.join(incl, "gpu", chpl_gpu.get()))
-        if gpu_type == "nvidia":
-            system.append("-I" + os.path.join(sdk_path, "include"))
-
-            # workaround an issue with __float128 not being supported by clang in device code
-            system.append("-D__STRICT_ANSI__=1")
-
-        elif gpu_type == "amd":
-            # -isystem instead of -I silences warnings from inside these includes.
-            system.append("-isystem" + os.path.join(sdk_path, "include"))
-            system.append("-isystem" + os.path.join(sdk_path, "hip", "include"))
-            system.append("-isystem" + os.path.join(sdk_path, "hsa", "include"))
+    gpu_bundled, gpu_system = chpl_gpu.get_runtime_includes_and_defines()
+    bundled.extend(gpu_bundled)
+    system.extend(gpu_system)
 
     if mem == "jemalloc" and chpl_jemalloc.get('target') == "bundled":
         # set -DCHPL_JEMALLOC_PREFIX=chpl_je_
@@ -89,30 +69,13 @@ def get_runtime_link_args(runtime_subdir):
     system = [ ]
 
     lib = chpl_home_utils.get_chpl_runtime_lib()
-    locale_model = chpl_locale_model.get()
 
     bundled.append("-L" + os.path.join(lib, runtime_subdir))
     bundled.append("-lchpl")
 
-    if locale_model == "gpu":
-        # If compiling for GPU locales, add CUDA to link path,
-        # and add cuda libraries
-        gpu_type = chpl_gpu.get()
-        sdk_path = chpl_gpu.get_sdk_path(gpu_type, sdk_type='include')
-        if gpu_type == "nvidia":
-            system.append("-L" + os.path.join(sdk_path, "lib64"))
-            system.append("-lcudart")
-            if chpl_platform.is_wsl():
-                # WSL needs to link with libcuda that belongs to the driver hosted in Windows
-                system.append("-L" + os.path.join("/usr", "lib", "wsl", "lib"))
-            system.append("-lcuda")
-        elif gpu_type == "amd":
-            paths = [sdk_path]
-            for p in paths:
-                lib_path = os.path.join(p, "lib")
-                system.append("-L" + lib_path)
-                system.append("-Wl,-rpath," + lib_path)
-            system.append("-lamdhip64")
+    gpu_bundled, gpu_system = chpl_gpu.get_runtime_link_args()
+    bundled.extend(gpu_bundled)
+    system.extend(gpu_system)
 
     # always link with the math library
     system.append("-lm")

--- a/util/chplenv/compile_link_args_utils.py
+++ b/util/chplenv/compile_link_args_utils.py
@@ -108,15 +108,11 @@ def get_runtime_link_args(runtime_subdir):
             system.append("-lcuda")
         elif gpu_type == "amd":
             paths = [sdk_path]
-            runtime_path = chpl_gpu.get_sdk_path(gpu_type, sdk_type='runtime')
-            if runtime_path not in paths:
-                paths.append(runtime_path)
             for p in paths:
                 lib_path = os.path.join(p, "lib")
                 system.append("-L" + lib_path)
                 system.append("-Wl,-rpath," + lib_path)
             system.append("-lamdhip64")
-            system.append("-lhsa-runtime64")
 
     # always link with the math library
     system.append("-lm")

--- a/util/chplenv/overrides.py
+++ b/util/chplenv/overrides.py
@@ -37,8 +37,6 @@ chplvars = [
              'CHPL_GPU_MEM_STRATEGY',
              'CHPL_CUDA_PATH',
              'CHPL_ROCM_PATH',
-             'CHPL_ROCM_BITCODE_PATH',
-             'CHPL_ROCM_INCLUDE_PATH',
              'CHPL_GPU_ARCH',
 
              'CHPL_COMM',

--- a/util/chplenv/overrides.py
+++ b/util/chplenv/overrides.py
@@ -39,7 +39,6 @@ chplvars = [
              'CHPL_ROCM_PATH',
              'CHPL_ROCM_BITCODE_PATH',
              'CHPL_ROCM_INCLUDE_PATH',
-             'CHPL_ROCM_RUNTIME_PATH'
              'CHPL_GPU_ARCH',
 
              'CHPL_COMM',

--- a/util/chplenv/printchplenv.py
+++ b/util/chplenv/printchplenv.py
@@ -108,7 +108,6 @@ CHPL_ENVS = [
     ChapelEnv('  CHPL_ROCM_PATH', INTERNAL),
     ChapelEnv('  CHPL_ROCM_BITCODE_PATH', INTERNAL),
     ChapelEnv('  CHPL_ROCM_INCLUDE_PATH', INTERNAL),
-    ChapelEnv('  CHPL_ROCM_RUNTIME_PATH', INTERNAL),
     ChapelEnv('  CHPL_CUDA_LIBDEVICE_PATH', INTERNAL),
     ChapelEnv('CHPL_COMM', RUNTIME | LAUNCHER | DEFAULT, 'comm'),
     ChapelEnv('  CHPL_COMM_SUBSTRATE', RUNTIME | LAUNCHER | DEFAULT),
@@ -321,7 +320,6 @@ def compute_internal_values():
     ENV_VALS['  CHPL_ROCM_PATH'] = chpl_gpu.get_sdk_path("amd")
     ENV_VALS['  CHPL_ROCM_BITCODE_PATH'] = chpl_gpu.get_sdk_path("amd", sdk_type="bitcode")
     ENV_VALS['  CHPL_ROCM_INCLUDE_PATH'] = chpl_gpu.get_sdk_path("amd", sdk_type="include")
-    ENV_VALS['  CHPL_ROCM_RUNTIME_PATH'] = chpl_gpu.get_sdk_path("amd", sdk_type="runtime")
 
 
 
@@ -377,7 +375,7 @@ def filter_tidy(chpl_env):
         return gpu == 'nvidia'
     elif chpl_env.name == '  CHPL_ROCM_PATH':
         return gpu == 'amd'
-    elif chpl_env.name in ('  CHPL_ROCM_BITCODE_PATH', '  CHPL_ROCM_INCLUDE_PATH', '  CHPL_ROCM_RUNTIME_PATH'):
+    elif chpl_env.name in ('  CHPL_ROCM_BITCODE_PATH', '  CHPL_ROCM_INCLUDE_PATH'):
         return gpu == 'amd'
     elif chpl_env.name == '  CHPL_GPU_ARCH':
         return gpu == 'nvidia' or gpu == 'amd'

--- a/util/chplenv/printchplenv.py
+++ b/util/chplenv/printchplenv.py
@@ -101,6 +101,7 @@ CHPL_ENVS = [
     ChapelEnv('CHPL_TARGET_BACKEND_CPU', INTERNAL),
     ChapelEnv('CHPL_LOCALE_MODEL', RUNTIME | LAUNCHER | DEFAULT, 'loc'),
     ChapelEnv('  CHPL_GPU', RUNTIME | DEFAULT, 'gpu'),
+    ChapelEnv('  CHPL_GPU_SDK_VERSION', RUNTIME),
     ChapelEnv('  CHPL_GPU_ARCH', INTERNAL),
     ChapelEnv('  CHPL_GPU_MEM_STRATEGY', RUNTIME , 'gpu_mem' ),
     ChapelEnv('  CHPL_CUDA_PATH', INTERNAL),
@@ -205,6 +206,7 @@ def compute_all_values():
 
     ENV_VALS['CHPL_LOCALE_MODEL'] = chpl_locale_model.get()
     ENV_VALS['  CHPL_GPU'] = chpl_gpu.get()
+    ENV_VALS['  CHPL_GPU_SDK_VERSION'] = chpl_gpu.get_sdk_version()
     ENV_VALS['  CHPL_CUDA_LIBDEVICE_PATH'] = chpl_gpu.get_cuda_libdevice_path()
     ENV_VALS['  CHPL_GPU_MEM_STRATEGY'] = chpl_gpu.get_gpu_mem_strategy()
     ENV_VALS['CHPL_COMM'] = chpl_comm.get()
@@ -379,6 +381,8 @@ def filter_tidy(chpl_env):
         return gpu == 'amd'
     elif chpl_env.name == '  CHPL_GPU_ARCH':
         return gpu == 'nvidia' or gpu == 'amd'
+    elif chpl_env.name == '  CHPL_GPU_SDK_VERSION':
+        return gpu != 'none'
     elif chpl_env.name == '  CHPL_HOST_JEMALLOC':
         return host_mem == 'jemalloc'
     elif chpl_env.name == '  CHPL_TARGET_JEMALLOC':

--- a/util/chplenv/printchplenv.py
+++ b/util/chplenv/printchplenv.py
@@ -107,6 +107,8 @@ CHPL_ENVS = [
     ChapelEnv('  CHPL_CUDA_PATH', INTERNAL),
     ChapelEnv('  CHPL_ROCM_PATH', INTERNAL),
     ChapelEnv('  CHPL_CUDA_LIBDEVICE_PATH', INTERNAL),
+    ChapelEnv('  CHPL_ROCM_LLVM_PATH', INTERNAL),
+    ChapelEnv('  CHPL_ROCM_AMDGCN_PATH', INTERNAL),
     ChapelEnv('CHPL_COMM', RUNTIME | LAUNCHER | DEFAULT, 'comm'),
     ChapelEnv('  CHPL_COMM_SUBSTRATE', RUNTIME | LAUNCHER | DEFAULT),
     ChapelEnv('  CHPL_GASNET_SEGMENT', RUNTIME | LAUNCHER | DEFAULT),
@@ -205,6 +207,8 @@ def compute_all_values():
     ENV_VALS['  CHPL_GPU'] = chpl_gpu.get()
     ENV_VALS['  CHPL_GPU_SDK_VERSION'] = chpl_gpu.get_sdk_version()
     ENV_VALS['  CHPL_CUDA_LIBDEVICE_PATH'] = chpl_gpu.get_cuda_libdevice_path()
+    ENV_VALS['  CHPL_ROCM_LLVM_PATH'] = chpl_gpu.get_rocm_llvm_path()
+    ENV_VALS['  CHPL_ROCM_AMDGCN_PATH'] = chpl_gpu.get_rocm_amdgcn_path()
     ENV_VALS['  CHPL_GPU_MEM_STRATEGY'] = chpl_gpu.get_gpu_mem_strategy()
     ENV_VALS['CHPL_COMM'] = chpl_comm.get()
     ENV_VALS['  CHPL_COMM_SUBSTRATE'] = chpl_comm_substrate.get()
@@ -369,6 +373,10 @@ def filter_tidy(chpl_env):
         return gpu == 'nvidia'
     elif chpl_env.name == '  CHPL_CUDA_LIBDEVICE_PATH':
         return gpu == 'nvidia'
+    elif chpl_env.name == '  CHPL_ROCM_LLVM_PATH':
+        return gpu == 'amd'
+    elif chpl_env.name == '  CHPL_ROCM_AMDGCN_PATH':
+        return gpu == 'amd'
     elif chpl_env.name == '  CHPL_ROCM_PATH':
         return gpu == 'amd'
     elif chpl_env.name == '  CHPL_GPU_ARCH':

--- a/util/chplenv/printchplenv.py
+++ b/util/chplenv/printchplenv.py
@@ -106,8 +106,6 @@ CHPL_ENVS = [
     ChapelEnv('  CHPL_GPU_MEM_STRATEGY', RUNTIME , 'gpu_mem' ),
     ChapelEnv('  CHPL_CUDA_PATH', INTERNAL),
     ChapelEnv('  CHPL_ROCM_PATH', INTERNAL),
-    ChapelEnv('  CHPL_ROCM_BITCODE_PATH', INTERNAL),
-    ChapelEnv('  CHPL_ROCM_INCLUDE_PATH', INTERNAL),
     ChapelEnv('  CHPL_CUDA_LIBDEVICE_PATH', INTERNAL),
     ChapelEnv('CHPL_COMM', RUNTIME | LAUNCHER | DEFAULT, 'comm'),
     ChapelEnv('  CHPL_COMM_SUBSTRATE', RUNTIME | LAUNCHER | DEFAULT),
@@ -318,8 +316,6 @@ def compute_internal_values():
     ENV_VALS['  CHPL_GPU_ARCH'] = chpl_gpu.get_arch()
     ENV_VALS['  CHPL_CUDA_PATH'] = chpl_gpu.get_sdk_path("nvidia")
     ENV_VALS['  CHPL_ROCM_PATH'] = chpl_gpu.get_sdk_path("amd")
-    ENV_VALS['  CHPL_ROCM_BITCODE_PATH'] = chpl_gpu.get_sdk_path("amd", sdk_type="bitcode")
-    ENV_VALS['  CHPL_ROCM_INCLUDE_PATH'] = chpl_gpu.get_sdk_path("amd", sdk_type="include")
 
 
 
@@ -374,8 +370,6 @@ def filter_tidy(chpl_env):
     elif chpl_env.name == '  CHPL_CUDA_LIBDEVICE_PATH':
         return gpu == 'nvidia'
     elif chpl_env.name == '  CHPL_ROCM_PATH':
-        return gpu == 'amd'
-    elif chpl_env.name in ('  CHPL_ROCM_BITCODE_PATH', '  CHPL_ROCM_INCLUDE_PATH'):
         return gpu == 'amd'
     elif chpl_env.name == '  CHPL_GPU_ARCH':
         return gpu == 'nvidia' or gpu == 'amd'

--- a/util/chplenv/third_party_utils.py
+++ b/util/chplenv/third_party_utils.py
@@ -471,3 +471,4 @@ def could_not_find_pkgconfig_pkg(pkg, envname):
     else:
         install_str = " with `brew install {0}`".format(pkg) if homebrew_utils.homebrew_exists() else ""
         error("Could not find a suitable {0} installation. Please install {0}{1} or set {2}=bundled.".format(pkg, install_str, envname))
+

--- a/util/chplenv/utils.py
+++ b/util/chplenv/utils.py
@@ -70,8 +70,9 @@ def try_run_command(command, cmd_input=None, combine_output=False):
         return (False, 0, None, None)
     byte_cmd_input = str.encode(cmd_input, "utf-8") if cmd_input else None
     output = process.communicate(input=byte_cmd_input)
-    return (True, process.returncode, output[0].decode("utf-8"),
-            output[1].decode("utf-8"))
+    my_stdout = output[0].decode("utf-8")
+    my_sterr = output[1].decode("utf-8") if combine_output and output[1] else None
+    return (True, process.returncode, my_stdout, my_sterr)
 
 
 def run_command(command, stdout=True, stderr=False, cmd_input=None):

--- a/util/chplenv/utils.py
+++ b/util/chplenv/utils.py
@@ -53,16 +53,18 @@ class CommandError(Exception):
     pass
 
 
-def try_run_command(command, cmd_input=None):
+def try_run_command(command, cmd_input=None, combine_output=False):
     """Command subprocess wrapper tolerating failure to find or run the cmd.
        For normal usage the vanilla run_command() may be simpler to use.
        This should be the only invocation of subprocess in all chplenv scripts.
        This could be replaced by subprocess.check_output, but that
        is only available after Python 2.7, and we still support 2.6 :("""
+    
+    stderr = subprocess.STDOUT if combine_output else subprocess.PIPE
     try:
         process = subprocess.Popen(command,
                                    stdout=subprocess.PIPE,
-                                   stderr=subprocess.PIPE,
+                                   stderr=stderr,
                                    stdin=subprocess.PIPE)
     except OSError:
         return (False, 0, None, None)


### PR DESCRIPTION
Reworks many of our configuration settings around `CHPL_GPU` to improve the clarity improve the user expierence when setting up Chapel for GPUs.

Major highlights:
- For the most part, if the target gpu compiler is in `PATH`, our scripts will "do the right thing"
- Exposes the current CUDA/ROCm version as `CHPL_GPU_SDK_VERSION`
- Switches to inferring information like versions and paths to be based on invocations of the target gpu compiler

Implementation changes:
- Most information is now determined by looking at the ouptut of a test compile of the target gpu compiler, i.e.: `echo ""int main() { return 0; }" | nvcc -v -c -x cu - -o /dev/null &2>&1`
- Reworked what `CHPL_ROCM_PATH` means (and remove the sub vars for this, which were confusing). This now always points to the directory such that `CHPL_ROCM_PATH/bin/hipcc` exists. This was the previous definition, but this PR enforces that better improves our logic to infer that
- Added `CHPL_ROCM_AMDGCN_PATH` and `CHPL_ROCM_LLVM_PATH`, both of which are based on information gained from actually invoking `hipcc`. This removes many heuristics we had for finding this
- Moved compile/link argument detection into `chpl_gpu.py`
- The Chapel compiler should now do a much better job of working with spack installs of the target gpu compiler

TODO: I just any error message that made sense at the time, I want to evaluate and craft better messages

Testing
- ROCm 4
  - [ ] validated that printchplenv output is correct, with/without `CHPL_ROCM_PATH`
  - [ ] validated proper errors occur when the path is wrong or the target gpu compiler is "broken"
  - [ ] `make check`
- ROCm 5
  - [ ] validated that printchplenv output is correct, with/without `CHPL_ROCM_PATH`
  - [ ] validated proper errors occur when the path is wrong or the target gpu compiler is "broken"
  - [ ] `make check`
- ROCm 6
  - [ ] validated that printchplenv output is correct, with/without `CHPL_ROCM_PATH`
  - [ ] validated proper errors occur when the path is wrong or the target gpu compiler is "broken"
  - [ ] `start_test test/gpu/native`
- CUDA 11
  - [ ] validated that printchplenv output is correct, with/without `CHPL_CUDA_PATH`
  - [ ] validated proper errors occur when the path is wrong or the target gpu compiler is "broken"
  - [ ] `start_test test/gpu/native`
- CUDA 12
  - [ ] validated that printchplenv output is correct, with/without `CHPL_CUDA_PATH`
  - [ ] validated proper errors occur when the path is wrong or the target gpu compiler is "broken"
  - [ ] `start_test test/gpu/native`
- Default config (no GPU)
  - [ ] validated that printchplenv output is correct
  - [ ] paratest with/without comm
- CHPL_GPU=cpu
  - [ ] validated that printchplenv output is correct
  - [ ] `start_test test/gpu/native`

<details>
<summary>command to validate paths</command>

```bash
printchplenv  --only CHPL_GPU,CHPL_GPU_SDK_VERSION,CHPL_CUDA_PATH,CHPL_CUDA_LIBDEVICE_PATH,CHPL_ROCM_PATH,CHPL_ROCM_LLVM_PATH,CHPL_ROCM_AMDGCN_PATH
```

</details>