### PR TITLE
Revert pinning GCC version for CHAMPS testing, stop testing potential

### DIFF
--- a/test/studies/champs/sub_test
+++ b/test/studies/champs/sub_test
@@ -87,7 +87,6 @@ test_compile icing
 if [ -z "$CHAMPS_QUICKSTART" ] || [ ! -z "$CHAMPS_COMPILE_ALL_EXECS" ] ; then
   test_compile flow
   test_compile drop
-  test_compile potential
   test_compile potentialPrep
   test_compile geo
   test_compile thermo
@@ -105,6 +104,7 @@ if [ -z "$CHAMPS_QUICKSTART" ] || [ ! -z "$CHAMPS_COMPILE_ALL_EXECS" ] ; then
   # system/backend issue. Until we figure out what's going wrong, stop testing
   # these executables with the C backend
   if [ "${CHPL_TARGET_COMPILER}" != "gnu" ] ; then
+    test_compile potential
     test_compile prep
     test_compile post
   fi

--- a/util/cron/common-champs.bash
+++ b/util/cron/common-champs.bash
@@ -32,8 +32,6 @@ module load cray-pmi
 module load cray-mpich
 module load cray-hdf5-parallel
 
-module load gcc-native/10.3
-
 module list
 
 # note that this part is similar to common-hpe-apollo.bash, but


### PR DESCRIPTION
https://github.com/chapel-lang/chapel/pull/26433 tried to pin an older GCC to avoid [CHAMPS' compilation OOM issues](https://github.com/Cray/chapel-private/issues/6529). That did not help. This PR adds `potential` to the blacklist, and reverts https://github.com/chapel-lang/chapel/pull/26433.