### PR TITLE
Disallow LLVM 20 with nvidia GPUS

### DIFF
--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -156,7 +156,7 @@ The following are further requirements for GPU support:
 
     * Note that LLVM versions older than 16 do not support CUDA 12.
 
-    * We do not yet support LLVM 20, see `this issue <https://github.com/llvm/llvm-project/issues/141626>`_.
+    * We do not yet support GPU programming with LLVM 20, see `this issue <https://github.com/llvm/llvm-project/issues/141626>`_.
 
   * If using ``CHPL_LLVM=system``, it must have been built with support for
     NVPTX target. You can check supported targets of your LLVM installation by

--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -152,9 +152,11 @@ The following are further requirements for GPU support:
 
   * CUDA toolkit version 11.7+ or 12.x must be installed.
 
-  * We test with system LLVM 20. Older versions may work.
+  * We test with bundled LLVM 19. Older versions may work.
 
     * Note that LLVM versions older than 16 do not support CUDA 12.
+
+    * We do not yet support LLVM 20, see `this issue <https://github.com/llvm/llvm-project/issues/141626>`_.
 
   * If using ``CHPL_LLVM=system``, it must have been built with support for
     NVPTX target. You can check supported targets of your LLVM installation by

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -457,6 +457,9 @@ def _validate_cuda_llvm_version_impl(gpu: gpu_type):
             "LLVM not built for %s, consider setting CHPL_LLVM to 'bundled'." %
             gpu.llvm_target, allowExempt=False
         )
+    if int(chpl_llvm.get_llvm_version()) >= 20:
+        error("Chapel does not support LLVM 20+ with CHPL_GPU=nvidia. "
+              "Please use CHPL_LLVM=bundled or LLVM 19 or earlier with CUDA.")
 
 def _validate_rocm_llvm_version_impl(gpu: gpu_type):
     major_version = get_sdk_version().split('.')[0]

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -459,7 +459,7 @@ def _validate_cuda_llvm_version_impl(gpu: gpu_type):
         )
     if int(chpl_llvm.get_llvm_version()) >= 20:
         error("Chapel does not support LLVM 20+ with CHPL_GPU=nvidia. "
-              "Please use CHPL_LLVM=bundled or LLVM 19 or earlier with CUDA.")
+              "Please use CHPL_LLVM=bundled or LLVM 19 or earlier.")
 
 def _validate_rocm_llvm_version_impl(gpu: gpu_type):
     major_version = get_sdk_version().split('.')[0]

--- a/util/cron/common-gpu-nvidia-hpe-cray-ex.bash
+++ b/util/cron/common-gpu-nvidia-hpe-cray-ex.bash
@@ -1,3 +1,7 @@
 # common settings for running GPU nightly testing on the HPE Cray EX system
 
 export CHPL_LAUNCHER_PARTITION=griz512
+
+# required due to https://github.com/chapel-lang/chapel/issues/27273
+export CHPL_LLVM=bundled
+unset CHPL_LLVM_CONFIG

--- a/util/cron/test-gpu-ex-cuda-12.bash
+++ b/util/cron/test-gpu-ex-cuda-12.bash
@@ -9,7 +9,6 @@ source $UTIL_CRON_DIR/common-gpu-nvidia-hpe-cray-ex.bash
 
 module load cuda/12.4
 
-export CHPL_LLVM=system
 export CHPL_COMM=none
 export CHPL_GPU=nvidia  # amd is also detected automatically
 

--- a/util/cron/test-gpu-ex-cuda-12.interop.bash
+++ b/util/cron/test-gpu-ex-cuda-12.interop.bash
@@ -19,7 +19,6 @@ module load cuda/12.4  # default is CUDA 12.5
 # This can be removed once we use CUDA 12.5
 export CHPL_LIB_PATH="/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/math_libs/lib64:$CHPL_LIB_PATH"
 
-export CHPL_LLVM=system
 export CHPL_TEST_GPU=true
 export CHPL_NIGHTLY_TEST_DIRS="gpu/interop/"
 

--- a/util/cron/test-gpu-ex-cuda-12.ofi.bash
+++ b/util/cron/test-gpu-ex-cuda-12.ofi.bash
@@ -9,7 +9,6 @@ source $UTIL_CRON_DIR/common-gpu-nvidia-hpe-cray-ex.bash
 
 module load cuda/12.4
 
-export CHPL_LLVM=system
 export CHPL_COMM=ofi
 export CHPL_GPU=nvidia  # amd is also detected automatically
 

--- a/util/cron/test-gpu-ex-cuda-12.specialization.bash
+++ b/util/cron/test-gpu-ex-cuda-12.specialization.bash
@@ -10,7 +10,6 @@ source $UTIL_CRON_DIR/common-gpu-nvidia-hpe-cray-ex.bash
 
 module load cuda/12.4
 
-export CHPL_LLVM=system
 export CHPL_COMM=none
 export CHPL_GPU=nvidia  # amd is also detected automatically
 


### PR DESCRIPTION
Disallows using LLVM 20 with CHPL_GPU=nvidia, due to upstream LLVM issues

See https://github.com/llvm/llvm-project/issues/141626 and https://github.com/chapel-lang/chapel/issues/27273

This PR also updates the docs and test configs

[Reviewed by @e-kayrakli]