### PR TITLE
Add native support for Python operators via Chapel operator overload 

### DIFF
--- a/modules/packages/Python.chpl
+++ b/modules/packages/Python.chpl
@@ -3718,88 +3718,110 @@ module Python {
       res = rhs.call(PyObjectPtr, "__radd__", lhs);
     return new Value(lhs.interpreter, res, isOwned=true);
   }
-  operator+=(ref lhs: owned Value, rhs: borrowed Value?) throws do
+  operator+=(ref lhs: owned Value, rhs: borrowed Value) throws do
     lhs.call("__iadd__", rhs);
+  operator+=(ref lhs: owned Value, ref rhs: Value) throws do
+    lhs += rhs.borrow();
   operator-(lhs: borrowed Value, rhs: borrowed Value): owned Value throws {
     var res = lhs.call(PyObjectPtr, "__sub__", rhs);
     if res == Py_NotImplemented then
       res = rhs.call(PyObjectPtr, "__rsub__", lhs);
     return new Value(lhs.interpreter, res, isOwned=true);
   }
-  operator-=(ref lhs: owned Value, rhs: borrowed Value?) throws do
+  operator-=(ref lhs: owned Value, rhs: borrowed Value) throws do
     lhs.call("__isub__", rhs);
+  operator-=(ref lhs: owned Value, ref rhs: Value) throws do
+    lhs -= rhs.borrow();
   operator*(lhs: borrowed Value, rhs: borrowed Value): owned Value throws {
     var res = lhs.call(PyObjectPtr, "__mul__", rhs);
     if res == Py_NotImplemented then
       res = rhs.call(PyObjectPtr, "__rmul__", lhs);
     return new Value(lhs.interpreter, res, isOwned=true);
   }
-  operator*=(ref lhs: owned Value, rhs: borrowed Value?) throws do
+  operator*=(ref lhs: owned Value, rhs: borrowed Value) throws do
     lhs.call("__imul__", rhs);
+  operator*=(ref lhs: owned Value, ref rhs: Value) throws do
+    lhs *= rhs.borrow();
   operator/(lhs: borrowed Value, rhs: borrowed Value): owned Value throws {
     var res = lhs.call(PyObjectPtr, "__truediv__", rhs);
     if res == Py_NotImplemented then
       res = rhs.call(PyObjectPtr, "__rtruediv__", lhs);
     return new Value(lhs.interpreter, res, isOwned=true);
   }
-  operator/=(ref lhs: owned Value, rhs: borrowed Value?) throws do
+  operator/=(ref lhs: owned Value, rhs: borrowed Value) throws do
     lhs.call("__itruediv__", rhs);
+  operator/=(ref lhs: owned Value, ref rhs: Value) throws do
+    lhs /= rhs.borrow();
   operator%(lhs: borrowed Value, rhs: borrowed Value): owned Value throws {
     var res = lhs.call(PyObjectPtr, "__mod__", rhs);
     if res == Py_NotImplemented then
       res = rhs.call(PyObjectPtr, "__rmod__", lhs);
     return new Value(lhs.interpreter, res, isOwned=true);
   }
-  operator%=(ref lhs: owned Value, rhs: borrowed Value?) throws do
+  operator%=(ref lhs: owned Value, rhs: borrowed Value) throws do
     lhs.call("__imod__", rhs);
+  operator%=(ref lhs: owned Value, ref rhs: Value) throws do
+    lhs %= rhs.borrow();
   operator**(lhs: borrowed Value, rhs: borrowed Value): owned Value throws {
     var res = lhs.call(PyObjectPtr, "__pow__", rhs);
     if res == Py_NotImplemented then
       res = rhs.call(PyObjectPtr, "__rpow__", lhs);
     return new Value(lhs.interpreter, res, isOwned=true);
   }
-  operator**=(ref lhs: owned Value, rhs: borrowed Value?) throws do
+  operator**=(ref lhs: owned Value, rhs: borrowed Value) throws do
     lhs.call("__ipow__", rhs);
+  operator**=(ref lhs: owned Value, ref rhs: Value) throws do
+    lhs **= rhs.borrow();
   operator&(lhs: borrowed Value, rhs: borrowed Value): owned Value throws {
     var res = lhs.call(PyObjectPtr, "__and__", rhs);
     if res == Py_NotImplemented then
       res = rhs.call(PyObjectPtr, "__rand__", lhs);
     return new Value(lhs.interpreter, res, isOwned=true);
   }
-  operator&=(ref lhs: owned Value, rhs: borrowed Value?) throws do
+  operator&=(ref lhs: owned Value, rhs: borrowed Value) throws do
     lhs.call("__iand__", rhs);
+  operator&=(ref lhs: owned Value, ref rhs: Value) throws do
+    lhs &= rhs.borrow();
   operator|(lhs: borrowed Value, rhs: borrowed Value): owned Value throws {
     var res = lhs.call(PyObjectPtr, "__or__", rhs);
     if res == Py_NotImplemented then
       res = rhs.call(PyObjectPtr, "__ror__", lhs);
     return new Value(lhs.interpreter, res, isOwned=true);
   }
-  operator|=(ref lhs: owned Value, rhs: borrowed Value?) throws do
+  operator|=(ref lhs: owned Value, rhs: borrowed Value) throws do
     lhs.call("__ior__", rhs);
+  operator|=(ref lhs: owned Value, ref rhs: Value) throws do
+    lhs |= rhs.borrow();
   operator^(lhs: borrowed Value, rhs: borrowed Value): owned Value throws {
     var res = lhs.call(PyObjectPtr, "__xor__", rhs);
     if res == Py_NotImplemented then
       res = rhs.call(PyObjectPtr, "__rxor__", lhs);
     return new Value(lhs.interpreter, res, isOwned=true);
   }
-  operator^=(ref lhs: owned Value, rhs: borrowed Value?) throws do
+  operator^=(ref lhs: owned Value, rhs: borrowed Value) throws do
     lhs.call("__ixor__", rhs);
+  operator^=(ref lhs: owned Value, ref rhs: Value) throws do
+    lhs ^= rhs.borrow();
   operator<<(lhs: borrowed Value, rhs: borrowed Value): owned Value throws {
     var res = lhs.call(PyObjectPtr, "__lshift__", rhs);
     if res == Py_NotImplemented then
       res = rhs.call(PyObjectPtr, "__rlshift__", lhs);
     return new Value(lhs.interpreter, res, isOwned=true);
   }
-  operator<<=(ref lhs: owned Value, rhs: borrowed Value?) throws do
+  operator<<=(ref lhs: owned Value, rhs: borrowed Value) throws do
     lhs.call("__ilshift__", rhs);
+  operator<<=(ref lhs: owned Value, ref rhs: Value) throws do
+    lhs <<= rhs.borrow();
   operator>>(lhs: borrowed Value, rhs: borrowed Value): owned Value throws {
     var res = lhs.call(PyObjectPtr, "__rshift__", rhs);
     if res == Py_NotImplemented then
       res = rhs.call(PyObjectPtr, "__rrshift__", lhs);
     return new Value(lhs.interpreter, res, isOwned=true);
   }
-  operator>>=(ref lhs: owned Value, rhs: borrowed Value?) throws do
+  operator>>=(ref lhs: owned Value, rhs: borrowed Value) throws do
     lhs.call("__irshift__", rhs);
+  operator>>=(ref lhs: owned Value, ref rhs: Value) throws do
+    lhs >>= rhs.borrow();
 
   //
   // unary ops

--- a/modules/packages/Python.chpl
+++ b/modules/packages/Python.chpl
@@ -570,6 +570,8 @@ module Python {
     var objgraph: PyObjectPtr = nil;
     @chpldoc.nodoc
     var isSubInterpreter: bool;
+    @chpldoc.nodoc
+    var operatorModule: PyObjectPtr = nil;
 
     @chpldoc.nodoc
     var anonModuleCounter: atomic int = 0;
@@ -653,6 +655,11 @@ module Python {
         throwChapelException("Failed to register Python array types for Chapel arrays");
       }
 
+      this.operatorModule = this.importModuleInternal("operator");
+      if this.operatorModule == nil {
+        throwChapelException("Failed to import operator module");
+      }
+
       if pyMemLeaks {
         // import objgraph
         this.objgraph = this.importModuleInternal("objgraph");
@@ -675,9 +682,11 @@ module Python {
     proc deinit()  {
       if this.isSubInterpreter then return;
 
+      var ctx = chpl_pythonContext.enter();
+
+      Py_DECREF(this.operatorModule);
+
       if pyMemLeaks && this.objgraph != nil {
-        var ctx = chpl_pythonContext.enter();
-        defer ctx.exit();
         // note: try! is used since we can't have a throwing deinit
 
         // run gc.collect() before showing growth
@@ -701,6 +710,9 @@ module Python {
 
         Py_DECREF(this.objgraph);
       }
+
+
+      ctx.exit();
 
       //
       // we are done, the thread keeping the interpreter alive can finish
@@ -1930,6 +1942,20 @@ module Python {
       return res;
     }
 
+    /*
+      Returns the type of the object.
+
+      Equivalent to calling ``type(obj)`` in Python.
+    */
+    proc pyType(): owned Value throws {
+      var ctx = chpl_pythonContext.enter();
+      defer ctx.exit();
+      var pyType = PyObject_Type(this.obj);
+      this.interpreter.checkException();
+      var res = interpreter.fromPythonInner(owned Value, pyType);
+      return res;
+    }
+
 
     /*
       Treat this value as a callable and call it with the given arguments.
@@ -2260,6 +2286,20 @@ module Python {
       // fromPython will decrement the ref count, so we need to increment it
       Py_INCREF(this.obj);
       return interpreter.fromPythonInner(value, this.obj);
+    }
+
+    /*
+      Retain a new Python object.
+      If the previous object was owned, decrements the reference count
+    */
+    @chpldoc.nodoc
+    proc retain(val: PyObjectPtr, isOwned: bool = true) {
+      var old = this.obj;
+      this.obj = val;
+      if this.isOwned {
+        Py_DECREF(old);
+      }
+      this.isOwned = isOwned;
     }
 
     /*
@@ -3712,144 +3752,144 @@ module Python {
   //
   // binary ops
   //
-  operator+(lhs: borrowed Value, rhs: borrowed Value): owned Value throws {
-    var res = lhs.call(PyObjectPtr, "__add__", rhs);
-    if res == Py_NotImplemented then
-      res = rhs.call(PyObjectPtr, "__radd__", lhs);
+  private inline proc _binaryOp(param op: string,
+                                lhs: borrowed Value,
+                                rhs: borrowed Value): owned Value throws {
+    var ctx = chpl_pythonContext.enter();
+    defer ctx.exit();
+    var res = PyObject_CallMethod(
+      lhs.interpreter.operatorModule, op,
+      "OO", lhs.getPyObject(), rhs.getPyObject());
+    lhs.interpreter.checkException();
     return new Value(lhs.interpreter, res, isOwned=true);
   }
+  inline proc _binaryOpInPlace(param op: string,
+                                lhs: borrowed Value,
+                                rhs: borrowed Value) throws {
+    var ctx = chpl_pythonContext.enter();
+    defer ctx.exit();
+    var res = PyObject_CallMethod(
+      lhs.interpreter.operatorModule, op,
+      "OO", lhs.getPyObject(), rhs.getPyObject());
+    lhs.interpreter.checkException();
+    lhs.retain(res);
+    lhs.interpreter.checkException();
+  }
+  operator+(lhs: borrowed Value, rhs: borrowed Value): owned Value throws do
+    return _binaryOp("add", lhs, rhs);
   operator+=(ref lhs: owned Value, rhs: borrowed Value) throws do
-    lhs.call("__iadd__", rhs);
-  operator+=(ref lhs: owned Value, ref rhs: Value) throws do
-    lhs += rhs.borrow();
-  operator-(lhs: borrowed Value, rhs: borrowed Value): owned Value throws {
-    var res = lhs.call(PyObjectPtr, "__sub__", rhs);
-    if res == Py_NotImplemented then
-      res = rhs.call(PyObjectPtr, "__rsub__", lhs);
-    return new Value(lhs.interpreter, res, isOwned=true);
-  }
+    _binaryOpInPlace("iadd", lhs, rhs);
+  operator+=(ref lhs: owned Value, const ref rhs: Value) throws do
+    _binaryOpInPlace("iadd", lhs.borrow(), rhs.borrow());
+  operator-(lhs: borrowed Value, rhs: borrowed Value): owned Value throws do
+    return _binaryOp("sub", lhs, rhs);
   operator-=(ref lhs: owned Value, rhs: borrowed Value) throws do
-    lhs.call("__isub__", rhs);
-  operator-=(ref lhs: owned Value, ref rhs: Value) throws do
-    lhs -= rhs.borrow();
-  operator*(lhs: borrowed Value, rhs: borrowed Value): owned Value throws {
-    var res = lhs.call(PyObjectPtr, "__mul__", rhs);
-    if res == Py_NotImplemented then
-      res = rhs.call(PyObjectPtr, "__rmul__", lhs);
-    return new Value(lhs.interpreter, res, isOwned=true);
-  }
+    _binaryOpInPlace("isub", lhs, rhs);
+  operator-=(ref lhs: owned Value, const ref rhs: Value) throws do
+    _binaryOpInPlace("isub", lhs.borrow(), rhs.borrow());
+  operator*(lhs: borrowed Value, rhs: borrowed Value): owned Value throws do
+    return _binaryOp("mul", lhs, rhs);
   operator*=(ref lhs: owned Value, rhs: borrowed Value) throws do
-    lhs.call("__imul__", rhs);
-  operator*=(ref lhs: owned Value, ref rhs: Value) throws do
-    lhs *= rhs.borrow();
-  operator/(lhs: borrowed Value, rhs: borrowed Value): owned Value throws {
-    var res = lhs.call(PyObjectPtr, "__truediv__", rhs);
-    if res == Py_NotImplemented then
-      res = rhs.call(PyObjectPtr, "__rtruediv__", lhs);
-    return new Value(lhs.interpreter, res, isOwned=true);
-  }
+    _binaryOpInPlace("imul", lhs, rhs);
+  operator*=(ref lhs: owned Value, const ref rhs: Value) throws do
+    _binaryOpInPlace("imul", lhs.borrow(), rhs.borrow());
+  operator/(lhs: borrowed Value, rhs: borrowed Value): owned Value throws do
+    return _binaryOp("truediv", lhs, rhs);
   operator/=(ref lhs: owned Value, rhs: borrowed Value) throws do
-    lhs.call("__itruediv__", rhs);
-  operator/=(ref lhs: owned Value, ref rhs: Value) throws do
-    lhs /= rhs.borrow();
-  operator%(lhs: borrowed Value, rhs: borrowed Value): owned Value throws {
-    var res = lhs.call(PyObjectPtr, "__mod__", rhs);
-    if res == Py_NotImplemented then
-      res = rhs.call(PyObjectPtr, "__rmod__", lhs);
-    return new Value(lhs.interpreter, res, isOwned=true);
-  }
+    _binaryOpInPlace("itruediv", lhs, rhs);
+  operator/=(ref lhs: owned Value, const ref rhs: Value) throws do
+    _binaryOpInPlace("itruediv", lhs.borrow(), rhs.borrow());
+   operator%(lhs: borrowed Value, rhs: borrowed Value): owned Value throws do
+    return _binaryOp("mod", lhs, rhs);
   operator%=(ref lhs: owned Value, rhs: borrowed Value) throws do
-    lhs.call("__imod__", rhs);
-  operator%=(ref lhs: owned Value, ref rhs: Value) throws do
-    lhs %= rhs.borrow();
-  operator**(lhs: borrowed Value, rhs: borrowed Value): owned Value throws {
-    var res = lhs.call(PyObjectPtr, "__pow__", rhs);
-    if res == Py_NotImplemented then
-      res = rhs.call(PyObjectPtr, "__rpow__", lhs);
-    return new Value(lhs.interpreter, res, isOwned=true);
-  }
+    _binaryOpInPlace("imod", lhs, rhs);
+  operator%=(ref lhs: owned Value, const ref rhs: Value) throws do
+    _binaryOpInPlace("imod", lhs.borrow(), rhs.borrow());
+  operator**(lhs: borrowed Value, rhs: borrowed Value): owned Value throws do
+    return _binaryOp("pow", lhs, rhs);
   operator**=(ref lhs: owned Value, rhs: borrowed Value) throws do
-    lhs.call("__ipow__", rhs);
-  operator**=(ref lhs: owned Value, ref rhs: Value) throws do
-    lhs **= rhs.borrow();
-  operator&(lhs: borrowed Value, rhs: borrowed Value): owned Value throws {
-    var res = lhs.call(PyObjectPtr, "__and__", rhs);
-    if res == Py_NotImplemented then
-      res = rhs.call(PyObjectPtr, "__rand__", lhs);
-    return new Value(lhs.interpreter, res, isOwned=true);
-  }
+    _binaryOpInPlace("ipow", lhs, rhs);
+  operator**=(ref lhs: owned Value, const ref rhs: Value) throws do
+    _binaryOpInPlace("ipow", lhs.borrow(), rhs.borrow());
+  operator&(lhs: borrowed Value, rhs: borrowed Value): owned Value throws do
+    return _binaryOp("and_", lhs, rhs);
   operator&=(ref lhs: owned Value, rhs: borrowed Value) throws do
-    lhs.call("__iand__", rhs);
-  operator&=(ref lhs: owned Value, ref rhs: Value) throws do
-    lhs &= rhs.borrow();
-  operator|(lhs: borrowed Value, rhs: borrowed Value): owned Value throws {
-    var res = lhs.call(PyObjectPtr, "__or__", rhs);
-    if res == Py_NotImplemented then
-      res = rhs.call(PyObjectPtr, "__ror__", lhs);
-    return new Value(lhs.interpreter, res, isOwned=true);
-  }
+    _binaryOpInPlace("iand", lhs, rhs);
+  operator&=(ref lhs: owned Value, const ref rhs: Value) throws do
+    _binaryOpInPlace("iand", lhs.borrow(), rhs.borrow());
+  operator|(lhs: borrowed Value, rhs: borrowed Value): owned Value throws do
+    return _binaryOp("or_", lhs, rhs);
   operator|=(ref lhs: owned Value, rhs: borrowed Value) throws do
-    lhs.call("__ior__", rhs);
-  operator|=(ref lhs: owned Value, ref rhs: Value) throws do
-    lhs |= rhs.borrow();
-  operator^(lhs: borrowed Value, rhs: borrowed Value): owned Value throws {
-    var res = lhs.call(PyObjectPtr, "__xor__", rhs);
-    if res == Py_NotImplemented then
-      res = rhs.call(PyObjectPtr, "__rxor__", lhs);
-    return new Value(lhs.interpreter, res, isOwned=true);
-  }
+    _binaryOpInPlace("ior", lhs, rhs);
+  operator|=(ref lhs: owned Value, const ref rhs: Value) throws do
+    _binaryOpInPlace("ior", lhs.borrow(), rhs.borrow());
+  operator^(lhs: borrowed Value, rhs: borrowed Value): owned Value throws do
+    return _binaryOp("xor", lhs, rhs);
   operator^=(ref lhs: owned Value, rhs: borrowed Value) throws do
-    lhs.call("__ixor__", rhs);
-  operator^=(ref lhs: owned Value, ref rhs: Value) throws do
-    lhs ^= rhs.borrow();
-  operator<<(lhs: borrowed Value, rhs: borrowed Value): owned Value throws {
-    var res = lhs.call(PyObjectPtr, "__lshift__", rhs);
-    if res == Py_NotImplemented then
-      res = rhs.call(PyObjectPtr, "__rlshift__", lhs);
-    return new Value(lhs.interpreter, res, isOwned=true);
-  }
+    _binaryOpInPlace("ixor", lhs, rhs);
+  operator^=(ref lhs: owned Value, const ref rhs: Value) throws do
+    _binaryOpInPlace("ixor", lhs.borrow(), rhs.borrow());
+  operator<<(lhs: borrowed Value, rhs: borrowed Value): owned Value throws do
+    return _binaryOp("lshift", lhs, rhs);
   operator<<=(ref lhs: owned Value, rhs: borrowed Value) throws do
-    lhs.call("__ilshift__", rhs);
-  operator<<=(ref lhs: owned Value, ref rhs: Value) throws do
-    lhs <<= rhs.borrow();
-  operator>>(lhs: borrowed Value, rhs: borrowed Value): owned Value throws {
-    var res = lhs.call(PyObjectPtr, "__rshift__", rhs);
-    if res == Py_NotImplemented then
-      res = rhs.call(PyObjectPtr, "__rrshift__", lhs);
-    return new Value(lhs.interpreter, res, isOwned=true);
-  }
+    _binaryOpInPlace("ilshift", lhs, rhs);
+  operator<<=(ref lhs: owned Value, const ref rhs: Value) throws do
+    _binaryOpInPlace("ilshift", lhs.borrow(), rhs.borrow());
+  operator>>(lhs: borrowed Value, rhs: borrowed Value): owned Value throws do
+    return _binaryOp("rshift", lhs, rhs);
   operator>>=(ref lhs: owned Value, rhs: borrowed Value) throws do
-    lhs.call("__irshift__", rhs);
-  operator>>=(ref lhs: owned Value, ref rhs: Value) throws do
-    lhs >>= rhs.borrow();
+    _binaryOpInPlace("irshift", lhs, rhs);
+  operator>>=(ref lhs: owned Value, const ref rhs: Value) throws do
+    _binaryOpInPlace("irshift", lhs.borrow(), rhs.borrow());
 
   //
   // unary ops
   //
+  private inline proc _unaryOp(param op: string,
+                               lhs: borrowed Value): owned Value throws {
+    var ctx = chpl_pythonContext.enter();
+    defer ctx.exit();
+    var res = PyObject_CallMethod(
+      lhs.interpreter.operatorModule, op,
+      "O", lhs.getPyObject());
+    lhs.interpreter.checkException();
+    return new Value(lhs.interpreter, res, isOwned=true);
+  }
   operator+(lhs: borrowed Value): owned Value throws do
-    return lhs.call("__pos__");
+    return _unaryOp("pos", lhs);
   operator-(lhs: borrowed Value): owned Value throws do
-    return lhs.call("__neg__");
+    return _unaryOp("neg", lhs);
   operator~(lhs: borrowed Value): owned Value throws do
-    return lhs.call("__invert__");
+    return _unaryOp("invert", lhs);
   operator!(lhs: borrowed Value): owned Value throws do
-    return lhs.call("__not__");
+    return _unaryOp("not_", lhs);
 
   //
   // comparison ops
   //
+  private inline proc _cmpOp(param op: string,
+                            lhs: borrowed Value,
+                            rhs: borrowed Value): bool throws {
+    var ctx = chpl_pythonContext.enter();
+    defer ctx.exit();
+    var res = PyObject_CallMethod(
+      lhs.interpreter.operatorModule, op,
+      "OO", lhs.getPyObject(), rhs.getPyObject());
+    lhs.interpreter.checkException();
+    return lhs.interpreter.fromPythonInner(bool, res);
+  }
   operator==(lhs: borrowed Value, rhs: borrowed Value): bool throws do
-    return lhs.call(bool, "__eq__", rhs);
+    return _cmpOp("eq", lhs, rhs);
   operator!=(lhs: borrowed Value, rhs: borrowed Value): bool throws do
-    return lhs.call(bool, "__ne__", rhs);
+    return _cmpOp("ne", lhs, rhs);
   operator<(lhs: borrowed Value, rhs: borrowed Value): bool throws do
-    return lhs.call(bool, "__lt__", rhs);
+    return _cmpOp("lt", lhs, rhs);
   operator<=(lhs: borrowed Value, rhs: borrowed Value): bool throws do
-    return lhs.call(bool, "__le__", rhs);
+    return _cmpOp("le", lhs, rhs);
   operator>(lhs: borrowed Value, rhs: borrowed Value): bool throws do
-    return lhs.call(bool, "__gt__", rhs);
+    return _cmpOp("gt", lhs, rhs);
   operator>=(lhs: borrowed Value, rhs: borrowed Value): bool throws do
-    return lhs.call(bool, "__ge__", rhs);
+    return _cmpOp("ge", lhs, rhs);
 
 
   @chpldoc.nodoc
@@ -3961,6 +4001,7 @@ module Python {
     extern proc PyMem_Free(ptr: c_ptr(void));
     extern proc PyObject_Str(obj: PyObjectPtr): PyObjectPtr; // `str(obj)`
     extern proc PyObject_Repr(obj: PyObjectPtr): PyObjectPtr; // `repr(obj)`
+    extern proc PyObject_Type(obj: PyObjectPtr): PyObjectPtr; // `type(obj)`
     extern proc PyImport_ImportModule(name: c_ptrConst(c_char)): PyObjectPtr;
 
     extern "chpl_PY_VERSION_HEX" const PY_VERSION_HEX: uint(64);
@@ -4171,6 +4212,10 @@ module Python {
     extern proc PyObject_CallMethodObjArgs(obj: PyObjectPtr,
                                            method: PyObjectPtr,
                                            args...): PyObjectPtr;
+    extern proc PyObject_CallMethod(obj: PyObjectPtr,
+                                    method: c_ptrConst(c_char),
+                                    format: c_ptrConst(c_char),
+                                    args...): PyObjectPtr;
 
 
     /*

--- a/modules/packages/Python.chpl
+++ b/modules/packages/Python.chpl
@@ -3709,6 +3709,127 @@ module Python {
   proc NoneType.serialize(writer, ref serializer) throws do
     writer.write(this:string);
 
+  //
+  // binary ops
+  //
+  operator+(lhs: borrowed Value, rhs: borrowed Value): owned Value throws {
+    var res = lhs.call(PyObjectPtr, "__add__", rhs);
+    if res == Py_NotImplemented then
+      res = rhs.call(PyObjectPtr, "__radd__", lhs);
+    return new Value(lhs.interpreter, res, isOwned=true);
+  }
+  operator+=(ref lhs: owned Value, rhs: borrowed Value?) throws do
+    lhs.call("__iadd__", rhs);
+  operator-(lhs: borrowed Value, rhs: borrowed Value): owned Value throws {
+    var res = lhs.call(PyObjectPtr, "__sub__", rhs);
+    if res == Py_NotImplemented then
+      res = rhs.call(PyObjectPtr, "__rsub__", lhs);
+    return new Value(lhs.interpreter, res, isOwned=true);
+  }
+  operator-=(ref lhs: owned Value, rhs: borrowed Value?) throws do
+    lhs.call("__isub__", rhs);
+  operator*(lhs: borrowed Value, rhs: borrowed Value): owned Value throws {
+    var res = lhs.call(PyObjectPtr, "__mul__", rhs);
+    if res == Py_NotImplemented then
+      res = rhs.call(PyObjectPtr, "__rmul__", lhs);
+    return new Value(lhs.interpreter, res, isOwned=true);
+  }
+  operator*=(ref lhs: owned Value, rhs: borrowed Value?) throws do
+    lhs.call("__imul__", rhs);
+  operator/(lhs: borrowed Value, rhs: borrowed Value): owned Value throws {
+    var res = lhs.call(PyObjectPtr, "__truediv__", rhs);
+    if res == Py_NotImplemented then
+      res = rhs.call(PyObjectPtr, "__rtruediv__", lhs);
+    return new Value(lhs.interpreter, res, isOwned=true);
+  }
+  operator/=(ref lhs: owned Value, rhs: borrowed Value?) throws do
+    lhs.call("__itruediv__", rhs);
+  operator%(lhs: borrowed Value, rhs: borrowed Value): owned Value throws {
+    var res = lhs.call(PyObjectPtr, "__mod__", rhs);
+    if res == Py_NotImplemented then
+      res = rhs.call(PyObjectPtr, "__rmod__", lhs);
+    return new Value(lhs.interpreter, res, isOwned=true);
+  }
+  operator%=(ref lhs: owned Value, rhs: borrowed Value?) throws do
+    lhs.call("__imod__", rhs);
+  operator**(lhs: borrowed Value, rhs: borrowed Value): owned Value throws {
+    var res = lhs.call(PyObjectPtr, "__pow__", rhs);
+    if res == Py_NotImplemented then
+      res = rhs.call(PyObjectPtr, "__rpow__", lhs);
+    return new Value(lhs.interpreter, res, isOwned=true);
+  }
+  operator**=(ref lhs: owned Value, rhs: borrowed Value?) throws do
+    lhs.call("__ipow__", rhs);
+  operator&(lhs: borrowed Value, rhs: borrowed Value): owned Value throws {
+    var res = lhs.call(PyObjectPtr, "__and__", rhs);
+    if res == Py_NotImplemented then
+      res = rhs.call(PyObjectPtr, "__rand__", lhs);
+    return new Value(lhs.interpreter, res, isOwned=true);
+  }
+  operator&=(ref lhs: owned Value, rhs: borrowed Value?) throws do
+    lhs.call("__iand__", rhs);
+  operator|(lhs: borrowed Value, rhs: borrowed Value): owned Value throws {
+    var res = lhs.call(PyObjectPtr, "__or__", rhs);
+    if res == Py_NotImplemented then
+      res = rhs.call(PyObjectPtr, "__ror__", lhs);
+    return new Value(lhs.interpreter, res, isOwned=true);
+  }
+  operator|=(ref lhs: owned Value, rhs: borrowed Value?) throws do
+    lhs.call("__ior__", rhs);
+  operator^(lhs: borrowed Value, rhs: borrowed Value): owned Value throws {
+    var res = lhs.call(PyObjectPtr, "__xor__", rhs);
+    if res == Py_NotImplemented then
+      res = rhs.call(PyObjectPtr, "__rxor__", lhs);
+    return new Value(lhs.interpreter, res, isOwned=true);
+  }
+  operator^=(ref lhs: owned Value, rhs: borrowed Value?) throws do
+    lhs.call("__ixor__", rhs);
+  operator<<(lhs: borrowed Value, rhs: borrowed Value): owned Value throws {
+    var res = lhs.call(PyObjectPtr, "__lshift__", rhs);
+    if res == Py_NotImplemented then
+      res = rhs.call(PyObjectPtr, "__rlshift__", lhs);
+    return new Value(lhs.interpreter, res, isOwned=true);
+  }
+  operator<<=(ref lhs: owned Value, rhs: borrowed Value?) throws do
+    lhs.call("__ilshift__", rhs);
+  operator>>(lhs: borrowed Value, rhs: borrowed Value): owned Value throws {
+    var res = lhs.call(PyObjectPtr, "__rshift__", rhs);
+    if res == Py_NotImplemented then
+      res = rhs.call(PyObjectPtr, "__rrshift__", lhs);
+    return new Value(lhs.interpreter, res, isOwned=true);
+  }
+  operator>>=(ref lhs: owned Value, rhs: borrowed Value?) throws do
+    lhs.call("__irshift__", rhs);
+
+  //
+  // unary ops
+  //
+  operator+(lhs: borrowed Value): owned Value throws do
+    return lhs.call("__pos__");
+  operator-(lhs: borrowed Value): owned Value throws do
+    return lhs.call("__neg__");
+  operator~(lhs: borrowed Value): owned Value throws do
+    return lhs.call("__invert__");
+  operator!(lhs: borrowed Value): owned Value throws do
+    return lhs.call("__not__");
+
+  //
+  // comparison ops
+  //
+  operator==(lhs: borrowed Value, rhs: borrowed Value): bool throws do
+    return lhs.call(bool, "__eq__", rhs);
+  operator!=(lhs: borrowed Value, rhs: borrowed Value): bool throws do
+    return lhs.call(bool, "__ne__", rhs);
+  operator<(lhs: borrowed Value, rhs: borrowed Value): bool throws do
+    return lhs.call(bool, "__lt__", rhs);
+  operator<=(lhs: borrowed Value, rhs: borrowed Value): bool throws do
+    return lhs.call(bool, "__le__", rhs);
+  operator>(lhs: borrowed Value, rhs: borrowed Value): bool throws do
+    return lhs.call(bool, "__gt__", rhs);
+  operator>=(lhs: borrowed Value, rhs: borrowed Value): bool throws do
+    return lhs.call(bool, "__ge__", rhs);
+
+
   @chpldoc.nodoc
   module CWChar {
     require "wchar.h";

--- a/modules/packages/Python.chpl
+++ b/modules/packages/Python.chpl
@@ -3775,71 +3775,81 @@ module Python {
     lhs.retain(res);
     lhs.interpreter.checkException();
   }
-  operator+(lhs: borrowed Value, rhs: borrowed Value): owned Value throws do
+  operator +(lhs: borrowed Value, rhs: borrowed Value): owned Value throws do
     return _binaryOp("add", lhs, rhs);
-  operator+=(ref lhs: owned Value, rhs: borrowed Value) throws do
+  operator +=(ref lhs: owned Value, rhs: borrowed Value) throws do
     _binaryOpInPlace("iadd", lhs, rhs);
-  operator+=(ref lhs: owned Value, const ref rhs: Value) throws do
+  operator +=(ref lhs: owned Value, const ref rhs: Value) throws do
     _binaryOpInPlace("iadd", lhs.borrow(), rhs.borrow());
-  operator-(lhs: borrowed Value, rhs: borrowed Value): owned Value throws do
+
+  operator -(lhs: borrowed Value, rhs: borrowed Value): owned Value throws do
     return _binaryOp("sub", lhs, rhs);
-  operator-=(ref lhs: owned Value, rhs: borrowed Value) throws do
+  operator -=(ref lhs: owned Value, rhs: borrowed Value) throws do
     _binaryOpInPlace("isub", lhs, rhs);
-  operator-=(ref lhs: owned Value, const ref rhs: Value) throws do
+  operator -=(ref lhs: owned Value, const ref rhs: Value) throws do
     _binaryOpInPlace("isub", lhs.borrow(), rhs.borrow());
-  operator*(lhs: borrowed Value, rhs: borrowed Value): owned Value throws do
+
+  operator *(lhs: borrowed Value, rhs: borrowed Value): owned Value throws do
     return _binaryOp("mul", lhs, rhs);
-  operator*=(ref lhs: owned Value, rhs: borrowed Value) throws do
+  operator *=(ref lhs: owned Value, rhs: borrowed Value) throws do
     _binaryOpInPlace("imul", lhs, rhs);
-  operator*=(ref lhs: owned Value, const ref rhs: Value) throws do
+  operator *=(ref lhs: owned Value, const ref rhs: Value) throws do
     _binaryOpInPlace("imul", lhs.borrow(), rhs.borrow());
-  operator/(lhs: borrowed Value, rhs: borrowed Value): owned Value throws do
+
+  operator /(lhs: borrowed Value, rhs: borrowed Value): owned Value throws do
     return _binaryOp("truediv", lhs, rhs);
-  operator/=(ref lhs: owned Value, rhs: borrowed Value) throws do
+  operator /=(ref lhs: owned Value, rhs: borrowed Value) throws do
     _binaryOpInPlace("itruediv", lhs, rhs);
-  operator/=(ref lhs: owned Value, const ref rhs: Value) throws do
+  operator /=(ref lhs: owned Value, const ref rhs: Value) throws do
     _binaryOpInPlace("itruediv", lhs.borrow(), rhs.borrow());
-   operator%(lhs: borrowed Value, rhs: borrowed Value): owned Value throws do
+
+  operator %(lhs: borrowed Value, rhs: borrowed Value): owned Value throws do
     return _binaryOp("mod", lhs, rhs);
-  operator%=(ref lhs: owned Value, rhs: borrowed Value) throws do
+  operator %=(ref lhs: owned Value, rhs: borrowed Value) throws do
     _binaryOpInPlace("imod", lhs, rhs);
-  operator%=(ref lhs: owned Value, const ref rhs: Value) throws do
+  operator %=(ref lhs: owned Value, const ref rhs: Value) throws do
     _binaryOpInPlace("imod", lhs.borrow(), rhs.borrow());
-  operator**(lhs: borrowed Value, rhs: borrowed Value): owned Value throws do
+
+  operator **(lhs: borrowed Value, rhs: borrowed Value): owned Value throws do
     return _binaryOp("pow", lhs, rhs);
-  operator**=(ref lhs: owned Value, rhs: borrowed Value) throws do
+  operator **=(ref lhs: owned Value, rhs: borrowed Value) throws do
     _binaryOpInPlace("ipow", lhs, rhs);
-  operator**=(ref lhs: owned Value, const ref rhs: Value) throws do
+  operator **=(ref lhs: owned Value, const ref rhs: Value) throws do
     _binaryOpInPlace("ipow", lhs.borrow(), rhs.borrow());
-  operator&(lhs: borrowed Value, rhs: borrowed Value): owned Value throws do
+
+  operator &(lhs: borrowed Value, rhs: borrowed Value): owned Value throws do
     return _binaryOp("and_", lhs, rhs);
-  operator&=(ref lhs: owned Value, rhs: borrowed Value) throws do
+  operator &=(ref lhs: owned Value, rhs: borrowed Value) throws do
     _binaryOpInPlace("iand", lhs, rhs);
-  operator&=(ref lhs: owned Value, const ref rhs: Value) throws do
+  operator &=(ref lhs: owned Value, const ref rhs: Value) throws do
     _binaryOpInPlace("iand", lhs.borrow(), rhs.borrow());
-  operator|(lhs: borrowed Value, rhs: borrowed Value): owned Value throws do
+
+  operator |(lhs: borrowed Value, rhs: borrowed Value): owned Value throws do
     return _binaryOp("or_", lhs, rhs);
-  operator|=(ref lhs: owned Value, rhs: borrowed Value) throws do
+  operator |=(ref lhs: owned Value, rhs: borrowed Value) throws do
     _binaryOpInPlace("ior", lhs, rhs);
-  operator|=(ref lhs: owned Value, const ref rhs: Value) throws do
+  operator |=(ref lhs: owned Value, const ref rhs: Value) throws do
     _binaryOpInPlace("ior", lhs.borrow(), rhs.borrow());
-  operator^(lhs: borrowed Value, rhs: borrowed Value): owned Value throws do
+
+  operator ^(lhs: borrowed Value, rhs: borrowed Value): owned Value throws do
     return _binaryOp("xor", lhs, rhs);
-  operator^=(ref lhs: owned Value, rhs: borrowed Value) throws do
+  operator ^=(ref lhs: owned Value, rhs: borrowed Value) throws do
     _binaryOpInPlace("ixor", lhs, rhs);
-  operator^=(ref lhs: owned Value, const ref rhs: Value) throws do
+  operator ^=(ref lhs: owned Value, const ref rhs: Value) throws do
     _binaryOpInPlace("ixor", lhs.borrow(), rhs.borrow());
-  operator<<(lhs: borrowed Value, rhs: borrowed Value): owned Value throws do
+
+  operator <<(lhs: borrowed Value, rhs: borrowed Value): owned Value throws do
     return _binaryOp("lshift", lhs, rhs);
-  operator<<=(ref lhs: owned Value, rhs: borrowed Value) throws do
+  operator <<=(ref lhs: owned Value, rhs: borrowed Value) throws do
     _binaryOpInPlace("ilshift", lhs, rhs);
-  operator<<=(ref lhs: owned Value, const ref rhs: Value) throws do
+  operator <<=(ref lhs: owned Value, const ref rhs: Value) throws do
     _binaryOpInPlace("ilshift", lhs.borrow(), rhs.borrow());
-  operator>>(lhs: borrowed Value, rhs: borrowed Value): owned Value throws do
+
+  operator >>(lhs: borrowed Value, rhs: borrowed Value): owned Value throws do
     return _binaryOp("rshift", lhs, rhs);
-  operator>>=(ref lhs: owned Value, rhs: borrowed Value) throws do
+  operator >>=(ref lhs: owned Value, rhs: borrowed Value) throws do
     _binaryOpInPlace("irshift", lhs, rhs);
-  operator>>=(ref lhs: owned Value, const ref rhs: Value) throws do
+  operator >>=(ref lhs: owned Value, const ref rhs: Value) throws do
     _binaryOpInPlace("irshift", lhs.borrow(), rhs.borrow());
 
   //
@@ -3855,13 +3865,13 @@ module Python {
     lhs.interpreter.checkException();
     return new Value(lhs.interpreter, res, isOwned=true);
   }
-  operator+(lhs: borrowed Value): owned Value throws do
+  operator +(lhs: borrowed Value): owned Value throws do
     return _unaryOp("pos", lhs);
-  operator-(lhs: borrowed Value): owned Value throws do
+  operator -(lhs: borrowed Value): owned Value throws do
     return _unaryOp("neg", lhs);
-  operator~(lhs: borrowed Value): owned Value throws do
+  operator ~(lhs: borrowed Value): owned Value throws do
     return _unaryOp("invert", lhs);
-  operator!(lhs: borrowed Value): owned Value throws do
+  operator !(lhs: borrowed Value): owned Value throws do
     return _unaryOp("not_", lhs);
 
   //
@@ -3878,17 +3888,19 @@ module Python {
     lhs.interpreter.checkException();
     return lhs.interpreter.fromPythonInner(bool, res);
   }
-  operator==(lhs: borrowed Value, rhs: borrowed Value): bool throws do
+  operator ==(lhs: borrowed Value, rhs: borrowed Value): bool throws do
     return _cmpOp("eq", lhs, rhs);
-  operator!=(lhs: borrowed Value, rhs: borrowed Value): bool throws do
+  operator !=(lhs: borrowed Value, rhs: borrowed Value): bool throws do
     return _cmpOp("ne", lhs, rhs);
-  operator<(lhs: borrowed Value, rhs: borrowed Value): bool throws do
+
+  operator <(lhs: borrowed Value, rhs: borrowed Value): bool throws do
     return _cmpOp("lt", lhs, rhs);
-  operator<=(lhs: borrowed Value, rhs: borrowed Value): bool throws do
+  operator <=(lhs: borrowed Value, rhs: borrowed Value): bool throws do
     return _cmpOp("le", lhs, rhs);
-  operator>(lhs: borrowed Value, rhs: borrowed Value): bool throws do
+
+  operator >(lhs: borrowed Value, rhs: borrowed Value): bool throws do
     return _cmpOp("gt", lhs, rhs);
-  operator>=(lhs: borrowed Value, rhs: borrowed Value): bool throws do
+  operator >=(lhs: borrowed Value, rhs: borrowed Value): bool throws do
     return _cmpOp("ge", lhs, rhs);
 
 

--- a/test/library/packages/Python/correctness/pythonOps.chpl
+++ b/test/library/packages/Python/correctness/pythonOps.chpl
@@ -4,8 +4,9 @@ proc main() {
   var interp = new Interpreter();
 
   doOps(new Value(interp, 1), new Value(interp, 2));
-  doOps(new Value(interp, 1.0), new Value(interp, 2.0));
+  doOps(new Value(interp, 2.0), new Value(interp, 1.0));
   doOps(new Value(interp, "hello"), new Value(interp, "world"));
+  doOps(new Value(interp, true), new Value(interp, false));
 }
 
 proc doOps(in lhs, in rhs) throws {
@@ -14,89 +15,221 @@ proc doOps(in lhs, in rhs) throws {
 
   writeln(" binary ops:");
   {
-    var a = lhs + rhs;
-    writeln("  +: ", a, " ", a.type:string);
-    var b = lhs - rhs;
-    writeln("  -: ", b, " ", b.type:string);
-    var c = lhs * rhs;
-    writeln("  *: ", c, " ", c.type:string);
-    var d = lhs / rhs;
-    writeln("  /: ", d, " ", d.type:string);
-    var e = lhs % rhs;
-    writeln("  %: ", e, " ", e.type:string);
-    var f = lhs ** rhs;
-    writeln("  **: ", f, " ", f.type:string);
-    var g = lhs & rhs;
-    writeln("  &: ", g, " ", g.type:string);
-    var h = lhs | rhs;
-    writeln("  |: ", h, " ", h.type:string);
-    var i = lhs ^ rhs;
-    writeln("  ^: ", i, " ", i.type:string);
-    var j = lhs << rhs;
-    writeln("  <<: ", j, " ", j.type:string);
-    var k = lhs >> rhs;
-    writeln("  >>: ", k, " ", k.type:string);
-    var l = lhs == rhs;
-    writeln("  ==: ", l, " ", l.type:string);
-    var m = lhs != rhs;
-    writeln("  !=: ", m, " ", m.type:string);
-    var n = lhs < rhs;
-    writeln("  <: ", n, " ", n.type:string);
-    var o = lhs <= rhs;
-    writeln("  <=: ", o, " ", o.type:string);
-    var p = lhs > rhs;
-    writeln("  >: ", p, " ", p.type:string);
-    var q = lhs >= rhs;
-    writeln("  >=: ", q, " ", q.type:string);
+    try {
+      var a = lhs + rhs;
+      writeln("  +: ", a, " ", a.type:string, " ", a.pyType());
+    } catch e {
+      writeln("  +: Exception: ", e.message());
+    }
+    try {
+      var b = lhs - rhs;
+      writeln("  -: ", b, " ", b.type:string, " ", b.pyType());
+    } catch e {
+      writeln("  -: Exception: ", e.message());
+    }
+    try {
+      var c = lhs * rhs;
+      writeln("  *: ", c, " ", c.type:string, " ", c.pyType());
+    } catch e {
+      writeln("  *: Exception: ", e.message());
+    }
+    try {
+      var d = lhs / rhs;
+      writeln("  /: ", d, " ", d.type:string, " ", d.pyType());
+    } catch e {
+      writeln("  /: Exception: ", e.message());
+    }
+    try {
+      var e = lhs % rhs;
+      writeln("  %: ", e, " ", e.type:string, " ", e.pyType());
+    } catch e {
+      writeln("  %: Exception: ", e.message());
+    }
+    try {
+      var f = lhs ** rhs;
+      writeln("  **: ", f, " ", f.type:string, " ", f.pyType());
+    } catch e {
+      writeln("  **: Exception: ", e.message());
+    }
+    try {
+      var g = lhs & rhs;
+      writeln("  &: ", g, " ", g.type:string, " ", g.pyType());
+    } catch e {
+      writeln("  &: Exception: ", e.message());
+    }
+    try {
+      var h = lhs | rhs;
+      writeln("  |: ", h, " ", h.type:string, " ", h.pyType());
+    } catch e {
+      writeln("  |: Exception: ", e.message());
+    }
+    try {
+      var i = lhs ^ rhs;
+      writeln("  ^: ", i, " ", i.type:string, " ", i.pyType());
+    } catch e {
+      writeln("  ^: Exception: ", e.message());
+    }
+    try {
+      var j = lhs << rhs;
+      writeln("  <<: ", j, " ", j.type:string, " ", j.pyType());
+    } catch e {
+      writeln("  <<: Exception: ", e.message());
+    }
+    try {
+      var k = lhs >> rhs;
+      writeln("  >>: ", k, " ", k.type:string, " ", k.pyType());
+    } catch e {
+      writeln("  >>: Exception: ", e.message());
+    }
+  }
+
+  writeln(" comparison ops:");
+  {
+    try {
+      var l = lhs == rhs;
+      writeln("  ==: ", l, " ", l.type:string);
+    } catch e {
+      writeln("  ==: Exception: ", e.message());
+    }
+    try {
+      var m = lhs != rhs;
+      writeln("  !=: ", m, " ", m.type:string);
+    } catch e {
+      writeln("  !=: Exception: ", e.message());
+    }
+    try {
+      var n = lhs < rhs;
+      writeln("  <: ", n, " ", n.type:string);
+    } catch e {
+      writeln("  <: Exception: ", e.message());
+    }
+    try {
+      var o = lhs <= rhs;
+      writeln("  <=: ", o, " ", o.type:string);
+    } catch e {
+      writeln("  <=: Exception: ", e.message());
+    }
+    try {
+      var p = lhs > rhs;
+      writeln("  >: ", p, " ", p.type:string);
+    } catch e {
+      writeln("  >: Exception: ", e.message());
+    }
+    try {
+      var q = lhs >= rhs;
+      writeln("  >=: ", q, " ", q.type:string);
+    } catch e {
+      writeln("  >=: Exception: ", e.message());
+    }
   }
 
   writeln(" unary ops:");
   {
-    var a = +lhs;
-    writeln("  +: ", a, " ", a.type:string);
-    var b = -lhs;
-    writeln("  -: ", b, " ", b.type:string);
-    var c = ~lhs;
-    writeln("  ~: ", c, " ", c.type:string);
-    var d = !lhs;
-    writeln("  !: ", d, " ", d.type:string);
+    try {
+      var a = +lhs;
+      writeln("  +: ", a, " ", a.type:string, " ", a.pyType());
+    } catch e {
+      writeln("  +: Exception: ", e.message());
+    }
+    try {
+      var b = -lhs;
+      writeln("  -: ", b, " ", b.type:string, " ", b.pyType());
+    } catch e {
+      writeln("  -: Exception: ", e.message());
+    }
+    try {
+      var c = ~lhs;
+      writeln("  ~: ", c, " ", c.type:string, " ", c.pyType());
+    } catch e {
+      writeln("  ~: Exception: ", e.message());
+    }
+    try {
+      var d = !lhs;
+      writeln("  !: ", d, " ", d.type:string, " ", d.pyType());
+    } catch e {
+      writeln("  !: Exception: ", e.message());
+    }
   }
 
   writeln(" assignment ops:");
   {
-    var a = lhs.value(owned Value);
-    a += rhs;
-    writeln("  +=: ", a, " ", a.type:string);
-    var b = lhs.value(owned Value);
-    b -= rhs;
-    writeln("  -=: ", b, " ", b.type:string);
-    var c = lhs.value(owned Value);
-    c *= rhs;
-    writeln("  *=: ", c, " ", c.type:string);
-    var d = lhs.value(owned Value);
-    d /= rhs;
-    writeln("  /=: ", d, " ", d.type:string);
-    var e = lhs.value(owned Value);
-    e %= rhs;
-    writeln("  %=: ", e, " ", e.type:string);
-    var f = lhs.value(owned Value);
-    f **= rhs;
-    writeln("  **=: ", f, " ", f.type:string);
-    var g = lhs.value(owned Value);
-    g &= rhs;
-    writeln("  &=: ", g, " ", g.type:string);
-    var h = lhs.value(owned Value);
-    h |= rhs;
-    writeln("  |=: ", h, " ", h.type:string);
-    var i = lhs.value(owned Value);
-    i ^= rhs;
-    writeln("  ^=: ", i, " ", i.type:string);
-    var j = lhs.value(owned Value);
-    j <<= rhs;
-    writeln("  <<=: ", j, " ", j.type:string);
-    var k = lhs.value(owned Value);
-    k >>= rhs;
-    writeln("  >>=: ", k, " ", k.type:string);
+    try {
+      var a = lhs.value(owned Value);
+      a += rhs;
+      writeln("  +=: ", a, " ", a.type:string, " ", a.pyType());
+    } catch e {
+      writeln("  +=: Exception: ", e.message());
+    }
+    try {
+      var b = lhs.value(owned Value);
+      b -= rhs;
+      writeln("  -=: ", b, " ", b.type:string, " ", b.pyType());
+    } catch e {
+      writeln("  -=: Exception: ", e.message());
+    }
+    try {
+      var c = lhs.value(owned Value);
+      c *= rhs;
+      writeln("  *=: ", c, " ", c.type:string, " ", c.pyType());
+    } catch e {
+      writeln("  *=: Exception: ", e.message());
+    }
+    try {
+      var d = lhs.value(owned Value);
+      d /= rhs;
+      writeln("  /=: ", d, " ", d.type:string, " ", d.pyType());
+    } catch e {
+      writeln("  /=: Exception: ", e.message());
+    }
+    try {
+      var e = lhs.value(owned Value);
+      e %= rhs;
+      writeln("  %=: ", e, " ", e.type:string, " ", e.pyType());
+    } catch e {
+      writeln("  %=: Exception: ", e.message());
+    }
+    try {
+      var f = lhs.value(owned Value);
+      f **= rhs;
+      writeln("  **=: ", f, " ", f.type:string, " ", f.pyType());
+    } catch e {
+      writeln("  **=: Exception: ", e.message());
+    }
+    try {
+      var g = lhs.value(owned Value);
+      g &= rhs;
+      writeln("  &=: ", g, " ", g.type:string, " ", g.pyType());
+    } catch e {
+      writeln("  &=: Exception: ", e.message());
+    }
+    try {
+      var h = lhs.value(owned Value);
+      h |= rhs;
+      writeln("  |=: ", h, " ", h.type:string, " ", h.pyType());
+    } catch e {
+      writeln("  |=: Exception: ", e.message());
+    }
+    try {
+      var i = lhs.value(owned Value);
+      i ^= rhs;
+      writeln("  ^=: ", i, " ", i.type:string, " ", i.pyType());
+    } catch e {
+      writeln("  ^=: Exception: ", e.message());
+    }
+    try {
+      var j = lhs.value(owned Value);
+      j <<= rhs;
+      writeln("  <<=: ", j, " ", j.type:string, " ", j.pyType());
+    } catch e {
+      writeln("  <<=: Exception: ", e.message());
+    }
+    try {
+      var k = lhs.value(owned Value);
+      k >>= rhs;
+      writeln("  >>=: ", k, " ", k.type:string, " ", k.pyType());
+    } catch e {
+      writeln("  >>=: Exception: ", e.message());
+    }
   }
   writeln("========================");
 }

--- a/test/library/packages/Python/correctness/pythonOps.chpl
+++ b/test/library/packages/Python/correctness/pythonOps.chpl
@@ -1,0 +1,102 @@
+use Python;
+
+proc main() {
+  var interp = new Interpreter();
+
+  doOps(new Value(interp, 1), new Value(interp, 2));
+  doOps(new Value(interp, 1.0), new Value(interp, 2.0));
+  doOps(new Value(interp, "hello"), new Value(interp, "world"));
+}
+
+proc doOps(in lhs, in rhs) throws {
+  writeln("lhs: ", lhs);
+  writeln("rhs: ", rhs);
+
+  writeln(" binary ops:");
+  {
+    var a = lhs + rhs;
+    writeln("  +: ", a, " ", a.type:string);
+    var b = lhs - rhs;
+    writeln("  -: ", b, " ", b.type:string);
+    var c = lhs * rhs;
+    writeln("  *: ", c, " ", c.type:string);
+    var d = lhs / rhs;
+    writeln("  /: ", d, " ", d.type:string);
+    var e = lhs % rhs;
+    writeln("  %: ", e, " ", e.type:string);
+    var f = lhs ** rhs;
+    writeln("  **: ", f, " ", f.type:string);
+    var g = lhs & rhs;
+    writeln("  &: ", g, " ", g.type:string);
+    var h = lhs | rhs;
+    writeln("  |: ", h, " ", h.type:string);
+    var i = lhs ^ rhs;
+    writeln("  ^: ", i, " ", i.type:string);
+    var j = lhs << rhs;
+    writeln("  <<: ", j, " ", j.type:string);
+    var k = lhs >> rhs;
+    writeln("  >>: ", k, " ", k.type:string);
+    var l = lhs == rhs;
+    writeln("  ==: ", l, " ", l.type:string);
+    var m = lhs != rhs;
+    writeln("  !=: ", m, " ", m.type:string);
+    var n = lhs < rhs;
+    writeln("  <: ", n, " ", n.type:string);
+    var o = lhs <= rhs;
+    writeln("  <=: ", o, " ", o.type:string);
+    var p = lhs > rhs;
+    writeln("  >: ", p, " ", p.type:string);
+    var q = lhs >= rhs;
+    writeln("  >=: ", q, " ", q.type:string);
+  }
+
+  writeln(" unary ops:");
+  {
+    var a = +lhs;
+    writeln("  +: ", a, " ", a.type:string);
+    var b = -lhs;
+    writeln("  -: ", b, " ", b.type:string);
+    var c = ~lhs;
+    writeln("  ~: ", c, " ", c.type:string);
+    var d = !lhs;
+    writeln("  !: ", d, " ", d.type:string);
+  }
+
+  writeln(" assignment ops:");
+  {
+    var a = lhs.value(owned Value);
+    a += rhs;
+    writeln("  +=: ", a, " ", a.type:string);
+    var b = lhs.value(owned Value);
+    b -= rhs;
+    writeln("  -=: ", b, " ", b.type:string);
+    var c = lhs.value(owned Value);
+    c *= rhs;
+    writeln("  *=: ", c, " ", c.type:string);
+    var d = lhs.value(owned Value);
+    d /= rhs;
+    writeln("  /=: ", d, " ", d.type:string);
+    var e = lhs.value(owned Value);
+    e %= rhs;
+    writeln("  %=: ", e, " ", e.type:string);
+    var f = lhs.value(owned Value);
+    f **= rhs;
+    writeln("  **=: ", f, " ", f.type:string);
+    var g = lhs.value(owned Value);
+    g &= rhs;
+    writeln("  &=: ", g, " ", g.type:string);
+    var h = lhs.value(owned Value);
+    h |= rhs;
+    writeln("  |=: ", h, " ", h.type:string);
+    var i = lhs.value(owned Value);
+    i ^= rhs;
+    writeln("  ^=: ", i, " ", i.type:string);
+    var j = lhs.value(owned Value);
+    j <<= rhs;
+    writeln("  <<=: ", j, " ", j.type:string);
+    var k = lhs.value(owned Value);
+    k >>= rhs;
+    writeln("  >>=: ", k, " ", k.type:string);
+  }
+  writeln("========================");
+}

--- a/test/library/packages/Python/correctness/pythonOps.chpl
+++ b/test/library/packages/Python/correctness/pythonOps.chpl
@@ -6,7 +6,7 @@ proc main() {
   doOps(new Value(interp, 1), new Value(interp, 2));
   doOps(new Value(interp, 2.0), new Value(interp, 1.0));
   doOps(new Value(interp, "hello"), new Value(interp, "world"));
-  doOps(new Value(interp, true), new Value(interp, false));
+  doOps(new Value(interp, false), new Value(interp, true));
 }
 
 proc doOps(in lhs, in rhs) throws {

--- a/test/library/packages/Python/correctness/pythonOps.good
+++ b/test/library/packages/Python/correctness/pythonOps.good
@@ -1,0 +1,156 @@
+lhs: 1
+rhs: 2
+ binary ops:
+  +: 3 owned Value <class 'int'>
+  -: -1 owned Value <class 'int'>
+  *: 2 owned Value <class 'int'>
+  /: 0.5 owned Value <class 'float'>
+  %: 1 owned Value <class 'int'>
+  **: 1 owned Value <class 'int'>
+  &: 0 owned Value <class 'int'>
+  |: 3 owned Value <class 'int'>
+  ^: 3 owned Value <class 'int'>
+  <<: 4 owned Value <class 'int'>
+  >>: 0 owned Value <class 'int'>
+ comparison ops:
+  ==: false bool
+  !=: true bool
+  <: true bool
+  <=: true bool
+  >: false bool
+  >=: false bool
+ unary ops:
+  +: 1 owned Value <class 'int'>
+  -: -1 owned Value <class 'int'>
+  ~: -2 owned Value <class 'int'>
+  !: False owned Value <class 'bool'>
+ assignment ops:
+  +=: 3 owned Value <class 'int'>
+  -=: -1 owned Value <class 'int'>
+  *=: 2 owned Value <class 'int'>
+  /=: 0.5 owned Value <class 'float'>
+  %=: 1 owned Value <class 'int'>
+  **=: 1 owned Value <class 'int'>
+  &=: 0 owned Value <class 'int'>
+  |=: 3 owned Value <class 'int'>
+  ^=: 3 owned Value <class 'int'>
+  <<=: 4 owned Value <class 'int'>
+  >>=: 0 owned Value <class 'int'>
+========================
+lhs: 2.0
+rhs: 1.0
+ binary ops:
+  +: 3.0 owned Value <class 'float'>
+  -: 1.0 owned Value <class 'float'>
+  *: 2.0 owned Value <class 'float'>
+  /: 2.0 owned Value <class 'float'>
+  %: 0.0 owned Value <class 'float'>
+  **: 2.0 owned Value <class 'float'>
+  &: Exception: unsupported operand type(s) for &: 'float' and 'float'
+  |: Exception: unsupported operand type(s) for |: 'float' and 'float'
+  ^: Exception: unsupported operand type(s) for ^: 'float' and 'float'
+  <<: Exception: unsupported operand type(s) for <<: 'float' and 'float'
+  >>: Exception: unsupported operand type(s) for >>: 'float' and 'float'
+ comparison ops:
+  ==: false bool
+  !=: true bool
+  <: false bool
+  <=: false bool
+  >: true bool
+  >=: true bool
+ unary ops:
+  +: 2.0 owned Value <class 'float'>
+  -: -2.0 owned Value <class 'float'>
+  ~: Exception: bad operand type for unary ~: 'float'
+  !: False owned Value <class 'bool'>
+ assignment ops:
+  +=: 3.0 owned Value <class 'float'>
+  -=: 1.0 owned Value <class 'float'>
+  *=: 2.0 owned Value <class 'float'>
+  /=: 2.0 owned Value <class 'float'>
+  %=: 0.0 owned Value <class 'float'>
+  **=: 2.0 owned Value <class 'float'>
+  &=: Exception: unsupported operand type(s) for &=: 'float' and 'float'
+  |=: Exception: unsupported operand type(s) for |=: 'float' and 'float'
+  ^=: Exception: unsupported operand type(s) for ^=: 'float' and 'float'
+  <<=: Exception: unsupported operand type(s) for <<=: 'float' and 'float'
+  >>=: Exception: unsupported operand type(s) for >>=: 'float' and 'float'
+========================
+lhs: hello
+rhs: world
+ binary ops:
+  +: helloworld owned Value <class 'str'>
+  -: Exception: unsupported operand type(s) for -: 'str' and 'str'
+  *: Exception: can't multiply sequence by non-int of type 'str'
+  /: Exception: unsupported operand type(s) for /: 'str' and 'str'
+  %: Exception: not all arguments converted during string formatting
+  **: Exception: unsupported operand type(s) for ** or pow(): 'str' and 'str'
+  &: Exception: unsupported operand type(s) for &: 'str' and 'str'
+  |: Exception: unsupported operand type(s) for |: 'str' and 'str'
+  ^: Exception: unsupported operand type(s) for ^: 'str' and 'str'
+  <<: Exception: unsupported operand type(s) for <<: 'str' and 'str'
+  >>: Exception: unsupported operand type(s) for >>: 'str' and 'str'
+ comparison ops:
+  ==: false bool
+  !=: true bool
+  <: true bool
+  <=: true bool
+  >: false bool
+  >=: false bool
+ unary ops:
+  +: Exception: bad operand type for unary +: 'str'
+  -: Exception: bad operand type for unary -: 'str'
+  ~: Exception: bad operand type for unary ~: 'str'
+  !: False owned Value <class 'bool'>
+ assignment ops:
+  +=: helloworld owned Value <class 'str'>
+  -=: Exception: unsupported operand type(s) for -=: 'str' and 'str'
+  *=: Exception: can't multiply sequence by non-int of type 'str'
+  /=: Exception: unsupported operand type(s) for /=: 'str' and 'str'
+  %=: Exception: not all arguments converted during string formatting
+  **=: Exception: unsupported operand type(s) for **=: 'str' and 'str'
+  &=: Exception: unsupported operand type(s) for &=: 'str' and 'str'
+  |=: Exception: unsupported operand type(s) for |=: 'str' and 'str'
+  ^=: Exception: unsupported operand type(s) for ^=: 'str' and 'str'
+  <<=: Exception: unsupported operand type(s) for <<=: 'str' and 'str'
+  >>=: Exception: unsupported operand type(s) for >>=: 'str' and 'str'
+========================
+lhs: True
+rhs: False
+ binary ops:
+  +: 1 owned Value <class 'int'>
+  -: 1 owned Value <class 'int'>
+  *: 0 owned Value <class 'int'>
+  /: Exception: division by zero
+  %: Exception: integer modulo by zero
+  **: 1 owned Value <class 'int'>
+  &: False owned Value <class 'bool'>
+  |: True owned Value <class 'bool'>
+  ^: True owned Value <class 'bool'>
+  <<: 1 owned Value <class 'int'>
+  >>: 1 owned Value <class 'int'>
+ comparison ops:
+  ==: false bool
+  !=: true bool
+  <: false bool
+  <=: false bool
+  >: true bool
+  >=: true bool
+ unary ops:
+  +: 1 owned Value <class 'int'>
+  -: -1 owned Value <class 'int'>
+  ~: -2 owned Value <class 'int'>
+  !: False owned Value <class 'bool'>
+ assignment ops:
+  +=: 1 owned Value <class 'int'>
+  -=: 1 owned Value <class 'int'>
+  *=: 0 owned Value <class 'int'>
+  /=: Exception: division by zero
+  %=: Exception: integer modulo by zero
+  **=: 1 owned Value <class 'int'>
+  &=: False owned Value <class 'bool'>
+  |=: True owned Value <class 'bool'>
+  ^=: True owned Value <class 'bool'>
+  <<=: 1 owned Value <class 'int'>
+  >>=: 1 owned Value <class 'int'>
+========================

--- a/test/library/packages/Python/correctness/pythonOps.good
+++ b/test/library/packages/Python/correctness/pythonOps.good
@@ -115,42 +115,42 @@ rhs: world
   <<=: Exception: unsupported operand type(s) for <<=: 'str' and 'str'
   >>=: Exception: unsupported operand type(s) for >>=: 'str' and 'str'
 ========================
-lhs: True
-rhs: False
+lhs: False
+rhs: True
  binary ops:
   +: 1 owned Value <class 'int'>
-  -: 1 owned Value <class 'int'>
+  -: -1 owned Value <class 'int'>
   *: 0 owned Value <class 'int'>
-  /: Exception: division by zero
-  %: Exception: integer modulo by zero
-  **: 1 owned Value <class 'int'>
+  /: 0.0 owned Value <class 'float'>
+  %: 0 owned Value <class 'int'>
+  **: 0 owned Value <class 'int'>
   &: False owned Value <class 'bool'>
   |: True owned Value <class 'bool'>
   ^: True owned Value <class 'bool'>
-  <<: 1 owned Value <class 'int'>
-  >>: 1 owned Value <class 'int'>
+  <<: 0 owned Value <class 'int'>
+  >>: 0 owned Value <class 'int'>
  comparison ops:
   ==: false bool
   !=: true bool
-  <: false bool
-  <=: false bool
-  >: true bool
-  >=: true bool
+  <: true bool
+  <=: true bool
+  >: false bool
+  >=: false bool
  unary ops:
-  +: 1 owned Value <class 'int'>
-  -: -1 owned Value <class 'int'>
-  ~: -2 owned Value <class 'int'>
-  !: False owned Value <class 'bool'>
+  +: 0 owned Value <class 'int'>
+  -: 0 owned Value <class 'int'>
+  ~: -1 owned Value <class 'int'>
+  !: True owned Value <class 'bool'>
  assignment ops:
   +=: 1 owned Value <class 'int'>
-  -=: 1 owned Value <class 'int'>
+  -=: -1 owned Value <class 'int'>
   *=: 0 owned Value <class 'int'>
-  /=: Exception: division by zero
-  %=: Exception: integer modulo by zero
-  **=: 1 owned Value <class 'int'>
+  /=: 0.0 owned Value <class 'float'>
+  %=: 0 owned Value <class 'int'>
+  **=: 0 owned Value <class 'int'>
   &=: False owned Value <class 'bool'>
   |=: True owned Value <class 'bool'>
   ^=: True owned Value <class 'bool'>
-  <<=: 1 owned Value <class 'int'>
-  >>=: 1 owned Value <class 'int'>
+  <<=: 0 owned Value <class 'int'>
+  >>=: 0 owned Value <class 'int'>
 ========================

--- a/test/library/packages/Python/correctness/pythonOps.prediff
+++ b/test/library/packages/Python/correctness/pythonOps.prediff
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# fixup for python <=3.9
+sed -e 's/\*\*=: Exception: unsupported operand type(s) for \*\* or pow()/**=: Exception: unsupported operand type(s) for **=/' $2 > $2.tmp
+mv $2.tmp $2


### PR DESCRIPTION
Adds native support for calling operator methods on Python objects via Chapel operators.

This allows users to natively write `myPyObj + myOtherPyObj`, rather than `myPyObj.call('__add__', myOtherPyObj)`.

This PR also adds the `pyType` method to get the type of a Python object, essentially `type(obj)` in Python

Resolves https://github.com/chapel-lang/chapel/issues/26911

- [x] `start_test test/library/packages/Python` with COMM=none and Python 3.13
- [x] `start_test test/library/packages/Python` with COMM=gasnet and Python 3.10

[Reviewed by @lydia-duncan]