### PR TITLE
Stop relying on CHPL_HOME being an evironment variable in chapel-py

### DIFF
--- a/frontend/lib/util/chplenv.cpp
+++ b/frontend/lib/util/chplenv.cpp
@@ -124,7 +124,7 @@ std::error_code findChplHome(const char* argv0, void* mainAddr,
                              bool& installed, bool& fromEnv,
                              std::string& diagnosticMessage) {
   std::string versionString = getMajorMinorVersion();
-  std::string guessFromBinaryPath = getExecutablePath(argv0, mainAddr);
+  std::string guessFromBinaryPath = argv0 && mainAddr ? getExecutablePath(argv0, mainAddr) : "";
   chplHomeOut = std::string();
 
   const char* chplHomeEnv = getenv("CHPL_HOME");

--- a/tools/chapel-py/src/method-tables/core-methods.h
+++ b/tools/chapel-py/src/method-tables/core-methods.h
@@ -79,6 +79,8 @@ CLASS_BEGIN(Context)
          std::string(chpl::UniqueString), return parsing::fileText(node, std::get<0>(args)).text())
   METHOD(Context, get_compiler_version, "Get the version of the Chapel compiler",
          std::string(), std::ignore = node; return chpl::getVersion())
+  METHOD(Context, get_chpl_home, "Get the CHPL_HOME path for this Context",
+         std::string(), std::ignore = node; return context.chplHome())
 CLASS_END(Context)
 
 CLASS_BEGIN(Location)

--- a/tools/chapel-py/src/method-tables/core-methods.h
+++ b/tools/chapel-py/src/method-tables/core-methods.h
@@ -80,7 +80,7 @@ CLASS_BEGIN(Context)
   METHOD(Context, get_compiler_version, "Get the version of the Chapel compiler",
          std::string(), std::ignore = node; return chpl::getVersion())
   METHOD(Context, get_chpl_home, "Get the CHPL_HOME path for this Context",
-         std::string(), std::ignore = node; return context.chplHome())
+         std::string(), std::ignore = node; return context->chplHome())
 CLASS_END(Context)
 
 CLASS_BEGIN(Location)

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -173,8 +173,8 @@ class ChplcheckProxy:
             if os.environ.get("CHPL_DEVELOPER", None):
                 print("Error loading chplcheck: ", str(msg), file=sys.stderr)
 
-        chpl_home = os.environ.get("CHPL_HOME")
-        if chpl_home is None:
+        chpl_home = chapel.Context().get_chpl_home()
+        if not chpl_home:
             error("CHPL_HOME not set")
             return None
 


### PR DESCRIPTION
Fixes a bug where chapel-py relied on CHPL_HOME being set, instead of using `findChplHome`. This causes problems when Chapel is prefix-installed and chapel-py is installed globally as `python3 -m pip install tools/chapel-py`

Followup to https://github.com/chapel-lang/chapel/pull/27348, which fixed the build system.

[Reviewed by @]