### PR TITLE
Dyno: check return types when validating interface constraints

### DIFF
--- a/frontend/include/chpl/types/BasicClassType.h
+++ b/frontend/include/chpl/types/BasicClassType.h
@@ -77,6 +77,11 @@ class BasicClassType final : public ManageableType {
 
   const Type* substitute(Context* context,
                          const PlaceholderMap& subs) const override {
+    if (!parentType_) {
+      CHPL_ASSERT(name() == USTR("RootClass"));
+      return this;
+    }
+
     return get(context, id(), name(),
                Type::substitute(context, parentType_, subs),
                Type::substitute(context, (const BasicClassType*) instantiatedFrom_, subs),

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -5644,9 +5644,18 @@ static bool validateReturnTypeForTemplate(ResolutionContext* rc,
   }
 
   if (!validIntent) {
-    CHPL_REPORT(rc->context(), InterfaceInvalidIntent, iftForErr,
-                implPointIdForErr, templateSig, candidateSig);
-    return false;
+    bool silenceReturnIntentError = false;
+    if (auto ag = templateFn->attributeGroup()) {
+      if (ag->hasPragma(uast::pragmatags::PRAGMA_IFC_ANY_RETURN_INTENT)) {
+        silenceReturnIntentError = true;
+      }
+    }
+
+    if (!silenceReturnIntentError) {
+      CHPL_REPORT(rc->context(), InterfaceInvalidIntent, iftForErr,
+                  implPointIdForErr, templateSig, candidateSig);
+      return false;
+    }
   }
 
   if (checkedYield) {

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -5592,7 +5592,7 @@ struct InterfaceCheckHelper {
     // for IDs being inside an interface is relatively slow.
     QualifiedType templateQT;
 
-    if (auto rt = templateFn->returnType()) {
+    if (templateFn->returnType()) {
       // Create a resolver for the interface, which pushes the current interface
       // as a frame for the resolver and thus provides 'witness' (which contains
       // associated types) to function resolution.

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -5679,7 +5679,7 @@ struct InterfaceCheckHelper {
     if (checkedYield) {
       // we checked the return type above, no more checks needed here.
     } else if (templateT != c.exprType().type()) {
-      // with the esxception of promotion, we expect an exact return type match
+      // with the exception of promotion, we expect an exact return type match
       if (!c.exprType().type()->isPromotionIteratorType()) {
         rc->context()->error(implPointId, "return type mismatch");
         return false;

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -5599,6 +5599,14 @@ struct InterfaceCheckHelper {
       ResolutionResultByPostorderID byPostorder;
       auto resolver = Resolver::createForInterfaceStmt(rc, itf, ift, witness, templateFn, byPostorder);
 
+      // Note: want to use the signature without substitutes here, because
+      // if we instantiate the signature with the "real" Self types, we
+      // get receiver scopes from Self when resolving the return type. However,
+      // we want the return type of the function to be determined entirely
+      // from its declaration within the interface, without the need to search
+      // instantiated scopes. So, use the signature with placeholders to
+      // perform return type resolution, _then_ replace the placeholders
+      // with associated types etc. to get the final return type.
       templateQT =
         returnType(rc, templateSig, c.poiInfo().poiScope())
           .substitute(rc->context(), *allPlaceholders);

--- a/frontend/test/resolution/testInterfaces.cpp
+++ b/frontend/test/resolution/testInterfaces.cpp
@@ -52,13 +52,13 @@ static std::string intercalate(const std::vector<std::string>& lines, const std:
 
 struct RecordSource {
   std::string typeName;
-  std::vector<std::tuple<bool, std::string>> methods;
+  std::vector<std::tuple<bool, std::string, std::string>> methods;
   std::vector<InterfaceSource*> interfaces;
 
   RecordSource(std::string name) : typeName(std::move(name)) {}
 
-  RecordSource& addMethod(bool isTypeMethod, std::string sig) {
-    methods.push_back({isTypeMethod, std::move(sig)});
+  RecordSource& addMethod(bool isTypeMethod, std::string sig, std::string kind = "proc") {
+    methods.push_back({isTypeMethod, std::move(sig), kind});
     return *this;
   }
 
@@ -75,7 +75,8 @@ struct RecordSource {
     for (const auto& line : methods) {
       auto isTypeMethod = std::get<0>(line);
       auto& sig = std::get<1>(line);
-      methodLines.push_back(indent + "proc " + (isTypeMethod ? "type " : "") + prefix + sig);
+      auto kind = std::get<2>(line);
+      methodLines.push_back(indent + kind + " " + (isTypeMethod ? "type " : "") + prefix + sig);
     }
     return methodLines;
   }
@@ -631,6 +632,128 @@ static void testFormalOrdering() {
   testSingleInterface(i, r2, ErrorType::InterfaceReorderedFnFormals);
 }
 
+static void testBasicReturnTypes() {
+  auto i = InterfaceSource("myInterface", "proc Self.foo(): int;");
+  auto r1 = RecordSource("myRec")
+    .addMethod(NOT_A_TYPE_METHOD, "foo() do return 42;")
+    .addInterfaceConstraint(i);
+  testSingleInterface(i, r1);
+
+  auto r2 = RecordSource("myRec")
+    .addMethod(NOT_A_TYPE_METHOD, "foo() do return 42.0;")
+    .addInterfaceConstraint(i);
+  testSingleInterface(i, r2, ErrorType::General /* InterfaceInvalidReturnType */);
+
+  auto r3 = RecordSource("myRec")
+    .addMethod(NOT_A_TYPE_METHOD, "foo() do return (42 : int(16));")
+    .addInterfaceConstraint(i);
+  testSingleInterface(i, r3, ErrorType::General /* InterfaceInvalidReturnType */);
+}
+
+static void testBasicReturnTypesIter() {
+  auto i = InterfaceSource("myInterface", "iter Self.foo(): int;");
+  auto r1 = RecordSource("myRec")
+    .addMethod(NOT_A_TYPE_METHOD, "foo() do yield 42;", "iter")
+    .addInterfaceConstraint(i);
+  testSingleInterface(i, r1);
+
+  auto r2 = RecordSource("myRec")
+    .addMethod(NOT_A_TYPE_METHOD, "foo() do yield 42.0;", "iter")
+    .addInterfaceConstraint(i);
+  testSingleInterface(i, r2, ErrorType::General /* InterfaceInvalidReturnType */);
+
+  auto r3 = RecordSource("myRec")
+    .addMethod(NOT_A_TYPE_METHOD, "foo() do yield (42 : int(16));", "iter")
+    .addInterfaceConstraint(i);
+  testSingleInterface(i, r3, ErrorType::General /* InterfaceInvalidReturnType */);
+}
+
+static void testMismatchedFnKind() {
+  auto i1 = InterfaceSource("myInterface", "iter Self.foo(): int;");
+  auto r1 = RecordSource("myRec")
+    .addMethod(NOT_A_TYPE_METHOD, "foo() do yield 42;", "proc")
+    .addInterfaceConstraint(i1);
+  testSingleInterface(i1, r1, ErrorType::General /* InterfaceInvalidReturnType */);
+
+  auto i2 = InterfaceSource("myInterface", "proc Self.foo(): int;");
+  auto r2 = RecordSource("myRec")
+    .addMethod(NOT_A_TYPE_METHOD, "foo() do yield 42;", "iter")
+    .addInterfaceConstraint(i1);
+  testSingleInterface(i2, r2, ErrorType::General /* InterfaceInvalidReturnType */);
+}
+
+static void testPromotion() {
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  {
+    std::string program =
+      R"""(
+      module M {
+        interface myInterface {
+          proc Self.foo();
+        }
+        record myRec : myInterface {
+          proc chpl__promotionType() type do return int;
+        }
+        proc int.foo() {}
+        param satisfies = __primitive("implements interface", myRec, myInterface) == 0;
+      }
+      )""";
+
+    auto satisfies = resolveTypesOfVariables(context, program, {"satisfies"}).at("satisfies");
+    assert(!guard.realizeErrors());
+    assert(satisfies.isParamTrue());
+  }
+
+  {
+    context->advanceToNextRevision(false);
+    std::string program =
+      R"""(
+      module M {
+        interface myInterface {
+          proc Self.foo(): int;
+        }
+        record myRec : myInterface {
+          proc chpl__promotionType() type do return int;
+        }
+        proc int.foo(): int {}
+        param satisfies = __primitive("implements interface", myRec, myInterface) == 0;
+      }
+      )""";
+
+    auto satisfies = resolveTypesOfVariables(context, program, {"satisfies"}).at("satisfies");
+    assert(guard.numErrors() > 0);
+    assert(findError(guard.errors(), ErrorType::General /* InterfacePromotionNonVoid */));
+    assert(satisfies.isParamFalse());
+    guard.realizeErrors();
+  }
+
+  {
+    context->advanceToNextRevision(false);
+    std::string program =
+      R"""(
+      module M {
+        interface myInterface {
+          proc Self.foo();
+        }
+        record myRec : myInterface {
+          proc chpl__promotionType() type do return int;
+        }
+        proc int.foo() do return 42;
+        param satisfies = __primitive("implements interface", myRec, myInterface) == 0;
+      }
+      )""";
+
+    auto satisfies = resolveTypesOfVariables(context, program, {"satisfies"}).at("satisfies");
+    assert(guard.numErrors() > 0);
+    assert(findError(guard.errors(), ErrorType::General /* InterfaceInvalidReturnType */));
+    assert(satisfies.isParamFalse());
+    guard.realizeErrors();
+  }
+}
+
 static void expectError(const std::string& program, ErrorType error) {
   Context ctx;
   Context* context = &ctx;
@@ -735,6 +858,11 @@ int main() {
   testAssociatedTypeInFn();
   testFormalNaming();
   testFormalOrdering();
+
+  testBasicReturnTypes();
+  testBasicReturnTypesIter();
+  testMismatchedFnKind();
+  testPromotion();
 
   // tests for the various error message cases
   testImplementsInvalidInterface();


### PR DESCRIPTION
Depends on https://github.com/chapel-lang/chapel/pull/26396.

This PR implements return type checking for interfaces. To fit that nicely into the existing structure, it separates the main "find function that matches the given interface requirement" into pieces (building the call, picking a candidate, checking the formals, return type, and return intent). From there, it implements the rules as currently specified in `interfaceResolution`.

The rules are as follows:

For types:
* For iterators, we check the yield type of the iterator, since calls to different `iter` procedures produce distinct _return_ types.
* Otherwise, we expect an exact match of the return type, with the one exception...
* When using a promoted call to satisfy an interface constraint (allowed in production), we require that both the interface requirement and the matching function return 'void'.

For intents:
* Outside of an exact match, we allow `ref`, `const ref`, and `param` returns where values are expected (we can just dereference / construct a value).
* For functions that expect `cons ref`, we allow `ref`, since we can always not modify the mutable reference.

Reviewed by @dlongnecke-cray -- thanks!

## Testing
- [x] dyno tests
- [x] paratest