### PR TITLE
Add Github Actions check for new large files

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -149,14 +149,14 @@ jobs:
           fetch-depth: 0
       - name: check commits for large files
         run: |
-              baseSHA=${{github.event.pull_request.base.sha}}
-              headSHA=${{github.event.pull_request.head.sha}}
-              # Loop through commits in reverse, starting from latest and ending
-              # at the first commit added in the PR.
-              currentSHA=$headSHA
-              while [[ "$(currentSHA)" != "$(baseSHA)" ]];
-              do
-                echo "currentSHA: $currentSHA"
-                git diff --name-only $currentSHA^ $currentSHA
-                currentSHA=$(git rev-parse $currentSHA^)
-              done
+          baseSHA=${{github.event.pull_request.base.sha}}
+          headSHA=${{github.event.pull_request.head.sha}}
+          # Loop through commits in reverse, starting from latest and ending
+          # at the first commit added in the PR.
+          currentSHA=$headSHA
+          while [[ "$(currentSHA)" != "$(baseSHA)" ]];
+          do
+            echo "currentSHA: $currentSHA"
+            git diff --name-only $currentSHA^ $currentSHA
+            currentSHA=$(git rev-parse $currentSHA^)
+          done

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -140,9 +140,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: print GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
+        run: echo "${{ toJson(github) }}"
       - name: checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -150,7 +150,7 @@ jobs:
       - name: check commits for large files
         run: |
               baseSHA=${{github.event.pull_request.base.sha}}
-              headSHA=${{github.event.pull_request.head.sha}})
+              headSHA=${{github.event.pull_request.head.sha}}
               # Loop through commits in reverse, starting from latest and ending
               # at the first commit added in the PR.
               currentSHA=$headSHA

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -150,10 +150,11 @@ jobs:
         run: |
           FILE_SIZE_LIMIT_KB=1024
 
-          # Loop backward through commits added in the PR, starting from the
-          # latest.
           baseSHA=${{github.event.pull_request.base.sha}}
           headSHA=${{github.event.pull_request.head.sha}}
+
+          # Loop backward through commits added in the PR, starting from the
+          # latest.
           for commit in $(git rev-list $baseSHA..$headSHA)
           do
             echo "Checking commit: $commit"
@@ -166,8 +167,10 @@ jobs:
                   continue
               fi
               echo "Checking file: $file"
+
               file_size=$(ls -l "$file" | awk '{print $5}')
               file_size_kb=$((file_size / 1024))
+
               if [ "$file_size_kb" -ge "$FILE_SIZE_LIMIT_KB" ]; then
                 echo "Error: ${file} is too large (size ${file_size_kb}KB, limit ${FILE_SIZE_LIMIT_KB}KB)."
                 exit 1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -157,6 +157,8 @@ jobs:
           for commit in $(git rev-list $baseSHA..$headSHA)
           do
             echo "Checking commit: $commit"
+            git checkout -q $commit
+
             # Get list of added, copied, or modified files from this commit.
             newFiles=$(git diff --name-only --diff-filter=ACM $commit^ $commit)
             while read -r file; do

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -145,6 +145,8 @@ jobs:
         run: echo "$GITHUB_CONTEXT"
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: check commits for large files
         run: |
               baseSHA=${{github.event.pull_request.base.sha}}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -172,7 +172,7 @@ jobs:
               file_size_kb=$((file_size / 1024))
 
               if [ "$file_size_kb" -ge "$FILE_SIZE_LIMIT_KB" ]; then
-                echo "Error: ${file} is too large (size ${file_size_kb}KB, limit ${FILE_SIZE_LIMIT_KB}KB)."
+                echo "Error: ${file} is too large (size ${file_size_kb}KB, limit ${FILE_SIZE_LIMIT_KB}KB). Introduced in commit: $commit"
                 exit 1
               fi
             done <<< "$newFiles"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -145,10 +145,11 @@ jobs:
           fetch-depth: 0
       - name: check commits for large files
         run: |
-          baseSHA=${{github.event.pull_request.base.sha}}
+          baseSHA=${{github.event.pull_request.head.sha}}
+          headSHA=${{github.event.pull_request.base.sha}}
           # Loop backward through commits added in the PR, starting from the
           # latest.
-          for commit in $(git rev-list main..$headSHA)
+          for commit in $(git rev-list $baseSHA..$headSHA)
           do
             echo "Current commit: $commit"
             git diff --name-only $commit^ $commit

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -145,8 +145,8 @@ jobs:
           fetch-depth: 0
       - name: check commits for large files
         run: |
-          baseSHA=${{github.event.pull_request.head.sha}}
-          headSHA=${{github.event.pull_request.base.sha}}
+          baseSHA=${{github.event.pull_request.base.sha}}
+          headSHA=${{github.event.pull_request.head.sha}}
           # Loop backward through commits added in the PR, starting from the
           # latest.
           for commit in $(git rev-list $baseSHA..$headSHA)

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -139,8 +139,6 @@ jobs:
   check_large_files:
     runs-on: ubuntu-latest
     steps:
-      - name: print GitHub context
-        run: echo "${{ toJson(github) }}"
       - name: checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -156,7 +156,7 @@ jobs:
           do
             echo "Checking commit: $commit"
             # Get list of added, copied, or modified files from this commit.
-            newFiles=$(git diff --name-status --diff-filter=ACM $commit^ $commit)
+            newFiles=$(git diff --name-only --diff-filter=ACM $commit^ $commit)
             while read -r file; do
               if [ "$file" = "" ]; then
                   continue

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -154,7 +154,7 @@ jobs:
           headSHA=${{github.event.pull_request.head.sha}}
           for commit in $(git rev-list $baseSHA..$headSHA)
           do
-            echo "Current commit: $commit"
+            echo "Checking commit: $commit"
             # Get list of added, copied, or modified files from this commit.
             newFiles=$(git diff --name-status --diff-filter=ACM $commit^ $commit)
             while read -r file; do
@@ -168,5 +168,5 @@ jobs:
                 echo "Error: ${file} is too large (size ${file_size_kb}KB, limit ${FILE_SIZE_LIMIT_KB}KB)."
                 exit 1
               fi
-            done <<< "$files"
+            done <<< "$newFiles"
           done

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -140,7 +140,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - name: checkout
+      - name: checkout commits on PR branch
         uses: actions/checkout@v4
         with:
           fetch-depth: $(( ${{github.event.pull_request.commits}} + 1 ))

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -150,13 +150,10 @@ jobs:
       - name: check commits for large files
         run: |
           baseSHA=${{github.event.pull_request.base.sha}}
-          headSHA=${{github.event.pull_request.head.sha}}
-          # Loop through commits in reverse, starting from latest and ending
-          # at the first commit added in the PR.
-          currentSHA=$headSHA
-          while [[ "$(currentSHA)" != "$(baseSHA)" ]];
+          # Loop backward through commits added in the PR, starting from the
+          # latest.
+          for commit in $(git rev-list main..$headSHA)
           do
-            echo "currentSHA: $currentSHA"
-            git diff --name-only $currentSHA^ $currentSHA
-            currentSHA=$(git rev-parse $currentSHA^)
+            echo "Current commit: $commit"
+            git diff --name-only $commit^ $commit
           done

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -146,12 +146,27 @@ jobs:
           fetch-depth: $(( ${{github.event.pull_request.commits}} + 1 ))
       - name: check commits for large files
         run: |
-          baseSHA=${{github.event.pull_request.base.sha}}
-          headSHA=${{github.event.pull_request.head.sha}}
+          FILE_SIZE_LIMIT_KB=1024
+
           # Loop backward through commits added in the PR, starting from the
           # latest.
+          baseSHA=${{github.event.pull_request.base.sha}}
+          headSHA=${{github.event.pull_request.head.sha}}
           for commit in $(git rev-list $baseSHA..$headSHA)
           do
             echo "Current commit: $commit"
-            git diff --name-only $commit^ $commit
+            # Get list of added, copied, or modified files from this commit.
+            newFiles=$(git diff --name-status --diff-filter=ACM $commit^ $commit)
+            while read -r file; do
+              if [ "$file" = "" ]; then
+                  continue
+              fi
+              echo "Checking file: $file"
+              file_size=$(ls -l "$file" | awk '{print $5}')
+              file_size_kb=$((file_size / 1024))
+              if [ "$file_size_kb" -ge "$FILE_SIZE_LIMIT_KB" ]; then
+                echo "Error: ${file} is too large (size ${file_size_kb}KB, limit ${FILE_SIZE_LIMIT_KB}KB)."
+                exit 1
+              fi
+            done <<< "$files"
           done

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -137,7 +137,7 @@ jobs:
       run: |
         ./util/buildRelease/smokeTest lint
   check_large_files:
-    if: github.event_name == "pull_request"
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: checkout

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -142,7 +142,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: $(( ${{github.event.pull_request.commits}} + 1 ))
       - name: check commits for large files
         run: |
           baseSHA=${{github.event.pull_request.base.sha}}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -137,6 +137,7 @@ jobs:
       run: |
         ./util/buildRelease/smokeTest lint
   check_large_files:
+    if: github.event_name == "pull_request"
     runs-on: ubuntu-latest
     steps:
       - name: checkout

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -136,3 +136,25 @@ jobs:
     - name: smokeTest lint
       run: |
         ./util/buildRelease/smokeTest lint
+  check_large_files:
+    runs-on: ubuntu-latest
+    steps:
+      - name: print GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: check commits for large files
+        run: |
+              baseSHA=${{github.event.pull_request.base.sha}}
+              headSHA=${{github.event.pull_request.head.sha}})
+              # Loop through commits in reverse, starting from latest and ending
+              # at the first commit added in the PR.
+              currentSHA=$headSHA
+              while [[ "$(currentSHA)" != "$(baseSHA)" ]];
+              do
+                echo "currentSHA: $currentSHA"
+                git diff --name-only $currentSHA^ $currentSHA
+                currentSHA=$(git rev-parse $currentSHA^)
+              done

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -140,10 +140,12 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
+      - name: count PR commits
+        run: echo "PR_NUM_COMMITS=$(( ${{ github.event.pull_request.commits }} + 2 ))" >> "${GITHUB_ENV}"
       - name: checkout commits on PR branch
         uses: actions/checkout@v4
         with:
-          fetch-depth: $(( ${{github.event.pull_request.commits}} + 1 ))
+          fetch-depth: ${{ env.PR_NUM_COMMITS }}
       - name: check commits for large files
         run: |
           FILE_SIZE_LIMIT_KB=1024


### PR DESCRIPTION
Adds a Github Actions CI check that errors if an unusually large file is introduced in any commit on a PR.

The limit for a "large" file is set to 1MB as a reasonable estimate.

Resolves https://github.com/Cray/chapel-private/issues/4295.

[reviewer info placeholder]

Testing:
- [x] check fails when large file added
  - [x] even if removed in a later commit