### PR TITLE
Update new test to take array as `const *`

### DIFF
--- a/test/extern/passArrays/printArr.h
+++ b/test/extern/passArrays/printArr.h
@@ -1,4 +1,4 @@
-static void printfArr(double* arr, int* size) {
+static void printfArr(const double* arr, int* size) {
   for (int i = 0; i<*size; i++) {
     printf("%lf ", arr[i]);
   }


### PR DESCRIPTION
This will fix the regressions that #27182 introduced in tests of the C back-end.  Sorry for the noise—I fear it is still going to take me several years to remember that arrays are no longer passed by 'ref' by default...  :(
