### PR TITLE
Properly handle parsing of equals in chplconfig

### DIFF
--- a/test/chplenv/chplconfig/correctness/chplconfig
+++ b/test/chplenv/chplconfig/correctness/chplconfig
@@ -5,7 +5,7 @@ CHPL_HOST_ARCH=x86_64
 CHPL_HOST_COMPILER=clang
 CHPL_TARGET_PLATFORM=darwin
 CHPL_TARGET_ARCH=x86_64
-CHPL_TARGET_COMPILER=clang
+CHPL_TARGET_COMPILER=clang --gcc-toolchain=/usr # nonsenseical value, but tests that it is accepted
 CHPL_TARGET_CPU=native
 CHPL_LOCALE_MODEL=flat
 CHPL_COMM=none

--- a/test/chplenv/chplconfig/correctness/correctness.chpl
+++ b/test/chplenv/chplconfig/correctness/correctness.chpl
@@ -8,7 +8,7 @@
 
 
 writeln("CHPL_TARGET_PLATFORM: darwin +");
-writeln("CHPL_TARGET_COMPILER: clang +");
+writeln("CHPL_TARGET_COMPILER: clang --gcc-toolchain=/usr +");
 writeln("CHPL_TARGET_ARCH: x86_64 +");
 writeln("CHPL_TARGET_CPU: native +");
 writeln("CHPL_LOCALE_MODEL: flat +");

--- a/test/chplenv/chplconfig/warnings/chplconfig
+++ b/test/chplenv/chplconfig/warnings/chplconfig
@@ -10,7 +10,8 @@ CHPL_TASKS == fifo
 CHPL_TASKS = = fifo
 # entry with '=' still works`
 CHPL_TARGET_CC = clang --gcc-toolchain=/usr
-
+# entry can start with ''
+CHPL_TARGET_CXX = '=/usr' # this is garbage for the purposes of testing
 
 # Unacceptable variable:
 CHPL_COMMS = none

--- a/test/chplenv/chplconfig/warnings/chplconfig
+++ b/test/chplenv/chplconfig/warnings/chplconfig
@@ -7,6 +7,10 @@
 
 # Incorrect format:
 CHPL_TASKS == fifo
+CHPL_TASKS = = fifo
+# entry with '=' still works`
+CHPL_TARGET_CC = clang --gcc-toolchain=/usr
+
 
 # Unacceptable variable:
 CHPL_COMMS = none

--- a/test/chplenv/chplconfig/warnings/warnings.chpl
+++ b/test/chplenv/chplconfig/warnings/warnings.chpl
@@ -13,5 +13,9 @@ Warning: Syntax Error: $CHPL_CONFIG/chplconfig:line 8\
               > CHPL_TASKS == fifo\
               Expected format is:\
               > CHPL_VAR = VALUE\
-Warning: $CHPL_CONFIG/chplconfig:line 11: \"CHPL_COMMS\" is not an acceptable variable\
-Warning: $CHPL_CONFIG/chplconfig:line 15: Duplicate entry of \"CHPL_COMM\"\n");
+Warning: Syntax Error: $CHPL_CONFIG/chplconfig:line 9\
+              > CHPL_TASKS = = fifo\
+              Expected format is:\
+              > CHPL_VAR = VALUE\
+Warning: $CHPL_CONFIG/chplconfig:line 15: \"CHPL_COMMS\" is not an acceptable variable\
+Warning: $CHPL_CONFIG/chplconfig:line 19: Duplicate entry of \"CHPL_COMM\"\n");

--- a/test/chplenv/chplconfig/warnings/warnings.chpl
+++ b/test/chplenv/chplconfig/warnings/warnings.chpl
@@ -17,5 +17,5 @@ Warning: Syntax Error: $CHPL_CONFIG/chplconfig:line 9\
               > CHPL_TASKS = = fifo\
               Expected format is:\
               > CHPL_VAR = VALUE\
-Warning: $CHPL_CONFIG/chplconfig:line 15: \"CHPL_COMMS\" is not an acceptable variable\
-Warning: $CHPL_CONFIG/chplconfig:line 19: Duplicate entry of \"CHPL_COMM\"\n");
+Warning: $CHPL_CONFIG/chplconfig:line 16: \"CHPL_COMMS\" is not an acceptable variable\
+Warning: $CHPL_CONFIG/chplconfig:line 20: Duplicate entry of \"CHPL_COMM\"\n");

--- a/test/chplenv/printchplenv/.gitignore
+++ b/test/chplenv/printchplenv/.gitignore
@@ -2,3 +2,6 @@ printchplenv.good
 printchplenvAll.good
 printchplenv-only.good
 printchplenv-only-value.good
+print-chpl-settings.1.good
+print-chpl-settings.2.good
+print-chpl-settings.3.good

--- a/util/chplenv/overrides.py
+++ b/util/chplenv/overrides.py
@@ -181,25 +181,29 @@ class ChapelConfig(object):
                 # Strip comments and trailing white space from line
                 line = line.split('#')[0].strip()
 
-                if self.skip_line(line, linenum):
+                res = self.check_line(line, linenum)
+                if not res:
                     continue
 
-                var, val = [f.strip() for f in line.split('=', maxsplit=1)]
+                var, val = res
                 self.chplconfig[var] = val
 
-    def skip_line(self, line, linenum):
+    def check_line(self, line, linenum):
         """
         Check the various conditions for skipping a line, accumulate warnings.
+
+        Returns the tuple (var, val) if the line is valid, otherwise None.
         """
 
         # Check if line is comment, by taking length of stripped line
         if len(line) == 0:
-            return True
+            return None
 
-        # Check for syntax errors
-        try:
-            var, val = [f.strip() for f in line.split('=')]
-        except ValueError:
+
+        parts = line.split('=', maxsplit=1)
+        var = parts[0].strip()
+        val = parts[-1].strip()
+        if len(parts) != 2 or val.startswith('='):
             self.warnings.append(
             (
                 'Syntax Error: {0}:line {1}\n'
@@ -207,7 +211,7 @@ class ChapelConfig(object):
                 '              Expected format is:\n'
                 '              > CHPL_VAR = VALUE'
             ).format(self.prettypath, linenum, line.strip('\n')))
-            return True
+            return None
 
         # Check if var is in the list of approved special variables
         if var not in chplvars:
@@ -215,8 +219,7 @@ class ChapelConfig(object):
             (
                 '{0}:line {1}: "{2}" is not an acceptable variable'
             ).format(self.prettypath, linenum, var))
-            return True
-
+            return None
         # Warn about duplicate entries, but don't skip, just overwrite
         elif var in self.chplconfig.keys():
             self.warnings.append(
@@ -225,7 +228,7 @@ class ChapelConfig(object):
             ).format(self.prettypath, linenum, var))
 
         # If we reach here, this is a valid assignment, so don't skip
-        return False
+        return (var, val)
 
     def printwarnings(self):
         """ Print any warnings accumulated throughout constructor """


### PR DESCRIPTION
Properly handles the parsing of chplconfig files. https://github.com/chapel-lang/chapel/pull/26178 added the ability to parse chplconfig variables with values including `=`, but that broke the warning for something like `CHPL_VAR==value`.

This PR resolves the issue by refactoring some of the parsing code in `overrides.py` to check error cases in `skip_line`, rather than relying on python exceptions. Then to avoid duplication of logic, renames `skip_line` to `check_line` and has it return the parsed variable.

Fixes the issue introduced in https://github.com/chapel-lang/chapel/pull/26178 and reverts https://github.com/chapel-lang/chapel/pull/26180

Tested by running `start_test test/chplenv`

[Reviewed by @DanilaFe]