### PR TITLE
limit github action to chapel-lang repo

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -192,7 +192,7 @@ jobs:
           done
 
   publish-docs:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.repository == 'chapel-lang/chapel'
     runs-on: ubuntu-latest
     needs: make_doc
     steps:


### PR DESCRIPTION
This adds a restriction to the `publish-docs` github action so that it only runs on `chapel-lang/chapel` and not on forks or mirrors of the repository, where it would always fail due to missing secrets. 

Tested against my own fork with and without matching repository names. 

Trivial change to solve an annoyance in an action that isn't actually doing anything yet. Not reviewed.