### PR TITLE
Fix Python module paths test in environments with strange Python installs

### DIFF
--- a/test/library/packages/Python/correctness/paths/checkPaths.chpl
+++ b/test/library/packages/Python/correctness/paths/checkPaths.chpl
@@ -21,7 +21,8 @@ proc cleanPath(in p) {
 proc getSysPathSpawn() {
   use Subprocess;
   var p = spawn(
-    [pythonToUse, "-c", "import sys; print(*sys.path, sep=',')"],
+    [pythonToUse,
+     "-c", "import sys; import site; site.main(); print(*sys.path, sep=',')"],
     stdout=pipeStyle.pipe);
 
   var output = p.stdout.readAll(string).strip();


### PR DESCRIPTION
Fixes an issue where some methods of Python installation would break this test's output. The specific scenario occurs when a Python install does customization of where libraries are called, this is called "site customization".

A [recent homebrew PR](https://github.com/Homebrew/homebrew-core/pull/218757) changed how the `site-packages` directory was setup and seemed to cause some packages paths to be invisible to the `python3` executable, but not to our Python module. This is because our Python module explicitly looks for site specific customization, which it seems the homebrew install of python does not do by default. This change broke a few nightly test configs, bringing this to our attention.

This can be "resolved" by forciblly resolving the site customization in the specific test that broke. We cannot change the Python module's resolution (as we rely on it doing site customization in other cases), but its enough to adjust the test. The test is more about making sure `PYTHONPATH` and `PYTHONUSERBASE` get properly handled, so this test adjustment doesn't change the purpose of the test.

- Testing
  - [x] nightly Mac system which broke
  - [x] my local dev Mac
  - [x] nightly linux64 test machine 

[Reviewed by @arezaii]