### PR TITLE
Don't free getenv result

### DIFF
--- a/modules/packages/CopyAggregation.chpl
+++ b/modules/packages/CopyAggregation.chpl
@@ -377,7 +377,7 @@ module AggregationPrimitives {
     extern proc getenv(name : c_ptrConst(c_char)) : c_ptrConst(c_char);
     const envValue = getenv(name.localize().c_str());
     const len = strLen(envValue);
-    const strval = try! string.createAdoptingBuffer(envValue, length=len);
+    const strval = try! string.createCopyingBuffer(envValue, length=len);
     if strval.isEmpty() { return default; }
     return try! strval: int;
   }


### PR DESCRIPTION
`getEnvInt` calls `createAdoptingBuffer` with the C string returned by `getenv`. It then returns the string cast as an int which frees the string. `getenv` returns a string constant, so this results in the free of an address that was not allocated, resulting in memory corruption. Calling `createCopyingBuffer` does not free the string when `getEnvInt` returns.