### PR TITLE
Resolve associative domain type expr module code in Dyno

### DIFF
--- a/compiler/passes/convert-typed-uast.cpp
+++ b/compiler/passes/convert-typed-uast.cpp
@@ -1098,9 +1098,7 @@ void TConverter::createMainFunctions() {
 
     // TODO: add converter or QualifiedType methods to more
     // easily construct a QualifiedType for common values like param false.
-    auto falseQt = types::QualifiedType(types::QualifiedType::PARAM,
-                                        types::BoolType::get(context),
-                                        types::BoolParam::get(context, false));
+    auto falseQt = types::QualifiedType::makeParamBool(context, false);
     auto ci = resolution::CallInfo(UniqueString::get(context, "_endCountAlloc"),
                                    /* calledType */ types::QualifiedType(),
                                    /* isMethodCall */ false,

--- a/frontend/include/chpl/types/DomainType.h
+++ b/frontend/include/chpl/types/DomainType.h
@@ -99,8 +99,9 @@ class DomainType final : public CompositeType {
 
   /** Return an associative domain type */
   static const DomainType* getAssociativeType(Context* context,
-                                              const QualifiedType& idxType,
-                                              const QualifiedType& parSafe);
+                                 const QualifiedType& instance,
+                                 const QualifiedType& idxType,
+                                 const QualifiedType& parSafe);
 
   const Type* substitute(Context* context,
                          const PlaceholderMap& subs) const override {

--- a/frontend/include/chpl/types/DomainType.h
+++ b/frontend/include/chpl/types/DomainType.h
@@ -99,9 +99,9 @@ class DomainType final : public CompositeType {
 
   /** Return an associative domain type */
   static const DomainType* getAssociativeType(Context* context,
-                                 const QualifiedType& instance,
-                                 const QualifiedType& idxType,
-                                 const QualifiedType& parSafe);
+                                              const QualifiedType& instance,
+                                              const QualifiedType& idxType,
+                                              const QualifiedType& parSafe);
 
   const Type* substitute(Context* context,
                          const PlaceholderMap& subs) const override {

--- a/frontend/include/chpl/types/QualifiedType.h
+++ b/frontend/include/chpl/types/QualifiedType.h
@@ -71,6 +71,12 @@ class QualifiedType final {
 
   static const char* kindToString(Kind k);
 
+  // Convenience functions to construct param types
+  static QualifiedType makeParamBool(Context* context, bool b);
+  static QualifiedType makeParamInt(Context* context, int64_t i);
+  static QualifiedType makeParamString(Context* context, UniqueString s);
+  static QualifiedType makeParamString(Context* context, std::string s);
+
  private:
   Kind kind_ = UNKNOWN;
   const Type* type_ = nullptr;

--- a/frontend/include/chpl/uast/prim-ops-list.h
+++ b/frontend/include/chpl/uast/prim-ops-list.h
@@ -139,8 +139,6 @@ PRIMITIVE_R(QUERY, "query")
 PRIMITIVE_R(QUERY_PARAM_FIELD, "query param field")
 PRIMITIVE_R(QUERY_TYPE_FIELD, "query type field")
 
-PRIMITIVE_R(STATIC_DOMAIN_TYPE, "static domain type")
-
 PRIMITIVE_R(STATIC_FUNCTION_VAR, "static function var")
 PRIMITIVE_R(STATIC_FUNCTION_VAR_VALIDATE_TYPE, "static function validate type")
 PRIMITIVE_R(STATIC_FUNCTION_VAR_WRAPPER, "static function var wrapper")

--- a/frontend/lib/resolution/InitResolver.cpp
+++ b/frontend/lib/resolution/InitResolver.cpp
@@ -295,9 +295,9 @@ static const DomainType* domainTypeFromSubsHelper(
       if (auto instanceBct = instanceCt->basicClassType()) {
         // Get BaseRectangularDom parent subs for rectangular domain info
         if (auto baseDom = instanceBct->parentClassType()) {
-          auto& rf = fieldsForTypeDecl(context, baseDom,
-                                       DefaultsPolicy::IGNORE_DEFAULTS);
           if (baseDom->id().symbolPath() == "ChapelDistribution.BaseRectangularDom") {
+            auto& rf = fieldsForTypeDecl(context, baseDom,
+                                         DefaultsPolicy::IGNORE_DEFAULTS);
             CHPL_ASSERT(rf.numFields() == 3);
             QualifiedType rank;
             QualifiedType idxType;
@@ -315,7 +315,24 @@ static const DomainType* domainTypeFromSubsHelper(
             return DomainType::getRectangularType(context, instanceQt, rank,
                                                   idxType, strides);
           } else if (baseDom->id().symbolPath() == "ChapelDistribution.BaseAssociativeDom") {
-            // TODO: support associative domains
+            // Currently the relevant associative domain fields are defined
+            // on all the children of BaseAssociativeDom, so get information
+            // from there.
+            auto& rf = fieldsForTypeDecl(context, instanceBct,
+                                         DefaultsPolicy::IGNORE_DEFAULTS);
+            CHPL_ASSERT(rf.numFields() >= 2);
+            QualifiedType idxType;
+            QualifiedType parSafe;
+            for (int i = 0; i < rf.numFields(); i++) {
+              if (rf.fieldName(i) == "idxType") {
+                idxType = rf.fieldType(i);
+              } else if (rf.fieldName(i) == "parSafe") {
+                parSafe = rf.fieldType(i);
+              }
+            }
+
+            return DomainType::getAssociativeType(context, instanceQt, idxType,
+                                                  parSafe);
           } else if (baseDom->id().symbolPath() == "ChapelDistribution.BaseSparseDom") {
             // TODO: support sparse domains
           } else {

--- a/frontend/lib/resolution/VarScopeVisitor.cpp
+++ b/frontend/lib/resolution/VarScopeVisitor.cpp
@@ -386,6 +386,20 @@ void VarScopeVisitor::exitAst(const uast::AstNode* ast) {
   inAstStack.pop_back();
 }
 
+bool VarScopeVisitor::enter(const TupleDecl* ast, RV& rv) {
+  enterAst(ast);
+  enterScope(ast, rv);
+
+  // TODO: handle tuple decls
+  return false;
+}
+void VarScopeVisitor::exit(const TupleDecl* ast, RV& rv) {
+  exitScope(ast, rv);
+  exitAst(ast);
+
+  return;
+}
+
 bool VarScopeVisitor::enter(const NamedDecl* ast, RV& rv) {
 
   if (ast->id().isSymbolDefiningScope()) {

--- a/frontend/lib/resolution/VarScopeVisitor.h
+++ b/frontend/lib/resolution/VarScopeVisitor.h
@@ -213,6 +213,9 @@ class VarScopeVisitor {
   bool enter(const NamedDecl* ast, RV& rv);
   void exit(const NamedDecl* ast, RV& rv);
 
+  bool enter(const TupleDecl* ast, RV& rv);
+  void exit(const TupleDecl* ast, RV& rv);
+
   bool enter(const OpCall* ast, RV& rv);
   void exit(const OpCall* ast, RV& rv);
 

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -788,8 +788,8 @@ void CallInitDeinit::handleDeclaration(const VarLikeDecl* ast, RV& rv) {
   VarFrame* frame = currentFrame();
 
   // check for use of deinited variables in type or init exprs
-  if (auto init = ast->initExpression()) {
-    processMentions(init, rv);
+  if (auto type = ast->typeExpression()) {
+    processMentions(type, rv);
   }
   if (auto init = ast->initExpression()) {
     processMentions(init, rv);

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -326,26 +326,6 @@ static QualifiedType primImplementsInterface(Context* context,
   return makeParamInt(context, witness ? 1 : 2);
 }
 
-static QualifiedType computeDomainType(Context* context, const CallInfo& ci) {
-  if (ci.numActuals() == 3) {
-    auto type = DomainType::getRectangularType(context,
-                                          QualifiedType(),
-                                          ci.actual(0).type(),
-                                          ci.actual(1).type(),
-                                          ci.actual(2).type());
-    return QualifiedType(QualifiedType::TYPE, type);
-  } else if (ci.numActuals() == 2) {
-    auto type = DomainType::getAssociativeType(context,
-                                               QualifiedType(),
-                                               ci.actual(0).type(),
-                                               ci.actual(1).type());
-    return QualifiedType(QualifiedType::TYPE, type);
-  } else {
-    CHPL_ASSERT(false && "unhandled domain type?");
-  }
-  return QualifiedType();
-}
-
 static QualifiedType primAddrOf(Context* context, const CallInfo& ci) {
   if (ci.numActuals() != 1) return QualifiedType();
 
@@ -1630,10 +1610,6 @@ CallResolutionResult resolvePrimCall(ResolutionContext* rc,
     case PRIM_GPU_REDUCE_WRAPPER:
       type = QualifiedType(QualifiedType::CONST_VAR,
                            VoidType::get(context));
-      break;
-
-    case PRIM_STATIC_DOMAIN_TYPE:
-      type = computeDomainType(context, ci);
       break;
 
     case PRIM_GET_COMPILER_VAR: {

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -336,6 +336,7 @@ static QualifiedType computeDomainType(Context* context, const CallInfo& ci) {
     return QualifiedType(QualifiedType::TYPE, type);
   } else if (ci.numActuals() == 2) {
     auto type = DomainType::getAssociativeType(context,
+                                               QualifiedType(),
                                                ci.actual(0).type(),
                                                ci.actual(1).type());
     return QualifiedType(QualifiedType::TYPE, type);

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -1804,9 +1804,7 @@ computeNumericValuesOfEnumElements(Context* context, ID node) {
   Resolver res = Resolver::createForEnumElements(context, enumNode, byPostorder);
 
   // The constant 'one' for adding
-  auto one = QualifiedType(QualifiedType::PARAM,
-                           IntType::get(context, 0),
-                           IntParam::get(context, 1));
+  auto one = QualifiedType::makeParamInt(context, 1);
 
   // A type to track what kind of signedness a value needs.
   enum RequiredSignedness {
@@ -1944,9 +1942,7 @@ computeNumericValuesOfEnumElements(Context* context, ID node) {
                                    UintType::get(context, 0),
                                    UintParam::get(context, (uint64_t) *signedValue));
       } else {
-        resultType = QualifiedType(QualifiedType::PARAM,
-                                   IntType::get(context, 0),
-                                   IntParam::get(context, *signedValue));
+        resultType = QualifiedType::makeParamInt(context, *signedValue);
       }
     }
 
@@ -3966,10 +3962,7 @@ static bool resolveFnCallSpecial(Context* context,
         if (srcQtEnumType && dstTy->isStringType()) {
           std::ostringstream oss;
           srcQt.param()->stringify(oss, chpl::StringifyKind::CHPL_SYNTAX);
-          auto ustr = UniqueString::get(context, oss.str());
-          exprTypeOut = QualifiedType(QualifiedType::PARAM,
-                                      RecordType::getStringType(context),
-                                      StringParam::get(context, ustr));
+          exprTypeOut = QualifiedType::makeParamString(context, oss.str());
           return true;
         }
 
@@ -3994,10 +3987,7 @@ static bool resolveFnCallSpecial(Context* context,
       // handle casting a type name to a string
       std::ostringstream oss;
       srcTy->stringify(oss, chpl::StringifyKind::CHPL_SYNTAX);
-      auto ustr = UniqueString::get(context, oss.str());
-      exprTypeOut = QualifiedType(QualifiedType::PARAM,
-                                  RecordType::getStringType(context),
-                                  StringParam::get(context, ustr));
+      exprTypeOut = QualifiedType::makeParamString(context, oss.str());
       return true;
     } else if (srcTy->isClassType() && dstTy->isClassType()) {
       // cast (borrowed class) : unmanaged
@@ -4043,8 +4033,7 @@ static bool resolveFnCallSpecial(Context* context,
       if (bothType || bothParam) {
         bool result = lhs == rhs;
         result = ci.name() == USTR("==") ? result : !result;
-        exprTypeOut = QualifiedType(QualifiedType::PARAM, BoolType::get(context),
-                                    BoolParam::get(context, result));
+        exprTypeOut = QualifiedType::makeParamBool(context, result);
         return true;
       }
     } else if (ci.numActuals() == 1 && ci.hasQuestionArg()) {
@@ -4063,9 +4052,7 @@ static bool resolveFnCallSpecial(Context* context,
       }
       result = ci.name() == USTR("==") ? result : !result;
       if (haveResult) {
-        exprTypeOut =
-            QualifiedType(QualifiedType::PARAM, BoolType::get(context),
-                          BoolParam::get(context, result));
+        exprTypeOut = QualifiedType::makeParamBool(context, result);
         return true;
       }
     }
@@ -4095,8 +4082,7 @@ static bool resolveFnCallSpecial(Context* context,
     }
     auto got = canPassScalar(context, ci.actual(0).type(), ci.actual(1).type());
     bool result = got.passes();
-    exprTypeOut = QualifiedType(QualifiedType::PARAM, BoolType::get(context),
-                                BoolParam::get(context, result));
+    exprTypeOut = QualifiedType::makeParamBool(context, result);
     return true;
   }
 
@@ -6101,9 +6087,7 @@ QualifiedType paramTypeFromValue(Context* context, T value);
 
 template <>
 QualifiedType paramTypeFromValue<bool>(Context* context, bool value) {
-  return QualifiedType(QualifiedType::PARAM,
-                       BoolType::get(context),
-                       BoolParam::get(context, value));
+  return QualifiedType::makeParamBool(context, value);
 }
 
 const std::unordered_map<UniqueString, QualifiedType>&

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2828,9 +2828,11 @@ helpResolveFunction(ResolutionContext* rc, const TypedFnSignature* sig,
   // same function twice when working with inferred 'out' formals)
   sig = sig->inferredFrom();
 
-  if (!sig->isInitializer() && sig->needsInstantiation()) {
-    CHPL_ASSERT(false && "Should only be called on concrete or fully "
-                         "instantiated functions");
+  if (!sig->isInitializer() && !sig->untyped()->isTypeConstructor() &&
+      sig->needsInstantiation()) {
+    CHPL_ASSERT(false &&
+                "Should only be called on concrete or fully "
+                "instantiated functions");
     return nullptr;
   }
 

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -4035,10 +4035,18 @@ static bool resolveFnCallSpecial(Context* context,
     if (ci.numActuals() == 2 || ci.hasQuestionArg()) {
       auto lhs = ci.actual(0).type();
 
-      // support comparisons with '?'
-      auto rhs = ci.hasQuestionArg() ?
-                   QualifiedType(QualifiedType::TYPE, AnyType::get(context)) :
-                   ci.actual(1).type();
+      QualifiedType rhs;
+      if (ci.hasQuestionArg()) {
+        // support type and param comparisions with '?'
+        if (lhs.isType()) {
+          rhs = QualifiedType(QualifiedType::TYPE, AnyType::get(context));
+        } else if (lhs.isParam()) {
+          rhs = QualifiedType(QualifiedType::PARAM, AnyType::get(context),
+                              nullptr);
+        }
+      } else {
+        rhs = ci.actual(1).type();
+      }
 
       bool bothType = lhs.kind() == QualifiedType::TYPE &&
                       rhs.kind() == QualifiedType::TYPE;

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -4050,15 +4050,23 @@ static bool resolveFnCallSpecial(Context* context,
     } else if (ci.numActuals() == 1 && ci.hasQuestionArg()) {
       // support type and param comparisons with '?'
       // TODO: will likely need adjustment once we are able to compare a
+      // partially-instantiated type's fields with '?'
       auto arg = ci.actual(0).type();
+      bool result = false;
+      bool haveResult = true;
       if (arg.isType()) {
-        exprTypeOut =
-            QualifiedType(QualifiedType::PARAM, BoolType::get(context),
-                          BoolParam::get(context, arg.type()->isAnyType()));
+        result = arg.type()->isAnyType();
       } else if (arg.isParam()) {
+        result = arg.param() == nullptr;
+      } else {
+        haveResult = false;
+      }
+      result = ci.name() == USTR("==") ? result : !result;
+      if (haveResult) {
         exprTypeOut =
             QualifiedType(QualifiedType::PARAM, BoolType::get(context),
-                          BoolParam::get(context, arg.param() == nullptr));
+                          BoolParam::get(context, result));
+        return true;
       }
     }
   }

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2824,6 +2824,9 @@ helpResolveFunction(ResolutionContext* rc, const TypedFnSignature* sig,
   // same function twice when working with inferred 'out' formals)
   sig = sig->inferredFrom();
 
+  // Signature should be concrete by now, except in the case of an initializer
+  // or type constructor in which case we may still have generic formals.
+  // For example, range(?) will reach this point.
   if (!sig->isInitializer() && !sig->untyped()->isTypeConstructor() &&
       sig->needsInstantiation()) {
     CHPL_ASSERT(false &&

--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -1205,8 +1205,7 @@ static bool helpComputeCompilerGeneratedReturnType(Context* context,
       auto ast = parsing::idToAst(context, enumType->id())->toEnum();
       CHPL_ASSERT(ast);
       int numElts = ast->numElements();
-      result = QualifiedType(QualifiedType::PARAM, IntType::get(context, 0),
-                             IntParam::get(context, numElts));
+      result = QualifiedType::makeParamInt(context, numElts);
       return true;
     }
     CHPL_ASSERT(false && "unhandled compiler-generated enum method");
@@ -1299,8 +1298,7 @@ static bool helpComputeReturnType(ResolutionContext* rc,
   } else if (untyped->isMethod() && sig->formalType(0).type()->isTupleType() &&
              untyped->name() == "size") {
     auto tup = sig->formalType(0).type()->toTupleType();
-    result = QualifiedType(QualifiedType::PARAM, IntType::get(context, 0),
-                           IntParam::get(context, tup->numElements()));
+    result = QualifiedType::makeParamInt(context, tup->numElements());
     return true;
 
     // if method call and the receiver points to a composite type definition,

--- a/frontend/lib/types/QualifiedType.cpp
+++ b/frontend/lib/types/QualifiedType.cpp
@@ -20,6 +20,7 @@
 #include "chpl/types/QualifiedType.h"
 
 #include "chpl/resolution/resolution-queries.h"
+#include "chpl/types/all-types.h"
 #include "chpl/types/Param.h"
 #include "chpl/types/Type.h"
 #include "chpl/types/TupleType.h"
@@ -50,6 +51,25 @@ bool QualifiedType::isParamKnownTuple() const {
     }
   }
   return false;
+}
+
+QualifiedType QualifiedType::makeParamBool(Context* context, bool b) {
+  return {QualifiedType::PARAM, BoolType::get(context),
+          BoolParam::get(context, b)};
+}
+
+QualifiedType QualifiedType::makeParamInt(Context* context, int64_t i) {
+  return {QualifiedType::PARAM, IntType::get(context, 0),
+          IntParam::get(context, i)};
+}
+
+QualifiedType QualifiedType::makeParamString(Context* context, UniqueString s) {
+  return {QualifiedType::PARAM, RecordType::getStringType(context),
+          StringParam::get(context, s)};
+}
+
+QualifiedType QualifiedType::makeParamString(Context* context, std::string s) {
+  return makeParamString(context, UniqueString::get(context, s));
 }
 
 bool QualifiedType::needsSplitInitTypeInfo(Context* context) const {

--- a/frontend/test/resolution/testDomains.cpp
+++ b/frontend/test/resolution/testDomains.cpp
@@ -110,7 +110,7 @@ module M {
 
   auto rankVarTy = findVarType(m, rr, "r");
   assert(rankVarTy == dType->rank());
-  assert(rankVarTy.param()->toIntParam()->value() == rank);
+  ensureParamInt(rankVarTy, rank);
 
   auto idxTypeVarTy = findVarType(m, rr, "i");
   assert(idxTypeVarTy == dType->idxType());
@@ -120,11 +120,11 @@ module M {
   assert(stridesVarTy == dType->strides());
   assert(stridesVarTy.param()->toEnumParam()->value().str == strides);
 
-  assert(findVarType(m, rr, "rk").param()->toBoolParam()->value() == true);
+  ensureParamBool(findVarType(m, rr, "rk"), true);
 
-  assert(findVarType(m, rr, "ak").param()->toBoolParam()->value() == false);
+  ensureParamBool(findVarType(m, rr, "ak"), false);
 
-  assert(findVarType(m, rr, "p").type() == IntType::get(context, 0));
+  assert(findVarType(m, rr, "p").type()->isIntType());
 
   assert(findVarType(m, rr, "z").type() == fullIndexType.type());
 
@@ -198,8 +198,8 @@ module M {
 
   assert(dType->kind() == domainKind);
   bool isRectangular = domainKind == DomainType::Kind::Rectangular;
-  assert(findVarType(m, rr, "rk").param()->toBoolParam()->value() == isRectangular);
-  assert(findVarType(m, rr, "ak").param()->toBoolParam()->value() == !isRectangular);
+  ensureParamBool(findVarType(m, rr, "rk"), isRectangular);
+  ensureParamBool(findVarType(m, rr, "ak"), !isRectangular);
 
   assert(guard.realizeErrors() == 0);
 }
@@ -260,13 +260,13 @@ module M {
   auto fullIndexType = findVarType(m, rr, "i");
   assert(findVarType(m, rr, "ig") == fullIndexType);
 
-  assert(findVarType(m, rr, "s").param()->toBoolParam()->value() == parSafe);
+  ensureParamBool(findVarType(m, rr, "s"), parSafe);
 
-  assert(findVarType(m, rr, "rk").param()->toBoolParam()->value() == false);
+  ensureParamBool(findVarType(m, rr, "rk"), false);
 
-  assert(findVarType(m, rr, "ak").param()->toBoolParam()->value() == true);
+  ensureParamBool(findVarType(m, rr, "ak"), true);
 
-  assert(findVarType(m, rr, "p").type() == IntType::get(context, 0));
+  assert(findVarType(m, rr, "p").type()->isIntType());
 
   assert(findVarType(m, rr, "z").type() == fullIndexType.type());
 
@@ -372,7 +372,7 @@ module M {
   assert(!findVarType(m, rr, "t").isUnknownOrErroneous());
   assert(!findVarType(m, rr, "i").isUnknownOrErroneous());
 
-  assert(findVarType(m, rr, "equal").isParamTrue());
+  ensureParamBool(findVarType(m, rr, "equal"), true);
 
   // assert(guard.realizeErrors() == 0);
 }

--- a/frontend/test/resolution/testDomains.cpp
+++ b/frontend/test/resolution/testDomains.cpp
@@ -41,6 +41,8 @@ static void testRectangular(Context* context,
                                   int rank,
                                   std::string idxType,
                                   std::string strides) {
+  printf("Testing: %s\n", domainType.c_str());
+
   context->advanceToNextRevision(false);
   setupModuleSearchPaths(context, false, false, {}, {});
   ErrorGuard guard(context);
@@ -153,13 +155,13 @@ module M {
   }
 
   assert(guard.realizeErrors() == 0);
-
-  printf("Success: %s\n", domainType.c_str());
 }
 
 static void testDomainLiteral(Context* context,
                                   std::string domainLiteral,
                                   DomainType::Kind domainKind) {
+  printf("Testing: %s\n", domainLiteral.c_str());
+
   context->advanceToNextRevision(false);
   setupModuleSearchPaths(context, false, false, {}, {});
   ErrorGuard guard(context);
@@ -200,14 +202,14 @@ module M {
   assert(findVarType(m, rr, "ak").param()->toBoolParam()->value() == !isRectangular);
 
   assert(guard.realizeErrors() == 0);
-
-  printf("Success: %s\n", domainLiteral.c_str());
 }
 
 static void testAssociative(Context* context,
                                   std::string domainType,
                                   std::string idxType,
                                   bool parSafe) {
+  printf("Testing: %s\n", domainType.c_str());
+
   context->advanceToNextRevision(false);
   setupModuleSearchPaths(context, false, false, {}, {});
   ErrorGuard guard(context);
@@ -295,13 +297,13 @@ module M {
   }
 
   assert(guard.errors().size() == 0);
-
-  printf("Success: %s\n", domainType.c_str());
 }
 
+// Ensure that we can't, e.g.,  pass a domain(1) to a domain(2)
 static void testBadPass(Context* context, std::string argType,
                         std::string actualType) {
-  // Ensure that we can't, e.g.,  pass a domain(1) to a domain(2)
+  printf("Testing: cannot pass %s to %s\n", actualType.c_str(), argType.c_str());
+
   context->advanceToNextRevision(false);
   setupModuleSearchPaths(context, false, false, {}, {});
   ErrorGuard guard(context);
@@ -333,8 +335,6 @@ module M {
   auto& e = guard.errors()[0];
   assert(e->type() == chpl::NoMatchingCandidates);
 
-  printf("Success: cannot pass %s to %s\n", actualType.c_str(), argType.c_str());
-
   // 'clear' rather than 'realize' to simplify test output
   guard.clearErrors();
 }
@@ -342,6 +342,9 @@ module M {
 static void testIndex(Context* context,
                       std::string domainType,
                       std::string expectedType) {
+  printf("Testing: index(%s) == %s\n", domainType.c_str(),
+         expectedType.c_str());
+
   context->advanceToNextRevision(false);
   setupModuleSearchPaths(context, false, false, {}, {});
   ErrorGuard guard(context);
@@ -372,9 +375,6 @@ module M {
   assert(findVarType(m, rr, "equal").isParamTrue());
 
   // assert(guard.realizeErrors() == 0);
-
-  printf("Success: index(%s) == %s\n", domainType.c_str(),
-         expectedType.c_str());
 }
 
 static void testBadDomainHelper(std::string domainType, Context* context,
@@ -410,6 +410,9 @@ module M {
 // Ensure we gracefully error for bad domain type expressions, with or without
 // the standard modules available.
 static void testBadDomain(Context* contextWithStd, std::string domainType) {
+  printf("Testing: cannot resolve %s\n",
+         domainType.c_str());
+
   // With standard modules
   {
     contextWithStd->advanceToNextRevision(false);
@@ -418,9 +421,6 @@ static void testBadDomain(Context* contextWithStd, std::string domainType) {
 
     testBadDomainHelper(domainType, contextWithStd, guard);
   }
-
-  printf("Success: cannot resolve %s\n",
-         domainType.c_str());
 }
 
 int main() {

--- a/frontend/test/resolution/testDomains.cpp
+++ b/frontend/test/resolution/testDomains.cpp
@@ -177,7 +177,7 @@ module M {
   param rk = d.isRectangular();
   param ak = d.isAssociative();
 
-  var p = d.pid();
+  var p = d.pid;
 
   for loopI in d {
     var z = loopI;

--- a/frontend/test/resolution/testDomains.cpp
+++ b/frontend/test/resolution/testDomains.cpp
@@ -374,7 +374,7 @@ module M {
 
   ensureParamBool(findVarType(m, rr, "equal"), true);
 
-  // assert(guard.realizeErrors() == 0);
+  assert(guard.realizeErrors() == 0);
 }
 
 static void testBadDomainHelper(std::string domainType, Context* context,

--- a/frontend/test/resolution/testDomains.cpp
+++ b/frontend/test/resolution/testDomains.cpp
@@ -158,101 +158,100 @@ module M {
   printf("Success: %s\n", domainType.c_str());
 }
 
-// static void testAssociative(Context* context,
-//                                   std::string domainType,
-//                                   std::string idxType,
-//                                   bool parSafe) {
-//   context->advanceToNextRevision(false);
-//   setupModuleSearchPaths(context, false, false, {}, {});
-//   ErrorGuard guard(context);
+static void testAssociative(Context* context,
+                                  std::string domainType,
+                                  std::string idxType,
+                                  bool parSafe) {
+  context->advanceToNextRevision(false);
+  setupModuleSearchPaths(context, false, false, {}, {});
+  ErrorGuard guard(context);
 
-//   std::string program =
-// R"""(
-// module M {
-//   var d : )""" + domainType + R"""(;
-//   type ig = )""" + idxType + R"""(;
+  std::string program =
+R"""(
+module M {
+  var d : )""" + domainType + R"""(;
+  type ig = )""" + idxType + R"""(;
 
-//   type i = d.idxType;
-//   param s = d.parSafe;
-//   param rk = d.isRectangular();
-//   param ak = d.isAssociative();
+  type i = d.idxType;
+  param s = d.parSafe;
+  param rk = d.isRectangular();
+  param ak = d.isAssociative();
 
-//   var p = d.pid();
+  var p = d.pid();
 
-//   for loopI in d {
-//     var z = loopI;
-//   }
+  for loopI in d {
+    var z = loopI;
+  }
 
-//   proc generic(arg: domain) {
-//     type GT = arg.type;
-//     return 42;
-//   }
+  proc generic(arg: domain) {
+    type GT = arg.type;
+    return 42;
+  }
 
-//   proc concrete(arg: )""" + domainType + R"""() {
-//     type CT = arg.type;
-//     return 42;
-//   }
+  proc concrete(arg: )""" + domainType + R"""() {
+    type CT = arg.type;
+    return 42;
+  }
 
-//   var g_ret = generic(d);
-//   var c_ret = concrete(d);
-// }
-// )""";
-//   // TODO: generic checks
+  var g_ret = generic(d);
+  var c_ret = concrete(d);
+}
+)""";
 
-//   auto path = UniqueString::get(context, "input.chpl");
-//   setFileText(context, path, std::move(program));
+  auto path = UniqueString::get(context, "input.chpl");
+  setFileText(context, path, std::move(program));
 
-//   const ModuleVec& vec = parseToplevel(context, path);
-//   const Module* m = vec[1]; 
+  const ModuleVec& vec = parseToplevel(context, path);
+  const Module* m = vec[1]; 
 
-//   const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
+  const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
 
-//   QualifiedType dType = findVarType(m, rr, "d");
-//   assert(dType.type()->isDomainType());
+  QualifiedType dType = findVarType(m, rr, "d");
+  assert(dType.type()->isDomainType());
 
-//   auto fullIndexType = findVarType(m, rr, "i");
-//   assert(findVarType(m, rr, "ig") == fullIndexType);
+  auto fullIndexType = findVarType(m, rr, "i");
+  assert(findVarType(m, rr, "ig") == fullIndexType);
 
-//   assert(findVarType(m, rr, "s").param()->toBoolParam()->value() == parSafe);
+  assert(findVarType(m, rr, "s").param()->toBoolParam()->value() == parSafe);
 
-//   assert(findVarType(m, rr, "rk").param()->toBoolParam()->value() == false);
+  assert(findVarType(m, rr, "rk").param()->toBoolParam()->value() == false);
 
-//   assert(findVarType(m, rr, "ak").param()->toBoolParam()->value() == true);
+  assert(findVarType(m, rr, "ak").param()->toBoolParam()->value() == true);
 
-//   assert(findVarType(m, rr, "p").type() == IntType::get(context, 0));
+  assert(findVarType(m, rr, "p").type() == IntType::get(context, 0));
 
-//   assert(findVarType(m, rr, "z").type() == fullIndexType.type());
+  assert(findVarType(m, rr, "z").type() == fullIndexType.type());
 
-//   {
-//     const Variable* g_ret = findOnlyNamed(m, "g_ret")->toVariable();
-//     auto res = rr.byAst(g_ret);
-//     assert(res.type().type()->isIntType());
+  {
+    const Variable* g_ret = findOnlyNamed(m, "g_ret")->toVariable();
+    auto res = rr.byAst(g_ret);
+    assert(res.type().type()->isIntType());
 
-//     auto call = resolveOnlyCandidate(context, rr.byAst(g_ret->initExpression()));
-//     // Generic function, should have been instantiated
-//     assert(call->signature()->instantiatedFrom() != nullptr);
+    auto call = resolveOnlyCandidate(context, rr.byAst(g_ret->initExpression()));
+    // Generic function, should have been instantiated
+    assert(call->signature()->instantiatedFrom() != nullptr);
 
-//     const Variable* GT = findOnlyNamed(m, "GT")->toVariable();
-//     assert(call->byAst(GT).type().type() == dType.type());
-//   }
+    const Variable* GT = findOnlyNamed(m, "GT")->toVariable();
+    assert(call->byAst(GT).type().type() == dType.type());
+  }
 
-//   {
-//     const Variable* c_ret = findOnlyNamed(m, "c_ret")->toVariable();
-//     auto res = rr.byAst(c_ret);
-//     assert(res.type().type()->isIntType());
+  {
+    const Variable* c_ret = findOnlyNamed(m, "c_ret")->toVariable();
+    auto res = rr.byAst(c_ret);
+    assert(res.type().type()->isIntType());
 
-//     auto call = resolveOnlyCandidate(context, rr.byAst(c_ret->initExpression()));
-//     // Concrete function, should not be instantiated
-//     assert(call->signature()->instantiatedFrom() == nullptr);
+    auto call = resolveOnlyCandidate(context, rr.byAst(c_ret->initExpression()));
+    // Concrete function, should not be instantiated
+    assert(call->signature()->instantiatedFrom() == nullptr);
 
-//     const Variable* CT = findOnlyNamed(m, "CT")->toVariable();
-//     assert(call->byAst(CT).type().type() == dType.type());
-//   }
+    const Variable* CT = findOnlyNamed(m, "CT")->toVariable();
+    assert(call->byAst(CT).type().type() == dType.type());
+  }
 
-//   assert(guard.errors().size() == 0);
+  assert(guard.errors().size() == 0);
 
-//   printf("Success: %s\n", domainType.c_str());
-// }
+  printf("Success: %s\n", domainType.c_str());
+}
 
 static void testBadPass(Context* context, std::string argType,
                         std::string actualType) {
@@ -390,26 +389,23 @@ int main() {
   testRectangular(context, "domain(3, int(16), strideKind.negOne)", 3, "int(16)", "negOne");
   testRectangular(context, "domain(strides=strideKind.negative, idxType=int, rank=1)", 1, "int", "negative");
 
-  // TODO: re-enable associative
-  // testAssociative(context, "domain(int)", "int", true);
-  // testAssociative(context, "domain(int, false)", "int", false);
-  // testAssociative(context, "domain(string)", "string", true);
+  testAssociative(context, "domain(int)", "int", true);
+  testAssociative(context, "domain(int, false)", "int", false);
+  testAssociative(context, "domain(string)", "string", true);
 
   testBadPass(context, "domain(1)", "domain(2)");
   testBadPass(context, "domain(1, int(16))", "domain(1, int(8))");
   testBadPass(context, "domain(1, int(8))", "domain(1, int(16))");
   testBadPass(context, "domain(1, strides=strideKind.negOne)", "domain(1, strides=strideKind.one)");
-  // TODO: re-enable associative badPass
-  // testBadPass(context, "domain(int)", "domain(string)");
-  // testBadPass(context, "domain(1)", "domain(int)");
+  testBadPass(context, "domain(int)", "domain(string)");
+  testBadPass(context, "domain(1)", "domain(int)");
 
   testIndex(context, "domain(1)", "int");
   testIndex(context, "domain(2)", "2*int");
   testIndex(context, "domain(1, bool)", "bool");
   testIndex(context, "domain(2, bool)", "2*bool");
-  // TODO: re-enable associative indexes
-  // testIndex(context, "domain(int)", "int");
-  // testIndex(context, "domain(string)", "string");
+  testIndex(context, "domain(int)", "int");
+  testIndex(context, "domain(string)", "string");
 
   testBadDomain(context, "domain()");
   testBadDomain(context, "domain(1, 2, 3, 4)");

--- a/frontend/test/resolution/testDomains.cpp
+++ b/frontend/test/resolution/testDomains.cpp
@@ -389,13 +389,11 @@ int main() {
   testRectangular(context, "domain(2, int(8))", 2, "int(8)", "one");
   testRectangular(context, "domain(3, int(16), strideKind.negOne)", 3, "int(16)", "negOne");
   testRectangular(context, "domain(strides=strideKind.negative, idxType=int, rank=1)", 1, "int", "negative");
-  context->collectGarbage();
 
   // TODO: re-enable associative
   // testAssociative(context, "domain(int)", "int", true);
   // testAssociative(context, "domain(int, false)", "int", false);
   // testAssociative(context, "domain(string)", "string", true);
-  // context->collectGarbage();
 
   testBadPass(context, "domain(1)", "domain(2)");
   testBadPass(context, "domain(1, int(16))", "domain(1, int(8))");
@@ -404,7 +402,6 @@ int main() {
   // TODO: re-enable associative badPass
   // testBadPass(context, "domain(int)", "domain(string)");
   // testBadPass(context, "domain(1)", "domain(int)");
-  context->collectGarbage();
 
   testIndex(context, "domain(1)", "int");
   testIndex(context, "domain(2)", "2*int");
@@ -413,7 +410,6 @@ int main() {
   // TODO: re-enable associative indexes
   // testIndex(context, "domain(int)", "int");
   // testIndex(context, "domain(string)", "string");
-  context->collectGarbage();
 
   testBadDomain(context, "domain()");
   testBadDomain(context, "domain(1, 2, 3, 4)");

--- a/frontend/test/resolution/testDomains.cpp
+++ b/frontend/test/resolution/testDomains.cpp
@@ -105,7 +105,6 @@ module M {
   assert(aa.action() == AssociatedAction::RUNTIME_TYPE);
 
   QualifiedType fullIndexType = findVarType(m, rr, "fullIndex");
-  (void)fullIndexType;
 
   auto rankVarTy = findVarType(m, rr, "r");
   assert(rankVarTy == dType->rank());

--- a/frontend/test/resolution/testDomains.cpp
+++ b/frontend/test/resolution/testDomains.cpp
@@ -202,7 +202,7 @@ module M {
   setFileText(context, path, std::move(program));
 
   const ModuleVec& vec = parseToplevel(context, path);
-  const Module* m = vec[1]; 
+  const Module* m = vec[0];
 
   const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
 


### PR DESCRIPTION
Get associative domain type expressions resolving using their module code in Dyno, and re-enable testing for them.

This PR itself contains little work and mostly just drove Dyno work needed to support the module code.

Contributes to https://github.com/Cray/chapel-private/issues/6729.

Also includes:
- adding a dyno test for _rectangular_ domain literals
- allowing `helpResolveFunction` to run on generic type constructors, per bug fix suggestion from Ben
- adjusting the handling of `param == ?` comparisons which was introduced in https://github.com/chapel-lang/chapel/pull/26219, so that it gets specially handled rather than trying to resolve a defined `==` operator
- skipping recursing into `TupleDecl`s in `VarScopeVisitor` to delay [implementing call-init-deinit support for them](https://github.com/Cray/chapel-private/issues/7021) for now
- an out-of-scope fix in `CallInitDeinit::handleDeclarations` where we clearly meant to reference type expr, but used init expr
- moving `makeParam[Int,String,Bool]` helpers in `prims.cpp` onto `QualifiedType` and use everywhere

Future work:
- resolve associative domain literals (https://github.com/chapel-lang/chapel/pull/26534)
- implement call-init-deinit for tuple splitting declarations/assignments (https://github.com/Cray/chapel-private/issues/7021)

[reviewer info placeholder]

Testing:
- [x] dyno tests
- [x] paratest