### PR TITLE
Dyno: Roll back silencing errors when resolving transitive functions

### DIFF
--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2180,13 +2180,7 @@ gatherUserDiagnostics(ResolutionContext* rc,
     // shouldn't happen, but it currently does in some cases.
     if (msc.fn()->needsInstantiation()) continue;
 
-    // HACK: suppress errors from resolving the function here. this is a hack to
-    //       avoid breaking existing tests which didn't expect errors emitted
-    //       during eager resolution.
-    auto resultAndErrors = rc->context()->runAndTrackErrors([rc, &msc, &c](Context* context) {
-      return resolveFunction(rc, msc.fn(), c.poiInfo().poiScope(), /* skipIfRunning */ true);
-    });
-    auto resolvedFn = resultAndErrors.result();
+    auto resolvedFn = resolveFunction(rc, msc.fn(), c.poiInfo().poiScope(), /* skipIfRunning */ true);
     if (!resolvedFn) continue;
 
     into.insert(into.end(), resolvedFn->diagnostics().begin(),

--- a/frontend/test/resolution/testCompilerError.cpp
+++ b/frontend/test/resolution/testCompilerError.cpp
@@ -169,11 +169,7 @@ static void testTwoErrors() {
     )""";
 
   resolveTypesOfVariables(ctx, program, {"x", "y"});
-  // Note: the HACK in which we silence errors from resolving nested calls
-  // (because we can't fully resolve the standard library) is in play,
-  // which means we don't see the UserDiagnosticEncounterError. Once
-  // that workaround is disabled (i.e., when we can resolve all functions without
-  // errors), we should test for that error here.
+  ensureErrorOnLine(ctx, guard.errors(), ErrorType::UserDiagnosticEncounterError, 645, "no", /* allowOthers = */ true);
   ensureErrorOnLine(ctx, guard.errors(), ErrorType::UserDiagnosticEmitError, 5, "no", /* allowOthers = */ true);
   ensureErrorOnLine(ctx, guard.errors(), ErrorType::UserDiagnosticEmitError, 7, "no", /* allowOthers = */ true);
   guard.realizeErrors();
@@ -200,7 +196,7 @@ static void testRunAndTrackErrors() {
     return resolveConcreteFunction(ctx, modules[0]->stmt(0)->id());
   });
   assert(!result.ranWithoutErrors());
-  assert(result.errors().size() == 1);
+  assert(result.errors().size() == 2);
   ensureErrorInErrorsModule(ctx, result.errors(), ErrorType::UserDiagnosticEncounterError);
 }
 
@@ -256,7 +252,7 @@ static void testEarlyReturn() {
   assert(x->isIntType());
   ensureErrorOnLine(ctx, guard.errors(), ErrorType::UserDiagnosticEmitError, 3, "Hello", /* allowOthers = */ true);
   ensureErrorOnLine(ctx, guard.errors(), ErrorType::UserDiagnosticEmitWarning, 13, "inside foo, after call to bar", /* allowOthers = */ true);
-  assert(guard.realizeErrors() == 3); /* one more for UserDiagnosticEncounterError */
+  assert(guard.realizeErrors() == 4); /* two more for UserDiagnosticEncounter{Error,Warning} */
 }
 
 int main() {

--- a/test/compflags/stopEarly/dyno-resolve-only.good
+++ b/test/compflags/stopEarly/dyno-resolve-only.good
@@ -1,3 +1,3 @@
-dyno-resolve-only.chpl:9: error: type mismatch between declared type of 'b' and initialization expression
 dyno-resolve-only.chpl:1: In function 'foo':
 dyno-resolve-only.chpl:3: error: type mismatch between declared type of 'y' and initialization expression
+dyno-resolve-only.chpl:9: error: type mismatch between declared type of 'b' and initialization expression


### PR DESCRIPTION
It looks like none of our tests need the workaround anymore, and it costs a lot in terms of performance.

Reviewed by @benharsh -- thanks!

## Testing
- [x] dyno tests
- [x] paratest