### PR TITLE
Fix type and assign call of `if var` declaration

### DIFF
--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -479,8 +479,11 @@ void CallInitDeinit::resolveDefaultInit(const VarLikeDecl* ast, RV& rv) {
 
 void CallInitDeinit::resolveAssign(const AstNode* ast,
                                    const QualifiedType& lhsType,
-                                   const QualifiedType& rhsType,
+                                   const QualifiedType& rhsTypeIn,
                                    RV& rv) {
+  VarFrame* frame = currentFrame();
+
+  auto rhsType = rhsTypeIn;
   if (lhsType.isUnknown() || lhsType.isErroneousType() ||
       rhsType.isUnknown() || rhsType.isErroneousType()) {
     return;
@@ -491,6 +494,21 @@ void CallInitDeinit::resolveAssign(const AstNode* ast,
       // Tuple unpacking assignment, handled directly by Resolver
       // (a, b, c) = foo();
       return;
+    }
+  }
+  // In an 'if var' decl, resolve assign as though the RHS is non-nil.
+  // We'll verify it is at runtime.
+  if (auto conditional = frame->scopeAst->toConditional()) {
+    if (ast->id() == conditional->condition()->id()) {
+      if (auto ty = rhsType.type()) {
+        auto ct = ty->toClassType();
+        // Enforced during type resolution
+        assert(ct);
+
+        rhsType = QualifiedType(
+            rhsType.kind(),
+            ct->withDecorator(context, ct->decorator().addNonNil()));
+      }
     }
   }
 
@@ -691,24 +709,7 @@ void CallInitDeinit::processInit(VarFrame* frame,
                         /* forMoveInit */ false,
                         rv);
       } else {
-        auto rhsTypeForAssign = rhsType;
-        // In an 'if var' decl, resolve assign as though the RHS is non-nil.
-        // We'll verify it is at runtime.
-        if (auto conditional = frame->scopeAst->toConditional()) {
-          if (ast->id() == conditional->condition()->id()) {
-            if (auto ty = rhsType.type()) {
-              auto ct = ty->toClassType();
-              // Enforced during type resolution
-              assert(ct);
-
-              rhsTypeForAssign = QualifiedType(
-                  rhsType.kind(),
-                  ct->withDecorator(context, ct->decorator().addNonNil()));
-            }
-          }
-        }
-
-        resolveAssign(ast, lhsType, rhsTypeForAssign, rv);
+        resolveAssign(ast, lhsType, rhsType, rv);
       }
     }
   }

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -503,7 +503,7 @@ void CallInitDeinit::resolveAssign(const AstNode* ast,
       if (auto ty = rhsType.type()) {
         auto ct = ty->toClassType();
         // Enforced during type resolution
-        assert(ct);
+        CHPL_ASSERT(ct);
 
         rhsType = QualifiedType(
             rhsType.kind(),

--- a/frontend/test/resolution/testCallInitDeinit.cpp
+++ b/frontend/test/resolution/testCallInitDeinit.cpp
@@ -1579,14 +1579,14 @@ static void test20a() {
         proc C.deinit() { }
 
         proc foo() {
-          var x : owned C = new C();
+          var x = new C();
           return x;
         }
       }
     )"""",
     {
-      {AssociatedAction::NEW_INIT, "M.foo@5",          ""},
-      {AssociatedAction::DEINIT,   "M.foo@9",          "x"},
+      {AssociatedAction::NEW_INIT, "M.foo@2",          ""},
+      {AssociatedAction::DEINIT,   "M.foo@6",          "x"},
     });
 }
 
@@ -1605,15 +1605,15 @@ static void test20a() {
 /*         proc C.deinit() { } */
 
 /*         proc foo() { */
-/*           var x : owned C = new C(3); */
+/*           var x = new C(3); */
 /*           return x; */
 /*         } */
 /*       } */
 /*     )"""", */
 /*     { */
-/*       {AssociatedAction::NEW_INIT,   "M.foo@6",    ""}, */
-/*       {AssociatedAction::INIT_OTHER, "x",          ""}, */
-/*       {AssociatedAction::DEINIT,     "M.foo@10",   "x"}, */
+/*       {AssociatedAction::NEW_INIT,   "M.foo@3",    ""},  */
+/*       {AssociatedAction::INIT_OTHER, "x",          ""},  */
+/*       {AssociatedAction::DEINIT,     "M.foo@7",    "x"}, */
 /*     }); */
 /* } */
 
@@ -1628,14 +1628,14 @@ static void test20c() {
         proc C.deinit() { }
 
         proc foo() {
-          var x : owned C? = new C();
+          var x = new C?();
           return x;
         }
       }
     )"""",
     {
-      {AssociatedAction::NEW_INIT,   "M.foo@6",    ""},
-      {AssociatedAction::DEINIT,     "M.foo@10",   "x"},
+      {AssociatedAction::NEW_INIT,   "M.foo@3",    ""},
+      {AssociatedAction::DEINIT,     "M.foo@7",    "x"},
     });
 }
 
@@ -1822,7 +1822,7 @@ static void test24() {
       module M {
         class R { }
         proc test() {
-          var y : unmanaged R? = new unmanaged R?();
+          var y = new unmanaged R?();
           if var x = y {
             x;
           }
@@ -1830,7 +1830,7 @@ static void test24() {
       }
     )"""",
     {
-      {AssociatedAction::NEW_INIT, "M.test@7",    ""},
+      {AssociatedAction::NEW_INIT, "M.test@3",    ""},
       {AssociatedAction::ASSIGN,   "x",           ""},
     });
 }

--- a/frontend/test/resolution/testCallInitDeinit.cpp
+++ b/frontend/test/resolution/testCallInitDeinit.cpp
@@ -1822,7 +1822,7 @@ static void test24() {
       module M {
         class R { }
         proc test() {
-          var y : unmanaged R? = new unmanaged R();
+          var y : unmanaged R? = new unmanaged R?();
           if var x = y {
             x;
           }
@@ -1830,7 +1830,7 @@ static void test24() {
       }
     )"""",
     {
-      {AssociatedAction::NEW_INIT, "M.test@6",    ""},
+      {AssociatedAction::NEW_INIT, "M.test@7",    ""},
       {AssociatedAction::ASSIGN,   "x",           ""},
     });
 }

--- a/frontend/test/resolution/testCallInitDeinit.cpp
+++ b/frontend/test/resolution/testCallInitDeinit.cpp
@@ -1815,6 +1815,26 @@ static void test23d() {
       });
 }
 
+// Test if var declaration
+static void test24() {
+  testActions("test24",
+    R""""(
+      module M {
+        class R { }
+        proc test() {
+          var y : unmanaged R? = new unmanaged R();
+          if var x = y {
+            x;
+          }
+        }
+      }
+    )"""",
+    {
+      {AssociatedAction::NEW_INIT, "M.test@6",    ""},
+      {AssociatedAction::ASSIGN,   "x",           ""},
+    });
+}
+
 // calling function with 'out' intent formal
 
 // calling functions with 'inout' intent formal
@@ -1910,6 +1930,8 @@ int main() {
   test23b();
   test23c();
   test23d();
+
+  test24();
 
   return 0;
 }


### PR DESCRIPTION
Fix two bugs concerning the type of a variable declared with `if var`/`if const`.

Fixes:
- Resolve the variable as non-nilable `unmanaged` if its init part is `unmanaged`, rather than always making it `borrowed`. This is language spec'd behavior.
- Treat the init part as non-nilable when resolving the `=` call from the variable initialization. This previously caused problems as the variable is always non-nilable, and you generally can't assign a nilable value into a non-nilable -- even though we know at runtime it will be non-nilable on this control flow path.

Also adds tests for both fixed cases.

Encountered working on array module code resolution.

[reviewer info placeholder]

Testing:
- [x] dyno tests
- [x] paratest