### PR TITLE
Prevent qthread cmake from messing up mac builds

### DIFF
--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -136,6 +136,11 @@ ifeq ($(CHPL_MAKE_TARGET_PLATFORM),darwin)
 endif
 endif
 
+# prevent CMake from inferring the wrong sysroot/XCode SDK
+ifeq ($(CHPL_MAKE_TARGET_PLATFORM),darwin)
+  CHPL_QTHREAD_CFG_OPTIONS += -DCMAKE_OSX_DEPLOYMENT_TARGET="" -DCMAKE_OSX_SYSROOT=""
+endif
+
 # reduce performance penalty in cases where numChapelTasks < numQthreadWorkers
 CHPL_QTHREAD_CFG_OPTIONS += -DQTHREADS_CONDWAIT_QUEUE=ON
 


### PR DESCRIPTION
Fixes an issue caught in our smoke tests where CMake was trying to be too smart and pick the right sysroot/XCode SDK version. This causes other issues down the line, so this PR prevents CMake from doing that

[Reviewed by @arezaii]