### PR TITLE
Prevent loading base dependencies more than once

### DIFF
--- a/util/cron/load-base-deps.bash
+++ b/util/cron/load-base-deps.bash
@@ -4,7 +4,7 @@
 
 # Prevent loading more than once
 if [ "$CHPL_BASE_DEPS_LOADED" = "true" ]; then
-  echo "Base dependencies already loaded, exiting $0 without reloading them..."
+  echo "Base dependencies already loaded, exiting ${BASH_SOURCE[0]} without reloading them..."
   return 0
 fi
 export CHPL_BASE_DEPS_LOADED=true

--- a/util/cron/load-base-deps.bash
+++ b/util/cron/load-base-deps.bash
@@ -2,6 +2,13 @@
 
 # Sources base dependencies required for all tests.
 
+# Prevent loading more than once
+if [ "$CHPL_BASE_DEPS_LOADED" = "true" ]; then
+  echo "Base dependencies already loaded, exiting $0 without reloading them..."
+  return 0
+fi
+export CHPL_BASE_DEPS_LOADED=true
+
 # For most systems, load all dependencies via spack
 if [[ "${HOSTNAME:0:6}" == "chapcs" || "${HOSTNAME:0:6}" == "chapvm" ]]; then
   if [ -f /data/cf/chapel/chpl-deps/chapcs11/load_chpl_deps.bash ] ; then


### PR DESCRIPTION
Make the `util/cron/load-base-deps.bash` script no-op on subsequent runs after the first, to avoid unnecessarily reloading dependencies.

We have some cases in our network of interdependent `util/cron/common*` scripts that cause this script to get `source`d more than once. To prevent wasting time or encountering the occasional issues from loading Spack into the shell more than once ([1](https://github.com/spack/spack/issues/31275), [2](https://github.com/spack/spack/issues/40901), [3](https://cray.slack.com/archives/CGSFYJN86/p1732123044192589)), guard against re-running this script.

This is something of a workaround because we could also adjust our scripts to not ultimately call `load-base-deps.bash` more than once. However, that might be difficult due to how much interdependency and order-sensitivity we have in these scripts.

[reviewer info placeholder]

Testing:
- [x] no longer getting error from recent issue in [slack thread](https://cray.slack.com/archives/CGSFYJN86/p1732123044192589)
- [x] manually running a test script succeeds
- [x] shellcheck on added lines