### PR TITLE
Turn off Apollo playground for now; set up for Qthreads as next config

### DIFF
--- a/util/cron/test-perf.hpe-apollo-hdr.gasnet-ibv.playground.bash
+++ b/util/cron/test-perf.hpe-apollo-hdr.gasnet-ibv.playground.bash
@@ -27,17 +27,17 @@ export GASNET_PHYSMEM_MAX="0.90"
 # When the multi-local playground is not used, set `SKIP_ML_PLAYGROUND=1
 #
 
-SKIP_ML_PLAYGROUND=0
+SKIP_ML_PLAYGROUND=1
 if [[ "$SKIP_ML_PLAYGROUND" == "1" ]]; then
   log_info "Skipping testing of the multi-local playground"
   exit
 fi
 
 # Test performance with the latest qthreads release.
-GITHUB_USER=jhh67
-GITHUB_BRANCH=gasnet
-SHORT_NAME=gasnet-snapshot
-START_DATE=02/27/25
+GITHUB_USER=insertinterestingnamehere
+GITHUB_BRANCH=qthread
+SHORT_NAME=qthread122
+START_DATE=03/08/25
 
 set -e
 checkout_branch $GITHUB_USER $GITHUB_BRANCH


### PR DESCRIPTION
This turns off the performance playground on Apollo, which had been testing the new GASNet, hadn't shown any major surprises, and that GASNet is now on main.

This'll be the first run with it off since Ahmad's https://github.hpe.com/hpe/hpc-chapel-ci-config/pull/1369 was merged, so it'll be interesting to see whether it stays blue as expected.

Meanwhile, I've also updated the playground to test Qthreads on multilocale, and will plan to enable that after a night or two of having it off to start gathering data there with an eye towards 2.5.