### PR TITLE
Fix cryptic "failed to exec /usr/bin/env" errors with gasnet launchers

### DIFF
--- a/runtime/src/chpl-launcher-common.c
+++ b/runtime/src/chpl-launcher-common.c
@@ -538,39 +538,45 @@ int chpl_launch_using_system(char* command, char* argv0) {
 
 char* chpl_get_enviro_keys(char sep)
 {
-  int pass;
-  int i;
-  int j;
-  int k = 0;
-  char* ret = NULL;
+  // count the variables in environ, and how many characters in each name
+  int numVars = 0;
+  int numChars = 0;
+  for(int i = 0; environ && environ[i]; i++) {
+    numVars++;
+    int keyLen = strstr(environ[i], "=") - environ[i];
 
-  for( pass = 0; pass < 2; pass++ ) {
-    k = 0;
-    for( i = 0; environ && environ[i]; i++ ) {
-      // We could do this for only some environment
-      // variables if we wanted to; that would amount
-      // to an if statement checking environ[i];
-      // but we find it to be more similar to MPI/SLURM
-      // to forward all environment variables.
-      // Count/store the separator
-      if( k > 0 ) {
-        if( pass == 0 ) k++;
-        else ret[k++] = sep;
-      }
-
-      for( j = 0; environ[i][j] && environ[i][j] != '='; j++ ) {
-        if( pass == 0 ) {
-          // on first pass, just count.
-          k++;
-        } else {
-          // on second pass, add to buffer.
-          ret[k++] = environ[i][j];
-        }
-      }
+    // if the key ends with _modshare, skip it
+    if (keyLen > 8 strncmp(environ[i] + keyLen - 8, "_modshare", 9) == 0) {
+      continue;
     }
-    if( pass == 0 ) ret = chpl_mem_allocMany(k+1, sizeof(char),
-                                             CHPL_RT_MD_COMMAND_BUFFER,-1,0);
+    numVars++;
+    numChars += keyLen;
   }
+  // allocate space for the keys, the separators, and the null terminator
+  int bufferLength = numChars + numVars + 1;
+  char* buffer = chpl_mem_allocMany(bufferLength, sizeof(char),
+                                 CHPL_RT_MD_COMMAND_BUFFER, -1, 0);
+
+  // copy the keys into the buffer
+  int bufferOffset = 0;
+  for(int i = 0; environ && environ[i]; i++) {
+
+    int keyLen = strstr(environ[i], "=") - environ[i];
+    // skip keys that end with _modshare
+    if (keyLen > 8 && strncmp(environ[i] + keyLen - 8, "_modshare", 9) == 0) {
+      continue;
+    }
+    strncpy(buffer + bufferOffset, environ[i], keyLen);
+    bufferOffset += keyLen;
+
+    buffer[bufferOffset] = sep;
+    bufferOffset++''
+  }
+  buffer[bufferOffset] = '\0';
+  buffer[bufferLength-1] = '\0';
+
+  return buffer;
+
 
   return ret;
 }

--- a/runtime/src/chpl-launcher-common.c
+++ b/runtime/src/chpl-launcher-common.c
@@ -546,7 +546,7 @@ char* chpl_get_enviro_keys(char sep)
     int keyLen = strstr(environ[i], "=") - environ[i];
 
     // if the key ends with _modshare, skip it
-    if (keyLen > 8 strncmp(environ[i] + keyLen - 8, "_modshare", 9) == 0) {
+    if (keyLen > 8 && strncmp(environ[i] + keyLen - 8, "_modshare", 9) == 0) {
       continue;
     }
     numVars++;
@@ -570,15 +570,12 @@ char* chpl_get_enviro_keys(char sep)
     bufferOffset += keyLen;
 
     buffer[bufferOffset] = sep;
-    bufferOffset++''
+    bufferOffset++;
   }
   buffer[bufferOffset] = '\0';
   buffer[bufferLength-1] = '\0';
 
   return buffer;
-
-
-  return ret;
 }
 
 

--- a/util/chplenv/chpl_unwind.py
+++ b/util/chplenv/chpl_unwind.py
@@ -38,7 +38,7 @@ def get_uniq_cfg_path():
 def get_compile_args():
     unwind_val = get()
     if unwind_val == 'bundled':
-         return third_party_utils.get_bundled_compile_args('libunwind')
+        return third_party_utils.get_bundled_compile_args('libunwind')
 
     return ([ ], [ ])
 

--- a/util/test/chpl_launchcmd.py
+++ b/util/test/chpl_launchcmd.py
@@ -57,8 +57,10 @@ def main():
     """Run the program!"""
     job = AbstractJob.init_from_environment()
     (stdout, stderr) = job.run()
+    logging.debug("I am after run {} {} {} {}", stdout, type(stdout), stderr, type(stderr))
     sys.stdout.buffer.write(stdout)
     sys.stderr.buffer.write(stderr)
+    logging.debug("I am after buffer writes")
 
 
 class AbstractJob(object):
@@ -400,6 +402,8 @@ class AbstractJob(object):
                 pass
 
             logging.info('The test finished with output of length {0}.'.format(len(output)))
+
+        logging.debug('Returning output and error from job.')
 
         return (output, error)
 
@@ -1145,7 +1149,7 @@ def _temp_dir(dir_prefix='chapel-test-tmp'):
         yield tmp_dir
     finally:
         logging.debug('Deleting temporary working directory at: {0}'.format(tmp_dir))
-        shutil.rmtree(tmp_dir)
+        # shutil.rmtree(tmp_dir)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes a cryptic error that can occur when there are enough environment variables that are long, causing us to run out of space in a buffer. This is especially a problem for something like spack, which is prone to embedding very long paths in many environment variables.

This PR works around this by excluding certain environment variables we know aren't needed, in this case the PR excludes all variables suffixed with `_modshare`. These variables end up being duplicateted, so you have `VAR="some long string"` and `VAR_modshare="some long string"`. Its not important we maintain the duplicates, so this PR just filters them out.

Tested that with this patch the error goes away

[Reviewed by @jhh67]