### PR TITLE
Gpu diag grid size

### DIFF
--- a/runtime/include/chpl-gpu-diags.h
+++ b/runtime/include/chpl-gpu-diags.h
@@ -142,10 +142,14 @@ int chpl_gpu_diags_is_enabled(void) {
   } while(0)
 
 #define chpl_gpu_diags_verbose_launch( \
-  ln, fn, device_id, blk_dim_x, blk_dim_y, blk_dim_z) \
+  ln, fn, device_id, \
+    grd_dim_x, grd_dim_y, grd_dim_z, \
+    blk_dim_x, blk_dim_y, blk_dim_z) \
     chpl_gpu_diags_verbose_printf(false, device_id,   \
-    "%s:%d: kernel launch (block size: %dx%dx%d)",    \
-    chpl_lookupFilename(fn), ln, blk_dim_x, blk_dim_y, blk_dim_z)
+    "%s:%d: kernel launch (grid size: %dx%dx%d, block size: %dx%dx%d)",    \
+    chpl_lookupFilename(fn), ln, \
+    grd_dim_x, grd_dim_y, grd_dim_z, \
+    blk_dim_x, blk_dim_y, blk_dim_z)
 
 #define chpl_gpu_diags_verbose_device_to_host_copy( \
   ln, fn, src_device_id, size, commid) \

--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -635,6 +635,15 @@ void* chpl_gpu_init_kernel_cfg(const char* fn_name, int64_t num_threads,
                                int blk_dim, int n_params, int n_pids,
                                int n_reduce_vars, int n_host_registered_vars,
                                int ln, int32_t fn) {
+
+  if (blk_dim <= 0) {
+    char msg[200];
+    snprintf(msg, sizeof(msg),
+             "Illegal block size was specified for the GPU kernel: %d\n",
+             blk_dim);
+    chpl_error(msg, ln, fn);
+  }
+
   void* ret = chpl_mem_alloc(sizeof(kernel_cfg),
                              CHPL_RT_MD_GPU_KERNEL_PARAM_META, ln, fn);
 

--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -808,6 +808,7 @@ static void launch_kernel(const char* name,
   chpl_gpu_impl_use_device(cfg->dev);
 
   chpl_gpu_diags_verbose_launch(cfg->ln, cfg->fn, cfg->dev,
+                                grd_dim_x, grd_dim_y, grd_dim_z,
                                 blk_dim_x, blk_dim_y, blk_dim_z);
   chpl_gpu_diags_incr(kernel_launch);
 

--- a/test/gpu/native/basics/diagsGridSize.chpl
+++ b/test/gpu/native/basics/diagsGridSize.chpl
@@ -1,0 +1,10 @@
+use GpuDiagnostics;
+
+on here.gpus[0] {
+  startVerboseGpu();
+  for size in 128..1024 by 128 {
+    @gpu.blockSize(size)
+    foreach i in 1..1500 { }
+  }
+  stopVerboseGpu();
+}

--- a/test/gpu/native/basics/diagsGridSize.good
+++ b/test/gpu/native/basics/diagsGridSize.good
@@ -1,0 +1,8 @@
+0 (gpu 0): diagsGridSize.chpl:7: kernel launch (grid size: 12x1x1, block size: 128x1x1)
+0 (gpu 0): diagsGridSize.chpl:7: kernel launch (grid size: 6x1x1, block size: 256x1x1)
+0 (gpu 0): diagsGridSize.chpl:7: kernel launch (grid size: 4x1x1, block size: 384x1x1)
+0 (gpu 0): diagsGridSize.chpl:7: kernel launch (grid size: 3x1x1, block size: 512x1x1)
+0 (gpu 0): diagsGridSize.chpl:7: kernel launch (grid size: 3x1x1, block size: 640x1x1)
+0 (gpu 0): diagsGridSize.chpl:7: kernel launch (grid size: 2x1x1, block size: 768x1x1)
+0 (gpu 0): diagsGridSize.chpl:7: kernel launch (grid size: 2x1x1, block size: 896x1x1)
+0 (gpu 0): diagsGridSize.chpl:7: kernel launch (grid size: 2x1x1, block size: 1024x1x1)


### PR DESCRIPTION
This PR adds the grid size to the kernel launch output when verbose GPU mode is used.

Resolves https://github.com/chapel-lang/chapel/issues/25980

While there, it also adds a proper runtime error for when a non-positive block size is specified by the user. Without it, I am getting floating point exceptions for 0 block size. It'll probably be an error message from the driver if you specify something negative.

TODO:
- [ ] add test for the new error message

Test:
- [ ] amd

