### PR TITLE
Allow loading non-Spack deps more than once

### DIFF
--- a/util/cron/load-base-deps.bash
+++ b/util/cron/load-base-deps.bash
@@ -2,12 +2,12 @@
 
 # Sources base dependencies required for all tests.
 
-# Prevent loading more than once
-if [ "$CHPL_BASE_DEPS_LOADED" = "true" ]; then
-  echo "Base dependencies already loaded, exiting ${BASH_SOURCE[0]} without reloading them..."
+# Prevent loading deps from Spack more than once
+if [ "$CHPL_SPACK_DEPS_LOADED" = "true" ]; then
+  echo "Base spack dependencies already loaded, exiting ${BASH_SOURCE[0]} without reloading them..."
   return 0
 fi
-export CHPL_BASE_DEPS_LOADED=true
+export CHPL_SPACK_DEPS_LOADED=true
 
 # For most systems, load all dependencies via spack
 if [[ "${HOSTNAME:0:6}" == "chapcs" || "${HOSTNAME:0:6}" == "chapvm" ]]; then
@@ -25,6 +25,7 @@ elif [[ "$(hostname -s)" == "richter-login" ]]; then
   fi
 else
   # For systems not using a Spack install
+  export CHPL_SPACK_DEPS_LOADED=false
 
   # load llvm
   if [ -f /hpcdc/project/chapel/setup_system_llvm.bash ] ; then


### PR DESCRIPTION
[Previously](https://github.com/chapel-lang/chapel/pull/26283) we disabled loading base dependencies (from `util/cron/load-base-deps.bash`) more than once. However, this breaks a pattern in our test scripts where we `module purge`, then reload non-Spack deps using that script, like in: https://github.com/chapel-lang/chapel/blob/831727315ba47bcd74ea283c9bcd9161f6039697/util/cron/common-hpe-apollo.bash#L11-L13

This maybe an undesirable pattern long-term (see https://github.com/Cray/chapel-private/issues/6913), but for now this is needed to make the workaround actually work.

Follow up to https://github.com/chapel-lang/chapel/pull/26283.

[reviewer info placeholder]

Testing:
- [ ] manual run of test script using `common-hpe-apollo.bash` after another `common`