### PR TITLE
Reduce frequency of checking Homebrew formula, limit to chapel-lang/chapel

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -192,7 +192,7 @@ jobs:
           done
 
   publish-docs:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.repository == 'chapel-lang/chapel'
     runs-on: ubuntu-latest
     needs: make_doc
     steps:

--- a/.github/workflows/monitor-homebrew.yml
+++ b/.github/workflows/monitor-homebrew.yml
@@ -3,7 +3,7 @@ name: Monitor Homebrew Formula
 on:
   workflow_dispatch: # Allows manual triggering of the workflow
   schedule:
-    - cron: '0 */4 * * *' # Runs every 4 hours
+    - cron: '0 0 * * *' # Runs every 24 hours
 
 
 env:
@@ -12,6 +12,7 @@ env:
 
 jobs:
   check-and-update:
+    if: github.repository == 'chapel-lang/chapel'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This lowers the frequency of checking for changes to the homebrew formula from 4 hours to 24 hours. It also changes the workflow to only run on `chapel-lang/chapel` and not forks of chapel.