### PR TITLE
Cleanup target var test output

### DIFF
--- a/test/llvm/debugInfo/lldb/targetVar.good
+++ b/test/llvm/debugInfo/lldb/targetVar.good
@@ -11,7 +11,6 @@ Breakpoint
 (lldb) r
 myLocal: 59
 myGlobal: 42
-Process XXXX launched: targetVar
 Process XXXX stopped
 * Thread #X, stop reason = breakpoint 2.1
     frame #0: 0xXXXX targetVar`foo_chpl(myFormal=XX) at targetVar.chpl:5

--- a/test/llvm/debugInfo/lldb/targetVar.prediff
+++ b/test/llvm/debugInfo/lldb/targetVar.prediff
@@ -29,8 +29,9 @@ sed -E -e 's/Breakpoint.*where.*at.*/Breakpoint/' \
        -e 's/name = .*, //' $file > $file.tmp
 mv $file.tmp $file
 
-# remove Target stopped
-sed -e '/Target 0: (targetVar) stopped./d' $file > $file.tmp
+# remove Target stopped and process launched lines
+sed -e '/Target 0: (targetVar) stopped./d' \
+    -e '/launched/d' $file > $file.tmp
 mv $file.tmp $file
 
 # remove 'settings set'


### PR DESCRIPTION
Cleanup target var test output, since the test can fail on some systems due to inconsistent output

[Not reviewed - trivial]