### PR TITLE
Avoid missing brace warning in new edition code

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -354,7 +354,7 @@ const char* compileCommandFilename = "compileCommand.tmp";
 const char* compileCommand = NULL;
 char compileVersion[64];
 
-std::array<std::string, 2> editions ({"2.0", "pre-edition"});
+std::array<std::string, 2> editions ({{"2.0", "pre-edition"}});
 std::string fEdition = "2.0";
 
 static bool fPrintCopyright = false;


### PR DESCRIPTION
[trivial, not reviewed]

This was turning up in Arkouda testing, though it's unclear if it was actually causing a failure there.

Passed a full paratest with futures