### PR TITLE
Always use a smaller number of trials for a memory benchmark

### DIFF
--- a/test/performance/memory/microMemoryAllocation.execopts
+++ b/test/performance/memory/microMemoryAllocation.execopts
@@ -1,6 +1,1 @@
-#!/usr/bin/env bash
-args="--printTime=false"
-if [ "$CHPL_TEST_VGRND_EXE" == "on" ] || [ "${CHPL_SANITIZE_EXE:-none}" != "none" ]; then
-  args="$args --trials=1000"
-fi
-echo $args
+--trials=10


### PR DESCRIPTION
Always use a smaller number of trials for a memory benchmark

[Reviewed by @stonea]