### PR TITLE
Ensure that STB image library uses Chapel allocation functions

### DIFF
--- a/modules/packages/ImageHelper/stb_image_helper.h
+++ b/modules/packages/ImageHelper/stb_image_helper.h
@@ -22,9 +22,9 @@
 
 #include "chpl-mem.h"
 
-#define STBIW_MALLOC(sz)        chpl_malloc(sz)
-#define STBIW_REALLOC(p,newsz)  chpl_realloc(p,newsz)
-#define STBIW_FREE(p)           chpl_free(p)
+#define STBIW_MALLOC(sz)        chpl_mem_alloc(sz, 0, 0, 0)
+#define STBIW_REALLOC(p,newsz)  chpl_mem_realloc(p, newsz, 0, 0, 0)
+#define STBIW_FREE(p)           chpl_mem_free(p, 0, 0)
 
 #define STB_IMAGE_IMPLEMENTATION
 #define STBI_ONLY_PNG

--- a/modules/packages/ImageHelper/stb_image_helper.h
+++ b/modules/packages/ImageHelper/stb_image_helper.h
@@ -20,6 +20,12 @@
 #ifndef CHPL_STB_IMAGE_WRITE_HELPER_H_
 #define CHPL_STB_IMAGE_WRITE_HELPER_H_
 
+#include "chpl-mem.h"
+
+#define STBIW_MALLOC(sz)        chpl_malloc(sz)
+#define STBIW_REALLOC(p,newsz)  chpl_realloc(p,newsz)
+#define STBIW_FREE(p)           chpl_free(p)
+
 #define STB_IMAGE_IMPLEMENTATION
 #define STBI_ONLY_PNG
 #define STBI_ONLY_JPEG


### PR DESCRIPTION
Adjusts the STB helper header to prefer using Chapel's allocation functions over the system default malloc/free.

This enables the allocations done by STB to be tracked by Chapels memory tracking system

[Reviewed by @DanilaFe]