### PR TITLE
Add a `sep` argument to `writeln`

### DIFF
--- a/modules/standard/ChapelIO.chpl
+++ b/modules/standard/ChapelIO.chpl
@@ -780,7 +780,7 @@ module ChapelIO {
   proc write(const args ...?n, sep: string = "") {
     if chpl_warnUnstable then
       compilerWarning("specifying 'sep' is an unstable feature");
-    try! stdout.writeHelper(args, none, sep);
+    try! stdout.writeHelper(none, sep, (...args));
   }
   @chpldoc.nodoc
   proc write(const args ...?n) {
@@ -791,11 +791,11 @@ module ChapelIO {
   proc writeln(const args ...?n, sep: string = "") {
     if chpl_warnUnstable then
       compilerWarning("specifying 'sep' is an unstable feature");
-    try! stdout.writeHelper(args, new chpl_ioNewline(), sep);
+    try! stdout.writeHelper(new chpl_ioNewline(), sep, (...args));
   }
   @chpldoc.nodoc
   proc writeln(const args ...?n) {
-    try! stdout.writeln((...args));
+    try! stdout.writeHelper(new chpl_ioNewline(), none, (...args));
   }
   // documented in the arguments version.
   @chpldoc.nodoc

--- a/modules/standard/ChapelIO.chpl
+++ b/modules/standard/ChapelIO.chpl
@@ -776,14 +776,27 @@ module ChapelIO {
   Error implements writeSerializable;
 
   /* Equivalent to ``try! stdout.write``. See :proc:`IO.fileWriter.write` */
+  pragma "last resort"
+  proc write(const args ...?n, sep: string = "") {
+    if chpl_warnUnstable then
+      compilerWarning("specifying 'sep' is an unstable feature");
+    try! stdout.writeHelper(args, none, sep);
+  }
+  @chpldoc.nodoc
   proc write(const args ...?n) {
     try! stdout.write((...args));
   }
   /* Equivalent to ``try! stdout.writeln``. See :proc:`IO.fileWriter.writeln` */
+  pragma "last resort"
+  proc writeln(const args ...?n, sep: string = "") {
+    if chpl_warnUnstable then
+      compilerWarning("specifying 'sep' is an unstable feature");
+    try! stdout.writeHelper(args, new chpl_ioNewline(), sep);
+  }
+  @chpldoc.nodoc
   proc writeln(const args ...?n) {
     try! stdout.writeln((...args));
   }
-
   // documented in the arguments version.
   @chpldoc.nodoc
   proc writeln() {

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -9721,13 +9721,13 @@ pragma "fn exempt instantiation limit"
 inline proc fileWriter.write(const args ...?k, sep: string = "") throws {
   if chpl_warnUnstable then
     compilerWarning("specifying 'sep' is an unstable feature");
-  this.writeHelper(args, none, sep);
+  this.writeHelper(none, sep, (...args));
 }
 
 pragma "fn exempt instantiation limit"
 @chpldoc.nodoc
 inline proc fileWriter.write(const args ...?k) throws {
-  this.writeHelper(args, none, none);
+  this.writeHelper(none, none, (...args));
 }
 
 
@@ -9762,16 +9762,16 @@ pragma "last resort"
 proc fileWriter.writeln(const args ...?k, sep:string="") throws {
   if chpl_warnUnstable then
     compilerWarning("specifying 'sep' is an unstable feature");
-  this.writeHelper(args, new chpl_ioNewline(), sep);
+  this.writeHelper(new chpl_ioNewline(), sep, (...args));
 }
 
 @chpldoc.nodoc
 proc fileWriter.writeln(const args ...?k) throws {
-  this.writeHelper(args, new chpl_ioNewline(), none);
+  this.writeHelper(new chpl_ioNewline(), none, (...args));
 }
 
 @chpldoc.nodoc
-proc fileWriter.writeHelper(const args, endl: ?endlType, sep: ?sepType) throws {
+inline proc fileWriter.writeHelper(endl: ?endlType, sep: ?sepType, const args...) throws {
   const origLocale = this.getLocaleOfIoRequest();
   on this._home {
     try this.lock(); defer { this.unlock(); }

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -9705,6 +9705,9 @@ proc fileReader.read(type t ...?numTypes) throws where numTypes > 1 {
    :arg args: a list of arguments to write. Basic types are handled
               internally, but for other types this function will call
               value.serialize() with the ``fileWriter`` as an argument.
+   :arg sep: a string separator that is printed in between each argument.
+             Defaults to the empty string. Note that specifying ``sep`` is
+             currently an unstable feature pending further design.
 
    :throws EofError: If EOF is reached before all the arguments could be
                      written.
@@ -9713,23 +9716,20 @@ proc fileReader.read(type t ...?numTypes) throws where numTypes > 1 {
    :throws SystemError: If data could not be written to the ``fileWriter``
                         due to a :ref:`system error<io-general-sys-error>`.
  */
+pragma "last resort"
 pragma "fn exempt instantiation limit"
-inline proc fileWriter.write(const args ...?k) throws {
-  const origLocale = this.getLocaleOfIoRequest();
-  on this._home {
-    try this.lock(); defer { this.unlock(); }
-    for param i in 0..k-1 {
-      if serializerType != nothing {
-        if serializerType == binarySerializer {
-          warnBinary(args(i).type, 2);
-        }
-        this._serializeOne(args(i), origLocale);
-      } else {
-        try _writeOne(_iokind.dynamic, args(i), origLocale);
-      }
-    }
-  }
+inline proc fileWriter.write(const args ...?k, sep: string = "") throws {
+  if chpl_warnUnstable then
+    compilerWarning("specifying 'sep' is an unstable feature");
+  this.writeHelper(args, none, sep);
 }
+
+pragma "fn exempt instantiation limit"
+@chpldoc.nodoc
+inline proc fileWriter.write(const args ...?k) throws {
+  this.writeHelper(args, none, none);
+}
+
 
 // documented in varargs version
 @chpldoc.nodoc
@@ -9747,6 +9747,9 @@ proc fileWriter.writeln() throws {
               called with zero or more arguments. Basic types are handled
               internally, but for other types this function will call
               value.serialize() with the fileWriter as an argument.
+   :arg sep: a string separator that is printed in between each argument.
+             Defaults to the empty string. Note that specifying ``sep`` is
+             currently an unstable feature pending further design.
 
    :throws EofError: If EOF is reached before all the arguments
                      could be written.
@@ -9755,8 +9758,40 @@ proc fileWriter.writeln() throws {
    :throws SystemError: If data could not be written to the ``fileWriter``
                         due to a :ref:`system error<io-general-sys-error>`.
  */
+pragma "last resort"
+proc fileWriter.writeln(const args ...?k, sep:string="") throws {
+  if chpl_warnUnstable then
+    compilerWarning("specifying 'sep' is an unstable feature");
+  this.writeHelper(args, new chpl_ioNewline(), sep);
+}
+
+@chpldoc.nodoc
 proc fileWriter.writeln(const args ...?k) throws {
-  try this.write((...args), new chpl_ioNewline());
+  this.writeHelper(args, new chpl_ioNewline(), none);
+}
+
+@chpldoc.nodoc
+proc fileWriter.writeHelper(const args, endl: ?endlType, sep: ?sepType) throws {
+  const origLocale = this.getLocaleOfIoRequest();
+  on this._home {
+    try this.lock(); defer { this.unlock(); }
+
+    for param i in 0..<args.size {
+      if i != 0 && sepType != nothing then
+        try _writeOne(_iokind.dynamic, sep, origLocale);
+
+      if serializerType != nothing {
+        if serializerType == binarySerializer {
+          warnBinary(args(i).type, 2);
+        }
+        this._serializeOne(args(i), origLocale);
+      } else {
+        try _writeOne(_iokind.dynamic, args(i), origLocale);
+      }
+    }
+    if endlType != nothing then
+      try _writeOne(_iokind.dynamic, endl, origLocale);
+  }
 }
 
 /*

--- a/test/functions/deitz/test_write_type_error.good
+++ b/test/functions/deitz/test_write_type_error.good
@@ -4,3 +4,4 @@ test_write_type_error.chpl:: note: because actual argument #1 is a type
 $CHPL_HOME/modules/standard/ChapelIO.chpl:: note: but is passed to non-type varargs formal 'args'
 test_write_type_error.chpl:: note: other candidates are:
 $CHPL_HOME/modules/standard/ChapelIO.chpl:: note:   writeln()
+$CHPL_HOME/modules/standard/ChapelIO.chpl:: note:   writeln(const args ...?n, sep: string = "")

--- a/test/functions/resolution/errors/badWrite.good
+++ b/test/functions/resolution/errors/badWrite.good
@@ -1,7 +1,8 @@
 badWrite.chpl:1: error: unresolved call 'write("hi", type int(64))'
-$CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn: note: this candidate did not match: write(const args ...?n)
+$CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn: note: this candidate did not match: write(const args ...?n, sep: string = "")
 badWrite.chpl:1: note: because actual argument #2 is a type
-$CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn: note: but is passed to non-type varargs formal 'args'
+$CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn: note: but is passed to non-type formal 'sep: string'
 badWrite.chpl:1: note: other candidates are:
+$CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn: note:   write(const args ...?n)
 $CHPL_HOME/modules/internal/Atomics.chpl:nnnn: note:   ref AtomicBool.write(val: bool, param order: memoryOrder = memoryOrder.seqCst)
 $CHPL_HOME/modules/internal/Atomics.chpl:nnnn: note:   ref AtomicT.write(val: valType, param order: memoryOrder = memoryOrder.seqCst)

--- a/test/functions/varargs/typeToVarArgs.good
+++ b/test/functions/varargs/typeToVarArgs.good
@@ -1,6 +1,7 @@
 typeToVarArgs.chpl:3: error: unresolved call 'writeln("x's type is: ", type int(64))'
-$CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn: note: this candidate did not match: writeln(const args ...?n)
+$CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn: note: this candidate did not match: writeln(const args ...?n, sep: string = "")
 typeToVarArgs.chpl:3: note: because actual argument #2 is a type
-$CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn: note: but is passed to non-type varargs formal 'args'
+$CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn: note: but is passed to non-type formal 'sep: string'
 typeToVarArgs.chpl:3: note: other candidates are:
+$CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn: note:   writeln(const args ...?n)
 $CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn: note:   writeln()

--- a/test/io/serializers/optionalArg.bad
+++ b/test/io/serializers/optionalArg.bad
@@ -1,9 +1,9 @@
 optionalArg.chpl:10: In function 'main':
 optionalArg.chpl:15: error: unresolved call 'writeln(R, serializer=jsonSerializer)'
-$CHPL_HOME/modules/standard/ChapelIO.chpl:1138: note: this candidate did not match: writeln(const args ...?n)
+$CHPL_HOME/modules/standard/ChapelIO.chpl:791: note: this candidate did not match: writeln(const args ...?n, sep: string = "")
 optionalArg.chpl:15: note: because call uses named argument serializer
-$CHPL_HOME/modules/standard/ChapelIO.chpl:1138: note: but function contains no formal named serializer
+$CHPL_HOME/modules/standard/ChapelIO.chpl:791: note: but function contains no formal named serializer
 optionalArg.chpl:15: note: other candidates are:
-$CHPL_HOME/modules/standard/ChapelIO.chpl:1144: note:   writeln()
-$CHPL_HOME/modules/standard/IO.chpl:9202: note:   fileWriter.writeln()
-$CHPL_HOME/modules/standard/IO.chpl:9224: note:   fileWriter.writeln(const args ...?k)
+$CHPL_HOME/modules/standard/ChapelIO.chpl:797: note:   writeln(const args ...?n)
+$CHPL_HOME/modules/standard/ChapelIO.chpl:802: note:   writeln()
+note: and 3 other candidates, use --print-all-candidates to see them

--- a/test/io/serializers/unstableWriting.good
+++ b/test/io/serializers/unstableWriting.good
@@ -1,22 +1,22 @@
 $CHPL_HOME/modules/standard/JSON.chpl:nnnn: In method 'serializeValue':
 $CHPL_HOME/modules/standard/JSON.chpl:nnnn: warning: Serialization of ranges with non-default Serializer is unstable, and may change in the future
   $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as jsonSerializer.serializeValue(writer: fileWriter(false,jsonSerializer), val: range(int(64),both,one)) from method '_serializeOne'
-  $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileWriter(true,jsonSerializer))._serializeOne(x: range(int(64),both,one), loc: locale) from method 'write'
-  $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileWriter(true,jsonSerializer)).write(args(0): range(int(64),both,one), args(1): chpl_ioNewline) from method 'writeln'
+  $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileWriter(true,jsonSerializer))._serializeOne(x: range(int(64),both,one), loc: locale) from method 'writeHelper'
+  $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileWriter(true,jsonSerializer)).writeHelper(args: 1*range(int(64),both,one), endl: chpl_ioNewline, sep: nothing) from method 'writeln'
   unstableWriting.chpl:7: called as (fileWriter(true,jsonSerializer)).writeln(args(0): range(int(64),both,one)) from function 'helper'
   unstableWriting.chpl:11: called as helper(thing: range(int(64),both,one))
 $CHPL_HOME/modules/standard/JSON.chpl:nnnn: In method 'serializeValue':
 $CHPL_HOME/modules/standard/JSON.chpl:nnnn: warning: Serialization of rectangular domains with non-default Serializer is unstable, and may change in the future
   $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as jsonSerializer.serializeValue(writer: fileWriter(false,jsonSerializer), val: domain(1,int(64),one)) from method '_serializeOne'
-  $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileWriter(true,jsonSerializer))._serializeOne(x: domain(1,int(64),one), loc: locale) from method 'write'
-  $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileWriter(true,jsonSerializer)).write(args(0): domain(1,int(64),one), args(1): chpl_ioNewline) from method 'writeln'
+  $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileWriter(true,jsonSerializer))._serializeOne(x: domain(1,int(64),one), loc: locale) from method 'writeHelper'
+  $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileWriter(true,jsonSerializer)).writeHelper(args: 1*domain(1,int(64),one), endl: chpl_ioNewline, sep: nothing) from method 'writeln'
   unstableWriting.chpl:7: called as (fileWriter(true,jsonSerializer)).writeln(args(0): domain(1,int(64),one)) from function 'helper'
   unstableWriting.chpl:12: called as helper(thing: domain(1,int(64),one))
 $CHPL_HOME/modules/standard/JSON.chpl:nnnn: In method 'serializeValue':
 $CHPL_HOME/modules/standard/JSON.chpl:nnnn: warning: Serialization of iterators with non-default Serializer is unstable, and may change in the future
   $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as jsonSerializer.serializeValue(writer: fileWriter(false,jsonSerializer), val: iterator) from method '_serializeOne'
-  $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileWriter(true,jsonSerializer))._serializeOne(x: iterator, loc: locale) from method 'write'
-  $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileWriter(true,jsonSerializer)).write(args(0): iterator, args(1): chpl_ioNewline) from method 'writeln'
+  $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileWriter(true,jsonSerializer))._serializeOne(x: iterator, loc: locale) from method 'writeHelper'
+  $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileWriter(true,jsonSerializer)).writeHelper(args: 1*iterator, endl: chpl_ioNewline, sep: nothing) from method 'writeln'
   unstableWriting.chpl:7: called as (fileWriter(true,jsonSerializer)).writeln(args(0): iterator) from function 'helper'
   unstableWriting.chpl:13: called as helper(thing: iterator)
 "1..10"

--- a/test/io/serializers/unstableWriting.good
+++ b/test/io/serializers/unstableWriting.good
@@ -2,21 +2,21 @@ $CHPL_HOME/modules/standard/JSON.chpl:nnnn: In method 'serializeValue':
 $CHPL_HOME/modules/standard/JSON.chpl:nnnn: warning: Serialization of ranges with non-default Serializer is unstable, and may change in the future
   $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as jsonSerializer.serializeValue(writer: fileWriter(false,jsonSerializer), val: range(int(64),both,one)) from method '_serializeOne'
   $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileWriter(true,jsonSerializer))._serializeOne(x: range(int(64),both,one), loc: locale) from method 'writeHelper'
-  $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileWriter(true,jsonSerializer)).writeHelper(args: 1*range(int(64),both,one), endl: chpl_ioNewline, sep: nothing) from method 'writeln'
+  $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileWriter(true,jsonSerializer)).writeHelper(endl: chpl_ioNewline, sep: nothing, args(0): range(int(64),both,one)) from method 'writeln'
   unstableWriting.chpl:7: called as (fileWriter(true,jsonSerializer)).writeln(args(0): range(int(64),both,one)) from function 'helper'
   unstableWriting.chpl:11: called as helper(thing: range(int(64),both,one))
 $CHPL_HOME/modules/standard/JSON.chpl:nnnn: In method 'serializeValue':
 $CHPL_HOME/modules/standard/JSON.chpl:nnnn: warning: Serialization of rectangular domains with non-default Serializer is unstable, and may change in the future
   $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as jsonSerializer.serializeValue(writer: fileWriter(false,jsonSerializer), val: domain(1,int(64),one)) from method '_serializeOne'
   $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileWriter(true,jsonSerializer))._serializeOne(x: domain(1,int(64),one), loc: locale) from method 'writeHelper'
-  $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileWriter(true,jsonSerializer)).writeHelper(args: 1*domain(1,int(64),one), endl: chpl_ioNewline, sep: nothing) from method 'writeln'
+  $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileWriter(true,jsonSerializer)).writeHelper(endl: chpl_ioNewline, sep: nothing, args(0): domain(1,int(64),one)) from method 'writeln'
   unstableWriting.chpl:7: called as (fileWriter(true,jsonSerializer)).writeln(args(0): domain(1,int(64),one)) from function 'helper'
   unstableWriting.chpl:12: called as helper(thing: domain(1,int(64),one))
 $CHPL_HOME/modules/standard/JSON.chpl:nnnn: In method 'serializeValue':
 $CHPL_HOME/modules/standard/JSON.chpl:nnnn: warning: Serialization of iterators with non-default Serializer is unstable, and may change in the future
   $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as jsonSerializer.serializeValue(writer: fileWriter(false,jsonSerializer), val: iterator) from method '_serializeOne'
   $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileWriter(true,jsonSerializer))._serializeOne(x: iterator, loc: locale) from method 'writeHelper'
-  $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileWriter(true,jsonSerializer)).writeHelper(args: 1*iterator, endl: chpl_ioNewline, sep: nothing) from method 'writeln'
+  $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileWriter(true,jsonSerializer)).writeHelper(endl: chpl_ioNewline, sep: nothing, args(0): iterator) from method 'writeln'
   unstableWriting.chpl:7: called as (fileWriter(true,jsonSerializer)).writeln(args(0): iterator) from function 'helper'
   unstableWriting.chpl:13: called as helper(thing: iterator)
 "1..10"

--- a/test/io/sungeun/funcPtr3.good
+++ b/test/io/sungeun/funcPtr3.good
@@ -1,3 +1,4 @@
 funcPtr3.chpl:1: error: cannot capture routine with name 'writeln' because it is overloaded
 $CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn: note: declared here
 $CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn: note: declared here
+$CHPL_HOME/modules/standard/ChapelIO.chpl:nnnn: note: declared here

--- a/test/library/standard/IO/writelnWithSep.chpl
+++ b/test/library/standard/IO/writelnWithSep.chpl
@@ -1,0 +1,47 @@
+use IO;
+
+proc test(writer, args) {
+  writer.write((...args));
+  writer.writeln();
+}
+proc testln(writer, args) {
+  writer.writeln((...args));
+}
+proc test(writer, args, sep) {
+  writer.write((...args), sep=sep);
+  writer.writeln();
+}
+proc testln(writer, args, sep) {
+  writer.writeln((...args), sep=sep);
+}
+
+writeln("test with no sep");
+test(stdout, (1, 2, 3));
+writeln("testln with no sep");
+testln(stdout, (4, 5, 6));
+writeln("test with sep");
+test(stdout, (1.0, "2", true), sep=", ");
+writeln("testln with sep");
+testln(stdout, (4.0, "5", false), sep=", ");
+
+
+record R {
+  var x: int;
+  var y: int;
+}
+class C {
+  var a: real;
+  var b: real;
+  var c: R;
+}
+
+
+writeln("testln with record with no sep");
+testln(stdout, (new R(1, 2), new R(3, 4)));
+writeln("testln with record with sep");
+testln(stdout, (new R(1, 2), new R(3, 4)), sep=";");
+
+writeln("testln with class with no sep");
+testln(stdout, (new C(a=1.0, b=2.0, c=new R(3, 4)), new C(a=5.0, b=6.0, c=new R(7, 8))));
+writeln("testln with class with sep");
+testln(stdout, (new C(a=1.0, b=2.0, c=new R(3, 4)), new C(a=5.0, b=6.0, c=new R(7, 8))), sep="\n");

--- a/test/library/standard/IO/writelnWithSep.good
+++ b/test/library/standard/IO/writelnWithSep.good
@@ -1,0 +1,17 @@
+test with no sep
+123
+testln with no sep
+456
+test with sep
+1.0, 2, true
+testln with sep
+4.0, 5, false
+testln with record with no sep
+(x = 1, y = 2)(x = 3, y = 4)
+testln with record with sep
+(x = 1, y = 2);(x = 3, y = 4)
+testln with class with no sep
+{a = 1.0, b = 2.0, c = (x = 3, y = 4)}{a = 5.0, b = 6.0, c = (x = 7, y = 8)}
+testln with class with sep
+{a = 1.0, b = 2.0, c = (x = 3, y = 4)}
+{a = 5.0, b = 6.0, c = (x = 7, y = 8)}

--- a/test/unstable/binaryFormat.good
+++ b/test/unstable/binaryFormat.good
@@ -1,11 +1,11 @@
 binaryFormat.chpl:4: warning: The ObjectSerialization module is unstable. The module's name, its types, and serialization format are subject to change.
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: In method 'writeHelper':
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: binary(De)Serializer's format for strings, bytes, and classes no longer includes length-bytes or nilability-bytes. Recompile with ``-swarnBinaryStructured=false`` to disable this warning. To utilize the old format, please use the unstable 'ObjectSerialization' package module.
-  $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileWriter(false,binarySerializer)).writeHelper(args: 1*owned C, endl: nothing, sep: nothing) from method 'write'
+  $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileWriter(false,binarySerializer)).writeHelper(endl: nothing, sep: nothing, args(0): owned C) from method 'write'
   binaryFormat.chpl:16: called as (fileWriter(false,binarySerializer)).write(args(0): owned C)
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: In method 'writeHelper':
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: binary(De)Serializer's format for strings, bytes, and classes no longer includes length-bytes or nilability-bytes. Recompile with ``-swarnBinaryStructured=false`` to disable this warning. To utilize the old format, please use the unstable 'ObjectSerialization' package module.
-  $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileWriter(false,binarySerializer)).writeHelper(args: 1*string, endl: nothing, sep: nothing) from method 'write'
+  $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileWriter(false,binarySerializer)).writeHelper(endl: nothing, sep: nothing, args(0): string) from method 'write'
   binaryFormat.chpl:17: called as (fileWriter(false,binarySerializer)).write(args(0): string)
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: In method 'read':
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: binary(De)Serializer's format for classes no longer includes nilability-bytes. Recompile with ``-swarnBinaryStructured=false`` to disable this warning. To utilize the old format, please use the unstable 'ObjectSerialization' package module.

--- a/test/unstable/binaryFormat.good
+++ b/test/unstable/binaryFormat.good
@@ -1,8 +1,10 @@
 binaryFormat.chpl:4: warning: The ObjectSerialization module is unstable. The module's name, its types, and serialization format are subject to change.
-binaryFormat.chpl:10: In function 'main':
-binaryFormat.chpl:16: warning: binary(De)Serializer's format for strings, bytes, and classes no longer includes length-bytes or nilability-bytes. Recompile with ``-swarnBinaryStructured=false`` to disable this warning. To utilize the old format, please use the unstable 'ObjectSerialization' package module.
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: In method 'write':
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: binary(De)Serializer's format for strings, bytes, and classes no longer includes length-bytes or nilability-bytes. Recompile with ``-swarnBinaryStructured=false`` to disable this warning. To utilize the old format, please use the unstable 'ObjectSerialization' package module.
+  binaryFormat.chpl:16: called as (fileWriter(false,binarySerializer)).write(args(0): owned C)
+$CHPL_HOME/modules/standard/IO.chpl:nnnn: In method 'writeHelper':
+$CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: binary(De)Serializer's format for strings, bytes, and classes no longer includes length-bytes or nilability-bytes. Recompile with ``-swarnBinaryStructured=false`` to disable this warning. To utilize the old format, please use the unstable 'ObjectSerialization' package module.
+  $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileWriter(false,binarySerializer)).writeHelper(args: 1*string, endl: nothing, sep: nothing) from method 'write'
   binaryFormat.chpl:17: called as (fileWriter(false,binarySerializer)).write(args(0): string)
 binaryFormat.chpl:10: In function 'main':
 binaryFormat.chpl:23: warning: binary(De)Serializer's format for classes no longer includes nilability-bytes. Recompile with ``-swarnBinaryStructured=false`` to disable this warning. To utilize the old format, please use the unstable 'ObjectSerialization' package module.

--- a/test/unstable/binaryFormat.good
+++ b/test/unstable/binaryFormat.good
@@ -1,13 +1,15 @@
 binaryFormat.chpl:4: warning: The ObjectSerialization module is unstable. The module's name, its types, and serialization format are subject to change.
-$CHPL_HOME/modules/standard/IO.chpl:nnnn: In method 'write':
+$CHPL_HOME/modules/standard/IO.chpl:nnnn: In method 'writeHelper':
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: binary(De)Serializer's format for strings, bytes, and classes no longer includes length-bytes or nilability-bytes. Recompile with ``-swarnBinaryStructured=false`` to disable this warning. To utilize the old format, please use the unstable 'ObjectSerialization' package module.
+  $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileWriter(false,binarySerializer)).writeHelper(args: 1*owned C, endl: nothing, sep: nothing) from method 'write'
   binaryFormat.chpl:16: called as (fileWriter(false,binarySerializer)).write(args(0): owned C)
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: In method 'writeHelper':
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: binary(De)Serializer's format for strings, bytes, and classes no longer includes length-bytes or nilability-bytes. Recompile with ``-swarnBinaryStructured=false`` to disable this warning. To utilize the old format, please use the unstable 'ObjectSerialization' package module.
   $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileWriter(false,binarySerializer)).writeHelper(args: 1*string, endl: nothing, sep: nothing) from method 'write'
   binaryFormat.chpl:17: called as (fileWriter(false,binarySerializer)).write(args(0): string)
-binaryFormat.chpl:10: In function 'main':
-binaryFormat.chpl:23: warning: binary(De)Serializer's format for classes no longer includes nilability-bytes. Recompile with ``-swarnBinaryStructured=false`` to disable this warning. To utilize the old format, please use the unstable 'ObjectSerialization' package module.
+$CHPL_HOME/modules/standard/IO.chpl:nnnn: In method 'read':
+$CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: binary(De)Serializer's format for classes no longer includes nilability-bytes. Recompile with ``-swarnBinaryStructured=false`` to disable this warning. To utilize the old format, please use the unstable 'ObjectSerialization' package module.
+  binaryFormat.chpl:23: called as (fileReader(false,binaryDeserializer)).read(args(0): owned C)
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: In method '_readInner':
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: binary(De)Serializer's format for classes no longer includes nilability-bytes. Recompile with ``-swarnBinaryStructured=false`` to disable this warning. To utilize the old format, please use the unstable 'ObjectSerialization' package module.
   $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileReader(false,binaryDeserializer))._readInner(args(0): borrowed C) from method 'read'
@@ -18,8 +20,9 @@ $CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: binary(De)Serializer's format
   $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileReader(false,binaryDeserializer))._deserializeOne(x: owned C, loc: locale) from method '_readInner'
   $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileReader(false,binaryDeserializer))._readInner(args(0): owned C) from method 'read'
   binaryFormat.chpl:23: called as (fileReader(false,binaryDeserializer)).read(args(0): owned C)
-binaryFormat.chpl:10: In function 'main':
-binaryFormat.chpl:38: warning: binary(De)Serializer's format for classes no longer includes nilability-bytes. Recompile with ``-swarnBinaryStructured=false`` to disable this warning. To utilize the old format, please use the unstable 'ObjectSerialization' package module.
+$CHPL_HOME/modules/standard/IO.chpl:nnnn: In method 'read':
+$CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: binary(De)Serializer's format for classes no longer includes nilability-bytes. Recompile with ``-swarnBinaryStructured=false`` to disable this warning. To utilize the old format, please use the unstable 'ObjectSerialization' package module.
+  binaryFormat.chpl:38: called as (fileReader(false,binaryDeserializer)).read(type t = owned C)
 ----- WRITING -----
 ----- READ BY VALUE -----
 string error: binaryDeserializer does not support reading 'string' or 'bytes'. Please use a method like 'fileReader.readBinary' instead.

--- a/test/unstable/binaryFormat.good
+++ b/test/unstable/binaryFormat.good
@@ -1,15 +1,13 @@
 binaryFormat.chpl:4: warning: The ObjectSerialization module is unstable. The module's name, its types, and serialization format are subject to change.
-$CHPL_HOME/modules/standard/IO.chpl:nnnn: In method 'writeHelper':
+$CHPL_HOME/modules/standard/IO.chpl:nnnn: In method 'write':
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: binary(De)Serializer's format for strings, bytes, and classes no longer includes length-bytes or nilability-bytes. Recompile with ``-swarnBinaryStructured=false`` to disable this warning. To utilize the old format, please use the unstable 'ObjectSerialization' package module.
-  $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileWriter(false,binarySerializer)).writeHelper(endl: nothing, sep: nothing, args(0): owned C) from method 'write'
   binaryFormat.chpl:16: called as (fileWriter(false,binarySerializer)).write(args(0): owned C)
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: In method 'writeHelper':
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: binary(De)Serializer's format for strings, bytes, and classes no longer includes length-bytes or nilability-bytes. Recompile with ``-swarnBinaryStructured=false`` to disable this warning. To utilize the old format, please use the unstable 'ObjectSerialization' package module.
   $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileWriter(false,binarySerializer)).writeHelper(endl: nothing, sep: nothing, args(0): string) from method 'write'
   binaryFormat.chpl:17: called as (fileWriter(false,binarySerializer)).write(args(0): string)
-$CHPL_HOME/modules/standard/IO.chpl:nnnn: In method 'read':
-$CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: binary(De)Serializer's format for classes no longer includes nilability-bytes. Recompile with ``-swarnBinaryStructured=false`` to disable this warning. To utilize the old format, please use the unstable 'ObjectSerialization' package module.
-  binaryFormat.chpl:23: called as (fileReader(false,binaryDeserializer)).read(args(0): owned C)
+binaryFormat.chpl:10: In function 'main':
+binaryFormat.chpl:23: warning: binary(De)Serializer's format for classes no longer includes nilability-bytes. Recompile with ``-swarnBinaryStructured=false`` to disable this warning. To utilize the old format, please use the unstable 'ObjectSerialization' package module.
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: In method '_readInner':
 $CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: binary(De)Serializer's format for classes no longer includes nilability-bytes. Recompile with ``-swarnBinaryStructured=false`` to disable this warning. To utilize the old format, please use the unstable 'ObjectSerialization' package module.
   $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileReader(false,binaryDeserializer))._readInner(args(0): borrowed C) from method 'read'
@@ -20,9 +18,8 @@ $CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: binary(De)Serializer's format
   $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileReader(false,binaryDeserializer))._deserializeOne(x: owned C, loc: locale) from method '_readInner'
   $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileReader(false,binaryDeserializer))._readInner(args(0): owned C) from method 'read'
   binaryFormat.chpl:23: called as (fileReader(false,binaryDeserializer)).read(args(0): owned C)
-$CHPL_HOME/modules/standard/IO.chpl:nnnn: In method 'read':
-$CHPL_HOME/modules/standard/IO.chpl:nnnn: warning: binary(De)Serializer's format for classes no longer includes nilability-bytes. Recompile with ``-swarnBinaryStructured=false`` to disable this warning. To utilize the old format, please use the unstable 'ObjectSerialization' package module.
-  binaryFormat.chpl:38: called as (fileReader(false,binaryDeserializer)).read(type t = owned C)
+binaryFormat.chpl:10: In function 'main':
+binaryFormat.chpl:38: warning: binary(De)Serializer's format for classes no longer includes nilability-bytes. Recompile with ``-swarnBinaryStructured=false`` to disable this warning. To utilize the old format, please use the unstable 'ObjectSerialization' package module.
 ----- WRITING -----
 ----- READ BY VALUE -----
 string error: binaryDeserializer does not support reading 'string' or 'bytes'. Please use a method like 'fileReader.readBinary' instead.

--- a/test/unstable/writelnSep.chpl
+++ b/test/unstable/writelnSep.chpl
@@ -1,0 +1,30 @@
+
+// specifying sep is unstable and only that
+
+{
+  write("H", "e", "l", "l", "o");
+  writeln(" ", "w", "o", "r", "l", "d");
+
+  // same behavior as above, but now its going to warn
+  write("H", "e", "l", "l", "o", sep="");
+  writeln(" ", "w", "o", "r", "l", "d", sep="");
+
+  // different behavior and it will warn
+  write("H", "e", "l", "l", "o", sep=" ");
+  writeln(" ", "w", "o", "r", "l", "d", sep=" ");
+}
+
+{
+  use IO;
+
+  stdout.write("H", "e", "l", "l", "o");
+  stdout.writeln(" ", "w", "o", "r", "l", "d");
+
+  // same behavior as above, but now its going to warn
+  stdout.write("H", "e", "l", "l", "o", sep="");
+  stdout.writeln(" ", "w", "o", "r", "l", "d", sep="");
+
+  // different behavior and it will warn
+  stdout.write("H", "e", "l", "l", "o", sep=" ");
+  stdout.writeln(" ", "w", "o", "r", "l", "d", sep=" ");
+}

--- a/test/unstable/writelnSep.good
+++ b/test/unstable/writelnSep.good
@@ -1,0 +1,14 @@
+writelnSep.chpl:9: warning: specifying 'sep' is an unstable feature
+writelnSep.chpl:10: warning: specifying 'sep' is an unstable feature
+writelnSep.chpl:13: warning: specifying 'sep' is an unstable feature
+writelnSep.chpl:14: warning: specifying 'sep' is an unstable feature
+writelnSep.chpl:24: warning: specifying 'sep' is an unstable feature
+writelnSep.chpl:25: warning: specifying 'sep' is an unstable feature
+writelnSep.chpl:28: warning: specifying 'sep' is an unstable feature
+writelnSep.chpl:29: warning: specifying 'sep' is an unstable feature
+Hello world
+Hello world
+H e l l o  w o r l d
+Hello world
+Hello world
+H e l l o  w o r l d


### PR DESCRIPTION
Adds a `sep` argument to `write` and `writeln`, which changes the separator between arguments to these functions.

By default, `write` and `writeln` will just concatenate all of the arguments passed to them with no separator. By specifying `sep`, users can now change this

```chapel
writeln(1, 2, 3); // prints as "123"
writeln(1, 2, 3, sep=", "); // prints as "1, 2, 3"
```

This is a new feature that has not undergone design review, so is being added as unstable.

Implementation note: this PR uses `last resort` to work around compiler issues with varargs and keywargs: see https://github.com/chapel-lang/chapel/issues/17188

- [x] paratest with/without gasnet


- Resolves https://github.com/chapel-lang/chapel/issues/25695
- Resolves https://github.com/chapel-lang/chapel/issues/14108

[Reviewed by @benharsh]