### PR TITLE
Fix compiler driver bug reading long dependency paths

### DIFF
--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -47,6 +47,7 @@
 #include <unistd.h>
 
 #include <cstring>
+#include <fstream>
 #include <sstream>
 #include <iostream>
 #include <cstdlib>
@@ -209,22 +210,11 @@ void restoreDriverTmp(const char* tmpFilePath,
   fileinfo* tmpFileDummy = openTmpFile(tmpFilePath, "a");
   closefile(tmpFileDummy);
 
-  fileinfo* tmpFile = openTmpFile(tmpFilePath, "r");
-
-  char strBuf[4096];
-  while (fgets(strBuf, sizeof(strBuf), tmpFile->fptr)) {
-    // Note: Using strlen here (instead of strnlen) is safe because fgets
-    // guarantees null termination.
-    size_t len = strlen(strBuf);
-    // remove trailing newline, which fgets preserves unless buffer is exceeded
-    assert(strBuf[len - 1] == '\n' && "stored line exceeds maximum length");
-    strBuf[--len] = '\0';
-
-    // invoke restoring function
-    restoreSavedString(strBuf);
+  std::ifstream fileStream(genIntermediateFilename(tmpFilePath));
+  std::string line;
+  while (std::getline(fileStream, line)) {
+    restoreSavedString(line.c_str());
   }
-
-  closefile(tmpFile);
 }
 
 void restoreDriverTmpMultiline(

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -208,9 +208,10 @@ void restoreDriverTmp(const char* tmpFilePath,
   // Create file iff it did not already exist, for simpler reading logic in the
   // rest of the function.
   fileinfo* tmpFileDummy = openTmpFile(tmpFilePath, "a");
+  const char* path = tmpFileDummy->pathname;
   closefile(tmpFileDummy);
 
-  std::ifstream fileStream(genIntermediateFilename(tmpFilePath));
+  std::ifstream fileStream(path);
   std::string line;
   while (std::getline(fileStream, line)) {
     restoreSavedString(line.c_str());


### PR DESCRIPTION
Fix a bug causing the compiler driver to crash when working with dependency paths longer than 4096 characters.

Fixed by reading with `std::getline` which has no line length limit, rather than `fgets` which requires a (finite) buffer.

Resolves https://github.com/chapel-lang/chapel/issues/26261.

[reviewer info placeholder]

Testing:
- [ ] compiling program with >4096 character dependency paths
- [ ] paratest
- [ ] `--no-compiler-driver` paratest