### PR TITLE
Increase the Arkouda test timeout to 500 seconds

### DIFF
--- a/util/cron/test-cray-xc-arkouda.bash
+++ b/util/cron/test-cray-xc-arkouda.bash
@@ -11,6 +11,9 @@ source $UTIL_CRON_DIR/common.bash
 source $UTIL_CRON_DIR/common-arkouda.bash
 export ARKOUDA_NUMLOCALES=16
 
+# The parquetMultiIO test may exceed the default 300-second timeout
+export CHPL_TEST_TIMEOUT=500
+
 module list
 
 # setup for XC perf (ugni, gnu, 28-core broadwell)

--- a/util/cron/test-cray-xc-arkouda.release.bash
+++ b/util/cron/test-cray-xc-arkouda.release.bash
@@ -11,6 +11,9 @@ source $UTIL_CRON_DIR/common.bash
 source $UTIL_CRON_DIR/common-arkouda.bash
 export ARKOUDA_NUMLOCALES=16
 
+# The parquetMultiIO test may exceed the default 300-second timeout
+export CHPL_TEST_TIMEOUT=500
+
 module list
 
 # setup for XC perf (ugni, gnu, 28-core broadwell)


### PR DESCRIPTION
The parquetMultiIO test may exceed the default 300-second timeout.

Resolves https://github.com/Cray/chapel-private/issues/7018. 