### PR TITLE
have nightly gpu ex tests use partition w/ NVIDIA A100 SXM4 40GB

### DIFF
--- a/util/cron/test-gpu-ex-cuda-11.bash
+++ b/util/cron/test-gpu-ex-cuda-11.bash
@@ -14,7 +14,7 @@ export CHPL_CUDA_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/23.3/cuda/11.8
 
 export CHPL_COMM=none
 export CHPL_LOCALE_MODEL=gpu
-export CHPL_LAUNCHER_PARTITION=allgriz
+export CHPL_LAUNCHER_PARTITION=griz256
 export CHPL_GPU=nvidia  # amd is also detected automatically
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-ex-cuda-11"

--- a/util/cron/test-gpu-ex-cuda-12.bash
+++ b/util/cron/test-gpu-ex-cuda-12.bash
@@ -11,7 +11,7 @@ module load cudatoolkit  # default is CUDA 12
 export CHPL_LLVM=bundled  # CUDA 12 is only supported with bundled LLVM
 export CHPL_COMM=none
 export CHPL_LOCALE_MODEL=gpu
-export CHPL_LAUNCHER_PARTITION=allgriz
+export CHPL_LAUNCHER_PARTITION=griz256
 export CHPL_GPU=nvidia  # amd is also detected automatically
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-ex-cuda-12"

--- a/util/cron/test-gpu-ex-cuda-12.colocales.bash
+++ b/util/cron/test-gpu-ex-cuda-12.colocales.bash
@@ -11,7 +11,7 @@ export SLURM_NETWORK=single_node_vni
 export CHPL_RT_LOCALES_PER_NODE=2
 module load cuda/12.4
 
-export CHPL_LAUNCHER_PARTITION=allgriz
+export CHPL_LAUNCHER_PARTITION=griz256
 export CHPL_GPU=nvidia
 export CHPL_NIGHTLY_TEST_DIRS="gpu/native/multiLocale"
 

--- a/util/cron/test-gpu-ex-cuda-12.interop.bash
+++ b/util/cron/test-gpu-ex-cuda-12.interop.bash
@@ -20,7 +20,7 @@ export CHPL_LIB_PATH="/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/math_libs/lib64:$CHP
 
 export CHPL_LLVM=bundled  # Using bundled LLVM since that's safer
 export CHPL_TEST_GPU=true
-export CHPL_LAUNCHER_PARTITION=allgriz
+export CHPL_LAUNCHER_PARTITION=griz256
 export CHPL_NIGHTLY_TEST_DIRS="gpu/interop/"
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-ex-cuda-12.interop"

--- a/util/cron/test-gpu-ex-cuda-12.ofi.bash
+++ b/util/cron/test-gpu-ex-cuda-12.ofi.bash
@@ -11,7 +11,7 @@ module load cudatoolkit  # default is CUDA 12
 export CHPL_LLVM=bundled  # CUDA 12 is only supported with bundled LLVM
 export CHPL_COMM=ofi
 export CHPL_LOCALE_MODEL=gpu
-export CHPL_LAUNCHER_PARTITION=allgriz
+export CHPL_LAUNCHER_PARTITION=griz256
 export CHPL_GPU=nvidia  # amd is also detected automatically
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-ex-cuda-12.ofi"

--- a/util/cron/test-gpu-ex-cuda-12.specialization.bash
+++ b/util/cron/test-gpu-ex-cuda-12.specialization.bash
@@ -11,7 +11,7 @@ module load cudatoolkit  # default is CUDA 12
 export CHPL_LLVM=bundled  # Using bundled LLVM since that's safer
 export CHPL_COMM=none
 export CHPL_LOCALE_MODEL=gpu
-export CHPL_LAUNCHER_PARTITION=allgriz
+export CHPL_LAUNCHER_PARTITION=griz256
 export CHPL_TEST_GPU=true
 export CHPL_GPU=nvidia  # amd is also detected automatically
 

--- a/util/cron/test-perf.gpu-ex-cuda-12.bash
+++ b/util/cron/test-perf.gpu-ex-cuda-12.bash
@@ -11,7 +11,7 @@ module load cudatoolkit  # default is CUDA 12
 export CHPL_LLVM=bundled  # Using bundled LLVM since that's safer
 export CHPL_COMM=none
 export CHPL_LOCALE_MODEL=gpu
-export CHPL_LAUNCHER_PARTITION=allgriz
+export CHPL_LAUNCHER_PARTITION=griz256
 export CHPL_GPU=nvidia  # amd is detected automatically
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.gpu-ex-cuda-12"

--- a/util/cron/test-perf.gpu-ex-cuda-12.um.bash
+++ b/util/cron/test-perf.gpu-ex-cuda-12.um.bash
@@ -11,7 +11,7 @@ module load cudatoolkit  # default is CUDA 12
 export CHPL_LLVM=bundled # Using bundled LLVM since that's safer
 export CHPL_COMM=none
 export CHPL_LOCALE_MODEL=gpu
-export CHPL_LAUNCHER_PARTITION=allgriz
+export CHPL_LAUNCHER_PARTITION=griz256
 export CHPL_GPU=nvidia  # amd is detected automatically
 export CHPL_GPU_MEM_STRATEGY=unified_memory
 


### PR DESCRIPTION
Our nightly gpu tests that run on an EX machine are using a partition that has both 40GB and 80GB NVIDIA A100's.  This causes issues with our current `deviceAttributes` test and more generally it seems like we should be running our tests (particularly for our perf jobs) on a partition that will have more consistent hardware.

This PR updates our nightly test configs to do that.

If we run into resource issues then we should back this out, but I think we should wait until we encounter such issues before trying to work on the larger, less homogeneous, partition.

See: https://github.com/Cray/chapel-private/issues/6847