### PR TITLE
Adds `--skip` and `--skip-bundled-modules` to chplcheck

### DIFF
--- a/tools/chplcheck/src/config.py
+++ b/tools/chplcheck/src/config.py
@@ -22,7 +22,6 @@ from typing import List, Union, Dict, Any, Optional
 import argparse
 import re
 
-
 @dataclass(frozen=True)
 class RuleSetting:
     """
@@ -77,6 +76,8 @@ class Config:
     disabled_rules: List[str]
     enabled_rules: List[str]
     skip_unstable: bool
+    skip_bundled: bool
+    skip_files: List[str]
     internal_prefixes: List[str]
     check_internal_prefixes: bool
     add_rules: List[str]
@@ -103,7 +104,21 @@ class Config:
             action="store_true",
             dest="chplcheck_skip_unstable",
             default=False,
-            help="Skip unstable rules when linting",
+            help="Skip unstable code when linting",
+        )
+        parser.add_argument(
+            f"--{prefix}skip-bundled-modules",
+            action="store_true",
+            dest="chplcheck_skip_bundled_modules",
+            default=False,
+            help="Skip standard modules when linting",
+        )
+        parser.add_argument(
+            f"--{prefix}skip",
+            action="append",
+            dest="chplcheck_skip_files",
+            default=[],
+            help="Skip a file when linting. Can be used multiple times. Accepts glob patterns.",
         )
         parser.add_argument(
             f"--{prefix}internal-prefix",
@@ -141,6 +156,8 @@ class Config:
             disabled_rules=args["chplcheck_disabled_rules"],
             enabled_rules=args["chplcheck_enabled_rules"],
             skip_unstable=args["chplcheck_skip_unstable"],
+            skip_bundled=args["chplcheck_skip_bundled_modules"],
+            skip_files=args["chplcheck_skip_files"],
             internal_prefixes=args["chplcheck_internal_prefixes"],
             check_internal_prefixes=args["chplcheck_check_internal_prefixes"],
             add_rules=args["chplcheck_add_rules"],

--- a/tools/chplcheck/src/config.py
+++ b/tools/chplcheck/src/config.py
@@ -110,8 +110,14 @@ class Config:
             f"--{prefix}skip-bundled-modules",
             action="store_true",
             dest="chplcheck_skip_bundled_modules",
-            default=False,
+            default=True,
             help="Skip standard modules when linting",
+        )
+        parser.add_argument(
+            f"--no-{prefix}skip-bundled-modules",
+            action="store_false",
+            dest="chplcheck_skip_bundled_modules",
+            help="Do not skip standard modules when linting",
         )
         parser.add_argument(
             f"--{prefix}skip",

--- a/tools/chplcheck/src/driver.py
+++ b/tools/chplcheck/src/driver.py
@@ -133,7 +133,7 @@ class LintDriver:
         path = os.path.abspath(path)
 
         if self.config.skip_bundled:
-            return chapel.is_bundled_module(path)
+            return context.is_bundled_path(path)
         elif len(self.config.skip_files) > 0:
             for skip_pattern in self.config.skip_files:
                 abs_skip_pattern = os.path.abspath(skip_pattern)
@@ -367,7 +367,7 @@ class LintDriver:
                         not self.config.check_internal_prefixes
                         and node
                         and self.has_internal_prefix(node)
-                    ):
+                    ) or (self._should_skip_path(context, node or toreport[0].path())):
                         continue
 
                     yield toreport


### PR DESCRIPTION
Adds two new flags to chplcheck to allow users to skip linting standard modules

The default is now to skip bundled modules, as users have no control over them

TODO:
- Add docs
- Add tests