### PR TITLE
dyno: Add initial support for ``_`` and de-tupled loop index variables

### DIFF
--- a/frontend/include/chpl/resolution/can-pass.h
+++ b/frontend/include/chpl/resolution/can-pass.h
@@ -243,6 +243,8 @@ bool canInstantiateSubstitutions(Context* context,
    ref-ness, etc) each of which are processed independently from
    the others. */
 class KindProperties {
+ public:
+  using Kind = types::QualifiedType::Kind;
  private:
   bool isConst = false;
   bool isRef = false;
@@ -265,7 +267,7 @@ class KindProperties {
 
  public:
   /* Decompose a qualified type kind into its properties. */
-  static KindProperties fromKind(types::QualifiedType::Kind kind);
+  static KindProperties fromKind(Kind kind);
 
   /* Set the refness property to the given one. */
   void setRef(bool isRef);
@@ -295,12 +297,16 @@ class KindProperties {
   void strictCombineWith(const KindProperties& other);
 
   /* Combine the properties of two kinds, returning the result as a kind. */
-  static types::QualifiedType::Kind combineKindsMeet(
-      types::QualifiedType::Kind kind1,
-      types::QualifiedType::Kind kind2);
+  static types::QualifiedType::Kind combineKindsMeet(Kind kind1, Kind kind2);
 
   /* Convert the set of kind properties back into a kind. */
   types::QualifiedType::Kind toKind() const;
+
+  /* Add constness to the given kind. */
+  static Kind addConstness(Kind kind);
+
+  /* Add refness to the given kind. */
+  static Kind addRefness(Kind kind);
 
   bool valid() const { return isValid; }
 

--- a/frontend/include/chpl/resolution/can-pass.h
+++ b/frontend/include/chpl/resolution/can-pass.h
@@ -297,7 +297,7 @@ class KindProperties {
   void strictCombineWith(const KindProperties& other);
 
   /* Combine the properties of two kinds, returning the result as a kind. */
-  static types::QualifiedType::Kind combineKindsMeet(Kind kind1, Kind kind2);
+  static Kind combineKindsMeet(Kind kind1, Kind kind2);
 
   /* Convert the set of kind properties back into a kind. */
   types::QualifiedType::Kind toKind() const;

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -2542,8 +2542,13 @@ class ResolvedExpression {
   /** set the toId */
   void setToId(ID toId) { toId_ = toId; }
 
-  /** set the type */
+  /** set the qualified type */
   void setType(const types::QualifiedType& type) { type_ = type; }
+
+  /** set the kind of the qualified type */
+  void setKind(types::QualifiedType::Kind kind) {
+    type_ = { kind, type_.type(), type_.param() };
+  }
 
   /** set the most specific */
   void setMostSpecific(const MostSpecificCandidates& mostSpecific) {

--- a/frontend/include/chpl/types/TupleType.h
+++ b/frontend/include/chpl/types/TupleType.h
@@ -95,12 +95,14 @@ class TupleType final : public CompositeType {
   getReferentialTuple(Context* context, std::vector<const Type*> eltTypes, bool makeConst=false);
 
   static const TupleType*
-  getQualifiedTuple(Context* context, std::vector<QualifiedType> eltTypes);
+  getQualifiedTuple(Context* context,
+                    std::vector<QualifiedType> eltTypes,
+                    bool isVarArgTuple = false);
 
   static const TupleType*
-  getStarTuple(Context* context,
-               QualifiedType paramSize,
-               QualifiedType starEltType);
+  getVarArgTuple(Context* context,
+                 QualifiedType paramSize,
+                 QualifiedType starEltType);
 
   const Type* substitute(Context* context,
                          const PlaceholderMap& subs) const override {

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2563,14 +2563,69 @@ Resolver::adjustTypesForOutFormals(const CallInfo& ci,
   }
 }
 
-void Resolver::resolveTupleUnpackAssign(ResolvedExpression& r,
-                                        const uast::AstNode* astForErr,
-                                        const Tuple* lhsTuple,
-                                        QualifiedType lhsType,
-                                        QualifiedType rhsType) {
-  // Check that lhsType = rhsType can work
+static bool
+isValidAssignmentTarget(const ID& id, const ResolvedExpression& re) {
+  // If the kind is a reference then it must point to an assignable name.
+  if (re.type().isRef()) return true;
+  // It's a non-ref returning call, so it returns a temporary value.
+  if (re.mostSpecific().foundCandidates()) return false;
+  return true;
+}
 
-  if (!lhsType.hasTypePtr()) {
+// Adjusts LHS tuple type so that its components are all references.
+// Does no sanity checks.
+static QualifiedType
+adjustLhsForTupleUnpackAssign(Resolver& rv,
+                              const uast::AstNode* astForErr,
+                              const Tuple* lhsTuple,
+                              const QualifiedType& lhsType) {
+  Context* context = rv.context;
+  std::vector<QualifiedType> eltTypes;
+
+  auto lhsT = lhsType.type() ? lhsType.type()->toTupleType() : nullptr;
+  if (!lhsT || lhsT->numElements() != lhsTuple->numActuals()) return lhsType;
+
+  for (int i = 0; i < lhsTuple->numActuals(); i++) {
+    auto actual = lhsTuple->actual(i);
+    auto ident = actual->toIdentifier();
+    auto& re = rv.byPostorder.byAst(actual);
+    QualifiedType qt;
+
+    if (ident && ident->name() == USTR("_")) {
+      // If the LHS actual is '_', then use the Nothing type. This is fine
+      // since the '_' will never be set.
+      qt = { QualifiedType::VAR, NothingType::get(context) };
+
+    } else {
+      // Otherwise, turn its qualifier into 'ref' / 'const ref' and make
+      // sure the actual is a valid assignment target.
+      auto eqt = lhsT->elementType(i);
+      auto kind = KindProperties::addRefness(eqt.kind());
+      qt = { kind, eqt.type(), eqt.param() };
+
+      // Finally, make sure the actual is a valid assignment target.
+      if (!isValidAssignmentTarget(actual->id(), re)) {
+        context->error(actual, "invalid lhs component in tuple assignment");
+      }
+    }
+
+    eltTypes.push_back(std::move(qt));
+  }
+
+  // Set the 'LHS' tuple type.
+  auto k = QualifiedType::VAR;
+  auto t = TupleType::getQualifiedTuple(context, std::move(eltTypes));
+  QualifiedType ret = { k, t };
+  rv.byPostorder.byAst(lhsTuple).setType(ret);
+  return ret;
+}
+
+void Resolver::resolveTupleUnpackAssign(const Tuple* lhsTuple,
+                                        const AstNode* astForErr,
+                                        const QualifiedType& initialLhsType,
+                                        const QualifiedType& rhsType) {
+  // Make sure that both the LHS and RHS have types
+  if (!initialLhsType.hasTypePtr()) {
     context->error(lhsTuple, "Unknown lhs tuple type in split tuple assign");
     return;
   }
@@ -2579,11 +2634,11 @@ void Resolver::resolveTupleUnpackAssign(ResolvedExpression& r,
     return;
   }
 
-  // First, check that lhsType and rhsType are tuples
-  const TupleType* lhsT = lhsType.type()->toTupleType();
+  // Then, check that lhsType and rhsType are tuples
+  const TupleType* initialLhsT = initialLhsType.type()->toTupleType();
   const TupleType* rhsT = rhsType.type()->toTupleType();
 
-  if (lhsT == nullptr) {
+  if (initialLhsT == nullptr) {
     context->error(lhsTuple, "lhs type is not tuple in split tuple assign");
     return;
   }
@@ -2593,11 +2648,8 @@ void Resolver::resolveTupleUnpackAssign(ResolvedExpression& r,
   }
 
   // Then, check that they have the same size
-  if (lhsTuple->numActuals() != rhsT->numElements()) {
-    context->error(lhsTuple, "tuple size mismatch in split tuple assign");
-    return;
-  }
-  if (lhsT->numElements() != rhsT->numElements()) {
+  if (lhsTuple->numActuals() != rhsT->numElements() ||
+      initialLhsT->numElements() != rhsT->numElements()) {
     context->error(lhsTuple, "tuple size mismatch in split tuple assign");
     return;
   }
@@ -2605,37 +2657,61 @@ void Resolver::resolveTupleUnpackAssign(ResolvedExpression& r,
   const Scope* scope = currentScope();
   auto inScopes = CallScopeInfo::forNormalCall(scope, poiScope);
 
-  // Finally, try to resolve 'operator=' between the elements
-  int i = 0;
-  for (auto actual : lhsTuple->actuals()) {
+  // Then, make sure that the LHS is valid and adjust its intent.
+  // It recomputes the LHS tuple type and sets it in 'byPostorder'.
+  // It does not recompute intents for component sub-expressions.
+  auto lhsType = adjustLhsForTupleUnpackAssign(*this, astForErr, lhsTuple,
+                                               initialLhsType);
+  auto lhsT = lhsType.type()->toTupleType();
+
+  for (int i = 0; i < lhsTuple->numActuals(); i++) {
+    auto actual = lhsTuple->actual(i);
+
     QualifiedType lhsEltType = lhsT->elementType(i);
     QualifiedType rhsEltType = rhsT->elementType(i);
     auto ident = actual->toIdentifier();
-    if (auto innerTuple = actual->toTuple()) {
-      resolveTupleUnpackAssign(r, astForErr, innerTuple, lhsEltType, rhsEltType);
-    } else if (ident && ident->name() == USTR("_")) {
-      // Do not perform an assignment in the case of a '_' variable.
-      continue;
-    } else {
-      std::vector<CallInfoActual> actuals;
-      actuals.push_back(CallInfoActual(lhsEltType, UniqueString()));
-      actuals.push_back(CallInfoActual(rhsEltType, UniqueString()));
-      auto ci = CallInfo (/* name */ USTR("="),
-                          /* calledType */ QualifiedType(),
-                          /* isMethodCall */ false,
-                          /* hasQuestionArg */ false,
-                          /* isParenless */ false,
-                          actuals);
 
-      auto c = resolveGeneratedCall(actual, &ci, &inScopes);
-      c.noteResult(&r, { { AssociatedAction::ASSIGN, lhsTuple->id() } });
+    // Do not perform an assignment in the case of a '_' variable.
+    if (ident && ident->name() == USTR("_")) continue;
+
+    if (auto innerTuple = actual->toTuple()) {
+      // Recurse if the element is a tuple.
+      resolveTupleUnpackAssign(innerTuple, astForErr, lhsEltType, rhsEltType);
+      continue;
     }
-    i++;
+
+    // Otherwise, try to resolve a call to 'operator=' between the elements.
+    std::vector<CallInfoActual> actuals;
+    actuals.push_back(CallInfoActual(lhsEltType, UniqueString()));
+    actuals.push_back(CallInfoActual(rhsEltType, UniqueString()));
+    auto ci = CallInfo (/* name */ USTR("="),
+                        /* calledType */ QualifiedType(),
+                        /* isMethodCall */ false,
+                        /* hasQuestionArg */ false,
+                        /* isParenless */ false,
+                        std::move(actuals));
+
+    auto& re = byPostorder.byAst(actual);
+    auto c = resolveGeneratedCall(actual, &ci, &inScopes);
+    c.noteResult(&re, { { AssociatedAction::ASSIGN, lhsTuple->id() } });
   }
 }
 
+static void adjustIndexVariableKind(Resolver& rv, const NamedDecl* nd,
+                                    const QualifiedType& considering) {
+  auto var = nd->toVarLikeDecl();
+  if (!var || var->storageKind() != uast::Qualifier::INDEX) return;
+
+  auto kind = considering.kind();
+  // Non-ref index variables are generally immutable, so make it 'const'.
+  if (!considering.isRef()) kind = KindProperties::addConstness(kind);
+
+  auto& re = rv.byPostorder.byAst(var);
+  re.setKind(kind);
+}
+
 void Resolver::resolveTupleUnpackDecl(const TupleDecl* lhsTuple,
-                                      QualifiedType rhsType) {
+                                      const QualifiedType& rhsType) {
   // Exit since 'resolveNamedDecl' also exits when scope-resolving.
   if (scopeResolveOnly) return;
 
@@ -2693,24 +2769,10 @@ void Resolver::resolveTupleUnpackDecl(const TupleDecl* lhsTuple,
     } else if (auto namedDecl = actual->toNamedDecl()) {
       resolveNamedDecl(namedDecl, rhsEltType.type());
 
-      // If the element is an index variable, then use the RHS's intent.
-      if (auto var = namedDecl->toVarLikeDecl()) {
-        if (var->storageKind() == uast::Qualifier::INDEX) {
-          auto& rr = byPostorder.byAst(var);
-          auto kind = rhsEltType.kind();
-
-          // If the kind is a value, set it to 'const'.
-          if (!rhsEltType.isRef() && !rhsEltType.isParam() &&
-              !rhsEltType.isType()) {
-            auto combiner = KindProperties::fromKind(kind);
-            combiner.setConst(true);
-            kind = combiner.toKind();
-          }
-          rr.setType({ kind, rr.type().type() });
-        }
-      }
+      // If the element is an index variable, adjust its qualifier.
+      adjustIndexVariableKind(*this, namedDecl, rhsEltType);
     } else {
-      CHPL_ASSERT(false && "case not handled");
+      CHPL_UNIMPL("Unhandled case when unpacking tuple decl");
     }
     i++;
   }
@@ -2983,13 +3045,9 @@ bool Resolver::resolveSpecialOpCall(const Call* call) {
   if (op->op() == USTR("=")) {
     if (op->numActuals() == 2) {
       if (auto lhsTuple = op->actual(0)->toTuple()) {
-
-        ResolvedExpression& r = byPostorder.byAst(op);
-        QualifiedType lhsType = byPostorder.byAst(op->actual(0)).type();
-        QualifiedType rhsType = byPostorder.byAst(op->actual(1)).type();
-
-        resolveTupleUnpackAssign(r, call,
-                                 lhsTuple, lhsType, rhsType);
+        auto& lhsType = byPostorder.byAst(op->actual(0)).type();
+        auto& rhsType = byPostorder.byAst(op->actual(1)).type();
+        resolveTupleUnpackAssign(lhsTuple, call, lhsType, rhsType);
         return true;
       }
 

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2673,6 +2673,23 @@ void Resolver::resolveTupleUnpackDecl(const TupleDecl* lhsTuple,
       resolveTupleUnpackDecl(innerTuple, rhsEltType);
     } else if (auto namedDecl = actual->toNamedDecl()) {
       resolveNamedDecl(namedDecl, rhsEltType.type());
+
+      // If the element is an index variable, then use the RHS's intent.
+      if (auto var = namedDecl->toVarLikeDecl()) {
+        if (var->storageKind() == uast::Qualifier::INDEX) {
+          auto& rr = byPostorder.byAst(var);
+          auto kind = rhsEltType.kind();
+
+          // If the kind is a value, set it to 'const'.
+          if (!rhsEltType.isRef() && !rhsEltType.isParam() &&
+              !rhsEltType.isType()) {
+            auto combiner = KindProperties::fromKind(kind);
+            combiner.setConst(true);
+            kind = combiner.toKind();
+          }
+          rr.setType({ kind, rr.type().type() });
+        }
+      }
     } else {
       CHPL_ASSERT(false && "case not handled");
     }

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1832,7 +1832,7 @@ static const Type* computeVarArgTuple(Resolver& resolver,
       auto newKind = resolveIntent(QualifiedType(qtKind, typePtr),
                                    /* isThis */ false, /* isInit */ false);
       QualifiedType elt = QualifiedType(newKind, typePtr);
-      typePtr = TupleType::getStarTuple(context, paramSize, elt);
+      typePtr = TupleType::getVarArgTuple(context, paramSize, elt);
     }
   }
 

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2605,13 +2605,17 @@ void Resolver::resolveTupleUnpackAssign(ResolvedExpression& r,
   const Scope* scope = currentScope();
   auto inScopes = CallScopeInfo::forNormalCall(scope, poiScope);
 
-  // Finally, try to resolve = between the elements
+  // Finally, try to resolve 'operator=' between the elements
   int i = 0;
   for (auto actual : lhsTuple->actuals()) {
     QualifiedType lhsEltType = lhsT->elementType(i);
     QualifiedType rhsEltType = rhsT->elementType(i);
+    auto ident = actual->toIdentifier();
     if (auto innerTuple = actual->toTuple()) {
       resolveTupleUnpackAssign(r, astForErr, innerTuple, lhsEltType, rhsEltType);
+    } else if (ident && ident->name() == USTR("_")) {
+      // Do not perform an assignment in the case of a '_' variable.
+      continue;
     } else {
       std::vector<CallInfoActual> actuals;
       actuals.push_back(CallInfoActual(lhsEltType, UniqueString()));
@@ -4281,6 +4285,14 @@ void Resolver::resolveIdentifier(const Identifier* ident) {
   const Decl* inDecl = declStack.back();
   if (inDecl->isVarLikeDecl() && ident->name() == USTR("?")) {
     result.setType(QualifiedType(QualifiedType::TYPE, getAnyType(*this, ident->id())));
+    return;
+  }
+
+  // Throwaway '_', must be handled elsewhere and has no type on its own.
+  // Use the '?' type as a placeholder since 'unknown' causes resolution
+  // of the tuple type to give up.
+  if (ident->name() == USTR("_")) {
+    result.setType(QualifiedType(QualifiedType::VAR, AnyType::get(context)));
     return;
   }
 

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2636,12 +2636,15 @@ void Resolver::resolveTupleUnpackAssign(ResolvedExpression& r,
 
 void Resolver::resolveTupleUnpackDecl(const TupleDecl* lhsTuple,
                                       QualifiedType rhsType) {
+  // Exit since 'resolveNamedDecl' also exits when scope-resolving.
+  if (scopeResolveOnly) return;
+
   if (!rhsType.hasTypePtr()) {
     CHPL_REPORT(context, TupleDeclUnknownType, lhsTuple);
     return;
   }
 
-  const TupleType* rhsT = rhsType.type() ? rhsType.type()->toTupleType() : nullptr;
+  auto rhsT = rhsType.type() ? rhsType.type()->toTupleType() : nullptr;
   std::vector<QualifiedType> eltTypes;
 
   if (rhsT == nullptr) {
@@ -2655,13 +2658,27 @@ void Resolver::resolveTupleUnpackDecl(const TupleDecl* lhsTuple,
       CHPL_REPORT(context, TupleDeclNotTuple, lhsTuple, rhsType.type());
       return;
     }
+
+  // Then, check that they have the same size
   } else if (lhsTuple->numDecls() != rhsT->numElements()) {
-    // Then, check that they have the same size
     CHPL_REPORT(context, TupleDeclMismatchedElems, lhsTuple, rhsT);
     return;
+
+  // Else, it's a tuple of the same size, so use the RHS element types
   } else {
+    QualifiedType::Kind lhsKind = (Qualifier) lhsTuple->intentOrKind();
+    bool isLhsIdxOrRef = lhsKind == Qualifier::INDEX ||
+                         isRefQualifier(lhsKind);
+
     for (int i = 0; i < rhsT->numElements(); i++) {
-      eltTypes.push_back(rhsT->elementType(i));
+      auto kind = rhsT->elementType(i).kind();
+      auto type = rhsT->elementType(i).type();
+
+      // If the LHS is a ref tuple or a tuple index e.g., for (i, j)..., and
+      // the RHS is a ref tuple, then we need to transform the detupled
+      // components into references to the original tuple's components.
+      if (isLhsIdxOrRef && rhsType.isRef()) kind = rhsType.kind();
+      eltTypes.push_back({ kind, type });
     }
   }
 
@@ -2669,8 +2686,10 @@ void Resolver::resolveTupleUnpackDecl(const TupleDecl* lhsTuple,
   int i = 0;
   for (auto actual : lhsTuple->decls()) {
     QualifiedType rhsEltType = eltTypes[i];
+
     if (auto innerTuple = actual->toTupleDecl()) {
       resolveTupleUnpackDecl(innerTuple, rhsEltType);
+
     } else if (auto namedDecl = actual->toNamedDecl()) {
       resolveNamedDecl(namedDecl, rhsEltType.type());
 
@@ -2697,14 +2716,48 @@ void Resolver::resolveTupleUnpackDecl(const TupleDecl* lhsTuple,
   }
 }
 
-void Resolver::resolveTupleDecl(const TupleDecl* td,
-                                const Type* useType) {
+void Resolver::resolveTupleDecl(const TupleDecl* td) {
+  QualifiedType::Kind declKind = (Qualifier) td->intentOrKind();
+  QualifiedType qt;
+
+  auto typeExpr = td->typeExpression();
+  auto initExpr = td->initExpression();
+
+  if (typeExpr == nullptr && initExpr == nullptr) {
+    // Note: we seem to rely on tuple components being 'var', and relying on
+    // the tuple's kind instead. Without this, the current instantiation
+    // logic won't allow, for example, passing (1, 2, 3) to (?, ?, ?).
+    auto anyType = QualifiedType(QualifiedType::VAR, AnyType::get(context));
+    std::vector<QualifiedType> eltTypes(td->numDecls(), anyType);
+    auto tup = TupleType::getQualifiedTuple(context, eltTypes);
+    qt = QualifiedType(declKind, tup);
+  } else {
+    QualifiedType typeExprT;
+    QualifiedType initExprT;
+
+    if (typeExpr != nullptr) {
+      ResolvedExpression& result = byPostorder.byAst(typeExpr);
+      typeExprT = result.type();
+    }
+    if (initExpr != nullptr) {
+      ResolvedExpression& result = byPostorder.byAst(initExpr);
+      initExprT = result.type();
+    }
+
+    qt = getTypeForDecl(td, typeExpr, initExpr, declKind, typeExprT,
+                        initExprT);
+  }
+
+  resolveTupleDecl(td, std::move(qt));
+}
+
+void Resolver::resolveTupleDecl(const TupleDecl* td, QualifiedType useType) {
   if (scopeResolveOnly) {
     return;
   }
 
   QualifiedType::Kind declKind = (Qualifier) td->intentOrKind();
-  QualifiedType useT;
+  QualifiedType qt;
 
   // Non-default intents are currently not allowed for tuple-grouped formals.
   //
@@ -2712,73 +2765,46 @@ void Resolver::resolveTupleDecl(const TupleDecl* td,
   // formal ``((a, b), c)``. Such nested formals should be handled by
   // ``resolveTupleUnpackDecl``.
   if (td->isTupleDeclFormal() && declKind != QualifiedType::DEFAULT_INTENT) {
-    useT = QualifiedType(declKind, ErroneousType::get(context));
-    ResolvedExpression& result = byPostorder.byAst(td);
-    result.setType(useT);
+    qt = QualifiedType(declKind, ErroneousType::get(context));
+    auto& result = byPostorder.byAst(td);
+    result.setType(qt);
     return;
   }
 
-  // Figure out the type to use for this tuple
-  if (useType != nullptr) {
-    useT = QualifiedType(declKind, useType);
-  } else if (substitutions != nullptr &&
-             substitutions->count(td->id()) != 0) {
+  // If there is a substitution, use that instead.
+  if (substitutions != nullptr && substitutions->count(td->id()) != 0) {
     auto sub = substitutions->find(td->id())->second;
     auto subTup = sub.hasTypePtr() ? sub.type()->toTupleType() : nullptr;
 
     if (subTup == nullptr) {
       // Rely on hasTypePtr check below to recognize error
-      useT = QualifiedType();
+      qt = QualifiedType();
     } else {
-      useT = sub;
+      qt = sub;
     }
+
+  // Otherwise use the type that was provided.
   } else {
-    QualifiedType typeExprT;
-    QualifiedType initExprT;
-
-    auto typeExpr = td->typeExpression();
-    auto initExpr = td->initExpression();
-
-    if (typeExpr == nullptr && initExpr == nullptr) {
-      // Note: we seem to rely on tuple components being 'var', and relying on
-      // the tuple's kind instead. Without this, the current instantiation
-      // logic won't allow, for example, passing (1, 2, 3) to (?, ?, ?).
-      std::vector<QualifiedType> eltTypes;
-      for (auto decl : td->decls()) {
-        eltTypes.push_back(QualifiedType(QualifiedType::VAR,
-                                         getAnyType(*this, decl->id())));
-      }
-      auto tup = TupleType::getQualifiedTuple(context, eltTypes);
-      useT = QualifiedType(declKind, tup);
-    } else {
-      if (typeExpr != nullptr) {
-        ResolvedExpression& result = byPostorder.byAst(typeExpr);
-        typeExprT = result.type();
-      }
-      if (initExpr != nullptr) {
-        ResolvedExpression& result = byPostorder.byAst(initExpr);
-        initExprT = result.type();
-      }
-
-      useT = getTypeForDecl(td, typeExpr, initExpr,
-                            declKind, typeExprT, initExprT);
-
-    }
+    qt = useType;
   }
 
-  if (!useT.hasTypePtr()) {
+  if (!qt.hasTypePtr()) {
     context->error(td, "Cannot establish type for tuple decl");
-    useT = QualifiedType(declKind, ErroneousType::get(context));
-  } else if (useT.type()->isTupleType()) {
-    useT = QualifiedType(useT.kind(),
-                         useT.type()->toTupleType()->toReferentialTuple(context));
+    qt = QualifiedType(declKind, ErroneousType::get(context));
+
+  } else if (auto tt = qt.type()->toTupleType()) {
+    // Adjust default-intent tuple types to be a referential tuple.
+    if (qt.kind() == QualifiedType::DEFAULT_INTENT) {
+      qt = QualifiedType(qt.kind(), tt->toReferentialTuple(context)); 
+    }
   }
 
   // save the type in byPostorder
   ResolvedExpression& result = byPostorder.byAst(td);
-  result.setType(useT);
+  result.setType(qt);
+
   // resolve the types of the tuple elements
-  resolveTupleUnpackDecl(td, useT);
+  resolveTupleUnpackDecl(td, std::move(qt));
 }
 
 bool Resolver::resolveSpecialNewCall(const Call* call) {
@@ -4903,7 +4929,14 @@ void Resolver::exit(const MultiDecl* decl) {
         if (auto v = d->toVarLikeDecl()) {
           resolveNamedDecl(v, t);
         } else if (auto td = d->toTupleDecl()) {
-          resolveTupleDecl(td, t);
+          if (t == nullptr) {
+            resolveTupleDecl(td);
+          } else {
+            // Use the declared intent.
+            auto kind = (Qualifier) td->intentOrKind();
+            QualifiedType qt = { kind, t };
+            resolveTupleDecl(td, std::move(qt));
+          }
         }
 
         // update lastType
@@ -4939,7 +4972,7 @@ bool Resolver::enter(const TupleDecl* decl) {
 }
 
 void Resolver::exit(const TupleDecl* decl) {
-  resolveTupleDecl(decl, /* useType */ nullptr);
+  resolveTupleDecl(decl);
   exitScope(decl);
 }
 
@@ -6972,7 +7005,7 @@ bool Resolver::enter(const IndexableLoop* loop) {
     ResolvedExpression& re = byPostorder.byAst(idx);
 
     if (idx->isTupleDecl() && !scopeResolveOnly) {
-      resolveTupleUnpackDecl(idx->toTupleDecl(), idxType);
+      resolveTupleDecl(idx->toTupleDecl(), idxType);
     } else {
       re.setType(idxType);
     }

--- a/frontend/lib/resolution/Resolver.h
+++ b/frontend/lib/resolution/Resolver.h
@@ -620,8 +620,9 @@ struct Resolver : BranchSensitiveVisitor<DefaultFrame> {
                               types::QualifiedType rhsType);
 
   // e.g. var (a, b) = mytuple
+  void resolveTupleDecl(const uast::TupleDecl* td);
   void resolveTupleDecl(const uast::TupleDecl* td,
-                        const types::Type* useType);
+                        types::QualifiedType useType);
 
   void validateAndSetToId(ResolvedExpression& r,
                           const uast::AstNode* exr,

--- a/frontend/lib/resolution/Resolver.h
+++ b/frontend/lib/resolution/Resolver.h
@@ -604,15 +604,6 @@ struct Resolver : BranchSensitiveVisitor<DefaultFrame> {
                                 const std::vector<const uast::AstNode*>& asts,
                                 const MostSpecificCandidates& fns);
 
-  // e.g. (a, b) = mytuple
-  // checks that tuple size matches and that the elements are assignable
-  // saves any '=' called for tuple components as associated actions in
-  // their respective resolved expressions
-  void resolveTupleUnpackAssign(const uast::Tuple* lhsTuple,
-                                const uast::AstNode* astForErr,
-                                const types::QualifiedType& lhsType,
-                                const types::QualifiedType& rhsType);
-
   // helper for resolveTupleDecl
   // e.g. var (a, b) = mytuple
   // checks that tuple size matches and establishes types for a and b

--- a/frontend/lib/resolution/Resolver.h
+++ b/frontend/lib/resolution/Resolver.h
@@ -606,18 +606,18 @@ struct Resolver : BranchSensitiveVisitor<DefaultFrame> {
 
   // e.g. (a, b) = mytuple
   // checks that tuple size matches and that the elements are assignable
-  // saves any '=' called into r.associatedFns
-  void resolveTupleUnpackAssign(ResolvedExpression& r,
+  // saves any '=' called for tuple components as associated actions in
+  // their respective resolved expressions
+  void resolveTupleUnpackAssign(const uast::Tuple* lhsTuple,
                                 const uast::AstNode* astForErr,
-                                const uast::Tuple* lhsTuple,
-                                types::QualifiedType lhsType,
-                                types::QualifiedType rhsType);
+                                const types::QualifiedType& lhsType,
+                                const types::QualifiedType& rhsType);
 
   // helper for resolveTupleDecl
   // e.g. var (a, b) = mytuple
   // checks that tuple size matches and establishes types for a and b
   void resolveTupleUnpackDecl(const uast::TupleDecl* lhsTuple,
-                              types::QualifiedType rhsType);
+                              const types::QualifiedType& rhsType);
 
   // e.g. var (a, b) = mytuple
   void resolveTupleDecl(const uast::TupleDecl* td);

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -545,8 +545,7 @@ getLhsForTupleUnpackAssign(Context* context,
       qt = { QualifiedType::VAR, NothingType::get(context) };
 
     } else {
-      // Otherwise, turn its qualifier into 'ref' / 'const ref' and make
-      // sure the actual is a valid assignment target.
+      // Otherwise, turn its qualifier into 'ref' / 'const ref'
       auto eqt = lhsT->elementType(i);
       auto kind = KindProperties::addRefness(eqt.kind());
       qt = { kind, eqt.type(), eqt.param() };

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -113,6 +113,11 @@ struct CallInitDeinit : VarScopeVisitor {
                      ID deinitedId,
                      const QualifiedType& type,
                      RV& rv);
+  void resolveTupleUnpackAssign(const Tuple* lhsTuple,
+                                const AstNode* astForErr,
+                                const QualifiedType& initialLhsType,
+                                const QualifiedType& rhsType,
+                                RV& rv);
 
 
   void processReturnThrowYield(const uast::AstNode* ast, RV& rv);
@@ -517,6 +522,111 @@ void CallInitDeinit::resolveDefaultInit(const VarLikeDecl* ast, RV& rv) {
   }
 }
 
+// Adjusts LHS tuple type so that its components are all references.
+// Does no sanity checks.
+static QualifiedType
+getLhsForTupleUnpackAssign(Context* context,
+                           const uast::AstNode* astForErr,
+                           const Tuple* lhsTuple,
+                           const QualifiedType& lhsType) {
+  std::vector<QualifiedType> eltTypes;
+
+  auto lhsT = lhsType.type() ? lhsType.type()->toTupleType() : nullptr;
+  if (!lhsT || lhsT->numElements() != lhsTuple->numActuals()) return lhsType;
+
+  for (int i = 0; i < lhsTuple->numActuals(); i++) {
+    auto actual = lhsTuple->actual(i);
+    auto ident = actual->toIdentifier();
+    QualifiedType qt;
+
+    if (ident && ident->name() == USTR("_")) {
+      // If the LHS actual is '_', then use the Nothing type. This is fine
+      // since the '_' will never be set.
+      qt = { QualifiedType::VAR, NothingType::get(context) };
+
+    } else {
+      // Otherwise, turn its qualifier into 'ref' / 'const ref' and make
+      // sure the actual is a valid assignment target.
+      auto eqt = lhsT->elementType(i);
+      auto kind = KindProperties::addRefness(eqt.kind());
+      qt = { kind, eqt.type(), eqt.param() };
+    }
+
+    eltTypes.push_back(std::move(qt));
+  }
+
+  // Set the 'LHS' tuple type.
+  auto k = QualifiedType::VAR;
+  auto t = TupleType::getQualifiedTuple(context, std::move(eltTypes));
+  QualifiedType ret = { k, t };
+  return ret;
+}
+
+
+void CallInitDeinit::resolveTupleUnpackAssign(const Tuple* lhsTuple,
+                                              const AstNode* astForErr,
+                                              const QualifiedType& initialLhsType,
+                                              const QualifiedType& rhsType,
+                                              RV& rv) {
+  // Make sure that both the LHS and RHS have types
+  if (!initialLhsType.hasTypePtr()) {
+    context->error(lhsTuple, "Unknown lhs tuple type in split tuple assign");
+    return;
+  }
+  if (!rhsType.hasTypePtr()) {
+    context->error(lhsTuple, "Unknown rhs tuple type in split tuple assign");
+    return;
+  }
+
+  // Then, check that lhsType and rhsType are tuples
+  const TupleType* initialLhsT = initialLhsType.type()->toTupleType();
+  const TupleType* rhsT = rhsType.type()->toTupleType();
+
+  if (initialLhsT == nullptr) {
+    context->error(lhsTuple, "lhs type is not tuple in split tuple assign");
+    return;
+  }
+  if (rhsT == nullptr) {
+    context->error(lhsTuple, "rhs type is not tuple in split tuple assign");
+    return;
+  }
+
+  // Then, check that they have the same size
+  if (lhsTuple->numActuals() != rhsT->numElements() ||
+      initialLhsT->numElements() != rhsT->numElements()) {
+    context->error(lhsTuple, "tuple size mismatch in split tuple assign");
+    return;
+  }
+
+  // Then, make sure that the LHS is valid and adjust its intent.
+  // It recomputes the LHS tuple type and sets it in 'byPostorder'.
+  // It does not recompute intents for component sub-expressions.
+  auto lhsType = getLhsForTupleUnpackAssign(context, astForErr, lhsTuple,
+                                            initialLhsType);
+  rv.byPostorder().byAst(lhsTuple).setType(lhsType);
+
+  auto lhsT = lhsType.type()->toTupleType();
+
+  for (int i = 0; i < lhsTuple->numActuals(); i++) {
+    auto actual = lhsTuple->actual(i);
+
+    QualifiedType lhsEltType = lhsT->elementType(i);
+    QualifiedType rhsEltType = rhsT->elementType(i);
+    auto ident = actual->toIdentifier();
+
+    // Do not perform an assignment in the case of a '_' variable.
+    if (ident && ident->name() == USTR("_")) continue;
+
+    if (auto innerTuple = actual->toTuple()) {
+      // Recurse if the element is a tuple.
+      resolveTupleUnpackAssign(innerTuple, astForErr, lhsEltType, rhsEltType, rv);
+      continue;
+    }
+
+    resolveAssign(actual, lhsEltType, rhsEltType, rv);
+  }
+}
+
 void CallInitDeinit::resolveAssign(const AstNode* ast,
                                    const QualifiedType& lhsType,
                                    const QualifiedType& rhsTypeIn,
@@ -531,8 +641,12 @@ void CallInitDeinit::resolveAssign(const AstNode* ast,
 
   if (auto call = ast->toOpCall()) {
     if (call->op() == "=" && call->child(0)->isTuple()) {
-      // Tuple unpacking assignment, handled directly by Resolver
+      // Tuple unpacking assignment
       // (a, b, c) = foo();
+      auto lhsTuple = call->actual(0)->toTuple();
+      auto& lhsType = rv.byPostorder().byAst(call->actual(0)).type();
+      auto& rhsType = rv.byPostorder().byAst(call->actual(1)).type();
+      resolveTupleUnpackAssign(lhsTuple, call, lhsType, rhsType, rv);
       return;
     }
   }

--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -1372,6 +1372,20 @@ types::QualifiedType::Kind KindProperties::combineKindsMeet(
   return kp1.toKind();
 }
 
+QualifiedType::Kind
+KindProperties::addConstness(QualifiedType::Kind kind) {
+  auto kp = KindProperties::fromKind(kind);
+  kp.setConst(true);
+  return kp.toKind();
+}
+
+QualifiedType::Kind
+KindProperties::addRefness(QualifiedType::Kind kind) {
+  auto kp = KindProperties::fromKind(kind);
+  kp.setRef(true);
+  return kp.toKind();
+}
+
 QualifiedType::Kind KindProperties::toKind() const {
   if (!isValid) return QualifiedType::UNKNOWN;
   if (isType) return QualifiedType::TYPE;

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2482,7 +2482,8 @@ instantiateSignatureImpl(ResolutionContext* rc,
     }
 
     if (instantiateVarArgs) {
-      const TupleType* t = TupleType::getQualifiedTuple(context, varargsTypes);
+      const TupleType* t = TupleType::getQualifiedTuple(context, varargsTypes,
+                                                        /*isVarArgTuple=*/true);
       auto formal = faMap.byFormalIdx(varArgIdx).formal()->toVarArgFormal();
       QualifiedType vat = QualifiedType(formal->storageKind(), t);
       substitutions.insert({formal->id(), vat});

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -4095,7 +4095,9 @@ static const Type* resolveBuiltinTypeCtor(Context* context,
     auto second = ci.actual(1).type();
     if (first.isParam() && first.type()->isIntType() &&
         second.isType()) {
-      return TupleType::getStarTuple(context, first, second);
+      auto num = first.param()->toIntParam()->value();
+      std::vector<const Type*> eltTypes(num, second.type());
+      return TupleType::getValueTuple(context, eltTypes);
     }
   }
 

--- a/frontend/lib/resolution/scope-types.cpp
+++ b/frontend/lib/resolution/scope-types.cpp
@@ -362,6 +362,10 @@ Scope::Scope(Context* context,
   if (isMethodScope) {         flags |= METHOD_SCOPE; }
   if (containsExternBlock) {   flags |= CONTAINS_EXTERN_BLOCK; }
   flags_ = flags;
+
+  // Remove the 'throwaway' variable '_' from any scope that contains it.
+  auto it = declared_.find(USTR("_"));
+  if (it != declared_.end()) declared_.erase(it);
 }
 
 void Scope::addBuiltinVar(UniqueString name) {

--- a/frontend/lib/resolution/scope-types.cpp
+++ b/frontend/lib/resolution/scope-types.cpp
@@ -362,10 +362,6 @@ Scope::Scope(Context* context,
   if (isMethodScope) {         flags |= METHOD_SCOPE; }
   if (containsExternBlock) {   flags |= CONTAINS_EXTERN_BLOCK; }
   flags_ = flags;
-
-  // Remove the 'throwaway' variable '_' from any scope that contains it.
-  auto it = declared_.find(USTR("_"));
-  if (it != declared_.end()) declared_.erase(it);
 }
 
 void Scope::addBuiltinVar(UniqueString name) {

--- a/frontend/lib/types/TupleType.cpp
+++ b/frontend/lib/types/TupleType.cpp
@@ -160,7 +160,8 @@ TupleType::getGenericTupleType(Context* context) {
 
 const TupleType*
 TupleType::getQualifiedTuple(Context* context,
-                             std::vector<QualifiedType> eltTypes) {
+                             std::vector<QualifiedType> eltTypes,
+                             bool isVarArgTuple) {
   SubstitutionsMap subs;
   int i = 0;
   for (const auto& t : eltTypes) {
@@ -169,20 +170,19 @@ TupleType::getQualifiedTuple(Context* context,
   }
 
   const TupleType* instantiatedFrom = getGenericTupleType(context);
-  const bool isVarArgTuple = true;
   return getTupleType(context, instantiatedFrom,
                       std::move(subs), isVarArgTuple).get();
 }
 
 const TupleType*
-TupleType::getStarTuple(Context* context,
-                        QualifiedType paramSize,
-                        QualifiedType varArgEltType) {
+TupleType::getVarArgTuple(Context* context,
+                          QualifiedType paramSize,
+                          QualifiedType varArgEltType) {
   if (!paramSize.isUnknown()) {
     // Fixed size, we can at least create a star tuple of AnyType
     int64_t numElements = paramSize.param()->toIntParam()->value();
     std::vector<QualifiedType> eltTypes(numElements, varArgEltType);
-    return getQualifiedTuple(context, eltTypes);
+    return getQualifiedTuple(context, eltTypes, true);
   } else {
     // Size unknown, store the expected element type
     const TupleType* instantiatedFrom = getGenericTupleType(context);

--- a/frontend/test/resolution/testTuples.cpp
+++ b/frontend/test/resolution/testTuples.cpp
@@ -1288,6 +1288,32 @@ static void test32() {
   assert(m["b"].type()->isIntType());
 }
 
+static void test33() {
+  printf("%s\n", __FUNCTION__);
+  Context ctx;
+  auto context = &ctx;
+  ErrorGuard guard(context);
+
+  std::string program =
+    R""""(
+    proc foo() { return (1.0, 2); }
+    proc test() {
+      var x : real;
+      var y : int;
+      (x, y, _) = foo();
+    }
+    test();
+    )"""";
+
+  auto mod = parseModule(context, program);
+  resolveModule(context, mod->id());
+
+  assert(guard.numErrors() == 1);
+  auto& err = guard.error(0);
+  assert(err->message() == "tuple size mismatch in split tuple assign");
+  guard.realizeErrors();
+}
+
 int main() {
   test1();
   test2();
@@ -1325,6 +1351,7 @@ int main() {
   test30();
   test31();
   test32();
+  test33();
 
   return 0;
 }

--- a/frontend/test/resolution/testTuples.cpp
+++ b/frontend/test/resolution/testTuples.cpp
@@ -1004,8 +1004,8 @@ static void test24() {
 
   std::string program =
     R""""(
-    operator=(ref lhs: real, ref rhs: real) {}
-    operator=(ref lhs: int, ref rhs: int) {}
+    operator=(ref lhs: real, rhs: real) {}
+    operator=(ref lhs: int, rhs: int) {}
     proc foo() { return (1.0, 2); }
     var x: real;
     (x, _) = foo();
@@ -1016,14 +1016,36 @@ static void test24() {
   assert(xQt.kind() == QualifiedType::VAR);
   assert(xQt.type()->isRealType());
 
-  // Get the type of the '(x, _)' tuple itself.
+
   auto mod = parseModule(context, program);
   auto& rr = resolveModule(context, mod->id());
-  auto astTup = mod->stmt(4)->toCall()->actual(0);
-  assert(astTup->isTuple());
+  assert(!guard.realizeErrors());
+
+  // Get the type of the '(x, _)' tuple itself.
+  auto astTup = mod->stmt(4)->toCall()->actual(0)->toTuple();
+  assert(astTup);
   auto& qtTup = rr.byAst(astTup).type();
-  assert(qtTup.kind() == QualifiedType::CONST_VAR);
+
+  // The tuple itself is 'VAR' because its components will be assigned to.
+  assert(qtTup.kind() == QualifiedType::VAR);
   assert(qtTup.type()->isTupleType());
+  auto tpTup = qtTup.type()->toTupleType();
+
+  // Its components are 'ref real(64)' and 'var nothing'.
+  for (int i = 0; i < tpTup->numElements(); i++) {
+    auto qt = tpTup->elementType(i);
+    assert(i != 0 || (qt.type()->isRealType() && qt.kind() == QualifiedType::REF));
+    assert(i != 1 || (qt.type()->isNothingType() && qt.kind() == QualifiedType::VAR));
+  }
+
+  // Finally confirm that there is an assignment for 'x' but not for '_'.
+  for (int i = 0; i < astTup->numActuals(); i++) {
+    auto actual = astTup->actual(i);
+    auto& actions = rr.byAst(actual).associatedActions();
+    assert(i != 0 || actions.size() == 1 &&
+                     actions[0].action() == AssociatedAction::ASSIGN);
+    assert(i != 1 || actions.size() == 0);
+  }
 }
 
 static void test25() {
@@ -1113,12 +1135,12 @@ static void test28() {
 
   auto m = resolveTypesOfVariables(context, program, { "i", "j", "z" });
   assert(!guard.realizeErrors());
-  assert(m["i"].kind() == QualifiedType::CONST_VAR);
-  assert(m["i"].type()->isIntType());
-  assert(m["j"].kind() == QualifiedType::CONST_VAR);
-  assert(m["j"].type()->isIntType());
-  assert(m["z"].kind() == QualifiedType::VAR);
-  assert(m["z"].type()->isIntType());
+  auto& i = m["i"];
+  assert(i.kind() == QualifiedType::CONST_VAR && i.type()->isIntType());
+  auto& j = m["j"];
+  assert(j.kind() == QualifiedType::CONST_VAR && j.type()->isIntType());
+  auto& z = m["z"];
+  assert(z.kind() == QualifiedType::VAR && z.type()->isIntType());
 }
 
 static void test29() {
@@ -1145,16 +1167,23 @@ static void test29() {
   auto& qtTup = rr.byAst(astTup).type();
   assert(qtTup.kind() == QualifiedType::REF);
   assert(qtTup.type()->isTupleType());
+  auto tpTup = qtTup.type()->toTupleType();
+  for (int i = 0; i < tpTup->numElements(); i++) {
+    auto qt = tpTup->elementType(i);
+    // But its elements are 'VAR'.
+    assert(qt.kind() == QualifiedType::VAR);
+    assert(qt.type()->isIntType());
+  }
 
   // The de-tupled components still maintain their 'REF'ness.
   auto m = resolveTypesOfVariables(context, program, { "i", "j", "z" });
   assert(!guard.realizeErrors());
-  assert(m["i"].kind() == QualifiedType::REF);
-  assert(m["i"].type()->isIntType());
-  assert(m["j"].kind() == QualifiedType::REF);
-  assert(m["j"].type()->isIntType());
-  assert(m["z"].kind() == QualifiedType::VAR);
-  assert(m["z"].type()->isIntType());
+  auto& i = m["i"];
+  assert(i.kind() == QualifiedType::REF && i.type()->isIntType());
+  auto& j = m["j"];
+  assert(j.kind() == QualifiedType::REF && j.type()->isIntType());
+  auto& z = m["z"];
+  assert(z.kind() == QualifiedType::VAR && z.type()->isIntType());
 }
 
 static void test30() {
@@ -1185,12 +1214,12 @@ static void test30() {
   // The de-tupled components still maintain their 'REF'ness.
   auto m = resolveTypesOfVariables(context, program, { "i", "j", "z" });
   assert(!guard.realizeErrors());
-  assert(m["i"].kind() == QualifiedType::CONST_REF);
-  assert(m["i"].type()->isIntType());
-  assert(m["j"].kind() == QualifiedType::CONST_REF);
-  assert(m["j"].type()->isIntType());
-  assert(m["z"].kind() == QualifiedType::VAR);
-  assert(m["z"].type()->isIntType());
+  auto& i = m["i"];
+  assert(i.kind() == QualifiedType::CONST_REF && i.type()->isIntType());
+  auto& j = m["j"];
+  assert(j.kind() == QualifiedType::CONST_REF && j.type()->isIntType());
+  auto& z = m["z"];
+  assert(z.kind() == QualifiedType::VAR && z.type()->isIntType());
 }
 
 static void test31() {

--- a/frontend/test/resolution/testTuples.cpp
+++ b/frontend/test/resolution/testTuples.cpp
@@ -1035,6 +1035,75 @@ static void test25() {
   assert(qt.type()->isRealType());
 }
 
+static void test26() {
+  printf("test26\n");
+  Context ctx;
+  auto context = &ctx;
+  ErrorGuard guard(context);
+
+  std::string program =
+    R""""(
+    record r {}
+    iter foo(): (int, r) { yield (0, new r()); }
+    for (x, y) in foo() do;
+    )"""";
+
+  auto m = resolveTypesOfVariables(context, program, { "x", "y" });
+  assert(!guard.realizeErrors());
+  assert(m["x"].kind() == QualifiedType::INDEX);
+  assert(m["x"].type()->isIntType());
+  assert(m["y"].kind() == QualifiedType::INDEX);
+  assert(m["y"].type()->isRecordType());
+}
+
+static void test27() {
+  printf("test27\n");
+  Context ctx;
+  auto context = &ctx;
+  ErrorGuard guard(context);
+
+  std::string program =
+    R""""(
+    record r {}
+    iter foo(): (int, r) { yield (0, new r()); }
+    for (x, _) in foo() do;
+    )"""";
+
+  auto qt = resolveTypeOfVariable(context, program, "x");
+  assert(!guard.realizeErrors());
+  assert(qt.kind() == QualifiedType::INDEX);
+  assert(qt.type()->isIntType());
+}
+
+// This is private issue #6382.
+static void test28() {
+  printf("test28\n");
+  Context ctx;
+  auto context = &ctx;
+  ErrorGuard guard(context);
+
+  std::string program =
+    R""""(
+    iter myIter() {
+      yield (1, 2);
+      yield (3, 4);
+    }
+
+    for (i, j) in myIter() {
+      var z = i;
+    }
+    )"""";
+
+  auto m = resolveTypesOfVariables(context, program, { "i", "j", "z" });
+  assert(!guard.realizeErrors());
+  assert(m["i"].kind() == QualifiedType::INDEX);
+  assert(m["i"].type()->isIntType());
+  assert(m["j"].kind() == QualifiedType::INDEX);
+  assert(m["j"].type()->isIntType());
+  assert(m["z"].kind() == QualifiedType::VAR);
+  assert(m["z"].type()->isIntType());
+}
+
 int main() {
   test1();
   test2();
@@ -1058,8 +1127,6 @@ int main() {
   test18();
   test19();
   testTupleGeneric();
-  test21();
-  test22();
 
   test20();
   test21();
@@ -1067,6 +1134,9 @@ int main() {
   test23();
   test24();
   test25();
+  test26();
+  test27();
+  test28();
 
   return 0;
 }

--- a/frontend/test/resolution/testTuples.cpp
+++ b/frontend/test/resolution/testTuples.cpp
@@ -28,7 +28,6 @@
 #include "chpl/uast/Record.h"
 #include "chpl/uast/TupleDecl.h"
 #include "chpl/uast/Variable.h"
-
 // assumes the last statement is a variable declaration for x.
 // returns the type of that.
 static void test1() {
@@ -997,6 +996,45 @@ static void test23() {
   ensureParamInt(qt, 2);
 }
 
+static void test24() {
+  printf("test24\n");
+  Context ctx;
+  auto context = &ctx;
+  ErrorGuard guard(context);
+
+  std::string program =
+    R""""(
+    operator=(ref lhs: real, ref rhs: real) {}
+    operator=(ref lhs: int, ref rhs: int) {}
+    proc foo() { return (1.0, 2); }
+    var x: real;
+    (x, _) = foo();
+    )"""";
+
+  auto qt = resolveQualifiedTypeOfX(context, program);
+  assert(!guard.realizeErrors());
+  assert(qt.kind() == QualifiedType::VAR);
+  assert(qt.type()->isRealType());
+}
+
+static void test25() {
+  printf("test25\n");
+  auto context = buildStdContext();
+  ErrorGuard guard(context);
+
+  std::string program =
+    R""""(
+    proc foo() { return (1.0, 2); }
+    var (v, _) = foo();
+    var x = v;
+    )"""";
+
+  auto qt = resolveQualifiedTypeOfX(context, program);
+  assert(!guard.realizeErrors());
+  assert(qt.kind() == QualifiedType::VAR);
+  assert(qt.type()->isRealType());
+}
+
 int main() {
   test1();
   test2();
@@ -1019,13 +1057,16 @@ int main() {
   test17();
   test18();
   test19();
-
   testTupleGeneric();
+  test21();
+  test22();
 
   test20();
   test21();
   test22();
   test23();
+  test24();
+  test25();
 
   return 0;
 }

--- a/frontend/test/resolution/testTuples.cpp
+++ b/frontend/test/resolution/testTuples.cpp
@@ -1050,9 +1050,9 @@ static void test26() {
 
   auto m = resolveTypesOfVariables(context, program, { "x", "y" });
   assert(!guard.realizeErrors());
-  assert(m["x"].kind() == QualifiedType::INDEX);
+  assert(m["x"].kind() == QualifiedType::CONST_VAR);
   assert(m["x"].type()->isIntType());
-  assert(m["y"].kind() == QualifiedType::INDEX);
+  assert(m["y"].kind() == QualifiedType::CONST_VAR);
   assert(m["y"].type()->isRecordType());
 }
 
@@ -1071,7 +1071,7 @@ static void test27() {
 
   auto qt = resolveTypeOfVariable(context, program, "x");
   assert(!guard.realizeErrors());
-  assert(qt.kind() == QualifiedType::INDEX);
+  assert(qt.kind() == QualifiedType::CONST_VAR);
   assert(qt.type()->isIntType());
 }
 
@@ -1096,9 +1096,9 @@ static void test28() {
 
   auto m = resolveTypesOfVariables(context, program, { "i", "j", "z" });
   assert(!guard.realizeErrors());
-  assert(m["i"].kind() == QualifiedType::INDEX);
+  assert(m["i"].kind() == QualifiedType::CONST_VAR);
   assert(m["i"].type()->isIntType());
-  assert(m["j"].kind() == QualifiedType::INDEX);
+  assert(m["j"].kind() == QualifiedType::CONST_VAR);
   assert(m["j"].type()->isIntType());
   assert(m["z"].kind() == QualifiedType::VAR);
   assert(m["z"].type()->isIntType());

--- a/frontend/test/test-resolution.cpp
+++ b/frontend/test/test-resolution.cpp
@@ -45,9 +45,17 @@ QualifiedType
 resolveQualifiedTypeOfX(Context* context, std::string program) {
   auto m = parseModule(context, std::move(program));
   assert(m->numStmts() > 0);
-  const Variable* x = m->stmt(m->numStmts()-1)->toVariable();
+  // Walk backwards and find the first variable named 'x'.
+  const Variable* x = nullptr;
+  for (int i = m->numStmts() - 1; i >= 0; i--) {
+    if (auto v = m->stmt(i)->toVariable()) {
+      if (v->name() == "x") {
+        x = v;
+        break;
+      }
+    }
+  }
   assert(x);
-  assert(x->name() == "x");
 
   const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
 

--- a/frontend/test/test-resolution.cpp
+++ b/frontend/test/test-resolution.cpp
@@ -274,6 +274,13 @@ resolveTypesOfVariablesInit(Context* context,
   return toReturn;
 }
 
+QualifiedType resolveTypeOfVariable(Context* context, std::string program,
+                                    const std::string& variable) {
+  auto m = resolveTypesOfVariables(context, std::move(program), { variable });
+  // If there is no key for 'variable', this constructs an empty value.
+  return m[variable];
+}
+
 void ensureParamInt(const QualifiedType& type, int64_t expectedValue) {
   assert(type.kind() == QualifiedType::PARAM);
   assert(type.type() != nullptr);

--- a/frontend/test/test-resolution.h
+++ b/frontend/test/test-resolution.h
@@ -77,6 +77,9 @@ resolveTypesOfVariables(Context* context,
 std::unordered_map<std::string, QualifiedType>
 resolveTypesOfVariables(Context* context, std::string program, const std::vector<std::string>& variables);
 
+QualifiedType resolveTypeOfVariable(Context* context, std::string program,
+                                    const std::string& variable);
+
 std::unordered_map<std::string, QualifiedType>
 resolveTypesOfVariablesInit(Context* context, std::string program, const std::vector<std::string>& variables);
 


### PR DESCRIPTION
This PR adds support for ``_`` throwaway variables, de-tupled loop index variables e.g., ``for (i, _) in foo() do;``, and ``ref`` tuples.

This is an updated version of #25418 , and is almost entirely the work of @dlongnecke-cray.

Testing:
- [x] test-frontend
- [x] primers with --dyno-resolve-only (expected tests passing)