### PR TITLE
Backport Fix For Performance Regression in Qthreads 1.21

### DIFF
--- a/third-party/qthread/README
+++ b/third-party/qthread/README
@@ -51,3 +51,39 @@ index 8269aa0949..bf022bc243 100644
  #define qthread_incr(ADDR, INCVAL) __sync_fetch_and_add(ADDR, INCVAL)
 
 ```
+
+* Backport a performance fix from the development version of qthreads.
+  https://github.com/chapel-lang/chapel/pull/26138
+
+```
+diff --git a/include/qt_atomics.h b/include/qt_atomics.h
+index 2ac887ed..2312c954 100644
+--- a/include/qt_atomics.h
++++ b/include/qt_atomics.h
+@@ -21,8 +21,24 @@
+ #define THREAD_FENCE_MEM_RELEASE THREAD_FENCE_MEM_RELEASE_IMPL
+ #endif
+
++#if QTHREAD_ASSEMBLY_ARCH == QTHREAD_IA32 ||                                   \
++  QTHREAD_ASSEMBLY_ARCH == QTHREAD_AMD64
+ #define SPINLOCK_BODY()                                                        \
+-  do { MACHINE_FENCE; } while (0)
++  do { __asm__ __volatile__("pause" ::: "memory"); } while (0)
++#elif QTHREAD_ASSEMBLY_ARCH == QTHREAD_ARM ||                                  \
++  QTHREAD_ASSEMBLY_ARCH == QTHREAD_ARMV8_A64
++#define SPINLOCK_BODY()                                                        \
++  do { __asm__ __volatile__("yield" ::: "memory"); } while (0)
++#elif QTHREAD_ASSEMBLY_ARCH == QTHREAD_POWERPC64 ||                            \
++  QTHREAD_ASSEMBLY_ARCH == QTHREAD_POWERPC32
++// For whatever reason the 29 (mdoio) version of this instruction performed
++// better in some back-of-the-envelope benchmarking so we're using that.
++#define SPINLOCK_BODY()                                                        \
++  do { __asm__ __volatile__("or 29,29,29" ::: "memory"); } while (0)
++#else
++#define SPINLOCK_BODY()                                                        \
++  do { atomic_thread_fence(memory_order_acq_rel); } while (0)
++#endif
+
+ #define QTHREAD_FASTLOCK_SETUP()                                               \
+   do {                                                                         \
+```


### PR DESCRIPTION
This backports a performance fix to cover a regression from qthreads 1.21.
In particular it adds some platform-specialized assembly that controls processor behavior while busy waiting.