### PR TITLE
Bump up stack size in a test

### DIFF
--- a/test/parallel/cobegin/gbt/cobegin-stacksize.execopts
+++ b/test/parallel/cobegin/gbt/cobegin-stacksize.execopts
@@ -3,5 +3,5 @@
 # sizes for all configurations. 2M should be high enough for all configurations
 # It can't be any higher because  cygwin currently only support 2M max. 16K is
 # the lowest we can go because fifo's min limit is 16K.
---depth=10000 -ECHPL_RT_CALL_STACK_SIZE=16K  #cobegin-stacksize-failure.good
+--depth=10000 -ECHPL_RT_CALL_STACK_SIZE=32K  #cobegin-stacksize-failure.good
 --depth=10000 -ECHPL_RT_CALL_STACK_SIZE=2M  #cobegin-stacksize-success.good


### PR DESCRIPTION
Follow on to https://github.com/chapel-lang/chapel/pull/27277.

With more code compiled in (?), we probably need bigger stacks. This test seems to be testing stack under- and over-flows. Adjusting the minimum stack size seem to make the test pass. However, the execopts file has a comment:

> These values are chosen to get one mode where the tests fails because we're
> out of stack and the other always succeeds. The tricky part is picking good
> sizes for all configurations. 2M should be high enough for all configurations
> It can't be any higher because  cygwin currently only support 2M max. 16K is
> the lowest we can go because fifo's min limit is 16K.

which makes me scared of making this change as maybe in some systems it might fail.

An alternative to this PR is to skipif this test with linux32 config. We seem to be doing that for ARM testing already.

