### PR TITLE
Dyno: improve performance when resolving

### DIFF
--- a/frontend/include/chpl/framework/Context-detail.h
+++ b/frontend/include/chpl/framework/Context-detail.h
@@ -25,6 +25,8 @@
 #include "chpl/util/memory.h"
 #include "chpl/util/hash.h"
 
+#include "llvm/ADT/SmallPtrSet.h"
+
 #include <chrono>
 #include <cstdint>
 #include <cstring>
@@ -307,7 +309,7 @@ class QueryMapResultBase {
   mutable ssize_t oldResultForErrorContents = -1;
 
   mutable QueryDependencyVec dependencies;
-  mutable std::set<const QueryMapResultBase*> recursionErrors;
+  mutable llvm::SmallPtrSet<const QueryMapResultBase*, 2> recursionErrors;
   mutable QueryErrorVec errors;
 
   QueryMapBase* parentQueryMap;
@@ -317,7 +319,7 @@ class QueryMapResultBase {
                      bool beingTestedForReuse,
                      bool emittedErrors,
                      size_t oldResultForErrorContents,
-                     std::set<const QueryMapResultBase*> recursionErrors,
+                     llvm::SmallPtrSet<const QueryMapResultBase*, 2> recursionErrors,
                      QueryMapBase* parentQueryMap);
   virtual ~QueryMapResultBase() = 0; // this is an abstract base class
   virtual void recompute(Context* context) const = 0;
@@ -346,7 +348,7 @@ class QueryMapResult final : public QueryMapResultBase {
                  bool beingTestedForReuse,
                  bool emittedErrors,
                  size_t oldResultForErrorContents,
-                 std::set<const QueryMapResultBase*> recursionErrors,
+                 llvm::SmallPtrSet<const QueryMapResultBase*, 2> recursionErrors,
                  QueryMap<ResultType, ArgTs...>* parentQueryMap,
                  std::tuple<ArgTs...> tupleOfArgs,
                  ResultType result)

--- a/frontend/include/chpl/framework/Context-detail.h
+++ b/frontend/include/chpl/framework/Context-detail.h
@@ -244,10 +244,7 @@ struct QueryDependency {
 };
 
 using QueryDependencyVec = std::vector<QueryDependency>;
-// The first component is the error emitted by the query, while the second
-// component stores whether or not the error was silenced (i.e. not reported).
-// The query contains all errors, but only prints the non-silenced ones.
-using QueryErrorVec = std::vector<std::pair<owned<ErrorBase>, bool>>;
+using QueryErrorVec = std::vector<owned<ErrorBase>>;
 
 class QueryMapResultBase {
  public:

--- a/frontend/include/chpl/framework/Context-detail.h
+++ b/frontend/include/chpl/framework/Context-detail.h
@@ -284,7 +284,9 @@ class QueryMapResultBase {
   //
   // This is not too strongly connected to emittedErrors (which tracks whether
   // errors --- if any --- were shown to the user for this query result only)
-  mutable bool errorsPresentInSelfOrDependencies = false;
+  //
+  // Bit 0 tracks if errors occurred, bit 1 tracks warnings.
+  mutable unsigned int errorsPresentInSelfOrDependencies:2;
   // Errors emitted when re-computing a query can refer to memory and data
   // that's temporarily allocated while running the computation. Then, if the
   // output of the query is the same as before, that temporary data can
@@ -314,7 +316,6 @@ class QueryMapResultBase {
                      RevisionNumber lastChanged,
                      bool beingTestedForReuse,
                      bool emittedErrors,
-                     bool errorsPresentInSelfOrDependencies,
                      size_t oldResultForErrorContents,
                      std::set<const QueryMapResultBase*> recursionErrors,
                      QueryMapBase* parentQueryMap);
@@ -336,7 +337,7 @@ class QueryMapResult final : public QueryMapResultBase {
   //  * a default-constructed result
   QueryMapResult(QueryMap<ResultType, ArgTs...>* parentQueryMap,
                  std::tuple<ArgTs...> tupleOfArgs)
-    : QueryMapResultBase(-1, -1, false, false, false, -1, {}, parentQueryMap),
+    : QueryMapResultBase(-1, -1, false, false, -1, {}, parentQueryMap),
       tupleOfArgs(std::move(tupleOfArgs)),
       result() {
   }
@@ -344,14 +345,13 @@ class QueryMapResult final : public QueryMapResultBase {
                  RevisionNumber lastChanged,
                  bool beingTestedForReuse,
                  bool emittedErrors,
-                 bool errorsPresentInSelfOrDependencies,
                  size_t oldResultForErrorContents,
                  std::set<const QueryMapResultBase*> recursionErrors,
                  QueryMap<ResultType, ArgTs...>* parentQueryMap,
                  std::tuple<ArgTs...> tupleOfArgs,
                  ResultType result)
     : QueryMapResultBase(lastChecked, lastChanged, beingTestedForReuse,
-                         emittedErrors, errorsPresentInSelfOrDependencies,
+                         emittedErrors,
                          oldResultForErrorContents,
                          std::move(recursionErrors), parentQueryMap),
       tupleOfArgs(std::move(tupleOfArgs)),

--- a/frontend/include/chpl/framework/Context.h
+++ b/frontend/include/chpl/framework/Context.h
@@ -163,12 +163,17 @@ class Context {
   class ErrorCollectionEntry {
    private:
     std::vector<owned<ErrorBase>>* storeInto_;
+    bool* noteErrorOccurredInto_;
     const querydetail::QueryMapResultBase* collectingQuery_;
 
     ErrorCollectionEntry(std::vector<owned<ErrorBase>>* storeInto,
+                         bool* noteErrorOccurredInto,
                          const querydetail::QueryMapResultBase* collectingQuery) :
-      storeInto_(storeInto), collectingQuery_(collectingQuery) {}
+      storeInto_(storeInto), noteErrorOccurredInto_(noteErrorOccurredInto),
+      collectingQuery_(collectingQuery) {}
 
+    void storeErrorsFromHelp(const querydetail::QueryMapResultBase* result,
+                            std::unordered_set<const querydetail::QueryMapResultBase*>& visited);
    public:
     /**
       When a parent query starts tracking errors, the tracking entry contains
@@ -191,7 +196,10 @@ class Context {
     createForRecomputing(const querydetail::QueryMapResultBase*);
 
     const querydetail::QueryMapResultBase* collectingQuery() const { return collectingQuery_; }
+
     void storeError(owned<ErrorBase> toStore) const;
+
+    void storeErrorsFrom(const querydetail::QueryMapResultBase* result);
   };
 
   class RecomputeMarker {

--- a/frontend/include/chpl/framework/Context.h
+++ b/frontend/include/chpl/framework/Context.h
@@ -587,7 +587,7 @@ class Context {
     not shown to the user.
    */
   template <typename F>
-  auto runAndTrackErrors(F&& f) -> RunResult<decltype(f(this))> {
+  auto runAndCaptureErrors(F&& f) -> RunResult<decltype(f(this))> {
     RunResult<decltype(f(this))> result;
     auto collectionRoot = queryStack.empty() ? nullptr : queryStack.back();
     errorCollectionStack.push_back(

--- a/frontend/include/chpl/framework/Context.h
+++ b/frontend/include/chpl/framework/Context.h
@@ -152,7 +152,7 @@ class Context {
 
   class ObservingRunResultBase {
    private:
-    bool hadErrors_;
+    bool hadErrors_ = false;
 
    public:
     ~ObservingRunResultBase();

--- a/frontend/include/chpl/framework/Context.h
+++ b/frontend/include/chpl/framework/Context.h
@@ -147,7 +147,7 @@ class Context {
     const std::vector<owned<ErrorBase>>& errors() const { return errors_; };
 
     /** Steal the errors that occurred while running, leaving this result empty. */
-    std::vector<owned<ErrorBase>> consumeErrors() { return std::move(errors_); };
+    std::vector<owned<ErrorBase>> consumeErrors();
 
     /**
       Checks if any syntax errors or errors occurred while running.

--- a/frontend/lib/framework/Context.cpp
+++ b/frontend/lib/framework/Context.cpp
@@ -142,6 +142,10 @@ Context::CapturingRunResultBase::CapturingRunResultBase(const Context::Capturing
   }
 }
 
+std::vector<owned<ErrorBase>> Context::CapturingRunResultBase::consumeErrors() {
+ return std::move(errors_);
+}
+
 bool Context::CapturingRunResultBase::ranWithoutErrors() const {
   for (auto& error : errors_) {
     auto kind = error->kind();

--- a/frontend/lib/framework/Context.cpp
+++ b/frontend/lib/framework/Context.cpp
@@ -1400,7 +1400,7 @@ QueryMapResultBase::QueryMapResultBase(RevisionNumber lastChecked,
                    bool beingTestedForReuse,
                    bool emittedErrors,
                    size_t oldResultForErrorContents,
-                   std::set<const QueryMapResultBase*> recursionErrors,
+                   llvm::SmallPtrSet<const QueryMapResultBase*, 2> recursionErrors,
                    QueryMapBase* parentQueryMap)
   : lastChecked(lastChecked),
     lastChanged(lastChanged),

--- a/frontend/lib/framework/Context.cpp
+++ b/frontend/lib/framework/Context.cpp
@@ -132,17 +132,17 @@ Context::Context(Context& consumeContext, Configuration newConfig) {
   config_.swap(newConfig);
 }
 
-Context::RunResultBase::RunResultBase() = default;
+Context::CapturingRunResultBase::CapturingRunResultBase() = default;
 
-Context::RunResultBase::~RunResultBase() = default;
+Context::CapturingRunResultBase::~CapturingRunResultBase() = default;
 
-Context::RunResultBase::RunResultBase(const Context::RunResultBase& other) {
+Context::CapturingRunResultBase::CapturingRunResultBase(const Context::CapturingRunResultBase& other) {
   for (auto& err : other.errors()) {
       errors_.push_back(err->clone());
   }
 }
 
-bool Context::RunResultBase::ranWithoutErrors() const {
+bool Context::CapturingRunResultBase::ranWithoutErrors() const {
   for (auto& error : errors_) {
     auto kind = error->kind();
     if (kind == ErrorBase::ERROR || kind == ErrorBase::SYNTAX) {
@@ -152,11 +152,30 @@ bool Context::RunResultBase::ranWithoutErrors() const {
   return true;
 }
 
+Context::ObservingRunResultBase::ObservingRunResultBase() = default;
+
+Context::ObservingRunResultBase::~ObservingRunResultBase() = default;
+
+Context::ObservingRunResultBase::ObservingRunResultBase(const Context::ObservingRunResultBase& other) {
+  this->hadErrors_ = other.hadErrors_;
+}
+
+bool Context::ObservingRunResultBase::ranWithoutErrors() const {
+  return !this->hadErrors_;
+}
+
 Context::ErrorCollectionEntry
 Context::ErrorCollectionEntry::createForTrackingQuery(
     std::vector<owned<ErrorBase>>* storeInto,
     const QueryMapResultBase* trackingQuery) {
   return Context::ErrorCollectionEntry(storeInto, nullptr, trackingQuery);
+}
+
+Context::ErrorCollectionEntry
+Context::ErrorCollectionEntry::createForTrackingQuery(
+    bool* noteErrorOccurredInto,
+    const QueryMapResultBase* trackingQuery) {
+  return Context::ErrorCollectionEntry(nullptr, noteErrorOccurredInto, trackingQuery);
 }
 
 Context::ErrorCollectionEntry

--- a/frontend/lib/framework/Context.cpp
+++ b/frontend/lib/framework/Context.cpp
@@ -1121,7 +1121,6 @@ void Context::updateForReuse(const QueryMapResultBase* resultEntry) {
   // Only re-report errors if they are not being silenced.
   if (errorCollectionStack.empty()) {
     for (auto& err: resultEntry->errors) {
-      // Only report an error if it wasn't silenced in the original run
       reportError(this, err.get());
     }
   }

--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -1340,13 +1340,27 @@ bool idIsParenlessFunction(Context* context, ID id) {
   return idIsFunction(context, id) && idIsParenlessFunctionQuery(context, id);
 }
 
-bool idIsNestedFunction(Context* context, ID id) {
-  if (id.isEmpty() || !idIsFunction(context, id)) return false;
-  for (auto up = id.parentSymbolId(context); up;
-            up = up.parentSymbolId(context)) {
-    if (idIsFunction(context, up) || idIsInterface(context, up)) return true;
+static bool const& idIsNestedFunctionQuery(Context* context, ID id) {
+  QUERY_BEGIN(idIsNestedFunctionQuery, context, id);
+
+  bool result = false;
+  if (id.isEmpty() || !idIsFunction(context, id)) {
+    result = false;
+  } else {
+    for (auto up = id.parentSymbolId(context); up;
+              up = up.parentSymbolId(context)) {
+      if (idIsFunction(context, up) || idIsInterface(context, up)) {
+        result = true;
+        break;
+      }
+    }
   }
-  return false;
+
+  return QUERY_END(result);
+}
+
+bool idIsNestedFunction(Context* context, ID id) {
+  return idIsNestedFunctionQuery(context, id);
 }
 
 template <typename Predicate>

--- a/frontend/lib/resolution/InitResolver.cpp
+++ b/frontend/lib/resolution/InitResolver.cpp
@@ -148,7 +148,7 @@ void InitResolver::resolveImplicitSuperInit() {
       return true;
     });
 
-    errorsFromImplicitSuperInit = std::move(cAndErrors.errors());
+    errorsFromImplicitSuperInit = cAndErrors.consumeErrors();
     updateSuperType(&c.result);
   }
 }

--- a/frontend/lib/resolution/InitResolver.cpp
+++ b/frontend/lib/resolution/InitResolver.cpp
@@ -143,7 +143,7 @@ void InitResolver::resolveImplicitSuperInit() {
     // Capture the errors emitted here and defer them until we know we haven't
     // found a "real" super.init call (which means a different error supercedes
     // these).
-    auto cAndErrors = ctx_->runAndTrackErrors([&c](Context* ctx) {
+    auto cAndErrors = ctx_->runAndCaptureErrors([&c](Context* ctx) {
       c.noteResultPrintCandidates(nullptr);
       return true;
     });

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2872,7 +2872,7 @@ static void resolveReduceAssign(Resolver& rv, const OpCall* op) {
   // reductions in the standard library are in the habit of accepting any RHS,
   // and then emitting errors from inside the implementation. Catch that
   // an emit a more specific error.
-  auto resolveResult = rv.context->runAndTrackErrors([&, op](Context* context) {
+  auto resolveResult = rv.context->runAndCaptureErrors([&, op](Context* context) {
     auto c = rv.resolveGeneratedCall(op, &ci, &inScopes);
     return c.noteResultWithoutError(&resolvedOp,
                                     { { AssociatedAction::REDUCE_ASSIGN, op->id() } });
@@ -2928,7 +2928,7 @@ bool Resolver::resolveSpecialPrimitiveCall(const Call* call) {
     if (primCall->numActuals() != 1) {
       result = typeErr(primCall, "invalid call to \"resolves\" primitive");
     } else {
-      auto resultAndErrors = context->runAndTrackErrors([&](Context* context) {
+      auto resultAndErrors = context->runAndCaptureErrors([&](Context* context) {
         primCall->actual(0)->traverse(*this);
         return byPostorder.byAst(primCall->actual(0)).type();
       });
@@ -3104,7 +3104,7 @@ resolveSpecialKeywordCallAsNormalCall(Resolver& rv,
                                       const FnCall* innerCall,
                                       UniqueString name,
                                       ResolvedExpression& noteInto) {
-  auto runResult = rv.context->runAndTrackErrors([&](Context* ctx) {
+  auto runResult = rv.context->runAndCaptureErrors([&](Context* ctx) {
     std::vector<const AstNode*> actualAsts;
     auto ci = CallInfo::create(rv.context, innerCall, rv.byPostorder,
                                /* raiseErrors */ true,
@@ -3214,7 +3214,7 @@ bool Resolver::resolveSpecialKeywordCall(const Call* call) {
 
       auto scope = currentScope();
       auto inScopes = CallScopeInfo::forNormalCall(scope, poiScope);
-      auto runResult = context->runAndTrackErrors([&](Context* ctx) {
+      auto runResult = context->runAndCaptureErrors([&](Context* ctx) {
         return resolveGeneratedCall(call, &ci, &inScopes);
       });
       auto& crr = runResult.result().result;

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2872,7 +2872,7 @@ static void resolveReduceAssign(Resolver& rv, const OpCall* op) {
   // reductions in the standard library are in the habit of accepting any RHS,
   // and then emitting errors from inside the implementation. Catch that
   // an emit a more specific error.
-  auto resolveResult = rv.context->runAndCaptureErrors([&, op](Context* context) {
+  auto resolveResult = rv.context->runAndDetectErrors([&, op](Context* context) {
     auto c = rv.resolveGeneratedCall(op, &ci, &inScopes);
     return c.noteResultWithoutError(&resolvedOp,
                                     { { AssociatedAction::REDUCE_ASSIGN, op->id() } });
@@ -2928,7 +2928,7 @@ bool Resolver::resolveSpecialPrimitiveCall(const Call* call) {
     if (primCall->numActuals() != 1) {
       result = typeErr(primCall, "invalid call to \"resolves\" primitive");
     } else {
-      auto resultAndErrors = context->runAndCaptureErrors([&](Context* context) {
+      auto resultAndErrors = context->runAndDetectErrors([&](Context* context) {
         primCall->actual(0)->traverse(*this);
         return byPostorder.byAst(primCall->actual(0)).type();
       });
@@ -3104,7 +3104,7 @@ resolveSpecialKeywordCallAsNormalCall(Resolver& rv,
                                       const FnCall* innerCall,
                                       UniqueString name,
                                       ResolvedExpression& noteInto) {
-  auto runResult = rv.context->runAndCaptureErrors([&](Context* ctx) {
+  auto runResult = rv.context->runAndDetectErrors([&](Context* ctx) {
     std::vector<const AstNode*> actualAsts;
     auto ci = CallInfo::create(rv.context, innerCall, rv.byPostorder,
                                /* raiseErrors */ true,
@@ -3214,7 +3214,7 @@ bool Resolver::resolveSpecialKeywordCall(const Call* call) {
 
       auto scope = currentScope();
       auto inScopes = CallScopeInfo::forNormalCall(scope, poiScope);
-      auto runResult = context->runAndCaptureErrors([&](Context* ctx) {
+      auto runResult = context->runAndDetectErrors([&](Context* ctx) {
         return resolveGeneratedCall(call, &ci, &inScopes);
       });
       auto& crr = runResult.result().result;

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -270,7 +270,7 @@ static QualifiedType primCallResolves(ResolutionContext* rc,
                            /* hasQuestionArg */ false,
                            /* isParenless */ false,
                            std::move(actuals));
-  auto callResult = context->runAndCaptureErrors([&](Context* context) {
+  auto callResult = context->runAndDetectErrors([&](Context* context) {
     return resolveGeneratedCall(rc, call, callInfo,
                                 inScopes);
   });
@@ -287,7 +287,7 @@ static QualifiedType primCallResolves(ResolutionContext* rc,
 
     if (resolveFn) {
       // We did find a candidate; resolve the function body.
-      auto bodyResult = context->runAndCaptureErrors([&](Context* context) {
+      auto bodyResult = context->runAndDetectErrors([&](Context* context) {
         return resolveFunction(rc, bestCandidate, inScopes.poiScope());
       });
       callAndFnResolved &= bodyResult.ranWithoutErrors();

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -270,7 +270,7 @@ static QualifiedType primCallResolves(ResolutionContext* rc,
                            /* hasQuestionArg */ false,
                            /* isParenless */ false,
                            std::move(actuals));
-  auto callResult = context->runAndTrackErrors([&](Context* context) {
+  auto callResult = context->runAndCaptureErrors([&](Context* context) {
     return resolveGeneratedCall(rc, call, callInfo,
                                 inScopes);
   });
@@ -287,7 +287,7 @@ static QualifiedType primCallResolves(ResolutionContext* rc,
 
     if (resolveFn) {
       // We did find a candidate; resolve the function body.
-      auto bodyResult = context->runAndTrackErrors([&](Context* context) {
+      auto bodyResult = context->runAndCaptureErrors([&](Context* context) {
         return resolveFunction(rc, bestCandidate, inScopes.poiScope());
       });
       callAndFnResolved &= bodyResult.ranWithoutErrors();

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -6345,7 +6345,7 @@ const ImplementationWitness* findOrImplementInterface(ResolutionContext* rc,
 
   // try automatically satisfy the interface if it's in the standard modules.
   if (parsing::idIsInBundledModule(rc->context(), ift->id())) {
-    auto runResult = rc->context()->runAndTrackErrors([&](Context* context) {
+    auto runResult = rc->context()->runAndCaptureErrors([&](Context* context) {
       return checkInterfaceConstraints(rc, instantiatedIft, implPointId, inScopes);
     });
     witness = runResult.result();

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -6345,7 +6345,7 @@ const ImplementationWitness* findOrImplementInterface(ResolutionContext* rc,
 
   // try automatically satisfy the interface if it's in the standard modules.
   if (parsing::idIsInBundledModule(rc->context(), ift->id())) {
-    auto runResult = rc->context()->runAndCaptureErrors([&](Context* context) {
+    auto runResult = rc->context()->runAndDetectErrors([&](Context* context) {
       return checkInterfaceConstraints(rc, instantiatedIft, implPointId, inScopes);
     });
     witness = runResult.result();

--- a/frontend/test/framework/testErrorTracking.cpp
+++ b/frontend/test/framework/testErrorTracking.cpp
@@ -44,12 +44,12 @@ static const std::string& queryThatErrors(Context* context) {
 static const std::string& queryThatCapturesErrors(Context* context) {
   QUERY_BEGIN(queryThatCapturesErrors, context);
   std::string output = "";
-  auto fineResult = context->runAndTrackErrors([](Context* ctx) {
+  auto fineResult = context->runAndCaptureErrors([](Context* ctx) {
     return inputQuery(ctx);
   });
   output += fineResult.ranWithoutErrors() ? "no errors" : "errors";
   output += " on the first go; ";
-  auto badResult = context->runAndTrackErrors([](Context* ctx) {
+  auto badResult = context->runAndCaptureErrors([](Context* ctx) {
     return queryThatErrors(ctx);
   });
   output += badResult.ranWithoutErrors() ? "no errors" : "errors";
@@ -62,7 +62,7 @@ static const std::string& queryThatCapturesErrors(Context* context) {
 static const std::string& queryThatCapturesCapturingErrors(Context* context) {
   QUERY_BEGIN(queryThatCapturesCapturingErrors, context);
   std::string output = "";
-  auto result = context->runAndTrackErrors([](Context* ctx) {
+  auto result = context->runAndCaptureErrors([](Context* ctx) {
     return queryThatCapturesErrors(ctx);
   });
   output += "[" + result.result() + "] ";
@@ -86,7 +86,7 @@ static const std::string& queryThatSilencesOwnErrors(Context* context) {
   QUERY_BEGIN(queryThatSilencesOwnErrors, context);
 
   context->error(ID(), "Non-hidden error, always emitted!");
-  auto result = context->runAndTrackErrors([](Context* ctx) {
+  auto result = context->runAndCaptureErrors([](Context* ctx) {
     ctx->error(ID(), "Hidden error, should not be emitted!");
     return ".";
   });
@@ -97,7 +97,7 @@ static const std::string& queryThatSilencesOwnErrors(Context* context) {
 static const std::string& queryThatTracksQueryThatSilencesOwnErrors(Context* context) {
   QUERY_BEGIN(queryThatTracksQueryThatSilencesOwnErrors, context);
 
-  auto result = context->runAndTrackErrors([](Context* ctx) {
+  auto result = context->runAndCaptureErrors([](Context* ctx) {
     return queryThatSilencesOwnErrors(ctx);
   });
 

--- a/frontend/test/resolution/testCompilerError.cpp
+++ b/frontend/test/resolution/testCompilerError.cpp
@@ -192,7 +192,7 @@ static void testRunAndTrackErrors() {
   assert(modules.size() == 1);
   assert(modules[0]->numStmts() == 1);
 
-  auto result = ctx->runAndTrackErrors([&](Context* ctx) {
+  auto result = ctx->runAndCaptureErrors([&](Context* ctx) {
     return resolveConcreteFunction(ctx, modules[0]->stmt(0)->id());
   });
   assert(!result.ranWithoutErrors());


### PR DESCRIPTION
This PR addresses an issue I observed while working on https://github.com/chapel-lang/chapel/pull/27031, namely that resolving `blockDist` was _slow_. After doing some profiling, I observed that a big chunk of time is spent in `storeErrorsFor`, which is a function invoked for `runAndTrackErrors`. My first course of actions was to disable unnecessary calls to `runAndTrackErrors`, which occurred in https://github.com/chapel-lang/chapel/pull/27041. This helped (see below table), but I still observed calls to `storeErrors` when profiling.

This call is unfortunately necessary for correctness: collecting errors needs to work in the presence of query caching, which means that we need to be able to capture errors even if we aren't actually re-running a computation. This is done by traversing the dependency graph to collect such errors. The traversal incurs a performance penalty, despite existing optimizations (skipping sub-graphs that don't have errors). 

The optimization in this PR comes from the observation that although collecting errors incurs this performance penalty, most callers to `runAndTrackErrors` do not care about the list of errors; they only care about whether these errors have occurred. Given that we already track whether errors occurred in sub-graphs (the optimization mentioned in the previous paragraph), this means that for calls that only care about the presence of errors, we can produce a result in O(1) time. This PR does just that.

A minor change to the optimization was to distinguish errors from warnings. `ranWithoutErrors` returns `ranWithoutErrors=true` if only errors were encountered; however, the Context tracks whether _any_ `Error`s were emitted, which includes warnings. Thus, this PR turns the boolean into a two-bit field, storing the presences of warnings and errors separately. 

While there, I noticed that `errorsPresentInSelfOrDependencies` was updated too aggressively, and did not account for silencing. As a result, some subgraphs were marked as having errors despite not having any. This previously simply reduced the number of cases in which the graph-skipping optimization fired, but now is important for correctness. This PR fixes that.

Finally, I noticed that there were some overheads in the profiler output from using a regular `set` from the standard library for tracking recursion errors. Recursion errors are the exception rather than the norm; moreover, the set being that of pointers enables some optimizations. I switched the code to use `llvm::SmallPtrSet`, which had a modest performance boost of 3-6%. 

## Performance Impact
| __Experiment__                                                                   | Time (debug) | Time (release) |
|----------------------------------------------------------------------------------|--------------|----------------|
| Baseline                                                                         | 91 seconds   | 9.7 seconds    |
| Remove runAndTrackErrors (#27041)                                                | 42 seconds   | -              |
| Stop collecting errors where possible (4db46d4c5ea463a5ea7c648cd5387e9a2a98e89f) | 31 seconds   | -              |
| Switch to llvm::SmallPtrSet (2e8f3477b1d6eccf7ed4c76145751105b395848d)           | 29 seconds   | 4.0 seconds    |

Reviewed by @arifthpe -- thanks!

## Testing
- [x] dyno tests
- [x] paratest