### PR TITLE
Reduce partitioning-sort test problem size for multilocale

### DIFF
--- a/test/library/standard/Sort/correctness/partitioning-sort-utilities.chpl
+++ b/test/library/standard/Sort/correctness/partitioning-sort-utilities.chpl
@@ -367,8 +367,9 @@ proc testDivideIntoPages() {
   if verbose then
     writeln("testDivideIntoPages");
 
+  const bigN = if numLocales == 1 then 1024*1024 else 10_000;
   for lower in [0, 100, 4096] {
-    for size in [0, 9, 21, 100, 1024*1024] {
+    for size in [0, 9, 21, 100, bigN] {
       for alignment in [1, 16, 21, 1024] {
         testDivideIntoPages(lower, size, alignment);
       }

--- a/test/library/standard/Sort/correctness/partitioning-sort.chpl
+++ b/test/library/standard/Sort/correctness/partitioning-sort.chpl
@@ -511,8 +511,9 @@ proc testSort(n: int, max: uint, param logBuckets: int, seed: int,
 
 proc testSorts() {
   var seed = 1;
+  const bign = if numLocales == 1 then 100_000 else 10_000;
   for sorter in ["sample", "radix"] {
-    for n in [10, 100, 100_000] {
+    for n in [10, 100, bign] {
       for max in [10, max(uint)] {
         for rnd in [false, true] {
           for noBaseCase in [false, true] {


### PR DESCRIPTION
Follow-up to PRs #27277 and #27382 to address timeouts in gasnet+quickstart. Does so by reducing the problem size when running multilocale.

Test change only -- not reviewed.

- [x] quickstart+gasnet test passes without timeout on the affected system