### PR TITLE
Fix test-networking-packages hostname-based hadoop path

### DIFF
--- a/util/cron/test-networking-packages.bash
+++ b/util/cron/test-networking-packages.bash
@@ -6,7 +6,7 @@ UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common.bash
 source $UTIL_CRON_DIR/common-quickstart.bash
 
-export HADOOP_HOME=/hpcdc/project/chapel/hadoop/$HOSTNAME
+export HADOOP_HOME=/hpcdc/project/chapel/hadoop/$(hostname -s)
 export CLASSPATH=$(${HADOOP_HOME}/bin/hadoop classpath --glob)
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HADOOP_HOME/lib/native:$JAVA_HOME/lib:$JAVA_HOME/lib/amd64/server
 


### PR DESCRIPTION
Use `hostname -s` instead of `$HOSTNAME` for the hostname-based path to hadoop, as it's in `chapcs11` without any qualification.

[trivial, not reviewed]

Testing:
- [x] fixes missing hadoop in manual run of `util/cron/test-networking-packages.bash`