### PR TITLE
Remove an outdated suggestion from the `./configure` documentation

### DIFF
--- a/doc/rst/usingchapel/building.rst
+++ b/doc/rst/usingchapel/building.rst
@@ -128,7 +128,7 @@ installed during the ``make install`` step. Specifically:
   This technique is designed to install Chapel using a standard
   directory structure for the purposes of integrating it into a
   standard location that is already in your path, such as
-  ``/usr/local/`` or ``~/``.  Note that elevated privileges are likely
+  ``/usr/local/``.  Note that elevated privileges are likely
   to be required for any system-wide installation locations.
 
   Please note that for any prefix-installed version of Chapel, the meaning of


### PR DESCRIPTION
Resolves #26107

The documentation was worded in such a way that it suggested `./configure --prefix=~/` was valid, but we removed support for specifying paths that aren't absolute last year, to more closely match the behavior of `autoconf`.  Remove the suggestion to use `~/` so that future readers don't encounter that error message (or at least don't encounter it on our suggestion).

Double checked the built documentation