### PR TITLE
Cyclic @gpu.itersPerThread

### DIFF
--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -1055,6 +1055,9 @@ class KernelArg {
 
 static bool isCallToPrimitiveWeShouldNotCopyIntoKernel(CallExpr *call);
 static bool isCallToPrimitiveWithHostRuntimeEffect(CallExpr *call);
+static VarSymbol* generateNumThreads(BlockStmt* gpuLaunchBlock,
+                                     GpuKernel* kernel,
+                                     const GpuizableLoop& gpuLoop);
 
 // Given a GpuizableLoop that was determined to be "eligible" we generate an
 // outlined function
@@ -1079,6 +1082,8 @@ class GpuKernel {
   std::vector<Symbol*> kernelIndices_;
   std::vector<KernelArg> kernelActuals_;
   SymbolMap  copyMap_;
+  VarSymbol* numThreads_;
+  Symbol*    localNumThreads_;
   Symbol*    localItersPerThread_;
   BlockStmt* userBody_; // where the loop's body goes
   BlockStmt* postBody_; // executed by all GPU threads (even if oob) at the end
@@ -1086,6 +1091,7 @@ class GpuKernel {
   int nReductionBufs_ = 0;
   int nHostRegisteredVars_ = 0;
   bool lateGpuizationFailure_ = false;
+  bool cyclicIPT_ = false; //wass
 
   public:
   GpuKernel(GpuizableLoop &gpuLoop, DefExpr* insertionPoint);
@@ -1100,6 +1106,8 @@ class GpuKernel {
   CallExpr* itersPerThreadCall() const {return itersPerThreadCall_; }
   Symbol* itersPerThread() const {return itersPerThread_; }
   bool hasItersPerThread() const { return itersPerThread_ != nullptr; }
+  bool blockIPT() const { return !cyclicIPT_; }
+  bool cyclicIPT() const { return cyclicIPT_; }
   int nReductionBufs() const {return nReductionBufs_; }
   int nHostRegisteredVars() const {return nHostRegisteredVars_; }
   void incNumHostRegisteredVars() { nHostRegisteredVars_ += 1; }
@@ -1117,7 +1125,10 @@ class GpuKernel {
 
   void generateIndexComputation();
   void generateOobCond();
-  void generateLoopOverIPT(Symbol* upperBound);
+  void generateIptLoopHelp(Symbol* index0, Symbol* upperBound0,
+                           Symbol* increment);
+  void generateBlockedLoopOverIPT(Symbol* upperBound);
+  void generateCyclicLoopOverIPT(Symbol* upperBound);
   void generateOobCondNoIPT(Symbol* upperBound);
   void generatePostBody();
   void markGPUSubCalls(FnSymbol* fn);
@@ -1139,6 +1150,8 @@ GpuKernel::GpuKernel(GpuizableLoop &gpuLoop, DefExpr* insertionPoint)
   , itersPerThread_(nullptr)
   , name_("")
   , launchBlock_(new BlockStmt())
+  , numThreads_(nullptr)
+  , localNumThreads_(nullptr)
   , localItersPerThread_(nullptr)
   , userBody_(nullptr)
   , postBody_(nullptr)
@@ -1176,6 +1189,7 @@ void GpuKernel::buildStubOutlinedFunction(DefExpr* insertionPoint) {
   fn_->addFlag(FLAG_ALWAYS_RESOLVE);
   fn_->addFlag(FLAG_GPU_CODEGEN);
 
+  numThreads_ = generateNumThreads(launchBlock_, this, gpuLoop);
   generateIndexComputation();
   generateOobCond();
   generatePostBody();
@@ -1528,7 +1542,7 @@ Symbol* GpuKernel::addLocalVariable(Symbol* symInLoop) {
  *  t1 = t0 + threadIdxX      // aka `global thread idx`
  *  index = t1 + lowerBound   // aka `calculated thread idx`
  *
- *  If we have @gpu.itersPerThread, instead generates:
+ *  If we have @gpu.itersPerThread with block policy, instead generates:
  *
  *  index = lowerBound + t1 * itersPerThread
  *
@@ -1559,9 +1573,14 @@ void GpuKernel::generateIndexComputation() {
     PRIM_ADD, tempVar, varThreadIdxX));
   fn_->insertAtTail(c2);
 
-  if (hasItersPerThread()) {
+  if (hasItersPerThread() && blockIPT()) {
     localItersPerThread_ = maybeAddCompilerGeneratedKernelArgument(
                                itersPerThread_, "chpl_itersPerThread");
+  }
+
+  if (hasItersPerThread() && cyclicIPT()) {
+    localNumThreads_ = maybeAddCompilerGeneratedKernelArgument(
+                               numThreads_, "chpl_numThreads");
   }
 
   for (std::vector<Symbol*>::size_type i=0 ; i<numIndices ; i++) {
@@ -1571,7 +1590,7 @@ void GpuKernel::generateIndexComputation() {
                                                            "chpl_lowerBound");
     VarSymbol* addend = tempVar1;
 
-    if (hasItersPerThread()) {
+    if (hasItersPerThread() && blockIPT()) {
       VarSymbol* tempVar2 = insertNewVarAndDef(fn_->body, "t2",
                                                tempVar1->type);
       fn_->insertAtTail(new CallExpr(PRIM_MOVE, tempVar2, new CallExpr(
@@ -1597,8 +1616,12 @@ void GpuKernel::generateOobCond() {
                               gpuLoop.upperBound(), "chpl_upperBound");
   this->userBody_ = new BlockStmt();
 
-  if (hasItersPerThread())
-    generateLoopOverIPT(localUpperBound);
+  if (hasItersPerThread()) {
+    if (blockIPT())
+      generateBlockedLoopOverIPT(localUpperBound);
+    if (cyclicIPT())
+      generateCyclicLoopOverIPT(localUpperBound);
+  }
   else
     generateOobCondNoIPT(localUpperBound);
 }
@@ -1625,7 +1648,30 @@ void GpuKernel::generateOobCondNoIPT(Symbol* localUpperBound) {
   fn_->insertAtTail(new CondStmt(new SymExpr(isInBounds), this->userBody_));
 }
 
+void GpuKernel::generateIptLoopHelp(Symbol* index0, Symbol* upperBound0,
+                                    Symbol* increment) {
+  // while loop condition variable
+  VarSymbol* whileVar = insertNewVarAndDef(fn_->body, "whileVar", dtBool);
+  Expr* whileExpr = new_Expr("'move'(%S,'<='(%S,%S))",
+                             whileVar, index0, upperBound0);
+  fn_->insertAtTail(whileExpr);
+
+  // while loop execute userBody_ then increment all indices
+  BlockStmt* whileBody = new BlockStmt();
+  whileBody->insertAtTail(this->userBody_);
+
+  for_vector(Symbol, index, kernelIndices_) {
+    whileBody->insertAtTail("'+='(%S,%S)", index, increment);
+  }
+
+  whileBody->insertAtTail(whileExpr->copy());
+
+  // create AST for the loop
+  fn_->insertAtTail(new WhileDoStmt(new SymExpr(whileVar), whileBody));
+}
+
 /* Adds the following AST to a GPU kernel
+ * to implement *block* IPT partitioning.
  *
  * // recall index[0] = lowerBound + `global thread idx` * itersPerThread
  * def threadBound = min(index[0] + itersPerThread - 1, upperBound)
@@ -1637,6 +1683,7 @@ void GpuKernel::generateOobCondNoIPT(Symbol* localUpperBound) {
  * loop in cleanupForeachLoopsGuaranteedToRunOnCpu() that will come later
  * and replace ex. GPU primitives like "gpu threadIdx x" with chpl_error.
  * Not to mention that the latter will break codegen.
+ * TODO: fix that, so we can generate CForLoop instead of WhileDoStmt:
  * So use WhileDoStmt instead as follows:
  *
  * def whileVar = index[0] <= threadBound
@@ -1647,7 +1694,7 @@ void GpuKernel::generateOobCondNoIPT(Symbol* localUpperBound) {
  *   whileVar = index[0] <= threadBound
  * })
  */
-void GpuKernel::generateLoopOverIPT(Symbol* upperBound) {
+void GpuKernel::generateBlockedLoopOverIPT(Symbol* upperBound) {
   // calculate 'threadBound'
   Symbol* index0 = kernelIndices_[0];
 
@@ -1667,24 +1714,15 @@ void GpuKernel::generateLoopOverIPT(Symbol* upperBound) {
   switchBlock->insertAtTail("'move'(%S,%S)", threadBound, upperBound);
   fn_->insertAtTail(new CondStmt(new SymExpr(switchToLB), switchBlock));
 
-  // while loop condition variable
-  VarSymbol* whileVar = insertNewVarAndDef(fn_->body, "whileVar", dtBool);
-  Expr* whileExpr = new_Expr("'move'(%S,'<='(%S,%S))",
-                             whileVar, index0, threadBound);
-  fn_->insertAtTail(whileExpr);
+  generateIptLoopHelp(index0, threadBound, new_IntSymbol(1));
+}
 
-  // while loop execute userBody_ then increment all indices
-  BlockStmt* whileBody = new BlockStmt();
-  whileBody->insertAtTail(this->userBody_);
-
-  for_vector(Symbol, index, kernelIndices_) {
-    whileBody->insertAtTail("'+='(%S,%S)", index, new_IntSymbol(1));
-  }
-
-  whileBody->insertAtTail(whileExpr->copy());
-
-  // create AST for the loop
-  fn_->insertAtTail(new WhileDoStmt(new SymExpr(whileVar), whileBody));
+/* Adds the following AST to a GPU kernel
+ * to implement *cyclic* IPT partitioning,
+ * analogously to generateBlockedLoopOverIPT().
+ *
+ */
+void GpuKernel::generateCyclicLoopOverIPT(Symbol* upperBound) {
 }
 
 void GpuKernel::generatePostBody() {
@@ -2105,7 +2143,7 @@ const std::unordered_set<PrimitiveTag>
  *  so generate the following instead:
  *
  *   chpl_block_delta = ub - lb
- *   chpl_block_delta_plus = chpl_block_delta + ipt
+ *   chpl_block_delta_plus = chpl_block_delta + itersPerThread
  *   chpl_gpu_num_threads = chpl_block_delta_plus / itersPerThread
  */
 static VarSymbol* generateNumThreads(BlockStmt* gpuLaunchBlock,
@@ -2151,12 +2189,9 @@ static VarSymbol* generateNumThreads(BlockStmt* gpuLaunchBlock,
 void GpuKernel::generateKernelLaunch() {
   VarSymbol* cfg = insertNewVarAndDef(launchBlock_, "kernel_cfg", dtCVoidPtr);
 
-  VarSymbol* numThreads = generateNumThreads(launchBlock_, this, gpuLoop);
-
-
   CallExpr* initCfgCall = new CallExpr(PRIM_GPU_INIT_KERNEL_CFG);
   initCfgCall->insertAtTail(fn());
-  initCfgCall->insertAtTail(numThreads);
+  initCfgCall->insertAtTail(numThreads_);
   initCfgCall->insertAtTail(blockSize());
   initCfgCall->insertAtTail(new_IntSymbol(kernelActuals().size()));
   initCfgCall->insertAtTail(new_IntSymbol(gpuLoop.pidGets().size()));

--- a/modules/standard/AutoGpu.chpl
+++ b/modules/standard/AutoGpu.chpl
@@ -107,20 +107,15 @@ module AutoGpu {
   */
   pragma "docs only"
   @chpldoc.attributeSignature("gpu.blockSize")
-  inline proc chpl__gpuBlockSizeAttr(arg: integral) {}
+  inline proc chpl__gpuBlockSizeAttr(blockSize: integral) {}
 
   inline proc chpl__gpuBlockSizeAttr(param counter: int, arg: integral) {
     if CHPL_LOCALE_MODEL == "gpu" then
-      __primitive("gpu set blockSize", arg, counter);
+      __primitive("gpu set blockSize", counter, arg);
   }
 
   pragma "last resort"
-  inline proc chpl__gpuBlockSizeAttr(param counter: int, rest ...) {
-    compilerError("'@gpu.blockSize' attribute must have exactly one argument: an integral value for the block size");
-  }
-
-  pragma "last resort"
-  inline proc chpl__gpuBlockSizeAttr(param counter: int) {
+  inline proc chpl__gpuBlockSizeAttr(args ...) {
     compilerError("'@gpu.blockSize' attribute must have exactly one argument: an integral value for the block size");
   }
 
@@ -139,23 +134,24 @@ module AutoGpu {
      // variable version (applies to loop expressions and promoted expressions)
      @gpu.itersPerThread(4)
      var A = (foreach i in 1..128 do i*i) + 1;
+
+   Specifying the `cyclic` argument to be `true` distributes the iterations
+   across GPU threads in cyclic fashion instead of the default block
+   discipline.
   */
   pragma "docs only"
   @chpldoc.attributeSignature("gpu.itersPerThread")
-  inline proc chpl__gpuItersPerThreadAttr(arg: integral) {}
+  inline proc chpl__gpuItersPerThreadAttr(itersPerThread: integral,
+                                          param cyclic: bool = false) {}
 
-  inline proc chpl__gpuItersPerThreadAttr(param counter: int, arg: integral) {
+  inline proc chpl__gpuItersPerThreadAttr(param counter: int, ipt: integral,
+                                          param cyclic: bool = false) {
     if CHPL_LOCALE_MODEL == "gpu" then
-      __primitive("gpu set itersPerThread", arg, counter);
+      __primitive("gpu set itersPerThread", counter, ipt, cyclic);
   }
 
   pragma "last resort"
-  inline proc chpl__gpuItersPerThreadAttr(param counter: int, rest ...) {
-    compilerError("'@gpu.itersPerThread' attribute must have exactly one argument: an integral value for the number of iterations per GPU thread");
-  }
-
-  pragma "last resort"
-  inline proc chpl__gpuItersPerThreadAttr(param counter: int) {
-    compilerError("'@gpu.itersPerThread' attribute must have exactly one argument: an integral value for the number of iterations per GPU thread");
+  inline proc chpl__gpuItersPerThreadAttr(args ...) {
+    compilerError("'@gpu.itersPerThread' attribute must have one or two arguments: an integral value for the number of iterations per GPU thread and optionally a param boolean value indicating whether the iterations should be distributed across GPU threads in a cyclic fashion, with block-distributed by default");
   }
 }

--- a/modules/standard/AutoGpu.chpl
+++ b/modules/standard/AutoGpu.chpl
@@ -152,6 +152,6 @@ module AutoGpu {
 
   pragma "last resort"
   inline proc chpl__gpuItersPerThreadAttr(args ...) {
-    compilerError("'@gpu.itersPerThread' attribute must have one or two arguments: an integral value for the number of iterations per GPU thread and optionally a param boolean value indicating whether the iterations should be distributed across GPU threads in a cyclic fashion, with block-distributed by default");
+    compilerError("'@gpu.itersPerThread' attribute must have one or two arguments: an integral value for the number of iterations per GPU thread and optionally a 'param' boolean value indicating whether the iterations should be distributed across GPU threads in a cyclic or block (default) fashion");
   }
 }

--- a/test/gpu/native/basics/itersPerThread.chpl
+++ b/test/gpu/native/basics/itersPerThread.chpl
@@ -71,8 +71,8 @@ proc test(numIndices: int, itersPerThread: int, blockSize: int, param cyclic) {
       if elm != gridDim[1] then
         { show("gridDim", gridDim); break; }
 
-    writef("numIndices %i  itersPerThread %i  blockSize %i/%i  gridSize %i\n",
-           numIndices, itersPerThread, blockSize, blockDim[1], gridDim[1]);
+    writef("numIndices %i  itersPerThread %i  blockSize %i/%i  gridSize %i  cyclic %?\n",
+           numIndices, itersPerThread, blockSize, blockDim[1], gridDim[1], cyclic);
     show("threadIdx", threadIdx);
     show("blockId",   blockId);
     writeln();

--- a/test/gpu/native/basics/itersPerThread.chpl
+++ b/test/gpu/native/basics/itersPerThread.chpl
@@ -50,12 +50,12 @@ proc show(name: string, arr) {
   writef("\n");
 }
 
-proc test(numIndices: int, itersPerThread: int, blockSize: int) {
+proc test(numIndices: int, itersPerThread: int, blockSize: int, param cyclic) {
   on here.gpus(0) {
     var threadIdx, blockDim, blockId, gridDim: [1..numIndices] int;
 
     @gpu.blockSize(blockSize)
-    @gpu.itersPerThread(itersPerThread)
+    @gpu.itersPerThread(itersPerThread, cyclic)
     foreach i in 1..numIndices {
       threadIdx[i] = __primitive("gpu threadIdx x");
       blockDim[i] = __primitive("gpu blockDim x");
@@ -82,14 +82,16 @@ proc test(numIndices: int, itersPerThread: int, blockSize: int) {
 
 writeln();
 
-test(32, 1, 3);
-test(32, 2, 3);
-test(32, 3, 3);
-test(32, 4, 3);
-test(32, 5, 3);
+for param cyclic in false..true {
+  test(32, 1, 3, cyclic);
+  test(32, 2, 3, cyclic);
+  test(32, 3, 3, cyclic);
+  test(32, 4, 3, cyclic);
+  test(32, 5, 3, cyclic);
 
-test(32, 8, 1);
-test(32, 8, 2);
-test(32, 8, 3);
-test(32, 8, 4);
-test(32, 8, 5);
+  test(32, 8, 1, cyclic);
+  test(32, 8, 2, cyclic);
+  test(32, 8, 3, cyclic);
+  test(32, 8, 4, cyclic);
+  test(32, 8, 5, cyclic);
+}

--- a/test/gpu/native/basics/itersPerThread.good
+++ b/test/gpu/native/basics/itersPerThread.good
@@ -6,83 +6,83 @@ itersPerThr=4  (400): 300 301 302 303 400 400 400 400 401 401 401 401 402 402 40
 blsz=5 ipt=3   (500): 500 500 500 501 501 501 502 502 502 503 503 503 504 504 504 500 500 500 501 501 501 502 502 502 503 405 405 405 100 100 100 100
 blsz=2 ipt=3   (600): 500 610 610 610 611 611 611 610 502 503 620 620 620 620 620 620 621 500 632 632 632 632 632 632 632 405 405 405 100 100 100 100
 
-numIndices 32  itersPerThread 1  blockSize 3/3  gridSize 11
+numIndices 32  itersPerThread 1  blockSize 3/3  gridSize 11  cyclic false
   threadIdx:  0  1  2  0  1  2  0  1  2  0  1  2  0  1  2  0  1  2  0  1  2  0  1  2  0  1  2  0  1  2  0  1
     blockId:  0  0  0  1  1  1  2  2  2  3  3  3  4  4  4  5  5  5  6  6  6  7  7  7  8  8  8  9  9  9 10 10
 
-numIndices 32  itersPerThread 2  blockSize 3/3  gridSize 6
+numIndices 32  itersPerThread 2  blockSize 3/3  gridSize 6  cyclic false
   threadIdx:  0  0  1  1  2  2  0  0  1  1  2  2  0  0  1  1  2  2  0  0  1  1  2  2  0  0  1  1  2  2  0  0
     blockId:  0  0  0  0  0  0  1  1  1  1  1  1  2  2  2  2  2  2  3  3  3  3  3  3  4  4  4  4  4  4  5  5
 
-numIndices 32  itersPerThread 3  blockSize 3/3  gridSize 4
+numIndices 32  itersPerThread 3  blockSize 3/3  gridSize 4  cyclic false
   threadIdx:  0  0  0  1  1  1  2  2  2  0  0  0  1  1  1  2  2  2  0  0  0  1  1  1  2  2  2  0  0  0  1  1
     blockId:  0  0  0  0  0  0  0  0  0  1  1  1  1  1  1  1  1  1  2  2  2  2  2  2  2  2  2  3  3  3  3  3
 
-numIndices 32  itersPerThread 4  blockSize 3/3  gridSize 3
+numIndices 32  itersPerThread 4  blockSize 3/3  gridSize 3  cyclic false
   threadIdx:  0  0  0  0  1  1  1  1  2  2  2  2  0  0  0  0  1  1  1  1  2  2  2  2  0  0  0  0  1  1  1  1
     blockId:  0  0  0  0  0  0  0  0  0  0  0  0  1  1  1  1  1  1  1  1  1  1  1  1  2  2  2  2  2  2  2  2
 
-numIndices 32  itersPerThread 5  blockSize 3/3  gridSize 3
+numIndices 32  itersPerThread 5  blockSize 3/3  gridSize 3  cyclic false
   threadIdx:  0  0  0  0  0  1  1  1  1  1  2  2  2  2  2  0  0  0  0  0  1  1  1  1  1  2  2  2  2  2  0  0
     blockId:  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  2  2
 
-numIndices 32  itersPerThread 8  blockSize 1/1  gridSize 4
+numIndices 32  itersPerThread 8  blockSize 1/1  gridSize 4  cyclic false
   threadIdx:  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
     blockId:  0  0  0  0  0  0  0  0  1  1  1  1  1  1  1  1  2  2  2  2  2  2  2  2  3  3  3  3  3  3  3  3
 
-numIndices 32  itersPerThread 8  blockSize 2/2  gridSize 2
+numIndices 32  itersPerThread 8  blockSize 2/2  gridSize 2  cyclic false
   threadIdx:  0  0  0  0  0  0  0  0  1  1  1  1  1  1  1  1  0  0  0  0  0  0  0  0  1  1  1  1  1  1  1  1
     blockId:  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1
 
-numIndices 32  itersPerThread 8  blockSize 3/3  gridSize 2
+numIndices 32  itersPerThread 8  blockSize 3/3  gridSize 2  cyclic false
   threadIdx:  0  0  0  0  0  0  0  0  1  1  1  1  1  1  1  1  2  2  2  2  2  2  2  2  0  0  0  0  0  0  0  0
     blockId:  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  1  1  1  1  1  1  1  1
 
-numIndices 32  itersPerThread 8  blockSize 4/4  gridSize 1
+numIndices 32  itersPerThread 8  blockSize 4/4  gridSize 1  cyclic false
   threadIdx:  0  0  0  0  0  0  0  0  1  1  1  1  1  1  1  1  2  2  2  2  2  2  2  2  3  3  3  3  3  3  3  3
     blockId:  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
 
-numIndices 32  itersPerThread 8  blockSize 5/5  gridSize 1
+numIndices 32  itersPerThread 8  blockSize 5/5  gridSize 1  cyclic false
   threadIdx:  0  0  0  0  0  0  0  0  1  1  1  1  1  1  1  1  2  2  2  2  2  2  2  2  3  3  3  3  3  3  3  3
     blockId:  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
 
-numIndices 32  itersPerThread 1  blockSize 3/3  gridSize 11
+numIndices 32  itersPerThread 1  blockSize 3/3  gridSize 11  cyclic true
   threadIdx:  0  1  2  0  1  2  0  1  2  0  1  2  0  1  2  0  1  2  0  1  2  0  1  2  0  1  2  0  1  2  0  1
     blockId:  0  0  0  1  1  1  2  2  2  3  3  3  4  4  4  5  5  5  6  6  6  7  7  7  8  8  8  9  9  9 10 10
 
-numIndices 32  itersPerThread 2  blockSize 3/3  gridSize 6
+numIndices 32  itersPerThread 2  blockSize 3/3  gridSize 6  cyclic true
   threadIdx:  0  1  2  0  1  2  0  1  2  0  1  2  0  1  2  0  0  1  2  0  1  2  0  1  2  0  1  2  0  1  2  0
     blockId:  0  0  0  1  1  1  2  2  2  3  3  3  4  4  4  5  0  0  0  1  1  1  2  2  2  3  3  3  4  4  4  5
 
-numIndices 32  itersPerThread 3  blockSize 3/3  gridSize 4
+numIndices 32  itersPerThread 3  blockSize 3/3  gridSize 4  cyclic true
   threadIdx:  0  1  2  0  1  2  0  1  2  0  1  0  1  2  0  1  2  0  1  2  0  1  0  1  2  0  1  2  0  1  2  0
     blockId:  0  0  0  1  1  1  2  2  2  3  3  0  0  0  1  1  1  2  2  2  3  3  0  0  0  1  1  1  2  2  2  3
 
-numIndices 32  itersPerThread 4  blockSize 3/3  gridSize 3
+numIndices 32  itersPerThread 4  blockSize 3/3  gridSize 3  cyclic true
   threadIdx:  0  1  2  0  1  2  0  1  0  1  2  0  1  2  0  1  0  1  2  0  1  2  0  1  0  1  2  0  1  2  0  1
     blockId:  0  0  0  1  1  1  2  2  0  0  0  1  1  1  2  2  0  0  0  1  1  1  2  2  0  0  0  1  1  1  2  2
 
-numIndices 32  itersPerThread 5  blockSize 3/3  gridSize 3
+numIndices 32  itersPerThread 5  blockSize 3/3  gridSize 3  cyclic true
   threadIdx:  0  1  2  0  1  2  0  0  1  2  0  1  2  0  0  1  2  0  1  2  0  0  1  2  0  1  2  0  0  1  2  0
     blockId:  0  0  0  1  1  1  2  0  0  0  1  1  1  2  0  0  0  1  1  1  2  0  0  0  1  1  1  2  0  0  0  1
 
-numIndices 32  itersPerThread 8  blockSize 1/1  gridSize 4
+numIndices 32  itersPerThread 8  blockSize 1/1  gridSize 4  cyclic true
   threadIdx:  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
     blockId:  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3
 
-numIndices 32  itersPerThread 8  blockSize 2/2  gridSize 2
+numIndices 32  itersPerThread 8  blockSize 2/2  gridSize 2  cyclic true
   threadIdx:  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1
     blockId:  0  0  1  1  0  0  1  1  0  0  1  1  0  0  1  1  0  0  1  1  0  0  1  1  0  0  1  1  0  0  1  1
 
-numIndices 32  itersPerThread 8  blockSize 3/3  gridSize 2
+numIndices 32  itersPerThread 8  blockSize 3/3  gridSize 2  cyclic true
   threadIdx:  0  1  2  0  0  1  2  0  0  1  2  0  0  1  2  0  0  1  2  0  0  1  2  0  0  1  2  0  0  1  2  0
     blockId:  0  0  0  1  0  0  0  1  0  0  0  1  0  0  0  1  0  0  0  1  0  0  0  1  0  0  0  1  0  0  0  1
 
-numIndices 32  itersPerThread 8  blockSize 4/4  gridSize 1
+numIndices 32  itersPerThread 8  blockSize 4/4  gridSize 1  cyclic true
   threadIdx:  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3
     blockId:  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
 
-numIndices 32  itersPerThread 8  blockSize 5/5  gridSize 1
+numIndices 32  itersPerThread 8  blockSize 5/5  gridSize 1  cyclic true
   threadIdx:  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3
     blockId:  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
 

--- a/test/gpu/native/basics/itersPerThread.good
+++ b/test/gpu/native/basics/itersPerThread.good
@@ -46,3 +46,43 @@ numIndices 32  itersPerThread 8  blockSize 5/5  gridSize 1
   threadIdx:  0  0  0  0  0  0  0  0  1  1  1  1  1  1  1  1  2  2  2  2  2  2  2  2  3  3  3  3  3  3  3  3
     blockId:  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
 
+numIndices 32  itersPerThread 1  blockSize 3/3  gridSize 11
+  threadIdx:  0  1  2  0  1  2  0  1  2  0  1  2  0  1  2  0  1  2  0  1  2  0  1  2  0  1  2  0  1  2  0  1
+    blockId:  0  0  0  1  1  1  2  2  2  3  3  3  4  4  4  5  5  5  6  6  6  7  7  7  8  8  8  9  9  9 10 10
+
+numIndices 32  itersPerThread 2  blockSize 3/3  gridSize 6
+  threadIdx:  0  1  2  0  1  2  0  1  2  0  1  2  0  1  2  0  0  1  2  0  1  2  0  1  2  0  1  2  0  1  2  0
+    blockId:  0  0  0  1  1  1  2  2  2  3  3  3  4  4  4  5  0  0  0  1  1  1  2  2  2  3  3  3  4  4  4  5
+
+numIndices 32  itersPerThread 3  blockSize 3/3  gridSize 4
+  threadIdx:  0  1  2  0  1  2  0  1  2  0  1  0  1  2  0  1  2  0  1  2  0  1  0  1  2  0  1  2  0  1  2  0
+    blockId:  0  0  0  1  1  1  2  2  2  3  3  0  0  0  1  1  1  2  2  2  3  3  0  0  0  1  1  1  2  2  2  3
+
+numIndices 32  itersPerThread 4  blockSize 3/3  gridSize 3
+  threadIdx:  0  1  2  0  1  2  0  1  0  1  2  0  1  2  0  1  0  1  2  0  1  2  0  1  0  1  2  0  1  2  0  1
+    blockId:  0  0  0  1  1  1  2  2  0  0  0  1  1  1  2  2  0  0  0  1  1  1  2  2  0  0  0  1  1  1  2  2
+
+numIndices 32  itersPerThread 5  blockSize 3/3  gridSize 3
+  threadIdx:  0  1  2  0  1  2  0  0  1  2  0  1  2  0  0  1  2  0  1  2  0  0  1  2  0  1  2  0  0  1  2  0
+    blockId:  0  0  0  1  1  1  2  0  0  0  1  1  1  2  0  0  0  1  1  1  2  0  0  0  1  1  1  2  0  0  0  1
+
+numIndices 32  itersPerThread 8  blockSize 1/1  gridSize 4
+  threadIdx:  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
+    blockId:  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3
+
+numIndices 32  itersPerThread 8  blockSize 2/2  gridSize 2
+  threadIdx:  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1
+    blockId:  0  0  1  1  0  0  1  1  0  0  1  1  0  0  1  1  0  0  1  1  0  0  1  1  0  0  1  1  0  0  1  1
+
+numIndices 32  itersPerThread 8  blockSize 3/3  gridSize 2
+  threadIdx:  0  1  2  0  0  1  2  0  0  1  2  0  0  1  2  0  0  1  2  0  0  1  2  0  0  1  2  0  0  1  2  0
+    blockId:  0  0  0  1  0  0  0  1  0  0  0  1  0  0  0  1  0  0  0  1  0  0  0  1  0  0  0  1  0  0  0  1
+
+numIndices 32  itersPerThread 8  blockSize 4/4  gridSize 1
+  threadIdx:  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3
+    blockId:  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
+
+numIndices 32  itersPerThread 8  blockSize 5/5  gridSize 1
+  threadIdx:  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3
+    blockId:  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
+


### PR DESCRIPTION
This PR implements the cyclic / round-robin assignment of loop iterations to GPU threads when the user passes a param `true` as the second argument to the `@gpu.itersPerThread` attribute.

This is a straightforward extension of the current implementation of `@gpu.itersPerThread` introduced in #25855 and retains its limitations. This PR advances #22175 by addressing https://github.com/chapel-lang/chapel/pull/25855#issuecomment-2327527618.

Next steps:

* [ ] Implement `@gpu.itersPerThread` for reduction kernels.
* [ ] Design: switch from a bool argument to a user-facing enum.

### Implementation notes

Switched PRIM_GPU_SET_BLOCKSIZE and PRIM_GPU_SET_ITERS_PER_THREAD to have the compiler-internal `counter` argument first.

Simplified the checking of the arguments to `@gpu.blockSize` and `@gpu.itersPerThread` in AutoGpu.chpl and in gpuTransforms.cpp.

Moved the call to `generateNumThreads()` to an earlier place within outlineEligibleLoop(), specifically from generateGpuAndNonGpuPaths -> generateKernelLaunch to GpuKernel::GpuKernel -> buildStubOutlinedFunction. This is because the numThreads symbol may now be needed in buildStubOutlinedFunction -> generateOobCond.

Testing:

* [x] standard and gasnet paratests
* [x] GPU=nvidia
* [ ] GPU=cpu
