### PR TITLE
Double the Arkouda timeout on the new performance configs

### DIFF
--- a/util/cron/test-perf.hpe-apollo-hdr.arkouda.bash
+++ b/util/cron/test-perf.hpe-apollo-hdr.arkouda.bash
@@ -23,6 +23,10 @@ source $UTIL_CRON_DIR/common-perf-hpe-apollo-hdr.bash
 source $UTIL_CRON_DIR/common-arkouda.bash
 export ARKOUDA_NUMLOCALES=16
 
+# on this system, the array_transfer test comes dangerously close to the
+# timeout. So, here we double it for peace of mind.
+export ARKOUDA_CLIENT_TIMEOUT=600
+
 export CHPL_GASNET_SEGMENT=fast
 export GASNET_PHYSMEM_MAX="0.90"
 

--- a/util/cron/test-perf.hpe-apollo-hdr.arkouda.colo.bash
+++ b/util/cron/test-perf.hpe-apollo-hdr.arkouda.colo.bash
@@ -26,6 +26,10 @@ source $UTIL_CRON_DIR/common-arkouda.bash
 export CHPL_RT_LOCALES_PER_NODE=2
 export ARKOUDA_NUMLOCALES=32
 
+# on this system, the array_transfer test comes dangerously close to the
+# timeout. So, here we double it for peace of mind.
+export ARKOUDA_CLIENT_TIMEOUT=600
+
 export CHPL_GASNET_SEGMENT=fast
 export GASNET_PHYSMEM_MAX="0.90"
 

--- a/util/cron/test-perf.hpe-apollo-hdr.arkouda.release.bash
+++ b/util/cron/test-perf.hpe-apollo-hdr.arkouda.release.bash
@@ -23,6 +23,10 @@ source $UTIL_CRON_DIR/common-perf-hpe-apollo-hdr.bash
 source $UTIL_CRON_DIR/common-arkouda.bash
 export ARKOUDA_NUMLOCALES=16
 
+# on this system, the array_transfer test comes dangerously close to the
+# timeout. So, here we double it for peace of mind.
+export ARKOUDA_CLIENT_TIMEOUT=600
+
 export CHPL_GASNET_SEGMENT=fast
 export GASNET_PHYSMEM_MAX="0.90"
 

--- a/util/cron/test-perf.hpe-apollo-hdr.arkouda.release.colo.bash
+++ b/util/cron/test-perf.hpe-apollo-hdr.arkouda.release.colo.bash
@@ -26,6 +26,10 @@ source $UTIL_CRON_DIR/common-arkouda.bash
 export CHPL_RT_LOCALES_PER_NODE=2
 export ARKOUDA_NUMLOCALES=32
 
+# on this system, the array_transfer test comes dangerously close to the
+# timeout. So, here we double it for peace of mind.
+export ARKOUDA_CLIENT_TIMEOUT=600
+
 export CHPL_GASNET_SEGMENT=fast
 export GASNET_PHYSMEM_MAX="0.90"
 


### PR DESCRIPTION
In manual tests, I see that the `array_transfer` test can take some time to finish. Moreover, sometimes, the average time to finish it almost doubles. That behavior seems random and can push the execution over the client timeout. This PR doubles the timeout.