### PR TITLE
Dyno: numerous minor fixes for "promotes default" test

### DIFF
--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -535,11 +535,19 @@ static QualifiedType staticFieldType(ResolutionContext* rc, const CallInfo& ci) 
     return QualifiedType();
   }
 
-  auto& fields = fieldsForTypeDecl(rc, compositeType, DefaultsPolicy::IGNORE_DEFAULTS);
-  for (int i = 0; fields.numFields(); i++) {
-    if (fields.fieldName(i) == fieldName) {
-      auto returnType = fields.fieldType(i).type();
-      return QualifiedType(QualifiedType::TYPE, returnType);
+  // unlike the "name to num" primitives and company, static field type looks
+  // for fields including the ones in parent classes.
+  while (compositeType) {
+    auto& fields = fieldsForTypeDecl(rc, compositeType, DefaultsPolicy::IGNORE_DEFAULTS);
+    for (int i = 0; i < fields.numFields(); i++) {
+      if (fields.fieldName(i) == fieldName) {
+        auto returnType = fields.fieldType(i).type();
+        return QualifiedType(QualifiedType::TYPE, returnType);
+      }
+    }
+
+    if (auto bct = compositeType->toBasicClassType()) {
+      compositeType = bct->parentClassType();
     }
   }
   return QualifiedType();

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -6272,6 +6272,10 @@ checkInterfaceConstraintsQuery(ResolutionContext* rc,
     auto fn = stmt->toFunction();
     if (!fn) continue;
 
+    if (auto ag = fn->attributeGroup()) {
+      if (ag->hasPragma(PRAGMA_DOCS_ONLY)) continue;
+    }
+
     anyWitnesses = true;
 
     // Note: construct a resolver with the witness above, which pushes

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -370,8 +370,7 @@ static bool isKindForFunctionalValue(QualifiedType::Kind kind) {
 // if we have `x.f(args)`, returns true if the above should be treated
 // as a method call with `f(this = x, args)`.
 static bool isKindForMethodReceiver(QualifiedType::Kind kind) {
-  return kind != QualifiedType::UNKNOWN &&
-         kind != QualifiedType::FUNCTION &&
+  return kind != QualifiedType::FUNCTION &&
          kind != QualifiedType::MODULE;
 }
 

--- a/frontend/test/resolution/testInterfaces.cpp
+++ b/frontend/test/resolution/testInterfaces.cpp
@@ -981,6 +981,21 @@ static void testInvalidImplementsArity() {
     )""", ErrorType::InterfaceNaryInInherits);
 };
 
+static void testDocsOny() {
+  // Self.bar is docs only, so we shouldn't require it to be implemented.
+
+  auto i = InterfaceSource("myInterface", "proc Self.foo();", "pragma \"docs only\" proc Self.bar();");
+  auto r1 = RecordSource("myRec")
+    .addMethod(NOT_A_TYPE_METHOD, "foo() {}")
+    .addInterfaceConstraint(i);
+  testSingleInterface(i, r1);
+
+  auto r2 = RecordSource("myRec")
+    .addMethod(NOT_A_TYPE_METHOD, "foo(x: int) {}")
+    .addInterfaceConstraint(i);
+  testSingleInterface(i, r2, ErrorType::InterfaceMissingFn);
+}
+
 int main() {
   // tests for "basic" interface resolution (unary interfaces)
   testRequiredMethodNoArgs();
@@ -1011,4 +1026,5 @@ int main() {
   testImplementsInvalidActual();
   testImplementsDuplicate();
   testInvalidImplementsArity();
+  testDocsOny();
 }

--- a/frontend/test/resolution/testResolve.cpp
+++ b/frontend/test/resolution/testResolve.cpp
@@ -722,6 +722,33 @@ static void test16() {
   }
 }
 
+static void test16b() {
+  auto context = buildStdContext();
+  // Make sure no errors make it to the user, even though we will get errors.
+  ErrorGuard guard(context);
+  auto variables = resolveTypesOfVariablesInit(context,
+      R"""(
+      class Parent {
+          var x: int;
+          var y: string;
+      }
+
+      class Child : Parent {
+          var z: (int, string);
+      }
+
+      var child = new Child();
+
+      param r1 = __primitive("static field type", child, "x") == int;
+      param r2 = __primitive("static field type", child, "y") == string;
+      param r3 = __primitive("static field type", child, "z") == (int, string);
+      )""", { "r1", "r2", "r3" });
+
+  for (auto& pair : variables) {
+    pair.second.isParamTrue();
+  }
+}
+
 // module-level split-init variables
 static void test17() {
   Context context;
@@ -2089,6 +2116,7 @@ int main() {
   test14();
   test15();
   test16();
+  test16b();
   test17();
   test18();
   test19();

--- a/frontend/test/resolution/testTypeQueries.cpp
+++ b/frontend/test/resolution/testTypeQueries.cpp
@@ -655,6 +655,31 @@ static void test21() {
   assert(vars.at("t").type()->isIntType());
 }
 
+static void test22() {
+  printf("%s\n", __FUNCTION__);
+  auto context = buildStdContext();
+  ErrorGuard guard(context);
+
+  auto vars = resolveTypesOfVariables(context,
+                R""""(
+                  proc f(arg: [?D]) { return D; }
+
+                  var A: [1..10] int,
+                      B: [1..10] real;
+                  var D1 = f(A);
+                  var D2 = f(B);
+                )"""", {"D1", "D2"});
+
+  auto check = [&vars](const std::string& name) {
+    assert(!vars.at(name).isUnknownOrErroneous());
+    assert(vars.at(name).type()->isDomainType());
+    assert(vars.at(name).type()->toDomainType()->rankInt() == 1);
+    ensureParamEnumStr(vars.at(name).type()->toDomainType()->strides(), "one");
+  };
+  check("D1");
+  check("D2");
+}
+
 int main() {
   test1();
   test2();
@@ -679,6 +704,7 @@ int main() {
   test19();
   test20();
   test21();
+  test22();
 
   return 0;
 }


### PR DESCRIPTION
Ben's comment on the resolver meta issue (https://github.com/Cray/chapel-private/issues/5108#issuecomment-2730119210) indicates that `promotes-default` is a spec test failing for an unknown reason. I took a look; the test was failing due to numerous minor bugs, trigger, in no small part, because it exercises `sort` and the `Sort` module. The bugs were as follows:

1. The `docs only` pragma was ignored when checking interface constraints, causing errors
2. I didn't realize that `static field type`, unlike the other reflection primitives, looks for parent fields as well
3. The parser doesn't always consistently represent type queries, and the array type query instruction only supported some of the cases.
4. for unknown `x`, the resolver could attempt to resolve `x.foo(bar)` as `foo(bar)`.

This PR fixes these bugs, and in doing so enables resolving `promotes-default` without errors.

Reviewed by @mppf -- thanks!

## Testing
- [x] promotes-default now passes
- [x] spectests w/dyno are now at 240 successful resolutions (testing along with Anna's changes as well).
- [x] dyno tests
- [x] paratest