### PR TITLE
Resolve associative domain literals

### DIFF
--- a/frontend/test/resolution/testDomains.cpp
+++ b/frontend/test/resolution/testDomains.cpp
@@ -442,6 +442,9 @@ int main() {
   testAssociative(context, "domain(int, false)", "int", false);
   testAssociative(context, "domain(string)", "string", true);
 
+  testDomainLiteral(context, "{1, 2, 3}", DomainType::Kind::Associative);
+  testDomainLiteral(context, "{\"apple\", \"banana\"}", DomainType::Kind::Associative);
+
   testBadPass(context, "domain(1)", "domain(2)");
   testBadPass(context, "domain(1, int(16))", "domain(1, int(8))");
   testBadPass(context, "domain(1, int(8))", "domain(1, int(16))");


### PR DESCRIPTION
Enable testing of associative domain literals in Dyno.

With some concurrent work done on `main`, no changes are needed in this PR to get the tests passing.

[reviewer info placeholder]

Testing:
- [x] paratest
- [x] dyno tests
