### PR TITLE
Partially revert Qthreads patch from #26328

### DIFF
--- a/third-party/qthread/README
+++ b/third-party/qthread/README
@@ -88,30 +88,3 @@ index 2ac887ed..2312c954 100644
  #define QTHREAD_FASTLOCK_SETUP()                                               \
    do {                                                                         \
 ```
-
-```
---- a/src/io.c
-+++ b/src/io.c
-@@ -74,7 +74,6 @@ static void qt_blocking_subsystem_internal_freemem(void) { /*{{{*/
- static void *qt_blocking_subsystem_proxy_thread(void *Q_UNUSED(arg)) { /*{{{*/
-   while (!atomic_load_explicit(&proxy_exit, memory_order_relaxed)) {
-     if (qt_process_blocking_call()) { break; }
--    MACHINE_FENCE;
-   }
-   atomic_fetch_sub_explicit(&io_worker_count, 1, memory_order_relaxed);
-   pthread_exit(NULL);
-```
-
-```
---- a/include/qthread/qthread.h
-+++ b/include/qthread/qthread.h
-@@ -87,7 +87,7 @@ using std::memory_order_relaxed;
-
- #include "macros.h"
-
--#define MACHINE_FENCE atomic_thread_fence(memory_order_acq_rel);
-+#define MACHINE_FENCE atomic_thread_fence(memory_order_seq_cst);
-
- #if QTHREAD_ASSEMBLY_ARCH == QTHREAD_AMD64
- #define QTHREAD_SWAPS_IMPLY_ACQ_REL_FENCES
-```

--- a/third-party/qthread/README
+++ b/third-party/qthread/README
@@ -88,3 +88,16 @@ index 2ac887ed..2312c954 100644
  #define QTHREAD_FASTLOCK_SETUP()                                               \
    do {                                                                         \
 ```
+
+```
+--- a/src/io.c
++++ b/src/io.c
+@@ -74,7 +74,6 @@ static void qt_blocking_subsystem_internal_freemem(void) { /*{{{*/
+ static void *qt_blocking_subsystem_proxy_thread(void *Q_UNUSED(arg)) { /*{{{*/
+   while (!atomic_load_explicit(&proxy_exit, memory_order_relaxed)) {
+     if (qt_process_blocking_call()) { break; }
+-    MACHINE_FENCE;
+   }
+   atomic_fetch_sub_explicit(&io_worker_count, 1, memory_order_relaxed);
+   pthread_exit(NULL);
+```

--- a/third-party/qthread/qthread-src/include/qthread/qthread.h
+++ b/third-party/qthread/qthread-src/include/qthread/qthread.h
@@ -87,7 +87,7 @@ using std::memory_order_relaxed;
 
 #include "macros.h"
 
-#define MACHINE_FENCE atomic_thread_fence(memory_order_seq_cst);
+#define MACHINE_FENCE atomic_thread_fence(memory_order_acq_rel);
 
 #if QTHREAD_ASSEMBLY_ARCH == QTHREAD_AMD64
 #define QTHREAD_SWAPS_IMPLY_ACQ_REL_FENCES

--- a/third-party/qthread/qthread-src/src/io.c
+++ b/third-party/qthread/qthread-src/src/io.c
@@ -74,7 +74,6 @@ static void qt_blocking_subsystem_internal_freemem(void) { /*{{{*/
 static void *qt_blocking_subsystem_proxy_thread(void *Q_UNUSED(arg)) { /*{{{*/
   while (!atomic_load_explicit(&proxy_exit, memory_order_relaxed)) {
     if (qt_process_blocking_call()) { break; }
-    MACHINE_FENCE;
   }
   atomic_fetch_sub_explicit(&io_worker_count, 1, memory_order_relaxed);
   pthread_exit(NULL);

--- a/third-party/qthread/qthread-src/src/io.c
+++ b/third-party/qthread/qthread-src/src/io.c
@@ -74,6 +74,7 @@ static void qt_blocking_subsystem_internal_freemem(void) { /*{{{*/
 static void *qt_blocking_subsystem_proxy_thread(void *Q_UNUSED(arg)) { /*{{{*/
   while (!atomic_load_explicit(&proxy_exit, memory_order_relaxed)) {
     if (qt_process_blocking_call()) { break; }
+    MACHINE_FENCE;
   }
   atomic_fetch_sub_explicit(&io_worker_count, 1, memory_order_relaxed);
   pthread_exit(NULL);


### PR DESCRIPTION
Partially reverts a Qthreads patch from #26328 which resulted in a performance penalty. The patch was meant to fix some performance regressions, but instead caused more than it helped.

This PR only reverts the changes to the definition of MACHINE_FENCE.

Closes https://github.com/chapel-lang/chapel/issues/26440

[Reviewed by @jhh67]