### PR TITLE
Make internal prefixes available to linter rules

### DIFF
--- a/tools/chplcheck/src/config.py
+++ b/tools/chplcheck/src/config.py
@@ -32,6 +32,7 @@ class Config:
     enabled_rules: List[str]
     skip_unstable: bool
     internal_prefixes: List[str]
+    check_internal_prefixes: bool
     add_rules: List[str]
 
     @classmethod
@@ -65,6 +66,13 @@ class Config:
             help="Add a prefix to the list of internal prefixes used when linting",
         )
         parser.add_argument(
+            f"--{prefix}check-internal-prefix",
+            action="append",
+            dest="chplcheck_check_internal_prefixes",
+            default=False,
+            help="Check symbols with internal prefixes when linting",
+        )
+        parser.add_argument(
             f"--{prefix}add-rules",
             action="append",
             dest="chplcheck_add_rules",
@@ -80,5 +88,6 @@ class Config:
             enabled_rules=args["chplcheck_enabled_rules"],
             skip_unstable=args["chplcheck_skip_unstable"],
             internal_prefixes=args["chplcheck_internal_prefixes"],
+            check_internal_prefixes=args["chplcheck_check_internal_prefixes"],
             add_rules=args["chplcheck_add_rules"],
         )

--- a/tools/chplcheck/src/driver.py
+++ b/tools/chplcheck/src/driver.py
@@ -104,7 +104,10 @@ class LintDriver:
 
         return True
 
-    def _has_internal_name(self, node: chapel.AstNode):
+    def has_internal_prefix(self, node: chapel.AstNode) -> bool:
+        """
+        Check if a node has a name that starts with one of the internal prefixes.
+        """
         if not hasattr(node, "name"):
             return False
         return any(
@@ -256,7 +259,10 @@ class LintDriver:
         for ast in asts:
             for rule in itertools.chain(self.BasicRules, self.AdvancedRules):
                 for toreport in self._check_rule(context, ast, rule):
-                    if self._has_internal_name(toreport[0]):
+                    if (
+                        not self.config.check_internal_prefixes
+                        and self.has_internal_prefix(toreport[0])
+                    ):
                         continue
 
                     yield toreport

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -113,26 +113,38 @@ def fixit_remove_unused_node(
     return None
 
 
-def name_for_linting(context: Context, node: NamedDecl) -> str:
+def name_for_linting(
+    context: Context, node: NamedDecl, internal_prefixes: List[str] = []
+) -> str:
     name = node.name()
 
     # Strip dollar signs.
     name = name.replace("$", "")
 
-    # TODO: thread `internal_prefixes` through to this and strip them for linting
+    # Strip internal prefixes.
+    for p in internal_prefixes:
+        if name.startswith(p):
+            name = name[len(p) :]
+            break
 
     return name
 
 
-def check_camel_case(context: Context, node: NamedDecl):
+def check_camel_case(
+    context: Context, node: NamedDecl, internal_prefixes: List[str] = []
+):
     return re.fullmatch(
-        r"([a-z]+([A-Z][a-z]*|\d+)*|[A-Z]+)?", name_for_linting(context, node)
+        r"([a-z]+([A-Z][a-z]*|\d+)*|[A-Z]+)?",
+        name_for_linting(context, node, internal_prefixes=internal_prefixes),
     )
 
 
-def check_pascal_case(context: Context, node: NamedDecl):
+def check_pascal_case(
+    context: Context, node: NamedDecl, internal_prefixes: List[str] = []
+):
     return re.fullmatch(
-        r"(([A-Z][a-z]*|\d+)+|[A-Z]+)?", name_for_linting(context, node)
+        r"(([A-Z][a-z]*|\d+)+|[A-Z]+)?",
+        name_for_linting(context, node, internal_prefixes=internal_prefixes),
     )
 
 
@@ -147,8 +159,11 @@ def register_rules(driver: LintDriver):
             return True
         if node.linkage() == "extern":
             return True
-        return check_camel_case(context, node) or check_pascal_case(
-            context, node
+        internal_prefixes = driver.config.internal_prefixes
+        return check_camel_case(
+            context, node, internal_prefixes=internal_prefixes
+        ) or check_pascal_case(
+            context, node, internal_prefixes=internal_prefixes
         )
 
     @driver.basic_rule(Record)
@@ -157,7 +172,10 @@ def register_rules(driver: LintDriver):
         Warn for records that are not 'camelCase'.
         """
 
-        return check_camel_case(context, node)
+        internal_prefixes = driver.config.internal_prefixes
+        return check_camel_case(
+            context, node, internal_prefixes=internal_prefixes
+        )
 
     @driver.basic_rule(Function)
     def CamelCaseFunctions(context: Context, node: Function):
@@ -177,7 +195,10 @@ def register_rules(driver: LintDriver):
         if node.name() == "init=":
             return True
 
-        return check_camel_case(context, node)
+        internal_prefixes = driver.config.internal_prefixes
+        return check_camel_case(
+            context, node, internal_prefixes=internal_prefixes
+        )
 
     @driver.basic_rule(Class)
     def PascalCaseClasses(context: Context, node: Class):
@@ -185,7 +206,10 @@ def register_rules(driver: LintDriver):
         Warn for classes that are not 'PascalCase'.
         """
 
-        return check_pascal_case(context, node)
+        internal_prefixes = driver.config.internal_prefixes
+        return check_pascal_case(
+            context, node, internal_prefixes=internal_prefixes
+        )
 
     @driver.basic_rule(Module)
     def PascalCaseModules(context: Context, node: Module):
@@ -193,7 +217,10 @@ def register_rules(driver: LintDriver):
         Warn for modules that are not 'PascalCase'.
         """
 
-        return node.kind() == "implicit" or check_pascal_case(context, node)
+        internal_prefixes = driver.config.internal_prefixes
+        return node.kind() == "implicit" or check_pascal_case(
+            context, node, internal_prefixes=internal_prefixes
+        )
 
     @driver.basic_rule(Module, default=False)
     def UseExplicitModules(_, node: Module):

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -135,7 +135,7 @@ def check_camel_case(
 ):
     return re.fullmatch(
         r"([a-z]+([A-Z][a-z]*|\d+)*|[A-Z]+)?",
-        name_for_linting(context, node, internal_prefixes=internal_prefixes),
+        name_for_linting(context, node, internal_prefixes),
     )
 
 
@@ -144,7 +144,7 @@ def check_pascal_case(
 ):
     return re.fullmatch(
         r"(([A-Z][a-z]*|\d+)+|[A-Z]+)?",
-        name_for_linting(context, node, internal_prefixes=internal_prefixes),
+        name_for_linting(context, node, internal_prefixes),
     )
 
 
@@ -161,10 +161,8 @@ def register_rules(driver: LintDriver):
             return True
         internal_prefixes = driver.config.internal_prefixes
         return check_camel_case(
-            context, node, internal_prefixes=internal_prefixes
-        ) or check_pascal_case(
-            context, node, internal_prefixes=internal_prefixes
-        )
+            context, node, internal_prefixes
+        ) or check_pascal_case(context, node, internal_prefixes)
 
     @driver.basic_rule(Record)
     def CamelCaseRecords(context: Context, node: Record):
@@ -173,9 +171,7 @@ def register_rules(driver: LintDriver):
         """
 
         internal_prefixes = driver.config.internal_prefixes
-        return check_camel_case(
-            context, node, internal_prefixes=internal_prefixes
-        )
+        return check_camel_case(context, node, internal_prefixes)
 
     @driver.basic_rule(Function)
     def CamelCaseFunctions(context: Context, node: Function):
@@ -196,9 +192,7 @@ def register_rules(driver: LintDriver):
             return True
 
         internal_prefixes = driver.config.internal_prefixes
-        return check_camel_case(
-            context, node, internal_prefixes=internal_prefixes
-        )
+        return check_camel_case(context, node, internal_prefixes)
 
     @driver.basic_rule(Class)
     def PascalCaseClasses(context: Context, node: Class):
@@ -207,9 +201,7 @@ def register_rules(driver: LintDriver):
         """
 
         internal_prefixes = driver.config.internal_prefixes
-        return check_pascal_case(
-            context, node, internal_prefixes=internal_prefixes
-        )
+        return check_pascal_case(context, node, internal_prefixes)
 
     @driver.basic_rule(Module)
     def PascalCaseModules(context: Context, node: Module):
@@ -219,7 +211,7 @@ def register_rules(driver: LintDriver):
 
         internal_prefixes = driver.config.internal_prefixes
         return node.kind() == "implicit" or check_pascal_case(
-            context, node, internal_prefixes=internal_prefixes
+            context, node, internal_prefixes
         )
 
     @driver.basic_rule(Module, default=False)


### PR DESCRIPTION
Makes the internal prefixes (as specified by `--internal-prefix chpl_`) be exposed to linter rules, rather than just the driver. Technically this was already possible, this PR just makes the naming based rules exclude the prefixes, such that `chpl_camelCase` is considered to be camelCase

[Reviewed by @DanilaFe]