### PR TITLE
Ignore PSHM warning when testing co-locales on GASNet

### DIFF
--- a/util/cron/common-gasnet.bash
+++ b/util/cron/common-gasnet.bash
@@ -12,6 +12,7 @@ export CHPL_COMM=gasnet
 export GASNET_SPAWNFN=L
 export GASNET_ROUTE_OUTPUT=0
 export CHPL_GASNET_CFG_OPTIONS=--disable-ibv
+export CHPL_SYSTEM_PREDIFF=$CHPL_HOME/util/test/prediff-for-gasnet
 
 # Bump the timeout slightly just because we're oversubscribed
 export CHPL_TEST_TIMEOUT=500

--- a/util/cron/common-hpe-apollo.bash
+++ b/util/cron/common-hpe-apollo.bash
@@ -7,6 +7,7 @@ UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 export CHPL_HOST_PLATFORM=hpe-apollo
 export CHPL_TEST_LAUNCHCMD=\$CHPL_HOME/util/test/chpl_launchcmd.py
 export CHPL_LAUNCHER_TIMEOUT=pbs
+export CHPL_SYSTEM_PREDIFF=$CHPL_HOME/util/test/prediff-for-gasnet
 
 module purge
 source $UTIL_CRON_DIR/load-base-deps.bash

--- a/util/test/prediff-for-gasnet
+++ b/util/test/prediff-for-gasnet
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+#
+# Remove warning about PSHM being disabled when there are co-locales.
+#
+import sys, re
+
+outfname = sys.argv[2]
+with open(outfname, "r") as f:
+    outText = f.read()
+
+msg = r"""\*\*\* WARNING \(proc 0\): Running with multiple processes per host without shared-memory communication support \(PSHM\).  This can significantly reduce performance.  Please re-configure GASNet using `--enable-pshm` to enable fast intra-host comms.
+"""
+outText = re.sub(msg, "", outText, flags = re.MULTILINE)
+
+with open(outfname, "w") as f:
+    f.write(outText)


### PR DESCRIPTION
Ignore PSHM warning when testing co-locales on GASNet. GASNet will print a warning if PSHM is disabled and there are multiple processes on the same node (i.e., there are co-locales). This warning should be ignored when checking test output.