### PR TITLE
Make Python interop module more resilient to different python environments

### DIFF
--- a/modules/packages/Python.chpl
+++ b/modules/packages/Python.chpl
@@ -270,13 +270,6 @@ module Python {
       PyConfig_InitIsolatedConfig(cfgPtr);
       defer PyConfig_Clear(cfgPtr);
 
-      // set program name
-      const wideChapel = "chapel".c_wstr();
-      checkPyStatus(
-        PyConfig_SetString(
-          cfgPtr, c_ptrTo(config_.program_name), wideChapel));
-      deallocate(wideChapel);
-
       // check VIRTUAL_ENV, if its set, make it the executable
       var venv = getenv("VIRTUAL_ENV".c_str());
       if venv != nil {


### PR DESCRIPTION
Fixes an issue where in the Python interop module that causes `PYTHONHOME` to be set in some python virtual environments. This would prevent any code using the Python module from running.

This code was intended to make for nicer error messages from the python interpreter, but it did not achieve that goal (so the code was mostly useless) and it messed up some python environments (i.e. conda), so it should be removed.

[Reviewed by @ShreyasKhandekar]