### PR TITLE
Remove old GPU+GASNet test

### DIFF
--- a/test/gpu/native/environment/gasnet.chpl
+++ b/test/gpu/native/environment/gasnet.chpl
@@ -1,3 +1,0 @@
-// We don't actually have a program to compile. Just want to ensure that
-// if CHPL_LOCALE_MODEL == gpu and CHPL_COMM == gasnet is a valid
-// combination.

--- a/test/gpu/native/environment/gasnet.compopts
+++ b/test/gpu/native/environment/gasnet.compopts
@@ -1,1 +1,0 @@
---comm gasnet --gasnet-segment fast --network-atomics none

--- a/test/gpu/native/environment/gasnet.prediff
+++ b/test/gpu/native/environment/gasnet.prediff
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-testname=$1
-outfile=$2
-
-tmpfile=$outfile.prediff.tmp
-grep -e 'Error:' -e 'none' $outfile > $tmpfile
-mv $tmpfile $outfile


### PR DESCRIPTION
Removes an old GPU+GASNet test. 

It that was meant to lock in that a user *could not* use GPUs+GASNet. It was then updated to lock in that a user *could* use GPUs+GASNet. But given the test doesn't actually run/do anything and we have full CHPL_COMM!= none testing on a few platforms (although not specifically GASNet), I am removing it.

[Reviewed by @stonea]