### PR TITLE
Add a verification check to `printchplenv` to catch build system misconfigurations

### DIFF
--- a/make/Makefile.base
+++ b/make/Makefile.base
@@ -81,7 +81,7 @@ ifndef CHPL_MAKE_CHPLENV_CACHE
 # Evaluate all of the definitions in CHPL_MAKE_ALL_VARS before running
 # printchplenv in order to pass the existing values from the compiler forward
 
-export CHPL_MAKE_CHPLENV_CACHE := $(shell $(CHPL_MAKE_ALL_VARS) $(CHPL_MAKE_HOME)/util/printchplenv --all --internal --no-tidy --make | tr '\n' '|' )
+export CHPL_MAKE_CHPLENV_CACHE := $(shell $(CHPL_MAKE_ALL_VARS) $(CHPL_MAKE_HOME)/util/printchplenv --all --internal --no-tidy --make --verify | tr '\n' '|')
 endif
 
 # This really needs TWO newlines!

--- a/util/chplenv/chplenv_verify.py
+++ b/util/chplenv/chplenv_verify.py
@@ -101,13 +101,28 @@ class TestCompile(VerificationPass):
         """
         return ""
 
-    def _compiler(self):
+    def _compiler_env_var(self):
         """
-        Returns the compiler to be used
+        Returns the compiler environment variable to be used
 
         Extended by subclasses
         """
-        return []
+        return ""
+
+    def _compiler(self):
+        """
+        Returns the compiler to be used, uses _compiler_env_var by default
+
+        Extended by subclasses
+        """
+        cc_var = self._compiler_env_var()
+        if not cc_var:
+            return []
+        cc = self.chplenv.get(cc_var)
+        if not cc:
+            self.msg = "{0} is missing".format(cc_var)
+            return []
+        return shlex.split(cc)
 
     def _compiler_args(self):
         """
@@ -174,12 +189,8 @@ class TestHostCompile(TestCompile):
     def _lang(self):
         return "C++"
 
-    def _compiler(self):
-        cxx = self.chplenv.get("CHPL_HOST_CXX")
-        if not cxx:
-            self.msg = "CHPL_HOST_CXX is missing"
-            return []
-        return shlex.split(cxx)
+    def _compiler_env_var(self):
+        return "CHPL_HOST_CXX"
 
     def _program(self):
         return """
@@ -202,12 +213,8 @@ class TestTargetCompileCC(TestCompile):
     def _lang(self):
         return "C"
 
-    def _compiler(self):
-        cc = self.chplenv.get("CHPL_TARGET_CC")
-        if not cc:
-            self.msg = "CHPL_TARGET_CC is missing"
-            return []
-        return shlex.split(cc)
+    def _compiler_env_var(self):
+        return "CHPL_TARGET_CC"
 
     def _program(self):
         return """
@@ -231,12 +238,8 @@ class TestTargetCompileCXX(TestCompile):
     def _lang(self):
         return "C++"
 
-    def _compiler(self):
-        cxx = self.chplenv.get("CHPL_TARGET_CXX")
-        if not cxx:
-            self.msg = "CHPL_TARGET_CXX is missing"
-            return []
-        return shlex.split(cxx)
+    def _compiler_env_var(self):
+        return "CHPL_TARGET_CXX"
 
     def _program(self):
         return """
@@ -259,12 +262,8 @@ class TestHostCanFindLLVM(TestCompile):
     def _lang(self):
         return "C++"
 
-    def _compiler(self):
-        cxx = self.chplenv.get("CHPL_HOST_CXX")
-        if not cxx:
-            self.msg = "CHPL_HOST_CXX is missing"
-            return []
-        return shlex.split(cxx)
+    def _compiler_env_var(self):
+        return "CHPL_HOST_CXX"
 
     def _compiler_args(self):
         comp_args = self.chplenv.get("CHPL_HOST_SYSTEM_COMPILE_ARGS", "")

--- a/util/chplenv/chplenv_verify.py
+++ b/util/chplenv/chplenv_verify.py
@@ -1,0 +1,289 @@
+"""
+Verifies that the current environment is set up correctly for building Chapel, and that once built the compiler will function correctly.
+"""
+
+import functools
+from utils import try_run_command, memoize
+import tempfile
+import shutil
+import sys
+import os
+import shlex
+
+passes = []
+
+def log(*args, **kwargs):
+    kwargs = {**kwargs, "file": sys.stderr}
+    verbose = False
+    if "verbose" in kwargs:
+        verbose = kwargs["verbose"]
+        del kwargs["verbose"]
+    if verbose:
+        print(*args, **kwargs)
+
+def register(_cls=None, *, after=None):
+    def decorator_register(cls):
+        global passes
+        if after:
+            idx = next(
+                i
+                for i, (name, _) in enumerate(passes)
+                if name == after.__name__
+            )
+            passes.insert(idx + 1, (cls.__name__, cls))
+        else:
+            passes.append((cls.__name__, cls))
+
+        @functools.wraps(cls)
+        def wrapper_register(*args, **kwargs):
+            return cls(*args, **kwargs)
+
+        return wrapper_register
+
+    if _cls is None:
+        return decorator_register
+    else:
+        return decorator_register(_cls)
+
+
+class VerificationPass:
+    def __init__(self, chplenv, verbose=False):
+        self.chplenv = chplenv
+        self.verbose = verbose
+        self.msg = None
+
+    def log(self, *args, **kwargs):
+        log("  ", *args, **kwargs, verbose=self.verbose)
+
+    def verify(self):
+        return False
+
+    def explain(self):
+        return self.msg or "Unknown error"
+
+
+class FileCleanupManager:
+    def __init__(self, *files):
+        self.files = list(files)
+
+    def track(self, f):
+        self.files.append(f)
+
+    def cleanup(self):
+        for f in self.files:
+            shutil.rmtree(f)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.cleanup()
+
+
+class TestCompile(VerificationPass):
+    """
+    Try and compile a hello world program
+    """
+
+    def _suffix(self):
+        return ""
+
+    def _lang(self):
+        return ""
+
+    def _compiler(self):
+        return []
+
+    def _compiler_args(self):
+        return []
+
+    def _program(self):
+        return ""
+
+
+    def verify(self):
+        tmpdir = tempfile.mkdtemp()
+
+        hello_file = tempfile.mkstemp(dir=tmpdir, suffix=self._suffix(), text=True)
+        with open(hello_file[1], "w") as f:
+            f.write(self._program())
+
+        with FileCleanupManager(tmpdir) as fcm:
+            cmd = self._compiler() + [hello_file[1], "-o", f"{tmpdir}/a.out"] + self._compiler_args()
+            self.log("Trying to compile with '{}'".format(" ".join(cmd)))
+            succ, ret, out, _ = try_run_command(cmd, combine_output=True)
+            if not succ or ret != 0:
+                out = out if out is not None else "unknown error"
+                self.msg = "Failed to compile program: {}".format(out)
+                return False
+
+            # Run the program
+            cmd = [f"{tmpdir}/a.out"]
+            self.log("Trying to run with '{}'".format(" ".join(cmd)))
+            succ, ret, out, _ = try_run_command(cmd, combine_output=True)
+            if not succ or ret != 0:
+                out = out if out is not None else "unknown error"
+                self.msg = "Failed to run program: {}".format(out)
+                return False
+
+        return True
+
+    def explain(self):
+        if not self.msg:
+            compiler = self._compiler()
+            if not compiler:
+                self.msg = "No compiler found"
+            self.msg = "{} compiler '{}' cannot compile programs".format(self._lang(), compiler[0])
+        return super().explain()
+
+
+@register
+class TestHostCompile(TestCompile):
+    """
+    Try and compile a hello world program using CHPL_HOST_CXX
+    """
+
+    def _suffix(self):
+        return ".cpp"
+
+    def _lang(self):
+        return "C++"
+
+    def _compiler(self):
+        cxx = self.chplenv.get("CHPL_HOST_CXX")
+        if not cxx:
+            self.msg = "CHPL_HOST_CXX is missing"
+            return []
+        return shlex.split(cxx)
+
+    def _program(self):
+        return """
+#include <iostream>
+int main() {
+  std::cout << "Hello, World!" << std::endl;
+  return 0;
+}
+"""
+
+@register(after=TestHostCompile)
+class TestTargetCompileCC(TestCompile):
+    """
+    Try and compile a hello world program using CHPL_TARGET_CC
+    """
+
+    def _suffix(self):
+        return ".c"
+
+    def _lang(self):
+        return "C"
+
+    def _compiler(self):
+        cc = self.chplenv.get("CHPL_TARGET_CC")
+        if not cc:
+            self.msg = "CHPL_TARGET_CC is missing"
+            return []
+        return shlex.split(cc)
+
+    def _program(self):
+        return """
+#include <stdio.h>
+int main() {
+    printf("Hello, World!\\n");
+    return 0;
+}
+"""
+
+
+@register(after=TestTargetCompileCC)
+class TestTargetCompileCXX(TestCompile):
+    """
+    Try and compile a hello world program using CHPL_TARGET_CXX
+    """
+
+    def _suffix(self):
+        return ".cpp"
+
+    def _lang(self):
+        return "C++"
+
+    def _compiler(self):
+        cxx = self.chplenv.get("CHPL_TARGET_CXX")
+        if not cxx:
+            self.msg = "CHPL_TARGET_CXX is missing"
+            return []
+        return shlex.split(cxx)
+
+    def _program(self):
+        return """
+#include <iostream>
+int main() {
+    std::cout << "Hello, World!" << std::endl;
+    return 0;
+}
+"""
+
+@register(after=TestHostCompile)
+class TestHostCanFindLLVM(TestCompile):
+    """
+    Try and compile a hello world program using CHPL_HOST_CXX that includes a header from LLVM
+    """
+
+    def _suffix(self):
+        return ".cpp"
+
+    def _lang(self):
+        return "C++"
+
+    def _compiler(self):
+        cxx = self.chplenv.get("CHPL_HOST_CXX")
+        if not cxx:
+            self.msg = "CHPL_HOST_CXX is missing"
+            return []
+        return shlex.split(cxx)
+
+    def _compiler_args(self):
+        comp_args = self.chplenv.get("CHPL_HOST_SYSTEM_COMPILE_ARGS", "")
+        link_args = self.chplenv.get("CHPL_HOST_SYSTEM_LINK_ARGS", "")
+        return super()._compiler_args() + shlex.split(comp_args) + shlex.split(link_args)
+
+    def _program(self):
+        return """
+#include "clang/Basic/Version.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/LLVMContext.h"
+#include <iostream>
+int main() {
+    std::cout << clang::getLLVMRevision() << std::endl;
+    llvm::LLVMContext Context;
+    llvm::Module M("mymod", Context);
+    return 0;
+}
+"""
+
+    def verify(self):
+        # if CHPL_LLVM=none, then we don't need to test this
+        if self.chplenv.get("CHPL_LLVM") == "none":
+            return True
+        return super().verify()
+
+    def explain(self):
+        compiler = self._compiler()
+        if not compiler:
+            return "No compiler found"
+        return "{} cannot find LLVM headers".format(compiler[0])
+
+
+def verify(chplenv, verbose=False):
+
+    mychplenv = {}
+    # Remove leading/trailing whitespace from keys
+    for k, v in chplenv.items():
+        mychplenv[k.strip()] = v
+
+    global passes
+    for name, cls in passes:
+        log(f"Running verification pass {name}", verbose=verbose)
+        p = cls(mychplenv, verbose=verbose)
+        if not p.verify():
+            return (False, p.explain())
+    return (True, None)

--- a/util/chplenv/chplenv_verify.py
+++ b/util/chplenv/chplenv_verify.py
@@ -82,22 +82,47 @@ class FileCleanupManager:
 
 class TestCompile(VerificationPass):
     """
-    Try and compile a hello world program
+    Abstract base class for testing compiling programs
     """
 
     def _suffix(self):
+        """
+        Returns the suffix of the file to be created
+
+        Extended by subclasses
+        """
         return ""
 
     def _lang(self):
+        """
+        Returns the language of the file to be created
+
+        Extended by subclasses
+        """
         return ""
 
     def _compiler(self):
+        """
+        Returns the compiler to be used
+
+        Extended by subclasses
+        """
         return []
 
     def _compiler_args(self):
+        """
+        Returns the compiler arguments to be used
+
+        Extended by subclasses
+        """
         return []
 
     def _program(self):
+        """
+        Returns the program to be compiled
+
+        Extended by subclasses
+        """
         return ""
 
 

--- a/util/chplenv/chplenv_verify.py
+++ b/util/chplenv/chplenv_verify.py
@@ -10,6 +10,7 @@ import sys
 import os
 import shlex
 
+
 def log(*args, **kwargs):
     kwargs = {**kwargs, "file": sys.stderr}
     verbose = False
@@ -18,6 +19,7 @@ def log(*args, **kwargs):
         del kwargs["verbose"]
     if verbose:
         print(*args, **kwargs)
+
 
 class VerificationPass:
     def __init__(self, chplenv, verbose=False):
@@ -113,16 +115,21 @@ class TestCompile(VerificationPass):
         """
         return ""
 
-
     def verify(self):
         tmpdir = tempfile.mkdtemp()
 
-        hello_file = tempfile.mkstemp(dir=tmpdir, suffix=self._suffix(), text=True)
+        hello_file = tempfile.mkstemp(
+            dir=tmpdir, suffix=self._suffix(), text=True
+        )
         with open(hello_file[1], "w") as f:
             f.write(self._program())
 
         with FileCleanupManager(tmpdir) as fcm:
-            cmd = self._compiler() + [hello_file[1], "-o", f"{tmpdir}/a.out"] + self._compiler_args()
+            cmd = (
+                self._compiler()
+                + [hello_file[1], "-o", f"{tmpdir}/a.out"]
+                + self._compiler_args()
+            )
             self.log("Trying to compile with '{}'".format(" ".join(cmd)))
             succ, ret, out, _ = try_run_command(cmd, combine_output=True)
             if not succ or ret != 0:
@@ -146,7 +153,9 @@ class TestCompile(VerificationPass):
             compiler = self._compiler()
             if not compiler:
                 self.msg = "No compiler found"
-            self.msg = "{} compiler '{}' cannot compile programs".format(self._lang(), compiler[0])
+            self.msg = "{} compiler '{}' cannot compile programs".format(
+                self._lang(), compiler[0]
+            )
         return super().explain()
 
 
@@ -172,6 +181,7 @@ int main() {
   return 0;
 }
 """
+
 
 class TestTargetCompileCC(TestCompile):
     """
@@ -220,6 +230,7 @@ int main() {
 }
 """
 
+
 class TestHostCanFindLLVM(TestCompile):
     """
     Try and compile a hello world program using CHPL_HOST_CXX that includes a header from LLVM
@@ -237,7 +248,11 @@ class TestHostCanFindLLVM(TestCompile):
     def _compiler_args(self):
         comp_args = self.chplenv.get("CHPL_HOST_SYSTEM_COMPILE_ARGS", "")
         link_args = self.chplenv.get("CHPL_HOST_SYSTEM_LINK_ARGS", "")
-        return super()._compiler_args() + shlex.split(comp_args) + shlex.split(link_args)
+        return (
+            super()._compiler_args()
+            + shlex.split(comp_args)
+            + shlex.split(link_args)
+        )
 
     def _program(self):
         return """
@@ -272,6 +287,7 @@ passes = [
     ("TestTargetCompileCXX", TestTargetCompileCXX),
     ("TestHostCanFindLLVM", TestHostCanFindLLVM),
 ]
+
 
 def verify(chplenv, verbose=False):
 

--- a/util/chplenv/utils.py
+++ b/util/chplenv/utils.py
@@ -13,6 +13,21 @@ except ImportError:
     # Backport for pre Python 3.2
     from distutils.spawn import find_executable as which
 
+
+_CHPL_DEVELOPER = False
+
+def CHPL_DEVELOPER():
+    global _CHPL_DEVELOPER
+    return _CHPL_DEVELOPER
+
+def init_CHPL_DEVELOPER():
+    global _CHPL_DEVELOPER
+    _CHPL_DEVELOPER = is_true(os.environ.get('CHPL_DEVELOPER', False))
+
+def set_CHPL_DEVELOPER(value):
+    global _CHPL_DEVELOPER
+    _CHPL_DEVELOPER = is_true(value)
+
 # should not need this outside of this class
 _warning_buffer = []
 _buffer_warnings = True
@@ -42,8 +57,7 @@ ignore_errors = False
 
 def error(msg, exception=Exception):
     """Exception raising wrapper that differentiates developer-mode output"""
-    developer = os.environ.get('CHPL_DEVELOPER')
-    if developer and developer != "0" and not ignore_errors:
+    if CHPL_DEVELOPER() and not ignore_errors:
         # before rasing the exception, flush the warnings
         flush_warnings()
         raise exception(msg)
@@ -180,6 +194,11 @@ def is_ver_in_range(versionStr, minimumStr, maximumStr):
             return False
 
     return False
+
+
+def is_true(value):
+    truthy = ('yes', 'Yes', 'YES', 'y', 'Y', 'true', 'True', 'TRUE', 't', 'T', '1', True)
+    return value in truthy
 
 
 class _UtilsTests(unittest.TestCase):


### PR DESCRIPTION
This PR adds a prototypical new flag to `printchplenv`, `--verify`. This will run verification passes on the current Chapel configuration.

This PR implements a few of these verification checks, the primary ones being checking that the host and target compilers work properly. This can help users diagnose issues with their toolchain, like https://github.com/chapel-lang/chapel/issues/24819

This PR also turns the verification on by default when `printchplenv` is invoked from `make`, but does not abort the build.

[Reviewed by @DanilaFe]