### PR TITLE
Allow passing Chapel arrays to Python functions without copying

### DIFF
--- a/modules/packages/Python.chpl
+++ b/modules/packages/Python.chpl
@@ -291,7 +291,7 @@ module Python {
       important for correctness, but may have a performance impact.
 
       See :config:`Python.checkExceptions` and
-      :method:`Interpreter.checkException` for more information.
+      :proc:`Interpreter.checkException` for more information.
     */
     // param checkExceptions: bool = Python.checkExceptions;
 
@@ -1505,14 +1505,14 @@ module Python {
 
     .. note::
 
-       While Chapel arrays can be indexed arbitrarily by specifing a domain
+       While Chapel arrays can be indexed arbitrarily by specifying a domain
        (e.g. ``var myArr: [2..by 4 #2]``), the equivalent Python array will
        also by indexed starting at 0 with a stride of 1. Methods like
-       :method:`~Array.getItem` do no translation of the domain and should be
+       :proc:`~Array.getItem` do no translation of the domain and should be
        called with the Python interpretation of the index.
 
 
-    To pass a Chapel array to a Python function, you would normallly
+    To pass a Chapel array to a Python function, you would normally
     just use the Chapel array directly, resulting in the data being copied in.
     To avoid this copy, first create an :type:`Array` object, then pass that to
     the Python function.

--- a/modules/packages/Python.chpl
+++ b/modules/packages/Python.chpl
@@ -1441,7 +1441,6 @@ module Python {
 
 
   // TODO: create adapters for other common Python types like Set, Dict, Tuple
-  // TODO: provide iteration directly on these types with a serial iterator
   /*
     Represents a Python list. This provides a Chapel interface to Python lists,
     where the Python interpreter owns the list.

--- a/modules/packages/Python.chpl
+++ b/modules/packages/Python.chpl
@@ -19,17 +19,7 @@
  */
 
 
-// TODO: manufacture a custom ArrayAdapter for Chapel arrays, allows for easy conversion to python types without copying
-//  this can be done in a few ways.
-//   1. create a class that wraps the array and implements the python list interface
-//   2. create a class that wraps the array and implements the numpy array interface
-
 //  TODO: represent python context managers as Chapel context managers
-
-// TODO: create adapters for common Python types that are subclasses of a Value class
-// this will prevent needing to round trip through python for some operations
-// for example, a List, Set, Dict, Tuple, etc.
-// these should provide native like operation, so `for i in pyList` should work
 
 // TODO: implement operators as dunder methods
 
@@ -278,6 +268,10 @@ module Python {
     return sep;
   }
 
+  private proc throwNewChapelException(message: string) throws {
+    throw new ChapelException(message);
+  }
+
   /*
     Represents the python interpreter. All code using the Python module should
     create and maintain a single instance of this class.
@@ -369,6 +363,11 @@ module Python {
       // I think we can do this by setting sys.stdout and sys.stderr to a python
       // object that looks like a python file but forwards calls like write to
       // Chapel's write
+
+      // init Array shim types
+      if createArrayShimType() == 0 {
+        throwNewChapelException("Failed to create array shim type");
+      }
 
       if pyMemLeaks {
         // import objgraph
@@ -502,7 +501,7 @@ module Python {
     proc compileModule(b: bytes,
                        modname: string = "chplmod"): PyObjectPtr throws {
       var code =
-        PyMarshal_ReadObjectFromString(b.c_str(), b.size.safeCast(c_size_t));
+        PyMarshal_ReadObjectFromString(b.c_str(), b.size.safeCast(Py_ssize_t));
       this.checkException();
       defer Py_DECREF(code);
 
@@ -637,7 +636,7 @@ module Python {
         return v;
       } else if t == bytes {
         var v =
-          PyBytes_FromStringAndSize(val.c_str(), val.size.safeCast(c_size_t));
+          PyBytes_FromStringAndSize(val.c_str(), val.size.safeCast(Py_ssize_t));
         this.checkException();
         return v;
       } else if isArrayType(t) && val.rank == 1 && val.isDefaultRectangular(){
@@ -669,6 +668,16 @@ module Python {
          a :type:`TypeConverter`.
     */
     proc fromPython(type t, obj: PyObjectPtr): t throws {
+      if isClassType(t) &&
+         (!isSharedClassType(t) &&
+          !isOwnedClassType(t) &&
+          !isUnmanagedClassType(t)) {
+        compilerError("fromPython only supports shared, owned, and unmanaged classes");
+      }
+      if isSubtype(t, Array?) {
+        compilerError("Cannot create an Array from an existing PyObject");
+      }
+
       for converter in this.converters {
         if converter.handlesType(t) {
           return converter.fromPython(this, t, obj);
@@ -735,11 +744,11 @@ module Python {
     proc toList(arr): PyObjectPtr throws
       where isArrayType(arr.type) &&
             arr.rank == 1 && arr.isDefaultRectangular() {
-      var pyList = PyList_New(arr.size.safeCast(c_size_t));
+      var pyList = PyList_New(arr.size.safeCast(Py_ssize_t));
       this.checkException();
       for i in 0..<arr.size {
         const idx = arr.domain.orderToIndex(i);
-        PyList_SetItem(pyList, i.safeCast(c_size_t), toPython(arr[idx]));
+        PyList_SetItem(pyList, i.safeCast(Py_ssize_t), toPython(arr[idx]));
         this.checkException();
       }
       return pyList;
@@ -750,10 +759,10 @@ module Python {
     */
     @chpldoc.nodoc
     proc toList(l: List.list(?)): PyObjectPtr throws {
-      var pyList = PyList_New(l.size.safeCast(c_size_t));
+      var pyList = PyList_New(l.size.safeCast(Py_ssize_t));
       this.checkException();
       for i in 0..<l.size {
-        PyList_SetItem(pyList, i.safeCast(c_size_t), toPython(l(i)));
+        PyList_SetItem(pyList, i.safeCast(Py_ssize_t), toPython(l(i)));
         this.checkException();
       }
       return pyList;
@@ -771,12 +780,12 @@ module Python {
 
       // if its a sequence with a known size, we can just iterate over it
       var res: T;
-      if PySequence_Size(obj) != res.size.safeCast(c_size_t) {
+      if PySequence_Size(obj) != res.size.safeCast(Py_ssize_t) {
         throw new ChapelException("Size mismatch");
       }
       for i in 0..<res.size {
         const idx = res.domain.orderToIndex(i);
-        var elm = PySequence_GetItem(obj, i.safeCast(c_size_t));
+        var elm = PySequence_GetItem(obj, i.safeCast(Py_ssize_t));
         this.checkException();
         res[idx] = fromPython(res.eltType, elm);
         this.checkException();
@@ -1195,7 +1204,7 @@ module Python {
       }
       defer for pyArg in pyArgs do Py_DECREF(pyArg);
 
-      var pyArg = PyTuple_Pack(args.size.safeCast(c_size_t), (...pyArgs));
+      var pyArg = PyTuple_Pack(args.size.safeCast(Py_ssize_t), (...pyArgs));
       interpreter.checkException();
 
       return pyArg;
@@ -1431,6 +1440,156 @@ module Python {
   }
 
 
+  // TODO: create adapters for other common Python types like Set, Dict, Tuple
+  // TODO: provide iteration directly on these types with a serial iterator
+  /*
+    Represents a Python list. This provides a Chapel interface to Python lists,
+    where the Python interpreter owns the list.
+  */
+  class PyList: Value {
+    @chpldoc.nodoc
+    proc init(in interpreter: borrowed Interpreter,
+              in obj: PyObjectPtr, isOwned: bool = true) {
+      super.init(interpreter, obj, isOwned=isOwned);
+    }
+
+    /*
+      Get the size of the list. Equivalent to calling ``len(obj)`` in Python.
+
+      :returns: The size of the list.
+    */
+    proc size: int throws {
+      var size = PyList_Size(this.get());
+      this.check();
+      return size;
+    }
+
+    /*
+      Get an item from the list. Equivalent to calling ``obj[idx]`` in Python.
+
+      :arg T: The Chapel type of the item to return.
+      :arg idx: The index of the item to get.
+      :returns: The item at the given index.
+    */
+    proc getItem(type T, idx: int): T throws {
+      var item = PyList_GetItem(this.get(), idx.safeCast(Py_ssize_t));
+      this.check();
+      return interpreter.fromPython(T, item);
+    }
+    /*
+      Set an item in the list. Equivalent to calling ``obj[idx] = item`` in
+      Python.
+
+      :arg idx: The index of the item to set.
+      :arg item: The item to set.
+    */
+    proc setItem(idx: int, item: ?) throws {
+      PyList_SetItem(this.get(),
+                     idx.safeCast(Py_ssize_t),
+                     interpreter.toPython(item));
+      this.check();
+    }
+  }
+
+  @chpldoc.nodoc
+  proc isSupportedArrayType(arr) param : bool {
+    return isArrayType(arr.type) &&
+           arr.rank == 1 &&
+           arr.idxType == int &&
+           arr.isDefaultRectangular();
+  }
+
+  /*
+    Represents a handle to a Chapel array that is usable by Python code. This
+    allows code to pass Chapel arrays to Python without copying the data. This
+    only works for 1D local rectangular arrays.
+
+    .. note::
+
+       While Chapel arrays can be indexed arbitrarily by specifing a domain
+       (e.g. ``var myArr: [2..by 4 #2]``), the equivalent Python array will
+       also by indexed starting at 0 with a stride of 1. Methods like
+       :method:`~Array.getItem` do no translation of the domain and should be
+       called with the Python interpretation of the index.
+
+
+    To pass a Chapel array to a Python function, you would normallly
+    just use the Chapel array directly, resulting in the data being copied in.
+    To avoid this copy, first create an :type:`Array` object, then pass that to
+    the Python function.
+
+    For example,
+
+    .. code-block:: chapel
+
+       myPythonFunction(NoneType, myChapelArray); // copies the data
+       var arr = new Array(interpreter, myChapelArray);
+       myPythonFunction(NoneType, arr); // no copy is done
+
+    .. warning::
+
+       If the array is invalidated or deallocated in Chapel, the Python code
+       will crash when it tries to access the array.
+  */
+  class Array: Value {
+    @chpldoc.nodoc
+    type eltType = nothing;
+    // TODO: call proper function for proper array type
+    /*
+      Create a new :type:`Array` object from a Chapel array.
+
+      :arg interpreter: The interpreter that this object is associated with.
+      :arg arr: The Chapel array to create the object from.
+    */
+    proc init(in interpreter: borrowed Interpreter, ref arr: []) throws
+      where isSupportedArrayType(arr) {
+      super.init(interpreter,
+                 createArrayShim(c_ptrTo(arr), arr.size.safeCast(Py_ssize_t)),
+                 isOwned=true);
+      this.eltType = arr.eltType;
+    }
+    @chpldoc.nodoc
+    proc init(in interpreter: borrowed Interpreter, ref arr: []) throws
+      where !isSupportedArrayType(arr) {
+      compilerError("Only 1D local rectangular arrays are currently supported");
+      this.eltType = nothing;
+    }
+    @chpldoc.nodoc
+    proc init(in interpreter: borrowed Interpreter,
+              in obj: PyObjectPtr, isOwned: bool = true) {
+      compilerError("Cannot create an Array from an existing PyObject");
+      this.eltType = nothing;
+    }
+
+    /*
+      Get the size of the array. Equivalent to calling ``len(obj)`` in Python or
+      ``originalArray.size`` in Chapel.
+
+      :returns: The size of the array.
+    */
+    proc size: int throws do
+      return this.call(int, "__len__");
+    /*
+      Get an item from the array. Equivalent to calling ``obj[idx]`` in Python
+      or ``originalArray[idx]`` in Chapel.
+
+      :arg idx: The index of the item to get.
+      :returns: The item at the given index.
+    */
+    proc getItem(idx: int): eltType throws do
+      return this.call(eltType, "__getitem__", idx);
+    /*
+      Set an item in the array. Equivalent to calling ``obj[idx] = item`` in
+      Python or ``originalArray[idx] = item`` in Chapel.
+
+      :arg idx: The index of the item to set.
+      :arg item: The item to set.
+    */
+    proc setItem(idx: int, item: eltType) throws do
+      this.call(NoneType, "__setitem__", idx, item);
+  }
+
+
   /*
     Represents the Global Interpreter Lock, this is used to ensure that only one
     thread is executing python code at a time. Each thread should have its own
@@ -1547,10 +1706,30 @@ module Python {
   }
 
   Value implements writeSerializable;
+  Function implements writeSerializable;
+  Module implements writeSerializable;
+  Class implements writeSerializable;
+  PyList implements writeSerializable;
   NoneType implements writeSerializable;
 
   @chpldoc.nodoc
   override proc Value.serialize(writer, ref serializer) throws do
+    writer.write(this:string);
+
+  @chpldoc.nodoc
+  override proc Function.serialize(writer, ref serializer) throws do
+    writer.write(this:string);
+
+  @chpldoc.nodoc
+  override proc Module.serialize(writer, ref serializer) throws do
+    writer.write(this:string);
+
+  @chpldoc.nodoc
+  override proc Class.serialize(writer, ref serializer) throws do
+    writer.write(this:string);
+
+  @chpldoc.nodoc
+  override proc PyList.serialize(writer, ref serializer) throws do
     writer.write(this:string);
 
   @chpldoc.nodoc
@@ -1582,6 +1761,7 @@ module Python {
     require "PythonHelper/ChapelPythonHelper.h";
     private use CTypes;
     private use super.CWChar;
+    import HaltWrappers;
 
 
 
@@ -1592,6 +1772,11 @@ module Python {
     type PyObjectPtr = c_ptr(PyObject);
     extern type PyTypeObject;
     type PyTypeObjectPtr = c_ptr(PyTypeObject);
+
+    // technically this is an extern type defined by python, but if we treat it
+    // as an opaque type, we can't use it in Chapel code in casts and such.
+    // using c_ssize_t should be sufficient and safe
+    type Py_ssize_t = c_ssize_t;
 
     extern type PyThreadState;
     type PyThreadStatePtr = c_ptr(PyThreadState);
@@ -1685,7 +1870,7 @@ module Python {
     extern proc PyImport_ExecCodeModule(name: c_ptrConst(c_char),
                                         code: PyObjectPtr): PyObjectPtr;
     extern proc PyMarshal_ReadObjectFromString(data: c_ptrConst(c_char),
-                                               size: c_size_t): PyObjectPtr;
+                                               size: Py_ssize_t): PyObjectPtr;
 
 
     /*
@@ -1722,9 +1907,9 @@ module Python {
     extern proc PyString_FromString(s: c_ptrConst(c_char)): PyObjectPtr;
     extern proc PyUnicode_AsUTF8(obj: PyObjectPtr): c_ptrConst(c_char);
     extern proc PyBytes_AsString(obj: PyObjectPtr): c_ptrConst(c_char);
-    extern proc PyBytes_Size(obj: PyObjectPtr): c_size_t;
+    extern proc PyBytes_Size(obj: PyObjectPtr): Py_ssize_t;
     extern proc PyBytes_FromStringAndSize(s: c_ptrConst(c_char),
-                                          size: c_size_t): PyObjectPtr;
+                                          size: Py_ssize_t): PyObjectPtr;
 
     proc Py_None: PyObjectPtr {
       extern proc chpl_Py_None(): PyObjectPtr;
@@ -1743,11 +1928,11 @@ module Python {
       Sequences
     */
     extern proc PySequence_Check(obj: PyObjectPtr): c_int;
-    extern proc PySequence_Size(obj: PyObjectPtr): c_size_t;
+    extern proc PySequence_Size(obj: PyObjectPtr): Py_ssize_t;
     extern proc PySequence_GetItem(obj: PyObjectPtr,
-                                   idx: c_size_t): PyObjectPtr;
+                                   idx: Py_ssize_t): PyObjectPtr;
     extern proc PySequence_SetItem(obj: PyObjectPtr,
-                                   idx: c_size_t,
+                                   idx: Py_ssize_t,
                                    value: PyObjectPtr);
 
 
@@ -1762,14 +1947,14 @@ module Python {
       Lists
     */
     extern proc PyList_Check(obj: PyObjectPtr): c_int;
-    extern proc PyList_New(size: c_size_t): PyObjectPtr;
+    extern proc PyList_New(size: Py_ssize_t): PyObjectPtr;
     extern proc PyList_SetItem(list: PyObjectPtr,
-                               idx: c_size_t,
+                               idx: Py_ssize_t,
                                item: PyObjectPtr);
-    extern proc PyList_GetItem(list: PyObjectPtr, idx: c_size_t): PyObjectPtr;
-    extern proc PyList_Size(list: PyObjectPtr): c_size_t;
+    extern proc PyList_GetItem(list: PyObjectPtr, idx: Py_ssize_t): PyObjectPtr;
+    extern proc PyList_Size(list: PyObjectPtr): Py_ssize_t;
     extern proc PyList_Insert(list: PyObjectPtr,
-                              idx: c_size_t,
+                              idx: Py_ssize_t,
                               item: PyObjectPtr);
     extern proc PyList_Append(list: PyObjectPtr, item: PyObjectPtr);
 
@@ -1778,7 +1963,7 @@ module Python {
     */
     extern proc PySet_New(): PyObjectPtr;
     extern proc PySet_Add(set: PyObjectPtr, item: PyObjectPtr);
-    extern proc PySet_Size(set: PyObjectPtr): c_size_t;
+    extern proc PySet_Size(set: PyObjectPtr): Py_ssize_t;
 
 
     /*
@@ -1795,7 +1980,7 @@ module Python {
                                key: PyObjectPtr): PyObjectPtr;
     extern proc PyDict_GetItemString(dict: PyObjectPtr,
                                      key: c_ptrConst(c_char)): PyObjectPtr;
-    extern proc PyDict_Size(dict: PyObjectPtr): c_size_t;
+    extern proc PyDict_Size(dict: PyObjectPtr): Py_ssize_t;
     extern proc PyDict_Keys(dict: PyObjectPtr): PyObjectPtr;
 
     extern proc PyObject_GetAttrString(obj: PyObjectPtr,
@@ -1807,7 +1992,7 @@ module Python {
     /*
       Tuples
     */
-    extern proc PyTuple_Pack(size: c_size_t, args...): PyObjectPtr;
+    extern proc PyTuple_Pack(size: Py_ssize_t, args...): PyObjectPtr;
 
     /*
       Functions
@@ -1828,6 +2013,10 @@ module Python {
     extern proc PyObject_CallMethodObjArgs(obj: PyObjectPtr,
                                            method: PyObjectPtr,
                                            args...): PyObjectPtr;
+
+    extern proc createArrayShimType(): int;
+    extern proc createArrayShim(data: c_ptr(int(64)),
+                                size: Py_ssize_t): PyObjectPtr;
 
   }
 }

--- a/modules/packages/Python.chpl
+++ b/modules/packages/Python.chpl
@@ -366,7 +366,7 @@ module Python {
       // Chapel's write
 
       if !ArrayTypes.createArrayTypes() {
-        throwChapelException("Failed to create array types");
+        throwChapelException("Failed to create Python array types for Chapel arrays");
       }
 
       if pyMemLeaks {
@@ -1522,6 +1522,7 @@ module Python {
     .. code-block:: chapel
 
        myPythonFunction(NoneType, myChapelArray); // copies the data
+
        var arr = new Array(interpreter, myChapelArray);
        myPythonFunction(NoneType, arr); // no copy is done
 
@@ -1533,7 +1534,6 @@ module Python {
   class Array: Value {
     @chpldoc.nodoc
     type eltType = nothing;
-    // TODO: call proper function for proper array type
     /*
       Create a new :type:`Array` object from a Chapel array.
 

--- a/modules/packages/PythonHelper/ArrayTypes.c
+++ b/modules/packages/PythonHelper/ArrayTypes.c
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2020-2025 Hewlett Packard Enterprise Development LP
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ArrayTypes.h"
+
+#define chpl_MAKE_ARRAY_STRUCT(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, _0, _1, _2) \
+  typedef struct { \
+    PyObject_HEAD \
+    DATATYPE* data; \
+    Py_ssize_t size; \
+  } Array##NAMESUFFIX##Object; \
+  PyTypeObject* Array##NAMESUFFIX##Type = NULL;
+chpl_ARRAY_TYPES(chpl_MAKE_ARRAY_STRUCT)
+#undef chpl_MAKE_ARRAY_STRUCT
+
+static int ArrayGenericObject_init(PyObject* self, PyObject* args, PyObject* kwargs) {
+  return 0;
+}
+#define chpl_MAKE_DEALLOC(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, _0, _1, _2) \
+  static void Array##NAMESUFFIX##Object_dealloc(Array##NAMESUFFIX##Object* self) { \
+    void (*tp_free)(PyObject*) = (void (*)(PyObject*))(PyType_GetSlot(Array##NAMESUFFIX##Type, Py_tp_free)); \
+    if (!tp_free) PyErr_SetString(PyExc_RuntimeError, "Could not free object"); \
+    else          tp_free((PyObject*) self); \
+  }
+chpl_ARRAY_TYPES(chpl_MAKE_DEALLOC)
+#undef chpl_MAKE_DEALLOC
+
+
+#define chpl_MAKE_REPR(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, _0, _1, _2) \
+  static PyObject* Array##NAMESUFFIX##Object_repr(Array##NAMESUFFIX##Object* self) { \
+    return PyUnicode_FromFormat("Array(eltType="CHAPELDATATYPE",size=%zd)", self->size); \
+  }
+chpl_ARRAY_TYPES(chpl_MAKE_REPR)
+#undef chpl_MAKE_REPR
+
+// TODO: how can we remove the error checking here with --no-checks or -scheckExceptions=false?
+#define chpl_MAKE_SETITEM(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, CHECKTYPE, ASTYPE, _0) \
+  static int Array##NAMESUFFIX##Object_setitem(Array##NAMESUFFIX##Object* self, Py_ssize_t index, PyObject* value) { \
+    if (!CHECKTYPE(value)) { \
+      PyErr_SetString(PyExc_TypeError, "can only assign "CHAPELDATATYPE" to this array"); \
+      return -1; \
+    } \
+    DATATYPE val = ASTYPE(value); \
+    if (PyErr_Occurred()) return -1; \
+    if (index < 0 || index >= self->size) { \
+      PyErr_SetString(PyExc_IndexError, "index out of bounds"); \
+      return -1; \
+    } \
+    self->data[index] = val; \
+    return 0; \
+  }
+chpl_ARRAY_TYPES(chpl_MAKE_SETITEM)
+#undef chpl_MAKE_SETITEM
+#define chpl_MAKE_GETITEM(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, CHECKTYPE, ASTYPE, FROMTYPE) \
+  static PyObject* Array##NAMESUFFIX##Object_getitem(Array##NAMESUFFIX##Object* self, Py_ssize_t index) { \
+    if (index < 0 || index >= self->size) { \
+      PyErr_SetString(PyExc_IndexError, "index out of bounds"); \
+      return NULL; \
+    } \
+    return FROMTYPE(self->data[index]); \
+  }
+chpl_ARRAY_TYPES(chpl_MAKE_GETITEM)
+#undef chpl_MAKE_GETITEM
+
+#define chpl_MAKE_LENGTH(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, _0, _1, _2) \
+  static Py_ssize_t Array##NAMESUFFIX##Object_length(Array##NAMESUFFIX##Object* self) { \
+    return self->size; \
+  }
+chpl_ARRAY_TYPES(chpl_MAKE_LENGTH)
+#undef chpl_MAKE_LENGTH
+
+
+#define chpl_MAKE_TYPE(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, _0, _1, _2) \
+  static chpl_bool createArray##NAMESUFFIX##Type(void) { \
+    PyType_Slot slots[] = { \
+      {Py_tp_init, (void*) ArrayGenericObject_init}, \
+      {Py_tp_dealloc, (void*) Array##NAMESUFFIX##Object_dealloc}, \
+      {Py_tp_doc, (void*) PyDoc_STR("Array" #NAMESUFFIX "Object")}, \
+      {Py_tp_new, (void*) PyType_GenericNew}, \
+      {Py_tp_repr, (void*) Array##NAMESUFFIX##Object_repr}, \
+      {Py_sq_ass_item, (void*) Array##NAMESUFFIX##Object_setitem}, \
+      {Py_sq_item, (void*) Array##NAMESUFFIX##Object_getitem}, \
+      {Py_mp_length, (void*)Array##NAMESUFFIX##Object_length}, \
+      {0, NULL} \
+    }; \
+    PyType_Spec spec = { \
+      /*name*/ "Array"#NAMESUFFIX, \
+      /*basicsize*/ sizeof(Array##NAMESUFFIX##Object), \
+      /*itemsize*/ 0, \
+      /*flags*/ Py_TPFLAGS_DEFAULT, \
+      /*slots*/ slots \
+    }; \
+    Array##NAMESUFFIX##Type = (PyTypeObject*)PyType_FromSpec(&spec); \
+    if (!Array##NAMESUFFIX##Type || PyType_Ready(Array##NAMESUFFIX##Type) < 0) return false; \
+    return true; \
+  }
+chpl_ARRAY_TYPES(chpl_MAKE_TYPE)
+#undef chpl_MAKE_TYPE
+
+chpl_bool createArrayTypes(void) {
+#define chpl_MAKE_TYPE(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, _0, _1, _2) \
+  if (!createArray##NAMESUFFIX##Type()) return false;
+chpl_ARRAY_TYPES(chpl_MAKE_TYPE)
+#undef chpl_MAKE_TYPE
+  return true;
+}
+
+#define chpl_CREATE_ARRAY(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, _0, _1, _2) \
+  PyObject* createArray##NAMESUFFIX(DATATYPE* data, Py_ssize_t size) { \
+    assert(Array##NAMESUFFIX##Type); \
+    PyObject* objPy = PyObject_CallNoArgs((PyObject *) Array##NAMESUFFIX##Type); \
+    Array##NAMESUFFIX##Object* obj = (Array##NAMESUFFIX##Object*) objPy; \
+    if (!obj) return NULL; \
+    obj->data = data; \
+    obj->size = size; \
+    return objPy; \
+  }
+chpl_ARRAY_TYPES(chpl_CREATE_ARRAY)
+#undef chpl_CREATE_ARRAY

--- a/modules/packages/PythonHelper/ArrayTypes.h
+++ b/modules/packages/PythonHelper/ArrayTypes.h
@@ -28,7 +28,7 @@
 // TODO: for some of the smaller types, when comsuming a PyObject we should check
 // if it will fit in the C type, and if not raise an error.
 //
-// args
+// args:
 // C datatype
 // Chapel datatype
 // array suffix

--- a/modules/packages/PythonHelper/ArrayTypes.h
+++ b/modules/packages/PythonHelper/ArrayTypes.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020-2025 Hewlett Packard Enterprise Development LP
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CHPL_PYTHON_HELPER_ARRAY_TYPES_H_
+#define CHPL_PYTHON_HELPER_ARRAY_TYPES_H_
+
+#include "ChapelPythonHelper.h"
+#include <stdint.h>
+#include "chpltypes.h"
+
+// TODO: for some of the smaller types, when comsuming a PyObject we should check
+// if it will fit in the C type, and if not raise an error.
+//
+// args
+// C datatype
+// Chapel datatype
+// array suffix
+// python check function
+// consuming PyObject function
+// producing PyObject function
+//
+#define chpl_ARRAY_TYPES(V) \
+  V(int64_t, "int(64)", I64, PyLong_Check, PyLong_AsLongLong, PyLong_FromLongLong) \
+  V(uint64_t, "uint(64)", U64, PyLong_Check, PyLong_AsUnsignedLongLong, PyLong_FromUnsignedLongLong) \
+  V(int32_t, "int(32)", I32, PyLong_Check, PyLong_AsLong, PyLong_FromLong) \
+  V(uint32_t, "uint(32)", U32, PyLong_Check, PyLong_AsUnsignedLong, PyLong_FromUnsignedLong) \
+  V(int16_t, "int(16)", I16, PyLong_Check, PyLong_AsLong, PyLong_FromLong) \
+  V(uint16_t, "uint(16)", U16, PyLong_Check, PyLong_AsUnsignedLong, PyLong_FromUnsignedLong) \
+  V(int8_t, "int(8)", I8, PyLong_Check, PyLong_AsLong, PyLong_FromLong) \
+  V(uint8_t, "uint(8)", U8, PyLong_Check, PyLong_AsUnsignedLong, PyLong_FromUnsignedLong) \
+  V(_real64, "real(64)", R64, PyFloat_Check, PyFloat_AsDouble, PyFloat_FromDouble) \
+  V(_real32, "real(32)", R32, PyFloat_Check, PyFloat_AsDouble, PyFloat_FromDouble) \
+  V(chpl_bool, "bool", Bool, PyBool_Check, PyObject_IsTrue, PyBool_FromLong)
+
+
+#define chpl_MAKE_ARRAY_TYPES(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, _0, _1, _2) extern PyTypeObject* Array##NAMESUFFIX##Type;
+chpl_ARRAY_TYPES(chpl_MAKE_ARRAY_TYPES)
+#undef chpl_MAKE_ARRAY_TYPES
+
+chpl_bool createArrayTypes(void);
+
+#define chpl_CREATE_ARRAY(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, _0, _1, _2) PyObject* createArray##NAMESUFFIX(DATATYPE* data, Py_ssize_t size);
+chpl_ARRAY_TYPES(chpl_CREATE_ARRAY)
+#undef chpl_CREATE_ARRAY
+
+#endif

--- a/modules/packages/PythonHelper/ChapelPythonHelper.h
+++ b/modules/packages/PythonHelper/ChapelPythonHelper.h
@@ -67,4 +67,82 @@ static inline PyObject* chpl_Py_None(void) { return (PyObject*)Py_None; }
 static inline PyObject* chpl_Py_True(void) { return (PyObject*)Py_True; }
 static inline PyObject* chpl_Py_False(void) { return (PyObject*)Py_False; }
 
+
+#include <stdint.h>
+typedef struct {
+  PyObject_HEAD
+  int64_t* data;
+  Py_ssize_t size;
+} ArrayShimObject;
+static PyTypeObject* ArrayShimType = NULL;
+
+static int ArrayShimObject_init(ArrayShimObject* self, PyObject* args, PyObject* kwargs) {
+  return 0;
+}
+static void ArrayShimObject_dealloc(ArrayShimObject* self) {
+  void (*tp_free)(PyObject*) = (void (*)(PyObject*))(PyType_GetSlot(ArrayShimType, Py_tp_free));
+  if (!tp_free) PyErr_SetString(PyExc_RuntimeError, "Could not free object");
+  else          tp_free((PyObject*) self);
+}
+static PyObject* ArrayShimObject_str(ArrayShimObject* self) {
+  return PyUnicode_FromFormat("ArrayI64(data: 0x%p, size: %zu)", self->data, self->size);
+}
+static int ArrayShimObject_setitem(ArrayShimObject* self, Py_ssize_t index, PyObject* value) {
+  if (!PyLong_Check(value)) {
+    PyErr_SetString(PyExc_TypeError, "ArrayShimObject only supports setting items with integers");
+    return -1;
+  }
+  int64_t val = PyLong_AsLong(value);
+  if (val == -1 && PyErr_Occurred()) return -1;
+  if (index < 0 || index >= self->size) {
+    PyErr_SetString(PyExc_IndexError, "ArrayShimObject index out of range");
+    return -1;
+  }
+  self->data[index] = val;
+  return 0;
+}
+static PyObject* ArrayShimObject_getitem(ArrayShimObject* self, Py_ssize_t index) {
+  if (index < 0 || index >= self->size) {
+    PyErr_SetString(PyExc_IndexError, "ArrayShimObject index out of range");
+    return NULL;
+  }
+  return PyLong_FromLong(self->data[index]);
+}
+static Py_ssize_t ArrayShimObject_length(ArrayShimObject* self) {
+  return self->size;
+}
+
+// should only be called once. returns 0 on failure, 1 on success
+static int createArrayShimType(void) {
+  PyType_Slot slots[] = {
+    {Py_tp_init, (void*) ArrayShimObject_init},
+    {Py_tp_dealloc, (void*) ArrayShimObject_dealloc},
+    {Py_tp_doc, (void*) PyDoc_STR("A shim to allow Chapel arrays to be used in Python")},
+    {Py_tp_new, (void*) PyType_GenericNew},
+    {Py_tp_str, (void*) ArrayShimObject_str},
+    {Py_sq_ass_item, (void*) ArrayShimObject_setitem},
+    {Py_sq_item, (void*) ArrayShimObject_getitem},
+    {Py_mp_length, (void*)ArrayShimObject_length},
+    {0, NULL}
+  };
+  PyType_Spec spec = {
+    /*name*/ "ArrayI64", // TODO: qualified name
+    /*basicsize*/ sizeof(ArrayShimObject),
+    /*itemsize*/ 0,
+    /*flags*/ Py_TPFLAGS_DEFAULT,
+    /*slots*/ slots
+  };
+  ArrayShimType = (PyTypeObject*)PyType_FromSpec(&spec);
+  if (!ArrayShimType || PyType_Ready(ArrayShimType) < 0) return 0;
+  return 1;
+}
+
+static PyObject* createArrayShim(int64_t* data, Py_ssize_t size) {
+  PyObject* objPy = PyObject_CallNoArgs((PyObject *) ArrayShimType);
+  ArrayShimObject* obj = (ArrayShimObject*) objPy;
+  obj->data = data;
+  obj->size = size;
+  return objPy;
+}
+
 #endif

--- a/modules/packages/PythonHelper/ChapelPythonHelper.h
+++ b/modules/packages/PythonHelper/ChapelPythonHelper.h
@@ -24,11 +24,11 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
-const uint64_t chpl_PY_VERSION_HEX = PY_VERSION_HEX;
-const char* chpl_PY_VERSION = PY_VERSION;
-const unsigned long chpl_PY_MAJOR_VERSION = PY_MAJOR_VERSION;
-const unsigned long chpl_PY_MINOR_VERSION = PY_MINOR_VERSION;
-const unsigned long chpl_PY_MICRO_VERSION = PY_MICRO_VERSION;
+static const uint64_t chpl_PY_VERSION_HEX = PY_VERSION_HEX;
+static const char* chpl_PY_VERSION = PY_VERSION;
+static const unsigned long chpl_PY_MAJOR_VERSION = PY_MAJOR_VERSION;
+static const unsigned long chpl_PY_MINOR_VERSION = PY_MINOR_VERSION;
+static const unsigned long chpl_PY_MICRO_VERSION = PY_MICRO_VERSION;
 
 static inline PyObject* chpl_PyEval_GetFrameGlobals(void) {
 #if PY_VERSION_HEX >= 0x030d0000 /* Python 3.13 */
@@ -66,83 +66,5 @@ static inline int chpl_PyGen_Check(PyObject* o) { return PyGen_Check(o); }
 static inline PyObject* chpl_Py_None(void) { return (PyObject*)Py_None; }
 static inline PyObject* chpl_Py_True(void) { return (PyObject*)Py_True; }
 static inline PyObject* chpl_Py_False(void) { return (PyObject*)Py_False; }
-
-
-#include <stdint.h>
-typedef struct {
-  PyObject_HEAD
-  int64_t* data;
-  Py_ssize_t size;
-} ArrayShimObject;
-static PyTypeObject* ArrayShimType = NULL;
-
-static int ArrayShimObject_init(ArrayShimObject* self, PyObject* args, PyObject* kwargs) {
-  return 0;
-}
-static void ArrayShimObject_dealloc(ArrayShimObject* self) {
-  void (*tp_free)(PyObject*) = (void (*)(PyObject*))(PyType_GetSlot(ArrayShimType, Py_tp_free));
-  if (!tp_free) PyErr_SetString(PyExc_RuntimeError, "Could not free object");
-  else          tp_free((PyObject*) self);
-}
-static PyObject* ArrayShimObject_str(ArrayShimObject* self) {
-  return PyUnicode_FromFormat("ArrayI64(data: 0x%p, size: %zu)", self->data, self->size);
-}
-static int ArrayShimObject_setitem(ArrayShimObject* self, Py_ssize_t index, PyObject* value) {
-  if (!PyLong_Check(value)) {
-    PyErr_SetString(PyExc_TypeError, "ArrayShimObject only supports setting items with integers");
-    return -1;
-  }
-  int64_t val = PyLong_AsLong(value);
-  if (val == -1 && PyErr_Occurred()) return -1;
-  if (index < 0 || index >= self->size) {
-    PyErr_SetString(PyExc_IndexError, "ArrayShimObject index out of range");
-    return -1;
-  }
-  self->data[index] = val;
-  return 0;
-}
-static PyObject* ArrayShimObject_getitem(ArrayShimObject* self, Py_ssize_t index) {
-  if (index < 0 || index >= self->size) {
-    PyErr_SetString(PyExc_IndexError, "ArrayShimObject index out of range");
-    return NULL;
-  }
-  return PyLong_FromLong(self->data[index]);
-}
-static Py_ssize_t ArrayShimObject_length(ArrayShimObject* self) {
-  return self->size;
-}
-
-// should only be called once. returns 0 on failure, 1 on success
-static int createArrayShimType(void) {
-  PyType_Slot slots[] = {
-    {Py_tp_init, (void*) ArrayShimObject_init},
-    {Py_tp_dealloc, (void*) ArrayShimObject_dealloc},
-    {Py_tp_doc, (void*) PyDoc_STR("A shim to allow Chapel arrays to be used in Python")},
-    {Py_tp_new, (void*) PyType_GenericNew},
-    {Py_tp_str, (void*) ArrayShimObject_str},
-    {Py_sq_ass_item, (void*) ArrayShimObject_setitem},
-    {Py_sq_item, (void*) ArrayShimObject_getitem},
-    {Py_mp_length, (void*)ArrayShimObject_length},
-    {0, NULL}
-  };
-  PyType_Spec spec = {
-    /*name*/ "ArrayI64", // TODO: qualified name
-    /*basicsize*/ sizeof(ArrayShimObject),
-    /*itemsize*/ 0,
-    /*flags*/ Py_TPFLAGS_DEFAULT,
-    /*slots*/ slots
-  };
-  ArrayShimType = (PyTypeObject*)PyType_FromSpec(&spec);
-  if (!ArrayShimType || PyType_Ready(ArrayShimType) < 0) return 0;
-  return 1;
-}
-
-static PyObject* createArrayShim(int64_t* data, Py_ssize_t size) {
-  PyObject* objPy = PyObject_CallNoArgs((PyObject *) ArrayShimType);
-  ArrayShimObject* obj = (ArrayShimObject*) objPy;
-  obj->data = data;
-  obj->size = size;
-  return objPy;
-}
 
 #endif

--- a/test/library/packages/Python/correctness/myArray.chpl
+++ b/test/library/packages/Python/correctness/myArray.chpl
@@ -20,13 +20,11 @@ def loop(arr):
   sys.stdout.flush()
 """;
 
-proc testArray(type t) {
+proc testArray(type t, const testArr) {
   writeln("testing array of type ", t:string);
   IO.stdout.flush();
 
-  var arr: [1..10] t;
-  forall i in arr.domain do
-    arr[i] = i:t;
+  var arr = testArr: t;
 
   var interp = new Interpreter();
 
@@ -50,16 +48,31 @@ proc testArray(type t) {
   IO.stdout.flush();
 }
 
+proc testArray(arr) {
+  testArray(int(64), arr);
+  testArray(uint(64), arr);
+  testArray(int(32), arr);
+  testArray(uint(32), arr);
+  testArray(int(16), arr);
+  testArray(uint(16), arr);
+  testArray(int(8), arr);
+  testArray(uint(8), arr);
+  testArray(real(64), arr);
+  testArray(real(32), arr);
+  testArray(bool, arr);
+}
+
 proc main() {
-  testArray(int(64));
-  testArray(uint(64));
-  testArray(int(32));
-  testArray(uint(32));
-  testArray(int(16));
-  testArray(uint(16));
-  testArray(int(8));
-  testArray(uint(8));
-  testArray(real(64));
-  testArray(real(32));
-  testArray(bool);
+
+  {
+    // test non-zero indexed array
+    var arr: [1..10] int;
+    forall i in arr.domain do
+      arr[i] = i;
+    testArray(arr);
+  }
+
+  // test array literal
+  testArray([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
 }

--- a/test/library/packages/Python/correctness/myArray.chpl
+++ b/test/library/packages/Python/correctness/myArray.chpl
@@ -1,16 +1,29 @@
 use Python;
+import IO;
 
 var pythonCode = """
 def loop(arr):
-  print("printing", arr)
-  for x in arr:
-    print(x)
+  print("printing", arr, end=": ")
+  print(", ".join(str(x) for x in arr))
   print("reset to 0")
   for i in range(len(arr)):
-    arr[i] = 0
+    if isinstance(arr[i], bool):
+      arr[i] = False
+    elif isinstance(arr[i], int):
+      arr[i] = 0
+    elif isinstance(arr[i], float):
+      arr[i] = 0.0
+    else:
+      raise TypeError("unknown type")
+
+  import sys
+  sys.stdout.flush()
 """;
 
 proc testArray(type t) {
+  writeln("testing array of type ", t:string);
+  IO.stdout.flush();
+
   var arr: [1..10] t;
   forall i in arr.domain do
     arr[i] = i:t;
@@ -19,19 +32,34 @@ proc testArray(type t) {
 
   var pyArr = new Array(interp, arr);
   writeln("python: ", pyArr);
-  pyArr.setItem(0, 17);
+  pyArr.setItem(0, 17:t);
   writeln("at 2: ", pyArr.getItem(2));
   writeln("size: ", pyArr.size);
   writeln("chapel: ", arr);
+  IO.stdout.flush();
 
   writeln("from python");
+  IO.stdout.flush();
   var pyCode = new Module(interp, '__empty__', pythonCode);
   var func = new Function(pyCode, 'loop');
   func(NoneType, pyArr);
+  IO.stdout.flush();
 
   writeln("from chapel: ", arr);
+  writeln("=========================");
+  IO.stdout.flush();
 }
 
 proc main() {
-
+  testArray(int(64));
+  testArray(uint(64));
+  testArray(int(32));
+  testArray(uint(32));
+  testArray(int(16));
+  testArray(uint(16));
+  testArray(int(8));
+  testArray(uint(8));
+  testArray(real(64));
+  testArray(real(32));
+  testArray(bool);
 }

--- a/test/library/packages/Python/correctness/myArray.chpl
+++ b/test/library/packages/Python/correctness/myArray.chpl
@@ -1,0 +1,37 @@
+use Python;
+
+var pythonCode = """
+def loop(arr):
+  print("printing", arr)
+  for x in arr:
+    print(x)
+  print("reset to 0")
+  for i in range(len(arr)):
+    arr[i] = 0
+""";
+
+proc testArray(type t) {
+  var arr: [1..10] t;
+  forall i in arr.domain do
+    arr[i] = i:t;
+
+  var interp = new Interpreter();
+
+  var pyArr = new Array(interp, arr);
+  writeln("python: ", pyArr);
+  pyArr.setItem(0, 17);
+  writeln("at 2: ", pyArr.getItem(2));
+  writeln("size: ", pyArr.size);
+  writeln("chapel: ", arr);
+
+  writeln("from python");
+  var pyCode = new Module(interp, '__empty__', pythonCode);
+  var func = new Function(pyCode, 'loop');
+  func(NoneType, pyArr);
+
+  writeln("from chapel: ", arr);
+}
+
+proc main() {
+
+}

--- a/test/library/packages/Python/correctness/myArray.good
+++ b/test/library/packages/Python/correctness/myArray.good
@@ -108,3 +108,113 @@ printing Array(eltType=bool,size=10): True, True, True, True, True, True, True, 
 reset to 0
 from chapel: false false false false false false false false false false
 =========================
+testing array of type int(64)
+python: Array(eltType=int(64),size=10)
+at 2: 3
+size: 10
+chapel: 17 2 3 4 5 6 7 8 9 10
+from python
+printing Array(eltType=int(64),size=10): 17, 2, 3, 4, 5, 6, 7, 8, 9, 10
+reset to 0
+from chapel: 0 0 0 0 0 0 0 0 0 0
+=========================
+testing array of type uint(64)
+python: Array(eltType=uint(64),size=10)
+at 2: 3
+size: 10
+chapel: 17 2 3 4 5 6 7 8 9 10
+from python
+printing Array(eltType=uint(64),size=10): 17, 2, 3, 4, 5, 6, 7, 8, 9, 10
+reset to 0
+from chapel: 0 0 0 0 0 0 0 0 0 0
+=========================
+testing array of type int(32)
+python: Array(eltType=int(32),size=10)
+at 2: 3
+size: 10
+chapel: 17 2 3 4 5 6 7 8 9 10
+from python
+printing Array(eltType=int(32),size=10): 17, 2, 3, 4, 5, 6, 7, 8, 9, 10
+reset to 0
+from chapel: 0 0 0 0 0 0 0 0 0 0
+=========================
+testing array of type uint(32)
+python: Array(eltType=uint(32),size=10)
+at 2: 3
+size: 10
+chapel: 17 2 3 4 5 6 7 8 9 10
+from python
+printing Array(eltType=uint(32),size=10): 17, 2, 3, 4, 5, 6, 7, 8, 9, 10
+reset to 0
+from chapel: 0 0 0 0 0 0 0 0 0 0
+=========================
+testing array of type int(16)
+python: Array(eltType=int(16),size=10)
+at 2: 3
+size: 10
+chapel: 17 2 3 4 5 6 7 8 9 10
+from python
+printing Array(eltType=int(16),size=10): 17, 2, 3, 4, 5, 6, 7, 8, 9, 10
+reset to 0
+from chapel: 0 0 0 0 0 0 0 0 0 0
+=========================
+testing array of type uint(16)
+python: Array(eltType=uint(16),size=10)
+at 2: 3
+size: 10
+chapel: 17 2 3 4 5 6 7 8 9 10
+from python
+printing Array(eltType=uint(16),size=10): 17, 2, 3, 4, 5, 6, 7, 8, 9, 10
+reset to 0
+from chapel: 0 0 0 0 0 0 0 0 0 0
+=========================
+testing array of type int(8)
+python: Array(eltType=int(8),size=10)
+at 2: 3
+size: 10
+chapel: 17 2 3 4 5 6 7 8 9 10
+from python
+printing Array(eltType=int(8),size=10): 17, 2, 3, 4, 5, 6, 7, 8, 9, 10
+reset to 0
+from chapel: 0 0 0 0 0 0 0 0 0 0
+=========================
+testing array of type uint(8)
+python: Array(eltType=uint(8),size=10)
+at 2: 3
+size: 10
+chapel: 17 2 3 4 5 6 7 8 9 10
+from python
+printing Array(eltType=uint(8),size=10): 17, 2, 3, 4, 5, 6, 7, 8, 9, 10
+reset to 0
+from chapel: 0 0 0 0 0 0 0 0 0 0
+=========================
+testing array of type real(64)
+python: Array(eltType=real(64),size=10)
+at 2: 3.0
+size: 10
+chapel: 17.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0 10.0
+from python
+printing Array(eltType=real(64),size=10): 17.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0
+reset to 0
+from chapel: 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0
+=========================
+testing array of type real(32)
+python: Array(eltType=real(32),size=10)
+at 2: 3.0
+size: 10
+chapel: 17.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0 10.0
+from python
+printing Array(eltType=real(32),size=10): 17.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0
+reset to 0
+from chapel: 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0
+=========================
+testing array of type bool
+python: Array(eltType=bool,size=10)
+at 2: true
+size: 10
+chapel: true true true true true true true true true true
+from python
+printing Array(eltType=bool,size=10): True, True, True, True, True, True, True, True, True, True
+reset to 0
+from chapel: false false false false false false false false false false
+=========================

--- a/test/library/packages/Python/correctness/myArray.good
+++ b/test/library/packages/Python/correctness/myArray.good
@@ -1,0 +1,110 @@
+testing array of type int(64)
+python: Array(eltType=int(64),size=10)
+at 2: 3
+size: 10
+chapel: 17 2 3 4 5 6 7 8 9 10
+from python
+printing Array(eltType=int(64),size=10): 17, 2, 3, 4, 5, 6, 7, 8, 9, 10
+reset to 0
+from chapel: 0 0 0 0 0 0 0 0 0 0
+=========================
+testing array of type uint(64)
+python: Array(eltType=uint(64),size=10)
+at 2: 3
+size: 10
+chapel: 17 2 3 4 5 6 7 8 9 10
+from python
+printing Array(eltType=uint(64),size=10): 17, 2, 3, 4, 5, 6, 7, 8, 9, 10
+reset to 0
+from chapel: 0 0 0 0 0 0 0 0 0 0
+=========================
+testing array of type int(32)
+python: Array(eltType=int(32),size=10)
+at 2: 3
+size: 10
+chapel: 17 2 3 4 5 6 7 8 9 10
+from python
+printing Array(eltType=int(32),size=10): 17, 2, 3, 4, 5, 6, 7, 8, 9, 10
+reset to 0
+from chapel: 0 0 0 0 0 0 0 0 0 0
+=========================
+testing array of type uint(32)
+python: Array(eltType=uint(32),size=10)
+at 2: 3
+size: 10
+chapel: 17 2 3 4 5 6 7 8 9 10
+from python
+printing Array(eltType=uint(32),size=10): 17, 2, 3, 4, 5, 6, 7, 8, 9, 10
+reset to 0
+from chapel: 0 0 0 0 0 0 0 0 0 0
+=========================
+testing array of type int(16)
+python: Array(eltType=int(16),size=10)
+at 2: 3
+size: 10
+chapel: 17 2 3 4 5 6 7 8 9 10
+from python
+printing Array(eltType=int(16),size=10): 17, 2, 3, 4, 5, 6, 7, 8, 9, 10
+reset to 0
+from chapel: 0 0 0 0 0 0 0 0 0 0
+=========================
+testing array of type uint(16)
+python: Array(eltType=uint(16),size=10)
+at 2: 3
+size: 10
+chapel: 17 2 3 4 5 6 7 8 9 10
+from python
+printing Array(eltType=uint(16),size=10): 17, 2, 3, 4, 5, 6, 7, 8, 9, 10
+reset to 0
+from chapel: 0 0 0 0 0 0 0 0 0 0
+=========================
+testing array of type int(8)
+python: Array(eltType=int(8),size=10)
+at 2: 3
+size: 10
+chapel: 17 2 3 4 5 6 7 8 9 10
+from python
+printing Array(eltType=int(8),size=10): 17, 2, 3, 4, 5, 6, 7, 8, 9, 10
+reset to 0
+from chapel: 0 0 0 0 0 0 0 0 0 0
+=========================
+testing array of type uint(8)
+python: Array(eltType=uint(8),size=10)
+at 2: 3
+size: 10
+chapel: 17 2 3 4 5 6 7 8 9 10
+from python
+printing Array(eltType=uint(8),size=10): 17, 2, 3, 4, 5, 6, 7, 8, 9, 10
+reset to 0
+from chapel: 0 0 0 0 0 0 0 0 0 0
+=========================
+testing array of type real(64)
+python: Array(eltType=real(64),size=10)
+at 2: 3.0
+size: 10
+chapel: 17.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0 10.0
+from python
+printing Array(eltType=real(64),size=10): 17.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0
+reset to 0
+from chapel: 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0
+=========================
+testing array of type real(32)
+python: Array(eltType=real(32),size=10)
+at 2: 3.0
+size: 10
+chapel: 17.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0 10.0
+from python
+printing Array(eltType=real(32),size=10): 17.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0
+reset to 0
+from chapel: 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0
+=========================
+testing array of type bool
+python: Array(eltType=bool,size=10)
+at 2: true
+size: 10
+chapel: true true true true true true true true true true
+from python
+printing Array(eltType=bool,size=10): True, True, True, True, True, True, True, True, True, True
+reset to 0
+from chapel: false false false false false false false false false false
+=========================

--- a/test/library/packages/Python/correctness/myArrayReturnArray.chpl
+++ b/test/library/packages/Python/correctness/myArrayReturnArray.chpl
@@ -1,0 +1,18 @@
+use Python;
+
+var pythonCode = """
+def returnSelf(arr):
+  return arr
+""";
+
+proc main() {
+  var arr: [1..10] int = 1..10;
+
+  var interp = new Interpreter();
+
+  var pyArr = new Array(interp, arr);
+  var pyCode = new Module(interp, '__empty__', pythonCode);
+  var func = new Function(pyCode, 'returnSelf');
+  var newArr = func(owned Array, pyArr);
+  writeln("from chapel: ", newArr);
+}

--- a/test/library/packages/Python/correctness/myArrayReturnArray.good
+++ b/test/library/packages/Python/correctness/myArrayReturnArray.good
@@ -1,0 +1,4 @@
+$CHPL_HOME/modules/packages/Python.chpl:nnnn: In method 'callInternal':
+$CHPL_HOME/modules/packages/Python.chpl:nnnn: error: Cannot create an Array from an existing PyObject
+  $CHPL_HOME/modules/packages/Python.chpl:nnnn: called as Value.callInternal(type retType = owned Array(nothing), pyArg: c_ptr(PyObject), kwargs: nothing) from method 'this'
+  myArrayReturnArray.chpl:16: called as Value.this(type retType = owned Array(nothing), args(0): owned Array(int(64)))

--- a/test/library/packages/Python/correctness/myArrayReturnArray.prediff
+++ b/test/library/packages/Python/correctness/myArrayReturnArray.prediff
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+$CHPL_HOME/util/test/prediff-obscure-module-linenos $@

--- a/test/library/packages/Python/correctness/myList.chpl
+++ b/test/library/packages/Python/correctness/myList.chpl
@@ -1,0 +1,34 @@
+use Python;
+import List;
+
+var pyCode = """
+def getList():
+  return list([1, 2, 3, 4, 5])
+""";
+
+proc main() {
+
+  var interp = new Interpreter();
+
+  var pyCodeModule = new Module(interp, '__empty__', pyCode);
+  var getListFunc = new Function(pyCodeModule, 'getList');
+
+  var lst = getListFunc(owned PyList);
+  writeln("lst ", lst);
+  writeln("size ", lst.size);
+  writeln("lst[0] ", lst.getItem(int, 0));
+  writeln("lst[1] ", lst.getItem(int, 1));
+  writeln("lst[lst.size-1] ", lst.getItem(int, lst.size-1));
+
+  try {
+    write("lst[lst.size] ");
+    writeln(lst.getItem(int, lst.size));
+  } catch e: PythonException {
+    writeln("Caught exception: ", e);
+  } catch e{
+    writeln("Caught unknown exception: ", e);
+  }
+
+  lst.setItem(0, 100);
+  writeln("lst ", lst);
+}

--- a/test/library/packages/Python/correctness/myList.chpl
+++ b/test/library/packages/Python/correctness/myList.chpl
@@ -3,7 +3,7 @@ import List;
 
 var pyCode = """
 def getList():
-  return list([1, 2, 3, 4, 5])
+  return [1, 2, "hi", False, 5]
 """;
 
 proc main() {
@@ -18,6 +18,7 @@ proc main() {
   writeln("size ", lst.size);
   writeln("lst[0] ", lst.getItem(int, 0));
   writeln("lst[1] ", lst.getItem(int, 1));
+  writeln("lst[2] ", lst.getItem(string, 2));
   writeln("lst[lst.size-1] ", lst.getItem(int, lst.size-1));
 
   try {

--- a/test/library/packages/Python/correctness/myList.good
+++ b/test/library/packages/Python/correctness/myList.good
@@ -1,0 +1,8 @@
+lst [1, 2, 'hi', False, 5]
+size 5
+lst[0] 1
+lst[1] 2
+lst[2] hi
+lst[lst.size-1] 5
+lst[lst.size] Caught exception: PythonException: list index out of range
+lst [100, 2, 'hi', False, 5]


### PR DESCRIPTION
Adds a new feature to the Python interop support, allowing Chapel arrays to be passed to Python functions without being copied. This allows Python code to modify Chapel arrays in place, rather than copying in/out.

This support is fairly limited to start with, only supporting integer, real, and bool types.

- [x] `start_test test/library/packages/Python`

[Reviewed by @lydia-duncan]