### PR TITLE
Fix typo in skipif for myModel

### DIFF
--- a/test/library/packages/Python/examples/torch/myModel.skipif
+++ b/test/library/packages/Python/examples/torch/myModel.skipif
@@ -4,7 +4,7 @@
 if [ -n "$CHPL_TEST_VGRND_EXE" ] && [ "$CHPL_TEST_VGRND_EXE" == "on" ]; then
   echo "True"
   exit 0
-else
+fi
 
 FILE_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 $FILE_DIR/../../skipIfAndInstallPackage.sh $FILE_DIR torch numpy


### PR DESCRIPTION
Fixes a typo in a skipif for a test.

The skipif worked to skip the test (since it exited), but I failed to notice the syntax error and subsequent failures in the working case

[Not reviewed - trivial]