### PR TITLE
Improve error when homebrew pkg-config fails to find dep

### DIFF
--- a/util/chplenv/third_party_utils.py
+++ b/util/chplenv/third_party_utils.py
@@ -481,5 +481,5 @@ def could_not_find_pkgconfig_pkg(pkg, envname):
         error("{0} is installed via homebrew, but pkg-config is not installed. Please install pkg-config with `brew install pkg-config`.".format(pkg))
     else:
         install_str = " with `brew install {0}`".format(pkg) if homebrew_utils.homebrew_exists() else ""
-        error("Could not find a suitable {0} installation with pkg-config. Please install {0}{1} or set {2}=bundled, or fix pkg-config configuration.".format(pkg, install_str, envname))
+        error("Could not find a suitable {0} installation with pkg-config. Please install {0}{1}, set {2}=bundled, or fix pkg-config configuration.".format(pkg, install_str, envname))
 


### PR DESCRIPTION
I recently ran into a strange issue with the Chapel Homebrew package:
```
Exception: hwloc is installed via homebrew, but pkg-config is not installed. Please install pkg-config with `brew install pkg-config`.
```

Though I did have homebrew `pkg-config` (and `hwloc`) installed, it turned out I had another installation of `pkg-config` (from macports) that came earlier in my `PATH` that couldn't find `hwloc`. This error message was somewhat confusing as clearly I did have `pkg-config` available.

So, clarify error messages for failing to find a dep with `pkg-config` in two ways:
- If we have homebrew and the dep installed with homebrew, check if we have `pkg-config` installed with homebrew as well before emitting an error about needing to install it.
- In the general error case, note that we looked for the dep using `pkg-config`, and that the user may need to adjust configuration of `pkg-config` to find the dep.

[reviewer info placeholder]