### PR TITLE
Fix dyno testing after #26269

### DIFF
--- a/frontend/test/resolution/testPromotion.cpp
+++ b/frontend/test/resolution/testPromotion.cpp
@@ -410,8 +410,7 @@ static void regressionTestRecursivePromotionTypeBug() {
   // with the type and param intents, it was possible to trigger recursive
   // queries. This PR ensures that no longer happens.
 
-  auto ctx = buildStdContext();
-  auto context = ctx.get();
+  auto context = buildStdContext();
 
   auto var = resolveTypeOfX(context,
       R"""(


### PR DESCRIPTION
``buildStdContext`` now returns a ``Context*`` rather than a unique_ptr.