### PR TITLE
Resolve more cases of 'C compiler cannot compile executables'

### DIFF
--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -770,7 +770,7 @@ def get_sysroot_resource_dir_args():
 @memoize
 def get_sysroot_linux_args():
     args = [ ]
-    # try invoking the system gcc to see if it needs it various extra flags
+    # try invoking the system gcc to see if it needs various extra flags
     dummy_main = '#include <stdio.h>\nint main() { return 0; }\n'
     _, _, stdout, _ = try_run_command(
         ["gcc", "-v", "-x", "c", "-", "-o", "/dev/null"],


### PR DESCRIPTION
Sometimes when building Chapel the build system will report something like 'C compiler cannot compile executable'. This can indicate the users system is missing some dependencies, or it can mean that extra arguments are needed to work. This PR improves the ability of chplenv to provide those arguments when needed.

Specifically this PR infers when `--sysroot` or `-Wl,-dynamic-linker` need to be passed to clang on linux systems.

Testing
- [x] tested that MacOS is unaffected
- [x] tested on various Linux systems that the output is correct (4 systems: two different linux clusters, hpe-cray-ex, and hpe-apollo)
- [x] tested that this patch resolves the issues on the original system that motivated this

[Reviewed by @mppf]