### PR TITLE
Prevent timeouts by lowering the number of trials for a test with asan/valgrind

### DIFF
--- a/test/performance/memory/microMemoryAllocation.execopts
+++ b/test/performance/memory/microMemoryAllocation.execopts
@@ -1,1 +1,6 @@
---printTime=false
+#!/usr/bin/env bash
+args="--printTime=false"
+if [ "$CHPL_TEST_VGRND_EXE" == "on" ] || [ "${CHPL_SANITIZE_EXE-none}" != "none" ]; then
+  args="$args --trials=1000"
+fi
+echo $args

--- a/test/performance/memory/microMemoryAllocation.execopts
+++ b/test/performance/memory/microMemoryAllocation.execopts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 args="--printTime=false"
-if [ "$CHPL_TEST_VGRND_EXE" == "on" ] || [ "${CHPL_SANITIZE_EXE-none}" != "none" ]; then
+if [ "$CHPL_TEST_VGRND_EXE" == "on" ] || [ "${CHPL_SANITIZE_EXE:-none}" != "none" ]; then
   args="$args --trials=1000"
 fi
 echo $args


### PR DESCRIPTION
Prevent timeouts by lowering the number of trials for a test with asan/valgrind

[Reviewed by @dlongnecke-cray]