### PR TITLE
Initial Py_buffer support for Chapel 1D arrays

### DIFF
--- a/modules/packages/PythonHelper/ArrayTypes.c
+++ b/modules/packages/PythonHelper/ArrayTypes.c
@@ -43,7 +43,7 @@ chpl_bool registerArrayTypeEnum(void) {
   if (!elements) return false;
   {
     int i = 0;
-#define chpl_MAKE_ENUM(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, _0, _1, _2) \
+#define chpl_MAKE_ENUM(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, ...) \
   PyDict_SetItemString(elements, #NAMESUFFIX, PyLong_FromLong(i++));
 chpl_ARRAY_TYPES(chpl_MAKE_ENUM)
 #undef chpl_MAKE_ENUM
@@ -68,7 +68,7 @@ chpl_ARRAY_TYPES(chpl_MAKE_ENUM)
 }
 
 
-#define chpl_MAKE_ARRAY_STRUCT(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, _0, _1, _2) \
+#define chpl_MAKE_ARRAY_STRUCT(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, ...) \
   typedef struct { \
     PyObject_HEAD \
     DATATYPE* data; \
@@ -84,7 +84,7 @@ chpl_ARRAY_TYPES(chpl_MAKE_ARRAY_STRUCT)
 static int ArrayGenericObject_init(PyObject* self, PyObject* args, PyObject* kwargs) {
   return 0;
 }
-#define chpl_MAKE_DEALLOC(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, _0, _1, _2) \
+#define chpl_MAKE_DEALLOC(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, ...) \
   static void Array##NAMESUFFIX##Object_dealloc(Array##NAMESUFFIX##Object* self) { \
     if (self->isOwned) chpl_mem_free(self->data, 0, 0); \
     Py_CLEAR(self->eltType); \
@@ -96,7 +96,7 @@ chpl_ARRAY_TYPES(chpl_MAKE_DEALLOC)
 #undef chpl_MAKE_DEALLOC
 
 
-#define chpl_MAKE_REPR(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, _0, _1, _2) \
+#define chpl_MAKE_REPR(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, ...) \
   static PyObject* Array##NAMESUFFIX##Object_repr(Array##NAMESUFFIX##Object* self) { \
     return PyUnicode_FromFormat("Array(eltType="CHAPELDATATYPE",size=%zd)", self->size); \
   }
@@ -104,7 +104,7 @@ chpl_ARRAY_TYPES(chpl_MAKE_REPR)
 #undef chpl_MAKE_REPR
 
 // TODO: how can we remove the error checking here with --no-checks or -scheckExceptions=false?
-#define chpl_MAKE_SETITEM(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, CHECKTYPE, ASTYPE, _0) \
+#define chpl_MAKE_SETITEM(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, CHECKTYPE, ASTYPE, ...) \
   static int Array##NAMESUFFIX##Object_sq_setitem(Array##NAMESUFFIX##Object* self, Py_ssize_t index, PyObject* value) { \
     if (!value) { \
       PyErr_SetString(PyExc_TypeError, "cannot delete items from this array"); \
@@ -126,7 +126,7 @@ chpl_ARRAY_TYPES(chpl_MAKE_REPR)
 chpl_ARRAY_TYPES(chpl_MAKE_SETITEM)
 #undef chpl_MAKE_SETITEM
 
-#define chpl_MAKE_SETITEM(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, CHECKTYPE, ASTYPE, _0) \
+#define chpl_MAKE_SETITEM(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, CHECKTYPE, ASTYPE, ...) \
   static int Array##NAMESUFFIX##Object_mp_setitem(Array##NAMESUFFIX##Object* self, PyObject* indexObj, PyObject* value) { \
     if (!value) { \
       PyErr_SetString(PyExc_TypeError, "cannot delete items from this array"); \
@@ -154,7 +154,7 @@ chpl_ARRAY_TYPES(chpl_MAKE_SETITEM)
 chpl_ARRAY_TYPES(chpl_MAKE_SETITEM)
 #undef chpl_MAKE_SETITEM
 
-#define chpl_MAKE_GETITEM(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, CHECKTYPE, ASTYPE, FROMTYPE) \
+#define chpl_MAKE_GETITEM(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, CHECKTYPE, ASTYPE, FROMTYPE, ...) \
   static PyObject* Array##NAMESUFFIX##Object_sq_getitem(Array##NAMESUFFIX##Object* self, Py_ssize_t index) { \
     if (index < 0 || index >= self->size) { \
       PyErr_SetString(PyExc_IndexError, "index out of bounds"); \
@@ -164,7 +164,7 @@ chpl_ARRAY_TYPES(chpl_MAKE_SETITEM)
   }
 chpl_ARRAY_TYPES(chpl_MAKE_GETITEM)
 #undef chpl_MAKE_GETITEM
-#define chpl_MAKE_GETITEM(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, CHECKTYPE, ASTYPE, FROMTYPE) \
+#define chpl_MAKE_GETITEM(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, CHECKTYPE, ASTYPE, FROMTYPE, ...) \
   static PyObject* Array##NAMESUFFIX##Object_mp_getitem(Array##NAMESUFFIX##Object* self, PyObject* indexObj) { \
     if (!PyLong_Check(indexObj)) { \
       /* TODO: support slices */ \
@@ -181,7 +181,7 @@ chpl_ARRAY_TYPES(chpl_MAKE_GETITEM)
 chpl_ARRAY_TYPES(chpl_MAKE_GETITEM)
 #undef chpl_MAKE_GETITEM
 
-#define chpl_MAKE_LENGTH(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, _0, _1, _2) \
+#define chpl_MAKE_LENGTH(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, ...) \
   static Py_ssize_t Array##NAMESUFFIX##Object_length(Array##NAMESUFFIX##Object* self) { \
     return self->size; \
   }
@@ -189,7 +189,42 @@ chpl_ARRAY_TYPES(chpl_MAKE_LENGTH)
 #undef chpl_MAKE_LENGTH
 
 
-#define chpl_MAKE_TYPE(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, _0, _1, _2) \
+// https://docs.python.org/3/c-api/typeobj.html#c.PyBufferProcs.bf_getbuffer
+// 1. Check if the request can be met. If not, raise BufferError, set view->obj to NULL and return -1.
+// 2. Fill in the requested fields.
+// 3. Increment an internal counter for the number of exports.
+// 4. Set view->obj to exporter and increment view->obj.
+// 5. Return 0.
+#define chpl_MAKE_GET_BUFFER(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, _0, _1, _2, SUPPORTSBUFFERS) \
+static int Array##NAMESUFFIX##Object_bf_getbuffer(Array##NAMESUFFIX##Object* arr, Py_buffer* view, int flags) { \
+  if (!SUPPORTSBUFFERS) { \
+    PyErr_SetString(PyExc_BufferError, "This array does not support the buffer protocol"); \
+    view->obj = NULL; \
+    return -1; \
+  } \
+  /* other error checking for invalid request in flags?! */ \
+  view->buf = arr->data; \
+  view->obj = (PyObject*) arr; \
+  view->len = arr->size * sizeof(DATATYPE); \
+  view->itemsize = sizeof(DATATYPE); \
+  view->readonly = 0; \
+  view->ndim = arr->ndim; \
+  view->format = NULL; \
+  if (flags & PyBUF_FORMAT) { \
+    view->format = "q"; /*compute format string based on datatype */ \
+  } \
+  /*TODO: support nd arrays*/ \
+  view->shape = NULL; \
+  view->strides = NULL; \
+  view->suboffsets = NULL; \
+  Py_INCREF(view->obj); \
+  return 0; \
+}
+chpl_ARRAY_TYPES(chpl_MAKE_GET_BUFFER)
+#undef chpl_MAKE_GET_BUFFER
+
+
+#define chpl_MAKE_TYPE(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, ...) \
   static chpl_bool createArray##NAMESUFFIX##Type(void) { \
     PyMethodDef methods[] = { \
       {NULL, NULL, 0, NULL}  /* Sentinel */ \
@@ -214,6 +249,7 @@ chpl_ARRAY_TYPES(chpl_MAKE_LENGTH)
       {Py_mp_length, (void*) Array##NAMESUFFIX##Object_length}, \
       {Py_tp_methods, (void*) methods}, \
       {Py_tp_members, (void*) members}, \
+      {Py_bf_getbuffer, (void*) Array##NAMESUFFIX##Object_bf_getbuffer}, \
       {0, NULL} \
     }; \
     PyType_Spec spec = { \
@@ -231,14 +267,14 @@ chpl_ARRAY_TYPES(chpl_MAKE_TYPE)
 #undef chpl_MAKE_TYPE
 
 chpl_bool createArrayTypes(void) {
-#define chpl_MAKE_TYPE(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, _0, _1, _2) \
+#define chpl_MAKE_TYPE(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, ...) \
   if (!createArray##NAMESUFFIX##Type()) return false;
 chpl_ARRAY_TYPES(chpl_MAKE_TYPE)
 #undef chpl_MAKE_TYPE
   return true;
 }
 
-#define chpl_CREATE_ARRAY(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, _0, _1, _2) \
+#define chpl_CREATE_ARRAY(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, ...) \
   PyObject* createArray##NAMESUFFIX(DATATYPE* data, Py_ssize_t size, chpl_bool isOwned) { \
     assert(Array##NAMESUFFIX##Type); \
     assert(ArrayTypeEnum); \

--- a/modules/packages/PythonHelper/ArrayTypes.c
+++ b/modules/packages/PythonHelper/ArrayTypes.c
@@ -195,7 +195,7 @@ chpl_ARRAY_TYPES(chpl_MAKE_LENGTH)
 // 3. Increment an internal counter for the number of exports.
 // 4. Set view->obj to exporter and increment view->obj.
 // 5. Return 0.
-#define chpl_MAKE_GET_BUFFER(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, _0, _1, _2, SUPPORTSBUFFERS) \
+#define chpl_MAKE_GET_BUFFER(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, _0, _1, _2, SUPPORTSBUFFERS, FORMATSTRING) \
 static int Array##NAMESUFFIX##Object_bf_getbuffer(Array##NAMESUFFIX##Object* arr, Py_buffer* view, int flags) { \
   if (!SUPPORTSBUFFERS) { \
     PyErr_SetString(PyExc_BufferError, "This array does not support the buffer protocol"); \
@@ -211,7 +211,7 @@ static int Array##NAMESUFFIX##Object_bf_getbuffer(Array##NAMESUFFIX##Object* arr
   view->ndim = arr->ndim; \
   view->format = NULL; \
   if (flags & PyBUF_FORMAT) { \
-    view->format = "q"; /*compute format string based on datatype */ \
+    view->format = FORMATSTRING; \
   } \
   /*TODO: support nd arrays*/ \
   view->shape = NULL; \

--- a/modules/packages/PythonHelper/ArrayTypes.h
+++ b/modules/packages/PythonHelper/ArrayTypes.h
@@ -35,30 +35,31 @@
 // python check function
 // consuming PyObject function
 // producing PyObject function
+// supports buffer protocol
 //
 #define chpl_ARRAY_TYPES(V) \
-  V(int64_t, "int(64)", I64, PyLong_Check, PyLong_AsLongLong, PyLong_FromLongLong) \
-  V(uint64_t, "uint(64)", U64, PyLong_Check, PyLong_AsUnsignedLongLong, PyLong_FromUnsignedLongLong) \
-  V(int32_t, "int(32)", I32, PyLong_Check, PyLong_AsLong, PyLong_FromLong) \
-  V(uint32_t, "uint(32)", U32, PyLong_Check, PyLong_AsUnsignedLong, PyLong_FromUnsignedLong) \
-  V(int16_t, "int(16)", I16, PyLong_Check, PyLong_AsLong, PyLong_FromLong) \
-  V(uint16_t, "uint(16)", U16, PyLong_Check, PyLong_AsUnsignedLong, PyLong_FromUnsignedLong) \
-  V(int8_t, "int(8)", I8, PyLong_Check, PyLong_AsLong, PyLong_FromLong) \
-  V(uint8_t, "uint(8)", U8, PyLong_Check, PyLong_AsUnsignedLong, PyLong_FromUnsignedLong) \
-  V(_real64, "real(64)", R64, PyFloat_Check, PyFloat_AsDouble, PyFloat_FromDouble) \
-  V(_real32, "real(32)", R32, PyFloat_Check, PyFloat_AsDouble, PyFloat_FromDouble) \
-  V(chpl_bool, "bool", Bool, PyBool_Check, PyObject_IsTrue, PyBool_FromLong) \
-  V(PyObject*, "array", A, (intptr_t), (PyObject*), (PyObject*))
+  V(int64_t, "int(64)", I64, PyLong_Check, PyLong_AsLongLong, PyLong_FromLongLong, true) \
+  V(uint64_t, "uint(64)", U64, PyLong_Check, PyLong_AsUnsignedLongLong, PyLong_FromUnsignedLongLong, true) \
+  V(int32_t, "int(32)", I32, PyLong_Check, PyLong_AsLong, PyLong_FromLong, true) \
+  V(uint32_t, "uint(32)", U32, PyLong_Check, PyLong_AsUnsignedLong, PyLong_FromUnsignedLong, true) \
+  V(int16_t, "int(16)", I16, PyLong_Check, PyLong_AsLong, PyLong_FromLong, true) \
+  V(uint16_t, "uint(16)", U16, PyLong_Check, PyLong_AsUnsignedLong, PyLong_FromUnsignedLong, true) \
+  V(int8_t, "int(8)", I8, PyLong_Check, PyLong_AsLong, PyLong_FromLong, true) \
+  V(uint8_t, "uint(8)", U8, PyLong_Check, PyLong_AsUnsignedLong, PyLong_FromUnsignedLong, true) \
+  V(_real64, "real(64)", R64, PyFloat_Check, PyFloat_AsDouble, PyFloat_FromDouble, true) \
+  V(_real32, "real(32)", R32, PyFloat_Check, PyFloat_AsDouble, PyFloat_FromDouble, true) \
+  V(chpl_bool, "bool", Bool, PyBool_Check, PyObject_IsTrue, PyBool_FromLong, true) \
+  V(PyObject*, "array", A, (intptr_t), (PyObject*), (PyObject*), false)
 
 
-#define chpl_MAKE_ARRAY_TYPES(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, _0, _1, _2) extern PyTypeObject* Array##NAMESUFFIX##Type;
+#define chpl_MAKE_ARRAY_TYPES(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, _0, _1, _2, _3) extern PyTypeObject* Array##NAMESUFFIX##Type;
 chpl_ARRAY_TYPES(chpl_MAKE_ARRAY_TYPES)
 #undef chpl_MAKE_ARRAY_TYPES
 
 chpl_bool registerArrayTypeEnum(void);
 chpl_bool createArrayTypes(void);
 
-#define chpl_CREATE_ARRAY(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, _0, _1, _2) PyObject* createArray##NAMESUFFIX(DATATYPE* data, Py_ssize_t size, chpl_bool isOwned);
+#define chpl_CREATE_ARRAY(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, _0, _1, _2, _3) PyObject* createArray##NAMESUFFIX(DATATYPE* data, Py_ssize_t size, chpl_bool isOwned);
 chpl_ARRAY_TYPES(chpl_CREATE_ARRAY)
 #undef chpl_CREATE_ARRAY
 

--- a/modules/packages/PythonHelper/ArrayTypes.h
+++ b/modules/packages/PythonHelper/ArrayTypes.h
@@ -36,30 +36,31 @@
 // consuming PyObject function
 // producing PyObject function
 // supports buffer protocol
+// format string
 //
 #define chpl_ARRAY_TYPES(V) \
-  V(int64_t, "int(64)", I64, PyLong_Check, PyLong_AsLongLong, PyLong_FromLongLong, true) \
-  V(uint64_t, "uint(64)", U64, PyLong_Check, PyLong_AsUnsignedLongLong, PyLong_FromUnsignedLongLong, true) \
-  V(int32_t, "int(32)", I32, PyLong_Check, PyLong_AsLong, PyLong_FromLong, true) \
-  V(uint32_t, "uint(32)", U32, PyLong_Check, PyLong_AsUnsignedLong, PyLong_FromUnsignedLong, true) \
-  V(int16_t, "int(16)", I16, PyLong_Check, PyLong_AsLong, PyLong_FromLong, true) \
-  V(uint16_t, "uint(16)", U16, PyLong_Check, PyLong_AsUnsignedLong, PyLong_FromUnsignedLong, true) \
-  V(int8_t, "int(8)", I8, PyLong_Check, PyLong_AsLong, PyLong_FromLong, true) \
-  V(uint8_t, "uint(8)", U8, PyLong_Check, PyLong_AsUnsignedLong, PyLong_FromUnsignedLong, true) \
-  V(_real64, "real(64)", R64, PyFloat_Check, PyFloat_AsDouble, PyFloat_FromDouble, true) \
-  V(_real32, "real(32)", R32, PyFloat_Check, PyFloat_AsDouble, PyFloat_FromDouble, true) \
-  V(chpl_bool, "bool", Bool, PyBool_Check, PyObject_IsTrue, PyBool_FromLong, true) \
-  V(PyObject*, "array", A, (intptr_t), (PyObject*), (PyObject*), false)
+  V(int64_t, "int(64)", I64, PyLong_Check, PyLong_AsLongLong, PyLong_FromLongLong, true, "q") \
+  V(uint64_t, "uint(64)", U64, PyLong_Check, PyLong_AsUnsignedLongLong, PyLong_FromUnsignedLongLong, true, "Q") \
+  V(int32_t, "int(32)", I32, PyLong_Check, PyLong_AsLong, PyLong_FromLong, true, "l") \
+  V(uint32_t, "uint(32)", U32, PyLong_Check, PyLong_AsUnsignedLong, PyLong_FromUnsignedLong, true, "L") \
+  V(int16_t, "int(16)", I16, PyLong_Check, PyLong_AsLong, PyLong_FromLong, true, "h") \
+  V(uint16_t, "uint(16)", U16, PyLong_Check, PyLong_AsUnsignedLong, PyLong_FromUnsignedLong, true, "H") \
+  V(int8_t, "int(8)", I8, PyLong_Check, PyLong_AsLong, PyLong_FromLong, true, "b") \
+  V(uint8_t, "uint(8)", U8, PyLong_Check, PyLong_AsUnsignedLong, PyLong_FromUnsignedLong, true, "B") \
+  V(_real64, "real(64)", R64, PyFloat_Check, PyFloat_AsDouble, PyFloat_FromDouble, true, "d") \
+  V(_real32, "real(32)", R32, PyFloat_Check, PyFloat_AsDouble, PyFloat_FromDouble, true, "f") \
+  V(chpl_bool, "bool", Bool, PyBool_Check, PyObject_IsTrue, PyBool_FromLong, true, "?") \
+  V(PyObject*, "array", A, (intptr_t), (PyObject*), (PyObject*), false, "P")
 
 
-#define chpl_MAKE_ARRAY_TYPES(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, _0, _1, _2, _3) extern PyTypeObject* Array##NAMESUFFIX##Type;
+#define chpl_MAKE_ARRAY_TYPES(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, ...) extern PyTypeObject* Array##NAMESUFFIX##Type;
 chpl_ARRAY_TYPES(chpl_MAKE_ARRAY_TYPES)
 #undef chpl_MAKE_ARRAY_TYPES
 
 chpl_bool registerArrayTypeEnum(void);
 chpl_bool createArrayTypes(void);
 
-#define chpl_CREATE_ARRAY(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, _0, _1, _2, _3) PyObject* createArray##NAMESUFFIX(DATATYPE* data, Py_ssize_t size, chpl_bool isOwned);
+#define chpl_CREATE_ARRAY(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, ...) PyObject* createArray##NAMESUFFIX(DATATYPE* data, Py_ssize_t size, chpl_bool isOwned);
 chpl_ARRAY_TYPES(chpl_CREATE_ARRAY)
 #undef chpl_CREATE_ARRAY
 

--- a/modules/packages/PythonHelper/ChapelPythonHelper.h
+++ b/modules/packages/PythonHelper/ChapelPythonHelper.h
@@ -85,4 +85,9 @@ static inline PyStatus chpl_Py_NewIsolatedInterpreter(PyThreadState** tstate) {
 #endif
 }
 
+static const int chpl_PyBUF_SIMPLE = PyBUF_SIMPLE;
+static const int chpl_PyBUF_WRITABLE = PyBUF_WRITABLE;
+static const int chpl_PyBUF_FORMAT = PyBUF_FORMAT;
+static const int chpl_PyBUF_ND = PyBUF_ND;
+
 #endif

--- a/test/library/packages/Python/correctness/arrays/PRETEST
+++ b/test/library/packages/Python/correctness/arrays/PRETEST
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+FILE_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+$FILE_DIR/../../skipIfAndInstallPackage.sh $FILE_DIR numpy &> /dev/null

--- a/test/library/packages/Python/correctness/arrays/SUPPRESSIF
+++ b/test/library/packages/Python/correctness/arrays/SUPPRESSIF
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# tests require numpy
+
+# respect CHPL_TEST_VENV_DIR if it is set and not none
+if [ -n "$CHPL_TEST_VENV_DIR" ] && [ "$CHPL_TEST_VENV_DIR" != "none" ]; then
+  chpl_python=$CHPL_TEST_VENV_DIR/bin/python3
+else
+  chpl_python=$($CHPL_HOME/util/config/find-python.sh)
+fi
+
+FILE_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+export PYTHONPATH=$FILE_DIR/python_libs:$PYTHONPATH
+
+# try and import numpy
+if ! $chpl_python -c "import numpy" &>/dev/null; then
+  echo "True"
+else
+  echo "False"
+fi

--- a/test/library/packages/Python/correctness/arrays/gradient.chpl
+++ b/test/library/packages/Python/correctness/arrays/gradient.chpl
@@ -1,0 +1,48 @@
+use Python;
+
+
+var code = """
+
+import numpy as np
+
+def gradModifyArg(arr, res):
+    arr_np = np.asarray(arr)
+    res_np = np.asarray(res)
+
+    res_np[:] = np.gradient(arr_np)
+
+def grad(arr):
+    x = np.asarray(arr)
+    return np.gradient(x)
+
+""";
+
+proc main() {
+  var interp = new Interpreter();
+  var mod = new Module(interp, '__empty__', code);
+  var gradModifyArg = new Function(mod, 'gradModifyArg');
+  var grad = new Function(mod, 'grad');
+
+  var arr = [1, 2, 4, 7, 11, 16];
+  var pyArr = new Array(interp, arr);
+
+
+  var res: [arr.domain] real;
+  {
+    var pyRes = new Array(interp, res);
+    gradModifyArg(NoneType, pyArr, pyRes);
+  }
+  write("gradModifyArg: ", res);
+  write(" dom: ", res.domain);
+  writeln(" eltType: ", res.eltType:string);
+
+  res = 0.0;
+
+  {
+    var pyRes = grad(owned PyArray(real), pyArr);
+    res = pyRes.array;
+  }
+  write("grad: ", res);
+  write(" dom: ", res.domain);
+  writeln(" eltType: ", res.eltType:string);
+}

--- a/test/library/packages/Python/correctness/arrays/gradient.good
+++ b/test/library/packages/Python/correctness/arrays/gradient.good
@@ -1,0 +1,2 @@
+gradModifyArg: 1.0 1.5 2.5 3.5 4.5 5.0 dom: {0..5} eltType: real(64)
+grad: 1.0 1.5 2.5 3.5 4.5 5.0 dom: {0..5} eltType: real(64)

--- a/test/library/packages/Python/correctness/arrays/numpyInterop.chpl
+++ b/test/library/packages/Python/correctness/arrays/numpyInterop.chpl
@@ -8,6 +8,10 @@ def saxpy(x, y, a):
   x_np = np.asarray(x)
   y_np = np.asarray(y)
   return a*x_np + y_np
+
+def numpyAssign(arr):
+  np_arr = np.asarray(arr)
+  np_arr[:] = 100
 """;
 
 proc main() {
@@ -15,6 +19,7 @@ proc main() {
   var interp = new Interpreter();
   var m = new Module(interp, '__empty__', code);
   var saxpy = new Function(m, 'saxpy');
+  var numpyAssign = new Function(m, 'numpyAssign');
 
   {
     var x = [1, 2, 3];
@@ -25,7 +30,7 @@ proc main() {
     var yArr = new Array(interp, y);
 
     var result = saxpy(owned Value, xArr, yArr, a);
-    writeln(result);
+    writeln("saxpy on 1D arrays: ", result);
   }
   writeln();
   {
@@ -37,7 +42,17 @@ proc main() {
     var yArr = new Array(interp, y);
 
     var result = saxpy(owned Value, xArr, yArr, a);
-    writeln(result);
+    writeln("saxpy on nested arrays: ", result);
+  }
+  writeln();
+  {
+    var x = [1, 2, 3, 4];
+    writeln("Before numpyAssign: ", x);
+    {
+      var xArr = new Array(interp, x);
+      numpyAssign(NoneType, xArr);
+    }
+    writeln("After numpyAssign: ", x);
   }
 
 

--- a/test/library/packages/Python/correctness/arrays/numpyInterop.good
+++ b/test/library/packages/Python/correctness/arrays/numpyInterop.good
@@ -1,4 +1,7 @@
-[ 6  9 12]
+saxpy on 1D arrays: [ 6  9 12]
 
-[[22. 40.]
- [58. 76.]]
+saxpy on nested arrays: [[8.29394166e+19 8.30171037e+19]
+ [8.30565102e+19 8.30959167e+19]]
+
+Before numpyAssign: 1 2 3 4
+After numpyAssign: 100 100 100 100

--- a/test/library/packages/Python/correctness/arrays/numpyInterop.good
+++ b/test/library/packages/Python/correctness/arrays/numpyInterop.good
@@ -1,7 +1,7 @@
 saxpy on 1D arrays: [ 6  9 12]
 
-saxpy on nested arrays: [[8.29394166e+19 8.30171037e+19]
- [8.30565102e+19 8.30959167e+19]]
+saxpy on nested arrays: [[22. 40.]
+ [58. 76.]]
 
 Before numpyAssign: 1 2 3 4
 After numpyAssign: 100 100 100 100

--- a/test/library/packages/Python/correctness/arrays/numpyInterop.skipif
+++ b/test/library/packages/Python/correctness/arrays/numpyInterop.skipif
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-FILE_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
-$FILE_DIR/../../skipIfAndInstallPackage.sh $FILE_DIR numpy

--- a/test/library/packages/Python/correctness/arrays/usePythonArray.chpl
+++ b/test/library/packages/Python/correctness/arrays/usePythonArray.chpl
@@ -1,0 +1,15 @@
+use Python;
+
+proc main() {
+  var interp = new Interpreter();
+  var mod = new Module(interp, "usePythonArray");
+  var doit = new Function(mod, 'doit');
+
+
+  var pyRes = doit(owned PyArray(int), 10, 11, 12, 13);
+  var res = pyRes.array;
+  write("arr: ", res);
+  write(" dom: ", res.domain);
+  writeln(" eltType: ", res.eltType:string);
+
+}

--- a/test/library/packages/Python/correctness/arrays/usePythonArray.good
+++ b/test/library/packages/Python/correctness/arrays/usePythonArray.good
@@ -1,0 +1,1 @@
+arr: 10 11 12 13 dom: {0..3} eltType: int(64)

--- a/test/library/packages/Python/correctness/arrays/usePythonArray.py
+++ b/test/library/packages/Python/correctness/arrays/usePythonArray.py
@@ -1,0 +1,5 @@
+import array
+
+def doit(*args):
+    a = array.array('l', args)
+    return a


### PR DESCRIPTION
Add initial support for passing Chapel arrays to Python as Py_buffer's and for reading Python objects that support the Py_buffer API.

This enables the following use case

```chapel
use Python;
proc main() {
  var interp = new Interpreter();
  var mod = new Module(interp, "buffer");
  var doit_numpy = new Function(mod, "doit_numpy");
  var doit_torch = new Function(mod, "doit_torch");
  var doit_numpy_plus_torch = new Function(mod, "doit_numpy_plus_torch");

  var arr = [1, 2, 3, 4, 5];
  var pyArr = new Array(interp, arr);

  writeln("Calling numpy version: ", arr);
  doit_numpy(NoneType, pyArr);
  writeln("Back in Chapel: ", arr);

  arr = [1, 2, 3, 4, 5];
  writeln("Calling torch version: ", arr);
  doit_torch(NoneType, pyArr);
  writeln("Back in Chapel: ", arr);


  arr = [1, 2, 3, 4, 5];
  writeln("Calling numpy+torch version: ", arr);
  doit_numpy_plus_torch(NoneType, pyArr);
  writeln("Back in Chapel: ", arr);
}
```

```python
import numpy as np
import torch

def doit_numpy(arr):
    x = np.asarray(arr)
    x[:] = 100

def doit_torch(arr):
    t = torch.frombuffer(arr, dtype=torch.int64)
    t[:] = 100

def doit_numpy_plus_torch(arr):
    t = torch.from_numpy(np.asarray(arr))
    t[:] = 100
```


- [x] `st test/library/packages/Python`
- [x] `st test/library/packages/Python` with gasnet

[Reviewed by @lydia-duncan]