### PR TITLE
Fix names of `c_ssize_t` and `c_size_t` in extern technote

### DIFF
--- a/doc/rst/technotes/extern.rst
+++ b/doc/rst/technotes/extern.rst
@@ -98,8 +98,8 @@ The Chapel names for C types are:
   c_uchar
   c_short
   c_ushort
-  ssize_t
-  size_t
+  c_ssize_t
+  c_size_t
   c_ptr(T)
   c_ptrConst(T)
   c_array(T,n)


### PR DESCRIPTION
Fix the names of the `c_ssize_t` and `c_size_t` symbols in the extern technote, which were missing their `c_` prefix.

These prefixes were added in https://github.com/chapel-lang/chapel/pull/19284.

[reviewer info placeholder]