### PR TITLE
Consider common class ancestors for dyno return type inference

### DIFF
--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -1294,7 +1294,7 @@ static optional<QualifiedType> findByAncestor(
     // don't consider the root of the class hierarchy for a common type
     if (!pct || pct->isObjectType()) return chpl::empty;
 
-    // decorator and intent should be irrelevant
+    // TODO: fix decorator and intent
     auto parentCt = ClassType::get(
         context, pct, nullptr,
         ClassTypeDecorator(

--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -1285,7 +1285,7 @@ types::QualifiedType::Kind KindProperties::makeConst(types::QualifiedType::Kind 
 static optional<QualifiedType> findByAncestor(
     Context* context, const std::vector<QualifiedType>& types,
     const KindRequirement& requiredKind) {
-  // Disallow subtype conversion for ref intent.
+  // disallow subtype conversions for ref intents
   if (requiredKind && isRefQualifier(*requiredKind)) return chpl::empty;
 
   std::vector<QualifiedType> parentTypes;
@@ -1298,16 +1298,14 @@ static optional<QualifiedType> findByAncestor(
     // don't consider the root of the class hierarchy for a common type
     if (!pct || pct->isObjectType()) return chpl::empty;
 
-    auto parentCt =
-        ClassType::get(context, pct, ct->manager(), ct->decorator());
-    parentTypes.emplace_back(QualifiedType(type.kind(), parentCt));
+    parentTypes.emplace_back(QualifiedType(
+        type.kind(),
+        ClassType::get(context, pct, ct->manager(), ct->decorator())));
   }
 
-  if (parentTypes.empty()) {
-    return chpl::empty;
-  } else {
-    return commonType(context, parentTypes, requiredKind);
-  }
+  if (parentTypes.empty()) return chpl::empty;
+
+  return commonType(context, parentTypes, requiredKind);
 }
 
 static optional<QualifiedType>
@@ -1375,15 +1373,11 @@ commonType(Context* context,
   // Try apply usual coercion rules to find common type
   // Performance: if the types vector ever becomes very long,
   // it might be worth using a unique'd vector here.
-  auto commonType = findByPassing(context, adjustedTypes);
-  if (commonType) {
+  if (auto commonType = findByPassing(context, adjustedTypes))
     return commonType;
-  }
 
-  commonType = findByAncestor(context, adjustedTypes, requiredKind);
-  if (commonType) {
+  if (auto commonType = findByAncestor(context, adjustedTypes, requiredKind))
     return commonType;
-  }
 
   bool paramRequired = requiredKind &&
                        *requiredKind == QualifiedType::PARAM;
@@ -1398,10 +1392,8 @@ commonType(Context* context,
       adjustedType = QualifiedType(bestKind, adjustedType.type());
     }
 
-    commonType = findByPassing(context, adjustedTypes);
-    if (commonType) {
+    if (auto commonType = findByPassing(context, adjustedTypes))
       return commonType;
-    }
   }
   return chpl::empty;
 }

--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -1290,15 +1290,16 @@ static optional<QualifiedType> findByParents(
     if (!classTy) return chpl::empty;
     auto bct = classTy->basicClassType();
     if (!bct) return chpl::empty;
+    auto pct = bct->parentClassType();
+    // don't consider the root of the class hierarchy for a common type
+    if (!pct || pct->isObjectType()) return chpl::empty;
 
-    if (auto pct = bct->parentClassType()) {
-      auto parentCt = ClassType::get(
-          context, pct, nullptr,
-          ClassTypeDecorator(
-              ClassTypeDecorator::ClassTypeDecoratorEnum::UNMANAGED_NILABLE));
-      parentTypes.emplace_back(
-          QualifiedType(QualifiedType::DEFAULT_INTENT, parentCt));
-    }
+    auto parentCt = ClassType::get(
+        context, pct, nullptr,
+        ClassTypeDecorator(
+            ClassTypeDecorator::ClassTypeDecoratorEnum::UNMANAGED_NILABLE));
+    parentTypes.emplace_back(
+        QualifiedType(QualifiedType::DEFAULT_INTENT, parentCt));
   }
 
   if (parentTypes.empty()) {

--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -1281,8 +1281,8 @@ types::QualifiedType::Kind KindProperties::makeConst(types::QualifiedType::Kind 
   return props.toKind();
 }
 
-// Try finding a common type between parents of class types
-static optional<QualifiedType> findByParents(
+// Try finding a common ancestor type between class types
+static optional<QualifiedType> findByAncestor(
     Context* context, const std::vector<QualifiedType>& types) {
   std::vector<QualifiedType> parentTypes;
   for (const auto& type : types) {
@@ -1379,7 +1379,7 @@ commonType(Context* context,
     return commonType;
   }
 
-  commonType = findByParents(context, adjustedTypes);
+  commonType = findByAncestor(context, adjustedTypes);
   if (commonType) {
     return commonType;
   }

--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -1294,6 +1294,7 @@ static optional<QualifiedType> findByAncestor(
     // don't consider the root of the class hierarchy for a common type
     if (!pct || pct->isObjectType()) return chpl::empty;
 
+    // decorator and intent should be irrelevant
     auto parentCt = ClassType::get(
         context, pct, nullptr,
         ClassTypeDecorator(

--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -1285,6 +1285,9 @@ types::QualifiedType::Kind KindProperties::makeConst(types::QualifiedType::Kind 
 static optional<QualifiedType> findByAncestor(
     Context* context, const std::vector<QualifiedType>& types,
     const KindRequirement& requiredKind) {
+  // Disallow subtype conversion for ref intent.
+  if (requiredKind && isRefQualifier(*requiredKind)) return chpl::empty;
+
   std::vector<QualifiedType> parentTypes;
   for (const auto& type : types) {
     auto ct = type.type()->toClassType();

--- a/frontend/test/resolution/testReturnTypes.cpp
+++ b/frontend/test/resolution/testReturnTypes.cpp
@@ -1141,6 +1141,36 @@ static void testCPtrEltType() {
     assert(qt.type()->toUintType()->bitwidth() == 8);
   }
 }
+
+static void testChildClasses() {
+  Context ctx;
+  Context* context = &ctx;
+
+  std::string program = R"""(
+  class Parent {}
+
+  class A : Parent {}
+  class B : Parent {}
+
+  proc test(cond : bool = false) : Parent {
+    if cond then return new A();
+    else return new B();
+  }
+
+  var x = test();
+  )""";
+
+  auto qt = resolveTypeOfXInit(context, program);
+
+  auto ct = qt.type()->toClassType();
+  assert(ct);
+  auto mt = ct->manageableType();
+  assert(mt);
+  auto bct = mt->toBasicClassType();
+  assert(bct);
+  assert(bct->name() == "Parent");
+}
+
 // TODO: test param coercion (param int(32) = 1 and param int(64) = 2)
 // looks like canPass doesn't handle this very well.
 
@@ -1192,5 +1222,8 @@ int main() {
   testSelectParams();
 
   testCPtrEltType();
+
+  testChildClasses();
+
   return 0;
 }

--- a/frontend/test/resolution/testReturnTypes.cpp
+++ b/frontend/test/resolution/testReturnTypes.cpp
@@ -1163,6 +1163,7 @@ static void testChildClasses() {
     auto qt = resolveTypeOfXInit(context, program);
     auto ct = qt.type()->toClassType();
     assert(ct);
+    assert(ct->manager() && ct->manager()->isAnyOwnedType());
     auto mt = ct->manageableType();
     assert(mt);
     auto bct = mt->toBasicClassType();
@@ -1246,6 +1247,7 @@ static void testChildClasses() {
     auto qt = resolveTypeOfXInit(context, program);
     auto ct = qt.type()->toClassType();
     assert(ct);
+    assert(ct->manager() && ct->manager()->isAnyOwnedType());
     auto mt = ct->manageableType();
     assert(mt);
     auto bct = mt->toBasicClassType();
@@ -1280,6 +1282,7 @@ static void testChildClasses() {
     auto qt = resolveTypeOfXInit(context, program);
     auto ct = qt.type()->toClassType();
     assert(ct);
+    assert(ct->manager() && ct->manager()->isAnyOwnedType());
     auto mt = ct->manageableType();
     assert(mt);
     auto bct = mt->toBasicClassType();
@@ -1287,6 +1290,29 @@ static void testChildClasses() {
     assert(bct->name() == "Parent");
 
     assert(guard.realizeErrors() == 0);
+  }
+
+  // Shared ancestor, but ref intent
+  {
+    Context ctx;
+    Context* context = &ctx;
+    ErrorGuard guard(context);
+
+    std::string program = ops + R"""(
+    class Parent {}
+    class A : Parent {}
+    class B : Parent {}
+    proc test(cond : bool = false) ref {
+      if cond then return new A();
+      else return new B();
+    }
+    var x = test();
+    )""";
+
+    auto qt = resolveTypeOfXInit(context, program);
+    assert(qt.isErroneousType());
+
+    assert(guard.realizeErrors() == 1);
   }
 }
 


### PR DESCRIPTION
Enable Dyno to infer return type based on a shared ancestor between potentially-returned class types.

Adds testing for several such cases, including generic parents.

Resolves https://github.com/Cray/chapel-private/issues/6773.

[reviewer info placeholder]

Testing:
- [x] reproducer from backing issue OP
- [x] dyno tests
- [x] paratest