### PR TITLE
fix bad rpath in chapel-py when using --prefix installs

### DIFF
--- a/tools/chapel-py/setup.py
+++ b/tools/chapel-py/setup.py
@@ -47,6 +47,19 @@ host_cxx = str(chpl_variables.get("CHPL_HOST_CXX"))
 
 host_bin_subdir = str(chpl_variables.get("CHPL_HOST_BIN_SUBDIR"))
 chpl_lib_path = os.path.join(chpl_home, "lib", "compiler", host_bin_subdir)
+# For installations using --prefix, the build and final lib paths are going to
+#  differ figure out the install location now and write it to the rpath
+chpl_home_utils = os.path.join(
+    chpl_home, "util", "chplenv", "chpl_home_utils.py"
+)
+chpl_install_lib_path = (
+    subprocess.check_output(
+        ["python", chpl_home_utils, "--configured-install-lib-prefix"],
+    )
+    .decode(sys.stdout.encoding)
+    .strip()
+    .splitlines()
+)
 
 CXXFLAGS = []
 if have_llvm and have_llvm != "none":
@@ -67,6 +80,12 @@ LDFLAGS += [
     "-Wl,-rpath,{}".format(chpl_lib_path),
     "-lChplFrontendShared",
 ]
+
+if chpl_install_lib_path is not None:
+    LDFLAGS += [
+        "-L{}".format(chpl_install_lib_path),
+        "-Wl,-rpath,{}".format(chpl_install_lib_path),
+    ]
 
 if str(chpl_variables.get("CHPL_SANITIZE")) == "address":
     if str(chpl_variables.get("CHPL_HOST_PLATFORM")) == "darwin":

--- a/tools/chapel-py/setup.py
+++ b/tools/chapel-py/setup.py
@@ -58,7 +58,6 @@ chpl_install_lib_path = (
     )
     .decode(sys.stdout.encoding)
     .strip()
-    .splitlines()
 )
 
 CXXFLAGS = []
@@ -81,7 +80,7 @@ LDFLAGS += [
     "-lChplFrontendShared",
 ]
 
-if chpl_install_lib_path is not None:
+if chpl_install_lib_path != 'None':
     LDFLAGS += [
         "-L{}".format(chpl_install_lib_path),
         "-Wl,-rpath,{}".format(chpl_install_lib_path),

--- a/tools/chapel-py/setup.py
+++ b/tools/chapel-py/setup.py
@@ -80,7 +80,7 @@ LDFLAGS += [
     "-lChplFrontendShared",
 ]
 
-if chpl_install_lib_path != 'None':
+if chpl_install_lib_path != "None":
     LDFLAGS += [
         "-L{}".format(chpl_install_lib_path),
         "-Wl,-rpath,{}".format(chpl_install_lib_path),

--- a/util/chplenv/chpl_home_utils.py
+++ b/util/chplenv/chpl_home_utils.py
@@ -83,7 +83,8 @@ def get_chpl_configured_install_lib_prefix():
         chpl_prefix = None
         with open(os.path.join(chpl_home, "configured-prefix"), "r") as f:
             chpl_prefix = f.read().strip()
-        assert chpl_prefix is not None
+        # Problems with the configured-prefix file - maybe empty
+        assert chpl_prefix != "" and chpl_prefix is not None
         return os.path.join(
             chpl_prefix,
             "lib",
@@ -91,6 +92,7 @@ def get_chpl_configured_install_lib_prefix():
             chpl_version_string,
             "compiler",
         )
+    return None
 
 @memoize
 def get_chpl_version_from_install():


### PR DESCRIPTION
This fixes an issue where installing Chapel using `--prefix` would not encode the correct rpath in the shared library that was created for python. The change here looks for the presence of a `configured-prefix` file in the build tree and uses that and the chapel version from `CMakeLists.txt` to encode the proper rpath based on the installation destination.

[reviewed by @jabraham17 and @bonachea - thanks!]