### PR TITLE
Add missing `const` qualifiers from `char*` declarations

### DIFF
--- a/runtime/src/launch/slurm-gasnetrun_common/slurm-gasnetrun_common.h
+++ b/runtime/src/launch/slurm-gasnetrun_common/slurm-gasnetrun_common.h
@@ -319,7 +319,7 @@ static char* chpl_launch_create_command(int argc, char* argv[],
 
     fclose(slurmFile);
     chmod(slurmFilename, 0755);
-    char* format="sbatch %s\n";
+    const char* format="sbatch %s\n";
     int baseCommandLen = strlen(slurmFilename) + strlen(format);
     baseCommand = (char*)chpl_mem_allocMany(baseCommandLen, sizeof(char),
                                             CHPL_RT_MD_COMMAND_BUFFER, -1, 0);
@@ -352,7 +352,7 @@ static char* chpl_launch_create_command(int argc, char* argv[],
     for (i=1; i<argc; i++) {
       chpl_append_to_cmd(&iCom, &len, " '%s'", argv[i]);
     }
-    char* format = "salloc %s";
+    const char* format = "salloc %s";
     int baseCommandLen = strlen(format) + len + 1;
     baseCommand = (char*)chpl_mem_allocMany(baseCommandLen, sizeof(char),
                                             CHPL_RT_MD_COMMAND_BUFFER, -1, 0);


### PR DESCRIPTION
The code here is longstanding, but has recently started getting tested in GASNet's test configurations as a result of #26236, which makes greater use of slurm by default.  They compile in developer mode to get maximal errors and warnings, and that tripped a warning for some `char* ... = "literal";` declarations that should've been `const char*`.

This suggests that we should potentially be dialing up warnings in our own nightly testing, which is somewhat thematically related to https://github.com/Cray/chapel-private/issues/3138
