### PR TITLE
dyno workaround: `.type` instead of capturing type var in doAssign

### DIFF
--- a/modules/internal/BytesStringCommon.chpl
+++ b/modules/internal/BytesStringCommon.chpl
@@ -1188,7 +1188,9 @@ module BytesStringCommon {
 
     inline proc helpMe(ref lhs: t, rhs: t) {
       if compiledForSingleLocale() || rhs.locale_id == chpl_nodeID {
-        if t == string {
+        // Workaround: Switched from 't' to 'lhs.type' here as Dyno doesn't
+        // support capturing variables into nested procs yet. Anna 2025-02-27
+        if lhs.type == string {
           reinitWithNewBuffer(lhs, rhs.buff, rhs.buffLen, rhs.buffSize,
                               rhs.numCodepoints);
         }
@@ -1200,7 +1202,8 @@ module BytesStringCommon {
         var remote_buf:bufferType = nil;
         if len != 0 then
           remote_buf = bufferCopyRemote(rhs.locale_id, rhs.buff, len);
-        if t==string {
+        // Same workaround as above
+        if lhs.type == string {
           reinitWithOwnedBuffer(lhs, remote_buf, len, len+1,
                                 rhs.cachedNumCodepoints);
         }


### PR DESCRIPTION
Workaround for lack of variable capture in nested procs.

Logged in https://github.com/Cray/chapel-private/issues/6154.

[reviewer info placeholder]