### PR TITLE
CLS/chplcheck: Support editor agnostic configuration files

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -2346,6 +2346,7 @@ static void dynoConfigureContext(std::string chpl_module_path) {
 
   chpl::parsing::setupModuleSearchPaths(gContext,
                                         CHPL_HOME,
+                                        "", //moduleRoot
                                         fMinimalModules,
                                         CHPL_LOCALE_MODEL,
                                         fEnableTaskTracking,

--- a/doc/rst/tools/chpl-language-server/chpl-language-server.rst
+++ b/doc/rst/tools/chpl-language-server/chpl-language-server.rst
@@ -141,6 +141,35 @@ language server with linting enabled various ``chplcheck`` flags:
      --chplcheck-disable-rule UnusedLoopIndex \
      --chplcheck-add-rules path/to/my/myrules.py
 
+Configuration Files
+^^^^^^^^^^^^^^^^^^^
+
+``chpl-language-server`` can be configured without passing command line flags using a
+configuration file. This file can be specified using the ``--config`` (also
+``-c``) flag. The configuration file can either be a YAML file or a specific
+TOML file. For example, running ``chpl-language-server -c config.yaml`` will load the
+configuration from ``config.yaml``. Additionally, ``chpl-language-server`` will look for a
+configuration files in the current directory named ``chpl-language-server.cfg`` or
+``.chpl-language-server.cfg`` (in that order).
+
+Most command line options can be specified in the configuration file. For
+example, the following YAML configuration file will enable end of block markers for loops and declarations.
+
+.. code-block:: yaml
+
+   end-markers: "loop,decl"
+
+TOML configuration files can also be used, for example the following is the same configuration as above:
+
+.. code-block:: toml
+
+   [tool.chpl-language-server]
+   end-markers = ["loop", "decl"]
+
+This configuration can also be added to a :ref:`Mason <readme-mason>`
+configuration file. ``CLS`` will automatically use a configuration file
+contained in a ``Mason.toml`` file in the current directory.
+
 Configuring Chapel Projects
 ---------------------------
 

--- a/doc/rst/tools/chplcheck/chplcheck.rst
+++ b/doc/rst/tools/chplcheck/chplcheck.rst
@@ -148,6 +148,39 @@ as at least 1 rule opts in to using them. For example, custom rules could confor
 to the setting ``MyIgnoreList``, which could be set as
 ``--setting MyIgnoreList="foo,bar"``.
 
+Configuration Files
+-------------------
+
+``chplcheck`` can be configured without passing command line flags using a
+configuration file. This file can be specified using the ``--config`` (also
+``-c``) flag. The configuration file can either be a YAML file or a specific
+TOML file. For example, running ``chplcheck -c config.yaml`` will load the
+configuration from ``config.yaml``. Additionally, ``chplcheck`` will look for a
+configuration files in the current directory named ``chplcheck.cfg`` or
+``.chplcheck.cfg`` (in that order).
+
+Most command line options can be specified in the configuration file. For
+example, the following YAML configuration file will explicitly enable the
+``UseExplicitModules`` rule and disable the ``UnusedLoopIndex`` and
+``UnusedFormal`` rules:
+
+.. code-block:: yaml
+
+   enable-rule: ["UseExplicitModules"]
+   disable-rule: ["UnusedLoopIndex", "UnusedFormal"]
+
+TOML configuration files can also be used, for example the following is the same configuration as above:
+
+.. code-block:: toml
+
+   [tool.chplcheck]
+   enable-rule = ["UseExplicitModules"]
+   disable-rule = ["UnusedLoopIndex", "UnusedFormal"]
+
+This configuration can also be added to a :ref:`Mason <readme-mason>`
+configuration file. ``chplcheck`` will automatically use a configuration file
+contained in a ``Mason.toml`` file in the current directory.
+
 Setting Up In Your Editor
 -------------------------
 

--- a/frontend/include/chpl/parsing/parsing-queries.h
+++ b/frontend/include/chpl/parsing/parsing-queries.h
@@ -299,6 +299,11 @@ void setBundledModulePath(Context* context, UniqueString path);
     chplSysModulesSubdir -- CHPL_SYS_MODULES_SUBDIR
     chplModulePath       -- CHPL_MODULE_PATH
 
+  The 'moduleRoot' argument allows overriding the default module root. If
+  'moduleRoot' is the empty string, then the default of 'CHPL_HOME/modules' is
+  used. Regardless, if 'minimalModules' is true '/minimal' is appended to the
+  'moduleRoot'.
+
   The arguments 'prependInternalModulePaths' and 'prependStandardModulePaths',
   if non-empty, allow one to override where the context will search for
   internal and standard modules, respectively. It will search each successive
@@ -312,6 +317,7 @@ void setBundledModulePath(Context* context, UniqueString path);
 void setupModuleSearchPaths(
                   Context* context,
                   const std::string& chplHome,
+                  const std::string& moduleRoot,
                   bool minimalModules,
                   const std::string& chplLocaleModel,
                   bool enableTaskTracking,
@@ -323,6 +329,18 @@ void setupModuleSearchPaths(
                   const std::vector<std::string>& prependStandardModulePaths,
                   const std::vector<std::string>& cmdLinePaths,
                   const std::vector<std::string>& inputFilenames);
+
+/**
+  Overload of the more general setupModuleSearchPaths that uses the
+  context's stored chplHome and chplEnv to determine the values of most
+  arguments.
+*/
+void setupModuleSearchPaths(Context* context,
+                            const std::string& moduleRoot,
+                            bool minimalModules,
+                            bool enableTaskTracking,
+                            const std::vector<std::string>& cmdLinePaths,
+                            const std::vector<std::string>& inputFilenames);
 
 /**
   Overload of the more general setupModuleSearchPaths that uses the

--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -1042,12 +1042,8 @@ std::string getExistingFileInModuleSearchPath(Context* context,
       // internal/standard module.
 
       bool firstMatchBundled =
-        filePathIsInInternalModule(context, UniqueString::get(context, found)) ||
-        filePathIsInStandardModule(context, UniqueString::get(context, found)) ||
         filePathIsInBundledModule(context, UniqueString::get(context, found));
       bool curMatchBundled =
-        filePathIsInInternalModule(context, UniqueString::get(context, check)) ||
-        filePathIsInStandardModule(context, UniqueString::get(context, check)) ||
         filePathIsInBundledModule(context, UniqueString::get(context, check));
 
       bool skip = firstMatchBundled && curMatchBundled;

--- a/test/chplcheck/configfile-toml.chpl
+++ b/test/chplcheck/configfile-toml.chpl
@@ -1,0 +1,1 @@
+configfile.chpl

--- a/test/chplcheck/configfile-toml.chplcheckopts
+++ b/test/chplcheck/configfile-toml.chplcheckopts
@@ -1,0 +1,1 @@
+--config configfile.toml

--- a/test/chplcheck/configfile.chpl
+++ b/test/chplcheck/configfile.chpl
@@ -1,0 +1,3 @@
+module configfile {
+  for i in 1..10 {}
+}

--- a/test/chplcheck/configfile.chplcheckopts
+++ b/test/chplcheck/configfile.chplcheckopts
@@ -1,0 +1,1 @@
+-c configfile.yaml

--- a/test/chplcheck/configfile.toml
+++ b/test/chplcheck/configfile.toml
@@ -1,0 +1,2 @@
+[tool.chplcheck]
+disable-rule = ["UnusedLoopIndex", "PascalCaseModules"]

--- a/test/chplcheck/configfile.yaml
+++ b/test/chplcheck/configfile.yaml
@@ -1,0 +1,1 @@
+disable-rule: ["UnusedLoopIndex", "PascalCaseModules"]

--- a/third-party/chpl-venv/chapel-py-requirements.txt
+++ b/third-party/chpl-venv/chapel-py-requirements.txt
@@ -4,5 +4,7 @@ lsprotocol==2023.0.1
 pygls==1.3.1
 typeguard==4.3.0
 ConfigArgParse==1.7
+PyYAML==6.0.2 # required by ConfigArgParse
+toml==0.10.2 # required by ConfigArgParse
 # needed for <python3.11
 exceptiongroup==1.2.2

--- a/tools/chapel-py/src/chapel/__init__.py
+++ b/tools/chapel-py/src/chapel/__init__.py
@@ -393,7 +393,7 @@ def files_with_stdlib_contexts(
     """
 
     def setup_with_stdlib(ctx):
-        ctx.set_module_paths([], [])
+        ctx.set_module_paths("", [], [])
         if setup:
             setup(ctx)
 

--- a/tools/chapel-py/src/chapel/__init__.py
+++ b/tools/chapel-py/src/chapel/__init__.py
@@ -393,7 +393,7 @@ def files_with_stdlib_contexts(
     """
 
     def setup_with_stdlib(ctx):
-        ctx.set_module_paths("", [], [])
+        ctx.set_module_paths([], [])
         if setup:
             setup(ctx)
 

--- a/tools/chapel-py/src/method-tables/core-methods.h
+++ b/tools/chapel-py/src/method-tables/core-methods.h
@@ -45,11 +45,12 @@ CLASS_BEGIN(Context)
          }
          return topLevelNodes)
   METHOD(Context, set_module_paths, "Set the module path arguments to the given lists of module paths and filenames",
-         void(std::vector<std::string>, std::vector<std::string>),
+         void(std::string, std::vector<std::string>, std::vector<std::string>),
 
-         auto& paths = std::get<0>(args);
-         auto& filenames = std::get<1>(args);
-         parsing::setupModuleSearchPaths(node, false, false, paths, filenames);
+         auto& modRoot = std::get<0>(args);
+         auto& paths = std::get<1>(args);
+         auto& filenames = std::get<2>(args);
+         parsing::setupModuleSearchPaths(node, modRoot, false, false, paths, filenames);
          if (auto autoUseScope = resolution::scopeForAutoModule(node)) {
            std::ignore = resolution::resolveVisibilityStmts(node, autoUseScope, false);
          })

--- a/tools/chapel-py/src/method-tables/core-methods.h
+++ b/tools/chapel-py/src/method-tables/core-methods.h
@@ -55,7 +55,7 @@ CLASS_BEGIN(Context)
          })
   METHOD(Context, _set_module_paths, "Set the module path arguments to the given lists of module paths and filenames, using a potentially different module root",
           void(std::string, std::vector<std::string>, std::vector<std::string>),
- 
+
           auto& modRoot = std::get<0>(args);
           auto& paths = std::get<1>(args);
           auto& filenames = std::get<2>(args);

--- a/tools/chapel-py/src/method-tables/core-methods.h
+++ b/tools/chapel-py/src/method-tables/core-methods.h
@@ -45,15 +45,24 @@ CLASS_BEGIN(Context)
          }
          return topLevelNodes)
   METHOD(Context, set_module_paths, "Set the module path arguments to the given lists of module paths and filenames",
-         void(std::string, std::vector<std::string>, std::vector<std::string>),
+         void(std::vector<std::string>, std::vector<std::string>),
 
-         auto& modRoot = std::get<0>(args);
-         auto& paths = std::get<1>(args);
-         auto& filenames = std::get<2>(args);
-         parsing::setupModuleSearchPaths(node, modRoot, false, false, paths, filenames);
+         auto& paths = std::get<0>(args);
+         auto& filenames = std::get<1>(args);
+         parsing::setupModuleSearchPaths(node, false, false, paths, filenames);
          if (auto autoUseScope = resolution::scopeForAutoModule(node)) {
            std::ignore = resolution::resolveVisibilityStmts(node, autoUseScope, false);
          })
+  METHOD(Context, _set_module_paths, "Set the module path arguments to the given lists of module paths and filenames, using a potentially different module root",
+          void(std::string, std::vector<std::string>, std::vector<std::string>),
+ 
+          auto& modRoot = std::get<0>(args);
+          auto& paths = std::get<1>(args);
+          auto& filenames = std::get<2>(args);
+          parsing::setupModuleSearchPaths(node, modRoot, false, false, paths, filenames);
+          if (auto autoUseScope = resolution::scopeForAutoModule(node)) {
+            std::ignore = resolution::resolveVisibilityStmts(node, autoUseScope, false);
+          })
   METHOD(Context, is_bundled_path, "Check if the given file path is within the bundled (built-in) Chapel files",
          bool(chpl::UniqueString),
 

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -692,7 +692,7 @@ class ContextContainer:
         self.std_module_root = self.cls_config.args.get("std_module_root", "")
         self.module_paths.extend(self.cls_config.args.get("module_dirs", []))
 
-        self.context.set_module_paths(self.std_module_root, self.module_paths, self.file_paths)
+        self.context._set_module_paths(self.std_module_root, self.module_paths, self.file_paths)
 
     def register_signature(self, sig: chapel.TypedSignature) -> str:
         """
@@ -739,7 +739,7 @@ class ContextContainer:
         """
 
         self.context.advance_to_next_revision(False)
-        self.context.set_module_paths(self.std_module_root, self.module_paths, self.file_paths)
+        self.context._set_module_paths(self.std_module_root, self.module_paths, self.file_paths)
 
         with self.context.track_errors() as errors:
             for fi in self.file_infos:

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -1378,7 +1378,11 @@ class CLSConfig:
 
     def _construct_parser(self):
         self.parser = configargparse.ArgParser(
-            default_config_files=[os.path.join(os.getcwd(), "Mason.toml")],
+            default_config_files=[
+                os.path.join(os.getcwd(), "chpl-language-server.cfg"),
+                os.path.join(os.getcwd(), ".chpl-language-server.cfg"),
+                os.path.join(os.getcwd(), "Mason.toml"),
+            ],
             config_file_parser_class=configargparse.CompositeConfigParser(
                 [
                     configargparse.YAMLConfigFileParser,

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -671,7 +671,12 @@ class EndMarkerPattern:
 
 
 class ContextContainer:
-    def __init__(self, file: str, cls_config: "CLSConfig", config: Optional["WorkspaceConfig"]):
+    def __init__(
+        self,
+        file: str,
+        cls_config: "CLSConfig",
+        config: Optional["WorkspaceConfig"],
+    ):
         self.cls_config: CLSConfig = cls_config
         self.config: Optional["WorkspaceConfig"] = config
         self.file_paths: List[str] = []
@@ -692,7 +697,9 @@ class ContextContainer:
         self.std_module_root = self.cls_config.args.get("std_module_root", "")
         self.module_paths.extend(self.cls_config.args.get("module_dirs", []))
 
-        self.context._set_module_paths(self.std_module_root, self.module_paths, self.file_paths)
+        self.context._set_module_paths(
+            self.std_module_root, self.module_paths, self.file_paths
+        )
 
     def register_signature(self, sig: chapel.TypedSignature) -> str:
         """
@@ -739,7 +746,9 @@ class ContextContainer:
         """
 
         self.context.advance_to_next_revision(False)
-        self.context._set_module_paths(self.std_module_root, self.module_paths, self.file_paths)
+        self.context._set_module_paths(
+            self.std_module_root, self.module_paths, self.file_paths
+        )
 
         with self.context.track_errors() as errors:
             for fi in self.file_infos:
@@ -1384,8 +1393,12 @@ class CLSConfig:
             self.parser.set_defaults(**{dest: default})
 
         add_bool_flag("resolver", "resolver", False)
-        self.parser.add_argument("--std-module-root", default="", help=configargparse.SUPPRESS)
-        self.parser.add_argument("-M", "--module-dir", action="append", default=[])
+        self.parser.add_argument(
+            "--std-module-root", default="", help=configargparse.SUPPRESS
+        )
+        self.parser.add_argument(
+            "-M", "--module-dir", action="append", default=[]
+        )
         add_bool_flag("type-inlays", "type_inlays", True)
         add_bool_flag("param-inlays", "param_inlays", True)
         add_bool_flag("literal-arg-inlays", "literal_arg_inlays", True)

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -1379,7 +1379,14 @@ class CLSConfig:
     def _construct_parser(self):
         self.parser = configargparse.ArgParser(
             default_config_files=[],
-            config_file_parser_class=configargparse.CompositeConfigParser([configargparse.YAMLConfigFileParser, configargparse.TomlConfigParser(["tool.chpl-language-server"])]),
+            config_file_parser_class=configargparse.CompositeConfigParser(
+                [
+                    configargparse.YAMLConfigFileParser,
+                    configargparse.TomlConfigParser(
+                        ["tool.chpl-language-server"]
+                    ),
+                ]
+            ),
             args_for_setting_config_path=["--config", "-c"],
         )
 

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -671,9 +671,11 @@ class EndMarkerPattern:
 
 
 class ContextContainer:
-    def __init__(self, file: str, config: Optional["WorkspaceConfig"]):
+    def __init__(self, file: str, cls_config: "CLSConfig", config: Optional["WorkspaceConfig"]):
+        self.cls_config: CLSConfig = cls_config
         self.config: Optional["WorkspaceConfig"] = config
         self.file_paths: List[str] = []
+        self.std_module_root: str = ""
         self.module_paths: List[str] = [os.path.dirname(os.path.abspath(file))]
         self.context: chapel.Context = chapel.Context()
         self.file_infos: List["FileInfo"] = []
@@ -687,7 +689,10 @@ class ContextContainer:
                 self.module_paths = file_config["module_dirs"]
                 self.file_paths = file_config["files"]
 
-        self.context.set_module_paths(self.module_paths, self.file_paths)
+        self.std_module_root = self.cls_config.args.get("std_module_root", "")
+        self.module_paths.extend(self.cls_config.args.get("module_dirs", []))
+
+        self.context.set_module_paths(self.std_module_root, self.module_paths, self.file_paths)
 
     def register_signature(self, sig: chapel.TypedSignature) -> str:
         """
@@ -734,7 +739,7 @@ class ContextContainer:
         """
 
         self.context.advance_to_next_revision(False)
-        self.context.set_module_paths(self.module_paths, self.file_paths)
+        self.context.set_module_paths(self.std_module_root, self.module_paths, self.file_paths)
 
         with self.context.track_errors() as errors:
             for fi in self.file_infos:
@@ -1379,6 +1384,8 @@ class CLSConfig:
             self.parser.set_defaults(**{dest: default})
 
         add_bool_flag("resolver", "resolver", False)
+        self.parser.add_argument("--std-module-root", default="", help=configargparse.SUPPRESS)
+        self.parser.add_argument("-M", "--module-dir", action="append", default=[])
         add_bool_flag("type-inlays", "type_inlays", True)
         add_bool_flag("param-inlays", "param_inlays", True)
         add_bool_flag("literal-arg-inlays", "literal_arg_inlays", True)
@@ -1530,7 +1537,7 @@ class ChapelLanguageServer(LanguageServer):
         if path in self.contexts:
             return self.contexts[path]
 
-        context = ContextContainer(path, workspace_config)
+        context = ContextContainer(path, self.config, workspace_config)
         for file in context.file_paths:
             self.contexts[file] = context
         self.contexts[path] = context

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -42,6 +42,7 @@ import json
 import re
 import sys
 import importlib.util
+import copy
 
 import chapel
 from chapel.lsp import location_to_range, error_to_diagnostic
@@ -693,8 +694,8 @@ class ContextContainer:
                 self.module_paths = file_config["module_dirs"]
                 self.file_paths = file_config["files"]
 
-        self.std_module_root = self.cls_config.args.get("std_module_root", "")
-        self.module_paths.extend(self.cls_config.args.get("module_dirs", []))
+        self.std_module_root = self.cls_config.get("std_module_root")
+        self.module_paths.extend(self.cls_config.get("module_dir"))
 
         self.context._set_module_paths(
             self.std_module_root, self.module_paths, self.file_paths
@@ -1408,7 +1409,7 @@ class CLSConfig:
             "--std-module-root", default="", help=configargparse.SUPPRESS
         )
         self.parser.add_argument(
-            "-M", "--module-dir", action="append", default=[]
+            "--module-dir", "-M", action="append", default=[]
         )
         add_bool_flag("type-inlays", "type_inlays", True)
         add_bool_flag("param-inlays", "param_inlays", True)
@@ -1450,7 +1451,7 @@ class CLSConfig:
             )
 
     def parse_args(self):
-        self.args = vars(self.parser.parse_args())
+        self.args = copy.deepcopy(vars(self.parser.parse_args()))
         self._parse_end_markers()
         self._validate_end_markers()
 

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -1378,7 +1378,7 @@ class CLSConfig:
 
     def _construct_parser(self):
         self.parser = configargparse.ArgParser(
-            default_config_files=[],
+            default_config_files=[os.path.join(os.getcwd(), "Mason.toml")],
             config_file_parser_class=configargparse.CompositeConfigParser(
                 [
                     configargparse.YAMLConfigFileParser,

--- a/tools/chpl-language-server/src/chpl-shim.py
+++ b/tools/chpl-language-server/src/chpl-shim.py
@@ -31,7 +31,7 @@ from chapel.core import *
 
 def list_parsed_files(files, module_paths):
     ctx = Context()
-    ctx.set_module_paths(module_paths, files)
+    ctx.set_module_paths("", module_paths, files)
 
     for file in files:
         asts = ctx.parse(file)

--- a/tools/chpl-language-server/src/chpl-shim.py
+++ b/tools/chpl-language-server/src/chpl-shim.py
@@ -31,7 +31,7 @@ from chapel.core import *
 
 def list_parsed_files(files, module_paths):
     ctx = Context()
-    ctx.set_module_paths("", module_paths, files)
+    ctx.set_module_paths(module_paths, files)
 
     for file in files:
         asts = ctx.parse(file)

--- a/tools/chplcheck/src/chplcheck.py
+++ b/tools/chplcheck/src/chplcheck.py
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-import argparse
+import configargparse
 from collections import defaultdict
 import importlib.util
 import os
@@ -195,8 +195,10 @@ def print_rules(driver: LintDriver, show_all=True):
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        prog="chplcheck", description="A linter for the Chapel language"
+    parser = configargparse.ArgParser(
+        default_config_files=[],
+        config_file_parser_class=configargparse.CompositeConfigParser([configargparse.YAMLConfigFileParser, configargparse.TomlConfigParser(["tool.chplcheck"])]),
+        args_for_setting_config_path=["--config", "-c"],
     )
     parser.add_argument("filenames", nargs="*")
     Config.add_arguments(parser)

--- a/tools/chplcheck/src/chplcheck.py
+++ b/tools/chplcheck/src/chplcheck.py
@@ -197,7 +197,12 @@ def print_rules(driver: LintDriver, show_all=True):
 def main():
     parser = configargparse.ArgParser(
         default_config_files=[],
-        config_file_parser_class=configargparse.CompositeConfigParser([configargparse.YAMLConfigFileParser, configargparse.TomlConfigParser(["tool.chplcheck"])]),
+        config_file_parser_class=configargparse.CompositeConfigParser(
+            [
+                configargparse.YAMLConfigFileParser,
+                configargparse.TomlConfigParser(["tool.chplcheck"]),
+            ]
+        ),
         args_for_setting_config_path=["--config", "-c"],
     )
     parser.add_argument("filenames", nargs="*")

--- a/tools/chplcheck/src/chplcheck.py
+++ b/tools/chplcheck/src/chplcheck.py
@@ -215,7 +215,6 @@ def main():
     parser.add_argument("filenames", nargs="*")
     parser.add_argument(
         "--file",
-        "-f",
         action="append",
         default=[],
         help="Add a file to the list of 'filenames' to lint",

--- a/tools/chplcheck/src/chplcheck.py
+++ b/tools/chplcheck/src/chplcheck.py
@@ -199,7 +199,11 @@ def print_rules(driver: LintDriver, show_all=True):
 
 def main():
     parser = configargparse.ArgParser(
-        default_config_files=[os.path.join(os.getcwd(), "Mason.toml")],
+        default_config_files=[
+            os.path.join(os.getcwd(), "chplcheck.cfg"),
+            os.path.join(os.getcwd(), ".chplcheck.cfg"),
+            os.path.join(os.getcwd(), "Mason.toml"),
+        ],
         config_file_parser_class=configargparse.CompositeConfigParser(
             [
                 configargparse.YAMLConfigFileParser,

--- a/tools/chplcheck/src/lsp.py
+++ b/tools/chplcheck/src/lsp.py
@@ -149,10 +149,10 @@ def run_lsp(driver: LintDriver):
         if uri in contexts:
             context = contexts[uri]
             context.advance_to_next_revision(False)
-            context.set_module_paths([], [])
+            context.set_module_paths("", [], [])
         else:
             context = chapel.core.Context()
-            context.set_module_paths([], [])
+            context.set_module_paths("", [], [])
             contexts[uri] = context
         return context
 

--- a/tools/chplcheck/src/lsp.py
+++ b/tools/chplcheck/src/lsp.py
@@ -149,10 +149,10 @@ def run_lsp(driver: LintDriver):
         if uri in contexts:
             context = contexts[uri]
             context.advance_to_next_revision(False)
-            context.set_module_paths("", [], [])
+            context.set_module_paths([], [])
         else:
             context = chapel.core.Context()
-            context.set_module_paths("", [], [])
+            context.set_module_paths([], [])
             contexts[uri] = context
         return context
 

--- a/tools/chpldoc/chpldoc.cpp
+++ b/tools/chpldoc/chpldoc.cpp
@@ -2465,6 +2465,7 @@ int main(int argc, char** argv) {
   auto chplModulePath = (it != chplEnv->end()) ? it->second : "";
   setupModuleSearchPaths(gContext,
                          CHPL_HOME,
+                         "", //moduleRoot
                          false, //minimal modules
                          chplEnv->at("CHPL_LOCALE_MODEL"),
                          false, //task tracking


### PR DESCRIPTION
This PR expands the existing support for using ConfigArgParse to allow for editor-agnostic configuration files. This allows users to specify options for their project in an editor-agnostic way, and then allow CLS/chplcheck to auto-pick them up.

This also integrates nicely with Mason, allowing users to specify CLS/chplcheck options in a Mason.toml file. For example

```toml
[brick]
...

[tool.chplcheck]
disable-rule = ["UnusedLoopIndex"]

```

This PR also expands the options for chplcheck, allowing the following

```toml
...

[tool.chplcheck]
file = ["src/*.chpl"]
add-rules = ["lint/rules.py"]
disable-rule = ["IncorrectIndentation"]

```

This lets users specify all the options needed in 1 file, and then from the project root running just `chplcheck` does the right thing

This PR also adds the -M/--module-dir options to CLS, allowing users to add a few paths to the module search path instead of needing a full .cls-commands file. This also includes adding an internal, developer only, ability to set the root directory for standard modules.

- [x] paratest with/without gasnet

[Reviewed by @DanilaFe]