### PR TITLE
Fix internal error when erroneously writing `super.init` twice

### DIFF
--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -513,7 +513,10 @@ static InitNormalize preNormalize(AggregateType* at,
         } else if (isSuperInit(callExpr) == true) {
           Expr* next = callExpr->next;
 
-          INT_ASSERT(state.isPhase0() == true);
+          if (state.isPhase0() != true) {
+            USR_FATAL(callExpr,
+                       "duplicate use of 'super.init()' in initializer, this should only be called once");
+          }
           state.completePhase0(callExpr);
 
           if (at->isRecord() == true) {

--- a/test/classes/initializers/inheritance/duplicate-super-init.chpl
+++ b/test/classes/initializers/inheritance/duplicate-super-init.chpl
@@ -1,0 +1,11 @@
+class P { }
+class C: P {
+  proc init() {
+    super.init();
+    super.init();
+  }
+}
+
+proc main() {
+  var c = new C();
+}

--- a/test/classes/initializers/inheritance/duplicate-super-init.good
+++ b/test/classes/initializers/inheritance/duplicate-super-init.good
@@ -1,0 +1,2 @@
+duplicate-super-init.chpl:3: In initializer:
+duplicate-super-init.chpl:5: error: duplicate use of 'super.init()' in initializer, this should only be called once


### PR DESCRIPTION
Fixes an internal error when `super.init()` appears twice in a initializer and replaces it with a nicer error

Testing
- [x] paratest with/without gasnet

[Reviewed by @lydia-duncan]