### PR TITLE
Dyno: allow standalone iteration over single-element `zip`s 

### DIFF
--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -2051,12 +2051,6 @@ struct TheseResolutionResult {
        to resolve. In this case, the zipperedFailure_ and zipperedFailureIndex_
        fields are set. */
     THESE_FAIL_ZIPPERED_ARG_FAILED,
-    /* We started resolving a zippered-like iterator using (e.g.), a leader
-       iterator. In some cases, this means we "commit" to the leader/follower
-       path, so we didn't attempt to use a serial iterator.
-
-       TODO: this doesn't match production. */
-    THESE_FAIL_FOUND_DIFFERENT_ITERATOR,
     /* Mismatch between the claimed promotion type and the type yielded by the
        iterator. */
     THESE_FAIL_PROMOTION_TYPE_YIELD_MISMATCH,

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -5029,7 +5029,7 @@ resolveIterDetailsInPriorityOrder(Resolver& rv,
 
   if (mask & IterDetails::SERIAL) {
     if (resolveIterDetailsForZipperedArgs(rv, ret, ics, Function::SERIAL,
-                                          ret.leaderYieldType, storeFailures)) {
+                                          QualifiedType(), storeFailures)) {
       ret.succeededAt = IterDetails::SERIAL;
       return ret;
     }

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -4996,8 +4996,6 @@ resolveIterDetailsInPriorityOrder(Resolver& rv,
 
   IterDetails ret;
 
-  debuggerBreakHere();
-
   if (mask & IterDetails::STANDALONE) {
     CHPL_ASSERT(ics.size() == 1);
     auto& ic = ics[0];

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -5069,6 +5069,10 @@ static IterDetails resolveNonZipExpression(Resolver& rv,
 
   auto iterandRe = rv.byPostorder.byAst(iterand);
 
+  if (iterandRe.type().isUnknownOrErroneous()) {
+    // The iterand is unknown, no work to do.
+  }
+
   // Resolve iterators, stopping immediately when we get a valid yield type.
   // We are outside of a zippering contex, so call with only a single IterandComponent.
   std::vector<IterandComponent> ics = {
@@ -5277,6 +5281,10 @@ resolveZipExpression(Resolver& rv, const IndexableLoop* loop, const Zip* zip) {
   if (auto leader = (zip->numActuals() ? zip->actual(0) : nullptr)) {
     auto leaderQt = rv.byPostorder.byAst(leader).type();
 
+    if (leaderQt.isUnknownOrErroneous()) {
+      return QualifiedType();
+    }
+
     const auto skippingAllIterands = -1;
     int m = IterDetails::NONE;
     if (singletonZip) {
@@ -5309,6 +5317,10 @@ resolveZipExpression(Resolver& rv, const IndexableLoop* loop, const Zip* zip) {
     for (int i = 1; i < zip->numActuals(); i++) {
       auto follower = zip->actual(i);
       ics.emplace_back(rv, follower, follower);
+
+      if (ics.back().iterandQt.isUnknownOrErroneous()) {
+        return QualifiedType();
+      }
     }
 
     auto result = resolveIterDetailsInPriorityOrder(rv, ics, m, &failures);

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -64,7 +64,6 @@ namespace {
       NONE            = 0b0000,
       STANDALONE      = 0b0001,
       LEADER_FOLLOWER = 0b0010,
-      FOLLOWER        = 0b0100,
       SERIAL          = 0b1000,
     };
 
@@ -90,6 +89,18 @@ namespace {
 
     // This will be set to the yield type of the first iterator to succeed.
     QualifiedType idxType;
+
+    Pieces& piecesForIterKind(const Function::IteratorKind kind) {
+      switch (kind) {
+        case Function::STANDALONE: return standalone;
+        case Function::LEADER: return leader;
+        case Function::FOLLOWER: return follower;
+        case Function::SERIAL: return serial;
+        default:
+          CHPL_ASSERT(false && "shouldn't happen");
+          return serial;
+      }
+    }
   };
 }
 
@@ -106,12 +117,11 @@ resolveIterTypeWithTag(Resolver& rv,
 // Resolve iterators according to the policy set in 'mask' (see the type
 // 'IterDetails::Policy'). Resolution stops the moment an iterator is
 // found with a usable yield type.
-static IterDetails resolveIterDetails(Resolver& rv,
-                                      const AstNode* astForErr,
-                                      const AstNode* iterand,
-                                      const QualifiedType& leaderYieldType,
-                                      int mask,
-                                      bool emitError);
+static IterDetails resolveNonZipExpression(Resolver& rv,
+                                           const AstNode* astForErr,
+                                           const AstNode* iterand,
+                                           const QualifiedType& leaderYieldType,
+                                           int mask);
 
 Resolver::~Resolver() {
   if (didPushFrame) {
@@ -4877,19 +4887,123 @@ void Resolver::exit(const New* node) {
   }
 }
 
+struct IterandComponent {
+ public:
+  QualifiedType iterandQt;
+  const AstNode* astForErr;
+  const AstNode* iterand;
+
+  const IteratorType* iteratingOver;
+
+  IterandComponent(Resolver& rv,
+                   const AstNode* astForErr,
+                   const AstNode* iterand)
+    : astForErr(astForErr), iterand(iterand) {
+    auto& iterandRe = rv.byPostorder.byAst(iterand);
+    this->iterandQt = iterandRe.type();
+    if (!this->iterandQt.isUnknownOrErroneous()) {
+      this->iteratingOver = this->iterandQt.type()->toIteratorType();
+    } else {
+      // The thing-to-be-iterated is not an iterator, but it might be iterable
+      // using its 'these()' method. Don't resolve it now, since we haven't
+      // decided on which overloads we need; resolveIterTypeWithTag will do that
+      // on finding that toIterate is null.
+
+      this->iteratingOver = nullptr;
+    }
+  }
+};
+
+using IteratorFailures = std::vector<std::tuple<Function::IteratorKind, TheseResolutionResult>>;
+
+// If index is nonzero, notes the given failure are a cause for a zippered
+// failure. Otherwise, notes it as a top-level failure.
+static void
+noteTheseResolutionFailure(Resolver& rv,
+                           IteratorFailures& failures,
+                           Function::IteratorKind kind,
+                           int index,
+                           const QualifiedType& receiver,
+                           TheseResolutionResult&& result) {
+  if (rv.scopeResolveOnly) {
+    return;
+  }
+
+  if (index != -1) {
+    auto ownedResult = std::make_unique<TheseResolutionResult>(std::move(result));
+    auto zipperedTheseResult =
+      TheseResolutionResult::failure(std::move(ownedResult), index, receiver);
+    failures.push_back({ kind, std::move(zipperedTheseResult) });
+  } else {
+    failures.push_back({ kind, std::move(result) });
+  }
+}
+
+static bool
+resolveIterDetailsForZipperedArgs(Resolver& rv,
+                                  IterDetails& outIterDetails,
+                                  const std::vector<IterandComponent>& ics,
+                                  Function::IteratorKind iterKind,
+                                  const QualifiedType& leaderYieldType,
+                                  IteratorFailures* storeFailures) {
+  bool succeededAll = true;
+  std::vector<QualifiedType> idxTypes;
+  auto kind = QualifiedType::CONST_VAR;
+  int index = 0;
+  for (auto& ic : ics) {
+    auto& pieces = outIterDetails.piecesForIterKind(iterKind);
+    auto idxType = resolveIterTypeWithTag(rv, pieces,
+                                          ic.iteratingOver, ic.astForErr,
+                                          ic.iterand, iterKind,
+                                          leaderYieldType);
+    if (idxType.isUnknownOrErroneous()) {
+      // Note the first failed resolution
+      if (succeededAll && storeFailures) {
+        noteTheseResolutionFailure(rv, *storeFailures, iterKind, index,
+                                   ic.iterandQt,
+                                   std::move(pieces.resolutionResult));
+      }
+      succeededAll = false;
+    } else if (!idxType.isConst()) {
+      kind = QualifiedType::VAR;
+    }
+
+    idxTypes.push_back(std::move(idxType));
+    index++;
+  }
+
+  if (succeededAll) {
+    CHPL_ASSERT(idxTypes.size() == ics.size());
+    if (ics.size() > 1) {
+      auto tupleType =
+        TupleType::getQualifiedTuple(rv.context, std::move(idxTypes));
+      outIterDetails.idxType = QualifiedType(kind, tupleType);
+    } else {
+      outIterDetails.idxType = idxTypes[0];
+    }
+  }
+
+  return succeededAll;
+}
+
 // This helper resolves by priority order as described in 'IterDetails'.
 static IterDetails
 resolveIterDetailsInPriorityOrder(Resolver& rv,
-                                  const IteratorType* iteratingOver,
-                                  const AstNode* astForErr,
-                                  const AstNode* iterand,
-                                  const QualifiedType& leaderYieldType,
-                                  int mask) {
+                                  const std::vector<IterandComponent>& ics,
+                                  int mask,
+                                  IteratorFailures* storeFailures = nullptr) {
+  CHPL_ASSERT(ics.size() > 0);
+
   IterDetails ret;
-  bool computedLeaderYieldType = false;
+
+  debuggerBreakHere();
+
   if (mask & IterDetails::STANDALONE) {
-    ret.idxType = resolveIterTypeWithTag(rv, ret.standalone, iteratingOver, astForErr,
-                                         iterand, Function::STANDALONE, {});
+    CHPL_ASSERT(ics.size() == 1);
+    auto& ic = ics[0];
+    ret.idxType = resolveIterTypeWithTag(rv, ret.standalone,
+                                         ic.iteratingOver, ic.astForErr,
+                                         ic.iterand, Function::STANDALONE, {});
     if (!ret.idxType.isUnknownOrErroneous()) {
       ret.succeededAt = IterDetails::STANDALONE;
       return ret;
@@ -4897,34 +5011,27 @@ resolveIterDetailsInPriorityOrder(Resolver& rv,
   }
 
   if (mask & IterDetails::LEADER_FOLLOWER) {
-    ret.leaderYieldType = resolveIterTypeWithTag(rv, ret.leader, iteratingOver, astForErr,
-                                                 iterand, Function::LEADER,
+    auto& ic = ics[0];
+    ret.leaderYieldType = resolveIterTypeWithTag(rv, ret.leader,
+                                                 ic.iteratingOver, ic.astForErr,
+                                                 ic.iterand, Function::LEADER,
                                                  {});
-    computedLeaderYieldType = true;
-  } else if (mask & IterDetails::FOLLOWER) {
-    ret.leaderYieldType = leaderYieldType;
   }
 
-  if (mask & IterDetails::LEADER_FOLLOWER ||
-      mask & IterDetails::FOLLOWER) {
-    if (!ret.leaderYieldType.isUnknownOrErroneous()) {
-      ret.idxType = resolveIterTypeWithTag(rv, ret.follower, iteratingOver, astForErr,
-                                           iterand, Function::FOLLOWER,
-                                           ret.leaderYieldType);
-      if (!ret.idxType.isUnknownOrErroneous()) {
-        ret.succeededAt = computedLeaderYieldType
-            ? IterDetails::LEADER_FOLLOWER
-            : IterDetails::FOLLOWER;
-        return ret;
-      }
+  if (mask & IterDetails::LEADER_FOLLOWER &&
+      !ret.leaderYieldType.isUnknownOrErroneous()) {
+    if (resolveIterDetailsForZipperedArgs(rv, ret, ics, Function::FOLLOWER,
+                                          ret.leaderYieldType, storeFailures)) {
+      ret.succeededAt = IterDetails::LEADER_FOLLOWER;
+      return ret;
     }
   }
 
   if (mask & IterDetails::SERIAL) {
-    ret.idxType = resolveIterTypeWithTag(rv, ret.serial, iteratingOver, astForErr,
-                                         iterand, Function::SERIAL, {});
-    if (!ret.idxType.isUnknownOrErroneous()) {
+    if (resolveIterDetailsForZipperedArgs(rv, ret, ics, Function::SERIAL,
+                                          ret.leaderYieldType, storeFailures)) {
       ret.succeededAt = IterDetails::SERIAL;
+      return ret;
     }
   }
 
@@ -4953,32 +5060,23 @@ issueErrorForFailedIterDetails(Context* context,
                          iterandType, std::move(failures));
 }
 
-static IterDetails resolveIterDetails(Resolver& rv,
-                                      const AstNode* astForErr,
-                                      const AstNode* iterand,
-                                      const QualifiedType& leaderYieldType,
-                                      int mask,
-                                      bool emitError) {
+static IterDetails resolveNonZipExpression(Resolver& rv,
+                                           const AstNode* astForErr,
+                                           const AstNode* iterand,
+                                           const QualifiedType& leaderYieldType,
+                                           int mask) {
   if (rv.scopeResolveOnly) {
     return {};
   }
 
   auto iterandRe = rv.byPostorder.byAst(iterand);
-  const IteratorType* iteratingOver = nullptr;
-  if (!iterandRe.type().isUnknownOrErroneous()) {
-    iteratingOver = iterandRe.type().type()->toIteratorType();
-  } else {
-    // The thing-to-be-iterated is not an iterator, but it might be iterable
-    // using its 'these()' method. Don't resolve it now, since we haven't
-    // decided on which overloads we need; resolveIterTypeWithTag will do that
-    // on finding that toIterate is null.
-  }
 
   // Resolve iterators, stopping immediately when we get a valid yield type.
-  auto ret = resolveIterDetailsInPriorityOrder(rv, iteratingOver,
-                                               astForErr, iterand,
-                                               leaderYieldType,
-                                               mask);
+  // We are outside of a zippering contex, so call with only a single IterandComponent.
+  std::vector<IterandComponent> ics = {
+    IterandComponent(rv, astForErr, iterand)
+  };
+  auto ret = resolveIterDetailsInPriorityOrder(rv, ics, mask);
 
   // Only issue a "not iterable" error if the iterand has a type. If it was
   // not typed then earlier resolution of the iterand will have spit out an
@@ -4986,11 +5084,7 @@ static IterDetails resolveIterDetails(Resolver& rv,
   if (ret.succeededAt == IterDetails::NONE && !iterandRe.type().isUnknownOrErroneous()) {
     auto& iterandRE = rv.byPostorder.byAst(iterand);
     if (!iterandRE.type().isUnknownOrErroneous()) {
-      if (emitError) {
-        ret.idxType = issueErrorForFailedIterDetails(rv.context, ret, astForErr, iterand, iterandRE.type());
-      } else {
-        ret.idxType = QualifiedType();
-      }
+      ret.idxType = issueErrorForFailedIterDetails(rv.context, ret, astForErr, iterand, iterandRE.type());
     }
   }
 
@@ -5170,52 +5264,21 @@ static bool resolveParamForLoop(Resolver& rv, const For* forLoop) {
   return false;
 }
 
-// If index is nonzero, notes the given failure are a cause for a zippered
-// failure. Otherwise, notes it as a top-level failure.
-static void noteTheseResolutionFailure(
-    Resolver& rv,
-    std::vector<std::tuple<Function::IteratorKind, TheseResolutionResult>>& failures,
-    Function::IteratorKind kind,
-    int index,
-    const QualifiedType& receiver,
-    TheseResolutionResult&& result) {
-  if (rv.scopeResolveOnly) {
-    return;
-  }
-
-  if (index != -1) {
-    auto ownedResult = std::make_unique<TheseResolutionResult>(std::move(result));
-    auto zipperedTheseResult =
-      TheseResolutionResult::failure(std::move(ownedResult), index, receiver);
-    failures.push_back({ kind, std::move(zipperedTheseResult) });
-  } else {
-    failures.push_back({ kind, std::move(result) });
-  }
-}
-
 static QualifiedType
 resolveZipExpression(Resolver& rv, const IndexableLoop* loop, const Zip* zip) {
+  // Failures to find various iteration strategies (serial, follower) go here.
+  IteratorFailures failures;
+
   Context* context = rv.context;
   bool loopRequiresParallel = loop->isForall();
   bool loopPrefersParallel = loopRequiresParallel || loop->isBracketLoop();
   QualifiedType ret;
 
-  // We build up tuple element types by resolving all the zip actuals.
-  std::vector<QualifiedType> eltTypes;
-
-  // We determine the follower policy by resolving the leader actual.
-  auto followerPolicy = IterDetails::NONE;
-  QualifiedType leaderYieldType;
-
-  std::vector<std::tuple<Function::IteratorKind, TheseResolutionResult>> failures;
-
-  const auto skippingAllIterands = -1;
-
-  // Get the leader actual.
+  // Compute the mask for this zip expression
   if (auto leader = (zip->numActuals() ? zip->actual(0) : nullptr)) {
-    auto iterandQt = rv.byPostorder.byAst(leader).type();
+    auto leaderQt = rv.byPostorder.byAst(leader).type();
 
-    // Set the policy mask for the leader based on the loop properties.
+    const auto skippingAllIterands = -1;
     int m = IterDetails::NONE;
     if (loopPrefersParallel) {
       m |= IterDetails::LEADER_FOLLOWER;
@@ -5223,7 +5286,7 @@ resolveZipExpression(Resolver& rv, const IndexableLoop* loop, const Zip* zip) {
       // Note that we will not attempt a leader/follower iterator.
       noteTheseResolutionFailure(rv, failures, Function::LEADER,
                                  skippingAllIterands,
-                                 rv.byPostorder.byAst(leader).type(),
+                                 leaderQt,
                                  TheseResolutionResult());
     }
 
@@ -5232,103 +5295,31 @@ resolveZipExpression(Resolver& rv, const IndexableLoop* loop, const Zip* zip) {
     } else {
       // Note that we will not attempt a serial iterator for any iterand.
       noteTheseResolutionFailure(rv, failures, Function::SERIAL, skippingAllIterands,
-                                 iterandQt, TheseResolutionResult());
+                                 leaderQt, TheseResolutionResult());
     }
 
     CHPL_ASSERT(m != IterDetails::NONE);
 
-    // Resolve the leader iterator.
-    auto dt = resolveIterDetails(rv, leader, leader, {}, m, /* emitError */ false);
+    // Compute iterator components to resolve as part of zippering.
+    std::vector<IterandComponent> ics = {
+      IterandComponent(rv, leader, leader)
+    };
+    for (int i = 1; i < zip->numActuals(); i++) {
+      auto follower = zip->actual(i);
+      ics.emplace_back(rv, follower, follower);
+    }
 
-    eltTypes.push_back(dt.idxType);
-
-    // Configure what followers should do using the iterator details.
-    if (dt.succeededAt == IterDetails::LEADER_FOLLOWER) {
-      followerPolicy = IterDetails::FOLLOWER;
-      leaderYieldType = dt.leaderYieldType;
-
-      // Note that we won't be attempting a serial iterator, even thought
-      // it was supported.
-      if (!loopRequiresParallel) {
-        auto result =TheseResolutionResult::failure(
-            TheseResolutionResult::THESE_FAIL_FOUND_DIFFERENT_ITERATOR,
-            iterandQt);
-        noteTheseResolutionFailure(rv, failures, Function::SERIAL,
-                                   skippingAllIterands,
-                                   iterandQt, std::move(result));
-      }
-    } else if (dt.succeededAt == IterDetails::SERIAL) {
-      followerPolicy = IterDetails::SERIAL;
-
-      // We didn't find a leader iterator, so note that as a failure in case
-      // we fail to find a serial iterator for other elements in the zip.
-      noteTheseResolutionFailure(rv, failures, Function::LEADER, 0, iterandQt,
-                                 std::move(dt.leader.resolutionResult));
-    } else {
-      ret = { QualifiedType::UNKNOWN, ErroneousType::get(context) };
-
-      // If we tried to resolve the parallel iterator, note that we failed.
-      if (loopPrefersParallel) {
-        noteTheseResolutionFailure(rv, failures, Function::LEADER, 0, iterandQt,
-                                   std::move(dt.leader.resolutionResult));
-      }
-
-      // If we tried to resolve the serial iterator, note that we failed.
-      if (!loopRequiresParallel) {
-        noteTheseResolutionFailure(rv, failures, Function::SERIAL, 0, iterandQt,
-                                   std::move(dt.serial.resolutionResult));
-      }
+    auto result = resolveIterDetailsInPriorityOrder(rv, ics, m, &failures);
+    if (result.succeededAt != IterDetails::NONE) {
+      ret = result.idxType;
     }
   }
 
-  // Resolve the follower iterator or serial iterator for all followers.
-  // It is possible for the follower policy to be 'NONE', in which case
-  // no iterators will be resolved, but the follower iterands will be
-  // resolved.
-  bool failedOthers = false;
-  for (int i = 1; i < zip->numActuals(); i++) {
-    auto actual = zip->actual(i);
-    auto dt = resolveIterDetails(rv, actual, actual, leaderYieldType,
-                                 followerPolicy, /* emitError */ false);
-    auto& qt = dt.idxType;
-    if (qt.isUnknownOrErroneous() && followerPolicy != IterDetails::NONE) {
-      bool isSerial = followerPolicy == IterDetails::SERIAL;
 
-      if (!failedOthers) {
-        noteTheseResolutionFailure(rv, failures,
-                                   isSerial ? Function::SERIAL : Function::FOLLOWER,
-                                   i, rv.byPostorder.byAst(actual).type(),
-                                   std::move(isSerial ?
-                                             dt.serial.resolutionResult :
-                                             dt.follower.resolutionResult));
-      }
-
-      failedOthers = true;
-    }
-
-    eltTypes.push_back(qt);
-  }
-
-  CHPL_ASSERT(((int) eltTypes.size()) == zip->numActuals());
-
-  auto kind = QualifiedType::CONST_VAR;
-  for (auto& et : eltTypes) {
-    if (!et.isUnknownOrErroneous() && !et.isConst()) {
-      kind = QualifiedType::VAR;
-      break;
-    }
-  }
-
-  if (!rv.scopeResolveOnly && (ret.isErroneousType() || failedOthers)) {
+  if (!rv.scopeResolveOnly && ret.isUnknownOrErroneous()) {
     // Emit a NonIterable error.
     ret = CHPL_TYPE_ERROR(context, NonIterable, loop, zip,
                           QualifiedType(), std::move(failures));
-  }
-
-  if (!ret.isErroneousType()) {
-    // This 'TupleType' builder preserves references for index types.
-    auto type = TupleType::getQualifiedTuple(context, std::move(eltTypes));
-    ret = { kind, type };
   }
 
   auto& reZip = rv.byPostorder.byAst(zip);
@@ -5503,7 +5494,7 @@ bool Resolver::enter(const IndexableLoop* loop) {
     if (!loopRequiresParallel) m |= IterDetails::SERIAL;
     CHPL_ASSERT(m != IterDetails::NONE);
 
-    auto dt = resolveIterDetails(*this, loop, iterand, {}, m, /* emitError */ true);
+    auto dt = resolveNonZipExpression(*this, loop, iterand, {}, m);
     idxType = dt.idxType;
   }
 
@@ -5742,8 +5733,8 @@ static QualifiedType resolveReduceScanOp(Resolver& resolver,
                                          const AstNode* op,
                                          const AstNode* iterand) {
   iterand->traverse(resolver);
-  auto dt = resolveIterDetails(resolver, reduceOrScan, iterand, {},
-                               IterDetails::SERIAL, /* emitError */ true);
+  auto dt = resolveNonZipExpression(resolver, reduceOrScan, iterand, {},
+                                    IterDetails::SERIAL);
   auto idxType = dt.idxType;
   if (idxType.isUnknown()) return QualifiedType();
   auto opClass = determineReduceScanOp(resolver, reduceOrScan, op, idxType);

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -5270,6 +5270,7 @@ resolveZipExpression(Resolver& rv, const IndexableLoop* loop, const Zip* zip) {
   Context* context = rv.context;
   bool loopRequiresParallel = loop->isForall();
   bool loopPrefersParallel = loopRequiresParallel || loop->isBracketLoop();
+  bool singletonZip = zip->numActuals() == 1;
   QualifiedType ret;
 
   // Compute the mask for this zip expression
@@ -5278,6 +5279,9 @@ resolveZipExpression(Resolver& rv, const IndexableLoop* loop, const Zip* zip) {
 
     const auto skippingAllIterands = -1;
     int m = IterDetails::NONE;
+    if (singletonZip) {
+      m |= IterDetails::STANDALONE;
+    }
     if (loopPrefersParallel) {
       m |= IterDetails::LEADER_FOLLOWER;
     } else {

--- a/frontend/lib/resolution/resolution-error-classes-list.cpp
+++ b/frontend/lib/resolution/resolution-error-classes-list.cpp
@@ -1152,9 +1152,9 @@ static void printTheseResults(
       bool isSerial = iterKind == uast::Function::SERIAL;
       wr.message(start, "this loop does not support ", isSerial ? "serial" : "parallel", " iterators", end);
     } else if (reason == TheseResolutionResult::THESE_FAIL_NO_LOOP_EXPR_STANDALONE) {
-      wr.message(start, "loop expressions do not have standalone iterators", end);
+      wr.message(start, "loop expressions with more than one zippered iterand do not have standalone iterators", end);
     } else if (reason == TheseResolutionResult::THESE_FAIL_NO_PROMO_STANDALONE) {
-      wr.message(start, "promoted expressions do not have standalone iterators", end);
+      wr.message(start, "promoted expressions with more than one zippered iterand do not have standalone iterators", end);
     } else if (reason == TheseResolutionResult::THESE_FAIL_SERIAL_LOOP_EXPR) {
       wr.message(start, "the loop expression iterated over is explicitly serial", end);
     } else if (reason == TheseResolutionResult::THESE_FAIL_NO_ITERATOR_WITH_TAG) {

--- a/frontend/lib/resolution/resolution-error-classes-list.cpp
+++ b/frontend/lib/resolution/resolution-error-classes-list.cpp
@@ -1171,9 +1171,6 @@ static void printTheseResults(
                         currentTr->zipperedFailureIndex() + 1,
                         ", ", currentTr->zipperedFailure()->iterandType(),
                         ") does not support a ", iterKindStr, " iterator", end);
-    } else if (reason == TheseResolutionResult::THESE_FAIL_FOUND_DIFFERENT_ITERATOR) {
-      wr.message(start, "the first zippered iterand had a parallel follower, "
-                        "which is prioritized over serial iteration", end);
     } else if (reason == TheseResolutionResult::THESE_FAIL_PROMOTION_TYPE_YIELD_MISMATCH) {
       wr.message(start, "the claimed scalar type for promotion does not match the type yielded from the iterator", end);
     }

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -5815,8 +5815,9 @@ resolveTheseCallForZipperedArguments(ResolutionContext* rc,
   bool serial = iterKind == Function::SERIAL;
   auto iterandType = QualifiedType(QualifiedType::CONST_VAR, iterType);
 
-  // Loop expressions don't have standalone iterators.
-  if (standalone) {
+  // Loop expressions and promotion only support standalone iterators
+  // when there's a single iterand.
+  if (standalone && zippered.size() > 1) {
     auto reason = iterType->isLoopExprIteratorType() ?
       TheseResolutionResult::THESE_FAIL_NO_LOOP_EXPR_STANDALONE :
       TheseResolutionResult::THESE_FAIL_NO_PROMO_STANDALONE;

--- a/frontend/test/resolution/testLoopIndexVars.cpp
+++ b/frontend/test/resolution/testLoopIndexVars.cpp
@@ -145,7 +145,7 @@ static void testAmbiguous() {
 
   const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
   auto idx = rr.byAst(loop->index());
-  assert(idx.type().isErroneousType());
+  assert(idx.type().isUnknown());
   assert(guard.realizeErrors() == 1);
 }
 

--- a/frontend/test/resolution/testLoopIndexVars.cpp
+++ b/frontend/test/resolution/testLoopIndexVars.cpp
@@ -951,8 +951,6 @@ static void testForallLoopExpressionStandalone(Context* context) {
     R""""(
     iter i1() { yield 0.0; }
     iter i1(param tag: iterKind) where tag == iterKind.standalone { yield 0.0; }
-    iter i1(param tag: iterKind) where tag == iterKind.leader { yield (0,0); }
-    iter i1(param tag: iterKind, followThis) where tag == iterKind.follower { yield 0.0; }
     )"""";
 
   pairIteratorInLoopExpression(context, iters, "i1()", {"forall", "do"}, {"forall", "do"},
@@ -975,14 +973,47 @@ static void testForallLoopExpressionLeaderFollower(Context* context) {
 static void testBracketLoopExpressionStandalone(Context* context) {
   auto iters =
     R""""(
-    iter i1() { yield 0.0; }
+    iter i1(param tag: iterKind) where tag == iterKind.standalone { yield 0.0; }
+    )"""";
+
+  pairIteratorInLoopExpression(context, iters, "i1()", {"[", "]"}, {"[", "]"},
+                               [](const QualifiedType& t) { return t.type()->isRealType(); });
+}
+
+static void testBracketLoopExpressionStandaloneZipperedSingleton(Context* context) {
+  auto iters =
+    R""""(
+    iter i1(param tag: iterKind) where tag == iterKind.standalone { yield 0.0; }
+    )"""";
+
+  pairIteratorInLoopExpression(context, iters, "zip(i1())", {"[", "]"}, {"[", "]"},
+                               [](const QualifiedType& t) { return t.type()->isRealType(); });
+}
+
+static void testBracketLoopExpressionStandaloneZippered(Context* context) {
+  auto iters =
+    R""""(
+    iter i1(param tag: iterKind) where tag == iterKind.standalone { yield 0.0; }
+    )"""";
+
+  pairIteratorInLoopExpression(context, iters, "zip(i1(), i1())", {"[", "]"}, {"[", "]"},
+                               [](const QualifiedType& t) { assert(false && "should not be called"); return true; },
+                               /* expectErrors */ 1);
+}
+
+static void testBracketLoopExpressionZippered(Context* context) {
+  auto iters =
+    R""""(
     iter i1(param tag: iterKind) where tag == iterKind.standalone { yield 0.0; }
     iter i1(param tag: iterKind) where tag == iterKind.leader { yield (0,0); }
     iter i1(param tag: iterKind, followThis) where tag == iterKind.follower { yield 0.0; }
     )"""";
 
-  pairIteratorInLoopExpression(context, iters, "i1()", {"[", "]"}, {"[", "]"},
-                               [](const QualifiedType& t) { return t.type()->isRealType(); });
+  pairIteratorInLoopExpression(context, iters, "zip(i1(), i1())", {"[", "]"}, {"[", "]"},
+                               [](const QualifiedType& t) {
+    return t.type()->isTupleType() &&
+           t.type()->toTupleType()->starType().type()->isRealType();
+  });
 }
 
 static void testBracketLoopExpressionLeaderFollower(Context* context) {
@@ -1118,6 +1149,9 @@ int main() {
   testForallLoopExpressionStandalone(context);
   testForallLoopExpressionLeaderFollower(context);
   testBracketLoopExpressionStandalone(context);
+  testBracketLoopExpressionStandaloneZippered(context);
+  testBracketLoopExpressionStandaloneZipperedSingleton(context);
+  testBracketLoopExpressionZippered(context);
   testBracketLoopExpressionLeaderFollower(context);
   testBracketLoopExpressionSerial(context);
   testForLoopExpressionInForall(context);

--- a/frontend/test/resolution/testLoopIndexVars.cpp
+++ b/frontend/test/resolution/testLoopIndexVars.cpp
@@ -1060,6 +1060,30 @@ static void testForallExpressionInForLoop(Context* context) {
                                [](const QualifiedType& t) { return t.type()->toRealType(); });
 }
 
+static void testBracketLoopSerialFallback(Context* context) {
+  // Test that a bracket loop expression falls back to the serial iterator
+  // if a leader is present, but one of the followers is not.
+  auto iters =
+    R""""(
+    iter i1() { yield 0.0; }
+    iter i1(param tag: iterKind) where tag == iterKind.leader { yield (0,0); }
+    iter i1(param tag: iterKind, followThis) where tag == iterKind.follower { yield 0.0; }
+
+    iter i2() { yield 0.0; }
+    iter i2(param tag: iterKind) where tag == iterKind.leader { yield (0,0); }
+    )"""";
+
+  // Follower iterator yields tuples of ints, so expect tuples of ints.
+  pairIteratorInLoopExpression(context, iters, "zip(i1(), i2())", {"[", "]"}, {"[", "]"},
+                               [](const QualifiedType& t) {
+    if (auto tt = t.type()->toTupleType()) {
+      if (!tt->isStarTuple()) return false;
+      return tt->starType().type()->isRealType();
+    }
+    return false;
+  });
+}
+
 int main() {
   testSimpleLoop("for");
   testSimpleLoop("coforall");
@@ -1099,6 +1123,8 @@ int main() {
   testForLoopExpressionInForall(context);
   testForLoopExpressionInBracketLoop(context);
   testForallExpressionInForLoop(context);
+
+  testBracketLoopSerialFallback(context);
 
   return 0;
 }

--- a/frontend/test/resolution/testPromotion.cpp
+++ b/frontend/test/resolution/testPromotion.cpp
@@ -247,9 +247,6 @@ static void test8() {
 }
 
 static void test9() {
-  // Disabled: promotion doesn't have standalone iterators at this time
-  return;
-
   // Promotion respects parallelism allowed by loops (invoking parallel iterator)
   runProgram(
       { "proc foo(x: int) do return true;",


### PR DESCRIPTION
This PR depends on https://github.com/chapel-lang/chapel/pull/26265. The clean diff is https://github.com/chapel-lang/chapel/pull/26273/files/dcfba2c700b91bdd262919a15306116d5be8f1fd..6399bfa6a10b2a62ded679cbd39bec93a142a610.

@bradcray pointed out that it seems to make sense to allow promoted functions over a single argument and loop expressions with a single iterand to have a standalone iterator if their iterand has one. This PR implements this, specifically by doing the following:

* Allowing loops over `zip` with a single argument to invoke the standalone iterator; this brings the behavior of `zip(i())` closer to `i()`
* Adjusting the compiler-generated implementation of `iter these` for loop expressions and promoted functions to allow `STANDALONE` iteration if there's only a single iterand.
* Adjusting the error messages to indicate that only multi-iterand (zippered) promotions and loops don't have standalone iterators.

While there, I noticed that iterator resolution will attempt to invoke `these` on `UnknownType()` in parallel iteration cases. This PR adjusts the implementation to bail early if any of the iterands is Unknown, since that means we can't accurately resolve any iterators.

Reviewed by @benharsh -- thanks!

## Testing
- [x] dyno tests, including new tests for standalone iteration (zippered and not), and a re-enabled standalone promotion test