### PR TITLE
Fix whitespace for tests for chplenv warnings

### DIFF
--- a/test/chplenv/chplconfig/warnings/notfound.chpl
+++ b/test/chplenv/chplconfig/warnings/notfound.chpl
@@ -6,6 +6,4 @@
 
  */
 
-writeln("\
-Warning: No chplconfig or .chplconfig file is found in the defined $CHPL_CONFIG\
-");
+writeln("\n\nWarning: No chplconfig or .chplconfig file is found in the defined $CHPL_CONFIG");

--- a/test/chplenv/chplconfig/warnings/warnings.chpl
+++ b/test/chplenv/chplconfig/warnings/warnings.chpl
@@ -8,7 +8,7 @@
 
 
 
-writeln("\
+writeln("\n\
 Warning: Syntax Error: $CHPL_CONFIG/chplconfig:line 8\
               > CHPL_TASKS == fifo\
               Expected format is:\
@@ -18,4 +18,4 @@ Warning: Syntax Error: $CHPL_CONFIG/chplconfig:line 9\
               Expected format is:\
               > CHPL_VAR = VALUE\
 Warning: $CHPL_CONFIG/chplconfig:line 16: \"CHPL_COMMS\" is not an acceptable variable\
-Warning: $CHPL_CONFIG/chplconfig:line 20: Duplicate entry of \"CHPL_COMM\"\n");
+Warning: $CHPL_CONFIG/chplconfig:line 20: Duplicate entry of \"CHPL_COMM\"");


### PR DESCRIPTION
Fixes the whitespace for some tests which changed due to a change in how warnings are printed

[Not Reviewed - trivial]