### PR TITLE
add perf graph data for v2.4

### DIFF
--- a/util/pastPerformance/testReleasesPerformance
+++ b/util/pastPerformance/testReleasesPerformance
@@ -214,6 +214,10 @@ testReleasePerformance
 export CHPL_TEST_PERF_DATE="12/12/24"
 export CHPL_HOME=$chpl_release_home/chapel-2.3.0
 testReleasePerformance
+
+export CHPL_TEST_PERF_DATE="03/20/25"
+export CHPL_HOME=$chpl_release_home/chapel-2.4.0
+testReleasePerformance
 #
 # ADD NEW RELEASES HERE AS THEY ARE CREATED.
 #

--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -179,6 +179,10 @@ var branchInfo = [
                     "releaseDate": "2024-12-12",
                     "branchDate" : "2024-12-06",
                     "revision": -1},
+                  { "release": "2.4.0",
+                    "releaseDate": "2025-03-20",
+                    "branchDate" : "2025-03-14",
+                    "revision": -1},
                   ];
 
 var indexMap = {};


### PR DESCRIPTION
This adds performance graph data for the 2.4 release. Previous update for 2.3 was https://github.com/chapel-lang/chapel/pull/26393


[reviewed by @arifthpe - thanks!]