### PR TITLE
dyno: More progress on the typed converter

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -2723,15 +2723,22 @@ void AggregateType::buildCopyInitializer() {
     SET_LINENO(this);
 
     bool isGeneric = false;
-    // If this type is generic, then the 'other' formal needs to be generic as
-    // well
-    // TODO: Why can't we use 'fieldIsGeneric' here?
-    for_fields(fieldDefExpr, this) {
-      if (VarSymbol* field = toVarSymbol(fieldDefExpr)) {
-        if (field->hasFlag(FLAG_SUPER_CLASS) == false) {
-          if (field->hasFlag(FLAG_PARAM) || field->isType() ||
-              (field->defPoint->init == NULL && field->defPoint->exprType == NULL)) {
-            isGeneric = true;
+
+    // If the function has this flag, it was created by the frontend and
+    // is fully resolved even if it doesn't have all the information the
+    // old resolver normally expects to find.
+    if (!this->symbol->hasFlag(FLAG_RESOLVED_EARLY)) {
+      // If this type is generic, then the 'other' formal needs to be generic as
+      // well
+      // TODO: Why can't we use 'fieldIsGeneric' here?
+      for_fields(fieldDefExpr, this) {
+        if (VarSymbol* field = toVarSymbol(fieldDefExpr)) {
+          if (field->hasFlag(FLAG_SUPER_CLASS) == false) {
+            if (field->hasFlag(FLAG_PARAM) || field->isType() ||
+                (field->defPoint->init == NULL &&
+                 field->defPoint->exprType == NULL)) {
+              isGeneric = true;
+            }
           }
         }
       }

--- a/compiler/AST/baseAST.cpp
+++ b/compiler/AST/baseAST.cpp
@@ -411,6 +411,24 @@ ModuleSymbol* BaseAST::getModule() {
   return retval;
 }
 
+bool BaseAST::shouldNotMutateEarly() {
+  if (auto sym = toSymbol(this)) {
+    if (sym->hasFlag(FLAG_RESOLVED_EARLY)) return true;
+  }
+
+  if (auto t = toType(this)) {
+    if (t->symbol->hasFlag(FLAG_RESOLVED_EARLY)) return true;
+  }
+
+  // Check to see if the AST is in a dyno-generated symbol.
+  auto mod = this->getModule();
+  auto fn = this->getFunction();
+  if (mod && mod->hasFlag(FLAG_RESOLVED_EARLY)) return true;
+  if (fn && fn->hasFlag(FLAG_RESOLVED_EARLY)) return true;
+
+  return false;
+}
+
 bool BaseAST::isRef() {
   return this->qualType().isRef();
 }

--- a/compiler/AST/view.cpp
+++ b/compiler/AST/view.cpp
@@ -658,6 +658,7 @@ void print_view_noline(BaseAST* ast) {
   fflush(stdout);
 }
 
+// TODO: Take a reference and decay it to avoid copying when debugging.
 template <typename T>
 void nprint_dyno_type(T t) {
   if constexpr(std::is_pointer<T>::value) {
@@ -681,6 +682,10 @@ void nprint_view(const chpl::uast::AstNode* x) {
 }
 
 void nprint_view(const chpl::types::Type* x) {
+  nprint_dyno_type(x);
+}
+
+void nprint_view(const chpl::types::QualifiedType& x) {
   nprint_dyno_type(x);
 }
 

--- a/compiler/AST/view.cpp
+++ b/compiler/AST/view.cpp
@@ -658,13 +658,63 @@ void print_view_noline(BaseAST* ast) {
   fflush(stdout);
 }
 
+template <typename T>
+void nprint_dyno_type(T t) {
+  if constexpr(std::is_pointer<T>::value) {
+    // Special-casing pointer types.
+    if (t == nullptr) {
+      printf("<NULL>");
+    } else {
+      t->dump();
+    }
+  } else {
+    // Not a pointer type.
+    t.dump();
+  }
+
+  fflush(stdout);
+}
+
+// TODO: A nice one-liner we can use to force instantiation for a type?
+void nprint_view(const chpl::uast::AstNode* x) {
+  nprint_dyno_type(x);
+}
+
+void nprint_view(const chpl::types::Type* x) {
+  nprint_dyno_type(x);
+}
+
+void nprint_view(const chpl::resolution::CallInfo& x) {
+  nprint_dyno_type(x);
+}
+
+void nprint_view(const chpl::resolution::ResolvedExpression* x) {
+  nprint_dyno_type(x);
+}
+
+void nprint_view(const chpl::resolution::TypedFnSignature* x) {
+  nprint_dyno_type(x);
+}
+
+void nprint_view(const chpl::resolution::UntypedFnSignature* x) {
+  nprint_dyno_type(x);
+}
+
+void nprint_view(const chpl::ID& x) {
+  nprint_dyno_type(x);
+}
+
+void nprint_view(const chpl::UniqueString& x) {
+  nprint_dyno_type(x);
+}
+
 void nprint_view(int id) {
   if (BaseAST* ast = aidWithError(id, "nprint_view"))
     nprint_view(ast);
 }
 
 void nprint_view(BaseAST* ast) {
-  if (ast==NULL) {
+  if (ast == nullptr) {
     printf("<NULL>");
   } else {
     type_nprint_view(ast);

--- a/compiler/AST/view.cpp
+++ b/compiler/AST/view.cpp
@@ -658,21 +658,19 @@ void print_view_noline(BaseAST* ast) {
   fflush(stdout);
 }
 
-// TODO: Take a reference and decay it to avoid copying when debugging.
 template <typename T>
-void nprint_dyno_type(T t) {
-  if constexpr(std::is_pointer<T>::value) {
-    // Special-casing pointer types.
-    if (t == nullptr) {
-      printf("<NULL>");
-    } else {
-      t->dump();
-    }
+void nprint_dyno_type(const T* t) {
+  if (t == nullptr) {
+    printf("<NULL>");
   } else {
-    // Not a pointer type.
-    t.dump();
+    t->dump();
   }
+  fflush(stdout);
+}
 
+template <typename T>
+void nprint_dyno_type(const T& t) {
+  t.dump();
   fflush(stdout);
 }
 

--- a/compiler/include/baseAST.h
+++ b/compiler/include/baseAST.h
@@ -262,6 +262,12 @@ public:
   int               linenum()                                    const;
   const char*       stringLoc()                                  const;
 
+  // This AST is a symbol with the flag 'FLAG_RESOLVED_EARLY' or it is
+  // contained in a symbol marked with that flag. It should be handled
+  // differently by compiler passes prior to the end of 'callDestructors',
+  // in particular it should not be mutated by those passes.
+  bool              shouldNotMutateEarly();
+
   bool              isRef();
   bool              isWideRef();
   bool              isRefOrWideRef();

--- a/compiler/include/view.h
+++ b/compiler/include/view.h
@@ -25,6 +25,11 @@
 #include "vec.h"
 #include <vector>
 
+// Include 'dyno' headers to add 'nprint' overloads for 'dyno' types.
+#include <chpl/uast/all-uast.h>
+#include <chpl/resolution/resolution-types.h>
+#include <chpl/types/all-types.h>
+
 class GenRet;
 class ResolutionCandidate;
 
@@ -61,6 +66,16 @@ void nprint_view(int id);
 void nprint_view(BaseAST* ast);
 void nprint_view(GenRet& gen); // defined in codegen/codegen.cpp
 void nprint_view_noline(BaseAST* ast);
+
+// Add overloads for 'dyno' stuff, as needed.
+void nprint_view(const chpl::uast::AstNode* x);
+void nprint_view(const chpl::types::Type* x);
+void nprint_view(const chpl::resolution::CallInfo& x);
+void nprint_view(const chpl::resolution::ResolvedExpression* x);
+void nprint_view(const chpl::resolution::TypedFnSignature* x);
+void nprint_view(const chpl::resolution::UntypedFnSignature* x);
+void nprint_view(const chpl::ID& x);
+void nprint_view(const chpl::UniqueString& x);
 
 void mark_view(BaseAST* ast, int id);
 

--- a/compiler/include/view.h
+++ b/compiler/include/view.h
@@ -70,6 +70,7 @@ void nprint_view_noline(BaseAST* ast);
 // Add overloads for 'dyno' stuff, as needed.
 void nprint_view(const chpl::uast::AstNode* x);
 void nprint_view(const chpl::types::Type* x);
+void nprint_view(const chpl::types::QualifiedType& x);
 void nprint_view(const chpl::resolution::CallInfo& x);
 void nprint_view(const chpl::resolution::ResolvedExpression* x);
 void nprint_view(const chpl::resolution::TypedFnSignature* x);

--- a/compiler/passes/convert-typed-uast.cpp
+++ b/compiler/passes/convert-typed-uast.cpp
@@ -3884,17 +3884,18 @@ void TConverter::ActualConverter::prepareCalledFnConversionState() {
 
   // Prepare the state block for the called function.
   // TODO: Helper function?
-  calledFnState_ = {
-    .symbol                 = parsing::idToAst(context, rf->id()),
-    .fnSymbol               = tc_->findOrConvertFunction(rf),
-    .moduleSymbol           = moduleSymbol,
-    .retVar                 = nullptr,
-    .epilogueLabel          = nullptr,
-    .resolvedFunction       = rf,
-    .actualConverter        = this,
-    .moduleFromLibraryFile  = moduleSymbol->hasFlag(FLAG_PRECOMPILED),
-    .topLevelModTag         = moduleSymbol->modTag
-  };
+  // NOTE: Also, GCC is not happy with an initializer-list, here.
+  auto& s = calledFnState_;
+  s = {};
+  s.symbol                 = parsing::idToAst(context, rf->id());
+  s.fnSymbol               = tc_->findOrConvertFunction(rf);
+  s.moduleSymbol           = moduleSymbol;
+  s.retVar                 = nullptr;
+  s.epilogueLabel          = nullptr;
+  s.resolvedFunction       = rf;
+  s.actualConverter        = this;
+  s.moduleFromLibraryFile  = moduleSymbol->hasFlag(FLAG_PRECOMPILED);
+  s.topLevelModTag         = moduleSymbol->modTag;
 }
 
 void TConverter::ActualConverter::convertActual(const FormalActual& fa) {

--- a/compiler/passes/convert-typed-uast.cpp
+++ b/compiler/passes/convert-typed-uast.cpp
@@ -3837,7 +3837,6 @@ void TConverter::ActualConverter::convertActual(const FormalActual& fa) {
   std::swap(calledFnState_, tc_->cur);
   tc_->pushBlock(tc_->cur.moduleSymbol->block);
 
-
   ResolutionContext rcval(context);
   ResolvedVisitor<TConverter> rvCalledFn(&rcval, fn, *tc_, rr);
 
@@ -3871,8 +3870,10 @@ convertAndInsertActuals(CallExpr* call, int fromMappingIdx) {
 
   tc_->enterCallActuals(call);
 
-  INT_ASSERT(0 <= fromMappingIdx && fromMappingIdx < actualState_.size());
-
+  if (!actualState_.empty()) {
+    const int hi = (int) actualState_.size();
+    INT_ASSERT(0 <= fromMappingIdx && fromMappingIdx < hi);
+  }
   // Convert each formal/actual mapping starting from the one requested.
   int i = 0;
   for (const FormalActual& fa : fam_.byFormals()) {

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -288,6 +288,8 @@ void normalize() {
 
   // perform some checks on destructors
   forv_Vec(FnSymbol, fn, gFnSymbols) {
+    if (shouldSkipNormalizing(fn)) continue;
+
     if (fn->hasFlag(FLAG_DESTRUCTOR)) {
       if (fn->formals.length           <  2 ||
           fn->getFormal(1)->typeInfo() != gMethodToken->typeInfo()) {

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -135,21 +135,7 @@ static TypeSymbol* expandTypeAlias(SymExpr* se);
 ************************************** | *************************************/
 
 static bool shouldSkipNormalizing(BaseAST* ast) {
-  if (auto sym = toSymbol(ast)) {
-    if (sym->hasFlag(FLAG_RESOLVED_EARLY)) return true;
-  }
-
-  if (auto t = toType(ast)) {
-    if (t->symbol->hasFlag(FLAG_RESOLVED_EARLY)) return true;
-  }
-
-  // Check to see if the AST is in a dyno-generated symbol.
-  auto mod = ast->getModule();
-  auto fn = ast->getFunction();
-  if (mod && mod->hasFlag(FLAG_RESOLVED_EARLY)) return true;
-  if (fn && fn->hasFlag(FLAG_RESOLVED_EARLY)) return true;
-
-  return false;
+  return ast->shouldNotMutateEarly();
 }
 
 static void handleSharedCArrays() {

--- a/compiler/resolution/addAutoDestroyCalls.cpp
+++ b/compiler/resolution/addAutoDestroyCalls.cpp
@@ -70,6 +70,8 @@ void addAutoDestroyCalls() {
   LastMentionMap lmm;
 
   forv_Vec(FnSymbol, fn, gFnSymbols) {
+    if (fn->hasFlag(FLAG_RESOLVED_EARLY)) continue;
+
     if (fn->hasFlag(FLAG_EXTERN))
       continue; // no need to add auto-destroy in extern fn prototypes
 

--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -1079,7 +1079,7 @@ static void insertGlobalAutoDestroyCalls() {
 
       inited.clear();
       initedSet.clear();
-      if (mod->initFn != NULL) {
+      if (mod->initFn && !mod->initFn->hasFlag(FLAG_RESOLVED_EARLY)) {
         collectGlobals(mod, mod->initFn->body, inited, initedSet);
       } else {
         // Collect variables from modules without initFn

--- a/frontend/include/chpl/parsing/parsing-queries.h
+++ b/frontend/include/chpl/parsing/parsing-queries.h
@@ -512,6 +512,11 @@ bool idIsParenlessFunction(Context* context, ID id);
 bool idIsNestedFunction(Context* context, ID id);
 
 /**
+ Returns true if the ID is a nested method.
+ */
+bool idIsNestedMethod(Context* context, ID id);
+
+/**
  Returns true if the ID refers to a private declaration.
  */
 bool idIsPrivateDecl(Context* context, ID id);

--- a/frontend/include/chpl/parsing/parsing-queries.h
+++ b/frontend/include/chpl/parsing/parsing-queries.h
@@ -512,11 +512,6 @@ bool idIsParenlessFunction(Context* context, ID id);
 bool idIsNestedFunction(Context* context, ID id);
 
 /**
- Returns true if the ID is a nested method.
- */
-bool idIsNestedMethod(Context* context, ID id);
-
-/**
  Returns true if the ID refers to a private declaration.
  */
 bool idIsPrivateDecl(Context* context, ID id);
@@ -582,6 +577,13 @@ const uast::AstNode* parentAst(Context* context, const uast::AstNode* node);
   or the empty ID when given a toplevel module.
  */
 ID idToParentModule(Context* context, ID id);
+
+/**
+  Given an ID 'id', attempt to lookup the declared linkage of the composite
+  type associated with 'id'. Returns 'DEFAULT_LINKAGE' if no such AST was
+  found.
+ */
+uast::Decl::Linkage idToDeclLinkage(Context* context, ID id);
 
 /**
   Returns 'true' if ID refers to a toplevel module.

--- a/frontend/include/chpl/resolution/call-graph.h
+++ b/frontend/include/chpl/resolution/call-graph.h
@@ -30,9 +30,11 @@ namespace resolution {
 
 
 struct CalledFnOrder {
-  int depth; // depth of call graph at which this one was added
-  int index; // index in the call graph at which this one was added
+  int depth = -1; // depth of call graph at which this one was added
+  int index = -1; // index in the call graph at which this one was added
 };
+
+bool operator ==(const CalledFnOrder& x, const CalledFnOrder& y);
 
 // key: a ResolvedFunction* that was called
 // value: the depth at which that ResolvedFunction was added

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -2434,7 +2434,7 @@ class ResolvedExpression {
 
   /** for simple (non-function Identifier) cases, the ID of a NamedDecl it
    * refers to */
-  ID toId() const { return toId_; }
+  const ID& toId() const { return toId_; }
 
   /** check whether this resolution result refers to a compiler builtin like `bool`. */
   bool isBuiltin() const { return isBuiltin_; }

--- a/frontend/include/chpl/types/AnyClassType.h
+++ b/frontend/include/chpl/types/AnyClassType.h
@@ -38,7 +38,8 @@ class AnyClassType final : public ManageableType {
                      /* ID */ ID(),
                      /* name */ USTR("class"),
                      /* instantiatedFrom */ nullptr,
-                     /* subs */ SubstitutionsMap()) {
+                     /* subs */ SubstitutionsMap(),
+                     uast::Decl::DEFAULT_LINKAGE) {
   }
 
   bool contentsMatchInner(const Type* other) const override {

--- a/frontend/include/chpl/types/ArrayType.h
+++ b/frontend/include/chpl/types/ArrayType.h
@@ -40,7 +40,8 @@ class ArrayType final : public CompositeType {
             const ArrayType* instantiatedFrom,
             SubstitutionsMap subs)
     : CompositeType(typetags::ArrayType, id, name,
-                    instantiatedFrom, std::move(subs))
+                    instantiatedFrom, std::move(subs),
+                    uast::Decl::DEFAULT_LINKAGE)
   {
   }
 

--- a/frontend/include/chpl/types/BasicClassType.h
+++ b/frontend/include/chpl/types/BasicClassType.h
@@ -39,9 +39,11 @@ class BasicClassType final : public ManageableType {
   BasicClassType(ID id, UniqueString name,
                  const BasicClassType* parentType,
                  const BasicClassType* instantiatedFrom,
-                 SubstitutionsMap subs)
+                 SubstitutionsMap subs,
+                 CompositeType::Linkage linkage)
     : ManageableType(typetags::BasicClassType, id, name,
-                     instantiatedFrom, std::move(subs)),
+                     instantiatedFrom, std::move(subs),
+                     linkage),
       parentType_(parentType)
   {
     // all classes should have a parent type, except for object
@@ -63,7 +65,8 @@ class BasicClassType final : public ManageableType {
   getBasicClassType(Context* context, ID id, UniqueString name,
                     const BasicClassType* parentType,
                     const BasicClassType* instantiatedFrom,
-                    SubstitutionsMap subs);
+                    SubstitutionsMap subs,
+                    CompositeType::Linkage linkage);
 
  public:
 

--- a/frontend/include/chpl/types/CompositeType.h
+++ b/frontend/include/chpl/types/CompositeType.h
@@ -88,6 +88,7 @@ class CompositeType : public Type {
   using SubstitutionsMap = std::unordered_map<ID, types::QualifiedType>;
   using SubstitutionPair = std::pair<ID, QualifiedType>;
   using SortedSubstitutions = std::vector<SubstitutionPair>;
+  using Linkage = uast::Decl::Linkage;
 
  protected:
   ID id_;
@@ -100,13 +101,17 @@ class CompositeType : public Type {
   // If so, what types/params should we use?
   SubstitutionsMap subs_;
 
+  Linkage linkage_ = uast::Decl::DEFAULT_LINKAGE;
+
   CompositeType(typetags::TypeTag tag,
                 ID id, UniqueString name,
                 const CompositeType* instantiatedFrom,
-                SubstitutionsMap subs)
+                SubstitutionsMap subs,
+                Linkage linkage)
     : Type(tag), id_(id), name_(name),
       instantiatedFrom_(instantiatedFrom),
-      subs_(std::move(subs)) {
+      subs_(std::move(subs)),
+      linkage_(linkage) {
 
     // check instantiated only from same type of object
     CHPL_ASSERT(instantiatedFrom_ == nullptr || instantiatedFrom_->tag() == tag);
@@ -126,7 +131,8 @@ class CompositeType : public Type {
     return id_ == other->id_ &&
            name_ == other->name_ &&
            instantiatedFrom_ == other->instantiatedFrom_ &&
-           subs_ == other->subs_;
+           subs_ == other->subs_ &&
+           linkage_ == other->linkage_;
   }
 
   void compositeTypeMarkUniqueStringsInner(Context* context) const {
@@ -162,7 +168,7 @@ class CompositeType : public Type {
   UniqueString name() const { return name_; }
 
   /** Returns the linkage of the underlying uAST for this composite. */
-  uast::Decl::Linkage linkage(Context* context) const;
+  uast::Decl::Linkage linkage() const { return linkage_; }
 
   /** If this type represents an instantiated type,
       returns the type it was instantiated from.

--- a/frontend/include/chpl/types/CompositeType.h
+++ b/frontend/include/chpl/types/CompositeType.h
@@ -22,11 +22,9 @@
 
 #include "chpl/types/Type.h"
 #include "chpl/types/QualifiedType.h"
+#include "chpl/uast/Decl.h"
 
 namespace chpl {
-namespace uast {
-  class Decl;
-}
 namespace types {
 
 
@@ -162,6 +160,9 @@ class CompositeType : public Type {
 
   /** Returns the name of the uAST associated with this CompositeType */
   UniqueString name() const { return name_; }
+
+  /** Returns the linkage of the underlying uAST for this composite. */
+  uast::Decl::Linkage linkage(Context* context) const;
 
   /** If this type represents an instantiated type,
       returns the type it was instantiated from.

--- a/frontend/include/chpl/types/DomainType.h
+++ b/frontend/include/chpl/types/DomainType.h
@@ -63,7 +63,8 @@ class DomainType final : public CompositeType {
              SubstitutionsMap subs,
              Kind kind)
     : CompositeType(typetags::DomainType, id, name,
-                    instantiatedFrom, std::move(subs)),
+                    instantiatedFrom, std::move(subs),
+                    uast::Decl::DEFAULT_LINKAGE),
       kind_(kind)
   {
   }

--- a/frontend/include/chpl/types/ManageableType.h
+++ b/frontend/include/chpl/types/ManageableType.h
@@ -39,8 +39,11 @@ class ManageableType : public CompositeType {
   ManageableType(typetags::TypeTag tag,
                 ID id, UniqueString name,
                 const CompositeType* instantiatedFrom,
-                SubstitutionsMap subs)
-    : CompositeType(tag, std::move(id), name, instantiatedFrom, std::move(subs)) {}
+                SubstitutionsMap subs,
+                CompositeType::Linkage linkage)
+    : CompositeType(tag, std::move(id), name, instantiatedFrom,
+                    std::move(subs),
+                    linkage) {}
 };
 
 } // end namespace types

--- a/frontend/include/chpl/types/RecordType.h
+++ b/frontend/include/chpl/types/RecordType.h
@@ -35,9 +35,11 @@ class RecordType final : public CompositeType {
  private:
   RecordType(ID id, UniqueString name,
              const RecordType* instantiatedFrom,
-             SubstitutionsMap subs)
+             SubstitutionsMap subs,
+             CompositeType::Linkage linkage)
     : CompositeType(typetags::RecordType, id, name,
-                    instantiatedFrom, std::move(subs))
+                    instantiatedFrom, std::move(subs),
+                    linkage)
   { }
 
   bool contentsMatchInner(const Type* other) const override {
@@ -51,7 +53,8 @@ class RecordType final : public CompositeType {
   static const owned<RecordType>&
   getRecordType(Context* context, ID id, UniqueString name,
                 const RecordType* instantiatedFrom,
-                SubstitutionsMap subs);
+                SubstitutionsMap subs,
+                CompositeType::Linkage linkage);
 
  public:
 

--- a/frontend/include/chpl/types/TupleType.h
+++ b/frontend/include/chpl/types/TupleType.h
@@ -45,7 +45,8 @@ class TupleType final : public CompositeType {
             SubstitutionsMap subs,
             bool isVarArgTuple)
     : CompositeType(typetags::TupleType, id, name,
-                    instantiatedFrom, std::move(subs)),
+                    instantiatedFrom, std::move(subs),
+                    uast::Decl::DEFAULT_LINKAGE),
       isVarArgTuple_(isVarArgTuple)
   {
     assert(!id.isEmpty());

--- a/frontend/include/chpl/types/UnionType.h
+++ b/frontend/include/chpl/types/UnionType.h
@@ -35,9 +35,11 @@ class UnionType final : public CompositeType {
  private:
   UnionType(ID id, UniqueString name,
             const UnionType* instantiatedFrom,
-            SubstitutionsMap subs)
+            SubstitutionsMap subs,
+            CompositeType::Linkage linkage)
     : CompositeType(typetags::UnionType, id, name,
-                    instantiatedFrom, std::move(subs))
+                    instantiatedFrom, std::move(subs),
+                    linkage)
   { }
 
   bool contentsMatchInner(const Type* other) const override {
@@ -51,7 +53,8 @@ class UnionType final : public CompositeType {
   static const owned<UnionType>&
   getUnionType(Context* context, ID id, UniqueString name,
                const UnionType* instantiatedFrom,
-               SubstitutionsMap subs);
+               SubstitutionsMap subs,
+               CompositeType::Linkage linkage);
  public:
   static const UnionType* get(Context* context, ID id, UniqueString name,
                               const UnionType* instantiatedFrom,

--- a/frontend/include/chpl/uast/Decl.h
+++ b/frontend/include/chpl/uast/Decl.h
@@ -182,6 +182,22 @@ class Decl : public AstNode {
 DECLARE_SERDE_ENUM(uast::Decl::Visibility, uint8_t);
 DECLARE_SERDE_ENUM(uast::Decl::Linkage, uint8_t);
 
+template<> struct stringify<uast::Decl::Linkage> {
+  void operator()(std::ostream& streamOut,
+                  StringifyKind stringKind,
+                  const uast::Decl::Linkage& stringMe) const {
+    switch (stringMe) {
+      case uast::Decl::Linkage::DEFAULT_LINKAGE:
+        break;
+      case uast::Decl::Linkage::EXPORT:
+        streamOut << "export";
+        break;
+      case uast::Decl::Linkage::EXTERN:
+        streamOut << "extern";
+        break;
+    }
+  }
+};
 } // end namespace chpl
 
 namespace std {

--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -1342,6 +1342,15 @@ bool idIsNestedFunction(Context* context, ID id) {
   return false;
 }
 
+bool idIsNestedMethod(Context* context, ID id) {
+  if (id.isEmpty() || !idIsMethod(context, id)) return false;
+  for (auto up = id.parentSymbolId(context); up;
+            up = up.parentSymbolId(context)) {
+    if (idIsMethod(context, up)) return true;
+  }
+  return false;
+}
+
 template <typename Predicate>
 bool idIsSymbolDefiningScope(Context* context, ID id, Predicate&& predicate) {
   if (!id.isSymbolDefiningScope()) {

--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -1307,6 +1307,13 @@ static const bool& idIsModuleScopeVarQuery(Context* context, ID id) {
   return QUERY_END(result);
 }
 
+uast::Decl::Linkage idToDeclLinkage(Context* context, ID id) {
+  auto ast = id ? parsing::idToAst(context, id) : nullptr;
+  auto decl = ast ? ast->toDecl() : nullptr;
+  auto ret = decl ? decl->linkage() : uast::Decl::DEFAULT_LINKAGE;
+  return ret;
+}
+
 bool idIsModuleScopeVar(Context* context, ID id) {
   return idIsModuleScopeVarQuery(context, id);
 }
@@ -1338,15 +1345,6 @@ bool idIsNestedFunction(Context* context, ID id) {
   for (auto up = id.parentSymbolId(context); up;
             up = up.parentSymbolId(context)) {
     if (idIsFunction(context, up) || idIsInterface(context, up)) return true;
-  }
-  return false;
-}
-
-bool idIsNestedMethod(Context* context, ID id) {
-  if (id.isEmpty() || !idIsMethod(context, id)) return false;
-  for (auto up = id.parentSymbolId(context); up;
-            up = up.parentSymbolId(context)) {
-    if (idIsMethod(context, up)) return true;
   }
   return false;
 }

--- a/frontend/lib/resolution/call-graph.cpp
+++ b/frontend/lib/resolution/call-graph.cpp
@@ -34,6 +34,10 @@ namespace resolution {
 using namespace uast;
 using namespace types;
 
+bool operator==(const CalledFnOrder& x, const CalledFnOrder& y) {
+  return x.depth == y.depth && x.index == y.index;
+}
+
 struct CalledFnCollector {
   using RV = ResolvedVisitor<CalledFnCollector>;
 

--- a/frontend/lib/types/BasicClassType.cpp
+++ b/frontend/lib/types/BasicClassType.cpp
@@ -29,13 +29,15 @@ const owned<BasicClassType>&
 BasicClassType::getBasicClassType(Context* context, ID id, UniqueString name,
                                   const BasicClassType* parentType,
                                   const BasicClassType* instantiatedFrom,
-                                  SubstitutionsMap subs) {
+                                  SubstitutionsMap subs,
+                                  CompositeType::Linkage linkage) {
   QUERY_BEGIN(getBasicClassType, context, id, name,
-              parentType, instantiatedFrom, subs);
+              parentType, instantiatedFrom, subs,
+              linkage);
 
   auto result = toOwned(new BasicClassType(id, name,
                                            parentType, instantiatedFrom,
-                                           std::move(subs)));
+                                           std::move(subs), linkage));
   return QUERY_END(result);
 }
 
@@ -47,9 +49,11 @@ BasicClassType::get(Context* context, ID id, UniqueString name,
   // getRootClassType should be used to construct RootClass
   // everything else should have a parent type.
   CHPL_ASSERT(parentType != nullptr);
+  auto linkage = parsing::idToDeclLinkage(context, id);
   return getBasicClassType(context, id, name,
                            parentType, instantiatedFrom,
-                           std::move(subs)).get();
+                           std::move(subs),
+                           linkage).get();
 }
 
 const BasicClassType*
@@ -57,10 +61,12 @@ BasicClassType::getRootClassType(Context* context) {
   ID emptyId;
   auto name = UniqueString::get(context, "RootClass");
 
+  auto linkage = uast::Decl::DEFAULT_LINKAGE;
   return getBasicClassType(context, emptyId, name,
                            /* parentType */ nullptr,
                            /* instantiatedFrom */ nullptr,
-                           SubstitutionsMap()).get();
+                           SubstitutionsMap(),
+                           linkage).get();
 }
 
 const BasicClassType*
@@ -69,10 +75,12 @@ BasicClassType::getReduceScanOpType(Context* context) {
       context, "ChapelReduce", "ReduceScanOp");
   auto objectType = getRootClassType(context);
 
+  auto linkage = uast::Decl::DEFAULT_LINKAGE;
   return getBasicClassType(context, id, name,
                            /* parentType */ objectType,
                            /* instantiatedFrom */ nullptr,
-                           SubstitutionsMap()).get();
+                           SubstitutionsMap(),
+                           linkage).get();
 }
 
 bool BasicClassType::isSubtypeOf(Context* context,

--- a/frontend/lib/types/CompositeType.cpp
+++ b/frontend/lib/types/CompositeType.cpp
@@ -93,19 +93,6 @@ sortedSubstitutionsMap(const CompositeType::SubstitutionsMap& subs) {
   return v;
 }
 
-uast::Decl::Linkage CompositeType::linkage(Context* context) const {
-  if (this->hasPragma(context, uast::PRAGMA_EXTERN)) return uast::Decl::EXTERN;
-  if (this->hasPragma(context, uast::PRAGMA_EXPORT)) return uast::Decl::EXPORT;
-  if (auto& id = this->id()) {
-    if (auto ast = parsing::idToAst(context, id)) {
-      auto decl = ast->toDecl();
-      CHPL_ASSERT(decl);
-      return decl->linkage();
-    }
-  }
-  return {};
-}
-
 void CompositeType::stringifySubstitutions(std::ostream& ss,
                                            chpl::StringifyKind stringKind,
                                            const SubstitutionsMap& subs) {

--- a/frontend/lib/types/CompositeType.cpp
+++ b/frontend/lib/types/CompositeType.cpp
@@ -93,6 +93,19 @@ sortedSubstitutionsMap(const CompositeType::SubstitutionsMap& subs) {
   return v;
 }
 
+uast::Decl::Linkage CompositeType::linkage(Context* context) const {
+  if (this->hasPragma(context, uast::PRAGMA_EXTERN)) return uast::Decl::EXTERN;
+  if (this->hasPragma(context, uast::PRAGMA_EXPORT)) return uast::Decl::EXPORT;
+  if (auto& id = this->id()) {
+    if (auto ast = parsing::idToAst(context, id)) {
+      auto decl = ast->toDecl();
+      CHPL_ASSERT(decl);
+      return decl->linkage();
+    }
+  }
+  return {};
+}
+
 void CompositeType::stringifySubstitutions(std::ostream& ss,
                                            chpl::StringifyKind stringKind,
                                            const SubstitutionsMap& subs) {

--- a/frontend/lib/types/RecordType.cpp
+++ b/frontend/lib/types/RecordType.cpp
@@ -28,11 +28,14 @@ namespace types {
 const owned<RecordType>&
 RecordType::getRecordType(Context* context, ID id, UniqueString name,
                           const RecordType* instantiatedFrom,
-                          SubstitutionsMap subs) {
-  QUERY_BEGIN(getRecordType, context, id, name, instantiatedFrom, subs);
+                          SubstitutionsMap subs,
+                          CompositeType::Linkage linkage) {
+  QUERY_BEGIN(getRecordType, context, id, name, instantiatedFrom, subs,
+              linkage);
 
   auto result = toOwned(new RecordType(id, name,
-                                       instantiatedFrom, std::move(subs)));
+                                       instantiatedFrom, std::move(subs),
+                                       linkage));
 
   return QUERY_END(result);
 }
@@ -41,8 +44,9 @@ const RecordType*
 RecordType::get(Context* context, ID id, UniqueString name,
                 const RecordType* instantiatedFrom,
                 SubstitutionsMap subs) {
+  auto linkage = parsing::idToDeclLinkage(context, id);
   return getRecordType(context, id, name,
-                       instantiatedFrom, std::move(subs)).get();
+                       instantiatedFrom, std::move(subs), linkage).get();
 }
 
 

--- a/frontend/lib/types/Type.cpp
+++ b/frontend/lib/types/Type.cpp
@@ -428,10 +428,7 @@ bool Type::needsInitDeinitCall(const Type* t) {
     // OK, can default-initialize enums to first element
     return false;
   /*
-<<<<<<< HEAD
   // TODO: Wire this up when we reintroduce the FunctionType.
-=======
->>>>>>> d95396529b (First chunk of progress towards getting 'proc main() {}' to compile)
   } else if (t->isFunctionType()) {
     return false;
   */

--- a/frontend/lib/types/Type.cpp
+++ b/frontend/lib/types/Type.cpp
@@ -428,7 +428,10 @@ bool Type::needsInitDeinitCall(const Type* t) {
     // OK, can default-initialize enums to first element
     return false;
   /*
+<<<<<<< HEAD
   // TODO: Wire this up when we reintroduce the FunctionType.
+=======
+>>>>>>> d95396529b (First chunk of progress towards getting 'proc main() {}' to compile)
   } else if (t->isFunctionType()) {
     return false;
   */

--- a/frontend/lib/types/UnionType.cpp
+++ b/frontend/lib/types/UnionType.cpp
@@ -28,11 +28,14 @@ namespace types {
 const owned<UnionType>&
 UnionType::getUnionType(Context* context, ID id, UniqueString name,
                         const UnionType* instantiatedFrom,
-                        SubstitutionsMap subs) {
-  QUERY_BEGIN(getUnionType, context, id, name, instantiatedFrom, subs);
+                        SubstitutionsMap subs,
+                        CompositeType::Linkage linkage) {
+  QUERY_BEGIN(getUnionType, context, id, name, instantiatedFrom, subs,
+              linkage);
 
   auto result = toOwned(new UnionType(id, name,
-                                      instantiatedFrom, std::move(subs)));
+                                      instantiatedFrom, std::move(subs),
+                                      linkage));
 
   return QUERY_END(result);
 }
@@ -41,8 +44,9 @@ const UnionType*
 UnionType::get(Context* context, ID id, UniqueString name,
                const UnionType* instantiatedFrom,
                SubstitutionsMap subs) {
+  auto linkage = parsing::idToDeclLinkage(context, id);
   return getUnionType(context, id, name,
-                      instantiatedFrom, std::move(subs)).get();
+                      instantiatedFrom, std::move(subs), linkage).get();
 }
 
 


### PR DESCRIPTION
This PR adds more of my contributions to the typed converter. It adds support for compiling more language features such as parenless method calls, field access, logical operator short-circuiting, default values for records, and more! We can now write fun programs like the following.

```chapel
record r {
  var x: int;
  proc method() { return x; }
}

var r1: r;
var x1 = r1.x;
var x2 = r1.method();
```

- Support inserting AST at either the statement or expression level
- Convert default-argument values for initializer calls (e.g., to support compiler-generated default-initializers)
- Fold away `param` expressions immediately in `convertExpr`
- Attach flags to generated `AggregateType`, mark them as `RESOLVED`
- Convert opaque `types::ExternType*` and attach flags to them when the `type` variable for their declaration is evaluated
- Construct default values for record types and `extern` records
- Skip default-initialization under `PRAGMA_NO_INIT`
- Convert tuple values e.g., `(x, y)`
- Convert field access expressions with explicit receivers
- Convert parenless method calls with explicit receivers
- Convert `||` and `&&` with support for short-circuiting
- Generate default values for default-argument values in compiler-generated procedures
- Convert dot expressions (e.g., `x.y`)
- Add a method to `BaseAST*` called `shouldNotMutateEarly()`

TESTING

- [x] `make -j && make check`
- [x] `make -j test-frontend`
- [x] `make -j test-cls`
- [x] `ALL` w/ `linux64`, `standard`

Reviewed by @mppf. Thanks!