### PR TITLE
limit email workflow to chapel-lang/chapel repo

### DIFF
--- a/.github/workflows/email.yml
+++ b/.github/workflows/email.yml
@@ -8,8 +8,8 @@ on:
 
 jobs:
   send_email:
-   # run this workflow step only when the PR is merged
-    if:  github.event.pull_request.merged == true
+   # run this workflow step only when the PR is merged, only on the chapel-lang/chapel repo.
+    if:  github.event.pull_request.merged == true && github.repository == 'chapel-lang/chapel'
     runs-on: ubuntu-latest
     steps:
       - name: print git events


### PR DESCRIPTION
This limits the github workflow `email` to only run on the `chapel-lang/chapel` repo. 

Currently if you merge a commit to the main branch of a fork the `email` workflow will fire and error out. This prevents it from running on forks. 

[reviewed by @arifthpe - thanks!]