### PR TITLE
Strip CHPL_LLVM_LINK_ARGS after removing jemalloc

### DIFF
--- a/frontend/CMakeLists.txt
+++ b/frontend/CMakeLists.txt
@@ -66,7 +66,7 @@ endif()
 
 # Don't pass through jemalloc for the time being.
 string(REPLACE "-ljemalloc" "" CHPL_LLVM_LINK_ARGS "${CHPL_LLVM_LINK_ARGS}")
-
+string(STRIP "${CHPL_LLVM_LINK_ARGS}" CHPL_LLVM_LINK_ARGS)
 
 set(CHPL_MAIN_SRC_DIR     ${CMAKE_CURRENT_SOURCE_DIR})
 set(CHPL_MAIN_INCLUDE_DIR ${CHPL_MAIN_SRC_DIR}/include)


### PR DESCRIPTION
This fixes a CMake configuration: after removing -ljemalloc from CHPL_LLVM_LINK_ARGS, the remaining string is
"-Lpath/to/chapel/third-party/jemalloc/install/host/linux65-x86_64-gnu/lib " (notice the trailing space). According to CMake policy CMP0004, this is not valid, so solve by simply stripping whitespace from the string manually.