### PR TITLE
remove trailing semicolons from python files

### DIFF
--- a/doc/rst/search_index_entries.py
+++ b/doc/rst/search_index_entries.py
@@ -93,7 +93,7 @@ def on_build_finish(app, exc):
 
     # remove 'Search.setIndex(' as well as the trailing )
     searchindex = remove_prefix(searchindex, 'Search.setIndex(')
-    searchindex = remove_suffix(searchindex, ')');
+    searchindex = remove_suffix(searchindex, ')')
 
     # parse the result as a json object
     index = json.loads(searchindex)

--- a/doc/util/literate_chapel.py
+++ b/doc/util/literate_chapel.py
@@ -82,7 +82,7 @@ def to_pieces(handle, islearnChapelInYMinutes=False):
             state = 'blockcomment'
             if commentstarts > 0:
                 # reset indentation at the start of a block comment
-                #indentation = -1;
+                #indentation = -1
                 pass
         elif line.startswith('//'):
             state = 'linecomment'

--- a/test/execflags/jhh/helper.py
+++ b/test/execflags/jhh/helper.py
@@ -40,7 +40,7 @@ def checkLauncherArg(prog, outputFile, outputContent=None, delete=False):
                 else:
                     fGood.write(content)
             else:
-                fGood.write('Launcher argument missing: ' +  arg);
+                fGood.write('Launcher argument missing: ' +  arg)
         if delete:
             # Delete the output file. Its name isn't fixed and .cleanfiles doesn't do globbing.
             os.unlink(outputFile)

--- a/test/exercises/wavelet/plot.py
+++ b/test/exercises/wavelet/plot.py
@@ -15,7 +15,7 @@ ax[0].plot(signal)
 ax[0].set_title("ecg signal")
 
 # plot detail layers
-fmin = 0;
+fmin = 0
 fmax = math.floor(len(coeffs) / 2**num_levels)
 for i in range(0, num_levels):
     idx = num_levels - i

--- a/test/interop/python/multilocale/use_bar.py
+++ b/test/interop/python/multilocale/use_bar.py
@@ -4,5 +4,5 @@ bar.chpl_setup(1)
 bar.foo()
 x = 3
 y = bar.takesAndReturns(x)
-bar.threadring(1000, 98);
+bar.threadring(1000, 98)
 bar.chpl_cleanup()

--- a/test/interop/python/multilocale/use_checkExplicitLibname.py
+++ b/test/interop/python/multilocale/use_checkExplicitLibname.py
@@ -4,5 +4,5 @@ checkExplicitLibname.chpl_setup(1)
 checkExplicitLibname.foo()
 x = 3
 y = checkExplicitLibname.takesAndReturns(x)
-checkExplicitLibname.threadring(1000, 98);
+checkExplicitLibname.threadring(1000, 98)
 checkExplicitLibname.chpl_cleanup()

--- a/test/interop/python/multilocale/use_testing.py
+++ b/test/interop/python/multilocale/use_testing.py
@@ -4,5 +4,5 @@ testing.chpl_setup(1)
 testing.foo()
 x = 3
 y = testing.takesAndReturns(x)
-testing.threadring(1000, 98);
+testing.threadring(1000, 98)
 testing.chpl_cleanup()

--- a/test/interop/python/noLibFlag/use_bar.py
+++ b/test/interop/python/noLibFlag/use_bar.py
@@ -4,5 +4,5 @@ bar.chpl_setup()
 bar.foo()
 x = 3
 y = bar.takesAndReturns(x)
-bar.threadring(1000, 98);
+bar.threadring(1000, 98)
 bar.chpl_cleanup()

--- a/test/interop/python/noLibFlag/use_pythonCompile.py
+++ b/test/interop/python/noLibFlag/use_pythonCompile.py
@@ -4,5 +4,5 @@ pythonCompile.chpl_setup()
 pythonCompile.foo()
 x = 3
 y = pythonCompile.takesAndReturns(x)
-pythonCompile.threadring(1000, 98);
+pythonCompile.threadring(1000, 98)
 pythonCompile.chpl_cleanup()

--- a/test/interop/python/use_bar.py
+++ b/test/interop/python/use_bar.py
@@ -4,5 +4,5 @@ bar.chpl_setup()
 bar.foo()
 x = 3
 y = bar.takesAndReturns(x)
-bar.threadring(1000, 98);
+bar.threadring(1000, 98)
 bar.chpl_cleanup()

--- a/test/interop/python/use_checkExplicitLibname.py
+++ b/test/interop/python/use_checkExplicitLibname.py
@@ -4,5 +4,5 @@ checkExplicitLibname.chpl_setup()
 checkExplicitLibname.foo()
 x = 3
 y = checkExplicitLibname.takesAndReturns(x)
-checkExplicitLibname.threadring(1000, 98);
+checkExplicitLibname.threadring(1000, 98)
 checkExplicitLibname.chpl_cleanup()

--- a/test/interop/python/use_testing.py
+++ b/test/interop/python/use_testing.py
@@ -4,5 +4,5 @@ testing.chpl_setup()
 testing.foo()
 x = 3
 y = testing.takesAndReturns(x)
-testing.threadring(1000, 98);
+testing.threadring(1000, 98)
 testing.chpl_cleanup()

--- a/test/library/packages/ProtobufProtocolSupport/endToEnd/enums/read.py
+++ b/test/library/packages/ProtobufProtocolSupport/endToEnd/enums/read.py
@@ -16,7 +16,7 @@ if messageObj.b != 564:
 else:
     print("true")
     
-lst = [];
+lst = []
 lst.append(enums_pb2.color.blue)
 lst.append(enums_pb2.color.green)
 if messageObj.c != lst:
@@ -29,7 +29,7 @@ if messageObj.d != messageObj.fruit.orange:
 else:
     print("true")
     
-lst = [];
+lst = []
 lst.append(messageObj.fruit.orange)
 lst.append(messageObj.fruit.apple)
 if messageObj.e != lst:

--- a/test/library/packages/ProtobufProtocolSupport/endToEnd/enums/write.py
+++ b/test/library/packages/ProtobufProtocolSupport/endToEnd/enums/write.py
@@ -1,6 +1,6 @@
 import enums_pb2
 
-messageObj = enums_pb2.enumTest();
+messageObj = enums_pb2.enumTest()
 
 messageObj.a = enums_pb2.color.blue
 

--- a/test/library/packages/ProtobufProtocolSupport/endToEnd/oneofs/write.py
+++ b/test/library/packages/ProtobufProtocolSupport/endToEnd/oneofs/write.py
@@ -3,7 +3,7 @@ import oneofs_pb2
 messageObj = oneofs_pb2.Foo()
 
 messageObj.co = oneofs_pb2.color.green
-messageObj.name = b"chapel";
+messageObj.name = b"chapel"
 
 messageObj.mfield.a = 67
 messageObj.ifield = 45

--- a/test/library/packages/ProtobufProtocolSupport/endToEnd/repeatedfield/read.py
+++ b/test/library/packages/ProtobufProtocolSupport/endToEnd/repeatedfield/read.py
@@ -6,7 +6,7 @@ file = open("out", "rb")
 messageObj.ParseFromString(file.read())
 file.close()
 
-lst = [];
+lst = []
 lst.append(1)
 lst.append(2445464)
 if messageObj.ui64 != lst:
@@ -14,7 +14,7 @@ if messageObj.ui64 != lst:
 else:
     print("true")
 
-lst = [];
+lst = []
 lst.append(1)
 lst.append(24454)
 if messageObj.ui32 != lst:
@@ -22,7 +22,7 @@ if messageObj.ui32 != lst:
 else:
     print("true")
     
-lst = [];
+lst = []
 lst.append(-100)
 lst.append(244540000000)
 if messageObj.i64 != lst:
@@ -30,23 +30,23 @@ if messageObj.i64 != lst:
 else:
     print("true")
     
-lst = [];
-lst.append(-500);
-lst.append(2445489);
+lst = []
+lst.append(-500)
+lst.append(2445489)
 if messageObj.i32 != lst:
     print("false")
 else:
     print("true")
     
-lst = [];
-lst.append(True);
-lst.append(False);
+lst = []
+lst.append(True)
+lst.append(False)
 if messageObj.bo != lst:
     print("false")
 else:
     print("true")
     
-lst = [];
+lst = []
 lst.append(-500)
 lst.append(-24454890000)
 if messageObj.si64 != lst:
@@ -54,7 +54,7 @@ if messageObj.si64 != lst:
 else:
     print("true")
     
-lst = [];
+lst = []
 lst.append(-50)
 lst.append(-2445489)
 if messageObj.si32 != lst:

--- a/test/library/packages/ProtobufProtocolSupport/endToEnd/typesTest/write.py
+++ b/test/library/packages/ProtobufProtocolSupport/endToEnd/typesTest/write.py
@@ -13,7 +13,7 @@ messageObj.bo = True
 messageObj.si64 = -675348989989
 messageObj.si32 = -214748364
 
-messageObj.byt = b'\x97\xB3\xE6\xCC\x01';
+messageObj.byt = b'\x97\xB3\xE6\xCC\x01'
 
 messageObj.st = "Protobuf implementation for chapel"
 
@@ -23,8 +23,8 @@ messageObj.fi64 = 100000000000
 messageObj.fl = 444.23444
 messageObj.db = 444444444444.23444
 
-messageObj.sf32 = -4567;
-messageObj.sf64 = 6473899292;
+messageObj.sf32 = -4567
+messageObj.sf64 = 6473899292
 
 file = open("out", "wb")
 file.write(messageObj.SerializeToString())

--- a/test/library/standard/Sort/performance/comparison/python-sort-random.py
+++ b/test/library/standard/Sort/performance/comparison/python-sort-random.py
@@ -1,7 +1,7 @@
 import random
 import time
 
-n = 128*1024*1024;
+n = 128*1024*1024
 
 t1 = time.time()
 array = [random.randint(0, 0xffffffffffffffff) for _ in range(n)]

--- a/test/runtime/configMatters/launch/jhh/co-locales/co-locales.py
+++ b/test/runtime/configMatters/launch/jhh/co-locales/co-locales.py
@@ -73,7 +73,7 @@ class ColocaleArgs(unittest.TestCase):
         self.env = os.environ.copy()
 
     def runCmd(self, cmd):
-        output = runCmd(cmd, self.env);
+        output = runCmd(cmd, self.env)
         return output
 
     def test_00_base(self):
@@ -271,7 +271,7 @@ def getDir(compiler):
 
     # If $CHPL_HOME is not set, use the base installation of the compiler
 
-    chpl_home=os.getenv('CHPL_HOME', chpl_base);
+    chpl_home=os.getenv('CHPL_HOME', chpl_base)
     chpl_home=os.path.normpath(chpl_home)
 
     # Find the test directory
@@ -282,7 +282,7 @@ def getDir(compiler):
             Fatal('Cannot find test directory '+chpl_home+'/test or '+testdir)
     # Needed for MacOS mount points
     testdir = os.path.realpath(testdir)
-    # sys.stdout.write('testdir='+testdir+'\n');
+    # sys.stdout.write('testdir='+testdir+'\n')
 
     # If user specified a different test directory (e.g. with --test-root flag on
     # start_test), use it instead.

--- a/test/runtime/configMatters/launch/jhh/reservation/reservation.py
+++ b/test/runtime/configMatters/launch/jhh/reservation/reservation.py
@@ -59,7 +59,7 @@ def skipif():
 class SrunTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        pass;
+        pass
 
     def setUp(self):
         if skipReason is not None:
@@ -70,7 +70,7 @@ class SrunTests(unittest.TestCase):
         self.env.pop('CHPL_LAUNCHER_USE_SBATCH', None)
 
     def runCmd(self, cmd):
-        output = runCmd(cmd, self.env);
+        output = runCmd(cmd, self.env)
         return output
 
     def test_00_base(self):
@@ -145,7 +145,7 @@ class SbatchTests(SrunTests):
         output = super().runCmd(cmd)
         batch = output.split()[-1]
         with open(batch) as fd:
-            output = fd.read();
+            output = fd.read()
         os.unlink(batch)
         return output
 
@@ -178,7 +178,7 @@ def getDir(compiler):
 
     # If $CHPL_HOME is not set, use the base installation of the compiler
 
-    chpl_home=os.getenv('CHPL_HOME', chpl_base);
+    chpl_home=os.getenv('CHPL_HOME', chpl_base)
     chpl_home=os.path.normpath(chpl_home)
 
     # Find the test directory
@@ -189,7 +189,7 @@ def getDir(compiler):
             Fatal('Cannot find test directory '+chpl_home+'/test or '+testdir)
     # Needed for MacOS mount points
     testdir = os.path.realpath(testdir)
-    # sys.stdout.write('testdir='+testdir+'\n');
+    # sys.stdout.write('testdir='+testdir+'\n')
 
     # If user specified a different test directory (e.g. with --test-root flag on
     # start_test), use it instead.

--- a/test/runtime/jhh/colocales/colocales.py
+++ b/test/runtime/jhh/colocales/colocales.py
@@ -81,7 +81,7 @@ class TestFramework(unittest.TestCase):
     def runCmd(self, cmd, env=None):
         if env is None:
             env = self.env
-        output = runCmd(cmd, env=env, check=False);
+        output = runCmd(cmd, env=env, check=False)
         return output
 
     # Returns a list of cores in the specified partition
@@ -324,7 +324,7 @@ class Ex2Tests(TestCases.TestCase):
         Warn about unused cores
         """
         output = self.runCmd("./colocales -r 0 -n 17")
-        self.assertIn("warning: 9 cores are unused\n", output);
+        self.assertIn("warning: 9 cores are unused\n", output)
 
     def test_13_remainder_node(self):
         """
@@ -384,7 +384,7 @@ class Ex3Tests(TestCases.TestCase):
         """
         Single locale gets all the GPUs
         """
-        output = self.runCmd("./colocales -r 0 -n 1");
+        output = self.runCmd("./colocales -r 0 -n 1")
         self.assertIn("GPUS: " + ' '.join(self.gpus), output)
 
     def test_11_two_colocales(self):
@@ -393,7 +393,7 @@ class Ex3Tests(TestCases.TestCase):
         """
         for i in range(0, 2):
             with self.subTest(i=i):
-                output = self.runCmd("./colocales -r %d -n 2" % i);
+                output = self.runCmd("./colocales -r %d -n 2" % i)
                 x = i * 2
                 self.assertIn("GPUS: " + ' '.join(self.gpus[x:x+1]), output)
 
@@ -403,7 +403,7 @@ class Ex3Tests(TestCases.TestCase):
         """
         for i in range(0, 4):
             with self.subTest(i=i):
-                output = self.runCmd("./colocales -r %d -n 4" % i);
+                output = self.runCmd("./colocales -r %d -n 4" % i)
                 self.assertIn("GPUS: " + self.gpus[i], output)
 
     def test_13_oversubscribed(self):
@@ -412,7 +412,7 @@ class Ex3Tests(TestCases.TestCase):
         """
         for i in range(0, 4):
             with self.subTest(i=i):
-                output = self.runCmd("./colocales -r %d -a 4" % i);
+                output = self.runCmd("./colocales -r %d -a 4" % i)
                 self.assertIn("GPUS: " + ' '.join(self.gpus), output)
 
 

--- a/test/runtime/jhh/cpuKinds/cpuKinds.py
+++ b/test/runtime/jhh/cpuKinds/cpuKinds.py
@@ -55,7 +55,7 @@ def skipif():
 class SrunTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        pass;
+        pass
 
     def setUp(self):
         if skipReason is not None:
@@ -63,7 +63,7 @@ class SrunTests(unittest.TestCase):
         self.env = os.environ.copy()
         self.env['HWLOC_XMLFILE'] = 'alderLake.xml'
     def runCmd(self, cmd):
-        output = runCmd(cmd, env=self.env, check=False);
+        output = runCmd(cmd, env=self.env, check=False)
         return output
 
     def test_00_base(self):

--- a/test/runtime/jhh/lps/lps_test.py
+++ b/test/runtime/jhh/lps/lps_test.py
@@ -361,7 +361,7 @@ def getDir(compiler):
 
     # If $CHPL_HOME is not set, use the base installation of the compiler
 
-    chpl_home=os.getenv('CHPL_HOME', chpl_base);
+    chpl_home=os.getenv('CHPL_HOME', chpl_base)
     chpl_home=os.path.normpath(chpl_home)
 
     # Find the test directory
@@ -372,7 +372,7 @@ def getDir(compiler):
             Fatal('Cannot find test directory '+chpl_home+'/test or '+testdir)
     # Needed for MacOS mount points
     testdir = os.path.realpath(testdir)
-    # sys.stdout.write('testdir='+testdir+'\n');
+    # sys.stdout.write('testdir='+testdir+'\n')
 
     # If user specified a different test directory (e.g. with --test-root flag on
     # start_test), use it instead.

--- a/test/runtime/jhh/misc/misc.py
+++ b/test/runtime/jhh/misc/misc.py
@@ -83,7 +83,7 @@ class AccessibleTests(unittest.TestCase):
     def runCmd(self, cmd, env=None):
         if env is None:
             env = self.env
-        output = runCmd(cmd, env=env, check=False);
+        output = runCmd(cmd, env=env, check=False)
         return output
 
     def getCores(self, base=0):

--- a/test/studies/amr/lib/python/regression_test.py
+++ b/test/studies/amr/lib/python/regression_test.py
@@ -52,8 +52,8 @@ def approximateDiff(file_name_1, file_name_2, tolerance):
     # they begin to diverge.
     #----------------------------------------------------------------------
     for i in range(min(len(lines_1), len(lines_2))):
-        split_1 = lines_1[i].split();
-        split_2 = lines_2[i].split();
+        split_1 = lines_1[i].split()
+        split_2 = lines_2[i].split()
   
         if len(split_1) == len(split_2):
             #-----------------------------------------------------------
@@ -91,7 +91,7 @@ output_file_name = sys.argv[1]
 
 if output_file_name.endswith(".comp.out.tmp"):
     output_file = open(output_file_name, 'w')
-    output_file.write("Compilation failed!\n");
+    output_file.write("Compilation failed!\n")
     output_file.write("See the errors in the file "+output_file_name+".save\n")
     output_file.close()
     exit(0)

--- a/test/studies/amr/regressions.py
+++ b/test/studies/amr/regressions.py
@@ -25,8 +25,8 @@ def approximateDiff(file_name_1, file_name_2, tolerance):
     
     if not(difference):
         for i in range(len(lines_1)):
-            s1 = lines_1[i].split();
-            s2 = lines_2[i].split();
+            s1 = lines_1[i].split()
+            s2 = lines_2[i].split()
             difference = False
       
             #==== Compare line lengths ====

--- a/test/users/npadmana/mpi/c2chapel.py
+++ b/test/users/npadmana/mpi/c2chapel.py
@@ -28,9 +28,9 @@ def typeDecl2Chapel(decl, varname=None, isArray=False, isPtr=False):
     if not isinstance(decl, c_ast.TypeDecl):
         decl.show()
         raise c_parser.ParseError("Unable to parse type declaration at %s"%decl.coord)
-    tmp = decl.type;
+    tmp = decl.type
     if varname is None :
-        varname = decl.declname;
+        varname = decl.declname
     if not isinstance(tmp, c_ast.IdentifierType):
         decl.show()
         raise c_parser.ParseError("Unable to parse type declaration at %s"%decl.coord)

--- a/test/users/vass/isX/src/isX.byBlankArgs-compWarns.py
+++ b/test/users/vass/isX/src/isX.byBlankArgs-compWarns.py
@@ -90,7 +90,7 @@ for pred in predList:
   say("  report(", pred, "Value(arg), \"",      pred, "Value\");")
   say("  report(", pred,  "Type(arg.type), \"", pred,  "Type\");")
 
-say("  if isTuple(arg) {");
+say("  if isTuple(arg) {")
 say("    report(isHomogeneousTuple(arg),\"isHomogeneousTuple\");")
 say("    report(isHomogeneousTupleValue(arg),\"isHomogeneousTupleValue\");")
 say("    report(isHomogeneousTupleType(arg.type),\"isHomogeneousTupleType\");")

--- a/test/users/vass/isX/src/isX.module-writeln.py
+++ b/test/users/vass/isX/src/isX.module-writeln.py
@@ -84,8 +84,8 @@ def predShow(varname, pred):
   say("report(%s(%s), \"%s\");\n" % (pred, varname, pred))
 
 for (varname, vartype) in varList:
-  say("\n");
-  say("write(\"%s (%s)\");\n" % (vartype, varname));
+  say("\n")
+  say("write(\"%s (%s)\");\n" % (vartype, varname))
 
   for pred in predList:
     predShow(varname,           pred)

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -107,7 +107,7 @@ def determine_gpu_type():
     error("Unable to determine GPU type%s, assign 'CHPL_GPU' to one of: [%s]" %
       ("" if len(typesFound) == 0 else " (detected: [%s])" %  ", ".join(typesFound),
        ", ".join(GPU_TYPES.keys())))
-    return None;
+    return None
 
 def get_llvm_override():
     if get() == 'amd':
@@ -129,7 +129,7 @@ def get():
         else:
             return chpl_gpu_env
     else:
-        return determine_gpu_type();
+        return determine_gpu_type()
 
 @memoize
 def get_arch():

--- a/util/chplenv/chpl_home_utils.py
+++ b/util/chplenv/chpl_home_utils.py
@@ -129,7 +129,7 @@ def add_vars_to_paths_helper(s, tofix):
 
             for kv in tofix:
               key = kv[0]
-              val = kv[1];
+              val = kv[1]
 
               if path.startswith(val):
                 rel = os.path.relpath(path, val)

--- a/util/chplenv/chpl_hwloc_debug.py
+++ b/util/chplenv/chpl_hwloc_debug.py
@@ -8,7 +8,7 @@ import chpl_hwloc
 
 @memoize
 def get():
-    hwloc_val = chpl_hwloc.get();
+    hwloc_val = chpl_hwloc.get()
     debug_val = overrides.get('CHPL_HWLOC_DEBUG')
     if not debug_val or hwloc_val != 'bundled':
         debug_val = 'nodbg'

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -182,7 +182,7 @@ def check_llvm_packages(llvm_config):
                     contents = f.read()
                     if llvm_version in contents:
                         usr_include_clang_ok = True
-                        clang_include_ok = True;
+                        clang_include_ok = True
 
     llvm_lib_dir = run_command([llvm_config, '--libdir']).strip()
 
@@ -195,16 +195,16 @@ def check_llvm_packages(llvm_config):
         clang_lib_name = 'libclang-cpp.so'
 
     if os.path.isdir(llvm_lib_dir):
-        clang_cpp_lib = os.path.join(llvm_lib_dir, clang_lib_name);
+        clang_cpp_lib = os.path.join(llvm_lib_dir, clang_lib_name)
         clang_cpp_lib_ok = os.path.exists(clang_cpp_lib)
         if usr_include_clang_ok and not clang_cpp_lib_ok:
             # use e.g. /usr/lib/libclang-cpp.so
-            clang_cpp_lib = os.path.join("/usr/lib", clang_lib_name);
+            clang_cpp_lib = os.path.join("/usr/lib", clang_lib_name)
             clang_cpp_lib_ok = os.path.exists(clang_cpp_lib)
 
         if usr_include_clang_ok and not clang_cpp_lib_ok:
             # use e.g. /usr/lib64/libclang-cpp.so
-            clang_cpp_lib = os.path.join("/usr/lib64", clang_lib_name);
+            clang_cpp_lib = os.path.join("/usr/lib64", clang_lib_name)
             clang_cpp_lib_ok = os.path.exists(clang_cpp_lib)
 
     s = ''
@@ -822,7 +822,7 @@ def get_system_llvm_built_sdkroot():
 def get_clang_basic_args():
     clang_args = [ ]
 
-    gcc_install_dir = get_gcc_install_dir();
+    gcc_install_dir = get_gcc_install_dir()
     if gcc_install_dir:
         clang_args.append('--gcc-install-dir=' + gcc_install_dir)
     else:

--- a/util/chplenv/chpl_qthreads.py
+++ b/util/chplenv/chpl_qthreads.py
@@ -6,7 +6,7 @@ from utils import memoize
 @memoize
 def get_uniq_cfg_path():
     def_uniq_cfg = third_party_utils.default_uniq_cfg_path()
-    lm = chpl_locale_model.get();
+    lm = chpl_locale_model.get()
     target_mem = chpl_mem.get('target')
     hwloc = chpl_hwloc.get()
     return '{0}-{1}-{2}-{3}'.format(def_uniq_cfg, lm, target_mem, hwloc)

--- a/util/chplenv/compile_link_args_utils.py
+++ b/util/chplenv/compile_link_args_utils.py
@@ -23,7 +23,7 @@ def get_runtime_includes_and_defines():
 
     incl = chpl_home_utils.get_chpl_runtime_incl()
     locale_model = chpl_locale_model.get()
-    comm = chpl_comm.get();
+    comm = chpl_comm.get()
     tasks = chpl_tasks.get()
     atomics = chpl_atomics.get()
     mem = chpl_mem.get('target')

--- a/util/chplenv/third_party_utils.py
+++ b/util/chplenv/third_party_utils.py
@@ -124,7 +124,7 @@ def pkgconfig_get_system_compile_args(pkg):
     if not pkgconfig_system_has_package(pkg):
         return (None, None)
     # run pkg-config to get the cflags
-    cflags_line = run_command(['pkg-config', '--cflags'] + [pkg]);
+    cflags_line = run_command(['pkg-config', '--cflags'] + [pkg])
     cflags = cflags_line.split()
     return ([ ], cflags)
 
@@ -210,7 +210,7 @@ def pkgconfig_get_system_link_args(pkg, static=pkgconfig_default_static()):
     if static:
       static_arg = ['--static']
 
-    libs_line = run_command(['pkg-config', '--libs'] + static_arg + [pkg]);
+    libs_line = run_command(['pkg-config', '--libs'] + static_arg + [pkg])
     libs = libs_line.split()
     return ([ ], libs)
 

--- a/util/config/make_sys_basic_types.py
+++ b/util/config/make_sys_basic_types.py
@@ -102,7 +102,7 @@ def get_sys_c_types(docs=False):
     compileline_env.pop('CHPL_MAKE_CHPLENV_CACHE', None)
     compileline_proc = subprocess.Popen([compileline_cmd, '--compile'],
         stdout=subprocess.PIPE, env=compileline_env)
-    compileline = compileline_proc.communicate()[0].decode("utf-8").strip();
+    compileline = compileline_proc.communicate()[0].decode("utf-8").strip()
     logging.debug('Compile line: {0}'.format(compileline))
 
     # Create temp header file with *_MAX macros, then run it through the C

--- a/util/config/replace-paths.py
+++ b/util/config/replace-paths.py
@@ -14,7 +14,7 @@ we replace references to that absolute path with $CHPL_RUNTIME_LIB.
 if __name__ == '__main__':
 
   parser = optparse.OptionParser(usage='usage: %prog [--fixpath key path]')
-  parser.add_option('--fixpath', nargs=2, dest='fixpath', action='append');
+  parser.add_option('--fixpath', nargs=2, dest='fixpath', action='append')
   
   (options, args) = parser.parse_args()
 
@@ -24,14 +24,14 @@ if __name__ == '__main__':
     for kv in options.fixpath:
 
       key = kv[0]
-      val = kv[1];
+      val = kv[1]
 
       val = os.path.realpath(val)
       tofix.append([key, val])
 
     #for kv in tofix:
     #  key = kv[0]
-    #  val = kv[1];
+    #  val = kv[1]
     #  sys.stdout.write("will replace {0} with {1}\n".format(val,key))
 
     for line in sys.stdin.readlines():
@@ -61,7 +61,7 @@ if __name__ == '__main__':
         for kv in tofix:
 
           key = kv[0]
-          val = kv[1];
+          val = kv[1]
 
           #sys.stdout.write("does it start with {0}\n".format(val))
           if path.startswith(val):

--- a/util/devel/test/apptainer/extract-docs.py
+++ b/util/devel/test/apptainer/extract-docs.py
@@ -206,7 +206,7 @@ for subpath in subdirs:
 
 tab = { }
 
-i = 0;
+i = 0
 while i < len(subdirs):
   subpath = subdirs[i]
   names = [ ]

--- a/util/devel/test/apptainer/tryit.py
+++ b/util/devel/test/apptainer/tryit.py
@@ -104,7 +104,7 @@ def main():
             ok = True
             # Build/rebuild image.sif if needed
             if os.path.exists("image.sif") and args.rebuild:
-                printAndLog(log, "Removing {}/image.sif".format(d));
+                printAndLog(log, "Removing {}/image.sif".format(d))
                 os.remove("image.sif")
             if not os.path.exists("image.sif"):
                 e,r = runAndLog(log, ["apptainer", "build", "--fakeroot",
@@ -136,10 +136,10 @@ def main():
 
             if args.cleanup:
                 if os.path.exists("image.sif"):
-                    printAndLog(log, "Removing {}/image.sif".format(d));
+                    printAndLog(log, "Removing {}/image.sif".format(d))
                     os.remove("image.sif")
                 if os.path.exists("chapel"):
-                    printAndLog(log, "Removing {}/chapel".format(d));
+                    printAndLog(log, "Removing {}/chapel".format(d))
                     shutil.rmtree("chapel")
 
             printAndLog(log, "")

--- a/util/misc/gen-LAPACK/extern-tool/Passes.py
+++ b/util/misc/gen-LAPACK/extern-tool/Passes.py
@@ -97,7 +97,7 @@ doc_args_dimensions_regex = re.compile( r"(\w+)[- ]by[- ](\w+)(?: coefficient)? 
 
 # Parses the human documentation of the fortran base of scalar ints to determine how (if at all) they relate to matrix arrays
 # Captures: [1,what] the semantic information of relation (order, rows, columns, rank) [2,who] an unbroken sentence of names referring to matrices/arrays
-scalar_matrix_relation_regex = re.compile( r"(?:number\s+of\s+)?(?P<what>\w+)\s+(?:(?:of)|(?:in))\s+(?:the\s+)?(?:input\s+)?(?:(?:matrix)|(?:matrices)|(?:submatrix))?(?:\s+)?(?P<who>(?:(?:(?:\w+\( \w+ \))|(?:\w+))\s*)+)" );
+scalar_matrix_relation_regex = re.compile( r"(?:number\s+of\s+)?(?P<what>\w+)\s+(?:(?:of)|(?:in))\s+(?:the\s+)?(?:input\s+)?(?:(?:matrix)|(?:matrices)|(?:submatrix))?(?:\s+)?(?P<who>(?:(?:(?:\w+\( \w+ \))|(?:\w+))\s*)+)" )
 
 # Parses the function purpose documentation from the documentation
 # Captures: [1,body] the human readable text documenting the purpose of the function
@@ -322,7 +322,7 @@ class LAPACKFunctionDefinePass ( Pass ):
           proc_node.set( "return-type", proc_decl.group( "type" ) )
         #print "\t", proc_decl.group("name")
         
-        arguments = proc_decl.group( "arguments" ).split( "," );
+        arguments = proc_decl.group( "arguments" ).split( "," )
         if len( arguments ) >= 1 and arguments[0] != "":
           args_node = SubElement( proc_node, "arguments-list" )
           arg_counter = 0
@@ -545,7 +545,7 @@ class AssociateArgsToArrayPass ( Pass ):
         proc_info[ proc_name ] = {}
       '''
       base_name = proc_name.lower()
-      match = func_name_group_regex.search( base_name );
+      match = func_name_group_regex.search( base_name )
       if match == None:
         #print proc_name, "(", base_name, ") does not match regex"
         continue
@@ -849,7 +849,7 @@ class AssociateFunctionsLAPACKtoLAPACKEPass ( Pass ):
       '''
       misses = [] 
       for f_arg in lapack_f_proc.findall( "./arguments-list/argument" ):
-        f_arg_name = f_arg.get( "name" );
+        f_arg_name = f_arg.get( "name" )
         c_arg = lapack_c_proc.find( "./arguments-list/argument/[@name='" + f_arg_name.lower() + "']" )
         
         # skip non-analogous args.
@@ -965,7 +965,7 @@ class EasyAssociateArgsPass ( Pass ):
         #continue
 
       for f_arg in f_proc.findall( "./arguments-list/argument" ):
-        f_arg_name = f_arg.get( "name" );
+        f_arg_name = f_arg.get( "name" )
         c_arg = c_proc.find( "./arguments-list/argument/[@name='" + f_arg_name.lower() + "']" )
         
         # skip non-analogous args.
@@ -1477,7 +1477,7 @@ class ChapelerrificLAPACKEFunctionsPass ( Pass ):
     Pass.resolve( selfname, xml_tree ) 
     print "[",selfname,"]"
 
-    chapel_module = xml_tree.find( "./chapel-module" );
+    chapel_module = xml_tree.find( "./chapel-module" )
     chapel_procedures = chapel_module.find( "./procedures" )
     
     for proc in chapel_procedures.findall( "./procedure" ):
@@ -1487,7 +1487,7 @@ class ChapelerrificLAPACKEFunctionsPass ( Pass ):
       
       base_name = proc_name.replace( "LAPACKE_", "" )
       
-      match = func_name_group_regex.search( base_name );
+      match = func_name_group_regex.search( base_name )
       
       if match == None:
         #print proc_name, "(", base_name, ") does not match regex"
@@ -1586,7 +1586,7 @@ class ChapelerrificLAPACKEFunctionsPass ( Pass ):
             if associate_array in args_names:
               array = associate_array
               field = fields[ arrays.index( array ) ]
-              break;
+              break
           
           if field == "rows":
             pass_through[ arg.get("name") ] = "(if matrix_order == lapack_memory_order.row_major then " + array + ".domain.dim(1).size else " + array + ".domain.dim(2).size) : c_int"
@@ -1782,7 +1782,7 @@ class ChapelModuleExternProcPass ( Pass ):
     module_root = xml_tree.find( "./chapel-module" )
     module_procs = module_root.find( "./procedures" )
     
-    proc_count = 0;
+    proc_count = 0
     
     for proc in module_procs.findall( "./procedure" ):
           
@@ -1802,7 +1802,7 @@ class ChapelModuleExternProcPass ( Pass ):
       ordered_args = [None] * len( proc_args )
       
       for arg in proc_args:
-        ordered_args[ int( arg.get( "position" ) ) ] = arg;
+        ordered_args[ int( arg.get( "position" ) ) ] = arg
 
       def_code = SegmentProducer( "extern proc " + proc_name )
       args_code = ListProducer( ", ", "(", ")" )
@@ -1872,7 +1872,7 @@ class ChapelModuleStringToCharWraperProcPass ( Pass ):
       
       char_flag = False
       for arg in proc_args:
-        ordered_args[ int( arg.get( "position" ) ) ] = arg;
+        ordered_args[ int( arg.get( "position" ) ) ] = arg
         char_flag = arg.get( "type" ) == "c_char" or char_flag
       
       # skip procedures that dont have char arguments
@@ -1951,7 +1951,7 @@ class ChapelModuleChapelerrificProcPass ( Pass ):
       
       base_name = proc.get("name").replace( "LAPACKE_", "" )
       
-      match = func_name_group_regex.search( base_name );
+      match = func_name_group_regex.search( base_name )
       if match == None:
         #print proc.get("name"), "(", base_name, ") does not match regex"
         continue
@@ -2006,7 +2006,7 @@ class ChapelModuleChapelerrificProcPass ( Pass ):
         ordered_args = [None] * len( proc_args )
     
         for arg in proc_args:
-          ordered_args[ int( arg.get( "position" ) ) ] = arg;
+          ordered_args[ int( arg.get( "position" ) ) ] = arg
     
         code.append( SegmentProducer( "inline proc " + proc_name ) )
         
@@ -2385,7 +2385,7 @@ class BucketLAPACKFunctionGroupsPass ( Pass ):
       
       base_name = proc_name.replace( "LAPACKE_", "" ) #.replace( "_work", "" )
       
-      match = func_name_group_regex.search( base_name );
+      match = func_name_group_regex.search( base_name )
       
       if match == None:
         print proc_name, "(", base_name, ") does not match regex"
@@ -2477,7 +2477,7 @@ class ImportAbstractLAPACKFunctionsPass ( Pass ):
         for arg in config.findall( "./analogue-arguments-list/argument" ):
           arg_name = arg.get("name")
           arg_relates[ arg_name ] = config.find( "./arguments-relationships/argument/[@name='" + arg_name + "']" )
-          ana_args.append( arg );
+          ana_args.append( arg )
         
       
         for type in config.findall("./types/type"):
@@ -2556,9 +2556,9 @@ class CommonArgumentCollectionPass ( Pass ):
         
         func_args_type = {} # {func_name} => {arg_name} => type_name
         for type_func in config_node.findall( "./types/type" ):
-          type_name = type_func.get( "name" );
-          all_funcs.add( type_name );
-          func_args_type[ type_name ]  = {};
+          type_name = type_func.get( "name" )
+          all_funcs.add( type_name )
+          func_args_type[ type_name ]  = {}
           
           chapel_func = xml_tree.find( type_func.get( "analogue" ) )
           
@@ -2635,9 +2635,9 @@ class DropAttemptedAssociations ( Pass ):
     Pass.resolve( selfname, xml_tree ) 
     print "[",selfname,"]"
     
-    output_xml = ET.Element( "pass" );
+    output_xml = ET.Element( "pass" )
     output_xml.set( "name", "DropAttemptedAssociations" )
-    output_procs = SubElement( output_xml, "procedures" );
+    output_procs = SubElement( output_xml, "procedures" )
     
     for chpl_proc in xml_tree.findall( "./chapel-module/procedures/procedure" ):
       proc_name = chpl_proc.get( "name" )
@@ -2646,7 +2646,7 @@ class DropAttemptedAssociations ( Pass ):
       
       base_name = proc_name.replace( "LAPACKE_", "" )
       
-      match = func_name_group_regex.search( base_name );
+      match = func_name_group_regex.search( base_name )
       
       if match == None:
         print proc_name, "(", base_name, ") does not match regex"
@@ -2747,7 +2747,7 @@ class DropAttemptedAssociations ( Pass ):
             if associate_array in args_names:
               array = associate_array
               field = fields[ arrays.index( array ) ]
-              break;
+              break
           
           if field == "rows":
             pass_through[ arg.get("name") ] = "if matrix_order == LAPACK_ROW_MAJOR then " + array + ".domain.dim(1).size else " + array + ".domain.dim(2).size "
@@ -2859,7 +2859,7 @@ class AbstractDropAttemptedAssociations ( Pass ):
           for i in range( len( method_args ) ):
             if method_args[i].get("name") == rm:
               method_args.remove( method_args[i] )
-              break;
+              break
           
         interface_node = SubElement( config_node, "method-arguments" )   
         for arg in method_args :
@@ -3833,13 +3833,13 @@ class FindLAPACKFunctionGroups ( Pass ):
       proc_name = proc.get( "name" )
       base_name = proc_name.replace( "LAPACK_", "" ).replace( "LAPACKE_", "" ).replace( "_work", "" )
       
-      match = func_name_group_regex.search( base_name );
+      match = func_name_group_regex.search( base_name )
       
       if match == None:
         print proc_name, "ie", base_name, "does not match regex"
         continue
       
-      #names.add( base_name );
+      #names.add( base_name )
       func = match.group( "function" )
       config = match.group( "mtype" )
       
@@ -3906,7 +3906,7 @@ class PrintArgDoc ( Pass ):
     text_node = lapack_node.find( "./text" )
     procs_node = lapack_node.find( "./procedures" )
     
-    doc_set = set();
+    doc_set = set()
     total = 0
     docked = 0
     arg="A"
@@ -4077,7 +4077,7 @@ class SolveArgsUnionFor ( Pass ):
     unique = set()
     co = set()
     non = set()
-    unset = True;
+    unset = True
     for group_node in abstract_lapack.findall( "./group" ):
       for config_node in group_node.findall( "./matrix-configuration" ):
         print config_node.get( "name" ) + group_node.get( "name" )
@@ -4097,7 +4097,7 @@ class SolveArgsUnionFor ( Pass ):
           co |= array_args
           if unset:
             unique |= array_args
-            unset = False;
+            unset = False
           else:
             unique &= array_args
           print unique, "\n"
@@ -4125,7 +4125,7 @@ class FindDifferentLengthCalls ( Pass ):
         continue
       base_name = proc.get("name").replace( "LAPACKE_", "" )
       
-      match = func_name_group_regex.search( base_name );
+      match = func_name_group_regex.search( base_name )
       if match == None:
         #print proc.get("name"), "(", base_name, ") does not match regex"
         continue
@@ -4169,7 +4169,7 @@ class IsNOrMEverTheSame ( Pass ):
       proc_name = proc_node.get( "name" )
       '''
       base_name = proc_name.lower()
-      match = func_name_group_regex.search( base_name );
+      match = func_name_group_regex.search( base_name )
       if match == None:
         #print proc_name, "(", base_name, ") does not match regex"
         continue
@@ -4345,7 +4345,7 @@ class TestInputGroupsGen ( Pass ):
         for arg in config.findall( "./analogue-arguments-list/argument" ):
           arg_name = arg.get("name")
           arg_relates[ arg_name ] = config.find( "./arguments-relationships/argument/[@name='" + arg_name + "']" )
-          ana_args.append( arg );
+          ana_args.append( arg )
         
       
         for type in config.findall("./types/type"):

--- a/util/misc/gen-LAPACK/extern-tool/codetools.py
+++ b/util/misc/gen-LAPACK/extern-tool/codetools.py
@@ -25,7 +25,7 @@ class SegmentProducer ( CodeProducer ):
     self.value = str( string )
     
   def generate( self ):
-    return self.value;
+    return self.value
   
   def scope(self):
     pass
@@ -79,7 +79,7 @@ class SequenceOfProducers ( CodeProducer ):
     string = str()
     for producer in self.producers:
       string += producer.generate()
-    return string;
+    return string
 
 class ListProducer ( SequenceOfProducers ):
   def __init__( self, sep=", ", prefix = "", suffix = "" ):
@@ -95,7 +95,7 @@ class ListProducer ( SequenceOfProducers ):
       producer = self.producers[i]
       string += producer.generate() + (self.sep if i < count_producers - 1 else "")
     string += self.suffix
-    return string;
+    return string
 
 class ScopeProducer ( SequenceOfProducers ):
 
@@ -140,7 +140,7 @@ class ScopeProducer ( SequenceOfProducers ):
       else:
         string += CodeProducer.tab*(self.depth+1) + producer.generate()
     string += CodeProducer.tab*(self.depth) + LineProducer("}").generate()
-    return string;
+    return string
     
   
 

--- a/util/misc/gen-LAPACK/extern-tool/main.py
+++ b/util/misc/gen-LAPACK/extern-tool/main.py
@@ -21,7 +21,7 @@ def main():
   Passes.lapacke_include = Passes.lapack_root + "/lapacke/include"
   Passes.blas_src = Passes.lapack_root + "/BLAS/SRC"
 
-  root = ET.Element( "root" );
+  root = ET.Element( "root" )
   DumpCodePass.apply( root )
 
 if __name__ == "__main__": main()

--- a/util/test/genGraphs.py
+++ b/util/test/genGraphs.py
@@ -916,7 +916,7 @@ class GraphClass:
                             self.datfilenames.append(myDatFile)
                             self.perfkeys.append(perf)
                             self.graphkeys.append(graph)
-                            break;
+                            break
                     # it's possible we still didn't fine the file, but if
                     # that's the case the test wasn't run for any configuration
                     # and we won't generate data for any series which won't
@@ -1002,7 +1002,7 @@ def main():
             conf = temp[0]
             multiConf.append(conf)
             if len(temp) > 1 and temp[1] == 'v':
-                defaultMultiConf.append(conf);
+                defaultMultiConf.append(conf)
         if len(defaultMultiConf) == 0:
             defaultMultiConf.append(multiConf[0])
     else:

--- a/util/test/start_test.py
+++ b/util/test/start_test.py
@@ -868,7 +868,7 @@ def set_up_general():
     if args.valgrind or args.valgrind_exe:
         # Stay below valgrind's --max-threads option, which defaults to 500
         if not "CHPL_RT_NUM_THREADS_PER_LOCALE" in os.environ:
-            os.environ["CHPL_RT_NUM_THREADS_PER_LOCALE"] = "450";
+            os.environ["CHPL_RT_NUM_THREADS_PER_LOCALE"] = "450"
         else:
             logger.write("[Warning: Deadlock is possible since you set CHPL_RT_NUM_THREADS_PER_LOCALE]")
 

--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -201,7 +201,7 @@ def SuckOutputWithTimeout(stream, timeout):
         now = time.time()
         if end_time <= now:
             # Maybe return partial result instead?
-            raise ReadTimeoutException('Teh tiem iz out!');
+            raise ReadTimeoutException('Teh tiem iz out!')
         ready_set = select.select([stream], [], [], end_time - now)[0]
         if stream in ready_set:
             bytes = stream.read()
@@ -464,7 +464,7 @@ def printTestVariation(compoptsnum, compoptslist,
         printExecOpts = False
 
     if (not printCompOpts) and (not printExecOpts):
-        return;
+        return
 
     sys.stdout.write(' (')
     if printCompOpts:
@@ -759,9 +759,9 @@ def get_chpl_base(compiler):
 def get_chpl_home(chpl_base):
     """Returns the normalized path to the Chapel installation."""
     # If $CHPL_HOME is not set, use the base installation of the compiler
-    chpl_home=os.getenv('CHPL_HOME', chpl_base);
+    chpl_home=os.getenv('CHPL_HOME', chpl_base)
     chpl_home=os.path.normpath(chpl_home)
-    # sys.stdout.write('CHPL_HOME='+chpl_home+'\n');
+    # sys.stdout.write('CHPL_HOME='+chpl_home+'\n')
     return chpl_home
 
 def get_test_dir(chpl_home):
@@ -773,7 +773,7 @@ def get_test_dir(chpl_home):
             Fatal('Cannot find test directory '+chpl_home+'/test or '+testdir)
     # Needed for MacOS mount points
     testdir = os.path.realpath(testdir)
-    # sys.stdout.write('testdir='+testdir+'\n');
+    # sys.stdout.write('testdir='+testdir+'\n')
 
     # If user specified a different test directory (e.g. with --test-root flag on
     # start_test), use it instead.
@@ -800,13 +800,13 @@ def get_local_dir(test_dir):
 def get_util_dir():
     """Find the test util directory -- set this in start_test to use
         a version of start_test other than the one in CHPL_HOME."""
-    utildir=os.getenv('CHPL_TEST_UTIL_DIR');
+    utildir=os.getenv('CHPL_TEST_UTIL_DIR')
     if utildir is None or not os.path.isdir(utildir):
         Fatal('Cannot find test util directory {0}'.format(utildir))
 
     # Needed for MacOS mount points
     utildir = os.path.realpath(utildir)
-    # sys.stdout.write('utildir='+utildir+'\n');
+    # sys.stdout.write('utildir='+utildir+'\n')
     return utildir
 
 def get_config_dir(util_dir):
@@ -873,7 +873,7 @@ def main():
         timedexec=utildir+'/test/timedexec'
         if not os.access(timedexec,os.R_OK|os.X_OK):
             Fatal('Cannot execute timedexec script \''+timedexec+'\'')
-    # sys.stdout.write('timedexec='+timedexec+'\n');
+    # sys.stdout.write('timedexec='+timedexec+'\n')
 
     # HW platform
     platform = run_process([utildir+'/chplenv/chpl_platform.py', '--target'], stdout=subprocess.PIPE)[1]
@@ -1032,12 +1032,12 @@ def main():
         compstdin='/dev/null'
     # sys.stdout.write('compstdin=%s\n'%(compstdin))
 
-    globalLastcompopts=list();
+    globalLastcompopts=list()
     if os.access('./LASTCOMPOPTS',os.R_OK):
         globalLastcompopts+=run_process(['cat', './LASTCOMPOPTS'], stdout=subprocess.PIPE)[1].strip().split()
     # sys.stdout.write('globalLastcompopts=%s\n'%(globalLastcompopts))
 
-    globalLastexecopts=list();
+    globalLastexecopts=list()
     if os.access('./LASTEXECOPTS',os.R_OK):
         globalLastexecopts+=run_process(['cat', './LASTEXECOPTS'], stdout=subprocess.PIPE)[1].strip().split()
     # sys.stdout.write('globalLastexecopts=%s\n'%(globalLastexecopts))
@@ -1272,10 +1272,10 @@ def main():
             execname += '.{0}'.format(os.getpid())
         # print test_filename
 
-        is_c_test = testname.endswith(".test.c");
-        is_ml_c_test = testname.endswith(".ml-test.c");
-        is_cpp_test = testname.endswith(".test.cpp");
-        is_ml_cpp_test = testname.endswith(".ml-test.cpp");
+        is_c_test = testname.endswith(".test.c")
+        is_ml_c_test = testname.endswith(".ml-test.c")
+        is_cpp_test = testname.endswith(".test.cpp")
+        is_ml_cpp_test = testname.endswith(".ml-test.cpp")
         is_c_or_cpp_test = (is_c_test or is_cpp_test)
         is_ml_c_or_cpp_test = (is_ml_c_test or is_ml_cpp_test)
         c_or_cpp = None
@@ -1720,7 +1720,7 @@ def main():
             # remember to add the cleaner solution soon.
             #
             comptimeout = 4*timeout
-            cmd=ShellEscapeCommand(cmd);
+            cmd=ShellEscapeCommand(cmd)
             sys.stdout.write('[Executing compiler %s'%(cmd))
             if args:
                 sys.stdout.write(' %s'%(' '.join(args)))
@@ -1736,7 +1736,7 @@ def main():
                 if status == 222:
                     sys.stdout.write('%s[Error: Timed out compilation for %s/%s'%
                                      (futuretest, localdir, test_filename))
-                    printTestVariation(compoptsnum, compoptslist);
+                    printTestVariation(compoptsnum, compoptslist)
                     sys.stdout.write(']\n')
                     sys.stdout.write('[Compilation output was as follows:]\n')
                     sys.stdout.write(trim_output(output))
@@ -1754,7 +1754,7 @@ def main():
                 except ReadTimeoutException:
                     sys.stdout.write('%s[Error: Timed out compilation for %s/%s'%
                                      (futuretest, localdir, test_filename))
-                    printTestVariation(compoptsnum, compoptslist);
+                    printTestVariation(compoptsnum, compoptslist)
                     sys.stdout.write(']\n')
                     KillProc(p, killtimeout)
                     cleanup(execname)
@@ -1781,11 +1781,11 @@ def main():
                   # remove lines like
                   # somefile.c:
                   # that some C compilers emit when compiling multiple files
-                  output = output.replace(arg + ":\n", "");
+                  output = output.replace(arg + ":\n", "")
 
             if (status!=0 or not executebin):
                 # Save original output
-                origoutput = output;
+                origoutput = output
                 dealWithBinary = False
 
                 # Compare compiler output with expected program output
@@ -1878,7 +1878,7 @@ def main():
                     sys.stdout.write('%s[Error '%(futuretest))
                 sys.stdout.write('matching compiler output for %s/%s'%
                                      (localdir, test_filename))
-                printTestVariation(compoptsnum, compoptslist);
+                printTestVariation(compoptsnum, compoptslist)
                 sys.stdout.write(']\n')
 
                 # If there was a prediff it may have hidden the compilation
@@ -1895,14 +1895,14 @@ def main():
                     if os.access(badfile, os.R_OK):
                         badresult = DiffBadFiles(badfile, complog)
                         if badresult==0:
-                            os.unlink(complog);
+                            os.unlink(complog)
                             sys.stdout.write('[Clean match against .bad file ')
                         else:
                             # bad file doesn't match, which is bad
                             sys.stdout.write('[Error matching .bad file ')
                         sys.stdout.write('for %s/%s'%(localdir, test_filename))
-                        printTestVariation(compoptsnum, compoptslist);
-                        sys.stdout.write(']\n');
+                        printTestVariation(compoptsnum, compoptslist)
+                        sys.stdout.write(']\n')
 
                 cleanup(execname)
                 cleanup(printpassesfile)
@@ -1994,7 +1994,7 @@ def main():
                         sys.stdout.write('[Success finding compiler performance keys for %s/%s]\n'% (localdir, test_filename))
                     else:
                         sys.stdout.write('[Error finding compiler performance keys for %s/%s.]\n'% (localdir, test_filename))
-                        printTestVariation(compoptsnum, compoptslist);
+                        printTestVariation(compoptsnum, compoptslist)
                         sys.stdout.write('computePerfStats output was:\n%s\n'%(compkeysOutput))
                         sys.stdout.flush()
                         sys.stdout.write('Deleting .dat files for %s/%s because of failure to find all keys\n'%(localdir, test_filename))
@@ -2038,7 +2038,7 @@ def main():
                 execopts = tlist[0].strip()
 
                 if numlocexecopts != None:
-                    execopts += numlocexecopts;
+                    execopts += numlocexecopts
                 if len(tlist) > 1:
                     # Ignore everything after the first token
                     explicitexecgoodfile = tlist[1].strip().split()[0]
@@ -2174,7 +2174,7 @@ def main():
                       # come from and checking for '<' would have to be factored out or duplicated
                       print('[Skipping test with stdin redirection ("<") in execopts since '
                             '-nostdinredirect is given {0}/{1}]'.format(localdir, test_filename))
-                      break;
+                      break
                   elif redirectin == "/dev/null":
                     if os.access(execOptRedirect, os.R_OK):
                       redirectin = execOptRedirect
@@ -2224,7 +2224,7 @@ def main():
                                 sys.stdout.write('%s[Error: %s %s/%s'%
                                                 (futuretest, launcher_error, localdir, test_filename))
                                 printTestVariation(compoptsnum, compoptslist,
-                                                   execoptsnum, execoptslist);
+                                                   execoptsnum, execoptslist)
                                 sys.stdout.write(']\n')
                                 sys.stdout.write('[Execution output was as follows:]\n')
                                 sys.stdout.write(trim_output(output))
@@ -2247,7 +2247,7 @@ def main():
                                 sys.stdout.write('%s[Error: Timed out executing program %s/%s'%
                                                 (futuretest, localdir, test_filename))
                                 printTestVariation(compoptsnum, compoptslist,
-                                                   execoptsnum, execoptslist);
+                                                   execoptsnum, execoptslist)
                                 sys.stdout.write(']\n')
                                 sys.stdout.write('[Execution output was as follows:]\n')
                                 sys.stdout.write(trim_output(output))
@@ -2278,7 +2278,7 @@ def main():
                                 sys.stdout.write('%s[Error: Timed out executing program %s/%s'%
                                                 (futuretest, localdir, test_filename))
                                 printTestVariation(compoptsnum, compoptslist,
-                                                   execoptsnum, execoptslist);
+                                                   execoptsnum, execoptslist)
                                 sys.stdout.write(']\n')
                                 KillProc(p, killtimeout)
 
@@ -2413,7 +2413,7 @@ def main():
                                             (localdir, test_filename))
                             if result!=0:
                                 printTestVariation(compoptsnum, compoptslist,
-                                                   execoptsnum, execoptslist);
+                                                   execoptsnum, execoptslist)
                             sys.stdout.write(']\n')
 
                             if (result != 0 and futuretest != ''):
@@ -2421,14 +2421,14 @@ def main():
                                 if os.access(badfile, os.R_OK):
                                     badresult = DiffFiles(badfile, execlog)
                                     if badresult==0:
-                                        os.unlink(execlog);
+                                        os.unlink(execlog)
                                         sys.stdout.write('[Clean match against .bad file ')
                                     else:
                                         # bad file doesn't match, which is bad
                                         sys.stdout.write('[Error matching .bad file ')
                                     sys.stdout.write('for %s/%s'%(localdir, test_filename))
-                                    printTestVariation(compoptsnum, compoptslist);
-                                    sys.stdout.write(']\n');
+                                    printTestVariation(compoptsnum, compoptslist)
+                                    sys.stdout.write(']\n')
 
 
                     if perftest:
@@ -2474,7 +2474,7 @@ def main():
                                                 (localdir, test_filename))
                                 if status!=0:
                                     printTestVariation(compoptsnum, compoptslist,
-                                                    execoptsnum, execoptslist);
+                                                    execoptsnum, execoptslist)
                                 sys.stdout.write(']\n')
                         # only notify for a failed execution if launching the test was successful
                         elif (not launcher_error):


### PR DESCRIPTION
This cleans up the syntax in our python files by removing the trailing semicolons that sometimes find their way in.

TESTING:

- [x] paratest `[Summary: #Successes = 17657 | #Failures = 0 | #Futures = 887]`
- [x] paratest w/gasnet `[Summary: #Successes = 17838 | #Failures = 0 | #Futures = 896]`

[reviewed by @ShreyasKhandekar - thanks!]