### PR TITLE
Prevent unused warning in testTaskIntents for GCC 7.5

### DIFF
--- a/frontend/test/resolution/testTaskIntents.cpp
+++ b/frontend/test/resolution/testTaskIntents.cpp
@@ -337,6 +337,7 @@ static void testTaskVar() {
   assert(guard.realizeErrors() == 0);
 
   for (auto& [name, var] : vars) {
+    std::ignore = name; // avoid unused variable warning with old GCC (7.5)
     assert(!var.isUnknownOrErroneous() && var.type()->isIntType());
   }
 }


### PR DESCRIPTION
Add a no-op use of a variable to avoid an unused variable warning-as-error from GCC 7.5, in `testTaskIntents.cpp`.

[reviewer info placeholder]

Testing:
- [x] no more warning