### PR TITLE
Dyno: resolution fixes variety pack

### DIFF
--- a/frontend/include/chpl/resolution/can-pass.h
+++ b/frontend/include/chpl/resolution/can-pass.h
@@ -96,6 +96,8 @@ class CanPassResult {
   static bool isTypeGeneric(Context* context, const types::QualifiedType& qt);
   static bool isTypeGeneric(Context* context, const types::Type* t);
 
+  static CanPassResult ensureSubtypeConversionInstantiates(CanPassResult r);
+
   static bool
   canConvertNumeric(Context* context,
                     const types::Type* actualT,

--- a/frontend/include/chpl/resolution/resolution-error-classes-list.h
+++ b/frontend/include/chpl/resolution/resolution-error-classes-list.h
@@ -75,6 +75,7 @@ ERROR_CLASS(IteratorsInOtherScopes, const uast::AstNode*, const resolution::Type
 ERROR_CLASS(MemManagementNonClass, const uast::New*, const types::Type*)
 ERROR_CLASS(MissingInclude, const uast::Include*, std::string)
 ERROR_CLASS(MissingFormalInstantiation, const uast::AstNode*, std::vector<std::tuple<const uast::Decl*, types::QualifiedType>>)
+ERROR_CLASS(MismatchedInitializerResult, const uast::AstNode*, const types::CompositeType*, const types::CompositeType*, std::vector<std::tuple<ID, chpl::UniqueString, types::QualifiedType, types::QualifiedType>>)
 ERROR_CLASS(ModuleAsVariable, const uast::AstNode*, const uast::AstNode*, const uast::Module*)
 ERROR_CLASS(MultipleEnumElems, const uast::AstNode*, chpl::UniqueString, const uast::Enum*, std::vector<ID>)
 ERROR_CLASS(MultipleInheritance, const uast::Class*, const uast::AstNode*, const uast::AstNode*)

--- a/frontend/lib/resolution/InitResolver.cpp
+++ b/frontend/lib/resolution/InitResolver.cpp
@@ -454,6 +454,12 @@ static const Type* ctFromSubs(Context* context,
 const Type* InitResolver::computeReceiverTypeConsideringState(void) {
   auto ctInitial = initialRecvType_->getCompositeType();
 
+  // for the purposes of determing if subs are needed, we want to inspect the
+  // base type.
+  if (auto ctInitialBase = ctInitial->instantiatedFromCompositeType()) {
+    ctInitial = ctInitialBase;
+  }
+
   // The non-default fields are used to determine if we need to create
   // substitutions. I.e., if a field is concrete even if we ignore defaults,
   // no reason to add a substitution.
@@ -791,8 +797,8 @@ bool InitResolver::applyResolvedInitCallToState(const FnCall* node,
   }
 
   auto initialCompType = initialRecvType_->getCompositeType();
-  if (initialCompType->instantiatedFromCompositeType()) {
-    initialCompType = initialCompType->instantiatedFromCompositeType();
+  if (auto initialCompTypeBase = initialCompType->instantiatedFromCompositeType()) {
+    initialCompType = initialCompTypeBase;
   }
 
   CHPL_ASSERT(receiverCompType == initialCompType);

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1255,16 +1255,23 @@ void Resolver::resolveTypeQueries(const AstNode* formalTypeExpr,
   }
 }
 
+void Resolver::resolveVarArgSizeQuery(const uast::VarArgFormal* varArgFormal,
+                                      int numVarArgs) {
+  if (auto countQuery = varArgFormal->count()) {
+    if (countQuery->isTypeQuery()) {
+      ResolvedExpression& result = byPostorder.byAst(countQuery);
+      result.setType(QualifiedType::makeParamInt(context, numVarArgs));
+    }
+  }
+}
+
 void Resolver::resolveTypeQueriesFromFormalType(const VarLikeDecl* formal,
                                                 QualifiedType formalType) {
   if (auto varargs = formal->toVarArgFormal()) {
     const TupleType* tuple = formalType.type()->toTupleType();
 
     // args...?n
-    if (auto countQuery = varargs->count()) {
-      ResolvedExpression& result = byPostorder.byAst(countQuery);
-      result.setType(QualifiedType::makeParamInt(context, tuple->numElements()));
-    }
+    resolveVarArgSizeQuery(varargs, tuple->numElements());
 
     if (auto typeExpr = formal->typeExpression()) {
       QualifiedType useType = tuple->elementType(0);

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1838,7 +1838,12 @@ void Resolver::resolveNamedDecl(const NamedDecl* decl, const Type* useType) {
         if (inferFromInit == false && !isTypeOrParam)  {
           // check also for a generic type as the type expression
           auto g = getTypeGenericity(context, typeExprT);
-          if (g != Type::GENERIC) {
+
+          // "generic with defaults" at this point means "generic" because
+          // getTypeGenericity considers the type expression's substitutions,
+          // and existing logic would have inserted the defaults if possible.
+          // Thus, this expression is explicitly generic.
+          if (g != Type::GENERIC && g != Type::GENERIC_WITH_DEFAULTS) {
             inferFromInit = true;
           }
         }

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -3004,6 +3004,9 @@ QualifiedType Resolver::typeForId(const ID& id, bool localGenericToUnknown) {
     return QualifiedType(QualifiedType::TYPE, t);
   } else if (asttags::isModule(tag)) {
     return QualifiedType(QualifiedType::MODULE, nullptr);
+  } else if (asttags::isEnum(tag)) {
+    const Type* t = initialTypeForTypeDecl(context, id);
+    return QualifiedType(QualifiedType::TYPE, t);
   } else if (asttags::isInterface(tag)) {
     const Type* t = initialTypeForInterface(context, id);
     return QualifiedType(QualifiedType::TYPE, t);

--- a/frontend/lib/resolution/Resolver.h
+++ b/frontend/lib/resolution/Resolver.h
@@ -394,6 +394,9 @@ struct Resolver {
                           bool isNonStarVarArg = false,
                           bool isTopLevel = true);
 
+  void resolveVarArgSizeQuery(const uast::VarArgFormal* varArgFormal,
+                              int numVarArgs);
+
   /* When resolving a function with a TypeQuery, we need to
      resolve the type that is queried, since it can be used
      on its own later.

--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -520,9 +520,8 @@ CanPassResult CanPassResult::canPassSubtypeNonBorrowing(Context* context,
   // nil -> pointers
   if (actualT->isNilType() && formalT->isNilablePtrType() &&
       !formalT->isCStringType()) {
-    bool instantiates = false;
     return CanPassResult(/* no fail reason */ {},
-                         instantiates,
+                         /* instantiates */ false,
                          /*promotes*/ false,
                          /*conversion*/ SUBTYPE);
   }

--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -521,13 +521,6 @@ CanPassResult CanPassResult::canPassSubtypeNonBorrowing(Context* context,
   if (actualT->isNilType() && formalT->isNilablePtrType() &&
       !formalT->isCStringType()) {
     bool instantiates = false;
-    if (auto ct = formalT->toClassType()) {
-      if (auto mt = ct->manageableType()) {
-        if (mt->isAnyClassType()) {
-          instantiates = true;
-        }
-      }
-    }
     return CanPassResult(/* no fail reason */ {},
                          instantiates,
                          /*promotes*/ false,

--- a/frontend/lib/resolution/resolution-error-classes-list.cpp
+++ b/frontend/lib/resolution/resolution-error-classes-list.cpp
@@ -1213,6 +1213,32 @@ void ErrorMissingFormalInstantiation::write(ErrorWriterBase& wr) const {
   }
 }
 
+void ErrorMismatchedInitializerResult::write(ErrorWriterBase& wr) const {
+  auto node = std::get<0>(info_);
+  auto initialCT = std::get<1>(info_);
+  auto finalCT = std::get<2>(info_);
+  auto& mismatches = std::get<3>(info_);
+
+  wr.heading(kind_, type_, node, "final result of initialization does not match the initial type.");
+  wr.message("In the following initialization: ");
+  wr.code(justOneLine(node), { node });
+  wr.message("The initializer was invoked with an instantiated type '", initialCT, "'.");
+  wr.message("However, the initializer resulted in a value of type '", finalCT, "'.");
+
+  for (auto& mismatch : mismatches) {
+    auto& id = std::get<0>(mismatch);
+    auto fieldName = std::get<1>(mismatch);
+    auto& expectedType = std::get<2>(mismatch);
+    auto& actualType = std::get<3>(mismatch);
+
+    wr.message("");
+    wr.note(id, "field '", fieldName, "' started with type '", expectedType.type(),
+            "', but had incompatible type '", actualType.type(), "' "
+            "after initialization.");
+    wr.codeForDef(id);
+  }
+}
+
 void ErrorModuleAsVariable::write(ErrorWriterBase& wr) const {
   auto node = std::get<0>(info_);
   auto parent = std::get<1>(info_);

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -3289,7 +3289,15 @@ isInitialTypedSignatureApplicable(Context* context,
       } else {
         got = canPassFn(context, actualType, formalType);
       }
-      if (!got.passes()) {
+      if (got.passes()) {
+        // fine, continue to next entry
+      } else if (got.reason() == FAIL_DID_NOT_INSTANTIATE) {
+        // A conversion is possible, but the formal type is generic and
+        // the actual doesn't have enough info to instantiate. However,
+        // this is only the "initial" check -- previous formals might contribute
+        // information that makes the formal concrete. Allow this for now.
+      } else {
+        CHPL_ASSERT(!got.passes());
         return ApplicabilityResult::failure(tfs, got.reason(), entry.formalIdx());
       }
     }

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2417,6 +2417,7 @@ ApplicabilityResult instantiateSignature(ResolutionContext* rc,
       QualifiedType vat = QualifiedType(formal->storageKind(), t);
       substitutions.insert({formal->id(), vat});
       r.byAst(formal).setType(vat);
+      visitor.resolveVarArgSizeQuery(formal, t->numElements());
 
       // note that a substitution was used here
       if ((size_t) varArgIdx >= formalsInstantiated.size()) {

--- a/frontend/lib/resolution/signature-checks.cpp
+++ b/frontend/lib/resolution/signature-checks.cpp
@@ -61,7 +61,8 @@ static const bool& checkSignatureQuery(Context* context,
     auto thisIntent = sig->formalType(0).kind();
     auto rhsIntent = sig->formalType(1).kind();
     // check the intent of the 'this' argument
-    if (!(isGenericQualifier(thisIntent) || isRefQualifier(thisIntent))) {
+    if (!(isGenericQualifier(thisIntent) || isRefQualifier(thisIntent) ||
+          (isInQualifier(thisIntent) && sig->formalType(0).type()->isClassType()))) {
       context->error(errId, "Bad 'this' intent for init=");
     }
     bool rhsIntentGenericOrRef = isGenericQualifier(rhsIntent) ||

--- a/frontend/test/resolution/testEnums.cpp
+++ b/frontend/test/resolution/testEnums.cpp
@@ -719,6 +719,28 @@ static void test21() {
   check(vars.at("z"), "blue");
 }
 
+static void test22() {
+  auto context = buildStdContext();
+  QualifiedType qt =  resolveTypeOfXInit(context,
+                         R""""(
+                         proc id(param x) param do return x;
+                         proc foo() param {
+                           enum color {
+                             red, green, blue
+                           }
+
+                           return id(color.red);
+                         }
+
+                         var x = foo();
+                         )"""");
+  assert(qt.kind() == QualifiedType::PARAM);
+  assert(qt.type() && qt.type()->isEnumType());
+  assert(qt.param() && qt.param()->isEnumParam());
+
+  ensureParamEnumStr(qt, "red");
+}
+
 int main() {
   test1();
   test2();
@@ -741,6 +763,7 @@ int main() {
   test19();
   test20();
   test21();
+  test22();
 
   return 0;
 }

--- a/frontend/test/resolution/testRanges.cpp
+++ b/frontend/test/resolution/testRanges.cpp
@@ -322,6 +322,23 @@ static void test11(Context* context) {
   check("y5", "positive");
 }
 
+static void test12(Context* context) {
+  context->advanceToNextRevision(false);
+  setupModuleSearchPaths(context, false, false, {}, {});
+  QualifiedType qt =  resolveTypeOfXInit(context,
+                         R""""(
+                         proc foo(arg: range(?) = 0..) do return arg;
+                         var x = foo(0..#10);
+                         )"""", true);
+  assert(qt.type() != nullptr);
+  auto rangeType = qt.type()->toRecordType();
+  assert(rangeType != nullptr);
+  auto idxType = getRangeIndexType(context, rangeType, "both");
+  assert(idxType.type() != nullptr);
+  assert(idxType.type()->isIntType());
+
+}
+
 int main() {
   // first test runs without environment and stdlib.
   test1();
@@ -340,5 +357,6 @@ int main() {
   test9(ctx);
   test10(ctx);
   test11(ctx);
+  test12(ctx);
   return 0;
 }

--- a/frontend/test/resolution/testVarArgs.cpp
+++ b/frontend/test/resolution/testVarArgs.cpp
@@ -852,6 +852,25 @@ static void testGenericInstantiationDisambiguation() {
   CHPL_ASSERT(qt->isIntType());
 }
 
+static void testWhereClauseOnSizeQuery() {
+  auto context = buildStdContext();
+  auto program = std::string(
+    R"""(
+    proc test(xs ...?k) param where k > 1 do return true;
+    proc test(arg) param do return false;
+
+    param x = test(1);
+    param y = test(1, 2, 3);
+    )""");
+
+  auto qts = resolveTypesOfVariables(context, program, {"x", "y"});
+  auto& qtX = qts.at("x");
+  auto& qtY = qts.at("y");
+
+  ensureParamBool(qtX, false);
+  ensureParamBool(qtY, true);
+}
+
 //
 // TODO: test where-clauses:
 //
@@ -883,6 +902,7 @@ int main(int argc, char** argv) {
   testCount();
   testAlignment();
   testGenericInstantiationDisambiguation();
+  testWhereClauseOnSizeQuery();
 
   printf("\nAll tests passed successfully.\n");
 


### PR DESCRIPTION
This PR goes through the resolution meta-issue and fixes a number of relatively simple issues encountered in the course of resolving the specs.

Closes https://github.com/Cray/chapel-private/issues/7036 (querying vararg size in `where` clause)
Closes https://github.com/Cray/chapel-private/issues/7034 ("passing nested enums to generic functions", but actually resolving nested enums at all)
Closes https://github.com/Cray/chapel-private/issues/7033 (`range(?)` formals becoming concrete; more broadly, `R(?)` formals becoming concrete for generic-with-defaults `R`)
Closes https://github.com/Cray/chapel-private/issues/7030 (resolving `new` on type aliases to instantiated types).
Closes https://github.com/Cray/chapel-private/issues/6927 (assigning `nil` to `ddata`, but broadly fixing candidate selection w/ generic formals and subtype conversions)

Reviewed by @riftEmber -- thanks!

## Testing
- [x] dyno tests
- [x] paratest