### PR TITLE
Handle PRs not based off recent main in large files check

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -153,14 +153,15 @@ jobs:
           baseSHA=${{github.event.pull_request.base.sha}}
           headSHA=${{github.event.pull_request.head.sha}}
 
+          echo "Base SHA: $baseSHA"
+          echo "Head SHA: $headSHA"
+          echo "${{github.event.pull_request.commits}} commits in PR"
+
           # Loop backward through commits added in the PR, starting from the
           # latest.
+          commitIdx=0
           for commit in $(git rev-list $baseSHA..$headSHA)
           do
-            if [ "$commit" = "$baseSHA" ]; then
-              break
-            fi
-
             echo "Checking commit: $commit"
             git checkout -q $commit
 
@@ -180,4 +181,11 @@ jobs:
                 exit 1
               fi
             done <<< "$newFiles"
+
+            # Stop after going through the number of commits this PR has.
+            commitIdx=$((commitIdx+1))
+            if [ "$commitIdx" =  "${{github.event.pull_request.commits}}" ]; then
+              echo "Stopping after $commitIdx commits, on commit $commit"
+              break
+            fi
           done


### PR DESCRIPTION
Previously failed due to trying to go all the way back to what Github calls the "base" SHA, which turns out is what we'll merge on top of rather than the parent of the first commit in the PR.

Follow up to https://github.com/chapel-lang/chapel/pull/26371.

[trivial fix, not reviewed]