### PR TITLE
Dyno: implement `.bytes()`, other fixes for `allNumericsBinary.chpl`

### DIFF
--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -5694,9 +5694,9 @@ QualifiedType Resolver::typeForEnumElement(const EnumType* enumType,
   return qt;
 }
 
-// static bool isDotDomainAccess(const Dot* dot) {
-//   return dot->field() == USTR("domain");
-// }
+static bool isDotDomainAccess(const Dot* dot) {
+  return dot->field() == USTR("domain");
+}
 
 void Resolver::exit(const Dot* dot) {
   ResolvedExpression& receiver = byPostorder.byAst(dot->receiver());
@@ -5717,7 +5717,7 @@ void Resolver::exit(const Dot* dot) {
     // Special case: Don't try to resolve calls to .domain here, as we
     // need to proceed to the handling logic below.
     if (!receiver.type().isUnknown() && receiver.type().type() &&
-        receiver.type().type()->getCompositeType() &&
+        (receiver.type().type()->getCompositeType() || isDotDomainAccess(dot)) &&
         dot->field() != USTR("init")) {
       std::vector<CallInfoActual> actuals;
       actuals.push_back(CallInfoActual(receiver.type(), USTR("this")));

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -4401,6 +4401,31 @@ static bool resolveFnCallSpecialType(Context* context,
   return false;
 }
 
+static bool resolveMethodCallSpecial(Context* context,
+                                     const AstNode* astContext,
+                                     const CallInfo& ci,
+                                     const CallScopeInfo& inScopes,
+                                     CallResolutionResult& result) {
+  if (!ci.isMethodCall()) {
+    return false;
+  }
+
+  ResolutionContext rcval(context);
+  auto rc = &rcval;
+
+  // Methods that require resolving some kind of helper method to build
+  // the type.
+
+  if (ci.name() == USTR("domain") && ci.isParenless()) {
+    auto newName = UniqueString::get(context, "_dom");
+    auto ctorCall = CallInfo::copyAndRename(ci, newName);
+    result = resolveGeneratedCall(rc, astContext, ctorCall, inScopes);
+    return true;
+  }
+
+  return false;
+}
+
 static MostSpecificCandidates
 resolveFnCallForTypeCtor(Context* context,
                          const CallInfo& ci,
@@ -5642,6 +5667,10 @@ CallResolutionResult resolveCall(ResolutionContext* rc,
       return keywordRes;
     }
 
+    if (resolveMethodCallSpecial(context, call, ci, inScopes, keywordRes)) {
+      return keywordRes;
+    }
+
     // otherwise do regular call resolution
     return resolveFnCall(rc, call, call, ci, inScopes, rejected, skipForwarding);
   } else if (auto prim = call->toPrimCall()) {
@@ -5704,6 +5733,12 @@ CallResolutionResult resolveGeneratedCall(ResolutionContext* rc,
   if (resolveFnCallSpecial(rc->context(), astContext, ci, tmpRetType)) {
     return CallResolutionResult(std::move(tmpRetType));
   }
+
+  CallResolutionResult keywordRes;
+  if (resolveMethodCallSpecial(rc->context(), astContext, ci, inScopes, keywordRes)) {
+    return keywordRes;
+  }
+
   // otherwise do regular call resolution
   const Call* call = nullptr;
   return resolveFnCall(rc, astContext, call, ci, inScopes, rejected);

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -4423,6 +4423,13 @@ static bool resolveMethodCallSpecial(Context* context,
     return true;
   }
 
+  if (ci.name() == USTR("bytes") && !ci.isParenless()) {
+    auto newName = UniqueString::get(context, "chpl_bytes");
+    auto ctorCall = CallInfo::copyAndRename(ci, newName);
+    result = resolveGeneratedCall(rc, astContext, ctorCall, inScopes);
+    return true;
+  }
+
   return false;
 }
 

--- a/frontend/test/resolution/testResolve.cpp
+++ b/frontend/test/resolution/testResolve.cpp
@@ -2014,6 +2014,30 @@ static void testDotLocale() {
   assert(guard.realizeErrors() == 0);
 }
 
+// .bytes() should be rewritten to .chpl_bytes()
+static void testDotBytes() {
+  auto context = buildStdContext();
+  ErrorGuard guard(context);
+
+  auto variables = resolveTypesOfVariables(context,
+    R"""(
+      var str = "hello";
+      var bts = b"hello";
+
+      var x = str.bytes();
+      var y = bts.bytes();
+    )""", { "x", "y" });
+
+  for (auto& kv : variables) {
+    auto& qt = kv.second;
+
+    assert(!qt.isUnknownOrErroneous());
+    assert(qt.type()->isArrayType());
+    assert(qt.type()->toArrayType()->eltType().type()->isUintType());
+    assert(qt.type()->toArrayType()->eltType().type()->toUintType()->bitwidth() == 8);
+  }
+}
+
 // even if a formal's type has defaults, if it's explicitly made generic
 // with (?) it should not be concrete.
 static void testExplicitlyGenericFormal() {
@@ -2252,6 +2276,7 @@ int main() {
   testAsciiPrim();
 
   testDotLocale();
+  testDotBytes();
 
   testExplicitlyGenericFormal();
 


### PR DESCRIPTION
This PR, which depends on https://github.com/chapel-lang/chapel/pull/27150, fixes the remaining failures in `test/types/coerce/allNumericsBinary.chpl`. 

Specifically, the things that were failing were `.bytes()` on stings (which, consulting `convert-uast.cpp`, I learned is rewritten in production to `chpl_bytes`), and some weird errors about loop labels being incorrect. This, I:

* Observed that rewriting `.bytes()` to `.chpl_bytes()` matches pretty closely the rewriting of `atomic` to `chpl__atomicType`. I also noticed that `.domain` -> `._dom` rewriting is very similar, and not handled there.
* Consulted with @arifthpe to see if it was a bad idea (she didn't seem to think so) to move where `.domain` is handled, then moved `.domain` handling into a new `handleMethodCallSpecial` helper in `resolution-queries`.
* Implemented the `.bytes()` rewriting in the same helper.
* Fixed the issue with loop labels by always marking loops as having a `LOOP` kind, which simplified logic considerably.

Now, all `.x` -> `.chpl_y` rewrites are handled uniformly inside `handleMethodCallSpecial`.

Reviewed by @arifthpe -- thanks!

## Testing
- [x] dyno tests
- [x] paratest
- [x] `--dyno-resolve-only` tests