### PR TITLE
Simplify package building helpers

### DIFF
--- a/util/cron/create_release_aptrpm.bash
+++ b/util/cron/create_release_aptrpm.bash
@@ -50,6 +50,10 @@ fi
 if [ $(__package_type_from_os $OS) == "apt" ]; then
   apt_conf="./util/packaging/common/apt.conf"
   rm -f $apt_conf
+
+  if [ -z "$PROXY_ADDRESS_FOR_HTTP" ]; then echo "PROXY_ADDRESS_FOR_HTTP must be set."; exit 1; fi
+  if [ -z "$PROXY_ADDRESS_FOR_HTTPS" ]; then echo "PROXY_ADDRESS_FOR_HTTPS must be set."; exit 1; fi
+
   echo "Acquire::http::proxy \"$PROXY_ADDRESS_FOR_HTTP\";" >> $apt_conf
   echo "Acquire::https::proxy \"$PROXY_ADDRESS_FOR_HTTPS\";" >> $apt_conf
   export INJECT_BEFORE_DEPS="COPY ./common/apt.conf /etc/apt/apt.conf"

--- a/util/cron/create_release_aptrpm.bash
+++ b/util/cron/create_release_aptrpm.bash
@@ -5,12 +5,9 @@
 # Argument are set via the environment:
 #   CHPL_VERSION: The version of the release to create.
 #   CHPL_TARBALL: The location of the tarball to use. If not set, the tarball will be downloaded.
-#   PACKAGE_TYPE: The type of package to build. Either 'apt' or 'rpm'.
 #   OS: The OS to build the package for. e.g. 'ubuntu22'
 #   PACKAGE_NAME: The name of the package to build. e.g. 'chapel'
 #   PACKAGE_VERSION: The version of the package to build, usually this is '1'
-#   DOCKER_DIR_NAME: The name of the directory in util/packaging/{PACKAGE_TYPE} that contains the Dockerfile to use.
-#   DOCKER_IMAGE_BASE: The name of the Docker image to use, including tag.
 #   PARALLEL: The number of cores to use for building the package. Default is 1.
 
 #
@@ -47,6 +44,15 @@ if [ -n "$CHPL_TARBALL" ]; then
   log_info "Using local tarball: $CHPL_TARBALL"
   mkdir -p $CHPL_HOME/util/packaging/tarballs
   cp $CHPL_TARBALL $CHPL_HOME/util/packaging/tarballs/chapel-${CHPL_VERSION}.tar.gz
+fi
+
+# For debian builds, setup some extra proxy/network information
+if [ $(__package_type_from_os $OS) == "apt" ]; then
+  apt_conf="./util/packaging/common/apt.conf"
+  rm -f $apt_conf
+  echo "Acquire::http::proxy \"$PROXY_ADDRESS_FOR_HTTP\";" >> $apt_conf
+  echo "Acquire::https::proxy \"$PROXY_ADDRESS_FOR_HTTP\";" >> $apt_conf
+  export INJECT_BEFORE_DEPS="COPY ./common/apt.conf /etc/apt/apt.conf"
 fi
 
 # if BUILD_CROSS_PLATFORM is set, build the cross-platform package

--- a/util/cron/create_release_aptrpm.bash
+++ b/util/cron/create_release_aptrpm.bash
@@ -17,12 +17,9 @@
 # Arguments
 #
 if [ -z "$CHPL_VERSION" ]; then echo "CHPL_VERSION must be set."; exit 1; fi
-if [ -z "$PACKAGE_TYPE" ]; then echo "PACKAGE_TYPE must be set."; exit 1; fi
 if [ -z "$OS" ]; then echo "OS must be set."; exit 1; fi
 if [ -z "$PACKAGE_NAME" ]; then echo "PACKAGE_NAME must be set."; exit 1; fi
 if [ -z "$PACKAGE_VERSION" ]; then echo "PACKAGE_VERSION must be set."; exit 1; fi
-if [ -z "$DOCKER_DIR_NAME" ]; then echo "DOCKER_DIR_NAME must be set."; exit 1; fi
-if [ -z "$DOCKER_IMAGE_BASE" ]; then echo "DOCKER_IMAGE_BASE must be set."; exit 1; fi
 PARALLEL=${PARALLEL:-1}
 
 
@@ -55,10 +52,10 @@ fi
 # if BUILD_CROSS_PLATFORM is set, build the cross-platform package
 if [ -n "$BUILD_CROSS_PLATFORM" ]; then
   log_info "Building cross-platform $PACKAGE_NAME $PACKAGE_TYPE package on $OS"
-  __build_all_packages $PACKAGE_TYPE $OS $PACKAGE_NAME $CHPL_VERSION $PACKAGE_VERSION $DOCKER_DIR_NAME $DOCKER_IMAGE_BASE $PARALLEL
+  __build_all_packages $OS $PACKAGE_NAME $CHPL_VERSION $PACKAGE_VERSION $PARALLEL
 else
   log_info "Building $PACKAGE_NAME $PACKAGE_TYPE package on $OS"
-  __build_native_package $PACKAGE_TYPE $OS $PACKAGE_NAME $CHPL_VERSION $PACKAGE_VERSION $DOCKER_DIR_NAME $DOCKER_IMAGE_BASE $PARALLEL
+  __build_native_package $OS $PACKAGE_NAME $CHPL_VERSION $PACKAGE_VERSION $PARALLEL
 fi
 
 log_info "Testing $PACKAGE_NAME"

--- a/util/cron/create_release_aptrpm.bash
+++ b/util/cron/create_release_aptrpm.bash
@@ -51,7 +51,7 @@ if [ $(__package_type_from_os $OS) == "apt" ]; then
   apt_conf="./util/packaging/common/apt.conf"
   rm -f $apt_conf
   echo "Acquire::http::proxy \"$PROXY_ADDRESS_FOR_HTTP\";" >> $apt_conf
-  echo "Acquire::https::proxy \"$PROXY_ADDRESS_FOR_HTTP\";" >> $apt_conf
+  echo "Acquire::https::proxy \"$PROXY_ADDRESS_FOR_HTTPS\";" >> $apt_conf
   export INJECT_BEFORE_DEPS="COPY ./common/apt.conf /etc/apt/apt.conf"
 fi
 

--- a/util/packaging/common/.gitignore
+++ b/util/packaging/common/.gitignore
@@ -1,0 +1,1 @@
+apt.conf

--- a/util/packaging/common/build_helpers.sh
+++ b/util/packaging/common/build_helpers.sh
@@ -75,28 +75,28 @@ __wget_chpl_release() {
 }
 
 __build_all_packages() {
-  if [[ $# -ne 4 && $# -ne 5 ]]; then
-    echo "Usage: __build_packages <os> <package_name> <chapel_version> <package_version> <para>"
+  if [[ $# -ne 5 ]]; then
+    echo "Usage: __build_all_packages <os> <package_name> <chapel_version> <package_version> <para>"
     return
   fi
   __build_packages $1 $2 $3 $4 '--platform=linux/amd64,linux/arm64' $5
 }
 __build_x8664_package() {
-  if [[ $# -ne 4 && $# -ne 5 ]]; then
-    echo "Usage: __build_packages <os> <package_name> <chapel_version> <package_version> <para>"
+  if [[ $# -ne 5 ]]; then
+    echo "Usage: __build_x8664_package <os> <package_name> <chapel_version> <package_version> <para>"
     return
   fi
   __build_packages $1 $2 $3 $4 '--platform=linux/amd64' $5
 }
 __build_arm64_package() {
-  if [[ $# -ne 4 && $# -ne 5 ]]; then
-    echo "Usage: __build_packages <os> <package_name> <chapel_version> <package_version> <para>"
+  if [[ $# -ne 5 ]]; then
+    echo "Usage: __build_arm64_package <os> <package_name> <chapel_version> <package_version> <para>"
     return
   fi
   __build_packages $1 $2 $3 $4 '--platform=linux/arm64' $5
 }
 __build_native_package() {
-  if [[ $# -ne 4 && $# -ne 5 ]]; then
+  if [[ $# -ne 5 ]]; then
     echo "Usage: __build_packages <os> <package_name> <chapel_version> <package_version> <para>"
     return
   fi
@@ -104,14 +104,12 @@ __build_native_package() {
 }
 
 __build_packages() {
-  # use this to build a container image for local testing
   local os=$1
   local package_name=$2
   local chapel_version=$3
   local package_version=$4
   local architecture_string=$5
-  # default to 1 core
-  local para=${6:-1}
+  local para=$6
   local pkg_type=$(__package_type_from_os $os)
   local docker_dir_name=$os
   local docker_image_base=$(__docker_image_from_os $os)
@@ -165,8 +163,7 @@ __build_image() {
   local package_name=$2
   local chapel_version=$3
   local package_version=$4
-  # default to 1 core
-  local para=${5:-1}
+  local para=$5
   local pkg_type=$(__package_type_from_dir $os)
   local docker_dir_name=$os
   local docker_image_base=$(__docker_image_from_dir $os)

--- a/util/packaging/common/build_helpers.sh
+++ b/util/packaging/common/build_helpers.sh
@@ -21,6 +21,7 @@ __package_type_from_os() {
     ;;
     *)
     pkg_type="unknown"
+    exit 1
     ;;
   esac
   echo $pkg_type
@@ -57,6 +58,7 @@ __docker_image_from_os() {
     ;;
     *)
     docker_image_base="unknown"
+    exit 1
     ;;
   esac
   echo $docker_image_base
@@ -172,9 +174,9 @@ __build_image() {
   local chapel_version=$3
   local package_version=$4
   local para=$5
-  local pkg_type=$(__package_type_from_dir $os)
+  local pkg_type=$(__package_type_from_os $os)
   local docker_dir_name=$os
-  local docker_image_base=$(__docker_image_from_dir $os)
+  local docker_image_base=$(__docker_image_from_os $os)
 
   if [ $pkg_type = "unknown" ]; then
     echo "Unknown package type for OS $os"

--- a/util/packaging/common/build_helpers.sh
+++ b/util/packaging/common/build_helpers.sh
@@ -114,6 +114,14 @@ __build_packages() {
   local docker_dir_name=$os
   local docker_image_base=$(__docker_image_from_os $os)
 
+  if [ $pkg_type = "unknown" ]; then
+    echo "Unknown package type for OS $os"
+    return 1
+  fi
+  if [ -z "$docker_image_base" ]; then
+    echo "Unknown docker image base for OS $os"
+    return 1
+  fi
 
   __wget_chpl_release $chapel_version
 
@@ -167,6 +175,15 @@ __build_image() {
   local pkg_type=$(__package_type_from_dir $os)
   local docker_dir_name=$os
   local docker_image_base=$(__docker_image_from_dir $os)
+
+  if [ $pkg_type = "unknown" ]; then
+    echo "Unknown package type for OS $os"
+    return 1
+  fi
+  if [ -z "$docker_image_base" ]; then
+    echo "Unknown docker image base for OS $os"
+    return 1
+  fi
 
   __wget_chpl_release $chapel_version
 

--- a/util/packaging/common/build_helpers.sh
+++ b/util/packaging/common/build_helpers.sh
@@ -21,7 +21,6 @@ __package_type_from_os() {
     ;;
     *)
     pkg_type="unknown"
-    exit 1
     ;;
   esac
   echo $pkg_type
@@ -58,7 +57,6 @@ __docker_image_from_os() {
     ;;
     *)
     docker_image_base="unknown"
-    exit 1
     ;;
   esac
   echo $docker_image_base

--- a/util/packaging/common/build_helpers.sh
+++ b/util/packaging/common/build_helpers.sh
@@ -6,7 +6,60 @@ __get_docker_tag() {
   local chapel_version=$3
   local package_version=$4
 
-  __docker_tag="chapel/${package_name}-${chapel_version}-${os}:${package_version}"
+  echo "chapel/${package_name}-${chapel_version}-${os}:${package_version}"
+}
+
+
+__package_type_from_os() {
+  local pkg_type
+  case $1 in
+    "amzn2023" | "fc41" | "fc42" | "el9" | "el10")
+    pkg_type="rpm"
+    ;;
+    "debian11" | "debian12" | "ubuntu22" | "ubuntu24")
+    pkg_type="apt"
+    ;;
+    *)
+    pkg_type="unknown"
+    ;;
+  esac
+  echo $pkg_type
+}
+__docker_image_from_os() {
+  local docker_image_base
+  case $1 in
+    "amzn2023")
+    docker_image_base="amazonlinux:2023"
+    ;;
+    "fc41")
+    docker_image_base="fedora:41"
+    ;;
+    "fc42")
+    docker_image_base="fedora:42"
+    ;;
+    "el9")
+    docker_image_base="rockylinux/rockylinux:9"
+    ;;
+    "el10")
+    docker_image_base="almalinux:10"
+    ;;
+    "debian11")
+    docker_image_base="debian:11"
+    ;;
+    "debian12")
+    docker_image_base="debian:12"
+    ;;
+    "ubuntu22")
+    docker_image_base="ubuntu:22.04"
+    ;;
+    "ubuntu24")
+    docker_image_base="ubuntu:24.04"
+    ;;
+    *)
+    docker_image_base="unknown"
+    ;;
+  esac
+  echo $docker_image_base
 }
 
 __wget_chpl_release() {
@@ -22,36 +75,53 @@ __wget_chpl_release() {
 }
 
 __build_all_packages() {
-  __build_packages $1 $2 $3 $4 $5 $6 $7 '--platform=linux/amd64,linux/arm64' $8
+  if [[ $# -ne 4 && $# -ne 5 ]]; then
+    echo "Usage: __build_packages <os> <package_name> <chapel_version> <package_version> <para>"
+    return
+  fi
+  __build_packages $1 $2 $3 $4 '--platform=linux/amd64,linux/arm64' $5
 }
 __build_x8664_package() {
-  __build_packages $1 $2 $3 $4 $5 $6 $7 '--platform=linux/amd64' $8
+  if [[ $# -ne 4 && $# -ne 5 ]]; then
+    echo "Usage: __build_packages <os> <package_name> <chapel_version> <package_version> <para>"
+    return
+  fi
+  __build_packages $1 $2 $3 $4 '--platform=linux/amd64' $5
 }
 __build_arm64_package() {
-  __build_packages $1 $2 $3 $4 $5 $6 $7 '--platform=linux/arm64' $8
+  if [[ $# -ne 4 && $# -ne 5 ]]; then
+    echo "Usage: __build_packages <os> <package_name> <chapel_version> <package_version> <para>"
+    return
+  fi
+  __build_packages $1 $2 $3 $4 '--platform=linux/arm64' $5
 }
 __build_native_package() {
-  __build_packages $1 $2 $3 $4 $5 $6 $7 '' $8
+  if [[ $# -ne 4 && $# -ne 5 ]]; then
+    echo "Usage: __build_packages <os> <package_name> <chapel_version> <package_version> <para>"
+    return
+  fi
+  __build_packages $1 $2 $3 $4 '' $5
 }
 
 __build_packages() {
-  local pkg_type=$1
-  local os=$2
-  local package_name=$3
-  local chapel_version=$4
-  local package_version=$5
-  local docker_dir_name=$6
-  local docker_image_base=$7
-  local architecture_string=$8
-
+  # use this to build a container image for local testing
+  local os=$1
+  local package_name=$2
+  local chapel_version=$3
+  local package_version=$4
+  local architecture_string=$5
   # default to 1 core
-  local para=${9:-1}
+  local para=${6:-1}
+  local pkg_type=$(__package_type_from_os $os)
+  local docker_dir_name=$os
+  local docker_image_base=$(__docker_image_from_os $os)
+
 
   __wget_chpl_release $chapel_version
 
   local package_dir="${CHPL_HOME}/util/packaging/${pkg_type}/${docker_dir_name}"
   local fill_script="${CHPL_HOME}/util/packaging/${pkg_type}/common/fill_docker_template.py"
-  __get_docker_tag $os $package_name $chapel_version $package_version
+  docker_tag=$(__get_docker_tag $os $package_name $chapel_version $package_version)
 
   pushd ${package_dir}
 
@@ -84,29 +154,28 @@ __build_packages() {
     --build-arg "DOCKER_DIR_NAME=$docker_dir_name" \
     --build-arg "DOCKER_IMAGE_NAME_FULL=$docker_image_name_full" \
     --build-arg "PARALLEL=$para" \
-    -t $__docker_tag \
+    -t $docker_tag \
     -f Dockerfile ../..
   popd
 }
 
 __build_image() {
   # use this to build a container image for local testing
-  local pkg_type=$1
-  local os=$2
-  local package_name=$3
-  local chapel_version=$4
-  local package_version=$5
-  local docker_dir_name=$6
-  local docker_image_base=$7
-
+  local os=$1
+  local package_name=$2
+  local chapel_version=$3
+  local package_version=$4
   # default to 1 core
-  local para=${8:-1}
+  local para=${5:-1}
+  local pkg_type=$(__package_type_from_dir $os)
+  local docker_dir_name=$os
+  local docker_image_base=$(__docker_image_from_dir $os)
 
   __wget_chpl_release $chapel_version
 
   local package_dir="${CHPL_HOME}/util/packaging/${pkg_type}/${docker_dir_name}"
   local fill_script="${CHPL_HOME}/util/packaging/${pkg_type}/common/fill_docker_template.py"
-  __get_docker_tag $os $package_name $chapel_version $package_version
+  docker_tag=$(__get_docker_tag $os $package_name $chapel_version $package_version)
 
   pushd ${package_dir}
 
@@ -137,7 +206,7 @@ __build_image() {
     --build-arg "DOCKER_DIR_NAME=$docker_dir_name" \
     --build-arg "DOCKER_IMAGE_NAME_FULL=$docker_image_name_full" \
     --build-arg "PARALLEL=$para" \
-    -t $__docker_tag \
+    -t $docker_tag \
     -f Dockerfile ../..
   popd
 }
@@ -147,9 +216,9 @@ __run_container() {
   local chapel_version=$3
   local package_version=$4
 
-  __get_docker_tag $os $package_name $chapel_version $package_version
+  docker_tag=$(__get_docker_tag $os $package_name $chapel_version $package_version)
 
-  docker run -it --rm $__docker_tag
+  docker run -it --rm $docker_tag
 }
 
 __test_package() {


### PR DESCRIPTION
Simplifies packaging building helpers to make the code more maintainable in the future and easier to diagnose issues with it.

This creates less places someone needs to update files to add new OSes, and makes the command much simpler and easier to remember (with a help message when its wrong)

[Reviewed by @arifthpe]