### PR TITLE
Dyno/CI: Split linters into a separate job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -81,7 +81,6 @@ jobs:
     - uses: actions/checkout@v4
     - name: run dyno linters
       run: |
-        CHPL_HOME=$PWD make modules
         CHPL_HOME=$PWD CHPL_HOST_CC=clang-13 CHPL_HOST_CXX=clang++-13 make run-dyno-linters
 
   check_compiler_dyno_tests:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -70,6 +70,20 @@ jobs:
       run: |
         ./util/buildRelease/smokeTest quickstart mason chpl
 
+  check_dyno_linters:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/chapel-github-ci:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.github_token }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: run dyno linters
+      run: |
+        CHPL_HOME=$PWD make modules
+        CHPL_HOME=$PWD CHPL_HOST_CC=clang-13 CHPL_HOST_CXX=clang++-13 make run-dyno-linters
+
   check_compiler_dyno_tests:
     runs-on: ubuntu-latest
     container:
@@ -84,9 +98,6 @@ jobs:
       run: |
         CHPL_HOME=$PWD make modules
         CHPL_HOME=$PWD make DYNO_ENABLE_ASSERTIONS=1 test-dyno -j`util/buildRelease/chpl-make-cpu_count`
-    - name: run dyno linters
-      run: |
-        CHPL_HOME=$PWD CHPL_HOST_CC=clang-13 CHPL_HOST_CXX=clang++-13 make run-dyno-linters
     - name: check undocumented symbols
       run: |
         CHPL_HOME=$PWD make DYNO_ENABLE_ASSERTIONS=1 chapel-py-venv -j`util/buildRelease/chpl-make-cpu_count`


### PR DESCRIPTION
These take a while, and we don't want them on the slow path.

Reviewed by @arifthpe -- thanks!