### PR TITLE
Fix `--verify` with a bundled LLVM

### DIFF
--- a/util/chplenv/chplenv_verify.py
+++ b/util/chplenv/chplenv_verify.py
@@ -194,7 +194,21 @@ int main() {
 """
 
 
-class TestTargetCompileCC(TestCompile):
+class TestTargetCompile(TestCompile):
+
+    def skipif(self):
+        if self.chplenv.get("CHPL_TARGET_COMPILER") == "llvm":
+            # if CHPL_LLVM is bundled, skip if the bundled LLVM is missing
+            # if CHPL_LLVM is none and CHPL_LLVM_SUPPORT is bundled, skip if the bundled LLVM is missing
+            if (self.chplenv.get("CHPL_LLVM") == "bundled" or
+                (self.chplenv.get("CHPL_LLVM") == "none" and
+                self.chplenv.get("CHPL_LLVM_SUPPORT") == "bundled")):
+                llvm_config = self.chplenv.get("CHPL_LLVM_CONFIG")
+                if not llvm_config or not os.path.exists(llvm_config):
+                    return True
+        return super().skipif()
+
+class TestTargetCompileCC(TestTargetCompile):
     """
     Try and compile a hello world program using CHPL_TARGET_CC
     """
@@ -218,7 +232,7 @@ int main() {
 """
 
 
-class TestTargetCompileCXX(TestCompile):
+class TestTargetCompileCXX(TestTargetCompile):
     """
     Try and compile a hello world program using CHPL_TARGET_CXX
     """
@@ -250,6 +264,14 @@ class TestHostCanFindLLVM(TestCompile):
     def skipif(self):
         if os.getenv("CHPLENV_SKIP_HOST", None) is not None:
             return True
+        # if CHPL_LLVM is bundled, skip if the bundled LLVM is missing
+        # if CHPL_LLVM is none and CHPL_LLVM_SUPPORT is bundled, skip if the bundled LLVM is missing
+        if (self.chplenv.get("CHPL_LLVM") == "bundled" or
+            (self.chplenv.get("CHPL_LLVM") == "none" and
+            self.chplenv.get("CHPL_LLVM_SUPPORT") == "bundled")):
+            llvm_config = self.chplenv.get("CHPL_LLVM_CONFIG")
+            if not llvm_config or not os.path.exists(llvm_config):
+                return True
         return super().skipif()
 
     def _suffix(self):
@@ -262,8 +284,14 @@ class TestHostCanFindLLVM(TestCompile):
         return "CHPL_HOST_CXX"
 
     def _compiler_args(self):
-        comp_args = self.chplenv.get("CHPL_HOST_SYSTEM_COMPILE_ARGS", "")
-        link_args = self.chplenv.get("CHPL_HOST_SYSTEM_LINK_ARGS", "")
+        comp_args = (
+            self.chplenv.get("CHPL_HOST_BUNDLED_COMPILE_ARGS", "") + " " +
+            self.chplenv.get("CHPL_HOST_SYSTEM_COMPILE_ARGS", "")
+        )
+        link_args = (
+            self.chplenv.get("CHPL_HOST_BUNDLED_LINK_ARGS", "") + " " +
+            self.chplenv.get("CHPL_HOST_SYSTEM_LINK_ARGS", "")
+        )
         return (
             super()._compiler_args()
             + shlex.split(comp_args)
@@ -284,17 +312,12 @@ int main() {
 }
 """
 
-    def verify(self):
-        # if CHPL_LLVM=none, then we don't need to test this
-        if self.chplenv.get("CHPL_LLVM") == "none":
-            return True
-        return super().verify()
-
     def explain(self):
         compiler = self._compiler()
         if not compiler:
             return "No compiler found"
-        return "{} cannot find LLVM headers".format(compiler[0])
+        return "{}{}{} cannot find LLVM headers".format(
+            super().explain(), os.linesep, compiler[0])
 
 
 passes = [


### PR DESCRIPTION
Fixes `printchplenv --verify` when using a bundled LLVM

[Reviewed by @DanilaFe]