### PR TITLE
chapel-py: add dump and stringify capabilities to AstNode

### DIFF
--- a/tools/chapel-py/src/core-types.cpp
+++ b/tools/chapel-py/src/core-types.cpp
@@ -154,6 +154,30 @@ PyObject* AstNodeObject::iter(AstNodeObject *self) {
   return wrapIterPair((ContextObject*) self->contextObject, self->value_->children());
 }
 
+PyObject* AstNodeObject::str(AstNodeObject *self) {
+  if (!self->value_) {
+    raiseExceptionForIncorrectlyConstructedType("AstNode");
+    return nullptr;
+  }
+
+  std::stringstream ss;
+  self->value_->stringify(ss, CHPL_SYNTAX);
+  auto typeString = ss.str();
+  return Py_BuildValue("s", typeString.c_str());
+}
+
+PyObject* AstNodeObject::repr(AstNodeObject *self) {
+  if (!self->value_) {
+    raiseExceptionForIncorrectlyConstructedType("AstNode");
+    return nullptr;
+  }
+
+  std::stringstream ss;
+  self->value_->stringify(ss, DEBUG_DETAIL);
+  auto typeString = ss.str();
+  return Py_BuildValue("s", typeString.c_str());
+}
+
 void ChapelTypeObject_dealloc(ChapelTypeObject* self) {
   Py_XDECREF(self->contextObject);
   callPyTypeSlot_tp_free(ChapelTypeObject::PythonType, (PyObject*) self);

--- a/tools/chapel-py/src/core-types.h
+++ b/tools/chapel-py/src/core-types.h
@@ -140,9 +140,13 @@ struct AstNodeObject : public PythonClassWithContext<AstNodeObject, const chpl::
   static constexpr const char* DocStr = "The base type of Chapel AST nodes";
 
   static PyObject* iter(AstNodeObject *self);
+  static PyObject* str(AstNodeObject *self);
+  static PyObject* repr(AstNodeObject *self);
 
   static PyTypeObject* configurePythonType() {
-    std::array<PyType_Slot, 1> extraSlots = {
+    std::array<PyType_Slot, 3> extraSlots = {
+      PyType_Slot{Py_tp_str, (void*) AstNodeObject::str},
+      PyType_Slot{Py_tp_repr, (void*) AstNodeObject::repr},
       PyType_Slot{Py_tp_iter, (void*) AstNodeObject::iter},
     };
     PyTypeObject* configuring = PythonClassWithContext<AstNodeObject, const chpl::uast::AstNode*>::configurePythonType(Py_TPFLAGS_BASETYPE, extraSlots);


### PR DESCRIPTION
This enables using `str(node)` to get a stringified representation of the AST node.

Reviewed by @jabraham17 -- thanks!

## Testing
- [x] `make test-cls`