### PR TITLE
Add support for CHPL_PYTHON

### DIFF
--- a/util/config/find-python.sh
+++ b/util/config/find-python.sh
@@ -1,14 +1,26 @@
 #!/bin/sh
 
-for cmd in python3 python python2; do
-  if command -v $cmd > /dev/null 2>&1
+# Check a command, $1, to see if its a valid executable
+# if it is, print it and exit, otherwise do nothing
+function check_python {
+  if command -v $1 > /dev/null 2>&1
   then
-    if $cmd --version > /dev/null 2>&1
+    if $1 --version > /dev/null 2>&1
     then
-      echo $cmd
+      echo $1
       exit 0
     fi
   fi
+}
+
+if [ -n "$CHPL_PYTHON" ]; then
+  check_python $CHPL_PYTHON
+  echo "python executable '$CHPL_PYTHON' not found" 1>&2
+  exit 1
+fi
+
+for cmd in python3 python python2; do
+  check_python $cmd
 done
 
 echo "python3 not found - please install python3 and add it to PATH" 1>&2

--- a/util/config/find-python.sh
+++ b/util/config/find-python.sh
@@ -2,7 +2,7 @@
 
 # Check a command, $1, to see if its a valid executable
 # if it is, print it and exit, otherwise do nothing
-function check_python {
+check_python() {
   if command -v $1 > /dev/null 2>&1
   then
     if $1 --version > /dev/null 2>&1


### PR DESCRIPTION
Adds support for CHPL_PYTHON. This variable allows users and developers to select a different version of Python than the default one in PATH. This variable does not affect builds of the compiler, it is a runtime config only.

Example usage on a system with `python3`, `python3.12` and `python3.13`

```bash
`util/config/find-python.sh` --version # reports 3.13
`CHPL_PYTHON=python3 util/config/find-python.sh` --version # reports 3.13
`CHPL_PYTHON=python3.12 util/config/find-python.sh` --version # reports 3.12
`CHPL_PYTHON=python3.13 util/config/find-python.sh` --version # reports 3.13
```

This PR is intentionally leaving this variable undocumented for now. Changing the python version at runtime could have unintended side effects that would be difficult for users to debug.

[Reviewed by @lydia-duncan and @DanilaFe]