### PR TITLE
Fix `mason test` not working when `make install` is used

### DIFF
--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -20,7 +20,6 @@
 
 
 use ArgumentParser;
-use ChplConfig;
 use FileSystem;
 use List;
 use Map;
@@ -422,14 +421,16 @@ proc getTestPath(fullPath: string, testPath = "") : string {
 proc getRuntimeComm() throws {
   var line: string;
   var python: string;
-  var findPython = spawn([CHPL_HOME:string+"/util/config/find-python.sh"],
-                         stdout = pipeStyle.pipe);
+  var findPython = spawn(
+    [MasonUtils.CHPL_HOME:string+"/util/config/find-python.sh"],
+    stdout = pipeStyle.pipe);
   while findPython.stdout.readLine(line) {
     python = line.strip();
   }
 
-  var checkComm = spawn([python, CHPL_HOME:string+"/util/chplenv/chpl_comm.py"],
-                        stdout = pipeStyle.pipe);
+  var checkComm = spawn(
+    [python, MasonUtils.CHPL_HOME:string+"/util/chplenv/chpl_comm.py"],
+    stdout = pipeStyle.pipe);
   while checkComm.stdout.readLine(line) {
     comm = line.strip();
   }

--- a/util/packaging/apt/test/Dockerfile.template
+++ b/util/packaging/apt/test/Dockerfile.template
@@ -22,4 +22,5 @@ WORKDIR /home/user/MyPackage
 RUN chplcheck src/*.chpl
 RUN mason build
 RUN mason run -- -nl 1
+RUN mkdir test && touch test/test.chpl mason test
 WORKDIR /home/user

--- a/util/packaging/rpm/test/Dockerfile.template
+++ b/util/packaging/rpm/test/Dockerfile.template
@@ -20,4 +20,5 @@ WORKDIR /home/user/MyPackage
 RUN chplcheck src/*.chpl
 RUN mason build
 RUN mason run -- -nl 1
+RUN mkdir test && touch test/test.chpl mason test
 WORKDIR /home/user


### PR DESCRIPTION
Fixes an issue where `mason` was using the wrong CHPL_HOME path.

Previously, `mason` relied on a CHPL_HOME embedded in the binary. This was used to run tests via `mason test`. However, with `make install` CHPL_HOME would be different at build time versus install time.

This PR resolves the issue by having mason use the following for `CHPL_HOME`.
1. if the env var `CHPL_HOME` is set, use that
2. if `chpl` is available in PATH, use the `CHPL_HOME` from that (as reported by `--print-chpl-home`)
3. otherwise, fallback to the previous CHPL_HOME definition (from ChplConfig).

This PR also adds a step to our packaging configs to exercise `mason test` to ensure it continues to work.

Resolves https://github.com/chapel-lang/chapel/issues/25356

[Reviewed by @benharsh]