### PR TITLE
Fix Python module version incompatability with Python 3.9

### DIFF
--- a/modules/packages/Python.chpl
+++ b/modules/packages/Python.chpl
@@ -675,7 +675,7 @@ module Python {
     @chpldoc.nodoc
     proc compileModule(s: string, modname: string): PyObjectPtr throws
     {
-      var code = Py_CompileString(s.c_str(), "<string>", Py_file_input);
+      var code = chpl_Py_CompileString(s.c_str(), "<string>", Py_file_input);
       this.checkException();
       defer Py_DECREF(code);
 
@@ -2396,9 +2396,9 @@ module Python {
     extern proc PyRun_String(code: c_ptrConst(c_char), start: c_int,
                              globals: PyObjectPtr,
                              locals: PyObjectPtr): PyObjectPtr;
-    extern proc Py_CompileString(code: c_ptrConst(c_char),
-                                 filename: c_ptrConst(c_char),
-                                 start: c_int): PyObjectPtr;
+    extern proc chpl_Py_CompileString(code: c_ptrConst(c_char),
+                                      filename: c_ptrConst(c_char),
+                                      start: c_int): PyObjectPtr;
     extern proc PyImport_ExecCodeModule(name: c_ptrConst(c_char),
                                         code: PyObjectPtr): PyObjectPtr;
     extern proc PyMarshal_ReadObjectFromString(data: c_ptrConst(c_char),

--- a/modules/packages/PythonHelper/ArrayTypes.c
+++ b/modules/packages/PythonHelper/ArrayTypes.c
@@ -223,6 +223,12 @@ static int Array##NAMESUFFIX##Object_bf_getbuffer(Array##NAMESUFFIX##Object* arr
 chpl_ARRAY_TYPES(chpl_MAKE_GET_BUFFER)
 #undef chpl_MAKE_GET_BUFFER
 
+#if PY_VERSION_HEX >= 0x030a0000 /* Python 3.10 */
+#define chpl_Py_TPFLAGS_SEQUENCE Py_TPFLAGS_SEQUENCE
+#else
+#define chpl_Py_TPFLAGS_SEQUENCE 0
+#endif
+
 
 #define chpl_MAKE_TYPE(DATATYPE, CHAPELDATATYPE, NAMESUFFIX, ...) \
   static chpl_bool createArray##NAMESUFFIX##Type(void) { \
@@ -256,7 +262,7 @@ chpl_ARRAY_TYPES(chpl_MAKE_GET_BUFFER)
       /*name*/ "Array"#NAMESUFFIX, \
       /*basicsize*/ sizeof(Array##NAMESUFFIX##Object), \
       /*itemsize*/ 0, \
-      /*flags*/ Py_TPFLAGS_DEFAULT | Py_TPFLAGS_SEQUENCE, \
+      /*flags*/ Py_TPFLAGS_DEFAULT | chpl_Py_TPFLAGS_SEQUENCE, \
       /*slots*/ slots \
     }; \
     Array##NAMESUFFIX##Type = (PyTypeObject*)PyType_FromSpec(&spec); \

--- a/modules/packages/PythonHelper/ChapelPythonHelper.h
+++ b/modules/packages/PythonHelper/ChapelPythonHelper.h
@@ -68,6 +68,11 @@ static inline PyObject* chpl_Py_True(void) { return (PyObject*)Py_True; }
 static inline PyObject* chpl_Py_False(void) { return (PyObject*)Py_False; }
 
 
+static inline PyObject* chpl_Py_CompileString(const char* str,
+                                              const char* filename, int start) {
+  return Py_CompileString(str, filename, start);
+}
+
 static inline PyStatus chpl_Py_NewIsolatedInterpreter(PyThreadState** tstate) {
 #if PY_VERSION_HEX >= 0x030c0000 /* Python 3.12 */
   PyInterpreterConfig config = {


### PR DESCRIPTION
Fixes a few issues with the Python module with Python 3.9

- avoids Py_TPFLAGS_SEQUENCE, added in 3.10
- avoids Py_CompileString, which in 3.9 was a macro

Spot checked Python module tests with Python 3.9

[Reviewed by @lydia-duncan]