### PR TITLE
Clarify build requirements for chapel-py

### DIFF
--- a/doc/rst/tools/chapel-py/chapel-py.rst
+++ b/doc/rst/tools/chapel-py/chapel-py.rst
@@ -69,12 +69,19 @@ Make sure that you have a from-source build of Chapel available in your
 in your path. The build script also requires that the development package of
 Python be installed (for many package managers this is called
 ``python3-devel``). With those constraints met, you can just run ``make
-chapel-py-venv``:
-
-This will allow you to use the Python bindings from a Python script run with
+chapel-py-venv``. This will allow you to use the Python bindings from a
+Python script run with
 ``$CHPL_HOME/util/config/run-in-venv-with-python-bindings.bash python3``,
-instead of just ``python3``. If you wish to install the Python bindings in your
-system Python, run ``python3 -m pip install $CHPL_HOME/tools/chapel-py``.
+instead of just ``python3``.
+
+If you wish to install the Python bindings in your system python, you must manually build the dependencies first and then install the Chapel Python bindings.
+
+.. code-block:: bash
+
+   cd $CHPL_HOME
+   make frontend-shared
+   python3 -m pip install $CHPL_HOME/tools/chapel-py
+
 
 Usage
 -----


### PR DESCRIPTION
Clarifies some of the build requirements for chapel-py.

A user recently had an issue building chapel-py manually (i.e. through pip directly, not make). While we had this process documented, we failed to clarify the dependencies. This PR rectifies that.


[Reviewed by @DanilaFe]