### PR TITLE
Make sure chapel-py based tools always use the same python

### DIFF
--- a/test/chplcheck/SKIPIF
+++ b/test/chplcheck/SKIPIF
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-if $CHPL_HOME/util/config/run-in-venv-with-python-bindings.bash python3 -c "import chapel" 2> /dev/null; then
+python=$($CHPL_HOME/util/config/find-python.sh)
+if $CHPL_HOME/util/config/run-in-venv-with-python-bindings.bash $python -c "import chapel" 2> /dev/null; then
     echo "False"
 else
     echo "True"

--- a/test/chplcheck/fixit-interactive/SKIPIF
+++ b/test/chplcheck/fixit-interactive/SKIPIF
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-if $CHPL_HOME/util/config/run-in-venv-with-python-bindings.bash python3 -c "import chapel" 2> /dev/null; then
+python=$($CHPL_HOME/util/config/find-python.sh)
+if $CHPL_HOME/util/config/run-in-venv-with-python-bindings.bash $python python3 -c "import chapel" 2> /dev/null; then
     echo "False"
 else
     echo "True"

--- a/test/chplcheck/rule-settings/SKIPIF
+++ b/test/chplcheck/rule-settings/SKIPIF
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-if $CHPL_HOME/util/config/run-in-venv-with-python-bindings.bash python3 -c "import chapel" 2> /dev/null; then
+python=$($CHPL_HOME/util/config/find-python.sh)
+if $CHPL_HOME/util/config/run-in-venv-with-python-bindings.bash $python python3 -c "import chapel" 2> /dev/null; then
     echo "False"
 else
     echo "True"

--- a/third-party/chpl-venv/Makefile
+++ b/third-party/chpl-venv/Makefile
@@ -117,7 +117,7 @@ chapel-py-venv: FORCE $(CHPL_VENV_VIRTUALENV_DIR_OK)
 	mkdir -p $(CHPL_MAKE_HOME)/tools/chapel-py/src/chapel/core
 	CHPL_HOME=$(CHPL_MAKE_HOME) bash \
 		$(CHPL_MAKE_HOME)/util/config/run-in-venv-with-python-bindings.bash \
-		python3 -c 'import chapel; print(chapel.Context()._get_pyi_file())' \
+		$(CHPL_MAKE_PYTHON) -c 'import chapel; print(chapel.Context()._get_pyi_file())' \
 		>$(CHPL_MAKE_HOME)/tools/chapel-py/src/chapel/core/__init__.pyi && \
 		cp $(CHPL_MAKE_HOME)/tools/chapel-py/src/chapel/core/__init__.pyi $(CHPL_VENV_CHPL_FRONTEND_PY_DEPS)/chapel/core.pyi
 

--- a/tools/chpl-language-server/Makefile
+++ b/tools/chpl-language-server/Makefile
@@ -42,7 +42,7 @@ chpl-language-server: chpl-language-server-venv
 
 test-chpl-language-server: chpl-language-server chpl-language-server-test-venv
 	$(CHPL_MAKE_HOME)/util/config/run-in-venv-with-python-bindings.bash \
-		python3 -m pytest test/*.py
+		$(CHPL_MAKE_PYTHON) -m pytest test/*.py
 
 clean: clean-link clean-link-shim clean-pycache
 

--- a/tools/chpl-language-server/chpl-language-server
+++ b/tools/chpl-language-server/chpl-language-server
@@ -30,6 +30,8 @@ if [ -z "$CHPL_HOME" ]; then
   fi
 fi
 
-exec $CHPL_HOME/util/config/run-in-venv-with-python-bindings.bash \
+python=$($CHPL_HOME/util/config/find-python.sh)
+
+exec $CHPL_HOME/util/config/run-in-venv-with-python-bindings.bash $python \
      $CHPL_HOME/tools/chpl-language-server/src/chpl-language-server.py "$@"
 

--- a/tools/chpl-language-server/chpl-shim
+++ b/tools/chpl-language-server/chpl-shim
@@ -30,5 +30,7 @@ if [ -z "$CHPL_HOME" ]; then
   fi
 fi
 
-exec $CHPL_HOME/util/config/run-in-venv-with-python-bindings.bash \
+python=$($CHPL_HOME/util/config/find-python.sh)
+
+exec $CHPL_HOME/util/config/run-in-venv-with-python-bindings.bash $python \
      $CHPL_HOME/tools/chpl-language-server/src/chpl-shim.py "$@"

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 #
 # Copyright 2024-2025 Hewlett Packard Enterprise Development LP
 # Other additional copyright holders may be indicated within.

--- a/tools/chplcheck/chplcheck
+++ b/tools/chplcheck/chplcheck
@@ -31,6 +31,8 @@ if [ -z "$CHPL_HOME" ]; then
   fi
 fi
 
-exec $CHPL_HOME/util/config/run-in-venv-with-python-bindings.bash \
+python=$($CHPL_HOME/util/config/find-python.sh)
+
+exec $CHPL_HOME/util/config/run-in-venv-with-python-bindings.bash $python \
      $CHPL_HOME/tools/chplcheck/src/chplcheck.py "$@"
 

--- a/tools/chplcheck/examples/SKIPIF
+++ b/tools/chplcheck/examples/SKIPIF
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-if $CHPL_HOME/util/config/run-in-venv-with-python-bindings.bash python3 -c "import chapel" 2> /dev/null; then
+python=$($CHPL_HOME/util/config/find-python.sh)
+if $CHPL_HOME/util/config/run-in-venv-with-python-bindings.bash $python -c "import chapel" 2> /dev/null; then
     echo "False"
 else
     echo "True"

--- a/tools/chplcheck/src/chplcheck.py
+++ b/tools/chplcheck/src/chplcheck.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 #
 # Copyright 2023-2025 Hewlett Packard Enterprise Development LP
 # Other additional copyright holders may be indicated within.

--- a/tools/chpldoc/findUndocumentedSymbols
+++ b/tools/chpldoc/findUndocumentedSymbols
@@ -25,5 +25,7 @@ if [ -z "$CHPL_HOME" ]; then
   exit 1
 fi
 
-exec $CHPL_HOME/util/config/run-in-venv-with-python-bindings.bash \
+python=$($CHPL_HOME/util/config/find-python.sh)
+
+exec $CHPL_HOME/util/config/run-in-venv-with-python-bindings.bash $python \
      $CHPL_HOME/tools/chpldoc/findUndocumentedSymbols.py "$@"

--- a/tools/chpldoc/findUndocumentedSymbols.py
+++ b/tools/chpldoc/findUndocumentedSymbols.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 #
 # Copyright 2020-2025 Hewlett Packard Enterprise Development LP
 # Copyright 2004-2019 Cray Inc.


### PR DESCRIPTION
This PR changes some scripts to ensure all chapel-py based tools always use the same python, i.e. the one from `find-python.sh`. 

We were slightly inconsistent about this before, which meant that if `find-python.sh` returned a different python version than the default `python3` version, runtime errors would occur. This is unlikely to happen to users, since to expose this issue you need to edit `find-python.sh` to return specific versions of python (i.e. `python3.12` instead of `python3`)

[Reviewed by @DanilaFe]