### PR TITLE
Update load-base-deps for new chapcs Spack location

### DIFF
--- a/util/cron/load-base-deps.bash
+++ b/util/cron/load-base-deps.bash
@@ -4,8 +4,8 @@
 
 # For most systems, load all dependencies via spack
 if [[ "${HOSTNAME:0:6}" == "chapcs" || "${HOSTNAME:0:6}" == "chapvm" ]]; then
-  if [ -f /data/cf/chapel/chpl-deps/chapcs11/load_chpl_deps.bash ] ; then
-    source /data/cf/chapel/chpl-deps/chapcs11/load_chpl_deps.bash
+  if [ -f /hpcdc/project/chapel/chpl-deps/chapcs11/load_chpl_deps.bash ] ; then
+    source /hpcdc/project/chapel/chpl-deps/chapcs11/load_chpl_deps.bash
   fi
 elif [[ "$(hostname -s)" == "osprey" || "$(hostname -s)" == "atlas" ||
         "$(hostname -s)" == "pinoak-login1" ]]; then


### PR DESCRIPTION
Update `util/cron/load-base-deps.bash` to use the location of the new Spack install on `chapcs`/`chapvm` machines.

For https://github.com/Cray/chapel-private/issues/7022.

[trivial, not reviewed]