### PR TITLE
Fix build errors with LLVM 11

### DIFF
--- a/compiler/llvm/llvmGlobalToWide.cpp
+++ b/compiler/llvm/llvmGlobalToWide.cpp
@@ -170,9 +170,10 @@ namespace {
 #if HAVE_LLVM_VER > 110
     V->removeAttributes(AttributeList::ReturnIndex, mask);
 #else
-  for (auto attr : mask) {
-    V->removeAttribute(AttributeList::ReturnIndex, attr);
-  }
+    auto& ctx = V->getContext();
+    for (auto attr: AttributeSet::get(ctx, mask)) {
+      V->removeAttribute(AttributeList::ReturnIndex, attr);
+    }
 #endif
 #endif
   }
@@ -186,9 +187,10 @@ namespace {
 #if HAVE_LLVM_VER > 110
     V->removeAttributes(idx+1, mask);
 #else
-  for (auto attr : mask) {
-    V->removeAttribute(idx+1, attr);
-  }
+    auto& ctx = V->getContext();
+    for (auto attr: AttributeSet::get(ctx, mask)) {
+      V->removeAttribute(idx+1, attr);
+    }
 #endif
 #endif
   }

--- a/compiler/llvm/llvmGlobalToWide.cpp
+++ b/compiler/llvm/llvmGlobalToWide.cpp
@@ -167,7 +167,13 @@ namespace {
 #if HAVE_LLVM_VER >= 140
     V->removeRetAttrs(mask);
 #else
+#if HAVE_LLVM_VER > 110
     V->removeAttributes(AttributeList::ReturnIndex, mask);
+#else
+  for (auto attr : mask) {
+    V->removeAttribute(AttributeList::ReturnIndex, attr);
+  }
+#endif
 #endif
   }
   template <typename BaseTy, std::enable_if_t<std::is_base_of_v<Function, BaseTy> ||
@@ -177,7 +183,13 @@ namespace {
 #if HAVE_LLVM_VER >= 140
     V->removeParamAttrs(idx, mask);
 #else
+#if HAVE_LLVM_VER > 110
     V->removeAttributes(idx+1, mask);
+#else
+  for (auto attr : mask) {
+    V->removeAttribute(idx+1, attr);
+  }
+#endif
 #endif
   }
 

--- a/compiler/llvm/llvmGlobalToWide.cpp
+++ b/compiler/llvm/llvmGlobalToWide.cpp
@@ -172,7 +172,7 @@ namespace {
 #else
     auto& ctx = V->getContext();
     for (auto attr: AttributeSet::get(ctx, mask)) {
-      V->removeAttribute(AttributeList::ReturnIndex, attr);
+      V->removeAttribute(AttributeList::ReturnIndex, attr.getKindAsEnum());
     }
 #endif
 #endif
@@ -189,7 +189,7 @@ namespace {
 #else
     auto& ctx = V->getContext();
     for (auto attr: AttributeSet::get(ctx, mask)) {
-      V->removeAttribute(idx+1, attr);
+      V->removeAttribute(idx+1, attr.getKindAsEnum());
     }
 #endif
 #endif


### PR DESCRIPTION
Fixes some compiler build errors with LLVM 11 introduced by https://github.com/chapel-lang/chapel/pull/25964

Tested that `make check` works with LLVM 11.

[Reviewed by @riftEmber]