### PR TITLE
fix assertions for non-(`chpl_t` or `chpl_p`) field type resolution on shared/owned

### DIFF
--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2571,18 +2571,13 @@ QualifiedType Resolver::typeForId(const ID& id, bool localGenericToUnknown) {
     // that we are working with a nested method
     if (auto rt = methodReceiverType().type()) {
       // get the new class type if the receiver is a class
-      auto nct = rt->toClassType();
-      // get the manager record using ClassType method managerRecordType()
-      if (auto mr = checkIfReceiverIsManagerRecord(context, nct, parentId)) {
-        ct = mr;
-        auto fieldName = parsing::fieldIdToName(context, id);
-        // TODO: shared has additional fields that are not generic
-        if (fieldName == "chpl_t" || fieldName == "chpl_p") {
-          auto intent = fieldName == "chpl_t" ? QualifiedType::TYPE : QualifiedType::VAR;
-          auto borrowed = nct->withDecorator(context, nct->decorator().toBorrowed());
-          return QualifiedType(intent, borrowed);
+      if (auto ct = rt->toClassType()) {
+        if (auto mr = ct->managerRecordType(context)) {
+          rt = mr;
         }
-      } else if (auto comprt = rt->getCompositeType()) {
+      }
+
+      if (auto comprt = rt->getCompositeType()) {
         if (comprt->id() == parentId) {
           ct = comprt; // handle record, class with field
         } else if (auto bct = comprt->toBasicClassType()) {

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2577,10 +2577,11 @@ QualifiedType Resolver::typeForId(const ID& id, bool localGenericToUnknown) {
         ct = mr;
         auto fieldName = parsing::fieldIdToName(context, id);
         // TODO: shared has additional fields that are not generic
-        CHPL_ASSERT(fieldName == "chpl_t" || fieldName == "chpl_p");
-        auto intent = fieldName == "chpl_t" ? QualifiedType::TYPE : QualifiedType::VAR;
-        auto borrowed = nct->withDecorator(context, nct->decorator().toBorrowed());
-        return QualifiedType(intent, borrowed);
+        if (fieldName == "chpl_t" || fieldName == "chpl_p") {
+          auto intent = fieldName == "chpl_t" ? QualifiedType::TYPE : QualifiedType::VAR;
+          auto borrowed = nct->withDecorator(context, nct->decorator().toBorrowed());
+          return QualifiedType(intent, borrowed);
+        }
       } else if (auto comprt = rt->getCompositeType()) {
         if (comprt->id() == parentId) {
           ct = comprt; // handle record, class with field


### PR DESCRIPTION
We run into these as part of resolving `IO.chpl` with types. After this PR, resolving `IO.chpl` still crashes, but with different errors.

Reviewed by @arezaii -- thanks!

## Testing
- [x] dyno tests still pass