### PR TITLE
Update the suppressif for these tests

### DIFF
--- a/test/library/packages/HDFS/hdfsNumbers.suppressif
+++ b/test/library/packages/HDFS/hdfsNumbers.suppressif
@@ -2,4 +2,4 @@
 
 from ctypes.util import find_library
 
-print (find_library('hdfs') is None)
+print ((find_library('hdfs') is None) or (find_library('jvm') is None))

--- a/test/library/packages/HDFS/hello-hadoop.suppressif
+++ b/test/library/packages/HDFS/hello-hadoop.suppressif
@@ -2,4 +2,4 @@
 
 from ctypes.util import find_library
 
-print (find_library('hdfs') is None)
+print ((find_library('hdfs') is None) or (find_library('jvm') is None))


### PR DESCRIPTION
It looks like our test environment is missing libjvm (which I think has something to do with Java, judging by the set up steps I followed to replicate nightly's behavior)

Tested the failure in a setting without hadoop and in the environment where the tests fail.