### PR TITLE
Treat cuda includes as system includes

### DIFF
--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -356,7 +356,8 @@ def get_runtime_compile_args():
     # If compiling for GPU locales, add CUDA runtime headers to include path
     bundled.append("-I" + os.path.join(incl, "gpu", gpu_type))
     if gpu_type == "nvidia":
-        system.append("-I" + os.path.join(sdk_path, "include"))
+        # treat the CUDA SDK as a system include
+        system.append("-idirafter" + os.path.join(sdk_path, "include"))
 
         # workaround an issue with __float128 not being supported by clang in device code
         system.append("-D__STRICT_ANSI__=1")


### PR DESCRIPTION
Fixes an issue where warnings in cuda headers would cause the build to fail. By treating those headers as system includes, we can ignore those warnings.

Note: on some systems, there are cuda headers that come from the cray programming environment, which this PR does not handle.

[Reviewed by @riftEmber]