### PR TITLE
Handle CC/CXX for the chapel-py build

### DIFF
--- a/doc/rst/tools/chapel-py/chapel-py.rst
+++ b/doc/rst/tools/chapel-py/chapel-py.rst
@@ -65,12 +65,17 @@ Installation
 ------------
 
 Make sure that you have a from-source build of Chapel available in your
-``CHPL_HOME``. Currently, the build script also requires having LLVM available
-in your path. The build script also requires that the development package of
-Python be installed (for many package managers this is called
-``python3-devel``). With those constraints met, you can just run ``make
-chapel-py-venv``. This will allow you to use the Python bindings from a
-Python script run with
+``CHPL_HOME``, the development package for Python (for many package managers
+this is called ``python3-devel``), and that you satisfy all the other
+:ref:`Chapel prerequisites <readme-prereqs>`. Then the Python bindings can be
+built and installed as:
+
+.. code-block::
+
+   cd $CHPL_HOME
+   make chapel-py-venv
+
+This will allow you to use the Python bindings from a Python script run with
 ``$CHPL_HOME/util/config/run-in-venv-with-python-bindings.bash python3``,
 instead of just ``python3``.
 

--- a/doc/rst/tools/chapel-py/chapel-py.rst
+++ b/doc/rst/tools/chapel-py/chapel-py.rst
@@ -80,7 +80,18 @@ If you wish to install the Python bindings in your system python, you must manua
 
    cd $CHPL_HOME
    make frontend-shared
-   python3 -m pip install $CHPL_HOME/tools/chapel-py
+   CC=$CC CXX=$CXX python3 -m pip install $CHPL_HOME/tools/chapel-py
+
+.. note::
+
+   The ``CC=$CC CXX=$CXX`` prefix is necessary to ensure that the Python
+   bindings are built with the correct compiler. Even if you have ``CC`` and
+   ``CXX`` unset in your environment they must be set to some empty value,
+   otherwise the build may fail in unexpected ways. Using ``CC=$CC CXX=$CXX``
+   is a workaround that preserves the values of these variables from the
+   environment, but also sets them to an empty value if they are unset. This is
+   a workaround for an issue with the Python build system, and will not be
+   necessary in the future.
 
 
 Usage

--- a/third-party/chpl-venv/Makefile
+++ b/third-party/chpl-venv/Makefile
@@ -107,8 +107,11 @@ chapel-py-venv: FORCE $(CHPL_VENV_VIRTUALENV_DIR_OK)
 	@# Install chapel-py's Python package into the Python Application
 	@# directory structure at $(CHPL_VENV_CHPL_FRONTEND_PY_DEPS)
 	@# this is python version specific
+	@#
+	@# note that CC/CXX are explicitly set to avoid scikit-build/scikit-build-core#1114
 	export PATH="$(CHPL_VENV_VIRTUALENV_BIN):$$PATH" && \
 	export VIRTUAL_ENV=$(CHPL_VENV_VIRTUALENV_DIR) && \
+	CC=$(CHPL_MAKE_HOST_CC) CXX=$(CHPL_MAKE_HOST_CXX) \
 	CHPL_HOME=$(CHPL_MAKE_HOME) $(PIP) install --upgrade \
 	  $(CHPL_PIP_INSTALL_PARAMS) $(LOCAL_PIP_FLAGS) \
 	  --target $(CHPL_VENV_CHPL_FRONTEND_PY_DEPS) \

--- a/tools/chapel-py/CMakeLists.txt
+++ b/tools/chapel-py/CMakeLists.txt
@@ -32,15 +32,8 @@ set(CHPL_HOME_UTILS "${CHPL_HOME}/util/chplenv/chpl_home_utils.py")
 set(CHPL_COMPILER_PY "${CHPL_HOME}/util/chplenv/chpl_compiler.py")
 
 # Function to execute Chapel environment commands
-#
-# This runs with CC/CXX unset. This is slightly dangerous, because printchplenv
-# could be relying on CC/CXX to set the host compiler properly, but cmake
-# adamantly refuses to not set CC/CXX to some default value, even if a user
-# hasn't set them (or even if -DCMAKE_C_COMPILER= and -DCMAKE_CXX_COMPILER= are
-# explicitly set).
-#
 execute_process(
-  COMMAND ${CMAKE_COMMAND} -E env CC= CXX= -- ${CHPL_PRINTCHPLENV} --internal --all --anonymize --simple
+  COMMAND ${CHPL_PRINTCHPLENV} --internal --all --anonymize --simple
   OUTPUT_VARIABLE CHPL_ENV_OUTPUT
   RESULT_VARIABLE CHPL_ENV_RESULT
   OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -67,7 +60,7 @@ get_chapel_env_var("CHPL_SANITIZE" CHPL_SANITIZE)
 get_chapel_env_var("CHPL_HOST_PLATFORM" CHPL_HOST_PLATFORM)
 
 execute_process(
-  COMMAND ${CMAKE_COMMAND} -E env CC= CXX= -- ${Python_EXECUTABLE} ${CHPL_COMPILER_PY} --cc --host --compiler-only
+  COMMAND ${Python_EXECUTABLE} ${CHPL_COMPILER_PY} --cc --host --compiler-only
   OUTPUT_VARIABLE CHPL_HOST_CC
   RESULT_VARIABLE CHPL_HOST_CC_RESULT
   OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -76,7 +69,7 @@ if(NOT CHPL_HOST_CC_RESULT EQUAL 0)
   message(FATAL_ERROR "Failed to get host C compiler")
 endif()
 execute_process(
-  COMMAND ${CMAKE_COMMAND} -E env CC= CXX= -- ${Python_EXECUTABLE} ${CHPL_COMPILER_PY} --cc --host --additional
+  COMMAND ${Python_EXECUTABLE} ${CHPL_COMPILER_PY} --cc --host --additional
   OUTPUT_VARIABLE CHPL_HOST_CC_FLAGS
   RESULT_VARIABLE CHPL_HOST_CC_FLAGS_RESULT
   OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -86,7 +79,7 @@ if(NOT CHPL_HOST_CC_FLAGS_RESULT EQUAL 0)
 endif()
 
 execute_process(
-  COMMAND ${CMAKE_COMMAND} -E env CC= CXX= -- ${Python_EXECUTABLE} ${CHPL_COMPILER_PY} --cxx --host --compiler-only
+  COMMAND ${Python_EXECUTABLE} ${CHPL_COMPILER_PY} --cxx --host --compiler-only
   OUTPUT_VARIABLE CHPL_HOST_CXX
   RESULT_VARIABLE CHPL_HOST_CXX_RESULT
   OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -95,7 +88,7 @@ if(NOT CHPL_HOST_CXX_RESULT EQUAL 0)
   message(FATAL_ERROR "Failed to get host C++ compiler")
 endif()
 execute_process(
-  COMMAND ${CMAKE_COMMAND} -E env CC= CXX= -- ${Python_EXECUTABLE} ${CHPL_COMPILER_PY} --cxx --host --additional
+  COMMAND ${Python_EXECUTABLE} ${CHPL_COMPILER_PY} --cxx --host --additional
   OUTPUT_VARIABLE CHPL_HOST_CXX_FLAGS
   RESULT_VARIABLE CHPL_HOST_CXX_FLAGS_RESULT
   OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -133,7 +126,7 @@ message(STATUS "Chapel lib path: ${CHPL_LIB_PATH}")
 
 # Get Chapel install lib path
 execute_process(
-  COMMAND ${CMAKE_COMMAND} -E env CC= CXX= -- ${Python_EXECUTABLE} ${CHPL_HOME_UTILS} --configured-install-lib-prefix
+  COMMAND ${Python_EXECUTABLE} ${CHPL_HOME_UTILS} --configured-install-lib-prefix
   OUTPUT_VARIABLE CHPL_INSTALL_LIB_PATH
   RESULT_VARIABLE CHPL_INSTALL_RESULT
   OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -169,7 +162,7 @@ if(CHPL_LLVM AND NOT CHPL_LLVM STREQUAL "none")
 endif()
 set(LLVM_CXX_FLAGS "")
 execute_process(
-  COMMAND ${CMAKE_COMMAND} -E env CC= CXX= -- ${Python_EXECUTABLE} ${CHPL_LLVM_PY} --host-cxxflags
+  COMMAND ${Python_EXECUTABLE} ${CHPL_LLVM_PY} --host-cxxflags
   OUTPUT_VARIABLE LLVM_CXX_FLAGS
   RESULT_VARIABLE LLVM_FLAGS_RESULT
   OUTPUT_STRIP_TRAILING_WHITESPACE


### PR DESCRIPTION
Fixes the issue that https://github.com/chapel-lang/chapel/pull/27502 tried to fix, where an incorrect CC/CXX was inferred by Python/CMake.

The fix of CC/CXX broke more configurations than it fixed, because in many situations we rely on CC/CXX to infer HOST_CC/HOST_CXX

<details>

<summary> details of issue </summary>

The problem is that CC/CXX are being set to some value and passed to the CMakeLists.txt, which is then passed along as a part of the environment when invoking `printchplenv`. On some systems, this can break `printchplenv`'s detection of the host compiler. Some of these problems where fixed by improving `printchplenv`, but fundamentally one problem that can occur is that `chapel-py` and dyno end up using different compilers, which can have ABI problems.

I originally thought this problem was caused by CMake setting CC/CXX to default values, but after further investigation I don't think thats the case. In a standalone CMake file, CC/CXX/CMAKE_C_COMPILER/CMAKE_CXX_COMPILER are all unset (unless set by the user). The way CMake is invoked for chapel-py, we run `pip install tools/chapel-py`, which invokes the build tool (scikit-build-core), which invokes cmake. scikit-build-core explicitly sets CC/CXX.

In the event CC/CXX are unset in the environment, [scikit-build-core will infer them based on sysconfig](https://github.com/scikit-build/scikit-build-core/pull/782), essentially the CC/CXX used to build python.

Most of the time, I think this ends up being fine. But with spack installs and Cray PE modules, things break. 

In the future if this continues to be a problem we should consider switching to py-build-cmake, an alternative build tool to scikit-build-core. My impression is that scikit-build-core has wider adoption and better support, so I am disinclined to switch. Resolving https://github.com/scikit-build/scikit-build-core/issues/1114 will fix things properly for us.

</details>

The solution is to make sure CC/CXX is always set in the env, which means that users who wish to manually install the Python bindings will need to override CC/CXX. This PR documents this.

[Reviewed by @lydia-duncan]