### PR TITLE
Remove cmake note in quickstart instructions

### DIFF
--- a/doc/rst/usingchapel/QUICKSTART.rst
+++ b/doc/rst/usingchapel/QUICKSTART.rst
@@ -104,8 +104,7 @@ rebuild Chapel from source in a different configuration:
 
   - Or, use ``export CHPL_LLVM=bundled`` to have Chapel build and use the
     bundled version of LLVM. Note that building the bundled version of
-    LLVM can take a long time and requires CMake version 3.20 or
-    higher.
+    LLVM can take a long time.
 
   - Use ``export CHPL_LLVM=none`` to continue using the C back-end rather
     than LLVM

--- a/doc/rst/usingchapel/QUICKSTART.rst
+++ b/doc/rst/usingchapel/QUICKSTART.rst
@@ -104,7 +104,7 @@ rebuild Chapel from source in a different configuration:
 
   - Or, use ``export CHPL_LLVM=bundled`` to have Chapel build and use the
     bundled version of LLVM. Note that building the bundled version of
-    LLVM can take a long time and requires CMake version 3.13.4 or
+    LLVM can take a long time and requires CMake version 3.20 or
     higher.
 
   - Use ``export CHPL_LLVM=none`` to continue using the C back-end rather


### PR DESCRIPTION
Updates the note about cmake being required int the quickstart instructions, since its already a general prereq.

[Reviewed by @mppf]