### PR TITLE
Fix string maniuplation in environment forwarding

### DIFF
--- a/runtime/src/chpl-launcher-common.c
+++ b/runtime/src/chpl-launcher-common.c
@@ -546,7 +546,7 @@ char* chpl_get_enviro_keys(char sep)
     int keyLen = strstr(environ[i], "=") - environ[i];
 
     // if the key ends with _modshare, skip it
-    if (keyLen > 8 && strncmp(environ[i] + keyLen - 8, "_modshare", 9) == 0) {
+    if (keyLen > 8 && strncmp(environ[i] + keyLen - 9, "_modshare", 9) == 0) {
       continue;
     }
     numVars++;
@@ -563,7 +563,7 @@ char* chpl_get_enviro_keys(char sep)
 
     int keyLen = strstr(environ[i], "=") - environ[i];
     // skip keys that end with _modshare
-    if (keyLen > 8 && strncmp(environ[i] + keyLen - 8, "_modshare", 9) == 0) {
+    if (keyLen > 8 && strncmp(environ[i] + keyLen - 9, "_modshare", 9) == 0) {
       continue;
     }
     strncpy(buffer + bufferOffset, environ[i], keyLen);

--- a/util/test/chpl_launchcmd.py
+++ b/util/test/chpl_launchcmd.py
@@ -57,10 +57,8 @@ def main():
     """Run the program!"""
     job = AbstractJob.init_from_environment()
     (stdout, stderr) = job.run()
-    logging.debug("I am after run {} {} {} {}", stdout, type(stdout), stderr, type(stderr))
     sys.stdout.buffer.write(stdout)
     sys.stderr.buffer.write(stderr)
-    logging.debug("I am after buffer writes")
 
 
 class AbstractJob(object):
@@ -402,8 +400,6 @@ class AbstractJob(object):
                 pass
 
             logging.info('The test finished with output of length {0}.'.format(len(output)))
-
-        logging.debug('Returning output and error from job.')
 
         return (output, error)
 
@@ -1149,7 +1145,7 @@ def _temp_dir(dir_prefix='chapel-test-tmp'):
         yield tmp_dir
     finally:
         logging.debug('Deleting temporary working directory at: {0}'.format(tmp_dir))
-        # shutil.rmtree(tmp_dir)
+        shutil.rmtree(tmp_dir)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes the string manipulation code for checking which variables to forward to the system launcher (slurm/pbs).

Fixes an off-by-one error that was added in https://github.com/chapel-lang/chapel/pull/26281

[Reviewed by @e-kayrakli]