### PR TITLE
Remove top-level `SymExpr`s from the AST

### DIFF
--- a/compiler/resolution/cleanups.cpp
+++ b/compiler/resolution/cleanups.cpp
@@ -124,6 +124,14 @@ static void removeUnusedFunctions() {
   }
 }
 
+static void removeTopLevelSymExprs() {
+  for_alive_in_Vec(SymExpr, se, gSymExprs) {
+    if (se->getStmtExpr() == se) {
+      se->remove();
+    }
+  }
+}
+
 static CallExpr* replaceRuntimeTypeGetField(CallExpr* call) {
   SymExpr* rt = toSymExpr(call->get(1));
 
@@ -1037,6 +1045,8 @@ void pruneResolvedTree() {
   removeTiMarks();
 
   removeUnusedFunctions();
+
+  removeTopLevelSymExprs();
 
   if (fRemoveUnreachableBlocks) {
     deadBlockElimination();

--- a/test/types/records/generic/generic-type-standalone-mention.chpl
+++ b/test/types/records/generic/generic-type-standalone-mention.chpl
@@ -1,0 +1,2 @@
+record R { var arg; }
+R;


### PR DESCRIPTION
They aren't used for anything, so deleting them is reasonable.

This fixes https://github.com/chapel-lang/chapel/issues/25885. The crux of that issue is that we incorrectly identify the `R` type as "unused", since it's generic but not used for any sub-classes and is never instantiated. I first attempted to fix the problem by adjusting `isUnusedClass` to respect `SymExprs` still in the tree that still point to the class. However, subsequent code __deletes all generic type declarations, because by that point we expect all occurrences to be concrete__:

```Chapel
new genericType(...); // replaced with a call to concreteType.init
var x: genericType = ...; // replaced with `var x: concreteType`

// the following:
proc foo(type arg) {}
foo(genericType)
// is replaced with:
proc foo() {}
foo();
```

Deleting all generic types seems like a reasonable approach to me; the standalone variables are a weird exception, in which the type is neither instantiated nor removed. Moreover, since they don't modify or even really access the variable, these standalone `SymExprs` can be safely removed. This PR does just that.

Reviewed by @jabraham17 -- thanks!

## Testing
- [x] paratest
