### PR TITLE
fix a passing future by adjusting test output

### DIFF
--- a/test/statements/conditionals/integralReturnTypesInConditional.bad
+++ b/test/statements/conditionals/integralReturnTypesInConditional.bad
@@ -1,0 +1,1 @@
+All the assertions passed - meaning the bug in prod still exists!

--- a/test/statements/conditionals/integralReturnTypesInConditional.chpl
+++ b/test/statements/conditionals/integralReturnTypesInConditional.chpl
@@ -1,2 +1,3 @@
 require "integralTests.chpl";
 use integralTests;
+writeln("All the assertions passed - meaning the bug in prod still exists!");

--- a/test/statements/conditionals/integralReturnTypesInConditional.good
+++ b/test/statements/conditionals/integralReturnTypesInConditional.good
@@ -1,0 +1,4 @@
+# any assertion failure should be looked into. The assertions will need to be
+# adjusted in the .precomp script if/when #26991 is resolved. A good result should
+# look like all or most of the existing assertions for testExpressionZero
+# and testProcCastZero failing


### PR DESCRIPTION
This fixes a future that had the same .good/.bad and so always showed as passing.

[test change only, not reviewed] 