### PR TITLE
Fix some flag names that were out of date and expand to the complete set

### DIFF
--- a/man/chpl.rst
+++ b/man/chpl.rst
@@ -233,11 +233,12 @@ OPTIONS
 
 **\--[no-]warn-param-implicit-numeric-conversions**
 
-    When used in conjunction with ``warn-int-uint``,
-    ``--warn-real-real``, or ``--warn-integral-integral``, this flag
-    enables [or disables] these compilation warnings about implicitly
-    converting between numeric types to also apply when the converted
-    value is a ``param``.
+    When used in conjunction with ``--warn-int-to-uint``,
+    ``--warn-small-integral-to-float``, ``--warn-integral-to-float``,
+    ``--warn-float-to-float``, or ``--warn-integral-to-integral``,
+    this flag enables [or disables] these compilation warnings about
+    implicitly converting between numeric types to also apply when the
+    converted value is a ``param``.
 
 *Parallelism Control Options*
 


### PR DESCRIPTION
@mppf : Can you check my work here?  Specifically:

* Updating the three existing flag names whose names changed seems like a no-brainer and not worth review
* Was adding the other two flag names the right thing to do, or are they not relevant here?
* Is it correct that only `warn-param-implicit-numeric-conversions` and not `warn-implicit-numeric-conversions` refers to these flags?