### PR TITLE
Fix chpldoc bug with single statement functions

### DIFF
--- a/frontend/lib/parsing/ParserContext.h
+++ b/frontend/lib/parsing/ParserContext.h
@@ -439,7 +439,7 @@ struct ParserContext {
 
   void enterScopeForFunctionDecl(FunctionParts& fp,
                                  AstNode* retType);
-  void exitScopeForFunctionDecl(FunctionParts& fp);
+  void exitScopeForFunctionDecl(YYLTYPE bodyLocation, FunctionParts& fp);
 
   AstNode* buildLambda(YYLTYPE location, FunctionParts& fp);
 
@@ -791,5 +791,5 @@ struct ParserContext {
   CommentsAndStmt buildLabelStmt(YYLTYPE location, PODUniqueString name,
                                  CommentsAndStmt cs);
 
-  ParserExprList* buildSingleStmtRoutineBody(CommentsAndStmt cs);
+  ParserExprList* buildSingleStmtRoutineBody(YYLTYPE location, CommentsAndStmt cs);
 };

--- a/frontend/lib/parsing/ParserContextImpl.h
+++ b/frontend/lib/parsing/ParserContextImpl.h
@@ -1720,7 +1720,9 @@ CommentsAndStmt ParserContext::buildFunctionDecl(YYLTYPE location,
     }
   }
 
-  this->clearComments();
+  auto last = makeLocationAtLast(location);
+  auto commentsToDiscard = gatherComments(last);
+  clearComments(commentsToDiscard);
 
   cs.stmt = f.release();
   return cs;
@@ -1747,8 +1749,11 @@ void ParserContext::enterScopeForFunctionDecl(FunctionParts& fp,
     this->enterScope(asttags::Function, fp.name->name());
   }
 }
-void ParserContext::exitScopeForFunctionDecl(FunctionParts& fp) {
-  this->clearComments();
+void ParserContext::exitScopeForFunctionDecl(YYLTYPE bodyLocation,
+                                             FunctionParts& fp) {
+  auto last = makeLocationAtLast(bodyLocation);
+  auto commentsToDiscard = gatherComments(last);
+  clearComments(commentsToDiscard);
 
   fp.errorExpr = checkForFunctionErrors(fp, fp.returnType);
   // May never have been built if there was a syntax error.
@@ -3623,7 +3628,7 @@ ParserContext::buildLabelStmt(YYLTYPE location, PODUniqueString name,
 
 
 ParserExprList*
-ParserContext::buildSingleStmtRoutineBody(CommentsAndStmt cs) {
-  this->clearComments();
+ParserContext::buildSingleStmtRoutineBody(YYLTYPE location, CommentsAndStmt cs) {
+  cs = this->finishStmt(location, cs);
   return this->makeList(cs);
 }

--- a/frontend/lib/parsing/bison-chpl-lib.cpp
+++ b/frontend/lib/parsing/bison-chpl-lib.cpp
@@ -6017,7 +6017,7 @@ yyreduce:
 
   case 12: /* stmt_base: decl_base  */
 #line 732 "chpl.ypp"
-                            { (yyval.commentsAndStmt) = context->finishStmt((yyvsp[0].commentsAndStmt)); }
+                            { (yyval.commentsAndStmt) = context->finishStmt((yylsp[0]), (yyvsp[0].commentsAndStmt)); }
 #line 6022 "bison-chpl-lib.cpp"
     break;
 
@@ -7068,7 +7068,7 @@ yyreduce:
 #line 1488 "chpl.ypp"
     {
       // visibility should be default when inner_class_level_stmt is parsed
-      (yyval.commentsAndStmt) = context->finishStmt((yyvsp[0].commentsAndStmt));
+      (yyval.commentsAndStmt) = context->finishStmt((yylsp[0]), (yyvsp[0].commentsAndStmt));
       context->visibility = Decl::DEFAULT_VISIBILITY;
     }
 #line 7075 "bison-chpl-lib.cpp"
@@ -8460,7 +8460,7 @@ yyreduce:
       (yyvsp[-3].throwsTag) != ThrowsTag_DEFAULT ? (yylsp[-3]) :
         ((yyvsp[-4].expr) != nullptr ? (yylsp[-4]) :
           ((yyvsp[-5].returnTag).isValid && (Function::ReturnIntent)(yyvsp[-5].returnTag).intent != Function::DEFAULT_RETURN_INTENT ? (yylsp[-5]) : (yylsp[-6]))));
-    context->exitScopeForFunctionDecl(fp);
+    context->exitScopeForFunctionDecl((yylsp[0]), fp);
     (yyval.functionParts) = fp;
   }
 #line 8467 "bison-chpl-lib.cpp"
@@ -8933,7 +8933,7 @@ yyreduce:
 
   case 465: /* function_body_stmt: TDO toplevel_stmt  */
 #line 2779 "chpl.ypp"
-                    { (yyval.exprList) = context->buildSingleStmtRoutineBody((yyvsp[0].commentsAndStmt)); }
+                    { (yyval.exprList) = context->buildSingleStmtRoutineBody((yylsp[0]), (yyvsp[0].commentsAndStmt)); }
 #line 8938 "bison-chpl-lib.cpp"
     break;
 

--- a/frontend/lib/parsing/chpl.ypp
+++ b/frontend/lib/parsing/chpl.ypp
@@ -729,7 +729,13 @@ stmt:
 
 stmt_base:
   tryable_stmt      // (no '->finishStmt()' required b/c 'tryable_stmt' did it)
-| decl_base                 { $$ = context->finishStmt($1); }
+
+// 'decl_base' passes its location because in the case of a single-stmt
+// proceduring using 'do', the parser might scoop up a comment following the
+// procedure. If we don't pass in the location, the comment will be cleared by
+// 'finishStmt'.
+| decl_base                 { $$ = context->finishStmt(@1, $1); }
+
 | include_module_stmt       { $$ = context->finishStmt($1); }
 | block_stmt                { $$ = context->finishStmt($1); }
 | use_stmt                  { $$ = context->finishStmt($1); }
@@ -1487,7 +1493,7 @@ class_level_stmt:
 | inner_class_level_stmt
     {
       // visibility should be default when inner_class_level_stmt is parsed
-      $$ = context->finishStmt($1);
+      $$ = context->finishStmt(@1, $1);
       context->visibility = Decl::DEFAULT_VISIBILITY;
     }
 | TPUBLIC {context->noteDeclStartLoc(@1);
@@ -2507,7 +2513,7 @@ fn_decl_stmt:
       $4 != ThrowsTag_DEFAULT ? @4 :
         ($3 != nullptr ? @3 :
           ($2.isValid && (Function::ReturnIntent)$2.intent != Function::DEFAULT_RETURN_INTENT ? @2 : @1)));
-    context->exitScopeForFunctionDecl(fp);
+    context->exitScopeForFunctionDecl(@7, fp);
     $$ = fp;
   }
 ;
@@ -2776,7 +2782,7 @@ opt_function_body_stmt:
 
 function_body_stmt:
   block_stmt_body   { $$ = $1; }
-| TDO toplevel_stmt { $$ = context->buildSingleStmtRoutineBody($2); }
+| TDO toplevel_stmt { $$ = context->buildSingleStmtRoutineBody(@2, $2); }
 ;
 
 query_expr:

--- a/test/chpldoc/functions/singleStmtRoutine.doc.catfiles
+++ b/test/chpldoc/functions/singleStmtRoutine.doc.catfiles
@@ -1,0 +1,1 @@
+docs/source/modules/M.rst

--- a/test/chpldoc/functions/singleStmtRoutine.doc.chpl
+++ b/test/chpldoc/functions/singleStmtRoutine.doc.chpl
@@ -1,0 +1,10 @@
+// This test exists to ensure that a single-statement routine does not cause
+// the following comment to be dropped by the parser.
+
+module M {
+  /* doc foo */
+  proc foo() do if false then ;
+
+  /* doc bar */
+  proc bar() { }
+}

--- a/test/chpldoc/functions/singleStmtRoutine.doc.good
+++ b/test/chpldoc/functions/singleStmtRoutine.doc.good
@@ -1,0 +1,27 @@
+.. default-domain:: chpl
+
+.. module:: M
+
+M
+=
+**Usage**
+
+.. code-block:: chapel
+
+   use M;
+
+
+or
+
+.. code-block:: chapel
+
+   import M;
+
+.. function:: proc foo()
+
+   doc foo 
+
+.. function:: proc bar()
+
+   doc bar 
+


### PR DESCRIPTION
This commit fixes a bug where the parser would drop a comment if the preceding function was a single-statement body ending in an else-less 'if then'. For example:

```chpl
/* doc foo */
proc foo() do if false then ;

/* doc bar */
proc bar() { }
```

Here, the 'doc bar' docstring would be dropped entirely by the parser.

The reason for this was that when parsing the if-then, the parser would scoop up the 'doc bar' comment while looking for the end of the if-then statement. Then, the parser would proceed to clear its comments at various points while building the function.

The solution is to instead invoke 'clearComments' with a set of comments gathered from the last location represented by the function.

A test is added to lock in this behavior.

Resolves https://github.com/chapel-lang/chapel/issues/25790

Testing:
- [x] paratest
- [x] diff'd 'make docs' results before and after, no changes