### PR TITLE
Fix the new skipif by using python and more checking

### DIFF
--- a/test/runtime/ferguson/cache-remote-mock-tests/mock-ra-perf.skipif
+++ b/test/runtime/ferguson/cache-remote-mock-tests/mock-ra-perf.skipif
@@ -1,1 +1,7 @@
-CHPL_RT_LOCALES_PER_NODE>1
+#!/usr/bin/env python3
+
+import os
+
+lpn = os.getenv("CHPL_RT_LOCALES_PER_NODE", default="1")
+
+print(int(lpn)>1)

--- a/test/runtime/ferguson/cache-remote-mock-tests/mock-ra-perf.skipif
+++ b/test/runtime/ferguson/cache-remote-mock-tests/mock-ra-perf.skipif
@@ -4,4 +4,4 @@ import os
 
 lpn = os.getenv("CHPL_RT_LOCALES_PER_NODE", default="1")
 
-print(int(lpn)>1)
+print(int(lpn) > 1 if lpn.isdigit() else False)


### PR DESCRIPTION
https://github.com/chapel-lang/chapel/pull/27108 added a skipif, which was too naive and wasn't processing correctly. This PR uses a Python implementation for that purpose to properly check for an environment variable's value.

This time, I made sure that the `start_test -respect-skipifs` produces the correct output.