### PR TITLE
Bump Arkouda release version to 2.3

### DIFF
--- a/util/cron/common-arkouda.bash
+++ b/util/cron/common-arkouda.bash
@@ -49,7 +49,7 @@ if [ -f "$SETUP_PYTHON" ]; then
   source $SETUP_PYTHON
 fi
 
-export CHPL_WHICH_RELEASE_FOR_ARKOUDA="2.2.0"
+export CHPL_WHICH_RELEASE_FOR_ARKOUDA="2.3.0"
 # test against Chapel release (checking out current test/cron directories)
 function test_release() {
   export CHPL_TEST_PERF_DESCRIPTION=release


### PR DESCRIPTION
This PR bumps the Chapel release version Arkouda's nightly testing uses to 2.3.

Resolves https://github.com/Cray/chapel-private/issues/7027