### PR TITLE
Remove use of /data/cf in testReleasesPerformance

### DIFF
--- a/util/pastPerformance/testReleasesPerformance
+++ b/util/pastPerformance/testReleasesPerformance
@@ -67,7 +67,7 @@ fi
 # This is a place where all releases will be unpacked and built with
 # optimizations on, debugging off.
 #
-export chpl_release_home=/data/cf/chapel/chapel-releases
+export chpl_release_home=/hpcdc/project/chapel/chapel-releases
 
 if [[ -z $CHPL_TEST_PERF_DIR ]]; then
     export CHPL_TEST_PERF_DIR=$CHPL_HOME/test/perfdat-releases


### PR DESCRIPTION
Update a path in `util/pastPerformance/testReleasesPerformance` from `/data/cf/chapel/chapel-releases` to `/hpcdc/project/chapel/chapel-releases`.

The previous directory did not exist on that filesystem, so I'm not sure how this has been working so far. Maybe it hasn't actually been getting used. In any case, I did not create the dir on the new filesystem as part of this.

This is the only path needing to be updated outside of the test configs in `util/cron`, which will be changed in a separate PR.

Part of https://github.com/Cray/chapel-private/issues/7042.

[reviewer info placeholder]