### PR TITLE
Add support for Python dictionaries to the Python module

### DIFF
--- a/modules/packages/Python.chpl
+++ b/modules/packages/Python.chpl
@@ -1166,6 +1166,7 @@ module Python {
         var pyKey = toPython(key);
         var pyValue = toPython(m[key]);
         PyDict_SetItem(pyDict, pyKey, pyValue);
+        Py_DECREF(pyValue);
         this.checkException();
       }
       return pyDict;
@@ -1223,7 +1224,9 @@ module Python {
         var val = PyDict_GetItem(obj, key);
         this.checkException();
 
+        Py_INCREF(key);
         var keyVal = this.fromPython(keyType, key);
+        Py_INCREF(val);
         m.add(keyVal, this.fromPython(valType, val));
       }
 
@@ -2061,6 +2064,7 @@ module Python {
     proc get(type T, key: ?): T throws {
       var item = PyDict_GetItem(this.getPyObject(), interpreter.toPython(key));
       this.check();
+      Py_INCREF(item);
       return interpreter.fromPython(T, item);
     }
     @chpldoc.nodoc
@@ -2075,8 +2079,10 @@ module Python {
       :arg item: The item to set.
     */
     proc set(key: ?, item: ?) throws {
+      var val = interpreter.toPython(item);
       PyDict_SetItem(this.getPyObject(), interpreter.toPython(key),
-                     interpreter.toPython(item));
+                     val);
+      Py_DECREF(val);
       this.check();
     }
 

--- a/modules/packages/Python.chpl
+++ b/modules/packages/Python.chpl
@@ -2068,6 +2068,19 @@ module Python {
       this.check();
       return new PyDict(this.interpreter, c);
     }
+
+    /*
+      Check if an item is in the dict.  Equivalent to calling ``item in obj`` in
+      Python.
+
+      :arg key: The key to check for membership in the dict.
+    */
+    proc contains(key: ?): bool throws {
+      var result = PyDict_Contains(this.getPyObject(),
+                                   interpreter.toPython(key));
+      this.check();
+      return result: bool;
+    }
   }
 
   /*
@@ -2772,6 +2785,7 @@ module Python {
       Dictionaries
     */
     extern proc PyDict_New(): PyObjectPtr;
+    extern proc PyDict_Contains(dict: PyObjectPtr, key: PyObjectPtr): c_int;
     extern proc PyDict_SetItem(dict: PyObjectPtr,
                                key: PyObjectPtr,
                                value: PyObjectPtr);

--- a/test/library/packages/Python/correctness/arrays/myDict.chpl
+++ b/test/library/packages/Python/correctness/arrays/myDict.chpl
@@ -19,6 +19,10 @@ proc main() {
   writeln("get one ", d.get("one"));
   writeln("get two ", d.get(int, "two"));
   writeln("get three ", d.get("three"));
+  writeln("contains one ", d.contains("one"));
+  writeln("contains two ", d.contains("two"));
+  writeln("contains three ", d.contains("three"));
+  writeln("contains four ", d.contains("four"));
 
   d.set("four", 4);
   writeln("get four after set four ", d.get("four"));

--- a/test/library/packages/Python/correctness/arrays/myDict.chpl
+++ b/test/library/packages/Python/correctness/arrays/myDict.chpl
@@ -1,0 +1,43 @@
+use Python;
+import Map;
+
+var pyCode = """
+def getDict():
+  return dict(one=1, two=2, three=3)
+""";
+
+proc main() {
+
+  var interp = new Interpreter();
+
+  var pyCodeModule = interp.importModule('__empty__', pyCode);
+  var getDictFunc = pyCodeModule.get('getDict');
+
+  var d = getDictFunc(owned PyDict);
+  writeln("d ", d);
+  writeln("size ", d.size);
+  writeln("get one ", d.get("one"));
+  writeln("get two ", d.get(int, "two"));
+  writeln("get three ", d.get("three"));
+
+  d.set("four", 4);
+  writeln("get four after set four ", d.get("four"));
+
+  var d2 = d.copy();
+  writeln("d2 size ", d2.size);
+
+  d.del("three");
+  writeln("size after delete of three ", d.size);
+
+  d.clear();
+  writeln("size after clear ", d.size);
+  writeln("d2 size after d1 clear ", d2.size);
+
+  try {
+    d.del("five"); // Try deleting something not in the dict
+  } catch e: PythonException {
+    writeln("Caught exception: ", e);
+  } catch e {
+    writeln("Caught unknown exception: ", e);
+  }
+}

--- a/test/library/packages/Python/correctness/arrays/myDict.chpl
+++ b/test/library/packages/Python/correctness/arrays/myDict.chpl
@@ -40,7 +40,10 @@ proc main() {
   try {
     d.del("five"); // Try deleting something not in the dict
   } catch e: PythonException {
-    writeln("Caught exception: ", e);
+    // The exception actually caught depends on the version of Python, so don't
+    // print it out.  With Python 3.10, it's a general PythonException.  With
+    // Python 3.12, it's the more specific KeyError.
+    writeln("Caught exception");
   } catch e {
     writeln("Caught unknown exception: ", e);
   }

--- a/test/library/packages/Python/correctness/arrays/myDict.good
+++ b/test/library/packages/Python/correctness/arrays/myDict.good
@@ -3,6 +3,10 @@ size 3
 get one 1
 get two 2
 get three 3
+contains one true
+contains two true
+contains three true
+contains four false
 get four after set four 4
 d2 size 4
 size after delete of three 3

--- a/test/library/packages/Python/correctness/arrays/myDict.good
+++ b/test/library/packages/Python/correctness/arrays/myDict.good
@@ -12,4 +12,4 @@ d2 size 4
 size after delete of three 3
 size after clear 0
 d2 size after d1 clear 4
-Caught exception: KeyError: 'five'
+Caught exception

--- a/test/library/packages/Python/correctness/arrays/myDict.good
+++ b/test/library/packages/Python/correctness/arrays/myDict.good
@@ -1,0 +1,11 @@
+d {'one': 1, 'two': 2, 'three': 3}
+size 3
+get one 1
+get two 2
+get three 3
+get four after set four 4
+d2 size 4
+size after delete of three 3
+size after clear 0
+d2 size after d1 clear 4
+Caught exception: KeyError: 'five'

--- a/test/library/packages/Python/correctness/basicTypes.chpl
+++ b/test/library/packages/Python/correctness/basicTypes.chpl
@@ -2,6 +2,7 @@ use Python;
 import Reflection;
 import List;
 import Set;
+import Map;
 
 config const print = false;
 
@@ -38,6 +39,11 @@ proc roundTripFunction(func: borrowed) {
     s.add(i);
   }
   testType(s.type, s);
+  var m = new Map.map(int, int);
+  for i in arr {
+    m.add(i, i*2);
+  }
+  testType(m.type, m);
 
 }
 proc roundTripClass(clsType: borrowed) {
@@ -88,6 +94,11 @@ proc roundTripClass(clsType: borrowed) {
   }
   testType(s.type, s, new Set.set(int));
 
+  var m = new Map.map(int, int);
+  for i in arr {
+    m.add(i, i*2);
+  }
+  testType(m.type, m, new Map.map(int, int));
 }
 
 proc main() {

--- a/test/library/packages/Python/memleaks/basicTypes.chpl
+++ b/test/library/packages/Python/memleaks/basicTypes.chpl
@@ -1,4 +1,4 @@
-use Python, List;
+use Python, List, Map;
 
 config const print = false;
 var interp = new Interpreter();
@@ -69,6 +69,15 @@ proc main() {
   { // assoc arrays
     var assoc = ["foo" => "bar", "baz" => "qux"];
     testType(assoc.type, assoc);
+  }
+
+  { // maps
+    var m = new map(string, int);
+    m.add("one", 1);
+    m.add("two", 2);
+    m.add("three", 3);
+
+    testType(m.type, m);
   }
 
 }

--- a/test/library/packages/Python/memleaks/maps.chpl
+++ b/test/library/packages/Python/memleaks/maps.chpl
@@ -1,0 +1,30 @@
+use Python, Map;
+
+var interp = new Interpreter();
+
+proc main() {
+  // Use a lambda instead of importing a module and a function to avoid memory
+  // leaks that aren't our fault.
+  var getDictFunc = interp.compileLambda("lambda : dict(first = [1, 2, 3], second = [1, 3, 5, 7], third = ['foo', 'bar'])");
+
+  var d = getDictFunc(owned PyDict);
+  // Would print the dictionary, but Python's dictionary printing leaks memory
+  // Furthermore, those leaks vary depending on the Python version used
+  writeln("d size ", d.size);
+
+  // Would print the list result but that also leaks memory because of Python
+  var l = d.get("second");
+
+  var l2 = d.get("third");
+
+  d.del("second");
+  writeln("d size after deleting second ", d.size);
+
+  // What happens if I swap 'em?
+  d.set("second", l2);
+  d.set("third", l);
+  writeln("d size after swap ", d.size);
+
+  d.clear();
+  writeln("d size after clear ", d.size);
+}

--- a/test/library/packages/Python/memleaks/maps.good
+++ b/test/library/packages/Python/memleaks/maps.good
@@ -1,0 +1,4 @@
+d size 3
+d size after deleting second 2
+d size after swap 3
+d size after clear 0


### PR DESCRIPTION
Resolves Cray/chapel-private#7140

Covers:
- writing the type
- size
- get
- set
- del
- clear
- copy
- contains

Also ensures the type can be converted to and from a Chapel map.

Does not cover:
- items
- keys
- values
- pop
- update
as these methods are handled differently in their C API than in Python itself.

Adds a new PythonException subclass in support of the `del` method, though the use of this subclass seems to be dependent on the Python version (it was used with Python 3.12, but Python 3.10 didn't recognize it while still giving a failure).

Added a basic test of the new type and a memleaks test of it.  Extended the basicTypes test and the memleaks basicTypes test to include it.  Passed a full paratest with futures.