### PR TITLE
Dyno: Fix test-frontend segfaults

### DIFF
--- a/frontend/test/test-common.cpp
+++ b/frontend/test/test-common.cpp
@@ -80,9 +80,12 @@ const uast::AstNode* findOnlyNamed(const uast::Module* mod, std::string name) {
   return col.only();
 }
 
-static std::unique_ptr<Context> _reusedContext;
 
 chpl::Context* buildStdContext(chpl::CompilerFlags flags) {
+  // Note: If we make this 'global', we run into double-free errors most likely
+  // due to  some linking issue.
+  static std::unique_ptr<Context> _reusedContext;
+
   if (_reusedContext.get() == nullptr) {
     std::string chpl_home;
     if (const char* chpl_home_env = getenv("CHPL_HOME")) {


### PR DESCRIPTION
We appear to be encountering some kind of issue by placing this static variable at the file-level scope, which results in a double destruction of a ``Context``. Moving it inside ``buildStdContext`` resolves the failures.