### PR TITLE
Suppress shoc-sort failures in ROCm6 configuration

### DIFF
--- a/test/gpu/native/studies/shoc/shoc-sort.suppressif
+++ b/test/gpu/native/studies/shoc/shoc-sort.suppressif
@@ -14,7 +14,7 @@ check_conditions() {
         return 1
     fi
 
-    # Check if CHPL_GPU_SDK_VERSION contains '6'
+    # Check if CHPL_GPU_SDK_VERSION starts with '6'
     chpl_env_output=$("$chpl_home/util/printchplenv" --all)
     if echo "$chpl_env_output" | grep -q 'CHPL_GPU_SDK_VERSION: 6'; then
         return 0

--- a/test/gpu/native/studies/shoc/shoc-sort.suppressif
+++ b/test/gpu/native/studies/shoc/shoc-sort.suppressif
@@ -1,0 +1,4 @@
+# known issues with ROCm https://github.com/chapel-lang/chapel/issues/26669
+# Use a heuristic to check for ROCm 6.
+# Note: This is a substring comparison (check if 6 is a substring of the version string).
+CHPL_GPU_SDK_VERSION <= 6

--- a/test/gpu/native/studies/shoc/shoc-sort.suppressif
+++ b/test/gpu/native/studies/shoc/shoc-sort.suppressif
@@ -1,4 +1,30 @@
-# known issues with ROCm https://github.com/chapel-lang/chapel/issues/26669
-# Use a heuristic to check for ROCm 6.
-# Note: This is a substring comparison (check if 6 is a substring of the version string).
-CHPL_GPU_SDK_VERSION <= 6
+#!/bin/bash
+# Suppress ROCm6 shoc-sort failures: https://github.com/chapel-lang/chapel/issues/26669
+check_conditions() {
+    chpl_gpu=$(printenv CHPL_GPU)
+    chpl_test_perf_label=$(printenv CHPL_TEST_PERF_LABEL)
+
+    # Check if CHPL_GPU is 'amd' and CHPL_TEST_PERF_LABEL is set 
+    if [[ "$chpl_gpu" != "amd" || -z "$chpl_test_perf_label" ]]; then
+        return 1
+    fi
+
+    chpl_home=$(printenv CHPL_HOME)
+    if [[ -z "$chpl_home" ]]; then
+        return 1
+    fi
+
+    # Check if CHPL_GPU_SDK_VERSION contains '6'
+    chpl_env_output=$("$chpl_home/util/printchplenv" --all)
+    if echo "$chpl_env_output" | grep -q 'CHPL_GPU_SDK_VERSION: 6'; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+if check_conditions; then
+    echo "True"
+else
+    echo "False"
+fi


### PR DESCRIPTION
Add a temporary suppressif for this failing test.

See https://github.com/chapel-lang/chapel/issues/26669 for more details about the issue.

Testing:-
- [X] suppressif does **not** fire in correctness tests
- [X] suppressif does fire in performance tests when using `-perflabel=gpu-` on EX with ROCm6