### PR TITLE
Dyno: fix an unused variable warning.

### DIFF
--- a/frontend/lib/resolution/split-init.cpp
+++ b/frontend/lib/resolution/split-init.cpp
@@ -517,7 +517,8 @@ void FindSplitInits::propagateChildToParent(VarFrame* frame, VarFrame* parent, c
     // propagate initedVars and mentionedVars
     // to mentionedVars in the parent, and to global result if they are split-
     // inited here.
-    for (const auto& [id, qt] : frame->initedVarsVec) {
+    for (const auto& idQt : frame->initedVarsVec) {
+      auto& id = idQt.first;
       if (frame->eligibleVars.count(id) == 0) {
         if (parent) parent->mentionedVars.insert(id);
       } else {


### PR DESCRIPTION
This warning gets escalated into an error on some compilers.

Trivial, will not be reviewed, but was actually reviewed by @dlongnecke-cray -- thanks!

- [x] builds on macos
- [x] builds with GCC 7.5 on a linux system