### PR TITLE
Add Fedora 41 to portability testing

### DIFF
--- a/util/devel/test/apptainer/current/fedora-41-nollvm/image.def
+++ b/util/devel/test/apptainer/current/fedora-41-nollvm/image.def
@@ -1,0 +1,11 @@
+BootStrap: docker
+From: quay.io/fedora/fedora:41
+
+%files
+    ../../provision-scripts/* /provision-scripts/
+
+%post
+    /provision-scripts/dnf-deps.sh
+
+%runscript
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/apptainer/current/fedora-41/image.def
+++ b/util/devel/test/apptainer/current/fedora-41/image.def
@@ -1,0 +1,13 @@
+BootStrap: docker
+From: quay.io/fedora/fedora:41
+
+%files
+    ../../provision-scripts/* /provision-scripts/
+
+%post
+    /provision-scripts/dnf-deps.sh
+    # installs llvm / clang version ???
+    /provision-scripts/dnf-llvm.sh
+
+%runscript
+    ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/vagrant/README-distro-timelines.txt
+++ b/util/devel/test/vagrant/README-distro-timelines.txt
@@ -95,7 +95,9 @@ x 37 EOL Nov 2023
 x 38 EOL May 2024
 x 39 EOL Nov 2024
   40 EOL May 2025
-  41 release Oct 2024
+  41 EOL Nov 2025
+  42 release Apr 2025
+  43 release Nov 2025
 
 FreeBSD -- see https://www.freebsd.org/security/unsupported.html
         -- and https://app.vagrantup.com/freebsd


### PR DESCRIPTION
This PR adds apptainer image definition files for Fedora 41 for use in portability testing.

Reviewed by @arezaii - thanks!