### PR TITLE
Clean generated pytest files for chpl-language-server

### DIFF
--- a/tools/chpl-language-server/Makefile
+++ b/tools/chpl-language-server/Makefile
@@ -57,6 +57,7 @@ clobber: clean
 
 clean-pycache:
 	find $(CHPL_MAKE_HOME)/tools/chpl-language-server -type d -name __pycache__ -exec rm -rf {} +
+	rm -rf $(CHPL_MAKE_HOME)/tools/chpl-language-server/test/.pytest_cache
 
 clean-link:
 ifneq ($(wildcard $(link)),)


### PR DESCRIPTION
Adds logic to cleanup files generated by pytest when testing chpl-language-server

[Reviewed by @DanilaFe]