### PR TITLE
Cleanup a few tests after fixing global debug information

### DIFF
--- a/test/library/standard/Debugger/breakpoint/useBreakpoint-lldb.compopts
+++ b/test/library/standard/Debugger/breakpoint/useBreakpoint-lldb.compopts
@@ -1,1 +1,9 @@
--g
+#!/usr/bin/env bash
+
+backend=$($CHPL_HOME/util/printchplenv --value --only CHPL_TARGET_COMPILER)
+
+if [[ "$backend" == "llvm" ]]; then
+  echo " -g"
+else
+  echo " -g --no-munge-user-idents"
+fi

--- a/test/llvm/debugInfo/gdb/targetVar.skipif
+++ b/test/llvm/debugInfo/gdb/targetVar.skipif
@@ -1,1 +1,6 @@
+# this can remove too much of the debug info
 COMPOPTS <= --fast
+# baseline testing has extra call_temps left behind that mess up the good file
+COMPOPTS <= --baseline
+# valgrind messes up output
+CHPL_TEST_VGRND_EXE == on

--- a/test/llvm/debugInfo/lldb/targetVar.prediff
+++ b/test/llvm/debugInfo/lldb/targetVar.prediff
@@ -33,6 +33,10 @@ mv $file.tmp $file
 sed -e '/Target 0: (targetVar) stopped./d' $file > $file.tmp
 mv $file.tmp $file
 
+# remove 'settings set'
+sed -e '/settings set/d' $file > $file.tmp
+mv $file.tmp $file
+
 # remove empty lines and space
 sed -e '/^[[:space:]]*$/d' -e 's/[[:space:]]*$//' $file > $file.tmp
 mv $file.tmp $file

--- a/test/llvm/debugInfo/lldb/targetVar.skipif
+++ b/test/llvm/debugInfo/lldb/targetVar.skipif
@@ -1,1 +1,6 @@
+# this can remove too much of the debug info
 COMPOPTS <= --fast
+# baseline testing has extra call_temps left behind that mess up the good file
+COMPOPTS <= --baseline
+# valgrind messes up output
+CHPL_TEST_VGRND_EXE == on

--- a/util/test/prediff-for-debug
+++ b/util/test/prediff-for-debug
@@ -1,5 +1,19 @@
-#!/usr/bin/env bash
+#!/usr/bin/env python3
 
-outfile=$2
-grep -v 'skipping debug map object with duplicate name and timestamp' $outfile > $outfile.tmp
-mv $outfile.tmp $outfile
+import sys
+
+file=sys.argv[2]
+
+with open(file, 'rb') as f:
+    contents = f.read()
+
+lines = contents.split(b'\n')
+output = []
+for line in lines:
+    if b'skipping debug map object with duplicate name and timestamp' not in line:
+        output.append(line)
+
+output = b'\n'.join(output)
+
+with open(file, 'wb') as f:
+    f.write(output)


### PR DESCRIPTION
Cleans up a few tests that were failing in some configs

- Skips valgrind testing, as that messes up text matching
- Adds `--no-munge-user-idents` with the C backend
- Skips baseline testing, as that results in more temps that show up in the debug output
- Adds a prediff for `settings set` for lldb to help with `--memLeaks` testing
- rewrites `util/test/prediff-for-debug` to avoid binary IO failures

[Not reviewed - trivial]