### PR TITLE
Fix internal error when assigning a type to a value

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -9175,9 +9175,9 @@ static void moveHaltMoveIsUnacceptable(CallExpr* call) {
   } else {
     if (lhsSym->hasFlag(FLAG_TYPE_VARIABLE) == false &&
         lhsSym->hasFlag(FLAG_MAYBE_TYPE)    == false) {
-      FnSymbol* fn = toFnSymbol(call->parentSymbol);
 
-      if (fn->getReturnSymbol() == lhsSym) {
+      if (auto fn = toFnSymbol(call->parentSymbol);
+               fn && fn->getReturnSymbol() == lhsSym) {
         USR_FATAL(call, "illegal return of type where value is expected");
 
       } else if (lhsSym->hasFlag(FLAG_CHPL__ITER) == true) {

--- a/test/classes/deitz/types/type_to_value_error_intent.chpl
+++ b/test/classes/deitz/types/type_to_value_error_intent.chpl
@@ -1,0 +1,10 @@
+class C {
+  var x: int;
+}
+
+var c: borrowed C?;
+
+forall 1..10 with (var c = C()) {
+}
+
+writeln(c);

--- a/test/classes/deitz/types/type_to_value_error_intent.good
+++ b/test/classes/deitz/types/type_to_value_error_intent.good
@@ -1,0 +1,1 @@
+type_to_value_error_intent.chpl:7: error: illegal assignment of type to value


### PR DESCRIPTION
Fixes an internal error when trying to assign a type to a value inside a task intent.

Resolves https://github.com/chapel-lang/chapel/issues/26511

- [ ] full paratest with/without gasnet

[Reviewed by @]