### PR TITLE
Adjust numBits(bool) error message

### DIFF
--- a/frontend/include/chpl/types/BoolType.h
+++ b/frontend/include/chpl/types/BoolType.h
@@ -27,9 +27,7 @@ namespace types {
 
 
 /**
-  This class represents a bool type, e.g. `bool` or `bool(32)`.
-
-  Note that `bool` normally has width `8` but `bool(8)` is a separate type.
+  This class represents a bool type, i.e. `bool`.
  */
 class BoolType final : public PrimitiveType {
  private:

--- a/frontend/include/chpl/types/BoolType.h
+++ b/frontend/include/chpl/types/BoolType.h
@@ -27,7 +27,7 @@ namespace types {
 
 
 /**
-  This class represents a bool type, i.e. `bool`.
+  This class represents the `bool` type.
  */
 class BoolType final : public PrimitiveType {
  private:

--- a/modules/standard/Types.chpl
+++ b/modules/standard/Types.chpl
@@ -703,7 +703,7 @@ This is available for all numeric types.
 */
 pragma "no where doc"
 proc numBits(type t) param where t == bool {
-  compilerError("default-width 'bool' does not have a well-defined size");
+  compilerError("'bool' does not have a well-defined size");
 }
 @chpldoc.nodoc
 proc numBits(type t) param where t == int(8) do return 8;

--- a/test/types/bool/bradc/numBitsBytesDefault.good
+++ b/test/types/bool/bradc/numBitsBytesDefault.good
@@ -1,3 +1,3 @@
 numBitsBytesDefault.chpl:3: In function 'printSizes':
-numBitsBytesDefault.chpl:4: error: default-width 'bool' does not have a well-defined size
+numBitsBytesDefault.chpl:4: error: 'bool' does not have a well-defined size
   numBitsBytesDefault.chpl:9: called as printSizes(type t = bool)


### PR DESCRIPTION
Adjusts the error message for calling `numBits` on a boolean to reflect the current state of the language, sionce there is no special "default width" bool type.

While there, I also updated some out of date dyno docs on this topic. And while updating these docs, I realized that Dyno defined the `defaultBitwidth` for a bool to be 0, while it defined the bitwidth for any given type to be `8`. I didn't really want to mess with changing that, but it was weird enough that I am noting it here.

[Reviewed by @bradcray]