### PR TITLE
Hide documentation for a non-public Python module function

### DIFF
--- a/modules/packages/Python.chpl
+++ b/modules/packages/Python.chpl
@@ -1036,6 +1036,7 @@ module Python {
       Converts a python dictionary to an associative array.
       Steals a reference to obj.
     */
+    @chpldoc.nodoc
     proc fromDict(type T, obj: PyObjectPtr): T throws
       where isArrayType(T) {
 


### PR DESCRIPTION
Hides the documentation for a non-public Python module function. This function was just missing its `@chpldoc.nodoc`

[Not reviewed - trivial]