### PR TITLE
Fix Portability issue with inet_aton on FreeBSD 13.2 chapel-lang#22549

### DIFF
--- a/runtime/src/qio/sys.c
+++ b/runtime/src/qio/sys.c
@@ -116,7 +116,7 @@ int sys_set_sys_sockaddr_t(sys_sockaddr_t* addr, const char* host, u_int16_t por
     struct sockaddr_in *addr_inet = (struct sockaddr_in *)&addr->addr;
     addr_inet->sin_family = AF_INET;
     addr_inet->sin_port = htons(port);
-    return inet_aton(host, &addr_inet->sin_addr);
+    return inet_pton(AF_INET, host, &addr_inet->sin_addr);
   }
   else if(family == AF_INET6){
     struct sockaddr_in6 *addr_inet6 = (struct sockaddr_in6 *)&addr->addr;


### PR DESCRIPTION
Fix Portability issue with inet_aton on FreeBSD 13.x and 14.x #22549

Updated inet_aton to inet_pton system call.

Signed-off-by : emorras@emorras.eu