### PR TITLE
Use dependencies in lustre on an XC test system

### DIFF
--- a/util/cron/load-base-deps.bash
+++ b/util/cron/load-base-deps.bash
@@ -16,6 +16,10 @@ elif [[ "$(hostname -s)" == "richter-login" ]]; then
   if [ -f /hpelustre/chapelu/chpl-deps/richter-login/load_chpl_deps.bash ] ; then
     source /hpelustre/chapelu/chpl-deps/richter-login/load_chpl_deps.bash
   fi
+elif [[ "$(hostname -s)" == "horizon" ]]; then
+  if [ -f /lus/scratch/chapelu/chpl-deps/horizon/load_chpl_deps.bash ] ; then
+    source /lus/scratch/chapelu/chpl-deps/horizon/load_chpl_deps.bash
+  fi
 else
   # For systems not using a Spack install
 


### PR DESCRIPTION
This PR adds a special case for a testing system which has broken mounts on compute nodes. After this PR, dependencies on the lustre filesystem will be used instead. This will enable dynamically loading dependencies.

I'll test this manually to see if the dependencies we'll end up using still work.