### PR TITLE
Use CHPL_LLVM=system with CHPL_GPU=nvidia on ex test systems

### DIFF
--- a/util/cron/test-gpu-ex-cuda-12.bash
+++ b/util/cron/test-gpu-ex-cuda-12.bash
@@ -8,7 +8,7 @@ source $CWD/common-hpe-cray-ex.bash
 
 module load cudatoolkit  # default is CUDA 12
 
-export CHPL_LLVM=bundled  # CUDA 12 is only supported with bundled LLVM
+export CHPL_LLVM=system
 export CHPL_COMM=none
 export CHPL_LOCALE_MODEL=gpu
 export CHPL_LAUNCHER_PARTITION=griz256

--- a/util/cron/test-gpu-ex-cuda-12.interop.bash
+++ b/util/cron/test-gpu-ex-cuda-12.interop.bash
@@ -18,7 +18,7 @@ module load cuda/12.4  # default is CUDA 12.5
 # This can be removed once we use CUDA 12.5
 export CHPL_LIB_PATH="/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/math_libs/lib64:$CHPL_LIB_PATH"
 
-export CHPL_LLVM=bundled  # Using bundled LLVM since that's safer
+export CHPL_LLVM=system  # Using bundled LLVM since that's safer
 export CHPL_TEST_GPU=true
 export CHPL_LAUNCHER_PARTITION=griz256
 export CHPL_NIGHTLY_TEST_DIRS="gpu/interop/"

--- a/util/cron/test-gpu-ex-cuda-12.interop.bash
+++ b/util/cron/test-gpu-ex-cuda-12.interop.bash
@@ -18,7 +18,7 @@ module load cuda/12.4  # default is CUDA 12.5
 # This can be removed once we use CUDA 12.5
 export CHPL_LIB_PATH="/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/math_libs/lib64:$CHPL_LIB_PATH"
 
-export CHPL_LLVM=system  # Using bundled LLVM since that's safer
+export CHPL_LLVM=system
 export CHPL_TEST_GPU=true
 export CHPL_LAUNCHER_PARTITION=griz256
 export CHPL_NIGHTLY_TEST_DIRS="gpu/interop/"

--- a/util/cron/test-gpu-ex-cuda-12.ofi.bash
+++ b/util/cron/test-gpu-ex-cuda-12.ofi.bash
@@ -8,7 +8,7 @@ source $CWD/common-hpe-cray-ex.bash
 
 module load cudatoolkit  # default is CUDA 12
 
-export CHPL_LLVM=bundled  # CUDA 12 is only supported with bundled LLVM
+export CHPL_LLVM=system
 export CHPL_COMM=ofi
 export CHPL_LOCALE_MODEL=gpu
 export CHPL_LAUNCHER_PARTITION=griz256

--- a/util/cron/test-gpu-ex-cuda-12.specialization.bash
+++ b/util/cron/test-gpu-ex-cuda-12.specialization.bash
@@ -8,7 +8,7 @@ source $CWD/common-hpe-cray-ex.bash
 
 module load cudatoolkit  # default is CUDA 12
 
-export CHPL_LLVM=bundled  # Using bundled LLVM since that's safer
+export CHPL_LLVM=system
 export CHPL_COMM=none
 export CHPL_LOCALE_MODEL=gpu
 export CHPL_LAUNCHER_PARTITION=griz256

--- a/util/cron/test-perf.gpu-ex-cuda-12.bash
+++ b/util/cron/test-perf.gpu-ex-cuda-12.bash
@@ -8,7 +8,7 @@ source $CWD/common-hpe-cray-ex.bash
 
 module load cudatoolkit  # default is CUDA 12
 
-export CHPL_LLVM=bundled  # Using bundled LLVM since that's safer
+export CHPL_LLVM=system
 export CHPL_COMM=none
 export CHPL_LOCALE_MODEL=gpu
 export CHPL_LAUNCHER_PARTITION=griz256

--- a/util/cron/test-perf.gpu-ex-cuda-12.um.bash
+++ b/util/cron/test-perf.gpu-ex-cuda-12.um.bash
@@ -8,7 +8,7 @@ source $CWD/common-hpe-cray-ex.bash
 
 module load cudatoolkit  # default is CUDA 12
 
-export CHPL_LLVM=bundled # Using bundled LLVM since that's safer
+export CHPL_LLVM=system
 export CHPL_COMM=none
 export CHPL_LOCALE_MODEL=gpu
 export CHPL_LAUNCHER_PARTITION=griz256


### PR DESCRIPTION
Changes our test scripts to use CHPL_LLVM=system with CHPL_GPU=nvidia on ex test systems, since Chapel works with the system LLVM (which is currently LLVM 19). This should reduce the time spent running CUDA tests on these systems

[Reviewed by @ShreyasKhandekar]