### PR TITLE
Fix a const-ness issue in cHelper.c

### DIFF
--- a/test/release/examples/primers/cHelper.c
+++ b/test/release/examples/primers/cHelper.c
@@ -15,7 +15,7 @@ int sum(int a, int b){
     return a+b;
 }
 
-int sumArray(int64_t a[], int size){
+int sumArray(const int64_t a[], int size){
     int i;
     int retVal =0;
     for(i=0; i<size; ++i){

--- a/test/release/examples/primers/cHelper.h
+++ b/test/release/examples/primers/cHelper.h
@@ -7,7 +7,7 @@ extern uint32_t y;
 typedef int myType;
 int useMyType(myType arg);
 int sum(int, int);
-int sumArray(int64_t[], int);
+int sumArray(const int64_t[], int);
 
 typedef struct {
   int64_t a;


### PR DESCRIPTION
Until yesterday, interopWithC.chpl had not been getting tested with the C back-end because its skipif was skipping if LLVM wasn't being used as the back-end compiler (rather than if LLVM was configured so that 'extern' blocks could be used).

After fixing this in https://github.com/chapel-lang/chapel/pull/26783 yesterday, we started getting a warning-as-error for certain back-end C configurations (e.g., gcc, but seemingly not clang) due to 'const'ness being discarded when passing an array out to the external 'sumArray' call.  That call wasn't modifying its array argument, so in this PR, I've added a 'const' qualifier to the routine and its prototype, which makes the issue go away.
