### PR TITLE
Revert a mistake in chapcs.no-local testing

### DIFF
--- a/util/cron/test-perf.chapcs.no-local.bash
+++ b/util/cron/test-perf.chapcs.no-local.bash
@@ -12,6 +12,6 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.no-local"
 perf_args="-performance-description no-local -performance-configs default:v,no-local:v -sync-dir-suffix no-local"
 perf_args="${perf_args} -performance -numtrials 1 -startdate 09/13/17"
 
-nightly_args="${nightly_args} -nobuild"
+nightly_args="${nightly_args} -no-local"
 
 $UTIL_CRON_DIR/nightly -cron ${nightly_args} ${perf_args}


### PR DESCRIPTION
I mistakenly merged a debugging code causing nightly failures. This PR reverts that change.