### PR TITLE
Revert "Run complete test suite on HPE Cray EX"

### DIFF
--- a/util/cron/test-hpe-cray-ex-ofi.bash
+++ b/util/cron/test-hpe-cray-ex-ofi.bash
@@ -11,4 +11,4 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="hpe-cray-ex-ofi"
 export CHPL_RT_COMM_OFI_EXPECTED_PROVIDER="cxi"
 export CHPL_RT_MAX_HEAP_SIZE=16g
 
-$UTIL_CRON_DIR/nightly -cron -blog ${nightly_args}
+$UTIL_CRON_DIR/nightly -cron -examples -blog ${nightly_args}


### PR DESCRIPTION
The complete test suite runs too long and never finishes.

This reverts commit c2084e04384a0d179f59343e89f97e734aa91cfd.