### PR TITLE
Dyno: Refactor uAST generation

### DIFF
--- a/frontend/include/chpl/framework/ID.h
+++ b/frontend/include/chpl/framework/ID.h
@@ -159,6 +159,13 @@ class ID final {
                         FabricatedIdKind kind);
 
   /**
+    Create an ID that represents a uAST node created during compilation.
+   */
+  static ID generatedId(UniqueString symbolPath,
+                       int postOrderId,
+                       int numChildIds);
+
+  /**
     Return the number of ids contained in this node, not including itself. In
     the postorder traversal numbering, the ids contained appear before the node.
 

--- a/frontend/include/chpl/framework/ID.h
+++ b/frontend/include/chpl/framework/ID.h
@@ -110,7 +110,7 @@ class ID final {
         return -1;
       } else {
         // generated uAST nodes
-        return (postOrderId_ * -1) - ID_GEN_START - 1;
+        return (postOrderId_ * -1) + ID_GEN_START - 1;
       }
     } else {
       return postOrderId_;

--- a/frontend/include/chpl/parsing/parsing-queries.h
+++ b/frontend/include/chpl/parsing/parsing-queries.h
@@ -116,20 +116,6 @@ parseFileContainingIdToBuilderResult(Context* context, ID id,
                                      UniqueString* setParentSymbolPath=nullptr);
 
 /**
-  Fetch the BuilderResult storing compiler-generated uAST based on the given
-  symbolPath.
- */
-const uast::BuilderResult&
-getCompilerGeneratedBuilder(Context* context, UniqueString symbolPath);
-
-/**
-  Set the BuilderResult storing compiler-generated uAST based on the given
-  symbolPath.
- */
-void setCompilerGeneratedBuilder(Context* context, UniqueString symbolPath,
-                                 uast::BuilderResult result);
-
-/**
   A function for counting the tokens when parsing
 */
 void countTokens(Context* context, UniqueString path, ParserStats* parseStats);

--- a/frontend/include/chpl/resolution/resolution-queries.h
+++ b/frontend/include/chpl/resolution/resolution-queries.h
@@ -563,9 +563,9 @@ CallResolutionResult resolveTheseCall(ResolutionContext* rc,
   BuilderResult storing the generated default function uAST.
 */
 const uast::BuilderResult*
-buildDefaultFunction(Context* context,
-                     UniqueString typePath,
-                     UniqueString name);
+builderResultForDefaultFunction(Context* context,
+                                UniqueString typePath,
+                                UniqueString name);
 
 
 } // end namespace resolution

--- a/frontend/include/chpl/resolution/resolution-queries.h
+++ b/frontend/include/chpl/resolution/resolution-queries.h
@@ -558,6 +558,15 @@ CallResolutionResult resolveTheseCall(ResolutionContext* rc,
                                       const types::QualifiedType& followThis,
                                       const CallScopeInfo& inScopes);
 
+/**
+  Given a type's symbol path and the name of a default function, return a
+  BuilderResult storing the generated default function uAST.
+*/
+const uast::BuilderResult*
+buildDefaultFunction(Context* context,
+                     UniqueString typePath,
+                     UniqueString name);
+
 
 } // end namespace resolution
 } // end namespace chpl

--- a/frontend/include/chpl/resolution/resolution-queries.h
+++ b/frontend/include/chpl/resolution/resolution-queries.h
@@ -558,6 +558,7 @@ CallResolutionResult resolveTheseCall(ResolutionContext* rc,
                                       const types::QualifiedType& followThis,
                                       const CallScopeInfo& inScopes);
 
+// Note: Defined in default-functions.cpp
 /**
   Given a type's symbol path and the name of a default function, return a
   BuilderResult storing the generated default function uAST.

--- a/frontend/include/chpl/uast/Builder.h
+++ b/frontend/include/chpl/uast/Builder.h
@@ -127,7 +127,6 @@ class Builder final {
                                                 UniqueString parentSymbolPath);
 
   static owned<Builder> createForGeneratedCode(Context* context,
-                                               const char* filepath,
                                                ID generatedFrom);
 
   /** Construct a Builder for use when reading uAST from a library file. */

--- a/frontend/include/chpl/uast/Builder.h
+++ b/frontend/include/chpl/uast/Builder.h
@@ -77,7 +77,7 @@ class Builder final {
   // These are removed in the astToLocation_ map.
   AstLocMap notedLocations_;
 
-  ID generatedFrom_;
+  bool isGenerated_;
 
   // These map AST to additional locations while the builder is building.
   // This is an equivalent to notedLocations for the additional locations.
@@ -92,11 +92,11 @@ class Builder final {
   Builder(Context* context, UniqueString filePath,
           UniqueString startingSymbolPath,
           const libraries::LibraryFile* lib,
-          ID generatedFrom = ID())
+          bool isGenerated = false)
     : context_(context),
       startingSymbolPath_(startingSymbolPath),
-      br(filePath, lib, generatedFrom),
-      generatedFrom_(generatedFrom)
+      br(filePath, lib),
+      isGenerated_(isGenerated)
   {
   }
 
@@ -111,7 +111,7 @@ class Builder final {
   void copyAdditionalLocation(AstLocMap& m, const AstNode* from, const AstNode* to);
   void deleteAdditionalLocation(AstLocMap& m, const AstNode* ast);
 
-  bool isGenerated() { return !generatedFrom_.isEmpty(); }
+  bool isGenerated() { return isGenerated_; }
 
  public:
   /** Construct a Builder for parsing a top-level module */
@@ -128,8 +128,7 @@ class Builder final {
 
   static owned<Builder> createForGeneratedCode(Context* context,
                                                const char* filepath,
-                                               ID generatedFrom,
-                                               UniqueString parentSymbolPath);
+                                               ID generatedFrom);
 
   /** Construct a Builder for use when reading uAST from a library file. */
   static owned<Builder> createForLibraryFileModule(

--- a/frontend/include/chpl/uast/BuilderResult.h
+++ b/frontend/include/chpl/uast/BuilderResult.h
@@ -142,8 +142,6 @@ class BuilderResult final {
   // but only for modules & symbols stored in the symbol table
   llvm::DenseMap<ID, std::pair<int,int>> libraryFileSymbols_;
 
-  ID generatedFrom_;
-
   // For use with library files.
   // Returns the module index & symbol index for the symbol
   // containing the passed ID.
@@ -164,11 +162,9 @@ class BuilderResult final {
   /** Construct a BuilderResult that records a particular file path.
       Optional arguments include:
         - a LibraryFile to refer to in place of a file
-        - an ID from which this uAST was generated
       */
   BuilderResult(UniqueString filePath,
-                const libraries::LibraryFile* lib = nullptr,
-                ID generatedFrom = ID());
+                const libraries::LibraryFile* lib = nullptr);
 
   /** Return the file path this result refers to */
   UniqueString filePath() const {

--- a/frontend/lib/framework/ID.cpp
+++ b/frontend/lib/framework/ID.cpp
@@ -142,7 +142,8 @@ ID ID::parentSymbolId(Context* context) const {
   }
 
   if (this->isFabricatedId() &&
-      this->fabricatedIdKind() == FabricatedIdKind::Generated) {
+      this->fabricatedIdKind() == FabricatedIdKind::Generated &&
+      !isSymbolDefiningScope()) {
     return ID(parentSymPath, ID_GEN_START, 0);
   } else {
     // Otherwise, construct an ID for the parent symbol

--- a/frontend/lib/framework/ID.cpp
+++ b/frontend/lib/framework/ID.cpp
@@ -129,6 +129,20 @@ ID ID::fabricateId(Context* context,
   return newId;
 }
 
+ID ID::generatedId(UniqueString symbolPath,
+                 int postOrderId,
+                 int numChildIds) {
+  int pid;
+  if (postOrderId == -1) {
+    pid = ID_GEN_START;
+  } else {
+    pid = ID_GEN_START - 1 - postOrderId;
+  }
+
+  return ID(symbolPath, pid, numChildIds);
+}
+
+
 ID ID::parentSymbolId(Context* context) const {
   if (postOrderId_ >= 0) {
     // Create an ID with postorder id -1 instead

--- a/frontend/lib/framework/ID.cpp
+++ b/frontend/lib/framework/ID.cpp
@@ -144,24 +144,27 @@ ID ID::generatedId(UniqueString symbolPath,
 
 
 ID ID::parentSymbolId(Context* context) const {
-  if (postOrderId_ >= 0) {
-    // Create an ID with postorder id -1 instead
-    return ID(symbolPath_, -1, 0);
+  UniqueString pathToUse;
+  if (postOrderId() >= 0) {
+    pathToUse = symbolPath_;
+  } else {
+    pathToUse = ID::parentSymbolPath(context, symbolPath_);
+    if (pathToUse.isEmpty()) {
+      // no parent symbol path so return an empty ID
+      return ID();
+    }
   }
 
-  UniqueString parentSymPath = ID::parentSymbolPath(context, symbolPath_);
-  if (parentSymPath.isEmpty()) {
-    // no parent symbol path so return an empty ID
-    return ID();
-  }
-
+  // Assumption: Generated uAST symbols that define a scope do not themselves
+  // contain symbols that define a scope. This means that if we see a generated
+  // scope-defining symbol, its parent must not be generated uAST.
   if (this->isFabricatedId() &&
       this->fabricatedIdKind() == FabricatedIdKind::Generated &&
       !isSymbolDefiningScope()) {
-    return ID(parentSymPath, ID_GEN_START, 0);
+    return ID(pathToUse, ID_GEN_START, 0);
   } else {
     // Otherwise, construct an ID for the parent symbol
-    return ID(parentSymPath, -1, 0);
+    return ID(pathToUse, -1, 0);
   }
 }
 

--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -204,7 +204,7 @@ parseFileContainingIdToBuilderResult(Context* context,
     auto symbolPath = ID::parentSymbolPath(context, id.symbolPath());
     auto symbolName = id.symbolName(context);
 
-    const BuilderResult* br = resolution::buildDefaultFunction(context, symbolPath, symbolName);
+    const BuilderResult* br = resolution::builderResultForDefaultFunction(context, symbolPath, symbolName);
     if (br != nullptr) {
       if (setParentSymbolPath) *setParentSymbolPath = symbolPath;
     }

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -391,7 +391,7 @@ const BuilderResult& buildInitializer(Context* context, ID typeID) {
   auto typeDecl = parsing::idToAst(context, typeID)->toAggregateDecl();
   auto parentMod = parsing::idToParentModule(context, typeID);
   auto modName = "chpl__generated_" + parentMod.symbolName(context).str() + "_" + typeDecl->name().str() + "_init";
-  auto bld = Builder::createForGeneratedCode(context, modName.c_str(), typeID, parentMod.symbolPath());
+  auto bld = Builder::createForGeneratedCode(context, modName.c_str(), typeID);
   auto builder = bld.get();
   auto dummyLoc = parsing::locateId(context, typeID);
 

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -389,9 +389,7 @@ const BuilderResult& buildInitializer(Context* context, ID typeID) {
   QUERY_BEGIN(buildInitializer, context, typeID);
 
   auto typeDecl = parsing::idToAst(context, typeID)->toAggregateDecl();
-  auto parentMod = parsing::idToParentModule(context, typeID);
-  auto modName = "chpl__generated_" + parentMod.symbolName(context).str() + "_" + typeDecl->name().str() + "_init";
-  auto bld = Builder::createForGeneratedCode(context, modName.c_str(), typeID);
+  auto bld = Builder::createForGeneratedCode(context, typeID);
   auto builder = bld.get();
   auto dummyLoc = parsing::locateId(context, typeID);
 

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -1353,60 +1353,6 @@ getCompilerGeneratedFunction(Context* context,
   return nullptr;
 }
 
-static const BuilderResult&
-buildAssignmentOperators(Context* context,
-                         QualifiedType lhs, QualifiedType rhs) {
-  std::stringstream ss;
-  lhs.type()->stringify(ss, chpl::StringifyKind::CHPL_SYNTAX);
-  auto typeName = ss.str();
-
-  auto modName = "chpl__generated_" + typeName + "_=";
-  auto baseName = UniqueString::get(context, "ChapelBase");
-  auto bld = Builder::createForGeneratedCode(context, modName.c_str(), ID(baseName, ID_GEN_START, 0), UniqueString::get(context, "ChapelBase"));
-  auto builder = bld.get();
-  auto dummyLoc = Location(UniqueString::get(context, "ChapelBase.="));
-
-  auto lhsFormal = Formal::build(builder, dummyLoc, nullptr,
-                                 UniqueString::get(context, "lhs"),
-                                 Formal::REF, nullptr, nullptr);
-  auto rhsFormal = Formal::build(builder, dummyLoc, nullptr,
-                                 UniqueString::get(context, "rhs"),
-                                 Formal::CONST, nullptr, nullptr);
-  AstList formals;
-  formals.push_back(std::move(lhsFormal));
-  formals.push_back(std::move(rhsFormal));
-
-  AstList stmts;
-  auto body = Block::build(builder, dummyLoc, std::move(stmts));
-  auto genFn = Function::build(builder,
-                               dummyLoc, {},
-                               Decl::Visibility::PUBLIC,
-                               Decl::Linkage::DEFAULT_LINKAGE,
-                               /*linkageName=*/{},
-                               USTR("="),
-                               /*inline=*/false, /*override=*/false,
-                               Function::Kind::OPERATOR,
-                               /*receiver=*/nullptr,
-                               Function::ReturnIntent::DEFAULT_RETURN_INTENT,
-                               // throws, primaryMethod, parenless
-                               false, false, false,
-                               std::move(formals),
-                               // returnType, where, lifetime, body
-                               {}, {}, {}, std::move(body));
-
-  builder->noteChildrenLocations(genFn.get(), dummyLoc);
-  builder->addToplevelExpression(std::move(genFn));
-
-  auto result = builder->result();
-
-  auto modPath = result.topLevelExpression(0)->id().symbolPath();
-  parsing::setCompilerGeneratedBuilder(context, modPath, std::move(result));
-
-  auto& br = parsing::getCompilerGeneratedBuilder(context, modPath);
-
-  return br;
-}
-
 static const TypedFnSignature* const&
 getCompilerGeneratedBinaryOpQuery(Context* context,
                                   types::QualifiedType lhs,
@@ -1421,48 +1367,6 @@ getCompilerGeneratedBinaryOpQuery(Context* context,
     } else if (rhs.type() && rhs.type()->isEnumType()) {
       result = generateCastToEnum(context, lhs, rhs);
     }
-  } else if (name == USTR("=") &&
-             lhs.type() == rhs.type() &&
-             (lhs.type()->isPrimitiveType() ||
-              lhs.type()->isTupleType() ||
-              lhs.type()->isClassType())) {
-
-    auto& br = buildAssignmentOperators(context, lhs, rhs);
-    auto assignFn = br.topLevelExpression(0)->child(0)->toFunction();
-
-    auto lhsType = QualifiedType(QualifiedType::REF, lhs.type());
-    auto rhsType = QualifiedType(QualifiedType::CONST_IN, rhs.type());
-    std::vector<QualifiedType> formalTypes = {lhsType, rhsType};
-
-    auto lhsDet =
-        UntypedFnSignature::FormalDetail(UniqueString::get(context, "lhs"),
-                                         UntypedFnSignature::DK_NO_DEFAULT, assignFn->formal(0));
-    auto rhsDet =
-        UntypedFnSignature::FormalDetail(UniqueString::get(context, "rhs"),
-                                       UntypedFnSignature::DK_NO_DEFAULT, assignFn->formal(1));
-    std::vector<UntypedFnSignature::FormalDetail> ufsFormals = {lhsDet, rhsDet};
-
-    auto ufs = UntypedFnSignature::get(context,
-                          /*id*/ assignFn->id(),
-                          /*name*/ USTR("="),
-                          /*isMethod*/ false,
-                          /*isTypeConstructor*/ false,
-                          /*isCompilerGenerated*/ true,
-                          /*throws*/ false,
-                          /*idTag*/ asttags::Function,
-                          /*kind*/ uast::Function::Kind::OPERATOR,
-                          /*formals*/ std::move(ufsFormals),
-                          /*whereClause*/ nullptr);
-
-    result = TypedFnSignature::get(context,
-                                   ufs,
-                                   std::move(formalTypes),
-                                   TypedFnSignature::WHERE_NONE,
-                                   /* needsInstantiation */ false,
-                                   /* instantiatedFrom */ nullptr,
-                                   /* parentFn */ nullptr,
-                                   /* formalsInstantiated */ Bitmap(),
-                                   /* outerVariables */ {});
   }
 
   return QUERY_END(result);

--- a/frontend/lib/resolution/default-functions.h
+++ b/frontend/lib/resolution/default-functions.h
@@ -83,6 +83,7 @@ getCompilerGeneratedBinaryOp(Context* context,
                        const types::QualifiedType rhs,
                        UniqueString name);
 
+const uast::BuilderResult& buildInitializer(Context* context, ID typeID);
 
 } // end namespace resolution
 } // end namespace chpl

--- a/frontend/lib/resolution/default-functions.h
+++ b/frontend/lib/resolution/default-functions.h
@@ -84,6 +84,7 @@ getCompilerGeneratedBinaryOp(Context* context,
                        UniqueString name);
 
 const uast::BuilderResult& buildInitializer(Context* context, ID typeID);
+const uast::BuilderResult& buildTypeConstructor(Context* context, ID typeID);
 
 } // end namespace resolution
 } // end namespace chpl

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -1517,7 +1517,7 @@ buildTypeConstructor(Context* context, ID typeID) {
 
   auto parentMod = parsing::idToParentModule(context, typeID);
   auto modName = "chpl__generated_" + parentMod.symbolName(context).str() + "_" + typeDecl->name().str();
-  auto bld = Builder::createForGeneratedCode(context, modName.c_str(), typeID, parentMod.symbolPath());
+  auto bld = Builder::createForGeneratedCode(context, modName.c_str(), typeID);
   auto builder = bld.get();
   auto dummyLoc = parsing::locateId(context, typeID);
 

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -5896,6 +5896,21 @@ CallResolutionResult resolveTheseCall(ResolutionContext* rc,
   return resolveGeneratedCall(rc->context(), astContext, ci, inScopes);
 }
 
+const BuilderResult*
+buildDefaultFunction(Context* context,
+                     UniqueString typePath,
+                     UniqueString name) {
+  auto typeID = ID(typePath);
+
+  if (name == USTR("init")) {
+    return &buildInitializer(context, typeID);
+  } else if (typeID.symbolName(context) == name) {
+    return &buildTypeConstructor(context, typeID);
+  }
+
+  return nullptr;
+}
+
 
 } // end namespace resolution
 } // end namespace chpl

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -5838,9 +5838,9 @@ CallResolutionResult resolveTheseCall(ResolutionContext* rc,
 }
 
 const BuilderResult*
-buildDefaultFunction(Context* context,
-                     UniqueString typePath,
-                     UniqueString name) {
+builderResultForDefaultFunction(Context* context,
+                                UniqueString typePath,
+                                UniqueString name) {
   auto typeID = ID(typePath);
 
   if (name == USTR("init")) {

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -3995,26 +3995,17 @@ considerCompilerGeneratedOperators(Context* context,
                                    const Scope* inScope,
                                    const PoiScope* inPoiScope,
                                    CandidatesAndForwardingInfo& candidates) {
-  if (!ci.isOpCall() || ci.numActuals() != 2) return nullptr;
-
-  // Generate assignment operators if the standard library isn't available.
-  bool generateAssign = parsing::bundledModulePath(context).isEmpty() &&
-                        ci.name() == USTR("=");
+  if (!ci.isOpCall()) return nullptr;
 
   // Avoid invoking the query if we don't need a binary operation here.
-  if (!(ci.numActuals() == 2 &&
-        (ci.name() == USTR(":") || generateAssign))) {
+  if (ci.name() != USTR(":") || ci.numActuals() != 2) {
     return nullptr;
   }
 
   auto lhsType = ci.actual(0).type();
   auto rhsType = ci.actual(1).type();
-
-  if (lhsType.type() == nullptr || rhsType.type() == nullptr) return nullptr;
-
-  if (ci.name() == USTR(":") &&
-      !lhsType.type()->isEnumType() &&
-      !rhsType.type()->isEnumType()) {
+  if (!(lhsType.type() && lhsType.type()->isEnumType()) &&
+      !(rhsType.type() && rhsType.type()->isEnumType())) {
     return nullptr;
   }
 

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -1513,11 +1513,7 @@ static const BuilderResult&
 buildTypeConstructor(Context* context, ID typeID) {
   QUERY_BEGIN(buildTypeConstructor, context, typeID);
 
-  auto typeDecl = parsing::idToAst(context, typeID)->toAggregateDecl();
-
-  auto parentMod = parsing::idToParentModule(context, typeID);
-  auto modName = "chpl__generated_" + parentMod.symbolName(context).str() + "_" + typeDecl->name().str();
-  auto bld = Builder::createForGeneratedCode(context, modName.c_str(), typeID);
+  auto bld = Builder::createForGeneratedCode(context, typeID);
   auto builder = bld.get();
   auto dummyLoc = parsing::locateId(context, typeID);
 

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -1509,84 +1509,6 @@ bool shouldIncludeFieldInTypeConstructor(Context* context,
   return false;
 }
 
-static const BuilderResult&
-buildTypeConstructor(Context* context, ID typeID) {
-  QUERY_BEGIN(buildTypeConstructor, context, typeID);
-
-  auto bld = Builder::createForGeneratedCode(context, typeID);
-  auto builder = bld.get();
-  auto dummyLoc = parsing::locateId(context, typeID);
-
-  AstList formals;
-  auto ct = initialTypeForTypeDecl(context, typeID)->getCompositeType();
-
-  if (auto bct = ct->toBasicClassType()) {
-    auto parent = bct->parentClassType();
-    if (parent && !parent->isObjectType()) {
-      auto& br = buildTypeConstructor(context, parent->id());
-      auto fn = br.topLevelExpression(0)->toFunction();
-
-      for (auto formal : fn->formals()) {
-        formals.push_back(formal->copy());
-      }
-    }
-  }
-
-  // attempt to resolve the fields
-  DefaultsPolicy defaultsPolicy = DefaultsPolicy::IGNORE_DEFAULTS;
-  const ResolvedFields& f = fieldsForTypeDecl(context, ct,
-                                              defaultsPolicy,
-                                              /* syntaxOnly */ true);
-
-  // find the generic fields from the type and add
-  // these as type constructor arguments.
-  int nFields = f.numFields();
-  for (int i = 0; i < nFields; i++) {
-    auto declId = f.fieldDeclId(i);
-    auto declAst = parsing::idToAst(context, declId);
-    CHPL_ASSERT(declAst);
-    auto fieldDecl = declAst->toVariable();
-    CHPL_ASSERT(fieldDecl);
-    QualifiedType formalType;
-    if (isFieldSyntacticallyGeneric(context, declId, nullptr)) {
-
-      auto typeExpr = fieldDecl->typeExpression();
-      auto initExpr = fieldDecl->initExpression();
-      auto kind = fieldDecl->kind() == Variable::PARAM ? Variable::PARAM : Variable::TYPE;
-      owned<AstNode> formal = Formal::build(builder, dummyLoc,
-                                            /*attributeGroup=*/nullptr,
-                                            fieldDecl->name(),
-                                            (Formal::Intent)kind,
-                                            typeExpr ? typeExpr->copy() : nullptr,
-                                            initExpr ? initExpr->copy() : nullptr);
-      formals.push_back(std::move(formal));
-    }
-  }
-
-  auto genFn = Function::build(builder, dummyLoc, {},
-                               Decl::Visibility::PUBLIC,
-                               Decl::Linkage::DEFAULT_LINKAGE,
-                               /*linkageName=*/{},
-                               ct->name(),
-                               /*inline=*/false, /*override=*/false,
-                               Function::Kind::PROC,
-                               /*receiver=*/{},
-                               Function::ReturnIntent::DEFAULT_RETURN_INTENT,
-                               // throws, primaryMethod, parenless
-                               false, false, false,
-                               std::move(formals),
-                               // returnType, where, lifetime, body
-                               {}, {}, {}, {});
-
-  builder->noteChildrenLocations(genFn.get(), dummyLoc);
-  builder->addToplevelExpression(std::move(genFn));
-
-  // Finalize the uAST and obtain the BuilderResult
-  auto res = builder->result();
-
-  return QUERY_END(res);
-}
-
 static const TypedFnSignature* const&
 typeConstructorInitialQuery(Context* context, const Type* t)
 {
@@ -5835,21 +5757,6 @@ CallResolutionResult resolveTheseCall(ResolutionContext* rc,
                      /* isParenless */ false,
                      /* actuals */ std::move(actuals));
   return resolveGeneratedCall(rc->context(), astContext, ci, inScopes);
-}
-
-const BuilderResult*
-builderResultForDefaultFunction(Context* context,
-                                UniqueString typePath,
-                                UniqueString name) {
-  auto typeID = ID(typePath);
-
-  if (name == USTR("init")) {
-    return &buildInitializer(context, typeID);
-  } else if (typeID.symbolName(context) == name) {
-    return &buildTypeConstructor(context, typeID);
-  }
-
-  return nullptr;
 }
 
 

--- a/frontend/lib/uast/Builder.cpp
+++ b/frontend/lib/uast/Builder.cpp
@@ -120,9 +120,11 @@ owned<Builder> Builder::createForIncludedModule(Context* context,
 }
 
 owned<Builder> Builder::createForGeneratedCode(Context* context,
-                                               const char* filepath,
                                                ID generatedFrom) {
-  auto uniqueFilename = UniqueString::get(context, filepath);
+  // Note: currently filePath only appears to be used when modules are
+  // involved, and generated uAST is currently expected to be a single
+  // top-level function. Locations will be set manually by caller.
+  auto uniqueFilename = UniqueString::get(context, "<dummy>");
   auto b = new Builder(context, uniqueFilename, generatedFrom.symbolPath(),
                        /* LibraryFile */ nullptr,
                        /* isGenerated=*/true);

--- a/frontend/lib/uast/Builder.cpp
+++ b/frontend/lib/uast/Builder.cpp
@@ -121,12 +121,11 @@ owned<Builder> Builder::createForIncludedModule(Context* context,
 
 owned<Builder> Builder::createForGeneratedCode(Context* context,
                                                const char* filepath,
-                                               ID generatedFrom,
-                                               UniqueString parentSymbolPath) {
+                                               ID generatedFrom) {
   auto uniqueFilename = UniqueString::get(context, filepath);
-  auto b = new Builder(context, uniqueFilename, parentSymbolPath,
+  auto b = new Builder(context, uniqueFilename, generatedFrom.symbolPath(),
                        /* LibraryFile */ nullptr,
-                       generatedFrom);
+                       /* isGenerated=*/true);
   return toOwned(b);
 }
 
@@ -335,9 +334,7 @@ void Builder::assignIDs() {
   int i = 0;
   int commentIndex = 0;
 
-  if (!generatedFrom_.isEmpty()) {
-    pathVec = ID::expandSymbolPath(context_, generatedFrom_.symbolPath());
-  } else if (!startingSymbolPath_.isEmpty()) {
+  if (!startingSymbolPath_.isEmpty()) {
     // start from the starting symbol path if it exists
     pathVec = ID::expandSymbolPath(context_, startingSymbolPath_);
   }

--- a/frontend/lib/uast/Builder.cpp
+++ b/frontend/lib/uast/Builder.cpp
@@ -494,8 +494,13 @@ void Builder::doAssignIDs(AstNode* ast, UniqueString symbolPath, int& i,
     }
 
     int numContainedIds = freshId;
-    int postOrderId = this->isGenerated() ? -3 : -1;
-    ast->setID(ID(newSymbolPath, postOrderId, numContainedIds));
+    ID id;
+    if (isGenerated()) {
+      id = ID::generatedId(newSymbolPath, -1, numContainedIds);
+    } else {
+      id = ID(newSymbolPath, -1, numContainedIds);
+    }
+    ast->setID(id);
 
     // Note: when creating a new symbol (e.g. fn), we're not incrementing i.
     // The new symbol ID has the updated path (e.g. function name)
@@ -516,10 +521,15 @@ void Builder::doAssignIDs(AstNode* ast, UniqueString symbolPath, int& i,
     }
 
     int afterChildID = i;
-    int myID = this->isGenerated() ? -4 - afterChildID : afterChildID;
     i++; // count the ID for the node we are currently visiting
     int numContainedIDs = afterChildID - firstChildID;
-    ast->setID(ID(symbolPath, myID, numContainedIDs));
+    ID id;
+    if (isGenerated()) {
+      id = ID::generatedId(symbolPath, afterChildID, numContainedIDs);
+    } else {
+      id = ID(symbolPath, afterChildID, numContainedIDs);
+    }
+    ast->setID(id);
   }
 
   // update idToAst_ for the visited AST node

--- a/frontend/lib/uast/Builder.cpp
+++ b/frontend/lib/uast/Builder.cpp
@@ -447,6 +447,15 @@ void Builder::doAssignIDs(AstNode* ast, UniqueString symbolPath, int& i,
       }
     }
 
+    // Assumption: doAssignIDs is invoked on top-level uAST with an empty
+    // string for the symbolPath. If the symbolPath is not empty, and this
+    // builder is for generated uAST, then we have violated the assumption that
+    // there is only one scope-defining symbol.
+    if (isGenerated() && !symbolPath.isEmpty()) {
+      CHPL_ASSERT(false && "generated uAST may not contain scope-defining "
+                           "symbols other than the top-level symbol");
+    }
+
     int repeat = 0;
     auto search = duplicates.find(declName);
     if (search != duplicates.end()) {

--- a/frontend/lib/uast/Builder.cpp
+++ b/frontend/lib/uast/Builder.cpp
@@ -219,7 +219,9 @@ void Builder::noteSymbolTableSymbols(SymbolTableVec vec) {
 }
 
 BuilderResult Builder::result() {
-  this->createImplicitModuleIfNeeded();
+  if (isGenerated() == false) {
+    this->createImplicitModuleIfNeeded();
+  }
   this->assignIDs();
 
   // if we have a symbolTableVec, use it to compute
@@ -333,14 +335,17 @@ void Builder::assignIDs() {
   int i = 0;
   int commentIndex = 0;
 
-  if (!startingSymbolPath_.isEmpty()) {
+  if (!generatedFrom_.isEmpty()) {
+    pathVec = ID::expandSymbolPath(context_, generatedFrom_.symbolPath());
+  } else if (!startingSymbolPath_.isEmpty()) {
     // start from the starting symbol path if it exists
     pathVec = ID::expandSymbolPath(context_, startingSymbolPath_);
   }
 
   for (auto const& ownedExpression: br.topLevelExpressions_) {
     AstNode* ast = ownedExpression.get();
-    if (ast->isModule() || ast->isComment()) {
+    bool isModuleOrComment = ast->isModule() || ast->isComment();
+    if (isGenerated() || isModuleOrComment) {
       UniqueString emptyString;
       doAssignIDs(ast, emptyString, i, commentIndex, pathVec, duplicates);
     } else {

--- a/frontend/lib/uast/BuilderResult.cpp
+++ b/frontend/lib/uast/BuilderResult.cpp
@@ -44,9 +44,8 @@ BuilderResult::BuilderResult()
 
 
 BuilderResult::BuilderResult(UniqueString filePath,
-                             const libraries::LibraryFile* lib,
-                             ID generatedFrom)
-  : filePath_(filePath), libraryFile_(lib), generatedFrom_(generatedFrom)
+                             const libraries::LibraryFile* lib)
+  : filePath_(filePath), libraryFile_(lib)
 {
 }
 
@@ -99,7 +98,6 @@ void BuilderResult::swap(BuilderResult& other) {
 
   std::swap(libraryFile_, other.libraryFile_);
   libraryFileSymbols_.swap(other.libraryFileSymbols_);
-  generatedFrom_.swap(other.generatedFrom_);
 }
 
 bool BuilderResult::update(BuilderResult& keep, BuilderResult& addin) {
@@ -120,11 +118,6 @@ bool BuilderResult::update(BuilderResult& keep, BuilderResult& addin) {
     computeIdMaps(ast.get(), nullptr, newIdToAst, newIdToParent);
   }
 
-  if (!addin.generatedFrom_.isEmpty()) {
-    // Assumption: single top-level expression that is a module
-    newIdToParent[keep.topLevelExpression(0)->id()] = addin.generatedFrom_;
-  }
-
   // now update the ID and Locations maps in keep
   changed |= defaultUpdate(keep.idToAst_, newIdToAst);
   changed |= defaultUpdate(keep.idToParentId_, newIdToParent);
@@ -143,7 +136,6 @@ bool BuilderResult::update(BuilderResult& keep, BuilderResult& addin) {
                            addin.commentIdToLocation_);
   changed |= defaultUpdateBasic(keep.libraryFile_, addin.libraryFile_);
   changed |= defaultUpdate(keep.libraryFileSymbols_, addin.libraryFileSymbols_);
-  changed |= defaultUpdate(keep.generatedFrom_, addin.generatedFrom_);
 
   return changed;
 }
@@ -192,8 +184,6 @@ void BuilderResult::mark(Context* context) const {
 
   // libraryFileSymbols_ only has IDs that should have been marked above
   (void) libraryFileSymbols_;
-
-  generatedFrom_.mark(context);
 
   // update the filePathForModuleName query
   BuilderResult::updateFilePaths(context, *this);

--- a/frontend/test/framework/testIds.cpp
+++ b/frontend/test/framework/testIds.cpp
@@ -231,12 +231,35 @@ static void test4() {
   checkFromString(context, id3a);
 }
 
+static void testGenerated() {
+  Context ctx;
+  Context* context = &ctx;
+
+  auto path = UniqueString::get(context, "MyMod.MyType.foo");
+  ID root = ID::generatedId(path, -1, 0);
+  assert(root.postOrderId() == -1);
+  assert(root.isFabricatedId());
+  assert(root.fabricatedIdKind() == ID::FabricatedIdKind::Generated);
+
+  ID child = ID::generatedId(path, 5, 0);
+  assert(child.postOrderId() == 5);
+  assert(child.isFabricatedId());
+  assert(child.fabricatedIdKind() == ID::FabricatedIdKind::Generated);
+  assert(child.parentSymbolId(context) == root);
+
+  ID type = ID(UniqueString::get(context, "MyMod.MyType"), -1, 0);
+  ID parent = root.parentSymbolId(context);
+  assert(type == parent);
+  assert(parent.isFabricatedId() == false);
+}
+
 
 int main() {
   test1();
   test2();
   test3();
   test4();
+  testGenerated();
 
   return 0;
 }

--- a/frontend/test/resolution/testClasses.cpp
+++ b/frontend/test/resolution/testClasses.cpp
@@ -134,6 +134,7 @@ static void test3() {
   printf("test3\n");
 
   std::string program = R"""(
+    operator =(ref lhs: int, const rhs: int) {}
     class C {
       var a, b : int;
     }
@@ -165,6 +166,7 @@ static void test4() {
   ErrorGuard guard(context);
 
   std::string program = R"""(
+    operator =(ref lhs: 2*int, const rhs : 2*int) {}
     class Bar {
       param rank : int;
       var myTup : rank*int;

--- a/frontend/test/resolution/testConstChecking.cpp
+++ b/frontend/test/resolution/testConstChecking.cpp
@@ -294,18 +294,20 @@ static void test6a() {
   testConstChecking("test6a",
     R""""(
       module M {
+        operator =(ref lhs: int, const rhs: int) {}
         proc test() {
           const x: int = 0;
           x = 34;
         }
       }
     )"""",
-    {5});
+    {6});
 }
 static void test6b() {
   testConstChecking("test6b",
     R""""(
       module M {
+        operator =(ref lhs: int, const rhs: int) {}
         proc test() {
           const x: int = 0;
           const ref y = x;
@@ -313,12 +315,13 @@ static void test6b() {
         }
       }
     )"""",
-    {6});
+    {7});
 }
 static void test6c() {
   testConstChecking("test6c",
     R""""(
       module M {
+        operator =(ref lhs: int, const rhs: int) {}
         proc test() {
           const x: int = 0;
           ref y = x;
@@ -326,7 +329,7 @@ static void test6c() {
         }
       }
     )"""",
-    {5});
+    {6});
 }
 
 static void test7a() {

--- a/frontend/test/resolution/testCopyElision.cpp
+++ b/frontend/test/resolution/testCopyElision.cpp
@@ -46,7 +46,10 @@ static void testCopyElision(const char* test,
   std::string testname = test;
   testname += ".chpl";
   auto path = UniqueString::get(context, testname);
-  std::string contents = program;
+  std::string contents = "module M {\n";
+  contents += "operator =(ref lhs: int, const rhs: int){}\n";
+  contents += program;
+  contents += "\n}";
   setFileText(context, path, contents);
 
   const ModuleVec& vec = parseToplevel(context, path);
@@ -132,12 +135,10 @@ static void testCopyElision(const char* test,
 static void test1() {
   testCopyElision("test1",
     R""""(
-      module M {
 
         proc test() {
           var x:int = 0;
         }
-      }
     )"""",
     {});
 }
@@ -145,13 +146,11 @@ static void test1() {
 static void test2() {
   testCopyElision("test2",
     R""""(
-      module M {
 
         proc test() {
           var x;
           x = 1;
         }
-      }
     )"""",
     {});
 }
@@ -159,12 +158,10 @@ static void test2() {
 static void test3() {
   testCopyElision("test3",
     R""""(
-      module M {
         proc test() {
           var x:int;
           var y = x;
         }
-      }
     )"""",
     {"M.test@3"});
 }
@@ -173,14 +170,12 @@ static void test3() {
 static void test4() {
   testCopyElision("test4",
     R""""(
-      module M {
 
         proc test() {
           var x:int;
           var y = x;
           x;
         }
-      }
     )"""",
     {});
 }
@@ -188,7 +183,6 @@ static void test4() {
 static void test5() {
   testCopyElision("test5",
     R""""(
-      module M {
         proc test(cond: bool) {
           var x:int;
           if cond {
@@ -197,7 +191,6 @@ static void test5() {
           }
           x;
         }
-      }
     )"""",
     {"M.test@6"});
 }
@@ -205,7 +198,6 @@ static void test5() {
 static void test6() {
   testCopyElision("test6",
     R""""(
-      module M {
         proc test(cond: bool) {
           var x:int;
           var y;
@@ -215,7 +207,6 @@ static void test6() {
             y = x;
           }
         }
-      }
     )"""",
     {"M.test@8", "M.test@12"});
 }
@@ -223,12 +214,10 @@ static void test6() {
 static void test7() {
   testCopyElision("test7",
     R""""(
-      module M {
         proc test() {
           var i: int;
           ref r = i;
         }
-      }
     )"""",
     {});
 }
@@ -236,13 +225,11 @@ static void test7() {
 static void test8() {
   testCopyElision("test8",
     R""""(
-      module M {
         proc test() {
           var i: int;
           ref r = i;
           ref rr = r;
         }
-      }
     )"""",
     {});
 }
@@ -250,13 +237,11 @@ static void test8() {
 static void test9() {
   testCopyElision("test9",
     R""""(
-      module M {
         proc fIn(arg: int) { }
         proc test() {
           var x:int;
           fIn(x);
         }
-      }
     )"""",
     {"M.test@3"});
 }
@@ -264,14 +249,12 @@ static void test9() {
 static void test10() {
   testCopyElision("test10",
     R""""(
-      module M {
         proc fIn(arg: int) { }
         proc test() {
           var x:int;
           fIn(x);
           x;
         }
-      }
     )"""",
     {});
 }
@@ -279,13 +262,11 @@ static void test10() {
 static void test11() {
   testCopyElision("test11",
     R""""(
-      module M {
         proc test() {
           var x:int;
           var y;
           y = x;
         }
-      }
     )"""",
     {"M.test@5"});
 }
@@ -293,7 +274,6 @@ static void test11() {
 static void test12() {
   testCopyElision("test12",
     R""""(
-      module M {
 
         proc test() {
           var x:int;
@@ -301,7 +281,6 @@ static void test12() {
           y = x;
           y = x;
         }
-      }
     )"""",
     {});
 }
@@ -309,7 +288,6 @@ static void test12() {
 static void test13() {
   testCopyElision("test13",
     R""""(
-      module M {
 
         proc test(cond: bool) {
           var x:int;
@@ -317,7 +295,6 @@ static void test13() {
             var y = x;
           }
         }
-      }
     )"""",
     {});
 }
@@ -325,7 +302,6 @@ static void test13() {
 static void test14() {
   testCopyElision("test14",
     R""""(
-      module M {
         proc test(cond: bool) {
           var x:int;
           var y;
@@ -335,7 +311,6 @@ static void test14() {
             y = x;
           }
         }
-      }
     )"""",
     {"M.test@10"});
 }
@@ -343,7 +318,6 @@ static void test14() {
 static void test15() {
   testCopyElision("test15",
     R""""(
-      module M {
         proc test(cond: bool) {
           var x:int;
           var y;
@@ -353,7 +327,6 @@ static void test15() {
             return;
           }
         }
-      }
     )"""",
     {"M.test@8"});
 }
@@ -361,14 +334,12 @@ static void test15() {
 static void test16() {
   testCopyElision("test16",
     R""""(
-      module M {
         proc test() throws {
           var x:int;
           try {
             var y = x;
           }
         }
-      }
     )"""",
     {"M.test@3"});
 }
@@ -376,7 +347,6 @@ static void test16() {
 static void test17() {
   testCopyElision("test17",
     R""""(
-      module M {
 
         proc test() {
           var x:int;
@@ -386,7 +356,6 @@ static void test17() {
           } catch {
           }
         }
-      }
     )"""",
     {});
 }
@@ -394,7 +363,6 @@ static void test17() {
 static void test18() {
   testCopyElision("test18",
     R""""(
-      module M {
 
         proc test() {
           var x:int;
@@ -405,7 +373,6 @@ static void test18() {
             y;
           }
         }
-      }
     )"""",
     {});
 }
@@ -413,7 +380,6 @@ static void test18() {
 static void test19() {
   testCopyElision("test19",
     R""""(
-      module M {
         proc test() {
           var x:int;
           var y;
@@ -423,7 +389,6 @@ static void test19() {
             return;
           }
         }
-      }
     )"""",
     {"M.test@5"});
 }
@@ -431,7 +396,6 @@ static void test19() {
 static void test20() {
   testCopyElision("test20",
     R""""(
-      module M {
 
         proc test() {
           var x:int;
@@ -442,7 +406,6 @@ static void test20() {
             y = x;
           }
         }
-      }
     )"""",
     {});
 }
@@ -450,7 +413,6 @@ static void test20() {
 static void test21() {
   testCopyElision("test21",
     R""""(
-      module M {
 
         proc test() {
           var x:int;
@@ -460,7 +422,6 @@ static void test21() {
             y = x;
           }
         }
-      }
     )"""",
     {});
 }
@@ -468,7 +429,6 @@ static void test21() {
 static void test22() {
   testCopyElision("test22",
     R""""(
-      module M {
         proc test() {
           try {
           } catch {
@@ -476,7 +436,6 @@ static void test22() {
             var y = x;
           }
         }
-      }
     )"""",
     {"M.test@4"});
 }
@@ -484,14 +443,12 @@ static void test22() {
 static void test23() {
   testCopyElision("test23",
     R""""(
-      module M {
         record R {
           var field: int;
         }
         proc R.test() {
           var x = field;
         }
-      }
     )"""",
     {});
 }
@@ -500,10 +457,8 @@ static void test24() {
   // module scope variables aren't subject to copy elision
   testCopyElision("test24",
     R""""(
-      module M {
         var x: int;
         var y = x;
-      }
     )"""",
     {},
     /* resolveModule */ true);
@@ -513,12 +468,10 @@ static void test25() {
   // module scope variables aren't subject to copy elision
   testCopyElision("test25",
     R""""(
-      module M {
         var x: int;
         proc test() {
           var y = x;
         }
-      }
     )"""",
     {});
 }
@@ -528,7 +481,6 @@ static void test25() {
 static void test26() {
   testCopyElision("test26",
     R""""(
-      module M {
 
         proc test() {
           var x: int;
@@ -537,7 +489,6 @@ static void test26() {
           z = x;
           z = y;
         }
-      }
     )"""",
     {"M.test@7"});
 }
@@ -545,7 +496,6 @@ static void test26() {
 static void test27() {
   testCopyElision("test27",
     R""""(
-      module M {
 
         proc test() {
           var x: int;
@@ -556,7 +506,6 @@ static void test27() {
           }
           z = y;
         }
-      }
     )"""",
     {"M.test@7"});
 }
@@ -564,7 +513,6 @@ static void test27() {
 static void test28() {
   testCopyElision("test28",
     R""""(
-      module M {
 
         config const cond = true;
 
@@ -579,7 +527,6 @@ static void test28() {
           }
           z = c;
         }
-      }
     )"""",
     {"M.test@8", "M.test@12"});
 }
@@ -587,7 +534,6 @@ static void test28() {
 static void test29() {
   testCopyElision("test29",
     R""""(
-      module M {
 
         config const cond = true;
 
@@ -602,7 +548,6 @@ static void test29() {
           }
           z = b;
         }
-      }
     )"""",
     {"M.test@7"});
 }
@@ -611,46 +556,38 @@ static void test29() {
 static void test30() {
   testCopyElision("test30",
     R""""(
-      module M {
         proc test(out x: int) {
           var y = x;
           return;
         }
-      }
     )"""",
     {});
 }
 static void test31() {
   testCopyElision("test31",
     R""""(
-      module M {
         proc test(out x: int) {
           var y = x;
         }
-      }
     )"""",
     {});
 }
 static void test32() {
   testCopyElision("test32",
     R""""(
-      module M {
         proc test(inout x: int) {
           var y = x;
           return;
         }
-      }
     )"""",
     {});
 }
 static void test33() {
   testCopyElision("test33",
     R""""(
-      module M {
         proc test(inout x: int) {
           var y = x;
         }
-      }
     )"""",
     {});
 }
@@ -658,7 +595,6 @@ static void test33() {
 static void test34() {
   testCopyElision("test34",
     R""""(
-      module M {
 
         config const cond = true;
 
@@ -673,7 +609,6 @@ static void test34() {
           }
           z = c;
         }
-      }
     )"""",
     {"M.test@8"});
 }
@@ -681,7 +616,6 @@ static void test34() {
 static void test35() {
   testCopyElision("test35a1",
     R""""(
-      module M {
         config const cond = true;
         proc test() {
           var x: int = 0;
@@ -689,12 +623,10 @@ static void test35() {
           type T = real;
           {x;}
         }
-      }
     )"""",
     {});
   testCopyElision("test35a2",
     R""""(
-      module M {
         config const cond = true;
         proc test() {
           var x: int = 0;
@@ -706,13 +638,11 @@ static void test35() {
             x;
           }
         }
-      }
     )"""",
     {});
   
   testCopyElision("test35a",
     R""""(
-      module M {
 
         proc test() {
           var x: int = 0;
@@ -724,12 +654,10 @@ static void test35() {
             x;
           }
         }
-      }
     )"""",
     {});
   testCopyElision("test35b",
     R""""(
-      module M {
 
         proc test() {
           var x: int = 0;
@@ -741,7 +669,6 @@ static void test35() {
             x;
           }
         }
-      }
     )"""",
     {"M.test@4"});
 }
@@ -749,7 +676,6 @@ static void test35() {
 static void test36() {
   testCopyElision("test36a",
     R""""(
-      module M {
 
         proc test() {
           var x: int = 0;
@@ -759,12 +685,10 @@ static void test36() {
             y;
           }
         }
-      }
     )"""",
     {"M.test@4"});
   testCopyElision("test36b",
     R""""(
-      module M {
 
         proc test() {
           var x: int = 0;
@@ -774,12 +698,10 @@ static void test36() {
             x;
           }
         }
-      }
     )"""",
     {"M.test@4"});
   testCopyElision("test36c",
     R""""(
-      module M {
 
         proc test() {
           var x: int = 0;
@@ -789,12 +711,10 @@ static void test36() {
             y;
           }
         }
-      }
     )"""",
     {"M.test@4"});
   testCopyElision("test36d",
     R""""(
-      module M {
 
         proc test() {
           var x: int = 0;
@@ -804,7 +724,6 @@ static void test36() {
             x;
           }
         }
-      }
     )"""",
     {});
 }
@@ -812,7 +731,6 @@ static void test36() {
 static void test37() {
   testCopyElision("test37a",
     R""""(
-      module M {
 
         proc test() {
           var x: int = 0;
@@ -824,12 +742,10 @@ static void test37() {
             otherwise do x;
           }
         }
-      }
     )"""",
     {"M.test@4"});
   testCopyElision("test37b",
     R""""(
-      module M {
 
         proc test() {
           var x: int = 0;
@@ -841,12 +757,10 @@ static void test37() {
             otherwise do x;
           }
         }
-      }
     )"""",
     {});
   testCopyElision("test37c",
     R""""(
-      module M {
 
         proc test() {
           var x: int = 0;
@@ -858,7 +772,6 @@ static void test37() {
             otherwise do x;
           }
         }
-      }
     )"""",
     {});
 }
@@ -866,7 +779,6 @@ static void test37() {
 static void test38() {
   testCopyElision("test38a",
     R""""(
-      module M {
 
         proc test() {
           var x: int = 0;
@@ -877,12 +789,10 @@ static void test38() {
             when real do y;
           }
         }
-      }
     )"""",
     {"M.test@4"});
   testCopyElision("test38b",
     R""""(
-      module M {
 
         proc test() {
           var x: int = 0;
@@ -893,12 +803,10 @@ static void test38() {
             when real do y;
           }
         }
-      }
     )"""",
     {});
   testCopyElision("test38c",
     R""""(
-      module M {
 
         proc test() {
           var x: int = 0;
@@ -909,7 +817,6 @@ static void test38() {
             when real do y;
           }
         }
-      }
     )"""",
     {"M.test@4"});
 }
@@ -917,7 +824,6 @@ static void test38() {
 static void test39() {
   testCopyElision("test39a",
     R""""(
-      module M {
 
         proc test() {
           var x: int = 0;
@@ -931,12 +837,10 @@ static void test39() {
             when real do y;
           }
         }
-      }
     )"""",
     {"M.test@4"});
   testCopyElision("test39b",
     R""""(
-      module M {
 
         proc test() {
           var x: int = 0;
@@ -950,12 +854,10 @@ static void test39() {
             when real do y;
           }
         }
-      }
     )"""",
     {"M.test@4"});
   testCopyElision("test39c",
     R""""(
-      module M {
         config const cond = true;
         proc test() {
           var x: int = 0;
@@ -975,12 +877,10 @@ static void test39() {
             }
           }
         }
-      }
     )"""",
     {});
   testCopyElision("test39d",
     R""""(
-      module M {
         config const cond = true;
         proc test() {
           var x: int = 0;
@@ -1000,7 +900,6 @@ static void test39() {
             }
           }
         }
-      }
     )"""",
     {"M.test@4"});
 }
@@ -1008,7 +907,6 @@ static void test39() {
 static void test40() {
   testCopyElision("test40a",
     R""""(
-      module M {
 
         proc test() {
           var x: int = 0;
@@ -1019,12 +917,10 @@ static void test40() {
             x;
           }
         }
-      }
     )"""",
     {});
   testCopyElision("test40b",
     R""""(
-      module M {
 
         proc test() {
           var x: int = 0;
@@ -1037,12 +933,10 @@ static void test40() {
 
 
         }
-      }
     )"""",
     {"M.test@4"});
   testCopyElision("test40c",
     R""""(
-      module M {
 
         proc test() {
           var x: int = 0;
@@ -1056,12 +950,10 @@ static void test40() {
           }
 
         }
-      }
     )"""",
     {"M.test@4"});
   testCopyElision("test40d",
     R""""(
-      module M {
 
         proc test() {
           var x: int = 0;
@@ -1073,12 +965,10 @@ static void test40() {
             return;
           }
         }
-      }
     )"""",
     {});
   testCopyElision("test40e",
     R""""(
-      module M {
 
         proc test() {
           var x: int = 0;
@@ -1090,12 +980,10 @@ static void test40() {
           }
 
         }
-      }
     )"""",
     {});
   testCopyElision("test40e",
     R""""(
-      module M {
 
         proc test() {
           var x: int = 0;
@@ -1107,12 +995,10 @@ static void test40() {
           }
 
         }
-      }
     )"""",
     {"M.test@4"});
   testCopyElision("test40f",
     R""""(
-      module M {
 
         proc test() {
           var x: int = 0;
@@ -1124,7 +1010,6 @@ static void test40() {
           }
           x;
           }
-      }
     )"""",
     {});
 }
@@ -1132,7 +1017,6 @@ static void test40() {
 static void test41() {
   testCopyElision("test41a",
     R""""(
-      module M {
         operator ==(ref lhs: int, rhs: int) {
           __primitive("==", lhs, rhs);
         }
@@ -1150,12 +1034,10 @@ static void test41() {
             }
           }
         }
-      }
     )"""",
     {});
   testCopyElision("test41b",
     R""""(
-      module M {
         operator ==(ref lhs: int, rhs: int) {
           __primitive("==", lhs, rhs);
         }
@@ -1176,7 +1058,6 @@ static void test41() {
             }
           }
         }
-      }
     )"""",
     {});
 }
@@ -1184,7 +1065,6 @@ static void test41() {
 static void test42() {
   testCopyElision("test42a",
     R""""(
-      module M {
         operator ==(ref lhs: int, rhs: int) {
           __primitive("==", lhs, rhs);
         }
@@ -1202,12 +1082,10 @@ static void test42() {
             }
           }
         }
-      }
     )"""",
     {});
   testCopyElision("test42b",
     R""""(
-      module M {
         operator ==(ref lhs: int, rhs: int) {
           __primitive("==", lhs, rhs);
         }
@@ -1225,7 +1103,6 @@ static void test42() {
             }
           }
         }
-      }
     )"""",
     {"M.test@12","M.test@18"});
 }
@@ -1233,7 +1110,6 @@ static void test42() {
 static void test43() {
   testCopyElision("test43a",
     R""""(
-      module M {
         operator ==(ref lhs: int, rhs: int) {
           __primitive("==", lhs, rhs);
         }
@@ -1251,12 +1127,10 @@ static void test43() {
             }
           }
         }
-      }
     )"""",
     {});
   testCopyElision("test43b",
     R""""(
-      module M {
         operator ==(ref lhs: int, rhs: int) {
           __primitive("==", lhs, rhs);
         }
@@ -1277,7 +1151,6 @@ static void test43() {
             }
           }
         }
-      }
     )"""",
     {"M.test@7"});
 }

--- a/frontend/test/resolution/testForwarding.cpp
+++ b/frontend/test/resolution/testForwarding.cpp
@@ -133,6 +133,7 @@ static void test4() {
   const char* contents =
     R""""(
     module M {
+      operator =(ref lhs: int, rhs: int) {}
       operator +=(ref lhs: int, rhs: int) { }
       record Inner {
         var i: int;
@@ -167,6 +168,7 @@ static void test5a() {
   const char* contents =
     R""""(
     module M {
+      operator =(ref lhs: int, rhs: int) {}
       operator +=(ref lhs: int, rhs: int) { }
       record Inner1 {
         var i: int;
@@ -205,6 +207,7 @@ static void test5b() {
   const char* contents =
     R""""(
     module M {
+      operator =(ref lhs: int, rhs: int) {}
       operator +=(ref lhs: int, rhs: int) { }
       record Inner1 {
         var i: int;
@@ -253,6 +256,7 @@ static void test6a() {
   const char* contents =
     R""""(
     module M {
+      operator =(ref lhs: int, rhs: int) {}
       operator +=(ref lhs: int, rhs: int) { }
       record Inner1 {
         var i: int;
@@ -305,6 +309,7 @@ static void test6b() {
   const char* contents =
     R""""(
     module M {
+      operator =(ref lhs: int, rhs: int) {}
       operator +=(ref lhs: int, rhs: int) { }
       record Inner1 {
         var i: int;

--- a/frontend/test/resolution/testInitSemantics.cpp
+++ b/frontend/test/resolution/testInitSemantics.cpp
@@ -28,6 +28,8 @@
 #define TEST_NAME(ctx__) TEST_NAME_FROM_FN_NAME(ctx__)
 
 std::string otherOps = R"""(
+    operator =(ref lhs: int, rhs: int) {}
+    operator =(ref lhs: real, rhs: real) {}
     operator >(ref lhs: int, rhs: int) {
       return __primitive(">", lhs, rhs);
     }
@@ -39,7 +41,7 @@ static void testFieldUseBeforeInit1(void) {
   ErrorGuard guard(ctx);
 
   auto path = TEST_NAME(ctx);
-  std::string contents = R""""(
+  std::string contents = otherOps + R""""(
     record r {
       var x: int;
     }
@@ -73,7 +75,7 @@ static void testFieldUseBeforeInit1(void) {
   // Check the first error to see if it lines up.
   auto& msg = guard.errors()[0];
   assert(msg->message() == "'x' is used before it is initialized");
-  assert(msg->location(ctx).firstLine() == 7);
+  assert(msg->location(ctx).firstLine() == 13);
   assert(guard.realizeErrors());
 }
 
@@ -83,7 +85,7 @@ static void testInitReturnVoid(void) {
   ErrorGuard guard(ctx);
 
   auto path = TEST_NAME(ctx);
-  std::string contents = R""""(
+  std::string contents = otherOps + R""""(
     record r {
       var x: int;
     }
@@ -111,7 +113,7 @@ static void testInitReturnVoid(void) {
   // Check the error (which comes last) to see if it lines up.
   auto& msg = guard.errors().back();
   assert(msg->message() == "initializers can only return 'void'");
-  assert(msg->location(ctx).firstLine() == 8);
+  assert(msg->location(ctx).firstLine() == 14);
   assert(guard.realizeErrors());
 }
 
@@ -121,7 +123,7 @@ static void testInitReturnEarly(void) {
   ErrorGuard guard(ctx);
 
   auto path = TEST_NAME(ctx);
-  std::string contents = R""""(
+  std::string contents = otherOps + R""""(
     record r {
       var x: int;
     }
@@ -149,7 +151,7 @@ static void testInitReturnEarly(void) {
   // Check the first error to see if it lines up.
   auto& msg = guard.errors()[0];
   assert(msg->message() == "cannot return from initializer before initialization is complete");
-  assert(msg->location(ctx).firstLine() == 7);
+  assert(msg->location(ctx).firstLine() == 13);
   assert(guard.realizeErrors());
 }
 
@@ -159,7 +161,7 @@ static void testInitThrow(void) {
   ErrorGuard guard(ctx);
 
   auto path = TEST_NAME(ctx);
-  std::string contents = R""""(
+  std::string contents = otherOps + R""""(
     record r {
       var x: int;
     }
@@ -187,7 +189,7 @@ static void testInitThrow(void) {
   // Check the first error to see if it lines up.
   auto& msg = guard.errors()[0];
   assert(msg->message() == "initializers are not yet allowed to throw errors");
-  assert(msg->location(ctx).firstLine() == 8);
+  assert(msg->location(ctx).firstLine() == 14);
   assert(guard.realizeErrors());
 }
 
@@ -197,7 +199,7 @@ static void testInitTryBang(void) {
   ErrorGuard guard(ctx);
 
   auto path = TEST_NAME(ctx);
-  std::string contents = R""""(
+  std::string contents = otherOps + R""""(
     record r {
       var x: int;
     }
@@ -226,7 +228,7 @@ static void testInitTryBang(void) {
   // Check the first error to see if it lines up.
   auto& msg = guard.errors()[0];
   assert(msg->message() == "Only catch-less try! statements are allowed in initializers for now");
-  assert(msg->location(ctx).firstLine() == 8);
+  assert(msg->location(ctx).firstLine() == 14);
   assert(guard.realizeErrors());
 }
 
@@ -255,7 +257,7 @@ static void testInitInsideLoops(void) {
     ErrorGuard guard(ctx);
 
     auto path = TEST_NAME(ctx);
-    std::string contents = R""""(
+    std::string contents = otherOps + R""""(
       record r {
         var x: int;
       }
@@ -282,7 +284,7 @@ static void testInitInsideLoops(void) {
     // Check the error (which comes last) to see if it lines up.
     auto& msg = guard.errors().back();
     assert(msg->message() == message);
-    assert(msg->location(ctx).firstLine() == 7);
+    assert(msg->location(ctx).firstLine() == 13);
     assert(guard.realizeErrors());
   }
 }
@@ -293,9 +295,9 @@ static void testThisComplete(void) {
   ErrorGuard guard(ctx);
 
   auto path = TEST_NAME(ctx);
-  std::string contents = R""""(
+  std::string contents = otherOps + R""""(
     record r {
-      var x: int;
+      var x : int;
       var y : int;
       var z : int;
     }
@@ -327,7 +329,7 @@ static void testSecondAssign(void) {
   ErrorGuard guard(ctx);
 
   auto path = TEST_NAME(ctx);
-  std::string contents = R""""(
+  std::string contents = otherOps + R""""(
     record r {
       var x: int;
     }
@@ -358,7 +360,7 @@ static void testOutOfOrder(void) {
   ErrorGuard guard(ctx);
 
   auto path = TEST_NAME(ctx);
-  std::string contents = R""""(
+  std::string contents = otherOps + R""""(
     record r {
       var x, y, z: int;
     }
@@ -384,7 +386,7 @@ static void testOutOfOrder(void) {
 
   auto& msg = guard.errors()[0];
   assert(msg->message() == "Field \"x\" initialized out of order");
-  assert(msg->location(ctx).firstLine() == 7);
+  assert(msg->location(ctx).firstLine() == 13);
   assert(guard.realizeErrors());
 }
 
@@ -394,7 +396,7 @@ static void testInitCondBasic(void) {
   ErrorGuard guard(ctx);
 
   auto path = TEST_NAME(ctx);
-  std::string contents = R""""(
+  std::string contents = otherOps + R""""(
     record r {
       var x: int;
       var y : int;
@@ -433,7 +435,7 @@ static void testInitCondBadOrder(void) {
   ErrorGuard guard(ctx);
 
   auto path = TEST_NAME(ctx);
-  std::string contents = R""""(
+  std::string contents = otherOps + R""""(
     record r {
       var x: int;
       var y : int;
@@ -466,12 +468,12 @@ static void testInitCondBadOrder(void) {
   {
     auto& msg = guard.errors()[0];
     assert(msg->message() == "Field \"x\" initialized out of order");
-    assert(msg->location(ctx).firstLine() == 10);
+    assert(msg->location(ctx).firstLine() == 16);
   }
   {
     auto& msg = guard.errors()[1];
     assert(msg->message() == "Field \"y\" initialized out of order");
-    assert(msg->location(ctx).firstLine() == 12);
+    assert(msg->location(ctx).firstLine() == 18);
   }
   assert(guard.realizeErrors());
 }
@@ -1115,7 +1117,7 @@ static void testAssignThenInit(void) {
 }
 
 static void testUseAfterInit() {
-  std::string program = R"""(
+  std::string program = otherOps + R"""(
     operator *(const ref lhs: real, const rhs : int) : real {
       var ret : real;
       return ret;
@@ -1150,7 +1152,7 @@ static void testInitEqOther(void) {
   Context* ctx = &context;
   ErrorGuard guard(ctx);
 
-  std::string program = R"""(
+  std::string program = otherOps + R"""(
     record R {
       type T;
       var field : T;
@@ -1319,7 +1321,7 @@ static void testInheritance() {
     Context* context = &ctx;
     ErrorGuard guard(context);
 
-    std::string program = R"""(
+    std::string program = otherOps + R"""(
       class Parent { var x : int; }
       class Child : Parent { var y : real; }
 
@@ -1343,7 +1345,7 @@ static void testInheritance() {
     Context* context = &ctx;
     ErrorGuard guard(context);
 
-    std::string program = R"""(
+    std::string program = otherOps + R"""(
       class Parent { var x : int; }
       class Child : Parent { var y : real; }
 
@@ -1496,7 +1498,7 @@ static void testInheritance() {
     Context* context = &ctx;
     ErrorGuard guard(context);
 
-    std::string program = R"""(
+    std::string program = otherOps + R"""(
       class A {
         type TA;
         var a : TA;
@@ -1623,7 +1625,7 @@ static void testImplicitSuperInit() {
   // Ensure we resolve the body of implicit super.init() calls
   {
     // use 'test' to ensure 'q' has the right type
-    std::string program = R"""(
+    std::string program = otherOps + R"""(
       proc test(arg: uint) {}
 
       class A {
@@ -1683,7 +1685,7 @@ static void testImplicitSuperInit() {
 static void testInitGenericAfterConcrete() {
   // With generic var initialized properly
   {
-    std::string program = R"""(
+    std::string program = otherOps + R"""(
       record Foo {
         var a:int;
         var b;
@@ -1707,7 +1709,7 @@ static void testInitGenericAfterConcrete() {
 
   // With generic var not initialized, so not enough info
   {
-    std::string program = R"""(
+    std::string program = otherOps + R"""(
       record Foo {
         var a:int;
         var b;

--- a/frontend/test/resolution/testMaybeConst.cpp
+++ b/frontend/test/resolution/testMaybeConst.cpp
@@ -278,6 +278,7 @@ static void test3h() {
   testMaybeRef("test3h",
     R""""(
       module M {
+        operator =(ref lhs: int, rhs: int) {}
         var global: int;
         proc foo() ref { return global; }         // M.foo
         proc foo() const ref { return global; }   // M.foo#1
@@ -295,6 +296,7 @@ static void test3i() {
   testMaybeRef("test3i",
     R""""(
       module M {
+        operator =(ref lhs: int, rhs: int) {}
         var global: int;
         proc foo() ref { return global; }         // M.foo
         proc foo() const ref { return global; }   // M.foo#1
@@ -428,6 +430,7 @@ static void test4h() {
   testMaybeRef("test4h",
     R""""(
       module M {
+        operator =(ref lhs: int, rhs: int) {}
         var global: int;
         proc foo() ref { return global; }         // M.foo
         proc foo() { return global; }             // M.foo#1
@@ -445,6 +448,7 @@ static void test4i() {
   testMaybeRef("test4i",
     R""""(
       module M {
+        operator =(ref lhs: int, rhs: int) {}
         var global: int;
         proc foo() ref { return global; }         // M.foo
         proc foo() { return global; }             // M.foo#1
@@ -739,6 +743,7 @@ static void test6h() {
   testMaybeRef("test6h",
     R""""(
       module M {
+        operator =(ref lhs: int, rhs: int) {}
         var global: int;
         proc foo() const ref { return global; }     // M.foo
         proc foo() { return global; }               // M.foo#1
@@ -757,6 +762,7 @@ static void test6i() {
   testMaybeRef("test6i",
     R""""(
       module M {
+        operator =(ref lhs: int, rhs: int) {}
         var global: int;
         proc foo() ref { return global; }        // M.foo
         proc foo() const ref { return global; }  // M.foo#1

--- a/frontend/test/resolution/testNew.cpp
+++ b/frontend/test/resolution/testNew.cpp
@@ -643,6 +643,8 @@ static void testCompilerGeneratedGenericNewWithDefaultInit() {
 
   auto vars = resolveTypesOfVariables(context,
     R"""(
+    operator =(ref lhs: int, const rhs: int) {}
+    operator =(ref lhs: real, const rhs: real) {}
     record r {
       param flag : bool;
       var x : if flag then int else real;
@@ -697,6 +699,8 @@ static void testCompilerGeneratedGenericNew() {
 
   auto vars = resolveTypesOfVariables(context,
     R"""(
+    operator =(ref lhs: int, const rhs: int) {}
+    operator =(ref lhs: real, const rhs: real) {}
     record r {
       param flag : bool;
       var x : if flag then int else real;
@@ -778,6 +782,8 @@ static void testCompilerGeneratedGenericNewWithDefaultInitClass() {
 
   auto vars = resolveTypesOfVariables(context,
     R"""(
+    operator =(ref lhs: int, const rhs: int) {}
+    operator =(ref lhs: real, const rhs: real) {}
     class C {
       param flag : bool;
       var x : if flag then int else real;
@@ -836,6 +842,8 @@ static void testCompilerGeneratedGenericNewClass() {
 
   auto vars = resolveTypesOfVariables(context,
     R"""(
+    operator =(ref lhs: int, const rhs: int) {}
+    operator =(ref lhs: real, const rhs: real) {}
     class C {
       param flag : bool;
       var x : if flag then int else real;

--- a/frontend/test/resolution/testSplitInit.cpp
+++ b/frontend/test/resolution/testSplitInit.cpp
@@ -47,7 +47,10 @@ static void testSplitInit(const char* test,
   std::string testname = test;
   testname += ".chpl";
   auto path = UniqueString::get(context, testname);
-  std::string contents = program;
+  std::string contents = "module M {\n";
+  contents += "operator =(ref lhs: int, const rhs: int) {}\n";
+  contents += program;
+  contents += "}";
   setFileText(context, path, contents);
 
   const ModuleVec& vec = parseToplevel(context, path);
@@ -120,11 +123,9 @@ static void testSplitInit(const char* test,
 static void test1() {
   testSplitInit("test1",
     R""""(
-      module M {
         proc test() {
           var x:int = 0;
         }
-      }
     )"""",
     {});
 }
@@ -132,12 +133,10 @@ static void test1() {
 static void test2() {
   testSplitInit("test2",
     R""""(
-      module M {
         proc test() {
           var yes1;
           yes1 = 1;
         }
-      }
     )"""",
     {"yes1"});
 }
@@ -145,12 +144,10 @@ static void test2() {
 static void test3() {
   testSplitInit("test3",
     R""""(
-      module M {
         proc test() {
           var yes1:int;
           yes1 = 1;
         }
-      }
     )"""",
     {"yes1"});
 }
@@ -159,7 +156,6 @@ static void test3() {
 static void test4() {
   testSplitInit("test4",
     R""""(
-      module M {
         proc test() {
           var x:int = 0;
           var yes2;
@@ -168,7 +164,6 @@ static void test4() {
             yes2 = 2;
           }
         }
-      }
     )"""",
     {"yes2"});
 }
@@ -176,7 +171,6 @@ static void test4() {
 static void test5() {
   testSplitInit("test5",
     R""""(
-      module M {
         proc test(cond: bool) {
           var x:int = 0;
           var yes3;
@@ -196,7 +190,6 @@ static void test5() {
             no = 22;
           }
         }
-      }
     )"""",
     {"yes3"});
 }
@@ -204,7 +197,6 @@ static void test5() {
 static void test6() {
   testSplitInit("test6",
     R""""(
-      module M {
         proc test(cond: bool, otherCond: bool) {
           var yes5;
           if cond {
@@ -215,7 +207,6 @@ static void test6() {
             yes5 = 555;
           }
         }
-      }
     )"""",
     {"yes5"});
 }
@@ -223,12 +214,10 @@ static void test6() {
 static void test7() {
   testSplitInit("test7",
     R""""(
-      module M {
         proc test() {
           var no1 = 4;
           no1 = 5;
         }
-      }
     )"""",
     {});
 }
@@ -236,7 +225,6 @@ static void test7() {
 static void test8() {
   testSplitInit("test8",
     R""""(
-      module M {
         proc test() {
           {
             var no2:int;
@@ -244,7 +232,6 @@ static void test8() {
             no2 = 57;
           }
         }
-      }
     )"""",
     {});
 }
@@ -252,7 +239,6 @@ static void test8() {
 static void test9() {
   testSplitInit("test9",
     R""""(
-      module M {
         proc test() {
           {
             var no3:int;
@@ -260,7 +246,6 @@ static void test9() {
             no3 = 57;
           }
         }
-      }
     )"""",
     {});
 }
@@ -268,14 +253,12 @@ static void test9() {
 static void test10() {
   testSplitInit("test10",
     R""""(
-      module M {
         proc test(cond: bool) {
           var x;
           if cond then
             return;
           x = 11;
         }
-      }
     )"""",
     {"x"});
 }
@@ -283,14 +266,12 @@ static void test10() {
 static void test11() {
   testSplitInit("test11",
     R""""(
-      module M {
         proc test(cond: bool) throws {
           var x;
           if cond then
             throw nil;
           x = 11;
         }
-      }
     )"""",
     {"x"});
 }
@@ -298,7 +279,6 @@ static void test11() {
 static void test12() {
   testSplitInit("test12",
     R""""(
-      module M {
         proc test() {
           var x:int;
           try {
@@ -309,7 +289,6 @@ static void test12() {
             return;
           }
         }
-      }
     )"""",
     {"x"});
 }
@@ -317,7 +296,6 @@ static void test12() {
 static void test13() {
   testSplitInit("test13",
     R""""(
-      module M {
         proc test() {
           var x:int;
           try {
@@ -327,7 +305,6 @@ static void test13() {
           } catch {
           }
         }
-      }
     )"""",
     {});
 }
@@ -335,7 +312,6 @@ static void test13() {
 static void test14() {
   testSplitInit("test14",
     R""""(
-      module M {
         proc test() {
           var x:int;
           try {
@@ -346,7 +322,6 @@ static void test14() {
             x = 1;
           }
         }
-      }
     )"""",
     {});
 }
@@ -354,7 +329,6 @@ static void test14() {
 static void test15() {
   testSplitInit("test15",
     R""""(
-      module M {
         proc test() {
           var x:int;
           try {
@@ -362,7 +336,6 @@ static void test15() {
             x = 1;
           }
         }
-      }
     )"""",
     {});
 }
@@ -370,11 +343,9 @@ static void test15() {
 static void test16() {
   testSplitInit("test16",
     R""""(
-      module M {
         proc test(out formal: int) {
           formal = 4;
         }
-      }
     )"""",
     {"formal"});
 }
@@ -382,13 +353,11 @@ static void test16() {
 static void test17() {
   testSplitInit("test17",
     R""""(
-      module M {
         proc fOut(out formal: int) { formal = 4; }
         proc test() {
           var x:int;
           fOut(x);
         }
-      }
     )"""",
     {"x"});
 }
@@ -396,13 +365,11 @@ static void test17() {
 static void test18() {
   testSplitInit("test18",
     R""""(
-      module M {
         proc fOut(out formal: int) { formal = 4; }
         proc test() {
           var x;
           fOut(x);
         }
-      }
     )"""",
     {"x"});
 }
@@ -410,14 +377,12 @@ static void test18() {
 static void test19() {
   testSplitInit("test19",
     R""""(
-      module M {
         proc int.fOut(out formal: int) { formal = 4; }
         proc test() {
           var myInt = 4;
           var x;
           myInt.fOut(x);
         }
-      }
     )"""",
     {"x"});
 }
@@ -426,7 +391,6 @@ static void test19() {
 static void test20() {
   testSplitInit("test20",
     R""""(
-      module M {
         proc fOut(out formals:int...) {
           formals = (4,);
         }
@@ -434,7 +398,6 @@ static void test20() {
           var x;
           fOut(x);
         }
-      }
     )"""",
     {"x"},
     /* expect errors for now as a temporary workaround */ ERRORS_EXPECTED);
@@ -442,7 +405,6 @@ static void test20() {
 static void test21() {
   testSplitInit("test21",
     R""""(
-      module M {
         proc fOut(out formals:int...) {
           formals = (4,5);
         }
@@ -451,7 +413,6 @@ static void test21() {
           var y;
           fOut(x, y);
         }
-      }
     )"""",
     {"x", "y"},
     /* expect errors for now as a temporary workaround */ ERRORS_EXPECTED);
@@ -461,7 +422,6 @@ static void test21() {
 static void test22() {
   testSplitInit("test22",
     R""""(
-      module M {
         proc fOut(out formals...) {
           formals = (4,);
         }
@@ -469,7 +429,6 @@ static void test22() {
           var x:int;
           fOut(x);
         }
-      }
     )"""",
     {"x"});
 }
@@ -477,7 +436,6 @@ static void test22() {
 static void test23() {
   testSplitInit("test23",
     R""""(
-      module M {
         proc fOut(out formals...) {
           formals = (4,5);
         }
@@ -486,7 +444,6 @@ static void test23() {
           var y:int;
           fOut(x, y);
         }
-      }
     )"""",
     {"x", "y"});
 }
@@ -494,7 +451,6 @@ static void test23() {
 static void test24() {
   testSplitInit("test24",
     R""""(
-      module M {
         proc fOut(out formals...) {
           formals = (4,);
         }
@@ -502,14 +458,12 @@ static void test24() {
           var x;
           fOut(x);
         }
-      }
     )"""",
     {"x"});
 }
 static void test25() {
   testSplitInit("test25",
     R""""(
-      module M {
         proc fOut(out formals...) {
           formals = (4,5);
         }
@@ -518,7 +472,6 @@ static void test25() {
           var y;
           fOut(x, y);
         }
-      }
     )"""",
     {"x", "y"});
 }*/
@@ -526,7 +479,6 @@ static void test25() {
 static void test26a() {
   testSplitInit("test26a",
     R""""(
-      module M {
         proc test(r: bool) {
           var x;
           if r {
@@ -535,7 +487,6 @@ static void test26a() {
             x = 3.0i;
           }
         }
-      }
     )"""",
     {}, ERRORS_EXPECTED);
 }
@@ -543,7 +494,6 @@ static void test26a() {
 static void test26b() {
   testSplitInit("test26b",
     R""""(
-      module M {
         proc test(r: bool) {
           var x;
           if r {
@@ -552,7 +502,6 @@ static void test26b() {
             x = 3.0;
           }
         }
-      }
     )"""",
     {}, ERRORS_EXPECTED);
 }
@@ -560,7 +509,6 @@ static void test26b() {
 static void test26c() {
   testSplitInit("test26c",
     R""""(
-      module M {
         proc test(r: bool) {
           var x;
           if r {
@@ -570,7 +518,6 @@ static void test26c() {
             x = myInt8;
           }
         }
-      }
     )"""",
     {}, ERRORS_EXPECTED);
 }
@@ -578,14 +525,12 @@ static void test26c() {
 static void test27() {
   testSplitInit("test27",
     R""""(
-      module M {
         proc test(ref arg: int) {
           var x:int;
           on arg {
             x = 52;
           }
         }
-      }
     )"""",
     {});
 }
@@ -593,14 +538,12 @@ static void test27() {
 static void test28() {
   testSplitInit("test28",
     R""""(
-      module M {
         proc test() {
           var x:int;
           local {
             x = 52;
           }
         }
-      }
     )"""",
     {"x"});
 }
@@ -608,14 +551,12 @@ static void test28() {
 static void test29() {
   testSplitInit("test29",
     R""""(
-      module M {
         proc test() {
           var x:int;
           serial {
             x = 52;
           }
         }
-      }
     )"""",
     {"x"});
 }
@@ -623,7 +564,6 @@ static void test29() {
 static void test30() {
   testSplitInit("test30",
     R""""(
-      module M {
         proc test(r: bool) {
           var x, y;
           if r {
@@ -634,7 +574,6 @@ static void test30() {
             x = 6;
           }
         }
-      }
     )"""",
     {}, ERRORS_EXPECTED);
 }
@@ -643,7 +582,6 @@ static void test30() {
 static void test31() {
   testSplitInit("test31",
     R""""(
-      module M {
         proc test() {
           var x: int;
           inner1();
@@ -652,7 +590,6 @@ static void test31() {
             x;
           }
         }
-      }
     )"""",
     {});
 }
@@ -660,7 +597,6 @@ static void test31() {
 static void test32() {
   testSplitInit("test32",
     R""""(
-      module M {
         proc test() {
           var x: int;
           proc inner1() {
@@ -669,7 +605,6 @@ static void test32() {
           x = 1;
           inner1();
         }
-      }
     )"""",
     {});
 }
@@ -677,7 +612,6 @@ static void test32() {
 static void test33() {
   testSplitInit("test33",
     R""""(
-      module M {
         proc test() {
           var x: int;
           inner1();
@@ -686,7 +620,6 @@ static void test33() {
             x = 44;
           }
         }
-      }
     )"""",
     {});
 }
@@ -694,7 +627,6 @@ static void test33() {
 static void test34() {
   testSplitInit("test34",
     R""""(
-      module M {
         proc test() {
           var x: int;
           proc inner1() {
@@ -703,7 +635,6 @@ static void test34() {
           x;
           inner1();
         }
-      }
     )"""",
     {});
 }
@@ -713,7 +644,6 @@ static void test34() {
 static void test35() {
   testSplitInit("test35",
     R""""(
-      module M {
         var g: int;
         proc f(out x: int) const ref { return g; }
         proc f(    x: int)       ref { return g; }
@@ -721,7 +651,6 @@ static void test35() {
           var x;
           f(x);
         }
-      }
     )"""",
     {});
 }
@@ -729,7 +658,6 @@ static void test35() {
 static void test36() {
   testSplitInit("test36",
     R""""(
-      module M {
         var g: int;
         proc f(out x: int,     y: int) const ref { return g; }
         proc f(    x: int, out y: int)       ref { return g; }
@@ -737,7 +665,6 @@ static void test36() {
           var x, y;
           f(x, y);
         }
-      }
     )"""",
     {});
 }
@@ -746,14 +673,12 @@ static void test36() {
 static void test37() {
   testSplitInit("test37",
     R""""(
-      module M {
         proc test(cond: bool) {
           var x;
           if cond then
             return x;
           x = 11;
         }
-      }
     )"""",
     {});
 }
@@ -761,7 +686,6 @@ static void test37() {
 static void test38() {
   testSplitInit("test38",
     R""""(
-      module M {
         proc test() {
           var x:int;
           if x {
@@ -770,7 +694,6 @@ static void test38() {
             x = 11;
           }
         }
-      }
     )"""",
     {});
 }
@@ -778,13 +701,11 @@ static void test38() {
 static void test39() {
   testSplitInit("test39",
     R""""(
-      module M {
         proc test() {
           var x:int;
           var y = x;
           x = 11;
         }
-      }
     )"""",
     {});
 }
@@ -792,7 +713,6 @@ static void test39() {
 static void test40() {
   testSplitInit("test40",
     R""""(
-      module M {
         proc test(cond: bool) {
           var x:int;
           if cond {
@@ -800,7 +720,6 @@ static void test40() {
           }
           x = 11;
         }
-      }
     )"""",
     {});
 }
@@ -808,7 +727,6 @@ static void test40() {
 static void test41() {
   testSplitInit("test41",
     R""""(
-      module M {
         proc test() {
           var x:int;
           {
@@ -816,7 +734,6 @@ static void test41() {
           }
           x = 11;
         }
-      }
     )"""",
     {});
 }
@@ -824,7 +741,6 @@ static void test41() {
 static void test42() {
   testSplitInit("test42",
     R""""(
-      module M {
         proc test() throws {
           var x:int;
           try {
@@ -832,7 +748,6 @@ static void test42() {
           }
           x = 11;
         }
-      }
     )"""",
     {});
 }
@@ -840,7 +755,6 @@ static void test42() {
 static void test43() {
   testSplitInit("test43",
     R""""(
-      module M {
         proc test() {
           var x:int;
           try {
@@ -849,7 +763,6 @@ static void test43() {
           }
           x = 11;
         }
-      }
     )"""",
     {});
 }
@@ -857,7 +770,6 @@ static void test43() {
 static void test44() {
   testSplitInit("test44",
     R""""(
-      module M {
         proc test(cond: bool) {
           var x:int;
           if cond {
@@ -870,7 +782,6 @@ static void test44() {
             }
           }
         }
-      }
     )"""",
     {"x"});
 }
@@ -878,7 +789,6 @@ static void test44() {
 static void test45() {
   testSplitInit("test45",
     R""""(
-      module M {
         proc test(cond: bool) {
           var x:int;
           if cond {
@@ -889,7 +799,6 @@ static void test45() {
             }
           }
         }
-      }
     )"""",
     {});
 }
@@ -897,7 +806,6 @@ static void test45() {
 static void test46() {
   testSplitInit("test46",
     R""""(
-      module M {
         proc test(cond: bool) {
           var x:int;
           if cond {
@@ -910,7 +818,6 @@ static void test46() {
             }
           }
         }
-      }
     )"""",
     {"x"});
 }
@@ -922,7 +829,6 @@ static void test46() {
 static void test47() {
   testSplitInit("test47",
     R""""(
-      module M {
         config var cond = true;
 
         proc test(out x: int) {
@@ -932,7 +838,6 @@ static void test47() {
             x = 5;
           }
         }
-      }
     )"""",
     {});
 }
@@ -941,14 +846,12 @@ static void test47() {
 static void test48() {
   testSplitInit("test48",
     R""""(
-      module M {
         proc test(out x: int) {
           try {
           } catch {
             return;
           }
         }
-      }
     )"""",
     {});
 }
@@ -956,12 +859,10 @@ static void test48() {
 static void test49() {
   testSplitInit("test49",
     R""""(
-      module M {
         proc test(out x: int) {
           return;
           x = 23;
         }
-      }
     )"""",
     {});
 }
@@ -974,7 +875,6 @@ static void test49() {
 static void test50() {
   testSplitInit("test50",
     R""""(
-      module M {
         config var cond = false;
 
         proc test(out x: int) throws {
@@ -984,14 +884,12 @@ static void test50() {
             x = 5;
           }
         }
-      }
     )"""",
     {"x"});
 }
 static void test51() {
   testSplitInit("test51",
     R""""(
-      module M {
         proc test(out x: int) throws {
           try {
             x = 5;
@@ -999,7 +897,6 @@ static void test51() {
             throw nil;
           }
         }
-      }
     )"""",
     {"x"});
 }
@@ -1007,12 +904,10 @@ static void test51() {
 static void test52() {
   testSplitInit("test52",
     R""""(
-      module M {
         proc test(out x: int) throws {
           throw nil;
           x = 23;
         }
-      }
     )"""",
     {});
 }
@@ -1020,7 +915,6 @@ static void test52() {
 static void test53() {
   testSplitInit("test53",
     R""""(
-      module M {
         config var cond = false;
 
         proc test() throws {
@@ -1032,7 +926,6 @@ static void test53() {
           }
           x;
         }
-      }
     )"""",
     {});
 }
@@ -1040,14 +933,12 @@ static void test53() {
 static void test54() {
   testSplitInit("test54",
     R""""(
-      module M {
         proc test() {
           var x;
           if true then
             return;
           x = 11;
         }
-      }
     )"""",
     {});
 }
@@ -1055,14 +946,12 @@ static void test54() {
 static void test55() {
   testSplitInit("test55",
     R""""(
-      module M {
         proc test() {
           var x;
           if false then
             return;
           x = 11;
         }
-      }
     )"""",
     {"x"});
 }
@@ -1070,7 +959,6 @@ static void test55() {
 static void test56() {
   testSplitInit("test56",
     R""""(
-      module M {
         proc test() {
           type T = int;
           var x;
@@ -1078,7 +966,6 @@ static void test56() {
             return;
           x = 11;
         }
-      }
     )"""",
     {});
 }
@@ -1086,14 +973,12 @@ static void test56() {
 static void test57() {
   testSplitInit("test57",
     R""""(
-      module M {
         proc test() {
           var x;
           if false then
             return;
           x = 11;
         }
-      }
     )"""",
     {"x"});
 }
@@ -1102,7 +987,6 @@ static void test57() {
 static void test58() {
   testSplitInit("test58",
     R""""(
-      module M {
         proc test() {
           var x;
           if true then
@@ -1112,7 +996,6 @@ static void test58() {
           x = 3;
           return;
         }
-      }
     )"""",
     {"x"});
 }
@@ -1120,7 +1003,6 @@ static void test58() {
 static void test59() {
   testSplitInit("test59",
     R""""(
-      module M {
         proc test() {
           var x;
           if false then
@@ -1130,7 +1012,6 @@ static void test59() {
           x = 3;
           return;
         }
-      }
     )"""",
     {"x"});
 }
@@ -1138,7 +1019,6 @@ static void test59() {
 static void test60() {
   testSplitInit("test60",
     R""""(
-      module M {
         config const cond: bool = true;
         proc test() {
           var x;
@@ -1149,7 +1029,6 @@ static void test60() {
           x = 3;
           return;
         }
-      }
     )"""",
     {});
 }
@@ -1157,7 +1036,6 @@ static void test60() {
 static void test61() {
   testSplitInit("test61",
     R""""(
-      module M {
         config const cond: bool = true;
         proc test() {
           var x;
@@ -1168,7 +1046,6 @@ static void test61() {
           x = 3;
           return;
         }
-      }
     )"""",
     {"x"});
 }
@@ -1176,7 +1053,6 @@ static void test61() {
 static void test62() {
   testSplitInit("test62",
     R""""(
-      module M {
         operator ==(ref lhs: int, rhs: int) {
           __primitive("==", lhs, rhs);
         }
@@ -1196,7 +1072,6 @@ static void test62() {
           }
           return;
         }
-      }
     )"""",
     {"x"});
 }
@@ -1204,7 +1079,6 @@ static void test62() {
 static void test63() {
   testSplitInit("test63",
     R""""(
-      module M {
         operator ==(ref lhs: int, rhs: int) {
           __primitive("==", lhs, rhs);
         }
@@ -1221,7 +1095,6 @@ static void test63() {
           }
           return;
         }
-      }
     )"""",
     {});
 }
@@ -1229,7 +1102,6 @@ static void test63() {
 static void test64() {
   testSplitInit("test64",
     R""""(
-      module M {
         operator ==(ref lhs: int, rhs: int) {
           __primitive("==", lhs, rhs);
         }
@@ -1249,7 +1121,6 @@ static void test64() {
           }
           return;
         }
-      }
     )"""",
     {"x"});
 }
@@ -1258,7 +1129,6 @@ static void test64() {
 static void test65() {
   testSplitInit("test65",
     R""""(
-      module M {
         operator ==(ref lhs: int, rhs: int) {
           __primitive("==", lhs, rhs);
         }
@@ -1277,7 +1147,6 @@ static void test65() {
           x = 3;
           return;
         }
-      }
     )"""",
     {});
 }
@@ -1286,7 +1155,6 @@ static void test65() {
 static void test66() {
   testSplitInit("test66",
     R""""(
-      module M {
         operator ==(ref lhs: int, rhs: int) {
           __primitive("==", lhs, rhs);
         }
@@ -1307,7 +1175,6 @@ static void test66() {
           x = 2;
           return;
         }
-      }
     )"""",
     {});
 }
@@ -1315,7 +1182,6 @@ static void test66() {
 static void test67() {
   testSplitInit("test67a",
     R""""(
-      module M {
         operator ==(ref lhs: int, rhs: int) {
           __primitive("==", lhs, rhs);
         }
@@ -1329,12 +1195,10 @@ static void test67() {
             otherwise { y = 1; x = 2; }
           }
         }
-      }
     )"""",
     {}, ERRORS_EXPECTED);
   testSplitInit("test67b",
     R""""(
-      module M {
         operator ==(ref lhs: int, rhs: int) {
           __primitive("==", lhs, rhs);
         }
@@ -1348,12 +1212,10 @@ static void test67() {
             otherwise { z = 0; y = 1; x = 2; }
           }
         }
-      }
     )"""",
     {}, ERRORS_EXPECTED);
   testSplitInit("test67c",
     R""""(
-      module M {
         operator ==(ref lhs: int, rhs: int) {
           __primitive("==", lhs, rhs);
         }
@@ -1367,12 +1229,10 @@ static void test67() {
             otherwise { z = 0; y = 1; x = 2; }
           }
         }
-      }
     )"""",
     {"z", "y", "x"});
   testSplitInit("test67d",
     R""""(
-      module M {
         operator ==(ref lhs: int, rhs: int) {
           __primitive("==", lhs, rhs);
         }
@@ -1386,7 +1246,6 @@ static void test67() {
             otherwise {z = 1; x = 4; return;}
           }
         }
-      }
     )"""",
     {"z", "x", "y"});
 }
@@ -1395,7 +1254,6 @@ static void test67() {
 static void testParamTrueWhen() {
   testSplitInit("testFirstParamTrueWhenNoOtherwise",
     R""""(
-      module M {
         proc test() {
           type T = int;
           var x;
@@ -1408,12 +1266,10 @@ static void testParamTrueWhen() {
             }
           }
         }
-      }
     )"""",
     {"x"});
     testSplitInit("testSecondParamTrueWhenNoOtherwise",
     R""""(
-      module M {
         proc test() {
           type T = real;
           var x: int;
@@ -1425,12 +1281,10 @@ static void testParamTrueWhen() {
             }
           }
         }
-      }
     )"""",
     {});
     testSplitInit("testNoParamTrueWhenNoOtherwise",
     R""""(
-      module M {
         proc test() {
           type T = string;
           var x: int;
@@ -1443,12 +1297,10 @@ static void testParamTrueWhen() {
           }
           x = 3;
         }
-      }
     )"""",
     {"x"});
     testSplitInit("testNoParamTrueWhenYesOtherwise",
     R""""(
-      module M {
         proc test() {
           type T = string;
           var x: int;
@@ -1463,14 +1315,12 @@ static void testParamTrueWhen() {
           }
           x = 3;
         }
-      }
     )"""",
     {"x"});
 }
 static void test64a() {
   testSplitInit("test64a_passing",
     R""""(
-      module M {
         operator ==(ref lhs: int, rhs: int) {
           __primitive("==", lhs, rhs);
         }
@@ -1488,12 +1338,10 @@ static void test64a() {
           }
           x = 12;
         }
-      }
     )"""",
     {"x"});
     testSplitInit("test64a",
     R""""(
-      module M {
         operator ==(ref lhs: int, rhs: int) {
           __primitive("==", lhs, rhs);
         }
@@ -1511,7 +1359,6 @@ static void test64a() {
           }
           x = 12;
         }
-      }
     )"""",
     {"x"});
 }
@@ -1520,7 +1367,6 @@ static void test64a() {
 static void test65a() {
   testSplitInit("test65a",
     R""""(
-      module M {
         proc test() {
           type T = int;
           var x;
@@ -1533,7 +1379,6 @@ static void test65a() {
             }
           }
         }
-      }
     )"""",
     {"x"});
 }
@@ -1542,7 +1387,6 @@ static void test65a() {
 static void test68() {
   testSplitInit("test68",
     R""""(
-      module M {
         proc test() {
           param x:int;
           x = 5;
@@ -1560,7 +1404,6 @@ static void test68() {
             }
           }
         }
-      }
     )"""",
     {"x", "y"});
 }

--- a/frontend/test/resolution/testTypeConstruction.cpp
+++ b/frontend/test/resolution/testTypeConstruction.cpp
@@ -1291,6 +1291,8 @@ static void testRecursiveTypeConstructor() {
 
   auto p = parseTypeAndFieldsOfX(context,
       R"""(
+      operator =(ref lhs: real, const rhs: real) {}
+      operator =(ref lhs: unmanaged class?, const in rhs: unmanaged class?) {}
       class Node {
         type eltType = int;
         var data: eltType;
@@ -1330,6 +1332,8 @@ static void testRecursiveTypeConstructorAlias() {
 
   auto p = parseTypeAndFieldsOfX(context,
       R"""(
+      operator =(ref lhs: int, const rhs: int) {}
+      operator =(ref lhs: unmanaged class?, const in rhs: unmanaged class?) {}
       class Node {
           type eltType = int;
           var data: eltType;
@@ -1370,6 +1374,7 @@ static void testRecursiveTypeConstructorGeneric() {
 
   std::ignore = resolveTypeOfXInit(context,
       R"""(
+      operator =(ref lhs: unmanaged class?, const in rhs: unmanaged class?) {}
       class Node {
           type eltType = int;
           var data: eltType;
@@ -1397,6 +1402,8 @@ static void testRecursiveTypeConstructorMutual() {
 
   auto p = parseTypeAndFieldsOfX(context,
       R"""(
+      operator =(ref lhs: real, const rhs: real) {}
+      operator =(ref lhs: owned class?, const in rhs: owned class?) {}
       class MutA {
         type eltType;
         var data: eltType;


### PR DESCRIPTION
Previously, generated uAST was being created given a particular type
possibly with other information about how the call was being invoked.
Generated uAST was then created as a fake 'included' module with a
parent symbol path was that of the module in which the type was defined.
This uAST was then stored and retrieved using some set/get queries in
``chpl::parsing``.

This PR updates the implementation to instead rely on generated
functions using the type's symbol path as its parent path. This allows
``parseFileContainingIdToBuilderResult`` to use a generated ID's symbol
path and symbol name to query the uAST, as opposed to using the old
getter method. Now, we rely on the ``buildDefaultFunction`` query in
``chpl::resolution``.

For example, a default initializer will have a path like
``MyMod.MyType.init``. With the parent symbol path of ``MyMod.MyType``
we can query the type's uAST if needed, and with the name ``init`` we
know which uAST-generating function to invoke (e.g. ``buildInitializer``).

This change requires that Builders of generated code be able to support a
non-module as a top-level expression. This is achieved by disabling implicit
module creation for generated uAST. Currently it is expected that this
top-level expression will be a ``Function``.

The recently-added compiler-generated assignment operators do not fit in
well with this new representation because the primitive types do not have an
ID associated with them. For now, it is simpler to remove those generated
operators and go back to using manually-created operators in testing. Future
work is expected to eliminate the need for such operators by using either the
standard or minimal modules.

Cleanup:
- get rid of file paths for generated uAST
- tidy up creation of generated IDs, moving post-order-id logic into ID.cpp
- Simplify usage of "generatedFrom" ID in Builder

Testing:
- [x] test-dyno
- [x] full local