### PR TITLE
Default to CHPL_LAUNCHER=none when not on a known cluster and CHPL_COMM=none

### DIFF
--- a/util/chplenv/chpl_launcher.py
+++ b/util/chplenv/chpl_launcher.py
@@ -29,29 +29,7 @@ def get():
     if not launcher_val:
         platform_val = chpl_platform.get('target')
 
-        if platform_val.startswith('cray-x') or platform_val.startswith('hpe-cray-'):
-            has_aprun = which('aprun')
-            has_slurm = which('srun')
-            if has_aprun and has_slurm:
-                launcher_val = 'none'
-                warning("Both 'aprun' and 'srun' are available on this system. Please explicitly set CHPL_LAUNCHER.")
-            elif has_aprun:
-                launcher_val = 'aprun'
-            elif has_slurm:
-                launcher_val = 'slurm-srun'
-            else:
-                # FIXME: Need to detect aprun/srun differently. On a cray
-                #        system with an eslogin node, it is possible that aprun
-                #        will not be available on the eslogin node (only on the
-                #        login node).
-                #
-                #        has_aprun and has_slurm should look other places
-                #        (maybe the modules?) to decide.
-                #        (thomasvandoren, 2014-08-12)
-                launcher_val = 'none'
-                warning('Cannot detect launcher on this system. Please '
-                        'set CHPL_LAUNCHER in the environment.')
-        elif comm_val == 'gasnet':
+        if comm_val == 'gasnet':
             if substrate_val == 'smp':
                 launcher_val = 'smp'
             elif substrate_val == 'mpi':
@@ -63,10 +41,35 @@ def get():
             elif substrate_val == 'ofi':
                 launcher_val = slurm_prefix('gasnetrun_ofi')
         else:
-            if which('srun'):
-                launcher_val = 'slurm-srun'
+            is_known_cluster = (platform_val.startswith('cray-') or
+                                platform_val.startswith('hpe-'))
+            if is_known_cluster:
+                has_aprun = which('aprun')
+                has_slurm = which('srun')
+                if has_aprun and has_slurm:
+                    launcher_val = 'none'
+                    warning("Both 'aprun' and 'srun' are available on this system. Please explicitly set CHPL_LAUNCHER.")
+                elif has_aprun:
+                    launcher_val = 'aprun'
+                elif has_slurm:
+                    launcher_val = 'slurm-srun'
+                else:
+                    # FIXME: Need to detect aprun/srun differently. On a cray
+                    #        system with an eslogin node, it is possible that aprun
+                    #        will not be available on the eslogin node (only on the
+                    #        login node).
+                    #
+                    #        has_aprun and has_slurm should look other places
+                    #        (maybe the modules?) to decide.
+                    #        (thomasvandoren, 2014-08-12)
+                    launcher_val = 'none'
+                    warning('Cannot detect launcher on this system. Please '
+                            'set CHPL_LAUNCHER in the environment.')
             else:
-                launcher_val = 'none'
+                if comm_val != "none" and which('srun'):
+                    launcher_val = 'slurm-srun'
+                else:
+                    launcher_val = 'none'
 
     if launcher_val is None:
         launcher_val = 'none'

--- a/util/chplenv/chpl_launcher.py
+++ b/util/chplenv/chpl_launcher.py
@@ -27,8 +27,6 @@ def get():
                   'required'.format(launcher_val))
 
     if not launcher_val:
-        platform_val = chpl_platform.get('target')
-
         if comm_val == 'gasnet':
             if substrate_val == 'smp':
                 launcher_val = 'smp'
@@ -41,9 +39,7 @@ def get():
             elif substrate_val == 'ofi':
                 launcher_val = slurm_prefix('gasnetrun_ofi')
         else:
-            is_known_cluster = (platform_val.startswith('cray-') or
-                                platform_val.startswith('hpe-'))
-            if is_known_cluster:
+            if chpl_platform.is_cluster('target'):
                 has_aprun = which('aprun')
                 has_slurm = which('srun')
                 if has_aprun and has_slurm:

--- a/util/chplenv/chpl_platform.py
+++ b/util/chplenv/chpl_platform.py
@@ -85,6 +85,15 @@ def is_cray(flag='host'):
     return platform.startswith('cray') or is_hpe_cray(flag)
 
 @memoize
+def is_hpe_apollo(flag='host'):
+    platform = get(flag)
+    return platform == 'hpe-apollo'
+
+@memoize
+def is_cluster(flag='host'):
+    return is_cray(flag) or is_hpe_apollo(flag)
+
+@memoize
 def get_mac_os_version():
     release, version, machine = platform.mac_ver()
     return release


### PR DESCRIPTION
Per the discussion on #27079, changes the default of CHPL_LAUNCHER to none when not on a known cluster and CHPL_COMM=none

Implements the results of https://github.com/chapel-lang/chapel/issues/27079#issuecomment-2807107888

Note: this PR refactors the logic for selecting the default to avoid duplicating logic for the default of `slurm-srun`.

[Reviewed by @arifthpe and @e-kayrakli]

Testing
- with slurm installed
  - CHPL_COMM=none 
    - [x] `CHPL_HOST_PLATFORM=linux64 printchplenv` reports `CHPL_LAUNCHER=none`
    - [x] `CHPL_HOST_PLATFORM=hpe-cray-ex printchplenv` reports `CHPL_LAUNCHER=slurm-srun`
    - [x] `CHPL_HOST_PLATFORM=hpe-cray-xd printchplenv` reports `CHPL_LAUNCHER=slurm-srun`
    - [x] `CHPL_HOST_PLATFORM=cray-xc printchplenv` reports `CHPL_LAUNCHER=slurm-srun`
    - [x] `CHPL_HOST_PLATFORM=cray-cs printchplenv` reports `CHPL_LAUNCHER=slurm-srun`
    - [x] `CHPL_HOST_PLATFORM=hpe-apollo printchplenv` reports `CHPL_LAUNCHER=slurm-srun`
  - `CHPL_COMM=ofi`
    - [x] `CHPL_HOST_PLATFORM=linux64 printchplenv` reports `CHPL_LAUNCHER=slurm-srun`
    - [x]  `CHPL_HOST_PLATFORM=hpe-cray-ex printchplenv` reports `CHPL_LAUNCHER=slurm-srun`
    - [x] `CHPL_HOST_PLATFORM=hpe-cray-xd printchplenv` reports `CHPL_LAUNCHER=slurm-srun`
    - [x] `CHPL_HOST_PLATFORM=cray-cs printchplenv` reports `CHPL_LAUNCHER=slurm-srun`
    - [x] `CHPL_HOST_PLATFORM=hpe-apollo printchplenv` reports `CHPL_LAUNCHER=slurm-srun`
  - `CHPL_COMM=gasnet CHPL_COMM_SUBSTRATE=ibv`
    - [x] `CHPL_HOST_PLATFORM=linux64 printchplenv` reports `CHPL_LAUNCHER=slurm-gasnetrun_ibv`
    - [x]  `CHPL_HOST_PLATFORM=hpe-cray-ex printchplenv` reports `CHPL_LAUNCHER=slurm-gasnetrun_ibv`
    - [x] `CHPL_HOST_PLATFORM=hpe-cray-xd printchplenv` reports `CHPL_LAUNCHER=slurm-gasnetrun_ibv`
    - [x] `CHPL_HOST_PLATFORM=cray-cs printchplenv` reports `CHPL_LAUNCHER=slurm-gasnetrun_ibv`
    - [x] `CHPL_HOST_PLATFORM=hpe-apollo printchplenv` reports `CHPL_LAUNCHER=slurm-gasnetrun_ibv`
  - [x] `CHPL_HOST_PLATFORM=cray-xc CHPL_COMM=ugni printchplenv` reports `CHPL_LAUNCHER=slurm-srun`
- without slurm installed
  - CHPL_COMM=none 
    - [x] `CHPL_HOST_PLATFORM=linux64 printchplenv` reports `CHPL_LAUNCHER=none`
    - [x] `CHPL_HOST_PLATFORM=hpe-cray-ex printchplenv` reports `CHPL_LAUNCHER=none` (with a warning)
    - [x] `CHPL_HOST_PLATFORM=hpe-cray-xd printchplenv` reports `CHPL_LAUNCHER=none` (with a warning)
    - [x] `CHPL_HOST_PLATFORM=cray-xc printchplenv` reports ``CHPL_LAUNCHER=none` (with a warning)
    - [x] `CHPL_HOST_PLATFORM=cray-cs printchplenv` reports `CHPL_LAUNCHER=none` (with a warning)
    - [x] `CHPL_HOST_PLATFORM=hpe-apollo printchplenv` reports `CHPL_LAUNCHER=none` (with a warning)
  - `CHPL_COMM=ofi`
    - [x] `CHPL_HOST_PLATFORM=linux64 printchplenv` reports `CHPL_LAUNCHER=none` (with a warning)
    - [x]  `CHPL_HOST_PLATFORM=hpe-cray-ex printchplenv` reports `CHPL_LAUNCHER=none` (with a warning)
    - [x] `CHPL_HOST_PLATFORM=hpe-cray-xd printchplenv` reports `CHPL_LAUNCHER=none` (with a warning)
    - [x] `CHPL_HOST_PLATFORM=cray-cs printchplenv` reports `CHPL_LAUNCHER=none` (with a warning)
    - [x] `CHPL_HOST_PLATFORM=hpe-apollo printchplenv` reports `CHPL_LAUNCHER=none` (with a warning)
  - `CHPL_COMM=gasnet CHPL_COMM_SUBSTRATE=ibv`
    - [x] `CHPL_HOST_PLATFORM=linux64 printchplenv` reports `CHPL_LAUNCHER=gasnetrun_ibv`
    - [x]  `CHPL_HOST_PLATFORM=hpe-cray-ex printchplenv` reports `CHPL_LAUNCHER=gasnetrun_ibv`
    - [x] `CHPL_HOST_PLATFORM=hpe-cray-xd printchplenv` reports `CHPL_LAUNCHER=gasnetrun_ibv`
    - [x] `CHPL_HOST_PLATFORM=cray-cs printchplenv` reports `CHPL_LAUNCHER=gasnetrun_ibv`
    - [x] `CHPL_HOST_PLATFORM=hpe-apollo printchplenv` reports `CHPL_LAUNCHER=gasnetrun_ibv`
  - [x] `CHPL_HOST_PLATFORM=cray-xc CHPL_COMM=ugni printchplenv` reports `CHPL_LAUNCHER=none`  (with a warning)