### PR TITLE
Add `.. index::` for chplconfig to make it more searchable

### DIFF
--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -1028,6 +1028,9 @@ variables that support each option, run the compiler with the ``--help-env``
 flag.  For boolean flags and toggles, setting the environment variable to any
 value selects that flag.
 
+.. index::
+   single: chplconfig; Chapel configuration file
+
 .. _readme-chplenv.chplconfig:
 
 Chapel Configuration Files


### PR DESCRIPTION
Adds an index entry for `chplconfig` files so its more searchable in the docs

[Trivial - not reviewed]