### PR TITLE
Remove unused variable from structured binding

### DIFF
--- a/frontend/lib/parsing/ParserContextImpl.h
+++ b/frontend/lib/parsing/ParserContextImpl.h
@@ -858,11 +858,11 @@ Array* ParserContext::buildNDArray(YYLTYPE location, ParserNDArrayList* lst) {
   auto loc = convertLocation(location);
 
   BuildArrayRowsContext barc;
-  auto [rows, _] = barc.buildArrayRows(this, lst, loc,
-                        /*start*/0, /*end*/lst->size()-1);
+  auto rows = barc.buildArrayRows(this, lst, loc,
+                                   /*start*/0, /*end*/lst->size()-1);
   barc.realizeErrors(this, lst);
   delete lst;
-  return Array::build(builder, loc, std::move(rows)).release();
+  return Array::build(builder, loc, std::move(rows.first)).release();
 }
 
 


### PR DESCRIPTION
Removes the unused variable in a structured binding, by removing the structured binding and accessing the first member of the pair.

[Reviewed by @arifthpe]