### PR TITLE
Remove a GPU locale model suppressif

### DIFF
--- a/test/release/examples/primers/cClient.suppressif
+++ b/test/release/examples/primers/cClient.suppressif
@@ -1,4 +1,0 @@
-#!/usr/bin/env python3
-
-import os
-print(os.getenv('CHPL_LOCALE_MODEL') == 'gpu')


### PR DESCRIPTION
After https://github.com/chapel-lang/chapel/pull/26741, the `cClient` primer can now be run with the CPU-as-device mode. I confirmed this locally. I didn't dig too deep into why, but this test has an `extern proc` whose return type must have been impacted by that PR. By looking at the last suppressed failure of this test, it looks like an internal compiler error, which could be because the GPU transforms' sensitivity to return types or some bogus AST generated because of it.

Tested locally with cpu-as-device mode.