### PR TITLE
Require a minimum of CUDA 11.7 for CHPL_GPU=nvidia

### DIFF
--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -150,7 +150,7 @@ The following are further requirements for GPU support:
 
 * Specifically for targeting NVIDIA GPUs:
 
-  * CUDA toolkit version 11.x or 12.x must be installed.
+  * CUDA toolkit version 11.7+ or 12.x must be installed.
 
   * We test with system LLVM 19. Older versions may work.
 
@@ -663,7 +663,7 @@ marked with * are covered in our nightly testing configurations.
 
   * Hardware: RTX A2000, P100*, V100*, A100*, H100, GH200
 
-  * Software: CUDA 11.3, 11.6, 11.8*, 12.0, 12.2, 12.4*
+  * Software: CUDA 11.7, 11.8*, 12.0, 12.2, 12.4*
 
 * AMD
 

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -476,7 +476,7 @@ def _validate_rocm_llvm_version_impl(gpu: gpu_type):
 def _validate_cuda_version_impl():
     """Check that the installed CUDA version is >= MIN_REQ_VERSION and <
        MAX_REQ_VERSION"""
-    MIN_REQ_VERSION = "7"
+    MIN_REQ_VERSION = "11.7"
     MAX_REQ_VERSION = "13"
 
     cuda_version = get_sdk_version()


### PR DESCRIPTION
Require a minimum version of CUDA, 11.7, for building the compiler/runtime with CHPL_GPU=nvidia

[Reviewed by @e-kayrakli]