### PR TITLE
remove inreplace line for python3 in chpl-venv makefile

### DIFF
--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -30,7 +30,6 @@ class Chapel < Formula
     # It should be noted that this will expand to: 'for cmd in python3.13 python3 python python2; do'
     # in our find-python.sh script.
     inreplace "util/config/find-python.sh", /^(for cmd in )(python3 )/, "\\1#{python} \\2"
-    inreplace "third-party/chpl-venv/Makefile", "python3 -c ", "#{python} -c "
 
     # a lot of scripts have a python3 or python shebang, which does not point to python3.12 anymore
     Pathname.glob("**/*.py") do |pyfile|


### PR DESCRIPTION
This adjusts the chapel homebrew formula used to build main in response to changes in https://github.com/chapel-lang/chapel/pull/26514 that removed the exact string `inreplace` was searching for.

Fixes failing homebrew tests.

TESTING:

- [x] Homebrew rebuilds locally