### PR TITLE
Add missing VisibilityClause methods to chapel-py

### DIFF
--- a/tools/chapel-py/src/method-tables/uast-methods.h
+++ b/tools/chapel-py/src/method-tables/uast-methods.h
@@ -343,6 +343,10 @@ CLASS_END(Use)
 CLASS_BEGIN(VisibilityClause)
   PLAIN_GETTER(VisibilityClause, symbol, "Get the symbol referenced by this VisibilityClause node",
                const chpl::uast::AstNode*, return node->symbol())
+  PLAIN_GETTER(VisibilityClause, limitation_kind, "Get the limitation kind of this VisibilityClause node",
+               const char*, return VisibilityClause::limitationKindToString(node->limitationKind()))
+  PLAIN_GETTER(VisibilityClause, limitations, "Get the limitations of this VisibilityClause node",
+               IterAdapterBase*, return mkIterPair(node->limitations()))
 CLASS_END(VisibilityClause)
 
 CLASS_BEGIN(WithClause)


### PR DESCRIPTION
Adds missing VisibilityClause methods to chapel-py, specifically `limitation_kind` and `limitations`.

[Reviewed by @DanilaFe]