### PR TITLE
Remove GASNet comm layer from XC

### DIFF
--- a/util/build_configs/cray-internal/setenv-xc-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-x86_64.bash
@@ -127,7 +127,7 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
         log_info "Building Chapel component: runtime"
 
         compilers=gnu,llvm,intel
-        comms=gasnet,none,ugni
+        comms=none,ugni
         launchers=pbs-aprun,aprun,none,slurm-srun
         substrates=aries,none
         locale_models=flat


### PR DESCRIPTION
The Aries conduit has been removed from GASNet as of GASNet-EX 2025.2.0-snapshot, thus we should no longer try to build it.

Resolves https://github.com/Cray/chapel-private/issues/7212.