### PR TITLE
Set `CC` in addition to `CXX` in regex ctests

### DIFF
--- a/test/regex/ferguson/ctests/sub_test
+++ b/test/regex/ferguson/ctests/sub_test
@@ -14,8 +14,6 @@ then
 fi
 
 DIR=regex/ferguson/ctests
-CC=gcc
-CXX=g++
 DEFS=`$CHPL_HOME/util/config/compileline --includes-and-defines`
 RSRC="$CHPL_HOME/runtime/src/qio"
 RE2_INSTALL_DIR=$($CHPL_HOME/util/config/compileline --libraries | \

--- a/test/regex/ferguson/ctests/sub_test
+++ b/test/regex/ferguson/ctests/sub_test
@@ -14,6 +14,7 @@ then
 fi
 
 DIR=regex/ferguson/ctests
+CC=gcc
 CXX=g++
 DEFS=`$CHPL_HOME/util/config/compileline --includes-and-defines`
 RSRC="$CHPL_HOME/runtime/src/qio"
@@ -45,6 +46,7 @@ else
 fi
 
 COMP=`$CHPL_HOME/util/chplenv/chpl_compiler.py --target`
+CC=`$CHPL_HOME/util/printchplenv --all --simple | grep CHPL_TARGET_CC | cut -d = -f 2-`
 CXX=`$CHPL_HOME/util/printchplenv --all --simple | grep CHPL_TARGET_CXX | cut -d = -f 2-`
 ASAN=`$CHPL_HOME/util/printchplenv --all --simple | grep CHPL_SANITIZE_EXE | cut -d = -f 2-`
 if [ "$COMP" = "gnu" ]
@@ -63,6 +65,7 @@ fi
 
 if [ "$ASAN" = "address" ]
 then
+  CC="$CC -fsanitize=address"
   CXX="$CXX -fsanitize=address"
 fi
 


### PR DESCRIPTION
After recent Spack changes, `CC` was being set to clang in some configurations, which conflicted to the `CXX` setting of a gnu compiler. Although only `CXX` is used for this test, chplenv complains about the mismatch. Resolve by setting `CC` analogously.

The specific situation hit was by Lydia, whose bashrc loaded an older spack setup that included LLVM 17 and didn't unset `CC`/`CXX`. It's still unclear why this started being hit after the recent LLVM 19 Spack upgrade, but in any case this test should probably not just fail when encountering a clang `CC`.

[reviewer info placeholder]

Testing:
- [x] tests pass in reproducer configuration
- [x] tests pass in "new" nightly configuration