### PR TITLE
annotate arkouda tests running with --isolated

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -2552,7 +2552,7 @@ arkouda: &arkouda-base
   12/25/24:
     - text: Running tests with --isolated
       config: 16-node-xc
-  01/01/25:
+  01/02/25:
     - text: No longer running tests with --isolated
       config:  16-node-xc
 

--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -2549,6 +2549,12 @@ arkouda: &arkouda-base
     - Part of argTypeReductionMessage refactor (Bears-R-Us/arkouda#3845)
   10/29/24:
     - Fix performance regression in reductions benchmark (Bears-R-Us/arkouda#3874)
+  12/25/24:
+    - text: Running tests with --isolated
+      config: 16-node-xc
+  01/01/25:
+    - text: No longer running tests with --isolated
+      config:  16-node-xc
 
 arkouda-string:
   <<: *arkouda-base


### PR DESCRIPTION
arkouda tests on 16-node-xc ran with --isolated between 12/25/24 and 1/1/25

Nightly job was configured to run off of: https://github.com/chapel-lang/chapel/compare/main...vasslitvinov:chapel:arkouda-server-per-test