### PR TITLE
Update the best known configuration for debugging Chapel

### DIFF
--- a/doc/rst/usingchapel/debugging.rst
+++ b/doc/rst/usingchapel/debugging.rst
@@ -175,7 +175,8 @@ debugging. Any of them can be omitted as desired.
   Flag                                 Description
   ===================================  =========================================
   ``-g``                               Generate debug symbols in the executable
-  ``--target-compiler=gnu``            Target the C backend
+  ``--target-compiler=gnu``            Target the C backend with GCC
+  ``--target-compiler=clang``          Target the C backend with Clang
   ``--savec <dir>``                    Write out the generated C to a given
                                        directory
   ``--preserve-inlined-line-numbers``  When code gets inlined (e.g. replacing a


### PR DESCRIPTION
Updates the best known configuration for debugging Chapel for 2.5 to reflect improvements to the LLVM backend for debugging.

[Reviewed by @mppf]