### PR TITLE
Fix docs rendering error in spec for modules

### DIFF
--- a/doc/rst/language/spec/modules.rst
+++ b/doc/rst/language/spec/modules.rst
@@ -238,7 +238,7 @@ within the ``use`` statement.
 
       use libsci.blas;
 
-    .. BLOCK-test-chapelpost
+   .. BLOCK-test-chapelpost
 
       } }
    


### PR DESCRIPTION
Fixes a docs rendering error in the spec for modules, caused by extraneous white space

Tested with `make spectests` and `make docs`.

[Not reviewed - trivial]