### PR TITLE
Dyno: fix infinite recursion caused by `init=` on "core" types.

### DIFF
--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -338,6 +338,7 @@ extern bool fDynoGenStdLib;
 extern bool fDynoLibGenOrUse;
 
 extern size_t fDynoBreakOnHash;
+extern bool   fDynoBreakOnHashSet;
 
 extern bool fResolveConcreteFns;
 extern bool fIdBasedMunging;

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -389,6 +389,7 @@ bool fDynoGenLib = false;
 bool fDynoGenStdLib = false;
 bool fDynoLibGenOrUse = false; // .dyno file or --dyno-gen-lib/std
 size_t fDynoBreakOnHash = 0;
+bool   fDynoBreakOnHashSet = false;
 bool fDynoNoBreakError = false;
 static std::string fDynoTimingPath;
 
@@ -1049,6 +1050,10 @@ static void setWarnSpecial(const ArgumentDescription* desc, const char* unused) 
   setWarnTupleIteration(desc, unused);
 }
 
+static void setDynoBreakOnHash(const ArgumentDescription* desc, const char* arg) {
+  fDynoBreakOnHashSet = true;
+}
+
 static void setLogDir(const ArgumentDescription* desc, const char* arg) {
   fLogDir = true;
 }
@@ -1487,7 +1492,7 @@ static ArgumentDescription arg_desc[] = {
  {"dyno-debug-trace", ' ', NULL, "Enable [disable] debug-trace output when using dyno compiler library", "N", &fDynoDebugTrace, "CHPL_DYNO_DEBUG_TRACE", NULL},
  {"dyno-timing", ' ', NULL, "Enable [disable] timing output when using dyno compiler library", "P", &fDynoTimingPath, "CHPL_DYNO_TIMING", NULL},
  {"dyno-debug-print-parsed-files", ' ', NULL, "Enable [disable] printing all files that were parsed by Dyno", "N", &fDynoDebugPrintParsedFiles, "CHPL_DYNO_DEBUG_PRINT_PARSED_FILES", NULL},
- {"dyno-break-on-hash", ' ' , NULL, "Break when query with given hash value is executed when using dyno compiler library", "X", &fDynoBreakOnHash, "CHPL_DYNO_BREAK_ON_HASH", NULL},
+ {"dyno-break-on-hash", ' ' , NULL, "Break when query with given hash value is executed when using dyno compiler library", "X", &fDynoBreakOnHash, "CHPL_DYNO_BREAK_ON_HASH", setDynoBreakOnHash},
  {"dyno-gen-lib", ' ', "<path>", "Specify files named on the command line should be saved into a .dyno library", "P", NULL, NULL, addDynoGenLib},
  {"dyno-gen-std", ' ', NULL, "Generate a .dyno library file for the standard library", "F", &fDynoGenStdLib, NULL, setDynoGenStdLib},
  {"dyno-verify-serialization", ' ', NULL, "Enable [disable] verification of serialization", "N", &fDynoVerifySerialization, NULL, NULL},
@@ -2353,7 +2358,7 @@ static void dynoConfigureContext(std::string chpl_module_path) {
                                         cmdLineModPaths,
                                         getChplFilenames());
   gContext->setDebugTraceFlag(fDynoDebugTrace);
-  gContext->setBreakOnHash(fDynoBreakOnHash);
+  if (fDynoBreakOnHashSet) gContext->setBreakOnHash(fDynoBreakOnHash);
 
   // set whether dyno assertions should fire based on developer flag
   chpl::setAssertions(developer);

--- a/frontend/lib/resolution/call-graph.cpp
+++ b/frontend/lib/resolution/call-graph.cpp
@@ -175,6 +175,8 @@ int gatherTransitiveFnsCalledByFn(Context* context,
   // Now, consider each direct call. Add it to 'called' and
   // also handle it recursively, if we added it.
   for (auto kv : directCalls) {
+    if (kv.first == nullptr) continue;
+
     auto pair = called.insert(kv);
     if (pair.second) {
       // The insertion took place, so it is the first time handling this fn.

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -137,7 +137,8 @@ needCompilerGeneratedMethod(Context* context, const Type* type,
 
   if (type->isNothingType()) return false;
 
-  if (isNameOfCompilerGeneratedMethod(name) ||
+  bool isAggregate = type->getCompositeType() || type->isRecordLike();
+  if ((isAggregate && isNameOfCompilerGeneratedMethod(name)) ||
       (type->isRecordType() && !isBuiltinTypeOperator(name))) {
     if (!areOverloadsPresentInDefiningScope(context, type, QualifiedType::INIT_RECEIVER, name)) {
       return true;

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -5207,24 +5207,6 @@ resolveFnCall(ResolutionContext* rc,
   // infer types of generic 'out' formals from function bodies
   mostSpecific.inferOutFormals(rc, instantiationPoiScope);
 
-  // Make sure that we are resolving initializer bodies even when the
-  // signature is concrete, because there are semantic checks.
-  bool isCallInfoForInit = (ci.name() == USTR("init") ||
-                            ci.name() == USTR("init=")) &&
-                            ci.isMethodCall();
-  if (isCallInfoForInit && mostSpecific.numBest() == 1) {
-    auto candidateFn = mostSpecific.only().fn();
-    CHPL_ASSERT(candidateFn->isInitializer());
-
-    // TODO: Can we move this into the 'InitVisitor'?
-    // Note: resolveFunction is already called on the initializer during
-    // instantiation
-    if (!candidateFn->untyped()->isCompilerGenerated() &&
-        candidateFn->instantiatedFrom() == nullptr) {
-      std::ignore = resolveFunction(rc, candidateFn, inScopes.poiScope());
-    }
-  }
-
   // compute the return types
   optional<QualifiedType> retType;
   optional<QualifiedType> yieldedType;

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -1215,7 +1215,10 @@ MostSpecificCandidate::fromTypedFnSignature(ResolutionContext* rc,
 
     if (!formalType.type() || !actualType.type()) continue;
 
-    auto got = canPass(rc->context(), actualType, formalType);
+    auto canPassFn =
+      actualType.kind() == QualifiedType::INIT_RECEIVER ? canPassScalar
+                                                        : canPass;
+    auto got = canPassFn(rc->context(), actualType, formalType);
     if (got.converts() && formalType.kind() == QualifiedType::CONST_REF) {
       coercionFormal = fa.formalIdx();
       coercionActual = fa.actualIdx();


### PR DESCRIPTION
Closes https://github.com/Cray/chapel-private/issues/7069.

Bundles https://github.com/chapel-lang/chapel/pull/26641 (clean diff IOU) to get at the heart of the issue.

There are two minor issues causing the bug.

1. We resolved `init=` two times (once from `MostSpecificCandidate`, see https://github.com/chapel-lang/chapel/pull/26613) and once in `resolveFnCall`. The latter call was redundant and is vestige of an older version of the resolver.
2. The second `init=` call did not guard `skipIfRunning` like most other calls, and thus didn't circumvent recursion errors.  However, since its purpose was to emit diagnostics from the `init=` body, it's sound to skip recursive calls, since the outer call will still issue these diagnostics.

Since this code is redundant, I simply removed it. Triggering the issue in Dyno without prod was a little challenging (it's important that PoI information is not used, which means the call to functions in `init=` needs to be fully concrete and not an instantiation). 

Reviewed by @benharsh -- thanks!

## Testing
- [x] dyno tests
- [x] paratest