### PR TITLE
Implement various primitives in Dyno

### DIFF
--- a/frontend/include/chpl/types/Type.h
+++ b/frontend/include/chpl/types/Type.h
@@ -272,6 +272,8 @@ class Type {
    */
   bool isUserRecordType() const;
 
+  bool isRecordLike() const;
+
   /** Returns true if the this type has the pragma 'p' attached to it. */
   bool hasPragma(Context* context, uast::pragmatags::PragmaTag p) const;
 
@@ -344,6 +346,8 @@ class Type {
       All other cases are considered to be POD.
   */
   static bool isPod(Context* context, const Type* t);
+
+  static bool needsInitDeinitCall(const Type* t);
 
   /// \cond DO_NOT_DOCUMENT
   DECLARE_DUMP;

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -368,46 +368,6 @@ void CallInitDeinit::processDeinitsAndPropagate(VarFrame* frame,
   }
 }
 
-static bool isRecordLike(const Type* t) {
-  if (auto ct = t->toClassType()) {
-    auto decorator = ct->decorator();
-    // no action needed for 'borrowed' or 'unmanaged'
-    // (these should just default initialized to 'nil',
-    //  so nothing else needs to be resolved)
-    if (! (decorator.isBorrowed() || decorator.isUnmanaged() ||
-          decorator.isUnknownManagement())) {
-      return true;
-    }
-  } else if (t->isRecordType() || t->isUnionType()) {
-    return true;
-  }
-  // TODO: tuples?
-
-  return false;
-}
-
-static bool typeNeedsInitDeinitCall(const Type* t) {
-  if (t == nullptr || t->isUnknownType() || t->isErroneousType()) {
-    // can't do anything with these
-    return false;
-  } else if (t->isPrimitiveType() || t->isBuiltinType() || t->isCStringType() ||
-             t->isNilType() || t->isNothingType() || t->isVoidType()) {
-    // OK, we can always default initialize primitive numeric types,
-    // and as well we assume that for the non-generic builtin types
-    // e.g. TaskIdType.
-    // No need to resolve anything additional now.
-    return false;
-  } else if (t->isEnumType()) {
-    // OK, can default-initialize enums to first element
-    return false;
-  } else if (t->isFunctionType()) {
-    return false;
-  }
-
-  return isRecordLike(t);
-}
-
-
 void CallInitDeinit::resolveDefaultInit(const VarLikeDecl* ast, RV& rv) {
   // Type variables do not need default init.
   if (ast->storageKind() == Qualifier::TYPE) return;
@@ -446,7 +406,7 @@ void CallInitDeinit::resolveDefaultInit(const VarLikeDecl* ast, RV& rv) {
     }
   }
 
-  if (!typeNeedsInitDeinitCall(vt)) {
+  if (!Type::needsInitDeinitCall(vt)) {
     // nothing to do here
   } else if (vt->isTupleType()) {
     // TODO: probably need to do something here, at least in some cases
@@ -563,7 +523,7 @@ void CallInitDeinit::resolveCopyInit(const AstNode* ast,
                                      const QualifiedType& rhsType,
                                      bool forMoveInit,
                                      RV& rv) {
-  if (!typeNeedsInitDeinitCall(lhsType.type())) {
+  if (!Type::needsInitDeinitCall(lhsType.type())) {
     // TODO: we could resolve it anyway
     return;
   }
@@ -672,7 +632,7 @@ void CallInitDeinit::processInit(VarFrame* frame,
                                  const QualifiedType& rhsType,
                                  RV& rv) {
   if (lhsType.type() == rhsType.type() &&
-      !typeNeedsInitDeinitCall(lhsType.type())) {
+      !Type::needsInitDeinitCall(lhsType.type())) {
     // TODO: we should resolve it anyway
     return;
   }
@@ -722,7 +682,7 @@ void CallInitDeinit::processInit(VarFrame* frame,
     } else {
       // it is copy initialization, so use init= for records
       // and assign for other stuff
-      if (lhsType.type() != nullptr && isRecordLike(lhsType.type())) {
+      if (lhsType.type() != nullptr && lhsType.type()->isRecordLike()) {
         resolveCopyInit(ast, rhsAst,
                         lhsType, rhsType,
                         /* forMoveInit */ false,
@@ -741,7 +701,7 @@ void CallInitDeinit::resolveDeinit(const AstNode* ast,
                                    RV& rv) {
 
   // nothing to do for 'int' etc
-  if (!typeNeedsInitDeinitCall(type.type())) {
+  if (!Type::needsInitDeinitCall(type.type())) {
     return;
   } else if (type.type()->isTupleType()) {
     // TODO: probably need to do something here, at least in some cases
@@ -968,7 +928,7 @@ void CallInitDeinit::handleInFormal(const FnCall* ast, const AstNode* actual,
   // is the copy for 'in' elided?
   if (elidedCopyFromIds.count(actual->id()) > 0 &&
       isValue(actualType.kind()) &&
-      typeNeedsInitDeinitCall(actualType.type())) {
+      Type::needsInitDeinitCall(actualType.type())) {
     // it is move initialization
     resolveMoveInit(actual, actual, formalType, actualType, rv);
 

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -385,6 +385,18 @@ static QualifiedType primTypeof(Context* context, PrimitiveTag prim, const CallI
   return QualifiedType(QualifiedType::TYPE, typePtr);
 }
 
+static QualifiedType primPromotionType(Context* context, const CallInfo& ci) {
+  if (ci.numActuals() != 1) return QualifiedType();
+  auto actualQt = ci.actual(0).type();
+
+  auto promoTy = getPromotionType(context, actualQt).type();
+
+  // We want a type result, even if the prim was passed a value.
+  auto promoQt = QualifiedType(QualifiedType::TYPE, promoTy);
+
+  return promoQt;
+}
+
 static QualifiedType primGetSvecMember(Context* context, PrimitiveTag prim,
                                        const CallInfo& ci) {
   CHPL_ASSERT(prim == PRIM_GET_SVEC_MEMBER ||
@@ -1668,7 +1680,7 @@ CallResolutionResult resolvePrimCall(ResolutionContext* rc,
       break;
 
     case PRIM_SCALAR_PROMOTION_TYPE:
-      CHPL_UNIMPL("misc primitives");
+      type = primPromotionType(context, ci);
       break;
     case PRIM_STATIC_FIELD_TYPE:
       type = staticFieldType(context, ci);

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -389,12 +389,13 @@ static QualifiedType primPromotionType(Context* context, const CallInfo& ci) {
   if (ci.numActuals() != 1) return QualifiedType();
   auto actualQt = ci.actual(0).type();
 
-  auto promoTy = getPromotionType(context, actualQt).type();
+  auto promoQt = getPromotionType(context, actualQt);
+  if (promoQt.isUnknown()) promoQt = actualQt;
 
   // We want a type result, even if the prim was passed a value.
-  auto promoQt = QualifiedType(QualifiedType::TYPE, promoTy);
+  auto res = QualifiedType(QualifiedType::TYPE, promoQt.type());
 
-  return promoQt;
+  return res;
 }
 
 static QualifiedType primGetSvecMember(Context* context, PrimitiveTag prim,

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -987,6 +987,12 @@ static QualifiedType primIsPod(Context* context, const CallInfo& ci) {
   });
 }
 
+static QualifiedType primNeedsAutoDestroy(Context* context, const CallInfo& ci) {
+  return actualTypeHasProperty(context, ci, [=](auto t) {
+    return Type::needsInitDeinitCall(t) && !Type::isPod(context, t);
+  });
+}
+
 static QualifiedType
 primIsCoercible(Context* context, const CallInfo& ci) {
   if (ci.numActuals() < 2) return QualifiedType();
@@ -1245,8 +1251,11 @@ CallResolutionResult resolvePrimCall(ResolutionContext* rc,
       break;
 
     case PRIM_HAS_DEFAULT_VALUE:
-    case PRIM_NEEDS_AUTO_DESTROY:
       CHPL_UNIMPL("various primitives");
+      break;
+
+    case PRIM_NEEDS_AUTO_DESTROY:
+      type = primNeedsAutoDestroy(context, ci);
       break;
 
     case PRIM_CALL_RESOLVES:

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -1746,7 +1746,6 @@ CallResolutionResult resolvePrimCall(ResolutionContext* rc,
     case PRIM_BLOCK_UNLOCAL:
     case PRIM_LOGICAL_FOLDER:
     case PRIM_WIDE_MAKE:
-    case PRIM_WIDE_GET_LOCALE:
     case PRIM_REGISTER_GLOBAL_VAR:
     case PRIM_BROADCAST_GLOBAL_VARS:
     case PRIM_PRIVATE_BROADCAST:
@@ -1769,6 +1768,11 @@ CallResolutionResult resolvePrimCall(ResolutionContext* rc,
     case PRIM_FORCE_THUNK:
     case PRIM_THUNK_RESULT_TYPE:
       CHPL_UNIMPL("misc primitives");
+      break;
+
+    case PRIM_WIDE_GET_LOCALE:
+      type = QualifiedType(QualifiedType::CONST_VAR,
+                           CompositeType::getLocaleIDType(context));
       break;
 
     case PRIM_GATHER_TESTS:

--- a/frontend/lib/types/CompositeType.cpp
+++ b/frontend/lib/types/CompositeType.cpp
@@ -180,8 +180,8 @@ const RecordType* CompositeType::getLocaleType(Context* context) {
 }
 
 const RecordType* CompositeType::getLocaleIDType(Context* context) {
-  auto id = ID();
-  auto name = UniqueString::get(context, "chpl_localeID_t");
+  auto [id, name] = parsing::getSymbolFromTopLevelModule(
+      context, "LocaleModelHelpRuntime", "chpl_localeID_t");
   return RecordType::get(context, id, name,
                          /* instantiatedFrom */ nullptr,
                          SubstitutionsMap());

--- a/frontend/test/resolution/testResolve.cpp
+++ b/frontend/test/resolution/testResolve.cpp
@@ -1816,6 +1816,26 @@ static void testCallableAmbiguity() {
   assert(guard.realizeErrors());
 }
 
+// Test use of the 'scalar promotion type' primitive.
+// Implementation of getting promotion types is tested more thoroughly
+// elsewhere, so this is just a very basic test the prims works as expected.
+static void testPromotionPrim() {
+  Context* context = buildStdContext();
+  ErrorGuard guard(context);
+
+  std::string prog =
+    R"""(
+      var d : domain(1, real);
+      type t = __primitive("scalar promotion type", d);
+      param x = (t == real);
+    )""";
+
+  auto x = resolveTypeOfXInit(context, prog);
+  ensureParamBool(x, true);
+
+  assert(guard.realizeErrors() == 0);
+}
+
 int main() {
   test1();
   test2();
@@ -1850,6 +1870,8 @@ int main() {
   testFormalFunctionShadowing();
   testFunctionFormalShadowing();
   testCallableAmbiguity();
+
+  testPromotionPrim();
 
   return 0;
 }

--- a/frontend/test/resolution/testResolve.cpp
+++ b/frontend/test/resolution/testResolve.cpp
@@ -1823,17 +1823,33 @@ static void testPromotionPrim() {
   Context* context = buildStdContext();
   ErrorGuard guard(context);
 
-  std::string prog =
-    R"""(
-      var d : domain(1, real);
-      type t = __primitive("scalar promotion type", d);
-      param x = (t == real);
-    )""";
+  {
+    std::string prog =
+      R"""(
+        var d : domain(1, real);
+        type t = __primitive("scalar promotion type", d);
+        param x = (t == real);
+      )""";
 
-  auto x = resolveTypeOfXInit(context, prog);
-  ensureParamBool(x, true);
+    auto x = resolveTypeOfXInit(context, prog);
+    ensureParamBool(x, true);
 
-  assert(guard.realizeErrors() == 0);
+    assert(guard.realizeErrors() == 0);
+  }
+
+  {
+    context->advanceToNextRevision(false);
+    std::string prog =
+      R"""(
+        type t = __primitive("scalar promotion type", int);
+        param x = (t == int);
+      )""";
+
+    auto x = resolveTypeOfXInit(context, prog);
+    ensureParamBool(x, true);
+
+    assert(guard.realizeErrors() == 0);
+  }
 }
 
 // Test the '_wide_get_locale' primitive.

--- a/frontend/test/resolution/testResolve.cpp
+++ b/frontend/test/resolution/testResolve.cpp
@@ -1836,6 +1836,28 @@ static void testPromotionPrim() {
   assert(guard.realizeErrors() == 0);
 }
 
+// Test the '_wide_get_locale' primitive.
+static void testGetLocalePrim() {
+  Context* context = buildStdContext();
+  ErrorGuard guard(context);
+
+  auto variables = resolveTypesOfVariables(context,
+    R"""(
+      var x : real;
+      var locId = __primitive("_wide_get_locale", x);
+      var sublocId = chpl_sublocFromLocaleID(locId);
+    )""", { "locId", "sublocId" });
+
+  auto locId = variables.at("locId");
+  assert(locId.type());
+  assert(locId.type() == CompositeType::getLocaleIDType(context));
+  auto sublocId = variables.at("sublocId");
+  assert(sublocId.type());
+  assert(sublocId.type()->isIntType());
+
+  assert(guard.realizeErrors() == 0);
+}
+
 int main() {
   test1();
   test2();
@@ -1872,6 +1894,7 @@ int main() {
   testCallableAmbiguity();
 
   testPromotionPrim();
+  testGetLocalePrim();
 
   return 0;
 }


### PR DESCRIPTION
Implement a few primitives in Dyno, needed for https://github.com/chapel-lang/chapel/pull/26534:
- `scalar promotion type`
- `needs auto destroy`
- `_wide_get_locale`

Adds testing for all except `needs auto destroy`, as its logic is very closely copied from production.

[reviewer info placeholder]

Testing:
- [x] dyno tests
- [x] paratest