### PR TITLE
Add skipif for future test

### DIFF
--- a/test/extern/ferguson/bug-global-c-array.skipif
+++ b/test/extern/ferguson/bug-global-c-array.skipif
@@ -1,1 +1,2 @@
 CHPL_COMM == none
+CHPL_TARGET_COMPILER != llvm


### PR DESCRIPTION
Adds a skipif for a future test which has a different failure mode with the C backend

[Not reviewed - trivial]