### PR TITLE
Add c_addrOf[Const] on domain unstable overloads

### DIFF
--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -1034,6 +1034,12 @@ module CTypes {
     return c_pointer_return(x);
   }
 
+  @chpldoc.nodoc
+  @unstable("using 'c_addrOf' with a domain argument is unstable")
+  inline proc c_addrOf(ref x: ?t): c_ptr(t) where isDomainType(t) {
+    return c_pointer_return(x);
+  }
+
   /*
     Like :proc:`c_addrOf`, but returns a :type:`c_ptrConst` which disallows
     direct modification of the pointee.
@@ -1041,6 +1047,13 @@ module CTypes {
   inline proc c_addrOfConst(const ref x: ?t): c_ptrConst(t) {
     if isDomainType(t) then
       compilerError("c_addrOfConst domain type not supported");
+    return c_pointer_return_const(x);
+  }
+
+  @chpldoc.nodoc
+  @unstable("using 'c_addrOfConst' with a domain argument is unstable")
+  inline proc c_addrOfConst(const ref x: ?t): c_ptrConst(t)
+      where isDomainType(t) {
     return c_pointer_return_const(x);
   }
 

--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -1034,6 +1034,8 @@ module CTypes {
     return c_pointer_return(x);
   }
 
+  // Added as unstable for 2.4, can be merged into stable version once we're
+  // confident in it.
   @chpldoc.nodoc
   @unstable("using 'c_addrOf' with a domain argument is unstable")
   inline proc c_addrOf(ref x: ?t): c_ptr(t) where isDomainType(t) {
@@ -1050,6 +1052,7 @@ module CTypes {
     return c_pointer_return_const(x);
   }
 
+  // See note on corresponding c_addrOf overload
   @chpldoc.nodoc
   @unstable("using 'c_addrOfConst' with a domain argument is unstable")
   inline proc c_addrOfConst(const ref x: ?t): c_ptrConst(t)

--- a/test/types/cptr/c_ptrTo_domain.3.good
+++ b/test/types/cptr/c_ptrTo_domain.3.good
@@ -1,1 +1,0 @@
-c_ptrTo_domain.chpl:10: error: c_addrOf domain type not supported

--- a/test/types/cptr/c_ptrTo_domain.4.good
+++ b/test/types/cptr/c_ptrTo_domain.4.good
@@ -1,1 +1,0 @@
-c_ptrTo_domain.chpl:11: error: c_addrOfConst domain type not supported

--- a/test/types/cptr/c_ptrTo_domain.chpl
+++ b/test/types/cptr/c_ptrTo_domain.chpl
@@ -7,7 +7,5 @@ var myDom : domain(1);
 select funcToTest {
   when "c_ptrTo" do c_ptrTo(myDom);
   when "c_ptrToConst" do c_ptrToConst(myDom);
-  when "c_addrOf" do c_addrOf(myDom);
-  when "c_addrOfConst" do c_addrOfConst(myDom);
   otherwise writeln("invalid function specified");
 }

--- a/test/types/cptr/c_ptrTo_domain.compopts
+++ b/test/types/cptr/c_ptrTo_domain.compopts
@@ -1,4 +1,2 @@
 -sfuncToTest='"c_ptrTo"'       # c_ptrTo_domain.1.good
 -sfuncToTest='"c_ptrToConst"'  # c_ptrTo_domain.2.good
--sfuncToTest='"c_addrOf"'      # c_ptrTo_domain.3.good
--sfuncToTest='"c_addrOfConst"' # c_ptrTo_domain.4.good

--- a/test/unstable/c_addrOf-domain.chpl
+++ b/test/unstable/c_addrOf-domain.chpl
@@ -1,0 +1,6 @@
+use CTypes;
+
+var d : domain(1) = {1..10};
+
+var ptr : c_ptr(domain(1)) = c_addrOf(d);
+var constPtr : c_ptrConst(domain(1)) = c_addrOfConst(d);

--- a/test/unstable/c_addrOf-domain.good
+++ b/test/unstable/c_addrOf-domain.good
@@ -1,0 +1,2 @@
+c_addrOf-domain.chpl:5: warning: using 'c_addrOf' with a domain argument is unstable
+c_addrOf-domain.chpl:6: warning: using 'c_addrOfConst' with a domain argument is unstable


### PR DESCRIPTION
Add unstable overloads of `c_addrOf`/`c_addrOfConst` which take domain arguments.

Eventually (in >=2 releases) these should be made stable if no blocking issues are encountered. At that point we can just remove the error from the main overload, and remove these new overloads.

Includes adding tests for the new unstable functionality.

Resolves https://github.com/Cray/chapel-private/issues/6971.

[reviewer info placeholder]

Testing:
- [x] paratest