### PR TITLE
Remove deprecated code from String module

### DIFF
--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -349,13 +349,6 @@ module Bytes {
       initWithNewBuffer(this, b.buff, length=b.numBytes, size=b.numBytes+1);
     }
 
-    @deprecated("the type 'c_string' is deprecated; please use one of the 'bytes.create*ingBuffer' methods that takes a 'c_ptrConst(c_char)' instead")
-    proc init=(b: c_string) {
-      init this;
-      var length = b.size;
-      initWithNewBuffer(this, b: bufferType, length=length, size=length+1);
-    }
-
     inline proc byteIndices do return 0..<size;
 
     inline proc param size param do
@@ -1121,12 +1114,6 @@ module Bytes {
   inline operator :(x: string, type t: bytes) {
     return bytes.createCopyingBuffer(x.buff, length=x.numBytes, size=x.numBytes+1);
   }
-  @chpldoc.nodoc
-  @deprecated("the type 'c_string' is deprecated; please use one of the 'bytes.create*ingBuffer' methods that takes a 'c_ptrConst(c_char)' instead")
-  inline operator :(x: c_string, type t: bytes) {
-    var length = x.size;
-    return bytes.createCopyingBuffer(x: bufferType, length=length, size=length+1);
-  }
 
 
   /*
@@ -1191,16 +1178,6 @@ module Bytes {
   */
   operator bytes.=(ref lhs: bytes, rhs: bytes) : void {
     doAssign(lhs, rhs);
-  }
-
-  /*
-     Copies the c_string `rhs_c` into the bytes `lhs`.
-
-     Halts if `lhs` is a remote bytes.
-  */
-  @deprecated("the type 'c_string' is deprecated; please use one of the 'bytes.create*ingBuffer' methods that takes a 'c_ptrConst(c_char)' instead")
-  operator bytes.=(ref lhs: bytes, rhs_c: c_string) : void {
-    lhs = bytes.createCopyingBuffer(rhs_c:c_ptrConst(c_char));
   }
 
   //

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -23,15 +23,6 @@
 
 module ChapelBase {
 
-  // We deprecate in the module code so that we don't have to modify dyno
-  // to teach it about the 'c_string' type. We perform the deprecation in
-  // ChapelBase so that you don't have to 'import CTypes' to see the type
-  // 'c_string' (which could break a lot of programs). This is OK because
-  // after the deprecation period we can just remove 'c_string' entirely.
-  pragma "last resort"
-  @deprecated(notes="the type 'c_string' is deprecated; please 'use CTypes' and replace 'c_string' with 'c_ptrConst(c_char)'")
-  type c_string = chpl_c_string;
-
   // c_fn_ptr stuff
 
   // although it can just be a compiler-inserted primitive,
@@ -91,9 +82,6 @@ module ChapelBase {
   pragma "global type symbol"
   pragma "no object"
   class _object { }
-
-  @deprecated(notes="the 'object' abstract root class has been deprecated; please use 'RootClass' instead")
-  class object { }
 
   enum iterKind {leader, follower, standalone};
 
@@ -2632,15 +2620,6 @@ module ChapelBase {
   }
 
   // Type functions for representing function types
-
-  @deprecated("The 'func' procedure type constructor is deprecated, please use 'proc' syntax instead")
-  inline proc func() type { return __primitive("create fn type", void); }
-
-  @deprecated("The 'func' procedure type constructor is deprecated, please use 'proc' syntax instead")
-  inline proc func(type rettype) type { return __primitive("create fn type", rettype); }
-
-  @deprecated("The 'func' procedure type constructor is deprecated, please use 'proc' syntax instead")
-  inline proc func(type t...?n, type rettype) type { return __primitive("create fn type", (...t), rettype); }
 
   proc isIterator(ic: _iteratorClass) param do return true;
   proc isIterator(ir: _iteratorRecord) param do return true;

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -490,15 +490,6 @@ module String {
     return ret;
   }
 
-  @chpldoc.nodoc
-  @deprecated("the type 'c_string' is deprecated; please use the variant of 'string.createBorrowingBuffer' that takes a 'c_ptrConst(c_char)' instead")
-  inline proc type string.createBorrowingBuffer(x: chpl_c_string,
-                                                length=x.size) : string throws {
-    return string.createBorrowingBuffer(x:bufferType,
-                                        length=length,
-                                        size=length+1);
-  }
-
   /*
     Creates a new :type:`string` which takes ownership of the memory allocated for a
     :class:`~CTypes.c_ptr`. The buffer will be freed when the :type:`string` is deinitialized.
@@ -518,15 +509,6 @@ module String {
   */
   proc type string.createAdoptingBuffer(x: c_ptr(?t),
                                         length=strLen(x)) : string throws {
-    return string.createAdoptingBuffer(x:bufferType,
-                                       length=length,
-                                       size=length+1);
-  }
-
-  @chpldoc.nodoc
-  @deprecated("the type 'c_string' is deprecated; please use the variant of 'string.createAdoptingBuffer' that takes a 'c_ptrConst(c_char)' instead")
-  inline proc type string.createAdoptingBuffer(x: chpl_c_string,
-                                               length=x.size) : string throws {
     return string.createAdoptingBuffer(x:bufferType,
                                        length=length,
                                        size=length+1);
@@ -656,18 +638,6 @@ module String {
     // anyways. But it has a default and probably it's good to keep it here for
     // interface consistency
     return decodeByteBuffer(x:bufferType, length, policy);
-  }
-
-  @chpldoc.nodoc
-  @deprecated("the type 'c_string' is deprecated; please use the variant of 'string.createCopyingBuffer' that takes a 'c_ptrConst(c_char)' instead")
-  inline proc type string.createCopyingBuffer(x: chpl_c_string,
-                                              length=x.size,
-                                              policy=decodePolicy.strict
-                                              ) : string throws {
-    return string.createCopyingBuffer(x:bufferType,
-                                      length=length,
-                                      size=length+1,
-                                      policy);
   }
 
   // non-validating string factory functions are in this submodule. This
@@ -1165,38 +1135,6 @@ module String {
       const x:string = this; // assignment makes it local
       return x;
     }
-  }
-
-  /*
-    Get a `c_ptrConst(c_char)` from a :type:`string`. The returned
-    :class:`~CTypes.c_ptrConst` shares the buffer with the :type:`string`.
-
-    .. warning::
-
-        This can only be called safely on a :type:`string` whose home is
-        the current locale.  This property can be enforced by calling
-        :proc:`string.localize()` before :proc:`string.c_str()`. If the
-        string is remote, the program will halt.
-
-    For example:
-
-    .. code-block:: chapel
-
-      var my_string = "Hello!";
-      on different_locale {
-        printf("%s", my_string.localize().c_str());
-      }
-
-    :returns:
-        A `c_ptrConst(c_char)` that points to the underlying buffer used by this
-        :type:`string`. The returned `c_ptrConst(c_char)` is only valid when used
-        on the same locale as the string.
-   */
-  pragma "last resort"
-  @deprecated("'string.c_str()' has moved to 'CTypes'. Please 'use CTypes' to access ':proc:`~CTypes.string.c_str`'")
-  inline proc string.c_str() : c_ptrConst(c_char) {
-    use CTypes only c_str;
-    return this.c_str();
   }
 
   /*
@@ -2433,18 +2371,6 @@ module String {
   //
   // Casts (casts to & from other primitive types are in StringCasts)
   //
-
-  // Cast from c_string to string
-  @chpldoc.nodoc
-  @deprecated("the type 'c_string' is deprecated; please use one of the 'string.create*ingBuffer' methods that takes a 'c_ptrConst(c_char)' instead")
-  operator :(cs: c_string, type t: string)  {
-    try {
-      return string.createCopyingBuffer(cs:c_ptrConst(c_char));
-    }
-    catch {
-      halt("Casting a non-UTF-8 c_string to string");
-    }
-  }
 
   // Cast from byteIndex to int
   @chpldoc.nodoc


### PR DESCRIPTION
Deprecations were introduced by the following PRs:
* https://github.com/chapel-lang/chapel/pull/22622
* https://github.com/chapel-lang/chapel/pull/23220

Which occurred more than 6 months ago.

## Testing
- [ ] paratest