### PR TITLE
Fix comment in stopwatch primer.

### DIFF
--- a/test/release/examples/primers/timers.chpl
+++ b/test/release/examples/primers/timers.chpl
@@ -10,8 +10,10 @@
 use Time;
 
 //
-// The ``quiet`` configuration constant is set to ``false`` when testing
-// (via start_test) so that this test is deterministic.
+// In order to aid in testing this primer, the ``quiet`` 
+// configuration constant is set to ``true``
+// (via start_test) so that this test is deterministic
+// (i.e., the output doesn't change every run)
 //
 config const quiet: bool = false;
 


### PR DESCRIPTION
This fixes two things:
1. The comment said `false` instead of `true`
2. The comment was a little jarring when reading the primer from the docs, I reworded the sentence to better explain what's going on