### PR TITLE
Dyno: fix double-tagging issue when re-resolving calls

### DIFF
--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -5311,8 +5311,14 @@ rerunCallInfoWithIteratorTag(ResolutionContext* rc,
   if (iterKindActual.isUnknown()) return empty;
 
   std::vector<CallInfoActual> actuals;
-  for (const auto& actual : ci.actuals())
+  for (const auto& actual : ci.actuals()) {
+    // If the user explictly specified a tag, we can't re-run with a different tag.
+    if (actual.byName() == USTR("tag")) {
+      return empty;
+    }
+
     actuals.push_back(actual);
+  }
   actuals.emplace_back(iterKindActual, USTR("tag"));
 
   auto newCi = CallInfo(ci.name(), ci.calledType(), ci.isMethodCall(),


### PR DESCRIPTION
This fixes a bug in which a call that was explicitly tagged, like `foo(tag = standalone)`, could be re-resolved to a different iterator kind.

In general, the purpose of re-resolving calls is to support cases like `foo()` where `foo()` only has a parallel overload. In this case, we can silently insert a tag and resolution proceeds as normal. However, overriding an explicitly-provided tag seems wrong.

Moreover, the current implementation could insert duplicate tags. Upon failing to resolve `foo(tag = standalone)`, it would try to also resolve `foo(tag = standalone, tag = standalone)` and `foo(tag = standalone, tag = leader)`. Since duplicate named actuals are ruled out syntactically, and since these calls are generated and have no corresponding AST, this would succeed. This would make it possible for an explicitly standalone call to resolve to a leader overload, because the last provided tag would be used.

This led to a curious behavior in which `foo(tag)` and `foo(tag = tag)` were not equivalent. The former would not succeed a re-resolution with a differen tag, because it would need -- separately -- a positional argument and then another formal. The latter, however, would succeed due to the aforementioned behavior in which the second of same-named actuals would be preferred.

This PR simply quits the re-resolution process if it finds a pre-existing tag. This rules out double-tagging and restores consistency to the two forms of calls.

## Testing
- [x] dyno tests
- [x] `--dyno-resolve-only` tests