### PR TITLE
Allow users to omit the return type on some Python calls

### DIFF
--- a/modules/packages/Python.chpl
+++ b/modules/packages/Python.chpl
@@ -118,7 +118,7 @@
          var subInterpreter = new SubInterpreter(interpreter);
          var m = new Module(subInterpreter, 'myMod', code);
          var hello = new Function(m, 'hello');
-         hello(NoneType);
+         hello();
        }
      }
 
@@ -325,8 +325,8 @@
      writeln("Let's call some Python!");
      IO.stdout.flush(); // flush the Chapel output buffer before calling Python
 
-     func(NoneType, "Hello, World!");
-     func(NoneType, "Goodbye, World!");
+     func("Hello, World!");
+     func("Goodbye, World!");
      interp.flush(); // flush the Python output buffer before calling Chapel again
 
      writeln("Back to Chapel");
@@ -1730,11 +1730,19 @@ module Python {
       :arg idx: The index of the item to get.
       :returns: The item at the given index.
     */
+    pragma "docs only"
+    proc getItem(type T = owned Value, idx: int): T throws do
+      compilerError("docs only");
+
+    @chpldoc.nodoc
     proc getItem(type T, idx: int): T throws {
       var item = PySequence_GetItem(this.get(), idx.safeCast(Py_ssize_t));
       this.check();
       return interpreter.fromPython(T, item);
     }
+    proc getItem(idx: int): owned Value throws do
+      return this.getItem(owned Value, idx);
+
     /*
       Set an item in the list. Equivalent to calling ``obj[idx] = item`` in
       Python.

--- a/modules/packages/Python.chpl
+++ b/modules/packages/Python.chpl
@@ -1672,31 +1672,6 @@ module Python {
               obj: PyObjectPtr, isOwned: bool = true) {
       super.init(interpreter, obj, isOwned=isOwned);
     }
-
-    @chpldoc.nodoc
-    proc newInstance(const args...): PyObjectPtr throws {
-      var pyArg = packTuple((...args));
-      defer Py_DECREF(pyArg);
-      var pyRes = PyObject_Call(this.get(), pyArg, nil);
-      this.check();
-      return pyRes;
-    }
-    @chpldoc.nodoc
-    proc newInstance(): PyObjectPtr throws {
-      var pyRes = PyObject_CallNoArgs(this.get());
-      this.check();
-      return pyRes;
-    }
-
-    /*
-      Create a new instance of a Python class
-    */
-    proc this(const args...): owned Value throws do
-      return new Value(interpreter, newInstance((...args)), isOwned=true);
-    @chpldoc.nodoc
-    proc this(): owned Value throws do
-      return new Value(interpreter, newInstance(), isOwned=true);
-
   }
 
 

--- a/modules/packages/Python.chpl
+++ b/modules/packages/Python.chpl
@@ -2052,6 +2052,10 @@ module Python {
     writer.write(this:string);
 
   @chpldoc.nodoc
+  proc NoneType.serialize(writer, ref serializer) throws do
+    writer.write(this:string);
+
+  @chpldoc.nodoc
   module CWChar {
     require "wchar.h";
     extern "wchar_t" type c_wchar;

--- a/modules/packages/Python.chpl
+++ b/modules/packages/Python.chpl
@@ -1740,6 +1740,7 @@ module Python {
       this.check();
       return interpreter.fromPython(T, item);
     }
+    @chpldoc.nodoc
     proc getItem(idx: int): owned Value throws do
       return this.getItem(owned Value, idx);
 

--- a/test/library/packages/Python/correctness/argPassingTest.chpl
+++ b/test/library/packages/Python/correctness/argPassingTest.chpl
@@ -7,6 +7,7 @@ proc test_no_args(mod: borrowed Module) {
   var func = new Function(mod, funcName);
 
   func(NoneType);
+  func();
 
   // error: wrong return type
   try { func(int); }
@@ -23,6 +24,7 @@ proc test_one_arg(mod: borrowed Module) {
   var func = new Function(mod, funcName);
 
   func(NoneType, 1);
+  func(2);
 
   // error: not enough args
   try { func(NoneType); }
@@ -39,8 +41,8 @@ proc test_two_args(mod: borrowed Module) {
   var func = new Function(mod, funcName);
 
   func(NoneType, 1, 2);
-  func(NoneType, "hello", "world");
-  func(NoneType, None, None);
+  func("hello", "world");
+  func(None, None);
 
   // error: not enough args
   try { func(NoneType, 3); }
@@ -58,12 +60,13 @@ proc test_varargs(mod: borrowed Module) {
   var func = new Function(mod, funcName);
 
   func(NoneType);
-  func(NoneType, 1);
-  func(NoneType, 1, 2);
-  func(NoneType, 1, 2, 3);
-  func(NoneType, 1, 2, 3, [1,2,3,]);
-  func(NoneType, 1, 2, 3, [1,2,3,], 4);
+  func(1);
+  func(1, 2);
+  func(1, 2, 3);
+  func(1, 2, 3, [1,2,3,]);
+  func(1, 2, 3, [1,2,3,], 4);
   func(NoneType, 1, 2, 3, [1,2,3,], 4, ["key" => "value", "key2" => "value2"]);
+  func(1, 2, 3, [1,2,3,], 4, ["key" => "value", "key2" => "value2"]);
 }
 proc test_one_arg_with_default(mod: borrowed Module) {
   const funcName = "one_arg_with_default";
@@ -71,6 +74,8 @@ proc test_one_arg_with_default(mod: borrowed Module) {
 
   func(NoneType);
   func(NoneType, 7);
+  func();
+  func(7);
 }
 proc test_three_args_with_default(mod: borrowed Module) {
   const funcName = "three_args_with_default";
@@ -80,6 +85,7 @@ proc test_three_args_with_default(mod: borrowed Module) {
   func(NoneType, 8, 9);
   func(NoneType, 8, 9, 10);
   func(NoneType, 8, kwargs=["c" => 10]);
+  func(8, kwargs=["c" => 10]);
 }
 proc test_three_args_with_default_and_kwargs(mod: borrowed Module) {
   const funcName = "three_args_with_default_and_kwargs";
@@ -88,7 +94,7 @@ proc test_three_args_with_default_and_kwargs(mod: borrowed Module) {
   func(NoneType, 8);
   func(NoneType, 8, 9);
   func(NoneType, 8, 9, 10);
-  func(NoneType, 8, kwargs=["b" => 10]);
+  func(8, kwargs=["b" => 10]);
   func(NoneType, 8, kwargs=["c" => 11, "abc" => 12]);
 }
 proc test_varargs_and_kwargs(mod: borrowed Module) {
@@ -99,6 +105,7 @@ proc test_varargs_and_kwargs(mod: borrowed Module) {
   func(NoneType, 1);
   func(NoneType, 1, ["key" => "value"]);
   func(NoneType, kwargs=["a" => 19]);
+  func(kwargs=["a" => 19]);
   func(NoneType, 1, kwargs=["a" => 20]);
   func(NoneType, 1, 2, ["key" => "value"], kwargs=["a" => 7, "b" => 8]);
 }

--- a/test/library/packages/Python/correctness/argPassingTest.good
+++ b/test/library/packages/Python/correctness/argPassingTest.good
@@ -1,8 +1,10 @@
 called no_args
 called no_args
+called no_args
 Caught PythonException: 'NoneType' object cannot be interpreted as an integer
 Caught PythonException: no_args() takes 0 positional arguments but 1 was given
 called one_arg with 1
+called one_arg with 2
 Caught PythonException: one_arg() missing 1 required positional argument: 'a'
 Caught PythonException: one_arg() takes 1 positional argument but 2 were given
 called two_args with 1 and 2
@@ -24,11 +26,16 @@ called varargs
   args: 1, 2, 3, [1, 2, 3], 4
 called varargs
   args: 1, 2, 3, [1, 2, 3], 4, {'key2': 'value2', 'key': 'value'}
+called varargs
+  args: 1, 2, 3, [1, 2, 3], 4, {'key2': 'value2', 'key': 'value'}
+called one_arg_with_default with 1
+called one_arg_with_default with 7
 called one_arg_with_default with 1
 called one_arg_with_default with 7
 called three_args_with_default with 8, 2, and 3
 called three_args_with_default with 8, 9, and 3
 called three_args_with_default with 8, 9, and 10
+called three_args_with_default with 8, 2, and 10
 called three_args_with_default with 8, 2, and 10
 called three_args_with_default_and_kwargs with 8, 2, and 3
   kwargs:
@@ -49,6 +56,9 @@ called varargs_and_kwargs
 called varargs_and_kwargs
   args: 1, {'key': 'value'}
   kwargs:
+called varargs_and_kwargs
+  args:
+  kwargs: a=19
 called varargs_and_kwargs
   args:
   kwargs: a=19

--- a/test/library/packages/Python/correctness/arrays/gradient.chpl
+++ b/test/library/packages/Python/correctness/arrays/gradient.chpl
@@ -30,7 +30,7 @@ proc main() {
   var res: [arr.domain] real;
   {
     var pyRes = new Array(interp, res);
-    gradModifyArg(NoneType, pyArr, pyRes);
+    gradModifyArg(pyArr, pyRes);
   }
   write("gradModifyArg: ", res);
   write(" dom: ", res.domain);

--- a/test/library/packages/Python/correctness/arrays/myArray.chpl
+++ b/test/library/packages/Python/correctness/arrays/myArray.chpl
@@ -43,7 +43,7 @@ proc testArray(type t, const testArr) {
   IO.stdout.flush();
   var pyCode = new Module(interp, '__empty__', pythonCode);
   var func = new Function(pyCode, 'loop');
-  func(NoneType, pyArr);
+  func(pyArr);
   IO.stdout.flush();
 
   writeln("from chapel: ", arr);

--- a/test/library/packages/Python/correctness/arrays/myList.chpl
+++ b/test/library/packages/Python/correctness/arrays/myList.chpl
@@ -21,6 +21,7 @@ proc main() {
   writeln("lst[2] ", lst.getItem(string, 2));
   writeln("lst[lst.size-1] ", lst.getItem(int, lst.size-1));
   writeln("lst[-3] ", lst.getItem(owned Value, -3));
+  writeln("lst[-3] ", lst.getItem(-3));
 
   try {
     write("lst[lst.size] ");

--- a/test/library/packages/Python/correctness/arrays/myList.good
+++ b/test/library/packages/Python/correctness/arrays/myList.good
@@ -5,5 +5,6 @@ lst[1] 2
 lst[2] hi
 lst[lst.size-1] 5
 lst[-3] hi
+lst[-3] hi
 lst[lst.size] Caught exception: PythonException: list index out of range
 lst [100, 2, 'hi', False, 5]

--- a/test/library/packages/Python/correctness/arrays/numpyInterop.chpl
+++ b/test/library/packages/Python/correctness/arrays/numpyInterop.chpl
@@ -29,7 +29,7 @@ proc main() {
     var xArr = new Array(interp, x);
     var yArr = new Array(interp, y);
 
-    var result = saxpy(owned Value, xArr, yArr, a);
+    var result = saxpy(xArr, yArr, a);
     writeln("saxpy on 1D arrays: ", result);
   }
   writeln();
@@ -41,7 +41,7 @@ proc main() {
     var xArr = new Array(interp, x);
     var yArr = new Array(interp, y);
 
-    var result = saxpy(owned Value, xArr, yArr, a);
+    var result = saxpy(xArr, yArr, a);
     writeln("saxpy on nested arrays: ", result);
   }
   writeln();
@@ -50,7 +50,7 @@ proc main() {
     writeln("Before numpyAssign: ", x);
     {
       var xArr = new Array(interp, x);
-      numpyAssign(NoneType, xArr);
+      numpyAssign(xArr);
     }
     writeln("After numpyAssign: ", x);
   }

--- a/test/library/packages/Python/correctness/basicTypes.chpl
+++ b/test/library/packages/Python/correctness/basicTypes.chpl
@@ -52,7 +52,7 @@ proc roundTripClass(clsType: borrowed) {
     if print then writeln("    obj.getter(): ", res);
     assert(res == other);
 
-    obj.call(NoneType, "setter", value);
+    obj.call("setter", value);
     res = obj.getAttr(t, "value");
     if print then writeln("    obj.value: ", res);
     assert(res == value);

--- a/test/library/packages/Python/correctness/defaultType.chpl
+++ b/test/library/packages/Python/correctness/defaultType.chpl
@@ -1,0 +1,109 @@
+use Python;
+
+
+var code = """
+def do_nothing():
+    pass
+def get_int():
+    return 42
+def pass_through(x):
+    return x
+""";
+
+var interp = new Interpreter();
+var mod = new Module(interp, '__empty__', code);
+var do_nothing = new Function(mod, 'do_nothing');
+var get_int = new Function(mod, 'get_int');
+var pass_through = new Function(mod, 'pass_through');
+
+{
+  writeln("do_nothing()");
+
+  var x = do_nothing();
+  writeln(x, " - ", x.type:string);
+  var y = do_nothing(NoneType);
+  writeln(y, " - ", y.type:string);
+  var z = do_nothing(owned Value);
+  writeln(z, " - ", z.type:string);
+  var w = do_nothing(owned Value?);
+  writeln(w, " - ", w.type:string);
+
+  var v: owned Value? = do_nothing();
+  writeln(v, " - ", v.type:string);
+
+  writeln("=====");
+}
+
+{
+  writeln("get_int()");
+
+  var x = get_int();
+  writeln(x, " - ", x.type:string);
+  var y = get_int(NoneType);
+  writeln(y, " - ", y.type:string);
+  var z = get_int(owned Value);
+  writeln(z, " - ", z.type:string);
+  var w = get_int(owned Value?);
+  writeln(w, " - ", w.type:string);
+
+  var v: owned Value? = get_int();
+  writeln(v, " - ", v.type:string);
+
+  writeln("=====");
+}
+
+
+{
+  writeln("pass_through(17)");
+
+  var x = pass_through(17);
+  writeln(x, " - ", x.type:string);
+  var y = pass_through(NoneType, 17);
+  writeln(y, " - ", y.type:string);
+  var z = pass_through(owned Value, 17);
+  writeln(z, " - ", z.type:string);
+  var w = pass_through(owned Value?, 17);
+  writeln(w, " - ", w.type:string);
+
+  var v: owned Value? = pass_through(17);
+  writeln(v, " - ", v.type:string);
+
+  writeln("=====");
+}
+
+{
+  writeln("pass_through(None)");
+
+  var x = pass_through(None);
+  writeln(x, " - ", x.type:string);
+  var y = pass_through(NoneType, None);
+  writeln(y, " - ", y.type:string);
+  var z = pass_through(owned Value, None);
+  writeln(z, " - ", z.type:string);
+  var w = pass_through(owned Value?, None);
+  writeln(w, " - ", w.type:string);
+
+  var v: owned Value? = pass_through(None);
+  writeln(v, " - ", v.type:string);
+
+  writeln("=====");
+}
+
+
+{
+  writeln("pass_through(\"hi\")");
+
+  var x = pass_through("hi");
+  writeln(x, " - ", x.type:string);
+  var y = pass_through(NoneType, "hi");
+  writeln(y, " - ", y.type:string);
+  var z = pass_through(owned Value, "hi");
+  writeln(z, " - ", z.type:string);
+  var w = pass_through(owned Value?, "hi");
+  writeln(w, " - ", w.type:string);
+
+  var v: owned Value? = pass_through("hi");
+  writeln(v, " - ", v.type:string);
+
+  writeln("=====");
+}

--- a/test/library/packages/Python/correctness/defaultType.good
+++ b/test/library/packages/Python/correctness/defaultType.good
@@ -1,0 +1,35 @@
+do_nothing()
+None - owned Value
+None - NoneType
+None - owned Value
+None - owned Value?
+None - owned Value?
+=====
+get_int()
+42 - owned Value
+None - NoneType
+42 - owned Value
+42 - owned Value?
+42 - owned Value?
+=====
+pass_through(17)
+17 - owned Value
+None - NoneType
+17 - owned Value
+17 - owned Value?
+17 - owned Value?
+=====
+pass_through(None)
+None - owned Value
+None - NoneType
+None - owned Value
+None - owned Value?
+None - owned Value?
+=====
+pass_through("hi")
+hi - owned Value
+None - NoneType
+hi - owned Value
+hi - owned Value?
+hi - owned Value?
+=====

--- a/test/library/packages/Python/correctness/iteratorTest.chpl
+++ b/test/library/packages/Python/correctness/iteratorTest.chpl
@@ -24,7 +24,7 @@ proc test(func: borrowed Function) {
 
   {
     // convert to a list via a Value
-    var obj = func(owned Value, low, high);
+    var obj = func(low, high);
     if print then writeln("  Value: ", obj.str());
 
     var res = obj.value(List.list(int));

--- a/test/library/packages/Python/correctness/loadingCode/fromCloudPickle.chpl
+++ b/test/library/packages/Python/correctness/loadingCode/fromCloudPickle.chpl
@@ -11,10 +11,10 @@ var my_function =
                interp.loadPickle(openReader("my_function.pkl").readAll(bytes)));
 
 // run my_function
-var res = my_function(owned Value);
-res.call(NoneType, "print");
+var res = my_function();
+res.call("print");
 
 // create an instance of MyClass
 var obj = MyClass(10);
-obj.call(NoneType, "print");
+obj.call("print");
 

--- a/test/library/packages/Python/correctness/loadingCode/moduleFromBytes.chpl
+++ b/test/library/packages/Python/correctness/loadingCode/moduleFromBytes.chpl
@@ -12,12 +12,12 @@ var MyClass = new Class(mod, "MyClass");
 var my_function = new Function(mod, "my_function");
 
 // run my_function
-var v = my_function(owned Value);
-v.call(NoneType, "print");
+var v = my_function();
+v.call("print");
 
 // create an instance of MyClass
 var obj = MyClass(10);
-obj.call(NoneType, "print");
+obj.call("print");
 
 
 

--- a/test/library/packages/Python/correctness/loadingCode/moduleFromString.chpl
+++ b/test/library/packages/Python/correctness/loadingCode/moduleFromString.chpl
@@ -10,6 +10,6 @@ var interp = new Interpreter();
 
 var mod = new Module(interp, "mymod", modStr);
 var foo = mod.getAttr(owned Function, "foo");
-foo(NoneType, 1);
-foo(NoneType, [1,2,3]);
-foo(NoneType, "str");
+foo(1);
+foo([1,2,3]);
+foo("str");

--- a/test/library/packages/Python/correctness/subInterp.chpl
+++ b/test/library/packages/Python/correctness/subInterp.chpl
@@ -20,7 +20,7 @@ proc main() {
     var m = new Module(localInterp, '__empty__', code);
     var f = new Function(m, 'hello');
     for i in 1..#itersPerTask {
-      f(NoneType, tid, i);
+      f(tid, i);
     }
   }
 

--- a/test/library/packages/Python/examples/torch/myModel.chpl
+++ b/test/library/packages/Python/examples/torch/myModel.chpl
@@ -17,36 +17,36 @@ proc main() {
 
   // create the model
   var model = myModelClass();
-  var input_tensor = tensor(owned Value, [[1.0,]], kwargs=["requires_grad" => false]);
+  var input_tensor = tensor([[1.0,]], kwargs=["requires_grad" => false]);
   writeln("Input tensor: ", input_tensor);
 
   // init model weights to 0.9
   {
     var params = model.call(list(owned Value?), "parameters");
     for p in params {
-      var data_ = p!.getAttr(owned Value, "data");
-      data_.call(NoneType, "fill_", 0.9);
+      var data_ = p!.getAttr("data");
+      data_.call("fill_", 0.9);
     }
   }
 
   // run model
-  var pred = model(owned Value, input_tensor);
+  var pred = model(input_tensor);
 
   // compute the loss
   var loss_fn = MSELoss();
-  var target = tensor(owned Value, [[2.0,]]);
+  var target = tensor([[2.0,]]);
   writeln("Target: ", target);
-  var loss = loss_fn(owned Value, pred, target);
-  loss.call(NoneType, "backward");
+  var loss = loss_fn(pred, target);
+  loss.call("backward");
 
   // update the model's parameters
   var learning_rate = 0.01;
   var params = model.call(list(owned Value?), "parameters");
   for p in params {
-    var data = p!.getAttr(owned Value, "data");
-    var grad = p!.getAttr(owned Value, "grad");
-    var temp = grad.call(owned Value, "__mul__", learning_rate);
-    var temp2 = data.call(owned Value, "__sub__", temp);
+    var data = p!.getAttr("data");
+    var grad = p!.getAttr("grad");
+    var temp = grad.call("__mul__", learning_rate);
+    var temp2 = data.call("__sub__", temp);
     p!.setAttr("data", temp2);
   }
 

--- a/test/library/packages/Python/memleaks/lambdas.good
+++ b/test/library/packages/Python/memleaks/lambdas.good
@@ -3,4 +3,4 @@
 [[1, 2, 3], [1, 2, 3]]
 skipping potentially leaking print
 [1]
-()
+None


### PR DESCRIPTION
Allows users to omit the return type on a call to Python code when they don't care what the type is. The defaults to `owned Value`, which is a wrapper around the underlying type. This `Value` can be captured by users and later converted to a Chapel type, continue to be used by other functions as a `Value` type (with no extra overhead), or ignored alltogether (in the case a function from python doesn't return anything).

This significantly cleans up some user-facing Python code

Before this PR
```chapel
doNothing(NoneType);
funcReturnsNothing(NoneType, 1, 2, 3);
var x: owned Value = getAValue(owned Value);
```

After this PR
```chapel
doNothing();
funcReturnsNothing(1, 2, 3);
var x: owned Value = getAValue();
```

- [x] ran `start_test test/library/packages/Python/`

[Reviewed by @lydia-duncan]