### PR TITLE
Dyno: Passing anymanaged child to type formal constrained by parent type

### DIFF
--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -443,6 +443,16 @@ CanPassResult CanPassResult::canPassDecorators(Context* context,
                                                ClassTypeDecorator actual,
                                                ClassTypeDecorator formal) {
   if (actual == formal) {
+    if (actual.isNilable() == formal.isNilable()) {
+      if (formal.isUnknownManagement()) {
+        // Account for the case when passing an unmanaged class type to
+        // an any-managed type formal, which is technically an instantiation.
+        return CanPassResult(/* no fail reason, passes */ {},
+                             /*instantiates*/ true,
+                             /*promotes*/ false,
+                             /*conversion*/ NONE);
+      }
+    }
     return passAsIs();
   }
 

--- a/frontend/test/resolution/testClasses.cpp
+++ b/frontend/test/resolution/testClasses.cpp
@@ -330,6 +330,34 @@ static void test6() {
   assert(guard.numErrors() == 0);
 }
 
+static void test7() {
+  printf("test7\n");
+
+  std::string program = R"""(
+    class Parent {
+    }
+
+    class Child : Parent {
+    }
+
+    proc test(type T: Parent) {
+      var ret = new unmanaged T();
+      return ret;
+    }
+
+    var x = test(Child);
+  )""";
+  auto context = buildStdContext();
+  ErrorGuard guard(context);
+
+  auto x = resolveQualifiedTypeOfX(context, program);
+  auto t = x.type()->toClassType();
+  assert(t);
+  assert(t->decorator().isUnmanaged());
+  assert(t->decorator().isNonNilable());
+  assert(t->basicClassType()->name() == "Parent");
+}
+
 
 
 int main() {
@@ -339,6 +367,7 @@ int main() {
   test4();
   test5();
   test6();
+  test7();
 
   return 0;
 }


### PR DESCRIPTION
This change allows for the passing of an 'anymanaged' child class type to an anymanaged type formal constrained by the child's parent type. For example:

```
proc test(type T: Parent) { }
test(Child);
```

Note: Within the body of ``test``, the formal ``T`` will be of type ``Parent``.

The implementation itself modifies our "can pass" logic to always instantiate when passing a valid actual type to an anymanaged formal type, even if the actual itself is 'anymanaged'.

A test is added to lock in this behavior.

Testing:
- [x] test-frontend