### PR TITLE
Update prediff for networking test

### DIFF
--- a/test/library/packages/Curl/check-http-setopt.prediff
+++ b/test/library/packages/Curl/check-http-setopt.prediff
@@ -1,4 +1,5 @@
 #!/bin/bash
 cat $2 | grep check-http-setopt > $2.tmp
 cat $2 | grep HTTP/1 | sed 's/\r$//' >> $2.tmp
-mv $2.tmp $2
+# get rid of 'using HTTP' lines
+cat $2.tmp | grep -v 'using HTTP' > $2


### PR DESCRIPTION
Updates a prediff for a networking test to exclude some output about "using HTTP/1.x". This is needed due to a dependency change on the test system

[Reviewed by @riftEmber]