### PR TITLE
Exclude generated minimal modules from copyright check

### DIFF
--- a/util/test/checkCopyrights.bash
+++ b/util/test/checkCopyrights.bash
@@ -81,6 +81,7 @@ files_wo_copy=$(find $source_dirs -type f \( \
     grep -v frontend/lib/parsing/flex-chpl-lib.cpp | \
     grep -v frontend/lib/util/git-version.cpp | \
     grep -v 'modules/standard/gen/.*/ChapelSysCTypes.chpl' | \
+    grep -v 'modules/minimal/standard/gen/.*/ChapelSysCTypes.chpl' | \
     grep -v 'modules/packages/ImageHelper/stb/.*.h' | \
     xargs grep -i -L "${copyright_pattern}")
 


### PR DESCRIPTION
Fixes an issue introduced by https://github.com/chapel-lang/chapel/pull/26576 where running `smokeTest lint` on a Chapel source tree with an existing build fails due to missing copyrights in generated files.

[Reviewed by @lydia-duncan]