### PR TITLE
Fix issues in `distBag.addBulk`

### DIFF
--- a/modules/packages/DistributedBag.chpl
+++ b/modules/packages/DistributedBag.chpl
@@ -984,7 +984,7 @@ module DistributedBag
       }
 
       // add the elements to the tail
-      for elt in elts[0..#size] do block.pushTail(elt);
+      for elt in elts do block.pushTail(elt);
       tail += size;
 
       // check split request

--- a/modules/packages/DistributedBag.chpl
+++ b/modules/packages/DistributedBag.chpl
@@ -976,7 +976,7 @@ module DistributedBag
       if (block.tailId + size > block.cap) {
         const neededCap = block.cap*2**ceil(log2((block.tailId + size) / block.cap:real)):int;
         if (neededCap >= distributedBagMaxSegmentCap) then
-          size = distributedBagMaxSegmentCap - block.tailId - 1;
+          size = distributedBagMaxSegmentCap - block.tailId;
         lock_block.readFE();
         block.cap = min(distributedBagMaxSegmentCap, neededCap);
         block.dom = {0..#block.cap};
@@ -984,7 +984,12 @@ module DistributedBag
       }
 
       // add the elements to the tail
-      for elt in elts do block.pushTail(elt);
+      var c = 0;
+      for elt in elts {
+        block.pushTail(elt);
+        c += 1;
+        if (c == size) then break;
+      }
       tail += size;
 
       // check split request

--- a/test/library/packages/DistributedBag/addBulk.chpl
+++ b/test/library/packages/DistributedBag/addBulk.chpl
@@ -5,18 +5,32 @@
 use DistributedBag;
 
 config const nElems = 1000;
-const defaultMaxSegmentCap = DistributedBag.distributedBagMaxSegmentCap;
 
-var bag = new distBag(int);
+// Test 1: check the number of elements inserted and the capacity limit of the segments.
+{
+  const defaultMaxSegmentCap = DistributedBag.distributedBagMaxSegmentCap;
 
-// Check the number of elements inserted.
-const successfulInsertions = bag.addBulk(1..nElems, 0);
-assert(successfulInsertions == nElems);
-assert(bag.getSize() == nElems);
+  var bag = new distBag(int);
 
-// Test the limit of the segments.
-const successfulInsertions2 = bag.addBulk(1..defaultMaxSegmentCap, 0);
-assert(successfulInsertions2 == defaultMaxSegmentCap - nElems);
-assert(bag.getSize() == defaultMaxSegmentCap);
+  // Check the number of elements inserted.
+  const successfulInsertions = bag.addBulk(1..nElems, 0);
+  assert(successfulInsertions == nElems);
+  assert(bag.getSize() == nElems);
 
-writeln("SUCCESS");
+  // Test the capacity limit of the segments.
+  const successfulInsertions2 = bag.addBulk(1..defaultMaxSegmentCap, 0);
+  assert(successfulInsertions2 == defaultMaxSegmentCap - nElems);
+  assert(bag.getSize() == defaultMaxSegmentCap);
+
+  writeln("Test 1: SUCCESS");
+}
+
+// Test 2: check the elements inserted (array slice)
+{
+  const A: [0..9] int = [0,1,2,3,4,5,6,7,8,9];
+
+  var bag = new distBag(int);
+
+  bag.addBulk(A[2..9], 0);
+  writeln("Output test 2: ", bag);
+}

--- a/test/library/packages/DistributedBag/addBulk.chpl
+++ b/test/library/packages/DistributedBag/addBulk.chpl
@@ -6,31 +6,53 @@ use DistributedBag;
 
 config const nElems = 1000;
 
-// Test 1: check the number of elements inserted and the capacity limit of the segments.
+// Test 1: checks the number of elements inserted and the capacity limit of the segments.
 {
   const defaultMaxSegmentCap = DistributedBag.distributedBagMaxSegmentCap;
 
-  var bag = new distBag(int);
+  // Saturates a segment at once while it is empty.
+  {
+    var bag = new distBag(int);
 
-  // Check the number of elements inserted.
-  const successfulInsertions = bag.addBulk(1..nElems, 0);
-  assert(successfulInsertions == nElems);
-  assert(bag.getSize() == nElems);
+    const successfulInsertions = bag.addBulk(1..(2*defaultMaxSegmentCap), 0);
+    assert(successfulInsertions == defaultMaxSegmentCap);
+    assert(bag.getSize() == defaultMaxSegmentCap);
+  }
 
-  // Test the capacity limit of the segments.
-  const successfulInsertions2 = bag.addBulk(1..defaultMaxSegmentCap, 0);
-  assert(successfulInsertions2 == defaultMaxSegmentCap - nElems);
-  assert(bag.getSize() == defaultMaxSegmentCap);
+  // Inserts some elements into a segment, and then saturates it.
+  {
+    var bag = new distBag(int);
+
+    const successfulInsertions = bag.addBulk(1..nElems, 0);
+    assert(successfulInsertions == nElems);
+    assert(bag.getSize() == nElems);
+
+    const successfulInsertions2 = bag.addBulk(1..defaultMaxSegmentCap, 0);
+    assert(successfulInsertions2 == defaultMaxSegmentCap - nElems);
+    assert(bag.getSize() == defaultMaxSegmentCap);
+  }
 
   writeln("Test 1: SUCCESS");
 }
 
-// Test 2: check the elements inserted (array slice)
+// Test 2: checks the elements inserted using an array or range.
 {
   const A: [0..9] int = [0,1,2,3,4,5,6,7,8,9];
+  const r = 0..9;
 
-  var bag = new distBag(int);
+  // Inserts an array slice.
+  {
+    var bag = new distBag(int);
 
-  bag.addBulk(A[2..9], 0);
-  writeln("Output test 2: ", bag);
+    bag.addBulk(A[2..9], 0);
+    writeln("Output test 2a: ", bag);
+  }
+
+  // Inserts strided range.
+  {
+    var bag = new distBag(int);
+
+    bag.addBulk(r[0.. by 3], 0);
+    writeln("Output test 2b: ", bag);
+  }
 }

--- a/test/library/packages/DistributedBag/addBulk.good
+++ b/test/library/packages/DistributedBag/addBulk.good
@@ -1,2 +1,3 @@
 Test 1: SUCCESS
-Output test 2: [2, 3, 4, 5, 6, 7, 8, 9]
+Output test 2a: [2, 3, 4, 5, 6, 7, 8, 9]
+Output test 2b: [0, 3, 6, 9]

--- a/test/library/packages/DistributedBag/addBulk.good
+++ b/test/library/packages/DistributedBag/addBulk.good
@@ -1,1 +1,2 @@
-SUCCESS
+Test 1: SUCCESS
+Output test 2: [2, 3, 4, 5, 6, 7, 0, 0]

--- a/test/library/packages/DistributedBag/addBulk.good
+++ b/test/library/packages/DistributedBag/addBulk.good
@@ -1,2 +1,2 @@
 Test 1: SUCCESS
-Output test 2: [2, 3, 4, 5, 6, 7, 0, 0]
+Output test 2: [2, 3, 4, 5, 6, 7, 8, 9]


### PR DESCRIPTION
In the `addBulk` procedure of the `distBag` data structure, things are as follows:

```chapel
inline proc ref addElements(elts): int
    {
      var size = elts.size;
      ...
      // add the elements to the tail
      for elt in elts[0..#size] do block.pushTail(elt);
      tail += size;
      ...
    }
```
This produces an issue when the input `elts` is not 0-based (e.g., array slices). For example,
```chapel
const A: [0..9] int = [0,1,2,3,4,5,6,7,8,9];
var bag = new distBag(int);
bag.addBulk(A[2..9], 0);
writeln(bag);
```
returns `[2, 3, 4, 5, 6, 7, 0, 0]` instead of `[2, 3, 4, 5, 6, 7, 8, 9]`.

A fix for this is to iterate over `elts` without specifying the domain, and use a counter to make sure that we do not insert more elements than we can. I also update the tests to make sure that this bug doesn't come back in the future.