### PR TITLE
Apply nested proc workarounds for array writing

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1819,7 +1819,7 @@ module DefaultRectangular {
   // formals as needed, to avoid issues with generic parent procs and variable
   // capture.
   // Anna, 2025-03-04
-  private proc recursiveArrayReaderWriter(f, arr, dom, helper, in idx, dim=0, in last=false) throws {
+  private proc recursiveArrayReaderWriter(f, arr, dom, ref helper, in idx, dim=0, in last=false) throws {
     param rank = arr.rank;
     type idxType = arr.idxType;
     type idxSignedType = chpl__signedType(chpl__idxTypeToIntIdxType(idxType));


### PR DESCRIPTION
Apply two workarounds to array writing related procs to avoid nested proc issues:
- Move `rwLiteral` out of `DefaultRectangularDom.dsiSerialReadWrite` and `DefaultRectangular.chpl_serialReadWriteRectangularHelper` and explicitly pass `f` formal
- Move `recursiveArrayReaderWriter` out of `DefaultRectangular.chpl_serialReadWriteRectangularHelper` and add several formals

These workarounds became necessary for spectests including `release/examples/spec/Arrays/decls` to pass following https://github.com/chapel-lang/chapel/pull/26792, whereas they were not needed previously; probably due to more code getting resolved. This PR brings `Arrays` spectest failures down from 14 to 10.

Logged in https://github.com/Cray/chapel-private/issues/6154.

[reviewer info placeholder]

Testing:
- [x] expected array spectests pass
- [x] dyno tests
- [x] paratest