### PR TITLE
add annotations week of 1/23/25

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -609,6 +609,10 @@ all:
   12/12/24:
     - text: Backport Fix For Performance Regression in Qthreads 1.21 (#26328)
       config: chapcs, 16-node-apollo-hdr, 16-node-hpe-cray-ex, 1-node-hpe-cray-ex
+  01/06/25:
+    - text: Partially revert Qthreads patch from #26328 (#26468)
+      config: chapcs, 16-node-apollo-hdr, 16-node-hpe-cray-ex, 1-node-hpe-cray-ex
+
 
 # End all
 
@@ -1699,7 +1703,9 @@ nbody:
     - Change param-based nbody to foreach-based (#24745)
   10/06/24:
     - Update my study version of nbody to be like nbody#2, but using foreach loops (#26044)
-
+  01/06/25:
+    - Suspect - Raise number of threads used by GASNet by default + add warning if exceeded (#26448)
+ 
 no-op:
   02/24/17:
     - upgrade hwloc to 1.11.6 (#5411)

--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -1666,6 +1666,9 @@ miniMD.ml-time:
     - Manually hoist loop-invariant array access in miniMD (#7432)
   09/26/17:
     - Prevent certain data races upon 'in' forall intents (#7467)
+  01/06/25:
+    - text: Suspect - Raise number of threads used by GASNet by default + add warning if exceeded (#26448)
+      config: 16-node-apollo-hdr
 
 ml-memleaksfull:
   04/04/20:
@@ -1703,8 +1706,6 @@ nbody:
     - Change param-based nbody to foreach-based (#24745)
   10/06/24:
     - Update my study version of nbody to be like nbody#2, but using foreach loops (#26044)
-  01/06/25:
-    - Suspect - Raise number of threads used by GASNet by default + add warning if exceeded (#26448)
  
 no-op:
   02/24/17:


### PR DESCRIPTION
- qthreads partial reversion (impacts thread ring shootout benchmark)
- Add annotation indicating we suspect a PR raising the number of gasnet threads may have influenced nbody perf on Apollo. If not due to that, it could also be due to some bimodal machine behavior, graph history makes it look like such behavior may exist.
