### PR TITLE
Fix the memleaks failure with my new test

### DIFF
--- a/modules/packages/Python.chpl
+++ b/modules/packages/Python.chpl
@@ -494,6 +494,7 @@ module Python {
         memcpy(execCStr+venvLen, pythonPathExt.buff,
                pythonPathExt.size.safeCast(c_size_t));
         execCStr[newSize] = 0;
+        defer chpl_here_free(execCStr);
 
         const executable = string.createBorrowingBuffer(execCStr);
         const wideExecutable = executable.c_wstr();


### PR DESCRIPTION
Free the memory allocated for the buffer when we're done with it.  I could have sworn I ran that test with `-memleaks` as well, but maybe I did it with an earlier version of the change or something.  In any case, this thankfully doesn't break the fix.

Passed a full standard paratest, test/library/packages/Python with gasnet, and the test itself with `-memleaks`