### PR TITLE
Skip the SciPy test with valgrind, like we do for the torch test

### DIFF
--- a/test/library/packages/Python/examples/scipy/checkScipyLinAlg.skipif
+++ b/test/library/packages/Python/examples/scipy/checkScipyLinAlg.skipif
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
 
+# skip valgrind testing: if CHPL_TEST_VGRND_EXE is set and 'on'
+if [ -n "$CHPL_TEST_VGRND_EXE" ] && [ "$CHPL_TEST_VGRND_EXE" == "on" ]; then
+  echo "True"
+  exit 0
+fi
+
 FILE_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 $FILE_DIR/../../skipIfAndInstallPackage.sh $FILE_DIR scipy


### PR DESCRIPTION
The torch test also relies on numpy, and the error we're seeing here seems like a numpy specific error:

> (path stuff)numpy/_core/getlimits.py:551: UserWarning: Signature b'\x00\xd0\xcc\xcc\xcc\xcc\xcc\xcc\xfb\xbf\x00\x00\x00\x00\x00\x00' for <class 'numpy.longdouble'> does not match any known type: falling back to type probe function.
> This warnings indicates broken support for the dtype!
>   machar = _get_machar(dtype)

----
Signed-off-by: Lydia Duncan <lydia-duncan@users.noreply.github.com>