### PR TITLE
Refactor chapel-py to use the C Python Stable API

### DIFF
--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -33,7 +33,7 @@ sys.path.insert(0, os.path.abspath('./'))
 old_sys_path = sys.path.copy()
 sys.path.insert(0, os.path.abspath('../../util/chplenv'))
 import chpl_home_utils
-chapel_py_dir = chpl_home_utils.get_chpldeps(True)
+chapel_py_dir = chpl_home_utils.get_chpldeps(chapel_py=True)
 del chpl_home_utils
 sys.path = old_sys_path
 

--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -30,11 +30,13 @@ sys.path.insert(0, os.path.abspath('./'))
 # to prevent failures if chapel-py is not built/installed, check if its installed
 # if installed, add the path and generate the rst file
 # if not installed, just create the file so that the build doesn't fail
-chapel_py_dir = os.path.abspath(
-    "../../third-party/chpl-venv/install/chpl-frontend-py-deps-py"
-    + str(sys.version_info.major)
-    + str(sys.version_info.minor)
-)
+old_sys_path = sys.path.copy()
+sys.path.insert(0, os.path.abspath('../../util/chplenv'))
+import chpl_home_utils
+chapel_py_dir = chpl_home_utils.get_chpldeps(True)
+del chpl_home_utils
+sys.path = old_sys_path
+
 include_chapel_py_docs = False
 chapel_py_api_template = os.path.abspath("./tools/chapel-py/chapel-py-api-template.rst")
 chapel_py_api_rst = os.path.abspath("./tools/chapel-py/chapel-py-api.rst")

--- a/doc/rst/usingchapel/prereqs.rst
+++ b/doc/rst/usingchapel/prereqs.rst
@@ -55,7 +55,8 @@ for using Chapel:
 In addition, several optional components have additional requirements:
 
   * Python 3.9 or newer is required if you want to use chpldoc, c2chapel,
-    or Chapel's test system. These additionally require ``python3-devel``
+    chapel-py, chplcheck, chpl-language-server, or Chapel's test system. These
+    additionally require ``python3-devel``
     or the equivalent package; ``python3`` and ``pip3`` commands; and the
     ``venv`` Python package.
 

--- a/third-party/chpl-venv/Makefile.include
+++ b/third-party/chpl-venv/Makefile.include
@@ -32,6 +32,5 @@ CHPL_VENV_VIRTUALENV_DIR_DEPS2_OK=$(CHPL_VENV_BUILD)/build-venv/ok2
 CHPL_VENV_VIRTUALENV_BIN=$(CHPL_VENV_VIRTUALENV_DIR)/bin
 CHPL_VENV_INSTALL=$(CHPL_VENV_DIR)/install
 CHPL_VENV_CHPLDEPS=$(CHPL_VENV_INSTALL)/chpldeps
-# CHPL_VENV_CHPL_FRONTEND_PY_DEPS=$(CHPL_VENV_INSTALL)/chpl-frontend-py-deps-py$(shell $(PYTHON) -c 'import sys; print(str(sys.version_info.major) + str(sys.version_info.minor))')
-CHPL_VENV_CHPL_FRONTEND_PY_DEPS=$(CHPL_VENV_CHPLDEPS)
+CHPL_VENV_CHPL_FRONTEND_PY_DEPS=$(shell $(PYTHON) $(CHPL_MAKE_HOME)/util/chplenv/chpl_home_utils.py --chpldeps-chapel-py)
 CHPL_VENV_CHPLDEPS_MAIN=$(CHPL_VENV_CHPLDEPS)/__main__.py

--- a/third-party/chpl-venv/Makefile.include
+++ b/third-party/chpl-venv/Makefile.include
@@ -32,5 +32,6 @@ CHPL_VENV_VIRTUALENV_DIR_DEPS2_OK=$(CHPL_VENV_BUILD)/build-venv/ok2
 CHPL_VENV_VIRTUALENV_BIN=$(CHPL_VENV_VIRTUALENV_DIR)/bin
 CHPL_VENV_INSTALL=$(CHPL_VENV_DIR)/install
 CHPL_VENV_CHPLDEPS=$(CHPL_VENV_INSTALL)/chpldeps
-CHPL_VENV_CHPL_FRONTEND_PY_DEPS=$(CHPL_VENV_INSTALL)/chpl-frontend-py-deps-py$(shell $(PYTHON) -c 'import sys; print(str(sys.version_info.major) + str(sys.version_info.minor))')
+# CHPL_VENV_CHPL_FRONTEND_PY_DEPS=$(CHPL_VENV_INSTALL)/chpl-frontend-py-deps-py$(shell $(PYTHON) -c 'import sys; print(str(sys.version_info.major) + str(sys.version_info.minor))')
+CHPL_VENV_CHPL_FRONTEND_PY_DEPS=$(CHPL_VENV_CHPLDEPS)
 CHPL_VENV_CHPLDEPS_MAIN=$(CHPL_VENV_CHPLDEPS)/__main__.py

--- a/third-party/chpl-venv/chapel-py-requirements.txt
+++ b/third-party/chpl-venv/chapel-py-requirements.txt
@@ -4,3 +4,5 @@ lsprotocol==2023.0.1
 pygls==1.3.1
 typeguard==4.3.0
 ConfigArgParse==1.7
+# needed for <python3.11
+exceptiongroup==1.2.2

--- a/tools/chapel-py/setup.py
+++ b/tools/chapel-py/setup.py
@@ -105,7 +105,7 @@ setup(
             depends=glob.glob("src/**/*.h", recursive=True),
             extra_compile_args=CXXFLAGS,
             extra_link_args=LDFLAGS,
-            py_limited_api=use_stable_api
+            py_limited_api=use_stable_api,
         )
     ],
 )

--- a/tools/chapel-py/setup.py
+++ b/tools/chapel-py/setup.py
@@ -85,14 +85,6 @@ if str(chpl_variables.get("CHPL_SANITIZE")) == "address":
 os.environ["CC"] = host_cc
 os.environ["CXX"] = host_cxx
 
-# We use a stable API for Python 3.10+
-# The limiting factor here is PyUnicode_AsUTF8AndSize, which was introduced in 3.10
-# If we are trying to build for an older version, we need to use the non-stable API
-use_stable_api = False
-if sys.version_info[:2] >= (3, 10):
-    use_stable_api = True
-    CXXFLAGS += ["-DCHAPEL_PY_USE_STABLE_API"]
-
 setup(
     name="chapel",
     version="0.1",
@@ -105,7 +97,7 @@ setup(
             depends=glob.glob("src/**/*.h", recursive=True),
             extra_compile_args=CXXFLAGS,
             extra_link_args=LDFLAGS,
-            py_limited_api=use_stable_api,
+            py_limited_api=True,
         )
     ],
 )

--- a/tools/chapel-py/setup.py
+++ b/tools/chapel-py/setup.py
@@ -84,6 +84,15 @@ if str(chpl_variables.get("CHPL_SANITIZE")) == "address":
 
 os.environ["CC"] = host_cc
 os.environ["CXX"] = host_cxx
+
+# We use a stable API for Python 3.10+
+# The limiting factor here is PyUnicode_AsUTF8AndSize, which was introduced in 3.10
+# If we are trying to build for an older version, we need to use the non-stable API
+use_stable_api = False
+if sys.version_info[:2] >= (3, 10):
+    use_stable_api = True
+    CXXFLAGS += ["-DCHAPEL_PY_USE_STABLE_API"]
+
 setup(
     name="chapel",
     version="0.1",
@@ -96,6 +105,7 @@ setup(
             depends=glob.glob("src/**/*.h", recursive=True),
             extra_compile_args=CXXFLAGS,
             extra_link_args=LDFLAGS,
+            py_limited_api=use_stable_api
         )
     ],
 )

--- a/tools/chapel-py/src/PythonWrapper.h
+++ b/tools/chapel-py/src/PythonWrapper.h
@@ -20,10 +20,14 @@
 #ifndef CHAPEL_PY_PYTHON_WRAPPER_H
 #define CHAPEL_PY_PYTHON_WRAPPER_H
 
-#ifdef CHAPEL_PY_USE_STABLE_API
-// use a stable API version of python 3.10
-#define Py_LIMITED_API 0x030A0000
-#endif
+//
+// Python.h should only be included in this header file, other files should
+// include this one.
+// This header guarantees a specific stable version of Python.h is used.
+//
+
+// use a stable API version of python 3.8
+#define Py_LIMITED_API 0x03080000
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 

--- a/tools/chapel-py/src/PythonWrapper.h
+++ b/tools/chapel-py/src/PythonWrapper.h
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2023-2025 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef CHAPEL_PY_PYTHON_WRAPPER_H
 #define CHAPEL_PY_PYTHON_WRAPPER_H
 

--- a/tools/chapel-py/src/PythonWrapper.h
+++ b/tools/chapel-py/src/PythonWrapper.h
@@ -1,0 +1,11 @@
+#ifndef CHAPEL_PY_PYTHON_WRAPPER_H
+#define CHAPEL_PY_PYTHON_WRAPPER_H
+
+#ifdef CHAPEL_PY_USE_STABLE_API
+// use a stable API version of python 3.10
+#define Py_LIMITED_API 0x030A0000
+#endif
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#endif

--- a/tools/chapel-py/src/chapel.cpp
+++ b/tools/chapel-py/src/chapel.cpp
@@ -17,8 +17,7 @@
  * limitations under the License.
  */
 
-#define PY_SSIZE_T_CLEAN
-#include "Python.h"
+#include "PythonWrapper.h"
 #include "chpl/framework/check-build.h"
 #include "chpl/framework/Context.h"
 #include "chpl/parsing/parsing-queries.h"

--- a/tools/chapel-py/src/core-types-gen.cpp
+++ b/tools/chapel-py/src/core-types-gen.cpp
@@ -183,7 +183,8 @@ ACTUAL_ITERATOR(FnCall);
       /*slots*/ slots \
     }; \
     auto parentType = parentTypeFor(TAG); \
-    TYPE = (PyTypeObject*)PyType_FromSpecWithBases(&spec, (PyObject*)parentType); \
+    auto bases = PyTuple_Pack(1, parentType); \
+    TYPE = (PyTypeObject*)PyType_FromSpecWithBases(&spec, bases); \
     if (!TYPE || PyType_Ready(TYPE) < 0) return false; \
   } while(0);
 

--- a/tools/chapel-py/src/core-types-gen.cpp
+++ b/tools/chapel-py/src/core-types-gen.cpp
@@ -133,7 +133,7 @@ struct InvokeHelper<void(Args...)> {
     if (!node) return nullptr; \
     \
     auto argList = Py_BuildValue("(O)", (PyObject*) self); \
-    auto astCallIterObjectPy = PyObject_CallObject((PyObject *) &AstCallIterType, argList); \
+    auto astCallIterObjectPy = PyObject_CallObject((PyObject *) AstCallIterType, argList); \
     Py_XDECREF(argList); \
     \
     auto astCalliterObject = (AstCallIterObject*) astCallIterObjectPy; \

--- a/tools/chapel-py/src/core-types-gen.cpp
+++ b/tools/chapel-py/src/core-types-gen.cpp
@@ -97,7 +97,9 @@ struct InvokeHelper<void(Args...)> {
   template <typename F>
   static PyObject* invoke(ContextObject* contextObject, F&& fn) {
     fn();
-    Py_RETURN_NONE;
+    // In python3.12, Py_None is immortal and this is not needed
+    Py_INCREF(Py_None);
+    return Py_None;
   }
 };
 

--- a/tools/chapel-py/src/core-types-gen.cpp
+++ b/tools/chapel-py/src/core-types-gen.cpp
@@ -176,7 +176,7 @@ ACTUAL_ITERATOR(FnCall);
       {0, nullptr} \
     }; \
     PyType_Spec spec = { \
-      /*name*/ #NAME, \
+      /*name*/ "chapel."#NAME, \
       /*basicsize*/ sizeof(NAME##Object), \
       /*itemsize*/ 0, \
       /*flags*/ FLAGS, \
@@ -185,7 +185,6 @@ ACTUAL_ITERATOR(FnCall);
     auto parentType = parentTypeFor(TAG); \
     TYPE = (PyTypeObject*)PyType_FromSpecWithBases(&spec, (PyObject*)parentType); \
     if (!TYPE || PyType_Ready(TYPE) < 0) return false; \
-    /*TODO: need to set PyDict_SetItemString(configuring->tp_dict, "__module__", "chapel"); */ \
   } while(0);
 
 bool setupGeneratedTypes() {

--- a/tools/chapel-py/src/core-types-gen.cpp
+++ b/tools/chapel-py/src/core-types-gen.cpp
@@ -45,7 +45,7 @@ using namespace uast;
  */
 #define DEFINE_INIT_FOR(NAME, TAG) \
   int NAME##Object_init(NAME##Object* self, PyObject* args, PyObject* kwargs) { \
-    return callPyTypeSlot_tp_init(NAME##Type, (PyObject*) self, args, kwargs); \
+    return callPyTypeSlot_tp_init(parentTypeFor(TAG), (PyObject*) self, args, kwargs); \
   }
 
 /* Use the X-macros pattern to invoke DEFINE_INIT_FOR for each AST node type. */
@@ -93,9 +93,7 @@ struct InvokeHelper<void(Args...)> {
   template <typename F>
   static PyObject* invoke(ContextObject* contextObject, F&& fn) {
     fn();
-    // In python3.12, Py_None is immortal and this is not needed
-    Py_INCREF(Py_None);
-    return Py_None;
+    chpl_PY_RETURN_NONE;
   }
 };
 

--- a/tools/chapel-py/src/core-types-gen.h
+++ b/tools/chapel-py/src/core-types-gen.h
@@ -47,7 +47,7 @@
     ContextObject* context() const { return (ContextObject*) parent.contextObject; } \
   }; \
   \
-  extern PyTypeObject NAME##Type;
+  extern PyTypeObject* NAME##Type;
 
 /* Generate a Python object for reach AST node type. */
 #define GENERATED_TYPE(ROOT, ROOT_TYPE, NAME, TYPE, TAG, FLAGS) DECLARE_PY_OBJECT_FOR(ROOT, NAME)
@@ -95,6 +95,6 @@ struct PerTypeMethods {
   {#NAME, NODE##Object_##NAME, METH_NOARGS, DOCSTR},
 #include "method-tables.h"
 
-void setupGeneratedTypes();
+bool setupGeneratedTypes();
 
 #endif

--- a/tools/chapel-py/src/core-types.cpp
+++ b/tools/chapel-py/src/core-types.cpp
@@ -156,7 +156,7 @@ PyObject* AstNodeObject::iter(AstNodeObject *self) {
 
 void ChapelTypeObject_dealloc(ChapelTypeObject* self) {
   Py_XDECREF(self->contextObject);
-  call_tp_free(ChapelTypeObject::PythonType, (PyObject*) self);
+  callPyTypeSlot_tp_free(ChapelTypeObject::PythonType, (PyObject*) self);
 }
 
 PyObject* ChapelTypeObject::str(ChapelTypeObject* self) {

--- a/tools/chapel-py/src/core-types.cpp
+++ b/tools/chapel-py/src/core-types.cpp
@@ -106,7 +106,7 @@ std::string generatePyiFile() {
     printedAnything = false; \
     generated.insert(NODE##Object::Name); \
     if (auto parentType = ParentTypeInfo<NODE##Object>::parentTypeObject()) { \
-      ss << "(" /*TODO:<< parentType->tp_name*/ << ")"; \
+      ss << "(" << getTypeName(parentType) << ")"; \
     } \
     ss << ":" << std::endl;
   #define METHOD(NODE, NAME, DOCSTR, TYPEFN, BODY) \
@@ -133,8 +133,7 @@ std::string generatePyiFile() {
     if(generated.find(NODE##Object::Name) == generated.end()) { \
       ss << "class " << NODE##Object::Name; \
       if (auto parentType = ParentTypeInfo<NODE##Object>::parentTypeObject()) { \
-        /*auto tp_name = PyType_GetSlot(parentTypeFor(TAG), Py_tp_name);*/ \
-        ss << "(" /*TODO<< tp_name*/ << ")"; \
+        ss << "(" << getTypeName(parentType) << ")"; \
       } \
       ss << ":" << std::endl; \
       ss << "    pass" << std::endl; \

--- a/tools/chapel-py/src/core-types.cpp
+++ b/tools/chapel-py/src/core-types.cpp
@@ -26,6 +26,7 @@
 #include "python-types.h"
 #include "error-tracker.h"
 #include "resolution.h"
+#include "python-type-helper.h"
 
 using namespace chpl;
 using namespace uast;
@@ -105,7 +106,7 @@ std::string generatePyiFile() {
     printedAnything = false; \
     generated.insert(NODE##Object::Name); \
     if (auto parentType = ParentTypeInfo<NODE##Object>::parentTypeObject()) { \
-      ss << "(" << parentType->tp_name << ")"; \
+      ss << "(" /*TODO:<< parentType->tp_name*/ << ")"; \
     } \
     ss << ":" << std::endl;
   #define METHOD(NODE, NAME, DOCSTR, TYPEFN, BODY) \
@@ -132,7 +133,8 @@ std::string generatePyiFile() {
     if(generated.find(NODE##Object::Name) == generated.end()) { \
       ss << "class " << NODE##Object::Name; \
       if (auto parentType = ParentTypeInfo<NODE##Object>::parentTypeObject()) { \
-        ss << "(" << parentTypeFor(TAG)->tp_name << ")"; \
+        /*auto tp_name = PyType_GetSlot(parentTypeFor(TAG), Py_tp_name);*/ \
+        ss << "(" /*TODO<< tp_name*/ << ")"; \
       } \
       ss << ":" << std::endl; \
       ss << "    pass" << std::endl; \
@@ -155,7 +157,7 @@ PyObject* AstNodeObject::iter(AstNodeObject *self) {
 
 void ChapelTypeObject_dealloc(ChapelTypeObject* self) {
   Py_XDECREF(self->contextObject);
-  Py_TYPE(self)->tp_free((PyObject *) self);
+  call_tp_free(ChapelTypeObject::PythonType, (PyObject*) self);
 }
 
 PyObject* ChapelTypeObject::str(ChapelTypeObject* self) {
@@ -186,14 +188,14 @@ PyTypeObject* parentTypeFor(asttags::AstTag tag) {
 #define AST_BEGIN_SUBCLASSES(NAME)
 #define AST_END_SUBCLASSES(NAME) \
   if (tag > asttags::START_##NAME && tag < asttags::END_##NAME) { \
-    return &NAME##Type; \
+    return NAME##Type; \
   }
 #include "chpl/uast/uast-classes-list.h"
 #undef AST_NODE
 #undef AST_LEAF
 #undef AST_BEGIN_SUBCLASSES
 #undef AST_END_SUBCLASSES
-  return &AstNodeObject::PythonType;
+  return AstNodeObject::PythonType;
 }
 
 PyTypeObject* parentTypeFor(types::typetags::TypeTag tag) {
@@ -202,18 +204,18 @@ PyTypeObject* parentTypeFor(types::typetags::TypeTag tag) {
 #define TYPE_BEGIN_SUBCLASSES(NAME)
 #define TYPE_END_SUBCLASSES(NAME) \
   if (tag > types::typetags::START_##NAME && tag < types::typetags::END_##NAME) { \
-    return &NAME##Type; \
+    return NAME##Type; \
   }
 #include "chpl/types/type-classes-list.h"
 #undef TYPE_NODE
 #undef BUILTIN_TYPE_NODE
 #undef TYPE_BEGIN_SUBCLASSES
 #undef TYPE_END_SUBCLASSES
-  return &ChapelTypeObject::PythonType;
+  return ChapelTypeObject::PythonType;
 }
 
 PyTypeObject* parentTypeFor(chpl::types::paramtags::ParamTag tag) {
-  return &ParamObject::PythonType;
+  return ParamObject::PythonType;
 }
 
 PyObject* wrapGeneratedType(ContextObject* context, const AstNode* node) {
@@ -226,7 +228,7 @@ PyObject* wrapGeneratedType(ContextObject* context, const AstNode* node) {
   switch (node->tag()) {
 #define CAST_TO(NAME) \
     case asttags::NAME: \
-      toReturn = PyObject_CallObject((PyObject*) &NAME##Type, args); \
+      toReturn = PyObject_CallObject((PyObject*) NAME##Type, args); \
       ((NAME##Object*) toReturn)->parent.value_ = node->to##NAME(); \
       break;
 #define AST_NODE(NAME) CAST_TO(NAME)
@@ -256,7 +258,7 @@ PyObject* wrapGeneratedType(ContextObject* context, const types::Type* node) {
   switch (node->tag()) {
 #define CAST_TO(NAME) \
     case types::typetags::NAME: \
-      toReturn = PyObject_CallObject((PyObject*) &NAME##Type, args); \
+      toReturn = PyObject_CallObject((PyObject*) NAME##Type, args); \
       ((NAME##Object*) toReturn)->parent.value_ = (const types::Type*) node->to##NAME(); \
       break;
 #define TYPE_NODE(NAME) CAST_TO(NAME)
@@ -286,7 +288,7 @@ PyObject* wrapGeneratedType(ContextObject* context, const chpl::types::Param* no
   switch (node->tag()) {
 #define PARAM_NODE(NAME, TYPE) \
     case chpl::types::paramtags::NAME: \
-      toReturn = PyObject_CallObject((PyObject*) &NAME##Type, args); \
+      toReturn = PyObject_CallObject((PyObject*) NAME##Type, args); \
       ((NAME##Object*) toReturn)->parent.value_ = node->to##NAME(); \
       break;
 #include "chpl/types/param-classes-list.h"

--- a/tools/chapel-py/src/core-types.h
+++ b/tools/chapel-py/src/core-types.h
@@ -116,13 +116,12 @@ struct LocationObject : public PythonClass<LocationObject, chpl::Location> {
   static PyTypeObject* configurePythonType() {
     // Configure the necessary methods to make inserting into sets working:
 
-    size_t numExtraSlots = 3;
-    PyType_Slot extraSlots[] = {
-      {Py_tp_str, (void*) str},
+    std::array<PyType_Slot, 3> extraSlots = {
+      PyType_Slot{Py_tp_str, (void*) str},
       {Py_nb_add, (void*) add},
       {Py_nb_subtract, (void*) subtract},
     };
-    PyTypeObject* configuring = PythonClassWithContext<LocationObject, chpl::Location>::configurePythonType(Py_TPFLAGS_DEFAULT, extraSlots, numExtraSlots);
+    PyTypeObject* configuring = PythonClassWithContext<LocationObject, chpl::Location>::configurePythonType(Py_TPFLAGS_DEFAULT, extraSlots);
     return configuring;
   }
 };
@@ -143,11 +142,10 @@ struct AstNodeObject : public PythonClassWithContext<AstNodeObject, const chpl::
   static PyObject* iter(AstNodeObject *self);
 
   static PyTypeObject* configurePythonType() {
-    size_t numExtraSlots = 1;
-    PyType_Slot extraSlots[] = {
-      {Py_tp_iter, (void*) AstNodeObject::iter},
+    std::array<PyType_Slot, 1> extraSlots = {
+      PyType_Slot{Py_tp_iter, (void*) AstNodeObject::iter},
     };
-    PyTypeObject* configuring = PythonClassWithContext<AstNodeObject, const chpl::uast::AstNode*>::configurePythonType(Py_TPFLAGS_BASETYPE, extraSlots, numExtraSlots);
+    PyTypeObject* configuring = PythonClassWithContext<AstNodeObject, const chpl::uast::AstNode*>::configurePythonType(Py_TPFLAGS_BASETYPE, extraSlots);
     return configuring;
   }
 };
@@ -162,11 +160,10 @@ struct ChapelTypeObject  : public PythonClassWithContext<ChapelTypeObject, const
   static PyObject* str(ChapelTypeObject* self);
 
   static PyTypeObject* configurePythonType() {
-    size_t numExtraSlots = 1;
-    PyType_Slot extraSlots[] = {
-      {Py_tp_str, (void*) ChapelTypeObject::str},
+    std::array<PyType_Slot, 1> extraSlots = {
+      PyType_Slot{Py_tp_str, (void*) ChapelTypeObject::str},
     };
-    PyTypeObject* configuring = PythonClassWithContext<ChapelTypeObject, const chpl::types::Type*>::configurePythonType(Py_TPFLAGS_BASETYPE, extraSlots, numExtraSlots);
+    PyTypeObject* configuring = PythonClassWithContext<ChapelTypeObject, const chpl::types::Type*>::configurePythonType(Py_TPFLAGS_BASETYPE, extraSlots);
     return configuring;
   }
 };
@@ -179,11 +176,10 @@ struct ParamObject : public PythonClassWithContext<ParamObject, const chpl::type
   static PyObject* str(ParamObject* self);
 
   static PyTypeObject* configurePythonType() {
-    size_t numExtraSlots = 1;
-    PyType_Slot extraSlots[] = {
-      {Py_tp_str, (void*) ParamObject::str},
+    std::array<PyType_Slot, 1> extraSlots = {
+      PyType_Slot{Py_tp_str, (void*) ParamObject::str},
     };
-    PyTypeObject* configuring = PythonClassWithContext<ParamObject, const chpl::types::Param*>::configurePythonType(Py_TPFLAGS_BASETYPE, extraSlots, numExtraSlots);
+    PyTypeObject* configuring = PythonClassWithContext<ParamObject, const chpl::types::Param*>::configurePythonType(Py_TPFLAGS_BASETYPE, extraSlots);
     return configuring;
   }
 };
@@ -237,12 +233,11 @@ struct TypedSignatureObject : public PythonClassWithContext<TypedSignatureObject
 
   static PyTypeObject* configurePythonType() {
     // Configure the necessary methods to make inserting into sets working:
-    size_t numExtraSlots = 2;
-    PyType_Slot extraSlots[] = {
-      {Py_tp_hash, (void*) hash},
+    std::array<PyType_Slot, 2> extraSlots = {
+      PyType_Slot{Py_tp_hash, (void*) hash},
       {Py_tp_richcompare, (void*) richcompare},
     };
-    PyTypeObject* configuring = PythonClassWithContext<TypedSignatureObject, TypedSignatureAndPoiScope>::configurePythonType(Py_TPFLAGS_DEFAULT, extraSlots, numExtraSlots);
+    PyTypeObject* configuring = PythonClassWithContext<TypedSignatureObject, TypedSignatureAndPoiScope>::configurePythonType(Py_TPFLAGS_DEFAULT, extraSlots);
     return configuring;
   }
 };

--- a/tools/chapel-py/src/core-types.h
+++ b/tools/chapel-py/src/core-types.h
@@ -20,8 +20,7 @@
 #ifndef CHAPEL_PY_CORE_TYPES_H
 #define CHAPEL_PY_CORE_TYPES_H
 
-#define PY_SSIZE_T_CLEAN
-#include "Python.h"
+#include "PythonWrapper.h"
 #include "chpl/framework/Context.h"
 #include "chpl/uast/AstTag.h"
 #include "error-tracker.h"

--- a/tools/chapel-py/src/core-types.h
+++ b/tools/chapel-py/src/core-types.h
@@ -136,8 +136,7 @@ struct ScopeObject : public PythonClassWithContext<ScopeObject, const chpl::reso
 using VisibleSymbol = std::tuple<chpl::UniqueString, std::vector<const chpl::uast::AstNode*>>;
 
 struct AstNodeObject : public PythonClassWithContext<AstNodeObject, const chpl::uast::AstNode*> {
-  static constexpr const char* QualifiedName = "AstNode";
-  // TODO: restore chapel.
+  static constexpr const char* QualifiedName = "chapel.AstNode";
   static constexpr const char* Name = "AstNode";
   static constexpr const char* DocStr = "The base type of Chapel AST nodes";
 
@@ -156,8 +155,7 @@ struct AstNodeObject : public PythonClassWithContext<AstNodeObject, const chpl::
 using QualifiedTypeTuple = std::tuple<const char*, Nilable<const chpl::types::Type*>, Nilable<const chpl::types::Param*>>;
 
 struct ChapelTypeObject  : public PythonClassWithContext<ChapelTypeObject, const chpl::types::Type*> {
-  static constexpr const char* QualifiedName = "ChapelType";
-  // TODO: restore chapel.
+  static constexpr const char* QualifiedName = "chapel.ChapelType";
   static constexpr const char* Name = "ChapelType";
   static constexpr const char* DocStr = "The base type of Chapel types";
 
@@ -174,8 +172,7 @@ struct ChapelTypeObject  : public PythonClassWithContext<ChapelTypeObject, const
 };
 
 struct ParamObject : public PythonClassWithContext<ParamObject, const chpl::types::Param*> {
-  static constexpr const char* QualifiedName = "Param";
-    // TODO: restore chapel.
+  static constexpr const char* QualifiedName = "chapel.Param";
   static constexpr const char* Name = "Param";
   static constexpr const char* DocStr = "The base type of Chapel parameters (compile-time known values)";
 

--- a/tools/chapel-py/src/error-tracker.h
+++ b/tools/chapel-py/src/error-tracker.h
@@ -20,7 +20,7 @@
 #ifndef CHAPEL_PY_ERROR_TRACKER_H
 #define CHAPEL_PY_ERROR_TRACKER_H
 
-#include "Python.h"
+#include "PythonWrapper.h"
 #include "chpl/framework/Context.h"
 #include "chpl/framework/ErrorBase.h"
 #include "python-class.h"

--- a/tools/chapel-py/src/iterator-support.cpp
+++ b/tools/chapel-py/src/iterator-support.cpp
@@ -34,7 +34,7 @@ bool setupAstIterType() {
       {0, nullptr}
     };
     PyType_Spec spec = {
-      /*name*/ "AstIter",
+      /*name*/ "chapel.AstIter",
       /*basicsize*/ sizeof(AstIterObject),
       /*itemsize*/ 0,
       /*flags*/ Py_TPFLAGS_DEFAULT,
@@ -42,7 +42,6 @@ bool setupAstIterType() {
     };
     AstIterType = (PyTypeObject*)PyType_FromSpec(&spec);
     if (!AstIterType || PyType_Ready(AstIterType) < 0) return false;
-    // TODO: set module name
     return true;
 }
 
@@ -94,7 +93,7 @@ bool setupAstCallIterType() {
     {0, nullptr}
   };
   PyType_Spec spec = {
-    /*name*/ "AstCallIter",
+    /*name*/ "chapel.AstCallIter",
     /*basicsize*/ sizeof(AstCallIterObject),
     /*itemsize*/ 0,
     /*flags*/ Py_TPFLAGS_DEFAULT,
@@ -102,7 +101,6 @@ bool setupAstCallIterType() {
   };
   AstCallIterType = (PyTypeObject*)PyType_FromSpec(&spec);
   if (!AstCallIterType || PyType_Ready(AstCallIterType) < 0) return false;
-  // TODO: set module name
   return true;
 }
 

--- a/tools/chapel-py/src/iterator-support.cpp
+++ b/tools/chapel-py/src/iterator-support.cpp
@@ -19,22 +19,31 @@
 
 #include "iterator-support.h"
 #include "core-types-gen.h"
+#include "python-type-helper.h"
 
-PyTypeObject AstIterType = {
-  PyVarObject_HEAD_INIT(NULL, 0)
-};
+PyTypeObject* AstIterType = NULL;
 
-void setupAstIterType() {
-  AstIterType.tp_name = "chapel.AstIter";
-  AstIterType.tp_basicsize = sizeof(AstIterObject);
-  AstIterType.tp_itemsize = 0;
-  AstIterType.tp_dealloc = (destructor) AstIterObject_dealloc;
-  AstIterType.tp_flags = Py_TPFLAGS_DEFAULT;
-  AstIterType.tp_doc = PyDoc_STR("An iterator over Chapel AST nodes");
-  AstIterType.tp_iter = (getiterfunc) AstIterObject_iter;
-  AstIterType.tp_iternext = (iternextfunc) AstIterObject_next;
-  AstIterType.tp_init = (initproc) AstIterObject_init;
-  AstIterType.tp_new = PyType_GenericNew;
+bool setupAstIterType() {
+  PyType_Slot slots[] = {
+      {Py_tp_dealloc, (void*) AstIterObject_dealloc},
+      {Py_tp_doc, (void*) PyDoc_STR("An iterator over Chapel AST nodes")},
+      {Py_tp_iter, (void*) AstIterObject_iter},
+      {Py_tp_iternext, (void*) AstIterObject_next},
+      {Py_tp_init, (void*) AstIterObject_init},
+      {Py_tp_new, (void*) PyType_GenericNew},
+      {0, nullptr}
+    };
+    PyType_Spec spec = {
+      /*name*/ "AstIter",
+      /*basicsize*/ sizeof(AstIterObject),
+      /*itemsize*/ 0,
+      /*flags*/ Py_TPFLAGS_DEFAULT,
+      /*slots*/ slots
+    };
+    AstIterType = (PyTypeObject*)PyType_FromSpec(&spec);
+    if (!AstIterType || PyType_Ready(AstIterType) < 0) return false;
+    // TODO: set module name
+    return true;
 }
 
 int AstIterObject_init(AstIterObject* self, PyObject* args, PyObject* kwargs) {
@@ -54,7 +63,7 @@ int AstIterObject_init(AstIterObject* self, PyObject* args, PyObject* kwargs) {
 void AstIterObject_dealloc(AstIterObject* self) {
   delete self->iterAdapter;
   Py_XDECREF(self->contextObject);
-  Py_TYPE(self)->tp_free((PyObject *) self);
+  call_tp_free(AstIterType, (PyObject*) self);
 }
 
 PyObject* AstIterObject_iter(AstIterObject *self) {
@@ -72,21 +81,29 @@ PyObject* AstIterObject_next(AstIterObject *self) {
   return nullptr;
 }
 
-PyTypeObject AstCallIterType = {
-  PyVarObject_HEAD_INIT(NULL, 0)
-};
+PyTypeObject* AstCallIterType = NULL;
 
-void setupAstCallIterType() {
-  AstCallIterType.tp_name = "chapel.AstCallIter";
-  AstCallIterType.tp_basicsize = sizeof(AstCallIterObject);
-  AstCallIterType.tp_itemsize = 0;
-  AstCallIterType.tp_dealloc = (destructor) AstCallIterObject_dealloc;
-  AstCallIterType.tp_flags = Py_TPFLAGS_DEFAULT;
-  AstCallIterType.tp_doc = PyDoc_STR("An iterator over Chapel function call actuals");
-  AstCallIterType.tp_iter = (getiterfunc) AstCallIterObject_iter;
-  AstCallIterType.tp_iternext = (iternextfunc) AstCallIterObject_next;
-  AstCallIterType.tp_init = (initproc) AstCallIterObject_init;
-  AstCallIterType.tp_new = PyType_GenericNew;
+bool setupAstCallIterType() {
+  PyType_Slot slots[] = {
+    {Py_tp_dealloc, (void*) AstCallIterObject_dealloc},
+    {Py_tp_doc, (void*) PyDoc_STR("An iterator over Chapel function call actuals")},
+    {Py_tp_iter, (void*) AstCallIterObject_iter},
+    {Py_tp_iternext, (void*) AstCallIterObject_next},
+    {Py_tp_init, (void*) AstCallIterObject_init},
+    {Py_tp_new, (void*) PyType_GenericNew},
+    {0, nullptr}
+  };
+  PyType_Spec spec = {
+    /*name*/ "AstCallIter",
+    /*basicsize*/ sizeof(AstCallIterObject),
+    /*itemsize*/ 0,
+    /*flags*/ Py_TPFLAGS_DEFAULT,
+    /*slots*/ slots
+  };
+  AstIterType = (PyTypeObject*)PyType_FromSpec(&spec);
+  if (!AstIterType || PyType_Ready(AstIterType) < 0) return false;
+  // TODO: set module name
+  return true;
 }
 
 int AstCallIterObject_init(AstCallIterObject* self, PyObject* args, PyObject* kwargs) {
@@ -103,7 +120,7 @@ int AstCallIterObject_init(AstCallIterObject* self, PyObject* args, PyObject* kw
 
 void AstCallIterObject_dealloc(AstCallIterObject* self) {
   Py_XDECREF(self->contextObject);
-  Py_TYPE(self)->tp_free((PyObject *) self);
+  call_tp_free(AstCallIterType, (PyObject*) self);
 }
 
 PyObject* AstCallIterObject_iter(AstCallIterObject *self) {

--- a/tools/chapel-py/src/iterator-support.cpp
+++ b/tools/chapel-py/src/iterator-support.cpp
@@ -62,7 +62,7 @@ int AstIterObject_init(AstIterObject* self, PyObject* args, PyObject* kwargs) {
 void AstIterObject_dealloc(AstIterObject* self) {
   delete self->iterAdapter;
   Py_XDECREF(self->contextObject);
-  call_tp_free(AstIterType, (PyObject*) self);
+  callPyTypeSlot_tp_free(AstIterType, (PyObject*) self);
 }
 
 PyObject* AstIterObject_iter(AstIterObject *self) {
@@ -118,7 +118,7 @@ int AstCallIterObject_init(AstCallIterObject* self, PyObject* args, PyObject* kw
 
 void AstCallIterObject_dealloc(AstCallIterObject* self) {
   Py_XDECREF(self->contextObject);
-  call_tp_free(AstCallIterType, (PyObject*) self);
+  callPyTypeSlot_tp_free(AstCallIterType, (PyObject*) self);
 }
 
 PyObject* AstCallIterObject_iter(AstCallIterObject *self) {

--- a/tools/chapel-py/src/iterator-support.cpp
+++ b/tools/chapel-py/src/iterator-support.cpp
@@ -100,8 +100,8 @@ bool setupAstCallIterType() {
     /*flags*/ Py_TPFLAGS_DEFAULT,
     /*slots*/ slots
   };
-  AstIterType = (PyTypeObject*)PyType_FromSpec(&spec);
-  if (!AstIterType || PyType_Ready(AstIterType) < 0) return false;
+  AstCallIterType = (PyTypeObject*)PyType_FromSpec(&spec);
+  if (!AstCallIterType || PyType_Ready(AstCallIterType) < 0) return false;
   // TODO: set module name
   return true;
 }
@@ -149,7 +149,7 @@ PyObject* AstCallIterObject_next(AstCallIterObject *self) {
 
 PyObject* wrapIterAdapter(ContextObject* context, IterAdapterBase* iterAdapter) {
   auto argList = Py_BuildValue("(O)", (PyObject*) context);
-  auto astIterObjectPy = PyObject_CallObject((PyObject *) &AstIterType, argList);
+  auto astIterObjectPy = PyObject_CallObject((PyObject *) AstIterType, argList);
   auto astIterObject = (AstIterObject*) astIterObjectPy;
 
   astIterObject->iterAdapter = iterAdapter;

--- a/tools/chapel-py/src/iterator-support.h
+++ b/tools/chapel-py/src/iterator-support.h
@@ -66,9 +66,9 @@ struct AstIterObject {
   IterAdapterBase* iterAdapter;
   PyObject* contextObject;
 };
-extern PyTypeObject AstIterType;
+extern PyTypeObject* AstIterType;
 
-void setupAstIterType();
+bool setupAstIterType();
 
 int AstIterObject_init(AstIterObject* self, PyObject* args, PyObject* kwargs);
 void AstIterObject_dealloc(AstIterObject* self);
@@ -84,9 +84,9 @@ struct AstCallIterObject {
   const chpl::uast::AstNode* (*childGetter)(const void*, int);
   PyObject* contextObject;
 };
-extern PyTypeObject AstCallIterType;
+extern PyTypeObject* AstCallIterType;
 
-void setupAstCallIterType();
+bool setupAstCallIterType();
 
 int AstCallIterObject_init(AstCallIterObject* self, PyObject* args, PyObject* kwargs);
 void AstCallIterObject_dealloc(AstCallIterObject* self);

--- a/tools/chapel-py/src/iterator-support.h
+++ b/tools/chapel-py/src/iterator-support.h
@@ -20,8 +20,7 @@
 #ifndef CHAPEL_PY_ITERATOR_SUPPORT_H
 #define CHAPEL_PY_ITERATOR_SUPPORT_H
 
-#define PY_SSIZE_T_CLEAN
-#include "Python.h"
+#include "PythonWrapper.h"
 #include "chpl/framework/Context.h"
 #include "core-types.h"
 

--- a/tools/chapel-py/src/python-class.h
+++ b/tools/chapel-py/src/python-class.h
@@ -19,7 +19,8 @@
 
 #ifndef CHAPEL_PY_PYTHON_CLASS_H
 #define CHAPEL_PY_PYTHON_CLASS_H
-#include "Python.h"
+
+#include "PythonWrapper.h"
 #include "chpl/framework/Context.h"
 #include <optional>
 

--- a/tools/chapel-py/src/python-class.h
+++ b/tools/chapel-py/src/python-class.h
@@ -176,8 +176,7 @@ PyTypeObject* PythonClass<Self,T>::PythonType = Self::configurePythonType();
 // Forward-declaring doesn't cut it because we need ContextObject::PythonType.
 
 struct ContextObject : public PythonClass<ContextObject, chpl::Context> {
-  static constexpr const char* QualifiedName = "Context";
-  // TODI: restore chapel.
+  static constexpr const char* QualifiedName = "chapel.Context";
   static constexpr const char* Name = "Context";
   static constexpr const char* DocStr = "The Chapel context object that tracks various frontend state";
 

--- a/tools/chapel-py/src/python-class.h
+++ b/tools/chapel-py/src/python-class.h
@@ -23,6 +23,7 @@
 #include "PythonWrapper.h"
 #include "chpl/framework/Context.h"
 #include <optional>
+#include <array>
 #include "python-type-helper.h"
 
 template <typename ObjectType>
@@ -103,12 +104,12 @@ struct PythonClass {
     return 0;
   }
 
+  template <size_t SIZE = 0>
   static PyTypeObject* configurePythonType(unsigned int flags = Py_TPFLAGS_DEFAULT,
-                                           PyType_Slot* extraSlots = nullptr,
-                                           size_t numExtraSlot = 0) {
+                                           std::array<PyType_Slot, SIZE> extraSlots = {}) {
 
     auto numBaseSlots = 5;
-    auto numSlots = numBaseSlots + numExtraSlot;
+    auto numSlots = numBaseSlots + SIZE;
 
     auto slots = std::unique_ptr<PyType_Slot[]>(new PyType_Slot[numSlots+1]);
     slots[numSlots] = {0, nullptr};
@@ -117,7 +118,7 @@ struct PythonClass {
     slots[2] = {Py_tp_methods, (void*) PerTypeMethods<Self>::methods};
     slots[3] = {Py_tp_init, (void*) Self::init};
     slots[4] = {Py_tp_new, (void*) PyType_GenericNew};
-    for (size_t i = 0; i < numExtraSlot; i++) {
+    for (size_t i = 0; i < SIZE; i++) {
       slots[numBaseSlots + i] = extraSlots[i];
     }
 

--- a/tools/chapel-py/src/python-class.h
+++ b/tools/chapel-py/src/python-class.h
@@ -95,7 +95,7 @@ struct PythonClass {
 
   static void dealloc(Self* self) {
     ((PythonClass*) self)->value_.~T();
-    call_tp_free(Self::PythonType, (PyObject*) self);
+    callPyTypeSlot_tp_free(Self::PythonType, (PyObject*) self);
   }
 
   static int init(Self* self, PyObject* args, PyObject* kwargs) {

--- a/tools/chapel-py/src/python-type-helper.h
+++ b/tools/chapel-py/src/python-type-helper.h
@@ -1,0 +1,16 @@
+
+#ifndef CHAPEL_PY_PYTHON_TYPE_HELPER_H
+#define CHAPEL_PY_PYTHON_TYPE_HELPER_H
+
+#include "PythonWrapper.h"
+
+static void call_tp_free(PyTypeObject* type, PyObject* self) {
+  auto tp_free = (void (*)(PyObject*))(PyType_GetSlot(type, Py_tp_free));
+  if (!tp_free) {
+    PyErr_SetString(PyExc_RuntimeError, "Could not free object");
+  } else {
+    tp_free(self);
+  }
+}
+
+#endif

--- a/tools/chapel-py/src/python-type-helper.h
+++ b/tools/chapel-py/src/python-type-helper.h
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2023-2025 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #ifndef CHAPEL_PY_PYTHON_TYPE_HELPER_H
 #define CHAPEL_PY_PYTHON_TYPE_HELPER_H

--- a/tools/chapel-py/src/python-type-helper.h
+++ b/tools/chapel-py/src/python-type-helper.h
@@ -31,4 +31,15 @@ static void call_tp_free(PyTypeObject* type, PyObject* self) {
   }
 }
 
+static const char* getTypeName(PyTypeObject* obj) {
+  PyObject* name_attr = PyObject_GetAttrString((PyObject*) obj, "__name__");
+  if (!name_attr) {
+    PyErr_SetString(PyExc_RuntimeError, "Could not get type name");
+    return nullptr;
+  }
+  const char* name = PyUnicode_AsUTF8AndSize(name_attr, NULL);
+  Py_XDECREF(name_attr);
+  return name;
+}
+
 #endif

--- a/tools/chapel-py/src/python-type-helper.h
+++ b/tools/chapel-py/src/python-type-helper.h
@@ -22,7 +22,7 @@
 
 #include "PythonWrapper.h"
 
-static void callPyTypeSlot_tp_free(PyTypeObject* type, PyObject* self) {
+static inline void callPyTypeSlot_tp_free(PyTypeObject* type, PyObject* self) {
   auto tp_free = (freefunc)PyType_GetSlot(type, Py_tp_free);
   if (!tp_free) {
     PyErr_SetString(PyExc_RuntimeError, "Could not free object");
@@ -30,7 +30,7 @@ static void callPyTypeSlot_tp_free(PyTypeObject* type, PyObject* self) {
   }
   tp_free(self);
 }
-static int callPyTypeSlot_tp_init(PyTypeObject* type, PyObject* self, PyObject* args, PyObject* kwargs) {
+static inline int callPyTypeSlot_tp_init(PyTypeObject* type, PyObject* self, PyObject* args, PyObject* kwargs) {
   auto func = (initproc)PyType_GetSlot(type, Py_tp_init);
   if (!func) {
     PyErr_SetString(PyExc_TypeError, "Cannot initialize object");
@@ -40,7 +40,7 @@ static int callPyTypeSlot_tp_init(PyTypeObject* type, PyObject* self, PyObject* 
 }
 
 
-static const char* getCStringFromPyObjString(PyObject* obj) {
+static inline const char* getCStringFromPyObjString(PyObject* obj) {
   const char* str;
   if (!PyArg_Parse(obj, "s", &str)) {
     PyErr_SetString(PyExc_RuntimeError, "Could not get string from object");

--- a/tools/chapel-py/src/python-types.h
+++ b/tools/chapel-py/src/python-types.h
@@ -26,6 +26,7 @@
 #include <vector>
 #include <set>
 #include <tuple>
+#include "python-type-helper.h"
 
 /* The general idea here is the following: we want to add an allowlist
    of C++ types that have defined conversions to and from Python types.
@@ -135,9 +136,7 @@ PyObject* wrapOptional(ContextObject* context, const std::optional<T>& opt) {
   if (opt) {
     return PythonReturnTypeInfo<T>::wrap(context, *opt);
   } else {
-    // In python3.12, Py_None is immortal and this is not needed
-    Py_INCREF(Py_None);
-    return Py_None;
+    chpl_PY_RETURN_NONE;
   }
 }
 
@@ -213,9 +212,7 @@ PyObject* wrapNilable(ContextObject* context, const Nilable<T>& opt) {
   if (opt.value) {
     return PythonReturnTypeInfo<T>::wrap(context, opt.value);
   } else {
-    // In python3.12, Py_None is immortal and this is not needed
-    Py_INCREF(Py_None);
-    return Py_None;
+    chpl_PY_RETURN_NONE;
   }
 }
 
@@ -241,9 +238,9 @@ std::string nilableTypeString() {
 
 DEFINE_INOUT_TYPE(bool, "bool", PyBool_FromLong(TO_WRAP), PyLong_AsLong(TO_UNWRAP));
 DEFINE_INOUT_TYPE(int, "int", Py_BuildValue("i", TO_WRAP), PyLong_AsLong(TO_UNWRAP));
-DEFINE_INOUT_TYPE(const char*, "str", Py_BuildValue("s", TO_WRAP), PyUnicode_AsUTF8AndSize(TO_UNWRAP, NULL));
-DEFINE_INOUT_TYPE(chpl::UniqueString, "str", Py_BuildValue("s", TO_WRAP.c_str()), chpl::UniqueString::get(&CONTEXT->value_, PyUnicode_AsUTF8AndSize(TO_UNWRAP, NULL)));
-DEFINE_INOUT_TYPE(std::string, "str", Py_BuildValue("s", TO_WRAP.c_str()), std::string(PyUnicode_AsUTF8AndSize(TO_UNWRAP, NULL)));
+DEFINE_INOUT_TYPE(const char*, "str", Py_BuildValue("s", TO_WRAP), getCStringFromPyObjString(TO_UNWRAP));
+DEFINE_INOUT_TYPE(chpl::UniqueString, "str", Py_BuildValue("s", TO_WRAP.c_str()), chpl::UniqueString::get(&CONTEXT->value_, getCStringFromPyObjString(TO_UNWRAP)));
+DEFINE_INOUT_TYPE(std::string, "str", Py_BuildValue("s", TO_WRAP.c_str()), std::string(getCStringFromPyObjString(TO_UNWRAP)));
 DEFINE_INOUT_TYPE(const chpl::uast::AstNode*, "AstNode", wrapGeneratedType(CONTEXT, TO_WRAP), ((AstNodeObject*) TO_UNWRAP)->value_);
 DEFINE_INOUT_TYPE(const chpl::types::Type*, "ChapelType", wrapGeneratedType(CONTEXT, TO_WRAP), ((ChapelTypeObject*) TO_UNWRAP)->value_);
 DEFINE_INOUT_TYPE(const chpl::types::Param*, "Param", wrapGeneratedType(CONTEXT, TO_WRAP), ((ParamObject*) TO_UNWRAP)->value_);

--- a/tools/chapel-py/src/python-types.h
+++ b/tools/chapel-py/src/python-types.h
@@ -237,9 +237,9 @@ std::string nilableTypeString() {
 
 DEFINE_INOUT_TYPE(bool, "bool", PyBool_FromLong(TO_WRAP), PyLong_AsLong(TO_UNWRAP));
 DEFINE_INOUT_TYPE(int, "int", Py_BuildValue("i", TO_WRAP), PyLong_AsLong(TO_UNWRAP));
-DEFINE_INOUT_TYPE(const char*, "str", Py_BuildValue("s", TO_WRAP), PyUnicode_AsUTF8(TO_UNWRAP));
-DEFINE_INOUT_TYPE(chpl::UniqueString, "str", Py_BuildValue("s", TO_WRAP.c_str()), chpl::UniqueString::get(&CONTEXT->value_, PyUnicode_AsUTF8(TO_UNWRAP)));
-DEFINE_INOUT_TYPE(std::string, "str", Py_BuildValue("s", TO_WRAP.c_str()), std::string(PyUnicode_AsUTF8(TO_UNWRAP)));
+DEFINE_INOUT_TYPE(const char*, "str", Py_BuildValue("s", TO_WRAP), PyUnicode_AsUTF8AndSize(TO_UNWRAP, NULL));
+DEFINE_INOUT_TYPE(chpl::UniqueString, "str", Py_BuildValue("s", TO_WRAP.c_str()), chpl::UniqueString::get(&CONTEXT->value_, PyUnicode_AsUTF8AndSize(TO_UNWRAP, NULL)));
+DEFINE_INOUT_TYPE(std::string, "str", Py_BuildValue("s", TO_WRAP.c_str()), std::string(PyUnicode_AsUTF8AndSize(TO_UNWRAP, NULL)));
 DEFINE_INOUT_TYPE(const chpl::uast::AstNode*, "AstNode", wrapGeneratedType(CONTEXT, TO_WRAP), ((AstNodeObject*) TO_UNWRAP)->value_);
 DEFINE_INOUT_TYPE(const chpl::types::Type*, "ChapelType", wrapGeneratedType(CONTEXT, TO_WRAP), ((ChapelTypeObject*) TO_UNWRAP)->value_);
 DEFINE_INOUT_TYPE(const chpl::types::Param*, "Param", wrapGeneratedType(CONTEXT, TO_WRAP), ((ParamObject*) TO_UNWRAP)->value_);

--- a/tools/chapel-py/src/python-types.h
+++ b/tools/chapel-py/src/python-types.h
@@ -135,7 +135,9 @@ PyObject* wrapOptional(ContextObject* context, const std::optional<T>& opt) {
   if (opt) {
     return PythonReturnTypeInfo<T>::wrap(context, *opt);
   } else {
-    Py_RETURN_NONE;
+    // In python3.12, Py_None is immortal and this is not needed
+    Py_INCREF(Py_None);
+    return Py_None;
   }
 }
 
@@ -211,7 +213,9 @@ PyObject* wrapNilable(ContextObject* context, const Nilable<T>& opt) {
   if (opt.value) {
     return PythonReturnTypeInfo<T>::wrap(context, opt.value);
   } else {
-    Py_RETURN_NONE;
+    // In python3.12, Py_None is immortal and this is not needed
+    Py_INCREF(Py_None);
+    return Py_None;
   }
 }
 

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -1890,8 +1890,8 @@ class ChapelLanguageServer(LanguageServer):
             item.data is None
             or not isinstance(item.data, list)
             or not isinstance(item.data[0], str)
-            or not isinstance(item.data[1], Optional[str])
-            or not isinstance(item.data[2], Optional[str])
+            or not isinstance(item.data[1], (str, None))
+            or not isinstance(item.data[2], (str, None))
         ):
             self.show_message(
                 "Call hierarchy item contains missing or invalid additional data",

--- a/util/chplenv/chpl_home_utils.py
+++ b/util/chplenv/chpl_home_utils.py
@@ -159,13 +159,7 @@ def get_chpldeps(chapel_py=False):
     if not chapel_py:
         chpl_venv = os.path.join(base, "chpldeps")
     else:
-        # for 3.10+, we can use chpl-frontend-py-deps
-        # for other versions, we have to use chpl-frontend-py-deps-pyX.Y
-        name = "chpl-frontend-py-deps"
-        minor_version = sys.version_info.minor
-        if minor_version < 10:
-            name += "-py" + str(minor_version)
-        chpl_venv = os.path.join(base, name)
+        chpl_venv = os.path.join(base, "chpl-frontend-py-deps")
     return chpl_venv
 
 @memoize

--- a/util/chplenv/chpl_home_utils.py
+++ b/util/chplenv/chpl_home_utils.py
@@ -154,12 +154,18 @@ def add_vars_to_paths(s):
 # Get the chpl-venv install directory:
 # $CHPL_HOME/third-party/chpl-venv/install/chpldeps
 @memoize
-def get_chpldeps(version=None):
+def get_chpldeps(chapel_py=False):
     base = os.path.join(get_chpl_third_party(), "chpl-venv", "install")
-    if version is None:
+    if not chapel_py:
         chpl_venv = os.path.join(base, "chpldeps")
     else:
-        chpl_venv = os.path.join(base, "chpl-frontend-py-deps-py" + str(version))
+        # for 3.10+, we can use chpl-frontend-py-deps
+        # for other versions, we have to use chpl-frontend-py-deps-pyX.Y
+        name = "chpl-frontend-py-deps"
+        minor_version = sys.version_info.minor
+        if minor_version < 10:
+            name += "-py" + str(minor_version)
+        chpl_venv = os.path.join(base, name)
     return chpl_venv
 
 @memoize
@@ -180,12 +186,10 @@ def _main():
     parser.add_option('--chpldeps', action='store_const',
                       dest='func', const=get_chpldeps)
     parser.add_option(
-        "--chpldeps-version",
+        "--chpldeps-chapel-py",
         action="store_const",
         dest="func",
-        const=lambda: get_chpldeps(
-            str(sys.version_info.major) + str(sys.version_info.minor)
-        ),
+        const=lambda: get_chpldeps(True),
     )
     parser.add_option('--using-module', action='store_const',
                       dest='func', const=using_chapel_module)

--- a/util/config/run-in-venv-with-python-bindings.bash
+++ b/util/config/run-in-venv-with-python-bindings.bash
@@ -10,7 +10,7 @@ PLATFORM=$("$CHPL_HOME/util/printchplenv" --value --only CHPL_HOST_PLATFORM)
 # Perform checks and set up environment variables for virtual env.
 source $CWD/run-in-venv-common.bash
 
-chpl_frontend_py_deps=$("$python" "$CHPL_HOME/util/chplenv/chpl_home_utils.py" --chpldeps-version)
+chpl_frontend_py_deps=$("$python" "$CHPL_HOME/util/chplenv/chpl_home_utils.py" --chpldeps)
 export PYTHONPATH="$chpl_frontend_py_deps":$PYTHONPATH
 
 if [ ! -d "$chpl_frontend_py_deps/chapel" ]; then

--- a/util/config/run-in-venv-with-python-bindings.bash
+++ b/util/config/run-in-venv-with-python-bindings.bash
@@ -16,12 +16,6 @@ export PYTHONPATH="$chpl_frontend_py_deps":$PYTHONPATH
 if [ ! -d "$chpl_frontend_py_deps/chapel" ]; then
   python_version=$("$python" -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')
   echo "chapel python bindings are not built for python ${python_version}" 1>&2
-  # if there is a versioned directory, the user may have built chapel with a different python version
-  ls -d "$chpl_frontend_py_deps-py*/chapel" >/dev/null 2>&1
-  exit_code=$?
-  if [[ $exit_code -ne 0 ]]; then
-    echo "make sure your current python version matches the one used to build chapel" 1>&2
-  fi
   exit 1
 fi
 

--- a/util/config/run-in-venv-with-python-bindings.bash
+++ b/util/config/run-in-venv-with-python-bindings.bash
@@ -16,8 +16,10 @@ export PYTHONPATH="$chpl_frontend_py_deps":$PYTHONPATH
 if [ ! -d "$chpl_frontend_py_deps/chapel" ]; then
   python_version=$("$python" -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')
   echo "chapel python bindings are not built for python ${python_version}" 1>&2
-  # if chpl_frontend_py_deps does not end with 'deps', tell user to match python version
-  if [[ "$chpl_frontend_py_deps" != *deps ]]; then
+  # if there is a versioned directory, the user may have built chapel with a different python version
+  ls -d "$chpl_frontend_py_deps-py*/chapel" >/dev/null 2>&1
+  exit_code=$?
+  if [[ $exit_code -ne 0 ]]; then
     echo "make sure your current python version matches the one used to build chapel" 1>&2
   fi
   exit 1

--- a/util/config/run-in-venv-with-python-bindings.bash
+++ b/util/config/run-in-venv-with-python-bindings.bash
@@ -10,13 +10,16 @@ PLATFORM=$("$CHPL_HOME/util/printchplenv" --value --only CHPL_HOST_PLATFORM)
 # Perform checks and set up environment variables for virtual env.
 source $CWD/run-in-venv-common.bash
 
-chpl_frontend_py_deps=$("$python" "$CHPL_HOME/util/chplenv/chpl_home_utils.py" --chpldeps)
+chpl_frontend_py_deps=$("$python" "$CHPL_HOME/util/chplenv/chpl_home_utils.py" --chpldeps-chapel-py)
 export PYTHONPATH="$chpl_frontend_py_deps":$PYTHONPATH
 
 if [ ! -d "$chpl_frontend_py_deps/chapel" ]; then
   python_version=$("$python" -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')
   echo "chapel python bindings are not built for python ${python_version}" 1>&2
-  echo "make sure your current python version matches the one used to build chapel" 1>&2
+  # if chpl_frontend_py_deps does not end with 'deps', tell user to match python version
+  if [[ "$chpl_frontend_py_deps" != *deps ]]; then
+    echo "make sure your current python version matches the one used to build chapel" 1>&2
+  fi
   exit 1
 fi
 


### PR DESCRIPTION
Refactors chapel-py to only use the C Python Stable API when possible. This means that chapel-py will no longer be constrained to run with the Python version it was built with. This allows users more flexibility in how they use chapel-py.

Testing:
- Building with Python 3.13
  - [x] run `start_test test/chplcheck` and `make test-cls` with Python 3.13
  - [x] run `start_test test/chplcheck` and `make test-cls` with Python 3.12
  - [x] run `start_test test/chplcheck` and `make test-cls` with Python 3.11
  - [x] run `start_test test/chplcheck` and `make test-cls` with Python 3.10
  - [x] run `start_test test/chplcheck` and `make test-cls` with Python 3.9
- Building with Python 3.10
  - [x] run `start_test test/chplcheck` and `make test-cls` with Python 3.13
  - [x] run `start_test test/chplcheck` and `make test-cls` with Python 3.12
  - [x] run `start_test test/chplcheck` and `make test-cls` with Python 3.11
  - [x] run `start_test test/chplcheck` and `make test-cls` with Python 3.10
  - [x] run `start_test test/chplcheck` and `make test-cls` with Python 3.9


Performance Impact

|       | main | this PR |
|---|---|---|
| `chplcheck` | 1.7s | 1.7s |
| `chplcheck modules/standard/IO.chpl` | 4.9s | 4.8s |
| `chplcheck modules/standard/Sort.chpl` | 2.9s | 3.2s |


[Reviewed by @DanilaFe]