### PR TITLE
Resolve TODO in `Map` docs

### DIFF
--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -391,10 +391,21 @@ module Map {
                       '`parSafe=true`', 2);
     }
 
+    @chpldoc.nodoc
+    proc ref this(k: keyType) ref
+      where isDefaultInitializable(valType) {
+      _warnForParSafeIndexing();
 
-    // TODO (Jade 11/6/23): This doc comment should go on the `this` overload
-    // without `where` that is marked `throws`. However, there is a current
-    // limitation in chpldoc with return intents and `throws` (#23776)
+      _enter(); defer _leave();
+
+      var (_, slot) = table.findAvailableSlot(k);
+      if !table.isSlotFull(slot) {
+        var val: valType;
+        table.fillSlot(slot, k, val);
+      }
+      return table.table[slot].val;
+    }
+
     /*
       If the key exists in the map, get a reference to the value mapped
       to the given key. If the key does not exist in the map, the value
@@ -414,21 +425,6 @@ module Map {
 
       :returns: Reference to the value mapped to the given key.
     */
-    proc ref this(k: keyType) ref
-      where isDefaultInitializable(valType) {
-      _warnForParSafeIndexing();
-
-      _enter(); defer _leave();
-
-      var (_, slot) = table.findAvailableSlot(k);
-      if !table.isSlotFull(slot) {
-        var val: valType;
-        table.fillSlot(slot, k, val);
-      }
-      return table.table[slot].val;
-    }
-
-    @chpldoc.nodoc
     proc ref this(k: keyType) ref throws {
       _warnForParSafeIndexing();
 


### PR DESCRIPTION
Resolves a TODO in the `Map` docs which was blocked by a chpldoc/chapeldomain bug. That [bug](https://github.com/chapel-lang/chapel/issues/23776) is fixed with https://github.com/chapel-lang/sphinxcontrib-chapeldomain/pull/103 and https://github.com/chapel-lang/chapel/pull/27468, so the TODO can be resolved

[Reviewed by @ShreyasKhandekar]