### PR TITLE
Fix testing compopts for old python versions

### DIFF
--- a/test/library/packages/Python/COMPOPTS
+++ b/test/library/packages/Python/COMPOPTS
@@ -12,4 +12,9 @@ PYTHON_INCLUDE_DIR=$($chpl_python -c "import sysconfig; print(sysconfig.get_path
 PYTHON_LIB_DIR=$($chpl_python -c "import sysconfig; print(sysconfig.get_config_var('LIBDIR'))")
 PYTHON_LDVERSION=$($chpl_python -c "import sysconfig; print(sysconfig.get_config_var('LDVERSION'))")
 
-echo "--ccflags -isystem$PYTHON_INCLUDE_DIR -L$PYTHON_LIB_DIR --ldflags -Wl,-rpath,$PYTHON_LIB_DIR -lpython$PYTHON_LDVERSION"
+DISABLE_WARNINGS=""
+# some older python's don't use `#ifndef` when they should
+# so we disable redefintion warnings for clean testing
+DISABLE_WARNINGS+="--ccflags -Wno-macro-redefined"
+
+echo "--ccflags -isystem$PYTHON_INCLUDE_DIR -L$PYTHON_LIB_DIR --ldflags -Wl,-rpath,$PYTHON_LIB_DIR -lpython$PYTHON_LDVERSION $DISABLE_WARNINGS"


### PR DESCRIPTION
Fixes the compopts specified for a Python test to handle older Python versions.

[Reviewed by @ShreyasKhandekar]