### PR TITLE
Remove some logic in docs builds related to Google Analytics

### DIFF
--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -226,9 +226,6 @@ if not on_rtd:
         'sticky_navigation': True,
     }
 
-    analytics_id = os.environ.get('CHPLDOC_ANALYTICS_ID')
-    if analytics_id:
-        html_theme_options['analytics_id'] = analytics_id
 
 
 # Theme options are theme-specific and customize the look and feel of a theme

--- a/third-party/chpl-venv/chpldoc-sphinx-project/source/conf.py
+++ b/third-party/chpl-venv/chpldoc-sphinx-project/source/conf.py
@@ -120,9 +120,6 @@ if not on_rtd:
         'sticky_navigation': True,
     }
 
-    analytics_id = os.environ.get('CHPLDOC_ANALYTICS_ID')
-    if analytics_id:
-        html_theme_options['analytics_id'] = analytics_id
 
 
 # Theme options are theme-specific and customize the look and feel of a theme


### PR DESCRIPTION
It isn't clear to me that this logic is actually being used for anything today (building a version of docs without these lines and diffing against other recent docs didn't _seem_ to show any related differences), but I feel better not having this logic in here anyway given that we're not using Google Analytics anymore and don't want to be using cookies.
