### PR TITLE
Prevent qthread cmake from setting the OSX deployment target

### DIFF
--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -138,7 +138,7 @@ endif
 
 # prevent CMake from inferring the wrong sysroot/XCode SDK
 ifeq ($(CHPL_MAKE_TARGET_PLATFORM),darwin)
-  CHPL_QTHREAD_CFG_OPTIONS += -DCMAKE_OSX_DEPLOYMENT_TARGET="" -DCMAKE_OSX_SYSROOT=""
+  CHPL_QTHREAD_CFG_OPTIONS += -DCMAKE_OSX_DEPLOYMENT_TARGET= -DCMAKE_OSX_SYSROOT=
 endif
 
 # reduce performance penalty in cases where numChapelTasks < numQthreadWorkers

--- a/third-party/qthread/README
+++ b/third-party/qthread/README
@@ -60,3 +60,20 @@ index eb8ac5b1..ea03ed6d 100644
        qassert(hwloc_topology_init(&topology), 0);
        qassert(hwloc_topology_load(topology), 0);
 
+
+Prevent CMake from overriding the OSX deployment target
+--- a/third-party/qthread/qthread-src/CMakeLists.txt
++++ b/third-party/qthread/qthread-src/CMakeLists.txt
+@@ -16,6 +16,11 @@ else()
+     LANGUAGES C ASM CXX)
+ endif()
+ 
++# This must be done after `project` or it gets overridden by cmake
++if(APPLE)
++  set(CMAKE_OSX_DEPLOYMENT_TARGET "" CACHE STRING "" FORCE)
++endif()
++
+ include(GNUInstallDirs)
+ 
+ set(THREADS_PREFER_PTHREAD_FLAG ON)
+

--- a/third-party/qthread/qthread-src/CMakeLists.txt
+++ b/third-party/qthread/qthread-src/CMakeLists.txt
@@ -16,6 +16,11 @@ else()
     LANGUAGES C ASM CXX)
 endif()
 
+# This must be done after `project` or it gets overridden by cmake
+if(APPLE)
+  set(CMAKE_OSX_DEPLOYMENT_TARGET "" CACHE STRING "" FORCE)
+endif()
+
 include(GNUInstallDirs)
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)


### PR DESCRIPTION
Forces the QThread CMake file to not attempt to set the OSX deployment target.

This PR has the same goal and idea of https://github.com/chapel-lang/chapel/pull/26959, but done more forcefully by editing the CMakeLists.txt file instead of just passing the variable on the command line.

The patch forces `CMAKE_OSX_DEPLOYMENT_TARGET` to be the empty string to override the default CMake behavior (which is to try and infer a correct deployment target). This must be done after `project`, otherwise it gets overridden by the default CMake behavior.

I suspect this is incorrect behavior on CMakes part, as the documentation for [`CMAKE_OSX_DEPLOYMENT_TARGET`](https://cmake.org/cmake/help/v3.31/variable/CMAKE_OSX_DEPLOYMENT_TARGET.html) states that setting it to an empty value prevents CMake from trying to infer it, which does not seem to be the case. The docs also say it must be set before `project`, but setting it to an empty string before `project` still results in it being overwritten

[Reviewed by @arezaii]