### PR TITLE
Use the proper header wchar_t with a C++ compiler

### DIFF
--- a/modules/packages/Python.chpl
+++ b/modules/packages/Python.chpl
@@ -2415,7 +2415,7 @@ module Python {
 
   @chpldoc.nodoc
   module CWChar {
-    require "wchar.h";
+    require "PythonHelper/chpl_wchar.h";
     extern "wchar_t" type c_wchar;
     private use CTypes;
 

--- a/modules/packages/PythonHelper/chpl_wchar.h
+++ b/modules/packages/PythonHelper/chpl_wchar.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020-2025 Hewlett Packard Enterprise Development LP
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#ifdef __cplusplus
+#include <cwchar>
+#else
+#include <wchar.h>
+#endif


### PR DESCRIPTION
Use the proper header wchar_t with a C++ compiler, where this should only occur with GPUs

[Reviewed by @lydia-duncan]