### PR TITLE
fix FreeBSD warning/error about missing `inet_aton`

### DIFF
--- a/runtime/src/qio/sys.c
+++ b/runtime/src/qio/sys.c
@@ -116,7 +116,7 @@ int sys_set_sys_sockaddr_t(sys_sockaddr_t* addr, const char* host, u_int16_t por
     struct sockaddr_in *addr_inet = (struct sockaddr_in *)&addr->addr;
     addr_inet->sin_family = AF_INET;
     addr_inet->sin_port = htons(port);
-    return inet_aton(host, &addr_inet->sin_addr);
+    return inet_pton(AF_INET, host, &addr_inet->sin_addr);
   }
   else if(family == AF_INET6){
     struct sockaddr_in6 *addr_inet6 = (struct sockaddr_in6 *)&addr->addr;


### PR DESCRIPTION
This is a copy of a closed PR https://github.com/chapel-lang/chapel/pull/26452/

Patch was originally submitted by @EduardoMorras, [emorras@emorras.eu](mailto:emorras@emorras.eu)

This fixes a portability issue with FreeBSD 13.4, 14.1, and 14.2 (maybe others) when using LLVM version 19 (maybe others) 

resolves https://github.com/chapel-lang/chapel/issues/22549

TESTING:
- [x] gasnet paratest `[Summary: #Successes = 17955 | #Failures = 0 | #Futures = 916]`
- [x] paratest `[Summary: #Successes = 17772 | #Failures = 0 | #Futures = 905]`
- [x] paratest w/C backend `[Summary: #Successes = 17626 | #Failures = 0 | #Futures = 893]`
- [x] local testing of `test/library/packages/Socket/` `[Summary: #Successes = 13 | #Failures = 0 | #Futures = 0 | #Warnings = 0 ]`

[reviewed by @mppf - thanks!]