### PR TITLE
Improve error message when trying to sort an unsupported record

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -3406,6 +3406,7 @@ module ChapelBase {
 
   proc chpl_field_lt(a: [] ?t, b: [] t) {
     compilerError("ordered comparisons not supported by default on records with array fields");
+    return false;
   }
 
   inline proc chpl_field_lt(a, b) where !isArrayType(a.type) {
@@ -3414,6 +3415,7 @@ module ChapelBase {
 
   proc chpl_field_gt(a: [] ?t, b: [] t) {
     compilerError("ordered comparisons not supported by default on records with array fields");
+    return false;
   }
 
   inline proc chpl_field_gt(a, b) where !isArrayType(a.type) {

--- a/modules/standard/Sort.chpl
+++ b/modules/standard/Sort.chpl
@@ -413,7 +413,6 @@ inline proc chpl_compare(a:?t, b:t, comparator:?rec) {
             canResolveMethod(comparator, "keyPart", a, 0) {
     return compareByPart(a, b, comparator);
   } else {
-    // never reached, chpl_check_comparator will catch this
     proc baseComparatorType(type c) type {
       if c == defaultComparator then
         return c;
@@ -423,7 +422,9 @@ inline proc chpl_compare(a:?t, b:t, comparator:?rec) {
         return c;
     }
     if baseComparatorType(comparator.type) == defaultComparator {
-      compilerError("The defaultComparator does not support sorting ", t:string, " elements");
+      compilerError(
+        "The defaultComparator does not support sorting elements of type '",
+        t:string, "'");
     } else {
       compilerError(
         "The comparator ", comparator.type:string,

--- a/modules/standard/Sort.chpl
+++ b/modules/standard/Sort.chpl
@@ -414,10 +414,22 @@ inline proc chpl_compare(a:?t, b:t, comparator:?rec) {
     return compareByPart(a, b, comparator);
   } else {
     // never reached, chpl_check_comparator will catch this
-    compilerError(
-      "The comparator ", comparator.type:string,
-      " must implement either 'keyComparator', 'keyPartComparator', or ",
-      "'relativeComparator' for ", t:string);
+    proc baseComparatorType(type c) type {
+      if c == defaultComparator then
+        return c;
+      else if isSubtype(c, reverseComparator) then
+        return baseComparatorType(c.comparator);
+      else
+        return c;
+    }
+    if baseComparatorType(comparator.type) == defaultComparator {
+      compilerError("The defaultComparator does not support sorting ", t:string, " elements");
+    } else {
+      compilerError(
+        "The comparator ", comparator.type:string,
+        " must implement either 'keyComparator', 'keyPartComparator', or ",
+        "'relativeComparator' for ", t:string);
+    }
   }
 }
 

--- a/test/library/standard/Sort/errors/sortArrayField.chpl
+++ b/test/library/standard/Sort/errors/sortArrayField.chpl
@@ -1,0 +1,11 @@
+use Sort;
+
+record r {
+  var field: [1..3] real;
+}
+
+var Arr: [1..10] r;
+
+sort(Arr);
+
+writeln(Arr);

--- a/test/library/standard/Sort/errors/sortArrayField.good
+++ b/test/library/standard/Sort/errors/sortArrayField.good
@@ -1,5 +1,5 @@
 $CHPL_HOME/modules/standard/Sort.chpl:nnnn: In function 'insertionSortMoveElts':
-$CHPL_HOME/modules/standard/Sort.chpl:nnnn: error: The defaultComparator does not support sorting r elements
+$CHPL_HOME/modules/standard/Sort.chpl:nnnn: error: The defaultComparator does not support sorting elements of type 'r'
   $CHPL_HOME/modules/standard/Sort.chpl:nnnn: called as insertionSortMoveElts(Data: [domain(1,int(64),one)] r, comparator: defaultComparator, lo: int(64), hi: int(64)) from function 'quickSortImpl'
   $CHPL_HOME/modules/standard/Sort.chpl:nnnn: called as quickSortImpl(Data: [domain(1,int(64),one)] r, minlen: int(64), comparator: defaultComparator, start: int(64), end: int(64)) from function 'quickSort'
   $CHPL_HOME/modules/standard/Sort.chpl:nnnn: called as quickSort(Data: [domain(1,int(64),one)] r, minlen: int(64), comparator: defaultComparator, region: range(int(64),both,one)) from function 'unstableSort'

--- a/test/library/standard/Sort/errors/sortArrayField.good
+++ b/test/library/standard/Sort/errors/sortArrayField.good
@@ -1,0 +1,7 @@
+$CHPL_HOME/modules/standard/Sort.chpl:nnnn: In function 'insertionSortMoveElts':
+$CHPL_HOME/modules/standard/Sort.chpl:nnnn: error: The defaultComparator does not support sorting r elements
+  $CHPL_HOME/modules/standard/Sort.chpl:nnnn: called as insertionSortMoveElts(Data: [domain(1,int(64),one)] r, comparator: defaultComparator, lo: int(64), hi: int(64)) from function 'quickSortImpl'
+  $CHPL_HOME/modules/standard/Sort.chpl:nnnn: called as quickSortImpl(Data: [domain(1,int(64),one)] r, minlen: int(64), comparator: defaultComparator, start: int(64), end: int(64)) from function 'quickSort'
+  $CHPL_HOME/modules/standard/Sort.chpl:nnnn: called as quickSort(Data: [domain(1,int(64),one)] r, minlen: int(64), comparator: defaultComparator, region: range(int(64),both,one)) from function 'unstableSort'
+  $CHPL_HOME/modules/standard/Sort.chpl:nnnn: called as unstableSort(x: [domain(1,int(64),one)] r, comparator: defaultComparator, region: range(int(64),both,one)) from function 'sort'
+  sortArrayField.chpl:9: called as sort(x: [domain(1,int(64),one)] r, comparator: defaultComparator, param stable = false)


### PR DESCRIPTION
Improve error message when trying to sort an unsupported record

There are two fixes here
1. Adjust `chpl_field_lt` to always return a value, its not required for normal calls becayse of the `compilerError`, but it seems to trip `canResolve` up.
2. Specialize the error message for `chpl_compare` when the defaultComparator can't be used to sort elements

- [x] paratest with/without gasnet

Resolves https://github.com/chapel-lang/chapel/issues/26729

[Reviewed by @lydia-duncan]