### PR TITLE
Fix python setup script not being found

### DIFF
--- a/util/cron/common-python.bash
+++ b/util/cron/common-python.bash
@@ -11,13 +11,13 @@ function set_and_check_python_version() {
   # override `python`
   export PATH=/hpcdc/project/chapel/no-python:$PATH
 
-  local setup_script="/hpcdc/project/chapel/setup_python.bash $major_ver.$minor_ver"
+  local setup_script="/hpcdc/project/chapel/setup_python.bash"
 
   if [[ -f "${setup_script}" ]] ; then
-    source ${setup_script}
+    source ${setup_script} $major_ver.$minor_ver
   else
-    echo "[Warning: cannot find the python configuration script: ${setup_script}]"
-    return 1
+    echo "[Error: cannot find the python configuration script: ${setup_script}]"
+    exit 2
   fi
 
   check_python_version $ver_str


### PR DESCRIPTION
Fix a mistake in which the argument to the new Python setup script was checked as part of its path, so the script was considered missing.

Additionally, switch from a warning to a fatal error if the needed Python setup script is not allowed. This will make it impossible to silently use the wrong Python version as we are before this fix.

Follow up to https://github.com/chapel-lang/chapel/pull/26584.

[trivial fix, not reviewed]