### PR TITLE
Make GPU library tests respect CXXFLAGS

### DIFF
--- a/test/gpu/native/interop/gpuLibrary/Makefile
+++ b/test/gpu/native/interop/gpuLibrary/Makefile
@@ -1,10 +1,10 @@
 include lib/Makefile.udf2
 test_udf2_make_cpu: test_udf2.cpp lib/libudf2.a
-	@$(CHPL_COMPILER) -x c++ -lstdc++ $(CHPL_CFLAGS) -o test_udf2_make $< $(CHPL_LDFLAGS)
+	@$(CHPL_COMPILER) -x c++ -lstdc++ $(CXXFLAGS) $(CHPL_CFLAGS) -o test_udf2_make $< $(CHPL_LDFLAGS)
 
 test_udf2_make_nvidia: test_udf2.cpp lib/libudf2.a
-	@$(CHPL_COMPILER) -x cuda -lstdc++ $(CHPL_CFLAGS) -o test_udf2_make $< $(CHPL_LDFLAGS)
+	@$(CHPL_COMPILER) -x cuda -lstdc++ $(CXXFLAGS) $(CHPL_CFLAGS) -o test_udf2_make $< $(CHPL_LDFLAGS)
 
 test_udf2_make_amd: test_udf2.cpp lib/libudf2.a
-	@$(CHPL_COMPILER) -x hip -lstdc++ $(CHPL_CFLAGS) -o test_udf2_make $< $(CHPL_LDFLAGS)
+	@$(CHPL_COMPILER) -x hip -lstdc++ $(CXXFLAGS) $(CHPL_CFLAGS) -o test_udf2_make $< $(CHPL_LDFLAGS)
 

--- a/test/gpu/native/interop/gpuLibrary/udf2.prediff
+++ b/test/gpu/native/interop/gpuLibrary/udf2.prediff
@@ -14,7 +14,7 @@ if [[ "$chpl_gpu" == "nvidia" ]]; then
 elif [[ "$chpl_gpu" == "amd" ]]; then
   gpu_flags="-x hip"
 fi
-$cxx $gpu_flags test_udf2.cpp -Ilib -Llib/ -ludf2 $libs -o test_udf2_compileline
+$cxx $CXXFLAGS $gpu_flags test_udf2.cpp -Ilib -Llib/ -ludf2 $libs -o test_udf2_compileline
 echo "Running test_udf2_compileline" >> $OUTFILE
 ./test_udf2_compileline >> $OUTFILE
 


### PR DESCRIPTION
Adjusts a test locking in GPU library behavior to respect CXXFLAGS.

This was preventing this test from running properly on some systems where extra flags set in CXXFLAGS are required for GPU compilation.

Note that this PR has no changes to the cmake version of this test, as cmake was automatically respecting CXXFLAGS (as it should)

[Reviewed by @e-kayrakli]