### PR TITLE
fix homebrew-linux test that encountered merge conflict

### DIFF
--- a/util/packaging/docker/test/Dockerfile
+++ b/util/packaging/docker/test/Dockerfile
@@ -15,6 +15,10 @@ RUN mkdir -p /home/linuxbrew
 # RUN sudo apt-get install -y vim
 # ENV EDITOR=vim
 
+# Do the updates before applying our chapel.rb changes
+RUN brew upgrade
+RUN brew update
+
 # necessary so that updated chapel.rb formula can be committed, which is only way it
 # will be tested
 RUN git config --global user.name "Chapel Tester"

--- a/util/packaging/docker/test/Dockerfile
+++ b/util/packaging/docker/test/Dockerfile
@@ -16,8 +16,11 @@ RUN mkdir -p /home/linuxbrew
 # ENV EDITOR=vim
 
 # Do the updates before applying our chapel.rb changes
-RUN brew upgrade
+# Update Homebrew itself
 RUN brew update
+# Upgrade to the latest version of all installed formulae
+RUN brew upgrade
+
 
 # necessary so that updated chapel.rb formula can be committed, which is only way it
 # will be tested

--- a/util/packaging/docker/test/brew_install.bash
+++ b/util/packaging/docker/test/brew_install.bash
@@ -3,8 +3,6 @@
 export HOMEBREW_NO_INSTALL_FROM_API=1
 # Might not be needed, but also doesn't hurt and matches homebrew CI
 export HOMEBREW_NO_AUTO_UPDATE=1
-#Update homebrew
-brew update
 
 #Script used in docker exec command to test homebrew formula
 # brew test-bot --only-tap-syntax
@@ -15,30 +13,30 @@ brew update
 #       echo "brew test-bot --only-tap-syntax succeeded"
 # fi
 
-# # tests commands
-# brew test-bot --only-cleanup-before
-# if [ $? -ne 0 ]; then
-#       echo "brew test-bot --only-cleanup-before failed"
-#       exit 1
-# else
-#       echo "brew test-bot --only-cleanup-before succeeded"
-# fi
+# tests commands
+brew test-bot --only-cleanup-before
+if [ $? -ne 0 ]; then
+      echo "brew test-bot --only-cleanup-before failed"
+      exit 1
+else
+      echo "brew test-bot --only-cleanup-before succeeded"
+fi
 
-# brew test-bot --only-setup
-#     if [ $? -ne 0 ]; then
-#       echo "brew test-bot --only-setup failed"
-#       exit 1
-#       else
-#       echo "brew test-bot --only-setup succeeded"
-#     fi
+brew test-bot --only-setup
+    if [ $? -ne 0 ]; then
+      echo "brew test-bot --only-setup failed"
+      exit 1
+      else
+      echo "brew test-bot --only-setup succeeded"
+    fi
 
-# brew test-bot --only-formulae-dependents --junit --testing-formulae=chapel --skipped-or-failed-formulae=chapel
-# if [ $? -ne 0 ]; then
-#       echo "brew test-bot --only-formulae-dependents --junit --testing-formulae=chapel --skipped-or-failed-formulae=chapel failed"
-#       exit 1
-# else
-#       echo "brew test-bot --only-formulae-dependents --junit --testing-formulae=chapel --skipped-or-failed-formulae=chapel succeeded"
-# fi
+brew test-bot --only-formulae-dependents --junit --testing-formulae=chapel --skipped-or-failed-formulae=chapel
+if [ $? -ne 0 ]; then
+      echo "brew test-bot --only-formulae-dependents --junit --testing-formulae=chapel --skipped-or-failed-formulae=chapel failed"
+      exit 1
+else
+      echo "brew test-bot --only-formulae-dependents --junit --testing-formulae=chapel --skipped-or-failed-formulae=chapel succeeded"
+fi
 
 # This is the bulk of the testing and the same command that Homebrew CI runs
 brew test-bot  --skip-online-checks --only-formulae --junit --only-json-tab --skip-dependents --testing-formulae="chapel" --added-formulae="" --deleted-formulae=""

--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -78,7 +78,6 @@ class Chapel < Formula
       rm_r("third-party/llvm/llvm-src/")
       rm_r("third-party/gasnet/gasnet-src/")
       rm_r("third-party/libfabric/libfabric-src/")
-      rm_r("third-party/fltk/fltk-1.3.8-source.tar.gz")
       rm_r("third-party/libunwind/libunwind-src/")
       rm_r("third-party/gmp/gmp-src/")
       rm_r("third-party/qthread/qthread-src/")


### PR DESCRIPTION
This fixes the `homebrew-linux` testing that was broken by a merge conflict when applying the copy of `chapel-main.rb` to the repo for testing. The solution was to change the order of operations so the repo is updated before our new file is copied in. 

Other changes include re-enabling more brew test-bot commands and removing the deletion of the `fltk` sources as they were removed from our third-party directory recently.

TESTING:

- [x] local linux-x86 testing
- [x] local mac-arm testing

[reviewed by @riftEmber - thanks!]