### PR TITLE
exclude versionButton.php from rsync command

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -214,6 +214,6 @@ jobs:
           rm -f py-modindex.html
           # Remove all hidden files except .htaccess
           find . -maxdepth 1 -type f -name ".*" ! -name ".htaccess" -exec rm -f {} +
-          rsync -avz --cvs-exclude --delete --relative --dry-run . ${{ secrets.WEBSITE_USER }}@${{ secrets.WEBSITE_URL }}:${{ secrets.WEBSITE_PATH }}
+          rsync -avz --cvs-exclude --delete --relative --exclude="versionButton.php" --dry-run . ${{ secrets.WEBSITE_USER }}@${{ secrets.WEBSITE_URL }}:${{ secrets.WEBSITE_PATH }}
           rm ~/.ssh/id_rsa
           rm ~/.ssh/known_hosts


### PR DESCRIPTION
This updates the GHCI workflow to stop deleting the `versionButton.php` file on the remote side.

Since https://github.com/chapel-lang/chapel/pull/26670 removed `versionButton.php`, `rsync` wants to delete it now since it doesn't exist on the source side. This adds an `exclude` option to the `rsync` command to ignore it.