### PR TITLE
Revert 27463 due to dependency issues

### DIFF
--- a/util/packaging/docker/github-ci/Dockerfile
+++ b/util/packaging/docker/github-ci/Dockerfile
@@ -2,25 +2,25 @@
 # tzdata is necessary for util/test/check_annotations.py to function properly (get the right dates)
 # locales is necessary for util/buildRelease/smokeTest docs
 
-FROM ubuntu:24.04
+FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
     bash \
-    clang-19 \
+    clang-13 \
     cmake \
     cscope \
     doxygen \
     g++ \
     gcc \
     git \
-    libclang-19-dev \
-    libclang-cpp19-dev \
+    libclang-13-dev \
+    libclang-cpp13-dev \
     libedit-dev \
-    llvm-19 \
-    llvm-19-dev \
-    llvm-19-tools \
+    llvm-13 \
+    llvm-13-dev \
+    llvm-13-tools \
     locales \
     m4 \
     make \


### PR DESCRIPTION
Reverts https://github.com/chapel-lang/chapel/pull/27463, because I missed that some CI checks explicitly used clang-13

Once I resolve that, I will redo this. But reverting for now to avoid breaking the CI for others

[Reviewed by @arifthpe]