### PR TITLE
Adjust skipif for 'LoadForeignLibrary.chpl' to skip linux64+aarch64

### DIFF
--- a/test/dynamic-loading/LoadForeignLibrary.skipif
+++ b/test/dynamic-loading/LoadForeignLibrary.skipif
@@ -1,1 +1,14 @@
-CHPL_TARGET_COMPILER!=llvm
+#!/usr/bin/env python3
+
+import os
+
+if os.getenv('CHPL_TARGET_COMPILER') != 'llvm':
+  # Procedure pointers don't work with C backend right now.
+  print('True')
+elif os.getenv('CHPL_TARGET_PLATFORM') == 'linux64' and \
+     os.getenv('CHPL_TARGET_ARCH') == 'aarch64':
+  # Getting errors in codegen for this setup right now.
+  print('True')
+else:
+  # OK
+  print('False')


### PR DESCRIPTION
There are errors in the backend when compiling this test that I just haven't gotten around to fixing yet. So adjust the `.skipif` for this test to be a `python3` script that skips when `linux64`+`aarch64`. Trivial and not reviewed.