### PR TITLE
add 01/24/25 annotation about chapcs system updates

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -612,6 +612,9 @@ all:
   01/06/25:
     - text: Partially revert Qthreads patch from #26328 (#26468)
       config: chapcs, 16-node-apollo-hdr, 16-node-hpe-cray-ex, 1-node-hpe-cray-ex
+  01/24/25:
+    - text: OS and file system update
+      config: chapcs
   02/03/25:
     - text: Started using ROCm 6.x
       config: 1-node-mi250x


### PR DESCRIPTION
Several tests were affected by an updated that happened on 01/24/25 to chapcs's OS and file system.  This PR adds an annotation about this.