### PR TITLE
Add the missing include to the GPU specialization config

### DIFF
--- a/util/cron/test-gpu-ex-cuda-12.specialization.bash
+++ b/util/cron/test-gpu-ex-cuda-12.specialization.bash
@@ -6,6 +6,7 @@ UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common-native-gpu.bash
 source $UTIL_CRON_DIR/common-hpe-cray-ex.bash
 source $UTIL_CRON_DIR/common-gpu-hpe-cray-ex.bash
+source $UTIL_CRON_DIR/common-gpu-nvidia-hpe-cray-ex.bash
 
 module load cuda/12.4
 


### PR DESCRIPTION
I missed this file while adjusting the partition we run GPU testing on. The end result was that we were using the default partition which is AMD-based, but this config is for NVIDIA. So, we were getting `no CUDA-capable device is detected`

