### PR TITLE
Updates and fixes to task parallel primer

### DIFF
--- a/test/release/examples/primers/taskParallel.chpl
+++ b/test/release/examples/primers/taskParallel.chpl
@@ -102,7 +102,7 @@ coforall i in 1..n {
 
 // As with the ``cobegin`` statement, the original task will wait
 // until the ``coforall``'s child tasks have completed before
-// proceeding.  As a result, in this example, all output from within
+// proceeding.  For this example, this means that all output from within
 // the ``coforall`` loop will precede the following output:
 
 writeln("4: output from main task");

--- a/test/release/examples/primers/taskParallel.prediff
+++ b/test/release/examples/primers/taskParallel.prediff
@@ -71,7 +71,8 @@ for line in lines:
             continue
         if isSeparator(line):
             continue
-        (left, num, iterstr, iter) = rest.rsplit(' ', 3)
+        (junk, left, num, iter) = rest.split(' ', 3)
+        print(left, num, iter, sep=":::")
         seenIters.append(iter)
         if seenIters.count(iter) != int(num):
             errs += 1


### PR DESCRIPTION
This updates the task parallel primer to use the term 'task' instead of thread.  While spot-checking the sections affected by this, I also made some localized changes to improve the clarity and precision of the descriptions.  I also added some more material at the front to define what a 'task' is (roughly) and to move a `config const` down closer to where it's used.

I also noticed that the messages printed by the main/first coforall example in this primer were very weird, implying that each statement within the body was printed by a distinct task.  This may have been a copy-paste error from the second coforall loop example, which uses 'begin's, but still surprises me that it'd been around for so long.

Note that I did not do a complete read-through of the primer in the interest of time, but given the above, think it may be beneficial to do so.
