### PR TITLE
Fix the partitioning of resources for the smp substrate

### DIFF
--- a/runtime/src/launch/smp/launch-smp.c
+++ b/runtime/src/launch/smp/launch-smp.c
@@ -35,8 +35,11 @@ int chpl_launch(int argc, char* argv[], int32_t numLocales,
   if ((numLocalesPerNode > 1) && (numNodes != 1)) {
     chpl_error("smp launcher does not support multiple nodes", 0, 0);
   }
-
-  chpl_env_set_uint("GASNET_PSHM_NODES", numLocales, 1);
+  // numLocales is the total number of locales (i.e. numNodes * numLocalesPerNode)
+  // force CHPL_RT_LOCALES_PER_NODE to this value,
+  // since the user could have passed just `-nl 4`
+  chpl_env_set_uint("CHPL_RT_LOCALES_PER_NODE", (uint64_t)numLocales, 1);
+  chpl_env_set_uint("GASNET_PSHM_NODES", (uint64_t)numLocales, 1);
 
   chpl_compute_real_binary_name(argv[0]);
   snprintf(baseCommand, sizeof(baseCommand), "%s", chpl_get_real_binary_name());


### PR DESCRIPTION
Fixes an issue where requesting locales as `-nl 2` to the smp substrate would not properly partition resources

- [x] Tested that the following code had the proper number of cores/locales partitioned

```chapel
for l in Locales do on l {
  for tid in 0..#here.maxTaskPar {
    writeln("Hello, world! (from task ", tid:string, " of ", here.maxTaskPar:string, " on locale ", here.id:string, ")");
  }
}
```

[Reviewed by @]