### PR TITLE
Fix test outdated due to c_string removal

### DIFF
--- a/test/execflags/gbt/getenv.chpl
+++ b/test/execflags/gbt/getenv.chpl
@@ -1,3 +1,5 @@
-extern proc getenv(const name: c_string): c_string;
-extern proc printf(const fmt: c_string, const arg1: c_string);
+use CTypes;
+
+extern proc getenv(const name: c_ptrConst(c_char)): c_ptrConst(c_char);
+extern proc printf(const fmt: c_ptrConst(c_char), const arg1: c_ptrConst(c_char));
 for loc in Locales do on loc do printf('%s\n', getenv('GETENV_ENV_VAR'));


### PR DESCRIPTION
`c_string` is no longer defined.

Reviewed by @lydia-duncan -- thanks!

## Testing
- [x] paratest gasnet