### PR TITLE
Dyno: Fix (callable variable, function) disambiguation

### DIFF
--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -234,6 +234,10 @@ class IdAndFlags {
     return (flags_ & TYPE) != 0;
   }
 
+  bool isFunctionLike() const {
+    return isParenfulFunction() || isMethodOrField();
+  }
+
   /** Returns true if haveFlags matches filterFlags, and does not match
       the exclude flag set. See the comments on Flags and FlagSet for
       how the matching works.

--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -409,6 +409,7 @@ class MatchingIdsWithName {
 
  private:
   llvm::SmallVector<IdAndFlags, 1> idvs_;
+  bool encounteredFnNonFnConflict_ = false;
 
   /** Construct a MatchingIdsWithName referring to the same IDs
       as the passed OwnedIdsWithName.  */
@@ -471,6 +472,17 @@ class MatchingIdsWithName {
 
   /** Construct a empty MatchingIdsWithName containing no IDs. */
   MatchingIdsWithName() { }
+
+  /** Note that when populating this list, we found functions and non-functions
+      at the same scope level. */
+  void noteFnNonFnConflict() {
+    encounteredFnNonFnConflict_ = true;
+  }
+
+  /** Returns 'true' if we found functions and non-functions at the same scope level. */
+  bool encounteredFnNonFnConflict() const {
+    return encounteredFnNonFnConflict_;
+  }
 
   /** Append an IdAndFlags. */
   void append(IdAndFlags idv) {

--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -235,6 +235,11 @@ class IdAndFlags {
   }
 
   bool isFunctionLike() const {
+    // * functions are obviously function-like (shouldn't stop lookup)
+    // * parenless functions that are methods might not match the receiver,
+    //   so they should not stop the lookup either (treat them as function-like)
+    // * fields are effectively resolved as accessor functions, so they should
+    //   also not stop the lookup.
     return isParenfulFunction() || isMethodOrField();
   }
 

--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -285,7 +285,9 @@ class LookupResult {
 
  public:
   LookupResult(bool found, bool nonFunctions)
-    : found_(found), nonFunctions_(nonFunctions) {}
+    : found_(found), nonFunctions_(nonFunctions) {
+    CHPL_ASSERT(!nonFunctions_ || found);
+  }
 
   static LookupResult empty() { return {false, false}; }
 

--- a/frontend/include/chpl/resolution/scope-types.h
+++ b/frontend/include/chpl/resolution/scope-types.h
@@ -554,7 +554,8 @@ class MatchingIdsWithName {
   }
 
   bool operator==(const MatchingIdsWithName& other) const {
-    return idvs_ == other.idvs_;
+    return idvs_ == other.idvs_ &&
+           encounteredFnNonFnConflict_ == other.encounteredFnNonFnConflict_;
   }
   bool operator!=(const MatchingIdsWithName& other) const {
     return !(*this == other);
@@ -565,6 +566,7 @@ class MatchingIdsWithName {
     for (const auto& x : idvs_) {
       ret = hash_combine(ret, chpl::hash(x));
     }
+    ret = hash_combine(ret, encounteredFnNonFnConflict_);
     return ret;
   }
 

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -3414,6 +3414,15 @@ void Resolver::resolveIdentifier(const Identifier* ident) {
   auto parenlessInfo = ParenlessOverloadInfo();
   auto ids = lookupIdentifier(ident, resolvingCalledIdent, parenlessInfo);
 
+  // If we requested IDs including potential overloads, and found
+  // both a variable and a function at the same point, we're not sure how to
+  // resolve the call (via regular call resolution or 'proc this' resolution).
+  // Issue an error.
+  if (ids.encounteredFnNonFnConflict()) {
+    result.setType(typeErr(ident, "ambiguity between function and non-function at the same scope level"));
+    return;
+  }
+
   // If we looked up a called identifier and found ambiguity between variables
   // only, resolve as an implicit 'this' call on the innermost variable.
   // TODO: replace this hacky solution with an adjustment to the scope

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -3428,9 +3428,8 @@ void Resolver::resolveIdentifier(const Identifier* ident) {
   // in the same place.
   if (resolvingCalledIdent && ids.numIds() > 1) {
     bool onlyVars = true;
-    for (auto idIt = ids.begin(); idIt != ids.end(); ++idIt) {
-      if (!parsing::idToAst(context, idIt.curIdAndFlags().id())
-               ->isVarLikeDecl()) {
+    for (int i = 0; i < ids.numIds(); i++) {
+      if (ids.idAndFlags(i).isFunctionLike() ){
         onlyVars = false;
         break;
       }

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -3423,10 +3423,9 @@ void Resolver::resolveIdentifier(const Identifier* ident) {
     return;
   }
 
-  // If we looked up a called identifier and found ambiguity between variables
-  // only, resolve as an implicit 'this' call on the innermost variable.
-  // TODO: replace this hacky solution with an adjustment to the scope
-  // resolution process
+  // If we looked up a called identifier and got back several variables,
+  // give up, since the lookup process only does that if they're defined
+  // in the same place.
   if (resolvingCalledIdent && ids.numIds() > 1) {
     bool onlyVars = true;
     for (auto idIt = ids.begin(); idIt != ids.end(); ++idIt) {
@@ -3436,8 +3435,10 @@ void Resolver::resolveIdentifier(const Identifier* ident) {
         break;
       }
     }
+
     if (onlyVars) {
-      ids.truncate(1);
+      result.setType(typeErr(ident, "ambiguous callable value in called expression"));
+      return;
     }
   }
 

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -4090,6 +4090,8 @@ lookupCalledExpr(Context* context,
   // For parenless non-method calls, only find the innermost match
   if (ci.isParenless() && !ci.isMethodCall()) {
     config |= LOOKUP_INNERMOST;
+  } else {
+    config |= LOOKUP_STOP_NON_FN;
   }
 
   if (ci.isMethodCall()) {

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -4109,6 +4109,21 @@ lookupCalledExpr(Context* context,
                                       /* receiverScopeHelper */ nullptr,
                                       name, config, visited);
 
+  // At this point, we don't allow "switching gears" to 'proc this'-based
+  // resolution of non-function names. The calling code is expected to
+  // have set up the CallInfo with 'name = "this"' if that's what it wanted.
+  // So, rule out non-functional IDs.
+  //
+  // This relies on the fact that under LOOKUP_STOP_NON_FN, the non-functional
+  // IDs are last. (except in the case of ambiguity, but that should've been
+  // ruled out by calling code as well).
+  if (config & LOOKUP_STOP_NON_FN) {
+    for (int i = 0; i < ret.numIds(); i++) {
+      auto& idv = ret.idAndFlags(i);
+      if (!idv.isFunctionLike() && !idv.isType()) ret.truncate(i);
+    }
+  }
+
   return ret;
 }
 

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -416,10 +416,16 @@ CallInfo CallInfo::create(Context* context,
     auto calledExprType = tryGetType(calledExpr, byPostorder);
     auto dotReceiverType = tryGetType(dotReceiver, byPostorder);
 
-    if (calledExprType && isKindForFunctionalValue(calledExprType->kind())) {
+    if (calledExprType &&
+        (isKindForFunctionalValue(calledExprType->kind()) ||
+         calledExprType->isErroneousType())) {
       // If e.g. x is a value (and not a function, then x(0) translates to x.this(0)
       // Run this case even if the receiver is a module, since we might be
       // trying to invoke 'this' on value x in M.x.
+      //
+      // In the case of ErroneousType, assume that the called thing was
+      // a value (ambiguity or other "benign" UNKNOWN would not produce errors).
+      // Later, this can lead to skipping resolving the call altogether.
 
       name = USTR("this");
       // add the 'this' argument as well

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -875,8 +875,8 @@ LookupResult LookupHelper::doLookupInImportsAndUses(
         auto idv = idAndFlagsForScopeSymbol(context, is.scope());
         if (idv.matchesFilter(filterFlags, excludeFlagSet)) {
           result.append(idv);
-          found |= LookupResult(/* found */ true, 
-                                /* nonFunctions */ !idv.isParenfulFunction());
+          found |= LookupResult(/* found */ true,
+                                /* nonFunctions */ !idv.isFunctionLike());
           if (trace) {
             ResultVisibilityTrace t;
             t.scope = cur->scope();

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -632,7 +632,6 @@ struct LookupHelper {
   CheckedScopes& checkedScopes;
   MatchingIdsWithName& result;
   bool& foundExternBlock;
-  bool& fnAndNonFnAtSameLevel;
   int prevNumResults = 0;
   std::vector<VisibilityTraceElt>* traceCurPath = nullptr;
   std::vector<ResultVisibilityTrace>* traceResult = nullptr;
@@ -647,7 +646,6 @@ struct LookupHelper {
                CheckedScopes& checkedScopes,
                MatchingIdsWithName& result,
                bool& foundExternBlock,
-               bool& fnAndNonFnAtSameLevel,
                int prevNumResults,
                std::vector<VisibilityTraceElt>* traceCurPath,
                std::vector<ResultVisibilityTrace>* traceResult,
@@ -658,7 +656,6 @@ struct LookupHelper {
       receiverScopeHelper(receiverScopeHelper),
       checkedScopes(checkedScopes),
       result(result), foundExternBlock(foundExternBlock),
-      fnAndNonFnAtSameLevel(fnAndNonFnAtSameLevel),
       prevNumResults(prevNumResults),
       traceCurPath(traceCurPath), traceResult(traceResult),
       shadowedResults(shadowedResults),
@@ -725,7 +722,7 @@ bool LookupHelper::shouldFinishLookup(const LookupResult& got, bool onlyInnermos
     for (int i = itemsBefore; i < result.numIds(); i++) {
       auto& idv = result.idAndFlags(i);
       if (idv.isFunctionLike()) {
-        fnAndNonFnAtSameLevel = true;
+        result.noteFnNonFnConflict();
         break;
       }
     }
@@ -1732,14 +1729,12 @@ helpLookupInScope(Context* context,
   bool stopNonFn = (config & LOOKUP_STOP_NON_FN) != 0;
   bool checkExternBlocks = (config & LOOKUP_EXTERN_BLOCKS) != 0;
   bool foundExternBlock = false;
-  bool fnAndNonFnAtSameLevel = false;
   int prevNumResults = 0;
   CheckedScopes savedCheckedScopes;
 
   auto helper = LookupHelper(context, resolving, receiverScopeHelper,
                              checkedScopes, result,
                              foundExternBlock,
-                             fnAndNonFnAtSameLevel,
                              prevNumResults,
                              traceCurPath, traceResult,
                              shadowed, traceShadowed,

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -660,38 +660,39 @@ struct LookupHelper {
       allowCached(allowCached) {
   }
 
-  bool doLookupInImportsAndUses(const Scope* scope,
-                                const ResolvedVisibilityScope* cur,
-                                UniqueString name,
-                                LookupConfig config,
-                                IdAndFlags::Flags filterFlags,
-                                const IdAndFlags::FlagSet& excludeFilter,
-                                VisibilitySymbols::ShadowScope shadowScope,
-                                bool* foundInAllContents,
-                                std::unordered_set<ID>* foundInClauses,
-                                std::unordered_set<ID>* ignoreClauses);
+  LookupResult doLookupInImportsAndUses(const Scope* scope,
+                                        const ResolvedVisibilityScope* cur,
+                                        UniqueString name,
+                                        LookupConfig config,
+                                        IdAndFlags::Flags filterFlags,
+                                        const IdAndFlags::FlagSet& excludeFilter,
+                                        VisibilitySymbols::ShadowScope shadowScope,
+                                        bool* foundInAllContents,
+                                        std::unordered_set<ID>* foundInClauses,
+                                        std::unordered_set<ID>* ignoreClauses);
 
-  bool doLookupInAutoModules(const Scope* scope,
-                             UniqueString name,
-                             bool onlyInnermost,
-                             bool skipPrivateVisibilities,
-                             bool onlyMethodsFields,
-                             bool includeMethods);
+  LookupResult doLookupInAutoModules(const Scope* scope,
+                                     UniqueString name,
+                                     bool onlyInnermost,
+                                     bool stopNonFn,
+                                     bool skipPrivateVisibilities,
+                                     bool onlyMethodsFields,
+                                     bool includeMethods);
 
-  bool doLookupEnclosingModuleName(const Scope* scope, UniqueString name);
+  LookupResult doLookupEnclosingModuleName(const Scope* scope, UniqueString name);
 
-  bool doLookupInToplevelModules(const Scope* scope, UniqueString name);
+  LookupResult doLookupInToplevelModules(const Scope* scope, UniqueString name);
 
-  bool doLookupInReceiverScopes(const Scope* scope,
-                                const MethodLookupHelper* receiverScopes,
-                                UniqueString name,
-                                LookupConfig config);
+  LookupResult doLookupInReceiverScopes(const Scope* scope,
+                                        const MethodLookupHelper* receiverScopes,
+                                        UniqueString name,
+                                        LookupConfig config);
 
-  bool doLookupInExternBlocks(const Scope* scope, UniqueString name);
+  LookupResult doLookupInExternBlocks(const Scope* scope, UniqueString name);
 
-  bool doLookupInScope(const Scope* scope,
-                       UniqueString name,
-                       LookupConfig config);
+  LookupResult doLookupInScope(const Scope* scope,
+                               UniqueString name,
+                               LookupConfig config);
 };
 
 static const Scope* const& scopeForAutoModuleQuery(Context* context) {
@@ -746,7 +747,7 @@ idAndFlagsForScopeSymbol(Context* context, const Scope* scope) {
 
 // config has settings for this part of the search
 // filterFlags has the filter used when considering the module name itself
-bool LookupHelper::doLookupInImportsAndUses(
+LookupResult LookupHelper::doLookupInImportsAndUses(
                                    const Scope* scope,
                                    const ResolvedVisibilityScope* cur,
                                    UniqueString name,
@@ -758,13 +759,14 @@ bool LookupHelper::doLookupInImportsAndUses(
                                    std::unordered_set<ID>* foundInClauses,
                                    std::unordered_set<ID>* ignoreClauses) {
   bool onlyInnermost = (config & LOOKUP_INNERMOST) != 0;
+  bool stopNonFn = (config & LOOKUP_STOP_NON_FN) != 0;
   bool skipPrivateVisibilities = (config & LOOKUP_SKIP_PRIVATE_VIS) != 0;
   bool onlyMethodsFields = (config & LOOKUP_ONLY_METHODS_FIELDS) != 0;
   bool checkExternBlocks = (config & LOOKUP_EXTERN_BLOCKS) != 0;
   bool skipPrivateUseImport = (config & LOOKUP_SKIP_PRIVATE_USE_IMPORT) != 0;
   bool includeMethods = (config & LOOKUP_METHODS) != 0;
   bool trace = (traceCurPath != nullptr && traceResult != nullptr);
-  bool found = false;
+  auto found = LookupResult::empty();
 
   if (cur != nullptr) {
     // check to see if it's mentioned in names/renames
@@ -817,6 +819,9 @@ bool LookupHelper::doLookupInImportsAndUses(
         if (onlyInnermost) {
           newConfig |= LOOKUP_INNERMOST;
         }
+        if (stopNonFn) {
+          newConfig |= LOOKUP_STOP_NON_FN;
+        }
         if (onlyMethodsFields) {
           newConfig |= LOOKUP_ONLY_METHODS_FIELDS;
         }
@@ -849,7 +854,7 @@ bool LookupHelper::doLookupInImportsAndUses(
           traceCurPath->push_back(std::move(elt));
         }
 
-        bool foundHere = doLookupInScope(symScope, nameToLookUp, newConfig);
+        auto foundHere = doLookupInScope(symScope, nameToLookUp, newConfig);
         found |= foundHere;
         // note if we found it from the contents in a bulk
         // operation like 'use M'
@@ -870,7 +875,8 @@ bool LookupHelper::doLookupInImportsAndUses(
         auto idv = idAndFlagsForScopeSymbol(context, is.scope());
         if (idv.matchesFilter(filterFlags, excludeFlagSet)) {
           result.append(idv);
-          found = true;
+          found |= LookupResult(/* found */ true, 
+                                /* nonFunctions */ !idv.isParenfulFunction());
           if (trace) {
             ResultVisibilityTrace t;
             t.scope = cur->scope();
@@ -900,14 +906,15 @@ bool LookupHelper::doLookupInImportsAndUses(
   return found;
 }
 
-bool LookupHelper::doLookupInAutoModules(const Scope* scope,
-                                         UniqueString name,
-                                         bool onlyInnermost,
-                                         bool skipPrivateVisibilities,
-                                         bool onlyMethodsFields,
-                                         bool includeMethods) {
+LookupResult LookupHelper::doLookupInAutoModules(const Scope* scope,
+                                                 UniqueString name,
+                                                 bool onlyInnermost,
+                                                 bool stopNonFn,
+                                                 bool skipPrivateVisibilities,
+                                                 bool onlyMethodsFields,
+                                                 bool includeMethods) {
   bool trace = (traceCurPath != nullptr && traceResult != nullptr);
-  bool found = false;
+  auto found = LookupResult::empty();
 
   if (scope->autoUsesModules() && !skipPrivateVisibilities) {
     const Scope* autoModScope = scopeForAutoModule(context);
@@ -918,6 +925,10 @@ bool LookupHelper::doLookupInAutoModules(const Scope* scope,
 
       if (onlyInnermost) {
         newConfig |= LOOKUP_INNERMOST;
+      }
+
+      if (stopNonFn) {
+        newConfig |= LOOKUP_STOP_NON_FN;
       }
 
       if (onlyMethodsFields) {
@@ -946,20 +957,20 @@ bool LookupHelper::doLookupInAutoModules(const Scope* scope,
   return found;
 }
 
-bool LookupHelper::doLookupEnclosingModuleName(const Scope* scope,
-                                               UniqueString name) {
+LookupResult LookupHelper::doLookupEnclosingModuleName(const Scope* scope,
+                                                       UniqueString name) {
   // this code assumes that 'scope' is a module scope
   CHPL_ASSERT(scope && scope->moduleScope() == scope);
 
   if (name != scope->name())
-    return false;
+    return LookupResult::empty();
 
   // Ignore this match for enclosing module names that aren't valid
   // Chapel file names. This avoids compilation failures for
   // implicit modules created from a filename of the form <keyword>.chpl
   // e.g. domain.chpl
   if (getReservedIdentifier(name))
-    return false;
+    return LookupResult::empty();
 
   // the name matches! record the match
   //
@@ -976,14 +987,14 @@ bool LookupHelper::doLookupEnclosingModuleName(const Scope* scope,
     traceResult->push_back(std::move(t));
   }
 
-  return true;
+  return LookupResult(/* found */ true, /* nonFunctions */ true);
 }
 
-bool LookupHelper::doLookupInToplevelModules(const Scope* scope,
-                                             UniqueString name) {
+LookupResult LookupHelper::doLookupInToplevelModules(const Scope* scope,
+                                                     UniqueString name) {
   const Module* mod = parsing::getToplevelModule(context, name);
   if (mod == nullptr)
-    return false;
+    return LookupResult::empty();
 
   if (traceCurPath && traceResult) {
     ResultVisibilityTrace t;
@@ -996,7 +1007,7 @@ bool LookupHelper::doLookupInToplevelModules(const Scope* scope,
 
   result.append(IdAndFlags::createForModule(mod->id(), /* isPublic */ true));
 
-  return true;
+  return LookupResult(/* found */ true, /* nonFunctions */ true);
 }
 
 // Receiver scopes support two cases:
@@ -1006,13 +1017,13 @@ bool LookupHelper::doLookupInToplevelModules(const Scope* scope,
 //
 // This method searches parents scopes (for secondary methods)
 // if LOOKUP_PARENTS is included in 'config'.
-bool LookupHelper::doLookupInReceiverScopes(
+LookupResult LookupHelper::doLookupInReceiverScopes(
                          const Scope* scope,
                          const MethodLookupHelper* receiverScopes,
                          UniqueString name,
                          LookupConfig config) {
   if (receiverScopes == nullptr) {
-    return false;
+    return LookupResult::empty();
   }
 
   bool checkParents = (config & LOOKUP_PARENTS) != 0;
@@ -1106,6 +1117,7 @@ bool LookupHelper::doLookupInReceiverScopes(
   // using receiverScopes->isReceiverApplicable.
   int endSize = result.numIds();
   int cur = startParentsSize;
+  bool nonFunctions = false;
   for (int i = startParentsSize; i < endSize; i++) {
     IdAndFlags& idv = result.idAndFlags(i);
     if (receiverScopes->isReceiverApplicable(context, idv.id())) {
@@ -1113,6 +1125,7 @@ bool LookupHelper::doLookupInReceiverScopes(
       if (cur != i) {
         result.idAndFlags(cur) = idv;
       }
+      nonFunctions |= !idv.isParenfulFunction();
       cur++;
     }
   }
@@ -1124,7 +1137,7 @@ bool LookupHelper::doLookupInReceiverScopes(
     traceResult->resize(cur);
   }
 
-  return cur > startSize;
+  return LookupResult(/* found */ cur > startSize, nonFunctions);
 }
 
 // returns IDs of all extern blocks directly contained within scope
@@ -1143,10 +1156,12 @@ static const std::vector<ID>& gatherExternBlocks(Context* context, ID scopeID) {
   return QUERY_END(result);
 }
 
-bool LookupHelper::doLookupInExternBlocks(const Scope* scope,
-                                          UniqueString name) {
+LookupResult LookupHelper::doLookupInExternBlocks(const Scope* scope,
+                                                  UniqueString name) {
   // Which are the IDs of the contained extern block(s)?
   const std::vector<ID>& exbIds = gatherExternBlocks(context, scope->id());
+
+  bool found = false;
 
   // Consider each extern block in turn. Does it have a symbol with that name?
   for (const auto& exbId : exbIds) {
@@ -1167,6 +1182,7 @@ bool LookupHelper::doLookupInExternBlocks(const Scope* scope,
                             /* isType */ false); // maybe a lie
 
       result.append(std::move(idv));
+      found = true;
 
       if (traceCurPath && traceResult) {
         ResultVisibilityTrace t;
@@ -1179,7 +1195,7 @@ bool LookupHelper::doLookupInExternBlocks(const Scope* scope,
     }
   }
 
-  return true;
+  return LookupResult(found, /* nonFunctions; might be a lie; see above */ true);
 }
 
 // Returns the IdAndFlags for a common builtin, or nullptr.
@@ -1226,6 +1242,12 @@ static const IdAndFlags* getReservedIdentifier(UniqueString name) {
   return nullptr;
 }
 
+static bool doneLooking(const LookupResult& got, bool onlyInnermost, bool stopNonFn) {
+  if (got && onlyInnermost) return true;
+  if (got.nonFunctions() && stopNonFn) return true;
+  return false;
+}
+
 // appends to result
 //
 // traceCurPath and traceResult support gathering additional information
@@ -1239,14 +1261,15 @@ static const IdAndFlags* getReservedIdentifier(UniqueString name) {
 // if both tracing arguments are not nullptr, traceResult will be updated to
 // have one entry for each of the elements in result, saving the traceCurPath
 // that provided that element in result.
-bool LookupHelper::doLookupInScope(const Scope* scope,
-                                   UniqueString name,
-                                   LookupConfig config) {
+LookupResult LookupHelper::doLookupInScope(const Scope* scope,
+                                           UniqueString name,
+                                           LookupConfig config) {
   bool checkDecls = (config & LOOKUP_DECLS) != 0;
   bool checkUseImport = (config & LOOKUP_IMPORT_AND_USE) != 0;
   bool checkParents = (config & LOOKUP_PARENTS) != 0;
   bool checkToplevel = (config & LOOKUP_TOPLEVEL) != 0;
   bool onlyInnermost = (config & LOOKUP_INNERMOST) != 0;
+  bool stopNonFn = (config & LOOKUP_STOP_NON_FN) != 0;
   bool skipPrivateVisibilities = (config & LOOKUP_SKIP_PRIVATE_VIS) != 0;
   bool goPastModules = (config & LOOKUP_GO_PAST_MODULES) != 0;
   bool onlyMethodsFields = (config & LOOKUP_ONLY_METHODS_FIELDS) != 0;
@@ -1260,7 +1283,7 @@ bool LookupHelper::doLookupInScope(const Scope* scope,
   if (checkParents && !onlyMethodsFields) {
     if (const IdAndFlags* got = getReservedIdentifier(name)) {
       result.append(*got);
-      return true;
+      return LookupResult(/* found */ true, /* nonFunctions */ true);
     }
   }
 
@@ -1306,7 +1329,7 @@ bool LookupHelper::doLookupInScope(const Scope* scope,
       // (which, because these are filters, means that foundFilter is
       //  less restricted / more general / subsumes curFilter),
       // there is no need to visit this scope further.
-      return false;
+      return LookupResult::empty();
     }
 
     // ok, we can search for curFilter but exclude what was already found
@@ -1361,9 +1384,9 @@ bool LookupHelper::doLookupInScope(const Scope* scope,
 
   // gather non-shadow scope information
   // (declarations in this scope as well as public use / import)
+  auto got = LookupResult::empty();
+  auto gotBeforeWarning = LookupResult::empty();
   {
-    bool got = false;
-
     // lookup in the module's public symbols if we have it
     if (modPublicSyms) {
       got |=
@@ -1405,35 +1428,39 @@ bool LookupHelper::doLookupInScope(const Scope* scope,
           checkMoreForWarning = true;
           onlyInnermost = false;
           firstResultForWarning = result.numIds();
+          gotBeforeWarning = got;
         }
       }
     }
-    if (onlyInnermost && got) return true;
+    if (doneLooking(got, onlyInnermost, stopNonFn)) return got;
   }
 
   // now check shadow scope 1 (only relevant for 'private use')
   if (checkUseImport && !skipShadowScopes) {
-    bool got = false;
+    auto gotInSS1 = LookupResult::empty();
     bool foundInAll = false;
-    got |= doLookupInImportsAndUses(scope, r, name, config,
-                                    curFilter, excludeFilter,
-                                    VisibilitySymbols::SHADOW_SCOPE_ONE,
-                                    &foundInAll,
-                                    &foundInShadowScopeOneClauses,
-                                    /* ignoreClauses */ nullptr);
+    gotInSS1 |= doLookupInImportsAndUses(scope, r, name, config,
+                                         curFilter, excludeFilter,
+                                         VisibilitySymbols::SHADOW_SCOPE_ONE,
+                                         &foundInAll,
+                                         &foundInShadowScopeOneClauses,
+                                         /* ignoreClauses */ nullptr);
 
     // treat the auto-used modules as if they were 'private use'd
-    got |= doLookupInAutoModules(scope, name,
-                                 onlyInnermost,
-                                 skipPrivateVisibilities,
-                                 onlyMethodsFields,
-                                 includeMethods);
-    if (got && canCheckMoreForWarning && !checkMoreForWarning && foundInAll) {
+    gotInSS1 |= doLookupInAutoModules(scope, name,
+                                      onlyInnermost,
+                                      stopNonFn,
+                                      skipPrivateVisibilities,
+                                      onlyMethodsFields,
+                                      includeMethods);
+    if (gotInSS1 && canCheckMoreForWarning && !checkMoreForWarning && foundInAll) {
       checkMoreForWarning = true;
       onlyInnermost = false;
       firstResultForWarning = result.numIds();
     }
-    if (onlyInnermost && got) return true;
+
+    got |= gotInSS1;
+    if (doneLooking(got, onlyInnermost, stopNonFn)) return got;
   }
 
   std::unordered_set<ID>* ignoreClausesForShadowScopeTwo = nullptr;
@@ -1445,19 +1472,21 @@ bool LookupHelper::doLookupInScope(const Scope* scope,
 
   // now check shadow scope 2 (only relevant for 'private use')
   if (checkUseImport && !skipShadowScopes) {
-    bool got = false;
-    got = doLookupInImportsAndUses(scope, r, name, config,
-                                   curFilter, excludeFilter,
-                                   VisibilitySymbols::SHADOW_SCOPE_TWO,
-                                   /* foundInAllContents */ nullptr,
-                                   /* foundInClauses */ nullptr,
-                                   ignoreClausesForShadowScopeTwo);
-    if (got && canCheckMoreForWarning && !checkMoreForWarning) {
+    auto gotInSS2 = LookupResult::empty();
+    gotInSS2 = doLookupInImportsAndUses(scope, r, name, config,
+                                        curFilter, excludeFilter,
+                                        VisibilitySymbols::SHADOW_SCOPE_TWO,
+                                        /* foundInAllContents */ nullptr,
+                                        /* foundInClauses */ nullptr,
+                                        ignoreClausesForShadowScopeTwo);
+    if (gotInSS2 && canCheckMoreForWarning && !checkMoreForWarning) {
       checkMoreForWarning = true;
       onlyInnermost = false;
       firstResultForWarning = result.numIds();
     }
-    if (onlyInnermost && got) return true;
+
+    got |= gotInSS2;
+    if (doneLooking(got, onlyInnermost, stopNonFn)) return got;
   }
 
   // If we are at a method scope, consider receiver scopes now
@@ -1467,8 +1496,8 @@ bool LookupHelper::doLookupInScope(const Scope* scope,
   if (scope->isMethodScope() && receiverScopeHelper != nullptr) {
     auto rcvScopes =
       receiverScopeHelper->methodLookupForMethodId(context, scope->id());
-    bool got = doLookupInReceiverScopes(scope, rcvScopes, name, config);
-    if (onlyInnermost && got) return true;
+    got |= doLookupInReceiverScopes(scope, rcvScopes, name, config);
+    if (doneLooking(got, onlyInnermost, stopNonFn)) return got;
   }
 
   // consider the outer scopes due to nesting
@@ -1508,22 +1537,21 @@ bool LookupHelper::doLookupInScope(const Scope* scope,
 
         // search without considering receiver scopes
         // (considered separately below)
-        bool got = doLookupInScope(cur, name, newConfig);
+        got |= doLookupInScope(cur, name, newConfig);
 
         if (trace) {
           traceCurPath->pop_back();
         }
 
-        if (onlyInnermost && got) return true;
+        if (doneLooking(got, onlyInnermost, stopNonFn)) return got;
 
         // and then search only considering receiver scopes
         // as if the receiver scope were just outside of this scope.
         if (cur->isMethodScope() && receiverScopeHelper != nullptr) {
           auto rcvScopes =
             receiverScopeHelper->methodLookupForMethodId(context, cur->id());
-          bool got = doLookupInReceiverScopes(scope, rcvScopes,
-                                              name, newConfig);
-          if (onlyInnermost && got) return true;
+          got |= doLookupInReceiverScopes(scope, rcvScopes, name, newConfig);
+          if (doneLooking(got, onlyInnermost, stopNonFn)) return got;
         }
       }
     }
@@ -1536,13 +1564,13 @@ bool LookupHelper::doLookupInScope(const Scope* scope,
         traceCurPath->push_back(std::move(elt));
       }
 
-      bool got = doLookupInScope(cur, name, newConfig);
+      got |= doLookupInScope(cur, name, newConfig);
 
       if (trace) {
         traceCurPath->pop_back();
       }
 
-      if (onlyInnermost && got) return true;
+      if (doneLooking(got, onlyInnermost, stopNonFn)) return got;
     }
 
     if (!goPastModules && (reachedModule || isModule(scope->tag()))) {
@@ -1560,13 +1588,13 @@ bool LookupHelper::doLookupInScope(const Scope* scope,
         traceCurPath->push_back(std::move(elt));
       }
 
-      bool got = doLookupEnclosingModuleName(modScope, name);
+      got |= doLookupEnclosingModuleName(modScope, name);
 
       if (trace) {
         traceCurPath->pop_back();
       }
 
-      if (onlyInnermost && got) return true;
+      if (doneLooking(got, onlyInnermost, stopNonFn)) return got;
     }
 
     // check also in the root scope if this isn't already the root scope
@@ -1586,19 +1614,19 @@ bool LookupHelper::doLookupInScope(const Scope* scope,
         traceCurPath->push_back(std::move(elt));
       }
 
-      bool got = doLookupInScope(rootScope, name, newConfig);
+      got |= doLookupInScope(rootScope, name, newConfig);
 
       if (trace) {
         traceCurPath->pop_back();
       }
 
-      if (onlyInnermost && got) return true;
+      if (doneLooking(got, onlyInnermost, stopNonFn)) return got;
     }
   }
 
   if (checkToplevel) {
-    bool got = doLookupInToplevelModules(scope, name);
-    if (onlyInnermost && got) return true;
+    got |= doLookupInToplevelModules(scope, name);
+    if (doneLooking(got, onlyInnermost, stopNonFn)) return got;
   }
 
   // If LOOKUP_EXTERN_BLOCKS is set, and this scope has an extern block,
@@ -1608,7 +1636,7 @@ bool LookupHelper::doLookupInScope(const Scope* scope,
   if (checkExternBlocks && scope->containsExternBlock() &&
       !checkMoreForWarning) {
     foundExternBlock = true;
-    doLookupInExternBlocks(scope, name);
+    got |= doLookupInExternBlocks(scope, name);
   }
 
   if (checkMoreForWarning) {
@@ -1633,6 +1661,7 @@ bool LookupHelper::doLookupInScope(const Scope* scope,
       }
 
       result.truncate(firstResultForWarning);
+      got = gotBeforeWarning;
       if (trace) {
         traceResult->resize(firstResultForWarning);
       }
@@ -1644,10 +1673,10 @@ bool LookupHelper::doLookupInScope(const Scope* scope,
     CHPL_ASSERT(traceCurPath->size() == traceCurPathSize);
   }
 
-  return result.numIds() > startSize;
+  return got;
 }
 
-static bool
+static LookupResult
 helpLookupInScope(Context* context,
                   const Scope* scope,
                   const ResolvedVisibilityScope* resolving,
@@ -1664,6 +1693,7 @@ helpLookupInScope(Context* context,
                   std::vector<ResultVisibilityTrace>* traceShadowed=nullptr)
 {
   bool onlyInnermost = (config & LOOKUP_INNERMOST) != 0;
+  bool stopNonFn = (config & LOOKUP_STOP_NON_FN) != 0;
   bool checkExternBlocks = (config & LOOKUP_EXTERN_BLOCKS) != 0;
   bool foundExternBlock = false;
   CheckedScopes savedCheckedScopes;
@@ -1682,7 +1712,7 @@ helpLookupInScope(Context* context,
     savedCheckedScopes = checkedScopes;
   }
 
-  bool got = false;
+  auto got = LookupResult::empty();
 
   if (scope) {
     got |= helper.doLookupInScope(scope, name, config);
@@ -1691,7 +1721,7 @@ helpLookupInScope(Context* context,
   // When resolving a Dot expression like myRecord.foo, we might not be inside
   // of a method at all, but we should still search the definition point
   // of the relevant record.
-  if (methodLookupHelper != nullptr && !(got && onlyInnermost)) {
+  if (methodLookupHelper != nullptr && !(doneLooking(got, onlyInnermost, stopNonFn))) {
     got |= helper.doLookupInReceiverScopes(scope, methodLookupHelper,
                                            name, config);
   }
@@ -1703,7 +1733,7 @@ helpLookupInScope(Context* context,
     checkedScopes = savedCheckedScopes;
 
     if (scope) {
-      got = helper.doLookupInScope(scope, name, config);
+      got |= helper.doLookupInScope(scope, name, config);
     }
   }
 
@@ -1717,7 +1747,7 @@ helpLookupInScope(Context* context,
 
 // similar to helpLookupInScope but also emits a shadowing warning
 // in some cases.
-static bool helpLookupInScopeWithShadowingWarning(
+static LookupResult helpLookupInScopeWithShadowingWarning(
                             Context* context,
                             const Scope* scope,
                             const ResolvedVisibilityScope* resolving,
@@ -1733,7 +1763,7 @@ static bool helpLookupInScopeWithShadowingWarning(
   CheckedScopes checkedScopesForRetry = checkedScopes;
   MatchingIdsWithName shadowed;
 
-  bool got = helpLookupInScope(context, scope, resolving,
+  auto got = helpLookupInScope(context, scope, resolving,
                                methodLookupHelper, receiverScopeHelper,
                                name, config, checkedScopes, vec,
                                allowCached,

--- a/frontend/lib/resolution/scope-types.cpp
+++ b/frontend/lib/resolution/scope-types.cpp
@@ -231,7 +231,7 @@ OwnedIdsWithName::gatherMatches(MatchingIdsWithName& dst,
     if (cur->matchesFilter(filterFlags, excludeFlagSet)) {
       dst.idvs_.push_back(*cur);
       anyAppended = true;
-      anyNonFunctions |= !cur->isParenfulFunction() && !cur->isMethodOrField();
+      anyNonFunctions |= !cur->isFunctionLike();
     }
   }
 

--- a/frontend/lib/resolution/scope-types.cpp
+++ b/frontend/lib/resolution/scope-types.cpp
@@ -199,7 +199,7 @@ void FlagSet::mark(Context* context) const {
   // nothing, because flags don't need to be marked.
 }
 
-bool
+LookupResult
 OwnedIdsWithName::gatherMatches(MatchingIdsWithName& dst,
                                 IdAndFlags::Flags filterFlags,
                                 const IdAndFlags::FlagSet& excludeFlagSet) const
@@ -209,8 +209,10 @@ OwnedIdsWithName::gatherMatches(MatchingIdsWithName& dst,
   // Are all of the filter flags present in flagsOr?
   // If not, it is not possible for this to match.
   if ((ownedIds.flagsOr_ & filterFlags) != filterFlags) {
-    return false;
+    return LookupResult::empty();
   }
+
+  bool anyNonFunctions = false;
 
   const IdAndFlags* beginIds = nullptr;
   const IdAndFlags* endIds = nullptr;
@@ -229,10 +231,11 @@ OwnedIdsWithName::gatherMatches(MatchingIdsWithName& dst,
     if (cur->matchesFilter(filterFlags, excludeFlagSet)) {
       dst.idvs_.push_back(*cur);
       anyAppended = true;
+      anyNonFunctions |= !cur->isParenfulFunction() && !cur->isMethodOrField();
     }
   }
 
-  return anyAppended;
+  return LookupResult(/* found */ anyAppended, /* nonFunctions */ anyNonFunctions);
 
 }
 
@@ -309,16 +312,16 @@ void MatchingIdsWithName::stringify(std::ostream& ss,
   }
 }
 
-bool lookupInDeclMap(const DeclMap& declared,
-                     UniqueString name,
-                     MatchingIdsWithName& result,
-                     IdAndFlags::Flags filterFlags,
-                     const IdAndFlags::FlagSet& excludeFlags) {
+LookupResult lookupInDeclMap(const DeclMap& declared,
+                             UniqueString name,
+                             MatchingIdsWithName& result,
+                             IdAndFlags::Flags filterFlags,
+                             const IdAndFlags::FlagSet& excludeFlags) {
   auto search = declared.find(name);
   if (search != declared.end()) {
     return search->second.gatherMatches(result, filterFlags, excludeFlags);
   }
-  return false;
+  return LookupResult::empty();
 }
 
 

--- a/frontend/test/resolution/testResolve.cpp
+++ b/frontend/test/resolution/testResolve.cpp
@@ -1739,7 +1739,7 @@ static void testInfiniteCycleBug() {
   std::ignore = resolveQualifiedTypeOfX(context, program1);
 }
 
-// a callable foraml (like a tuple) is preferred to functions in outer
+// a callable formal (like a tuple) is preferred to functions in outer
 // scopes.
 static void testFormalFunctionShadowing() {
   std::string program =
@@ -1762,7 +1762,7 @@ static void testFormalFunctionShadowing() {
   CHPL_ASSERT(t.type()->isIntType());
 }
 
-// a callable foraml (like a tuple) interrupts the search for functions as
+// a callable formal (like a tuple) interrupts the search for functions as
 // an optimization for "distance" (any functions beyond the callable formal
 // are further away than any functions we've already found).
 static void testFunctionFormalShadowing() {

--- a/frontend/test/resolution/testResolve.cpp
+++ b/frontend/test/resolution/testResolve.cpp
@@ -1739,6 +1739,83 @@ static void testInfiniteCycleBug() {
   std::ignore = resolveQualifiedTypeOfX(context, program1);
 }
 
+// a callable foraml (like a tuple) is preferred to functions in outer
+// scopes.
+static void testFormalFunctionShadowing() {
+  std::string program =
+    R"""(
+    record R { proc this(x: int) do return 42; }
+
+    proc foo(x) do return 1.0;
+    proc foo(x: int) do return new R();
+    proc bar(foo: R) do return foo(0);
+
+    var x = bar(new R());
+    )""";
+
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  auto t = resolveTypeOfXInit(context, program);
+  CHPL_ASSERT(!t.isUnknownOrErroneous());
+  CHPL_ASSERT(t.type()->isIntType());
+}
+
+// a callable foraml (like a tuple) interrupts the search for functions as
+// an optimization for "distance" (any functions beyond the callable formal
+// are further away than any functions we've already found).
+static void testFunctionFormalShadowing() {
+  std::string program =
+    R"""(
+    record R { proc this(x: int) do return 42; }
+
+    proc foo(x: int) do return new R();
+    proc bar(foo: R) {
+      proc foo(x) do return 1.0;
+      return foo(0);
+    }
+
+    var x = bar(new R());
+    )""";
+
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  auto t = resolveTypeOfXInit(context, program);
+  CHPL_ASSERT(!t.isUnknownOrErroneous());
+  CHPL_ASSERT(t.type()->isRealType());
+}
+
+// Today, we don't perform overload selection for callable objects. Instead,
+// expect an error to be issued.
+static void testCallableAmbiguity() {
+  std::string program =
+    R"""(
+    module Lib {
+      record R {
+        proc this() do return 42;
+      }
+    }
+    module M1 { use Lib; var x: R; }
+    module M2 { use Lib; var x: R; }
+    module M3 {
+      use M1;
+      use M2;
+
+      var y = x(0);
+    }
+    )""";
+
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  std::ignore = resolveTypesOfVariables(context, program, { "y" });
+  assert(guard.realizeErrors());
+}
+
 int main() {
   test1();
   test2();
@@ -1769,6 +1846,10 @@ int main() {
   test27();
 
   testInfiniteCycleBug();
+
+  testFormalFunctionShadowing();
+  testFunctionFormalShadowing();
+  testCallableAmbiguity();
 
   return 0;
 }

--- a/test/deprecated/dmapType.good
+++ b/test/deprecated/dmapType.good
@@ -19,11 +19,11 @@ dmapType.chpl:72: warning: 'BlockCyclic' is deprecated, please use 'blockCycDist
 dmapType.chpl:72: warning: 'BlockCyclic' is deprecated, please use 'blockCycDist' instead
 dmapType.chpl:84: warning: 'DimensionalDist2D' is deprecated, please use 'dimensionalDist2D' instead
 dmapType.chpl:85: warning: 'DimensionalDist2D' is deprecated, please use 'dimensionalDist2D' instead
+dmapType.chpl:92: warning: 'DimensionalDist2D' is deprecated, please use 'dimensionalDist2D' instead
 dmapType.chpl:93: warning: 'DimensionalDist2D' is deprecated, please use 'dimensionalDist2D' instead
 dmapType.chpl:99: warning: 'Hashed' is deprecated, please use 'hashedDist' instead
 dmapType.chpl:103: warning: 'Hashed' is deprecated, please use 'hashedDist' instead
 dmapType.chpl:103: warning: 'Hashed' is deprecated, please use 'hashedDist' instead
-dmapType.chpl:92: warning: 'DimensionalDist2D' is deprecated, please use 'dimensionalDist2D' instead
 dmapType.chpl:4: warning: The use of 'dmap' is deprecated for this distribution; please replace 'new dmap(new <DistName>(<args>))' with 'new <DistName>(<args>)'
 dmapType.chpl:8: warning: The use of 'dmap' is deprecated for this distribution; please replace 'dmap(<DistName>(<args>))' with '<DistName>(<args>)'
 dmapType.chpl:14: warning: The use of 'dmap' is deprecated for this distribution; please replace 'new dmap(new <DistName>(<args>))' with 'new <DistName>(<args>)'

--- a/test/errors/scope-resolution/redefinition/parenless-and-parenful-fns.1.good
+++ b/test/errors/scope-resolution/redefinition/parenless-and-parenful-fns.1.good
@@ -1,3 +1,4 @@
 parenless-and-parenful-fns.chpl:1: In module 'M':
 parenless-and-parenful-fns.chpl:2: error: 'foo' has multiple definitions
 parenless-and-parenful-fns.chpl:3: note: redefined here
+parenless-and-parenful-fns.chpl:5: error: ambiguity between function and non-function at the same scope level

--- a/test/errors/scope-resolution/redefinition/parenless-and-parenful-fns.2.good
+++ b/test/errors/scope-resolution/redefinition/parenless-and-parenful-fns.2.good
@@ -11,3 +11,6 @@
       |   ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
       |
 
+─── error in parenless-and-parenful-fns.chpl:5 ───
+  Ambiguity between function and non-function at the same scope level
+

--- a/test/functions/bradc/resolution/arrayVsFn.good
+++ b/test/functions/bradc/resolution/arrayVsFn.good
@@ -1,2 +1,3 @@
 arrayVsFn.chpl:1: error: 'A' has multiple definitions
 arrayVsFn.chpl:3: note: redefined here
+arrayVsFn.chpl:8: error: ambiguity between function and non-function at the same scope level


### PR DESCRIPTION
This is a precursor to another PR, which enables resolution of more of the domain module code, and finds this curious case that doesn't work in Dyno:

```Chapel
proc foo(x: int) {}
proc bar(foo: (int, int)) {
  var res = foo(0);
}
```

In production, we expect the call to `foo` in the body of `bar` to be a tuple element access, but dyno incorrectly attempts to perform full function resolution. This is difficult since the inner `foo` is not a function.

In production, we resolve this problem by stopping the search for functions when we encounter a variable. In the case of an innermost variable, this is sound since variables are not overloaded or disambiguated (innermost is preferred). In the case of functions, this is sound because any functions defined _after_ the variable during the search must be more distant in terms of scopes, and thus would be rejected in favor of "nearer" functions.

I chose to implement this behavior in Dyno, particularly because of a `TODO` by @riftEmber that seemed to be adjusting for this kind of behavior. To do so in the most performant way (i.e., without iterating over the list of found IDs to see if any were variables), I adjusted all the lookup procedures to return a `LookupResult` instead of a boolean. This type is boolean-like (it supports `operator bool` and `|=`), but it contains _two_ booleans, one of which is whether a variable was found. From there, I adjust the early-return logic (previously: `innermostOnly && got`) to also handle the case of "I found a variable so I should stop looking". 

The only tricky aspect is detecting ambiguity, in which we found a function and non-function at the exact same place. We need to report an error when a variable _and_ a non-variable were found since the last "return point" (last check for `innermostOnly && got` etc.). For this, I did fall back to an iteration: if a variable is detected in a scope, and there are several copies of that variable, it's almost certainly an error.

Reviewed by @riftEmber -- thanks!

## Testing
- [x] dyno tests
- [x] paratest