### PR TITLE
Remove non-portable test for Python module

### DIFF
--- a/test/library/packages/Python/correctness/arrays/arrayTypes.chpl
+++ b/test/library/packages/Python/correctness/arrays/arrayTypes.chpl
@@ -116,7 +116,6 @@ proc main() {
     writeln("Chapel array: ", chplArray2);
   }
   testNumpy(bool, 'bool', true, false);
-  testNumpy(c_char, 'byte', 0x60, 0x61, 0x62);
   testNumpy(c_schar, 'byte', -1, -2, -3);
   testNumpy(c_uchar, 'ubyte', 1, 2, 3);
   testNumpy(c_short, 'short', -1, -2, -3);

--- a/test/library/packages/Python/correctness/arrays/arrayTypes.good
+++ b/test/library/packages/Python/correctness/arrays/arrayTypes.good
@@ -49,16 +49,6 @@ Python array: [[ True]
 Chapel array: true
 false
 Testing numpy type (1d array): np.byte
-Python array: [96 97 98]
-Chapel array: 96 97 98
-Testing numpy type (nd array): np.byte
-Python array: [[96]
- [97]
- [98]]
-Chapel array: 96
-97
-98
-Testing numpy type (1d array): np.byte
 Python array: [-1 -2 -3]
 Chapel array: -1 -2 -3
 Testing numpy type (nd array): np.byte


### PR DESCRIPTION
Removes one test case for the Python module, because its not portable and not that useful to test.

Since the sign of `char` is implementation defined, comparing it against a signed byte may not work on some platforms

[Reviewed by @lydia-duncan]
