### PR TITLE
Update flags needed to build with Python module

### DIFF
--- a/modules/packages/Python.chpl
+++ b/modules/packages/Python.chpl
@@ -69,7 +69,8 @@
      PYTHON_LDVERSION=$(python3 -c "import sysconfig; print(sysconfig.get_config_var('LDVERSION'))")
 
      chpl --ccflags -isystem$PYTHON_INCLUDE_DIR \
-          -L$PYTHON_LIB_DIR -lpython$PYTHON_LDVERSION ...Chapel source files...
+          -L$PYTHON_LIB_DIR --ldflags -Wl,-rpath,$PYTHON_LIB_DIR \
+          -lpython$PYTHON_LDVERSION ...Chapel source files...
 
   Parallel Execution
   ------------------

--- a/test/library/packages/Python/COMPOPTS
+++ b/test/library/packages/Python/COMPOPTS
@@ -12,4 +12,4 @@ PYTHON_INCLUDE_DIR=$($chpl_python -c "import sysconfig; print(sysconfig.get_path
 PYTHON_LIB_DIR=$($chpl_python -c "import sysconfig; print(sysconfig.get_config_var('LIBDIR'))")
 PYTHON_LDVERSION=$($chpl_python -c "import sysconfig; print(sysconfig.get_config_var('LDVERSION'))")
 
-echo "--ccflags -isystem$PYTHON_INCLUDE_DIR -L$PYTHON_LIB_DIR -lpython$PYTHON_LDVERSION"
+echo "--ccflags -isystem$PYTHON_INCLUDE_DIR -L$PYTHON_LIB_DIR --ldflags -Wl,-rpath,$PYTHON_LIB_DIR -lpython$PYTHON_LDVERSION"


### PR DESCRIPTION
Updates the flags needed to build with the Python module to include "-Wl,-rpath", so that there is no reliance on the value of LD_LIBRARY_PATH

[Reviewed by @DanilaFe]