### PR TITLE
Suppress a python failure due to a system build issue that is not our fault

### DIFF
--- a/test/interop/python/pythonFriendliness/checkNotUsed.suppressif
+++ b/test/interop/python/pythonFriendliness/checkNotUsed.suppressif
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 
-import subprocess, os
+import subprocess, os, sys
 
 NotOK = False
 
 try:
   # If the `help("modules")` command doesn't work on its own, we're not going
   # to get useful information out of this test, so suppress the failure
-  subproc = subprocess.run('help("modules")', check=True)
+  subproc = subprocess.run((sys.executable, '-c', 'help("modules")'),
+                           check=True)
   if (subproc.returncode != 0):
      NotOK = True
 except:

--- a/test/interop/python/pythonFriendliness/checkNotUsed.suppressif
+++ b/test/interop/python/pythonFriendliness/checkNotUsed.suppressif
@@ -1,16 +1,16 @@
 #!/usr/bin/env python3
 
-import subprocess
+import subprocess, os
 
-OK = True
+NotOK = False
 
 try:
   # If the `help("modules")` command doesn't work on its own, we're not going
   # to get useful information out of this test, so suppress the failure
   subproc = subprocess.run('help("modules")', check=True)
   if (subproc.returncode != 0):
-     OK = False
+     NotOK = True
 except:
-  OK = False
+  NotOK = True
 
-print(OK)
+print(NotOK and os.getenv("CHPL_TARGET_COMPILER") == "cray-prgenv-gnu")

--- a/test/interop/python/pythonFriendliness/checkNotUsed.suppressif
+++ b/test/interop/python/pythonFriendliness/checkNotUsed.suppressif
@@ -1,14 +1,13 @@
 #!/usr/bin/env python3
 
-import subprocess, os, sys
+import subprocess, os
 
 NotOK = False
 
 try:
   # If the `help("modules")` command doesn't work on its own, we're not going
   # to get useful information out of this test, so suppress the failure
-  subproc = subprocess.run((sys.executable, '-c', 'help("modules")'),
-                           check=True)
+  subproc = subprocess.run('python3 -c help("modules")', check=True)
   if (subproc.returncode != 0):
      NotOK = True
 except:

--- a/test/interop/python/pythonFriendliness/checkNotUsed.suppressif
+++ b/test/interop/python/pythonFriendliness/checkNotUsed.suppressif
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+import subprocess
+
+OK = True
+
+try:
+  # If the `help("modules")` command doesn't work on its own, we're not going
+  # to get useful information out of this test, so suppress the failure
+  subproc = subprocess.run('help("modules")', check=True)
+  if (subproc.returncode != 0):
+     OK = False
+except:
+  OK = False
+
+print(OK)


### PR DESCRIPTION
One of the machines we run on has a problem with the `help("modules")` command that we are testing we didn't break.  This problem is independent of Chapel so should be suppressed until it is fixed (which will be outside of our control)

Verified that the suppressif triggers appropriately on the machine with the issue and doesn't trigger in normal testing.
I'm not entirely convinced it'll give us a "passing suppressif" message, though, but I'm not sure how to do that without also sweeping potential future issues under the rug if the failure mode changes