### PR TITLE
Add a future to lock in the behavior when an iterator is unstable 

### DIFF
--- a/test/unstable-keyword/iterator/COMPOPTS
+++ b/test/unstable-keyword/iterator/COMPOPTS
@@ -1,0 +1,1 @@
+--warn-unstable

--- a/test/unstable-keyword/iterator/onlySerial.bad
+++ b/test/unstable-keyword/iterator/onlySerial.bad
@@ -1,0 +1,45 @@
+onlySerial.chpl:5: In function 'main':
+onlySerial.chpl:7: warning: The serial version of foo is unstable
+onlySerial.chpl:13: warning: The serial version of foo is unstable
+onlySerial.chpl:20: warning: The serial version of foo is unstable
+onlySerial.chpl:64: In iterator 'foo':
+onlySerial.chpl:69: warning: range.translate() is unstable and its behavior may change in the future
+  onlySerial.chpl:20: called as foo(param tag = iterKind.leader)
+onlySerial.chpl:76: In iterator 'foo':
+onlySerial.chpl:79: warning: range.translate() is unstable and its behavior may change in the future
+  $CHPL_HOME/modules/internal/ChapelIteratorSupport.chpl:641: called as foo(param tag = iterKind.follower, followThis: 1*range(int(64),both,one))
+  within internal functions (use --print-callstack-on-error to see)
+onlySerial.chpl:5: In function 'main':
+onlySerial.chpl:27: warning: The serial version of foo is unstable
+testing call of serial
+in the serial iterator
+0
+1
+2
+3
+4
+5
+6
+7
+8
+9
+testing call of standalone
+in the standalone iterator
+0 1 2 3 4 5 6 7 8 9
+testing call of leader (and follower)
+in the leader iterator
+in the follower iterator
+in the follower iterator
+in the follower iterator
+in the follower iterator
+in the follower iterator
+in the follower iterator
+0 2 4 6 8 10 12 14 16 18
+testing call of just follower
+in the follower iterator
+in the follower iterator
+in the follower iterator
+in the follower iterator
+in the follower iterator
+in the follower iterator
+0 3 6 9 12 15 18 21 24 27

--- a/test/unstable-keyword/iterator/onlySerial.bad
+++ b/test/unstable-keyword/iterator/onlySerial.bad
@@ -1,16 +1,16 @@
-onlySerial.chpl:5: In function 'main':
-onlySerial.chpl:7: warning: The serial version of foo is unstable
-onlySerial.chpl:13: warning: The serial version of foo is unstable
-onlySerial.chpl:20: warning: The serial version of foo is unstable
-onlySerial.chpl:64: In iterator 'foo':
-onlySerial.chpl:69: warning: range.translate() is unstable and its behavior may change in the future
-  onlySerial.chpl:20: called as foo(param tag = iterKind.leader)
-onlySerial.chpl:76: In iterator 'foo':
-onlySerial.chpl:79: warning: range.translate() is unstable and its behavior may change in the future
+onlySerial.chpl:7: In function 'main':
+onlySerial.chpl:9: warning: The serial version of foo is unstable
+onlySerial.chpl:15: warning: The serial version of foo is unstable
+onlySerial.chpl:22: warning: The serial version of foo is unstable
+onlySerial.chpl:68: In iterator 'foo':
+onlySerial.chpl:73: warning: range.translate() is unstable and its behavior may change in the future
+  onlySerial.chpl:22: called as foo(param tag = iterKind.leader)
+onlySerial.chpl:80: In iterator 'foo':
+onlySerial.chpl:85: warning: range.translate() is unstable and its behavior may change in the future
   $CHPL_HOME/modules/internal/ChapelIteratorSupport.chpl:641: called as foo(param tag = iterKind.follower, followThis: 1*range(int(64),both,one))
   within internal functions (use --print-callstack-on-error to see)
-onlySerial.chpl:5: In function 'main':
-onlySerial.chpl:27: warning: The serial version of foo is unstable
+onlySerial.chpl:7: In function 'main':
+onlySerial.chpl:31: warning: The serial version of foo is unstable
 testing call of serial
 in the serial iterator
 0
@@ -28,18 +28,8 @@ in the standalone iterator
 0 1 2 3 4 5 6 7 8 9
 testing call of leader (and follower)
 in the leader iterator
-in the follower iterator
-in the follower iterator
-in the follower iterator
-in the follower iterator
-in the follower iterator
-in the follower iterator
+in the follower iterator at least once
 0 2 4 6 8 10 12 14 16 18
 testing call of just follower
-in the follower iterator
-in the follower iterator
-in the follower iterator
-in the follower iterator
-in the follower iterator
-in the follower iterator
+in the follower iterator at least once
 0 3 6 9 12 15 18 21 24 27

--- a/test/unstable-keyword/iterator/onlySerial.chpl
+++ b/test/unstable-keyword/iterator/onlySerial.chpl
@@ -1,0 +1,83 @@
+// Tests behavior when a serial iterator is declared unstable (but none of the
+// others are)
+var rangeToUse = 0..9;
+
+proc main() {
+  writeln("testing call of serial");
+  for i in foo() {
+    writeln(i);
+  }
+
+  writeln("testing call of standalone");
+  var arr1: [rangeToUse] int;
+  forall i in foo() {
+    arr1[i] = i;
+  }
+  writeln(arr1);
+
+  writeln("testing call of leader (and follower)");
+  var arr2: [rangeToUse] int;
+  forall (val, loc) in zip(foo(), arr2) {
+    loc = val*2;
+  }
+  writeln(arr2);
+
+  writeln("testing call of just follower");
+  var arr3: [rangeToUse] int;
+  forall (loc, val) in zip(arr3, foo()) {
+    loc = val*3;
+  }
+  writeln(arr3);
+}
+
+@unstable("The serial version of foo is unstable")
+iter foo() {
+  writeln("in the serial iterator");
+  for i in rangeToUse {
+    yield i;
+  }
+}
+
+iter foo(param tag) where tag == iterKind.standalone {
+  writeln("in the standalone iterator");
+  for i in rangeToUse {
+    yield i;
+  }
+}
+
+// Stolen from the parallel iterators primer
+proc computeChunk(r: range, myChunk, numChunks) {
+  const numElems = r.size;
+  const elemsperChunk = numElems/numChunks;
+  const rem = numElems%numChunks;
+  var mylow = r.low;
+  if myChunk < rem {
+    mylow += (elemsperChunk+1)*myChunk;
+    return mylow..#(elemsperChunk + 1);
+  } else {
+    mylow += ((elemsperChunk+1)*rem + (elemsperChunk)*(myChunk-rem));
+    return mylow..#elemsperChunk;
+  }
+}
+
+// Partially stolen from the parallel iterators primer
+iter foo(param tag) where tag == iterKind.leader {
+  writeln("in the leader iterator");
+
+  coforall tid in 0..#here.maxTaskPar {
+    const myIters = computeChunk(rangeToUse, tid, here.maxTaskPar);
+    const zeroBasedIters = myIters.translate(-rangeToUse.low);
+
+    yield (zeroBasedIters,);
+  }
+}
+
+// Also stolen from the parallel iterators primer
+iter foo(param tag, followThis) where tag == iterKind.follower {
+  writeln("in the follower iterator");
+  const (followInds,) = followThis;
+  const lowBasedIters = followInds.translate(rangeToUse.low);
+
+  for i in lowBasedIters do
+    yield i;
+}

--- a/test/unstable-keyword/iterator/onlySerial.chpl
+++ b/test/unstable-keyword/iterator/onlySerial.chpl
@@ -2,6 +2,8 @@
 // others are)
 var rangeToUse = 0..9;
 
+var triggeredFollower: atomic bool = false;
+
 proc main() {
   writeln("testing call of serial");
   for i in foo() {
@@ -21,6 +23,8 @@ proc main() {
     loc = val*2;
   }
   writeln(arr2);
+
+  triggeredFollower.clear();
 
   writeln("testing call of just follower");
   var arr3: [rangeToUse] int;
@@ -74,7 +78,9 @@ iter foo(param tag) where tag == iterKind.leader {
 
 // Also stolen from the parallel iterators primer
 iter foo(param tag, followThis) where tag == iterKind.follower {
-  writeln("in the follower iterator");
+  if (triggeredFollower.testAndSet() == false) {
+    writeln("in the follower iterator at least once");
+  }
   const (followInds,) = followThis;
   const lowBasedIters = followInds.translate(rangeToUse.low);
 

--- a/test/unstable-keyword/iterator/onlySerial.future
+++ b/test/unstable-keyword/iterator/onlySerial.future
@@ -1,0 +1,2 @@
+bug: unstable warnings on iterator overloads trigger too often
+#TBD

--- a/test/unstable-keyword/iterator/onlySerial.future
+++ b/test/unstable-keyword/iterator/onlySerial.future
@@ -1,2 +1,2 @@
 bug: unstable warnings on iterator overloads trigger too often
-#TBD
+#26590

--- a/test/unstable-keyword/iterator/onlySerial.good
+++ b/test/unstable-keyword/iterator/onlySerial.good
@@ -1,10 +1,10 @@
-onlySerial.chpl:5: In function 'main':
-onlySerial.chpl:7: warning: The serial version of foo is unstable
-onlySerial.chpl:64: In iterator 'foo':
-onlySerial.chpl:69: warning: range.translate() is unstable and its behavior may change in the future
-  onlySerial.chpl:20: called as foo(param tag = iterKind.leader)
-onlySerial.chpl:76: In iterator 'foo':
-onlySerial.chpl:79: warning: range.translate() is unstable and its behavior may change in the future
+onlySerial.chpl:7: In function 'main':
+onlySerial.chpl:9: warning: The serial version of foo is unstable
+onlySerial.chpl:68: In iterator 'foo':
+onlySerial.chpl:73: warning: range.translate() is unstable and its behavior may change in the future
+  onlySerial.chpl:22: called as foo(param tag = iterKind.leader)
+onlySerial.chpl:80: In iterator 'foo':
+onlySerial.chpl:85: warning: range.translate() is unstable and its behavior may change in the future
   $CHPL_HOME/modules/internal/ChapelIteratorSupport.chpl:641: called as foo(param tag = iterKind.follower, followThis: 1*range(int(64),both,one))
   within internal functions (use --print-callstack-on-error to see)
 testing call of serial
@@ -24,18 +24,8 @@ in the standalone iterator
 0 1 2 3 4 5 6 7 8 9
 testing call of leader (and follower)
 in the leader iterator
-in the follower iterator
-in the follower iterator
-in the follower iterator
-in the follower iterator
-in the follower iterator
-in the follower iterator
+in the follower iterator at least once
 0 2 4 6 8 10 12 14 16 18
 testing call of just follower
-in the follower iterator
-in the follower iterator
-in the follower iterator
-in the follower iterator
-in the follower iterator
-in the follower iterator
+in the follower iterator at least once
 0 3 6 9 12 15 18 21 24 27

--- a/test/unstable-keyword/iterator/onlySerial.good
+++ b/test/unstable-keyword/iterator/onlySerial.good
@@ -1,0 +1,41 @@
+onlySerial.chpl:5: In function 'main':
+onlySerial.chpl:7: warning: The serial version of foo is unstable
+onlySerial.chpl:64: In iterator 'foo':
+onlySerial.chpl:69: warning: range.translate() is unstable and its behavior may change in the future
+  onlySerial.chpl:20: called as foo(param tag = iterKind.leader)
+onlySerial.chpl:76: In iterator 'foo':
+onlySerial.chpl:79: warning: range.translate() is unstable and its behavior may change in the future
+  $CHPL_HOME/modules/internal/ChapelIteratorSupport.chpl:641: called as foo(param tag = iterKind.follower, followThis: 1*range(int(64),both,one))
+  within internal functions (use --print-callstack-on-error to see)
+testing call of serial
+in the serial iterator
+0
+1
+2
+3
+4
+5
+6
+7
+8
+9
+testing call of standalone
+in the standalone iterator
+0 1 2 3 4 5 6 7 8 9
+testing call of leader (and follower)
+in the leader iterator
+in the follower iterator
+in the follower iterator
+in the follower iterator
+in the follower iterator
+in the follower iterator
+in the follower iterator
+0 2 4 6 8 10 12 14 16 18
+testing call of just follower
+in the follower iterator
+in the follower iterator
+in the follower iterator
+in the follower iterator
+in the follower iterator
+in the follower iterator
+0 3 6 9 12 15 18 21 24 27


### PR DESCRIPTION
See #26590 .  Basically, marking any iterator as unstable will cause the unstable warning to fire, even if that particular iterator is not used.  This test demonstrates the issue for serial iterators, but standalone, leader, and follower iterators were also exhibiting the same behavior (and I suspect will be solved by the same solution).

