### PR TITLE
Resolve issue with Chapel's nvidia GPU support with LLVM 20+

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2849,7 +2849,7 @@ static std::string generateClangGpuLangArgs() {
 
     // to get old behavior: https://releases.llvm.org/19.1.0/tools/clang/docs/ReleaseNotes.html#cuda-hip-language-changes
     if (getGpuCodegenType() == GpuCodegenType::GPU_CG_NVIDIA_CUDA) {
-      args += " --cuda-include-ptx=all"
+      args += " --cuda-include-ptx=all";
     }
   }
   return args;

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2846,6 +2846,11 @@ static std::string generateClangGpuLangArgs() {
     if (gpuArches.size() >= 1) {
       args += " " + std::string("--offload-arch=") + *gpuArches.begin();
     }
+
+    // to get old behavior: https://releases.llvm.org/19.1.0/tools/clang/docs/ReleaseNotes.html#cuda-hip-language-changes
+    if (getGpuCodegenType() == GpuCodegenType::GPU_CG_NVIDIA_CUDA) {
+      args += " --cuda-include-ptx=all"
+    }
   }
   return args;
 }

--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -152,11 +152,9 @@ The following are further requirements for GPU support:
 
   * CUDA toolkit version 11.7+ or 12.x must be installed.
 
-  * We test with bundled LLVM 19. Older versions may work.
+  * We test with system LLVM 20. Older versions may work.
 
     * Note that LLVM versions older than 16 do not support CUDA 12.
-
-    * We do not yet support GPU programming with LLVM 20, see `this issue <https://github.com/llvm/llvm-project/issues/141626>`_.
 
   * If using ``CHPL_LLVM=system``, it must have been built with support for
     NVPTX target. You can check supported targets of your LLVM installation by

--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -152,7 +152,7 @@ The following are further requirements for GPU support:
 
   * CUDA toolkit version 11.7+ or 12.x must be installed.
 
-  * We test with system LLVM 20. Older versions may work.
+  * We test with LLVM 20. Older versions may work.
 
     * Note that LLVM versions older than 16 do not support CUDA 12.
 

--- a/runtime/src/gpu/nvidia/Makefile.share
+++ b/runtime/src/gpu/nvidia/Makefile.share
@@ -21,14 +21,12 @@ SRCS = $(GPU_SRCS)
 
 GPU_OBJS = $(addprefix $(GPU_OBJDIR)/,$(addsuffix .o,$(basename $(GPU_SRCS))))
 
-# 1. our bundled clang (15 as of today) doesn't support warp-reductions which
-# came in with 8.x. So, we are limiting our runtime binary to 7.5. This seems to
-# work fine even if the user code is compiled with >7.5.
-# 2. clang-14 wants offload-arch to be passed multiple times and doesn't accept
+# TODO: clang-14 wants offload-arch to be passed multiple times and doesn't accept
 # a comma-separated list.
 RUNTIME_CXXFLAGS += -x cuda -Wno-unknown-cuda-version \
                     -Xclang -fcuda-allow-variadic-functions \
-                    --offload-arch=$(CHPL_MAKE_GPU_ARCH)
+                    --offload-arch=$(CHPL_MAKE_GPU_ARCH) \
+										--cuda-include-ptx=all
 
 # With cuda 11, cub headers have unused typedefs
 RUNTIME_CXXFLAGS += -Wno-error=unused-local-typedef

--- a/runtime/src/gpu/nvidia/Makefile.share
+++ b/runtime/src/gpu/nvidia/Makefile.share
@@ -26,7 +26,7 @@ GPU_OBJS = $(addprefix $(GPU_OBJDIR)/,$(addsuffix .o,$(basename $(GPU_SRCS))))
 RUNTIME_CXXFLAGS += -x cuda -Wno-unknown-cuda-version \
                     -Xclang -fcuda-allow-variadic-functions \
                     --offload-arch=$(CHPL_MAKE_GPU_ARCH) \
-										--cuda-include-ptx=all
+                    --cuda-include-ptx=all
 
 # With cuda 11, cub headers have unused typedefs
 RUNTIME_CXXFLAGS += -Wno-error=unused-local-typedef

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -457,9 +457,6 @@ def _validate_cuda_llvm_version_impl(gpu: gpu_type):
             "LLVM not built for %s, consider setting CHPL_LLVM to 'bundled'." %
             gpu.llvm_target, allowExempt=False
         )
-    if int(chpl_llvm.get_llvm_version()) >= 20:
-        error("Chapel does not support LLVM 20+ with CHPL_GPU=nvidia. "
-              "Please use CHPL_LLVM=bundled or LLVM 19 or earlier.")
 
 def _validate_rocm_llvm_version_impl(gpu: gpu_type):
     major_version = get_sdk_version().split('.')[0]

--- a/util/cron/common-gpu-nvidia-hpe-cray-ex.bash
+++ b/util/cron/common-gpu-nvidia-hpe-cray-ex.bash
@@ -1,7 +1,4 @@
 # common settings for running GPU nightly testing on the HPE Cray EX system
 
 export CHPL_LAUNCHER_PARTITION=griz512
-
-# required due to https://github.com/chapel-lang/chapel/issues/27273
-export CHPL_LLVM=bundled
-unset CHPL_LLVM_CONFIG
+export CHPL_LLVM=system


### PR DESCRIPTION
Resolves an issue where Chapel's nvidia GPU support was broken with LLVM 20+, due to changes in the clang driver.

See https://github.com/llvm/llvm-project/issues/141626 for more details on the original issue and the solution. TL;DR With LLVM 20+ the PTX assembly is no longer included in the GPU binary by default, meaning we can only target the exact architecture specified in CHPL_GPU_ARCH. Passing `--cuda-include-ptx=all` restores the previous behavior.

Resolves https://github.com/chapel-lang/chapel/issues/27273 and reverts https://github.com/chapel-lang/chapel/pull/27282

Tested on an EX with `start_test test/gpu/native/reduction`

[Reviewed by @arifthpe and @e-kayrakli]