### PR TITLE
More gpu cpu testing

### DIFF
--- a/test/release/examples/primers/fact.c
+++ b/test/release/examples/primers/fact.c
@@ -14,13 +14,13 @@ int fact(int x){
 
 
 data* getNewData(void){
-    data *d = malloc(sizeof(data));
+    data *d = (data*)malloc(sizeof(data));
     d->x = 5;
     return d;
 }
 
 data* fact_d(data *d){
-    data *s = malloc(sizeof(data));
+    data *s = (data*)malloc(sizeof(data));
     
     if(d->x <= 1){
         s->x = 1;
@@ -34,7 +34,7 @@ data* fact_d(data *d){
 }
 
 data* getDataStructPtr(void){
-    data *d = malloc(sizeof(data));
+    data *d = (data*)malloc(sizeof(data));
     d->x = 10;
     return d;
 }

--- a/util/cron/test-gpu-cpu.bash
+++ b/util/cron/test-gpu-cpu.bash
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 #
-# GPU native testing using cpu-as-device mode on a Cray CS (using none for
-# CHPL_COMM)
+# GPU native testing on a Cray CS
+#  * cpu-as-device mode
+#  * CHPL_COMM=none
 
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-slurm-gasnet-cray-cs.bash

--- a/util/cron/test-gpu-ex-cpu.bash
+++ b/util/cron/test-gpu-ex-cpu.bash
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 #
-# GPU native testing on a Cray EX (using none for CHPL_COMM)
+# GPU native testing on a Cray EX
+#  * cpu-as-device mode
+#  * CHPL_COMM=none
 
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-native-gpu.bash
@@ -9,6 +11,9 @@ source $CWD/common-hpe-cray-ex.bash
 export CHPL_GPU=cpu
 export CHPL_COMM=none
 export CHPL_GPU_NO_CPU_MODE_WARNING=y
+
+# Test also release/examples
+export CHPL_NIGHTLY_TEST_DIRS="$CHPL_NIGHTLY_TEST_DIRS release/examples"
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-ex-cpu"
 $CWD/nightly -cron ${nightly_args}


### PR DESCRIPTION
Enable nightly testing of `release/examples` in the cpu-as-device mode, aka CHPL_GPU=cpu, on EX, by analogy to #26221.

While there, fix this error, which we get in CHPL_GPU=amd testing using the bundled LLVM 18:
```
fact.c:17:11: error: cannot initialize a variable of type 'data *' (aka '_data *') with an rvalue of type 'void *'
   17 |     data *d = malloc(sizeof(data));
      |           ^   ~~~~~~~~~~~~~~~~~~~~
```

Trivial and proposed by @jabraham17. Not reviewed.