### PR TITLE
Remove test-specific overload of atomic max

### DIFF
--- a/test/studies/uts/uts_deq.chpl
+++ b/test/studies/uts/uts_deq.chpl
@@ -163,18 +163,6 @@ class TreeNode {
 }
 
 
-/* Compute atomically:  this = max(this, other) */
-proc ref AtomicT.max(other: int) {
-  var curMax = this.read();
-  while curMax < other && !this.compareExchangeWeak(curMax, other) { }
-}
-
-proc RAtomicT.max(other: int) {
-  var curMax = this.read();
-  while curMax < other && !this.compareExchangeWeak(curMax, other) { }
-}
-
-
 /*
 ** Print out search parameters
 */


### PR DESCRIPTION
With #25900 merged, `test/studies/uts/uts_deq.chpl` started failing because it implemented its own `atomic max` routine locally.  Here, I'm removing that overload to try and avoid failures in tonight's testing.