### PR TITLE
Pin nightly CHPL_GPU=amd perf testing to use rocm 6.2.0

### DIFF
--- a/util/cron/test-perf.gpu-ex-rocm.bash
+++ b/util/cron/test-perf.gpu-ex-rocm.bash
@@ -10,7 +10,9 @@ source $UTIL_CRON_DIR/common-native-gpu-perf.bash
 # CONFIG_NAME
 source $UTIL_CRON_DIR/common-perf.bash
 
-module load rocm # load the default version of ROCm
+# module load rocm # load the default version of ROCm
+# pin to rocm 6.2 for now, https://github.com/chapel-lang/chapel/issues/26934
+module load rocm/6.2.0
 
 export CHPL_COMM=none
 export CHPL_LLVM=bundled


### PR DESCRIPTION
Pins nightly perf testing for CHPL_GPU=amd to use rocm 6.20, since the default on the test system has changed and we do not yet support rocm 6.3.

[Reviewed by @vasslitvinov]