### PR TITLE
Fix issues with runtime code in CPU-as-device mode

### DIFF
--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -87,6 +87,7 @@ static void override_number_of_devices(void) {
 }
 
 static void find_and_setup_devices(int numAllDevices) {
+#ifndef GPU_RUNTIME_CPU
   // Collect PCI information about each available device.
   chpl_topo_pci_addr_t *allAddrs = chpl_malloc(sizeof(*allAddrs) * numAllDevices);
   for (int i=0 ; i < numAllDevices; i++) {
@@ -129,6 +130,9 @@ static void find_and_setup_devices(int numAllDevices) {
 
   chpl_free(allAddrs);
   chpl_free(addrs);
+#else
+  int numDevices = numAllDevices;
+#endif
 
   chpl_gpu_num_devices = numDevices;
   assert(chpl_gpu_num_devices >= 0);
@@ -140,9 +144,7 @@ void chpl_gpu_init(void) {
   int numAllDevices;
   chpl_gpu_impl_begin_init(&numAllDevices);
 
-#ifndef GPU_RUNTIME_CPU
   find_and_setup_devices(numAllDevices);
-#endif
 
   // override number of devices if applicable
   override_number_of_devices();

--- a/runtime/src/gpu/cpu/gpu-cpu.c
+++ b/runtime/src/gpu/cpu/gpu-cpu.c
@@ -36,7 +36,7 @@
 
 void chpl_gpu_impl_begin_init(int* num_all_devices) {
   CHPL_GPU_DEBUG("Initializing none GPU layer.\n");
-  *num_devices = 1;
+  *num_all_devices = 1;
 }
 
 void chpl_gpu_impl_collect_topo_addr_info(chpl_topo_pci_addr_t* into,


### PR DESCRIPTION
There were some renaming and runtime bugs in CPU-as-device mode; this PR fixes them.

Reviewed by @e-kayrakli -- thanks!

## Testing
- [x] `test/gpu/native` test