### PR TITLE
Add an explicit cast for discarding const

### DIFF
--- a/modules/packages/PythonHelper/ArrayTypes.c
+++ b/modules/packages/PythonHelper/ArrayTypes.c
@@ -211,7 +211,7 @@ static int Array##NAMESUFFIX##Object_bf_getbuffer(Array##NAMESUFFIX##Object* arr
   view->ndim = arr->ndim; \
   view->format = NULL; \
   if (flags & PyBUF_FORMAT) { \
-    view->format = FORMATSTRING; \
+    view->format = (char*)FORMATSTRING; \
   } \
   /*TODO: support nd arrays*/ \
   view->shape = NULL; \


### PR DESCRIPTION
Adds an explicit cast for discarding const when assigning a string literal to a `char*`

[Reviewed by @lydia-duncan]