### PR TITLE
Prevent running `paratest.chapcs` or `paratest.chapdl` with a slurm launcher

### DIFF
--- a/util/test/paratest.chapcs
+++ b/util/test/paratest.chapcs
@@ -167,8 +167,19 @@ def running_during_nightly():
     return nightly_start_exclusive <= now <= nightly_end_exclusive
 
 
+def using_a_slurm_launcher():
+    import chpl_launcher
+    launcher = chpl_launcher.get()
+    return "slurm" in launcher
+
+
 def main(paratest_args):
     """ Just run paratest with the user's args """
+
+    if using_a_slurm_launcher():
+        print("This script is not intended to be run with a slurm-based launcher")
+        exit(1)
+
     if running_during_nightly():
         print('Please avoid running when nightly has exclusive access')
         exit(1)


### PR DESCRIPTION
Prevents running `paratest.chapcs` or `paratest.chapdl` if the current Chapel environment is using a slurm based launcher.

Using a slurm launcher with these scripts will either result in very slow execution or a confusing error, so these PR heads that off by preventing that from occurring in the first place.

Note: this PR only adjusts `paratest.chapcs`, as `paratest.chapdl` calls `paratest.chapcs`

- [x] verified that with `CHPL_LAUNCHER=none`, `paratest.*` works
- [x] verified that with `CHPL_LAUNCHER=slurm-srun`, `paratest.*` errors

[Reviewed by @lydia-duncan]