### PR TITLE
Adjust documentation for `c_ptrTo` and `c_addrOf`

### DIFF
--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -766,8 +766,8 @@ module CTypes {
     To avoid this special behavior and just get the variable address naively
     regardless of type, use :proc:`c_addrOf` instead.
 
-    Domains and non-local or non-rectangular arrays are not supported, and will
-    cause a compiler error.
+    Domains, non-local arrays, and non-rectangular arrays are not supported,
+    and will cause a compiler error.
 
     .. note::
 


### PR DESCRIPTION
Clarify documentation on the `CTypes` functions `c_ptrTo` and `c_addrOf`, partly to note recent behavior changes on `c_addrOf`.

Adjustments:
- Explicitly call out that `c_ptrTo` on a non-local and/or non-rectangular array is disallowed.
- Move list of disallowed `c_ptrTo` args from the `x` formal's description to the body of the function documentation, to put it closer to the list of "special behaviors" as it is a similar concern.
- Remove statement on `c_ptrTo` that it has the same behavior as `c_addrOf` except on "special behavior" types, which is no longer true as `c_addrOf` now permits more argument types. This is also to avoid having the same or similar information listed in two places.
- Note in `c_addrOf` docs that it allows any type of argument, in contrast to `c_ptrTo`.

Follow up to in https://github.com/chapel-lang/chapel/pull/26512 and https://github.com/chapel-lang/chapel/pull/26563.

[reviewer info placeholder]