### PR TITLE
Rename gdbShouldBreakHere to debuggerBreakHere in the compiler

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -1368,7 +1368,7 @@ AggregateType* AggregateType::generateType(SymbolMap& subs, CallExpr* call, cons
 }
 
 void AggregateType::resolveConcreteType() {
-  if (this->id == breakOnResolveID) gdbShouldBreakHere();
+  if (this->id == breakOnResolveID) debuggerBreakHere();
 
   if (resolveStatus == RESOLVING || resolveStatus == RESOLVED) {
     // Recursively constructing this type

--- a/compiler/AST/baseAST.cpp
+++ b/compiler/AST/baseAST.cpp
@@ -195,7 +195,7 @@ void trace_remove(BaseAST* ast, char flag) {
   }
   if (ast->id == breakOnRemoveID) {
     if (deletedIdON() == true) fflush(deletedIdHandle);
-    gdbShouldBreakHere();
+    debuggerBreakHere();
   }
   // There should never be an attempt to delete a global type.
   if (flag != 'z' && // At least, not before compiler shutdown.
@@ -367,7 +367,7 @@ int lastNodeIDUsed() {
 // BaseAST instance in gdb.
 static void checkid(int id) {
   if (id == breakOnID) {
-    gdbShouldBreakHere();
+    debuggerBreakHere();
   }
 }
 

--- a/compiler/AST/foralls.cpp
+++ b/compiler/AST/foralls.cpp
@@ -951,7 +951,7 @@ static void resolveIdxVar(ForallStmt* pfs, FnSymbol* iterFn)
   // Set QualifiedType of the index variable.
   QualifiedType iType = fsIterYieldType(pfs, iterFn);
   VarSymbol* idxVar = parIdxVar(pfs);
-  if (idxVar->id == breakOnResolveID) gdbShouldBreakHere();
+  if (idxVar->id == breakOnResolveID) debuggerBreakHere();
 
   idxVar->type = iType.type();
   idxVar->qual = iType.getQual();
@@ -1211,7 +1211,7 @@ void static setupRecIterFields(ForallStmt* fs, CallExpr* parIterCall);
 // Returns the next expression to resolve.
 CallExpr* resolveForallHeader(ForallStmt* pfs, SymExpr* origSE)
 {
-  if (pfs->id == breakOnResolveID) gdbShouldBreakHere();
+  if (pfs->id == breakOnResolveID) debuggerBreakHere();
 
   // We only get here for origSE==firstIteratedExpr() .
   // If at that time there are other elements in iterExprs(), we remove them.
@@ -1711,7 +1711,7 @@ static Expr* lowerReduceOp(Expr* ref, SymExpr* opSE, SymExpr* dataSE,
 // for_exprs_postorder framework by placing it after the no-op.
 //
 Expr* lowerPrimReduce(CallExpr* call) {
-  if (call->id == breakOnResolveID) gdbShouldBreakHere();
+  if (call->id == breakOnResolveID) debuggerBreakHere();
 
   Expr*   callStmt = call->getStmtExpr();
   CallExpr*   noop = new CallExpr(PRIM_NOOP);

--- a/compiler/codegen/cg-CForLoop.cpp
+++ b/compiler/codegen/cg-CForLoop.cpp
@@ -266,7 +266,7 @@ static void addLoopMetadata(llvm::Instruction* instruction,
 GenRet CForLoop::codegen()
 {
   if (id == breakOnCodegenID)
-    gdbShouldBreakHere();
+    debuggerBreakHere();
 
   GenInfo* info    = gGenInfo;
   FILE*    outfile = info->cfile;

--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -183,7 +183,7 @@ GenRet SymExpr::codegen() {
   GenRet ret;
 
   if (id == breakOnCodegenID)
-    gdbShouldBreakHere();
+    debuggerBreakHere();
 
   if( outfile ) {
     if (getStmtExpr() && getStmtExpr() == this)
@@ -4312,7 +4312,7 @@ GenRet CallExpr::codegen() {
   GenRet ret;
 
   // Note (for debugging), function name is in parentSymbol->cname.
-  if (id == breakOnCodegenID) gdbShouldBreakHere();
+  if (id == breakOnCodegenID) debuggerBreakHere();
 
   if (getStmtExpr() == this) codegenStmt(this);
 
@@ -6750,7 +6750,7 @@ static bool codegenIsSpecialPrimitive(BaseAST* target, Expr* e, GenRet& ret) {
   if(!call) return false;
 
   if (call->id == breakOnCodegenID)
-    gdbShouldBreakHere();
+    debuggerBreakHere();
 
   if (call->primitive) {
     switch (call->primitive->tag) {

--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -489,7 +489,7 @@ GenRet VarSymbol::codegenVarSymbol(bool lhsInSetReference) {
   ret.chplType = typeInfo();
 
   if (id == breakOnCodegenID)
-    gdbShouldBreakHere();
+    debuggerBreakHere();
 
   if( outfile ) {
     // dtString immediates don't actually codegen as immediates, we just use
@@ -908,7 +908,7 @@ void VarSymbol::codegenGlobalDef(bool isHeader) {
   if( id == breakOnCodegenID ||
       (breakOnCodegenCname[0] &&
        0 == strcmp(cname, breakOnCodegenCname)) ) {
-    gdbShouldBreakHere();
+    debuggerBreakHere();
   }
 
   if( info->cfile ) {
@@ -978,7 +978,7 @@ void VarSymbol::codegenDef() {
   GenInfo* info = gGenInfo;
 
   if (id == breakOnCodegenID)
-    gdbShouldBreakHere();
+    debuggerBreakHere();
 
   // Local variable symbols should never be
   // generated for extern or void types
@@ -1153,7 +1153,7 @@ GenRet ArgSymbol::codegen() {
 
   if (this->id == breakOnCodegenID ||
       this->defPoint->id == breakOnCodegenID) {
-    gdbShouldBreakHere();
+    debuggerBreakHere();
   }
 
   ret.chplType = this->type;
@@ -1482,7 +1482,7 @@ void TypeSymbol::codegenDef() {
   if( id == breakOnCodegenID ||
       (breakOnCodegenCname[0] &&
        0 == strcmp(cname, breakOnCodegenCname)) ) {
-    gdbShouldBreakHere();
+    debuggerBreakHere();
   }
 
   if (!hasFlag(FLAG_EXTERN)) {
@@ -2571,9 +2571,9 @@ importPrecompiledFunctionProto(chpl::ID fnId, const char* cname) {
 #endif
 
 void FnSymbol::codegenPrototype() {
-  if (id == breakOnCodegenID) gdbShouldBreakHere();
+  if (id == breakOnCodegenID) debuggerBreakHere();
   if (breakOnCodegenCname[0] && !strcmp(cname, breakOnCodegenCname)) {
-    gdbShouldBreakHere();
+    debuggerBreakHere();
   }
 
   GenInfo *info = gGenInfo;
@@ -2805,7 +2805,7 @@ void FnSymbol::codegenDef() {
   if( id == breakOnCodegenID ||
       (breakOnCodegenCname[0] &&
        0 == strcmp(cname, breakOnCodegenCname)) ) {
-    gdbShouldBreakHere();
+    debuggerBreakHere();
   }
 
   if (!needsCodegenWrtGPU(this)) return;
@@ -2945,7 +2945,7 @@ void FnSymbol::codegenDef() {
     }
 
     for_formals(arg, this) {
-      if (arg->id == breakOnCodegenID) gdbShouldBreakHere();
+      if (arg->id == breakOnCodegenID) debuggerBreakHere();
 
       const clang::CodeGen::ABIArgInfo* argInfo = NULL;
       if (CGI) {

--- a/compiler/codegen/cg-type.cpp
+++ b/compiler/codegen/cg-type.cpp
@@ -510,7 +510,7 @@ void AggregateType::codegenDef() {
   llvm::Type *type = NULL;
   int structAlignment = ALIGNMENT_UNINIT;
 #endif
-  if (id == breakOnCodegenID) gdbShouldBreakHere();
+  if (id == breakOnCodegenID) debuggerBreakHere();
 
   if (symbol->hasFlag(FLAG_STAR_TUPLE)) {
     if( outfile ) {

--- a/compiler/etc/gdb.commands
+++ b/compiler/etc/gdb.commands
@@ -25,4 +25,4 @@ end
 define parentlocid
   call debugSummary(debugParentSym($arg0))
 end
-break gdbShouldBreakHere
+break debuggerBreakHere

--- a/compiler/etc/lldb.commands
+++ b/compiler/etc/lldb.commands
@@ -7,4 +7,4 @@ command regex dview 's/(.*)/expr -- (%1).dump()/'
 command regex flags  's/(.*)/expr -- viewFlags(%1)/'
 command regex loc    's/(.*)/expr -- ::stringLoc(%1)/'
 
-breakpoint set -n gdbShouldBreakHere
+breakpoint set -n debuggerBreakHere

--- a/compiler/include/misc.h
+++ b/compiler/include/misc.h
@@ -49,13 +49,13 @@
 // results in something like:
 // INTERNAL ERROR in compilerSrc.c (lineno): your text here (usrSrc:usrLineno)
 
-#define INT_FATAL      gdbShouldBreakHere(), \
+#define INT_FATAL      debuggerBreakHere(), \
                        setupError(TOSTRING(COMPILER_SUBDIR), __FILE__, __LINE__, 1), handleError
 
-#define USR_FATAL      gdbShouldBreakHere(), \
+#define USR_FATAL      debuggerBreakHere(), \
                        setupError(TOSTRING(COMPILER_SUBDIR), __FILE__, __LINE__, 2), handleError
 
-#define USR_FATAL_CONT gdbShouldBreakHere(), \
+#define USR_FATAL_CONT debuggerBreakHere(), \
                        setupError(TOSTRING(COMPILER_SUBDIR), __FILE__, __LINE__, 3), handleError
 
 #define USR_WARN       setupError(TOSTRING(COMPILER_SUBDIR), __FILE__, __LINE__, 4), handleError

--- a/compiler/llvm/llvmUtil.cpp
+++ b/compiler/llvm/llvmUtil.cpp
@@ -676,7 +676,7 @@ static int addLlvmValue(const llvm::Value* val) {
 
 const llvm::Value* trackLLVMValue(const llvm::Value* val) {
   int newId = addLlvmValue(val);
-  if (newId == breakOnLLVMID) gdbShouldBreakHere();
+  if (newId == breakOnLLVMID) debuggerBreakHere();
   return val;
 }
 

--- a/compiler/passes/convert-typed-uast.cpp
+++ b/compiler/passes/convert-typed-uast.cpp
@@ -67,10 +67,10 @@
 // If defined as 1, dump debug output from the converter to stdout.
 #define TC_DEBUG_TRACE 0
 
-// Wrapper around 'CHPL_UNIMPL' that also calls 'gdbShouldBreakHere()'.
+// Wrapper around 'CHPL_UNIMPL' that also calls 'debuggerBreakHere()'.
 #define TC_UNIMPL(msg__) do { \
   CHPL_UNIMPL(msg__); \
-  gdbShouldBreakHere(); \
+  debuggerBreakHere(); \
 } while (0)
 
 

--- a/compiler/resolution/cullOverReferences.cpp
+++ b/compiler/resolution/cullOverReferences.cpp
@@ -73,7 +73,7 @@ static const int breakOnId3 = 0;
   do { \
     if (sym->id == breakOnId1 || sym->id == breakOnId2 || \
         sym->id == breakOnId3) { \
-      gdbShouldBreakHere(); \
+      debuggerBreakHere(); \
     } \
   } while (0)
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -2416,7 +2416,7 @@ static void reissueMsgHelp(CallExpr* from, const char* str, bool err) {
   if (err) {
     USR_FATAL(from, "%s", str);
   } else {
-    gdbShouldBreakHere();
+    debuggerBreakHere();
     USR_WARN(from, "%s", str);
   }
 }
@@ -3687,7 +3687,7 @@ static void warnForCallConcreteType(CallExpr* call, Type* t) {
 
 static Type* resolveTypeSpecifier(CallInfo& info) {
   CallExpr* call = info.call;
-  if (call->id == breakOnResolveID) gdbShouldBreakHere();
+  if (call->id == breakOnResolveID) debuggerBreakHere();
 
   Type* ret = NULL;
 
@@ -3965,7 +3965,7 @@ FnSymbol* resolveNormalCall(CallExpr* call, check_state_t checkState) {
   if (call->id == breakOnResolveID) {
     printf("breaking on resolve call %d:\n", call->id);
     print_view(call);
-    gdbShouldBreakHere();
+    debuggerBreakHere();
   }
 
   resolveGenericActuals(call);
@@ -5622,7 +5622,7 @@ static void filterCandidate(CallInfo&                  info,
     USR_PRINT(fn, "Considering function: %s", toString(fn));
 
     if (info.call->id == breakOnResolveID) {
-      gdbShouldBreakHere();
+      debuggerBreakHere();
     }
   }
 
@@ -7347,7 +7347,7 @@ static void handleTaskIntentArgs(CallInfo& info, FnSymbol* taskFn) {
       // INT_ASSERT(varActual->type->symbol->hasFlag(FLAG_GENERIC) == false);
 
       if (formal->id == breakOnResolveID)
-        gdbShouldBreakHere();
+        debuggerBreakHere();
 
       IntentTag origFormalIntent = formal->intent;
 
@@ -8001,7 +8001,7 @@ static Symbol* resolveFieldSymbol(Type* base, Expr* fieldExpr) {
 static void resolveSetMember(CallExpr* call) {
 
   if (call->id == breakOnResolveID) {
-    gdbShouldBreakHere();
+    debuggerBreakHere();
   }
 
   Symbol* fs = resolveFieldSymbol(call->get(1)->typeInfo()->getValType(),
@@ -8078,7 +8078,7 @@ static void handleSetMemberTypeMismatch(Type*     t,
 
 static void resolveInitField(CallExpr* call) {
   if (call->id == breakOnResolveID) {
-    gdbShouldBreakHere();
+    debuggerBreakHere();
   }
 
   INT_ASSERT(call->argList.length == 3);
@@ -8156,7 +8156,7 @@ static void resolveInitField(CallExpr* call) {
     // fields from the old instantiation
 
     if (fs->id == breakOnResolveID) {
-      gdbShouldBreakHere();
+      debuggerBreakHere();
     }
 
     bool ignoredHasDefault = false;
@@ -8493,7 +8493,7 @@ void resolveInitVar(CallExpr* call) {
   bool isParamString = dst->hasFlag(FLAG_PARAM) && isString(srcType);
 
   if (call->id == breakOnResolveID) {
-    gdbShouldBreakHere();
+    debuggerBreakHere();
   }
 
   if (call->isPrimitive(PRIM_INIT_VAR_SPLIT_INIT)) {
@@ -9097,7 +9097,7 @@ static bool isMoveFromMain(CallExpr* call) {
 
 static void resolveMove(CallExpr* call) {
   if (call->id == breakOnResolveID) {
-    gdbShouldBreakHere();
+    debuggerBreakHere();
   }
 
   if (moveIsAcceptable(call) == false) {
@@ -9321,7 +9321,7 @@ Type* moveDetermineLhsType(CallExpr* call) {
 
   if (lhsSym->type == dtUnknown || lhsSym->type == dtNil) {
     if (lhsSym->id == breakOnResolveID) {
-      gdbShouldBreakHere();
+      debuggerBreakHere();
     }
 
     Type* type = call->get(2)->typeInfo();
@@ -9800,7 +9800,7 @@ static bool isUndecoratedClassNew(CallExpr* newExpr, Type* newType);
 static void resolveNew(CallExpr* newExpr) {
 
   if (newExpr->id == breakOnResolveID) {
-    gdbShouldBreakHere();
+    debuggerBreakHere();
   }
 
   // If it's a managed new, detect the _chpl_manager named arg and remove it
@@ -10545,7 +10545,7 @@ static Expr* resolveFunctionTypeConstructor(DefExpr* def) {
   INT_ASSERT(fn->type == dtUnknown);
 
   if (def->id == breakOnResolveID || fn->id == breakOnResolveID) {
-    gdbShouldBreakHere();
+    debuggerBreakHere();
   }
 
   bool isBodyResolved = fcfs::checkAndResolveSignature(fn, def);
@@ -10696,7 +10696,7 @@ static Expr* resolveFunctionCapture(FnSymbol* fn, Expr* use,
                                     bool discardType,
                                     bool useClass) {
   if (fn->id == breakOnResolveID || use->id == breakOnResolveID) {
-    gdbShouldBreakHere();
+    debuggerBreakHere();
   }
 
   // Discarding the type (e.g., for 'c_ptrTo') is well specified.
@@ -10815,7 +10815,7 @@ static Expr* maybeResolveFunctionCapturePrimitive(CallExpr* call) {
     return nullptr;
   }
 
-  if (call->id == breakOnResolveID) gdbShouldBreakHere();
+  if (call->id == breakOnResolveID) debuggerBreakHere();
 
   switch (call->primitive->tag) {
 
@@ -10924,7 +10924,7 @@ Expr* resolveExpr(Expr* expr) {
   Expr*     retval = NULL;
 
   if (expr->id == breakOnResolveID)
-    gdbShouldBreakHere();
+    debuggerBreakHere();
 
   SET_LINENO(expr);
 
@@ -13665,7 +13665,7 @@ static void resolvePrimInit(CallExpr* call) {
 
 static void resolvePrimInit(CallExpr* call, Symbol* val, Type* type) {
 
-  if (call->id == breakOnResolveID) gdbShouldBreakHere();
+  if (call->id == breakOnResolveID) debuggerBreakHere();
 
   AggregateType* at = toAggregateType(type);
   val->type = type;
@@ -13957,7 +13957,7 @@ static void errorInvalidParamInit(CallExpr* call, Symbol* val, Type* type) {
 static void lowerPrimInit(CallExpr* call, Symbol* val, Type* type,
                           Expr* preventingSplitInit) {
 
-  if (call->id == breakOnResolveID) gdbShouldBreakHere();
+  if (call->id == breakOnResolveID) debuggerBreakHere();
 
   AggregateType* at     = toAggregateType(type);
 
@@ -14747,7 +14747,7 @@ static void resolveInitRef(CallExpr* call) {
                refSym->hasFlag(FLAG_REF_VAR));
     INT_ASSERT(refSym->type == dtUnknown); // fyi
 
-    if (refSym->id == breakOnResolveID) gdbShouldBreakHere();
+    if (refSym->id == breakOnResolveID) debuggerBreakHere();
     resolveExpr(call->get(2)); // the normalized type expression
     Expr* typeExpr = call->get(2)->remove();
     if (SymExpr* typeSE = toSymExpr(typeExpr))

--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -642,7 +642,7 @@ static void handleTaskPrivate(LoopWithShadowVarsInterface* fs, ShadowVarSymbol* 
 
 static void handleOneShadowVar(LoopWithShadowVarsInterface* fs, ShadowVarSymbol* svar)
 {
-  if (svar->id == breakOnResolveID) gdbShouldBreakHere();
+  if (svar->id == breakOnResolveID) debuggerBreakHere();
 
   switch (svar->intent) {
     case TFI_IN:           handleIn(fs, svar, false);   break;

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -598,7 +598,7 @@ static void resolveInitCall(CallExpr* call, bool emitCallResolutionErrors,
   if (call->id == breakOnResolveID) {
     printf("breaking on resolve call %d:\n", call->id);
     print_view(call);
-    gdbShouldBreakHere();
+    debuggerBreakHere();
   }
 
   if (info.isWellFormed(call) == true) {
@@ -742,7 +742,7 @@ static void doGatherInitCandidates(CallInfo&                  info,
         USR_PRINT(visibleFn, "Considering function: %s", toString(visibleFn));
 
         if (info.call->id == breakOnResolveID) {
-          gdbShouldBreakHere();
+          debuggerBreakHere();
         }
       }
 
@@ -786,7 +786,7 @@ static void resolveInitializerMatch(FnSymbol* fn) {
     if (fn->id == breakOnResolveID) {
       printf("breaking on resolve fn %s[%d] (%d args)\n",
              fn->name, fn->id, fn->numFormals());
-      gdbShouldBreakHere();
+      debuggerBreakHere();
     }
 
     insertFormalTemps(fn);

--- a/compiler/resolution/interfaceResolution.cpp
+++ b/compiler/resolution/interfaceResolution.cpp
@@ -383,7 +383,7 @@ void resolveInterfaceSymbol(InterfaceSymbol* isym) {
 
   cgprint("resolving interface declaration %s  %s {\n",
           symstring(isym), debugLoc(isym));
-  if (isym->id == breakOnResolveID) gdbShouldBreakHere();
+  if (isym->id == breakOnResolveID) debuggerBreakHere();
 
   for_alist(stmt, isym->ifcBody->body) {
    if (FnSymbol* fn = toFnSymbol(toDefExpr(stmt)->sym))
@@ -754,7 +754,7 @@ void resolveConstrainedGenericFun(FnSymbol* fn) {
 
   cgprint("resolving CG function early %s  %s {\n",
           symstring(fn), debugLoc(fn));
-  if (fn->id == breakOnResolveID) gdbShouldBreakHere();
+  if (fn->id == breakOnResolveID) debuggerBreakHere();
 
   createRepsForIfcSymbols(fn, ifcInfo);
 
@@ -1122,7 +1122,7 @@ static bool addReqFnConstraints(BlockStmt* holder, FnSymbol* reqFn,
     FnSymbol* wrapFn = wrapOneImplementsStatement(istm);
     // We postulate that this constraint holds. Resolving it is meaningless.
     // This means however that istm will not have its tables filled in.
-    if (wrapFn->id == breakOnResolveID) gdbShouldBreakHere();
+    if (wrapFn->id == breakOnResolveID) debuggerBreakHere();
     wrapFn->addFlag(FLAG_RESOLVED);
   }
 
@@ -1724,7 +1724,7 @@ static bool resolveImplementsStmt(FnSymbol* wrapFn, ImplementsStmt* istm,
                                   Expr*   addlSite,
                                   bool    reportErrors,
                                   bool    generatedOnly) {
-  if (istm->id == breakOnResolveID) gdbShouldBreakHere();
+  if (istm->id == breakOnResolveID) debuggerBreakHere();
 
   IfcConstraint* icon = istm->iConstraint;
   InterfaceSymbol* isym = icon->ifcSymbol();
@@ -2216,7 +2216,7 @@ ConstraintSat constraintIsSatisfiedAtCallSite(CallExpr*      callsite,
                                               IfcConstraint* constraint,
                                               SymbolMap&     substitutions) {
   if (callsite->id == breakOnResolveID  ||
-      constraint->id == breakOnResolveID ) gdbShouldBreakHere();
+      constraint->id == breakOnResolveID ) debuggerBreakHere();
 
   InterfaceSymbol* isym = constraint->ifcSymbol();
 

--- a/compiler/resolution/lateConstCheck.cpp
+++ b/compiler/resolution/lateConstCheck.cpp
@@ -54,7 +54,7 @@ static const bool doPrintDebugInfo = false;
   do { \
     if (sym__->id == breakOnId1 || sym__->id == breakOnId2 || \
         sym__->id == breakOnId3) { \
-      gdbShouldBreakHere(); \
+      debuggerBreakHere(); \
     } \
   } while (0)
 

--- a/compiler/resolution/lifetime.cpp
+++ b/compiler/resolution/lifetime.cpp
@@ -464,7 +464,7 @@ void checkLifetimesInFunction(FnSymbol* fn) {
       printf("Visiting function %s id %i\n", inFn->name, inFn->id);
       nprint_view(inFn);
     }
-    gdbShouldBreakHere();
+    debuggerBreakHere();
   }
 
   // Figure out the scope for local variables / arguments
@@ -1109,7 +1109,7 @@ bool LifetimeState::setInferredLifetimeToMin(Symbol* sym, LifetimePair lt) {
 
   if (inferredLifetime.count(sym) == 0) {
     if (sym->id == breakOnId)
-      gdbShouldBreakHere();
+      debuggerBreakHere();
 
     inferredLifetime[sym] = lt;
     changed = true;
@@ -1119,13 +1119,13 @@ bool LifetimeState::setInferredLifetimeToMin(Symbol* sym, LifetimePair lt) {
     // with debugging code and change tracking.
     if (isLifetimeShorter(lt.referent, value.referent)) {
       if (sym->id == breakOnId)
-        gdbShouldBreakHere();
+        debuggerBreakHere();
       value.referent = lt.referent;
       changed = true;
     }
     if (isLifetimeShorter(lt.borrowed, value.borrowed)) {
       if (sym->id == breakOnId)
-        gdbShouldBreakHere();
+        debuggerBreakHere();
       value.borrowed = lt.borrowed;
       changed = true;
     }
@@ -2102,7 +2102,7 @@ bool IntrinsicLifetimesVisitor::enterDefExpr(DefExpr* def) {
       lp.borrowed = infiniteLifetime();
 
     if (sym->id == debugLifetimesForId)
-      gdbShouldBreakHere();
+      debuggerBreakHere();
 
     lifetimes->intrinsicLifetime[sym] = lp;
   }
@@ -2129,7 +2129,7 @@ static bool isCallToFunctionReturningNotOwned(CallExpr* call) {
 bool IntrinsicLifetimesVisitor::enterCallExpr(CallExpr* call) {
 
   if (call->id == debugLifetimesForId)
-    gdbShouldBreakHere();
+    debuggerBreakHere();
 
   // Traverse into task functions
   if (FnSymbol* calledFn = call->resolvedFunction())
@@ -2203,7 +2203,7 @@ bool IntrinsicLifetimesVisitor::enterCallExpr(CallExpr* call) {
   if (initSym && !lt.unknown) {
 
     if (initSym->id == debugLifetimesForId)
-      gdbShouldBreakHere();
+      debuggerBreakHere();
 
     lifetimes->intrinsicLifetime[initSym].borrowed = lt;
   }
@@ -2220,7 +2220,7 @@ bool IntrinsicLifetimesVisitor::enterCallExpr(CallExpr* call) {
 bool InferLifetimesVisitor::enterCallExpr(CallExpr* call) {
 
   if (call->id == debugLifetimesForId)
-    gdbShouldBreakHere();
+    debuggerBreakHere();
 
   // Traverse into task functions
   if (FnSymbol* calledFn = call->resolvedFunction())
@@ -2266,7 +2266,7 @@ bool InferLifetimesVisitor::enterCallExpr(CallExpr* call) {
         // When setting the reference, set its intrinsic lifetime.
         if (!lp.referent.unknown || !lp.borrowed.unknown) {
           if (lhs->id == debugLifetimesForId)
-            gdbShouldBreakHere();
+            debuggerBreakHere();
 
           LifetimePair & intrinsic = lifetimes->intrinsicLifetime[lhs];
           intrinsic = lifetimes->minimumLifetimePair(intrinsic, lp);
@@ -2313,7 +2313,7 @@ bool InferLifetimesVisitor::enterCallExpr(CallExpr* call) {
 bool InferLifetimesVisitor::enterForLoop(ForLoop* forLoop) {
 
   if (forLoop->id == debugLifetimesForId)
-    gdbShouldBreakHere();
+    debuggerBreakHere();
 
   // Gather the loop details to understand the
   // correspondence between what was iterated over
@@ -2402,7 +2402,7 @@ bool InferLifetimesVisitor::enterForLoop(ForLoop* forLoop) {
     if (index->isRef()) {
       if (!lp.referent.unknown || !lp.borrowed.unknown) {
         if (index->id == debugLifetimesForId)
-          gdbShouldBreakHere();
+          debuggerBreakHere();
 
         LifetimePair & intrinsic = lifetimes->intrinsicLifetime[index];
         intrinsic = lifetimes->minimumLifetimePair(intrinsic, lp);
@@ -2544,7 +2544,7 @@ static void emitError(Expr* inExpr,
 bool EmitLifetimeErrorsVisitor::enterCallExpr(CallExpr* call) {
 
   if (call->id == debugLifetimesForId)
-    gdbShouldBreakHere();
+    debuggerBreakHere();
 
   // Traverse into task functions
   if (FnSymbol* calledFn = call->resolvedFunction())

--- a/compiler/resolution/lowerForalls.cpp
+++ b/compiler/resolution/lowerForalls.cpp
@@ -1465,7 +1465,7 @@ static void handleIteratorForwarders(ForallStmt* fs,
 /////////// handle one ForallStmt ///////////
 
 static void lowerOneForallStmt(ForallStmt* fs) {
-  if (fs->id == breakOnResolveID) gdbShouldBreakHere();
+  if (fs->id == breakOnResolveID) debuggerBreakHere();
 
   // If this fails, need to filter out those FSes.
   INT_ASSERT(fs->inTree() && fs->getFunction()->isResolved());

--- a/compiler/resolution/lowerLoopContexts.cpp
+++ b/compiler/resolution/lowerLoopContexts.cpp
@@ -961,7 +961,7 @@ void lowerContexts() {
     for_vector(BaseAST, ast, asts) {
       if (CForLoop* loop = toCForLoop(ast)) {
         CONTEXT_DEBUG(0, "encountered a C loop", loop);
-        if (loop->id == breakOnResolveID) gdbShouldBreakHere();
+        if (loop->id == breakOnResolveID) debuggerBreakHere();
 
         ContextHandler h(loop);
         h.collectHandleAndOuterContexts();

--- a/compiler/resolution/nilChecking.cpp
+++ b/compiler/resolution/nilChecking.cpp
@@ -585,7 +585,7 @@ static void checkCall(
   CallExpr* initCall = NULL;
 
   if (call->id == debugNilsForId)
-    gdbShouldBreakHere();
+    debuggerBreakHere();
 
   // set moveLike and userCall
   if (call->isPrimitive(PRIM_MOVE) ||
@@ -1137,7 +1137,7 @@ static void checkBasicBlock(
     }
 
     if (expr->id == debugNilsForId)
-      gdbShouldBreakHere();
+      debuggerBreakHere();
 
     if (ForallStmt* forall = toForallStmt(expr)) {
 
@@ -1318,7 +1318,7 @@ static void findNilDereferencesInFn(FnSymbol* fn) {
   if (debugging) {
     printf("Visiting function %s id %i\n", fn->name, fn->id);
     nprint_view(fn);
-    gdbShouldBreakHere();
+    debuggerBreakHere();
   }
 
   BasicBlock::buildBasicBlocks(fn);

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -581,7 +581,7 @@ static Expr* preFoldPrimInitVarForManagerResource(CallExpr* call) {
       INT_ASSERT(isSymExpr(call->get(2)));
 
       if (call->id == breakOnResolveID) {
-        gdbShouldBreakHere();
+        debuggerBreakHere();
       }
 
       Symbol* lhs = se->symbol();
@@ -727,7 +727,7 @@ static Expr* preFoldPrimInitVarForManagerResource(CallExpr* call) {
 }
 
 static Expr* preFoldPrimResolves(CallExpr* call) {
-  if (call->id == breakOnResolveID) gdbShouldBreakHere();
+  if (call->id == breakOnResolveID) debuggerBreakHere();
 
   // This primitive should only have one actual.
   INT_ASSERT(call && call->numActuals() == 1);

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -536,7 +536,7 @@ void resolveFunction(FnSymbol* fn, CallExpr* forCall) {
     if (fn->id == breakOnResolveID) {
       printf("breaking on resolve fn %s[%d] (%d args)\n",
              fn->name, fn->id, fn->numFormals());
-      gdbShouldBreakHere();
+      debuggerBreakHere();
     }
 
     fn->addFlag(FLAG_RESOLVED);
@@ -3016,7 +3016,7 @@ static void insertCasts(BaseAST* ast, FnSymbol* fn,
             lhsType = lhsType->getValType();
 
           if (call->id == breakOnResolveID)
-            gdbShouldBreakHere();
+            debuggerBreakHere();
 
           Symbol* to = lhs->symbol();
           Symbol* toType = NULL;

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -1120,7 +1120,7 @@ const char* clearErrorFormat() {
 
 void clean_exit(int status) {
   if (status != 0) {
-    gdbShouldBreakHere();
+    debuggerBreakHere();
   }
 
   cleanup_for_exit();

--- a/doc/rst/developer/bestPractices/CompilerDebugging.rst
+++ b/doc/rst/developer/bestPractices/CompilerDebugging.rst
@@ -152,7 +152,7 @@ Other tips
   (gdb) break checkNormalized
     stop right after the normalization pass
 
-  gdbShouldBreakHere()
+  debuggerBreakHere()
     compiler/etc/gdb.commands sets a breakpoint on this function
 
 

--- a/doc/rst/developer/bestPractices/CompilerIRTricks.rst
+++ b/doc/rst/developer/bestPractices/CompilerIRTricks.rst
@@ -89,7 +89,7 @@ To break on the creation of a particular ID, use ``--break-on-id``:
   Breakpoint 1 at 0x527ae0
   (gdb) run
   Starting program: chpl --break-on-id 70157 -o ./bin/hello ./test/release/example/hello.chpl
-  Breakpoint 1, 0x0000000000527ae0 in gdbShouldBreakHere ()
+  Breakpoint 1, 0x0000000000527ae0 in debuggerBreakHere ()
   (gdb) 
 
 Should you want to break on more than one ID without running gdb several

--- a/frontend/include/chpl/util/break.h
+++ b/frontend/include/chpl/util/break.h
@@ -22,7 +22,6 @@
 #define CHPL_UTIL_BREAK_H
 
 // must be exported to avoid dead-code elimination by C++ compiler
-void gdbShouldBreakHere();
 void debuggerBreakHere();
 
 #endif

--- a/frontend/lib/framework/Context.cpp
+++ b/frontend/lib/framework/Context.cpp
@@ -914,7 +914,7 @@ void Context::collectGarbage() {
 
 void Context::report(owned<ErrorBase> error) {
   if (!config_.disableErrorBreakpoints) {
-    gdbShouldBreakHere();
+    debuggerBreakHere();
   }
 
   // If errorCollectionStack is not empty, errors are being collected, and

--- a/frontend/lib/util/break.cpp
+++ b/frontend/lib/util/break.cpp
@@ -20,10 +20,6 @@
 #include "chpl/util/break.h"
 
 // must be non-static to avoid dead-code elim. when compiling -O3
-void gdbShouldBreakHere() {
-
-}
-
 void debuggerBreakHere() {
-  gdbShouldBreakHere();
+
 }


### PR DESCRIPTION
Renames `gdbShouldBreakHere` to `debuggerBreakHere` in the compiler. This is so we use a debugger agnostic term as the function can be used with other debuggers (e.g. lldb)

- [x] standard linux64 paratest
- [x] checked that basic debugging still works with gdb
- [x] checked that basic debugging still works with lldb

[Reviewed by @benharsh]