### PR TITLE
Workaround a GASNet issue with GCC 15

### DIFF
--- a/third-party/gasnet/Makefile
+++ b/third-party/gasnet/Makefile
@@ -116,6 +116,9 @@ GASNET_CFLAGS += -fPIE
 endif
 endif
 
+# workaround for https://gasnet-bugs.lbl.gov/bugzilla/show_bug.cgi?id=4787
+GASNET_CFLAGS += -Wno-incompatible-pointer-types
+
 CHPL_GASNET_ENV_VARS:= CC='$(CC)' CXX='$(CXX)' MPI_CC='$(MPI_CC)' CFLAGS='$(GASNET_CFLAGS)' CXXFLAGS='$(GASNET_CFLAGS)'
 
 CHPL_GASNET_CFG_OPTIONS += $(CHPL_GASNET_MORE_CFG_OPTIONS)

--- a/third-party/gasnet/Makefile
+++ b/third-party/gasnet/Makefile
@@ -116,8 +116,13 @@ GASNET_CFLAGS += -fPIE
 endif
 endif
 
-# workaround for https://gasnet-bugs.lbl.gov/bugzilla/show_bug.cgi?id=4787
+# Prevent fatal compile errors from GCC 15+ due to GASNet bug #4787
+# https://gasnet-bugs.lbl.gov/bugzilla/show_bug.cgi?id=4787
+ifeq ($(CHPL_MAKE_TARGET_COMPILER),gnu)
+ifeq ($(shell test $(GNU_GCC_MAJOR_VERSION) -ge 15; echo "$$?"),0)
 GASNET_CFLAGS += -Wno-incompatible-pointer-types
+endif
+endif
 
 CHPL_GASNET_ENV_VARS:= CC='$(CC)' CXX='$(CXX)' MPI_CC='$(MPI_CC)' CFLAGS='$(GASNET_CFLAGS)' CXXFLAGS='$(GASNET_CFLAGS)'
 

--- a/third-party/gasnet/Makefile.setup
+++ b/third-party/gasnet/Makefile.setup
@@ -32,3 +32,11 @@ endif
 # Remove -Winline from GASNet's provided flags
 # (might not be needed if it always comes in GASNET_OPT_CFLAGS)
 CHPL_GASNET_CFLAGS = $(CHPL_GASNET_CFLAGS_ALL:-Winline=)
+
+# Prevent GCC 15+ fatal errors on AM handler table initialization
+# (see https://gasnet-bugs.lbl.gov/bugzilla/show_bug.cgi?id=4787)
+ifeq ($(CHPL_MAKE_TARGET_COMPILER),gnu)
+ifeq ($(shell test $(GNU_GCC_MAJOR_VERSION) -ge 15; echo "$$?"),0)
+CHPL_GASNET_CFLAGS += -Wno-incompatible-pointer-types
+endif
+endif


### PR DESCRIPTION
Add a `-Wno-incompatible-pointer-types` for the gasnet build to avoid issues with GCC 15

[Reviewed by @jhh67, Reviewed and co-contributed by @bonachea and @PHHargrove]