### PR TITLE
Add chplcheck rule for boolean conditionals that can be simplified

### DIFF
--- a/test/chplcheck/SimpleBoolConditional.chpl
+++ b/test/chplcheck/SimpleBoolConditional.chpl
@@ -1,0 +1,42 @@
+module SimpleBoolConditional {
+  proc foo(x) {
+    return if x /**/ == 1 then true else false;
+  }
+  proc fooInv(x) {
+    return if x == 1 then false else true;
+  }
+  proc bar(x) {
+    if x == /**/1 then
+      return true;
+    else
+      return false;
+  }
+  proc barInv(x) {
+    if x == 1 then
+      return false;
+    else
+      return true;
+  }
+  proc egg(x) {
+    if x == 1 {
+      return true;
+    } else {
+      return false;
+    }
+  }
+  proc eggInv(x) {
+    if x /**/== 1 {
+      return false;
+    } else {
+      return true;
+    }
+  }
+  proc spam(x) {
+    var a = if x == 1 then true else false;
+    var b = if x == 2 then false else true;
+
+    const c = if x == 3 then true else false,
+          d = if x == 4 then false else true;
+    return a && b && c && d;
+  }
+}

--- a/test/chplcheck/SimpleBoolConditional.good
+++ b/test/chplcheck/SimpleBoolConditional.good
@@ -1,0 +1,12 @@
+SimpleBoolConditional.chpl:3: node violates rule SimpleBoolConditional
+SimpleBoolConditional.chpl:6: node violates rule SimpleBoolConditional
+SimpleBoolConditional.chpl:9: node violates rule SimpleBoolConditional
+SimpleBoolConditional.chpl:15: node violates rule SimpleBoolConditional
+SimpleBoolConditional.chpl:21: node violates rule SimpleBoolConditional
+SimpleBoolConditional.chpl:28: node violates rule SimpleBoolConditional
+SimpleBoolConditional.chpl:35: node violates rule SimpleBoolConditional
+SimpleBoolConditional.chpl:36: node violates rule SimpleBoolConditional
+SimpleBoolConditional.chpl:36: node violates rule ConsecutiveDecls
+SimpleBoolConditional.chpl:38: node violates rule SimpleBoolConditional
+SimpleBoolConditional.chpl:39: node violates rule SimpleBoolConditional
+[Success matching fixit for SimpleBoolConditional]

--- a/test/chplcheck/SimpleBoolConditional.good-fixit
+++ b/test/chplcheck/SimpleBoolConditional.good-fixit
@@ -1,0 +1,28 @@
+module SimpleBoolConditional {
+  proc foo(x) {
+    return x /**/ == 1;
+  }
+  proc fooInv(x) {
+    return !(x == 1);
+  }
+  proc bar(x) {
+    return x == /**/1
+  }
+  proc barInv(x) {
+    return !(x == 1)
+  }
+  proc egg(x) {
+    return x == 1
+  }
+  proc eggInv(x) {
+    return !(x /**/== 1)
+  }
+  proc spam(x) {
+    var a = x == 1;
+    var b = !(x == 2);
+
+    const c = x == 3,
+          d = !(x == 4);
+    return a && b && c && d;
+  }
+}

--- a/tools/chplcheck/examples/SimpleBoolConditional.chpl
+++ b/tools/chplcheck/examples/SimpleBoolConditional.chpl
@@ -1,0 +1,22 @@
+/*
+  Conditionals that result in a single boolean value do not need to be written
+  as a conditional expression. The following demonstrates this.
+  The expressions for ``A`` and ``B`` are equivalent.
+*/
+config const x = 1;
+const A = x == 1;
+const B = if x == 1 then true else false;
+
+/*
+  This is also true for if statements which return a boolean value on both
+  branches. The procedures ``foo`` and ``bar`` are equivalent.
+*/
+proc foo(x) {
+  if x == 1 then
+    return true;
+  else
+    return false;
+}
+proc bar(x) {
+  return x == 1;
+}

--- a/tools/chplcheck/examples/SimpleBoolConditional.good
+++ b/tools/chplcheck/examples/SimpleBoolConditional.good
@@ -1,0 +1,2 @@
+SimpleBoolConditional.chpl:8: node violates rule SimpleBoolConditional
+SimpleBoolConditional.chpl:15: node violates rule SimpleBoolConditional

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -342,6 +342,9 @@ def rules(driver: LintDriver):
 
     @driver.basic_rule(chapel.Conditional)
     def SimpleBoolConditional(context, node: chapel.Conditional):
+        """
+        Warn for boolean conditionals that can be simplified.
+        """
         then = list(node.then_block().stmts())
         else_block = node.else_block()
         else_block = list(else_block.stmts()) if else_block else []


### PR DESCRIPTION
Adds a new rule to chplcheck for simple boolean conditionals that can be simplified, like `var cond = if x ==1 then true else false;`.

I came up with this rule after finding it as a common anti-pattern in user code.

- [ ] `start_test test/chplcheck`

[Reviewed by @]