### PR TITLE
Skipif 'extremeBlock' under gasnet/fast on darwin

### DIFF
--- a/test/distributions/bradc/extremeBlock.skipif
+++ b/test/distributions/bradc/extremeBlock.skipif
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Our darwin testing machine cannot handle 32 locales
+# under gasnet with segment=fast, so skip this test in that config.
+
+if [[ $CHPL_TARGET_PLATFORM == darwin &&
+      $CHPL_COMM            == gasnet &&
+      $CHPL_GASNET_SEGMENT  == fast   ]]; then
+  echo True
+else
+  echo False
+fi


### PR DESCRIPTION
Our darwin testing machine cannot handle 32 locales under gasnet with segment=fast, so skipif
the test `test/distributions/bradc/extremeBlock.chpl` in that configuration.

For the record, fourteen locales report this:
```
internal>: error: Out of memory allocating "tasking layer unspecified data"
```

Not reviewed. Supported by Brad.