### PR TITLE
Document CHPL_RT_COMM_OFI_DEDICATED_AMH_CORES=true

### DIFF
--- a/doc/rst/platforms/aws.rst
+++ b/doc/rst/platforms/aws.rst
@@ -306,6 +306,8 @@ Chapel code. Users may wish to add this to their ``.bashrc``:
    export CHPL_RT_COMM_OFI_DEDICATED_AMH_CORES=true
    export CHPL_RT_COMM_OFI_CONNECT_EAGERLY=true
 
+See also :ref:`readme-libfabric-CHPL_RT_COMM_OFI_DEDICATED_AMH_CORES` and
+:ref:`readme-libfabric-CHPL_RT_COMM_OFI_CONNECT_EAGERLY`.
 
 For best performance, users should also set ``export
 FI_EFA_USE_DEVICE_RDMA=1``. This enables higher network performance by using

--- a/doc/rst/platforms/comm-layers/libfabric.rst
+++ b/doc/rst/platforms/comm-layers/libfabric.rst
@@ -318,6 +318,25 @@ across the nodes assigned to the job.  Overloading can still be an issue
 if there are more Chapel locales (program instances) than nodes in the
 slurm job, however.
 
+Other Settings
+--------------
+
+Setting these two environment variables can improve performance.
+
+.. code-block:: bash
+
+   export CHPL_RT_COMM_OFI_DEDICATED_AMH_CORES=true
+   export CHPL_RT_COMM_OFI_CONNECT_EAGERLY=true
+
+Setting ``CHPL_RT_COMM_OFI_DEDICATED_AMH_CORES=true`` will
+dedicate a core to the active message handler progress thread. For
+example, when using ``CHPL_RT_COMM_OFI_DEDICATED_AMH_CORES=true`` on a
+128-core system, there will be 127 cores available for ``forall`` loops
+and similar. The other core is reserved to service requests that arrive
+over the network. This can improve performance in some cases.
+
+
+
 
 .. _Homebrew: https://github.com/Homebrew/brew
 

--- a/doc/rst/platforms/comm-layers/libfabric.rst
+++ b/doc/rst/platforms/comm-layers/libfabric.rst
@@ -321,21 +321,27 @@ slurm job, however.
 Other Settings
 --------------
 
-Setting these two environment variables can improve performance.
+Setting these environment variables can improve performance in some cases.
 
-.. code-block:: bash
+.. _readme-libfabric-CHPL_RT_COMM_OFI_DEDICATED_AMH_CORES:
 
-   export CHPL_RT_COMM_OFI_DEDICATED_AMH_CORES=true
-   export CHPL_RT_COMM_OFI_CONNECT_EAGERLY=true
+``CHPL_RT_COMM_OFI_DEDICATED_AMH_CORES``
+  Setting ``CHPL_RT_COMM_OFI_DEDICATED_AMH_CORES=true`` will
+  dedicate a core to the active message handler progress thread. For
+  example, when using ``CHPL_RT_COMM_OFI_DEDICATED_AMH_CORES=true`` on a
+  128-core system, there will be 127 cores available for ``forall`` loops
+  and similar. The other core is reserved to service requests that arrive
+  over the network. Setting this variable can improve performance in some
+  communication-intensive cases.
 
-Setting ``CHPL_RT_COMM_OFI_DEDICATED_AMH_CORES=true`` will
-dedicate a core to the active message handler progress thread. For
-example, when using ``CHPL_RT_COMM_OFI_DEDICATED_AMH_CORES=true`` on a
-128-core system, there will be 127 cores available for ``forall`` loops
-and similar. The other core is reserved to service requests that arrive
-over the network. This can improve performance in some cases.
+.. _readme-libfabric-CHPL_RT_COMM_OFI_CONNECT_EAGERLY:
 
-
+``CHPL_RT_COMM_OFI_CONNECT_EAGERLY``
+  Setting ``CHPL_RT_COMM_OFI_CONNECT_EAGERLY=true`` will cause the runtime to
+  do extra work at application launch to set up communication. Normally
+  this is done on as-needed basis, which can slow down initial
+  communication. Setting this variable can result in increased
+  performance at the cost of slightly slower application launch.
 
 
 .. _Homebrew: https://github.com/Homebrew/brew

--- a/doc/rst/platforms/comm-layers/libfabric.rst
+++ b/doc/rst/platforms/comm-layers/libfabric.rst
@@ -339,7 +339,7 @@ Setting these environment variables can improve performance in some cases.
 ``CHPL_RT_COMM_OFI_CONNECT_EAGERLY``
   Setting ``CHPL_RT_COMM_OFI_CONNECT_EAGERLY=true`` will cause the runtime to
   do extra work at application launch to set up communication. Normally
-  this is done on as-needed basis, which can slow down initial
+  this is done on an as-needed basis, which can slow down initial
   communication. Setting this variable can result in increased
   performance at the cost of slightly slower application launch.
 

--- a/doc/rst/platforms/networks/infiniband.rst
+++ b/doc/rst/platforms/networks/infiniband.rst
@@ -362,18 +362,23 @@ GASNet also provides additional environment variable settings that can
 optionally be used to control the detailed behavior of these threads, see the
 GASNet documentation referenced in :ref:`ibv-conduit-docs`.
 
+.. _readme-infiniband-CHPL_RT_COMM_GASNET_DEDICATED_PROGRESS_CORE:
+
 By default, the blocking progress threads are created by GASNet and do not
 have any thread-specific core binding.  An experimental Chapel feature
-allows more control over the behavior of the blocking progress threads:
+allows the blocking progress thread to be bound to a specific core:
 
 .. code-block:: bash
 
+      export CHPL_RT_COMM_GASNET_DEDICATED_PROGRESS_CORE=true
       export CHPL_RT_COMM_GASNET_DEFER_PROGRESS_THREADS=true
 
-Specifically, this setting enables the
-``CHPL_RT_COMM_GASNET_DEDICATED_PROGRESS_CORE`` setting described in the
-earlier section to additionally control the placement and binding of GASNet's
-blocking send and receive progress threads.
+This combination dedicates a core for the receive progress thread (as
+well as the PSHM progress thread, if using co-locales). That core will be
+dedicated to improving communication performance and will not be
+avaliable for other computation. Note that it is possible to dedicate a
+core for the PSHM progress thread without changing the receive progress
+thread by setting only the first of these.
 
 .. _ibv-conduit-docs:
 

--- a/doc/rst/technotes/optimization.rst
+++ b/doc/rst/technotes/optimization.rst
@@ -325,6 +325,15 @@ colocales
   ``none`` or ``unknown``, can allow using newer instruction sets (e.g.
   AVX512) and improve performance.
 
+``CHPL_RT_COMM_OFI_DEDICATED_AMH_CORES``
+
+  When using ``CHPL_COMM=ofi``, setting this environment variable will
+  dedicate a core to the active message handler progress thread. For
+  example, when using ``CHPL_RT_COMM_OFI_DEDICATED_AMH_CORES=true`` on a
+  128-core system, there will be 127 cores available for ``forall`` loops
+  and similar. The other core is reserved to service requests that arrive
+  over the network. This can improve performance in some cases.
+
 ..
   comment: cover ``--llvm-wide-opt`` when it becomes less experemental
 

--- a/doc/rst/technotes/optimization.rst
+++ b/doc/rst/technotes/optimization.rst
@@ -325,14 +325,19 @@ colocales
   ``none`` or ``unknown``, can allow using newer instruction sets (e.g.
   AVX512) and improve performance.
 
-``CHPL_RT_COMM_OFI_DEDICATED_AMH_CORES``
+Network-specific communication settings
 
-  When using ``CHPL_COMM=ofi``, setting this environment variable will
-  dedicate a core to the active message handler progress thread. For
-  example, when using ``CHPL_RT_COMM_OFI_DEDICATED_AMH_CORES=true`` on a
-  128-core system, there will be 127 cores available for ``forall`` loops
-  and similar. The other core is reserved to service requests that arrive
-  over the network. This can improve performance in some cases.
+  Please see the documentation for the network that you are using for
+  more details on what can be adjusted. Some specific variables you might
+  consider:
+
+    * :ref:`CHPL_RT_COMM_OFI_DEDICATED_AMH_CORES <readme-libfabric-CHPL_RT_COMM_OFI_DEDICATED_AMH_CORES>`
+      when using ``CHPL_COMM=ofi`` can be used to dedicate a core to
+      service requests that arrive over the network
+
+    * :ref:`CHPL_RT_COMM_GASNET_DEDICATED_PROGRESS_CORE <readme-infiniband-CHPL_RT_COMM_GASNET_DEDICATED_PROGRESS_CORE>`
+      when using ``CHPL_COMM=gasnet`` with ``CHPL_COMM_SUBSTRATE=ibv``
+      offers a similar capability for InfiniBand
 
 ..
   comment: cover ``--llvm-wide-opt`` when it becomes less experemental


### PR DESCRIPTION
This PR adds documentation for `CHPL_RT_COMM_OFI_DEDICATED_AMH_CORES=true` and improves some documentation of related settings.

Reviewed by @jabraham17 - thanks!

- [x] full comm=none testing