### PR TITLE
Fix `--verify`: Only include LLVM support headers if only LLVM support is used

### DIFF
--- a/util/chplenv/chplenv_verify.py
+++ b/util/chplenv/chplenv_verify.py
@@ -300,7 +300,8 @@ class TestHostCanFindLLVM(TestCompile):
         )
 
     def _program(self):
-        return """
+        if self.chplenv.get("CHPL_LLVM") != "none":
+            return """
 #include "clang/Basic/Version.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/LLVMContext.h"
@@ -312,6 +313,17 @@ int main() {
     return 0;
 }
 """
+        else:
+            return """
+#include "llvm/Support/raw_ostream.h"
+#include <iostream>
+int main() {
+    std::cout << "Hello, World!" << std::endl;
+    llvm::outs() << "Hello, LLVM!\\n";
+    return 0;
+}
+"""
+
 
     def explain(self):
         compiler = self._compiler()


### PR DESCRIPTION
Fixes --verify for printchplenv to only try and include LLVM support headers when we are only using LLVM support libraries.

[Reviewed by @]