### PR TITLE
Dyno: hook up production to handle Dyno's dual compiler error reporting

### DIFF
--- a/frontend/include/chpl/resolution/resolution-queries.h
+++ b/frontend/include/chpl/resolution/resolution-queries.h
@@ -660,6 +660,18 @@ determineBestReturnIntentOverload(const MostSpecificCandidates& candidates,
                                   Access access,
                                   bool& outAmbiguity);
 
+/**
+  This query is invoked when a diagnostic message via `compilerError` is
+  emitted at the place it wanted to be emitted. This can be used by
+  library consumers to see if fallback diagnostics can be skipped.
+ */
+bool const& noteErrorMessage(Context* context, UniqueString message);
+
+/**
+  Same as `noteErrorMessage`, but for warning messages.
+ */
+bool const& noteWarningMessage(Context* context, UniqueString message);
+
 
 } // end namespace resolution
 } // end namespace chpl

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1977,8 +1977,10 @@ void Resolver::emitUserDiagnostic(const CompilerDiagnostic& diagnostic,
                                   const uast::AstNode* astForErr) {
   if (diagnostic.isError()) {
     CHPL_REPORT(context, UserDiagnosticEmitError, diagnostic.message(), astForErr->id());
+    noteErrorMessage(context, diagnostic.message());
   } else if (diagnostic.isWarning()) {
     CHPL_REPORT(context, UserDiagnosticEmitWarning, diagnostic.message(), astForErr->id());
+    noteWarningMessage(context, diagnostic.message());
   }
 }
 

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -7227,6 +7227,16 @@ determineBestReturnIntentOverload(const MostSpecificCandidates& candidates,
   return best;
 }
 
+bool const& noteErrorMessage(Context* context, UniqueString message) {
+  QUERY_BEGIN(noteErrorMessage, context, message);
+  return QUERY_END(true);
+}
+
+bool const& noteWarningMessage(Context* context, UniqueString message) {
+  QUERY_BEGIN(noteWarningMessage, context, message);
+  return QUERY_END(true);
+}
+
 
 } // end namespace resolution
 } // end namespace chpl

--- a/test/errors/resolution/compilerDiagnostics.1.good
+++ b/test/errors/resolution/compilerDiagnostics.1.good
@@ -1,0 +1,4 @@
+compilerDiagnostics.chpl:15: warning: 1-argument version of foo called with type: real(64)
+compilerDiagnostics.chpl:16: warning: 1-argument version of foo called with type: string
+compilerDiagnostics.chpl:20: error: foo() called with non-matching types: int(64) != real(64)
+compilerDiagnostics.chpl:21: error: foo() called with non-matching types: string != real(64)

--- a/test/errors/resolution/compilerDiagnostics.2.good
+++ b/test/errors/resolution/compilerDiagnostics.2.good
@@ -1,0 +1,24 @@
+─── warning in compilerDiagnostics.chpl:15 [UserDiagnosticEmitWarning] ───
+  1-argument version of foo called with type: real(64)
+       |
+    15 | foo(3.4);
+       |
+
+─── warning in compilerDiagnostics.chpl:16 [UserDiagnosticEmitWarning] ───
+  1-argument version of foo called with type: string
+       |
+    16 | foo("hi");
+       |
+
+─── error in compilerDiagnostics.chpl:20 [UserDiagnosticEmitError] ───
+  Foo() called with non-matching types: int(64) != real(64)
+       |
+    20 | foo(1, 2.3);
+       |
+
+─── error in compilerDiagnostics.chpl:21 [UserDiagnosticEmitError] ───
+  Foo() called with non-matching types: string != real(64)
+       |
+    21 | foo("hi", 2.3);
+       |
+

--- a/test/errors/resolution/compilerDiagnostics.chpl
+++ b/test/errors/resolution/compilerDiagnostics.chpl
@@ -1,0 +1,21 @@
+proc foo(x, y) {
+  if (x.type != y.type) then
+    compilerError("foo() called with non-matching types: ",
+                  x.type:string, " != ", y.type:string);
+  writeln("In 2-argument foo...");
+}
+
+proc foo(x) {
+  compilerWarning("1-argument version of foo called with type: ",
+                  x.type:string);
+  writeln("In generic foo!");
+}
+
+
+foo(3.4);
+foo("hi");
+foo(1, 2);
+foo(1.2, 3.4);
+foo("hi", "bye");
+foo(1, 2.3);
+foo("hi", 2.3);

--- a/test/errors/resolution/compilerDiagnostics.prediff
+++ b/test/errors/resolution/compilerDiagnostics.prediff
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if grep -v 'Unimplemented: PRIM_IS_FCF_TYPE' $2 > $2.tmp; then
+    mv $2.tmp $2
+fi


### PR DESCRIPTION
Closes https://github.com/Cray/chapel-private/issues/7093.

This PR adds a query that gets set when error message are emitted as requested at the desired location. If that query is set, the "fallback" diagnostics are skipped.

Reviewed by @benharsh -- thanks!

## Testing
- [x] dyno
- [x] paratest