### PR TITLE
Dyno: adjust `compilerError` to interrupt resolution of functions

### DIFF
--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -2408,6 +2408,8 @@ class ResolvedExpression {
   ID toId_;
   // Is this a reference to a compiler-created primitive?
   bool isBuiltin_ = false;
+  // Did this expression cause the function to stop being resolved?
+  bool causedFatalError_ = false;
 
   // For a function call, what is the most specific candidate,
   // or when using return intent overloading, what are the most specific
@@ -2440,6 +2442,9 @@ class ResolvedExpression {
   /** check whether this resolution result refers to a compiler builtin like `bool`. */
   bool isBuiltin() const { return isBuiltin_; }
 
+  /** check whether this resolution result caused a fatal error. */
+  bool causedFatalError() const { return causedFatalError_; }
+
   /** For a function call, what is the most specific candidate, or when using
    * return intent overloading, what are the most specific candidates? The
    * choice between these needs to happen later than the main function
@@ -2463,6 +2468,9 @@ class ResolvedExpression {
 
   /** set the isPrimitive flag */
   void setIsBuiltin(bool isBuiltin) { isBuiltin_ = isBuiltin; }
+
+  /** set the causedFatalError flag */
+  void setCausedFatalError(bool causedFatalError) { causedFatalError_ = causedFatalError; }
 
   /** set the toId */
   void setToId(ID toId) { toId_ = toId; }

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -2499,6 +2499,7 @@ class ResolvedExpression {
     return type_ == other.type_ &&
            toId_ == other.toId_ &&
            isBuiltin_ == other.isBuiltin_ &&
+           causedFatalError_ == other.causedFatalError_ &&
            mostSpecific_ == other.mostSpecific_ &&
            poiScope_ == other.poiScope_ &&
            associatedActions_ == other.associatedActions_ &&
@@ -2511,6 +2512,7 @@ class ResolvedExpression {
     type_.swap(other.type_);
     toId_.swap(other.toId_);
     std::swap(isBuiltin_, other.isBuiltin_);
+    std::swap(causedFatalError_, other.causedFatalError_);
     mostSpecific_.swap(other.mostSpecific_);
     std::swap(poiScope_, other.poiScope_);
     std::swap(associatedActions_, other.associatedActions_);

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2300,6 +2300,7 @@ bool Resolver::CallResultWrapper::noteResultWithoutError(
     const CallResolutionResult& result,
     optional<ActionAndId> actionAndId) {
   bool needsErrors = false;
+  bool markErroneous = false;
 
   for (auto& diagnostic : gatherUserDiagnostics(resolver.rc, result)) {
     // The diagnostic's depth means it's aimed for further up the call stack.
@@ -2323,10 +2324,11 @@ bool Resolver::CallResultWrapper::noteResultWithoutError(
       // we're asked not to emit errors, and only return if errors are
       // needed.
       needsErrors = true;
+      markErroneous = diagnostic.kind() == CompilerDiagnostic::ERROR;
     }
   }
 
-  if (!result.exprType().hasTypePtr() || needsErrors) {
+  if (!result.exprType().hasTypePtr() || markErroneous) {
     if (!actionAndId && r) {
       // Only set the type to erroneous if we're handling an actual user call,
       // and not an associated action.

--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -337,6 +337,9 @@ struct ReturnTypeInferrer : BranchSensitiveVisitor<DefaultFrame, ResolvedVisitor
   const types::Param* determineIfValue(const uast::AstNode* ast, RV& rv) override;
   void traverseNode(const uast::AstNode* ast, RV& rv) override;
 
+  bool enter(const FnCall* ast, RV& rv);
+  void exit(const FnCall* ast, RV& rv);
+
   bool enter(const Function* fn, RV& rv);
   void exit(const Function* fn, RV& rv);
 
@@ -503,6 +506,22 @@ const types::Param* ReturnTypeInferrer::determineIfValue(const uast::AstNode* as
 }
 void ReturnTypeInferrer::traverseNode(const uast::AstNode* ast, RV& rv) {
   ast->traverse(rv);
+}
+
+bool ReturnTypeInferrer::enter(const FnCall* ast, RV& rv) {
+  enterScope(ast, rv);
+
+  if (auto rr = rv.byPostorder().byAstOrNull(ast)) {
+    if (rr->causedFatalError()) {
+      markFatalError();
+    }
+  }
+
+  return true;
+}
+
+void ReturnTypeInferrer::exit(const FnCall* ast, RV& rv) {
+  exitScope(ast, rv);
 }
 
 bool ReturnTypeInferrer::enter(const Function* fn, RV& rv) {


### PR DESCRIPTION
Resolves https://github.com/Cray/chapel-private/issues/7229.

Depends on https://github.com/chapel-lang/chapel/pull/26999.

Quoting from that issue: a lot of Chapel production code (including in library modules) looks like this:

```Chapel
proc foo(param cond) {
    if cond then compilerError("This condition should not be met");
    codeThatOnlyCompilesIfCondIsFalse();
}
```

These rely on the fact that `codeThatOnlyCompilesIfCondIsFalse()` will not be resolved if an error is already emitted. This means terminating resolution of `foo()`, much like we do with `return` in https://github.com/chapel-lang/chapel/pull/26955.
This PR implements that.

One conceptual curiosity is that this conflicts with Dyno's existing approach of attempting to continue resolving programs to get partial information. Specifically, expressions that emitted errors are marked with `ErroneousType`, and if the rest of the types can be inferred despite the error, we infer them. This is desirable (partial information is useful in editors, for example), but counter to stopping resolution in its tracks. This PR goes for a two-phase handling of `compilerError`, which distinguishes functions that call compiler error directly and functions that simply observe errors emitted by a call.

* __For functions that invoke `compilerError` directly__, this PR makes use of the changes in https://github.com/chapel-lang/chapel/pull/26955 to stop resolution in its tracks. This requires some communication between the resolver and the other branch-sensitive passes to inform them of the fatal error, which I achieve using a new flag on `ResolvedExpression` called `causedFatalError_`[^1].
  * Functions that are meant as "helpers" for invoking `compilerError` (i.e., those that are ignored using the `depth` argument) are considered "direct" callers to `compilerError` for the purposes of this phase. That's because they mostly just serve to augment the `compilerError` in some way.
* __For invocations of functions that error__, this PR simply marks the call as `ErroneousType`, without interrupting the resolution of the current function etc. Thus, if we call `foo()`, and `foo()` issues a `compilerError`, we print the error and mark `foo()` as `ErroneousType`, but (as described above) continue resolving with partial information.

This way, I believe we can reconcile the expectation of `compilerError` as terminating resolution, while still allowing us to compute partial information in other contexts. See the program tested by this PR:

```Chapel
      proc foo() {
        bar();
        return 42;
      }
      proc bar() {
        compilerError("Hello");
        compilerWarnning("inside bar, after call to compilerError");
      }
      var x = foo();
```

Here, the error "Hello" immediately terminates resolution of `bar()` (so the "inside bar" warning is never printed). This error is issued on the `bar();` line, but we proceed past this line, and, since the `return 42` doesn't depend on the call to `bar()`, correctly determine that the `var x` is an `int`.

## Testing
- [x] dyno tests
- [x] paratest
- [x] spectests still work as before

Reviewed by @benharsh -- thanks!

[^1]: I have checked and on my machine, this flag does not cause the `ResolvedExpression` type to increaase in size, presumably due to the way that struct is padded. So this does not cause size / memory penalties .