### PR TITLE
Add a CI check for untested documentation examples

### DIFF
--- a/modules/standard/Sort.chpl
+++ b/modules/standard/Sort.chpl
@@ -105,6 +105,7 @@ array being sorted.
 
 The default key method would look like this:
 
+.. BLOCK-test-allowCodeBlock
 .. code-block:: chapel
 
   proc defaultComparator.key(elt) {
@@ -125,6 +126,7 @@ operator, which is used by the base compare method of all sort routines. If the
 ``<`` operator is not defined for the return type, the user may define it
 themselves like so:
 
+.. BLOCK-test-allowCodeBlock
 .. code-block:: chapel
 
   operator <(x: returnType, y: returnType): bool {
@@ -157,6 +159,7 @@ indicating how x and y compare to each other. The conditions between ``x`` and
 
 The default compare method for a signed integral type can look like this:
 
+.. BLOCK-test-allowCodeBlock
 .. code-block:: chapel
 
     proc defaultComparator.compare(x, y) {

--- a/util/buildRelease/smokeTest
+++ b/util/buildRelease/smokeTest
@@ -142,6 +142,17 @@ if [ $LINT -eq 1 ]; then
         exit 1
     fi
 
+    # check that the docs have don't use literal .. code-block:: chpl
+    # TODO: improve the script so it does not have to ignore the spec explicitly
+    echo "Checking for literal .. code-block:: chpl"
+    $($CHPL_HOME/util/config/find-python.sh) \
+      $CHPL_HOME/util/devel/lookForCodeBlocks modules doc/rst/ \
+      --ignore doc/rst/language/spec
+    if [ $? -ne 0 ] ; then
+        echo "Found literal code blocks"
+        exit 1
+    fi
+
     # done with lint checks
 fi
 

--- a/util/devel/lookForCodeBlocks
+++ b/util/devel/lookForCodeBlocks
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+import sys
+import os
+import glob
+from itertools import chain
+import pathlib
+import argparse
+
+
+def check_file(filename):
+    """
+    Open a file and check for '.. code-block:: [chapel|chpl]' directives.
+    Return a list of tuples with the filename and linenumber
+
+    if the previous line is '.. BLOCK-test-allowCodeBlock', then skip this line.
+    """
+    code_blocks = []
+    with open(filename, "rb") as fp:
+        lines = fp.readlines()
+        for linenum, line in enumerate(lines):
+            line = line.strip()
+            prevline = lines[linenum - 1].strip() if linenum > 0 else b""
+            if (
+                line.startswith(b".. code-block:: chapel")
+                or line.startswith(b".. code-block:: chpl")
+            ) and not prevline.startswith(b".. BLOCK-test-allowCodeBlock"):
+                code_blocks.append((filename, linenum + 1))
+
+    return code_blocks
+
+
+def check_files(filenames):
+    result = chain.from_iterable(check_file(fn) for fn in filenames)
+    return sorted(result, key=lambda x: (x[0], x[1]))
+
+
+def ignore_files(filenames, ignore_patterns=[]):
+    """
+    filter out files that match any of the ignore patterns.
+    """
+    if not ignore_patterns:
+        return filenames
+
+    ignored_files = set()
+    for filename in filenames:
+        resolved_filename = pathlib.Path(filename).resolve()
+        for pattern in ignore_patterns:
+            if resolved_filename.is_relative_to(pattern):
+                ignored_files.add(filename)
+            if resolved_filename.match(pattern):
+                ignored_files.add(filename)
+
+    return [fn for fn in filenames if fn not in ignored_files]
+
+
+def get_gitignore_patterns(chplhome: pathlib.Path):
+    """
+    Read the .gitignore file for the docs and return a list of patterns.
+    """
+
+    directory = chplhome / "doc"
+    gitignore_path = directory / ".gitignore"
+    if not gitignore_path.exists():
+        patterns = []
+    else:
+        with gitignore_path.open("r") as f:
+            patterns = [
+                line.strip()
+                for line in f
+                if line.strip() and not line.startswith("#")
+            ]
+
+    resolve_patterns = []
+    for p in patterns:
+        if p.startswith("/"):
+            p = str(directory / p[1:])
+        elif not p.startswith("*"):
+            p = str(directory / p)
+        resolve_patterns.append(p)
+    return resolve_patterns
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "files",
+        nargs="*",
+        help="Files or directories to check for code blocks. "
+             "If a directory is provided, all files in it will be checked.",
+    )
+    parser.add_argument('--ignore', action='append', default=[],
+                        help='Patterns to ignore, e.g., "*.rst" or "docs/*"')
+
+    args = parser.parse_args()
+    filenames = []
+    for a in args.files:
+        if os.path.isdir(a):
+            filenames.extend(
+                str(p) for p in pathlib.Path(a).rglob("*") if p.is_file()
+            )
+        elif os.path.isfile(a):
+            filenames.append(a)
+        else:
+            filenames.extend(glob.glob(a, recursive=True))
+
+    chplhome = pathlib.Path(__file__).parent.parent.parent
+    ignore_patterns = get_gitignore_patterns(chplhome)
+    for p in args.ignore:
+        ignore_patterns.append(str(pathlib.Path(p).resolve()))
+    filenames = ignore_files(filenames, ignore_patterns)
+
+    results = check_files(filenames)
+    if len(results) != 0:
+        print("Found plain code blocks!")
+        print("Please turn these into testable code blocks")
+        print(*("  {}:{}".format(*r) for r in results), sep="\n")
+        return 1
+    else:
+        return 0
+
+
+if __name__ == "__main__":
+    exit(main())


### PR DESCRIPTION
Adds a new CI check to prevent untested code examples in the docs from being added.

DRAFT: requires https://github.com/chapel-lang/chapel/issues/11090 to be resolved