### PR TITLE
Add prediff for Python module test with version sensitive output

### DIFF
--- a/test/library/packages/Python/correctness/exceptionsFromInit.prediff
+++ b/test/library/packages/Python/correctness/exceptionsFromInit.prediff
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+sed "s/('invalid syntax', ('<string>'.*$/invalid syntax (<string>, line 1)/" $2 > $2.tmp
+mv $2.tmp $2


### PR DESCRIPTION
Adds a prediff for a Python module test whose output can change based on the Python version used.

[Reviewed by @lydia-duncan]