### PR TITLE
Update minimum clang versions to 11

### DIFF
--- a/doc/rst/usingchapel/prereqs.rst
+++ b/doc/rst/usingchapel/prereqs.rst
@@ -28,9 +28,7 @@ for using Chapel:
 
       * GCC 7.4 or newer
 
-      * Clang 5.0 or newer
-
-      * Apple Clang 10.0 or newer
+      * Clang / Apple Clang 11.0 or newer
 
     * C11 support, while not required, will enable faster atomic operations.
 


### PR DESCRIPTION
This is based on observations by Paul Hargrove and Michael Ferguson about where our build breaks down, as summarized on https://github.com/chapel-lang/chapel/issues/26851

Resolves #26851.
