### PR TITLE
Expand nightly LLVM version tests to include the `test/llvm` folder

### DIFF
--- a/util/cron/test-linux64-llvm11.bash
+++ b/util/cron/test-linux64-llvm11.bash
@@ -17,5 +17,6 @@ fi
 export CHPL_LAUNCHER=none
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-llvm11"
+export CHPL_NIGHTLY_TEST_DIRS="llvm/"
 
 $UTIL_CRON_DIR/nightly -cron -examples -blog ${nightly_args}

--- a/util/cron/test-linux64-llvm12.bash
+++ b/util/cron/test-linux64-llvm12.bash
@@ -17,5 +17,6 @@ fi
 export CHPL_LAUNCHER=none
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-llvm12"
+export CHPL_NIGHTLY_TEST_DIRS="llvm/"
 
 $UTIL_CRON_DIR/nightly -cron -examples -blog ${nightly_args}

--- a/util/cron/test-linux64-llvm13.bash
+++ b/util/cron/test-linux64-llvm13.bash
@@ -17,5 +17,6 @@ fi
 export CHPL_LAUNCHER=none
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-llvm13"
+export CHPL_NIGHTLY_TEST_DIRS="llvm/"
 
 $UTIL_CRON_DIR/nightly -cron -examples -blog ${nightly_args}

--- a/util/cron/test-linux64-llvm14.bash
+++ b/util/cron/test-linux64-llvm14.bash
@@ -17,5 +17,6 @@ fi
 export CHPL_LAUNCHER=none
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-llvm14"
+export CHPL_NIGHTLY_TEST_DIRS="llvm/"
 
 $UTIL_CRON_DIR/nightly -cron -examples -blog ${nightly_args}

--- a/util/cron/test-linux64-llvm15.bash
+++ b/util/cron/test-linux64-llvm15.bash
@@ -27,5 +27,6 @@ fi
 export CHPL_LAUNCHER=none
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-llvm15"
+export CHPL_NIGHTLY_TEST_DIRS="llvm/"
 
 $UTIL_CRON_DIR/nightly -cron -examples -blog ${nightly_args}

--- a/util/cron/test-linux64-llvm16.bash
+++ b/util/cron/test-linux64-llvm16.bash
@@ -18,5 +18,6 @@ fi
 export CHPL_LAUNCHER=none
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-llvm16"
+export CHPL_NIGHTLY_TEST_DIRS="llvm/"
 
 $UTIL_CRON_DIR/nightly -cron -examples -blog ${nightly_args}

--- a/util/cron/test-linux64-llvm17.bash
+++ b/util/cron/test-linux64-llvm17.bash
@@ -18,5 +18,6 @@ fi
 export CHPL_LAUNCHER=none
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-llvm17"
+export CHPL_NIGHTLY_TEST_DIRS="llvm/"
 
 $UTIL_CRON_DIR/nightly -cron -examples -blog ${nightly_args}

--- a/util/cron/test-linux64-llvm18.bash
+++ b/util/cron/test-linux64-llvm18.bash
@@ -18,5 +18,6 @@ fi
 export CHPL_LAUNCHER=none
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-llvm18"
+export CHPL_NIGHTLY_TEST_DIRS="llvm/"
 
 $UTIL_CRON_DIR/nightly -cron -examples -blog ${nightly_args}

--- a/util/cron/test-linux64-llvm19.bash
+++ b/util/cron/test-linux64-llvm19.bash
@@ -19,5 +19,6 @@ fi
 export CHPL_LAUNCHER=none
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-llvm19"
+export CHPL_NIGHTLY_TEST_DIRS="llvm/"
 
-$UTIL_CRON_DIR/nightly -cron -examples ${nightly_args}
+$UTIL_CRON_DIR/nightly -cron -examples -blog ${nightly_args}

--- a/util/cron/test-linux64-llvm20.bash
+++ b/util/cron/test-linux64-llvm20.bash
@@ -18,5 +18,6 @@ fi
 export CHPL_LAUNCHER=none
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-llvm20"
+export CHPL_NIGHTLY_TEST_DIRS="llvm/"
 
-$UTIL_CRON_DIR/nightly -cron -examples ${nightly_args}
+$UTIL_CRON_DIR/nightly -cron -examples -blog ${nightly_args}


### PR DESCRIPTION
Expands nightly LLVM version tests to include the `test/llvm` folder

[Reviewed by @]