### PR TITLE
Fix chapel-py build issues with older pip

### DIFF
--- a/third-party/chpl-venv/Makefile
+++ b/third-party/chpl-venv/Makefile
@@ -37,11 +37,11 @@ $(CHPL_VENV_VIRTUALENV_DIR_DEPS1_OK):
 
 	@# Now create the venv to use to get the dependencies
 	$(PYTHON) -m venv $(CHPL_VENV_VIRTUALENV_DIR)
-	@# Now install wheel so we can pip install
+	@# Now install pip/wheel so we can pip install
 	export PATH="$(CHPL_VENV_VIRTUALENV_BIN):$$PATH" && \
 	export VIRTUAL_ENV=$(CHPL_VENV_VIRTUALENV_DIR) && \
 	$(PIP) install --upgrade \
-	  $(CHPL_PIP_INSTALL_PARAMS) $(LOCAL_PIP_FLAGS) wheel && \
+	  $(CHPL_PIP_INSTALL_PARAMS) $(LOCAL_PIP_FLAGS) pip wheel && \
 	touch $(CHPL_VENV_VIRTUALENV_DIR_DEPS1_OK)
 
 ifdef CHPL_PIP_FROM_SOURCE


### PR DESCRIPTION
Fixes a build issue with chapel-py when trying to use a very old version of pip.

This issue is the source of a nightly test problem where pip 20 is used. The issue is that when installing from a setup.py, that version of pip copies the source tree to a temp directory, which breaks our method of finding CHPL_HOME.

The fix in this PR is to always upgrade pip when making our chpldeps venv.

NOTE: this does not fix the root issue, if a user tries to do `pip install tools/chapel-py` with an older pip, it will not work.

[Reviewed by @arifthpe]