### PR TITLE
Add nightly job for NVIDIA GPUs + colocales

### DIFF
--- a/test/gpu/native/multiLocale/SKIPIF
+++ b/test/gpu/native/multiLocale/SKIPIF
@@ -1,1 +1,4 @@
-CHPL_COMM != gasnet
+#!/usr/bin/env python3
+
+import os
+print(os.getenv('CHPL_COMM') not in ('gasnet', 'ofi'))

--- a/util/cron/test-gpu-ex-cuda-12.colocales.bash
+++ b/util/cron/test-gpu-ex-cuda-12.colocales.bash
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# GPU native testing on a Cray EX for colocales specifically
+
+CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+source $CWD/common-native-gpu.bash
+source $CWD/common-hpe-cray-ex.bash
+source $CWD/common-ofi.bash
+
+export SLURM_NETWORK=single_node_vni
+module load cudatoolkit  # default is CUDA 12
+
+export CHPL_LLVM=bundled  # CUDA 12 is only supported with bundled LLVM
+export CHPL_LAUNCHER_PARTITION=allgriz
+export CHPL_GPU=nvidia
+export CHPL_NIGHTLY_TEST_DIRS="test/gpu/native/multiLocale/"
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-ex-cuda-12.colocales"
+$CWD/nightly -cron ${nightly_args}

--- a/util/cron/test-gpu-ex-cuda-12.colocales.bash
+++ b/util/cron/test-gpu-ex-cuda-12.colocales.bash
@@ -9,9 +9,8 @@ source $CWD/common-ofi.bash
 
 export SLURM_NETWORK=single_node_vni
 export CHPL_RT_LOCALES_PER_NODE=2
-module load cudatoolkit  # default is CUDA 12
+module load cuda/12.4
 
-export CHPL_LLVM=bundled  # CUDA 12 is only supported with bundled LLVM
 export CHPL_LAUNCHER_PARTITION=allgriz
 export CHPL_GPU=nvidia
 export CHPL_NIGHTLY_TEST_DIRS="gpu/native/multiLocale"

--- a/util/cron/test-gpu-ex-cuda-12.colocales.bash
+++ b/util/cron/test-gpu-ex-cuda-12.colocales.bash
@@ -8,6 +8,7 @@ source $CWD/common-hpe-cray-ex.bash
 source $CWD/common-ofi.bash
 
 export SLURM_NETWORK=single_node_vni
+export CHPL_RT_LOCALES_PER_NODE=2
 module load cudatoolkit  # default is CUDA 12
 
 export CHPL_LLVM=bundled  # CUDA 12 is only supported with bundled LLVM

--- a/util/cron/test-gpu-ex-cuda-12.colocales.bash
+++ b/util/cron/test-gpu-ex-cuda-12.colocales.bash
@@ -14,7 +14,7 @@ module load cudatoolkit  # default is CUDA 12
 export CHPL_LLVM=bundled  # CUDA 12 is only supported with bundled LLVM
 export CHPL_LAUNCHER_PARTITION=allgriz
 export CHPL_GPU=nvidia
-export CHPL_NIGHTLY_TEST_DIRS="test/gpu/native/multiLocale/"
+export CHPL_NIGHTLY_TEST_DIRS="gpu/native/multiLocale"
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-ex-cuda-12.colocales"
 $CWD/nightly -cron ${nightly_args}


### PR DESCRIPTION
Though the GPU runtime includes code to support colocales, it was not tested automatically prior to this PR. This PR adds a new configuration that runs only the tests in `test/gpu/native/multiLocale` using `CHPL_RT_LOCALES_PER_NODE=2`, enabling colocales. In this configuration, the `main` branch before John's fix failed to build, which indicates that it accurately tests the colocale assignment code.

While there, I noticed that even without colocales, the `test/gpu/native/multiLocale` folder is not tested under OFI, since the SKIPIF is more specific and requires GASNet. This PR adjusts the skip if to allow either GASNet or OFI.

Reviewed by @e-kayrakli -- thanks!

## Testing
I ran:

```bash
CHPL_NIGHTLY_DO_NOTHING=true source ./util/cron/test-gpu-ex-cuda-12.colocales.bash
make -j32
start_test test/gpu/native/multiLocale
```

And it ran all the tests, and passed. Moreover, explicitly running one of the tests with `--dry-run` clearly indicates that one node for every two locales is being requested from slurm:
```
--quiet --nodes=1 --ntasks=2
```
    