### PR TITLE
Dyno: enable generic `sync` types

### DIFF
--- a/frontend/include/chpl/types/CompositeType.h
+++ b/frontend/include/chpl/types/CompositeType.h
@@ -246,6 +246,9 @@ class CompositeType : public Type {
   /** Get the record _shared implementing shared */
   static const RecordType* getSharedRecordType(Context* context, const BasicClassType* bct);
 
+  /** Get the sync type (_syncvar record) */
+  static const RecordType* getSyncType(Context* context);
+
   /* Get the Error type */
   static const ClassType* getErrorType(Context* context);
 

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -4396,11 +4396,6 @@ static bool resolveFnCallSpecialType(Context* context,
     auto ctorCall = CallInfo::copyAndRename(ci, newName);
     result = resolveCall(rc, call, ctorCall, inScopes);
     return true;
-  } else if (ci.name() == "sync") {
-    auto newName = UniqueString::get(context, "_syncvar");
-    auto ctorCall = CallInfo::copyAndRename(ci, newName);
-    result = resolveCall(rc, call, ctorCall, inScopes);
-    return true;
   }
 
   return false;

--- a/frontend/lib/types/CompositeType.cpp
+++ b/frontend/lib/types/CompositeType.cpp
@@ -246,6 +246,14 @@ CompositeType::getSharedRecordType(Context* context, const BasicClassType* bct) 
   return tryCreateManagerRecord(context, getSharedRecordId(context), bct);
 }
 
+const RecordType*
+CompositeType::getSyncType(Context* context) {
+  auto [id, name] =
+      parsing::getSymbolFromTopLevelModule(context, "ChapelSyncvar", "_syncvar");
+  return RecordType::get(context, id, name,
+                         /* instantiatedFrom */ nullptr, SubstitutionsMap());
+}
+
 const ClassType* CompositeType::getErrorType(Context* context) {
   auto [id, name] =
       parsing::getSymbolFromTopLevelModule(context, "Errors", "Error");

--- a/frontend/lib/types/Type.cpp
+++ b/frontend/lib/types/Type.cpp
@@ -130,6 +130,9 @@ void Type::gatherBuiltins(Context* context,
   gatherType(context, map, "range", rangeType);
   gatherType(context, map, "_range", rangeType);
 
+  auto syncType = CompositeType::getSyncType(context);
+  gatherType(context, map, "sync", syncType);
+
   gatherType(context, map, "Error", CompositeType::getErrorType(context));
 
   gatherType(context, map, "domain", DomainType::getGenericDomainType(context));

--- a/frontend/test/resolution/testResolve.cpp
+++ b/frontend/test/resolution/testResolve.cpp
@@ -2099,6 +2099,22 @@ static void testEarlyRuntimeContinue() {
   // guard should have no errors
 }
 
+static void testGenericSync() {
+  auto context = buildStdContext();
+  ErrorGuard guard(context);
+
+  auto qt = resolveTypeOfXInit(context,
+    R"""(
+      proc foo (x: sync) do return 3;
+      var a : sync int;
+      var x = foo(a);
+    )""");
+
+  assert(qt.type() && qt.type()->isIntType());
+
+  // guard should have no errors
+}
+
 int main() {
   test1();
   test2();
@@ -2150,6 +2166,8 @@ int main() {
   testRuntimeEarlyReturn();
   testEarlyContinue();
   testEarlyRuntimeContinue();
+
+  testGenericSync();
 
   return 0;
 }


### PR DESCRIPTION
https://github.com/Cray/chapel-private/issues/7304

This is done by treating `sync` more like `range`. Specifically, we directly rewrite `sync` to `_syncvar`, like we rewrite `range` to `_range`. This is an improvement over `main` because on `main`, the rewriting only happens when a call is being handled. As a result, `sync` standalone -- which isn't a call -- isn't handled. Under the new regime, the rewrite happens earlier, enabling both the original support (`sync int` parses as `sync(int)` resolves to `_syncvar(int)`) and adding generic support (`sync` is an alias for `_syncvar`).

Reviewed by @arifthpe -- thanks!

## Testing
- [x] dyno tests
- [x] paratest