### PR TITLE
Fix the map.init= arg intent

### DIFF
--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -213,7 +213,7 @@ module Map {
       :arg other: The map to initialize from.
       :type other: map
     */
-    proc init=(ref other: map(?kt, ?vt, ?ps)) lifetime this < other {
+    proc init=(const ref other: map(?kt, ?vt, ?ps)) lifetime this < other {
 
       // TODO: There has got to be some way that we can abstract this!
       // Arguably this is something that the compiler should be

--- a/test/library/standard/Map/copyInitArgIntent.chpl
+++ b/test/library/standard/Map/copyInitArgIntent.chpl
@@ -1,0 +1,11 @@
+use Map;
+
+proc foo(const ref m: map(int, int)) {
+  var newMap = m;
+  writeln(newMap[10]);
+}
+
+var m = new map(int, int);
+m[10] = 10;
+
+foo(m);


### PR DESCRIPTION
I noticed that I wasn't able to pass `map`s as `const ref`s and use them in copy initializers. I believe the fix is simple, but `map` has some complicated internal implementation for class management etc, for which this fix here might be problematic.

Test:
- [x] linux64
- [x] gasnet