### PR TITLE
Fix too much memory being used by comm handles on ofi

### DIFF
--- a/runtime/src/chpl-cache.c
+++ b/runtime/src/chpl-cache.c
@@ -1985,12 +1985,12 @@ chpl_bool do_wait_for(struct rdcache_s* cache, cache_seqn_t sn)
                       chpl_nodeID, (int)chpl_task_getId(),
                       (int) cache->pending_sequence_numbers[index],
                       (int) cache->completed_request_number));
-    }
-
-    // Stop if we have an uncompleted request for a later sequence number
-    if (cache->pending_sequence_numbers[index] > sn) {
-      DEBUG_PRINT(("wait_for stopped at %i\n", index));
-      break;
+    } else {
+      // Stop if we have an uncompleted request for a later sequence number
+      if (cache->pending_sequence_numbers[index] > sn) {
+        DEBUG_PRINT(("wait_for stopped at %i\n", index));
+        break;
+      }
     }
   }
   return waited;


### PR DESCRIPTION
This PR fixes a problem that I was observing with a suffix sorting application where it was requiring significantly more memory than I expected when running with CHPL_COMM=ofi.

The issue is that the `--cache-remote` code will do non-blocking PUTs (generally speaking). Meanwhile, the ofi comm layer allocates some memory for each nonblocking handle. There is code to free a handle in `do_wait_for`, but this code will only free one handle per trip through the `while` loop, and the `while` loop is stopped if the pending sequence numbers of the later requests are larger. However, the runtime might have already completed such requests, so this PR adjusts this loop so that it keeps running until one of the following conditions is met:
 * there are no more pending requests
 * there is a pending request with a later sequence number that the comms layer does not think is already complete

Before this PR, this loop would stop if there was a pending request with a later sequence number, regardless of whether the comms layer thinks it is complete. That behavior resulted in the possibility of having many comm handles stacking up for completed operations, waiting to be freed.