### PR TITLE
Use an explicit slurm partition on test config

### DIFF
--- a/util/cron/test-hpe-cray-ex-ofi.bash
+++ b/util/cron/test-hpe-cray-ex-ofi.bash
@@ -10,6 +10,7 @@ source $UTIL_CRON_DIR/common-hpe-cray-ex.bash
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="hpe-cray-ex-ofi"
 export CHPL_RT_COMM_OFI_EXPECTED_PROVIDER="cxi"
 export CHPL_RT_MAX_HEAP_SIZE=16g
+export SLURM_PARTITION=allnodes 
 
 
 # test a small subset of all tests due to limited resources


### PR DESCRIPTION
Adds an explicit SLURM_PARTITION to a test config. This is required for the machine this config runs on