### PR TITLE
Reduce the number of times `--verify` runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ all: comprt
 	@test -r Makefile.devel && $(MAKE) develall || echo ""
 
 comprt: FORCE
+	@$(MAKE) chplenv-verify
 	@$(MAKE) compiler
 	@$(MAKE) third-party-try-opt
 	@$(MAKE) always-build-test-venv
@@ -70,6 +71,7 @@ comprt: FORCE
 	@$(MAKE) runtime
 	@$(MAKE) modules
 	@$(MAKE) chpl-cmake-module-files
+	@$(MAKE) chplenv-verify
 
 notcompiler: FORCE
 	@$(MAKE) third-party-try-opt
@@ -230,6 +232,11 @@ compile-util-python: FORCE
 	  fi ; \
 	else \
 	  echo "Not compiling Python scripts - missing compileall" ; \
+	fi
+
+chplenv-verify: FORCE
+	-@if [ -z "$$CHPLENV_SKIP_VERIFY" ]; then \
+	$(CHPL_MAKE_ALL_VARS) $(CHPL_MAKE_HOME)/util/printchplenv --verify >/dev/null ; \
 	fi
 
 clean: FORCE

--- a/make/Makefile.base
+++ b/make/Makefile.base
@@ -81,7 +81,7 @@ ifndef CHPL_MAKE_CHPLENV_CACHE
 # Evaluate all of the definitions in CHPL_MAKE_ALL_VARS before running
 # printchplenv in order to pass the existing values from the compiler forward
 
-export CHPL_MAKE_CHPLENV_CACHE := $(shell $(CHPL_MAKE_ALL_VARS) $(CHPL_MAKE_HOME)/util/printchplenv --all --internal --no-tidy --make --verify | tr '\n' '|')
+export CHPL_MAKE_CHPLENV_CACHE := $(shell $(CHPL_MAKE_ALL_VARS) $(CHPL_MAKE_HOME)/util/printchplenv --all --internal --no-tidy --make | tr '\n' '|')
 endif
 
 # This really needs TWO newlines!


### PR DESCRIPTION
Reduces the number of times `printchplenv --verify` runs. It was found to be significantly slowing down builds because it was being invoked too often (caused by reinvoking `make` many times).

It also adds a developer-only `CHPLENV_SKIP_VERIFY` environment variable to skip these checks all-together.

[Reviewed by @DanilaFe]