### PR TITLE
Use standard modules in dyno testing

### DIFF
--- a/frontend/include/chpl/types/CompositeType.h
+++ b/frontend/include/chpl/types/CompositeType.h
@@ -234,30 +234,6 @@ class CompositeType : public Type {
   /** Get the record _shared implementing shared */
   static const RecordType* getSharedRecordType(Context* context, const BasicClassType* bct);
 
-  /** When compiling without a standard library (for testing purposes),
-      the compiler code needs to work around the fact that there
-      is no definition available for the bundled types needed
-      by the language but provided in the library (such as 'string' or 'Error').
-      This function allows code to easily detect that case.
-   */
-  static bool isMissingBundledType(Context* context, ID id);
-
-  /** When compiling without a standard library (for testing purposes),
-      the compiler code needs to work around the fact that there
-      is no definition available for the class types needed
-      by the language but provided in the library (such as 'ReduceScanOp').
-      This function allows code to easily detect that case.
-   */
-  static bool isMissingBundledClassType(Context* context, ID id);
-
-  /** When compiling without a standard library (for testing purposes),
-      the compiler code needs to work around the fact that there
-      is no definition available for the record types needed
-      by the language but provided in the library (such as 'string').
-      This function allows code to easily detect that case.
-   */
-  static bool isMissingBundledRecordType(Context* context, ID id);
-
   /* Get the Error type */
   static const ClassType* getErrorType(Context* context);
 

--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -770,7 +770,7 @@ void setupModuleSearchPaths(Context* context,
   auto chplModulePath = (it != chplEnv->end()) ? it->second : "";
   setupModuleSearchPaths(context,
                          chplHomeStr,
-                         false,
+                         minimalModules,
                          chplEnv->at("CHPL_LOCALE_MODEL"),
                          false,
                          chplEnv->at("CHPL_TASKS"),

--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -1262,10 +1262,6 @@ static const AstTag& idToTagQuery(Context* context, ID id) {
     const AstNode* ast = astForIdQuery(context, id);
     if (ast != nullptr) {
       result = ast->tag();
-    } else if (types::CompositeType::isMissingBundledRecordType(context, id)) {
-      result = asttags::Record;
-    } else if (types::CompositeType::isMissingBundledClassType(context, id)) {
-      result = asttags::Class;
     }
   }
 

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -3970,14 +3970,6 @@ void Resolver::exit(const Range* range) {
     return;
   }
 
-  const RecordType* rangeType = CompositeType::getRangeType(context);
-  if (CompositeType::isMissingBundledRecordType(context, rangeType->id())) {
-    // The range record is part of the standard library, but
-    // it's possible to invoke the resolver without the stdlib.
-    // In this case, mark ranges as UnknownType, but do not error.
-    return;
-  }
-
   // Encode the type of the range as two bits: bounded below, bounded above.
   int boundType = (range->lowerBound() != nullptr) << 1 |
                   (range->upperBound() != nullptr);
@@ -4035,11 +4027,6 @@ void Resolver::exit(const uast::Domain* decl) {
   }
 
   const DomainType* genericDomainType = DomainType::getGenericDomainType(context);
-  if (CompositeType::isMissingBundledRecordType(context, genericDomainType->id())) {
-    // If we don't have the standard library code backing the Domain type, leave
-    // it unresolved.
-    return;
-  }
 
   if (decl->numExprs() == 0) {
     // Generic domain, as in a generic-domain array

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -884,10 +884,7 @@ const ResolvedFields& fieldsForTypeDeclQuery(Context* context,
   if (auto bct = ct->toBasicClassType()) {
     isObjectType = bct->isObjectType();
   }
-  bool isMissingBundledType =
-    CompositeType::isMissingBundledType(context, ct->id());
-
-  if (isObjectType || isMissingBundledType) {
+  if (isObjectType) {
     // no need to try to resolve the fields for the object type,
     // which doesn't have a real uAST ID.
     // for built-in types like Errors when we didn't parse the standard library
@@ -987,10 +984,7 @@ const ResolvedFields& resolveForwardingExprs(Context* context,
   if (auto bct = ct->toBasicClassType()) {
     isObjectType = bct->isObjectType();
   }
-  bool isMissingBundledType =
-    CompositeType::isMissingBundledType(context, ct->id());
-
-  if (isObjectType || isMissingBundledType) {
+  if (isObjectType) {
     // no need to try to resolve the fields for the object type,
     // which doesn't have a real uAST ID.
     // for built-in types like Errors when we didn't parse the standard library

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -529,8 +529,7 @@ static const Scope* const& scopeForIdQuery(Context* context, ID idIn) {
     // TODO: would it be beneficial to use idToTag in most cases here?
     const uast::AstNode* ast = parsing::idToAst(context, id);
     if (ast == nullptr) {
-      if (CompositeType::isMissingBundledType(context, id) ||
-          (id.isFabricatedId() &&
+      if ((id.isFabricatedId() &&
           id.fabricatedIdKind() == ID::FabricatedIdKind::Generated)) {
         // if there are no bundled modules selected,
         // to enable testing, just return the top-level scope for these

--- a/frontend/lib/types/CompositeType.cpp
+++ b/frontend/lib/types/CompositeType.cpp
@@ -233,11 +233,6 @@ static const RecordType* tryCreateManagerRecord(Context* context,
       subs[fields.fieldDeclId(i)] = QualifiedType(QualifiedType::TYPE, ct);
       break;
     }
-    if (fields.numFields() == 0) {
-      CHPL_ASSERT(CompositeType::isMissingBundledRecordType(context,
-                                                            instantiatedFrom->id()));
-      return nullptr;
-    }
   }
 
   auto name = recordId.symbolName(context);
@@ -254,39 +249,6 @@ CompositeType::getOwnedRecordType(Context* context, const BasicClassType* bct) {
 const RecordType*
 CompositeType::getSharedRecordType(Context* context, const BasicClassType* bct) {
   return tryCreateManagerRecord(context, getSharedRecordId(context), bct);
-}
-
-bool CompositeType::isMissingBundledType(Context* context, ID id) {
-  return isMissingBundledClassType(context, id) ||
-         isMissingBundledRecordType(context, id);
-}
-
-bool CompositeType::isMissingBundledRecordType(Context* context, ID id) {
-  bool noLibrary = parsing::bundledModulePath(context).isEmpty();
-  if (noLibrary) {
-    return id == CompositeType::getStringType(context)->id() ||
-           id == CompositeType::getRangeType(context)->id() ||
-           id == TupleType::getGenericTupleType(context)->id() ||
-           id == CompositeType::getBytesType(context)->id() ||
-           id == CompositeType::getDistributionType(context)->id() ||
-           id == DomainType::getGenericDomainType(context)->id() ||
-           id == getOwnedRecordId(context) ||
-           id == getSharedRecordId(context);
-  }
-
-  return false;
-}
-
-bool CompositeType::isMissingBundledClassType(Context* context, ID id) {
-  bool noLibrary = parsing::bundledModulePath(context).isEmpty();
-  if (noLibrary) {
-    return id == BasicClassType::getReduceScanOpType(context)->id() ||
-           id == CompositeType::getErrorType(context)->basicClassType()->id() ||
-           id == CPtrType::getId(context) ||
-           id == CPtrType::getConstId(context);
-  }
-
-  return false;
 }
 
 const ClassType* CompositeType::getErrorType(Context* context) {

--- a/frontend/lib/types/DomainType.cpp
+++ b/frontend/lib/types/DomainType.cpp
@@ -108,10 +108,6 @@ DomainType::getRectangularType(Context* context,
       break;
     }
   }
-  if (instanceFieldId.isEmpty()) {
-    CHPL_ASSERT(isMissingBundledRecordType(context, genericDomain->id()));
-    instanceFieldId = ID(USTR("_instance"), 0, 0);
-  }
   subs.emplace(instanceFieldId, instance);
 
   auto name = UniqueString::get(context, "_domain");

--- a/frontend/test/resolution/testCallInitDeinit.cpp
+++ b/frontend/test/resolution/testCallInitDeinit.cpp
@@ -109,8 +109,7 @@ static void testActions(const char* test,
                         bool expectErrors=false) {
   printf("### %s\n\n", test);
 
-  Context ctx;
-  Context* context = &ctx;
+  Context* context = buildStdContext();
   ErrorGuard guard(context);
 
   std::string testname = test;
@@ -550,9 +549,6 @@ static void test5d() {
   testActions("test5d",
     R""""(
       module M {
-        operator =(ref lhs: numeric, const in rhs: numeric) {
-          __primitive("=", lhs, rhs);
-        }
         record R { type T; var field : T; }
         proc R.init(type T, field = 0) {
           this.T = T;
@@ -1675,8 +1671,6 @@ static void test22() {
       R"""(
       module M {
         // call-init-deinit wants this to transmute R.c into the reciever of C.helper
-        operator =(ref lhs: borrowed C, rhs: unmanaged C) {
-        }
 
         class C {
           var x : int;

--- a/frontend/test/resolution/testCanPass.cpp
+++ b/frontend/test/resolution/testCanPass.cpp
@@ -391,8 +391,7 @@ static void test6() {
 
 static void test7() {
   printf("test7\n");
-  Context ctx;
-  Context* context = &ctx;
+  Context* context = buildStdContext();
   Context* c = context;
 
   // test that we can pass a child class to its parent class type

--- a/frontend/test/resolution/testCatch.cpp
+++ b/frontend/test/resolution/testCatch.cpp
@@ -43,8 +43,7 @@ static void testIt(const char* testName,
                    int expectedErrorCount=0,
                    bool validateClassType=true) {
   printf("test %s\n", testName);
-  Context ctx;
-  Context* context = &ctx;
+  Context* context = buildStdContext();
   ErrorGuard guard(context);
   auto path = UniqueString::get(context, testName);
   std::string contents = program;
@@ -327,7 +326,7 @@ static void test9() {
 // "try without a catchall in a non-throwing function"
 static void test10(Parser* parser) {
   // test for a try without a catchall in a non-throwing function
-  auto ctx = parser->context();
+  auto ctx = buildStdContext();
   auto path = UniqueString::get(ctx, "test10.chpl");
 
   ErrorGuard guard(ctx);
@@ -359,7 +358,7 @@ static void test10(Parser* parser) {
 
 // catchall placed before the end of a catch list in non-throwing function
 static void test11(Parser* parser) {
-  auto ctx = parser->context();
+  auto ctx = buildStdContext();
   auto path = UniqueString::get(ctx, "test11.chpl");
 
   ErrorGuard guard(ctx);
@@ -376,7 +375,6 @@ static void test11(Parser* parser) {
                           }
                         }
               )"""";
-  ctx->advanceToNextRevision(false);
   setFileText(ctx, path, program);
   const ModuleVec& vec = parseToplevel(ctx, path);
   auto mod = vec[0]->toModule();
@@ -395,7 +393,7 @@ static void test11(Parser* parser) {
 
 // cannot throw in a non-throwing function
 static void test12(Parser* parser) {
-  auto ctx = parser->context();
+  auto ctx = buildStdContext();
   auto path = UniqueString::get(ctx, "test12.chpl");
 
   ErrorGuard guard(ctx);
@@ -406,7 +404,6 @@ static void test12(Parser* parser) {
                           }
                         }
               )"""";
-  ctx->advanceToNextRevision(false);
   setFileText(ctx, path, program);
   const ModuleVec& vec = parseToplevel(ctx, path);
   auto mod = vec[0]->toModule();
@@ -425,7 +422,7 @@ static void test12(Parser* parser) {
 
 // "is in a try but not handled"
 static void test13(Parser* parser) {
-  auto ctx = parser->context();
+  auto ctx = buildStdContext();
   auto path = UniqueString::get(ctx, "test13.chpl");
 
   ErrorGuard guard(ctx);
@@ -442,7 +439,6 @@ static void test13(Parser* parser) {
                           }
                         }
               )"""";
-  ctx->advanceToNextRevision(false);
   setFileText(ctx, path, program);
   const ModuleVec& vec = parseToplevel(ctx, path);
   auto mod = vec[0]->toModule();
@@ -470,7 +466,7 @@ static void test13(Parser* parser) {
 
 // "deinit is not permitted to throw"
 static void test14(Parser* parser) {
-  auto ctx = parser->context();
+  auto ctx = buildStdContext();
   auto path = UniqueString::get(ctx, "test14.chpl");
 
   ErrorGuard guard(ctx);
@@ -481,7 +477,6 @@ static void test14(Parser* parser) {
                           }
                         }
               )"""";
-  ctx->advanceToNextRevision(false);
   setFileText(ctx, path, program);
   const ModuleVec& vec = parseToplevel(ctx, path);
   auto mod = vec[0]->toModule();
@@ -500,7 +495,7 @@ static void test14(Parser* parser) {
 // test for a try wit a catch but not a catchall in a non-throwing function
 static void test15(Parser* parser) {
 
-  auto ctx = parser->context();
+  auto ctx = buildStdContext();
   auto path = UniqueString::get(ctx, "test15.chpl");
 
   ErrorGuard guard(ctx);
@@ -517,7 +512,6 @@ static void test15(Parser* parser) {
                           }
                         }
               )"""";
-  ctx->advanceToNextRevision(false);
   setFileText(ctx, path, program);
   const ModuleVec& vec = parseToplevel(ctx, path);
   auto mod = vec[0]->toModule();
@@ -540,7 +534,7 @@ static void test15(Parser* parser) {
 
 // check fatal error handling mode
 static void test16(Parser* parser) {
-  auto ctx = parser->context();
+  auto ctx = buildStdContext();
   auto path = UniqueString::get(ctx, "test16.chpl");
 
   ErrorGuard guard(ctx);
@@ -553,7 +547,6 @@ static void test16(Parser* parser) {
                         }
                         canThrow(true);
               )"""";
-  ctx->advanceToNextRevision(false);
   setFileText(ctx, path, program);
   const ModuleVec& vec = parseToplevel(ctx, path);
   auto mod = vec[0]->toModule();
@@ -569,7 +562,7 @@ static void test16(Parser* parser) {
 // check relaxed error handling mode
 static void test17(Parser* parser) {
 
-  auto ctx = parser->context();
+  auto ctx = buildStdContext();
   auto path = UniqueString::get(ctx, "test17.chpl");
 
   ErrorGuard guard(ctx);
@@ -584,7 +577,6 @@ static void test17(Parser* parser) {
                           canThrow(true);
                         }
               )"""";
-  ctx->advanceToNextRevision(false);
   setFileText(ctx, path, program);
   const ModuleVec& vec = parseToplevel(ctx, path);
   auto mod = vec[0]->toModule();
@@ -603,7 +595,7 @@ static void test17(Parser* parser) {
 // check fatal error handling mode prototype module
 static void test18(Parser* parser) {
 
-  auto ctx = parser->context();
+  auto ctx = buildStdContext();
   auto path = UniqueString::get(ctx, "test18.chpl");
 
   ErrorGuard guard(ctx);
@@ -618,7 +610,6 @@ static void test18(Parser* parser) {
                           canThrow(true);
                         }
               )"""";
-  ctx->advanceToNextRevision(false);
   setFileText(ctx, path, program);
   const ModuleVec& vec = parseToplevel(ctx, path);
   auto mod = vec[0]->toModule();
@@ -636,7 +627,7 @@ static void test18(Parser* parser) {
 // check fatal error handling mode - implicit module
 static void test19(Parser* parser) {
 
-  auto ctx = parser->context();
+  auto ctx = buildStdContext();
   auto path = UniqueString::get(ctx, "test19.chpl");
 
   ErrorGuard guard(ctx);
@@ -649,7 +640,6 @@ static void test19(Parser* parser) {
                         }
                         canThrow(true);
               )"""";
-  ctx->advanceToNextRevision(false);
   setFileText(ctx, path, program);
   const ModuleVec& vec = parseToplevel(ctx, path);
   auto mod = vec[0]->toModule();
@@ -665,7 +655,7 @@ static void test19(Parser* parser) {
 
 
 static void test20(Parser* parser) {
-  auto ctx = parser->context();
+  auto ctx = buildStdContext();
   auto path = UniqueString::get(ctx, "test20.chpl");
 
   ErrorGuard guard(ctx);
@@ -687,7 +677,6 @@ static void test20(Parser* parser) {
                           }
                         }
                        )"""";
-  ctx->advanceToNextRevision(false);
   setFileText(ctx, path, program);
   const ModuleVec& vec = parseToplevel(ctx, path);
   auto mod = vec[0]->toModule();
@@ -711,7 +700,7 @@ static void test20(Parser* parser) {
 
 
 static void test21(Parser* parser) {
- auto ctx = parser->context();
+ auto ctx = buildStdContext();
   auto path = UniqueString::get(ctx, "test21.chpl");
 
   ErrorGuard guard(ctx);
@@ -730,7 +719,6 @@ static void test21(Parser* parser) {
                           }
                         }
                        )"""";
-  ctx->advanceToNextRevision(false);
   setFileText(ctx, path, program);
   const ModuleVec& vec = parseToplevel(ctx, path);
   auto mod = vec[0]->toModule();
@@ -745,7 +733,7 @@ static void test21(Parser* parser) {
 }
 
 static void test22(Parser* parser) {
-  auto ctx = parser->context();
+  auto ctx = buildStdContext();
   auto path = UniqueString::get(ctx, "test22.chpl");
 
   ErrorGuard guard(ctx);
@@ -762,7 +750,6 @@ static void test22(Parser* parser) {
                           }
                         }
                        )"""";
-  ctx->advanceToNextRevision(false);
   setFileText(ctx, path, program);
   const ModuleVec& vec = parseToplevel(ctx, path);
   auto mod = vec[0]->toModule();
@@ -782,7 +769,7 @@ static void test22(Parser* parser) {
 
 // nested try where catchall is only in outermost try
 static void test23(Parser* parser) {
-  auto ctx = parser->context();
+  auto ctx = buildStdContext();
   auto path = UniqueString::get(ctx, "test23.chpl");
 
   ErrorGuard guard(ctx);
@@ -799,7 +786,6 @@ static void test23(Parser* parser) {
                           }
                         }
                        )"""";
-  ctx->advanceToNextRevision(false);
   setFileText(ctx, path, program);
   const ModuleVec& vec = parseToplevel(ctx, path);
   auto mod = vec[0]->toModule();
@@ -810,7 +796,7 @@ static void test23(Parser* parser) {
 
 // nested try without a catchall
 static void test24(Parser* parser) {
-  auto ctx = parser->context();
+  auto ctx = buildStdContext();
   auto path = UniqueString::get(ctx, "test24.chpl");
 
   ErrorGuard guard(ctx);
@@ -827,7 +813,6 @@ static void test24(Parser* parser) {
                           }
                         }
                        )"""";
-  ctx->advanceToNextRevision(false);
   setFileText(ctx, path, program);
   const ModuleVec& vec = parseToplevel(ctx, path);
   auto mod = vec[0]->toModule();
@@ -862,8 +847,7 @@ static void test25() {
 
 
 int main() {
-  Context context;
-  Context* ctx = &context;
+  Context* ctx = buildStdContext();
   auto parser = Parser::createForTopLevelModule(ctx);
 
   Parser* p = &parser;

--- a/frontend/test/resolution/testClassTypeclass.cpp
+++ b/frontend/test/resolution/testClassTypeclass.cpp
@@ -65,8 +65,7 @@ bool shouldPass = true;
 bool shouldNotPass = false;
 
 static void testProgram(std::string intent, std::string management, std::vector<std::pair<ArgumentType, bool>> args) {
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   // Build the program.

--- a/frontend/test/resolution/testClasses.cpp
+++ b/frontend/test/resolution/testClasses.cpp
@@ -134,7 +134,6 @@ static void test3() {
   printf("test3\n");
 
   std::string program = R"""(
-    operator =(ref lhs: int, const rhs: int) {}
     class C {
       var a, b : int;
     }
@@ -146,8 +145,7 @@ static void test3() {
     var foo = new C(40, 2);
     var x = foo.getA();
     )""";
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
   auto m = parseModule(context, program);
   auto results = resolveModule(context, m->id());
@@ -161,12 +159,10 @@ static void test3() {
 static void test4() {
   printf("test4\n");
 
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   std::string program = R"""(
-    operator =(ref lhs: 2*int, const rhs : 2*int) {}
     class Bar {
       param rank : int;
       var myTup : rank*int;

--- a/frontend/test/resolution/testConstChecking.cpp
+++ b/frontend/test/resolution/testConstChecking.cpp
@@ -36,8 +36,7 @@ testConstChecking(const char* test,
                   std::vector<int> expectedErrorLines) {
   printf("\n### %s\n", test);
 
-  Context ctx;
-  Context* context = &ctx;
+  Context* context = buildStdContext();
   ErrorGuard guard(context);
 
   std::string testname = test;
@@ -294,20 +293,18 @@ static void test6a() {
   testConstChecking("test6a",
     R""""(
       module M {
-        operator =(ref lhs: int, const rhs: int) {}
         proc test() {
           const x: int = 0;
           x = 34;
         }
       }
     )"""",
-    {6});
+    {5});
 }
 static void test6b() {
   testConstChecking("test6b",
     R""""(
       module M {
-        operator =(ref lhs: int, const rhs: int) {}
         proc test() {
           const x: int = 0;
           const ref y = x;
@@ -315,13 +312,12 @@ static void test6b() {
         }
       }
     )"""",
-    {7});
+    {6});
 }
 static void test6c() {
   testConstChecking("test6c",
     R""""(
       module M {
-        operator =(ref lhs: int, const rhs: int) {}
         proc test() {
           const x: int = 0;
           ref y = x;
@@ -329,7 +325,7 @@ static void test6c() {
         }
       }
     )"""",
-    {6});
+    {5});
 }
 
 static void test7a() {

--- a/frontend/test/resolution/testCopyAssignablePrimitives.cpp
+++ b/frontend/test/resolution/testCopyAssignablePrimitives.cpp
@@ -38,8 +38,7 @@ static constexpr bool testExact = !testType;
 static void testPrimitive(
     std::string preamble,
     std::vector<std::tuple<const char*, const char*, bool, bool>> args) {
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   /* ErrorGuard guard(context); */
 
   std::stringstream ps;

--- a/frontend/test/resolution/testCopyElision.cpp
+++ b/frontend/test/resolution/testCopyElision.cpp
@@ -39,15 +39,15 @@ static void testCopyElision(const char* test,
                             bool expectErrors=false) {
   printf("%s\n", test);
 
-  Context ctx;
-  Context* context = &ctx;
+  //Context ctx;
+  //Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   std::string testname = test;
   testname += ".chpl";
   auto path = UniqueString::get(context, testname);
   std::string contents = "module M {\n";
-  contents += "operator =(ref lhs: int, const rhs: int){}\n";
   contents += program;
   contents += "\n}";
   setFileText(context, path, contents);
@@ -1017,9 +1017,6 @@ static void test40() {
 static void test41() {
   testCopyElision("test41a",
     R""""(
-        operator ==(ref lhs: int, rhs: int) {
-          __primitive("==", lhs, rhs);
-        }
         config const cond = 2;
         proc test() {
           var x: int = 0;
@@ -1038,9 +1035,6 @@ static void test41() {
     {});
   testCopyElision("test41b",
     R""""(
-        operator ==(ref lhs: int, rhs: int) {
-          __primitive("==", lhs, rhs);
-        }
         config const cond = 2;
         proc test() {
           var x: int = 0;
@@ -1065,10 +1059,6 @@ static void test41() {
 static void test42() {
   testCopyElision("test42a",
     R""""(
-        operator ==(ref lhs: int, rhs: int) {
-          __primitive("==", lhs, rhs);
-        }
-
         proc test() {
           var c: int = 0;
           var x: int = 0;
@@ -1086,10 +1076,6 @@ static void test42() {
     {});
   testCopyElision("test42b",
     R""""(
-        operator ==(ref lhs: int, rhs: int) {
-          __primitive("==", lhs, rhs);
-        }
-
         proc test() {
           var c: int = 0;
           var x: int = 0;
@@ -1110,10 +1096,6 @@ static void test42() {
 static void test43() {
   testCopyElision("test43a",
     R""""(
-        operator ==(ref lhs: int, rhs: int) {
-          __primitive("==", lhs, rhs);
-        }
-
         proc test() {
           var c: int = 0;
           var x: int = 0;
@@ -1131,10 +1113,6 @@ static void test43() {
     {});
   testCopyElision("test43b",
     R""""(
-        operator ==(ref lhs: int, rhs: int) {
-          __primitive("==", lhs, rhs);
-        }
-
         proc test() {
           var c: int = 0;
           var x: int = 0;

--- a/frontend/test/resolution/testDeprecationUnstable.cpp
+++ b/frontend/test/resolution/testDeprecationUnstable.cpp
@@ -430,8 +430,7 @@ static void test1(void) {
 
 // Warnings should not be emitted for method receivers.
 static void test2(void) {
-  Context context;
-  Context* ctx = turnOnWarnUnstable(&context);
+  Context* ctx = turnOnWarnUnstable(buildStdContext());
   ErrorGuard guard(ctx);
 
   auto path = TEST_NAME(ctx);
@@ -577,8 +576,7 @@ static void test4(ErrorType expectedError) {
         ? "@unstable"
         : "@deprecated";
 
-  Context context;
-  Context* ctx = turnOnWarnUnstable(&context);
+  Context* ctx = turnOnWarnUnstable(buildStdContext());
   ErrorGuard guard(ctx);
 
   auto path = TEST_NAME(ctx);

--- a/frontend/test/resolution/testDisambiguation.cpp
+++ b/frontend/test/resolution/testDisambiguation.cpp
@@ -124,8 +124,7 @@ static void checkCalledIndex(Context* context,
 }
 
 static void test1() {
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   checkCalledIndex(context,
       R""""(
@@ -165,8 +164,7 @@ static void test1() {
 }
 
 static void test2() {
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   checkCalledIndex(context,
       R""""(
@@ -211,8 +209,7 @@ static void test2() {
 }
 
 static void test3() {
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   checkCalledIndex(context,
       R""""(
@@ -282,8 +279,7 @@ static void test3() {
 
 // updated disambiguation based on width of argument
 static void test4() {
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   std::string program =
     R""""(
@@ -336,8 +332,7 @@ static void test4() {
 }
 
 static void test5() {
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   std::string program = R"""(
@@ -357,8 +352,7 @@ static void test5() {
 }
 
 static void test6() {
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   std::string program = R"""(

--- a/frontend/test/resolution/testDomains.cpp
+++ b/frontend/test/resolution/testDomains.cpp
@@ -390,8 +390,7 @@ static void testBadDomain(Context* contextWithStd, std::string domainType) {
 int main() {
   // Set up context with standard modules, re-used between tests for
   // performance.
-  auto ctx = buildStdContext();
-  auto context = ctx.get();
+  auto context = buildStdContext();
 
   testRectangular(context, "domain(1)", 1, "int", "one");
   testRectangular(context, "domain(2)", 2, "int", "one");

--- a/frontend/test/resolution/testDomains.cpp
+++ b/frontend/test/resolution/testDomains.cpp
@@ -365,15 +365,6 @@ module M {
 // Ensure we gracefully error for bad domain type expressions, with or without
 // the standard modules available.
 static void testBadDomain(Context* contextWithStd, std::string domainType) {
-  // Without standard modules
-  {
-    Context ctx;
-    Context* context = &ctx;
-    ErrorGuard guard(context);
-
-    testBadDomainHelper(domainType, context, guard);
-  }
-
   // With standard modules
   {
     contextWithStd->advanceToNextRevision(false);

--- a/frontend/test/resolution/testEnums.cpp
+++ b/frontend/test/resolution/testEnums.cpp
@@ -29,8 +29,7 @@
 #include "chpl/uast/Variable.h"
 
 static void test1() {
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   QualifiedType qt =  resolveTypeOfXInit(context,
                          R""""(
                          enum color {
@@ -53,8 +52,7 @@ static void test1() {
 }
 
 static void test2() {
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   QualifiedType qt =  resolveTypeOfXInit(context,
                          R""""(
                          enum color {
@@ -68,8 +66,7 @@ static void test2() {
 }
 
 static void test3() {
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   QualifiedType qt =  resolveTypeOfXInit(context,
                          R""""(
                          enum color {
@@ -84,8 +81,7 @@ static void test3() {
 
 // Test numeric conversions of enums
 static void test4() {
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   auto vars = resolveTypesOfVariables(context,
@@ -132,8 +128,7 @@ enumConstantValues(Context* context, const QualifiedType& qt) {
 }
 
 static void test5() {
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   auto vars = resolveTypesOfVariables(context,
@@ -174,8 +169,7 @@ static void test5() {
 }
 
 static void test6() {
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   auto vars = resolveTypesOfVariables(context,
@@ -208,8 +202,7 @@ static void test6() {
 }
 
 static void test7() {
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   auto vars = resolveTypesOfVariables(context,
@@ -242,8 +235,7 @@ static void test7() {
 }
 
 static void test8() {
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   auto vars = resolveTypesOfVariables(context,
@@ -276,8 +268,7 @@ static void test8() {
 }
 
 static void test9() {
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   auto vars = resolveTypesOfVariables(context,
@@ -310,8 +301,7 @@ static void test9() {
 }
 
 static void test10() {
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   auto vars = resolveTypesOfVariables(context,
@@ -338,8 +328,7 @@ static void test10() {
 }
 
 static void test11() {
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   // Production allows multiple constants to have the same numeric value.
@@ -374,8 +363,7 @@ static void test11() {
 }
 
 static void test12() {
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   // Production allows multiple constants to have the same numeric value.
@@ -405,8 +393,7 @@ static void test12() {
 }
 
 static void test13() {
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   // Production allows multiple constants to have the same numeric value.
@@ -434,8 +421,7 @@ static void test13() {
 }
 
 static void test14() {
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   // Production allows multiple constants to have the same numeric value.
@@ -471,8 +457,7 @@ static void test14() {
 
 
 static void test15() {
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   // Production allows multiple constants to have the same numeric value.
@@ -504,8 +489,7 @@ static void test15() {
 }
 
 static void test16() {
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   auto vars = resolveTypesOfVariables(context,
@@ -552,8 +536,7 @@ static void test16() {
 }
 
 static void test17() {
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   auto vars = resolveTypesOfVariables(context,
@@ -600,8 +583,7 @@ static void test17() {
 }
 
 static void test18() {
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   auto vars = resolveTypesOfVariables(context,
@@ -648,16 +630,11 @@ static void test18() {
 }
 
 static void test19() {
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   auto vars = resolveTypesOfVariables(context,
       R"""(
-      iter type enum.these(){
-        for param i in 0..<this.size do
-          yield chpl__orderToEnum(i, this);
-      }
       enum color {
         red, green, blue
       }
@@ -672,8 +649,7 @@ static void test19() {
 }
 
 static void test20() {
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   auto vars = resolveTypesOfVariables(context,

--- a/frontend/test/resolution/testForwarding.cpp
+++ b/frontend/test/resolution/testForwarding.cpp
@@ -29,14 +29,12 @@
 static void test1() {
   printf("test1\n");
 
-  Context ctx;
-  Context* context = &ctx;
+  Context* context = buildStdContext();
   ErrorGuard guard(context);
 
   const char* contents =
     R""""(
     module M {
-      operator +=(ref lhs: int, rhs: int) { }
       record Inner {
         var i: int;
         proc ref addOne() {
@@ -61,14 +59,12 @@ static void test1() {
 static void test2() {
   printf("test2\n");
 
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   const char* contents =
     R""""(
     module M {
-      operator +=(ref lhs: int, rhs: int) { }
       record Inner {
         var i: int;
         proc ref addOne() {
@@ -96,15 +92,12 @@ static void test2() {
 static void test3() {
   printf("test3\n");
 
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   const char* contents =
     R""""(
     module M {
-      operator +=(ref lhs: int, rhs: int) { }
-
       class C {
         forwarding var impl: unmanaged C;
       }
@@ -126,15 +119,12 @@ static void test3() {
 static void test4() {
   printf("test4\n");
 
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   const char* contents =
     R""""(
     module M {
-      operator =(ref lhs: int, rhs: int) {}
-      operator +=(ref lhs: int, rhs: int) { }
       record Inner {
         var i: int;
         proc init() { this.i = 0; };
@@ -161,15 +151,12 @@ static void test4() {
 static void test5a() {
   printf("test5a\n");
 
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   const char* contents =
     R""""(
     module M {
-      operator =(ref lhs: int, rhs: int) {}
-      operator +=(ref lhs: int, rhs: int) { }
       record Inner1 {
         var i: int;
         proc init() { this.i = 0; };
@@ -200,15 +187,12 @@ static void test5a() {
 static void test5b() {
   printf("test5b\n");
 
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   const char* contents =
     R""""(
     module M {
-      operator =(ref lhs: int, rhs: int) {}
-      operator +=(ref lhs: int, rhs: int) { }
       record Inner1 {
         var i: int;
         proc init() { this.i = 0; };
@@ -249,15 +233,12 @@ static void test5b() {
 static void test6a() {
   printf("test6a\n");
 
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   const char* contents =
     R""""(
     module M {
-      operator =(ref lhs: int, rhs: int) {}
-      operator +=(ref lhs: int, rhs: int) { }
       record Inner1 {
         var i: int;
         proc init() { this.i = 0; };
@@ -302,15 +283,12 @@ static void test6a() {
 static void test6b() {
   printf("test6b\n");
 
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   const char* contents =
     R""""(
     module M {
-      operator =(ref lhs: int, rhs: int) {}
-      operator +=(ref lhs: int, rhs: int) { }
       record Inner1 {
         var i: int;
         proc init() { this.i = 0; };
@@ -365,8 +343,7 @@ static void test6b() {
 static void testExpr() {
   printf("testExpr\n");
 
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   const char* contents =
@@ -396,8 +373,7 @@ static void testExpr() {
 }
 
 static void forwardForwardHelper(std::string stmt, bool isVar = false) {
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   std::string contents =
@@ -460,14 +436,12 @@ static void testForwardForwardExpr() {
 static void test7() {
   printf("test7\n");
 
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   const char* contents =
     R""""(
     module M {
-      operator +=(ref lhs: int, rhs: int) { }
       record Inner {
         var i: int;
         pragma "last resort"
@@ -500,8 +474,7 @@ static void test7() {
 static void test8() {
   printf("test8\n");
 
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   const char* contents =

--- a/frontend/test/resolution/testFunctionCalls.cpp
+++ b/frontend/test/resolution/testFunctionCalls.cpp
@@ -31,8 +31,7 @@
 static void test1() {
   // make sure that function return type computation does not throw
   // away the param.
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   QualifiedType qt =  resolveTypeOfXInit(context,
                          R""""(
                          proc p(param x: int(64), param y: int(64)) param do return __primitive("+", x, y);
@@ -48,8 +47,7 @@ static void test1() {
 
 static void test2() {
   // make sure unknown types don't slip into candidate search
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   QualifiedType qt =  resolveTypeOfXInit(context,
                          R""""(
                          proc test(z) {}
@@ -62,8 +60,7 @@ static void helpTest3(const std::string& theFunction) {
   // Make sure that types depending on earlier actual types are properly
   // enforced
   {
-    Context ctx;
-    auto context = &ctx;
+    auto context = buildStdContext();
     auto qt = resolveTypeOfXInit(context, theFunction +
                                  R""""(
                                  var x = f(true, "hello", "world");
@@ -72,8 +69,7 @@ static void helpTest3(const std::string& theFunction) {
     assert(qt.type()->isStringType());
   }
   {
-    Context ctx;
-    auto context = &ctx;
+    auto context = buildStdContext();
     auto qt = resolveTypeOfXInit(context, theFunction +
                                  R""""(
                                  var x = f(false, 0, 1);
@@ -82,8 +78,7 @@ static void helpTest3(const std::string& theFunction) {
     assert(qt.type()->isIntType());
   }
   {
-    Context ctx;
-    auto context = &ctx;
+    auto context = buildStdContext();
     auto qt = resolveTypeOfXInit(context, theFunction +
                                  R""""(
                                  var x = f(true, 0, 1);
@@ -91,8 +86,7 @@ static void helpTest3(const std::string& theFunction) {
     assert(qt.isUnknown());
   }
   {
-    Context ctx;
-    auto context = &ctx;
+    auto context = buildStdContext();
     auto qt = resolveTypeOfXInit(context, theFunction +
                                  R""""(
                                  var x = f(false, "hello", "world");
@@ -100,8 +94,7 @@ static void helpTest3(const std::string& theFunction) {
     assert(qt.isUnknown());
   }
   {
-    Context ctx;
-    auto context = &ctx;
+    auto context = buildStdContext();
     auto qt = resolveTypeOfXInit(context, theFunction +
                                  R""""(
                                  var x = f(true, "hello", 0);
@@ -134,13 +127,10 @@ static void test3b() {
 
 // Test calling dependently typed type constructor, for type with param field
 static void test4() {
-  Context ctx;
-  auto context = &ctx;
-
   // With param field type declared
   {
     printf("part 1\n");
-    context->advanceToNextRevision(true);
+    auto context = buildStdContext();
     ErrorGuard guard(context);
 
     const std::string program =
@@ -165,7 +155,7 @@ static void test4() {
   // Param field of generic type
   {
     printf("part 2\n");
-    context->advanceToNextRevision(true);
+    auto context = buildStdContext();
 
     const std::string program =
       R""""(
@@ -188,7 +178,7 @@ static void test4() {
   // With param formal type declared
   {
     printf("part 3\n");
-    context->advanceToNextRevision(true);
+    auto context = buildStdContext();
 
     const std::string program =
       R""""(

--- a/frontend/test/resolution/testGenericDefaults.cpp
+++ b/frontend/test/resolution/testGenericDefaults.cpp
@@ -160,10 +160,6 @@ static void test4() {
 
 static void test5() {
   std::string common = R"""(
-    operator =(ref lhs: int, rhs : int) {
-      __primitive("=", lhs, rhs);
-    }
-
     record R {
       type T = int;
       var field : T;
@@ -181,8 +177,7 @@ static void test5() {
 
   {
     // Test methods on generics with defaults
-    Context ctx;
-    auto context = &ctx;
+    auto context = buildStdContext();
     ErrorGuard guard(context);
     std::string program = common + R"""(
       proc blah(x: R(string)) {
@@ -199,8 +194,7 @@ static void test5() {
   }
   {
     // Test passing to generic arguments with types that are generic-with-defaults
-    Context ctx;
-    auto context = &ctx;
+    auto context = buildStdContext();
     ErrorGuard guard(context);
     std::string program = common + R"""(
       //
@@ -230,8 +224,7 @@ static void test5() {
   }
   {
     // Test passing to generic arguments with types that are generic-with-defaults
-    Context ctx;
-    auto context = &ctx;
+    auto context = buildStdContext();
     ErrorGuard guard(context);
     std::string program = common + R"""(
       proc copy(arg) {

--- a/frontend/test/resolution/testIf.cpp
+++ b/frontend/test/resolution/testIf.cpp
@@ -106,8 +106,7 @@ static void test6() {
 }
 
 static void testIfVarErrorUseInElseBranch1() {
-  Context context;
-  auto ctx = &context;
+  auto ctx = buildStdContext();
   ErrorGuard guard(ctx);
 
   auto path = TEST_NAME_FROM_FN_NAME(ctx);
@@ -153,8 +152,7 @@ static void testIfVarErrorUseInElseBranch1() {
 
 // In this variation the use is in a 'else-if'.
 static void testIfVarErrorUseInElseBranch2() {
-  Context context;
-  auto ctx = &context;
+  auto ctx = buildStdContext();
   ErrorGuard guard(ctx);
 
   auto path = TEST_NAME_FROM_FN_NAME(ctx);
@@ -205,8 +203,7 @@ static void testIfVarErrorUseInElseBranch2() {
 
 // In this variation the use is in a deeply nested block.
 static void testIfVarErrorUseInElseBranch3() {
-  Context context;
-  auto ctx = &context;
+  auto ctx = buildStdContext();
   ErrorGuard guard(ctx);
 
   auto path = TEST_NAME_FROM_FN_NAME(ctx);
@@ -250,8 +247,7 @@ static void testIfVarErrorUseInElseBranch3() {
 
 // Uses of two if-vars with the same name across multiple branches.
 static void testIfVarErrorUseInElseBranch4() {
-  Context context;
-  auto ctx = &context;
+  auto ctx = buildStdContext();
   ErrorGuard guard(ctx);
 
   auto path = TEST_NAME_FROM_FN_NAME(ctx);
@@ -321,8 +317,7 @@ static void testIfVarErrorUseInElseBranch4() {
 }
 
 static void testIfVarErrorNonClassType() {
-  Context context;
-  auto ctx = &context;
+  auto ctx = buildStdContext();
   ErrorGuard guard(ctx);
 
   auto path = TEST_NAME_FROM_FN_NAME(ctx);
@@ -354,8 +349,7 @@ static void testIfVarErrorNonClassType() {
 }
 
 static void testIfVarNonNilInThen() {
-  Context context;
-  auto ctx = &context;
+  auto ctx = buildStdContext();
   ErrorGuard guard(ctx);
 
   auto path = TEST_NAME_FROM_FN_NAME(ctx);

--- a/frontend/test/resolution/testIf.cpp
+++ b/frontend/test/resolution/testIf.cpp
@@ -29,8 +29,7 @@
 #include "chpl/uast/Variable.h"
 
 static void test1() {
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   QualifiedType qt =  resolveQualifiedTypeOfX(context,
                          R""""(
                          var x : if true then string else "not-a-type";
@@ -39,8 +38,7 @@ static void test1() {
 }
 
 static void test2() {
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   QualifiedType qt =  resolveQualifiedTypeOfX(context,
                          R""""(
                          var x : if false then "not-a-type" else int;
@@ -49,8 +47,7 @@ static void test2() {
 }
 
 static void test3() {
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   QualifiedType qt =  resolveQualifiedTypeOfX(context,
                          R""""(
                          var b : bool;
@@ -62,8 +59,7 @@ static void test3() {
 }
 
 static void test4() {
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   QualifiedType qt =  resolveTypeOfXInit(context,
                          R""""(
                          var b : bool;
@@ -76,8 +72,7 @@ static void test4() {
 }
 
 static void test5() {
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   QualifiedType qt =  resolveTypeOfXInit(context,
                          R""""(
                          record r {}
@@ -93,8 +88,7 @@ static void test5() {
 }
 
 static void test6() {
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   QualifiedType qt =  resolveTypeOfXInit(context,
                          R""""(
                          param b : bool;
@@ -384,8 +378,7 @@ static void testIfVarNonNilInThen() {
 }
 
 static void testIfVarBorrow() {
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   std::string program =

--- a/frontend/test/resolution/testInitSemantics.cpp
+++ b/frontend/test/resolution/testInitSemantics.cpp
@@ -25,23 +25,14 @@
 #include "chpl/types/all-types.h"
 #include "chpl/uast/all-uast.h"
 
-#define TEST_NAME(ctx__) TEST_NAME_FROM_FN_NAME(ctx__)
-
-std::string otherOps = R"""(
-    operator =(ref lhs: int, rhs: int) {}
-    operator =(ref lhs: real, rhs: real) {}
-    operator >(ref lhs: int, rhs: int) {
-      return __primitive(">", lhs, rhs);
-    }
-    )""";
+#define TEST_NAME(context__) TEST_NAME_FROM_FN_NAME(context__)
 
 static void testFieldUseBeforeInit1(void) {
-  Context context;
-  Context* ctx = &context;
-  ErrorGuard guard(ctx);
+  auto context = buildStdContext();
+  ErrorGuard guard(context);
 
-  auto path = TEST_NAME(ctx);
-  std::string contents = otherOps + R""""(
+  auto path = TEST_NAME(context);
+  std::string contents = R""""(
     record r {
       var x: int;
     }
@@ -59,33 +50,32 @@ static void testFieldUseBeforeInit1(void) {
     var obj = new r();
     )"""";
 
-  setFileText(ctx, path, contents);
+  setFileText(context, path, contents);
 
   // Get the module.
-  auto& br = parseAndReportErrors(ctx, path);
+  auto& br = parseAndReportErrors(context, path);
   assert(br.numTopLevelExpressions() == 1);
   auto mod = br.topLevelExpression(0)->toModule();
   assert(mod);
 
   // Resolve the module.
-  std::ignore = resolveModule(ctx, mod->id());
+  std::ignore = resolveModule(context, mod->id());
 
   assert(guard.numErrors(/* countWarnings */ false) == 6);
 
   // Check the first error to see if it lines up.
   auto& msg = guard.errors()[0];
   assert(msg->message() == "'x' is used before it is initialized");
-  assert(msg->location(ctx).firstLine() == 13);
+  assert(msg->location(context).firstLine() == 7);
   assert(guard.realizeErrors());
 }
 
 static void testInitReturnVoid(void) {
-  Context context;
-  Context* ctx = &context;
-  ErrorGuard guard(ctx);
+  auto context = buildStdContext();
+  ErrorGuard guard(context);
 
-  auto path = TEST_NAME(ctx);
-  std::string contents = otherOps + R""""(
+  auto path = TEST_NAME(context);
+  std::string contents = R""""(
     record r {
       var x: int;
     }
@@ -97,33 +87,32 @@ static void testInitReturnVoid(void) {
     var obj = new r();
     )"""";
 
-  setFileText(ctx, path, contents);
+  setFileText(context, path, contents);
 
   // Get the module.
-  auto& br = parseAndReportErrors(ctx, path);
+  auto& br = parseAndReportErrors(context, path);
   assert(br.numTopLevelExpressions() == 1);
   auto mod = br.topLevelExpression(0)->toModule();
   assert(mod);
 
   // Resolve the module.
-  std::ignore = resolveModule(ctx, mod->id());
+  std::ignore = resolveModule(context, mod->id());
 
   assert(guard.numErrors(/* countWarnings */ false) == 1);
 
   // Check the error (which comes last) to see if it lines up.
   auto& msg = guard.errors().back();
   assert(msg->message() == "initializers can only return 'void'");
-  assert(msg->location(ctx).firstLine() == 14);
+  assert(msg->location(context).firstLine() == 8);
   assert(guard.realizeErrors());
 }
 
 static void testInitReturnEarly(void) {
-  Context context;
-  Context* ctx = &context;
-  ErrorGuard guard(ctx);
+  auto context = buildStdContext();
+  ErrorGuard guard(context);
 
-  auto path = TEST_NAME(ctx);
-  std::string contents = otherOps + R""""(
+  auto path = TEST_NAME(context);
+  std::string contents = R""""(
     record r {
       var x: int;
     }
@@ -135,33 +124,32 @@ static void testInitReturnEarly(void) {
     var obj = new r();
     )"""";
 
-  setFileText(ctx, path, contents);
+  setFileText(context, path, contents);
 
   // Get the module.
-  auto& br = parseAndReportErrors(ctx, path);
+  auto& br = parseAndReportErrors(context, path);
   assert(br.numTopLevelExpressions() == 1);
   auto mod = br.topLevelExpression(0)->toModule();
   assert(mod);
 
   // Resolve the module.
-  std::ignore = resolveModule(ctx, mod->id());
+  std::ignore = resolveModule(context, mod->id());
 
   assert(guard.errors().size() == 1);
 
   // Check the first error to see if it lines up.
   auto& msg = guard.errors()[0];
   assert(msg->message() == "cannot return from initializer before initialization is complete");
-  assert(msg->location(ctx).firstLine() == 13);
+  assert(msg->location(context).firstLine() == 7);
   assert(guard.realizeErrors());
 }
 
 static void testInitThrow(void) {
-  Context context;
-  Context* ctx = &context;
-  ErrorGuard guard(ctx);
+  auto context = buildStdContext();
+  ErrorGuard guard(context);
 
-  auto path = TEST_NAME(ctx);
-  std::string contents = otherOps + R""""(
+  auto path = TEST_NAME(context);
+  std::string contents = R""""(
     record r {
       var x: int;
     }
@@ -173,33 +161,32 @@ static void testInitThrow(void) {
     var obj = new r();
     )"""";
 
-  setFileText(ctx, path, contents);
+  setFileText(context, path, contents);
 
   // Get the module.
-  auto& br = parseAndReportErrors(ctx, path);
+  auto& br = parseAndReportErrors(context, path);
   assert(br.numTopLevelExpressions() == 1);
   auto mod = br.topLevelExpression(0)->toModule();
   assert(mod);
 
   // Resolve the module.
-  std::ignore = resolveModule(ctx, mod->id());
+  std::ignore = resolveModule(context, mod->id());
 
   assert(guard.errors().size() == 1);
 
   // Check the first error to see if it lines up.
   auto& msg = guard.errors()[0];
   assert(msg->message() == "initializers are not yet allowed to throw errors");
-  assert(msg->location(ctx).firstLine() == 14);
+  assert(msg->location(context).firstLine() == 8);
   assert(guard.realizeErrors());
 }
 
 static void testInitTryBang(void) {
-  Context context;
-  Context* ctx = &context;
-  ErrorGuard guard(ctx);
+  auto context = buildStdContext();
+  ErrorGuard guard(context);
 
-  auto path = TEST_NAME(ctx);
-  std::string contents = otherOps + R""""(
+  auto path = TEST_NAME(context);
+  std::string contents = R""""(
     record r {
       var x: int;
     }
@@ -212,23 +199,23 @@ static void testInitTryBang(void) {
     var obj = new r();
     )"""";
 
-  setFileText(ctx, path, contents);
+  setFileText(context, path, contents);
 
   // Get the module.
-  auto& br = parseAndReportErrors(ctx, path);
+  auto& br = parseAndReportErrors(context, path);
   assert(br.numTopLevelExpressions() == 1);
   auto mod = br.topLevelExpression(0)->toModule();
   assert(mod);
 
   // Resolve the module.
-  std::ignore = resolveModule(ctx, mod->id());
+  std::ignore = resolveModule(context, mod->id());
 
   assert(guard.errors().size() == 1);
 
   // Check the first error to see if it lines up.
   auto& msg = guard.errors()[0];
   assert(msg->message() == "Only catch-less try! statements are allowed in initializers for now");
-  assert(msg->location(ctx).firstLine() == 14);
+  assert(msg->location(context).firstLine() == 8);
   assert(guard.realizeErrors());
 }
 
@@ -252,12 +239,11 @@ static void testInitInsideLoops(void) {
   for (size_t i = 0; i < inits.size(); i++) {
     auto& loop = inits[i];
     auto& message = messages[i];
-    Context context;
-    Context* ctx = &context;
-    ErrorGuard guard(ctx);
+    auto context = buildStdContext();
+    ErrorGuard guard(context);
 
-    auto path = TEST_NAME(ctx);
-    std::string contents = otherOps + R""""(
+    auto path = TEST_NAME(context);
+    std::string contents = R""""(
       record r {
         var x: int;
       }
@@ -268,34 +254,33 @@ static void testInitInsideLoops(void) {
       var obj = new r();
       )"""";
 
-    setFileText(ctx, path, contents);
+    setFileText(context, path, contents);
 
     // Get the module.
-    auto& br = parseAndReportErrors(ctx, path);
+    auto& br = parseAndReportErrors(context, path);
     assert(br.numTopLevelExpressions() == 1);
     auto mod = br.topLevelExpression(0)->toModule();
     assert(mod);
 
     // Resolve the module.
-    std::ignore = resolveModule(ctx, mod->id());
+    std::ignore = resolveModule(context, mod->id());
 
     assert(guard.numErrors(/* countWarnings */ false) == 1);
 
     // Check the error (which comes last) to see if it lines up.
     auto& msg = guard.errors().back();
     assert(msg->message() == message);
-    assert(msg->location(ctx).firstLine() == 13);
+    assert(msg->location(context).firstLine() == 7);
     assert(guard.realizeErrors());
   }
 }
 
 static void testThisComplete(void) {
-  Context context;
-  Context* ctx = &context;
-  ErrorGuard guard(ctx);
+  auto context = buildStdContext();
+  ErrorGuard guard(context);
 
-  auto path = TEST_NAME(ctx);
-  std::string contents = otherOps + R""""(
+  auto path = TEST_NAME(context);
+  std::string contents = R""""(
     record r {
       var x : int;
       var y : int;
@@ -309,27 +294,26 @@ static void testThisComplete(void) {
     var obj = new r();
     )"""";
 
-  setFileText(ctx, path, contents);
+  setFileText(context, path, contents);
 
   // Get the module.
-  auto& br = parseAndReportErrors(ctx, path);
+  auto& br = parseAndReportErrors(context, path);
   assert(br.numTopLevelExpressions() == 1);
   auto mod = br.topLevelExpression(0)->toModule();
   assert(mod);
 
   // Resolve the module.
-  std::ignore = resolveModule(ctx, mod->id());
+  std::ignore = resolveModule(context, mod->id());
 
   assert(guard.errors().size() == 0);
 }
 
 static void testSecondAssign(void) {
-  Context context;
-  Context* ctx = &context;
-  ErrorGuard guard(ctx);
+  auto context = buildStdContext();
+  ErrorGuard guard(context);
 
-  auto path = TEST_NAME(ctx);
-  std::string contents = otherOps + R""""(
+  auto path = TEST_NAME(context);
+  std::string contents = R""""(
     record r {
       var x: int;
     }
@@ -340,27 +324,26 @@ static void testSecondAssign(void) {
     var obj = new r();
     )"""";
 
-  setFileText(ctx, path, contents);
+  setFileText(context, path, contents);
 
   // Get the module.
-  auto& br = parseAndReportErrors(ctx, path);
+  auto& br = parseAndReportErrors(context, path);
   assert(br.numTopLevelExpressions() == 1);
   auto mod = br.topLevelExpression(0)->toModule();
   assert(mod);
 
   // Resolve the module.
-  std::ignore = resolveModule(ctx, mod->id());
+  std::ignore = resolveModule(context, mod->id());
 
   assert(guard.errors().size() == 0);
 }
 
 static void testOutOfOrder(void) {
-  Context context;
-  Context* ctx = &context;
-  ErrorGuard guard(ctx);
+  auto context = buildStdContext();
+  ErrorGuard guard(context);
 
-  auto path = TEST_NAME(ctx);
-  std::string contents = otherOps + R""""(
+  auto path = TEST_NAME(context);
+  std::string contents = R""""(
     record r {
       var x, y, z: int;
     }
@@ -371,32 +354,31 @@ static void testOutOfOrder(void) {
     var obj = new r();
     )"""";
 
-  setFileText(ctx, path, contents);
+  setFileText(context, path, contents);
 
   // Get the module.
-  auto& br = parseAndReportErrors(ctx, path);
+  auto& br = parseAndReportErrors(context, path);
   assert(br.numTopLevelExpressions() == 1);
   auto mod = br.topLevelExpression(0)->toModule();
   assert(mod);
 
   // Resolve the module.
-  std::ignore = resolveModule(ctx, mod->id());
+  std::ignore = resolveModule(context, mod->id());
 
   assert(guard.errors().size() == 1);
 
   auto& msg = guard.errors()[0];
   assert(msg->message() == "Field \"x\" initialized out of order");
-  assert(msg->location(ctx).firstLine() == 13);
+  assert(msg->location(context).firstLine() == 7);
   assert(guard.realizeErrors());
 }
 
 static void testInitCondBasic(void) {
-  Context context;
-  Context* ctx = &context;
-  ErrorGuard guard(ctx);
+  auto context = buildStdContext();
+  ErrorGuard guard(context);
 
-  auto path = TEST_NAME(ctx);
-  std::string contents = otherOps + R""""(
+  auto path = TEST_NAME(context);
+  std::string contents = R""""(
     record r {
       var x: int;
       var y : int;
@@ -412,16 +394,16 @@ static void testInitCondBasic(void) {
     var obj = new r(false);
     )"""";
 
-  setFileText(ctx, path, contents);
+  setFileText(context, path, contents);
 
   // Get the module.
-  auto& br = parseAndReportErrors(ctx, path);
+  auto& br = parseAndReportErrors(context, path);
   assert(br.numTopLevelExpressions() == 1);
   auto mod = br.topLevelExpression(0)->toModule();
   assert(mod);
 
   // Resolve the module.
-  std::ignore = resolveModule(ctx, mod->id());
+  std::ignore = resolveModule(context, mod->id());
 
   assert(guard.errors().size() == 0);
 
@@ -430,12 +412,11 @@ static void testInitCondBasic(void) {
 }
 
 static void testInitCondBadOrder(void) {
-  Context context;
-  Context* ctx = &context;
-  ErrorGuard guard(ctx);
+  auto context = buildStdContext();
+  ErrorGuard guard(context);
 
-  auto path = TEST_NAME(ctx);
-  std::string contents = otherOps + R""""(
+  auto path = TEST_NAME(context);
+  std::string contents = R""""(
     record r {
       var x: int;
       var y : int;
@@ -452,43 +433,38 @@ static void testInitCondBadOrder(void) {
     var obj = new r(false);
     )"""";
 
-  setFileText(ctx, path, contents);
+  setFileText(context, path, contents);
 
   // Get the module.
-  auto& br = parseAndReportErrors(ctx, path);
+  auto& br = parseAndReportErrors(context, path);
   assert(br.numTopLevelExpressions() == 1);
   auto mod = br.topLevelExpression(0)->toModule();
   assert(mod);
 
   // Resolve the module.
-  std::ignore = resolveModule(ctx, mod->id());
+  std::ignore = resolveModule(context, mod->id());
 
   assert(guard.errors().size() == 2);
 
   {
     auto& msg = guard.errors()[0];
     assert(msg->message() == "Field \"x\" initialized out of order");
-    assert(msg->location(ctx).firstLine() == 16);
+    assert(msg->location(context).firstLine() == 10);
   }
   {
     auto& msg = guard.errors()[1];
     assert(msg->message() == "Field \"y\" initialized out of order");
-    assert(msg->location(ctx).firstLine() == 18);
+    assert(msg->location(context).firstLine() == 12);
   }
   assert(guard.realizeErrors());
 }
 
 static void testInitCondGenericDiff(void) {
-  Context context;
-  Context* ctx = &context;
-  ErrorGuard guard(ctx);
+  auto context = buildStdContext();
+  ErrorGuard guard(context);
 
-  auto path = TEST_NAME(ctx);
+  auto path = TEST_NAME(context);
   std::string contents = R""""(
-    operator >(const lhs : int, const rhs : int) {
-      return __primitive(">", lhs, rhs);
-    }
-
     record R {
       type T;
       param P : int;
@@ -508,37 +484,32 @@ static void testInitCondGenericDiff(void) {
     var r = new R(int, 11);
     )"""";
 
-  setFileText(ctx, path, contents);
+  setFileText(context, path, contents);
 
   // Get the module.
-  auto& br = parseAndReportErrors(ctx, path);
+  auto& br = parseAndReportErrors(context, path);
   assert(br.numTopLevelExpressions() == 1);
   auto mod = br.topLevelExpression(0)->toModule();
   assert(mod);
 
   // Resolve the module.
-  std::ignore = resolveModule(ctx, mod->id());
+  std::ignore = resolveModule(context, mod->id());
 
   assert(guard.errors().size() == 1);
 
   // Check the first error to see if it lines up.
   auto& msg = guard.errors()[0];
   assert(msg->message() == "Initializer must compute the same type in each branch");
-  assert(msg->location(ctx).firstLine() == 10);
+  assert(msg->location(context).firstLine() == 6);
   assert(guard.realizeErrors());
 }
 
 static void testInitCondGeneric(void) {
-  Context context;
-  Context* ctx = &context;
-  ErrorGuard guard(ctx);
+  auto context = buildStdContext();
+  ErrorGuard guard(context);
 
-  auto path = TEST_NAME(ctx);
+  auto path = TEST_NAME(context);
   std::string contents = R""""(
-    operator >(const lhs : int, const rhs : int) {
-      return __primitive(">", lhs, rhs);
-    }
-
     record R {
       type T;
       param P : int;
@@ -558,31 +529,26 @@ static void testInitCondGeneric(void) {
     var r = new R(int, 11);
     )"""";
 
-  setFileText(ctx, path, contents);
+  setFileText(context, path, contents);
 
   // Get the module.
-  auto& br = parseAndReportErrors(ctx, path);
+  auto& br = parseAndReportErrors(context, path);
   assert(br.numTopLevelExpressions() == 1);
   auto mod = br.topLevelExpression(0)->toModule();
   assert(mod);
 
   // Resolve the module.
-  std::ignore = resolveModule(ctx, mod->id());
+  std::ignore = resolveModule(context, mod->id());
 
   assert(guard.errors().size() == 0);
 }
 
 static void testInitParamCondGeneric(void) {
-  Context context;
-  Context* ctx = &context;
-  ErrorGuard guard(ctx);
+  auto context = buildStdContext();
+  ErrorGuard guard(context);
 
-  auto path = UniqueString::get(ctx, "mod");
+  auto path = UniqueString::get(context, "mod");
   std::string contents = R""""(
-    operator >(const lhs : int, const rhs : int) {
-      return __primitive(">", lhs, rhs);
-    }
-
     record R {
       type T;
       param P : int;
@@ -606,42 +572,41 @@ static void testInitParamCondGeneric(void) {
     type Y = R(int, 5);
     )"""";
 
-  setFileText(ctx, path, contents);
+  setFileText(context, path, contents);
 
   // Get the module.
-  auto& br = parseAndReportErrors(ctx, path);
+  auto& br = parseAndReportErrors(context, path);
   assert(br.numTopLevelExpressions() == 1);
   auto mod = br.topLevelExpression(0)->toModule();
   assert(mod);
 
   // Resolve the module.
-  const ResolutionResultByPostorderID& rr = resolveModule(ctx, mod->id());
+  const ResolutionResultByPostorderID& rr = resolveModule(context, mod->id());
 
   assert(guard.errors().size() == 0);
 
   {
-    auto t = mod->stmt(2)->toVariable();
+    auto t = mod->stmt(1)->toVariable();
     auto tType = rr.byAst(t).type();
-    auto X = mod->stmt(4)->toVariable();
+    auto X = mod->stmt(3)->toVariable();
     auto XType = rr.byAst(X).type();
     assert(tType.type() == XType.type());
   }
   {
-    auto f = mod->stmt(3)->toVariable();
+    auto f = mod->stmt(2)->toVariable();
     auto fType = rr.byAst(f).type();
-    auto Y = mod->stmt(5)->toVariable();
+    auto Y = mod->stmt(4)->toVariable();
     auto YType = rr.byAst(Y).type();
     assert(fType.type() == YType.type());
   }
 }
 
 static void testNotThisDot(void) {
-  Context context;
-  Context* ctx = &context;
-  ErrorGuard guard(ctx);
+  auto context = buildStdContext();
+  ErrorGuard guard(context);
 
-  auto path = TEST_NAME(ctx);
-  std::string contents = otherOps + R""""(
+  auto path = TEST_NAME(context);
+  std::string contents = R""""(
     record X {
       proc type foo() {
         return 5;
@@ -663,22 +628,21 @@ static void testNotThisDot(void) {
     var r : R;
     )"""";
 
-  setFileText(ctx, path, contents);
+  setFileText(context, path, contents);
 
   // Get the module.
-  auto& br = parseAndReportErrors(ctx, path);
+  auto& br = parseAndReportErrors(context, path);
   assert(br.numTopLevelExpressions() == 1);
   auto mod = br.topLevelExpression(0)->toModule();
   assert(mod);
 
   // Resolve the module.
-  std::ignore = resolveModule(ctx, mod->id());
+  std::ignore = resolveModule(context, mod->id());
 }
 
 static void testRelevantInit(void) {
-  Context context;
-  Context* ctx = &context;
-  ErrorGuard guard(ctx);
+  auto context = buildStdContext();
+  ErrorGuard guard(context);
 
   //
   // Based on behavior implemented by production compiler back in:
@@ -690,14 +654,10 @@ static void testRelevantInit(void) {
   // resolve 'X.init' and 'R.init' for the formal 'x' in 'R.init'.
   //
 
-  auto path = TEST_NAME(ctx);
-  std::string contents = otherOps + R""""(
+  auto path = TEST_NAME(context);
+  std::string contents = R""""(
     record X {
       var val : int;
-    }
-
-    operator =(ref lhs: X, const rhs: X) {
-      lhs.val = rhs.val;
     }
 
     record R {
@@ -711,22 +671,21 @@ static void testRelevantInit(void) {
     var r: R;
     )"""";
 
-  setFileText(ctx, path, contents);
+  setFileText(context, path, contents);
 
   // Get the module.
-  auto& br = parseAndReportErrors(ctx, path);
+  auto& br = parseAndReportErrors(context, path);
   assert(br.numTopLevelExpressions() == 1);
   auto mod = br.topLevelExpression(0)->toModule();
   assert(mod);
 
   // Resolve the module.
-  std::ignore = resolveModule(ctx, mod->id());
+  std::ignore = resolveModule(context, mod->id());
 }
 
 static void testOwnedUserInit(void) {
-  Context context;
-  Context* ctx = &context;
-  ErrorGuard guard(ctx);
+  auto context = buildStdContext();
+  ErrorGuard guard(context);
 
   // Ensure we can resolve a user-defined initializer call for an owned class,
   // which requires an implicit borrowing conversion of the receiver from owned
@@ -734,8 +693,8 @@ static void testOwnedUserInit(void) {
   // also defines an init, to ensure implicit subtype conversion to the parent
   // class doesn't make it a candidate.
 
-  auto path = TEST_NAME(ctx);
-  std::string contents = otherOps + R""""(
+  auto path = TEST_NAME(context);
+  std::string contents = R""""(
     class Parent {
       proc init() {}
     }
@@ -747,16 +706,16 @@ static void testOwnedUserInit(void) {
     var c = new owned Child();
     )"""";
 
-  setFileText(ctx, path, contents);
+  setFileText(context, path, contents);
 
   // Get the module.
-  auto& br = parseAndReportErrors(ctx, path);
+  auto& br = parseAndReportErrors(context, path);
   assert(br.numTopLevelExpressions() == 1);
   auto mod = br.topLevelExpression(0)->toModule();
   assert(mod);
 
   // Resolve the module.
-  std::ignore = resolveModule(ctx, mod->id());
+  std::ignore = resolveModule(context, mod->id());
 }
 
 // Replaces a placeholder with possible values to help test more programs.
@@ -826,8 +785,7 @@ static void testInitFromInit(void) {
       )""";
 
   for (auto version : getAllVersions(prog)) {
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     ErrorGuard guard(context);
     auto qt = resolveTypeOfXInit(context, version);
 
@@ -888,8 +846,7 @@ static void testInitInParamBranchFromInit(void) {
 
 
   for (auto version : getAllVersions(prog)) {
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     ErrorGuard guard(context);
 
     auto qts = resolveTypesOfVariables(context, version, {"x", "y"});
@@ -973,8 +930,7 @@ static void testInitInBranchFromInit(void) {
 
   for (auto version : getAllVersions(prog)) {
     // test calling 'this.init' from another initializer.
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     ErrorGuard guard(context);
 
     auto qts = resolveTypesOfVariables(context, version, {"x", "y"});
@@ -1066,8 +1022,7 @@ static void testBadInitInBranchFromInit(void) {
 
   for (auto version : getAllVersions(prog)) {
     // test calling 'this.init' from another initializer.
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     ErrorGuard guard(context);
 
     std::ignore = resolveTypeOfXInit(context, version);
@@ -1100,8 +1055,7 @@ static void testAssignThenInit(void) {
 
   for (auto version : getAllVersions(prog)) {
     // test calling 'this.init' from another initializer.
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     ErrorGuard guard(context);
 
     std::ignore = resolveTypeOfXInit(context, version);
@@ -1117,12 +1071,7 @@ static void testAssignThenInit(void) {
 }
 
 static void testUseAfterInit() {
-  std::string program = otherOps + R"""(
-    operator *(const ref lhs: real, const rhs : int) : real {
-      var ret : real;
-      return ret;
-    }
-
+  std::string program = R"""(
     class PointDoubleX {
       var a, b : real;
 
@@ -1140,19 +1089,17 @@ static void testUseAfterInit() {
     var x = new PointDoubleX(1.0, 2.0);
   )""";
 
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   std::ignore = resolveTypeOfX(context, program);
 }
 
 static void testInitEqOther(void) {
-  Context context;
-  Context* ctx = &context;
-  ErrorGuard guard(ctx);
+  auto context = buildStdContext();
+  ErrorGuard guard(context);
 
-  std::string program = otherOps + R"""(
+  std::string program = R"""(
     record R {
       type T;
       var field : T;
@@ -1169,7 +1116,7 @@ static void testInitEqOther(void) {
     var y:R(?) = 42.0;
   )""";
 
-  auto results = resolveTypesOfVariables(ctx, program, {"x", "y"});
+  auto results = resolveTypesOfVariables(context, program, {"x", "y"});
   auto xt = results["x"];
   assert(xt.type()->isRecordType());
   std::stringstream ss;
@@ -1209,8 +1156,7 @@ static void testInheritance() {
 
   // basic usage
   {
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     ErrorGuard guard(context);
 
     std::string program = parentChild + grandparent + R"""(
@@ -1230,8 +1176,7 @@ static void testInheritance() {
 
   // named arguments
   {
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     ErrorGuard guard(context);
 
     std::string program = parentChild + grandparent + R"""(
@@ -1251,8 +1196,7 @@ static void testInheritance() {
 
   // user-defined parent initializer
   {
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     ErrorGuard guard(context);
 
     std::string program = parentChild + R"""(
@@ -1266,8 +1210,7 @@ static void testInheritance() {
     std::ignore = resolveModule(context, m->id());
   }
   {
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     ErrorGuard guard(context);
 
     std::string program = grandparent + R"""(
@@ -1282,8 +1225,7 @@ static void testInheritance() {
     std::ignore = resolveModule(context, m->id());
   }
   {
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     ErrorGuard guard(context);
 
     std::string program = grandparent + R"""(
@@ -1299,8 +1241,7 @@ static void testInheritance() {
 
   // super.init example
   {
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     ErrorGuard guard(context);
 
     std::string program = grandparent + R"""(
@@ -1317,17 +1258,12 @@ static void testInheritance() {
 
   // Allow parent field access with implicit super.init
   {
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     ErrorGuard guard(context);
 
-    std::string program = otherOps + R"""(
+    std::string program = R"""(
       class Parent { var x : int; }
       class Child : Parent { var y : real; }
-
-      operator *(const lhs: int, rhs: real) : real {
-        return __primitive("*", lhs, rhs);
-      }
 
       proc Child.init() {
         this.y = x * 42.0;
@@ -1341,17 +1277,12 @@ static void testInheritance() {
 
   // Error for accessing parent field before super.init
   {
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     ErrorGuard guard(context);
 
-    std::string program = otherOps + R"""(
+    std::string program = R"""(
       class Parent { var x : int; }
       class Child : Parent { var y : real; }
-
-      operator *(const lhs: int, rhs: real) : real {
-        return __primitive("*", lhs, rhs);
-      }
 
       proc Child.init() {
         this.x = 42;
@@ -1383,8 +1314,7 @@ static void testInheritance() {
 
   // Basic generic case
   {
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     ErrorGuard guard(context);
 
     std::string program = R"""(
@@ -1420,8 +1350,7 @@ static void testInheritance() {
 
   // Generic parent, concrete child
   {
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     ErrorGuard guard(context);
 
     std::string program = R"""(
@@ -1454,8 +1383,7 @@ static void testInheritance() {
 
   // Generic grandparent, concrete parent, concrete child
   {
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     ErrorGuard guard(context);
 
     std::string program = R"""(
@@ -1494,11 +1422,10 @@ static void testInheritance() {
 
   // Default initializer
   {
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     ErrorGuard guard(context);
 
-    std::string program = otherOps + R"""(
+    std::string program = R"""(
       class A {
         type TA;
         var a : TA;
@@ -1520,8 +1447,7 @@ static void testInheritance() {
 
   // Default initializer when parent has user-defined initializer
   {
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     ErrorGuard guard(context);
 
     std::string program = R"""(
@@ -1557,8 +1483,7 @@ static void testInheritance() {
 
   // Default initializer when grandparent has user-defined initializer
   {
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     ErrorGuard guard(context);
 
     std::string program = R"""(
@@ -1602,8 +1527,7 @@ static void testInheritance() {
   // Make sure that existence of an interface in the inherit-exprs list
   // does not cause a super.init call to be generated.
   {
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     ErrorGuard guard(context);
 
     std::string program = R"""(
@@ -1625,7 +1549,7 @@ static void testImplicitSuperInit() {
   // Ensure we resolve the body of implicit super.init() calls
   {
     // use 'test' to ensure 'q' has the right type
-    std::string program = otherOps + R"""(
+    std::string program = R"""(
       proc test(arg: uint) {}
 
       class A {
@@ -1661,8 +1585,7 @@ static void testImplicitSuperInit() {
       var y = new B("");
     )""";
 
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     ErrorGuard guard(context);
 
     auto vars = resolveTypesOfVariables(context, program, {"x", "y"});
@@ -1685,7 +1608,7 @@ static void testImplicitSuperInit() {
 static void testInitGenericAfterConcrete() {
   // With generic var initialized properly
   {
-    std::string program = otherOps + R"""(
+    std::string program = R"""(
       record Foo {
         var a:int;
         var b;
@@ -1699,8 +1622,7 @@ static void testInitGenericAfterConcrete() {
       var x = myFoo.b;
     )""";
 
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     auto t = resolveTypeOfX(context, program);
 
     assert(t);
@@ -1709,7 +1631,7 @@ static void testInitGenericAfterConcrete() {
 
   // With generic var not initialized, so not enough info
   {
-    std::string program = otherOps + R"""(
+    std::string program = R"""(
       record Foo {
         var a:int;
         var b;
@@ -1722,8 +1644,7 @@ static void testInitGenericAfterConcrete() {
       var x = myFoo.b;
     )""";
 
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     ErrorGuard guard(context);
     auto t = resolveTypeOfX(context, program);
 

--- a/frontend/test/resolution/testInitSemantics.cpp
+++ b/frontend/test/resolution/testInitSemantics.cpp
@@ -1682,10 +1682,7 @@ static void testNilFieldInit() {
     var a = test();
     var b = new R();
   )""";
-  auto config = getConfigWithHome();
-  Context ctx(config);
-  Context* context = &ctx;
-  setupModuleSearchPaths(context, false, false, {}, {});
+  Context* context = buildStdContext();
   ErrorGuard guard(context);
 
   auto vars = resolveTypesOfVariables(context, program, {"a", "b"});
@@ -1710,10 +1707,7 @@ static void testGenericFieldInit() {
       var c = new R("test");
       )""";
 
-    auto config = getConfigWithHome();
-    Context ctx(config);
-    Context* context = &ctx;
-    setupModuleSearchPaths(context, false, false, {}, {});
+    Context* context = buildStdContext();
     ErrorGuard guard(context);
 
     auto vars = resolveTypesOfVariables(context, program, {"a", "b", "c"});
@@ -1746,10 +1740,7 @@ static void testGenericFieldInit() {
 
       var r  = new R();
       )""";
-    auto config = getConfigWithHome();
-    Context ctx(config);
-    Context* context = &ctx;
-    setupModuleSearchPaths(context, false, false, {}, {});
+    Context* context = buildStdContext();
     ErrorGuard guard(context);
 
     auto vars = resolveTypesOfVariables(context, program, {"r"});
@@ -1765,6 +1756,7 @@ static void testGenericFieldInit() {
     guard.realizeErrors();
   }
   {
+    printf("one\n");
     std::string program = R"""(
       record G { type T; var x : T; }
 
@@ -1802,8 +1794,7 @@ static void testGenericFieldInit() {
       var c = test("test");
       )""";
 
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     ErrorGuard guard(context);
 
     auto vars = resolveTypesOfVariables(context, program, {"a", "b", "c"});

--- a/frontend/test/resolution/testIterators.cpp
+++ b/frontend/test/resolution/testIterators.cpp
@@ -426,12 +426,12 @@ static void testNewShadowCandidates(Context* context) {
 }
 
 int main() {
-  auto ctx = buildStdContext();
-  testStandaloneWithoutSerial(ctx.get());
-  testLeaderFollowerWithoutSerial(ctx.get());
-  testIncompatibleYieldTypes(ctx.get());
-  testIteratorFnPoi(ctx.get());
-  testIteratorFnPoiIgnoresIterationScope(ctx.get());
-  testLoopExprIteratorPoi(ctx.get());
-  testNewShadowCandidates(ctx.get());
+  auto context = buildStdContext();
+  testStandaloneWithoutSerial(context);
+  testLeaderFollowerWithoutSerial(context);
+  testIncompatibleYieldTypes(context);
+  testIteratorFnPoi(context);
+  testIteratorFnPoiIgnoresIterationScope(context);
+  testLoopExprIteratorPoi(context);
+  testNewShadowCandidates(context);
 }

--- a/frontend/test/resolution/testLoopIndexVars.cpp
+++ b/frontend/test/resolution/testLoopIndexVars.cpp
@@ -88,8 +88,7 @@ struct ParamCollector {
 
 static void testSimpleLoop(std::string loopName) {
   printf("testing simple loop '%s'\n", loopName.c_str());
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto loopText = myiter + loopName +
 R"""( i in myiter() {
@@ -123,8 +122,7 @@ R"""( i in myiter() {
 
 static void testAmbiguous() {
   printf("testAmbiguous\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   //
@@ -151,8 +149,7 @@ static void testAmbiguous() {
 
 static void testThese() {
   printf("testThese\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   //
@@ -176,8 +173,7 @@ static void testThese() {
 
 static void testTheseReturn() {
   printf("testTheseReturn\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   //
@@ -203,8 +199,7 @@ static void testTheseReturn() {
 
 static void testNoThese() {
   printf("testNoThese\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   //
@@ -229,8 +224,7 @@ static void testNoThese() {
 
 static void testAmbiguousThese() {
   printf("testAmbiguousThese\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   //
@@ -261,8 +255,7 @@ static void testAmbiguousThese() {
 
 static void testNoIndex() {
   printf("testNoIndex\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   auto iterText = myiter +
@@ -277,8 +270,7 @@ static void testNoIndex() {
 
 static void testTheseNoIndex() {
   printf("testTheseNoIndex\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   auto theseText = recIter +
@@ -306,8 +298,7 @@ static void testTheseNoIndex() {
 
 static void testCForLoop() {
   printf("testCForLoop\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
   ResolutionContext rcval(context);
   auto rc = &rcval;
@@ -345,8 +336,7 @@ static void testCForLoop() {
 
 static void testParamFor() {
   printf("testParamFor\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
   ResolutionContext rcval(context);
   //
@@ -390,8 +380,7 @@ static void testParamFor() {
 //
 static void testNestedParamFor() {
   printf("testNestedParamFor\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
   ResolutionContext rcval(context);
   auto rc = &rcval;
@@ -446,8 +435,7 @@ static void testNestedParamFor() {
 
 static void testIndexScope0() {
   printf("testIndexScope0\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   //
@@ -477,8 +465,7 @@ static void testIndexScope0() {
 
 static void testIndexScope1() {
   printf("testIndexScope1\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   // Ensure that each mention of 'i' refers to the correct index variable.

--- a/frontend/test/resolution/testLoopIndexVars.cpp
+++ b/frontend/test/resolution/testLoopIndexVars.cpp
@@ -1079,8 +1079,7 @@ int main() {
   testIndexScope1();
 
   // Use a single context instance to avoid re-resolving internal modules.
-  auto ctx = buildStdContext();
-  Context* context = ctx.get();
+  auto context = buildStdContext();
   testIterSigDetection(context);
   testExplicitTaggedIter(context);
   testSerialZip(context);

--- a/frontend/test/resolution/testMaybeConst.cpp
+++ b/frontend/test/resolution/testMaybeConst.cpp
@@ -39,8 +39,7 @@ testMaybeRef(const char* test,
              bool expectErrors=false) {
   printf("\n### %s\n", test);
 
-  Context ctx;
-  Context* context = &ctx;
+  Context* context = buildStdContext();
   ErrorGuard guard(context);
 
   ResolutionContext rcval(context);
@@ -278,7 +277,6 @@ static void test3h() {
   testMaybeRef("test3h",
     R""""(
       module M {
-        operator =(ref lhs: int, rhs: int) {}
         var global: int;
         proc foo() ref { return global; }         // M.foo
         proc foo() const ref { return global; }   // M.foo#1
@@ -296,7 +294,6 @@ static void test3i() {
   testMaybeRef("test3i",
     R""""(
       module M {
-        operator =(ref lhs: int, rhs: int) {}
         var global: int;
         proc foo() ref { return global; }         // M.foo
         proc foo() const ref { return global; }   // M.foo#1
@@ -430,7 +427,6 @@ static void test4h() {
   testMaybeRef("test4h",
     R""""(
       module M {
-        operator =(ref lhs: int, rhs: int) {}
         var global: int;
         proc foo() ref { return global; }         // M.foo
         proc foo() { return global; }             // M.foo#1
@@ -448,7 +444,6 @@ static void test4i() {
   testMaybeRef("test4i",
     R""""(
       module M {
-        operator =(ref lhs: int, rhs: int) {}
         var global: int;
         proc foo() ref { return global; }         // M.foo
         proc foo() { return global; }             // M.foo#1
@@ -743,7 +738,6 @@ static void test6h() {
   testMaybeRef("test6h",
     R""""(
       module M {
-        operator =(ref lhs: int, rhs: int) {}
         var global: int;
         proc foo() const ref { return global; }     // M.foo
         proc foo() { return global; }               // M.foo#1
@@ -762,7 +756,6 @@ static void test6i() {
   testMaybeRef("test6i",
     R""""(
       module M {
-        operator =(ref lhs: int, rhs: int) {}
         var global: int;
         proc foo() ref { return global; }        // M.foo
         proc foo() const ref { return global; }  // M.foo#1

--- a/frontend/test/resolution/testMethodCalls.cpp
+++ b/frontend/test/resolution/testMethodCalls.cpp
@@ -29,8 +29,7 @@
 
 // Test resolving a simple primary and secondary method in defining scope.
 static void test1() {
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   auto path = UniqueString::get(context, "test1.chpl");
@@ -106,8 +105,7 @@ static void test1() {
 
 // Similar test but for parenless methods.
 static void test2() {
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   auto path = UniqueString::get(context, "test2.chpl");
@@ -183,8 +181,7 @@ static void test2() {
 // test case to lock in correct behavior w.r.t. T being both a
 // field and a formal.
 static void test3() {
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   const char* contents = R""""(
@@ -206,8 +203,7 @@ static void test3() {
 }
 
 static void test4() {
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   auto path = UniqueString::get(context, "test4.chpl");
@@ -267,8 +263,7 @@ static void test4() {
 
 // Test a field being named the same as the record.
 static void test5() {
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   auto path = UniqueString::get(context, "test5.chpl");
@@ -322,8 +317,7 @@ static void test5() {
 }
 
 static void test6() {
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   std::string program =
@@ -350,8 +344,7 @@ static void test6() {
 
 static void test7() {
   {
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     ErrorGuard guard(context);
 
     std::string program =
@@ -369,8 +362,7 @@ static void test7() {
     assert(initType.type()->isIntType());
   }
   {
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     ErrorGuard guard(context);
 
     std::string program =
@@ -392,8 +384,7 @@ static void test7() {
 
 static void runAndAssert(std::string program,
                          std::function<bool(QualifiedType)> fn) {
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
   QualifiedType initType = resolveTypeOfXInit(context, program);
   //assert(initType.type()->isStringType());
@@ -483,8 +474,7 @@ static void test8() {
   // Ensure that methods whose where-clause always results in 'false' cannot
   // be called.
   {
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     ErrorGuard guard(context);
 
     std::string program = base + R""""(
@@ -501,8 +491,7 @@ static void test8() {
 }
 
 static void test9() {
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   std::string program = R"""(
@@ -539,8 +528,7 @@ static void test9() {
 static void test10() {
   // Ensure that secondary methods like 'proc x.myMethod()' are generic
   // even if 'x' is generic-with-defaults.
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   std::string program = R"""(
@@ -573,8 +561,7 @@ static void test10() {
 static void test11() {
   // Type method calls are allowed on nilable classes; their receiver should
   // be generic over nilability and management.
-  Context ctx;
-  Context* context = &ctx;
+  Context* context = buildStdContext();
   ErrorGuard guard(context);
 
   std::string program = R"""(
@@ -599,8 +586,7 @@ static void test11() {
 }
 
 static void test12() {
-  Context ctx;
-  Context* context = &ctx;
+  Context* context = buildStdContext();
   ErrorGuard guard(context);
 
   std::string program = R"""(
@@ -633,8 +619,7 @@ static void test12() {
 static void test13() {
   // Test fields that are deemed concrete by the initial type constructor
   // logic but are then discovered to be generic (this should produce errors).
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   std::string program = R"""(
@@ -671,8 +656,7 @@ static void test14() {
   // fields of parent class Bar aren't instantiated yet. A robust check
   // (locked down by this issue) must ensure that all parent classes are
   // fully instantiated before issuing the error.
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   std::string program = R"""(
@@ -705,8 +689,7 @@ static void test14() {
 static void test14b() {
   // Test that the error from test13 is correctly emitted when inheritance
   // is in play.
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   std::string program = R"""(
@@ -744,8 +727,7 @@ static void test16() {
 
   {
     // For automatic variable
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     ErrorGuard guard(context);
 
     std::string program = R"""(
@@ -770,8 +752,7 @@ static void test16() {
 
   {
     // For formal
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     ErrorGuard guard(context);
 
     std::string program = R"""(
@@ -800,8 +781,7 @@ static void test17() {
 
   // Parenful
   {
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     ErrorGuard guard(context);
 
     std::string program = R"""(
@@ -827,8 +807,7 @@ static void test17() {
 
   // Parenless
   {
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     ErrorGuard guard(context);
 
     std::string program = R"""(

--- a/frontend/test/resolution/testMethodFieldAccess.cpp
+++ b/frontend/test/resolution/testMethodFieldAccess.cpp
@@ -40,8 +40,7 @@ static void testIt(const char* testName,
                    const char* fieldIdStr,
                    bool scopeResolveOnly=false) {
   printf("test %s\n", testName);
-  Context ctx;
-  Context* context = &ctx;
+  Context* context = buildStdContext();
 
   auto path = UniqueString::get(context, testName);
   std::string contents = program;

--- a/frontend/test/resolution/testNestedFunctions.cpp
+++ b/frontend/test/resolution/testNestedFunctions.cpp
@@ -560,7 +560,7 @@ static void test13(Context* ctx) {
 
 int main() {
   auto context = buildStdContext();
-  Context* ctx = turnOnWarnUnstable(context.get());
+  Context* ctx = turnOnWarnUnstable(context);
 
   test0(ctx);
   test1(ctx);

--- a/frontend/test/resolution/testNew.cpp
+++ b/frontend/test/resolution/testNew.cpp
@@ -158,8 +158,7 @@ static void testEmptyRecordCompilerGenInit() {
 }
 
 static void testTertMethodCallCrossModule() {
-  Context context;
-  Context* ctx = &context;
+  Context* ctx = buildStdContext();
   ErrorGuard guard(ctx);
 
   auto path = TEST_NAME(ctx);

--- a/frontend/test/resolution/testNew.cpp
+++ b/frontend/test/resolution/testNew.cpp
@@ -401,16 +401,11 @@ static void testClassManagementNilabilityInNewExpr() {
 }
 
 static void testGenericRecordUserInitDependentField() {
-  Context context;
-  Context* ctx = &context;
-  ErrorGuard guard(ctx);
+  Context* context = buildStdContext();
+  ErrorGuard guard(context);
 
-  auto path = TEST_NAME(ctx);
+  auto path = TEST_NAME(context);
   std::string contents = R""""(
-    operator =(ref lhs: int, rhs: int) {
-      __primitive("=", lhs, rhs);
-    }
-
     record r {
       type f1;
       param f2: int;
@@ -423,23 +418,23 @@ static void testGenericRecordUserInitDependentField() {
     var obj = new r(int, 8);
     )"""";
 
-  setFileText(ctx, path, contents);
+  setFileText(context, path, contents);
 
   // Get the module and the UAST we need.
-  auto& br = parseAndReportErrors(ctx, path);
+  auto& br = parseAndReportErrors(context, path);
   assert(!guard.realizeErrors());
 
   assert(br.numTopLevelExpressions() == 1);
   auto mod = br.singleModule();
   assert(mod);
-  assert(mod->numStmts() == 3);
-  auto rec = mod->stmt(1)->toRecord();
+  assert(mod->numStmts() == 2);
+  auto rec = mod->stmt(0)->toRecord();
   assert(rec);
-  auto obj = mod->stmt(2)->toVariable();
+  auto obj = mod->stmt(1)->toVariable();
   assert(obj);
 
   // Resolve the module.
-  auto& rr = resolveModule(ctx, mod->id());
+  auto& rr = resolveModule(context, mod->id());
 
   // Inspect the type of the variable 'obj'.
   auto& reObj = rr.byAst(obj);
@@ -454,41 +449,41 @@ static void testGenericRecordUserInitDependentField() {
   assert(rt->substitutions().size() == 2);
 
   // Check the first field of the instantiated record via substitutions.
-  auto idf1 = parsing::fieldIdWithName(ctx, rt->id(),
-                                       UniqueString::get(ctx, "f1"));
+  auto idf1 = parsing::fieldIdWithName(context, rt->id(),
+                                       UniqueString::get(context, "f1"));
   assert(!idf1.isEmpty());
   auto qtf1 = rt->substitution(idf1);
   assert(qtf1.kind() == QualifiedType::TYPE);
-  assert(qtf1.type() == IntType::get(ctx, 0));
+  assert(qtf1.type() == IntType::get(context, 0));
   assert(qtf1.param() == nullptr);
 
   // Check the second field of the instantiated record via substitutions.
-  auto idf2 = parsing::fieldIdWithName(ctx, rt->id(),
-                                       UniqueString::get(ctx, "f2"));
+  auto idf2 = parsing::fieldIdWithName(context, rt->id(),
+                                       UniqueString::get(context, "f2"));
   assert(!idf2.isEmpty());
   auto qtf2 = rt->substitution(idf2);
   assert(qtf2.kind() == QualifiedType::PARAM);
-  assert(qtf2.type() == IntType::get(ctx, 0));
+  assert(qtf2.type() == IntType::get(context, 0));
   assert(qtf2.param()->isIntParam());
   assert(qtf2.param()->toIntParam()->value() == 8);
 
   // Now check all fields via the resolved fields query.
-  auto& rf = fieldsForTypeDecl(ctx, rt, DefaultsPolicy::USE_DEFAULTS);
+  auto& rf = fieldsForTypeDecl(context, rt, DefaultsPolicy::USE_DEFAULTS);
   assert(rf.numFields() == 3);
   assert(!rf.isGeneric());
   assert(!rf.isGenericWithDefaults());
 
   // First field is 'type int(64)'
-  auto ft1 = QualifiedType(QualifiedType::TYPE, IntType::get(ctx, 0));
+  auto ft1 = QualifiedType(QualifiedType::TYPE, IntType::get(context, 0));
   assert(rf.fieldType(0) == ft1);
 
   // Second is 'param int = 8'
-  auto ft2 = QualifiedType(QualifiedType::PARAM, IntType::get(ctx, 0),
-                           IntParam::get(ctx, 8));
+  auto ft2 = QualifiedType(QualifiedType::PARAM, IntType::get(context, 0),
+                           IntParam::get(context, 8));
   assert(rf.fieldType(1) == ft2);
 
   // Last is 'var int'
-  auto ft3 = QualifiedType(QualifiedType::VAR, IntType::get(ctx, 0));
+  auto ft3 = QualifiedType(QualifiedType::VAR, IntType::get(context, 0));
   assert(rf.fieldType(2) == ft3);
 
   // Confirm that the TFS for the initializer is correct.
@@ -637,14 +632,11 @@ static void testNewGenericWithDefaults() {
 }
 
 static void testCompilerGeneratedGenericNewWithDefaultInit() {
-  Context ctx;
-  Context* context = &ctx;
+  Context* context = buildStdContext();
   ErrorGuard guard(context);
 
   auto vars = resolveTypesOfVariables(context,
     R"""(
-    operator =(ref lhs: int, const rhs: int) {}
-    operator =(ref lhs: real, const rhs: real) {}
     record r {
       param flag : bool;
       var x : if flag then int else real;
@@ -693,14 +685,11 @@ static void testCompilerGeneratedGenericNewWithDefaultInit() {
 }
 
 static void testCompilerGeneratedGenericNew() {
-  Context ctx;
-  Context* context = &ctx;
+  Context* context = buildStdContext();
   ErrorGuard guard(context);
 
   auto vars = resolveTypesOfVariables(context,
     R"""(
-    operator =(ref lhs: int, const rhs: int) {}
-    operator =(ref lhs: real, const rhs: real) {}
     record r {
       param flag : bool;
       var x : if flag then int else real;
@@ -776,14 +765,11 @@ static void testCompilerGeneratedGenericNew() {
 }
 
 static void testCompilerGeneratedGenericNewWithDefaultInitClass() {
-  Context ctx;
-  Context* context = &ctx;
+  Context* context = buildStdContext();
   ErrorGuard guard(context);
 
   auto vars = resolveTypesOfVariables(context,
     R"""(
-    operator =(ref lhs: int, const rhs: int) {}
-    operator =(ref lhs: real, const rhs: real) {}
     class C {
       param flag : bool;
       var x : if flag then int else real;
@@ -836,14 +822,11 @@ static void testCompilerGeneratedGenericNewWithDefaultInitClass() {
 }
 
 static void testCompilerGeneratedGenericNewClass() {
-  Context ctx;
-  Context* context = &ctx;
+  Context* context = buildStdContext();
   ErrorGuard guard(context);
 
   auto vars = resolveTypesOfVariables(context,
     R"""(
-    operator =(ref lhs: int, const rhs: int) {}
-    operator =(ref lhs: real, const rhs: real) {}
     class C {
       param flag : bool;
       var x : if flag then int else real;
@@ -922,17 +905,11 @@ static void testCompilerGeneratedGenericNewClass() {
 }
 
 static void testSimpleUserGenericNew() {
-  Context ctx;
-  Context* context = &ctx;
+  Context* context = buildStdContext();
   ErrorGuard guard(context);
 
   auto vars = resolveTypesOfVariables(context,
     R"""(
-    // Need an operator= for non-compile-time values to be assigned.
-    operator =(ref lhs: numeric, rhs: numeric) {
-      __primitive("=", lhs, rhs);
-    }
-
     class C {
       var x;
 
@@ -980,17 +957,11 @@ static void testSimpleUserGenericNew() {
 }
 
 static void testUserGenericNew() {
-  Context ctx;
-  Context* context = &ctx;
+  Context* context = buildStdContext();
   ErrorGuard guard(context);
 
   auto vars = resolveTypesOfVariables(context,
     R"""(
-    // Need an operator= for non-compile-time values to be assigned.
-    operator =(ref lhs: numeric, rhs: numeric) {
-      __primitive("=", lhs, rhs);
-    }
-
     record r {
       param flag : bool;
       var x : if flag then int else real;

--- a/frontend/test/resolution/testReductions.cpp
+++ b/frontend/test/resolution/testReductions.cpp
@@ -124,8 +124,7 @@ static void test4(Context* context) {
 
 int main() {
   // Use a single context instance to avoid re-resolving internal modules.
-  auto ctx = buildStdContext();
-  Context* context = ctx.get();
+  auto context = buildStdContext();
 
   test1(context);
   test2(context);

--- a/frontend/test/resolution/testReflection.cpp
+++ b/frontend/test/resolution/testReflection.cpp
@@ -30,8 +30,8 @@
 
 // test num fields and field num to name
 static void test1() {
-  Context context;
-  auto variables = resolveTypesOfVariables(&context,
+  auto context = buildStdContext();
+  auto variables = resolveTypesOfVariables(context,
       R"""(
       record R {
          var a, b: int;
@@ -58,8 +58,8 @@ static void test1() {
 //
 // test field num to name
 static void test2() {
-  Context context;
-  auto variables = resolveTypesOfVariables(&context,
+  auto context = buildStdContext();
+  auto variables = resolveTypesOfVariables(context,
       R"""(
       record R {
          var a, b: int;
@@ -84,8 +84,8 @@ static void test2() {
 
 // Test field by num
 static void test3() {
-  Context context;
-  auto variables = resolveTypesOfVariables(&context,
+  auto context = buildStdContext();
+  auto variables = resolveTypesOfVariables(context,
       R"""(
       record R {
          var a, b: int;
@@ -111,8 +111,8 @@ static void test3() {
 
 // Test is bound
 static void test4() {
-  Context context;
-  auto variables = resolveTypesOfVariables(&context,
+  auto context = buildStdContext();
+  auto variables = resolveTypesOfVariables(context,
       R"""(
       record R {
          var a, b: int;
@@ -146,8 +146,8 @@ static void test4() {
 
 // Test call resolves
 static void test5() {
-  Context context;
-  auto variables = resolveTypesOfVariables(&context,
+  auto context = buildStdContext();
+  auto variables = resolveTypesOfVariables(context,
       R"""(
       proc f(x: int) {}
       proc f(x: bool) {}
@@ -177,10 +177,10 @@ static void test5() {
 
 // Test call resolves
 static void test6() {
-  Context context;
+  auto context = buildStdContext();
   // Make sure no errors make it to the user, even though we will get errors.
-  ErrorGuard guard(&context);
-  auto variables = resolveTypesOfVariables(&context,
+  ErrorGuard guard(context);
+  auto variables = resolveTypesOfVariables(context,
       R"""(
       proc f(x: int) {}
       proc f(x: bool) {}
@@ -210,8 +210,8 @@ static void test6() {
 //
 // Test call resolves
 static void test7() {
-  Context context;
-  auto variables = resolveTypesOfVariables(&context,
+  auto context = buildStdContext();
+  auto variables = resolveTypesOfVariables(context,
       R"""(
       record R {
         proc f(x: int) {}
@@ -244,10 +244,10 @@ static void test7() {
 
 // Test call resolves
 static void test8() {
-  Context context;
+  auto context = buildStdContext();
   // Make sure no errors make it to the user, even though we will get errors.
-  ErrorGuard guard(&context);
-  auto variables = resolveTypesOfVariables(&context,
+  ErrorGuard guard(context);
+  auto variables = resolveTypesOfVariables(context,
       R"""(
       record R {
         proc f(x: int) {}
@@ -279,10 +279,10 @@ static void test8() {
 }
 
 static void test9() {
-  Context context;
+  auto context = buildStdContext();
   // Make sure no errors make it to the user, even though we will get errors.
-  ErrorGuard guard(&context);
-  auto variables = resolveTypesOfVariables(&context,
+  ErrorGuard guard(context);
+  auto variables = resolveTypesOfVariables(context,
       R"""(
       record R {
           proc f() {}

--- a/frontend/test/resolution/testResolve.cpp
+++ b/frontend/test/resolution/testResolve.cpp
@@ -1712,14 +1712,13 @@ static void test27() {
 // up in some cases of the query system.
 static void testInfiniteCycleBug() {
   auto context = buildStdContext();
-  auto ctx = context.get();
 
-  ctx->advanceToNextRevision(false);
-  setupModuleSearchPaths(ctx, false, false, {}, {});
+  context->advanceToNextRevision(false);
+  setupModuleSearchPaths(context, false, false, {}, {});
 
   CompilerFlags flags;
   flags.set(CompilerFlags::WARN_UNSTABLE, true);
-  setCompilerFlags(ctx, std::move(flags));
+  setCompilerFlags(context, std::move(flags));
 
   std::string program0 =
     R""""(
@@ -1731,10 +1730,10 @@ static void testInfiniteCycleBug() {
     var x = foo();
     )"""";
 
-  std::ignore = resolveQualifiedTypeOfX(ctx, program0);
+  std::ignore = resolveQualifiedTypeOfX(context, program0);
 
-  ctx->advanceToNextRevision(false);
-  setupModuleSearchPaths(ctx, false, false, {}, {});
+  context->advanceToNextRevision(false);
+  setupModuleSearchPaths(context, false, false, {}, {});
 
   std::string program1 =
     R""""(
@@ -1746,7 +1745,7 @@ static void testInfiniteCycleBug() {
     var x = baz();
     )"""";
 
-  std::ignore = resolveQualifiedTypeOfX(ctx, program1);
+  std::ignore = resolveQualifiedTypeOfX(context, program1);
 }
 
 int main() {

--- a/frontend/test/resolution/testResolve.cpp
+++ b/frontend/test/resolution/testResolve.cpp
@@ -229,8 +229,7 @@ static void test3() {
 // case for instantiation, conversions, and type construction
 static void test4() {
   printf("test4\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto path = UniqueString::get(context, "input.chpl");
   std::string contents = R""""(
@@ -1178,7 +1177,7 @@ static void test22() {
   // Resolve unambiguous call to 'this'.
   {
     printf("part 1\n");
-    context->advanceToNextRevision(true);
+    auto context = buildStdContext();
     ErrorGuard guard(context);
 
     std::string contents =
@@ -1561,11 +1560,9 @@ static void test25() {
 static void test26() {
   // Test resolving a generic type field usage in a method signature.
 
-  Context ctx;
-  Context* context = &ctx;
-  ErrorGuard guard(context);
-
   {
+    Context* context = buildStdContext();
+    ErrorGuard guard(context);
     // 'this' qualified, type field
     std::string prog =
       R"""(
@@ -1581,11 +1578,11 @@ static void test26() {
     auto t = resolveTypeOfXInit(context, prog);
     ensureParamInt(t, 1);
     assert(guard.realizeErrors() == 0);
-
-    context->advanceToNextRevision(false);
   }
 
   {
+    Context* context = buildStdContext();
+    ErrorGuard guard(context);
     // unqualified, type field
     std::string prog =
       R"""(
@@ -1601,11 +1598,11 @@ static void test26() {
     auto t = resolveTypeOfXInit(context, prog);
     ensureParamInt(t, 1);
     assert(guard.realizeErrors() == 0);
-
-    context->advanceToNextRevision(false);
   }
 
   {
+    Context* context = buildStdContext();
+    ErrorGuard guard(context);
     // 'this' qualified, type parenless proc, concrete receiver
     std::string prog =
       R"""(
@@ -1621,11 +1618,11 @@ static void test26() {
     auto t = resolveTypeOfXInit(context, prog);
     ensureParamInt(t, 1);
     assert(guard.realizeErrors() == 0);
-
-    context->advanceToNextRevision(false);
   }
 
   {
+    Context* context = buildStdContext();
+    ErrorGuard guard(context);
     // unqualified, type parenless proc, concrete receiver
     std::string prog =
       R"""(
@@ -1641,11 +1638,11 @@ static void test26() {
     auto t = resolveTypeOfXInit(context, prog);
     ensureParamInt(t, 1);
     assert(guard.realizeErrors() == 0);
-
-    context->advanceToNextRevision(false);
   }
 
   {
+    Context* context = buildStdContext();
+    ErrorGuard guard(context);
     // 'this' qualified, type parenless proc, generic receiver
     std::string prog =
       R"""(
@@ -1662,11 +1659,11 @@ static void test26() {
     auto t = resolveTypeOfXInit(context, prog);
     ensureParamInt(t, 1);
     assert(guard.realizeErrors() == 0);
-
-    context->advanceToNextRevision(false);
   }
 
   {
+    Context* context = buildStdContext();
+    ErrorGuard guard(context);
     // unqualified, type parenless proc, generic receiver
     std::string prog =
       R"""(
@@ -1683,8 +1680,6 @@ static void test26() {
     auto t = resolveTypeOfXInit(context, prog);
     ensureParamInt(t, 1);
     assert(guard.realizeErrors() == 0);
-
-    context->advanceToNextRevision(false);
   }
 }
 
@@ -1713,9 +1708,6 @@ static void test27() {
 static void testInfiniteCycleBug() {
   auto context = buildStdContext();
 
-  context->advanceToNextRevision(false);
-  setupModuleSearchPaths(context, false, false, {}, {});
-
   CompilerFlags flags;
   flags.set(CompilerFlags::WARN_UNSTABLE, true);
   setCompilerFlags(context, std::move(flags));
@@ -1732,8 +1724,7 @@ static void testInfiniteCycleBug() {
 
   std::ignore = resolveQualifiedTypeOfX(context, program0);
 
-  context->advanceToNextRevision(false);
-  setupModuleSearchPaths(context, false, false, {}, {});
+  context = buildStdContext();
 
   std::string program1 =
     R""""(

--- a/frontend/test/resolution/testResolverVerboseErrors.cpp
+++ b/frontend/test/resolution/testResolverVerboseErrors.cpp
@@ -332,9 +332,15 @@ static const char* errorManyCandidates = R"""(
   Omitting 6 more candidates that didn't match.
 )""";
 
-static void testResolverError(const char* program, const char* error) {
+static void testResolverError(const char* program, const char* error,
+                              bool standard = true) {
+  Context* context = nullptr;
   Context ctx;
-  Context* context = &ctx;
+  if (standard) {
+    context = buildStdContext();
+  } else {
+    context = &ctx;
+  }
   ErrorGuard guard(context);
 
   while (*error == '\n') error++;
@@ -370,7 +376,8 @@ int main() {
   testResolverError(progVarArgMismatch, errorVarArgMismatch);
   testResolverError(progWhereClauseFalse, errorWhereClauseFalse);
   testResolverError(progBasic, errorBasic);
-  testResolverError(progOther, errorOther);
+  // Avoid standard modules for now to prevent very long list of candidates
+  testResolverError(progOther, errorOther, false);
   testResolverError(progManyCandidates, errorManyCandidates);
 
   return 0;

--- a/frontend/test/resolution/testReturnTypes.cpp
+++ b/frontend/test/resolution/testReturnTypes.cpp
@@ -101,8 +101,7 @@ static std::vector<QualifiedType> extractDefinedTypes(Context* context,
 template <typename F>
 void testProgram(const std::vector<ReturnVariant>& variants, F func,
                  QualifiedType::Kind kind = QualifiedType::DEFAULT_INTENT) {
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   auto program = buildProgram(variants);
   std::cout << "--- test program ---" << std::endl;
   std::cout << program.c_str() << std::endl;
@@ -614,8 +613,7 @@ static void testControlFlowYield1() {
     }
     )""";
 
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   auto mod = parseModule(context, program);
@@ -643,8 +641,7 @@ static void testControlFlowYield2() {
     }
     )""";
 
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   auto mod = parseModule(context, program);
@@ -911,8 +908,7 @@ static void testSelectTypes() {
     type x = foo(int);
     )""";
 
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     ErrorGuard guard(context);
     auto qt = resolveTypeOfXInit(context, program);
     assert(qt.type()->isIntType());

--- a/frontend/test/resolution/testReturnTypes.cpp
+++ b/frontend/test/resolution/testReturnTypes.cpp
@@ -1081,15 +1081,14 @@ static void testSelectParams() {
 }
 
 // Assumes loop body will return param string "asdf"
-static void paramLoopTestHelper(Context* context, const char* loopBody,
+static void paramLoopTestHelper(const char* loopBody,
                                 const char* loopRange, bool returnedFromLoop,
                                 bool useEmptyLoop = false) {
-  context->advanceToNextRevision(false);
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   // Construct test program
   std::ostringstream oss;
-  oss << ops;
   oss << "proc foo() param {\n";
   oss << "  for param i in " << loopRange << " {\n";
   oss << loopBody;
@@ -1118,20 +1117,15 @@ static void paramLoopTestHelper(Context* context, const char* loopBody,
 
 // Test returns from within param for loops
 static void testParamLoop() {
-  Context ctx;
-  Context* context = &ctx;
-
   // Basic case
-  paramLoopTestHelper(context,
-                      R"""(
+  paramLoopTestHelper(R"""(
                       return "asdf";
                       )""",
                       "0..2",
                       true);
 
   // Return statement in else branch taken
-  paramLoopTestHelper(context,
-                      R"""(
+  paramLoopTestHelper(R"""(
                       if i == 1 {
                         return true;
                       } else {
@@ -1142,8 +1136,7 @@ static void testParamLoop() {
                       true);
 
   // Return statement in param TRUE if
-  paramLoopTestHelper(context,
-                      R"""(
+  paramLoopTestHelper(R"""(
                       if i == 1 {
                         return "asdf";
                       }
@@ -1152,8 +1145,7 @@ static void testParamLoop() {
                       true);
 
   // Return statement in param FALSE if
-  paramLoopTestHelper(context,
-                      R"""(
+  paramLoopTestHelper(R"""(
                       if i == 3 {
                         return "asdf";
                       }
@@ -1162,8 +1154,7 @@ static void testParamLoop() {
                       false);
 
   // Return statement in a param loop with no iterations
-  paramLoopTestHelper(context,
-                      R"""(
+  paramLoopTestHelper(R"""(
                       return "asdf";
                       )""",
                       "1..0",
@@ -1171,8 +1162,7 @@ static void testParamLoop() {
                       /* useEmptyLoop */ true);
 
   // Return statement in iteration after break
-  paramLoopTestHelper(context,
-                      R"""(
+  paramLoopTestHelper(R"""(
                       break;
                       return "asdf";
                       )""",
@@ -1180,8 +1170,7 @@ static void testParamLoop() {
                       false);
 
   // Return statement in iteration after continue
-  paramLoopTestHelper(context,
-                      R"""(
+  paramLoopTestHelper(R"""(
                       continue;
                       return "asdf";
                       )""",
@@ -1189,8 +1178,7 @@ static void testParamLoop() {
                       false);
 
   // Return statement in iteration after a conditional break, only after return
-  paramLoopTestHelper(context,
-                      R"""(
+  paramLoopTestHelper(R"""(
                       if i == 1 {
                         break;
                       }
@@ -1200,8 +1188,7 @@ static void testParamLoop() {
                       true);
 
   // Return statement in iteration after a conditional break, before any return
-  paramLoopTestHelper(context,
-                      R"""(
+  paramLoopTestHelper(R"""(
                       if i == 0 {
                         break;
                       }
@@ -1212,8 +1199,7 @@ static void testParamLoop() {
 
   // Return statement in iteration after a conditional continue, in only some
   // iterations
-  paramLoopTestHelper(context,
-                      R"""(
+  paramLoopTestHelper(R"""(
                       if i == 0 {
                         continue;
                       }
@@ -1223,8 +1209,7 @@ static void testParamLoop() {
                       true);
 
   // Return statement in iteration after a conditional continue, in all iterations
-  paramLoopTestHelper(context,
-                      R"""(
+  paramLoopTestHelper(R"""(
                       if i != 3 {
                         continue;
                       }
@@ -1236,11 +1221,10 @@ static void testParamLoop() {
 
 // Test return from within non-param loop (shouldn't work)
 static void testNonParamLoop() {
-  Context ctx;
-  Context* context = &ctx;
+  Context* context = buildStdContext();
   ErrorGuard guard(context);
 
-  std::string program = ops + R"""(
+  std::string program = R"""(
   proc foo() {
     for i in 0..2 {
       return "asdf";

--- a/frontend/test/resolution/testReturnTypes.cpp
+++ b/frontend/test/resolution/testReturnTypes.cpp
@@ -142,8 +142,7 @@ enum class ControlFlowResult {
 };
 
 static void testControlFlow(std::string controlFlow, ControlFlowResult expectedResult) {
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
   auto program = buildControlFlowProgram(controlFlow);
   std::cout << "--- test program ---" << std::endl;

--- a/frontend/test/resolution/testSplitInit.cpp
+++ b/frontend/test/resolution/testSplitInit.cpp
@@ -40,15 +40,13 @@ static void testSplitInit(const char* test,
                           bool expectErrors=false) {
   printf("%s\n", test);
 
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   std::string testname = test;
   testname += ".chpl";
   auto path = UniqueString::get(context, testname);
   std::string contents = "module M {\n";
-  contents += "operator =(ref lhs: int, const rhs: int) {}\n";
   contents += program;
   contents += "}";
   setFileText(context, path, contents);
@@ -1053,10 +1051,6 @@ static void test61() {
 static void test62() {
   testSplitInit("test62",
     R""""(
-        operator ==(ref lhs: int, rhs: int) {
-          __primitive("==", lhs, rhs);
-        }
-
         proc test(i: int) {
           var x;
           select i {
@@ -1079,10 +1073,6 @@ static void test62() {
 static void test63() {
   testSplitInit("test63",
     R""""(
-        operator ==(ref lhs: int, rhs: int) {
-          __primitive("==", lhs, rhs);
-        }
-
         proc test(i: int) {
           var x;
           select i {
@@ -1102,10 +1092,6 @@ static void test63() {
 static void test64() {
   testSplitInit("test64",
     R""""(
-        operator ==(ref lhs: int, rhs: int) {
-          __primitive("==", lhs, rhs);
-        }
-
         proc test(i: int) {
           var x;
           select i {
@@ -1129,10 +1115,6 @@ static void test64() {
 static void test65() {
   testSplitInit("test65",
     R""""(
-        operator ==(ref lhs: int, rhs: int) {
-          __primitive("==", lhs, rhs);
-        }
-
         config const i: int;
         proc test(i: int) {
           var x;
@@ -1155,10 +1137,6 @@ static void test65() {
 static void test66() {
   testSplitInit("test66",
     R""""(
-        operator ==(ref lhs: int, rhs: int) {
-          __primitive("==", lhs, rhs);
-        }
-
         config const i: int;
         proc test(i: int) {
           var x;
@@ -1182,10 +1160,6 @@ static void test66() {
 static void test67() {
   testSplitInit("test67a",
     R""""(
-        operator ==(ref lhs: int, rhs: int) {
-          __primitive("==", lhs, rhs);
-        }
-
         config const i: int;
         proc test(i: int) {
           var x, y;
@@ -1199,10 +1173,6 @@ static void test67() {
     {}, ERRORS_EXPECTED);
   testSplitInit("test67b",
     R""""(
-        operator ==(ref lhs: int, rhs: int) {
-          __primitive("==", lhs, rhs);
-        }
-
         config const i: int;
         proc test(i: int) {
           var x, y, z;
@@ -1216,10 +1186,6 @@ static void test67() {
     {}, ERRORS_EXPECTED);
   testSplitInit("test67c",
     R""""(
-        operator ==(ref lhs: int, rhs: int) {
-          __primitive("==", lhs, rhs);
-        }
-
         config const i: int;
         proc test(i: int) {
           var x, y, z;
@@ -1233,10 +1199,6 @@ static void test67() {
     {"z", "y", "x"});
   testSplitInit("test67d",
     R""""(
-        operator ==(ref lhs: int, rhs: int) {
-          __primitive("==", lhs, rhs);
-        }
-
         config const i: int;
         proc test(i: int) {
           var x,y,z;
@@ -1321,10 +1283,6 @@ static void testParamTrueWhen() {
 static void test64a() {
   testSplitInit("test64a_passing",
     R""""(
-        operator ==(ref lhs: int, rhs: int) {
-          __primitive("==", lhs, rhs);
-        }
-
         proc test() {
           type T = int;
           var x;
@@ -1342,10 +1300,6 @@ static void test64a() {
     {"x"});
     testSplitInit("test64a",
     R""""(
-        operator ==(ref lhs: int, rhs: int) {
-          __primitive("==", lhs, rhs);
-        }
-
         proc test() {
           type T = real;
           var x;

--- a/frontend/test/resolution/testTaskIntents.cpp
+++ b/frontend/test/resolution/testTaskIntents.cpp
@@ -40,14 +40,6 @@
 static bool debug = false;
 static bool verbose = false;
 
-// all contexts stored for later cleanup
-static std::vector<Context*> globalContexts;
-static Context* getNewContext() {
-  Context* ret = new Context();
-  globalContexts.push_back(ret);
-  return ret;
-}
-
 std::vector<const ErrorBase*> errors;
 
 static const Module* parseModule(Context* context, const char* src) {
@@ -230,7 +222,7 @@ static Collector customHelper(std::string program, ResolutionContext* rc, Module
 
 // helper for running task intent tests
 static void kindHelper(Qualifier kind, const std::string& constructName) {
-  Context* context = getNewContext();
+  Context* context = buildStdContext();
   ResolutionContext rcval(context);
   auto rc = &rcval;
 
@@ -309,7 +301,7 @@ static void testKinds() {
 static void reduceHelper(const std::string& constructName) {
   assert(constructName == "forall" || constructName == "coforall");
 
-  Context* context = getNewContext();
+  Context* context = buildStdContext();
   ResolutionContext rcval(context);
   auto rc = &rcval;
 
@@ -376,11 +368,6 @@ int main(int argc, char** argv) {
   testReduce();
 
   printf("\nAll tests passed successfully.\n");
-
-  // Cleanup
-  for (auto* con : globalContexts) {
-    delete con;
-  }
 
   return 0;
 }

--- a/frontend/test/resolution/testTuples.cpp
+++ b/frontend/test/resolution/testTuples.cpp
@@ -33,8 +33,7 @@
 // returns the type of that.
 static void test1() {
   printf("test1\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto qt = resolveTypeOfXInit(context,
                 R""""(
@@ -59,8 +58,7 @@ static void test1() {
 
 static void test2() {
   printf("test2\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto qt = resolveTypeOfXInit(context,
                 R""""(
@@ -81,8 +79,7 @@ static void test2() {
 
 static void test3() {
   printf("test3\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto qt = resolveTypeOfXInit(context,
                 R""""(
@@ -112,8 +109,7 @@ static void test3() {
 
 static void test4() {
   printf("test4\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto qt = resolveTypeOfXInit(context,
                 R""""(
@@ -138,8 +134,7 @@ static void test4() {
 
 static void test5() {
   printf("test5\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto qt = resolveQualifiedTypeOfX(context,
                 R""""(
@@ -165,8 +160,7 @@ static void test5() {
 
 static void test6() {
   printf("test6\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto qt = resolveTypeOfXInit(context,
                 R""""(
@@ -191,8 +185,7 @@ static void test6() {
 
 static void test7() {
   printf("test7\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto qt = resolveTypeOfXInit(context,
                 R""""(
@@ -216,8 +209,7 @@ static void test7() {
 
 static void test8() {
   printf("test8\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto qt = resolveTypeOfXInit(context,
                 R""""(
@@ -240,8 +232,7 @@ static void test8() {
 
 static void test9() {
   printf("test9\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto M = parseModule(context,
                 R""""(
@@ -274,8 +265,7 @@ static void test9() {
 
 static void test9b() {
   printf("test9b\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   {
     ErrorGuard guard(context);
@@ -342,8 +332,7 @@ static void test9b() {
 
 static void test10() {
   printf("test10\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto M = parseModule(context,
                 R""""(
@@ -376,8 +365,7 @@ static void test10() {
 
 static void test11() {
   printf("test11\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto qt = resolveTypeOfXInit(context,
                 R""""(
@@ -430,8 +418,7 @@ static void test11b() {
 
 static void test12() {
   printf("test12\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto qt = resolveTypeOfXInit(context,
                 R""""(
@@ -460,8 +447,7 @@ static void test12() {
 
 static void test13() {
   printf("test13\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto qt = resolveTypeOfXInit(context,
                 R""""(
@@ -495,8 +481,7 @@ static void test14() {
   printf("test14\n");
 
   {
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     ErrorGuard guard(context);
 
     auto qt = resolveTypeOfXInit(context,
@@ -517,8 +502,7 @@ static void test14() {
   }
 
   {
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     ErrorGuard guard(context);
 
     // Using a homogeneous tuple type expression
@@ -540,8 +524,7 @@ static void test14() {
     assert(vars["retTwo"].type()->isIntType());
   }
   {
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     ErrorGuard guard(context);
 
     auto qt = resolveTypeOfXInit(context,
@@ -567,8 +550,7 @@ static void test14() {
     guard.realizeErrors();
   }
   {
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     ErrorGuard guard(context);
 
     auto vars = resolveTypesOfVariables(context,
@@ -599,8 +581,7 @@ static void test14() {
     assert(vars["varC"].type()->isStringType());
   }
   {
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     ErrorGuard guard(context);
 
     auto vars = resolveTypesOfVariables(context,
@@ -640,8 +621,7 @@ static void test14() {
 
 static void test15() {
   printf("test15\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto qt = resolveTypeOfXInit(context,
                 R""""(
@@ -662,8 +642,7 @@ static void test15() {
 
 static void test16() {
   printf("test16\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto qt = resolveQualifiedTypeOfX(context,
                 R""""(
@@ -678,8 +657,7 @@ static void test16() {
 
 static void test17() {
   printf("test17\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto qt = resolveQualifiedTypeOfX(context,
                 R""""(
@@ -741,8 +719,7 @@ static void argHelper(std::string formal, std::string actual,
 
 static void test18() {
   printf("test18\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto program = R""""(
                   var t = (1, "hello", 3.0);
@@ -767,8 +744,7 @@ static void test18() {
 // Test "get svec member[ value]" primitives
 static void test19() {
   printf("test19\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto program = R""""(
                   var t = (1, 2, 3);
@@ -858,8 +834,7 @@ static const TypedFnSignature* test20Helper(Context* context, std::string progra
 static void test20() {
   printf("test20\n");
   {
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     auto program = R"""(
       proc foo(v: ?t) do return v;
       var x = foo((1, "hello"));
@@ -876,8 +851,7 @@ static void test20() {
     assert(tt->elementType(1).kind() == QualifiedType::REF);
   }
   {
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     auto program = R"""(
       proc foo(const v: ?t) do return v;
       var x = foo((1, "hello"));
@@ -894,8 +868,7 @@ static void test20() {
     assert(tt->elementType(1).kind() == QualifiedType::CONST_REF);
   }
   {
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     auto program = R"""(
       proc foo(in v: ?t) do return v;
       var x = foo((1, "hello"));
@@ -912,8 +885,7 @@ static void test20() {
     assert(tt->elementType(1).kind() == QualifiedType::VAR);
   }
   {
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     auto program = R"""(
       proc foo(const in v: ?t) do return v;
       var x = foo((1, "hello"));
@@ -930,8 +902,7 @@ static void test20() {
     assert(tt->elementType(1).kind() == QualifiedType::CONST_VAR);
   }
   {
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     auto program = R"""(
       proc foo(ref v: ?t) do return v;
       var t = (1,"hello");
@@ -949,8 +920,7 @@ static void test20() {
     assert(tt->elementType(1).kind() == QualifiedType::VAR);
   }
   {
-    Context ctx;
-    Context* context = &ctx;
+    auto context = buildStdContext();
     auto program = R"""(
       proc foo(const ref v: ?t) do return v;
       var x = foo((1,"hello"));
@@ -972,8 +942,7 @@ static void test21() {
   // Ensure that (type int, type int) tuples in type expression are properly
   // handled when they are specifying the type of var or const variable.
 
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   auto program = R"""(
     var x: 2*int = (7,3);
     const y: 2*int = (7,3);

--- a/frontend/test/resolution/testTuples.cpp
+++ b/frontend/test/resolution/testTuples.cpp
@@ -398,8 +398,7 @@ static void test11() {
 
 static void test11b() {
   printf("test11b\n");
-  auto uctx = buildStdContext();
-  auto context = uctx.get();
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   // Exercises a case where the frontend was attempting to resolve an '='
@@ -700,13 +699,10 @@ static void test17() {
 
 static void argHelper(std::string formal, std::string actual,
                            bool shouldResolve) {
-  Context ctx;
-  Context* context = &ctx;
+  Context* context = buildStdContext();
   ErrorGuard guard(context);
 
   std::string program = R"""(
-    operator =(ref lhs: _tuple, const ref rhs: _tuple) {}
-
     proc foo(arg: )""" + formal + R"""() {
       return arg;
     }

--- a/frontend/test/resolution/testTypeConstruction.cpp
+++ b/frontend/test/resolution/testTypeConstruction.cpp
@@ -30,8 +30,7 @@
 
 static void test1() {
   printf("test1\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto m = parseModule(context, "var i: int;\n"
                                 "var i8: int(8);\n"
@@ -90,8 +89,7 @@ static void test1() {
 
 static void test2() {
   printf("test2\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto m = parseModule(context, "var b: bool;\n");
 
@@ -106,8 +104,7 @@ static void test2() {
 
 static void test3() {
   printf("test3\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto m = parseModule(context, "var r: real;\n"
                                 "var r32: real(32);\n"
@@ -195,8 +192,7 @@ parseTypeAndFieldsOfX(Context* context, const char* program) {
 
 static void test4a() {
   printf("test4a\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context, "record R { var field: int; }\n"
                                  "var x: R;\n");
@@ -214,8 +210,7 @@ static void test4a() {
 
 static void test4b() {
   printf("test4b\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context, "record R { var field; }\n"
                                  "var x: R(int);\n");
@@ -233,8 +228,7 @@ static void test4b() {
 
 static void test5() {
   printf("test5\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context, "record R { type t; }\n"
                                  "var x: R(int);\n");
@@ -264,8 +258,7 @@ static void test5() {
 
 static void test6() {
   printf("test6\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context, "record R { param p; }\n"
                                  "var x: R(1);\n");
@@ -284,8 +277,7 @@ static void test6() {
 
 static void test7() {
   printf("test7\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context, "record R { type t = int; }\n"
                                  "var x: R(real);\n");
@@ -303,8 +295,7 @@ static void test7() {
 
 static void test8() {
   printf("test8\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context, "record R { type t = int; }\n"
                                  "var x: R;\n");
@@ -322,8 +313,7 @@ static void test8() {
 
 static void test9() {
   printf("test9\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context, "record R { param p = 1; }\n"
                                  "var x: R(2);\n");
@@ -342,8 +332,7 @@ static void test9() {
 
 static void test10() {
   printf("test10\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context, "record R { param p = 1; }\n"
                                  "var x: R;\n");
@@ -362,8 +351,7 @@ static void test10() {
 
 static void test11() {
   printf("test11\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context, "record R { type t = int; }\n"
                                  "var x: R();\n");
@@ -381,8 +369,7 @@ static void test11() {
 
 static void test12() {
   printf("test12\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context, "record R { type t = int; }\n"
                                  "var x: R(?);\n");
@@ -400,8 +387,7 @@ static void test12() {
 
 static void test13() {
   printf("test13\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context, "record R { param p = 1; }\n"
                                  "var x: R();\n");
@@ -419,8 +405,7 @@ static void test13() {
 
 static void test14() {
   printf("test14\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context, "record R { param p = 1; }\n"
                                  "var x: R(?);\n");
@@ -439,8 +424,7 @@ static void test14() {
 
 static void test15() {
   printf("test15\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context, "class C { var field: int; }\n"
                                  "var x: C;\n");
@@ -464,8 +448,7 @@ static void test15() {
 
 static void test16() {
   printf("test16\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context, "class C { var field: int; }\n"
                                  "var x: C?;\n");
@@ -490,8 +473,7 @@ static void test16() {
 
 static void test17() {
   printf("test17\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context, "class C { var field: int; }\n"
                                  "var x: borrowed C;\n");
@@ -514,8 +496,7 @@ static void test17() {
 
 static void test18() {
   printf("test18\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context, "class C { var field: int; }\n"
                                  "var x: borrowed C?;\n");
@@ -538,8 +519,7 @@ static void test18() {
 
 static void test19() {
   printf("test19\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context, "class C { var field: int; }\n"
                                  "var x: unmanaged C;\n");
@@ -562,8 +542,7 @@ static void test19() {
 
 static void test20() {
   printf("test20\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context, "class C { var field: int; }\n"
                                  "var x: unmanaged C?;\n");
@@ -586,8 +565,7 @@ static void test20() {
 
 static void test21() {
   printf("test21\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context, "class C { var field: int; }\n"
                                  "var x: owned C;\n");
@@ -610,8 +588,7 @@ static void test21() {
 
 static void test22() {
   printf("test22\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context, "class C { var field: int; }\n"
                                  "var x: owned C?;\n");
@@ -634,8 +611,7 @@ static void test22() {
 
 static void test23() {
   printf("test23\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context, "class C { var field: int; }\n"
                                  "var x: shared C;\n");
@@ -658,8 +634,7 @@ static void test23() {
 
 static void test23q() {
   printf("test23q\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context, "class C { var field: int; }\n"
                                  "var x: shared C?;\n");
@@ -682,8 +657,7 @@ static void test23q() {
 
 static void test24() {
   printf("test24\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context, "class C { var field; }\n"
                                  "var x: C(int);\n");
@@ -706,8 +680,7 @@ static void test24() {
 
 static void test25() {
   printf("test25\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context, "class C { var field; }\n"
                                  "var x: C(int)?;\n");
@@ -730,8 +703,7 @@ static void test25() {
 
 static void test26() {
   printf("test26\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context, "class C { var field; }\n"
                                  "var x: borrowed C(int)?;\n");
@@ -754,8 +726,7 @@ static void test26() {
 
 static void test27() {
   printf("test27\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context, "class C { type t; }\n"
                                  "var x: owned C(int)?;\n");
@@ -778,8 +749,7 @@ static void test27() {
 
 static void test28() {
   printf("test28\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context, "class C { type t = int; }\n"
                                  "var x: C;\n");
@@ -802,8 +772,7 @@ static void test28() {
 
 static void test29() {
   printf("test29\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context, "class C { type t = int; }\n"
                                  "var x: C();\n");
@@ -826,8 +795,7 @@ static void test29() {
 
 static void test30() {
   printf("test30\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context, "class C { type t = int; }\n"
                                  "var x: borrowed C?;\n");
@@ -850,8 +818,7 @@ static void test30() {
 
 static void test31() {
   printf("test31\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context, "class C { type t = int; }\n"
                                  "var x: borrowed C()?;\n");
@@ -874,8 +841,7 @@ static void test31() {
 
 static void test32() {
   printf("test32\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context, "class C { type t = int; }\n"
                                  "var x: shared C(real)?;\n");
@@ -898,8 +864,7 @@ static void test32() {
 
 static void test33() {
   printf("test33\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context, "class C { type t = int; }\n"
                                  "var x: C(real)?;\n");
@@ -922,8 +887,7 @@ static void test33() {
 
 static void test34() {
   printf("test34\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context, "class C { type t = int; }\n"
                                  "var x: unmanaged C(real);\n");
@@ -950,8 +914,7 @@ static void test34() {
 // see issue #18817.
 static void testTypeAndFnSameName() {
   printf("testTypeAndFnSameName\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto m = parseModule(context, R""""(
                                   record R {
@@ -996,8 +959,7 @@ static void testTypeAndFnSameName() {
 
 static void test35() {
   printf("test35\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context,
                         R""""(
@@ -1045,8 +1007,7 @@ static void test35() {
 
 static void test36() {
   printf("test36\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context,
                         R""""(
@@ -1078,8 +1039,7 @@ static void test36() {
 
 static void test37() {
   printf("test37\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context,
                         R""""(
@@ -1114,8 +1074,7 @@ static void test37() {
 
 static void test38() {
   printf("test38\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context,
                         R""""(
@@ -1162,8 +1121,7 @@ static void test38() {
 
 static void test39() {
   printf("test39\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context,
                         R""""(
@@ -1192,8 +1150,7 @@ static void test39() {
 
 static void test40() {
   printf("test40\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context,
                         R""""(
@@ -1218,8 +1175,7 @@ static void test40() {
 
 static void test41() {
   printf("test41\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context,
                         R""""(
@@ -1252,8 +1208,7 @@ static void test41() {
 
 static void test42() {
   printf("test42\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto p = parseTypeAndFieldsOfX(context,
                         R""""(
@@ -1285,14 +1240,11 @@ static void test42() {
 
 static void testRecursiveTypeConstructor() {
   printf("testRecursiveTypeConstructor\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   auto p = parseTypeAndFieldsOfX(context,
       R"""(
-      operator =(ref lhs: real, const rhs: real) {}
-      operator =(ref lhs: unmanaged class?, const in rhs: unmanaged class?) {}
       class Node {
         type eltType = int;
         var data: eltType;
@@ -1326,14 +1278,11 @@ static void testRecursiveTypeConstructor() {
 
 static void testRecursiveTypeConstructorAlias() {
   printf("testRecursiveTypeConstructorAlias\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   auto p = parseTypeAndFieldsOfX(context,
       R"""(
-      operator =(ref lhs: int, const rhs: int) {}
-      operator =(ref lhs: unmanaged class?, const in rhs: unmanaged class?) {}
       class Node {
           type eltType = int;
           var data: eltType;
@@ -1368,13 +1317,11 @@ static void testRecursiveTypeConstructorAlias() {
 
 static void testRecursiveTypeConstructorGeneric() {
   printf("testRecursiveTypeConstructorGeneric\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   std::ignore = resolveTypeOfXInit(context,
       R"""(
-      operator =(ref lhs: unmanaged class?, const in rhs: unmanaged class?) {}
       class Node {
           type eltType = int;
           var data: eltType;
@@ -1396,16 +1343,12 @@ static void testRecursiveTypeConstructorGeneric() {
 
 static void testRecursiveTypeConstructorMutual() {
   printf("testRecursiveTypeConstructorMutual\n");
-  auto config = getConfigWithHome();
-  Context ctx(config);
-  Context* context = &ctx;
+  Context* context = buildStdContext();
   ErrorGuard guard(context);
   setupModuleSearchPaths(context, false, false, {}, {});
 
   auto p = parseTypeAndFieldsOfX(context,
       R"""(
-      operator =(ref lhs: real, const rhs: real) {}
-      operator =(ref lhs: owned class?, const in rhs: owned class?) {}
       class MutA {
         type eltType;
         var data: eltType;
@@ -1469,8 +1412,7 @@ static void testRecursiveTypeConstructorMutual() {
 
 static void test43() {
   printf("test43\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   auto p = parseTypeAndFieldsOfX(context,
                         R""""(
                         class A {
@@ -1503,8 +1445,7 @@ static void test43() {
 
 static void test44() {
   printf("test44\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   // Test that symbols referred to in type constructors are visible, including:

--- a/frontend/test/resolution/testTypeOperators.cpp
+++ b/frontend/test/resolution/testTypeOperators.cpp
@@ -28,40 +28,37 @@
 #include "chpl/uast/Module.h"
 
 static void test1() {
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   QualifiedType qt1 =  resolveTypeOfXInit(context, "var x = int == int;");
   assert(qt1.isParamTrue());
-  ctx.advanceToNextRevision(false);
+  context->advanceToNextRevision(false);
   QualifiedType qt2 =  resolveTypeOfXInit(context, "var x = int != int;");
   assert(qt2.isParamFalse());
-  ctx.advanceToNextRevision(false);
+  context->advanceToNextRevision(false);
   QualifiedType qt3 =  resolveTypeOfXInit(context, "var x = bool == int;");
   assert(qt3.isParamFalse());
-  ctx.advanceToNextRevision(false);
+  context->advanceToNextRevision(false);
   QualifiedType qt4 =  resolveTypeOfXInit(context, "var x = bool != int;");
   assert(qt4.isParamTrue());
 }
 
 static void test2() {
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   QualifiedType qt1 =  resolveTypeOfXInit(context, "var x = 1 == 1;");
   assert(qt1.isParamTrue());
-  ctx.advanceToNextRevision(false);
+  context->advanceToNextRevision(false);
   QualifiedType qt2 =  resolveTypeOfXInit(context, "var x = 1 != 1;");
   assert(qt2.isParamFalse());
-  ctx.advanceToNextRevision(false);
+  context->advanceToNextRevision(false);
   QualifiedType qt3 =  resolveTypeOfXInit(context, "var x = 1 == 2;");
   assert(qt3.isParamFalse());
-  ctx.advanceToNextRevision(false);
+  context->advanceToNextRevision(false);
   QualifiedType qt4 =  resolveTypeOfXInit(context, "var x = 1 != 2;");
   assert(qt4.isParamTrue());
 }
 
 static void test3() {
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   QualifiedType qt1 =  resolveTypeOfXInit(context,
                          R""""(
                          param p : int = 0;
@@ -71,8 +68,7 @@ static void test3() {
 }
 
 static void test4() {
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   QualifiedType qt1 =  resolveTypeOfXInit(context,

--- a/frontend/test/resolution/testTypeQueries.cpp
+++ b/frontend/test/resolution/testTypeQueries.cpp
@@ -31,8 +31,7 @@
 
 static void test1() {
   printf("test1\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto t1 = resolveTypeOfX(context,
                 R""""(
@@ -69,8 +68,7 @@ static void test1() {
 
 static void test2() {
   printf("test2\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto t = resolveTypeOfX(context,
                 R""""(
@@ -92,8 +90,7 @@ static void test2() {
 
 static void test3() {
   printf("test3\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto t = resolveTypeOfX(context,
                 R""""(
@@ -115,8 +112,7 @@ static void test3() {
 
 static void test4() {
   printf("test4\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto t = resolveTypeOfX(context,
                 R""""(
@@ -138,8 +134,7 @@ static void test4() {
 
 static void test5() {
   printf("test5\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto t = resolveTypeOfX(context,
                 R""""(
@@ -156,8 +151,7 @@ static void test5() {
 
 static void test6() {
   printf("test6\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto t = resolveTypeOfX(context,
                 R""""(
@@ -175,8 +169,7 @@ static void test6() {
 
 static void test7() {
   printf("test7\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto t = resolveTypeOfX(context,
                 R""""(
@@ -192,8 +185,7 @@ static void test7() {
 
 static void test8() {
   printf("test8\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto t = resolveTypeOfX(context,
                 R""""(
@@ -209,8 +201,7 @@ static void test8() {
 
 static void test9() {
   printf("test9\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto t = resolveTypeOfX(context,
                 R""""(
@@ -229,8 +220,7 @@ static void test9() {
 
 static void test10() {
   printf("test10\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto path = UniqueString::get(context, "input.chpl");
   std::string contents = R""""(
@@ -292,8 +282,7 @@ static void test10() {
 
 static void test11() {
   printf("test11\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto t = resolveTypeOfX(context,
                 R""""(
@@ -312,8 +301,7 @@ static void test11() {
 
 static void test12a() {
   printf("test12\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto t = resolveTypeOfX(context,
                 R""""(
@@ -341,8 +329,7 @@ static void test12a() {
 
 static void test12b() {
   printf("test12\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto t = resolveTypeOfX(context,
                 R""""(
@@ -374,8 +361,7 @@ static void test12b() {
 
 static void test13a() {
   printf("test13a\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto qt = resolveTypeOfXInit(context,
                 R""""(
@@ -396,8 +382,7 @@ static void test13a() {
 
 static void test13b() {
   printf("test13b\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto qt = resolveTypeOfXInit(context,
                 R""""(
@@ -418,8 +403,7 @@ static void test13b() {
 
 static void test14() {
   printf("test14\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto t = resolveTypeOfX(context,
                 R""""(
@@ -447,8 +431,7 @@ static void test14() {
 
 static void test15() {
   printf("test15\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto qt = resolveTypeOfXInit(context,
                 R""""(
@@ -473,8 +456,7 @@ static void test15() {
 
 static void test16() {
   printf("test16\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   std::string setup =
                 R""""(
@@ -495,7 +477,7 @@ static void test16() {
                 )"""");
   assert(qt.type() && qt.type()->isBoolType());
 
-  context->advanceToNextRevision(false);
+  context = buildStdContext();
   qt = resolveQualifiedTypeOfX(context, setup +
                 R""""(
                   var a: R(bool, string);
@@ -504,7 +486,7 @@ static void test16() {
                 )"""");
   assert(qt.type() && qt.type()->isBoolType());
 
-  context->advanceToNextRevision(false);
+  context = buildStdContext();
   qt = resolveQualifiedTypeOfX(context, setup +
                 R""""(
                   var a: R(bool, string);
@@ -517,8 +499,7 @@ static void test16() {
 
 static void test17() {
   printf("test17\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   std::string setup =
                 R""""(
@@ -540,7 +521,7 @@ static void test17() {
                 )"""");
   assert(qt.isErroneousType());
 
-  context->advanceToNextRevision(false);
+  context = buildStdContext();
   qt = resolveQualifiedTypeOfX(context, setup+
                 R""""(
                   var a: R(bool, int);
@@ -549,7 +530,7 @@ static void test17() {
                 )"""");
   assert(qt.isErroneousType());
 
-  context->advanceToNextRevision(false);
+  context = buildStdContext();
   qt = resolveQualifiedTypeOfX(context, setup +
                 R""""(
                   var a: R(bool, int);
@@ -560,8 +541,7 @@ static void test17() {
 
 static void test18() {
   printf("test17\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   auto qt = resolveQualifiedTypeOfX(context, R"""(
@@ -588,8 +568,7 @@ static void test18() {
 
 static void test19() {
   printf("%s\n", __FUNCTION__);
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   auto qt = resolveQualifiedTypeOfX(context,

--- a/frontend/test/resolution/testVarArgs.cpp
+++ b/frontend/test/resolution/testVarArgs.cpp
@@ -40,13 +40,6 @@
 static bool debug = true;
 static bool verbose = true;
 
-static std::vector<Context*> globalContexts;
-static Context* getNewContext() {
-  Context* ret = new Context();
-  globalContexts.push_back(ret);
-  return ret;
-}
-
 std::vector<const ErrorBase*> errors;
 
 static const Module* parseModule(Context* context, const char* src) {
@@ -505,8 +498,7 @@ static void testMatcher(Qualifier formalIntent,
   std::string program = buildProgram(formalIntent, formalType, count,
                                      info, fail);
 
-  Context ctx;
-  Context* context = &ctx;
+  Context* context = buildStdContext();
   ErrorGuard guard(context);
   ResolutionContext rcval(context);
   auto rc = &rcval;
@@ -536,7 +528,7 @@ static void testMatcher(Qualifier formalIntent,
 static Collector
 customHelper(std::string program, bool fail = false,
              std::vector<owned<ErrorBase>>* errorsOut=nullptr) {
-  Context* context = getNewContext();
+  Context* context = buildStdContext();
   ErrorGuard guard(context);
   ResolutionContext rcval(context);
   auto rc = &rcval;
@@ -874,11 +866,6 @@ int main(int argc, char** argv) {
   testAlignment();
 
   printf("\nAll tests passed successfully.\n");
-
-  // Cleanup
-  for (auto* con : globalContexts) {
-    delete con;
-  }
 
   return 0;
 }

--- a/frontend/test/test-common.h
+++ b/frontend/test/test-common.h
@@ -53,6 +53,6 @@ parseStringAndReportErrors(chpl::parsing::Parser* parser, const char* filename,
 
 const chpl::uast::AstNode* findOnlyNamed(const chpl::uast::Module* mod, std::string name);
 
-std::unique_ptr<chpl::Context> buildStdContext();
+chpl::Context* buildStdContext();
 
 #endif

--- a/tools/chapel-py/src/method-tables/type-methods.h
+++ b/tools/chapel-py/src/method-tables/type-methods.h
@@ -40,11 +40,5 @@ CLASS_BEGIN(CompositeType)
                auto& id = node->id();
                if (id.isEmpty()) return nullptr;
 
-               // If running without the standard library, builtin types
-               // that we expect to find in module code could be missing.
-               bool missingId =
-                 chpl::types::CompositeType::isMissingBundledType(context, id);
-               if (missingId) return nullptr;
-
                return parsing::idToAst(context, id))
 CLASS_END(CompositeType)


### PR DESCRIPTION
This PR modifies the compiler to remove special cases for "missing" bundled types. This PR also updates testing to use the standard library when these types are needed.

Testing:
- [x] test-dyno
- [x] local paratest