### PR TITLE
Save raw output from performance test timeout

### DIFF
--- a/test/optimizations/autoAggregation/perf/autoAggNegativeImpact.prediff
+++ b/test/optimizations/autoAggregation/perf/autoAggNegativeImpact.prediff
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-echo CHPL_RT_CALL_STACK_SIZE=1m
+
 if [[ $CHPL_TARGET_PLATFORM == hpe-apollo ]]; then
-    echo CHPL_LAUNCHCMD_DEBUG=1
+    cp "$2" "$2".raw
 fi
+


### PR DESCRIPTION
Turn on chpl_launchCmd debugging and save the raw output on the HPE Apollo platform. This is to help with debugging a timeout of this test.