### PR TITLE
Fix usage of shutil.rmtree on a symlink in sub_clean

### DIFF
--- a/util/test/sub_clean
+++ b/util/test/sub_clean
@@ -73,7 +73,7 @@ def cleanCleanfiles(d, c, rmCore):
             for g in globfiles:
                 print('Removing '+g)
                 try:
-                    if os.path.isdir(g):
+                    if os.path.isdir(g) and not os.path.islink(g):
                         shutil.rmtree(g)
                     else:
                         os.unlink(g)


### PR DESCRIPTION
Fixes a usage of `shutil.rmtree` in `sub_clean`, per the [Python docs](https://docs.python.org/3/library/shutil.html#shutil.rmtree) it should not be called on symlinks.

This was causing `sub_clean` to silently fail to delete symlinks to directories, which failed silently due to the `try`/`catch`/`pass` surrounding the code

[Reviewed by @arezaii]