### PR TITLE
Add unstable `extractMatches` overload that returns a value

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -12379,7 +12379,11 @@ proc fileReader._extractMatch(m:regexMatch, ref arg:?t, ref error:errorCode)
       }
     }
     else {
-      arg = s:arg.type;
+      try {
+        arg = s:arg.type;
+      } catch {
+        error = EFORMAT;
+      }
     }
   } else {
     var empty:arg.type;
@@ -12411,6 +12415,25 @@ proc fileReader.extractMatch(m:regexMatch, ref arg) throws {
     try this._ch_ioerror(err, "in fileReader.extractMatch(m:regexMatch, ref " +
                               arg.type:string + ")");
   }
+}
+
+/*  Returns the value of a match
+
+    Assumes that the :record:`~IO.fileReader` has been marked before where
+    the captures are being returned. Will change the fileReader
+    offset to just after the match. Will not do anything
+    if error is set.
+
+    :arg m: a :record:`Regex.regexMatch` storing a location that matched
+    :arg t: the type of the value to return, defaults to string
+
+    :throws SystemError: If a match could not be extracted.
+ */
+@unstable("this overload of extractMatch is unstable pending a design discussion")
+proc fileReader.extractMatch(m: regexMatch, type t = string): t throws {
+  var arg:t;
+  try this.extractMatch(m, arg);
+  return arg;
 }
 
 // Assumes that the fileReader has been marked where the search began

--- a/test/regex/ferguson/extractMatches.chpl
+++ b/test/regex/ferguson/extractMatches.chpl
@@ -1,0 +1,72 @@
+use Regex;
+use IO;
+
+
+var contents = "X1X2   X3 X4";
+writeln(contents);
+var f = openMemFile();
+{
+  var w = f.writer(locking=false);
+  w.write(contents);
+  w.close();
+}
+
+{
+  writeln("get string");
+  var r = f.reader(locking=false);
+  var re = new regex("X(\\d)");
+  for m in r.matches(re, 1) {
+    var e: string;
+    r.extractMatch(m(1), e);
+    writeln("get ", e, " ", e.type:string);
+  }
+}
+
+{
+  writeln("get int");
+  var r = f.reader(locking=false);
+  var re = new regex("X(\\d)");
+  for m in r.matches(re, 1) {
+    var e: int;
+    r.extractMatch(m(1), e);
+    writeln("get ", e, " ", e.type:string);
+  }
+}
+
+{
+  writeln("get string returned");
+  var r = f.reader(locking=false);
+  var re = new regex("X(\\d)");
+  for m in r.matches(re, 1) {
+    var e = r.extractMatch(m(1));
+    writeln("get ", e, " ", e.type:string);
+  }
+}
+
+{
+  writeln("get int returned");
+  var r = f.reader(locking=false);
+  var re = new regex("X(\\d)");
+  for m in r.matches(re, 1) {
+    var e = r.extractMatch(m(1), int);
+    writeln("get ", e, " ", e.type:string);
+  }
+}
+
+
+{
+  writeln("get wrong type");
+  var r = f.reader(locking=false);
+  var re = new regex("X(\\d)");
+  try {
+    for m in r.matches(re) {
+      var e = r.extractMatch(m(0), int);
+      writeln("get ", e, " ", e.type:string);
+    }
+    writeln("should have thrown already");
+  } catch e: BadFormatError {
+    writeln("correctly caught bad format error");
+  } catch {
+    writeln("unknown error was thrown");
+  }
+}

--- a/test/regex/ferguson/extractMatches.compopts
+++ b/test/regex/ferguson/extractMatches.compopts
@@ -1,0 +1,1 @@
+--warn-unstable

--- a/test/regex/ferguson/extractMatches.good
+++ b/test/regex/ferguson/extractMatches.good
@@ -1,0 +1,26 @@
+extractMatches.chpl:41: warning: this overload of extractMatch is unstable pending a design discussion
+extractMatches.chpl:51: warning: this overload of extractMatch is unstable pending a design discussion
+extractMatches.chpl:63: warning: this overload of extractMatch is unstable pending a design discussion
+X1X2   X3 X4
+get string
+get 1 string
+get 2 string
+get 3 string
+get 4 string
+get int
+get 1 int(64)
+get 2 int(64)
+get 3 int(64)
+get 4 int(64)
+get string returned
+get 1 string
+get 2 string
+get 3 string
+get 4 string
+get int returned
+get 1 int(64)
+get 2 int(64)
+get 3 int(64)
+get 4 int(64)
+get wrong type
+correctly caught bad format error


### PR DESCRIPTION
Adds an overload of `fileReader.extractMatches` that returns a value, instead of modifying a ref argument. This new overload is unstable, pending a design discussion about it.

This PR also fixes a bug where trying to extract a non-string/bytes value from a match would not compile.

Testing
- [x] full paratest with/without comm

[Reviewed by @ShreyasKhandekar]