### PR TITLE
Enable testing GPU=cpu over release/examples

### DIFF
--- a/test/release/examples/gpu/SKIPIF
+++ b/test/release/examples/gpu/SKIPIF
@@ -1,1 +1,5 @@
+# to pass testing, we need GPUs enabled
 CHPL_LOCALE_MODEL != gpu
+
+# skip "cpu as gpu" mode because comm counts differ
+CHPL_GPU == cpu

--- a/test/release/examples/gpu/hello-gpu.comm-none.good
+++ b/test/release/examples/gpu/hello-gpu.comm-none.good
@@ -1,1 +1,0 @@
-CORRECT = true

--- a/util/cron/test-gpu-cpu.bash
+++ b/util/cron/test-gpu-cpu.bash
@@ -11,10 +11,8 @@ export CHPL_GPU=cpu
 export CHPL_COMM=none
 export CHPL_GPU_NO_CPU_MODE_WARNING=y
 
-# some tests in release/examples fail after adding the initial support for
-# distributed arrays. We need to have a fix for that before re-enabling
-# release/examples testing.
-# export CHPL_NIGHTLY_TEST_DIRS="$CHPL_NIGHTLY_TEST_DIRS release/examples"
+# Test also release/examples
+export CHPL_NIGHTLY_TEST_DIRS="$CHPL_NIGHTLY_TEST_DIRS release/examples"
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-cpu"
 $CWD/nightly -cron ${nightly_args}


### PR DESCRIPTION
This PR enables testing of `release/examples` in the CHPL_GPU=cpu configuration, reverting #24365.

All tests pass except `hello-gpu.chpl` where the comm counts differ from proper gpu execution. Skipif this test for this configuration.

While there, remove an unnecessary .good file.

Testing change requested in #24365, not reviewed.