### PR TITLE
Move new Arkouda test configs to the master branch

### DIFF
--- a/util/cron/test-hpe-apollo-hdr.arkouda.bash
+++ b/util/cron/test-hpe-apollo-hdr.arkouda.bash
@@ -4,9 +4,6 @@
 
 UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 
-export ARKOUDA_URL=https://github.com/e-kayrakli/arkouda.git
-export ARKOUDA_BRANCH=server-util-pbs
-
 export ARKOUDA_DEP_DIR=/hpelustre/chapelu/arkouda-deps
 export ARKOUDA_SKIP_CHECK_DEPS=true
 

--- a/util/cron/test-hpe-apollo-hdr.arkouda.release.bash
+++ b/util/cron/test-hpe-apollo-hdr.arkouda.release.bash
@@ -4,9 +4,6 @@
 
 UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 
-export ARKOUDA_URL=https://github.com/e-kayrakli/arkouda.git
-export ARKOUDA_BRANCH=server-util-pbs
-
 export ARKOUDA_DEP_DIR=/hpelustre/chapelu/arkouda-deps
 export ARKOUDA_SKIP_CHECK_DEPS=true
 

--- a/util/cron/test-perf.hpe-apollo-hdr.arkouda.bash
+++ b/util/cron/test-perf.hpe-apollo-hdr.arkouda.bash
@@ -4,9 +4,6 @@
 
 UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 
-export ARKOUDA_URL=https://github.com/e-kayrakli/arkouda.git
-export ARKOUDA_BRANCH=server-util-pbs
-
 export ARKOUDA_DEP_DIR=/hpelustre/chapelu/arkouda-deps
 export ARKOUDA_SKIP_CHECK_DEPS=true
 

--- a/util/cron/test-perf.hpe-apollo-hdr.arkouda.colo.bash
+++ b/util/cron/test-perf.hpe-apollo-hdr.arkouda.colo.bash
@@ -5,9 +5,6 @@
 
 UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 
-export ARKOUDA_URL=https://github.com/e-kayrakli/arkouda.git
-export ARKOUDA_BRANCH=server-util-pbs
-
 export ARKOUDA_DEP_DIR=/hpelustre/chapelu/arkouda-deps
 export ARKOUDA_SKIP_CHECK_DEPS=true
 

--- a/util/cron/test-perf.hpe-apollo-hdr.arkouda.release.bash
+++ b/util/cron/test-perf.hpe-apollo-hdr.arkouda.release.bash
@@ -4,9 +4,6 @@
 
 UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 
-export ARKOUDA_URL=https://github.com/e-kayrakli/arkouda.git
-export ARKOUDA_BRANCH=server-util-pbs
-
 export ARKOUDA_DEP_DIR=/hpelustre/chapelu/arkouda-deps
 export ARKOUDA_SKIP_CHECK_DEPS=true
 

--- a/util/cron/test-perf.hpe-apollo-hdr.arkouda.release.colo.bash
+++ b/util/cron/test-perf.hpe-apollo-hdr.arkouda.release.colo.bash
@@ -5,9 +5,6 @@
 
 UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 
-export ARKOUDA_URL=https://github.com/e-kayrakli/arkouda.git
-export ARKOUDA_BRANCH=server-util-pbs
-
 export ARKOUDA_DEP_DIR=/hpelustre/chapelu/arkouda-deps
 export ARKOUDA_SKIP_CHECK_DEPS=true
 


### PR DESCRIPTION
https://github.com/Bears-R-Us/arkouda/pull/4088 was merged in couple of days ago. Now we can start testing the `master` Arkouda branch in the new configs. This PR removes specific fork/branch from testing scripts.