### PR TITLE
Dyno: Fix ambiguity error caused by instantiated type formals

### DIFF
--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -1081,7 +1081,11 @@ CanPassResult CanPassResult::canPassScalar(Context* context,
     // 'AnyType' has special meaning elsewhere, so it doesn't count as
     // instantiation here.
     if (formalQT.kind() == QualifiedType::TYPE && !formalT->isAnyType()) {
-      return instantiate();
+      if (isTypeGeneric(context, formalQT)) {
+        return instantiate();
+      } else {
+        return passAsIs();
+      }
     }
 
     // otherwise we can pass as-is

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -4256,6 +4256,12 @@ static bool resolveFnCallSpecial(Context* context,
     auto srcTy = srcQt.type();
     auto dstTy = dstQt.type();
 
+    if (!srcQt.isType() && srcTy == dstTy) {
+      // TODO: insert copy for unnecessary casts involving records
+      exprTypeOut = srcQt;
+      return true;
+    }
+
     auto targetParamGuess = Param::tryGuessParamTagFromType(dstQt.type());
     if (srcQt.isParam() && !targetParamGuess) {
       // We're casting a param value, but the destination type can't be

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2276,6 +2276,7 @@ instantiateSignatureImpl(ResolutionContext* rc,
     visitor.skipTypeQueries = false;
 
     bool addSub = false;
+    bool isInstantiated = false;
     QualifiedType useType;
     const auto formal = untypedSignature->formalDecl(entry.formalIdx());
     const auto& actualType = entry.actualType();
@@ -2336,6 +2337,7 @@ instantiateSignatureImpl(ResolutionContext* rc,
       }
 
       if (got.instantiates() || formalType.isType()) {
+        addSub = true;
         // add a substitution for a valid value
         //
         // if no conversion took place, then we can use the actual type. One
@@ -2345,17 +2347,23 @@ instantiateSignatureImpl(ResolutionContext* rc,
         // of the same type), but we want to instantiate with whatever the
         // formal type was (e.g., if we're the formal is `_owned(C)`, instantiate
         // with `_owned(C)`).
-        if (!got.converts() && instantiateAcrossManagerRecordConversion(context, formalType, actualType, useType)) {
-          // useType was set as an out parameter of the call in the condition.
-          addSub = true;
-        } else if (!got.converts()) {
-          // use the actual type since no conversion/promotion was needed
-          addSub = true;
-          useType = scalarType;
+        if (!got.converts()) {
+          if (instantiateAcrossManagerRecordConversion(context, formalType, actualType, useType)) {
+            // useType was set as an out parameter of the call in the condition.
+            isInstantiated = true;
+          } else if (formalType.isType() && !got.instantiates()) {
+            // When a type formal's type expression is a specific instantiation,
+            // e.g., `type T : R(int)`, we want to add a substitution but
+            // should not consider it instantiated.
+            useType = scalarType;
+          } else {
+            // use the actual type since no conversion/promotion was needed
+            isInstantiated = true;
+            useType = scalarType;
+          }
         } else {
+          isInstantiated = true;
           // get instantiation type
-          addSub = true;
-
           useType = getInstantiationType(context,
                                          scalarType,
                                          formalType);
@@ -2419,7 +2427,10 @@ instantiateSignatureImpl(ResolutionContext* rc,
         if ((size_t) formalIdx >= formalsInstantiated.size()) {
           formalsInstantiated.resize(sig->numFormals());
         }
-        formalsInstantiated.setBit(formalIdx, true);
+
+        if (isInstantiated) {
+          formalsInstantiated.setBit(formalIdx, true);
+        }
       }
 
       formalIdx++;

--- a/frontend/test/resolution/testCanPass.cpp
+++ b/frontend/test/resolution/testCanPass.cpp
@@ -616,7 +616,7 @@ static void test9() {
 }
 
 static void test10() {
-  printf("test9\n");
+  printf("test10\n");
   Context ctx;
   Context* context = &ctx;
 
@@ -626,8 +626,8 @@ static void test10() {
         type A, B;
       }
 
-      type a = Bar(int);
-      type b = Bar(int, int);
+      type a = C(int);
+      type b = C(int, int);
       )""", {"a", "b"});
 
 

--- a/frontend/test/resolution/testCast.cpp
+++ b/frontend/test/resolution/testCast.cpp
@@ -588,6 +588,36 @@ static void test47() {
   testBorrow("var c = new unmanaged C?();", true);
 }
 
+static void test48() {
+  // Mimics a situation found in CTypes, involving the casts for c_ptr(void)
+  // Technically these are ambiguous, but we avoid the cast entirely becase
+  // the src/dest types are the same.
+  Context* context = buildStdContext();
+  ErrorGuard guard(context);
+  std::string program =
+    R"""(
+    record R {
+      type T;
+      var x : T;
+    }
+
+    operator :(x:R, type t:R(int)) {
+      return __primitive("cast", t, x);
+    }
+
+    operator :(x:R(int), type t:R) {
+      return __primitive("cast", t, x);
+    }
+
+    var r = new R(int);
+    var x = r:R(int);
+    )""";
+
+  auto xInit = resolveQualifiedTypeOfX(context, program);
+
+  assert(toString(xInit) == "R(int(64))");
+}
+
 int main() {
   test1();
   test2();
@@ -636,6 +666,7 @@ int main() {
   test45();
   test46();
   test47();
+  test48();
 
   return 0;
 }

--- a/frontend/test/resolution/testInitSemantics.cpp
+++ b/frontend/test/resolution/testInitSemantics.cpp
@@ -1806,12 +1806,6 @@ static void testInitGenericAfterConcrete() {
   }
 }
 
-static std::string toString(QualifiedType type) {
-  std::stringstream ss;
-  type.type()->stringify(ss, chpl::StringifyKind::CHPL_SYNTAX);
-  return ss.str();
-}
-
 static void testNilFieldInit() {
   std::string program = R"""(
     class C { var x: int; }

--- a/frontend/test/test-resolution.cpp
+++ b/frontend/test/test-resolution.cpp
@@ -568,3 +568,9 @@ void testArrayMaterialize(Context* context, const char* prelude, const char* ite
 void testArrayCoerce(Context* context, const char* prelude, const char* typeExpr, const char* iterable, int expectedRank, const char* expectedStride, const char* expectedCopyInitFn) {
   testArrayAssign(context, prelude, typeExpr, iterable, expectedRank, expectedStride, AssociatedAction::INIT_OTHER, expectedCopyInitFn);
 }
+
+std::string toString(QualifiedType type) {
+  std::stringstream ss;
+  type.type()->stringify(ss, chpl::StringifyKind::CHPL_SYNTAX);
+  return ss.str();
+}

--- a/frontend/test/test-resolution.h
+++ b/frontend/test/test-resolution.h
@@ -128,4 +128,6 @@ void testArrayAssign(Context* context, const char* prelude, const char* typeExpr
 void testArrayMaterialize(Context* context, const char* prelude, const char* iterable, int expectedRank, const char* expectedStride, const char* expectedCopyInitFn);
 void testArrayCoerce(Context* context, const char* prelude, const char* typeExpr, const char* iterable, int expectedRank, const char* expectedStride, const char* expectedCopyInitFn);
 
+std::string toString(QualifiedType type);
+
 #endif


### PR DESCRIPTION
This PR fixes a bug in dyno where we fail to recognize that certain type formals are more specific than others. For example, prior to this PR dyno would fail to recognize that a formal like ``type t: R(int)`` was more specific than ``type t: R(?)`` when the argument was ``R(int)``.

This was caused in part by ``canPass`` returning a value indicating that the fully specified type formal was instantiated, when that's not the case (because the types already match). This is fixed by only returning ``instantiate()`` when the type is generic.

Now that we can correctly recognize this case, we need to stop marking the formal as "instantiated" in the TypedFnSignature. This requires some changes in ``instantiateSignatureImpl`` to stop assuming that a substitution requires an instantiation, and to track that property separately. Some light refactoring was done to bring all the non-conversion cases under one branch.

This PR also includes a workaround for a separate bug where we fail to generate a copy for casts between the same types.

Testing:
- [x] test-frontend
- [ ] paratest