### PR TITLE
Dyno: add backtracing LLDB script

### DIFF
--- a/util/devel/dyno_backtrace.py
+++ b/util/devel/dyno_backtrace.py
@@ -59,5 +59,5 @@ def backtrace(debugger, command, result, internal_dict):
 
         frame = frame.parent
 
-    for i, (name, file, line, idx) in enumerate(reversed(trace)):
+    for i, (name, file, line, idx) in enumerate(trace):
         print("{:2d}: {} at {}:{} (lldb frame {})".format(i, name, file, line, idx))

--- a/util/devel/dyno_backtrace.py
+++ b/util/devel/dyno_backtrace.py
@@ -1,0 +1,63 @@
+"""
+Dyno stack trace script.
+
+Though Dyno often performs re-computation, it's typical for the
+compiler stacktrace to mirror (with a lot of function calls) the trace of
+resolving the Chapel program. We can clean up this information, skipping
+a lot of in-between frames, and print a Chapel-only trace. That's what this
+script does.
+
+To use the script, add the following lines to your .lldbinit file:
+
+    command script import /path/to/dyno_backtrace.py
+    command script add -f dyno_backtrace.backtrace dbt
+
+Then, in the debugger, you can run the `dbt` command to print the Chapel
+stack trace.
+"""
+
+import os
+
+def get_child_by_name(value, name):
+    return next(child for child in value.children if child.name == name)
+
+def std_string_to_str(value):
+    return value.GetSummary().strip('"')
+
+def unique_string_to_str(value):
+    return std_string_to_str(value.EvaluateExpression("this.str()"))
+
+def unpack_location(root_dir, loc_value):
+    file = unique_string_to_str(get_child_by_name(loc_value, "path_"))
+    line = int(get_child_by_name(loc_value, "firstLine_").GetValueAsSigned())
+    if file.startswith(root_dir):
+        file = file[len(root_dir):]
+    return file, line
+
+def backtrace(debugger, command, result, internal_dict):
+    target = debugger.GetSelectedTarget()
+    root_dir = os.getcwd()
+    root = target.GetProcess().GetThreadAtIndex(0).GetFrameAtIndex(0)
+    frame = root
+
+    trace = []
+    while frame is not None:
+        name = frame.GetFunctionName()
+        if name is None:
+            break
+
+        if name.startswith("chpl::resolution::resolveFnCall("):
+            rc = frame.variables[0]
+            context = rc.deref.EvaluateExpression("this.context()")
+            ast = frame.variables[1]
+
+            location = frame.EvaluateExpression("parsing::locateAst({}, {})".format(context.GetName(), ast.GetName()))
+
+            call_info = frame.variables[3]
+            call_name = unique_string_to_str(get_child_by_name(call_info.deref, "name_"))
+            trace.append((call_name, *unpack_location(root_dir, location), frame.idx))
+
+        frame = frame.parent
+
+    for i, (name, file, line, idx) in enumerate(reversed(trace)):
+        print("{:2d}: {} at {}:{} (lldb frame {})".format(i, name, file, line, idx))


### PR DESCRIPTION
LLDB exposes a convenient Python API. We can leverage this API to print clean stacktaces while resolving Dyno programs. See also my comment in the file.

```
Dyno stack trace script.

Though Dyno often performs re-computation, it's typical for the
compiler stacktrace to mirror (with a lot of function calls) the trace of
resolving the Chapel program. We can clean up this information, skipping
a lot of in-between frames, and print a Chapel-only trace. That's what this
script does.

To use the script, add the following lines to your .lldbinit file:

    command script import /path/to/dyno_backtrace.py
    command script add -f dyno_backtrace.backtrace dbt

Then, in the debugger, you can run the `dbt` command to print the Chapel
stack trace.
```

The output looks like this:

```
(lldb) dbt
 0: chpl__buildDomainRuntimeType at input.chpl:3 (lldb frame 152)
 1: init at /modules/internal/ChapelDomain.chpl:110 (lldb frame 137)
 2: newAssociativeDom at /modules/internal/ChapelDomain.chpl:1117 (lldb frame 118)
 3: dsiNewAssociativeDom at /modules/internal/ChapelDistribution.chpl:115 (lldb frame 103)
 4: init at /modules/internal/DefaultRectangular.chpl:110 (lldb frame 88)
 5: init at /modules/internal/DefaultAssociative.chpl:96 (lldb frame 69)
 6: init= at /modules/internal/ChapelHashtable.chpl:260 (lldb frame 45)
 7: chpl__promotionType at /modules/internal/OwnedObject.chpl:40 (lldb frame 27)
 8: borrow at /modules/internal/OwnedObject.chpl:49 (lldb frame 13)
```

Reviewed by @arifthpe -- thanks!