### PR TITLE
Rename `gdbShouldBreakHere` to `debuggerBreakHere` in the runtime

### DIFF
--- a/runtime/include/gdb.h
+++ b/runtime/include/gdb.h
@@ -27,7 +27,7 @@
 extern "C" {
 #endif
 
-void gdbShouldBreakHere(void);  // must be in separate file to avoid elimination
+void debuggerBreakHere(void);  // must be in separate file to avoid elimination
 
 inline static void chpl_debugtrap(void) {
   #ifdef __has_builtin

--- a/runtime/src/chplexit.c
+++ b/runtime/src/chplexit.c
@@ -35,7 +35,7 @@ static void chpl_exit_common(int status, int all) {
   fflush(stdout);
   fflush(stderr);
   if (status != 0) {
-    gdbShouldBreakHere();
+    debuggerBreakHere();
   }
   chpl_finalize(status, all);
   exit(status);

--- a/runtime/src/comm/none/comm-none.c
+++ b/runtime/src/comm/none/comm-none.c
@@ -123,7 +123,7 @@ void chpl_comm_post_mem_init(void) { }
 
 int chpl_comm_run_in_gdb(int argc, char* argv[], int gdbArgnum, int* status) {
   int i;
-  char* command = chpl_glom_strings(2, "gdb -q -ex 'break gdbShouldBreakHere' --args ",
+  char* command = chpl_glom_strings(2, "gdb -q -ex 'break debuggerBreakHere' --args ",
                                     argv[0]);
   for (i=1; i<argc; i++) {
     if (i != gdbArgnum) {
@@ -137,7 +137,7 @@ int chpl_comm_run_in_gdb(int argc, char* argv[], int gdbArgnum, int* status) {
 
 int chpl_comm_run_in_lldb(int argc, char* argv[], int lldbArgnum, int* status) {
   int i;
-  char* command = chpl_glom_strings(2, "lldb -o 'b gdbShouldBreakHere' -- ",
+  char* command = chpl_glom_strings(2, "lldb -o 'b debuggerBreakHere' -- ",
                                     argv[0]);
   for (i=1; i<argc; i++) {
     if (i != lldbArgnum) {

--- a/runtime/src/gdb.c
+++ b/runtime/src/gdb.c
@@ -25,4 +25,4 @@
 #include <stdio.h>
 
 
-void gdbShouldBreakHere(void) {printf("%s", "");}
+void debuggerBreakHere(void) {printf("%s", "");}

--- a/test/execflags/lldbddash/declint.prediff
+++ b/test/execflags/lldbddash/declint.prediff
@@ -8,7 +8,7 @@ tmpfile=$outfile.raw.tmp
 # some lldbs print out extra stuff.  This filters it out
 #
 mv $outfile $tmpfile
-grep -v "Breakpoint 1: where" $tmpfile | grep -v "target create" | grep -v "Current executable set to" | grep -v "b gdbShouldBreakHere" > $outfile
+grep -v "Breakpoint 1: where" $tmpfile | grep -v "target create" | grep -v "Current executable set to" | grep -v "b debuggerBreakHere" > $outfile
 # Also filter out line about memleaks arguments to executable
 mv $outfile $tmpfile
 grep -v 'settings set -- target.run-args  "--memLeaks"' $tmpfile > $outfile

--- a/test/types/records/ferguson/tracking/Tracking.chpl
+++ b/test/types/records/ferguson/tracking/Tracking.chpl
@@ -56,8 +56,8 @@ proc trackAllocation(c: RootClass, id:int, x:int) {
   opsLock.readFE();
   ops.pushBack( (1, c:unmanaged, id, x, 1+counter.fetchAdd(1)) );
   if id == breakOnAllocateId {
-    extern proc gdbShouldBreakHere();
-    gdbShouldBreakHere();
+    extern proc debuggerBreakHere();
+    debuggerBreakHere();
   }
   opsLock.writeEF(true);
 }


### PR DESCRIPTION
Renames `gdbShouldBreakHere` to `debuggerBreakHere` in the runtime. This is so we use a debugger agnostic term as the function can be used with other debuggers (e.g. lldb)

- [ ] standard linux64 paratest

[Reviewed by @]