### PR TITLE
Fix versionButton symbolic link

### DIFF
--- a/doc/util/versionButton.php
+++ b/doc/util/versionButton.php
@@ -1,1 +1,1 @@
-../versionButton.php
+../../chapel-static/docs/versionButton.php


### PR DESCRIPTION
In my previous commit, I forgot that docs/main is itself a symbolic link to a directory that is automatically updated by Jenkins distinctly from the main static website directory.  The result was that "../" didn't work as a path since it wouldn't end up in 'docs/' bit the directory to which Jenkins syncs.

Here, I've updated the symbolic link to go to the static website to find the versionButton.php.  This time, I've tested this same path on the live website, so as long as I didn't make a trancription error, it ought to work.
