### PR TITLE
Move nvidia testing to a different partition, cleanup scripts a bit

### DIFF
--- a/util/cron/common-gpu-nvidia-hpe-cray-ex.bash
+++ b/util/cron/common-gpu-nvidia-hpe-cray-ex.bash
@@ -1,0 +1,3 @@
+# common settings for running GPU nightly testing on the HPE Cray EX system
+
+export CHPL_LAUNCHER_PARTITION=griz512

--- a/util/cron/test-gpu-ex-cuda-11.bash
+++ b/util/cron/test-gpu-ex-cuda-11.bash
@@ -5,6 +5,7 @@
 UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common-native-gpu.bash
 source $UTIL_CRON_DIR/common-hpe-cray-ex.bash
+source $UTIL_CRON_DIR/common-gpu-nvidia-hpe-cray-ex.bash
 
 module load cuda/11.8
 
@@ -14,7 +15,6 @@ export CHPL_CUDA_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/23.3/cuda/11.8
 
 export CHPL_COMM=none
 export CHPL_LOCALE_MODEL=gpu
-export CHPL_LAUNCHER_PARTITION=griz256
 export CHPL_GPU=nvidia  # amd is also detected automatically
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-ex-cuda-11"

--- a/util/cron/test-gpu-ex-cuda-11.bash
+++ b/util/cron/test-gpu-ex-cuda-11.bash
@@ -14,7 +14,6 @@ module load cuda/11.8
 export CHPL_CUDA_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/23.3/cuda/11.8
 
 export CHPL_COMM=none
-export CHPL_LOCALE_MODEL=gpu
 export CHPL_GPU=nvidia  # amd is also detected automatically
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-ex-cuda-11"

--- a/util/cron/test-gpu-ex-cuda-12.bash
+++ b/util/cron/test-gpu-ex-cuda-12.bash
@@ -5,13 +5,13 @@
 UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common-native-gpu.bash
 source $UTIL_CRON_DIR/common-hpe-cray-ex.bash
+source $UTIL_CRON_DIR/common-gpu-nvidia-hpe-cray-ex.bash
 
 module load cuda/12.4
 
 export CHPL_LLVM=system
 export CHPL_COMM=none
 export CHPL_LOCALE_MODEL=gpu
-export CHPL_LAUNCHER_PARTITION=griz256
 export CHPL_GPU=nvidia  # amd is also detected automatically
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-ex-cuda-12"

--- a/util/cron/test-gpu-ex-cuda-12.bash
+++ b/util/cron/test-gpu-ex-cuda-12.bash
@@ -11,7 +11,6 @@ module load cuda/12.4
 
 export CHPL_LLVM=system
 export CHPL_COMM=none
-export CHPL_LOCALE_MODEL=gpu
 export CHPL_GPU=nvidia  # amd is also detected automatically
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-ex-cuda-12"

--- a/util/cron/test-gpu-ex-cuda-12.colocales.bash
+++ b/util/cron/test-gpu-ex-cuda-12.colocales.bash
@@ -6,12 +6,12 @@ UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common-native-gpu.bash
 source $UTIL_CRON_DIR/common-hpe-cray-ex.bash
 source $UTIL_CRON_DIR/common-ofi.bash
+source $UTIL_CRON_DIR/common-gpu-nvidia-hpe-cray-ex.bash
 
 export SLURM_NETWORK=single_node_vni
 export CHPL_RT_LOCALES_PER_NODE=2
 module load cuda/12.4
 
-export CHPL_LAUNCHER_PARTITION=griz256
 export CHPL_GPU=nvidia
 export CHPL_NIGHTLY_TEST_DIRS="gpu/native/multiLocale"
 

--- a/util/cron/test-gpu-ex-cuda-12.interop.bash
+++ b/util/cron/test-gpu-ex-cuda-12.interop.bash
@@ -5,6 +5,7 @@
 UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common.bash
 source $UTIL_CRON_DIR/common-hpe-cray-ex.bash
+source $UTIL_CRON_DIR/common-gpu-nvidia-hpe-cray-ex.bash
 
 
 # We need 12.4 for the stream test because the CUDA driver on pinoak
@@ -20,7 +21,6 @@ export CHPL_LIB_PATH="/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/math_libs/lib64:$CHP
 
 export CHPL_LLVM=system
 export CHPL_TEST_GPU=true
-export CHPL_LAUNCHER_PARTITION=griz256
 export CHPL_NIGHTLY_TEST_DIRS="gpu/interop/"
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-ex-cuda-12.interop"

--- a/util/cron/test-gpu-ex-cuda-12.ofi.bash
+++ b/util/cron/test-gpu-ex-cuda-12.ofi.bash
@@ -11,7 +11,6 @@ module load cuda/12.4
 
 export CHPL_LLVM=system
 export CHPL_COMM=ofi
-export CHPL_LOCALE_MODEL=gpu
 export CHPL_GPU=nvidia  # amd is also detected automatically
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-ex-cuda-12.ofi"

--- a/util/cron/test-gpu-ex-cuda-12.ofi.bash
+++ b/util/cron/test-gpu-ex-cuda-12.ofi.bash
@@ -5,13 +5,13 @@
 UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common-native-gpu.bash
 source $UTIL_CRON_DIR/common-hpe-cray-ex.bash
+source $UTIL_CRON_DIR/common-gpu-nvidia-hpe-cray-ex.bash
 
 module load cuda/12.4
 
 export CHPL_LLVM=system
 export CHPL_COMM=ofi
 export CHPL_LOCALE_MODEL=gpu
-export CHPL_LAUNCHER_PARTITION=griz256
 export CHPL_GPU=nvidia  # amd is also detected automatically
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-ex-cuda-12.ofi"

--- a/util/cron/test-gpu-ex-cuda-12.specialization.bash
+++ b/util/cron/test-gpu-ex-cuda-12.specialization.bash
@@ -5,13 +5,13 @@
 UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common-native-gpu.bash
 source $UTIL_CRON_DIR/common-hpe-cray-ex.bash
+source $UTIL_CRON_DIR/common-gpu-hpe-cray-ex.bash
 
 module load cuda/12.4
 
 export CHPL_LLVM=system
 export CHPL_COMM=none
 export CHPL_LOCALE_MODEL=gpu
-export CHPL_LAUNCHER_PARTITION=griz256
 export CHPL_TEST_GPU=true
 export CHPL_GPU=nvidia  # amd is also detected automatically
 

--- a/util/cron/test-gpu-ex-cuda-12.specialization.bash
+++ b/util/cron/test-gpu-ex-cuda-12.specialization.bash
@@ -11,8 +11,6 @@ module load cuda/12.4
 
 export CHPL_LLVM=system
 export CHPL_COMM=none
-export CHPL_LOCALE_MODEL=gpu
-export CHPL_TEST_GPU=true
 export CHPL_GPU=nvidia  # amd is also detected automatically
 
 export CHPL_GPU_SPECIALIZATION=y

--- a/util/cron/test-gpu-ex-rocm-62.bash
+++ b/util/cron/test-gpu-ex-rocm-62.bash
@@ -11,7 +11,6 @@ module load rocm/6.2.0  # pin to rocm 6.2.0
 export CHPL_COMM=none
 export CHPL_LLVM=bundled
 unset CHPL_LLVM_CONFIG  # we need this to avoid warnings
-export CHPL_LOCALE_MODEL=gpu
 export CHPL_LAUNCHER_PARTITION=bardpeak  # bardpeak is the default queue
 export CHPL_GPU=amd  # also detected by default
 export CHPL_GPU_ARCH=gfx90a

--- a/util/cron/test-gpu-ex-rocm-62.ofi.bash
+++ b/util/cron/test-gpu-ex-rocm-62.ofi.bash
@@ -11,7 +11,6 @@ module load rocm/6.2.0  # pin to rocm 6.2.0
 export CHPL_COMM=ofi
 export CHPL_LLVM=bundled
 unset CHPL_LLVM_CONFIG  # we need this to avoid warnings
-export CHPL_LOCALE_MODEL=gpu
 export CHPL_LAUNCHER_PARTITION=bardpeak  # bardpeak is the default queue
 export CHPL_GPU=amd  # also detected by default
 export CHPL_GPU_ARCH=gfx90a

--- a/util/cron/test-perf.gpu-ex-cuda-12.bash
+++ b/util/cron/test-perf.gpu-ex-cuda-12.bash
@@ -5,13 +5,13 @@
 UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common-native-gpu.bash
 source $UTIL_CRON_DIR/common-hpe-cray-ex.bash
+source $UTIL_CRON_DIR/common-gpu-nvidia-hpe-cray-ex.bash
 
 module load cuda/12.4
 
 export CHPL_LLVM=system
 export CHPL_COMM=none
 export CHPL_LOCALE_MODEL=gpu
-export CHPL_LAUNCHER_PARTITION=griz256
 export CHPL_GPU=nvidia  # amd is detected automatically
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.gpu-ex-cuda-12"

--- a/util/cron/test-perf.gpu-ex-cuda-12.bash
+++ b/util/cron/test-perf.gpu-ex-cuda-12.bash
@@ -11,7 +11,6 @@ module load cuda/12.4
 
 export CHPL_LLVM=system
 export CHPL_COMM=none
-export CHPL_LOCALE_MODEL=gpu
 export CHPL_GPU=nvidia  # amd is detected automatically
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.gpu-ex-cuda-12"

--- a/util/cron/test-perf.gpu-ex-cuda-12.um.bash
+++ b/util/cron/test-perf.gpu-ex-cuda-12.um.bash
@@ -5,13 +5,13 @@
 UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common-native-gpu.bash
 source $UTIL_CRON_DIR/common-hpe-cray-ex.bash
+source $UTIL_CRON_DIR/common-gpu-nvidia-hpe-cray-ex.bash
 
 module load cuda/12.4
 
 export CHPL_LLVM=system
 export CHPL_COMM=none
 export CHPL_LOCALE_MODEL=gpu
-export CHPL_LAUNCHER_PARTITION=griz256
 export CHPL_GPU=nvidia  # amd is detected automatically
 export CHPL_GPU_MEM_STRATEGY=unified_memory
 

--- a/util/cron/test-perf.gpu-ex-cuda-12.um.bash
+++ b/util/cron/test-perf.gpu-ex-cuda-12.um.bash
@@ -11,7 +11,6 @@ module load cuda/12.4
 
 export CHPL_LLVM=system
 export CHPL_COMM=none
-export CHPL_LOCALE_MODEL=gpu
 export CHPL_GPU=nvidia  # amd is detected automatically
 export CHPL_GPU_MEM_STRATEGY=unified_memory
 

--- a/util/cron/test-perf.gpu-ex-rocm.bash
+++ b/util/cron/test-perf.gpu-ex-rocm.bash
@@ -17,7 +17,6 @@ module load rocm/6.2.0
 export CHPL_COMM=none
 export CHPL_LLVM=bundled
 unset CHPL_LLVM_CONFIG  # we need this to avoid warnings
-export CHPL_LOCALE_MODEL=gpu
 export CHPL_LAUNCHER_PARTITION=bardpeak  # bardpeak is the default queue
 export CHPL_GPU=amd  # also detected by default
 export CHPL_GPU_ARCH=gfx90a


### PR DESCRIPTION
Due to changes in the nightly testing system's setup, we have to move our `nvidia` testing to a different partition. This PR mainly handles that. Specifically:

- Creates a `common-gpu-nvidia-hpe-cray-ex` script to have `CHPL_LAUNCHER_PARTITION` export, as we repeat that in many scripts.
- While there, also removes `CHPL_LOCALE_MODEL` and `CHPL_TEST_GPU` from individual scripts, as they are set in the `common-native-gpu.bash` script, which is sourced by all GPU test scripts.

The `deviceAttributes` test may fail on the new partition. I am unable to test there, so choose to merge the PR without any change to the test to make progress on nightly testing runs. I'll adjust the test if there's any fallout.