### PR TITLE
Adjust `fixpaths.py` to preserve the original RPATH order

### DIFF
--- a/util/packaging/common/fixpaths.py
+++ b/util/packaging/common/fixpaths.py
@@ -64,8 +64,9 @@ for f in files:
     if len(new_path) == 0:
         sp.check_call(["chrpath", "-d", f])
     else:
-        # remove duplicates
-        new_path = list(set(new_path))
+        # remove duplicates and preserve order
+        seen = set()
+        new_path = [x for x in new_path if not (x in seen or seen.add(x))]
 
         path = ":".join(new_path)
         sp.check_call(["chrpath", "-r", path, f])


### PR DESCRIPTION
Adjusts the `fixpaths` script, used by the packaging builds, to preserve the original order of the RPATHs it modifies.

This fixes an issue where a properly constructed RPATH with `$ORIGIN` was being turned into an incorrect RPATH, since `$ORIGIN` by convention should go first.

[Reviewed by @arifthpe]