### PR TITLE
Add build system docs for building chapel projects

### DIFF
--- a/doc/rst/usingchapel/compiling.rst
+++ b/doc/rst/usingchapel/compiling.rst
@@ -168,11 +168,12 @@ Running ``make DEBUG=1`` will compile the program with debugging enabled and
 CMake
 ^^^^^
 
-Chapel provides a few support files for building Chapel programs with CMake. The
+Although CMake does not yet support Chapel programs natively, the
 Chapel source tree contains a directory,
 `util/cmake <https://github.com/chapel-lang/chapel/tree/main/util/cmake>`_,
 which can be added to a CMake project to support building Chapel programs.
-Take the following steps:
+
+To enable CMake support for your Chapel project, take the following steps:
 
 #. Copy the ``util/cmake`` directory from the Chapel source tree to your
    project. You may want to copy the files to a subdirectory like ``cmake``, or
@@ -190,6 +191,9 @@ might look like this:
    project(myProgram LANGUAGES CHPL)
 
    add_executable(myProgram main.chpl myModule.chpl)
+
+Based on the value of ``CMAKE_BUILD_TYPE`` additional flags will be
+added, for example ``--fast`` for ``CMAKE_BUILD_TYPE=release``.
 
 This can then be used like any other CMake project. For example, the following
 will build a release version of the program:

--- a/doc/rst/usingchapel/compiling.rst
+++ b/doc/rst/usingchapel/compiling.rst
@@ -5,7 +5,7 @@ Compiling Chapel Programs
 =========================
 
 The Chapel compiler converts programs expressed in Chapel source code
-into the corresponding executable form.  This document briefly discusses
+into the corresponding executable form. This document briefly discusses
 running the Chapel compiler.
 
 .. contents::
@@ -110,3 +110,92 @@ auto-complete the option and add a space, ready for the next option.
 
      % chpl --cac<tab>
      % chpl --cache-remote
+
+------------------------------
+Integrating Into Build Systems
+------------------------------
+
+Larger projects using Chapel may wish to setup a build system to manage
+compilation of their Chapel code. This section provides a brief overview of a
+few common build systems and how they can be used with Chapel.
+
+Mason
+^^^^^
+
+:ref:`Mason <readme-mason>` is the Chapel package manager and build system. See
+the :ref:`Mason Guide <index-mason-guide>` for a walkthrough of how to use
+Mason to manage your Chapel projects.
+
+Make
+^^^^
+
+If you wish to use Make to compile your Chapel code, you can specify a recipe
+that contains all of the Chapel files and flags in a single invocation. Chapel
+currently does not support separate compilation, so all Chapel files must be
+compiled together.
+
+For example, a simple ``Makefile`` that compiles a Chapel project might look
+like this. This can be extended with other flags or dependencies as needed:
+
+.. code-block:: Makefile
+
+   CHPL := chpl
+   DEBUG ?= 0
+   TARGET := myProgram
+
+   .PHONY: all
+   all: $(TARGET)
+
+   ifeq ($(DEBUG),1)
+   CHPL_FLAGS += -g
+   else
+   CHPL_FLAGS += --fast
+   endif
+
+   SOURCES := $(wildcard *.chpl)
+
+   $(TARGET): $(SOURCES)
+   	$(CHPL) $(CHPL_FLAGS) $< -o $@
+
+   .PHONY: clean
+   clean:
+   	rm -f $(TARGET)
+
+This can be used by running ``make`` in the directory containing the Makefile.
+Running ``make DEBUG=1`` will compile the program with debugging enabled and
+``make clean`` will remove the compiled program.
+
+CMake
+^^^^^
+
+Chapel provides a few support files for building Chapel programs with CMake. The
+Chapel source tree contains a directory,
+`util/cmake <https://github.com/chapel-lang/chapel/tree/main/util/cmake>`_,
+which can be added to a CMake project to support building Chapel programs.
+Take the following steps:
+
+#. Copy the ``util/cmake`` directory from the Chapel source tree to your
+   project. You may want to copy the files to a subdirectory like ``cmake``, or
+   you can just copy them to the root of your project.
+#. Add ``find_package(chpl REQUIRED HINTS .)`` to your ``CMakeLists.txt`` file.
+
+For example, a simple ``CMakeLists.txt`` file that compiles a Chapel project
+might look like this:
+
+.. code-block:: cmake
+
+   cmake_minimum_required(VERSION 3.20)
+   find_package(chpl REQUIRED HINTS .)
+
+   project(myProgram LANGUAGES CHPL)
+
+   add_executable(myProgram main.chpl myModule.chpl)
+
+This can then be used like any other CMake project. For example, the following
+will build a release version of the program:
+
+.. code-block:: sh
+
+   mkdir build && cd build
+   cmake .. -DCMAKE_BUILD_TYPE=release
+   cmake --build .


### PR DESCRIPTION
Adds a new section to the [compiling](https://chapel-lang.org/docs/2.4/usingchapel/compiling.html) docs, listing various build systems users can use. This PR adds Mason (just a pointer to the mason docs really), Makefile, and CMake

[Reviewed by @lydia-duncan  and @arezaii]