### PR TITLE
Dyno: Fix duplicate ID documentation errors

### DIFF
--- a/frontend/doc/doxygen-pitfalls.txt
+++ b/frontend/doc/doxygen-pitfalls.txt
@@ -74,3 +74,30 @@ then the log will include something like:
   Running directive: .. cpp:enum:: 
 
 for this case.
+
+---
+"CRITICAL: Duplicate ID: <long alphanumeric string>"
+---
+
+Unclear at this time what truly causes these kinds of errors, but it is
+suspected to be a bug in doxygen.
+
+A real-world example of this kind of error:
+
+```
+$CHPL_HOME/doc/rst/developer/compiler-internals/types.rst:6: CRITICAL: Duplicate ID: "_param_tag_8h_1ac254bac687cc93f8b6cb77b99f231f82".
+CHPL_HOME/doc/rst/developer/compiler-internals/types.rst:6: WARNING: Duplicate explicit target name: "_param_tag_8h_1ac254bac687cc93f8b6cb77b99f231f82".
+```
+
+This particular error concerned the ``ParamTag`` type. Because we make
+``ParamTag`` available via ``chpl::types::ParamTag`` with a statement like the
+one below, doxygen seems to get confused and emits the error:
+
+```
+using chpl::types::paramtags::ParamTag;
+```
+
+Disabling documentation of the 'using' statement quiets things down.
+
+Using the listed ID, you can search in ``build/doc/doxygen/xml/`` and from
+there can usually find a proper type name, and more useful information.

--- a/frontend/include/chpl/types/ParamTag.h
+++ b/frontend/include/chpl/types/ParamTag.h
@@ -57,7 +57,9 @@ enum ParamTag {
 } // end namespace paramtags
 
 // Enable AstTag to be used as chpl::types::ParamTag
+/// \cond DO_NOT_DOCUMENT
 using chpl::types::paramtags::ParamTag;
+/// \endcond
 
 } // end namespace types
 

--- a/frontend/include/chpl/types/Type.h
+++ b/frontend/include/chpl/types/Type.h
@@ -351,6 +351,7 @@ class Type {
 
   static bool needsInitDeinitCall(const Type* t);
 
+  /// \cond DO_NOT_DOCUMENT
   // Define a struct to do tag-driven dynamic dispatch over types.
   template <typename ReturnType, typename Visitor>
   struct Dispatcher {
@@ -408,6 +409,7 @@ class Type {
       CHPL_ASSERT(false && "this code should never be run");
     }
   };
+  /// \endcond DO_NOT_DOCUMENT
 
  public:
 

--- a/frontend/include/chpl/types/TypeTag.h
+++ b/frontend/include/chpl/types/TypeTag.h
@@ -95,7 +95,9 @@ const char* tagToString(TypeTag tag);
 } // end namespace typetags
 
 // Enable AstTag to be used as chpl::types::TypeTag
+/// \cond DO_NOT_DOCUMENT
 using chpl::types::typetags::TypeTag;
+/// \endcond
 
 } // end namespace types
 } // end namespace chpl

--- a/frontend/include/chpl/uast/AstNode.h
+++ b/frontend/include/chpl/uast/AstNode.h
@@ -371,6 +371,7 @@ class AstNode {
 
  private:
 
+  /// \cond DO_NOT_DOCUMENT
   template <typename ReturnType, typename Visitor>
   struct Dispatcher {
     static ReturnType doDispatch(const AstNode* ast, Visitor& v) {
@@ -449,6 +450,7 @@ class AstNode {
       CHPL_ASSERT(false && "this code should never be run");
     }
   };
+  /// \endcond DO_NOT_DOCUMENT
 
  public:
 

--- a/frontend/include/chpl/uast/AstTag.h
+++ b/frontend/include/chpl/uast/AstTag.h
@@ -100,7 +100,9 @@ const char* tagToString(AstTag tag);
 } // end namespace asttags
 
 // Enable AstTag to be used as chpl::uast::AstTag
+/// \cond DO_NOT_DOCUMENT
 using chpl::uast::asttags::AstTag;
+/// \endcond
 
 } // end namespace uast
 

--- a/frontend/include/chpl/uast/Pragma.h
+++ b/frontend/include/chpl/uast/Pragma.h
@@ -30,8 +30,10 @@ namespace pragmatags {
 enum PragmaTag {
   PRAGMA_UNKNOWN,
 // Discard everything but the name when building enum values.
+/// \cond DO_NOT_DOCUMENT
 #define PRAGMA(name__, canParse__, parseStr__, desc__) \
   PRAGMA_ ## name__,
+/// \endcond
 #include "chpl/uast/PragmaList.h"
 #undef PRAGMA
   NUM_KNOWN_PRAGMAS


### PR DESCRIPTION
For reasons unknown, certain symbols recently began causing arcane
errors while building documentation for the frontend. Disabling
documentation for the types affected by this PR silences these
errors. These errors general complained about some kind of duplicate ID.

I'm inclined to think this is some kind of bug in doxygen.
