### PR TITLE
Pin to debug info version for test

### DIFF
--- a/test/runtime/stacktrace/fact-linenum-default.bad
+++ b/test/runtime/stacktrace/fact-linenum-default.bad
@@ -1,0 +1,8 @@
+fact-linenum-default.chpl:2: error: halt reached
+Stacktrace
+
+halt() at $CHPL_HOME/modules/standard/Errors.chpl:nnnn
+fact() at fact-linenum-default.chpl:1
+fact() at fact-linenum-default.chpl:1
+fact() at fact-linenum-default.chpl:1
+chpl__init_fact-linenum-default() at fact-linenum-default.chpl:1

--- a/test/runtime/stacktrace/fact-linenum-default.chpl
+++ b/test/runtime/stacktrace/fact-linenum-default.chpl
@@ -1,0 +1,1 @@
+fact-linenum.chpl

--- a/test/runtime/stacktrace/fact-linenum-default.compopts
+++ b/test/runtime/stacktrace/fact-linenum-default.compopts
@@ -1,0 +1,1 @@
+-g --cpp-lines

--- a/test/runtime/stacktrace/fact-linenum-default.future
+++ b/test/runtime/stacktrace/fact-linenum-default.future
@@ -1,0 +1,5 @@
+bug: debug info in a stack trace should work without needing to specify -gdwarf
+
+
+This future is a duplicate of fact-linenum.chpl, when the future is resolved
+this test can be deleted and fact-linenum.compopts modified

--- a/test/runtime/stacktrace/fact-linenum-default.good
+++ b/test/runtime/stacktrace/fact-linenum-default.good
@@ -1,0 +1,8 @@
+fact-linenum-default.chpl:2: error: halt reached
+Stacktrace
+
+halt() at $CHPL_HOME/modules/standard/Errors.chpl:nnnn
+fact() at fact-linenum-default.chpl:2
+fact() at fact-linenum-default.chpl:3
+fact() at fact-linenum-default.chpl:3
+chpl__init_fact-linenum-default() at fact-linenum-default.chpl:1

--- a/test/runtime/stacktrace/fact-linenum-default.skipif
+++ b/test/runtime/stacktrace/fact-linenum-default.skipif
@@ -1,0 +1,1 @@
+fact-linenum.skipif

--- a/test/runtime/stacktrace/fact-linenum.compopts
+++ b/test/runtime/stacktrace/fact-linenum.compopts
@@ -1,1 +1,1 @@
--g --cpp-lines
+-g --cpp-lines --ccflags -gdwarf-4


### PR DESCRIPTION
Pin debug info the DWARF 4 for a test.

The proper fix is to fix our debug info, this is temporary to get the test passing again

This PR also adds a future to capture the desire to make this work better again

[Reviewed by @riftEmber]