### PR TITLE
chapel-py: check for invalid instance of bridged classes to avoid internal errors

### DIFF
--- a/tools/chapel-py/src/core-types-gen.cpp
+++ b/tools/chapel-py/src/core-types-gen.cpp
@@ -102,7 +102,8 @@ struct InvokeHelper<void(Args...)> {
  */
 #define METHOD(NODE, NAME, DOCSTR, TYPEFN, BODY)\
   PyObject* NODE##Object_##NAME(PyObject *self, PyObject *argsTup) {\
-    auto&& node = ((NODE##Object*) self)->unwrap(); \
+    auto* node = ((NODE##Object*) self)->unwrap(); \
+    if (!node) return nullptr; \
     auto contextObject = ((NODE##Object*) self)->context(); \
     auto context = &contextObject->value_; \
     auto args = PythonFnHelper<TYPEFN>::unwrapArgs(contextObject, argsTup); \
@@ -123,6 +124,7 @@ struct InvokeHelper<void(Args...)> {
 #define ACTUAL_ITERATOR(NAME)\
   PyObject* NAME##Object_actuals(PyObject *self, PyObject *Py_UNUSED(ignored)) { \
     auto node = ((NAME##Object*) self)->unwrap(); \
+    if (!node) return nullptr; \
     \
     auto argList = Py_BuildValue("(O)", (PyObject*) self); \
     auto astCallIterObjectPy = PyObject_CallObject((PyObject *) &AstCallIterType, argList); \

--- a/tools/chapel-py/src/core-types-gen.h
+++ b/tools/chapel-py/src/core-types-gen.h
@@ -39,9 +39,7 @@
   \
     const auto unwrap() const { \
       if (parent.value_) { \
-        PyErr_Format(PyExc_RuntimeError, \
-                     "invalid instance of class '%s'; please do not manually construct instances of this class.", \
-                      #NAME); \
+        raiseExceptionForIncorrectlyConstructedType(#NAME); \
         return static_cast<decltype(parent.value_->to##NAME())>(nullptr); \
       } \
       return parent.value_->to##NAME(); \

--- a/tools/chapel-py/src/core-types-gen.h
+++ b/tools/chapel-py/src/core-types-gen.h
@@ -38,7 +38,7 @@
     static constexpr const char* DocStr = "An object that represents a Chapel " #NAME; \
   \
     const auto unwrap() const { \
-      if (parent.value_) { \
+      if (!parent.value_) { \
         raiseExceptionForIncorrectlyConstructedType(#NAME); \
         return static_cast<decltype(parent.value_->to##NAME())>(nullptr); \
       } \

--- a/tools/chapel-py/src/core-types-gen.h
+++ b/tools/chapel-py/src/core-types-gen.h
@@ -37,7 +37,15 @@
     static constexpr const char* Name = #NAME; \
     static constexpr const char* DocStr = "An object that represents a Chapel " #NAME; \
   \
-    const auto unwrap() const { return parent.value_->to##NAME(); } \
+    const auto unwrap() const { \
+      if (parent.value_) { \
+        PyErr_Format(PyExc_RuntimeError, \
+                     "invalid instance of class '%s'; please do not manually construct instances of this class.", \
+                      #NAME); \
+        return static_cast<decltype(parent.value_->to##NAME())>(nullptr); \
+      } \
+      return parent.value_->to##NAME(); \
+    } \
     ContextObject* context() const { return (ContextObject*) parent.contextObject; } \
   }; \
   \

--- a/tools/chapel-py/src/core-types.cpp
+++ b/tools/chapel-py/src/core-types.cpp
@@ -146,6 +146,10 @@ std::string generatePyiFile() {
 }
 
 PyObject* AstNodeObject::iter(AstNodeObject *self) {
+  if (!self->value_) {
+    raiseExceptionForIncorrectlyConstructedType("AstNode");
+    return nullptr;
+  }
   return wrapIterPair((ContextObject*) self->contextObject, self->value_->children());
 }
 
@@ -155,6 +159,10 @@ void ChapelTypeObject_dealloc(ChapelTypeObject* self) {
 }
 
 PyObject* ChapelTypeObject::str(ChapelTypeObject* self) {
+  if (!self->value_) {
+    raiseExceptionForIncorrectlyConstructedType("Type");
+    return nullptr;
+  }
   std::stringstream ss;
   self->value_->stringify(ss, CHPL_SYNTAX);
   auto typeString = ss.str();
@@ -162,6 +170,10 @@ PyObject* ChapelTypeObject::str(ChapelTypeObject* self) {
 }
 
 PyObject* ParamObject::str(ParamObject* self) {
+  if (!self->value_) {
+    raiseExceptionForIncorrectlyConstructedType("Param");
+    return nullptr;
+  }
   std::stringstream ss;
   self->value_->stringify(ss, CHPL_SYNTAX);
   auto typeString = ss.str();

--- a/tools/chapel-py/src/core-types.h
+++ b/tools/chapel-py/src/core-types.h
@@ -117,7 +117,7 @@ struct LocationObject : public PythonClass<LocationObject, chpl::Location> {
 
   static PyTypeObject configurePythonType() {
     // Configure the necessary methods to make inserting into sets working:
-    PyTypeObject configuring = PythonClassWithObject<LocationObject, chpl::Location>::configurePythonType();
+    PyTypeObject configuring = PythonClassWithContext<LocationObject, chpl::Location>::configurePythonType();
     configuring.tp_str = (reprfunc) str;
     configuring.tp_as_number = &location_as_number;
     configuring.tp_as_number->nb_subtract = (binaryfunc) subtract;
@@ -126,7 +126,7 @@ struct LocationObject : public PythonClass<LocationObject, chpl::Location> {
   }
 };
 
-struct ScopeObject : public PythonClassWithObject<ScopeObject, const chpl::resolution::Scope*> {
+struct ScopeObject : public PythonClassWithContext<ScopeObject, const chpl::resolution::Scope*> {
   static constexpr const char* QualifiedName = "chapel.Scope";
   static constexpr const char* Name = "Scope";
   static constexpr const char* DocStr = "A scope in the Chapel program, such as a block.";
@@ -134,7 +134,7 @@ struct ScopeObject : public PythonClassWithObject<ScopeObject, const chpl::resol
 
 using VisibleSymbol = std::tuple<chpl::UniqueString, std::vector<const chpl::uast::AstNode*>>;
 
-struct AstNodeObject : public PythonClassWithObject<AstNodeObject, const chpl::uast::AstNode*> {
+struct AstNodeObject : public PythonClassWithContext<AstNodeObject, const chpl::uast::AstNode*> {
   static constexpr const char* QualifiedName = "chapel.AstNode";
   static constexpr const char* Name = "AstNode";
   static constexpr const char* DocStr = "The base type of Chapel AST nodes";
@@ -142,7 +142,7 @@ struct AstNodeObject : public PythonClassWithObject<AstNodeObject, const chpl::u
   static PyObject* iter(AstNodeObject *self);
 
   static PyTypeObject configurePythonType() {
-    PyTypeObject configuring = PythonClassWithObject<AstNodeObject, const chpl::uast::AstNode*>::configurePythonType();
+    PyTypeObject configuring = PythonClassWithContext<AstNodeObject, const chpl::uast::AstNode*>::configurePythonType();
     configuring.tp_iter = (getiterfunc) AstNodeObject::iter;
     configuring.tp_flags = Py_TPFLAGS_BASETYPE;
     return configuring;
@@ -151,7 +151,7 @@ struct AstNodeObject : public PythonClassWithObject<AstNodeObject, const chpl::u
 
 using QualifiedTypeTuple = std::tuple<const char*, Nilable<const chpl::types::Type*>, Nilable<const chpl::types::Param*>>;
 
-struct ChapelTypeObject  : public PythonClassWithObject<ChapelTypeObject, const chpl::types::Type*> {
+struct ChapelTypeObject  : public PythonClassWithContext<ChapelTypeObject, const chpl::types::Type*> {
   static constexpr const char* QualifiedName = "chapel.ChapelType";
   static constexpr const char* Name = "ChapelType";
   static constexpr const char* DocStr = "The base type of Chapel types";
@@ -159,14 +159,14 @@ struct ChapelTypeObject  : public PythonClassWithObject<ChapelTypeObject, const 
   static PyObject* str(ChapelTypeObject* self);
 
   static PyTypeObject configurePythonType() {
-    PyTypeObject configuring = PythonClassWithObject<ChapelTypeObject, const chpl::types::Type*>::configurePythonType();
+    PyTypeObject configuring = PythonClassWithContext<ChapelTypeObject, const chpl::types::Type*>::configurePythonType();
     configuring.tp_str = (reprfunc) ChapelTypeObject::str;
     configuring.tp_flags = Py_TPFLAGS_BASETYPE;
     return configuring;
   }
 };
 
-struct ParamObject : public PythonClassWithObject<ParamObject, const chpl::types::Param*> {
+struct ParamObject : public PythonClassWithContext<ParamObject, const chpl::types::Param*> {
   static constexpr const char* QualifiedName = "chapel.Param";
   static constexpr const char* Name = "Param";
   static constexpr const char* DocStr = "The base type of Chapel parameters (compile-time known values)";
@@ -174,14 +174,14 @@ struct ParamObject : public PythonClassWithObject<ParamObject, const chpl::types
   static PyObject* str(ParamObject* self);
 
   static PyTypeObject configurePythonType() {
-    PyTypeObject configuring = PythonClassWithObject<ParamObject, const chpl::types::Param*>::configurePythonType();
+    PyTypeObject configuring = PythonClassWithContext<ParamObject, const chpl::types::Param*>::configurePythonType();
     configuring.tp_str = (reprfunc) ParamObject::str;
     configuring.tp_flags = Py_TPFLAGS_BASETYPE;
     return configuring;
   }
 };
 
-struct ResolvedExpressionObject : public PythonClassWithObject<ResolvedExpressionObject, const chpl::resolution::ResolvedExpression*> {
+struct ResolvedExpressionObject : public PythonClassWithContext<ResolvedExpressionObject, const chpl::resolution::ResolvedExpression*> {
   static constexpr const char* QualifiedName = "chapel.ResolvedExpression";
   static constexpr const char* Name = "ResolvedExpression";
   static constexpr const char* DocStr = "Container for type information about a particular AST node.";
@@ -194,7 +194,7 @@ struct MostSpecificCandidateAndPoiScope {
   const chpl::resolution::PoiScope* poiScope;
 };
 
-struct MostSpecificCandidateObject : public PythonClassWithObject<MostSpecificCandidateObject, MostSpecificCandidateAndPoiScope> {
+struct MostSpecificCandidateObject : public PythonClassWithContext<MostSpecificCandidateObject, MostSpecificCandidateAndPoiScope> {
   static constexpr const char* QualifiedName = "chapel.MostSpecificCandidate";
   static constexpr const char* Name = "MostSpecificCandidate";
   static constexpr const char* DocStr = "A candidate function returned from call resolution that represents the most specific overload matching the call.";
@@ -207,7 +207,7 @@ struct TypedSignatureAndPoiScope {
   const chpl::resolution::PoiScope* poiScope;
 };
 
-struct TypedSignatureObject : public PythonClassWithObject<TypedSignatureObject, TypedSignatureAndPoiScope> {
+struct TypedSignatureObject : public PythonClassWithContext<TypedSignatureObject, TypedSignatureAndPoiScope> {
   static constexpr const char* QualifiedName = "chapel.TypedSignature";
   static constexpr const char* Name = "TypedSignature";
   static constexpr const char* DocStr = "The signature of a particular function. Could include types gathered when instantiating the function";
@@ -230,7 +230,7 @@ struct TypedSignatureObject : public PythonClassWithObject<TypedSignatureObject,
 
   static PyTypeObject configurePythonType() {
     // Configure the necessary methods to make inserting into sets working:
-    PyTypeObject configuring = PythonClassWithObject<TypedSignatureObject, TypedSignatureAndPoiScope>::configurePythonType();
+    PyTypeObject configuring = PythonClassWithContext<TypedSignatureObject, TypedSignatureAndPoiScope>::configurePythonType();
     configuring.tp_hash = (hashfunc) hash;
     configuring.tp_richcompare = (richcmpfunc) richcompare;
     return configuring;

--- a/tools/chapel-py/src/error-tracker.h
+++ b/tools/chapel-py/src/error-tracker.h
@@ -27,7 +27,7 @@
 
 struct ContextObject;
 
-struct ErrorObject : public PythonClassWithObject<ErrorObject, chpl::owned<chpl::ErrorBase>> {
+struct ErrorObject : public PythonClassWithContext<ErrorObject, chpl::owned<chpl::ErrorBase>> {
   static constexpr const char* QualifiedName = "chapel.Error";
   static constexpr const char* Name = "Error";
   static constexpr const char* DocStr = "An error that occurred as part of processing a file with the Chapel compiler frontend";
@@ -35,7 +35,7 @@ struct ErrorObject : public PythonClassWithObject<ErrorObject, chpl::owned<chpl:
 
 using LocationAndNote = std::tuple<chpl::Location, std::string>;
 
-struct ErrorManagerObject : public PythonClassWithObject<ErrorManagerObject, std::tuple<>> {
+struct ErrorManagerObject : public PythonClassWithContext<ErrorManagerObject, std::tuple<>> {
   static constexpr const char* QualifiedName = "chapel.ErrorManager";
   static constexpr const char* Name = "ErrorManager";
   static constexpr const char* DocStr = "A wrapper container to help track the errors from a Context.";

--- a/tools/chapel-py/src/python-class.h
+++ b/tools/chapel-py/src/python-class.h
@@ -122,7 +122,7 @@ PyTypeObject PythonClass<Self,T>::PythonType = Self::configurePythonType();
 // Because the ContextObject is essential to other pieces of the API (it's attached
 // to many other Chapel objects to save the user the work of threading through
 // a Context instance), we need to declare and define it here for the next
-// template (PythonClassWithObject) to use.
+// template (PythonClassWithContext) to use.
 //
 // Forward-declaring doesn't cut it because we need ContextObject::PythonType.
 
@@ -139,7 +139,7 @@ struct ContextObject : public PythonClass<ContextObject, chpl::Context> {
 };
 
 template <typename Self, typename T>
-struct PythonClassWithObject : public PythonClass<Self, T> {
+struct PythonClassWithContext : public PythonClass<Self, T> {
   PyObject* contextObject;
 
   static void dealloc(Self* self) {

--- a/tools/chapel-py/src/python-class.h
+++ b/tools/chapel-py/src/python-class.h
@@ -179,9 +179,7 @@ struct PythonClassWithContext : public PythonClass<Self, T> {
   PyObject* contextObject;
 
   static void dealloc(Self* self) {
-    if (self->contextObject) {
-      Py_DECREF(self->contextObject);
-    }
+    Py_XDECREF(self->contextObject);
     PythonClass<Self, T>::dealloc(self);
   }
 

--- a/tools/chapel-py/src/python-class.h
+++ b/tools/chapel-py/src/python-class.h
@@ -28,6 +28,16 @@ struct PerTypeMethods;
 
 struct ContextObject;
 
+/** ===== Standalone functions used throughout chapel-py ===== */
+
+static inline void raiseExceptionForIncorrectlyConstructedType(const char* type) {
+  PyErr_Format(PyExc_RuntimeError,
+               "invalid instance of class '%s'; please do not manually "
+               "construct instances of this class.",
+               type);
+}
+
+
 template <typename Self, typename T>
 struct PythonClass {
   PyObject_HEAD
@@ -57,9 +67,7 @@ struct PythonClass {
   // Returns whether everything is OK.
   bool raiseIfInvalid() {
     if (shouldReturnNone(value_)) {
-      PyErr_Format(PyExc_RuntimeError,
-                   "invalid instance of class '%s'; please do not manually construct instances of this class.",
-                   Self::PythonType.tp_name);
+      raiseExceptionForIncorrectlyConstructedType(Self::Name);
       return false;
     }
     return true;


### PR DESCRIPTION
Closes https://github.com/chapel-lang/chapel/issues/25937.

This PR improves the situation in which AST or other bridged objects are incorrectly constructed (specifically, when they are constructed explicitly by the user). In this case, their internal representations can contain `null` values, which causes exception. This PR introduces checking for such cases, raising Python exceptions.

Now, none of the following operations produce internal errors, and raise instead:

<details>
<summary>Expand console output</summary>

```console
>>> import chapel
>>> c = chapel.Context()
>>> id = chapel.Identifier(c)
>>> id.unique_id()
Traceback (most recent call last):
  File "<python-input-3>", line 1, in <module>
    id.unique_id()
    ~~~~~~~~~~~~^^
RuntimeError: invalid instance of class 'AstNode'; please do not manually construct instances of this class.
>>> for node in id:
...     print(node)
...
Traceback (most recent call last):
  File "<python-input-4>", line 1, in <module>
    for node in id:
                ^^
RuntimeError: invalid instance of class 'AstNode'; please do not manually construct instances of this class.
>>> tmp = BoolParam()
Traceback (most recent call last):
  File "<python-input-5>", line 1, in <module>
    tmp = BoolParam()
          ^^^^^^^^^
NameError: name 'BoolParam' is not defined
>>> tmp = chapel.BoolParam()
Traceback (most recent call last):
  File "<python-input-6>", line 1, in <module>
    tmp = chapel.BoolParam()
TypeError: function takes exactly 1 argument (0 given)
>>> tmp = chapel.BoolParam(c)
>>> print(tmp)
Traceback (most recent call last):
  File "<python-input-8>", line 1, in <module>
    print(tmp)
    ~~~~~^^^^^
RuntimeError: invalid instance of class 'Param'; please do not manually construct instances of this class.
```
</details>

The main change in this PR is that, to signal an incorrectly-constructed type, we need an "empty value". This has to happen for all objects in `method-tables.h`, because all those methods are generated using the same body. Some objects defined in `method-tables.h` contain non-pointer values and would return them by reference; however, references cannot be used to signal an empty value, and cannot be stored in `std::optional`. Thus, this PR switches the implementation to always return pointers from `.unwrap()`, using `nullptr` to signal failure. This requires an SFINAE-based re-implementation of `unwrap` for `PythonClass` and subtypes. The generated types do not use `PythonClass`, and always use pointers, so their implementation is only adjusted to raise.

Reviewed by @jabraham17 -- thanks!

## Testing
- [x] `make test-cls` works