### PR TITLE
Improve sort docs after new impl

### DIFF
--- a/modules/standard/Sort.chpl
+++ b/modules/standard/Sort.chpl
@@ -681,6 +681,8 @@ After the call, ``x`` will store elements in sorted order.
 
 The choice of sorting algorithm used is made by the implementation.
 
+At present, non-distributed arrays and Block-distributed arrays can be sorted.
+
 .. note::
 
   When reordering elements, the sort implementation might use assignment, memory

--- a/modules/standard/Sort.chpl
+++ b/modules/standard/Sort.chpl
@@ -160,7 +160,9 @@ The default compare method for a signed integral type can look like this:
 .. code-block:: chapel
 
     proc defaultComparator.compare(x, y) {
-      return x - y;
+      if x < y then return -1;
+      else if x > y then return 1;
+      else return 0;
     }
 
 

--- a/modules/standard/Sort.chpl
+++ b/modules/standard/Sort.chpl
@@ -687,11 +687,29 @@ The choice of sorting algorithm used is made by the implementation.
 
 .. note::
 
-  This function currently either uses a parallel radix sort or a parallel
-  improved quick sort. For stable sort, it uses Timsort.
-  The algorithms used will change over time.
+  This function chooses among the following algorithms based on the arguments:
 
-  It currently uses parallel radix sort if the following conditions are met:
+   * a local, parallel radix sort
+   * a parallel improved quick sort
+   * TimSort
+   * a distributed, parallel radix sort
+   * a distributed, parallel sample sort
+
+  The algorithms used will change over time. Currently, the choice process is:
+
+   * use the local radix sort for ``stable=false`` sorting a non-distributed
+     array where radix sorting is possible (see below)
+   * use the improved quick sort for ``stable=false`` sorting of a
+     non-distributed array when radix sorting is not possible
+   * use TimSort for ``stable=true`` sorting of a non-distributed array
+   * use a distributed, parallel radix sort when sorting a distributed array
+     where radix sorting is possible (for both ``stable=true`` and
+     ``stable=false``)
+   * use a distributed, parallel sample sort when sorting a distributed array
+     and radix sorting is not possible (for both ``stable=true`` and
+     ``stable=false``).
+
+  Radix sorting is possible if the following conditions are met:
 
     * the array being sorted is over a non-strided domain
     * ``comparator`` includes a ``keyPart`` method for ``eltType``


### PR DESCRIPTION
Follow-up to PR #27277. This PR adjusts the documentation for `proc sort` to describe the current algorithm choice. It also addresses issue #27295 by adjusting the example `compare` method in the Sort documentation.

Reviewed by @jabraham17 - thanks!