### PR TITLE
Switch /data/cf to /hpcdc/project and use new setup scripts

### DIFF
--- a/util/cron/common-arkouda.bash
+++ b/util/cron/common-arkouda.bash
@@ -43,12 +43,6 @@ fi
 # enable arrow/parquet support
 export ARKOUDA_SERVER_PARQUET_SUPPORT=true
 
-# Arkouda requires a newer python
-SETUP_PYTHON=$COMMON_DIR/setup_python_arkouda.bash
-if [ -f "$SETUP_PYTHON" ]; then
-  source $SETUP_PYTHON
-fi
-
 export CHPL_WHICH_RELEASE_FOR_ARKOUDA="2.3.0"
 # test against Chapel release (checking out current test/cron directories)
 function test_release() {

--- a/util/cron/common-llvm.bash
+++ b/util/cron/common-llvm.bash
@@ -25,23 +25,6 @@ esac
 
 if test "$CHPL_LLVM" = bundled; then
 
-    # Ensure that python 2.7 is at front of PATH. This is only done for
-    # llvm configuration because the test systems are _very_ finicky about
-    # python 2.6 due to some environmental configurations.
-    #
-    # Ideally, this would only apply to the `make compile` step in
-    # nightly, but there is not a good way to do that right now. One can
-    # imagine adding a "pre-make-compile hook" to nightly. Maybe an env
-    # var with a comment to executes, but it seems ok for the chpldoc test
-    # to fail on llvm for now.
-    # (thomasvandoren, 2015-03-11)
-     py27_setup=/data/cf/chapel/setup_python27.bash
-    if [ -f "${py27_setup}" ] ; then
-        source ${py27_setup}
-    else
-        echo "[Warning: llvm may not build correctly with python: $(which python)]"
-    fi
-
     # 2021-10-26: Developer-installed cmake version required by LLVM 12
     cmake_setup=/data/cf/chapel/setup_cmake_nightly.bash
     if [ -f "${cmake_setup}" ] ; then

--- a/util/cron/common-llvm.bash
+++ b/util/cron/common-llvm.bash
@@ -26,7 +26,7 @@ esac
 if test "$CHPL_LLVM" = bundled; then
 
     # 2021-10-26: Developer-installed cmake version required by LLVM 12
-    cmake_setup=/data/cf/chapel/setup_cmake_nightly.bash
+    cmake_setup=/hpcdc/project/chapel/setup_cmake_nightly.bash
     if [ -f "${cmake_setup}" ] ; then
         source ${cmake_setup}
     else

--- a/util/cron/common-mpicc.bash
+++ b/util/cron/common-mpicc.bash
@@ -10,4 +10,4 @@ export CHPL_TASKS=fifo
 export CHPL_TARGET_COMPILER=mpi-gnu
 
 # setup mpich 3.3.1
-source /data/cf/chapel/setup_mpich331.bash
+source /hpcdc/project/chapel/setup_mpich331.bash

--- a/util/cron/common-native-gpu.bash
+++ b/util/cron/common-native-gpu.bash
@@ -4,7 +4,7 @@ source $UTIL_CRON_DIR/common.bash
 
 # Use latest system LLVM, to use an earlier version uncomment and pass version
 # number as a parameter to the script.
-# source /hpcdc/project/chapel/setup_system_llvm.bash
+# source /hpcdc/project/chapel/setup_llvm.bash
 
 export CHPL_LLVM=system
 export CHPL_LOCALE_MODEL=gpu

--- a/util/cron/common-python.bash
+++ b/util/cron/common-python.bash
@@ -11,7 +11,7 @@ function set_and_check_python_version() {
   # override `python`
   export PATH=/hpcdc/project/chapel/no-python:$PATH
 
-  local setup_script="/hpcdc/project/chapel/setup_python$major_ver$minor_ver.bash"
+  local setup_script="/hpcdc/project/chapel/setup_python.bash $major_ver.$minor_ver"
 
   if [[ -f "${setup_script}" ]] ; then
     source ${setup_script}

--- a/util/cron/load-base-deps.bash
+++ b/util/cron/load-base-deps.bash
@@ -20,8 +20,8 @@ else
   # For systems not using a Spack install
 
   # load llvm
-  if [ -f /hpcdc/project/chapel/setup_system_llvm.bash ] ; then
-    source /hpcdc/project/chapel/setup_system_llvm.bash
+  if [ -f /hpcdc/project/chapel/setup_llvm.bash ] ; then
+    source /hpcdc/project/chapel/setup_llvm.bash
   elif [ -f /cy/users/chapelu/setup_system_llvm.bash ] ; then
     source /cy/users/chapelu/setup_system_llvm.bash
   fi

--- a/util/cron/test-c-backend.bash
+++ b/util/cron/test-c-backend.bash
@@ -3,8 +3,6 @@
 # Full test suite with CHPL_LLVM=none and CHPL_TARGET_COMPILER=gnu
 # on linux64. Now uses paratest.server.
 
-# Needs /data/cf/chapel/setup_python27.bash (common-llvm)
-
 UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common.bash
 source $UTIL_CRON_DIR/common-c-backend.bash

--- a/util/cron/test-cray-xc-gpu-arkouda.bash
+++ b/util/cron/test-cray-xc-gpu-arkouda.bash
@@ -7,7 +7,7 @@ UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common.bash
 
 # Setup for GPU:
-source /hpcdc/project/chapel/setup_system_llvm.bash $LLVM_VERSION
+source /hpcdc/project/chapel/setup_llvm.bash $LLVM_VERSION
 module load cudatoolkit
 export CHPL_TARGET_COMPILER=llvm
 export CHPL_LLVM=system

--- a/util/cron/test-linux64-gcc101.bash
+++ b/util/cron/test-linux64-gcc101.bash
@@ -11,7 +11,7 @@ export CHPL_LLVM=none
 export CHPL_LLVM_SUPPORT=bundled
 unset CHPL_LLVM_CONFIG
 
-source /data/cf/chapel/setup_gcc101.bash     # host-specific setup for target compiler
+source /hpcdc/project/chapel/setup_gcc101.bash     # host-specific setup for target compiler
 
 # Set environment variables to nudge cmake towards GCC 10.1
 export CHPL_CMAKE_USE_CC_CXX=1

--- a/util/cron/test-linux64-gcc101.bash
+++ b/util/cron/test-linux64-gcc101.bash
@@ -11,7 +11,7 @@ export CHPL_LLVM=none
 export CHPL_LLVM_SUPPORT=bundled
 unset CHPL_LLVM_CONFIG
 
-source /hpcdc/project/chapel/setup_gcc101.bash     # host-specific setup for target compiler
+source /hpcdc/project/chapel/setup_gcc.bash 10.1
 
 # Set environment variables to nudge cmake towards GCC 10.1
 export CHPL_CMAKE_USE_CC_CXX=1

--- a/util/cron/test-linux64-gcc112.bash
+++ b/util/cron/test-linux64-gcc112.bash
@@ -11,7 +11,7 @@ export CHPL_LLVM=none
 export CHPL_LLVM_SUPPORT=bundled
 unset CHPL_LLVM_CONFIG
 
-source /hpcdc/project/chapel/setup_gcc112.bash     # host-specific setup for target compiler
+source /hpcdc/project/chapel/setup_gcc.bash 11.2
 
 # Set environment variables to nudge cmake towards GCC 11.2
 export CHPL_CMAKE_USE_CC_CXX=1

--- a/util/cron/test-linux64-gcc112.bash
+++ b/util/cron/test-linux64-gcc112.bash
@@ -11,7 +11,7 @@ export CHPL_LLVM=none
 export CHPL_LLVM_SUPPORT=bundled
 unset CHPL_LLVM_CONFIG
 
-source /data/cf/chapel/setup_gcc112.bash     # host-specific setup for target compiler
+source /hpcdc/project/chapel/setup_gcc112.bash     # host-specific setup for target compiler
 
 # Set environment variables to nudge cmake towards GCC 11.2
 export CHPL_CMAKE_USE_CC_CXX=1

--- a/util/cron/test-linux64-gcc74.bash
+++ b/util/cron/test-linux64-gcc74.bash
@@ -11,7 +11,7 @@ export CHPL_LLVM=none
 export CHPL_LLVM_SUPPORT=bundled
 unset CHPL_LLVM_CONFIG
 
-source /data/cf/chapel/setup_gcc74.bash     # host-specific setup for target compiler
+source /hpcdc/project/chapel/setup_gcc74.bash     # host-specific setup for target compiler
 
 # Set environment variables to nudge cmake towards GCC 7.4
 export CHPL_CMAKE_USE_CC_CXX=1

--- a/util/cron/test-linux64-gcc74.bash
+++ b/util/cron/test-linux64-gcc74.bash
@@ -11,7 +11,7 @@ export CHPL_LLVM=none
 export CHPL_LLVM_SUPPORT=bundled
 unset CHPL_LLVM_CONFIG
 
-source /hpcdc/project/chapel/setup_gcc74.bash     # host-specific setup for target compiler
+source /hpcdc/project/chapel/setup_gcc.bash 7.4
 
 # Set environment variables to nudge cmake towards GCC 7.4
 export CHPL_CMAKE_USE_CC_CXX=1

--- a/util/cron/test-linux64-gcc91.bash
+++ b/util/cron/test-linux64-gcc91.bash
@@ -11,7 +11,7 @@ export CHPL_LLVM=none
 export CHPL_LLVM_SUPPORT=bundled
 unset CHPL_LLVM_CONFIG
 
-source /hpcdc/project/chapel/setup_gcc91.bash     # host-specific setup for target compiler
+source /hpcdc/project/chapel/setup_gcc.bash 9.1
 
 # Set environment variables to nudge cmake towards GCC 9.1
 export CHPL_CMAKE_USE_CC_CXX=1

--- a/util/cron/test-linux64-gcc91.bash
+++ b/util/cron/test-linux64-gcc91.bash
@@ -11,7 +11,7 @@ export CHPL_LLVM=none
 export CHPL_LLVM_SUPPORT=bundled
 unset CHPL_LLVM_CONFIG
 
-source /data/cf/chapel/setup_gcc91.bash     # host-specific setup for target compiler
+source /hpcdc/project/chapel/setup_gcc91.bash     # host-specific setup for target compiler
 
 # Set environment variables to nudge cmake towards GCC 9.1
 export CHPL_CMAKE_USE_CC_CXX=1

--- a/util/cron/test-linux64-llvm11.bash
+++ b/util/cron/test-linux64-llvm11.bash
@@ -5,7 +5,7 @@
 UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common.bash
 
-source /hpcdc/project/chapel/setup_system_llvm.bash 11
+source /hpcdc/project/chapel/setup_llvm.bash 11
 
 clang_version=$(clang -dumpversion)
 if [ "$clang_version" != "11.0.1" ]; then

--- a/util/cron/test-linux64-llvm11.bash
+++ b/util/cron/test-linux64-llvm11.bash
@@ -5,7 +5,7 @@
 UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common.bash
 
-source /data/cf/chapel/setup_system_llvm.bash 11
+source /hpcdc/project/chapel/setup_system_llvm.bash 11
 
 clang_version=$(clang -dumpversion)
 if [ "$clang_version" != "11.0.1" ]; then

--- a/util/cron/test-linux64-llvm12.bash
+++ b/util/cron/test-linux64-llvm12.bash
@@ -5,7 +5,7 @@
 UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common.bash
 
-source /data/cf/chapel/setup_system_llvm.bash 12
+source /hpcdc/project/chapel/setup_system_llvm.bash 12
 
 clang_version=$(clang -dumpversion)
 if [ "$clang_version" != "12.0.1" ]; then

--- a/util/cron/test-linux64-llvm12.bash
+++ b/util/cron/test-linux64-llvm12.bash
@@ -5,7 +5,7 @@
 UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common.bash
 
-source /hpcdc/project/chapel/setup_system_llvm.bash 12
+source /hpcdc/project/chapel/setup_llvm.bash 12
 
 clang_version=$(clang -dumpversion)
 if [ "$clang_version" != "12.0.1" ]; then

--- a/util/cron/test-linux64-llvm13.bash
+++ b/util/cron/test-linux64-llvm13.bash
@@ -5,7 +5,7 @@
 UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common.bash
 
-source /hpcdc/project/chapel/setup_system_llvm.bash 13
+source /hpcdc/project/chapel/setup_llvm.bash 13
 
 clang_version=$(clang -dumpversion)
 if [ "$clang_version" != "13.0.0" ]; then

--- a/util/cron/test-linux64-llvm13.bash
+++ b/util/cron/test-linux64-llvm13.bash
@@ -5,7 +5,7 @@
 UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common.bash
 
-source /data/cf/chapel/setup_system_llvm.bash 13
+source /hpcdc/project/chapel/setup_system_llvm.bash 13
 
 clang_version=$(clang -dumpversion)
 if [ "$clang_version" != "13.0.0" ]; then

--- a/util/cron/test-linux64-llvm14.bash
+++ b/util/cron/test-linux64-llvm14.bash
@@ -5,7 +5,7 @@
 UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common.bash
 
-source /hpcdc/project/chapel/setup_system_llvm.bash 14
+source /hpcdc/project/chapel/setup_llvm.bash 14
 
 clang_version=$(clang -dumpversion)
 if [ "$clang_version" != "14.0.0" ]; then

--- a/util/cron/test-linux64-llvm14.bash
+++ b/util/cron/test-linux64-llvm14.bash
@@ -5,7 +5,7 @@
 UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common.bash
 
-source /data/cf/chapel/setup_system_llvm.bash 14
+source /hpcdc/project/chapel/setup_system_llvm.bash 14
 
 clang_version=$(clang -dumpversion)
 if [ "$clang_version" != "14.0.0" ]; then

--- a/util/cron/test-linux64-llvm15.bash
+++ b/util/cron/test-linux64-llvm15.bash
@@ -5,7 +5,7 @@
 UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common.bash
 
-source /hpcdc/project/chapel/setup_system_llvm.bash 15
+source /hpcdc/project/chapel/setup_llvm.bash 15
 
 # Check LLVM version via llvm-config from CHPL_LLVM_CONFIG
 llvm_version=$($CHPL_LLVM_CONFIG --version)

--- a/util/cron/test-linux64-llvm15.bash
+++ b/util/cron/test-linux64-llvm15.bash
@@ -5,7 +5,7 @@
 UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common.bash
 
-source /data/cf/chapel/setup_system_llvm.bash 15
+source /hpcdc/project/chapel/setup_system_llvm.bash 15
 
 # Check LLVM version via llvm-config from CHPL_LLVM_CONFIG
 llvm_version=$($CHPL_LLVM_CONFIG --version)

--- a/util/cron/test-linux64-llvm16.bash
+++ b/util/cron/test-linux64-llvm16.bash
@@ -5,7 +5,7 @@
 UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common.bash
 
-source /hpcdc/project/chapel/setup_system_llvm.bash 16
+source /hpcdc/project/chapel/setup_llvm.bash 16
 
 # Check LLVM version via llvm-config from CHPL_LLVM_CONFIG
 llvm_version=$($CHPL_LLVM_CONFIG --version)

--- a/util/cron/test-linux64-llvm16.bash
+++ b/util/cron/test-linux64-llvm16.bash
@@ -5,7 +5,7 @@
 UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common.bash
 
-source /data/cf/chapel/setup_system_llvm.bash 16
+source /hpcdc/project/chapel/setup_system_llvm.bash 16
 
 # Check LLVM version via llvm-config from CHPL_LLVM_CONFIG
 llvm_version=$($CHPL_LLVM_CONFIG --version)

--- a/util/cron/test-linux64-llvm17.bash
+++ b/util/cron/test-linux64-llvm17.bash
@@ -5,7 +5,7 @@
 UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common.bash
 
-source /hpcdc/project/chapel/setup_system_llvm.bash 17
+source /hpcdc/project/chapel/setup_llvm.bash 17
 
 # Check LLVM version via llvm-config from CHPL_LLVM_CONFIG
 llvm_version=$($CHPL_LLVM_CONFIG --version)

--- a/util/cron/test-linux64-llvm17.bash
+++ b/util/cron/test-linux64-llvm17.bash
@@ -5,7 +5,7 @@
 UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common.bash
 
-source /data/cf/chapel/setup_system_llvm.bash 17
+source /hpcdc/project/chapel/setup_system_llvm.bash 17
 
 # Check LLVM version via llvm-config from CHPL_LLVM_CONFIG
 llvm_version=$($CHPL_LLVM_CONFIG --version)

--- a/util/cron/test-linux64-llvm18.bash
+++ b/util/cron/test-linux64-llvm18.bash
@@ -5,7 +5,7 @@
 UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common.bash
 
-source /data/cf/chapel/setup_system_llvm.bash 18
+source /hpcdc/project/chapel/setup_system_llvm.bash 18
 
 # Check LLVM version via llvm-config from CHPL_LLVM_CONFIG
 llvm_version=$($CHPL_LLVM_CONFIG --version)

--- a/util/cron/test-linux64-llvm18.bash
+++ b/util/cron/test-linux64-llvm18.bash
@@ -5,7 +5,7 @@
 UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common.bash
 
-source /hpcdc/project/chapel/setup_system_llvm.bash 18
+source /hpcdc/project/chapel/setup_llvm.bash 18
 
 # Check LLVM version via llvm-config from CHPL_LLVM_CONFIG
 llvm_version=$($CHPL_LLVM_CONFIG --version)

--- a/util/cron/test-linux64-llvm19.bash
+++ b/util/cron/test-linux64-llvm19.bash
@@ -5,7 +5,7 @@
 UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common.bash
 
-source /data/cf/chapel/setup_system_llvm.bash 19
+source /hpcdc/project/chapel/setup_system_llvm.bash 19
 export CHPL_LLVM_GCC_PREFIX='none' # spack llvm is configured with proper gcc
 
 # Check LLVM version via llvm-config from CHPL_LLVM_CONFIG

--- a/util/cron/test-linux64-llvm19.bash
+++ b/util/cron/test-linux64-llvm19.bash
@@ -5,7 +5,7 @@
 UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common.bash
 
-source /hpcdc/project/chapel/setup_system_llvm.bash 19
+source /hpcdc/project/chapel/setup_llvm.bash 19
 export CHPL_LLVM_GCC_PREFIX='none' # spack llvm is configured with proper gcc
 
 # Check LLVM version via llvm-config from CHPL_LLVM_CONFIG

--- a/util/cron/test-linux64-python36.bash
+++ b/util/cron/test-linux64-python36.bash
@@ -8,6 +8,6 @@ source $UTIL_CRON_DIR/common-python.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-python36"
 
-set_and_check_python_version "3.6.10"
+set_and_check_python_version "3.6.15"
 
 $UTIL_CRON_DIR/nightly -cron -pythonDep ${nightly_args}

--- a/util/cron/test-linux64-python37.bash
+++ b/util/cron/test-linux64-python37.bash
@@ -8,6 +8,6 @@ source $UTIL_CRON_DIR/common-python.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-python37"
 
-set_and_check_python_version "3.7.9"
+set_and_check_python_version "3.7.17"
 
 $UTIL_CRON_DIR/nightly -cron -pythonDep ${nightly_args}

--- a/util/cron/test-networking-packages.bash
+++ b/util/cron/test-networking-packages.bash
@@ -6,7 +6,7 @@ UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common.bash
 source $UTIL_CRON_DIR/common-quickstart.bash
 
-export HADOOP_HOME=/data/cf/chapel/hadoop/$HOSTNAME
+export HADOOP_HOME=/hpcdc/project/chapel/hadoop/$HOSTNAME
 export JAVA_HOME=/usr/lib64/jvm/jre
 export CLASSPATH=$(${HADOOP_HOME}/bin/hadoop classpath --glob)
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HADOOP_HOME/lib/native:$JAVA_HOME/lib:$JAVA_HOME/lib/amd64/server

--- a/util/cron/test-perf.chapcs.arkouda.release.bash
+++ b/util/cron/test-perf.chapcs.arkouda.release.bash
@@ -14,7 +14,7 @@ if [ -n "$CHPL_WHICH_RELEASE_FOR_ARKOUDA" ]; then
   # removed when we no longer care about testing against that release.
   if [ "$CHPL_WHICH_RELEASE_FOR_ARKOUDA" = "2.2.0" ]; then
     # use LLVM 18, latest supported by 2.2.0
-    if [ -f /data/cf/chapel/setup_system_llvm.bash ] ; then
+    if [ -f /hpcdc/project/chapel/setup_system_llvm.bash ] ; then
       # Hack to avoid build issues with GMP. Spack installed GMP is pulled in as
       # a dependency of GDB. Then for some reason, it's (undesirably) linked
       # against by the bundled GMP's self-tests, causing them to fail due to
@@ -22,7 +22,7 @@ if [ -n "$CHPL_WHICH_RELEASE_FOR_ARKOUDA" ]; then
       # Anna 2024-06-17
       module unload gdb
 
-      source /data/cf/chapel/setup_system_llvm.bash 18
+      source /hpcdc/project/chapel/setup_system_llvm.bash 18
     fi
   else
     # Default to using latest LLVM.

--- a/util/cron/test-perf.chapcs.arkouda.release.bash
+++ b/util/cron/test-perf.chapcs.arkouda.release.bash
@@ -14,7 +14,7 @@ if [ -n "$CHPL_WHICH_RELEASE_FOR_ARKOUDA" ]; then
   # removed when we no longer care about testing against that release.
   if [ "$CHPL_WHICH_RELEASE_FOR_ARKOUDA" = "2.2.0" ]; then
     # use LLVM 18, latest supported by 2.2.0
-    if [ -f /hpcdc/project/chapel/setup_system_llvm.bash ] ; then
+    if [ -f /hpcdc/project/chapel/setup_llvm.bash ] ; then
       # Hack to avoid build issues with GMP. Spack installed GMP is pulled in as
       # a dependency of GDB. Then for some reason, it's (undesirably) linked
       # against by the bundled GMP's self-tests, causing them to fail due to
@@ -22,7 +22,7 @@ if [ -n "$CHPL_WHICH_RELEASE_FOR_ARKOUDA" ]; then
       # Anna 2024-06-17
       module unload gdb
 
-      source /hpcdc/project/chapel/setup_system_llvm.bash 18
+      source /hpcdc/project/chapel/setup_llvm.bash 18
     fi
   else
     # Default to using latest LLVM.


### PR DESCRIPTION
Replace uses of `/data/cf/chapel` with `/hpcdc/project/chapel` in nightly test scripts, and update to use the new `setup_[gcc,python,llvm].bash` scripts where possible.

The new scripts take version arguments and always pull from a (new) Spack install, replacing the need for many version-specific scripts and manual installs. I have set up all the scripts referenced in these paths as part of this work.

Also includes some side effects:
- The patch versions of Python 3.6 and Python 3.7 used are changed. Spack only offers the latest patch version of each of these long-EOL versions, so this was more convenient.
- Switched to using a new `setup_llvm.bash` to replace `setup_system_llvm.bash` on `/hpcdc`, which always loads from a new Spack.
- Removed the use of a separate `setup_python_arkouda.bash` for Arkouda, as it seems to now be using the same version as our normal testing.

Part of https://github.com/Cray/chapel-private/issues/5902 and https://github.com/Cray/chapel-private/issues/7042.

[reviewer info placeholder]