### PR TITLE
Dyno resolve returns within param for loop

### DIFF
--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -624,8 +624,9 @@ bool ReturnTypeInferrer::enter(const For* forLoop, RV& rv) {
         child->traverse(loopVis);
       }
 
-      // stop processing subsequent bodies after a return or break statement
       if (hasHitBreak() || hasReturnedOrThrown()) {
+        // Stop processing subsequent loop bodies after a return or break
+        // statement; they're never reached.
         break;
       }
     }

--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -483,7 +483,9 @@ void ReturnTypeInferrer::exitScope(const uast::AstNode* node) {
 
     for (auto& subFrame : parentFrame->subFrames) {
       if (subFrame.astNode == node) {
-        CHPL_ASSERT(!storedAsSubFrame && "should not be possible");
+        CHPL_ASSERT(
+            !storedAsSubFrame &&
+            "should not be possible to store a frame as multiple sub-frames");
         subFrame.frame = std::move(poppingFrame);
         storedAsSubFrame = true;
       }

--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -460,18 +460,16 @@ void ReturnTypeInferrer::exitScope(const uast::AstNode* node) {
     bool allContinue = true;
     bool allSkip = true;
     for (auto& subFrame : poppingFrame->subFrames) {
-      if (subFrame.skip) continue;
-      allSkip = false;
+      if (subFrame.skip)
+        continue;
+      else
+        allSkip = false;
 
-      if (subFrame.frame == nullptr || !subFrame.frame->returnsOrThrows) {
-        allReturnOrThrow = false;
-      }
-      if (subFrame.frame == nullptr || !subFrame.frame->breaks) {
-        allBreak = false;
-      }
-      if (subFrame.frame == nullptr || !subFrame.frame->continues) {
-        allContinue = false;
-      }
+      bool frameNonEmpty = subFrame.frame != nullptr;
+
+      allReturnOrThrow &= frameNonEmpty && subFrame.frame->returnsOrThrows;
+      allBreak &= frameNonEmpty && subFrame.frame->breaks;
+      allContinue &= frameNonEmpty && subFrame.frame->continues;
     }
 
     // If all subframes skipped, then there were no returns.

--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -284,8 +284,8 @@ struct ReturnTypeInferrer {
   bool enter(const Select* sel, RV& rv);
   void exit(const Select* sel, RV& rv);
 
-  bool enter(const For* sel, RV& rv);
-  void exit(const For* sel, RV& rv);
+  bool enter(const For* forLoop, RV& rv);
+  void exit(const For* forLoop, RV& rv);
 
   bool enter(const Break* brk, RV& rv);
   void exit(const Break* brk, RV& rv);

--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -374,6 +374,8 @@ QualifiedType ReturnTypeInferrer::returnedType() {
                               (QualifiedType::Kind) returnIntent);
     if (!retType) {
       // Couldn't find common type, so return type is incorrect.
+      // TODO: replace with custom error class, and give more information about
+      // why we couldn't determine a return type
       context->error(fnAstForErr, "could not determine return type for function");
       retType = QualifiedType(QualifiedType::UNKNOWN, ErroneousType::get(context));
     }

--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -639,15 +639,6 @@ void ReturnTypeInferrer::exit(const For* forLoop, RV& rv) {
   exitScope(forLoop);
 }
 
-// int ReturnTypeInferrer::findEnclosingLoopFrame() {
-//   for (int i = returnFrames.size() - 1; i >= 0; i--) {
-//     if (returnFrames[i]->scopeAst->isLoop()) {
-//       return i;
-//     }
-//   }
-//   CHPL_ASSERT(false && "should not be possible");
-// }
-
 bool ReturnTypeInferrer::enter(const Break* brk, RV& rv) {
   CHPL_ASSERT(!returnFrames.empty());
   returnFrames.back()->breaks = true;

--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -460,10 +460,11 @@ void ReturnTypeInferrer::exitScope(const uast::AstNode* node) {
     bool allContinue = true;
     bool allSkip = true;
     for (auto& subFrame : poppingFrame->subFrames) {
-      if (subFrame.skip)
+      if (subFrame.skip) {
         continue;
-      else
+      } else {
         allSkip = false;
+      }
 
       bool frameNonEmpty = subFrame.frame != nullptr;
 

--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -437,10 +437,13 @@ void ReturnTypeInferrer::exitScope(const uast::AstNode* node) {
 
   bool parentReturnsOrThrows = poppingFrame->returnsOrThrows;
 
-  if (poppingFrame->scopeAst->isLoop() && !(poppingFrame->scopeAst->isFor() && poppingFrame->scopeAst->toFor()->isParam())) {
-    // Could have while true { break; return; }, so do not propagate
-    // returns.
-    parentReturnsOrThrows = false;
+  if (poppingFrame->scopeAst->isLoop()) {
+    if (!(poppingFrame->scopeAst->isFor() &&
+          poppingFrame->scopeAst->toFor()->isParam())) {
+      // Do not propagate returns from non-param loops, as we can't statically
+      // know what they'll do at runtime.
+      parentReturnsOrThrows = false;
+    }
   }
 
   // Integrate sub-frame information.

--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -272,8 +272,6 @@ struct ReturnTypeInferrer {
   bool markReturnOrThrow();
   bool hasReturnedOrThrown();
 
-  void markBreak();
-  void markContinue();
   bool hasHitBreak();
   bool hasHitBreakOrContinue();
 
@@ -515,16 +513,6 @@ bool ReturnTypeInferrer::hasReturnedOrThrown() {
   return returnFrames.back()->returnsOrThrows;
 }
 
-void ReturnTypeInferrer::markBreak() {
-  CHPL_ASSERT(!returnFrames.empty());
-  returnFrames.back()->breaks = true;
-}
-
-void ReturnTypeInferrer::markContinue() {
-  CHPL_ASSERT(!returnFrames.empty());
-  returnFrames.back()->continues = true;
-}
-
 bool ReturnTypeInferrer::hasHitBreak() {
   if (returnFrames.empty()) return false;
   auto& topFrame = returnFrames.back();
@@ -661,12 +649,14 @@ void ReturnTypeInferrer::exit(const For* forLoop, RV& rv) {
 // }
 
 bool ReturnTypeInferrer::enter(const Break* brk, RV& rv) {
-  markBreak();
+  CHPL_ASSERT(!returnFrames.empty());
+  returnFrames.back()->breaks = true;
   return false;
 }
 void ReturnTypeInferrer::exit(const Break* brk, RV& rv) {}
 bool ReturnTypeInferrer::enter(const Continue* cont, RV& rv) {
-  markContinue();
+  CHPL_ASSERT(!returnFrames.empty());
+  returnFrames.back()->continues = true;
   return false;
 }
 void ReturnTypeInferrer::exit(const Continue* cont, RV& rv) {}

--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -627,6 +627,7 @@ bool ReturnTypeInferrer::enter(const For* forLoop, RV& rv) {
   enterScope(forLoop);
 
   if (forLoop->isParam()) {
+    // For param loops, "unroll" by manually traversing each iteration.
     const ResolvedExpression& rr = rv.byAst(forLoop);
     const ResolvedParamLoop* resolvedLoop = rr.paramLoop();
     CHPL_ASSERT(resolvedLoop);
@@ -642,9 +643,11 @@ bool ReturnTypeInferrer::enter(const For* forLoop, RV& rv) {
         break;
       }
     }
-  }
 
-  return false;
+    return false;
+  } else {
+    return true;
+  }
 }
 void ReturnTypeInferrer::exit(const For* forLoop, RV& rv) {
   exitScope(forLoop);

--- a/frontend/test/resolution/testReturnTypes.cpp
+++ b/frontend/test/resolution/testReturnTypes.cpp
@@ -1221,6 +1221,98 @@ static void testParamLoop() {
                                          program);
     ensureParamBool(qt, true);
   }
+
+  // Return in iteration after a conditional break, hit only after return
+  {
+    Context ctx;
+    Context* context = &ctx;
+    ErrorGuard guard(context);
+
+    std::string program = ops + R"""(
+    proc foo() param {
+      for param i in 0..2 {
+        if i == 1 {
+          break;
+        }
+        return "asdf";
+      }
+      return true;
+    }
+    param x = foo();
+    )""";
+    QualifiedType qt = resolveTypeOfXInit(context,
+                                         program);
+    ensureParamString(qt, "asdf");
+  }
+
+  // Return in iteration after a conditional break, hit before any return
+  {
+    Context ctx;
+    Context* context = &ctx;
+    ErrorGuard guard(context);
+
+    std::string program = ops + R"""(
+    proc foo() param {
+      for param i in 0..2 {
+        if i == 0 {
+          break;
+        }
+        return "asdf";
+      }
+      return true;
+    }
+    param x = foo();
+    )""";
+    QualifiedType qt = resolveTypeOfXInit(context,
+                                         program);
+    ensureParamBool(qt, true);
+  }
+
+  // Return in iteration after a conditional continue, hit in only some iterations
+  {
+    Context ctx;
+    Context* context = &ctx;
+    ErrorGuard guard(context);
+
+    std::string program = ops + R"""(
+    proc foo() param {
+      for param i in 0..2 {
+        if i == 0 {
+          continue;
+        }
+        return "asdf";
+      }
+      return true;
+    }
+    param x = foo();
+    )""";
+    QualifiedType qt = resolveTypeOfXInit(context,
+                                         program);
+    ensureParamString(qt, "asdf");
+  }
+
+  // Return in iteration after a conditional continue, hit in all iterations
+  {
+    Context ctx;
+    Context* context = &ctx;
+    ErrorGuard guard(context);
+
+    std::string program = ops + R"""(
+    proc foo() param {
+      for param i in 0..2 {
+        if i != 3 {
+          continue;
+        }
+        return "asdf";
+      }
+      return true;
+    }
+    param x = foo();
+    )""";
+    QualifiedType qt = resolveTypeOfXInit(context,
+                                         program);
+    ensureParamBool(qt, true);
+  }
 }
 
 static void testCPtrEltType() {

--- a/frontend/test/resolution/testReturnTypes.cpp
+++ b/frontend/test/resolution/testReturnTypes.cpp
@@ -1179,6 +1179,48 @@ static void testParamLoop() {
                                          program);
     ensureParamBool(qt, true);
   }
+
+  // Return in iteration after break
+  {
+    Context ctx;
+    Context* context = &ctx;
+    ErrorGuard guard(context);
+
+    std::string program = ops + R"""(
+    proc foo() param {
+      for param i in 0..2 {
+        break;
+        return "asdf";
+      }
+      return true;
+    }
+    param x = foo();
+    )""";
+    QualifiedType qt = resolveTypeOfXInit(context,
+                                         program);
+    ensureParamBool(qt, true);
+  }
+
+  // Return in iteration after continue
+  {
+    Context ctx;
+    Context* context = &ctx;
+    ErrorGuard guard(context);
+
+    std::string program = ops + R"""(
+    proc foo() param {
+      for param i in 0..2 {
+        break;
+        return "asdf";
+      }
+      return true;
+    }
+    param x = foo();
+    )""";
+    QualifiedType qt = resolveTypeOfXInit(context,
+                                         program);
+    ensureParamBool(qt, true);
+  }
 }
 
 static void testCPtrEltType() {

--- a/frontend/test/resolution/testReturnTypes.cpp
+++ b/frontend/test/resolution/testReturnTypes.cpp
@@ -1315,6 +1315,30 @@ static void testParamLoop() {
   }
 }
 
+// Test return from within non-param loop (shouldn't work)
+static void testNonParamLoop() {
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  std::string program = ops + R"""(
+  proc foo() {
+    for i in 0..2 {
+      return "asdf";
+    }
+    return true;
+  }
+  var x = foo();
+  )""";
+  QualifiedType qt = resolveTypeOfXInit(context,
+                                       program);
+
+  assert(qt.isErroneousType());
+  assert(guard.numErrors() == 1);
+  assert(guard.error(0)->message() == "could not determine return type for function");
+  guard.realizeErrors();
+}
+
 static void testCPtrEltType() {
   std::string chpl_home;
   if (const char* chpl_home_env = getenv("CHPL_HOME")) {
@@ -1565,6 +1589,7 @@ int main() {
   testSelectParams();
 
   testParamLoop();
+  testNonParamLoop();
 
   testCPtrEltType();
 

--- a/frontend/test/resolution/testReturnTypes.cpp
+++ b/frontend/test/resolution/testReturnTypes.cpp
@@ -1116,6 +1116,29 @@ static void testParamLoop() {
     ensureParamString(qt, "asdf");
   }
 
+  // Different returns in subsequent iterations
+  {
+    Context ctx;
+    Context* context = &ctx;
+    ErrorGuard guard(context);
+
+    std::string program = ops + R"""(
+    proc foo() param {
+      for param i in 0..2 {
+        if i == 1 {
+          return "asdf";
+        } else {
+          return true;
+        }
+      }
+    }
+    param x = foo();
+    )""";
+    QualifiedType qt = resolveTypeOfXInit(context,
+                                         program);
+    ensureParamBool(qt, true);
+  }
+
   // Return in param TRUE conditional inside param loop iteration
   {
     Context ctx;


### PR DESCRIPTION
Add dyno support for returns from within param for loops, matching production behavior.

Implemented by extending `ReturnTypeInferrer` to descend into param for loops, and respect `break` and `continue` statements which it can now encounter.

Includes adding testing for the fixed case, as well as several similar patterns of returning within a param loop.

Resolves https://github.com/Cray/chapel-private/issues/6787.

[reviewer info placeholder]

Testing:
- [x] dyno tests
- [x] paratest
- [x] resolves reproducer from backing issue