### PR TITLE
Minimal modules: generate minimal CTypes

### DIFF
--- a/modules/Makefile
+++ b/modules/Makefile
@@ -36,8 +36,10 @@ CHPL_MAKE_HOST_TARGET = --target
 include $(CHPL_MAKE_HOME)/make/Makefile.base
 
 SYS_MODULES_DIR=standard/gen/$(CHPL_MAKE_SYS_MODULES_SUBDIR)
+SYS_MODULES_DIR_MINIMAL=minimal/standard/gen/$(CHPL_MAKE_SYS_MODULES_SUBDIR)
 SYS_CTYPES_MODULE_DOC=standard/ChapelSysCTypes.chpl
 SYS_CTYPES_MODULE=$(SYS_MODULES_DIR)/ChapelSysCTypes.chpl
+SYS_CTYPES_MODULE_MINIMAL=$(SYS_MODULES_DIR_MINIMAL)/ChapelSysCTypes.chpl
 
 MODULE_SPHINX=${CHPL_MAKE_HOME}/modules/sphinx
 DOC_BUILD=${CHPL_MAKE_HOME}/build/doc
@@ -46,7 +48,7 @@ COPY_IF_DIFFERENT = $(CHPL_MAKE_PYTHON) $(CHPL_MAKE_HOME)/util/config/update-if-
 
 default: all
 
-all: $(SYS_CTYPES_MODULE)
+all: $(SYS_CTYPES_MODULE) $(SYS_CTYPES_MODULE_MINIMAL)
 	$(TAGS_COMMAND)
 
 clean: FORCE
@@ -64,6 +66,10 @@ MAKE_SYS_BASIC_TYPES=$(CHPL_MAKE_HOME)/util/config/make_sys_basic_types.py
 $(SYS_CTYPES_MODULE): $(MAKE_SYS_BASIC_TYPES)
 	mkdir -p $(@D)
 	cd $(@D) && $(CHPL_MAKE_PYTHON) $(MAKE_SYS_BASIC_TYPES) $(@F)
+
+$(SYS_CTYPES_MODULE_MINIMAL): $(MAKE_SYS_BASIC_TYPES)
+	mkdir -p $(@D)
+	cd $(@D) && $(CHPL_MAKE_PYTHON) $(MAKE_SYS_BASIC_TYPES) --minimal $(@F)
 
 $(SYS_CTYPES_MODULE_DOC): $(MAKE_SYS_BASIC_TYPES)
 	mkdir -p $(@D)

--- a/modules/minimal/internal/CTypes.chpl
+++ b/modules/minimal/internal/CTypes.chpl
@@ -18,5 +18,5 @@
  */
 module CTypes {
   public use CPtr;
-  extern type c_char = int(8);
+  public use ChapelSysCTypes;
 }

--- a/util/config/make_sys_basic_types.py
+++ b/util/config/make_sys_basic_types.py
@@ -76,14 +76,14 @@ def main():
 
     # Get the module content first, since it can lead to errors/early exits if
     # something goes wrong.
-    module_content = get_sys_c_types(args.doc)
+    module_content = get_sys_c_types(args.doc,args.minimal)
     with open(args.output_file, 'w') as fp:
         fp.write(module_content)
         fp.write('\n')
     logging.debug('Wrote module to: {0}'.format(args.output_file))
 
 
-def get_sys_c_types(docs=False):
+def get_sys_c_types(docs=False,minimal=False):
     """Returns a string with the ChapelSysCTypes.chpl module content."""
 
     # Find the $CHPL_HOME/util/config/ dir.
@@ -200,22 +200,23 @@ def get_sys_c_types(docs=False):
         if chpl_type == 'c_ptr':
             handled_c_ptr = True
 
-    # Finally, print out set of asserts for module. They assert that the
-    # sizeof(<extern chpl type>) matches the sizeof(<chpl type>). E.g.
-    #
-    #   assert(sizeof(c_int) == sizeof(int(32)));
-    #
-    sys_c_types.append("""
-{
-  extern proc sizeof(type t): c_size_t;
-""")
-    for i, max_value in enumerate(max_values):
-        _, chpl_type, _ = _types[i]
-        if chpl_type.startswith('c_'):
-            chpl_value = _max_value_to_chpl_type.get(str(max_value))
-            sys_c_types.append('  assert(sizeof({chpl_type}) == sizeof({chpl_value}))'
-                               ';'.format(**locals()))
-    sys_c_types.append('}')
+    if not minimal:
+        # Finally, print out set of asserts for module. They assert that the
+        # sizeof(<extern chpl type>) matches the sizeof(<chpl type>). E.g.
+        #
+        #   assert(sizeof(c_int) == sizeof(int(32)));
+        #
+        sys_c_types.append("""
+    {
+      extern proc sizeof(type t): c_size_t;
+    """)
+        for i, max_value in enumerate(max_values):
+            _, chpl_type, _ = _types[i]
+            if chpl_type.startswith('c_'):
+                chpl_value = _max_value_to_chpl_type.get(str(max_value))
+                sys_c_types.append('  assert(sizeof({chpl_type}) == sizeof({chpl_value}))'
+                                   ';'.format(**locals()))
+        sys_c_types.append('}')
 
     return '\n'.join(sys_c_types)
 
@@ -252,6 +253,10 @@ def _parse_args():
     parser.add_option(
         '--doc', action='store_true',
         help='Build ChapelSysCTypes module for chpldoc.'
+    )
+    parser.add_option(
+        '--minimal', action='store_true',
+        help='Build ChapelSysCTypes module for minimal modules.'
     )
 
     opts, args = parser.parse_args()

--- a/util/config/make_sys_basic_types.py
+++ b/util/config/make_sys_basic_types.py
@@ -206,6 +206,8 @@ def get_sys_c_types(docs=False,minimal=False):
         #
         #   assert(sizeof(c_int) == sizeof(int(32)));
         #
+        # Do not do this when generating minimal modules because '==' is
+        # not defined.
         sys_c_types.append("""
     {
       extern proc sizeof(type t): c_size_t;


### PR DESCRIPTION
The removal of C strings and C string literals from Dyno required changes to some minimal module tests; in particular, it required representing C strings the way C represents them -- as pointers to characters. I originally picked `c_char = int(8)`, but this is not correct on all platforms due to signedness. As a result, some minimal module tests were throwing assertion errors.

This PR changes things by actually generating C types for minimal modules. This is just like generating C types for standard modules, but it doesn't generate the various assertions, because `==` is typically not in scope.

Reviewed by @lydia-duncan -- thanks!

## Testing
- [x] paratest