### PR TITLE
Dyno: enable more initial signature patterns

### DIFF
--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -5245,7 +5245,7 @@ void Resolver::exit(const Dot* dot) {
     if (receiver.type().type() != nullptr) {
       receiverType = receiver.type().type();
     } else {
-      receiverType = ErroneousType::get(context);
+      receiverType = UnknownType::get(context);
     }
 
     if (!receiver.type().isType()) {

--- a/frontend/test/resolution/testTuples.cpp
+++ b/frontend/test/resolution/testTuples.cpp
@@ -963,6 +963,23 @@ static void test21() {
   ensureParamBool(vars["secondMatch"], true);
 }
 
+static void test22() {
+  // Ensure that homogeneous tuple addition works
+
+  auto context = buildStdContext();
+  auto program = R"""(
+    var t1 = (1,2,3);
+    var t2 = t1 + 1;
+    param match = t1.type == t2.type;
+  )""";
+
+  auto vars = resolveTypesOfVariables(context, program,
+                                      {"t1", "t2", "match"});
+  assert(vars["t1"].type()->isTupleType());
+  assert(vars["t2"].type()->isTupleType());
+  ensureParamBool(vars["match"], true);
+}
+
 
 int main() {
   test1();
@@ -991,5 +1008,6 @@ int main() {
 
   test20();
   test21();
+  test22();
   return 0;
 }


### PR DESCRIPTION
Closes https://github.com/Cray/chapel-private/issues/7070.

Dyno's initial signatures are deliberately partial. They are used to filter out obviously non-matching candidates, while skipping the difficult parts of instantiation. As a result, they don't incorporate dependent type information, type queries, etc.

This means in such complicated instantiation cases, it's "expected" for unknown types to be present in initial signatures, and compiler logic should work with that. Prior to this PR, the `.type` expression produced `ErroneousType` for `.type` on known things, which broke the aforementioned expectation. This PR changes `.type` to produce `UnknownType` instead, which is preferred anyway since Dyno's convention is to only create `ErroneousTypes` when errors are issued.

Reviewed by @benharsh -- thanks!

## Testing
- [x] dyno tests
- [x] paratest