### PR TITLE
Fix colocales performance graphs

### DIFF
--- a/util/cron/test-perf.hpe-apollo-hdr.gasnet-ibv.fast.colo-nopshm.bash
+++ b/util/cron/test-perf.hpe-apollo-hdr.gasnet-ibv.fast.colo-nopshm.bash
@@ -14,7 +14,7 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.hpe-apollo-hdr.gasnet-ibv.fast.colo-n
 
 source $CWD/common-hpe-apollo.bash
 source $CWD/common-perf-hpe-apollo-hdr.bash
-perf_hpe_apollo_args="-performance-configs gn-ibv-fast:v,gn-ibv-fast-colo:v,gasnet-ibv.fast.colo-nopshm:v -perflabel ml- -startdate 09/04/24"
+perf_hpe_apollo_args="-performance-configs gn-ibv-fast:v,gn-ibv-fast-colo:v,gn-ibv.fast.colo-nopshm:v -perflabel ml- -startdate 09/04/24"
 
 export CHPL_GASNET_SEGMENT=fast
 export GASNET_PHYSMEM_MAX="0.90"

--- a/util/cron/test-perf.hpe-apollo-hdr.gasnet-ibv.fast.colo.bash
+++ b/util/cron/test-perf.hpe-apollo-hdr.gasnet-ibv.fast.colo.bash
@@ -14,7 +14,7 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.hpe-apollo-hdr.gasnet-ibv.fast.colo"
 
 source $CWD/common-hpe-apollo.bash
 source $CWD/common-perf-hpe-apollo-hdr.bash
-perf_hpe_apollo_args="-performance-configs gn-ibv-fast:v,gn-ibv-fast-colo:v,gasnet-ibv.fast.colo-nopshm:v -perflabel ml- -startdate 09/04/24"
+perf_hpe_apollo_args="-performance-configs gn-ibv-fast:v,gn-ibv-fast-colo:v,gn-ibv.fast.colo-nopshm:v -perflabel ml- -startdate 09/04/24"
 
 export CHPL_GASNET_SEGMENT=fast
 export GASNET_PHYSMEM_MAX="0.90"


### PR DESCRIPTION
Fixes a typo in the colocales performance graphs that was preventing them from getting correct results.

Problem: The data was being generated in the correct place, but then when `genGraphs` was run it used a different path and failed.

[Reviewed by @jhh67]