### PR TITLE
Skip test with launchers that do not support co-locales

### DIFF
--- a/test/runtime/jhh/numColocales2.skipif
+++ b/test/runtime/jhh/numColocales2.skipif
@@ -1,0 +1,7 @@
+CHPL_LAUNCHER == amudprun
+CHPL_LAUNCHER == aprun
+CHPL_LAUNCHER == lsf-gasnetrun_ibv
+CHPL_LAUNCHER == mpirun
+CHPL_LAUNCHER == mpirun4ofi
+CHPL_LAUNCHER == pals
+CHPL_LAUNCHER == pbs-aprun


### PR DESCRIPTION
`test/runtime/jhh/numColocales2.chpl` should be skipped with launchers that do not support co-locales.

Resolves https://github.com/Cray/chapel-private/issues/6981.