### PR TITLE
Remove old sort-related deprecations

### DIFF
--- a/modules/layouts/LayoutCS.chpl
+++ b/modules/layouts/LayoutCS.chpl
@@ -433,7 +433,7 @@ class CSDom: BaseSparseDomImpl(?) {
 
     if this.compressRows then
       bulkAdd_prepareInds(inds, dataSorted, isUnique,
-                          cmp = new Sort.DefaultComparator());
+                          cmp = new Sort.defaultComparator());
     else
       bulkAdd_prepareInds(inds, dataSorted, isUnique, cmp=_columnComparator);
 

--- a/modules/packages/Search.chpl
+++ b/modules/packages/Search.chpl
@@ -22,15 +22,6 @@
  */
 module Search {
   public use Sort only defaultComparator, reverseComparator;
-
-  // TODO: remove this module and its public use when the deprecations have been
-  // removed
-  pragma "ignore deprecated use"
-  private module HideDeprecatedReexport {
-    public use Sort only DefaultComparator, ReverseComparator;
-  }
-
-  public use HideDeprecatedReexport;
   private use Sort;
 
 /*

--- a/modules/packages/SortedMap.chpl
+++ b/modules/packages/SortedMap.chpl
@@ -35,15 +35,6 @@ module SortedMap {
   import Sort.{relativeComparator};
   public use Sort only defaultComparator;
 
-  // TODO: remove this module and its public use when the deprecations have been
-  // removed
-  pragma "ignore deprecated use"
-  private module HideDeprecatedReexport {
-    public use Sort only DefaultComparator;
-  }
-
-  public use HideDeprecatedReexport;
-
   // Lock code lifted from modules/standard/List.chpl.
   @chpldoc.nodoc
   type _lockType = ChapelLocks.chpl_LocalSpinlock;

--- a/modules/packages/SortedSet.chpl
+++ b/modules/packages/SortedSet.chpl
@@ -42,15 +42,6 @@ module SortedSet {
   private use IO;
   public use Sort only defaultComparator;
 
-  // TODO: remove this module and its public use when the deprecations have been
-  // removed
-  pragma "ignore deprecated use"
-  private module HideDeprecatedReexport {
-    public use Sort only DefaultComparator;
-  }
-
-  public use HideDeprecatedReexport;
-
   record sortedSet : writeSerializable {
     /* The type of the elements contained in this sortedSet. */
     type eltType;

--- a/modules/standard/Heap.chpl
+++ b/modules/standard/Heap.chpl
@@ -44,15 +44,6 @@ module Heap {
   private use IO;
 
   public use Sort only defaultComparator, reverseComparator;
-
-  // TODO: remove this module and its public use when the deprecations have been
-  // removed
-  pragma "ignore deprecated use"
-  private module HideDeprecatedReexport {
-    public use Sort only DefaultComparator, ReverseComparator;
-  }
-
-  public use HideDeprecatedReexport;
   private use Sort;
 
   // The locker is borrowed from List.chpl

--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -66,11 +66,6 @@ module List {
   private use Math;
   private import Reflection.getRoutineName;
 
-  //
-  // TODO: remove me when `list.sort` is removed
-  //
-  private use Sort;
-
   @chpldoc.nodoc
   private const _initialCapacity = 8;
 
@@ -1547,22 +1542,6 @@ module List {
 
       return result;
     }
-
-    //TODO: When this is removed make sure to remove the `use Sort` from this module
-    /*
-      Sort the items of this list in place using a comparator. If no comparator
-      is provided, sort this list using the default sort order of its elements.
-
-      .. warning::
-
-        Sorting the elements of this list may invalidate existing references
-        to the elements contained in this list.
-
-      :arg comparator: A comparator used to sort this list.
-    */
-    @deprecated("'list.sort' is deprecated - please use the :proc:`sort(x: list)<Sort.sort>` procedure from the :mod:`Sort` module instead")
-    proc ref sort(comparator: ?rec= new Sort.DefaultComparator()) do
-      Sort.sort(this, comparator);
 
     /*
       Return a copy of the element at a given index in this list.

--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -38,13 +38,6 @@
       - remove
       - pop
       - clear
-      - sort
-
-      .. warning::
-
-        :proc:`list.sort<List.list.sort>` is deprecated - please use the
-        :proc:`sort(x: list)<Sort.sort>` procedure from the
-        :mod:`Sort` module instead
 
   Additionally, all references to list elements are invalidated when the list
   is deinitialized.

--- a/modules/standard/Sort.chpl
+++ b/modules/standard/Sort.chpl
@@ -3698,22 +3698,6 @@ record defaultComparator: keyPartComparator {
 
   /*
    Default compare method used in sort functions.
-   Uses the `<` operator to compute the ordering between ``a`` and ``b``.
-   See also `The .compare method`_.
-
-   :returns: 1 if ``b < a``
-   :returns: 0 if ``a == b``
-   :returns: -1 if ``a < b``
-   */
-  pragma "last resort"
-  @deprecated("compare with 'a' and 'b' arguments is deprecated, please use compare with 'x' and 'y' arguments instead")
-  inline
-  proc compare(a, b) {
-    return compare(x=a, y=b);
-  }
-
-  /*
-   Default compare method used in sort functions.
    Uses the `<` operator to compute the ordering between ``x`` and ``y``.
    See also `The .compare method`_.
 
@@ -4166,16 +4150,6 @@ record reverseComparator: keyPartComparator {
   inline
   proc doCompare(cmp, a, b) {
     return cmp.compare(b, a);
-  }
-
-  /*
-   Reverses ``comparator.compare``. See also `The .compare method`_.
-   */
-  pragma "last resort"
-  @deprecated("compare with 'a' and 'b' arguments is deprecated, please use compare with 'x' and 'y' arguments instead")
-  inline
-  proc compare(a, b) where hasCompare(a, b) || hasCompareFromKey(a) {
-    return compare(x=a, y=b);
   }
 
   /*

--- a/modules/standard/Sort.chpl
+++ b/modules/standard/Sort.chpl
@@ -3690,10 +3690,6 @@ private proc comparatorImplementsRelative(cmp) param do
 interface sortComparator { }
 
 /* Default comparator used in sort functions.*/
-@deprecated("The DefaultComparator record has been renamed to :record:`defaultComparator`, please use that name instead")
-type DefaultComparator = defaultComparator;
-
-/* Default comparator used in sort functions.*/
 record defaultComparator: keyPartComparator {
 
   /*
@@ -3990,10 +3986,6 @@ record defaultComparator: keyPartComparator {
     return (section:int(8), part);
   }
 }
-
-/* Reverse comparator built from another comparator.*/
-@deprecated("The ReverseComparator record has been renamed to :record:`reverseComparator`, please use that name instead")
-type ReverseComparator = reverseComparator;
 
 /* Reverse comparator built from another comparator.*/
 record reverseComparator: keyPartComparator {

--- a/test/compflags/ferguson/print-module-resolution.good
+++ b/test/compflags/ferguson/print-module-resolution.good
@@ -154,8 +154,6 @@ ChapelDistribution
   from print-module-resolution.ChapelStandard.LocaleModel.LocaleModelHelpFlat.LocaleModelHelpSetup.DefaultRectangular.ChapelDistribution
 RangeChunk
   from print-module-resolution.ChapelStandard.LocaleModel.LocaleModelHelpFlat.LocaleModelHelpSetup.DefaultRectangular.DefaultSparse.RangeChunk
-HideDeprecatedReexport
-  from print-module-resolution.ChapelStandard.LocaleModel.LocaleModelHelpFlat.LocaleModelHelpSetup.DefaultRectangular.DefaultSparse.Search.HideDeprecatedReexport
 Search
   from print-module-resolution.ChapelStandard.LocaleModel.LocaleModelHelpFlat.LocaleModelHelpSetup.DefaultRectangular.DefaultSparse.Search
 DefaultSparse

--- a/test/deprecated/Heap/depComparatorNames.chpl
+++ b/test/deprecated/Heap/depComparatorNames.chpl
@@ -1,3 +1,0 @@
-use Heap;
-new Heap.DefaultComparator();
-new Heap.ReverseComparator();

--- a/test/deprecated/Heap/depComparatorNames.good
+++ b/test/deprecated/Heap/depComparatorNames.good
@@ -1,2 +1,0 @@
-depComparatorNames.chpl:2: warning: The DefaultComparator record has been renamed to defaultComparator, please use that name instead
-depComparatorNames.chpl:3: warning: The ReverseComparator record has been renamed to reverseComparator, please use that name instead

--- a/test/deprecated/Search/depComparatorNames.chpl
+++ b/test/deprecated/Search/depComparatorNames.chpl
@@ -1,3 +1,0 @@
-use Search;
-new Search.DefaultComparator();
-new Search.ReverseComparator();

--- a/test/deprecated/Search/depComparatorNames.good
+++ b/test/deprecated/Search/depComparatorNames.good
@@ -1,2 +1,0 @@
-depComparatorNames.chpl:2: warning: The DefaultComparator record has been renamed to defaultComparator, please use that name instead
-depComparatorNames.chpl:3: warning: The ReverseComparator record has been renamed to reverseComparator, please use that name instead

--- a/test/deprecated/Sort/comparatorArgs.chpl
+++ b/test/deprecated/Sort/comparatorArgs.chpl
@@ -1,7 +1,0 @@
-use Sort;
-
-var myDefComp = new defaultComparator();
-writeln(myDefComp.compare(a=3, b=4));
-
-var myRevComp = new reverseComparator();
-writeln(myDefComp.compare(a=3, b=4));

--- a/test/deprecated/Sort/comparatorArgs.good
+++ b/test/deprecated/Sort/comparatorArgs.good
@@ -1,4 +1,0 @@
-comparatorArgs.chpl:4: warning: compare with 'a' and 'b' arguments is deprecated, please use compare with 'x' and 'y' arguments instead
-comparatorArgs.chpl:7: warning: compare with 'a' and 'b' arguments is deprecated, please use compare with 'x' and 'y' arguments instead
--1
--1

--- a/test/deprecated/Sort/depComparatorNames.chpl
+++ b/test/deprecated/Sort/depComparatorNames.chpl
@@ -1,3 +1,0 @@
-use Sort;
-new Sort.DefaultComparator();
-new Sort.ReverseComparator();

--- a/test/deprecated/Sort/depComparatorNames.good
+++ b/test/deprecated/Sort/depComparatorNames.good
@@ -1,2 +1,0 @@
-depComparatorNames.chpl:2: warning: The DefaultComparator record has been renamed to defaultComparator, please use that name instead
-depComparatorNames.chpl:3: warning: The ReverseComparator record has been renamed to reverseComparator, please use that name instead

--- a/test/deprecated/Sort/listSort.chpl
+++ b/test/deprecated/Sort/listSort.chpl
@@ -1,5 +1,0 @@
-use List;
-
-var l = new list([4, 8, 2, 1, 7, 3, 9, 6, 5]);
-l.sort();
-writeln(l);

--- a/test/deprecated/Sort/listSort.good
+++ b/test/deprecated/Sort/listSort.good
@@ -1,2 +1,0 @@
-listSort.chpl:4: warning: 'list.sort' is deprecated - please use the Sort.sort procedure from the Sort module instead
-[1, 2, 3, 4, 5, 6, 7, 8, 9]

--- a/test/deprecated/SortedMap/depComparatorNames.chpl
+++ b/test/deprecated/SortedMap/depComparatorNames.chpl
@@ -1,2 +1,0 @@
-use SortedMap;
-new SortedMap.DefaultComparator();

--- a/test/deprecated/SortedMap/depComparatorNames.good
+++ b/test/deprecated/SortedMap/depComparatorNames.good
@@ -1,1 +1,0 @@
-depComparatorNames.chpl:2: warning: The DefaultComparator record has been renamed to defaultComparator, please use that name instead

--- a/test/deprecated/SortedSet/depComparatorNames.chpl
+++ b/test/deprecated/SortedSet/depComparatorNames.chpl
@@ -1,2 +1,0 @@
-use SortedSet;
-new SortedSet.DefaultComparator();

--- a/test/deprecated/SortedSet/depComparatorNames.good
+++ b/test/deprecated/SortedSet/depComparatorNames.good
@@ -1,1 +1,0 @@
-depComparatorNames.chpl:2: warning: The DefaultComparator record has been renamed to defaultComparator, please use that name instead

--- a/test/modules/sungeun/init/printModuleInitOrder.good
+++ b/test/modules/sungeun/init/printModuleInitOrder.good
@@ -44,8 +44,6 @@ Initializing Modules:
          ChapelHashtable
         ExternalArray
         RangeChunk
-        Search
-         HideDeprecatedReexport
       LocaleModelHelpRuntime
      LocaleModelHelpMem
     LocalesArray

--- a/test/optimizations/deadCodeElimination/elliot/countDeadModules.good
+++ b/test/optimizations/deadCodeElimination/elliot/countDeadModules.good
@@ -1,1 +1,1 @@
-Removed 34 dead modules.
+Removed 35 dead modules.


### PR DESCRIPTION
[reviewed by @jabraham17]

This cleans up some deprecations that have been present since at least 2.3, including:

- defaultComparator.compare with `a` and `b` arguments
- reverseComparator.compare with `a` and `b` arguments
- DefaultComparator
- ReverseCompartor
- list.sort

Removes the old deprecation tests, and updates a few tests that respond when modules are removed (since there were some helper modules we used to make nicer deprecation messages for accessing DefaultComparator and ReverseComparator from Search, SortedSet, Heap, and SortedMap)

Passed a full paratest with futures