### PR TITLE
Dyno: continue resolution after 'throws'

### DIFF
--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -7343,7 +7343,7 @@ void Resolver::exit(const Return* ret) {
   if (initResolver) {
     initResolver->checkEarlyReturn(ret);
   }
-  markReturnOrThrow();
+  markReturn();
 }
 
 static const Loop* findLastLoop(Resolver& rv) {
@@ -7425,7 +7425,7 @@ void Resolver::exit(const Throw* node) {
   if (initResolver) {
     context->error(node, "initializers are not yet allowed to throw errors");
   }
-  markReturnOrThrow();
+  markThrow();
 }
 
 bool Resolver::enter(const Try* node) {

--- a/frontend/lib/resolution/VarScopeVisitor.cpp
+++ b/frontend/lib/resolution/VarScopeVisitor.cpp
@@ -494,7 +494,7 @@ bool VarScopeVisitor::enter(const Return* ast, RV& rv) {
 }
 void VarScopeVisitor::exit(const Return* ast, RV& rv) {
   if (!scopeStack.empty()) {
-    markReturnOrThrow();
+    markReturn();
     handleReturn(ast, rv);
   }
   exitAst(ast);
@@ -524,7 +524,7 @@ bool VarScopeVisitor::enter(const Throw* ast, RV& rv) {
 }
 void VarScopeVisitor::exit(const Throw* ast, RV& rv) {
   if (!scopeStack.empty()) {
-    markReturnOrThrow();
+    markThrow();
     handleThrow(ast, rv);
   }
   exitAst(ast);

--- a/frontend/lib/resolution/VarScopeVisitor.h
+++ b/frontend/lib/resolution/VarScopeVisitor.h
@@ -315,7 +315,7 @@ namespace uast {
 template <>
 struct AstVisitorPrecondition<resolution::VarScopeVisitor> {
   static bool skipSubtree(const AstNode* node, resolution::VarScopeVisitor& rv) {
-    return rv.isDoneExecuting();
+    return rv.isDoneExecuting() || rv.markedThrow();
   }
 };
 

--- a/frontend/lib/resolution/return-type-inference.cpp
+++ b/frontend/lib/resolution/return-type-inference.cpp
@@ -585,7 +585,7 @@ bool ReturnTypeInferrer::enter(const Continue* cont, RV& rv) {
 void ReturnTypeInferrer::exit(const Continue* cont, RV& rv) {}
 
 bool ReturnTypeInferrer::enter(const Return* ret, RV& rv) {
-  markReturnOrThrow();
+  markReturn();
 
   if (functionKind == Function::ITER) {
     // Plain returns don't count towards type inference for iterators.

--- a/frontend/test/resolution/testReturnTypes.cpp
+++ b/frontend/test/resolution/testReturnTypes.cpp
@@ -127,7 +127,7 @@ void testProgram(const std::vector<ReturnVariant>& variants, F func,
 
 static std::string buildControlFlowProgram(std::string controlFlow) {
   std::string program = "";
-  program += "proc f() {\n  // Inserted control flow\n";
+  program += "proc f() throws {\n  // Inserted control flow\n";
   program += controlFlow;
   program += "\n  // End inserted control flow\n  return \"hello\";\n}";
   program += "\nvar x = f();";
@@ -601,6 +601,29 @@ static void testControlFlow16() {
 
       var b = false;
       if b then /* fall through to the default return */
+      )"""
+  , ControlFlowResult::AllPathsReturn);
+}
+
+static void testControlFlow17() {
+  testControlFlow(
+      R"""(
+      throw new Error("nope");
+      return 1;
+      )"""
+  , ControlFlowResult::AllPathsReturn);
+}
+
+static void testControlFlow18() {
+  testControlFlow(
+      R"""(
+      var arg = false;
+      if arg {
+        return true;
+      } else {
+        throw new Error("test");
+      }
+      return 1;
       )"""
   , ControlFlowResult::AllPathsReturn);
 }
@@ -1462,6 +1485,8 @@ int main() {
   testControlFlow14();
   testControlFlow15();
   testControlFlow16();
+  testControlFlow17();
+  testControlFlow18();
 
   testControlFlowYield1();
   testControlFlowYield2();


### PR DESCRIPTION
Evidently this is necessary, since we have existing examples that rely on return type inference in cases like `throw; return`.

To make this work, adjust the BranchSensitiveVisitor and its related types to distinguish between "throws" and "returns", and adjust the `isDoneExecuting` check to not return true for throws. Then, for analyses that DO ignore code after throwing etc., broaden the early-return check to include throwing in addition to `isDoneExecuting`.

This has the net effect of making the Dyno resolver proceed past `throws` statements, resolving expressions etc. in `return` and `yield`s, as well as making return type inference do something similar.

Reviewed by @arifthpe -- thanks!

## Testing
- [x] dyno tests
- [x] spec tests
- [x] primers
- [x] paratest