### PR TITLE
Fix: explicitly invoking CMD in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,3 +89,7 @@ FROM chapel-base AS chapel
 COPY --from=chapel-build $CHPL_HOME $CHPL_HOME
 
 ENV PATH="${PATH}:${CHPL_HOME}/bin:${CHPL_HOME}/util"
+
+# Not relying on inherited CMD command in debian:11 base image.
+# Instead, explicitly invoking it in this image.
+CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,6 +90,5 @@ COPY --from=chapel-build $CHPL_HOME $CHPL_HOME
 
 ENV PATH="${PATH}:${CHPL_HOME}/bin:${CHPL_HOME}/util"
 
-# Not relying on inherited CMD command in debian:11 base image.
-# Instead, explicitly invoking it in this image.
+# Explicitly invoking CMD in this image.
 CMD ["/bin/bash"]


### PR DESCRIPTION
## Context
The dockerfile present at the root of the project does not have either a `CMD` or an `ENTRYPOINT` command.
This PR fixes it.

## Related Issue
- https://github.com/chapel-lang/chapel/issues/25955