### PR TITLE
Contributors list for Chapel 2.4

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -22,7 +22,7 @@ Contributors to the Chapel 2.4 release
 * [Shreyas Khandekar], [HPE] (former intern from [University of Arizona])
 * Vassily Litvinov, [HPE]
 * David Longnecker, [HPE]
-* Audrey Mendez-Pratt, individual contributor, formerly [HPE]
+* Audrey Mendez-Pratt, individual contributor (formerly [HPE])
 * Eduardo Morras, individual contributor
 * Brandon Neth, [HPE] (former intern from [University of Arizona])
 * Amanda Potts, individual contributor

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,15 +3,12 @@ Chapel Contributors
 
 The following people have contributed to Chapel releases:
 
-Contributors to the Chapel 2.3 release
+Contributors to the Chapel 2.4 release
 --------------------------------------
 * Jade Abraham, [HPE]
 * [Dan Bonachea], [Lawrence Berkeley National Laboratory]
-* Paul Cassella, [HPE]
 * [Brad Chamberlain], [HPE]
-* Rui Chen, individual contributor
 * Soohoon Choi, [HPE]
-* Jeremiah Corrado, [HPE]
 * Lydia Duncan, [HPE]
 * Daniel Fedorin, [HPE]
 * Michael Ferguson, [HPE]
@@ -23,14 +20,11 @@ Contributors to the Chapel 2.3 release
 * [Shreyas Khandekar], [HPE] (former intern from [University of Arizona])
 * Vassily Litvinov, [HPE]
 * David Longnecker, [HPE]
-* Ben McDonald, [HPE] (former intern from [Gonzaga University])
-* Josh Milthorpe, individual contributor, [ORNL], 
 * Brandon Neth, [HPE] (former intern from [University of Arizona])
+* Amanda Potts, individual contributor
 * Ahmad Rezaii, [HPE]
 * Anna Rift, [HPE]
 * Andy Stone, [HPE] (former [Cray Inc.] intern from [Colorado State University])
-* Michelle Mills Strout, [HPE]
-* Robin Voetter, individual contributor
 * Tim Zinsky, [HPE]
 
 Contributors to previous releases
@@ -56,7 +50,9 @@ Contributors to previous releases
 * John Byrne, [HPE]
 * Zixian Cai, individual contributor
 * David Callahan, [Cray Inc.]
+* Paul Cassella, [HPE]
 * Sanket Chaudhari, individual contributor
+* Rui Chen, individual contributor
 * Naman Chikara, individual contributor
 * R Chinmay, individual contributor
 * Sung-Eun Choi, [Cray Inc.]
@@ -64,6 +60,7 @@ Contributors to previous releases
 * Sarah Coghlan, [HPE]
 * Cristian-loan Condruz, individual contributor
 * Andrew Consroe, [HPE]
+* Jeremiah Corrado, [HPE]
 * Anway De, individual contributor
 * Steve Deitz, [Cray Inc.]
 * Laura Delaney, [Cray Inc.] intern from [Whitworth University]
@@ -119,6 +116,7 @@ Contributors to previous releases
 * Priyank Lohariwal, individual contributor
 * Juan Lopez, [Universidad de Málaga (University of Malaga)]
 * Simon Lund, [Københavns Universitet (University of Copenhagen)]
+* Ben McDonald, [HPE] (former intern from [Gonzaga University])
 * Tom MacDonald, [Cray Inc.]
 * Deepak Majeti, individual contributor
 * Prabhanjan Mannari, individual contributor
@@ -127,6 +125,7 @@ Contributors to previous releases
 * Cory McCartan, [Cray Inc.] intern from Sammamish High School
 * Damian McGuckin, [Pacific Engineering Systems International]
 * Erin Melia, individual contributor
+* Josh Milthorpe, individual contributor, [ORNL], 
 * Kyle Milz, individual contributor
 * Iain Moncrief, [HPE] intern from [Oregon State University]
 * Barry Moore, [University of Pittsburgh]
@@ -184,6 +183,7 @@ Contributors to previous releases
 * Srinivas Sridharan, [University of Notre Dame] / [ORNL]
 * Jenna Hoole Starkey, [HPE]
 * George Stelle, [Sandia National Laboratories]
+* Michelle Mills Strout, [HPE]
 * Chris Swenson, individual contributor
 * [Kenjiro Taura], [University of Tokyo]
 * Chris Taylor, [DOD]
@@ -199,6 +199,7 @@ Contributors to previous releases
 * Thomas Van Doren, individual contributor / [Cray Inc.]
 * Varsha Verma, individual contributor
 * Branch Vincent, individual contributor
+* Robin Voetter, individual contributor
 * Chris Wailes, [Indiana University]
 * Tony Wallace, [Cray Inc.]
 * Vivian Wang, individual contributor, [GHC] 2022 Open Source Day

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,6 +6,7 @@ The following people have contributed to Chapel releases:
 Contributors to the Chapel 2.4 release
 --------------------------------------
 * Jade Abraham, [HPE]
+* Shreyas Atre, individual contributor
 * [Dan Bonachea], [Lawrence Berkeley National Laboratory]
 * [Brad Chamberlain], [HPE]
 * Soohoon Choi, [HPE]

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -22,8 +22,10 @@ Contributors to the Chapel 2.4 release
 * [Shreyas Khandekar], [HPE] (former intern from [University of Arizona])
 * Vassily Litvinov, [HPE]
 * David Longnecker, [HPE]
+* Eduardo Morras, individual contributor
 * Brandon Neth, [HPE] (former intern from [University of Arizona])
 * Amanda Potts, individual contributor
+* Audrey Mendez-Pratt, individual contributor, formerly [HPE]
 * Ahmad Rezaii, [HPE]
 * Anna Rift, [HPE]
 * Andy Stone, [HPE] (former [Cray Inc.] intern from [Colorado State University])
@@ -156,7 +158,6 @@ Contributors to previous releases
 * Parth Sarthi Prasad, individual contributor
 * Chris Stinson, individual contributor
 * Kumar Prasun, individual contributor
-* Audrey Pratt, [HPE]
 * Surya Priy, individual contributor
 * Lee Prokowich, [Cray Inc.]
 * Elliot Ronaghan, [HPE]

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,6 +9,7 @@ Contributors to the Chapel 2.4 release
 * Shreyas Atre, individual contributor
 * [Dan Bonachea], [Lawrence Berkeley National Laboratory]
 * [Brad Chamberlain], [HPE]
+* R Chinmay, individual contributor
 * Soohoon Choi, [HPE]
 * Lydia Duncan, [HPE]
 * Daniel Fedorin, [HPE]
@@ -55,7 +56,6 @@ Contributors to previous releases
 * Sanket Chaudhari, individual contributor
 * Rui Chen, individual contributor
 * Naman Chikara, individual contributor
-* R Chinmay, individual contributor
 * Sung-Eun Choi, [Cray Inc.]
 * Mike Chu, [Advanced Micro Devices, Inc.]
 * Sarah Coghlan, [HPE]

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -22,10 +22,10 @@ Contributors to the Chapel 2.4 release
 * [Shreyas Khandekar], [HPE] (former intern from [University of Arizona])
 * Vassily Litvinov, [HPE]
 * David Longnecker, [HPE]
+* Audrey Mendez-Pratt, individual contributor, formerly [HPE]
 * Eduardo Morras, individual contributor
 * Brandon Neth, [HPE] (former intern from [University of Arizona])
 * Amanda Potts, individual contributor
-* Audrey Mendez-Pratt, individual contributor, formerly [HPE]
 * Ahmad Rezaii, [HPE]
 * Anna Rift, [HPE]
 * Andy Stone, [HPE] (former [Cray Inc.] intern from [Colorado State University])


### PR DESCRIPTION
Refreshed the list of most recent contributors to reflect those who contributed code, triage, and release artifacts for Chapel 2.4.

Thanks to first-time contributors @ajpotts, @SAtacker, and @EduardoMorras, as well as returning contributors @astatide , and @rchinmay !