### PR TITLE
Dyno: Improve nested function receivers and call-graph

### DIFF
--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -2769,6 +2769,17 @@ class ResolvedFunction {
   /** the set of point-of-instantiations used by the instantiation */
   const PoiInfo& poiInfo() const { return poiInfo_; }
 
+  const ResolvedFunction* getNestedResult(const TypedFnSignature* sig,
+                                          const PoiScope* poiScope) const {
+    auto poiInfo = PoiInfo(poiScope);
+    auto it = sigAndInfoToChildPtr_.find(std::make_pair(sig, poiScope));
+    if (it != sigAndInfoToChildPtr_.end()) {
+      return it->second;
+    } else {
+      return nullptr;
+    }
+  }
+
   bool operator==(const ResolvedFunction& other) const {
     return signature_ == other.signature_ &&
            returnIntent_ == other.returnIntent_ &&

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -36,6 +36,7 @@
 #include "chpl/util/hash.h"
 #include "chpl/util/memory.h"
 
+#include <optional>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -483,6 +484,16 @@ class OuterVariables {
     auto it = mentionIdToTargetId_.find(mention);
     if (it == mentionIdToTargetId_.end()) return nullptr;
     return &*targetIdToType_.find(it->second);
+  }
+
+  /** If available, returns the type associated with an outer variable's ID */
+  const std::optional<QualifiedType> targetType(const ID& target) const {
+    auto it = targetIdToType_.find(target);
+    if (it == targetIdToType_.end()) {
+      return {};
+    } else {
+      return { it->second };
+    }
   }
 
   bool isEmpty() const {

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -3945,6 +3945,8 @@ bool Resolver::lookupOuterVariable(QualifiedType& out,
   // Use the cached result if it exists.
   if (auto p = outerVariables.targetAndTypeOrNull(mention)) {
     type = p->second;
+  } else if (auto t = outerVariables.targetType(target)) {
+    type = *t;
 
   } else if (isFieldAccess) {
     // If the target ID is a field, we have to walk up parent frames

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -416,6 +416,7 @@ Resolver::createForFunction(ResolutionContext* rc,
     const TypedFnSignature* pfn = typedFnSignature->parentFn();
     while (pfn) {
       if (pfn->isMethod()) {
+        ret.inCompositeType = pfn->formalType(0).type()->getCompositeType();
         ret.allowReceiverScopes = true;
         break;
       }

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -651,6 +651,7 @@ Resolver::paramLoopResolver(Resolver& parent,
   ret.declStack = parent.declStack;
   ret.byPostorder.setupForParamLoop(loop, parent.byPostorder);
   ret.typedSignature = parent.typedSignature;
+  ret.rc = parent.rc;
 
   return ret;
 }

--- a/frontend/lib/resolution/Resolver.h
+++ b/frontend/lib/resolution/Resolver.h
@@ -207,7 +207,7 @@ struct Resolver {
 
   // set up Resolver to resolve an instantiation of a Function signature
   static Resolver
-  createForInstantiatedSignature(Context* context,
+  createForInstantiatedSignature(ResolutionContext* rc,
                                  const uast::Function* fn,
                                  const SubstitutionsMap& substitutions,
                                  const PoiScope* poiScope,

--- a/frontend/lib/resolution/call-graph.cpp
+++ b/frontend/lib/resolution/call-graph.cpp
@@ -93,6 +93,10 @@ struct CalledFnCollector {
   void exit(const AstNode* ast, RV& rv) {
   }
 
+  // TODO: How can we make this work through ``resolveFunction``, rather than
+  // relying on the cached map in ``ResolvedFunction``? The problem appears to
+  // be that we never use the 'global cache' when storing queries for
+  // nested functions, so the results only live on in ``ResolvedFunction``.
   const ResolvedFunction* getResolvedFunction(const TypedFnSignature* sig,
                            const PoiScope* poiScope) {
     chpl::resolution::ResolutionContext rcval(context);

--- a/frontend/lib/resolution/call-graph.cpp
+++ b/frontend/lib/resolution/call-graph.cpp
@@ -92,6 +92,23 @@ struct CalledFnCollector {
   }
   void exit(const AstNode* ast, RV& rv) {
   }
+
+  const ResolvedFunction* getResolvedFunction(const TypedFnSignature* sig,
+                           const PoiScope* poiScope) {
+    chpl::resolution::ResolutionContext rcval(context);
+    const ResolvedFunction* fn = nullptr;
+    if (resolvedFunction) {
+      if (auto stored = resolvedFunction->getNestedResult(sig, poiScope)) {
+        fn = stored;
+      }
+    }
+
+    if (fn == nullptr) {
+      fn = resolveFunction(&rcval, sig, poiScope);
+    }
+
+    return fn;
+  }
 };
 
 
@@ -129,8 +146,7 @@ void CalledFnCollector::collectCalls(const ResolvedExpression* re) {
   for (const auto& candidate : re->mostSpecific()) {
     if (const TypedFnSignature* sig = candidate.fn()) {
       if (sig->untyped()->idIsFunction()) {
-        chpl::resolution::ResolutionContext rcval(context);
-        const ResolvedFunction* fn = resolveFunction(&rcval, sig, poiScope);
+        auto fn = getResolvedFunction(sig, poiScope);
         collect(fn);
       }
     }
@@ -142,8 +158,7 @@ void CalledFnCollector::collectCalls(const ResolvedExpression* re) {
     // Ideally, that would work by generating uAST for them.
     if (const TypedFnSignature* sig = action.fn()) {
       if (sig->untyped()->idIsFunction()) {
-        chpl::resolution::ResolutionContext rcval(context);
-        const ResolvedFunction* fn = resolveFunction(&rcval, sig, poiScope);
+        auto fn = getResolvedFunction(sig, poiScope);
         collect(fn);
       }
     }

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2091,7 +2091,7 @@ static QualifiedType getVarArgTupleElemType(const QualifiedType& varArgType) {
   }
 }
 
-static Resolver createResolverForAst(Context* context,
+static Resolver createResolverForAst(ResolutionContext* rc,
                                      const Function* fn,
                                      const AggregateDecl* ad,
                                      const Enum* ed,
@@ -2099,15 +2099,15 @@ static Resolver createResolverForAst(Context* context,
                                      const PoiScope* poiScope,
                                      ResolutionResultByPostorderID& r) {
   if (fn != nullptr) {
-    return Resolver::createForInstantiatedSignature(context, fn, substitutions,
+    return Resolver::createForInstantiatedSignature(rc, fn, substitutions,
                                                     poiScope, r);
   } else if (ad != nullptr) {
-    return Resolver::createForInstantiatedSignatureFields(context, ad,
+    return Resolver::createForInstantiatedSignatureFields(rc->context(), ad,
                                                           substitutions,
                                                           poiScope, r);
   } else {
     CHPL_ASSERT(ed != nullptr);
-    return Resolver::createForEnumElements(context, ed, r);
+    return Resolver::createForEnumElements(rc->context(), ed, r);
   }
 }
 
@@ -2228,7 +2228,7 @@ ApplicabilityResult instantiateSignature(ResolutionContext* rc,
   int varArgIdx = -1;
 
   ResolutionResultByPostorderID r;
-  auto visitor = createResolverForAst(context, fn, ad, ed, substitutions,
+  auto visitor = createResolverForAst(rc, fn, ad, ed, substitutions,
                                       poiScope, r);
 
   // TODO: Stop copying these back in.

--- a/frontend/test/resolution/testNestedFunctions.cpp
+++ b/frontend/test/resolution/testNestedFunctions.cpp
@@ -379,6 +379,35 @@ static void test5d(Context* ctx) {
   assert(qt.type() && qt.type()->isIntType());
 }
 
+// Similar to the other 5x cases, but with a secondary method
+static void test5e(Context* ctx) {
+  ADVANCE_PRESERVING_STANDARD_MODULES_(ctx);
+  ErrorGuard guard(ctx);
+
+  std::string program =
+    R"""(
+    record R {
+      type T;
+      var x : T;
+    }
+
+    proc R.foobar() {
+      proc helper(arg: T) {
+        return arg;
+      }
+
+      return helper(x);
+    }
+
+    var r : R(int);
+    var x = r.foobar();
+    )""";
+
+  auto qt = resolveQualifiedTypeOfX(ctx, program);
+  assert(qt.kind() == QualifiedType::VAR);
+  assert(qt.type() && qt.type()->isIntType());
+}
+
 // Same as test5 but with a nested method instead of a nested function.
 static void test6(Context* ctx) {
   ADVANCE_PRESERVING_STANDARD_MODULES_(ctx);
@@ -683,6 +712,7 @@ int main() {
   test5b(ctx);
   test5c(ctx);
   test5d(ctx);
+  test5e(ctx);
   test6(ctx);
   // test7(ctx);
   // test8(ctx);

--- a/frontend/test/resolution/testNestedFunctions.cpp
+++ b/frontend/test/resolution/testNestedFunctions.cpp
@@ -382,30 +382,60 @@ static void test5d(Context* ctx) {
 // Similar to the other 5x cases, but with a secondary method
 static void test5e(Context* ctx) {
   ADVANCE_PRESERVING_STANDARD_MODULES_(ctx);
-  ErrorGuard guard(ctx);
+  {
+    ErrorGuard guard(ctx);
 
-  std::string program =
-    R"""(
-    record R {
-      type T;
-      var x : T;
-    }
-
-    proc R.foobar() {
-      proc helper(arg: T) {
-        return arg;
+    std::string program =
+      R"""(
+      record R {
+        type T;
+        var x : T;
       }
 
-      return helper(x);
-    }
+      proc R.foobar() {
+        proc helper(arg: T) {
+          return arg;
+        }
 
-    var r : R(int);
-    var x = r.foobar();
-    )""";
+        return helper(x);
+      }
 
-  auto qt = resolveQualifiedTypeOfX(ctx, program);
-  assert(qt.kind() == QualifiedType::VAR);
-  assert(qt.type() && qt.type()->isIntType());
+      var r : R(int);
+      var x = r.foobar();
+      )""";
+
+    auto qt = resolveQualifiedTypeOfX(ctx, program);
+    assert(qt.kind() == QualifiedType::VAR);
+    assert(qt.type() && qt.type()->isIntType());
+  }
+  {
+    ErrorGuard guard(ctx);
+
+    std::string program =
+      R"""(
+      record R {
+        type T;
+        var x : T;
+      }
+
+      proc R.foobar() {
+        // generic case
+        proc helper(arg: T, other: ?) {
+          return __primitive("+", arg, other);
+        }
+
+        return helper(x, 5);
+      }
+
+      var r : R(int);
+      var x = r.foobar();
+
+      )""";
+
+    auto qt = resolveQualifiedTypeOfX(ctx, program);
+    assert(qt.kind() == QualifiedType::VAR);
+    assert(qt.type() && qt.type()->isIntType());
+  }
 }
 
 // Same as test5 but with a nested method instead of a nested function.

--- a/frontend/test/resolution/testNestedFunctions.cpp
+++ b/frontend/test/resolution/testNestedFunctions.cpp
@@ -768,6 +768,37 @@ static void test15(Context* ctx) {
   std::ignore = gatherTransitiveFnsCalledByModInit(ctx, m->id(), called);
 }
 
+static void test16(Context* ctx) {
+  ADVANCE_PRESERVING_STANDARD_MODULES_(ctx);
+  ErrorGuard guard(ctx);
+
+  std::string program =
+    R"""(
+    proc helper(args) {
+      proc nested() {
+        var sum = 0;
+        for param dim in 0..args.size-1 {
+          if args(dim).type != int {
+            sum += 1;
+          }
+        }
+        return sum;
+      }
+
+      return nested();
+    }
+
+    var args = (1, 2, 3, 4);
+    var x = helper(args);
+    )""";
+
+  std::ignore = resolveTypeOfX(ctx, program);
+
+  auto m = parseModule(ctx, std::move(program));
+  CalledFnsSet called;
+  std::ignore = gatherTransitiveFnsCalledByModInit(ctx, m->id(), called);
+}
+
 int main() {
   auto context = buildStdContext();
   Context* ctx = turnOnWarnUnstable(context);
@@ -793,6 +824,7 @@ int main() {
   test13(ctx);
   test14(ctx);
   test15(ctx);
+  test16(ctx);
 
   return 0;
 }

--- a/modules/internal/BytesStringCommon.chpl
+++ b/modules/internal/BytesStringCommon.chpl
@@ -1188,9 +1188,7 @@ module BytesStringCommon {
 
     inline proc helpMe(ref lhs: t, rhs: t) {
       if compiledForSingleLocale() || rhs.locale_id == chpl_nodeID {
-        // Workaround: Switched from 't' to 'lhs.type' here as Dyno doesn't
-        // support capturing variables into nested procs yet. Anna 2025-02-27
-        if lhs.type == string {
+        if t == string {
           reinitWithNewBuffer(lhs, rhs.buff, rhs.buffLen, rhs.buffSize,
                               rhs.numCodepoints);
         }
@@ -1202,8 +1200,7 @@ module BytesStringCommon {
         var remote_buf:bufferType = nil;
         if len != 0 then
           remote_buf = bufferCopyRemote(rhs.locale_id, rhs.buff, len);
-        // Same workaround as above
-        if lhs.type == string {
+        if t == string {
           reinitWithOwnedBuffer(lhs, remote_buf, len, len+1,
                                 rhs.cachedNumCodepoints);
         }

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -2340,18 +2340,12 @@ private proc isBCPindex(type t) param do
     if isPositiveStride(newStrides, st) then
       // start from the low index
       return if hasLowBoundForIter(r)
-             // inlined: newAlignedRange(r.chpl_alignedLowAsIntForIter)
-             // because Dyno can't helper capturing nested functions.
-             then new range(i, b, newStrides, lw, hh, st,
-                            r.chpl_alignedLowAsIntForIter, true, true)
+             then newAlignedRange(r.chpl_alignedLowAsIntForIter)
              else if st == 1 then newZeroAlmtRange() else newUnalignedRange();
     else
       // start from the high index
       return if hasHighBoundForIter(r)
-             // inlined: newAlignedRange(r.chpl_alignedHighAsIntForIter)
-             // because Dyno can't helper capturing nested functions.
-             then new range(i, b, newStrides, lw, hh, st,
-                            r.chpl_alignedHighAsIntForIter, true, true)
+             then newAlignedRange(r.chpl_alignedHighAsIntForIter)
              else if st == -1 then newZeroAlmtRange() else newUnalignedRange();
 
     proc newAlignedRange(alignment) do

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -2717,7 +2717,7 @@ private proc isBCPindex(type t) param do
     type resultType = r.chpl_integralIdxType;
     type strType = chpl__rangeStrideType(resultType);
 
-    proc absSameType(r, type resultType) {
+    proc absSameType() {
       if r.hasNegativeStride() {
         return (-r.stride):resultType;
       } else {
@@ -2731,14 +2731,14 @@ private proc isBCPindex(type t) param do
                          bounds = boundKind.both,
                          strides = r.strides,
                          _low = r._low,
-                         _high = r._low - absSameType(r, resultType),
+                         _high = r._low - absSameType(),
                          _stride = r.stride,
                          alignmentValue = r._alignment);
       } else if (r.hasHighBound()) {
         return new range(idxType = r.idxType,
                          bounds = boundKind.both,
                          strides = r.strides,
-                         _low = r._high + absSameType(r, resultType),
+                         _low = r._high + absSameType(),
                          _high = r._high,
                          _stride = r.stride,
                          alignmentValue = r._alignment);


### PR DESCRIPTION
This PR fixes various issues when attempting to use an implicit receiver in a nested function by appropriately setting up certain fields in the Resolver factory methods.

This PR also silences some errors that were being issued by call-graph. It was assumed that these ``resolveFunction`` calls would generally be querying a cached result, but ``ResolutionContext`` never saved its nested function query results in the ``Context`` because it was in an "unstable" state. The results have been stored in ``ResolvedFunction`` however, and are used by this PR to avoid re-resolving the functions without a suitable stack of "frames".

Ideally we wouldn't have to deal with this manually at all and just have ``resolveFunction`` work, but it's not clear to me at this time how to make that happen.

Testing:
- [x] test-dyno