### PR TITLE
Fix overloaded parnless as base expr

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4378,16 +4378,15 @@ static FnSymbol* resolveNormalCall(CallInfo&            info,
                                    ResolutionCandidate* bestRef,
                                    ResolutionCandidate* bestConstRef,
                                    ResolutionCandidate* bestValue) {
-  CallExpr*            call          = info.call;
-  CallExpr*            refCall       = NULL;
-  CallExpr*            valueCall     = NULL;
-  CallExpr*            constRefCall  = NULL;
-  CallExpr*            ccAnchor      = NULL; // the last of the above CallExprs
-  ResolutionCandidate* best          = NULL;
-  FnSymbol*            retval        = NULL;
-  CallExpr*            partialParent = call->partialTag ?
-                                       toCallExpr(call->parentExpr) :
-                                       NULL;
+  CallExpr* call = info.call;
+  CallExpr* refCall = NULL;
+  CallExpr* valueCall = NULL;
+  CallExpr* constRefCall = NULL;
+  CallExpr* ccAnchor = NULL; // the last of the above CallExprs
+  ResolutionCandidate* best = NULL;
+  FnSymbol* retval = NULL;
+  CallExpr* partialParent = call->partialTag ? toCallExpr(call->parentExpr) :
+                                               NULL;
 
   if (bestRef      != NULL) {
     refCall = call;

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4378,13 +4378,16 @@ static FnSymbol* resolveNormalCall(CallInfo&            info,
                                    ResolutionCandidate* bestRef,
                                    ResolutionCandidate* bestConstRef,
                                    ResolutionCandidate* bestValue) {
-  CallExpr*            call         = info.call;
-  CallExpr*            refCall      = NULL;
-  CallExpr*            valueCall    = NULL;
-  CallExpr*            constRefCall = NULL;
-  CallExpr*            ccAnchor     = NULL; // the last of the above CallExprs
-  ResolutionCandidate* best         = NULL;
-  FnSymbol*            retval       = NULL;
+  CallExpr*            call          = info.call;
+  CallExpr*            refCall       = NULL;
+  CallExpr*            valueCall     = NULL;
+  CallExpr*            constRefCall  = NULL;
+  CallExpr*            ccAnchor      = NULL; // the last of the above CallExprs
+  ResolutionCandidate* best          = NULL;
+  FnSymbol*            retval        = NULL;
+  CallExpr*            partialParent = call->partialTag ?
+                                       toCallExpr(call->parentExpr) :
+                                       NULL;
 
   if (bestRef      != NULL) {
     refCall = call;
@@ -4400,7 +4403,8 @@ static FnSymbol* resolveNormalCall(CallInfo&            info,
     } else {
       valueCall = call->copy();
 
-      call->insertAfter(valueCall);
+      auto insertAfter = partialParent ? call->parentExpr : call;
+      insertAfter->insertAfter(valueCall);
     }
 
     instantiateBody(bestValue->fn);
@@ -4410,7 +4414,8 @@ static FnSymbol* resolveNormalCall(CallInfo&            info,
   if (bestConstRef != NULL) {
     constRefCall = call->copy();
 
-    call->insertAfter(constRefCall);
+    auto insertAfter = partialParent ? call->parentExpr : call;
+    insertAfter->insertAfter(constRefCall);
 
     instantiateBody(bestConstRef->fn);
 
@@ -4500,11 +4505,21 @@ static FnSymbol* resolveNormalCall(CallInfo&            info,
     // Replace the call with a new ContextCallExpr containing 2 or 3 calls
     ContextCallExpr* contextCall = new ContextCallExpr();
 
-    ccAnchor->insertAfter(contextCall);
+    if (partialParent) {
+      // If we're partial, we're actually the baseExpr of some other call;
+      // handle that below, after we've removed the previous base expression.
+    } else {
+      ccAnchor->insertAfter(contextCall);
+    }
 
     if (refCall      != NULL) refCall->remove();
     if (valueCall    != NULL) valueCall->remove();
     if (constRefCall != NULL) constRefCall->remove();
+
+    if (partialParent) {
+      partialParent->baseExpr = contextCall;
+      parent_insert_help(partialParent, contextCall);
+    }
 
     contextCall->setRefValueConstRefOptions(refCall,
                                             valueCall,

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -150,6 +150,9 @@ Expr* preFold(CallExpr* call) {
 
       thisTemp->addFlag(FLAG_EXPR_TEMP);
 
+      // toCallExpr(baseExpr) lies and returns a CallExpr for ContextCall.
+      // In this case, we want to store the whole ContextCall in a temp;
+      // so, check if we were lied to.
       Expr* receiver = nullptr;
       if (auto cc = toContextCallExpr(callExpr->parentExpr)) {
         receiver = cc;

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -150,9 +150,15 @@ Expr* preFold(CallExpr* call) {
 
       thisTemp->addFlag(FLAG_EXPR_TEMP);
 
-      callExpr->replace(new UnresolvedSymExpr("this"));
+      Expr* receiver = nullptr;
+      if (auto cc = toContextCallExpr(callExpr->parentExpr)) {
+        receiver = cc;
+      } else {
+        receiver = callExpr;
+      }
 
-      retval = new CallExpr(PRIM_MOVE, thisTemp, callExpr);
+      receiver->replace(new UnresolvedSymExpr("this"));
+      retval = new CallExpr(PRIM_MOVE, thisTemp, receiver);
 
       call->insertAtHead(new SymExpr(thisTemp));
       call->insertAtHead(gMethodToken);

--- a/test/functions/resolution/parenless-return-intent-overloaded-proc-this-imag.chpl
+++ b/test/functions/resolution/parenless-return-intent-overloaded-proc-this-imag.chpl
@@ -1,0 +1,3 @@
+var c: complex = 1.2 + 3.4i;
+
+writeln(c.re());

--- a/test/functions/resolution/parenless-return-intent-overloaded-proc-this-imag.good
+++ b/test/functions/resolution/parenless-return-intent-overloaded-proc-this-imag.good
@@ -1,0 +1,1 @@
+parenless-return-intent-overloaded-proc-this-imag.chpl:3: error: unresolved access of 'real(64)' by '()'

--- a/test/functions/resolution/parenless-return-intent-overloaded-proc-this-reasonable.chpl
+++ b/test/functions/resolution/parenless-return-intent-overloaded-proc-this-reasonable.chpl
@@ -1,0 +1,14 @@
+record callable {
+  proc this() {
+    writeln("I'm a callable thingie!");
+  }
+}
+
+record R {
+  var myCallable_: callable;
+
+  proc fn do return myCallable_;
+  proc ref fn ref do return myCallable_;
+}
+var r = new R();
+r.fn();

--- a/test/functions/resolution/parenless-return-intent-overloaded-proc-this-reasonable.good
+++ b/test/functions/resolution/parenless-return-intent-overloaded-proc-this-reasonable.good
@@ -1,0 +1,1 @@
+I'm a callable thingie!

--- a/test/functions/resolution/parenless-return-intent-overloaded-proc-this.chpl
+++ b/test/functions/resolution/parenless-return-intent-overloaded-proc-this.chpl
@@ -1,0 +1,12 @@
+record R {}
+var r = new R();
+var myConstant = 1.0;
+
+proc R.foo {
+  return myConstant;
+}
+proc R.foo ref {
+  return myConstant;
+}
+
+r.foo();

--- a/test/functions/resolution/parenless-return-intent-overloaded-proc-this.good
+++ b/test/functions/resolution/parenless-return-intent-overloaded-proc-this.good
@@ -1,0 +1,1 @@
+parenless-return-intent-overloaded-proc-this.chpl:12: error: unresolved access of 'real(64)' by '()'


### PR DESCRIPTION
Closes https://github.com/chapel-lang/chapel/issues/26263.

The issue in question is that we get an internal error while invoking a return-intent-overloaded parenless procedure. 

```Chapel
record R {}
var r = new R();
var myConstant = 1.0;

proc R.foo {
  return myConstant;
}
proc R.foo ref {
  return myConstant;
}

r.foo();
```

At the surface level, this is caused by the code that attempts to do return intent overloading; it assumes that the overloaded call is a part of a list. When a field is being invoked, like `r.foo()`, the overloaded call (`r.foo`) is actually the base expression, which is not in any list.

I think it's conceivable for this combination of features to be used in user code; if `myConstant` wasn't an integer but actually a record/class with `proc this` defined on it, `r.foo()` would invoke that `proc this`, and that seems reasonable enough. So, my approach was to make this case "work", up to the type-correctness of invoking the `proc this`.

To that end, this PR adds some extra checking to handle the case where a return-intent-overloaded call is the base expression of another call. This required two primary changes; the `insertAfter` diff is the first, and the `partialParent->baseExpr = contextCall;` is the other.

This gets us further, but code for invoking `proc this` doesn't expect the base expression to be a `ContextCall` / overloaded call either. This PR adjusts that as well.

Reviewed by @lydia-duncan -- thanks!

## Testing
- [x] both tests from 26263
- [x] paratest