### PR TITLE
Get the CC/CXX directly from chplenv for qthreads

### DIFF
--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -172,10 +172,10 @@ qthread-config: FORCE
 	-DCMAKE_INSTALL_PREFIX='$(QTHREAD_INSTALL_DIR)' \
 	-DCMAKE_INSTALL_LIBDIR='$(QTHREAD_LIB_DIR)' \
 	-DBUILD_SHARED_LIBS=OFF \
-	-DCMAKE_C_COMPILER='$(CC)' \
-	-DCMAKE_C_FLAGS='$(CFLAGS)' \
-	-DCMAKE_CXX_COMPILER='$(CXX)' \
-	-DCMAKE_CXX_FLAGS='$(CXXFLAGS)' \
+	-DCMAKE_C_COMPILER='$(shell $(CHPL_MAKE_PYTHON) $(CHPL_MAKE_HOME)/util/chplenv/chpl_compiler.py --cc --target --compiler-only)' \
+	-DCMAKE_C_FLAGS='$(shell $(CHPL_MAKE_PYTHON) $(CHPL_MAKE_HOME)/util/chplenv/chpl_compiler.py --cc --target --additional) $(CFLAGS)' \
+	-DCMAKE_CXX_COMPILER='$(shell $(CHPL_MAKE_PYTHON) $(CHPL_MAKE_HOME)/util/chplenv/chpl_compiler.py --cxx --target --compiler-only)' \
+	-DCMAKE_CXX_FLAGS='$(shell $(CHPL_MAKE_PYTHON) $(CHPL_MAKE_HOME)/util/chplenv/chpl_compiler.py --cxx --target --additional) $(CXXFLAGS)' \
 	-DCMAKE_MAKE_PROGRAM='$(MAKE)'
 
 qthread-build: FORCE

--- a/util/chplenv/chpl_compiler.py
+++ b/util/chplenv/chpl_compiler.py
@@ -528,10 +528,28 @@ def _main():
                       const='host', default='host')
     parser.add_option('--target', dest='flag', action='store_const',
                       const='target')
+    parser.add_option('--cc', dest='which', action='store_const',
+                      const='c', default=None, help='get CHPL_{flag}_CC')
+    parser.add_option('--cxx', dest='which', action='store_const',
+                      const='c++', help='get CHPL_{flag}_CXX')
+    parser.add_option('--compiler-only', dest='parts', action='store_const',
+                      const='compiler', default='all')
+    parser.add_option('--additional', dest='parts', action='store_const',
+                      const='additional', help='get additional compiler args')
     (options, args) = parser.parse_args()
 
-    compiler_val = get(options.flag)
-    sys.stdout.write("{0}\n".format(compiler_val))
+    if options.which is None:
+        compiler_val = get(options.flag)
+        sys.stdout.write("{0}\n".format(compiler_val))
+    else:
+        compiler = get_compiler_command(options.flag, options.which)
+        if options.parts == 'compiler':
+            sys.stdout.write("{0}\n".format(compiler[0]))
+        elif options.parts == 'additional':
+            sys.stdout.write("{0}\n".format(' '.join(compiler[1:])))
+        else:
+            sys.stdout.write("{0}\n".format(' '.join(compiler)))
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Changes the qthreads Makefile to specify `CMAKE_[C|CXX]_COMPILER` to a value from `chplenv/chpl_compiler.py`. This allows us to the flags when the compiler has more than just the executable in it.

This also adjusts `chplenv/chpl_compiler.py` to support this use case.

This is required on platforms where `CHPL_TARGET_[CC|CXX]` has more than the executable in it. For example `CHPL_TARGET_CC: clang --gcc-toolchain=/usr`. Specifying this whole string as `CMAKE_C_COMPILER` causes CMake to fail to build. This PR fixes this by only specifying `clang` to `CMAKE_C_COMPILER`, and moving `--gcc-toolchain=/usr` to `CMAKE_C_FLAGS`.

[Reviewed by @arezaii]