### PR TITLE
Add a github workflow to auto-create meeting topics

### DIFF
--- a/.github/workflows/meetings.yml
+++ b/.github/workflows/meetings.yml
@@ -6,9 +6,19 @@ on:
     - cron: '0 18 * * 2' # Runs every week on Tuesday at 11 PT
 
 jobs:
-  check-and-update:
+  create-discussion:
+    name: Create Weekly Discussion
+
     if: github.repository == 'chapel-lang/chapel'
+    permissions:
+      discussions: write
+      contents: read
     runs-on: ubuntu-latest
+
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      owner: "chapel-lang"
+      repo_name: "chapel"
 
     steps:
     - name: compute date
@@ -18,32 +28,56 @@ jobs:
         echo "next_meeting_date=$date" >> $GITHUB_ENV
       shell: bash
 
-    - name: create pull request
-      run: >
-        gh api
-          --method POST
-          -H "Accept: application/vnd.github+json"
-          -H "X-GitHub-Api-Version: 2022-11-28"
-          /orgs/chapel-lang/teams/chapel/discussions
-          -f "title=Chapel project meeting: agenda items for ${{ env.next_meeting_date }}" -f "body='${{ env.agenda_body }}'"
+    - name: create discussion
+      run: |
+        repositoryId=$(gh api graphql \
+          -f query='{ repository(owner: "${{ env.owner }}",
+                      name: "${{ env.repo_name }}") { id } }' \
+          | jq -r '.data.repository.id')
+
+        categoryId=$(gh api graphql \
+          -f query='{ repository(owner: "${{ env.owner }}",
+                      name: "${{ env.repo_name }}")
+                      { discussionCategories(first: 10) { nodes { id, name} } } }' \
+          | jq -r '.data.repository.discussionCategories.nodes | .[] | select(.name=="${{ env.category_name }}") | .id')
+
+        body="${{ env.agenda_body }}"
+        title="Chapel project meeting: agenda items for ${{ env.next_meeting_date }}"
+
+        QUERY='mutation($repositoryId: ID!, $categoryId: ID!, $title: String!, $body: String!) {
+          createDiscussion(input: {
+            repositoryId: $repositoryId,
+            categoryId: $categoryId,
+            title: $title,
+            body: $body
+          }) {
+            discussion {
+              id
+            }
+          }
+        }'
+        gh api graphql \
+          -f repositoryId="$repositoryId" \
+          -f categoryId="$categoryId" \
+          -f title="$title" \
+          -f body="$body" \
+          -f query="$QUERY"
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           next_meeting_date: ${{ env.next_meeting_date }}
+          owner: ${{ env.owner }}
+          repo_name: ${{ env.repo_name }}
+          category_name: "Weekly meeting topics"
           agenda_body: |
             This discussion is intended as a place for Chapel community members to propose agenda items for the weekly Chapel meeting on ${{ env.next_meeting_date }}.  Potential categories for items include:
-
             * **News:** Quick updates or announcements to keep people in the loop on key efforts or topics
             * **Demos:** Have something cool to show off?  Do it in a ~5-minute demo
             * **Short Topics:** Have something that needs a quick discussion, description, or straw poll?  Propose a ~5-minute discussion topic
             * **Longer Topics:** Have a more detailed topic you'd like us to try to cover?  Propose the topic and how much time you think it will require and we'll try to fit it in.
-
             If you'd like to propose an item in any of these categories, please reply to this discussion.
-
             In addition to the above sections, we have some standing agenda items, such as:
             * **Triage:** What is the state of testing and are there issues that need more attention?
             * **User Issues:** What new user issues have come up in the past week, and which should we prioritize?
             * **Q&A:** Have something you want to ask, but don't think is worth everyone's time?  We'll open the floor to questions as the official meeting wraps up.
             * …  **[your idea here]** …
-
             To join the meeting, use [this link](https://teams.microsoft.com/l/meetup-join/19%3ameeting_N2M5M2E2NTEtNTFkMi00ZjA1LThiNDQtMjFjY2U2ZDc5ODk3%40thread.v2/0?context=%7b%22Tid%22%3a%22105b2061-b669-4b31-92ac-24d304d195dc%22%2c%22Oid%22%3a%22bef28eea-6179-4f21-b284-84c6a0aeacc3%22%7d)
-

--- a/.github/workflows/meetings.yml
+++ b/.github/workflows/meetings.yml
@@ -1,0 +1,49 @@
+name: Weekly Meeting Topics
+
+on:
+  workflow_dispatch: # Allows manual triggering of the workflow
+  schedule:
+    - cron: '0 18 * * 2' # Runs every week on Tuesday at 11 PT
+
+jobs:
+  check-and-update:
+    if: github.repository == 'chapel-lang/chapel'
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: compute date
+      id: date
+      run: |
+        date=$(date -d '+7 days' '+%Y-%m-%d')
+        echo "next_meeting_date=$date" >> $GITHUB_ENV
+      shell: bash
+
+    - name: create pull request
+      run: >
+        gh api
+          --method POST
+          -H "Accept: application/vnd.github+json"
+          -H "X-GitHub-Api-Version: 2022-11-28"
+          /orgs/chapel-lang/teams/chapel/discussions
+          -f "title=Chapel project meeting: agenda items for ${{ env.next_meeting_date }}" -f "body='${{ env.agenda_body }}'"
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          next_meeting_date: ${{ env.next_meeting_date }}
+          agenda_body: |
+            This discussion is intended as a place for Chapel community members to propose agenda items for the weekly Chapel meeting on ${{ env.next_meeting_date }}.  Potential categories for items include:
+
+            * **News:** Quick updates or announcements to keep people in the loop on key efforts or topics
+            * **Demos:** Have something cool to show off?  Do it in a ~5-minute demo
+            * **Short Topics:** Have something that needs a quick discussion, description, or straw poll?  Propose a ~5-minute discussion topic
+            * **Longer Topics:** Have a more detailed topic you'd like us to try to cover?  Propose the topic and how much time you think it will require and we'll try to fit it in.
+
+            If you'd like to propose an item in any of these categories, please reply to this discussion.
+
+            In addition to the above sections, we have some standing agenda items, such as:
+            * **Triage:** What is the state of testing and are there issues that need more attention?
+            * **User Issues:** What new user issues have come up in the past week, and which should we prioritize?
+            * **Q&A:** Have something you want to ask, but don't think is worth everyone's time?  We'll open the floor to questions as the official meeting wraps up.
+            * …  **[your idea here]** …
+
+            To join the meeting, use [this link](https://teams.microsoft.com/l/meetup-join/19%3ameeting_N2M5M2E2NTEtNTFkMi00ZjA1LThiNDQtMjFjY2U2ZDc5ODk3%40thread.v2/0?context=%7b%22Tid%22%3a%22105b2061-b669-4b31-92ac-24d304d195dc%22%2c%22Oid%22%3a%22bef28eea-6179-4f21-b284-84c6a0aeacc3%22%7d)
+


### PR DESCRIPTION
Adds a github workflow to auto-create meeting topics for the public chapel meetings

Resolves https://github.com/chapel-lang/chapel/issues/27143

Tested in a private repo

[Reviewed by @arezaii]