### PR TITLE
Print new expressions properly in language server

### DIFF
--- a/tools/chpl-language-server/src/symbol_signature.py
+++ b/tools/chpl-language-server/src/symbol_signature.py
@@ -463,6 +463,7 @@ def _indexable_loop_to_string(loop: chapel.IndexableLoop) -> List[Component]:
 
     return comps
 
+
 def _new_to_string(new: chapel.New) -> List[Component]:
     """
     Convert a new expression to a string

--- a/tools/chpl-language-server/src/symbol_signature.py
+++ b/tools/chpl-language-server/src/symbol_signature.py
@@ -190,6 +190,8 @@ def _node_to_string(node: chapel.AstNode, sep="") -> List[Component]:
         return _range_to_string(node)
     elif isinstance(node, chapel.Block):
         return _list_to_string(node.stmts(), sep)
+    elif isinstance(node, chapel.New):
+        return _new_to_string(node)
 
     return [Component(ComponentTag.PLACEHOLDER, None)]
 
@@ -460,3 +462,13 @@ def _indexable_loop_to_string(loop: chapel.IndexableLoop) -> List[Component]:
     comps.extend(_node_to_string(loop.body()))
 
     return comps
+
+def _new_to_string(new: chapel.New) -> List[Component]:
+    """
+    Convert a new expression to a string
+    """
+    mng = new.management()
+    if mng != "" and mng != "default":
+        mng = mng + " "
+    type_ = _node_to_string(new.type_expression())
+    return [_wrap_str("new "), _wrap_str(mng)] + type_

--- a/tools/chpl-language-server/test/document_symbols.py
+++ b/tools/chpl-language-server/test/document_symbols.py
@@ -168,8 +168,8 @@ async def test_document_symbols_exprs(client: LanguageClient):
         "const e = for 1..10 do 1;",
         "const f = {(1 + 2)..<10};",
         "const g = -f.size;",
-        "const h = new R()",
-        "const i = new owned C()",
+        "const h = new R();",
+        "const i = new owned C();",
     ]
     file = "\n".join(exprs)
 

--- a/tools/chpl-language-server/test/document_symbols.py
+++ b/tools/chpl-language-server/test/document_symbols.py
@@ -168,6 +168,8 @@ async def test_document_symbols_exprs(client: LanguageClient):
         "const e = for 1..10 do 1;",
         "const f = {(1 + 2)..<10};",
         "const g = -f.size;",
+        "const h = new R()",
+        "const i = new owned C()",
     ]
     file = "\n".join(exprs)
 


### PR DESCRIPTION
Adds support for printing something like `new TypeName()` in the language server. This allows users to see new expressions when hovering over a symbol.

[Reviewed by @DanilaFe]