### PR TITLE
Dyno: Implement `ascii` primitive

### DIFF
--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -931,7 +931,8 @@ static QualifiedType primAscii(ResolutionContext* rc, const PrimCall* call, cons
   // 'param' contexts. So, here, only handle the 'param' cases.
 
   UniqueString str;
-  if (!toParamStringActual(ci.actual(0).type(), str)) {
+  if (!toParamStringActual(ci.actual(0).type(), str) &&
+      !toParamBytesActual(ci.actual(0).type(), str)) {
     return QualifiedType();
   }
 

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -923,6 +923,33 @@ static QualifiedType primObjectToInt(Context* context, const CallInfo& ci) {
   return QualifiedType(argType.kind(), IntType::get(context, 64));
 }
 
+static QualifiedType primAscii(ResolutionContext* rc, const PrimCall* call, const CallInfo& ci) {
+  if (ci.numActuals() != 1 && ci.numActuals() != 2) return QualifiedType();
+
+  // production's legacy handling of this primitive includes fallbacks for
+  // runtime cases. However, all uses in the standard library today are in
+  // 'param' contexts. So, here, only handle the 'param' cases.
+
+  UniqueString str;
+  if (!toParamStringActual(ci.actual(0).type(), str)) {
+    return QualifiedType();
+  }
+
+  int64_t index = 0;
+  if (ci.numActuals() == 3 && !toParamIntActual(ci.actual(1).type(), index)) {
+    return QualifiedType();
+  }
+
+  if (index >= str.length()) {
+    rc->context()->error(call, "index out of range");
+    return QualifiedType();
+  }
+
+  return QualifiedType(QualifiedType::PARAM,
+                       UintType::get(rc->context(), 8),
+                       UintParam::get(rc->context(), str.c_str()[index]));
+}
+
 /*
   for get real/imag primitives
 */
@@ -1570,12 +1597,20 @@ CallResolutionResult resolvePrimCall(ResolutionContext* rc,
       break;
     }
     case PRIM_STRING_LENGTH_CODEPOINTS:
+      CHPL_UNIMPL("misc primitives");
+      break;
+
     case PRIM_ASCII:
+      type = primAscii(rc, call, ci);
+      break;
+
     case PRIM_STRING_ITEM:
     case PRIM_BYTES_ITEM:
     case PRIM_STRING_INDEX:
     case PRIM_STRING_COPY:
     case PRIM_STRING_SELECT:
+      CHPL_UNIMPL("misc primitives");
+      break;
 
     /* primitives that always return bool */
     case PRIM_EQUAL:

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -941,7 +941,7 @@ static QualifiedType primAscii(ResolutionContext* rc, const PrimCall* call, cons
     return QualifiedType();
   }
 
-  if (index >= str.length()) {
+  if (index < 0 || (uint64_t) index >= str.length()) {
     rc->context()->error(call, "index out of range");
     return QualifiedType();
   }

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -937,7 +937,7 @@ static QualifiedType primAscii(ResolutionContext* rc, const PrimCall* call, cons
   }
 
   int64_t index = 0;
-  if (ci.numActuals() == 3 && !toParamIntActual(ci.actual(1).type(), index)) {
+  if (ci.numActuals() == 2 && !toParamIntActual(ci.actual(1).type(), index)) {
     return QualifiedType();
   }
 

--- a/frontend/test/resolution/testResolve.cpp
+++ b/frontend/test/resolution/testResolve.cpp
@@ -1964,6 +1964,37 @@ static void testArrayGetPrim() {
   assert(r4.type()->isIntType() && r4.type()->toIntType()->bitwidth() == 8);
 }
 
+static void testAsciiPrim() {
+  Context* context = buildStdContext();
+  ErrorGuard guard(context);
+
+  auto variables = resolveTypesOfVariables(context,
+    R"""(
+      param b = __primitive("ascii", "b");
+      param h = __primitive("ascii", "hi", 0);
+      param i = __primitive("ascii", "hi", 1);
+      param c = __primitive("ascii", b"c");
+      param p = __primitive("ascii", b"po", 0);
+      param o = __primitive("ascii", b"po", 1);
+    )""", { "b", "h", "i", "c", "p", "o" });
+
+  auto b = variables.at("b");
+  ensureParamUint(b, 98);
+
+  auto h = variables.at("h");
+  ensureParamUint(h, 104);
+  auto i = variables.at("i");
+  ensureParamUint(i, 105);
+
+  auto c = variables.at("c");
+  ensureParamUint(c, 99);
+
+  auto p = variables.at("p");
+  ensureParamUint(p, 112);
+  auto o = variables.at("o");
+  ensureParamUint(o, 111);
+}
+
 // Test the '.locale' query.
 static void testDotLocale() {
   Context ctx;
@@ -2218,6 +2249,7 @@ int main() {
   testPromotionPrim();
   testGetLocalePrim();
   testArrayGetPrim();
+  testAsciiPrim();
 
   testDotLocale();
 


### PR DESCRIPTION
Curiously, there was a _very_ old issue with the list of primitives in `prims.cpp`: because a `break` was missing, a lot of the string primitives were marked as successfully handled, and returning a boolean. `ascii` was one of those primitives. This PR implements the primitive, and correctly marks the other string primitives unimplemented. This may lead to test failures that were masked, somehow, by the handling of string primitives as boolean-returning functions.

Reviewed by @arifthpe -- thanks!

## Testing
- [x] dyno tests
- [x] paratest
- [x] `--dyno-resolve-only` tests