### PR TITLE
Make sure to use 16 compute nodes in colocale performance testing

### DIFF
--- a/util/cron/test-perf.hpe-apollo-hdr.gasnet-ibv.fast.colo-nopshm.bash
+++ b/util/cron/test-perf.hpe-apollo-hdr.gasnet-ibv.fast.colo-nopshm.bash
@@ -18,7 +18,10 @@ perf_hpe_apollo_args="-performance-configs gn-ibv-fast:v,gn-ibv-fast-colo:v,gn-i
 
 export CHPL_GASNET_SEGMENT=fast
 export GASNET_PHYSMEM_MAX="0.90"
+
 export CHPL_RT_LOCALES_PER_NODE=2
+export CHPL_START_TEST_ARGS="--numlocales=32"
+
 export CHPL_GASNET_MORE_CFG_OPTIONS=--disable-pshm
 
 nightly_args="${nightly_args} -no-buildcheck"

--- a/util/cron/test-perf.hpe-apollo-hdr.gasnet-ibv.fast.colo.bash
+++ b/util/cron/test-perf.hpe-apollo-hdr.gasnet-ibv.fast.colo.bash
@@ -18,7 +18,10 @@ perf_hpe_apollo_args="-performance-configs gn-ibv-fast:v,gn-ibv-fast-colo:v,gn-i
 
 export CHPL_GASNET_SEGMENT=fast
 export GASNET_PHYSMEM_MAX="0.90"
+
 export CHPL_RT_LOCALES_PER_NODE=2
+export CHPL_START_TEST_ARGS="--numlocales=32"
+
 export CHPL_GASNET_MORE_CFG_OPTIONS=--enable-pshm
 
 nightly_args="${nightly_args} -no-buildcheck"


### PR DESCRIPTION
This PR passes `--numLocales=32` to `start_test` to ensure that we get 16 compute nodes in colocale performance testing.

Note that colocale testing uses `CHPL_RT_LOCALES_PER_NODE=2` to ask for colocales, which, with `-nl16` results in using 8 compute nodes.