### PR TITLE
Dyno: Fix testPch on macos

### DIFF
--- a/frontend/test/clang/testPch.cpp
+++ b/frontend/test/clang/testPch.cpp
@@ -99,7 +99,9 @@ static void testIt(const char* testName,
     std::map<std::string, const char*> env;
     std::string printOutput;
     auto result = chpl::getChplEnv(env, chpl_home.c_str(), &printOutput);
-    clangCCArgs.push_back(result.get()["CHPL_LLVM_CLANG_C"]);
+    auto clangc = result.get()["CHPL_LLVM_CLANG_C"];
+    assert(!clangc.empty() && "CHPL_LLVM_CLANG_C not found");
+    clangCCArgs.push_back(clangc);
     util::setClangFlags(context, clangCCArgs);
 
     auto tpch =

--- a/frontend/test/clang/testPch.cpp
+++ b/frontend/test/clang/testPch.cpp
@@ -92,6 +92,16 @@ static void testIt(const char* testName,
     }
     assert(externBlock);
 
+    // TODO: For some unknown reason, we need to add the clang C compiler
+    // as an argument on macos. Otherwise, we get errors about ``stdio.h`` not
+    // being found.
+    std::vector<std::string> clangCCArgs;
+    std::map<std::string, const char*> env;
+    std::string printOutput;
+    auto result = chpl::getChplEnv(env, chpl_home.c_str(), &printOutput);
+    clangCCArgs.push_back(result.get()["CHPL_LLVM_CLANG_C"]);
+    util::setClangFlags(context, clangCCArgs);
+
     auto tpch =
       util::createClangPrecompiledHeader(context, externBlock->id()).get();
     if (lastResult != nullptr) {


### PR DESCRIPTION
For some unknown reason, we need to add the clang C compiler as an argument and call ``setClangFlags``. Otherwise, clang can't find headers like ``stdio.h`` and the test fails. This only occurs on macos.