### PR TITLE
Add more information to the editions entry on reshape

### DIFF
--- a/doc/rst/technotes/editions.rst
+++ b/doc/rst/technotes/editions.rst
@@ -131,6 +131,5 @@ remain in the pre-edition until they are deemed sufficiently complete.
   - the (default-on) check to make sure dimensions don’t get split or combined
     in surprising (potentially buggy) ways
 
-  See the note on ``reshape`` in
-  :ref:`Predefined_Functions_and_Methods_on_Arrays` for more information.
+  See the note on :chpl:proc:`~ChapelArray.reshape` for more information.
 


### PR DESCRIPTION
[reviewed by @jabraham17]

Suggested by Brad when I asked him to look over the entry.

Calls out some more changes made to the feature, and adds a link to `reshape` for more details.

Checked the built documentation locally.