### PR TITLE
Don't set `--gcc-install-dir` on darwin and freebsd

### DIFF
--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -760,6 +760,11 @@ def is_gcc_install_dir_supported():
 def get_gcc_install_dir():
     gcc_dir = overrides.get('CHPL_LLVM_GCC_INSTALL_DIR', '')
 
+    # darwin and FreeBSD default to clang, so shouldn't need GCC toolchain
+    host_platform = chpl_platform.get('host')
+    if host_platform == "darwin" or host_platform == "freebsd":
+        return gcc_dir
+
     flag_supported = is_gcc_install_dir_supported()
 
     if gcc_dir:


### PR DESCRIPTION
Avoid passing the `--gcc-install-dir` Clang argument on Darwin and FreeBSD systems, where it is not needed and can issue unused argument warnings.

This change mirrors what we do for `--gcc-toolchain` as of https://github.com/chapel-lang/chapel/pull/18820. As in that case it can be overridden by the user with an environment variable.

This was causing failures in FreeBSD portability testing on `main`, and has been since the 2.4 release (but not 2.3). I suspect this began with either https://github.com/chapel-lang/chapel/pull/26429 or the release of a new LLVM version making it to FreeBSD repos, but haven't confirmed either way.

While we aren't hitting any fatal issues on Darwin (and don't do explicit, warnings-are-fatal testing there), I think this is justified as it is also a system where GCC is default and this argument is unneeded.

[reviewer info placeholder]

Testing:
- [x] passes FreeBSD portability tests
- [x] `make check` succeeds on my mac