### PR TITLE
Abort the perf playgrounds if git operations fail

### DIFF
--- a/util/cron/common-playground.bash
+++ b/util/cron/common-playground.bash
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+function checkout_branch()
+{
+  local user=$1
+  local branch=$2
+  git branch -D $user-$branch
+  git checkout -b $user-$branch
+  git pull https://github.com/$user/chapel.git $branch
+}

--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -14,6 +14,7 @@ UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 export CHPL_TEST_PERF_CONFIG_NAME='chapcs'
 
 source $UTIL_CRON_DIR/common-perf.bash
+source $UTIL_CRON_DIR/common-playground.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground"
 
@@ -31,9 +32,9 @@ GITHUB_BRANCH=qthread
 SHORT_NAME=qthread122
 START_DATE=02/21/25
 
-git branch -D $GITHUB_USER-$GITHUB_BRANCH
-git checkout -b $GITHUB_USER-$GITHUB_BRANCH
-git pull https://github.com/$GITHUB_USER/chapel.git $GITHUB_BRANCH
+set -e
+checkout_branch $GITHUB_USER $GITHUB_BRANCH
+set +x
 
 perf_args="-performance-description $SHORT_NAME -performance-configs default:v,$SHORT_NAME:v -sync-dir-suffix $SHORT_NAME"
 perf_args="${perf_args} -numtrials 1 -startdate $START_DATE"

--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -34,7 +34,7 @@ START_DATE=02/21/25
 
 set -e
 checkout_branch $GITHUB_USER $GITHUB_BRANCH
-set +x
+set +e
 
 perf_args="-performance-description $SHORT_NAME -performance-configs default:v,$SHORT_NAME:v -sync-dir-suffix $SHORT_NAME"
 perf_args="${perf_args} -numtrials 1 -startdate $START_DATE"

--- a/util/cron/test-perf.hpe-apollo-hdr.gasnet-ibv.playground.bash
+++ b/util/cron/test-perf.hpe-apollo-hdr.gasnet-ibv.playground.bash
@@ -38,9 +38,9 @@ GITHUB_BRANCH=gasnet
 SHORT_NAME=gasnet-snapshot
 START_DATE=02/27/25
 
-git branch -D $GITHUB_USER-$GITHUB_BRANCH
-git checkout -b $GITHUB_USER-$GITHUB_BRANCH
-git pull https://github.com/$GITHUB_USER/chapel.git $GITHUB_BRANCH
+set -e
+checkout_branch $GITHUB_USER $GITHUB_BRANCH
+set +x
 
 nightly_args="${nightly_args} -no-buildcheck"
 # don't use `perf_hpe_apollo_args`, the settings are overwritten here

--- a/util/cron/test-perf.hpe-apollo-hdr.gasnet-ibv.playground.bash
+++ b/util/cron/test-perf.hpe-apollo-hdr.gasnet-ibv.playground.bash
@@ -40,7 +40,7 @@ START_DATE=02/27/25
 
 set -e
 checkout_branch $GITHUB_USER $GITHUB_BRANCH
-set +x
+set +e
 
 nightly_args="${nightly_args} -no-buildcheck"
 # don't use `perf_hpe_apollo_args`, the settings are overwritten here


### PR DESCRIPTION
Aborts the perf playgrounds if any of the git operations to apply an external branch fail

[Reviewed by @arifthpe]