### PR TITLE
Remove `sorted` in the pre-edition

### DIFF
--- a/doc/rst/technotes/editions.rst
+++ b/doc/rst/technotes/editions.rst
@@ -133,3 +133,8 @@ remain in the pre-edition until they are deemed sufficiently complete.
 
   See the note on :chpl:proc:`~ChapelArray.reshape` for more information.
 
+- The ``domain.sorted`` iterator method has been removed. It was only
+  implemented for associative domains (as that was the only type of domain that
+  could be sorted) and all other ``sort`` / ``sorted`` methods have been
+  removed. The intended replacement is to import ``Sort`` and call
+  :chpl:proc:`Sort.sorted(domain)<Sort.sorted>`.

--- a/doc/rst/technotes/editions.rst
+++ b/doc/rst/technotes/editions.rst
@@ -138,3 +138,6 @@ remain in the pre-edition until they are deemed sufficiently complete.
   could be sorted) and all other ``sort`` / ``sorted`` methods have been
   removed. The intended replacement is to import ``Sort`` and call
   :chpl:proc:`Sort.sorted(domain)<Sort.sorted>`.
+
+  The temporary config ``noSortedWarnings`` has also been removed, as its only
+  purpose was to suppress warnings about the ``domain.sorted`` method.

--- a/modules/internal/ChapelDomain.chpl
+++ b/modules/internal/ChapelDomain.chpl
@@ -47,6 +47,7 @@ module ChapelDomain {
   config param noNegativeStrideWarnings = false;
 
   @chpldoc.nodoc
+  @edition(last="2.0")
   config param noSortedWarnings = false;
 
   pragma "no copy return"

--- a/modules/internal/ChapelDomain.chpl
+++ b/modules/internal/ChapelDomain.chpl
@@ -2827,6 +2827,7 @@ module ChapelDomain {
          It is recommended to use :proc:`Sort.sorted` instead of this method.
 
     */
+    @edition(last="2.0")
     iter sorted(comparator:?t = chpl_defaultComparator()) {
       if !this.isAssociative() then
         compilerError("'.sorted()' is only supported on associative domains");

--- a/test/library/standard/Sort/errors/sortDomainArray.assoc7-removed.good
+++ b/test/library/standard/Sort/errors/sortDomainArray.assoc7-removed.good
@@ -1,0 +1,6 @@
+sortDomainArray.chpl:55: error: unresolved call 'DefaultAssociativeDom(string,false).sorted()'
+$CHPL_HOME/modules/standard/Sort.chpl:nnnn: note: this candidate did not match: sorted(x: domain, comparator: ? = new defaultComparator())
+sortDomainArray.chpl:55: note: because call is written as a method call
+$CHPL_HOME/modules/standard/Sort.chpl:nnnn: note: but candidate function is not a method
+sortDomainArray.chpl:55: note: other candidates are:
+$CHPL_HOME/modules/standard/Sort.chpl:nnnn: note:   sorted(x, comparator: ? = new defaultComparator())

--- a/test/library/standard/Sort/errors/sortDomainArray.compopts
+++ b/test/library/standard/Sort/errors/sortDomainArray.compopts
@@ -2,9 +2,11 @@
 -sassoc3 -sassoc6 -srect4 -srect5 -srect6 # sortDomainArray.good
 
 # this case has warnings
--sassoc7 # sortDomainArray.assoc7.good
+-sassoc7 --edition=2.0 # sortDomainArray.assoc7.good
+# this case errors
+-sassoc7 --edition=pre-edition # sortDomainArray.assoc7-removed.good
 # disable the warnings with a compiler flag
--sassoc7 -snoSortedWarnings # sortDomainArray.good
+-sassoc7 --edition=2.0 -snoSortedWarnings # sortDomainArray.good
 
 
 # the rest should be some form of compiler error


### PR DESCRIPTION
Removes the `iter sorted` method on associative arrays, which was meant to be removed/unstable in 2.0 but was forgotten. Since removing it now constitutes a breaking change, this PR removes it in the next edition of Chapel.

 - [x] paratest with/without gasnet

[Reviewed by @ShreyasKhandekar  and @lydia-duncan]

