### PR TITLE
Dyno: const ref field access, aliasing arrays

### DIFF
--- a/frontend/include/chpl/resolution/resolution-queries.h
+++ b/frontend/include/chpl/resolution/resolution-queries.h
@@ -687,6 +687,7 @@ Access accessForQualifier(uast::Qualifier q);
 const MostSpecificCandidate*
 determineBestReturnIntentOverload(const MostSpecificCandidates& candidates,
                                   Access access,
+                                  types::QualifiedType::Kind &outReturnKind,
                                   bool& outAmbiguity);
 
 /**

--- a/frontend/include/chpl/types/ArrayType.h
+++ b/frontend/include/chpl/types/ArrayType.h
@@ -101,6 +101,8 @@ class ArrayType final : public CompositeType {
 
   const RuntimeType* runtimeType(Context* context) const;
 
+  bool isAliasingArray(Context* context) const;
+
   ~ArrayType() = default;
 
   virtual void stringify(std::ostream& ss,

--- a/frontend/include/chpl/types/ArrayType.h
+++ b/frontend/include/chpl/types/ArrayType.h
@@ -73,8 +73,6 @@ class ArrayType final : public CompositeType {
                                        const QualifiedType& domainType,
                                        const QualifiedType& eltType);
 
-  const RuntimeType* getDomainRuntimeType() const;
-
   const Type* substitute(Context* context,
                          const PlaceholderMap& subs) const override {
     return getArrayTypeQuery(context,

--- a/frontend/include/chpl/types/FnIteratorType.h
+++ b/frontend/include/chpl/types/FnIteratorType.h
@@ -37,15 +37,20 @@ class FnIteratorType final : public IteratorType {
    */
   const resolution::TypedFnSignature* iteratorFn_;
 
+  QualifiedType yieldType_;
+
   FnIteratorType(const resolution::PoiScope* poiScope,
-                 const resolution::TypedFnSignature* iteratorFn)
+                 const resolution::TypedFnSignature* iteratorFn,
+                 QualifiedType yieldType)
     : IteratorType(typetags::FnIteratorType, poiScope),
-      iteratorFn_(iteratorFn) {}
+      iteratorFn_(iteratorFn),
+      yieldType_(std::move(yieldType)) {}
 
   bool contentsMatchInner(const Type* other) const override {
     auto rhs = (FnIteratorType*) other;
     return iteratorTypeContentsMatchInner(rhs) &&
-           this->iteratorFn_ == rhs->iteratorFn_;
+           this->iteratorFn_ == rhs->iteratorFn_ &&
+           this->yieldType_ == rhs->yieldType_;
   }
 
   void markUniqueStringsInner(Context* context) const override;
@@ -53,20 +58,26 @@ class FnIteratorType final : public IteratorType {
   static const owned <FnIteratorType>&
   getFnIteratorType(Context* context,
                     const resolution::PoiScope* poiScope,
-                    const resolution::TypedFnSignature* iteratorFn);
+                    const resolution::TypedFnSignature* iteratorFn,
+                    QualifiedType yieldType);
 
  public:
   static const FnIteratorType* get(Context* context,
                                    const resolution::PoiScope* poiScope,
-                                   const resolution::TypedFnSignature* iteratorFn);
+                                   const resolution::TypedFnSignature* iteratorFn,
+                                   QualifiedType yieldType);
 
   virtual const Type* substitute(Context* context,
                                  const PlaceholderMap& subs) const override {
-    return get(context, poiScope_, iteratorFn_->substitute(context, subs));
+    return get(context, poiScope_, iteratorFn_->substitute(context, subs), yieldType_.substitute(context, subs));
   }
 
   const resolution::TypedFnSignature* iteratorFn() const {
     return iteratorFn_;
+  }
+
+  const QualifiedType& yieldType() const {
+    return yieldType_;
   }
 };
 

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -4810,9 +4810,11 @@ bool Resolver::enter(const uast::Manage* manage) {
         auto overloadsIt = witness->returnIntentOverloads().find(id);
         if (overloadsIt != witness->returnIntentOverloads().end()) {
           bool ambiguity;
+          QualifiedType::Kind ignoredKind;
           auto bestCandidate =
             determineBestReturnIntentOverload(overloadsIt->second,
                                               accessContext,
+                                              ignoredKind,
                                               ambiguity);
           CHPL_ASSERT(!ambiguity);
           CHPL_ASSERT(bestCandidate);

--- a/frontend/lib/resolution/disambiguation.cpp
+++ b/frontend/lib/resolution/disambiguation.cpp
@@ -1693,7 +1693,11 @@ static void testArgMapHelper(const DisambiguationContext& dctx,
   // since that affects the disambiguation.
 
   if (forwardingTo.type() != nullptr) {
-    actualType = forwardingTo;
+    if (auto fmlDecl = fa.formal()->toNamedDecl()) {
+      if (fmlDecl->name() == USTR("this")) {
+        actualType = forwardingTo;
+      }
+    }
   }
   CanPassResult result = canPass(dctx.rc->context(), actualType, formalType);
   CHPL_ASSERT(result.passes());

--- a/frontend/lib/resolution/maybe-const.cpp
+++ b/frontend/lib/resolution/maybe-const.cpp
@@ -231,9 +231,11 @@ bool AdjustMaybeRefs::enter(const Call* ast, RV& rv) {
   // is it return intent overloading? resolve that
   if (candidates.numBest() > 1) {
     Access access = currentAccess();
-    auto kind = re.type().kind();
+    auto kind = QualifiedType::UNKNOWN;
     bool ambiguity;
     auto best = determineBestReturnIntentOverload(candidates, access, kind, ambiguity);
+    if (kind == QualifiedType::UNKNOWN)
+      kind = re.type().kind();
     if (ambiguity)
       context->error(ast, "Too much recursion to infer return intent overload");
 

--- a/frontend/lib/resolution/maybe-const.cpp
+++ b/frontend/lib/resolution/maybe-const.cpp
@@ -231,18 +231,18 @@ bool AdjustMaybeRefs::enter(const Call* ast, RV& rv) {
   // is it return intent overloading? resolve that
   if (candidates.numBest() > 1) {
     Access access = currentAccess();
+    auto kind = re.type().kind();
     bool ambiguity;
-    auto best = determineBestReturnIntentOverload(candidates, access, ambiguity);
+    auto best = determineBestReturnIntentOverload(candidates, access, kind, ambiguity);
     if (ambiguity)
       context->error(ast, "Too much recursion to infer return intent overload");
 
     CHPL_ASSERT(best);
-    auto fn = best->fn();
     resolver.validateAndSetMostSpecific(re, ast, MostSpecificCandidates::getOnly(*best));
 
-    // recompute the return type
-    // (all that actually needs to change is the return intent)
-    re.setType(returnType(rc, fn, re.poiScope()));
+    // adjust the return intent to one corresponding to the overload
+    CHPL_ASSERT(re.type().param() == nullptr);
+    re.setType(QualifiedType(kind, re.type().type()));
   }
 
   // there should be only one candidate at this point

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -7134,7 +7134,7 @@ yieldTypeForIterator(ResolutionContext* rc,
 
   QualifiedType ret;
   if (auto fnIter = iter->toFnIteratorType()) {
-    ret = yieldType(rc, fnIter->iteratorFn(), iter->poiScope());
+    ret = fnIter->yieldType();
   } else if (auto loopIter = iter->toLoopExprIteratorType()) {
     ret = loopIter->yieldType();
   } else {
@@ -7491,10 +7491,7 @@ static const types::QualifiedType& getPromotionTypeQuery(Context* context, types
   } else if (auto loopIt = qt.type()->toLoopExprIteratorType()) {
     ret = loopIt->yieldType();
   } else if (auto fnIt = qt.type()->toFnIteratorType()) {
-    // TODO, the iteratorFn could be a nested function, in which case a default
-    //       resolution context is not sufficient.
-    ResolutionContext rc(context);
-    ret = yieldType(&rc, fnIt->iteratorFn(), fnIt->poiScope());
+    ret = fnIt->yieldType();
   } else if (auto promoIt = qt.type()->toPromotionIteratorType()) {
     ret = promoIt->yieldType();
   } else {

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -7608,9 +7608,12 @@ Access accessForQualifier(Qualifier q) {
   return VALUE; // including IN at least
 }
 
+// leaves outReturnKind unchanged if no return intent overload selection
+// took place.
 const MostSpecificCandidate*
 determineBestReturnIntentOverload(const MostSpecificCandidates& candidates,
                                   Access access,
+                                  QualifiedType::Kind& outReturnKind,
                                   bool& outAmbiguity) {
   outAmbiguity = false;
   const MostSpecificCandidate* best = nullptr;
@@ -7637,6 +7640,12 @@ determineBestReturnIntentOverload(const MostSpecificCandidates& candidates,
       else if (bestConstRef) best = &bestConstRef;
       else best = &bestRef;
     }
+
+    // set the determined return intent.
+    if (best == &bestRef) outReturnKind = QualifiedType::REF;
+    else if (best == &bestConstRef) outReturnKind = QualifiedType::CONST_REF;
+    else if (best == &bestValue) outReturnKind = QualifiedType::CONST_VAR;
+
   } else if (candidates.numBest() == 1) {
     best = &candidates.only();
   }

--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -1171,7 +1171,7 @@ returnTypes(ResolutionContext* rc,
   result.second = result.first;
   if (sig->isIterator() && !result.second.isUnknownOrErroneous()) {
     result.second = QualifiedType(result.second.kind(),
-                                  FnIteratorType::get(context, poiScope, sig));
+                                  FnIteratorType::get(context, poiScope, sig, result.second));
   }
 
   return CHPL_RESOLUTION_QUERY_END(result);

--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -54,7 +54,8 @@ using namespace uast;
 using namespace types;
 
 // forward declarations
-static QualifiedType adjustForReturnIntent(uast::Function::ReturnIntent ri,
+static QualifiedType adjustForReturnIntent(Context* context,
+                                           uast::Function::ReturnIntent ri,
                                            QualifiedType retType);
 
 
@@ -468,7 +469,7 @@ QualifiedType ReturnTypeInferrer::returnedType() {
       context->error(fnAst, "could not determine return type for function");
       retType = QualifiedType(QualifiedType::UNKNOWN, ErroneousType::get(context));
     }
-    auto adjType = adjustForReturnIntent(returnIntent, *retType);
+    auto adjType = adjustForReturnIntent(context, returnIntent, *retType);
     return adjType;
   }
 }
@@ -750,14 +751,23 @@ static QualifiedType computeTypeOfField(ResolutionContext* rc,
   return QualifiedType(QualifiedType::VAR, ErroneousType::get(context));
 }
 
-static QualifiedType adjustForReturnIntent(uast::Function::ReturnIntent ri,
+static QualifiedType adjustForReturnIntent(Context* context,
+                                           uast::Function::ReturnIntent ri,
                                            QualifiedType retType) {
 
   QualifiedType::Kind kind = (QualifiedType::Kind) ri;
-  // adjust default / const return intent to 'var'
-  if (kind == QualifiedType::DEFAULT_INTENT ||
-      kind == QualifiedType::VAR) {
+  // adjust const return intent to 'var'
+  if (kind == QualifiedType::VAR) {
     kind = QualifiedType::CONST_VAR;
+  // do the same for default intent, except for aliasing arrays, which
+  // are non-const by default.
+  } else if (kind == QualifiedType::DEFAULT_INTENT) {
+    const ArrayType* at = nullptr;
+    if (retType.type() && (at = retType.type()->toArrayType()) && at->isAliasingArray(context)) {
+      kind = QualifiedType::VAR;
+    } else {
+      kind = QualifiedType::CONST_VAR;
+    }
   }
   return QualifiedType(kind, retType.type(), retType.param());
 }
@@ -1100,7 +1110,7 @@ static bool helpComputeReturnType(ResolutionContext* rc,
 
       auto g = getTypeGenericity(context, result.type());
       if (g == Type::CONCRETE) {
-        result = adjustForReturnIntent(fn->returnIntent(), result);
+        result = adjustForReturnIntent(context, fn->returnIntent(), result);
         return true;
       }
     }

--- a/frontend/lib/types/ArrayType.cpp
+++ b/frontend/lib/types/ArrayType.cpp
@@ -39,6 +39,34 @@ const RuntimeType* ArrayType::runtimeType(Context* context) const {
   return resolution::getRuntimeType(context, this);
 }
 
+static bool const& isAliasingArrayQuery(Context* context, const ArrayType* at) {
+  QUERY_BEGIN(isAliasingArrayQuery, context, at);
+  bool res = false;
+  // assume that there's only one ID that doesn't have a blank path,
+  // and that this ID is the instance field.
+  for (auto& sub : at->substitutions()) {
+    if (sub.first.symbolPath().isEmpty()) continue;
+    auto instanceQt = sub.second;
+
+    if (instanceQt.isUnknownOrErroneous()) break;
+
+    if (auto ct = instanceQt.type()->getCompositeType()) {
+      auto ast = parsing::idToAst(context, ct->id());
+      if (auto ag = ast->attributeGroup()) {
+        if (ag->hasPragma(uast::pragmatags::PRAGMA_ALIASING_ARRAY)) {
+          res = true;
+          break;
+        }
+      }
+    }
+  }
+
+  return QUERY_END(res);
+}
+
+bool ArrayType::isAliasingArray(Context* context) const {
+  return isAliasingArrayQuery(context, this);
+}
 
 void ArrayType::stringify(std::ostream& ss,
                            chpl::StringifyKind stringKind) const {

--- a/frontend/lib/types/FnIteratorType.cpp
+++ b/frontend/lib/types/FnIteratorType.cpp
@@ -26,22 +26,25 @@ namespace types {
 
 void FnIteratorType::markUniqueStringsInner(Context* context) const {
   iteratorFn_->mark(context);
+  yieldType_.mark(context);
 }
 
 const owned<FnIteratorType>&
 FnIteratorType::getFnIteratorType(Context* context,
                                   const resolution::PoiScope* poiScope,
-                                  const resolution::TypedFnSignature* iteratorFn) {
-  QUERY_BEGIN(getFnIteratorType, context, poiScope, iteratorFn);
-  auto result = toOwned(new FnIteratorType(poiScope, iteratorFn));
+                                  const resolution::TypedFnSignature* iteratorFn,
+                                  QualifiedType retType) {
+  QUERY_BEGIN(getFnIteratorType, context, poiScope, iteratorFn, retType);
+  auto result = toOwned(new FnIteratorType(poiScope, iteratorFn, retType));
   return QUERY_END(result);
 }
 
 const FnIteratorType*
 FnIteratorType::get(Context* context,
                     const resolution::PoiScope* poiScope,
-                    const resolution::TypedFnSignature* iteratorFn) {
-  return getFnIteratorType(context, poiScope, iteratorFn).get();
+                    const resolution::TypedFnSignature* iteratorFn,
+                    QualifiedType retType) {
+  return getFnIteratorType(context, poiScope, iteratorFn, retType).get();
 }
 
 }  // end namespace types

--- a/frontend/lib/types/PromotionIteratorType.cpp
+++ b/frontend/lib/types/PromotionIteratorType.cpp
@@ -29,15 +29,17 @@ void PromotionIteratorType::markUniqueStringsInner(Context* context) const {
   for (const auto& pair : promotedFormals_) {
     pair.second.mark(context);
   }
+  yieldType_.mark(context);
 }
 
 const owned<PromotionIteratorType>&
 PromotionIteratorType::getPromotionIteratorType(Context* context,
                                                 const resolution::PoiScope* poiScope,
                                                 const resolution::TypedFnSignature* scalarFn,
+                                                QualifiedType retType,
                                                 resolution::SubstitutionsMap promotedFormals) {
-  QUERY_BEGIN(getPromotionIteratorType, context, poiScope, scalarFn, promotedFormals);
-  auto result = toOwned(new PromotionIteratorType(poiScope, scalarFn, std::move(promotedFormals)));
+  QUERY_BEGIN(getPromotionIteratorType, context, poiScope, scalarFn, retType, promotedFormals);
+  auto result = toOwned(new PromotionIteratorType(poiScope, scalarFn, std::move(retType), std::move(promotedFormals)));
   return QUERY_END(result);
 }
 
@@ -45,8 +47,9 @@ const PromotionIteratorType*
 PromotionIteratorType::get(Context* context,
                            const resolution::PoiScope* poiScope,
                            const resolution::TypedFnSignature* scalarFn,
+                           QualifiedType retType,
                            resolution::SubstitutionsMap promotedFormals) {
-  return getPromotionIteratorType(context, poiScope, scalarFn, std::move(promotedFormals)).get();
+  return getPromotionIteratorType(context, poiScope, scalarFn, std::move(retType), std::move(promotedFormals)).get();
 }
 
 }  // end namespace types


### PR DESCRIPTION
Closes https://github.com/Cray/chapel-private/issues/7333. There's no issue for const field accessors, but this would close that too.

The original program I set out to make work was this:

```Chapel
proc helper(ref data) {
  data[5] = 10;
}

proc test() {
  var A : [1..10] int;
  helper(A[1..5]);
}
test();
```

The curiosity here is that `ref data` accepts a mutable reference, and we are passing it a slice. Normally, a value produced by an expression cannot be passed to a mutable reference, since it's a temporary. However, slices produce values that _alias_ other arrays. Although they are values, they can be used for non-const references.

The fact that the result of slicing `A` is const for const `A` and non-const for non-const `A` seemed similar to how field access works (fields are refs if the receiver is mutable, const refs if it's not). In looking for how we handle the latter in Dyno, I noticed that we don't. Thus, prior to this PR, the following program causes no problems.

```Chapel
record R { var x: int; }
const r: R;
ref myX = r.x;
```

Thus, I set out to handle both things (field access and slicing). In production, the latter is implemented via `pragma "reference to const when const this"`. However, such adjustments -- which depend on the constness of the receiver _actual_ type -- happen _separately_ from computing the return type a function (which, once it's been instantiated, does not depend on the actuals at all). This, in turn, meant that they would need to be done separately from `returnType`, `returnTypes`, and `yieldType` queries. I was concerned about this, because we call `returnType` a lot, and having to adjust each call site was difficult in some cases, and impossible in others.

Thus, I made the following changes:

* Switched `PromotionIteratorType` to contain its yield type, determined at the time where a promoted call is detected. This is needed anyway since one could promote a `"reference to const when const this"` function, and thus, a typed signature alone does not uniquely determine the yielded type of a `PromotionIteratorType`. 
* For the same reason, changes `FnIteratorType` to contain its yield type.
* Avoids re-running `returnType` when handling return intent overloading. As a comment there points out, the only thing that needs to change is the intent of the result type; we can infer that from the chosen overload.

This leaves very few places where `returnType` and friends are used. The only place that then requires changes for handling constness is in "mainline" call resolution code. This PR adjusts that, including checks for field constnesss and `"reference to const when const this"`.

This, however, was not sufficient to get the `slices` primer to resolve. It seems like we have special `const` checking exceptions for when the type being returned is an aliasing array. This PR adjusts the return intent inference logic to detect aliasing arrays -- and aliasing arrays only -- and mark them as non-const.

Reviewed by @benharsh -- thanks!

## Testing
- [x] dyno tests
- [x] `release/examples/spec` (no change)
- [x] `release/examples/primers` (-1 failure, `slices` is now passing)
- [x] paratest