### PR TITLE
Remove deprecated code from Version

### DIFF
--- a/modules/standard/Version.chpl
+++ b/modules/standard/Version.chpl
@@ -128,46 +128,6 @@ module Version {
   chplVersion = new versionValue(chplMajor, chplMinor, chplUpdate, chplSHA);
 
   /*
-    This record represents a software version that is modeled after a semantic
-    version. It uses ``param`` values to represent its components in order to
-    support compile-time comparison of version numbers which in turn
-    permits code to specialize to specific versions of Chapel.  When
-    printed or converted to a string, it is represented as
-    ``major.minor.update (commit)``.
-    Note that ordered comparisons between two :type:`sourceVersion`
-    values that only differ in their ``commit`` values are not
-    supported due to the challenges involved in ordering commit
-    values.  However, when a value with an empty ``update`` value is
-    compared to one whose ``update`` is non-empty, the latter is
-    considered to be earlier than (less than) the former, due to the
-    interpretation that it represents a pre-release of the official
-    release.
-  */
-  @deprecated(notes="sourceVersion is deprecated, please use versionValue instead.")
-  type sourceVersion = versionValue;
-
-  /*
-    A helper function that creates a new sourceVersion from its arguments.
-    :arg major: The major version number
-    :type major: `int`
-    :arg minor: The minor version number
-    :type minor: `int`
-    :arg update: The optional update version number (defaults to 0)
-    :type update: `int`
-    :arg commit: The optional commit ID (defaults to "")
-    :type commit: `string`
-    :returns: A new version value of type :type:`sourceVersion`.
-  */
-  @deprecated(notes="createVersion is deprecated, please use 'new versionValue()' instead.")
-  proc createVersion(param major: int,
-                     param minor: int,
-                     param update: int = 0,
-                     param commit: string = ""): sourceVersion(?) {
-    return new sourceVersion(major, minor, update, commit);
-  }
-
-
-  /*
     This record represents a software version that is modeled after
     a semantic version, though not 100% true to the semver spec. The main
     deviation from the spec is that ``versionValue`` doesn't support pre-release

--- a/test/library/standard/Version/compareVersionTypes.chpl
+++ b/test/library/standard/Version/compareVersionTypes.chpl
@@ -17,9 +17,6 @@ const v2_2_1_p = new versionValue(2,2,1,"ddd");
 const v3_1_0_p = new versionValue(3,1,0,"eee");
 const v3_1_1_p = new versionValue(3,1,1,"fff");
 
-// test for deprecated sourceVersion
-const v3_1_1_psv = new sourceVersion(3,1,1,"fff");
-
 var x = 2, y = 1, z = 3, q = 0;
 
 const v2_1_0_c = new version(x,y);
@@ -121,9 +118,9 @@ compareBothVersions(v3_1_0, v3_1_1_c);
 compareBothVersions(v3_1_0_c, v3_1_1_p);
 compareBothVersions(v3_1_0, v3_1_1_p_c);
 
-compareBothVersions(v3_1_0, v3_1_1_psv);
-compareBothVersions(v3_1_1, v3_1_1_psv);
-compareBothVersions(v3_1_1_p, v3_1_1_psv);
+compareBothVersions(v3_1_0, v3_1_1_p);
+compareBothVersions(v3_1_1, v3_1_1_p);
+compareBothVersions(v3_1_1_p, v3_1_1_p);
 
 proc compareBothVersions(v1, v2) {
   compareVersions(v1,v2);

--- a/test/library/standard/Version/compareVersionTypes.good
+++ b/test/library/standard/Version/compareVersionTypes.good
@@ -1,4 +1,3 @@
-compareVersionTypes.chpl:21: warning: sourceVersion is deprecated, please use versionValue instead.
 Comparing versions:
 3.1.1
 3.1.1

--- a/test/library/standard/Version/versionCastIsParam.chpl
+++ b/test/library/standard/Version/versionCastIsParam.chpl
@@ -1,9 +1,9 @@
 use Version;
 
-var v = createVersion(1,23,0);
+var v = new versionValue(1,23,0);
 param test = ("version " + v:string == "version 1.23.0");
 
-var v2 = createVersion(1,23,0,"vass");
+var v2 = new versionValue(1,23,0,"vass");
 compilerWarning(v2:string);
 
 if test == false then

--- a/test/library/standard/Version/versionCastIsParam.good
+++ b/test/library/standard/Version/versionCastIsParam.good
@@ -1,4 +1,2 @@
-versionCastIsParam.chpl:3: warning: createVersion is deprecated, please use 'new versionValue()' instead.
-versionCastIsParam.chpl:6: warning: createVersion is deprecated, please use 'new versionValue()' instead.
 versionCastIsParam.chpl:7: warning: 1.23.0 (vass)
 versionCastIsParam.chpl:13: error: Yay!


### PR DESCRIPTION
The deprecated code here precedes the existence of @ deprecated, and thus is over 6 monts old.

The PRs that introduced `versionValue` (versus `sourceVersion`):
* https://github.com/chapel-lang/chapel/pull/21088

Sorry, didn't mean to ping anyone :-) 

Reviewed by @riftEmber -- thanks!

- [x] paratest