### PR TITLE
Add quickstart Darwin test script

### DIFF
--- a/util/cron/test-quickstart.darwin.bash
+++ b/util/cron/test-quickstart.darwin.bash
@@ -8,6 +8,6 @@ source $UTIL_CRON_DIR/common-quickstart.bash
 source $UTIL_CRON_DIR/common-darwin.bash
 source $UTIL_CRON_DIR/common-localnode-paratest.bash
 
-export CHPL_NIGHTLY_TEST_CONFIG_NAME="darwin-quickstart"
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="quickstart.darwin"
 
 $UTIL_CRON_DIR/nightly -cron -examples $(get_nightly_paratest_args)


### PR DESCRIPTION
Add a test script `util/cron/test-quickstart.darwin.bash` to test the quickstart configuration over examples only on Darwin.

[reviewer info placeholder]

Testing:
- [x] manual run succeeds
  - got error `FileNotFoundError: [Errno 2] No such file or directory: 'chapel-tests.xml'`, but so did a manual run of another test which is passing nightly, so probably just lack of proper setup