### PR TITLE
Fix version check for Python to match docs

### DIFF
--- a/third-party/chpl-venv/Makefile
+++ b/third-party/chpl-venv/Makefile
@@ -26,11 +26,11 @@ cleanall: FORCE clean
 clobber: FORCE clean
 	rm -rf install
 
-OLD_PYTHON_ERROR="python3 version 3.5 or later is required to install chpldoc and start_test dependencies. See https://www.python.org/"
+OLD_PYTHON_ERROR="python3 version 3.9 or later is required to install chpldoc and start_test dependencies. See https://www.python.org/"
 
 $(CHPL_VENV_VIRTUALENV_DIR_DEPS1_OK):
 	@# First check the python version is OK
-	@if $(PYTHON) -c 'import sys; sys.exit(int(sys.version_info[:2] >= (3, 5)))'; then \
+	@if $(PYTHON) -c 'import sys; sys.exit(int(sys.version_info[:2] >= (3, 9)))'; then \
 	  echo $(OLD_PYTHON_ERROR); \
 	  exit 1; \
 	fi


### PR DESCRIPTION
Fixes a check for the Python version for test-venv/chpldoc, which was still using Python 3.5. We actually only support Python 3.9+, see https://chapel-lang.org/docs/main/usingchapel/prereqs.html#chapel-prerequisites

[Reviewed by @jhh67 and @mppf]