### PR TITLE
Add checking that CHPL_UNWIND is a valid value

### DIFF
--- a/util/chplenv/chpl_unwind.py
+++ b/util/chplenv/chpl_unwind.py
@@ -12,7 +12,7 @@ def get():
     osx = platform_val.startswith('darwin')
     val = overrides.get('CHPL_UNWIND')
 
-    if val and val != 'none' and val != 'bundled' and val != 'system':
+    if val and val not in ('none', 'bundled', 'system'):
         error("Invalid CHPL_UNWIND value {0}\n"
               "Valid values are none, bundled, or system".format(val))
 

--- a/util/chplenv/chpl_unwind.py
+++ b/util/chplenv/chpl_unwind.py
@@ -12,6 +12,10 @@ def get():
     osx = platform_val.startswith('darwin')
     val = overrides.get('CHPL_UNWIND')
 
+    if val and val != 'none' and val != 'bundled' and val != 'system':
+        error("Invalid CHPL_UNWIND value {0}\n"
+              "Valid values are none, bundled, or system".format(val))
+
     if linux:
         if val == 'bundled':
             return 'bundled'


### PR DESCRIPTION
I recently was confused by `CHPL_UNWIND=libunwind` not seeming to work. It's because it should be `CHPL_UNWIND=bundled`. To make it easier to detect related problems in the future, this PR adds checking that `CHPL_UNWIND` is `none` `bundled` or `system` and otherwise emits an error in `printchplenv`.

Reviewed by @jabraham17 - thanks!

- [x] full comm=none testing