### PR TITLE
Reduce intent -- nice error message upon type error

### DIFF
--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -254,7 +254,8 @@ static void insertFinalGenerate(LoopWithShadowVarsInterface* fs,
 {
   if (fs->needsInitialAccumulate()) {
     VarSymbol* genTemp = newTemp("chpl_gentemp");
-    fs->asExpr()->insertAfter(new CallExpr("=", fiVarSym, genTemp));
+    fs->asExpr()->insertAfter("chpl_check_assign_reduce_result(%S,%S)",
+                              fiVarSym, genTemp);
     fs->asExpr()->insertAfter("'move'(%S, generate(%S,%S))",
                     genTemp, gMethodToken, globalOp);
     fs->asExpr()->insertAfter(new DefExpr(genTemp));

--- a/modules/internal/ChapelReduce.chpl
+++ b/modules/internal/ChapelReduce.chpl
@@ -126,10 +126,18 @@ module ChapelReduce {
       if ! canResolve("+", x, x) then
         // Issue a user-friendly error.
         compilerError("+ reduce cannot be used on values of the type ",
-                      eltType:string);
+            eltType:string, " because they cannot be summed using '+'");
       return (x + x).type;
     }
    }
+  }
+
+  proc chpl_check_assign_reduce_result(ref target, in value) {
+    if __primitive("call resolves", "=", target, value) then
+      target = value;
+    else
+      compilerError("cannot store reduction result of type ", value.type:string,
+                    " into a variable of type ", target.type:string);
   }
 
   pragma "ReduceScanOp"

--- a/test/parallel/forall/reduce-intents/ri-error-result-type.chpl
+++ b/test/parallel/forall/reduce-intents/ri-error-result-type.chpl
@@ -1,0 +1,11 @@
+// ensure a user-friendly error message
+
+var arr: [1..1000] bool;
+var sum: bool;
+
+// + on booleans produces an int
+forall a in arr with (+ reduce sum) {
+  sum += a;
+}
+
+writeln(sum);

--- a/test/parallel/forall/reduce-intents/ri-error-result-type.good
+++ b/test/parallel/forall/reduce-intents/ri-error-result-type.good
@@ -1,0 +1,1 @@
+ri-error-result-type.chpl:7: error: cannot store reduction result of type int(64) into a variable of type bool

--- a/test/reductions/reduceAtomics.bad
+++ b/test/reductions/reduceAtomics.bad
@@ -1,1 +1,1 @@
-reduceAtomics.chpl:12: error: + reduce cannot be used on values of the type atomic int(64)
+reduceAtomics.chpl:12: error: + reduce cannot be used on values of the type atomic int(64) because they cannot be summed using '+'

--- a/test/reductions/vass/illegal-elttype.good
+++ b/test/reductions/vass/illegal-elttype.good
@@ -1,2 +1,2 @@
 illegal-elttype.chpl:6: In function 'main':
-illegal-elttype.chpl:7: error: + reduce cannot be used on values of the type RRR
+illegal-elttype.chpl:7: error: + reduce cannot be used on values of the type RRR because they cannot be summed using '+'


### PR DESCRIPTION
Resolves #27060

The compiler now emits a user-friendly error message when the result of the reduction calculated using a reduce intent cannot be stored in the corresponding outer variable due to a type mismatch.

While there, add a clarification to an existing error message.

Testing: standard and gasnet paratests.