### PR TITLE
Add suppressif for memleaks testing for importError test

### DIFF
--- a/test/library/packages/Python/correctness/importError.suppressif
+++ b/test/library/packages/Python/correctness/importError.suppressif
@@ -1,0 +1,2 @@
+# suppress due to https://github.com/chapel-lang/chapel/issues/26437
+EXECOPTS <= memLeaks

--- a/test/library/packages/Python/correctness/importError.suppressif
+++ b/test/library/packages/Python/correctness/importError.suppressif
@@ -1,2 +1,2 @@
-# suppress due to https://github.com/chapel-lang/chapel/issues/26437
+# memory leaks due to https://github.com/chapel-lang/chapel/issues/26437
 EXECOPTS <= memLeaks


### PR DESCRIPTION
Adds a suppressif for a new test which leaks memory due to https://github.com/chapel-lang/chapel/issues/26437

[Not reviewed, trivial]