### PR TITLE
Add CHPL_TARGET=hpe-cray-xd and Improve OFI_OOB detection

### DIFF
--- a/doc/rst/platforms/cray.rst
+++ b/doc/rst/platforms/cray.rst
@@ -95,7 +95,8 @@ Building Chapel for an HPE Cray System from Source
        System         CHPL_HOST_PLATFORM
        =============  ==================
        EX series      hpe-cray-ex
-       Apollo series  hpe-apollo   
+       Apollo series  hpe-apollo
+       XD series      hpe-cray-xd
        XC series      cray-xc
        CS series      cray-cs
        =============  ==================

--- a/doc/rst/platforms/infiniband.rst
+++ b/doc/rst/platforms/infiniband.rst
@@ -33,6 +33,12 @@ For HPE Apollo:
 
 .. code-block:: bash
 
+      export CHPL_HOST_PLATFORM=hpe-apollo
+
+For HPE Cray XD:
+
+.. code-block:: bash
+
       export CHPL_HOST_PLATFORM=hpe-cray-xd
 
 For Cray CS:

--- a/doc/rst/platforms/infiniband.rst
+++ b/doc/rst/platforms/infiniband.rst
@@ -25,7 +25,7 @@ Chapel with InfiniBand support, set:
       export CHPL_COMM=gasnet
       export CHPL_COMM_SUBSTRATE=ibv
 
-Alternatively, when running on an HPE Apollo or Cray CS system
+Alternatively, when running on an HPE Apollo, HPE Cray XD, Cray CS system
 ``CHPL_HOST_PLATFORM`` can be set instead, in which case the comm
 and substrate settings will be inferred.
 
@@ -33,7 +33,7 @@ For HPE Apollo:
 
 .. code-block:: bash
 
-      export CHPL_HOST_PLATFORM=hpe-apollo
+      export CHPL_HOST_PLATFORM=hpe-cray-xd
 
 For Cray CS:
 

--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -106,6 +106,7 @@ CHPL_HOST_PLATFORM
         cray-xc      Cray XC\ |trade|
         hpe-cray-ex  HPE Cray EX
         hpe-apollo   HPE Apollo
+        hpe-cray-xd  HPE Cray XD
         ===========  ==================================
 
    Platform-specific documentation is available for most of these platforms in

--- a/util/chplenv/chpl_comm.py
+++ b/util/chplenv/chpl_comm.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import sys
+import shutil
 
 import chpl_platform, overrides
 from utils import memoize
@@ -16,15 +17,18 @@ def get():
         # Use ofi on hpe-cray-ex
         elif platform_val == 'hpe-cray-ex':
             comm_val = 'ofi'
-        elif platform_val == 'hpe-cray-xd':
-            # could be slingshot (ofi) or ibv (gasnet)
-            # default to ofi for now
-            comm_val = 'ofi'
         # Use gasnet on cray-cs and hpe-apollo
         elif platform_val in ('cray-cs', 'hpe-apollo'):
             comm_val = 'gasnet'
+        # use gasnet for ibv
+        elif shutil.which('ibstat'):
+            comm_val = 'gasnet'
+        # use ofi for slingshot
+        elif shutil.which('cxi_stat'):
+            comm_val = 'ofi'
         else:
             comm_val = 'none'
+
     return comm_val
 
 

--- a/util/chplenv/chpl_comm.py
+++ b/util/chplenv/chpl_comm.py
@@ -26,6 +26,9 @@ def get():
         # use ofi for slingshot
         elif shutil.which('cxi_stat'):
             comm_val = 'ofi'
+        # default to ofi on cray-xd when we can't determine ib/cxi
+        elif platform_val == 'hpe-cray-xd':
+            comm_val = 'ofi'
         else:
             comm_val = 'none'
 

--- a/util/chplenv/chpl_comm.py
+++ b/util/chplenv/chpl_comm.py
@@ -11,8 +11,14 @@ def get():
     comm_val = overrides.get('CHPL_COMM')
     if not comm_val:
         platform_val = chpl_platform.get('target')
+        # use gasnet for ibv
+        if shutil.which('ibstat'):
+            comm_val = 'gasnet'
+        # use ofi for slingshot
+        elif shutil.which('cxi_stat'):
+            comm_val = 'ofi'
         # Use ugni on cray-xc series
-        if platform_val == 'cray-xc':
+        elif platform_val == 'cray-xc':
             comm_val = 'ugni'
         # Use ofi on hpe-cray-ex
         elif platform_val == 'hpe-cray-ex':
@@ -20,13 +26,7 @@ def get():
         # Use gasnet on cray-cs and hpe-apollo
         elif platform_val in ('cray-cs', 'hpe-apollo'):
             comm_val = 'gasnet'
-        # use gasnet for ibv
-        elif shutil.which('ibstat'):
-            comm_val = 'gasnet'
-        # use ofi for slingshot
-        elif shutil.which('cxi_stat'):
-            comm_val = 'ofi'
-        # default to ofi on cray-xd when we can't determine ib/cxi
+        # default to ofi on cray-xd when we can't determine ib vs cxi
         elif platform_val == 'hpe-cray-xd':
             comm_val = 'ofi'
         else:

--- a/util/chplenv/chpl_comm.py
+++ b/util/chplenv/chpl_comm.py
@@ -16,6 +16,10 @@ def get():
         # Use ofi on hpe-cray-ex
         elif platform_val == 'hpe-cray-ex':
             comm_val = 'ofi'
+        elif platform_val == 'hpe-cray-xd':
+            # could be slingshot (ofi) or ibv (gasnet)
+            # default to ofi for now
+            comm_val = 'ofi'
         # Use gasnet on cray-cs and hpe-apollo
         elif platform_val in ('cray-cs', 'hpe-apollo'):
             comm_val = 'gasnet'

--- a/util/chplenv/chpl_comm.py
+++ b/util/chplenv/chpl_comm.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 import sys
+import os
+import re
 import shutil
 
-import chpl_platform, overrides
+import overrides
 from utils import memoize
 
 
@@ -10,30 +12,88 @@ from utils import memoize
 def get():
     comm_val = overrides.get('CHPL_COMM')
     if not comm_val:
-        platform_val = chpl_platform.get('target')
-        # use gasnet for ibv
-        if shutil.which('ibstat'):
-            comm_val = 'gasnet'
-        # use ofi for slingshot
-        elif shutil.which('cxi_stat'):
-            comm_val = 'ofi'
-        # Use ugni on cray-xc series
-        elif platform_val == 'cray-xc':
+        network = get_network()
+        if network == 'aries':
             comm_val = 'ugni'
-        # Use ofi on hpe-cray-ex
-        elif platform_val == 'hpe-cray-ex':
-            comm_val = 'ofi'
-        # Use gasnet on cray-cs and hpe-apollo
-        elif platform_val in ('cray-cs', 'hpe-apollo'):
+        elif network == 'ibv':
             comm_val = 'gasnet'
-        # default to ofi on cray-xd when we can't determine ib vs cxi
-        elif platform_val == 'hpe-cray-xd':
+        elif network == 'cxi':
             comm_val = 'ofi'
         else:
-            comm_val = 'none'
+            # fall back to platform detection if we can't determine the network
+            import chpl_platform
+            platform_val = chpl_platform.get('target')
+            # Use ugni on cray-xc series
+            if platform_val == 'cray-xc':
+                comm_val = 'ugni'
+            # Use ofi on hpe-cray-ex
+            elif platform_val == 'hpe-cray-ex':
+                comm_val = 'ofi'
+            # Use gasnet on cray-cs and hpe-apollo
+            elif platform_val in ('cray-cs', 'hpe-apollo'):
+                comm_val = 'gasnet'
+            # default to ofi on cray-xd when we can't determine ib vs cxi
+            elif platform_val == 'hpe-cray-xd':
+                comm_val = 'ofi'
+            else:
+                comm_val = 'none'
 
     return comm_val
 
+
+@memoize
+def _is_aries():
+    # Check for cray platform. It is a cray platform if there is a
+    # cle-release/CLEinfo config file with a known network value in it.
+    cle_info_file = os.path.abspath('/etc/opt/cray/release/cle-release') # CLE >= 6
+    if not os.path.exists(cle_info_file):
+        cle_info_file = os.path.abspath('/etc/opt/cray/release/CLEinfo') # CLE <= 5
+
+    if os.path.exists(cle_info_file):
+        with open(cle_info_file, 'r') as fp:
+            cle_info = fp.read()
+        net_pattern = re.compile('^NETWORK=(?P<net>[a-zA-Z]+)$', re.MULTILINE)
+        net_match = net_pattern.search(cle_info)
+        if net_match is not None and len(net_match.groups()) == 1:
+            net = net_match.group('net')
+            if net.lower() == 'ari':
+                return True
+    return False
+
+@memoize
+def _is_ibv():
+    """
+    Look for '/dev/infiniband/uverbs0' and '/sys/class/net/ib*'
+    """
+    return (shutil.which('ibstat') and
+            os.path.exists('/dev/infiniband/uverbs0') and
+            any(dev.startswith('ib') for dev in os.listdir('/sys/class/net/')))
+
+@memoize
+def _is_cxi():
+    """
+    Look for '/sys/class/net/hsn*', '/sys/class/cxi/', and '/dev/cxi*'
+    """
+    return (shutil.which('cxi_stat') and
+            any(dev.startswith('hsn') for dev in os.listdir('/sys/class/net/')) and
+            os.path.exists('/sys/class/cxi/') and
+            any(dev.startswith('cxi') for dev in os.listdir('/dev/')))
+
+@memoize
+def get_network():
+    """
+    Determines NIC of the current system, must be 'cxi', 'ibv', 'aries', or 'unknown'
+    """
+    network = None
+    if _is_aries():
+        network = 'aries'
+    elif _is_ibv():
+        network = 'ibv'
+    elif _is_cxi():
+        network = 'cxi'
+    else:
+        network = 'unknown'
+    return network
 
 def _main():
     comm_val = get()

--- a/util/chplenv/chpl_comm.py
+++ b/util/chplenv/chpl_comm.py
@@ -82,7 +82,8 @@ def _is_cxi():
 @memoize
 def get_network():
     """
-    Determines NIC of the current system, must be 'cxi', 'ibv', 'aries', or 'unknown'
+    Guesses the network type of the current system.
+    Returns 'cxi', 'ibv', 'aries', or 'unknown'
     """
     network = None
     if _is_aries():

--- a/util/chplenv/chpl_comm_ofi_oob.py
+++ b/util/chplenv/chpl_comm_ofi_oob.py
@@ -27,14 +27,20 @@ def get():
     #
     platform_val = chpl_platform.get('target')
     launcher_val = chpl_launcher.get()
-    if platform_val in ('cray-xc', 'hpe-cray-ex'):
+    if 'cray-x' in platform_val or platform_val == 'hpe-cray-ex':
         oob_val = 'pmi2'
     elif 'cray-' in platform_val:
         oob_val = 'mpi'
     elif 'mpi' in launcher_val:
         oob_val = 'mpi'
     else:
-        oob_val = 'sockets'
+        import chpl_compiler
+        if third_party_utils.pkgconfig_system_has_package('pmi2'):
+            oob_val = 'pmi2'
+        elif "-lpmi2" in chpl_compiler.get_system_link_args('target'):
+            oob_val = 'pmi2'
+        else:
+            oob_val = 'sockets'
 
     return oob_val
 

--- a/util/chplenv/chpl_comm_ofi_oob.py
+++ b/util/chplenv/chpl_comm_ofi_oob.py
@@ -27,7 +27,7 @@ def get():
     #
     platform_val = chpl_platform.get('target')
     launcher_val = chpl_launcher.get()
-    if 'cray-x' in platform_val or platform_val == 'hpe-cray-ex':
+    if 'cray-x' in platform_val or chpl_platform.is_hpe_cray('target'):
         oob_val = 'pmi2'
     elif 'cray-' in platform_val:
         oob_val = 'mpi'

--- a/util/chplenv/chpl_comm_segment.py
+++ b/util/chplenv/chpl_comm_segment.py
@@ -15,7 +15,7 @@ def get():
             platform_val = chpl_platform.get('target')
             if substrate_val in ('aries', 'smp', 'ucx'):
                 segment_val = 'fast'
-            elif substrate_val == 'ofi' and platform_val == 'hpe-cray-ex':
+            elif substrate_val == 'ofi' and chpl_platform.is_hpe_cray('target'):
                 segment_val = 'fast'
             elif substrate_val == 'ibv':
                 segment_val = 'large'

--- a/util/chplenv/chpl_comm_substrate.py
+++ b/util/chplenv/chpl_comm_substrate.py
@@ -14,6 +14,10 @@ def get():
         platform_val = chpl_platform.get('target')
 
         if comm_val == 'gasnet':
+            if shutil.which('ibstat'):
+                substrate_val = 'ibv'
+            elif shutil.which('cxi_stat'):
+                substrate_val = 'ofi'
             if platform_val == 'cray-xc':
                 substrate_val = 'aries'
             elif platform_val == 'hpe-cray-ex':
@@ -22,10 +26,6 @@ def get():
                 substrate_val = 'ibv'
             elif platform_val == 'pwr6':
                 substrate_val = 'ibv'
-            elif shutil.which('ibstat'):
-                substrate_val = 'ibv'
-            elif shutil.which('cxi_stat'):
-                substrate_val = 'ofi'
             else:
                 substrate_val = 'udp'
         else:

--- a/util/chplenv/chpl_comm_substrate.py
+++ b/util/chplenv/chpl_comm_substrate.py
@@ -22,6 +22,9 @@ def get():
                 substrate_val = 'aries'
             elif platform_val == 'hpe-cray-ex':
                 substrate_val = 'ofi'
+            elif platform_val == 'hpe-cray-xd':
+                # default to ofi on XD when we can't determine ib vs cxi
+                substrate_val = 'ofi'
             elif platform_val in ('cray-cs', 'hpe-apollo'):
                 substrate_val = 'ibv'
             elif platform_val == 'pwr6':

--- a/util/chplenv/chpl_comm_substrate.py
+++ b/util/chplenv/chpl_comm_substrate.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import sys
+import shutil
 
 import chpl_comm, chpl_platform, overrides
 from utils import memoize
@@ -21,6 +22,10 @@ def get():
                 substrate_val = 'ibv'
             elif platform_val == 'pwr6':
                 substrate_val = 'ibv'
+            elif shutil.which('ibstat'):
+                substrate_val = 'ibv'
+            elif shutil.which('cxi_stat'):
+                substrate_val = 'ofi'
             else:
                 substrate_val = 'udp'
         else:

--- a/util/chplenv/chpl_comm_substrate.py
+++ b/util/chplenv/chpl_comm_substrate.py
@@ -18,7 +18,7 @@ def get():
                 substrate_val = 'ibv'
             elif shutil.which('cxi_stat'):
                 substrate_val = 'ofi'
-            if platform_val == 'cray-xc':
+            elif platform_val == 'cray-xc':
                 substrate_val = 'aries'
             elif platform_val == 'hpe-cray-ex':
                 substrate_val = 'ofi'

--- a/util/chplenv/chpl_compiler.py
+++ b/util/chplenv/chpl_compiler.py
@@ -28,7 +28,7 @@ def validate_compiler(compiler_val, flag):
 @memoize
 def get_prgenv_compiler():
     platform_val = chpl_platform.get('target')
-    if platform_val.startswith('cray-x') or platform_val == 'hpe-cray-ex':
+    if 'cray-x' in platform_val or platform_val == 'hpe-cray-ex':
         subcompiler = os.environ.get('PE_ENV', 'none')
         if subcompiler != 'none':
             return "cray-prgenv-{0}".format(subcompiler.lower())

--- a/util/chplenv/chpl_compiler.py
+++ b/util/chplenv/chpl_compiler.py
@@ -28,7 +28,7 @@ def validate_compiler(compiler_val, flag):
 @memoize
 def get_prgenv_compiler():
     platform_val = chpl_platform.get('target')
-    if 'cray-x' in platform_val or platform_val == 'hpe-cray-ex':
+    if 'cray-x' in platform_val or chpl_platform.is_hpe_cray('target'):
         subcompiler = os.environ.get('PE_ENV', 'none')
         if subcompiler != 'none':
             return "cray-prgenv-{0}".format(subcompiler.lower())

--- a/util/chplenv/chpl_cpu.py
+++ b/util/chplenv/chpl_cpu.py
@@ -71,12 +71,13 @@ def get_module_lcd_cpu(platform_val, cpu):
             return "arm-thunderx2"
         else:
             return "sandybridge"
-    elif platform_val == "hpe-cray-ex":
+    elif chpl_platform.is_hpe_cray('target'):
         if is_known_arm(cpu):
             return "none"    # we don't know what we need here yet
         else:
             cray_network = os.environ.get('CRAYPE_NETWORK_TARGET', 'none')
             if cray_network.startswith("slingshot") or cray_network == "ofi":
+                # TODO: this is not always true, it just means this has a PrgEnv module
                 return "x86-rome"       # We're building on an HPE Cray EX system!
             else:
                 return "sandybridge"    # We're still building on an XC.

--- a/util/chplenv/chpl_libfabric.py
+++ b/util/chplenv/chpl_libfabric.py
@@ -13,7 +13,6 @@ def get():
     comm_val = chpl_comm.get()
     if comm_val == 'ofi':
         libfabric_val = overrides.get('CHPL_LIBFABRIC')
-        platform_val = chpl_platform.get('target')
         if not libfabric_val:
             if third_party_utils.pkgconfig_system_has_package('libfabric'):
                 libfabric_val = 'system'
@@ -21,8 +20,8 @@ def get():
                 libfabric_val = 'bundled'
         if libfabric_val == 'none':
             error("CHPL_LIBFABRIC must not be 'none' when CHPL_COMM is ofi")
-        elif platform_val == 'hpe-cray-ex' and libfabric_val != 'system':
-            warning('CHPL_LIBFABRIC!=system is discouraged on HPE Cray EX')
+        elif chpl_platform.is_hpe_cray('target') and libfabric_val != 'system':
+            warning('CHPL_LIBFABRIC!=system is discouraged on HPE Cray')
     else:
         libfabric_val = 'none'
 

--- a/util/chplenv/chpl_libfabric.py
+++ b/util/chplenv/chpl_libfabric.py
@@ -62,16 +62,6 @@ def get_compile_args():
                 error("Could not find a system install of 'libfabric', try setting LIBFABRIC_DIR")
             args = x
 
-    if libfabric_val == 'system' or libfabric_val == 'bundled':
-        flags = [ ]
-        ofi_oob_val = chpl_comm_ofi_oob.get()
-        if ofi_oob_val == 'mpi':
-            mpi_dir_val = overrides.get_environ('MPI_DIR')
-            if mpi_dir_val:
-                flags.append('-I' + mpi_dir_val + '/include')
-
-        args[1].extend(flags)
-
     return args
 
 
@@ -110,35 +100,6 @@ def get_link_args():
                     libs.append(pcl.replace('-L', '-Wl,-rpath,', 1))
 
         args[1].extend(libs)
-
-    if libfabric_val == 'system' or libfabric_val == 'bundled':
-        libs = [ ]
-        ofi_oob_val = chpl_comm_ofi_oob.get()
-        if ofi_oob_val == 'mpi':
-            mpi_dir_val = overrides.get_environ('MPI_DIR')
-            if mpi_dir_val:
-                mpi_lib_dir = os.path.join(mpi_dir_val, 'lib64')
-                if not os.path.exists(mpi_lib_dir):
-                    mpi_lib_dir = os.path.join(mpi_dir_val, 'lib')
-                    if not os.path.exists(mpi_lib_dir):
-                        mpi_lib_dir = None
-
-                if mpi_lib_dir:
-                    libs.append('-L' + mpi_lib_dir)
-                    libs.append('-Wl,-rpath,' + mpi_lib_dir)
-                    mpi_lib_name = 'mpi'
-                    if glob.glob(mpi_lib_dir + '/libmpich.*'):
-                        mpi_lib_name = 'mpich'
-                    libs.append('-l' + mpi_lib_name)
-
-        # If we're using the PMI2 out-of-band support we have to reference
-        # libpmi2 explicitly, except on Cray XC systems.
-        platform_val = chpl_platform.get('target')
-        if ofi_oob_val == 'pmi2' and 'cray-xc' != platform_val:
-            libs.append('-lpmi2')
-
-        args[1].extend(libs)
-
 
     return args
 

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -1041,7 +1041,7 @@ def gather_pe_chpl_pkgconfig_libs():
 
     ret = os.environ.get('PE_CHAPEL_PKGCONFIG_LIBS', '')
     if comm != 'none':
-        if platform != 'hpe-cray-ex':
+        if not chpl_platform.is_hpe_cray('target'):
             # Adding -lhugetlbfs gets the PrgEnv driver to add the appropriate
             # linker option for static linking with it. While it's not always
             # used with Chapel programs, it is expected to be the common case

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -1074,7 +1074,6 @@ def gather_pe_chpl_pkgconfig_libs():
 @memoize
 def get_clang_prgenv_args():
 
-    platform = chpl_platform.get('target')
     comp_args = [ ]
     link_args = [ ]
 

--- a/util/chplenv/chpl_platform.py
+++ b/util/chplenv/chpl_platform.py
@@ -40,6 +40,8 @@ def get(flag='host'):
     if not platform_val:
         network = os.environ.get('CRAYPE_NETWORK_TARGET', '')
         if network.startswith("slingshot") or network == "ofi":
+            # TODO: This is not really true, as this env is set to ofi on
+            # HPE Cray XD systems as well. but this is a decent enough guess
             platform_val = 'hpe-cray-ex'
 
     if not platform_val:

--- a/util/chplenv/compile_link_args_utils.py
+++ b/util/chplenv/compile_link_args_utils.py
@@ -145,6 +145,8 @@ def compute_internal_compile_link_args(runtime_subdir):
     if chpl_comm.get() == 'ofi':
         extend2(tgt_compile, chpl_libfabric.get_compile_args())
         extend2(tgt_link, chpl_libfabric.get_link_args())
+        extend2(tgt_compile, chpl_comm_ofi_oob.get_compile_args())
+        extend2(tgt_link, chpl_comm_ofi_oob.get_link_args())
     elif chpl_comm.get() == 'gasnet':
         extend2(tgt_compile, chpl_gasnet.get_compile_args())
         extend2(tgt_link, chpl_gasnet.get_link_args())

--- a/util/chplenv/third_party_utils.py
+++ b/util/chplenv/third_party_utils.py
@@ -189,7 +189,7 @@ def pkgconfig_get_bundled_compile_args(pkg, ucp='', pcfile=''):
 # default static value for pkgconfig_get_system_link_args
 # and pkgconfig_get_bundled_link_args
 def pkgconfig_default_static():
-    static = chpl_platform.get('target')!='hpe-cray-ex'
+    static = not chpl_platform.is_hpe_cray('target')
     return static
 
 #


### PR DESCRIPTION
This PR adds support for setting `CHPL_HOST_TARGET=hpe-cray-xd` to support that platform. This also includes adding logic to distinguish between an XD with slingshot and infiniband.

This PR makes several other improvements, including improving OFI_OOB detection, general infiniband detection, general slingshot detection, and general refactoring

Tested on
- 3 different EXs with slingshot
- 2 different XD with IBV
- an hpe apollo with IBV
- an XC

This PR resolves https://github.com/chapel-lang/chapel/issues/26917 and resolves https://github.com/chapel-lang/chapel/issues/26918


[Reviewed by @mppf]
