### PR TITLE
Fix `--help` and man page output for `--target-mem`

### DIFF
--- a/man/chpl.rst
+++ b/man/chpl.rst
@@ -977,13 +977,14 @@ doc/rst/usingchapel/chplenv.rst in your Chapel installation.
     overrides the $CHPL\_MAKE environment variable (defaults to a best guess
     based on $CHPL\_HOST\_PLATFORM).
 
+.. _man-target-mem:
 .. _man-mem:
 
-**\--mem <mem-impl>**
+**\--target-mem <mem-impl>**
 
     Specify the memory allocator used for dynamic memory management. This
-    flag corresponds with and overrides the $CHPL\_MEM environment variable
-    (defaults to a best guess based on $CHPL\_COMM).
+    flag corresponds with and overrides the $CHPL\_TARGET\_MEM environment
+    variable (defaults to a best guess based on $CHPL\_COMM).
 
 .. _man-re2:
 

--- a/test/compflags/bradc/help/userhelp.good
+++ b/test/compflags/bradc/help/userhelp.good
@@ -203,7 +203,7 @@ Compiler Configuration Options:
                                       position-independent code
       --locale-model <locale-model>   Specify locale model to use
       --make <make utility>           Make utility for generated code
-      --mem <mem-impl>                Specify the memory manager
+      --target-mem <mem-impl>         Specify the memory manager
       --re2 <re2-version>             Specify RE2 library
       --target-arch <architecture>    Target architecture / machine type
       --target-compiler <compiler>    Compiler for generated code

--- a/util/chpl-completion.bash
+++ b/util/chpl-completion.bash
@@ -169,7 +169,6 @@ _chpl ()
 --main-module \
 --make \
 --max-c-ident-len \
---mem \
 --memory-frees \
 --minimal-modules \
 --mllvm \
@@ -397,6 +396,7 @@ _chpl ()
 --target-arch \
 --target-compiler \
 --target-cpu \
+--target-mem \
 --target-platform \
 --task-tracking \
 --tasks \
@@ -501,7 +501,6 @@ _chpl ()
 --main-module \
 --make \
 --max-c-ident-len \
---mem \
 --mllvm \
 --module-dir \
 --munge-user-idents \
@@ -611,6 +610,7 @@ _chpl ()
 --target-arch \
 --target-compiler \
 --target-cpu \
+--target-mem \
 --target-platform \
 --task-tracking \
 --tasks \


### PR DESCRIPTION
Fixes the `--help` and man page output after changing `--mem` to `--target-mem`

[Reviewed by @jhh67]