### PR TITLE
Run full GASNet performance suite w/ co-locales and PSHM

### DIFF
--- a/util/cron/test-perf.hpe-apollo-hdr.gasnet-ibv.fast.colo.bash
+++ b/util/cron/test-perf.hpe-apollo-hdr.gasnet-ibv.fast.colo.bash
@@ -24,7 +24,4 @@ export CHPL_GASNET_MORE_CFG_OPTIONS=--enable-pshm
 nightly_args="${nightly_args} -no-buildcheck"
 perf_args="-performance-description gn-ibv-fast-colo -numtrials 1 -sync-dir-suffix colocales"
 
-# Remove this for production
-export CHPL_NIGHTLY_TEST_DIRS=release/examples/benchmarks
-
 $CWD/nightly -cron ${perf_args} ${perf_hpe_apollo_args} ${nightly_args}


### PR DESCRIPTION
Now that the basic test infrastructure works, run the full GASNet performance suite w/ co-locales and PSHM enabled.