### PR TITLE
Avoid warnings about `-c` and `-fsyntax-only`

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -1656,12 +1656,12 @@ void setupClang(GenInfo* info, std::string mainFile)
     clangInfo->driverArgs.push_back(clangInfo->clangOtherArgs[i]);
   }
 
-  clangInfo->driverArgs.push_back("-c");
-  // chpl - always compile rt file
-  clangInfo->driverArgs.push_back(mainFile.c_str());
-
   if (!fLlvmCodegen)
     clangInfo->driverArgs.push_back("-fsyntax-only");
+  else
+    clangInfo->driverArgs.push_back("-c");
+  // chpl - always compile rt file
+  clangInfo->driverArgs.push_back(mainFile.c_str());
 
   if( printSystemCommands && developer ) {
     for( size_t i = 0; i < clangInfo->driverArgs.size(); i++ ) {

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -1660,6 +1660,7 @@ void setupClang(GenInfo* info, std::string mainFile)
     clangInfo->driverArgs.push_back("-fsyntax-only");
   else
     clangInfo->driverArgs.push_back("-c");
+
   // chpl - always compile rt file
   clangInfo->driverArgs.push_back(mainFile.c_str());
 


### PR DESCRIPTION
Avoids warnings about unused "-c" in newer clang versions when parsing extern blocks with CHPL_LLVM!=none and CHPL_TARGET_COMPILER!=llvm

Spot checked `start_test examples/primers/interopWithC.chpl`

[Reviewed by @arifthpe]