### PR TITLE
dyno: fix zippering resolution in bracket loops

### DIFF
--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -2051,12 +2051,6 @@ struct TheseResolutionResult {
        to resolve. In this case, the zipperedFailure_ and zipperedFailureIndex_
        fields are set. */
     THESE_FAIL_ZIPPERED_ARG_FAILED,
-    /* We started resolving a zippered-like iterator using (e.g.), a leader
-       iterator. In some cases, this means we "commit" to the leader/follower
-       path, so we didn't attempt to use a serial iterator.
-
-       TODO: this doesn't match production. */
-    THESE_FAIL_FOUND_DIFFERENT_ITERATOR,
     /* Mismatch between the claimed promotion type and the type yielded by the
        iterator. */
     THESE_FAIL_PROMOTION_TYPE_YIELD_MISMATCH,

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -5029,7 +5029,7 @@ resolveIterDetailsInPriorityOrder(Resolver& rv,
 
   if (mask & IterDetails::SERIAL) {
     if (resolveIterDetailsForZipperedArgs(rv, ret, ics, Function::SERIAL,
-                                          ret.leaderYieldType, storeFailures)) {
+                                          QualifiedType(), storeFailures)) {
       ret.succeededAt = IterDetails::SERIAL;
       return ret;
     }

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -64,7 +64,6 @@ namespace {
       NONE            = 0b0000,
       STANDALONE      = 0b0001,
       LEADER_FOLLOWER = 0b0010,
-      FOLLOWER        = 0b0100,
       SERIAL          = 0b1000,
     };
 
@@ -90,6 +89,18 @@ namespace {
 
     // This will be set to the yield type of the first iterator to succeed.
     QualifiedType idxType;
+
+    Pieces& piecesForIterKind(const Function::IteratorKind kind) {
+      switch (kind) {
+        case Function::STANDALONE: return standalone;
+        case Function::LEADER: return leader;
+        case Function::FOLLOWER: return follower;
+        case Function::SERIAL: return serial;
+        default:
+          CHPL_ASSERT(false && "shouldn't happen");
+          return serial;
+      }
+    }
   };
 }
 
@@ -106,12 +117,11 @@ resolveIterTypeWithTag(Resolver& rv,
 // Resolve iterators according to the policy set in 'mask' (see the type
 // 'IterDetails::Policy'). Resolution stops the moment an iterator is
 // found with a usable yield type.
-static IterDetails resolveIterDetails(Resolver& rv,
-                                      const AstNode* astForErr,
-                                      const AstNode* iterand,
-                                      const QualifiedType& leaderYieldType,
-                                      int mask,
-                                      bool emitError);
+static IterDetails resolveNonZipExpression(Resolver& rv,
+                                           const AstNode* astForErr,
+                                           const AstNode* iterand,
+                                           const QualifiedType& leaderYieldType,
+                                           int mask);
 
 Resolver::~Resolver() {
   if (didPushFrame) {
@@ -4877,19 +4887,123 @@ void Resolver::exit(const New* node) {
   }
 }
 
+struct IterandComponent {
+ public:
+  QualifiedType iterandQt;
+  const AstNode* astForErr;
+  const AstNode* iterand;
+
+  const IteratorType* iteratingOver;
+
+  IterandComponent(Resolver& rv,
+                   const AstNode* astForErr,
+                   const AstNode* iterand)
+    : astForErr(astForErr), iterand(iterand) {
+    auto& iterandRe = rv.byPostorder.byAst(iterand);
+    this->iterandQt = iterandRe.type();
+    if (!this->iterandQt.isUnknownOrErroneous()) {
+      this->iteratingOver = this->iterandQt.type()->toIteratorType();
+    } else {
+      // The thing-to-be-iterated is not an iterator, but it might be iterable
+      // using its 'these()' method. Don't resolve it now, since we haven't
+      // decided on which overloads we need; resolveIterTypeWithTag will do that
+      // on finding that toIterate is null.
+
+      this->iteratingOver = nullptr;
+    }
+  }
+};
+
+using IteratorFailures = std::vector<std::tuple<Function::IteratorKind, TheseResolutionResult>>;
+
+// If index is nonzero, notes the given failure are a cause for a zippered
+// failure. Otherwise, notes it as a top-level failure.
+static void
+noteTheseResolutionFailure(Resolver& rv,
+                           IteratorFailures& failures,
+                           Function::IteratorKind kind,
+                           int index,
+                           const QualifiedType& receiver,
+                           TheseResolutionResult&& result) {
+  if (rv.scopeResolveOnly) {
+    return;
+  }
+
+  if (index != -1) {
+    auto ownedResult = std::make_unique<TheseResolutionResult>(std::move(result));
+    auto zipperedTheseResult =
+      TheseResolutionResult::failure(std::move(ownedResult), index, receiver);
+    failures.push_back({ kind, std::move(zipperedTheseResult) });
+  } else {
+    failures.push_back({ kind, std::move(result) });
+  }
+}
+
+static bool
+resolveIterDetailsForZipperedArgs(Resolver& rv,
+                                  IterDetails& outIterDetails,
+                                  const std::vector<IterandComponent>& ics,
+                                  Function::IteratorKind iterKind,
+                                  const QualifiedType& leaderYieldType,
+                                  IteratorFailures* storeFailures) {
+  bool succeededAll = true;
+  std::vector<QualifiedType> idxTypes;
+  auto kind = QualifiedType::CONST_VAR;
+  int index = 0;
+  for (auto& ic : ics) {
+    auto& pieces = outIterDetails.piecesForIterKind(iterKind);
+    auto idxType = resolveIterTypeWithTag(rv, pieces,
+                                          ic.iteratingOver, ic.astForErr,
+                                          ic.iterand, iterKind,
+                                          leaderYieldType);
+    if (idxType.isUnknownOrErroneous()) {
+      // Note the first failed resolution
+      if (succeededAll && storeFailures) {
+        noteTheseResolutionFailure(rv, *storeFailures, iterKind, index,
+                                   ic.iterandQt,
+                                   std::move(pieces.resolutionResult));
+      }
+      succeededAll = false;
+    } else if (!idxType.isConst()) {
+      kind = QualifiedType::VAR;
+    }
+
+    idxTypes.push_back(std::move(idxType));
+    index++;
+  }
+
+  if (succeededAll) {
+    CHPL_ASSERT(idxTypes.size() == ics.size());
+    if (ics.size() > 1) {
+      auto tupleType =
+        TupleType::getQualifiedTuple(rv.context, std::move(idxTypes));
+      outIterDetails.idxType = QualifiedType(kind, tupleType);
+    } else {
+      outIterDetails.idxType = idxTypes[0];
+    }
+  }
+
+  return succeededAll;
+}
+
 // This helper resolves by priority order as described in 'IterDetails'.
 static IterDetails
 resolveIterDetailsInPriorityOrder(Resolver& rv,
-                                  const IteratorType* iteratingOver,
-                                  const AstNode* astForErr,
-                                  const AstNode* iterand,
-                                  const QualifiedType& leaderYieldType,
-                                  int mask) {
+                                  const std::vector<IterandComponent>& ics,
+                                  int mask,
+                                  IteratorFailures* storeFailures = nullptr) {
+  CHPL_ASSERT(ics.size() > 0);
+
   IterDetails ret;
-  bool computedLeaderYieldType = false;
+
+  debuggerBreakHere();
+
   if (mask & IterDetails::STANDALONE) {
-    ret.idxType = resolveIterTypeWithTag(rv, ret.standalone, iteratingOver, astForErr,
-                                         iterand, Function::STANDALONE, {});
+    CHPL_ASSERT(ics.size() == 1);
+    auto& ic = ics[0];
+    ret.idxType = resolveIterTypeWithTag(rv, ret.standalone,
+                                         ic.iteratingOver, ic.astForErr,
+                                         ic.iterand, Function::STANDALONE, {});
     if (!ret.idxType.isUnknownOrErroneous()) {
       ret.succeededAt = IterDetails::STANDALONE;
       return ret;
@@ -4897,34 +5011,27 @@ resolveIterDetailsInPriorityOrder(Resolver& rv,
   }
 
   if (mask & IterDetails::LEADER_FOLLOWER) {
-    ret.leaderYieldType = resolveIterTypeWithTag(rv, ret.leader, iteratingOver, astForErr,
-                                                 iterand, Function::LEADER,
+    auto& ic = ics[0];
+    ret.leaderYieldType = resolveIterTypeWithTag(rv, ret.leader,
+                                                 ic.iteratingOver, ic.astForErr,
+                                                 ic.iterand, Function::LEADER,
                                                  {});
-    computedLeaderYieldType = true;
-  } else if (mask & IterDetails::FOLLOWER) {
-    ret.leaderYieldType = leaderYieldType;
   }
 
-  if (mask & IterDetails::LEADER_FOLLOWER ||
-      mask & IterDetails::FOLLOWER) {
-    if (!ret.leaderYieldType.isUnknownOrErroneous()) {
-      ret.idxType = resolveIterTypeWithTag(rv, ret.follower, iteratingOver, astForErr,
-                                           iterand, Function::FOLLOWER,
-                                           ret.leaderYieldType);
-      if (!ret.idxType.isUnknownOrErroneous()) {
-        ret.succeededAt = computedLeaderYieldType
-            ? IterDetails::LEADER_FOLLOWER
-            : IterDetails::FOLLOWER;
-        return ret;
-      }
+  if (mask & IterDetails::LEADER_FOLLOWER &&
+      !ret.leaderYieldType.isUnknownOrErroneous()) {
+    if (resolveIterDetailsForZipperedArgs(rv, ret, ics, Function::FOLLOWER,
+                                          ret.leaderYieldType, storeFailures)) {
+      ret.succeededAt = IterDetails::LEADER_FOLLOWER;
+      return ret;
     }
   }
 
   if (mask & IterDetails::SERIAL) {
-    ret.idxType = resolveIterTypeWithTag(rv, ret.serial, iteratingOver, astForErr,
-                                         iterand, Function::SERIAL, {});
-    if (!ret.idxType.isUnknownOrErroneous()) {
+    if (resolveIterDetailsForZipperedArgs(rv, ret, ics, Function::SERIAL,
+                                          ret.leaderYieldType, storeFailures)) {
       ret.succeededAt = IterDetails::SERIAL;
+      return ret;
     }
   }
 
@@ -4953,32 +5060,23 @@ issueErrorForFailedIterDetails(Context* context,
                          iterandType, std::move(failures));
 }
 
-static IterDetails resolveIterDetails(Resolver& rv,
-                                      const AstNode* astForErr,
-                                      const AstNode* iterand,
-                                      const QualifiedType& leaderYieldType,
-                                      int mask,
-                                      bool emitError) {
+static IterDetails resolveNonZipExpression(Resolver& rv,
+                                           const AstNode* astForErr,
+                                           const AstNode* iterand,
+                                           const QualifiedType& leaderYieldType,
+                                           int mask) {
   if (rv.scopeResolveOnly) {
     return {};
   }
 
   auto iterandRe = rv.byPostorder.byAst(iterand);
-  const IteratorType* iteratingOver = nullptr;
-  if (!iterandRe.type().isUnknownOrErroneous()) {
-    iteratingOver = iterandRe.type().type()->toIteratorType();
-  } else {
-    // The thing-to-be-iterated is not an iterator, but it might be iterable
-    // using its 'these()' method. Don't resolve it now, since we haven't
-    // decided on which overloads we need; resolveIterTypeWithTag will do that
-    // on finding that toIterate is null.
-  }
 
   // Resolve iterators, stopping immediately when we get a valid yield type.
-  auto ret = resolveIterDetailsInPriorityOrder(rv, iteratingOver,
-                                               astForErr, iterand,
-                                               leaderYieldType,
-                                               mask);
+  // We are outside of a zippering contex, so call with only a single IterandComponent.
+  std::vector<IterandComponent> ics = {
+    IterandComponent(rv, astForErr, iterand)
+  };
+  auto ret = resolveIterDetailsInPriorityOrder(rv, ics, mask);
 
   // Only issue a "not iterable" error if the iterand has a type. If it was
   // not typed then earlier resolution of the iterand will have spit out an
@@ -4986,11 +5084,7 @@ static IterDetails resolveIterDetails(Resolver& rv,
   if (ret.succeededAt == IterDetails::NONE && !iterandRe.type().isUnknownOrErroneous()) {
     auto& iterandRE = rv.byPostorder.byAst(iterand);
     if (!iterandRE.type().isUnknownOrErroneous()) {
-      if (emitError) {
-        ret.idxType = issueErrorForFailedIterDetails(rv.context, ret, astForErr, iterand, iterandRE.type());
-      } else {
-        ret.idxType = QualifiedType();
-      }
+      ret.idxType = issueErrorForFailedIterDetails(rv.context, ret, astForErr, iterand, iterandRE.type());
     }
   }
 
@@ -5170,52 +5264,21 @@ static bool resolveParamForLoop(Resolver& rv, const For* forLoop) {
   return false;
 }
 
-// If index is nonzero, notes the given failure are a cause for a zippered
-// failure. Otherwise, notes it as a top-level failure.
-static void noteTheseResolutionFailure(
-    Resolver& rv,
-    std::vector<std::tuple<Function::IteratorKind, TheseResolutionResult>>& failures,
-    Function::IteratorKind kind,
-    int index,
-    const QualifiedType& receiver,
-    TheseResolutionResult&& result) {
-  if (rv.scopeResolveOnly) {
-    return;
-  }
-
-  if (index != -1) {
-    auto ownedResult = std::make_unique<TheseResolutionResult>(std::move(result));
-    auto zipperedTheseResult =
-      TheseResolutionResult::failure(std::move(ownedResult), index, receiver);
-    failures.push_back({ kind, std::move(zipperedTheseResult) });
-  } else {
-    failures.push_back({ kind, std::move(result) });
-  }
-}
-
 static QualifiedType
 resolveZipExpression(Resolver& rv, const IndexableLoop* loop, const Zip* zip) {
+  // Failures to find various iteration strategies (serial, follower) go here.
+  IteratorFailures failures;
+
   Context* context = rv.context;
   bool loopRequiresParallel = loop->isForall();
   bool loopPrefersParallel = loopRequiresParallel || loop->isBracketLoop();
   QualifiedType ret;
 
-  // We build up tuple element types by resolving all the zip actuals.
-  std::vector<QualifiedType> eltTypes;
-
-  // We determine the follower policy by resolving the leader actual.
-  auto followerPolicy = IterDetails::NONE;
-  QualifiedType leaderYieldType;
-
-  std::vector<std::tuple<Function::IteratorKind, TheseResolutionResult>> failures;
-
-  const auto skippingAllIterands = -1;
-
-  // Get the leader actual.
+  // Compute the mask for this zip expression
   if (auto leader = (zip->numActuals() ? zip->actual(0) : nullptr)) {
-    auto iterandQt = rv.byPostorder.byAst(leader).type();
+    auto leaderQt = rv.byPostorder.byAst(leader).type();
 
-    // Set the policy mask for the leader based on the loop properties.
+    const auto skippingAllIterands = -1;
     int m = IterDetails::NONE;
     if (loopPrefersParallel) {
       m |= IterDetails::LEADER_FOLLOWER;
@@ -5223,7 +5286,7 @@ resolveZipExpression(Resolver& rv, const IndexableLoop* loop, const Zip* zip) {
       // Note that we will not attempt a leader/follower iterator.
       noteTheseResolutionFailure(rv, failures, Function::LEADER,
                                  skippingAllIterands,
-                                 rv.byPostorder.byAst(leader).type(),
+                                 leaderQt,
                                  TheseResolutionResult());
     }
 
@@ -5232,103 +5295,31 @@ resolveZipExpression(Resolver& rv, const IndexableLoop* loop, const Zip* zip) {
     } else {
       // Note that we will not attempt a serial iterator for any iterand.
       noteTheseResolutionFailure(rv, failures, Function::SERIAL, skippingAllIterands,
-                                 iterandQt, TheseResolutionResult());
+                                 leaderQt, TheseResolutionResult());
     }
 
     CHPL_ASSERT(m != IterDetails::NONE);
 
-    // Resolve the leader iterator.
-    auto dt = resolveIterDetails(rv, leader, leader, {}, m, /* emitError */ false);
+    // Compute iterator components to resolve as part of zippering.
+    std::vector<IterandComponent> ics = {
+      IterandComponent(rv, leader, leader)
+    };
+    for (int i = 1; i < zip->numActuals(); i++) {
+      auto follower = zip->actual(i);
+      ics.emplace_back(rv, follower, follower);
+    }
 
-    eltTypes.push_back(dt.idxType);
-
-    // Configure what followers should do using the iterator details.
-    if (dt.succeededAt == IterDetails::LEADER_FOLLOWER) {
-      followerPolicy = IterDetails::FOLLOWER;
-      leaderYieldType = dt.leaderYieldType;
-
-      // Note that we won't be attempting a serial iterator, even thought
-      // it was supported.
-      if (!loopRequiresParallel) {
-        auto result =TheseResolutionResult::failure(
-            TheseResolutionResult::THESE_FAIL_FOUND_DIFFERENT_ITERATOR,
-            iterandQt);
-        noteTheseResolutionFailure(rv, failures, Function::SERIAL,
-                                   skippingAllIterands,
-                                   iterandQt, std::move(result));
-      }
-    } else if (dt.succeededAt == IterDetails::SERIAL) {
-      followerPolicy = IterDetails::SERIAL;
-
-      // We didn't find a leader iterator, so note that as a failure in case
-      // we fail to find a serial iterator for other elements in the zip.
-      noteTheseResolutionFailure(rv, failures, Function::LEADER, 0, iterandQt,
-                                 std::move(dt.leader.resolutionResult));
-    } else {
-      ret = { QualifiedType::UNKNOWN, ErroneousType::get(context) };
-
-      // If we tried to resolve the parallel iterator, note that we failed.
-      if (loopPrefersParallel) {
-        noteTheseResolutionFailure(rv, failures, Function::LEADER, 0, iterandQt,
-                                   std::move(dt.leader.resolutionResult));
-      }
-
-      // If we tried to resolve the serial iterator, note that we failed.
-      if (!loopRequiresParallel) {
-        noteTheseResolutionFailure(rv, failures, Function::SERIAL, 0, iterandQt,
-                                   std::move(dt.serial.resolutionResult));
-      }
+    auto result = resolveIterDetailsInPriorityOrder(rv, ics, m, &failures);
+    if (result.succeededAt != IterDetails::NONE) {
+      ret = result.idxType;
     }
   }
 
-  // Resolve the follower iterator or serial iterator for all followers.
-  // It is possible for the follower policy to be 'NONE', in which case
-  // no iterators will be resolved, but the follower iterands will be
-  // resolved.
-  bool failedOthers = false;
-  for (int i = 1; i < zip->numActuals(); i++) {
-    auto actual = zip->actual(i);
-    auto dt = resolveIterDetails(rv, actual, actual, leaderYieldType,
-                                 followerPolicy, /* emitError */ false);
-    auto& qt = dt.idxType;
-    if (qt.isUnknownOrErroneous() && followerPolicy != IterDetails::NONE) {
-      bool isSerial = followerPolicy == IterDetails::SERIAL;
 
-      if (!failedOthers) {
-        noteTheseResolutionFailure(rv, failures,
-                                   isSerial ? Function::SERIAL : Function::FOLLOWER,
-                                   i, rv.byPostorder.byAst(actual).type(),
-                                   std::move(isSerial ?
-                                             dt.serial.resolutionResult :
-                                             dt.follower.resolutionResult));
-      }
-
-      failedOthers = true;
-    }
-
-    eltTypes.push_back(qt);
-  }
-
-  CHPL_ASSERT(((int) eltTypes.size()) == zip->numActuals());
-
-  auto kind = QualifiedType::CONST_VAR;
-  for (auto& et : eltTypes) {
-    if (!et.isUnknownOrErroneous() && !et.isConst()) {
-      kind = QualifiedType::VAR;
-      break;
-    }
-  }
-
-  if (!rv.scopeResolveOnly && (ret.isErroneousType() || failedOthers)) {
+  if (!rv.scopeResolveOnly && ret.isUnknownOrErroneous()) {
     // Emit a NonIterable error.
     ret = CHPL_TYPE_ERROR(context, NonIterable, loop, zip,
                           QualifiedType(), std::move(failures));
-  }
-
-  if (!ret.isErroneousType()) {
-    // This 'TupleType' builder preserves references for index types.
-    auto type = TupleType::getQualifiedTuple(context, std::move(eltTypes));
-    ret = { kind, type };
   }
 
   auto& reZip = rv.byPostorder.byAst(zip);
@@ -5503,7 +5494,7 @@ bool Resolver::enter(const IndexableLoop* loop) {
     if (!loopRequiresParallel) m |= IterDetails::SERIAL;
     CHPL_ASSERT(m != IterDetails::NONE);
 
-    auto dt = resolveIterDetails(*this, loop, iterand, {}, m, /* emitError */ true);
+    auto dt = resolveNonZipExpression(*this, loop, iterand, {}, m);
     idxType = dt.idxType;
   }
 
@@ -5742,8 +5733,8 @@ static QualifiedType resolveReduceScanOp(Resolver& resolver,
                                          const AstNode* op,
                                          const AstNode* iterand) {
   iterand->traverse(resolver);
-  auto dt = resolveIterDetails(resolver, reduceOrScan, iterand, {},
-                               IterDetails::SERIAL, /* emitError */ true);
+  auto dt = resolveNonZipExpression(resolver, reduceOrScan, iterand, {},
+                                    IterDetails::SERIAL);
   auto idxType = dt.idxType;
   if (idxType.isUnknown()) return QualifiedType();
   auto opClass = determineReduceScanOp(resolver, reduceOrScan, op, idxType);

--- a/frontend/lib/resolution/resolution-error-classes-list.cpp
+++ b/frontend/lib/resolution/resolution-error-classes-list.cpp
@@ -1171,9 +1171,6 @@ static void printTheseResults(
                         currentTr->zipperedFailureIndex() + 1,
                         ", ", currentTr->zipperedFailure()->iterandType(),
                         ") does not support a ", iterKindStr, " iterator", end);
-    } else if (reason == TheseResolutionResult::THESE_FAIL_FOUND_DIFFERENT_ITERATOR) {
-      wr.message(start, "the first zippered iterand had a parallel follower, "
-                        "which is prioritized over serial iteration", end);
     } else if (reason == TheseResolutionResult::THESE_FAIL_PROMOTION_TYPE_YIELD_MISMATCH) {
       wr.message(start, "the claimed scalar type for promotion does not match the type yielded from the iterator", end);
     }

--- a/frontend/test/resolution/testLoopIndexVars.cpp
+++ b/frontend/test/resolution/testLoopIndexVars.cpp
@@ -145,7 +145,7 @@ static void testAmbiguous() {
 
   const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
   auto idx = rr.byAst(loop->index());
-  assert(idx.type().isErroneousType());
+  assert(idx.type().isUnknown());
   assert(guard.realizeErrors() == 1);
 }
 

--- a/frontend/test/resolution/testLoopIndexVars.cpp
+++ b/frontend/test/resolution/testLoopIndexVars.cpp
@@ -1060,6 +1060,30 @@ static void testForallExpressionInForLoop(Context* context) {
                                [](const QualifiedType& t) { return t.type()->toRealType(); });
 }
 
+static void testBracketLoopSerialFallback(Context* context) {
+  // Test that a bracket loop expression falls back to the serial iterator
+  // if a leader is present, but one of the followers is not.
+  auto iters =
+    R""""(
+    iter i1() { yield 0.0; }
+    iter i1(param tag: iterKind) where tag == iterKind.leader { yield (0,0); }
+    iter i1(param tag: iterKind, followThis) where tag == iterKind.follower { yield 0.0; }
+
+    iter i2() { yield 0.0; }
+    iter i2(param tag: iterKind) where tag == iterKind.leader { yield (0,0); }
+    )"""";
+
+  // Follower iterator yields tuples of ints, so expect tuples of ints.
+  pairIteratorInLoopExpression(context, iters, "zip(i1(), i2())", {"[", "]"}, {"[", "]"},
+                               [](const QualifiedType& t) {
+    if (auto tt = t.type()->toTupleType()) {
+      if (!tt->isStarTuple()) return false;
+      return tt->starType().type()->isRealType();
+    }
+    return false;
+  });
+}
+
 int main() {
   testSimpleLoop("for");
   testSimpleLoop("coforall");
@@ -1099,6 +1123,8 @@ int main() {
   testForLoopExpressionInForall(context);
   testForLoopExpressionInBracketLoop(context);
   testForallExpressionInForLoop(context);
+
+  testBracketLoopSerialFallback(context);
 
   return 0;
 }


### PR DESCRIPTION
This PR fixes a TODO left behind in https://github.com/chapel-lang/chapel/pull/26215 to fix an issue introduced by https://github.com/chapel-lang/chapel/pull/24915. 

The issue is that in Dyno, a zippered loop "commits" to either a serial or parallel iterator, and then proceeds to resolve the rest of the iterands given that commitment. Thus, if the leader has a leader and follower, Dyno decides that all the other iterands need to be resolved as followers. This can fall through when the loop allows serial iteration, and one of the iterands doesn't have a follower: in this case, it's possible that the loop is resolvable as a serial `zip`, but since Dyno has committed to parallel iteration, we don't make that attempt.

The crux is the issue is that that we do "column major" resolution of iterators, rather than "row major", where the rows and columns are from the following table: 

```
            iterand1 iterand2 iterand3
            -----------------------------
leader    | yes      yes      yes
follower  | yes      no       yes
serial    | yes      yes      yes
```

On `main`, we first check all iterators of `iterand1`, then all iterators of `iterand2`, then all iterators of `iterand3`. However, this isn't the strategy used in production. Performing resolution in this order makes it necessary to "commit" to a strategy, since by the time we resolved all iterators of `iterand1`, we still don't know which one of them is going to end up being relevant.

This was an artifact of code re-use; a function (on `main`, `resolveIterDetailsInPriorityOrder`, was used for the non-zippered case, and worked with a single operand, attempting first the `leader`, then the `follower`, etc. The zippering code resolves this function, which effectively implements the "column major" approach.

This PR fixes the issue by switching us to row-major iteration; we first attempt the leader, then all followers if applicable, then all serial iterators if the followers fell through. By doing so, we can match the semantics of `zip`'ed loop expressions. 

## Implementation
To implement this, the PR changes `resolveIterDetailsInPriorityOrder` to accept a vector of iterands-to-handle, in the order they occurred while being zippered. The original `resolveIterDetailsInPriorityOrder` becomes a special case where the vector has only a single element. To make the vector work, it was convenient to define a new struct `IterandComponent`, which contains the AST data, type, etc. that was previously passed to `resolveIterDetailsInPriorityOrder`.

The PR subsequently moves the error noting logic out of `resolveZipExpression` and into `resolveIterDetailsInPriorityOrder`, which notes errors as they come up in row-major order, one error per row. 

While there, this PR adjusts the code that sets the index type to not make it `Erroneous` if an error was not issued. This follows Dyno conventions; `ErroneousTypes` are provided when the user sees an error message, and `UnknownType` is used otherwise.

Doing the above uncovered a bug in initializer resolution in which the default initializer was resolved for loop index variables. This is unnecessary, since loop index variables are yielded from the iterator. This issues was previously masked because we didn't resolve default initializers for erroneous types.

## Testing
- [x] dyno tests, with a new test for bracket loops' new row-major resolution