### PR TITLE
Refactor chpl_do_format to reduce code size

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -12148,8 +12148,8 @@ proc bytes.format(args ...?k): bytes throws {
   return b"";
 }
 
-private proc chpl_do_format_read(f, offset: int) throws {
-  var buf = allocate(uint(8), (offset+1).safeCast(c_size_t));
+private proc chpl_do_format_read(f, size: int) throws {
+  var buf = allocate(uint(8), (size+1).safeCast(c_size_t));
   var r = f.reader(locking=false);
   defer {
     try {
@@ -12157,14 +12157,14 @@ private proc chpl_do_format_read(f, offset: int) throws {
     } catch { /* ignore deferred close error */ }
   }
 
-  r.readBinary(buf, offset);
+  r.readBinary(buf, size);
 
   // close errors are thrown instead of ignored
   r.close();
   f.close();
 
   // Add the terminating NULL byte to make C string conversion easy.
-  buf[offset] = 0;
+  buf[size] = 0;
 
   return buf;
 }
@@ -12197,7 +12197,7 @@ private proc chpl_do_format(fmt:?t, args ...?k): t throws
     w.close();
   }
 
-  return t.createAdoptingBuffer(chpl_do_format_read(f, offset), offset, offset+1);
+  return t.createAdoptingBuffer(chpl_do_format_read(f, size=offset), offset, offset+1);
 }
 
 


### PR DESCRIPTION
Refactors `chpl_do_format` to reduce the amount of duplicated code when this function is instantiated many times.

In large applications (Arkouda with CHPL_COMM=none and `ARKOUDA_QUICK_COMPILE=1`), this results in a 300% reduction in code size for `chpl_do_format`. Overall, it results only about a 2% reduction for the entire application (which is close to being just noise).

<details>

The following script was used to compute the above stats. This is slightly modified from https://github.com/Cray/chapel-private/issues/1260#issuecomment-678566707, with part of the idea for this patch coming from https://github.com/Cray/chapel-private/issues/4224#issuecomment-1399091007

```python
#!/usr/bin/env python3

# if you pass one argument only: it must be the path to the generated C file,
# and the output will be number of lines in each generated function

# if you pass two arguments: the second must be `--loc`. It'll print out the
# total size of the generated code coming from Chapel code. This assumes that
# every function has a /* Foo.chpl:100 */ up top

import sys
import os
import argparse

def compute(filename, loc=False, sort=False):

    loc_to_body_size = {}

    print("==== Reading file: {} ====".format(filename))
    with open(filename, 'r') as f:
        in_func = False
        in_body = False
        cur_depth = 0
        line_no = 0
        body_size = 0
        fn_name = ''
        line_before = ''
        location_info = ''
        for l in f:
            line_no += 1

            if in_body:
                body_size += 1

            if l.startswith('static') or l.startswith('syserr'):
                if not in_func:
                    in_func = True
                    if '{' in l:
                        in_body = True
                        cur_depth += 1

                    fn_name = l.split('(')[0].split()[-1]
                    location_info = line_before.strip()
                else:
                    print('Something fishy happened (100)', line_no)
            elif '{' in l and '}' in l:
                continue
            elif 'str_literal' in l:
                continue
            elif '{' in l:
                if not in_func:
                    print('Something fishy happened (200)', line_no)
                if in_func and not in_body:
                    assert(cur_depth == 0)
                    in_body = True
                cur_depth += 1
            elif l.strip() == '}':
                if not in_func:
                    print('Something fishy happened (300)', line_no)
                if not in_body:
                    print('Something fishy happened (400)', line_no)
                cur_depth -= 1
                if cur_depth == 0:
                    in_func = False
                    in_body = False
                    body_size -= 1
                    if loc:
                        if location_info in loc_to_body_size:
                            loc_to_body_size[location_info] += body_size
                        else:
                            loc_to_body_size[location_info] = body_size
                    else:
                        loc_to_body_size[fn_name] = body_size
                    body_size = 0

            line_before = l

    # for (l, s) in loc_to_body_size.items():
    #     print("{:6} {}".format(s, l))
    if sort:
        loc_to_body_size = sorted(loc_to_body_size.items(), key=lambda x: x[1], reverse=True)
    else:
        loc_to_body_size = loc_to_body_size.items()
    for (l, s) in loc_to_body_size:
        print("{:6} {}".format(s, l))

    print("==== Done reading file: {} ====".format(filename))

    return sum(s for _, s in loc_to_body_size)

if __name__ == '__main__':

    parser = argparse.ArgumentParser(description='Count lines in generated C code.')
    parser.add_argument('filename', type=str, help='Path to the generated C file')
    parser.add_argument('--loc', action='store_true', help='Count lines of code per Chapel location')
    parser.add_argument('--sort', action='store_true', help='Sort the output by size')

    args = parser.parse_args()

    files_to_check = []
    if os.path.isdir(args.filename):
        for root, dirs, files in os.walk(args.filename):
            for file in files:
                if file.endswith('.c'):
                    files_to_check.append(os.path.join(root, file))
    else:
        files_to_check.append(args.filename)


    tot = 0
    for file in files_to_check:
        tot+=compute(file, loc=args.loc, sort=args.sort)
    print("Total lines counted: {}".format(tot))

```

</details>


- [x] paratest with/without gasnet

[Reviewed by @e-kayrakli ]