### PR TITLE
Remove the check that the compiler doesn't insert deinit's of records

### DIFF
--- a/compiler/main/checks.cpp
+++ b/compiler/main/checks.cpp
@@ -55,7 +55,6 @@ static void checkIsIterator(); // Ensure each iterator is flagged so.
 static void check_afterInlineFunctions();
 static void checkResolveRemovedPrims(void); // Checks that certain primitives
                                             // are removed after resolution
-static void checkNoRecordDeletes();  // No 'delete' on records.
 static void checkTaskRemovedPrims(); // Checks that certain primitives are
                                      // removed after task functions are
                                      // created.
@@ -547,7 +546,6 @@ static void check_afterResolution()
   checkReturnTypesHaveRefTypes();
   if (fVerify)
   {
-    checkNoRecordDeletes();
     checkTaskRemovedPrims();
     checkResolveRemovedPrims();
 // Disabled for now because user warnings should not be logged multiple times:
@@ -695,16 +693,6 @@ checkResolveRemovedPrims(void) {
       }
     }
   }
-}
-
-static void checkNoRecordDeletes() {
-  // No need to do for_alive_in_Vec - there shouldn't be any, period.
-  // User errors are to be detected by chpl__delete() in the modules.
-  forv_Vec(CallExpr, call, gCallExprs)
-    if (FnSymbol* fn = call->resolvedFunction())
-      if(fn->hasFlag(FLAG_DESTRUCTOR))
-        if (!isClassLike(call->get(1)->typeInfo()->getValType()))
-          INT_FATAL(call, "delete not on a class");
 }
 
 static void


### PR DESCRIPTION
PR #26990 added record deinit() calls as part of its work to deinitialize classes in the event of throwing initializers / 'new' calls.  This caused all such tests to fail when compiling with --verify, as we have had a pre-existing check for some time to ensure that the compiler-generated code does not delete/destroy/deinit records.

In this PR, I'm removing the check to permit these calls to go through, since the point of 'deinit()' is to support the compiler's ability to call it, like the calls inserted in #26990.

Clearly, the compiler is calling deinit already when destroying things in other code paths, but DavidL and I postulated that it's only doing it through chpl__autoDestroy().  If correct, that suggests my PR could've called chpl__autoDestroy() instead, but I view that call as an unfortunate carryover from early days prior to completing initializers and deinit(), and think it's clearer and more straightforward to call deinit() directly when that suffices, like here.

Note that user calls to deinit() are prohibited by other means, so this doesn't change the user's ability to (not) call deinit.