### PR TITLE
Default to a slurm-based launcher regardless of platform

### DIFF
--- a/util/chplenv/chpl_launcher.py
+++ b/util/chplenv/chpl_launcher.py
@@ -6,9 +6,9 @@ import chpl_comm, chpl_comm_substrate, chpl_platform, overrides
 from utils import which, error, memoize, warning
 
 
-def slurm_prefix(base_launcher, platform_val):
-    """ If salloc is available and we're on a cray-cs/hpe-apollo, prefix with slurm-"""
-    if platform_val in ('cray-cs', 'hpe-apollo') and which('salloc'):
+def slurm_prefix(base_launcher):
+    """ If salloc is available, prefix with slurm-"""
+    if which('salloc'):
         return 'slurm-{}'.format(base_launcher)
     return base_launcher
 
@@ -34,6 +34,7 @@ def get():
             has_slurm = which('srun')
             if has_aprun and has_slurm:
                 launcher_val = 'none'
+                warning("Both 'aprun' and 'srun' are available on this system. Please explicitly set CHPL_LAUNCHER.")
             elif has_aprun:
                 launcher_val = 'aprun'
             elif has_slurm:
@@ -47,21 +48,22 @@ def get():
                 #        has_aprun and has_slurm should look other places
                 #        (maybe the modules?) to decide.
                 #        (thomasvandoren, 2014-08-12)
+                launcher_val = 'none'
                 warning('Cannot detect launcher on this system. Please '
                         'set CHPL_LAUNCHER in the environment.')
         elif comm_val == 'gasnet':
             if substrate_val == 'smp':
                 launcher_val = 'smp'
             elif substrate_val == 'mpi':
-                launcher_val = slurm_prefix('gasnetrun_mpi', platform_val)
+                launcher_val = slurm_prefix('gasnetrun_mpi')
             elif substrate_val == 'ibv':
-                launcher_val = slurm_prefix('gasnetrun_ibv', platform_val)
+                launcher_val = slurm_prefix('gasnetrun_ibv')
             elif substrate_val == 'ucx':
-                launcher_val = slurm_prefix('gasnetrun_ucx', platform_val)
+                launcher_val = slurm_prefix('gasnetrun_ucx')
             elif substrate_val == 'ofi':
-                launcher_val = slurm_prefix('gasnetrun_ofi', platform_val)
+                launcher_val = slurm_prefix('gasnetrun_ofi')
         else:
-            if platform_val in ('cray-cs', 'hpe-apollo') and which('srun'):
+            if which('srun'):
                 launcher_val = 'slurm-srun'
             else:
                 launcher_val = 'none'

--- a/util/cron/common-localnode-paratest.bash
+++ b/util/cron/common-localnode-paratest.bash
@@ -30,3 +30,6 @@ function get_nightly_paratest_args
     gen_nodefile ${nodepara} ${parnodefile}
     echo "-parnodefile ${parnodefile}"
 }
+
+# Disable the launcher for local testing
+export CHPL_LAUNCHER=none

--- a/util/cron/test-c2chapel.bash
+++ b/util/cron/test-c2chapel.bash
@@ -18,4 +18,6 @@ export CHPL_NIGHTLY_TEST_DIRS="c2chapel/"
 CHPL_BIN_SUBDIR=`"$CHPL_HOME"/util/chplenv/chpl_bin_subdir.py`
 export PATH="$CHPL_HOME/bin/$CHPL_BIN_SUBDIR:$PATH"
 
+export CHPL_LAUNCHER=none
+
 $UTIL_CRON_DIR/nightly -cron

--- a/util/cron/test-fast-comp.bash
+++ b/util/cron/test-fast-comp.bash
@@ -9,6 +9,8 @@ export CHPL_TEST_PERF_CONFIG_NAME='comp-fast'
 source $UTIL_CRON_DIR/common.bash
 source $UTIL_CRON_DIR/common-fast.bash
 
+export CHPL_LAUNCHER=none
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="fast-comp"
 
 nightly_args="${nightly_args} -examples -componly -compperformance (--fast)"

--- a/util/cron/test-gasnet-asan.bash
+++ b/util/cron/test-gasnet-asan.bash
@@ -22,6 +22,7 @@ export CHPL_RT_CACHE_QUIET=true
 #
 export CHPL_COMM_SUBSTRATE=udp
 export CHPL_GASNET_SEGMENT=everything
+unset CHPL_LAUNCHER
 
 $UTIL_CRON_DIR/nightly -cron -multilocale ${nightly_args} $(get_nightly_paratest_args 8)
 

--- a/util/cron/test-gasnet-everything.bash
+++ b/util/cron/test-gasnet-everything.bash
@@ -12,5 +12,6 @@ export GASNET_QUIET=Y
 
 # Test a GASNet compile using the default segment (everything for linux64)
 export CHPL_GASNET_SEGMENT=everything
+unset CHPL_LAUNCHER
 
 $UTIL_CRON_DIR/nightly -cron -futures $(get_nightly_paratest_args 8)

--- a/util/cron/test-gasnet-fast.bash
+++ b/util/cron/test-gasnet-fast.bash
@@ -12,5 +12,6 @@ export GASNET_QUIET=Y
 
 # Test a GASNet compile using the fast segment
 export CHPL_GASNET_SEGMENT=fast
+unset CHPL_LAUNCHER
 
 $UTIL_CRON_DIR/nightly -cron -multilocale $(get_nightly_paratest_args 8)

--- a/util/cron/test-host-jemalloc.bash
+++ b/util/cron/test-host-jemalloc.bash
@@ -5,6 +5,7 @@
 UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common.bash
 
+export CHPL_LAUNCHER=none
 export CHPL_HOST_MEM="jemalloc"
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="host-jemalloc"
 

--- a/util/cron/test-linux64-clang.bash
+++ b/util/cron/test-linux64-clang.bash
@@ -13,6 +13,8 @@ unset CXX
 export CHPL_HOST_COMPILER=clang
 export CHPL_TARGET_COMPILER=clang
 
+export CHPL_LAUNCHER=none
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-clang"
 
 $UTIL_CRON_DIR/nightly -cron -examples -blog ${nightly_args}

--- a/util/cron/test-linux64-gcc101.bash
+++ b/util/cron/test-linux64-gcc101.bash
@@ -25,6 +25,8 @@ if [ "$gcc_version" != "10.1.0" ]; then
   exit 2
 fi
 
+export CHPL_LAUNCHER=none
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-gcc101"
 
 $UTIL_CRON_DIR/nightly -cron -examples -blog ${nightly_args}

--- a/util/cron/test-linux64-gcc112.bash
+++ b/util/cron/test-linux64-gcc112.bash
@@ -25,6 +25,8 @@ if [ "$gcc_version" != "11.2.0" ]; then
   exit 2
 fi
 
+export CHPL_LAUNCHER=none
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-gcc112"
 
 $UTIL_CRON_DIR/nightly -cron -examples -blog ${nightly_args}

--- a/util/cron/test-linux64-gcc74.bash
+++ b/util/cron/test-linux64-gcc74.bash
@@ -25,6 +25,8 @@ if [ "$gcc_version" != "7.4.0" ]; then
   exit 2
 fi
 
+export CHPL_LAUNCHER=none
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-gcc74"
 
 $UTIL_CRON_DIR/nightly -cron -examples -blog ${nightly_args}

--- a/util/cron/test-linux64-gcc91.bash
+++ b/util/cron/test-linux64-gcc91.bash
@@ -25,6 +25,8 @@ if [ "$gcc_version" != "9.1.0" ]; then
   exit 2
 fi
 
+export CHPL_LAUNCHER=none
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-gcc91"
 
 $UTIL_CRON_DIR/nightly -cron -examples -blog ${nightly_args}

--- a/util/cron/test-linux64-intrinsics-atomics.bash
+++ b/util/cron/test-linux64-intrinsics-atomics.bash
@@ -7,6 +7,8 @@ source $UTIL_CRON_DIR/common.bash
 
 export CHPL_ATOMICS=intrinsics
 
+export CHPL_LAUNCHER=none
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-intrinsics-atomics"
 
 export CHPL_NIGHTLY_TEST_DIRS="release/examples/ runtime/configMatters/ types/atomic/"

--- a/util/cron/test-linux64-llvm-bundled.bash
+++ b/util/cron/test-linux64-llvm-bundled.bash
@@ -9,6 +9,8 @@ export CHPL_LLVM=bundled
 # To avoid warning about this being ignored with bundled LLVM
 unset CHPL_LLVM_CONFIG
 
+export CHPL_LAUNCHER=none
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-llvm-bundled"
 
 $UTIL_CRON_DIR/nightly -cron -examples -blog ${nightly_args}

--- a/util/cron/test-linux64-llvm11.bash
+++ b/util/cron/test-linux64-llvm11.bash
@@ -14,6 +14,8 @@ if [ "$clang_version" != "11.0.1" ]; then
   exit 2
 fi
 
+export CHPL_LAUNCHER=none
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-llvm11"
 
 $UTIL_CRON_DIR/nightly -cron -examples -blog ${nightly_args}

--- a/util/cron/test-linux64-llvm12.bash
+++ b/util/cron/test-linux64-llvm12.bash
@@ -14,6 +14,8 @@ if [ "$clang_version" != "12.0.1" ]; then
   exit 2
 fi
 
+export CHPL_LAUNCHER=none
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-llvm12"
 
 $UTIL_CRON_DIR/nightly -cron -examples -blog ${nightly_args}

--- a/util/cron/test-linux64-llvm13.bash
+++ b/util/cron/test-linux64-llvm13.bash
@@ -14,6 +14,8 @@ if [ "$clang_version" != "13.0.0" ]; then
   exit 2
 fi
 
+export CHPL_LAUNCHER=none
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-llvm13"
 
 $UTIL_CRON_DIR/nightly -cron -examples -blog ${nightly_args}

--- a/util/cron/test-linux64-llvm14.bash
+++ b/util/cron/test-linux64-llvm14.bash
@@ -14,6 +14,8 @@ if [ "$clang_version" != "14.0.0" ]; then
   exit 2
 fi
 
+export CHPL_LAUNCHER=none
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-llvm14"
 
 $UTIL_CRON_DIR/nightly -cron -examples -blog ${nightly_args}

--- a/util/cron/test-linux64-llvm15.bash
+++ b/util/cron/test-linux64-llvm15.bash
@@ -24,6 +24,8 @@ fi
 #   exit 2
 # fi
 
+export CHPL_LAUNCHER=none
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-llvm15"
 
 $UTIL_CRON_DIR/nightly -cron -examples -blog ${nightly_args}

--- a/util/cron/test-linux64-llvm16.bash
+++ b/util/cron/test-linux64-llvm16.bash
@@ -15,6 +15,8 @@ if [ "$llvm_version" != "16.0.6" ]; then
   exit 2
 fi
 
+export CHPL_LAUNCHER=none
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-llvm16"
 
 $UTIL_CRON_DIR/nightly -cron -examples -blog ${nightly_args}

--- a/util/cron/test-linux64-llvm17.bash
+++ b/util/cron/test-linux64-llvm17.bash
@@ -15,6 +15,8 @@ if [ "$llvm_version" != "17.0.6" ]; then
   exit 2
 fi
 
+export CHPL_LAUNCHER=none
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-llvm17"
 
 $UTIL_CRON_DIR/nightly -cron -examples -blog ${nightly_args}

--- a/util/cron/test-linux64-llvm18.bash
+++ b/util/cron/test-linux64-llvm18.bash
@@ -15,6 +15,8 @@ if [ "$llvm_version" != "18.1.3" ]; then
   exit 2
 fi
 
+export CHPL_LAUNCHER=none
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-llvm18"
 
 $UTIL_CRON_DIR/nightly -cron -examples -blog ${nightly_args}

--- a/util/cron/test-linux64-llvm19.bash
+++ b/util/cron/test-linux64-llvm19.bash
@@ -16,6 +16,8 @@ if [ "$llvm_version" != "19.1.0" ]; then
   exit 2
 fi
 
+export CHPL_LAUNCHER=none
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-llvm19"
 
 $UTIL_CRON_DIR/nightly -cron -examples ${nightly_args}

--- a/util/cron/test-linux64-locks-atomics.bash
+++ b/util/cron/test-linux64-locks-atomics.bash
@@ -7,6 +7,8 @@ source $UTIL_CRON_DIR/common.bash
 
 export CHPL_ATOMICS=locks
 
+export CHPL_LAUNCHER=none
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-locks-atomics"
 
 export CHPL_NIGHTLY_TEST_DIRS="release/examples/ runtime/configMatters/ types/atomic/"

--- a/util/cron/test-linux64-python35.bash
+++ b/util/cron/test-linux64-python35.bash
@@ -6,6 +6,8 @@ UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common.bash
 source $UTIL_CRON_DIR/common-python.bash
 
+export CHPL_LAUNCHER=none
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-python35"
 
 set_python_version "3.5"

--- a/util/cron/test-linux64-python36.bash
+++ b/util/cron/test-linux64-python36.bash
@@ -6,6 +6,8 @@ UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common.bash
 source $UTIL_CRON_DIR/common-python.bash
 
+export CHPL_LAUNCHER=none
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-python36"
 
 set_python_version "3.6"

--- a/util/cron/test-linux64-python37.bash
+++ b/util/cron/test-linux64-python37.bash
@@ -6,6 +6,8 @@ UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common.bash
 source $UTIL_CRON_DIR/common-python.bash
 
+export CHPL_LAUNCHER=none
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-python37"
 
 set_python_version "3.7"

--- a/util/cron/test-linux64-python39.bash
+++ b/util/cron/test-linux64-python39.bash
@@ -6,6 +6,8 @@ UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common.bash
 source $UTIL_CRON_DIR/common-python.bash
 
+export CHPL_LAUNCHER=none
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-python39"
 
 set_python_version "3.9"

--- a/util/cron/test-memleaks.examples.bash
+++ b/util/cron/test-memleaks.examples.bash
@@ -6,6 +6,8 @@ UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common.bash
 source $UTIL_CRON_DIR/common-memleaks.bash
 
+export CHPL_LAUNCHER=none
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="memleaks.examples"
 
 $UTIL_CRON_DIR/nightly -cron -memleaks -examples

--- a/util/cron/test-networking-packages.bash
+++ b/util/cron/test-networking-packages.bash
@@ -25,6 +25,8 @@ $HADOOP_HOME/bin/hdfs dfs -chown -R $USER /
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="networking-packages"
 export CHPL_NIGHTLY_TEST_DIRS="library/packages/Curl library/packages/HDFS library/packages/URL"
 
+export CHPL_LAUNCHER=none
+
 $UTIL_CRON_DIR/nightly -cron ${nightly_args}
 
 # clean up test files

--- a/util/cron/test-no-local.incr.bash
+++ b/util/cron/test-no-local.incr.bash
@@ -12,4 +12,6 @@ export CHPL_SYSTEM_PREDIFF=$CHPL_HOME/util/test/prediff-for-incremental-warning
 # incremental compilation not currently supported with LLVM
 export CHPL_LLVM=none
 
+export CHPL_LAUNCHER=none
+
 $UTIL_CRON_DIR/nightly -cron -no-local -examples -compopts --incremental

--- a/util/cron/test-no-local.linux32.bash
+++ b/util/cron/test-no-local.linux32.bash
@@ -6,6 +6,8 @@
 UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common.bash
 
+export CHPL_LAUNCHER=none
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="no-local.linux32"
 
 $UTIL_CRON_DIR/nightly -cron -examples -no-local

--- a/util/cron/test-perf.chapcs.bash
+++ b/util/cron/test-perf.chapcs.bash
@@ -8,6 +8,8 @@ export CHPL_TEST_PERF_CONFIG_NAME='chapcs'
 
 source $UTIL_CRON_DIR/common-perf.bash
 
+export CHPL_LAUNCHER=none
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs"
 
 $UTIL_CRON_DIR/nightly -cron -performance -releasePerformance -numtrials 5 -startdate 09/10/15

--- a/util/cron/test-perf.chapcs.c-backend.bash
+++ b/util/cron/test-perf.chapcs.c-backend.bash
@@ -11,6 +11,8 @@ source $UTIL_CRON_DIR/common-c-backend.bash
 # common-llvm restricts us to extern/fergeson, we want all the perf tests
 unset CHPL_NIGHTLY_TEST_DIRS
 
+export CHPL_LAUNCHER=none
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.c-backend"
 
 perf_args="-performance-description c-backend -performance-configs default:v,c-backend:v -sync-dir-suffix c-backend"

--- a/util/cron/test-perf.chapcs.clang.bash
+++ b/util/cron/test-perf.chapcs.clang.bash
@@ -15,6 +15,8 @@ unset CXX
 export CHPL_HOST_COMPILER=clang
 export CHPL_TARGET_COMPILER=clang
 
+export CHPL_LAUNCHER=none
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.clang"
 
 SHORT_NAME=clang

--- a/util/cron/test-perf.chapcs.no-local.bash
+++ b/util/cron/test-perf.chapcs.no-local.bash
@@ -7,6 +7,8 @@ export CHPL_TEST_PERF_CONFIG_NAME='chapcs'
 
 source $UTIL_CRON_DIR/common-perf.bash
 
+export CHPL_LAUNCHER=none
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.no-local"
 
 perf_args="-performance-description no-local -performance-configs default:v,no-local:v -sync-dir-suffix no-local"

--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -15,6 +15,8 @@ export CHPL_TEST_PERF_CONFIG_NAME='chapcs'
 
 source $UTIL_CRON_DIR/common-perf.bash
 
+export CHPL_LAUNCHER=none
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground"
 
 #

--- a/util/cron/test-perf.chapel-shootout-llvm.bash
+++ b/util/cron/test-perf.chapel-shootout-llvm.bash
@@ -10,6 +10,8 @@ export CHPL_TEST_PERF_CONFIG_NAME="shootout"
 source $UTIL_CRON_DIR/common-perf.bash
 source $UTIL_CRON_DIR/common-llvm.bash
 
+export CHPL_LAUNCHER=none
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapel-shootout-llvm"
 
 export CHPL_NIGHTLY_TEST_DIRS="release/examples/benchmarks/shootout studies/shootout performance/elliot"

--- a/util/cron/test-perf.chapel-shootout.bash
+++ b/util/cron/test-perf.chapel-shootout.bash
@@ -9,6 +9,8 @@ export CHPL_TEST_PERF_CONFIG_NAME="shootout"
 
 source $UTIL_CRON_DIR/common-perf.bash
 
+export CHPL_LAUNCHER=none
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapel-shootout"
 
 export CHPL_NIGHTLY_TEST_DIRS="release/examples/benchmarks/shootout studies/shootout performance/elliot"

--- a/util/cron/test-valgrind.bash
+++ b/util/cron/test-valgrind.bash
@@ -10,6 +10,8 @@ source $UTIL_CRON_DIR/common-localnode-paratest.bash
 # valgrind serializes execution, so don't limit to one executable at a time
 unset CHPL_TEST_LIMIT_RUNNING_EXECUTABLES
 
+export CHPL_LAUNCHER=none
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="valgrind"
 
 $UTIL_CRON_DIR/nightly -cron -valgrind -examples ${nightly_args} $(get_nightly_paratest_args 8)

--- a/util/cron/test-valgrindexe.bash
+++ b/util/cron/test-valgrindexe.bash
@@ -10,6 +10,8 @@ source $UTIL_CRON_DIR/common-localnode-paratest.bash
 # valgrind serializes execution, so don't limit to one executable at a time
 unset CHPL_TEST_LIMIT_RUNNING_EXECUTABLES
 
+export CHPL_LAUNCHER=none
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="valgrindexe"
 
 $UTIL_CRON_DIR/nightly -cron -valgrindexe ${nightly_args} $(get_nightly_paratest_args 8)


### PR DESCRIPTION
Changes the default for `CHPL_LAUNCHER` to default to a slurm-based launcher regardless of platform.

Testing:
- [x] check that a slurm system defaults properly
- [x] ensure internal testing machines will not be broken by this change

Resolves https://github.com/chapel-lang/chapel/issues/26170

[Reviewed by @jhh67]