### PR TITLE
Use all fields in `AstListNoCommentsIterator.operator==`

### DIFF
--- a/frontend/include/chpl/uast/Comment.h
+++ b/frontend/include/chpl/uast/Comment.h
@@ -147,7 +147,7 @@ class AstListNoCommentsIterator {
            this->end == rhs.end;
   }
   bool operator!=(const AstListNoCommentsIterator<CastToType> rhs) const {
-    return this->it != rhs.it;
+    return !(*this == rhs);
   }
 
   // needs to support * and ->


### PR DESCRIPTION
Add some fields to this `==` that were previously absent, failing linter checks.

This started getting caught by the linter as of https://github.com/chapel-lang/chapel/pull/27465.

Additionally adjust `operator!=` to just return the negation of `operator==`, where it previously returned the negation of the old body of `operator==`.

[trivial, not reviewed]

Testing:
- [ ] dyno tests
- [ ] dyno tests with the following temporarily added to `operator==`, to rule out behavior changes: `this->it != rhs.it || (this->begin == rhs.begin && this->end == rhs.end)`
- [ ] paratest