### PR TITLE
Dyno let multiple declaration inits use previous variables

### DIFF
--- a/frontend/include/chpl/uast/MultiDecl.h
+++ b/frontend/include/chpl/uast/MultiDecl.h
@@ -43,7 +43,7 @@ namespace uast {
   \endrst
 
   Each of the lines above is represented by a MultiDecl containing a
-  list of VariableDecls.  Note that the initial value and/or type is inferred
+  list of Variables.  Note that the initial value and/or type is inferred
   from later declarations.
 
   Since the MultiDecl does not itself have a name, it is not
@@ -97,7 +97,7 @@ class MultiDecl final : public Decl {
                                 AstList varDecls);
 
   /**
-    Return a way to iterate over the contained VariableDecls and Comments.
+    Return a way to iterate over the contained Decls and Comments.
    */
   AstListIteratorPair<AstNode> declOrComments() const {
     auto begin = numDeclOrComments()
@@ -108,7 +108,7 @@ class MultiDecl final : public Decl {
   }
 
   /**
-   Return the number of VariableDecls and Comments contained.
+   Return the number of Decls and Comments contained.
    */
   int numDeclOrComments() const {
     int numNonChildren = 0;
@@ -118,7 +118,7 @@ class MultiDecl final : public Decl {
   }
 
   /**
-   Return the i'th contained VariableDecl or Comment.
+   Return the i'th contained Decl or Comment.
    */
   const AstNode* declOrComment(int i) const {
     CHPL_ASSERT(i >= 0 && i < numDeclOrComments());

--- a/frontend/include/chpl/uast/TupleDecl.h
+++ b/frontend/include/chpl/uast/TupleDecl.h
@@ -44,7 +44,7 @@ namespace uast {
   \endrst
 
   Each of the lines above is represented by a TupleDecl containing a
-  list of VariableDecls.  Note that the initial value and/or type is inferred
+  list of Variables.  Note that the initial value and/or type is inferred
   from later declarations.
 
   Since the Tuple does not itself have a name, it is not

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -3796,7 +3796,6 @@ void Resolver::exit(const MultiDecl* decl) {
   // This effectively splits the decls into groups that share a type/init.
   auto it = decl->decls().begin();
   auto groupBegin = it;
-  gdbShouldBreakHere();
   const AstNode* curTypeExpr = nullptr;
   const AstNode* curInitExpr = nullptr;
   while (it != decl->decls().end()) {

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -3796,22 +3796,20 @@ bool Resolver::enter(const MultiDecl* decl) {
     const AstNode* initExpr = nullptr;
     getVarLikeOrTupleTypeInit(d, typeExpr, initExpr);
 
-    if (typeExpr != nullptr) {
-      typeExpr->traverse(*this);
-    }
-    if (initExpr != nullptr) {
-      initExpr->traverse(*this);
-    }
+    // if (typeExpr != nullptr) {
+    //   typeExpr->traverse(*this);
+    // }
+    // if (initExpr != nullptr) {
+    //   initExpr->traverse(*this);
+    // }
 
     exitScope(d);
   }
 
   return false;
 }
-void Resolver::exit(const MultiDecl* decl) {
-  if (scopeResolveOnly)
-    return;
 
+void Resolver::exit(const MultiDecl* decl) {
   // Separate decls into groups of decls sharing a type/init.
   std::vector<std::vector<const Decl*>> declGroups;
   std::vector<const Decl*> currentGroup;
@@ -3840,6 +3838,15 @@ void Resolver::exit(const MultiDecl* decl) {
       const AstNode* typeExpr = nullptr;
       const AstNode* initExpr = nullptr;
       getVarLikeOrTupleTypeInit(d, typeExpr, initExpr);
+
+      // Resolve type and init expressions if present.
+      if (typeExpr != nullptr) {
+        typeExpr->traverse(*this);
+      }
+      if (initExpr != nullptr) {
+        initExpr->traverse(*this);
+      }
+      if (scopeResolveOnly) continue;
 
       // if it has neither init nor type, use the type from the
       // variable to the right.

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -3796,6 +3796,7 @@ void Resolver::exit(const MultiDecl* decl) {
   // This effectively splits the decls into groups that share a type/init.
   auto it = decl->decls().begin();
   auto groupBegin = it;
+  gdbShouldBreakHere();
   while (it != decl->decls().end()) {
     const Decl* individualDecl = *it;
 
@@ -3813,7 +3814,8 @@ void Resolver::exit(const MultiDecl* decl) {
     if (!scopeResolveOnly && (typeExpr || initExpr)) {
       // Decl with type/init encountered, resolve and propagate the type info
       // backwards through its group.
-      auto groupIt = it;
+      auto groupEnd = std::next(it);
+      auto groupIt = groupEnd;
       const Type* lastType = nullptr;
       while (groupIt != groupBegin) {
         --groupIt;
@@ -3852,8 +3854,8 @@ void Resolver::exit(const MultiDecl* decl) {
         lastType = result.type().type();
       }
 
-      // Advance group beginning pointer to past the end of this group
-      groupBegin = std::next(it);
+      // Advance to beginning of next group
+      groupBegin = groupEnd;
     }
 
     ++it;

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -3784,28 +3784,9 @@ static void getVarLikeOrTupleTypeInit(const AstNode* ast,
 }
 
 bool Resolver::enter(const MultiDecl* decl) {
-  gdbShouldBreakHere();
   enterScope(decl);
 
-  // Establish the type or init expressions within
-  // by visiting those nodes
-  for (auto d : decl->decls()) {
-    enterScope(d);
-
-    const AstNode* typeExpr = nullptr;
-    const AstNode* initExpr = nullptr;
-    getVarLikeOrTupleTypeInit(d, typeExpr, initExpr);
-
-    // if (typeExpr != nullptr) {
-    //   typeExpr->traverse(*this);
-    // }
-    // if (initExpr != nullptr) {
-    //   initExpr->traverse(*this);
-    // }
-
-    exitScope(d);
-  }
-
+  // Traversal is done in exit
   return false;
 }
 
@@ -3824,7 +3805,6 @@ void Resolver::exit(const MultiDecl* decl) {
       currentGroup.clear();
     }
   }
-  gdbShouldBreakHere();
 
   // Visit each group, working in reverse order within groups to set type/init.
   for (const auto& declGroup : declGroups) {

--- a/frontend/test/resolution/testMultiDecl.cpp
+++ b/frontend/test/resolution/testMultiDecl.cpp
@@ -250,6 +250,33 @@ static void test6() {
   assert(xt->isIntType());
 }
 
+static void test7() {
+  printf("test7\n");
+  Context ctx;
+  Context* context = &ctx;
+
+  auto M = parseModule(context,
+                R""""(
+                  var a = 1, b = (1 + a);
+                )"""");
+
+  assert(M->numStmts() == 1);
+  const MultiDecl* md = M->stmt(0)->toMultiDecl();
+  assert(md);
+  auto a = md->declOrComment(0)->toVariable();
+  assert(a);
+  auto b = md->declOrComment(1)->toVariable();
+  assert(b);
+
+  const ResolutionResultByPostorderID& rr = resolveModule(context, M->id());
+  auto aQt = rr.byAst(a).type();
+  auto bQt = rr.byAst(b).type();
+  assert(aQt.kind() == QualifiedType::VAR);
+  assert(aQt.type()->isIntType());
+  assert(bQt.kind() == QualifiedType::VAR);
+  assert(bQt.type()->isIntType());
+}
+
 int main() {
   test1();
   test2();
@@ -257,6 +284,7 @@ int main() {
   test4();
   test5();
   test6();
+  test7();
 
   return 0;
 }

--- a/frontend/test/resolution/testMultiDecl.cpp
+++ b/frontend/test/resolution/testMultiDecl.cpp
@@ -257,11 +257,12 @@ static void test7() {
 
   auto M = parseModule(context,
                 R""""(
+                  operator +(lhs: int, rhs: int) do return __primitive("+", lhs, rhs);
                   var a = 1, b = (1 + a);
                 )"""");
 
-  assert(M->numStmts() == 1);
-  const MultiDecl* md = M->stmt(0)->toMultiDecl();
+  assert(M->numStmts() == 2);
+  const MultiDecl* md = M->stmt(1)->toMultiDecl();
   assert(md);
   auto a = md->declOrComment(0)->toVariable();
   assert(a);


### PR DESCRIPTION
Allow dyno resolution of variable inits in a multiple declaration to use type information from earlier variables in the declaration.

This enables resolving a variable whose initialization part uses a previous variable in the same declaration, such as `var a = 1, b = (1 + a);`, which works in production.

Additionally includes refactoring `MultiDecl` resolution from two loop [nests] (`O(n)` and `O(n^2)`) to one (`O(n^2)`). This is done by traversing the individual decls in an outer loop, then backtracking within an inner loop for each "group" that shares the same type and/or init part. To support this, `AstListNoCommentsIterator` is adjusted from a forward to a bidirectional iterator.

Includes adding tests for the fixed case.

Resolves https://github.com/Cray/chapel-private/issues/6792.

[reviewer info placeholder]

Testing:
- [x] dyno tests
- [x] paratest
- [x] backing issue reproducer fixed