### PR TITLE
Dyno: enable PoI instantiation cache and make other perf. optimizations

### DIFF
--- a/frontend/include/chpl/framework/Context-detail.h
+++ b/frontend/include/chpl/framework/Context-detail.h
@@ -273,6 +273,13 @@ class QueryMapResultBase {
   // and that field is used for a lot of things, so for the time being, the
   // extra boolean is fine.
   mutable bool beingTestedForReuse = false;
+  // queries that aren't set in "usual" ways (e.g., ones that are set by
+  // another query) should be marked externallySet. This ensures that these queries,
+  // which would have no dependencies and thus always look like their result
+  // can be reused, are treated properly. For the most part, this means that
+  // queries that rely on an externally set query will be recomputed, possibly
+  // prompting the externally-set query to be set again.
+  mutable bool externallySet = false;
 
   // Whether or not errors from this query result have been shown to the
   // user (they may not have been if some query checked for errors).
@@ -314,6 +321,7 @@ class QueryMapResultBase {
   QueryMapResultBase(RevisionNumber lastChecked,
                      RevisionNumber lastChanged,
                      bool beingTestedForReuse,
+                     bool externallySet,
                      bool emittedErrors,
                      size_t oldResultForErrorContents,
                      llvm::SmallPtrSet<const QueryMapResultBase*, 2> recursionErrors,
@@ -336,7 +344,7 @@ class QueryMapResult final : public QueryMapResultBase {
   //  * a default-constructed result
   QueryMapResult(QueryMap<ResultType, ArgTs...>* parentQueryMap,
                  std::tuple<ArgTs...> tupleOfArgs)
-    : QueryMapResultBase(-1, -1, false, false, -1, {}, parentQueryMap),
+    : QueryMapResultBase(-1, -1, false, false, false, -1, {}, parentQueryMap),
       tupleOfArgs(std::move(tupleOfArgs)),
       result() {
   }

--- a/frontend/include/chpl/framework/Context.h
+++ b/frontend/include/chpl/framework/Context.h
@@ -466,7 +466,8 @@ class Context {
       const querydetail::QueryMapResult<ResultType, ArgTs...>* r,
       const std::tuple<ArgTs...>& tupleOfArgs,
       ResultType result,
-      bool forSetter);
+      bool forSetter,
+      bool markExternallySet);
 
   template<typename ResultType,
            typename... ArgTs>
@@ -475,7 +476,8 @@ class Context {
       querydetail::QueryMap<ResultType, ArgTs...>* queryMap,
       const std::tuple<ArgTs...>& tupleOfArgs,
       ResultType result,
-      bool forSetter);
+      bool forSetter,
+      bool markExternallySet);
 
   template<typename ResultType,
            typename... ArgTs>
@@ -486,7 +488,8 @@ class Context {
        ResultType result,
        const char* traceQueryName,
        bool isInputQuery,
-       bool forSetter);
+       bool forSetter,
+       bool markExternallySet);
 
   void recomputeIfNeeded(const querydetail::QueryMapResultBase* resultEntry);
   void updateForReuse(const querydetail::QueryMapResultBase* resultEntry);
@@ -1108,7 +1111,8 @@ class Context {
       const std::tuple<ArgTs...>& tupleOfArgs,
       ResultType result,
       const char* traceQueryName,
-      bool isInputQuery);
+      bool isInputQuery,
+      bool markExternallySet);
 
 
   /**

--- a/frontend/include/chpl/framework/all-global-strings.h
+++ b/frontend/include/chpl/framework/all-global-strings.h
@@ -28,6 +28,7 @@
 
 X(tombstone           , "<tombstone>")
 X(empty               , "<empty>")
+X(unknownLibPath      , "<unknown library path>")
 X(align               , "align")
 X(assertOnGpu         , "assertOnGpu")
 X(atomic              , "atomic")

--- a/frontend/include/chpl/framework/query-impl.h
+++ b/frontend/include/chpl/framework/query-impl.h
@@ -672,6 +672,16 @@ Context::querySetterUpdateResult(
   auto QUERY_RECOMPUTATION_MARKER = context->markRecomputing(false); \
   QUERY_BEGIN_TIMING(context);
 
+#define QUERY_BEGIN_EXTERNALLY_SET(func, context, ...) \
+  QUERY_BEGIN_INNER(false, func, #func, context, __VA_ARGS__); \
+  BEGIN_QUERY_FOUND->externallySet = true; \
+  if (QUERY_USE_SAVED()) { \
+    return QUERY_GET_SAVED(); \
+  } \
+  CHPL_ASSERT(false && "query configured to be only set by other queries is being computed on its own"); \
+  auto QUERY_RECOMPUTATION_MARKER = context->markRecomputing(false); \
+  QUERY_BEGIN_TIMING(context);
+
 /**
   Write
 

--- a/frontend/include/chpl/resolution/ResolutionContext.h
+++ b/frontend/include/chpl/resolution/ResolutionContext.h
@@ -500,7 +500,8 @@ class ResolutionContext::GlobalQuery {
   void inactiveStore(RetByVal x) {
     context_->querySetterUpdateResult(QUERY, ap_, std::move(x),
                                       name_,
-                                      isInput_);
+                                      isInput_,
+                                      /* markExternallySet */ false);
   }
 
   bool isRunning() {
@@ -674,7 +675,7 @@ ResolutionContext createDummyRC(Context* context);
 #define CHPL_RESOLUTION_REF_TO_CURRENT_QUERY_HANDLE() (rcquery__)
 
 /** Use this to store a result for any 'CHPL_RESOLUTION_QUERY...' query. */
-#define CHPL_RESOLUTION_QUERY_STORE_RESULT(fn__, rc__, x__, ...) do { \
+#define CHPL_RESOLUTION_QUERY_UNSAFE_STORE_RESULT(fn__, rc__, x__, ...) do { \
     auto rcq__ = rc__->createQueryClass<fn__>(#fn__, __VA_ARGS__); \
     rcq__.inactiveStore(std::move(x__)); \
   } while (0)

--- a/frontend/lib/framework/Context.cpp
+++ b/frontend/lib/framework/Context.cpp
@@ -721,7 +721,8 @@ void Context::setFilePathForModuleId(ID moduleID, UniqueString path) {
                        tupleOfArgs, path,
                        "filePathForModuleIdSymbolPathQuery",
                        /* isInputQuery */ false,
-                       /* forSetter */ true);
+                       /* forSetter */ true,
+                       /* markExternallySet */ false);
 
   if (enableDebugTrace) {
     printf("%i SETTING FILE PATH FOR MODULE %s -> %s\n", queryTraceDepth,
@@ -810,7 +811,8 @@ void Context::registerLibraryForModule(ID moduleId,
                        tupleOfArgs, libPath,
                        "pathHasLibraryQuery",
                        /* isInputQuery */ false,
-                       /* forSetter */ true);
+                       /* forSetter */ true,
+                       /* markExternallySet */ false);
 
   // also update the lookup by module ID
   setFilePathForModuleId(moduleId, filePath);

--- a/frontend/lib/framework/Context.cpp
+++ b/frontend/lib/framework/Context.cpp
@@ -784,7 +784,7 @@ bool Context::pathIsInLibrary(UniqueString filePath,
     return true;
   }
 
-  pathOut = UniqueString::get(this, "<unknown library path>");
+  pathOut = USTR("<unknown library path>");
   return false;
 }
 

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2868,9 +2868,10 @@ static const ResolvedFunction* const&
 resolveFunctionByResolvedInfoQuery(Context* context,
                                    const TypedFnSignature* sig,
                                    PoiInfo poiInfo) {
-  QUERY_BEGIN(resolveFunctionByResolvedInfoQuery, context, sig, poiInfo);
+  QUERY_BEGIN_EXTERNALLY_SET(resolveFunctionByResolvedInfoQuery, context, sig, poiInfo);
 
-  // should only ever be SET by 'resolveFunctionByInfoQuery'
+  // should only ever be SET by 'resolveFunctionByInfoQuery'. Since we got
+  // here, something is wrong; return a bogus result.
   const ResolvedFunction* ret = nullptr;
 
   return QUERY_END(ret);

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2899,7 +2899,7 @@ resolveFunctionByInfoQuery(ResolutionContext* rc,
     auto resolvedPoiTrace = resolved->poiInfo().createTraceFor(sig);
 
     // Try to store in the generic cache.
-    CHPL_RESOLUTION_QUERY_STORE_RESULT(resolveFunctionByPoisQuery, rc,
+    CHPL_RESOLUTION_QUERY_UNSAFE_STORE_RESULT(resolveFunctionByPoisQuery, rc,
         std::move(resolved),
         resolvedPoiTrace);
 
@@ -2914,7 +2914,7 @@ resolveFunctionByInfoQuery(ResolutionContext* rc,
     // which links the fully resolved signature to the result.
     if (finalSig != sig) {
       auto& saved = resolveFunctionByPoisQuery(rc, resolvedPoiTrace);
-      CHPL_RESOLUTION_QUERY_STORE_RESULT(resolveFunctionByInfoQuery, rc,
+      CHPL_RESOLUTION_QUERY_UNSAFE_STORE_RESULT(resolveFunctionByInfoQuery, rc,
           saved.get(),
           finalSig,
           poiInfo);

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2864,6 +2864,46 @@ resolveFunctionByPoisQuery(ResolutionContext* rc, PoiInfo::Trace poiTrace) {
   return CHPL_RESOLUTION_QUERY_END(ret);
 }
 
+// Why does this query exist in addition to resolveFunctionByInfoQuery?
+//
+// Overall, the goal is to enable generic instantiation caching. There are,
+// in fact, two kinds of PoiInfo: resolved and unresolved ones, which
+// correspond loosely to "before instantiation" and "after instantiation".
+//
+// Unresolved PoI infos simply contain a PoI scope in which a function's
+// body should be resolved. Caching these queries would prevent having
+// to re-resolve a function called mutliple times from the same scope, but
+// it will not do anything clever about PoI compatibility (see see PR #16261, e.g.).
+//
+// Resolved PoI infos don't contain the scope in which they were resolved; instead,
+// they contain a trace of all functions that used PoI. By the logic described
+// in PR #16261, the same instantiation can be re-used in another PoI scope if
+// all PoI calls in its trace are visible from that other scope. As a special
+// case, a function that didn't use any PoI calls can be re-used in any scope.
+//
+// Resolved PoI infos have two important properties:
+// 2. They can only be constructed after resolving a function instantiation.
+//    Pragmatically, this means that they can't serve as a-priori inputs
+//    to "resolveFunction" (otherwise, we'd need to resolve the function
+//    to resolve the function).
+//
+//    This hints at the need for two queries, one that gets called with the
+//    "initial" PoI scope, and one that gets set after the function is resolved.
+//
+// 1. Importantly, by removing the PoI scope and replacing it with the trace,
+//    resolved PoiInfos actually describe _sets of PoI scopes_ that are compatible
+//    with a given instantiation for the purposes of reuse. The compatibility
+//    check is encoded in PoiInfo::canReuse. In fact, to fit into the query framework,
+//    the '==' operator is relaxed to "compatibility": uInfo == rInfo is true
+//    if the unresolved info uInfo is compatible with the resolved info rInfo.
+//
+//    This essentially forces a query that operates on "resolved" infos to
+//    not have any dependencies, because it represents a related set of
+//    resolutions, each of which would presumably have different dependencies.
+//    Having incompatible dependencies would wreak havoc on the query system.
+//    Instead, we have '...ByInfoQuery', which includes all the dependencies
+//    of resolving the function, and '...ByResolvedInfoQuery', which is
+//    set and used when possible.
 static const ResolvedFunction* const&
 resolveFunctionByResolvedInfoQuery(Context* context,
                                    const TypedFnSignature* sig,
@@ -2884,6 +2924,12 @@ resolveFunctionByInfoQuery(ResolutionContext* rc,
   CHPL_RESOLUTION_QUERY_BEGIN(resolveFunctionByInfoQuery, rc, sig, poiInfo);
 
   const ResolvedFunction* ret = nullptr;
+  // note: this lookup searches for "compatible" post-resolution POI infos
+  //       because we're feeding it an unresolved PoI info, and its
+  //       entries are always stored from resolved PoI infos. Operator ==
+  //       decides compatibility in that case. See comment on
+  //       resolveFunctionByResolvedInfoQuery, and the implementation
+  //       of PoiInfo::operator==.
   if (rc->context()->hasCurrentResultForQuery(resolveFunctionByResolvedInfoQuery,
                                               std::make_tuple(sig, poiInfo))) {
     ret = resolveFunctionByResolvedInfoQuery(rc->context(), sig, poiInfo);

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -1190,6 +1190,16 @@ void PoiInfo::accumulateRecursive(const TypedFnSignature* signature,
 bool PoiInfo::canReuse(const PoiInfo& check) const {
   CHPL_ASSERT(resolved_ && !check.resolved_);
 
+  if (poiScope_ == check.poiScope_) {
+    // if the POI scopes are the same, then we can reuse
+    return true;
+  }
+
+  if (poiFnIdsUsed_.empty() && recursiveFnsUsed_.empty()) {
+    // if we have no POI functions used, then we can reuse
+    return true;
+  }
+
   // Performance TODO: consider function names etc -- see PR #16261
   return false;
 }


### PR DESCRIPTION
Depends on https://github.com/chapel-lang/chapel/pull/27082.

This PR is another in a series of efforts to improve Dyno's performance. It has some minor changes, as well as a major one: enabling a rudimentary caching of function instantiations. Specifically, this PR enables caching and re-use of functions that did not use PoI (most of them, it turns out!). This had a huge impact on resolution performance: in my benchmarks, `chpl --dyno-resolve-only` is now __15-22% faster than production__ with `--stop-after-pass=resolve`.

## Memory performance
In this PR, I spent a considerable amount of time looking at the memory allocations in Dyno, motivated by the fact that, when comparing performance, Dyno spent significantly more time in the "system", but a comparable amount of time in "user" execution. I assumed that File IO could not be the cause (presumably both Dyno and production are reading the same files), which made me investigate allocations. Indeed, Dyno makes a number of small allocations, and this is what I targeted first.

1. A global string, `<unknown library path>`, was being interned numerous times. This PR makes it a global, pre-allocated string, which greatly reduced the number of allocations while attempting to intern the string.
2. ~~The `CheckedScopes` set was updated numerous times as part of scope resolution, triggering small allocations. This PR switches to using C++'s [memory_resource](https://en.cppreference.com/w/cpp/header/memory_resource) framework, which enables stack-allocating some storage for the `CheckedScopes` set. This led to a modest performance improvement (around 3%)~~
    * Apparently, this C++17 stdlib feature is not available prior to GCC 9.1, which is above our minimum of 7.5. Since it's not as crucial to the improvements in this PR, I've removed it to enable all builds to pass.

## Instantiation Caching
I also tackled a direction suggested by @mppf: enabling re-use of function instantiations like production does (#16261). As a specific case, because functions that resolve without PoI are guaranteed to resolve in any PoI scope (because non-PoI candidates are always preferred), there's no need to re-resolve their bodies. This PR enables the specific case by building on the `PoiInfo` framework already in place through Michael's efforts.

Although it seems to me that the `PoiInfo` was intended to fit into the `resolveFunctionByInfo` query (and enable other queries to use "similar", but not equal, calls to the query), I found that it's most efficient to introduce _another_ query (`resolveFunctionByResolvedInfo`). The current scheme is as follows:

* `resolveFunctionByInfo` caches results of resolving a function in a particular PoI scope. This is for _any_ resolution, including resolutions that ended up using PoI functions. This appears useful when a function that uses PoI (and thus, is not covered by the optimization in this PR, which re-uses results of non-PoI instantiations), is called multiple times in the same scope.
* `resolveFunctionByResolvedInfo` caches function instantiations along with their "PoI traces" (which track all PoI calls). This cache is queried based on `PoiInfo::canReuse`, which today simply checks if no POI function calls were made when resolving the body of the function. This covers a very large number of generic functions in a standard library. In the future, if `canReuse` is extended to check more cases, `resolveFunctionByResolvedInfo` will start caching those results too.

Importantly, "PoI traces" used as keys for the `resolveFunctionByResolvedInfo` query can only be computed after a function is resolved. This necessitates having `resolveFunctionByInfo` set `resolveFunctionByResolvedInfo`. However, naively, setting queries does not fit into the query system. As a result, this PR adjusts the `QUERY_STORE_RESULT` to behave sanely, by invalidating results that were "stored" into queries externally under recomputation.

## Results

In release mode, I've observed the following times:

| Test                  | Time to resolve `issue-7139.chpl` | Cumulative improvement |
|-----------------------|-----------------------------------|------------------------|
| reference             | 3.15s                             | -                      |
| memory optimizations  | 3.05s                             | 3%                     |
| instantiation caching | 2.0s                              | 36%                    |

Comparisons to production are encouraging as well.

|                          | Time (Dyno #27082) | Time (Dyno, this PR) | Time (Production)  | Relative Time (Production vs Dyno, this PR, __higher is better__) |
|--------------------------|--------------------|----------------------|--------------------|-------------------------------------------------------------------|
| Issue 7139 (Motivator)   | 3.140 s ±  0.034 s | 1.968 s ±  0.052 s   | 2.364 s ±  0.020 s | 1.22 ± 0.01                                                       |
| `parIters.chpl` primer   | 2.372 s ±  0.029 s | 1.918 s ±  0.041 s   | 2.181 s ±  0.027 s | 1.14 ± 0.03                                                       |
| `atomics.chpl` primer    | 2.177 s ±  0.038 s | 1.888 s ±  0.040 s   | 2.148 s ±  0.022 s | 1.14 ± 0.03                                                       |
| `forallLoops.chp` primer | 2.468 s ±  0.032 s | 1.936 s ±  0.034 s   | 2.209 s ±  0.037 s | 1.14 ± 0.03                                                       |

**Above, we were 15-22% better than production.** 

> [!WARNING]  
> These performance results do not and will not represent Dyno's final performance. Dyno is not capable of resolving every primer, which indicates that there may be features missing (and thus, not "costing time"), and makes it so that I cannot perform an accurate performance analysis on a fully representative sample of programs.
>
> Moreover, Dyno's performance often comes down to caching. This might mean that for large programs (which consume more cache space), the time savings will be smaller.

Reviewed by @dlongnecke-cray -- thanks!

## Testing
- performance tests (see above)
- dyno tests (4x faster now than the used to be before my work!)
- paratest