### PR TITLE
Make spec's docs of `init=` on records testable and refresh them so they work again

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -161,6 +161,7 @@ clean: clean-source clean-build clean-build-dir clean-doxygen clean-pycache FORC
 cleanall: clean-source clean-build clean-build-dir clean-doxygen clean-pycache FORCE
 
 clobber: clean-source clean-build clean-build-dir clean-doxygen clean-pycache FORCE
+	cd ../third-party/chpl-venv/ && make clobber
 
 clean-source: clean-module-docs clean-primers clean-examples clean-symlinks clean-collect-syntax clean-compiler-internals clean-chplcheck-docs FORCE
 

--- a/doc/rst/language/spec/conversions.rst
+++ b/doc/rst/language/spec/conversions.rst
@@ -456,7 +456,7 @@ constant (:ref:`Implicit_Compile_Time_Constant_Conversions`), ranges
 
 In addition, these implicit conversions can be defined for record types
 by implementing ``init=`` and possibly the ``=`` operator between two
-types as described in :ref:`Advanced_Copy_Initialization` and
+types as described in :ref:`Mixed-Type_Copy_Initialization` and
 :ref:`Function_Overloading`.  ``init=`` will be called for initialization
 as described in :ref:`Split_Initialization` and the ``=`` operator will
 be invoked for other uses of assignment.

--- a/doc/rst/language/spec/records.rst
+++ b/doc/rst/language/spec/records.rst
@@ -566,7 +566,7 @@ record type.
 to convert an expression of one type (``T1``) into another (``T2``)
 using forms like: ``var myT1: T1 = myT2;``.  The other common way of
 converting types in this way is to use a cast, like ``myT2: T1``, so
-Chapel requires both signatures as a means of ensuring the type author
+Chapel requires both operations as a means of ensuring the type author
 makes both forms available.
 
 As an example:

--- a/doc/rst/language/spec/records.rst
+++ b/doc/rst/language/spec/records.rst
@@ -547,19 +547,27 @@ record and its copy are the same:
 Note that the generic fields must still be manually initialized, despite
 the type already being known. Future work may allow these fields to be inferred.
 
-.. _Advanced_Copy_Initialization:
+.. _Mixed-Type_Copy_Initialization:
 
-Advanced Copy Initialization
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Mixed-Type Copy Initialization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A copy initializer can also be used to specify how a record should be
-initialized from a value of an arbitrary type. This kind of copy initializer is
-invoked when a variable declaration's initialization expression is not of the
-same type as the record being initialized.
+initialized from a value of a distinct type. This kind of *mixed-type
+copy initializer* is invoked when a variable declaration's
+initialization expression is not of the same type as the record being
+initialized.
 
-Defining a mixed-type copy initializer like this requires defining a cast
-operator that converts from the argument type to the record type.  The
-reason for this is TODO...
+Defining a mixed-type copy initializer like this also requires
+defining a cast operator that converts from the argument type to the
+record type.
+
+*Rationale*: Supporting a mixed-type copy initializer provides a way
+to convert an expression of one type (``T1``) into another (``T2``)
+using forms like: ``var myT1: T1 = myT2;``.  The other common way of
+converting types in this way is to use a cast, like ``myT2: T1``, so
+CHapel requires both signatures as a means of ensuring the type author
+makes both forms available.
 
 As an example:
 
@@ -577,14 +585,14 @@ As an example:
        writeln("normal init=");
      }
 
-     // initialize from a string
+     // mixed-type copy initializer, from a string
      proc MyString.init=(other: string) {
        this.s = other;
        writeln("string init=");
      }
 
      // the required cast operator (which can optionally be implemented
-     // in terms of the copy initializer, as done here)
+     // in terms of the copy initializer, as is done here)
      operator :(x: string, type t: MyString) {
        writeln("cast");
        const s: MyString = x;
@@ -592,9 +600,9 @@ As an example:
      }
   
      var a = new MyString("hello");
-     var b = a; // "normal init="
-     var c: MyString = "goodbye"; // "string init="
-     var d = "goodbye": MyString; // cast, inferring the return type
+     var b = a;                    // prints "normal init="
+     var c: MyString = "goodbye";  // prints "string init="
+     var d = "goodbye": MyString;  // prints "cast" and "string init=' due to the implementation
 
   .. BLOCK-test-chapelpost
 

--- a/doc/rst/language/spec/records.rst
+++ b/doc/rst/language/spec/records.rst
@@ -566,7 +566,7 @@ record type.
 to convert an expression of one type (``T1``) into another (``T2``)
 using forms like: ``var myT1: T1 = myT2;``.  The other common way of
 converting types in this way is to use a cast, like ``myT2: T1``, so
-CHapel requires both signatures as a means of ensuring the type author
+Chapel requires both signatures as a means of ensuring the type author
 makes both forms available.
 
 As an example:


### PR DESCRIPTION
As pointed out in #27249, we have not been testing a few of our examples in the records chapter of the spec.  As a result, they silently broke when we added the requirement that a mixed-type `init=` must also define a cast between those types.  This adds the missing casts and makes the remaining examples testable.  It also adds a mention of the requirement and its rationale.

While here, I did some other cleanup:
* made other reasonable examples in the chapter not mentioned in #27249 testable/tested
* renamed a test called `paramPassing.chpl` to `argPassing.chpl` because we're not passing `param`s in it
* renamed "Advanced Copy Initialization" to "Mixed-Type Copy Initialization" because it seems more precise, and the term "Advanced" never really gave me any idea what I'd find in the section
* removed a semicolon from a prototype because it isn't really legal Chapel syntax
* improved the `make clobber` step in the `doc/` directory (which virtually seems required whenever time passes between `make docs` runs for me) also clobber the `third-party/chpl-venv` directory because in many cases that is required.  See https://github.com/chapel-lang/chapel/pull/27251/commits/3cabe840ddf40ba5a7936c45e20232fd57dfd40f for details.

Resolves #27249
