### PR TITLE
Dyno: add environment flag to save currently loaded files into a temporary directory

### DIFF
--- a/frontend/test/CMakeLists.txt
+++ b/frontend/test/CMakeLists.txt
@@ -17,7 +17,7 @@
 
 # define target for the common code for all dyno tests
 add_library(tests-common OBJECT EXCLUDE_FROM_ALL
-            test-common.cpp test-parsing.cpp test-resolution.cpp)
+            test-common.cpp ErrorGuard.cpp test-parsing.cpp test-resolution.cpp)
 target_link_libraries(tests-common ChplFrontend)
 
 add_custom_target(tests)

--- a/frontend/test/ErrorGuard.cpp
+++ b/frontend/test/ErrorGuard.cpp
@@ -52,22 +52,12 @@ static void errorGuardSignalHandler(int sig) {
       // standard modules are in CHPL_HOME, don't copy them out.
       if (chpl::parsing::filePathIsInBundledModule(currentGuard->context(), file)) continue;
 
-      // file could've been included from another. don't know how to handle that.
-      // auto queryArgs = std::make_tuple(file, chpl::UniqueString());
-      // if (!currentGuard->context()->hasCurrentResultForQuery(chpl::parsing::parseFileToBuilderResult, queryArgs)) continue;
-
       // copy file into temporary directory.
-
-      // use LLVM to join the file path in 'file' to the path in 'path'
       auto destPath = path + "/" + file.str();
-
       auto fileText = chpl::parsing::fileText(currentGuard->context(), file);
       std::ignore = chpl::writeFile(destPath.c_str(), fileText.text());
     }
 
-    // files have been copied into the temporary directory. now symlink it.
-    // there's no chpl:: helper. use only standard C++. the symlinkTarget
-    // is expected to be the complete path.
     if (std::remove(target) != 0) {
       printf("failed to remove symlink target %s\n", symlinkTarget());
     }

--- a/frontend/test/ErrorGuard.cpp
+++ b/frontend/test/ErrorGuard.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2025 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ErrorGuard.h"
+#include "chpl/parsing/parsing-queries.h"
+#include "chpl/util/filesystem.h"
+#include <csignal>
+#include <cstdlib>
+#include <filesystem>
+
+static ErrorGuard* currentGuard = nullptr;
+static int guardCount = 0;
+
+
+// check CHPL_DEBUG_DYNO_DUMP_SYMLINK for a directory to symlink to the
+// directory created by makeTempDir
+static const char* symlinkTarget() {
+  static const char* target = std::getenv("CHPL_DEBUG_DYNO_DUMP_SYMLINK");
+  return target;
+}
+
+extern "C" {
+
+static void errorGuardSignalHandler(int sig) {
+  debuggerBreakHere();
+
+  auto target = symlinkTarget();
+  if (!target) return;
+
+  if (currentGuard) {
+    std::string path;
+    if (chpl::makeTempDir("state-dump", path)) return;
+
+    auto files = chpl::parsing::introspectParsedFiles(currentGuard->context());
+    for (auto file : files) {
+      // standard modules are in CHPL_HOME, don't copy them out.
+      if (chpl::parsing::filePathIsInBundledModule(currentGuard->context(), file)) continue;
+
+      // file could've been included from another. don't know how to handle that.
+      // auto queryArgs = std::make_tuple(file, chpl::UniqueString());
+      // if (!currentGuard->context()->hasCurrentResultForQuery(chpl::parsing::parseFileToBuilderResult, queryArgs)) continue;
+
+      // copy file into temporary directory.
+
+      // use LLVM to join the file path in 'file' to the path in 'path'
+      auto destPath = path + "/" + file.str();
+
+      auto fileText = chpl::parsing::fileText(currentGuard->context(), file);
+      std::ignore = chpl::writeFile(destPath.c_str(), fileText.text());
+    }
+
+    // files have been copied into the temporary directory. now symlink it.
+    // there's no chpl:: helper. use only standard C++. the symlinkTarget
+    // is expected to be the complete path.
+    if (std::remove(target) != 0) {
+      printf("failed to remove symlink target %s\n", symlinkTarget());
+    }
+
+    std::filesystem::create_symlink(path, target);
+
+    printf("created Chapel file dump directory %s\n", path.c_str());
+    printf("symlinked to %s\n", symlinkTarget());
+  }
+}
+
+}
+
+void ErrorGuard::installSignalHandler() {
+  if (!symlinkTarget()) return;
+
+  currentGuard = this;
+  guardCount++;
+
+  assert(guardCount == 1 && "ErrorGuard::installSignalHandler called more than once");
+  std::signal(SIGSEGV, errorGuardSignalHandler);
+  std::signal(SIGABRT, errorGuardSignalHandler);
+}
+
+void ErrorGuard::removeSignalHandler() {
+  if (!symlinkTarget()) return;
+
+  guardCount--;
+  currentGuard = nullptr;
+
+  std::signal(SIGSEGV, SIG_DFL);
+  std::signal(SIGABRT, SIG_DFL);
+}

--- a/frontend/test/ErrorGuard.cpp
+++ b/frontend/test/ErrorGuard.cpp
@@ -54,6 +54,11 @@ static void errorGuardSignalHandler(int sig) {
 
       // copy file into temporary directory.
       auto destPath = path + "/" + file.str();
+
+      // create any needed subdirectories
+      auto destDir = std::filesystem::path(destPath).parent_path();
+      std::filesystem::create_directories(destDir);
+
       auto fileText = chpl::parsing::fileText(currentGuard->context(), file);
       std::ignore = chpl::writeFile(destPath.c_str(), fileText.text());
     }

--- a/frontend/test/ErrorGuard.h
+++ b/frontend/test/ErrorGuard.h
@@ -64,9 +64,13 @@ class ErrorGuard {
   }
 
  public:
+  void installSignalHandler();
+  void removeSignalHandler();
+
   ErrorGuard(chpl::Context* ctx) : ctx_(ctx) {
     auto handler = prepareAndStoreHandler();
     oldErrorHandler_ = ctx_->installErrorHandler(std::move(handler));
+    installSignalHandler();
   }
 
   inline chpl::Context* context() const { return ctx_; }
@@ -130,6 +134,7 @@ class ErrorGuard {
 
   /** The guard destructor will assert that no errors have occurred. */
   ~ErrorGuard() {
+    removeSignalHandler();
     assert(!this->realizeErrors());
     std::ignore = ctx_->installErrorHandler(std::move(oldErrorHandler_));
   }


### PR DESCRIPTION
This is a developer-oriented PR implementing an item that has long since been on my wishlist. It adds a new environment variable, `CHPL_DEBUG_DYNO_DUMP_SYMLINK`, which is intended to point at a destination directory.

The flag affects the Dyno test system by adjusting the `ErrorGuard` behavior in the following way. Whenever it's set, and whenever a dyno tests throws a segmentation fault or hits an assertion, a custom signal handler is invoked. This handler introspects the current error guard's context object for user-defined Chapel files. It then saves the files into a temorary directory, and creates a symbolic link to the path in `CHPL_DEBUG_DYNO_DUMP_SYMLINK`.

This is convenient because it allows developers to quickly inspect the code that was last used when an assertion is encountered. For instance, I can apply the following diff, causing `testPrimHasDefaultValue.cpp` to crash:

```diff
diff --git a/frontend/test/resolution/testPrimHasDefaultValue.cpp b/frontend/test/resolution/testPrimHasDefaultValue.cpp
index 0a1d28b64b0..cabdfc3b348 100644
--- a/frontend/test/resolution/testPrimHasDefaultValue.cpp
+++ b/frontend/test/resolution/testPrimHasDefaultValue.cpp
@@ -62,6 +62,8 @@ static void ensureExpectedDefaultValue(Context* context, const char* type, bool
   } else {
     assert(guard.realizeErrors());
   }
+
+  assert(false);
 }

 int main() {
```

If I run it with:

```
export CHPL_DEBUG_DYNO_DUMP_SYMLINK=$(pwd)/lastrun
```

I can find `lastrun` to contain `A0.chpl` and `B0.chpl`:

```
➜  chapel git:(dump-chapel-state) ✗ find lastrun/ -name "*.chpl" | xargs cat

proc foo() { var x: int; }
param result = __primitive("type has default value", int);%
```

Reviewed by @benharsh -- thanks!