### PR TITLE
Skip test on GASNet with co-locales

### DIFF
--- a/test/optimizations/autoAggregation/perf/autoAggNegativeImpact.skipif
+++ b/test/optimizations/autoAggregation/perf/autoAggNegativeImpact.skipif
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+
+# This test hangs on GASNet with co-locales and should be skipped.
+# See https://github.com/Cray/chapel-private/issues/7173 for details.
+
+import os
+
+colocales = int(os.getenv('CHPL_RT_LOCALES_PER_NODE', '1'))
+comm = os.getenv('CHPL_COMM', 'none')
+print((colocales > 1) and (comm == 'gasnet'))


### PR DESCRIPTION
This test hangs on GASNet with co-locales and should be skipped. See https://github.com/Cray/chapel-private/issues/7173 for details.