### PR TITLE
Run complete test suite on HPE Cray EX

### DIFF
--- a/util/cron/test-hpe-cray-ex-ofi.bash
+++ b/util/cron/test-hpe-cray-ex-ofi.bash
@@ -11,4 +11,4 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="hpe-cray-ex-ofi"
 export CHPL_RT_COMM_OFI_EXPECTED_PROVIDER="cxi"
 export CHPL_RT_MAX_HEAP_SIZE=16g
 
-$UTIL_CRON_DIR/nightly -cron -examples -blog ${nightly_args}
+$UTIL_CRON_DIR/nightly -cron -blog ${nightly_args}


### PR DESCRIPTION
Remove the -examples argument to nightly so the complete test suite is run.