### PR TITLE
Add a prediff to this test to avoid module line number adjustments

### DIFF
--- a/test/unstable-keyword/iterator/onlySerial.bad
+++ b/test/unstable-keyword/iterator/onlySerial.bad
@@ -7,7 +7,7 @@ onlySerial.chpl:73: warning: range.translate() is unstable and its behavior may 
   onlySerial.chpl:22: called as foo(param tag = iterKind.leader)
 onlySerial.chpl:80: In iterator 'foo':
 onlySerial.chpl:85: warning: range.translate() is unstable and its behavior may change in the future
-  $CHPL_HOME/modules/internal/ChapelIteratorSupport.chpl:641: called as foo(param tag = iterKind.follower, followThis: 1*range(int(64),both,one))
+  $CHPL_HOME/modules/internal/ChapelIteratorSupport.chpl:nnnn: called as foo(param tag = iterKind.follower, followThis: 1*range(int(64),both,one))
   within internal functions (use --print-callstack-on-error to see)
 onlySerial.chpl:7: In function 'main':
 onlySerial.chpl:31: warning: The serial version of foo is unstable

--- a/test/unstable-keyword/iterator/onlySerial.good
+++ b/test/unstable-keyword/iterator/onlySerial.good
@@ -5,7 +5,7 @@ onlySerial.chpl:73: warning: range.translate() is unstable and its behavior may 
   onlySerial.chpl:22: called as foo(param tag = iterKind.leader)
 onlySerial.chpl:80: In iterator 'foo':
 onlySerial.chpl:85: warning: range.translate() is unstable and its behavior may change in the future
-  $CHPL_HOME/modules/internal/ChapelIteratorSupport.chpl:641: called as foo(param tag = iterKind.follower, followThis: 1*range(int(64),both,one))
+  $CHPL_HOME/modules/internal/ChapelIteratorSupport.chpl:nnnn: called as foo(param tag = iterKind.follower, followThis: 1*range(int(64),both,one))
   within internal functions (use --print-callstack-on-error to see)
 testing call of serial
 in the serial iterator

--- a/test/unstable-keyword/iterator/onlySerial.prediff
+++ b/test/unstable-keyword/iterator/onlySerial.prediff
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# Designed to squash out line numbers from modules files to prevent
+# sensitivities to code locations.  Borrowed from
+# `test/functions/operatorOverloads/operatorMethods/nestedMethodBad.prediff`
+#
+
+tmpfile=$2
+
+tmptmp=`mktemp "tmp.XXXXXX"`
+
+regex='\|CHPL_HOME/modules|s/:[0-9:]*:/:nnnn:/'
+
+sed -e "$regex" $tmpfile > $tmptmp
+
+mv $tmptmp $tmpfile


### PR DESCRIPTION
And update the .bad/.good files to match that prediff's expectations

Not sure why I keep thinking the module line number adjustments will happen automatically but whatever