### PR TITLE
Add raCommCheckLCG diagnostics

### DIFF
--- a/test/multilocale/deitz/needMultiLocales/raCommCheck.chpl
+++ b/test/multilocale/deitz/needMultiLocales/raCommCheck.chpl
@@ -155,6 +155,15 @@ proc verifyResults() {
   const numErrors = + reduce [i in TableSpace] (T(i) != i);
   if (printStats) then writeln("Number of errors is: ", numErrors, "\n");
 
+  if numErrors > (errorTolerance * N_U) {
+    writeln("Number of errors is: ", numErrors, "\n");
+    writeln("error tolerance = ", errorTolerance * N_U);
+    for loc in Locales do on loc {
+      writeln("Locale", loc.id, " name is '", loc.name, "'");
+      writeln("Locale", loc.id, " hostname is '", loc.hostname, "'");
+    }
+  }
+
   //
   // Return whether or not the number of errors was within the benchmark's
   // tolerance.

--- a/test/multilocale/deitz/needMultiLocales/raCommCheckLCG.compopts
+++ b/test/multilocale/deitz/needMultiLocales/raCommCheckLCG.compopts
@@ -1,1 +1,2 @@
 -M../../../release/examples/benchmarks/hpcc --no-warnings
+-M../../../release/examples/benchmarks/hpcc --no-warnings --no-auto-local-access


### PR DESCRIPTION
This adds some raCommCheckLCG diagnostics without copying the array, which I suspect caused things to unexpectedly work last time.

Also adds compopt with ALA off to see if that still fails.