### PR TITLE
Fix chplconfig test after improved chplenv error checking

### DIFF
--- a/test/chplenv/chplconfig/correctness/chplconfig
+++ b/test/chplenv/chplconfig/correctness/chplconfig
@@ -5,7 +5,7 @@ CHPL_HOST_ARCH=x86_64
 CHPL_HOST_COMPILER=clang
 CHPL_TARGET_PLATFORM=darwin
 CHPL_TARGET_ARCH=x86_64
-CHPL_TARGET_COMPILER=clang --gcc-toolchain=/usr # nonsenseical value, but tests that it is accepted
+CHPL_TARGET_COMPILER=clang --gcc-toolchain=/usr # nonsensical value, but tests that it is accepted
 CHPL_TARGET_CPU=native
 CHPL_LOCALE_MODEL=flat
 CHPL_COMM=none

--- a/test/chplenv/chplconfig/unset_overrides.sh
+++ b/test/chplenv/chplconfig/unset_overrides.sh
@@ -2,7 +2,7 @@
 
 export PRINTCHPLENV=$CHPL_HOME/util/printchplenv
 
-CHPL_OVERRIDES=$(${PRINTCHPLENV} --overrides --simple | awk -F'=' '{print $1}')
+CHPL_OVERRIDES=$(${PRINTCHPLENV} --no-tidy --overrides --simple | awk -F'=' '{print $1}')
 
 for CHPL_VAR in ${CHPL_OVERRIDES}; do
     if [ ${CHPL_VAR} != "CHPL_HOME" ]; then


### PR DESCRIPTION
Fixes a failing test (`test/chplenv/chplconfig/warnings/warnings.chpl`) resulting from https://github.com/chapel-lang/chapel/pull/26501.

This issue occurs in a very strange way.
1. The test system always explicitly sets `CHPL_GASNET_SEGMENT`, in the default shared mem config this will always be `none`
    `os.environ["CHPL_GASNET_SEGMENT"] = chpl_comm_segment.get()`
2. This test uses a value of `CHPL_COMM=gasnet` when testing for multiple values of `CHPL_COMM` in a chplconfig file.
3. This test uses a custom script to ensure a clean environment when diff-ing the test output, `test/chplenv/chplconfig/unset_overrides.sh`.
    - This script uses the `--overrides` flag of `printchplenv` to determine what variables to unset.
4. By default, `--tidy` is thrown by `printchplenv` to restrict the chplenv output to only relevant variables, e.g. with CHPL_COMM=none, gasnet specific variables aren't shown

This results in the good file for the test being generated with `CHPL_COMM=gasnet` and `CHPL_GASNET_SEGMENT=none`, which is not valid. This is allowed to happen because the `unset_overrides.sh` script is unintentionally leaving garbage chplenv variables behind.

The solution to this is to make `unset_overrides.sh` explicitly use `--no-tidy`, so that it actually does what it is supposed to. Note this must be done before `--overrides` on the CLI, otherwise it has no effect (flags are applied in order)

This PR also fixes a typo I noticed while determining all this.

[Reviewed by @lydia-duncan]