### PR TITLE
Make sure `smp` is included in the list of valid substartes

### DIFF
--- a/util/chplenv/chpl_comm_substrate.py
+++ b/util/chplenv/chpl_comm_substrate.py
@@ -39,7 +39,7 @@ def get():
         else:
             substrate_val = 'none'
 
-    check_valid_var("CHPL_COMM_SUBSTRATE", substrate_val, ("none", "aries", "ofi", "ibv", "udp", "mpi"))
+    check_valid_var("CHPL_COMM_SUBSTRATE", substrate_val, ("none", "aries", "ofi", "ibv", "udp", "smp", "mpi"))
     return substrate_val
 
 


### PR DESCRIPTION
Adds `smp` to the list of valid substrates, I forgot about this when developing https://github.com/chapel-lang/chapel/pull/26501

[Not reviewed - trivial]