### PR TITLE
Dyno: fixes to timing script and infrastructure

### DIFF
--- a/frontend/test/resolution/testInteractive.cpp
+++ b/frontend/test/resolution/testInteractive.cpp
@@ -237,6 +237,7 @@ int main(int argc, char** argv) {
   bool enableStdLib = false;
   bool warnUnstable = false;
   const char* timing = nullptr;
+  bool timeAllGenerations = false;
   for (int i = 1; i < argc; i++) {
     if (0 == strcmp(argv[i], "--std")) {
       enableStdLib = true;
@@ -262,6 +263,8 @@ int main(int argc, char** argv) {
       }
       timing = argv[i+1];
       i++;
+    } else if (0 == strcmp(argv[i], "--time-all-generations")) {
+      timeAllGenerations = true;
     } else if (0 == strcmp(argv[i], "--brief")) {
       brief = true;
     } else if (0 == strcmp(argv[i], "--warn-unstable")) {
@@ -296,6 +299,8 @@ int main(int argc, char** argv) {
     return 0; // need this to return 0 for testing to be happy
   }
 
+  if (timing && timeAllGenerations) ctx->beginQueryTimingTrace(timing);
+
   while (true) {
     ctx->advanceToNextRevision(gc);
 
@@ -304,7 +309,7 @@ int main(int argc, char** argv) {
     setupSearchPaths(ctx, enableStdLib, cmdLinePaths, files);
     typeForBuiltin(ctx, UniqueString::get(ctx, "int"));
     ctx->setDebugTraceFlag(trace);
-    if (timing) ctx->beginQueryTimingTrace(timing);
+    if (timing && !timeAllGenerations) ctx->beginQueryTimingTrace(timing);
 
     CompilerFlags flags;
     flags.set(CompilerFlags::WARN_UNSTABLE, warnUnstable);
@@ -380,7 +385,7 @@ int main(int argc, char** argv) {
 
     printf("Ran %i queries to compute the above\n\n",
            ctx->numQueriesRunThisRevision());
-    if (timing) ctx->endQueryTimingTrace();
+    if (timing && !timeAllGenerations) ctx->endQueryTimingTrace();
 
     if (gc) {
       ctx->collectGarbage();
@@ -408,5 +413,6 @@ int main(int argc, char** argv) {
     }
   }
 
+  if (timing && timeAllGenerations) ctx->endQueryTimingTrace();
   return 0;
 }

--- a/frontend/util/analyze-query-trace
+++ b/frontend/util/analyze-query-trace
@@ -191,7 +191,7 @@ def to_dot(root: Forest, buf=sys.stdout, min_show_percent=1):
 
     fastest = fastest_self(root)
     slowest = slowest_self(root)
-    fastest_elapsed = fastest.self_elapsed
+    fastest_elapsed = fastest.self_elapsed + 0.001  # avoid div by zero
 
     # Print all the nodes and their labels
     for x in visit_forest(root):


### PR DESCRIPTION
This PR makes a small fix to the timing script, and adjust `testInteractive` to allow saving timing information across generations.

The fix to the timing script avoids division by zero (which happens often on my machine). I've run into the issue many times, but each time neglected to submit a simple fix. 

The change to `testInteractive` adds a new `--time-all-generations` switch to `testInteractive` which configures it to continue gathering query timings across generations, rather than saving the latest generation's timing and discarding others. This way, it's possible to measure the impact of changes to the query system on performance.

My sample script to gather performance switching back and forth between two files:

```bash
#!/bin/bash

# Create a pipe
pipe=/tmp/testpipe

if [[ ! -p $pipe ]]; then
    mkfifo $pipe
fi
echo "Pipe created"

exec 3<>$pipe
echo "Pipe opened"

$(find build -name "testInteractive") domains.main.chpl --std --time $1 --time-all-generations < $pipe &
echo "y" >&3
sleep 10

cp domains.2.chpl domains.main.chpl
echo "y" >&3
sleep 5

cp domains.1.chpl domains.main.chpl
echo "y" >&3
sleep 5

echo "n" >&3
sleep 5

exec 3>&-
rm $pipe
```

Reviewed by @benharsh -- thanks!

Running the script as `./script somefile`, you can then feed `somefile` into `frontend/util/analyze-query-trace`.