### PR TITLE
Avoid C++ compiler warnings in dyno tests

### DIFF
--- a/frontend/test/resolution/testLoopIndexVars.cpp
+++ b/frontend/test/resolution/testLoopIndexVars.cpp
@@ -555,7 +555,7 @@ static void testNestedParamForLabeledBreakContinue(const std::string& control, i
   CHPL_ASSERT(guard.numErrors(/* countWarnings */ false) == 0);
   // expected warnings is multiplied by two since we track emitting AND showing
   // the warning
-  CHPL_ASSERT(guard.numErrors() == expectedWarnings * 2);
+  CHPL_ASSERT(guard.numErrors() == (size_t) expectedWarnings * 2);
   guard.realizeErrors();
 }
 

--- a/frontend/test/resolution/testTuples.cpp
+++ b/frontend/test/resolution/testTuples.cpp
@@ -1050,8 +1050,8 @@ static void test24() {
   for (int i = 0; i < astTup->numActuals(); i++) {
     auto actual = astTup->actual(i);
     auto& actions = fnRR.byAst(actual).associatedActions();
-    assert(i != 0 || actions.size() == 1 &&
-                     actions[0].action() == AssociatedAction::ASSIGN);
+    assert(i != 0 || (actions.size() == 1 &&
+                      actions[0].action() == AssociatedAction::ASSIGN));
     assert(i != 1 || actions.size() == 0);
   }
 }


### PR DESCRIPTION
I observed some warnings-as-errors when doing `make test-dyno` with GCC 14.2. This PR fixes them.