### PR TITLE
Enable release/examples GPU testing

### DIFF
--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -2572,7 +2572,8 @@ void FnSymbol::codegenPrototype() {
 
     if (generatingGPUKernel) {
       func->setConvergent();
-      if (!hasFlag(FLAG_GPU_AND_CPU_CODEGEN)) {
+      if (!hasFlag(FLAG_GPU_AND_CPU_CODEGEN) &&
+          !hasFlag(FLAG_GPU_SPECIALIZATION)) {
         switch (getGpuCodegenType()) {
           case GpuCodegenType::GPU_CG_NVIDIA_CUDA:
             func->setCallingConv(llvm::CallingConv::PTX_Kernel);
@@ -3130,7 +3131,7 @@ void FnSymbol::codegenDef() {
       if( ! debug_info )
         problems = llvm::verifyFunction(*func, &llvm::errs());
       if( problems ) {
-        INT_FATAL("LLVM function verification failed");
+        INT_FATAL(this, "LLVM function verification failed");
       }
     }
 

--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -2306,6 +2306,17 @@ codegenFunctionTypeLLVM(FnSymbol* fn, llvm::AttributeList& attrs,
 
 #endif
 
+bool needsCodegenWrtGPU(FnSymbol* fn) {
+  if (fn->hasFlag(FLAG_NO_CODEGEN))
+    return false;
+
+  if (gCodegenGPU)
+    return fn->hasFlag(FLAG_GPU_AND_CPU_CODEGEN) ||
+           fn->hasFlag(FLAG_GPU_CODEGEN);
+  else
+    return !fn->hasFlag(FLAG_GPU_CODEGEN);
+}
+
 // forHeader == true when generating the C header.
 GenRet FnSymbol::codegenFunctionType(bool forHeader) {
   GenInfo* info = gGenInfo;
@@ -2501,14 +2512,7 @@ void FnSymbol::codegenPrototype() {
   GenInfo *info = gGenInfo;
 
   if (hasFlag(FLAG_EXTERN) && !hasFlag(FLAG_GENERATE_SIGNATURE)) return;
-  if (hasFlag(FLAG_NO_CODEGEN))   return;
-  if (gCodegenGPU == true) {
-    if (hasFlag(FLAG_GPU_AND_CPU_CODEGEN) == false &&
-       hasFlag(FLAG_GPU_CODEGEN) == false)
-      return;
-    if (hasFlag(FLAG_NOT_CALLED_FROM_GPU))
-      return;
-  }
+  if (! needsCodegenWrtGPU(this)) return;
 
   if( info->cfile ) {
     // In C, we don't need to generate prototypes for external
@@ -2553,8 +2557,9 @@ void FnSymbol::codegenPrototype() {
       return;
     }
 
-    bool generatingGPUKernel = (gCodegenGPU && hasFlag(FLAG_GPU_CODEGEN));
-
+    bool generatingGPUKernel = (gCodegenGPU && hasFlag(FLAG_GPU_KERNEL));
+    bool generatingGPUFun = (gCodegenGPU &&
+      ( hasFlag(FLAG_GPU_CODEGEN) || hasFlag(FLAG_GPU_AND_CPU_CODEGEN) ));
     llvm::Function::LinkageTypes linkage = llvm::Function::InternalLinkage;
     if (fDynoLibGenOrUse) {
       linkage = llvm::Function::LinkOnceODRLinkage;
@@ -2570,10 +2575,9 @@ void FnSymbol::codegenPrototype() {
                                                   info->module);
     trackLLVMValue(func);
 
-    if (generatingGPUKernel) {
+    if (generatingGPUFun) {
       func->setConvergent();
-      if (!hasFlag(FLAG_GPU_AND_CPU_CODEGEN) &&
-          !hasFlag(FLAG_GPU_SPECIALIZATION)) {
+      if (hasFlag(FLAG_GPU_KERNEL)) {
         switch (getGpuCodegenType()) {
           case GpuCodegenType::GPU_CG_NVIDIA_CUDA:
             func->setCallingConv(llvm::CallingConv::PTX_Kernel);
@@ -2759,12 +2763,7 @@ void FnSymbol::codegenDef() {
     gdbShouldBreakHere();
   }
 
-  if( hasFlag(FLAG_NO_CODEGEN) ) return;
-
-  if( (hasFlag(FLAG_GPU_CODEGEN) != gCodegenGPU) &&
-      !hasFlag(FLAG_GPU_AND_CPU_CODEGEN)) return;
-
-  if (gCodegenGPU && hasFlag(FLAG_NOT_CALLED_FROM_GPU)) return;
+  if (!needsCodegenWrtGPU(this)) return;
 
   info->cStatements.clear();
   info->cLocalDecls.clear();

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -834,7 +834,7 @@ genVirtualMethodTable(std::vector<TypeSymbol*>& types, bool isHeader) {
         if (Vec<FnSymbol*>* vfns = virtualMethodTable.get(ct)) {
           int i = 0;
           forv_Vec(FnSymbol, vfn, *vfns) {
-            if (vfn->hasFlag(FLAG_GPU_CODEGEN) == gCodegenGPU) {
+            if (needsCodegenWrtGPU(vfn)) {
               int classId = ct->classId;
               int fnId = i;
               int index = gMaxVMT * classId + fnId;
@@ -1821,8 +1821,7 @@ static void codegen_header(std::set<const char*> & cnames,
   // collect functions and apply canonical sort
   //
   forv_Vec(FnSymbol, fn, gFnSymbols) {
-    if ((fn->hasFlag(FLAG_GPU_CODEGEN) == gCodegenGPU) ||
-        fn->hasFlag(FLAG_GPU_AND_CPU_CODEGEN)) {
+    if (needsCodegenWrtGPU(fn)) {
       functions.push_back(fn);
     }
   }

--- a/compiler/include/codegen.h
+++ b/compiler/include/codegen.h
@@ -214,6 +214,7 @@ void setupClang(GenInfo* info, std::string rtmain);
 #endif
 
 bool isBuiltinExternCFunction(const char* cname);
+bool needsCodegenWrtGPU(FnSymbol* fn);
 
 const char* legalizeName(const char* name);
 

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2308,7 +2308,7 @@ void finishCodegenLLVM() {
       llvm::MDString::get(info->module->getContext(), chapel_string))
   );
 
-  if(debug_info)debug_info->finalize();
+  if (debug_info) debug_info->finalize();
 
   // finish bringing in symbols from separately compiled .dyno files
   if (fDynoLibGenOrUse && !fDynoGenLib) {
@@ -2316,11 +2316,11 @@ void finishCodegenLLVM() {
   }
 
   // Verify the LLVM module.
-  if( developer ) {
+  if (developer || fVerify) {
     bool problems;
     problems = verifyModule(*info->module, &errs());
     //problems = false;
-    if(problems) {
+    if (problems) {
       INT_FATAL("LLVM module verification failed");
     }
   }

--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -830,6 +830,7 @@ FnSymbol* GpuizableLoop::createErroringStubForGpu(FnSymbol* fn) {
   gpuCopy->name = astr(gpuCopy->name, "_gpuError");
   gpuCopy->cname = astr(gpuCopy->cname, "_gpuError");
   gpuCopy->addFlag(FLAG_GPU_CODEGEN);
+  gpuCopy->addFlag(FLAG_GPU_SPECIALIZATION); //for proper calling convention
   gpuCopy->removeFlag(FLAG_NOT_CALLED_FROM_GPU);
   fn->defPoint->insertAfter(new DefExpr(gpuCopy));
 

--- a/frontend/include/chpl/uast/PragmaList.h
+++ b/frontend/include/chpl/uast/PragmaList.h
@@ -292,18 +292,21 @@ PRAGMA(GET_MODULE_NAME, ypr, "get module name", "replace calls to this function 
 
 PRAGMA(GLOBAL_TYPE_SYMBOL, ypr, "global type symbol", "is accessible through a global type variable")
 PRAGMA(GLOBAL_VAR_BUILTIN, ypr, "global var builtin", "is accessible through a global symbol variable")
-PRAGMA(GPU_CODEGEN, ypr, "codegen for GPU", "generate GPU code and set function calling convention to kernel launch")
-PRAGMA(GPU_AND_CPU_CODEGEN, ypr, "codegen for CPU and GPU", "generate both GPU and CPU code")
+
+// GPU-related flags
+PRAGMA(GPU_KERNEL, npr, "GPU kernel", "GPU kernel function to be launched on the device")
+PRAGMA(GPU_CODEGEN, ypr, "codegen for GPU", "this function may execute on a GPU")
+PRAGMA(GPU_AND_CPU_CODEGEN, ypr, "codegen for CPU and GPU", "this function may execute on a GPU or on a CPU")
+PRAGMA(GPU_SPECIALIZATION, npr, "gpu specialization", "reachable only from `on (a GPU sublocale)`")
+PRAGMA(NO_GPU_CODEGEN, ypr, "no gpu codegen", "this function is GPU-ineligible")
+PRAGMA(NOT_CALLED_FROM_GPU, ypr, "not called from gpu", "runtime error if this function is called from a gpu")
 PRAGMA(ASSERT_ON_GPU, ypr, "assert on gpu", "triggers runtime assertion if not running on device")
-PRAGMA(GPU_SPECIALIZATION, npr, "gpu specialization", ncm)
-PRAGMA(NOT_CALLED_FROM_GPU, ypr, "not called from gpu", "this function will never be called from a gpu")
-PRAGMA(REDUCTION_TEMP, npr, "reduction temp variable", ncm)
 
 PRAGMA(HAS_POSTINIT, ypr, "has postinit", "type that has a postinit method")
 PRAGMA(HAS_RUNTIME_TYPE, ypr, "has runtime type", "type that has an associated runtime type")
-
 PRAGMA(IGNORE_RUNTIME_TYPE, ypr, "ignore runtime type", "use the static type only in the return value")
 PRAGMA(IGNORE_IN_GLOBAL_ANALYSIS, ypr, "ignore in global analysis", "ignore this function in global use-before-def analysis")
+PRAGMA(REDUCTION_TEMP, npr, "reduction temp variable", ncm)
 PRAGMA(RVV, npr, "RVV", "variable is the return value variable")
 PRAGMA(YVV, npr, "YVV", "variable is a yield value variable")
 PRAGMA(HEAP, npr, "heap", ncm)
@@ -442,8 +445,6 @@ PRAGMA(NO_REMOTE_MEMORY_FENCE, ypr, "no remote memory fence", ncm)
 PRAGMA(NO_RENAME, npr, "no rename", ncm)
 PRAGMA(NO_RVF, ypr, "do not RVF", ncm)
 PRAGMA(NO_WIDE_CLASS, ypr, "no wide class", ncm)
-
-PRAGMA(NO_GPU_CODEGEN, ypr, "no gpu codegen", ncm)
 
 // See ORDER_INDEPENDENT_YIELDING_LOOPS below
 PRAGMA(NOT_ORDER_INDEPENDENT_YIELDING_LOOPS, ypr, "not order independent yielding loops", "yielding loops in iterator itself are not order independent")

--- a/test/gpu/native/basics/bug23045.chpl
+++ b/test/gpu/native/basics/bug23045.chpl
@@ -12,7 +12,6 @@ extern {
 }
 
 pragma "codegen for GPU"
-pragma "always resolve function"
 extern proc printInt(x : c_int);
 
 proc testValue(){

--- a/test/gpu/native/cudaOnly/gpuAddNums/gpuAddNums.chpl
+++ b/test/gpu/native/cudaOnly/gpuAddNums/gpuAddNums.chpl
@@ -76,8 +76,7 @@ extern {
 
 }
 
-pragma "codegen for GPU"
-pragma "always resolve function"
+pragma "GPU kernel"
 export proc add_nums(dst_ptr: c_ptr(real(64))){
   //var a = 1+2;
   dst_ptr[0] = dst_ptr[0]+10;

--- a/test/gpu/native/cudaOnly/gpuAddNums/gpuAddNums_primitive.chpl
+++ b/test/gpu/native/cudaOnly/gpuAddNums/gpuAddNums_primitive.chpl
@@ -37,8 +37,7 @@ extern {
 
 }
 
-pragma "codegen for GPU"
-pragma "always resolve function"
+pragma "GPU kernel"
 export proc add_nums(dst_ptr: c_ptr(real(64))){
   dst_ptr[0] = dst_ptr[0]+5;
 }

--- a/test/gpu/native/distArray/issue-26202.chpl
+++ b/test/gpu/native/distArray/issue-26202.chpl
@@ -1,0 +1,67 @@
+
+use StencilDist;
+
+// set up simulation constants
+config const xLen = 2.0,
+             yLen = 2.0,
+             nx = 31,
+             ny = 31,
+             sourceMag = 100.0,
+             maxIters = 100;
+
+const dx = xLen / (nx-1),
+      dy = yLen / (ny-1);
+
+// simulation settings
+config const makePlots = false;
+
+// define problem space
+const space = stencilDist.createDomain({0..<ny, 0..<nx}, fluff=(1,1)),
+      spaceInner = space.expand(-1);
+
+proc main() {
+    // define pressure and source arrays
+    var p, b: [space] real = 0.0;
+
+    // set boundary conditions
+    p[..,    0] = 0;                     // p = 0 @ x = 0
+    p[.., nx-1] = [j in 0..<ny] j * dy;  // p = y @ x = xLen
+    p[0,    ..] = p[1, ..];              // dp/dy = 0 @ y = 0
+    p[ny-1, ..] = p[ny-2, ..];           // dp/dy = 0 @ y = yLen
+
+    // set sink/source terms
+    b[3*ny/4, nx/4] = sourceMag;
+    b[ny/4, 3*nx/4] = -sourceMag;
+
+    solvePoisson(p, b);
+
+    writeln("success!");
+}
+
+proc solvePoisson(ref p: [?d] real, const ref b: [d] real) {
+    // temporary copy of p
+    var pn = p;
+
+    // solve for maxIters iterations
+    for 1..maxIters {
+        p <=> pn;
+        pn.updateFluff();
+        poissonKernel(p, pn, b);
+        neumannBC(p);
+    }
+}
+
+proc poissonKernel(ref p: [] real, const ref pn: [] real, const ref b: [] real) {
+    forall (i, j) in spaceInner {
+        p[i, j] = (
+            dy**2 * (pn[i, j+1] + pn[i, j-1]) +
+            dx**2 * (pn[i+1, j] + pn[i-1, j]) -
+            dx**2 * dy**2 * b[i, j]
+        ) / (2.0 * (dx**2 + dy**2));
+    }
+}
+
+proc neumannBC(ref p: [] real) {
+    p[0,    ..] = p[1, ..];    // dp/dy = 0 @ y = 0
+    p[ny-1, ..] = p[ny-2, ..]; // dp/dy = 0 @ y = yLen
+}

--- a/test/gpu/native/distArray/issue-26202.good
+++ b/test/gpu/native/distArray/issue-26202.good
@@ -1,0 +1,1 @@
+success!

--- a/test/gpu/native/simpleExternHello.chpl
+++ b/test/gpu/native/simpleExternHello.chpl
@@ -4,7 +4,6 @@
 extern { static __device__ __host__ void externHello() {  printf("hello\n"); }; }
 
 pragma "codegen for GPU"
-pragma "always resolve function"
 extern proc externHello();
 
 on here.gpus[0] {

--- a/test/gpu/native/studies/transpose/transpose.chpl
+++ b/test/gpu/native/studies/transpose/transpose.chpl
@@ -76,8 +76,7 @@ inline proc transposeClever(original, ref output) {
   }
 }
 
-pragma "codegen for GPU"
-pragma "always resolve function"
+pragma "GPU kernel"
 export proc transposeMatrix(odata: c_ptr(dataType), idata: c_ptr(dataType), width: int, height: int) {
   // Allocate extra columns for the shared 2D array to avoid bank conflicts.
   param paddedBlockSize = blockSize + blockPadding;

--- a/test/gpu/native/threadBlockAndGridPrimitives.chpl
+++ b/test/gpu/native/threadBlockAndGridPrimitives.chpl
@@ -5,8 +5,7 @@ use CTypes;
 
 param VALS_PER_THREAD=13;
 
-pragma "codegen for GPU"
-pragma "always resolve function"
+pragma "GPU kernel"
 export proc add_nums(dst_ptr: c_ptr(real(32))){
   var tid_x = __primitive("gpu threadIdx x");
   var tid_y = __primitive("gpu threadIdx y");

--- a/test/release/examples/primers/interopWithC.suppressif
+++ b/test/release/examples/primers/interopWithC.suppressif
@@ -1,0 +1,4 @@
+# This test currently gives this:
+# /usr/local/cuda-11.8/include/thrust/functional.h:598: error: 'square' has multiple definitions, redefined at:
+#   /usr/local/cuda-11.8/include/thrust/functional.h:598
+CHPL_GPU == nvidia

--- a/util/cron/common-native-gpu.bash
+++ b/util/cron/common-native-gpu.bash
@@ -9,7 +9,7 @@ source $CWD/common.bash
 export CHPL_LLVM=system
 export CHPL_LOCALE_MODEL=gpu
 export CHPL_TEST_GPU=true
-export CHPL_NIGHTLY_TEST_DIRS="gpu/native users/engin/context"
+export CHPL_NIGHTLY_TEST_DIRS="gpu/native users/engin/context release/examples"
 
 unset CHPL_START_TEST_ARGS
 nightly_args="${nightly_args} -no-buildcheck"

--- a/util/cron/test-gpu-cpu.bash
+++ b/util/cron/test-gpu-cpu.bash
@@ -12,8 +12,5 @@ export CHPL_GPU=cpu
 export CHPL_COMM=none
 export CHPL_GPU_NO_CPU_MODE_WARNING=y
 
-# Test also release/examples
-export CHPL_NIGHTLY_TEST_DIRS="$CHPL_NIGHTLY_TEST_DIRS release/examples"
-
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-cpu"
 $CWD/nightly -cron ${nightly_args}

--- a/util/cron/test-gpu-ex-cpu.bash
+++ b/util/cron/test-gpu-ex-cpu.bash
@@ -12,8 +12,5 @@ export CHPL_GPU=cpu
 export CHPL_COMM=none
 export CHPL_GPU_NO_CPU_MODE_WARNING=y
 
-# Test also release/examples
-export CHPL_NIGHTLY_TEST_DIRS="$CHPL_NIGHTLY_TEST_DIRS release/examples"
-
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-ex-cpu"
 $CWD/nightly -cron ${nightly_args}


### PR DESCRIPTION
This PR re-enables GPU testing over `test/release/examples`. For that, it (a) applies a `suppressif` on a test that generates a namespace-related error when compiling under CUDA, which I did not investigate, and (b) fixes the LLVM calling convention that was previously set incorrectly for the compiler-generated gpu-error stubs, causing LLVM verification failure in `release/examples/benchmarks/hpcc/ra-atomics` and a couple others, by introducing `FLAG_GPU_KERNEL` and `pragma "GPU kernel"`.

#### Implementation notes

I tidied up the uses of several flags/pragmas in the compiler and tests. Here are highlights:

| use | old | "gpu codegen" | "gpu and cpu codegen" | new | "gpu codegen" | "gpu and cpu codegen" | "gpu kernel" |
| :--- | --- | :--- | :--- | --- | :--- | :--- | :--- |
| kernel | | + | - | | + | - | + |
| executed only on device | | n/a | n/a | | + | - | - |
| called from kernel, possibly also on host | | + | + | | - | + | - |

where the gpu-error stubs fall into the "executed only on device" category.

We can/should replace these flags with an enum that allows clean categorization of a function into these categories that we have today:

* unlabeled/default == for CPU only (or for both CPU and GPU?)
* for CPU only
* for GPU only
* a GPU kernel ==> for GPU only
* invoked from a GPU kernel -- same as "for GPU only?"
* for both CPU and GPU
* specialized for GPU execution == FLAG_GPU_SPECIALIZATION ==> for GPU only
* not specialized for GPU execution when specialization is ON
  in the future this will mean "for CPU only"
* not GPU eligible == FLAG_NO_GPU_CODEGEN
* assumed never invoked on GPU == FLAG_NOT_CALLED_FROM_GPU
  in the future this will generate a halt() when the assumption is broken

I am leaving this refactoring outside the scope of this PR.

While there, I enabled LLVM module verification when compiling with `--verify` -- for consistency with LLVM function verification.

Testing:  ROCm and CUDA