### PR TITLE
Improve errors for invalid files in Image module

### DIFF
--- a/modules/packages/Image.chpl
+++ b/modules/packages/Image.chpl
@@ -147,7 +147,7 @@ module Image {
       when imageType.png do PNGHelper.write(outfile, pixels);
       when imageType.jpg do JPGHelper.write(outfile, pixels);
       otherwise
-        throw new Error("Don't know how to write images of type: " + format:string);
+        throw new IllegalArgumentError("Don't know how to write images of type: " + format:string);
     }
   }
 
@@ -166,7 +166,7 @@ module Image {
       when imageType.png do return PNGHelper.read(infile);
       when imageType.jpg do return JPGHelper.read(infile);
       otherwise
-        throw new Error("Don't know how to read images of type: " + format:string);
+        throw new IllegalArgumentError("Don't know how to read images of type: " + format:string);
     }
   }
 

--- a/modules/packages/Image.chpl
+++ b/modules/packages/Image.chpl
@@ -147,7 +147,7 @@ module Image {
       when imageType.png do PNGHelper.write(outfile, pixels);
       when imageType.jpg do JPGHelper.write(outfile, pixels);
       otherwise
-        throw new Error("Don't know how to write images of type: ", format);
+        throw new Error("Don't know how to write images of type: " + format:string);
     }
   }
 
@@ -166,7 +166,7 @@ module Image {
       when imageType.png do return PNGHelper.read(infile);
       when imageType.jpg do return JPGHelper.read(infile);
       otherwise
-        throw new Error("Don't know how to read images of type: ", format);
+        throw new Error("Don't know how to read images of type: " + format:string);
     }
   }
 

--- a/modules/packages/Image.chpl
+++ b/modules/packages/Image.chpl
@@ -686,7 +686,8 @@ module Image {
 
     proc readPng(const ref infile: fileReader(?)) throws {
       const bytes_ = infile.readAll();
-      if bytes_.size >= 3 && bytes_[0..#3] != b"PNG" then
+      if bytes_.size >= 8 &&
+         bytes_[0..#8] != b"\x89\x50\x4E\x47\x0D\x0A\x1A\x0A" then
         throw new Error("Not a PNG file");
       return readCommon(bytes_);
     }

--- a/modules/packages/Image.chpl
+++ b/modules/packages/Image.chpl
@@ -686,6 +686,7 @@ module Image {
 
     proc readPng(const ref infile: fileReader(?)) throws {
       const bytes_ = infile.readAll();
+      // magic number: https://en.wikipedia.org/wiki/List_of_file_signatures
       if bytes_.size >= 8 &&
          bytes_[0..#8] != b"\x89\x50\x4E\x47\x0D\x0A\x1A\x0A" then
         throw new Error("Not a PNG file");
@@ -693,6 +694,7 @@ module Image {
     }
     proc readJpg(const ref infile: fileReader(?)) throws {
       const bytes_ = infile.readAll();
+      // magic number: https://en.wikipedia.org/wiki/List_of_file_signatures
       if bytes_.size >= 3 && bytes_[0..#3] != b"\xFF\xD8\xFF" then
         throw new Error("Not a JPG file");
       return readCommon(bytes_);

--- a/modules/packages/Image.chpl
+++ b/modules/packages/Image.chpl
@@ -147,7 +147,7 @@ module Image {
       when imageType.png do PNGHelper.write(outfile, pixels);
       when imageType.jpg do JPGHelper.write(outfile, pixels);
       otherwise
-        halt("Don't know how to write images of type: ", format);
+        throw new Error("Don't know how to write images of type: ", format);
     }
   }
 
@@ -166,7 +166,7 @@ module Image {
       when imageType.png do return PNGHelper.read(infile);
       when imageType.jpg do return JPGHelper.read(infile);
       otherwise
-        halt("Don't know how to read images of type: ", format);
+        throw new Error("Don't know how to read images of type: ", format);
     }
   }
 
@@ -626,9 +626,7 @@ module Image {
                                       req_comp: c_int): c_ptr(uint(8));
     private extern proc stbi_image_free(data: c_ptr(void)): void;
 
-    private proc readCommon(const ref infile: fileReader(?)) throws {
-      // read bytes in
-      const bytes_ = infile.readAll();
+    private proc readCommon(const ref bytes_: bytes) throws {
       const nBytes = bytes_.size.safeCast(c_int);
       const buffer = bytes_.c_str():c_ptrConst(void);
 
@@ -636,22 +634,22 @@ module Image {
       var x, y, comp: c_int;
       const ok = stbi_info_from_memory(buffer, nBytes, c_ptrTo(x), c_ptrTo(y), c_ptrTo(comp));
       if ok == 0 then
-        halt("Failed to read image info");
+        throw new Error("Failed to read image info");
 
       // check that the image is 3 channels and 8 bits per channel
       if comp != 3 && comp != 4 then
-        halt("Image must have 3 or 4 channels");
+        throw new Error("Image must have 3 or 4 channels");
 
       const is_16 = stbi_is_16_bit_from_memory(buffer, nBytes);
       if is_16 then
-        halt("Image must have 8 bits per channel");
+        throw new Error("Image must have 8 bits per channel");
 
 
       // read image
       var x_, y_, comp_: c_int;
       var data = stbi_load_from_memory(buffer, nBytes, c_ptrTo(x_), c_ptrTo(y_), c_ptrTo(comp_), 0);
       if data == nil then
-        halt("Failed to read image");
+        throw new Error("Failed to read image");
       assert(x_ == x && y_ == y && comp_ == comp);
       defer stbi_image_free(data);
 
@@ -687,10 +685,16 @@ module Image {
     }
 
     proc readPng(const ref infile: fileReader(?)) throws {
-      return readCommon(infile);
+      const bytes_ = infile.readAll();
+      if bytes_.size >= 3 && bytes_[0..#3] != b"PNG" then
+        throw new Error("Not a PNG file");
+      return readCommon(bytes_);
     }
     proc readJpg(const ref infile: fileReader(?)) throws {
-      return readCommon(infile);
+      const bytes_ = infile.readAll();
+      if bytes_.size >= 3 && bytes_[0..#3] != b"\xFF\xD8\xFF" then
+        throw new Error("Not a JPG file");
+      return readCommon(bytes_);
     }
 
   }

--- a/test/library/packages/Image/readWrongFormat.chpl
+++ b/test/library/packages/Image/readWrongFormat.chpl
@@ -66,4 +66,28 @@ proc main() {
   //   writeln("Error reading PNG as BMP: ", e.message());
   // }
 
+  // GOOD CASES
+  // try and read the JPG as a JPG
+  try {
+    readImage("pixels.jpg", imageType.jpg);
+    writeln("read JPG as JPG");
+  } catch e: Error {
+    writeln("Error reading JPG as JPG: ", e.message());
+  }
+  // try and read the PNG as a PNG
+  try {
+    readImage("pixels.png", imageType.png);
+    writeln("read PNG as PNG");
+  } catch e: Error {
+    writeln("Error reading PNG as PNG: ", e.message());
+  }
+   // TODO: BMP reading is not yet supported
+  // try and read the BMP as a BMP
+  // try {
+  //   readImage("pixels.bmp", imageType.bmp);
+  //   writeln("read BMP as BMP");
+  // } catch e: Error {
+  //   writeln("Error reading BMP as BMP: ", e.message());
+  // }
+
 }

--- a/test/library/packages/Image/readWrongFormat.chpl
+++ b/test/library/packages/Image/readWrongFormat.chpl
@@ -1,0 +1,69 @@
+use Image;
+use IO;
+
+
+proc main() {
+
+  var colors: [1..#3, 1..#3] 3*int;
+
+  colors[1, ..] = [(0xFF,0,0), (0,0xFF,0), (0,0,0xFF)];
+  colors[2, ..] = [(0,0xFF,0), (0,0,0xFF), (0xFF,0,0)];
+  colors[3, ..] = [(0,0,0xFF), (0xFF,0,0), (0,0xFF,0)];
+
+  var pixels = colorToPixel(colors, format=(rgbColor.blue, rgbColor.green, rgbColor.red));
+
+  writeImage("pixels.jpg", imageType.jpg, pixels);
+  writeImage("pixels.png", imageType.png, pixels);
+  writeImage("pixels.bmp", imageType.bmp, pixels);
+
+
+  // try and read the BMP as a JPG
+  try {
+    readImage("pixels.bmp", imageType.jpg);
+    writeln("read BMP as JPG");
+  } catch e: Error {
+    writeln("Error reading BMP as JPG: ", e.message());
+  }
+
+  // try and read the BMP as a PNG
+  try {
+    readImage("pixels.bmp", imageType.png);
+    writeln("read BMP as PNG");
+  } catch e: Error {
+    writeln("Error reading BMP as PNG: ", e.message());
+  }
+
+  // try and read the JPG as a PNG
+  try {
+    readImage("pixels.jpg", imageType.png);
+    writeln("read JPG as PNG");
+  } catch e: Error {
+    writeln("Error reading JPG as PNG: ", e.message());
+  }
+
+  // try and read the PNG as a JPG
+  try {
+    readImage("pixels.png", imageType.jpg);
+    writeln("read PNG as JPG");
+  } catch e: Error {
+    writeln("Error reading PNG as JPG: ", e.message());
+  }
+
+
+  // TODO: BMP reading is not yet supported
+  // try and read the JPG as a BMP
+  // try {
+  //   readImage("pixels.jpg", imageType.bmp);
+  //   writeln("read JPG as BMP");
+  // } catch e: Error {
+  //   writeln("Error reading JPG as BMP: ", e.message());
+  // }
+  // try and read the PNG as a BMP
+  // try {
+  //   readImage("pixels.png", imageType.bmp);
+  //   writeln("read PNG as BMP");
+  // } catch e: Error {
+  //   writeln("Error reading PNG as BMP: ", e.message());
+  // }
+
+}

--- a/test/library/packages/Image/readWrongFormat.cleanfiles
+++ b/test/library/packages/Image/readWrongFormat.cleanfiles
@@ -1,0 +1,3 @@
+pixels.jpg
+pixels.bmp
+pixels.png

--- a/test/library/packages/Image/readWrongFormat.good
+++ b/test/library/packages/Image/readWrongFormat.good
@@ -1,0 +1,4 @@
+Error reading BMP as JPG: Not a JPG file
+Error reading BMP as PNG: Not a PNG file
+Error reading JPG as PNG: Not a PNG file
+Error reading PNG as JPG: Not a JPG file

--- a/test/library/packages/Image/readWrongFormat.good
+++ b/test/library/packages/Image/readWrongFormat.good
@@ -2,3 +2,5 @@ Error reading BMP as JPG: Not a JPG file
 Error reading BMP as PNG: Not a PNG file
 Error reading JPG as PNG: Not a PNG file
 Error reading PNG as JPG: Not a JPG file
+read JPG as JPG
+read PNG as PNG

--- a/test/library/packages/Image/smallMovie.prediff
+++ b/test/library/packages/Image/smallMovie.prediff
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# remove all output before the seperator
+# remove all output before the separator
 sep=$(cat SEPARATOR.txt)
 sed "1,/$sep/d" $2 > $2.tmp
 mv $2.tmp $2


### PR DESCRIPTION
Improve the errors generated by the Image module when reading an incorrect/invalid file.

This PR also adjusts a few halts in throwing functions to throw catchable errors, rather halting.

- [x] `start_test test/library/packages/Image/`

[Reviewed by @ShreyasKhandekar]