### PR TITLE
Turn off floating point warning for --no-ieee-float with C backend

### DIFF
--- a/make/compiler/Makefile.clang
+++ b/make/compiler/Makefile.clang
@@ -73,6 +73,10 @@ CXX_STD :=
 CXX11_STD :=
 endif
 
+ifndef CLANG_MAJOR_VERSION
+export CLANG_MAJOR_VERSION := $(shell $(CC) -dumpversion | awk '{split($$1,a,"."); printf("%s", a[1]);}')
+endif
+
 #
 # Flags for compiler, runtime, and generated code
 #
@@ -100,6 +104,9 @@ endif
 
 # Set flag for lax or IEEE floating point
 FAST_FLOAT_GEN_CFLAGS = -ffast-math
+ifeq ($(shell test $(CLANG_MAJOR_VERSION) -ge 18; echo "$$?"),0)
+FAST_FLOAT_GEN_CFLAGS += -Wno-nan-infinity-disabled
+endif
 IEEE_FLOAT_GEN_CFLAGS = -fno-fast-math
 
 ifeq ($(CHPL_MAKE_PLATFORM), darwin)


### PR DESCRIPTION
Turns off floating point warning for --no-ieee-float with C backend.

This was working for the LLVM backend but not the C backend. The same solution can be used, just in a different place. The solution for LLVM was added in https://github.com/chapel-lang/chapel/pull/24848

With clang 18+, when using `-ffast-math` (enabled by Chapel's `--no-ieee-float`) a warning is thrown when using some C math functions related to inf and NaN. These warnings can and must be disabled by `-Wno-nan-infinity-disabled` since C math functions are included in all compiles as they are stubbed out in the runtime. 

Future work may include investigating a more fine grained approach. Should we suppress the warning for the runtime stubs but propagate it for user code which falls into this category?

[Reviewed by @mppf]