### PR TITLE
Use const-qualified pointers where needed in Python module

### DIFF
--- a/modules/packages/Python.chpl
+++ b/modules/packages/Python.chpl
@@ -1395,7 +1395,7 @@ module Python {
 
     extern var Py_False: PyObjectPtr;
     extern var Py_True: PyObjectPtr;
-    extern "chpl_Py_None" var Py_None: PyObjectPtr;
+    extern "chpl_Py_None" var Py_None: c_ptrConst(PyObject);
 
     /*
       Sequences

--- a/modules/packages/Python.chpl
+++ b/modules/packages/Python.chpl
@@ -1391,7 +1391,7 @@ module Python {
     extern proc PyFloat_AsDouble(obj: PyObjectPtr): real(64);
     extern proc PyBool_FromLong(v: c_long): PyObjectPtr;
     extern proc PyString_FromString(s: c_ptrConst(c_char)): PyObjectPtr;
-    extern proc PyUnicode_AsUTF8(obj: PyObjectPtr): c_ptr(c_char);
+    extern proc PyUnicode_AsUTF8(obj: PyObjectPtr): c_ptrConst(c_char);
 
     extern var Py_False: PyObjectPtr;
     extern var Py_True: PyObjectPtr;

--- a/modules/packages/Python.chpl
+++ b/modules/packages/Python.chpl
@@ -1393,8 +1393,8 @@ module Python {
     extern proc PyString_FromString(s: c_ptrConst(c_char)): PyObjectPtr;
     extern proc PyUnicode_AsUTF8(obj: PyObjectPtr): c_ptrConst(c_char);
 
-    extern var Py_False: PyObjectPtr;
-    extern var Py_True: PyObjectPtr;
+    extern var Py_False: c_ptrConst(PyObject);
+    extern var Py_True: c_ptrConst(PyObject);
     extern "chpl_Py_None" var Py_None: c_ptrConst(PyObject);
 
     /*

--- a/modules/packages/Python.chpl
+++ b/modules/packages/Python.chpl
@@ -1393,9 +1393,18 @@ module Python {
     extern proc PyString_FromString(s: c_ptrConst(c_char)): PyObjectPtr;
     extern proc PyUnicode_AsUTF8(obj: PyObjectPtr): c_ptrConst(c_char);
 
-    extern var Py_False: c_ptrConst(PyObject);
-    extern var Py_True: c_ptrConst(PyObject);
-    extern "chpl_Py_None" var Py_None: c_ptrConst(PyObject);
+    proc Py_None: PyObjectPtr {
+      extern proc chpl_Py_None(): PyObjectPtr;
+      return chpl_Py_None();
+    }
+    proc Py_True: PyObjectPtr {
+      extern proc chpl_Py_True(): PyObjectPtr;
+      return chpl_Py_True();
+    }
+    proc Py_False: PyObjectPtr {
+      extern proc chpl_Py_False(): PyObjectPtr;
+      return chpl_Py_False();
+    }
 
     /*
       Sequences

--- a/modules/packages/PythonHelper/ChapelPythonHelper.h
+++ b/modules/packages/PythonHelper/ChapelPythonHelper.h
@@ -55,8 +55,8 @@ static inline PyObject* chpl_PyErr_GetRaisedException(void) {
 static inline int chpl_PyList_Check(PyObject* o) { return PyList_Check(o); }
 static inline int chpl_PyGen_Check(PyObject* o) { return PyGen_Check(o); }
 
-static inline PyObject* chpl_Py_None() { return (PyObject*)Py_None; }
-static inline PyObject* chpl_Py_True() { return (PyObject*)Py_True; }
-static inline PyObject* chpl_Py_False() { return (PyObject*)Py_False; }
+static inline PyObject* chpl_Py_None(void) { return (PyObject*)Py_None; }
+static inline PyObject* chpl_Py_True(void) { return (PyObject*)Py_True; }
+static inline PyObject* chpl_Py_False(void) { return (PyObject*)Py_False; }
 
 #endif

--- a/modules/packages/PythonHelper/ChapelPythonHelper.h
+++ b/modules/packages/PythonHelper/ChapelPythonHelper.h
@@ -55,6 +55,8 @@ static inline PyObject* chpl_PyErr_GetRaisedException(void) {
 static inline int chpl_PyList_Check(PyObject* o) { return PyList_Check(o); }
 static inline int chpl_PyGen_Check(PyObject* o) { return PyGen_Check(o); }
 
-const PyObject* chpl_Py_None = Py_None;
+static inline PyObject* chpl_Py_None() { return (PyObject*)Py_None; }
+static inline PyObject* chpl_Py_True() { return (PyObject*)Py_True; }
+static inline PyObject* chpl_Py_False() { return (PyObject*)Py_False; }
 
 #endif


### PR DESCRIPTION
Uses the correct pointer types for extern functions. This causes issues in some configurations, especially with the C backend.

For example for `PyUnicode_AsUTF8` it should return `const char*`, not `char*`. 

For the constants like `Py_None`, `Py_True`, and `Py_False`, this PR wraps their definitions in C which discards the const qualifier. While this is unfortunate, their types do not match the other PyObjectPtr types, and could cause other issues.

[Reviewed by @dlongnecke-cray]