### PR TITLE
Skip ChplPrefixReserved for extern functions

### DIFF
--- a/test/chplcheck/ChplPrefixReserved.chpl
+++ b/test/chplcheck/ChplPrefixReserved.chpl
@@ -2,4 +2,6 @@ module ChplModule{
   var chpl_var: real;
   proc chpl_proc() {}
   record chpl_record {}
+
+  extern proc chpl_task_getId(): chpl_taskID_t;
 }

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -397,6 +397,9 @@ def rules(driver: LintDriver):
         Warn for user-defined names that start with the 'chpl\\_' reserved prefix.
         """
 
+        if node.linkage() == "extern":
+            return True
+
         if node.name().startswith("chpl_"):
             path = node.location().path()
             return context.is_bundled_path(path)


### PR DESCRIPTION
Skips linting for the prefix `chpl_` being reserved on extern functions, because users have no control over extern code in their Chapel code.

[Reviewed by @DanilaFe]