### PR TITLE
Update chapcs11 hostname in syncPerfGraphs

### DIFF
--- a/util/cron/syncPerfGraphs.py
+++ b/util/cron/syncPerfGraphs.py
@@ -67,7 +67,7 @@ def syncToCrayWebhost(dirToSync, destDir, logFile, numRetries):
 
     # Assumes correct username and authentication for iad1-shared-b8-21.dreamhost.com is
     # configured for the current system.
-    webHost = 'chapcs11.us.cray.com'
+    webHost = 'chapcs11.hpc.amslabs.hpecorp.net'
     perfBaseDir = '/hpcdc/data/users/chapelu/public_html/perf'
     perfDir = posixpath.join(perfBaseDir, destDir)
 


### PR DESCRIPTION
Update for hostname change from `chapcs11.us.cray.com` to `chapcs11.hpc.amslabs.hpecorp.net`.

[trivial, not reviewed]