### PR TITLE
Remove deprecated 'CodepointSplittingError'

### DIFF
--- a/modules/standard/Errors.chpl
+++ b/modules/standard/Errors.chpl
@@ -161,9 +161,6 @@ module Errors {
     }
   }
 
-  @deprecated(notes=":class:`CodepointSplittingError` is deprecated; please use :class:`CodepointSplitError` instead")
-  type CodepointSplittingError = CodepointSplitError;
-
   // Used by the runtime to accumulate errors. This type
   // supports adding errors concurrently but need not support
   // iterating over the errors concurrently. Errors

--- a/test/deprecated/cpSplittingError.chpl
+++ b/test/deprecated/cpSplittingError.chpl
@@ -1,1 +1,0 @@
-var cpe = new CodepointSplittingError("info");


### PR DESCRIPTION
This is removed in favor of 'CodepointSplitError'.

Deprecations were introduced by the following PRs:
* https://github.com/chapel-lang/chapel/pull/22678

This occurred 2023, which is longer than our deprecation period.

Reviewed by @e-kayrakli -- thanks!

## Testing
- [x] paratest