### PR TITLE
Add editions documentation

### DIFF
--- a/doc/rst/developer/bestPractices/EditionsDev.rst
+++ b/doc/rst/developer/bestPractices/EditionsDev.rst
@@ -28,4 +28,11 @@ The ``@edition`` attribute requires one or both of the following arguments:
 
 When using the attribute, the old behavior should be marked with
 ``@edition(last="<most recent edition name>")``, while the new behavior should
-be marked with ``@edition(first="pre-edition")``.  This will
+be marked with ``@edition(first="pre-edition")``.  This will ensure that the
+old behavior remains available with previous editions, while the new behavior
+becomes available in the ``pre-edition``.  E.g.,
+
+.. literalinclude:: ../../../../test/edition/basics/attributeCheck.chpl
+   :language: chapel
+   :start-after: START_EXAMPLE
+   :end-before: STOP_EXAMPLE

--- a/doc/rst/developer/bestPractices/EditionsDev.rst
+++ b/doc/rst/developer/bestPractices/EditionsDev.rst
@@ -127,4 +127,5 @@ like:
 
 This will make use of the existing edition computations in the compiler (saving
 execution time performance), and allow the runtime code to use a descriptive
-name for the argument that reflects the behavior being changed.
+name for the argument that reflects the behavior being changed.  Alternatively,
+a separate overload could be added to the runtime to handle the change.

--- a/doc/rst/developer/bestPractices/EditionsDev.rst
+++ b/doc/rst/developer/bestPractices/EditionsDev.rst
@@ -36,3 +36,10 @@ becomes available in the ``pre-edition``.  E.g.,
    :language: chapel
    :start-after: START_EXAMPLE
    :end-before: STOP_EXAMPLE
+
+.. note::
+
+   Though ``default`` is a supported value for the ``--edition`` compilation
+   flag, it is not supported for either the ``first`` or ``last`` argument of
+   the edition attribute.  These arguments must be concrete, specific editions.
+

--- a/doc/rst/developer/bestPractices/EditionsDev.rst
+++ b/doc/rst/developer/bestPractices/EditionsDev.rst
@@ -8,11 +8,18 @@ Editions
 New Editions Process
 --------------------
 
-When creating new editions, be sure to add the new edition name to the array of
-editions in the compiler just **before** ``pre-edition``.  Update all desired
-changes that are currently associated with ``pre-edition`` to be linked with
-this new edition name, and update :ref:`edition-changes` to list those changes
-under this new release name instead of under :ref:`pre-edition-changes`.
+When creating new editions, be sure to:
+
+- Add the new edition name to the array of editions in the compiler just
+  **before** ``pre-edition``.
+- Update all desired changes that are currently associated with ``pre-edition``
+  to be linked with this new edition name.
+
+  - Update :ref:`edition-changes` to list those changes under this new release
+    name instead of under :ref:`pre-edition-changes`.
+
+- When https://github.com/chapel-lang/chapel/issues/27336 gets implemented, be
+  sure to update it as well.
 
 -----------------------------------
 Associating Changes With An Edition

--- a/doc/rst/developer/bestPractices/EditionsDev.rst
+++ b/doc/rst/developer/bestPractices/EditionsDev.rst
@@ -1,0 +1,31 @@
+.. _best-practices-editions:
+
+========
+Editions
+========
+
+The implementation of editions is currently in progress.  Here are some
+supported ways to tie a change to a particular edition.
+
+----------------------
+The @edition Attribute
+----------------------
+
+For breaking changes that can exist entirely in module code, the ``@edition``
+attribute can be used.
+
+The ``@edition`` attribute requires one or both of the following arguments:
+
+- first
+
+  - To specify the earliest edition that will include this symbol.  When not
+    specified, will be the earliest supported edition.
+
+- last
+
+  - To specify the final edition that will include this symbol.  When not
+    specified, will be ``pre-edition``.
+
+When using the attribute, the old behavior should be marked with
+``@edition(last="<most recent edition name>")``, while the new behavior should
+be marked with ``@edition(first="pre-edition")``.  This will

--- a/doc/rst/developer/bestPractices/EditionsDev.rst
+++ b/doc/rst/developer/bestPractices/EditionsDev.rst
@@ -4,12 +4,28 @@
 Editions
 ========
 
+--------------------
+New Editions Process
+--------------------
+
+When creating new editions, be sure to add the new edition name to the array of
+editions in the compiler just **before** ``pre-edition``.  Update all desired
+changes that are currently associated with ``pre-edition`` to be linked with
+this new edition name, and update :ref:`edition-changes` to list those changes
+under this new release name instead of under :ref:`pre-edition-changes`.
+
+-----------------------------------
+Associating Changes With An Edition
+-----------------------------------
+
 The implementation of editions is currently in progress.  Here are some
 supported ways to tie a change to a particular edition.
 
-----------------------
+.. _edition-attribute:
+
+++++++++++++++++++++++
 The @edition Attribute
-----------------------
+++++++++++++++++++++++
 
 For breaking changes that can exist entirely in module code, the ``@edition``
 attribute can be used.
@@ -41,5 +57,67 @@ becomes available in the ``pre-edition``.  E.g.,
 
    Though ``default`` is a supported value for the ``--edition`` compilation
    flag, it is not supported for either the ``first`` or ``last`` argument of
-   the edition attribute.  These arguments must be concrete, specific editions.
+   the edition attribute.  These arguments must be concrete, specific editions,
+   to avoid potential implementation bugs.
 
+Generally, specifying both ``first`` and ``last`` is most helpful if a feature
+has been changed in multiple editions.  It is hoped that such occurrences will
+be rare.
+
+++++++++++++++++
+Compiler Changes
+++++++++++++++++
+
+When making a change that should be supported by the compiler itself, one should
+be careful to indicate the range of editions to which the change is applicable,
+rather than specifying a single edition.  There is a helper function to use to
+validate that the compiled edition is within a known first and last edition,
+which can be used to determine if the change should apply.  There is also a
+helper function to validate that the edition range specified itself is valid.
+
+The ``Symbol`` AST node in the production compiler will return the default
+values listed in :ref:`edition-attribute` if they are not explicitly provided.
+This will be useful when extending attribute support to more than just function
+resolution, but for specific compiler-level breaking changes the range will
+likely have to be explicitly specified.
+
+All known editions are stored in an array in the compiler in order, and the last
+edition in the array is always ``pre-edition``.
+
++++++++++++++++
+Runtime Changes
++++++++++++++++
+
+Since users will specify the edition to use via a compilation flag, it's likely
+better to avoid edition-specific computations in the runtime.  That doesn't
+preclude the possibility of needing certain implementation decisions to happen
+at runtime, but in general it's probably better to have done the computation of
+which implementation to use based on the compiled edition during compilation.
+
+As a concrete example, changing the printing behavior of nan in complex numbers
+requires modifying our runtime I/O code
+(https://github.com/chapel-lang/chapel/pull/27011).  The best way to handle this
+is probably adding an argument to ``qio_channel_print_complex`` to indicate
+which version of the implementation to use, and then using the attribute
+solution in module code to switch between how that argument is set.  Something
+like:
+
+.. code-block:: chapel
+
+   @edition(first="pre-edition")
+   proc chpl_print_complex(...) {
+     return qio_channel_print_complex(false, _channel_internal, re, im,
+                                      numBytes(re.type),
+                                      /* edition applicable */ true);
+   }
+
+   @edition(last="2.0")
+   proc chpl_print_complex(...) {
+     return qio_channel_print_complex(false, _channel_internal, re, im,
+                                      numBytes(re.type),
+                                      /* edition applicable */ false);
+   }
+
+This will make use of the existing edition computations in the compiler (saving
+execution time performance), and allow the runtime code to use a descriptive
+name for the argument that reflects the behavior being changed.

--- a/doc/rst/developer/bestPractices/index.rst
+++ b/doc/rst/developer/bestPractices/index.rst
@@ -16,6 +16,7 @@ Best Practices for Contributors
    DCO
    CompilerDebugging
    CompilerIRTricks
+   EditionsDev
    ErrorWarningMessaging
    RuntimeLibrary
    GeneratedCode
@@ -95,6 +96,9 @@ developers.  A possible reading order is roughly as follows:
 
 :ref:`best-practices-unstable`:
   How to mark features as unstable
+
+:ref:`best-practices-editions`:
+  How to tie a particular change to a particular (set of) edition(s)
 
 :ref:`readme-nightlytesting`
   How to run nightly testing

--- a/doc/rst/technotes/editions.rst
+++ b/doc/rst/technotes/editions.rst
@@ -91,6 +91,8 @@ edition being considered old and that edition having its support removed.
 
 .. TODO: list old editions and their final release here, in a chart
 
+.. _edition-changes:
+
 -------
 Changes
 -------

--- a/doc/rst/technotes/editions.rst
+++ b/doc/rst/technotes/editions.rst
@@ -1,0 +1,117 @@
+.. _readme-editions:
+
+========
+Editions
+========
+
+Chapel 2.5 introduces the concept of editions as a way of enabling continued
+language evolution.
+
+An edition is a version of the language.  It is accessible using a new
+compilation flag, ``--edition``.  When the ``--edition`` flag is not used, the
+default edition will be relied upon.
+
+The following table contains the currently maintained editions, with a brief
+description:
+
++-----------------+------------------------------------------------------------+
+| Edition Name    | Description                                                |
++=================+============================================================+
+| ``2.0``         | The language as it stood with the 2.0 release.  Currently  |
+|                 | the default edition.                                       |
++-----------------+------------------------------------------------------------+
+| ``default``     | The default edition.  Currently the same as the ``2.0``    |
+|                 | edition, but may change over time.                         |
+|                 |                                                            |
+|                 | See :ref:`default-edition`.                                |
++-----------------+------------------------------------------------------------+
+| ``pre-edition`` | A collection of changes intended for future editions.      |
+|                 |                                                            |
+|                 | See :ref:`pre-edition` and :ref:`pre-edition-changes`.     |
++-----------------+------------------------------------------------------------+
+
+When a change is required that would break existing user codes, the change will
+be guarded by an edition.  Users interested in updating to use this new behavior
+can compile their code with ``--edition=<edition with the change>``, while the
+majority of users can continue to rely on the old behavior by default.
+
+The 2.5 release introduced two editions, ``2.0`` and ``pre-edition``.  ``2.0``
+is the default edition and will remain the default for the foreseeable future.
+``pre-edition`` is a gathering point for breaking changes until there is a
+sufficient quantity of them to justify a new edition.
+
+.. _default-edition:
+
+-------------------
+The Default Edition
+-------------------
+
+``2.0`` is the default edition and will remain the default for the foreseeable
+future.
+
+When no ``--edition`` flag is used at compilation, the default edition will be
+relied upon.  It can also be specified via ``--edition=default``, or by
+explicitly listing the default edition's unique name (e.g., ``--edition=2.0``).
+
+Relying upon ``--edition=default`` or leaving the edition unspecified can be
+beneficial.  Users should note, however, that when the default edition changes,
+this will result in behavior changes across releases.
+
+The default edition will not change frequently.  No future edition will
+immediately become the default upon its creation.  There will always be at least
+one release cycle between an edition's creation and becoming the default
+edition, if not more.
+
+.. TODO: link to information about flag to see changes between editions, when it
+   exists
+
+.. _pre-edition:
+
+-------------------
+The Pre-Edition
+-------------------
+
+The ``pre-edition`` is a gathering point for breaking changes until there is a
+sufficient quantity of them to justify a new edition.  There will always be a
+``pre-edition``, though users should avoid relying on it for production code as
+breaking changes will be introduced to it without warning.
+
+Changes that have been elevated from the ``pre-edition`` into an official
+edition will still be present in the ``pre-edition`` going forward, until such
+time as a conflicting change is made.
+
+------------
+Old Editions
+------------
+
+Editions that are no longer the default will eventually stop being supported.
+However, no edition will be dropped immediately upon being replaced by another
+default edition, there will always be at least one release cycle between an
+edition being considered old and that edition having its support removed.
+
+.. TODO: list old editions and their final release here, in a chart
+
+-------
+Changes
+-------
+
+This section is intended as a living list of breaking changes and which edition
+they were introduced in.
+
+.. _pre-edition-changes:
+
+++++++++++++++++++++++++++
+Changes in the Pre-Edition
+++++++++++++++++++++++++++
+
+
+The following are a list of breaking changes currently accessible by compiling
+with ``--edition=pre-edition``.  When a new edition is created, some of these
+changes may be included in that edition as well, while others may continue to
+remain in the pre-edition until they are deemed sufficiently complete.
+
+- The ``reshape`` function has been modified to support aliasing.  This enables
+  viewing an existing array's elements using a different shape for the array.
+  This behavior is potentially breaking for ``ref = reshape(A, D);`` cases.
+  The behavior when storing into a ``var`` or ``const`` is unchanged.
+

--- a/doc/rst/technotes/editions.rst
+++ b/doc/rst/technotes/editions.rst
@@ -46,8 +46,7 @@ sufficient quantity of them to justify a new edition.
 The Default Edition
 -------------------
 
-``2.0`` is the default edition and will remain the default for the foreseeable
-future.
+``2.0`` is the default edition.
 
 When no ``--edition`` flag is used at compilation, the default edition will be
 relied upon.  It can also be specified via ``--edition=default``, or by
@@ -62,8 +61,14 @@ immediately become the default upon its creation.  There will always be at least
 one release cycle between an edition's creation and becoming the default
 edition, if not more.
 
-.. TODO: link to information about flag to see changes between editions, when it
-   exists
+.. note::
+
+   We anticipate adding a compilation flag to aid in transitioning between
+   editions.  The design on that flag has not been finalized, but any ideas
+   along those lines are welcome, see
+   https://github.com/chapel-lang/chapel/issues/27336 for the most recent
+   discussion on that subject.
+
 
 .. _pre-edition:
 

--- a/doc/rst/technotes/index.rst
+++ b/doc/rst/technotes/index.rst
@@ -83,6 +83,7 @@ Compiler Features
    Checking Overload Sets <overloadSets>
    Checking Variable Lifetimes <lifetimeChecking>
    Compiler Driver Mode <driver>
+   Editions <editions>
    LLVM Support <llvm>
    Variables to Detect Compilation Configuration <globalvars>
 

--- a/man/chpl.rst
+++ b/man/chpl.rst
@@ -125,11 +125,12 @@ OPTIONS
 
 .. _man-edition:
 
-**\--edition**
+**\--edition <edition>**
 
     Specify the language edition to use.  Enables breaking changes that are
     associated with the particular edition specified (as well as those that were
-    associated with earlier editions).
+    associated with earlier editions).  See
+    $CHPL\_HOME/doc/rst/technotes/editions.rst for more information.
 
 .. _man-permit-unhandled-module-errors:
 

--- a/man/chpl.rst
+++ b/man/chpl.rst
@@ -130,6 +130,7 @@ OPTIONS
     Specify the language edition to use.  Enables breaking changes that are
     associated with the particular edition specified (as well as those that were
     associated with earlier editions).  See
+    https://chapel-lang.org/docs/technotes/editions.html or
     $CHPL\_HOME/doc/rst/technotes/editions.rst for more information.
 
 .. _man-permit-unhandled-module-errors:

--- a/test/edition/basics/attributeCheck.chpl
+++ b/test/edition/basics/attributeCheck.chpl
@@ -1,3 +1,4 @@
+/* START_EXAMPLE */
 @edition(first="pre-edition")
 proc foo(x: int) {
   writeln("in new edition foo with arg x=", x);
@@ -7,6 +8,7 @@ proc foo(x: int) {
 proc foo(x: int) {
   writeln("in old edition foo with arg x=", x);
 }
+/* STOP_EXAMPLE */
 
 // Check specifying both first and last works
 @edition(first="2.0", last="pre-edition")


### PR DESCRIPTION
Reviewed by @jabraham17

Resolves Cray/chapel-private#7409

This adds two documents related to the new editions feature:
- A user-facing technote on how to use the feature and what to expect
- A developer-oriented document, covering implementation tips for both new editions and how to link breaking changes to editions

To support the developer document, I made a small modification to one of the editions tests so that it could be linked in the documentation.  This will hopefully prevent that example from breaking without us noticing it.

Also fixed an issue I noticed with the man page description of the flag.

Looks good with `make docs`, passed a full paratest with futures (due to the test and man page update).