### PR TITLE
Resolve logger warnings

### DIFF
--- a/util/build_configs/build_configs.py
+++ b/util/build_configs/build_configs.py
@@ -277,7 +277,7 @@ def get_chpl_misc(opts, args, build_env):
     if chpl_home_env:
         chpl_home_env = os.path.abspath(chpl_home_env)
         if chpl_home_env != chpl_home_opt:
-            logging.warn('Resetting build_env[CHPL_HOME],\nfrom\t{0}\nto\t{1}'.format(chpl_home_env, chpl_home_opt))
+            logging.warning('Resetting build_env[CHPL_HOME],\nfrom\t{0}\nto\t{1}'.format(chpl_home_env, chpl_home_opt))
 
     chpl_home = chpl_home_opt
     logging.info('Using CHPL_HOME={0}'.format(chpl_home))
@@ -311,7 +311,7 @@ def get_chpl_misc(opts, args, build_env):
         logging.error('From {0}\n{1}\n{2}\nexit code {3}'.format(chplenv_cmd, error, output, result))
         sys.exit(2)
     if error:
-        logging.warn('From {0}\n{1}\n{2}'.format(chplenv_cmd, error, output))
+        logging.warning('From {0}\n{1}\n{2}'.format(chplenv_cmd, error, output))
     elif not output:
         logging.error('{0}\nreturns no output'.format(chplenv_cmd))
         sys.exit(2)
@@ -494,7 +494,7 @@ def build_chpl(counter, build_config, env, chpl_misc, parallel=False, verbose=Fa
         with elapsed_time('Config number {0}'.format(counter)):
             result, output, error = check_output(dryrun_cmd, chpl_home, build_env)
         if result or error:
-            logging.warn('Errors/Warnings from printchplenv, config {0}\n{1}\n{2}\nExit code {3}'.format(
+            logging.warning('Errors/Warnings from printchplenv, config {0}\n{1}\n{2}\nExit code {3}'.format(
                 build_config_name, output, error, result))
         elif verbose:
             logging.debug('Results from printchplenv, config {0}\n{1}\n{2}\nExit code {3}'.format(

--- a/util/test/convert_start_test_log_to_junit_xml.py
+++ b/util/test/convert_start_test_log_to_junit_xml.py
@@ -354,7 +354,7 @@ def _get_test_time(test_case_lines):
     if time_line_idx == -1:
         msg = 'Could not find elapsed time line in: {0}'.format(
             test_case_lines)
-        logging.warn(msg)
+        logging.warning(msg)
         if DEBUG:
             raise ValueError(msg)
     time_line = test_case_lines[time_line_idx]
@@ -366,7 +366,7 @@ def _get_test_time(test_case_lines):
     else:
         time = '0.0'
         msg = 'Could not find time in: {0}'.format(time_line)
-        logging.warn(msg)
+        logging.warning(msg)
         if DEBUG:
             raise ValueError(msg)
     return max(float(time),0.0)


### PR DESCRIPTION
# PR Summary
This small PR resolves the annoying deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```
