### PR TITLE
Update docs pulldown menu to mark 'docs/main' as 2.4 (pre-release)

### DIFF
--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -128,13 +128,13 @@ master_doc = 'index'
 # 'version' adds a redundant version number onto the top of the sidebar
 # automatically (rtd-theme). We also don't use |version| anywhere in rst
 
-chplversion = '2.3'                  # TODO -- parse from `chpl --version`
+chplversion = '2.4'                  # TODO -- parse from `chpl --version`
 shortversion = chplversion.replace('-', '&#8209') # prevent line-break at hyphen, if any
 html_context = {"chplversion":chplversion}
 
 # The full version, including alpha/beta/rc tags.
-# release = '2.3.0 (pre-release)'
-release = '2.3.0'
+release = '2.4.0 (pre-release)'
+# release = '2.3.0'
 
 # General information about the project.
 project = u'Chapel Documentation'

--- a/doc/util/versionButton.php
+++ b/doc/util/versionButton.php
@@ -89,7 +89,7 @@ if (pagePath == "") {
 function dropSetup() {
   var currentRelease = "2.2"; // what does the public have?
   var stagedRelease = "2.3";  // is there a release staged but not yet public?
-  var nextRelease = "2.3";    // what's the next release? (on docs/main)
+  var nextRelease = "2.4";    // what's the next release? (on docs/main)
   var button = document.getElementById("versionButton");
   // Uses unicode down-pointing triangle
   var arrow = " &#9660;";


### PR DESCRIPTION
This is the standard update at this point in the release cycle.
