### PR TITLE
Add warnings for setting CHPL_LLVM_VERSION and CHPL_GPU_SDK_VERSION

### DIFF
--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -476,7 +476,7 @@ def _validate_rocm_llvm_version_impl(gpu: gpu_type):
 def _validate_cuda_version_impl():
     """Check that the installed CUDA version is >= MIN_REQ_VERSION and <
        MAX_REQ_VERSION"""
-    MIN_REQ_VERSION = "7"
+    MIN_REQ_VERSION = "11.7"
     MAX_REQ_VERSION = "13"
 
     cuda_version = get_sdk_version()
@@ -511,6 +511,14 @@ def _validate_cuda_version_impl():
 
 def get_sdk_version():
     gpu = GPU_TYPES[get()]
+
+    if os.environ.get('CHPL_GPU_SDK_VERSION') is not None:
+        fixstr = "."
+        if gpu.real_gpu:
+            var = gpu.sdk_path_env
+            fixstr = " and set {} to the desired version-specific path instead.".format(var)
+        warning("Setting CHPL_GPU_SDK_VERSION has no effect. Unset CHPL_GPU_SDK_VERSION"+fixstr)
+
     if not gpu.real_gpu:
         return 'none'
     version = gpu.find_version(get_gpu_compiler())

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -369,6 +369,8 @@ def get_llvm_config():
 
 @memoize
 def get_llvm_version():
+    if os.environ.get('CHPL_LLVM_VERSION') is not None:
+        warning("Setting CHPL_LLVM_VERSION has no effect. Unset CHPL_LLVM_VERSION and set CHPL_LLVM_CONFIG to the desired 'llvm-config' path instead.")
     (llvm_version, _) = check_llvm_config(get_llvm_config())
     return llvm_version
 


### PR DESCRIPTION
Warn when CHPL_LLVM_VERSION and CHPL_GPU_SDK_VERSION are set in environment variables. These variables are ignored, but if a user sees them in the printchplenv output they may incorrectly set them and expect them to have an effect. This PR adds a warning telling users that it has no effect how to resolve the warning.

[Reviewed by @vasslitvinov]