### PR TITLE
Increase instantiation limit for Arkouda testing

### DIFF
--- a/util/cron/test-hpe-apollo-hdr.arkouda.bash
+++ b/util/cron/test-hpe-apollo-hdr.arkouda.bash
@@ -7,6 +7,7 @@ UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 export ARKOUDA_DEP_DIR=/hpelustre/chapelu/arkouda-deps
 export ARKOUDA_SKIP_CHECK_DEPS=true
 export CHPL_TEST_ARKOUDA_MULTI_DIM=true
+export CHPL_INSTANTIATION_LIMIT=1024 # This is needed for compiling multidim arkouda. See #27069
 
 export CHPL_TEST_ARKOUDA_PERF=false
 export ARKOUDA_DEVELOPER=true

--- a/util/cron/test-hpe-apollo-hdr.arkouda.release.bash
+++ b/util/cron/test-hpe-apollo-hdr.arkouda.release.bash
@@ -7,6 +7,7 @@ UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 export ARKOUDA_DEP_DIR=/hpelustre/chapelu/arkouda-deps
 export ARKOUDA_SKIP_CHECK_DEPS=true
 export CHPL_TEST_ARKOUDA_MULTI_DIM=true
+export CHPL_INSTANTIATION_LIMIT=1024 # This is needed for compiling multidim arkouda. See #27069
 
 export CHPL_TEST_ARKOUDA_PERF=false
 export ARKOUDA_DEVELOPER=true


### PR DESCRIPTION
Adjust the instantiation limit to 1024 to resolve compilation issues when testing Arkouda with multiple dimensions, as described in issue https://github.com/Bears-R-Us/arkouda/issues/4227