### PR TITLE
Fix parboil test failure with LLVM 19

### DIFF
--- a/test/studies/parboil/SAD/sadSerial.chpl
+++ b/test/studies/parboil/SAD/sadSerial.chpl
@@ -199,7 +199,7 @@ proc sad4OneMacroblock(ref macroblockSad: [] uint(16), frame: [] uint(16), refer
               var refy = min(height - 1, max(0, framey + posy + blky*4 + y));
               var b = reference[rlow + refy*width + refx];
               var a = frame[flow + (blky*4 + y) * width + (blkx*4 + x)];
-              sad += abs(a:int - b:int):uint(16); // danger, need these casts
+              sad += if a > b then a - b else b - a;
             }
           }
           macroblockSad[mlow + MAX_POS_PADDED*(4*blky + blkx) + pos] = sad;


### PR DESCRIPTION
Fixes `test/studies/parboil/SAD/sadSerial.chpl`, which is currently failing due to the upgrade to LLVM 19.

This PR changes the test to use an if-statement to compute the difference between 2 `uint(16)`, instead of an `abs` with up/down casting. With LLVM 19, the vectorizer is more aggressive and breaks the casting version. See https://github.com/chapel-lang/chapel/issues/26301

[Reviewed by @dlongnecke-cray]