### PR TITLE
Fix erroneous verification warning about not being able to use jemalloc

### DIFF
--- a/util/chplenv/chplenv_verify.py
+++ b/util/chplenv/chplenv_verify.py
@@ -293,6 +293,11 @@ class TestHostCanFindLLVM(TestCompile):
             self.chplenv.get("CHPL_HOST_BUNDLED_LINK_ARGS", "") + " " +
             self.chplenv.get("CHPL_HOST_SYSTEM_LINK_ARGS", "")
         )
+
+        # strip out jemalloc to avoid linker warnings on some systems
+        if "jemalloc" in link_args:
+            link_args = link_args.replace("-ljemalloc", "")
+
         return (
             super()._compiler_args()
             + shlex.split(comp_args)


### PR DESCRIPTION
Fixes an erroneous verification warning about missing jemalloc libraries by removing that argument from the link args. For the purposes of verification, its not needed.

[Reviewed by @DanilaFe]