### PR TITLE
Show iterations grouped by GPU thread and block

### DIFF
--- a/test/gpu/native/basics/itersPerThread.good
+++ b/test/gpu/native/basics/itersPerThread.good
@@ -6,83 +6,357 @@ itersPerThr=4  (400): 300 301 302 303 400 400 400 400 401 401 401 401 402 402 40
 blsz=5 ipt=3   (500): 500 500 500 501 501 501 502 502 502 503 503 503 504 504 504 500 500 500 501 501 501 502 502 502 503 405 405 405 100 100 100 100
 blsz=2 ipt=3   (600): 500 610 610 610 611 611 611 610 502 503 620 620 620 620 620 620 621 500 632 632 632 632 632 632 632 405 405 405 100 100 100 100
 
-numIndices 32  itersPerThread 1  blockSize 3/3  gridSize 11  cyclic false
+numIndices 32  itersPerThread 1  blockSize 3  gridSize 11  block
   threadIdx:  0  1  2  0  1  2  0  1  2  0  1  2  0  1  2  0  1  2  0  1  2  0  1  2  0  1  2  0  1  2  0  1
     blockId:  0  0  0  1  1  1  2  2  2  3  3  3  4  4  4  5  5  5  6  6  6  7  7  7  8  8  8  9  9  9 10 10
+bl th | iters
+ 0  0 |  1 .
+ 0  1 |  2 .
+ 0  2 |  3 .
+ 1  0 |  4 .
+ 1  1 |  5 .
+ 1  2 |  6 .
+ 2  0 |  7 .
+ 2  1 |  8 .
+ 2  2 |  9 .
+ 3  0 | 10 .
+ 3  1 | 11 .
+ 3  2 | 12 .
+ 4  0 | 13 .
+ 4  1 | 14 .
+ 4  2 | 15 .
+ 5  0 | 16 .
+ 5  1 | 17 .
+ 5  2 | 18 .
+ 6  0 | 19 .
+ 6  1 | 20 .
+ 6  2 | 21 .
+ 7  0 | 22 .
+ 7  1 | 23 .
+ 7  2 | 24 .
+ 8  0 | 25 .
+ 8  1 | 26 .
+ 8  2 | 27 .
+ 9  0 | 28 .
+ 9  1 | 29 .
+ 9  2 | 30 .
+10  0 | 31 .
+10  1 | 32 .
+10  2 | .
 
-numIndices 32  itersPerThread 2  blockSize 3/3  gridSize 6  cyclic false
+numIndices 32  itersPerThread 2  blockSize 3  gridSize 6  block
   threadIdx:  0  0  1  1  2  2  0  0  1  1  2  2  0  0  1  1  2  2  0  0  1  1  2  2  0  0  1  1  2  2  0  0
     blockId:  0  0  0  0  0  0  1  1  1  1  1  1  2  2  2  2  2  2  3  3  3  3  3  3  4  4  4  4  4  4  5  5
+bl th | iters
+ 0  0 |  1  2 .
+ 0  1 |  3  4 .
+ 0  2 |  5  6 .
+ 1  0 |  7  8 .
+ 1  1 |  9 10 .
+ 1  2 | 11 12 .
+ 2  0 | 13 14 .
+ 2  1 | 15 16 .
+ 2  2 | 17 18 .
+ 3  0 | 19 20 .
+ 3  1 | 21 22 .
+ 3  2 | 23 24 .
+ 4  0 | 25 26 .
+ 4  1 | 27 28 .
+ 4  2 | 29 30 .
+ 5  0 | 31 32 .
+ 5  1 | .
+ 5  2 | .
 
-numIndices 32  itersPerThread 3  blockSize 3/3  gridSize 4  cyclic false
+numIndices 32  itersPerThread 3  blockSize 3  gridSize 4  block
   threadIdx:  0  0  0  1  1  1  2  2  2  0  0  0  1  1  1  2  2  2  0  0  0  1  1  1  2  2  2  0  0  0  1  1
     blockId:  0  0  0  0  0  0  0  0  0  1  1  1  1  1  1  1  1  1  2  2  2  2  2  2  2  2  2  3  3  3  3  3
+bl th | iters
+ 0  0 |  1  2  3 .
+ 0  1 |  4  5  6 .
+ 0  2 |  7  8  9 .
+ 1  0 | 10 11 12 .
+ 1  1 | 13 14 15 .
+ 1  2 | 16 17 18 .
+ 2  0 | 19 20 21 .
+ 2  1 | 22 23 24 .
+ 2  2 | 25 26 27 .
+ 3  0 | 28 29 30 .
+ 3  1 | 31 32 .
+ 3  2 | .
 
-numIndices 32  itersPerThread 4  blockSize 3/3  gridSize 3  cyclic false
+numIndices 32  itersPerThread 4  blockSize 3  gridSize 3  block
   threadIdx:  0  0  0  0  1  1  1  1  2  2  2  2  0  0  0  0  1  1  1  1  2  2  2  2  0  0  0  0  1  1  1  1
     blockId:  0  0  0  0  0  0  0  0  0  0  0  0  1  1  1  1  1  1  1  1  1  1  1  1  2  2  2  2  2  2  2  2
+bl th | iters
+ 0  0 |  1  2  3  4 .
+ 0  1 |  5  6  7  8 .
+ 0  2 |  9 10 11 12 .
+ 1  0 | 13 14 15 16 .
+ 1  1 | 17 18 19 20 .
+ 1  2 | 21 22 23 24 .
+ 2  0 | 25 26 27 28 .
+ 2  1 | 29 30 31 32 .
+ 2  2 | .
 
-numIndices 32  itersPerThread 5  blockSize 3/3  gridSize 3  cyclic false
+numIndices 32  itersPerThread 5  blockSize 3  gridSize 3  block
   threadIdx:  0  0  0  0  0  1  1  1  1  1  2  2  2  2  2  0  0  0  0  0  1  1  1  1  1  2  2  2  2  2  0  0
     blockId:  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  2  2
+bl th | iters
+ 0  0 |  1  2  3  4  5 .
+ 0  1 |  6  7  8  9 10 .
+ 0  2 | 11 12 13 14 15 .
+ 1  0 | 16 17 18 19 20 .
+ 1  1 | 21 22 23 24 25 .
+ 1  2 | 26 27 28 29 30 .
+ 2  0 | 31 32 .
+ 2  1 | .
+ 2  2 | .
 
-numIndices 32  itersPerThread 8  blockSize 1/1  gridSize 4  cyclic false
+numIndices 32  itersPerThread 8  blockSize 1  gridSize 4  block
   threadIdx:  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
     blockId:  0  0  0  0  0  0  0  0  1  1  1  1  1  1  1  1  2  2  2  2  2  2  2  2  3  3  3  3  3  3  3  3
+bl th | iters
+ 0  0 |  1  2  3  4  5  6  7  8 .
+ 1  0 |  9 10 11 12 13 14 15 16 .
+ 2  0 | 17 18 19 20 21 22 23 24 .
+ 3  0 | 25 26 27 28 29 30 31 32 .
 
-numIndices 32  itersPerThread 8  blockSize 2/2  gridSize 2  cyclic false
+numIndices 32  itersPerThread 8  blockSize 2  gridSize 2  block
   threadIdx:  0  0  0  0  0  0  0  0  1  1  1  1  1  1  1  1  0  0  0  0  0  0  0  0  1  1  1  1  1  1  1  1
     blockId:  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1
+bl th | iters
+ 0  0 |  1  2  3  4  5  6  7  8 .
+ 0  1 |  9 10 11 12 13 14 15 16 .
+ 1  0 | 17 18 19 20 21 22 23 24 .
+ 1  1 | 25 26 27 28 29 30 31 32 .
 
-numIndices 32  itersPerThread 8  blockSize 3/3  gridSize 2  cyclic false
+numIndices 32  itersPerThread 8  blockSize 3  gridSize 2  block
   threadIdx:  0  0  0  0  0  0  0  0  1  1  1  1  1  1  1  1  2  2  2  2  2  2  2  2  0  0  0  0  0  0  0  0
     blockId:  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  1  1  1  1  1  1  1  1
+bl th | iters
+ 0  0 |  1  2  3  4  5  6  7  8 .
+ 0  1 |  9 10 11 12 13 14 15 16 .
+ 0  2 | 17 18 19 20 21 22 23 24 .
+ 1  0 | 25 26 27 28 29 30 31 32 .
+ 1  1 | .
+ 1  2 | .
 
-numIndices 32  itersPerThread 8  blockSize 4/4  gridSize 1  cyclic false
+numIndices 32  itersPerThread 8  blockSize 4  gridSize 1  block
   threadIdx:  0  0  0  0  0  0  0  0  1  1  1  1  1  1  1  1  2  2  2  2  2  2  2  2  3  3  3  3  3  3  3  3
     blockId:  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
+bl th | iters
+ 0  0 |  1  2  3  4  5  6  7  8 .
+ 0  1 |  9 10 11 12 13 14 15 16 .
+ 0  2 | 17 18 19 20 21 22 23 24 .
+ 0  3 | 25 26 27 28 29 30 31 32 .
 
-numIndices 32  itersPerThread 8  blockSize 5/5  gridSize 1  cyclic false
+numIndices 32  itersPerThread 8  blockSize 5  gridSize 1  block
   threadIdx:  0  0  0  0  0  0  0  0  1  1  1  1  1  1  1  1  2  2  2  2  2  2  2  2  3  3  3  3  3  3  3  3
     blockId:  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
+bl th | iters
+ 0  0 |  1  2  3  4  5  6  7  8 .
+ 0  1 |  9 10 11 12 13 14 15 16 .
+ 0  2 | 17 18 19 20 21 22 23 24 .
+ 0  3 | 25 26 27 28 29 30 31 32 .
+ 0  4 | .
 
-numIndices 32  itersPerThread 1  blockSize 3/3  gridSize 11  cyclic true
+numIndices 32  itersPerThread 1  blockSize 3  gridSize 11  cyclic
   threadIdx:  0  1  2  0  1  2  0  1  2  0  1  2  0  1  2  0  1  2  0  1  2  0  1  2  0  1  2  0  1  2  0  1
     blockId:  0  0  0  1  1  1  2  2  2  3  3  3  4  4  4  5  5  5  6  6  6  7  7  7  8  8  8  9  9  9 10 10
+bl th | iters
+ 0  0 |  1 .
+ 0  1 |  2 .
+ 0  2 |  3 .
+ 1  0 |  4 .
+ 1  1 |  5 .
+ 1  2 |  6 .
+ 2  0 |  7 .
+ 2  1 |  8 .
+ 2  2 |  9 .
+ 3  0 | 10 .
+ 3  1 | 11 .
+ 3  2 | 12 .
+ 4  0 | 13 .
+ 4  1 | 14 .
+ 4  2 | 15 .
+ 5  0 | 16 .
+ 5  1 | 17 .
+ 5  2 | 18 .
+ 6  0 | 19 .
+ 6  1 | 20 .
+ 6  2 | 21 .
+ 7  0 | 22 .
+ 7  1 | 23 .
+ 7  2 | 24 .
+ 8  0 | 25 .
+ 8  1 | 26 .
+ 8  2 | 27 .
+ 9  0 | 28 .
+ 9  1 | 29 .
+ 9  2 | 30 .
+10  0 | 31 .
+10  1 | 32 .
+10  2 | .
 
-numIndices 32  itersPerThread 2  blockSize 3/3  gridSize 6  cyclic true
+numIndices 32  itersPerThread 2  blockSize 3  gridSize 6  cyclic
   threadIdx:  0  1  2  0  1  2  0  1  2  0  1  2  0  1  2  0  0  1  2  0  1  2  0  1  2  0  1  2  0  1  2  0
     blockId:  0  0  0  1  1  1  2  2  2  3  3  3  4  4  4  5  0  0  0  1  1  1  2  2  2  3  3  3  4  4  4  5
+bl th | iters
+ 0  0 |  1 17 .
+ 0  1 |  2 18 .
+ 0  2 |  3 19 .
+ 1  0 |  4 20 .
+ 1  1 |  5 21 .
+ 1  2 |  6 22 .
+ 2  0 |  7 23 .
+ 2  1 |  8 24 .
+ 2  2 |  9 25 .
+ 3  0 | 10 26 .
+ 3  1 | 11 27 .
+ 3  2 | 12 28 .
+ 4  0 | 13 29 .
+ 4  1 | 14 30 .
+ 4  2 | 15 31 .
+ 5  0 | 16 32 .
+ 5  1 | .
+ 5  2 | .
 
-numIndices 32  itersPerThread 3  blockSize 3/3  gridSize 4  cyclic true
+numIndices 32  itersPerThread 3  blockSize 3  gridSize 4  cyclic
   threadIdx:  0  1  2  0  1  2  0  1  2  0  1  0  1  2  0  1  2  0  1  2  0  1  0  1  2  0  1  2  0  1  2  0
     blockId:  0  0  0  1  1  1  2  2  2  3  3  0  0  0  1  1  1  2  2  2  3  3  0  0  0  1  1  1  2  2  2  3
+bl th | iters
+ 0  0 |  1 12 23 .
+ 0  1 |  2 13 24 .
+ 0  2 |  3 14 25 .
+ 1  0 |  4 15 26 .
+ 1  1 |  5 16 27 .
+ 1  2 |  6 17 28 .
+ 2  0 |  7 18 29 .
+ 2  1 |  8 19 30 .
+ 2  2 |  9 20 31 .
+ 3  0 | 10 21 32 .
+ 3  1 | 11 22 .
+ 3  2 | .
 
-numIndices 32  itersPerThread 4  blockSize 3/3  gridSize 3  cyclic true
+numIndices 32  itersPerThread 4  blockSize 3  gridSize 3  cyclic
   threadIdx:  0  1  2  0  1  2  0  1  0  1  2  0  1  2  0  1  0  1  2  0  1  2  0  1  0  1  2  0  1  2  0  1
     blockId:  0  0  0  1  1  1  2  2  0  0  0  1  1  1  2  2  0  0  0  1  1  1  2  2  0  0  0  1  1  1  2  2
+bl th | iters
+ 0  0 |  1  9 17 25 .
+ 0  1 |  2 10 18 26 .
+ 0  2 |  3 11 19 27 .
+ 1  0 |  4 12 20 28 .
+ 1  1 |  5 13 21 29 .
+ 1  2 |  6 14 22 30 .
+ 2  0 |  7 15 23 31 .
+ 2  1 |  8 16 24 32 .
+ 2  2 | .
 
-numIndices 32  itersPerThread 5  blockSize 3/3  gridSize 3  cyclic true
+numIndices 32  itersPerThread 5  blockSize 3  gridSize 3  cyclic
   threadIdx:  0  1  2  0  1  2  0  0  1  2  0  1  2  0  0  1  2  0  1  2  0  0  1  2  0  1  2  0  0  1  2  0
     blockId:  0  0  0  1  1  1  2  0  0  0  1  1  1  2  0  0  0  1  1  1  2  0  0  0  1  1  1  2  0  0  0  1
+bl th | iters
+ 0  0 |  1  8 15 22 29 .
+ 0  1 |  2  9 16 23 30 .
+ 0  2 |  3 10 17 24 31 .
+ 1  0 |  4 11 18 25 32 .
+ 1  1 |  5 12 19 26 .
+ 1  2 |  6 13 20 27 .
+ 2  0 |  7 14 21 28 .
+ 2  1 | .
+ 2  2 | .
 
-numIndices 32  itersPerThread 8  blockSize 1/1  gridSize 4  cyclic true
+numIndices 32  itersPerThread 8  blockSize 1  gridSize 4  cyclic
   threadIdx:  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
     blockId:  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3
+bl th | iters
+ 0  0 |  1  5  9 13 17 21 25 29 .
+ 1  0 |  2  6 10 14 18 22 26 30 .
+ 2  0 |  3  7 11 15 19 23 27 31 .
+ 3  0 |  4  8 12 16 20 24 28 32 .
 
-numIndices 32  itersPerThread 8  blockSize 2/2  gridSize 2  cyclic true
+numIndices 32  itersPerThread 8  blockSize 2  gridSize 2  cyclic
   threadIdx:  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1
     blockId:  0  0  1  1  0  0  1  1  0  0  1  1  0  0  1  1  0  0  1  1  0  0  1  1  0  0  1  1  0  0  1  1
+bl th | iters
+ 0  0 |  1  5  9 13 17 21 25 29 .
+ 0  1 |  2  6 10 14 18 22 26 30 .
+ 1  0 |  3  7 11 15 19 23 27 31 .
+ 1  1 |  4  8 12 16 20 24 28 32 .
 
-numIndices 32  itersPerThread 8  blockSize 3/3  gridSize 2  cyclic true
+numIndices 32  itersPerThread 8  blockSize 3  gridSize 2  cyclic
   threadIdx:  0  1  2  0  0  1  2  0  0  1  2  0  0  1  2  0  0  1  2  0  0  1  2  0  0  1  2  0  0  1  2  0
     blockId:  0  0  0  1  0  0  0  1  0  0  0  1  0  0  0  1  0  0  0  1  0  0  0  1  0  0  0  1  0  0  0  1
+bl th | iters
+ 0  0 |  1  5  9 13 17 21 25 29 .
+ 0  1 |  2  6 10 14 18 22 26 30 .
+ 0  2 |  3  7 11 15 19 23 27 31 .
+ 1  0 |  4  8 12 16 20 24 28 32 .
+ 1  1 | .
+ 1  2 | .
 
-numIndices 32  itersPerThread 8  blockSize 4/4  gridSize 1  cyclic true
+numIndices 32  itersPerThread 8  blockSize 4  gridSize 1  cyclic
   threadIdx:  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3
     blockId:  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
+bl th | iters
+ 0  0 |  1  5  9 13 17 21 25 29 .
+ 0  1 |  2  6 10 14 18 22 26 30 .
+ 0  2 |  3  7 11 15 19 23 27 31 .
+ 0  3 |  4  8 12 16 20 24 28 32 .
 
-numIndices 32  itersPerThread 8  blockSize 5/5  gridSize 1  cyclic true
+numIndices 32  itersPerThread 8  blockSize 5  gridSize 1  cyclic
   threadIdx:  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3  0  1  2  3
     blockId:  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
+bl th | iters
+ 0  0 |  1  5  9 13 17 21 25 29 .
+ 0  1 |  2  6 10 14 18 22 26 30 .
+ 0  2 |  3  7 11 15 19 23 27 31 .
+ 0  3 |  4  8 12 16 20 24 28 32 .
+ 0  4 | .
+
+numIndices 18  itersPerThread 2  blockSize 2  gridSize 5  cyclic
+  threadIdx:  0  1  0  1  0  1  0  1  0  0  1  0  1  0  1  0  1  0
+    blockId:  0  0  1  1  2  2  3  3  4  0  0  1  1  2  2  3  3  4
+bl th | iters
+ 0  0 |  1 10 .
+ 0  1 |  2 11 .
+ 1  0 |  3 12 .
+ 1  1 |  4 13 .
+ 2  0 |  5 14 .
+ 2  1 |  6 15 .
+ 3  0 |  7 16 .
+ 3  1 |  8 17 .
+ 4  0 |  9 18 .
+ 4  1 | .
+
+numIndices 18  itersPerThread 2  blockSize 3  gridSize 3  cyclic
+  threadIdx:  0  1  2  0  1  2  0  1  2  0  1  2  0  1  2  0  1  2
+    blockId:  0  0  0  1  1  1  2  2  2  0  0  0  1  1  1  2  2  2
+bl th | iters
+ 0  0 |  1 10 .
+ 0  1 |  2 11 .
+ 0  2 |  3 12 .
+ 1  0 |  4 13 .
+ 1  1 |  5 14 .
+ 1  2 |  6 15 .
+ 2  0 |  7 16 .
+ 2  1 |  8 17 .
+ 2  2 |  9 18 .
+
+numIndices 18  itersPerThread 2  blockSize 6  gridSize 2  cyclic
+  threadIdx:  0  1  2  3  4  5  0  1  2  0  1  2  3  4  5  0  1  2
+    blockId:  0  0  0  0  0  0  1  1  1  0  0  0  0  0  0  1  1  1
+bl th | iters
+ 0  0 |  1 10 .
+ 0  1 |  2 11 .
+ 0  2 |  3 12 .
+ 0  3 |  4 13 .
+ 0  4 |  5 14 .
+ 0  5 |  6 15 .
+ 1  0 |  7 16 .
+ 1  1 |  8 17 .
+ 1  2 |  9 18 .
+ 1  3 | .
+ 1  4 | .
+ 1  5 | .
 


### PR DESCRIPTION
Exends the test of `@gpu.itersPerThread` with a utility function that groups loop iterations by thread and block that execute them. For example:

```
numIndices 32  itersPerThread 5  blockSize 3  gridSize 3  block
bl th | iters
 0  0 |  1  2  3  4  5 .
 0  1 |  6  7  8  9 10 .
 0  2 | 11 12 13 14 15 .
 1  0 | 16 17 18 19 20 .
 1  1 | 21 22 23 24 25 .
 1  2 | 26 27 28 29 30 .
 2  0 | 31 32 .
 2  1 | .
 2  2 | .

numIndices 32  itersPerThread 5  blockSize 3  gridSize 3  cyclic
bl th | iters
 0  0 |  1  8 15 22 29 .
 0  1 |  2  9 16 23 30 .
 0  2 |  3 10 17 24 31 .
 1  0 |  4 11 18 25 32 .
 1  1 |  5 12 19 26 .
 1  2 |  6 13 20 27 .
 2  0 |  7 14 21 28 .
 2  1 | .
 2  2 | .
```

Also extends sanity checks.

Test enhancement. Not reviewed.