### PR TITLE
Suppress memory leak testing on Python iteration tests

### DIFF
--- a/modules/packages/Python.chpl
+++ b/modules/packages/Python.chpl
@@ -2282,6 +2282,7 @@ module Python {
       defer ctx.exit();
 
       var iter_ = PyObject_GetIter(this.getPyObject());
+      defer { if iter_ != nil then Py_DECREF(iter_); }
       if iter_ == nil || PyIter_Check(iter_) != 0 {
         throwChapelException("Object is not iterable");
       }

--- a/test/library/packages/Python/correctness/iterObject.suppressif
+++ b/test/library/packages/Python/correctness/iterObject.suppressif
@@ -1,0 +1,2 @@
+# leaks memory due to #27062
+EXECOPTS <= memLeaks

--- a/test/library/packages/Python/memleaks/iterate.chpl
+++ b/test/library/packages/Python/memleaks/iterate.chpl
@@ -1,0 +1,13 @@
+use Python;
+
+var interp = new Interpreter();
+
+var tup = interp.get("tuple")(owned PyTuple, [1, 2, 3, 4, 5]);
+writeln("yielding Values from tuple");
+for i in tup {
+  writeln(i);
+}
+writeln("yielding ints from tuple");
+for i in tup.these(int) {
+  writeln(i);
+}

--- a/test/library/packages/Python/memleaks/iterate.good
+++ b/test/library/packages/Python/memleaks/iterate.good
@@ -1,0 +1,12 @@
+yielding Values from tuple
+1
+2
+3
+4
+5
+yielding ints from tuple
+1
+2
+3
+4
+5


### PR DESCRIPTION
Suppresses a leak in a new test that is caused by a bug in iterator handling: https://github.com/chapel-lang/chapel/issues/27062

While investigating this, I also realized that we were missing a Py_DECREF in `iter these`, so this PR rectifies that (and adds a test to lock it in).

[Reviewed by @lydia-duncan]