### PR TITLE
Skip a dynamic loading test if the C backend is being used

### DIFF
--- a/test/dynamic-loading/LoadForeignLibrary.skipif
+++ b/test/dynamic-loading/LoadForeignLibrary.skipif
@@ -1,0 +1,1 @@
+CHPL_LLVM==none


### PR DESCRIPTION
Skip the `LoadForeignLibrary.chpl` test if we are running with the C backend. Function pointers aren't supported yet on the C backend. Trivial and not reviewed.