### PR TITLE
Fixes get_llvm_clang when specifying multiple args to `CC`

### DIFF
--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -601,7 +601,7 @@ def get_llvm_clang_noargs(lang):
     # if it was provided by a user setting, just use that
     provided = get_overriden_llvm_clang(lang)
     if provided:
-        return provided
+        return provided[0]
 
     clang = None
     llvm_val = get()
@@ -619,6 +619,11 @@ def get_llvm_clang_noargs(lang):
 # then necessary arguments
 @memoize
 def get_llvm_clang(lang):
+
+    # if it was provided by a user setting, just use that
+    provided = get_overriden_llvm_clang(lang)
+    if provided:
+        return provided
 
     clang = get_llvm_clang_noargs(lang)
     if not clang:


### PR DESCRIPTION
Fixes an issue introduced by https://github.com/chapel-lang/chapel/pull/27443 a function was expecting a string but could sometimes get a list of strings instead

This was caused by the loss of some logic around `get_overriden_llvm_clang` when implementing #27443

[Reviewed by @]

