### PR TITLE
typo fix: gpu 'maxGridDimX' device attribute was accidentally capatilized

### DIFF
--- a/modules/standard/GPU.chpl
+++ b/modules/standard/GPU.chpl
@@ -1273,7 +1273,7 @@ module GPU
     proc maxBlockDimX : int do return chpl_gpu_query_attribute(this.gpuId : c_int, CHPL_GPU_ATTRIBUTE__MAX_BLOCK_DIM_X);
     proc maxBlockDimY : int do return chpl_gpu_query_attribute(this.gpuId : c_int, CHPL_GPU_ATTRIBUTE__MAX_BLOCK_DIM_Y);
     proc maxBlockDimZ : int do return chpl_gpu_query_attribute(this.gpuId : c_int, CHPL_GPU_ATTRIBUTE__MAX_BLOCK_DIM_Z);
-    proc MaxGridDimX : int do return chpl_gpu_query_attribute(this.gpuId : c_int, CHPL_GPU_ATTRIBUTE__MAX_GRID_DIM_X);
+    proc maxGridDimX : int do return chpl_gpu_query_attribute(this.gpuId : c_int, CHPL_GPU_ATTRIBUTE__MAX_GRID_DIM_X);
     proc maxGridDimY : int do return chpl_gpu_query_attribute(this.gpuId : c_int, CHPL_GPU_ATTRIBUTE__MAX_GRID_DIM_Y);
     proc maxGridDimZ : int do return chpl_gpu_query_attribute(this.gpuId : c_int, CHPL_GPU_ATTRIBUTE__MAX_GRID_DIM_Z);
     proc maxSharedMemoryPerBlock : int do return chpl_gpu_query_attribute(this.gpuId : c_int, CHPL_GPU_ATTRIBUTE__MAX_SHARED_MEMORY_PER_BLOCK);

--- a/test/gpu/native/deviceAttributes.chpl
+++ b/test/gpu/native/deviceAttributes.chpl
@@ -12,7 +12,7 @@ else {
     writeln("maxBlockDimX: ", deviceAttributes(here).maxBlockDimX);
     writeln("maxBlockDimY: ", deviceAttributes(here).maxBlockDimY);
     writeln("maxBlockDimZ: ", deviceAttributes(here).maxBlockDimZ);
-    writeln("MaxGridDimX: ", deviceAttributes(here).MaxGridDimX);
+    writeln("maxGridDimX: ", deviceAttributes(here).maxGridDimX);
     writeln("maxGridDimY: ", deviceAttributes(here).maxGridDimY);
     writeln("maxGridDimZ: ", deviceAttributes(here).maxGridDimZ);
     writeln("maxSharedMemoryPerBlock: ", deviceAttributes(here).maxSharedMemoryPerBlock);

--- a/test/gpu/native/deviceAttributes.cpu.c
+++ b/test/gpu/native/deviceAttributes.cpu.c
@@ -7,7 +7,7 @@ void runBaselineVersion(void) {
   printf("maxBlockDimX: -1\n");
   printf("maxBlockDimY: -1\n");
   printf("maxBlockDimZ: -1\n");
-  printf("MaxGridDimX: -1\n");
+  printf("maxGridDimX: -1\n");
   printf("maxGridDimY: -1\n");
   printf("maxGridDimZ: -1\n");
   printf("maxSharedMemoryPerBlock: -1\n");

--- a/test/gpu/native/deviceAttributes.cuda.c
+++ b/test/gpu/native/deviceAttributes.cuda.c
@@ -28,7 +28,7 @@ void runBaselineVersion(void) {
   reportAttribute("maxBlockDimX", CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X);
   reportAttribute("maxBlockDimY", CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Y);
   reportAttribute("maxBlockDimZ", CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Z);
-  reportAttribute("MaxGridDimX", CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_X);
+  reportAttribute("maxGridDimX", CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_X);
   reportAttribute("maxGridDimY", CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Y);
   reportAttribute("maxGridDimZ", CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Z);
   reportAttribute("maxSharedMemoryPerBlock", CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK);


### PR DESCRIPTION
The gpu 'maxGridDimX' device attribute was accidentally capitalized to 'MaxGridDimX'. This PR fixes the typo.