### PR TITLE
Dyno: Improve initialization of fields from non-matching types

### DIFF
--- a/frontend/include/chpl/parsing/parsing-queries.h
+++ b/frontend/include/chpl/parsing/parsing-queries.h
@@ -686,6 +686,11 @@ uast::Module::Kind idToModuleKind(Context* context, ID id);
 */
 bool isSpecialMethodName(UniqueString name);
 
+/*
+  Given a function call, determine if it is a call to a class manager.
+*/
+bool isCallToClassManager(const uast::FnCall* call);
+
 } // end namespace parsing
 } // end namespace chpl
 #endif

--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -2065,5 +2065,17 @@ bool isSpecialMethodName(UniqueString name) {
   }
 }
 
+bool isCallToClassManager(const uast::FnCall* call) {
+  if (auto ident = call->calledExpression()->toIdentifier()) {
+    auto name = ident->name();
+    return name == USTR("owned") || name == USTR("_owned") ||
+           name == USTR("shared") || name == USTR("_shared") ||
+           name == USTR("unmanaged") ||
+           name == USTR("borrowed");
+  }
+
+  return false;
+}
+
 } // end namespace parsing
 } // end namespace chpl

--- a/frontend/lib/resolution/InitResolver.cpp
+++ b/frontend/lib/resolution/InitResolver.cpp
@@ -838,6 +838,7 @@ bool InitResolver::handleAssignmentToField(const OpCall* node) {
 
       state->initPointId = node->id();
       state->isInitialized = true;
+      initPoints.insert(node);
 
       // We could probably get away with running this less, but it's easier
       // to just attempt updating the receiver type for each field even if the
@@ -963,6 +964,10 @@ void InitResolver::checkEarlyReturn(const Return* ret) {
       (size_t)currentFieldIndex_ < fieldIdsByOrdinal_.size()) {
     ctx_->error(ret, "cannot return from initializer before initialization is complete");
   }
+}
+
+bool InitResolver::isInitPoint(const uast::AstNode* node) {
+  return initPoints.find(node) != initPoints.end();
 }
 
 } // end namespace resolution

--- a/frontend/lib/resolution/InitResolver.cpp
+++ b/frontend/lib/resolution/InitResolver.cpp
@@ -824,7 +824,13 @@ bool InitResolver::handleAssignmentToField(const OpCall* node) {
       // Recompute field type in case it depends on a recently-instantiated
       // field. For example, ``var curField : typeField;``.
       auto rf = resolveFieldDecl(ctx_, currentRecvType_->getCompositeType(), fieldId, DefaultsPolicy::IGNORE_DEFAULTS);
-      auto initialFieldType = rf.fieldType(0);
+      QualifiedType initialFieldType;
+      for (int i = 0; i < rf.numFields(); i++) {
+        auto id = rf.fieldDeclId(i);
+        if (id == fieldId) {
+          initialFieldType = rf.fieldType(i);
+        }
+      }
 
       auto rhsType = initResolver_.byPostorder.byAst(rhs).type();
       auto adjusted = QualifiedType(QualifiedType::TYPE, initialFieldType.type());

--- a/frontend/lib/resolution/InitResolver.h
+++ b/frontend/lib/resolution/InitResolver.h
@@ -73,6 +73,9 @@ class InitResolver {
   // Stores field ID and ID of the uAST referencing the field.
   std::vector<std::pair<ID, ID>> useOfSuperFields_;
 
+  //initialization points to guide handling `=` operators
+  std::set<const uast::AstNode*> initPoints;
+
   InitResolver(Context* ctx, Resolver& visitor,
                const uast::Function* fn,
                const types::Type* recvType)
@@ -155,6 +158,9 @@ public:
   const TypedFnSignature* finalize(void);
 
   void checkEarlyReturn(const uast::Return* ret);
+
+  // Returns true if the AST node is an initialization point
+  bool isInitPoint(const uast::AstNode* node);
 };
 
 } // end namespace resolution

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -951,15 +951,6 @@ static void varArgTypeQueryError(Context* context,
   result.setType(errType);
 }
 
-static bool isCallToClassManager(const FnCall* call) {
-  auto ident = call->calledExpression()->toIdentifier();
-  if (!ident) return false;
-  auto name = ident->name();
-  return name == USTR("owned") || name == USTR("shared") ||
-         name == USTR("_owned") || name == USTR("_shared") ||
-         name == USTR("unmanaged") || name == USTR("borrowed");
-}
-
 static std::vector<const TypeQuery*>
 collectTypeQueriesIn(const AstNode* ast, bool recurse=true) {
   std::vector<const TypeQuery*> ret;
@@ -1048,7 +1039,7 @@ void Resolver::resolveTypeQueries(const AstNode* formalTypeExpr,
           }
         }
       }
-    } else if (isCallToClassManager(call) &&
+    } else if (parsing::isCallToClassManager(call) &&
                call->numActuals() == 1 &&
                actualTypePtr->isClassType()) {
       // Strip the owned/shared/etc. for both the formal and the type

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -366,7 +366,8 @@ static bool isRecordLike(const Type* t) {
     // no action needed for 'borrowed' or 'unmanaged'
     // (these should just default initialized to 'nil',
     //  so nothing else needs to be resolved)
-    if (! (decorator.isBorrowed() || decorator.isUnmanaged())) {
+    if (! (decorator.isBorrowed() || decorator.isUnmanaged() ||
+          decorator.isUnknownManagement())) {
       return true;
     }
   } else if (t->isRecordType() || t->isUnionType()) {

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -900,10 +900,13 @@ void CallInitDeinit::handleAssign(const OpCall* ast, RV& rv) {
   // check for use of deinited variables
   processMentions(ast, rv);
 
+  bool isInit = splitInited;
+  isInit |= resolver.initResolver && resolver.initResolver->isInitPoint(ast);
+
   if (lhsType.isType() || lhsType.isParam()) {
     // these are basically 'move' initialization
     resolveMoveInit(ast, rhsAst, lhsType, rhsType, rv);
-  } else if (splitInited) {
+  } else if (isInit) {
     processInit(frame, ast, lhsType, rhsType, rv);
   } else {
     // it is assignment, so resolve the '=' call

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -3225,20 +3225,26 @@ static const Type* getManagedClassType(Context* context,
   UniqueString name = ci.name();
 
   if (ci.hasQuestionArg()) {
-    if (ci.numActuals() != 0) {
-      context->error(astForErr, "invalid class type construction");
-      return ErroneousType::get(context);
-    } else if (name == USTR("owned")) {
-      return AnyOwnedType::get(context);
+
+    const Type* ret = nullptr;
+    if (name == USTR("owned")) {
+      ret = AnyOwnedType::get(context);
     } else if (name == USTR("shared")) {
-      return AnySharedType::get(context);
+      ret = AnySharedType::get(context);
     } else if (name == USTR("unmanaged")) {
-      return ClassType::get(context, AnyClassType::get(context), nullptr, ClassTypeDecorator(ClassTypeDecorator::UNMANAGED));
+      ret = ClassType::get(context, AnyClassType::get(context), nullptr, ClassTypeDecorator(ClassTypeDecorator::UNMANAGED));
     } else if (name == USTR("borrowed")) {
-      return ClassType::get(context, AnyClassType::get(context), nullptr, ClassTypeDecorator(ClassTypeDecorator::BORROWED));
+      ret = ClassType::get(context, AnyClassType::get(context), nullptr, ClassTypeDecorator(ClassTypeDecorator::BORROWED));
     } else {
       // case not handled in here
       return nullptr;
+    }
+
+    if (ret != nullptr && ci.numActuals() != 0) {
+      context->error(astForErr, "invalid class type construction");
+      return ErroneousType::get(context);
+    } else {
+      return ret;
     }
   }
 

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -3764,10 +3764,14 @@ static bool resolveFnCallSpecial(Context* context,
 
   if (ci.name() == USTR("isCoercible")) {
     if (ci.numActuals() != 2) {
-      context->error(astForErr, "bad call to %s", ci.name().c_str());
-      exprTypeOut = QualifiedType(QualifiedType::UNKNOWN,
-                                  ErroneousType::get(context));
-      return true;
+      if (!ci.isMethodCall()) {
+        context->error(astForErr, "bad call to %s", ci.name().c_str());
+        exprTypeOut = QualifiedType(QualifiedType::UNKNOWN,
+                                    ErroneousType::get(context));
+        return true;
+      } else {
+        return false;
+      }
     }
     auto got = canPass(context, ci.actual(0).type(), ci.actual(1).type());
     bool result = got.passes();

--- a/frontend/test/resolution/testInitSemantics.cpp
+++ b/frontend/test/resolution/testInitSemantics.cpp
@@ -1737,6 +1737,38 @@ static void testInitGenericAfterConcrete() {
   }
 }
 
+static void testNilFieldInit() {
+  std::string program = R"""(
+    class C { var x: int; }
+    record R {
+      var x: unmanaged C?;
+      proc init() {
+        x = nil;
+      }
+    }
+
+    var x: R;
+  )""";
+  auto config = getConfigWithHome();
+  Context ctx(config);
+  Context* context = &ctx;
+  setupModuleSearchPaths(context, false, false, {}, {});
+  ErrorGuard guard(context);
+  ResolutionContext rcval(context);
+  auto rc = &rcval;
+  auto m = parseModule(context, std::move(program));
+  auto recordDecl = m->stmt(1)->toAggregateDecl();
+  auto initFunc = recordDecl->declOrComment(1)->toFunction();
+  assert(initFunc);
+
+  auto untyped = UntypedFnSignature::get(context, initFunc);
+  auto typed = typedSignatureInitial(rc, untyped);
+  auto inFn = resolveFunction(rc, typed, nullptr);
+  assert(inFn);
+
+  assert(guard.errors().size() == 0);
+}
+
 // TODO:
 // - test using defaults for types and params
 //   - also in conditionals
@@ -1782,6 +1814,8 @@ int main() {
   testImplicitSuperInit();
 
   testInitGenericAfterConcrete();
+
+  testNilFieldInit();
 
   return 0;
 }

--- a/frontend/test/resolution/testTypeConstruction.cpp
+++ b/frontend/test/resolution/testTypeConstruction.cpp
@@ -1395,10 +1395,12 @@ static void testRecursiveTypeConstructorGeneric() {
 }
 
 static void testRecursiveTypeConstructorMutual() {
-  printf("testRecursiveTypeConstructor\n");
-  Context ctx;
+  printf("testRecursiveTypeConstructorMutual\n");
+  auto config = getConfigWithHome();
+  Context ctx(config);
   Context* context = &ctx;
   ErrorGuard guard(context);
+  setupModuleSearchPaths(context, false, false, {}, {});
 
   auto p = parseTypeAndFieldsOfX(context,
       R"""(


### PR DESCRIPTION
Prior to this PR InitResolver would always use the RHS type of field initialization statements to set the type of the field. For example, in "this.foo = RHS;", the field 'foo' would always use the type of RHS when resolving any relevant initialization calls (e.g. assignment). A real-world example is initializing a nilable class from ``nil``.

This PR uses ``Resolver::getTypeForDecl`` to check that the types are compatible, and then uses the computed type for 'foo'.

This PR also includes various other improvements needed to get tests working:
- correctly identifying field initialization during call-init-deinit (thanks to @brandon-neth)
- fix faulty "invalid class type construction" error when not dealing with managed classes
- Enable comparisons between types and ``?``
- Fix for faulty ``isCoercible`` error (mistakenly attempted to resolve as a method)
- Update ``isRecordLike`` in call-init-deinit to return false for any-managed
- Improve syntactic detection of genericity for managed and nilable classes (thanks to @DanilaFe)

Thusly, new tests are added to demonstrate correct initialization of generic fields when initialized from a type that does not match.

Testing:
- [x] test-dyno