### PR TITLE
Updates Twitter link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,6 @@ GitHub:                https://github.com/chapel-lang/chapel
 Discussion forums:     https://chapel.discourse.group
 Gitter chat room:      https://gitter.im/chapel-lang/chapel
 Stack Overflow:        http://stackoverflow.com/questions/tagged/chapel
-Twitter:               https://twitter.com/ChapelLanguage
+X (Twitter):           https://x.com/ChapelLanguage
 Facebook:              https://www.facebook.com/ChapelLanguage
 =====================  ========================================================
-


### PR DESCRIPTION
Twitter is still referenced in the resources section, even though the name was deprecated in July 2023 in favor of X. Since the website now refers to X, this PR proposes to update the reference accordingly.