### PR TITLE
add tests for use domain formal before defined

### DIFF
--- a/test/domains/compilerErrors/domainFormalUseBeforeDefine.chpl
+++ b/test/domains/compilerErrors/domainFormalUseBeforeDefine.chpl
@@ -1,0 +1,7 @@
+proc domainArgsInRange(matrix:[0..#D1][0..#D2] real, D1 : int, D2 : int) {
+  // should be an error to use D1 and D2 before defined
+}
+
+proc domainArg(ref A:[dom1] real, ref B:[dom1] real, dom1:domain(1)) {
+  // should be an error to use dom1 before defined
+}

--- a/test/domains/compilerErrors/domainFormalUseBeforeDefine.good
+++ b/test/domains/compilerErrors/domainFormalUseBeforeDefine.good
@@ -1,0 +1,10 @@
+domainFormalUseBeforeDefine.chpl:1: In function 'domainArgsInRange':
+domainFormalUseBeforeDefine.chpl:1: error: statement references variable 'D1' before it is defined
+domainFormalUseBeforeDefine.chpl:1: note: the variable 'D1' is defined here
+domainFormalUseBeforeDefine.chpl:1: error: statement references variable 'D2' before it is defined
+domainFormalUseBeforeDefine.chpl:1: note: the variable 'D2' is defined here
+domainFormalUseBeforeDefine.chpl:5: In function 'domainArg':
+domainFormalUseBeforeDefine.chpl:5: error: statement references variable 'dom1' before it is defined
+domainFormalUseBeforeDefine.chpl:5: note: the variable 'dom1' is defined here
+domainFormalUseBeforeDefine.chpl:5: error: statement references variable 'dom1' before it is defined
+domainFormalUseBeforeDefine.chpl:5: note: the variable 'dom1' is defined here


### PR DESCRIPTION
Add regression test for a formal pattern that was previously allowing the use of formals before they were defined due to a bug/limitation in the compiler.

As an example, consider the following function signature:
```chapel
proc foo(baz: t, type t) {
	//...
}
```

Here the formal `baz` is declared as having the type `t`, and `type t` is defined as the second formal.

The compiler rightly complains that we've used the `type t` before it was defined.

The solution is to reorder the formals such that the type t is defined first:
```chapel
proc foo(type t, baz: t) {
	//...
}
```

However, because we can’t enforce domain type bounds at compile time, doing something similar with a domain appeared to work.

```chapel
proc bar(baz: [d] real, d:domain(1)) {
	//...
}
```

This appeared to work because behind the scenes, the compiler is rewriting this array domain expression into the function body as an internal call due to special handling of array domain expressions.

As we move more of the resolution process into the new compiler (Dyno), errors like this are detected at compile time and so formals need to observe the same define-before-use rules as other variables. 

This requires reordering the formals such that the domain comes before the array formal that uses it. If call sites do not use named arguments, their ordering will similarly need to be adjusted.


[reviewed by @mppf - thanks!]
