### PR TITLE
Exclude ChapelSysCTypes from the documentation like other builtins

### DIFF
--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -183,6 +183,7 @@ exclude_patterns = ['Makefile',
                     'builtins/String.rst',
                     'modules/standard/AutoMath.rst',
                     'modules/standard/ChapelIO.rst',
+                    'modules/standard/ChapelSysCTypes.rst',
 
                     # exclude the chapel-py files
                     'tools/chapel-py/chapel-py-api-template.rst',


### PR DESCRIPTION
Fixes https://github.com/chapel-lang/chapel/issues/26871, by making sure that `ChapelSysCTypes` is excluded from sphinx as its already included in the CTypes docs

resolves https://github.com/chapel-lang/chapel/issues/26871

[Reviewed by @lydia-duncan]