### PR TITLE
Fix some issues with 32-bit builds on allocations support

### DIFF
--- a/modules/standard/MemDiagnostics.chpl
+++ b/modules/standard/MemDiagnostics.chpl
@@ -264,15 +264,15 @@ iter allocations(minSize: integral = 0) {
   extern proc chpl_memtable_size(): c_int;
   extern proc chpl_memtable_entry(idx: c_int): c_ptr(void);
   extern proc chpl_memtable_next_entry(entry): c_ptr(void);
-  extern proc chpl_memtable_entry_addr(entry): uint;
-  extern proc chpl_memtable_entry_size(entry): uint;
+  extern proc chpl_memtable_entry_addr(entry): c_uintptr;
+  extern proc chpl_memtable_entry_size(entry): c_size_t;
 
   const hashSize = chpl_memtable_size();
   for i in 0..<hashSize {
     var entry = chpl_memtable_entry(i);
     while entry != nil {
-      var addr = chpl_memtable_entry_addr(entry);
-      var size = chpl_memtable_entry_size(entry);
+      var addr = chpl_memtable_entry_addr(entry): uint;
+      var size = chpl_memtable_entry_size(entry): uint;
 
       if size >= minSize then yield (addr,size);
 

--- a/runtime/include/chplmemtrack.h
+++ b/runtime/include/chplmemtrack.h
@@ -59,8 +59,8 @@ void chpl_stopVerboseMemHere(void);
 int chpl_memtable_size(void);
 void* chpl_memtable_entry(int idx);
 void* chpl_memtable_next_entry(void* entry);
-uint64_t chpl_memtable_entry_addr(void* entry);
-uint64_t chpl_memtable_entry_size(void* entry);
+uintptr_t chpl_memtable_entry_addr(void* entry);
+size_t chpl_memtable_entry_size(void* entry);
 
 ///// These entry points are the essential memory tracking interface, called
 //    at memory allocation and deallocation points.

--- a/runtime/src/chplmemtrack.c
+++ b/runtime/src/chplmemtrack.c
@@ -804,12 +804,12 @@ void* chpl_memtable_next_entry(void* entry) {
   return (void*)(((memTableEntry*)entry)->nextInBucket);
 }
 
-uint64_t chpl_memtable_entry_addr(void* entry) {
-  return (uint64_t)(((memTableEntry*)entry)->memAlloc);
+uintptr_t chpl_memtable_entry_addr(void* entry) {
+  return (uintptr_t)(((memTableEntry*)entry)->memAlloc);
 }
 
-uint64_t chpl_memtable_entry_size(void* entry) {
+size_t chpl_memtable_entry_size(void* entry) {
   memTableEntry* _entry = (memTableEntry*)entry;
-  return (uint64_t)(_entry->size*_entry->number);
+  return (size_t)(_entry->size*_entry->number);
 }
 


### PR DESCRIPTION
We observed some issues with building the runtime on 32-bit systems. This is a fallout from https://github.com/chapel-lang/chapel/pull/26118.

This PR addresses the issue, which was about pointer sizes. While there, I also adjusted a size variable to have `size_t` type for better conformance to standards/conventions. The Chapel wrapper `allocations` still casts things to `uint`, so I don't expect any behavioral change for the user.

Test:
- [x] local `library/standard/Memory/Diagnostics/allocationsIter.chpl`
- [x] no-local `library/standard/Memory/Diagnostics/allocationsIter.chpl`