### PR TITLE
Fix updateGITLOG for Arkouda

### DIFF
--- a/util/devel/updateGITLOG
+++ b/util/devel/updateGITLOG
@@ -11,7 +11,8 @@ fi
 echo "Getting log for branch $BRANCH"
     
 #git fetch chapel-lang master
-git log $BRANCH --first-parent -m --name-status --pretty=format:"-----------------------------------------------------------------------------%n%ncommit %h%nMerge: %p%nDate:   %ad%nAuthor: %an <%ae>%n%n%s%n%n%b%n" --reverse . | dos2unix > GITLOG
+git log $BRANCH --first-parent -m --name-status --pretty=format:"-----------------------------------------------------------------------------%n%ncommit %h%nMerge: %p%nDate:   %ad%nAuthor: %an <%ae>%n%n%s%n%n%b%n" --reverse . | dos2unix -f > GITLOG
+#git log $BRANCH --first-parent -m --name-status --pretty=format:"-----------------------------------------------------------------------------%n%ncommit %h%nMerge: %p%nDate:   %ad%nAuthor: %an <%ae>%n%n%s%n%n%b%n" --reverse . > GITLOG
 
 # TODO: Can I use tformat to put the %b after the list of files?  And a label
 # to search on to find it?


### PR DESCRIPTION
One of Arkouda's merge messages introduced some sort of binary character that makes `dos2unix` choke.  This adds a `-f` flag to force our way past it.
