### PR TITLE
Fix chpldoc indentation of documentation text for methods on nested types

### DIFF
--- a/test/chpldoc/nested.doc.chpl
+++ b/test/chpldoc/nested.doc.chpl
@@ -32,8 +32,81 @@ record R {
 
   */
   record Inner {
-    /* Inner Method. */
+    /*
+       Inner Method.
+
+       Multiline comment.
+    */
     proc innerMethod() {
+    }
+
+    /*
+      Documentation for ``InnerMost``
+
+      .. code-block:: text
+
+        This code-block should not overflow to 'innerMostMethod'!
+
+    */
+    record InnerMost {
+      /*
+         InnerMost Method.
+
+         Multiline comment.
+      */
+      proc innerMostMethod() {
+      }
+    }
+  }
+}
+
+/*
+  Documentation for class C.
+
+  .. code-block:: text
+
+    a code block!
+*/
+class C {
+  var x : int;
+
+  /* Document 'foo' */
+  proc foo() {
+  }
+
+  /*
+    Documentation for ``Inner``
+
+    .. code-block:: text
+
+      This code-block should not overflow to 'innerMethod'!
+
+  */
+  class Inner {
+    /*
+       Inner Method.
+
+       Multiline comment.
+    */
+    proc innerMethod() {
+    }
+
+    /*
+      Documentation for ``InnerMost``
+
+      .. code-block:: text
+
+        This code-block should not overflow to 'innerMostMethod'!
+
+    */
+    class InnerMost {
+      /*
+         InnerMost Method.
+
+         Multiline comment.
+      */
+      proc innerMostMethod() {
+      }
     }
   }
 }

--- a/test/chpldoc/nested.doc.good
+++ b/test/chpldoc/nested.doc.good
@@ -45,5 +45,81 @@ or
 
       .. method:: proc innerMethod()
 
-      Inner Method. 
+         
+         Inner Method.
+         
+         Multiline comment.
+         
+
+      .. record:: InnerMost
+
+         
+         Documentation for ``InnerMost``
+         
+         .. code-block:: text
+         
+           This code-block should not overflow to 'innerMostMethod'!
+         
+         
+
+         .. method:: proc innerMostMethod()
+
+            
+            InnerMost Method.
+            
+            Multiline comment.
+            
+
+.. class:: C
+
+   
+   Documentation for class C.
+   
+   .. code-block:: text
+   
+     a code block!
+
+   .. attribute:: var x: int
+
+   .. method:: proc foo()
+
+      Document 'foo' 
+
+   .. class:: Inner
+
+      
+      Documentation for ``Inner``
+      
+      .. code-block:: text
+      
+        This code-block should not overflow to 'innerMethod'!
+      
+      
+
+      .. method:: proc innerMethod()
+
+         
+         Inner Method.
+         
+         Multiline comment.
+         
+
+      .. class:: InnerMost
+
+         
+         Documentation for ``InnerMost``
+         
+         .. code-block:: text
+         
+           This code-block should not overflow to 'innerMostMethod'!
+         
+         
+
+         .. method:: proc innerMostMethod()
+
+            
+            InnerMost Method.
+            
+            Multiline comment.
+            
 


### PR DESCRIPTION
This PR fixes a bug with the indentation of documentation for nested type methods, which previously was not being indented. Previously, in #23558, I made a fix focused on nested types, but failed to recognize the issue would apply to methods on those types as well.

The solution here is to increment the indentation depth for both the nested type and its children, _and_ to carry over that indentation depth through calls to ``rstDoc``.

Before, ``rstDoc`` would start from a depth of 1 and relied on the way that child documentation was combined to get correct indentation. When ``rstDoc`` returns, the result is stored in a list of children objects. Later, when we go to process those children, we increment the indentation depth before printing their contents. This only works if the child has a single line of documentation, and does not account for multiline docs. This means we need to get the indentation right before this processing step (i.e. ``RstResult::output``).

Resolves https://github.com/chapel-lang/chapel/issues/25540

Testing:
- [x] paratest
- [x] diff'd 'make docs' results before and after (whitespace indentation improvements to IO serialization docs)