### PR TITLE
Fix internal error when using `CHPL_GPU=amd` and hugepages

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -351,6 +351,21 @@ static void genGlobalInt32(const char *cname, int value) {
 #endif
   }
 }
+static void genGlobalUInt64(const char *cname, uint64_t value) {
+  GenInfo *info = gGenInfo;
+  if (info->cfile) {
+    fprintf(info->cfile, "const uint64_t %s = %" PRIu64 ";\n", cname, value);
+  } else {
+#ifdef HAVE_LLVM
+    llvm::GlobalVariable *globalInt =
+        llvm::cast<llvm::GlobalVariable>(info->module->getOrInsertGlobal(
+            cname, llvm::IntegerType::getInt64Ty(info->module->getContext())));
+    globalInt->setInitializer(info->irBuilder->getInt64(value));
+    globalInt->setConstant(true);
+    info->lvt->addGlobalValue(cname, globalInt, GEN_PTR, false, dtInt[INT_SIZE_64]);
+#endif
+  }
+}
 
 static bool
 isObjectOrSubclass(Type* t)
@@ -2636,6 +2651,7 @@ static void embedGpuCode() {
   }
 
   genGlobalRawString("chpl_gpuBinary", buffer, buffer.length());
+  genGlobalUInt64("chpl_gpuBinarySize", uint64_t(buffer.length()));
 }
 
 static void codegenGpuGlobals() {

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -351,6 +351,10 @@ static void genGlobalInt32(const char *cname, int value) {
 #endif
   }
 }
+
+// this is currently only used for GPU compilation, and gets unused function
+// warnings without HAVE_LLVM
+#ifdef HAVE_LLVM
 static void genGlobalUInt64(const char *cname, uint64_t value) {
   GenInfo *info = gGenInfo;
   if (info->cfile) {
@@ -366,6 +370,7 @@ static void genGlobalUInt64(const char *cname, uint64_t value) {
 #endif
   }
 }
+#endif
 
 static bool
 isObjectOrSubclass(Type* t)

--- a/runtime/src/gpu/common/cuda-shared.h
+++ b/runtime/src/gpu/common/cuda-shared.h
@@ -29,7 +29,7 @@
 #include "cuda-utils.h"
 
 static inline
-void* chpl_gpu_load_module(const char* fatbin_data) {
+void* chpl_gpu_load_module(const char* fatbin_data, const uint64_t fatbin_size) {
   CUmodule cuda_module;
 
   CUDA_CALL(cuModuleLoadData(&cuda_module, fatbin_data));

--- a/runtime/src/gpu/nvidia/gpu-nvidia.c
+++ b/runtime/src/gpu/nvidia/gpu-nvidia.c
@@ -43,6 +43,7 @@
 
 // this is compiler-generated
 extern const char* chpl_gpuBinary;
+extern const uint64_t chpl_gpuBinarySize;
 
 static CUcontext *chpl_gpu_primary_ctx;
 static CUdevice  *chpl_gpu_devices;
@@ -207,7 +208,7 @@ void chpl_gpu_impl_init(int* num_devices) {
 
         CUDA_CALL(cuCtxSetCurrent(context));
         // load the module and setup globals within
-        CUmodule module = chpl_gpu_load_module(chpl_gpuBinary);
+        CUmodule module = chpl_gpu_load_module(chpl_gpuBinary, chpl_gpuBinarySize);
         chpl_gpu_cuda_modules[i] = module;
 
         cuDeviceGetAttribute(&deviceClockRates[i],


### PR DESCRIPTION
This fixes an issue where the runtime would fail to load the GPU fatbin when sufficiently large hugepages were being used.

```
internal error: gpu-amd.c:62: Error calling HIP function: file not found (Code: 301)
```

This was only an issue `CHPL_GPU=amd`, not `CHPL_GPU=nvidia`. @jhh67 found that copying the global fatbin to a local buffer before calling `hipModuleLoadData` was sufficient to work around the issue. Its not totally clear why `hipModuleLoadData` has this issue, but the fix is simple enough and low impact (this code only runs once per GPU at startup).

This PR applies @jhh67's fix by copying the fatbin only when hugepages are enabled, which requires threading `chpl_gpuBinarySize` into the runtime.

Tested that the following test case works without hugepages and that it doesn't trigger the copy. Also tested that various hugepage sizes (up to 32M) work and trigger the copy.
```chapel
coforall loc in Locales do on loc {
   coforall subloc in here.gpus do on subloc {
     var A : [0..10] int;
     foreach i in 0..10  do A[i] = i * 2;
     writeln("on ", here, " A = ", A);
   }
}
```

[Reviewed by @jhh67]