### PR TITLE
Fix syntax warning for invalid escape sequence in slurm prediff

### DIFF
--- a/util/test/prediff-for-slurm
+++ b/util/test/prediff-for-slurm
@@ -17,9 +17,9 @@ msgs = (
 """,
 """srun: Job step aborted: Waiting up to [0-9]+ seconds for job step .*
 """,
-"""slurmstepd: error: \*\*\* STEP [0-9.]+ ON .+ CANCELLED AT [-0-9T.:]+ \*\*\*
+r"""slurmstepd: error: \*\*\* STEP [0-9.]+ ON .+ CANCELLED AT [-0-9T.:]+ \*\*\*
 """,
-"""slurmstepd: error: .+ \[[0-9]+] .*
+r"""slurmstepd: error: .+ \[[0-9]+] .*
 """,
 """srun: error: spank: /opt/cray/.*: Plugin file not found
 """,
@@ -29,7 +29,7 @@ msgs = (
 """,
 """diff: .*/[.]module/PrgEnv-.*: No such file or directory
 """,
-"""\*\*\* WARNING \(proc 0\): Running with multiple processes per host without shared-memory communication support \(PSHM\).  This can significantly reduce performance.  Please re-configure GASNet using `--enable-pshm` to enable fast intra-host comms.
+r"""\*\*\* WARNING \(proc 0\): Running with multiple processes per host without shared-memory communication support \(PSHM\).  This can significantly reduce performance.  Please re-configure GASNet using `--enable-pshm` to enable fast intra-host comms.
 """,
 )
 


### PR DESCRIPTION
Fixes a syntax warning in `util/test/prediff-for-slurm` where bad escape sequences where used. The solution is to use a raw string.

Caused by newer python versions doing extra checks

[Reviewed by @riftEmber]