### PR TITLE
Dyno: resolution fixes variety pack 2

### DIFF
--- a/frontend/include/chpl/parsing/parsing-queries.h
+++ b/frontend/include/chpl/parsing/parsing-queries.h
@@ -598,6 +598,7 @@ bool idIsFunctionWithWhere(Context* context, ID id);
 /**
   Given an ID for a Variable, returns the ID of the containing
   MultiDecl or TupleDecl, if any, and the ID of the variable otherwise.
+  For other IDs, returns the original ID.
  */
 ID idToContainingMultiDeclId(Context* context, ID id);
 

--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -1618,13 +1618,6 @@ idToContainingMultiDeclIdQuery(Context* context, ID id) {
   QUERY_BEGIN(idToContainingMultiDeclIdQuery, context, id);
 
   ID cur = id;
-  AstTag tagForId = idToTag(context, id);
-  // TODO: do we really need this assert? In which cases do we arrive here unexpectedly?
-  CHPL_ASSERT(isVariable(tagForId)  ||
-              isMultiDecl(tagForId) ||
-              isTupleDecl(tagForId) ||
-              isForwardingDecl(tagForId));
-
   while (true) {
     ID parent = idToParentId(context, cur);
     AstTag parentTag = idToTag(context, parent);

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -654,7 +654,8 @@ isOuterVariable(Resolver& rv, const Identifier* ident, const ID& target) {
       }
     */
     // Return 'false' if the module is not the most immediate parent AST.
-    auto targetParentAstId = parsing::idToParentId(context, target);
+    auto enclosingMutliDecl = parsing::idToContainingMultiDeclId(context, target);
+    auto targetParentAstId = parsing::idToParentId(context, enclosingMutliDecl);
     return targetParentSymbolId != targetParentAstId;
   }
 

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2792,6 +2792,7 @@ shouldSkipCallResolution(Resolver* rv, const uast::AstNode* callLike,
       // always skip if there is an ErroneousType
       skip = ERRONEOUS_ACT;
     } else if (!toId.isEmpty() && !isNonOutFormal &&
+               qt.isUnknown() &&
                qt.kind() != QualifiedType::PARAM &&
                qt.kind() != QualifiedType::TYPE &&
                qt.isRef() == false) {

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2854,6 +2854,15 @@ helpResolveFunction(ResolutionContext* rc, const TypedFnSignature* sig,
     if (CHPL_RESOLUTION_IS_GLOBAL_QUERY_RUNNING(f, rc, sig, poiInfo)) {
       return nullptr;
     }
+
+    // unstable resolver frames mean no query is running, but we could
+    // still be recursively processing the function. This is still
+    // considered "running".
+    for (auto& frame : rc->frames()) {
+      if (frame.signature() == sig) {
+        return nullptr;
+      }
+    }
   }
 
   // lookup in the map using this PoiInfo

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -1707,7 +1707,8 @@ QualifiedType getInstantiationType(Context* context,
 
   // this function should only be called when instantiation is required
   CHPL_ASSERT(canPass(context, actualType, formalType).passes());
-  CHPL_ASSERT(canPass(context, actualType, formalType).instantiates());
+  CHPL_ASSERT(canPass(context, actualType, formalType).instantiates() ||
+              formalType.isType());
 
   if (auto actualCt = actualT->toClassType()) {
     // handle decorated class passed to decorated class
@@ -2249,7 +2250,7 @@ ApplicabilityResult instantiateSignature(ResolutionContext* rc,
         scalarType = getPromotionType(context, actualType);
       }
 
-      if (got.instantiates()) {
+      if (got.instantiates() || formalType.isType()) {
         // add a substitution for a valid value
         if (!got.converts()) {
           // use the actual type since no conversion/promotion was needed

--- a/frontend/test/resolution/testClasses.cpp
+++ b/frontend/test/resolution/testClasses.cpp
@@ -359,7 +359,7 @@ static void test7() {
 }
 
 static void test8() {
-  printf("test7\n");
+  printf("test8\n");
 
   std::string program = R"""(
     class Parent {

--- a/frontend/test/resolution/testClasses.cpp
+++ b/frontend/test/resolution/testClasses.cpp
@@ -358,7 +358,37 @@ static void test7() {
   assert(t->basicClassType()->name() == "Parent");
 }
 
+static void test8() {
+  printf("test7\n");
 
+  std::string program = R"""(
+    class Parent {
+    }
+
+    class Child : Parent {
+    }
+
+    proc test(type T: Parent?) {
+      var ret = new unmanaged T();
+      return ret;
+    }
+
+    var x = test(Child);
+  )""";
+  auto context = buildStdContext();
+  ErrorGuard guard(context);
+
+  auto filename = UniqueString::get(context, "test8.chpl");
+  setFileText(context, filename, program);
+  auto m = parse(context, filename, UniqueString())[0];
+  auto r = resolveModule(context, m->id());
+
+  auto x = findVariable(m, "x");
+  auto& xres = r.byAst(x->initExpression());
+
+  assert(xres.mostSpecific().only());
+  assert(!xres.mostSpecific().only().fn()->needsInstantiation());
+}
 
 int main() {
   test1();
@@ -368,6 +398,7 @@ int main() {
   test5();
   test6();
   test7();
+  test8();
 
   return 0;
 }

--- a/frontend/test/resolution/testResolve.cpp
+++ b/frontend/test/resolution/testResolve.cpp
@@ -1899,6 +1899,21 @@ static void testExplicitlyGenericFormal() {
   }
 }
 
+static void testGlobalMultiDecl() {
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  auto xQt = resolveTypeOfXInit(context,
+    R"""(
+      var a, b: int;
+      proc foo() do return a;
+      var x = foo();
+    )""");
+
+  assert(xQt.type()->isIntType());
+}
+
 int main() {
   test1();
   test2();
@@ -1938,6 +1953,8 @@ int main() {
   testGetLocalePrim();
 
   testExplicitlyGenericFormal();
+
+  testGlobalMultiDecl();
 
   return 0;
 }


### PR DESCRIPTION
Closes https://github.com/Cray/chapel-private/issues/7096.
Closes https://github.com/Cray/chapel-private/issues/7031.
Closes https://github.com/Cray/chapel-private/issues/7095.

This PR makes some more fixes to dyno. Included in the medley:

1. We previously relied on `isQueryRunning` to avoid infinite recursion when gathering diagnostics. This does not work with nested functions since they don't start queries. This PR adjusts the check to also visit the resolver's frames and detect recursion that way.
2. We previously did not insert substitutions for `type` formals when they only required coercion and not instantiation. This PR fixes that by always inserting substitutions for `type` formals.
3. We detected module-level variables by checking that the declaration's parent was a module. this is not true for declarations inside of a multi-decl; so, find the parent multi-decl before moving on to see if it's at the module root.
4. We erroneously resolved function calls with generic actuals when the actuals referred to a variable. This was intended to support split-initialization. Now, only do this when the variable type is unknown (otherwise, it has already been initialized).

Reviewed by @arezaii -- thanks!

## Testing
- [x] dyno tests
- [x] paratest