### PR TITLE
Dyno: solidify `init=`, partial instantiations

### DIFF
--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2490,35 +2490,6 @@ void Resolver::resolveTupleDecl(const TupleDecl* td,
   resolveTupleUnpackDecl(td, useT);
 }
 
-static void findMismatchedInstantiations(Context* context,
-                                         const CompositeType* originalCT,
-                                         const CompositeType* finalCT,
-                                         std::vector<std::tuple<ID, UniqueString, QualifiedType, QualifiedType>>& out) {
-  while (originalCT) {
-    CHPL_ASSERT(finalCT);
-    if (!originalCT->instantiatedFromCompositeType()) break;
-
-    for (auto& [id, qt] : originalCT->substitutions()) {
-      auto finalSub = finalCT->substitutions().find(id);
-      if (finalSub == finalCT->substitutions().end()) {
-        out.emplace_back(id, parsing::fieldIdToName(context, id), qt, QualifiedType());
-      } else {
-        auto& finalQt = finalSub->second;
-        if (qt != finalQt) {
-          out.emplace_back(id, parsing::fieldIdToName(context, id), qt, finalQt);
-        }
-      }
-    }
-
-    if (auto clt = originalCT->toBasicClassType()) {
-      originalCT = clt->parentClassType();
-      finalCT = finalCT->toBasicClassType()->parentClassType();
-    } else {
-      break;
-    }
-  }
-}
-
 bool Resolver::resolveSpecialNewCall(const Call* call) {
   if (!call->calledExpression() ||
       !call->calledExpression()->isNew()) {
@@ -2576,8 +2547,7 @@ bool Resolver::resolveSpecialNewCall(const Call* call) {
   // to the constructor. However, the constructor can do something entirely
   // different, and override the subs we passed in. This is an error, which
   // we should check for if we added named actuals.
-  bool validateFinalType =
-    addExistingSubstitutionsAsActuals(context, qtNewExpr.type(), actuals, actualAsts);
+  addExistingSubstitutionsAsActuals(context, qtNewExpr.type(), actuals, actualAsts);
 
   // Remaining actuals.
   prepareCallInfoActuals(call, actuals, questionArg, &actualAsts);
@@ -2622,19 +2592,6 @@ bool Resolver::resolveSpecialNewCall(const Call* call) {
 
     auto qt = QualifiedType(QualifiedType::VAR, type);
     re.setType(qt);
-
-    if (validateFinalType) {
-      auto originalCT = initReceiverType->getCompositeType();
-      auto finalCT = type->getCompositeType();
-      CHPL_ASSERT(originalCT);
-      CHPL_ASSERT(finalCT);
-
-      if (!finalCT->isInstantiationOf(context, originalCT)) {
-        std::vector<std::tuple<ID, UniqueString, QualifiedType, QualifiedType>> mismatches;
-        findMismatchedInstantiations(context, originalCT, finalCT, mismatches);
-        CHPL_REPORT(context, MismatchedInitializerResult, call, originalCT, finalCT, std::move(mismatches));
-      }
-    }
   }
 
   return true;

--- a/frontend/test/resolution/testInitSemantics.cpp
+++ b/frontend/test/resolution/testInitSemantics.cpp
@@ -1131,6 +1131,83 @@ static void testInitEqOther(void) {
   assert(ss.str() == "R(real(64))");
 }
 
+static void testInitEqOtherIncomplete(void) {
+  auto context = buildStdContext();
+  ErrorGuard guard(context);
+
+  std::string program = R"""(
+    record R {
+      type T;
+      var field : T;
+    }
+    proc R.init=(other: ?) {}
+    var x:R(int) = 4;
+  )""";
+
+  auto results = resolveTypesOfVariables(context, program, {"x"});
+  auto xt = results["x"];
+  assert(xt.type()->isRecordType());
+  std::stringstream ss;
+  xt.type()->stringify(ss, chpl::StringifyKind::CHPL_SYNTAX);
+  assert(ss.str() == "R(int(64))");
+
+  // There should be an error, since we never initialized the field T in
+  // the init= call.
+  assert(guard.realizeErrors() == 1);
+}
+
+static void testInitEqOtherChangeType(void) {
+  auto context = buildStdContext();
+  ErrorGuard guard(context);
+
+  std::string program = R"""(
+    record R {
+      type T;
+      var field : T;
+    }
+    proc R.init=(other: ?) {
+      this.T = (other.type, other.type);
+      this.field = (other, other);
+    }
+    var x:R(?) = 4;
+  )""";
+
+  auto results = resolveTypesOfVariables(context, program, {"x"});
+  auto xt = results["x"];
+  assert(xt.type()->isRecordType());
+  std::stringstream ss;
+  xt.type()->stringify(ss, chpl::StringifyKind::CHPL_SYNTAX);
+  assert(ss.str() == "R((int(64), int(64)))");
+}
+
+static void testInitEqOtherChangeTypeBad(void) {
+  auto context = buildStdContext();
+  ErrorGuard guard(context);
+
+  std::string program = R"""(
+    record R {
+      type T;
+      var field : T;
+    }
+    proc R.init=(other: ?) {
+      this.T = (other.type, other.type);
+      this.field = (other, other);
+    }
+    var x:R(int) = 4;
+  )""";
+
+  auto results = resolveTypesOfVariables(context, program, {"x"});
+  auto xt = results["x"];
+  assert(xt.type()->isRecordType());
+  std::stringstream ss;
+  xt.type()->stringify(ss, chpl::StringifyKind::CHPL_SYNTAX);
+  assert(ss.str() == "R((int(64), int(64)))");
+
+  assert(guard.numErrors() == 1);
+  assert(guard.error(0)->type() == ErrorType::MismatchedInitializerResult);
+  guard.realizeErrors();
+}
+
 static void testInheritance() {
   std::string parentChild = R"""(
     class Parent {
@@ -2205,6 +2282,9 @@ int main() {
   testUseAfterInit();
 
   testInitEqOther();
+  testInitEqOtherIncomplete();
+  testInitEqOtherChangeType();
+  testInitEqOtherChangeTypeBad();
 
   testInheritance();
 


### PR DESCRIPTION
Closes https://github.com/Cray/chapel-private/issues/6925. (wasn't broken on `main`).

As part of a discussion with Ben, we noticed that the following pattern works in Dyno but likely shouldn't:

```Chapel
record R {
  type eltType;

  proc init=(other: this.type.eltType) {

  }
}

var x: R(int) = 5;
```

In Dyno, we allowed initializers to implicitly keep the types they started with. Since the call to `init=` "began" with `R(int)`, we silently allowed `eltType` to become `int`. However, in production, we require the user to configure the fields explicitly with arguments from the `init=` call.

In fixing this, I also noted that the `init=` call, unlike the `init` call, would not catch it if I changed `eltType` to something incompatible with the original argument. This is because the check for "incompatible final instantiation" was limited to the Resolver, and not to all calls to initializers. This PR changes that by moving the instantiation validation code to `InitResolver`, and invoking it upon `finalize`.

This PR also adds regression tests for `this.type` in `init=`, ensuring https://github.com/Cray/chapel-private/issues/6925 stays closed.

Reviewed by @benharsh -- thanks!

## Testing
- [x] dyno tests
- [x] paratest