### PR TITLE
Exclude generated chplcheck rules from the docs

### DIFF
--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -188,6 +188,7 @@ exclude_patterns = ['Makefile',
                     # exclude the chapel-py files
                     'tools/chapel-py/chapel-py-api-template.rst',
                     'tools/chapel-py/chapel-py-api.rst',
+                    'tools/chplcheck/generated/rules.rst',
                    ]
 
 # The reST default role (used for this markup: `text`) to use for all


### PR DESCRIPTION
Exclude generated chplcheck rules from the docs, since it gets brought in by `.. include`. This fixes an issue where the docs had duplicate entries for the chplcheck rules. This was only visible by URL manipulation or from the search bar

[Reviewed by @DanilaFe]