### PR TITLE
Fix the cpu-as-device implementation of `chpl_gpu_clock`, skipif a new test

### DIFF
--- a/runtime/include/gpu/cpu/chpl-gpu-gen-includes.h
+++ b/runtime/include/gpu/cpu/chpl-gpu-gen-includes.h
@@ -78,9 +78,9 @@ static inline void chpl_assert_on_gpu(int32_t lineno, int32_t filenameIdx) {
   }
 }
 
-static inline unsigned int chpl_gpu_clock(void) {
+static inline unsigned int chpl_gpu_clock(int32_t lineno, int32_t filenameIdx) {
   if (!chpl_gpu_no_cpu_mode_warning) {
-    chpl_warning("chpl_gpu_clock was called.", 0, 0);
+    chpl_warning("chpl_gpu_clock was called.", lineno, filenameIdx);
   }
   return (unsigned int)clock();
 }

--- a/test/gpu/native/basics/gpuClockOnHost.skipif
+++ b/test/gpu/native/basics/gpuClockOnHost.skipif
@@ -1,0 +1,1 @@
+CHPL_GPU==cpu


### PR DESCRIPTION
This is to address the fallout from https://github.com/chapel-lang/chapel/pull/27022.

- cpu-as-device implementation of `chpl_gpu_clock` needed line and file number formals
- the new test needs to be skipped with cpu-as-device as the warning we are testing is specific to having actual GPUs

Test:
- [x] spot-check on cpu-as-device mode
- [x] the test is skipped properly
- [x] full cpu-as-device