### PR TITLE
Rename `pre-edition` to `preview`

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -350,7 +350,7 @@ const char* compileCommandFilename = "compileCommand.tmp";
 const char* compileCommand = NULL;
 char compileVersion[64];
 
-std::array<std::string, 2> editions ({{"2.0", "pre-edition"}});
+std::array<std::string, 2> editions ({{"2.0", "preview"}});
 std::string fEdition = "2.0";
 
 static bool fPrintCopyright = false;
@@ -902,6 +902,13 @@ static void setEdition(const ArgumentDescription* desc, const char* arg) {
 
   if (val == "default") {
     // Use the default edition, which is set at the declaration point
+
+  } else if (val == "pre-edition") {
+    USR_WARN("'pre-edition' has been renamed to 'preview'.  This option will "
+             "still be available for a few releases, but we recommend updating "
+             "to the new name.");
+    fEdition = editions.back();
+
   } else if (!isValidEdition(val)) {
     printf("--edition only accepts a limited set of values.  Current options");
     printf(" are:\n");

--- a/doc/rst/technotes/editions.rst
+++ b/doc/rst/technotes/editions.rst
@@ -25,9 +25,9 @@ description:
 |                 |                                                            |
 |                 | See :ref:`default-edition`.                                |
 +-----------------+------------------------------------------------------------+
-| ``pre-edition`` | A collection of changes intended for future editions.      |
+| ``preview``     | A collection of changes intended for future editions.      |
 |                 |                                                            |
-|                 | See :ref:`pre-edition` and :ref:`pre-edition-changes`.     |
+|                 | See :ref:`preview-edition` and :ref:`preview-changes`.     |
 +-----------------+------------------------------------------------------------+
 
 When a change is required that would break existing user codes, the change will
@@ -35,10 +35,11 @@ be guarded by an edition.  Users interested in updating to use this new behavior
 can compile their code with ``--edition=<edition with the change>``, while the
 majority of users can continue to rely on the old behavior by default.
 
-The 2.5 release introduced two editions, ``2.0`` and ``pre-edition``.  ``2.0``
-is the default edition and will remain the default for the foreseeable future.
-``pre-edition`` is a gathering point for breaking changes until there is a
-sufficient quantity of them to justify a new edition.
+The 2.5 release introduced two editions, ``2.0`` and ``pre-edition``.  In 2.6,
+``pre-edition`` was renamed to ``preview``.  ``2.0`` is the default edition and
+will remain the default for the foreseeable future.  ``preview`` is a gathering
+point for breaking changes until there is a sufficient quantity of them to
+justify a new edition.
 
 .. _default-edition:
 
@@ -70,20 +71,20 @@ edition, if not more.
    discussion on that subject.
 
 
-.. _pre-edition:
+.. _preview-edition:
 
 -------------------
-The Pre-Edition
+The Preview Edition
 -------------------
 
-The ``pre-edition`` is a gathering point for breaking changes until there is a
-sufficient quantity of them to justify a new edition.  There will always be a
-``pre-edition``, though users should avoid relying on it for production code as
-breaking changes will be introduced to it without warning.
+The ``preview`` edition is a gathering point for breaking changes until there is
+a sufficient quantity of them to justify a new edition.  There will always be a
+``preview`` edition, though users should avoid relying on it for production code
+as breaking changes will be introduced to it without warning.
 
-Changes that have been elevated from the ``pre-edition`` into an official
-edition will still be present in the ``pre-edition`` going forward, until such
-time as a conflicting change is made.
+Changes that have been elevated from the ``preview`` edition into an official
+edition will still be present in the ``preview`` edition going forward, until
+such time as a conflicting change is made.
 
 ------------
 Old Editions
@@ -105,17 +106,17 @@ Changes
 This section is intended as a living list of breaking changes and which edition
 they were introduced in.
 
-.. _pre-edition-changes:
+.. _preview-changes:
 
-++++++++++++++++++++++++++
-Changes in the Pre-Edition
-++++++++++++++++++++++++++
+++++++++++++++++++++++++++++++
+Changes in the Preview Edition
+++++++++++++++++++++++++++++++
 
 
 The following are a list of breaking changes currently accessible by compiling
-with ``--edition=pre-edition``.  When a new edition is created, some of these
+with ``--edition=preview``.  When a new edition is created, some of these
 changes may be included in that edition as well, while others may continue to
-remain in the pre-edition until they are deemed sufficiently complete.
+remain in the preview until they are deemed sufficiently complete.
 
 - The ``reshape`` function has been modified to support aliasing.  This enables
   viewing an existing array's elements using a different shape for the array.

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2924,7 +2924,7 @@ module ChapelArray {
 
   // The following are the historical reshape() procedures that rely
   // on copying the array's elements, proposed to be replaced by the
-  // pre-edition variants that follow
+  // preview edition variants that follow
 
   /* Return a copy of the array ``A`` containing the same values but
      in the shape of the domain ``D``. The number of indices in the
@@ -2936,7 +2936,7 @@ module ChapelArray {
 
         In addition to the above version of reshape(), there is
         another experimental version that is available when compiling
-        with ``--edition=pre-edition``.  Its main feature is that, by
+        with ``--edition=preview``.  Its main feature is that, by
         default, it creates a reshaped version of the array that
         aliases the original elements rather than making a copy of
         them.  Other new features include:
@@ -3010,7 +3010,7 @@ module ChapelArray {
   }
 
   // The following is the proposed new reshape() implementation that
-  // supports aliasing by default, currently part of a pre-edition
+  // supports aliasing by default, currently part of a preview edition
 
   @chpldoc.nodoc
   config param checkReshapeDimsByDefault = boundsChecking;
@@ -3026,7 +3026,7 @@ module ChapelArray {
   pragma "no promotion when by ref"
   pragma "fn returns aliasing array"
   @chpldoc.nodoc
-  @edition(first="pre-edition")
+  @edition(first="preview")
   proc reshape(arr: [], ranges: range(?)...) {
     return arr.chpl_aliasReshape(ranges, checkReshapeDimsByDefault);
   }
@@ -3034,14 +3034,14 @@ module ChapelArray {
   pragma "no promotion when by ref"
   pragma "fn returns aliasing array"
   @chpldoc.nodoc
-  @edition(first="pre-edition")
+  @edition(first="preview")
   proc reshape(arr: [], ranges: range(?)..., checkDims: bool) {
     return arr.chpl_aliasReshape(ranges, checkDims);
   }
 
   pragma "last resort"
   @chpldoc.nodoc
-  @edition(first="pre-edition")
+  @edition(first="preview")
   proc reshape(arr: [], ranges: range(?)..., param copy: bool)
    where copy == true {
     return arr.chpl_copyReshape({(...ranges)}, checkReshapeDimsByDefault);
@@ -3051,14 +3051,14 @@ module ChapelArray {
   pragma "fn returns aliasing array"
   pragma "last resort"
   @chpldoc.nodoc
-  @edition(first="pre-edition")
+  @edition(first="preview")
   proc reshape(arr: [], ranges: range(?)..., param copy: bool)
    where copy == false {
     return arr.chpl_aliasReshape({(...ranges)}, checkReshapeDimsByDefault);
   }
 
   @chpldoc.nodoc
-  @edition(first="pre-edition")
+  @edition(first="preview")
   proc reshape(arr: [], ranges: range(?)...,
                checkDims = checkReshapeDimsByDefault, param copy = false)
    where copy == true {
@@ -3068,7 +3068,7 @@ module ChapelArray {
   pragma "no promotion when by ref"
   pragma "fn returns aliasing array"
   @chpldoc.nodoc
-  @edition(first="pre-edition")
+  @edition(first="preview")
   proc reshape(arr: [], ranges: range(?)...,
                checkDims = checkReshapeDimsByDefault, param copy = false)
    where copy == false {
@@ -3079,7 +3079,7 @@ module ChapelArray {
   // doesn't alias, so can't use the "fn returns aliasing array" pragma
 
   @chpldoc.nodoc
-  @edition(first="pre-edition")
+  @edition(first="preview")
   proc reshape(arr: [], dom: domain(?), checkDims=checkReshapeDimsByDefault,
                param copy = false) where copy == true {
     return arr.chpl_copyReshape(dom, checkDims);
@@ -3088,7 +3088,7 @@ module ChapelArray {
   pragma "no promotion when by ref"
   pragma "fn returns aliasing array"
   @chpldoc.nodoc
-  @edition(first="pre-edition")
+  @edition(first="preview")
   proc reshape(arr: [], dom: domain(?), checkDims=checkReshapeDimsByDefault,
                param copy = false) where copy == false {
     return arr.chpl_aliasReshape(dom, checkDims);

--- a/test/arrays/doc-examples/ArrayReshape.compopts
+++ b/test/arrays/doc-examples/ArrayReshape.compopts
@@ -1,1 +1,1 @@
---edition=pre-edition
+--edition=preview

--- a/test/arrays/reshape/new-edition/COMPOPTS
+++ b/test/arrays/reshape/new-edition/COMPOPTS
@@ -1,1 +1,1 @@
---edition=pre-edition
+--edition=preview

--- a/test/arrays/reshape/new-edition/transition/oldVsNew.compopts
+++ b/test/arrays/reshape/new-edition/transition/oldVsNew.compopts
@@ -1,2 +1,2 @@
 --edition=2.0          # oldVsNew.good
---edition=pre-edition  # oldVsNew-new.good
+--edition=preview      # oldVsNew-new.good

--- a/test/edition/basics/attributeCheck-badArgName.chpl
+++ b/test/edition/basics/attributeCheck-badArgName.chpl
@@ -1,4 +1,4 @@
-@edition(fisrt="pre-edition")
+@edition(fisrt="preview")
 proc foo(x: int) {
   writeln("in new edition foo with arg x=", x);
 }

--- a/test/edition/basics/attributeCheck-badOrdering.chpl
+++ b/test/edition/basics/attributeCheck-badOrdering.chpl
@@ -1,5 +1,5 @@
 // Checks the behavior when first is a newer edition than last
-@edition(first="pre-edition", last="2.0")
+@edition(first="preview", last="2.0")
 proc foo() {
   writeln("huh, that shouldn't have worked");
 }

--- a/test/edition/basics/attributeCheck-badOrdering.good
+++ b/test/edition/basics/attributeCheck-badOrdering.good
@@ -1,1 +1,1 @@
-attributeCheck-badOrdering.chpl:3: error: last edition '2.0' is earlier than first edition 'pre-edition'
+attributeCheck-badOrdering.chpl:3: error: last edition '2.0' is earlier than first edition 'preview'

--- a/test/edition/basics/attributeCheck-noArgName.chpl
+++ b/test/edition/basics/attributeCheck-noArgName.chpl
@@ -1,4 +1,4 @@
-@edition("pre-edition")
+@edition("preview")
 proc foo(x: int) {
   writeln("in new edition foo with arg x=", x);
 }

--- a/test/edition/basics/attributeCheck.chpl
+++ b/test/edition/basics/attributeCheck.chpl
@@ -1,5 +1,5 @@
 /* START_EXAMPLE */
-@edition(first="pre-edition")
+@edition(first="preview")
 proc foo(x: int) {
   writeln("in new edition foo with arg x=", x);
 }
@@ -11,7 +11,7 @@ proc foo(x: int) {
 /* STOP_EXAMPLE */
 
 // Check specifying both first and last works
-@edition(first="2.0", last="pre-edition")
+@edition(first="2.0", last="preview")
 proc bar(s: string) {
   writeln(s);
 }
@@ -22,7 +22,7 @@ proc baz() {
   writeln("in old baz");
 }
 
-@edition(first="pre-edition", last="pre-edition")
+@edition(first="preview", last="preview")
 proc baz() {
   writeln("in new baz");
 }

--- a/test/edition/basics/attributeCheck.compopts
+++ b/test/edition/basics/attributeCheck.compopts
@@ -1,4 +1,5 @@
  # attributeCheck.good
 --edition=default # attributeCheck.good
 --edition=2.0 # attributeCheck.good
---edition=pre-edition # attributeCheck.new.good
+--edition=preview # attributeCheck.new.good
+--edition=pre-edition # attributeCheck.pre-edition.good

--- a/test/edition/basics/attributeCheck.pre-edition.good
+++ b/test/edition/basics/attributeCheck.pre-edition.good
@@ -1,0 +1,6 @@
+warning: 'pre-edition' has been renamed to 'preview'.  This option will still be available for a few releases, but we recommend updating to the new name.
+warning: 'pre-edition' has been renamed to 'preview'.  This option will still be available for a few releases, but we recommend updating to the new name.
+warning: 'pre-edition' has been renamed to 'preview'.  This option will still be available for a few releases, but we recommend updating to the new name.
+in new edition foo with arg x=17
+always relevant
+in new baz

--- a/test/edition/basics/flagCheck.badEdition.good
+++ b/test/edition/basics/flagCheck.badEdition.good
@@ -1,4 +1,4 @@
 --edition only accepts a limited set of values.  Current options are:
 default (currently '2.0')
 2.0
-pre-edition
+preview

--- a/test/edition/basics/flagCheck.compopts
+++ b/test/edition/basics/flagCheck.compopts
@@ -1,5 +1,6 @@
  # flagCheck.good
 --edition=default
 --edition=2.0
---edition=pre-edition
+--edition=preview
+--edition=pre-edition # flagCheck.pre-edition.good
 --edition=thisHadBetterNeverBeAnActualEditionNameYall # flagCheck.badEdition.good

--- a/test/edition/basics/flagCheck.pre-edition.good
+++ b/test/edition/basics/flagCheck.pre-edition.good
@@ -1,0 +1,3 @@
+warning: 'pre-edition' has been renamed to 'preview'.  This option will still be available for a few releases, but we recommend updating to the new name.
+warning: 'pre-edition' has been renamed to 'preview'.  This option will still be available for a few releases, but we recommend updating to the new name.
+warning: 'pre-edition' has been renamed to 'preview'.  This option will still be available for a few releases, but we recommend updating to the new name.

--- a/test/library/standard/Sort/errors/sortDomainArray.compopts
+++ b/test/library/standard/Sort/errors/sortDomainArray.compopts
@@ -4,7 +4,7 @@
 # this case has warnings
 -sassoc7 --edition=2.0 # sortDomainArray.assoc7.good
 # this case errors
--sassoc7 --edition=pre-edition # sortDomainArray.assoc7-removed.good
+-sassoc7 --edition=preview # sortDomainArray.assoc7-removed.good
 # disable the warnings with a compiler flag
 -sassoc7 --edition=2.0 -snoSortedWarnings # sortDomainArray.good
 


### PR DESCRIPTION
We decided to rename the edition where we accumulate changes from `pre-edition` to `preview`.

Resolves #27383 

Updates the documentation to (mostly) use the new name.

In the compiler, update the name stored in the editions array, but continue to accept `pre-edition` for a while longer, generating a warning when the old name is used.

Unfortunately, this warning will fire three times instead of just once.  I believe this is because we do several subprocesses for the compiler and flags need to be checked at all of them.  I tried several strategies to make the message get printed just once but I think the only way to truly manage it is to make it an error instead of a warning and I don't think that's appropriate

Update ChapelArray to use `preview` in the edition attribute after the renaming.

Update the editions tests for the edition name change:
- Use `preview` instead of `pre-edition` for all edition attributes
- Update expected messages that include the name
- Add addition testing of the `--edition` flag to use `preview` and make special
  .good files for using `pre-edition` that check the warning is printed
- Adjusted tests for `reshape` and `sorted` to use the new name instead of the old one

Passed a full paratest with futures