### PR TITLE
Add --describe-candidates

### DIFF
--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -178,6 +178,7 @@ extern char driverTmpDir[FILENAME_MAX];
 // end compiler driver control flags
 extern bool fExitLeaks;
 extern bool fPrintAllCandidates;
+extern bool fDescribeCandidates;
 extern bool fPrintCallGraph;
 extern bool fPrintCallStackOnError;
 extern bool fAutoPrintCallStackOnError;

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -295,6 +295,7 @@ bool fExplainVerbose = false;
 bool fParseOnly = false;
 bool fPrintCallGraph = false;
 bool fPrintAllCandidates = false;
+bool fDescribeCandidates = false;
 bool fAutoPrintCallStackOnError = true;
 bool fPrintCallStackOnError = false;
 bool fPrintIDonError = false;
@@ -1337,6 +1338,7 @@ static ArgumentDescription arg_desc[] = {
 
  {"", ' ', NULL, "Miscellaneous Options", NULL, NULL, NULL, NULL},
  {"detailed-errors", ' ', NULL, "Enable [disable] detailed error messages", "N", &fDetailedErrors, "CHPL_DETAILED_ERRORS", NULL},
+ {"describe-candidates", ' ', NULL, "[Don't] print the reason candidates don't match on a resolution failure", "N", &fDescribeCandidates, "CHPL_DESCRIBE_CANDIDATES", NULL},
  {"devel", ' ', NULL, "Compile as a developer [user]", "N", &developer, "CHPL_DEVELOPER", driverSetDevelSettings},
  {"explain-call", ' ', "<function or operator name>[:<module>][:<line>]", "Explain resolution of call", "S256", fExplainCall, NULL, NULL},
  {"explain-instantiation", ' ', "<function|type>[:<module>][:<line>]", "Explain instantiation of function or type", "S256", fExplainInstantiation, NULL, NULL},

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5237,8 +5237,8 @@ static void generateUnresolvedMsg(CallInfo& info, Vec<FnSymbol*>& visibleFns) {
 
     sortExampleCandidates(info, visibleFns);
 
-    int nPrintDetails = 1;
-    int nPrint = 3; // unused if fPrintAllCandidates
+    int nPrintDetails = 1; // ignored if fDescribeCandidates
+    int nPrint = 3;        // ignored if fPrintAllCandidates
 
     Vec<FnSymbol*> filteredFns;
     if (fPrintAllCandidates || visibleFns.n <= nPrint + 1) {
@@ -5276,7 +5276,7 @@ static void generateUnresolvedMsg(CallInfo& info, Vec<FnSymbol*>& visibleFns) {
     int nPrinted = 0; // how many candidates have we printed?
     bool printedOne = false;  // have we printed one "other candidate"?
     forv_Vec(FnSymbol, fn, filteredFns) {
-      if (nPrinted < nPrintDetails) {
+      if (fDescribeCandidates || nPrinted < nPrintDetails) {
         explainCandidateRejection(info, fn);
       } else {
         if (printedOne == false) {

--- a/test/functions/resolution/errors/fail-many-candidates.all.good
+++ b/test/functions/resolution/errors/fail-many-candidates.all.good
@@ -1,0 +1,8 @@
+fail-many-candidates.chpl:16: error: unresolved call 'foo(1, "hello")'
+fail-many-candidates.chpl:13: note: this candidate did not match: foo(a, b)
+fail-many-candidates.chpl:13: note: because where clause evaluated to false
+fail-many-candidates.chpl:16: note: other candidates are:
+fail-many-candidates.chpl:1: note:   foo(a: int, b: int)
+fail-many-candidates.chpl:4: note:   foo(a: string, b: int)
+fail-many-candidates.chpl:7: note:   foo(a: string, b: string)
+fail-many-candidates.chpl:10: note:   foo(a: real, b: real)

--- a/test/functions/resolution/errors/fail-many-candidates.chpl
+++ b/test/functions/resolution/errors/fail-many-candidates.chpl
@@ -1,0 +1,16 @@
+proc foo(a: int, b: int) {
+}
+
+proc foo(a: string, b: int) {
+}
+
+proc foo(a: string, b: string) {
+}
+
+proc foo(a: real, b: real) {
+}
+
+proc foo(a, b) where a.type == bytes && b.type == bytes {
+}
+
+foo(1, "hello");

--- a/test/functions/resolution/errors/fail-many-candidates.compopts
+++ b/test/functions/resolution/errors/fail-many-candidates.compopts
@@ -1,0 +1,4 @@
+ # fail-many-candidates.default.good
+--describe-candidates # fail-many-candidates.describe.good
+--print-all-candidates # fail-many-candidates.all.good
+--describe-candidates --print-all-candidates # fail-many-candidates.describe-all.good

--- a/test/functions/resolution/errors/fail-many-candidates.default.good
+++ b/test/functions/resolution/errors/fail-many-candidates.default.good
@@ -1,0 +1,7 @@
+fail-many-candidates.chpl:16: error: unresolved call 'foo(1, "hello")'
+fail-many-candidates.chpl:13: note: this candidate did not match: foo(a, b)
+fail-many-candidates.chpl:13: note: because where clause evaluated to false
+fail-many-candidates.chpl:16: note: other candidates are:
+fail-many-candidates.chpl:1: note:   foo(a: int, b: int)
+fail-many-candidates.chpl:4: note:   foo(a: string, b: int)
+note: and 2 other candidates, use --print-all-candidates to see them

--- a/test/functions/resolution/errors/fail-many-candidates.describe-all.good
+++ b/test/functions/resolution/errors/fail-many-candidates.describe-all.good
@@ -1,0 +1,15 @@
+fail-many-candidates.chpl:16: error: unresolved call 'foo(1, "hello")'
+fail-many-candidates.chpl:13: note: this candidate did not match: foo(a, b)
+fail-many-candidates.chpl:13: note: because where clause evaluated to false
+fail-many-candidates.chpl:1: note: this candidate did not match: foo(a: int, b: int)
+fail-many-candidates.chpl:16: note: because actual argument #2 with type 'string'
+fail-many-candidates.chpl:1: note: is passed to formal 'b: int(64)'
+fail-many-candidates.chpl:4: note: this candidate did not match: foo(a: string, b: int)
+fail-many-candidates.chpl:16: note: because actual argument #1 with type 'int(64)'
+fail-many-candidates.chpl:4: note: is passed to formal 'a: string'
+fail-many-candidates.chpl:7: note: this candidate did not match: foo(a: string, b: string)
+fail-many-candidates.chpl:16: note: because actual argument #1 with type 'int(64)'
+fail-many-candidates.chpl:7: note: is passed to formal 'a: string'
+fail-many-candidates.chpl:10: note: this candidate did not match: foo(a: real, b: real)
+fail-many-candidates.chpl:16: note: because actual argument #2 with type 'string'
+fail-many-candidates.chpl:10: note: is passed to formal 'b: real(64)'

--- a/test/functions/resolution/errors/fail-many-candidates.describe.good
+++ b/test/functions/resolution/errors/fail-many-candidates.describe.good
@@ -1,0 +1,10 @@
+fail-many-candidates.chpl:16: error: unresolved call 'foo(1, "hello")'
+fail-many-candidates.chpl:13: note: this candidate did not match: foo(a, b)
+fail-many-candidates.chpl:13: note: because where clause evaluated to false
+fail-many-candidates.chpl:1: note: this candidate did not match: foo(a: int, b: int)
+fail-many-candidates.chpl:16: note: because actual argument #2 with type 'string'
+fail-many-candidates.chpl:1: note: is passed to formal 'b: int(64)'
+fail-many-candidates.chpl:4: note: this candidate did not match: foo(a: string, b: int)
+fail-many-candidates.chpl:16: note: because actual argument #1 with type 'int(64)'
+fail-many-candidates.chpl:4: note: is passed to formal 'a: string'
+note: there are also 2 other candidates, use --print-all-candidates to see them


### PR DESCRIPTION
In working on a Chapel program recently, I ran into a situation where I was having trouble seeing why a particular candidate didn't resolve for a call. Today, we describe the detailed reason for a call failure when printing the first candidate. But, the candidate I was expecting to match was a later candidate, and so the details weren't printed out. I worked around this issue by commenting out some of the other candidates.

This PR adds a flag, `--describe-candidates`, that asks the compiler to print the detailed reason for a call failure when printing any candidate.

- [ ] check if the name is good
- [ ] add to the chpl man page