### PR TITLE
Fix bug in shoc-sort skipif

### DIFF
--- a/test/gpu/native/studies/shoc/shoc-sort.skipif
+++ b/test/gpu/native/studies/shoc/shoc-sort.skipif
@@ -6,7 +6,7 @@ check_conditions() {
 
     # Skip test in CPU-as-device mode
     if [[ "$chpl_gpu" == "cpu" ]]; then
-        return 1
+        return 0
     fi
 
     # Check if CHPL_GPU is 'amd' and CHPL_TEST_PERF_LABEL is set 


### PR DESCRIPTION
Because I forgot what is `true` in bash 🤦

- Now we're skipping in cpu-as-device again