### PR TITLE
Dyno: resolve `dmapped` expressions as calls to `chpl__distributed`

### DIFF
--- a/frontend/test/resolution/testDomainsRectangular.cpp
+++ b/frontend/test/resolution/testDomainsRectangular.cpp
@@ -203,6 +203,24 @@ static void testBadDomain(Context* contextWithStd, std::string domainType) {
   }
 }
 
+// check that the 'dmapped' call is handled via a call to 'chpl__distributed'
+static void testDmapped() {
+  auto context = buildStdContext();
+  ErrorGuard guard(context);
+
+  auto qt = resolveTypeOfXInit(context,
+    R"""(
+      use BlockDist;
+
+      var Space = {1..10, 1..10};
+      var Dist = new blockDist(Space);
+      var D = Space dmapped Dist;
+      var x = D.distribution.type : string;
+  )""");
+
+  ensureParamString(qt, "blockDist(2, int(64), unmanaged DefaultDist)");
+}
+
 int main() {
   // Set up context with standard modules, re-used between tests for
   // performance.
@@ -235,6 +253,8 @@ int main() {
   testBadDomain(context, "domain(\"asdf\", \"asdf2\")");
   testBadDomain(context, "domain(1, \"asdf\")");
   testBadDomain(context, "domain(1, int, \"asdf\")");
+
+  testDmapped();
 
   return 0;
 }


### PR DESCRIPTION
Closes https://github.com/Cray/chapel-private/issues/7318.

Not much interesting here, just a standard rewrite of a builtin operator to a call to a standard function. A _tiny_ detail is that we swap the arguments of `dmapped` so that `D dmapped dist` becomes `chpl__distributed(dist, D, definedConst)`.

Upon consulting with `convert-uast.cpp`, which is the only place `chpl__distributed` is mentioned, I've determined that `definedConst` is always set to `true`, so this PR keeps that quirk.

Reviewed by @arifthpe -- thanks!

## Testing
- [x] dyno tests
- [x] paratest