### PR TITLE
Remove Python 3.9 version pin for arkouda testing

### DIFF
--- a/util/cron/common-arkouda.bash
+++ b/util/cron/common-arkouda.bash
@@ -43,14 +43,6 @@ fi
 # enable arrow/parquet support
 export ARKOUDA_SERVER_PARQUET_SUPPORT=true
 
-SETUP_PYTHON=$COMMON_DIR/setup_python39.bash
-if [ -f "$SETUP_PYTHON" ]; then
-  echo "Setting up Python using $SETUP_PYTHON"
-  source $SETUP_PYTHON
-  echo "Using Python $(which python3)"
-else
-  echo "Can't find Python setup script $SETUP_PYTHON"
-fi
 
 export CHPL_WHICH_RELEASE_FOR_ARKOUDA="2.3.0"
 


### PR DESCRIPTION
Removes Python 3.9 version pin for arkouda testing.

[Reviewed by @e-kayrakli]