### PR TITLE
Use getpass.getuser instead of os.getlogin

### DIFF
--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -7,6 +7,7 @@ import tempfile
 import glob
 import itertools
 import re
+import getpass
 from contextlib import contextmanager
 
 
@@ -123,7 +124,7 @@ def main():
 
     # pointers to temporary directory where chapel will be built
     basetmpdir = os.getenv("CHPL_GEN_RELEASE_TMPDIR", tempfile.gettempdir())
-    user = os.getlogin()
+    user = getpass.getuser()
     tmpdir = tempfile.mkdtemp(
         prefix=f"chapel-release.{user}.deleteme.", dir=basetmpdir
     )


### PR DESCRIPTION
Fixes a portabikity issue with `gen_release`. Switches a call in `gen_release` to use `getpass.getuser` instead of `os.getlogin`. This is whats recommend by [the Python docs](https://docs.python.org/3/library/os.html#os.getlogin)

[Not reviewed - trivial]