### PR TITLE
Fix Python module portability issues, especially on linux 32

### DIFF
--- a/modules/packages/Python.chpl
+++ b/modules/packages/Python.chpl
@@ -3209,7 +3209,8 @@ module Python {
           throw new ChapelException("Index out of bounds");
         }
 
-      var ptr_ = (this.view.buf:c_intptr + offset): c_ptr(void): c_ptr(eltType);
+      var ptr_ =
+        (this.view.buf:c_intptr + offset:c_intptr): c_ptr(void): c_ptr(eltType);
       return ptr_.deref();
     }
 

--- a/test/library/packages/Python/correctness/arrays/memoryView.chpl
+++ b/test/library/packages/Python/correctness/arrays/memoryView.chpl
@@ -71,13 +71,9 @@ proc main() {
     var lst = memView.call(owned PyList, 'tolist');
     writeln("tolist: ", lst);
 
-    var pyArray = interp.fromPython(
-      owned PyArray(real(32), 3),
-      arrRef.getPyObject()
-    );
+    var pyArray = arrRef.value(owned PyArray(real(32), 3));
     var result = pyArray.these();
     writeln("Round tripped array:\n", result);
-
   }
 
 }

--- a/test/library/packages/Python/correctness/arrays/ndArrayMemoryView.chpl
+++ b/test/library/packages/Python/correctness/arrays/ndArrayMemoryView.chpl
@@ -18,9 +18,7 @@ writeln(memview.get('strides'));
 writeln(memview.get('ndim'));
 try {
   var pyArr = new PyArray(real, 2, interp, buf.getPyObject(), isOwned=false);
-} catch e: BufferError {
-  writeln(e);
+} catch e {
+  writeln(e.message());
   writeln("This is expected because the buffer is not writable");
-} catch {
-  writeln("Unexpected error");
 }

--- a/test/library/packages/Python/correctness/arrays/ndArrayMemoryView.good
+++ b/test/library/packages/Python/correctness/arrays/ndArrayMemoryView.good
@@ -1,5 +1,5 @@
 (3, 4)
 (32, 8)
 2
-BufferError: Object is not writable.
+Object is not writable.
 This is expected because the buffer is not writable

--- a/test/library/packages/Python/correctness/arrays/usePythonArray.chpl
+++ b/test/library/packages/Python/correctness/arrays/usePythonArray.chpl
@@ -1,4 +1,4 @@
-use Python;
+use Python, CTypes;
 
 proc main() {
   var interp = new Interpreter();
@@ -6,7 +6,7 @@ proc main() {
   var doit = mod.get('doit');
 
 
-  var pyRes = doit(owned PyArray(int, 1), 10, 11, 12, 13);
+  var pyRes = doit(owned PyArray(c_long, 1), 10, 11, 12, 13);
   var res = pyRes.array();
   write("arr: ", res);
   write(" dom: ", res.domain);

--- a/test/library/packages/Python/correctness/arrays/usePythonArray.execopts
+++ b/test/library/packages/Python/correctness/arrays/usePythonArray.execopts
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if [[ "$CHPL_TARGET_PLATFORM" == "linux32" ]]; then
+  echo " # usePythonArray.linux32.good"
+else
+  echo " # usePythonArray.good"
+fi

--- a/test/library/packages/Python/correctness/arrays/usePythonArray.linux32.good
+++ b/test/library/packages/Python/correctness/arrays/usePythonArray.linux32.good
@@ -1,0 +1,1 @@
+arr: 10 11 12 13 dom: {0..3} eltType: int(32)

--- a/util/config/embed-python.sh
+++ b/util/config/embed-python.sh
@@ -17,6 +17,6 @@ PYTHON_LDVERSION=$($chpl_python -c "import sysconfig; print(sysconfig.get_config
 DISABLE_WARNINGS=""
 # some older python's don't use `#ifndef` when they should
 # so we disable redefinition warnings for clean testing
-DISABLE_WARNINGS+="--ccflags -Wno-macro-redefined"
+DISABLE_WARNINGS="$DISABLE_WARNINGS --ccflags -Wno-macro-redefined"
 
 echo "--ccflags -isystem$PYTHON_INCLUDE_DIR -L$PYTHON_LIB_DIR --ldflags -Wl,-rpath,$PYTHON_LIB_DIR -lpython$PYTHON_LDVERSION $DISABLE_WARNINGS"


### PR DESCRIPTION
Fixes a number of portability issues nightly testing revealed, especially on linux 32. However, some issues are also caused by different versions of Python.

- [x] `start_test test/library/packages/Python/correctness/arrays/` on MacOS with Python 3.13
- [x] `start_test test/library/packages/Python/correctness/arrays/` on linux32 with Python 3.11

[Reviewed by @lydia-duncan]

