### PR TITLE
bump up heap size for nightly cray ex perf job again

### DIFF
--- a/util/cron/test-perf.hpe-cray-ex.ofi.bash
+++ b/util/cron/test-perf.hpe-cray-ex.ofi.bash
@@ -16,7 +16,7 @@ source $CWD/common-ofi.bash || \
 source $CWD/common-hpe-cray-ex.bash
 
 export CHPL_RT_COMM_OFI_EXPECTED_PROVIDER="cxi"
-export CHPL_RT_MAX_HEAP_SIZE="50%"
+export CHPL_RT_MAX_HEAP_SIZE="80%"
 
 nightly_args="${nightly_args} -no-buildcheck"
 perf_args="-performance -perflabel ml- -numtrials 1"


### PR DESCRIPTION
Following up on <https://github.com/chapel-lang/chapel/pull/26069>.  Increasing `CHPL_RT_MAX_HEAP_SIZE` for that job helped some previously failing tests to pass. There still remain some tests that look like they're hitting out of memory issues.

If this causes issues tomorrow night I'll send a followup PR to revert. Apologies for the PR noise in the interim.