### PR TITLE
Dyno: implement builtin borrow

### DIFF
--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -4306,7 +4306,7 @@ static bool resolveFnCallSpecial(Context* context,
 
   if (ci.name() == USTR("borrow") && ci.numActuals() == 1 && ci.isMethodCall()) {
     // this is the equivalent of the production compiler's `resolveClassBorrowMethod`.
-    // A call to `isClassLike` there rejects handling `owned` and `shared,
+    // A call to `isClassLike` there rejects handling `owned` and `shared`,
     // so only handle undecorated class types here.
 
     auto receiver = ci.methodReceiverType();

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -4318,11 +4318,13 @@ static bool resolveFnCallSpecial(Context* context,
        !receiverCt->decorator().isManaged());
 
     if (handle) {
-      bool nilable = receiverCt && receiverCt->decorator().isNilable();
       auto finalBct = receiverBct ? receiverBct : receiverCt->manageableType();
 
-      auto decorator = ClassTypeDecorator(
-          nilable ? ClassTypeDecorator::BORROWED : ClassTypeDecorator::BORROWED_NONNIL);
+      auto decorator = ClassTypeDecorator(ClassTypeDecorator::BORROWED);
+      if (receiverCt) {
+        decorator = decorator.copyNilabilityFrom(receiverCt->decorator());
+      }
+
       auto outTy = ClassType::get(context, finalBct, nullptr, decorator);
       exprTypeOut = QualifiedType(QualifiedType::VAR, outTy);
       return true;

--- a/frontend/test/resolution/testCast.cpp
+++ b/frontend/test/resolution/testCast.cpp
@@ -352,21 +352,29 @@ static void test35() {
 //   testHelper(&ctx, program, ComplexType::get(&ctx, 0), ComplexParam::get(&ctx, Param::ComplexDouble(1.1, 2.2)));
 // }
 
-// TODO: enum to int cast
-// static void test37() {
-//   printf("test37\n");
-//   Context ctx;
-//   std::string program = "enum E { A=0, B, C } param x = E.A : int; ";
-//   testHelper(&ctx, program, IntType::get(&ctx, 0), IntParam::get(&ctx, 0));
-// }
+static void test37() {
+  printf("test37\n");
+  Context ctx;
+  std::string program = "enum E { A=0, B, C } param x = E.A : int; ";
+  testHelper(&ctx, program, IntType::get(&ctx, 0), IntParam::get(&ctx, 0));
+}
 
-// TODO: int to enum cast
-// static void test38() {
-//   printf("test38\n");
-//   Context ctx;
-//   std::string program = "enum E { A=0, B, C } param x = 0 : E; ";
-//   testHelper(&ctx, program, EnumType::get(&ctx, 0), EnumParam::get(&ctx, 0));
-// }
+static void test38() {
+  printf("test38\n");
+  Context ctx;
+  std::string program = "enum E { A=0, B, C } param x = 0 : E; ";
+
+  auto enumId = ID(UniqueString::get(&ctx, "input.E"), -1, 0);
+  auto eltId = ID(enumId.symbolPath(), 1, 1);
+
+  // invoking 'EnumType::get' prior to resolving a program causes problems,
+  // so don't use the helper in order to defer constructing the EnumType.
+  QualifiedType qt = resolveQualifiedTypeOfX(&ctx, program);
+
+  assert(qt.hasTypePtr());
+  assert(qt.type() == EnumType::get(&ctx, enumId, UniqueString::get(&ctx, "E")));
+  assert(qt.param() == EnumParam::get(&ctx, {eltId, "A"}));
+}
 
 
 // enum to nothing cast (error)
@@ -596,8 +604,8 @@ int main() {
   test34();
   test35();
   // test36();
-  // test37();
-  // test38();
+  test37();
+  test38();
   test39();
   test40();
   test41();

--- a/frontend/test/resolution/testCast.cpp
+++ b/frontend/test/resolution/testCast.cpp
@@ -567,6 +567,29 @@ static void test46() {
   }
 }
 
+static void test47() {
+  printf("test47\n");
+  Context ctx;
+  Context* context = &ctx;
+
+  auto testBorrow = [context](std::string buildC, bool expectNilable) {
+    context->advanceToNextRevision(false);
+    ErrorGuard guard(context);
+
+    auto fullProg = "class C{}\n" + buildC + "\nvar x = c.borrow();";
+    auto xInit = resolveTypeOfXInit(context, fullProg);
+    assert(xInit.type());
+    assert(xInit.type()->isClassType());
+    assert(xInit.type()->toClassType()->decorator().isBorrowed());
+    assert(xInit.type()->toClassType()->decorator().isNilable() == expectNilable);
+  };
+
+  testBorrow("var cu = new unmanaged C();\n var c = cu : borrowed;", false);
+  testBorrow("var cu = new unmanaged C?();\n var c = cu : borrowed;", true);
+  testBorrow("var c = new unmanaged C();", false);
+  testBorrow("var c = new unmanaged C?();", true);
+}
+
 int main() {
   test1();
   test2();
@@ -614,6 +637,7 @@ int main() {
   test44();
   test45();
   test46();
+  test47();
 
   return 0;
 }


### PR DESCRIPTION
Closes https://github.com/Cray/chapel-private/issues/7295.

This PR implements the compiler-generated `.borrow()` method on unmanaged and borrowed types. The reference production version here is here:

https://github.com/chapel-lang/chapel/blob/6e19ea5cd74fccb382216874412db4cfeae70949/compiler/resolution/functionResolution.cpp#L3315

While there, I noticed that some of the tests in `testCast` are commented out but should work. I re-enabled them.

Reviewed by @benharsh -- thanks!

## Testing
- [x] dyno tests
- [x] paratest