### PR TITLE
Revert "Prevent loading base dependencies more than once"

### DIFF
--- a/util/cron/load-base-deps.bash
+++ b/util/cron/load-base-deps.bash
@@ -2,13 +2,6 @@
 
 # Sources base dependencies required for all tests.
 
-# Prevent loading more than once
-if [ "$CHPL_BASE_DEPS_LOADED" = "true" ]; then
-  echo "Base dependencies already loaded, exiting ${BASH_SOURCE[0]} without reloading them..."
-  return 0
-fi
-export CHPL_BASE_DEPS_LOADED=true
-
 # For most systems, load all dependencies via spack
 if [[ "${HOSTNAME:0:6}" == "chapcs" || "${HOSTNAME:0:6}" == "chapvm" ]]; then
   if [ -f /data/cf/chapel/chpl-deps/chapcs11/load_chpl_deps.bash ] ; then


### PR DESCRIPTION
Reverts chapel-lang/chapel#26283

Unfortunately I found the previous change breaks tests with test scripts that contain a `module purge` followed by re-loading dependencies: https://github.com/chapel-lang/chapel/blob/831727315ba47bcd74ea283c9bcd9161f6039697/util/cron/common-hpe-apollo.bash#L11-L13

That's probably an undesirable pattern, but I don't expect to be able to fix it before code freeze, so to get configs that use this working again I'll have to back this out. Once we have the long-term solution of https://github.com/Cray/chapel-private/issues/6913 the original workaround won't be necessary anyways.

[reverting previous PR, not reviewed]