### PR TITLE
Fix deviceattributes test for runs that use CHPL_COMM

### DIFF
--- a/test/gpu/native/deviceAttributes.prediff
+++ b/test/gpu/native/deviceAttributes.prediff
@@ -1,8 +1,3 @@
 #!/bin/sh
 
-NL=""
-if [[ "$CHPL_COMM" != "none" && -n "$CHPL_COMM" ]]; then
-  NL="-nl 1"
-fi
-
-./deviceAttributes $NL --runBaseline=true > deviceAttributes.good
+./deviceAttributes -nl 1 --runBaseline=true > deviceAttributes.good


### PR DESCRIPTION
This PR fixes a broken test.

The GPU device attributes test has a prediff file that dynamically generates a `.good` file by calling out to a Chapel program (which in turn calls out to CUDA or HIP code that generates a bunch of expected "device attributes" that we'll check against).

Anyway, when we're using `CHPL_COMM != none` we need the prediff script to pass this program `-nl 1` to avoid getting this error:

`error: Specify number of locales via -nl <#> or --numLocales=<#>`

This PR updates the prediff script to do that.