### PR TITLE
Add one more error checking in slurm-srun sbatch code path

### DIFF
--- a/runtime/src/launch/slurm-srun/launch-slurm-srun.c
+++ b/runtime/src/launch/slurm-srun/launch-slurm-srun.c
@@ -376,6 +376,11 @@ static char* chpl_launch_create_command(int argc, char* argv[],
     const int ret = snprintf(slurmFilename, filename_size, "%s%d",
                              baseSBATCHFilename, (int)mypid);
 
+    if (ret <= 0) {
+      chpl_internal_error("An unexpected error occured while generating \
+                          sbatch filename");
+    }
+
     // open the batch file and create the header
 
     slurmFile = fopen(slurmFilename, "w");


### PR DESCRIPTION
This came up as an unused variable error on `ret`, which is something I added for debugging. But then the debugging code is removed, leaving the variable unused. This PR adds proper error checking based on that variable instead of removing it.

Locally was able to build the runtime with `CHPL_LAUNCHER=slurm-srun`