### PR TITLE
Add tests of casting inf and nan to `complex`

### DIFF
--- a/test/types/complex/inf-cast-by-part.bad
+++ b/test/types/complex/inf-cast-by-part.bad
@@ -1,0 +1,3 @@
+uncaught IllegalArgumentError: bad cast from string 'inf + infi' to complex(128)
+  inf-cast-by-part.chpl:1: thrown here
+  inf-cast-by-part.chpl:1: uncaught here

--- a/test/types/complex/inf-cast-by-part.chpl
+++ b/test/types/complex/inf-cast-by-part.chpl
@@ -1,0 +1,8 @@
+var c = "inf + infi":complex;
+writeln(c.re, " ", c.im);
+
+var c2 = "1.2 + infi":complex;
+writeln(c2.re, " ", c2.im);
+
+var c3 = "inf + 3.4i":complex;
+writeln(c3.re, " ", c3.im);

--- a/test/types/complex/inf-cast-by-part.future
+++ b/test/types/complex/inf-cast-by-part.future
@@ -1,4 +1,4 @@
 bug: can't always cast strings with inf parts to complex numbers
-#TBD
+#27399
 
 When this issue is resolved, the skipif should be removed

--- a/test/types/complex/inf-cast-by-part.future
+++ b/test/types/complex/inf-cast-by-part.future
@@ -1,0 +1,4 @@
+bug: can't always cast strings with inf parts to complex numbers
+#TBD
+
+When this issue is resolved, the skipif should be removed

--- a/test/types/complex/inf-cast-by-part.good
+++ b/test/types/complex/inf-cast-by-part.good
@@ -1,0 +1,3 @@
+inf inf
+1.2 inf
+inf 3.4

--- a/test/types/complex/inf-cast-by-part.skipif
+++ b/test/types/complex/inf-cast-by-part.skipif
@@ -1,0 +1,1 @@
+CHPL_TARGET_PLATFORM != linux64

--- a/test/types/complex/nan-cast-by-part.chpl
+++ b/test/types/complex/nan-cast-by-part.chpl
@@ -1,0 +1,8 @@
+var c = "nan + nani":complex;
+writeln(c.re, " ", c.im);
+
+var c2 = "1.2 + nani":complex;
+writeln(c2.re, " ", c2.im);
+
+var c3 = "nan + 3.4i":complex;
+writeln(c3.re, " ", c3.im);

--- a/test/types/complex/nan-cast-by-part.good
+++ b/test/types/complex/nan-cast-by-part.good
@@ -1,0 +1,3 @@
+nan nan
+1.2 nan
+nan 3.4

--- a/test/types/complex/nan-cast-by-part.good
+++ b/test/types/complex/nan-cast-by-part.good
@@ -1,3 +1,3 @@
 nan nan
-1.2 nan
+nan nan
 nan 3.4


### PR DESCRIPTION
Covers casting string versions of complex numbers involving nan and inf into Chapel `complex`.

Inspired by, but distinct from, string-to-inf-nan.chpl from Brad's #27011 by virtue of trying to print the individual components of the `complex` result.

The nan version works without issue in all places I tried it.  The inf version worked on my machine but failed on our linux testing box, hence the tests.

