### PR TITLE
homebrew testing update to pin llvm 19

### DIFF
--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -16,7 +16,7 @@ class Chapel < Formula
   depends_on "gmp"
   depends_on "hwloc"
   depends_on "jemalloc"
-  depends_on "llvm"
+  depends_on "llvm@19"
   depends_on "pkgconf"
   depends_on "python@3.13"
 


### PR DESCRIPTION
This just pins main's test formula to LLVM 19 now that LLVM 20 is the canonical version in Homebrew. 

Related update to release formula: https://github.com/chapel-lang/chapel/pull/27017/