### PR TITLE
Fix el10 package builds due to rpmlint error

### DIFF
--- a/util/packaging/rpm/amzn2023-gasnet-udp/rpmlintrc
+++ b/util/packaging/rpm/amzn2023-gasnet-udp/rpmlintrc
@@ -1,0 +1,2 @@
+from Config import *
+addFilter("E: hardcoded-library-path")

--- a/util/packaging/rpm/amzn2023-ofi-slurm/rpmlintrc
+++ b/util/packaging/rpm/amzn2023-ofi-slurm/rpmlintrc
@@ -1,0 +1,2 @@
+from Config import *
+addFilter("E: hardcoded-library-path")

--- a/util/packaging/rpm/amzn2023/rpmlintrc
+++ b/util/packaging/rpm/amzn2023/rpmlintrc
@@ -1,0 +1,2 @@
+from Config import *
+addFilter("E: hardcoded-library-path")

--- a/util/packaging/rpm/common/fill_docker_template.py
+++ b/util/packaging/rpm/common/fill_docker_template.py
@@ -104,7 +104,7 @@ COPY --chown=user ./rpm/common/make_spec.py /home/user/make_spec.py
 COPY --chown=user ./common/package_name.py /home/user/package_name.py
 RUN python3 make_spec.py $BASENAME $CHAPEL_VERSION $PACKAGE_VERSION $OS_NAME $TARGETARCH
 
-COPY --chown=user ./rpm/common/rpmlintrc /home/user/.rpmlintrc
+COPY --chown=user ./rpm/$DOCKER_DIR_NAME/rpmlintrc /home/user/.rpmlintrc
 RUN rpmdev-setuptree && \\
     cp chapel-$CHAPEL_VERSION.tar.gz $(rpm --eval '%{_sourcedir}') && \\
     ignore_unused=$([[ "$(rpm --eval '%{dist_name}')" == "Fedora Linux" ]] && echo "--ignore-unused-rpmlintrc") || echo "" && \\

--- a/util/packaging/rpm/common/rpmlintrc
+++ b/util/packaging/rpm/common/rpmlintrc
@@ -1,2 +1,0 @@
-from Config import *
-addFilter("E: hardcoded-library-path")

--- a/util/packaging/rpm/el10-gasnet-udp/rpmlintrc
+++ b/util/packaging/rpm/el10-gasnet-udp/rpmlintrc
@@ -1,0 +1,1 @@
+from Config import *

--- a/util/packaging/rpm/el10-ofi-slurm/rpmlintrc
+++ b/util/packaging/rpm/el10-ofi-slurm/rpmlintrc
@@ -1,0 +1,1 @@
+from Config import *

--- a/util/packaging/rpm/el10/rpmlintrc
+++ b/util/packaging/rpm/el10/rpmlintrc
@@ -1,0 +1,1 @@
+from Config import *

--- a/util/packaging/rpm/el9-gasnet-udp/rpmlintrc
+++ b/util/packaging/rpm/el9-gasnet-udp/rpmlintrc
@@ -1,0 +1,2 @@
+from Config import *
+addFilter("E: hardcoded-library-path")

--- a/util/packaging/rpm/el9-ofi-slurm/rpmlintrc
+++ b/util/packaging/rpm/el9-ofi-slurm/rpmlintrc
@@ -1,0 +1,2 @@
+from Config import *
+addFilter("E: hardcoded-library-path")

--- a/util/packaging/rpm/el9/rpmlintrc
+++ b/util/packaging/rpm/el9/rpmlintrc
@@ -1,0 +1,2 @@
+from Config import *
+addFilter("E: hardcoded-library-path")

--- a/util/packaging/rpm/fc41-gasnet-udp/rpmlintrc
+++ b/util/packaging/rpm/fc41-gasnet-udp/rpmlintrc
@@ -1,0 +1,2 @@
+from Config import *
+addFilter("E: hardcoded-library-path")

--- a/util/packaging/rpm/fc41/rpmlintrc
+++ b/util/packaging/rpm/fc41/rpmlintrc
@@ -1,0 +1,2 @@
+from Config import *
+addFilter("E: hardcoded-library-path")

--- a/util/packaging/rpm/fc42-gasnet-udp/rpmlintrc
+++ b/util/packaging/rpm/fc42-gasnet-udp/rpmlintrc
@@ -1,0 +1,2 @@
+from Config import *
+addFilter("E: hardcoded-library-path")

--- a/util/packaging/rpm/fc42/rpmlintrc
+++ b/util/packaging/rpm/fc42/rpmlintrc
@@ -1,0 +1,2 @@
+from Config import *
+addFilter("E: hardcoded-library-path")


### PR DESCRIPTION
Fixes an issue seen the el10 package builds, where rpmlint would complain about an unused filter.

We did see builds pass with el10, but apparently one of the dependencies changes and caused this to start occurring. Its annoying that rpmlint is so picky (the warning is about us silencing another warning that doesn't occur), but the simple solution is to just stop trying to filter our that one warning for el10

Tested el10 and el9 locally.

[Reviewed by @arifthpe]