### PR TITLE
Fix unintentionally negated condition

### DIFF
--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -2814,7 +2814,7 @@ void FnSymbol::codegenDef() {
   info->cLocalDecls.clear();
 
   if( outfile ) {
-    if (saveCDir.empty()) {
+    if (!saveCDir.empty()) {
      if (const char* rawname = fname()) {
       zlineToFileIfNeeded(this, outfile);
       const char* name = strrchr(rawname, '/');


### PR DESCRIPTION
Fix an unintentionally negated guard against empty `saveCDir` when outputting line number comments in generated C.

The condition was changed in https://github.com/chapel-lang/chapel/pull/26357 from `strcmp(saveCDir, "")` to `saveCDir.empty()`, unintentionally flipping it. This caused a bug where line number comments were not emitted in generated C code.

Thanks @vasslitvinov for catching this.

Follow up to https://github.com/chapel-lang/chapel/pull/26357.

[reviewer info placeholder]