### PR TITLE
Reduce the code size impact of `bitshiftChecks`

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1263,23 +1263,23 @@ module ChapelBase {
   }
 
   inline operator <<(param a: int(?w), param b: integral) param {
-    bitshiftChecks(a, b);
+    if boundsChecking then bitshiftChecks(a, b);
     // Intentionally cast `a` to `uint(w)` for an unsigned left shift.
     return __primitive("<<", a:uint(w), b):int(w);
   }
 
   inline operator <<(param a: uint(?w), param b: integral) param {
-   bitshiftChecks(a, b);
+    if boundsChecking then bitshiftChecks(a, b);
     return __primitive("<<", a, b);
   }
 
   inline operator >>(param a: int(?w), param b: integral) param {
-    bitshiftChecks(a, b);
+    if boundsChecking then bitshiftChecks(a, b);
     return __primitive(">>", a, b);
   }
 
   inline operator >>(param a: uint(?w), param b: integral) param {
-    bitshiftChecks(a, b);
+    if boundsChecking then bitshiftChecks(a, b);
     return __primitive(">>", a, b);
   }
 


### PR DESCRIPTION
Reduces the code size impact of `bitshiftChecks` by removing `inline` from its definition. 

There is no reason this function should be inlined, as its just error checking. I suspect it was marked inline to make sure the line numbers matched user code. But through the use of a pragma and `errorDepth=2` we can achieve the same thing.

Making these changes results in large savings for generated code size in large applications. In arkouda, it saved reduced the number of lines of generated C code by 18x in `src/SipHash.chpl`, which results in a 5% overall reduction in generated code size (using Arkouda with CHPL_COMM=none and `ARKOUDA_QUICK_COMPILE=1` and `ARKOUDA_RUNTIME_CHECKS=1`).

I identified this improvement with similar techniques to the ones used in #27511

- [x] paratest with/without gasnet

[Reviewed by @e-kayrakli]