### PR TITLE
Dyno: Fix default arguments for multi-decl fields

### DIFF
--- a/frontend/lib/resolution/InitResolver.cpp
+++ b/frontend/lib/resolution/InitResolver.cpp
@@ -833,7 +833,9 @@ bool InitResolver::handleAssignmentToField(const OpCall* node) {
       }
 
       auto rhsType = initResolver_.byPostorder.byAst(rhs).type();
-      auto adjusted = QualifiedType(QualifiedType::TYPE, initialFieldType.type());
+      auto declType = initialFieldType.isType() ? AnyType::get(ctx_) :
+                                                  initialFieldType.type();
+      auto adjusted = QualifiedType(QualifiedType::TYPE, declType);
       // TODO: prevent 'getTypeForDecl' from issuing the error message, and
       // instead do something field-specific.
       auto computed = initResolver_.getTypeForDecl(node,

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -298,6 +298,18 @@ static bool initHelper(Context* context,
       auto groupBegin = it;
       const AstNode* curTypeExpr = nullptr;
       const AstNode* curInitExpr = nullptr;
+
+      // Iterate over decls until we find one with either a type-expression or
+      // init-expression. Once found, the inner loop propagates the
+      // type/init-expressions to previous decls without such expressions.
+      //
+      // For example, in a multi-decl like this:
+      //
+      //   var a, b: string, c, d = 0;
+      //
+      // The outer loop would do nothing for variables, 'a' and 'c'. Then,
+      // when 'b' and 'd' are examined, their expressions will be propagated
+      // back to 'a' and 'c' during the inner loop.
       while (it != multi->decls().end()) {
         const VarLikeDecl* curDecl = (*it)->toVarLikeDecl();
 

--- a/frontend/test/resolution/testInitSemantics.cpp
+++ b/frontend/test/resolution/testInitSemantics.cpp
@@ -1844,6 +1844,35 @@ static void testGenericFieldInit() {
   }
 }
 
+static void testDefaultArgs() {
+  {
+    std::string program = R"""(
+      class Parent {
+        var x, y: real;
+      }
+
+      class Child : Parent {
+        var z : real;
+        var a, b: int, c, d = 42.0;
+      }
+
+      var A = new Child();
+      var B = new Child(1.0, 2.0, 3.0); // x=1.0, y=2.0, z=3.0
+      var C = new Child(y=10.0);
+      )""";
+
+    Context* context = buildStdContext();
+    ErrorGuard guard(context);
+
+    auto vars = resolveTypesOfVariables(context, program, {"A", "B", "C"});
+
+    // Note: These type strings are not stabilized
+    assert(toString(vars["A"]) == "owned Child");
+    assert(toString(vars["B"]) == "owned Child");
+    assert(toString(vars["C"]) == "owned Child");
+  }
+}
+
 // TODO:
 // - test using defaults for types and params
 //   - also in conditionals
@@ -1893,6 +1922,8 @@ int main() {
   testNilFieldInit();
 
   testGenericFieldInit();
+
+  testDefaultArgs();
 
   return 0;
 }


### PR DESCRIPTION
Prior to this PR, default initializer arguments for multi-declaration fields did not themselves have default values. Let's say we have three fields declared in this manner: ``var a, b, c: int``. Each of these fields is an ``int`` and should have a default value of ``0``. Due to the way the frontend builds uAST, fields ``a`` and ``b`` did not directly contain a type expression or initialization expression from which a default value could be derived.

This PR updates the logic to correctly copy type expressions and initialization expressions, once encountered, to preceding fields lacking such expressions.

This PR also includes a small fix for generic field initialization, to resolve a bug with the ``Generics/initializersForGenericFields.chpl`` primer.

Testing:
- [x] test-frontend