### PR TITLE
Performance graph updates for release 2.5

### DIFF
--- a/util/pastPerformance/testReleasesPerformance
+++ b/util/pastPerformance/testReleasesPerformance
@@ -218,6 +218,10 @@ testReleasePerformance
 export CHPL_TEST_PERF_DATE="03/20/25"
 export CHPL_HOME=$chpl_release_home/chapel-2.4.0
 testReleasePerformance
+
+export CHPL_TEST_PERF_DATE="06/12/25"
+export CHPL_HOME=$chpl_release_home/chapel-2.5.0
+testReleasePerformance
 #
 # ADD NEW RELEASES HERE AS THEY ARE CREATED.
 #

--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -183,6 +183,10 @@ var branchInfo = [
                     "releaseDate": "2025-03-20",
                     "branchDate" : "2025-03-14",
                     "revision": -1},
+                  { "release": "2.5.0",
+                    "releaseDate": "2025-06-12",
+                    "branchDate" : "2025-06-06",
+                    "revision": -1},
                   ];
 
 var indexMap = {};


### PR DESCRIPTION
This adds performance graph data for the 2.5 release.

Corresponding previous update for 2.4: https://github.com/chapel-lang/chapel/pull/26942

[reviewer info placeholder]

Testing:
- [x] perf graphs viewed locally has line for release