### PR TITLE
Motivators skipif adjustment

### DIFF
--- a/test/functions/fcf/pointers/Motivators.skipif
+++ b/test/functions/fcf/pointers/Motivators.skipif
@@ -3,7 +3,7 @@
 # Temporarily skip this test on Linux arm64
 
 if [[ $CHPL_TARGET_PLATFORM != darwin &&
-      $CHPL_TARGET_ARCH     == arm64 ]]; then
+      $CHPL_TARGET_ARCH     == aarch64 ]]; then
   echo True
 else
   echo False


### PR DESCRIPTION
This PR edits the `Motivators.skipif` file with the goal of having this test skipif-ed in the linux/aarch64 testing configuration.

This skipif was introduced in #27138 as an interim solution to suppress a compiler crash in that configuration. It did not fire in that configuration because `CHPL_TARGET_ARCH` has the value `aarch64`, according to the test logs.

Trivial, not reviewed.
