### PR TITLE
increase frequency of GH homebrew checks

### DIFF
--- a/.github/workflows/monitor-homebrew.yml
+++ b/.github/workflows/monitor-homebrew.yml
@@ -3,9 +3,9 @@ name: Monitor Homebrew Formula
 on:
   workflow_dispatch: # Allows manual triggering of the workflow
   schedule:
-    - cron: '0 14 * * *' # Runs at 7:00 AM Pacific Time (2:00 PM UTC)
-    - cron: '30 20 * * *' # Runs at 1:30 PM Pacific Time (8:30 PM UTC)
-    - cron: '30 23 * * *' # Runs at 4:30 PM Pacific Time (11:30 PM UTC)
+    - cron: '0 14 * * *' # Runs at 7:00 AM PDT (6:00 AM PST) (2:00 PM UTC)
+    - cron: '30 20 * * *' # Runs at 1:30 PM PDT (12:30 PM PST) (8:30 PM UTC)
+    - cron: '30 23 * * *' # Runs at 4:30 PM PDT (3:30 PM PST) (11:30 PM UTC)
 
 
 env:

--- a/.github/workflows/monitor-homebrew.yml
+++ b/.github/workflows/monitor-homebrew.yml
@@ -3,7 +3,9 @@ name: Monitor Homebrew Formula
 on:
   workflow_dispatch: # Allows manual triggering of the workflow
   schedule:
-    - cron: '0 0 * * *' # Runs every 24 hours
+    - cron: '0 14 * * *' # Runs at 7:00 AM Pacific Time (2:00 PM UTC)
+    - cron: '30 20 * * *' # Runs at 1:30 PM Pacific Time (8:30 PM UTC)
+    - cron: '30 23 * * *' # Runs at 4:30 PM Pacific Time (11:30 PM UTC)
 
 
 env:


### PR DESCRIPTION
This changes the Github workflow that compares our Homebrew formula to the published formula to run three times a day instead of once. 

With this change, the formula should be checked at 7am, 1:30pm, and 4:30pm pacific daylight time. When the time change occurs in the fall, these will run at 6am, 12:30pm, and 3:30pm pacific standard time. 

[reviewed by @arifthpe - thanks!]