### PR TITLE
fix deviceattributes test by having cuda/hip calls to avoid nodiscard warning

### DIFF
--- a/test/gpu/native/deviceAttributes.cuda.c
+++ b/test/gpu/native/deviceAttributes.cuda.c
@@ -2,20 +2,26 @@
 #include <cuda.h>
 #include <stdio.h>
 
+#define CUDA_CALL(call) do {\
+  if(call) { \
+    printf("!!! error encountered on ROCM call\n"); \
+  } \
+} while(0);
+
 CUdevice device;
 
 static void reportAttribute(const char *name, CUdevice_attribute attr) {
   int val;
-  cuDeviceGetAttribute(&val, attr, device);
+  CUDA_CALL(cuDeviceGetAttribute(&val, attr, device));
   printf("%s: %d\n", name, val);
 }
 
 void runBaselineVersion(void) {
-  cuInit(0);
-  cuDeviceGet(&device, 0);
+  CUDA_CALL(cuInit(0));
+  CUDA_CALL(cuDeviceGet(&device, 0));
 
   char name[0xFF];
-  cuDeviceGetName(name, 0xFF, device);
+  CUDA_CALL(cuDeviceGetName(name, 0xFF, device));
   printf("name: %s\n", name);
 
   reportAttribute("maxThreadsPerBlock", CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK);

--- a/test/gpu/native/deviceAttributes.cuda.c
+++ b/test/gpu/native/deviceAttributes.cuda.c
@@ -4,7 +4,7 @@
 
 #define CUDA_CALL(call) do {\
   if(call) { \
-    printf("!!! error encountered on ROCM call\n"); \
+    printf("!!! error encountered on CUDA call\n"); \
   } \
 } while(0);
 

--- a/test/gpu/native/deviceAttributes.hip.c
+++ b/test/gpu/native/deviceAttributes.hip.c
@@ -7,20 +7,27 @@
 #include <hip/hip_runtime_api.h>
 #include <hip/hip_common.h>
 
+#define ROCM_CALL(call) do {\
+  if(call) { \
+    printf("!!! error encountered on ROCM call\n"); \
+  } \
+} while(0);
+
 hipDevice_t device;
 
 static void reportAttribute(const char *name, hipDeviceAttribute_t attr) {
   int val;
-  hipDeviceGetAttribute(&val, attr, device);
+  hipError_t err;
+  ROCM_CALL(hipDeviceGetAttribute(&val, attr, device));
   printf("%s: %d\n", name, val);
 }
 
 void runBaselineVersion(void) {
-  hipInit(0);
-  hipDeviceGet(&device, 0);
+  ROCM_CALL(hipInit(0));
+  ROCM_CALL(hipDeviceGet(&device, 0));
 
   char name[0xFF];
-  hipDeviceGetName(name, 0xFF, device);
+  ROCM_CALL(hipDeviceGetName(name, 0xFF, device));
   printf("name: %s\n", name);
 
   reportAttribute("maxThreadsPerBlock", hipDeviceAttributeMaxThreadsPerBlock);


### PR DESCRIPTION
It looks like for certain versions of HIP you'll get warnings like this if you call a HIP function and discard (don't capture) its result:

```
> deviceAttributes.hip.c:14:3: warning: ignoring return value of function declared with 'nodiscard' attribute [-Wunused-result]
>    14 |   hipDeviceGetAttribute(&val, attr, device);
```

I guess this a best practice as these functions return an error code and if you're not capturing it then you're not doing any error checking.

Anyway, this PR updates the deviceAttributes test to do this error checking and avoid this warning.

While at it, I do the same thing for CUDA.