### PR TITLE
Improve performance of `start_test` by reducing what gets computed

### DIFF
--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -146,7 +146,7 @@ import re
 import shlex
 import datetime
 import errno
-from functools import reduce
+from functools import reduce, cache
 import atexit
 
 def elapsed_sub_test_time():
@@ -849,6 +849,7 @@ def main():
     # purpose. compileline will not work correctly in some configurations when run
     # outside of its directory tree.
     compileline = os.path.join(chpl_home, 'util', 'config', 'compileline')
+    @cache
     def run_compileline(flag, lookingfor):
         (returncode, result, _) = run_process([compileline, flag],
                                               stdout=subprocess.PIPE,

--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -858,13 +858,6 @@ def main():
             Fatal('Cannot find ' + lookingfor)
         return result
 
-    c_compiler = run_compileline('--compile', 'c compiler')
-    cpp_compiler = run_compileline('--compile-c++', 'c++ compiler')
-    host_c_compiler = run_compileline('--host-c-compiler', 'host c compiler')
-    host_cpp_compiler = run_compileline('--host-cxx-compiler', 'host c++ compiler')
-    runtime_includes_and_defines = run_compileline('--includes-and-defines',
-                                                   'runtime includes and defines')
-
     # Use timedexec
     # As much as I hate calling out to another script for the time out stuff,
     #  subprocess doesn't quite cut it for this kind of stuff
@@ -1684,13 +1677,17 @@ def main():
                 args = ['-o', test_filename]+shlex.split(compopts)+[testname]
                 cmd = None
                 if is_c_test:
-                    cmd = c_compiler
+                    cmd = run_compileline('--compile', 'c compiler')
                 elif is_ml_c_test:
+                    host_c_compiler = run_compileline('--host-c-compiler', 'host c compiler')
+                    runtime_includes_and_defines = run_compileline('--includes-and-defines', 'runtime includes and defines')
                     cmd_pieces = [host_c_compiler, runtime_includes_and_defines]
                     cmd = ' '.join(cmd_pieces)
                 elif is_cpp_test:
-                    cmd = cpp_compiler
+                    cmd = run_compileline('--compile-c++', 'c++ compiler')
                 elif is_ml_cpp_test:
+                    host_cpp_compiler = run_compileline('--host-cxx-compiler', 'host c++ compiler')
+                    runtime_includes_and_defines = run_compileline('--includes-and-defines', 'runtime includes and defines')
                     cmd_pieces = [host_cpp_compiler, runtime_includes_and_defines]
                     cmd = ' '.join(cmd_pieces)
             else:


### PR DESCRIPTION
Moves calls to `compileline` into where they are actually needed, which is only a small subset of tests. 

Before this PR `start_test examples/hello.chpl` took 22 seconds on my Mac. Now it takes 15 seconds.

[Reviewed by @DanilaFe]