### PR TITLE
Add linter rule for unused type queries

### DIFF
--- a/test/chplcheck/UnusedTypeQuery.chpl
+++ b/test/chplcheck/UnusedTypeQuery.chpl
@@ -1,0 +1,10 @@
+module UnusedTypeQuery {
+
+  proc foo(ref a: ?t) {
+    a = 1;
+  }
+  proc bar(ref arr: [?d] ?elt) where elt == int{
+    arr[1] = 1;
+  }
+
+}

--- a/test/chplcheck/UnusedTypeQuery.good
+++ b/test/chplcheck/UnusedTypeQuery.good
@@ -1,0 +1,2 @@
+UnusedTypeQuery.chpl:3: node violates rule UnusedTypeQuery
+UnusedTypeQuery.chpl:6: node violates rule UnusedTypeQuery

--- a/test/chplcheck/activerules.good
+++ b/test/chplcheck/activerules.good
@@ -18,3 +18,4 @@ Active rules:
   UnusedLoopIndex              Warn for unused index variables in loops.
   UnusedTaskIntent             Warn for unused task intents in functions.
   UnusedTupleUnpack            Warn for unused tuple unpacking, such as '(_, _)'.
+  UnusedTypeQueries            Warn for unused type queries in functions.

--- a/test/chplcheck/allrules.good
+++ b/test/chplcheck/allrules.good
@@ -21,4 +21,5 @@ Available rules (default rules marked with *):
   * UnusedLoopIndex              Warn for unused index variables in loops.
   * UnusedTaskIntent             Warn for unused task intents in functions.
   * UnusedTupleUnpack            Warn for unused tuple unpacking, such as '(_, _)'.
+  * UnusedTypeQueries            Warn for unused type queries in functions.
     UseExplicitModules           Warn for code that relies on auto-inserted implicit modules.

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -698,6 +698,29 @@ def register_rules(driver: LintDriver):
         return [fixit] if fixit else []
 
     @driver.advanced_rule
+    def UnusedTypeQueries(context: Context, root: AstNode):
+        """
+        Warn for unused type queries in functions.
+        """
+        if isinstance(root, Comment):
+            return
+
+        typequeries = dict()
+        uses = set()
+
+        for tq, _ in chapel.each_matching(root, TypeQuery):
+
+            typequeries[tq.unique_id()] = tq
+
+        for use, _ in chapel.each_matching(root, Identifier):
+            refersto = use.to_node()
+            if refersto:
+                uses.add(refersto.unique_id())
+
+        for unused in typequeries.keys() - uses:
+            yield AdvancedRuleResult(typequeries[unused])
+
+    @driver.advanced_rule
     def UnusedLoopIndex(context: Context, root: AstNode):
         """
         Warn for unused index variables in loops.


### PR DESCRIPTION
Adds a chplcheck rule that warns if a user has a type query (e.g. `aType` in `proc foo(a: ?aType)`), but doesn't use it. This is almost identical in terms of motivation and implementation to `UnusedFormal`