### PR TITLE
Add `repr` method to Python.Value base class

### DIFF
--- a/modules/packages/Python.chpl
+++ b/modules/packages/Python.chpl
@@ -1529,6 +1529,21 @@ module Python {
     }
 
     /*
+      Returns the debug string representation of the object.
+
+      Equivalent to calling ``repr(obj)`` in Python.
+    */
+    proc repr(): string throws {
+      var g = PyGILState_Ensure();
+      defer PyGILState_Release(g);
+      var pyStr = PyObject_Repr(this.obj);
+      this.interpreter.checkException();
+      var res = interpreter.fromPythonInner(string, pyStr);
+      return res;
+    }
+
+
+    /*
       Treat this value as a callable and call it with the given arguments.
 
       This handles conversion from Chapel types to Python types and back, by
@@ -2837,6 +2852,7 @@ module Python {
     extern "chpl_Py_CLEAR" proc Py_CLEAR(obj: c_ptr(PyObjectPtr));
     extern proc PyMem_Free(ptr: c_ptr(void));
     extern proc PyObject_Str(obj: PyObjectPtr): PyObjectPtr; // `str(obj)`
+    extern proc PyObject_Repr(obj: PyObjectPtr): PyObjectPtr; // `repr(obj)`
     extern proc PyImport_ImportModule(name: c_ptrConst(c_char)): PyObjectPtr;
 
     extern "chpl_PY_VERSION_HEX" const PY_VERSION_HEX: uint(64);

--- a/test/library/packages/Python/correctness/objToString.chpl
+++ b/test/library/packages/Python/correctness/objToString.chpl
@@ -1,0 +1,37 @@
+use Python, List, Set, Map;
+var interp = new Interpreter();
+
+var mod = interp.importModule("mod", """
+class my_class:
+  def __init__(self, *args):
+    self.args = args
+
+  def __str__(self):
+    return ', '.join(map(str, self.args))
+
+  def __repr__(self):
+    return f"my_class({', '.join(map(repr, self.args))})"
+""");
+
+proc test(obj: borrowed) {
+  writeln("str: ", obj.str());
+  writeln("repr: ", obj.repr());
+  writeln("default: ", obj);
+  writeln("================");
+}
+
+var my_class = mod.get('my_class');
+
+test(new Value(interp, "hello"));
+test(new Value(interp, interp.toPython(1)));
+test(new Value(interp, [1, 2, 3]));
+
+test(my_class(1, 2, 3));
+test(my_class("hello", "world"));
+test(my_class(1, "hello", 2, "world"));
+
+var m = new map(string, int);
+m["hello"] = 1;
+m["world"] = 2;
+test(my_class(new list([1, 2, 3]), new set(string, ["hello", "world"]), m));
+

--- a/test/library/packages/Python/correctness/objToString.good
+++ b/test/library/packages/Python/correctness/objToString.good
@@ -1,0 +1,28 @@
+str: hello
+repr: 'hello'
+default: hello
+================
+str: 1
+repr: 1
+default: 1
+================
+str: [1, 2, 3]
+repr: [1, 2, 3]
+default: [1, 2, 3]
+================
+str: 1, 2, 3
+repr: my_class(1, 2, 3)
+default: 1, 2, 3
+================
+str: hello, world
+repr: my_class('hello', 'world')
+default: hello, world
+================
+str: 1, hello, 2, world
+repr: my_class(1, 'hello', 2, 'world')
+default: 1, hello, 2, world
+================
+str: [1, 2, 3], {'world', 'hello'}, {'hello': 1, 'world': 2}
+repr: my_class([1, 2, 3], {'world', 'hello'}, {'hello': 1, 'world': 2})
+default: [1, 2, 3], {'world', 'hello'}, {'hello': 1, 'world': 2}
+================


### PR DESCRIPTION
Adds `repr` as a standalone method to the Python.Value base class. This corresponds to the Python `repr(obj)`.

[Reviewed by @lydia-duncan]