### PR TITLE
Use `srun` in the `slurm-gasnetrun_*` launchers instead of `salloc`

### DIFF
--- a/doc/rst/platforms/networks/infiniband.rst
+++ b/doc/rst/platforms/networks/infiniband.rst
@@ -90,8 +90,8 @@ pbs-gasnetrun_ibv     queue jobs using PBS (qsub)
 lsf-gasnetrun_ibv     queue jobs using LSF (bsub)
 ===================  ======================================
 
-``CHPL_LAUNCHER`` will typically default to ``gasnetrun_ibv`` unless ``salloc``
-is in your path, in which case it will default to
+``CHPL_LAUNCHER`` will typically default to ``gasnetrun_ibv`` unless ``srun``/
+``salloc`` is in your path, in which case it will default to
 ``slurm-gasnetrun_ibv``
 
 By default Slurm, PBS, and LSF versions launch in an interactive

--- a/doc/rst/usingchapel/launcher.rst
+++ b/doc/rst/usingchapel/launcher.rst
@@ -104,8 +104,8 @@ If ``CHPL_LAUNCHER`` is left unset, a default is picked as follows:
   CHPL_COMM_SUBSTRATE=ofi  [slurm-]gasnetrun_ofi
   =======================  ==============================================
 
-  If salloc is in the user's path, then the slurm version of these launchers
-  will be used. Otherwise, the base ``gasnetrun_*`` launcher is used.
+  If salloc or srun is in the user's path, then the slurm version of these
+  launchers will be used. Otherwise, the base ``gasnetrun_*`` launcher is used.
 
 * otherwise, if ``CHPL_TARGET_PLATFORM`` is a HPE system or a Cray system:
 
@@ -165,8 +165,8 @@ When ``CHPL_COMM == gasnet``, this will also be used to set the value of
 
 .. _using-slurm:
 
-Using Slurm
-+++++++++++
+Using Native Slurm
+++++++++++++++++++
 
 To use native Slurm, set:
 
@@ -174,16 +174,19 @@ To use native Slurm, set:
 
   export CHPL_LAUNCHER=slurm-srun
 
-On Cray systems, this will happen automatically if srun is found in your
-path, but not when both srun and aprun are found in your path. Native
-Slurm is the best option where it works, but at the time of this writing,
-there are problems with it when combined with ``CHPL_COMM=gasnet`` and the
-UDP or InfiniBand conduits. So, for these configurations please see:
+On Cray systems, this will happen automatically if srun is found in your path
+and you are not using GASNet, but not when both srun and aprun are found in
+your path. Native Slurm is the best option where it works, but at the time of
+this writing, there are problems with it when combined with
+``CHPL_COMM=gasnet`` and the UDP or InfiniBand conduits. So, for these
+configurations please see:
 
   * :ref:`readme-infiniband` for information about using Slurm with
     InfiniBand.
   * :ref:`using-udp-slurm` for information about using Slurm with the UDP
     conduit
+  * :ref:`_using-slurm-gasnet` for information about using Slurm with
+    the GASNet launchers.
 
 Common Slurm Settings
 *********************
@@ -292,6 +295,27 @@ Common Slurm Settings
   .. code-block:: bash
 
     export CHPL_LAUNCHER_WALLTIME=00:10:00
+
+
+.. _using-slurm-gasnet:
+
+Using the GASNet Slurm Launchers
+++++++++++++++++++++++++++++++++
+
+When using CHPL_COMM=gasnet and Slurm is available, Chapel will prefer to use
+the slurm-prefixed version of the GASNet launchers, such as
+``slurm-gasnetrun_ibv``.
+
+The GASNet Slurm launchers use ``srun`` by default to launch the program onto
+the compute nodes. This can be run from a login node or from within an existing
+allocation. The GASNet Slurm launchers can also just use ``salloc`` directly by
+setting ``CHPL_RT_GASNETRUN_LAUNCHER`` to ``salloc``. Note that using
+``salloc`` will not work if run within an existing allocation. To request batch
+submission, set ``CHPL_LAUNCHER_USE_SBATCH``.
+
+If you prefer to make Slurm commands yourself explicitly set the
+``CHPL_LAUNCHER`` environment variable to the non-slurm version of the GASNet
+launcher, such as ``gasnetrun_ibv``.
 
 .. _ssh-launchers-with-slurm:
 

--- a/util/chplenv/chpl_launcher.py
+++ b/util/chplenv/chpl_launcher.py
@@ -7,8 +7,8 @@ from utils import which, error, memoize, warning, check_valid_var
 
 
 def slurm_prefix(base_launcher):
-    """ If salloc is available, prefix with slurm-"""
-    if which('salloc'):
+    """ If srun|salloc is available, prefix with slurm-"""
+    if which('srun') or which('salloc'):
         return 'slurm-{}'.format(base_launcher)
     return base_launcher
 

--- a/util/test/chpl_launchcmd.py
+++ b/util/test/chpl_launchcmd.py
@@ -277,10 +277,8 @@ class AbstractJob(object):
         if more_l:
             submit_command.append('{0}'.format(more_l))
 
-
         logging.info('qsub command: "{0}"'.format(' '.join(submit_command)))
         return submit_command
-
 
     def run(self):
         """Run batch job in subprocess and wait for job to complete.
@@ -560,6 +558,21 @@ class AbstractJob(object):
             logging.error('No test command provided.')
             raise ValueError('No test command found.')
 
+        # validate the value of CHPL_LAUNCHER
+        chpl_home = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "..", "..")
+        )
+        chpl_launcher = subprocess.check_output(
+            ["{}/util/chplenv/chpl_launcher.py".format(chpl_home)],
+            encoding="utf-8",
+        ).strip()
+        if chpl_launcher.startswith("pbs-"):
+            msg = "CHPL_LAUNCHER is set to {}, which is not supported".format(
+                chpl_launcher
+            )
+            logging.error(msg)
+            raise ValueError(msg)
+
         job_flavor = cls._detect_job_flavor()
         logging.info('Detected job flavor: {0}'.format(job_flavor.__name__))
         return job_flavor(test_command, args)
@@ -629,7 +642,6 @@ class AbstractJob(object):
                                 'Please put a space between "-nl" and number of '
                                 'locales, if that\'s the purpose.'.format(arg))
 
-
     @classmethod
     def _get_test_command(cls, args, unparsed_args):
         """Returns test command by folding numLocales args into unparsed command line
@@ -684,7 +696,6 @@ class AbstractJob(object):
                             help=('Optional queue specification for reserving '
                                   'specific queues. Can also be set with env var '
                                   'CHPL_LAUNCHCMD_QUEUES'))
-
 
         args, unparsed_args = parser.parse_known_args()
 


### PR DESCRIPTION
Changes `slurm-gasnetrun_*` launchers to use `srun`, instead of `salloc`. Since `srun` can be used inside of an existing allocation, it is preferred. The previous behavior can be restored by using `CHPL_RT_GASNETRUN_LAUNCHER`

Key Changes
- switch slurm launchers to use srun, which an env var to switch back to the old salloc
- add a new env var for slurm debugging, analogous to `SALLOC_DEBUG`
- add documentation for the behavior of `slurm-gasnetrun_*`
- make the runtime infer a slurm gasnet launcher based on the presence of `srun` or `salloc`
- adjust `chpl_launchcmd.py` to prevent usage with a `pbs-*` launcher 

Resolves https://github.com/chapel-lang/chapel/issues/27103


- [ ] tested on IBV Slurm system
- [ ] tested on IBV PBS system