### PR TITLE
Improve location reporting for BoolLitInCondStmt

### DIFF
--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -358,7 +358,7 @@ def rules(driver: LintDriver):
         """
         Warn for boolean literals like 'true' in a conditional statement.
         """
-        return BasicRuleResult(node)
+        return BasicRuleResult(node.condition(), data=node)
 
     # TODO: at some point, we should support a fixit that removes the
     # conditions and the braces, but the way locations work right now makes
@@ -371,7 +371,7 @@ def rules(driver: LintDriver):
         """
         Remove the unused branch of a conditional statement, keeping the braces.
         """
-        node = result.node
+        node = result.data
         lines = chapel.get_file_lines(context, node)
 
         cond = node.condition()


### PR DESCRIPTION
Improves the location reporting for the linter rule BoolLitInCondStmt. The location reported is now only for the condition, which makes for much nicer linter warnings (especially when run in the LSP)

Before
<img width="1687" alt="Screenshot 2025-02-26 at 1 31 48 PM" src="https://github.com/user-attachments/assets/8163f24c-139c-4934-ba33-2e0a3334b74d" />
After
<img width="1686" alt="Screenshot 2025-02-26 at 1 31 29 PM" src="https://github.com/user-attachments/assets/4eed58fe-8c64-456a-acc2-e2b8dc79867b" />

[Reviewed by @DanilaFe]
