### PR TITLE
Remove confusing line in IO.file.init docs

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1849,8 +1849,6 @@ operations
   This is an alternative way to create a :record:`file`.  The main way to do so
   is via the :proc:`open` function.
 
-The system file descriptor will be closed when the Chapel file is closed.
-
 .. note::
 
   This function can be used to create Chapel files that refer to system file


### PR DESCRIPTION
Removes confusing line in IO.file.init docs. The line states that the file will always close the file descriptor, but this not only conflicts with later parts of the documentation, but with the implementation.

[Reviewed by @]