### PR TITLE
Exclude draining AND drained nodes from paratests

### DIFF
--- a/util/test/paratest.chapcs
+++ b/util/test/paratest.chapcs
@@ -73,7 +73,7 @@ def get_exclusive_nodes():
                  '--noheader',
                  '--responding',
                  '--format="NO;%D;%N;%N;None"',
-                 '--states=DRAINING']
+                 '--states=DRAIN']
     sinfo_out = run_command_wrapper(sinfo_cmd)
 
     num_exclusive_nodes = 0


### PR DESCRIPTION
Drained nodes cannot have new jobs sent to them. The slurm `sinfo` command, which we use to count how many nodes to launch jobs on, does not have support for filtering out drained nodes. Instead, we separately query the number of drained nodes and subtract it from the total node number. However, we only query the number of drain__ing__ nodes, and not the number of nodes that have already been drained (but are still not accepting new jobs). This PR fixes that. From the [slurm docs](https://slurm.schedmd.com/sinfo.html), `DRAIN` includes both `DRAINING` and `DRAINED`:

> DRAIN (for node in DRAINING or DRAINED states), DRAINED, DRAINING

Reviewed by @riftEmber -- thanks!

## Testing
- [x] I launched a paratest :)