### PR TITLE
Update UDP docs to mention "DNSLookup" error and `CHPL_RT_MASTERIP`

### DIFF
--- a/doc/rst/platforms/udp.rst
+++ b/doc/rst/platforms/udp.rst
@@ -182,4 +182,9 @@ the local machine, use:
   export CHPL_RT_MASTERIP=127.0.0.1
   export CHPL_RT_WORKERIP=127.0.0.0  # may be optional
 
+I get ``worker failed DNSLookup on master host name`` error messages
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+When running in a local, oversubscribed setting, this error can often
+be resolved by setting ``CHPL_RT_MASTER_IP`` as described in the
+previous section.


### PR DESCRIPTION
This error was sufficiently unfamiliar to me that it would not have occurred to me to apply this fix, and I didn't see any indication of it in our docs, so added this section to capture it and the fix.

I've had this edit sitting in my tree for a few days now, but am pushing it tonight to fire off another smoke test.
