### PR TITLE
Dyno: avoid resolving array constructors when scopeResolveOnly is set

### DIFF
--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -6519,7 +6519,7 @@ bool Resolver::enter(const IndexableLoop* loop) {
   iterand->traverse(*this);
 
   bool shapedLikeArray = false;
-  if ((shapedLikeArray = isShapedLikeArray(loop))) {
+  if (!scopeResolveOnly && (shapedLikeArray = isShapedLikeArray(loop))) {
     // Array expressions and bracket loops can look very similar.
     // For array type expressions, we do not need to go through the
     // iterator/'these' logic handled below. Resolve the body so we can check


### PR DESCRIPTION
This caused problem building Arkouda without `--dyno`, where a normal "scope resolution" pass triggered resolution, which doesn't work yet.

Reviewed by @benharsh -- thanks!

## Testing
- [x] dyno tests
- [x] paratest