### PR TITLE
Add a workaround for fedora LLVM not finding stddef.h

### DIFF
--- a/util/chplenv/chpl_platform.py
+++ b/util/chplenv/chpl_platform.py
@@ -67,6 +67,16 @@ def get(flag='host'):
 
     return platform_val
 
+@memoize
+def get_linux_distribution():
+    distribution = 'unknown'
+    try:
+        os_release = platform.freedesktop_os_release()
+    except OSError:
+        os_release = dict()
+
+    distribution = os_release.get('ID', distribution).lower()
+    return distribution
 
 @memoize
 def is_wsl():


### PR DESCRIPTION
Adds a workaround for fedora LLVM not finding stddef.h. The solution is to infer and explicitly pass `-resource-dir`.

Tested on Fedora 42 with LLVM 20.1.7 and LLVM 20.1.6

Resolves https://github.com/chapel-lang/chapel/issues/27417

[Reviewed by @]