### PR TITLE
Add `assertRegexMatch` to the UnitTest module

### DIFF
--- a/modules/packages/UnitTest.chpl
+++ b/modules/packages/UnitTest.chpl
@@ -49,6 +49,7 @@ Here are the assert functions available in the UnitTest module:
 - :proc:`~Test.assertNotEqual`
 - :proc:`~Test.assertGreaterThan`
 - :proc:`~Test.assertLessThan`
+- :proc:`~Test.assertRegexMatch`
 
 Test Metadata Functions
 -----------------------
@@ -242,6 +243,7 @@ Output:
 */
 module UnitTest {
   use Reflection;
+  use Regex;
   use TestError;
   use List, Map;
   private use IO, IO.FormattedIO;
@@ -546,12 +548,30 @@ module UnitTest {
     pragma "insert line file info"
     pragma "always propagate line file info"
     proc assertRegexMatch(x: ?t, pattern: t) throws {
-      use Regex;
-
       var re = new regex(pattern);
-      if !re.search(x).matched {
+      checkAssertRegexMatch(x, re);
+    }
+
+    /*
+      Assert that x matches the pre-compiled regular expression object.
+
+      :arg x: The first string or bytes to match.
+      :arg pattern: The pre-compiled regular expression object.
+      :throws AssertionError: If x doesn't match the regex
+    */
+    pragma "insert line file info"
+    pragma "always propagate line file info"
+    proc assertRegexMatch(x: ?t, re: regex(t)) throws {
+      checkAssertRegexMatch(x, re);
+    }
+
+    pragma "insert line file info"
+    pragma "always propagate line file info"
+    @chpldoc.nodoc
+    proc checkAssertRegexMatch(x: ?t, re: regex(t)) throws {
+      if !re.match(x) {
         const errorMsg = "assert failed - '%?' doesn't match\
-                          the regular expression '%?'".format(x, pattern);
+                          the regular expression '%?'".format(x, re:t);
         throw new owned AssertionError(errorMsg);
       }
     }

--- a/modules/packages/UnitTest.chpl
+++ b/modules/packages/UnitTest.chpl
@@ -553,7 +553,6 @@ module UnitTest {
         const errorMsg = "assert failed - '%?' doesn't match\
                           the regular expression '%?'".format(x, pattern);
         throw new owned AssertionError(errorMsg);
-
       }
     }
 

--- a/modules/packages/UnitTest.chpl
+++ b/modules/packages/UnitTest.chpl
@@ -536,6 +536,27 @@ module UnitTest {
       checkAssertEquality(first, second);
     }
 
+    /*
+      Assert that x matches the regular expression pattern.
+
+      :arg x: The first string or bytes to match.
+      :arg pattern: The regular expression pattern.
+      :throws AssertionError: If x doesn't match the regex
+    */
+    pragma "insert line file info"
+    pragma "always propagate line file info"
+    proc assertRegexMatch(x: ?t, pattern: t) throws {
+      use Regex;
+
+      var re = new regex(pattern);
+      if !re.search(x).matched {
+        const errorMsg = "assert failed - '%?' doesn't match\
+                          the regular expression '%?'".format(x, pattern);
+        throw new owned AssertionError(errorMsg);
+
+      }
+    }
+
     pragma "insert line file info"
     pragma "always propagate line file info"
     @chpldoc.nodoc

--- a/modules/packages/UnitTest.chpl
+++ b/modules/packages/UnitTest.chpl
@@ -541,6 +541,10 @@ module UnitTest {
     /*
       Assert that x matches the regular expression pattern.
 
+      .. warning::
+
+        This method requires Chapel to be built with `CHPL_RE2=bundled`.
+
       :arg x: The first string or bytes to match.
       :arg pattern: The regular expression pattern.
       :throws AssertionError: If x doesn't match the regex
@@ -554,6 +558,10 @@ module UnitTest {
 
     /*
       Assert that x matches the pre-compiled regular expression object.
+
+      .. warning::
+
+        This method requires Chapel to be built with `CHPL_RE2=bundled`.
 
       :arg x: The first string or bytes to match.
       :arg pattern: The pre-compiled regular expression object.

--- a/test/library/packages/UnitTest/AssertRegexMatch/SKIPIF
+++ b/test/library/packages/UnitTest/AssertRegexMatch/SKIPIF
@@ -1,0 +1,1 @@
+CHPL_RE2==none

--- a/test/library/packages/UnitTest/AssertRegexMatch/testAssertRegexMatch.chpl
+++ b/test/library/packages/UnitTest/AssertRegexMatch/testAssertRegexMatch.chpl
@@ -1,14 +1,27 @@
 use UnitTest;
+use Regex;
 
-proc assertRegexMatchTestPass(test: borrowed Test) throws {
-
+proc assertRegexMatchTestStringPass(test: borrowed Test) throws {
   var str = "test";
   test.assertRegexMatch(str, ".*es.*");
 }
 
-proc assertRegexMatchTestFail(test: borrowed Test) throws {
+proc assertRegexMatchTestStringFail(test: borrowed Test) throws {
   var str = "test";
   test.assertRegexMatch(str, ".*ES.*");
+}
+
+proc assertRegexMatchTestObjectPass(test: borrowed Test) throws {
+  var str = "test";
+  var re = new regex(".*es.*");
+  test.assertRegexMatch(str, re);
+}
+
+proc assertRegexMatchTestObjectFail(test: borrowed Test) throws {
+  var str = "test";
+
+  var re = new regex(".*ES.*");
+  test.assertRegexMatch(str, re);
 }
 
 UnitTest.main();

--- a/test/library/packages/UnitTest/AssertRegexMatch/testAssertRegexMatch.chpl
+++ b/test/library/packages/UnitTest/AssertRegexMatch/testAssertRegexMatch.chpl
@@ -1,0 +1,14 @@
+use UnitTest;
+
+proc assertRegexMatchTestPass(test: borrowed Test) throws {
+
+  var str = "test";
+  test.assertRegexMatch(str, ".*es.*");
+}
+
+proc assertRegexMatchTestFail(test: borrowed Test) throws {
+  var str = "test";
+  test.assertRegexMatch(str, ".*ES.*");
+}
+
+UnitTest.main();

--- a/test/library/packages/UnitTest/AssertRegexMatch/testAssertRegexMatch.good
+++ b/test/library/packages/UnitTest/AssertRegexMatch/testAssertRegexMatch.good
@@ -1,10 +1,20 @@
-assertRegexMatchTestPass()
+assertRegexMatchTestStringPass()
 Flavour: OK
 ======================================================================
 ----------------------------------------------------------------------
-assertRegexMatchTestFail()
+assertRegexMatchTestStringFail()
 Flavour: FAIL
 ======================================================================
 AssertionError: in testAssertRegexMatch.chpl:11 - assert failed - 'test' doesn't match
+                          the regular expression '.*ES.*'
+----------------------------------------------------------------------
+assertRegexMatchTestObjectPass()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+assertRegexMatchTestObjectFail()
+Flavour: FAIL
+======================================================================
+AssertionError: in testAssertRegexMatch.chpl:24 - assert failed - 'test' doesn't match
                           the regular expression '.*ES.*'
 ----------------------------------------------------------------------

--- a/test/library/packages/UnitTest/AssertRegexMatch/testAssertRegexMatch.good
+++ b/test/library/packages/UnitTest/AssertRegexMatch/testAssertRegexMatch.good
@@ -1,0 +1,10 @@
+assertRegexMatchTestPass()
+Flavour: OK
+======================================================================
+----------------------------------------------------------------------
+assertRegexMatchTestFail()
+Flavour: FAIL
+======================================================================
+AssertionError: in testAssertRegexMatch.chpl:11 - assert failed - 'test' doesn't match
+                          the regular expression '.*ES.*'
+----------------------------------------------------------------------


### PR DESCRIPTION
I needed this check while working on the Prometheus module. Granted, users can do their own checking and use `assertTrue`, but it feels like hiding the regular expression details would be a good addition to the UnitTest library.

Test
- [x] local