### PR TITLE
Fix self-referential `PRECOMP` symlinks in Python tests

### DIFF
--- a/test/interop/python/chapelBytes/PRECOMP
+++ b/test/interop/python/chapelBytes/PRECOMP
@@ -1,1 +1,1 @@
-PRECOMP
+../PRECOMP

--- a/test/interop/python/initFile/PRECOMP
+++ b/test/interop/python/initFile/PRECOMP
@@ -1,1 +1,1 @@
-PRECOMP
+../PRECOMP


### PR DESCRIPTION
Fix some `PRECOMP`s which symlinked to themselves in Python interop tests, instead of to the shared `PRECOMP` one level up from them.

This was getting hit for a Spack build of the Chapel main branch with message `find must skip [...]/PRECOMP: [Errno 40] Too many levels of symbolic links`. It didn't affect version-specific builds as they use the Chapel release tarball, which doesn't include these tests.

Introduced in https://github.com/chapel-lang/chapel/pull/26198.

[reviewer info placeholder]