### PR TITLE
Fix temporary file cleanup

### DIFF
--- a/runtime/include/chpl-mem-desc.h
+++ b/runtime/include/chpl-mem-desc.h
@@ -103,7 +103,7 @@ extern "C" {
   m(GPU_KERNEL_PARAM,      "pointer to a kernel arg",                 true ), \
   m(GPU_KERNEL_PARAM_BUFF, "array of pointers to kernel args",        true ), \
   m(GPU_KERNEL_PARAM_META, "metadata about kernel parameters",        true ), \
-  m(ERROR_MSG,            "error message",                            true ), \
+  m(ERROR_MSG,             "error message",                           true ), \
   m(NUM,                   "*** this must be the last entry ***",     true )
 
 //

--- a/runtime/include/chpl-mem-desc.h
+++ b/runtime/include/chpl-mem-desc.h
@@ -103,6 +103,7 @@ extern "C" {
   m(GPU_KERNEL_PARAM,      "pointer to a kernel arg",                 true ), \
   m(GPU_KERNEL_PARAM_BUFF, "array of pointers to kernel args",        true ), \
   m(GPU_KERNEL_PARAM_META, "metadata about kernel parameters",        true ), \
+  m(ERROR_MSG,            "error message",                            true ), \
   m(NUM,                   "*** this must be the last entry ***",     true )
 
 //

--- a/runtime/src/launch/pbs-gasnetrun_ibv/launch-pbs-gasnetrun_ibv.c
+++ b/runtime/src/launch/pbs-gasnetrun_ibv/launch-pbs-gasnetrun_ibv.c
@@ -245,20 +245,26 @@ static char* chpl_launch_create_command(int argc, char* argv[],
   return command;
 }
 
+static void unlinkFile(char *name) {
+  int rc = unlink(name);
+  if (rc) {
+    char *fmt = "Unlink of \"%s\" failed: %s\n";
+    char *err = strerror(errno);
+    int msgSize = strlen(name) + strlen(err) + strlen(fmt) + 1;
+    char *msg = chpl_mem_alloc(msgSize, CHPL_RT_MD_ERROR_MSG, 0, 0);
+    snprintf(msg, msgSize, fmt, name, err);
+    chpl_internal_error(msg);
+    // Not reached.
+    chpl_mem_free(msg, 0, 0);
+  }
+}
+
+
 static void chpl_launch_cleanup(void) {
 #ifndef DEBUG_LAUNCH
   if (!chpl_doDryRun()) {
-    {
-      char command[sizeof(pbsFilename) + 4];
-      (void) snprintf(command, sizeof(command), "rm %s", pbsFilename);
-      system(command);
-    }
-
-    {
-      char command[sizeof(expectFilename) + 4];
-      (void) snprintf(command, sizeof(command), "rm %s", expectFilename);
-      system(command);
-    }
+    unlinkFile(pbsFilename);
+    unlinkFile(expectFilename);
   }
 #endif
   chpl_mem_free(pbsFilename, 0, 0);


### PR DESCRIPTION
The command buffers used to delete the PBS temporary files were too small, causing the file names to be truncated and the files to not be deleted. The launcher now unlinks the files, obviating the need for a command buffer. This approach also generates an error message if the unlink fails.