### PR TITLE
Make CHPL_LIB_PATH ignore empty strings

### DIFF
--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -91,7 +91,23 @@ static void addPath(const char* pathVar, std::vector<const char*>* pathvec) {
       colon++;                            // and advance to the next
     }
 
-    pathvec->push_back(astr(dirString));
+    // FIXME (Maybe?)
+    // Following the precedent of $PATH on Unix, we should
+    // treat empty strings between colons like  :: or trailing/leading
+    // colons as meaning to add the current directory to the path.
+    // If we don't include the current directory in the CHPL_LIB_PATH by
+    // default, this behavior below is incorrect, and instead of ignoring
+    // empty strings, it should figure out the current directory and add
+    // that to the path.
+    // Alternatively, we can alter the compiler to throw -L . when
+    // CHPL_LIB_PATH has empty strings in between colons.
+    // However, if we do include the current directory in CHPL_LIB_PATH
+    // by default, then this doesn't need fixing, delete this FIXME.
+
+    // ignore empty strings
+    if (dirString && *dirString) {
+      pathvec->push_back(astr(dirString));
+    }
 
     dirString = colon;                     // advance dirString
   } while (colon != NULL);

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -105,7 +105,7 @@ static void addPath(const char* pathVar, std::vector<const char*>* pathvec) {
     // by default, then this doesn't need fixing, delete this FIXME.
 
     // ignore empty strings
-    if (dirString && *dirString) {
+    if (dirString && strlen(dirString) > 0) {
       pathvec->push_back(astr(dirString));
     }
 


### PR DESCRIPTION
If `CHPL_LIB_PATH` has colons in it, we split the path based on the colons. However, if we have a trailing or leading colon, or two colons back to back (`::`) in CHPL_LIB_PATH, it get's added as an empty string. This cases errors since there isn't an argument to go with `-L` for the target compiler.
Ex:

```
clang++: error: argument to '-L' is missing (expected 1 value)
```

This makes the change such the the `addPath` function ignores the empty strings in CHPL_LIB_PATH.

Will resolve nightly test failures in `test-gpu-ex-cuda-12.interop`.