### PR TITLE
Add arkouda perf triage annotations (3/27/25) 

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -2575,6 +2575,12 @@ arkouda: &arkouda-base
   01/02/25:
     - text: No longer running tests with --isolated
       config:  16-node-xc
+  03/06/25:
+    - text: Suspected systems changes
+      config: 16-node-xc
+  03/28/25:
+    - text: Add ARKOUDA_DEFAULT_TEMP_DIRECTORY for arkouda perf tests (#26949)
+      config: 16-node-hpe-apollo-hdr
 
 arkouda-string:
   <<: *arkouda-base

--- a/util/test/check_annotations.py
+++ b/util/test/check_annotations.py
@@ -93,7 +93,8 @@ def check_configs(ann_data):
     known_configs = {'shootout', 'chap03', 'chap04', 'bradc-lnx', 'chapcs',
                      '16-node-xc', '1-node-xc', '16-node-cs', '16-node-cs-hdr',
                      'chapcs.comm-counts', '1-node-p100', '1-node-mi60',
-                     '16-node-apollo-hdr', '16-node-hpe-cray-ex', '1-node-hpe-cray-ex', '1-node-a100', '1-node-mi250x'}
+                     '16-node-apollo-hdr', '16-node-hpe-cray-ex', '1-node-hpe-cray-ex', '1-node-a100', '1-node-mi250x',
+                     '16-node-hpe-apollo-hdr'}
     for graph in ann_data:
         for _, annotations in ann_data[graph].items():
             for ann in annotations:


### PR DESCRIPTION
- Between 3/6/25 and 3/12/25 we see plained perf changes in Stream Performance , Scan Performance, Reduce Performance, Array Creation Performance, DataFrame Display Performance. We've investigated this and haven't found a root cause. We're going to annotate that we suspect these impacts are due to systems changes.
- Temp directory change impacting Arkouda IO tests on hpe-apollo-hdr config (#26949).