### PR TITLE
Misc adjustments to Tuples spec page

### DIFF
--- a/doc/rst/language/spec/tuples.rst
+++ b/doc/rst/language/spec/tuples.rst
@@ -336,7 +336,7 @@ Tuple Destructuring
 
 Tuples can be split into their components in the following ways:
 
--  In assignment where multiple expression on the left-hand side of the
+-  In assignment where multiple expressions on the left-hand side of the
    assignment operator are grouped using tuple notation.
 
 -  In variable declarations where multiple variables in a declaration
@@ -360,7 +360,7 @@ Tuples can be split into their components in the following ways:
 Splitting a Tuple with Assignment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When multiple expression on the left-hand side of an assignment operator
+When multiple expressions on the left-hand side of an assignment operator
 are grouped using tuple notation, the tuple on the right-hand side is
 split into its components. The number of grouped expressions must be
 equal to the size of the tuple on the right-hand side. In addition to


### PR DESCRIPTION
Make several small improvements to the Tuples spec page.

Includes:
- Add "A trailing comma is allowed" to the tuple type section.
  - Already existed in tuple value section; move it earlier in the paragraph to immediately follow the mention of comma-separated values.
- Add a production in the tuple type grammar to allow for a trailing comma on an (N>1)-tuple.
- Add references to relevant later sections in the Tuple Values section.
- Fix a grammar typo.

[reviewer info placeholder]

Testing:
- [x] local docs build looks right and links work