### PR TITLE
Begin the process of (potentially) retiring the testVFlag/testVerboseFlag tests

### DIFF
--- a/test/multilocale/numLocales/bradc/testVFlag.skipif
+++ b/test/multilocale/numLocales/bradc/testVFlag.skipif
@@ -1,1 +1,3 @@
 CHPL_LAUNCHER == slurm-gasnetrun_ibv
+CHPL_LAUNCHER == slurm-srun
+CHPL_COMM == gasnet

--- a/test/multilocale/numLocales/bradc/testVerboseFlag.skipif
+++ b/test/multilocale/numLocales/bradc/testVerboseFlag.skipif
@@ -1,1 +1,3 @@
 CHPL_LAUNCHER == slurm-gasnetrun_ibv
+CHPL_LAUNCHER == slurm-srun
+CHPL_COMM == gasnet


### PR DESCRIPTION
This pair of tests checks that `-v` / `--verbose` work as expected in Chapel multilocale programs.  When the tests were added, the only thing verbose mode did was to print out a little roll call of the nodes as they started running, which made it very portable and worth testing.  Since then, verbose mode has also caused aspects of the runtime, like Qthreads and GASNet or libfabric, to also print out additional information about their startup, along with the launcher commands being executed.  As a result, the logic around these tests to keep them working (either screening for such information or passing over it) has similarly grown, and grown far more complex.

Most recently, we've seen failures in slurm-srun testing due to Vass's bug-fix PR that quotes additional arguments in:

https://github.com/chapel-lang/chapel/pull/26450

and then failures in GASNet testing due to the new capability to print out the segment size/type in:

https://github.com/chapel-lang/chapel/pull/26791

and

https://github.com/chapel-lang/chapel/pull/26811

Here, I'm skipping over these configurations for the time being as a potential stepping stone toward retiring these tests altogether, or only testing them in CHPL_COMM=none, CHPL_LAUNCHER=none mode.

Another approach would be to preserve the rollcall behavior, either by:

* introducing multiple verbosity levels
* introducing a `--rollcall` flag
* having the runtime startup information be controlled by a separate flag like `--debug`, `--devel` or possibly just CHPL_DEVELOPER

The downsides to some of these approaches are that there's the potential for flags like these to interfere with configs/flags that the user wants to support, which makes the "CHPL_DEVELOPER" approach most attractive to me, and the "multiple verbosity levels" next most attractive.

In any case, rather than taking a stance on this design, this PR is intended mostly to quiet the failing cases for the time being and to pave the way for further reducing the maintenance burden going forward that these tests have unfortunately, unintentionally, and gradually added over time.

Resolves https://github.com/Cray/chapel-private/issues/7010
