### PR TITLE
Adjust Arkouda colocale performance testing to sync to the correct dir

### DIFF
--- a/util/cron/common-arkouda.bash
+++ b/util/cron/common-arkouda.bash
@@ -66,5 +66,9 @@ function test_nightly() {
 }
 
 function sync_graphs() {
-  $CHPL_HOME/util/cron/syncPerfGraphs.py $CHPL_TEST_PERF_DIR/html/ arkouda/$CHPL_TEST_PERF_CONFIG_NAME
+  if [[ -n $CHPL_TEST_PERF_SYNC_DIR_SUFFIX ]]; then
+    $CHPL_HOME/util/cron/syncPerfGraphs.py $CHPL_TEST_PERF_DIR/html/ arkouda/$CHPL_TEST_PERF_CONFIG_NAME/$CHPL_TEST_PERF_SYNC_DIR_SUFFIX
+  else
+    $CHPL_HOME/util/cron/syncPerfGraphs.py $CHPL_TEST_PERF_DIR/html/ arkouda/$CHPL_TEST_PERF_CONFIG_NAME
+  fi
 }

--- a/util/cron/test-perf.hpe-apollo-hdr.arkouda.colo.bash
+++ b/util/cron/test-perf.hpe-apollo-hdr.arkouda.colo.bash
@@ -35,10 +35,13 @@ export GASNET_PHYSMEM_MAX="0.90"
 
 export CHPL_LLVM_GCC_PREFIX='none'
 
-nightly_args="${nightly_args} -no-buildcheck -sync-dir-suffix colocales"
+nightly_args="${nightly_args} -no-buildcheck"
 
 module list
 
+# normally, the syncdir suffix is an arg to nightly. But arkouda doesn't sync
+# graphs through nightly. It has its own sync_graphs
+export CHPL_TEST_PERF_SYNC_DIR_SUFFIX=colocales
 export CHPL_TEST_PERF_DESCRIPTION=nightly-colo
 export CHPL_TEST_PERF_CONFIGS="release,nightly,release-colo:v,nightly-colo:v"
 

--- a/util/cron/test-perf.hpe-apollo-hdr.arkouda.release.colo.bash
+++ b/util/cron/test-perf.hpe-apollo-hdr.arkouda.release.colo.bash
@@ -35,10 +35,13 @@ export GASNET_PHYSMEM_MAX="0.90"
 
 export CHPL_LLVM_GCC_PREFIX='none'
 
-nightly_args="${nightly_args} -no-buildcheck -sync-dir-suffix colocales"
+nightly_args="${nightly_args} -no-buildcheck"
 
 module list
 
+# normally, the syncdir suffix is an arg to nightly. But arkouda doesn't sync
+# graphs through nightly. It has its own sync_graphs
+export CHPL_TEST_PERF_SYNC_DIR_SUFFIX=colocales
 export CHPL_TEST_PERF_DESCRIPTION=release-colo
 export CHPL_TEST_PERF_CONFIGS="release,nightly,release-colo:v,nightly-colo:v"
 


### PR DESCRIPTION
Normally, we pass `-sync-dir-suffix` to `nightly` to sync a perf test's result into a subdirectory on dreamhost. However, Arkouda syncs its own graphs, where that variable is ineffective. This PR wires in that value through an environment variables to make sure that colocale performance plots go to the right location.