### PR TITLE
Dyno: add workaround for finding 'serialize' methods in ChapelIO

### DIFF
--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -38,6 +38,9 @@ namespace resolution {
 using namespace uast;
 using namespace types;
 
+static bool isDeSerializeMethod(UniqueString name) {
+  return name == USTR("serialize") || name == USTR("deserialize");
+}
 
 /**
   Return true if 'name' is the name of a compiler generated method.
@@ -50,7 +53,7 @@ static bool isNameOfCompilerGeneratedMethod(UniqueString name) {
     return true;
   }
 
-  if (name == USTR("serialize") || name == USTR("deserialize")) {
+  if (isDeSerializeMethod(name)) {
     return true;
   }
 
@@ -80,6 +83,21 @@ areOverloadsPresentInDefiningScope(Context* context,
                                /* methodLookupHelper */ nullptr,
                                /* receiverScopeHelper */ nullptr,
                                name, config);
+
+  // this ought to be solved by interfaces, but today it isn't. As a workaround
+  // for some standard types having their (de)serialize methods defined in
+  // ChapelIO, search that module too.
+  if (ids.numIds() == 0 && isDeSerializeMethod(name)) {
+    auto chapelIo =
+      parsing::getToplevelModule(context,
+                                 UniqueString::get(context, "ChapelIO"));
+    if (!chapelIo) return false;
+
+    ids = lookupNameInScope(context, scopeForModule(context, chapelIo->id()),
+                            /* methodLookupHelper */ nullptr,
+                            /* receiverScopeHelper */ nullptr,
+                            name, config);
+  }
 
   // nothing found
   if (ids.numIds() == 0) return false;


### PR DESCRIPTION
Closes https://github.com/Cray/chapel-private/issues/7090.
Probably closes https://github.com/Cray/chapel-private/issues/7098 (the assertion is during `canPass` for compiler-generated tuple functions, which this PR ought to disable).

In production, we generate `serialize` functions for types if no `serialize` function is present _anywhere in the program_. Dyno, however, is an incremental compiler, and as a result, it cannot use "anywhere in the program" properties (not to mention, due to various scoping rules, the "anywhere in the program" rule can get you into hot water). Instead, Dyno uses a type's definition point to search for `serialize` etc. 

This would be nice, except that we define some serialization functions for builtin types in `ChapelIO`, away from the types' definition points. This PR works around this in Dyno, by deliberately including `ChapelIO` as a place where we search for existing `serialize` fns.

In the ideal world, we would like for this to be solved using interfaces. In this world, `serialize` would not be automatically generated _except when auto-satisfying the `writeSerializable` interface_, and only using functions available in the current scope. This would solve the problem with checking "anywhere in the program", as well as other non-dyno-related problems ("`serialize` should only be special if the interface is present, but right now it's special anyway"). However, we are not yet in the ideal world, and production cannot handle that sort of implementation today.

Reviewed by @benharsh -- thanks!

## Testing
- [x] dyno tests
- [x] paratest