### PR TITLE
Refactor and fix chapel dependencies for the arkouda release tests

### DIFF
--- a/util/cron/test-hpe-apollo-hdr.arkouda.release.bash
+++ b/util/cron/test-hpe-apollo-hdr.arkouda.release.bash
@@ -30,6 +30,14 @@ export GASNET_PHYSMEM_MAX="0.90"
 
 export CHPL_LLVM_GCC_PREFIX='none'
 
+if [ -n "$CHPL_WHICH_RELEASE_FOR_ARKOUDA" ]; then
+  release_dependencies
+else
+  echo "CHPL_WHICH_RELEASE_FOR_ARKOUDA not set, cannot run Arkouda release test!"
+  exit 1
+fi
+
+
 nightly_args="${nightly_args} -no-buildcheck"
 
 module list

--- a/util/cron/test-perf.chapcs.arkouda.release.bash
+++ b/util/cron/test-perf.chapcs.arkouda.release.bash
@@ -9,29 +9,7 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.arkouda.release"
 source $UTIL_CRON_DIR/common-arkouda.bash
 
 if [ -n "$CHPL_WHICH_RELEASE_FOR_ARKOUDA" ]; then
-  # Note: Add more cases to the following 'if' whenever we need to test a
-  # release that does not support our latest available LLVM. Cases can be
-  # removed when we no longer care about testing against that release.
-  if [ "$CHPL_WHICH_RELEASE_FOR_ARKOUDA" = "2.4.0" ]; then
-    # use LLVM 19, latest supported by 2.4.0
-    if [ -f /hpcdc/project/chapel/setup_llvm.bash ] ; then
-      # Hack to avoid build issues with GMP. Spack installed GMP is pulled in as
-      # a dependency of GDB. Then for some reason, it's (undesirably) linked
-      # against by the bundled GMP's self-tests, causing them to fail due to
-      # version mismatch. Avoid this by unloading GDB and therefore GMP.
-      # Anna 2024-06-17
-      module unload gdb
-
-      source /hpcdc/project/chapel/setup_llvm.bash 19
-    else
-      echo "CHPL_WHICH_RELEASE_FOR_ARKOUDA is set to $CHPL_WHICH_RELEASE_FOR_ARKOUDA, but no setup_llvm.bash found!"
-      exit 1
-    fi
-  else
-    # Default to using latest LLVM.
-    # (Shouldn't need to set it here, we are already able to access default LLVM)
-    :
-  fi
+  release_dependencies
 else
   echo "CHPL_WHICH_RELEASE_FOR_ARKOUDA not set, cannot run Arkouda release test!"
   exit 1

--- a/util/cron/test-perf.hpe-apollo-hdr.arkouda.release.bash
+++ b/util/cron/test-perf.hpe-apollo-hdr.arkouda.release.bash
@@ -33,6 +33,14 @@ export GASNET_PHYSMEM_MAX="0.90"
 
 export CHPL_LLVM_GCC_PREFIX='none'
 
+if [ -n "$CHPL_WHICH_RELEASE_FOR_ARKOUDA" ]; then
+  release_dependencies
+else
+  echo "CHPL_WHICH_RELEASE_FOR_ARKOUDA not set, cannot run Arkouda release test!"
+  exit 1
+fi
+
+
 nightly_args="${nightly_args} -no-buildcheck"
 
 module list

--- a/util/cron/test-perf.hpe-apollo-hdr.arkouda.release.colo.bash
+++ b/util/cron/test-perf.hpe-apollo-hdr.arkouda.release.colo.bash
@@ -35,6 +35,14 @@ export GASNET_PHYSMEM_MAX="0.90"
 
 export CHPL_LLVM_GCC_PREFIX='none'
 
+if [ -n "$CHPL_WHICH_RELEASE_FOR_ARKOUDA" ]; then
+  release_dependencies
+else
+  echo "CHPL_WHICH_RELEASE_FOR_ARKOUDA not set, cannot run Arkouda release test!"
+  exit 1
+fi
+
+
 nightly_args="${nightly_args} -no-buildcheck"
 
 module list


### PR DESCRIPTION
Refactors and fixes some of the dependency setup for arkouda+chapel release tests.

This PR refactors some of the common logic to helpers in `common-arkouda`, and makes the apollo-hdr release tests use the bundled LLVM

[Reviewed by @]