### PR TITLE
Configure qthreads with a 128-bit cache line on Apple Macs

### DIFF
--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -146,6 +146,13 @@ SCHEDULER = $(CHPL_QTHREAD_SCHEDULER)
 endif
 CHPL_QTHREAD_CFG_OPTIONS += --with-scheduler=$(SCHEDULER)
 
+# only do this on M1+ Macs
+ifeq ($(CHPL_MAKE_TARGET_ARCH),arm64)
+ifeq ($(CHPL_MAKE_TARGET_PLATFORM),darwin)
+  CHPL_QTHREAD_CFG_OPTIONS += --with-cacheline-width=128
+endif
+endif
+
 # reduce performance penalty in cases where numChapelTasks < numQthreadWorkers
 CHPL_QTHREAD_CFG_OPTIONS += --enable-condwait-queue
 


### PR DESCRIPTION
Configure qthreads with a 128-bit cache line on Apple Macs, since that gives a slight performance increases

This was suggested by @insertinterestingnamehere offline and after testing on my M1 mac, I found slight performance improvements in some micro benchmarks

### Mac M1 results (n=5)
| Benchmark                  | Without explicit cacheline | With explicit cacheline | percent improvement |
| -------------------------- | -------------------------- | ----------------------- | ------------------- |
| empty-coforall             | 1.988                      | 1.812                   |  9.294%             |
| empty-forBegin             | 1.950                      | 1.885                   |  3.357%             |
| empty-forall               | 1.888                      | 1.788                   |  5.434%             |
| empty-serialCoforall       | 0.089                      | 0.089                   |  0.120%             |
| empty-serialForBegin       | 0.150                      | 0.147                   |  1.654%             |
| empty-serialForall         | 0.029                      | 0.029                   |  0.024%             |
| taskyield Elapsed time 1:  | 0.248                      | 0.196                   | 23.661%             |
| taskyield Elapsed time 4:  | 1.124                      | 1.086                   |  3.451%             |
| taskyield Elapsed time 16: | 2.919                      | 2.710                   |  7.432%             |


[Reviewed by @jhh67 and @insertinterestingnamehere]