### PR TITLE
Dyno: generate `==`, `<`, `<=`, etc. by comparisons on fields

### DIFF
--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -411,6 +411,11 @@ class UntypedFnSignature {
   /// \endcond DO_NOT_DOCUMENT
 };
 
+const UntypedFnSignature*
+getUntypedFnSignatureForFn(Context* context,
+                           const uast::Function* fn,
+                           ID const* compilerGeneratedOrigin = nullptr);
+
 /**
   This type stores the outer variables used by a function. For each mention
   of an outer variable, it keeps track of the outer variable's ID and type.

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -457,10 +457,14 @@ const BuilderResult& buildInitEquals(Context* context, ID typeID) {
                                   std::move(thisType), nullptr);
 
   // TODO: constrain type to be same as 'typeID', possibly through 'this.type'?
+  auto thisDotType =  Dot::build(builder, dummyLoc,
+                                 Identifier::build(builder, dummyLoc, USTR("this")),
+                                 USTR("type"));
+
   auto otherName = UniqueString::get(context, "other");
   auto otherFormal = Formal::build(builder, dummyLoc, nullptr,
                                    otherName, Formal::DEFAULT_INTENT,
-                                   nullptr, nullptr);
+                                   std::move(thisDotType), nullptr);
   AstList formals;
   formals.push_back(std::move(otherFormal));
 

--- a/frontend/lib/resolution/default-functions.h
+++ b/frontend/lib/resolution/default-functions.h
@@ -85,6 +85,7 @@ getCompilerGeneratedBinaryOp(Context* context,
 
 const uast::BuilderResult& buildInitializer(Context* context, ID typeID);
 const uast::BuilderResult& buildInitEquals(Context* context, ID typeID);
+const uast::BuilderResult& buildRecordComparison(Context* context, ID typeID);
 const uast::BuilderResult& buildTypeConstructor(Context* context, ID typeID);
 const uast::BuilderResult& buildDeinit(Context* context, ID typeID);
 const uast::BuilderResult& buildDeSerialize(Context* context, ID typeID, bool isSerializer);

--- a/frontend/lib/resolution/default-functions.h
+++ b/frontend/lib/resolution/default-functions.h
@@ -86,6 +86,11 @@ getCompilerGeneratedBinaryOp(Context* context,
 const uast::BuilderResult& buildInitializer(Context* context, ID typeID);
 const uast::BuilderResult& buildInitEquals(Context* context, ID typeID);
 const uast::BuilderResult& buildRecordComparison(Context* context, ID typeID);
+const uast::BuilderResult& buildRecordInequalityComparison(Context* context, ID typeID);
+const uast::BuilderResult& buildRecordCompareLt(Context* context, ID typeID);
+const uast::BuilderResult& buildRecordCompareLe(Context* context, ID typeID);
+const uast::BuilderResult& buildRecordCompareGt(Context* context, ID typeID);
+const uast::BuilderResult& buildRecordCompareGe(Context* context, ID typeID);
 const uast::BuilderResult& buildTypeConstructor(Context* context, ID typeID);
 const uast::BuilderResult& buildDeinit(Context* context, ID typeID);
 const uast::BuilderResult& buildDeSerialize(Context* context, ID typeID, bool isSerializer);

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -101,8 +101,8 @@ UntypedFnSignature::get(Context* context, ID id,
                                compilerGeneratedOrigin).get();
 }
 
-static const UntypedFnSignature*
-getUntypedFnSignatureForFn(Context* context, const uast::Function* fn) {
+const UntypedFnSignature*
+getUntypedFnSignatureForFn(Context* context, const uast::Function* fn, ID const* compilerGeneratedOrigin) {
   const UntypedFnSignature* result = nullptr;
 
   if (fn != nullptr) {
@@ -134,11 +134,13 @@ getUntypedFnSignatureForFn(Context* context, const uast::Function* fn) {
     result = UntypedFnSignature::get(context, fn->id(), fn->name(),
                                      fn->isMethod(),
                                      /* isTypeConstructor */ false,
-                                     /* isCompilerGenerated */ false,
+                                     /* isCompilerGenerated */ compilerGeneratedOrigin != nullptr,
                                      /* throws */ fn->throws(),
                                      /* idTag */ asttags::Function,
                                      fn->kind(),
-                                     std::move(formals), fn->whereClause());
+                                     std::move(formals), fn->whereClause(),
+                                     compilerGeneratedOrigin ? *compilerGeneratedOrigin
+                                                             : ID());
   }
 
   return result;

--- a/frontend/lib/resolution/signature-checks.cpp
+++ b/frontend/lib/resolution/signature-checks.cpp
@@ -70,7 +70,8 @@ static const bool& checkSignatureQuery(Context* context,
     // check the intent of the rhs argument
     if (sig->formalType(0).type() == sig->formalType(1).type()) {
       // same-type case: only const/default/ref/const ref RHS is allowed
-      if (!rhsIntentGenericOrRef) {
+      // allow 'in' for borrowed RHS, such as when defining init= for a class.
+      if (!rhsIntentGenericOrRef && !sig->formalType(0).type()->isClassType()) {
         context->error(errId, "Bad intent for same-type init= other argument");
       }
     } else {

--- a/frontend/test/resolution/testOperatorOverloads.cpp
+++ b/frontend/test/resolution/testOperatorOverloads.cpp
@@ -495,6 +495,19 @@ static void test10() {
       )""", { "> with int", "< with int",
               "> with bool", "< with bool",
               "> with real", "< with real" });
+
+  helpTestGeneratedComparisons(
+      R"""(
+      record R {
+        type typeField = int;
+        var x: wrapper(int);
+        var y: wrapper(bool);
+        var z: wrapper(real);
+      }
+      var tmp = new R() >= new R();
+      )""", { "> with int", "< with int",
+              "> with bool", "< with bool",
+              "> with real", "< with real" });
 }
 
 int main() {

--- a/frontend/test/resolution/testOperatorOverloads.cpp
+++ b/frontend/test/resolution/testOperatorOverloads.cpp
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+#include "test-common.h"
 #include "test-resolution.h"
 
 // basic definition tests with cast operator
@@ -220,8 +221,8 @@ static void test3() {
 
 // test that we get a compiler generated record method for `==` when none exist
 static void test4() {
-  Context ctx;
-  Context* context = &ctx;
+  // generated field comparison uses chpl_field_neq, which is part of the stdib.
+  Context* context = buildStdContext();
   ErrorGuard guard(context);
 
   std::string program =
@@ -296,8 +297,7 @@ static void test6() {
 // test that we do get a compiler generated record method for `==`
 // when other operators exist
 static void test7() {
-  Context ctx;
-  Context* context = &ctx;
+  Context* context = buildStdContext();
   ErrorGuard guard(context);
 
   std::string program =
@@ -321,8 +321,7 @@ static void test7() {
 
 // test that we get compiler generated methods for = and == when inside a proc
 static void test8() {
-  Context ctx;
-  Context* context = &ctx;
+  Context* context = buildStdContext();
   ErrorGuard guard(context);
 
   std::string program =


### PR DESCRIPTION
Closes https://github.com/Cray/chapel-private/issues/7263.

This PR generates various comparison operators as they are generated in production. Roughly, for `==`, the comparison is roughly as follows:

```Chapel
operator ==(lhs, rhs) {
  if chpl_field_neq(lhs.field1, rhs.field1) then return false;
  // ....
  if chpl_field_neq(lhs.fieldN, rhs.fieldN) then return false;
  return true;
}
```

For inequality, I generate:

```Chapel
operator !=(lhs, rhs) {
  return chpl_field_neq(lhs.field1, rhs.field1) || /* ... */ || chpl_field_neq(lhs.fieldN, rhs.fieldN) || false;
}
```

For comparison, we actually do two order comparisons per field.

```Chapel
operator <=(lhs, rhs) {
  if chpl_field_lt(lhs.field1, rhs.field1) then return true;
  if chpl_field_lt(rhs.field1, lhs.field1) then return false;
  // ....

  return true; /* implied equal. For <, this returns false instead. */
}
```

To support all of this (and reduce the load of generating per-field operators, this PR defines a new struct `FieldFnBuilder`. This builder helps reduce the boilerplate when constructing per-field functions by re-using a dummy locations, shortcuts to AST builders, and generalizing field iteration code via `eachFieldPair`. It then adjusts `init=` and `operator=` handling to make use of this builder.

While there, I also noticed that on `main`, we explicitly build untyped signatures for the compiler-generated functions. I saw this was unnecessary for `init=` and the operators I've defined. As a result, I moved `getUntypedFnSignatureForFn` into a header, and allowed it to take an optional `compilerGeneratedOrigin` which (in addition to being used as an argument for builders) decides whether a function is marked compiler-generated (previously, `getUntypedFnSignatureForFn` only worked with user-defined functions). This, along with `typedSignatureFromGenerator`, saved a lot of boilerplate for taking a compiler-generated `Function` AST and providing a corresponding typed signature. This also helped simplify `buildInitUfsFormals` to remove a `init=`-specific special case.

Finally, I consolidated the "is compiler generated" and "pick compiler generated signature" logic by having both paths go through a function-pointer-returning `generatorForCompilerGeneratedRecordOperator`. When the function pointer is not `nullptr`, the given string names a compiler-generated operator. The function pointer gives the function to construct a `TypedSignature` for that operator.

Reviewed by @benharsh -- thanks!

## Testing
- [x] frontend tests
- [x] spectests with `--dyno-resolve-only`
- [x] paratest