### PR TITLE
Iterator type string details

### DIFF
--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -183,6 +183,17 @@ void Type::setSubstitutionWithName(const char* name, Symbol* value) {
   INT_FATAL("substitution not found");
 }
 
+// "iterator|promoted expression yielding ..."
+// result may be non-astr()
+static const char* toIteratorString(AggregateType* at, bool decorateAllClasses) {
+  const char* kind = at->symbol->hasFlag(FLAG_PROMOTION_ITERATOR_RECORD)
+    ? "promoted expression" : "iterator";
+  if (IteratorInfo* ii = at->iteratorInfo)
+    if (Type* yt = ii->yieldedType)
+      return astr(kind, " yielding ", toString(yt, decorateAllClasses));
+  return kind;
+}
+
 const char* toString(Type* type, bool decorateAllClasses) {
   const char* retval = NULL;
 
@@ -238,7 +249,7 @@ const char* toString(Type* type, bool decorateAllClasses) {
         }
       } else if (vt->symbol->hasFlag(FLAG_ITERATOR_RECORD)) {
         if (developer == false)
-          retval = "iterator";
+          retval = toIteratorString(at, decorateAllClasses);
       } else if (at->symbol->hasFlag(FLAG_ATOMIC_TYPE) &&
                  (strcmp(at->symbol->name, "AtomicBool") == 0 ||
                   strcmp(at->symbol->name, "RAtomicBool") == 0)) {

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -2696,6 +2696,18 @@ Type* arrayElementType(Type* arrayType) {
   return eltType;
 }
 
+// some simple cases, not exhaustive
+static const char* chooseSeparatorForType(const char* type) {
+  if (startsWith(type, "i") ||
+      startsWith(type, "a") ||
+      startsWith(type, "own") ||
+      startsWith(type, "[") )
+    return "an ";
+  else
+    // todo: perhaps switch this to "a(n) "; need to update many .good files
+    return "a ";
+}
+
 static void issueInitConversionError(Symbol* to, Symbol* toType, Symbol* from,
                                      Expr* where) {
 
@@ -2733,8 +2745,8 @@ static void issueInitConversionError(Symbol* to, Symbol* toType, Symbol* from,
     sep = "";
     fromStr = "nil";
   } else {
-    sep = "a ";
     fromStr = toString(fromValType);
+    sep = chooseSeparatorForType(fromStr);
   }
 
   USR_FATAL_CONT(where,

--- a/test/arrays/ferguson/return-array-as-int.good
+++ b/test/arrays/ferguson/return-array-as-int.good
@@ -1,3 +1,3 @@
 return-array-as-int.chpl:7: In method 'setRowNames':
-return-array-as-int.chpl:8: error: cannot initialize return value of type 'int(64)' from a '[domain(1,int(64),one)] int(64)'
+return-array-as-int.chpl:8: error: cannot initialize return value of type 'int(64)' from an '[domain(1,int(64),one)] int(64)'
   return-array-as-int.chpl:12: called as NamedMatrix.setRowNames(rn: [domain(1,int(64),one)] string)

--- a/test/arrays/formals/promotedExprAsArrayActual.bad
+++ b/test/arrays/formals/promotedExprAsArrayActual.bad
@@ -1,4 +1,4 @@
 promotedExprAsArrayActual.chpl:3: error: unresolved call 'doSomething(promoted expression)'
 promotedExprAsArrayActual.chpl:1: note: this candidate did not match: doSomething(arg: [] int)
-promotedExprAsArrayActual.chpl:3: note: because actual argument #1 with type 'iterator'
+promotedExprAsArrayActual.chpl:3: note: because actual argument #1 with type 'promoted expression yielding int(64)'
 promotedExprAsArrayActual.chpl:1: note: is passed to formal 'arg: []'

--- a/test/arrays/marybeth/test_arrayops.good
+++ b/test/arrays/marybeth/test_arrayops.good
@@ -1,4 +1,4 @@
 test_arrayops.chpl:10: error: unresolved call 'maxIndex(promoted expression)'
 test_arrayops.chpl:12: note: this candidate did not match: maxIndex(A: [?D])
-test_arrayops.chpl:10: note: because actual argument #1 with type 'iterator'
+test_arrayops.chpl:10: note: because actual argument #1 with type 'promoted expression yielding real(64)'
 test_arrayops.chpl:12: note: is passed to formal 'A: []'

--- a/test/arrays/promotion/promotedArgToArrayFormal.bad
+++ b/test/arrays/promotion/promotedArgToArrayFormal.bad
@@ -1,4 +1,4 @@
 promotedArgToArrayFormal.chpl:9: error: unresolved call 'bar(promoted expression)'
 promotedArgToArrayFormal.chpl:11: note: this candidate did not match: bar(arrayArg: [] int)
-promotedArgToArrayFormal.chpl:9: note: because actual argument #1 with type 'iterator'
+promotedArgToArrayFormal.chpl:9: note: because actual argument #1 with type 'promoted expression yielding int(64)'
 promotedArgToArrayFormal.chpl:11: note: is passed to formal 'arrayArg: []'

--- a/test/arrays/shapes/tmacd-promotion.good
+++ b/test/arrays/shapes/tmacd-promotion.good
@@ -12,4 +12,4 @@
 [ArrayViewRankChangeDom(2,int(64),one,3*bool,3*int(64),int(64),unmanaged ArrayViewRankChangeDist(unmanaged DefaultDist,3*bool,3*int(64)))] int(64)
 ====== const ref NN =====
 0 0 0 0
-iterator
+promoted expression yielding int(64)

--- a/test/classes/casts/to-unmanaged-no-init.good
+++ b/test/classes/casts/to-unmanaged-no-init.good
@@ -2,7 +2,7 @@ to-unmanaged-no-init.chpl:7: error: cannot initialize variable 'myUnmanaged' of 
 to-unmanaged-no-init.chpl:9: error: cannot initialize variable 'myUnmanaged' of type 'unmanaged A?' from a 'borrowed A'
 to-unmanaged-no-init.chpl:17: error: cannot initialize variable 'myUnmanaged' of type 'unmanaged A?' from a 'shared A?'
 to-unmanaged-no-init.chpl:19: error: cannot initialize variable 'myUnmanaged' of type 'unmanaged A?' from a 'borrowed A'
-to-unmanaged-no-init.chpl:7: error: cannot initialize 'myUnmanaged' of type 'unmanaged A?' from a 'owned A?'
+to-unmanaged-no-init.chpl:7: error: cannot initialize 'myUnmanaged' of type 'unmanaged A?' from an 'owned A?'
 to-unmanaged-no-init.chpl:9: error: cannot initialize 'myUnmanaged' of type 'unmanaged A?' from a 'borrowed A'
 to-unmanaged-no-init.chpl:17: error: cannot initialize 'myUnmanaged' of type 'unmanaged A?' from a 'shared A?'
 to-unmanaged-no-init.chpl:19: error: cannot initialize 'myUnmanaged' of type 'unmanaged A?' from a 'borrowed A'

--- a/test/classes/errors/nilability-init-field-dflt/init-field-dflt-nonnil-borrowed-from-oknil-owned.good
+++ b/test/classes/errors/nilability-init-field-dflt/init-field-dflt-nonnil-borrowed-from-oknil-owned.good
@@ -1,2 +1,2 @@
-init-field-dflt-nonnil-borrowed-from-oknil-owned.chpl:8: error: cannot initialize 'lhs' of type 'borrowed MyClass' from a 'owned MyClass?'
+init-field-dflt-nonnil-borrowed-from-oknil-owned.chpl:8: error: cannot initialize 'lhs' of type 'borrowed MyClass' from an 'owned MyClass?'
 init-field-dflt-nonnil-borrowed-from-oknil-owned.chpl:13: error: done

--- a/test/classes/errors/nilability-init-field-dflt/init-field-dflt-nonnil-unmanaged-from-nonnil-owned.good
+++ b/test/classes/errors/nilability-init-field-dflt/init-field-dflt-nonnil-unmanaged-from-nonnil-owned.good
@@ -1,2 +1,2 @@
-init-field-dflt-nonnil-unmanaged-from-nonnil-owned.chpl:8: error: cannot initialize 'lhs' of type 'unmanaged MyClass' from a 'owned MyClass'
+init-field-dflt-nonnil-unmanaged-from-nonnil-owned.chpl:8: error: cannot initialize 'lhs' of type 'unmanaged MyClass' from an 'owned MyClass'
 init-field-dflt-nonnil-unmanaged-from-nonnil-owned.chpl:13: error: done

--- a/test/classes/errors/nilability-init-field-dflt/init-field-dflt-nonnil-unmanaged-from-oknil-owned.good
+++ b/test/classes/errors/nilability-init-field-dflt/init-field-dflt-nonnil-unmanaged-from-oknil-owned.good
@@ -1,2 +1,2 @@
-init-field-dflt-nonnil-unmanaged-from-oknil-owned.chpl:8: error: cannot initialize 'lhs' of type 'unmanaged MyClass' from a 'owned MyClass?'
+init-field-dflt-nonnil-unmanaged-from-oknil-owned.chpl:8: error: cannot initialize 'lhs' of type 'unmanaged MyClass' from an 'owned MyClass?'
 init-field-dflt-nonnil-unmanaged-from-oknil-owned.chpl:13: error: done

--- a/test/classes/errors/nilability-init-field-dflt/init-field-dflt-oknil-unmanaged-from-nonnil-owned.good
+++ b/test/classes/errors/nilability-init-field-dflt/init-field-dflt-oknil-unmanaged-from-nonnil-owned.good
@@ -1,2 +1,2 @@
-init-field-dflt-oknil-unmanaged-from-nonnil-owned.chpl:8: error: cannot initialize 'lhs' of type 'unmanaged MyClass?' from a 'owned MyClass'
+init-field-dflt-oknil-unmanaged-from-nonnil-owned.chpl:8: error: cannot initialize 'lhs' of type 'unmanaged MyClass?' from an 'owned MyClass'
 init-field-dflt-oknil-unmanaged-from-nonnil-owned.chpl:13: error: done

--- a/test/classes/errors/nilability-init-field-dflt/init-field-dflt-oknil-unmanaged-from-oknil-owned.good
+++ b/test/classes/errors/nilability-init-field-dflt/init-field-dflt-oknil-unmanaged-from-oknil-owned.good
@@ -1,2 +1,2 @@
-init-field-dflt-oknil-unmanaged-from-oknil-owned.chpl:8: error: cannot initialize 'lhs' of type 'unmanaged MyClass?' from a 'owned MyClass?'
+init-field-dflt-oknil-unmanaged-from-oknil-owned.chpl:8: error: cannot initialize 'lhs' of type 'unmanaged MyClass?' from an 'owned MyClass?'
 init-field-dflt-oknil-unmanaged-from-oknil-owned.chpl:13: error: done

--- a/test/classes/fields/default-expression-2.good
+++ b/test/classes/fields/default-expression-2.good
@@ -1,5 +1,5 @@
 default-expression-2.chpl:7: In initializer:
-default-expression-2.chpl:9: error: cannot initialize field 'a' of type 'bool' from a 'int(64)'
+default-expression-2.chpl:9: error: cannot initialize field 'a' of type 'bool' from an 'int(64)'
   default-expression-2.chpl:15: called as SymEntry.init(a: int(64))
 default-expression-2.chpl:16: warning: SymEntry(nothing)
 default-expression-2.chpl:17: warning: bool

--- a/test/classes/nilability/bang-array.bad
+++ b/test/classes/nilability/bang-array.bad
@@ -1,4 +1,4 @@
 bang-array.chpl:9: error: unresolved call 'foo(promoted expression)'
 bang-array.chpl:11: note: this candidate did not match: foo(arrayArg: [] C)
-bang-array.chpl:9: note: because actual argument #1 with type 'iterator'
+bang-array.chpl:9: note: because actual argument #1 with type 'promoted expression yielding borrowed C'
 bang-array.chpl:11: note: is passed to formal 'arrayArg: []'

--- a/test/expressions/bradc/reduceVsMathPrec2.bad
+++ b/test/expressions/bradc/reduceVsMathPrec2.bad
@@ -1,1 +1,0 @@
-reduceVsMathPrec2.chpl:12: error: cannot initialize 'total' of type 'int(64)' from a 'iterator'

--- a/test/expressions/bradc/reduceVsMathPrec2.future
+++ b/test/expressions/bradc/reduceVsMathPrec2.future
@@ -1,6 +1,0 @@
-error message: assign array to scalar
-
-This future correctly throws an error, but the message exposes
-the iterator class.  I'm not particularly attached to the 
-message in my .good file, but we need to remove the exposure
-of the iterator class.

--- a/test/expressions/bradc/reduceVsMathPrec2.good
+++ b/test/expressions/bradc/reduceVsMathPrec2.good
@@ -1,1 +1,1 @@
-reduceVsMathPrec2.chpl:12: error: Cannot assign to int(64) from array
+reduceVsMathPrec2.chpl:12: error: cannot initialize 'total' of type 'int(64)' from a 'promoted expression yielding int(64)'

--- a/test/functions/iterators/errors/incorrectYieldTypes.good
+++ b/test/functions/iterators/errors/incorrectYieldTypes.good
@@ -1,3 +1,3 @@
 incorrectYieldTypes.chpl:4: In iterator 'IT':
-incorrectYieldTypes.chpl:6: error: cannot initialize yield value of type 'int(64)' from a '[domain(1,int(64),one)] locale'
+incorrectYieldTypes.chpl:6: error: cannot initialize yield value of type 'int(64)' from an '[domain(1,int(64),one)] locale'
 incorrectYieldTypes.chpl:8: error: cannot initialize yield value of type 'int(64)' from a 'domain(1,int(64),one)'

--- a/test/functions/iterators/vass/forall-over-iteratorRecord-arg.good
+++ b/test/functions/iterators/vass/forall-over-iteratorRecord-arg.good
@@ -1,4 +1,4 @@
 forall-over-iteratorRecord-arg.chpl:21: In function 'myTestProc':
 forall-over-iteratorRecord-arg.chpl:23: error: a forall loop over a formal argument corresponding to a for/forall/promoted expression or an iterator call is not implemented
 forall-over-iteratorRecord-arg.chpl:34: note: the actual argument is here
-  forall-over-iteratorRecord-arg.chpl:34: called as myTestProc(IR: iterator)
+  forall-over-iteratorRecord-arg.chpl:34: called as myTestProc(IR: promoted expression yielding int(64))

--- a/test/functions/resolution/errors/printAdditionalErrors-1.all.good
+++ b/test/functions/resolution/errors/printAdditionalErrors-1.all.good
@@ -4,7 +4,7 @@ printAdditionalErrors-1.chpl:9: warning: postponed error: fatal error in f1()
   printAdditionalErrors-1.chpl:17: called as canResolve(param fname = "f1", args(0): int(64)) from module 'printAdditionalErrors-1'
 printAdditionalErrors-1.chpl:19: warning: NOOOO, f1() does not resolve
 printAdditionalErrors-1.chpl:11: In function 'f2':
-printAdditionalErrors-1.chpl:12: error: cannot initialize 'y' of type 'int(8)' from a 'int(64)'
+printAdditionalErrors-1.chpl:12: error: cannot initialize 'y' of type 'int(8)' from an 'int(64)'
 printAdditionalErrors-1.chpl:22: warning: YESSS, f2() resolves
 printAdditionalErrors-1.chpl:14: In function 'f3':
 printAdditionalErrors-1.chpl:15: error: unresolved call 'f1(3, 4)'

--- a/test/functions/resolution/errors/printAdditionalErrors-1.dflt.good
+++ b/test/functions/resolution/errors/printAdditionalErrors-1.dflt.good
@@ -1,6 +1,6 @@
 printAdditionalErrors-1.chpl:19: warning: NOOOO, f1() does not resolve
 printAdditionalErrors-1.chpl:11: In function 'f2':
-printAdditionalErrors-1.chpl:12: error: cannot initialize 'y' of type 'int(8)' from a 'int(64)'
+printAdditionalErrors-1.chpl:12: error: cannot initialize 'y' of type 'int(8)' from an 'int(64)'
 printAdditionalErrors-1.chpl:22: warning: YESSS, f2() resolves
 printAdditionalErrors-1.chpl:14: In function 'f3':
 printAdditionalErrors-1.chpl:15: error: unresolved call 'f1(3, 4)'

--- a/test/functions/resolution/errors/printAdditionalErrors-1.pae.good
+++ b/test/functions/resolution/errors/printAdditionalErrors-1.pae.good
@@ -2,7 +2,7 @@ printAdditionalErrors-1.chpl:8: In function 'f1':
 printAdditionalErrors-1.chpl:9: warning: postponed error: fatal error in f1()
 printAdditionalErrors-1.chpl:19: warning: NOOOO, f1() does not resolve
 printAdditionalErrors-1.chpl:11: In function 'f2':
-printAdditionalErrors-1.chpl:12: error: cannot initialize 'y' of type 'int(8)' from a 'int(64)'
+printAdditionalErrors-1.chpl:12: error: cannot initialize 'y' of type 'int(8)' from an 'int(64)'
 printAdditionalErrors-1.chpl:22: warning: YESSS, f2() resolves
 printAdditionalErrors-1.chpl:14: In function 'f3':
 printAdditionalErrors-1.chpl:15: error: unresolved call 'f1(3, 4)'

--- a/test/io/serializers/unstableWriting.good
+++ b/test/io/serializers/unstableWriting.good
@@ -14,11 +14,11 @@ $CHPL_HOME/modules/standard/JSON.chpl:nnnn: warning: Serialization of rectangula
   unstableWriting.chpl:12: called as helper(thing: domain(1,int(64),one))
 $CHPL_HOME/modules/standard/JSON.chpl:nnnn: In method 'serializeValue':
 $CHPL_HOME/modules/standard/JSON.chpl:nnnn: warning: Serialization of iterators with non-default Serializer is unstable, and may change in the future
-  $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as jsonSerializer.serializeValue(writer: fileWriter(false,jsonSerializer), val: iterator) from method '_serializeOne'
-  $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileWriter(true,jsonSerializer))._serializeOne(x: iterator, loc: locale) from method 'writeHelper'
-  $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileWriter(true,jsonSerializer)).writeHelper(endl: chpl_ioNewline, sep: nothing, args(0): iterator) from method 'writeln'
-  unstableWriting.chpl:7: called as (fileWriter(true,jsonSerializer)).writeln(args(0): iterator) from function 'helper'
-  unstableWriting.chpl:13: called as helper(thing: iterator)
+  $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as jsonSerializer.serializeValue(writer: fileWriter(false,jsonSerializer), val: iterator yielding int(64)) from method '_serializeOne'
+  $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileWriter(true,jsonSerializer))._serializeOne(x: iterator yielding int(64), loc: locale) from method 'writeHelper'
+  $CHPL_HOME/modules/standard/IO.chpl:nnnn: called as (fileWriter(true,jsonSerializer)).writeHelper(endl: chpl_ioNewline, sep: nothing, args(0): iterator yielding int(64)) from method 'writeln'
+  unstableWriting.chpl:7: called as (fileWriter(true,jsonSerializer)).writeln(args(0): iterator yielding int(64)) from function 'helper'
+  unstableWriting.chpl:13: called as helper(thing: iterator yielding int(64))
 "1..10"
 ["1..10"]
 [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]

--- a/test/library/packages/Crypto/utils/buffer2.good
+++ b/test/library/packages/Crypto/utils/buffer2.good
@@ -1,2 +1,2 @@
 buffer2.chpl:1: In function 'main':
-buffer2.chpl:5: error: cannot initialize a value of type 'uint(8)' from a 'int(64)'
+buffer2.chpl:5: error: cannot initialize a value of type 'uint(8)' from an 'int(64)'

--- a/test/library/standard/Reflection/canResolvePromoReturn.good
+++ b/test/library/standard/Reflection/canResolvePromoReturn.good
@@ -1,12 +1,12 @@
 true
 true true true
-iterator
+promoted expression yielding bool
 bool
 true
 true
 true
 false false false
-iterator
+promoted expression yielding bool
 bool
 false
 false

--- a/test/statements/split-init/splitInitIteratorExpressions.bad
+++ b/test/statements/split-init/splitInitIteratorExpressions.bad
@@ -1,1 +1,1 @@
-splitInitIteratorExpressions.chpl:6: error: Split initialization uses multiple types; another initialization has type [domain(1,int(64),one)] string but this initialization has type iterator
+splitInitIteratorExpressions.chpl:6: error: Split initialization uses multiple types; another initialization has type [domain(1,int(64),one)] string but this initialization has type iterator yielding string

--- a/test/users/thom/arrArgBlank-promote.good
+++ b/test/users/thom/arrArgBlank-promote.good
@@ -1,4 +1,4 @@
 arrArgBlank-promote.chpl:10: error: unresolved call 'writeArr(promoted expression)'
 arrArgBlank-promote.chpl:3: note: this candidate did not match: writeArr(X: [] real)
-arrArgBlank-promote.chpl:10: note: because actual argument #1 with type 'iterator'
+arrArgBlank-promote.chpl:10: note: because actual argument #1 with type 'promoted expression yielding real(64)'
 arrArgBlank-promote.chpl:3: note: is passed to formal 'X: []'

--- a/test/users/thom/arrArgConst-promote.good
+++ b/test/users/thom/arrArgConst-promote.good
@@ -1,4 +1,4 @@
 arrArgConst-promote.chpl:10: error: unresolved call 'writeArr(promoted expression)'
 arrArgConst-promote.chpl:3: note: this candidate did not match: writeArr(const X: [] real)
-arrArgConst-promote.chpl:10: note: because actual argument #1 with type 'iterator'
+arrArgConst-promote.chpl:10: note: because actual argument #1 with type 'promoted expression yielding real(64)'
 arrArgConst-promote.chpl:3: note: is passed to formal 'const X: []'

--- a/test/users/thom/arrArgRef-promote.good
+++ b/test/users/thom/arrArgRef-promote.good
@@ -1,4 +1,4 @@
 arrArgRef-promote.chpl:10: error: unresolved call 'writeArr(promoted expression)'
 arrArgRef-promote.chpl:3: note: this candidate did not match: writeArr(ref X: [] real)
-arrArgRef-promote.chpl:10: note: because actual argument #1 with type 'iterator'
+arrArgRef-promote.chpl:10: note: because actual argument #1 with type 'promoted expression yielding real(64)'
 arrArgRef-promote.chpl:3: note: is passed to formal 'ref X: []'


### PR DESCRIPTION
The compiler messages now report the type of an iterable expression as `iterator yielding TYPE` or `promoted expression yielding TYPE`, with an appropriate TYPE. Previously it reported these types simply as `iterator`.

De-futurizes `test/expressions/bradc/reduceVsMathPrec2.chpl`

Changes the article to be used in one of the error messages before the type name from `a` to `an` in some common cases like "from an 'iterator'" or "from an 'owned'".

Testing: standard and gasnet paratests.