### PR TITLE
Add testing image mapping for el10 packages

### DIFF
--- a/util/packaging/common/test_package.py
+++ b/util/packaging/common/test_package.py
@@ -42,6 +42,7 @@ def determine_arch(package):
 def infer_docker_os(package):
     os_tag_to_docker = {
         "el9": "rockylinux/rockylinux:9",
+        "el10": "almalinux:10",
         "amzn2023": "amazonlinux:2023",
         "ubuntu22": "ubuntu:22.04",
         "ubuntu24": "ubuntu:24.04",


### PR DESCRIPTION
Add a mapping for `el10` packages to the appropriate Docker image to use for testing them.

Follow up to https://github.com/chapel-lang/chapel/pull/27323.

[skipping review for expediency]

Testing:
- [x] manual local run of an el10 package build passes