### PR TITLE
Dyno: Fix disambiguation bug with param integral formals

### DIFF
--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -1018,10 +1018,13 @@ CanPassResult CanPassResult::canPass(Context* context,
   const Param* actualParam = actualQT.param();
   const Param* formalParam = formalQT.param();
   if (actualParam && formalParam) {
-    if (actualParam != formalParam) {
-      // passing different param values won't do
-      return fail(FAIL_MISMATCHED_PARAM);
-    } // otherwise continue with type information
+    // Note: Comparing 'actualParam' and 'formalParam' here isn't quite enough.
+    // We could have squeezed an int(64) '0' into a uint(64) formal, which
+    // would then be instantiated as a uint(64) '0'.
+    //
+    // Passing a param with a value to another such param isn't valid in Chapel,
+    // so the caller should be responsible for catching that case and dealing
+    // with it based on the context of the two arguments.
   } else if (formalParam && !actualParam) {
     // this case doesn't make sense
     CHPL_ASSERT(false && "case not expected");
@@ -1357,6 +1360,29 @@ commonType(Context* context,
   if (!properties.valid()) return chpl::empty;
   auto bestKind = properties.toKind();
 
+  // Check param values of each type. If a param is required and the values
+  // do not match then there is no common type.
+  //
+  // If a param is not required and there is a mismatch continue on without
+  // param-ness.
+  bool paramRequired = requiredKind &&
+                       *requiredKind == QualifiedType::PARAM;
+  if (bestKind == QualifiedType::PARAM || paramRequired) {
+    auto firstParam = types.front().param();
+    bool mismatch = false;
+    for (auto& type : types) {
+      mismatch = mismatch || type.param() != firstParam;
+    }
+    if (mismatch) {
+      if (paramRequired) {
+        return chpl::empty;
+      } else {
+        properties.setParam(false);
+        bestKind = properties.toKind();
+      }
+    }
+  }
+
   // Create a new list of types with their kinds adjusted.
   std::vector<QualifiedType> adjustedTypes;
   for (const auto& type : types) {
@@ -1379,22 +1405,6 @@ commonType(Context* context,
   if (auto commonType = findByAncestor(context, adjustedTypes, requiredKind))
     return commonType;
 
-  bool paramRequired = requiredKind &&
-                       *requiredKind == QualifiedType::PARAM;
-
-  if (bestKind == QualifiedType::PARAM && !paramRequired) {
-    // We couldn't unify the types as params, but maybe if we downgrade
-    // them to values, it'll work.
-    properties.setParam(false);
-    bestKind = properties.toKind();
-    for (auto& adjustedType : adjustedTypes) {
-      // adjust kind and strip param
-      adjustedType = QualifiedType(bestKind, adjustedType.type());
-    }
-
-    if (auto commonType = findByPassing(context, adjustedTypes))
-      return commonType;
-  }
   return chpl::empty;
 }
 

--- a/frontend/test/resolution/testDisambiguation.cpp
+++ b/frontend/test/resolution/testDisambiguation.cpp
@@ -356,6 +356,28 @@ static void test5() {
   assert(qt.type()->isIntType());
 }
 
+static void test6() {
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  std::string program = R"""(
+    proc helper(param a : int(64), param b : int(64)) param {
+      return true;
+    }
+
+    proc helper(param a : uint(64), param b : uint(64)) param {
+      return false;
+    }
+
+    param val : uint = 1;
+    var x = if helper(val, 0) then 5 else "42";
+  )""";
+
+  auto qt = resolveQualifiedTypeOfX(context, program);
+  assert(qt.type()->isStringType());
+}
+
 int main() {
 
   test1();
@@ -363,6 +385,7 @@ int main() {
   test3();
   test4();
   test5();
+  test6();
 
   return 0;
 }


### PR DESCRIPTION
Fixes a disambiguation bug caused by re-checking if an instantiation was correct by using the instantiated param-with-a-value formal with canPass. In the test case added by this PR, we would compare an ``int`` actual to an instantiated ``uint`` formal, which of course have different ``Param*`` classes, meaning the candidate would be discarded.

Testing:
- [x] test-dyno