### PR TITLE
Ensure 'latest' Docker image isn't rebuilt before push

### DIFF
--- a/util/cron/test-docker.bash
+++ b/util/cron/test-docker.bash
@@ -67,7 +67,10 @@ update_image() {
     docker buildx build --platform=linux/amd64,linux/arm64 --push . -t "$imageName"
   else
     # Also push as 'latest' tag if this is a release build.
-    # Use base image name (without tag) to use Docker's default tag 'latest'
+    # Use base image name (without tag) to use Docker's default tag 'latest'.
+    # This has to be done in a single invocation of 'build' to ensure we don't
+    # rebuild the image for the 'latest' tag, which would result in it having
+    # a different SHA.
     docker buildx build --platform=linux/amd64,linux/arm64 --push . -t "$imageName" -t "$baseImageName"
   fi
 


### PR DESCRIPTION
Ensure the `latest` Docker image has the same SHA as the release-tagged image.

For the 2.4 Docker image release I observed the `latest` and `2.4` images had different SHAs, though they are intended to be the same image. Examining the build logs, this was due to the false assumption that doing a second identical build command for `latest` immediately after the one for `2.4` would use the same cached result, which isn't guaranteed. Fix this by pushing both tags in the same build command invocation so they are guaranteed to be on the same image.

[trivial, not reviewed]