### PR TITLE
Test chpl-language-server with quickstart

### DIFF
--- a/util/cron/test-quickstart.bash
+++ b/util/cron/test-quickstart.bash
@@ -9,4 +9,4 @@ source $UTIL_CRON_DIR/common-localnode-paratest.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="quickstart"
 
-$UTIL_CRON_DIR/nightly -cron $(get_nightly_paratest_args)
+$UTIL_CRON_DIR/nightly -cron -chpl-language-server $(get_nightly_paratest_args)


### PR DESCRIPTION
Add testing for chpl-language-server to quickstart, since this is a common user config

resolves https://github.com/chapel-lang/chapel/issues/25181

[Reviewed by @DanilaFe]