### PR TITLE
Turn on `-buildcheck` for gpus in nightly tests

### DIFF
--- a/util/cron/common-native-gpu-perf.bash
+++ b/util/cron/common-native-gpu-perf.bash
@@ -5,4 +5,4 @@
 # set this before sourcing common-perf
 export CHPL_TEST_PERF_SUBDIR='gpu'
 
-nightly_args="${nightly_args} -performance -perflabel gpu- -numtrials 5"
+nightly_args="${nightly_args} -no-buildcheck -performance -perflabel gpu- -numtrials 5"

--- a/util/cron/common-native-gpu.bash
+++ b/util/cron/common-native-gpu.bash
@@ -12,4 +12,3 @@ export CHPL_TEST_GPU=true
 export CHPL_NIGHTLY_TEST_DIRS="gpu/native users/engin/context release/examples"
 
 unset CHPL_START_TEST_ARGS
-nightly_args="${nightly_args} -no-buildcheck"


### PR DESCRIPTION
Removes the `-no-buildcheck` in all GPU configs. This is an artifact from when `make check` did not support GPUs, but now it does and we want to test that.

This PR does maintain `-no-buildcheck` in the GPU perf configs, this matches what we do for other perf configs.

[Reviewed by @]