### PR TITLE
Add a longer timeout for the dist-performance performance test

### DIFF
--- a/test/library/standard/Sort/performance/dist-performance.ml-timeout
+++ b/test/library/standard/Sort/performance/dist-performance.ml-timeout
@@ -1,0 +1,2 @@
+# it was timing out, trying longer timout
+1000


### PR DESCRIPTION
Follow-up to PR #27277.

This PR adds a timeout file to give the dist-performance performance test the ability to run longer before it times out. This change is intended to address timeouts we are seeing in an EX multilocale performance testing configuration.

Test change only -- not reviewed.