### PR TITLE
Add tests for the unstable warnings on totalMicroseconds and totalMilliseconds

### DIFF
--- a/test/unstable/Time/checkTotalMicro.chpl
+++ b/test/unstable/Time/checkTotalMicro.chpl
@@ -1,0 +1,7 @@
+use Time;
+
+var a = new timeDelta(microseconds=10);
+writeln(a.totalMicroseconds());
+
+var b = new timeDelta(minutes=2, seconds=3);
+writeln(b.totalMicroseconds());

--- a/test/unstable/Time/checkTotalMicro.good
+++ b/test/unstable/Time/checkTotalMicro.good
@@ -1,0 +1,4 @@
+checkTotalMicro.chpl:4: warning: 'timeDelta.totalMicroseconds()' is unstable because it is new
+checkTotalMicro.chpl:7: warning: 'timeDelta.totalMicroseconds()' is unstable because it is new
+10
+123000000

--- a/test/unstable/Time/checkTotalMilli.chpl
+++ b/test/unstable/Time/checkTotalMilli.chpl
@@ -1,0 +1,7 @@
+use Time;
+
+var a = new timeDelta(milliseconds=10);
+writeln(isClose(a.totalMilliseconds(), 10.0));
+
+var b = new timeDelta(minutes=2, seconds=3);
+writeln(isClose(b.totalMilliseconds(), 123000.0));

--- a/test/unstable/Time/checkTotalMilli.good
+++ b/test/unstable/Time/checkTotalMilli.good
@@ -1,0 +1,4 @@
+checkTotalMilli.chpl:4: warning: 'timeDelta.totalMilliseconds()' is unstable because it is new
+checkTotalMilli.chpl:7: warning: 'timeDelta.totalMilliseconds()' is unstable because it is new
+true
+true


### PR DESCRIPTION
I mistakenly did not add these when adding the methods, rectify that oversight.

Thanks Shreyas for pointing it out!