### PR TITLE
Exclude AutoGPU from the docs

### DIFF
--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -182,7 +182,7 @@ exclude_patterns = ['Makefile',
                     'builtins/SharedObject.rst',
                     'builtins/String.rst',
                     'modules/standard/AutoMath.rst',
-                    'modules/standard/AutoGPU.rst',
+                    'modules/standard/AutoGpu.rst',
                     'modules/standard/ChapelIO.rst',
                     'modules/standard/ChapelSysCTypes.rst',
 

--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -182,6 +182,7 @@ exclude_patterns = ['Makefile',
                     'builtins/SharedObject.rst',
                     'builtins/String.rst',
                     'modules/standard/AutoMath.rst',
+                    'modules/standard/AutoGPU.rst',
                     'modules/standard/ChapelIO.rst',
                     'modules/standard/ChapelSysCTypes.rst',
 


### PR DESCRIPTION
Exclude AutoGPU from the docs, since it is `include`d in the GPU docs. This prevents AutoGPU from showing up in search results.

[Reviewed by @lydia-duncan]