### PR TITLE
Dyno: Various copy-elision and split-init fixes

### DIFF
--- a/frontend/lib/resolution/VarScopeVisitor.cpp
+++ b/frontend/lib/resolution/VarScopeVisitor.cpp
@@ -235,15 +235,14 @@ void VarScopeVisitor::handleConditional(const Conditional* cond, RV& rv) {
   if (thenFrame) frames.push_back(thenFrame);
   if (elseFrame) frames.push_back(elseFrame);
 
-  // 'total' indicates whether a branch is always taken
-  bool total = false;
+  bool alwaysTaken = false;
   if (elseFrame) {
-    total = true;
+    alwaysTaken = true;
   } else if (thenFrame && thenFrame->knownPath) {
-    total = true;
+    alwaysTaken = true;
   }
 
-  handleDisjunction(cond, frame, frames, total, rv);
+  handleDisjunction(cond, frame, frames, alwaysTaken, rv);
   handleScope(cond, rv);
 }
 
@@ -251,14 +250,14 @@ void VarScopeVisitor::handleSelect(const Select* sel, RV& rv) {
   auto frame = currentFrame();
 
   std::vector<VarFrame*> frames;
-  bool total = sel->hasOtherwise();
+  bool alwaysTaken = sel->hasOtherwise();
   for(int i = 0; i < sel->numWhenStmts(); i++) {
     auto whenFrame = currentWhenFrame(i);
     if (!whenFrame) continue;
     frames.push_back(whenFrame);
-    total |= whenFrame->paramTrueCond;
+    alwaysTaken |= whenFrame->paramTrueCond;
   }
-  handleDisjunction(sel, frame, frames, total, rv);
+  handleDisjunction(sel, frame, frames, alwaysTaken, rv);
   handleScope(sel, rv);
 }
 

--- a/frontend/lib/resolution/VarScopeVisitor.cpp
+++ b/frontend/lib/resolution/VarScopeVisitor.cpp
@@ -335,9 +335,11 @@ bool VarScopeVisitor::enter(const OpCall* ast, RV& rv) {
     rhsAst->traverse(rv);
 
     handleAssign(ast, rv);
-  }
 
-  return false;
+    return false;
+  } else {
+    return true;
+  }
 }
 
 void VarScopeVisitor::exit(const OpCall* ast, RV& rv) {

--- a/frontend/lib/resolution/VarScopeVisitor.cpp
+++ b/frontend/lib/resolution/VarScopeVisitor.cpp
@@ -234,7 +234,16 @@ void VarScopeVisitor::handleConditional(const Conditional* cond, RV& rv) {
   std::vector<VarFrame*> frames;
   if (thenFrame) frames.push_back(thenFrame);
   if (elseFrame) frames.push_back(elseFrame);
-  handleDisjunction(cond, frame, frames, elseFrame != nullptr, rv);
+
+  // 'total' indicates whether a branch is always taken
+  bool total = false;
+  if (elseFrame) {
+    total = true;
+  } else if (thenFrame && thenFrame->knownPath) {
+    total = true;
+  }
+
+  handleDisjunction(cond, frame, frames, total, rv);
   handleScope(cond, rv);
 }
 

--- a/frontend/lib/resolution/VarScopeVisitor.h
+++ b/frontend/lib/resolution/VarScopeVisitor.h
@@ -73,17 +73,17 @@ class VarScopeVisitor : public BranchSensitiveVisitor<VarFrame, MutatingResolved
   /** Called for <expr> = <expr> assignment pattern */
   virtual void handleAssign(const uast::OpCall* ast, RV& rv) = 0;
   /** Called for an actual passed to an 'out' formal */
-  virtual void handleOutFormal(const uast::FnCall* ast,
+  virtual void handleOutFormal(const uast::Call* ast,
                                const uast::AstNode* actual,
                                const types::QualifiedType& formalType, RV& rv) = 0;
   /** Called for an actual passed to an 'in' formal */
-  virtual void handleInFormal(const uast::FnCall* ast,
+  virtual void handleInFormal(const uast::Call* ast,
                               const uast::AstNode* actual,
                               const types::QualifiedType& formalType,
                               const types::QualifiedType* actualScalarType,
                               RV& rv) = 0;
   /** Called for an actual passed to an 'out' formal */
-  virtual void handleInoutFormal(const uast::FnCall* ast,
+  virtual void handleInoutFormal(const uast::Call* ast,
                                  const uast::AstNode* actual,
                                  const types::QualifiedType& formalType,
                                  const types::QualifiedType* actualScalarType,
@@ -154,7 +154,7 @@ class VarScopeVisitor : public BranchSensitiveVisitor<VarFrame, MutatingResolved
 
   /** Update initedVars if a call with at 'out' formal
       represents a split-init. Returns true if it was a split init. */
-  bool processSplitInitOut(const FnCall* ast,
+  bool processSplitInitOut(const Call* ast,
                            const AstNode* actual,
                            const std::set<ID>& allSplitInitedVars,
                            RV& rv);
@@ -171,6 +171,7 @@ class VarScopeVisitor : public BranchSensitiveVisitor<VarFrame, MutatingResolved
   const types::Param* determineWhenCaseValue(const uast::AstNode* ast, RV& extraData) override;
   const types::Param* determineIfValue(const uast::AstNode* ast, RV& extraData) override;
   void traverseNode(const uast::AstNode* ast, RV& rv) override;
+  bool resolvedCallHelper(const Call* callAst, RV& rv);
 
  public:
   void enterAst(const uast::AstNode* ast);

--- a/frontend/lib/resolution/VarScopeVisitor.h
+++ b/frontend/lib/resolution/VarScopeVisitor.h
@@ -112,12 +112,12 @@ class VarScopeVisitor : public BranchSensitiveVisitor<VarFrame, MutatingResolved
   virtual void handleSelect(const uast::Select* cond, RV& rv);
   /** Generalizes processing Conditional and Select nodes after handling
       their contents. Updates currentFrame based on the frames of the
-      possible branching targets stored in frames. total indicates whether
-      a branch is taken no matter the input. */
+      possible branching targets stored in frames. 'alwaysTaken' indicates
+      whether a branch is taken no matter the input. */
   virtual void handleDisjunction(const uast::AstNode * node,
                                  VarFrame* currentFrame,
                                  const std::vector<VarFrame*>& frames,
-                                 bool total,
+                                 bool alwaysTaken,
                                  RV& rv) = 0;
   /** Called to process any other Scope after handling its contents --
       should update scopeStack.back() which is the frame for the Try.

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -144,7 +144,7 @@ struct CallInitDeinit : VarScopeVisitor {
   void handleDisjunction(const AstNode * node,
                          VarFrame * currentFrame,
                          const std::vector<VarFrame*>& frames,
-                         bool total, RV& rv) override;
+                         bool alwaysTaken, RV& rv) override;
   void handleScope(const AstNode* ast, RV& rv) override;
 };
 
@@ -1255,7 +1255,7 @@ void CallInitDeinit::handleTry(const Try* t, RV& rv) {
 void CallInitDeinit::handleDisjunction(const uast::AstNode * node,
                                  VarFrame* currentFrame,
                                  const std::vector<VarFrame*>& frames,
-                                 bool total, RV& rv) {
+                                 bool alwaysTaken, RV& rv) {
 
   for (auto frame : frames) {
     if(!frame->controlFlowInfo.returnsOrThrows()) {

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -126,14 +126,14 @@ struct CallInitDeinit : VarScopeVisitor {
   void handleDeclaration(const VarLikeDecl* ast, RV& rv) override;
   void handleMention(const Identifier* ast, ID varId, RV& rv) override;
   void handleAssign(const OpCall* ast, RV& rv) override;
-  void handleOutFormal(const FnCall* ast, const AstNode* actual,
+  void handleOutFormal(const Call* ast, const AstNode* actual,
                        const QualifiedType& formalType,
                        RV& rv) override;
-  void handleInFormal(const FnCall* ast, const AstNode* actual,
+  void handleInFormal(const Call* ast, const AstNode* actual,
                       const QualifiedType& formalType,
                       const QualifiedType* actualScalarType,
                       RV& rv) override;
-  void handleInoutFormal(const FnCall* ast, const AstNode* actual,
+  void handleInoutFormal(const Call* ast, const AstNode* actual,
                          const QualifiedType& formalType,
                          const QualifiedType* actualScalarType,
                          RV& rv) override;
@@ -328,7 +328,8 @@ void CallInitDeinit::checkUseOfDeinited(const AstNode* useAst, ID varId) {
       }
 
       // TODO: fix this error
-      context->error(useAst, "use of dead / already deinited variable");
+      context->error(useAst, "use of dead / already deinited variable '%s'",
+                     useAst->toIdentifier()->name().str().c_str());
       break;
     }
   }
@@ -1096,7 +1097,7 @@ void CallInitDeinit::handleAssign(const OpCall* ast, RV& rv) {
     resolveAssign(ast, lhsType, rhsType, rv);
   }
 }
-void CallInitDeinit::handleOutFormal(const FnCall* ast,
+void CallInitDeinit::handleOutFormal(const Call* ast,
                                      const AstNode* actual,
                                      const QualifiedType& formalType,
                                      RV& rv) {
@@ -1122,7 +1123,7 @@ void CallInitDeinit::handleOutFormal(const FnCall* ast,
     resolveAssign(actual, actualType, formalType, rv);
   }
 }
-void CallInitDeinit::handleInFormal(const FnCall* ast, const AstNode* actual,
+void CallInitDeinit::handleInFormal(const Call* ast, const AstNode* actual,
                                     const QualifiedType& formalType,
                                     const QualifiedType* actualScalarType,
                                     RV& rv) {
@@ -1159,7 +1160,7 @@ void CallInitDeinit::handleInFormal(const FnCall* ast, const AstNode* actual,
   }
 }
 
-void CallInitDeinit::handleInoutFormal(const FnCall* ast,
+void CallInitDeinit::handleInoutFormal(const Call* ast,
                                        const AstNode* actual,
                                        const QualifiedType& formalType,
                                        const QualifiedType* actualScalarType,

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -854,7 +854,7 @@ void CallInitDeinit::processInit(VarFrame* frame,
       ID rhsDeclId = refersToId(rhsAst, rv);
       // copy elision with '=' should only apply to myVar = myOtherVar
       CHPL_ASSERT(!rhsDeclId.isEmpty());
-      frame->deinitedVars.emplace(rhsDeclId, ast->id());
+      frame->deinitedVars.emplace(rhsDeclId, currentStatement()->id());
     } else if (isCallProducingValue(rhsAst, rhsType, rv)) {
       // e.g. var x; x = callReturningValue();
       resolveMoveInit(ast, rhsAst, lhsType, rhsType, rv);
@@ -1152,7 +1152,7 @@ void CallInitDeinit::handleInFormal(const FnCall* ast, const AstNode* actual,
     ID actualId = refersToId(actual, rv);
     // copy elision should only apply to copies from variables
     CHPL_ASSERT(!actualId.isEmpty());
-    frame->deinitedVars.emplace(actualId, ast->id());
+    frame->deinitedVars.emplace(actualId, currentStatement()->id());
   } else {
     processInit(frame, actual, formalType,
                 actualScalarType ? *actualScalarType : actualType, rv);

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -323,8 +323,7 @@ void CallInitDeinit::checkUseOfDeinited(const AstNode* useAst, ID varId) {
     VarFrame* frame = scopeStack[i].get();
     if (frame->deinitedVars.count(varId) > 0) {
       // For vars dead after a call, don't error for uses within that call.
-      if (frame->deinitedVars[varId] ==
-          parsing::idToParentId(context, useAst->id())) {
+      if (frame->deinitedVars[varId].contains(useAst->id())) {
         continue;
       }
 
@@ -809,12 +808,6 @@ void CallInitDeinit::processInit(VarFrame* frame,
                                  const QualifiedType& lhsType,
                                  const QualifiedType& rhsType,
                                  RV& rv) {
-  if (lhsType.type() == rhsType.type() &&
-      !Type::needsInitDeinitCall(lhsType.type())) {
-    // TODO: we should resolve it anyway
-    return;
-  }
-
   // ast should be:
   //  * a '=' call
   //  * a VarLikeDecl
@@ -1149,8 +1142,7 @@ void CallInitDeinit::handleInFormal(const FnCall* ast, const AstNode* actual,
 
   // is the copy for 'in' elided?
   if (elidedCopyFromIds.count(actual->id()) > 0 &&
-      isValue(actualType.kind()) &&
-      Type::needsInitDeinitCall(actualType.type())) {
+      isValue(actualType.kind())) {
     CHPL_ASSERT(actualScalarType == nullptr);
     // it is move initialization
     resolveMoveInit(actual, actual, formalType, actualType, rv);

--- a/frontend/lib/resolution/copy-elision.cpp
+++ b/frontend/lib/resolution/copy-elision.cpp
@@ -88,14 +88,14 @@ struct FindElidedCopies : VarScopeVisitor {
   void handleDeclaration(const VarLikeDecl* ast, RV& rv) override;
   void handleMention(const Identifier* ast, ID varId, RV& rv) override;
   void handleAssign(const OpCall* ast, RV& rv) override;
-  void handleOutFormal(const FnCall* ast, const AstNode* actual,
+  void handleOutFormal(const Call* ast, const AstNode* actual,
                        const QualifiedType& formalType,
                        RV& rv) override;
-  void handleInFormal(const FnCall* ast, const AstNode* actual,
+  void handleInFormal(const Call* ast, const AstNode* actual,
                       const QualifiedType& formalType,
                       const QualifiedType* actualScalarType,
                       RV& rv) override;
-  void handleInoutFormal(const FnCall* ast, const AstNode* actual,
+  void handleInoutFormal(const Call* ast, const AstNode* actual,
                          const QualifiedType& formalType,
                          const QualifiedType* actualScalarType,
                          RV& rv) override;
@@ -335,7 +335,7 @@ void FindElidedCopies::handleAssign(const OpCall* ast, RV& rv) {
     processMentions(lhsAst, rv);
   }
 }
-void FindElidedCopies::handleOutFormal(const FnCall* ast,
+void FindElidedCopies::handleOutFormal(const Call* ast,
                                        const AstNode* actual,
                                        const QualifiedType& formalType,
                                        RV& rv) {
@@ -345,7 +345,7 @@ void FindElidedCopies::handleOutFormal(const FnCall* ast,
   // updated initedVars for split init
   processSplitInitOut(ast, actual, allSplitInitedVars, rv);
 }
-void FindElidedCopies::handleInFormal(const FnCall* ast, const AstNode* actual,
+void FindElidedCopies::handleInFormal(const Call* ast, const AstNode* actual,
                                       const QualifiedType& formalType,
                                       const QualifiedType* actualScalarType,
                                       RV& rv) {
@@ -374,7 +374,7 @@ void FindElidedCopies::handleInFormal(const FnCall* ast, const AstNode* actual,
     processMentions(actual, rv);
   }
 }
-void FindElidedCopies::handleInoutFormal(const FnCall* ast,
+void FindElidedCopies::handleInoutFormal(const Call* ast,
                                          const AstNode* actual,
                                          const QualifiedType& formalType,
                                          const QualifiedType* actualScalarType,

--- a/frontend/lib/resolution/copy-elision.cpp
+++ b/frontend/lib/resolution/copy-elision.cpp
@@ -594,6 +594,10 @@ static bool allowsCopyElision(const AstNode* ast) {
          ast->isTry();
 }
 
+// Note: This method is expected to be called _after_ special handling of
+// branching uAST, such that the results were collected into a single 'frame'.
+// Calling this method on each branch without first collecting the results
+// could erroneously clear the parent frame's 'points'.
 void FindElidedCopies::propagateChildToParent(VarFrame* frame, VarFrame* parent, const AstNode* ast) {
   // if it's the function's body block, consider out/inout formals mentioned
   // (since they will be used by the implicit return)

--- a/frontend/lib/resolution/copy-elision.cpp
+++ b/frontend/lib/resolution/copy-elision.cpp
@@ -108,7 +108,7 @@ struct FindElidedCopies : VarScopeVisitor {
   void handleDisjunction(const AstNode * node, 
                          VarFrame * currentFrame,
                          const std::vector<VarFrame*>& frames, 
-                         bool total, RV& rv) override;
+                         bool alwaysTaken, RV& rv) override;
   
   void handleScope(const AstNode* ast, RV& rv) override;
 };
@@ -438,7 +438,7 @@ static void propagateMentionsAndInits(VarFrame* parentFrame, VarFrame* childFram
 void FindElidedCopies::handleDisjunction(const AstNode * node,
                                          VarFrame * currentFrame, 
                                          const std::vector<VarFrame*>& frames,
-                                         bool total, RV& rv) {
+                                         bool alwaysTaken, RV& rv) {
   //propagate mentions to the parent
   for(auto frame: frames) {
     propagateMentionsAndInits(currentFrame, frame);
@@ -474,7 +474,7 @@ void FindElidedCopies::handleDisjunction(const AstNode * node,
   for (auto pair : idCounts) {
     // Variable did not occur in all frames, it does not get promoted. Instead,
     // consider it a 'mention' and propagate.
-    if (pair.second != nonReturningFrames.size() || !total) {
+    if (pair.second != nonReturningFrames.size() || !alwaysTaken) {
       CopyElisionState& parentState = currentFrame->copyElisionState[pair.first];
       parentState.lastIsCopy = false;
       parentState.points.clear();

--- a/frontend/lib/resolution/copy-elision.cpp
+++ b/frontend/lib/resolution/copy-elision.cpp
@@ -604,7 +604,8 @@ void FindElidedCopies::propagateChildToParent(VarFrame* frame, VarFrame* parent,
         ID id = pair.first;
         const CopyElisionState& state = pair.second;
 
-        // non-local variables cannot be elided, and so are treated as mentions
+        // non-local variables cannot be elided in loop bodies, and so are
+        // treated as mentions
         if (state.lastIsCopy &&
             frame->eligibleVars.count(id) == 0 &&
             !isLoopBody) {

--- a/frontend/lib/resolution/copy-elision.cpp
+++ b/frontend/lib/resolution/copy-elision.cpp
@@ -340,7 +340,7 @@ void FindElidedCopies::handleOutFormal(const Call* ast,
                                        const QualifiedType& formalType,
                                        RV& rv) {
   // 'out' can't be the RHS for an elided copy
-  processMentions(actual, rv);
+  actual->traverse(rv);
 
   // updated initedVars for split init
   processSplitInitOut(ast, actual, allSplitInitedVars, rv);
@@ -366,6 +366,9 @@ void FindElidedCopies::handleInFormal(const Call* ast, const AstNode* actual,
         elide = true;
       }
     }
+  } else if (actualToId.isEmpty()) {
+    actual->traverse(rv);
+    return;
   }
 
   if (elide) {
@@ -380,7 +383,7 @@ void FindElidedCopies::handleInoutFormal(const Call* ast,
                                          const QualifiedType* actualScalarType,
                                          RV& rv) {
   // 'inout' can't be the RHS for an elided copy
-  processMentions(actual, rv);
+  actual->traverse(rv);
 }
 
 void FindElidedCopies::handleReturn(const uast::Return* ast, RV& rv) {

--- a/frontend/lib/resolution/split-init.cpp
+++ b/frontend/lib/resolution/split-init.cpp
@@ -84,7 +84,7 @@ struct FindSplitInits : VarScopeVisitor {
   void handleDisjunction(const AstNode * node, 
                          VarFrame * currentFrame,
                          const std::vector<VarFrame*>& frames, 
-                         bool total, RV& rv) override;
+                         bool alwaysTaken, RV& rv) override;
 
   void handleScope(const AstNode* ast, RV& rv) override;
 };
@@ -301,7 +301,7 @@ std::map<ID,QualifiedType> FindSplitInits::verifyInitOrderAndType(const AstNode 
 void FindSplitInits::handleDisjunction(const AstNode * node, 
                                        VarFrame * currentFrame, 
                                        const std::vector<VarFrame*>& frames, 
-                                       bool total, RV& rv) {
+                                       bool alwaysTaken, RV& rv) {
 
   // gather the set of variables inited in any of the branches
   std::set<ID> locallyInitedVars;
@@ -342,7 +342,7 @@ void FindSplitInits::handleDisjunction(const AstNode * node,
     }
   }
 
-  if (!total) {
+  if (!alwaysTaken) {
     for (auto frame: frames) {
       propagateMentions(currentFrame, frame);
     } 

--- a/frontend/lib/resolution/split-init.cpp
+++ b/frontend/lib/resolution/split-init.cpp
@@ -64,14 +64,14 @@ struct FindSplitInits : VarScopeVisitor {
   void handleDeclaration(const VarLikeDecl* ast, RV& rv) override;
   void handleMention(const Identifier* ast, ID varId, RV& rv) override;
   void handleAssign(const OpCall* ast, RV& rv) override;
-  void handleOutFormal(const FnCall* ast, const AstNode* actual,
+  void handleOutFormal(const Call* ast, const AstNode* actual,
                        const QualifiedType& formalType,
                        RV& rv) override;
-  void handleInFormal(const FnCall* ast, const AstNode* actual,
+  void handleInFormal(const Call* ast, const AstNode* actual,
                       const QualifiedType& formalType,
                       const QualifiedType* actualScalarType,
                       RV& rv) override;
-  void handleInoutFormal(const FnCall* ast, const AstNode* actual,
+  void handleInoutFormal(const Call* ast, const AstNode* actual,
                          const QualifiedType& formalType,
                          const QualifiedType* actualScalarType,
                          RV& rv) override;
@@ -199,7 +199,7 @@ void FindSplitInits::handleAssign(const OpCall* ast, RV& rv) {
   }
 }
 
-void FindSplitInits::handleOutFormal(const FnCall* ast, const AstNode* actual,
+void FindSplitInits::handleOutFormal(const Call* ast, const AstNode* actual,
                                      const QualifiedType& formalType, RV& rv) {
   ID toId = refersToId(actual, rv);
   if (!toId.isEmpty()) {
@@ -210,14 +210,14 @@ void FindSplitInits::handleOutFormal(const FnCall* ast, const AstNode* actual,
   }
 }
 
-void FindSplitInits::handleInFormal(const FnCall* ast, const AstNode* actual,
+void FindSplitInits::handleInFormal(const Call* ast, const AstNode* actual,
                                     const QualifiedType& formalType,
                                     const QualifiedType* actualScalarType,
                                     RV& rv) {
   processMentions(actual, rv);
 }
 
-void FindSplitInits::handleInoutFormal(const FnCall* ast, const AstNode* actual,
+void FindSplitInits::handleInoutFormal(const Call* ast, const AstNode* actual,
                                        const QualifiedType& formalType,
                                        const QualifiedType* actualScalarType,
                                        RV& rv) {

--- a/frontend/lib/resolution/split-init.cpp
+++ b/frontend/lib/resolution/split-init.cpp
@@ -303,27 +303,6 @@ void FindSplitInits::handleDisjunction(const AstNode * node,
                                        const std::vector<VarFrame*>& frames, 
                                        bool total, RV& rv) {
 
-  // first, if the branch is known at compile time, just process that one.
-  for(auto frame: frames) {
-    if (!frame->paramTrueCond) continue;
-
-    for (auto pair : frame->initedVarsVec) {
-      const auto & id = pair.first;
-      const auto & rhsType = pair.second;
-      if (frame->eligibleVars.count(id) > 0) {
-        // variable is local to this frame's scope; save the result.
-        allSplitInitedVars.insert(id);
-      } else {
-        // variable was declared in an outer scope, and this is only
-        // possible path, so its definitely a valid split init
-        addInit(currentFrame, id, rhsType);
-      }
-    }
-
-    propagateMentions(currentFrame, frame);
-    return;
-  }
-
   // gather the set of variables inited in any of the branches
   std::set<ID> locallyInitedVars;
   for(auto frame : frames) {

--- a/frontend/test/resolution/testCopyElision.cpp
+++ b/frontend/test/resolution/testCopyElision.cpp
@@ -241,7 +241,7 @@ static void test5() {
 }
 
 static void test6() {
-  testCopyElision("test6",
+  testCopyElision("test6a",
     R""""(
         proc test(cond: bool) {
           var x:int;
@@ -254,6 +254,23 @@ static void test6() {
         }
     )"""",
     {"M.test@8", "M.test@12"});
+
+  testCopyElision("test6b",
+    R""""(
+        proc test(cond: bool) {
+          var x:int;
+          if cond {
+            var y = x;
+            var z = y;
+            return;
+          } else {
+            var y = x;
+            var z = y;
+            return;
+          }
+        }
+    )"""",
+    {"M.test@6", "M.test@8", "M.test@12", "M.test@14"});
 }
 
 static void test7() {

--- a/frontend/test/resolution/testCopyElision.cpp
+++ b/frontend/test/resolution/testCopyElision.cpp
@@ -1261,6 +1261,20 @@ static void test45() {
   */
 }
 
+static void test46() {
+  testCopyElision("test46",
+    R""""(
+
+        proc helper(in arg: int) { return 0; }
+        proc test(cond: bool) {
+          var x:int = 0;
+          var a = x;
+          return helper(x) + helper(x);
+        }
+    )"""",
+    {"M.test@11"});
+}
+
 int main() {
   test1();
   test2();
@@ -1307,5 +1321,6 @@ int main() {
   test43();
   test44();
   test45();
+  test46();
   return 0;
 }

--- a/frontend/test/resolution/testCopyElision.cpp
+++ b/frontend/test/resolution/testCopyElision.cpp
@@ -1346,16 +1346,18 @@ static void test47() {
           proc helper(in arg: int) { return 0; }
           proc test(cond: bool) {
             var x:int = 0;
+            var y:int = 0;
             )"""" + loop + R""""( { // OK to elide in iterand
-              var z = x; // should not elide
+              var z = y; // should not elide
             }
           }
       )"""",
-      IDs); // ID of 'x' in call to 'helper'
+      IDs);
   };
-  test("for i in stuff(x)", {"M.test@7"});
-  test("for i in stuff(helper(x))", {"M.test@8"});
-  test("while helper(x)", {"M.test@6"});
+  test("for i in stuff(x)", {"M.test@10"});
+  test("for i in stuff(y)", {}); // 'x' used in loop, should not elide
+  test("for i in stuff(helper(x))", {"M.test@11"});
+  test("while helper(x)", {"M.test@9"});
 
   // TODO: with clause
   //test("forall i in stuff(x) with (var copy = x)", {});

--- a/frontend/test/resolution/testCopyElision.cpp
+++ b/frontend/test/resolution/testCopyElision.cpp
@@ -1355,9 +1355,9 @@ static void test47() {
       IDs);
   };
   test("for i in stuff(x)", {"M.test@10"});
-  test("for i in stuff(y)", {}); // 'x' used in loop, should not elide
+  test("for i in stuff(y)", {}); // 'y' used in loop, should not elide
   test("for i in stuff(helper(x))", {"M.test@11"});
-  test("while helper(x)", {"M.test@9"});
+  test("while helper(x)", {});
 
   // TODO: with clause
   //test("forall i in stuff(x) with (var copy = x)", {});

--- a/frontend/test/resolution/testCopyElision.cpp
+++ b/frontend/test/resolution/testCopyElision.cpp
@@ -193,7 +193,7 @@ static void test5() {
           x;
         }
     )"""",
-    {"M.test@8"});
+    {"M.test@8"}); // ID of 'var y'
 
   testCopyElision("test5b",
     R""""(
@@ -207,7 +207,7 @@ static void test5() {
           }
         }
     )"""",
-    {"M.test@8"});
+    {"M.test@8"}); // ID of 'var y'
 
   testCopyElision("test5c",
     R""""(
@@ -223,7 +223,7 @@ static void test5() {
           }
         }
     )"""",
-    {"M.test@8", "M.test@12"});
+    {"M.test@8", "M.test@12"}); // IDs of 'var y' and 'var yy'
 
   testCopyElision("test5d",
     R""""(
@@ -237,7 +237,7 @@ static void test5() {
           var zz = x;
         }
     )"""",
-    {"M.test@8", "M.test@13"});
+    {"M.test@8", "M.test@13"}); // IDs of 'var y' and 'var zz'
 }
 
 static void test6() {
@@ -1272,7 +1272,7 @@ static void test46() {
           return helper(x) + helper(x);
         }
     )"""",
-    {"M.test@11"});
+    {"M.test@11"}); // ID of 'x' in second 'helper(x)'
 }
 
 int main() {

--- a/frontend/test/resolution/testCopyElision.cpp
+++ b/frontend/test/resolution/testCopyElision.cpp
@@ -181,10 +181,11 @@ static void test4() {
 }
 
 static void test5() {
-  testCopyElision("test5",
+  testCopyElision("test5a",
     R""""(
         proc test(cond: bool) {
           var x:int;
+          var z = x;
           if cond {
             var y = x;
             return;
@@ -192,7 +193,51 @@ static void test5() {
           x;
         }
     )"""",
-    {"M.test@6"});
+    {"M.test@8"});
+
+  testCopyElision("test5b",
+    R""""(
+        proc test(cond: bool) {
+          var x:int;
+          var z = x;
+          if cond {
+            var y = x;
+            return;
+          } else {
+          }
+        }
+    )"""",
+    {"M.test@8"});
+
+  testCopyElision("test5c",
+    R""""(
+        proc test(cond: bool) {
+          var x:int;
+          var z = x;
+          if cond {
+            var y = x;
+            return;
+          } else {
+            var yy = x;
+            return;
+          }
+        }
+    )"""",
+    {"M.test@8", "M.test@12"});
+
+  testCopyElision("test5d",
+    R""""(
+        proc test(cond: bool) {
+          var x:int;
+          var z = x;
+          if cond {
+            var y = x;
+            return;
+          }
+          var zz = x;
+        }
+    )"""",
+    {"M.test@8", "M.test@13"});
 }
 
 static void test6() {
@@ -286,13 +331,28 @@ static void test12() {
 }
 
 static void test13() {
-  testCopyElision("test13",
+  testCopyElision("test13a",
     R""""(
 
         proc test(cond: bool) {
           var x:int;
+          var z = x;
           if cond {
             var y = x;
+          }
+        }
+    )"""",
+    {});
+  testCopyElision("test13b",
+    R""""(
+
+        proc helper(in arg: int) { return 0; }
+        proc test(cond: bool) {
+          var x:int;
+          var z = helper(x);
+          if cond {
+          } else {
+            var y = helper(x);
           }
         }
     )"""",

--- a/frontend/test/resolution/testCopyElision.cpp
+++ b/frontend/test/resolution/testCopyElision.cpp
@@ -1279,7 +1279,7 @@ static void test45() {
 }
 
 static void test46() {
-  testCopyElision("test46",
+  testCopyElision("test46a",
     R""""(
 
         proc helper(in arg: int) { return 0; }
@@ -1290,6 +1290,30 @@ static void test46() {
         }
     )"""",
     {"M.test@11"}); // ID of 'x' in second 'helper(x)'
+  testCopyElision("test46b",
+    R""""(
+
+        proc double(in x: int, in y: int) { return 0; }
+        proc helper(in arg: int) { return 0; }
+        proc test(cond: bool) {
+          var x:int = 0;
+          var a = x;
+          return double(helper(x), helper(x));
+        }
+    )"""",
+    {"M.test@12"}); // ID of 'x' in second 'helper(x)'
+  testCopyElision("test46c",
+    R""""(
+
+        proc helper(in arg: int) { return 0; }
+        proc test(cond: bool) {
+          var x:int = 0;
+          var a = x;
+          var b = helper(x);
+          return b;
+        }
+    )"""",
+    {"M.test@8"}); // ID of 'x' in call to 'helper'
 }
 
 int main() {

--- a/frontend/test/resolution/testCustomInfer.cpp
+++ b/frontend/test/resolution/testCustomInfer.cpp
@@ -45,6 +45,7 @@ module M {
     return int;
   }
 
+  operator =(ref lhs: int, const rhs: int) {}
   operator =(ref lhs: int, const rhs: R) {
     lhs = rhs.val;
   }

--- a/frontend/test/resolution/testDeprecationUnstable.cpp
+++ b/frontend/test/resolution/testDeprecationUnstable.cpp
@@ -222,6 +222,8 @@ static void test0(void) {
   std::string contents =
     R""""(
     module testDeprecationWarningsForTypes {
+      operator =(ref lhs: int, const rhs: int) {}
+      inline operator =(ref a:enum, b:enum) where (a.type == b.type) {}
 
       @deprecated
       record r1 { var x: int; }
@@ -515,6 +517,8 @@ static void test3(void) {
     R""""(
 
     module testNoWarningsForUnstableMentionsInUnstable {
+      operator =(ref lhs: int, const rhs: int) {}
+
       @unstable("this variable is unstable")
       var x: int = 0;
       var y: int = 1;
@@ -561,8 +565,8 @@ static void test3(void) {
   assert(mod);
 
   // Force resolve 'main' since we may not always do that yet.
-  assert(mod->numStmts() == 5);
-  const Function* mainFn = mod->stmt(4)->toFunction();
+  assert(mod->numStmts() == 6);
+  const Function* mainFn = mod->stmt(5)->toFunction();
   std::ignore = resolveConcreteFunction(ctx, mainFn->id());
 
   assert(guard.numErrors() == 2);
@@ -572,10 +576,10 @@ static void test3(void) {
 
   auto& e0 = guard.error(0);
   assert(e0->message() == "this module is unstable");
-  assert(e0->location(ctx).line() == 32);
+  assert(e0->location(ctx).line() == 34);
   auto& e1 = guard.error(1);
   assert(e1->message() == "this module is unstable");
-  assert(e1->location(ctx).line() == 33);
+  assert(e1->location(ctx).line() == 35);
 
   assert(guard.realizeErrors());
 }
@@ -645,6 +649,8 @@ static void test5(void) {
 
   std::string contents =
     R""""(
+    operator =(ref lhs: int, const rhs: int) {}
+
     @deprecated
     var x = 0;
     @unstable
@@ -683,12 +689,12 @@ static void test5(void) {
   assert(mod);
 
   // Force resolve 'main' since we may not always do that yet.
-  assert(mod->numStmts() == 9);
-  const Function* f1 = mod->stmt(4)->toFunction();
+  assert(mod->numStmts() == 10);
+  const Function* f1 = mod->stmt(5)->toFunction();
   std::ignore = resolveConcreteFunction(ctx, f1->id());
-  const Function* f2 = mod->stmt(6)->toFunction();
+  const Function* f2 = mod->stmt(7)->toFunction();
   std::ignore = resolveConcreteFunction(ctx, f2->id());
-  const Function* f3 = mod->stmt(8)->toFunction();
+  const Function* f3 = mod->stmt(9)->toFunction();
   std::ignore = resolveConcreteFunction(ctx, f3->id());
 
 

--- a/frontend/test/resolution/testHeapBuffer.cpp
+++ b/frontend/test/resolution/testHeapBuffer.cpp
@@ -43,6 +43,8 @@ void testHeapBufferArg(const char* formalType, const char* actualType, F&& test)
 
   std::stringstream ss;
 
+  ss << "operator =(ref lhs: int, const rhs: int) {}" << std::endl;
+  ss << "operator =(ref lhs: _ddata(?t), const rhs: _ddata(t)) {}" << std::endl;
   ss << "record rec { type someType; }" << std::endl;
   ss << "proc f(x: " << formalType << ") { return 0; }" << std::endl;
   ss << "var arg: " << actualType << ";" << std::endl;
@@ -56,14 +58,14 @@ void testHeapBufferArg(const char* formalType, const char* actualType, F&& test)
 
   assert(modules.size() == 1);
   auto mainMod = modules[0];
-  assert(mainMod->numStmts() == 4);
+  assert(mainMod->numStmts() == 6);
 
-  auto fChild = mainMod->child(1);
+  auto fChild = mainMod->child(3);
   assert(fChild->isFunction());
   auto fFn = fChild->toFunction();
   assert(fFn->name() == "f");
 
-  auto fCallVar = mainMod->child(3);
+  auto fCallVar = mainMod->child(5);
   assert(fCallVar->isVariable());
 
   auto& modResResult = resolveModule(context, mainMod->id());
@@ -158,6 +160,7 @@ static void test8() {
 
   std::string program = R"""(
   module M{
+    operator =(ref lhs: int, const rhs: int) {}
     module X {
       proc foo() {
         var ret : _ddata(int);
@@ -223,6 +226,7 @@ static void test11() {
   ErrorGuard guard(context);
 
   std::string program = R"""(
+  operator =(ref lhs: _ddata(?t), const rhs: _ddata(t)) {}
   proc foo(x: _ddata(?t), y: _ddata(t)) do return y;
   var ptrInt: _ddata(int);
   var ptrReal: _ddata(real);

--- a/frontend/test/resolution/testInitSemantics.cpp
+++ b/frontend/test/resolution/testInitSemantics.cpp
@@ -1933,6 +1933,7 @@ static void testGenericFieldInit() {
   {
     printf("one\n");
     std::string program = R"""(
+      operator =(ref lhs: int, const rhs: int) {}
       record G { type T; var x : T; }
 
       proc G.init=(other: this.type) {
@@ -1981,6 +1982,8 @@ static void testGenericFieldInit() {
   }
   {
     std::string program = R"""(
+      operator =(ref lhs: int, const rhs: int) {}
+      operator =(ref lhs: real, const rhs: real) {}
       record G { type T; var x : T; }
 
       proc G.init=(other: this.type) {
@@ -2022,6 +2025,7 @@ static void testGenericFieldInit() {
 static void testDefaultArgs() {
   {
     std::string program = R"""(
+      operator =(ref lhs: real, const rhs: real) {}
       class Parent {
         var x, y: real;
       }

--- a/frontend/test/resolution/testMultiDecl.cpp
+++ b/frontend/test/resolution/testMultiDecl.cpp
@@ -241,6 +241,7 @@ static void test6() {
   ErrorGuard guard(context);
 
   std::string program = R"""(
+    operator =(ref lhs: int, const rhs: int) {}
     var a, b : int;
 
     var x = a;

--- a/frontend/test/resolution/testOperatorOverloads.cpp
+++ b/frontend/test/resolution/testOperatorOverloads.cpp
@@ -42,6 +42,7 @@ static void test1() {
   // primary operator method
   QualifiedType qt2 = resolveTypeOfXInit(context,
     R""""(
+      operator =(ref lhs: int, const rhs: int) {}
       record R {
         var field: int;
         operator :(z: R, type t: int) { return z.field; }
@@ -57,6 +58,7 @@ static void test1() {
   // secondary operator method
   QualifiedType qt3 = resolveTypeOfXInit(context,
     R""""(
+      operator =(ref lhs: int, const rhs: int) {}
       record R {
         var field: int;
       }
@@ -72,6 +74,7 @@ static void test1() {
   // non-method operator
   QualifiedType qt4 = resolveTypeOfXInit(context,
     R""""(
+      operator =(ref lhs: int, const rhs: int) {}
       record R {
         var field: int;
       }
@@ -93,6 +96,7 @@ static void test2() {
   // method and function operator definitions in the same scope should conflict (ambiguous call)
   QualifiedType qt1 = resolveTypeOfXInit(context,
     R""""(
+      operator =(ref lhs: int, const rhs: int) {}
       record R {
         var field: int;
       }
@@ -109,6 +113,7 @@ static void test2() {
   // access to R should implicitly grant access to its method operators
   QualifiedType qt2 = resolveTypeOfXInit(context,
     R""""(
+      operator =(ref lhs: int, const rhs: int) {}
       module M {
         record R {
           var field: int;
@@ -134,6 +139,7 @@ static void test3() {
   // incorrectly defined unary operator overload
   QualifiedType qt1 = resolveTypeOfXInit(context,
     R""""(
+      operator =(ref lhs: int, const rhs: int) {}
       record R {
         var field: int;
         operator !(z: R, type t: int) { return z.field; }
@@ -149,6 +155,7 @@ static void test3() {
   // correct unary operator overload
   QualifiedType qt2 = resolveTypeOfXInit(context,
     R""""(
+      operator =(ref lhs: int, const rhs: int) {}
       record R {
         var field: int;
         operator !(z: R) { return z.field; }
@@ -164,6 +171,7 @@ static void test3() {
   // overloading more operators
   QualifiedType qt3 = resolveTypeOfXInit(context,
     R""""(
+      operator =(ref lhs: int, const rhs: int) {}
       record R {
         var field: int;
         operator +(z: R, t: int) { return z.field; }
@@ -178,6 +186,7 @@ static void test3() {
 
   QualifiedType qt4 = resolveTypeOfXInit(context,
     R""""(
+      operator =(ref lhs: int, const rhs: int) {}
       record R {
         var field: int;
         operator >(z: R, t: complex) { return true; }
@@ -192,6 +201,7 @@ static void test3() {
 
   QualifiedType qt5 = resolveTypeOfXInit(context,
     R""""(
+      operator =(ref lhs: int, const rhs: int) {}
       record R {
         var field: int;
       }
@@ -208,6 +218,7 @@ static void test3() {
   // overloading operator for non-compound types
   QualifiedType qt6 = resolveTypeOfXInit(context,
     R""""(
+      operator =(ref lhs: int, const rhs: int) {}
       operator *(a: int, b: int) { return true; }
       var a: int = 2;
       var b: int = 3;
@@ -227,6 +238,7 @@ static void test4() {
 
   std::string program =
     R""""(
+      operator =(ref lhs: int, const rhs: int) {}
       record R {
         var x : int;
       }
@@ -253,6 +265,8 @@ static void test5() {
 
   std::string program =
     R""""(
+      operator =(ref lhs: real, const rhs: real) {}
+      operator =(ref lhs: int, const rhs: int) {}
       record R {
         var x : int;
       }
@@ -278,6 +292,7 @@ static void test6() {
 
   std::string program =
     R""""(
+      operator =(ref lhs: int, const rhs: int) {}
       record R {
         var x : int;
       }
@@ -302,6 +317,7 @@ static void test7() {
 
   std::string program =
     R""""(
+      operator =(ref lhs: int, const rhs: int) {}
       record R {
         var x : int;
       }

--- a/frontend/test/resolution/testPromotion.cpp
+++ b/frontend/test/resolution/testPromotion.cpp
@@ -101,7 +101,13 @@ static void runProgram(std::vector<const char*> prog, F&& f, Types... types) {
   auto context = &ctx;
   ErrorGuard guard(context);
 
-  std::string program = "module ChapelBase {\n  enum iterKind { standalone, leader, follower };\noperator =(ref lhs: int, const rhs: int) {}\noperator =(ref lhs:real, const rhs:real) {}\n}\n";
+  std::string program = R"""(
+module ChapelBase {
+  enum iterKind { standalone, leader, follower };
+  operator =(ref lhs:int, const rhs:int) {}
+  operator =(ref lhs:real, const rhs:real) {}
+}
+)""";
 
   auto addType = [&](auto arg) {
     for (const auto& line : arg.strs())

--- a/frontend/test/resolution/testPromotion.cpp
+++ b/frontend/test/resolution/testPromotion.cpp
@@ -101,7 +101,7 @@ static void runProgram(std::vector<const char*> prog, F&& f, Types... types) {
   auto context = &ctx;
   ErrorGuard guard(context);
 
-  std::string program = "module ChapelBase {\n  enum iterKind { standalone, leader, follower };\n}\n";
+  std::string program = "module ChapelBase {\n  enum iterKind { standalone, leader, follower };\noperator =(ref lhs: int, const rhs: int) {}\noperator =(ref lhs:real, const rhs:real) {}\n}\n";
 
   auto addType = [&](auto arg) {
     for (const auto& line : arg.strs())

--- a/frontend/test/resolution/testResolve.cpp
+++ b/frontend/test/resolution/testResolve.cpp
@@ -1350,6 +1350,7 @@ static void test22() {
               return 5;
             }
           }
+          operator =(ref lhs: int, const rhs: int) {}
           var outer : Outer;
           param x = outer.inner(1);
         }
@@ -1374,6 +1375,7 @@ static void test23() {
   {
     std::string prog =
       R"""(
+      operator =(ref lhs: int, const rhs: int) {}
       record R {
         var x : int;
 
@@ -1405,6 +1407,7 @@ static void test23() {
     context->advanceToNextRevision(false);
     std::string prog =
       R"""(
+      operator =(ref lhs: int, const rhs: int) {}
       record Inner {
         var x : int;
 
@@ -1468,6 +1471,8 @@ static void test24() {
           return foo(x);
         }
       }
+
+      operator =(ref lhs: int, const rhs: int) {}
 
       record myRecord {}
       proc foo(r: myRecord) do return 42;
@@ -2067,6 +2072,7 @@ static void testGlobalMultiDecl() {
 
   auto xQt = resolveTypeOfXInit(context,
     R"""(
+      operator =(ref lhs: int, const rhs: int) {}
       var a, b: int;
       proc foo() do return a;
       var x = foo();

--- a/frontend/test/resolution/testResolverVerboseErrors.cpp
+++ b/frontend/test/resolution/testResolverVerboseErrors.cpp
@@ -277,6 +277,7 @@ record R {
 
 var r: R;
 r.x("hello");
+operator =(ref lhs: int, const rhs: int) {}
 )""";
 
 static const char* errorOther = R"""(

--- a/frontend/test/resolution/testTuples.cpp
+++ b/frontend/test/resolution/testTuples.cpp
@@ -1139,6 +1139,7 @@ static void test28() {
     for (i, j) in myIter() {
       var z = i;
     }
+    operator=(ref lhs: int, rhs: int) {}
     )"""";
 
   auto m = resolveTypesOfVariables(context, program, { "i", "j", "z" });
@@ -1165,6 +1166,7 @@ static void test29() {
     for (i, j) in myIter() {
       var z = i;
     }
+    operator=(ref lhs: int, rhs: int) {}
     )"""";
 
   // The entire tuple (i, j) is itself a 'REF' tuple.
@@ -1208,6 +1210,7 @@ static void test30() {
     for (i, j) in myIter() {
       var z = i;
     }
+    operator=(ref lhs: int, rhs: int) {}
     )"""";
 
   // The entire tuple (i, j) is itself a 'REF' tuple.

--- a/frontend/test/resolution/testTypePropertyPrimitives.cpp
+++ b/frontend/test/resolution/testTypePropertyPrimitives.cpp
@@ -580,6 +580,8 @@ static void test12() {
             class c1 { var x: int; }
             record r10 { var x: owned c1?; }
             record r11 { var x: r9(?); }
+            operator =(ref lhs: int, const rhs: int) {}
+            operator =(ref lhs: real, const rhs: real) {}
             )""",
     /* primitive */ chpl::uast::primtags::PRIM_IS_POD,
     /* calls */ {

--- a/frontend/test/test-resolution.cpp
+++ b/frontend/test/test-resolution.cpp
@@ -517,7 +517,11 @@ module M {
 }
 
 void testArrayAssign(Context* context, const char* prelude, const char* typeExpr, const char* iterable, int expectedRank, const char* expectedStride, AssociatedAction::Action actionKind, const char* expectedCopyInitFn) {
-  std::string wholeString = std::string(prelude) + "\n\n" + "proc main() { var A" + typeExpr + " = " + iterable + "; }\n";
+  std::string ops = R"""(
+    operator =(ref lhs: int, const rhs: int) {}
+    operator =(ref lhs: real, const rhs: real) {}
+  )""";
+  std::string wholeString = ops + std::string(prelude) + "\n\n" + "proc main() { var A" + typeExpr + " = " + iterable + "; }\n";
   printf("=== Resolving program: ===\n");
   printf("%s\n", wholeString.c_str());
 


### PR DESCRIPTION
This PR started off with a simple idea: Reduce special cases for types that do not need init/deinit.

Right now we do not sufficiently account for all cases in which a type does not need init/deinit, meaning that sometimes we skip checks and others we don't. Instead of incomplete skipping of checks and resolution for the sake of simplicity, let's just make it actually work for such types.

This also helps simplify things for typed conversion, as this commit will cause assignment operators to be resolved and stored. Another benefit is increased testing of copy-elision/split-init rules now that we're testing against integers more regularly as well.

This PR required a change from using 'idToParentId' to 'ID::contains' to account for usage in nested calls.

-----

The next change improves copy elision for if-stmts without else branches.

With this PR, dyno now correctly recognizes that 'x' inside this conditional means we should not copy-elide when initializing 'z':

```chpl
  var x:int;
  var z = x; // can't copy-elide, it's mentioned in the conditional
  if cond {
    var y = x; // can't copy-elide, not in all 'branches'
  }
```

-----
This PR updates dyno to correctly propagate elided copies when a branch returns.

When a branch returns, we can propagate copies within that branch, knowing they cannot be used afterwards.

Requires a fix to 'propagateChildToParent', where we need to clear the parent's elision points that are made invalid by the child having any elisions of the same variable.

-----

``VarScopeVisitor`` has been improved to correctly invoke ``handleDisjunction`` with the proper value for ``total``, which should be true when the then-case conditional is param-true. Also renames ``total`` to the more helpful name of ``alwaysTaken``. This allows us to remove some special case code in copy elision and split-init.

-----

Lastly, copy-elision's interaction with loops is improved by disallowing variables outside the loop to be elided inside the loop, and instead treating those cases as mentions. This PR also allows the non-body children of the loop to be eligible for copy elision. An exception is made for ``While`` and ``DoWhile`` loops, as their condition is repeatedly invoked.

-----

Other bugs fixed along the way:
- use ``currentStatement()`` instead of the call's uAST when storing deinit points
- use ``ID::contains`` to check for uses within a statement
- update VarScopeVisitor to correctly traverse OpCalls, and treat them like FnCalls (required refactoring)
- fixed copy-elision to correctly traverse nested calls

Also adds new tests to lock in this behavior.

Testing:
- [x] test-frontend
- [x] paratest
- [x] test/frontend/