### PR TITLE
`c_string` removal fixes

### DIFF
--- a/test/compflags/bradc/minimalModules/SKIPIF
+++ b/test/compflags/bradc/minimalModules/SKIPIF
@@ -4,3 +4,4 @@ CHPL_COMM != none
 COMPOPTS <= --no-local
 CHPL_LOCALE_MODEL != flat
 EXECOPTS <= memLeaks
+CHPL_LLVM == none

--- a/test/types/coerce/ferguson/coercion-dispatch-minimal-modules.skipif
+++ b/test/types/coerce/ferguson/coercion-dispatch-minimal-modules.skipif
@@ -4,3 +4,4 @@ CHPL_COMM != none
 COMPOPTS <= --no-local
 CHPL_LOCALE_MODEL != flat
 EXECOPTS <= memLeaks
+CHPL_LLVM == none

--- a/tools/chpl-language-server/src/symbol_signature.py
+++ b/tools/chpl-language-server/src/symbol_signature.py
@@ -183,8 +183,6 @@ def _node_to_string(node: chapel.AstNode, sep="") -> List[Component]:
         return [_wrap_str(node.text())]
     elif isinstance(node, chapel.StringLiteral):
         return [_wrap_str('"' + node.value() + '"')]
-    elif isinstance(node, chapel.CStringLiteral):
-        return [_wrap_str('c"' + node.value() + '"')]
     elif isinstance(node, chapel.FnCall):
         return _fncall_to_string(node)
     elif isinstance(node, chapel.OpCall):


### PR DESCRIPTION
These have been causing nightly failures in some corner cases. I had to use `extern` blocks to use strings with minimal modules (which requires LLVM), and I neglected `CStringLiteral` in CLS because it didn't show up as a (C++) use of the now-removed AST node.

Reviewed by @jabraham17 -- thanks!

## Testing
- [x] `make test-cls`
- [x] the tests are now skipped under LLVM=none