### PR TITLE
Fix the suppressif file to actually detect the failure condition

### DIFF
--- a/test/interop/python/pythonFriendliness/checkNotUsed.suppressif
+++ b/test/interop/python/pythonFriendliness/checkNotUsed.suppressif
@@ -7,7 +7,8 @@ NotOK = False
 try:
   # If the `help("modules")` command doesn't work on its own, we're not going
   # to get useful information out of this test, so suppress the failure
-  subproc = subprocess.run('python3 -c help("modules")', check=True)
+  subproc = subprocess.run(('python3', '-c', 'help("modules")'), check=True,
+                           capture_output=True)
   if (subproc.returncode != 0):
      NotOK = True
 except:


### PR DESCRIPTION
Matt pointed out that I had accidentally written the subprocess command in such a way that subprocess was escaping the whole command and so acting like it detected the failure mode when really it was just not running the command in a way that would work.  After fixing that, I also needed to hide the failure output from start_test so it wouldn't think the suppressif had failed.  With that all fixed, we now appropriately suppress the failure mode

Tested locally and on the machine where the failure occurred