### PR TITLE
Add skipifs for new Python parquet example

### DIFF
--- a/test/library/packages/Python/examples/parquet/readParquet.skipif
+++ b/test/library/packages/Python/examples/parquet/readParquet.skipif
@@ -1,0 +1,11 @@
+# skip valgrind + numba/numpy testing
+# numba (really numpy) doesn't like valgrind due to 80 bit float precision issues
+#  - https://github.com/numpy/numpy/issues/12930
+#  - https://valgrind.org/docs/manual/manual-core.html#manual-core.limits
+CHPL_TEST_VGRND_EXE==on
+
+# pyarrow/pandas doesn't build well on linux32
+CHPL_TARGET_PLATFORM==linux32
+
+# requires iterator inlining
+COMPOPTS <= --baseline


### PR DESCRIPTION
Adds a skipif for a few testing configuration where the Python parquet example fails

[Not reviewed - trivial]