### PR TITLE
Delete deprecated 'chpl_task_yield' function

### DIFF
--- a/modules/internal/LocaleModelHelpRuntime.chpl
+++ b/modules/internal/LocaleModelHelpRuntime.chpl
@@ -124,8 +124,6 @@ module LocaleModelHelpRuntime {
   extern proc chpl_task_addTask(fn: int,
                                 args: chpl_task_bundle_p, args_size: c_size_t,
                                 subloc_id: int);
-  @deprecated("'chpl_task_yield' is deprecated, please use 'currentTask.yieldExecution' instead")
-  extern proc chpl_task_yield();
 
   //
   // Add a task for a begin statement.

--- a/test/deprecated/taskYield.chpl
+++ b/test/deprecated/taskYield.chpl
@@ -1,1 +1,0 @@
-chpl_task_yield();

--- a/test/deprecated/taskYield.good
+++ b/test/deprecated/taskYield.good
@@ -1,1 +1,0 @@
-taskYield.chpl:1: warning: 'chpl_task_yield' is deprecated, please use 'currentTask.yieldExecution' instead


### PR DESCRIPTION
Deprecations were introduced by the following PRs:
* https://github.com/chapel-lang/chapel/pull/22883

Which occurred more than 6 months ago.

Reviewed by @jhh67 -- thanks!

## Testing

- [x] paratest