### PR TITLE
Convert `testReleaseHelp` script to bash

### DIFF
--- a/util/buildRelease/testReleaseHelp
+++ b/util/buildRelease/testReleaseHelp
@@ -1,142 +1,136 @@
-#!/bin/csh
-
+#!/bin/bash
 #
-# unsetenv normal Chapel environment variables
+# unset normal Chapel environment variables
 #
-unsetenv CHPL_HOME
-unsetenv CHPL_NIGHTLY_LOGDIR
-unsetenv CHPL_DEVELOPER
-unsetenv CHPL_HOST_PLATFORM
-unsetenv CHPL_TARGET_PLATFORM
-unsetenv CHPLDEVTMP
+unset CHPL_HOME
+unset CHPL_NIGHTLY_LOGDIR
+unset CHPL_DEVELOPER
+unset CHPL_HOST_PLATFORM
+unset CHPL_TARGET_PLATFORM
+unset CHPLDEVTMP
 
-set mymake = $argv[1]
+mymake="$1"
 
 # Number of logical processes on current system. Will be used as number of jobs
 # when calling make with parallel execution.
-set num_procs = `${0:h}/chpl-make-cpu_count`
+num_procs=$($(dirname "$0")/chpl-make-cpu_count)
 
 #
 # execute actions specified in README
 #
-if ( $#argv == 0 ) then
-    echo "usage: $argv[0] <make utility>"
-    exit(1);
-endif
-source util/quickstart/setchplenv.csh
-set tmpstatus = $status
-if ($tmpstatus != 0) then
-    echo "ERROR: source of setchplenv.csh failed"
-    exit($tmpstatus)
-endif
+if [[ $# == 0 ]]; then
+    echo "usage: $0 <make utility>"
+    exit 1
+fi
+
+source util/quickstart/setchplenv.bash
+tmpstatus=$?
+if [[ $tmpstatus != 0 ]]; then
+    echo "ERROR: source of setchplenv.bash failed"
+    exit $tmpstatus
+fi
+
 $mymake -j$num_procs
-set tmpstatus = $status
-if ($tmpstatus != 0) then
+tmpstatus=$?
+if [[ $tmpstatus != 0 ]]; then
     echo "ERROR: make failed"
-    exit($tmpstatus)
-endif
-rehash   # required for csh only; if we convert this to bash, drop this
-set tmpstatus = $status
-if ($tmpstatus != 0) then
-    echo "ERROR: make failed"
-    exit($tmpstatus)
-endif
+    exit $tmpstatus
+fi
+
 $mymake check
-set tmpstatus = $status
-if ($tmpstatus != 0) then
+tmpstatus=$?
+if [[ $tmpstatus != 0 ]]; then
     echo "ERROR: make check failed"
-    exit($tmpstatus)
-endif
+    exit $tmpstatus
+fi
+
 chpl -o hello examples/hello.chpl
-set tmpstatus = $status
-if ($tmpstatus != 0) then
+tmpstatus=$?
+if [[ $tmpstatus != 0 ]]; then
     echo "ERROR: compilation of hello.chpl failed"
-    exit($tmpstatus)
-endif
+    exit $tmpstatus
+fi
+
 ./hello
-set tmpstatus = $status
-if ($tmpstatus != 0) then
+tmpstatus=$?
+if [[ $tmpstatus != 0 ]]; then
     echo "ERROR: execution of hello failed"
-    exit($tmpstatus)
-endif
+    exit $tmpstatus
+fi
 
 # Build chpldoc and run chpldoc-check.
 $mymake -j$num_procs chpldoc
-set tmpstatus = $status
-if ($tmpstatus != 0) then
+tmpstatus=$?
+if [[ $tmpstatus != 0 ]]; then
     echo "ERROR: make chpldoc failed"
-    exit($tmpstatus)
-endif
-rehash   # required for csh only; if we convert this to bash, drop this
+    exit $tmpstatus
+fi
 
 $mymake check-chpldoc
-set tmpstatus = $status
-if ($tmpstatus != 0) then
+tmpstatus=$?
+if [[ $tmpstatus != 0 ]]; then
     echo "ERROR: make check-chpldoc failed"
-    exit($tmpstatus)
-endif
+    exit $tmpstatus
+fi
 
 $mymake protoc-gen-chpl
-set tmpstatus = $status
-if ($tmpstatus != 0) then
+tmpstatus=$?
+if [[ $tmpstatus != 0 ]]; then
     echo "ERROR: make protoc-gen-chpl failed"
-    exit($tmpstatus)
-endif
-
-
+    exit $tmpstatus
+fi
 
 # Calculate expected version string from CMakeLists.txt
-set major=`cat CMakeLists.txt | grep 'set(CHPL_MAJOR_VERSION' | cut -f2 -d' ' | sed 's/)//g'`
-set minor=`cat CMakeLists.txt | grep 'set(CHPL_MINOR_VERSION' | cut -f2 -d' ' | sed 's/)//g'`
-set patch=`cat CMakeLists.txt | grep 'set(CHPL_PATCH_VERSION' | cut -f2 -d' ' | sed 's/)//g'`
-set expected_version_string="$major.$minor.$patch"
+major=$(cat CMakeLists.txt | grep 'set(CHPL_MAJOR_VERSION' | cut -f2 -d' ' | sed 's/)//g')
+minor=$(cat CMakeLists.txt | grep 'set(CHPL_MINOR_VERSION' | cut -f2 -d' ' | sed 's/)//g')
+patch=$(cat CMakeLists.txt | grep 'set(CHPL_PATCH_VERSION' | cut -f2 -d' ' | sed 's/)//g')
+expected_version_string="$major.$minor.$patch"
 
 # Test chpl --version for expected string version.
-set version_string = `chpl --version | grep 'chpl version' | cut -d' ' -f 3`
-set versionstatus = $status
-if ($versionstatus != 0) then
+version_string=$(chpl --version | grep 'chpl version' | cut -d' ' -f 3)
+versionstatus=$?
+if [[ $versionstatus != 0 ]]; then
     echo "ERROR: execution of chpl --version failed"
-    exit($versionstatus)
-endif
-if ($version_string != "$expected_version_string") then
+    exit $versionstatus
+fi
+
+if [[ "$version_string" != "$expected_version_string" ]]; then
     echo "ERROR: unexpected version string, received '$version_string' expected '$expected_version_string'"
-    exit(1)
-endif
+    exit 1
+fi
 
 #
 # run make in examples directory
 #
 cd examples
 $mymake -j$num_procs
-set tmpstatus = $status
-if ($tmpstatus != 0) then
+tmpstatus=$?
+if [[ $tmpstatus != 0 ]]; then
     echo "ERROR: compiling examples with 'make' failed"
-    exit($tmpstatus)
-endif
+    exit $tmpstatus
+fi
 cd ..
-
 
 #
 # run test system on examples directory
 #
 cd examples
-set tmpstatus = $status
-if ($tmpstatus != 0) then
+tmpstatus=$?
+if [[ $tmpstatus != 0 ]]; then
     echo "ERROR: cd into examples failed"
-    exit($tmpstatus)
-endif
+    exit $tmpstatus
+fi
 
-set start_test_flags = ''
-if ($?CHPL_TEST_RELEASE_NORECURSE) then
-    set start_test_flags = ${start_test_flags}' --norecurse'
-endif
+start_test_flags=''
+if [[ -n "${CHPL_TEST_RELEASE_NORECURSE:-}" ]]; then
+    start_test_flags="${start_test_flags} --norecurse"
+fi
 
 ./start_test ${start_test_flags} -logfile Logs/testReleaseHelp.log
-
-set tmpstatus = $status
-if ($tmpstatus != 0) then
+tmpstatus=$?
+if [[ $tmpstatus != 0 ]]; then
     echo "ERROR: testing of examples failed"
-    exit($tmpstatus)
-endif
+    exit $tmpstatus
+fi
 
-exit(0)
+exit 0

--- a/util/buildRelease/testReleaseHelp
+++ b/util/buildRelease/testReleaseHelp
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # unset normal Chapel environment variables
 #


### PR DESCRIPTION
Closes https://github.com/chapel-lang/chapel/issues/26561
Closes https://github.com/chapel-lang/chapel/issues/14133 (excluding the additional Travis CI check request)

Port [`testReleaseHelp`](https://github.com/chapel-lang/chapel/blob/main/util/buildRelease/testReleaseHelp) to bash.

Test run logs (using `cmake-3.25.1`):
<details>
<summary>Log</summary>

```bash
@subhramit ➜ /workspaces/chapel (convert-script) $ ./util/buildRelease/testReleaseHelp make
Setting CHPL_HOME to /workspaces/chapel
Updating PATH to include /workspaces/chapel/bin/linux64-x86_64
                     and /workspaces/chapel/util
Updating MANPATH to include /workspaces/chapel/man
Setting CHPL_COMM to none
Setting CHPL_TASKS to fifo
Setting CHPL_TARGET_MEM to cstdlib
Setting CHPL_HOST_MEM to cstdlib
Setting CHPL_GMP to none
Setting CHPL_RE2 to none
Setting CHPL_LLVM to none
Making the compiler...
make[2]: Nothing to be done for 'llvm'.
make[2]: Nothing to be done for 'jemalloc'.
make[2]: Nothing to be done for 'mimalloc'.
***** ./ *****
-- Configuring Chapel version: 2.5.0
-- CMAKE_INSTALL_PREFIX is /usr/local
CHPL_DEVELOPER is not set, using OFF
-- No CHPL_LLVM_GCC_PREFIX env var or value given from command line.
-- Using Python: python3
-- Could NOT find Doxygen (missing: DOXYGEN_EXECUTABLE) (Required is at least version "1.8.17")
Cannot build linters without LLVM - skipping
-- Configuring done
-- Generating done
-- Build files have been written to: /workspaces/chapel/build/compiler/linux64/gnu/x86_64/hostmem-cstdlib/llvm-none/19/san-none
[  1%] checking sensitive files for version changes...
[  3%] Built target git-sha-obj
[  3%] Built target update-release-and-version-info
[ 55%] Built target ChplFrontend-obj
[ 55%] Built target ChplFrontend
[100%] Built target chpl
cd third-party && make try-re2;
make[2]: Nothing to be done for 'try-re2'.
cd third-party && make try-gmp;
make[2]: Nothing to be done for 'try-gmp'.
Making the runtime...
***** src/mem/ *****
***** src/comm/ *****
***** src/threads/ *****
***** src/tasks/ *****
***** src/mem/cstdlib/ *****
***** src/comm/none/ *****
***** src/tasks/fifo/ *****
***** src/threads/pthreads/ *****
***** src/timers/ *****
***** src/topo/ *****
***** src/topo/none/ *****
***** src/ *****
***** src/timers/generic/ *****
***** src/qio/ *****
***** src/gpu/ *****
***** src/gpu/none/ *****
***** src/qio/regex/none/ *****
***** ./ *****
Making the modules...
make[2]: Nothing to be done for 'default'.
Generating CMake module files...
cp /workspaces/chapel/util/cmake/*.cmake /workspaces/chapel/util/cmake/*.cmake.in /workspaces/chapel/lib/cmake/chpl
[Info] Running minimal test script: $CHPL_HOME/util/test/checkChplInstall
[Info] Found executable chpl in /workspaces/chapel/bin/linux64-x86_64/chpl.
[Info] Found $CHPL_HOME directory: /workspaces/chapel
[Info] /home/codespace/.chpl already exists. Using it.
[Info] Temporary test job directory: /home/codespace/.chpl/chapel-test-nnrjB8
[Info] Compiling $CHPL_HOME/test/release/examples/hello6-taskpar-dist.chpl
[Info] Compiling with CHPL_TARGET_COMPILER=gnu
[Info] Test job compiled into /home/codespace/.chpl/chapel-test-nnrjB8/hello6-taskpar-dist
[Info] $CHPL_LAUNCHER=none is compatible with test script.
[Info] Running test job.
[Info] Test job complete.
SUCCESS: 'make check' passed!
Hello, world!
cd chpl-venv && make chpldoc-venv
make[2]: Nothing to be done for 'chpldoc-venv'.
make[1]: Nothing to be done for 'llvm'.
cd compiler && make chpldoc
-- Configuring Chapel version: 2.5.0
-- CMAKE_INSTALL_PREFIX is /usr/local
CHPL_DEVELOPER is not set, using OFF
-- No CHPL_LLVM_GCC_PREFIX env var or value given from command line.
-- Using Python: python3
-- Could NOT find Doxygen (missing: DOXYGEN_EXECUTABLE) (Required is at least version "1.8.17")
Cannot build linters without LLVM - skipping
-- Configuring done
-- Generating done
-- Build files have been written to: /workspaces/chapel/build/compiler/linux64/gnu/x86_64/hostmem-cstdlib/llvm-none/19/san-none
[  3%] checking sensitive files for version changes...
[  6%] Built target git-sha-obj
[  6%] Built target update-release-and-version-info
[100%] Built target ChplFrontend-obj
[100%] Built target ChplFrontend
[100%] Built target chpldoc
make[1]: Nothing to be done for 'default'.
cd chpl-venv && make chpldoc-venv
make[3]: Nothing to be done for 'chpldoc-venv'.
cd man && make chpldoc
make[2]: Nothing to be done for 'chpldoc'.
cd chpl-venv && make chpldoc-venv
make[2]: Nothing to be done for 'chpldoc-venv'.
make[1]: Nothing to be done for 'llvm'.
cd compiler && make chpldoc
-- Configuring Chapel version: 2.5.0
-- CMAKE_INSTALL_PREFIX is /usr/local
CHPL_DEVELOPER is not set, using OFF
-- No CHPL_LLVM_GCC_PREFIX env var or value given from command line.
-- Using Python: python3
-- Could NOT find Doxygen (missing: DOXYGEN_EXECUTABLE) (Required is at least version "1.8.17")
Cannot build linters without LLVM - skipping
-- Configuring done
-- Generating done
-- Build files have been written to: /workspaces/chapel/build/compiler/linux64/gnu/x86_64/hostmem-cstdlib/llvm-none/19/san-none
[  3%] checking sensitive files for version changes...
[  3%] Built target update-release-and-version-info
[ 96%] Built target ChplFrontend-obj
[100%] Built target git-sha-obj
[100%] Built target ChplFrontend
[100%] Built target chpldoc
make[1]: Nothing to be done for 'default'.
cd chpl-venv && make chpldoc-venv
make[3]: Nothing to be done for 'chpldoc-venv'.
cd man && make chpldoc
make[2]: Nothing to be done for 'chpldoc'.
cd chpl-venv && make test-venv
make[2]: Nothing to be done for 'test-venv'.
Running the chpldoc tests found in: /workspaces/chapel/test/release/examples
Testing /home/codespace/.chpl/chapel-test-1MyU3p/chpldoc.doc.chpl ... 
[done]
chpldoc installation works as expected!
cd chpl-venv && make chpldoc-venv
make[2]: Nothing to be done for 'chpldoc-venv'.
make[1]: Nothing to be done for 'llvm'.
cd compiler && make chpldoc
-- Configuring Chapel version: 2.5.0
-- CMAKE_INSTALL_PREFIX is /usr/local
CHPL_DEVELOPER is not set, using OFF
-- No CHPL_LLVM_GCC_PREFIX env var or value given from command line.
-- Using Python: python3
-- Could NOT find Doxygen (missing: DOXYGEN_EXECUTABLE) (Required is at least version "1.8.17")
Cannot build linters without LLVM - skipping
-- Configuring done
-- Generating done
-- Build files have been written to: /workspaces/chapel/build/compiler/linux64/gnu/x86_64/hostmem-cstdlib/llvm-none/19/san-none
[  3%] checking sensitive files for version changes...
[  3%] Built target update-release-and-version-info
[ 96%] Built target ChplFrontend-obj
[100%] Built target git-sha-obj
[100%] Built target ChplFrontend
[100%] Built target chpldoc
make[1]: Nothing to be done for 'default'.
cd chpl-venv && make chpldoc-venv
make[3]: Nothing to be done for 'chpldoc-venv'.
cd man && make chpldoc
make[2]: Nothing to be done for 'chpldoc'.
cd third-party && make try-re2;
make[2]: Nothing to be done for 'try-re2'.
cd third-party && make try-gmp;
make[2]: Nothing to be done for 'try-gmp'.
Making the runtime...
***** src/comm/ *****
***** src/comm/none/ *****
***** src/mem/ *****
***** src/mem/cstdlib/ *****
***** src/tasks/ *****
***** src/tasks/fifo/ *****
***** src/threads/ *****
***** src/threads/pthreads/ *****
***** src/timers/ *****
***** src/timers/generic/ *****
***** src/topo/ *****
***** src/topo/none/ *****
***** src/qio/regex/none/ *****
***** src/qio/ *****
***** src/gpu/none/ *****
***** src/gpu/ *****
***** src/ *****
***** ./ *****
Making the modules...
make[2]: Nothing to be done for 'default'.
cd tools/protoc-gen-chpl && make && make install
Building protoc-gen-chpl..
gcc     -pthread -I. -std=c++17 -o /workspaces/chapel/bin/linux64-x86_64/protoc-gen-chpl reflection_class.cpp message_field.cpp enum.cpp message.cpp repeated_primitive_field.cpp repeated_message_field.cpp repeated_enum_field.cpp field_base.cpp map_field.cpp primitive_field.cpp generator.cpp helpers.cpp enum_field.cpp protoc-gen-chpl.cpp -lprotobuf -pthread -lprotobuf -lprotoc -lstdc++
In file included from reflection_class.cpp:22:
./message.h:27:10: fatal error: google/protobuf/compiler/code_generator.h: No such file or directory
   27 | #include <google/protobuf/compiler/code_generator.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
In file included from enum.cpp:22:
./helpers.h:28:10: fatal error: google/protobuf/compiler/code_generator.h: No such file or directory
   28 | #include <google/protobuf/compiler/code_generator.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
message.cpp:25:10: fatal error: google/protobuf/compiler/code_generator.h: No such file or directory
   25 | #include <google/protobuf/compiler/code_generator.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
In file included from field_base.cpp:24:
./helpers.h:28:10: fatal error: google/protobuf/compiler/code_generator.h: No such file or directory
   28 | #include <google/protobuf/compiler/code_generator.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
In file included from generator.cpp:26:
./generator.h:26:10: fatal error: google/protobuf/compiler/code_generator.h: No such file or directory
   26 | #include <google/protobuf/compiler/code_generator.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
In file included from helpers.cpp:23:
./helpers.h:28:10: fatal error: google/protobuf/compiler/code_generator.h: No such file or directory
   28 | #include <google/protobuf/compiler/code_generator.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
protoc-gen-chpl.cpp:21:10: fatal error: google/protobuf/compiler/plugin.h: No such file or directory
   21 | #include <google/protobuf/compiler/plugin.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[1]: *** [Makefile:55: /workspaces/chapel/bin/linux64-x86_64/protoc-gen-chpl] Error 1
make: *** [Makefile:192: protoc-gen-chpl] Error 2
ERROR: make protoc-gen-chpl failed
```

</details>

(The protobuf error is unrelated to the changes)