### PR TITLE
Fix dependencies for el9, el10, and amzn2023

### DIFF
--- a/util/packaging/rpm/amzn2023-gasnet-udp/rpmlintrc
+++ b/util/packaging/rpm/amzn2023-gasnet-udp/rpmlintrc
@@ -1,2 +1,0 @@
-from Config import *
-addFilter("E: hardcoded-library-path")

--- a/util/packaging/rpm/amzn2023-ofi-slurm/rpmlintrc
+++ b/util/packaging/rpm/amzn2023-ofi-slurm/rpmlintrc
@@ -1,2 +1,0 @@
-from Config import *
-addFilter("E: hardcoded-library-path")

--- a/util/packaging/rpm/amzn2023/Dockerfile.template
+++ b/util/packaging/rpm/amzn2023/Dockerfile.template
@@ -5,12 +5,11 @@
 @@{INJECT_BEFORE_DEPS}
 
 RUN dnf upgrade -y && \
-    dnf install -y epel-release && \
     dnf install -y --allowerasing \
       gcc gcc-c++ m4 perl python3 python3-devel bash make gawk git cmake \
       which diffutils wget vim sudo \
       llvm-devel clang clang-devel \
-      pmix-devel slurm-devel \
+      pmix-devel \
       rpm-build rpm-devel rpmlint coreutils patch rpmdevtools chrpath
 
 @@{USER_CREATION}

--- a/util/packaging/rpm/amzn2023/Dockerfile.template
+++ b/util/packaging/rpm/amzn2023/Dockerfile.template
@@ -5,12 +5,13 @@
 @@{INJECT_BEFORE_DEPS}
 
 RUN dnf upgrade -y && \
+    dnf install -y epel-release && \
     dnf install -y --allowerasing \
       gcc gcc-c++ m4 perl python3 python3-devel bash make gawk git cmake \
       which diffutils wget vim sudo \
       llvm-devel clang clang-devel \
-      rpm-build rpm-devel rpmlint coreutils patch rpmdevtools chrpath \
-      pmix-devel slurm-devel
+      pmix-devel slurm-devel \
+      rpm-build rpm-devel rpmlint coreutils patch rpmdevtools chrpath
 
 @@{USER_CREATION}
 

--- a/util/packaging/rpm/amzn2023/spec.template
+++ b/util/packaging/rpm/amzn2023/spec.template
@@ -8,7 +8,7 @@ License: Apache-2.0
 Source0: chapel-%{version}.tar.gz
 
 Requires: bash perl git llvm-devel clang clang-devel python3 python3-devel make
-Requires: pmix-devel slurm-devel
+Requires: pmix-devel
 
 %description
 Chapel Programming Language

--- a/util/packaging/rpm/amzn2023/spec.template
+++ b/util/packaging/rpm/amzn2023/spec.template
@@ -7,7 +7,8 @@ Summary: Chapel
 License: Apache-2.0
 Source0: chapel-%{version}.tar.gz
 
-Requires: bash perl git llvm-devel clang clang-devel python3 python3-devel make pmix-devel slurm-devel
+Requires: bash perl git llvm-devel clang clang-devel python3 python3-devel make
+Requires: pmix-devel slurm-devel
 
 %description
 Chapel Programming Language

--- a/util/packaging/rpm/el10-gasnet-udp/rpmlintrc
+++ b/util/packaging/rpm/el10-gasnet-udp/rpmlintrc
@@ -1,1 +1,0 @@
-from Config import *

--- a/util/packaging/rpm/el10-ofi-slurm/rpmlintrc
+++ b/util/packaging/rpm/el10-ofi-slurm/rpmlintrc
@@ -1,1 +1,0 @@
-from Config import *

--- a/util/packaging/rpm/el10/Dockerfile.template
+++ b/util/packaging/rpm/el10/Dockerfile.template
@@ -10,7 +10,7 @@ RUN dnf upgrade -y && \
       gcc gcc-c++ m4 perl python3 python3-devel bash make gawk git cmake \
       which diffutils wget vim sudo \
       llvm-devel clang clang-devel \
-      pmix-devel slurm-devel \
+      pmix-devel \
       rpm-build rpm-devel rpmlint coreutils patch rpmdevtools chrpath
 
 @@{USER_CREATION}

--- a/util/packaging/rpm/el10/Dockerfile.template
+++ b/util/packaging/rpm/el10/Dockerfile.template
@@ -5,14 +5,12 @@
 @@{INJECT_BEFORE_DEPS}
 
 RUN dnf upgrade -y && \
+    dnf install -y epel-release && \
     dnf install -y --allowerasing \
       gcc gcc-c++ m4 perl python3 python3-devel bash make gawk git cmake \
       which diffutils wget vim sudo \
       llvm-devel clang clang-devel \
-      pmix-devel slurm-devel libfabric libfabric-devel && \
-    dnf install -y --allowerasing epel-release && \
-    dnf upgrade -y && \
-    dnf install -y --allowerasing \
+      pmix-devel slurm-devel \
       rpm-build rpm-devel rpmlint coreutils patch rpmdevtools chrpath
 
 @@{USER_CREATION}

--- a/util/packaging/rpm/el10/spec.template
+++ b/util/packaging/rpm/el10/spec.template
@@ -8,7 +8,7 @@ License: Apache-2.0
 Source0: chapel-%{version}.tar.gz
 
 Requires: bash perl git llvm-devel clang clang-devel python3 python3-devel make
-Requires: pmix-devel slurm-devel
+Requires: pmix-devel
 
 %description
 Chapel Programming Language

--- a/util/packaging/rpm/el10/spec.template
+++ b/util/packaging/rpm/el10/spec.template
@@ -8,7 +8,7 @@ License: Apache-2.0
 Source0: chapel-%{version}.tar.gz
 
 Requires: bash perl git llvm-devel clang clang-devel python3 python3-devel make
-Requires: pmix-devel slurm-devel libfabric libfabric-devel
+Requires: pmix-devel slurm-devel
 
 %description
 Chapel Programming Language

--- a/util/packaging/rpm/el9-gasnet-udp/rpmlintrc
+++ b/util/packaging/rpm/el9-gasnet-udp/rpmlintrc
@@ -1,2 +1,0 @@
-from Config import *
-addFilter("E: hardcoded-library-path")

--- a/util/packaging/rpm/el9-ofi-slurm/rpmlintrc
+++ b/util/packaging/rpm/el9-ofi-slurm/rpmlintrc
@@ -1,2 +1,0 @@
-from Config import *
-addFilter("E: hardcoded-library-path")

--- a/util/packaging/rpm/el9/Dockerfile.template
+++ b/util/packaging/rpm/el9/Dockerfile.template
@@ -10,8 +10,7 @@ RUN dnf upgrade -y && \
       gcc gcc-c++ m4 perl python3 python3-devel bash make gawk git cmake \
       which diffutils wget vim sudo \
       llvm-devel clang clang-devel \
-      jemalloc jemalloc-devel gmp-devel hwloc hwloc-devel \
-      pmix-devel slurm-devel libfabric libfabric-devel \
+      pmix-devel slurm-devel \
       rpm-build rpm-devel rpmlint coreutils patch rpmdevtools chrpath
 
 @@{USER_CREATION}

--- a/util/packaging/rpm/el9/Dockerfile.template
+++ b/util/packaging/rpm/el9/Dockerfile.template
@@ -10,7 +10,7 @@ RUN dnf upgrade -y && \
       gcc gcc-c++ m4 perl python3 python3-devel bash make gawk git cmake \
       which diffutils wget vim sudo \
       llvm-devel clang clang-devel \
-      pmix-devel slurm-devel \
+      pmix-devel \
       rpm-build rpm-devel rpmlint coreutils patch rpmdevtools chrpath
 
 @@{USER_CREATION}

--- a/util/packaging/rpm/el9/spec.template
+++ b/util/packaging/rpm/el9/spec.template
@@ -8,7 +8,7 @@ License: Apache-2.0
 Source0: chapel-%{version}.tar.gz
 
 Requires: bash perl git llvm-devel clang clang-devel python3 python3-devel make
-Requires: pmix-devel slurm-devel
+Requires: pmix-devel
 
 %description
 Chapel Programming Language

--- a/util/packaging/rpm/el9/spec.template
+++ b/util/packaging/rpm/el9/spec.template
@@ -8,8 +8,7 @@ License: Apache-2.0
 Source0: chapel-%{version}.tar.gz
 
 Requires: bash perl git llvm-devel clang clang-devel python3 python3-devel make
-Requires: jemalloc jemalloc-devel gmp-devel hwloc hwloc-devel
-Requires: pmix-devel slurm-devel libfabric libfabric-devel
+Requires: pmix-devel slurm-devel
 
 %description
 Chapel Programming Language

--- a/util/packaging/rpm/fc41-gasnet-udp/rpmlintrc
+++ b/util/packaging/rpm/fc41-gasnet-udp/rpmlintrc
@@ -1,2 +1,0 @@
-from Config import *
-addFilter("E: hardcoded-library-path")

--- a/util/packaging/rpm/fc41/spec.template
+++ b/util/packaging/rpm/fc41/spec.template
@@ -8,7 +8,7 @@ License: Apache-2.0
 Source0: chapel-%{version}.tar.gz
 
 Requires: bash perl git llvm-devel clang clang-devel python3 python3-devel make
-Requires: pmix-devel slurm-devel
+Requires: pmix-devel
 
 %description
 Chapel Programming Language

--- a/util/packaging/rpm/fc41/spec.template
+++ b/util/packaging/rpm/fc41/spec.template
@@ -8,6 +8,7 @@ License: Apache-2.0
 Source0: chapel-%{version}.tar.gz
 
 Requires: bash perl git llvm-devel clang clang-devel python3 python3-devel make
+Requires: pmix-devel slurm-devel
 
 %description
 Chapel Programming Language

--- a/util/packaging/rpm/fc42-gasnet-udp/rpmlintrc
+++ b/util/packaging/rpm/fc42-gasnet-udp/rpmlintrc
@@ -1,2 +1,0 @@
-from Config import *
-addFilter("E: hardcoded-library-path")

--- a/util/packaging/rpm/fc42/spec.template
+++ b/util/packaging/rpm/fc42/spec.template
@@ -8,7 +8,7 @@ License: Apache-2.0
 Source0: chapel-%{version}.tar.gz
 
 Requires: bash perl git llvm-devel clang clang-devel python3 python3-devel make
-Requires: pmix-devel slurm-devel
+Requires: pmix-devel
 
 %description
 Chapel Programming Language

--- a/util/packaging/rpm/fc42/spec.template
+++ b/util/packaging/rpm/fc42/spec.template
@@ -8,6 +8,7 @@ License: Apache-2.0
 Source0: chapel-%{version}.tar.gz
 
 Requires: bash perl git llvm-devel clang clang-devel python3 python3-devel make
+Requires: pmix-devel slurm-devel
 
 %description
 Chapel Programming Language


### PR DESCRIPTION
Fixes some OS dependencies which were broken in https://github.com/chapel-lang/chapel/pull/25340.

The "fix" is to remove `slurm-devel` as a dependency, this still allows the package to build everything and be installed. Just if a user tries to run a compiled chapel progam using `slurm-srun` they will not be able to (which was the case before, they need to have slurm installed AND configured properly)

For simplicity, this PR also removes a few other dependencies that are not being used yet

- [x] tested el10

Also cleaned up some files that were left behind due to conflicting PRs

[Reviewed by @arifthpe]