### PR TITLE
Dyno: Resolve initializers for nested types

### DIFF
--- a/frontend/lib/resolution/default-functions.h
+++ b/frontend/lib/resolution/default-functions.h
@@ -54,7 +54,7 @@ bool needCompilerGeneratedMethod(Context* context, const types::Type* type,
   If no method was generated, returns nullptr.
 */
 const TypedFnSignature*
-getCompilerGeneratedMethod(Context* context,
+getCompilerGeneratedMethod(ResolutionContext* rc,
                            const types::QualifiedType receiverType,
                            UniqueString name, bool parenless);
 

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -4341,7 +4341,7 @@ resolveFnCallForTypeCtor(Context* context,
 }
 
 static const TypedFnSignature*
-considerCompilerGeneratedMethods(Context* context,
+considerCompilerGeneratedMethods(ResolutionContext* rc,
                                  const CallInfo& ci,
                                  CandidatesAndForwardingInfo& candidates) {
   // only consider compiler-generated methods and opcalls, for now
@@ -4353,13 +4353,13 @@ considerCompilerGeneratedMethods(Context* context,
   auto receiverType = receiver.type();
 
   // if not compiler-generated, then nothing to do
-  if (!needCompilerGeneratedMethod(context, receiverType.type(), ci.name(),
+  if (!needCompilerGeneratedMethod(rc->context(), receiverType.type(), ci.name(),
                                    ci.isParenless())) {
     return nullptr;
   }
 
   // get the compiler-generated function, may be generic
-  auto tfs = getCompilerGeneratedMethod(context, receiverType, ci.name(),
+  auto tfs = getCompilerGeneratedMethod(rc, receiverType, ci.name(),
                                         ci.isParenless());
   return tfs;
 }
@@ -4403,26 +4403,26 @@ considerCompilerGeneratedOperators(Context* context,
 }
 
 static void
-considerCompilerGeneratedCandidates(Context* context,
+considerCompilerGeneratedCandidates(ResolutionContext* rc,
                                     const AstNode* astForErr,
                                     const CallInfo& ci,
                                     CandidatesAndForwardingInfo& candidates,
                                     std::vector<ApplicabilityResult>* rejected) {
   const TypedFnSignature* tfs = nullptr;
 
-  tfs = considerCompilerGeneratedMethods(context, ci, candidates);
+  tfs = considerCompilerGeneratedMethods(rc, ci, candidates);
   if (tfs == nullptr) {
-    tfs = considerCompilerGeneratedFunctions(context, ci, candidates);
+    tfs = considerCompilerGeneratedFunctions(rc->context(), ci, candidates);
   }
   if (tfs == nullptr) {
-    tfs = considerCompilerGeneratedOperators(context, ci, candidates);
+    tfs = considerCompilerGeneratedOperators(rc->context(), ci, candidates);
   }
 
   if (!tfs) return;
 
   // check if the initial signature matches
   auto faMap = FormalActualMap(tfs->untyped(), ci);
-  if (!isInitialTypedSignatureApplicable(context, tfs, faMap, ci).success()) {
+  if (!isInitialTypedSignatureApplicable(rc->context(), tfs, faMap, ci).success()) {
     return;
   }
 
@@ -4433,8 +4433,7 @@ considerCompilerGeneratedCandidates(Context* context,
   }
 
   // need to instantiate before storing
-  ResolutionContext rcval(context);
-  auto instantiated = doIsCandidateApplicableInstantiating(&rcval,
+  auto instantiated = doIsCandidateApplicableInstantiating(rc,
                                                            tfs,
                                                            ci,
                                                            /* POI */ nullptr);
@@ -4445,7 +4444,7 @@ considerCompilerGeneratedCandidates(Context* context,
   }
 
   if (!instantiated.candidate()->isInitializer() &&
-      checkUninstantiatedFormals(context, astForErr, instantiated.candidate())) {
+      checkUninstantiatedFormals(rc->context(), astForErr, instantiated.candidate())) {
     return; // do not push invalid candidate into list
   }
 
@@ -4732,7 +4731,7 @@ gatherAndFilterCandidatesForwarding(ResolutionContext* rc,
     for (const auto& fci : forwardingCis) {
       size_t start = nonPoiCandidates.size();
       // consider compiler-generated candidates
-      considerCompilerGeneratedCandidates(context, astContext, fci,
+      considerCompilerGeneratedCandidates(rc, astContext, fci,
                                           nonPoiCandidates,
                                           rejected);
       // update forwardingTo
@@ -4956,7 +4955,7 @@ gatherAndFilterCandidates(ResolutionContext* rc,
   //  the poiInfo from these is not gathered, because such methods should
   //  always be available in any scope that can refer to the type & are
   //  considered part of the custom type)
-  considerCompilerGeneratedCandidates(context, astContext, ci,
+  considerCompilerGeneratedCandidates(rc, astContext, ci,
                                       candidates,
                                       rejected);
 

--- a/frontend/test/resolution/testNestedFunctions.cpp
+++ b/frontend/test/resolution/testNestedFunctions.cpp
@@ -657,8 +657,6 @@ static void test14(Context* ctx) {
         var tv_usec: suseconds_t;
       }
 
-      // TODO: fix initialization of nested types
-      pragma "no init"
       var tv : timeval;
       var ret = __primitive("cast", int, tv.tv_sec);
       return ret;


### PR DESCRIPTION
Fixes initialization of nested types by threading a ResolutionContext through the default-function helpers. Without this context, the initial type signature can fail to resolve if fields rely on outer variables.