### PR TITLE
add annotation about perf improvement on pass/return strings test

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -638,6 +638,8 @@ arguments:
     - Three way refpair (#5561)
   09/20/17:
     - Adjust string pass/return test (#7360)
+  02/04/25:
+    - Avoid passing 'size=0' to memalign (#26645)
 
 arrayInitDeinitPerf:
   02/28/23:


### PR DESCRIPTION
I've manually verified that the following PR improves the performance of the "Passing and returning strings" test on chapcs:

https://github.com/chapel-lang/chapel/pull/26645
