### PR TITLE
Fix mistakes from removing `FILENAME_MAX`

### DIFF
--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -294,10 +294,8 @@ const char* getDirectory(const char* filename) {
   if (filenamebase == NULL) {
     return astr(".");
   } else {
-    const int len = filenamebase - filename;
-    char dir[len + 1];
-    strncpy(dir, filename, len);
-    dir[len] = '\0';
+    const int pos = filenamebase - filename;
+    std::string dir(filename, pos);
     return astr(dir);
   }
 }

--- a/runtime/src/launch/slurm-srun/launch-slurm-srun.c
+++ b/runtime/src/launch/slurm-srun/launch-slurm-srun.c
@@ -364,7 +364,7 @@ static char* chpl_launch_create_command(int argc, char* argv[],
         (strlen(baseSBATCHFilename) + snprintf(NULL, 0, "%d", (int)mypid) + 1),
         sizeof(char), CHPL_RT_MD_FILENAME, -1, 0);
     // set the sbatch filename
-    snprintf(slurmFilename, sizeof(slurmFilename), "%s%d", baseSBATCHFilename,
+    snprintf(slurmFilename, strlen(slurmFilename), "%s%d", baseSBATCHFilename,
              (int)mypid);
 
     // open the batch file and create the header

--- a/runtime/src/launch/slurm-srun/launch-slurm-srun.c
+++ b/runtime/src/launch/slurm-srun/launch-slurm-srun.c
@@ -443,12 +443,12 @@ static char* chpl_launch_create_command(int argc, char* argv[],
       snprintf(stdoutFileNoFmt, stdoutFileLen, "%s", outputfn);
     }
     else {
-      char* format="%s.%s.out";
+      const char* format="%s.%s.out";
       int stdoutFileLen = strlen(format) + strlen(argv[0]) + strlen("%j");
       stdoutFile = (char*)chpl_mem_allocMany(stdoutFileLen, sizeof(char),
                                              CHPL_RT_MD_FILENAME, -1, 0);
       snprintf(stdoutFile, stdoutFileLen, format, argv[0], "%j");
-      char* tempArg = "$SLURM_JOB_ID";
+      const char* tempArg = "$SLURM_JOB_ID";
       int stdoutFileNoFmtLen =
           strlen(format) + strlen(argv[0]) + strlen(tempArg);
       stdoutFileNoFmt = (char*)chpl_mem_allocMany(
@@ -466,8 +466,8 @@ static char* chpl_launch_create_command(int argc, char* argv[],
     // If we're buffering the output, set the temp output file name.
     // It's always <tmpDir>/binaryName.<jobID>.out.
     if (bufferStdout != NULL) {
-      char* format = "%s/%s.%s.out";
-      char* tempArg = "$SLURM_JOB_ID";
+      const char* format = "%s/%s.%s.out";
+      const char* tempArg = "$SLURM_JOB_ID";
       int tmpStdoutFileNoFmtLen =
           strlen(format) + strlen(tmpDir) + strlen(argv[0]) + strlen(tempArg);
       tmpStdoutFileNoFmt = (char*)chpl_mem_allocMany(
@@ -521,7 +521,7 @@ static char* chpl_launch_create_command(int argc, char* argv[],
 
     // the baseCommand is what will call the batch file
     // that was just created
-    char* format = "sbatch %s\n";
+    const char* format = "sbatch %s\n";
     int baseCommandLen = strlen(slurmFilename) + strlen(format);
     baseCommand = (char*)chpl_mem_allocMany(baseCommandLen, sizeof(char),
                                             CHPL_RT_MD_COMMAND_BUFFER, -1, 0);
@@ -611,7 +611,7 @@ static char* chpl_launch_create_command(int argc, char* argv[],
     }
 
     // launch the job using srun
-    char* format = "srun %s";
+    const char* format = "srun %s";
     int baseCommandLen = strlen(format) + len + 1;
     baseCommand = (char*)chpl_mem_allocMany(baseCommandLen, sizeof(char),
                                             CHPL_RT_MD_COMMAND_BUFFER, -1, 0);


### PR DESCRIPTION
Fix a handful of errors made in removing `FILENAME_MAX` from the compiler and runtime.

Follow up to https://github.com/chapel-lang/chapel/pull/26357 and https://github.com/chapel-lang/chapel/pull/26381.

[trivial fixes, not reviewed]

Testing:
- [x] paratest
- [x] C paratest
- [x] gasnet paratest
- [x] GPU tests
- [x] manual run of an affected test config for each failure mode