### PR TITLE
Add a missing skipif for test that requires iterator inlining

### DIFF
--- a/test/library/packages/Python/correctness/arrays/ndArray.skipif
+++ b/test/library/packages/Python/correctness/arrays/ndArray.skipif
@@ -1,0 +1,2 @@
+# requires iterator inlining
+COMPOPTS <= --baseline


### PR DESCRIPTION
Adds a missing skipif for test that requires iterator inlining

[Not reviewed - trivial]