### PR TITLE
Cleanup packaging scripts and docs to reflect LLVM 19 support

### DIFF
--- a/doc/rst/usingchapel/prereqs.rst
+++ b/doc/rst/usingchapel/prereqs.rst
@@ -37,9 +37,9 @@ for using Chapel:
   * CMake is available and ``cmake`` runs version 3.20 or later.
 
   * The LLVM backend is now the default and it is easiest to use it with a
-    system-wide installation of LLVM and clang. On Mac OS X, LLVM 14 through 18
+    system-wide installation of LLVM and clang. On Mac OS X, LLVM 14 through 19
     are currently supported. On other platforms, LLVM and clang versions 11
-    through 18 are currently supported. If a system-wide installation of
+    through 19 are currently supported. If a system-wide installation of
     LLVM and clang with one of those versions is not available, you can
     use the bundled LLVM or disable LLVM support (see
     :ref:`readme-chplenv.CHPL_LLVM`).

--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -15,7 +15,7 @@ class Chapel < Formula
   depends_on "gmp"
   depends_on "hwloc"
   depends_on "jemalloc"
-  depends_on "llvm@18"
+  depends_on "llvm"
   depends_on "pkg-config"
   depends_on "python@3.13"
 

--- a/util/packaging/rpm/fc41-gasnet-udp/Dockerfile.template
+++ b/util/packaging/rpm/fc41-gasnet-udp/Dockerfile.template
@@ -8,7 +8,7 @@ RUN dnf upgrade -y && \
     dnf install -y \
       gcc gcc-c++ m4 perl python3 python3-devel bash make gawk git cmake \
       which diffutils wget vim \
-      llvm18-devel clang18 clang18-devel \
+      llvm-devel clang clang-devel \
       rpm-build rpm-devel rpmlint coreutils patch rpmdevtools chrpath
 
 @@{USER_CREATION}

--- a/util/packaging/rpm/fc41-gasnet-udp/spec.template
+++ b/util/packaging/rpm/fc41-gasnet-udp/spec.template
@@ -7,7 +7,7 @@ Summary: Chapel
 License: Apache-2.0
 Source0: chapel-%{version}.tar.gz
 
-Requires: bash perl git llvm18-devel clang18 clang18-devel python3 python3-devel make
+Requires: bash perl git llvm-devel clang clang-devel python3 python3-devel make
 
 %description
 Chapel Programming Language

--- a/util/packaging/rpm/fc41/Dockerfile.template
+++ b/util/packaging/rpm/fc41/Dockerfile.template
@@ -8,7 +8,7 @@ RUN dnf upgrade -y && \
     dnf install -y \
       gcc gcc-c++ m4 perl python3 python3-devel bash make gawk git cmake \
       which diffutils wget vim \
-      llvm18-devel clang18 clang18-devel \
+      llvm-devel clang clang-devel \
       rpm-build rpm-devel rpmlint coreutils patch rpmdevtools chrpath
 
 @@{USER_CREATION}

--- a/util/packaging/rpm/fc41/spec.template
+++ b/util/packaging/rpm/fc41/spec.template
@@ -7,7 +7,7 @@ Summary: Chapel
 License: Apache-2.0
 Source0: chapel-%{version}.tar.gz
 
-Requires: bash perl git llvm18-devel clang18 clang18-devel python3 python3-devel make
+Requires: bash perl git llvm-devel clang clang-devel python3 python3-devel make
 
 %description
 Chapel Programming Language


### PR DESCRIPTION
Adjusts packaging scripts and docs to reflect that we support LLVM 19 as of https://github.com/chapel-lang/chapel/pull/25964

[Reviewed by @arezaii]