### PR TITLE
Address instability in prefetchCounters

### DIFF
--- a/test/runtime/configMatters/comm/cache-remote/prefetchCounters.chpl
+++ b/test/runtime/configMatters/comm/cache-remote/prefetchCounters.chpl
@@ -53,9 +53,7 @@ proc testCounters(id: int)
     // We want it to be aligned to a multiple of pageSize so that
     // there is no instability in the test.
     const locPtr = allocate(int, numElems, alignment=alignment, clear=true);
-    // Except use _ddata as a standin for the array to remove
-    const A = locPtr : _ddata(int);
-    //var A = makeArrayFromPtr(locPtr, numElems);
+    var A = makeArrayFromPtr(locPtr, numElems);
 
     //#########################################################################
     //

--- a/test/runtime/configMatters/comm/cache-remote/prefetchCounters.good
+++ b/test/runtime/configMatters/comm/cache-remote/prefetchCounters.good
@@ -1,12 +1,14 @@
-Running test 1
+Running test 1 numPrefetches=32
 	cache_num_prefetches: 32
 	cache_prefetch_unused: 32
 	cache_prefetch_waited: 0
 Running test 2
+Running test 2 numPrefetches=32
 	cache_num_prefetches: 32
 	cache_prefetch_unused: 16
 	cache_prefetch_waited: 0
 Running test 3
+Running test 3 numPrefetches=32
 	cache_num_prefetches: 32
 	cache_prefetch_unused: 0
 	cache_prefetch_waited: 32


### PR DESCRIPTION
This PR makes several changes to prefetchCounters to avoid instability in the test.

1. It aligns the memory allocated for the test array to avoid the potential for different array buffer alignment causing different behavior.
2. It prefetches data more than a cache page apart (to avoid the possibility for the readahead to impact things, though it shouldn't because multi-page readahead is disabled by default)
3. Instead of waiting for prefetches with a "make work" loop, it waits for a PUT through the cache that happens after the prefetches.

Note that, at present, the logic in `chpl-cache.c` in `do_wait_for` can't necessarily tell the difference between "waited for a prefetch" and "the comms layer thought it had to wait for a prefetch but once it looked it found everything ready". This could be handled with a timer, so that "waited" has some definition in terms of time that has practical value. The PUT approach in the test avoids this problem because the cache currently waits for pending events in sequence order, so in practice it actually waits for the prefetches while waiting for the PUT. Anyway, it provides a way to consistently check the prefetch counters, which is the purpose of this test.

Test change only -- not reviewed.