### PR TITLE
Fix missing Py_DECREF in older Python versions

### DIFF
--- a/modules/packages/Python.chpl
+++ b/modules/packages/Python.chpl
@@ -1343,7 +1343,7 @@ module Python {
     extern proc PyStatus_Exception(in status: PyStatus): bool;
     extern proc Py_Finalize();
     extern proc Py_INCREF(obj: PyObjectPtr);
-    extern proc Py_DECREF(obj: PyObjectPtr);
+    extern "chpl_Py_DECREF" proc Py_DECREF(obj: PyObjectPtr);
     extern proc PyObject_Str(obj: PyObjectPtr): PyObjectPtr; // `str(obj)`
     extern proc PyImport_ImportModule(name: c_ptrConst(c_char)): PyObjectPtr;
 

--- a/modules/packages/PythonHelper/ChapelPythonHelper.h
+++ b/modules/packages/PythonHelper/ChapelPythonHelper.h
@@ -52,6 +52,8 @@ static inline PyObject* chpl_PyErr_GetRaisedException(void) {
 #endif
 }
 
+static inline void chpl_Py_DECREF(PyObject* o) { Py_DECREF(o); }
+
 static inline int chpl_PyList_Check(PyObject* o) { return PyList_Check(o); }
 static inline int chpl_PyGen_Check(PyObject* o) { return PyGen_Check(o); }
 


### PR DESCRIPTION
Fixes errors about being unable to link against `Py_DECREF` in older versions of Python, due to `Py_DECREF` being a "complex macro" in older version (Prior to Python 3.11).

Tested with Python 3.10 and 3.13

[Reviewed by @DanilaFe]