### PR TITLE
Remove common-hpe-cray-ex GCC version pinning

### DIFF
--- a/util/cron/common-hpe-cray-ex.bash
+++ b/util/cron/common-hpe-cray-ex.bash
@@ -6,11 +6,6 @@ module unload $(module --terse list 2>&1 | grep PrgEnv-)
 
 module load PrgEnv-gnu
 
-# Load a newer gcc to avoid LLVM build errors
-module swap gcc gcc/12.2.0
-# Our test machine actually calls it 'gcc-native'
-module swap gcc-native gcc-native/12.3
-
 module load cray-pmi
 
 export CHPL_HOST_PLATFORM=hpe-cray-ex


### PR DESCRIPTION
Remove GCC module version pinning in `util/cron/common-hpe-cray-ex.bash`, as it may no longer be needed and it would be good to just support the latest version.

Follow up to https://github.com/chapel-lang/chapel/pull/26442.

[reviewer info placeholder]

Testing:
- [ ] manual run of an EX test config that sources this file