### PR TITLE
Add FooLibrary.notest

### DIFF
--- a/test/interop/C/cmakelists/targetToLibToChpl/FooLibrary.notest
+++ b/test/interop/C/cmakelists/targetToLibToChpl/FooLibrary.notest
@@ -1,0 +1,1 @@
+Temporary skip this test because it is failing in the standard configuration.


### PR DESCRIPTION
Do not test test/interop/C/cmakelists/targetToLibToChpl/FooLibrary.chpl because it fails for me in the standard configuration due to #27173

Not reviewed. This is a temporary measure to avoid the potential impact on nightly testing. To be reverted once this test passes again.
