### PR TITLE
Install CMake files for Chapel projects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ comprt: FORCE
 	@$(MAKE) always-build-cls
 	@$(MAKE) runtime
 	@$(MAKE) modules
+	@$(MAKE) chpl-cmake-module-files
 
 notcompiler: FORCE
 	@$(MAKE) third-party-try-opt
@@ -204,6 +205,10 @@ chpl-language-server: frontend-shared FORCE
 	@# the time of writing this target is always FORCEd (so we'd end up
 	@# building it twice).
 	cd tools/chpl-language-server && $(MAKE) all install
+
+chpl-cmake-module-files: FORCE
+	@echo "Generating CMake module files..."
+	@cd compiler && $(MAKE) chpl-cmake-module-files
 
 lint-standard-modules: chplcheck FORCE
 	tools/chplcheck/chplcheck --skip-unstable \

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -65,12 +65,15 @@ clean-cmakecache: FORCE
 
 cleanall: $(CLEANALLSUBDIRS) echocompilerdir
 	rm -rf $(CLEANALL_TARGS)
+	@$(MAKE) clean-chpl-cmake-module-files
 
 cleandeps: $(CLEANSUBDIRDEPS) echocompilerdir
 	rm -f $(DEPENDS)
+	@$(MAKE) clean-chpl-cmake-module-files
 
 clobber: $(CLOBBERSUBDIRS) echocompilerdir
 	rm -rf ./$(CLOBBER_TARGS)
+	@$(MAKE) clean-chpl-cmake-module-files
 
 
 #
@@ -95,6 +98,7 @@ $(CHPL_CONFIG_CHECK): | $(CHPL_BIN_DIR)
 
 
 COMPILER_LIB_DIR = $(CHPL_MAKE_HOME)/lib/compiler/$(CHPL_MAKE_HOST_BIN_SUBDIR)
+CMAKE_LIB_DIR = $(CHPL_MAKE_HOME)/lib/cmake/chpl
 
 CMAKE_FLAGS = -DCMAKE_RUNTIME_OUTPUT_DIRECTORY=$(CHPL_BIN_DIR) -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=$(COMPILER_LIB_DIR) -DCHPL_CXX_FLAGS="$(COMP_CXXFLAGS)" -DCHPL_LD_FLAGS="$(LDFLAGS)"
 
@@ -150,6 +154,7 @@ clean: FORCE $(CLEANSUBDIRS) echocompilerdir
 	fi
 	rm -f $(CLEAN_TARGS)
 	@$(MAKE) clean-cmakecache
+	@$(MAKE) clean-chpl-cmake-module-files
 
 # used in test-frontend to make sure cmake is configured with assertions on
 CMAKE_FLAGS_NO_NDEBUG=$(subst -DNDEBUG,,$(CMAKE_FLAGS))
@@ -214,10 +219,19 @@ chpldoc: FORCE $(CHPLDOC)
 
 MAKEALLCHPLDEFSUBDIRS = $(CHPLDEF_SUBDIRS:%=%.makedir)
 
+chpl-cmake-module-files: FORCE $(CMAKE_LIB_DIR)
+	cp $(CHPL_MAKE_HOME)/util/cmake/*.cmake $(CHPL_MAKE_HOME)/util/cmake/*.cmake.in $(CMAKE_LIB_DIR)
+
+clean-chpl-cmake-module-files: FORCE
+	rm -rf $(CMAKE_LIB_DIR)
+
 $(COMPILER_BUILD):
 	mkdir -p $@
 
 $(CHPL_BIN_DIR):
+	mkdir -p $@
+
+$(CMAKE_LIB_DIR):
 	mkdir -p $@
 
 install-chpl-chpldoc: FORCE $(CHPL_CONFIG_CHECK)

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -65,11 +65,9 @@ clean-cmakecache: FORCE
 
 cleanall: $(CLEANALLSUBDIRS) echocompilerdir
 	rm -rf $(CLEANALL_TARGS)
-	@$(MAKE) clean-chpl-cmake-module-files
 
 cleandeps: $(CLEANSUBDIRDEPS) echocompilerdir
 	rm -f $(DEPENDS)
-	@$(MAKE) clean-chpl-cmake-module-files
 
 clobber: $(CLOBBERSUBDIRS) echocompilerdir
 	rm -rf ./$(CLOBBER_TARGS)
@@ -154,7 +152,6 @@ clean: FORCE $(CLEANSUBDIRS) echocompilerdir
 	fi
 	rm -f $(CLEAN_TARGS)
 	@$(MAKE) clean-cmakecache
-	@$(MAKE) clean-chpl-cmake-module-files
 
 # used in test-frontend to make sure cmake is configured with assertions on
 CMAKE_FLAGS_NO_NDEBUG=$(subst -DNDEBUG,,$(CMAKE_FLAGS))

--- a/util/buildRelease/install.sh
+++ b/util/buildRelease/install.sh
@@ -127,6 +127,7 @@ then
   DEST_RUNTIME_LIB="$PREFIX/lib/chapel/$VERS/runtime/lib"
   DEST_RUNTIME_INCL="$PREFIX/lib/chapel/$VERS/runtime/include"
   DEST_THIRD_PARTY="$PREFIX/lib/chapel/$VERS/third-party"
+  DEST_CMAKE_LIB="$PREFIX/lib/cmake/chpl"
   DEST_CHPL_HOME="$PREFIX/share/chapel/$VERS"
   echo "Installing Chapel split to bin, lib, share to $PREFIX"
   if [ "$CHPL_HOME" = "$PREFIX" ]
@@ -140,6 +141,7 @@ else
   DEST_RUNTIME_LIB="$DEST_DIR/lib"
   DEST_RUNTIME_INCL="$DEST_DIR/runtime/include"
   DEST_THIRD_PARTY="$DEST_DIR/third-party"
+  DEST_CMAKE_LIB="$DEST_DIR/lib/cmake/chpl"
   DEST_CHPL_HOME="$DEST_DIR"
   echo "Installing Chapel-as-a-directory to $DEST_DIR"
   if [ "$CHPL_HOME" = "$DEST_DIR" ]
@@ -246,6 +248,8 @@ myinstallfileto () {
 
 # copy compiler and runtime lib
 myinstalldir  lib                     "$DEST_RUNTIME_LIB"
+# copy cmake files to the cmake lib directory
+myinstalldir  lib/cmake/chpl          "$DEST_CMAKE_LIB"
 
 # copy runtime include
 myinstalldir  runtime/include         "$DEST_RUNTIME_INCL"

--- a/util/chplenv/chpl_home_utils.py
+++ b/util/chplenv/chpl_home_utils.py
@@ -229,6 +229,10 @@ def _main():
                       dest='func', const=using_chapel_module)
     parser.add_option('--configured-install-lib-prefix', action='store_const',
                       dest='func', const=get_chpl_configured_install_lib_prefix)
+    parser.add_option('--runtime-lib', action='store_const',
+                      dest='func', const=get_chpl_runtime_lib)
+    parser.add_option('--runtime-incl', action='store_const',
+                      dest='func', const=get_chpl_runtime_incl)
     (options, args) = parser.parse_args()
 
     if options.func:

--- a/util/packaging/apt/common/copy_files.py
+++ b/util/packaging/apt/common/copy_files.py
@@ -1,4 +1,5 @@
 import sys
+import os
 import subprocess as sp
 from package_name import package_name
 
@@ -20,4 +21,6 @@ dirs = [
 for f in files:
     sp.check_call(["cp", f, f"{deb_name}{f}"])
 for d in dirs:
+    dirname = os.path.dirname(d)
+    os.makedirs(f"{deb_name}{dirname}", exist_ok=True)
     sp.check_call(["cp", "-r", d, f"{deb_name}{d}"])

--- a/util/packaging/apt/common/copy_files.py
+++ b/util/packaging/apt/common/copy_files.py
@@ -14,6 +14,7 @@ files = [
 ]
 dirs = [
     "/usr/lib/chapel",
+    "/usr/lib/cmake/chpl",
     "/usr/share/chapel",
 ]
 for f in files:

--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -92,6 +92,7 @@ class Chapel < Formula
     bin.install libexec.glob("bin/#{platform}/*")
     bin.env_script_all_files libexec/"bin"/platform, CHPL_HOME: libexec
     man1.install_symlink libexec.glob("man/man1/*.1")
+    (lib/"cmake/chpl").install libexec.glob("lib/cmake/chpl/*")
   end
 
   test do

--- a/util/packaging/rpm/amzn2023-gasnet-udp/spec.template
+++ b/util/packaging/rpm/amzn2023-gasnet-udp/spec.template
@@ -35,7 +35,7 @@ cp %{_prefix}/bin/chplcheck %{buildroot}/%{_prefix}/bin/chplcheck
 cp %{_prefix}/bin/chpl-language-server %{buildroot}/%{_prefix}/bin/chpl-language-server
 # Libraries
 cp -r %{_prefix}/lib/chapel %{buildroot}/%{_prefix}/lib/chapel
-cp -r %{_prefix}/lib/cmake/chpl %{buildroot}/%{_prefix}/lib/cmake/chpl
+cp -r %{_prefix}/lib/cmake/chpl %{buildroot}/%{_prefix}/lib/cmake
 # CHPL_HOME
 cp -r %{_prefix}/share/chapel %{buildroot}/%{_prefix}/share/chapel
 
@@ -47,5 +47,6 @@ cp -r %{_prefix}/share/chapel %{buildroot}/%{_prefix}/share/chapel
 %{_prefix}/bin/chpl-language-server
 %{_prefix}/lib/chapel/*
 %{_prefix}/share/chapel/*
+%{_prefix}/lib/cmake/chpl/*
 
 %changelog

--- a/util/packaging/rpm/amzn2023-gasnet-udp/spec.template
+++ b/util/packaging/rpm/amzn2023-gasnet-udp/spec.template
@@ -25,6 +25,7 @@ mkdir -p %{buildroot}/%{_prefix}
 mkdir -p %{buildroot}/%{_prefix}/bin
 mkdir -p %{buildroot}/%{_prefix}/lib
 mkdir -p %{buildroot}/%{_prefix}/share
+mkdir -p %{buildroot}/%{_prefix}/lib/cmake/chpl
 
 # Binaries
 cp %{_prefix}/bin/chpl %{buildroot}/%{_prefix}/bin/chpl
@@ -34,6 +35,7 @@ cp %{_prefix}/bin/chplcheck %{buildroot}/%{_prefix}/bin/chplcheck
 cp %{_prefix}/bin/chpl-language-server %{buildroot}/%{_prefix}/bin/chpl-language-server
 # Libraries
 cp -r %{_prefix}/lib/chapel %{buildroot}/%{_prefix}/lib/chapel
+cp -r %{_prefix}/lib/cmake/chpl %{buildroot}/%{_prefix}/lib/cmake/chpl
 # CHPL_HOME
 cp -r %{_prefix}/share/chapel %{buildroot}/%{_prefix}/share/chapel
 

--- a/util/packaging/rpm/amzn2023-ofi-slurm/spec.template
+++ b/util/packaging/rpm/amzn2023-ofi-slurm/spec.template
@@ -35,7 +35,7 @@ cp %{_prefix}/bin/chplcheck %{buildroot}/%{_prefix}/bin/chplcheck
 cp %{_prefix}/bin/chpl-language-server %{buildroot}/%{_prefix}/bin/chpl-language-server
 # Libraries
 cp -r %{_prefix}/lib/chapel %{buildroot}/%{_prefix}/lib/chapel
-cp -r %{_prefix}/lib/cmake/chpl %{buildroot}/%{_prefix}/lib/cmake/chpl
+cp -r %{_prefix}/lib/cmake/chpl %{buildroot}/%{_prefix}/lib/cmake
 # CHPL_HOME
 cp -r %{_prefix}/share/chapel %{buildroot}/%{_prefix}/share/chapel
 
@@ -47,5 +47,6 @@ cp -r %{_prefix}/share/chapel %{buildroot}/%{_prefix}/share/chapel
 %{_prefix}/bin/chpl-language-server
 %{_prefix}/lib/chapel/*
 %{_prefix}/share/chapel/*
+%{_prefix}/lib/cmake/chpl/*
 
 %changelog

--- a/util/packaging/rpm/amzn2023-ofi-slurm/spec.template
+++ b/util/packaging/rpm/amzn2023-ofi-slurm/spec.template
@@ -25,6 +25,7 @@ mkdir -p %{buildroot}/%{_prefix}
 mkdir -p %{buildroot}/%{_prefix}/bin
 mkdir -p %{buildroot}/%{_prefix}/lib
 mkdir -p %{buildroot}/%{_prefix}/share
+mkdir -p %{buildroot}/%{_prefix}/lib/cmake/chpl
 
 # Binaries
 cp %{_prefix}/bin/chpl %{buildroot}/%{_prefix}/bin/chpl
@@ -34,6 +35,7 @@ cp %{_prefix}/bin/chplcheck %{buildroot}/%{_prefix}/bin/chplcheck
 cp %{_prefix}/bin/chpl-language-server %{buildroot}/%{_prefix}/bin/chpl-language-server
 # Libraries
 cp -r %{_prefix}/lib/chapel %{buildroot}/%{_prefix}/lib/chapel
+cp -r %{_prefix}/lib/cmake/chpl %{buildroot}/%{_prefix}/lib/cmake/chpl
 # CHPL_HOME
 cp -r %{_prefix}/share/chapel %{buildroot}/%{_prefix}/share/chapel
 

--- a/util/packaging/rpm/amzn2023/spec.template
+++ b/util/packaging/rpm/amzn2023/spec.template
@@ -35,7 +35,7 @@ cp %{_prefix}/bin/chplcheck %{buildroot}/%{_prefix}/bin/chplcheck
 cp %{_prefix}/bin/chpl-language-server %{buildroot}/%{_prefix}/bin/chpl-language-server
 # Libraries
 cp -r %{_prefix}/lib/chapel %{buildroot}/%{_prefix}/lib/chapel
-cp -r %{_prefix}/lib/cmake/chpl %{buildroot}/%{_prefix}/lib/cmake/chpl
+cp -r %{_prefix}/lib/cmake/chpl %{buildroot}/%{_prefix}/lib/cmake
 # CHPL_HOME
 cp -r %{_prefix}/share/chapel %{buildroot}/%{_prefix}/share/chapel
 
@@ -47,5 +47,6 @@ cp -r %{_prefix}/share/chapel %{buildroot}/%{_prefix}/share/chapel
 %{_prefix}/bin/chpl-language-server
 %{_prefix}/lib/chapel/*
 %{_prefix}/share/chapel/*
+%{_prefix}/lib/cmake/chpl/*
 
 %changelog

--- a/util/packaging/rpm/amzn2023/spec.template
+++ b/util/packaging/rpm/amzn2023/spec.template
@@ -25,6 +25,7 @@ mkdir -p %{buildroot}/%{_prefix}
 mkdir -p %{buildroot}/%{_prefix}/bin
 mkdir -p %{buildroot}/%{_prefix}/lib
 mkdir -p %{buildroot}/%{_prefix}/share
+mkdir -p %{buildroot}/%{_prefix}/lib/cmake/chpl
 
 # Binaries
 cp %{_prefix}/bin/chpl %{buildroot}/%{_prefix}/bin/chpl
@@ -34,6 +35,7 @@ cp %{_prefix}/bin/chplcheck %{buildroot}/%{_prefix}/bin/chplcheck
 cp %{_prefix}/bin/chpl-language-server %{buildroot}/%{_prefix}/bin/chpl-language-server
 # Libraries
 cp -r %{_prefix}/lib/chapel %{buildroot}/%{_prefix}/lib/chapel
+cp -r %{_prefix}/lib/cmake/chpl %{buildroot}/%{_prefix}/lib/cmake/chpl
 # CHPL_HOME
 cp -r %{_prefix}/share/chapel %{buildroot}/%{_prefix}/share/chapel
 

--- a/util/packaging/rpm/el9-gasnet-udp/spec.template
+++ b/util/packaging/rpm/el9-gasnet-udp/spec.template
@@ -35,7 +35,7 @@ cp %{_prefix}/bin/chplcheck %{buildroot}/%{_prefix}/bin/chplcheck
 cp %{_prefix}/bin/chpl-language-server %{buildroot}/%{_prefix}/bin/chpl-language-server
 # Libraries
 cp -r %{_prefix}/lib/chapel %{buildroot}/%{_prefix}/lib/chapel
-cp -r %{_prefix}/lib/cmake/chpl %{buildroot}/%{_prefix}/lib/cmake/chpl
+cp -r %{_prefix}/lib/cmake/chpl %{buildroot}/%{_prefix}/lib/cmake
 # CHPL_HOME
 cp -r %{_prefix}/share/chapel %{buildroot}/%{_prefix}/share/chapel
 
@@ -47,5 +47,6 @@ cp -r %{_prefix}/share/chapel %{buildroot}/%{_prefix}/share/chapel
 %{_prefix}/bin/chpl-language-server
 %{_prefix}/lib/chapel/*
 %{_prefix}/share/chapel/*
+%{_prefix}/lib/cmake/chpl/*
 
 %changelog

--- a/util/packaging/rpm/el9-gasnet-udp/spec.template
+++ b/util/packaging/rpm/el9-gasnet-udp/spec.template
@@ -25,6 +25,7 @@ mkdir -p %{buildroot}/%{_prefix}
 mkdir -p %{buildroot}/%{_prefix}/bin
 mkdir -p %{buildroot}/%{_prefix}/lib
 mkdir -p %{buildroot}/%{_prefix}/share
+mkdir -p %{buildroot}/%{_prefix}/lib/cmake/chpl
 
 # Binaries
 cp %{_prefix}/bin/chpl %{buildroot}/%{_prefix}/bin/chpl
@@ -34,6 +35,7 @@ cp %{_prefix}/bin/chplcheck %{buildroot}/%{_prefix}/bin/chplcheck
 cp %{_prefix}/bin/chpl-language-server %{buildroot}/%{_prefix}/bin/chpl-language-server
 # Libraries
 cp -r %{_prefix}/lib/chapel %{buildroot}/%{_prefix}/lib/chapel
+cp -r %{_prefix}/lib/cmake/chpl %{buildroot}/%{_prefix}/lib/cmake/chpl
 # CHPL_HOME
 cp -r %{_prefix}/share/chapel %{buildroot}/%{_prefix}/share/chapel
 

--- a/util/packaging/rpm/el9-ofi-slurm/spec.template
+++ b/util/packaging/rpm/el9-ofi-slurm/spec.template
@@ -35,7 +35,7 @@ cp %{_prefix}/bin/chplcheck %{buildroot}/%{_prefix}/bin/chplcheck
 cp %{_prefix}/bin/chpl-language-server %{buildroot}/%{_prefix}/bin/chpl-language-server
 # Libraries
 cp -r %{_prefix}/lib/chapel %{buildroot}/%{_prefix}/lib/chapel
-cp -r %{_prefix}/lib/cmake/chpl %{buildroot}/%{_prefix}/lib/cmake/chpl
+cp -r %{_prefix}/lib/cmake/chpl %{buildroot}/%{_prefix}/lib/cmake
 # CHPL_HOME
 cp -r %{_prefix}/share/chapel %{buildroot}/%{_prefix}/share/chapel
 
@@ -47,5 +47,6 @@ cp -r %{_prefix}/share/chapel %{buildroot}/%{_prefix}/share/chapel
 %{_prefix}/bin/chpl-language-server
 %{_prefix}/lib/chapel/*
 %{_prefix}/share/chapel/*
+%{_prefix}/lib/cmake/chpl/*
 
 %changelog

--- a/util/packaging/rpm/el9-ofi-slurm/spec.template
+++ b/util/packaging/rpm/el9-ofi-slurm/spec.template
@@ -25,6 +25,7 @@ mkdir -p %{buildroot}/%{_prefix}
 mkdir -p %{buildroot}/%{_prefix}/bin
 mkdir -p %{buildroot}/%{_prefix}/lib
 mkdir -p %{buildroot}/%{_prefix}/share
+mkdir -p %{buildroot}/%{_prefix}/lib/cmake/chpl
 
 # Binaries
 cp %{_prefix}/bin/chpl %{buildroot}/%{_prefix}/bin/chpl
@@ -34,6 +35,7 @@ cp %{_prefix}/bin/chplcheck %{buildroot}/%{_prefix}/bin/chplcheck
 cp %{_prefix}/bin/chpl-language-server %{buildroot}/%{_prefix}/bin/chpl-language-server
 # Libraries
 cp -r %{_prefix}/lib/chapel %{buildroot}/%{_prefix}/lib/chapel
+cp -r %{_prefix}/lib/cmake/chpl %{buildroot}/%{_prefix}/lib/cmake/chpl
 # CHPL_HOME
 cp -r %{_prefix}/share/chapel %{buildroot}/%{_prefix}/share/chapel
 

--- a/util/packaging/rpm/el9/spec.template
+++ b/util/packaging/rpm/el9/spec.template
@@ -35,7 +35,7 @@ cp %{_prefix}/bin/chplcheck %{buildroot}/%{_prefix}/bin/chplcheck
 cp %{_prefix}/bin/chpl-language-server %{buildroot}/%{_prefix}/bin/chpl-language-server
 # Libraries
 cp -r %{_prefix}/lib/chapel %{buildroot}/%{_prefix}/lib/chapel
-cp -r %{_prefix}/lib/cmake/chpl %{buildroot}/%{_prefix}/lib/cmake/chpl
+cp -r %{_prefix}/lib/cmake/chpl %{buildroot}/%{_prefix}/lib/cmake
 # CHPL_HOME
 cp -r %{_prefix}/share/chapel %{buildroot}/%{_prefix}/share/chapel
 
@@ -47,5 +47,6 @@ cp -r %{_prefix}/share/chapel %{buildroot}/%{_prefix}/share/chapel
 %{_prefix}/bin/chpl-language-server
 %{_prefix}/lib/chapel/*
 %{_prefix}/share/chapel/*
+%{_prefix}/lib/cmake/chpl/*
 
 %changelog

--- a/util/packaging/rpm/el9/spec.template
+++ b/util/packaging/rpm/el9/spec.template
@@ -25,6 +25,7 @@ mkdir -p %{buildroot}/%{_prefix}
 mkdir -p %{buildroot}/%{_prefix}/bin
 mkdir -p %{buildroot}/%{_prefix}/lib
 mkdir -p %{buildroot}/%{_prefix}/share
+mkdir -p %{buildroot}/%{_prefix}/lib/cmake/chpl
 
 # Binaries
 cp %{_prefix}/bin/chpl %{buildroot}/%{_prefix}/bin/chpl
@@ -34,6 +35,7 @@ cp %{_prefix}/bin/chplcheck %{buildroot}/%{_prefix}/bin/chplcheck
 cp %{_prefix}/bin/chpl-language-server %{buildroot}/%{_prefix}/bin/chpl-language-server
 # Libraries
 cp -r %{_prefix}/lib/chapel %{buildroot}/%{_prefix}/lib/chapel
+cp -r %{_prefix}/lib/cmake/chpl %{buildroot}/%{_prefix}/lib/cmake/chpl
 # CHPL_HOME
 cp -r %{_prefix}/share/chapel %{buildroot}/%{_prefix}/share/chapel
 

--- a/util/packaging/rpm/fc40-gasnet-udp/spec.template
+++ b/util/packaging/rpm/fc40-gasnet-udp/spec.template
@@ -35,7 +35,7 @@ cp %{_prefix}/bin/chplcheck %{buildroot}/%{_prefix}/bin/chplcheck
 cp %{_prefix}/bin/chpl-language-server %{buildroot}/%{_prefix}/bin/chpl-language-server
 # Libraries
 cp -r %{_prefix}/lib/chapel %{buildroot}/%{_prefix}/lib/chapel
-cp -r %{_prefix}/lib/cmake/chpl %{buildroot}/%{_prefix}/lib/cmake/chpl
+cp -r %{_prefix}/lib/cmake/chpl %{buildroot}/%{_prefix}/lib/cmake
 # CHPL_HOME
 cp -r %{_prefix}/share/chapel %{buildroot}/%{_prefix}/share/chapel
 
@@ -47,5 +47,6 @@ cp -r %{_prefix}/share/chapel %{buildroot}/%{_prefix}/share/chapel
 %{_prefix}/bin/chpl-language-server
 %{_prefix}/lib/chapel/*
 %{_prefix}/share/chapel/*
+%{_prefix}/lib/cmake/chpl/*
 
 %changelog

--- a/util/packaging/rpm/fc40-gasnet-udp/spec.template
+++ b/util/packaging/rpm/fc40-gasnet-udp/spec.template
@@ -25,6 +25,7 @@ mkdir -p %{buildroot}/%{_prefix}
 mkdir -p %{buildroot}/%{_prefix}/bin
 mkdir -p %{buildroot}/%{_prefix}/lib
 mkdir -p %{buildroot}/%{_prefix}/share
+mkdir -p %{buildroot}/%{_prefix}/lib/cmake/chpl
 
 # Binaries
 cp %{_prefix}/bin/chpl %{buildroot}/%{_prefix}/bin/chpl
@@ -34,6 +35,7 @@ cp %{_prefix}/bin/chplcheck %{buildroot}/%{_prefix}/bin/chplcheck
 cp %{_prefix}/bin/chpl-language-server %{buildroot}/%{_prefix}/bin/chpl-language-server
 # Libraries
 cp -r %{_prefix}/lib/chapel %{buildroot}/%{_prefix}/lib/chapel
+cp -r %{_prefix}/lib/cmake/chpl %{buildroot}/%{_prefix}/lib/cmake/chpl
 # CHPL_HOME
 cp -r %{_prefix}/share/chapel %{buildroot}/%{_prefix}/share/chapel
 

--- a/util/packaging/rpm/fc40/spec.template
+++ b/util/packaging/rpm/fc40/spec.template
@@ -35,7 +35,7 @@ cp %{_prefix}/bin/chplcheck %{buildroot}/%{_prefix}/bin/chplcheck
 cp %{_prefix}/bin/chpl-language-server %{buildroot}/%{_prefix}/bin/chpl-language-server
 # Libraries
 cp -r %{_prefix}/lib/chapel %{buildroot}/%{_prefix}/lib/chapel
-cp -r %{_prefix}/lib/cmake/chpl %{buildroot}/%{_prefix}/lib/cmake/chpl
+cp -r %{_prefix}/lib/cmake/chpl %{buildroot}/%{_prefix}/lib/cmake
 # CHPL_HOME
 cp -r %{_prefix}/share/chapel %{buildroot}/%{_prefix}/share/chapel
 
@@ -47,5 +47,6 @@ cp -r %{_prefix}/share/chapel %{buildroot}/%{_prefix}/share/chapel
 %{_prefix}/bin/chpl-language-server
 %{_prefix}/lib/chapel/*
 %{_prefix}/share/chapel/*
+%{_prefix}/lib/cmake/chpl/*
 
 %changelog

--- a/util/packaging/rpm/fc40/spec.template
+++ b/util/packaging/rpm/fc40/spec.template
@@ -25,6 +25,7 @@ mkdir -p %{buildroot}/%{_prefix}
 mkdir -p %{buildroot}/%{_prefix}/bin
 mkdir -p %{buildroot}/%{_prefix}/lib
 mkdir -p %{buildroot}/%{_prefix}/share
+mkdir -p %{buildroot}/%{_prefix}/lib/cmake/chpl
 
 # Binaries
 cp %{_prefix}/bin/chpl %{buildroot}/%{_prefix}/bin/chpl
@@ -34,6 +35,7 @@ cp %{_prefix}/bin/chplcheck %{buildroot}/%{_prefix}/bin/chplcheck
 cp %{_prefix}/bin/chpl-language-server %{buildroot}/%{_prefix}/bin/chpl-language-server
 # Libraries
 cp -r %{_prefix}/lib/chapel %{buildroot}/%{_prefix}/lib/chapel
+cp -r %{_prefix}/lib/cmake/chpl %{buildroot}/%{_prefix}/lib/cmake/chpl
 # CHPL_HOME
 cp -r %{_prefix}/share/chapel %{buildroot}/%{_prefix}/share/chapel
 

--- a/util/packaging/rpm/fc41-gasnet-udp/spec.template
+++ b/util/packaging/rpm/fc41-gasnet-udp/spec.template
@@ -35,7 +35,7 @@ cp %{_prefix}/bin/chplcheck %{buildroot}/%{_prefix}/bin/chplcheck
 cp %{_prefix}/bin/chpl-language-server %{buildroot}/%{_prefix}/bin/chpl-language-server
 # Libraries
 cp -r %{_prefix}/lib/chapel %{buildroot}/%{_prefix}/lib/chapel
-cp -r %{_prefix}/lib/cmake/chpl %{buildroot}/%{_prefix}/lib/cmake/chpl
+cp -r %{_prefix}/lib/cmake/chpl %{buildroot}/%{_prefix}/lib/cmake
 # CHPL_HOME
 cp -r %{_prefix}/share/chapel %{buildroot}/%{_prefix}/share/chapel
 
@@ -47,5 +47,6 @@ cp -r %{_prefix}/share/chapel %{buildroot}/%{_prefix}/share/chapel
 %{_prefix}/bin/chpl-language-server
 %{_prefix}/lib/chapel/*
 %{_prefix}/share/chapel/*
+%{_prefix}/lib/cmake/chpl/*
 
 %changelog

--- a/util/packaging/rpm/fc41-gasnet-udp/spec.template
+++ b/util/packaging/rpm/fc41-gasnet-udp/spec.template
@@ -25,6 +25,7 @@ mkdir -p %{buildroot}/%{_prefix}
 mkdir -p %{buildroot}/%{_prefix}/bin
 mkdir -p %{buildroot}/%{_prefix}/lib
 mkdir -p %{buildroot}/%{_prefix}/share
+mkdir -p %{buildroot}/%{_prefix}/lib/cmake/chpl
 
 # Binaries
 cp %{_prefix}/bin/chpl %{buildroot}/%{_prefix}/bin/chpl
@@ -34,6 +35,7 @@ cp %{_prefix}/bin/chplcheck %{buildroot}/%{_prefix}/bin/chplcheck
 cp %{_prefix}/bin/chpl-language-server %{buildroot}/%{_prefix}/bin/chpl-language-server
 # Libraries
 cp -r %{_prefix}/lib/chapel %{buildroot}/%{_prefix}/lib/chapel
+cp -r %{_prefix}/lib/cmake/chpl %{buildroot}/%{_prefix}/lib/cmake/chpl
 # CHPL_HOME
 cp -r %{_prefix}/share/chapel %{buildroot}/%{_prefix}/share/chapel
 

--- a/util/packaging/rpm/fc41/spec.template
+++ b/util/packaging/rpm/fc41/spec.template
@@ -35,7 +35,7 @@ cp %{_prefix}/bin/chplcheck %{buildroot}/%{_prefix}/bin/chplcheck
 cp %{_prefix}/bin/chpl-language-server %{buildroot}/%{_prefix}/bin/chpl-language-server
 # Libraries
 cp -r %{_prefix}/lib/chapel %{buildroot}/%{_prefix}/lib/chapel
-cp -r %{_prefix}/lib/cmake/chpl %{buildroot}/%{_prefix}/lib/cmake/chpl
+cp -r %{_prefix}/lib/cmake/chpl %{buildroot}/%{_prefix}/lib/cmake
 # CHPL_HOME
 cp -r %{_prefix}/share/chapel %{buildroot}/%{_prefix}/share/chapel
 
@@ -47,5 +47,7 @@ cp -r %{_prefix}/share/chapel %{buildroot}/%{_prefix}/share/chapel
 %{_prefix}/bin/chpl-language-server
 %{_prefix}/lib/chapel/*
 %{_prefix}/share/chapel/*
+%{_prefix}/lib/cmake/chpl/*
+
 
 %changelog

--- a/util/packaging/rpm/fc41/spec.template
+++ b/util/packaging/rpm/fc41/spec.template
@@ -25,6 +25,7 @@ mkdir -p %{buildroot}/%{_prefix}
 mkdir -p %{buildroot}/%{_prefix}/bin
 mkdir -p %{buildroot}/%{_prefix}/lib
 mkdir -p %{buildroot}/%{_prefix}/share
+mkdir -p %{buildroot}/%{_prefix}/lib/cmake/chpl
 
 # Binaries
 cp %{_prefix}/bin/chpl %{buildroot}/%{_prefix}/bin/chpl
@@ -34,6 +35,7 @@ cp %{_prefix}/bin/chplcheck %{buildroot}/%{_prefix}/bin/chplcheck
 cp %{_prefix}/bin/chpl-language-server %{buildroot}/%{_prefix}/bin/chpl-language-server
 # Libraries
 cp -r %{_prefix}/lib/chapel %{buildroot}/%{_prefix}/lib/chapel
+cp -r %{_prefix}/lib/cmake/chpl %{buildroot}/%{_prefix}/lib/cmake/chpl
 # CHPL_HOME
 cp -r %{_prefix}/share/chapel %{buildroot}/%{_prefix}/share/chapel
 


### PR DESCRIPTION
Adds an install step to move the CMake module files in `util/cmake` to `CHPL_HOME/lib`/`INSTALL_PREFIX/lib/cmake/chpl`

This makes these files readily available to users without needing to copy the files into their project

testing
- [x] build from source with CHPL_HOME build puts the files in the right place
- [x] install from source with chpl-home build puts the files in the right place
- [x] install from source with prefix build puts the files in the right place
- [x] homebrew changes work as expected
- [x] rpm changes work as expected
  - tested fedora 41
- [x] apt/deb changes work as expected
  - tested ubuntu 24

[Reviewed by @arezaii]