### PR TITLE
Dyno: Fix visibility distance bug by only passing in poiScope when relevant

### DIFF
--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -4974,9 +4974,21 @@ findMostSpecificAndCheck(ResolutionContext* rc,
                          const PoiScope* inPoiScope,
                          PoiInfo& poiInfo) {
 
+  // When checking visibility distance, we need to choose either the callScope
+  // or the poiScope. Currently the poiScope is favored if both are available.
+  //
+  // If the poiScope is passed, but was not used to find candidates, then
+  // visibility distance could be wrong if candidates are equally visible from
+  // the poiScope, but not equally visible from the callScope.
+  //
+  // If there were no POI candidates found, then the poiScope should not be
+  // used. See 'testDistance' in 'testDisambiguation'.
+  auto poiScopeToUse = firstPoiCandidate >= candidates.size() ? nullptr :
+                       inPoiScope;
+
   // find most specific candidates / disambiguate
   MostSpecificCandidates mostSpecific =
-      findMostSpecificCandidates(rc, candidates, ci, inScope, inPoiScope);
+      findMostSpecificCandidates(rc, candidates, ci, inScope, poiScopeToUse);
 
   // perform fn signature checking for any instantiated candidates that are used
   for (const MostSpecificCandidate& candidate : mostSpecific) {


### PR DESCRIPTION
This fix is motivated by a real-world example involving real-to-(bytes or string) casting, and the "_real_cast_helper" functions in the ``BytesCasts`` and ``StringCasts`` modules. Both modules leak this function, which eventually leaks out through ``ChapelStandard``, which both of these modules also use. This means the calls to ``_real_cast_helper`` in both modules can see both versions of the function.

Prior to this change, dyno was always using the POI scope for visibility distance calculation. The POI scope, in this case, was at the source of the call to the real-to-string cast (in the user module), where both ``_real_cast_helper`` functions were equally visible. Notably, the candidates themselves were not found using POI.

Following the lead of the production compiler, we should instead only use the poiScope if the candidates were actually found using POI information.

Testing:
- [x] test-dyno