### PR TITLE
Add `--temp-directory` for arkouda testing

### DIFF
--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -22,6 +22,8 @@ if [ -n "${CHPL_TEST_LAUNCHCMD}" ] ; then
   export ARKOUDA_SERVER_LAUNCH_PREFIX=$(echo "$CHPL_TEST_LAUNCHCMD --walltime=$ARKOUDA_ALLOC_TIMEOUT" | envsubst)
 fi
 
+export ARKOUDA_PYTEST_OPTIONS=${CHPL_TEST_ARKOUDA_PYTEST_OPTIONS:-""}
+
 # Arkouda needs chpl in PATH
 bin_subdir=$($CHPL_HOME/util/chplenv/chpl_bin_subdir.py)
 export "PATH=$CHPL_HOME/bin/$bin_subdir:$PATH"

--- a/util/cron/common-arkouda-hpe-apollo-hdr.bash
+++ b/util/cron/common-arkouda-hpe-apollo-hdr.bash
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+#
+# Configure environment for arkouda testing on hpe-apollo-hdr
+
+PYTEST_TEMP_DIR=/hpelustre/chapelu/arkouda-scratch/$CHPL_NIGHTLY_TEST_CONFIG_NAME
+rm -rf $PYTEST_TEMP_DIR; mkdir -p $PYTEST_TEMP_DIR
+export CHPL_TEST_ARKOUDA_PYTEST_OPTIONS="--temp-directory=$PYTEST_TEMP_DIR"

--- a/util/cron/test-hpe-apollo-hdr.arkouda.bash
+++ b/util/cron/test-hpe-apollo-hdr.arkouda.bash
@@ -19,6 +19,8 @@ source $UTIL_CRON_DIR/common-hpe-apollo.bash
 #
 # setup arkouda
 source $UTIL_CRON_DIR/common-arkouda.bash
+source $UTIL_CRON_DIR/common-arkouda-hpe-apollo-hdr.bash
+
 export ARKOUDA_NUMLOCALES=16
 
 export CHPL_GASNET_SEGMENT=fast

--- a/util/cron/test-hpe-apollo-hdr.arkouda.release.bash
+++ b/util/cron/test-hpe-apollo-hdr.arkouda.release.bash
@@ -19,6 +19,8 @@ source $UTIL_CRON_DIR/common-hpe-apollo.bash
 #
 # setup arkouda
 source $UTIL_CRON_DIR/common-arkouda.bash
+source $UTIL_CRON_DIR/common-arkouda-hpe-apollo-hdr.bash
+
 export ARKOUDA_NUMLOCALES=16
 
 export CHPL_GASNET_SEGMENT=fast

--- a/util/cron/test-perf.hpe-apollo-hdr.arkouda.bash
+++ b/util/cron/test-perf.hpe-apollo-hdr.arkouda.bash
@@ -22,9 +22,6 @@ source $UTIL_CRON_DIR/common-perf-hpe-apollo-hdr.bash
 # setup arkouda
 source $UTIL_CRON_DIR/common-arkouda.bash
 
-PYTEST_TEMP_DIR=/hpelustre/chapelu/arkouda-scratch/$CHPL_NIGHTLY_TEST_CONFIG_NAME
-rm -rf $PYTEST_TEMP_DIR; mkdir -p $PYTEST_TEMP_DIR
-export CHPL_TEST_ARKOUDA_PYTEST_OPTIONS="--temp-directory=$PYTEST_TEMP_DIR"
 export ARKOUDA_NUMLOCALES=16
 
 export CHPL_GASNET_SEGMENT=fast

--- a/util/cron/test-perf.hpe-apollo-hdr.arkouda.bash
+++ b/util/cron/test-perf.hpe-apollo-hdr.arkouda.bash
@@ -21,6 +21,10 @@ source $UTIL_CRON_DIR/common-perf-hpe-apollo-hdr.bash
 #
 # setup arkouda
 source $UTIL_CRON_DIR/common-arkouda.bash
+
+PYTEST_TEMP_DIR=/hpelustre/chapelu/arkouda-scratch/$CHPL_NIGHTLY_TEST_CONFIG_NAME
+rm -rf $PYTEST_TEMP_DIR; mkdir -p $PYTEST_TEMP_DIR
+export CHPL_TEST_ARKOUDA_PYTEST_OPTIONS="--temp-directory=$PYTEST_TEMP_DIR"
 export ARKOUDA_NUMLOCALES=16
 
 export CHPL_GASNET_SEGMENT=fast

--- a/util/cron/test-perf.hpe-apollo-hdr.arkouda.release.bash
+++ b/util/cron/test-perf.hpe-apollo-hdr.arkouda.release.bash
@@ -21,6 +21,7 @@ source $UTIL_CRON_DIR/common-perf-hpe-apollo-hdr.bash
 #
 # setup arkouda
 source $UTIL_CRON_DIR/common-arkouda.bash
+
 export ARKOUDA_NUMLOCALES=16
 
 export CHPL_GASNET_SEGMENT=fast


### PR DESCRIPTION
Adds `--temp-directory` for arkouda testing, to workaround filesystem issues on our test systems

[Reviewed by @e-kayrakli]