### PR TITLE
Add a copy of binarytrees5.chpl to our submitted directory

### DIFF
--- a/test/studies/shootout/submitted/binarytrees-submitted.graph
+++ b/test/studies/shootout/submitted/binarytrees-submitted.graph
@@ -1,5 +1,5 @@
-perfkeys: real, real, real
-graphkeys: release, submitted (3), submitted (4)
-files: binarytrees.dat, binarytrees-submitted.dat, binarytrees4.dat
+perfkeys: real, real, real, real
+graphkeys: release, submitted (3), submitted (4), submitted (5)
+files: binarytrees.dat, binarytrees-submitted.dat, binarytrees4.dat, binarytrees5.dat
 graphtitle: Submitted Binary Trees Shootout Benchmark (n=21)
 ylabel: Time (seconds)

--- a/test/studies/shootout/submitted/binarytrees5.chpl
+++ b/test/studies/shootout/submitted/binarytrees5.chpl
@@ -1,0 +1,96 @@
+/* The Computer Language Benchmarks Game
+   https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
+
+   contributed by Jade Abraham
+   based on the Chapel #3 version by Casey Battaglino, Ben Harshbarger, and
+     Brad Chamberlain
+*/
+
+use Allocators, Math;
+
+config const n = 10;                         // the maximum tree depth
+
+proc main() {
+  const minDepth = 4,                        // the shallowest tree
+        maxDepth = max(minDepth + 2, n),     // the deepest normal tree
+        strDepth = maxDepth + 1,             // the depth of the "stretch" tree
+        depths = minDepth..maxDepth by 2,    // the range of depths to create
+        nodeSize = 24;                       // the size of a node
+  var stats: [depths] (int,int);             // stores statistics for the trees
+
+  inline proc poolSize(depth, num=1) do return num*2**(depth+1)*nodeSize;
+
+  //
+  // Create the short-lived "stretch" tree, checksum it, and print its stats.
+  //
+  {
+    const pool = new bumpPtrMemPool(poolSize(strDepth), alignment=0),
+          strTree = newWithAllocator(pool, unmanaged Tree, strDepth, pool);
+    writeln("stretch tree of depth ", strDepth, "\t check: ", strTree.sum());
+  }
+
+  //
+  // Build the long-lived tree.
+  //
+  const pool = new bumpPtrMemPool(poolSize(maxDepth), alignment=0),
+        llTree = newWithAllocator(pool, unmanaged Tree, maxDepth, pool);
+
+  //
+  // Iterate over the depths. At each depth, create the required trees in
+  // parallel, compute their sums, and free them.
+  //
+  for depth in depths {
+    const iterations = 2**(maxDepth - depth + minDepth),
+          ps = poolSize(depth, divCeilPos(iterations, here.maxTaskPar));
+    var sum = 0;
+
+    forall 1..iterations
+      with (+ reduce sum,
+            var pool = new bumpPtrMemPool(ps, alignment=0)) {
+      const t = newWithAllocator(pool, unmanaged Tree, depth, pool);
+      sum += t.sum();
+    }
+    stats[depth] = (iterations, sum);
+  }
+
+  //
+  // Print out the stats for the trees of varying depths.
+  //
+  for (depth, (numTrees, checksum)) in zip(depths, stats) do
+    writeln(numTrees, "\t trees of depth ", depth, "\t check: ", checksum);
+
+  //
+  // Checksum the long-lived tree, print its stats, and free it.
+  //
+  writeln("long lived tree of depth ", maxDepth, "\t check: ", llTree.sum());
+}
+
+
+//
+// A simple balanced tree node class
+//
+class Tree {
+  var left, right: unmanaged Tree?;
+
+  //
+  // A Tree-building initializer
+  //
+  proc init(depth, pool) {
+    if depth > 0 {
+      const d = depth - 1;
+      left  = newWithAllocator(pool, unmanaged Tree, d, pool);
+      right = newWithAllocator(pool, unmanaged Tree, d, pool);
+    }
+  }
+
+  //
+  // Add up tree node, freeing as we go
+  //
+  proc sum(): int {
+    var sum = 1;
+    if left {
+      sum += left!.sum() + right!.sum();
+    }
+    return sum;
+  }
+}

--- a/test/studies/shootout/submitted/binarytrees5.good
+++ b/test/studies/shootout/submitted/binarytrees5.good
@@ -1,0 +1,1 @@
+binarytrees3.good

--- a/test/studies/shootout/submitted/binarytrees5.perfexecopts
+++ b/test/studies/shootout/submitted/binarytrees5.perfexecopts
@@ -1,0 +1,1 @@
+--n=21 # binarytrees5

--- a/test/studies/shootout/submitted/binarytrees5.perfkeys
+++ b/test/studies/shootout/submitted/binarytrees5.perfkeys
@@ -1,0 +1,1 @@
+binarytrees3.perfkeys


### PR DESCRIPTION
This belatedly adds a copy of the binarytrees5.chpl benchmark that Jade submitted after the 2.2 release to our submitted directory to track its performance going forward.