### PR TITLE
Fix issues with using a non-default system LLVM with CHPL_LLVM_CONFIG

### DIFF
--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -1103,7 +1103,7 @@ def get_system_include_directories(flag, lang):
         lines = stdout.splitlines()
         start_includes_regex = re.compile(r"#include.+search starts here")
         end_includes_regex = re.compile(r"End of search list")
-        ignoring_regex = re.compile(r"ignoring nonexistent")
+        ignoring_regex = re.compile(r"(?:ignoring nonexistent)|(?:as it is a non-system)")
         collecting = False
         for line in lines:
             if start_includes_regex.search(line):

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -1147,12 +1147,12 @@ def filter_llvm_config_flags(llvm_val, flags):
             flag == '-std=c++14'):
             continue # filter out these flags
 
+        #
         # include LLVM headers as system headers using -isystem
         # this avoids warnings inside of LLVM headers by treating LLVM headers
         #
-        # With LLVM=system, also add the include as -I. This preserves the
-        # directory search order if the directory is already a system include
-        # see https://gcc.gnu.org/onlinedocs/gcc/Directory-Options.html
+        # If the header is already a system header, using -isystem will break
+        # the include search. In that case, just use -I (which technically wont do anythings)
         #
         if flag.startswith('-I'):
             directory = flag[2:]


### PR DESCRIPTION
Fixes compiler build issues when using a system LLVM that is different than the standard LLVM. For example, an LLVM installed at `/usr/` would conflict with an LLVM installed at `/home/user/llvm-install` (which was accessed by `CHPL_LLVM_CONFIG=/home/user/llvm-install`)

Subsumes https://github.com/chapel-lang/chapel/pull/26212 and https://github.com/chapel-lang/chapel/pull/26402

Previous work had tried to take advantage of various clang/gcc flags to achieve the right behavior, however this not working in all cases. This PR does following.

1. computes the existing search paths for the compiler
2. for each LLVM include directory specified as `-I`
  - In a bundled LLVM build: always use '-isystem'
  - In a system LLVM build: use '-isystem' if its not an existing search path, otherwise use '-I'

Testing
- [x] `make check` with HOST_CC=clang, LLVM=system
- [x] `make check` with HOST_CC=clang, LLVM=bundled
- [x] `make check` with HOST_CC=clang, LLVM=system, LLVM_CONFIG=/some/path, with/without a normal system LLVM
- [x] `make check` with HOST_CC=gnu, LLVM=system
- [x] `make check` with HOST_CC=gnu, LLVM=bundled
- [x] `make check` with HOST_CC=gnu, LLVM=system, LLVM_CONFIG=/some/path, with/without a normal system LLVM
- [x] Sanity check that normal compilations on Mac are not broken

[Reviewed by @mppf]