### PR TITLE
Reduce the problem size if there are co-locales

### DIFF
--- a/test/scan/scanPerf.ml-execopts
+++ b/test/scan/scanPerf.ml-execopts
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
 
+# This test can run out of memory if there are co-locales because the amount
+# of available shared memory may be less than the amount of physical
+# memory. Until there is a better way for applications to determine how
+# much memory they should use, scale the memory fraction by the number
+# of co-locales.
+
 import os
 
 colocales = int(os.getenv('CHPL_RT_LOCALES_PER_NODE', "1"))

--- a/test/scan/scanPerf.ml-execopts
+++ b/test/scan/scanPerf.ml-execopts
@@ -1,1 +1,7 @@
---printTiming --printArray=false --memFraction=4
+#!/usr/bin/env python3
+
+import os
+
+colocales = int(os.getenv('CHPL_RT_LOCALES_PER_NODE', "1"))
+fraction = 4 * colocales
+print(f"--printTiming --printArray=false --memFraction={fraction}")

--- a/test/scan/scanPerf.ml-execopts
+++ b/test/scan/scanPerf.ml-execopts
@@ -5,6 +5,9 @@
 # memory. Until there is a better way for applications to determine how
 # much memory they should use, scale the memory fraction by the number
 # of co-locales.
+#
+# This should be revisited when
+# https://github.com/chapel-lang/chapel/issues/26786 has been resolved.
 
 import os
 


### PR DESCRIPTION
Co-locales necessarily share physical memory, requiring a proportionally smaller problem size.