### PR TITLE
activate module docs published from ghci

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -226,6 +226,6 @@ jobs:
           rm -f py-modindex.html
           # Remove all hidden files except .htaccess
           find . -maxdepth 1 -type f -name ".*" ! -name ".htaccess" -exec rm -f {} +
-          rsync -avz --cvs-exclude --delete --relative --dry-run . ${{ secrets.WEBSITE_USER }}@${{ secrets.WEBSITE_URL }}:${{ secrets.WEBSITE_PATH }}
+          rsync -avz --cvs-exclude --delete --relative . ${{ secrets.WEBSITE_USER }}@${{ secrets.WEBSITE_URL }}:${{ secrets.WEBSITE_PATH }}
           rm ~/.ssh/id_rsa
           rm ~/.ssh/known_hosts


### PR DESCRIPTION
This brings the github action to publish the module docs during the CI workflow live by removing the `dry-run` flag from the `rsync` command. 

CI change only - not reviewed