### PR TITLE
Improve error when using -j with LLVM back-end

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -2042,7 +2042,7 @@ static void checkLLVMCodeGen() {
     }
 
     if (fIncrementalCompilation)
-      USR_FATAL("Incremental compilation is not yet supported with LLVM");
+      USR_FATAL("'chpl' does not currently support '-j'/'--parallel-make' or '--incremental' compilation when using the LLVM back-end");
   }
 
   if (0 == strcmp(CHPL_LLVM, "none")) {
@@ -2262,6 +2262,7 @@ static void validateSettings() {
   checkUnsupportedConfigs();
 
   checkRuntimeBuilt();
+
 }
 
 static chpl::CompilerGlobals dynoBuildCompilerGlobals() {

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -2262,7 +2262,6 @@ static void validateSettings() {
   checkUnsupportedConfigs();
 
   checkRuntimeBuilt();
-
 }
 
 static chpl::CompilerGlobals dynoBuildCompilerGlobals() {

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -2041,8 +2041,12 @@ static void checkLLVMCodeGen() {
       USR_FATAL("CHPL_TARGET_COMPILER=llvm not yet supported for this architecture");
     }
 
-    if (fIncrementalCompilation)
-      USR_FATAL("'chpl' does not currently support '-j'/'--parallel-make' or '--incremental' compilation when using the LLVM back-end");
+    if (fIncrementalCompilation) {
+      const char* flag = (fParMake ? "-j'/'--parallel-make" : "--incremental");
+      USR_WARN("'chpl' does not currently support '%s' when using the LLVM "
+               "back-end (flag ignored)", flag);
+                          
+    }
   }
 
   if (0 == strcmp(CHPL_LLVM, "none")) {

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -2045,7 +2045,6 @@ static void checkLLVMCodeGen() {
       const char* flag = (fParMake ? "-j'/'--parallel-make" : "--incremental");
       USR_WARN("'chpl' does not currently support '%s' when using the LLVM "
                "back-end (flag ignored)", flag);
-                          
     }
   }
 

--- a/test/compflags/kushal/llvm-incremental.bad
+++ b/test/compflags/kushal/llvm-incremental.bad
@@ -1,1 +1,1 @@
-error: Incremental compilation is not yet supported with LLVM
+error: 'chpl' does not currently support '-j'/'--parallel-make' or '--incremental' compilation when using the LLVM back-end

--- a/test/compflags/kushal/llvm-incremental.bad
+++ b/test/compflags/kushal/llvm-incremental.bad
@@ -1,1 +1,2 @@
-error: 'chpl' does not currently support '-j'/'--parallel-make' or '--incremental' compilation when using the LLVM back-end
+warning: 'chpl' does not currently support '--incremental' when using the LLVM back-end (flag ignored)
+Hello World!

--- a/test/compflags/kushal/llvm-incremental.compopts
+++ b/test/compflags/kushal/llvm-incremental.compopts
@@ -1,3 +1,1 @@
 --incremental
--j 4
---parallel-make 4

--- a/test/compflags/kushal/llvm-incremental.compopts
+++ b/test/compflags/kushal/llvm-incremental.compopts
@@ -1,1 +1,3 @@
 --incremental
+-j 4
+--parallel-make 4

--- a/test/compflags/kushal/llvm-parallel-make.bad
+++ b/test/compflags/kushal/llvm-parallel-make.bad
@@ -1,0 +1,2 @@
+warning: 'chpl' does not currently support '-j'/'--parallel-make' when using the LLVM back-end (flag ignored)
+Hello World!

--- a/test/compflags/kushal/llvm-parallel-make.chpl
+++ b/test/compflags/kushal/llvm-parallel-make.chpl
@@ -1,0 +1,1 @@
+llvm-incremental.chpl

--- a/test/compflags/kushal/llvm-parallel-make.compopts
+++ b/test/compflags/kushal/llvm-parallel-make.compopts
@@ -1,0 +1,2 @@
+-j 4
+--parallel-make 4

--- a/test/compflags/kushal/llvm-parallel-make.future
+++ b/test/compflags/kushal/llvm-parallel-make.future
@@ -1,0 +1,3 @@
+feature request: LLVM compilation doesn't yet support '-j'
+
+Currently the parallel compilation feature has not been implemented for llvm.

--- a/test/compflags/kushal/llvm-parallel-make.good
+++ b/test/compflags/kushal/llvm-parallel-make.good
@@ -1,0 +1,1 @@
+llvm-incremental.good


### PR DESCRIPTION
Throwing `-j` on a compilation results in `--incremental` being thrown as well, which is not supported by the LLVM back-end.  In issue #26326, Engin points out that the historical wording of the error generated in this case wasn't all that useful for those using '-j' who might not have any idea what the '--incremental' flag does or why they were getting the error.  This PR expands the error to specifically mention those flags as well when used, changes the error to a warning (it's not like your compilation won't work after all), and clones an existing future test to check that it fires and generates the right message in the new cases.

Resolves #26326.
