### PR TITLE
Fix a bug with casting inf to imag

### DIFF
--- a/runtime/src/chplcast.c
+++ b/runtime/src/chplcast.c
@@ -188,7 +188,16 @@ _define_string_to_float_precise(real, 64, "%lf")
     if (scanningNCounts() && numitems == 3) {                           \
       numitems = 2;                                                     \
     }                                                                   \
-    if (numitems == 1) {                                                \
+    if (numitems == 0) {                                                \
+      if (0 == strncmp(str, "infi", 4)) {                               \
+        val = INFINITY;                                                 \
+        *invalid = 0;                                                   \
+        *invalidCh = '\0';                                              \
+      } else {                                                          \
+        *invalid = 1;                                                   \
+        *invalidCh = *str;                                              \
+      }                                                                 \
+    } else if (numitems == 1) {                                         \
       /* missing terminating i */                                       \
       *invalid = 2;                                                     \
       *invalidCh = i;                                                   \

--- a/test/types/imag/inf-conversion.chpl
+++ b/test/types/imag/inf-conversion.chpl
@@ -1,0 +1,8 @@
+var str = "infi";
+
+proc f(arg: imag) { writeln(arg); }
+f(str: imag);
+f(inf: imag);
+
+//var str2 = "inf";
+//f(str2: imag);

--- a/test/types/imag/inf-conversion.chpl
+++ b/test/types/imag/inf-conversion.chpl
@@ -3,6 +3,3 @@ var str = "infi";
 proc f(arg: imag) { writeln(arg); }
 f(str: imag);
 f(inf: imag);
-
-//var str2 = "inf";
-//f(str2: imag);

--- a/test/types/imag/inf-conversion.good
+++ b/test/types/imag/inf-conversion.good
@@ -1,0 +1,2 @@
+infi
+infi

--- a/test/types/imag/nan-conversion.chpl
+++ b/test/types/imag/nan-conversion.chpl
@@ -1,0 +1,8 @@
+var str = "nani";
+
+proc f(arg: imag) { writeln(arg); }
+f(str: imag);
+f(nan: imag);
+
+//var str2 = "nan";
+//f(str2: imag);

--- a/test/types/imag/nan-conversion.chpl
+++ b/test/types/imag/nan-conversion.chpl
@@ -3,6 +3,3 @@ var str = "nani";
 proc f(arg: imag) { writeln(arg); }
 f(str: imag);
 f(nan: imag);
-
-//var str2 = "nan";
-//f(str2: imag);

--- a/test/types/imag/nan-conversion.good
+++ b/test/types/imag/nan-conversion.good
@@ -1,0 +1,2 @@
+nani
+nani


### PR DESCRIPTION
[reviewed by @mppf]

On my local machine, I was seeing that casting `infi` ("imaginary infinity"), from a string to the `imag` type was working just fine, but when I took it to our main testing machine, it was encountering a "bad cast" error.  This change avoids that error so that the cast works in both settings.

Adds a test locking in that the bug has been fixed with `infi`, and a test of doing the same thing with `nani` (which always worked).

Passed a full paratest with futures