### PR TITLE
Fix implementation of PrivateDist equality and inequality

### DIFF
--- a/modules/dists/PrivateDist.chpl
+++ b/modules/dists/PrivateDist.chpl
@@ -114,14 +114,14 @@ record privateDist: writeSerializable {
 
   @chpldoc.nodoc
   inline operator ==(d1: privateDist, d2: privateDist) {
-    if (d1._value == d2._value) then
-      return true;
-    return d1._value.dsiEqualDMaps(d2._value);
+    // privateDists never differ, so these are inherently equal
+    return true;
   }
 
   @chpldoc.nodoc
   inline operator !=(d1: privateDist, d2: privateDist) {
-    return !(d1 == d2);
+    // privateDists never differ, so these are inherently equal
+    return false;
   }
 
   proc serialize(writer, ref serializer) throws {

--- a/test/distributions/private/equals.chpl
+++ b/test/distributions/private/equals.chpl
@@ -1,0 +1,7 @@
+use PrivateDist;
+
+var p1 = new privateDist();
+var p2 = new privateDist();
+
+writeln(p1 == p2);
+writeln(p1 != p2);

--- a/test/distributions/private/equals.good
+++ b/test/distributions/private/equals.good
@@ -1,0 +1,2 @@
+true
+false

--- a/test/distributions/private/passToTypedFormal.chpl
+++ b/test/distributions/private/passToTypedFormal.chpl
@@ -1,0 +1,14 @@
+use PrivateDist;
+
+proc foo(a: [PrivateSpace] real) {
+  writeln("In foo");
+}
+
+var D: domain(1) dmapped new privateDist();
+
+var A: [PrivateSpace] real;
+var B: [D] real;
+
+foo(A);
+foo(B);
+

--- a/test/distributions/private/passToTypedFormal.good
+++ b/test/distributions/private/passToTypedFormal.good
@@ -1,0 +1,2 @@
+In foo
+In foo


### PR DESCRIPTION
The previous implementation  of `==` on `privateDist` objects relied on a dsi procedure that had not been implemented for privateDists, which seems to have been a mistake of mine in #23393.  However, since all privateDists are equivalent (they take no arguments), this is overkill, and we can just declare them equal in the routine as it stands. Add this capability and a test of it, as well as a test that exercises `==` indirectly by passing an array argument to a formal with a `privateDist` domain.