### PR TITLE
Dyno: cache function signature instantiations, reduce cache impact of some queries

### DIFF
--- a/frontend/include/chpl/resolution/resolution-queries.h
+++ b/frontend/include/chpl/resolution/resolution-queries.h
@@ -365,6 +365,14 @@ types::QualifiedType yieldType(ResolutionContext* rc,
                                const TypedFnSignature* sig,
                                const PoiScope* poiScope);
 
+/* Returns a pair of (yieldType(), returnType()) for the function.
+   These can differ if the function has ITER kind, which may
+   have an 'int' return type but creates an iterable yielding 'int' when called. */
+const std::pair<types::QualifiedType, types::QualifiedType>&
+returnTypes(ResolutionContext* rc,
+            const TypedFnSignature* sig,
+            const PoiScope* poiScope);
+
 /**
   Compute the types for any generic 'out' formal types after instantiation
   of any other generic arguments.

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -561,6 +561,9 @@ class CallInfo {
  public:
   using CallInfoActualIterable = Iterable<std::vector<CallInfoActual>>;
 
+  /** default constructor for the query system */
+  CallInfo() : name_(), calledType_() {}
+
   /** Construct a CallInfo that contains QualifiedTypes for actuals */
   CallInfo(UniqueString name, types::QualifiedType calledType,
            bool isMethodCall,
@@ -731,6 +734,20 @@ class CallInfo {
     return chpl::hash(name_, calledType_, isMethodCall_, isOpCall_,
                       hasQuestionArg_, isParenless_,
                       actuals_);
+  }
+  static bool update(CallInfo& keep,
+                     CallInfo& addin) {
+    return defaultUpdate(keep, addin);
+  }
+
+  void swap(CallInfo& other) {
+    std::swap(name_, other.name_);
+    std::swap(calledType_, other.calledType_);
+    std::swap(isMethodCall_, other.isMethodCall_);
+    std::swap(isOpCall_, other.isOpCall_);
+    std::swap(hasQuestionArg_, other.hasQuestionArg_);
+    std::swap(isParenless_, other.isParenless_);
+    actuals_.swap(other.actuals_);
   }
 
   void stringify(std::ostream& ss, chpl::StringifyKind stringKind) const;

--- a/frontend/include/chpl/util/assertions.h
+++ b/frontend/include/chpl/util/assertions.h
@@ -44,7 +44,8 @@ void chpl_unimpl(const char* filename, const char* func, int lineno,
 #define CHPL_ASSERT(expr__) \
   do { \
     if constexpr (false) { \
-      std::ignore = expr__; \
+      auto res = expr__; \
+      (void) res; \
     } \
   } while (0)
 

--- a/frontend/include/chpl/util/assertions.h
+++ b/frontend/include/chpl/util/assertions.h
@@ -42,10 +42,7 @@ void chpl_unimpl(const char* filename, const char* func, int lineno,
 #ifdef NDEBUG
 // release mode
 #define CHPL_ASSERT(expr__) \
-  do { \
-    bool ignore = expr__; \
-    (void) ignore; \
-   } while (0)
+  do {} while (0)
 
 #else
 // debug mode

--- a/frontend/include/chpl/util/assertions.h
+++ b/frontend/include/chpl/util/assertions.h
@@ -42,7 +42,11 @@ void chpl_unimpl(const char* filename, const char* func, int lineno,
 #ifdef NDEBUG
 // release mode
 #define CHPL_ASSERT(expr__) \
-  do {} while (0)
+  do { \
+    if constexpr (false) { \
+      std::ignore = expr__; \
+    } \
+  } while (0)
 
 #else
 // debug mode

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2160,10 +2160,11 @@ static bool instantiateAcrossManagerRecordConversion(Context* context,
 
 // TODO: We could remove the 'ResolutionContext' argument if we figure out
 // a different way/decide not to resolve initializer bodies down below.
-ApplicabilityResult instantiateSignature(ResolutionContext* rc,
-                                         const TypedFnSignature* sig,
-                                         const CallInfo& call,
-                                         const PoiScope* poiScope) {
+static ApplicabilityResult
+instantiateSignatureImpl(ResolutionContext* rc,
+                         const TypedFnSignature* sig,
+                         const CallInfo& call,
+                         const PoiScope* poiScope) {
   // Performance: Should this query use a similar approach to
   // resolveFunctionByInfoQuery, where the PoiInfo and visibility
   // are consulted?
@@ -2634,6 +2635,23 @@ ApplicabilityResult instantiateSignature(ResolutionContext* rc,
   // Body resolution will be done by MostSpecificCandidate when constructed.
 
   return ApplicabilityResult::success(result);
+}
+
+static ApplicabilityResult const&
+instantiateSignatureQuery(ResolutionContext* rc,
+                          const TypedFnSignature* sig,
+                          const CallInfo& call,
+                          const PoiScope* poiScope) {
+  CHPL_RESOLUTION_QUERY_BEGIN(instantiateSignatureQuery, rc, sig, call, poiScope);
+  auto ret = instantiateSignatureImpl(rc, sig, call, poiScope);
+  return CHPL_RESOLUTION_QUERY_END(ret);
+}
+
+ApplicabilityResult instantiateSignature(ResolutionContext* rc,
+                                         const TypedFnSignature* sig,
+                                         const CallInfo& call,
+                                         const PoiScope* poiScope) {
+  return instantiateSignatureQuery(rc, sig, call, poiScope);
 }
 
 // This implements the body of 'resolveFunctionByInfo'. It returns a new

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -5270,7 +5270,8 @@ resolutionResultFromMostSpecificCandidate(ResolutionContext* rc,
   QualifiedType exprType;
   QualifiedType yieldedType;
   if (msc.fn()) {
-    exprType = returnType(rc, msc.fn(), instantiationPoiScope);
+    auto& yieldAndRet = returnTypes(rc, msc.fn(), instantiationPoiScope);
+    exprType = yieldAndRet.second;
 
     if (!msc.promotedFormals().empty()) {
       yieldedType = exprType;
@@ -5283,7 +5284,7 @@ resolutionResultFromMostSpecificCandidate(ResolutionContext* rc,
     }
 
     if (msc.fn()->isIterator() && yieldedType.isUnknown()) {
-      yieldedType = yieldType(rc, msc.fn(), instantiationPoiScope);
+      yieldedType = yieldAndRet.first;
     }
   }
 
@@ -5391,56 +5392,57 @@ resolveFnCall(ResolutionContext* rc,
   optional<QualifiedType> retType;
   optional<QualifiedType> yieldedType;
   for (const MostSpecificCandidate& candidate : mostSpecific) {
-    if (candidate.fn() != nullptr) {
-      bool isIterator = candidate.fn()->isIterator();
+    if (candidate.fn() == nullptr) continue;
 
-      QualifiedType rt;
-      // TODO: Ideally we'd refactor things such that we instantiate some kind
-      // of hidden argument to these functions that is then returned. Alas, we
-      // still need this stuff to work with production, so we create this hack.
-      if (handleReflectionFunction(rc, candidate.fn(), call, rt)) {
-        CHPL_ASSERT(rt.isParam() && rt.hasParamPtr());
-      } else {
-        rt = returnType(rc, candidate.fn(),
-                        instantiationPoiScope);
+    QualifiedType rt;
+    if (handleReflectionFunction(rc, candidate.fn(), call, rt)) {
+      CHPL_ASSERT(rt.isParam() && rt.hasParamPtr());
+      CHPL_ASSERT(mostSpecific.numBest() == 1);
+      CHPL_ASSERT(candidate.fn()->numFormals() == 0);
+      retType = rt;
+      break;
+    }
+
+    bool isIterator = candidate.fn()->isIterator();
+    auto& yieldAndRet =
+      returnTypes(rc, candidate.fn(), instantiationPoiScope);
+    rt = yieldAndRet.second;
+
+    QualifiedType yt;
+
+    if (!candidate.promotedFormals().empty()) {
+      // this is actually a promotion; construct a promotion type instead.
+      yt = rt;
+      rt = QualifiedType(rt.kind(), PromotionIteratorType::get(context, instantiationPoiScope, candidate.fn(), candidate.promotedFormals()));
+    }
+
+    if (retType && retType->type() != rt.type()) {
+      // The actual iterator type for each overload will be different
+      // since it includes the TypedFnSignature, and different overloads
+      // are different TypedFnSignatures. Don't error, though.
+      //
+      // TODO: how do iterators + iterator groups work with return intent
+      // overloading?
+      if (!isIterator) {
+        context->error(candidate.fn(),
+                       nullptr,
+                       "return intent overload type does not match");
+      }
+    } else if (!retType) {
+      retType = rt;
+    }
+
+    if (isIterator || !yt.isUnknown()) {
+      if (yt.isUnknown()) {
+        yt = yieldAndRet.first;
       }
 
-      QualifiedType yt;
-
-      if (!candidate.promotedFormals().empty()) {
-        // this is actually a promotion; construct a promotion type instead.
-        yt = rt;
-        rt = QualifiedType(rt.kind(), PromotionIteratorType::get(context, instantiationPoiScope, candidate.fn(), candidate.promotedFormals()));
-      }
-
-      if (retType && retType->type() != rt.type()) {
-        // The actual iterator type for each overload will be different
-        // since it includes the TypedFnSignature, and different overloads
-        // are different TypedFnSignatures. Don't error, though.
-        //
-        // TODO: how do iterators + iterator groups work with return intent
-        // overloading?
-        if (!isIterator) {
-          context->error(candidate.fn(),
-                         nullptr,
-                         "return intent overload type does not match");
-        }
-      } else if (!retType) {
-        retType = rt;
-      }
-
-      if (isIterator || !yt.isUnknown()) {
-        if (yt.isUnknown()) {
-          yt = yieldType(rc, candidate.fn(), instantiationPoiScope);
-        }
-
-        if (yieldedType && yieldedType->type() != yt.type()) {
-          context->error(candidate.fn(),
-                         nullptr,
-                         "return intent overload type does not match");
-        } else if (!yieldedType) {
-          yieldedType = yt;
-        }
+      if (yieldedType && yieldedType->type() != yt.type()) {
+        context->error(candidate.fn(),
+                       nullptr,
+                       "return intent overload type does not match");
+      } else if (!yieldedType) {
+        yieldedType = yt;
       }
     }
   }

--- a/frontend/lib/types/Param.cpp
+++ b/frontend/lib/types/Param.cpp
@@ -624,13 +624,26 @@ QualifiedType Param::fold(Context* context,
 
 void Param::stringify(std::ostream& ss, chpl::StringifyKind stringKind) const {
 
+  // for debug output, remove newlines so that we don't break output
+  // that expects to be printed on a single line.
+  auto cleanStr = [stringKind](std::string& toClean) {
+    if (stringKind != CHPL_SYNTAX) {
+      std::string::size_type pos = 0;
+      while ((pos = toClean.find('\n', pos)) != std::string::npos) {
+        toClean.replace(pos, 1, "\\n");
+        pos += 2;
+      }
+    }
+    return toClean;
+  };
 
   switch (tag_) {
 #define PARAM_NODE(NAME, VALTYPE) \
     case paramtags::NAME: { \
       const NAME* casted = (const NAME*) this; \
       auto value = casted->value(); \
-      ss << Param::valueToString(value); \
+      std::string valueStr = Param::valueToString(value); \
+      ss << cleanStr(valueStr); \
       break; \
     }
 // Apply the above macros to param-classes-list.h


### PR DESCRIPTION
This PR aims to further improve Dyno's resolution performance.

I started by looking at the number of queries we call, in hopes that we can reduce the number of invocations to them. In the past, `idToAst` has been one of Dyno's hottest queries, and this remains to be the case. However, unlike previous times, I found no opportunities to elide calls to this function. Instead, I took the following steps to reduce the amount of work done by Dyno:

* I determined that `scopeForId` and its recursive self-invocations make up the bulk of calls to `idToAst`. I found no ways to reduce uses of `idToAst` in `scopeForId`, but I did find a way to reduce the number of `scopeForId` invocations. It turns out that code `GatherMentionedModules` runs `scopeForId` for every identifier, which invokes `scopeForId`. Many identifiers share scopes (they don't create their own ones!), so this causes redundant cache entries. Instead, this PR adjusts `GatherMentionedModules` to match other visitors (e.g., `Resolver`) and push scopes when a scope-creating AST node is entered. This actually increased the number of calls to `scopeForId`, because not all scopes have identifiers. I thus further tweaked this to lazily invoke `scopeForId` when it's needed. This didn't have a noticeable runtime performance, but it did reduce the number of queries executed by a large number.
* I observed that the `returnType()` query always invokes `returnTypeWithoutIterable` (aka `yieldType()`). As a result, there is always an equal number of cache entries for these two. Moreover, several places in the resolver use both queries, which means double the lookups. I fused the two queries into a single, tuple-returning query. This halves the number of storage entries required for computing the return type, and, where applicable, also halves the number of query cache lookups. I didn't measure any performance impact in release mode, but it did reduce the number of queries executed.

When I was debugging the above, I noticed issues with output as part of `--dyno-enable-tracing` caused by newlines in `param` strings. I adjusted the DETAIL logging of these strings to escape newlines so that tracing output is unaffected.

After this, I turned back to profiler output. I noticed that `saveDependencyInParent` contributes a large amount of overhead. I also noticed some oddities in debug mode profiles: creating the start end end iterators for the recursion error set was taking a significant amount of time. There ought not be recursion errors at all! I guarded the recursion error insertion (which creates these iterators) behind a size check, and made other similar changes. This reduced the runtime overhead of `saveDependencyInParent` by 0.5 seconds in the debug build, but the change is within noise in release mode.

I also noticed that `CHPL_ASSERT` seems to execute its body in release mode. After checking with @arezaii, @dlongnecke-cray, and @mppf, it seems like there's no reason to do so in release. This PR removes that.

Finally, following @benharsh's suggestion to investigate re-traversals, I discovered that the generated formals for the `_range` constructor were being re-traversed thousands of times. This was because calls to `instantiateSignature` were not cached, which meant that each invocation of a generic constructor triggered re-resolution. I turned `instantiateSignature` into a query, winning roughly 10% in terms of performance on my benchmark (still the sample program from https://github.com/Cray/chapel-private/issues/7139): ~3.5 seconds -> ~3.15 seconds. This narrows the gap between Dyno and production on this benchmark to ~20%. 

Encouragingly, I'm seeing Dyno reach comparable performance while resolving other benchmarks. Comparing invocations of `--dyno-resolve-only` and `--stop-after-pass=resolve`, I saw the following results:

|                          | Time (Dyno `main`) | Time (Dyno, this PR) | Time (Production)  | Relative Time (Dyno, this PR vs Production, lower is better) |
|--------------------------|--------------------|----------------------|--------------------|--------------------------------------------------------------|
| Issue 7139 (Motivator)   | 3.497 s ±  0.079 s | 3.140 s ±  0.034 s   | 2.545 s ±  0.038 s | 1.23 ± 0.02                                                  |
| `parIters.chpl` primer   | 2.483 s ±  0.072 s | 2.372 s ±  0.029 s   | 2.314 s ±  0.023 s | 1.02 ± 0.02                                                  |
| `atomics.chpl` primer    | 2.314 s ±  0.028 s | 2.177 s ±  0.038 s   | 2.277 s ±  0.040 s | 0.95 ± 0.03                                                  |
| `forallLoops.chp` primer | 2.571 s ±  0.037 s | 2.468 s ±  0.032 s   | 2.358 s ±  0.041 s | 1.05 ± 0.02                                                  |

Reviewed by @benharsh -- thanks!

# Testing
- [x] dyno tests
- [x] paratest