### PR TITLE
Use the correct library suffix for `--library --dynamic`

### DIFF
--- a/compiler/codegen/library.cpp
+++ b/compiler/codegen/library.cpp
@@ -403,8 +403,10 @@ void codegen_library_cmakelists() {
 
 const char* getLibraryExtension() {
   if (fLibraryCompile) {
-    if (fLinkStyle==LS_DYNAMIC) return ".so";
-    else return ".a";
+    if (fLinkStyle==LS_DYNAMIC)
+      return !strcmp(CHPL_TARGET_PLATFORM, "darwin") ? ".dylib" : ".so";
+    else
+      return ".a";
   }
   return "";
 }


### PR DESCRIPTION
Switches the suffix for `--library --dynamic` to be `.dylib` on MacOS.

- [x] `start_test test/interop/C/makefiles/dynamicLinking/`

[Reviewed by @lydia-duncan]