### PR TITLE
Fix GPU halting under OFI

### DIFF
--- a/compiler/optimizations/gpuTransforms.cpp
+++ b/compiler/optimizations/gpuTransforms.cpp
@@ -2034,7 +2034,7 @@ void GpuKernel::markGPUSubCalls(FnSymbol* fn) {
   errorForOuterVarAccesses(fn);
 
   std::vector<CallExpr*> calls;
-  collectCallExprs(fn, calls);
+  collectCallExprsForGpuEligibilityAnalysis(fn, calls);
   for_vector(CallExpr, call, calls) {
     if (FnSymbol* fn = call->resolvedFunction()) {
       markGPUSubCalls(fn);


### PR DESCRIPTION
In some cases (multi-locale compilation), we seem to generate more string-like operations in the body of `halt`. They are never triggered (they're in the CPU-only body of the function), but they do get flagged for outer variable access etc. Since we know GPUs won't be running that code, don't flag these as dangerous.

Reviewed by @vasslitvinov -- thanks!

## Testing
- [x] `test/gpu/native` NVIDIA
- [x] `test/gpu/native` AMD
- [x] halting test on OFI