### PR TITLE
Include gasnet fix for race condition

### DIFF
--- a/third-party/gasnet/README
+++ b/third-party/gasnet/README
@@ -35,3 +35,4 @@ The modifications that we have made to the official GASNet release are
 as follows:
 
 * Cherry-picked 76c8a6a39 - Address bug 4723 in which ssh-spawner chokes tcsh
+* Cherry-picked 919c963af5 - coll: fix set+enable race on gasnete_barrier_pf

--- a/third-party/gasnet/gasnet-src/extended-ref/gasnet_extended_refbarrier.c
+++ b/third-party/gasnet/gasnet-src/extended-ref/gasnet_extended_refbarrier.c
@@ -33,7 +33,7 @@ static gasnet_seginfo_t *gasnete_rdmabarrier_auxseg = NULL;
 /*keep a list of active barriers across all the teams. The poller walks the list and then kicks
  each one of them*/
 /*XXX: for now only team all registers their pollers*/
-gasneti_progressfn_t gasnete_barrier_pf= NULL;
+gasneti_progressfn_t gasnete_barrier_pf = GASNETI_PROGRESSFN_INITIALIZER;
 
 GASNETI_INLINE(gasnete_barrier_pf_enable)
 void gasnete_barrier_pf_enable(gasnete_coll_team_t team) {

--- a/third-party/gasnet/gasnet-src/gasnet_help.h
+++ b/third-party/gasnet/gasnet-src/gasnet_help.h
@@ -1186,6 +1186,13 @@ typedef void (*gasneti_progressfn_t)(void);
     GASNETE_BARRIER_PROGRESSFN(FN)     
 #endif
 
+// When using a variable of type gasneti_progressfn_t which is to be set at
+// runtime, use of a no-op progress function as the initial value can avoid
+// issues with a race between visibility of the writes to the progress function
+// variable and to the variable that enables it (see bug 4766).
+extern void gasneti_empty_pf(void);
+#define GASNETI_PROGRESSFN_INITIALIZER (&gasneti_empty_pf)
+
 #if GASNET_DEBUG
   extern gasneti_progressfn_t gasneti_debug_progressfn_bool;
   extern gasneti_progressfn_t gasneti_debug_progressfn_counted;

--- a/third-party/gasnet/gasnet-src/gasnet_internal.c
+++ b/third-party/gasnet/gasnet-src/gasnet_internal.c
@@ -158,6 +158,8 @@ gasneti_TM_t gasneti_thing_that_goes_thunk_in_the_dark = NULL;
   gasneti_progressfn_t gasneti_debug_progressfn_counted = gasneti_disabled_progressfn;
 #endif
 
+void gasneti_empty_pf(void) {}
+
 gasnet_seginfo_t *gasneti_seginfo = NULL;
 gasnet_seginfo_t *gasneti_seginfo_aux = NULL;
 


### PR DESCRIPTION
This commit includes changes from
 https://bitbucket.org/berkeleylab/gasnet/pull-requests/653

The commits fix a race condition causing sporadic crashes on program startup.  We observed these crashes on Mac OS X running on ARM systems with segment=fast (see https://github.com/Cray/chapel-private/issues/7065 ).

- [x] full comm=none testing
- [x] full gasnet oversubscribed testing

Reviewed by @e-kayrakli and @bonachea - thanks!