### PR TITLE
Make deleting a branch not an error if it doesn't exist

### DIFF
--- a/util/cron/common-playground.bash
+++ b/util/cron/common-playground.bash
@@ -4,7 +4,9 @@ function checkout_branch()
 {
   local user=$1
   local branch=$2
-  git branch -D $user-$branch
+  # log_info relies on common.bash being sourced first, not enforced by this file
+  log_info "Checking out branch $branch from user $user"
+  git branch -D $user-$branch || true
   git checkout -b $user-$branch
   git pull --no-rebase https://github.com/$user/chapel.git $branch
 }


### PR DESCRIPTION
Fixes an issue where the playground would crash when trying to delete a git branch that did not exist yet.

Also adds some improved logging.

[Not reviewed]