### PR TITLE
Make using CHPL_GASNET_SEGMENT=everything and CHPL_COMM_SUBSTRATE=smp|ucx a build time error

### DIFF
--- a/doc/rst/usingchapel/multilocale.rst
+++ b/doc/rst/usingchapel/multilocale.rst
@@ -145,6 +145,7 @@ directly by network hardware.  The options are:
 
 everything
   All memory is available for remote memory access.
+  This option is not supported with the ``smp`` substrate.
 fast
   A limited portion of memory is available and optimized for fastest remote
   memory access

--- a/doc/rst/usingchapel/multilocale.rst
+++ b/doc/rst/usingchapel/multilocale.rst
@@ -145,7 +145,7 @@ directly by network hardware.  The options are:
 
 everything
   All memory is available for remote memory access.
-  This option is not supported with the ``smp`` substrate.
+  This option is not supported with the ``smp`` or ``ucx`` substrates.
 fast
   A limited portion of memory is available and optimized for fastest remote
   memory access

--- a/util/chplenv/chpl_comm_segment.py
+++ b/util/chplenv/chpl_comm_segment.py
@@ -2,7 +2,7 @@
 import sys
 
 import chpl_comm, chpl_comm_substrate, chpl_platform, overrides
-from utils import memoize, check_valid_var
+from utils import memoize, check_valid_var, error
 
 
 @memoize
@@ -24,6 +24,10 @@ def get():
         check_valid_var("CHPL_GASNET_SEGMENT", segment_val, ("fast", "large", "everything"))
     else:
         segment_val = 'none'
+
+    if segment_val == 'everything' and chpl_comm_substrate.get() == 'smp':
+        error("CHPL_GASNET_SEGMENT=everything is not supported with CHPL_COMM_SUBSTRATE=smp. Please use CHPL_GASNET_SEGMENT=fast or CHPL_GASNET_SEGMENT=large instead")
+
     return segment_val
 
 

--- a/util/chplenv/chpl_comm_segment.py
+++ b/util/chplenv/chpl_comm_segment.py
@@ -25,8 +25,13 @@ def get():
     else:
         segment_val = 'none'
 
-    if segment_val == 'everything' and chpl_comm_substrate.get() == 'smp':
-        error("CHPL_GASNET_SEGMENT=everything is not supported with CHPL_COMM_SUBSTRATE=smp. Please use CHPL_GASNET_SEGMENT=fast or CHPL_GASNET_SEGMENT=large instead")
+    substrate_val = chpl_comm_substrate.get()
+    if segment_val == "everything" and substrate_val in ("smp", "ucx"):
+        error(
+            "CHPL_GASNET_SEGMENT=everything is not supported with "
+            + "CHPL_COMM_SUBSTRATE={0}. Please use ".format(substrate_val)
+            + "CHPL_GASNET_SEGMENT=fast or CHPL_GASNET_SEGMENT=large instead"
+        )
 
     return segment_val
 


### PR DESCRIPTION
Adds a build time check for CHPL_GASNET_SEGMENT=everything and CHPL_COMM_SUBSTRATE=smp|ucx, which is unsupported and can fail in surprising ways to users.

This PR also updates the documentation to reflect that this configuration is unsupported.

Resolves https://github.com/chapel-lang/chapel/issues/27224

[Reviewed by @jhh67 and @bonachea]