### PR TITLE
Fix unsupported tuple template argument deduction under 'clang 11.0.0'

### DIFF
--- a/compiler/passes/convert-typed-uast.cpp
+++ b/compiler/passes/convert-typed-uast.cpp
@@ -383,10 +383,12 @@ struct TConverter final : UastConverter {
   ~TConverter();
 
   void setupEssentialModuleGlobalVars() {
-    std::vector<std::tuple<ModuleSymbol**, ModuleSymbol**, const char*>> v = {
-      std::tuple { &modChapelBase,  &baseModule,    "ChapelBase"  },
-      std::tuple { &modChapelTuple, nullptr,        "ChapelTuple" },
-      std::tuple { &modIO,          &ioModule,      "IO"          },
+    using Entry = std::tuple<ModuleSymbol**, ModuleSymbol**, const char*>;
+
+    std::vector<Entry> v {
+      Entry { &modChapelBase,  &baseModule,    "ChapelBase"  },
+      Entry { &modChapelTuple, nullptr,        "ChapelTuple" },
+      Entry { &modIO,          &ioModule,      "IO"          },
     };
 
     for (auto [ptr1, ptr2, str] : v) {


### PR DESCRIPTION
Fix a C++ compiler bug. Adjust by using a type alias that fully instantiates the tuple type.

Reviewed by @benharsh.