### PR TITLE
Improve error messages when the ROCm version is unsupported

### DIFF
--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -554,7 +554,7 @@ def _validate_rocm_version_impl():
 
     if not is_ver_in_range(rocm_version, MIN_REQ_VERSION, MAX_REQ_VERSION) and not is_ver_in_range(rocm_version, MIN_ROCM6_REQ_VERSION, MAX_ROCM6_REQ_VERSION):
         _reportMissingGpuReq(
-            "Chapel requires ROCm versions %s to %s or %s and %s, "
+            "Chapel requires ROCm versions %s to %s or %s to %s, "
             "detected version %s on system." %
             (MIN_REQ_VERSION, MAX_REQ_VERSION_NICE, MIN_ROCM6_REQ_VERSION, MAX_ROCM6_REQ_VERSION_NICE, rocm_version))
         return False

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -539,9 +539,12 @@ def _validate_rocm_version_impl():
     """Check that the installed ROCM version is >= MIN_REQ_VERSION and <
        MAX_REQ_VERSION"""
     MIN_REQ_VERSION = "5.0"
-    MAX_REQ_VERSION = "5.5"
+    MAX_REQ_VERSION = "5.5" # upper bound non-inclusive
+    MAX_REQ_VERSION_NICE = "5.4.x"
+
     MIN_ROCM6_REQ_VERSION = "6"
-    MAX_ROCM6_REQ_VERSION = "6.3"
+    MAX_ROCM6_REQ_VERSION = "6.3" # upper bound non-inclusive
+    MAX_ROCM6_REQ_VERSION_NICE = "6.2.x"
 
     rocm_version = get_sdk_version()
 
@@ -551,9 +554,9 @@ def _validate_rocm_version_impl():
 
     if not is_ver_in_range(rocm_version, MIN_REQ_VERSION, MAX_REQ_VERSION) and not is_ver_in_range(rocm_version, MIN_ROCM6_REQ_VERSION, MAX_ROCM6_REQ_VERSION):
         _reportMissingGpuReq(
-            "Chapel requires ROCm to be a version between %s and %s or between %s and %s, "
+            "Chapel requires ROCm versions %s to %s or %s and %s, "
             "detected version %s on system." %
-            (MIN_REQ_VERSION, MAX_REQ_VERSION, MIN_ROCM6_REQ_VERSION, MAX_ROCM6_REQ_VERSION, rocm_version))
+            (MIN_REQ_VERSION, MAX_REQ_VERSION_NICE, MIN_ROCM6_REQ_VERSION, MAX_ROCM6_REQ_VERSION_NICE, rocm_version))
         return False
 
     return True

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -542,7 +542,7 @@ def _validate_rocm_version_impl():
     MAX_REQ_VERSION = "5.5" # upper bound non-inclusive
     MAX_REQ_VERSION_NICE = "5.4.x"
 
-    MIN_ROCM6_REQ_VERSION = "6"
+    MIN_ROCM6_REQ_VERSION = "6.0"
     MAX_ROCM6_REQ_VERSION = "6.3" # upper bound non-inclusive
     MAX_ROCM6_REQ_VERSION_NICE = "6.2.x"
 


### PR DESCRIPTION
Improves the error message about supported ROCm versions to avoid ambiguity.

Before: `Chapel requires ROCm to be a version between 5.0 and 5.5 or between 6 and 6.3, detected version 6.3.0 on system.`
After: `Error: Chapel requires ROCm versions 5.0 to 5.4.x or 6.0 to 6.2.x, detected version 6.3.0 on system.`

Tested with various ROCm versions

[Reviewed by @vasslitvinov]