### PR TITLE
use cmake and python to keep version numbers updated

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,10 +39,15 @@ set(CHPL_MAJOR_VERSION 2)
 set(CHPL_MINOR_VERSION 4)
 set(CHPL_PATCH_VERSION 0)
 set(CHPL_BUILD_VERSION 0)
+
 set(CHPL_PREV_MAJOR_VERSION 2)
 set(CHPL_PREV_MINOR_VERSION 2)
 set(CHPL_PREV_PATCH_VERSION 0)
-set(CHPL_PREV_BUILD_VERSION 0)
+
+set(CHPL_NEXT_MAJOR_VERSION 2)
+set(CHPL_NEXT_MINOR_VERSION 4)
+set(CHPL_NEXT_PATCH_VERSION 0)
+
 
 # Flip this to 'true' when we're ready to roll out a release; then back
 # after branching
@@ -414,6 +419,9 @@ add_custom_target(update-release-and-version-info ALL
           ${CHPL_PREV_MAJOR_VERSION}
           ${CHPL_PREV_MINOR_VERSION}
           ${CHPL_PREV_PATCH_VERSION}
+          ${CHPL_NEXT_MAJOR_VERSION}
+          ${CHPL_NEXT_MINOR_VERSION}
+          ${CHPL_NEXT_PATCH_VERSION}
           "--files"
           ${SRC_DIR}/doc/rst/conf.py
           ${SRC_DIR}/man/confchpl.rst

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -405,6 +405,30 @@ if (${CHPL_OFFICIAL_RELEASE})
 else()
   set(RELEASE_FLAG "")
 endif()
+
+# Gather files that are sensitive to version number changes and update them.
+# Check if they exist here because in the release tarball, some of these
+# files will not be present.
+set(VERSION_FILES "")
+list(APPEND VERSION_FILES
+  "${SRC_DIR}/doc/rst/conf.py"
+  "${SRC_DIR}/doc/rst/language/archivedSpecs.rst"
+  "${SRC_DIR}/doc/rst/usingchapel/QUICKSTART.rst"
+  "${SRC_DIR}/doc/rst/usingchapel/chplenv.rst"
+  "${SRC_DIR}/man/confchpl.rst"
+  "${SRC_DIR}/man/confchpldoc.rst"
+  "${SRC_DIR}/test/compflags/bradc/printstuff/versionhelp.sh"
+  "${SRC_DIR}/test/chpldoc/compflags/combinations/versionhelp-chpldoc.sh"
+  "${SRC_DIR}/test/compflags/bradc/printstuff/version.goodstart"
+)
+
+set(EXISTING_VERSION_FILES "")
+foreach(FILE ${VERSION_FILES})
+  if(EXISTS ${FILE})
+    list(APPEND EXISTING_VERSION_FILES ${FILE})
+  endif()
+endforeach()
+
 add_custom_target(update-release-and-version-info ALL
   COMMAND ${CHPL_CMAKE_PYTHON}
           ${SRC_DIR}/util/config/update-release-and-version-info
@@ -415,15 +439,7 @@ add_custom_target(update-release-and-version-info ALL
           ${CHPL_PREV_MINOR_VERSION}
           ${CHPL_PREV_PATCH_VERSION}
           "--files"
-          ${SRC_DIR}/doc/rst/conf.py
-          ${SRC_DIR}/doc/rst/language/archivedSpecs.rst
-          ${SRC_DIR}/doc/rst/usingchapel/QUICKSTART.rst
-          ${SRC_DIR}/doc/rst/usingchapel/chplenv.rst
-          ${SRC_DIR}/man/confchpl.rst
-          ${SRC_DIR}/man/confchpldoc.rst
-          ${SRC_DIR}/test/compflags/bradc/printstuff/versionhelp.sh
-          ${SRC_DIR}/test/chpldoc/compflags/combinations/versionhelp-chpldoc.sh
-          ${SRC_DIR}/test/compflags/bradc/printstuff/version.goodstart
+          ${EXISTING_VERSION_FILES}
           ${RELEASE_FLAG}
   COMMENT "checking sensitive files for version changes..."
   VERBATIM)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,3 +394,32 @@ else()
   install(TARGETS chpldoc OPTIONAL
           RUNTIME DESTINATION "bin/${CHPL_HOST_BIN_SUBDIR}")
 endif()
+
+set(SRC_DIR     ${CMAKE_CURRENT_SOURCE_DIR})
+if (${CHPL_OFFICIAL_RELEASE})
+  set(RELEASE_FLAG "--official-release")
+else()
+  set(RELEASE_FLAG "")
+endif()
+add_custom_target(update-release-and-version-info ALL
+  COMMAND ${CHPL_CMAKE_PYTHON}
+          ${SRC_DIR}/util/config/update-release-and-version-info
+          ${CHPL_MAJOR_VERSION}
+          ${CHPL_MINOR_VERSION}
+          ${CHPL_PATCH_VERSION}
+          "--files"
+          ${SRC_DIR}/doc/rst/conf.py
+          ${SRC_DIR}/man/confchpl.rst
+          ${SRC_DIR}/man/confchpldoc.rst
+          ${SRC_DIR}/doc/rst/language/archivedSpecs.rst
+          ${SRC_DIR}/doc/rst/usingchapel/QUICKSTART.rst
+          ${SRC_DIR}/test/compflags/bradc/printstuff/versionhelp.sh
+          ${SRC_DIR}/test/chpldoc/compflags/combinations/versionhelp-chpldoc.sh
+          ${SRC_DIR}/doc/util/versionButton.php
+          ${SRC_DIR}/test/compflags/bradc/printstuff/version.goodstart
+          ${RELEASE_FLAG}
+  COMMENT "checking sensitive files for version changes..."
+  VERBATIM)
+add_dependencies(chpl update-release-and-version-info)
+add_dependencies(chpldoc update-release-and-version-info)
+add_dependencies(ChplFrontend-obj update-release-and-version-info)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,10 @@ set(CHPL_MAJOR_VERSION 2)
 set(CHPL_MINOR_VERSION 4)
 set(CHPL_PATCH_VERSION 0)
 set(CHPL_BUILD_VERSION 0)
+set(CHPL_PREV_MAJOR_VERSION 2)
+set(CHPL_PREV_MINOR_VERSION 2)
+set(CHPL_PREV_PATCH_VERSION 0)
+set(CHPL_PREV_BUILD_VERSION 0)
 
 # Flip this to 'true' when we're ready to roll out a release; then back
 # after branching
@@ -407,6 +411,9 @@ add_custom_target(update-release-and-version-info ALL
           ${CHPL_MAJOR_VERSION}
           ${CHPL_MINOR_VERSION}
           ${CHPL_PATCH_VERSION}
+          ${CHPL_PREV_MAJOR_VERSION}
+          ${CHPL_PREV_MINOR_VERSION}
+          ${CHPL_PREV_PATCH_VERSION}
           "--files"
           ${SRC_DIR}/doc/rst/conf.py
           ${SRC_DIR}/man/confchpl.rst

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,11 +44,6 @@ set(CHPL_PREV_MAJOR_VERSION 2)
 set(CHPL_PREV_MINOR_VERSION 3)
 set(CHPL_PREV_PATCH_VERSION 0)
 
-set(CHPL_NEXT_MAJOR_VERSION 2)
-set(CHPL_NEXT_MINOR_VERSION 5)
-set(CHPL_NEXT_PATCH_VERSION 0)
-
-
 # Flip this to 'true' when we're ready to roll out a release; then back
 # after branching
 set(CHPL_OFFICIAL_RELEASE false)
@@ -419,15 +414,11 @@ add_custom_target(update-release-and-version-info ALL
           ${CHPL_PREV_MAJOR_VERSION}
           ${CHPL_PREV_MINOR_VERSION}
           ${CHPL_PREV_PATCH_VERSION}
-          ${CHPL_NEXT_MAJOR_VERSION}
-          ${CHPL_NEXT_MINOR_VERSION}
-          ${CHPL_NEXT_PATCH_VERSION}
           "--files"
           ${SRC_DIR}/doc/rst/conf.py
           ${SRC_DIR}/doc/rst/language/archivedSpecs.rst
           ${SRC_DIR}/doc/rst/usingchapel/QUICKSTART.rst
           ${SRC_DIR}/doc/rst/usingchapel/chplenv.rst
-          ${SRC_DIR}/doc/util/versionButton.php
           ${SRC_DIR}/man/confchpl.rst
           ${SRC_DIR}/man/confchpldoc.rst
           ${SRC_DIR}/test/compflags/bradc/printstuff/versionhelp.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,11 +41,11 @@ set(CHPL_PATCH_VERSION 0)
 set(CHPL_BUILD_VERSION 0)
 
 set(CHPL_PREV_MAJOR_VERSION 2)
-set(CHPL_PREV_MINOR_VERSION 2)
+set(CHPL_PREV_MINOR_VERSION 3)
 set(CHPL_PREV_PATCH_VERSION 0)
 
 set(CHPL_NEXT_MAJOR_VERSION 2)
-set(CHPL_NEXT_MINOR_VERSION 4)
+set(CHPL_NEXT_MINOR_VERSION 5)
 set(CHPL_NEXT_PATCH_VERSION 0)
 
 
@@ -424,13 +424,14 @@ add_custom_target(update-release-and-version-info ALL
           ${CHPL_NEXT_PATCH_VERSION}
           "--files"
           ${SRC_DIR}/doc/rst/conf.py
-          ${SRC_DIR}/man/confchpl.rst
-          ${SRC_DIR}/man/confchpldoc.rst
           ${SRC_DIR}/doc/rst/language/archivedSpecs.rst
           ${SRC_DIR}/doc/rst/usingchapel/QUICKSTART.rst
+          ${SRC_DIR}/doc/rst/usingchapel/chplenv.rst
+          ${SRC_DIR}/doc/util/versionButton.php
+          ${SRC_DIR}/man/confchpl.rst
+          ${SRC_DIR}/man/confchpldoc.rst
           ${SRC_DIR}/test/compflags/bradc/printstuff/versionhelp.sh
           ${SRC_DIR}/test/chpldoc/compflags/combinations/versionhelp-chpldoc.sh
-          ${SRC_DIR}/doc/util/versionButton.php
           ${SRC_DIR}/test/compflags/bradc/printstuff/version.goodstart
           ${RELEASE_FLAG}
   COMMENT "checking sensitive files for version changes..."

--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -132,13 +132,12 @@ master_doc = 'index'
 # 'version' adds a redundant version number onto the top of the sidebar
 # automatically (rtd-theme). We also don't use |version| anywhere in rst
 
-chplversion = '2.4'                  # TODO -- parse from `chpl --version`
+chplversion = '2.4'
 shortversion = chplversion.replace('-', '&#8209') # prevent line-break at hyphen, if any
 html_context = {"chplversion":chplversion}
 
 # The full version, including alpha/beta/rc tags.
 release = '2.4.0 (pre-release)'
-# release = '2.3.0'
 
 # General information about the project.
 project = u'Chapel Documentation'

--- a/util/config/update-release-and-version-info
+++ b/util/config/update-release-and-version-info
@@ -1,7 +1,15 @@
 import argparse
+from enum import Enum
+
 
 # Represents a file or maybe a group of similar files that are updated the same way
 class FileUpdater:
+
+    class VersionType(Enum):
+        CURRENT = 1
+        PREVIOUS = 2
+        NEXT = 3
+
     def __init__(self, file_path, major_version, minor_version, patch_version, release, prev_major_version, prev_minor_version, prev_patch_version, next_major_version, next_minor_version, next_patch_version):
         self.file_path = file_path
         self.major_version = major_version
@@ -15,12 +23,38 @@ class FileUpdater:
         self.next_patch_version = next_patch_version
         self.release = release
 
-        # TODO: would be nice to have preformatted version strings in the base class
-        #       short_version would be maj.min unless patch>0, then maj.min.patch
-        #       long_version would always be maj.min.patch
-        #       These should be available for both the current and previous version numbers
-        #       they could also be overridden by the subclass if for example,
-        #       a file should never have a three digit short_version
+    # Get the version number in the form of "X.Y" no matter if Z is 0 or not
+    def short_version(self, type=VersionType.CURRENT):
+        if type == self.VersionType.CURRENT:
+            return "{}.{}".format(self.major_version, self.minor_version)
+        elif type == self.VersionType.PREVIOUS:
+            return "{}.{}".format(self.prev_major_version, self.prev_minor_version)
+        elif type == self.VersionType.NEXT:
+            return "{}.{}".format(self.next_major_version, self.next_minor_version)
+        else:
+            raise ValueError("Unrecognized VersionType: {}".format(type))
+
+    # Get the version number in the form of "X.Y.Z" or "X.Y" if Z is 0
+    def short_maybe_long_version(self, type=VersionType.CURRENT):
+        if type == self.VersionType.CURRENT:
+            return "{}.{}".format(self.major_version, self.minor_version) if self.patch_version == 0 else "{}.{}.{}".format(self.major_version, self.minor_version, self.patch_version)
+        elif type == self.VersionType.PREVIOUS:
+            return "{}.{}".format(self.prev_major_version, self.prev_minor_version) if self.prev_patch_version == 0 else "{}.{}.{}".format(self.prev_major_version, self.prev_minor_version, self.prev_patch_version)
+        elif type == self.VersionType.NEXT:
+            return "{}.{}".format(self.next_major_version, self.next_minor_version) if self.next_patch_version == 0 else "{}.{}.{}".format(self.next_major_version, self.next_minor_version, self.next_patch_version)
+        else:
+            raise ValueError("Unrecognized VersionType: {}".format(type))
+
+    # Get the version number in the form of "X.Y.Z"
+    def long_version(self, type=VersionType.CURRENT):
+        if type == self.VersionType.CURRENT:
+            return "{}.{}.{}".format(self.major_version, self.minor_version, self.patch_version)
+        elif type == self.VersionType.PREVIOUS:
+            return "{}.{}.{}".format(self.prev_major_version, self.prev_minor_version, self.prev_patch_version)
+        elif type == self.VersionType.NEXT:
+            return "{}.{}.{}".format(self.next_major_version, self.next_minor_version, self.next_patch_version)
+        else:
+            raise ValueError("Unrecognized VersionType: {}".format(type))
 
     def read_file(self):
         with open(self.file_path, 'r') as f:
@@ -37,8 +71,8 @@ class FileUpdater:
 class ConfPyUpdater(FileUpdater):
     def update(self):
         lines = self.read_file()
-        version_string = "chplversion = '{}.{}'\n".format(self.major_version, self.minor_version)
-        release_string = "release = '{}.{}.{} {}'\n".format(self.major_version, self.minor_version, self.patch_version, "" if self.release else "(pre-release)")
+        version_string = "chplversion = '{}'\n".format(self.short_maybe_long_version())
+        release_string = "release = '{} {}'\n".format(self.long_version(), "" if self.release else "(pre-release)")
         any_changed = False
         for i, line in enumerate(lines):
             if line.startswith('chplversion = \'') and not line == version_string:
@@ -54,10 +88,7 @@ class ConfPyUpdater(FileUpdater):
 class ManConfUpdater(FileUpdater):
     def update(self):
         lines = self.read_file()
-        if self.patch_version > 0:
-          release_string = ":Version: {}.{}.{} {}\n".format(self.major_version, self.minor_version, self.patch_version, "" if self.release else "pre-release")
-        else:
-          release_string = ":Version: {}.{} {}\n".format(self.major_version, self.minor_version, "" if self.release else "pre-release")
+        release_string = ":Version: {} {}\n".format(self.short_maybe_long_version(), "" if self.release else "pre-release")
         any_changed = False
         for i, line in enumerate(lines):
             if line.startswith(':Version: ') and not line.strip() == release_string.strip():
@@ -72,7 +103,9 @@ class ArchivedSpecUpdater(FileUpdater):
         # this needs the PREV version number to be able to update the archive without messing up
         if self.release:
           lines = self.read_file()
-          archive_string = "* `Chapel {}.{} <https://chapel-lang.org/docs/{}.{}/index.html>`_\n".format(self.prev_major_version, self.prev_minor_version, self.prev_major_version, self.prev_minor_version)
+          # add 1 or 2 spaces depending on the length of the previous minor version
+          padding = 3 - len(str(self.prev_minor_version))
+          archive_string = "* `Chapel {}{}<https://chapel-lang.org/docs/{}/index.html>`_\n".format(self.short_version(self.VersionType.PREVIOUS), ' ' * padding, self.short_version(self.VersionType.PREVIOUS))
           any_changed = False
           if not archive_string in lines:
             for i, line in enumerate(lines):
@@ -87,18 +120,18 @@ class QuickStartUpdater(FileUpdater):
     def update(self):
         if self.release:
           lines = self.read_file()
-          version_string = "1) If you don't already have the Chapel {}.{} source release, see\n".format(self.major_version, self.minor_version)
-          tar_string = "         tar xzf chapel-{}.{}.{}.tar.gz\n".format(self.major_version, self.minor_version, self.patch_version)
-          cd_string =  "         cd chapel-{}.{}.{}\n".format(self.major_version, self.minor_version, self.patch_version)
+          version_string = "1) If you don't already have the Chapel {} source release, see\n".format(self.short_maybe_long_version())
+          tar_string = "         tar xzf chapel-{}.tar.gz\n".format(self.long_version())
+          cd_string =  "         cd chapel-{}\n".format(self.long_version())
           any_changed = False
           for i, line in enumerate(lines):
               if line.startswith('1) If you don\'t already have the Chapel ') and not line.strip() == version_string.strip():
                   lines[i] = version_string
                   any_changed = True
-              elif line.startswith("         tar xzf chapel-") and not line.strip() == tar_string.strip():
+              elif line.strip().startswith("tar xzf chapel-") and not line.strip() == tar_string.strip():
                   lines[i] = tar_string
                   any_changed = True
-              elif line.startswith("         cd chapel-") and not line.strip() == cd_string.strip():
+              elif line.strip().startswith("cd chapel-") and not line.strip() == cd_string.strip():
                   lines[i] = cd_string
                   any_changed = True
           if any_changed:
@@ -109,10 +142,10 @@ class ChplEnvUpdater(FileUpdater):
     def update(self):
         if self.release:
           lines = self.read_file()
-          export_string = "        export CHPL_HOME=~/chapel-{}.{}.{}\n".format(self.major_version, self.minor_version, self.patch_version)
+          export_string = "        export CHPL_HOME=~/chapel-{}\n".format(self.long_version())
           any_changed = False
           for i, line in enumerate(lines):
-              if line.startswith('        export CHPL_HOME=~/chapel-') and not line.strip() == export_string.strip():
+              if line.strip().startswith('export CHPL_HOME=~/chapel-') and not line.strip() == export_string.strip():
                   lines[i] = export_string
                   any_changed = True
           if any_changed:
@@ -149,28 +182,25 @@ class VersionHelpUpdater(FileUpdater):
         if any_changed:
           self.write_file(lines)
 
-# TODO: Implement the VersionButtonUpdater with specific rules for updating the version here
 class VersionButtonUpdater(FileUpdater):
     # steady-state: docs refers to prev-release and docs/main refers to current release
     def update(self):
         lines = self.read_file()
         any_changed = False
-        cur_rel = 'var currentRelease = "{}.{}";'
-        stage_rel = 'var stagedRelease = "{}.{}";'
-        next_rel = 'var nextRelease = "{}.{}";'
-        if self.release:
-            for i, line in enumerate(lines):
-                if line.strip().startswith('var nextRelease = ') and not line.strip() == 'var nextRelease = "{}.{}";    // what\'s the next release? (on docs/main)'.format(self.next_major_version, self.next_minor_version):
-                    any_changed = True
-                    lines[i] = '  var nextRelease = "{}.{}";    // what\'s the next release? (on docs/main)\n'.format(self.next_major_version, self.next_minor_version)
-        else:
-            for i, line in enumerate(lines):
-                if line.strip().startswith('var currentRelease = ') and not line.strip() == 'var currentRelease = "{}.{}";    // what does the public have?'.format(self.prev_major_version, self.prev_minor_version):
-                    any_changed = True
-                    lines[i] = '  var currentRelease = "{}.{}";    // what does the public have?\n'.format(self.prev_major_version, self.prev_minor_version)
-                elif line.strip().startswith('var stagedRelease = ') and not line.strip() == 'var stagedRelease = "{}.{}";    // is there a release staged but not yet public?'.format(self.major_version, self.minor_version):
-                    any_changed = True
-                    lines[i] = '  var stagedRelease = "{}.{}";    // is there a release staged but not yet public?\n'.format(self.major_version, self.minor_version)
+        cur_rel = '  var currentRelease = "{}"; // what does the public have?\n'.format(self.short_maybe_long_version(self.VersionType.PREVIOUS))
+        staged_rel = '  var stagedRelease = "{}";  // is there a release staged but not yet public?\n'.format(self.short_maybe_long_version())
+        next_rel = '  var nextRelease = "{}";    // what\'s the next release? (on docs/main)\n'.format(self.short_maybe_long_version(self.VersionType.NEXT)) if self.release else 'var nextRelease = "{}";    // what\'s the next release? (on docs/main)\n'.format(self.short_maybe_long_version())
+
+        for i, line in enumerate(lines):
+            if line.strip().startswith('var nextRelease = ') and not line.strip() == next_rel.strip():
+                any_changed = True
+                lines[i] = next_rel
+            elif line.strip().startswith('var currentRelease = ') and not line.strip() == cur_rel.strip():
+                any_changed = True
+                lines[i] = cur_rel
+            elif line.strip().startswith('var stagedRelease = ') and not line.strip() == staged_rel.strip():
+                any_changed = True
+                lines[i] = staged_rel
         if any_changed:
             self.write_file(lines)
 
@@ -178,7 +208,7 @@ class VersionButtonUpdater(FileUpdater):
 class GoodStartUpdater(FileUpdater):
     def update(self):
         lines = self.read_file()
-        version_string = " version {}.{}.{}".format(self.major_version, self.minor_version, self.patch_version)
+        version_string = " version {}".format(self.long_version())
         any_changed = False
         for i, line in enumerate(lines):
             if line.strip().startswith('version') and not line.strip() == version_string.strip():

--- a/util/config/update-release-and-version-info
+++ b/util/config/update-release-and-version-info
@@ -2,12 +2,22 @@ import argparse
 
 # Represents a file or maybe a group of similar files that are updated the same way
 class FileUpdater:
-    def __init__(self, file_path, major_version, minor_version, patch_version, release):
+    def __init__(self, file_path, major_version, minor_version, patch_version, release, prev_major_version, prev_minor_version, prev_patch_version):
         self.file_path = file_path
         self.major_version = major_version
         self.minor_version = minor_version
         self.patch_version = patch_version
+        self.prev_major_version = prev_major_version
+        self.prev_minor_version = prev_minor_version
+        self.prev_patch_version = prev_patch_version
         self.release = release
+
+        # TODO: would be nice to have preformatted version strings in the base class
+        #       short_version would be maj.min unless patch>0, then maj.min.patch
+        #       long_version would always be maj.min.patch
+        #       These should be available for both the current and previous version numbers
+        #       they could also be overridden by the subclass if for example,
+        #       a file should never have a three digit short_version
 
     def read_file(self):
         with open(self.file_path, 'r') as f:
@@ -56,10 +66,10 @@ class ManConfUpdater(FileUpdater):
 # Updates the archivedSpecs.rst file only when moving to an official release
 class ArchivedSpecUpdater(FileUpdater):
     def update(self):
-        # TODO: this needs the OLD version number to be able to update the archive without messing up
+        # this needs the PREV version number to be able to update the archive without messing up
         if self.release:
           lines = self.read_file()
-          archive_string = "* `Chapel {}.{} <https://chapel-lang.org/docs/{}.{}/index.html>`_\n".format(self.major_version, self.minor_version - 1, self.major_version, self.minor_version - 1)
+          archive_string = "* `Chapel {}.{} <https://chapel-lang.org/docs/{}.{}/index.html>`_\n".format(self.prev_major_version, self.prev_minor_version, self.prev_major_version, self.prev_minor_version)
           any_changed = False
           if not archive_string in lines:
             for i, line in enumerate(lines):
@@ -138,8 +148,29 @@ class VersionHelpUpdater(FileUpdater):
 
 # TODO: Implement the VersionButtonUpdater with specific rules for updating the version here
 class VersionButtonUpdater(FileUpdater):
+    # steady-state: docs refers to prev-release and docs/main refers to current release
     def update(self):
-        pass
+        lines = self.read_file()
+        any_changed = False
+        cur_rel = 'var currentRelease = "{}.{}";'
+        stage_rel = 'var stagedRelease = "{}.{}";'
+        next_rel = 'var nextRelease = "{}.{}";'
+        if self.release:
+            for i, line in enumerate(lines):
+                # TODO: Store the next release in cmake too? This is a pretty naive way, just incrementing the minor version by 1.
+                if line.strip().startswith('var nextRelease = ') and not line.strip() == 'var nextRelease = "{}.{}";    // what\'s the next release? (on docs/main)'.format(self.major_version, self.minor_version + 1):
+                    any_changed = True
+                    lines[i] = '  var nextRelease = "{}.{}";    // what\'s the next release? (on docs/main)\n'.format(self.major_version, self.minor_version + 1)
+        else:
+            for i, line in enumerate(lines):
+                if line.strip().startswith('var currentRelease = ') and not line.strip() == 'var currentRelease = "{}.{}";    // what does the public have?'.format(self.prev_major_version, self.prev_minor_version):
+                    any_changed = True
+                    lines[i] = '  var currentRelease = "{}.{}";    // what does the public have?\n'.format(self.prev_major_version, self.prev_minor_version)
+                elif line.strip().startswith('var stagedRelease = ') and not line.strip() == 'var stagedRelease = "{}.{}";    // is there a release staged but not yet public?'.format(self.major_version, self.minor_version):
+                    any_changed = True
+                    lines[i] = '  var stagedRelease = "{}.{}";    // is there a release staged but not yet public?\n'.format(self.major_version, self.minor_version)
+        if any_changed:
+            self.write_file(lines)
 
 # Updates the version in the version.goodstart file
 class GoodStartUpdater(FileUpdater):
@@ -160,27 +191,30 @@ def main():
     parser.add_argument('major_version', type=int, help='The major version of Chapel')
     parser.add_argument('minor_version', type=int, help='The minor version of Chapel')
     parser.add_argument('patch_version', type=int, help='The patch version of Chapel')
+    parser.add_argument('prev_major_version', type=int, help='The previous major version of Chapel')
+    parser.add_argument('prev_minor_version', type=int, help='The previous minor version of Chapel')
+    parser.add_argument('prev_patch_version', type=int, help='The previous patch version of Chapel')
     parser.add_argument('--official-release', dest='release', action="store_true", help='Is this an official release?')
 
     args = parser.parse_args()
     for fpath in args.files:
       # Determine which updater to use based on the file name or other criteria
       if fpath.endswith('conf.py'):
-          updater = ConfPyUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release)
+          updater = ConfPyUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release, args.prev_major_version, args.prev_minor_version, args.prev_patch_version)
       elif fpath.endswith('confchpl.rst') or fpath.endswith('confchpldoc.rst'):
-          updater = ManConfUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release)
+          updater = ManConfUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release, args.prev_major_version, args.prev_minor_version, args.prev_patch_version)
       elif fpath.endswith('archivedSpecs.rst'):
-          updater = ArchivedSpecUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release)
+          updater = ArchivedSpecUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release, args.prev_major_version, args.prev_minor_version, args.prev_patch_version)
       elif fpath.endswith('QUICKSTART.rst'):
-          updater = QuickStartUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release)
+          updater = QuickStartUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release, args.prev_major_version, args.prev_minor_version, args.prev_patch_version)
       elif fpath.endswith('chplenv.rst'):
-          updater = ChplEnvUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release)
+          updater = ChplEnvUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release, args.prev_major_version, args.prev_minor_version, args.prev_patch_version)
       elif fpath.endswith('versionhelp.sh') or fpath.endswith('versionhelp-chpldoc.sh'):
-          updater = VersionHelpUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release)
+          updater = VersionHelpUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release, args.prev_major_version, args.prev_minor_version, args.prev_patch_version)
       elif fpath.endswith('versionButton.php'):
-          updater = VersionButtonUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release)
+          updater = VersionButtonUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release, args.prev_major_version, args.prev_minor_version, args.prev_patch_version)
       elif fpath.endswith('version.goodstart'):
-          updater = GoodStartUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release)
+          updater = GoodStartUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release, args.prev_major_version, args.prev_minor_version, args.prev_patch_version)
       else:
           raise ValueError("Unrecognized file name: {}".format(fpath))
 

--- a/util/config/update-release-and-version-info
+++ b/util/config/update-release-and-version-info
@@ -3,6 +3,7 @@ from enum import Enum
 
 
 # Represents a file or maybe a group of similar files that are updated the same way
+# If you add a new FileUpdater subclass, you should also add it to the updaters map
 class FileUpdater:
 
     class VersionType(Enum):
@@ -277,7 +278,7 @@ def main():
     )
     parser.add_argument(
         "prev_patch_version", type=int, help="The previous patch version of Chapel"
-    )    
+    )
     parser.add_argument(
         "--official-release",
         dest="release",
@@ -286,6 +287,7 @@ def main():
     )
 
     args = parser.parse_args()
+    # MAINTENANCE: Add entries for any new files that need updating
     updaters = {
         "conf.py": ConfPyUpdater,
         "confchpl.rst": ManConfUpdater,

--- a/util/config/update-release-and-version-info
+++ b/util/config/update-release-and-version-info
@@ -10,7 +10,20 @@ class FileUpdater:
         PREVIOUS = 2
         NEXT = 3
 
-    def __init__(self, file_path, major_version, minor_version, patch_version, release, prev_major_version, prev_minor_version, prev_patch_version, next_major_version, next_minor_version, next_patch_version):
+    def __init__(
+        self,
+        file_path,
+        major_version,
+        minor_version,
+        patch_version,
+        release,
+        prev_major_version,
+        prev_minor_version,
+        prev_patch_version,
+        next_major_version,
+        next_minor_version,
+        next_patch_version,
+    ):
         self.file_path = file_path
         self.major_version = major_version
         self.minor_version = minor_version
@@ -37,119 +50,188 @@ class FileUpdater:
     # Get the version number in the form of "X.Y.Z" or "X.Y" if Z is 0
     def short_maybe_long_version(self, type=VersionType.CURRENT):
         if type == self.VersionType.CURRENT:
-            return "{}.{}".format(self.major_version, self.minor_version) if self.patch_version == 0 else "{}.{}.{}".format(self.major_version, self.minor_version, self.patch_version)
+            return (
+                "{}.{}".format(self.major_version, self.minor_version)
+                if self.patch_version == 0
+                else "{}.{}.{}".format(
+                    self.major_version, self.minor_version, self.patch_version
+                )
+            )
         elif type == self.VersionType.PREVIOUS:
-            return "{}.{}".format(self.prev_major_version, self.prev_minor_version) if self.prev_patch_version == 0 else "{}.{}.{}".format(self.prev_major_version, self.prev_minor_version, self.prev_patch_version)
+            return (
+                "{}.{}".format(self.prev_major_version, self.prev_minor_version)
+                if self.prev_patch_version == 0
+                else "{}.{}.{}".format(
+                    self.prev_major_version,
+                    self.prev_minor_version,
+                    self.prev_patch_version,
+                )
+            )
         elif type == self.VersionType.NEXT:
-            return "{}.{}".format(self.next_major_version, self.next_minor_version) if self.next_patch_version == 0 else "{}.{}.{}".format(self.next_major_version, self.next_minor_version, self.next_patch_version)
+            return (
+                "{}.{}".format(self.next_major_version, self.next_minor_version)
+                if self.next_patch_version == 0
+                else "{}.{}.{}".format(
+                    self.next_major_version,
+                    self.next_minor_version,
+                    self.next_patch_version,
+                )
+            )
         else:
             raise ValueError("Unrecognized VersionType: {}".format(type))
 
     # Get the version number in the form of "X.Y.Z"
     def long_version(self, type=VersionType.CURRENT):
         if type == self.VersionType.CURRENT:
-            return "{}.{}.{}".format(self.major_version, self.minor_version, self.patch_version)
+            return "{}.{}.{}".format(
+                self.major_version, self.minor_version, self.patch_version
+            )
         elif type == self.VersionType.PREVIOUS:
-            return "{}.{}.{}".format(self.prev_major_version, self.prev_minor_version, self.prev_patch_version)
+            return "{}.{}.{}".format(
+                self.prev_major_version,
+                self.prev_minor_version,
+                self.prev_patch_version,
+            )
         elif type == self.VersionType.NEXT:
-            return "{}.{}.{}".format(self.next_major_version, self.next_minor_version, self.next_patch_version)
+            return "{}.{}.{}".format(
+                self.next_major_version,
+                self.next_minor_version,
+                self.next_patch_version,
+            )
         else:
             raise ValueError("Unrecognized VersionType: {}".format(type))
 
     def read_file(self):
-        with open(self.file_path, 'r') as f:
+        with open(self.file_path, "r") as f:
             return f.readlines()
 
     def write_file(self, lines):
-        with open(self.file_path, 'w') as f:
+        with open(self.file_path, "w") as f:
             f.writelines(lines)
 
     def update(self):
         raise NotImplementedError("Subclasses should implement this method")
+
 
 # Handles conf.py
 class ConfPyUpdater(FileUpdater):
     def update(self):
         lines = self.read_file()
         version_string = "chplversion = '{}'\n".format(self.short_maybe_long_version())
-        release_string = "release = '{} {}".format(self.long_version(), "" if self.release else "(pre-release)").strip()
+        release_string = "release = '{} {}".format(
+            self.long_version(), "" if self.release else "(pre-release)"
+        ).strip()
         any_changed = False
         for i, line in enumerate(lines):
-            if line.startswith('chplversion = \'') and not line.strip() == version_string:
+            if (
+                line.startswith("chplversion = '")
+                and not line.strip() == version_string
+            ):
                 lines[i] = version_string
                 any_changed = True
-            elif line.startswith('release = \'') and not line.strip() == release_string:
+            elif line.startswith("release = '") and not line.strip() == release_string:
                 lines[i] = release_string + "'\n"
                 any_changed = True
         if any_changed:
             self.write_file(lines)
 
+
 # Handles man/confchpl.rst and man/confchpldoc.rst
 class ManConfUpdater(FileUpdater):
     def update(self):
         lines = self.read_file()
-        release_string = ":Version: {} {}".format(self.short_maybe_long_version(), "" if self.release else "pre-release").strip()
+        release_string = ":Version: {} {}".format(
+            self.short_maybe_long_version(), "" if self.release else "pre-release"
+        ).strip()
         any_changed = False
         for i, line in enumerate(lines):
-            if line.startswith(':Version: ') and not line.strip() == release_string:
-                lines[i] = release_string + '\n'
+            if line.startswith(":Version: ") and not line.strip() == release_string:
+                lines[i] = release_string + "\n"
                 any_changed = True
         if any_changed:
             self.write_file(lines)
+
 
 # Updates the archivedSpecs.rst file only when moving to an official release
 class ArchivedSpecUpdater(FileUpdater):
     def update(self):
         # this needs the PREV version number to be able to update the archive without messing up
         if self.release:
-          lines = self.read_file()
-          # add 1 or 2 spaces depending on the length of the previous minor version
-          padding = 3 - len(str(self.prev_minor_version))
-          archive_string = "* `Chapel {}{}<https://chapel-lang.org/docs/{}/index.html>`_\n".format(self.short_version(self.VersionType.PREVIOUS), ' ' * padding, self.short_version(self.VersionType.PREVIOUS))
-          any_changed = False
-          if not archive_string in lines:
-            for i, line in enumerate(lines):
-              if line.startswith('Online Documentation Archives'):
-                lines.insert(i + 2, archive_string)
-                any_changed = True
-          if any_changed:
-              self.write_file(lines)
+            lines = self.read_file()
+            # add 1 or 2 spaces depending on the length of the previous minor version
+            padding = 3 - len(str(self.prev_minor_version))
+            archive_string = (
+                "* `Chapel {}{}<https://chapel-lang.org/docs/{}/index.html>`_\n".format(
+                    self.short_version(self.VersionType.PREVIOUS),
+                    " " * padding,
+                    self.short_version(self.VersionType.PREVIOUS),
+                )
+            )
+            any_changed = False
+            if not archive_string in lines:
+                for i, line in enumerate(lines):
+                    if line.startswith("Online Documentation Archives"):
+                        lines.insert(i + 2, archive_string)
+                        any_changed = True
+            if any_changed:
+                self.write_file(lines)
+
 
 # Updates the QUICKSTART.rst file only when moving to an official release
 class QuickStartUpdater(FileUpdater):
     def update(self):
         if self.release:
-          lines = self.read_file()
-          version_string = "1) If you don't already have the Chapel {} source release, see\n".format(self.short_maybe_long_version())
-          tar_string = "         tar xzf chapel-{}.tar.gz\n".format(self.long_version())
-          cd_string =  "         cd chapel-{}\n".format(self.long_version())
-          any_changed = False
-          for i, line in enumerate(lines):
-              if line.startswith('1) If you don\'t already have the Chapel ') and not line.strip() == version_string.strip():
-                  lines[i] = version_string
-                  any_changed = True
-              elif line.strip().startswith("tar xzf chapel-") and not line.strip() == tar_string.strip():
-                  lines[i] = tar_string
-                  any_changed = True
-              elif line.strip().startswith("cd chapel-") and not line.strip() == cd_string.strip():
-                  lines[i] = cd_string
-                  any_changed = True
-          if any_changed:
-              self.write_file(lines)
+            lines = self.read_file()
+            version_string = "1) If you don't already have the Chapel {} source release, see\n".format(
+                self.short_maybe_long_version()
+            )
+            tar_string = "         tar xzf chapel-{}.tar.gz\n".format(
+                self.long_version()
+            )
+            cd_string = "         cd chapel-{}\n".format(self.long_version())
+            any_changed = False
+            for i, line in enumerate(lines):
+                if (
+                    line.startswith("1) If you don't already have the Chapel ")
+                    and not line.strip() == version_string.strip()
+                ):
+                    lines[i] = version_string
+                    any_changed = True
+                elif (
+                    line.strip().startswith("tar xzf chapel-")
+                    and not line.strip() == tar_string.strip()
+                ):
+                    lines[i] = tar_string
+                    any_changed = True
+                elif (
+                    line.strip().startswith("cd chapel-")
+                    and not line.strip() == cd_string.strip()
+                ):
+                    lines[i] = cd_string
+                    any_changed = True
+            if any_changed:
+                self.write_file(lines)
+
 
 # Updates the chplenv.rst file only when moving to an official release
 class ChplEnvUpdater(FileUpdater):
     def update(self):
         if self.release:
-          lines = self.read_file()
-          export_string = "        export CHPL_HOME=~/chapel-{}\n".format(self.long_version())
-          any_changed = False
-          for i, line in enumerate(lines):
-              if line.strip().startswith('export CHPL_HOME=~/chapel-') and not line.strip() == export_string.strip():
-                  lines[i] = export_string
-                  any_changed = True
-          if any_changed:
-              self.write_file(lines)
+            lines = self.read_file()
+            export_string = "        export CHPL_HOME=~/chapel-{}\n".format(
+                self.long_version()
+            )
+            any_changed = False
+            for i, line in enumerate(lines):
+                if (
+                    line.strip().startswith("export CHPL_HOME=~/chapel-")
+                    and not line.strip() == export_string.strip()
+                ):
+                    lines[i] = export_string
+                    any_changed = True
+            if any_changed:
+                self.write_file(lines)
+
 
 # Updates the versionhelp.sh and versionhelp-chpldoc.sh files when moving to an official release
 # and again when moving to a pre-release with a version bump
@@ -158,51 +240,78 @@ class VersionHelpUpdater(FileUpdater):
         any_changed = False
         lines = self.read_file()
         if self.release:
-          for i, line in enumerate(lines):
-            if line.startswith('diff $CWD/../../../../compiler/main/BUILD_VERSION $CWD/zero.txt'):
-                lines[i] = "# {}".format(line)
-                any_changed = True
-            elif line.startswith("  { echo -n \" pre-release (\" &&"):
-                lines[i] = "# {}".format(line)
-                any_changed = True
-            elif line.startswith("# echo \"\""):
-                lines[i] = "{}".format(line[2:])
-                any_changed = True
+            for i, line in enumerate(lines):
+                if line.startswith(
+                    "diff $CWD/../../../../compiler/main/BUILD_VERSION $CWD/zero.txt"
+                ):
+                    lines[i] = "# {}".format(line)
+                    any_changed = True
+                elif line.startswith('  { echo -n " pre-release (" &&'):
+                    lines[i] = "# {}".format(line)
+                    any_changed = True
+                elif line.startswith('# echo ""'):
+                    lines[i] = "{}".format(line[2:])
+                    any_changed = True
         else:
-          for i, line in enumerate(lines):
-            if line.startswith('# diff $CWD/../../../../compiler/main/BUILD_VERSION $CWD/zero.txt'):
-                lines[i] = "{}".format(line[2:])
-                any_changed = True
-            elif line.startswith("#   { echo -n \" pre-release (\" &&"):
-                lines[i] = "{}".format(line[2:])
-                any_changed = True
-            elif line.startswith("echo \"\""):
-                lines[i] = "# {}".format(line)
-                any_changed = True
+            for i, line in enumerate(lines):
+                if line.startswith(
+                    "# diff $CWD/../../../../compiler/main/BUILD_VERSION $CWD/zero.txt"
+                ):
+                    lines[i] = "{}".format(line[2:])
+                    any_changed = True
+                elif line.startswith('#   { echo -n " pre-release (" &&'):
+                    lines[i] = "{}".format(line[2:])
+                    any_changed = True
+                elif line.startswith('echo ""'):
+                    lines[i] = "# {}".format(line)
+                    any_changed = True
         if any_changed:
-          self.write_file(lines)
+            self.write_file(lines)
+
 
 class VersionButtonUpdater(FileUpdater):
     # steady-state: docs refers to prev-release and docs/main refers to current release
     def update(self):
         lines = self.read_file()
         any_changed = False
-        cur_rel = '  var currentRelease = "{}"; // what does the public have?\n'.format(self.short_maybe_long_version(self.VersionType.PREVIOUS))
-        staged_rel = '  var stagedRelease = "{}";  // is there a release staged but not yet public?\n'.format(self.short_maybe_long_version())
-        next_rel = '  var nextRelease = "{}";    // what\'s the next release? (on docs/main)\n'.format(self.short_maybe_long_version(self.VersionType.NEXT)) if self.release else 'var nextRelease = "{}";    // what\'s the next release? (on docs/main)\n'.format(self.short_maybe_long_version())
+        cur_rel = '  var currentRelease = "{}"; // what does the public have?\n'.format(
+            self.short_maybe_long_version(self.VersionType.PREVIOUS)
+        )
+        staged_rel = '  var stagedRelease = "{}";  // is there a release staged but not yet public?\n'.format(
+            self.short_maybe_long_version()
+        )
+        next_rel = (
+            '  var nextRelease = "{}";    // what\'s the next release? (on docs/main)\n'.format(
+                self.short_maybe_long_version(self.VersionType.NEXT)
+            )
+            if self.release
+            else 'var nextRelease = "{}";    // what\'s the next release? (on docs/main)\n'.format(
+                self.short_maybe_long_version()
+            )
+        )
 
         for i, line in enumerate(lines):
-            if line.strip().startswith('var nextRelease = ') and not line.strip() == next_rel.strip():
+            if (
+                line.strip().startswith("var nextRelease = ")
+                and not line.strip() == next_rel.strip()
+            ):
                 any_changed = True
                 lines[i] = next_rel
-            elif line.strip().startswith('var currentRelease = ') and not line.strip() == cur_rel.strip():
+            elif (
+                line.strip().startswith("var currentRelease = ")
+                and not line.strip() == cur_rel.strip()
+            ):
                 any_changed = True
                 lines[i] = cur_rel
-            elif line.strip().startswith('var stagedRelease = ') and not line.strip() == staged_rel.strip():
+            elif (
+                line.strip().startswith("var stagedRelease = ")
+                and not line.strip() == staged_rel.strip()
+            ):
                 any_changed = True
                 lines[i] = staged_rel
         if any_changed:
             self.write_file(lines)
+
 
 # Updates the version in the version.goodstart file
 class GoodStartUpdater(FileUpdater):
@@ -211,49 +320,171 @@ class GoodStartUpdater(FileUpdater):
         version_string = " version {}".format(self.long_version())
         any_changed = False
         for i, line in enumerate(lines):
-            if line.strip().startswith('version') and not line.strip() == version_string.strip():
+            if (
+                line.strip().startswith("version")
+                and not line.strip() == version_string.strip()
+            ):
                 lines[i] = version_string
                 any_changed = True
         if any_changed:
             self.write_file(lines)
 
+
 def main():
-    parser = argparse.ArgumentParser(description='Update the version and release/pre-release info in files')
-    parser.add_argument('-f', '--files', nargs="+", help='The file(s) to update')
-    parser.add_argument('major_version', type=int, help='The major version of Chapel')
-    parser.add_argument('minor_version', type=int, help='The minor version of Chapel')
-    parser.add_argument('patch_version', type=int, help='The patch version of Chapel')
-    parser.add_argument('prev_major_version', type=int, help='The previous major version of Chapel')
-    parser.add_argument('prev_minor_version', type=int, help='The previous minor version of Chapel')
-    parser.add_argument('prev_patch_version', type=int, help='The previous patch version of Chapel')
-    parser.add_argument('next_major_version', type=int, help='The next major version of Chapel')
-    parser.add_argument('next_minor_version', type=int, help='The next minor version of Chapel')
-    parser.add_argument('next_patch_version', type=int, help='The next patch version of Chapel')
-    parser.add_argument('--official-release', dest='release', action="store_true", help='Is this an official release?')
+    parser = argparse.ArgumentParser(
+        description="Update the version and release/pre-release info in files"
+    )
+    parser.add_argument("-f", "--files", nargs="+", help="The file(s) to update")
+    parser.add_argument("major_version", type=int, help="The major version of Chapel")
+    parser.add_argument("minor_version", type=int, help="The minor version of Chapel")
+    parser.add_argument("patch_version", type=int, help="The patch version of Chapel")
+    parser.add_argument(
+        "prev_major_version", type=int, help="The previous major version of Chapel"
+    )
+    parser.add_argument(
+        "prev_minor_version", type=int, help="The previous minor version of Chapel"
+    )
+    parser.add_argument(
+        "prev_patch_version", type=int, help="The previous patch version of Chapel"
+    )
+    parser.add_argument(
+        "next_major_version", type=int, help="The next major version of Chapel"
+    )
+    parser.add_argument(
+        "next_minor_version", type=int, help="The next minor version of Chapel"
+    )
+    parser.add_argument(
+        "next_patch_version", type=int, help="The next patch version of Chapel"
+    )
+    parser.add_argument(
+        "--official-release",
+        dest="release",
+        action="store_true",
+        help="Is this an official release?",
+    )
 
     args = parser.parse_args()
     for fpath in args.files:
-      # Determine which updater to use based on the file name or other criteria
-      if fpath.endswith('conf.py'):
-          updater = ConfPyUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release, args.prev_major_version, args.prev_minor_version, args.prev_patch_version, args.next_major_version, args.next_minor_version, args.next_patch_version)
-      elif fpath.endswith('confchpl.rst') or fpath.endswith('confchpldoc.rst'):
-          updater = ManConfUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release, args.prev_major_version, args.prev_minor_version, args.prev_patch_version, args.next_major_version, args.next_minor_version, args.next_patch_version)
-      elif fpath.endswith('archivedSpecs.rst'):
-          updater = ArchivedSpecUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release, args.prev_major_version, args.prev_minor_version, args.prev_patch_version, args.next_major_version, args.next_minor_version, args.next_patch_version)
-      elif fpath.endswith('QUICKSTART.rst'):
-          updater = QuickStartUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release, args.prev_major_version, args.prev_minor_version, args.prev_patch_version, args.next_major_version, args.next_minor_version, args.next_patch_version)
-      elif fpath.endswith('chplenv.rst'):
-          updater = ChplEnvUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release, args.prev_major_version, args.prev_minor_version, args.prev_patch_version, args.next_major_version, args.next_minor_version, args.next_patch_version)
-      elif fpath.endswith('versionhelp.sh') or fpath.endswith('versionhelp-chpldoc.sh'):
-          updater = VersionHelpUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release, args.prev_major_version, args.prev_minor_version, args.prev_patch_version, args.next_major_version, args.next_minor_version, args.next_patch_version)
-      elif fpath.endswith('versionButton.php'):
-          updater = VersionButtonUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release, args.prev_major_version, args.prev_minor_version, args.prev_patch_version, args.next_major_version, args.next_minor_version, args.next_patch_version)
-      elif fpath.endswith('version.goodstart'):
-          updater = GoodStartUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release, args.prev_major_version, args.prev_minor_version, args.prev_patch_version, args.next_major_version, args.next_minor_version, args.next_patch_version)
-      else:
-          raise ValueError("Unrecognized file name: {}".format(fpath))
+        # Determine which updater to use based on the file name or other criteria
+        if fpath.endswith("conf.py"):
+            updater = ConfPyUpdater(
+                fpath,
+                args.major_version,
+                args.minor_version,
+                args.patch_version,
+                args.release,
+                args.prev_major_version,
+                args.prev_minor_version,
+                args.prev_patch_version,
+                args.next_major_version,
+                args.next_minor_version,
+                args.next_patch_version,
+            )
+        elif fpath.endswith("confchpl.rst") or fpath.endswith("confchpldoc.rst"):
+            updater = ManConfUpdater(
+                fpath,
+                args.major_version,
+                args.minor_version,
+                args.patch_version,
+                args.release,
+                args.prev_major_version,
+                args.prev_minor_version,
+                args.prev_patch_version,
+                args.next_major_version,
+                args.next_minor_version,
+                args.next_patch_version,
+            )
+        elif fpath.endswith("archivedSpecs.rst"):
+            updater = ArchivedSpecUpdater(
+                fpath,
+                args.major_version,
+                args.minor_version,
+                args.patch_version,
+                args.release,
+                args.prev_major_version,
+                args.prev_minor_version,
+                args.prev_patch_version,
+                args.next_major_version,
+                args.next_minor_version,
+                args.next_patch_version,
+            )
+        elif fpath.endswith("QUICKSTART.rst"):
+            updater = QuickStartUpdater(
+                fpath,
+                args.major_version,
+                args.minor_version,
+                args.patch_version,
+                args.release,
+                args.prev_major_version,
+                args.prev_minor_version,
+                args.prev_patch_version,
+                args.next_major_version,
+                args.next_minor_version,
+                args.next_patch_version,
+            )
+        elif fpath.endswith("chplenv.rst"):
+            updater = ChplEnvUpdater(
+                fpath,
+                args.major_version,
+                args.minor_version,
+                args.patch_version,
+                args.release,
+                args.prev_major_version,
+                args.prev_minor_version,
+                args.prev_patch_version,
+                args.next_major_version,
+                args.next_minor_version,
+                args.next_patch_version,
+            )
+        elif fpath.endswith("versionhelp.sh") or fpath.endswith(
+            "versionhelp-chpldoc.sh"
+        ):
+            updater = VersionHelpUpdater(
+                fpath,
+                args.major_version,
+                args.minor_version,
+                args.patch_version,
+                args.release,
+                args.prev_major_version,
+                args.prev_minor_version,
+                args.prev_patch_version,
+                args.next_major_version,
+                args.next_minor_version,
+                args.next_patch_version,
+            )
+        elif fpath.endswith("versionButton.php"):
+            updater = VersionButtonUpdater(
+                fpath,
+                args.major_version,
+                args.minor_version,
+                args.patch_version,
+                args.release,
+                args.prev_major_version,
+                args.prev_minor_version,
+                args.prev_patch_version,
+                args.next_major_version,
+                args.next_minor_version,
+                args.next_patch_version,
+            )
+        elif fpath.endswith("version.goodstart"):
+            updater = GoodStartUpdater(
+                fpath,
+                args.major_version,
+                args.minor_version,
+                args.patch_version,
+                args.release,
+                args.prev_major_version,
+                args.prev_minor_version,
+                args.prev_patch_version,
+                args.next_major_version,
+                args.next_minor_version,
+                args.next_patch_version,
+            )
+        else:
+            raise ValueError("Unrecognized file name: {}".format(fpath))
 
-      updater.update()
+        updater.update()
+
 
 if __name__ == "__main__":
     main()

--- a/util/config/update-release-and-version-info
+++ b/util/config/update-release-and-version-info
@@ -1,0 +1,190 @@
+import argparse
+
+# Represents a file or maybe a group of similar files that are updated the same way
+class FileUpdater:
+    def __init__(self, file_path, major_version, minor_version, patch_version, release):
+        self.file_path = file_path
+        self.major_version = major_version
+        self.minor_version = minor_version
+        self.patch_version = patch_version
+        self.release = release
+
+    def read_file(self):
+        with open(self.file_path, 'r') as f:
+            return f.readlines()
+
+    def write_file(self, lines):
+        with open(self.file_path, 'w') as f:
+            f.writelines(lines)
+
+    def update(self):
+        raise NotImplementedError("Subclasses should implement this method")
+
+# Handles conf.py
+class ConfPyUpdater(FileUpdater):
+    def update(self):
+        lines = self.read_file()
+        version_string = "chplversion = '{}.{}'\n".format(self.major_version, self.minor_version)
+        release_string = "release = '{}.{}.{} {}'\n".format(self.major_version, self.minor_version, self.patch_version, "" if self.release else "(pre-release)")
+        any_changed = False
+        for i, line in enumerate(lines):
+            if line.startswith('chplversion = \'') and not line == version_string:
+                lines[i] = version_string
+                any_changed = True
+            elif line.startswith('release = \'') and not line.strip() == release_string.strip():
+                lines[i] = release_string
+                any_changed = True
+        if any_changed:
+            self.write_file(lines)
+
+# Handles man/confchpl.rst and man/confchpldoc.rst
+class ManConfUpdater(FileUpdater):
+    def update(self):
+        lines = self.read_file()
+        if self.patch_version > 0:
+          release_string = ":Version: {}.{}.{} {}\n".format(self.major_version, self.minor_version, self.patch_version, "" if self.release else "pre-release")
+        else:
+          release_string = ":Version: {}.{} {}\n".format(self.major_version, self.minor_version, "" if self.release else "pre-release")
+        any_changed = False
+        for i, line in enumerate(lines):
+            if line.startswith(':Version: ') and not line.strip() == release_string.strip():
+                lines[i] = release_string
+                any_changed = True
+        if any_changed:
+            self.write_file(lines)
+
+# Updates the archivedSpecs.rst file only when moving to an official release
+class ArchivedSpecUpdater(FileUpdater):
+    def update(self):
+        # TODO: this needs the OLD version number to be able to update the archive without messing up
+        if self.release:
+          lines = self.read_file()
+          archive_string = "* `Chapel {}.{} <https://chapel-lang.org/docs/{}.{}/index.html>`_\n".format(self.major_version, self.minor_version - 1, self.major_version, self.minor_version - 1)
+          any_changed = False
+          if not archive_string in lines:
+            for i, line in enumerate(lines):
+              if line.startswith('Online Documentation Archives'):
+                lines.insert(i + 2, archive_string)
+                any_changed = True
+          if any_changed:
+              self.write_file(lines)
+
+# Updates the QUICKSTART.rst file only when moving to an official release
+class QuickStartUpdater(FileUpdater):
+    def update(self):
+        if self.release:
+          lines = self.read_file()
+          version_string = "1) If you don't already have the Chapel {}.{} source release, see\n".format(self.major_version, self.minor_version)
+          tar_string = "         tar xzf chapel-{}.{}.{}.tar.gz\n".format(self.major_version, self.minor_version, self.patch_version)
+          cd_string =  "         cd chapel-{}.{}.{}\n".format(self.major_version, self.minor_version, self.patch_version)
+          any_changed = False
+          for i, line in enumerate(lines):
+              if line.startswith('1) If you don\'t already have the Chapel ') and not line.strip() == version_string.strip():
+                  lines[i] = version_string
+                  any_changed = True
+              elif line.startswith("         tar xzf chapel-") and not line.strip() == tar_string.strip():
+                  lines[i] = tar_string
+                  any_changed = True
+              elif line.startswith("         cd chapel-") and not line.strip() == cd_string.strip():
+                  lines[i] = cd_string
+                  any_changed = True
+          if any_changed:
+              self.write_file(lines)
+
+# Updates the chplenv.rst file only when moving to an official release
+class ChplEnvUpdater(FileUpdater):
+    def update(self):
+        if self.release:
+          lines = self.read_file()
+          export_string = "        export CHPL_HOME=~/chapel-{}.{}.{}\n".format(self.major_version, self.minor_version, self.patch_version)
+          any_changed = False
+          for i, line in enumerate(lines):
+              if line.startswith('        export CHPL_HOME=~/chapel-') and not line.strip() == export_string.strip():
+                  lines[i] = export_string
+                  any_changed = True
+          if any_changed:
+              self.write_file(lines)
+
+# Updates the versionhelp.sh and versionhelp-chpldoc.sh files when moving to an official release
+# and again when moving to a pre-release with a version bump
+class VersionHelpUpdater(FileUpdater):
+    def update(self):
+        any_changed = False
+        lines = self.read_file()
+        if self.release:
+          for i, line in enumerate(lines):
+            if line.startswith('diff $CWD/../../../../compiler/main/BUILD_VERSION $CWD/zero.txt'):
+                lines[i] = "# {}".format(line)
+                any_changed = True
+            elif line.startswith("  { echo -n \" pre-release (\" &&"):
+                lines[i] = "# {}".format(line)
+                any_changed = True
+            elif line.startswith("# echo \"\""):
+                lines[i] = "{}".format(line[2:])
+                any_changed = True
+        else:
+          for i, line in enumerate(lines):
+            if line.startswith('# diff $CWD/../../../../compiler/main/BUILD_VERSION $CWD/zero.txt'):
+                lines[i] = "{}".format(line[2:])
+                any_changed = True
+            elif line.startswith("#   { echo -n \" pre-release (\" &&"):
+                lines[i] = "{}".format(line[2:])
+                any_changed = True
+            elif line.startswith("echo \"\""):
+                lines[i] = "# {}".format(line)
+                any_changed = True
+        if any_changed:
+          self.write_file(lines)
+
+# TODO: Implement the VersionButtonUpdater with specific rules for updating the version here
+class VersionButtonUpdater(FileUpdater):
+    def update(self):
+        pass
+
+# Updates the version in the version.goodstart file
+class GoodStartUpdater(FileUpdater):
+    def update(self):
+        lines = self.read_file()
+        version_string = " version {}.{}.{}".format(self.major_version, self.minor_version, self.patch_version)
+        any_changed = False
+        for i, line in enumerate(lines):
+            if line.strip().startswith('version') and not line.strip() == version_string.strip():
+                lines[i] = version_string
+                any_changed = True
+        if any_changed:
+            self.write_file(lines)
+
+def main():
+    parser = argparse.ArgumentParser(description='Update the version and release/pre-release info in files')
+    parser.add_argument('-f', '--files', nargs="+", help='The file(s) to update')
+    parser.add_argument('major_version', type=int, help='The major version of Chapel')
+    parser.add_argument('minor_version', type=int, help='The minor version of Chapel')
+    parser.add_argument('patch_version', type=int, help='The patch version of Chapel')
+    parser.add_argument('--official-release', dest='release', action="store_true", help='Is this an official release?')
+
+    args = parser.parse_args()
+    for fpath in args.files:
+      # Determine which updater to use based on the file name or other criteria
+      if fpath.endswith('conf.py'):
+          updater = ConfPyUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release)
+      elif fpath.endswith('confchpl.rst') or fpath.endswith('confchpldoc.rst'):
+          updater = ManConfUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release)
+      elif fpath.endswith('archivedSpecs.rst'):
+          updater = ArchivedSpecUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release)
+      elif fpath.endswith('QUICKSTART.rst'):
+          updater = QuickStartUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release)
+      elif fpath.endswith('chplenv.rst'):
+          updater = ChplEnvUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release)
+      elif fpath.endswith('versionhelp.sh') or fpath.endswith('versionhelp-chpldoc.sh'):
+          updater = VersionHelpUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release)
+      elif fpath.endswith('versionButton.php'):
+          updater = VersionButtonUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release)
+      elif fpath.endswith('version.goodstart'):
+          updater = GoodStartUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release)
+      else:
+          raise ValueError("Unrecognized file name: {}".format(fpath))
+
+      updater.update()
+
+if __name__ == "__main__":
+    main()

--- a/util/config/update-release-and-version-info
+++ b/util/config/update-release-and-version-info
@@ -8,7 +8,6 @@ class FileUpdater:
     class VersionType(Enum):
         CURRENT = 1
         PREVIOUS = 2
-        NEXT = 3
 
     def __init__(
         self,
@@ -20,9 +19,6 @@ class FileUpdater:
         prev_major_version,
         prev_minor_version,
         prev_patch_version,
-        next_major_version,
-        next_minor_version,
-        next_patch_version,
     ):
         self.file_path = file_path
         self.major_version = major_version
@@ -31,9 +27,6 @@ class FileUpdater:
         self.prev_major_version = prev_major_version
         self.prev_minor_version = prev_minor_version
         self.prev_patch_version = prev_patch_version
-        self.next_major_version = next_major_version
-        self.next_minor_version = next_minor_version
-        self.next_patch_version = next_patch_version
         self.release = release
 
     # Get the version number in the form of "X.Y" no matter if Z is 0 or not
@@ -42,8 +35,6 @@ class FileUpdater:
             return "{}.{}".format(self.major_version, self.minor_version)
         elif type == self.VersionType.PREVIOUS:
             return "{}.{}".format(self.prev_major_version, self.prev_minor_version)
-        elif type == self.VersionType.NEXT:
-            return "{}.{}".format(self.next_major_version, self.next_minor_version)
         else:
             raise ValueError("Unrecognized VersionType: {}".format(type))
 
@@ -67,16 +58,6 @@ class FileUpdater:
                     self.prev_patch_version,
                 )
             )
-        elif type == self.VersionType.NEXT:
-            return (
-                "{}.{}".format(self.next_major_version, self.next_minor_version)
-                if self.next_patch_version == 0
-                else "{}.{}.{}".format(
-                    self.next_major_version,
-                    self.next_minor_version,
-                    self.next_patch_version,
-                )
-            )
         else:
             raise ValueError("Unrecognized VersionType: {}".format(type))
 
@@ -91,12 +72,6 @@ class FileUpdater:
                 self.prev_major_version,
                 self.prev_minor_version,
                 self.prev_patch_version,
-            )
-        elif type == self.VersionType.NEXT:
-            return "{}.{}.{}".format(
-                self.next_major_version,
-                self.next_minor_version,
-                self.next_patch_version,
             )
         else:
             raise ValueError("Unrecognized VersionType: {}".format(type))
@@ -269,50 +244,6 @@ class VersionHelpUpdater(FileUpdater):
             self.write_file(lines)
 
 
-class VersionButtonUpdater(FileUpdater):
-    # steady-state: docs refers to prev-release and docs/main refers to current release
-    def update(self):
-        lines = self.read_file()
-        any_changed = False
-        cur_rel = '  var currentRelease = "{}"; // what does the public have?\n'.format(
-            self.short_maybe_long_version(self.VersionType.PREVIOUS)
-        )
-        staged_rel = '  var stagedRelease = "{}";  // is there a release staged but not yet public?\n'.format(
-            self.short_maybe_long_version()
-        )
-        next_rel = (
-            '  var nextRelease = "{}";    // what\'s the next release? (on docs/main)\n'.format(
-                self.short_maybe_long_version(self.VersionType.NEXT)
-            )
-            if self.release
-            else 'var nextRelease = "{}";    // what\'s the next release? (on docs/main)\n'.format(
-                self.short_maybe_long_version()
-            )
-        )
-
-        for i, line in enumerate(lines):
-            if (
-                line.strip().startswith("var nextRelease = ")
-                and not line.strip() == next_rel.strip()
-            ):
-                any_changed = True
-                lines[i] = next_rel
-            elif (
-                line.strip().startswith("var currentRelease = ")
-                and not line.strip() == cur_rel.strip()
-            ):
-                any_changed = True
-                lines[i] = cur_rel
-            elif (
-                line.strip().startswith("var stagedRelease = ")
-                and not line.strip() == staged_rel.strip()
-            ):
-                any_changed = True
-                lines[i] = staged_rel
-        if any_changed:
-            self.write_file(lines)
-
-
 # Updates the version in the version.goodstart file
 class GoodStartUpdater(FileUpdater):
     def update(self):
@@ -346,16 +277,7 @@ def main():
     )
     parser.add_argument(
         "prev_patch_version", type=int, help="The previous patch version of Chapel"
-    )
-    parser.add_argument(
-        "next_major_version", type=int, help="The next major version of Chapel"
-    )
-    parser.add_argument(
-        "next_minor_version", type=int, help="The next minor version of Chapel"
-    )
-    parser.add_argument(
-        "next_patch_version", type=int, help="The next patch version of Chapel"
-    )
+    )    
     parser.add_argument(
         "--official-release",
         dest="release",
@@ -376,9 +298,6 @@ def main():
                 args.prev_major_version,
                 args.prev_minor_version,
                 args.prev_patch_version,
-                args.next_major_version,
-                args.next_minor_version,
-                args.next_patch_version,
             )
         elif fpath.endswith("confchpl.rst") or fpath.endswith("confchpldoc.rst"):
             updater = ManConfUpdater(
@@ -390,9 +309,6 @@ def main():
                 args.prev_major_version,
                 args.prev_minor_version,
                 args.prev_patch_version,
-                args.next_major_version,
-                args.next_minor_version,
-                args.next_patch_version,
             )
         elif fpath.endswith("archivedSpecs.rst"):
             updater = ArchivedSpecUpdater(
@@ -404,9 +320,6 @@ def main():
                 args.prev_major_version,
                 args.prev_minor_version,
                 args.prev_patch_version,
-                args.next_major_version,
-                args.next_minor_version,
-                args.next_patch_version,
             )
         elif fpath.endswith("QUICKSTART.rst"):
             updater = QuickStartUpdater(
@@ -418,9 +331,6 @@ def main():
                 args.prev_major_version,
                 args.prev_minor_version,
                 args.prev_patch_version,
-                args.next_major_version,
-                args.next_minor_version,
-                args.next_patch_version,
             )
         elif fpath.endswith("chplenv.rst"):
             updater = ChplEnvUpdater(
@@ -432,9 +342,6 @@ def main():
                 args.prev_major_version,
                 args.prev_minor_version,
                 args.prev_patch_version,
-                args.next_major_version,
-                args.next_minor_version,
-                args.next_patch_version,
             )
         elif fpath.endswith("versionhelp.sh") or fpath.endswith(
             "versionhelp-chpldoc.sh"
@@ -448,23 +355,6 @@ def main():
                 args.prev_major_version,
                 args.prev_minor_version,
                 args.prev_patch_version,
-                args.next_major_version,
-                args.next_minor_version,
-                args.next_patch_version,
-            )
-        elif fpath.endswith("versionButton.php"):
-            updater = VersionButtonUpdater(
-                fpath,
-                args.major_version,
-                args.minor_version,
-                args.patch_version,
-                args.release,
-                args.prev_major_version,
-                args.prev_minor_version,
-                args.prev_patch_version,
-                args.next_major_version,
-                args.next_minor_version,
-                args.next_patch_version,
             )
         elif fpath.endswith("version.goodstart"):
             updater = GoodStartUpdater(
@@ -476,9 +366,6 @@ def main():
                 args.prev_major_version,
                 args.prev_minor_version,
                 args.prev_patch_version,
-                args.next_major_version,
-                args.next_minor_version,
-                args.next_patch_version,
             )
         else:
             raise ValueError("Unrecognized file name: {}".format(fpath))

--- a/util/config/update-release-and-version-info
+++ b/util/config/update-release-and-version-info
@@ -2,7 +2,7 @@ import argparse
 
 # Represents a file or maybe a group of similar files that are updated the same way
 class FileUpdater:
-    def __init__(self, file_path, major_version, minor_version, patch_version, release, prev_major_version, prev_minor_version, prev_patch_version):
+    def __init__(self, file_path, major_version, minor_version, patch_version, release, prev_major_version, prev_minor_version, prev_patch_version, next_major_version, next_minor_version, next_patch_version):
         self.file_path = file_path
         self.major_version = major_version
         self.minor_version = minor_version
@@ -10,6 +10,9 @@ class FileUpdater:
         self.prev_major_version = prev_major_version
         self.prev_minor_version = prev_minor_version
         self.prev_patch_version = prev_patch_version
+        self.next_major_version = next_major_version
+        self.next_minor_version = next_minor_version
+        self.next_patch_version = next_patch_version
         self.release = release
 
         # TODO: would be nice to have preformatted version strings in the base class
@@ -157,10 +160,9 @@ class VersionButtonUpdater(FileUpdater):
         next_rel = 'var nextRelease = "{}.{}";'
         if self.release:
             for i, line in enumerate(lines):
-                # TODO: Store the next release in cmake too? This is a pretty naive way, just incrementing the minor version by 1.
-                if line.strip().startswith('var nextRelease = ') and not line.strip() == 'var nextRelease = "{}.{}";    // what\'s the next release? (on docs/main)'.format(self.major_version, self.minor_version + 1):
+                if line.strip().startswith('var nextRelease = ') and not line.strip() == 'var nextRelease = "{}.{}";    // what\'s the next release? (on docs/main)'.format(self.next_major_version, self.next_minor_version):
                     any_changed = True
-                    lines[i] = '  var nextRelease = "{}.{}";    // what\'s the next release? (on docs/main)\n'.format(self.major_version, self.minor_version + 1)
+                    lines[i] = '  var nextRelease = "{}.{}";    // what\'s the next release? (on docs/main)\n'.format(self.next_major_version, self.next_minor_version)
         else:
             for i, line in enumerate(lines):
                 if line.strip().startswith('var currentRelease = ') and not line.strip() == 'var currentRelease = "{}.{}";    // what does the public have?'.format(self.prev_major_version, self.prev_minor_version):
@@ -194,27 +196,30 @@ def main():
     parser.add_argument('prev_major_version', type=int, help='The previous major version of Chapel')
     parser.add_argument('prev_minor_version', type=int, help='The previous minor version of Chapel')
     parser.add_argument('prev_patch_version', type=int, help='The previous patch version of Chapel')
+    parser.add_argument('next_major_version', type=int, help='The next major version of Chapel')
+    parser.add_argument('next_minor_version', type=int, help='The next minor version of Chapel')
+    parser.add_argument('next_patch_version', type=int, help='The next patch version of Chapel')
     parser.add_argument('--official-release', dest='release', action="store_true", help='Is this an official release?')
 
     args = parser.parse_args()
     for fpath in args.files:
       # Determine which updater to use based on the file name or other criteria
       if fpath.endswith('conf.py'):
-          updater = ConfPyUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release, args.prev_major_version, args.prev_minor_version, args.prev_patch_version)
+          updater = ConfPyUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release, args.prev_major_version, args.prev_minor_version, args.prev_patch_version, args.next_major_version, args.next_minor_version, args.next_patch_version)
       elif fpath.endswith('confchpl.rst') or fpath.endswith('confchpldoc.rst'):
-          updater = ManConfUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release, args.prev_major_version, args.prev_minor_version, args.prev_patch_version)
+          updater = ManConfUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release, args.prev_major_version, args.prev_minor_version, args.prev_patch_version, args.next_major_version, args.next_minor_version, args.next_patch_version)
       elif fpath.endswith('archivedSpecs.rst'):
-          updater = ArchivedSpecUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release, args.prev_major_version, args.prev_minor_version, args.prev_patch_version)
+          updater = ArchivedSpecUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release, args.prev_major_version, args.prev_minor_version, args.prev_patch_version, args.next_major_version, args.next_minor_version, args.next_patch_version)
       elif fpath.endswith('QUICKSTART.rst'):
-          updater = QuickStartUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release, args.prev_major_version, args.prev_minor_version, args.prev_patch_version)
+          updater = QuickStartUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release, args.prev_major_version, args.prev_minor_version, args.prev_patch_version, args.next_major_version, args.next_minor_version, args.next_patch_version)
       elif fpath.endswith('chplenv.rst'):
-          updater = ChplEnvUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release, args.prev_major_version, args.prev_minor_version, args.prev_patch_version)
+          updater = ChplEnvUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release, args.prev_major_version, args.prev_minor_version, args.prev_patch_version, args.next_major_version, args.next_minor_version, args.next_patch_version)
       elif fpath.endswith('versionhelp.sh') or fpath.endswith('versionhelp-chpldoc.sh'):
-          updater = VersionHelpUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release, args.prev_major_version, args.prev_minor_version, args.prev_patch_version)
+          updater = VersionHelpUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release, args.prev_major_version, args.prev_minor_version, args.prev_patch_version, args.next_major_version, args.next_minor_version, args.next_patch_version)
       elif fpath.endswith('versionButton.php'):
-          updater = VersionButtonUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release, args.prev_major_version, args.prev_minor_version, args.prev_patch_version)
+          updater = VersionButtonUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release, args.prev_major_version, args.prev_minor_version, args.prev_patch_version, args.next_major_version, args.next_minor_version, args.next_patch_version)
       elif fpath.endswith('version.goodstart'):
-          updater = GoodStartUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release, args.prev_major_version, args.prev_minor_version, args.prev_patch_version)
+          updater = GoodStartUpdater(fpath, args.major_version, args.minor_version, args.patch_version, args.release, args.prev_major_version, args.prev_minor_version, args.prev_patch_version, args.next_major_version, args.next_minor_version, args.next_patch_version)
       else:
           raise ValueError("Unrecognized file name: {}".format(fpath))
 

--- a/util/config/update-release-and-version-info
+++ b/util/config/update-release-and-version-info
@@ -286,91 +286,35 @@ def main():
     )
 
     args = parser.parse_args()
+    updaters = {
+        "conf.py": ConfPyUpdater,
+        "confchpl.rst": ManConfUpdater,
+        "confchpldoc.rst": ManConfUpdater,
+        "archivedSpecs.rst": ArchivedSpecUpdater,
+        "QUICKSTART.rst": QuickStartUpdater,
+        "chplenv.rst": ChplEnvUpdater,
+        "versionhelp.sh": VersionHelpUpdater,
+        "versionhelp-chpldoc.sh": VersionHelpUpdater,
+        "version.goodstart": GoodStartUpdater,
+    }
+
     for fpath in args.files:
-        # Determine which updater to use based on the file name or other criteria
-        if fpath.endswith("conf.py"):
-            updater = ConfPyUpdater(
-                fpath,
-                args.major_version,
-                args.minor_version,
-                args.patch_version,
-                args.release,
-                args.prev_major_version,
-                args.prev_minor_version,
-                args.prev_patch_version,
-            )
-        elif fpath.endswith("confchpl.rst") or fpath.endswith("confchpldoc.rst"):
-            updater = ManConfUpdater(
-                fpath,
-                args.major_version,
-                args.minor_version,
-                args.patch_version,
-                args.release,
-                args.prev_major_version,
-                args.prev_minor_version,
-                args.prev_patch_version,
-            )
-        elif fpath.endswith("archivedSpecs.rst"):
-            updater = ArchivedSpecUpdater(
-                fpath,
-                args.major_version,
-                args.minor_version,
-                args.patch_version,
-                args.release,
-                args.prev_major_version,
-                args.prev_minor_version,
-                args.prev_patch_version,
-            )
-        elif fpath.endswith("QUICKSTART.rst"):
-            updater = QuickStartUpdater(
-                fpath,
-                args.major_version,
-                args.minor_version,
-                args.patch_version,
-                args.release,
-                args.prev_major_version,
-                args.prev_minor_version,
-                args.prev_patch_version,
-            )
-        elif fpath.endswith("chplenv.rst"):
-            updater = ChplEnvUpdater(
-                fpath,
-                args.major_version,
-                args.minor_version,
-                args.patch_version,
-                args.release,
-                args.prev_major_version,
-                args.prev_minor_version,
-                args.prev_patch_version,
-            )
-        elif fpath.endswith("versionhelp.sh") or fpath.endswith(
-            "versionhelp-chpldoc.sh"
-        ):
-            updater = VersionHelpUpdater(
-                fpath,
-                args.major_version,
-                args.minor_version,
-                args.patch_version,
-                args.release,
-                args.prev_major_version,
-                args.prev_minor_version,
-                args.prev_patch_version,
-            )
-        elif fpath.endswith("version.goodstart"):
-            updater = GoodStartUpdater(
-                fpath,
-                args.major_version,
-                args.minor_version,
-                args.patch_version,
-                args.release,
-                args.prev_major_version,
-                args.prev_minor_version,
-                args.prev_patch_version,
-            )
+        for key, updater_class in updaters.items():
+            if fpath.endswith(key):
+                updater = updater_class(
+                    fpath,
+                    args.major_version,
+                    args.minor_version,
+                    args.patch_version,
+                    args.release,
+                    args.prev_major_version,
+                    args.prev_minor_version,
+                    args.prev_patch_version,
+                )
+                updater.update()
+                break
         else:
             raise ValueError("Unrecognized file name: {}".format(fpath))
-
-        updater.update()
 
 
 if __name__ == "__main__":

--- a/util/config/update-release-and-version-info
+++ b/util/config/update-release-and-version-info
@@ -72,14 +72,14 @@ class ConfPyUpdater(FileUpdater):
     def update(self):
         lines = self.read_file()
         version_string = "chplversion = '{}'\n".format(self.short_maybe_long_version())
-        release_string = "release = '{} {}'\n".format(self.long_version(), "" if self.release else "(pre-release)")
+        release_string = "release = '{} {}".format(self.long_version(), "" if self.release else "(pre-release)").strip()
         any_changed = False
         for i, line in enumerate(lines):
-            if line.startswith('chplversion = \'') and not line == version_string:
+            if line.startswith('chplversion = \'') and not line.strip() == version_string:
                 lines[i] = version_string
                 any_changed = True
-            elif line.startswith('release = \'') and not line.strip() == release_string.strip():
-                lines[i] = release_string
+            elif line.startswith('release = \'') and not line.strip() == release_string:
+                lines[i] = release_string + "'\n"
                 any_changed = True
         if any_changed:
             self.write_file(lines)
@@ -88,11 +88,11 @@ class ConfPyUpdater(FileUpdater):
 class ManConfUpdater(FileUpdater):
     def update(self):
         lines = self.read_file()
-        release_string = ":Version: {} {}\n".format(self.short_maybe_long_version(), "" if self.release else "pre-release")
+        release_string = ":Version: {} {}".format(self.short_maybe_long_version(), "" if self.release else "pre-release").strip()
         any_changed = False
         for i, line in enumerate(lines):
-            if line.startswith(':Version: ') and not line.strip() == release_string.strip():
-                lines[i] = release_string
+            if line.startswith(':Version: ') and not line.strip() == release_string:
+                lines[i] = release_string + '\n'
                 any_changed = True
         if any_changed:
             self.write_file(lines)

--- a/util/config/update-release-and-version-info
+++ b/util/config/update-release-and-version-info
@@ -161,7 +161,7 @@ class ArchivedSpecUpdater(FileUpdater):
             # add 1 or 2 spaces depending on the length of the previous minor version
             padding = 3 - len(str(self.prev_minor_version))
             archive_string = (
-                "* `Chapel {}{}<https://chapel-lang.org/docs/{}/index.html>`_\n".format(
+                "* `Chapel {}{}<https://chapel-lang.org/docs/{}/>`_\n".format(
                     self.short_version(self.VersionType.PREVIOUS),
                     " " * padding,
                     self.short_version(self.VersionType.PREVIOUS),


### PR DESCRIPTION
This uses a combination of python scripts and cmake dependencies to keep the version number information consistent with the information in `CMakeLists.txt`. The purpose is to avoid manually having to update the version number across a variety of documents with every release. With this change, the version numbers will be correctly updated based on the status of the `CHPL_OFFICIAL_RELEASE` flag, and the current and previous version numbers. 

This necessitated tracking the past version number as the `archived-spec.rst` file needs to know the previous version number. 

Because we can't predict the past version number from the current one, it was necessary to add these fields to the `CMakeLists.txt` file.

New files that need updating can be handled by creating new instances of the `FileUpdater` class and implementing the `update` method. 

TESTING:

- [x] mock release steps on local branch

[reviewed by @tzinsky - thanks!]