### PR TITLE
Print `printchplenv` warnings at the end of the output

### DIFF
--- a/util/chplenv/printchplenv.py
+++ b/util/chplenv/printchplenv.py
@@ -633,6 +633,8 @@ def main():
     ret = printchplenv(contents, filters, options.format, only=only)
     stdout.write(ret)
 
+    utils.flush_warnings()
+
 
 if __name__ == '__main__':
     main()

--- a/util/chplenv/utils.py
+++ b/util/chplenv/utils.py
@@ -48,17 +48,15 @@ def error(msg, exception=Exception):
         flush_warnings()
         raise exception(msg)
     else:
-        out = ['\nError: ', msg, '\n']
+        out = '\nError: {}\n'.format(msg)
         if ignore_errors:
-            sys.stderr.write(''.join(out))
+            sys.stderr.write(out)
         else:
             # flush warnings, print error, and exit
             # technically, there is no need to flush warnings here, but might as well
             flush_warnings()
-            sys.stderr.write(''.join(out))
+            sys.stderr.write(out)
             sys.exit(1)
-
-
 
 def memoize(func):
     """Function memoizing decorator"""

--- a/util/chplenv/utils.py
+++ b/util/chplenv/utils.py
@@ -26,9 +26,12 @@ def set_buffer_warnings(buffer_warnings):
     global _buffer_warnings
     _buffer_warnings = buffer_warnings
 
+def should_buffer_warnings():
+    return _buffer_warnings and not ignore_errors
+
 def warning(msg):
     if not os.environ.get('CHPLENV_SUPPRESS_WARNINGS'):
-        if _buffer_warnings:
+        if should_buffer_warnings():
             _warning_buffer.append(msg)
         else:
             sys.stderr.write('Warning: ')
@@ -50,6 +53,7 @@ def error(msg, exception=Exception):
             sys.stderr.write(''.join(out))
         else:
             # flush warnings, print error, and exit
+            # technically, there is no need to flush warnings here, but might as well
             flush_warnings()
             sys.stderr.write(''.join(out))
             sys.exit(1)

--- a/util/chplenv/utils.py
+++ b/util/chplenv/utils.py
@@ -13,12 +13,27 @@ except ImportError:
     # Backport for pre Python 3.2
     from distutils.spawn import find_executable as which
 
+# should not need this outside of this class
+_warning_buffer = []
+_buffer_warnings = True
+def flush_warnings():
+    for warning in _warning_buffer:
+        sys.stderr.write('Warning: ')
+        sys.stderr.write(warning)
+        sys.stderr.write('\n')
+    _warning_buffer.clear()
+def set_buffer_warnings(buffer_warnings):
+    global _buffer_warnings
+    _buffer_warnings = buffer_warnings
 
 def warning(msg):
     if not os.environ.get('CHPLENV_SUPPRESS_WARNINGS'):
-        sys.stderr.write('Warning: ')
-        sys.stderr.write(msg)
-        sys.stderr.write('\n')
+        if _buffer_warnings:
+            _warning_buffer.append(msg)
+        else:
+            sys.stderr.write('Warning: ')
+            sys.stderr.write(msg)
+            sys.stderr.write('\n')
 
 ignore_errors = False
 
@@ -26,13 +41,19 @@ def error(msg, exception=Exception):
     """Exception raising wrapper that differentiates developer-mode output"""
     developer = os.environ.get('CHPL_DEVELOPER')
     if developer and developer != "0" and not ignore_errors:
+        # before rasing the exception, flush the warnings
+        flush_warnings()
         raise exception(msg)
     else:
-        sys.stderr.write('\nError: ')
-        sys.stderr.write(msg)
-        sys.stderr.write('\n')
-        if not ignore_errors:
+        out = ['\nError: ', msg, '\n']
+        if ignore_errors:
+            sys.stderr.write(''.join(out))
+        else:
+            # flush warnings, print error, and exit
+            flush_warnings()
+            sys.stderr.write(''.join(out))
             sys.exit(1)
+
 
 
 def memoize(func):


### PR DESCRIPTION
Changes how `printchplenv` prints warnings so that the warnings are outputed last. 

Prior to this PR, `printchplenv` warnings could get lost if the terminal scrolled past. This PR puts the warnings last so that users can be more directly notified. The exception is in the error case. If there was an error and printchplenv is going to exit, all to the warnings are printed before the errors, so that users can see warnings that may have lead to the error being produced.

Note: if a user throws `--ignore-errors`, no warning buffering is done, otherwise `printchplenv` may crash without dumping the buffer out.

Testing:
- `CHPL_LLVM_VERSION=2 printchplenv --all` shows the warning at the bottom
- `CHPL_DEVELOPER=1 CHPL_TARGET_COMPILER=gnu CHPL_TARGET_CC=clang CHPL_LLVM_VERSION=2 printchplenv --all` shows the warning and then the exception
- `CHPL_DEVELOPER=0 CHPL_TARGET_COMPILER=gnu CHPL_TARGET_CC=clang CHPL_LLVM_VERSION=2 printchplenv --all` shows the warning and then prints the error
- `CHPL_TARGET_COMPILER=gnu CHPL_TARGET_CC=clang CHPL_LLVM_VERSION=2 printchplenv --all --ignore-errors` does no buffering

[Reviewed by @vasslitvinov]