### PR TITLE
Attempted fixes to both chapcs and apollo playgrounds

### DIFF
--- a/util/cron/common-playground.bash
+++ b/util/cron/common-playground.bash
@@ -6,5 +6,5 @@ function checkout_branch()
   local branch=$2
   git branch -D $user-$branch
   git checkout -b $user-$branch
-  git pull https://github.com/$user/chapel.git $branch
+  git pull --no-rebase https://github.com/$user/chapel.git $branch
 }

--- a/util/cron/test-perf.hpe-apollo-hdr.gasnet-ibv.playground.bash
+++ b/util/cron/test-perf.hpe-apollo-hdr.gasnet-ibv.playground.bash
@@ -8,6 +8,7 @@ export CHPL_TEST_PERF_SUBDIR="hpe-apollo"
 export CHPL_TEST_PERF_CONFIG_NAME='16-node-apollo-hdr'
 
 source $UTIL_CRON_DIR/common-perf.bash
+source $UTIL_CRON_DIR/common-playground.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.hpe-apollo-hdr.gasnet-ibv.playground"
 


### PR DESCRIPTION
In #26804 which was merged last night, it appears that a `source $UTIL_CRON_DIR/common-playground.bash` was forgotten, which caused the new subroutine `checkout_branch()` not to be available to be called. This adds that `source`, similar to `test-perf.chapcs.playground.bash` in hopes of resolving it in the next run.

The chapcs playground also didn't run last night, due to getting the standard "divergent branch" error that's common in newer versions of `git` (possibly because these are the first playgrounds we've run on chapcs since the OS upgrade).  So I've added the `--no-rebase` flag to the `git pull` command in order to get the traditional/historical "merge" behavior.
