### PR TITLE
Fix call resolution search order for forwarded proc as method

### DIFF
--- a/frontend/include/chpl/resolution/resolution-queries.h
+++ b/frontend/include/chpl/resolution/resolution-queries.h
@@ -434,7 +434,8 @@ CallResolutionResult resolveCall(ResolutionContext* rc,
                                  const uast::Call* call,
                                  const CallInfo& ci,
                                  const CallScopeInfo& inScopes,
-                                 std::vector<ApplicabilityResult>* rejected=nullptr);
+                                 std::vector<ApplicabilityResult>* rejected=nullptr,
+                                 bool skipForwarding = false);
 
 /**
   Similar to resolveCall, but handles the implicit scope provided by a method.

--- a/frontend/test/resolution/testForwarding.cpp
+++ b/frontend/test/resolution/testForwarding.cpp
@@ -506,6 +506,41 @@ static void test8() {
   assert(guard.realizeErrors() == 0);
 }
 
+// Ensure we don't search for forwarded candidates after finding non-forwarded
+// ones, even if the forwarded candidates are methods.
+static void test9() {
+  printf("test9\n");
+
+  auto context = buildStdContext();
+  ErrorGuard guard(context);
+
+  const char* contents =
+    R""""(
+    module M {
+      class Bar {
+        proc getVal() : real do return 4;
+      }
+
+      proc getVal() : int do return 3;
+
+      class Foo {
+        var b : owned Bar = new Bar();
+        forwarding b;
+
+        proc doSomething() do return getVal();
+      }
+
+      var f : Foo = new Foo();
+      var x = f.doSomething();
+    }
+    )"""";
+
+  auto qt = resolveQualifiedTypeOfX(context, contents);
+  assert(qt.type()->isIntType());
+
+  assert(guard.realizeErrors() == 0);
+}
+
 
 int main() {
   test1();
@@ -525,6 +560,7 @@ int main() {
   // TODO: forwarding with only, except
 
   test8();
+  test9();
 
   return 0;
 }


### PR DESCRIPTION
Fix a bug where Dyno would consider forwarded method candidates even when non-forwarded function candidates were found, for a call within a method.

We only want to search for forwarding candidates if we haven't found any non-forwarding candidates. However, when resolving a call in a method, we first try resolving it as a function and then as a method with an implicit receiver. If we find function candidates, we still want to search for method candidates, but we do not want to search for forwarding method candidates even if there are no non-forwarding method candidates. This PR adds logic to skip that.

Added a test for the fixed case, where the test would previously encounter ambiguity between the non-forwarded function and forwarded method.

This bug was incidentally causing query recursion in https://github.com/Cray/chapel-private/issues/7087, where the definition of `chpl__promotionType` on `_array` relies on the correct search order.

Resolves https://github.com/Cray/chapel-private/issues/7087.

[reviewer info placeholder]

Testing:
- [x] dyno tests
- [x] paratest
- [x] fixes https://github.com/Cray/chapel-private/issues/7087 (in combination with [basic array resolution](https://github.com/chapel-lang/chapel/pull/26628))