### PR TITLE
Respect CFLAGS and LDFLAGS when compiling C libraries

### DIFF
--- a/third-party/hwloc/Makefile
+++ b/third-party/hwloc/Makefile
@@ -75,7 +75,7 @@ hwloc-config: FORCE
 	mkdir -p $(HWLOC_BUILD_DIR)
 	cd $(HWLOC_BUILD_DIR) && $(HWLOC_SUBDIR)/configure CC='$(CC)' \
 		CFLAGS='$(CFLAGS)' CXX='$(CXX)' CXXFLAGS='$(CFLAGS)' \
-		LDFLAGS='$(RUNTIME_LFLAGS)' --prefix=$(HWLOC_INSTALL_DIR) \
+		LDFLAGS='$(RUNTIME_LFLAGS) $(LDFLAGS)' --prefix=$(HWLOC_INSTALL_DIR) \
 		$(CHPL_HWLOC_CFG_OPTIONS)
 
 hwloc-build: FORCE

--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -216,7 +216,7 @@ qthread-config: FORCE
 	mkdir -p $(QTHREAD_BUILD_DIR)
 	cd $(QTHREAD_BUILD_DIR) \
 	&& $(QTHREAD_SUBDIR)/configure CC='$(CC)' CFLAGS='$(CFLAGS)' \
-	       CXX='$(CXX)'  CXXFLAGS='$(CFLAGS)' LDFLAGS='$(RUNTIME_LFLAGS)' \
+	       CXX='$(CXX)'  CXXFLAGS='$(CFLAGS)' LDFLAGS='$(RUNTIME_LFLAGS) $(LDFLAGS)' \
 	       --prefix=$(QTHREAD_INSTALL_DIR) $(CHPL_QTHREAD_CFG_OPTIONS)
 
 qthread-build: FORCE

--- a/util/config/make_sys_basic_types.py
+++ b/util/config/make_sys_basic_types.py
@@ -103,6 +103,7 @@ def get_sys_c_types(docs=False):
     compileline_proc = subprocess.Popen([compileline_cmd, '--compile'],
         stdout=subprocess.PIPE, env=compileline_env)
     compileline = compileline_proc.communicate()[0].decode("utf-8").strip()
+    compileline += ' ' + os.environ.get('CFLAGS', '')
     logging.debug('Compile line: {0}'.format(compileline))
 
     # Create temp header file with *_MAX macros, then run it through the C


### PR DESCRIPTION
This PR fixes places in out build system that did not respect CFLAGS/LDFLAGS. This causes issues where these env vars hold important flags that are required for correct compilation on some systems, especially when using the bundled LLVM.

[Reviewed by @]