### PR TITLE
Dyno: implement `array_get` primitive for more types

### DIFF
--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -575,6 +575,8 @@ static QualifiedType arrayGet(ResolutionContext* rc, const PrimCall* call, const
 
   if (auto ptr = act.type()->toCPtrType()) {
     return QualifiedType(QualifiedType::REF, ptr->eltType());
+  } else if (auto ptr = act.type()->toHeapBufferType()) {
+    return QualifiedType(QualifiedType::REF, ptr->eltType());
   } else if (auto ct = act.type()->toCompositeType()) {
     auto ast = parsing::idToAst(rc->context(), ct->id());
     bool hasSupportedPragmas =

--- a/frontend/test/resolution/testResolve.cpp
+++ b/frontend/test/resolution/testResolve.cpp
@@ -1924,6 +1924,8 @@ static void testArrayGetPrim() {
   assert(r1.kind() == QualifiedType::REF);
   assert(r1.type()->isIntType() && r1.type()->toIntType()->isDefaultWidth());
 
+  // note: in production, even const c_ptr returns non-const REF from
+  // this call.
   auto& r2 = variables.at("r2");
   assert(r2.kind() == QualifiedType::REF);
   assert(r2.type()->isBoolType());

--- a/frontend/test/resolution/testResolve.cpp
+++ b/frontend/test/resolution/testResolve.cpp
@@ -1901,6 +1901,42 @@ static void testGetLocalePrim() {
   assert(guard.realizeErrors() == 0);
 }
 
+static void testArrayGetPrim() {
+  auto context = buildStdContext();
+  ErrorGuard guard(context);
+
+  auto variables = resolveTypesOfVariablesInit(context,
+    R"""(
+      use CTypes;
+
+      var a: c_ptr(int);
+      var b: c_ptrConst(bool);
+      var c: _ddata(real);
+      var d: c_array(int(8), 4);
+
+      var r1 = __primitive("array_get", a, 0);
+      var r2 = __primitive("array_get", b, 0);
+      var r3 = __primitive("array_get", c, 0);
+      var r4 = __primitive("array_get", d, 0);
+    )""", { "r1", "r2", "r3", "r4" });
+
+  auto& r1 = variables.at("r1");
+  assert(r1.kind() == QualifiedType::REF);
+  assert(r1.type()->isIntType() && r1.type()->toIntType()->isDefaultWidth());
+
+  auto& r2 = variables.at("r2");
+  assert(r2.kind() == QualifiedType::REF);
+  assert(r2.type()->isBoolType());
+
+  auto& r3 = variables.at("r3");
+  assert(r3.kind() == QualifiedType::REF);
+  assert(r3.type()->isRealType() && r3.type()->toRealType()->isDefaultWidth());
+
+  auto& r4 = variables.at("r4");
+  assert(r4.kind() == QualifiedType::REF);
+  assert(r4.type()->isIntType() && r4.type()->toIntType()->bitwidth() == 8);
+}
+
 // Test the '.locale' query.
 static void testDotLocale() {
   Context ctx;
@@ -2137,6 +2173,7 @@ int main() {
 
   testPromotionPrim();
   testGetLocalePrim();
+  testArrayGetPrim();
 
   testDotLocale();
 


### PR DESCRIPTION
On `main`, `array_get` only supports `c_ptr`. However, in production, any type with `pragma "data class"` or `pragma "c array"` can be used as an argument for the primitive. This PR adds:

* General handling for any record or class declared "data class". This handling matches production. Any type that has one of the two pragmas has its fields searched for an `eltType` field, and that field is used to compute result of indexing.
* Special handling for `_ddata`, which has the `"data class"` pragma but is specially handled in Dyno's type representation via the `HeapBufferType`, which mirrors `CPtrType`. The handling is nearly identical to `CPtrType`'s handling.

Reviewed by @mppf -- thanks!

## Testing
- [x] dyno tests
- [x] paratest