### PR TITLE
Add missing calls to `CUDA_CALL` in cub wrappers

### DIFF
--- a/runtime/src/gpu/nvidia/gpu-nvidia-cub.cc
+++ b/runtime/src/gpu/nvidia/gpu-nvidia-cub.cc
@@ -99,15 +99,15 @@ void chpl_gpu_impl_sort_##chpl_kind##_##data_type(data_type* data_in, \
                                                   int n, void* stream) {\
   void* temp = NULL; \
   size_t temp_bytes = 0; \
-  cub::DeviceRadixSort::cub_kind(temp, temp_bytes, data_in, data_out,\
+  CUDA_CALL(cub::DeviceRadixSort::cub_kind(temp, temp_bytes, data_in, data_out,\
                                  n, /*beginBit*/0, \
                                  /*endBit*/ sizeof(data_type)*8,\
-                                 (CUstream)stream); \
+                                 (CUstream)stream)); \
   CUDA_CALL(cuMemAlloc(((CUdeviceptr*)&temp), temp_bytes)); \
-  cub::DeviceRadixSort::cub_kind(temp, temp_bytes, data_in, data_out,\
+  CUDA_CALL(cub::DeviceRadixSort::cub_kind(temp, temp_bytes, data_in, data_out,\
                                  n, /*beginBit*/0, \
                                  /*endBit*/ sizeof(data_type)*8,\
-                                 (CUstream)stream); \
+                                 (CUstream)stream)); \
   CUDA_CALL(cuMemFree((CUdeviceptr)temp)); \
 }
 

--- a/runtime/src/gpu/nvidia/gpu-nvidia-cub.cc
+++ b/runtime/src/gpu/nvidia/gpu-nvidia-cub.cc
@@ -48,11 +48,11 @@ void chpl_gpu_impl_##chpl_kind##_reduce_##data_type(data_type* data, int n,\
   CUDA_CALL(cuMemAlloc(&result, sizeof(data_type))); \
   void* temp = NULL; \
   size_t temp_bytes = 0; \
-  cub::DeviceReduce::cub_kind(temp, temp_bytes, data, (data_type*)result, n,\
-                              (CUstream)stream); \
+  CUDA_CALL(cub::DeviceReduce::cub_kind(temp, temp_bytes, data, (data_type*)result, n,\
+                              (CUstream)stream)); \
   CUDA_CALL(cuMemAlloc(((CUdeviceptr*)&temp), temp_bytes)); \
-  cub::DeviceReduce::cub_kind(temp, temp_bytes, data, (data_type*)result, n,\
-                              (CUstream)stream); \
+  CUDA_CALL(cub::DeviceReduce::cub_kind(temp, temp_bytes, data, (data_type*)result, n,\
+                              (CUstream)stream)); \
   CUDA_CALL(cuMemcpyDtoHAsync(val, result, sizeof(data_type),\
                               (CUstream)stream)); \
   CUDA_CALL(cuMemFree(result)); \
@@ -74,11 +74,11 @@ void chpl_gpu_impl_##chpl_kind##_reduce_##data_type(data_type* data, int n,\
   CUDA_CALL(cuMemAlloc(&result, sizeof(kvp))); \
   void* temp = NULL; \
   size_t temp_bytes = 0; \
-  cub::DeviceReduce::cub_kind(temp, temp_bytes, data, (kvp*)result, n,\
-                              (CUstream)stream);\
+  CUDA_CALL(cub::DeviceReduce::cub_kind(temp, temp_bytes, data, (kvp*)result, n,\
+                              (CUstream)stream));\
   CUDA_CALL(cuMemAlloc(((CUdeviceptr*)&temp), temp_bytes)); \
-  cub::DeviceReduce::cub_kind(temp, temp_bytes, data, (kvp*)result, n,\
-                              (CUstream)stream);\
+  CUDA_CALL(cub::DeviceReduce::cub_kind(temp, temp_bytes, data, (kvp*)result, n,\
+                              (CUstream)stream));\
   kvp result_host; \
   CUDA_CALL(cuMemcpyDtoHAsync(&result_host, result, sizeof(kvp),\
                               (CUstream)stream)); \


### PR DESCRIPTION
Adds some missing calls to `CUDA_CALL` in the cub wrappers for reductions and sorts

[Reviewed by @e-kayrakli]