### PR TITLE
Fix spurious pathchk error output from configure

### DIFF
--- a/configure
+++ b/configure
@@ -83,7 +83,7 @@ CONFIGURED=""
 if [ "$DEST_DIR_SET" -ne 0 ]
 then
   case $DEST_DIR in 
-    (/*) pathchk "$DEST_DIR" || exit -1 ;;
+    (/*) pathchk "$DEST_DIR" || { echo "error: invalid directory name for --chpl-home: $DEST_DIR"; exit -1; };;
     (*) 
     echo "error: expected an absolute directory name for --chpl-home: $DEST_DIR"
     exit -1
@@ -94,7 +94,7 @@ then
   CONFIGURED=configured-chpl-home
 else
   case $PREFIX in 
-    (/*) pathchk "$PREFIX" || exit -1 ;;
+    (/*) pathchk "$PREFIX" || { echo "error: invalid directory name for --prefix: $PREFIX"; exit -1; };;
     (*) 
     echo "error: expected an absolute directory name for --prefix: $PREFIX"
     exit -1

--- a/configure
+++ b/configure
@@ -83,7 +83,7 @@ CONFIGURED=""
 if [ "$DEST_DIR_SET" -ne 0 ]
 then
   case $DEST_DIR in 
-    (/*) pathchk -- "$1";; 
+    (/*) pathchk "$DEST_DIR" || exit -1 ;;
     (*) 
     echo "error: expected an absolute directory name for --chpl-home: $DEST_DIR"
     exit -1
@@ -94,7 +94,7 @@ then
   CONFIGURED=configured-chpl-home
 else
   case $PREFIX in 
-    (/*) pathchk -- "$1";; 
+    (/*) pathchk "$PREFIX" || exit -1 ;;
     (*) 
     echo "error: expected an absolute directory name for --prefix: $PREFIX"
     exit -1


### PR DESCRIPTION
Currently every Chapel `configure` I run on Linux (regardless of whether or not I pass `--prefix` or `--chpl-home`) prints the following spurious error to the console as the first line of output:

```
pathchk: '': No such file or directory
```

This spurious output appears to be a completely harmless/cosmetic defect. However given that it occurs so early in the build it also means that every time a Spack build of Chapel fails this spurious line of output gets printed as the first detected error in Spack's error summary, which is unfortunate because it's completely a "red herring".

Source inspection reveals the scripting here appears to be Just Plain Wrong: there's a `pathchk` command that is being passed garbage and doesn't accomplish its apparent intended purpose of validating the PREFIX/DEST_DIR.


This commit fixes the scripting defect to remove the spurious error output and actually validate PREFIX/DEST_DIR. 