### PR TITLE
Close memory leak with PrivateDist

### DIFF
--- a/modules/dists/PrivateDist.chpl
+++ b/modules/dists/PrivateDist.chpl
@@ -175,8 +175,6 @@ class PrivateImpl: BaseDist, writeSerializable {
   proc trackDomains() param do return false;
 
   override proc dsiTrackDomains() do    return false;
-
-  override proc singleton() param do return true;
 }
 
 class PrivateDom: BaseRectangularDom(?) {


### PR DESCRIPTION
The new tests I added allocated new instances of 'privateDist' which we don't technically prevent, and which the docs suggest is a reasonable thing to do. However, this caused leaks because PrivateDist is labeled as a singleton which prevents the implementation class from being freed.

Given that multiple instances can be created, I don't think it makes sense to consider it a singleton as the code traditionally has.  It may be that we used to have all PrivateDists share the same implementation class, such that it was truly a singleton, and that I broke or changed that when I converted it to a record, but I'm not certain.

This singleton marker was added in
https://github.com/chapel-lang/chapel/pull/4762 and test/parallel/taskPar/sungeun/private.chpl was used as the rationale, yet it seems to be passing, so I'm not sure that original motivation holds any longer (where, again, it could be that the implementation changed enough that that was a factor).

We could look into making it truly a singleton again, but I'm not sure it's worth the effort given that I don't think it's used much to begin with, and I don't think it's likely that a given program will make a ton of distinct instances of it anyway.