### PR TITLE
Add a skipif for this test with `--fast`, it relies on bounds checking

### DIFF
--- a/test/library/standard/Set/zippering/arrayShorter2.skipif
+++ b/test/library/standard/Set/zippering/arrayShorter2.skipif
@@ -1,0 +1,2 @@
+# This check is turned off by --fast, so don't run with it
+COMPOPTS <= --fast


### PR DESCRIPTION
Passed a fresh checkout of the test with and without `--fast`