### PR TITLE
Fix two issues with python interop module

### DIFF
--- a/modules/packages/Python.chpl
+++ b/modules/packages/Python.chpl
@@ -1014,7 +1014,7 @@ module Python {
       :arg interpreter: The interpreter that this object is associated with.
       :arg pickleData: The pickle data to load.
     */
-    proc init(in interpreter: borrowed Interpreter, pickleData: bytes) {
+    proc init(in interpreter: borrowed Interpreter, pickleData: bytes) throws {
       this.interpreter = interpreter;
       this.isOwned = true;
       init this;

--- a/modules/packages/Python.chpl
+++ b/modules/packages/Python.chpl
@@ -1577,7 +1577,7 @@ module Python {
     extern proc Py_InitializeFromConfig(config_: c_ptr(PyConfig)): PyStatus;
     extern proc PyStatus_Exception(in status: PyStatus): bool;
     extern proc Py_Finalize();
-    extern proc Py_INCREF(obj: PyObjectPtr);
+    extern "chpl_Py_INCREF" proc Py_INCREF(obj: PyObjectPtr);
     extern "chpl_Py_DECREF" proc Py_DECREF(obj: PyObjectPtr);
     extern "chpl_Py_CLEAR" proc Py_CLEAR(obj: c_ptr(PyObjectPtr));
     extern proc PyMem_Free(ptr: c_ptr(void));

--- a/modules/packages/PythonHelper/ChapelPythonHelper.h
+++ b/modules/packages/PythonHelper/ChapelPythonHelper.h
@@ -52,6 +52,7 @@ static inline PyObject* chpl_PyErr_GetRaisedException(void) {
 #endif
 }
 
+static inline void chpl_Py_INCREF(PyObject* o) { Py_INCREF(o); }
 static inline void chpl_Py_DECREF(PyObject* o) { Py_DECREF(o); }
 static inline void chpl_Py_CLEAR(PyObject** o) { Py_CLEAR(*o); }
 


### PR DESCRIPTION
Fixes to small issues added in a recent PR to the Python interop module

- Py_INCREF on some systems is a macro
- `throws` was missing on a new init overload

[Reviewed by @DanilaFe]