### PR TITLE
add split-init error when uninitialized var used as actual

### DIFF
--- a/frontend/include/chpl/resolution/resolution-error-classes-list.h
+++ b/frontend/include/chpl/resolution/resolution-error-classes-list.h
@@ -80,7 +80,7 @@ ERROR_CLASS(MultipleEnumElems, const uast::AstNode*, chpl::UniqueString, const u
 ERROR_CLASS(MultipleInheritance, const uast::Class*, const uast::AstNode*, const uast::AstNode*)
 ERROR_CLASS(MultipleQuestionArgs, const uast::FnCall*, const uast::AstNode*, const uast::AstNode*)
 ERROR_CLASS(NestedClassFieldRef, const uast::TypeDecl*, const uast::TypeDecl*, const uast::AstNode*, ID)
-ERROR_CLASS(NoMatchingCandidates, const uast::AstNode*, resolution::CallInfo, std::vector<resolution::ApplicabilityResult>)
+ERROR_CLASS(NoMatchingCandidates, const uast::AstNode*, resolution::CallInfo, std::vector<resolution::ApplicabilityResult>, std::vector<resolution::FormalActual>, std::vector<const uast::VarLikeDecl*>)
 ERROR_CLASS(NonClassInheritance, const uast::AggregateDecl*, const uast::AstNode*, const types::Type*)
 ERROR_CLASS(NonIterable, const uast::AstNode*, const uast::AstNode*, types::QualifiedType, std::vector<std::tuple<uast::Function::IteratorKind, chpl::resolution::TheseResolutionResult>>)
 ERROR_CLASS(NoMatchingEnumValue, const uast::AstNode*, const types::EnumType*, types::QualifiedType)

--- a/frontend/include/chpl/resolution/resolution-error-classes-list.h
+++ b/frontend/include/chpl/resolution/resolution-error-classes-list.h
@@ -80,7 +80,7 @@ ERROR_CLASS(MultipleEnumElems, const uast::AstNode*, chpl::UniqueString, const u
 ERROR_CLASS(MultipleInheritance, const uast::Class*, const uast::AstNode*, const uast::AstNode*)
 ERROR_CLASS(MultipleQuestionArgs, const uast::FnCall*, const uast::AstNode*, const uast::AstNode*)
 ERROR_CLASS(NestedClassFieldRef, const uast::TypeDecl*, const uast::TypeDecl*, const uast::AstNode*, ID)
-ERROR_CLASS(NoMatchingCandidates, const uast::AstNode*, resolution::CallInfo, std::vector<resolution::ApplicabilityResult>, std::vector<resolution::FormalActual>, std::vector<const uast::VarLikeDecl*>)
+ERROR_CLASS(NoMatchingCandidates, const uast::AstNode*, resolution::CallInfo, std::vector<resolution::ApplicabilityResult>, std::vector<const uast::VarLikeDecl*>)
 ERROR_CLASS(NonClassInheritance, const uast::AggregateDecl*, const uast::AstNode*, const types::Type*)
 ERROR_CLASS(NonIterable, const uast::AstNode*, const uast::AstNode*, types::QualifiedType, std::vector<std::tuple<uast::Function::IteratorKind, chpl::resolution::TheseResolutionResult>>)
 ERROR_CLASS(NoMatchingEnumValue, const uast::AstNode*, const types::EnumType*, types::QualifiedType)

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -1431,6 +1431,11 @@ class ApplicabilityResult {
   PassingFailureReason formalReason() const { return formalReason_; }
 
   int formalIdx() const { return formalIdx_; }
+
+  inline bool failedDueToWrongActual() const {
+    return candidateReason_ == resolution::FAIL_CANNOT_PASS &&
+           formalReason_ != resolution::FAIL_UNKNOWN_FORMAL_TYPE;
+  }
 };
 
 /** FormalActual holds information on a function formal and its binding (if any) */

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1002,16 +1002,17 @@ handleRejectedCandidates(Context* context,
     if (/* skip computing the formal-actual map because it will go poorly
            with an unknown formal. */
         !candidate.failedDueToWrongActual()) {
-          continue;
+      continue;
     }
     auto fn = candidate.initialForErr();
     resolution::FormalActualMap fa(fn, ci);
     auto& badPass = fa.byFormalIdx(candidate.formalIdx());
     const uast::AstNode *actualExpr = nullptr;
     const uast::VarLikeDecl *actualDecl = nullptr;
-    CHPL_ASSERT(0 <= badPass.actualIdx() &&
-        (size_t)badPass.actualIdx() < actualAsts.size());
-    actualExpr = actualAsts[badPass.actualIdx()];
+    size_t actualIdx = badPass.actualIdx();
+    if (0 <= actualIdx && actualIdx < actualAsts.size()) {
+      actualExpr = actualAsts[badPass.actualIdx()];
+    }
 
     // look for a definition point of the actual for error reporting of
     // uninitialized vars typically in the case of bad split-initialization

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -994,9 +994,7 @@ handleRejectedCandidates(Context* context,
                          const std::vector<const uast::AstNode*>& actualAsts) {
   // By performing some processing in the resolver, we can issue a nicer error
   // explaining why each candidate was rejected.
-  std::vector<resolution::FormalActual> badPasses;
   std::vector<const uast::VarLikeDecl*> actualDecls;
-  badPasses.resize(rejected.size());
   actualDecls.resize(rejected.size());
   // check each rejected candidate for uninitialized actuals
   for (size_t i = 0; i < rejected.size(); i++) {
@@ -1008,7 +1006,6 @@ handleRejectedCandidates(Context* context,
       auto fn = candidate.initialForErr();
       resolution::FormalActualMap fa(fn, ci);
       auto& badPass = fa.byFormalIdx(candidate.formalIdx());
-      badPasses[i] = badPass;
       const uast::AstNode *actualExpr = nullptr;
       const uast::VarLikeDecl *actualDecl = nullptr;
       if (call && 0 <= badPass.actualIdx() &&
@@ -1028,8 +1025,8 @@ handleRejectedCandidates(Context* context,
       actualDecls[i] = actualDecl;
     }
   }
-  CHPL_ASSERT(badPasses.size() == rejected.size() && rejected.size() == actualDecls.size());
-  CHPL_REPORT(context, NoMatchingCandidates, call, ci, rejected, badPasses, actualDecls);
+  CHPL_ASSERT(rejected.size() == actualDecls.size());
+  CHPL_REPORT(context, NoMatchingCandidates, call, ci, rejected, actualDecls);
 }
 
 static void varArgTypeQueryError(Context* context,
@@ -1947,10 +1944,9 @@ Resolver::issueErrorForFailedCallResolution(const uast::AstNode* astForErr,
                      ci.name().c_str());
     } else {
       std::vector<const uast::VarLikeDecl*> uninitializedActuals;
-      std::vector<resolution::FormalActual> faPairs;
       // could not find a most specific candidate
       std::vector<ApplicabilityResult> rejected;
-      CHPL_REPORT(context, NoMatchingCandidates, astForErr, ci, rejected, faPairs, uninitializedActuals);
+      CHPL_REPORT(context, NoMatchingCandidates, astForErr, ci, rejected, uninitializedActuals);
     }
   } else {
     context->error(astForErr, "Cannot establish type for call expression");

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2050,17 +2050,16 @@ void Resolver::handleResolvedCallPrintCandidates(ResolvedExpression& r,
         badPasses.resize(rejected.size());
         actualDecls.resize(rejected.size());
         // check each rejected candidate for uninitialized actuals
-
         for (size_t i = 0; i < rejected.size(); i++) {
           auto& candidate = rejected[i];
           if (candidate.reason() == resolution::FAIL_CANNOT_PASS &&
-            /* skip printing detailed info_ here because computing the formal-actual
-            map will go poorly with an unknown formal. */
-            candidate.formalReason() != resolution::FAIL_UNKNOWN_FORMAL_TYPE) {
+              /* skip printing detailed info_ here because computing the formal-actual
+              map will go poorly with an unknown formal. */
+              candidate.formalReason() != resolution::FAIL_UNKNOWN_FORMAL_TYPE) {
             auto fn = candidate.initialForErr();
             resolution::FormalActualMap fa(fn, ci);
             auto badPass = fa.byFormalIdx(candidate.formalIdx());
-            badPasses[i] =badPass;
+            badPasses[i] = badPass;
             const uast::AstNode* actualExpr = nullptr;
             const uast::VarLikeDecl* actualDecl = nullptr;
             if (call && 0 <= badPass.actualIdx() &&

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2047,8 +2047,12 @@ void Resolver::handleResolvedCallPrintCandidates(ResolvedExpression& r,
         // error explaining why each candidate was rejected.
         std::vector<resolution::FormalActual> badPasses;
         std::vector<const uast::VarLikeDecl*> actualDecls;
+        badPasses.resize(rejected.size());
+        actualDecls.resize(rejected.size());
         // check each rejected candidate for uninitialized actuals
-        for (auto& candidate : rejected) {
+
+        for (size_t i = 0; i < rejected.size(); i++) {
+          auto& candidate = rejected[i];
           if (candidate.reason() == resolution::FAIL_CANNOT_PASS &&
             /* skip printing detailed info_ here because computing the formal-actual
             map will go poorly with an unknown formal. */
@@ -2056,7 +2060,7 @@ void Resolver::handleResolvedCallPrintCandidates(ResolvedExpression& r,
             auto fn = candidate.initialForErr();
             resolution::FormalActualMap fa(fn, ci);
             auto badPass = fa.byFormalIdx(candidate.formalIdx());
-            badPasses.push_back(badPass);
+            badPasses[i] =badPass;
             const uast::AstNode* actualExpr = nullptr;
             const uast::VarLikeDecl* actualDecl = nullptr;
             if (call && 0 <= badPass.actualIdx() &&
@@ -2073,9 +2077,10 @@ void Resolver::handleResolvedCallPrintCandidates(ResolvedExpression& r,
                 actualDecl = var->toVarLikeDecl();
               }
             }
-            actualDecls.push_back(actualDecl);
+            actualDecls[i] = actualDecl;
           }
         }
+        CHPL_ASSERT((badPasses.size() == rejected.size()) && (rejected.size() == actualDecls.size()));
         CHPL_REPORT(context, NoMatchingCandidates, call, ci, rejected, badPasses, actualDecls);
         return;
       }

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1012,7 +1012,7 @@ handleRejectedCandidates(Context* context,
       const uast::AstNode *actualExpr = nullptr;
       const uast::VarLikeDecl *actualDecl = nullptr;
       if (call && 0 <= badPass.actualIdx() &&
-          badPass.actualIdx() < actualAsts.size()) {
+          (size_t)badPass.actualIdx() < actualAsts.size()) {
         actualExpr = actualAsts[badPass.actualIdx()];
       }
       // look for a definition point of the actual for error reporting of

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -999,10 +999,9 @@ handleRejectedCandidates(Context* context,
   // check each rejected candidate for uninitialized actuals
   for (size_t i = 0; i < rejected.size(); i++) {
     auto &candidate = rejected[i];
-    if (candidate.reason() == resolution::FAIL_CANNOT_PASS &&
-        /* skip computing the formal-actual map because it will go poorly
+    if (/* skip computing the formal-actual map because it will go poorly
            with an unknown formal. */
-        candidate.formalReason() != resolution::FAIL_UNKNOWN_FORMAL_TYPE) {
+        candidate.failedDueToWrongActual()) {
       auto fn = candidate.initialForErr();
       resolution::FormalActualMap fa(fn, ci);
       auto& badPass = fa.byFormalIdx(candidate.formalIdx());

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -991,8 +991,8 @@ handleRejectedCandidates(Context* context,
                          std::vector<ApplicabilityResult>& rejected,
                          const resolution::CallInfo& ci,
                          const uast::Call*& call) {
-  // There were candidates but we threw them out. We can issue a nicer
-  // error explaining why each candidate was rejected.
+  // By performing some processing in the resolver, we can issue a nicer error
+  // explaining why each candidate was rejected.
   std::vector<resolution::FormalActual> badPasses;
   std::vector<const uast::VarLikeDecl*> actualDecls;
   badPasses.resize(rejected.size());
@@ -1001,8 +1001,8 @@ handleRejectedCandidates(Context* context,
   for (size_t i = 0; i < rejected.size(); i++) {
     auto &candidate = rejected[i];
     if (candidate.reason() == resolution::FAIL_CANNOT_PASS &&
-        /* skip printing detailed info_ here because computing the formal-actual
-        map will go poorly with an unknown formal. */
+        /* skip computing the formal-actual map because it will go poorly
+           with an unknown formal. */
         candidate.formalReason() != resolution::FAIL_UNKNOWN_FORMAL_TYPE) {
       auto fn = candidate.initialForErr();
       resolution::FormalActualMap fa(fn, ci);
@@ -2090,6 +2090,7 @@ void Resolver::handleResolvedCallPrintCandidates(ResolvedExpression& r,
       }
 
       if (!rejected.empty()) {
+        // There were candidates but we threw them out. Report on those.
         handleRejectedCandidates(context, byPostorder, rejected, ci, call);
         return;
       }

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1947,6 +1947,7 @@ Resolver::issueErrorForFailedCallResolution(const uast::AstNode* astForErr,
       std::vector<const uast::VarLikeDecl*> uninitializedActuals;
       // could not find a most specific candidate
       std::vector<ApplicabilityResult> rejected;
+      CHPL_ASSERT(rejected.size() == uninitializedActuals.size());
       CHPL_REPORT(context, NoMatchingCandidates, astForErr, ci, rejected, uninitializedActuals);
     }
   } else {

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2049,11 +2049,10 @@ void Resolver::handleResolvedCallPrintCandidates(ResolvedExpression& r,
         std::vector<const uast::VarLikeDecl*> actualDecls;
         // check each rejected candidate for uninitialized actuals
         for (auto& candidate : rejected) {
-          auto reason = candidate.reason();
-          if (reason == resolution::FAIL_CANNOT_PASS &&
-          /* skip printing detailed info_ here because computing the formal-actual
+          if (candidate.reason() == resolution::FAIL_CANNOT_PASS &&
+            /* skip printing detailed info_ here because computing the formal-actual
             map will go poorly with an unknown formal. */
-          candidate.formalReason() != resolution::FAIL_UNKNOWN_FORMAL_TYPE) {
+            candidate.formalReason() != resolution::FAIL_UNKNOWN_FORMAL_TYPE) {
             auto fn = candidate.initialForErr();
             resolution::FormalActualMap fa(fn, ci);
             auto badPass = fa.byFormalIdx(candidate.formalIdx());
@@ -2064,8 +2063,8 @@ void Resolver::handleResolvedCallPrintCandidates(ResolvedExpression& r,
                 badPass.actualIdx() < call->numActuals()) {
               actualExpr = call->actual(badPass.actualIdx());
             }
-            // look for a definition point of the actual for error reporting of uninitialized vars
-            // typically in the case of bad split-initialization
+            // look for a definition point of the actual for error reporting of
+            // uninitialized vars typically in the case of bad split-initialization
             if (actualExpr && actualExpr->isIdentifier()) {
               auto& resolvedExpr = byPostorder.byAst(actualExpr->toIdentifier());
               if (auto id = resolvedExpr.toId()) {

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1010,9 +1010,8 @@ handleRejectedCandidates(Context* context,
     const uast::AstNode *actualExpr = nullptr;
     const uast::VarLikeDecl *actualDecl = nullptr;
     size_t actualIdx = badPass.actualIdx();
-    if (0 <= actualIdx && actualIdx < actualAsts.size()) {
-      actualExpr = actualAsts[badPass.actualIdx()];
-    }
+    CHPL_ASSERT(0 <= actualIdx && actualIdx < actualAsts.size());
+    actualExpr = actualAsts[badPass.actualIdx()];
 
     // look for a definition point of the actual for error reporting of
     // uninitialized vars typically in the case of bad split-initialization
@@ -2445,7 +2444,7 @@ bool Resolver::resolveSpecialNewCall(const Call* call) {
   // Prepare receiver.
   auto receiverInfo = CallInfoActual(calledType, USTR("this"));
   actuals.push_back(std::move(receiverInfo));
-
+  actualAsts.push_back(newExpr->typeExpression());
   // Remaining actuals.
   prepareCallInfoActuals(call, actuals, questionArg, &actualAsts);
   CHPL_ASSERT(!questionArg);
@@ -2455,6 +2454,7 @@ bool Resolver::resolveSpecialNewCall(const Call* call) {
                      /* hasQuestionArg */ questionArg != nullptr,
                      /* isParenless */ false,
                      std::move(actuals));
+  CHPL_ASSERT(actualAsts.size() == (size_t)ci.numActuals());
   auto inScope = scopeStack.back();
   auto inPoiScope = poiScope;
   auto inScopes = CallScopeInfo::forNormalCall(inScope, inPoiScope);

--- a/frontend/lib/resolution/Resolver.h
+++ b/frontend/lib/resolution/Resolver.h
@@ -488,6 +488,7 @@ struct Resolver {
                                          const CallScopeInfo& inScopes,
                                          const types::QualifiedType& receiverType,
                                          const CallResolutionResult& c,
+                                         std::vector<const uast::AstNode*>& actualAsts,
                                          optional<ActionAndId> associatedActionAndId = {});
 
   // If the variable with the passed ID has unknown or generic type,
@@ -597,7 +598,8 @@ struct Resolver {
   // includes special handling for operators and tuple literals
   void prepareCallInfoActuals(const uast::Call* call,
                               std::vector<CallInfoActual>& actuals,
-                              const uast::AstNode*& questionArg);
+                              const uast::AstNode*& questionArg,
+                              std::vector<const uast::AstNode*>* actualAsts);
 
   // prepare a CallInfo by inspecting the called expression and actuals
   CallInfo prepareCallInfoNormalCall(const uast::Call* call);

--- a/frontend/lib/resolution/resolution-error-classes-list.cpp
+++ b/frontend/lib/resolution/resolution-error-classes-list.cpp
@@ -685,7 +685,7 @@ static void printRejectedCandidates(ErrorWriterBase& wr,
         auto actualName = "'" + actualExpr->toIdentifier()->name().str() + "'";
         wr.message("The actual ", actualName,
                    " expects to be split-initialized because it is declared without a type or initialization expression here:");
-        wr.code(offendingActual, { offendingActual });
+        wr.codeForDef(offendingActual);
         wr.message("The call to '", ci.name() ,"' occurs before any valid initialization points:");
         wr.code(actualExpr, { actualExpr });
         actualPrinted = true;

--- a/frontend/lib/resolution/resolution-error-classes-list.cpp
+++ b/frontend/lib/resolution/resolution-error-classes-list.cpp
@@ -647,11 +647,9 @@ static void printRejectedCandidates(ErrorWriterBase& wr,
                                     GetActual&& getActual,
                                     const std::vector<const uast::VarLikeDecl*>* actualDecls) {
   unsigned int printCount = 0;
-  unsigned int iterCount = 0;
   static const unsigned int maxPrintCount = 2;
   for (auto& candidate : rejected) {
     if (printCount == maxPrintCount) break;
-    printCount++;
 
     auto reason = candidate.reason();
     wr.message("");
@@ -675,7 +673,9 @@ static void printRejectedCandidates(ErrorWriterBase& wr,
         formalName = "'" + buildTupleDeclName(formalDecl->toTupleDecl()) + "'";
       }
       bool actualPrinted = false;
-      const uast::VarLikeDecl* offendingActual =  actualDecls!=nullptr ? actualDecls->at(iterCount) : nullptr;\
+      const uast::VarLikeDecl* offendingActual =  actualDecls ?
+                                                  actualDecls->at(printCount) :
+                                                  nullptr;
       if (badPass.formalType().isUnknown()) {
         // The formal type can be unknown in an initial instantiation if it
         // depends on the previous formals' types. In that case, don't print it
@@ -789,6 +789,7 @@ static void printRejectedCandidates(ErrorWriterBase& wr,
       }
       wr.code(candidate.idForErr());
     }
+    printCount++;
   }
 
   if (printCount < rejected.size()) {
@@ -1331,7 +1332,6 @@ void ErrorNoMatchingCandidates::write(ErrorWriterBase& wr) const {
   auto call = node->toCall();
   auto& ci = std::get<resolution::CallInfo>(info_);
   auto& rejected = std::get<std::vector<resolution::ApplicabilityResult>>(info_);
-  // auto& formalActuals = std::get<std::vector<resolution::FormalActual>>(info_);
   auto& actualDecls = std::get<std::vector<const uast::VarLikeDecl*>>(info_);
 
   wr.heading(kind_, type_, node, "unable to resolve call to '", ci.name(), "': no matching candidates.");

--- a/frontend/lib/resolution/resolution-error-classes-list.cpp
+++ b/frontend/lib/resolution/resolution-error-classes-list.cpp
@@ -651,6 +651,7 @@ static void printRejectedCandidates(ErrorWriterBase& wr,
   for (auto& candidate : rejected) {
     if (printCount == maxPrintCount) break;
     wr.message("");
+    auto reason = candidate.reason();
     if (/* skip printing detailed info_ here because computing the formal-actual
         map will go poorly with an unknown formal. */
         candidate.failedDueToWrongActual()) {
@@ -702,7 +703,6 @@ static void printRejectedCandidates(ErrorWriterBase& wr,
       if (!actualPrinted && actualExpr) {
         wr.code(actualExpr, { actualExpr });
       }
-
       auto formalReason = candidate.formalReason();
       if (formalReason == resolution::FAIL_INCOMPATIBLE_NILABILITY) {
         auto formalDec = badPass.formalType().type()->toClassType()->decorator();
@@ -761,7 +761,6 @@ static void printRejectedCandidates(ErrorWriterBase& wr,
       }
       wr.code(candidate.idForErr());
     } else {
-      auto reason = candidate.reason();
       std::string reasonStr = "";
       if (reason == resolution::FAIL_VARARG_MISMATCH) {
         reasonStr = "the number of varargs was incorrect:";

--- a/test/errors/resolution/noMatchingCandidates.1.good
+++ b/test/errors/resolution/noMatchingCandidates.1.good
@@ -1,0 +1,5 @@
+noMatchingCandidates.chpl:6: error: unable to resolve call to 'fn': no matching candidates
+noMatchingCandidates.chpl:2: note: the following candidate didn't match because an actual couldn't be passed to a formal
+noMatchingCandidates.chpl:6: note: The actual 'x' expects to be split-initialized because it is declared without a type or initialization expression here
+noMatchingCandidates.chpl:14: error: unable to resolve call to 'fn': no matching candidates
+noMatchingCandidates.chpl:10: note: the following candidate didn't match because an actual couldn't be passed to a formal

--- a/test/errors/resolution/noMatchingCandidates.2.good
+++ b/test/errors/resolution/noMatchingCandidates.2.good
@@ -1,0 +1,45 @@
+─── error in noMatchingCandidates.chpl:6 [NoMatchingCandidates] ───
+  Unable to resolve call to 'fn': no matching candidates.
+      |
+    6 |   fn(x);
+      |
+  
+  The following candidate didn't match because an actual couldn't be passed to a formal:
+      |
+    2 |   proc fn(const arg) {
+      |           ⎺⎺⎺⎺⎺⎺⎺⎺⎺
+    3 |     arg;
+    4 |   }  
+      |
+  The actual 'x' expects to be split-initialized because it is declared without a type or initialization expression here:
+      |
+    5 |   var x;
+      |       ⎺
+      |
+  The call to 'fn' occurs before any valid initialization points:
+      |
+    6 |   fn(x);
+      |      ⎺
+      |
+  The call to 'fn' cannot initialize 'x' because only 'out' formals can be used to split-initialize. However, 'x' is passed to formal 'arg' which has intent 'const'.
+
+─── error in noMatchingCandidates.chpl:14 [NoMatchingCandidates] ───
+  Unable to resolve call to 'fn': no matching candidates.
+       |
+    14 |   fn(x);  
+       |
+  
+  The following candidate didn't match because an actual couldn't be passed to a formal:
+       |
+    10 |   proc fn(arg:string) {
+       |           ⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
+    11 |     arg;
+    12 |   }  
+       |
+  The formal 'arg' expects a value of type 'string', but the actual was a value of type 'int(64)'.
+       |
+    14 |   fn(x);  
+       |      ⎺
+       |
+  Formals with kind 'const ref' expect the actual to be a subtype, but 'int(64)' is not a subtype of 'string'.
+

--- a/test/errors/resolution/noMatchingCandidates.chpl
+++ b/test/errors/resolution/noMatchingCandidates.chpl
@@ -1,0 +1,35 @@
+{ // expects split-init
+  proc fn(const arg) {
+    arg;
+  }  
+  var x;
+  fn(x);
+  x=5;  
+}
+{ // type mismatch
+  proc fn(arg:string) {
+    arg;
+  }  
+  var x=5;
+  fn(x);  
+}
+// Tests needed:
+// call was parenful but method is parenless
+
+// call was parenless but method was parenful
+
+// bad where clause
+
+// bad vararg count
+
+// star tuple mismatches
+
+// tuple size mismatches
+
+// The 'ref' intent requires the formal and actual types to match exactly
+
+// bad subtype
+
+// incompatible manager
+
+// incompatible nilability


### PR DESCRIPTION
This adds detection of an uninitialized variable used as an actual to a non-out formal. The previous error was a generic failure to resolve function [NoMatchingCandidates] and this improves the message by indicating that the candidate did not match because of the uninitialized actual passed to a non-out formal. 

resolves https://github.com/Cray/chapel-private/issues/6624

Example program:
```chapel
proc fn(const arg) {
  arg;
}
proc main() {
  var x;
  fn(x);
  x=5;
}

```

in production this produces the following error message:
```
MyTestModule.chpl:9: In function 'main':
MyTestModule.chpl:10: error: 'x' is not initialized and has no type
MyTestModule.chpl:10: note: cannot find initialization point to split-init this variable
MyTestModule.chpl:11: note: 'x' is used here before it is initialized
```

previous error message compiling with `chpl MyTestModule.chpl --dyno --detailed-errors`:
```
─── error in MyTestModule.chpl:11 [NoMatchingCandidates] ───
  Unable to resolve call to 'fn': no matching candidates.
       |
    11 |   fn(x);
       |
  
  The following candidate didn't match because an actual couldn't be passed to a formal:
      |
    6 | proc fn(const arg) {
      |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺
    7 |   arg;
    8 | }
      |
  The formal 'arg' expects a value of type '?', but the actual was a value of type 'UnknownType'.
       |
    11 |   fn(x);
       |      ⎺
       |

```

Updated error message with `-dyno --detailed-errors`:
```
─── error in MyTestModule.chpl:11 [NoMatchingCandidates] ───
  Unable to resolve call to 'fn': no matching candidates.
       |
    11 |   fn(x);
       |
  
  The following candidate didn't match because an actual couldn't be passed to a formal:
      |
    6 | proc fn(const arg) {
      |         ⎺⎺⎺⎺⎺⎺⎺⎺⎺
    7 |   arg;
    8 | }
      |
  The actual 'x' expects to be split-initialized because it is declared without a type or initialization expression here:
       |
    10 |   var x;
       |       ⎺
       |
  The call to fn occurs before any valid initialization points:
       |
    11 |   fn(x);
       |      ⎺
       |
  The call to 'fn' cannot initialize 'x' because only 'out' formals can be used to split-initialize. However, 'x' is passed to formal 'arg' which has intent 'const'.

```

updated error message with `--dyno --no-detailed-errors`
```
MyTestModule.chpl:9: In function 'main':
MyTestModule.chpl:11: error: unable to resolve call to 'fn': no matching candidates
MyTestModule.chpl:1: In module 'MyTestModule':
MyTestModule.chpl:6: note: the following candidate didn't match because an actual couldn't be passed to a formal
MyTestModule.chpl:9: In function 'main':
MyTestModule.chpl:11: note: The actual 'x' expects to be split-initialized because it is declared without a type or initialization expression here
```

TESTING:

- [x] paratest `[Summary: #Successes = 17721 | #Failures = 0 | #Futures = 904]`
- [x] gasnet paratest `[Summary: #Successes = 17906 | #Failures = 0 | #Futures = 915]`

[reviewed by @DanilaFe - thank you!]