### PR TITLE
Change mpicc to use system installed MPI framework

### DIFF
--- a/util/cron/common-mpicc.bash
+++ b/util/cron/common-mpicc.bash
@@ -9,5 +9,5 @@ source $UTIL_CRON_DIR/common.bash
 export CHPL_TASKS=fifo
 export CHPL_TARGET_COMPILER=mpi-gnu
 
-# setup mpich 3.3.1
-source /hpcdc/project/chapel/setup_mpich331.bash
+# setup mpich 
+source /hpcdc/project/chapel/setup_mpi.bash


### PR DESCRIPTION
This is a trivial change to use a version of MPI installed on the chapcs and chapvm systems.  The shared mpich 3.3.1 is not being properly detected by the systems and this change is need.   