### PR TITLE
Turn logging on for a PRETEST that installs python dependencies

### DIFF
--- a/test/library/packages/Python/correctness/arrays/PRETEST
+++ b/test/library/packages/Python/correctness/arrays/PRETEST
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 FILE_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
-$FILE_DIR/../../skipIfAndInstallPackage.sh $FILE_DIR numpy &> /dev/null
+$FILE_DIR/../../skipIfAndInstallPackage.sh $FILE_DIR numpy


### PR DESCRIPTION
Turn logging on for a PRETEST that installs python dependencies, this makes it easier to debug errors

[Not reviewed - trivial]