### PR TITLE
Make a `printchplenv` error be a `./configure` error

### DIFF
--- a/configure
+++ b/configure
@@ -124,7 +124,8 @@ fi
 # and then move it.
 # Note that the resulting chplconfig is expected to cover the same
 # material as any existing chplconfig.
-./util/printchplenv --all --simple --overrides --anonymize > configured-chplconfig || exit 1
+# if printchplenv failed, remove the temporary file and exit
+./util/printchplenv --all --simple --overrides --anonymize > configured-chplconfig || rm -f configured-chplconfig ; exit 1
 mv configured-chplconfig chplconfig
 
 # Compile the Python scripts in util before installation.

--- a/configure
+++ b/configure
@@ -125,7 +125,7 @@ fi
 # Note that the resulting chplconfig is expected to cover the same
 # material as any existing chplconfig.
 # if printchplenv failed, remove the temporary file and exit
-./util/printchplenv --all --simple --overrides --anonymize > configured-chplconfig || rm -f configured-chplconfig ; exit 1
+./util/printchplenv --all --simple --overrides --anonymize > configured-chplconfig || { rm -f configured-chplconfig; exit 1; }
 mv configured-chplconfig chplconfig
 
 # Compile the Python scripts in util before installation.

--- a/configure
+++ b/configure
@@ -124,7 +124,7 @@ fi
 # and then move it.
 # Note that the resulting chplconfig is expected to cover the same
 # material as any existing chplconfig.
-./util/printchplenv --all --simple --overrides --anonymize > configured-chplconfig
+./util/printchplenv --all --simple --overrides --anonymize > configured-chplconfig || exit 1
 mv configured-chplconfig chplconfig
 
 # Compile the Python scripts in util before installation.
@@ -136,7 +136,7 @@ make compile-util-python
 echo
 echo "  Currently selected Chapel configuration:"
 echo
-./util/printchplenv --anonymize
+./util/printchplenv --anonymize || exit 1
 echo
 echo "  Selected installation options:"
 echo


### PR DESCRIPTION
Enforces that errors in `printchplenv` cause `./configure` to also result in an error.

This prevents an issue where `printchplenv` identifies a configure time error and makes no output, but accidentally overwrites the `chplconfig` file and allows builds to continue, just with the default config.

Thanks to @PHHargrove for helping identify and resolve this issue

[Reviewed by @arifthpe]