### PR TITLE
Move meeting bot an hour earlier

### DIFF
--- a/.github/workflows/meetings.yml
+++ b/.github/workflows/meetings.yml
@@ -3,7 +3,7 @@ name: Weekly Meeting Topics
 on:
   workflow_dispatch: # Allows manual triggering of the workflow
   schedule:
-    - cron: '0 17 * * 2' # Runs every week on Tuesday at 11 PT
+    - cron: '0 17 * * 2' # Runs every week on Tuesday at 10 PT
 
 jobs:
   create-discussion:


### PR DESCRIPTION
Currently, the meeting topics generator bot fires at 11am PT, but in practice doesn't tend to run until 11:25pm.  Usually I'm wanting the next week's meeting notes right when this week's meeting wraps up, so I'm moving it an hour earlier, on the argument that there's no real downside to having it show up a bit early anyway.
