### PR TITLE
Add skipifs for baseline testing for tests with throwing iterators

### DIFF
--- a/test/library/packages/Python/correctness/arrays/arrayTypes.skipif
+++ b/test/library/packages/Python/correctness/arrays/arrayTypes.skipif
@@ -1,2 +1,4 @@
 COMPOPTS <= --no-checks
 COMPOPTS <= --fast
+# requires iterator inlining
+COMPOPTS <= --baseline

--- a/test/library/packages/Python/correctness/arrays/memoryView.skipif
+++ b/test/library/packages/Python/correctness/arrays/memoryView.skipif
@@ -1,4 +1,2 @@
-COMPOPTS <= --no-checks
-COMPOPTS <= --fast
 # requires iterator inlining
 COMPOPTS <= --baseline


### PR DESCRIPTION
Skips baseline testing for a few tests that exercise throwing iterators, which is not supported by `--baseline`.

[Not reviewed - trivial]