### PR TITLE
Remove debug compopt from raCommCheckLCG

### DIFF
--- a/test/multilocale/deitz/needMultiLocales/raCommCheckLCG.compopts
+++ b/test/multilocale/deitz/needMultiLocales/raCommCheckLCG.compopts
@@ -1,2 +1,1 @@
 -M../../../release/examples/benchmarks/hpcc --no-warnings
--M../../../release/examples/benchmarks/hpcc --no-warnings --no-auto-local-access


### PR DESCRIPTION
This compopt was added in a longshot attempt to gain some information about the testing failure in raCommCheckLCG, but now that the test is passing (for as-yet unknown reasons) I'm removing it.