### PR TITLE
Update IB/Omni-Path docs to talk about GASNet and MPI playing nice together / point to GASNet READMEs

### DIFF
--- a/doc/rst/platforms/infiniband.rst
+++ b/doc/rst/platforms/infiniband.rst
@@ -105,15 +105,17 @@ Selecting a Spawner
 Under the covers, ``gasnetrun_ibv``-based launchers must figure out
 how to spawn jobs and get them up and running on the compute nodes.
 GASNet's three ways of doing this on InfiniBand systems are ``ssh``,
-``pmi``, and ``mpi``.  When MPI is detected at configure time, it will
-be selected as the default, but we recommend using one of the other
-options if possible.
+``pmi``, and ``mpi``, described just below.  When MPI is detected at
+configure time, it will be selected as the default, but we recommend
+using one of the other options if possible.  This can be done by
+setting the ``GASNET_IBV_SPAWNER`` environment variable, whose legal
+values are:
 
-* ``ssh``: Based on our experience, we recommend launching with the
-  ``ssh`` option, if possible.  This requires the ability to ``ssh``
-  to the system's compute nodes, which is not supported by all
-  systems, depending on how they are configured.  See the following
-  sub-section for details on this option.
+* ``ssh``: Based on our experience, this is the preferred option, when
+  possible.  This requires the ability to ``ssh`` to the system's
+  compute nodes, which is not supported by all systems, depending on
+  how they are configured.  See the following sub-section for details
+  on this option.
   
 * ``pmi``: When GASNet's configure step detects a PMI-capable job
   scheduler like Slurm, ``pmi`` can be the next best choice because it
@@ -121,9 +123,9 @@ options if possible.
 
 * ``mpi``: When the previous cases are not options, ``mpi`` serves as
   a reasonable last resort.  Note that it may, depending on its
-  configuration, incur a performance penalty because MPI may be
-  running concurrently with GASNet.  See the second subsection below
-  for tips on this option.
+  configuration, incur a performance penalty due to competition
+  between MPI and GASNet for limited communication resources.  See the
+  second subsection below for best practices when using this option.
 
 
 Using SSH for Job Launch
@@ -174,8 +176,17 @@ configuration output.
 As mentioned above, a potential downside of using MPI for launching
 Chapel programs is that the resources that it requires to get the
 program up and running can interfere with those needed by GASNet.  In
-some cases, this can result in performance impacts, while in others,
-it can prevent GASNet from accessing the resources at all.
+some cases, this can result in negative impacts on performance.  In
+others, it can prevent GASNet from accessing the network resources it
+requires at all.  For example, the following error is an example of
+one in which MPI is preventing GASNet from accessing what it needs
+(albeit using the ``ofi`` conduit rather than the ``ibv`` conduit
+preferred for InfiniBand):
+
+.. code-block:: bash
+
+   *** FATAL ERROR (proc 0): in gasnetc_ofi_init() at /third-party/gasnet/gasnet-src/ofi-conduit/gasnet_ofi.c:1336: fi_endpoint for rdma failed: -22(Invalid argument)
+
 
 For tips and best practices about how to configure/use GASNet to avoid
 such conflicts with MPI, please refer to the section "Build-time

--- a/doc/rst/platforms/infiniband.rst
+++ b/doc/rst/platforms/infiniband.rst
@@ -114,8 +114,8 @@ values are:
 * ``ssh``: Based on our experience, this is the preferred option, when
   possible.  This requires the ability to ``ssh`` to the system's
   compute nodes, which is not supported by all systems, depending on
-  how they are configured.  See the following sub-section for details
-  on this option.
+  how they are configured.  See :ref:`the following
+  sub-section<using-ssh>` for details on this option.
   
 * ``pmi``: When GASNet's configure step detects a PMI-capable job
   scheduler like Slurm, ``pmi`` can be the next best choice because it
@@ -131,8 +131,10 @@ values are:
   a reasonable last resort.  Note that it may, depending on its
   configuration, incur a performance penalty due to competition
   between MPI and GASNet for limited communication resources.  See the
-  second subsection below for best practices when using this option.
+  :ref:`using-mpi` section below for best practices when using this
+  option.
 
+.. _using-ssh:
 
 Using SSH for Job Launch
 ------------------------
@@ -174,6 +176,7 @@ descriptions of ``GASNET_SSH_CMD`` and ``GASNET_SSH_OPTIONS`` in the
 (also available at
 ``$CHPL_HOME/third-party/gasnet/gasnet-src/other/ssh-spawner/README``).
 
+.. _using-mpi:
 
 Using MPI for Job Launch
 ------------------------

--- a/doc/rst/platforms/infiniband.rst
+++ b/doc/rst/platforms/infiniband.rst
@@ -119,8 +119,13 @@ values are:
   
 * ``pmi``: When GASNet's configure step detects a PMI-capable job
   scheduler like Slurm, ``pmi`` can be the next best choice because it
-  often "just works" and can reduce overhead compared to ``mpi``.
-
+  often "just works" and can reduce overhead compared to ``mpi``.  For
+  more information about this option, including how to configure job
+  launch via ``PMIRUN_CMD``, see the [GASNet README for the PMI-based
+  spawner](https://bitbucket.org/berkeleylab/gasnet/src/master/other/pmi-spawner/README)
+  (also available at
+  ``$CHPL_HOME/third-party/gasnet/gasnet-src/other/pmi-spawner/README``).
+  
 * ``mpi``: When the previous cases are not options, ``mpi`` serves as
   a reasonable last resort.  Note that it may, depending on its
   configuration, incur a performance penalty due to competition
@@ -160,6 +165,14 @@ If you see the same error message this may indicate ssh connections
 to compute nodes are not allowed, in which case using the MPI
 spawner may be your only option.
 
+For further information about environment variables that can be used
+to control how `ssh` is used to launch your Chapel program, see the
+descriptions of ``GASNET_SSH_CMD`` and ``GASNET_SSH_OPTIONS`` in the
+[GASNet README for the ssh
+spawner](https://bitbucket.org/berkeleylab/gasnet/src/master/other/ssh-spawner/README)
+(also available at
+``$CHPL_HOME/third-party/gasnet/gasnet-src/other/ssh-spawner/README``).
+
 
 Using MPI for Job Launch
 ------------------------
@@ -190,8 +203,12 @@ preferred for InfiniBand):
 
 For tips and best practices about how to configure/use GASNet to avoid
 such conflicts with MPI, please refer to the section "Build-time
-Configuration" in the [GASNet
-README](https://bitbucket.org/berkeleylab/gasnet/src/master/other/mpi-spawner/README).
+Configuration" in the [GASNet README for the MPI
+spawner](https://bitbucket.org/berkeleylab/gasnet/src/master/other/mpi-spawner/README)
+(also available at
+``$CHPL_HOME/third-party/gasnet/gasnet-src/other/mpi-spawner/README``).
+Within this README, see also the description of the ``MPIRUN_CMD``
+environment variable as a means of configuring how jobs are started.
    
 
 --------------------

--- a/doc/rst/platforms/infiniband.rst
+++ b/doc/rst/platforms/infiniband.rst
@@ -120,9 +120,10 @@ options if possible.
   often "just works" and can reduce overhead compared to ``mpi``.
 
 * ``mpi``: When the previous cases are not options, ``mpi`` serves as
-  a reasonable last resort.  Note that it can incur a performance
-  penalty because MPI will be running concurrently with GASNet.  See
-  the second subsection below for tips on this option.
+  a reasonable last resort.  Note that it may, depending on its
+  configuration, incur a performance penalty because MPI may be
+  running concurrently with GASNet.  See the second subsection below
+  for tips on this option.
 
 
 Using SSH for Job Launch
@@ -170,6 +171,17 @@ configuration output.
 
    export GASNET_IBV_SPAWNER=mpi
 
+As mentioned above, a potential downside of using MPI for launching
+Chapel programs is that the resources that it requires to get the
+program up and running can interfere with those needed by GASNet.  In
+some cases, this can result in performance impacts, while in others,
+it can prevent GASNet from accessing the resources at all.
+
+For tips and best practices about how to configure/use GASNet to avoid
+such conflicts with MPI, please refer to the section "Build-time
+Configuration" in the [GASNet
+README](https://bitbucket.org/berkeleylab/gasnet/src/master/other/mpi-spawner/README).
+   
 
 --------------------
 Verifying Job Launch

--- a/doc/rst/platforms/infiniband.rst
+++ b/doc/rst/platforms/infiniband.rst
@@ -367,8 +367,9 @@ blocking send and receive progress threads.
 See Also
 --------
 
-For more information on these and other available GASNet options,
-including configuring to launch through MPI, please refer to
-GASNet's official `InfiniBand conduit documentation
-<https://gasnet.lbl.gov/dist/ibv-conduit/README>`_, which can also be found
-in ``$CHPL_HOME/third-party/gasnet/gasnet-src/ibv-conduit/README``.
+For more information on these and other available GASNet options when
+targeting InfiniBand, please refer to GASNet's official `InfiniBand
+conduit documentation
+<https://gasnet.lbl.gov/dist/ibv-conduit/README>`_, which can also be
+found in
+``$CHPL_HOME/third-party/gasnet/gasnet-src/ibv-conduit/README``.

--- a/doc/rst/platforms/infiniband.rst
+++ b/doc/rst/platforms/infiniband.rst
@@ -121,8 +121,9 @@ values are:
   scheduler like Slurm, ``pmi`` can be the next best choice because it
   often "just works" and can reduce overhead compared to ``mpi``.  For
   more information about this option, including how to configure job
-  launch via ``PMIRUN_CMD``, see the [GASNet README for the PMI-based
-  spawner](https://bitbucket.org/berkeleylab/gasnet/src/master/other/pmi-spawner/README)
+  launch via ``PMIRUN_CMD``, see the `GASNet README for the PMI-based
+  spawner
+  <https://bitbucket.org/berkeleylab/gasnet/src/master/other/pmi-spawner/README>`_
   (also available at
   ``$CHPL_HOME/third-party/gasnet/gasnet-src/other/pmi-spawner/README``).
   
@@ -168,8 +169,8 @@ spawner may be your only option.
 For further information about environment variables that can be used
 to control how `ssh` is used to launch your Chapel program, see the
 descriptions of ``GASNET_SSH_CMD`` and ``GASNET_SSH_OPTIONS`` in the
-[GASNet README for the ssh
-spawner](https://bitbucket.org/berkeleylab/gasnet/src/master/other/ssh-spawner/README)
+`GASNet README for the ssh spawner
+<https://bitbucket.org/berkeleylab/gasnet/src/master/other/ssh-spawner/README>`_
 (also available at
 ``$CHPL_HOME/third-party/gasnet/gasnet-src/other/ssh-spawner/README``).
 
@@ -203,8 +204,8 @@ preferred for InfiniBand):
 
 For tips and best practices about how to configure/use GASNet to avoid
 such conflicts with MPI, please refer to the section "Build-time
-Configuration" in the [GASNet README for the MPI
-spawner](https://bitbucket.org/berkeleylab/gasnet/src/master/other/mpi-spawner/README)
+Configuration" in the `GASNet README for the MPI spawner
+<https://bitbucket.org/berkeleylab/gasnet/src/master/other/mpi-spawner/README>`_
 (also available at
 ``$CHPL_HOME/third-party/gasnet/gasnet-src/other/mpi-spawner/README``).
 Within this README, see also the description of the ``MPIRUN_CMD``

--- a/doc/rst/platforms/omnipath.rst
+++ b/doc/rst/platforms/omnipath.rst
@@ -72,8 +72,9 @@ values are:
   scheduler like Slurm, ``pmi`` can be the next best choice because it
   often "just works" and can reduce overhead compared to ``mpi``.  For
   more information about this option, including how to configure job
-  launch via ``PMIRUN_CMD``, see the [GASNet README for the PMI-based
-  spawner](https://bitbucket.org/berkeleylab/gasnet/src/master/other/pmi-spawner/README)
+  launch via ``PMIRUN_CMD``, see the `GASNet README for the PMI-based
+  spawner
+  <https://bitbucket.org/berkeleylab/gasnet/src/master/other/pmi-spawner/README>`_
   (also available at
   ``$CHPL_HOME/third-party/gasnet/gasnet-src/other/pmi-spawner/README``).
 
@@ -119,8 +120,8 @@ spawner may be your only option.
 For further information about environment variables that can be used
 to control how `ssh` is used to launch your Chapel program, see the
 descriptions of ``GASNET_SSH_CMD`` and ``GASNET_SSH_OPTIONS`` in the
-[GASNet README for the ssh
-spawner](https://bitbucket.org/berkeleylab/gasnet/src/master/other/ssh-spawner/README)
+`GASNet README for the ssh spawner
+<https://bitbucket.org/berkeleylab/gasnet/src/master/other/ssh-spawner/README>`_
 (also available at
 ``$CHPL_HOME/third-party/gasnet/gasnet-src/other/ssh-spawner/README``).
 
@@ -152,8 +153,8 @@ one in which MPI is preventing GASNet from accessing what it needs:
 
 For tips and best practices about how to configure/use GASNet to avoid
 such conflicts with MPI, please refer to the section "Build-time
-Configuration" in the [GASNet README for the MPI
-spawner](https://bitbucket.org/berkeleylab/gasnet/src/master/other/mpi-spawner/README)
+Configuration" in the `GASNet README for the MPI spawner
+<https://bitbucket.org/berkeleylab/gasnet/src/master/other/mpi-spawner/README>`_
 (also available at
 ``$CHPL_HOME/third-party/gasnet/gasnet-src/other/mpi-spawner/README``).
 Within this README, see also the description of the ``MPIRUN_CMD``

--- a/doc/rst/platforms/omnipath.rst
+++ b/doc/rst/platforms/omnipath.rst
@@ -70,7 +70,12 @@ values are:
   
 * ``pmi``: When GASNet's configure step detects a PMI-capable job
   scheduler like Slurm, ``pmi`` can be the next best choice because it
-  often "just works" and can reduce overhead compared to ``mpi``.
+  often "just works" and can reduce overhead compared to ``mpi``.  For
+  more information about this option, including how to configure job
+  launch via ``PMIRUN_CMD``, see the [GASNet README for the PMI-based
+  spawner](https://bitbucket.org/berkeleylab/gasnet/src/master/other/pmi-spawner/README)
+  (also available at
+  ``$CHPL_HOME/third-party/gasnet/gasnet-src/other/pmi-spawner/README``).
 
 * ``mpi``: When the previous cases are not options, ``mpi`` serves as
   a reasonable last resort.  Note that it may, depending on its
@@ -111,6 +116,14 @@ If you see the same error message this may indicate ssh connections
 to compute nodes are not allowed, in which case using the MPI
 spawner may be your only option.
 
+For further information about environment variables that can be used
+to control how `ssh` is used to launch your Chapel program, see the
+descriptions of ``GASNET_SSH_CMD`` and ``GASNET_SSH_OPTIONS`` in the
+[GASNet README for the ssh
+spawner](https://bitbucket.org/berkeleylab/gasnet/src/master/other/ssh-spawner/README)
+(also available at
+``$CHPL_HOME/third-party/gasnet/gasnet-src/other/ssh-spawner/README``).
+
 
 Using MPI for Job Launch
 ------------------------
@@ -139,8 +152,12 @@ one in which MPI is preventing GASNet from accessing what it needs:
 
 For tips and best practices about how to configure/use GASNet to avoid
 such conflicts with MPI, please refer to the section "Build-time
-Configuration" in the [GASNet
-README](https://bitbucket.org/berkeleylab/gasnet/src/master/other/mpi-spawner/README).
+Configuration" in the [GASNet README for the MPI
+spawner](https://bitbucket.org/berkeleylab/gasnet/src/master/other/mpi-spawner/README)
+(also available at
+``$CHPL_HOME/third-party/gasnet/gasnet-src/other/mpi-spawner/README``).
+Within this README, see also the description of the ``MPIRUN_CMD``
+environment variable as a means of configuring how jobs are started.
 
 
 --------------------

--- a/doc/rst/platforms/omnipath.rst
+++ b/doc/rst/platforms/omnipath.rst
@@ -53,15 +53,30 @@ slurm-gasnetrun_ofi   queue jobs using Slurm (srun/sbatch)
 Selecting a Spawner
 -------------------
 
-Under the covers ``gasnetrun_ofi``-based launchers must figure out
+Under the covers, ``gasnetrun_ofi``-based launchers must figure out
 how to spawn jobs and get them up and running on the compute nodes.
-GASNet's two primary means of doing this on Omni-Path clusters are
-``ssh`` and ``mpi``. GASNet will default to ``mpi`` if MPI support
-is detected at configure time, otherwise it will default to ``ssh``.
-Using ``mpi`` will likely incur a performance penalty because MPI
-will be running concurrently with GASNet. Running with ``ssh`` is
-recommended, but not all systems support ssh'ing to compute nodes so
-it is not always the default.
+GASNet's three ways of doing this on Omni-Path clusters are ``ssh``,
+``pmi``, and ``mpi``, described just below.  When MPI is detected at
+configure time, it will be selected as the default, but we recommend
+using one of the other options if possible.  This can be done by
+setting the ``GASNET_OFI_SPAWNER`` environment variable, whose legal
+values are:
+
+* ``ssh``: Based on our experience, this is the preferred option, when
+  possible.  This requires the ability to ``ssh`` to the system's
+  compute nodes, which is not supported by all systems, depending on
+  how they are configured.  See the following sub-section for details
+  on this option.
+  
+* ``pmi``: When GASNet's configure step detects a PMI-capable job
+  scheduler like Slurm, ``pmi`` can be the next best choice because it
+  often "just works" and can reduce overhead compared to ``mpi``.
+
+* ``mpi``: When the previous cases are not options, ``mpi`` serves as
+  a reasonable last resort.  Note that it may, depending on its
+  configuration, incur a performance penalty due to competition
+  between MPI and GASNet for limited communication resources.  See the
+  second subsection below for best practices when using this option.
 
 
 Using SSH for Job Launch
@@ -75,7 +90,7 @@ To launch Omni-Path jobs with SSH, use the following:
    export GASNET_OFI_SPAWNER=ssh
 
    # Specify the nodes to run on (only required when using plain
-   # gasnetrun_ofi outside a Slurm reservation)
+   # gasnetrun_ofi outside a Slurm/PBS/LSF reservation)
    export GASNET_SSH_SERVERS="nid00001 nid00002 nid00003 ..."
 
 If you receive an error message like:
@@ -109,9 +124,23 @@ configuration output.
 
    export GASNET_OFI_SPAWNER=mpi
 
-It's worth noting that some configurations do not allow opening the
-network device multiple times from a single process, so this method
-may not be reliable.
+As mentioned above, a potential downside of using MPI for launching
+Chapel programs is that the resources that it requires to get the
+program up and running can interfere with those needed by GASNet.  In
+some cases, this can result in negative impacts on performance.  In
+others, it can prevent GASNet from accessing the network resources it
+requires at all.  For example, the following error is an example of
+one in which MPI is preventing GASNet from accessing what it needs:
+
+.. code-block:: bash
+
+   *** FATAL ERROR (proc 0): in gasnetc_ofi_init() at /third-party/gasnet/gasnet-src/ofi-conduit/gasnet_ofi.c:1336: fi_endpoint for rdma failed: -22(Invalid argument)
+
+
+For tips and best practices about how to configure/use GASNet to avoid
+such conflicts with MPI, please refer to the section "Build-time
+Configuration" in the [GASNet
+README](https://bitbucket.org/berkeleylab/gasnet/src/master/other/mpi-spawner/README).
 
 
 --------------------

--- a/doc/rst/platforms/omnipath.rst
+++ b/doc/rst/platforms/omnipath.rst
@@ -196,8 +196,9 @@ may be required to get access to all cores.
 See Also
 --------
 
-For more information on these and other available GASNet options,
-including configuring to launch through MPI, please refer to
+For more information on these and other available options when
+targeting Omni-Path through GASNet via OFI/libfabric, please refer to
 GASNet's official `ofi conduit documentation
-<https://gasnet.lbl.gov/dist/ofi-conduit/README>`_, which can also be found
-in ``$CHPL_HOME/third-party/gasnet/gasnet-src/ofi-conduit/README``.
+<https://gasnet.lbl.gov/dist/ofi-conduit/README>`_, which can also be
+found in
+``$CHPL_HOME/third-party/gasnet/gasnet-src/ofi-conduit/README``.

--- a/doc/rst/platforms/omnipath.rst
+++ b/doc/rst/platforms/omnipath.rst
@@ -65,8 +65,8 @@ values are:
 * ``ssh``: Based on our experience, this is the preferred option, when
   possible.  This requires the ability to ``ssh`` to the system's
   compute nodes, which is not supported by all systems, depending on
-  how they are configured.  See the following sub-section for details
-  on this option.
+  how they are configured.  See :ref:`the following
+  sub-section<using-ssh>` for details on this option.
   
 * ``pmi``: When GASNet's configure step detects a PMI-capable job
   scheduler like Slurm, ``pmi`` can be the next best choice because it
@@ -82,7 +82,8 @@ values are:
   a reasonable last resort.  Note that it may, depending on its
   configuration, incur a performance penalty due to competition
   between MPI and GASNet for limited communication resources.  See the
-  second subsection below for best practices when using this option.
+  :ref:`using-mpi` section below for best practices when using this
+  option.
 
 
 Using SSH for Job Launch


### PR DESCRIPTION
This PR is motivated by a desire to talk more about how GASNet and MPI can conflict with one another in their desire for resources, leading to either performance hits or simply an error trying to acquire the desired resources.  It includes an error message that we've seen a few times (ourselves, and by users) in recent Omni-Path runs.  It primarily points off to GASNet documentation for remedies.

While here, I also did some wordsmithing (including an improvement suggested by Paul), added additional links to GASNet documentation about mpi/pmi/ssh spawners, and made sure the OmniPath and IB cases are still in sync (a few things had drifted apart).

Related to this PR:
* @jabraham17 has a start at an attempt to refactor our multilocale documentation to make it better organized and avoid repetition (https://github.com/chapel-lang/chapel/issues/25410)
* https://github.com/Cray/chapel-private/issues/6519 is an internal issue that documents an Omni-Path failure of this sort that we hit
* https://chapel.discourse.group/t/chapel-not-working-for-omnipath-slurm/40154 is a Discourse thread where a user hit this sort of Omni-Path failure.

Resolves #26676.