### PR TITLE
Keep cray-libsci in the EX testing environment

### DIFF
--- a/util/cron/common-hpe-cray-ex.bash
+++ b/util/cron/common-hpe-cray-ex.bash
@@ -11,9 +11,6 @@ module load PrgEnv-gnu/8.4.0
 module swap gcc gcc/12.2.0
 module load cray-pmi
 
-# cray-libsci currently has a problem on the Cray EX we run on
-module unload cray-libsci
-
 export CHPL_HOST_PLATFORM=hpe-cray-ex
 
 # Work around cxi provider bugs that limit memory registration


### PR DESCRIPTION
In https://github.com/chapel-lang/chapel/pull/23774, I unloaded `cray-libsci` from the environment, possibly to avoid some issues with GPU testing. With expanded testing on EX, we are seeing that we need that module for some BLAS tests. Testing it again, I am observing that some GPU tests are passing with that module loaded and BLAS tests work fine. So, I am removing the explicit unload to observe the behavior over a night's testing.