### PR TITLE
Fix CHPL_GPU=nvidia performance tests on EX

### DIFF
--- a/util/cron/test-perf.gpu-ex-cuda-12.bash
+++ b/util/cron/test-perf.gpu-ex-cuda-12.bash
@@ -9,7 +9,6 @@ source $UTIL_CRON_DIR/common-gpu-nvidia-hpe-cray-ex.bash
 
 module load cuda/12.4
 
-export CHPL_LLVM=system
 export CHPL_COMM=none
 export CHPL_GPU=nvidia  # amd is detected automatically
 

--- a/util/cron/test-perf.gpu-ex-cuda-12.um.bash
+++ b/util/cron/test-perf.gpu-ex-cuda-12.um.bash
@@ -9,7 +9,6 @@ source $UTIL_CRON_DIR/common-gpu-nvidia-hpe-cray-ex.bash
 
 module load cuda/12.4
 
-export CHPL_LLVM=system
 export CHPL_COMM=none
 export CHPL_GPU=nvidia  # amd is detected automatically
 export CHPL_GPU_MEM_STRATEGY=unified_memory


### PR DESCRIPTION
Fixes CHPL_GPU=nvidia performance tests on EX by removing CHPL_LLVM=system

[Not reviewed - trivial]