### PR TITLE
Update CI image to a newer OS/package depedencies

### DIFF
--- a/util/packaging/docker/github-ci/Dockerfile
+++ b/util/packaging/docker/github-ci/Dockerfile
@@ -8,19 +8,19 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
     bash \
-    clang \
+    clang-19 \
     cmake \
     cscope \
     doxygen \
     g++ \
     gcc \
     git \
-    libclang-dev \
-    libclang-cpp-dev \
+    libclang-19-dev \
+    libclang-cpp19-dev \
     libedit-dev \
-    llvm \
-    llvm-dev \
-    llvm-tools \
+    llvm-19 \
+    llvm-19-dev \
+    llvm-19-tools \
     locales \
     m4 \
     make \

--- a/util/packaging/docker/github-ci/Dockerfile
+++ b/util/packaging/docker/github-ci/Dockerfile
@@ -2,7 +2,7 @@
 # tzdata is necessary for util/test/check_annotations.py to function properly (get the right dates)
 # locales is necessary for util/buildRelease/smokeTest docs
 
-FROM ubuntu:24.10
+FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/util/packaging/docker/github-ci/Dockerfile
+++ b/util/packaging/docker/github-ci/Dockerfile
@@ -2,26 +2,25 @@
 # tzdata is necessary for util/test/check_annotations.py to function properly (get the right dates)
 # locales is necessary for util/buildRelease/smokeTest docs
 
-# We use 22.04 to get llvm-13
-FROM ubuntu:22.04
+FROM ubuntu:24.10
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
     bash \
-    clang-13 \
+    clang \
     cmake \
     cscope \
     doxygen \
     g++ \
     gcc \
     git \
-    libclang-13-dev \
-    libclang-cpp13-dev \
+    libclang-dev \
+    libclang-cpp-dev \
     libedit-dev \
-    llvm-13 \
-    llvm-13-dev \
-    llvm-13-tools \
+    llvm \
+    llvm-dev \
+    llvm-tools \
     locales \
     m4 \
     make \


### PR DESCRIPTION
Updates the CI image to use newer dependencies.

Updates from LLVM/clang 13 to 19. To do this, also updates the OS from Ubuntu 22 LTS to Ubuntu 24 LTS. This is required to [drop support for older LLVMs](https://github.com/chapel-lang/chapel/issues/27269)

[Reviewed by @arifthpe]