### PR TITLE
Fix issue with chplconfig not supporting variables with equals signs

### DIFF
--- a/util/chplenv/overrides.py
+++ b/util/chplenv/overrides.py
@@ -184,7 +184,7 @@ class ChapelConfig(object):
                 if self.skip_line(line, linenum):
                     continue
 
-                var, val = [f.strip() for f in line.split('=')]
+                var, val = [f.strip() for f in line.split('=', maxsplit=1)]
                 self.chplconfig[var] = val
 
     def skip_line(self, line, linenum):
@@ -198,7 +198,7 @@ class ChapelConfig(object):
 
         # Check for syntax errors
         try:
-            var, val = [f.strip() for f in line.split('=')]
+            var, val = [f.strip() for f in line.split('=', maxsplit=1)]
         except ValueError:
             self.warnings.append(
             (


### PR DESCRIPTION
Fixes an issue where if a `chplconfig` file has a variable with a value that contains an equals sign, it will break with an error like `Warning: Syntax Error: $CHPL_HOME/chplconfig:line`.

This resolves an issue a user saw on a system where `--gcc-toolchain=...` was apart of the definition for `CHPL_TARGET_CC/CXX`

[Reviewed by @e-kayrakli]