### PR TITLE
Fix not-equals in `compositeTypeContentsMatchInner`

### DIFF
--- a/frontend/include/chpl/types/CompositeType.h
+++ b/frontend/include/chpl/types/CompositeType.h
@@ -126,7 +126,7 @@ class CompositeType : public Type {
 
   bool compositeTypeContentsMatchInner(const CompositeType* other) const {
     return id_ == other->id_ &&
-           name_ != other->name_ &&
+           name_ == other->name_ &&
            instantiatedFrom_ == other->instantiatedFrom_ &&
            subs_ == other->subs_;
   }


### PR DESCRIPTION
Fix an almost certainly not intended not-equals comparison of `name`s in `compositeTypeContentsMatchInner`.

Introduced in https://github.com/chapel-lang/chapel/pull/19109.

Noticed by @DanilaFe .

[trivial, not reviewed]

Testing:
- [x] paratest
- [x] dyno tests