### PR TITLE
Guard bounds-checking in `log2` with `--checks`

### DIFF
--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -1075,8 +1075,8 @@ module Math {
   }
 
   private inline proc chpl_logBasePow2(val: int(?w), baseLog2) {
-    if (val < 1) {
-      halt("Can't take the log() of a non-positive integer");
+    if boundsChecking && val < 1 {
+      HaltWrappers.boundsCheckHalt("Can't take the log() of a non-positive integer");
     }
     return _logBasePow2Help(val, baseLog2);
   }

--- a/test/library/standard/Math/bradc/lg2neg.compopts
+++ b/test/library/standard/Math/bradc/lg2neg.compopts
@@ -1,0 +1,2 @@
+# this test requires checks
+--checks

--- a/test/library/standard/Math/bradc/lg2zero.compopts
+++ b/test/library/standard/Math/bradc/lg2zero.compopts
@@ -1,0 +1,2 @@
+# this test requires checks
+--checks


### PR DESCRIPTION
Add a missing check for `boundsChecking` on a bounds check inside of `Math.log2`.

[Reviewed by @e-kayrakli]