### PR TITLE
Dyno: fixes to enable resolving more reductions

### DIFF
--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -4318,11 +4318,13 @@ static bool resolveFnCallSpecial(Context* context,
        !receiverCt->decorator().isManaged());
 
     if (handle) {
-      bool nilable = receiverCt && receiverCt->decorator().isNilable();
       auto finalBct = receiverBct ? receiverBct : receiverCt->manageableType();
 
-      auto decorator = ClassTypeDecorator(
-          nilable ? ClassTypeDecorator::BORROWED : ClassTypeDecorator::BORROWED_NONNIL);
+      auto decorator = ClassTypeDecorator(ClassTypeDecorator::BORROWED);
+      if (receiverCt) {
+        decorator = decorator.copyNilabilityFrom(receiverCt->decorator());
+      }
+
       auto outTy = ClassType::get(context, finalBct, nullptr, decorator);
       exprTypeOut = QualifiedType(QualifiedType::VAR, outTy);
       return true;

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -3829,9 +3829,17 @@ static const Type* getNumericType(Context* context,
                                   const CallInfo& ci) {
   UniqueString name = ci.name();
 
-  if (name == USTR("int") || name == USTR("uint") || name == USTR("bool") ||
-      name == USTR("real") || name == USTR("imag") || name == USTR("complex")) {
+  bool namedCall =
+      name == USTR("int") || name == USTR("uint") || name == USTR("bool") ||
+      name == USTR("real") || name == USTR("imag") || name == USTR("complex");
 
+
+  bool calledType = false;
+  if (auto ct = ci.calledType().type()) {
+    calledType = ct->isNumericOrBoolType();
+  }
+
+  if (namedCall || calledType) {
     // Should we compute the generic version of the type (e.g. int(?))
     bool useGenericType = false;
 

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -4362,6 +4362,12 @@ static bool resolveFnCallSpecial(Context* context,
         exprTypeOut = QualifiedType(QualifiedType::UNKNOWN, ErroneousType::get(context));
       } else {
         auto member = tup->elementType(val);
+
+        // adjust kind ensure that tupleType(idx) is also a type.
+        if (thisType.isType()) {
+          member = QualifiedType(thisType.kind(), member.type());
+        }
+
         exprTypeOut = member;
       }
       return true;

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -436,7 +436,7 @@ CallInfo CallInfo::create(Context* context,
     auto calledExprType = tryGetType(calledExpr, byPostorder);
     auto dotReceiverType = tryGetType(dotReceiver, byPostorder);
 
-    auto makeMethodCall = [&]() {
+    auto makeCallToDotThis = [&]() {
       name = USTR("this");
       // add the 'this' argument as well
       isMethodCall = true;
@@ -457,7 +457,7 @@ CallInfo CallInfo::create(Context* context,
       // a value (ambiguity or other "benign" UNKNOWN would not produce errors).
       // Later, this can lead to skipping resolving the call altogether.
 
-      makeMethodCall();
+      makeCallToDotThis();
     } else if (dotReceiverType && dotReceiverType->kind() == QualifiedType::MODULE) {
       // In calls like `M.f()`, where `M` is a module, we need to restrict
       // our search to `M`'s scope. Signal this by setting `moduleScopeId`.
@@ -470,7 +470,7 @@ CallInfo CallInfo::create(Context* context,
       // enables accessing the individual element's types.
 
       if (calledExprType->type() && calledExprType->type()->isTupleType()) {
-        makeMethodCall();
+        makeCallToDotThis();
       } else {
         calledType = *calledExprType;
       }

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -436,6 +436,16 @@ CallInfo CallInfo::create(Context* context,
     auto calledExprType = tryGetType(calledExpr, byPostorder);
     auto dotReceiverType = tryGetType(dotReceiver, byPostorder);
 
+    auto makeMethodCall = [&]() {
+      name = USTR("this");
+      // add the 'this' argument as well
+      isMethodCall = true;
+      actuals.push_back(CallInfoActual(*calledExprType, USTR("this")));
+      if (actualAsts != nullptr) {
+        actualAsts->push_back(calledExpr);
+      }
+    };
+
     if (calledExprType &&
         (isKindForFunctionalValue(calledExprType->kind()) ||
          calledExprType->isErroneousType())) {
@@ -447,13 +457,7 @@ CallInfo CallInfo::create(Context* context,
       // a value (ambiguity or other "benign" UNKNOWN would not produce errors).
       // Later, this can lead to skipping resolving the call altogether.
 
-      name = USTR("this");
-      // add the 'this' argument as well
-      isMethodCall = true;
-      actuals.push_back(CallInfoActual(*calledExprType, USTR("this")));
-      if (actualAsts != nullptr) {
-        actualAsts->push_back(calledExpr);
-      }
+      makeMethodCall();
     } else if (dotReceiverType && dotReceiverType->kind() == QualifiedType::MODULE) {
       // In calls like `M.f()`, where `M` is a module, we need to restrict
       // our search to `M`'s scope. Signal this by setting `moduleScopeId`.
@@ -461,7 +465,15 @@ CallInfo CallInfo::create(Context* context,
         *moduleScopeId = byPostorder.byAst(dotReceiver).toId();
       /* TODO: set calledType? */
     } else if (calledExprType && !calledExprType->isUnknown() && calledExprType->isType()) {
-      calledType = *calledExprType;
+      // normally, we would say this is a type constructor and set calledType.
+      // However, for tuples, we treat this as a regular "proc this", which
+      // enables accessing the individual element's types.
+
+      if (calledExprType->type() && calledExprType->type()->isTupleType()) {
+        makeMethodCall();
+      } else {
+        calledType = *calledExprType;
+      }
     } else if (!call->isOpCall() && dotReceiverType &&
                isKindForMethodReceiver(dotReceiverType->kind())) {
       // Check for normal method call, maybe construct a receiver.

--- a/frontend/test/resolution/testCast.cpp
+++ b/frontend/test/resolution/testCast.cpp
@@ -352,21 +352,29 @@ static void test35() {
 //   testHelper(&ctx, program, ComplexType::get(&ctx, 0), ComplexParam::get(&ctx, Param::ComplexDouble(1.1, 2.2)));
 // }
 
-// TODO: enum to int cast
-// static void test37() {
-//   printf("test37\n");
-//   Context ctx;
-//   std::string program = "enum E { A=0, B, C } param x = E.A : int; ";
-//   testHelper(&ctx, program, IntType::get(&ctx, 0), IntParam::get(&ctx, 0));
-// }
+static void test37() {
+  printf("test37\n");
+  Context ctx;
+  std::string program = "enum E { A=0, B, C } param x = E.A : int; ";
+  testHelper(&ctx, program, IntType::get(&ctx, 0), IntParam::get(&ctx, 0));
+}
 
-// TODO: int to enum cast
-// static void test38() {
-//   printf("test38\n");
-//   Context ctx;
-//   std::string program = "enum E { A=0, B, C } param x = 0 : E; ";
-//   testHelper(&ctx, program, EnumType::get(&ctx, 0), EnumParam::get(&ctx, 0));
-// }
+static void test38() {
+  printf("test38\n");
+  Context ctx;
+  std::string program = "enum E { A=0, B, C } param x = 0 : E; ";
+
+  auto enumId = ID(UniqueString::get(&ctx, "input.E"), -1, 0);
+  auto eltId = ID(enumId.symbolPath(), 1, 1);
+
+  // invoking 'EnumType::get' prior to resolving a program causes problems,
+  // so don't use the helper in order to defer constructing the EnumType.
+  QualifiedType qt = resolveQualifiedTypeOfX(&ctx, program);
+
+  assert(qt.hasTypePtr());
+  assert(qt.type() == EnumType::get(&ctx, enumId, UniqueString::get(&ctx, "E")));
+  assert(qt.param() == EnumParam::get(&ctx, {eltId, "A"}));
+}
 
 
 // enum to nothing cast (error)
@@ -596,8 +604,8 @@ int main() {
   test34();
   test35();
   // test36();
-  // test37();
-  // test38();
+  test37();
+  test38();
   test39();
   test40();
   test41();

--- a/frontend/test/resolution/testCast.cpp
+++ b/frontend/test/resolution/testCast.cpp
@@ -567,6 +567,29 @@ static void test46() {
   }
 }
 
+static void test47() {
+  printf("test47\n");
+  Context ctx;
+  Context* context = &ctx;
+
+  auto testBorrow = [context](std::string buildC, bool expectNilable) {
+    context->advanceToNextRevision(false);
+    ErrorGuard guard(context);
+
+    auto fullProg = "class C{}\n" + buildC + "\nvar x = c.borrow();";
+    auto xInit = resolveTypeOfXInit(context, fullProg);
+    assert(xInit.type());
+    assert(xInit.type()->isClassType());
+    assert(xInit.type()->toClassType()->decorator().isBorrowed());
+    assert(xInit.type()->toClassType()->decorator().isNilable() == expectNilable);
+  };
+
+  testBorrow("var cu = new unmanaged C();\n var c = cu : borrowed;", false);
+  testBorrow("var cu = new unmanaged C?();\n var c = cu : borrowed;", true);
+  testBorrow("var c = new unmanaged C();", false);
+  testBorrow("var c = new unmanaged C?();", true);
+}
+
 int main() {
   test1();
   test2();
@@ -614,6 +637,7 @@ int main() {
   test44();
   test45();
   test46();
+  test47();
 
   return 0;
 }

--- a/frontend/test/resolution/testReductions.cpp
+++ b/frontend/test/resolution/testReductions.cpp
@@ -122,6 +122,68 @@ static void test4(Context* context) {
   assert(qt.type()->isBoolType());
 }
 
+// test 'minloc' and 'maxloc' reductions
+static void test5(Context* context) {
+  context->advanceToNextRevision(false);
+  setupModuleSearchPaths(context, false, false, {}, {});
+  auto qts = resolveTypesOfVariablesInit(context,
+                        R""""(
+                        iter f() {
+                          yield (1, 0);
+                          yield (2, 1);
+                          yield (3, 2);
+                        }
+                        var x = maxloc reduce f();
+                        var y = minloc reduce f();
+                        )"""", {"x", "y"});
+  for (auto& pair : qts) {
+    auto& qt = pair.second;
+    assert(qt.type());
+    assert(qt.type()->isTupleType());
+    assert(qt.type()->toTupleType()->numElements() == 2);
+    assert(qt.type()->toTupleType()->elementType(0).type()->isIntType());
+    assert(qt.type()->toTupleType()->elementType(1).type()->isIntType());
+  }
+}
+
+// test 'zip' forms for reductions (serial and parallel)
+static void test6(Context* context) {
+  context->advanceToNextRevision(false);
+  setupModuleSearchPaths(context, false, false, {}, {});
+  auto qts = resolveTypesOfVariablesInit(context,
+                        R""""(
+                        iter f() { yield 1; yield 2; yield 3; }
+
+                        var x = maxloc reduce zip(1..10, 1..10);
+                        var y = maxloc reduce zip(f(), f());
+                        )"""", {"x", "y"});
+  for (auto& pair : qts) {
+    auto& qt = pair.second;
+    assert(qt.type());
+    assert(qt.type()->isTupleType());
+    assert(qt.type()->toTupleType()->numElements() == 2);
+    assert(qt.type()->toTupleType()->elementType(0).type()->isIntType());
+    assert(qt.type()->toTupleType()->elementType(1).type()->isIntType());
+  }
+}
+
+// test 'reduce' with parallel-only iterators
+static void test7(Context* context) {
+  context->advanceToNextRevision(false);
+  setupModuleSearchPaths(context, false, false, {}, {});
+  auto qts = resolveTypesOfVariablesInit(context,
+                        R""""(
+                        iter f(param tag) where tag == iterKind.standalone { yield 1; yield 2; yield 3; }
+
+                        var x = + reduce f();
+                        )"""", {"x"});
+  for (auto& pair : qts) {
+    auto& qt = pair.second;
+    assert(qt.type());
+    assert(qt.type()->isIntType());
+  }
+}
+
 int main() {
   // Use a single context instance to avoid re-resolving internal modules.
   auto context = buildStdContext();
@@ -130,4 +192,7 @@ int main() {
   test2(context);
   test3(context);
   test4(context);
+  test5(context);
+  test6(context);
+  test7(context);
 }


### PR DESCRIPTION
Closes https://github.com/Cray/chapel-private/issues/7320.

Clean diff: https://github.com/chapel-lang/chapel/pull/27155/files/b905dc708c3808fdac291dcf60618fb40c1a6438..9088afe8c45e74998c3c6102e9f8054203b90d16

The forms didn't work for two reasons:

1. Dyno's type-level tuple indexing didn't work. `myTupType(0)` produced a `_tuple(0)` rather than a type corresponding to `myTupType`'s first element. I fix this with changes to `CallInfo::create` and a minor adjustment to `resolution-queries.cpp`
2. Reductions didn't handle `zip` expressions. It turns out the logic for resolving `zip` was already pretty neat and self-contained, so this PR simply moved some calls and arguments around to thread through `zip` handling for reductions. While there, I enabled parallel reductions to resolve.

Also while there, I noticed that code like `type idk = int; idk(0)` caused an assertion in the compiler. I fixed it by adjusting numeric type construction code to check not only for the name (which doesn't match `idk`) but also for the called type.

Reviewed by @benharsh -- thanks!

## Testing
- [x] dyno tests
- [x] paratest