### PR TITLE
Don't check base commit in large files check

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -157,6 +157,10 @@ jobs:
           # latest.
           for commit in $(git rev-list $baseSHA..$headSHA)
           do
+            if [ "$commit" = "$baseSHA" ]; then
+              break
+            fi
+
             echo "Checking commit: $commit"
             git checkout -q $commit
 


### PR DESCRIPTION
Prevent the new-large-files check from checking the commit being merged into, which caused an error when trying to retrieve its parent.

Follow up to https://github.com/chapel-lang/chapel/pull/26371.

[trivial fix, not reviewed]