### PR TITLE
General refactors and cleanup in chpl_llvm.py and chapel-py

### DIFF
--- a/tools/chapel-py/setup.py
+++ b/tools/chapel-py/setup.py
@@ -26,6 +26,7 @@ import glob
 
 chpl_home = str(os.getenv("CHPL_HOME"))
 chpl_printchplenv = os.path.join(chpl_home, "util", "printchplenv")
+chpl_llvm_py = os.path.join(chpl_home, "util", "chplenv", "chpl_llvm.py")
 chpl_variables_lines = (
     subprocess.check_output(
         [chpl_printchplenv, "--internal", "--all", " --anonymize", "--simple"]
@@ -66,7 +67,7 @@ if have_llvm and have_llvm != "none":
 
 CXXFLAGS += ["-Wno-c99-designator"]
 CXXFLAGS += (
-    subprocess.check_output([llvm_config, "--cxxflags"])
+    subprocess.check_output([chpl_llvm_py, "--host-cxxflags"])
     .decode(sys.stdout.encoding)
     .strip()
     .split()

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -1377,18 +1377,18 @@ def compute_host_link_settings():
         if shared_mode.strip() == 'static':
             llvm_dynamic = False
 
+        libdir = run_command([llvm_config, '--libdir'])
+        if libdir:
+            libdir = libdir.strip()
+            system.append('-L' + libdir)
+            system.append('-Wl,-rpath,' + libdir)
+
         # Make sure to put clang first on the link line
         # because depends on LLVM libraries
         if llvm_dynamic:
             system.append('-lclang-cpp')
         else:
             system.extend(clang_static_libs)
-
-        libdir = run_command([llvm_config, '--libdir'])
-        if libdir:
-            libdir = libdir.strip()
-            system.append('-L' + libdir)
-            system.append('-Wl,-rpath,' + libdir)
 
         ldflags = run_command([llvm_config,
                                '--ldflags', '--system-libs', '--libs'] +
@@ -1484,6 +1484,18 @@ def _main():
     parser.add_option('--llvm-config', dest='action',
                       action='store_const',
                       const='llvmconfig', default='')
+    parser.add_option('--host-cxxflags', dest='action',
+                      action='store_const',
+                      const='host-cxxflags', default='')
+    parser.add_option('--host-ldflags', dest='action',
+                      action='store_const',
+                      const='host-ldflags', default='')
+    parser.add_option('--tgt-ccflags', dest='action',
+                      action='store_const',
+                      const='tgt-ccflags', default='')
+    parser.add_option('--tgt-ldflags', dest='action',
+                      action='store_const',
+                      const='tgt-ldflags', default='')
     parser.add_option('--llvm-vesion', dest='action',
                       action='store_const',
                       const='llvmversion', default='')
@@ -1509,6 +1521,18 @@ def _main():
     elif options.action == 'llvmconfig':
         sys.stdout.write("{0}\n".format(llvm_config))
         validate_llvm_config()
+    elif options.action == 'host-cxxflags':
+        sys.stdout.write("{0}\n".format(
+            ' '.join(get_host_compile_args()[1])))
+    elif options.action == 'host-ldflags':
+        sys.stdout.write("{0}\n".format(
+            ' '.join(get_host_link_args()[1])))
+    elif options.action == 'tgt-ccflags':
+        sys.stdout.write("{0}\n".format(
+            ' '.join(get_host_compile_args()[0])))
+    elif options.action == 'tgt-ldflags':
+        sys.stdout.write("{0}\n".format(
+            ' '.join(get_host_link_args()[0])))
     elif options.action == 'llvmversion':
         llvm_version = get_llvm_version()
         sys.stdout.write("{0}\n".format(llvm_version))


### PR DESCRIPTION
Adds a few helper CLI options to chpl_llvm.py and uses them in `chapel-py`. This consolidates a bit more logic into one place.

This also reordered the usage of `llvm-config --libdir` to be before `-lclang-cpp`, since that is "more correct".

[Reviewed by @]