### PR TITLE
Skip multi-locale test if CHPL_COMM==none

### DIFF
--- a/test/runtime/jhh/numColocales2.skipif
+++ b/test/runtime/jhh/numColocales2.skipif
@@ -1,3 +1,4 @@
+CHPL_COMM == none
 CHPL_LAUNCHER == amudprun
 CHPL_LAUNCHER == aprun
 CHPL_LAUNCHER == lsf-gasnetrun_ibv


### PR DESCRIPTION
This test requires two co-locales.

[Trivial change to test configuration, not reviewed.]