### PR TITLE
fix build error for python bindings on some systems

### DIFF
--- a/tools/chapel-py/setup.py
+++ b/tools/chapel-py/setup.py
@@ -64,9 +64,8 @@ CXXFLAGS += ["-std=c++17", "-I{}/frontend/include".format(chpl_home)]
 LDFLAGS = []
 LDFLAGS += [
     "-L{}".format(chpl_lib_path),
+    "-Wl,-rpath,{}".format(chpl_lib_path),
     "-lChplFrontendShared",
-    "-Wl,-rpath",
-    chpl_lib_path,
 ]
 
 if str(chpl_variables.get("CHPL_SANITIZE")) == "address":


### PR DESCRIPTION
This fixes the generated rpath string for the python bindings shared library. There is a typo in the current version that creates separation and omits a comma from the linker flags format. This can cause a build error when installing Chapel in a prefix on some systems, like perlmutter. 

[reviewed by @jabraham17 - thanks!]