### PR TITLE
fix incorrect date on a perf annotation

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -2578,7 +2578,7 @@ arkouda: &arkouda-base
   03/06/25:
     - text: Suspected systems changes
       config: 16-node-xc
-  03/28/25:
+  03/20/25:
     - text: Add ARKOUDA_DEFAULT_TEMP_DIRECTORY for arkouda perf tests (#26949)
       config: 16-node-hpe-apollo-hdr
 


### PR DESCRIPTION
I mistakenly put the wrong date for this annotation (involving IO perf changes for Arkouda on IB):

https://github.com/chapel-lang/chapel/pull/26949

This PR fixes it (to be on 3/20 instead of 3/28).