### PR TITLE
Fix location reporting for lint rules on a AstNode with a name

### DIFF
--- a/test/chplcheck/UseNameLocations.chpl
+++ b/test/chplcheck/UseNameLocations.chpl
@@ -1,0 +1,18 @@
+module UseNameLocations {
+  /*
+    This test is to make sure name locations are used instead of normal
+    locations when reporting
+  */
+
+  proc
+  my_func
+  () {}
+
+  record
+  my_rec
+  {}
+
+  class
+  my_class
+  {}
+}

--- a/test/chplcheck/UseNameLocations.good
+++ b/test/chplcheck/UseNameLocations.good
@@ -1,0 +1,3 @@
+UseNameLocations.chpl:8: node violates rule CamelCaseFunctions
+UseNameLocations.chpl:12: node violates rule CamelCaseRecords
+UseNameLocations.chpl:16: node violates rule PascalCaseClasses

--- a/tools/chplcheck/src/lsp.py
+++ b/tools/chplcheck/src/lsp.py
@@ -36,14 +36,6 @@ from fixits import Fixit, Edit
 from driver import LintDriver
 
 
-def _get_location(node: chapel.AstNode):
-    """Helper to get the location of a node"""
-    if isinstance(node, chapel.NamedDecl):
-        return chapel.lsp.location_to_range(node.name_location())
-    else:
-        return chapel.lsp.location_to_range(node.location())
-
-
 def get_lint_diagnostics(
     context: chapel.Context, driver: LintDriver, asts: List[chapel.AstNode]
 ) -> List[Diagnostic]:

--- a/tools/chplcheck/src/rule_types.py
+++ b/tools/chplcheck/src/rule_types.py
@@ -40,6 +40,14 @@ def _build_ignore_fixit(
     return ignore
 
 
+def _get_location(node: chapel.AstNode):
+    """Helper to get the location of a node"""
+    if isinstance(node, chapel.NamedDecl):
+        return node.name_location()
+    else:
+        return node.location()
+
+
 @dataclass
 class RuleLocation:
     path_: str
@@ -332,7 +340,7 @@ class BasicRule(Rule[BasicRuleResult]):
         # addition to the fixits in the result itself)
         # add the fixits from the hooks to the fixits from the rule
         fixits = self.run_fixit_hooks(context, result) + fixits
-        loc = RuleLocation.from_chapel(result.node.location())
+        loc = RuleLocation.from_chapel(_get_location(result.node))
         return (loc, result.node, self.name, fixits)
 
     def check(
@@ -392,7 +400,7 @@ class AdvancedRule(Rule[AdvancedRuleResult]):
             # addition to the fixits in the result itself)
             # add the fixits from the hooks to the fixits from the rule
             fixits = self.run_fixit_hooks(context, result) + fixits
-            loc = RuleLocation.from_chapel(node.location())
+            loc = RuleLocation.from_chapel(_get_location(node))
             yield (loc, node, self.name, fixits)
 
 


### PR DESCRIPTION
Fixes the location reporting for AstNode's that have name locations. A previous [PR](https://github.com/chapel-lang/chapel/pull/26191) had accidentally broken this functionality,m this PR restores it.

Testing
- [x] ran `start_test test/chplcheck`

[Reviewed by @]