### PR TITLE
Add a warning when `gpuClock` is called from the host

### DIFF
--- a/modules/standard/GPU.chpl
+++ b/modules/standard/GPU.chpl
@@ -64,6 +64,8 @@ module GPU
   extern proc chpl_gpu_printf8(fmt, x1, x2, x3, x4, x5, x6, x7, x8) : void;
 
   pragma "codegen for CPU and GPU"
+  pragma "insert line file info"
+  pragma "always propagate line file info"
   extern proc chpl_gpu_clock() : uint;
 
   pragma "codegen for CPU and GPU"
@@ -142,6 +144,7 @@ module GPU
     This function is meant to be called to time sections of code within a GPU
     enabled loop.
   */
+  pragma "insert line file info"
   proc gpuClock() : uint {
     return chpl_gpu_clock();
   }

--- a/runtime/include/gpu/chpl-gpu-gen-common.h
+++ b/runtime/include/gpu/chpl-gpu-gen-common.h
@@ -154,10 +154,14 @@ __host__ static inline void chpl_assert_on_gpu(int32_t lineno, int32_t filenameI
   chpl_error("assertOnGpu() failed", lineno, filenameIdx);
 }
 
-__device__ static inline unsigned int chpl_gpu_clock(void) {
+__device__ static inline unsigned int chpl_gpu_clock(int32_t lineno,
+                                                     int32_t filenameIdx) {
   return (unsigned int)clock();
 }
-__host__ static inline unsigned int chpl_gpu_clock(void) {
+__host__ static inline unsigned int chpl_gpu_clock(int32_t lineno,
+                                                   int32_t filenameIdx) {
+  chpl_warning("gpuClock was called from the host, it will return 0.",
+               lineno, filenameIdx);
   return 0;
 }
 

--- a/test/gpu/native/basics/gpuClockOnHost.chpl
+++ b/test/gpu/native/basics/gpuClockOnHost.chpl
@@ -1,0 +1,7 @@
+use GPU;
+
+writeln(gpuClock());
+
+on here.gpus[0] {
+  writeln(gpuClock()); // still on host
+}

--- a/test/gpu/native/basics/gpuClockOnHost.good
+++ b/test/gpu/native/basics/gpuClockOnHost.good
@@ -1,0 +1,4 @@
+0
+0
+gpuClockOnHost.chpl:3: warning: gpuClock was called from the host, it will return 0.
+gpuClockOnHost.chpl:6: warning: gpuClock was called from the host, it will return 0.


### PR DESCRIPTION
Inspired by [this discourse topic](https://chapel.discourse.group/t/gpuclock-only-returns-0/41925/1).

This PR adds a warning when `gpuClock` is called from the host. When that happens we always return 0 silently. Understandably, that can be confusing.

There's a question of whether that warning should be suppressable when the same loop is executed both on the CPU and the GPU, for example. However, I see `gpuClock` as an advanced feature that should not be widely used. So, this PR doesn't go that far.

Test:
- [x] amd