### PR TITLE
Make the python interoperability jobs fail if dependencies are not installed

### DIFF
--- a/util/cron/common-python-interop.bash
+++ b/util/cron/common-python-interop.bash
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# Ensure we fail early if our dependencies for Python interoperability testing
+# are not met
+
+set -e
+
+echo "Ensuring numpy and Cython are installed"
+
+python3 -c "import numpy"
+python3 -c "import cython"

--- a/util/cron/getCompiler.py
+++ b/util/cron/getCompiler.py
@@ -1,0 +1,3 @@
+import chpl_compiler
+
+print(chpl_compiler.get())

--- a/util/cron/getCompiler.py
+++ b/util/cron/getCompiler.py
@@ -1,3 +1,3 @@
 import chpl_compiler
 
-print(chpl_compiler.get())
+print(chpl_compiler.get_compiler_name_c(chpl_compiler.get()))

--- a/util/cron/test-python-modules.bash
+++ b/util/cron/test-python-modules.bash
@@ -4,6 +4,7 @@
 
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common.bash
+source $CWD/common-python-interop.bash
 
 export CHPL_LIB_PIC=pic
 

--- a/util/cron/test-python-modules.gasnet.bash
+++ b/util/cron/test-python-modules.gasnet.bash
@@ -2,12 +2,35 @@
 #
 # Test generated Python modules
 
+set -e
+
+echo "Starting common setup"
+
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common-gasnet.bash
+source $CWD/common-python-interop.bash
 
+echo "Setting environment variables"
 export CHPL_LIB_PIC=pic
 export CHPL_LLVM=none
 
+# ensure we fail early if ZMQ is not present
+echo "Ensure ZMQ is installed"
+cCompiler=`PYTHONPATH=$CHPL_HOME/util/chplenv python3 getCompiler.py`
+echo "cCompiler is $cCompiler"
+
+zmqDirname="zmqDir-XXXXXX"
+actualDirname=`mktemp -d ${zmqDirname}`
+actualFilename="$actualDirname/zmq-test.c"
+echo '#include "zmq.h"' > $actualFilename
+echo 'int main (void) { return 0; }' >> $actualFilename
+
+$cCompiler $actualFilename -lzmq
+
+rm -r $actualDirname
+
+# Testing config changes
+echo "Setting Nightly variables"
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="python-modules.gasnet"
 export CHPL_NIGHTLY_TEST_DIRS="interop/python/multilocale"
 

--- a/util/cron/test-python-modules.gasnet.bash
+++ b/util/cron/test-python-modules.gasnet.bash
@@ -16,7 +16,7 @@ export CHPL_LLVM=none
 
 # ensure we fail early if ZMQ is not present
 echo "Ensure ZMQ is installed"
-cCompiler=`PYTHONPATH=$CHPL_HOME/util/chplenv python3 getCompiler.py`
+cCompiler=`PYTHONPATH=$CHPL_HOME/util/chplenv python3 $CWD/getCompiler.py`
 echo "cCompiler is $cCompiler"
 
 zmqDirname="zmqDir-XXXXXX"


### PR DESCRIPTION
Adds explicit testing of the presence of Cython and numpy to both jobs, and
ZMQ to the multilocale job.

Ensures that the scripts fail if these dependencies are not found.

Does this by creating a couple of helper files:
- a common bash script for checking Cython and numpy
- a python script for getting access to our compiler information.  This seemed
easier than trying to figure out how to do it in bash

When checking for ZMQ, create a temporary directory with a C file that checks if
the header is appropriately installed.  This is similar to the skipif handling
for the job, but distinct due to running before the Chapel compiler is built
(and thus before we can use the `compileline` command like that skipif does).  I
could have potentially updated the skipifs to use this pathway, but left that
as future work

This behaved appropriately on my local system (where ZMQ is not installed) and
on a linux box where numpy was not installed.
