### PR TITLE
Expand the docs for the Mason.toml manifest

### DIFF
--- a/doc/rst/tools/mason/guide/externaldependencies.rst
+++ b/doc/rst/tools/mason/guide/externaldependencies.rst
@@ -1,5 +1,7 @@
 :title: Mason Guide: *External Dependencies*
 
+.. _mason-external-dependencies:
+
 Using Non-Chapel Dependencies
 =============================
 Mason allows for specification of external, non-Chapel dependencies through two

--- a/doc/rst/tools/mason/guide/manifestfile.rst
+++ b/doc/rst/tools/mason/guide/manifestfile.rst
@@ -16,32 +16,135 @@ For example, ``Mason.toml``:
     chplVersion = "1.16.0"
     license = "None"
     name = "MyPackage"
+    type = "application"
     version = "0.1.0"
 
     [dependencies]
     curl = '1.0.0'
 
-The ``chplVersion`` field indicates Chapel releases compatible with this
-package. There are a number of accepted formats:
 
-.. code-block:: text
-
-    "1.16.0"         # 1.16.0 or later
-    "1.16"           # 1.16.0 or later
-    "1.16.0..1.19.0" # 1.16 through 1.19, inclusive
-
-By default, ``chplVersion`` is set to represent the current Chapel release or
-later. For example, if you are using the 1.16 release, chplVersion will be
-``1.16.0``.
-
-The ``license`` field indicates the software license under which the package is distributed.
-Any of the licenses available at the `SPDX License List <https://spdx.org/licenses/>`_ can be used for Mason packages.
-The license field defaults to ``None``.
+Format
+~~~~~~
 
 TOML is the configuration language chosen by the chapel team for
 configuring programs written in chapel. A TOML file contains the
 necessary information to build a chapel program using mason.
 View documentation for the TOML format here: `TOML Spec <https://github.com/toml-lang/toml>`_.
+
+Mason understands specific fields in the TOML file, which are described below.
+
+* ``[brick]``: This is the root table of the manifest file. It contains metadata
+  about the package itself.
+
+   * ``name``: The name of the package. This should be a unique identifier for
+     the package.
+
+   * ``type``: The type of the package. This can be
+     :ref:`application <mason-applications>`, :ref:`library <mason-libraries>`, or
+     :ref:`light <mason-lightweight-projects>`.
+
+   * ``version``: The version of the package, following semantic versioning
+     (e.g., "0.1.0").
+
+   * ``authors``: A list of authors of the package, formatted as strings.
+     Each author can be represented as a string with their name and
+     email address.
+
+   * ``chplVersion``: Indicates Chapel releases compatible with this
+     package. There are a number of accepted formats:
+
+        .. code-block:: text
+
+           "1.16.0"         # 1.16.0 or later
+           "1.16"           # 1.16.0 or later
+           "1.16.0..1.19.0" # 1.16 through 1.19, inclusive
+
+     By default, ``chplVersion`` is set to represent the current Chapel release or
+     later. For example, if you are using the 1.16 release, chplVersion will be
+     ``1.16.0``.
+
+   * ``license``: Indicates the software license under which the package is
+     distributed. Any of the licenses available at the
+     `SPDX License List <https://spdx.org/licenses/>`_ can be used for
+     Mason packages. The license field defaults to ``None``.
+
+   * ``tests``: A list of test files that are part of the package. These files
+     will be run when a user executes `mason test`.
+     See :ref:`testing-with-mason` for more information.
+
+* ``[dependencies]``: This section lists the dependencies of the package.
+  Dependencies can be listed in a few ways.
+
+   * Mason dependencies can be specified by name and version, like
+     ``myDep = '1.0.0'``. This specifies that the package depends on the
+     `myDep` package at version `1.0.0`.
+
+   * External dependencies are listed in the separate ``[system]`` section,
+     which is described below.
+
+   * Git dependencies are specified as an inline subtable with the name of
+     the dependency, for example:
+
+        .. code-block:: text
+
+           myDep = { git = "https://githib.com/username/myDep" }
+
+     This specifies that the package depends on the `myDep` package located at
+     the specified git repository URL. You can also specify a branch or a
+     specific revision of the git repository by adding `branch` or `rev` keys,
+     respectively. For example:
+
+        .. code-block:: text
+
+           myDep = { git = "https://githib.com/username/myDep", branch = "main" }
+           myDep = { git = "https://githib.com/username/myDep", rev = "43d462682851dd2fed6edf123e8fb699db124183" }
+
+     Instead of using the inline subtable syntax, you can also use the subtable
+     syntax to specify git dependencies:
+
+        .. code-block:: text
+
+           [dependencies.myDep]
+           git = "https://githib.com/username/myDep"
+           branch = "main"  # or rev = "43d462682851dd2fed6edf123e8fb699db124183"
+
+     See :ref:`mason-git-dependencies` for more information.
+
+* ``[system]``: This section is used to specify external dependencies that are
+  required for the package to build and run. These are specified as key value
+  pairs, where the key is the name of the system dependency and the value is
+  the version or other relevant information. For example:
+
+    .. code-block:: text
+
+       [system]
+       cmake = "3.18"
+
+  See :ref:`mason-external-dependencies` for more information on how to
+  specify external dependencies.
+
+* ``[examples]``: This section is used to specify example files that are
+  part of the package.
+
+   * ``examples``: A list of example files that are part of the package.
+     Files are listed relative to the ``example/`` directory
+     in the package root.
+
+* ``[examples.<example_name>]``: This section is used to specify compile
+  time and runtime arguments for a specific example file. ``<example_name>``
+  should be the name of the example module (this is the name of the file
+  without the path and without the ``.chpl`` extension).
+
+   * ``compopts``: A list of compile time arguments to be passed to the Chapel
+     compiler when building the example.
+
+   * ``execopts``: A list of runtime arguments to be passed to the example when
+     it is run.
+
+  See :ref:`mason-examples` for more information.
+
+
+Any other sections or fields in the TOML file will be ignored by Mason.
 
 The Lock File
 =============
@@ -63,6 +166,7 @@ a lock file is written below as if generated from the earlier example of a ``Mas
      license = "None"
      name = "MyPackage"
      source = "https://github.com/Spartee/MyPackage"
+     type = "application"
      version = "0.1.0"
 
 

--- a/doc/rst/tools/mason/guide/manifestfile.rst
+++ b/doc/rst/tools/mason/guide/manifestfile.rst
@@ -55,13 +55,13 @@ Mason understands specific fields in the TOML file, which are described below.
 
         .. code-block:: text
 
-           "1.16.0"         # 1.16.0 or later
-           "1.16"           # 1.16.0 or later
-           "1.16.0..1.19.0" # 1.16 through 1.19, inclusive
+           "2.1.0"         # 2.1.0 or later
+           "2.1"           # 2.1.0 or later
+           "2.1.0..2.4.0" # 2.1 through 2.4, inclusive
 
      By default, ``chplVersion`` is set to represent the current Chapel release or
-     later. For example, if you are using the 1.16 release, chplVersion will be
-     ``1.16.0``.
+     later. For example, if you are using the 2.1 release, chplVersion will be
+     ``2.1.0``.
 
    * ``license``: Indicates the software license under which the package is
      distributed. Any of the licenses available at the
@@ -87,7 +87,7 @@ Mason understands specific fields in the TOML file, which are described below.
 
         .. code-block:: text
 
-           myDep = { git = "https://githib.com/username/myDep" }
+           myDep = { git = "https://github.com/username/myDep" }
 
      This specifies that the package depends on the `myDep` package located at
      the specified git repository URL. You can also specify a branch or a
@@ -96,8 +96,8 @@ Mason understands specific fields in the TOML file, which are described below.
 
         .. code-block:: text
 
-           myDep = { git = "https://githib.com/username/myDep", branch = "main" }
-           myDep = { git = "https://githib.com/username/myDep", rev = "43d462682851dd2fed6edf123e8fb699db124183" }
+           myDep = { git = "https://github.com/username/myDep", branch = "main" }
+           myDep = { git = "https://github.com/username/myDep", rev = "43d462682851dd2fed6edf123e8fb699db124183" }
 
      Instead of using the inline subtable syntax, you can also use the subtable
      syntax to specify git dependencies:
@@ -105,7 +105,7 @@ Mason understands specific fields in the TOML file, which are described below.
         .. code-block:: text
 
            [dependencies.myDep]
-           git = "https://githib.com/username/myDep"
+           git = "https://github.com/username/myDep"
            branch = "main"  # or rev = "43d462682851dd2fed6edf123e8fb699db124183"
 
      See :ref:`mason-git-dependencies` for more information.

--- a/doc/rst/tools/mason/start/whymason.rst
+++ b/doc/rst/tools/mason/start/whymason.rst
@@ -38,6 +38,8 @@ Each of these types of mason packages serve different purposes and, to use mason
 it helps to know what each type has been designed for.
 
 
+.. _mason-applications:
+
 Mason Applications
 ~~~~~~~~~~~~~~~~~~
 A mason application, which is the default type of mason package, is meant to be a self-contained,
@@ -86,6 +88,8 @@ Some examples of when you would want to create a mason library as opposed to an 
   
 * You found some functionality missing from Chapel, and think others could benefit from your solution
 
+
+.. _mason-lightweight-projects:
 
 Mason Lightweight Projects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Expands the existing docs for Mason.toml to be more explicit about what belongs in a Mason.toml file.

Resolves https://github.com/chapel-lang/chapel/issues/13787

[Reviewed by @benharsh]