### PR TITLE
update homebrew formulas with changes from upstream

### DIFF
--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -1,5 +1,6 @@
 class Chapel < Formula
   include Language::Python::Shebang
+
   desc "Programming language for productive parallel computing at scale"
   homepage "https://chapel-lang.org/"
   url "<url-placeholder-value-injected-during-testing>"
@@ -16,11 +17,8 @@ class Chapel < Formula
   depends_on "hwloc"
   depends_on "jemalloc"
   depends_on "llvm"
-  depends_on "pkg-config"
+  depends_on "pkgconf"
   depends_on "python@3.13"
-
-  # LLVM is built with gcc11 and we will fail on linux with gcc version 5.xx
-  fails_with gcc: "5"
 
   def llvm
     deps.map(&:to_formula).find { |f| f.name.match? "^llvm" }

--- a/util/packaging/homebrew/chapel-release.rb
+++ b/util/packaging/homebrew/chapel-release.rb
@@ -1,5 +1,6 @@
 class Chapel < Formula
   include Language::Python::Shebang
+
   desc "Programming language for productive parallel computing at scale"
   homepage "https://chapel-lang.org/"
   url "https://github.com/chapel-lang/chapel/releases/download/2.2.0/chapel-2.2.0.tar.gz"
@@ -23,11 +24,8 @@ class Chapel < Formula
   depends_on "hwloc"
   depends_on "jemalloc"
   depends_on "llvm@18"
-  depends_on "pkg-config"
+  depends_on "pkgconf"
   depends_on "python@3.13"
-
-  # LLVM is built with gcc11 and we will fail on linux with gcc version 5.xx
-  fails_with gcc: "5"
 
   def llvm
     deps.map(&:to_formula).find { |f| f.name.match? "^llvm" }


### PR DESCRIPTION
This updates our homebrew packaging formulas with changes made by the homebrew maintainers to update `pkg-config` to `pkgconfig`. 

I expect this will mean new bottles for chapel will be built and when that happens the sha256 values for all the bottles will need to be updated.

This PR only updates the formulas we use for testing homebrew and was not reviewed.

TESTING:

- [x] local run of util/cron/test-homebrew.bash