### PR TITLE
Make revcomp variation yield processor when spin-waiting

### DIFF
--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc-gcc8-algs.chpl
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc-gcc8-algs.chpl
@@ -192,7 +192,8 @@ proc revcomp(ref seq, size) {
       if waitAlg == WaitFor {
         charsWritten.waitFor(myStartChar);
       } else if waitAlg == Spin {
-        while charsWritten.read() != myStartChar {}
+        while charsWritten.read() != myStartChar do
+          currentTask.yieldExecution();
       } else {
         compilerError("Unexpected wait algorithm: " + waitAlg:string);
       }


### PR DESCRIPTION
The valgrind executions of this test have been timing out with some frequency lately after some system upgrades in the spin version of the algorithm.  I think that, to be correct, the spin versions need to be yielding the processor, and that historically we've "gotten away" with not doing so without penalty or overhead.  Here, I'm updating the test to include the yield in hopes that it helps with the timeouts, and also to see what impact it has on the performance of the test.