### PR TITLE
Limit tests to avoid timeouts for partitioning-sort tests

### DIFF
--- a/test/library/standard/Sort/correctness/partitioning-sort-ml.compopts
+++ b/test/library/standard/Sort/correctness/partitioning-sort-ml.compopts
@@ -1,0 +1,1 @@
+--set Partitioning.PARTITIONING_EXTRA_CHECKS=true

--- a/test/library/standard/Sort/correctness/partitioning-sort-utilities-ml.compopts
+++ b/test/library/standard/Sort/correctness/partitioning-sort-utilities-ml.compopts
@@ -1,0 +1,1 @@
+--set Partitioning.PARTITIONING_EXTRA_CHECKS=true --set PartitioningUtility.BULK_COPY_EXTRA_CHECKS=true

--- a/test/library/standard/Sort/correctness/partitioning-sort-utilities.chpl
+++ b/test/library/standard/Sort/correctness/partitioning-sort-utilities.chpl
@@ -367,9 +367,9 @@ proc testDivideIntoPages() {
   if verbose then
     writeln("testDivideIntoPages");
 
-  for lower in [0, 100, 1000, 1024, 4096] {
-    for size in [0, 9, 21, 100, 543, 1024*1024] {
-      for alignment in [1, 16, 21, 64, 1024] {
+  for lower in [0, 100, 4096] {
+    for size in [0, 9, 21, 100, 1024*1024] {
+      for alignment in [1, 16, 21, 1024] {
         testDivideIntoPages(lower, size, alignment);
       }
     }

--- a/test/library/standard/Sort/correctness/partitioning-sort-utilities.compopts
+++ b/test/library/standard/Sort/correctness/partitioning-sort-utilities.compopts
@@ -1,0 +1,1 @@
+--set Partitioning.PARTITIONING_EXTRA_CHECKS=true --set PartitioningUtility.BULK_COPY_EXTRA_CHECKS=true

--- a/test/library/standard/Sort/correctness/partitioning-sort.chpl
+++ b/test/library/standard/Sort/correctness/partitioning-sort.chpl
@@ -512,8 +512,8 @@ proc testSort(n: int, max: uint, param logBuckets: int, seed: int,
 proc testSorts() {
   var seed = 1;
   for sorter in ["sample", "radix"] {
-    for n in [10, 30, 100, 100_000] {
-      for max in [0, 10, max(uint)] {
+    for n in [10, 100, 100_000] {
+      for max in [10, max(uint)] {
         for rnd in [false, true] {
           for noBaseCase in [false, true] {
             for fullBoundaries in [false, true] {
@@ -527,14 +527,18 @@ proc testSorts() {
                 continue;
               }
 
-              help(2);
-              help(4);
+              if n <= 100 {
+                help(2);
+                help(4);
+              }
               help(8);
               if sorter != "radix" {
                 // radix sorter assumes radix divides key type
                 help(10);
               }
-              help(16);
+              if n >= 10_000 && !noBaseCase {
+                help(16);
+              }
 
               seed += 1;
             }

--- a/test/library/standard/Sort/correctness/partitioning-sort.compopts
+++ b/test/library/standard/Sort/correctness/partitioning-sort.compopts
@@ -1,0 +1,1 @@
+--set Partitioning.PARTITIONING_EXTRA_CHECKS=true


### PR DESCRIPTION
* enables extra checking for more test coverage
* reduces the number of configurations / problem sizes tested to avoid the tests taking too long
* intended to address timeouts in the gasnet + quickstart configuration

Test change only -- not reviewed.