### PR TITLE
gasnet doesn't support network atomics

### DIFF
--- a/test/gpu/native/environment/gasnet.compopts
+++ b/test/gpu/native/environment/gasnet.compopts
@@ -1,1 +1,1 @@
---comm gasnet
+--comm gasnet --network-atomics none


### PR DESCRIPTION
`start_test` sets `CHPL_NETWORK_ATOMICS=ugni` because `CHPL_COMM=ugni`, but the test is passed "--comm gasnet", causing a mismatch between `CHPL_COMM` and `CHPL_NETWORK_ATOMICS`. Also pass the test "--network-atomics none" to prevent this error.