### PR TITLE
Fix a regression introduced in #26791

### DIFF
--- a/runtime/src/comm/gasnet/comm-gasnet-ex.c
+++ b/runtime/src/comm/gasnet/comm-gasnet-ex.c
@@ -1050,6 +1050,11 @@ void chpl_comm_post_task_init(void) {
     }
   }
   if (verbosity >= 2) { // print segment size information for each locale
+  #if GASNET_SEGMENT_EVERYTHING
+    if (!chpl_nodeID) {
+      printf("GASNet segment everything.\n");
+    }
+  #else
     char size_str[80], request_str[80];
     uintptr_t size = gex_Segment_QuerySize(mysegment);
     gasnett_format_number(size, size_str, sizeof(size_str), 1);
@@ -1061,6 +1066,7 @@ void chpl_comm_post_task_init(void) {
       strcat(request_str, ")");
     } else request_str[0] = '\0';
     printf("%i: GASNet segment size: %s%s\n", chpl_nodeID, size_str, request_str);
+  #endif
   }
 }
 


### PR DESCRIPTION
PR #26791 inadvertently introduced a segfault for `verbosity >= 2` and `CHPL_GASNET_SEGMENT=everything`.

In GASNET_SEGMENT_EVERYTHING mode, we don't have a real GASNet segment, and the attempt to invoke `gex_Segment_QuerySize` on the invalid segment introduced by #26791 was causing a segfault.