### PR TITLE
Bump Arkouda's release testing to version 2.4

### DIFF
--- a/util/cron/common-arkouda.bash
+++ b/util/cron/common-arkouda.bash
@@ -43,7 +43,7 @@ fi
 # enable arrow/parquet support
 export ARKOUDA_SERVER_PARQUET_SUPPORT=true
 
-export CHPL_WHICH_RELEASE_FOR_ARKOUDA="2.3.0"
+export CHPL_WHICH_RELEASE_FOR_ARKOUDA="2.4.0"
 
 function partial_checkout_release() {
   currentSha=`git rev-parse HEAD`


### PR DESCRIPTION
This PR updates Arkouda testing to use Chapel 2.4 release.