### PR TITLE
Dyno: only use calledType for type constructors

### DIFF
--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -575,6 +575,7 @@ class CallInfo {
         hasQuestionArg_(hasQuestionArg),
         isParenless_(isParenless),
         actuals_(std::move(actuals)) {
+    CHPL_ASSERT(calledType.isUnknown() || !isMethodCall);
     #ifndef NDEBUG
     if (isMethodCall) {
       CHPL_ASSERT(numActuals() >= 1);

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -575,11 +575,11 @@ class CallInfo {
         hasQuestionArg_(hasQuestionArg),
         isParenless_(isParenless),
         actuals_(std::move(actuals)) {
-    CHPL_ASSERT(calledType.isUnknown() || !isMethodCall);
     #ifndef NDEBUG
     if (isMethodCall) {
       CHPL_ASSERT(numActuals() >= 1);
       CHPL_ASSERT(this->actual(0).byName() == "this");
+      CHPL_ASSERT(calledType.isUnknown());
     }
     if (isParenless) {
       if (isMethodCall) {

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -678,6 +678,14 @@ class CallInfo {
                             const uast::AstNode*& questionArg,
                             std::vector<const uast::AstNode*>* actualAsts);
 
+  /** return the type of the 'this' actual, aka the receiver of a method call. */
+  types::QualifiedType methodReceiverType() const {
+    CHPL_ASSERT(isMethodCall());
+    CHPL_ASSERT(numActuals() > 0);
+    auto& firstActual = actual(0);
+    CHPL_ASSERT(firstActual.byName() == "this");
+    return firstActual.type();
+  }
 
   /** return the name of the called thing */
   const UniqueString name() const { return name_; }
@@ -1243,9 +1251,10 @@ struct CandidatesAndForwardingInfo {
 
   // Compute and fill in forwarding info for a range of newly-added candidates.
   void helpComputeForwardingTo(const CallInfo& fci, size_t start) {
+    CHPL_ASSERT(fci.isMethodCall());
     CHPL_ASSERT(forwardingInfo.size() <= start);
     forwardingInfo.resize(start);
-    types::QualifiedType forwardingReceiverActualType = fci.calledType();
+    types::QualifiedType forwardingReceiverActualType = fci.methodReceiverType();
     for (size_t i = start; i < candidates.size(); i++) {
       forwardingInfo.push_back(forwardingReceiverActualType);
     }

--- a/frontend/lib/resolution/InitResolver.cpp
+++ b/frontend/lib/resolution/InitResolver.cpp
@@ -126,7 +126,7 @@ void InitResolver::resolveImplicitSuperInit() {
                                   ClassTypeDecorator(ClassTypeDecorator::BORROWED_NONNIL));
     auto superQT = QualifiedType(QualifiedType::INIT_RECEIVER, superCT);
     actuals.push_back(CallInfoActual(superQT, USTR("this")));
-    auto ci = CallInfo(USTR("init"), superQT, true, false, false, actuals);
+    auto ci = CallInfo(USTR("init"), QualifiedType(), true, false, false, actuals);
     auto inScopes = CallScopeInfo::forNormalCall(initResolver_.currentScope(), initResolver_.poiScope);
 
     auto callContext = fn_->body();

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -5433,7 +5433,14 @@ void Resolver::handleCallExpr(const uast::Call* call) {
 
     // If the user has mistakenly instantiated a field of the type before
     // calling ``init``, then the receiver type will either be fully or
-    // partially instantiated. This will cause a failure to resolve the
+    // partially instantiated. E.g.,
+    //
+    //    proc init(...) {
+    //      this.typeField = ...;
+    //      this.init(....);
+    //    }
+    //
+    // This will cause a failure to resolve the inner
     // ``init`` call, and result in a confusing and unhelpful error message.
     // To resolve this problem, manually compute the fully-generic type that
     // is being initialized and reset the receiver.

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1565,7 +1565,7 @@ Resolver::computeCustomInferType(const AstNode* decl,
   std::vector<CallInfoActual> actuals = {std::move(receiver)};
 
   auto ci = CallInfo(/* name */ name,
-                     /* calledType */ calledType,
+                     /* calledType */ QualifiedType(),
                      /* isMethodCall */ true,
                      /* hasQuestionArg */ false,
                      /* isParenless */ false,
@@ -2814,7 +2814,7 @@ bool Resolver::resolveSpecialNewCall(const Call* call) {
   CHPL_ASSERT(!questionArg);
 
   // The 'new' will produce an 'init' call as a side effect.
-  auto ci = CallInfo(USTR("init"), calledType, isMethodCall,
+  auto ci = CallInfo(USTR("init"), QualifiedType(), isMethodCall,
                      /* hasQuestionArg */ questionArg != nullptr,
                      /* isParenless */ false,
                      std::move(actuals));
@@ -5443,7 +5443,7 @@ void Resolver::handleCallExpr(const uast::Call* call) {
     //
     // TODO: Move this logic into InitResolver.cpp - but where?
     if (initResolver && ci.name() == USTR("init")) {
-      auto gt = ci.isMethodCall() ? ci.calledType() : receiverType;
+      auto gt = ci.isMethodCall() ? ci.methodReceiverType() : receiverType;
       auto gen = getGenericType(context, gt.type());
       receiverType = QualifiedType(QualifiedType::INIT_RECEIVER, gen);
 
@@ -5700,7 +5700,7 @@ void Resolver::exit(const Dot* dot) {
     actuals.emplace_back(receiver.type(), USTR("this"));
     auto name = UniqueString::get(context, "_dom");
     auto ci = CallInfo(/* name */ name,
-                       /* calledType */ receiver.type(),
+                       /* calledType */ QualifiedType(),
                        /* isMethodCall */ true,
                        /* hasQuestionArg */ false,
                        /* isParenless */ true, actuals);
@@ -7100,7 +7100,7 @@ static QualifiedType getReduceScanOpResultType(Resolver& resolver,
   std::vector<CallInfoActual> typeActuals;
   typeActuals.push_back(CallInfoActual(thisActual, USTR("this")));
   auto ci = CallInfo (/* name */ USTR("generate"),
-                      /* calledType */ thisActual,
+                      /* calledType */ QualifiedType(),
                       /* isMethodCall */ true,
                       /* hasQuestionArg */ false,
                       /* isParenless */ false,

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -228,7 +228,7 @@ setupCallForCopyOrMove(Resolver& resolver,
     actuals.push_back(CallInfoActual(rhsType, UniqueString()));
     outAsts.push_back(rhsAst);
     auto ci = CallInfo (/* name */ USTR("init="),
-                        /* calledType */ varArg,
+                        /* calledType */ QualifiedType(),
                         /* isMethodCall */ true,
                         /* hasQuestionArg */ false,
                         /* isParenless */ false,
@@ -504,15 +504,8 @@ void CallInitDeinit::resolveDefaultInit(const VarLikeDecl* ast, RV& rv) {
                                         ignoredActualAsts);
     }
 
-    // Get the 'root' instantiation
-    const CompositeType* calledCT = compositeType;
-    while (auto insn = calledCT->instantiatedFromCompositeType()) {
-      calledCT = insn;
-    }
-    auto calledType = QualifiedType(QualifiedType::VAR, calledCT);
-
     auto ci = CallInfo (/* name */ USTR("init"),
-                        /* calledType */ calledType,
+                        /* calledType */ QualifiedType(),
                         /* isMethodCall */ true,
                         /* hasQuestionArg */ false,
                         /* isParenless */ false,
@@ -787,7 +780,7 @@ void CallInitDeinit::resolveDeinit(const AstNode* ast,
   std::vector<CallInfoActual> actuals;
   actuals.push_back(CallInfoActual(deinitType, USTR("this")));
   auto ci = CallInfo (/* name */ USTR("deinit"),
-                      /* calledType */ deinitType,
+                      /* calledType */ QualifiedType(),
                       /* isMethodCall */ true,
                       /* hasQuestionArg */ false,
                       /* isParenless */ false,

--- a/frontend/lib/resolution/copy-elision.cpp
+++ b/frontend/lib/resolution/copy-elision.cpp
@@ -132,7 +132,7 @@ bool FindElidedCopies::hasCrossTypeInitAssignWithIn(
   actuals.push_back(CallInfoActual(lhsType, USTR("this")));
   actuals.push_back(CallInfoActual(rhsType, UniqueString()));
   auto ci = CallInfo (/* name */ USTR("init="),
-                      /* calledType */ lhsType,
+                      /* calledType */ QualifiedType(),
                       /* isMethodCall */ true,
                       /* hasQuestionArg */ false,
                       /* isParenless */ false,


### PR DESCRIPTION
Co-authored with @arifthpe.

It seems like most of the resolution machinery is using `calledType` only to handle type constructor cases. However, `calledType` is inconsistently set across Dyno: sometimes it's present, sometimes it's not. This PR ensures all uses of `calledType` are for type constructors (this mostly boiled down to replacing `.calledType()` calls with equivalent `.methodReceiverType()` calls). After this, I adjusted all call info constructions to skip adding `calledType` unless they are a type constructor.

Reviewed by @arifthpe -- thanks!

## Testing
- [x] dyno tests
- [x] paratest