### PR TITLE
Change naming linting for extern symbols

### DIFF
--- a/test/chplcheck/CaseRules.chpl
+++ b/test/chplcheck/CaseRules.chpl
@@ -47,9 +47,18 @@ module CaseRules {
   var _privateVar: int;
 
   extern proc proc_from_another_lang();
-  extern proc Proc_with_Bad_consistenty();
+  extern proc Proc_with_Bad_consistency();
   extern var c_var: int(32);
   extern const c_const: int(32);
+  extern type type_from_another_lang;
+  extern record record_from_another_lang {}
+
+  extern "externName" proc proc_from_another_lang2();
+  extern "externName" proc Proc_with_Bad_consistency2();
+  extern "externName" var c_var2: int(32);
+  extern "externName" const c_const2: int(32);
+  extern "externName" type type_from_another_lang2;
+  extern "externName" record record_from_another_lang2 {}
 
   var justOneCapitalLetterAtTheE: string;
   const justO: real;

--- a/test/chplcheck/CaseRules.good
+++ b/test/chplcheck/CaseRules.good
@@ -14,4 +14,10 @@ CaseRules.chpl:37: node violates rule PascalCaseClasses
 CaseRules.chpl:39: node violates rule PascalCaseClasses
 CaseRules.chpl:42: node violates rule CamelOrPascalCaseVariables
 CaseRules.chpl:43: node violates rule CamelOrPascalCaseVariables
-CaseRules.chpl:70: node violates rule CamelCaseFunctions
+CaseRules.chpl:56: node violates rule CamelCaseFunctions
+CaseRules.chpl:57: node violates rule CamelCaseFunctions
+CaseRules.chpl:58: node violates rule CamelOrPascalCaseVariables
+CaseRules.chpl:59: node violates rule CamelOrPascalCaseVariables
+CaseRules.chpl:60: node violates rule CamelOrPascalCaseVariables
+CaseRules.chpl:61: node violates rule CamelCaseRecords
+CaseRules.chpl:79: node violates rule CamelCaseFunctions

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -162,7 +162,7 @@ def rules(driver: LintDriver):
 
         if node.name() == "_":
             return True
-        if node.linkage() == "extern":
+        if node.linkage() == "extern" and node.linkage_name() is None:
             return True
         internal_prefixes = driver.config.internal_prefixes
         return check_camel_case(
@@ -174,6 +174,9 @@ def rules(driver: LintDriver):
         """
         Warn for records that are not 'camelCase'.
         """
+
+        if node.linkage() == "extern" and node.linkage_name() is None:
+            return True
 
         internal_prefixes = driver.config.internal_prefixes
         return check_camel_case(context, node, internal_prefixes)
@@ -189,7 +192,7 @@ def rules(driver: LintDriver):
         if node.is_override():
             return True
 
-        if node.linkage() == "extern":
+        if node.linkage() == "extern" and node.linkage_name() is None:
             return True
         if node.kind() == "operator":
             return True


### PR DESCRIPTION
Fixes how we lint extern symbols in chplcheck for name violations.

Extern symbols should not be linted for name violations, because they typically come from another language that has different naming conventions. Furthermore, the user may have no control over the type name (i.e. using a third-party library). `chplcheck` already handled this correctly for functions and variables/types, but not for records. This PR rectifies that.

This PR also adds an opt-out, if the user has renamed their symbol, then they do have full control of the name and this PR turns on linting in that case. In the following program, we should lint the name `chapelFunc`, because that's a name picked by the user and not relevant to the external name.
```chapel
proc "extern_c_func" proc chapelFunc() { }
```

- [x] `start_test test/chplcheck`

[Reviewed by @brandon-neth] 