### PR TITLE
Dyno: enable module scope checks

### DIFF
--- a/frontend/lib/resolution/InitResolver.cpp
+++ b/frontend/lib/resolution/InitResolver.cpp
@@ -92,7 +92,7 @@ bool InitResolver::setupFromType(const Type* type) {
   }
 
   auto ct = type->getCompositeType();
-  auto& rf = fieldsForTypeDecl(initResolver_.rc, ct, DefaultsPolicy::USE_DEFAULTS);
+  auto& rf = fieldsForTypeDecl(initResolver_.rc, ct, DefaultsPolicy::IGNORE_DEFAULTS);
 
   // If any of the newly-set fields are type or params, setting them
   // effectively means the receiver is a different type.
@@ -158,15 +158,7 @@ void InitResolver::doSetupInitialState(void) {
   phase_ = isCallToSuperInitRequired() ? PHASE_NEED_SUPER_INIT
                                        : PHASE_NEED_COMPLETE;
 
-  // when initializing, don't insert substitutions into the fields. The user
-  // ought to explicitly set fields that need instantiations, unless they
-  // have defaults, but we'll figure those out later.
   const Type* setupFrom = initialRecvType_;
-  if (auto initialCt = initialRecvType_->toCompositeType()) {
-    if (auto initialCtInst = initialCt->instantiatedFromCompositeType()) {
-      setupFrom = initialCtInst;
-    }
-  }
   std::ignore = setupFromType(setupFrom);
 }
 

--- a/frontend/lib/resolution/Resolver.h
+++ b/frontend/lib/resolution/Resolver.h
@@ -602,7 +602,7 @@ struct Resolver : BranchSensitiveVisitor<DefaultFrame> {
   // handles setting types of variables for split init with 'out' formals
   void adjustTypesForOutFormals(const CallInfo& ci,
                                 const std::vector<const uast::AstNode*>& asts,
-                                const MostSpecificCandidates& fns);
+                                const CallResolutionResult& crr);
 
   // helper for resolveTupleDecl
   // e.g. var (a, b) = mytuple

--- a/frontend/lib/resolution/VarScopeVisitor.h
+++ b/frontend/lib/resolution/VarScopeVisitor.h
@@ -80,11 +80,13 @@ class VarScopeVisitor : public BranchSensitiveVisitor<VarFrame, MutatingResolved
   virtual void handleInFormal(const uast::FnCall* ast,
                               const uast::AstNode* actual,
                               const types::QualifiedType& formalType,
+                              const types::QualifiedType* actualScalarType,
                               RV& rv) = 0;
   /** Called for an actual passed to an 'out' formal */
   virtual void handleInoutFormal(const uast::FnCall* ast,
                                  const uast::AstNode* actual,
                                  const types::QualifiedType& formalType,
+                                 const types::QualifiedType* actualScalarType,
                                  RV& rv) = 0;
 
   /** Called for a 'return' */
@@ -302,7 +304,9 @@ computeActualFormalIntents(Context* context,
                            const CallInfo& ci,
                            const std::vector<const AstNode*>& actualAsts,
                            std::vector<uast::Qualifier>& actualFrmlIntents,
-                           std::vector<types::QualifiedType>& actualFrmlTypes);
+                           std::vector<types::QualifiedType>& actualFrmlTypes,
+                           std::vector<bool>& actualWasPromoted,
+                           const types::PromotionIteratorType* promoCtx);
 
 } // end namespace resolution
 

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -827,7 +827,9 @@ void CallInitDeinit::processInit(VarFrame* frame,
     rhsAst = r->value();
   } else if (auto y = ast->toYield()) {
     rhsAst = y->value();
-  } else {
+  }
+
+  if (rhsAst == nullptr) {
     rhsAst = ast;
   }
 

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -1290,16 +1290,9 @@ void callInitDeinit(Resolver& resolver) {
     symName = nd->name();
   }
 
-  // TODO: Run this for module initializer code as well. Currently if enabled,
-  // it breaks a large number of dyno tests that have module-initializer code
-  // containing things we can't resolve default-init for yet, such as
-  // fully-defaulted generic types. Either adjust the tests to expect the errors
-  // for unsupported code, or add the support, then enable this on modules.
-  if (!resolver.symbol->isModule()) {
-    CallInitDeinit uv(resolver.context, resolver,
-                      splitInitedVars, elidedCopyFromIds);
-    uv.process(resolver.symbol, resolver.byPostorder);
-  }
+  CallInitDeinit uv(resolver.context, resolver,
+                    splitInitedVars, elidedCopyFromIds);
+  uv.process(resolver.symbol, resolver.byPostorder);
 }
 
 

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -405,10 +405,9 @@ const BuilderResult& buildInitializer(Context* context, ID typeID) {
   auto builder = bld.get();
   auto dummyLoc = parsing::locateId(context, typeID);
 
-  auto thisType = Identifier::build(builder, dummyLoc, typeDecl->name());
   auto thisFormal = Formal::build(builder, dummyLoc, nullptr,
                                   USTR("this"), Formal::DEFAULT_INTENT,
-                                  std::move(thisType), nullptr);
+                                  nullptr, nullptr);
 
   AstList formals;
   AstList stmts;
@@ -823,10 +822,9 @@ const BuilderResult& buildDeinit(Context* context, ID typeID) {
   auto builder = bld.get();
   auto dummyLoc = parsing::locateId(context, typeID);
 
-  auto thisType = Identifier::build(builder, dummyLoc, typeID.symbolName(context));
   auto thisFormal = Formal::build(builder, dummyLoc, nullptr,
                                   USTR("this"), Formal::DEFAULT_INTENT,
-                                  std::move(thisType), nullptr);
+                                  nullptr, nullptr);
 
   AstList formals;
 

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -207,7 +207,7 @@ static GeneratorType generatorForCompilerGeneratedRecordOperator(UniqueString na
     return generateRecordCompareGtSignature;
   } else if (name == USTR(">=")) {
     return generateRecordCompareGeSignature;
-  } else if (name == USTR("init")) {
+  } else if (name == USTR("init=")) {
     return generateInitCopySignature;
   } else if (name == USTR("=")) {
     return generateRecordAssignment;

--- a/frontend/lib/resolution/split-init.cpp
+++ b/frontend/lib/resolution/split-init.cpp
@@ -514,14 +514,18 @@ void FindSplitInits::propagateChildToParent(VarFrame* frame, VarFrame* parent, c
   } else {
     // some kind of scope that does not allow split init
     // (e.g., a loop)
-    if (parent != nullptr) {
-      // propagate initedVars and mentionedVars
-      // to mentionedVars in the parent
-      for (const auto& id : frame->initedVars) {
-        if (frame->eligibleVars.count(id) == 0) {
-          parent->mentionedVars.insert(id);
-        }
+    // propagate initedVars and mentionedVars
+    // to mentionedVars in the parent, and to global result if they are split-
+    // inited here.
+    for (const auto& [id, qt] : frame->initedVarsVec) {
+      if (frame->eligibleVars.count(id) == 0) {
+        if (parent) parent->mentionedVars.insert(id);
+      } else {
+        // variable declared in this scope, so save the result
+        allSplitInitedVars.insert(id);
       }
+    }
+    if (parent != nullptr) {
       for (const auto& id : frame->mentionedVars) {
         if (frame->eligibleVars.count(id) == 0) {
           parent->mentionedVars.insert(id);

--- a/frontend/lib/resolution/split-init.cpp
+++ b/frontend/lib/resolution/split-init.cpp
@@ -69,9 +69,11 @@ struct FindSplitInits : VarScopeVisitor {
                        RV& rv) override;
   void handleInFormal(const FnCall* ast, const AstNode* actual,
                       const QualifiedType& formalType,
+                      const QualifiedType* actualScalarType,
                       RV& rv) override;
   void handleInoutFormal(const FnCall* ast, const AstNode* actual,
                          const QualifiedType& formalType,
+                         const QualifiedType* actualScalarType,
                          RV& rv) override;
 
   void handleReturn(const uast::Return* ast, RV& rv) override;
@@ -210,12 +212,14 @@ void FindSplitInits::handleOutFormal(const FnCall* ast, const AstNode* actual,
 
 void FindSplitInits::handleInFormal(const FnCall* ast, const AstNode* actual,
                                     const QualifiedType& formalType,
+                                    const QualifiedType* actualScalarType,
                                     RV& rv) {
   processMentions(actual, rv);
 }
 
 void FindSplitInits::handleInoutFormal(const FnCall* ast, const AstNode* actual,
                                        const QualifiedType& formalType,
+                                       const QualifiedType* actualScalarType,
                                        RV& rv) {
   processMentions(actual, rv);
 }

--- a/frontend/test/ErrorGuard.h
+++ b/frontend/test/ErrorGuard.h
@@ -134,8 +134,8 @@ class ErrorGuard {
 
   /** The guard destructor will assert that no errors have occurred. */
   ~ErrorGuard() {
-    removeSignalHandler();
     assert(!this->realizeErrors());
+    removeSignalHandler();
     std::ignore = ctx_->installErrorHandler(std::move(oldErrorHandler_));
   }
 };

--- a/frontend/test/resolution/testCast.cpp
+++ b/frontend/test/resolution/testCast.cpp
@@ -534,12 +534,10 @@ static void test45() {
 
 static void test46() {
   printf("test46\n");
-  Context ctx;
-  Context* context = &ctx;
 
   // Param
   {
-    context->advanceToNextRevision(false);
+    Context* context = buildStdContext();
     std::string program =
       R"""(
       param a = "asdf";
@@ -553,7 +551,7 @@ static void test46() {
 
   // Non-param
   {
-    context->advanceToNextRevision(false);
+    Context* context = buildStdContext();
     std::string program =
       R"""(
       var a = "asdf";

--- a/frontend/test/resolution/testDeprecationUnstable.cpp
+++ b/frontend/test/resolution/testDeprecationUnstable.cpp
@@ -275,8 +275,8 @@ static void test0(void) {
 
       var v1 = new r1();
       var v2 = new r2();
-      var v3 = new c1();
-      var v4 = new c2();
+      var v3 = new unmanaged c1();
+      var v4 = new unmanaged c2();
       var v5 = new u1();
       var v6 = new u2();
       var v7 = foo1;
@@ -469,7 +469,7 @@ static void test2(void) {
       proc C.baz() {}   // Tertiary
       proc r.baz() {}   // Tertiary
 
-      var a = new C();  // Unstable warning for this mention
+      var a = new unmanaged C();  // Unstable warning for this mention
       a.foo();
       a.bar();
       a.baz();
@@ -603,7 +603,7 @@ static void test4(ErrorType expectedError) {
     proc foo(x: C) {}
 
     proc main() {
-      var x = new C();
+      var x = new unmanaged C();
       foo(x);
     }
     )"""";

--- a/frontend/test/resolution/testEnums.cpp
+++ b/frontend/test/resolution/testEnums.cpp
@@ -690,8 +690,7 @@ static void test20() {
 
 // Non-param cast to string
 static void test21() {
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   auto vars = resolveTypesOfVariables(context,

--- a/frontend/test/resolution/testForwarding.cpp
+++ b/frontend/test/resolution/testForwarding.cpp
@@ -258,17 +258,17 @@ static void test6a() {
       }
 
       record Middle1 {
-        forwarding var field: Inner1;
-        forwarding var field: Inner2;
+        forwarding var field1: Inner1;
+        forwarding var field2: Inner2;
       }
       record Middle2 {
-        forwarding var field: Inner3;
-        forwarding var field: Inner4;
+        forwarding var field1: Inner3;
+        forwarding var field2: Inner4;
       }
 
       record Outer {
-        forwarding var impl: Middle1;
-        forwarding var impl: Middle2;
+        forwarding var impl1: Middle1;
+        forwarding var impl2: Middle2;
       }
 
       var rec: Outer;
@@ -408,7 +408,7 @@ static void forwardForwardHelper(std::string stmt, bool isVar = false) {
   auto qt = resolveQualifiedTypeOfX(context, contents);
   assert(qt.type()->isErroneousType());
 
-  unsigned int numExpected = isVar ? 3 : 2;
+  unsigned int numExpected = isVar ? 4 : 2;
   assert(guard.numErrors() == numExpected);
 
   assert(guard.error(0)->type() == chpl::NoMatchingCandidates);

--- a/frontend/test/resolution/testGenericDefaults.cpp
+++ b/frontend/test/resolution/testGenericDefaults.cpp
@@ -148,8 +148,7 @@ static void test4() {
     assert(qt.type()->isIntType());
   }
   {
-    Context ctx;
-    auto context = &ctx;
+    auto context = buildStdContext();
     QualifiedType qt =  resolveQualifiedTypeOfX(context,
                            R""""(
                            proc foo(type t = int) type do return t;

--- a/frontend/test/resolution/testHeapBuffer.cpp
+++ b/frontend/test/resolution/testHeapBuffer.cpp
@@ -44,7 +44,7 @@ void testHeapBufferArg(const char* formalType, const char* actualType, F&& test)
   std::stringstream ss;
 
   ss << "record rec { type someType; }" << std::endl;
-  ss << "proc f(x: " << formalType << ") {}" << std::endl;
+  ss << "proc f(x: " << formalType << ") { return 0; }" << std::endl;
   ss << "var arg: " << actualType << ";" << std::endl;
   ss << "var x = f(arg);" << std::endl;
 
@@ -239,7 +239,7 @@ static void test11() {
   assert(guard.realizeErrors() == 0);
 }
 
-static void runAllTests() {
+static void runCommonTests() {
   test1();
   test2();
   test3();
@@ -249,22 +249,26 @@ static void runAllTests() {
   test7();
   test8();
   test9();
-  test10();
   test11();
+}
+
+static void runTestsThatRequireStdlib() {
+  test10();
 }
 
 int main() {
   // With stdlib
   {
     context = new Context(getConfigWithHome());
-    runAllTests();
+    runCommonTests();
+    runTestsThatRequireStdlib();
     delete context;
   }
 
   // Without stdlib
   {
     context = new Context();
-    runAllTests();
+    runCommonTests();
     delete context;
   }
 

--- a/frontend/test/resolution/testLoopIndexVars.cpp
+++ b/frontend/test/resolution/testLoopIndexVars.cpp
@@ -1140,7 +1140,6 @@ static void pairIteratorInLoopExpression(
 static void testForLoopExpression(Context* context) {
 
   printf("%s\n", __FUNCTION__);
-  ErrorGuard guard(context);
 
   auto iters =
     R""""(
@@ -1549,7 +1548,6 @@ static void testBracketLoopExpressionUnpackedZippered(Context* context) {
 static void testForLoopExpressionTypeMethod(Context* context) {
 
   printf("%s\n", __FUNCTION__);
-  ErrorGuard guard(context);
 
   auto iters =
     R""""(

--- a/frontend/test/resolution/testMethodCalls.cpp
+++ b/frontend/test/resolution/testMethodCalls.cpp
@@ -639,7 +639,7 @@ static void test13() {
 
   auto vars = resolveTypesOfVariables(context, program, { "tmp" });
 
-  assert(guard.numErrors() == 2);
+  assert(guard.numErrors());
   for (auto& err : guard.errors()) {
     assert(err->type() == ErrorType::SyntacticGenericityMismatch);
   }

--- a/frontend/test/resolution/testMultiDecl.cpp
+++ b/frontend/test/resolution/testMultiDecl.cpp
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+#include "test-common.h"
 #include "test-resolution.h"
 
 #include "chpl/parsing/parsing-queries.h"
@@ -94,8 +95,7 @@ static void test2() {
 
 static void test3() {
   printf("test3\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
 
   auto M = parseModule(context,
                 R""""(

--- a/frontend/test/resolution/testNew.cpp
+++ b/frontend/test/resolution/testNew.cpp
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+#include "test-common.h"
 #include "test-resolution.h"
 
 #include "chpl/parsing/parsing-queries.h"
@@ -292,7 +293,8 @@ static void determineManagerAndDecorator(Context* ctx,
   return;
 }
 
-static void buildParseTestClassNewExpr(Context* ctx, const char* expr, int numErrors = 0) {
+static void buildParseTestClassNewExpr(const char* expr, int numErrors = 0) {
+  auto ctx = buildStdContext();
   ErrorGuard guard(ctx);
 
   static int testNumCounter = 0;
@@ -379,24 +381,21 @@ static void buildParseTestClassNewExpr(Context* ctx, const char* expr, int numEr
 
 // Test different combinations of management/nilability flavors.
 static void testClassManagementNilabilityInNewExpr() {
-  Context context;
-  Context* ctx = &context;
-
-  buildParseTestClassNewExpr(ctx, "new C()");
-  buildParseTestClassNewExpr(ctx, "new owned C()");
-  buildParseTestClassNewExpr(ctx, "new shared C()");
-  buildParseTestClassNewExpr(ctx, "new borrowed C()", 1);
-  buildParseTestClassNewExpr(ctx, "new unmanaged C()");
-  buildParseTestClassNewExpr(ctx, "new C?()");
-  buildParseTestClassNewExpr(ctx, "new owned C?()");
-  buildParseTestClassNewExpr(ctx, "new shared C?()");
-  buildParseTestClassNewExpr(ctx, "new borrowed C?()", 1);
-  buildParseTestClassNewExpr(ctx, "new unmanaged C?()");
-  buildParseTestClassNewExpr(ctx, "new C()?");
-  buildParseTestClassNewExpr(ctx, "new owned C()?");
-  buildParseTestClassNewExpr(ctx, "new shared C()?");
-  buildParseTestClassNewExpr(ctx, "new borrowed C()?", 1);
-  buildParseTestClassNewExpr(ctx, "new unmanaged C()?");
+  buildParseTestClassNewExpr("new C()");
+  buildParseTestClassNewExpr("new owned C()");
+  buildParseTestClassNewExpr("new shared C()");
+  buildParseTestClassNewExpr("new borrowed C()", 1);
+  buildParseTestClassNewExpr("new unmanaged C()");
+  buildParseTestClassNewExpr("new C?()");
+  buildParseTestClassNewExpr("new owned C?()");
+  buildParseTestClassNewExpr("new shared C?()");
+  buildParseTestClassNewExpr("new borrowed C?()", 1);
+  buildParseTestClassNewExpr("new unmanaged C?()");
+  buildParseTestClassNewExpr("new C()?");
+  buildParseTestClassNewExpr("new owned C()?");
+  buildParseTestClassNewExpr("new shared C()?");
+  buildParseTestClassNewExpr("new borrowed C()?", 1);
+  buildParseTestClassNewExpr("new unmanaged C()?");
 }
 
 static void testGenericRecordUserInitDependentField() {
@@ -506,8 +505,7 @@ static void testGenericRecordUserInitDependentField() {
 }
 
 static void testRecordNewSegfault(void) {
-  Context context;
-  Context* ctx = &context;
+  auto ctx = buildStdContext();
   ErrorGuard guard(ctx);
 
   auto path = TEST_NAME(ctx);

--- a/frontend/test/resolution/testOpaqueExternTypes.cpp
+++ b/frontend/test/resolution/testOpaqueExternTypes.cpp
@@ -226,6 +226,9 @@ static void test5() {
   auto notAType = types.at("notAType");
 
   assert(notAType.isUnknown());
+  assert(guard.numErrors() == 1);
+  assert(guard.errors()[0]->message() == "cannot default initialize variable using generic or unknown type");
+  guard.realizeErrors();
 }
 
 

--- a/frontend/test/resolution/testOperatorOverloads.cpp
+++ b/frontend/test/resolution/testOperatorOverloads.cpp
@@ -256,7 +256,7 @@ static void test5() {
       record R {
         var x : int;
       }
-      operator R.==(a: R, b: R) { return "true"; }
+      operator R.==(a: R, b: R) { return 4.2; }
 
       var a : R;
       var b : R;
@@ -265,7 +265,7 @@ static void test5() {
     )"""";
 
   QualifiedType initType = resolveTypeOfXInit(context, program);
-  assert(initType.type()->isStringType());
+  assert(initType.type()->isRealType());
   assert(initType.kind() == QualifiedType::CONST_VAR);
 }
 

--- a/frontend/test/resolution/testResolve.cpp
+++ b/frontend/test/resolution/testResolve.cpp
@@ -480,8 +480,7 @@ static void test9() {
 // error happens after disambiguation.
 static void test10() {
   printf("test10\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   ErrorGuard guard(context);
 
   auto path = UniqueString::get(context, "input.chpl");
@@ -497,7 +496,7 @@ static void test10() {
                              proc f(const ref arg: Parent, x: int(8)) { }
                              proc f(const ref arg: Parent, x: numeric) { }
 
-                             var x: owned Child;
+                             var x = new Child();
                              var sixtyFourBits: int = 0;
                              f(x, sixtyFourBits);
                           }
@@ -589,10 +588,10 @@ static void test13() {
 }
 
 static void test14() {
-  Context context;
+  auto context = buildStdContext();
   // Make sure no errors make it to the user, even though we will get errors.
-  ErrorGuard guard(&context);
-  auto variables = resolveTypesOfVariablesInit(&context,
+  ErrorGuard guard(context);
+  auto variables = resolveTypesOfVariablesInit(context,
       R"""(
       param xp = 42;
       var xv = 42;
@@ -610,10 +609,10 @@ static void test14() {
       var r7 = __primitive("addr of", int);
       )""", { "r1", "r2", "r3", "r4", "r5", "r6", "r7" });
 
-  auto refInt = QualifiedType(QualifiedType::REF, IntType::get(&context, 0));
-  auto constRefInt = QualifiedType(QualifiedType::CONST_REF, IntType::get(&context, 0));
-  auto refStr = QualifiedType(QualifiedType::REF, RecordType::getStringType(&context));
-  auto constRefStr = QualifiedType(QualifiedType::CONST_REF, RecordType::getStringType(&context));
+  auto refInt = QualifiedType(QualifiedType::REF, IntType::get(context, 0));
+  auto constRefInt = QualifiedType(QualifiedType::CONST_REF, IntType::get(context, 0));
+  auto refStr = QualifiedType(QualifiedType::REF, RecordType::getStringType(context));
+  auto constRefStr = QualifiedType(QualifiedType::CONST_REF, RecordType::getStringType(context));
 
   assert(variables.at("r1") == constRefInt);
   assert(variables.at("r2") == refInt);
@@ -689,10 +688,10 @@ static void test15() {
 }
 
 static void test16() {
-  Context context;
+  auto context = buildStdContext();
   // Make sure no errors make it to the user, even though we will get errors.
-  ErrorGuard guard(&context);
-  auto variables = resolveTypesOfVariablesInit(&context,
+  ErrorGuard guard(context);
+  auto variables = resolveTypesOfVariablesInit(context,
       R"""(
       record Concrete {
           var x: int;
@@ -707,7 +706,7 @@ static void test16() {
       }
 
       var conc: Concrete;
-      var inst: Generic(int, string, (int, string));
+      var inst = new Generic(1, "hello", (1, "hello"));
 
       param r1 = __primitive("static field type", conc, "x") == int;
       param r2 = __primitive("static field type", conc, "y") == string;
@@ -751,9 +750,9 @@ static void test16b() {
 
 // module-level split-init variables
 static void test17() {
-  Context context;
+  auto context = buildStdContext();
 
-  auto variables = resolveTypesOfVariables(&context,
+  auto variables = resolveTypesOfVariables(context,
       R"""(
       var foo;
       foo = 5;
@@ -859,8 +858,7 @@ static void test19() {
 
 // Accessing the param value of a split-init'd symbol in another module
 static void test20() {
-  Context ctx;
-  Context* context = &ctx;
+  Context* context = buildStdContext();
   ErrorGuard guard(context);
 
   std::string contents =
@@ -1997,8 +1995,7 @@ static void testAsciiPrim() {
 
 // Test the '.locale' query.
 static void testDotLocale() {
-  Context ctx;
-  Context* context = &ctx;
+  Context* context = buildStdContext();
   ErrorGuard guard(context);
 
   auto loc = resolveTypeOfXInit(context,

--- a/frontend/test/resolution/testResolverVerboseErrors.cpp
+++ b/frontend/test/resolution/testResolverVerboseErrors.cpp
@@ -49,7 +49,7 @@ class Child : Parent {}
 
 proc f(ref x: owned Parent) {}
 
-var x: owned Child;
+var x = new Child();
 f(x);
 )""";
 
@@ -104,7 +104,7 @@ class C {}
 
 proc f(x: owned C) {}
 
-var x: shared C;
+var x = new shared C();
 f(x);
 )""";
 

--- a/frontend/test/resolution/testRuntimePrimitives.cpp
+++ b/frontend/test/resolution/testRuntimePrimitives.cpp
@@ -35,8 +35,7 @@ static void predicatePrimTypeHelper(const char* primName, std::vector<const char
     program += arg;
   }
   program += ");";
-  Context ctx;
-  auto context = &ctx;
+  auto context = buildStdContext();
   QualifiedType qt =  resolveTypeOfXInit(context, std::move(program));
   assert(qt.kind() == expectedKind);
   auto typePtr = qt.type();


### PR DESCRIPTION
**Best reviewed commit-by-commit.**

Previously, `call-init-deinit.cpp` had the following comment:

```C++
// TODO: Run this for module initializer code as well. Currently if enabled,
// it breaks a large number of dyno tests that have module-initializer code
// containing things we can't resolve default-init for yet, such as
// fully-defaulted generic types. Either adjust the tests to expect the errors
// for unsupported code, or add the support, then enable this on modules.
if (!resolver.symbol->isModule()) {
```

It seems like we are far enough along that module-level variables don't break things in any cases I've tried. So, re-enable these steps. Lots of tests were relying on them not being invoked, so update those. While there, fix a number of bugs that came up. See each individual commit in this PR.

Reviewed by @benharsh -- thanks!

## Testing
- [x] dyno tests
- [x] spectests and primers with `--dyno-resolve-only` ("breaks" one test by emitting an additional, correct, error message)
- [x] paratest