### PR TITLE
Add support for `noinit` remote variables.

### DIFF
--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -2298,7 +2298,7 @@ struct Converter final : UastConverter {
     // Field multi-decl desugaring happens later in build.cpp and produces
     // different code; don't do redundant work here.
     bool isField = parsing::idIsField(context, node->id());
-    if (!isField) {
+    if (isField) {
       // post-parse checks should rule this out
       CHPL_ASSERT(!node->destination());
     }

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -3523,8 +3523,9 @@ struct Converter final : UastConverter {
       if (auto prevInitExpr = multiState->prevInitExpr) {
         Expr* replaceWith;
         if (prevInitExpr->isNoInitExpr()) {
-          // for remote variables, don't persist 'noinit', since we just
-          // select a different overload of buildRemoteWrapper.
+          // for remote variables, don't bother trying to replace 'noinit',
+          // since we already threw it away and selected a different overload of
+          // buildRemoteWrapper.
           replaceWith = isRemote ? nullptr : prevInitExpr->copy();
         } else if (typeExpr) {
           replaceWith = new CallExpr("chpl__readXX", new SymExpr(varSym));

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -3551,7 +3551,14 @@ struct Converter final : UastConverter {
       wrapperCall->insertAtTail(destinationExpr ? destinationExpr : new SymExpr(multiState->localeTemp));
 
       if (typeExpr) wrapperCall->insertAtTail(typeExpr);
-      if (initExpr) wrapperCall->insertAtTail(new CallExpr(PRIM_CREATE_THUNK, initExpr));
+      if (initExpr) {
+        SymExpr* initSe;
+        if ((initSe = toSymExpr(initExpr)) && initSe->symbol() == gNoInit) {
+          wrapperCall->insertAtTail(new SymExpr(dtVoid->symbol));
+        } else {
+          wrapperCall->insertAtTail(new CallExpr(PRIM_CREATE_THUNK, initExpr));
+        }
+      }
       auto wrapperDef = new DefExpr(wrapper, wrapperCall);
 
       auto wrapperGet = new CallExpr(".", new SymExpr(wrapper), new_CStringSymbol("get"));

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -3348,7 +3348,11 @@ struct Converter final : UastConverter {
 
     void replaceInitExpr(Expr* newExpr) {
       if (localeTemp) {
-        prevInitExpr->replace(newExpr);
+        // could not be in tree if we decided to choose a different overload
+        // for remote variable construction (e.g., a noinit version).
+        if (prevInitExpr->inTree()) {
+          prevInitExpr->replace(newExpr);
+        }
       } else {
         prev->defPoint->init = newExpr;
       }
@@ -3552,8 +3556,7 @@ struct Converter final : UastConverter {
 
       if (typeExpr) wrapperCall->insertAtTail(typeExpr);
       if (initExpr) {
-        SymExpr* initSe;
-        if ((initSe = toSymExpr(initExpr)) && initSe->symbol() == gNoInit) {
+        if (initExpr->isNoInitExpr()) {
           wrapperCall->insertAtTail(new SymExpr(dtVoid->symbol));
         } else {
           wrapperCall->insertAtTail(new CallExpr(PRIM_CREATE_THUNK, initExpr));

--- a/modules/internal/ChapelRemoteVars.chpl
+++ b/modules/internal/ChapelRemoteVars.chpl
@@ -25,13 +25,9 @@ module ChapelRemoteVars {
   class _remoteVarContainer {
     var containedValue;
 
-    proc init(in containedValue) {
-      this.containedValue = containedValue;
-    }
-
-    proc init(type containedValueType) {
+    proc type _noinit(type containedValueType) {
       var tmp: containedValueType = noinit;
-      this.containedValue = tmp;
+      return new _remoteVarContainer(tmp);
     }
   }
 
@@ -93,7 +89,7 @@ module ChapelRemoteVars {
     // We use a specific overload of the _remoteVarContainer constructor
     // which accepts a type and uses noinit.
     var c: owned _remoteVarContainer(inType)?;
-    on loc do c = new _remoteVarContainer(inType);
+    on loc do c = _remoteVarContainer._noinit(inType);
     return new _remoteVarWrapper(try! c : owned _remoteVarContainer(inType));
   }
 

--- a/modules/internal/ChapelRemoteVars.chpl
+++ b/modules/internal/ChapelRemoteVars.chpl
@@ -24,6 +24,15 @@ module ChapelRemoteVars {
 
   class _remoteVarContainer {
     var containedValue;
+
+    proc init(containedValue) {
+      this.containedValue = containedValue;
+    }
+
+    proc init(type containedValueType) {
+      var tmp: containedValueType = noinit;
+      this.containedValue = tmp;
+    }
   }
 
   record _remoteVarWrapper {
@@ -75,6 +84,16 @@ module ChapelRemoteVars {
     type inType = thunkToReturnType(tr.type);
     var c: owned _remoteVarContainer(inType)?;
     on loc do c = new _remoteVarContainer(__primitive("force thunk", tr));
+    return new _remoteVarWrapper(try! c : owned _remoteVarContainer(inType));
+  }
+
+  @unstable("remote variables are unstable")
+  inline proc chpl__buildRemoteWrapper(const ref loc, type inType, type noinitMarker) where noinitMarker == void {
+    // This is a special case to create a noinit remote variable.
+    // We use a specific overload of the _remoteVarContainer constructor
+    // which accepts a type and uses noinit.
+    var c: owned _remoteVarContainer(inType)?;
+    on loc do c = new _remoteVarContainer(inType);
     return new _remoteVarWrapper(try! c : owned _remoteVarContainer(inType));
   }
 

--- a/modules/internal/ChapelRemoteVars.chpl
+++ b/modules/internal/ChapelRemoteVars.chpl
@@ -25,7 +25,7 @@ module ChapelRemoteVars {
   class _remoteVarContainer {
     var containedValue;
 
-    proc init(containedValue) {
+    proc init(in containedValue) {
       this.containedValue = containedValue;
     }
 

--- a/test/variables/remote/noinit-vars.chpl
+++ b/test/variables/remote/noinit-vars.chpl
@@ -1,0 +1,15 @@
+record R {
+  proc init() {
+    writeln("R.init");
+  }
+}
+
+writeln("yesinit");
+on here.gpus[0] var A: [0..0] R;
+writeln("noinit");
+on here.gpus[0] var B: [0..0] R = noinit;
+
+writeln("yesinit");
+on here.gpus[0] var C, D: [0..0] R;
+writeln("noinit");
+on here.gpus[0] var E, F: [0..0] R = noinit;

--- a/test/variables/remote/noinit-vars.chpl
+++ b/test/variables/remote/noinit-vars.chpl
@@ -5,11 +5,11 @@ record R {
 }
 
 writeln("yesinit");
-on here.gpus[0] var A: [0..0] R;
+on Locales[0] var A: [0..0] R;
 writeln("noinit");
-on here.gpus[0] var B: [0..0] R = noinit;
+on Locales[0] var B: [0..0] R = noinit;
 
 writeln("yesinit");
-on here.gpus[0] var C, D: [0..0] R;
+on Locales[0] var C, D: [0..0] R;
 writeln("noinit");
-on here.gpus[0] var E, F: [0..0] R = noinit;
+on Locales[0] var E, F: [0..0] R = noinit;

--- a/test/variables/remote/noinit-vars.good
+++ b/test/variables/remote/noinit-vars.good
@@ -1,0 +1,7 @@
+yesinit
+R.init
+noinit
+yesinit
+R.init
+R.init
+noinit


### PR DESCRIPTION
Closes https://github.com/chapel-lang/chapel/issues/27068.

This PR adds support for `noinit` remote variables. There was previously no support for them, though I hadn't considered that case and as a consequence hadn't documented them. To support them, a degree of special-casing is required (an `x = noinit` expression is specially treated, and we rewrite initialization expressions for remote variables).

On the technical side, this PR adds a new overload to the remote variable builder. This overload is distinguished from others by a dummy `type` formal which is expected always to be `void` (inspired by the type of the `noinit` global variable). This overload simply constructs a remote variable wrapper with a `noinit`'ed temporary.

While there, I noticed that an assertion was incorrectly flipped in the body of the code. This assertion was for a case ruled out by post-parse checks; in developer builds, it ought to always fire. However, I suspect it didn't cause any problems because assertions are disabled in release mode. I flipped the assertion to its correct value.

Reviewed by @lydia-duncan -- thanks!

## Testing
- [x] paratest
- [x] `test/variables/remote`