### PR TITLE
Adjust find-python.sh to avoid re-running Python

### DIFF
--- a/util/config/find-python.sh
+++ b/util/config/find-python.sh
@@ -5,16 +5,17 @@
 check_python() {
   if command -v $1 > /dev/null 2>&1
   then
-    if $1 --version > /dev/null 2>&1
+    PYTHON_VERSION_OUTPUT=$($1 --version 2>&1)
+    if [ $? -eq 0 ]
     then
       MIN_MINOR_PYTHON_VERSION=5
-      if $1 -c "import sys; sys.exit(int(sys.version_info[:2] >= (3, $MIN_MINOR_PYTHON_VERSION)))" >/dev/null 2>&1
+      if printf "Python 3.%s\n%s\n" "$MIN_MINOR_PYTHON_VERSION" "$PYTHON_VERSION_OUTPUT" | sort -V -C
       then
-        vers=$($1 --version 2>&1)
-        echo "Chapel requires Python 3.$MIN_MINOR_PYTHON_VERSION or later, but found $vers" 1>&2
-      else
         echo $1
         exit 0
+      else
+        vers=$($1 --version 2>&1)
+        echo "Chapel requires Python 3.$MIN_MINOR_PYTHON_VERSION or later, but found $vers" 1>&2
       fi
     fi
   fi


### PR DESCRIPTION
Each Python invocation takes around 300-500ms. Invoking Python to compare versions takes a very long time. Since the compiler, dyno tests, and makefile targets use find-python.sh a lot, we want to reduce the time they take.

This commit adjusts the version check to save the result of `python --version`, and to use `sort`'s version-sorting mode (which prefers `3.10` to `3.2` etc.) to ensure proper ordering. This shaves off some time.

| Command | Before | After |
|---------|--------|-------|
| `chpl --dyno-resolve-only ...` | 2.6s | 2.3s |
| `make test-frontend` | 29s | 24s |
