### PR TITLE
Explicitly specify type to avoid relying on resolution order

### DIFF
--- a/modules/internal/ByteBufferHelpers.chpl
+++ b/modules/internal/ByteBufferHelpers.chpl
@@ -95,7 +95,7 @@ module ByteBufferHelpers {
       return dst;
   }
 
-  inline proc bufferCopyLocal(src_addr: bufferType, len: int) {
+  inline proc bufferCopyLocal(src_addr: bufferType, len: int): (bufferType, int) {
       const (dst, allocSize) = bufferAlloc(len+1);
       bufferMemcpyLocal(dst=dst, src=src_addr, len=len);
       dst[len] = 0;


### PR DESCRIPTION
This PR works around https://github.com/chapel-lang/chapel/issues/27140 by explicitly specifying a return type. See the issue for associated discussion. Closes https://github.com/Cray/chapel-private/issues/7292 in favor of https://github.com/chapel-lang/chapel/issues/27140.

## Testing
- [x] dyno tests
- [ ] paratest