### PR TITLE
Expand ability to infer CHPL_CUDA_PATH

### DIFF
--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -52,11 +52,10 @@ def _validate_rocm_llvm_version(gpu: gpu_type):
 @memoize
 def gpu_compiler_basic_compile(compiler: str, lang: str):
     dummy_main = "int main() { return 0; }"
-    exists, returncode, stdout, _ = try_run_command([compiler, "-v", "-c", "-x", lang, "-", "-o", "/dev/null"], cmd_input=dummy_main, combine_output=True)
-    if exists and returncode == 0 and stdout:
-        return stdout
-    else:
-        return None
+    _, _, stdout, _ = try_run_command([compiler, "-v", "-c", "-x", lang, "-", "-o", "/dev/null"], cmd_input=dummy_main, combine_output=True)
+    # NOTE: this code does not check if the code compiled properly,
+    # all we care about is the output
+    return stdout
 
 def _find_cuda_sdk_path(compiler: str):
     out = gpu_compiler_basic_compile(compiler, "cu")


### PR DESCRIPTION
This expands the ability of `printchplenv` to auto-identify the CHPL_CUDA_PATH.

After https://github.com/chapel-lang/chapel/pull/26072, this was inferred from an invocation of `nvcc`. However, on some systems `nvcc` may not work out of the box with the default options, but we can still compile for GPUs. So this PR removes the error checks to ensure that `nvcc` returns an exit code of 0, since all we care about is grepping for paths in the output.

[Reviewed by @]