### PR TITLE
Adjust test-docker release branch check for Jenkins quirk

### DIFF
--- a/util/cron/test-docker.bash
+++ b/util/cron/test-docker.bash
@@ -127,7 +127,7 @@ if [ -n "$RELEASE_VERSION" ]
 then
   log_info "Building and pushing nightly and release-tagged images for version: $RELEASE_VERSION"
   release_branch="release/$RELEASE_VERSION"
-  if [ "$(git rev-parse --abbrev-ref HEAD)" != "$release_branch" ]
+  if [ "$(git rev-parse HEAD)" != "$(git rev-parse $release_branch)" ]
   then
     log_error "Not on expected release branch $release_branch for version $RELEASE_VERSION, aborting"
     exit 1


### PR DESCRIPTION
Fix the check in `util/cron/test-docker.bash` that ensures we're working from the desired release branch when in release mode.

When run in the Jenkins job, this check failed despite having the correct revision checked out. This is because for some reason Jenkins (or the SCM plugin we use, or JJB, not sure) takes the branch you ask to check out, manually dereferences it to the commit it points to, and then checks out that commit by SHA. So `HEAD` points to a SHA rather than the branch name, and `git rev-parse --abbrev-ref HEAD` just returns `HEAD`.

Fixed by comparing the SHA of `HEAD` against the SHA of the desired branch directly.

[trivial, not reviewed]

Testing:
- [x] manual run of `test-docker.bash` in release mode