### PR TITLE
Dyno: Switch to a different mode of computing runtime types in Dyno

### DIFF
--- a/frontend/include/chpl/resolution/resolution-queries.h
+++ b/frontend/include/chpl/resolution/resolution-queries.h
@@ -669,6 +669,8 @@ builderResultForDefaultFunction(Context* context,
     for a range is the type of the range's elements. */
 const types::QualifiedType& getPromotionType(Context* context, types::QualifiedType qt);
 
+const types::RuntimeType* getRuntimeType(Context* context, const types::CompositeType* ct);
+
 Access accessForQualifier(uast::Qualifier q);
 
 const MostSpecificCandidate*

--- a/frontend/include/chpl/types/ArrayType.h
+++ b/frontend/include/chpl/types/ArrayType.h
@@ -61,7 +61,6 @@ class ArrayType final : public CompositeType {
 
   static const ID domainId;
   static const ID eltTypeId;
-  static const ID runtimeTypeId;
 
  public:
 
@@ -72,10 +71,6 @@ class ArrayType final : public CompositeType {
                                        const QualifiedType& instance,
                                        const QualifiedType& domainType,
                                        const QualifiedType& eltType);
-
-  static const ArrayType* getWithRuntimeType(Context* context,
-                                             const ArrayType* arrayType,
-                                             const RuntimeType* runtimeType);
 
   const RuntimeType* getDomainRuntimeType() const;
 
@@ -105,14 +100,7 @@ class ArrayType final : public CompositeType {
     }
   }
 
-  bool hasRuntimeType() const {
-    return subs_.count(runtimeTypeId);
-  }
-
-  const QualifiedType& runtimeType() const {
-    CHPL_ASSERT(hasRuntimeType());
-    return subs_.at(runtimeTypeId);
-  }
+  const RuntimeType* runtimeType(Context* context) const;
 
   ~ArrayType() = default;
 

--- a/frontend/include/chpl/types/DomainType.h
+++ b/frontend/include/chpl/types/DomainType.h
@@ -90,7 +90,6 @@ class DomainType final : public CompositeType {
   static const ID nonRectangularIdxTypeId;
   static const ID stridesId;
   static const ID parSafeId;
-  static const ID runtimeTypeId;
 
  public:
 
@@ -109,11 +108,6 @@ class DomainType final : public CompositeType {
                                               const QualifiedType& instance,
                                               const QualifiedType& idxType,
                                               const QualifiedType& parSafe);
-
-  /** embellishes the domain type with a runtime type. */
-  static const DomainType* getWithRuntimeType(Context* context,
-                                              const DomainType* domainType,
-                                              const RuntimeType* runtimeType);
 
   const Type* substitute(Context* context,
                          const PlaceholderMap& subs) const override {
@@ -159,14 +153,7 @@ class DomainType final : public CompositeType {
     return subs_.at(parSafeId);
   }
 
-  bool hasRuntimeType() const {
-    return subs_.count(runtimeTypeId);
-  }
-
-  const QualifiedType& runtimeType() const {
-    CHPL_ASSERT(hasRuntimeType());
-    return subs_.at(runtimeTypeId);
-  }
+  const RuntimeType* runtimeType(Context* context) const;
 
   ~DomainType() = default;
 

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -5229,8 +5229,6 @@ void Resolver::exit(const Dot* dot) {
   // to _dom.
   if (receiver.type().type() && receiver.type().type()->isArrayType() &&
       dot->field() == USTR("domain")) {
-    const auto arrayType = receiver.type().type()->toArrayType();
-
     std::vector<CallInfoActual> actuals;
     actuals.emplace_back(receiver.type(), USTR("this"));
     auto name = UniqueString::get(context, "_dom");
@@ -5243,12 +5241,8 @@ void Resolver::exit(const Dot* dot) {
     auto inScopes = CallScopeInfo::forNormalCall(inScope, poiScope);
     auto rr = resolveGeneratedCall(dot, &ci, &inScopes, name.c_str());
 
-    // Fill in RTT, as the domain returned here has lost its RTT info.
     auto baseDomainType = rr.result.exprType().type()->toDomainType();
-    auto domainType = DomainType::getWithRuntimeType(
-        context, baseDomainType, arrayType->getDomainRuntimeType());
-
-    r.setType(QualifiedType(QualifiedType::CONST_VAR, domainType));
+    r.setType(QualifiedType(QualifiedType::CONST_VAR, baseDomainType));
     return;
   }
 

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -498,15 +498,15 @@ static QualifiedType primGetRuntimeTypeField(Context* context,
 
   const RuntimeType* rtt = nullptr;
   if (auto dt = compositeType->toDomainType()) {
-    if (auto domainRtt = dt->runtimeType().type()) {
-      CHPL_ASSERT(domainRtt->isRuntimeType());
-      rtt = domainRtt->toRuntimeType();
-    }
+    auto domainRtt = dt->runtimeType(context);
+    CHPL_ASSERT(domainRtt);
+    CHPL_ASSERT(domainRtt->isRuntimeType());
+    rtt = domainRtt->toRuntimeType();
   } else if (auto at = compositeType->toArrayType()) {
-    if (auto arrayRtt = at->runtimeType().type()) {
-      CHPL_ASSERT(arrayRtt->isRuntimeType());
-      rtt = arrayRtt->toRuntimeType();
-    }
+    auto arrayRtt = at->runtimeType(context);
+    CHPL_ASSERT(arrayRtt);
+    CHPL_ASSERT(arrayRtt->isRuntimeType());
+    rtt = arrayRtt->toRuntimeType();
   }
 
   if (!rtt) return QualifiedType();

--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -1479,29 +1479,6 @@ void computeReturnType(Resolver& resolver) {
       v.process(fn->body(), resolver.byPostorder);
       resolver.returnType = v.returnedType();
     }
-
-    if (auto ag = fn->attributeGroup()) {
-      if (ag->hasPragma(uast::pragmatags::PRAGMA_RUNTIME_TYPE_INIT_FN)) {
-        // This function creates a runtime type, which notionally associates
-        // with the function's return type a record that contains
-        // all of the functions' arguments. Do that now.
-        auto rtt = RuntimeType::get(resolver.context, resolver.typedSignature);
-        const Type* newType = resolver.returnType.type();
-        if (resolver.returnType.isUnknownOrErroneous()) {
-          // Inference fail, nothing to embed with the runtime type.
-        } else if (auto dt = newType->toDomainType()) {
-          newType = DomainType::getWithRuntimeType(resolver.context, dt, rtt);
-        } else if (auto at = newType->toArrayType()) {
-          newType = ArrayType::getWithRuntimeType(resolver.context, at, rtt);
-        } else {
-          resolver.context->error(fn, "unsupported return type for runtime type constructor");
-          newType = ErroneousType::get(resolver.context);
-        }
-
-        resolver.returnType =
-          QualifiedType(resolver.returnType.kind(), newType, resolver.returnType.param());
-      }
-    }
   }
 }
 

--- a/frontend/lib/types/ArrayType.cpp
+++ b/frontend/lib/types/ArrayType.cpp
@@ -31,7 +31,11 @@ namespace types {
 
 const ID ArrayType::domainId = ID(UniqueString(), 0, 0);
 const ID ArrayType::eltTypeId = ID(UniqueString(), 1, 0);
-const ID ArrayType::runtimeTypeId = ID(UniqueString(), 2, 0);
+
+const RuntimeType* ArrayType::runtimeType(Context* context) const {
+  return resolution::getRuntimeType(context, this);
+}
+
 
 void ArrayType::stringify(std::ostream& ss,
                            chpl::StringifyKind stringKind) const {
@@ -103,57 +107,6 @@ ArrayType::getArrayType(Context* context,
   auto name = id.symbolName(context);
   auto instantiatedFrom = getGenericArrayType(context);
   return getArrayTypeQuery(context, id, name, instantiatedFrom, subs).get();
-}
-
-// TODO: We need to change how we represent runtime types, and keep them tied
-// to domain types at any `new _domain` call, rather than retrieving them
-// after the fact in cases that call this.
-static const RuntimeType* getDomainRttFromArrayRtt(
-    const RuntimeType* arrayRtt) {
-  CHPL_ASSERT(arrayRtt);
-
-  static const int domFormalIdx = 0;
-  const auto sig = arrayRtt->toRuntimeType()->initializer();
-  CHPL_ASSERT(sig->untyped()->formalName(domFormalIdx) == "dom");
-  CHPL_ASSERT(sig->formalType(domFormalIdx).type());
-
-  const auto domainTy = sig->formalType(domFormalIdx).type()->toDomainType();
-  CHPL_ASSERT(domainTy->hasRuntimeType());
-  const auto domainRuntimeTy = domainTy->runtimeType().type()->toRuntimeType();
-  CHPL_ASSERT(domainRuntimeTy);
-  return domainRuntimeTy;
-}
-
-const ArrayType* ArrayType::getWithRuntimeType(Context* context,
-                                               const ArrayType* arrayType,
-                                               const RuntimeType* runtimeType) {
-  CHPL_ASSERT(runtimeType != nullptr);
-  auto rttQt = QualifiedType(QualifiedType::TYPE, runtimeType);
-  auto subs = arrayType->substitutions();
-  subs.emplace(runtimeTypeId, rttQt);
-
-  // Insert RTT info into the domain substitution, since
-  // chpl__buildArrayRuntimeType returns us an array whose domain has no RTT.
-  auto baseDomainType = arrayType->domainType().type()->toDomainType();
-  auto domainRtt = getDomainRttFromArrayRtt(runtimeType);
-  subs[domainId] = QualifiedType(
-      QualifiedType::TYPE,
-      DomainType::getWithRuntimeType(context, baseDomainType, domainRtt));
-
-  const ArrayType* instantiatedFrom = nullptr;
-  if (auto sourceInstFrom = arrayType->instantiatedFromCompositeType()) {
-    CHPL_ASSERT(sourceInstFrom->isArrayType());
-    instantiatedFrom = sourceInstFrom->toArrayType();
-  }
-
-  return getArrayTypeQuery(context, arrayType->id(), arrayType->name(),
-                           instantiatedFrom, subs).get();
-}
-
-const RuntimeType* ArrayType::getDomainRuntimeType() const {
-  CHPL_ASSERT(hasRuntimeType());
-  const auto runtimeType = this->runtimeType().type();
-  return getDomainRttFromArrayRtt(runtimeType->toRuntimeType());
 }
 
 } // end namespace types

--- a/frontend/lib/types/DomainType.cpp
+++ b/frontend/lib/types/DomainType.cpp
@@ -35,7 +35,10 @@ const ID DomainType::rectangularIdxTypeId = ID(UniqueString(), 1, 0);
 const ID DomainType::nonRectangularIdxTypeId = ID(UniqueString(), 0, 0);
 const ID DomainType::stridesId = ID(UniqueString(), 2, 0);
 const ID DomainType::parSafeId = ID(UniqueString(), 1, 0);
-const ID DomainType::runtimeTypeId = ID(UniqueString(), 3, 0);
+
+const RuntimeType* DomainType::runtimeType(Context* context) const {
+  return resolution::getRuntimeType(context, this);
+}
 
 void DomainType::stringify(std::ostream& ss,
                            chpl::StringifyKind stringKind) const {
@@ -154,25 +157,6 @@ DomainType::getAssociativeType(Context* context,
   auto id = getDomainID(context);
   return getDomainType(context, id, name, /* instantiatedFrom */ genericDomain,
                        subs, DomainType::Kind::Associative).get();
-}
-
-const DomainType* DomainType::getWithRuntimeType(Context* context,
-                                                 const DomainType* domainType,
-                                                 const RuntimeType* runtimeType) {
-  CHPL_ASSERT(runtimeType != nullptr);
-  auto rttQt = QualifiedType(QualifiedType::TYPE, runtimeType);
-  auto subs = domainType->substitutions();
-  subs.emplace(runtimeTypeId, rttQt);
-
-  const DomainType* instantiatedFrom = nullptr;
-  if (auto sourceInstFrom = domainType->instantiatedFromCompositeType()) {
-    CHPL_ASSERT(sourceInstFrom->isDomainType());
-    instantiatedFrom = sourceInstFrom->toDomainType();
-  }
-
-  return getDomainType(context, domainType->id(), domainType->name(),
-                       instantiatedFrom, std::move(subs),
-                       domainType->kind()).get();
 }
 
 const QualifiedType& DomainType::getDefaultDistType(Context* context) {


### PR DESCRIPTION
This came up as a TODO on https://github.com/chapel-lang/chapel/pull/26628, and in a discussion as part of the Dyno meeting. Dyno, unlike production, can't statefully associate runtime types with their domains and arrays. Fortunately, there's a standard function `chpl__convertValueToRuntimeType` (thanks @benharsh for pointing it out) which invokes the corresponding builder. This PR leans on that function to define a query to compute an array's or domain's runtime type, removing runtime types from the substitutions of these types. This fixes a failure in CLS, where resolving the string module resulting in resolving a promoted expression, which, in turn, created an array without a runtime type.

Reviewed by @riftEmber -- thanks!

## Testing
- [x] dyno tests
- [x] paratest