### PR TITLE
Close memory leak caused by throwing postinits

### DIFF
--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -197,6 +197,9 @@ static FnSymbol* buildNewWrapper(FnSymbol* initFn, Expr* allocator = nullptr) {
       (type->hasPostInitializer() && type->postinit->throwsError())) {
     fn->throwsErrorInit();
     BlockStmt* tryBody = new BlockStmt(innerInit);
+    if (type->hasPostInitializer() == true) {
+      tryBody->insertAtTail(new CallExpr("postinit", gMethodToken, initTemp));
+    }
 
     const char* errorName = astr("e");
     BlockStmt* catchBody = new BlockStmt(callChplHereFree(initTemp));
@@ -227,11 +230,11 @@ static FnSymbol* buildNewWrapper(FnSymbol* initFn, Expr* allocator = nullptr) {
 
   } else {
     body->insertAtTail(innerInit);
+    if (type->hasPostInitializer() == true) {
+      body->insertAtTail(new CallExpr("postinit", gMethodToken, initTemp));
+    }
   }
 
-  if (type->hasPostInitializer() == true) {
-    body->insertAtTail(new CallExpr("postinit", gMethodToken, initTemp));
-  }
 
   VarSymbol* result = newTemp();
   Expr* resultExpr = NULL;


### PR DESCRIPTION
OK, well this is embarrassing.  Despite asserting in the PR message of #26430 that my throwing postinits would do the same thing as throwing inits do, apparently I never actually ran testing with memleaks turned on to make sure that no memory was leaked when a postinit throws, and...  Well, it was.  (Not a defense, but I had inspected the generated code and seen that we were emitting some code to handle its thrown errors, but didn't look closely enough to see that that handling didn't actually do any clean-up, just propagated the error and exited the routine).  Sloppy.

Here, I'm fixing my issue by tucking the call to postinit() into the same try...catch block as the throwing initializer code is put into (when either of them throws), which causes it to inherit the same outcomes, which is to say, free the memory.  If neither throws, it just gets inserted after the initializer as usual.

This should resolve the memory leaks failures we saw on Dec 20, 2024.
