### PR TITLE
Fix `CHPL_LLVM=bundled` on MacOS

### DIFF
--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -676,7 +676,7 @@ def get_gcc_prefix_dir():
         else:
             # Try to figure out the GCC prefix by running gcc
             out, err = run_command(['gcc', '-v'], stdout=True, stderr=True)
-            out = (out or '') + (err or '')
+            out = out + err
 
             # look for the --prefix= specified when GCC was configured
             words = out.split()

--- a/util/chplenv/utils.py
+++ b/util/chplenv/utils.py
@@ -59,7 +59,7 @@ def try_run_command(command, cmd_input=None, combine_output=False):
        This should be the only invocation of subprocess in all chplenv scripts.
        This could be replaced by subprocess.check_output, but that
        is only available after Python 2.7, and we still support 2.6 :("""
-    
+
     stderr = subprocess.STDOUT if combine_output else subprocess.PIPE
     try:
         process = subprocess.Popen(command,
@@ -71,7 +71,7 @@ def try_run_command(command, cmd_input=None, combine_output=False):
     byte_cmd_input = str.encode(cmd_input, "utf-8") if cmd_input else None
     output = process.communicate(input=byte_cmd_input)
     my_stdout = output[0].decode("utf-8")
-    my_sterr = output[1].decode("utf-8") if combine_output and output[1] else None
+    my_sterr = output[1].decode("utf-8") if output[1] else None
     return (True, process.returncode, my_stdout, my_sterr)
 
 


### PR DESCRIPTION
Fixes a regression where `CHPL_LLVM=bundled` on MacOS resulted in a python error in printchplenv. This was due to some incorrect logic in `try_run_command`, which was added as a part of https://github.com/chapel-lang/chapel/pull/26072. This was resulting in `my_stderr` always being either `None` or the empty string, which was not the correct behavior.

This was not caught previously, as `CHPL_LLVM=bundled` is not a common config on MacOS (or tested in nightly tests)

Tested that a full build of `CHPL_LLVM=bundled` works on MacOS

[Reviewed by @arezaii]