### PR TITLE
Enable runtime checks in Arkouda testing

### DIFF
--- a/util/cron/test-hpe-apollo-hdr.arkouda.bash
+++ b/util/cron/test-hpe-apollo-hdr.arkouda.bash
@@ -11,7 +11,7 @@ export ARKOUDA_DEP_DIR=/hpelustre/chapelu/arkouda-deps
 export ARKOUDA_SKIP_CHECK_DEPS=true
 
 export CHPL_TEST_ARKOUDA_PERF=false
-export ARKOUDA_QUICK_COMPILE=true
+export ARKOUDA_DEVELOPER=true
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="hpe-apollo-hdr.arkouda"
 

--- a/util/cron/test-hpe-apollo-hdr.arkouda.release.bash
+++ b/util/cron/test-hpe-apollo-hdr.arkouda.release.bash
@@ -11,7 +11,7 @@ export ARKOUDA_DEP_DIR=/hpelustre/chapelu/arkouda-deps
 export ARKOUDA_SKIP_CHECK_DEPS=true
 
 export CHPL_TEST_ARKOUDA_PERF=false
-export ARKOUDA_QUICK_COMPILE=true
+export ARKOUDA_DEVELOPER=true
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="hpe-apollo-hdr.arkouda.release"
 


### PR DESCRIPTION
This PR switches from `ARKOUDA_QUICK_COMPILE` to `ARKOUDA_DEVELOPER` in Arkouda testing. The effect is that we explicitly throw in `--checks` to make sure to catch errors.