### PR TITLE
Improve mason repo cache skipifs

### DIFF
--- a/test/mason/publish/licenseList.skipif
+++ b/test/mason/publish/licenseList.skipif
@@ -2,7 +2,8 @@
 
 import os
 
-if os.getenv("REPO_CACHE_PATH") == None:
+repo_cache_path = os.getenv("REPO_CACHE_PATH", None)
+if repo_cache_path == None or os.path.exists(repo_cache_path) == False:
    print(True)
 else:
    print(False)

--- a/test/mason/publish/licenseListNoCache.skipif
+++ b/test/mason/publish/licenseListNoCache.skipif
@@ -1,8 +1,0 @@
-#!/usr/bin/env python3
-
-import os
-
-if os.getenv("REPO_CACHE_PATH") != None:
-   print(True)
-else:
-   print(False)

--- a/test/mason/publish/licenseRefresh.skipif
+++ b/test/mason/publish/licenseRefresh.skipif
@@ -2,7 +2,8 @@
 
 import os
 
-if os.getenv("REPO_CACHE_PATH") == None:
+repo_cache_path = os.getenv("REPO_CACHE_PATH", None)
+if repo_cache_path == None or os.path.exists(repo_cache_path) == False:
    print(True)
 else:
    print(False)

--- a/test/mason/publish/licenseRefreshNoCache.skipif
+++ b/test/mason/publish/licenseRefreshNoCache.skipif
@@ -1,8 +1,0 @@
-#!/usr/bin/env python3
-
-import os
-
-if os.getenv("REPO_CACHE_PATH") != None:
-   print(True)
-else:
-   print(False)


### PR DESCRIPTION
Improves the mason repo cache skipifs. 

Almost all nightly correctness tests set REPO_CACHE_PATH, but the path does not necessarily exist on all systems. This caused the tests using these paths to fail.

For similar reasons, this PR removes the NoCache tests skipifs, as that skipif was always being used, so the test was never run.

Followup to https://github.com/chapel-lang/chapel/pull/26121