### PR TITLE
Add support for native Chapel iteration on Python objects

### DIFF
--- a/modules/packages/Python.chpl
+++ b/modules/packages/Python.chpl
@@ -2272,6 +2272,29 @@ module Python {
     */
     proc getPyObject() do return this.obj;
 
+    /*
+      Iterates over an iterable Python object.
+    */
+    @chpldoc.nodoc
+    iter these(type eltType = owned Value): eltType throws {
+      var g = PyGILState_Ensure();
+      defer PyGILState_Release(g);
+
+      var iter_ = PyObject_GetIter(this.getPyObject());
+      if iter_ == nil || PyIter_Check(iter_) != 0 {
+        throwChapelException("Object is not iterable");
+      }
+      while true {
+        var item = PyIter_Next(iter_);
+        interpreter.checkException();
+        if item == nil {
+          break;
+        }
+        yield interpreter.fromPythonInner(eltType, item);
+      }
+    }
+
+
     // TODO: call should support kwargs
 
     // Casts

--- a/modules/packages/Python.chpl
+++ b/modules/packages/Python.chpl
@@ -2277,8 +2277,8 @@ module Python {
     */
     @chpldoc.nodoc
     iter these(type eltType = owned Value): eltType throws {
-      var g = PyGILState_Ensure();
-      defer PyGILState_Release(g);
+      var ctx = chpl_pythonContext.enter();
+      defer ctx.exit();
 
       var iter_ = PyObject_GetIter(this.getPyObject());
       if iter_ == nil || PyIter_Check(iter_) != 0 {

--- a/test/library/packages/Python/correctness/iterObject.chpl
+++ b/test/library/packages/Python/correctness/iterObject.chpl
@@ -1,0 +1,97 @@
+use Python;
+
+
+proc main() {
+  var interp = new Interpreter();
+
+  var iterObject = interp.importModule("iterObject");
+
+
+  // iteration over an iterator
+  writeln("yielding Values from myCustomIterator");
+  for i in iterObject.get("myCustomIterator")() {
+    writeln(i);
+  }
+  writeln("yielding ints from myCustomIterator");
+  for i in iterObject.get("myCustomIterator")().these(int) {
+    writeln(i);
+  }
+
+  // iteration over an object
+  var obj = iterObject.get("MyCustomObject")();
+  writeln("yielding Values from MyCustomObject");
+  for i in obj {
+    writeln(i);
+  }
+  writeln("yielding ints from MyCustomObject");
+  for i in obj.these(int) {
+    writeln(i);
+  }
+
+  // iteration over a list
+  var lst = interp.get("list")(owned PyList, [1, 2, 3, 4, 5]);
+  writeln("yielding Values from list");
+  for i in lst {
+    writeln(i);
+  }
+  writeln("yielding ints from list");
+  for i in lst.these(int) {
+    writeln(i);
+  }
+
+  // iteration over a tuple
+  var tup = interp.get("tuple")(owned PyTuple, [1, 2, 3, 4, 5]);
+  writeln("yielding Values from tuple");
+  for i in tup {
+    writeln(i);
+  }
+  writeln("yielding ints from tuple");
+  for i in tup.these(int) {
+    writeln(i);
+  }
+
+  // iteration over a set
+  var s = interp.get("set")(owned PySet, [1, 2, 3, 4, 5]);
+  // sets are unordered, print the sum instead
+  writeln("sum of Values from set");
+  var sum = 0;
+  for i in s {
+    sum += i:int;
+  }
+  writeln(sum);
+  writeln("sum of ints from set");
+  sum = 0;
+  for i in s.these(int) {
+    sum += i;
+  }
+  writeln(sum);
+
+
+
+  try {
+    var x = new Value(interp, 1);
+    for i in x.these() {
+      writeln(i);
+    }
+  } catch e {
+    writeln("Caught Exception: ", e);
+  }
+  try {
+    for i in iterObject.get("IAmNotIterable")() {
+      writeln(i);
+    }
+  } catch e {
+    writeln("Caught Exception: ", e);
+  }
+  // error cases: unknown type
+  try {
+    record R { var x: int; }
+    for i in lst.these(R) {
+      writeln(i);
+    }
+  } catch e {
+    writeln("Caught Exception: ", e);
+  }
+
+
+}

--- a/test/library/packages/Python/correctness/iterObject.good
+++ b/test/library/packages/Python/correctness/iterObject.good
@@ -1,0 +1,50 @@
+yielding Values from myCustomIterator
+1
+2
+3
+4
+5
+yielding ints from myCustomIterator
+1
+2
+3
+4
+5
+yielding Values from MyCustomObject
+1
+2
+3
+4
+5
+yielding ints from MyCustomObject
+yielding Values from list
+1
+2
+3
+4
+5
+yielding ints from list
+1
+2
+3
+4
+5
+yielding Values from tuple
+1
+2
+3
+4
+5
+yielding ints from tuple
+1
+2
+3
+4
+5
+sum of Values from set
+15
+sum of ints from set
+15
+Caught Exception: ChapelException: Object is not iterable
+Caught Exception: ChapelException: Object is not iterable
+Caught Exception: ChapelException: Unsupported fromPython type: 'R'

--- a/test/library/packages/Python/correctness/iterObject.py
+++ b/test/library/packages/Python/correctness/iterObject.py
@@ -1,0 +1,36 @@
+
+
+class MyCustomObject:
+    def __init__(self):
+        self.data = [1, 2, 3, 4, 5]
+        self.index = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.index < len(self.data):
+            self.index += 1
+            return self.data[self.index - 1]
+        else:
+            raise StopIteration
+
+def myCustomIterator():
+    yield 1
+    yield 2
+    yield 3
+    yield 4
+    yield 5
+
+
+class IAmNotIterable():
+    def __init__(self):
+        self.data = [1, 2, 3, 4, 5]
+        self.index = 0
+
+    def __next__(self):
+        if self.index < len(self.data):
+            self.index += 1
+            return self.data[self.index - 1]
+        else:
+            raise StopIteration

--- a/test/library/packages/Python/correctness/iterObject.skipif
+++ b/test/library/packages/Python/correctness/iterObject.skipif
@@ -1,0 +1,2 @@
+# requires iterator inlining
+COMPOPTS <= --baseline


### PR DESCRIPTION
This PR adds support for iterating over iterable Python objects using native Chapel iteration.

- [x] Ran `start_test test/library/packages/Python`

[Reviewed by @lydia-duncan]