### PR TITLE
Work around an issue preventing users to catch errors from `JSON.fromJson`

### DIFF
--- a/modules/standard/JSON.chpl
+++ b/modules/standard/JSON.chpl
@@ -1180,6 +1180,11 @@ module JSON {
      :arg loadAs: The type to deserialize the JSON string into
 
      :returns: A value of type ``loadAs``.
+
+     .. warning::
+
+       Errors thrown from this function can only be caught if ``loadAs`` is a
+       default-initializable type.
    */
   @unstable
   proc fromJson(jsonString: string, type loadAs): loadAs throws {

--- a/modules/standard/JSON.chpl
+++ b/modules/standard/JSON.chpl
@@ -1194,6 +1194,7 @@ module JSON {
   }
 
   @chpldoc.nodoc
+  @unstable
   proc fromJson(jsonString: string, type loadAs): loadAs throws
       where isDefaultInitializable(loadAs) {
     var fileReader = openStringReader(jsonString,

--- a/modules/standard/JSON.chpl
+++ b/modules/standard/JSON.chpl
@@ -1185,7 +1185,12 @@ module JSON {
   proc fromJson(jsonString: string, type loadAs): loadAs throws {
     var fileReader = openStringReader(jsonString,
                                       deserializer=new jsonDeserializer());
-    return fileReader.read(loadAs);
+    // we want `return fileReader.read(loadAs)`. But that ends up using a
+    // non-throwing compiler-generated initializer. That prevents the user to
+    // catch errors that are due to malformed jsonString.
+    var ret: loadAs;
+    fileReader.read(ret);
+    return ret;
   }
 
   /* Given a Chapel value, serialize it into a JSON string using the

--- a/modules/standard/JSON.chpl
+++ b/modules/standard/JSON.chpl
@@ -1185,6 +1185,14 @@ module JSON {
   proc fromJson(jsonString: string, type loadAs): loadAs throws {
     var fileReader = openStringReader(jsonString,
                                       deserializer=new jsonDeserializer());
+    return fileReader.read(loadAs);
+  }
+
+  @chpldoc.nodoc
+  proc fromJson(jsonString: string, type loadAs): loadAs throws
+      where isDefaultInitializable(loadAs) {
+    var fileReader = openStringReader(jsonString,
+                                      deserializer=new jsonDeserializer());
     // we want `return fileReader.read(loadAs)`. But that ends up using a
     // non-throwing compiler-generated initializer. That prevents the user to
     // catch errors that are due to malformed jsonString.

--- a/test/io/serializers/jsonHelpers/fromJsonThrows.chpl
+++ b/test/io/serializers/jsonHelpers/fromJsonThrows.chpl
@@ -1,0 +1,20 @@
+import IO, JSON;
+
+record myRec {
+  var field: int;
+}
+
+var inFile = IO.open("fromJsonThrows.in", IO.ioMode.r);
+var inReader = inFile.reader();
+
+var rec: myRec;
+
+proc main() throws {
+  try {
+    rec = JSON.fromJson(inReader.readAll(string), myRec);
+    writeln(rec);
+  }
+  catch err: IllegalArgumentError {
+    writeln("Caught the error correctly");
+  }
+}

--- a/test/io/serializers/jsonHelpers/fromJsonThrows.cleanfiles
+++ b/test/io/serializers/jsonHelpers/fromJsonThrows.cleanfiles
@@ -1,0 +1,1 @@
+fromJsonThrows.in

--- a/test/io/serializers/jsonHelpers/fromJsonThrows.good
+++ b/test/io/serializers/jsonHelpers/fromJsonThrows.good
@@ -1,0 +1,1 @@
+Caught the error correctly

--- a/test/io/serializers/jsonHelpers/fromJsonThrows.preexec
+++ b/test/io/serializers/jsonHelpers/fromJsonThrows.preexec
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "{\"fiel\":10}" > fromJsonThrows.in


### PR DESCRIPTION
`JSON.fromJson` used the pattern:

```chpl
return reader.read(MyType);
```

this results in calling a compiler-generated deserialization initializer that does not throw. While working on Arkouda checkpointing that led to writing code in which there are uncatchable errors. I worked this around in Arkouda for the time being by having my own `fromJson`-like helper.

This PR adjusts the standard `fromJson` to use the following pattern, from which an error can be thrown and caught as expected:

```chpl
var ret: MyType;
reader.read(ret);
return ret;
```

Test:

- [x] local