### PR TITLE
Address problems on 32-bit

### DIFF
--- a/modules/standard/Sort/PartitioningUtility.chpl
+++ b/modules/standard/Sort/PartitioningUtility.chpl
@@ -25,7 +25,7 @@
 module PartitioningUtility {
 
 import BlockDist.blockDist;
-import CTypes.{c_int, c_sizeof, c_uintptr, c_ptr, c_ptrConst};
+import CTypes.{c_int, c_sizeof, c_uintptr, c_ptr, c_ptrConst, c_size_t};
 import ChplConfig.CHPL_COMM;
 import Communication;
 import CopyAggregation.{SrcAggregator,DstAggregator};
@@ -418,13 +418,14 @@ proc bulkCopy(ref dst: [], dstRegion: range,
         }
 
         forall dstPg in divideIntoPages(dstPtr..#nBytes, BULK_COPY_PAGE_SIZE) {
-          const dstPartPtr = dstPg.low:c_ptr(void);
-          const srcPartPtr = (srcPtr + (dstPg.low - dstPtr)):c_ptr(void);
+          const dstPartPtr = dstPg.low:c_uintptr:c_ptr(void);
+          const srcPartPtr =
+            (srcPtr + (dstPg.low - dstPtr)):c_uintptr:c_ptr(void);
           if BULK_COPY_EXTRA_CHECKS {
             assert((dstPtr..#nBytes).contains(dstPartPtr:uint..#dstPg.size));
             assert((srcPtr..#nBytes).contains(srcPartPtr:uint..#dstPg.size));
           }
-          memcpy(dstPartPtr, srcPartPtr, dstPg.size);
+          memcpy(dstPartPtr, srcPartPtr, dstPg.size:c_size_t);
         }
       } else {
         if BULK_COPY_EXTRA_CHECKS {
@@ -434,8 +435,9 @@ proc bulkCopy(ref dst: [], dstRegion: range,
           }
         }
         forall dstPg in divideIntoPages(dstPtr..#nBytes, BULK_COPY_PAGE_SIZE) {
-          const dstPartPtr = dstPg.low:c_ptr(void);
-          const srcPartPtr = (srcPtr + (dstPg.low - dstPtr)):c_ptr(void);
+          const dstPartPtr = dstPg.low:c_uintptr:c_ptr(void);
+          const srcPartPtr =
+            (srcPtr + (dstPg.low - dstPtr)):c_uintptr:c_ptr(void);
           if BULK_COPY_EXTRA_CHECKS {
             assert((dstPtr..#nBytes).contains(dstPartPtr:uint..#dstPg.size));
             assert((srcPtr..#nBytes).contains(srcPartPtr:uint..#dstPg.size));
@@ -472,13 +474,14 @@ proc bulkCopy(ref dst: [], dstRegion: range,
           }
         }
         forall dstPg in divideIntoPages(dstPtr..#nBytes, BULK_COPY_PAGE_SIZE) {
-          const dstPartPtr = dstPg.low:c_ptr(void);
-          const srcPartPtr = (srcPtr + (dstPg.low - dstPtr)):c_ptr(void);
+          const dstPartPtr = dstPg.low:c_uintptr:c_ptr(void);
+          const srcPartPtr =
+            (srcPtr + (dstPg.low - dstPtr)):c_uintptr:c_ptr(void);
           if BULK_COPY_EXTRA_CHECKS {
             assert((dstPtr..#nBytes).contains(dstPartPtr:uint..#dstPg.size));
             assert((srcPtr..#nBytes).contains(srcPartPtr:uint..#dstPg.size));
           }
-          memcpy(dstPartPtr, srcPartPtr, dstPg.size);
+          memcpy(dstPartPtr, srcPartPtr, dstPg.size:c_size_t);
         }
       } else {
         if BULK_COPY_EXTRA_CHECKS {
@@ -488,8 +491,9 @@ proc bulkCopy(ref dst: [], dstRegion: range,
           }
         }
         forall dstPg in divideIntoPages(dstPtr..#nBytes, BULK_COPY_PAGE_SIZE) {
-          const dstPartPtr = dstPg.low:c_ptr(void);
-          const srcPartPtr = (srcPtr + (dstPg.low - dstPtr)):c_ptr(void);
+          const dstPartPtr = dstPg.low:c_uintptr:c_ptr(void);
+          const srcPartPtr =
+            (srcPtr + (dstPg.low - dstPtr)):c_uintptr:c_ptr(void);
           if BULK_COPY_EXTRA_CHECKS {
             assert((dstPtr..#nBytes).contains(dstPartPtr:uint..#dstPg.size));
             assert((srcPtr..#nBytes).contains(srcPartPtr:uint..#dstPg.size));


### PR DESCRIPTION
Follow-up to PR #27277.

This PR makes some adjustment in response to failing tests on 32-bit systems.

* Cast the size argument for the `memcpy` calls from `int` to `c_size_t` (where these two are only different, currently, on 32-bit platforms)
* When casting between an integer and a pointer, cast first to `c_uintptr` to avoid C compiler errors about casting to a pointer from an integer of a different width.

The code in question is copying memory a chunk at a time. The integers started out as pointers, so will fit, and the memcpy calls have a bounded size.

- [x] failing tests on 32-bit, including `test/library/standard/Sort/correctness/distSort.chpl`, now pass
- [x] full comm=none testing

Reviewed by @jabraham17 - thanks!