### PR TITLE
Resolve non-param {enum,string}->string casts in dyno

### DIFF
--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -3681,6 +3681,7 @@ static bool resolveFnCallSpecial(Context* context,
   // TODO: .borrow()
   // TODO: chpl__coerceCopy
 
+  gdbShouldBreakHere();
   // Sometimes, actual types can be unknown since we are checking for 'out'
   // intent. No special functions here use the 'out' intent, so in this case,
   // return false.
@@ -3761,6 +3762,12 @@ static bool resolveFnCallSpecial(Context* context,
         exprTypeOut = QualifiedType(srcQt.kind(), outTy, srcQt.param());
         return true;
       }
+    } else if (!srcQt.isParam() && srcTy->isEnumType() && isDstType &&
+               dstTy->isStringType()) {
+      // non-param enum to string cast
+      exprTypeOut =
+          QualifiedType(QualifiedType::VAR, RecordType::getStringType(context));
+      return true;
     } else if (!isDstType) {
       // trying to cast to something that's not a type
       auto toName = tagToString(dstTy->tag());

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -3681,7 +3681,6 @@ static bool resolveFnCallSpecial(Context* context,
   // TODO: .borrow()
   // TODO: chpl__coerceCopy
 
-  gdbShouldBreakHere();
   // Sometimes, actual types can be unknown since we are checking for 'out'
   // intent. No special functions here use the 'out' intent, so in this case,
   // return false.

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -3761,9 +3761,10 @@ static bool resolveFnCallSpecial(Context* context,
         exprTypeOut = QualifiedType(srcQt.kind(), outTy, srcQt.param());
         return true;
       }
-    } else if (!srcQt.isParam() && srcTy->isEnumType() && isDstType &&
+    } else if (!srcQt.isParam() &&
+               (srcTy->isEnumType() || srcTy->isStringType()) && isDstType &&
                dstTy->isStringType()) {
-      // non-param enum to string cast
+      // supported non-param casts to string
       exprTypeOut =
           QualifiedType(QualifiedType::VAR, RecordType::getStringType(context));
       return true;

--- a/frontend/test/resolution/testCast.cpp
+++ b/frontend/test/resolution/testCast.cpp
@@ -506,6 +506,41 @@ static void test45() {
   }
 }
 
+static void test46() {
+  printf("test46\n");
+  Context ctx;
+  Context* context = &ctx;
+
+  // Param
+  {
+    context->advanceToNextRevision(false);
+    std::string program =
+      R"""(
+      param a = "asdf";
+      param x = a:string;
+      )""";
+
+    auto xInit = resolveTypeOfXInit(context, program);
+    assert(xInit.type());
+    ensureParamString(xInit, "asdf");
+  }
+
+  // Non-param
+  {
+    context->advanceToNextRevision(false);
+    std::string program =
+      R"""(
+      var a = "asdf";
+      var x = a:string;
+      )""";
+
+    auto xInit = resolveTypeOfXInit(context, program);
+    assert(xInit.type());
+    assert(!xInit.isParam());
+    assert(xInit.type()->isStringType());
+  }
+}
+
 int main() {
   test1();
   test2();
@@ -552,6 +587,7 @@ int main() {
   test43();
   test44();
   test45();
+  test46();
 
   return 0;
 }

--- a/frontend/test/resolution/testEnums.cpp
+++ b/frontend/test/resolution/testEnums.cpp
@@ -671,6 +671,7 @@ static void test19() {
   assert(vars.at("res").type()->isEnumType());
 }
 
+// Param cast to string
 static void test20() {
   Context ctx;
   auto context = &ctx;
@@ -711,6 +712,37 @@ static void test20() {
   assert(oss.str() == "R(green)");
 }
 
+// Non-param cast to string
+static void test21() {
+  Context ctx;
+  auto context = &ctx;
+  ErrorGuard guard(context);
+
+  auto vars = resolveTypesOfVariables(context,
+      R"""(
+        enum colors {red, green, blue};
+
+        param c = colors.red;
+        var s = c:string;
+
+        var x = colors.red:string;
+        var y = colors.green:string;
+        var z = colors.blue:string;
+      )""", {"s", "x", "y", "z"});
+
+  assert(guard.realizeErrors() == 0);
+
+  auto check = [] (QualifiedType qt, std::string text) {
+    assert(qt.type()->isStringType());
+    assert(!qt.isParam());
+  };
+
+  check(vars.at("s"), "red");
+  check(vars.at("x"), "red");
+  check(vars.at("y"), "green");
+  check(vars.at("z"), "blue");
+}
+
 int main() {
   test1();
   test2();
@@ -732,6 +764,7 @@ int main() {
   test18();
   test19();
   test20();
+  test21();
 
   return 0;
 }


### PR DESCRIPTION
Enable resolving non-param enum-to-string and string-to-string casts within dyno.

Note param enum casts were already implemented in https://github.com/chapel-lang/chapel/pull/25837. However, non-param casts weren't resolving, as this cast isn't implemented in module code.

Includes adding tests for these cases.

Resolves https://github.com/Cray/chapel-private/issues/6864.

[reviewer info placeholder]

Testing:
- [x] dyno tests
- [x] paratest
- [x] reproducer from OP succeeds