### PR TITLE
Remove `setVisibility(hidden)` on functions called from AMD kernels

### DIFF
--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -2588,19 +2588,6 @@ void FnSymbol::codegenPrototype() {
           case GpuCodegenType::GPU_CG_CPU:
             break;
         }
-      } else {
-        // This is a function called from a GPU kernel
-        // hipcc marks such functions as hidden visibility
-        // so we do the same here.
-        switch (getGpuCodegenType()) {
-          case GpuCodegenType::GPU_CG_NVIDIA_CUDA:
-            break; // no visibility change for NVIDIA
-          case GpuCodegenType::GPU_CG_AMD_HIP:
-            func->setVisibility(llvm::Function::HiddenVisibility);
-            break;
-          case GpuCodegenType::GPU_CG_CPU:
-            break;
-        }
       }
     }
 


### PR DESCRIPTION
Removes a workaround for calling functions from an AMD GPU kernel.

This was added in https://github.com/chapel-lang/chapel/pull/22002, but seems to no longer be required. This was causing an LLVM assert to hit when marking a function as both having external linkage and being marked hidden: https://github.com/chapel-lang/chapel/issues/26424

resolves https://github.com/chapel-lang/chapel/issues/26424

Testing
- [x] `start_test test/gpu/native` with CHPL_GPU=amd
- [x] `start_test test/release/examples` with CHPL_GPU=amd

[Reviewed by @stonea]