### PR TITLE
Override `--gasnet-segment` when overriding `--comm`

### DIFF
--- a/test/gpu/native/environment/gasnet.compopts
+++ b/test/gpu/native/environment/gasnet.compopts
@@ -1,1 +1,1 @@
---comm gasnet --network-atomics none
+--comm gasnet --gasnet-segment fast --network-atomics none


### PR DESCRIPTION
Adjusts a test to also use `--gasnet-segment`, as otherwise the test gets errors about invalid values of `CHPL_GASNET_SEGMENT`.

[Trivial - not reviewed]