### PR TITLE
Don't run C++ compiler checks when building launchers

### DIFF
--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -120,10 +120,18 @@ ifndef GNU_GCC_MINOR_VERSION
 export GNU_GCC_MINOR_VERSION := $(shell $(CC) -dumpversion | awk '{split($$1,a,"."); printf("%s", a[2]);}')
 endif
 ifndef GNU_GPP_MAJOR_VERSION
-export GNU_GPP_MAJOR_VERSION := $(shell $(CXX) -dumpversion | awk '{split($$1,a,"."); printf("%s", a[1]);}')
+ifneq ($(MAKE_LAUNCHER),1)
+export GNU_GPP_MAJOR_VERSION := $(shell $(CXX) -dumpversion | awk '{split($$1,a,"."); printf("%s", a[1]);}';)
+else
+export GNU_GPP_MAJOR_VERSION := 7
+endif
 endif
 ifndef GNU_GPP_MINOR_VERSION
-export GNU_GPP_MINOR_VERSION := $(shell $(CXX) -dumpversion | awk '{split($$1,a,"."); printf("%s", a[2]);}')
+ifneq ($(MAKE_LAUNCHER),1)
+export GNU_GPP_MINOR_VERSION := $(shell $(CXX) -dumpversion | awk '{split($$1,a,"."); printf("%s", a[2]);}';)
+else
+export GNU_GPP_MINOR_VERSION := 0
+endif
 endif
 ifndef GNU_GPP_SUPPORTS_MISSING_DECLS
 export GNU_GPP_SUPPORTS_MISSING_DECLS := $(shell test $(GNU_GPP_MAJOR_VERSION) -lt 4 || (test $(GNU_GPP_MAJOR_VERSION) -eq 4 && test $(GNU_GPP_MINOR_VERSION) -le 2); echo "$$?")
@@ -139,7 +147,11 @@ endif
 # be at least C++11 to match.
 #
 DEF_C_VER := $(shell echo __STDC_VERSION__ | $(CC) -E -x c - | sed -e '/^\#/d' -e 's/L$$//' -e 's/__STDC_VERSION__/0/')
-DEF_CXX_VER := $(shell echo __cplusplus | $(CXX) -E -x c++ - | sed -e '/^\#/d' -e 's/L$$//' -e 's/__cplusplus/0/')
+ifneq ($(MAKE_LAUNCHER),1)
+DEF_CXX_VER := $(shell  echo __cplusplus | $(CXX) -E -x c++ - | sed -e '/^\#/d' -e 's/L$$//' -e 's/__cplusplus/0/';)
+else
+DEF_CXX_VER := 2017
+endif
 C_STD := $(shell test $(DEF_C_VER) -lt 199901 && echo -std=gnu99)
 CXX_STD := $(shell test $(DEF_C_VER) -ge 201112 -a $(DEF_CXX_VER) -lt 201103 && echo -std=gnu++11)
 

--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -120,6 +120,11 @@ ifndef GNU_GCC_MINOR_VERSION
 export GNU_GCC_MINOR_VERSION := $(shell $(CC) -dumpversion | awk '{split($$1,a,"."); printf("%s", a[2]);}')
 endif
 ifndef GNU_GPP_MAJOR_VERSION
+#
+# When using this makefile to build a launcher, we don't use C++. Since g++ may
+# not be available, we default to minimum dummy versions to avoid errors about
+# missing g++.
+#
 ifneq ($(MAKE_LAUNCHER),1)
 export GNU_GPP_MAJOR_VERSION := $(shell $(CXX) -dumpversion | awk '{split($$1,a,"."); printf("%s", a[1]);}';)
 else


### PR DESCRIPTION
Fixes an issue where a user could have a Chapel install without the HOST_CXX compiler being available (e.g. a binary linux OS package), but the build system would try and invoke it when building launchers.

This issue was not a correctness issue, just when building a Chapel program a bunch of erroneous output would appear when invoking the Makefiles for the launcher. The fix is to just skip these C++ checks when the `Makefile.gnu` file is used to build a launcher, since none of the Chapel launchers require C++. This is done by replacing the invocations of `HOST_CXX` with a default value, since the result is just used to generate a set of compilation flags which are never used.

resolves https://github.com/chapel-lang/chapel/issues/27130

Tested that this resolves #27130 in an environment with no `g++`

[Reviewed by @mppf]