### PR TITLE
Add a suppressif for two debugging tests

### DIFF
--- a/test/library/standard/Debugger/breakpoint/useBreakpoint-gdb.suppressif
+++ b/test/library/standard/Debugger/breakpoint/useBreakpoint-gdb.suppressif
@@ -1,0 +1,2 @@
+# running lldb on multi-locale code is not yet well supported
+CHPL_COMM!=none

--- a/test/library/standard/Debugger/breakpoint/useBreakpoint-lldb.suppressif
+++ b/test/library/standard/Debugger/breakpoint/useBreakpoint-lldb.suppressif
@@ -1,0 +1,2 @@
+# running lldb on multi-locale code is not yet well supported
+CHPL_COMM!=none


### PR DESCRIPTION
Adds a suppressif for two debugging tests that do not yet work well with multi-locale code.

[Not reviewed - trivial]