### PR TITLE
Dyno: Basic support for resolving nested types

### DIFF
--- a/compiler/passes/convert-typed-uast.cpp
+++ b/compiler/passes/convert-typed-uast.cpp
@@ -1393,7 +1393,8 @@ TConverter::convertFunctionForGeneratedCall(const resolution::CallInfo& ci,
   auto scope = scopeForId(context, in->id());
   const PoiScope* poiScope = nullptr;
   auto scopeInfo = CallScopeInfo::forNormalCall(scope, poiScope);
-  auto r = resolveGeneratedCall(context, in, ci, scopeInfo);
+  auto rc = createDummyRC(context);
+  auto r = resolveGeneratedCall(&rc, in, ci, scopeInfo);
   const auto& candidate = r.mostSpecific().only();
   const TypedFnSignature* sig = candidate.fn();
   INT_ASSERT(sig);
@@ -2034,8 +2035,9 @@ struct ConvertTypeHelper {
   }
 
   Type* visit(const types::BasicClassType* bct) {
+    auto rc = createDummyRC(context());
     const ResolvedFields& rf =
-      fieldsForTypeDecl(context(), bct, DefaultsPolicy::USE_DEFAULTS);
+      fieldsForTypeDecl(&rc, bct, DefaultsPolicy::USE_DEFAULTS);
 
     AggregateType* at = toAggregateType(tc_->findConvertedType(bct));
     INT_ASSERT(at);
@@ -2063,8 +2065,9 @@ struct ConvertTypeHelper {
   }
 
   Type* visit(const types::RecordType* t) {
+    auto rc = createDummyRC(context());
     const ResolvedFields& rf =
-      fieldsForTypeDecl(context(), t, DefaultsPolicy::USE_DEFAULTS);
+      fieldsForTypeDecl(&rc, t, DefaultsPolicy::USE_DEFAULTS);
 
     AggregateType* at = toAggregateType(tc_->findConvertedType(t));
     INT_ASSERT(at);
@@ -2083,7 +2086,8 @@ struct ConvertTypeHelper {
   }
 
   Type* visit(const types::UnionType* t) {
-    auto& rf = fieldsForTypeDecl(context(), t, DefaultsPolicy::USE_DEFAULTS);
+    auto rc = createDummyRC(context());
+    auto& rf = fieldsForTypeDecl(&rc, t, DefaultsPolicy::USE_DEFAULTS);
 
     AggregateType* at = toAggregateType(tc_->findConvertedType(t));
     INT_ASSERT(at);

--- a/doc/util/nitpick_ignore
+++ b/doc/util/nitpick_ignore
@@ -27,6 +27,8 @@ cpp:identifier querydetail
 cpp:identifier querydetail::QueryMapResultBase
 cpp:identifier querydetail::QueryMap<ResultType, ArgTs...>
 cpp:identifier querydetail::QueryMap<ResultType, ArgTs...>::MapType
+cpp:identifier GlobalQueryT
+cpp:identifier GlobalQueryT::TraceFn
 cpp:identifier UniqueString
 cpp:identifier Resolver
 cpp:identifier ID

--- a/frontend/include/chpl/resolution/ResolutionContext.h
+++ b/frontend/include/chpl/resolution/ResolutionContext.h
@@ -635,6 +635,8 @@ class ResolutionContext::Query {
   }
 };
 
+ResolutionContext createDummyRC(Context* context);
+
 /** This macro can be used like 'QUERY_BEGIN', except it prevents the results
     of a query from being cached in the context query cache if the computed
     result could rely on state taken from the type 'ResolutionContext'.

--- a/frontend/include/chpl/resolution/ResolutionContext.h
+++ b/frontend/include/chpl/resolution/ResolutionContext.h
@@ -645,7 +645,12 @@ class ResolutionContext::Query {
   }
 };
 
+// TODO: This is meant as a temporary placeholder/sentinel for cases where we
+// currently don't have access to a pre-existing ResolutionContext. Eventually
+// uses of this function, and the function itself, should be removed.
+/// \cond DO_NOT_DOCUMENT
 ResolutionContext createDummyRC(Context* context);
+/// \endcond DO_NOT_DOCUMENT
 
 // TODO: Find a better way to get __rcTUple type for later use in TRACER
 /** This macro can be used like 'QUERY_BEGIN', except it prevents the results

--- a/frontend/include/chpl/resolution/ResolutionContext.h
+++ b/frontend/include/chpl/resolution/ResolutionContext.h
@@ -512,7 +512,7 @@ class ResolutionContext::GlobalQuery {
   }
 
   void registerTracer(TraceFn&& fn) {
-    beginMap_->registerTracer(fn);
+    beginMap_->registerTracer(std::move(fn));
   }
 };
 

--- a/frontend/include/chpl/resolution/resolution-queries.h
+++ b/frontend/include/chpl/resolution/resolution-queries.h
@@ -167,7 +167,7 @@ const types::Type* initialTypeForInterface(Context* context, ID declId);
   If syntaxOnly is set, computes basic information (field order, IDs)
   but does not compute types.
  */
-const ResolvedFields& resolveFieldDecl(Context* context,
+const ResolvedFields& resolveFieldDecl(ResolutionContext* rc,
                                        const types::CompositeType* ct,
                                        ID fieldId,
                                        DefaultsPolicy defaultsPolicy,
@@ -192,7 +192,7 @@ const ResolvedFields& resolveFieldDecl(Context* context,
   If syntaxOnly is set, computes basic information (field order, IDs)
   but does not compute types.
  */
-const ResolvedFields& fieldsForTypeDecl(Context* context,
+const ResolvedFields& fieldsForTypeDecl(ResolutionContext* rc,
                                         const types::CompositeType* ct,
                                         DefaultsPolicy defaultsPolicy,
                                         bool syntaxOnly = false);
@@ -217,7 +217,7 @@ const types::CompositeType* isNameOfField(Context* context,
   Computes the version of a type assuming that defaults for generics
   are needed. So, for 'record R { type t = int; }', this will return R(int).
  */
-const types::QualifiedType typeWithDefaults(Context* context,
+const types::QualifiedType typeWithDefaults(ResolutionContext* rc,
                                             types::QualifiedType t);
 
 /**
@@ -465,7 +465,7 @@ CallResolutionResult resolveCallInMethod(ResolutionContext* rc,
   scope of that call, find the most specific candidates as well
   as the point-of-instantiation scopes that were used when resolving them.
  */
-CallResolutionResult resolveGeneratedCall(Context* context,
+CallResolutionResult resolveGeneratedCall(ResolutionContext* rc,
                                           const uast::AstNode* astForErrAndPoi,
                                           const CallInfo& ci,
                                           const CallScopeInfo& inScopes,
@@ -481,7 +481,7 @@ CallResolutionResult resolveGeneratedCall(Context* context,
   If implicitReceiver.type() == nullptr, it will be ignored.
  */
 CallResolutionResult
-resolveGeneratedCallInMethod(Context* context,
+resolveGeneratedCallInMethod(ResolutionContext* rc,
                              const uast::AstNode* astForErrAndPoi,
                              const CallInfo& ci,
                              const CallScopeInfo& inScopes,
@@ -562,18 +562,11 @@ const ImplementationWitness* findOrImplementInterface(ResolutionContext* rc,
                                                       bool& foundExisting);
 
 /**
-  Given a type 't', compute whether or not 't' is default initializable.
-  If 't' is a generic type, it is considered non-default-initializable.
-  Considers the fields and substitutions of composite types.
-*/
-bool isTypeDefaultInitializable(Context* context, const types::Type* t);
-
-/**
   Determine whether type 't' is copyable/assignable from const or/and from ref.
   When checkCopyable is true, this checks copyability, and for false checks
   assignability.
 */
-CopyableAssignableInfo getCopyOrAssignableInfo(Context* context,
+CopyableAssignableInfo getCopyOrAssignableInfo(ResolutionContext* rc,
                                                const types::Type* t,
                                                bool checkCopyable);
 

--- a/frontend/include/chpl/types/Type.h
+++ b/frontend/include/chpl/types/Type.h
@@ -31,6 +31,10 @@
 
 namespace chpl {
 
+namespace resolution {
+  class ResolutionContext;
+}
+
 namespace uast {
   class Decl;
 }
@@ -345,9 +349,9 @@ class Type {
 
       All other cases are considered to be POD.
   */
-  static bool isPod(Context* context, const Type* t);
+  static bool isPod(chpl::resolution::ResolutionContext* rc, const Type* t);
 
-  static bool isDefaultInitializable(Context* context, const Type* t);
+  static bool isDefaultInitializable(chpl::resolution::ResolutionContext* rc, const Type* t);
 
   static bool needsInitDeinitCall(const Type* t);
 

--- a/frontend/lib/resolution/ResolutionContext.cpp
+++ b/frontend/lib/resolution/ResolutionContext.cpp
@@ -160,5 +160,9 @@ void ResolutionContext::popFrame(const ResolvedFunction* rf) {
   frames_.pop_back();
 }
 
+ResolutionContext createDummyRC(Context* context) {
+  return ResolutionContext(context);
+}
+
 } // end namespace resolution
 } // end namespace chpl

--- a/frontend/lib/resolution/Resolver.h
+++ b/frontend/lib/resolution/Resolver.h
@@ -246,7 +246,7 @@ struct Resolver {
 
   // set up Resolver to initially resolve field declaration types
   static Resolver
-  createForInitialFieldStmt(Context* context,
+  createForInitialFieldStmt(ResolutionContext* rc,
                             const uast::AggregateDecl* decl,
                             const uast::AstNode* fieldStmt,
                             const types::CompositeType* compositeType,

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -895,7 +895,8 @@ void CallInitDeinit::handleDeclaration(const VarLikeDecl* ast, RV& rv) {
     ID id = ast->id();
     frame->addToInitedVars(id);
     frame->localsAndDefers.push_back(id);
-  } else {
+  } else if (ast->attributeGroup() == nullptr ||
+             ast->attributeGroup()->hasPragma(uast::pragmatags::PRAGMA_NO_INIT) == false) {
     // default init it
     // not inited here and not split-inited, so default-initialize it
     resolveDefaultInit(ast, rv);

--- a/frontend/lib/resolution/copy-elision.cpp
+++ b/frontend/lib/resolution/copy-elision.cpp
@@ -137,7 +137,8 @@ bool FindElidedCopies::hasCrossTypeInitAssignWithIn(
                       actuals);
   const Scope* scope = scopeForId(context, ast->id());
   auto inScopes = CallScopeInfo::forNormalCall(scope, poiScope);
-  auto c = resolveGeneratedCall(context, ast, ci, inScopes);
+  auto rc = createDummyRC(context);
+  auto c = resolveGeneratedCall(&rc, ast, ci, inScopes);
   const MostSpecificCandidates& fns = c.mostSpecific();
   // return intent overloading should not be possible with an init=
   CHPL_ASSERT(fns.numBest() <= 1);

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -470,7 +470,8 @@ const BuilderResult& buildInitEquals(Context* context, ID typeID) {
 
   // attempt to resolve the fields
   DefaultsPolicy defaultsPolicy = DefaultsPolicy::IGNORE_DEFAULTS;
-  const ResolvedFields& rf = fieldsForTypeDecl(context, ct,
+  ResolutionContext rc(context);
+  const ResolvedFields& rf = fieldsForTypeDecl(&rc, ct,
                                                defaultsPolicy,
                                                /* syntaxOnly */ true);
   for (int i = 0; i < rf.numFields(); i++) {
@@ -1435,7 +1436,8 @@ static owned<Function> typeConstructorFnForComposite(Context* context,
 
   // attempt to resolve the fields
   DefaultsPolicy defaultsPolicy = DefaultsPolicy::IGNORE_DEFAULTS;
-  const ResolvedFields& f = fieldsForTypeDecl(context, ct,
+  ResolutionContext rc(context);
+  const ResolvedFields& f = fieldsForTypeDecl(&rc, ct,
                                               defaultsPolicy,
                                               /* syntaxOnly */ true);
 

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -944,7 +944,7 @@ const ResolvedFields& fieldsForTypeDeclQuery(ResolutionContext* rc,
   CHPL_RESOLUTION_QUERY_BEGIN(fieldsForTypeDeclQuery, rc, ct, defaultsPolicy, syntaxOnly);
   auto context = rc->context();
 
-  QUERY_REGISTER_TRACER(
+  CHPL_RESOLUTION_QUERY_REGISTER_TRACER(
     auto& id = std::get<0>(args)->id();
     auto typeName = std::get<0>(args)->name();
     auto traceText = std::string("resolving the fields of type '")

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -801,7 +801,8 @@ syntacticallyGenericFieldsPriorToIdHaveSubs(Context* context,
   }
 
   // Compute the fields without types so that we can iterate the fields.
-  auto& fieldsForOrder = fieldsForTypeDecl(context, ct, DefaultsPolicy::IGNORE_DEFAULTS,
+  ResolutionContext rc(context);
+  auto& fieldsForOrder = fieldsForTypeDecl(&rc, ct, DefaultsPolicy::IGNORE_DEFAULTS,
                                            /* syntaxOnly */ true);
   for (int i = 0; i < fieldsForOrder.numFields(); i++) {
     auto ithField = fieldsForOrder.fieldDeclId(i);

--- a/frontend/lib/types/ArrayType.cpp
+++ b/frontend/lib/types/ArrayType.cpp
@@ -91,7 +91,8 @@ ArrayType::getArrayType(Context* context,
   subs.emplace(ArrayType::eltTypeId, eltType);
 
   // Add substitution for _instance field
-  auto& rf = fieldsForTypeDecl(context, genericArray,
+  resolution::ResolutionContext rc(context);
+  auto& rf = fieldsForTypeDecl(&rc, genericArray,
                                resolution::DefaultsPolicy::IGNORE_DEFAULTS,
                                /* syntaxOnly */ true);
   ID instanceFieldId;

--- a/frontend/lib/types/CompositeType.cpp
+++ b/frontend/lib/types/CompositeType.cpp
@@ -214,7 +214,10 @@ static const RecordType* tryCreateManagerRecord(Context* context,
                                               recordId,
                                               /*bct*/ nullptr);
 
-    auto fields = fieldsForTypeDecl(context,
+    // Note: We know these types aren't nested, and so don't require a proper
+    // ResolutionContext at this time.
+    ResolutionContext rc(context);
+    auto fields = fieldsForTypeDecl(&rc,
                                     instantiatedFrom,
                                     DefaultsPolicy::IGNORE_DEFAULTS);
     for (int i = 0; i < fields.numFields(); i++) {

--- a/frontend/lib/types/DomainType.cpp
+++ b/frontend/lib/types/DomainType.cpp
@@ -102,7 +102,8 @@ static void insertInstanceIntoSubs(Context* context,
                                    const DomainType* genericDomain,
                                    const QualifiedType& instance) {
   // Add substitution for _instance field
-  auto& rf = fieldsForTypeDecl(context, genericDomain,
+  resolution::ResolutionContext rc(context);
+  auto& rf = fieldsForTypeDecl(&rc, genericDomain,
                                resolution::DefaultsPolicy::IGNORE_DEFAULTS,
                                /* syntaxOnly */ true);
   ID instanceFieldId;

--- a/frontend/test/resolution/testCPtr.cpp
+++ b/frontend/test/resolution/testCPtr.cpp
@@ -125,7 +125,8 @@ static void test4() {
     assert(eltT && eltT->isRecordType());
     auto rt = eltT->toRecordType();
     assert(rt->name() == "rec");
-    auto& fields = fieldsForTypeDecl(eg.context(), rt, DefaultsPolicy::IGNORE_DEFAULTS);
+    auto rc = createDummyRC(eg.context());
+    auto& fields = fieldsForTypeDecl(&rc, rt, DefaultsPolicy::IGNORE_DEFAULTS);
     assert(fields.numFields() == 1 && fields.fieldType(0).type()->isIntType());
   });
 }
@@ -204,7 +205,8 @@ static void test12() {
     assert(eltT && eltT->isRecordType());
     auto rt = eltT->toRecordType();
     assert(rt->name() == "rec");
-    auto& fields = fieldsForTypeDecl(eg.context(), rt, DefaultsPolicy::IGNORE_DEFAULTS);
+    auto rc = createDummyRC(eg.context());
+    auto& fields = fieldsForTypeDecl(&rc, rt, DefaultsPolicy::IGNORE_DEFAULTS);
     assert(fields.numFields() == 1 && fields.fieldType(0).type()->isIntType());
   });
 }
@@ -281,7 +283,8 @@ static void test20() {
     assert(eltT && eltT->isRecordType());
     auto rt = eltT->toRecordType();
     assert(rt->name() == "rec");
-    auto& fields = fieldsForTypeDecl(eg.context(), rt, DefaultsPolicy::IGNORE_DEFAULTS);
+    auto rc = createDummyRC(eg.context());
+    auto& fields = fieldsForTypeDecl(&rc, rt, DefaultsPolicy::IGNORE_DEFAULTS);
     assert(fields.numFields() == 1 && fields.fieldType(0).type()->isIntType());
   });
 }

--- a/frontend/test/resolution/testClasses.cpp
+++ b/frontend/test/resolution/testClasses.cpp
@@ -421,7 +421,8 @@ static void testInstantiateManagerRecord() {
     assert(!qt.isUnknownOrErroneous());
     assert(qt.type()->isRecordType());
 
-    auto fields = fieldsForTypeDecl(context, qt.type()->toRecordType(), DefaultsPolicy::IGNORE_DEFAULTS);
+    auto rc = createDummyRC(context);
+    auto fields = fieldsForTypeDecl(&rc, qt.type()->toRecordType(), DefaultsPolicy::IGNORE_DEFAULTS);
     bool foundField = false;
     for (int i = 0; i < fields.numFields(); i++) {
       if (fields.fieldName(i) == "chpl_t") {

--- a/frontend/test/resolution/testGenericDefaults.cpp
+++ b/frontend/test/resolution/testGenericDefaults.cpp
@@ -46,7 +46,8 @@ static void test1() {
   auto ct = qt.type()->toRecordType();
   auto baseCt = ct->instantiatedFrom();
   assert(baseCt != nullptr);
-  auto& fields = chpl::resolution::fieldsForTypeDecl(context, baseCt,
+  auto rc = createDummyRC(context);
+  auto& fields = chpl::resolution::fieldsForTypeDecl(&rc, baseCt,
       chpl::resolution::DefaultsPolicy::IGNORE_DEFAULTS);
   assert(fields.numFields() == 2);
   assert(fields.fieldName(0) == "typeWithDefault");
@@ -83,7 +84,8 @@ static void test2() {
   auto ct = qt.type()->toRecordType();
   auto baseCt = ct->instantiatedFrom();
   assert(baseCt == nullptr);
-  auto& fields = chpl::resolution::fieldsForTypeDecl(context, ct,
+  auto rc = createDummyRC(context);
+  auto& fields = chpl::resolution::fieldsForTypeDecl(&rc, ct,
       chpl::resolution::DefaultsPolicy::IGNORE_DEFAULTS);
   assert(fields.numFields() == 2);
   assert(fields.fieldName(0) == "typeWithDefault");
@@ -116,7 +118,8 @@ static void test3() {
   auto ct = qt.type()->toRecordType();
   auto baseCt = ct->instantiatedFrom();
   assert(baseCt == nullptr);
-  auto& fields = chpl::resolution::fieldsForTypeDecl(context, ct,
+  auto rc = createDummyRC(context);
+  auto& fields = chpl::resolution::fieldsForTypeDecl(&rc, ct,
       chpl::resolution::DefaultsPolicy::IGNORE_DEFAULTS);
   assert(fields.numFields() == 2);
   assert(fields.fieldName(0) == "typeWithDefault");

--- a/frontend/test/resolution/testHeapBuffer.cpp
+++ b/frontend/test/resolution/testHeapBuffer.cpp
@@ -120,7 +120,8 @@ static void test4() {
     assert(eltT && eltT->isRecordType());
     auto rt = eltT->toRecordType();
     assert(rt->name() == "rec");
-    auto& fields = fieldsForTypeDecl(eg.context(), rt, DefaultsPolicy::IGNORE_DEFAULTS);
+    auto rc = createDummyRC(eg.context());
+    auto& fields = fieldsForTypeDecl(&rc, rt, DefaultsPolicy::IGNORE_DEFAULTS);
     assert(fields.numFields() == 1 && fields.fieldType(0).type()->isIntType());
   });
 }

--- a/frontend/test/resolution/testInitSemantics.cpp
+++ b/frontend/test/resolution/testInitSemantics.cpp
@@ -794,7 +794,8 @@ static void testInitFromInit(void) {
     assert(recType);
     assert(recType->name() == "pair");
 
-    auto fields = fieldsForTypeDecl(context, recType, DefaultsPolicy::IGNORE_DEFAULTS);
+    auto rc = createDummyRC(context);
+    auto fields = fieldsForTypeDecl(&rc, recType, DefaultsPolicy::IGNORE_DEFAULTS);
 
     assert(fields.fieldName(0) == "fst");
     assert(fields.fieldName(1) == "snd");
@@ -859,7 +860,8 @@ static void testInitInParamBranchFromInit(void) {
       assert(recType);
       assert(recType->name() == "pair");
 
-      auto fields = fieldsForTypeDecl(context, recType, DefaultsPolicy::IGNORE_DEFAULTS);
+      auto rc = createDummyRC(context);
+      auto fields = fieldsForTypeDecl(&rc, recType, DefaultsPolicy::IGNORE_DEFAULTS);
 
       assert(fields.fieldName(0) == "fst");
       assert(fields.fieldName(1) == "snd");
@@ -887,7 +889,8 @@ static void testInitInParamBranchFromInit(void) {
       assert(recType);
       assert(recType->name() == "pair");
 
-      auto fields = fieldsForTypeDecl(context, recType, DefaultsPolicy::IGNORE_DEFAULTS);
+      auto rc = createDummyRC(context);
+      auto fields = fieldsForTypeDecl(&rc, recType, DefaultsPolicy::IGNORE_DEFAULTS);
 
       assert(fields.fieldName(0) == "fst");
       assert(fields.fieldName(1) == "snd");
@@ -943,7 +946,8 @@ static void testInitInBranchFromInit(void) {
       assert(recType);
       assert(recType->name() == "pair");
 
-      auto fields = fieldsForTypeDecl(context, recType, DefaultsPolicy::IGNORE_DEFAULTS);
+      auto rc = createDummyRC(context);
+      auto fields = fieldsForTypeDecl(&rc, recType, DefaultsPolicy::IGNORE_DEFAULTS);
 
       assert(fields.fieldName(0) == "fst");
       assert(fields.fieldName(1) == "snd");
@@ -971,7 +975,8 @@ static void testInitInBranchFromInit(void) {
       assert(recType);
       assert(recType->name() == "pair");
 
-      auto fields = fieldsForTypeDecl(context, recType, DefaultsPolicy::IGNORE_DEFAULTS);
+      auto rc = createDummyRC(context);
+      auto fields = fieldsForTypeDecl(&rc, recType, DefaultsPolicy::IGNORE_DEFAULTS);
 
       assert(fields.fieldName(0) == "fst");
       assert(fields.fieldName(1) == "snd");
@@ -2043,7 +2048,8 @@ static void testInitInstantiation(void) {
     CHPL_ASSERT(!qt.isUnknownOrErroneous());
     auto ct = qt.type()->getCompositeType();
     CHPL_ASSERT(ct);
-    auto fields = fieldsForTypeDecl(context, ct, DefaultsPolicy::IGNORE_DEFAULTS);
+    auto rc = createDummyRC(context);
+    auto fields = fieldsForTypeDecl(&rc, ct, DefaultsPolicy::IGNORE_DEFAULTS);
 
     assert(fields.fieldName(0) == "fst");
     assert(fields.fieldName(1) == "snd");
@@ -2105,12 +2111,13 @@ static void testInitInstantiationInherit() {
   assert(recType);
   assert(recType->name() == "B");
 
-  auto childFields = fieldsForTypeDecl(context, recType, DefaultsPolicy::IGNORE_DEFAULTS);
+  auto rc = createDummyRC(context);
+  auto childFields = fieldsForTypeDecl(&rc, recType, DefaultsPolicy::IGNORE_DEFAULTS);
   assert(childFields.fieldName(0) == "TB");
   assert(childFields.fieldType(0).type()->isIntType());
 
   auto parent = recType->toBasicClassType()->parentClassType();
-  auto parentFields = fieldsForTypeDecl(context, parent, DefaultsPolicy::IGNORE_DEFAULTS);
+  auto parentFields = fieldsForTypeDecl(&rc, parent, DefaultsPolicy::IGNORE_DEFAULTS);
   assert(parentFields.fieldName(0) == "TA");
   assert(parentFields.fieldType(0).type()->isRealType());
 }
@@ -2146,12 +2153,13 @@ static void testInitInstantiationInheritWrong() {
   assert(recType);
   assert(recType->name() == "B");
 
-  auto childFields = fieldsForTypeDecl(context, recType, DefaultsPolicy::IGNORE_DEFAULTS);
+  auto rc = createDummyRC(context);
+  auto childFields = fieldsForTypeDecl(&rc, recType, DefaultsPolicy::IGNORE_DEFAULTS);
   assert(childFields.fieldName(0) == "TB");
   assert(childFields.fieldType(0).type()->isRealType());
 
   auto parent = recType->toBasicClassType()->parentClassType();
-  auto parentFields = fieldsForTypeDecl(context, parent, DefaultsPolicy::IGNORE_DEFAULTS);
+  auto parentFields = fieldsForTypeDecl(&rc, parent, DefaultsPolicy::IGNORE_DEFAULTS);
   assert(parentFields.fieldName(0) == "TA");
   assert(parentFields.fieldType(0).type()->isRealType());
 

--- a/frontend/test/resolution/testNestedFunctions.cpp
+++ b/frontend/test/resolution/testNestedFunctions.cpp
@@ -642,6 +642,34 @@ static void test13(Context* ctx) {
   assert(qt.type() && qt.type()->isIntType());
 }
 
+static void test14(Context* ctx) {
+  ADVANCE_PRESERVING_STANDARD_MODULES_(ctx);
+  ErrorGuard guard(ctx);
+
+  std::string program =
+    R"""(
+    proc test() {
+      extern type time_t;
+      extern type suseconds_t;
+
+      record timeval {
+        var tv_sec: time_t;
+        var tv_usec: suseconds_t;
+      }
+
+      // TODO: fix initialization of nested types
+      pragma "no init"
+      var tv : timeval;
+      var ret = __primitive("cast", int, tv.tv_sec);
+      return ret;
+    }
+
+    var x = test();
+    )""";
+
+  std::ignore = resolveTypeOfX(ctx, program);
+}
+
 int main() {
   auto context = buildStdContext();
   Context* ctx = turnOnWarnUnstable(context);
@@ -664,6 +692,7 @@ int main() {
   test12(ctx);
   test12b(ctx);
   test13(ctx);
+  test14(ctx);
 
   return 0;
 }

--- a/frontend/test/resolution/testNew.cpp
+++ b/frontend/test/resolution/testNew.cpp
@@ -467,7 +467,8 @@ static void testGenericRecordUserInitDependentField() {
   assert(qtf2.param()->toIntParam()->value() == 8);
 
   // Now check all fields via the resolved fields query.
-  auto& rf = fieldsForTypeDecl(context, rt, DefaultsPolicy::USE_DEFAULTS);
+  auto rc = createDummyRC(context);
+  auto& rf = fieldsForTypeDecl(&rc, rt, DefaultsPolicy::USE_DEFAULTS);
   assert(rf.numFields() == 3);
   assert(!rf.isGeneric());
   assert(!rf.isGenericWithDefaults());
@@ -557,7 +558,8 @@ static void testGenericRecordUserSecondaryInitDependentField() {
   assert(ct->name() == "r");
 
   // It should already be instantiated, no need to use defaults.
-  auto fields = fieldsForTypeDecl(context, ct, DefaultsPolicy::IGNORE_DEFAULTS);
+  auto rc = createDummyRC(context);
+  auto fields = fieldsForTypeDecl(&rc, ct, DefaultsPolicy::IGNORE_DEFAULTS);
   assert(fields.numFields() == 3);
 
   auto f1 = fields.fieldType(0);
@@ -606,7 +608,8 @@ static void testNewGenericWithDefaults() {
     assert(ct->name() == "r");
 
     // It should already be instantiated, no need to use defaults.
-    auto fields = fieldsForTypeDecl(context, ct, DefaultsPolicy::IGNORE_DEFAULTS);
+    auto rc = createDummyRC(context);
+    auto fields = fieldsForTypeDecl(&rc, ct, DefaultsPolicy::IGNORE_DEFAULTS);
     assert(fields.numFields() == 1);
 
     auto f1 = fields.fieldType(0);
@@ -621,7 +624,8 @@ static void testNewGenericWithDefaults() {
     assert(ct->name() == "r");
 
     // It should already be instantiated, no need to use defaults.
-    auto fields = fieldsForTypeDecl(context, ct, DefaultsPolicy::IGNORE_DEFAULTS);
+    auto rc = createDummyRC(context);
+    auto fields = fieldsForTypeDecl(&rc, ct, DefaultsPolicy::IGNORE_DEFAULTS);
     assert(fields.numFields() == 1);
 
     auto f1 = fields.fieldType(0);
@@ -652,7 +656,8 @@ static void testCompilerGeneratedGenericNewWithDefaultInit() {
     assert(ct->name() == "r");
 
     // It should already be instantiated, no need to use defaults.
-    auto fields = fieldsForTypeDecl(context, ct, DefaultsPolicy::IGNORE_DEFAULTS);
+    auto rc = createDummyRC(context);
+    auto fields = fieldsForTypeDecl(&rc, ct, DefaultsPolicy::IGNORE_DEFAULTS);
     assert(fields.numFields() == 2);
 
     auto f1 = fields.fieldType(0);
@@ -670,7 +675,8 @@ static void testCompilerGeneratedGenericNewWithDefaultInit() {
     assert(ct->name() == "r");
 
     // It should already be instantiated, no need to use defaults.
-    auto fields = fieldsForTypeDecl(context, ct, DefaultsPolicy::IGNORE_DEFAULTS);
+    auto rc = createDummyRC(context);
+    auto fields = fieldsForTypeDecl(&rc, ct, DefaultsPolicy::IGNORE_DEFAULTS);
     assert(fields.numFields() == 2);
 
     auto f1 = fields.fieldType(0);
@@ -707,7 +713,8 @@ static void testCompilerGeneratedGenericNew() {
     assert(ct->name() == "r");
 
     // It should already be instantiated, no need to use defaults.
-    auto fields = fieldsForTypeDecl(context, ct, DefaultsPolicy::IGNORE_DEFAULTS);
+    auto rc = createDummyRC(context);
+    auto fields = fieldsForTypeDecl(&rc, ct, DefaultsPolicy::IGNORE_DEFAULTS);
     assert(fields.numFields() == 2);
 
     auto f1 = fields.fieldType(0);
@@ -725,7 +732,8 @@ static void testCompilerGeneratedGenericNew() {
     assert(ct->name() == "r");
 
     // It should already be instantiated, no need to use defaults.
-    auto fields = fieldsForTypeDecl(context, ct, DefaultsPolicy::IGNORE_DEFAULTS);
+    auto rc = createDummyRC(context);
+    auto fields = fieldsForTypeDecl(&rc, ct, DefaultsPolicy::IGNORE_DEFAULTS);
     assert(fields.numFields() == 2);
 
     auto f1 = fields.fieldType(0);
@@ -748,7 +756,8 @@ static void testCompilerGeneratedGenericNew() {
     assert(ct->name() == "r");
 
     // It should already be instantiated, no need to use defaults.
-    auto fields = fieldsForTypeDecl(context, ct, DefaultsPolicy::IGNORE_DEFAULTS);
+    auto rc = createDummyRC(context);
+    auto fields = fieldsForTypeDecl(&rc, ct, DefaultsPolicy::IGNORE_DEFAULTS);
     assert(fields.numFields() == 2);
 
     auto f1 = fields.fieldType(0);
@@ -787,7 +796,8 @@ static void testCompilerGeneratedGenericNewWithDefaultInitClass() {
     assert(ct->name() == "C");
 
     // It should already be instantiated, no need to use defaults.
-    auto fields = fieldsForTypeDecl(context, ct, DefaultsPolicy::IGNORE_DEFAULTS);
+    auto rc = createDummyRC(context);
+    auto fields = fieldsForTypeDecl(&rc, ct, DefaultsPolicy::IGNORE_DEFAULTS);
     assert(fields.numFields() == 2);
 
     auto f1 = fields.fieldType(0);
@@ -807,7 +817,8 @@ static void testCompilerGeneratedGenericNewWithDefaultInitClass() {
     assert(ct->name() == "C");
 
     // It should already be instantiated, no need to use defaults.
-    auto fields = fieldsForTypeDecl(context, ct, DefaultsPolicy::IGNORE_DEFAULTS);
+    auto rc = createDummyRC(context);
+    auto fields = fieldsForTypeDecl(&rc, ct, DefaultsPolicy::IGNORE_DEFAULTS);
     assert(fields.numFields() == 2);
 
     auto f1 = fields.fieldType(0);
@@ -845,7 +856,8 @@ static void testCompilerGeneratedGenericNewClass() {
     assert(ct);
 
     // It should already be instantiated, no need to use defaults.
-    auto fields = fieldsForTypeDecl(context, ct, DefaultsPolicy::IGNORE_DEFAULTS);
+    auto rc = createDummyRC(context);
+    auto fields = fieldsForTypeDecl(&rc, ct, DefaultsPolicy::IGNORE_DEFAULTS);
     assert(fields.numFields() == 2);
 
     auto f1 = fields.fieldType(0);
@@ -864,7 +876,8 @@ static void testCompilerGeneratedGenericNewClass() {
     assert(ct);
 
     // It should already be instantiated, no need to use defaults.
-    auto fields = fieldsForTypeDecl(context, ct, DefaultsPolicy::IGNORE_DEFAULTS);
+    auto rc = createDummyRC(context);
+    auto fields = fieldsForTypeDecl(&rc, ct, DefaultsPolicy::IGNORE_DEFAULTS);
     assert(fields.numFields() == 2);
 
     auto f1 = fields.fieldType(0);
@@ -888,7 +901,8 @@ static void testCompilerGeneratedGenericNewClass() {
     assert(ct);
 
     // It should already be instantiated, no need to use defaults.
-    auto fields = fieldsForTypeDecl(context, ct, DefaultsPolicy::IGNORE_DEFAULTS);
+    auto rc = createDummyRC(context);
+    auto fields = fieldsForTypeDecl(&rc, ct, DefaultsPolicy::IGNORE_DEFAULTS);
     assert(fields.numFields() == 2);
 
     auto f1 = fields.fieldType(0);
@@ -928,7 +942,8 @@ static void testSimpleUserGenericNew() {
     assert(ct->name() == "C");
 
     // It should already be instantiated, no need to use defaults.
-    auto fields = fieldsForTypeDecl(context, ct, DefaultsPolicy::IGNORE_DEFAULTS);
+    auto rc = createDummyRC(context);
+    auto fields = fieldsForTypeDecl(&rc, ct, DefaultsPolicy::IGNORE_DEFAULTS);
     assert(fields.numFields() == 1);
 
     auto f1 = fields.fieldType(0);
@@ -944,7 +959,8 @@ static void testSimpleUserGenericNew() {
     assert(ct->name() == "C");
 
     // It should already be instantiated, no need to use defaults.
-    auto fields = fieldsForTypeDecl(context, ct, DefaultsPolicy::IGNORE_DEFAULTS);
+    auto rc = createDummyRC(context);
+    auto fields = fieldsForTypeDecl(&rc, ct, DefaultsPolicy::IGNORE_DEFAULTS);
     assert(fields.numFields() == 1);
 
     auto f1 = fields.fieldType(0);
@@ -984,7 +1000,8 @@ static void testUserGenericNew() {
     assert(ct->name() == "r");
 
     // It should already be instantiated, no need to use defaults.
-    auto fields = fieldsForTypeDecl(context, ct, DefaultsPolicy::IGNORE_DEFAULTS);
+    auto rc = createDummyRC(context);
+    auto fields = fieldsForTypeDecl(&rc, ct, DefaultsPolicy::IGNORE_DEFAULTS);
     assert(fields.numFields() == 2);
 
     auto f1 = fields.fieldType(0);
@@ -1002,7 +1019,8 @@ static void testUserGenericNew() {
     assert(ct->name() == "r");
 
     // It should already be instantiated, no need to use defaults.
-    auto fields = fieldsForTypeDecl(context, ct, DefaultsPolicy::IGNORE_DEFAULTS);
+    auto rc = createDummyRC(context);
+    auto fields = fieldsForTypeDecl(&rc, ct, DefaultsPolicy::IGNORE_DEFAULTS);
     assert(fields.numFields() == 2);
 
     auto f1 = fields.fieldType(0);
@@ -1025,7 +1043,8 @@ static void testUserGenericNew() {
     assert(ct->name() == "r");
 
     // It should already be instantiated, no need to use defaults.
-    auto fields = fieldsForTypeDecl(context, ct, DefaultsPolicy::IGNORE_DEFAULTS);
+    auto rc = createDummyRC(context);
+    auto fields = fieldsForTypeDecl(&rc, ct, DefaultsPolicy::IGNORE_DEFAULTS);
     assert(fields.numFields() == 2);
 
     auto f1 = fields.fieldType(0);

--- a/frontend/test/resolution/testRanges.cpp
+++ b/frontend/test/resolution/testRanges.cpp
@@ -25,7 +25,8 @@
 static std::tuple<QualifiedType, std::string, std::string>
 getRangeInfo(Context* context, const RecordType* r) {
   assert(r->name() == "_range");
-  auto fields = fieldsForTypeDecl(context, r, DefaultsPolicy::IGNORE_DEFAULTS);
+  auto rc = createDummyRC(context);
+  auto fields = fieldsForTypeDecl(&rc, r, DefaultsPolicy::IGNORE_DEFAULTS);
 
   assert(fields.fieldName(0) == "idxType");
   assert(fields.fieldName(1) == "bounds");

--- a/frontend/test/resolution/testTypeConstruction.cpp
+++ b/frontend/test/resolution/testTypeConstruction.cpp
@@ -184,7 +184,8 @@ parseTypeAndFieldsOfX(Context* context, const char* program) {
   assert(ct != nullptr);
 
   auto defaultsPolicy = DefaultsPolicy::IGNORE_DEFAULTS;
-  const ResolvedFields& f = fieldsForTypeDecl(context, ct,
+  auto rc = createDummyRC(context);
+  const ResolvedFields& f = fieldsForTypeDecl(&rc, ct,
                                               defaultsPolicy);
 
   return std::make_pair(t, &f);
@@ -236,7 +237,8 @@ static void test5() {
   assert(rt);
   assert(rt->instantiatedFrom());
 
-  auto& initialFields = fieldsForTypeDecl(context,
+  auto rc = createDummyRC(context);
+  auto& initialFields = fieldsForTypeDecl(&rc,
                                           rt->instantiatedFrom(),
                                           DefaultsPolicy::IGNORE_DEFAULTS);
   assert(rt->instantiatedFrom()->instantiatedFrom() == nullptr);
@@ -1111,7 +1113,8 @@ static void test38() {
   assert(pct->parentClassType()->isObjectType());
   assert(pct->parentClassType() == BasicClassType::getRootClassType(context));
 
-  auto& parentFields = fieldsForTypeDecl(context, pct, DefaultsPolicy::IGNORE_DEFAULTS);
+  auto rc = createDummyRC(context);
+  auto& parentFields = fieldsForTypeDecl(&rc, pct, DefaultsPolicy::IGNORE_DEFAULTS);
   assert(parentFields.numFields() == 1);
   assert(parentFields.fieldName(0) == "parentField");
   assert(parentFields.fieldHasDefaultValue(0) == false);
@@ -1390,7 +1393,8 @@ static void testRecursiveTypeConstructorMutual() {
   assert(ctB->basicClassType()->instantiatedFrom());
 
   auto defaultsPolicy = DefaultsPolicy::IGNORE_DEFAULTS;
-  const ResolvedFields& fieldsB = fieldsForTypeDecl(context, ctB->basicClassType(),
+  auto rc = createDummyRC(context);
+  const ResolvedFields& fieldsB = fieldsForTypeDecl(&rc, ctB->basicClassType(),
                                                     defaultsPolicy);
 
   assert(fieldsB.numFields() == 3);


### PR DESCRIPTION
This PR enables some basic resolution of nested types by threading a ``ResolutionContext*`` through various API functions:
- resolveFieldDecl
- fieldsForTypeDecl
- typeWithDefaults
- resolveGeneratedCall
- resolveGeneratedCallInMethod
- getCopyOrAssignableInfo
- Type::isPod
- Type::isDefaultInitializable

These changes allow for resolution of nested types, their fields, and
their methods.

In the case of ``resolveFieldDecl``, a ``ResolutionContext`` is not
necessary when ``syntaxOnly=true``.

Other changes:
- Add ``createDummyRC`` as a sentinel for situations where a
  ResolutionContext is not readily available. Intended to be replaced
  eventually as ResolutionContext becomes more available.
- Hoist ``FieldDetail`` and ``ForwardingDetail`` out of
  ``ResolvedFields`` so that they can be hashed by
  ``ResolutionContext``.
- Removes unused ``isTypeDefaultInitializable`` function
- Basic support for "no init" pragma, to avoid testing issue
