### PR TITLE
Update GPU technote to reflect current dependecies

### DIFF
--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -152,7 +152,7 @@ The following are further requirements for GPU support:
 
   * CUDA toolkit version 11.x or 12.x must be installed.
 
-  * We test with system LLVM 18. Older versions may work.
+  * We test with system LLVM 19. Older versions may work.
 
     * Note that LLVM versions older than 16 do not support CUDA 12.
 
@@ -663,7 +663,7 @@ marked with * are covered in our nightly testing configurations.
 
   * Hardware: RTX A2000, P100*, V100*, A100*, H100, GH200
 
-  * Software: CUDA 11.3*, 11.6, 11.8*, 12.0, 12.2*, 12.4
+  * Software: CUDA 11.3, 11.6, 11.8*, 12.0, 12.2, 12.4*
 
 * AMD
 

--- a/test/gpu/native/llvmMoved.chpl
+++ b/test/gpu/native/llvmMoved.chpl
@@ -48,7 +48,7 @@
 
 // After addressing the checklist items (or creating a GH issue to do so)
 // modify the following const so that this test no longer fails.
-const EXPECTED_LLVM_VERSION = 18;
+const EXPECTED_LLVM_VERSION = 19;
 
 //-----------------------------------------------------------------------------
 


### PR DESCRIPTION
Updates the GPU technote to state that we currently test LLVM 19 and which cuda versions we actually test

Also updates `llvmMoved.chpl`

[Reviewed by @DanilaFe]