### PR TITLE
Add missing keywords to vim and emacs syntax highlighting

### DIFF
--- a/highlight/emacs/chpl-mode.el
+++ b/highlight/emacs/chpl-mode.el
@@ -87,7 +87,7 @@ not the type face."
   chpl '("as"
          "const" "config"
          "except" "export" "extern"
-         "import" "inline" "iter"
+         "implements" "import" "include" "inline" "iter"
          "lambda"
          "module"
          "only" "operator" "override"
@@ -110,11 +110,11 @@ will be handled.
 Note that presence on this list does not automatically treat the
 following identifier as a type; the keyword must also be present on
 `c-type-prefix-kwds' or `c-type-list-kwds' to accomplish that."
-  chpl '("class" "record" "union"))
+  chpl '("class" "record" "union" "interface"))
 
 (c-lang-defconst c-type-start-kwds
   "Keywords that can start a type."
-  chpl '("class" "enum" "record" "type" "union"))
+  chpl '("class" "enum" "record" "type" "union" "interface"))
 
 ;; Type aliases
 (c-lang-defconst c-typedef-decl-kwds

--- a/highlight/vim/syntax/chpl.vim
+++ b/highlight/vim/syntax/chpl.vim
@@ -258,7 +258,7 @@ endif
 
 " Chapel extensions
 syn keyword chplStatement	break return continue compilerWarning
-syn keyword chplStatement	new delete this these super use except only require import
+syn keyword chplStatement	new delete this these super use except only require import include
 syn keyword chplStatement	noinit init postinit deinit
 syn keyword chplStatement	manage implements
 syn keyword chplStatement	as module yield compilerError zip


### PR DESCRIPTION
Adds some missing keywords I noticed in the vim and emacs syntax highlighters.

Related vscode PR: https://github.com/chapel-lang/chapel-vscode/pull/21

[Reviewed by @lydia-duncan  and @DanilaFe]