### PR TITLE
Back out one of the changes in #26178 to get warnings/warnings.chpl working

### DIFF
--- a/util/chplenv/overrides.py
+++ b/util/chplenv/overrides.py
@@ -198,7 +198,7 @@ class ChapelConfig(object):
 
         # Check for syntax errors
         try:
-            var, val = [f.strip() for f in line.split('=', maxsplit=1)]
+            var, val = [f.strip() for f in line.split('=')]
         except ValueError:
             self.warnings.append(
             (


### PR DESCRIPTION
While paratesting my branch tonight, I found that

  chplenv/chplconfig/warnings/warnings.chpl

was failing due to PR #26178.  Though I'm not that familiar with this logic, it seems that reverting half of the changes in it keeps this test working as expected, though it may suggest we need to do more to both achieve the PR's aim and also keep errors for cases like this.
