### PR TITLE
Remove mentions of `c_string` in extern technote

### DIFF
--- a/doc/rst/technotes/extern.rst
+++ b/doc/rst/technotes/extern.rst
@@ -118,7 +118,7 @@ described in the next section.
 
 
 Pointer Types
-------------------------
+-------------
 
 Chapel supports the following C pointer types: c_ptr(T),
 c_ptrConst(T), and c_fn_ptr. In addition, it supports c_array(T,n).
@@ -839,7 +839,7 @@ types; for example:
 
 
 Pointer Types in Extern Blocks
--------------
+------------------------------
 
 See the section `Pointer Types`_ above for background on
 how the Chapel programs can work with C pointer types. Any pointer type used in


### PR DESCRIPTION
Remove mentions of `c_string` from the C Interop technote (`extern.rst`), as `c_string` no longer exists.

`c_string` was removed in https://github.com/chapel-lang/chapel/pull/26523.

[reviewer info placeholder]