### PR TITLE
Fix bug pointed out by Brad allowing casting `infisomething` to imag 

### DIFF
--- a/runtime/src/chplcast.c
+++ b/runtime/src/chplcast.c
@@ -189,7 +189,7 @@ _define_string_to_float_precise(real, 64, "%lf")
       numitems = 2;                                                     \
     }                                                                   \
     if (numitems == 0) {                                                \
-      if (0 == strncmp(str, "infi", 4)) {                               \
+      if (0 == strcmp(str, "infi")) {                                   \
         val = INFINITY;                                                 \
         *invalid = 0;                                                   \
         *invalidCh = '\0';                                              \

--- a/test/types/imag/badStringInfiCast.chpl
+++ b/test/types/imag/badStringInfiCast.chpl
@@ -1,0 +1,2 @@
+var c = "infigoop": imag; // shouldn't work
+writeln(c);

--- a/test/types/imag/badStringInfiCast.good
+++ b/test/types/imag/badStringInfiCast.good
@@ -1,0 +1,3 @@
+uncaught IllegalArgumentError: bad cast from string 'infigoop' to imag(64)
+  badStringInfiCast.chpl:1: thrown here
+  badStringInfiCast.chpl:1: uncaught here


### PR DESCRIPTION
My comparison was stopping early and so accepting things that weren't actually a match.

Add the test case Brad wrote to lock in that the fix worked.  It only was needed on linux, since the code follows a different path for Macs.

Passed a full paratest with futures