### PR TITLE
Remove unnecessary code after qthreads upgrade

### DIFF
--- a/runtime/etc/rtmain.c
+++ b/runtime/etc/rtmain.c
@@ -21,11 +21,6 @@
 // This file is used in LLVM backend compiles to compile the header
 // declarations for the Chapel runtime into an LLVM module.
 
-// Reduce our exposure to overloads of symbols with the same name
-// when parsing runtime headers in C++ mode during our LLVM codegen.
-// https://github.com/chapel-lang/chapel/issues/25506
-#define CHPL_AVOID_CPP_CODE 1
-
 #include "stdchpl.h"
 
 #include "chpl-gen-includes.h"

--- a/util/chplenv/chpl_qthreads.py
+++ b/util/chplenv/chpl_qthreads.py
@@ -17,8 +17,6 @@ def get_uniq_cfg_path():
 def get_compile_args():
     ucp_val = get_uniq_cfg_path()
     bundled, system = third_party_utils.get_bundled_compile_args('qthread', ucp=ucp_val)
-    # qthread headers may have unused variables
-    bundled.append('-Wno-error=unused-variable')
     return (bundled, system)
 
 


### PR DESCRIPTION
Removes unnecessary code after [qthreads upgrade](https://github.com/chapel-lang/chapel/pull/26823). The latest version makes the changes removed here (which were workarounds) obsolete

[Reviewed by @jhh67]