### PR TITLE
Fix `followThis` type in `ChapelHashtable._allSlots` follower

### DIFF
--- a/modules/internal/ChapelHashtable.chpl
+++ b/modules/internal/ChapelHashtable.chpl
@@ -211,7 +211,7 @@ module ChapelHashtable {
   private iter _allSlots(size: int, followThis, param tag: iterKind)
     where tag == iterKind.follower {
 
-    var (chunk, followThisDom) = followThis;
+    var chunk = followThis;
 
     if debugDefaultAssoc then
       writeln("In associative domain _allSlots follower iterator: ",


### PR DESCRIPTION
Fix trying to use an incorrect `followThis` type in the `ChapelHashtable._allSlots` follower iterator.

This appears to have been introduced in https://github.com/chapel-lang/chapel/pull/15739. The corresponding leader, when it lived in `DefaultAssociative`, did yield `(chunk, this)` as the follower expects. But in the move to its own module, the leader was changed to yield just the `chunk`, and the follower was left the same.

I caught this because in [Dyno associative domain resolution efforts](https://github.com/Cray/chapel-private/issues/6833), we need to resolve the serial iterator, and Dyno performs a check that the standalone and follower variants have the same yield type, so it needed to resolve the follower, which then failed due to this issue.

I don't know why this hasn't caused issues in production; it's possible this is just a dead code path at the moment. Resolving follower iteration over an associative domain (as part of a zip) works fine.

[reviewer info placeholder]

Testing:
- [x] paratest
- [x] C backend paratest
- [x] gasnet paratest
- [x] GPU tests