### PR TITLE
Fix errors about missing runtime if user sets CHPL_HOME in a prefix install with a "view"

### DIFF
--- a/frontend/lib/util/chplenv.cpp
+++ b/frontend/lib/util/chplenv.cpp
@@ -171,6 +171,21 @@ std::error_code findChplHome(const char* argv0, void* mainAddr,
       // The pre-configured prefix path matches the variable in the environment;
       // this indicates that the CHPL_HOME is from a prefix-based installation.
       installed = true;
+    } else if (llvm::sys::fs::exists(chplHomeEnv) &&
+               llvm::sys::fs::is_directory(chplHomeEnv) &&
+               llvm::sys::fs::exists(guessFromPrefix) &&
+               llvm::sys::fs::is_directory(guessFromPrefix)) {
+      auto chplHomeEnvChplConfig = std::string(chplHomeEnv) + "/chplconfig";
+      auto guessFromPrefixChplConfig = guessFromPrefix + "/chplconfig";
+      // checking isSameFile on a directory is not always reliable,
+      // so we check the chplconfig file inside the directories. This file should exist
+      // if both directories are valid CHPL_HOMEs for a prefix install
+      // this can occur if a user creates a "view" of a prefix install by creating
+      // new directories and symlinking files into them.
+      if (isSameFile(chplHomeEnvChplConfig, guessFromPrefixChplConfig)) {
+        // The chplconfig files match, so this is a prefix-based installation.
+        installed = true;
+      }
     }
 
     // Emit a warning if we could guess the CHPL_HOME from the binary's path,


### PR DESCRIPTION
Fixes an issue where chapel would fail to find the runtime library. This would occur in the following scenario

* the user did a prefix install
* the user then made a "view" of that prefix install by creating new directories and symlinking all the files
* the user also set CHPL_HOME

Chapel would then see CHPL_HOME being set, and because the directories containing Chapel were not the same inodes detection for a prefix-based install would fail. This would then result in Chapel looking in the wrong place for libraries.

In a prefix based install, users should not be setting CHPL_HOME (as there is no need to), but if they do it usually "just works". This fixes things so that even if a user (or the spack package) set CHPL_HOME it still works.

Fixes the issue described in https://github.com/chapel-lang/chapel/issues/27345

[Reviewed by @DanilaFe]

<details>

<summary> Steps to replicate and test this PR </summary>

```bash
git clone https://github.com/chapel-lang/chapel
cd chapel
./configure --prefix=/tmp/prefix/chapel
make
make install
rm -rf build lib
mkdir ~/chapel_view
cd ~/chapel_view
touch copy_view.sh
chmod+x copy_view.sh
	(use this script to create symlinks for the install)
	#!/bin/bash
	# copy_view.sh
	src=$1
	find "$src" -mindepth 1 | while read -r path; do
	  rel="${path#$src/}"
	  if [ -d "$path" ]; then
	    mkdir -p "./$rel"
	  else
	    mkdir -p "./$(dirname "$rel")"
	    ln -s "$path" "./$rel"
	  fi
	done

	(call from chapel_view, ./chapel_view /tmp/prefix/chapel)
ls -la
export CHPL_HOME=$(pwd)/share/chapel/2.5
bin/chpl hello.chpl
```


</details>
