### PR TITLE
Unpin Dockerfile base image and package versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,25 @@
 # Common stage: install dependencies, set up the Debian image
 # ===========================================================
 
-FROM debian:11 AS chapel-base
+FROM debian:latest AS chapel-base
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     bash \
     ca-certificates \
-    clang-11 \
+    clang \
     cmake \
     curl \
     file \
     gcc \
     git \
     g++ \
-    libclang-11-dev \
-    libclang-cpp11-dev \
+    libclang-dev \
+    libclang-cpp-dev \
     libedit-dev \
     libgmp10 \
     libgmp-dev \
-    llvm-11-dev \
-    llvm-11 \
-    llvm-11-tools \
+    llvm-dev \
+    llvm \
     locales \
     make \
     mawk \
@@ -28,7 +27,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     perl \
     pkg-config \
     protobuf-compiler \
-    python-setuptools \
+    python3-setuptools \
     python3 \
     python3-pip \
     python3-venv \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,33 +6,33 @@ FROM debian:latest AS chapel-base
 RUN apt-get update && apt-get install -y --no-install-recommends \
     bash \
     ca-certificates \
-    clang \
-    cmake \
     curl \
+    wget \
     file \
-    gcc \
-    git \
-    g++ \
-    libclang-dev \
-    libclang-cpp-dev \
-    libedit-dev \
-    libgmp10 \
-    libgmp-dev \
-    llvm-dev \
-    llvm \
     locales \
-    make \
+    libedit-dev \
+    git \
     mawk \
+    make \
+    cmake \
     m4 \
     perl \
     pkg-config \
+    gcc \
+    g++ \
+    clang \
+    libclang-dev \
+    libclang-cpp-dev \
+    llvm \
+    llvm-dev \
+    libgmp10 \
+    libgmp-dev \
     protobuf-compiler \
-    python3-setuptools \
     python3 \
+    python3-dev \
+    python3-setuptools \
     python3-pip \
     python3-venv \
-    python3-dev \
-    wget \
     && rm -rf /var/lib/apt/lists/*
 
 # configure locale

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,7 @@ RUN make cleanall
 # Hack to get access to Chapel binaries
 RUN cd $CHPL_HOME/bin && ln -s */* .
 
-# The .git folder is huge and we really don't need it.
+# Remove some unneeded files to reduce image size
 RUN rm -rf .git
 RUN for subdir in `ls test || true`; do \
       if [ "$subdir" != "release" ]; then \


### PR DESCRIPTION
Remove version specifications for the `debian` base image we use as well as package versions installed in the Docker image, so we always use a reasonable default and don't have to bump versions.

Resolves https://github.com/Cray/chapel-private/issues/6717.

[reviewer info placeholder]

Testing:
- [x] manual run of Docker test script succeeds