### PR TITLE
Remove ClassObject type for Python module

### DIFF
--- a/test/library/packages/Python/correctness/customType.chpl
+++ b/test/library/packages/Python/correctness/customType.chpl
@@ -20,7 +20,7 @@ class myRecConverter: TypeConverter {
   override proc fromPython(interpreter: borrowed Interpreter,
                            type T, obj: Python.CPythonInterface.PyObjectPtr): T throws {
     if T != myRec then halt("Expected myRec");
-    var cls = new ClassObject(interpreter, obj);
+    var cls = new Value(interpreter, obj);
     var res = new myRec(cls.getAttr(int, "x"), cls.getAttr(string, "y"));
     return res;
   }

--- a/test/library/packages/Python/correctness/fromCloudPickle.chpl
+++ b/test/library/packages/Python/correctness/fromCloudPickle.chpl
@@ -11,7 +11,7 @@ var my_function =
                interp.loadPickle(openReader("my_function.pkl").readAll(bytes)));
 
 // run my_function
-var res = my_function(owned ClassObject);
+var res = my_function(owned Value);
 res.call(NoneType, "print");
 
 // create an instance of MyClass

--- a/test/library/packages/Python/correctness/moduleFromBytes.chpl
+++ b/test/library/packages/Python/correctness/moduleFromBytes.chpl
@@ -12,7 +12,7 @@ var MyClass = new Class(mod, "MyClass");
 var my_function = new Function(mod, "my_function");
 
 // run my_function
-var v = my_function(owned ClassObject);
+var v = my_function(owned Value);
 v.call(NoneType, "print");
 
 // create an instance of MyClass

--- a/test/library/packages/Python/examples/bs4/findLinks.chpl
+++ b/test/library/packages/Python/examples/bs4/findLinks.chpl
@@ -25,7 +25,7 @@ proc main() {
   var cls = new Class(mod, "BeautifulSoup");
   var soup = cls(html, 'html.parser');
 
-  var res: list(owned ClassObject?);
+  var res: list(owned Value?);
   res = soup.call(res.type, "find_all", "a");
   for c in res {
     var linkText = c!.getAttr(string, "text");

--- a/test/library/packages/Python/examples/torch/myModel.chpl
+++ b/test/library/packages/Python/examples/torch/myModel.chpl
@@ -22,31 +22,31 @@ proc main() {
 
   // init model weights to 0.9
   {
-    var params = model.call(list(owned ClassObject?), "parameters");
+    var params = model.call(list(owned Value?), "parameters");
     for p in params {
-      var data_ = p!.getAttr(owned ClassObject, "data");
+      var data_ = p!.getAttr(owned Value, "data");
       data_.call(NoneType, "fill_", 0.9);
     }
   }
 
   // run model
-  var pred = model(owned ClassObject, input_tensor);
+  var pred = model(owned Value, input_tensor);
 
   // compute the loss
   var loss_fn = MSELoss();
   var target = tensor(owned Value, [[2.0,]]);
   writeln("Target: ", target);
-  var loss = loss_fn(owned ClassObject, pred, target);
+  var loss = loss_fn(owned Value, pred, target);
   loss.call(NoneType, "backward");
 
   // update the model's parameters
   var learning_rate = 0.01;
-  var params = model.call(list(owned ClassObject?), "parameters");
+  var params = model.call(list(owned Value?), "parameters");
   for p in params {
-    var data = p!.getAttr(owned ClassObject, "data");
-    var grad = p!.getAttr(owned ClassObject, "grad");
-    var temp = grad.call(owned ClassObject, "__mul__", learning_rate);
-    var temp2 = data.call(owned ClassObject, "__sub__", temp);
+    var data = p!.getAttr(owned Value, "data");
+    var grad = p!.getAttr(owned Value, "grad");
+    var temp = grad.call(owned Value, "__mul__", learning_rate);
+    var temp2 = data.call(owned Value, "__sub__", temp);
     p!.setAttr("data", temp2);
   }
 
@@ -54,7 +54,7 @@ proc main() {
   writeln("Loss: ", loss.call(real, "item"));
   writeln("Weights:");
   {
-    var params = model.call(list(owned ClassObject?), "parameters");
+    var params = model.call(list(owned Value?), "parameters");
     for p in params {
       writeln("  ", p!.call(real, "item"));
     }


### PR DESCRIPTION
Removes ClassObject as a special type for the Python module and moves its methods into the Value base class

This PR also adds some missing documention

[Reviewed by @DanilaFe]