### PR TITLE
Add some environment variables back in for CHAMPS

### DIFF
--- a/util/cron/common-champs.bash
+++ b/util/cron/common-champs.bash
@@ -41,6 +41,8 @@ module list
 export CHPL_HOST_PLATFORM=hpe-apollo
 export CHPL_TEST_LAUNCHCMD=\$CHPL_HOME/util/test/chpl_launchcmd.py
 export CHPL_LAUNCHER_TIMEOUT=pbs
+export CHPL_LAUNCHCMD_NUM_CPUS=144
+export CHPL_LAUNCHCMD_QUEUE=f2401THP
 source $UTIL_CRON_DIR/load-base-deps.bash
 
 module list


### PR DESCRIPTION
https://github.com/chapel-lang/chapel/pull/26707 moved the following exports to `common-hpe-apollo.bash`

```bash
export CHPL_LAUNCHCMD_NUM_CPUS=144
export CHPL_LAUNCHCMD_QUEUE=f2401THP
```

However, that script is not sourced by `common-champs.bash`, which instead sources the performance version of that script (which is where I moved those exports from). It looks like it is because of complicated web of dependencies and modules that need to be loaded. This is captured by the following comment in `common-champs.bash`

```bash
# note that this part is similar to common-hpe-apollo.bash, but
# we don't want the module operations in there, nor we can source it
# earlier. Because if we source load-chpl-deps.bash early, we can't
# load PrgEnv-gnu
export CHPL_HOST_PLATFORM=hpe-apollo
export CHPL_TEST_LAUNCHCMD=\$CHPL_HOME/util/test/chpl_launchcmd.py
export CHPL_LAUNCHER_TIMEOUT=pbs
source $UTIL_CRON_DIR/load-base-deps.bash
```

This PR adds the exports at the very top to the exports in this list.