### PR TITLE
Try an older version of GCC on CHAMPS testing

### DIFF
--- a/util/cron/common-champs.bash
+++ b/util/cron/common-champs.bash
@@ -32,6 +32,8 @@ module load cray-pmi
 module load cray-mpich
 module load cray-hdf5-parallel
 
+module load gcc-native/10.3
+
 module list
 
 # note that this part is similar to common-hpe-apollo.bash, but


### PR DESCRIPTION
This PR is an attempt to fix spreading OOM errors with CHAMPS using the C backend.