### PR TITLE
Always remove docker image before new build

### DIFF
--- a/util/cron/test-docker.bash
+++ b/util/cron/test-docker.bash
@@ -54,10 +54,7 @@ update_image() {
   log_info "Starting $imageName..."
 
   # Remove any existing image with the tag before building
-  if [ -n "$release_tag" ]
-  then
-    docker image rm --force "$imageName"
-  fi
+  docker image rm --force "$imageName"
 
   # Build and push image
   # Note: We push before testing due to a limitation of Docker


### PR DESCRIPTION
I noticed in a recent run of the `test-docker` job that it was clearly testing an old copy of the image; `chpl --version` said `2.3 pre-release`, though main is at `2.4 pre-release` now. I don't know why that image is getting picked for testing when a newer one with the same tag has just been built.

Try to fix this by always removing the image explicitly before building the new one, rather than relying on it being overwritten. Previously this was guarded to happen only for release build, but will now happen for nightly build as well.

[trivial fix attempt, not reviewed]