### PR TITLE
Fix internal errors in some forwarding statement cases

### DIFF
--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -2525,6 +2525,11 @@ struct Converter final : UastConverter {
     }
     ret->insertAtTail(forwardingStmt);
 
+    // We never pushed the forwarding function onto the symbol stack, so
+    // we don't need to exit. Exiting normally notes fixups, though, so
+    // do that now.
+    noteAllContainedFixups(fn, 0);
+
     return ret;
   }
 

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2976,6 +2976,11 @@ const ResolutionResultByPostorderID& scopeResolveAggregate(Context* context,
           child->isTupleDecl() ||
           child->isForwardingDecl()) {
         auto res = Resolver::createForScopeResolvingField(context, ad, child, result);
+
+        if (child->isForwardingDecl()) {
+          res.allowReceiverScopes = true;
+        }
+
         child->traverse(res);
       }
     }

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -1292,6 +1292,9 @@ static const ID& methodReceiverTypeIdForMethodId(Context* context,
           // we want to ignore errors here while just scope resolving.
         }
       }
+    } else if (ast->isForwardingDecl()) {
+      // Find the containing aggregate ID
+      result = parsing::idToParentId(context, methodId);
     }
   }
 

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -338,6 +338,7 @@ bool createsScope(asttags::AstTag tag) {
          || asttags::isLoop(tag)
          || asttags::isCobegin(tag)
          || asttags::isConditional(tag)
+         || asttags::isForwardingDecl(tag)
          || asttags::isSelect(tag)
          || asttags::isWhen(tag)
          || asttags::isTry(tag)
@@ -574,6 +575,12 @@ static const Scope* const& scopeForIdQuery(Context* context, ID idIn) {
 
       // Always generate a scope for do-while loops, to simplify the below
       if (ast->isDoWhile()) {
+        newScope = true;
+      }
+
+      // Always generate a scope for forwarding statements, to ensure they
+      // are in a 'method scope' when searching for receivers.
+      if (ast->isForwardingDecl()) {
         newScope = true;
       }
 

--- a/frontend/lib/resolution/scope-types.cpp
+++ b/frontend/lib/resolution/scope-types.cpp
@@ -340,6 +340,11 @@ Scope::Scope(Context* context,
   if (auto fn = ast->toFunction()) {
     isMethodScope = fn->isMethod();
   }
+  if (auto fd = ast->toForwardingDecl()) {
+    // Forwarding statements in aggregate types should be treated as if there's
+    // an implicit 'this' receiver, so create a method scope.
+    isMethodScope = true;
+  }
   gatherDeclsWithin(context, ast, declared_,
                     containsUseImport,
                     containsFunctionDecls,

--- a/frontend/lib/resolution/scope-types.cpp
+++ b/frontend/lib/resolution/scope-types.cpp
@@ -339,8 +339,7 @@ Scope::Scope(Context* context,
   }
   if (auto fn = ast->toFunction()) {
     isMethodScope = fn->isMethod();
-  }
-  if (auto fd = ast->toForwardingDecl()) {
+  } else if (ast->isForwardingDecl()) {
     // Forwarding statements in aggregate types should be treated as if there's
     // an implicit 'this' receiver, so create a method scope.
     isMethodScope = true;

--- a/frontend/test/uast/testStringify.cpp
+++ b/frontend/test/uast/testStringify.cpp
@@ -312,7 +312,6 @@ static void test1(Parser* parser) {
    }
    type t;
    var Array:[1..1] t;
-   forwarding Array[1]!;
    const A: [1..10] int = [i in 1..10] if (i < 3) then 100 else i;
    writeln(A);
    var Cs = [i in nums] if i then new C[i] else nil: owned C?;

--- a/test/classes/forwarding/forwarding-to-method-and-non-method.bad
+++ b/test/classes/forwarding/forwarding-to-method-and-non-method.bad
@@ -1,6 +1,0 @@
-internal error: PAS-CON-AST-nnnn chpl version mmmm
-
-Internal errors indicate a bug in the Chapel compiler,
-and we're sorry for the hassle.  We would appreciate your reporting this bug --
-please see https://chapel-lang.org/bugs.html for instructions.
-

--- a/test/classes/forwarding/forwarding-to-method-and-non-method.future
+++ b/test/classes/forwarding/forwarding-to-method-and-non-method.future
@@ -1,2 +1,0 @@
-bug: forwarding to non-method causes --verify failure or segfault
-#25692

--- a/test/classes/forwarding/outside-of-class.chpl
+++ b/test/classes/forwarding/outside-of-class.chpl
@@ -1,0 +1,5 @@
+module M {
+  var x: int;
+  forwarding x; // internal error
+  // forwarding var y: int; // results in the same error
+}

--- a/test/classes/forwarding/outside-of-class.good
+++ b/test/classes/forwarding/outside-of-class.good
@@ -1,0 +1,2 @@
+outside-of-class.chpl:1: In module 'M':
+outside-of-class.chpl:3: error: forwarding declarations are only allowed in records and classes


### PR DESCRIPTION
Closes https://github.com/chapel-lang/chapel/issues/25692.

This PR fixes internal errors with forwarding statements.

The first case is simple -- it occurs when a forwarding statement is used outside a class or record. This is disallowed (forwarding statements are only allowed as part of a class or record per the [forwarding tech note](https://chapel-lang.org/docs/technotes/forwarding.html)). So, this PR adds a new post-parse check to rule out forwarding statements in that location.

The second case (reported by Michael in a comment in https://github.com/chapel-lang/chapel/issues/25692#issuecomment-2332178411) is actually a combination of two errors:

1. The `convert-uast.cpp` step misses `TemporaryConversionSymbols` created in forwarding declarations. This is because forwarding declarations create nested functions, and noting fixup locations (which replace TCSs) doesn't descend into nested function. This issue doesn't happen in _real_ primary methods because fixups are explicitly noted when converting them, as part of `popFromSymStack`. The solution is simply to note fixups when generating these nested functions for forwarding statements. 
2. Though fixing (1) fixes the internal error, it's not sufficient to unfuturize Michael's test, because the code incorrectly prefers the standalone parenless procedure over the parenless method that's implicitly invoked. This, in turn, is caused by the fact that forwarding statements prior to this PR were not counted as "method scopes", so implicit `this` resolution did not occur. This PR changes this by:
    * Making forwarding statements have scopes, and marking these scopes as method scopes. This way, they are considered as part of receiver-based resolution with implicit `this`
    * Ensuring that the code that sets up the `ReceiverScopeHelper` knows how to set up receiver scopes when outside a method context (i.e., when resolving a field)
    * Configuring the `ReceiverScopeSimpleHelper` to properly determine the type ID when considering forwarding declarations

Together, these changes fully resolve both internal errors in the original issue.

Reviewed by @mppf -- thanks!

## Future Work
This PR only adds a rudimentary form of receiver scope handling, suited for scope resolution but not for type resolution. It will likely need to be expanded when we need these features to work in resolution.

## Testing
- [x] paratest