### PR TITLE
Dyno: fix nested type queries

### DIFF
--- a/frontend/include/chpl/types/BasicClassType.h
+++ b/frontend/include/chpl/types/BasicClassType.h
@@ -110,7 +110,8 @@ class BasicClassType final : public ManageableType {
       using a parent type and 'instantiates' is set to true if
       it requires instantiation.
    */
-  bool isSubtypeOf(const BasicClassType* parentType,
+  bool isSubtypeOf(Context* context,
+                   const BasicClassType* parentType,
                    bool& converts,
                    bool& instantiates) const;
 

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -6536,7 +6536,7 @@ constructReduceScanOpClass(Resolver& resolver,
   if (opType.kind() != QualifiedType::TYPE ||
       !actualClass ||
       !actualClass->basicClassType() ||
-      !actualClass->basicClassType()->isSubtypeOf(baseClass, converts, instantiates)) {
+      !actualClass->basicClassType()->isSubtypeOf(context, baseClass, converts, instantiates)) {
     CHPL_REPORT(context, ReductionNotReduceScanOp, reduceOrScan, opType);
   }
 
@@ -6731,7 +6731,7 @@ bool Resolver::enter(const Catch* node) {
       bool instantiates = false;
       if (auto bct = ct->basicClassType()) {
         isBasicClass = true;
-        if (!bct->isSubtypeOf(CompositeType::getErrorType(context)->basicClassType(), converts, instantiates)) {
+        if (!bct->isSubtypeOf(context, CompositeType::getErrorType(context)->basicClassType(), converts, instantiates)) {
           // get the penultimate type in the chain
           while (!bct->parentClassType()->isObjectType()) {
             bct = bct->parentClassType();

--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -1254,6 +1254,16 @@ bool canInstantiateSubstitutions(Context* context,
       auto r = canPass(context, mySubType, pSubType);
       if (r.passes() && !r.promotes() && !r.converts()) {
         // instantiation and same-type passing are allowed here
+        //
+        // canPass doesn't check param values for equivalence to allow handling
+        // coerciions and narrowing, so explicitly check them here.
+        if (pSubType.isParam()) {
+          bool compatible = pSubType.param() == nullptr ||
+                            mySubType.param() == pSubType.param();
+          if (!compatible) {
+            return false;
+          }
+        }
       } else {
         // it was not an instantiation
         return false;

--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -1256,7 +1256,7 @@ bool canInstantiateSubstitutions(Context* context,
         // instantiation and same-type passing are allowed here
         //
         // canPass doesn't check param values for equivalence to allow handling
-        // coerciions and narrowing, so explicitly check them here.
+        // coercions and narrowing, so explicitly check them here.
         if (pSubType.isParam()) {
           bool compatible = pSubType.param() == nullptr ||
                             mySubType.param() == pSubType.param();

--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -571,7 +571,7 @@ CanPassResult CanPassResult::canPassSubtypeNonBorrowing(Context* context,
         // From the previous conditional, we know the formal isn't another
         // 'any' class, so this actual cannot be passed.
         pass = false;
-      } else if (actualBct->isSubtypeOf(formalBct, converts, instantiates)) {
+      } else if (actualBct->isSubtypeOf(context, formalBct, converts, instantiates)) {
         // the basic class types are the same
         // or there was a subclass relationship
         // or there was instantiation

--- a/frontend/lib/types/BasicClassType.cpp
+++ b/frontend/lib/types/BasicClassType.cpp
@@ -75,7 +75,8 @@ BasicClassType::getReduceScanOpType(Context* context) {
                            SubstitutionsMap()).get();
 }
 
-bool BasicClassType::isSubtypeOf(const BasicClassType* parentType,
+bool BasicClassType::isSubtypeOf(Context* context,
+                                 const BasicClassType* parentType,
                                  bool& converts,
                                  bool& instantiates) const {
 
@@ -92,7 +93,7 @@ bool BasicClassType::isSubtypeOf(const BasicClassType* parentType,
     }
 
     // check also if t is an instantiation of parentType
-    if (t->instantiatedFrom() == parentType) {
+    if (t->isInstantiationOf(context, parentType)) {
       if (t != this) converts = true;
       instantiates = true;
       return true;

--- a/frontend/test/resolution/testCanPass.cpp
+++ b/frontend/test/resolution/testCanPass.cpp
@@ -615,6 +615,28 @@ static void test9() {
   r = canPass(context, vars.at("b"), formal); assert(passesAsIs(r));
 }
 
+static void test10() {
+  printf("test9\n");
+  Context ctx;
+  Context* context = &ctx;
+
+  auto vars = resolveTypesOfVariables(context,
+      R"""(
+      class C {
+        type A, B;
+      }
+
+      type a = Bar(int);
+      type b = Bar(int, int);
+      )""", {"a", "b"});
+
+
+  // test that partial instantiation passing works with classes
+  CanPassResult r;
+  r = canPass(context, vars.at("b"), vars.at("a"));
+  assert(passesInstantiates(r));
+}
+
 int main() {
   test1();
   test2();
@@ -625,6 +647,7 @@ int main() {
   test7();
   test8();
   test9();
+  test10();
 
   return 0;
 }

--- a/frontend/test/resolution/testTypeQueries.cpp
+++ b/frontend/test/resolution/testTypeQueries.cpp
@@ -589,6 +589,48 @@ static void test19() {
   assert(!guard.realizeErrors());
 }
 
+static void test20() {
+  printf("%s\n", __FUNCTION__);
+  auto context = buildStdContext();
+  ErrorGuard guard(context);
+
+  auto varTypes = resolveTypesOfVariables(context,
+                R""""(
+                class C {
+                  type elementType;
+                  type indexType;
+                  type containerType;
+                }
+                class Container {
+                  type containedType;
+                }
+                proc f(c: C(real,?t,?u)) type {
+                  return t;
+                }
+                proc g(c: C(?t,?u,Container(?))) type {
+                  return t;
+                }
+                proc h(c: C(?t,?u,Container(?v)), x: t, y: u, z: v) {
+                  return z;
+                }
+                var cc = new Container(int);
+                var c = new C(real, int, cc.type);
+                type r1 = f(c);
+                type r2 = g(c);
+                var r3 = h(c, 1.0, 2, 3);
+                var r4 = h(c, 1.0, 1.0, 3);
+                var r5 = h(c, 1.0, 1, 3.0);
+                )"""", {"r1", "r2", "r3", "r4", "r5"});
+
+  assert(!varTypes.at("r1").isUnknownOrErroneous() && varTypes.at("r1").type()->isIntType());
+  assert(!varTypes.at("r2").isUnknownOrErroneous() && varTypes.at("r2").type()->isRealType());
+  assert(!varTypes.at("r3").isUnknownOrErroneous() && varTypes.at("r3").type()->isIntType());
+  assert(varTypes.at("r4").isErroneousType());
+  assert(varTypes.at("r5").isErroneousType());
+
+  assert(guard.realizeErrors() == 2);
+}
+
 int main() {
   test1();
   test2();
@@ -611,6 +653,7 @@ int main() {
   test17();
   test18();
   test19();
+  test20();
 
   return 0;
 }


### PR DESCRIPTION
Closes https://github.com/Cray/chapel-private/issues/6474.

This seemed to be a problem to do with partial instantiations of types. We only handled passing (partially) instantiated class types to fully generic formals. This PR changes this by sharing the instantiation logic between record types and class types, and fixing a minor issue about (incompatible) param instantiations.

Reviewed by @benharsh -- thanks!

## Testing

- [x] dyno tests
- [x] paratest