### PR TITLE
Avoid passing 'size=0' to memalign

### DIFF
--- a/runtime/include/chpl-mem-hook.h
+++ b/runtime/include/chpl-mem-hook.h
@@ -74,7 +74,7 @@ void chpl_memhook_malloc_post(void* memAlloc,
                               size_t number, size_t size,
                               chpl_mem_descInt_t description,
                               int32_t lineno, int32_t filename) {
-  if (CHPL_MEMHOOKS_ACTIVE || memAlloc == NULL)
+  if (CHPL_MEMHOOKS_ACTIVE || (memAlloc == NULL && size != 0))
     chpl_memhook_check_post(memAlloc, description, lineno, filename);
   if (CHPL_MEMHOOKS_ACTIVE)
     chpl_track_malloc(memAlloc, number, size, description, lineno, filename);

--- a/runtime/include/chpl-mem-sys.h
+++ b/runtime/include/chpl-mem-sys.h
@@ -40,7 +40,7 @@ static inline void* sys_malloc(size_t size) {
 
 static inline void* sys_memalign(size_t boundary, size_t size) {
 #ifdef __GLIBC__
-  return memalign(boundary, size);
+  return (size == 0) ? NULL : memalign(boundary, size);
 #else
   void* ret = NULL;
   int rc;


### PR DESCRIPTION
With our current version of valgrind (3.20.0), we're getting a complaint about sending a size of 0 into memalign().  This PR addresses that by:

* having our memalign wrapper return 'NULL' if a size of 0 is passsed in rather than calling memalign()
* updating the post-malloc checks to avoid calling them when the returned pointer is NULL if the size was 0
