### PR TITLE
Stop setting chplenv variables in start_test

### DIFF
--- a/util/test/start_test.py
+++ b/util/test/start_test.py
@@ -1072,18 +1072,10 @@ def set_up_executables():
     locale_model = chpl_locale_model.get()
 
     logger.write('[comm: "{0}"]'.format(comm))
-    os.environ["CHPL_COMM"] = comm
-    os.environ["CHPL_GASNET_SEGMENT"] = chpl_comm_segment.get()
-    os.environ["CHPL_LAUNCHER"] = launcher
 
     logger.write('[networkAtomics: "{0}"]'.format(network_atomics))
-    os.environ["CHPL_NETWORK_ATOMICS"] = network_atomics
 
     logger.write('[localeModel: "{0}"]'.format(locale_model))
-    os.environ["CHPL_LOCALE_MODEL"] = locale_model
-
-    os.environ["CHPL_LLVM"] = chpl_llvm.get()
-    os.environ["CHPL_TASKS"] = chpl_tasks.get()
 
     # skip stdin tests for most custom launchers, except for amdprun and slurm
     if (launcher != "none" and launcher != "amudprun" and launcher !=

--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -338,7 +338,7 @@ def ReadFileWithComments(f, ignoreLeadingSpace=True, args=None):
             tmp_args = [os.path.abspath(f)]
             if args != None:
                 tmp_args += args
-            output = run_process_with_chpl_env(tmp_args, stdout=subprocess.PIPE, env=file_env)[1]
+            output = run_process_with_chpl_env(tmp_args, stdout=subprocess.PIPE)[1]
             mylines = output.splitlines()
 
         except OSError as e:

--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -181,6 +181,7 @@ def run_process_with_chpl_env(*args, **kwargs):
     chpl_env = get_chplenv()
     file_env = os.environ.copy()
     file_env.update(chpl_env)
+    file_env.update(kwargs.get('env', {}))
     kwargs['env'] = file_env
     return run_process(*args, **kwargs)
 
@@ -2374,7 +2375,7 @@ def main():
                             for sprediff in systemPrediffs:
                                 sys.stdout.write('[Executing system-wide prediff %s]\n'%(sprediff))
                                 sys.stdout.flush()
-                                stdout = run_process([sprediff, execname, execlog, compiler,
+                                stdout = run_process_with_chpl_env([sprediff, execname, execlog, compiler,
                                                       ' '.join(envCompopts)+' '+compopts, ' '.join(args)],
                                                      env=dict(list(os.environ.items()) + list(testenv.items())),
                                                      stdout=subprocess.PIPE, stderr=subprocess.STDOUT)[1]
@@ -2383,7 +2384,7 @@ def main():
                         if globalPrediff:
                             sys.stdout.write('[Executing ./PREDIFF]\n')
                             sys.stdout.flush()
-                            stdout = run_process(['./PREDIFF', execname, execlog, compiler,
+                            stdout = run_process_with_chpl_env(['./PREDIFF', execname, execlog, compiler,
                                                  ' '.join(envCompopts)+ ' '+compopts, ' '.join(args)],
                                                  env=dict(list(os.environ.items()) + list(testenv.items())),
                                                  stdout=subprocess.PIPE, stderr=subprocess.STDOUT)[1]
@@ -2392,7 +2393,7 @@ def main():
                         if prediff:
                             sys.stdout.write('[Executing prediff ./%s]\n'%(prediff))
                             sys.stdout.flush()
-                            stdout = run_process(['./'+prediff, execname, execlog, compiler,
+                            stdout = run_process_with_chpl_env(['./'+prediff, execname, execlog, compiler,
                                                  ' '.join(envCompopts)+' '+compopts, ' '.join(args)],
                                                  env=dict(list(os.environ.items()) + list(testenv.items())),
                                                  stdout=subprocess.PIPE, stderr=subprocess.STDOUT)[1]

--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -149,6 +149,18 @@ import errno
 from functools import reduce
 import atexit
 
+def memoize(func):
+    """Function memoizing decorator"""
+    cache = func.cache = {}
+
+    def memoize_wrapper(*args, **kwargs):
+        if kwargs:
+            return func(*args, **kwargs)
+        if args not in cache:
+            cache[args] = func(*args)
+        return cache[args]
+    return memoize_wrapper
+
 def elapsed_sub_test_time():
     """Print elapsed time for sub_test call to console."""
     global sub_test_start_time, localdir
@@ -272,6 +284,7 @@ def PerfDirFile(s):
 def PerfTFile(test_filename, sfx):
     return test_filename + '.' + perflabel + sfx
 
+@memoize
 def get_chplenv():
     env_cmd = [os.path.join(utildir, 'printchplenv'), '--all', '--simple', '--no-tidy', '--internal']
     chpl_env = run_process(env_cmd, stdout=subprocess.PIPE)[1]
@@ -908,25 +921,25 @@ def main():
         uniquifyTests = True
 
     # CHPL_COMM
-    chplcomm=os.getenv('CHPL_COMM','none').strip()
+    chplcomm=get_chplenv().get("CHPL_COMM", "none").strip()
     chplcommstr='.comm-'+chplcomm
     # sys.stdout.write('chplcomm=%s\n'%(chplcomm))
 
     # CHPL_NETWORK_ATOMICS
-    chplna=os.getenv('CHPL_NETWORK_ATOMICS','none').strip()
+    chplna=get_chplenv().get('CHPL_NETWORK_ATOMICS','none').strip()
     chplnastr='.na-'+chplna
     # sys.stdout.write('chplna=%s\n'%(chplna))
 
     # CHPL_LAUNCHER
-    chpllauncher=os.getenv('CHPL_LAUNCHER','none').strip()
+    chpllauncher=get_chplenv().get('CHPL_LAUNCHER','none').strip()
 
     # CHPL_LOCALE_MODEL
-    chpllm=os.getenv('CHPL_LOCALE_MODEL','flat').strip()
+    chpllm=get_chplenv().get('CHPL_LOCALE_MODEL','flat').strip()
     chpllmstr='.lm-'+chpllm
     # sys.stdout.write('lm=%s\n'%(chpllm))
 
     # CHPL_TASKS
-    chpltasks=os.getenv('CHPL_TASKS', 'none').strip()
+    chpltasks=get_chplenv().get('CHPL_TASKS', 'none').strip()
     chpltasksstr='.tasks-'+chpltasks
 
     #


### PR DESCRIPTION
This PR removes several lines from `start_test.py` which override certain environment variables.

Testing
- [ ] paratest with/without gasnet

[Reviewed by @]

## Rationale

I had to do this, because after https://github.com/chapel-lang/chapel/pull/26501 setting CHPL_GASNET_SEGMENT=none if CHPL_COMM=gasnet is an error. This led to confusing behavior with several tests (see https://github.com/chapel-lang/chapel/pull/26998). It also broke `test/gpu/native/environment/gasnet.chpl`. `chpl --comm gasnet test/gpu/native/environment/gasnet.chpl` is not an error, but `start_test test/gpu/native/environment/gasnet.chpl` (which has a compopts with `--comm gasnet` fails). This is confusing, and the easiest way to fix it is to fix `start_test.py`.

While I only had to remove setting `CHPL_GASNET_SEGMENT`, I found I could remove all of these variables. They create a confusing printout that doesn't match what the runner of `start_test` sees.

A diff of before/after this PR. Note that now the `*` (meaning a user override a variable in the environment) is now actually accurate.

```diff
21c21
< CHPL_COMM: none
---
> CHPL_COMM: none *
23c23
<   CHPL_GASNET_SEGMENT: none
---
>   CHPL_GASNET_SEGMENT: none *
26,27c26,27
< CHPL_TASKS: qthreads
< CHPL_LAUNCHER: none
---
> CHPL_TASKS: qthreads *
> CHPL_LAUNCHER: none *
35c35
<   CHPL_NETWORK_ATOMICS: none
---
>   CHPL_NETWORK_ATOMICS: none *
40c40
< CHPL_LLVM: system
---
> CHPL_LLVM: system *
```

Searching through the git history, I think the reason that these were override in the environment is a long-time holdover from when the test scripts used to be monolithic shell scripting, rather than a separate `start_test.py` and `sub_test.py`. This was needed to make skipifs and the like work. Today, other logic handles that, making this redundant.

To fully support this, I also had to update the logic for finding good files/executing scripts to not rely on environment variables