### PR TITLE
Dyno: fix ambiguity errors

### DIFF
--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -309,7 +309,7 @@ bool CanPassResult::canConvertNumeric(Context* context,
     // don't convert bools to complexes (per spec: "unintended by programmer")
 
     // coerce any integer type to any width complex
-    if (actualT->isNumericType())
+    if (actualT->isIntegralType())
       return true;
 
     // convert smaller complex types

--- a/frontend/test/resolution/testLet.cpp
+++ b/frontend/test/resolution/testLet.cpp
@@ -65,9 +65,8 @@ static void testOutOfOrder() {
   )""";
 
   resolveTypeOfXInit(context, program, /* requireType */ false);
-  assert(guard.numErrors() == 2);
+  assert(guard.numErrors() == 1);
   assert(guard.error(0)->type() == ErrorType::UseOfLaterVariable);
-  assert(guard.error(1)->type() == ErrorType::NoMatchingCandidates);
   guard.realizeErrors();
 }
 


### PR DESCRIPTION
This PR fixes some ambiguity errors in `test/types/coerce/allNumericsBinary.chpl`. It does not, however, fix all resolution errors -- there are still some to do with the `array_get` primitive, and maybe more. I just thought smaller, incremental PRs would be easier to review, and might unblock other tests somehow.

The two main changes are:
* Don't consider variables as "unknown but eligible for `out` intent" in more cases. Today, we resolve calls with unknown formals sometimes, but only when the actual refers to an unknown-typed variable. We take this to potentially mean the the call computes the variable's type via the `out` intent. However, if the variable is part of a loop, or has a type expression, or is set to a value, the `out` intent shouldn't set its type: it's unknown for other reasons, like failure to resolve an identifier.
* A piece of code in `canPass` used `isNumeric` to check for "any integer type". Numeric types include reals, which are not integers. This PR narrows the check to `isIntegral`, which only includes integers.

Reviewed by @arezaii -- thanks!

## Testing
- [x] dyno tests
- [x] paratest