### PR TITLE
Expand AVE to arrays of different types

### DIFF
--- a/modules/internal/ChapelArrayViewElision.chpl
+++ b/modules/internal/ChapelArrayViewElision.chpl
@@ -76,9 +76,6 @@ module ChapelArrayViewElision {
 
   proc chpl__ave_protoSlicesSupportAssignment(a: chpl__protoSlice,
                                               b: chpl__protoSlice) param: bool {
-    // for now, only same array types on both sides are supported
-    if a.ptrToArr.deref().type != b.ptrToArr.deref().type then return false;
-
     // either both sides are rank-changes, or neither is
     if a.isRankChange != b.isRankChange then return false;
 

--- a/test/optimizations/arrayViewElision/distributed.comm-none.good
+++ b/test/optimizations/arrayViewElision/distributed.comm-none.good
@@ -22,7 +22,7 @@ ArrayViewElision supported distributed.chpl:33
 	rhsIndexingExprs: 
 		range(int(64),both,one)
 
-ArrayViewElision not supported distributed.chpl:46
+ArrayViewElision supported distributed.chpl:46
 	lhsBaseType: [BlockDom(1,int(64),one,unmanaged DefaultDist)] int(64)
 	lhsIndexingExprs: 
 		range(int(64),both,one)

--- a/test/optimizations/arrayViewElision/distributed.good
+++ b/test/optimizations/arrayViewElision/distributed.good
@@ -22,7 +22,7 @@ ArrayViewElision supported (dynamic locality check required) distributed.chpl:33
 	rhsIndexingExprs: 
 		range(int(64),both,one)
 
-ArrayViewElision not supported distributed.chpl:46
+ArrayViewElision supported (dynamic locality check required) distributed.chpl:46
 	lhsBaseType: [BlockDom(1,int(64),one,unmanaged DefaultDist)] int(64)
 	lhsIndexingExprs: 
 		range(int(64),both,one)

--- a/test/optimizations/arrayViewElision/distributedToLocal.chpl
+++ b/test/optimizations/arrayViewElision/distributedToLocal.chpl
@@ -1,0 +1,37 @@
+const Space = {1..10};
+
+// not exhaustive.
+{
+  use BlockDist;
+
+  const D = Space dmapped new blockDist(Space);
+  var A: [Space] int = 1;
+  var B: [D] int = 2;
+
+  A[3..5] = B[3..5];
+  writeln(A);
+}
+
+{
+  // this is not supported today. Relevant doi functions need to be adjusted.
+  // This is not an AVE limitation.
+  use CyclicDist;
+
+  const D = Space dmapped new cyclicDist(Space.first);
+  var A: [Space] int = 1;
+  var B: [D] int = 2;
+
+  A[3..5] = B[3..5];
+  writeln(A);
+}
+
+{
+  use StencilDist;
+
+  const D = Space dmapped new stencilDist(Space);
+  var A: [Space] int = 1;
+  var B: [D] int = 2;
+
+  A[3..5] = B[3..5];
+  writeln(A);
+}

--- a/test/optimizations/arrayViewElision/distributedToLocal.comm-none.good
+++ b/test/optimizations/arrayViewElision/distributedToLocal.comm-none.good
@@ -1,0 +1,46 @@
+ArrayViewElision supported distributedToLocal.chpl:11
+	lhsBaseType: [domain(1,int(64),one)] int(64)
+	lhsIndexingExprs: 
+		range(int(64),both,one)
+	rhsBaseType: [BlockDom(1,int(64),one,unmanaged DefaultDist)] int(64)
+	rhsIndexingExprs: 
+		range(int(64),both,one)
+
+ArrayViewElision supported distributedToLocal.chpl:24
+	lhsBaseType: [domain(1,int(64),one)] int(64)
+	lhsIndexingExprs: 
+		range(int(64),both,one)
+	rhsBaseType: [CyclicDom(1,int(64),one)] int(64)
+	rhsIndexingExprs: 
+		range(int(64),both,one)
+
+ArrayViewElision supported distributedToLocal.chpl:35
+	lhsBaseType: [domain(1,int(64),one)] int(64)
+	lhsIndexingExprs: 
+		range(int(64),both,one)
+	rhsBaseType: [StencilDom(1,int(64),one,false)] int(64)
+	rhsIndexingExprs: 
+		range(int(64),both,one)
+
+Performing protoSlice bulk transfer
+operator =(a:[],b:[]): in chpl__bulkTransferArray
+operator =(a:[],b:[]): attempting doiBulkTransferToKnown
+operator =(a:[],b:[]): in chpl__bulkTransferArray
+operator =(a:[],b:[]): attempting doiBulkTransferFromKnown
+In DefaultRectangular._simpleTransfer(): Alo=(3,), Blo=(3,), len=3, elemSize=8
+operator =(a:[],b:[]): successfully completed bulk transfer
+operator =(a:[],b:[]): successfully completed bulk transfer
+1 1 2 2 2 1 1 1 1 1
+Performing protoSlice bulk transfer
+operator =(a:[],b:[]): in chpl__bulkTransferArray
+operator =(a:[],b:[]): bulk transfer did not happen
+1 1 2 2 2 1 1 1 1 1
+Performing protoSlice bulk transfer
+operator =(a:[],b:[]): in chpl__bulkTransferArray
+operator =(a:[],b:[]): attempting doiBulkTransferToKnown
+operator =(a:[],b:[]): in chpl__bulkTransferArray
+operator =(a:[],b:[]): attempting doiBulkTransferFromKnown
+In DefaultRectangular._simpleTransfer(): Alo=(3,), Blo=(3,), len=3, elemSize=8
+operator =(a:[],b:[]): successfully completed bulk transfer
+operator =(a:[],b:[]): successfully completed bulk transfer
+1 1 2 2 2 1 1 1 1 1

--- a/test/optimizations/arrayViewElision/distributedToLocal.compopts
+++ b/test/optimizations/arrayViewElision/distributedToLocal.compopts
@@ -1,0 +1,1 @@
+--report-array-view-elision -sdebugBulkTransfer

--- a/test/optimizations/arrayViewElision/distributedToLocal.good
+++ b/test/optimizations/arrayViewElision/distributedToLocal.good
@@ -1,0 +1,54 @@
+ArrayViewElision supported (dynamic locality check required) distributedToLocal.chpl:11
+	lhsBaseType: [domain(1,int(64),one)] int(64)
+	lhsIndexingExprs: 
+		range(int(64),both,one)
+	rhsBaseType: [BlockDom(1,int(64),one,unmanaged DefaultDist)] int(64)
+	rhsIndexingExprs: 
+		range(int(64),both,one)
+
+ArrayViewElision supported (dynamic locality check required) distributedToLocal.chpl:24
+	lhsBaseType: [domain(1,int(64),one)] int(64)
+	lhsIndexingExprs: 
+		range(int(64),both,one)
+	rhsBaseType: [CyclicDom(1,int(64),one)] int(64)
+	rhsIndexingExprs: 
+		range(int(64),both,one)
+
+ArrayViewElision supported (dynamic locality check required) distributedToLocal.chpl:35
+	lhsBaseType: [domain(1,int(64),one)] int(64)
+	lhsIndexingExprs: 
+		range(int(64),both,one)
+	rhsBaseType: [StencilDom(1,int(64),one,false)] int(64)
+	rhsIndexingExprs: 
+		range(int(64),both,one)
+
+operator =(a:[],b:[]): in chpl__bulkTransferArray
+operator =(a:[],b:[]): attempting doiBulkTransferFromKnown
+In DefaultRectangular._simpleTransfer(): Alo=(0,), Blo=(0,), len=1, elemSize=8
+operator =(a:[],b:[]): successfully completed bulk transfer
+operator =(a:[],b:[]): in chpl__bulkTransferArray
+operator =(a:[],b:[]): attempting doiBulkTransferFromKnown
+In DefaultRectangular._simpleTransfer(): Alo=(0,), Blo=(0,), len=1, elemSize=8
+operator =(a:[],b:[]): successfully completed bulk transfer
+Performing protoSlice bulk transfer
+operator =(a:[],b:[]): in chpl__bulkTransferArray
+operator =(a:[],b:[]): attempting doiBulkTransferToKnown
+operator =(a:[],b:[]): in chpl__bulkTransferArray
+operator =(a:[],b:[]): attempting doiBulkTransferFromKnown
+In DefaultRectangular._simpleTransfer(): Alo=(3,), Blo=(3,), len=3, elemSize=8
+operator =(a:[],b:[]): successfully completed bulk transfer
+operator =(a:[],b:[]): successfully completed bulk transfer
+1 1 2 2 2 1 1 1 1 1
+Performing protoSlice bulk transfer
+operator =(a:[],b:[]): in chpl__bulkTransferArray
+operator =(a:[],b:[]): bulk transfer did not happen
+1 1 2 2 2 1 1 1 1 1
+Performing protoSlice bulk transfer
+operator =(a:[],b:[]): in chpl__bulkTransferArray
+operator =(a:[],b:[]): attempting doiBulkTransferToKnown
+operator =(a:[],b:[]): in chpl__bulkTransferArray
+operator =(a:[],b:[]): attempting doiBulkTransferFromKnown
+In DefaultRectangular._simpleTransfer(): Alo=(3,), Blo=(3,), len=3, elemSize=8
+operator =(a:[],b:[]): successfully completed bulk transfer
+operator =(a:[],b:[]): successfully completed bulk transfer
+1 1 2 2 2 1 1 1 1 1

--- a/test/optimizations/arrayViewElision/localToDistributed.chpl
+++ b/test/optimizations/arrayViewElision/localToDistributed.chpl
@@ -1,0 +1,37 @@
+const Space = {1..10};
+
+// not exhaustive.
+{
+  use BlockDist;
+
+  const D = Space dmapped new blockDist(Space);
+  var A: [D] int = 1;
+  var B: [Space] int = 2;
+
+  A[3..5] = B[3..5];
+  writeln(A);
+}
+
+{
+  // this is not supported today. Relevant doi functions need to be adjusted.
+  // This is not an AVE limitation.
+  use CyclicDist;
+
+  const D = Space dmapped new cyclicDist(Space.first);
+  var A: [D] int = 1;
+  var B: [Space] int = 2;
+
+  A[3..5] = B[3..5];
+  writeln(A);
+}
+
+{
+  use StencilDist;
+
+  const D = Space dmapped new stencilDist(Space);
+  var A: [D] int = 1;
+  var B: [Space] int = 2;
+
+  A[3..5] = B[3..5];
+  writeln(A);
+}

--- a/test/optimizations/arrayViewElision/localToDistributed.compopts
+++ b/test/optimizations/arrayViewElision/localToDistributed.compopts
@@ -1,0 +1,1 @@
+--report-array-view-elision -sdebugBulkTransfer

--- a/test/optimizations/arrayViewElision/localToDistributed.good
+++ b/test/optimizations/arrayViewElision/localToDistributed.good
@@ -1,0 +1,46 @@
+ArrayViewElision supported localToDistributed.chpl:11
+	lhsBaseType: [BlockDom(1,int(64),one,unmanaged DefaultDist)] int(64)
+	lhsIndexingExprs: 
+		range(int(64),both,one)
+	rhsBaseType: [domain(1,int(64),one)] int(64)
+	rhsIndexingExprs: 
+		range(int(64),both,one)
+
+ArrayViewElision supported localToDistributed.chpl:24
+	lhsBaseType: [CyclicDom(1,int(64),one)] int(64)
+	lhsIndexingExprs: 
+		range(int(64),both,one)
+	rhsBaseType: [domain(1,int(64),one)] int(64)
+	rhsIndexingExprs: 
+		range(int(64),both,one)
+
+ArrayViewElision supported localToDistributed.chpl:35
+	lhsBaseType: [StencilDom(1,int(64),one,false)] int(64)
+	lhsIndexingExprs: 
+		range(int(64),both,one)
+	rhsBaseType: [domain(1,int(64),one)] int(64)
+	rhsIndexingExprs: 
+		range(int(64),both,one)
+
+Performing protoSlice bulk transfer
+operator =(a:[],b:[]): in chpl__bulkTransferArray
+operator =(a:[],b:[]): attempting doiBulkTransferFromKnown
+operator =(a:[],b:[]): in chpl__bulkTransferArray
+operator =(a:[],b:[]): attempting doiBulkTransferFromKnown
+In DefaultRectangular._simpleTransfer(): Alo=(3,), Blo=(3,), len=3, elemSize=8
+operator =(a:[],b:[]): successfully completed bulk transfer
+operator =(a:[],b:[]): successfully completed bulk transfer
+1 1 2 2 2 1 1 1 1 1
+Performing protoSlice bulk transfer
+operator =(a:[],b:[]): in chpl__bulkTransferArray
+operator =(a:[],b:[]): bulk transfer did not happen
+1 1 2 2 2 1 1 1 1 1
+Performing protoSlice bulk transfer
+operator =(a:[],b:[]): in chpl__bulkTransferArray
+operator =(a:[],b:[]): attempting doiBulkTransferFromKnown
+operator =(a:[],b:[]): in chpl__bulkTransferArray
+operator =(a:[],b:[]): attempting doiBulkTransferFromKnown
+In DefaultRectangular._simpleTransfer(): Alo=(3,), Blo=(3,), len=3, elemSize=8
+operator =(a:[],b:[]): successfully completed bulk transfer
+operator =(a:[],b:[]): successfully completed bulk transfer
+1 1 2 2 2 1 1 1 1 1


### PR DESCRIPTION
Michael has bumped into a case where AVE wasn't firing when arrays are of different type (block vs DR particularly). That seems to be because of a check I added for caution in the first PR, which looks like it was easy to remove.

This PR also adds tests, but note that Cyclic vs DR is still not supported. I don't think this is an AVE limitation -- such bulk transfer are probably not supported already.

Test
- [x] local
- [x] gasnet