### PR TITLE
Extend clang 18 deprecation warning silencing to 19

### DIFF
--- a/make/compiler/Makefile.clang
+++ b/make/compiler/Makefile.clang
@@ -193,10 +193,11 @@ WARN_CXXFLAGS += -Wno-deprecated-declarations
 endif
 
 #
-# Don't warn for deprecated declarations with clang 18
+# Don't warn for deprecated declarations with clang 18 or 19
 # https://github.com/llvm/llvm-project/issues/76515
 #
 COMP_CXXFLAGS += $(shell test $(CLANG_VER) -eq 18 && echo -Wno-deprecated-declarations)
+COMP_CXXFLAGS += $(shell test $(CLANG_VER) -eq 19 && echo -Wno-deprecated-declarations)
 
 endif
 


### PR DESCRIPTION
We're seeing the warnings encountered in https://github.com/llvm/llvm-project/issues/76515 for clang 19 in addition to 18, so extend the warning silencing to cover both.

[reviewer info placeholder]