### PR TITLE
Update docs to point to new webpages rather than old

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,10 +29,10 @@ For more information about Chapel, please refer to the following resources:
 
 =====================  ========================================================
 Project homepage:      https://chapel-lang.org
-Installing Chapel:     https://chapel-lang.org/download.html
+Installing Chapel:     https://chapel-lang.org/download/
 Building from source:  https://chapel-lang.org/docs/usingchapel/QUICKSTART.html
 Sample computations:   https://chapel-lang.org/hellos.html
-Learning Chapel:       https://chapel-lang.org/learning.html
+Learning Chapel:       https://chapel-lang.org/learn/
 Reporting bugs:        https://chapel-lang.org/bugs.html
 Chapel documentation:  https://chapel-lang.org/docs/
 GitHub:                https://github.com/chapel-lang/chapel

--- a/doc/rst/developer/bestPractices/GettingStarted.rst
+++ b/doc/rst/developer/bestPractices/GettingStarted.rst
@@ -23,10 +23,10 @@ with the project via the following steps:
   since that chapter was published, it may be helpful to refer to:
 
   - the CUG 2018 paper or presentation, "Chapel Comes of Age..."
-    available from https://chapel-lang.org/papers.html
+    available from https://chapel-lang.org/papers/
 
-  - the "State of the Project" talk from the most recent `CHIUW
-    workshop <https://chapel-lang.org/CHIUW.html>`_
+  - the "State of the Project" talk from the most recent `ChapelCon
+    meeting <https://chapel-lang.org/ChapelCon.html>`_
 
   - the `release notes <https://chapel-lang.org/releaseNotes.html>`_
     from the most recent Chapel release.
@@ -51,9 +51,9 @@ with the project via the following steps:
 * To learn the language, your best bets are to read the Chapel chapter
   mentioned above, read through the release's primer examples (located
   in ``test/[release/]examples/primers``), watch or browse a `Chapel
-  presentation <https://chapel-lang.org/presentations.html>`_, or
+  presentation <https://chapel-lang.org/presentations/>`_, or
   refer to the `learning Chapel page
-  <https://chapel-lang.org/learning.html>`_.
+  <https://chapel-lang.org/learn/>`_.
 
 * Familiarize yourself with the `language specification
   <https://chapel-lang.org/docs/language/spec/index.html>`_.  This can

--- a/doc/rst/language/evolution.rst
+++ b/doc/rst/language/evolution.rst
@@ -710,7 +710,7 @@ experiences:
 
   If you have a pattern that you're trying to write in an
   index-neutral style, but can't, don't hesitate to `ask for tips
-  <https://chapel-lang.org/community.html>`_.
+  <https://chapel-lang.org/community/>`_.
 
 
 * Some common pitfalls to check for in your code include:
@@ -768,7 +768,7 @@ Need Help?
 
 If you are able to share your code with us and would like help
 updating it to Chapel 1.22, please don't hesitate to `ask for help
-<https://chapel-lang.org/community.html>`_.  Given our experience in
+<https://chapel-lang.org/community/>`_.  Given our experience in
 updating the Chapel code base itself, we have found it fairly easy to
 update most codes, even when we're unfamiliar with them.
 

--- a/doc/rst/platforms/aws.rst
+++ b/doc/rst/platforms/aws.rst
@@ -259,7 +259,7 @@ To build Chapel from source for use on the cluster, follow these steps:
 
     If using a GPU instance, install the CUDA toolkit from the `NVIDIA website <https://developer.nvidia.com/cuda-downloads>`_.
 
-* Download a Chapel release from the `Download <https://chapel-lang.org/download.html>`_ page.
+* Download a Chapel release from the `Download <https://chapel-lang.org/download/>`_ page.
 * Build the Chapel release with ``CHPL_COMM=ofi`` as shown on the :ref:`readme-building` page.
 
    For best results, we recommend running the following prior to building

--- a/doc/rst/users-guide/base/hello.rst
+++ b/doc/rst/users-guide/base/hello.rst
@@ -26,7 +26,7 @@ and save it into a file, say ``hello.chpl``, you'll have written your
 first Chapel program.
 
 Given a working Chapel compiler (see `Downloading Chapel
-<https://chapel-lang.org/download.html>`_ for details), you can compile
+<https://chapel-lang.org/download/>`_ for details), you can compile
 the program using::
 
     chpl hello.chpl -o hello

--- a/doc/rst/usingchapel/QUICKSTART.rst
+++ b/doc/rst/usingchapel/QUICKSTART.rst
@@ -22,7 +22,7 @@ to :ref:`using-a-more-full-featured-chapel` below.
 
 
 1) If you don't already have the Chapel 2.3 source release, see
-   https://chapel-lang.org/download.html.
+   https://chapel-lang.org/download/
 
 
 2) Build Chapel in its 'Quickstart' configuration:

--- a/util/build_configs/cray-internal/generate-dev-releaseinfo.bash
+++ b/util/build_configs/cray-internal/generate-dev-releaseinfo.bash
@@ -68,11 +68,11 @@ Chapel $major.$minor
 
     Interested users are encouraged to ask questions and join
     discussions in a variety of forums (Stack Overflow, Gitter,
-    Discourse, etc.) listed at https://chapel-lang.org/community.html.
+    Discourse, etc.) listed at https://chapel-lang.org/community/
     Questions about Chapel can be directed to the Chapel team.  To file
     bugs or feature requests against Chapel, refer to
     \$CHPL_HOME/doc/html/usingchapel/bugs.html or
-    https://chapel-lang.org/bugs.html.
+    https://chapel-lang.org/docs/usingchapel/bugs.html.
 
 
 How Do I Get It?


### PR DESCRIPTION
This updates URLs within our docs to point to the new website rather than the URLs from the old website.  I believe most of these cases would automatically redirect to the new website, but the more we establish the new URLs as the canonical versions, the happier our Google search dashboard will be.

The one change here that's a little borderline is
https://chapel-lang.org/bugs.html which has been a (client-side) redirect for ages, though what it redirects to isn't the greatest of pages (a docs page that basically says "file a github issue."  Here, I've updated one such instance to avoid the redirect, but there are lots of others that I skipped over, feeling like we should probably establish a better bugs page in general.  I've opened an issue on the chapel-www repository to determine what we should do here.
