### PR TITLE
Prevnt SyntaxWarning with newer Python versions in `chpl_launchcmd.py`

### DIFF
--- a/util/test/chpl_launchcmd.py
+++ b/util/test/chpl_launchcmd.py
@@ -887,7 +887,7 @@ class PbsProJob(AbstractJob):
 
         # Use regex to find position of status. Then extract the one character
         # status from the job line.
-        pattern = re.compile('\sS\s')
+        pattern = re.compile(r'\sS\s')
         match = pattern.search(header_line)
         if match is not None:
             status_char = match.start() + 1


### PR DESCRIPTION
Newer Python versions warn for badly escaped strings, fixed by using a raw string

[Reviewed by @]