### PR TITLE
Improve the tuple out-of-bounds error message

### DIFF
--- a/modules/internal/ChapelTuple.chpl
+++ b/modules/internal/ChapelTuple.chpl
@@ -169,7 +169,9 @@ module ChapelTuple {
       compilerError("invalid access of non-homogeneous tuple by runtime value");
     if boundsChecking then
       if i < 0 || i > size-1 then
-        halt("tuple access out of bounds: ", i, " (accessing ", this.type:string, ")");
+        halt("tuple index out of bounds\n",
+             "note: index was ", i, " but the tuple type ", this.type:string,
+             " has bounds 0..", size-1);
     return __primitive("get svec member", this, i);
   }
 
@@ -181,7 +183,10 @@ module ChapelTuple {
       compilerError("invalid access of non-homogeneous tuple by runtime value");
     if boundsChecking then
       if i < 0 || i > size-1 then
-        halt("tuple access out of bounds: ", i, " (accessing ", this.type:string, ")");
+        halt("tuple index out of bounds\n",
+             "note: index was ", i, " but the tuple type ", this.type:string,
+             " has bounds 0..", size-1);
+
     return __primitive("get svec member", this, i);
   }
 

--- a/modules/internal/ChapelTuple.chpl
+++ b/modules/internal/ChapelTuple.chpl
@@ -169,7 +169,7 @@ module ChapelTuple {
       compilerError("invalid access of non-homogeneous tuple by runtime value");
     if boundsChecking then
       if i < 0 || i > size-1 then
-        halt("tuple access out of bounds: ", i);
+        halt("tuple access out of bounds: ", i, " (accessing ", this.type:string, ")");
     return __primitive("get svec member", this, i);
   }
 
@@ -181,7 +181,7 @@ module ChapelTuple {
       compilerError("invalid access of non-homogeneous tuple by runtime value");
     if boundsChecking then
       if i < 0 || i > size-1 then
-        halt("tuple access out of bounds: ", i);
+        halt("tuple access out of bounds: ", i, " (accessing ", this.type:string, ")");
     return __primitive("get svec member", this, i);
   }
 

--- a/test/types/tuple/homog/tuple-out-of-bounds-access.chpl
+++ b/test/types/tuple/homog/tuple-out-of-bounds-access.chpl
@@ -1,0 +1,13 @@
+var tup: 23*int;
+
+for i in 0..<tup.size {
+  tup[i] = i;
+}
+
+proc printelt(i: int) {
+  writeln(tup(i));
+}
+
+printelt(0);
+printelt(22);
+printelt(23);

--- a/test/types/tuple/homog/tuple-out-of-bounds-access.good
+++ b/test/types/tuple/homog/tuple-out-of-bounds-access.good
@@ -1,3 +1,4 @@
 0
 22
-tuple-out-of-bounds-access.chpl:8: error: halt reached - tuple access out of bounds: 23 (accessing 23*int(64))
+tuple-out-of-bounds-access.chpl:8: error: halt reached - tuple index out of bounds
+note: index was 23 but the tuple type 23*int(64) has bounds 0..22

--- a/test/types/tuple/homog/tuple-out-of-bounds-access.good
+++ b/test/types/tuple/homog/tuple-out-of-bounds-access.good
@@ -1,0 +1,3 @@
+0
+22
+tuple-out-of-bounds-access.chpl:8: error: halt reached - tuple access out of bounds: 23 (accessing 23*int(64))


### PR DESCRIPTION
This PR updates the `tuple access out of bounds` error to print out the tuple type in addition based on my recent experience being confused by this error. While there, it makes this error message more similar to the array out-of-bounds error.

Example error before this PR:
```
tuple-out-of-bounds-access.chpl:8: error: halt reached - tuple access out of bounds: 23
```

Example error after this PR:
```
tuple-out-of-bounds-access.chpl:8: error: halt reached - tuple index out of bounds
note: index was 23 but the tuple type 23*int(64) has bounds 0..22
```

Reviewed by @DanilaFe - thanks!

- [x] full comm=none testing