### PR TITLE
Add chpl-shim to linux packages

### DIFF
--- a/util/packaging/apt/common/copy_files.py
+++ b/util/packaging/apt/common/copy_files.py
@@ -12,6 +12,7 @@ files = [
     "/usr/bin/mason",
     "/usr/bin/chplcheck",
     "/usr/bin/chpl-language-server",
+    "/usr/bin/chpl-shim",
 ]
 dirs = [
     "/usr/lib/chapel",

--- a/util/packaging/rpm/amzn2023/spec.template
+++ b/util/packaging/rpm/amzn2023/spec.template
@@ -34,6 +34,7 @@ cp %{_prefix}/bin/chpldoc %{buildroot}/%{_prefix}/bin/chpldoc
 cp %{_prefix}/bin/mason %{buildroot}/%{_prefix}/bin/mason
 cp %{_prefix}/bin/chplcheck %{buildroot}/%{_prefix}/bin/chplcheck
 cp %{_prefix}/bin/chpl-language-server %{buildroot}/%{_prefix}/bin/chpl-language-server
+cp %{_prefix}/bin/chpl-shim %{buildroot}/%{_prefix}/bin/chpl-shim
 # Libraries
 cp -r %{_prefix}/lib/chapel %{buildroot}/%{_prefix}/lib/chapel
 cp -r %{_prefix}/lib/cmake/chpl %{buildroot}/%{_prefix}/lib/cmake

--- a/util/packaging/rpm/el10/spec.template
+++ b/util/packaging/rpm/el10/spec.template
@@ -34,6 +34,7 @@ cp %{_prefix}/bin/chpldoc %{buildroot}/%{_prefix}/bin/chpldoc
 cp %{_prefix}/bin/mason %{buildroot}/%{_prefix}/bin/mason
 cp %{_prefix}/bin/chplcheck %{buildroot}/%{_prefix}/bin/chplcheck
 cp %{_prefix}/bin/chpl-language-server %{buildroot}/%{_prefix}/bin/chpl-language-server
+cp %{_prefix}/bin/chpl-shim %{buildroot}/%{_prefix}/bin/chpl-shim
 # Libraries
 cp -r %{_prefix}/lib/chapel %{buildroot}/%{_prefix}/lib/chapel
 cp -r %{_prefix}/lib/cmake/chpl %{buildroot}/%{_prefix}/lib/cmake

--- a/util/packaging/rpm/el9/spec.template
+++ b/util/packaging/rpm/el9/spec.template
@@ -34,6 +34,7 @@ cp %{_prefix}/bin/chpldoc %{buildroot}/%{_prefix}/bin/chpldoc
 cp %{_prefix}/bin/mason %{buildroot}/%{_prefix}/bin/mason
 cp %{_prefix}/bin/chplcheck %{buildroot}/%{_prefix}/bin/chplcheck
 cp %{_prefix}/bin/chpl-language-server %{buildroot}/%{_prefix}/bin/chpl-language-server
+cp %{_prefix}/bin/chpl-shim %{buildroot}/%{_prefix}/bin/chpl-shim
 # Libraries
 cp -r %{_prefix}/lib/chapel %{buildroot}/%{_prefix}/lib/chapel
 cp -r %{_prefix}/lib/cmake/chpl %{buildroot}/%{_prefix}/lib/cmake

--- a/util/packaging/rpm/fc41/spec.template
+++ b/util/packaging/rpm/fc41/spec.template
@@ -34,6 +34,7 @@ cp %{_prefix}/bin/chpldoc %{buildroot}/%{_prefix}/bin/chpldoc
 cp %{_prefix}/bin/mason %{buildroot}/%{_prefix}/bin/mason
 cp %{_prefix}/bin/chplcheck %{buildroot}/%{_prefix}/bin/chplcheck
 cp %{_prefix}/bin/chpl-language-server %{buildroot}/%{_prefix}/bin/chpl-language-server
+cp %{_prefix}/bin/chpl-shim %{buildroot}/%{_prefix}/bin/chpl-shim
 # Libraries
 cp -r %{_prefix}/lib/chapel %{buildroot}/%{_prefix}/lib/chapel
 cp -r %{_prefix}/lib/cmake/chpl %{buildroot}/%{_prefix}/lib/cmake

--- a/util/packaging/rpm/fc42/spec.template
+++ b/util/packaging/rpm/fc42/spec.template
@@ -34,6 +34,7 @@ cp %{_prefix}/bin/chpldoc %{buildroot}/%{_prefix}/bin/chpldoc
 cp %{_prefix}/bin/mason %{buildroot}/%{_prefix}/bin/mason
 cp %{_prefix}/bin/chplcheck %{buildroot}/%{_prefix}/bin/chplcheck
 cp %{_prefix}/bin/chpl-language-server %{buildroot}/%{_prefix}/bin/chpl-language-server
+cp %{_prefix}/bin/chpl-shim %{buildroot}/%{_prefix}/bin/chpl-shim
 # Libraries
 cp -r %{_prefix}/lib/chapel %{buildroot}/%{_prefix}/lib/chapel
 cp -r %{_prefix}/lib/cmake/chpl %{buildroot}/%{_prefix}/lib/cmake


### PR DESCRIPTION
Adds the `chpl-shim` tool to the linux package builds, as it was previously missing

[Reviewed by @]