### PR TITLE
Fix linter checking for a tuple unpack in a formal

### DIFF
--- a/test/chplcheck/.gitignore
+++ b/test/chplcheck/.gitignore
@@ -1,0 +1,1 @@
+*.chpl.fixed

--- a/test/chplcheck/CLEANFILES
+++ b/test/chplcheck/CLEANFILES
@@ -1,0 +1,1 @@
+*.chpl.fixed

--- a/test/chplcheck/Unused.chpl
+++ b/test/chplcheck/Unused.chpl
@@ -38,4 +38,17 @@ module Unused {
   proc foo(Outer) {
     Outer[1] = 2;
   }
+
+  proc tup1((x, (y, z))) {
+    return (x, y, z);
+  }
+  proc tup2((x, y)) {
+    return x;
+  }
+  proc tup3(((x, z), y)) {
+    return y;
+  }
+  proc tup4((x, y)) {
+    return (1, 2);
+  }
 }

--- a/test/chplcheck/Unused.good
+++ b/test/chplcheck/Unused.good
@@ -3,3 +3,8 @@ Unused.chpl:3: node violates rule UnusedLoopIndex
 Unused.chpl:5: node violates rule UnusedLoopIndex
 Unused.chpl:13: node violates rule UnusedLoopIndex
 Unused.chpl:20: node violates rule UnusedLoopIndex
+Unused.chpl:45: node violates rule UnusedFormal
+Unused.chpl:48: node violates rule UnusedFormal
+Unused.chpl:48: node violates rule UnusedFormal
+Unused.chpl:51: node violates rule UnusedFormal
+Unused.chpl:51: node violates rule UnusedFormal

--- a/test/chplcheck/UnusedTupleUnpack.chpl
+++ b/test/chplcheck/UnusedTupleUnpack.chpl
@@ -4,3 +4,9 @@ foreach (_, _) in zip(1..10, 1..10) {}
 foreach (i, (_, _)) in zip(1..10, foreach pair in zip(1..10, 1..10) do pair) { i; }
 foreach (_, (_, _)) in zip(1..10, foreach pair in zip(1..10, 1..10) do pair) { i; }
 foreach ((_, _), _) in zip(foreach pair in zip(1..10, 1..10) do pair, 1..10) { i; }
+
+proc foo((_,_)) { }
+proc foo((_,x)) { return x; }
+proc foo((x,_)) { return x; }
+proc foo((_,(_,_))) { return x; }
+proc foo(((_,_),x)) { return x; }

--- a/test/chplcheck/UnusedTupleUnpack.good
+++ b/test/chplcheck/UnusedTupleUnpack.good
@@ -5,4 +5,8 @@ UnusedTupleUnpack.chpl:5: node violates rule UnusedTupleUnpack
 UnusedTupleUnpack.chpl:5: node violates rule UnusedTupleUnpack
 UnusedTupleUnpack.chpl:6: node violates rule UnusedTupleUnpack
 UnusedTupleUnpack.chpl:6: node violates rule UnusedTupleUnpack
+UnusedTupleUnpack.chpl:8: node violates rule UnusedTupleUnpack
+UnusedTupleUnpack.chpl:11: node violates rule UnusedTupleUnpack
+UnusedTupleUnpack.chpl:11: node violates rule UnusedTupleUnpack
+UnusedTupleUnpack.chpl:12: node violates rule UnusedTupleUnpack
 [Success matching fixit for UnusedTupleUnpack]

--- a/test/chplcheck/UnusedTupleUnpack.good-fixit
+++ b/test/chplcheck/UnusedTupleUnpack.good-fixit
@@ -4,3 +4,9 @@ foreach zip(1..10, 1..10) {}
 foreach (i, _) in zip(1..10, foreach pair in zip(1..10, 1..10) do pair) { i; }
 foreach (_, _) in zip(1..10, foreach pair in zip(1..10, 1..10) do pair) { i; }
 foreach (_, _) in zip(foreach pair in zip(1..10, 1..10) do pair, 1..10) { i; }
+
+proc foo((_,_)) { }
+proc foo((_,x)) { return x; }
+proc foo((x,_)) { return x; }
+proc foo((_,_)) { return x; }
+proc foo((_,x)) { return x; }


### PR DESCRIPTION
Fixes an issue where the linter was warning for an UnusedTupleUnpack on `proc foo((x, y))`. Fixing this issue then uncovered a few issues in the handling of tuple unpacks in UnusedFormal, also fixed in this PR.

Tested by running `start_test test/chplcheck`

[Reviewed by @DanilaFe]