### PR TITLE
set 2.3 to release status

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ set(CHPL_BUILD_VERSION 0)
 
 # Flip this to 'true' when we're ready to roll out a release; then back
 # after branching
-set(CHPL_OFFICIAL_RELEASE false)
+set(CHPL_OFFICIAL_RELEASE true)
 
 ### END config.h version value setting - configured_prefix set below ###
 

--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -133,8 +133,8 @@ shortversion = chplversion.replace('-', '&#8209') # prevent line-break at hyphen
 html_context = {"chplversion":chplversion}
 
 # The full version, including alpha/beta/rc tags.
-release = '2.3.0 (pre-release)'
-# release = '2.3.0'
+# release = '2.3.0 (pre-release)'
+release = '2.3.0'
 
 # General information about the project.
 project = u'Chapel Documentation'

--- a/doc/rst/language/archivedSpecs.rst
+++ b/doc/rst/language/archivedSpecs.rst
@@ -5,6 +5,7 @@ Documentation Archives
 
 Online Documentation Archives
 -----------------------------
+* `Chapel 2.2  <https://chapel-lang.org/docs/2.2/index.html>`_
 * `Chapel 2.1  <https://chapel-lang.org/docs/2.1/index.html>`_
 * `Chapel 2.0  <https://chapel-lang.org/docs/2.0/index.html>`_
 * `Chapel 1.33 <https://chapel-lang.org/docs/1.33/index.html>`_

--- a/doc/rst/usingchapel/QUICKSTART.rst
+++ b/doc/rst/usingchapel/QUICKSTART.rst
@@ -21,7 +21,7 @@ to :ref:`using-a-more-full-featured-chapel` below.
    packages you should have available to build and run Chapel.
 
 
-1) If you don't already have the Chapel 2.2 source release, see
+1) If you don't already have the Chapel 2.3 source release, see
    https://chapel-lang.org/download.html.
 
 
@@ -31,14 +31,14 @@ to :ref:`using-a-more-full-featured-chapel` below.
 
       .. code-block:: bash
 
-         tar xzf chapel-2.2.0.tar.gz
+         tar xzf chapel-2.3.0.tar.gz
 
    b. Make sure that you are in the directory that was created when
       unpacking the source release, for example:
 
       .. code-block:: bash
 
-         cd chapel-2.2.0
+         cd chapel-2.3.0
 
    c. Set up your environment for Chapel's Quickstart mode.
       If you are using a shell other than ``bash`` or ``zsh``,

--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -37,7 +37,7 @@ CHPL_HOME
 
     .. code-block:: sh
 
-        export CHPL_HOME=~/chapel-2.2.0
+        export CHPL_HOME=~/chapel-2.3.0
 
    .. note::
      This, and all other examples in the Chapel documentation, assumes you're

--- a/man/confchpl.rst
+++ b/man/confchpl.rst
@@ -1,5 +1,5 @@
 
-:Version: 2.3 pre-release
+:Version: 2.3
 :Manual section: 1
 :Title: \\fBchpl\\fP
 :Subtitle: Compiler for the Chapel Programming Language

--- a/man/confchpldoc.rst
+++ b/man/confchpldoc.rst
@@ -1,5 +1,5 @@
 
-:Version: 2.3 pre-release
+:Version: 2.3
 :Manual section: 1
 :Title: \\fBchpldoc\\fP
 :Subtitle: the Chapel Documentation Tool

--- a/test/chpldoc/compflags/combinations/versionhelp-chpldoc.sh
+++ b/test/chpldoc/compflags/combinations/versionhelp-chpldoc.sh
@@ -5,10 +5,10 @@ compiler=$3
 echo -n `basename $compiler`
 cat $CWD/../../../compflags/bradc/printstuff/version.goodstart
 # During pre-release mode
-diff $CWD/../../../../compiler/main/BUILD_VERSION $CWD/zero.txt > /dev/null 2>&1 && echo "" || \
-  { echo -n " pre-release (" && cat $CWD/../../../../compiler/main/BUILD_VERSION | tr -d \"\\n && echo ")" ; }
+# diff $CWD/../../../../compiler/main/BUILD_VERSION $CWD/zero.txt > /dev/null 2>&1 && echo "" || \
+#   { echo -n " pre-release (" && cat $CWD/../../../../compiler/main/BUILD_VERSION | tr -d \"\\n && echo ")" ; }
 # During release mode:
-#echo ""
+echo ""
 
 # print Sphinx and chapeldomain versions
 python=$($CWD/../../../../util/config/find-python.sh)

--- a/test/compflags/bradc/printstuff/versionhelp.sh
+++ b/test/compflags/bradc/printstuff/versionhelp.sh
@@ -5,10 +5,10 @@ compiler=$3
 echo -n `basename $compiler`
 cat $CWD/version.goodstart
 # During pre-release mode
-diff $CWD/../../../../compiler/main/BUILD_VERSION $CWD/zero.txt > /dev/null 2>&1 && echo "" || \
-  { echo -n " pre-release (" && cat $CWD/../../../../compiler/main/BUILD_VERSION | tr -d \"\\n && echo ")" ; }
+# diff $CWD/../../../../compiler/main/BUILD_VERSION $CWD/zero.txt > /dev/null 2>&1 && echo "" || \
+#   { echo -n " pre-release (" && cat $CWD/../../../../compiler/main/BUILD_VERSION | tr -d \"\\n && echo ")" ; }
 # During release mode:
-#echo ""
+echo ""
 
 if [ "$CHPL_LLVM" != "none" ]
 then


### PR DESCRIPTION
This updates the version numbering throughout the codebase in advance of the 2.3 release.

See https://github.com/chapel-lang/chapel/pull/25957 for past release preparation changes.

[reviewed by @riftEmber - thanks!]