### PR TITLE
Fix ambiguity resolving field on record var of same name

### DIFF
--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -3081,7 +3081,8 @@ doIsCandidateApplicableInitial(ResolutionContext* rc,
           }
         }
       }
-      if (containingType) {
+      if (containingType &&
+          containingType->id() == candidateId.parentSymbolId(context)) {
         auto ret = fieldAccessor(context, containingType, ci.name());
         return ApplicabilityResult::success(ret);
       }

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -3070,22 +3070,20 @@ doIsCandidateApplicableInitial(ResolutionContext* rc,
       // TODO: This doesn't have anything to do with this candidate. Shouldn't
       // we be handling this somewhere else?
       auto t = ci.actual(0).type().type();
-      if (auto ct = t->getCompositeType()) {
-        if (auto containingType = isNameOfField(context, ci.name(), ct)) {
-          auto ret = fieldAccessor(context, containingType, ci.name());
-          return ApplicabilityResult::success(ret);
-        }
+      auto containingType = isNameOfField(context, ci.name(), t);
+      if (!containingType) {
         // help handle the case where we're calling a field accessor on a manger.
         // while resolving the body of a method on owned to evaluate the applicability,
         // we need to be able to resolve the field accessor on the manager.
         if (auto classType = t->toClassType()) {
           if (auto managerType = classType->managerRecordType(context)) {
-            if (auto containingType = isNameOfField(context, ci.name(), managerType)) {
-              auto ret = fieldAccessor(context, containingType, ci.name());
-              return ApplicabilityResult::success(ret);
-            }
+            containingType = isNameOfField(context, ci.name(), managerType);
           }
         }
+      }
+      if (containingType) {
+        auto ret = fieldAccessor(context, containingType, ci.name());
+        return ApplicabilityResult::success(ret);
       }
     }
     // not a candidate

--- a/frontend/test/resolution/testFieldAccess.cpp
+++ b/frontend/test/resolution/testFieldAccess.cpp
@@ -169,32 +169,67 @@ static void test4() {
   scopeResolveFunction(context, innerMethod->id());
 }
 
+// Test no ambiguity for field access on record var that is a field of same name
 static void test5() {
   printf("test5\n");
   Context ctx;
   Context* context = &ctx;
-  ErrorGuard guard(context);
 
-  auto qt = resolveTypeOfXInit(context,
-                               R"""(
-    record Bar {
-      var table : int;
-    }
-
-    record Foo {
-      var table: Bar;
-
-      proc doSomething() {
-        return table.table;
+  // Simple case
+  {
+    context->advanceToNextRevision(false);
+    auto qt = resolveTypeOfXInit(context,
+                                 R"""(
+      record Bar {
+        var table : int;
       }
-    }
 
-    var myFoo = new Foo();
-    var x = myFoo.doSomething();
-   )""");
+      record Foo {
+        var table: Bar;
 
-  assert(qt.kind() == QualifiedType::CONST_VAR);
-  assert(qt.type()->isIntType());
+        proc doSomething() {
+          return table.table;
+        }
+      }
+
+      var myFoo = new Foo();
+      var x = myFoo.doSomething();
+     )""");
+
+    assert(qt.kind() == QualifiedType::CONST_VAR);
+    assert(qt.type()->isIntType());
+  }
+
+  // With inheritance
+  {
+    context->advanceToNextRevision(false);
+    auto qt = resolveTypeOfXInit(context,
+                                 R"""(
+      class Parent {
+        var table : int;
+      }
+      class Child : Parent {
+      }
+
+      record Foo {
+        var table: unmanaged Child;
+
+        proc init() {
+          table = new unmanaged Child();
+        }
+
+        proc doSomething() {
+          return table.table;
+        }
+      }
+
+      var myFoo = new Foo();
+      var x = myFoo.doSomething();
+     )""");
+
+    assert(qt.kind() == QualifiedType::CONST_VAR);
+    assert(qt.type()->isIntType());
+  }
 }
 
 int main() {

--- a/frontend/test/resolution/testFieldAccess.cpp
+++ b/frontend/test/resolution/testFieldAccess.cpp
@@ -169,11 +169,40 @@ static void test4() {
   scopeResolveFunction(context, innerMethod->id());
 }
 
+static void test5() {
+  printf("test5\n");
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  auto qt = resolveTypeOfXInit(context,
+                               R"""(
+    record Bar {
+      var table : int;
+    }
+
+    record Foo {
+      var table: Bar;
+
+      proc doSomething() {
+        return table.table;
+      }
+    }
+
+    var myFoo = new Foo();
+    var x = myFoo.doSomething();
+   )""");
+
+  assert(qt.kind() == QualifiedType::CONST_VAR);
+  assert(qt.type()->isIntType());
+}
+
 int main() {
   test1();
   test2();
   test3();
   test4();
+  test5();
 
   return 0;
 }

--- a/frontend/test/resolution/testFieldAccess.cpp
+++ b/frontend/test/resolution/testFieldAccess.cpp
@@ -132,12 +132,12 @@ static void test3() {
 }
 
 static void test4() {
-  printf("test3\n");
+  printf("test4\n");
   Context ctx;
   Context* context = &ctx;
   ErrorGuard guard(context);
 
-  auto path = UniqueString::get(context, "test3.chpl");
+  auto path = UniqueString::get(context, "test4.chpl");
   std::string contents = R""""(
     class Outer {
         var outerField: int;


### PR DESCRIPTION
Fix an incorrect ambiguity error when resolving an access to a field on a record variable that is itself a field.

The problem arose like this, using the added test case as an example:
1. In resolving `table.table`, we resolve a call with the name `table`. To find potential candidates we look up the name `table`, and find both the `var table: Bar` field on `Foo` and the `var table : int` field on `Bar`. At this point receiver type isn't considered.
2. We then filter candidates by applicability. For a field accessor, we were only checking a candidate's applicability based on if its name matches a name of a field on the correct receiver type. Both our candidates are named `table`, which is indeed the name of field on the receiver type `Bar`, so both are considered valid.
3. We have two valid candidates, so ambiguity results.

This PR fixes by making the applicability check also test if the candidate is actually a field on the receiver type (based on parent ID), in addition to if its name matches the name of a field on the receiver type. This filters out the candidate that is the field on `Foo`, as it is not a field of the receiver `Bar`.

Includes adding a test for the fixed case.

Resolves https://github.com/Cray/chapel-private/issues/6931.

[reviewer info placeholder]

Testing:
- [x] reproducer from backing issue succeeds
- [x] paratest
- [x] dyno tests