### PR TITLE
Adjust .skipif to check CHPL_TARGET_COMPILER instead of CHPL_LLVM

### DIFF
--- a/test/dynamic-loading/LoadForeignLibrary.skipif
+++ b/test/dynamic-loading/LoadForeignLibrary.skipif
@@ -1,1 +1,1 @@
-CHPL_LLVM==none
+CHPL_TARGET_COMPILER!=llvm


### PR DESCRIPTION
In #27210 I skipped a test if `CHPL_LLVM=none`. The intention was to skip the test if the LLVM backend is not being used. Adjust the skipif to check `CHPL_TARGET_COMPILER!=llvm` instead since that is more accurate. Trivial and not reviewed.