### PR TITLE
Fix `make docs` in a dirty source tree with chapel-py

### DIFF
--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -43,6 +43,8 @@ if os.path.exists(chapel_py_dir):
     include_chapel_py_docs = True
     shutil.copyfile(chapel_py_api_template, chapel_py_api_rst)
 else:
+    if os.path.exists(chapel_py_api_rst):
+        os.remove(chapel_py_api_rst)
     pathlib.Path(chapel_py_api_rst).touch()
     msg = (
         "chapel-py not built, skipping API docs generation. "


### PR DESCRIPTION
Fixes a build issue with the chapel-py docs when a previous build had chapel-py and the current build does not.

[Reviewed by @mppf]