### PR TITLE
Update remaining python dependencies for various tools

### DIFF
--- a/third-party/chpl-venv/c2chapel-requirements.txt
+++ b/third-party/chpl-venv/c2chapel-requirements.txt
@@ -1,3 +1,3 @@
 # tools/c2chapel/Makefile should match so fakeHeaders download matches
-pycparser==2.20
+pycparser==2.22
 pycparserext

--- a/third-party/chpl-venv/chapel-py-requirements.txt
+++ b/third-party/chpl-venv/chapel-py-requirements.txt
@@ -1,6 +1,6 @@
-attrs==23.1.0
-cattrs==23.1.2
+attrs==24.2.0
+cattrs==24.1.2
 lsprotocol==2023.0.1
-pygls==1.3.0
-typeguard==3.0.2
+pygls==1.3.1
+typeguard==4.3.0
 ConfigArgParse==1.7

--- a/third-party/chpl-venv/chpldoc-requirements1.txt
+++ b/third-party/chpl-venv/chpldoc-requirements1.txt
@@ -1,2 +1,2 @@
 # Split into 3 files to work around problems with CHPL_PIP_FROM_SOURCE
-MarkupSafe==2.1.5
+MarkupSafe==3.0.1

--- a/third-party/chpl-venv/chpldoc-requirements2.txt
+++ b/third-party/chpl-venv/chpldoc-requirements2.txt
@@ -1,7 +1,7 @@
 # Split into 3 files to work around problems with CHPL_PIP_FROM_SOURCE
-Jinja2==3.1.3
-Pygments==2.17.2
+Jinja2==3.1.4
+Pygments==2.18.0
 Sphinx==7.2.6
-urllib3==2.2.1
+urllib3==2.2.3
 docutils==0.20.1
-babel==2.14.0
+babel==2.16.0

--- a/third-party/chpl-venv/cls-test-requirements.txt
+++ b/third-party/chpl-venv/cls-test-requirements.txt
@@ -1,2 +1,2 @@
 pytest==8.3.3
-pytest-lsp==0.4.1
+pytest-lsp==0.4.3

--- a/third-party/chpl-venv/cls-test-requirements.txt
+++ b/third-party/chpl-venv/cls-test-requirements.txt
@@ -1,2 +1,2 @@
-pytest==8.2.0
+pytest==8.3.3
 pytest-lsp==0.4.1

--- a/third-party/chpl-venv/test-requirements.txt
+++ b/third-party/chpl-venv/test-requirements.txt
@@ -1,4 +1,4 @@
 PyYAML==6.0.2
-filelock==3.12.2
-argcomplete==3.1.2
-setuptools==68.0.0
+filelock==3.16.1
+argcomplete==3.5.1
+setuptools==75.1.0

--- a/tools/c2chapel/Makefile
+++ b/tools/c2chapel/Makefile
@@ -35,7 +35,7 @@ link=$(bdir)/c2chapel
 
 # Note, this version is used only for the fake headers,
 # but it should probably match third-party/chpl-venv/c2chapel-requirements.txt
-VERSION=2.20
+VERSION=2.22
 TAR=release_v$(VERSION).tar.gz
 
 RELEASE=https://github.com/eliben/pycparser/archive/$(TAR)


### PR DESCRIPTION
I had started this last week but an outside contributor got to the PyYAML change before I opened my PR :)

This does not tackle updating Sphinx, docutils, sphinx-rtd-theme or sphinxcontrib-chapeldomain, as the best update for those would require bumping the oldest version of Python we support to Python 3.10 (and might require updates to our testing system as a result).  So I'm waiting on the green light for that from the BTR team.

Updates:
- pytest (used by the language server) from 8.2.0 to 8.3.3
- pytest-lsp (used by the language server) from 0.4.1. to 0.4.3
- attrs (used by the python bindings) from 23.1.0 to 24.2.0
- cattrs (used by the python bindings) from 23.1.2 to 24.1.2
- pygls (used by the python bindings) from 1.3.0 to 1.3.1
- typeguard (used by the python bindings) from 3.0.2 to 4.3.0
- pycparser (used by c2chapel) from 2.20 to 2.22
- filelock (used by start_test) from 3.12.2 to 3.16.1
- argcomplete (used by start_test) from 3.1.2 to 3.5.1
- setuptools (used by start_test) from 68.0.0 to 75.1.0
- Jinja2 (used by chpldoc) from 3.1.3 to 3.1.4
- Pygments (used by chpldoc) from 2.17.2 to 2.18.0
- urllib3 (used by chpldoc) from 2.2.1 to 2.2.3
- babel (used by chpldoc) from 2.14.0 to 2.16.0

Also did not update two tools that had not had a new version update and didn't look into whether breathe could be updated

Ran:
- full paratest with futures
  - and verified that the number of tests and futures run did not change
- `make test-chpl-language-server`
- test/c2chapel after having explicitly built c2chapel