### PR TITLE
Remove JAVA_HOME declaration in NetworkingPackages test

### DIFF
--- a/util/cron/test-networking-packages.bash
+++ b/util/cron/test-networking-packages.bash
@@ -7,7 +7,6 @@ source $UTIL_CRON_DIR/common.bash
 source $UTIL_CRON_DIR/common-quickstart.bash
 
 export HADOOP_HOME=/hpcdc/project/chapel/hadoop/$HOSTNAME
-export JAVA_HOME=/usr/lib64/jvm/jre
 export CLASSPATH=$(${HADOOP_HOME}/bin/hadoop classpath --glob)
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HADOOP_HOME/lib/native:$JAVA_HOME/lib:$JAVA_HOME/lib/amd64/server
 


### PR DESCRIPTION
This is making an assumption about the location of java on the test systems.  This is a trivial change and was tested using this configuration: http://cfljenkins12.us.cray.com:8080/view/TZ%20Builds/job/tz-chapcs-correctness-test-networking-packages/4/.  
