### PR TITLE
chore: bump pyyaml to 6.0.2 to support py3.13 build

### DIFF
--- a/third-party/chpl-venv/test-requirements.txt
+++ b/third-party/chpl-venv/test-requirements.txt
@@ -1,4 +1,4 @@
-PyYAML==6.0.1
+PyYAML==6.0.2
 filelock==3.12.2
 argcomplete==3.1.2
 setuptools==68.0.0


### PR DESCRIPTION
pyyaml 6.0.2 release, https://github.com/yaml/pyyaml/releases/tag/6.0.2

relates to https://github.com/Homebrew/homebrew-core/pull/193881