### PR TITLE
dlopen: Fetch the 'dlopen' handle for the current locale before doing 'dlsym'

### DIFF
--- a/modules/internal/ChapelDynamicLoading.chpl
+++ b/modules/internal/ChapelDynamicLoading.chpl
@@ -316,7 +316,7 @@ module ChapelDynamicLoading {
         if shouldCreateNewEntry {
           var bin = new owned chpl_BinaryInfo(path, chpl_binaryInfoStore);
 
-          // Swap in the LOCALE-0 pointer. This clears the local variable.
+          // Swap in pointer on LOCALE-0. This clears the variable.
           bin._systemPtrs[0] <=> ptr0;
 
           var errBuf = new chpl_localBuffer(owned DynLibError?, numLocales);
@@ -338,9 +338,9 @@ module ChapelDynamicLoading {
                 on Locales[0] do errBuf[n] = err;
                 numErrs.add(1);
               } else if ptr {
-                // The buffer is not wide!
-                on Locales[0] do bin._systemPtrs[n] = ptr;
-                // Clear the pointer to avoid closing it in the defer.
+                // Swap in pointer on LOCALE-0. This clears the variable.
+                on Locales[0] do bin._systemPtrs[n] <=> ptr;
+
                 ptr = nil;
               } else {
                 // TODO: Construct an error instead.
@@ -469,7 +469,7 @@ module ChapelDynamicLoading {
             coforall loc in Locales[1..] do on loc {
               const n = (here.id: int);
 
-              // Fetch the system handle that is stored on Locale[0].
+              // Fetch the system handle that is stored on LOCALE-0.
               var handle: c_ptr(void);
               on Locales[0] do handle = _systemPtrs[n];
 

--- a/modules/internal/ChapelDynamicLoading.chpl
+++ b/modules/internal/ChapelDynamicLoading.chpl
@@ -440,10 +440,10 @@ module ChapelDynamicLoading {
         var shouldInternPointer = false;
 
         // No need to grab the lock, this should not be modified (or nil).
-        const handle = _systemPtrs[0];
-        assert(handle != nil);
+        const handle0 = _systemPtrs[0];
+        assert(handle0 != nil);
 
-        const ptr0 = localDynLoadSymbolLookup(sym, handle, errBuf[0]);
+        const ptr0 = localDynLoadSymbolLookup(sym, handle0, errBuf[0]);
 
         if errBuf[0] == nil && ptr0 != nil {
           manage this.withReadLock() {
@@ -468,6 +468,10 @@ module ChapelDynamicLoading {
             // Loop over all locales and fetch the symbol's local pointer.
             coforall loc in Locales[1..] do on loc {
               const n = (here.id: int);
+
+              // Fetch the system handle that is stored on Locale[0].
+              var handle: c_ptr(void);
+              on Locales[0] do handle = _systemPtrs[n];
 
               var err: owned DynLibError?;
               const ptr = localDynLoadSymbolLookup(sym, handle, err);

--- a/test/dynamic-loading/LoadForeignLibrary.skipif
+++ b/test/dynamic-loading/LoadForeignLibrary.skipif
@@ -1,1 +1,0 @@
-CHPL_TARGET_PLATFORM != darwin


### PR DESCRIPTION
This PR fixes a silly bug that was breaking the `LoadForeignLibrary.chpl` test on `linux64`. It turns out that we were incorrectly using the `dlopen` handle for `Locales[0]` on any other locale. This PR makes sure to grab the handle for the currently executing locale out of the buffer stored on `Locales[0]`.

The reason this bug was not observed on OSX is because, at least on my machine, when a shared object is dynamically loaded, it appears to be seated in the same virtual address range regardless of the process. I observed the following debugging output on OSX:

```
path: './TestCLibraryToLoad.so'
system-pointers: 0x4604bd80 0x4604bd80 0x4604bd80 0x4604bd80
opened symbols:
```

This isn't a bug: each different locale's process loaded up `./TestCLibraryToLoad.so` at the same exact virtual address. Note that there's no launcher and `GASNET_SPAWNFN=L`, so we're oversubscribing.

On `linux64` each locale presented a different address for the loaded in shared library.

I'm not sure if this is:

- Some failure for OSX to adhere to ASLR
- The OSX dynamic loader being able to get away with mapping to the same virtual address range
- Or the shared library being pinned for some reason (not fully relocatable?! I compiled with `-fPIC`)
- Maybe ASLR for libraries is just weaker on OSX?

But it's interesting nonetheless.

TESTING

- [x] `ALL` on `linux64`

Reviewed by @jabraham17. Thanks!