### PR TITLE
Modify to avoid `exit(0)`

### DIFF
--- a/test/runtime/jhh/numColocales.chpl
+++ b/test/runtime/jhh/numColocales.chpl
@@ -3,13 +3,14 @@
 use OS.POSIX;
 use IO.FormattedIO;
 
+var status = "Success";
 var value = getenv("CHPL_RT_LOCALES_PER_NODE");
 if value {
     var n = string.createCopyingBuffer(value):int;
     if n != here.numColocales {
         writef("CHPL_RT_LOCALES_PER_NODE != here.numColocales (%i != %i)\n",
                n, here.numColocales);
-        exit(0);
+        status = "Failure";
     }
 }
-writeln("Success");
+writeln(status);


### PR DESCRIPTION
`exit(0)` currently doesn't work with `CHPL_LAUNCHER=slurm-srun` and `CHPL_COMM=ofi`, so avoid it.