### PR TITLE
Dyno: fix outer variable bug triggeerd by Atomics module.

### DIFF
--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1809,7 +1809,7 @@ void Resolver::resolveNamedDecl(const NamedDecl* decl, const Type* useType) {
         // enclosing record or class.
         auto functionId = parsing::idToParentId(context, decl->id());
         auto aggregateId = parsing::idToParentId(context, functionId);
-        auto parentType = typeForId(aggregateId, /* localGenericToUnknown */ true);
+        auto parentType = typeForId(aggregateId);
         typeExprT = parentType;
         usedTypeExpressionOrSimilar = true;
       }
@@ -3063,7 +3063,7 @@ lookupFieldType(Resolver& rv, const CompositeType* ct, const ID& idField) {
   return {};
 }
 
-QualifiedType Resolver::typeForId(const ID& id, bool localGenericToUnknown) {
+QualifiedType Resolver::typeForId(const ID& id) {
   if (scopeResolveOnly) {
     auto kind = qualifiedTypeKindForId(context, id);
     const Type* type = nullptr;
@@ -3095,7 +3095,7 @@ QualifiedType Resolver::typeForId(const ID& id, bool localGenericToUnknown) {
     }
 
     if (!local) {
-      return parentResolver->typeForId(id, localGenericToUnknown);
+      return parentResolver->typeForId(id);
     }
   }
 
@@ -3988,7 +3988,7 @@ ResolvedExpression Resolver::resolveNameInModule(const UniqueString name) {
     return result;
   }
 
-  auto type = typeForId(id, /* localGenericToUnknown */ false);
+  auto type = typeForId(id);
 
   // Note: not computing defaults for generic-with-defaults since use/import
   // statements don't support `bla(?)`.
@@ -4197,10 +4197,8 @@ void Resolver::resolveIdentifier(const Identifier* ident) {
     // Attempt to lookup an outer variable.
     if (!lookupOuterVariable(type, ident, id)) {
 
-      // Otherwise, use the type established at declaration/initialization,
-      // but for things with generic type, use unknown.
-      bool localGenericToUnknown = true;
-      type = typeForId(id, localGenericToUnknown);
+      // Otherwise, use the type established at declaration/initialization
+      type = typeForId(id);
     }
 
     maybeEmitWarningsForId(this, type, ident, id);
@@ -5467,9 +5465,8 @@ void Resolver::exit(const Dot* dot) {
           // empty IDs from the scope resolution process are builtins
           CHPL_ASSERT(false && "Not handled yet!");
         } else {
-          // use the type established at declaration/initialization,
-          // but for things with generic type, use unknown.
-          type = typeForId(id, /*localGenericToUnknown*/ true);
+          // use the type established at declaration/initialization
+          type = typeForId(id);
         }
         maybeEmitWarningsForId(this, type, dot, id);
         validateAndSetToId(r, dot, id);
@@ -6671,7 +6668,7 @@ static bool computeTaskIntentInfo(Resolver& resolver, const NamedDecl* intent,
       if (resolvedId.isEmpty()) {
         type = typeForBuiltin(resolver.context, intent->name());
       } else {
-        type = resolver.typeForId(resolvedId, /*localGenericToUnknown*/ true);
+        type = resolver.typeForId(resolvedId);
       }
     }
     return true;

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -365,6 +365,9 @@ Resolver::createForFunction(ResolutionContext* rc,
   ret.fnBody = fn->body();
   ret.rc = rc;
 
+  // TODO: Stop copying these back in.
+  ret.outerVariables = typedFnSignature->outerVariables();
+
   // Push a 'ResolutionContext::Frame' for the function we are resolving.
   ret.rc->pushFrame(&ret, ResolutionContext::Frame::FUNCTION);
   ret.didPushFrame = true;

--- a/frontend/lib/resolution/Resolver.h
+++ b/frontend/lib/resolution/Resolver.h
@@ -658,12 +658,8 @@ struct Resolver {
   bool resolveSpecialCall(const uast::Call* call);
 
   /* What is the type for the symbol with a particular ID?
-     localGenericUnknown, if true, indicates that a use of a
-     field/formal with generic type (that is not substituted)
-     should be resolved to unknown. That is important
-     for initial resolution of such functions/types.
    */
-  types::QualifiedType typeForId(const ID& id, bool localGenericToUnknown);
+  types::QualifiedType typeForId(const ID& id);
 
   // prepare the CallInfoActuals by inspecting the actuals of a call
   // includes special handling for operators and tuple literals


### PR DESCRIPTION
As part of getting the typed converter to work, David recently enable resolving the formals of functions when resolving the function as a whole. This triggered a bug in which a missing `ResolutionContext` frame (missing due to call graph tracking not keeping tabs on resolution contexts) made an outer variable that was previously resolved `unknown`. However, the outer variable was stored in the typed signature; in this PR, adjust David's logic to ensure outer variable types are used as proper.

While there, observe that `localGenericToUnknown` is never used, and seems to be handled elsewhere; remove it.

Reviewed by @dlongnecke-cray -- thanks!

## Testing
- [x] dyno tests
- [x] paratest