### PR TITLE
Quote user arguments passed to slurm launchers

### DIFF
--- a/runtime/src/launch/slurm-gasnetrun_common/slurm-gasnetrun_common.h
+++ b/runtime/src/launch/slurm-gasnetrun_common/slurm-gasnetrun_common.h
@@ -347,7 +347,7 @@ static char* chpl_launch_create_command(int argc, char* argv[],
                    chpl_get_real_binary_wrapper(),
                    chpl_get_real_binary_name());
     for (i=1; i<argc; i++) {
-      len += snprintf(iCom+len, sizeof(iCom)-len, " %s", argv[i]);
+      len += snprintf(iCom+len, sizeof(iCom)-len, " '%s'", argv[i]);
     }
 
     snprintf(baseCommand, sizeof(baseCommand), "salloc %s", iCom);

--- a/runtime/src/launch/slurm-srun/launch-slurm-srun.c
+++ b/runtime/src/launch/slurm-srun/launch-slurm-srun.c
@@ -585,7 +585,7 @@ static char* chpl_launch_create_command(int argc, char* argv[],
 
     // add any arguments passed to the launcher to the binary
     for (i=1; i<argc; i++) {
-      len += snprintf(iCom+len, sizeof(iCom)-len, " %s", argv[i]);
+      len += snprintf(iCom+len, sizeof(iCom)-len, " '%s'", argv[i]);
     }
 
     // launch the job using srun


### PR DESCRIPTION
This safeguards spaces and most other symbols in the arguments passed to a compiled Chapel program that uses a slurm launcher, where such a safeguard was missing. For example:
```
./myProgram --myString='Hello, world!'
```
used to behave as if it were `./myProgram --myString=Hello, world!`, i.e., `world!` would be passed as a separate argument to `myProgram_real` when launched with slurm.

This is a stopgap solution to ensure that the test augmented in #26439 passes in slurm configurations. It is not bullet-proof because user arguments containing single quotes and/or backslashes will not be passed through properly.

Next steps: #26381 eliminates static limits on the size of user arguments. In the long run we want to switch from launching using `system()`, when quoting may be necessary, to using `execvp` to avoid the need to quote.

Discussed with Brad and Anna.