### PR TITLE
Update docs for `CHPL_LLVM_GCC_INSTALL_DIR`

### DIFF
--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -927,8 +927,10 @@ CHPL_LLVM_GCC_INSTALL_DIR
    Sometimes it's necessary to request that ``clang`` work with a
    particular version of GCC. If many versions are installed at the same
    prefix (e.g. ``/usr``) then ``CHPL_LLVM_GCC_PREFIX`` won't be able to
-   differentiate between them. That is where ``CHPL_LLVM_GCC_INSTALL_DIR``
-   comes in!
+   differentiate between them. The Chapel compiler tries to infer
+   this flag based upon the ``gcc`` currently available in your ``PATH``
+   but sometimes that strategy does not work. That is where
+   ``CHPL_LLVM_GCC_INSTALL_DIR`` comes in!
 
    To understand what to set ``CHPL_LLVM_GCC_INSTALL_DIR`` to in such
    cases, try a test compile:


### PR DESCRIPTION
Updates the docs for `CHPL_LLVM_GCC_INSTALL_DIR` to mention that they can now be inferred.

[Reviewed by @mppf]