### PR TITLE
Add '-comp-only' to paratest

### DIFF
--- a/util/test/paratest.client
+++ b/util/test/paratest.client
@@ -13,6 +13,7 @@
 #  valgrind - run valgrind (0=no, 1=both compiler and executable, 2=executable only)
 #  memleaks    - check for memleaks (0=no, 1=yes)
 #  memleakslog - check for memleaks creating a log file (0=no, 1=yes)
+#  componly - pass '-comp-only' to start_test
 #  compopts - optional Chapel compiler options
 #  execopts - optional test execution options
 #
@@ -52,9 +53,9 @@ sub main {
     chomp $node;
     ($node) = split (/\./, $node);
 
-    if ($#ARGV < 7) {
+    if ($#ARGV < 8) {
         fatal("insufficient arguments: '@ARGV'\n" .
-	      "Usage:  paratest.client id chapeltestdir testdir chplenv futures-mode valgrind memleaks memleakslog [compopts [execopts]]");
+	      "Usage:  paratest.client id chapeltestdir testdir chplenv futures-mode valgrind memleaks memleakslog componly [compopts [execopts]]");
     }
 
     $id = $ARGV[0];
@@ -69,11 +70,11 @@ sub main {
     $valgrind = "-valgrindexe" if ($ARGV[5] == 2);
 
     print "$id $workingdir $testdir $futures_mode $valgrind" if $debug;
-    if ($#ARGV>=8) {
-        $compopts = "-compopts \"" . $ARGV[8] . "\"";
-    }
     if ($#ARGV>=9) {
-        $execopts = "-execopts \"" . $ARGV[9] . "\"";
+        $compopts = "-compopts \"" . $ARGV[9] . "\"";
+    }
+    if ($#ARGV>=10) {
+        $execopts = "-execopts \"" . $ARGV[10] . "\"";
     }
 
     $synchfile = "$synchdir/$node.$id";
@@ -106,7 +107,10 @@ sub main {
     $memleakslog = "";
     $memleakslog = "-memleakslog $logdir/tmp.$dirfname.$node.memleaks" if ($ARGV[7] == 1);
 
-    $testarg = "-compiler $compiler -logfile $logfile $futures_mode $valgrind $compopts $execopts $memleaks $memleakslog";
+    $componly = "";
+    $componly = "-comp-only" if ($ARGV[8] == 1);
+
+    $testarg = "-compiler $compiler -logfile $logfile $futures_mode $valgrind $compopts $execopts $memleaks $memleakslog $componly";
     $testarg = "$testarg $testdir -norecurse";
 
     # Set up the Chapel environment passed in by paratest.server

--- a/util/test/paratest.server
+++ b/util/test/paratest.server
@@ -52,6 +52,7 @@ $junit_xml = 0;
 $junit_xml_file = "";
 $junit_remove_prefix = "";
 $timing_file = "";
+$componly = 0;
 # Once a node has timed out, we don't send it any more work, so this timeout
 # should be set higher than the time needed to process the largest directory.
 # -1 means "never time out".
@@ -282,7 +283,7 @@ sub feed_nodes {
                       $execopts = "\\\"$execopts\\\"";
                   }
                   # If the command line gets too long, consider using xargs
-                  $rem_cmd = "$rem_exec_cmd $client_script $readyid $pwd $testdir $chplenv $futures_mode $valgrind $memleaksflag $memleakslog $compopts $execopts";
+                  $rem_cmd = "$rem_exec_cmd $client_script $readyid $pwd $testdir $chplenv $futures_mode $valgrind $memleaksflag $memleakslog $componly $compopts $execopts";
                   if ($verbose) {
                       systemd ($rem_cmd);
                   } else {
@@ -686,6 +687,8 @@ sub main {
                 print "missing -junit-remove-prefix arg\n";
                 exit (8);
             }
+        } elsif (/^-comp-only$/) {
+          $componly = 1;
         } elsif (/^-help$|^-h$/) {
             print_help;
             exit (9);


### PR DESCRIPTION
Making this change in support of dyno testing, in the cases where we cannot yet type-convert but want to test for error messages.