### PR TITLE
Use correct launcher with gasnet nightly tests

### DIFF
--- a/util/cron/test-gasnet.darwin.bash
+++ b/util/cron/test-gasnet.darwin.bash
@@ -6,6 +6,7 @@ UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common-gasnet.bash
 source $UTIL_CRON_DIR/common-darwin.bash
 source $UTIL_CRON_DIR/common-localnode-paratest.bash
+unset CHPL_LAUNCHER
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gasnet.darwin"
 

--- a/util/cron/test-gasnet.fast.darwin.bash
+++ b/util/cron/test-gasnet.fast.darwin.bash
@@ -7,6 +7,7 @@ source $UTIL_CRON_DIR/common-gasnet.bash
 export CHPL_GASNET_SEGMENT=fast
 source $UTIL_CRON_DIR/common-darwin.bash
 source $UTIL_CRON_DIR/common-localnode-paratest.bash
+unset CHPL_LAUNCHER
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gasnet.fast.darwin"
 


### PR DESCRIPTION
Fixes two nightly configs that have the incorrect launcher after https://github.com/chapel-lang/chapel/pull/26236. These configs should default to using the GASNet launcher, not a slurm one

[Not reviewed - trivial]