### PR TITLE
Adjust a compiler comment to be accurate with the code

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2896,7 +2896,8 @@ static void helpComputeClangArgs(std::string& clangCC,
     addFilteredArgs(clangCCArgs, args);
   }
 
-  // add a -I. so we can find headers named on command line in same dir
+  // add a -iquote. so we can find headers named on command line in same dir
+  // using iquote over I to prevent accidently overriding system headers
   clangCCArgs.push_back("-iquote.");
 
   // add a -I for the generated code directory


### PR DESCRIPTION
Adjusts a comment in the compiler about the usage of `-iquote`

This is cleanup from https://github.com/chapel-lang/chapel/pull/27173

[Not reviewed - trivial comment only change]