### PR TITLE
Avoid fatal warning-as-error when compiling with mpicc

### DIFF
--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -209,6 +209,8 @@ endif
 #
 ifeq ($(shell test $(GNU_GCC_MAJOR_VERSION) -gt 7; echo "$$?"),0)
 SQUASH_WARN_GEN_CFLAGS += -Wno-stringop-overflow -Wno-array-bounds
+# also squash it for the runtime build to avoid a problem with mpicc
+WARN_CFLAGS += -Wno-error=stringop-overflow
 endif
 
 #


### PR DESCRIPTION
When compiling on a system with MPICH 4.0.2 and GCC 12.2.0, and `CHPL_TARGET_COMPILER=mpi-gnu`, we were seeing compilation fail (for `make WARNINGS=1`) due to a spurious warning from GCC when building the runtime. This type of spurious warning is already disabled when compiling the generated code. This PR uses `-Wno-error` to make it a warning (not an error) if it comes up when building the runtime with `make WARNINGS=1`.

Reviewed by @jabraham17 - thanks!

- [x] full comm=none testing with `CHPL_TARGET_COMPILER=gnu` and GCC 7 (when the new `-Wno-error` should not apply)
- [x] fixes `make` problem with mpich 4 and gcc 12 and `CHPL_TARGET_COMPILER=mpi-gnu`
- [x] `make` works OK with gcc 12 and `CHPL_TARGET_COMPILER=gnu`
