### PR TITLE
Improve CopyAggregation docs

### DIFF
--- a/modules/packages/CopyAggregation.chpl
+++ b/modules/packages/CopyAggregation.chpl
@@ -112,10 +112,22 @@ module CopyAggregation {
     type elemType;
     @chpldoc.nodoc
     var agg: if aggregate then DstAggregatorImpl(elemType) else nothing;
+    /* Sets ``dst = srcVal`` in a way that aggregates such updates
+       to improve communication efficiency assuming that ``dst`` is remote
+       and ``srcVal`` is local. */
     inline proc ref copy(ref dst: elemType, const in srcVal: elemType) {
       if aggregate then agg.copy(dst, srcVal);
                    else dst = srcVal;
     }
+    /* Flushes the aggregator & completes the updates queued up from the
+       ``copy`` calls.
+
+       :arg freeBuffers: if ``true``, deallocates buffers used by this
+                         aggregator. If ``false``, the buffers will remain
+                         allocated after this ``flush`` (to support further
+                         ``copy`` calls) and deallocated when the aggregator
+                         variable is deinitialized.
+     */
     inline proc ref flush(freeBuffers=false) {
       if aggregate then agg.flush(freeBuffers=freeBuffers);
     }
@@ -130,10 +142,22 @@ module CopyAggregation {
     type elemType;
     @chpldoc.nodoc
     var agg: if aggregate then SrcAggregatorImpl(elemType) else nothing;
+    /* Sets ``dst = src`` in a way that aggregates such updates
+       to improve communication efficiency assuming that ``dst`` is local
+       and ``src`` is remote. */
     inline proc ref copy(ref dst: elemType, const ref src: elemType) {
       if aggregate then agg.copy(dst, src);
                    else dst = src;
     }
+    /* Flushes the aggregator & completes the updates queued up from the
+       ``copy`` calls.
+
+       :arg freeBuffers: if ``true``, deallocates buffers used by this
+                         aggregator. If ``false``, the buffers will remain
+                         allocated after this ``flush`` (to support further
+                         ``copy`` calls) and deallocated when the aggregator
+                         variable is deinitialized.
+     */
     inline proc ref flush(freeBuffers=false) {
       if aggregate then agg.flush(freeBuffers=freeBuffers);
     }

--- a/modules/packages/CopyAggregation.chpl
+++ b/modules/packages/CopyAggregation.chpl
@@ -120,13 +120,13 @@ module CopyAggregation {
                    else dst = srcVal;
     }
     /* Flushes the aggregator & completes the updates queued up from the
-       ``copy`` calls.
+       :proc:`DstAggregator.copy` calls.
 
        :arg freeBuffers: if ``true``, deallocates buffers used by this
                          aggregator. If ``false``, the buffers will remain
                          allocated after this ``flush`` (to support further
-                         ``copy`` calls) and deallocated when the aggregator
-                         variable is deinitialized.
+                         :proc:`DstAggregator.copy` calls) and deallocated
+                         when the aggregator variable is deinitialized.
      */
     inline proc ref flush(freeBuffers=false) {
       if aggregate then agg.flush(freeBuffers=freeBuffers);
@@ -150,13 +150,13 @@ module CopyAggregation {
                    else dst = src;
     }
     /* Flushes the aggregator & completes the updates queued up from the
-       ``copy`` calls.
+       :proc:`SrcAggregator.copy` calls.
 
        :arg freeBuffers: if ``true``, deallocates buffers used by this
                          aggregator. If ``false``, the buffers will remain
                          allocated after this ``flush`` (to support further
-                         ``copy`` calls) and deallocated when the aggregator
-                         variable is deinitialized.
+                         :proc:`SrcAggregator.copy` calls) and deallocated
+                         when the aggregator variable is deinitialized.
      */
     inline proc ref flush(freeBuffers=false) {
       if aggregate then agg.flush(freeBuffers=freeBuffers);


### PR DESCRIPTION
This PR improves the CopyAggregation docs as a follow-up to PR #26681.

* documents `copy` methods
* documents `flush` methods including the new `freeBuffers` optional argument

Reviewed by @lydia-duncan - thanks!