### PR TITLE
Resolve performance regression with complex math functions

### DIFF
--- a/runtime/include/chplmath.h
+++ b/runtime/include/chplmath.h
@@ -45,33 +45,33 @@ MAYBE_GPU static inline int chpl_macro_float_signbit(float x) { return signbit(x
 #ifdef __cplusplus
 // workaround for C++ lacking C99 complex support
 #define chpl_complex_wrapper(basename)                                     \
-  MAYBE_GPU static inline double                                           \
+  MAYBE_GPU static ___always_inline double                                           \
     chpl_##basename(_complex128 x) { return __builtin_##basename(x); }     \
-  MAYBE_GPU static inline float                                            \
+  MAYBE_GPU static ___always_inline float                                            \
     chpl_##basename##f(_complex64 x) { return __builtin_##basename##f(x); }
 chpl_COMPLEX_RETURN_REAL(chpl_complex_wrapper)
 #undef chpl_complex_wrapper
 
 #define chpl_complex_wrapper(basename)                                     \
-  MAYBE_GPU static inline _complex128                                      \
+  MAYBE_GPU static ___always_inline _complex128                                      \
     chpl_##basename(_complex128 x) { return __builtin_##basename(x); }     \
-  MAYBE_GPU static inline _complex64                                       \
+  MAYBE_GPU static ___always_inline _complex64                                       \
     chpl_##basename##f(_complex64 x) { return __builtin_##basename##f(x); }
 chpl_COMPLEX_RETURN_COMPLEX(chpl_complex_wrapper)
 #undef chpl_complex_wrapper
 #else
 #define chpl_complex_wrapper(basename)                         \
-  MAYBE_GPU static inline double                               \
+  MAYBE_GPU static ___always_inline double                               \
     chpl_##basename(_complex128 x) { return basename(x); }     \
-  MAYBE_GPU static inline float                                \
+  MAYBE_GPU static ___always_inline float                                \
     chpl_##basename##f(_complex64 x) { return basename##f(x); }
 chpl_COMPLEX_RETURN_REAL(chpl_complex_wrapper)
 #undef chpl_complex_wrapper
 
 #define chpl_complex_wrapper(basename)                         \
-  MAYBE_GPU static inline _complex128                          \
+  MAYBE_GPU static ___always_inline _complex128                          \
     chpl_##basename(_complex128 x) { return basename(x); }     \
-  MAYBE_GPU static inline _complex64                           \
+  MAYBE_GPU static ___always_inline _complex64                           \
     chpl_##basename##f(_complex64 x) { return basename##f(x); }
 chpl_COMPLEX_RETURN_COMPLEX(chpl_complex_wrapper)
 #undef chpl_complex_wrapper


### PR DESCRIPTION
Fixes a performance issue introduced by https://github.com/chapel-lang/chapel/pull/26048. This PR added `chpl_` wrappers in the runtime for complex math functions in `Math` and `AutoMath`. These functions are marked `static inline`, but that is only a hint to the backend and if they are not i lined there may be a performance penalty (`test/studies/shootout/mandelbrot/jacobnelson/mandelbrot-complex.chpl` saw a 30% slowdown).

This is fixed by replacing `inline` with `___always_inline` (defined in `runtime/include/sys_basic.h`), to force inlining and prevent the regression.

Testing:
- [x] validated that performance recovers with `___always_inline`

[Reviewed by @e-kayrakli]