### PR TITLE
Improve portability of leak testing

### DIFF
--- a/test/arrays/arrOfArrs/leaking.bad
+++ b/test/arrays/arrOfArrs/leaking.bad
@@ -7,13 +7,13 @@ type is: [domain(2,int(64),one)] [domain(1,int(64),one)] [domain(1,int(64),one)]
 ================================================= Memory Leaks ==================================================
 Allocated Memory (Bytes)         Number   Size     Total    Description                      Address             
 =================================================================================================================
-leaking.chpl:5                   1        72       72       domain(1,int(64),one)            prediffed  
-leaking.chpl:6                   1        72       72       domain(1,int(64),one)            prediffed  
-leaking.chpl:7                   1        72       72       domain(1,int(64),one)            prediffed  
-leaking.chpl:7                   1        72       72       domain(1,int(64),one)            prediffed  
-leaking.chpl:8                   1        72       72       domain(1,int(64),one)            prediffed  
-leaking.chpl:9                   1        72       72       domain(1,int(64),one)            prediffed  
-leaking.chpl:9                   1        72       72       domain(1,int(64),one)            prediffed  
-leaking.chpl:9                   1        72       72       domain(1,int(64),one)            prediffed  
+leaking.chpl:5                   n        n       n       domain(1,int(64),one)            prediffed  
+leaking.chpl:6                   n        n       n       domain(1,int(64),one)            prediffed  
+leaking.chpl:7                   n        n       n       domain(1,int(64),one)            prediffed  
+leaking.chpl:7                   n        n       n       domain(1,int(64),one)            prediffed  
+leaking.chpl:8                   n        n       n       domain(1,int(64),one)            prediffed  
+leaking.chpl:9                   n        n       n       domain(1,int(64),one)            prediffed  
+leaking.chpl:9                   n        n       n       domain(1,int(64),one)            prediffed  
+leaking.chpl:9                   n        n       n       domain(1,int(64),one)            prediffed  
 =================================================================================================================
 

--- a/test/arrays/arrOfArrs/leaking.prediff
+++ b/test/arrays/arrOfArrs/leaking.prediff
@@ -1,3 +1,3 @@
 #!/bin/bash                                                                     
 sed -E "s/0x[0-9a-f]*/prediffed/" <$2 >$2.predifftmp
-mv $2.predifftmp $2
+sed -E "s/       [0-9]+/       n/g" <$2.predifftmp >$2


### PR DESCRIPTION
I forgot to take into account that the amount leaked by this new test could reflect:

* CHPL_COMM=none vs. !=none
* 32- vs 64-bit linux
* C compiler choices

which made my leaking.bad file a bit too specific to where I tested it and broke it in some of our test configurations.  This expands the prediff to not just filter the addresses being leaked but any other integer preceded by 7 spaces, which happens to cover the number of bytes per domain, and total, leaked, but also the count of 1.  This all seems acceptable, though.