### PR TITLE
Disable PIC for device code compiliation on NVIDIA

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -4775,6 +4775,14 @@ static void makeBinaryLLVMForCUDA(const std::string& artifactFilename,
   // functions are called from the kernel
   ptxasFlags += " --suppress-stack-size-warning ";
 
+  // With CUDA 12.4, PIC is on by default in ptxas. However, with some large
+  // codes, we see that ptxas disables PIC and issues a warning about it. Most
+  // likely, we are not going to benefit from PIC anytime soon (I don't even
+  // know what it means for us to benefit from that? Generated GPU code as
+  // shared library... for multiple Chapel applications?). So, disable PIC for
+  // the time being.
+  ptxasFlags += " --position-independent-code=false ";
+
   // Run ptxas for each architecture
   std::string profiles;
   for (auto& gpuArch : gpuArches) {

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -4775,13 +4775,17 @@ static void makeBinaryLLVMForCUDA(const std::string& artifactFilename,
   // functions are called from the kernel
   ptxasFlags += " --suppress-stack-size-warning ";
 
+
   // With CUDA 12.4, PIC is on by default in ptxas. However, with some large
   // codes, we see that ptxas disables PIC and issues a warning about it. Most
   // likely, we are not going to benefit from PIC anytime soon (I don't even
   // know what it means for us to benefit from that? Generated GPU code as
   // shared library... for multiple Chapel applications?). So, disable PIC for
   // the time being.
-  ptxasFlags += " --position-independent-code=false ";
+  const auto sdkVer = envMap["CHPL_GPU_SDK_VERSION"];
+  if (strncmp(sdkVer, "12", 2) == 0) {
+    ptxasFlags += " --position-independent-code=false ";
+  }
 
   // Run ptxas for each architecture
   std::string profiles;


### PR DESCRIPTION
With CUDA 12.4, PIC is on by default in ptxas. However, with some large codes, we see that ptxas disables PIC and issues a warning about it. Most likely, we are not going to benefit from PIC anytime soon (I don't even know what it means for us to benefit from that.. Generated GPU code as shared library... for multiple Chapel applications?). So, disable PIC for the time being to squash warnings.

I will keep an eye on performance in the next couple of days just in case.

Resolves https://github.com/Cray/chapel-private/issues/6934

Test
- [x] local jacobi with nvidia
- [x] full nvidia 11
- [x] spot-check nvidia 12