### PR TITLE
Use binary file I/O in prediff-for-gasnet

### DIFF
--- a/util/test/prediff-for-gasnet
+++ b/util/test/prediff-for-gasnet
@@ -5,12 +5,12 @@
 import sys, re
 
 outfname = sys.argv[2]
-with open(outfname, "r") as f:
+with open(outfname, "rb") as f:
     outText = f.read()
 
-msg = r"""\*\*\* WARNING \(proc 0\): Running with multiple processes per host without shared-memory communication support \(PSHM\).  This can significantly reduce performance.  Please re-configure GASNet using `--enable-pshm` to enable fast intra-host comms.
+msg = rb"""\*\*\* WARNING \(proc 0\): Running with multiple processes per host without shared-memory communication support \(PSHM\).  This can significantly reduce performance.  Please re-configure GASNet using `--enable-pshm` to enable fast intra-host comms.
 """
 outText = re.sub(msg, "", outText, flags = re.MULTILINE)
 
-with open(outfname, "w") as f:
+with open(outfname, "wb") as f:
     f.write(outText)


### PR DESCRIPTION
This PR fixes a problem we were seeing is some nightly testing configurations where a `\r` in the output was replaced by a `\n`. It adjusts `prediff-for-gasnet` to use binary I/O to avoid any newline translation that Python's default I/O tries to do.

Follow-up to PR #26611.

Reviewed by @jhh67 - thanks!

- [x] `CHPL_SYSTEM_PREDIFF=$CHPL_HOME/util/test/prediff-for-gasnet ./util/start_test  test/types/bytes/basic.chpl` now passes
- [x] full comm=gasnet testing