### PR TITLE
Add skipif for --baseline for throwing iterator test

### DIFF
--- a/test/library/packages/Python/correctness/arrays/iteration.skipif
+++ b/test/library/packages/Python/correctness/arrays/iteration.skipif
@@ -1,0 +1,2 @@
+# requires iterator inlining
+COMPOPTS <= --baseline


### PR DESCRIPTION
Adds a skipif for a test which uses throwing iterators, which is not supported with `--baseline`

[Not reviewed - trivial]