### PR TITLE
Reduce use of `index.html`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -528,7 +528,7 @@ Tool Improvements
 Documentation Improvements
 --------------------------
 * linked the module index from the documentation landing page  
-  (see https://chapel-lang.org/docs/2.2/index.html#indexes)
+  (see https://chapel-lang.org/docs/2.2/#indexes)
 
 Documentation Improvements for Tools
 ------------------------------------
@@ -972,7 +972,7 @@ Documentation Improvements
 Documentation Improvements for Tools
 ------------------------------------
 * refactored the tools documentation to be more user-friendly  
-  (see https://chapel-lang.org/docs/2.1/tools/index.html)
+  (see https://chapel-lang.org/docs/2.1/tools/)
 * documented how to install the language server and linter tools for Emacs  
   (see https://chapel-lang.org/docs/2.1/tools/chpl-language-server/chpl-language-server.html#emacs  
    and https://chapel-lang.org/docs/2.1/tools/chplcheck/chplcheck.html#emacs)
@@ -4893,7 +4893,7 @@ Documentation
 * updated GPU technote to expand on currently known limitations  
   (see https://chapel-lang.org/docs/1.26/technotes/gpu.html)
 * added chapter groupings to the language specification  
-  (see https://chapel-lang.org/docs/1.26/language/spec/index.html)
+  (see https://chapel-lang.org/docs/1.26/language/spec/)
 * grouped package modules by topic  
   (see https://chapel-lang.org/docs/1.26/modules/packages.html)
 * added documentation for many methods in the 'BigInteger' module  
@@ -4905,7 +4905,7 @@ Documentation
 * documented which elements are preserved in `set` operations with overlap  
   (see https://chapel-lang.org/docs/1.26/modules/standard/Set.html)
 * added a link to the online documentation index at the bottom of its sidebar  
-  (see https://chapel-lang.org/docs/1.26/index.html)
+  (see https://chapel-lang.org/docs/1.26/)
 * added documentation for the `CHPL_LLVM_GCC_PREFIX` environment variable  
   (see https://chapel-lang.org/docs/1.26/usingchapel/chplenv.html#chpl-llvm)
 
@@ -5200,9 +5200,9 @@ Documentation
    https://chapel-lang.org/docs/1.25/language/spec/types.html#module-ChapelComplex_forDocs,  
    and https://chapel-lang.org/docs/1.25/language/spec/locales.html#locale-methods)
 * added contributor documentation, such as best practices, to the online docs  
-  (see https://chapel-lang.org/docs/1.25/developer/index.html)
+  (see https://chapel-lang.org/docs/1.25/developer/)
 * added contributor documentation for the new compiler front-end  
-  (see https://chapel-lang.org/docs/1.25/developer/compiler-internals/index.html)
+  (see https://chapel-lang.org/docs/1.25/developer/compiler-internals/)
 * improved the description of the prerequisites for documentation builds  
   (see https://chapel-lang.org/docs/1.25/usingchapel/prereqs.html)
 * documented `CHPL_RT_UNWIND`  
@@ -5305,7 +5305,7 @@ Developer-oriented changes: Documentation
 * added a note about passing environment variables to `paratest`  
   (see https://chapel-lang.org/docs/1.25/developer/bestPractices/Sanitizers.html)
 * `make docs` now includes compiler docs if `doxygen` and `cmake` are available  
-  (see https://chapel-lang.org/docs/1.25/developer/compiler-internals/index.html)
+  (see https://chapel-lang.org/docs/1.25/developer/compiler-internals/)
 * combined the docs for `.join()` on `string`/`bytes` for arrays and tuples
 * updated `ofi` communication layer developer documentation
 
@@ -7111,7 +7111,7 @@ Memory Improvements
 Documentation
 -------------
 * converted the language specification from PDF (LaTeX) to HTML (rst)  
-  (see https://chapel-lang.org/docs/1.21/language/spec/index.html)
+  (see https://chapel-lang.org/docs/1.21/language/spec/)
 * generally updated documentation with respect to the changes in this release
 * improved the documentation for `owned` and `shared` classes  
   (see https://chapel-lang.org/docs/1.21/builtins/OwnedObject.html  
@@ -9910,7 +9910,7 @@ Example Codes
 Documentation
 -------------
 * added new users guide sections on promotion, constants, type aliases, configs  
-  (see https://chapel-lang.org/docs/1.15/users-guide/index.html)
+  (see https://chapel-lang.org/docs/1.15/users-guide/)
 * revised QUICKSTART instructions for clarity  
   (see https://chapel-lang.org/docs/1.15/usingchapel/QUICKSTART.html)
 * reorganized the doc/ directory in the release tarball  
@@ -9922,7 +9922,7 @@ Documentation
 * improved the Docker README information  
   (see https://hub.docker.com/r/chapel/chapel/)
 * reorganized the platform-specific documentation pages into categories  
-  (see https://chapel-lang.org/docs/1.15/platforms/index.html)
+  (see https://chapel-lang.org/docs/1.15/platforms/)
 * added documentation for dim() and dims() on arrays  
   (see https://chapel-lang.org/docs/1.15/builtins/internal/ChapelArray.html#ChapelArray.dims)
 * fixed the documentation for string.strip()  
@@ -10215,13 +10215,13 @@ Highlights (see subsequent sections for more details)
     (see https://chapel-lang.org/docs/1.14/technotes/extern.html#c-fn-ptr)
 * documentation and example code highlights:
   - added the primer and "hello world" example codes to the online documentation  
-    (see https://chapel-lang.org/docs/1.14/primers/index.html and  
-     https://chapel-lang.org/docs/1.14/examples/index.html)
+    (see https://chapel-lang.org/docs/1.14/primers/ and  
+     https://chapel-lang.org/docs/1.14/examples/)
   - completed and updated our suite of Computer Language Benchmark Game codes  
     (see $CHPL_HOME/examples/benchmarks/shootout/* and  
      http://benchmarksgame.alioth.debian.org/)
   - added several new pages to the online users guide  
-    (see https://chapel-lang.org/docs/1.14/users-guide/index.html)
+    (see https://chapel-lang.org/docs/1.14/users-guide/)
 * additional highlights:
   - made significant improvements to the 'chplvis' execution analysis tool  
     (see https://chapel-lang.org/docs/1.14/tools/chplvis/chplvis.html)
@@ -10399,13 +10399,13 @@ Tool Changes
 Documentation
 -------------
 * added the primer example codes to the online documentation  
-  (see https://chapel-lang.org/docs/1.14/primers/index.html)
+  (see https://chapel-lang.org/docs/1.14/primers/)
 * added the 'hello world' examples to the online documentation  
-  (see https://chapel-lang.org/docs/1.14/examples/index.html)
+  (see https://chapel-lang.org/docs/1.14/examples/)
 * added a new primer example for modules and 'use' statements  
   (see doc/release/examples/primers/modules.chpl)
 * added a number of new sections to the user's guide  
-  (see https://chapel-lang.org/docs/1.14/users-guide/index.html)
+  (see https://chapel-lang.org/docs/1.14/users-guide/)
 * significantly re-worked the multi-locale execution and quickstart docs  
   (see https://chapel-lang.org/docs/1.14/usingchapel/multilocale.html and  
    https://chapel-lang.org/docs/1.14/usingchapel/QUICKSTART.html)
@@ -10868,7 +10868,7 @@ Documentation
   (see https://chapel-lang.org/docs/1.13/language/evolution.html)
 * split the top-level README.rst file into README.rst and QUICKSTART.rst
 * started writing a Chapel Users Guide, though much work remains  
-  (see https://chapel-lang.org/docs/1.13/users-guide/index.html)
+  (see https://chapel-lang.org/docs/1.13/users-guide/)
 * improved the accuracy of Chapel's prerequisites list  
   (see https://chapel-lang.org/docs/1.13/usingchapel/prereqs.html)
 * improved wordings and descriptions in the language specification
@@ -11117,7 +11117,7 @@ Highlights
 * added new 'Barrier', 'Spawn', and 'LAPACK' modules to the standard set  
   (see "Standard Library/Modules" section below)
 * added chplvis: a new tool for visualizing Chapel communication and concurrency  
-  (see https://chapel-lang.org/docs/1.12/tools/chplvis/index.html)
+  (see https://chapel-lang.org/docs/1.12/tools/chplvis/)
 * added a new chapter describing Chapel's memory consistency model in detail  
   (see 'Memory Consistency Model' in the language spec)
 * added a 'vectorizeOnly()' iterator that vectorizes without task creation  
@@ -11155,7 +11155,7 @@ Environment/Configuration Changes
 Tool Changes
 ------------
 * added chplvis: a new tool for visualizing Chapel communication and concurrency  
-  (see https://chapel-lang.org/docs/1.12/tools/chplvis/index.html)
+  (see https://chapel-lang.org/docs/1.12/tools/chplvis/)
 * chpldoc improvements:
   - improved handling of enum, real, imag, and complex initializers
   - 'chpldoc' now generates values for enum symbols

--- a/doc/Makefile.sphinx
+++ b/doc/Makefile.sphinx
@@ -86,7 +86,7 @@ html-release: check-sphinxbuild source
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@chmod -R ugo+rX $(BUILDDIR)
 	@$(COPY_IF_DIFFERENT) util/versionButton.php $(BUILDDIR)/html/versionButton.php
-	@echo "ErrorDocument 404 https://chapel-lang.org/docs/$(WEB_DOC_VERSION)/index.html" > $(BUILDDIR)/html/.htaccess
+	@echo "ErrorDocument 404 https://chapel-lang.org/docs/$(WEB_DOC_VERSION)/" > $(BUILDDIR)/html/.htaccess
 	@echo copying searchtools.js
 	@cp $(CHPL_MAKE_HOME)/doc/rst/meta/static/searchtools.js $(BUILDDIR)/html/_static
 	@rm -Rf html

--- a/doc/rst/developer/bestPractices/GettingStarted.rst
+++ b/doc/rst/developer/bestPractices/GettingStarted.rst
@@ -56,7 +56,7 @@ with the project via the following steps:
   <https://chapel-lang.org/learning.html>`_.
 
 * Familiarize yourself with the `language specification
-  <https://chapel-lang.org/docs/language/spec/index.html>`_.  This can
+  <https://chapel-lang.org/docs/language/spec/>`_.  This can
   be a fairly dry/tedious task, so most people will tend to find other
   tasks to interleave it with, like programming.  Nevertheless, we
   want to emphasize how important it is for developers to be familiar

--- a/doc/rst/developer/bestPractices/README.md
+++ b/doc/rst/developer/bestPractices/README.md
@@ -1,2 +1,2 @@
 Please see
-[index.rst](https://chapel-lang.org/docs/main/developer/bestPractices/index.html)
+[index.rst](https://chapel-lang.org/docs/main/developer/bestPractices/)

--- a/doc/rst/developer/chips/inactive/14.rst
+++ b/doc/rst/developer/chips/inactive/14.rst
@@ -51,7 +51,7 @@ The user can select the unwind library using an environment variable, for
 example CHPL_UNWIND. If an unwind library is not specified, the runtime doesn't
 produce a stack trace.
 
-A candidate as the unwind library is `libunwind <http://www.nongnu.org/libunwind/index.html>`_. 
+A candidate as the unwind library is `libunwind <http://www.nongnu.org/libunwind/>`_. 
 libunwind is a MIT licensed library for stack unwinding under Linux on several
 architectures.
 

--- a/doc/rst/language/archivedSpecs.rst
+++ b/doc/rst/language/archivedSpecs.rst
@@ -5,32 +5,32 @@ Documentation Archives
 
 Online Documentation Archives
 -----------------------------
-* `Chapel 2.2  <https://chapel-lang.org/docs/2.2/index.html>`_
-* `Chapel 2.1  <https://chapel-lang.org/docs/2.1/index.html>`_
-* `Chapel 2.0  <https://chapel-lang.org/docs/2.0/index.html>`_
-* `Chapel 1.33 <https://chapel-lang.org/docs/1.33/index.html>`_
-* `Chapel 1.32 <https://chapel-lang.org/docs/1.32/index.html>`_
-* `Chapel 1.31 <https://chapel-lang.org/docs/1.31/index.html>`_
-* `Chapel 1.30 <https://chapel-lang.org/docs/1.30/index.html>`_
-* `Chapel 1.29 <https://chapel-lang.org/docs/1.29/index.html>`_
-* `Chapel 1.28 <https://chapel-lang.org/docs/1.28/index.html>`_
-* `Chapel 1.27 <https://chapel-lang.org/docs/1.27/index.html>`_
-* `Chapel 1.26 <https://chapel-lang.org/docs/1.26/index.html>`_
-* `Chapel 1.25 <https://chapel-lang.org/docs/1.25/index.html>`_
-* `Chapel 1.24 <https://chapel-lang.org/docs/1.24/index.html>`_
-* `Chapel 1.23 <https://chapel-lang.org/docs/1.23/index.html>`_
-* `Chapel 1.22 <https://chapel-lang.org/docs/1.22/index.html>`_
-* `Chapel 1.21 <https://chapel-lang.org/docs/1.21/index.html>`_
-* `Chapel 1.20 <https://chapel-lang.org/docs/1.20/index.html>`_
-* `Chapel 1.19 <https://chapel-lang.org/docs/1.19/index.html>`_
-* `Chapel 1.18 <https://chapel-lang.org/docs/1.18/index.html>`_
-* `Chapel 1.17 <https://chapel-lang.org/docs/1.17/index.html>`_
-* `Chapel 1.16 <https://chapel-lang.org/docs/1.16/index.html>`_
-* `Chapel 1.15 <https://chapel-lang.org/docs/1.15/index.html>`_
-* `Chapel 1.14 <https://chapel-lang.org/docs/1.14/index.html>`_
-* `Chapel 1.13 <https://chapel-lang.org/docs/1.13/index.html>`_
-* `Chapel 1.12 <https://chapel-lang.org/docs/1.12/index.html>`_
-* `Chapel 1.11 <https://chapel-lang.org/docs/1.11/index.html>`_
+* `Chapel 2.2  <https://chapel-lang.org/docs/2.2/>`_
+* `Chapel 2.1  <https://chapel-lang.org/docs/2.1/>`_
+* `Chapel 2.0  <https://chapel-lang.org/docs/2.0/>`_
+* `Chapel 1.33 <https://chapel-lang.org/docs/1.33/>`_
+* `Chapel 1.32 <https://chapel-lang.org/docs/1.32/>`_
+* `Chapel 1.31 <https://chapel-lang.org/docs/1.31/>`_
+* `Chapel 1.30 <https://chapel-lang.org/docs/1.30/>`_
+* `Chapel 1.29 <https://chapel-lang.org/docs/1.29/>`_
+* `Chapel 1.28 <https://chapel-lang.org/docs/1.28/>`_
+* `Chapel 1.27 <https://chapel-lang.org/docs/1.27/>`_
+* `Chapel 1.26 <https://chapel-lang.org/docs/1.26/>`_
+* `Chapel 1.25 <https://chapel-lang.org/docs/1.25/>`_
+* `Chapel 1.24 <https://chapel-lang.org/docs/1.24/>`_
+* `Chapel 1.23 <https://chapel-lang.org/docs/1.23/>`_
+* `Chapel 1.22 <https://chapel-lang.org/docs/1.22/>`_
+* `Chapel 1.21 <https://chapel-lang.org/docs/1.21/>`_
+* `Chapel 1.20 <https://chapel-lang.org/docs/1.20/>`_
+* `Chapel 1.19 <https://chapel-lang.org/docs/1.19/>`_
+* `Chapel 1.18 <https://chapel-lang.org/docs/1.18/>`_
+* `Chapel 1.17 <https://chapel-lang.org/docs/1.17/>`_
+* `Chapel 1.16 <https://chapel-lang.org/docs/1.16/>`_
+* `Chapel 1.15 <https://chapel-lang.org/docs/1.15/>`_
+* `Chapel 1.14 <https://chapel-lang.org/docs/1.14/>`_
+* `Chapel 1.13 <https://chapel-lang.org/docs/1.13/>`_
+* `Chapel 1.12 <https://chapel-lang.org/docs/1.12/>`_
+* `Chapel 1.11 <https://chapel-lang.org/docs/1.11/>`_
 
 
 Language Specification Archives

--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -687,7 +687,7 @@ Performance Tips
   program when NVIDIA's kernel mode driver is not already loaded and running.
   If you are using Linux and not running an X server on the target GPU, then
   you may wish to install `NVIDIA's `driver persistence daemon
-  <https://docs.nvidia.com/deploy/driver-persistence/index.html#persistence-daemon>`_
+  <https://docs.nvidia.com/deploy/driver-persistence/#persistence-daemon>`_
   to alleviate this issue.
 
 Tested Configurations
@@ -715,7 +715,7 @@ GPU Support on Windows Subsystem for Linux
 NVIDIA GPUs can be used on Windows through through WSL. To enable GPU support on
 WSL we require the CUDA Toolkit to be installed in the WSL environment and the
 NVIDIA driver to be installed on the Windows host. See the `NVIDIA documentation
-<https://docs.nvidia.com/cuda/wsl-user-guide/index.html#getting-started-with-cuda-on-wsl-2>`_
+<https://docs.nvidia.com/cuda/wsl-user-guide/#getting-started-with-cuda-on-wsl-2>`_
 for more information on setting up CUDA on WSL.
 See `Using Chapel on WSL <../platforms/windows.html#using-chapel-on-wsl>`_
 for more information on using Chapel with WSL.

--- a/util/buildRelease/changePrerelease
+++ b/util/buildRelease/changePrerelease
@@ -64,7 +64,7 @@ $sed_command "/release = '$1\.$3\.$5'/s/"$1\.$3\.$5"/"$2\.$4\.$6"/" $CHPL_HOME/d
 
 echo "Adding last release to archivedSpecs.rst"
 $sed_command "/* \`Chapel $7\.$8/i\\
-* \`Chapel $1\.$3 \<https://chapel-lang.org/docs/$1\.$3/index.html\>\`_
+* \`Chapel $1\.$3 \<https://chapel-lang.org/docs/$1\.$3/\>\`_
 " $CHPL_HOME/doc/rst/language/archivedSpecs.rst
 
 echo "Changing version numbers in QUICKSTART.rst"


### PR DESCRIPTION
This PR removes a number of instances of `index.html` files from our docs and code, motivated by:

* making URLs shorter, simpler, and more canonical
* reducing the number of index.html files I find when grepping the website for instances of it

Interestingly, I think there are many remaining uses in the generated docs which, I'm guessing, are inserted by sphinx, though it seems surprising that it wouldn't use directories rather than explicit index.html files…
