### PR TITLE
Fixed physical GPU ID to logical conversions

### DIFF
--- a/runtime/src/gpu/amd/gpu-amd.c
+++ b/runtime/src/gpu/amd/gpu-amd.c
@@ -46,8 +46,8 @@ extern const char* chpl_gpuBinary;
 
 static int numAllDevices = -1;
 static int numDevices = -1;
-static int *deviceIDToIndex = NULL;
-static hipDevice_t *indexToDeviceID = NULL;
+static int *dev_pid_to_lid_table = NULL;
+static hipDevice_t *dev_lid_to_pid_table = NULL;
 
 // array indexed by device ID (we load the same module once for each GPU).
 static hipModule_t *chpl_gpu_rocm_modules;
@@ -64,12 +64,35 @@ void* chpl_gpu_load_module(const char* fatbin_data) {
   return (void*)rocm_module;
 }
 
-static void switch_context(int dev_id) {
-  ROCM_CALL(hipSetDevice(indexToDeviceID[dev_id]));
+// Maps the "physical" device ID used by the HIP library to the "logical"
+// device ID used by this locale. The two may differ due to co-locales.
+// Logical device IDs start with zero in each co-locale and are equal to the
+// sublocale ID. Physical device IDs are the same for all co-locales on the
+// machine.
+
+static int dev_pid_to_lid(int32_t dev_pid) {
+  assert((dev_pid >= 0) && (dev_pid < numAllDevices));
+  int dev_lid = dev_pid_to_lid_table[dev_pid];
+  assert((dev_lid >= 0) && (dev_lid < numDevices));
+  return dev_lid;
 }
 
-void chpl_gpu_impl_use_device(c_sublocid_t dev_id) {
-  switch_context(dev_id);
+// Maps a logical device ID to physical device ID.
+
+static int dev_lid_to_pid(int dev_lid) {
+  assert((dev_lid >= 0) && (dev_lid < numDevices));
+  int dev_pid = dev_lid_to_pid_table[dev_lid];
+  assert((dev_pid >= 0) && (dev_pid < numAllDevices));
+  return dev_pid;
+}
+
+static void switch_context(int dev_lid) {
+  int dev_pid = dev_lid_to_pid(dev_lid);
+  ROCM_CALL(hipSetDevice(dev_pid));
+}
+
+void chpl_gpu_impl_use_device(c_sublocid_t dev_lid) {
+  switch_context(dev_lid);
 }
 
 static hipModule_t get_module(void) {
@@ -77,16 +100,14 @@ static hipModule_t get_module(void) {
   hipModule_t module;
 
   ROCM_CALL(hipGetDevice(&device));
-  assert((((int) device) >= 0) && (((int) device) < numAllDevices));
-  int index = deviceIDToIndex[(int)device];
-  assert((index >= 0) && (index < numDevices));
-  module = chpl_gpu_rocm_modules[index];
+  int dev_lid = dev_pid_to_lid((int32_t) device);
+  module = chpl_gpu_rocm_modules[dev_lid];
   return module;
 }
 
 extern c_nodeid_t chpl_nodeID;
 
-static void chpl_gpu_impl_set_globals(c_sublocid_t dev_id, hipModule_t module) {
+static void chpl_gpu_impl_set_globals(c_sublocid_t dev_lid, hipModule_t module) {
   hipDeviceptr_t ptr = NULL;;
   size_t glob_size;
 
@@ -193,22 +214,23 @@ void chpl_gpu_impl_init(int* num_devices) {
   }
 
   // Allocate the GPU data structures. Note that the HIP API, specifically
-  // hipGetDevice, returns the global device ID so we need deviceIDToIndex
-  // to map from the global device ID to an array index.
+  // hipGetDevice, returns the global device ID so we need
+  // dev_pid_to_lid_table to map from the global device ID to the logical
+  // device ID.
 
   numDevices = numAddrs;
   chpl_gpu_rocm_modules = chpl_malloc(sizeof(hipModule_t)*numDevices);
   deviceClockRates = chpl_malloc(sizeof(int)*numDevices);
-  indexToDeviceID = chpl_malloc(sizeof(int) * numDevices);
-  deviceIDToIndex = chpl_malloc(sizeof(int) * numAllDevices);
+  dev_lid_to_pid_table = chpl_malloc(sizeof(int) * numDevices);
+  dev_pid_to_lid_table = chpl_malloc(sizeof(int) * numAllDevices);
 
   for (int i = 0; i < numDevices; i++) {
     chpl_gpu_rocm_modules[i] = NULL;
-    indexToDeviceID[i] = -1;
+    dev_lid_to_pid_table[i] = -1;
   }
 
   for (int i = 0; i < numAllDevices; i++) {
-    deviceIDToIndex[i] = -1;
+    dev_pid_to_lid_table[i] = -1;
   }
 
   // Go through the PCI bus addresses returned by chpl_topo_selectMyDevices
@@ -237,8 +259,8 @@ void chpl_gpu_impl_init(int* num_devices) {
                               hipDeviceAttributeClockRate, device);
 
         // map array indices (relative device numbers) to global device IDs
-        indexToDeviceID[i] = device;
-        deviceIDToIndex[device] = i;
+        dev_lid_to_pid_table[i] = device;
+        dev_pid_to_lid_table[device] = i;
         chpl_gpu_impl_set_globals(i, module);
         break;
       }
@@ -396,7 +418,8 @@ void chpl_gpu_impl_mem_free(void* memAlloc) {
     // see note in chpl_gpu_mem_free
     hipPointerAttribute_t res;
     ROCM_CALL(hipPointerGetAttributes(&res, memAlloc));
-    switch_context(res.device);
+    int dev_lid = dev_pid_to_lid(res.device);
+    switch_context(dev_lid);
 
     assert(chpl_gpu_is_device_ptr(memAlloc));
 #ifdef CHPL_GPU_MEM_STRATEGY_ARRAY_ON_DEVICE
@@ -436,22 +459,22 @@ unsigned int chpl_gpu_device_clock_rate(int32_t devNum) {
   return (unsigned int)deviceClockRates[devNum];
 }
 
-bool chpl_gpu_impl_can_access_peer(int dev1, int dev2) {
+bool chpl_gpu_impl_can_access_peer(int dev_lid1, int dev_lid2) {
   int p2p;
-  int id1 = indexToDeviceID[dev1];
-  int id2 = indexToDeviceID[dev2];
-  ROCM_CALL(hipDeviceCanAccessPeer(&p2p, id1, id2));
+  int dev_pid1 = dev_lid_to_pid(dev_lid1);
+  int dev_pid2 = dev_lid_to_pid(dev_lid2);
+  ROCM_CALL(hipDeviceCanAccessPeer(&p2p, dev_pid1, dev_pid2));
   return p2p != 0;
 }
 
-void chpl_gpu_impl_set_peer_access(int dev1, int dev2, bool enable) {
-  int id1 = indexToDeviceID[dev1];
-  int id2 = indexToDeviceID[dev2];
-  ROCM_CALL(hipSetDevice(id1));
+void chpl_gpu_impl_set_peer_access(int dev_lid1, int dev_lid2, bool enable) {
+  int dev_pid1 = dev_lid_to_pid(dev_lid1);
+  int dev_pid2 = dev_lid_to_pid(dev_lid2);
+  ROCM_CALL(hipSetDevice(dev_pid1));
   if(enable) {
-    ROCM_CALL(hipDeviceEnablePeerAccess(id2, 0));
+    ROCM_CALL(hipDeviceEnablePeerAccess(dev_pid2, 0));
   } else {
-    ROCM_CALL(hipDeviceDisablePeerAccess(id2));
+    ROCM_CALL(hipDeviceDisablePeerAccess(dev_pid2));
   }
 }
 


### PR DESCRIPTION
The CUDA and HIP libraries refer to GPUs by unique IDs that are consecutive integers starting at zero. When GPUs are shared by co-locales the IDs of the GPUs used by a particular locale may not start with zero and they may not be consecutive, so they cannot be used as the sublocale ID or to index into arrays. Previous modifications to support co-locales introduced "physical" (global) IDs vs "logical" (relative) IDs, but it wasn't a very clean implementation and recent changes to memory management broke it. This PR cleans up the implementation, makes it more obvious what is going on, and adds various sanity checks.

Tested against `test/gpu/native/multiLocale` both without co-locales and with `CHPL_RT_LOCALES_ON_NODE=2` for both `CHPL_GPU=amd` and `CHPL_GPU=nvidia`. 

Resolves https://github.com/Cray/chapel-private/issues/6817.
Resolves https://github.com/chapel-lang/chapel/issues/26104.