### PR TITLE
Fix documentation issue with exponentiation in the spec, pointed out by Damian

### DIFF
--- a/doc/rst/language/spec/expressions.rst
+++ b/doc/rst/language/spec/expressions.rst
@@ -503,15 +503,14 @@ precedence than those listed later.
    ordering is to allow these operators to be used as
    non-short-circuiting logical operations.
 
-   In contrast to C, we give bitwise operations a higher precedence than
-   binary addition/subtraction and comparison operators. This enables
-   using the shift operators as shorthand for multiplication/division by
-   powers of 2, and also makes it easier to extract and test a bitmapped
-   field:
+   In contrast to C, we give bitwise operations a higher precedence than binary
+   addition/subtraction and comparison operators. This enables shift operators
+   to be used as shorthand for multiplication/division of integers by powers of
+   2, and also makes it easier to extract and test a bitmapped field:
 
    ======================= == =====================
    ``(x & MASK) == MASK``  as ``x & MASK == MASK``
-   ``a + b * pow(2,y)``    as ``a * b << y``
+   ``a * b * 2 ** y``      as ``a * b << y``
    ======================= == =====================
 
    One final area of note is the precedence of reductions. Two common

--- a/doc/rst/language/spec/expressions.rst
+++ b/doc/rst/language/spec/expressions.rst
@@ -510,7 +510,7 @@ precedence than those listed later.
 
    ======================= == =====================
    ``(x & MASK) == MASK``  as ``x & MASK == MASK``
-   ``a * b * 2 ** y``      as ``a * b << y``
+   ``a + b * 2 ** y``      as ``a + b << y``
    ======================= == =====================
 
    One final area of note is the precedence of reductions. Two common


### PR DESCRIPTION
[reviewed by @mppf]

Resolves #27165 

Damian noticed that we were accidentally using a `*` operator in an example involving exponentiation, when we should have been using `+`.  He also pointed out that the documentation mentioned a `pow` function but that he was having trouble finding it - I think this is because the `**` operator used to be a function named `pow` a long time ago and we must have missed updating this portion of the spec when it became the `**` operator.

Rectify both of those errors, and use a wordsmithing change he suggested in the previous paragraph.  I also validated that the two code snippets being compared did give the same result now for at least one set of `a, b, y` values.