### PR TITLE
Prevent quickstart config from accidentally creating a bad chplenv

### DIFF
--- a/util/quickstart/setchplenv.bash
+++ b/util/quickstart/setchplenv.bash
@@ -57,9 +57,13 @@ export CHPL_TASKS=fifo
 
 echo "Setting CHPL_TARGET_MEM to cstdlib"
 export CHPL_TARGET_MEM=cstdlib
+unset CHPL_TARGET_JEMALLOC
+unset CHPL_TARGET_MIMALLOC
 
 echo "Setting CHPL_HOST_MEM to cstdlib"
 export CHPL_HOST_MEM=cstdlib
+unset CHPL_HOST_JEMALLOC
+unset CHPL_HOST_MIMALLOC
 
 echo "Setting CHPL_GMP to none"
 export CHPL_GMP=none

--- a/util/quickstart/setchplenv.csh
+++ b/util/quickstart/setchplenv.csh
@@ -46,9 +46,13 @@ setenv CHPL_TASKS fifo
 
 echo "Setting CHPL_TARGET_MEM to cstdlib"
 setenv CHPL_TARGET_MEM cstdlib
+unsetenv CHPL_TARGET_JEMALLOC
+unsetenv CHPL_TARGET_MIMALLOC
 
 echo "Setting CHPL_HOST_MEM to cstdlib"
 setenv CHPL_HOST_MEM cstdlib
+unsetenv CHPL_HOST_JEMALLOC
+unsetenv CHPL_HOST_MIMALLOC
 
 echo "Setting CHPL_GMP to none"
 setenv CHPL_GMP none

--- a/util/quickstart/setchplenv.fish
+++ b/util/quickstart/setchplenv.fish
@@ -50,9 +50,13 @@ set -x CHPL_TASKS fifo
 
 echo "Setting CHPL_TARGET_MEM to cstdlib"
 set -x CHPL_TARGET_MEM cstdlib
+set -e CHPL_TARGET_JEMALLOC
+set -e CHPL_TARGET_MIMALLOC
 
 echo "Setting CHPL_HOST_MEM to cstdlib"
 set -x CHPL_HOST_MEM cstdlib
+set -e CHPL_HOST_JEMALLOC
+set -e CHPL_HOST_MIMALLOC
 
 echo "Setting CHPL_GMP to none"
 set -x CHPL_GMP none

--- a/util/quickstart/setchplenv.sh
+++ b/util/quickstart/setchplenv.sh
@@ -60,12 +60,16 @@ echo " "
 echo "Setting CHPL_TARGET_MEM to..."
 CHPL_TARGET_MEM=cstdlib
 export CHPL_TARGET_MEM
+unset CHPL_TARGET_JEMALLOC
+unset CHPL_TARGET_MIMALLOC
 echo "                           ...cstdlib"
 echo " "
 
 echo "Setting CHPL_HOST_MEM to..."
 CHPL_HOST_MEM=cstdlib
 export CHPL_HOST_MEM
+unset CHPL_HOST_JEMALLOC
+unset CHPL_HOST_MIMALLOC
 echo "                           ...cstdlib"
 echo " "
 


### PR DESCRIPTION
Adjusts the quickstart chplenv scripts to unset certain memory allocation chplenv variables that can break a users build.

This occurs in the following example scenario.
1. A user has a config built with CHPL_TARGET_MEM=jemalloc and CHPL_TARGET_JEMALLOC explicitly set to bundled or system
2. A user then sources `util/quickstart/setchplenv.bash`, which results in `CHPL_TARGET_MEM=cstdlib` and `CHPL_TARGET_JEMALLOC` being set, which is an invalid combination

[Reviewed by @]