### PR TITLE
Unpin LLVM 19 for homebrew formula

### DIFF
--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -16,7 +16,7 @@ class Chapel < Formula
   depends_on "gmp"
   depends_on "hwloc"
   depends_on "jemalloc"
-  depends_on "llvm@19"
+  depends_on "llvm"
   depends_on "pkgconf"
   depends_on "python@3.13"
 


### PR DESCRIPTION
Unpins the LLVM 19 as a dependency for the homebrew formula in our tree.

Normal release procedures should result in this change being propagated to homebrew-core.

[Reviewed by @arifthpe]