### PR TITLE
Fix debian 11 package build after dropping llvm 11 support

### DIFF
--- a/util/packaging/apt/debian11/Dockerfile.template
+++ b/util/packaging/apt/debian11/Dockerfile.template
@@ -9,7 +9,7 @@ RUN apt-get update && \
     apt-get install -y \
       curl wget vim sudo gcc g++ m4 perl chrpath \
       python3 python3-dev python3-venv bash make mawk git pkg-config cmake \
-      llvm-dev llvm clang libclang-dev libclang-cpp-dev libedit-dev
+      llvm-16-dev llvm-16 clang-16 libclang-16-dev libclang-cpp16-dev libedit-dev
 
 @@{USER_CREATION}
 

--- a/util/packaging/apt/debian11/control.template
+++ b/util/packaging/apt/debian11/control.template
@@ -3,4 +3,4 @@ Version: @@{CHAPEL_VERSION}
 Maintainer: chapel-lang
 Architecture: @@{TARGETARCH}
 Description: Chapel Programming Language
-Depends: git,gcc,llvm-dev,llvm,clang,libclang-dev,libclang-cpp-dev,python3,python3-dev,python3-venv,make
+Depends: git,gcc,llvm-16-dev,llvm-16,clang-16,libclang-16-dev,libclang-cpp16-dev,python3,python3-dev,python3-venv,make


### PR DESCRIPTION
Fixes the debian 11 package build after dropping LLVM 11 support, since debian 11 defaults to LLVM 11. The fix is to explicitly specify a LLVM version

- [x] double check debian 11 build locally

[Reviewed by @arifthpe]