### PR TITLE
Rename PyArray.these to PyArray.values

### DIFF
--- a/modules/packages/Python.chpl
+++ b/modules/packages/Python.chpl
@@ -3329,6 +3329,26 @@ module Python {
         "index must be a single int (for 1D arrays only) " +
         "or a tuple of ints");
 
+    //
+    // TODO: these are meant to prevent users from calling .these on a PyArray
+    // when they probaby wanted .values. But the mere presence of these as
+    // compiler errors prevents the any program using Value.these from
+    // compiling. And we can't just make them throw instead because inheritance
+    // prevents iterator inlining, which is not yet supported
+    //
+    // @chpldoc.nodoc
+    // override iter these(type eltType): eltType throws {
+    //   compilerError(
+    //     "Calling '.these(eltType)' on a PyArray is not supported."
+    //     + " Use '.values(eltType)' instead.");
+    // }
+    // @chpldoc.nodoc
+    // override iter these(): owned Value throws {
+    //   compilerError(
+    //     "Calling '.these()' on a PyArray is not supported."
+    //     + " Use '.values()' instead.");
+    // }
+
     /*
       Iterate over the elements of the Python array. This results in a Chapel
       iterator that yields the elements of the Python array. This yields
@@ -3339,12 +3359,12 @@ module Python {
       ``PyArray`` object, it does not need to be specified here.
     */
     pragma "docs only"
-    override iter these(type eltType = this.eltType) ref : eltType throws {
+    iter values(type eltType = this.eltType) ref : eltType throws {
       compilerError("docs only");
     }
 
     @chpldoc.nodoc
-    override iter these(type eltType) ref : eltType throws {
+    iter values(type eltType) ref : eltType throws {
       if eltType == nothing then
         compilerError("Element type must be specified at compile time");
 
@@ -3361,12 +3381,12 @@ module Python {
       }
     }
     @chpldoc.nodoc
-    override iter these() ref : eltType throws {
-      for e in these(eltType=this.eltType) do yield e;
+    iter values() ref : eltType throws {
+      for e in values(eltType=this.eltType) do yield e;
     }
     // TODO: it should also be possible to support leader/follower here
     @chpldoc.nodoc
-    iter these(param tag: iterKind, type eltType) ref : eltType throws
+    iter values(param tag: iterKind, type eltType) ref : eltType throws
      where tag == iterKind.standalone {
       if eltType == nothing then
         compilerError("Element type must be specified at compile time");
@@ -3384,9 +3404,9 @@ module Python {
       }
     }
     @chpldoc.nodoc
-    iter these(param tag: iterKind) ref : eltType throws
+    iter values(param tag: iterKind) ref : eltType throws
     where tag == iterKind.standalone do
-      foreach e in these(tag=tag, eltType=this.eltType) do yield e;
+      foreach e in values(tag=tag, eltType=this.eltType) do yield e;
 
     /*
       Get the Chapel array from the Python array. This results in a Chapel view

--- a/test/library/packages/Python/correctness/arrays/iteration.chpl
+++ b/test/library/packages/Python/correctness/arrays/iteration.chpl
@@ -1,0 +1,49 @@
+use Python, CTypes;
+
+var interp = new Interpreter();
+
+// use all 1's so we don't have to deal with different printing orders
+var lst = interp.get('list')([1, 1, 1]);
+var arr = interp.importModule('array')
+                .get('array')(owned PyArray(c_int, 1), 'i', lst);
+
+writeln("list:");
+for i in lst {
+  writeln(i);
+}
+
+writeln("array.values (default, for):");
+for i in arr.values() {
+  writeln(i);
+}
+writeln("array.values (default, foreach):");
+foreach i in arr.values() {
+  writeln(i);
+}
+writeln("array.values (default, forall):");
+forall i in arr.values() {
+  writeln(i);
+}
+
+writeln("array.values (eltType, for):");
+for i in arr.values(c_int) {
+  writeln(i);
+}
+writeln("array.values (eltType, foreach):");
+foreach i in arr.values(c_int) {
+  writeln(i);
+}
+writeln("array.values (eltType, forall):");
+forall i in arr.values(c_int) {
+  writeln(i);
+}
+
+// TODO: maybe in the future these will not work
+writeln("array.these (default, for):");
+for i in arr {
+  writeln(i);
+}
+writeln("array.these (eltType, for):");
+for i in arr.these(c_int) {
+  writeln(i);
+}

--- a/test/library/packages/Python/correctness/arrays/iteration.good
+++ b/test/library/packages/Python/correctness/arrays/iteration.good
@@ -1,0 +1,36 @@
+list:
+1
+1
+1
+array.values (default, for):
+1
+1
+1
+array.values (default, foreach):
+1
+1
+1
+array.values (default, forall):
+1
+1
+1
+array.values (eltType, for):
+1
+1
+1
+array.values (eltType, foreach):
+1
+1
+1
+array.values (eltType, forall):
+1
+1
+1
+array.these (default, for):
+1
+1
+1
+array.these (eltType, for):
+1
+1
+1

--- a/test/library/packages/Python/correctness/arrays/ndArray.chpl
+++ b/test/library/packages/Python/correctness/arrays/ndArray.chpl
@@ -79,11 +79,11 @@ proc testArray(type eltType, shape) {
     for param i in 0..#rank do idx[i] = 1;
     writeln("pyArr_genericPyArr.this(",idx,"): ",
       pyArr_genericPyArr[eltType, idx]);
-    for e in pyArr_genericPyArr.these(eltType) {
+    for e in pyArr_genericPyArr.values(eltType) {
       writeln("element: ", e);
     }
     var sum = 0:(if eltType == bool then int else eltType);
-    forall e in pyArr_genericPyArr.these(eltType) with (+ reduce sum) {
+    forall e in pyArr_genericPyArr.values(eltType) with (+ reduce sum) {
       sum reduce= e;
     }
     writeln("sum: ", sum:eltType);
@@ -102,11 +102,11 @@ proc testArray(type eltType, shape) {
     var idx: rank*int;
     writeln("pyArr_typeSpecified.this(",idx,"): ",
       pyArr_typeSpecified[idx]);
-    for e in pyArr_typeSpecified {
+    for e in pyArr_typeSpecified.values() {
       writeln("element: ", e);
     }
     var sum = 0:(if eltType == bool then int else eltType);
-    forall e in pyArr_typeSpecified with (+ reduce sum) {
+    forall e in pyArr_typeSpecified.values() with (+ reduce sum) {
       sum reduce= e;
     }
     writeln("sum: ", sum:eltType);
@@ -126,11 +126,11 @@ proc testArray(type eltType, shape) {
     for param i in 0..#rank do idx[i] = shape(i)-1;
     writeln("pyArr_rankSpecified.this(",idx,"): ",
       pyArr_rankSpecified[eltType, idx]);
-    for e in pyArr_rankSpecified.these(eltType) {
+    for e in pyArr_rankSpecified.values(eltType) {
       writeln("element: ", e);
     }
     var sum = 0:(if eltType == bool then int else eltType);
-    forall e in pyArr_rankSpecified.these(eltType) with (+ reduce sum) {
+    forall e in pyArr_rankSpecified.values(eltType) with (+ reduce sum) {
       sum reduce= e;
     }
     writeln("sum: ", sum:eltType);
@@ -149,11 +149,11 @@ proc testArray(type eltType, shape) {
     var idx: rank*int;
     writeln("pyArr_fullySpecified.this(",idx,"): ",
       pyArr_fullySpecified[idx]);
-    for e in pyArr_fullySpecified {
+    for e in pyArr_fullySpecified.values() {
       writeln("element: ", e);
     }
     var sum = 0:(if eltType == bool then int else eltType);
-    forall e in pyArr_fullySpecified with (+ reduce sum) {
+    forall e in pyArr_fullySpecified.values() with (+ reduce sum) {
       sum reduce= e;
     }
     writeln("sum: ", sum:eltType);
@@ -194,12 +194,12 @@ proc testArray(type eltType, shape) {
       writeln("pyArr_fullySpecified.this(1): ", pyArr_fullySpecified.this(1));
     }
 
-    for e in pyArr_fullySpecified {
+    for e in pyArr_fullySpecified.values() {
       writeln("element: ", e);
       e = 0:eltType;
     }
     writeln("pyArr_fullySpecified: ", pyArr_fullySpecified);
-    forall e in pyArr_fullySpecified {
+    forall e in pyArr_fullySpecified.values() {
       e = 1:eltType;
     }
     writeln("pyArr_fullySpecified: ", pyArr_fullySpecified);


### PR DESCRIPTION
Renames PyArray.these to a standalone PyArray.values. 

This is not the ideal API, but there are many challenges with inheritance+generics+iterators+exceptions. These issues result in https://github.com/chapel-lang/chapel/issues/27083, which is a frustrating bug. To avoid this also being a frustrating bug for users, this PR sidesteps many of the problems presented in that issue by just renaming `.these` to `.values`.

Note: this PR just renames the iterator (rather than using a deprecation), since none of this code has been released yet

Resolves #27083

- [x] `start_test test/library/packages/Python/` with GASNet and Python 3.13 on MacOS

[Reviewed by @]