### PR TITLE
Reduce timeout only on the HPE Apollo platform

### DIFF
--- a/test/parallel/taskCompare/elliot/empty-chpl-remote-taskspawn.ml-timeout
+++ b/test/parallel/taskCompare/elliot/empty-chpl-remote-taskspawn.ml-timeout
@@ -1,1 +1,7 @@
-100
+#!/bin/bash
+
+if [[ $CHPL_TARGET_PLATFORM == hpe-apollo ]]; then
+    echo 100
+else
+    echo 300
+fi


### PR DESCRIPTION
Setting the timeout to 100 seconds for all platforms caused some timeouts on the HPE Cray EX platform. Make the timeout conditional so it is 100 seconds on the HPE Apollo, and (the default) 300 seconds on everything else.