### PR TITLE
instantiate types with defaults when appropriate while comparing

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -2972,6 +2972,10 @@ FnSymbol* tryResolveCall(CallExpr* call, bool checkWithin) {
   return resolveNormalCall(call, checkState);
 }
 
+static Type* resolveGenericActual(SymExpr* se, CallExpr* inCall,
+                                  bool resolvePartials = false);
+static Type* resolveGenericActual(SymExpr* se, Type* type);
+
 static bool resolveTypeComparisonCall(CallExpr* call) {
 
   if (UnresolvedSymExpr* urse = toUnresolvedSymExpr(call->baseExpr)) {
@@ -2989,8 +2993,12 @@ static bool resolveTypeComparisonCall(CallExpr* call) {
             lhs->symbol()->hasFlag(FLAG_TYPE_VARIABLE) &&
             rhs->symbol()->hasFlag(FLAG_TYPE_VARIABLE))
         {
+            // Instantiate generic-with-default types if needed.
+            Type* lhsType = resolveGenericActual(lhs, call);
+            Type* rhsType = resolveGenericActual(rhs, call);
+
             Symbol* value = gFalse;
-            bool sameType = lhs->symbol()->type == rhs->symbol()->type;
+            bool sameType = lhsType == rhsType;
             if (eq && sameType)
               value = gTrue;
             if (ne && !sameType)
@@ -3158,10 +3166,6 @@ static bool isGenericSubclass(Type* targetType, Type* valueType) {
 
   return ret;
 }
-
-static Type* resolveGenericActual(SymExpr* se, CallExpr* inCall,
-                                  bool resolvePartials = false);
-static Type* resolveGenericActual(SymExpr* se, Type* type);
 
 static bool resolveBuiltinCastCall(CallExpr* call)
 {

--- a/test/types/records/generic/typeCompareWithDefaults.chpl
+++ b/test/types/records/generic/typeCompareWithDefaults.chpl
@@ -1,0 +1,28 @@
+record R {
+  param flag = true;
+}
+
+// Note: need two functions (instead of adding a second type formal) because
+// regular function calls have type actuals instantiated-if-needed. Thus,
+// foo(R) will be instantiate as foo(R(true)). As such, it wouldn't catch
+// the case in which the call `==` fails to instantiate R (the arg would already
+// be instantiated).
+
+proc foo(type t) {
+  if t == R then
+    writeln("Got an R");
+  else
+    writeln("It seems I didn't get an R, but rather a ", t:string);
+}
+
+proc bar(type t) {
+  if t == R(?) then
+    writeln("Got an R(?)");
+  else
+    writeln("It seems I didn't get an R(?), but rather a ", t:string);
+}
+
+foo(R);
+foo(R(?));
+bar(R);
+bar(R(?));

--- a/test/types/records/generic/typeCompareWithDefaults.good
+++ b/test/types/records/generic/typeCompareWithDefaults.good
@@ -1,0 +1,4 @@
+Got an R
+It seems I didn't get an R, but rather a R(?)
+It seems I didn't get an R(?), but rather a R(true)
+Got an R(?)


### PR DESCRIPTION
Fixes https://github.com/chapel-lang/chapel/issues/26132.

This is a very similar issue to the one in https://github.com/chapel-lang/chapel/pull/26151. A builtin function (`: string` in the previous PR, `==` in the current PR) did not correctly handle the case of generic-with-default symbols as arguments. This PR changes that.

Reviewed by @riftEmber -- thanks!

## Testing
- [x] paratest