### PR TITLE
Turn off Python sub-interpreter tests

### DIFF
--- a/modules/packages/Python.chpl
+++ b/modules/packages/Python.chpl
@@ -76,6 +76,11 @@
   Using Multiple Interpreters
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+  .. warning::
+
+     Sub-interpreter support in Chapel is highly experimental and currently has
+     undefined behavior.
+
   The most performant way to run Python code in parallel is to use multiple
   sub-interpreters. Each sub-interpreter is isolated from the others with its
   own GIL. This allows multiple threads to run Python code concurrently. Note
@@ -94,6 +99,7 @@
   ..
      START_TEST
      FILENAME: CoforallTestSub.chpl
+     NOEXEC
      START_GOOD
      Hello from a task
      Hello from a task
@@ -135,6 +141,7 @@
   ..
      START_TEST
      FILENAME: TaskPrivateSubInterp.chpl
+     NOEXEC
      START_GOOD
      10
      10
@@ -1241,7 +1248,8 @@ module Python {
     /*
       Returns the Chapel value of the object.
 
-      This is a shortcut for calling :proc:`~Interpreter.fromPython` on this object, however it does not consume the object.
+      This is a shortcut for calling :proc:`~Interpreter.fromPython` on this
+      object, however it does not consume the object.
     */
     proc value(type value) throws {
       // fromPython will decrement the reference count, so we need to increment it

--- a/test/library/packages/Python/correctness/compareIterationPatterns.chpl
+++ b/test/library/packages/Python/correctness/compareIterationPatterns.chpl
@@ -5,6 +5,7 @@ use Time;
 config const print = true;
 config const time = false;
 config const n = 10;
+config const runSubInterp = false;
 
 config const lambdaStr = "lambda x,: x + 1 if x % 2 != 0 else x";
 proc makeEven(x: int): int do return if x % 2 != 0 then x+1 else x;
@@ -112,7 +113,7 @@ proc main() {
       writeln("Parallel Python result: ", res);
   }
 
-  {
+  if runSubInterp {
     data = 1..#n;
     var s = new stopwatch();
     s.start();

--- a/test/library/packages/Python/correctness/compareIterationPatterns.good
+++ b/test/library/packages/Python/correctness/compareIterationPatterns.good
@@ -1,6 +1,5 @@
 data: 1 2 3 4 5 6 7 8 9 10
 Serial Python result: 2 2 4 4 6 6 8 8 10 10
 Parallel Python result: 2 2 4 4 6 6 8 8 10 10
-Parallel Python SubInterpreter result: 2 2 4 4 6 6 8 8 10 10
 Serial Chapel result: 2 2 4 4 6 6 8 8 10 10
 Parallel Chapel result: 2 2 4 4 6 6 8 8 10 10

--- a/test/library/packages/Python/correctness/noExceptions.future
+++ b/test/library/packages/Python/correctness/noExceptions.future
@@ -1,1 +1,1 @@
-feature request: ability to set override the global checkExceptions
+feature request: ability to override the global checkExceptions

--- a/test/library/packages/Python/correctness/subInterp.noexec
+++ b/test/library/packages/Python/correctness/subInterp.noexec
@@ -1,0 +1,1 @@
+sub interpreters are highly unstable

--- a/test/library/packages/Python/doc-examples/parse_docs.py
+++ b/test/library/packages/Python/doc-examples/parse_docs.py
@@ -39,6 +39,7 @@ class TestCase:
     good_file: File = field(default_factory=File)
     compopts: typing.Optional[File] = None
     execopts: typing.Optional[File] = None
+    noexec: bool = False
 
     def write(self, directory: str):
         self.test_file.write(directory)
@@ -47,6 +48,12 @@ class TestCase:
             self.compopts.write(directory)
         if self.execopts:
             self.execopts.write(directory)
+        if self.noexec:
+            noexec_file = os.path.join(
+                directory, self.test_file.basename() + ".noexec"
+            )
+            with open(noexec_file, "w"):
+                pass
 
 
 def parse(lines: typing.List[str]) -> typing.List[TestCase]:
@@ -130,6 +137,12 @@ def parse(lines: typing.List[str]) -> typing.List[TestCase]:
         ):
             mylines = [lines[cur_line].strip().split(":", maxsplit=1)[1].strip()]
             test.execopts = File(test_file.basename() + ".execopts", mylines)
+            cur_line += 1
+            continue
+
+        # set the noexec flag
+        if test and test_file and lines[cur_line].strip() == "NOEXEC":
+            test.noexec = True
             cur_line += 1
             continue
 


### PR DESCRIPTION
This PR turns off Python sub-interpreter tests. These tests have wildly unpredictable output due to race conditions. This PR also adds a warning to the docs warning users about this.

This PR has a few other nit cleanups.

