### PR TITLE
Add note about mac os x unwind

### DIFF
--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -979,6 +979,11 @@ CHPL_UNWIND
 
    If unset, ``CHPL_UNWIND`` defaults to ``none``
 
+   .. note::
+
+      At present, ``CHPL_UWIND=bundled`` does not work on Mac OS X.
+      ``CHPL_UNWIND=system`` should be used instead on that system.
+
 .. _readme-chplenv.CHPL_LIB_PIC:
 
 CHPL_LIB_PIC


### PR DESCRIPTION
Otherwise we might encourage users to run into this error

```
ValueError: Using CHPL_UNWIND=bundled is not supported on Mac OS X.
Use CHPL_UNWIND=system instead.
```