### PR TITLE
bundle docs in CI step to preserve symlinks

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,12 +48,12 @@ jobs:
       # also builds chapel-py so those docs are included
       run: |
         ./util/buildRelease/smokeTest quickstart chapel-py docs
+        tar -cvf docs.tar.gz -C doc/html .
     - name: upload docs
       uses: actions/upload-artifact@v4
       with:
         name: documentation
-        path: doc/html
-        include-hidden-files: true
+        path: docs.tar.gz
 
   make_mason:
     runs-on: ubuntu-latest
@@ -209,11 +209,13 @@ jobs:
 
       - name: push docs
         run: |
+          echo "extract docs"
+          tar -xvf docs.tar.gz
           echo "Publish module docs to web server"
           # py-modindex.html is not needed
           rm -f py-modindex.html
           # Remove all hidden files except .htaccess
           find . -maxdepth 1 -type f -name ".*" ! -name ".htaccess" -exec rm -f {} +
-          rsync -avz --cvs-exclude --delete --relative --exclude="versionButton.php" --dry-run . ${{ secrets.WEBSITE_USER }}@${{ secrets.WEBSITE_URL }}:${{ secrets.WEBSITE_PATH }}
+          rsync -avz --cvs-exclude --delete --relative --dry-run . ${{ secrets.WEBSITE_USER }}@${{ secrets.WEBSITE_URL }}:${{ secrets.WEBSITE_PATH }}
           rm ~/.ssh/id_rsa
           rm ~/.ssh/known_hosts


### PR DESCRIPTION
This modifies the CI process of uploading the documentation using `upload-artifact` action to include symlinks that don't resolve. The behavior of `upload-artifact` is that it ignores broken symlinks, so the changes to `versionButton.php` that made it a symlink also caused it to stop being included in the docs archive from the `upload-artifact` action.

The workaround is to have tar bundle the `docs/html` directory and then have the `upload-artifact` action upload that instead of the `docs/html` directory. This preserves the symlink, and performing a `diff -r` on the resulting folders shows the only difference is that the one bundled with tar includes `versionButton.php`.

CI change only - Not reviewed