### PR TITLE
Stop using perf playgrounds

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -621,6 +621,9 @@ all:
   02/27/25:
     - text: Avoid Overriding Clang Sysroot (#26761)
       config: chapcs
+  03/20/25:
+    - text: Update bundled qthreads to 1.22 (#26823)
+      config: chapcs, 16-node-apollo-hdr, 16-node-hpe-cray-ex, 1-node-hpe-cray-ex
 
 # End all
 

--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -27,10 +27,10 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground"
 #
 
 # Test performance with the latest qthreads release.
-GITHUB_USER=insertinterestingnamehere
-GITHUB_BRANCH=qthread
-SHORT_NAME=qthread122
-START_DATE=02/21/25
+GITHUB_USER=chapel-lang
+GITHUB_BRANCH=chapel
+SHORT_NAME=main
+START_DATE=03/20/25
 
 set -e
 checkout_branch $GITHUB_USER $GITHUB_BRANCH

--- a/util/cron/test-perf.hpe-apollo-hdr.gasnet-ibv.playground.bash
+++ b/util/cron/test-perf.hpe-apollo-hdr.gasnet-ibv.playground.bash
@@ -27,7 +27,7 @@ export GASNET_PHYSMEM_MAX="0.90"
 # When the multi-local playground is not used, set `SKIP_ML_PLAYGROUND=1
 #
 
-SKIP_ML_PLAYGROUND=0
+SKIP_ML_PLAYGROUND=1
 if [[ "$SKIP_ML_PLAYGROUND" == "1" ]]; then
   log_info "Skipping testing of the multi-local playground"
   exit


### PR DESCRIPTION
Stop using perf playgrounds for qthreads

This PR also annotates the qthreads upgrade

[Not reviewed - trivial]