### PR TITLE
Add `doc` to the list of initial ignored files in mason

### DIFF
--- a/tools/mason/MasonNew.chpl
+++ b/tools/mason/MasonNew.chpl
@@ -156,7 +156,7 @@ proc gitInit(dirName: string, show: bool) throws {
 
 /* Adds .gitignore to library project */
 proc addGitIgnore(dirName: string) {
-  var toIgnore = "target/\nMason.lock\n";
+  var toIgnore = "target/\nMason.lock\ndoc/\n";
   var gitIgnore = open(dirName+"/.gitignore", ioMode.cw);
   var GIwriter = gitIgnore.writer(locking=false);
   GIwriter.write(toIgnore);


### PR DESCRIPTION
Adds `doc` to the gitignore generated by mason, similar to how `target` is ignored

Resolves https://github.com/chapel-lang/chapel/issues/25015

[Reviewed by @benharsh]