### PR TITLE
remove supressif file for GPU mathKernel test

### DIFF
--- a/test/gpu/native/studies/math/mathKernels.suppressif
+++ b/test/gpu/native/studies/math/mathKernels.suppressif
@@ -1,2 +1,0 @@
-# doing cuda interop on a cray-cs hangs the whole program
-CHPL_TARGET_PLATFORM==cray-cs


### PR DESCRIPTION
`gpu/native/studies/math/mathKernels` is now passing on cray-cs. This PR removes the `supressif` file s.t. failures are no longer ignored in nightly testing.