### PR TITLE
add annotations for arkouda reduce regression and resolution

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -2512,6 +2512,10 @@ arkouda: &arkouda-base
     - Use Chapel 2.2 for Arkouda "release" nightly testing (#26014)
   10/09/24:
     - Fix array transfer performance regression (Bears-R-Us/arkouda#3826)
+  10/16/24:
+    - Part of argTypeReductionMessage refactor (Bears-R-Us/arkouda#3845)
+  10/29/24:
+    - Fix performance regression in reductions benchmark (Bears-R-Us/arkouda#3874)
 
 arkouda-string:
   <<: *arkouda-base


### PR DESCRIPTION
Adds an annotation for a recent Arkouda reduction performance regression:

- initial regression caused by: https://github.com/Bears-R-Us/arkouda/pull/3845
- resolved by: https://github.com/Bears-R-Us/arkouda/pull/3874
