### PR TITLE
Fix memory faults in slurm-gasnetrun_* launchers

### DIFF
--- a/runtime/src/chpl-launcher-common.c
+++ b/runtime/src/chpl-launcher-common.c
@@ -126,22 +126,25 @@ void chpl_append_to_cmd(char** cmdBufPtr, int* charsWritten,
   }
 
   // Determine additional characters to be written
-  const int addedLen = vsnprintf(NULL, 0, format, argsForLen) + 1;
+  // vsnprintf does not include the space for the null terminator, so plus one
+  const int requiredLength = vsnprintf(NULL, 0, format, argsForLen) + 1;
   va_end(argsForLen);
-  int newLen = *charsWritten + addedLen;
+  int newCmdBufSize = *charsWritten + requiredLength;
 
   // Allocate more memory if needed
-  if (newLen >= initialSize) {
-    *cmdBufPtr = (char*)chpl_mem_realloc(*cmdBufPtr, newLen * sizeof(char),
+  if (newCmdBufSize >= initialSize) {
+    *cmdBufPtr = (char*)chpl_mem_realloc(*cmdBufPtr, newCmdBufSize * sizeof(char),
                                         CHPL_RT_MD_COMMAND_BUFFER, -1, 0);
   }
 
-  // Write the new characters
-  const int actuallyWrote = vsnprintf(*cmdBufPtr + *charsWritten, addedLen, format, argsForPrint);
-  va_end(argsForPrint);
-  *charsWritten = actuallyWrote;
-}
+  char* currentBufEnd = *cmdBufPtr + *charsWritten;
+  int currentBufEndLen = requiredLength;
 
+  // Write the new characters
+  const int actuallyWrote = vsnprintf(currentBufEnd, currentBufEndLen, format, argsForPrint);
+  va_end(argsForPrint);
+  *charsWritten += actuallyWrote;
+}
 //
 // Use this function to run short utility programs that will return less
 //  than 1024 characters of output.  The program must not expect any input.

--- a/runtime/src/chpl-launcher-common.c
+++ b/runtime/src/chpl-launcher-common.c
@@ -126,7 +126,7 @@ void chpl_append_to_cmd(char** cmdBufPtr, int* charsWritten,
   }
 
   // Determine additional characters to be written
-  const int addedLen = vsnprintf(NULL, 0, format, argsForLen);
+  const int addedLen = vsnprintf(NULL, 0, format, argsForLen) + 1;
   va_end(argsForLen);
   int newLen = *charsWritten + addedLen;
 
@@ -137,9 +137,9 @@ void chpl_append_to_cmd(char** cmdBufPtr, int* charsWritten,
   }
 
   // Write the new characters
-  vsnprintf(*cmdBufPtr + *charsWritten, addedLen + 1, format, argsForPrint);
+  const int actuallyWrote = vsnprintf(*cmdBufPtr + *charsWritten, addedLen, format, argsForPrint);
   va_end(argsForPrint);
-  *charsWritten = newLen;
+  *charsWritten = actuallyWrote;
 }
 
 //

--- a/runtime/src/launch/slurm-gasnetrun_common/slurm-gasnetrun_common.h
+++ b/runtime/src/launch/slurm-gasnetrun_common/slurm-gasnetrun_common.h
@@ -186,8 +186,10 @@ static void propagate_environment(char** buf, int* charsWritten)
   // We could do this more selectively, but we would be likely
   // to leave out something important.
   char *enviro_keys = chpl_get_enviro_keys(',');
-  if (enviro_keys)
+  if (enviro_keys) {
     chpl_append_to_cmd(buf, charsWritten, " -E '%s'", enviro_keys);
+    chpl_mem_free(enviro_keys, 0, 0);
+  }
 }
 
 static char* chpl_launch_create_command(int argc, char* argv[],
@@ -389,11 +391,11 @@ int chpl_launch(int argc, char* argv[], int32_t numLocales,
 
   debug = getenv("CHPL_LAUNCHER_DEBUG");
 
-  retcode = chpl_launch_using_system(chpl_launch_create_command(argc, argv,
-                                          numLocales, numLocalesPerNode),
-            argv[0]);
+  char* command = chpl_launch_create_command(argc, argv, numLocales, numLocalesPerNode);
+  retcode = chpl_launch_using_system(command, argv[0]);
   chpl_launch_cleanup();
   chpl_mem_free(slurmFilename, 0, 0);
+  chpl_mem_free(command, 0, 0);
   return retcode;
 }
 


### PR DESCRIPTION
Fixes 1 memory fault and 2 memory leaks in the slurm-gasnetrun_ launchers. The memory fault was resulting in a confusing corruption of the `salloc` launch command, with garbage bytes being inserted. This was only repeatable with specific file name lengths. The problem was caused by strings not being properly null terminated, which was caused by an off-by-one error resulting from a bad assumption about `vsnprintf`. To debug and fix this memory fault I used valgrind, which flagged 2 other memory leaks (also fixed in this PR).

Testing

- [x] tested that previously failing code with corrupted memory now works
- [x] tested that previously failing code now runs cleanly with `valgrind --leak-check=full ...`
  - Note that running with `--show-leak-kinds=all` shows a bunch of extra leaks in `config.c`


Future work: What would it take to rewrite parts of the launchers in C++, instead of C. While rewriting the launchers in something other than C had been a long term goal, it can be daunting task. But using C++, we can interleave the existing C code with new C++ code and almost entirely eliminate these kinds of string processing errors. C++ is not a perfect language for this either, but its probably the easiest to start using immediately without large amounts of infrastructure/refactoring


[Reviewed by @benharsh]