### PR TITLE
Fix dyno 'already deinited' for record `in` arg

### DIFF
--- a/frontend/lib/resolution/VarScopeVisitor.h
+++ b/frontend/lib/resolution/VarScopeVisitor.h
@@ -321,7 +321,8 @@ struct VarFrame {
   std::vector<ID> initedOuterVars;
 
   // Which variables have been deinitialized early in this scope?
-  std::set<ID> deinitedVars;
+  // Map of (decl ID) -> (last use before deinit ID)
+  std::unordered_map<ID, ID> deinitedVars;
 
   VarFrame(const AstNode* scopeAst) : scopeAst(scopeAst) { }
 

--- a/frontend/lib/resolution/VarScopeVisitor.h
+++ b/frontend/lib/resolution/VarScopeVisitor.h
@@ -321,8 +321,8 @@ struct VarFrame {
   std::vector<ID> initedOuterVars;
 
   // Which variables have been deinitialized early in this scope?
-  // Map of (decl ID) -> (last use before deinit ID)
-  std::unordered_map<ID, ID> deinitedVars;
+  // Map of (decl ID) -> (use IDs in last stmt before deinit)
+  std::unordered_map<ID, std::unordered_set<ID>> deinitedVars;
 
   VarFrame(const AstNode* scopeAst) : scopeAst(scopeAst) { }
 

--- a/frontend/lib/resolution/VarScopeVisitor.h
+++ b/frontend/lib/resolution/VarScopeVisitor.h
@@ -305,7 +305,7 @@ struct VarFrame {
   // for copy elision:
   // Is the last mention of the variable a copy?
   // What are the copy points?
-  std::map<ID,CopyElisionState> copyElisionState;
+  std::unordered_map<ID,CopyElisionState> copyElisionState;
 
   // for call init deinit:
   // localsAndDefers contains both VarSymbol and DeferStmt in

--- a/frontend/lib/resolution/VarScopeVisitor.h
+++ b/frontend/lib/resolution/VarScopeVisitor.h
@@ -321,7 +321,7 @@ struct VarFrame {
   std::vector<ID> initedOuterVars;
 
   // Which variables have been deinitialized early in this scope?
-  // Map of (decl ID) -> (last use before deinit ID)
+  // Map of (ID of decl) -> (ID of stmt after which it is deinited)
   std::unordered_map<ID, ID> deinitedVars;
 
   VarFrame(const AstNode* scopeAst) : scopeAst(scopeAst) { }

--- a/frontend/lib/resolution/VarScopeVisitor.h
+++ b/frontend/lib/resolution/VarScopeVisitor.h
@@ -321,8 +321,8 @@ struct VarFrame {
   std::vector<ID> initedOuterVars;
 
   // Which variables have been deinitialized early in this scope?
-  // Map of (decl ID) -> (use IDs in last stmt before deinit)
-  std::unordered_map<ID, std::unordered_set<ID>> deinitedVars;
+  // Map of (decl ID) -> (last use before deinit ID)
+  std::unordered_map<ID, ID> deinitedVars;
 
   VarFrame(const AstNode* scopeAst) : scopeAst(scopeAst) { }
 

--- a/frontend/lib/resolution/VarScopeVisitor.h
+++ b/frontend/lib/resolution/VarScopeVisitor.h
@@ -321,7 +321,7 @@ struct VarFrame {
   std::vector<ID> initedOuterVars;
 
   // Which variables have been deinitialized early in this scope?
-  // Map of (ID of decl) -> (ID of stmt after which it is deinited)
+  // Map of (ID of decl) -> (ID of call after which it is deinited)
   std::unordered_map<ID, ID> deinitedVars;
 
   VarFrame(const AstNode* scopeAst) : scopeAst(scopeAst) { }

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -260,7 +260,7 @@ void CallInitDeinit::checkUseOfDeinited(const AstNode* useAst, ID varId) {
   for (ssize_t i = n - 1; i >= 0; i--) {
     VarFrame* frame = scopeStack[i].get();
     if (frame->deinitedVars.count(varId) > 0) {
-      // For vars dead at end of stmt, don't error for uses within stmt.
+      // For vars dead after a call, don't error for uses within that call.
       if (frame->deinitedVars[varId] ==
           parsing::idToParentId(context, useAst->id())) {
         continue;

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -260,8 +260,8 @@ void CallInitDeinit::checkUseOfDeinited(const AstNode* useAst, ID varId) {
   for (ssize_t i = n - 1; i >= 0; i--) {
     VarFrame* frame = scopeStack[i].get();
     if (frame->deinitedVars.count(varId) > 0) {
-      // skip error if this is a final use before deinit
-      if (frame->deinitedVars[varId].count(useAst->id()) > 0) continue;
+      // skip error if this is the final use before deinit
+      if (frame->deinitedVars[varId] == useAst->id()) continue;
 
       // TODO: fix this error
       context->error(useAst, "use of dead / already deinited variable");
@@ -286,7 +286,7 @@ void CallInitDeinit::processDeinitsForReturn(const AstNode* atAst,
                                              ID skipVarId,
                                              RV& rv) {
   std::set<ID> initedAnyFrame;
-  std::unordered_map<ID, std::unordered_set<ID>> deinitedAnyFrame;
+  std::unordered_map<ID, ID> deinitedAnyFrame;
 
   ssize_t n = scopeStack.size();
 
@@ -304,7 +304,7 @@ void CallInitDeinit::processDeinitsForReturn(const AstNode* atAst,
 
   // also count outOrInoutFormals as already deinited
   for (const auto& id : outOrInoutFormals) {
-    deinitedAnyFrame.insert({id, {}});
+    deinitedAnyFrame.emplace(id, ID());
   }
 
   for (ssize_t i = n - 1; i >= 0; i--) {
@@ -325,7 +325,7 @@ void CallInitDeinit::processDeinitsForReturn(const AstNode* atAst,
           resolveDeinit(atAst, varOrDeferId, type, rv);
         }
 
-        deinitedAnyFrame.insert({varOrDeferId, {}});
+        deinitedAnyFrame.emplace(varOrDeferId, ID());
       }
     }
   }
@@ -357,9 +357,9 @@ void CallInitDeinit::processDeinitsAndPropagate(VarFrame* frame,
         recordInitializationOrder(parent, id);
       }
     }
-    for (const auto& [declId, lastUseIds] : frame->deinitedVars) {
+    for (const auto& [declId, lastUseId] : frame->deinitedVars) {
       if (frame->declaredVars.count(declId) == 0) {
-        parent->deinitedVars.emplace(declId, lastUseIds);
+        parent->deinitedVars.emplace(declId, lastUseId);
       }
     }
   }
@@ -712,7 +712,7 @@ void CallInitDeinit::processInit(VarFrame* frame,
       ID rhsDeclId = refersToId(rhsAst, rv);
       // copy elision with '=' should only apply to myVar = myOtherVar
       CHPL_ASSERT(!rhsDeclId.isEmpty());
-      frame->deinitedVars.insert({rhsDeclId, {rhsAst->id()}});
+      frame->deinitedVars.emplace(rhsDeclId, rhsAst->id());
     } else if (isCallProducingValue(rhsAst, rhsType, rv)) {
       // e.g. var x; x = callReturningValue();
       resolveMoveInit(ast, rhsAst, lhsType, rhsType, rv);
@@ -974,7 +974,7 @@ void CallInitDeinit::handleInFormal(const FnCall* ast, const AstNode* actual,
     ID actualId = refersToId(actual, rv);
     // copy elision should only apply to copies from variables
     CHPL_ASSERT(!actualId.isEmpty());
-    frame->deinitedVars[actualId].emplace(actual->id());
+    frame->deinitedVars.emplace(actualId, actual->id());
   } else {
     processInit(frame, actual, formalType, actualType, rv);
   }
@@ -1020,7 +1020,7 @@ void CallInitDeinit::processReturnThrowYield(const uast::AstNode* ast, RV& rv) {
     if (copyElidesFromSkip) {
       // if it's a yield, we need to also mark the rhs ID variable dead
       VarFrame* frame = currentFrame();
-      frame->deinitedVars.insert({skipDeinitId, {}});
+      frame->deinitedVars.emplace(skipDeinitId, ID());
 
     } else if (needsCopyOrConv) {
       QualifiedType fnRetType = returnOrYieldType();

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -260,6 +260,9 @@ void CallInitDeinit::checkUseOfDeinited(const AstNode* useAst, ID varId) {
   for (ssize_t i = n - 1; i >= 0; i--) {
     VarFrame* frame = scopeStack[i].get();
     if (frame->deinitedVars.count(varId) > 0) {
+      // skip error if this is the final use before deinit
+      if (frame->deinitedVars[varId] == useAst->id()) continue;
+
       // TODO: fix this error
       context->error(useAst, "use of dead / already deinited variable");
       break;

--- a/frontend/lib/resolution/copy-elision.cpp
+++ b/frontend/lib/resolution/copy-elision.cpp
@@ -510,7 +510,7 @@ void FindElidedCopies::handleTry(const Try* t, RV& rv) {
 
   // don't copy elide if any catch clauses mention the variable
   // don't copy elide if any catch clause doesn't throw/return
-  std::map<ID,CopyElisionState> updatedState;
+  std::unordered_map<ID,CopyElisionState> updatedState;
   std::set<ID> catchMentions;
   bool allThrowOrReturn = true;
 

--- a/frontend/test/resolution/testCallInitDeinit.cpp
+++ b/frontend/test/resolution/testCallInitDeinit.cpp
@@ -1787,6 +1787,40 @@ static void test23c() {
       });
 }
 
+static void test23d() {
+  // Ensure the copy-elided in formal doesn't error when used in nested function
+  // calls.
+  testActions("test23d",
+      R"""(
+      module M {
+        record Foo {}
+
+        proc returnConstRef(const ref x) {
+          return x;
+        }
+
+        proc returnIn(in x) {
+          return x;
+        }
+
+        proc doSomething(in x) {
+          return doSomethingElse(returnConstRef(returnIn(x)));
+        }
+
+        proc doSomethingElse(in x) {
+          return 1;
+        }
+
+        proc test() {
+          var f : Foo;
+          var x = doSomething(f);
+        }
+      }
+      )""", {
+        {AssociatedAction::DEFAULT_INIT, "f",          ""}
+      });
+}
+
 // calling function with 'out' intent formal
 
 // calling functions with 'inout' intent formal
@@ -1881,6 +1915,7 @@ int main() {
   test23a();
   test23b();
   test23c();
+  test23d();
 
   return 0;
 }

--- a/frontend/test/resolution/testCallInitDeinit.cpp
+++ b/frontend/test/resolution/testCallInitDeinit.cpp
@@ -1707,6 +1707,30 @@ static void test22() {
       });
 }
 
+static void test23() {
+  testActions("test23",
+      R"""(
+      module M {
+        record Foo {}
+
+        proc doSomething(in x) {
+          return doSomethingElse(x);
+        }
+
+        proc doSomethingElse(in x) {
+          return 1;
+        }
+
+        proc test() {
+          var f : Foo;
+          var x = doSomething(f);
+        }
+      }
+      )""", {
+        {AssociatedAction::DEFAULT_INIT, "f",          ""}
+      });
+}
+
 // calling function with 'out' intent formal
 
 // calling functions with 'inout' intent formal
@@ -1797,6 +1821,8 @@ int main() {
   test21();
 
   test22();
+
+  test23();
 
   return 0;
 }

--- a/frontend/test/resolution/testCallInitDeinit.cpp
+++ b/frontend/test/resolution/testCallInitDeinit.cpp
@@ -1758,6 +1758,35 @@ static void test23b() {
       });
 }
 
+static void test23c() {
+  // Ensure the copy-elided in formal doesn't error for uses across multiple
+  // calls in the same statement.
+  testActions("test23c",
+      R"""(
+      module M {
+        // necessary to resolve + operator
+        operator +(a: int, b: int) do return __primitive("+", a, b);
+
+        record Foo {}
+
+        proc doSomething(in x) {
+          return doSomethingElse(x) + doSomethingElse(x);
+        }
+
+        proc doSomethingElse(in x) {
+          return 1;
+        }
+
+        proc test() {
+          var f : Foo;
+          var x = doSomething(f);
+        }
+      }
+      )""", {
+        {AssociatedAction::DEFAULT_INIT, "f",          ""}
+      });
+}
+
 // calling function with 'out' intent formal
 
 // calling functions with 'inout' intent formal
@@ -1851,6 +1880,7 @@ int main() {
 
   test23a();
   test23b();
+  test23c();
 
   return 0;
 }

--- a/frontend/test/resolution/testCallInitDeinit.cpp
+++ b/frontend/test/resolution/testCallInitDeinit.cpp
@@ -1708,6 +1708,7 @@ static void test22() {
 }
 
 static void test23a() {
+  // Ensure the copy-elided in formal doesn't error for its final use.
   testActions("test23a",
       R"""(
       module M {
@@ -1732,6 +1733,8 @@ static void test23a() {
 }
 
 static void test23b() {
+  // Ensure the copy-elided in formal doesn't error for multiple uses in the
+  // same call.
   testActions("test23b",
       R"""(
       module M {

--- a/frontend/test/resolution/testCallInitDeinit.cpp
+++ b/frontend/test/resolution/testCallInitDeinit.cpp
@@ -1707,8 +1707,8 @@ static void test22() {
       });
 }
 
-static void test23() {
-  testActions("test23",
+static void test23a() {
+  testActions("test23a",
       R"""(
       module M {
         record Foo {}
@@ -1718,6 +1718,30 @@ static void test23() {
         }
 
         proc doSomethingElse(in x) {
+          return 1;
+        }
+
+        proc test() {
+          var f : Foo;
+          var x = doSomething(f);
+        }
+      }
+      )""", {
+        {AssociatedAction::DEFAULT_INIT, "f",          ""}
+      });
+}
+
+static void test23b() {
+  testActions("test23b",
+      R"""(
+      module M {
+        record Foo {}
+
+        proc doSomething(in x) {
+          return doSomethingElse(x, x);
+        }
+
+        proc doSomethingElse(in x, in y) {
           return 1;
         }
 
@@ -1822,7 +1846,8 @@ int main() {
 
   test22();
 
-  test23();
+  test23a();
+  test23b();
 
   return 0;
 }


### PR DESCRIPTION
Fix a Dyno bug in which an 'already deinited' error would be emitted for an `in` intent record formal passed in turn as an `in` intent argument.

This applied to records because we care about deiniting them, and to `in` intent because it causes a copy or move. `call-init-deinit` detected copy-elision of the `in` formal while moving down the AST and declared it dead (at end of statement), but then emit an error for that same use while moving up the AST and checking for uses of dead variables. Fixed by keeping track of the statement after which a variable is dead, and not emitting errors for use of it within that statement.

A similar case also handled in this PR is the same `in` formal being passed as an argument to the same call multiple times, where just the last usage is copy-elided.

Resolves https://github.com/Cray/chapel-private/issues/6860.

[reviewer info placeholder]

Testing:
- [x] dyno tests
- [x] paratest
- [x] reproducer from backing issue passes