### PR TITLE
Fix CHPL_DEVELOPER build with gcc 14

### DIFF
--- a/compiler/include/vec.h
+++ b/compiler/include/vec.h
@@ -88,8 +88,8 @@ class Vec {
   C             *v;
   C             e[S];
 
-  Vec<C,S>();
-  Vec<C,S>(const Vec<C,S> &vv);
+  Vec();
+  Vec(const Vec<C,S> &vv);
   ~Vec() { if (v && v != e) free(v); }
 
   void add(C a);


### PR DESCRIPTION
Fixes a build error with CHPL_DEVELOPER=1 and gcc 14, caused by a warning from gcc. Removing the offending code does not seem to affect correctness

resolves https://github.com/chapel-lang/chapel/issues/26488

[Reviewed by @DanilaFe]