### PR TITLE
LSP: resolve 'go-to-definition' for calls, including in generic instantiations

### DIFF
--- a/frontend/lib/parsing/ParserContextImpl.h
+++ b/frontend/lib/parsing/ParserContextImpl.h
@@ -1489,8 +1489,8 @@ CommentsAndStmt ParserContext::buildFunctionDecl(YYLTYPE location,
   bool primaryMethod = false;
   if (currentScopeIsAggregate()) {
     if (fp.receiver == nullptr) {
-      fp.receiver = buildThisFormal(location, fp.thisIntentLoc, fp.thisIntent,
-                                    nullptr, nullptr);
+      fp.receiver = buildThisFormal(fp.thisIntentLoc, fp.thisIntentLoc,
+                                    fp.thisIntent, nullptr, nullptr);
       primaryMethod = true;
     }
   }

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -1090,6 +1090,7 @@ class FileInfo:
         start, end = self.instantiation_segments._get_segment_range(rng)
 
         segments_for_elt = {}
+
         def process_instantiation_segment(value_at_segment, elt_idx):
             if elt_idx in segments_for_elt:
                 return segments_for_elt[elt_idx]
@@ -1114,7 +1115,6 @@ class FileInfo:
             segments_for_elt[elt_idx] = calls_in_inst
             return calls_in_inst
 
-
         for i in range(start, end):
             # Find the segment and where it starts
             begin_pos, value_at_segment, elt_idx = (
@@ -1129,7 +1129,6 @@ class FileInfo:
                 next_pos, _, _ = self.instantiation_segments.segments[i + 1]
                 end_pos = min(end_pos, next_pos)
 
-
             # Figure out the calls in this instantiation. The same instantiation
             # can appear in multiple segments, since it could be interrupted
             # by a nested instantiation.
@@ -1137,8 +1136,7 @@ class FileInfo:
                 value_at_segment, elt_idx
             )
             self.call_segments.overwrite_range(
-                Range(begin_pos, end_pos),
-                calls_in_inst
+                Range(begin_pos, end_pos), calls_in_inst
             )
 
     def rebuild_index(self):

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -494,15 +494,14 @@ class PositionList(Generic[EltT]):
     def find(self, pos: Position) -> Optional[EltT]:
         idx = bisect_left(self.segments, pos, key=lambda x: x[0])
 
-        # In some cases, we may be on the boundary between two segments.
-        # Then, return the leftmost non-None segment.
         if idx >= 1 and self.segments[idx - 1][1] is not None:
             return self.segments[idx - 1][1]
-        elif (
-            idx < len(self.segments)
-            and self.segments[idx][1] is not None
-            and self.segments[idx][0] == pos
-        ):
+
+
+        # In some cases, we may be on the boundary between two segments.
+        # In this case, the next segment's start position is the same as
+        # the current position, and we should return the next segment.
+        if idx < len(self.segments) and self.segments[idx][0] == pos:
             return self.segments[idx][1]
 
         return None

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -386,7 +386,9 @@ class PositionList(Generic[EltT]):
     position in logarithmic time.
     """
 
-    def _elements_to_segments(self, elts: List[EltT], into: List[Tuple[Position, Optional[EltT], int]]):
+    def _elements_to_segments(
+        self, elts: List[EltT], into: List[Tuple[Position, Optional[EltT], int]]
+    ):
         # A list of not-yet-closed segments, sorted descending by their end positions
         # (so that we can pop the last one to close it).
         ongoing: List[Tuple[Position, EltT, int]] = []
@@ -472,8 +474,12 @@ class PositionList(Generic[EltT]):
         end = bisect_left(self.segments, rng.end, key=lambda x: x[0])
         return (start, end)
 
-    def _update_segments(self, rng: Range, new_segments: List[Tuple[Position, EltT, int]]):
-        new_segments = [seg for seg in new_segments if rng.start <= seg[0] < rng.end]
+    def _update_segments(
+        self, rng: Range, new_segments: List[Tuple[Position, EltT, int]]
+    ):
+        new_segments = [
+            seg for seg in new_segments if rng.start <= seg[0] < rng.end
+        ]
 
         seg_start, seg_end = self._get_segment_range(rng)
         if seg_end > 0:
@@ -498,7 +504,6 @@ class PositionList(Generic[EltT]):
             to_insert.append((rng.end, after_value, after_idx))
 
         self.segments[seg_start:seg_end] = to_insert
-
 
     def clear_range(self, rng: Range):
         elt_start, elt_end = self._get_elt_range(rng)
@@ -530,7 +535,6 @@ class PositionList(Generic[EltT]):
 
         if idx >= 1 and self.segments[idx - 1][1] is not None:
             return self.segments[idx - 1][1]
-
 
         # In some cases, we may be on the boundary between two segments.
         # In this case, the next segment's start position is the same as
@@ -824,7 +828,6 @@ class FileInfo:
             return
         self.scope_segments.append(s)
 
-
     def _resolve_call(
         self,
         node: chapel.FnCall,
@@ -1090,7 +1093,9 @@ class FileInfo:
         new_calls = PositionList[ResolvedPair](lambda x: x.ident.rng)
 
         for i in range(start, end):
-            begin_pos, value_at_segment, _ = self.instantiation_segments.segments[i]
+            begin_pos, value_at_segment, _ = (
+                self.instantiation_segments.segments[i]
+            )
             end_pos = rng.end
             if i + 1 < len(self.instantiation_segments.segments):
                 next_pos, _, _ = self.instantiation_segments.segments[i + 1]
@@ -1111,7 +1116,10 @@ class FileInfo:
 
                 # Only note calls in the current instantiation segment's range
                 call_and_range = NodeAndRange(node.called_expression())
-                if call_and_range.rng.start < begin_pos or call_and_range.rng.end > end_pos:
+                if (
+                    call_and_range.rng.start < begin_pos
+                    or call_and_range.rng.end > end_pos
+                ):
                     continue
 
                 new_calls.append(ResolvedPair(call_and_range, NodeAndRange(fn)))

--- a/tools/chpl-language-server/test/basic_resolver.py
+++ b/tools/chpl-language-server/test/basic_resolver.py
@@ -53,6 +53,65 @@ async def test_go_to_record_def(client: LanguageClient):
         await check_goto_type_def(client, doc, pos((2, 4)), pos((0, 7)))
         await check_goto_type_def(client, doc, pos((3, 9)), pos((0, 7)))
 
+@pytest.mark.asyncio
+async def test_go_to_call_basic(client: LanguageClient):
+    """
+    Ensure that 'go to definition' on a type actually works.
+    """
+
+    file = """
+           proc foo(x: int) {}
+           proc foo(x: bool) {}
+           foo(1);
+           foo(true);
+           """
+
+    async with source_file(client, file) as doc:
+        await check_goto_decl_def(client, doc, pos((2, 0)), pos((0, 5)))
+        await check_goto_decl_def(client, doc, pos((3, 0)), pos((1, 5)))
+
+@pytest.mark.asyncio
+async def test_go_to_call_generic(client: LanguageClient):
+    """
+    Ensure that 'go to definition' on a type actually works.
+    """
+
+    file = """
+           proc foo(x: int) {}
+           proc foo(x: bool) {}
+           proc bar(x) do foo(x);
+           bar(1);
+           bar(true);
+           """
+    lenses = [(pos((2, 5)), 3)]
+
+    async with source_file(client, file) as doc:
+        got_lenses = await check_generic_code_lenses(client, doc, lenses)
+        lenses_for_bar = got_lenses[(2, 5)]
+
+        async def select_inst(n, expect_title):
+            assert lenses_for_bar[n].command is not None
+            assert lenses_for_bar[n].command.title == expect_title
+            await execute_command(client, lenses_for_bar[n].command)
+
+        # Before selecting instantiation, should not know which call it is
+        await check_goto_decl_def(client, doc, pos((2, 15)), None)
+        await check_goto_decl_def(client, doc, pos((2, 19)), pos((2, 9)))
+
+        # Select the first instantiation
+        await select_inst(1, "Show instantiation")
+        await check_goto_decl_def(client, doc, pos((2, 15)), pos((0, 5)))
+        await check_goto_decl_def(client, doc, pos((2, 19)), pos((2, 9)))
+
+        # Select the second instantiation
+        await select_inst(2, "Show instantiation")
+        await check_goto_decl_def(client, doc, pos((2, 15)), pos((1, 5)))
+        await check_goto_decl_def(client, doc, pos((2, 19)), pos((2, 9)))
+
+        # Clear instantiation; call to 'foo' should be unclickable again.
+        await select_inst(0, "Show Generic")
+        await check_goto_decl_def(client, doc, pos((2, 15)), None)
+        await check_goto_decl_def(client, doc, pos((2, 19)), pos((2, 9)))
 
 @pytest.mark.asyncio
 @pytest.mark.xfail

--- a/tools/chpl-language-server/test/basic_resolver.py
+++ b/tools/chpl-language-server/test/basic_resolver.py
@@ -57,7 +57,7 @@ async def test_go_to_record_def(client: LanguageClient):
 @pytest.mark.asyncio
 async def test_go_to_call_basic(client: LanguageClient):
     """
-    Ensure that 'go to definition' on a type actually works.
+    Ensure that 'go to definition' works for concrete called functions.
     """
 
     file = """
@@ -75,7 +75,8 @@ async def test_go_to_call_basic(client: LanguageClient):
 @pytest.mark.asyncio
 async def test_go_to_call_generic(client: LanguageClient):
     """
-    Ensure that 'go to definition' on a type actually works.
+    Ensure that 'go to definition' works for generic functions and calls
+    made from within them.
     """
 
     file = """

--- a/tools/chpl-language-server/test/basic_resolver.py
+++ b/tools/chpl-language-server/test/basic_resolver.py
@@ -53,6 +53,7 @@ async def test_go_to_record_def(client: LanguageClient):
         await check_goto_type_def(client, doc, pos((2, 4)), pos((0, 7)))
         await check_goto_type_def(client, doc, pos((3, 9)), pos((0, 7)))
 
+
 @pytest.mark.asyncio
 async def test_go_to_call_basic(client: LanguageClient):
     """
@@ -69,6 +70,7 @@ async def test_go_to_call_basic(client: LanguageClient):
     async with source_file(client, file) as doc:
         await check_goto_decl_def(client, doc, pos((2, 0)), pos((0, 5)))
         await check_goto_decl_def(client, doc, pos((3, 0)), pos((1, 5)))
+
 
 @pytest.mark.asyncio
 async def test_go_to_call_generic(client: LanguageClient):
@@ -112,6 +114,7 @@ async def test_go_to_call_generic(client: LanguageClient):
         await select_inst(0, "Show Generic")
         await check_goto_decl_def(client, doc, pos((2, 15)), None)
         await check_goto_decl_def(client, doc, pos((2, 19)), pos((2, 9)))
+
 
 @pytest.mark.asyncio
 @pytest.mark.xfail


### PR DESCRIPTION
This PR implements go-to-definition for calls. It does so by introducing a new segment type (call segments) to denote things called at a given position.

![gotodefcall](https://github.com/user-attachments/assets/c71af92d-2d6e-42a4-848f-cb3a9f51db8f)


## Segment Lists Overhaul
This PR also implements a major overhaul of how `chpl-language-server`'s segment lists work. Specifically, it makes the segment lists work when items stored therein have arbitrary overlapping behavior (nesting, partial overlaps, disjointedness). Consider the following representation of a list of things which are found in a source file (e.g., names, calls, etc.)

```
        |------------| A
               |-------------| B
                       |--| C
                                  |---------| D
```

Prior to this PR, CLS stored a sorted list of these items, and used a binary search across the elements' start positions to find the item under the cursor. However, this didn't work in situations such as the B-C overlap in the diagram above. A binary search when the cursor is past C would find C as the next visible start position, and, since that position doesn't contain the cursor, return nothing. However, it should return B, which resumes after C is over. In other words, overlapping segments would "interrupt" ranges in CLS.

This is going to be a problem for nested instantiations (though they are currently not possible due to limitations of Dyno's resolver), since the location of the "inner" generic function overlaps with the location of the "outer" generic function, and thus, the region after the "inner" function will not be correctly determined to belong to the "outer" function (it would be interrupted). Since go-to-called-function support relies on instantiations, I elected to improve the situation in this PR.

I did so by additionally "flattening" the representation of item ranges, so that no parts of it overlap. The flattened representation of the above segment list is:

```
        |------|-------|--|--|----|---------|
         A      B       C  B  None D

```

Binary searches are performed using start positions of the flattened segments (the labeled `|`s in the above diagram). 

## Making Use of Instantiation Segments
To construct call segments (and thus support go-to-called-function), this PR makes use of instantiation segments. Specifically, when an instantiation at a particular range changes, CLS will iterate the affected instnatiation segments (which correspond to regions-within-an-instantiation in the user buffer) and re-run call resolution within, given the instantiation information.

Reviewed by @jabraham17 -- thanks!

## Testing
- [x] python tests for CLS