### PR TITLE
Add a suppressif file for a new test

### DIFF
--- a/test/library/standard/Memory/Diagnostics/allocationsIter.suppressif
+++ b/test/library/standard/Memory/Diagnostics/allocationsIter.suppressif
@@ -1,0 +1,1 @@
+COMPOPTS <= baseline

--- a/test/library/standard/Memory/Diagnostics/allocationsIter.suppressif
+++ b/test/library/standard/Memory/Diagnostics/allocationsIter.suppressif
@@ -1,1 +1,3 @@
+# baseline exhibits different number of allocations, which this test should be
+# sensitive to
 COMPOPTS <= baseline


### PR DESCRIPTION
The `allocations` iterator may yield different number of allocations when `--baseline` is used. The test associated with this iterator should be sensitive to the number of allocations. To make sure to be able to lock in the correct number of allocations while avoiding noise with `--baseline`, this PR adds a suppressif for `--baseline`.

Test:
- [x] test was failing with `--baseline`, now it is suppressed