### PR TITLE
dlopen: Fix bugs breaking compilation on `linux32`

### DIFF
--- a/modules/internal/ChapelDynamicLoading.chpl
+++ b/modules/internal/ChapelDynamicLoading.chpl
@@ -577,7 +577,10 @@ module ChapelDynamicLoading {
       return ret;
     }
 
-    inline proc _isKeyZeroBits(key: K) do return (key : int) == 0;
+    inline proc _isKeyZeroBits(x: ?t) where isAnyCPtr(t) do return x == nil;
+    inline proc _isKeyZeroBits(x: ?t) where isIntegral(t) do return x == 0;
+    inline proc _isKeyZeroBits(x) do return (x: int) == 0;
+
     inline proc _shouldTryToExpand() do return _loadFactor() > _maxLoadFactor;
     inline proc _shouldTryToShrink() do return _loadFactor() < _minLoadFactor;
 
@@ -587,9 +590,15 @@ module ChapelDynamicLoading {
       return if num < _baseBufferSize then _baseBufferSize else num;
     }
 
-    inline proc _hash(key: K): int {
+    // TODO: Look into adding 'c_ptr.hash()' and 'c_ptrConst.hash()'.
+    inline proc _hash(x: ?t): int where isAnyCPtr(t) {
+      const num = __primitive("object2int", x);
+      return _hash(num, check=false);
+    }
+
+    inline proc _hash(x: ?t, param check=true): int {
       use ChapelHashing;
-      var ret: int = ((key : int).hash() & max(int)) : int;
+      const ret = (x.hash() : int) & max(int);
       return ret;
     }
 


### PR DESCRIPTION
This PR fixes bugs that were breaking `chpl` builds on `linux32` with the `C` backend. It adjusts how the hashtable check `_isKeyZeroBits` is performed to avoid a cast to `int` in the case that the argument is a `c_ptr(void)`. This sidesteps a backend compiler error that is emitted when a 32-bit `void*` is cast to a `int64_t`.

I've also adjusted the hashtable's `_hash` wrapper to use the primitive `object2int` in order to avoid a cast causing a similar error. Future work could add this code to `CTypes.chpl` as the official `c_ptr`/`c_ptrConst` hash method.

These adjustments are to the custom hashtable implementation in the module `ChapelDynamicLoading`. They do not affect the public implementation in `ChapelHashtable`.

TESTING

- [x] `make check` w/ `linux32` `CHPL_LLVM=none`
- [x] `paratest` w/ `linux64`

Reviewed by @benharsh. Thanks much!