### PR TITLE
Hide another function that was accidentally getting included in the docs

### DIFF
--- a/modules/packages/Python.chpl
+++ b/modules/packages/Python.chpl
@@ -3982,9 +3982,9 @@ module Python {
     lhs.interpreter.checkException();
     return new Value(lhs.interpreter, res, isOwned=true);
   }
-  inline proc _binaryOpInPlace(param op: string,
-                                lhs: borrowed Value,
-                                rhs: borrowed Value) throws {
+  private inline proc _binaryOpInPlace(param op: string,
+                                       lhs: borrowed Value,
+                                       rhs: borrowed Value) throws {
     var ctx = chpl_pythonContext.enter();
     defer ctx.exit();
     var res = PyObject_CallMethod(


### PR DESCRIPTION
The one above it was private, so make this one private as well

Passed a full paratest with futures