### PR TITLE
Add prediff to sort output for Python test

### DIFF
--- a/test/library/packages/Python/correctness/objToString.good
+++ b/test/library/packages/Python/correctness/objToString.good
@@ -22,7 +22,7 @@ str: 1, hello, 2, world
 repr: my_class(1, 'hello', 2, 'world')
 default: 1, hello, 2, world
 ================
-str: [1, 2, 3], {'world', 'hello'}, {'hello': 1, 'world': 2}
-repr: my_class([1, 2, 3], {'world', 'hello'}, {'hello': 1, 'world': 2})
-default: [1, 2, 3], {'world', 'hello'}, {'hello': 1, 'world': 2}
+str: [1, 2, 3], {'hello', 'world'}, {'hello': 1, 'world': 2}
+repr: my_class([1, 2, 3], {'hello', 'world'}, {'hello': 1, 'world': 2})
+default: [1, 2, 3], {'hello', 'world'}, {'hello': 1, 'world': 2}
 ================

--- a/test/library/packages/Python/correctness/objToString.prediff
+++ b/test/library/packages/Python/correctness/objToString.prediff
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+import sys
+import re
+
+file = sys.argv[2]
+
+with open(file, 'r') as f:
+    lines = f.readlines()
+
+with open(file, 'w') as f:
+    for line in lines:
+        if "{" in line:
+            # grab the text between matching curly braces, split it on a comma,
+            # sort it, and replace it with the sorted version
+            matches = re.findall(r'\{([^}]+)\}', line)
+            for match in matches:
+                items = [item.strip() for item in match.split(',')]
+                items.sort()
+                sorted_match = '{' + ', '.join(items) + '}'
+                line = line.replace('{' + match + '}', sorted_match)
+        f.write(line)
+


### PR DESCRIPTION
Adds a prediff to sort the output of a Python test, since the output can potentially vary from run to run.

[Reviewed by @lydia-duncan]