### PR TITLE
Avoid a GMP potential ABI incompatibility with LLVM

### DIFF
--- a/modules/standard/GMP.chpl
+++ b/modules/standard/GMP.chpl
@@ -144,12 +144,8 @@ module GMP {
   //
   pragma "chpldoc ignore chpl prefix"
   proc chpl_gmp_init() {
-    extern proc chpl_gmp_mp_set_memory_functions(alloc:c_fn_ptr,
-                                                 realloc:c_fn_ptr,
-                                                 free:c_fn_ptr);
-    chpl_gmp_mp_set_memory_functions(c_ptrTo(chpl_gmp_alloc),
-                                     c_ptrTo(chpl_gmp_realloc),
-                                     c_ptrTo(chpl_gmp_free));
+    extern proc chpl_gmp_mp_set_memory_functions();
+    chpl_gmp_mp_set_memory_functions();
   }
 
   // Initialize GMP library on all locales

--- a/modules/standard/GMP.chpl
+++ b/modules/standard/GMP.chpl
@@ -114,31 +114,6 @@ module GMP {
 
   require "GMPHelper/chplgmp.h";
 
-  pragma "chpldoc ignore chpl prefix"
-  proc chpl_gmp_alloc(size:c_size_t) : c_ptr(void) {
-    pragma "insert line file info"
-    extern proc chpl_mem_alloc(size:c_size_t, md:chpl_mem_descInt_t) : c_ptr(void);
-    extern const CHPL_RT_MD_GMP:chpl_mem_descInt_t;
-    return chpl_mem_alloc(size, CHPL_RT_MD_GMP);
-  }
-
-  pragma "chpldoc ignore chpl prefix"
-  proc chpl_gmp_realloc(ptr:c_ptr(void),
-                               old_size:c_size_t, new_size:c_size_t) : c_ptr(void) {
-    pragma "insert line file info"
-    extern proc chpl_mem_realloc(ptr:c_ptr(void), size:c_size_t, md:chpl_mem_descInt_t) : c_ptr(void);
-    extern const CHPL_RT_MD_GMP:chpl_mem_descInt_t;
-    return chpl_mem_realloc(ptr, new_size, CHPL_RT_MD_GMP);
-  }
-
-  pragma "chpldoc ignore chpl prefix"
-  proc chpl_gmp_free(ptr:c_ptr(void), old_size:c_size_t) {
-    pragma "insert line file info"
-      extern proc chpl_mem_free(ptr:c_ptr(void)) : void;
-    chpl_mem_free(ptr);
-  }
-
-
   //
   // Initialize GMP to use Chapel's allocator
   //

--- a/modules/standard/GMPHelper/chplgmp.h
+++ b/modules/standard/GMPHelper/chplgmp.h
@@ -31,13 +31,23 @@
 
 // Need this workaround for some compilers until the Chapel
 // compiler moves away from representing all C fn pointers as void*
+static void* chpl_gmp_alloc(size_t size) {
+  return chpl_mem_alloc(size, CHPL_RT_MD_GMP, 0, 0);
+}
+
+static void* chpl_gmp_realloc(void* ptr, size_t old_size, size_t new_size) {
+  return chpl_mem_realloc(ptr, new_size, CHPL_RT_MD_GMP, 0, 0);
+}
+
+static void chpl_gmp_free(void* ptr, size_t old_size) {
+  return chpl_mem_free(ptr, 0, 0);
+}
+
 static inline
-void chpl_gmp_mp_set_memory_functions(c_fn_ptr alloc,
-                                      c_fn_ptr realloc,
-                                      c_fn_ptr free) {
-  mp_set_memory_functions((void *(*) (size_t)) alloc,
-                          (void *(*) (void *, size_t, size_t)) realloc,
-                          (void (*) (void *, size_t)) free);
+void chpl_gmp_mp_set_memory_functions(void) {
+  mp_set_memory_functions((void *(*) (size_t)) chpl_gmp_alloc,
+                          (void *(*) (void *, size_t, size_t)) chpl_gmp_realloc,
+                          (void (*) (void *, size_t)) chpl_gmp_free);
 }
 
 static inline

--- a/modules/standard/GMPHelper/chplgmp.h
+++ b/modules/standard/GMPHelper/chplgmp.h
@@ -32,22 +32,20 @@
 // Need this workaround for some compilers until the Chapel
 // compiler moves away from representing all C fn pointers as void*
 static void* chpl_gmp_alloc(size_t size) {
-  return chpl_mem_alloc(size, CHPL_RT_MD_GMP, 0, 0);
+  return chpl_mem_alloc(size, CHPL_RT_MD_GMP, __LINE__, 0);
 }
 
 static void* chpl_gmp_realloc(void* ptr, size_t old_size, size_t new_size) {
-  return chpl_mem_realloc(ptr, new_size, CHPL_RT_MD_GMP, 0, 0);
+  return chpl_mem_realloc(ptr, new_size, CHPL_RT_MD_GMP, __LINE__, 0);
 }
 
 static void chpl_gmp_free(void* ptr, size_t old_size) {
-  return chpl_mem_free(ptr, 0, 0);
+  return chpl_mem_free(ptr, __LINE__, 0);
 }
 
 static inline
 void chpl_gmp_mp_set_memory_functions(void) {
-  mp_set_memory_functions((void *(*) (size_t)) chpl_gmp_alloc,
-                          (void *(*) (void *, size_t, size_t)) chpl_gmp_realloc,
-                          (void (*) (void *, size_t)) chpl_gmp_free);
+  mp_set_memory_functions(chpl_gmp_alloc, chpl_gmp_realloc, chpl_gmp_free);
 }
 
 static inline


### PR DESCRIPTION
[reviewed by @mppf]

Credit for this idea goes to Michael.

Before this, we were passing un-exported function pointers to external C functions.  This was potentially one of the issues impacting a user code, though there still seem to be other issues.

This PR makes it so that we define those functions in C directly, allowing them to be passed more cleanly (although losing some information about the file where they were called in the process).

Passed a full paratest with futures