### PR TITLE
Chplcheck misleading indent fix

### DIFF
--- a/test/chplcheck/MisleadingIndentation.chpl
+++ b/test/chplcheck/MisleadingIndentation.chpl
@@ -28,4 +28,55 @@ writeln("second thing");
           writeln("Hello, world!");
       var unrelated = "hi";
   }
+
+  on Locale[0] do
+    writeln("Hello, world!");
+    writeln("Hello, world!");
+
+  for 1..10 do
+    for 1..10 do
+      writeln("Hello, world!");
+      writeln("Hello, world!");
+
+  for 1..10 do
+    on Locale[0] do
+      writeln("Hello, world!");
+      writeln("Hello, world!");
+
+  on Locale[0] do
+    for 1..10 do
+      writeln("Hello, world!");
+      writeln("Hello, world!");
+
+  on Locale[0] do
+    on Locale[0] do
+      writeln("Hello, world!");
+      writeln("Hello, world!");
+
+
+  for 1..10 do
+    for 1..10 do
+      for 1..10 do
+        writeln("Hello, world!");
+        writeln("Hello, world!");
+
+  for 1..10 do
+    for 1..10 do
+      for 1..10 do
+        for 1..10 do
+          writeln("Hello, world!");
+          writeln("Hello, world!");
+
+  for 1..10 do
+    for 1..10 do
+      on Locale[0] do
+        writeln("Hello, world!");
+        writeln("Hello, world!");
+
+  on Locale[0] do
+    on Locale[0] do
+      on Locale[0] do
+        writeln("Hello, world!");
+        writeln("Hello, world!");
+
 }

--- a/test/chplcheck/MisleadingIndentation.good
+++ b/test/chplcheck/MisleadingIndentation.good
@@ -3,4 +3,13 @@ MisleadingIndentation.chpl:13: node violates rule MisleadingIndentation
 MisleadingIndentation.chpl:18: node violates rule MisleadingIndentation
 MisleadingIndentation.chpl:23: node violates rule IncorrectIndentation
 MisleadingIndentation.chpl:24: node violates rule MisleadingIndentation
+MisleadingIndentation.chpl:34: node violates rule MisleadingIndentation
+MisleadingIndentation.chpl:39: node violates rule MisleadingIndentation
+MisleadingIndentation.chpl:44: node violates rule MisleadingIndentation
+MisleadingIndentation.chpl:49: node violates rule MisleadingIndentation
+MisleadingIndentation.chpl:54: node violates rule MisleadingIndentation
+MisleadingIndentation.chpl:61: node violates rule MisleadingIndentation
+MisleadingIndentation.chpl:68: node violates rule MisleadingIndentation
+MisleadingIndentation.chpl:74: node violates rule MisleadingIndentation
+MisleadingIndentation.chpl:80: node violates rule MisleadingIndentation
 [Success matching fixit for MisleadingIndentation]

--- a/test/chplcheck/MisleadingIndentation.good-fixit
+++ b/test/chplcheck/MisleadingIndentation.good-fixit
@@ -30,4 +30,55 @@ writeln(i);
           writeln("Hello, world!");
       var unrelated = "hi";
   }
+
+  on Locale[0] do
+    writeln("Hello, world!");
+  writeln("Hello, world!");
+
+  for 1..10 do
+    for 1..10 do
+      writeln("Hello, world!");
+  writeln("Hello, world!");
+
+  for 1..10 do
+    on Locale[0] do
+      writeln("Hello, world!");
+  writeln("Hello, world!");
+
+  on Locale[0] do
+    for 1..10 do
+      writeln("Hello, world!");
+  writeln("Hello, world!");
+
+  on Locale[0] do
+    on Locale[0] do
+      writeln("Hello, world!");
+  writeln("Hello, world!");
+
+
+  for 1..10 do
+    for 1..10 do
+      for 1..10 do
+        writeln("Hello, world!");
+  writeln("Hello, world!");
+
+  for 1..10 do
+    for 1..10 do
+      for 1..10 do
+        for 1..10 do
+          writeln("Hello, world!");
+  writeln("Hello, world!");
+
+  for 1..10 do
+    for 1..10 do
+      on Locale[0] do
+        writeln("Hello, world!");
+  writeln("Hello, world!");
+
+  on Locale[0] do
+    on Locale[0] do
+      on Locale[0] do
+        writeln("Hello, world!");
+  writeln("Hello, world!");
+
 }

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -571,8 +571,7 @@ def register_rules(driver: LintDriver):
             prev.append(stmt)
             append_nested_single_stmt(stmt, prev)
             return node  # Return the outermost on to use an anchor
-        
-        # Should we also check for Conditionals here?
+
         return None
 
     @driver.fixit(MisleadingIndentation)

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -544,7 +544,10 @@ def register_rules(driver: LintDriver):
                 continue
             yield from MisleadingIndentation(context, child)
 
-            if prev and any(p.location().start()[1] == child.location().start()[1] for p in prev):
+            if prev and any(
+                p.location().start()[1] == child.location().start()[1]
+                for p in prev
+            ):
                 yield AdvancedRuleResult(child, fix)
 
             prev = []
@@ -561,7 +564,7 @@ def register_rules(driver: LintDriver):
                     continue
                 prev.append(blockchild)
                 append_nested_single_stmt(blockchild, prev)
-                return node # Return the outermost loop to use an anchor
+                return node  # Return the outermost loop to use an anchor
         elif isinstance(node, On) and node.block_style() == "implicit":
             for stmt in node.stmts():
                 if isinstance(stmt, Comment):
@@ -570,7 +573,7 @@ def register_rules(driver: LintDriver):
                     continue
                 prev.append(stmt)
                 append_nested_single_stmt(stmt, prev)
-                return node # Return the outermost on to use an anchor
+                return node  # Return the outermost on to use an anchor
         # Should we also check for Conditionals here?
         return None
 
@@ -720,7 +723,6 @@ def register_rules(driver: LintDriver):
         uses = set()
 
         for tq, _ in chapel.each_matching(root, TypeQuery):
-
             typequeries[tq.unique_id()] = tq
 
         for use, _ in chapel.each_matching(root, Identifier):

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -557,23 +557,21 @@ def register_rules(driver: LintDriver):
         if isinstance(node, Loop) and node.block_style() == "implicit":
             children = list(node)
             # safe to access [-1], loops must have at least 1 child
-            for blockchild in reversed(list(children[-1])):
-                if isinstance(blockchild, Comment):
-                    continue
-                if might_incorrectly_report_location(blockchild):
-                    continue
-                prev.append(blockchild)
-                append_nested_single_stmt(blockchild, prev)
-                return node  # Return the outermost loop to use an anchor
+            inblock = reversed(list(children[-1]))
         elif isinstance(node, On) and node.block_style() == "implicit":
-            for stmt in node.stmts():
-                if isinstance(stmt, Comment):
-                    continue
-                if might_incorrectly_report_location(stmt):
-                    continue
-                prev.append(stmt)
-                append_nested_single_stmt(stmt, prev)
-                return node  # Return the outermost on to use an anchor
+            inblock = node.stmts()
+        else:
+            # Should we also check for Conditionals here?
+            return None
+        for stmt in inblock:
+            if isinstance(stmt, Comment):
+                continue
+            if might_incorrectly_report_location(stmt):
+                continue
+            prev.append(stmt)
+            append_nested_single_stmt(stmt, prev)
+            return node  # Return the outermost on to use an anchor
+        
         # Should we also check for Conditionals here?
         return None
 

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -551,9 +551,9 @@ def register_rules(driver: LintDriver):
             fix = append_nested_single_stmt(child, prev)
 
     def append_nested_single_stmt(node, prev: List[AstNode]):
-        if (isinstance(node, Loop)) and node.block_style() == "implicit":
+        if isinstance(node, Loop) and node.block_style() == "implicit":
             children = list(node)
-            # safe to access [-1], loops or on stmt must have at least 1 child
+            # safe to access [-1], loops must have at least 1 child
             for blockchild in reversed(list(children[-1])):
                 if isinstance(blockchild, Comment):
                     continue
@@ -562,6 +562,16 @@ def register_rules(driver: LintDriver):
                 prev.append(blockchild)
                 append_nested_single_stmt(blockchild, prev)
                 return node # Return the outermost loop to use an anchor
+        elif isinstance(node, On) and node.block_style() == "implicit":
+            for stmt in node.stmts():
+                if isinstance(stmt, Comment):
+                    continue
+                if might_incorrectly_report_location(stmt):
+                    continue
+                prev.append(stmt)
+                append_nested_single_stmt(stmt, prev)
+                return node # Return the outermost on to use an anchor
+        # Should we also check for Conditionals here?
         return None
 
     @driver.fixit(MisleadingIndentation)


### PR DESCRIPTION
Resolves https://github.com/chapel-lang/chapel/issues/26147

Previously, the linting rule for `MisleadingIndentation` did not warn for cases with a loop inside a loop, `on` statements inside a loop.

This adds support in `chplcheck` for this, and also updates the related test.

New Warnings are generated for cases like this (not exhaustive):

```chapel
  for 1..10 do
    for 1..10 do
      writeln("Hello, world!");
      writeln("Hello, world!");  // Lint: rule [MisleadingIndentation] violated

  for 1..10 do
    on Locale[0] do
      writeln("Hello, world!");
      writeln("Hello, world!");  // Lint: rule [MisleadingIndentation] violated

  on Locale[0] do
    for 1..10 do
      writeln("Hello, world!");
      writeln("Hello, world!");  // Lint: rule [MisleadingIndentation] violated

  on Locale[0] do
    on Locale[0] do
      writeln("Hello, world!");
      writeln("Hello, world!");  // Lint: rule [MisleadingIndentation] violated


  for 1..10 do
    for 1..10 do
      for 1..10 do
        writeln("Hello, world!");
        writeln("Hello, world!");  // Lint: rule [MisleadingIndentation] violated
```