### PR TITLE
Fix typo in chpl-language-server debug output

### DIFF
--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -172,7 +172,7 @@ class ChplcheckProxy:
 
         def error(msg: str):
             if os.environ.get("CHPL_DEVELOPER", None):
-                print("Error loading chplcheck: ", str(e), file=sys.stderr)
+                print("Error loading chplcheck: ", str(msg), file=sys.stderr)
 
         chpl_home = os.environ.get("CHPL_HOME")
         if chpl_home is None:


### PR DESCRIPTION
Fixes a typo in the error reporting for `chpl-language-server` when `CHPL_DEVELOPER` is set

[Not reviewed - trivial]