### PR TITLE
Adjust CHAMPS sub_test to warn about CHPL_TARGET_COMPILER=gnu

### DIFF
--- a/test/studies/champs/sub_test
+++ b/test/studies/champs/sub_test
@@ -77,7 +77,7 @@ fi
 echo "contents of $CHAMPS_HOME"
 ls $CHAMPS_HOME
 
-if [ $CHPL_TARGET_COMPILER == "gnu" ]; then
+if [ "${CHPL_TARGET_COMPILER}" == "gnu" ] ; then
   echo "[Warning: CHPL_TARGET_COMPILER is gnu, some compilations may time out. Prefer CHPL_TARGET_COMPILER=clang]"
 fi
 

--- a/test/studies/champs/sub_test
+++ b/test/studies/champs/sub_test
@@ -77,15 +77,23 @@ fi
 echo "contents of $CHAMPS_HOME"
 ls $CHAMPS_HOME
 
+if [ $CHPL_TARGET_COMPILER == "gnu" ]; then
+  echo "[Warning: CHPL_TARGET_COMPILER is gnu, some compilations may time out. Prefer CHPL_TARGET_COMPILER=clang]"
+fi
+
 # Compile CHAMPS executables
 test_compile icing
 
 if [ -z "$CHAMPS_QUICKSTART" ] || [ ! -z "$CHAMPS_COMPILE_ALL_EXECS" ] ; then
+  test_compile prep
   test_compile flow
   test_compile drop
+  test_compile potential
+  test_compile potentialPrep
   test_compile geo
   test_compile thermo
   test_compile postLink
+  test_compile post
   test_compile stochasticIcing
   test_compile octree
   test_compile eigenSolvePost
@@ -94,16 +102,6 @@ if [ -z "$CHAMPS_QUICKSTART" ] || [ ! -z "$CHAMPS_COMPILE_ALL_EXECS" ] ; then
   test_compile continuation
   test_compile stability
   test_compile coloring
-
-  # we are seeing OOM issues with the C backend that we attribute to a
-  # system/backend issue. Until we figure out what's going wrong, stop testing
-  # these executables with the C backend
-  if [ "${CHPL_TARGET_COMPILER}" != "gnu" ] ; then
-    test_compile potentialPrep
-    test_compile potential
-    test_compile prep
-    test_compile post
-  fi
 fi
 
 


### PR DESCRIPTION
Adjusts the CHAMPS sub_test to warn about CHPL_TARGET_COMPILER=gnu

Followup to https://github.com/chapel-lang/chapel/pull/26742

[Not reviewed]