### PR TITLE
Remove commented sysFilename var with FILENAME_MAX

### DIFF
--- a/runtime/src/launch/aprun/launch-aprun.c
+++ b/runtime/src/launch/aprun/launch-aprun.c
@@ -29,9 +29,6 @@
 #include "error.h"
 #include "aprun-utils.h"
 
-// #define baseSysFilename ".chpl-sys-"
-// char sysFilename[FILENAME_MAX];
-
 #define CHPL_CC_ARG "-cc"
 static const char *_ccArg = NULL;
 static const char* debug = NULL;


### PR DESCRIPTION
Remove some very old (2012) commented-out code containing a use of `FILENAME_MAX`.

Found this doing a final grep for any uses of `FILENAME_MAX` for https://github.com/chapel-lang/chapel/issues/8757.

Follow up to https://github.com/chapel-lang/chapel/pull/26381.

[trivial, not reviewed]