### PR TITLE
Dyno: fix promotion infinite recursion due to type returning functions

### DIFF
--- a/frontend/test/resolution/testPromotion.cpp
+++ b/frontend/test/resolution/testPromotion.cpp
@@ -408,6 +408,26 @@ static void testTertiaryMethod() {
 
 }
 
+static void regressionTestRecursivePromotionTypeBug() {
+  // previously, because we allowed promotion to be applied to functions
+  // with the type and param intents, it was possible to trigger recursive
+  // queries. This PR ensures that no longer happens.
+
+  auto ctx = buildStdContext();
+  auto context = ctx.get();
+
+  auto var = resolveTypeOfX(context,
+      R"""(
+      use OS;
+      var x = createSystemError(0);
+      )""");
+
+  assert(var);
+  assert(var->isClassType());
+  assert(var->toClassType()->basicClassType()->parentClassType() ==
+         CompositeType::getErrorType(context)->basicClassType());
+}
+
 int main() {
   // Run tests with primary and secondary method definitions (expecting
   // the same results).
@@ -436,6 +456,8 @@ int main() {
   }
 
   testTertiaryMethod();
+
+  regressionTestRecursivePromotionTypeBug();
 
   return 0;
 }


### PR DESCRIPTION
On main, because we allowed promotion to be applied to functions with the `type` and `param` intents, it was possible to trigger recursive queries, in which `chpl_promotionType` would be applied in a promoted manner. As a concrete example, the following test by @riftEmber caused an infinite recursion error:

```Chapel
use OS;
var x = createSystemError(0);
```

This PR ensures that this no longer happens, by matching the production compiler's behavior and skipping type-returning procedures:

https://github.com/chapel-lang/chapel/blob/df1f0f4965c069960e4053f9347a1e42067dcd80/compiler/resolution/functionResolution.cpp#L1783-L1788

Thank you @riftEmber for diagnosing the issue and reviewing the PR!

## Testing
- [x] dyno tests, including regression test