### PR TITLE
Change wording for Windows/WSL packages in docs

### DIFF
--- a/doc/rst/platforms/windows.rst
+++ b/doc/rst/platforms/windows.rst
@@ -32,9 +32,8 @@ This example shows how to install WSL and Ubuntu on Windows 10/11::
 There are two main approaches for using Chapel on WSL:
 
 1) Install via a prebuilt Chapel package. This is the quickest way to get up
-   and running, but it results in a copy of Chapel without GPU support and that
-   only supports shared-memory (single-locale) executions. See the list of available
-   packages released on the `Chapel GitHub page <https://github.com/chapel-lang/chapel/releases>`_.
+   and running. For a Chapel install with GPU support, build Chapel from source.
+   See the list of available packages released on the `Chapel GitHub page <https://github.com/chapel-lang/chapel/releases>`_.
 
 2) Build Chapel from source, as with any other UNIX system. This is slightly
    more involved, but supports Chapel's full feature set. See the list of prerequisites


### PR DESCRIPTION
Changes the wording around Windows/WSL install information for packages.

I encountered a user who was attempting to install Chapel for multi-locale execution with GASNet. They were building from source (I think thats just because what they were directed to), but they could have just installed the package and saved a lot of time. This made me wonder if our docs should mention the Linux packages on WSL, and I found they do but they also said only shared memory was supported. This PR updates that wording.

[Reviewed by @arezaii]  