### PR TITLE
Add a skipif for a test that requires iterator inlining

### DIFF
--- a/test/library/packages/Python/memleaks/iterate.skipif
+++ b/test/library/packages/Python/memleaks/iterate.skipif
@@ -1,0 +1,2 @@
+# requires iterator inlining
+COMPOPTS <= --baseline


### PR DESCRIPTION
Adds a skipif for a test that only works when iterator inlining is used, meaning `--baseline` testing cannot be run

[Not reviewed - trivial]