### PR TITLE
Use module cuda instead of cudatoolkit

### DIFF
--- a/util/cron/test-gpu-ex-cuda-12.bash
+++ b/util/cron/test-gpu-ex-cuda-12.bash
@@ -6,7 +6,7 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-native-gpu.bash
 source $CWD/common-hpe-cray-ex.bash
 
-module load cudatoolkit  # default is CUDA 12
+module load cuda/12.4
 
 export CHPL_LLVM=system
 export CHPL_COMM=none

--- a/util/cron/test-gpu-ex-cuda-12.ofi.bash
+++ b/util/cron/test-gpu-ex-cuda-12.ofi.bash
@@ -6,7 +6,7 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-native-gpu.bash
 source $CWD/common-hpe-cray-ex.bash
 
-module load cudatoolkit  # default is CUDA 12
+module load cuda/12.4
 
 export CHPL_LLVM=system
 export CHPL_COMM=ofi

--- a/util/cron/test-gpu-ex-cuda-12.specialization.bash
+++ b/util/cron/test-gpu-ex-cuda-12.specialization.bash
@@ -6,7 +6,7 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common-native-gpu.bash
 source $CWD/common-hpe-cray-ex.bash
 
-module load cudatoolkit  # default is CUDA 12
+module load cuda/12.4
 
 export CHPL_LLVM=system
 export CHPL_COMM=none

--- a/util/cron/test-perf.gpu-ex-cuda-12.bash
+++ b/util/cron/test-perf.gpu-ex-cuda-12.bash
@@ -6,7 +6,7 @@ CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common-native-gpu.bash
 source $CWD/common-hpe-cray-ex.bash
 
-module load cudatoolkit  # default is CUDA 12
+module load cuda/12.4
 
 export CHPL_LLVM=system
 export CHPL_COMM=none

--- a/util/cron/test-perf.gpu-ex-cuda-12.um.bash
+++ b/util/cron/test-perf.gpu-ex-cuda-12.um.bash
@@ -6,7 +6,7 @@ CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common-native-gpu.bash
 source $CWD/common-hpe-cray-ex.bash
 
-module load cudatoolkit  # default is CUDA 12
+module load cuda/12.4
 
 export CHPL_LLVM=system
 export CHPL_COMM=none


### PR DESCRIPTION
We have previously been advised that on this testing system we should be using `module load cuda`, instead of `module load cudatoolkit`. This was only changed in some of the configs, this PR changes them in all of them

[Reviewed by @ShreyasKhandekar]