### PR TITLE
Update GPU technote to reflect new LLVM support

### DIFF
--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -152,7 +152,7 @@ The following are further requirements for GPU support:
 
   * CUDA toolkit version 11.7+ or 12.x must be installed.
 
-  * We test with system LLVM 19. Older versions may work.
+  * We test with system LLVM 20. Older versions may work.
 
     * Note that LLVM versions older than 16 do not support CUDA 12.
 

--- a/test/gpu/native/llvmMoved.chpl
+++ b/test/gpu/native/llvmMoved.chpl
@@ -48,7 +48,7 @@
 
 // After addressing the checklist items (or creating a GH issue to do so)
 // modify the following const so that this test no longer fails.
-const EXPECTED_LLVM_VERSION = 19;
+const EXPECTED_LLVM_VERSION = 20;
 
 //-----------------------------------------------------------------------------
 

--- a/test/gpu/native/llvmMoved.skipif
+++ b/test/gpu/native/llvmMoved.skipif
@@ -1,2 +1,1 @@
-# AMD requires a non-bundled llvm, which may confuse this test
-CHPL_GPU==amd
+CHPL_LLVM==bundled


### PR DESCRIPTION
Updates the GPU technote to reflect the new LLVM support for 20, which is now tested nightly.

As part of that, it updates `llvmMoved.chpl` to match. Additionally, I made the skipif for the test more directly check its predicate.

[Reviewed by @arifthpe]