### PR TITLE
Improve logging for skipifs, especially for the Python module

### DIFF
--- a/test/library/packages/Python/skipIfAndInstallPackage.sh
+++ b/test/library/packages/Python/skipIfAndInstallPackage.sh
@@ -16,15 +16,18 @@ fi
 
 # try and import the first package, if it fails, try and install the packages
 if ! $chpl_python -c "import $PACKAGE" &>/dev/null; then
-
+  echo "[Attempting to install $PACKAGE]"
   MY_LIB_DIR=$INSTALL_DIR/python_libs
   $chpl_python -m pip install $PACKAGE $OTHER_PACKAGES --target=$MY_LIB_DIR 2>&1
   export PYTHONPATH=$MY_LIB_DIR:$PYTHONPATH
   if ! $chpl_python -c "import $PACKAGE" &>/dev/null; then
+    echo "[Failed to install $PACKAGE]"
     echo "True"
   else
+    echo "[Successfully installed $PACKAGE]"
     echo "False"
   fi
 else
+  echo "[Skipping installing $PACKAGE, already installed]"
   echo "False"
 fi

--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -1379,6 +1379,8 @@ def main():
             elif (suffix=='.skipif' and (os.access(f, os.R_OK) and
                    (os.getenv('CHPL_TEST_SINGLES')=='0'))):
                 testskipiffile=True
+                sys.stdout.write('[Checking skipif: %s.skipif]\n'%(test_filename))
+                sys.stdout.flush()
                 try:
                     skipme=False
                     skiptest=runSkipIf(f)
@@ -1398,6 +1400,9 @@ def main():
                     break
 
             elif ((suffix=='.suppressif' or name == 'SUPPRESSIF') and (os.access(f, os.R_OK))):
+                logname = "SUPPRESSIF" if name == "SUPPRESSIF" else "%s.suppressif" % (test_filename)
+                sys.stdout.write('[Checking suppressif: %s]\n'%(logname))
+                sys.stdout.flush()
                 try:
                     suppressme=False
                     suppresstest=runSkipIf(f)


### PR DESCRIPTION
Improves some of the logging we do for skipifs/suppressifs in `sub_test.py`. Additionally, improves logging in a Python module specific skipif

For example:
![Screenshot 2025-02-18 at 2 25 30 PM](https://github.com/user-attachments/assets/57b8e2fa-1a4c-462b-9710-ff2221653bba)


[Reviewed by @lydia-duncan]