### PR TITLE
Add `embed-python.sh` script to make building Chapel+Python code easier

### DIFF
--- a/modules/packages/Python.chpl
+++ b/modules/packages/Python.chpl
@@ -38,18 +38,21 @@
   ---------------------
 
   Compiling Chapel code that uses this module needs the ``Python.h`` header file
-  and requires linking with the Python library. If ``python3`` is installed,
-  this can be achieved with the following commands:
+  and requires linking with the Python library. The ``embed-python.sh`` script
+  provided with Chapel can be used to generate the necessary compiler flags.
+  Assuming ``python3`` is installed into the system path, the following command
+  can be used to compile Chapel code that uses this module:
 
   .. code-block:: bash
 
-     PYTHON_INCLUDE_DIR=$(python3 -c "import sysconfig; print(sysconfig.get_paths()['include'])")
-     PYTHON_LIB_DIR=$(python3 -c "import sysconfig; print(sysconfig.get_config_var('LIBDIR'))")
-     PYTHON_LDVERSION=$(python3 -c "import sysconfig; print(sysconfig.get_config_var('LDVERSION'))")
+     chpl $($(chpl --print-chpl-home)/util/config/embed-python.sh) ...Chapel source files...
 
-     chpl --ccflags -isystem$PYTHON_INCLUDE_DIR \
-          -L$PYTHON_LIB_DIR --ldflags -Wl,-rpath,$PYTHON_LIB_DIR \
-          -lpython$PYTHON_LDVERSION ...Chapel source files...
+  Alternative Python installations can be used by setting the ``CHPL_PYTHON``
+  environment variable:
+
+  .. code-block:: bash
+
+     chpl $(CHPL_PYTHON=/path/to/python3 $(chpl --print-chpl-home)/util/config/embed-python.sh) ...Chapel source files...
 
   .. warning::
 

--- a/test/library/packages/Python/COMPOPTS
+++ b/test/library/packages/Python/COMPOPTS
@@ -7,14 +7,4 @@ else
   chpl_python=$($CHPL_HOME/util/config/find-python.sh)
 fi
 
-
-PYTHON_INCLUDE_DIR=$($chpl_python -c "import sysconfig; print(sysconfig.get_paths()['include'])")
-PYTHON_LIB_DIR=$($chpl_python -c "import sysconfig; print(sysconfig.get_config_var('LIBDIR'))")
-PYTHON_LDVERSION=$($chpl_python -c "import sysconfig; print(sysconfig.get_config_var('LDVERSION'))")
-
-DISABLE_WARNINGS=""
-# some older python's don't use `#ifndef` when they should
-# so we disable redefintion warnings for clean testing
-DISABLE_WARNINGS+="--ccflags -Wno-macro-redefined"
-
-echo "--ccflags -isystem$PYTHON_INCLUDE_DIR -L$PYTHON_LIB_DIR --ldflags -Wl,-rpath,$PYTHON_LIB_DIR -lpython$PYTHON_LDVERSION $DISABLE_WARNINGS"
+CHPL_PYTHON=$chpl_python $CHPL_HOME/util/config/embed-python.sh

--- a/util/config/embed-python.sh
+++ b/util/config/embed-python.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env sh
+
+#
+# This script prints the flags required by the Chapel compiler to embed Python
+# code in a Chapel program. It is intended to be used by consumers of the
+# 'Python' module. See https://chapel-lang.org/docs/modules/packages/Python.html
+#
+
+# get the chpl home directory
+chpl_home=$(cd $(dirname $0) ; cd ..; cd ..; pwd)
+chpl_python=$("$chpl_home/util/config/find-python.sh")
+
+PYTHON_INCLUDE_DIR=$($chpl_python -c "import sysconfig; print(sysconfig.get_paths()['include'])")
+PYTHON_LIB_DIR=$($chpl_python -c "import sysconfig; print(sysconfig.get_config_var('LIBDIR'))")
+PYTHON_LDVERSION=$($chpl_python -c "import sysconfig; print(sysconfig.get_config_var('LDVERSION'))")
+
+DISABLE_WARNINGS=""
+# some older python's don't use `#ifndef` when they should
+# so we disable redefinition warnings for clean testing
+DISABLE_WARNINGS+="--ccflags -Wno-macro-redefined"
+
+echo "--ccflags -isystem$PYTHON_INCLUDE_DIR -L$PYTHON_LIB_DIR --ldflags -Wl,-rpath,$PYTHON_LIB_DIR -lpython$PYTHON_LDVERSION $DISABLE_WARNINGS"


### PR DESCRIPTION
Adds an `embed-python.sh` script to make getting the right compilation flags for building Chapel with the Python module easier.

When running code with the Python module standalone, I usually reuse one of the test directories COMPOPTS, but that doesn't really help users. This PR essentially makes that COMPOPTS user-facing to make it easier for users.

As future work, I think we could consider a proper command-line option for the compiler for this, something like `chpl --embed-python .....`. But if we do that, I think the Python module should be treated more like a standard module than a package module.

[Reviewed by @lydia-duncan]