### PR TITLE
Make sure gpu testing cleans up after itself

### DIFF
--- a/test/gpu/native/.gitignore
+++ b/test/gpu/native/.gitignore
@@ -1,1 +1,4 @@
 savec.good
+savec_dir
+deviceAttributes.good
+localeName.hostname

--- a/test/gpu/native/deviceAttributes.cleanfiles
+++ b/test/gpu/native/deviceAttributes.cleanfiles
@@ -1,0 +1,1 @@
+deviceAttributes.good

--- a/test/gpu/native/queryLocaleId.prediff
+++ b/test/gpu/native/queryLocaleId.prediff
@@ -2,3 +2,4 @@
 
 sort $2 > $2.sorted
 grep -v "warning:" $2.sorted >$2 # --fast generates different warning
+rm $2.sorted

--- a/test/gpu/native/studies/.gitignore
+++ b/test/gpu/native/studies/.gitignore
@@ -1,0 +1,2 @@
+gitClone.out
+gitPatch.out

--- a/test/gpu/native/varInInnerBlock.prediff
+++ b/test/gpu/native/varInInnerBlock.prediff
@@ -2,3 +2,4 @@
 
 awk '/NumArgs/ { print $NF; }' $2 > $2.awked
 tail -n1 $2.awked >$2  # only report the last launch
+rm $2.awked


### PR DESCRIPTION
Adds a few missing `.gitignore` and `.cleanfiles` for some GPU tests. This makes sure running `start_test` does not leave behind a bunch of files and dirty the tree

[Not reviewed - trivial]