### PR TITLE
Update .bad files for #26231

### DIFF
--- a/test/extern/ferguson/mismatch-errors/mismatch-ri-iv.bad
+++ b/test/extern/ferguson/mismatch-errors/mismatch-ri-iv.bad
@@ -1,8 +1,9 @@
 Incorrect number of arguments passed to called function!
   %n = call i32 @returnIntFromIntArg() #0
-internal error: COD-CG--BOL-nnnn chpl version mmmm
+mismatch-ri-iv.chpl:6: internal error: COD-CG--BOL-nnnn chpl version mmmm
 
 Internal errors indicate a bug in the Chapel compiler,
 and we're sorry for the hassle.  We would appreciate your reporting this bug --
-please see https://chapel-lang.org/bugs.html for instructions.
+please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
 

--- a/test/extern/ferguson/mismatch-errors/mismatch-riv-iv.bad
+++ b/test/extern/ferguson/mismatch-errors/mismatch-riv-iv.bad
@@ -1,8 +1,9 @@
 Incorrect number of arguments passed to called function!
-  %2 = call i32 @returnIntFromIntArg() #0
-internal error: COD-CG--BOL-nnnn chpl version mmmm
+  %n = call i32 @returnIntFromIntArg() #0
+mismatch-riv-iv.chpl:6: internal error: COD-CG--BOL-nnnn chpl version mmmm
 
 Internal errors indicate a bug in the Chapel compiler,
 and we're sorry for the hassle.  We would appreciate your reporting this bug --
-please see https://chapel-lang.org/bugs.html for instructions.
+please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
 

--- a/test/extern/ferguson/mismatch-errors/mismatch-riv-iv.prediff
+++ b/test/extern/ferguson/mismatch-errors/mismatch-riv-iv.prediff
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Ignore LLVM IR line number, as it is LLVM version-dependent
+
+TESTNAME=$1
+OUTFILE=$2
+
+TMPFILE="$outfile.prediff.tmp"
+mv $OUTFILE $TMPFILE
+sed -e 's/%[0-9]/%n/g' $TMPFILE > $OUTFILE
+rm $TMPFILE


### PR DESCRIPTION
This PR updates two .bad files with the source code location, which is now printed out upon an internal error due to #26231.

While there, duplicate the `.prediff` from one test to the other because it is equally applicable to both.

Test fix, not reviewed.