### PR TITLE
Cache true and false symbol creation

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -1788,14 +1788,7 @@ VarSymbol *new_CStringSymbol(const char *str) {
 
 VarSymbol* new_BoolSymbol(bool b) {
   // gTrue and gFalse are set up directly in initPrimitiveTypes.
-  // Why not just return these? test: studies/bale/indexgather/ig-variants
-  VarSymbol* proto = b ? gTrue : gFalse;
-  VarSymbol* s = new VarSymbol(
-    astr("_", proto->name, "_", istr(literal_id++)), dtBool);
-  rootModule->block->insertAtTail(new DefExpr(s));
-  s->immediate = new Immediate;
-  *s->immediate = *proto->immediate;
-  return s;
+  return b ? gTrue : gFalse;
 }
 
 VarSymbol *new_IntSymbol(int64_t b, IF1_int_type size) {

--- a/test/param/loop/boolInst.chpl
+++ b/test/param/loop/boolInst.chpl
@@ -1,0 +1,16 @@
+record R {
+  param flag = true;
+}
+
+proc bar(x: R(true)) {
+  writeln("In bar: ", x.type:string);
+}
+
+proc bar(x: R(false)) {
+  writeln("In bar: ", x.type:string);
+}
+
+for param flag in false..true {
+  var r = new R(flag);
+  bar(r);
+}

--- a/test/param/loop/boolInst.good
+++ b/test/param/loop/boolInst.good
@@ -1,0 +1,2 @@
+In bar: R(false)
+In bar: R(true)

--- a/test/studies/bale/indexgather/ig-variants.comm-none.good
+++ b/test/studies/bale/indexgather/ig-variants.comm-none.good
@@ -1,9 +1,5 @@
 ig-variants.chpl:60: note: Optimized assign to be unordered
-ig-variants.chpl:60: note: Optimized assign to be unordered
 ig-variants.chpl:68: note: Optimized assign to be unordered
-ig-variants.chpl:68: note: Optimized assign to be unordered
-ig-variants.chpl:76: note: Optimized assign to be unordered
-ig-variants.chpl:76: note: Optimized assign to be unordered
 ig-variants.chpl:76: note: Optimized assign to be unordered
 ig-variants.chpl:76: note: Optimized assign to be unordered
 17 1 4 19 14 19 7 19 11 2 12 2 14 14 9 17 0 19 3 6 10 2 3 8 6 6 8 7 13 15 9 5 5 18 15 18 1 2 0 18

--- a/test/studies/bale/indexgather/ig-variants.good
+++ b/test/studies/bale/indexgather/ig-variants.good
@@ -1,9 +1,5 @@
 ig-variants.chpl:60: note: Optimized assign to be unordered
-ig-variants.chpl:60: note: Optimized assign to be unordered
 ig-variants.chpl:68: note: Optimized assign to be unordered
-ig-variants.chpl:68: note: Optimized assign to be unordered
-ig-variants.chpl:76: note: Optimized assign to be unordered
-ig-variants.chpl:76: note: Optimized assign to be unordered
 ig-variants.chpl:76: note: Optimized assign to be unordered
 ig-variants.chpl:76: note: Optimized assign to be unordered
 57 61 4 59 74 59 67 79 11 62 32 22 74 14 9 17 20 79 3 26 70 62 23 68 46 46 28 27 33 35 69 5 45 38 75 38 21 2 40 38 24 50 36 73 71 37 23 77 30 14 68 76 17 68 27 59 42 38 26 55 1 50 13 14 16 30 39 31 30 1 46 57 15 71 12 26 32 18 35 64 57 64 12 21 62 43 9 56 21 74 42 57 42 19 55 73 2 3 76 8 43 37 52 7 51 68 30 40 35 6 73 17 34 9 31 31 73 48 67 49 25 1 5 42 27 59 47 70 59 62 4 25 29 72 6 67 0 1 4 27 71 75 52 38 63 3 45 62 58 66 77 32 66 54 18 31 48 8 16 24


### PR DESCRIPTION
Fixes https://github.com/chapel-lang/chapel/issues/26142.

Prior to this PR, each creation of a true/false symbol led to a new variable. This, in turn, resulted in redundant instantiations for the same value, including of record types. This meant that two `R(true)`s can actually be distinct, because `true`s could be different. This PR changes this to ensure the same `gTrue` and `gFalse` is returned from `new_BoolSymbol`. This matches the behavior of `new_IntSymbol`, which uses a cache.

This makes an existing test fail (`ig-variants.chpl`), but only because its .good file explicitly locks down the duplicate instantiation behavior, which is undesirable anyway. So, this PR changes that test with the expectation that `foo(true)` creates only a single instantiation, instead of N instantiations where N is the number of `true`s.

Reviewed by @vasslitvinov -- thanks!

## Testing
- [x] paratest