### PR TITLE
Prevent errors for unused variable warning in qthreads

### DIFF
--- a/util/chplenv/chpl_qthreads.py
+++ b/util/chplenv/chpl_qthreads.py
@@ -16,7 +16,10 @@ def get_uniq_cfg_path():
 @memoize
 def get_compile_args():
     ucp_val = get_uniq_cfg_path()
-    return third_party_utils.get_bundled_compile_args('qthread', ucp=ucp_val)
+    bundled, system = third_party_utils.get_bundled_compile_args('qthread', ucp=ucp_val)
+    # qthread headers may have unused variables
+    bundled.append('-Wno-error=unused-variable')
+    return (bundled, system)
 
 
 # returns 2-tuple of lists


### PR DESCRIPTION
Prevent errors for an unused variable warning in qthreads. This is only an issue when `ASSERTS=0` and `WARNINGS=1`, as there is a temporary in qthreads that is only used for an assert.

[Reviewed by @]