### PR TITLE
Remove deprecated code from ChapelArray

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1951,14 +1951,6 @@ module ChapelArray {
     return result;
   }
 
-  // How to cast arrays to strings
-  @chpldoc.nodoc
-  @deprecated(notes="casting arrays to string is deprecated; please use 'try! \"%?\".format()' from IO.FormattedIO instead")
-  operator :(x: [], type t:string) {
-    import IO.FormattedIO.string;
-    return try! "%?".format(x);
-  }
-
   pragma "last resort"
   @chpldoc.nodoc
   operator :(in x: [] ?et, type t: et) where t == et {
@@ -2703,26 +2695,11 @@ module ChapelArray {
       e = b;
   }
 
-  // required to prevent deprecation warnings being related to internal modules
-  @chpldoc.nodoc
-  @deprecated(notes="Direct assignment to 'sync' variables is deprecated; apply a 'write??()' method to modify one")
-  operator =(ref a: [], b: _desync(a.eltType)) where isSyncType(a.eltType) {
-    forall e in a do
-      e = b;
-  }
-
   //
   // op= overloads for array/scalar pairs
   //
   @chpldoc.nodoc
   operator +=(ref a: [], b: _desync(a.eltType)) {
-    forall e in a do
-      e += b;
-  }
-  // required to prevent deprecation warnings being related to internal modules
-  @chpldoc.nodoc
-  @deprecated("'op=' assignments to 'sync' variables are deprecated; add explicit '.read??'/'.write??' methods to modify one")
-  operator +=(ref a: [], b: _desync(a.eltType)) where isSyncType(a.eltType) {
     forall e in a do
       e += b;
   }
@@ -2732,23 +2709,9 @@ module ChapelArray {
     forall e in a do
       e -= b;
   }
-  // required to prevent deprecation warnings being related to internal modules
-  @chpldoc.nodoc
-  @deprecated("'op=' assignments to 'sync' variables are deprecated; add explicit '.read??'/'.write??' methods to modify one")
-  operator -=(ref a: [], b: _desync(a.eltType)) where isSyncType(a.eltType) {
-    forall e in a do
-      e -= b;
-  }
 
   @chpldoc.nodoc
   operator *=(ref a: [], b: _desync(a.eltType)) {
-    forall e in a do
-      e *= b;
-  }
-  // required to prevent deprecation warnings being related to internal modules
-  @chpldoc.nodoc
-  @deprecated("'op=' assignments to 'sync' variables are deprecated; add explicit '.read??'/'.write??' methods to modify one")
-  operator *=(ref a: [], b: _desync(a.eltType)) where isSyncType(a.eltType) {
     forall e in a do
       e *= b;
   }
@@ -2758,23 +2721,9 @@ module ChapelArray {
     forall e in a do
       e /= b;
   }
-  // required to prevent deprecation warnings being related to internal modules
-  @chpldoc.nodoc
-  @deprecated("'op=' assignments to 'sync' variables are deprecated; add explicit '.read??'/'.write??' methods to modify one")
-  operator /=(ref a: [], b: _desync(a.eltType)) where isSyncType(a.eltType) {
-    forall e in a do
-      e /= b;
-  }
 
   @chpldoc.nodoc
   operator %=(ref a: [], b: _desync(a.eltType)) {
-    forall e in a do
-      e %= b;
-  }
-  // required to prevent deprecation warnings being related to internal modules
-  @chpldoc.nodoc
-  @deprecated("'op=' assignments to 'sync' variables are deprecated; add explicit '.read??'/'.write??' methods to modify one")
-  operator %=(ref a: [], b: _desync(a.eltType)) where isSyncType(a.eltType) {
     forall e in a do
       e %= b;
   }
@@ -2784,23 +2733,9 @@ module ChapelArray {
     forall e in a do
       e **= b;
   }
-  // required to prevent deprecation warnings being related to internal modules
-  @chpldoc.nodoc
-  @deprecated("'op=' assignments to 'sync' variables are deprecated; add explicit '.read??'/'.write??' methods to modify one")
-  operator **=(ref a: [], b: _desync(a.eltType)) where isSyncType(a.eltType) {
-    forall e in a do
-      e **= b;
-  }
 
   @chpldoc.nodoc
   operator &=(ref a: [], b: _desync(a.eltType)) {
-    forall e in a do
-      e &= b;
-  }
-  // required to prevent deprecation warnings being related to internal modules
-  @chpldoc.nodoc
-  @deprecated("'op=' assignments to 'sync' variables are deprecated; add explicit '.read??'/'.write??' methods to modify one")
-  operator &=(ref a: [], b: _desync(a.eltType)) where isSyncType(a.eltType) {
     forall e in a do
       e &= b;
   }
@@ -2810,23 +2745,9 @@ module ChapelArray {
     forall e in a do
       e |= b;
   }
-  // required to prevent deprecation warnings being related to internal modules
-  @chpldoc.nodoc
-  @deprecated("'op=' assignments to 'sync' variables are deprecated; add explicit '.read??'/'.write??' methods to modify one")
-  operator |=(ref a: [], b: _desync(a.eltType)) where isSyncType(a.eltType) {
-    forall e in a do
-      e |= b;
-  }
 
   @chpldoc.nodoc
   operator ^=(ref a: [], b: _desync(a.eltType)) {
-    forall e in a do
-      e ^= b;
-  }
-  // required to prevent deprecation warnings being related to internal modules
-  @chpldoc.nodoc
-  @deprecated("'op=' assignments to 'sync' variables are deprecated; add explicit '.read??'/'.write??' methods to modify one")
-  operator ^=(ref a: [], b: _desync(a.eltType)) where isSyncType(a.eltType) {
     forall e in a do
       e ^= b;
   }
@@ -2836,23 +2757,9 @@ module ChapelArray {
     forall e in a do
       e >>= b;
   }
-  // required to prevent deprecation warnings being related to internal modules
-  @chpldoc.nodoc
-  @deprecated("'op=' assignments to 'sync' variables are deprecated; add explicit '.read??'/'.write??' methods to modify one")
-  operator >>=(ref a: [], b: _desync(a.eltType)) where isSyncType(a.eltType) {
-    forall e in a do
-      e >>= b;
-  }
 
   @chpldoc.nodoc
   operator <<=(ref a: [], b: _desync(a.eltType)) {
-    forall e in a do
-      e <<= b;
-  }
-  // required to prevent deprecation warnings being related to internal modules
-  @chpldoc.nodoc
-  @deprecated("'op=' assignments to 'sync' variables are deprecated; add explicit '.read??'/'.write??' methods to modify one")
-  operator <<=(ref a: [], b: _desync(a.eltType)) where isSyncType(a.eltType) {
     forall e in a do
       e <<= b;
   }


### PR DESCRIPTION
Deprecations were introduced by the following PRs:
* https://github.com/chapel-lang/chapel/pull/22639
* https://github.com/chapel-lang/chapel/pull/23380

Which occurred more than 6 months ago.

## Testing
- [ ] paratest