### PR TITLE
Double the arkouda perf test timeout on Apollo HDR

### DIFF
--- a/util/cron/test-perf.hpe-apollo-hdr.arkouda.bash
+++ b/util/cron/test-perf.hpe-apollo-hdr.arkouda.bash
@@ -25,9 +25,8 @@ source $UTIL_CRON_DIR/common-arkouda-hpe-apollo-hdr.bash
 
 export ARKOUDA_NUMLOCALES=16
 
-# on this system, the array_transfer test comes dangerously close to the
-# timeout. So, here we double it for peace of mind.
-export ARKOUDA_CLIENT_TIMEOUT=600
+# on this system, the several tests comes dangerously close to the timeout.
+export ARKOUDA_CLIENT_TIMEOUT=1200
 
 export CHPL_GASNET_SEGMENT=fast
 export GASNET_PHYSMEM_MAX="0.90"

--- a/util/cron/test-perf.hpe-apollo-hdr.arkouda.colo.bash
+++ b/util/cron/test-perf.hpe-apollo-hdr.arkouda.colo.bash
@@ -27,9 +27,8 @@ source $UTIL_CRON_DIR/common-arkouda-hpe-apollo-hdr.bash
 export CHPL_RT_LOCALES_PER_NODE=2
 export ARKOUDA_NUMLOCALES=32
 
-# on this system, the array_transfer test comes dangerously close to the
-# timeout. So, here we double it for peace of mind.
-export ARKOUDA_CLIENT_TIMEOUT=600
+# on this system, the several tests comes dangerously close to the timeout.
+export ARKOUDA_CLIENT_TIMEOUT=1200
 
 export CHPL_GASNET_SEGMENT=fast
 export GASNET_PHYSMEM_MAX="0.90"

--- a/util/cron/test-perf.hpe-apollo-hdr.arkouda.release.bash
+++ b/util/cron/test-perf.hpe-apollo-hdr.arkouda.release.bash
@@ -25,9 +25,8 @@ source $UTIL_CRON_DIR/common-arkouda-hpe-apollo-hdr.bash
 
 export ARKOUDA_NUMLOCALES=16
 
-# on this system, the array_transfer test comes dangerously close to the
-# timeout. So, here we double it for peace of mind.
-export ARKOUDA_CLIENT_TIMEOUT=600
+# on this system, the several tests comes dangerously close to the timeout.
+export ARKOUDA_CLIENT_TIMEOUT=1200
 
 export CHPL_GASNET_SEGMENT=fast
 export GASNET_PHYSMEM_MAX="0.90"

--- a/util/cron/test-perf.hpe-apollo-hdr.arkouda.release.colo.bash
+++ b/util/cron/test-perf.hpe-apollo-hdr.arkouda.release.colo.bash
@@ -27,9 +27,8 @@ source $UTIL_CRON_DIR/common-arkouda-hpe-apollo-hdr.bash
 export CHPL_RT_LOCALES_PER_NODE=2
 export ARKOUDA_NUMLOCALES=32
 
-# on this system, the array_transfer test comes dangerously close to the
-# timeout. So, here we double it for peace of mind.
-export ARKOUDA_CLIENT_TIMEOUT=600
+# on this system, the several tests comes dangerously close to the timeout.
+export ARKOUDA_CLIENT_TIMEOUT=1200
 
 export CHPL_GASNET_SEGMENT=fast
 export GASNET_PHYSMEM_MAX="0.90"


### PR DESCRIPTION
These perf test configs fail sporadically with timeouts, this PR doubles the timeout to help prevent that noise.

[Reviewed by @e-kayrakli]