### PR TITLE
update dyno test's expected error message text

### DIFF
--- a/frontend/test/resolution/testOpaqueExternTypes.cpp
+++ b/frontend/test/resolution/testOpaqueExternTypes.cpp
@@ -227,7 +227,7 @@ static void test5() {
 
   assert(notAType.isUnknown());
   assert(guard.numErrors() == 1);
-  assert(guard.errors()[0]->message() == "cannot default initialize variable using generic or unknown type");
+  assert(guard.errors()[0]->message() == "variable 'notAType' is declared without an initializer or type");
   guard.realizeErrors();
 }
 


### PR DESCRIPTION
This fixes a broken dyno test by updating the expected general error message text added in https://github.com/chapel-lang/chapel/pull/27203, to match the more specific error message that was added in https://github.com/chapel-lang/chapel/pull/27038.

TESTING:

- [x] all dyno tests pass

trivial change to test's expected error output only - not reviewed