### PR TITLE
Make the sync flag's type consistent in the Socket module

### DIFF
--- a/modules/packages/Socket.chpl
+++ b/modules/packages/Socket.chpl
@@ -859,7 +859,7 @@ proc connect(const ref address: ipAddr, in timeout = indefiniteTimeout): tcpConn
     setBlocking(socketFd, true);
     return new file(socketFd):tcpConn;
   }
-  var localSync: sync int = 0;
+  var localSync: sync c_short = 0;
   localSync.readFE();
   var writerEvent = event_new(event_loop_base, socketFd, EV_WRITE | EV_TIMEOUT, c_ptrTo(syncRWTCallback), c_ptrTo(localSync):c_ptr(void));
   defer {
@@ -1585,7 +1585,7 @@ pthread_create(c_ptrTo(event_loop_thread), nil:c_ptr(pthread_attr_t), c_ptrTo(di
 
 @chpldoc.nodoc
 proc syncRWTCallback(fd: c_int, event: c_short, arg: c_ptr(void)) {
-  var syncVariablePtr = arg: c_ptr(sync int);
+  var syncVariablePtr = arg: c_ptr(sync c_short);
   syncVariablePtr.deref().writeEF(event);
 }
 


### PR DESCRIPTION
The Socket module uses a sync variable in some of its functions to wait for some events. This sync variable is passed via `c_ptr`s to a callback function. However there are inconsistencies in the types used:

- There are 4 places where this happens: 3 of them uses `sync c_short`, 1 uses `sync int`
- The callback function assumes that the flag is `sync int`.

The callbacks seems to write a `c_short` into this sync variable. Therefore, I assume that `c_short` is a more correct choice. So, this PR makes the sync variable of `c_short` type and adjusts the callback.

Test:
- [x] local