### PR TITLE
Dyno: Allow conversion from value tuple to referential tuple formal

### DIFF
--- a/frontend/include/chpl/resolution/can-pass.h
+++ b/frontend/include/chpl/resolution/can-pass.h
@@ -58,6 +58,8 @@ class CanPassResult {
     BORROWS_SUBTYPE,
     /** Non-subtype conversion that doesn't produce a param */
     OTHER,
+    /** A conversion from a tuple to its referential tuple type equivalent */
+    TO_REFERENTIAL_TUPLE,
   };
 
  private:

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -5001,10 +5001,8 @@ void Resolver::exit(const uast::Array* decl) {
     arrayBuilderProc = "chpl__buildNDArrayExpr";
 
     // Get shape arg
-    std::vector<QualifiedType> shapeTupleElts;
-    for (auto dim : decl->shape()) {
-      shapeTupleElts.push_back(QualifiedType::makeParamInt(context, dim));
-    }
+    auto intType = QualifiedType(QualifiedType::VAR, IntType::get(context, 0));
+    std::vector<QualifiedType> shapeTupleElts(decl->shape().size(), intType);
     auto shapeTupleType = TupleType::getQualifiedTuple(context, shapeTupleElts);
     actualAsts.push_back(nullptr);
     actuals.emplace_back(
@@ -5047,6 +5045,7 @@ void Resolver::exit(const uast::Array* decl) {
   auto inScopes = CallScopeInfo::forNormalCall(scope, poiScope);
   auto c = resolveGeneratedCall(decl, &ci, &inScopes);
 
+  // TODO: We need an associated action here
   c.noteResult(&r);
 }
 

--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -664,6 +664,10 @@ CanPassResult CanPassResult::canConvertTuples(Context* context,
     return fail(FAIL_INCOMPATIBLE_TUPLE_STAR);
   }
 
+  if (aT->toReferentialTuple(context) == fT) {
+    return convert(TO_REFERENTIAL_TUPLE);
+  }
+
   int n = aT->numElements();
   if (aT->isStarTuple())
     n = 1; // only need to consider one type
@@ -1157,15 +1161,7 @@ CanPassResult CanPassResult::canPassScalar(Context* context,
       {
         auto actualTup = actualT->toTupleType();
         if (actualTup != nullptr  && formalT->isTupleType()) {
-          if (actualTup->isVarArgTuple() &&
-              actualTup->toReferentialTuple(context) == formalT) {
-            // Supports code like:
-            //   proc foo(args...) do
-            //     bar(args);
-            //
-            // TODO: Should this register as a conversion?
-            return passAsIs();
-          } else if (formalQT.kind() == QualifiedType::TYPE &&
+          if (formalQT.kind() == QualifiedType::TYPE &&
                 actualTup->toValueTuple(context) == formalT) {
             return passAsIs();
           } else if (formalQT.kind() != QualifiedType::TYPE) {

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -1231,8 +1231,12 @@ MostSpecificCandidate::fromTypedFnSignature(ResolutionContext* rc,
     auto canPassFn =
       actualType.kind() == QualifiedType::INIT_RECEIVER ? canPassScalar
                                                         : canPass;
+    // An exception is made for the case where we have to convert a tuple to
+    // its referential equivalent, which doesn't count as coercion in the
+    // conventional Chapel sense.
     auto got = canPassFn(rc->context(), actualType, formalType);
-    if (got.converts() && formalType.kind() == QualifiedType::CONST_REF) {
+    if (got.converts() && formalType.kind() == QualifiedType::CONST_REF &&
+        got.conversionKind() != CanPassResult::TO_REFERENTIAL_TUPLE) {
       coercionFormal = fa.formalIdx();
       coercionActual = fa.actualIdx();
       break;

--- a/frontend/test/resolution/testTuples.cpp
+++ b/frontend/test/resolution/testTuples.cpp
@@ -1314,6 +1314,26 @@ static void test33() {
   guard.realizeErrors();
 }
 
+static void test34() {
+  printf("%s\n", __FUNCTION__);
+  Context ctx;
+  auto context = &ctx;
+  ErrorGuard guard(context);
+
+  std::string program =
+    R""""(
+    record R {}
+    proc foo(x) {}
+
+    var data: ((R,),);
+    foo(data);
+    )"""";
+
+  // Should resolve without error
+  auto mod = parseModule(context, program);
+  resolveModule(context, mod->id());
+}
+
 int main() {
   test1();
   test2();
@@ -1352,6 +1372,7 @@ int main() {
   test31();
   test32();
   test33();
+  test34();
 
   return 0;
 }


### PR DESCRIPTION
Allows passing a value tuple to a referential tuple formal, as per the spec. Previously this check was erroneously limited to varargs. Also moves the check into the more appropriate ``canConvertTuples`` and adds a ``TO_REFERENTIAL_TUPLE`` conversion kind.

While there, fixes an erroneous construction of a call to ``chpl__buildNDArrayExpr``. Previously we built a tuple of param values, which isn't technically representable in the Chapel type system today. Instead, build a tuple of integers.

Testing:
- [x] test-frontend
- [x] paratest ``--dyno-resolve-only`` on primers and spec