### PR TITLE
Fix the partial checkout logic for arkouda testing

### DIFF
--- a/util/cron/common-arkouda.bash
+++ b/util/cron/common-arkouda.bash
@@ -50,8 +50,7 @@ function partial_checkout_release() {
   git checkout $CHPL_WHICH_RELEASE_FOR_ARKOUDA
   git checkout $currentSha -- $CHPL_HOME/test/
   git checkout $currentSha -- $CHPL_HOME/util/cron/
-  git checkout $currentSha -- $CHPL_HOME/util/test/perf/
-  git checkout $currentSha -- $CHPL_HOME/util/test/computePerfStats
+  git checkout $currentSha -- $CHPL_HOME/util/test/
   git checkout $currentSha -- $CHPL_HOME/third-party/chpl-venv/test-requirements.txt
 }
 


### PR DESCRIPTION
Fixes the partial checkout logic for arkouda testing to use the `util/test` from main.

[Reviewed by @DanilaFe]