### PR TITLE
Dyno: start tracking runtime types

### DIFF
--- a/compiler/passes/convert-typed-uast.cpp
+++ b/compiler/passes/convert-typed-uast.cpp
@@ -1464,6 +1464,9 @@ Type* TConverter::helpConvertType(const types::Type* t) {
     case typetags::DomainType:
        CHPL_UNIMPL("convert domain type");
       return dtUnknown; // TODO
+    case typetags::RuntimeType:
+       CHPL_UNIMPL("convert runtime type");
+      return dtUnknown; // TODO
 
     case typetags::BasicClassType:
       return helpConvertBasicClassType(t->toBasicClassType());

--- a/frontend/include/chpl/types/ArrayType.h
+++ b/frontend/include/chpl/types/ArrayType.h
@@ -62,6 +62,7 @@ class ArrayType final : public CompositeType {
 
   static const ID domainId;
   static const ID eltTypeId;
+  static const ID runtimeTypeId;
 
  public:
 
@@ -72,6 +73,10 @@ class ArrayType final : public CompositeType {
                                        const QualifiedType& instance,
                                        const QualifiedType& domainType,
                                        const QualifiedType& eltType);
+
+  static const ArrayType* getWithRuntimeType(Context* context,
+                                             const ArrayType* arrayType,
+                                             const RuntimeType* runtimeType);
 
   const Type* substitute(Context* context,
                          const PlaceholderMap& subs) const override {
@@ -92,6 +97,15 @@ class ArrayType final : public CompositeType {
 
   QualifiedType eltType() const {
     auto it = subs_.find(eltTypeId);
+    if (it != subs_.end()) {
+      return it->second;
+    } else {
+      return QualifiedType();
+    }
+  }
+
+  QualifiedType runtimeType() const {
+    auto it = subs_.find(runtimeTypeId);
     if (it != subs_.end()) {
       return it->second;
     } else {

--- a/frontend/include/chpl/types/DomainType.h
+++ b/frontend/include/chpl/types/DomainType.h
@@ -85,6 +85,13 @@ class DomainType final : public CompositeType {
                SubstitutionsMap subs,
                Kind kind = Kind::Unknown);
 
+  static const ID rankId;
+  static const ID rectangularIdxTypeId;
+  static const ID nonRectangularIdxTypeId;
+  static const ID stridesId;
+  static const ID parSafeId;
+  static const ID runtimeTypeId;
+
  public:
 
   /** Return the generic domain type */
@@ -102,6 +109,11 @@ class DomainType final : public CompositeType {
                                               const QualifiedType& instance,
                                               const QualifiedType& idxType,
                                               const QualifiedType& parSafe);
+
+  /** embellishes the domain type with a runtime type. */
+  static const DomainType* getWithRuntimeType(Context* context,
+                                              const DomainType* domainType,
+                                              const RuntimeType* runtimeType);
 
   const Type* substitute(Context* context,
                          const PlaceholderMap& subs) const override {
@@ -126,25 +138,29 @@ class DomainType final : public CompositeType {
 
   const QualifiedType& rank() const {
     CHPL_ASSERT(kind_ == Kind::Rectangular);
-    return subs_.at(ID(UniqueString(), 0, 0));
+    return subs_.at(rankId);
   }
 
   const QualifiedType& idxType() const {
     if (kind_ == Kind::Rectangular) {
-      return subs_.at(ID(UniqueString(), 1, 0));
+      return subs_.at(rectangularIdxTypeId);
     } else {
-      return subs_.at(ID(UniqueString(), 0, 0));
+      return subs_.at(nonRectangularIdxTypeId);
     }
   }
 
   const QualifiedType& strides() const {
     CHPL_ASSERT(kind_ == Kind::Rectangular);
-    return subs_.at(ID(UniqueString(), 2, 0));
+    return subs_.at(stridesId);
   }
 
   const QualifiedType& parSafe() const {
     CHPL_ASSERT(kind_ == Kind::Associative);
-    return subs_.at(ID(UniqueString(), 1, 0));
+    return subs_.at(parSafeId);
+  }
+
+  const QualifiedType& runtimeType() const {
+    return subs_.at(runtimeTypeId);
   }
 
   ~DomainType() = default;

--- a/frontend/include/chpl/types/RuntimeType.h
+++ b/frontend/include/chpl/types/RuntimeType.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2025 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CHPL_TYPES_RUNTIME_TYPE_H
+#define CHPL_TYPES_RUNTIME_TYPE_H
+
+#include "chpl/types/Type.h"
+#include "chpl/resolution/resolution-types.h"
+
+namespace chpl {
+namespace types {
+
+/**
+  This class encodes Chapel's notion of runtime types. In production,
+  calls to functions tagged with "runtime type init fn" are adjusted to
+  store their arguments into a new record. This record exists at runtime,
+  and is used as part of Chapel's runtime type support.
+ */
+class RuntimeType final : public Type {
+ private:
+  const resolution::TypedFnSignature* initializer_;
+
+  RuntimeType(const resolution::TypedFnSignature* initializer):
+    Type(typetags::RuntimeType), initializer_(initializer) {
+    CHPL_ASSERT(initializer != nullptr);
+    CHPL_ASSERT(!initializer->needsInstantiation());
+  }
+
+  static owned<RuntimeType> const&
+  getRuntimeType(Context* context,
+                 const resolution::TypedFnSignature* initializer);
+
+  bool contentsMatchInner(const Type* other) const override {
+    auto rhs = (const RuntimeType*) other;
+    return initializer_ == rhs->initializer_;
+  }
+
+  void markUniqueStringsInner(Context* context) const override {
+    initializer_->mark(context);
+  }
+
+  Genericity genericity() const override {
+    return CONCRETE;
+  }
+
+ public:
+  static const RuntimeType* get(Context* context,
+                                const resolution::TypedFnSignature* initializer);
+
+  const Type* substitute(Context* context,
+                         const PlaceholderMap& subs) const override {
+    return get(context, initializer_->substitute(context, subs));
+  }
+
+  const resolution::TypedFnSignature* initializer() const { return initializer_; }
+};
+
+} // end namespace types
+} // end namespace chpl
+
+#endif

--- a/frontend/include/chpl/types/all-types.h
+++ b/frontend/include/chpl/types/all-types.h
@@ -50,6 +50,7 @@
 #include "chpl/types/QualifiedType.h"
 #include "chpl/types/RealType.h"
 #include "chpl/types/RecordType.h"
+#include "chpl/types/RuntimeType.h"
 #include "chpl/types/TupleType.h"
 #include "chpl/types/Type.h"
 #include "chpl/types/Type.h"

--- a/frontend/include/chpl/types/type-classes-list.h
+++ b/frontend/include/chpl/types/type-classes-list.h
@@ -45,6 +45,7 @@ TYPE_NODE(ErroneousType)
 TYPE_NODE(NilType)
 TYPE_NODE(NothingType)
 TYPE_NODE(PlaceholderType)
+TYPE_NODE(RuntimeType)
 TYPE_NODE(UnknownType)
 TYPE_NODE(VoidType)
 

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2916,15 +2916,10 @@ bool Resolver::resolveSpecialKeywordCall(const Call* call) {
       // Copy the result of resolving 'domain' as the called identifier.
       r.setType(rCalledExp.type());
     } else {
-      // Get type by resolving the type of corresponding '_domain' init call
+      // Get type by resolving the type of corresponding domain builder call
       // TODO: prohibit associative domain with idxType 'domain'
       const AstNode* questionArg = nullptr;
       std::vector<CallInfoActual> actuals;
-      // Set up receiver
-      auto receiverType =
-          QualifiedType(QualifiedType::INIT_RECEIVER, rCalledExp.type().type());
-      auto receiverArg = CallInfoActual(receiverType, USTR("this"));
-      actuals.push_back(std::move(receiverArg));
       // Set up distribution arg
       auto defaultDistArg = CallInfoActual(
           DomainType::getDefaultDistType(context), UniqueString());
@@ -2934,9 +2929,9 @@ bool Resolver::resolveSpecialKeywordCall(const Call* call) {
       CHPL_ASSERT(!questionArg);
 
       auto ci =
-          CallInfo(USTR("init"),
-                   /* calledType */ receiverType,
-                   /* isMethodCall */ true,
+          CallInfo(UniqueString::get(context, "chpl__buildDomainRuntimeType"),
+                   /* calledType */ QualifiedType(),
+                   /* isMethodCall */ false,
                    /* hasQuestionArg */ false,
                    /* isParenless */ false,
                    actuals);
@@ -2946,19 +2941,15 @@ bool Resolver::resolveSpecialKeywordCall(const Call* call) {
       auto runResult = context->runAndTrackErrors([&](Context* ctx) {
         return resolveGeneratedCall(call, &ci, &inScopes);
       });
+      runResult.result().noteResultWithoutError(&r, { { AssociatedAction::RUNTIME_TYPE, fnCall->id() } });
 
-      // Use the init call's receiver type as the resulting TYPE
       QualifiedType receiverTy;
       if (runResult.ranWithoutErrors()) {
-        auto& c = runResult.result();
-        if (auto initMsc = c.result.mostSpecific().only()) {
-          c.noteResult(&r, {{AssociatedAction::RUNTIME_TYPE, fnCall->id()}});
-          receiverTy = initMsc.fn()->formalType(0);
-        }
+        receiverTy = runResult.result().result.exprType();
       }
-      if (!receiverTy.type()) {
+      if (receiverTy.isUnknownOrErroneous()) {
         std::vector<QualifiedType> actualTypesForErr;
-        for (auto it = actuals.begin() + 2; it != actuals.end(); ++it) {
+        for (auto it = actuals.begin() + 1; it != actuals.end(); ++it) {
           actualTypesForErr.push_back(it->type());
         }
         receiverTy = CHPL_TYPE_ERROR(context, InvalidDomainCall, fnCall,

--- a/frontend/lib/types/CMakeLists.txt
+++ b/frontend/lib/types/CMakeLists.txt
@@ -47,6 +47,7 @@ target_sources(ChplFrontend-obj
                PrimitiveType.cpp
                PtrType.cpp
                PromotionIteratorType.cpp
+               RuntimeType.cpp
                QualifiedType.cpp
                RealType.cpp
                RecordType.cpp

--- a/frontend/lib/types/DomainType.cpp
+++ b/frontend/lib/types/DomainType.cpp
@@ -19,6 +19,7 @@
 
 #include "chpl/types/DomainType.h"
 
+#include "chpl/types/RuntimeType.h"
 #include "chpl/framework/query-impl.h"
 #include "chpl/parsing/parsing-queries.h"
 #include "chpl/resolution/resolution-queries.h"
@@ -29,6 +30,12 @@
 namespace chpl {
 namespace types {
 
+const ID DomainType::rankId = ID(UniqueString(), 0, 0);
+const ID DomainType::rectangularIdxTypeId = ID(UniqueString(), 1, 0);
+const ID DomainType::nonRectangularIdxTypeId = ID(UniqueString(), 0, 0);
+const ID DomainType::stridesId = ID(UniqueString(), 2, 0);
+const ID DomainType::parSafeId = ID(UniqueString(), 1, 0);
+const ID DomainType::runtimeTypeId = ID(UniqueString(), 3, 0);
 
 void DomainType::stringify(std::ostream& ss,
                            chpl::StringifyKind stringKind) const {
@@ -147,6 +154,25 @@ DomainType::getAssociativeType(Context* context,
   auto id = getDomainID(context);
   return getDomainType(context, id, name, /* instantiatedFrom */ genericDomain,
                        subs, DomainType::Kind::Associative).get();
+}
+
+const DomainType* DomainType::getWithRuntimeType(Context* context,
+                                                 const DomainType* domainType,
+                                                 const RuntimeType* runtimeType) {
+  CHPL_ASSERT(runtimeType != nullptr);
+  auto rttQt = QualifiedType(QualifiedType::TYPE, runtimeType);
+  auto subs = domainType->substitutions();
+  subs.emplace(runtimeTypeId, rttQt);
+
+  const DomainType* instantiatedFrom = nullptr;
+  if (auto sourceInstFrom = domainType->instantiatedFromCompositeType()) {
+    CHPL_ASSERT(sourceInstFrom->isDomainType());
+    instantiatedFrom = sourceInstFrom->toDomainType();
+  }
+
+  return getDomainType(context, domainType->id(), domainType->name(),
+                       instantiatedFrom, std::move(subs),
+                       domainType->kind()).get();
 }
 
 const QualifiedType& DomainType::getDefaultDistType(Context* context) {

--- a/frontend/lib/types/RuntimeType.cpp
+++ b/frontend/lib/types/RuntimeType.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "chpl/types/RuntimeType.h"
+#include "chpl/framework/query-impl.h"
+
+namespace chpl {
+namespace types {
+
+owned<RuntimeType> const&
+RuntimeType::getRuntimeType(Context* context,
+                            const resolution::TypedFnSignature* initializer) {
+  QUERY_BEGIN(getRuntimeType, context, initializer);
+  auto result = toOwned(new RuntimeType(initializer));
+  return QUERY_END(result);
+}
+
+const RuntimeType* RuntimeType::get(Context* context,
+                                    const resolution::TypedFnSignature* initializer) {
+  return getRuntimeType(context, initializer).get();
+}
+
+} // end namespace types
+} // end namespace chpl

--- a/frontend/test/resolution/testDomainsAssociative.cpp
+++ b/frontend/test/resolution/testDomainsAssociative.cpp
@@ -129,9 +129,9 @@ int main() {
   // performance.
   auto context = buildStdContext();
 
-  testAssociative(context, "domain(int)", "int", true);
-  testAssociative(context, "domain(int, false)", "int", false);
-  testAssociative(context, "domain(string)", "string", true);
+  testAssociative(context, "domain(int)", "int", false);
+  testAssociative(context, "domain(int, true)", "int", true);
+  testAssociative(context, "domain(string)", "string", false);
 
   testDomainLiteral(context, "{1, 2, 3}", DomainType::Kind::Associative);
   testDomainLiteral(context, "{\"apple\", \"banana\"}", DomainType::Kind::Associative);

--- a/frontend/test/resolution/testDomainsAssociative.cpp
+++ b/frontend/test/resolution/testDomainsAssociative.cpp
@@ -50,6 +50,9 @@ module M {
   param rk = d.isRectangular();
   param ak = d.isAssociative();
 
+  type rttI = __primitive("get runtime type field", d, "idxType");
+  param rttS = __primitive("get runtime type field", d, "parSafe");
+
   var p = d.pid;
 
   for loopI in d {
@@ -85,7 +88,10 @@ module M {
   auto fullIndexType = findVarType(m, rr, "i");
   assert(findVarType(m, rr, "ig") == fullIndexType);
 
+  assert(findVarType(m, rr, "rttI").type() == fullIndexType.type());
+
   ensureParamBool(findVarType(m, rr, "s"), parSafe);
+  ensureParamBool(findVarType(m, rr, "rttS"), parSafe);
 
   ensureParamBool(findVarType(m, rr, "rk"), false);
 

--- a/frontend/test/resolution/testDomainsRectangular.cpp
+++ b/frontend/test/resolution/testDomainsRectangular.cpp
@@ -54,6 +54,10 @@ module M {
   param rk = d.isRectangular();
   param ak = d.isAssociative();
 
+  param rttR = __primitive("get runtime type field", d, "rank");
+  type rttI = __primitive("get runtime type field", d, "idxType");
+  param rttS = __primitive("get runtime type field", d, "strides");
+
   var p = d.pid;
 
   for loopI in d {
@@ -105,13 +109,19 @@ module M {
   assert(rankVarTy == dType->rank());
   ensureParamInt(rankVarTy, rank);
 
+  assert(findVarType(m, rr, "rttR") == rankVarTy);
+
   auto idxTypeVarTy = findVarType(m, rr, "i");
   assert(idxTypeVarTy == dType->idxType());
   assert(findVarType(m, rr, "ig") == idxTypeVarTy);
 
+  assert(findVarType(m, rr, "rttI") == idxTypeVarTy);
+
   auto stridesVarTy = findVarType(m, rr, "s");
   assert(stridesVarTy == dType->strides());
   assert(stridesVarTy.param()->toEnumParam()->value().str == strides);
+
+  assert(findVarType(m, rr, "rttS") == stridesVarTy);
 
   ensureParamBool(findVarType(m, rr, "rk"), true);
 


### PR DESCRIPTION
This PR adds support for runtime type records, which are built in production.

In production, domains and arrays are built using functions that have pragma `runtime type init fn`. This makes them behave quite oddly in many ways, but one crucial way is that calls to these functions _implicit wrap all the arguments to them into a record_. This record's type becomes associated with the type of the domain/array being constructed. Furthermore (presumably) at runtime -- where array and domain types have values, unlike most other Dyno types -- this record is stored as that value.

Operations on array and domain types will occasionally reference this record's fields using the primitive `get runtime type field`.

This PR implements this feature. It seemed most elegant -- though, as @riftEmber noted, somewhat excessive --  to store the runtime type function as part of a new `RuntimeType`, where the "fields" of the runtime type can be accessed by checking with the function's formals. This new `RuntimeType` is stored as part of its corresponding `ArrayType` and `DomainType` via substitutions. I chose, by the way, to keep using substitutions rather than transitioning to fields because this avoids paying for these types if they are not present (since they would not be saved into a map) and since it diverges less from the parent CompositeType.

Calls to `runtime type init fn`s are adjusted to embellish their return types with the generated `RuntimeType`. This enables the use of the `get runtime type field` primitive.

While there, I noticed that an existing TODO to emit error messages for domains-of-domains was handled by module code via the builder functions. So, I made slight tweaks to ensure those module code errors were emitted as desired, completing the TODO.

## Testing
- [x] dyno tests