### PR TITLE
Add a new docs-release Makefile target

### DIFF
--- a/Makefile.devel
+++ b/Makefile.devel
@@ -25,6 +25,9 @@ develall:
 docs: chpldoc man-chpl man-chpldoc
 	cd doc && $(MAKE) docs
 
+docs-release: chpldoc man-chpl man-chpldoc
+	cd doc && $(MAKE) docs-release
+
 checkdocs: FORCE
 	cd doc && $(MAKE) checkdocs
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -69,6 +69,9 @@ docs: FORCE
 	  echo " Try 'make frontend-docs'" ; \
 	fi
 
+docs-release: FORCE
+	$(MAKE) docs
+	cd html && rm versionButton.php && ln -s ../versionButton.php .
 
 man-chapel: FORCE
 	$(MAKE) man


### PR DESCRIPTION
With the 'versionButton.php' reorganization that took place in PR care with the versionButton.php file.  This PR adds a new target to the developer and doc/ Makefile called 'docs-release' that sets the versionButton.php file up to be the symbolic link we need it to be in the release (which differs from the one we need it to be when we're pushing the 'main' version of the docs to 'docs/main' on the live website).
