### PR TITLE
Test Qthreads RC In Performance Playgrounds

### DIFF
--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -25,10 +25,11 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground"
 # 4) Update START_DATE to be today, using the format mm/dd/yy
 #
 
-GITHUB_USER=chapel-lang
-GITHUB_BRANCH=chapel
-SHORT_NAME=main
-START_DATE=04/04/24
+# Test performance with the latest qthreads release.
+GITHUB_USER=insertinterestingnamehere
+GITHUB_BRANCH=qthread
+SHORT_NAME=qthread122
+START_DATE=02/21/25
 
 git branch -D $GITHUB_USER-$GITHUB_BRANCH
 git checkout -b $GITHUB_USER-$GITHUB_BRANCH

--- a/util/cron/test-perf.hpe-apollo-hdr.gasnet-ibv.playground.bash
+++ b/util/cron/test-perf.hpe-apollo-hdr.gasnet-ibv.playground.bash
@@ -26,16 +26,17 @@ export GASNET_PHYSMEM_MAX="0.90"
 # When the multi-local playground is not used, set `SKIP_ML_PLAYGROUND=1
 #
 
-SKIP_ML_PLAYGROUND=1
+SKIP_ML_PLAYGROUND=0
 if [[ "$SKIP_ML_PLAYGROUND" == "1" ]]; then
   log_info "Skipping testing of the multi-local playground"
   exit
 fi
 
-GITHUB_USER=bradcray
-GITHUB_BRANCH=enable-localize-domain-opt
-SHORT_NAME=localize-domain
-START_DATE=07/15/24
+# Test performance with the latest qthreads release.
+GITHUB_USER=insertinterestingnamehere
+GITHUB_BRANCH=qthread
+SHORT_NAME=qthread122_apollo
+START_DATE=02/21/2025
 
 git branch -D $GITHUB_USER-$GITHUB_BRANCH
 git checkout -b $GITHUB_USER-$GITHUB_BRANCH


### PR DESCRIPTION
This tests the pull request adding the Qthreads 1.22 release candidate in the performance playgrounds to check for any performance regressions/improvements.