### PR TITLE
Fixup docs and comments after removal of `assertOnFailToGpuize`

### DIFF
--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -114,7 +114,7 @@ Benchmark examples
 
 Test examples
 ~~~~~~~~~~~~~
-* `assertOnFailToGpuize <https://github.com/chapel-lang/chapel/blob/main/test/gpu/native/assertOnFailToGpuize.chpl>`_ -- various examples of loops that are not eligible for GPU execution
+* `assertOnFailToGpuizeAttr <https://github.com/chapel-lang/chapel/blob/main/test/gpu/native/assertOnFailToGpuizeAttr.chpl>`_ -- various examples of loops that are not eligible for GPU execution
 * `mathOps <https://github.com/chapel-lang/chapel/blob/main/test/gpu/native/mathOps.chpl>`_ -- calls to various math functions within kernels that call out to the CUDA Math library
 * `measureGpuCycles <https://github.com/chapel-lang/chapel/blob/main/test/gpu/native/measureGpuCycles.chpl>`_ -- measuring time within a GPU kernel
 * `promotion2 <https://github.com/chapel-lang/chapel/blob/main/test/gpu/native/promotion2.chpl>`_ -- GPU kernels from promoted expressions

--- a/test/gpu/native/assertOnFailToGpuizeAttr.chpl
+++ b/test/gpu/native/assertOnFailToGpuizeAttr.chpl
@@ -1,7 +1,3 @@
-// This test and assertOnFailToGpuize are siblings; they both test the
-// same functionality, one as an attribute (this one) and one as
-// a "magic function call" (the other one).
-
 use GPU;
 
 config param failureMode = 8;

--- a/test/gpu/native/assertOnNotGpuEligible.chpl
+++ b/test/gpu/native/assertOnNotGpuEligible.chpl
@@ -1,4 +1,4 @@
-// This test and assertOnFailToGpuize are siblings; this one tests
+// This test and assertOnFailToGpuizeAttr are siblings; this one tests
 // @gpu.assertEligible, which does not have a runtime component.
 
 use GPU;


### PR DESCRIPTION
That test specifically made use of the old, functional form of `assertOnGpu`, and was deleted when that form was removed. However, a couple of comments and the tech note still referenced it. Fix that.

Reviewed by @stonea -- thanks!