### PR TITLE
Remove (signatures of) deprecated type comparison operators

### DIFF
--- a/doc/rst/language/spec/types.rst
+++ b/doc/rst/language/spec/types.rst
@@ -977,10 +977,6 @@ The normal comparison operators are also available to compare types:
 
  * ``==`` checks if two types are equivalent
  * ``!=`` checks if two types are different
- * ``<`` and ``>`` check if one type is a proper subtype of another (see
-   :proc:`< <Types.<>`)
- * ``<=`` and ``>=`` check if one type is a subtype of another (see
-   :proc:`<= <Types.<=>`)
 
 It is possible to cast a type to a ``param`` string. This allows a type
 to be printed out.

--- a/modules/standard/Types.chpl
+++ b/modules/standard/Types.chpl
@@ -1028,29 +1028,4 @@ proc isProperSubtype(type sub, type sup) param {
   return __primitive("is_proper_subtype", sup, sub);
 }
 
-/* :returns: isProperSubtype(a,b) */
-pragma "docs only"
-@deprecated(notes="< operator is deprecated when comparing types; use isProperSubtype() instead")
-operator <(type a, type b) param {
-  return isProperSubtype(a,b);
-}
-/* :returns: isSubtype(a,b) */
-pragma "docs only"
-@deprecated(notes="<= operator is deprecated when comparing types; use isSubtype() instead")
-operator <=(type a, type b) param {
-  return isSubtype(a,b);
-}
-/* :returns: isProperSubtype(b,a) */
-pragma "docs only"
-@deprecated(notes="> operator is deprecated when comparing types; use isProperSubtype() instead")
-operator >(type a, type b) param {
-  return isProperSubtype(b,a);
-}
-/* :returns: isSubtype(b,a) */
-pragma "docs only"
-@deprecated(notes=">= operator is deprecated when comparing types; use isSubtype() instead")
-operator >=(type a, type b) param {
-  return isSubtype(b,a);
-}
-
 } // module Types


### PR DESCRIPTION
They were deprecated in https://github.com/chapel-lang/chapel/pull/21108 and removed from the compiler in https://github.com/chapel-lang/chapel/pull/23957 Even the removal was more than 6 month ago.

Reviewed by @stonea -- thanks!

## Testing
- [x] paratest