### PR TITLE
Allow including patch version in Docker release image tag

### DIFF
--- a/util/cron/test-docker.bash
+++ b/util/cron/test-docker.bash
@@ -131,6 +131,7 @@ then
   read major minor patch < <(echo $RELEASE_VERSION | ( IFS=".$IFS" ; read a b c && echo $a $b $c ))
   if [ "$patch" = "0" ]
   then
+    echo "Truncating patch version '$patch' from release $RELEASE_VERSION to determine branch name"
     release_ver_no_zero_patch="$major.$minor"
   fi
   release_branch="release/$release_ver_no_zero_patch"


### PR DESCRIPTION
Adjust Docker test script to expect release branch names to truncate off the patch version if it is `.0`.

This allows passing the full version string including patch to the script so it will build an image tagged as `major.minor.patch`, while still checking that we're building from the expected branch in release mode.

While here, also fix a bash syntax mistake from https://github.com/chapel-lang/chapel/pull/26952.

Resolves https://github.com/cray/chapel-private/issues/6738.

[reviewer info placeholder]