### PR TITLE
Fix a bug in handling of array 'type' fields from #26690

### DIFF
--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -126,7 +126,7 @@ static void helpDeinitFields(AggregateType* type, VarSymbol* _this,
   }
 
   for_fields(field, type) {
-    if (isRecord(field->type)) {
+    if (isRecord(field->type) && !field->hasFlag(FLAG_TYPE_VARIABLE)) {
       body->insertAtHead(new CallExpr("deinit", gMethodToken,
                            new CallExpr(PRIM_GET_MEMBER, _this, field)));
     } else if (field->hasFlag(FLAG_SUPER_CLASS) && field->type != dtObject) {

--- a/test/classes/initializers/errors/errHandling/deinitFields-arraytype.chpl
+++ b/test/classes/initializers/errors/errHandling/deinitFields-arraytype.chpl
@@ -1,0 +1,32 @@
+class C {
+  type t = [1..3] real;
+
+  proc helpThrow() throws {
+    throw new Error();
+  }
+  
+  proc init() throws {
+    init this;
+    helpThrow();
+  }
+}
+
+class D {
+  type t = [1..3] real;
+
+  proc postinit() throws {
+    throw new Error();
+  }
+}
+
+try {
+  var myC = new C();
+} catch {
+  writeln("Caught an error, as expected");
+}
+
+try {
+  var myD = new D();
+} catch {
+  writeln("Caught an error, as expected");
+}

--- a/test/classes/initializers/errors/errHandling/deinitFields-arraytype.good
+++ b/test/classes/initializers/errors/errHandling/deinitFields-arraytype.good
@@ -1,0 +1,2 @@
+Caught an error, as expected
+Caught an error, as expected


### PR DESCRIPTION
This resolves a bug introduced in yesterday's #26690 fix to call deinit() on fields when init/postinit throws.  Specifically, the net I cast was a bit too wide, and we were trying to call deinit() on 'type' fields that are arrays because they look like record fields (yet don't support a 'deinit()' call because we don't suppot 'deinit()' on types).

The fix here is simple, which is to just look for the presence of the "type variable" flag on the symbol and to skip over such cases when we're inserting the deinits.

This showed up in a pair of Python tests:

* test/library/packages/Python/correctness/arrays/nestedArrays.chpl
* test/library/packages/Python/correctness/arrays/numpyInterop.chpl

though they didn't get reported in nightly testing due to a pip unavailability / suppressif issue.  Here, I've added a specialized test to lock in this behavior going forward.
