### PR TITLE
Enable dyno-driven error messages in LSP

### DIFF
--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -1164,12 +1164,9 @@ class FileInfo:
         self.siblings = chapel.SiblingMap(asts)
 
         if self.use_resolver:
-            # TODO: suppress resolution errors due to false-positives
-            # this should be removed once the resolver is finished
-            with self.context.context.track_errors() as _:
-                for ast in asts:
-                    self._search_instantiations(ast)
-                self.call_segments.sort()
+            for ast in asts:
+                self._search_instantiations(ast)
+            self.call_segments.sort()
 
     def called_function_at_position(
         self, position: Position

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -2257,16 +2257,15 @@ def run_lsp():
             call for call, _ in chapel.each_matching(ast, chapel.core.FnCall)
         )
 
-        with fi.context.context.track_errors() as _:
-            for decl in decls:
-                instantiation = fi.get_inst_segment_at_position(decl.rng.start)
-                inlays.extend(ls.get_decl_inlays(decl, instantiation))
+        for decl in decls:
+            instantiation = fi.get_inst_segment_at_position(decl.rng.start)
+            inlays.extend(ls.get_decl_inlays(decl, instantiation))
 
-            for call in calls:
-                instantiation = fi.get_inst_segment_at_position(
-                    location_to_range(call.location()).start
-                )
-                inlays.extend(ls.get_call_inlays(call, instantiation))
+        for call in calls:
+            instantiation = fi.get_inst_segment_at_position(
+                location_to_range(call.location()).start
+            )
+            inlays.extend(ls.get_call_inlays(call, instantiation))
 
         return inlays
 

--- a/tools/chpl-language-server/test/call_inlays.py
+++ b/tools/chpl-language-server/test/call_inlays.py
@@ -94,7 +94,7 @@ async def test_call_inlays_complex(client: LanguageClient):
            // Not 'literals' in our sense:
            foo(3i + 4i);
            foo(1 + 1);
-           foo((-1) - (-i));
+           foo((-1) - (-1i));
            """
 
     inlays = [(pos((i, 4)), "a = ", None) for i in range(1, 9)]


### PR DESCRIPTION
The resolver is not finished, but the error messages are becoming more and more reasonable. I think, given that --resolver is experimental, it's safe to enable the errors now.

Reviewed by @jabraham17 -- thanks!

## Testing
- [x] `make test-cls` passes