### PR TITLE
Adjust chpl_launchcmd to be able to handle colocales with PBS

### DIFF
--- a/util/test/chpl_launchcmd.py
+++ b/util/test/chpl_launchcmd.py
@@ -508,7 +508,7 @@ class AbstractJob(object):
         os.environ["LMOD_QUIET"] = "1"
 
         logging.info(
-            'Starting {0} job "{1}" on {2} nodes with walltime {3} '
+            'Starting {0} job "{1}" on {2} locales with walltime {3} '
             'and output file: {4}'.format(
                 self.submit_bin, self.job_name, self.num_locales,
                 self.walltime, output_file))
@@ -920,19 +920,19 @@ class PbsProJob(AbstractJob):
         # When comm=none sub_test/start_test passes -nl -1 (i.e. num locales
         # is -1). For the tests to work, reserve one node and the regular
         # ncpus (this does not happen by default).
-        num_locales = self.num_locales
-        if num_locales == -1:
-            num_locales = 1
+        num_nodes = self.num_locales
+        if num_nodes == -1:
+            num_nodes = 1
 
         loc_per_node = int(os.environ.get('CHPL_RT_LOCALES_PER_NODE', '1'))
 
         logging.debug("Locales per node: {}".format(loc_per_node))
-        if num_locales%loc_per_node != 0:
+        if num_nodes%loc_per_node != 0:
             raise RuntimeError('Requested number of locales ({}) is not '
                                'divisible by CHPL_RT_LOCALES_PER_NODE '
-                               '({}).'.format(num_locales, loc_per_node))
+                               '({}).'.format(num_nodes, loc_per_node))
 
-        num_locales = int(num_locales/loc_per_node)
+        num_nodes = int(num_nodes/loc_per_node)
 
         if self.hostlist is not None:
             if loc_per_node != 1:
@@ -946,9 +946,9 @@ class PbsProJob(AbstractJob):
                                 
             # This relies on the caller to use the correct select syntax.
             select_stmt = select_pattern.format(self.hostlist)
-            select_stmt = select_stmt.replace('<num_locales>', str(num_locales))
-        elif num_locales > 0:
-            select_stmt = select_pattern.format(num_locales)
+            select_stmt = select_stmt.replace('<num_nodes>', str(num_nodes))
+        elif num_nodes > 0:
+            select_stmt = select_pattern.format(num_nodes)
 
             if self.num_cpus_resource is not None:
                 select_stmt += ':{0}={1}'.format(


### PR DESCRIPTION
This PR adjusts `chpl_launchcmd`, such that it allocates correct number of nodes when `CHPL_RT_LOCALES_PER_NODE` is used. Previously, it just allocated `nl` nodes, which is not the right thing to do with colocales.

This currently only fixes PBS side of the script. I'll try to fix the slurm side in this PR before merging it. Right now, I am planning this for post-release.