### PR TITLE
Skip two tests with older LLVMs

### DIFF
--- a/test/llvm/alignment/check-align16.skipif
+++ b/test/llvm/alignment/check-align16.skipif
@@ -1,0 +1,2 @@
+# compiler segfaults with LLVM 12
+CHPL_LLVM_VERSION==12

--- a/test/llvm/debugInfo/lldb/targetVar.skipif
+++ b/test/llvm/debugInfo/lldb/targetVar.skipif
@@ -4,3 +4,7 @@ COMPOPTS <= --fast
 COMPOPTS <= --baseline
 # valgrind messes up output
 CHPL_TEST_VGRND_EXE == on
+
+# older LLVM's don't support the right dwarf info
+CHPL_LLVM_VERSION==11
+CHPL_LLVM_VERSION==12


### PR DESCRIPTION
Skips two tests that fail with older LLVMs

Both of these LLVMs will likely be removed when resolving https://github.com/chapel-lang/chapel/issues/27269, so this is not a huge priority to fix these tests for old LLVMs

[Not reviewed - trivial]