### PR TITLE
Remove the non-portable realpath from chplcheck tests

### DIFF
--- a/test/chplcheck/PREDIFF
+++ b/test/chplcheck/PREDIFF
@@ -14,7 +14,7 @@ fi
 
 $CHPL_HOME/tools/chplcheck/chplcheck $FLAGS $1.chpl >>$2 2>&1
 
-dirpath=$(dirname $(realpath $1.chpl))
+dirpath=$(cd $(dirname $1.chpl) && pwd)
 if sed "s#$dirpath/##" $2 >$2.tmp; then
   mv $2.tmp $2
 fi

--- a/tools/chplcheck/examples/PREDIFF
+++ b/tools/chplcheck/examples/PREDIFF
@@ -14,7 +14,7 @@ fi
 
 $CHPL_HOME/tools/chplcheck/chplcheck $FLAGS $1.chpl >>$2 2>&1
 
-dirpath=$(dirname $(realpath $1.chpl))
+dirpath=$(cd $(dirname $1.chpl) && pwd)
 if sed "s#$dirpath/##" $2 >$2.tmp; then
   mv $2.tmp $2
 fi


### PR DESCRIPTION
Remove the non-portable realpath from chplcheck tests, replacing it with a `cd ...; pwd`

Tested on MacOS and Linux

[Reviewed by @DanilaFe]