### PR TITLE
Use new CURLINFO_CONTENT_LENGTH_DOWNLOAD_T

### DIFF
--- a/modules/packages/Curl.chpl
+++ b/modules/packages/Curl.chpl
@@ -390,7 +390,7 @@ module Curl {
   private extern const CURLOPT_READDATA: CURLoption;
 
   // Other Curl constants
-  private extern const CURLINFO_CONTENT_LENGTH_DOWNLOAD_T: curl_off_t;
+  private extern const CURLINFO_CONTENT_LENGTH_DOWNLOAD_T: CURLINFO;
 
   private extern const CURL_READFUNC_PAUSE:c_size_t;
   private extern const CURL_READFUNC_ABORT:c_size_t;

--- a/modules/packages/Curl.chpl
+++ b/modules/packages/Curl.chpl
@@ -390,7 +390,7 @@ module Curl {
   private extern const CURLOPT_READDATA: CURLoption;
 
   // Other Curl constants
-  private extern const CURLINFO_CONTENT_LENGTH_DOWNLOAD: c_int;
+  private extern const CURLINFO_CONTENT_LENGTH_DOWNLOAD_T: curl_off_t;
 
   private extern const CURL_READFUNC_PAUSE:c_size_t;
   private extern const CURL_READFUNC_ABORT:c_size_t;
@@ -779,11 +779,8 @@ module Curl {
 
         deallocate(buf.mem);
 
-        var lengthDouble: real(64);
         // Get the content length (for HTTP only)
-        curl_easy_getinfo_ptr(curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD, c_ptrTo(lengthDouble));
-        length = lengthDouble: int(64);
-        // One day, use CURLINFO_CONTENT_LENGTH_DOWNLOAD_T
+        curl_easy_getinfo_ptr(curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T, c_ptrTo(length));
 
         curl_easy_cleanup(curl);
       }


### PR DESCRIPTION
Switch from the deprecated `CURLINFO_CONTENT_LENGTH_DOWNLOAD` constant to its replacement `CURLINFO_CONTENT_LENGTH_DOWNLOAD_T` in the Curl package module.

Per [Curl docs](https://curl.se/libcurl/c/CURLINFO_CONTENT_LENGTH_DOWNLOAD.html), the old constant is deprecated since Curl 7.55, which was released in 2017.

[reviewer info placeholder]

Testing:
- [x] networking packages test
- [x] paratest