### PR TITLE
add blog testing to hpe-cray-ex-ofi test config

### DIFF
--- a/util/cron/test-hpe-cray-ex-ofi.bash
+++ b/util/cron/test-hpe-cray-ex-ofi.bash
@@ -11,4 +11,4 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="hpe-cray-ex-ofi"
 export CHPL_RT_COMM_OFI_EXPECTED_PROVIDER="cxi"
 export CHPL_RT_MAX_HEAP_SIZE=16g
 
-$CWD/nightly -cron -examples ${nightly_args}
+$CWD/nightly -cron -examples -blog ${nightly_args}


### PR DESCRIPTION
This adds blog testing to a single cray-ex config. It requires the companion PR https://github.hpe.com/hpe/hpc-chapel-ci-config/pull/1318 to be merged first, then this can be merged and should start testing the blog on the hpe-cray-ex platform