### PR TITLE
Minor dyno fixes

### DIFF
--- a/frontend/include/chpl/resolution/resolution-queries.h
+++ b/frontend/include/chpl/resolution/resolution-queries.h
@@ -677,7 +677,10 @@ builderResultForDefaultFunction(Context* context,
     for a range is the type of the range's elements. */
 const types::QualifiedType& getPromotionType(Context* context, types::QualifiedType qt, bool skipIfRunning = false);
 
+/// \cond DO_NOT_DOCUMENT
+// Common helper for ArrayType and DomainType
 const types::RuntimeType* getRuntimeType(Context* context, const types::CompositeType* ct);
+/// \endcond
 
 Access accessForQualifier(uast::Qualifier q);
 

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -3192,14 +3192,14 @@ bool Resolver::resolveSpecialKeywordCall(const Call* call) {
   } else if (fnName == "subdomain") {
     // check if we're inside a 'sparse subdomain' call, in which case we should
     // do nothing.
-    CHPL_ASSERT(callNodeStack.size() >= 2);
-    CHPL_ASSERT(callNodeStack.back() == fnCall);
-    auto parentCall = callNodeStack[callNodeStack.size() - 2];
-    if (parentCall->numActuals() == 1 && parentCall->actual(0) == fnCall) {
-      if (auto parentFnCall = parentCall->toFnCall()) {
-        if (parentFnCall->calledExpression()->isIdentifier() &&
-            parentFnCall->calledExpression()->toIdentifier()->name() == "sparse") {
-          return true;
+    if (callNodeStack.size() >= 2 && callNodeStack.back() == fnCall) {
+      auto parentCall = callNodeStack[callNodeStack.size() - 2];
+      if (parentCall->numActuals() == 1 && parentCall->actual(0) == fnCall) {
+        if (auto parentFnCall = parentCall->toFnCall()) {
+          auto parentIdent = parentFnCall->calledExpression()->toIdentifier();
+          if (parentIdent && parentIdent->name() == "sparse") {
+            return true;
+          }
         }
       }
     }

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -500,17 +500,12 @@ static QualifiedType primGetRuntimeTypeField(Context* context,
   if (auto dt = compositeType->toDomainType()) {
     while (dt->isSubdomain()) dt = dt->parentDomain();
 
-    auto domainRtt = dt->runtimeType(context);
-    CHPL_ASSERT(domainRtt);
-    CHPL_ASSERT(domainRtt->isRuntimeType());
-    rtt = domainRtt->toRuntimeType();
+    rtt = dt->runtimeType(context);
   } else if (auto at = compositeType->toArrayType()) {
-    auto arrayRtt = at->runtimeType(context);
-    CHPL_ASSERT(arrayRtt);
-    CHPL_ASSERT(arrayRtt->isRuntimeType());
-    rtt = arrayRtt->toRuntimeType();
+    rtt = at->runtimeType(context);
   }
 
+  // Might be the case if domain is the generic 'domain(?)'
   if (!rtt) return QualifiedType();
 
   for (int i = 0; i < rtt->initializer()->numFormals(); i++) {

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -190,8 +190,6 @@ static UniqueString getCallName(const uast::Call* call) {
       name = calledDot->field();
     } else if (auto op = called->toOpCall()) {
       name = op->op();
-    } else {
-      CHPL_UNIMPL("CallInfo without a name");
     }
   }
   return name;

--- a/frontend/lib/types/ArrayType.cpp
+++ b/frontend/lib/types/ArrayType.cpp
@@ -33,6 +33,9 @@ const ID ArrayType::domainId = ID(UniqueString(), 0, 0);
 const ID ArrayType::eltTypeId = ID(UniqueString(), 1, 0);
 
 const RuntimeType* ArrayType::runtimeType(Context* context) const {
+  auto dom = domainType().type()->toDomainType();
+  if (dom->kind() == DomainType::Kind::Unknown) return nullptr;
+
   return resolution::getRuntimeType(context, this);
 }
 

--- a/frontend/lib/types/DomainType.cpp
+++ b/frontend/lib/types/DomainType.cpp
@@ -38,6 +38,9 @@ const ID DomainType::parSafeId = ID(UniqueString(), 1, 0);
 const ID DomainType::parentDomainId = ID(UniqueString(), 0, 0);
 
 const RuntimeType* DomainType::runtimeType(Context* context) const {
+  // generic domains do not have a runtime type
+  if (kind() == DomainType::Kind::Unknown) return nullptr;
+
   return resolution::getRuntimeType(context, this);
 }
 


### PR DESCRIPTION
A few fixes to issues I noticed while going through the primers:
- allow non-sparse subdomain calls
- remove an inaccurate CHPL_UNIMPL warning
- allow assignment between extern types
- avoid an assertion failure when resolving runtime type of generic domain

Testing:
- [x] test-frontend