### PR TITLE
Change Arkouda sub_test to use a virtual environment for dependencies

### DIFF
--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -99,18 +99,20 @@ fi
 
 if [ ${CHPL_TEST_ARKOUDA_STOP_AFTER_BUILD} = "false" ]; then
 
-    # If Arkouda deps use any of our test deps, try to use the versions we want
+  # If Arkouda deps use any of our test deps, try to use the versions we want
   AK_PIP_CONTRAINTS="--constraint $CHPL_HOME/third-party/chpl-venv/test-requirements.txt"
-  log "Installing Arkouda using python3 at: $(which python3)"
   # create a virtual environment for running the tests
   # if one was already created and set in CHPL_TEST_VENV_DIR, use it
   if [ -n "$CHPL_TEST_VENV_DIR" ] && [ "$CHPL_TEST_VENV_DIR" != "none" ]; then
+    log "Using the existing virtual environment for Arkouda at '$CHPL_TEST_VENV_DIR'"
     source $CHPL_TEST_VENV_DIR/bin/activate
   else
+    log "Creating a new virtual environment for Arkouda using '$(which python3)'"
     python3 -m venv .venv
     source .venv/bin/activate
   fi
 
+  log "Installing Arkouda in the virtual environment using '$(which python3)'"
   if ! python3 -m pip install --force-reinstall --timeout 60 $AK_PIP_CONTRAINTS -e .[dev] ; then
     log_fatal_error "installing arkouda"
   fi

--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -98,12 +98,20 @@ else
 fi
 
 if [ ${CHPL_TEST_ARKOUDA_STOP_AFTER_BUILD} = "false" ]; then
-  # Install Arkouda and python dependencies to a python-deps subdir
-  export PYTHONUSERBASE=$ARKOUDA_HOME/python-deps
-  # If Arkouda deps use any of our test deps, try to use the versions we want
+
+    # If Arkouda deps use any of our test deps, try to use the versions we want
   AK_PIP_CONTRAINTS="--constraint $CHPL_HOME/third-party/chpl-venv/test-requirements.txt"
   log "Installing Arkouda using python3 at: $(which python3)"
-  if ! python3 -m pip install --force-reinstall --timeout 60 $AK_PIP_CONTRAINTS -e .[dev] --user ; then
+  # create a virtual environment for running the tests
+  # if one was already created and set in CHPL_TEST_VENV_DIR, use it
+  if [ -n "$CHPL_TEST_VENV_DIR" ] && [ "$CHPL_TEST_VENV_DIR" != "none" ]; then
+    source $CHPL_TEST_VENV_DIR/bin/activate
+  else
+    python3 -m venv .venv
+    source .venv/bin/activate
+  fi
+
+  if ! python3 -m pip install --force-reinstall --timeout 60 $AK_PIP_CONTRAINTS -e .[dev] ; then
     log_fatal_error "installing arkouda"
   fi
 
@@ -175,6 +183,15 @@ if [ ${CHPL_TEST_ARKOUDA_STOP_AFTER_BUILD} = "false" ]; then
     fi
     test_end
   fi
+
+  # deactivate the venv and cleanup
+  if [ -n "$CHPL_TEST_VENV_DIR" ] && [ "$CHPL_TEST_VENV_DIR" != "none" ]; then
+    deactivate
+  else
+    deactivate
+    rm -rf .venv
+  fi
+
 else
   # If we've gotten here then the build succeeded I need to create a "fake"
   # test for Jenkins even though in this mode all I really care about is the

--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -108,7 +108,8 @@ if [ ${CHPL_TEST_ARKOUDA_STOP_AFTER_BUILD} = "false" ]; then
     source $CHPL_TEST_VENV_DIR/bin/activate
   else
     log "Creating a new virtual environment for Arkouda using '$(which python3)'"
-    python3 -m venv .venv
+    ARKOUDA_TEST_VENV=.arkouda-nightly-test-venv
+    python3 -m venv $ARKOUDA_TEST_VENV
     source .venv/bin/activate
   fi
 
@@ -191,7 +192,8 @@ if [ ${CHPL_TEST_ARKOUDA_STOP_AFTER_BUILD} = "false" ]; then
     deactivate
   else
     deactivate
-    rm -rf .venv
+    log "Removing the virtual environment in $ARKOUDA_TEST_VENV"
+    rm -rf $ARKOUDA_TEST_VENV
   fi
 
 else


### PR DESCRIPTION
Changes the Arkouda testing we have to use a virtual environment for dependencies. This should resolve some issues we are having in our nightly testing and is better representative of how people actually use Arkouda.

Note: this PR respects the CHPL_TEST_VENV_DIR, which can be specified to re-use a test venv across multiple runs

[Reviewed by @e-kayrakli and @tzinsky]