### PR TITLE
Skip csh test if csh is missing

### DIFF
--- a/test/setchplenv/verify_setchplenv_scripts.py
+++ b/test/setchplenv/verify_setchplenv_scripts.py
@@ -171,6 +171,8 @@ class SetChplEnvTests(unittest.TestCase):
         """Verify bash versions of setchplenv.* work as expected."""
         self.check_scripts('bash', 'source', ':')
 
+    @_skip_if(shutil.which('csh') is None,
+              'csh is not installed on system.')
     def test_setchplenv__csh(self):
         """Verify csh versions of setchplenv.* work as expected."""
         self.check_scripts('csh', 'source', ':', post_source_cmd='rehash', shell_cmd='tcsh')


### PR DESCRIPTION
Adjust test script to skip testing csh if csh is not installed

[Not reviewed - trivial]