### PR TITLE
Dyno: implement uAST-enabled enum-to-string casts

### DIFF
--- a/frontend/include/chpl/resolution/resolution-queries.h
+++ b/frontend/include/chpl/resolution/resolution-queries.h
@@ -285,6 +285,16 @@ const TypedFnSignature* typeConstructorInitial(Context* context,
                                                const types::Type* t);
 
 /**
+  Check if a signature from typedSignatureInitial matches the given CallInfo,
+  without instantiation. This is an early check before a more involved
+  instantiateSignature (if the function is generic).
+ */
+ApplicabilityResult
+isInitialTypedSignatureApplicable(Context* context,
+                                  const TypedFnSignature* tfs,
+                                  const FormalActualMap& faMap,
+                                  const CallInfo& ci);
+/**
   Instantiate a TypedFnSignature from
    * the result of typedSignatureInitial,
    * a CallInfo describing the types at the call site, and

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -1578,10 +1578,12 @@ generateEnumMethod(ResolutionContext* rc,
                    UniqueString name) {
   const TypedFnSignature* result = nullptr;
   auto context = rc->context();
-  if (!areOverloadsPresentInDefiningScope(context, et, QualifiedType::TYPE, name)) {
-    if (auto generator = generatorForCompilerGeneratedEnumOperator(name)) {
+  if (auto generator = generatorForCompilerGeneratedEnumOperator(name)) {
+    if (!areOverloadsPresentInDefiningScope(context, et, QualifiedType::VAR, name)) {
       result = generator(rc, et);
-    } else if (name == USTR("size")) {
+    }
+  } else if (name == USTR("size")) {
+    if (!areOverloadsPresentInDefiningScope(context, et, QualifiedType::TYPE, name)) {
       // TODO: we should really have a way to just set the return type here
       std::vector<UntypedFnSignature::FormalDetail> formals;
       std::vector<QualifiedType> formalTypes;

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -197,6 +197,10 @@ areOperatorOverloadsPresentInDefiningScope(Context* context,
     // If this function was generic, and we couldn't instantiate it (e.g.
     // due to a 'where' clause), it's not an applicable candidate.
     if (sig->needsInstantiation()) {
+      // note: this is pretty much the body of doIsCandidateApplicableInstantiating
+      // in resolution queries, but that function is private, and it seemed
+      // not worth it to expose it in the header.
+
       auto result = instantiateSignature(&rcval, sig, ci, /* poiScope */ nullptr);
 
       // function didn't apply after instantiation

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -195,10 +195,16 @@ areOperatorOverloadsPresentInDefiningScope(Context* context,
     }
 
     // If this function was generic, and we couldn't instantiate it (e.g.
-    // due to a where clause), it's not an applicable candidate.
-    if (sig->needsInstantiation() &&
-        !instantiateSignature(&rcval, sig, ci, /* poiScope */ nullptr).success()) {
-      continue;
+    // due to a 'where' clause), it's not an applicable candidate.
+    if (sig->needsInstantiation()) {
+      auto result = instantiateSignature(&rcval, sig, ci, /* poiScope */ nullptr);
+
+      // function didn't apply after instantiation
+      if (!result.success()) continue;
+
+      // 'where' clause evaluated to false, so this doesn't apply
+      if (result.candidate()->whereClauseResult() == TypedFnSignature::WHERE_FALSE)
+        continue;
     }
 
     // found a candidate that matches!

--- a/frontend/lib/resolution/default-functions.h
+++ b/frontend/lib/resolution/default-functions.h
@@ -95,6 +95,7 @@ const uast::BuilderResult& buildTypeConstructor(Context* context, ID typeID);
 const uast::BuilderResult& buildDeinit(Context* context, ID typeID);
 const uast::BuilderResult& buildDeSerialize(Context* context, ID typeID, bool isSerializer);
 const uast::BuilderResult& buildEnumToOrder(Context* context, ID typeID);
+const uast::BuilderResult& buildEnumToStringOrBytesCast(Context* context, ID typeID);
 const uast::BuilderResult& buildOrderToEnum(Context* context, ID typeID);
 
 } // end namespace resolution

--- a/frontend/lib/resolution/default-functions.h
+++ b/frontend/lib/resolution/default-functions.h
@@ -51,8 +51,8 @@ bool needCompilerGeneratedMethod(Context* context, const types::Type* type,
   determing if compiler generation is needed.
  */
 bool needCompilerGeneratedOperator(Context* context,
-                                   const types::Type* lhs,
-                                   const types::Type* rhs,
+                                   const types::QualifiedType& lhs,
+                                   const types::QualifiedType& rhs,
                                    UniqueString name);
 
 /**

--- a/frontend/lib/resolution/default-functions.h
+++ b/frontend/lib/resolution/default-functions.h
@@ -46,6 +46,16 @@ bool needCompilerGeneratedMethod(Context* context, const types::Type* type,
                                  UniqueString name, bool parenless);
 
 /**
+  Same as getCompilerGeneratedMethod, but for operators. Here, we are more
+  discerning: the other argument to the oeprator is also considered when
+  determing if compiler generation is needed.
+ */
+bool needCompilerGeneratedOperator(Context* context,
+                                   const types::Type* lhs,
+                                   const types::Type* rhs,
+                                   UniqueString name);
+
+/**
   Given a type and a UniqueString representing the name of a method,
   determine if the type needs a method with such a name to be
   generated for it, and if so, generates and returns a
@@ -57,6 +67,17 @@ const TypedFnSignature*
 getCompilerGeneratedMethod(ResolutionContext* rc,
                            const types::QualifiedType receiverType,
                            UniqueString name, bool parenless);
+
+/**
+  Same as getCompilerGeneratedMethod, but for operators. Here, we are more
+  discerning: the other argument to the operator is also considered when
+  determining if compiler generation is needed.
+ */
+const TypedFnSignature*
+getCompilerGeneratedOperator(ResolutionContext* rc,
+                             const types::QualifiedType lhsType,
+                             const types::QualifiedType rhsType,
+                             UniqueString name);
 
 /**
   Given a CallInfo object describing a call, attempts to find a compiler-generated

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -3439,7 +3439,7 @@ isUntypedSignatureApplicable(Context* context,
 }
 
 // given a typed function signature, determine if it applies to a call
-static ApplicabilityResult
+ApplicabilityResult
 isInitialTypedSignatureApplicable(Context* context,
                                   const TypedFnSignature* tfs,
                                   const FormalActualMap& faMap,
@@ -4558,8 +4558,8 @@ considerCompilerGeneratedMethods(ResolutionContext* rc,
 
     // if we don't need the operator, nothing to do.
     auto& rhs = ci.actual(1).type();
-    if (!needCompilerGeneratedOperator(rc->context(), receiverType.type(),
-                                       rhs.type(), ci.name())) {
+    if (!needCompilerGeneratedOperator(rc->context(), receiverType,
+                                       rhs, ci.name())) {
       return nullptr;
     }
 

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -4275,7 +4275,7 @@ static bool resolveFnCallSpecial(Context* context,
         return true;
       }
     } else if (!srcQt.isParam() &&
-               (srcTy->isEnumType() || srcTy->isStringType()) && isDstType &&
+               srcTy->isStringType() && isDstType &&
                dstTy->isStringType()) {
       // supported non-param casts to string
       exprTypeOut =
@@ -4606,12 +4606,12 @@ considerCompilerGeneratedCandidates(ResolutionContext* rc,
                                     std::vector<ApplicabilityResult>* rejected) {
   const TypedFnSignature* tfs = nullptr;
 
-  tfs = considerCompilerGeneratedMethods(rc, ci, candidates);
+  tfs = considerCompilerGeneratedOperators(rc->context(), ci, candidates);
   if (tfs == nullptr) {
-    tfs = considerCompilerGeneratedFunctions(rc, ci, candidates);
+    tfs = considerCompilerGeneratedMethods(rc, ci, candidates);
   }
   if (tfs == nullptr) {
-    tfs = considerCompilerGeneratedOperators(rc->context(), ci, candidates);
+    tfs = considerCompilerGeneratedFunctions(rc, ci, candidates);
   }
 
   if (!tfs) return;


### PR DESCRIPTION
Closes https://github.com/Cray/chapel-private/issues/7328.

This PR enables generating enum-to-string cast uASTs. The casting to string itself was already implemented as a special case, but until now, we didn't have an AST for it. Also, casting to bytes was not supported.

To achieve this, the major changes in the PR are split into two parts.

1. __Refactor the builder helpers in `default-functions.cpp` to be more general__. Specifically, previously, the struct `FieldFnBuilder` provided convenience methods that simplified building uAST for things like `someRecord.operator==`. This PR factored out some support code into a `BinaryFnBuilder`, and defined a new `EnumCastBuilder` that had its own specializations of the necessary functions. The new `buildEnumToStringOrBytes` cast is defined using this new class hierarchy.
2. __Adjust default function construction to be more precise__. Specifically, a naive adjustment of `default-functions.cpp` code that introduced casts of enums to strings didn't work. This was because it thought (incorrectly) that in some cases there were user-defined overloads that precluded the auto-generation. The canonical example is:

   https://github.com/chapel-lang/chapel/blob/4e51e4fb89e9822f68d92c2986eb66504d36e979/modules/internal/ChapelBase.chpl#L1460
  
   Which is defined in a scope in which `ChapelIO` is present, and `ChapelIO` has a cast operator defined as follows:   

   https://github.com/chapel-lang/chapel/blob/4e51e4fb89e9822f68d92c2986eb66504d36e979/modules/standard/ChapelIO.chpl#L445-L447

The latter adjustment was fairly involved. In production, the problem doesn't occur because when generating default functions, we compare types for strict equality. Since the type of `?t` in the uninstantiated operator is `AnyType`, and the type of `ArrayInit` is, well, `ArrayInit`, a strict comparison returns "false". Thus, production still generates a cast for `ArrayInit`. However, the shape of the `ChapelIO` cast made me think: what if the `where` clause was `?t == ArrayInit`? a strict comparison of the type expressions would rule out the candidate as unrelated, but it SHOULD be treated as a user-defined overload that ought to prevent the generation of default functions.

In this PR, I've adjusted the code to invoke regular candidate applicability checking. Thus, a candidate is considered a "user-defined competing overbroad" precisely when it can be called with the given arguments. This enables full support for `where` clauses and precludes strict equality checks. 

This change, in turn, required separating compiler-generated methods (which only check the receiver type) from compiler-generated operators (which check all types as described above). For this, I added new variations on `needsCompilerGeneratedBla` for operators. I also tightened record `==` generation to more closely match production.