### PR TITLE
Dyno: fix bugs in the way of resolving `blockDist`

### DIFF
--- a/frontend/include/chpl/parsing/parsing-queries.h
+++ b/frontend/include/chpl/parsing/parsing-queries.h
@@ -617,9 +617,12 @@ bool idContainsFieldWithName(Context* context, ID typeDeclId,
                              UniqueString fieldName);
 
 /**
-  Given an AST node for a (multi-)declaration, find for a Variable
+  Given an AST node for a (multi-)declaration, find a Variable
   node that declares a field of the given name. Returns whether the field
-  was found, and, if it was, sets outFieldId to the ID of the Variable.
+  was found. Sets outFieldId to the ID of the Variable, or empty if one
+  was not found.
+
+  Performs a search for AST nodes covered by fieldIdWithName's documentation.
  */
 bool findFieldIdInDeclaration(const uast::AstNode* varDecl,
                               UniqueString fieldName,
@@ -628,6 +631,14 @@ bool findFieldIdInDeclaration(const uast::AstNode* varDecl,
 /**
   Given an ID for a Record/Union/Class Decl,
   and a field name, returns the ID for the Variable declaring that field.
+  Does so by looking recursively for either:
+
+  * the Variable declaration directly: 'var x: int'
+  * A MultiDecl containing the name: 'var x: int, y: int'
+  * A TupleDecl with the name as a component: 'var ((x, y), z) = ...'
+  * A ForwardingDecl that forwards methods from the variable: 'forwarding var x: R'
+
+  Ignores all other AST nodes in the Record/Union/Class.
  */
 ID fieldIdWithName(Context* context, ID typeDeclId,
                    UniqueString fieldName);

--- a/frontend/include/chpl/parsing/parsing-queries.h
+++ b/frontend/include/chpl/parsing/parsing-queries.h
@@ -617,6 +617,15 @@ bool idContainsFieldWithName(Context* context, ID typeDeclId,
                              UniqueString fieldName);
 
 /**
+  Given an AST node for a (multi-)declaration, find for a Variable
+  node that declares a field of the given name. Returns whether the field
+  was found, and, if it was, sets outFieldId to the ID of the Variable.
+ */
+bool findFieldIdInDeclaration(const uast::AstNode* varDecl,
+                              UniqueString fieldName,
+                              ID& outFieldId);
+
+/**
   Given an ID for a Record/Union/Class Decl,
   and a field name, returns the ID for the Variable declaring that field.
  */

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -659,6 +659,22 @@ class CallInfo {
                              const uast::AstNode*& questionArg,
                              std::vector<const uast::AstNode*>* actualAsts);
 
+  /** Same as prepareActuals, but instead of iterating over all the actuals
+      of a call, simply prepare a single actual.
+
+      Unlike prepareActuals, call can be null (if setting up an actual
+      from a call-like thing, like a domain expression).
+   */
+  static void prepareActual(Context* context,
+                            const uast::Call* call,
+                            const uast::AstNode* actual,
+                            int actualIdx,
+                            const ResolutionResultByPostorderID& byPostorder,
+                            bool raiseErrors,
+                            std::vector<CallInfoActual>& actuals,
+                            const uast::AstNode*& questionArg,
+                            std::vector<const uast::AstNode*>* actualAsts);
+
 
   /** return the name of the called thing */
   const UniqueString name() const { return name_; }

--- a/frontend/lib/framework/Context.cpp
+++ b/frontend/lib/framework/Context.cpp
@@ -1191,7 +1191,9 @@ bool Context::queryCanUseSavedResultAndPushIfNot(
 void Context::emitHiddenErrorsFor(const querydetail::QueryMapResultBase* result) {
   CHPL_ASSERT(!result->emittedErrors);
   for (auto& error : result->errors) {
-    reportError(this, error.first.get());
+    if (!error.second) {
+      reportError(this, error.first.get());
+    }
   }
   result->emittedErrors = true;
   for (auto& dependency : result->dependencies) {

--- a/frontend/lib/framework/Context.cpp
+++ b/frontend/lib/framework/Context.cpp
@@ -1191,6 +1191,7 @@ bool Context::queryCanUseSavedResultAndPushIfNot(
 void Context::emitHiddenErrorsFor(const querydetail::QueryMapResultBase* result) {
   CHPL_ASSERT(!result->emittedErrors);
   for (auto& error : result->errors) {
+    // don't emit errors that were silenced directly in the body of this query
     if (!error.second) {
       reportError(this, error.first.get());
     }

--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -1723,6 +1723,7 @@ bool findFieldIdInDeclaration(const AstNode* ast,
       return findFieldIdInDeclaration(fwdVar, fieldName, outFieldId);
     }
   }
+  outFieldId = ID();
   return false;
 }
 

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -3035,7 +3035,7 @@ shouldSkipCallResolution(Resolver* rv, const uast::AstNode* callLike,
                qt.isRef() == false) {
       // don't skip because it could be initialized with 'out' intent,
       // but not for non-out formals because they can't be split-initialized.
-    } else if (actualAst && actualAst->isTypeQuery() && ci.calledType().isType()) {
+    } else if (actualAst != nullptr && actualAst->isTypeQuery() && ci.calledType().isType()) {
       // don't skip for type queries in type constructors
     } else {
       if (qt.isParam() && qt.param() == nullptr) {

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -3050,7 +3050,11 @@ shouldSkipCallResolution(Resolver* rv, const uast::AstNode* callLike,
         auto g = getTypeGenericity(context, t);
         bool isBuiltinGeneric = (g == Type::GENERIC &&
                                  (t->isAnyType() || t->isBuiltinType()));
-        if (qt.isType() && isBuiltinGeneric && rv->substitutions == nullptr) {
+        bool noSubstitution =
+          rv->substitutions == nullptr ||
+          (!toId.isEmpty() && rv->substitutions->count(toId) == 0);
+
+        if (qt.isType() && isBuiltinGeneric && noSubstitution) {
           skip = GENERIC_TYPE;
         } else if (!qt.isType() && g != Type::CONCRETE) {
           skip = GENERIC_VALUE;

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -4285,7 +4285,12 @@ void Resolver::resolveIdentifier(const Identifier* ident) {
     auto receiverInfo = closestMethodReceiverInfo(allowNonLocal);
     if (receiverInfo) receiverType = std::get<1>(*receiverInfo);
 
-    if (receiverInfo && receiverType.type()) {
+    // in field types, don't try an implicit receiver, because the
+    // implicit receiver is the class/record, which is not fully constructed
+    // when the field type is being resolved.
+    bool skipImplicitParenless = fieldTypesOnly;
+
+    if (receiverInfo && receiverType.type() && !skipImplicitParenless) {
       std::vector<CallInfoActual> actuals;
       actuals.push_back(CallInfoActual(receiverType, USTR("this")));
       auto ci = CallInfo(/* name */ ident->name(),

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -6402,28 +6402,8 @@ tryResolveAssign(Context* context,
 
 static bool helpFieldNameCheck(const AstNode* ast,
                                UniqueString name) {
-  if (auto var = ast->toVarLikeDecl()) {
-    return var->name() == name;
-  } else if (auto mult = ast->toMultiDecl()) {
-    for (auto decl : mult->decls()) {
-      bool found = helpFieldNameCheck(decl, name);
-      if (found) {
-        return true;
-      }
-    }
-  } else if (auto tup = ast->toTupleDecl()) {
-    for (auto decl : tup->decls()) {
-      bool found = helpFieldNameCheck(decl, name);
-      if (found) {
-        return true;
-      }
-    }
-  } else if (auto fwd = ast->toForwardingDecl()) {
-    if (auto fwdVar = fwd->expr()->toVariable()) {
-      return fwdVar->name() == name;
-    }
-  }
-  return false;
+  ID ignoredId;
+  return parsing::findFieldIdInDeclaration(ast, name, ignoredId);
 }
 
 static const CompositeType* const&

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -263,97 +263,109 @@ void CallInfo::prepareActuals(Context* context,
                               std::vector<CallInfoActual>& actuals,
                               const AstNode*& questionArg,
                               std::vector<const uast::AstNode*>* actualAsts) {
-
-  const FnCall* fnCall = call->toFnCall();
-
   // Prepare the actuals of the call.
   for (int i = 0; i < call->numActuals(); i++) {
     auto actual = call->actual(i);
+    prepareActual(context, call, actual, i, byPostorder, raiseErrors,
+                  actuals, questionArg, actualAsts);
+  }
+}
 
-    if (isQuestionMark(actual)) {
-      if (call->isTuple()) {
-        // Expressions like (?,?,?)
-        UniqueString byName;
-        auto qt = QualifiedType(QualifiedType::TYPE, AnyType::get(context));
-        actuals.push_back(CallInfoActual(qt, byName));
-        if (actualAsts != nullptr) {
-          actualAsts->push_back(actual);
-        }
-      } else if (questionArg == nullptr) {
-        questionArg = actual;
-      } else {
-        CHPL_REPORT(context, MultipleQuestionArgs, fnCall, questionArg, actual);
-        // Keep questionArg pointing at the first question argument we found
-      }
-    } else {
-      QualifiedType actualType;
-      // replace default value with resolved if available
-      if (const ResolvedExpression* r = byPostorder.byAstOrNull(actual)) {
-        actualType = r->type();
-      }
+void CallInfo::prepareActual(Context* context,
+                             const Call* call,
+                             const AstNode* actual,
+                             int actualIdx,
+                             const ResolutionResultByPostorderID& byPostorder,
+                             bool raiseErrors,
+                             std::vector<CallInfoActual>& actuals,
+                             const AstNode*& questionArg,
+                             std::vector<const uast::AstNode*>* actualAsts) {
+  auto fnCall = call ? call->toFnCall() : nullptr;
+
+  if (isQuestionMark(actual)) {
+    if (call && call->isTuple()) {
+      // Expressions like (?,?,?)
       UniqueString byName;
-      if (fnCall && fnCall->isNamedActual(i)) {
-        byName = fnCall->actualName(i);
+      auto qt = QualifiedType(QualifiedType::TYPE, AnyType::get(context));
+      actuals.push_back(CallInfoActual(qt, byName));
+      if (actualAsts != nullptr) {
+        actualAsts->push_back(actual);
       }
+    } else if (questionArg == nullptr) {
+      questionArg = actual;
+    } else {
+      CHPL_REPORT(context, MultipleQuestionArgs, fnCall, questionArg, actual);
+      // Keep questionArg pointing at the first question argument we found
+    }
+  } else {
+    QualifiedType actualType;
+    // replace default value with resolved if available
+    if (const ResolvedExpression* r = byPostorder.byAstOrNull(actual)) {
+      actualType = r->type();
+    }
+    UniqueString byName;
+    if (fnCall && fnCall->isNamedActual(actualIdx)) {
+      byName = fnCall->actualName(actualIdx);
+    }
 
-      bool handledTupleExpansion = false;
-      if (auto op = actual->toOpCall()) {
-        if (op->op() == USTR("...")) {
-          if (op->numActuals() != 1) {
-            if (raiseErrors) {
-              context->error(op, "tuple expansion can only accept one argument");
-            }
-            actualType = QualifiedType(QualifiedType::VAR,
-                                       ErroneousType::get(context));
-          } else {
-            const ResolvedExpression& rr = byPostorder.byAst(op->actual(0));
-            actualType = rr.type();
+    bool handledTupleExpansion = false;
+    if (auto op = actual->toOpCall()) {
+      if (op->op() == USTR("...")) {
+        if (op->numActuals() != 1) {
+          if (raiseErrors) {
+            context->error(op, "tuple expansion can only accept one argument");
           }
-
-          // handle tuple expansion
-          if (!actualType.hasTypePtr() ||
-              actualType.type()->isUnknownType()) {
-            // leave the result unknown
-            actualType = QualifiedType(QualifiedType::VAR,
-                                       UnknownType::get(context));
-          } else if (actualType.type()->isErroneousType()) {
-            // let it stay erroneous type
-          } else if (!actualType.type()->isTupleType()) {
-            if (raiseErrors) {
-              CHPL_REPORT(context, TupleExpansionNonTuple, fnCall, op, actualType);
-            }
-            actualType = QualifiedType(QualifiedType::VAR,
-                                       ErroneousType::get(context));
-          } else {
-            if (!byName.isEmpty()) {
-              CHPL_REPORT(context, TupleExpansionNamedArgs, op, fnCall);
-            }
-
-            auto tupleType = actualType.type()->toTupleType();
-            int n = tupleType->numElements();
-            for (int i = 0; i < n; i++) {
-              tupleType->elementType(i);
-              // intentionally use the empty name (to ignore it if it was
-              // set and we issued an error above)
-              actuals.push_back(CallInfoActual(tupleType->elementType(i),
-                                               UniqueString()));
-              if (actualAsts != nullptr) {
-                actualAsts->push_back(op);
-              }
-            }
-            handledTupleExpansion = true;
-          }
+          actualType = QualifiedType(QualifiedType::VAR,
+              ErroneousType::get(context));
+        } else {
+          const ResolvedExpression& rr = byPostorder.byAst(op->actual(0));
+          actualType = rr.type();
         }
-      }
 
-      if (!handledTupleExpansion) {
-        actuals.push_back(CallInfoActual(actualType, byName));
-        if (actualAsts != nullptr) {
-          actualAsts->push_back(actual);
+        // handle tuple expansion
+        if (!actualType.hasTypePtr() ||
+            actualType.type()->isUnknownType()) {
+          // leave the result unknown
+          actualType = QualifiedType(QualifiedType::VAR,
+              UnknownType::get(context));
+        } else if (actualType.type()->isErroneousType()) {
+          // let it stay erroneous type
+        } else if (!actualType.type()->isTupleType()) {
+          if (raiseErrors) {
+            CHPL_REPORT(context, TupleExpansionNonTuple, fnCall, op, actualType);
+          }
+          actualType = QualifiedType(QualifiedType::VAR,
+              ErroneousType::get(context));
+        } else {
+          if (!byName.isEmpty()) {
+            CHPL_REPORT(context, TupleExpansionNamedArgs, op, fnCall);
+          }
+
+          auto tupleType = actualType.type()->toTupleType();
+          int n = tupleType->numElements();
+          for (int i = 0; i < n; i++) {
+            tupleType->elementType(i);
+            // intentionally use the empty name (to ignore it if it was
+            // set and we issued an error above)
+            actuals.push_back(CallInfoActual(tupleType->elementType(i),
+                  UniqueString()));
+            if (actualAsts != nullptr) {
+              actualAsts->push_back(op);
+            }
+          }
+          handledTupleExpansion = true;
         }
       }
     }
+
+    if (!handledTupleExpansion) {
+      actuals.push_back(CallInfoActual(actualType, byName));
+      if (actualAsts != nullptr) {
+        actualAsts->push_back(actual);
+      }
+    }
   }
+
 }
 
 // returns true if values of this kind should be treated as 'functional':

--- a/frontend/lib/resolution/scope-queries.cpp
+++ b/frontend/lib/resolution/scope-queries.cpp
@@ -254,6 +254,11 @@ struct GatherDecls {
   }
   void exit(const MultiDecl* d) { }
 
+  bool enter(const ForwardingDecl* d) {
+    return true;
+  }
+  void exit(const ForwardingDecl* d) { }
+
   bool enter(const Label* l) {
     gather(declared, l->name(), l->loop(), Decl::DEFAULT_VISIBILITY, atFieldLevel);
     return true;

--- a/frontend/test/resolution/testDomainsRectangular.cpp
+++ b/frontend/test/resolution/testDomainsRectangular.cpp
@@ -217,6 +217,7 @@ int main() {
 
   testDomainLiteral(context, "{1..10}", DomainType::Kind::Rectangular);
   testDomainLiteral(context, "{1..10, 1..10}", DomainType::Kind::Rectangular);
+  testDomainLiteral(context, "{(...(1..10, 1..10))}", DomainType::Kind::Rectangular);
 
   testDomainBadPass(context, "domain(1)", "domain(2)");
   testDomainBadPass(context, "domain(1, int(16))", "domain(1, int(8))");

--- a/frontend/test/resolution/testInitSemantics.cpp
+++ b/frontend/test/resolution/testInitSemantics.cpp
@@ -1839,6 +1839,33 @@ static void testNilFieldInit() {
   assert(toString(vars["b"]) == "R");
 }
 
+static void testForwardingFieldInit() {
+  std::string program = R"""(
+    record Inner { proc foo() {} }
+    record R {
+      forwarding var x: Inner;
+      proc init() {
+        this.x = new Inner();
+      }
+    }
+
+    // exists to work around current lack of default-init at module scope
+    proc test() {
+      var x: R;
+      return x;
+    }
+    var a = test();
+    var b = new R();
+  )""";
+  Context* context = buildStdContext();
+  ErrorGuard guard(context);
+
+  auto vars = resolveTypesOfVariables(context, program, {"a", "b"});
+
+  assert(toString(vars["a"]) == "R");
+  assert(toString(vars["b"]) == "R");
+}
+
 static void testGenericFieldInit() {
   {
     std::string program = R"""(
@@ -2333,6 +2360,8 @@ int main() {
   testInitGenericAfterConcrete();
 
   testNilFieldInit();
+
+  testForwardingFieldInit();
 
   testGenericFieldInit();
 


### PR DESCRIPTION
Fixes all the issues in the way of https://github.com/Cray/chapel-private/issues/7139 except https://github.com/Cray/chapel-private/issues/7264.

This includes:

* Tracking down a query error message issuing bug, in which you could get Dyno to issue a hidden error message
* Disabling implicit receivers for field initializers (how can you compute the field type, which has to happen prior to initializing an object, using a `this` of that same object?).
* Enabling tuple expansion in domain expressions (`{(...ranges)}`, and skipping resolving the builder for unknown types
* Improve the skipping of generic formals in partial instantiation cases by checking not just if a substitution map is present, but if it also contains an ID
* Enable forwarding fields to be treated like real fields (referred to by name, assigned, etc)

After this, Ben's example in https://github.com/Cray/chapel-private/issues/7139 compiles with only errors to do with task variables. I will tackle that next.

Concerningly, it takes a _while_ to resolve the program.

Reviewed by @mppf -- thanks!

## Testing
- [x] dyno tests
- [x] paratest