### PR TITLE
fix test in chpl-language-server for use before define, shadowing

### DIFF
--- a/tools/chpl-language-server/test/basic.py
+++ b/tools/chpl-language-server/test/basic.py
@@ -253,7 +253,7 @@ async def test_list_references(client: LanguageClient):
            var y = x;
            for i in 1..10 {
                 var z = x;
-                var x = 42 + i;
+                var y = 42 + i;
 
                 while true {
                     var i = 0;
@@ -266,7 +266,7 @@ async def test_list_references(client: LanguageClient):
         # 'find references' on definitions;
         # the cross checking will also validate the references.
         await check_references_and_cross_check(
-            client, doc, pos((0, 4)), [pos((0, 4)), pos((1, 8))]
+            client, doc, pos((0, 4)), [pos((0, 4)), pos((1, 8)), pos((3, 13))]
         )
         await check_references_and_cross_check(
             client, doc, pos((1, 4)), [pos((1, 4))]
@@ -278,7 +278,7 @@ async def test_list_references(client: LanguageClient):
             client, doc, pos((3, 9)), [pos((3, 9))]
         )
         await check_references_and_cross_check(
-            client, doc, pos((4, 9)), [pos((3, 13)), pos((4, 9))]
+            client, doc, pos((4, 9)), [pos((4, 9))]
         )
         await check_references_and_cross_check(
             client, doc, pos((7, 13)), [pos((7, 13)), pos((8, 17))]


### PR DESCRIPTION
This fixes a chpl-language-server test that was expecting resolution to a shadowed outer scope variable instead of the later defined variable. 

As demonstrated with this code:
```chapel
var y = 42;
{
  var x = 2*y;
  var y = 2*x;
  …
}
```

the use and definition of `y` within the inner block means we will report this as a use-before-define error because we don't bring outer variables into scope when they are redefined inside a block. 

The fix here is just to change the test to use a different variable name and update the expected results.

Previously, dyno was not detecting use-before-define errors in init-expressions like this, but https://github.com/chapel-lang/chapel/pull/26157 added detection for that which caused this test to start failing.

[reviewed by @jabraham17 - thank you!]