### PR TITLE
chpldoc and mason doc improvements to wire project info

### DIFF
--- a/third-party/chpl-venv/chpldoc-sphinx-project/source/conf.py
+++ b/third-party/chpl-venv/chpldoc-sphinx-project/source/conf.py
@@ -14,6 +14,7 @@
 
 import sys
 import os
+from datetime import datetime
 
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
@@ -49,14 +50,16 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'chpldoc'
+project = os.environ.get('CHPLDOC_PROJECT_NAME', 'PROJECT NAME').strip()
 
 author_text = os.environ.get('CHPLDOC_AUTHOR', 'AUTHOR TEXT')
 
+copyright_year = os.environ.get('CHPLDOC_COPYRIGHT_YEAR', datetime.now().year)
+
 if len(author_text):
-    copyright = u'2015, {0}'.format(author_text)
+    copyright = u'{}, {}'.format(copyright_year, author_text)
 else:
-    copyright = u'2015'
+    copyright = u'{}'.format(copyright_year)
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/tools/mason/MasonDoc.chpl
+++ b/tools/mason/MasonDoc.chpl
@@ -48,7 +48,11 @@ proc masonDoc(args: [] string) throws {
         // Must use relative paths with chpldoc to prevent baking in abs paths
         here.chdir(projectHome);
 
-        const command = 'chpldoc src/' + projectFile + ' -o doc/ --process-used-modules';
+        var command = 'chpldoc src/' + projectFile + ' -o doc/ --process-used-modules';
+        if projectName.size != 0 {
+          command += ' --name ' + projectName;
+        }
+
         writeln(command);
         runCommand(command);
       }


### PR DESCRIPTION
This PR makes several improvements for `mason doc`.

- The template sphinx configuration has couple of important fields programmable via new environment variables like `CHPLDOC_PROJECT_NAME`
- `chpldoc` now has the ability to use an existing `sphinx` project: a Mason package should be able to have its own conf.py + index.rst. Currently, chpldoc simply overrides it. This is exposed with `--has-sphinx` flag, which prevents coping the generic Chapel template.
- `mason doc` passes project name into the environment variable I mentioned above.

I will probably continue on this as I find time to improve the integration a bit better.

TODO:
- [ ] add a field to `Mason.toml` to pick up an existing sphinx config dir
- [ ] make Mason generate a stub of that config dir