### PR TITLE
Fix error emitted when returning iterator record by ref in some cases

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -466,7 +466,7 @@ static Type* canCoerceToCopyType(Type* actualType, Symbol* actualSym,
           !(fn->name == astr_initCopy || fn->name == astr_autoCopy ||
             fn->name == astr_coerceMove || fn->name == astr_coerceCopy)) {
 
-        if (formalSym == NULL || inOrOutFormalNeedingCopyType(formalSym)) {
+        if (formalSym != NULL && inOrOutFormalNeedingCopyType(formalSym)) {
           copyType = getCopyTypeDuringResolution(actualValType);
         }
       }


### PR DESCRIPTION
Closes https://github.com/chapel-lang/chapel/issues/25645.

I tested what _should_ happen normally in this case; since the function doesn't have a specified return intent, we do type inference, and so do various `canPass` calls for all the formals. The case for `ref int(8)` and `ref int(16)` is ruled out by that. However, we have a special rule that allows coercing iterator records to arrays, and that always ignores the ref intent. Overriding the refness check is required to make `inout` intents work. This PR narrows the refness-ignoring case, only ignoring refness if we're handling the `inout` case. This preserves other coercions by value, but rules out incorrect coercions by ref for type inference.

## Testing
- [x] paratest