### PR TITLE
Prevent erroneous chplenv warnings in start_test output

### DIFF
--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -316,6 +316,7 @@ def ReadFileWithComments(f, ignoreLeadingSpace=True, args=None):
             chpl_env = get_chplenv()
             file_env = os.environ.copy()
             file_env.update(chpl_env)
+            file_env["CHPLENV_SUPPRESS_WARNINGS"] = "1"
 
             # execute the file and grab its output
             tmp_args = [os.path.abspath(f)]


### PR DESCRIPTION
Prevents erroneous chplenv warnings in the start_test output, caused by invoking a chplenv script from within an executable sub_test file like an `execopts` or `prediff`

[Reviewed by @]