### PR TITLE
Skip interopWithChpl.test.c if LLVM is not enabled

### DIFF
--- a/test/release/examples/primers/interopWithC.skipif
+++ b/test/release/examples/primers/interopWithC.skipif
@@ -1,4 +1,1 @@
-#!/usr/bin/env python3
-
-import os
-print(os.getenv('CHPL_TARGET_COMPILER') != 'llvm')
+CHPL_LLVM == none

--- a/test/release/examples/primers/interopWithChpl.skipif
+++ b/test/release/examples/primers/interopWithChpl.skipif
@@ -1,0 +1,1 @@
+CHPL_LLVM == none


### PR DESCRIPTION
This adds a `.skipif` for the `interopWithChpl.test.c` added yesterday in #26762 if LLVM is not enabled within the Chapel compiler.  This is necessary due to the use of 'extern' blocks within `interopWithC.chpl`, which this test relies upon.  In my original PR, I'd missed that `interopWithC.chpl` has a similar skipif, which has been guarding it from the failures that the new test hit last night.

Referring to `interopWithC.skipif` after filing this fix, I noticed that it's been checking for whether the back-end compiler is LLVM rather than whether the `chpl` compiler was built with LLVM enabled, where the former is broader than the latter (e.g., an LLVM-enabled compiler can use a C back-end but still parse `extern` blocks).  I'm fairly certain that the latter is the only case we need to skip for, and the success of `interopWithChpl.test.c` last night suggests this, so I'm updating it to similarly skip only if `CHPL_LLVM=none`.

In updating the existing slkipif, I flipped it from a Python script to our text-based check format because:
* it seems strictly simpler / lighter-weight
* I'd prefer that we minimize the use of executable scripts in cases where they're not strictly needed, both for the reasons in the previous point and (to an extent) to minimize the number of things that a user might be expected to execute or that malicious code could potentially be injected.
* the fact that this example appears in the release underscores the previous points for me ("don't play an ace when a two will do")
* I like keeping the two scripts in sync since the two tests are tightly intertwined