### PR TITLE
Add missing argument to execopts

### DIFF
--- a/test/performance/memory/microMemoryAllocation.execopts
+++ b/test/performance/memory/microMemoryAllocation.execopts
@@ -1,1 +1,1 @@
---trials=10
+--trials=10 --printTime=false


### PR DESCRIPTION
Adds a missing argument to an execopts file

[Not reviewed - trivial]