### PR TITLE
Dyno: resolve task vars and fix errors in `in` task intents

### DIFF
--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -7163,14 +7163,14 @@ bool Resolver::enter(const TaskVar* taskVar) {
     }
     return false;
   } else {
-    enterScope(taskVar);
-    return true;
+    // upcast to named decl and treat as a "normal" variable
+    return enter(taskVar->toNamedDecl());
   }
 }
 
 void Resolver::exit(const TaskVar* taskVar) {
   if (!isTaskIntent(taskVar)) {
-    exitScope(taskVar);
+    exit(taskVar->toNamedDecl());
   }
 }
 

--- a/frontend/test/resolution/testDomainsSparse.cpp
+++ b/frontend/test/resolution/testDomainsSparse.cpp
@@ -79,7 +79,7 @@ module M {
 
   const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
 
-  const Variable* d = findVariable(m, "d");
+  auto d = findVariable(m, "d");
   assert(d);
   assert(d->name() == "d");
 

--- a/frontend/test/resolution/testScopeResolve.cpp
+++ b/frontend/test/resolution/testScopeResolve.cpp
@@ -61,9 +61,9 @@ static void test1() {
   setFileText(context, path, contents);
 
   const ModuleVec& vec = parseToplevel(context, path);
-  const Variable* x = findVariable(vec, "x");
+  auto x = findVariable(vec, "x");
   assert(x);
-  const Variable* y = findVariable(vec, "y");
+  auto y = findVariable(vec, "y");
   assert(y);
 
   const ResolvedExpression& re = scopeResolveIt(context, x->initExpression());
@@ -91,9 +91,9 @@ static void test2() {
   setFileText(context, path, contents);
 
   const ModuleVec& vec = parseToplevel(context, path);
-  const Variable* x = findVariable(vec, "x");
+  auto x = findVariable(vec, "x");
   assert(x);
-  const Variable* y = findVariable(vec, "y");
+  auto y = findVariable(vec, "y");
   assert(y);
 
   const ResolvedExpression& re = scopeResolveIt(context, x->initExpression());
@@ -121,9 +121,9 @@ static void test3() {
   setFileText(context, path, contents);
 
   const ModuleVec& vec = parseToplevel(context, path);
-  const Variable* x = findVariable(vec, "x");
+  auto x = findVariable(vec, "x");
   assert(x);
-  const Variable* y = findVariable(vec, "y");
+  auto y = findVariable(vec, "y");
   assert(y);
 
   const ResolvedExpression& re = scopeResolveIt(context, x->initExpression());
@@ -151,9 +151,9 @@ static void test4() {
   setFileText(context, path, contents);
 
   const ModuleVec& vec = parseToplevel(context, path);
-  const Variable* x = findVariable(vec, "x");
+  auto x = findVariable(vec, "x");
   assert(x);
-  const Variable* y = findVariable(vec, "y");
+  auto y = findVariable(vec, "y");
   assert(y);
 
   const ResolvedExpression& re = scopeResolveIt(context, x->initExpression());
@@ -181,9 +181,9 @@ static void test5() {
   setFileText(context, path, contents);
 
   const ModuleVec& vec = parseToplevel(context, path);
-  const Variable* x = findVariable(vec, "x");
+  auto x = findVariable(vec, "x");
   assert(x);
-  const Variable* y = findVariable(vec, "y");
+  auto y = findVariable(vec, "y");
   assert(y);
 
   const ResolvedExpression& re = scopeResolveIt(context, x->initExpression());
@@ -225,7 +225,7 @@ static void test6() {
   assert(inc->isPrototype() == false);
   assert(inc->name() == "Sub");
 
-  const Variable* x = findVariable(vec, "x");
+  auto x = findVariable(vec, "x");
   assert(x);
 
   const ResolvedExpression& re = scopeResolveIt(context, x->initExpression());
@@ -237,7 +237,7 @@ static void test6() {
   assert(sub->name() == "Sub");
   assert(sub->id().symbolPath() == "MM.Sub");
 
-  const Variable* y = findVariable(sub, "y");
+  auto y = findVariable(sub, "y");
   assert(y);
 
   assert(xInitId == y->id());
@@ -263,9 +263,9 @@ static void test7() {
   setFileText(context, path, contents);
 
   const ModuleVec& vec = parseToplevel(context, path);
-  const Variable* x = findVariable(vec, "x");
+  auto x = findVariable(vec, "x");
   assert(x);
-  const Variable* y = findVariable(vec, "y");
+  auto y = findVariable(vec, "y");
   assert(y);
 
   const ResolvedExpression& re = scopeResolveIt(context, x->initExpression());
@@ -305,13 +305,13 @@ static void test8() {
 
   const ModuleVec& vec = parseToplevel(context, path);
 
-  const Variable* x = findVariable(vec, "x");
+  auto x = findVariable(vec, "x");
   assert(x);
-  const Variable* y = findVariable(vec, "y");
+  auto y = findVariable(vec, "y");
   assert(y);
-  const Variable* a = findVariable(vec, "a");
+  auto a = findVariable(vec, "a");
   assert(a);
-  const Variable* b = findVariable(vec, "b");
+  auto b = findVariable(vec, "b");
   assert(b);
 
   assert(x->initExpression() == nullptr);
@@ -348,17 +348,17 @@ static void test9() {
 
   const ModuleVec& vec = parseToplevel(context, path);
 
-  const Variable* x = findVariable(vec, "x");
+  auto x = findVariable(vec, "x");
   assert(x);
-  const Variable* y = findVariable(vec, "y");
+  auto y = findVariable(vec, "y");
   assert(y);
-  const Variable* z = findVariable(vec, "z");
+  auto z = findVariable(vec, "z");
   assert(z);
-  const Variable* a = findVariable(vec, "a");
+  auto a = findVariable(vec, "a");
   assert(a);
-  const Variable* b = findVariable(vec, "b");
+  auto b = findVariable(vec, "b");
   assert(b);
-  const Variable* c = findVariable(vec, "c");
+  auto c = findVariable(vec, "c");
   assert(c);
 
   const ResolvedExpression& reA = scopeResolveIt(context, a->initExpression());
@@ -392,9 +392,9 @@ static void test10() {
 
   const ModuleVec& vec = parseToplevel(context, path);
 
-  const Variable* x = findVariable(vec, "x");
+  auto x = findVariable(vec, "x");
   assert(x);
-  const Variable* a = findVariable(vec, "a");
+  auto a = findVariable(vec, "a");
   assert(a);
 
   const ResolvedExpression& reA = scopeResolveIt(context, a->initExpression());
@@ -428,17 +428,17 @@ static void test11() {
 
   const ModuleVec& vec = parseToplevel(context, path);
 
-  const Variable* x = findVariable(vec, "x");
+  auto x = findVariable(vec, "x");
   assert(x);
-  const Variable* y = findVariable(vec, "y");
+  auto y = findVariable(vec, "y");
   assert(y);
-  const Variable* z = findVariable(vec, "z");
+  auto z = findVariable(vec, "z");
   assert(z);
-  const Variable* a = findVariable(vec, "a");
+  auto a = findVariable(vec, "a");
   assert(a);
-  const Variable* b = findVariable(vec, "b");
+  auto b = findVariable(vec, "b");
   assert(b);
-  const Variable* c = findVariable(vec, "c");
+  auto c = findVariable(vec, "c");
   assert(c);
 
   const ResolvedExpression& reA = scopeResolveIt(context, a->initExpression());
@@ -482,15 +482,15 @@ static void test12() {
 
   const ModuleVec& vec = parseToplevel(context, path);
 
-  const Variable* x = findVariable(vec, "x");
+  auto x = findVariable(vec, "x");
   assert(x);
-  const Variable* y = findVariable(vec, "y");
+  auto y = findVariable(vec, "y");
   assert(y);
-  const Variable* a = findVariable(vec, "a");
+  auto a = findVariable(vec, "a");
   assert(a);
-  const Variable* b = findVariable(vec, "b");
+  auto b = findVariable(vec, "b");
   assert(b);
-  const Variable* c = findVariable(vec, "c");
+  auto c = findVariable(vec, "c");
   assert(c);
 
   const ResolvedExpression& reA = scopeResolveIt(context, a->initExpression());
@@ -525,7 +525,7 @@ static void test13() {
   const ModuleVec& vec = parseToplevel(ctx, path);
 
   // Variable triggers resolution of use/import statements.
-  const Variable* x = findVariable(vec, "x");
+  auto x = findVariable(vec, "x");
   assert(x);
 
   std::ignore = scopeResolveIt(ctx, x);
@@ -566,9 +566,9 @@ static void test14() {
 
   const ModuleVec& vec = parseToplevel(context, path);
 
-  const Variable* x = findVariable(vec, "x");
+  auto x = findVariable(vec, "x");
   assert(x);
-  const Variable* y = findVariable(vec, "y");
+  auto y = findVariable(vec, "y");
   assert(y);
 
   const ResolvedExpression& reY = scopeResolveIt(context, y->initExpression());
@@ -600,9 +600,9 @@ static void test15() {
 
   const ModuleVec& vec = parseToplevel(context, path);
 
-  const Variable* x = findVariable(vec, "x");
+  auto x = findVariable(vec, "x");
   assert(x);
-  const Variable* y = findVariable(vec, "y");
+  auto y = findVariable(vec, "y");
   assert(y);
 
   const ResolvedExpression& reY = scopeResolveIt(context, y->initExpression());
@@ -635,9 +635,9 @@ static void test16() {
 
   const ModuleVec& vec = parseToplevel(context, path);
 
-  const Variable* x = findVariable(vec, "x");
+  auto x = findVariable(vec, "x");
   assert(x);
-  const Variable* y = findVariable(vec, "y");
+  auto y = findVariable(vec, "y");
   assert(y);
 
   const ResolvedExpression& reY = scopeResolveIt(context, y->initExpression());
@@ -663,7 +663,7 @@ static void test17() {
 
   const ModuleVec& vec = parseToplevel(context, path);
 
-  const Variable* x = findVariable(vec, "x");
+  auto x = findVariable(vec, "x");
   assert(x);
   // Trigger scope resolution
   const ResolvedExpression& reX = scopeResolveIt(context, x->initExpression());
@@ -705,7 +705,7 @@ static void test18() {
 
   const ModuleVec& vec = parseToplevel(context, path);
 
-  const Variable* x = findVariable(vec, "x");
+  auto x = findVariable(vec, "x");
   assert(x);
 
   const ResolvedExpression& reY = scopeResolveIt(context, x->initExpression());
@@ -740,7 +740,7 @@ static void test19() {
 
   const ModuleVec& vec = parseToplevel(context, path);
 
-  const Variable* x = findVariable(vec, "x");
+  auto x = findVariable(vec, "x");
   assert(x);
 
   const ResolvedExpression& reY = scopeResolveIt(context, x->initExpression());
@@ -769,7 +769,7 @@ static void test20() {
 
   const ModuleVec& vec = parseToplevel(context, path);
 
-  const Variable* x = findVariable(vec, "x");
+  auto x = findVariable(vec, "x");
   assert(x);
 
   const ResolvedExpression& reY = scopeResolveIt(context, x->initExpression());
@@ -799,7 +799,7 @@ static void test21() {
 
   const ModuleVec& vec = parseToplevel(context, path);
 
-  const Variable* x = findVariable(vec, "x");
+  auto x = findVariable(vec, "x");
   assert(x);
 
   for (auto mod : vec) {
@@ -830,7 +830,7 @@ static void test22() {
 
   const ModuleVec& vec = parseToplevel(context, path);
 
-  const Variable* x = findVariable(vec, "x");
+  auto x = findVariable(vec, "x");
   assert(x);
 
   const ResolvedExpression& reY = scopeResolveIt(context, x->initExpression());
@@ -860,7 +860,7 @@ static void test23() {
 
   const ModuleVec& vec = parseToplevel(context, path);
 
-  const Variable* x = findVariable(vec, "x");
+  auto x = findVariable(vec, "x");
   assert(x);
 
   const ResolvedExpression& reMc = scopeResolveIt(context, x->initExpression());
@@ -894,11 +894,11 @@ static void test24() {
 
   const ModuleVec& vec = parseToplevel(context, path);
 
-  const Variable* x = findVariable(vec, "x");
+  auto x = findVariable(vec, "x");
   assert(x);
-  const Variable* y = findVariable(vec, "y");
+  auto y = findVariable(vec, "y");
   assert(x);
-  const Variable* a = findVariable(vec, "a");
+  auto a = findVariable(vec, "a");
   assert(a);
 
   const ResolvedExpression& reB = scopeResolveIt(context, x->initExpression());
@@ -935,7 +935,7 @@ static void test25() {
 
   const ModuleVec& vec = parseToplevel(context, path);
 
-  const Variable* x = findVariable(vec, "x");
+  auto x = findVariable(vec, "x");
   assert(x);
 
   const ResolvedExpression& reC = scopeResolveIt(context, x->initExpression());
@@ -969,9 +969,9 @@ static void test26() {
 
   const ModuleVec& vec = parseToplevel(context, path);
 
-  const Variable* x = findVariable(vec, "x");
+  auto x = findVariable(vec, "x");
   assert(x);
-  const Variable* y = findVariable(vec, "y");
+  auto y = findVariable(vec, "y");
   assert(y);
 
   const ResolvedExpression& reY = scopeResolveIt(context, y->initExpression());
@@ -999,9 +999,9 @@ static void test27() {
 
   const ModuleVec& vec = parseToplevel(context, path);
 
-  const Variable* x = findVariable(vec, "x");
+  auto x = findVariable(vec, "x");
   assert(x);
-  const Variable* y = findVariable(vec, "y");
+  auto y = findVariable(vec, "y");
   assert(y);
 
   ID fnId = y->id().parentSymbolId(context);
@@ -1039,9 +1039,9 @@ static void test28() {
 
   const ModuleVec& vec = parseToplevel(context, path);
 
-  const Variable* x = findVariable(vec, "x");
+  auto x = findVariable(vec, "x");
   assert(x);
-  const Variable* y = findVariable(vec, "y");
+  auto y = findVariable(vec, "y");
   assert(y);
 
   ID fnId = y->id().parentSymbolId(context);
@@ -1077,9 +1077,9 @@ static void test29() {
 
   const ModuleVec& vec = parseToplevel(context, path);
 
-  const Variable* x = findVariable(vec, "x");
+  auto x = findVariable(vec, "x");
   assert(x);
-  const Variable* y = findVariable(vec, "y");
+  auto y = findVariable(vec, "y");
   assert(y);
 
   ID fnId = y->id().parentSymbolId(context);
@@ -1126,9 +1126,9 @@ static void test30() {
 
   const ModuleVec& vec = parseToplevel(context, path);
 
-  const Variable* x = findVariable(vec, "x");
+  auto x = findVariable(vec, "x");
   assert(x);
-  const Variable* y = findVariable(vec, "y");
+  auto y = findVariable(vec, "y");
   assert(y);
 
   ID fnId = y->id().parentSymbolId(context);
@@ -1171,7 +1171,7 @@ static void test30a() {
 
   const ModuleVec& vec = parseToplevel(context, path);
 
-  const Variable* y = findVariable(vec, "y");
+  auto y = findVariable(vec, "y");
   assert(y);
 
   ID fnId = y->id().parentSymbolId(context);
@@ -1205,7 +1205,7 @@ static void test31() {
 
   const ModuleVec& vec = parseToplevel(context, path);
 
-  const Variable* x = findVariable(vec, "x");
+  auto x = findVariable(vec, "x");
   assert(x);
 
   ID fnId = x->id().parentSymbolId(context);

--- a/frontend/test/resolution/testTaskIntents.cpp
+++ b/frontend/test/resolution/testTaskIntents.cpp
@@ -320,6 +320,27 @@ static void testKinds() {
   }
 }
 
+static void testTaskVar() {
+  auto ctx = buildStdContext();
+  ErrorGuard guard(ctx);
+  auto program =
+    R"""(
+      var outer : int;
+      forall i in 1..10 with (var x : int,
+                              ref outer) {
+        outer = x;
+        var y = x;
+      }
+    )""";
+
+  auto vars = resolveTypesOfVariables(ctx, program, {"x", "y"});
+  assert(guard.realizeErrors() == 0);
+
+  for (auto& [name, var] : vars) {
+    assert(!var.isUnknownOrErroneous() && var.type()->isIntType());
+  }
+}
+
 // helper for running reduce intent tests
 static void reduceHelper(const std::string& constructName, const char* op, const char* opAssign) {
   assert(constructName == "forall" || constructName == "coforall");
@@ -429,6 +450,7 @@ int main(int argc, char** argv) {
 
   // perform actual tests
   testKinds();
+  testTaskVar();
   testReduce();
   testReduceAssignNotVariable();
   testReduceAssignNotReduceIntent();

--- a/frontend/test/test-resolution.cpp
+++ b/frontend/test/test-resolution.cpp
@@ -186,10 +186,12 @@ void testCall(const char* testName,
   printf("\n");
 }
 
-const Variable* findVariable(const AstNode* ast, const char* name) {
-  if (auto v = ast->toVariable()) {
-    if (v->name() == name) {
-      return v;
+const VarLikeDecl* findVariable(const AstNode* ast, const char* name) {
+  if (auto v = ast->toVarLikeDecl()) {
+    if (!v->isFormal()) {
+      if (v->name() == name) {
+        return v;
+      }
     }
   }
 
@@ -201,7 +203,7 @@ const Variable* findVariable(const AstNode* ast, const char* name) {
   return nullptr;
 }
 
-const Variable* findVariable(const ModuleVec& vec, const char* name) {
+const VarLikeDecl* findVariable(const ModuleVec& vec, const char* name) {
   for (auto mod : vec) {
     auto got = findVariable(mod, name);
     if (got) return got;

--- a/frontend/test/test-resolution.h
+++ b/frontend/test/test-resolution.h
@@ -66,8 +66,8 @@ void testCall(const char* testName,
               const char* callIdStr,
               const char* calledFnIdStr);
 
-const Variable* findVariable(const AstNode* ast, const char* name);
-const Variable* findVariable(const ModuleVec& vec, const char* name);
+const VarLikeDecl* findVariable(const AstNode* ast, const char* name);
+const VarLikeDecl* findVariable(const ModuleVec& vec, const char* name);
 
 std::unordered_map<std::string, QualifiedType>
 resolveTypesOfVariables(Context* context,


### PR DESCRIPTION
Closes https://github.com/Cray/chapel-private/issues/7139 (resolving `blockDist`)
Closes https://github.com/Cray/chapel-private/issues/7264 (resolving task variables)

This PR implements task variables. I previously identified them as the last component to resolving `blockDist`. However, I was wrong; as a consequence, I rolled in a related fix that does take care of all the issues in `blockDist`.

For task variables, things are very simple. We already have code for handling variable declarations, and we already have code detecting a task variable (as opposed to a task intent). However, one was not using the other. I simply added a call to the "regular" handing of named declarations for task variables, and things "just worked".

The related bug was due to `call-init-deinit` attempting to default-initialize an `in x` task intent. I'd previously adjusted this code to disable default initialization for `[const] ref x`. For `in`, like in the `ref` case, we should not perform default-initialization, since the shadow variable created by the intent is initialized from the outer variable of the same name. However, unlike the `ref` case, we are creating a temp here, which does need initialization. So, this PR adjusts `in x` to be handled like `var x = <value of outerX.type>`. This fixes the last remaining issues in `blockDist`.

To make it easier to test this, I also adjusted the `findVariables` call to be able to pick up var-like things (like task intents). Its previous semantics have been to avoid formals, though, so I kept that aspect of it.

Reviewed by @benharsh -- thanks!

## Testing
- [x] dyno tests
- [x] paratest