### PR TITLE
Allow resolution of generic init= with concrete formals

### DIFF
--- a/test/classes/initializers/initequals/generics.chpl
+++ b/test/classes/initializers/initequals/generics.chpl
@@ -51,3 +51,54 @@ operator :(other, type t: R(other.type)) {
   writeln(B.type:string, ": ", B);
 }
 
+writeln("----- init= generic type expression -----");
+
+record GR { type T; var x : T; }
+
+proc GR.init=(other: this.type) {
+  this.T = other.T;
+  this.x = other.x;
+}
+
+proc GR.init=(other: ?t) where t != int {
+  this.T = other.type;
+  this.x = other;
+}
+
+// Purposefully test concrete argument. See #16497
+proc GR.init=(other: int) {
+  writeln("int!");
+  this.T = other.type;
+  this.x = other;
+}
+
+{
+  proc test(arg) {
+    var x : GR(?) = arg;
+    writeln(arg.type:string, " :: ", x.type:string, " :: ", x);
+  }
+  test(5);
+  test(10:uint);
+  test("foo");
+}
+
+writeln("----- init= generic type field -----");
+
+record X {
+  var x : GR(?);
+
+  proc init(arg) {
+    this.x = arg;
+  }
+}
+
+{
+  proc test(arg) {
+    var x = new X(arg);
+    writeln(arg.type:string, " :: ", x.type:string, " :: ", x);
+  }
+
+  test(5);
+  test(10:uint);
+  test("test");
+}

--- a/test/classes/initializers/initequals/generics.good
+++ b/test/classes/initializers/initequals/generics.good
@@ -10,3 +10,13 @@ init= from int(64)
 init= from string
 R(int(64)): (x = 5)
 R(string): (x = a string)
+----- init= generic type expression -----
+int!
+int(64) :: GR(int(64)) :: (x = 5)
+uint(64) :: GR(uint(64)) :: (x = 10)
+string :: GR(string) :: (x = foo)
+----- init= generic type field -----
+int!
+int(64) :: X(GR(int(64))) :: (x = (x = 5))
+uint(64) :: X(GR(uint(64))) :: (x = (x = 10))
+string :: X(GR(string)) :: (x = (x = test))


### PR DESCRIPTION
Consider the following program:

```chpl
record G { type T; var x : T; }

proc G.init=(other: this.type) {
  this.T = other.T;
  this.x = other.x;
}

proc G.init=(other: int) {
  this.T = int;
  this.x = other;
}

var x : G(?) = 5;
```

Previously this program would fail to compile, and give a confusing error message stating it had found the second 'init=' specifically for 'int', but that it somehow wasn't a candidate.

The bug was caused by some missing logic in ``computeSubstitutions`` which was incorrectly returning 'false' in this case. The solution was to manually ignore a generic 'this' formal for initializers.

Resolves #16497

Testing:
- [x] full local