### PR TITLE
Remove CHPL_COMM_SUBSTRATE=aries and fix broken CHPL_COMM_SUBSTRATE=ucx

### DIFF
--- a/doc/rst/platforms/cray.rst
+++ b/doc/rst/platforms/cray.rst
@@ -606,13 +606,17 @@ segments, though even then its performance will rarely match that of the
 ugni communication layer.  The relevant configurations are::
 
   CHPL_COMM=gasnet
-    CHPL_COMM_SUBSTRATE=aries (for XC)
     CHPL_GASNET_SEGMENT=fast or large
 
 In these configurations the heap is created with a fixed size at the
 beginning of execution.  The default size works well in most cases but
 if it doesn't a different size can be specified, as discussed in the
 following section.
+
+Note that the 'aries' substrate is no longer supported by GASNet, making it
+difficuly to target a Cray XC with GASNet. It is possible to use the 'ofi' or
+'mpi' substrates to target a Cray XC with GASNet, but this is not well
+supported or tested.
 
 
 gasnet Communication Layer and the Heap

--- a/doc/rst/platforms/cray.rst
+++ b/doc/rst/platforms/cray.rst
@@ -613,10 +613,9 @@ beginning of execution.  The default size works well in most cases but
 if it doesn't a different size can be specified, as discussed in the
 following section.
 
-Note that the 'aries' substrate is no longer supported by GASNet, making it
-difficuly to target a Cray XC with GASNet. It is possible to use the 'ofi' or
-'mpi' substrates to target a Cray XC with GASNet, but this is not well
-supported or tested.
+Note that as of Chapel 2.4, the 'aries' substrate is no longer supported by
+GASNet. It is still possible to use the 'ofi' or 'mpi' substrates to target a
+Cray XC with GASNet, but this is not well supported or tested.
 
 
 gasnet Communication Layer and the Heap

--- a/doc/rst/usingchapel/multilocale.rst
+++ b/doc/rst/usingchapel/multilocale.rst
@@ -114,9 +114,6 @@ ibv
 udp
     UDP - portable conduit, works on any network with a TCP/IP stack
     (see :ref:`Using the Portable UDP Conduit <using-udp>`)
-aries
-    Aries for Cray XC series
-    (see :ref:`Using Chapel on Cray Systems <readme-cray>`)
 mpi
     MPI - portable conduit, works on any network with MPI 1.1 or newer
 smp
@@ -131,7 +128,6 @@ Current defaults are:
 CHPL_TARGET_PLATFORM  CHPL_COMM_SUBSTRATE
 ====================  ===================
 cray-cs                ibv
-cray-xc                aries
 pwr6                   ibv
 other                  udp
 ====================  ===================
@@ -170,7 +166,6 @@ Current defaults are:
 ===================  ====================
 CHPL_COMM_SUBSTRATE  CHPL_GASNET_SEGMENT
 ===================  ====================
-aries                fast
 ibv                  large
 smp                  fast
 other                everything

--- a/modules/packages/MPI.chpl
+++ b/modules/packages/MPI.chpl
@@ -124,12 +124,9 @@ follows:
   CHPL_TARGET_COMPILER=cray-prgenv-{gnu, intel}
   CHPL_TASKS={qthreads, fifo}   # see discussion below
   CHPL_COMM={ugni, gasnet}
-  CHPL_COMM_SUBSTRATE={aries, mpi}   # if CHPL_COMM=gasnet
+  CHPL_COMM_SUBSTRATE=mpi   # if CHPL_COMM=gasnet
   MPICH_MAX_THREAD_SAFETY=multiple
   AMMPI_MPI_THREAD=multiple         # if CHPL_COMM_SUBSTRATE=mpi
-
-Running under ``gasnet+aries`` might require setting ``MPICH_GNI_DYNAMIC_CONN=disabled``.
-This is discussed :ref:`here <readme-cray-constraints>`.
 
 These are the configurations in which this module is currently tested. Any
 launcher should work fine for this mode. Support is expected to expand in
@@ -142,7 +139,7 @@ Since MPI is not natively Qthread-aware, some care is required to avoid deadlock
 section describes current recommendations on using ``CHPL_TASKS=qthreads`` and the MPI
 module.
 
-We assume that ``CHPL_COMM`` is either ``ugni`` or ``gasnet+aries``.
+We assume that ``CHPL_COMM`` is ``ugni``.
 We do not recommend using the MPI module with the ``gasnet+mpi`` communication backend
 and ``qthreads``.
 

--- a/util/chplenv/chpl_comm.py
+++ b/util/chplenv/chpl_comm.py
@@ -39,7 +39,7 @@ def get():
                 comm_val = 'none'
 
     if comm_val == 'gasnet' and get_network() == 'aries':
-        error("CHPL_COMM=gasnet is no longer supported on aries. Please use CHPL_COMM=ugni instead.")
+        error("CHPL_COMM=gasnet is no longer supported on Cray XC. Please use CHPL_COMM=ugni instead.")
 
     check_valid_var("CHPL_COMM", comm_val, ("none", "gasnet", "ofi", "ugni"))
     return comm_val

--- a/util/chplenv/chpl_comm.py
+++ b/util/chplenv/chpl_comm.py
@@ -4,7 +4,7 @@ import os
 import re
 import shutil
 
-import chpl_platform, overrides
+import overrides
 from utils import memoize, check_valid_var, error
 
 
@@ -38,8 +38,10 @@ def get():
             else:
                 comm_val = 'none'
 
-    if comm_val == 'gasnet' and get_network() == 'aries':
-        error("CHPL_COMM=gasnet is no longer supported on Cray XC. Please use CHPL_COMM=ugni instead.")
+    if comm_val == 'gasnet':
+        import chpl_platform
+        if get_network() == 'aries' or chpl_platform.get('target') == 'cray-xc':
+            error("CHPL_COMM=gasnet is no longer supported on Cray XC. Please use CHPL_COMM=ugni instead.")
 
     check_valid_var("CHPL_COMM", comm_val, ("none", "gasnet", "ofi", "ugni"))
     return comm_val

--- a/util/chplenv/chpl_comm.py
+++ b/util/chplenv/chpl_comm.py
@@ -5,7 +5,7 @@ import re
 import shutil
 
 import overrides
-from utils import memoize, check_valid_var, error
+from utils import memoize, check_valid_var
 
 
 @memoize

--- a/util/chplenv/chpl_comm.py
+++ b/util/chplenv/chpl_comm.py
@@ -38,11 +38,6 @@ def get():
             else:
                 comm_val = 'none'
 
-    if comm_val == 'gasnet':
-        import chpl_platform
-        if get_network() == 'aries' or chpl_platform.get('target') == 'cray-xc':
-            error("CHPL_COMM=gasnet is no longer supported on Cray XC. Please use CHPL_COMM=ugni instead.")
-
     check_valid_var("CHPL_COMM", comm_val, ("none", "gasnet", "ofi", "ugni"))
     return comm_val
 

--- a/util/chplenv/chpl_comm.py
+++ b/util/chplenv/chpl_comm.py
@@ -5,7 +5,7 @@ import re
 import shutil
 
 import chpl_platform, overrides
-from utils import memoize, check_valid_var
+from utils import memoize, check_valid_var, error
 
 
 @memoize
@@ -37,6 +37,9 @@ def get():
                 comm_val = 'ofi'
             else:
                 comm_val = 'none'
+
+    if comm_val == 'gasnet' and get_network() == 'aries':
+        error("CHPL_COMM=gasnet is no longer supported on aries. Please use CHPL_COMM=ugni instead.")
 
     check_valid_var("CHPL_COMM", comm_val, ("none", "gasnet", "ofi", "ugni"))
     return comm_val

--- a/util/chplenv/chpl_comm_segment.py
+++ b/util/chplenv/chpl_comm_segment.py
@@ -13,7 +13,7 @@ def get():
         if not segment_val:
             substrate_val = chpl_comm_substrate.get()
             platform_val = chpl_platform.get('target')
-            if substrate_val in ('aries', 'smp', 'ucx'):
+            if substrate_val in ('smp', 'ucx'):
                 segment_val = 'fast'
             elif substrate_val == 'ofi' and chpl_platform.is_hpe_cray('target'):
                 segment_val = 'fast'

--- a/util/chplenv/chpl_comm_substrate.py
+++ b/util/chplenv/chpl_comm_substrate.py
@@ -14,18 +14,14 @@ def get():
 
         if comm_val == 'gasnet':
             network = chpl_comm.get_network()
-            if network == 'aries':
-                substrate_val = 'aries'
-            elif network == 'ibv':
+            if network == 'ibv':
                 substrate_val = 'ibv'
             elif network == 'cxi':
                 substrate_val = 'ofi'
             else:
                 import chpl_platform
                 platform_val = chpl_platform.get('target')
-                if platform_val == 'cray-xc':
-                    substrate_val = 'aries'
-                elif platform_val == 'hpe-cray-ex':
+                if platform_val == 'hpe-cray-ex':
                     substrate_val = 'ofi'
                 elif platform_val == 'hpe-cray-xd':
                     # default to ofi on XD when we can't determine ib vs cxi
@@ -39,7 +35,8 @@ def get():
         else:
             substrate_val = 'none'
 
-    check_valid_var("CHPL_COMM_SUBSTRATE", substrate_val, ("none", "aries", "ofi", "ibv", "udp", "smp", "mpi"))
+    # values are ordered alphabetically, with none first
+    check_valid_var("CHPL_COMM_SUBSTRATE", substrate_val, ("none", "ibv", "mpi", "ofi", "smp", "ucx", "udp"))
     return substrate_val
 
 

--- a/util/chplenv/chpl_comm_substrate.py
+++ b/util/chplenv/chpl_comm_substrate.py
@@ -23,7 +23,9 @@ def get():
             else:
                 import chpl_platform
                 platform_val = chpl_platform.get('target')
-                if platform_val == 'hpe-cray-ex':
+                if platform_val == 'cray-xc':
+                    substrate_val = 'aries'
+                elif platform_val == 'hpe-cray-ex':
                     substrate_val = 'ofi'
                 elif platform_val == 'hpe-cray-xd':
                     # default to ofi on XD when we can't determine ib vs cxi

--- a/util/chplenv/chpl_comm_substrate.py
+++ b/util/chplenv/chpl_comm_substrate.py
@@ -3,7 +3,7 @@ import sys
 import shutil
 
 import chpl_comm, chpl_platform, overrides
-from utils import memoize, check_valid_var
+from utils import memoize, check_valid_var, error
 
 
 @memoize
@@ -34,6 +34,10 @@ def get():
                     substrate_val = 'udp'
         else:
             substrate_val = 'none'
+
+    # special case error for aries to be nice to users
+    if chpl_comm.get() == 'gasnet' and substrate_val == 'aries':
+        error("CHPL_COMM=gasnet is no longer supported on Cray XC. Please use CHPL_COMM=ugni instead and unset CHPL_COMM_SUBSTRATE.")
 
     # values are ordered alphabetically, with none first
     check_valid_var("CHPL_COMM_SUBSTRATE", substrate_val, ("none", "ibv", "mpi", "ofi", "smp", "ucx", "udp"))

--- a/util/chplenv/chpl_comm_substrate.py
+++ b/util/chplenv/chpl_comm_substrate.py
@@ -2,7 +2,7 @@
 import sys
 import shutil
 
-import chpl_comm, chpl_platform, overrides
+import chpl_comm, overrides
 from utils import memoize, check_valid_var, error
 
 

--- a/util/chplenv/chpl_comm_substrate.py
+++ b/util/chplenv/chpl_comm_substrate.py
@@ -14,7 +14,9 @@ def get():
 
         if comm_val == 'gasnet':
             network = chpl_comm.get_network()
-            if network == 'ibv':
+            if network == 'aries':
+                substrate_val = 'aries'
+            elif network == 'ibv':
                 substrate_val = 'ibv'
             elif network == 'cxi':
                 substrate_val = 'ofi'
@@ -37,7 +39,7 @@ def get():
 
     # special case error for aries to be nice to users
     if chpl_comm.get() == 'gasnet' and substrate_val == 'aries':
-        error("CHPL_COMM=gasnet is no longer supported on Cray XC. Please use CHPL_COMM=ugni instead and unset CHPL_COMM_SUBSTRATE.")
+        error("'CHPL_COMM=gasnet' with the 'aries' substrate is no longer supported. Please prefer using 'CHPL_COMM=ugni' instead")
 
     # values are ordered alphabetically, with none first
     check_valid_var("CHPL_COMM_SUBSTRATE", substrate_val, ("none", "ibv", "mpi", "ofi", "smp", "ucx", "udp"))

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -1055,9 +1055,6 @@ def gather_pe_chpl_pkgconfig_libs():
         if platform.startswith('cray-x'):
             ret = 'cray-ugni:' + ret
 
-        if comm == 'gasnet' and substrate == 'aries':
-            ret = 'cray-udreg:' + ret
-
         if comm == 'ofi' and chpl_libfabric.get() == 'system':
             ret = 'libfabric:' + ret
 


### PR DESCRIPTION
Removes support for CHPL_COMM_SUBSTRATE=aries, which GASNet no longer supporta.

The [latest update to Chapel's bundled GASNet](https://github.com/chapel-lang/chapel/pull/26830) removed support for CHPL_COMM_SUBSTRATE=aries. While this is not Chapel's preferred setting on aries (preferred is CHPL_COMM=ugni), users trying to use CHPL_COMM=gasnet and CHPL_COMM_SUBSTRATE=aries prior to this PR would get a build time error. This PR makes this a nicer error.

While there, this PR also adds 'ucx' to the list of allowed CHPL_COMM_SUBSTRATE, as it was missing. This support was always there but [previous work](https://github.com/chapel-lang/chapel/pull/26501) had mistakenly broken it

[Reviewed by @arifthpe, @jhh67, and @bonachea]