### PR TITLE
Dyno: Generate function bodies for init=, deinit, and (de)serializers

### DIFF
--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2704,6 +2704,17 @@ QualifiedType Resolver::typeForId(const ID& id, bool localGenericToUnknown) {
         }
       }
 
+      if (auto tup = rt->toTupleType()) {
+        auto field = parsing::idToAst(context, id)->toNamedDecl();
+        if (field && field->name() == USTR("size")) {
+          // Tuples don't store a 'size' in their substitutions map, so
+          // manually take care of things here.
+          auto intType = IntType::get(context, 0);
+          auto val = IntParam::get(context, tup->numElements());
+          return QualifiedType(QualifiedType::PARAM, intType, val);
+        }
+      }
+
       if (auto comprt = rt->getCompositeType()) {
         if (comprt->id() == parentId) {
           ct = comprt; // handle record, class with field

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -1431,6 +1431,14 @@ builderResultForDefaultFunction(Context* context,
 
   if (name == USTR("init")) {
     return &buildInitializer(context, typeID);
+  } else if (name == USTR("init=")) {
+    return &buildInitEquals(context, typeID);
+  } else if (name == USTR("deinit")) {
+    return &buildDeinit(context, typeID);
+  } else if (name == USTR("serialize")) {
+    return &buildDeSerialize(context, typeID, true);
+  } else if (name == USTR("deserialize")) {
+    return &buildDeSerialize(context, typeID, false);
   } else if (typeID.symbolName(context) == name) {
     return &buildTypeConstructor(context, typeID);
   }

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -437,6 +437,7 @@ const BuilderResult& buildInitEquals(Context* context, ID typeID) {
                                   USTR("this"), Formal::DEFAULT_INTENT,
                                   std::move(thisType), nullptr);
 
+  // TODO: constrain type to be same as 'typeID', possibly through 'this.type'?
   auto otherName = UniqueString::get(context, "other");
   auto otherFormal = Formal::build(builder, dummyLoc, nullptr,
                                    otherName, Formal::DEFAULT_INTENT,

--- a/frontend/lib/resolution/default-functions.h
+++ b/frontend/lib/resolution/default-functions.h
@@ -84,7 +84,10 @@ getCompilerGeneratedBinaryOp(Context* context,
                        UniqueString name);
 
 const uast::BuilderResult& buildInitializer(Context* context, ID typeID);
+const uast::BuilderResult& buildInitEquals(Context* context, ID typeID);
 const uast::BuilderResult& buildTypeConstructor(Context* context, ID typeID);
+const uast::BuilderResult& buildDeinit(Context* context, ID typeID);
+const uast::BuilderResult& buildDeSerialize(Context* context, ID typeID, bool isSerializer);
 
 } // end namespace resolution
 } // end namespace chpl

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -5029,7 +5029,7 @@ resolveCallInMethod(ResolutionContext* rc,
                     std::vector<ApplicabilityResult>* rejected) {
 
   CallResolutionResult asFunction = resolveCall(rc,call,ci,inScopes,rejected);
-  
+
   CallResolutionResult asMethod;
   if (shouldAttemptImplicitReceiver(ci, implicitReceiver)) {
     auto methodCi = CallInfo::createWithReceiver(ci, implicitReceiver);

--- a/frontend/lib/types/Type.cpp
+++ b/frontend/lib/types/Type.cpp
@@ -242,6 +242,10 @@ static bool
 compositeTypeIsPod(Context* context, const Type* t) {
   using namespace resolution;
 
+  if (auto cls = t->toClassType()) {
+    return !cls->decorator().isManaged();
+  }
+
   auto ct = t->getCompositeType();
   if (!ct) return false;
 


### PR DESCRIPTION
This PR generates uAST for ``init=``, ``deinit``, and ``(de)serializers)``, and cleans up some of the relevant implementations while we're at it. This PR also includes a couple of minor changes to either avoid crashes or fix bugs.

Testing:
- [x] test-dyno