### PR TITLE
Fix bash script for finding llvm FileCheck

### DIFF
--- a/test/llvm/PREDIFF
+++ b/test/llvm/PREDIFF
@@ -13,7 +13,7 @@ TMPFILE="$OUTFILE.prediff.tmp"
 LLVM_CONFIG=`${CHPL_HOME}/util/chplenv/chpl_llvm.py --llvm-config`
 BINDIR=`${LLVM_CONFIG} --bindir`
 FILECHECK="${BINDIR}/FileCheck"
-if [ command -v $FILECHECK >/dev/null ]; then
+if command -v $FILECHECK >/dev/null; then
   FILECHECK=`command -v $FILECHECK`
 else
   PREFIX=`${LLVM_CONFIG} --prefix`


### PR DESCRIPTION
Fixes a bad bash script that was resulting in us being unable to find FileCheck.

I failed to notice this in my testing because the script would fall back to another install of FileCheck on some systems, and so the bad bash scripting went unnoticed.

[not reviewed]