### PR TITLE
Avoid inlining functions that just do checks

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1383,7 +1383,7 @@ module ChapelArray {
     // checks should be performed and is set based on the value of
     // the --no-formal-domain-checks flag.
     //
-    inline proc chpl_checkArrArgDoms(formalDom: domain, param runtimeChecks: bool) {
+    proc chpl_checkArrArgDoms(formalDom: domain, param runtimeChecks: bool) {
       //
       // It's a compile-time error if the ranks don't match
       //

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -665,53 +665,46 @@ module ChapelBase {
   inline operator *(a: complex(64), b: imag(32)) do return (-a.im*_i2r(b), a.re*_i2r(b)) : complex(64);
   inline operator *(a: complex(128), b: imag(64)) do return (-a.im*_i2r(b), a.re*_i2r(b)) : complex(128);
 
+  pragma "always propagate line file info"
+  proc checkDivision(b) {
+    if b == 0 then halt("Attempt to divide by zero");
+  }
+  pragma "always propagate line file info"
+  proc checkModulus(b) {
+    if b == 0 then halt("Attempt to compute a modulus by zero");
+  }
+
   inline operator /(a: int(8), b: int(8)) {
-    if (chpl_checkDivByZero) then
-      if b == 0 then
-        halt("Attempt to divide by zero");
+    if chpl_checkDivByZero then checkDivision(b);
     return __primitive("/", a, b);
   }
   inline operator /(a: int(16), b: int(16)) {
-    if (chpl_checkDivByZero) then
-      if b == 0 then
-        halt("Attempt to divide by zero");
+    if chpl_checkDivByZero then checkDivision(b);
     return __primitive("/", a, b);
   }
   inline operator /(a: int(32), b: int(32)) {
-    if (chpl_checkDivByZero) then
-      if b == 0 then
-        halt("Attempt to divide by zero");
+    if chpl_checkDivByZero then checkDivision(b);
     return __primitive("/", a, b);
   }
   inline operator /(a: int(64), b: int(64)) {
-    if (chpl_checkDivByZero) then
-      if b == 0 then
-        halt("Attempt to divide by zero");
+    if chpl_checkDivByZero then checkDivision(b);
     return __primitive("/", a, b);
   }
 
   inline operator /(a: uint(8), b: uint(8)) {
-    if (chpl_checkDivByZero) then
-      if b == 0 then
-        halt("Attempt to divide by zero");
+    if chpl_checkDivByZero then checkDivision(b);
     return __primitive("/", a, b);
   }
   inline operator /(a: uint(16), b: uint(16)) {
-    if (chpl_checkDivByZero) then
-      if b == 0 then
-        halt("Attempt to divide by zero");
+    if chpl_checkDivByZero then checkDivision(b);
     return __primitive("/", a, b);
   }
   inline operator /(a: uint(32), b: uint(32)) {
-    if (chpl_checkDivByZero) then
-      if b == 0 then
-        halt("Attempt to divide by zero");
+    if chpl_checkDivByZero then checkDivision(b);
     return __primitive("/", a, b);
   }
   inline operator /(a: uint(64), b: uint(64)) {
-    if (chpl_checkDivByZero) then
-      if b == 0 then
-        halt("Attempt to divide by zero");
+    if chpl_checkDivByZero then checkDivision(b);
     return __primitive("/", a, b);
   }
 
@@ -828,52 +821,36 @@ module ChapelBase {
   //
 
   inline operator %(a: int(8), b: int(8)) {
-    if (chpl_checkDivByZero) then
-      if b == 0 then
-        halt("Attempt to compute a modulus by zero");
+    if chpl_checkDivByZero then checkModulus(b);
     return __primitive("%", a, b);
   }
   inline operator %(a: int(16), b: int(16)) {
-    if (chpl_checkDivByZero) then
-      if b == 0 then
-        halt("Attempt to compute a modulus by zero");
+    if chpl_checkDivByZero then checkModulus(b);
     return __primitive("%", a, b);
   }
   inline operator %(a: int(32), b: int(32)) {
-    if (chpl_checkDivByZero) then
-      if b == 0 then
-        halt("Attempt to compute a modulus by zero");
+    if chpl_checkDivByZero then checkModulus(b);
     return __primitive("%", a, b);
   }
   inline operator %(a: int(64), b: int(64)) {
-    if (chpl_checkDivByZero) then
-      if b == 0 then
-        halt("Attempt to compute a modulus by zero");
+    if chpl_checkDivByZero then checkModulus(b);
     return __primitive("%", a, b);
   }
 
   inline operator %(a: uint(8), b: uint(8)) {
-    if (chpl_checkDivByZero) then
-      if b == 0 then
-        halt("Attempt to compute a modulus by zero");
+    if chpl_checkDivByZero then checkModulus(b);
     return __primitive("%", a, b);
   }
   inline operator %(a: uint(16), b: uint(16)) {
-    if (chpl_checkDivByZero) then
-      if b == 0 then
-        halt("Attempt to compute a modulus by zero");
+    if chpl_checkDivByZero then checkModulus(b);
     return __primitive("%", a, b);
   }
   inline operator %(a: uint(32), b: uint(32)) {
-    if (chpl_checkDivByZero) then
-      if b == 0 then
-        halt("Attempt to compute a modulus by zero");
+    if chpl_checkDivByZero then checkModulus(b);
     return __primitive("%", a, b);
   }
   inline operator %(a: uint(64), b: uint(64)) {
-    if (chpl_checkDivByZero) then
-      if b == 0 then
-        halt("Attempt to compute a modulus by zero");
+    if chpl_checkDivByZero then checkModulus(b);
     return __primitive("%", a, b);
   }
 
@@ -923,16 +900,21 @@ module ChapelBase {
   // ** on primitive types
   //
 
+  pragma "always propagate line file info"
+  proc _intExpHelp_checkZero(a, b) {
+    if a == 0 then halt("cannot compute ", a, " ** ", b);
+  }
+
   inline proc _intExpHelp(a: integral, b) where a.type == b.type {
-    if isIntType(b.type) && b < 0 then
-      if a == 0 then
-        halt("cannot compute ", a, " ** ", b);
-      else if a == 1 then
+    if isIntType(b.type) && b < 0 {
+      if boundsChecking then _intExpHelp_checkZero(a, b);
+      if a == 1 then
         return 1;
       else if a == -1 then
         return if b % 2 == 0 then 1 else -1;
       else
         return 0;
+    }
     var i = b, y:a.type = 1, z = a;
     while i != 0 {
       if i % 2 == 1 then
@@ -1284,7 +1266,7 @@ module ChapelBase {
   }
 
   pragma "always propagate line file info"
-  private inline proc checkNotNil(x:borrowed class?) {
+  private proc checkNotNil(x:borrowed class?) {
     import HaltWrappers;
     // Check only if --nil-checks is enabled or user requested
     if chpl_checkNilDereferences || enablePostfixBangChecks {
@@ -1533,6 +1515,11 @@ module ChapelBase {
     return initMethod;
   }
 
+  pragma "always propagate line file info"
+  proc arrayInitHalt(initMethod) {
+    halt("ArrayInit.", initMethod, " should have been made concrete");
+  }
+
   proc init_elts(x, s, type t, lo=0:s.type) : void {
 
     var initMethod = init_elts_method(s, t);
@@ -1572,7 +1559,7 @@ module ChapelBase {
         }
       }
       otherwise {
-        halt("ArrayInit.", initMethod, " should have been made concrete");
+        arrayInitHalt(initMethod);
       }
     }
   }
@@ -2739,52 +2726,36 @@ module ChapelBase {
   }
 
   inline operator /=(ref lhs:int(8), rhs:int(8)) {
-    if (chpl_checkDivByZero) then
-      if rhs == 0 then
-        halt("Attempt to divide by zero");
+    if chpl_checkDivByZero then checkDivision(rhs);
     __primitive("/=", lhs, rhs);
   }
   inline operator /=(ref lhs:int(16), rhs:int(16)) {
-    if (chpl_checkDivByZero) then
-      if rhs == 0 then
-        halt("Attempt to divide by zero");
+    if chpl_checkDivByZero then checkDivision(rhs);
     __primitive("/=", lhs, rhs);
   }
   inline operator /=(ref lhs:int(32), rhs:int(32)) {
-    if (chpl_checkDivByZero) then
-      if rhs == 0 then
-        halt("Attempt to divide by zero");
+    if chpl_checkDivByZero then checkDivision(rhs);
     __primitive("/=", lhs, rhs);
   }
   inline operator /=(ref lhs:int(64), rhs:int(64)) {
-    if (chpl_checkDivByZero) then
-      if rhs == 0 then
-        halt("Attempt to divide by zero");
+    if chpl_checkDivByZero then checkDivision(rhs);
     __primitive("/=", lhs, rhs);
   }
 
   inline operator /=(ref lhs:uint(8), rhs:uint(8)) {
-    if (chpl_checkDivByZero) then
-      if rhs == 0 then
-        halt("Attempt to divide by zero");
+    if chpl_checkDivByZero then checkDivision(rhs);
     __primitive("/=", lhs, rhs);
   }
   inline operator /=(ref lhs:uint(16), rhs:uint(16)) {
-    if (chpl_checkDivByZero) then
-      if rhs == 0 then
-        halt("Attempt to divide by zero");
+    if chpl_checkDivByZero then checkDivision(rhs);
     __primitive("/=", lhs, rhs);
   }
   inline operator /=(ref lhs:uint(32), rhs:uint(32)) {
-    if (chpl_checkDivByZero) then
-      if rhs == 0 then
-        halt("Attempt to divide by zero");
+    if chpl_checkDivByZero then checkDivision(rhs);
     __primitive("/=", lhs, rhs);
   }
   inline operator /=(ref lhs:uint(64), rhs:uint(64)) {
-    if (chpl_checkDivByZero) then
-      if rhs == 0 then
-        halt("Attempt to divide by zero");
+    if chpl_checkDivByZero then checkDivision(rhs);
     __primitive("/=", lhs, rhs);
   }
 
@@ -2796,52 +2767,36 @@ module ChapelBase {
   }
 
   inline operator %=(ref lhs:int(8), rhs:int(8)) {
-    if (chpl_checkDivByZero) then
-      if rhs == 0 then
-        halt("Attempt to compute a modulus by zero");
+    if chpl_checkDivByZero then checkModulus(rhs);
     __primitive("%=", lhs, rhs);
   }
   inline operator %=(ref lhs:int(16), rhs:int(16)) {
-    if (chpl_checkDivByZero) then
-      if rhs == 0 then
-        halt("Attempt to compute a modulus by zero");
+    if chpl_checkDivByZero then checkModulus(rhs);
     __primitive("%=", lhs, rhs);
   }
   inline operator %=(ref lhs:int(32), rhs:int(32)) {
-    if (chpl_checkDivByZero) then
-      if rhs == 0 then
-        halt("Attempt to compute a modulus by zero");
+    if chpl_checkDivByZero then checkModulus(rhs);
     __primitive("%=", lhs, rhs);
   }
   inline operator %=(ref lhs:int(64), rhs:int(64)) {
-    if (chpl_checkDivByZero) then
-      if rhs == 0 then
-        halt("Attempt to compute a modulus by zero");
+    if chpl_checkDivByZero then checkModulus(rhs);
     __primitive("%=", lhs, rhs);
   }
 
   inline operator %=(ref lhs:uint(8), rhs:uint(8)) {
-    if (chpl_checkDivByZero) then
-      if rhs == 0 then
-        halt("Attempt to compute a modulus by zero");
+    if chpl_checkDivByZero then checkModulus(rhs);
     __primitive("%=", lhs, rhs);
   }
   inline operator %=(ref lhs:uint(16), rhs:uint(16)) {
-    if (chpl_checkDivByZero) then
-      if rhs == 0 then
-        halt("Attempt to compute a modulus by zero");
+    if chpl_checkDivByZero then checkModulus(rhs);
     __primitive("%=", lhs, rhs);
   }
   inline operator %=(ref lhs:uint(32), rhs:uint(32)) {
-    if (chpl_checkDivByZero) then
-      if rhs == 0 then
-        halt("Attempt to compute a modulus by zero");
+    if chpl_checkDivByZero then checkModulus(rhs);
     __primitive("%=", lhs, rhs);
   }
   inline operator %=(ref lhs:uint(64), rhs:uint(64)) {
-    if (chpl_checkDivByZero) then
-      if rhs == 0 then
-        halt("Attempt to compute a modulus by zero");
+    if chpl_checkDivByZero then checkModulus(rhs);
     __primitive("%=", lhs, rhs);
   }
 
@@ -3026,15 +2981,11 @@ module ChapelBase {
     return __primitive("/", a, b);
   }
   inline operator /(param a: uint(64), b: uint(64)) {
-    if (chpl_checkDivByZero) then
-      if b == 0 then
-        halt("Attempt to divide by zero");
+    if chpl_checkDivByZero then checkDivision(b);
     return __primitive("/", a, b);
   }
   inline operator /(param a: int(64), b: int(64)) {
-    if (chpl_checkDivByZero) then
-      if b == 0 then
-        halt("Attempt to divide by zero");
+    if chpl_checkDivByZero then checkDivision(b);
     return __primitive("/", a, b);
   }
 
@@ -3065,9 +3016,7 @@ module ChapelBase {
   }
   // necessary to support e.g. 10 % myuint
   inline operator %(param a: uint(64), b: uint(64)) {
-    if (chpl_checkDivByZero) then
-      if b == 0 then
-        halt("Attempt to compute a modulus by zero");
+    if chpl_checkDivByZero then checkModulus(b);
     return __primitive("%", a, b);
   }
   inline operator %(a: int(64), param b: int(64)) {
@@ -3075,9 +3024,7 @@ module ChapelBase {
     return __primitive("%", a, b);
   }
   inline operator %(param a: int(64), b: int(64)) {
-    if (chpl_checkDivByZero) then
-      if b == 0 then
-        halt("Attempt to compute a modulus by zero");
+    if chpl_checkDivByZero then checkModulus(b);
     return __primitive("%", a, b);
   }
 

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -666,11 +666,11 @@ module ChapelBase {
   inline operator *(a: complex(128), b: imag(64)) do return (-a.im*_i2r(b), a.re*_i2r(b)) : complex(128);
 
   pragma "always propagate line file info"
-  proc checkDivision(b) {
+  private proc checkDivision(b) {
     if b == 0 then halt("Attempt to divide by zero");
   }
   pragma "always propagate line file info"
-  proc checkModulus(b) {
+  private proc checkModulus(b) {
     if b == 0 then halt("Attempt to compute a modulus by zero");
   }
 
@@ -1516,7 +1516,7 @@ module ChapelBase {
   }
 
   pragma "always propagate line file info"
-  proc arrayInitHalt(initMethod) {
+  private proc arrayInitHalt(initMethod) {
     halt("ArrayInit.", initMethod, " should have been made concrete");
   }
 

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -901,7 +901,7 @@ module ChapelBase {
   //
 
   pragma "always propagate line file info"
-  proc _intExpHelp_checkZero(a, b) {
+  private proc _intExpHelp_checkZero(a, b) {
     if a == 0 then halt("cannot compute ", a, " ** ", b);
   }
 

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -1826,7 +1826,7 @@ private proc isBCPindex(type t) param do
   // Bounds checking
   //
 
-  inline proc range.chpl_boundsCheck(other: range(?e,?b,?s))
+  proc range.chpl_boundsCheck(other: range(?e,?b,?s))
     where b == boundKind.neither
   {
     if chpl__singleValIdxType(idxType) {
@@ -1839,7 +1839,7 @@ private proc isBCPindex(type t) param do
     return true;
   }
 
-  inline proc range.chpl_boundsCheck(other: range(?e,?b,?s))
+  proc range.chpl_boundsCheck(other: range(?e,?b,?s))
   {
     if ! this.isAligned()
       then return false;
@@ -1881,7 +1881,7 @@ private proc isBCPindex(type t) param do
 
   // used in checkRankChange(args) where each args(i) can be
   // either a range or an individual index
-  inline proc range.chpl_boundsCheck(other: idxType) do
+  proc range.chpl_boundsCheck(other: idxType) do
     return contains(other);
 
 
@@ -2267,7 +2267,7 @@ private proc isBCPindex(type t) param do
 
   /////////// operators 'by', 'align', '#' ///////////
 
-  inline proc chpl_check_step_integral(step) {
+  proc chpl_check_step_integral(step) {
     if !isIntegral(step.type) then
       compilerError("can't apply 'by' using step of a non-integral type ",
                     step.type:string);
@@ -2282,7 +2282,7 @@ private proc isBCPindex(type t) param do
   // Helpers to check if the stride of a range is invalid. Error (either at
   // runtime or compile time) if it's invalid.
 
-  inline proc chpl_range_check_stride(step, type idxType) {
+  proc chpl_range_check_stride(step, type idxType) {
     chpl_check_step_integral(step);
     type strType = chpl__rangeStrideType(idxType);
 
@@ -2297,7 +2297,7 @@ private proc isBCPindex(type t) param do
     }
   }
 
-  inline proc chpl_range_check_stride(param step, type idxType)  {
+  proc chpl_range_check_stride(param step, type idxType)  {
     chpl_check_step_integral(step);
     type strType = chpl__rangeStrideType(idxType);
 
@@ -3300,7 +3300,7 @@ private proc isBCPindex(type t) param do
     compilerError("iteration over a range with no bounds");
   }
 
-  private inline proc boundsCheckUnboundedRange(r: range(?)) {
+  private proc boundsCheckUnboundedRange(r: range(?)) {
     if boundsChecking {
       if ! r.hasFirstForIter() then
         HaltWrappers.boundsCheckHalt("iteration over range that has no first index");

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -2267,7 +2267,7 @@ private proc isBCPindex(type t) param do
 
   /////////// operators 'by', 'align', '#' ///////////
 
-  proc chpl_check_step_integral(step) {
+  private proc chpl_check_step_integral(step) {
     if !isIntegral(step.type) then
       compilerError("can't apply 'by' using step of a non-integral type ",
                     step.type:string);

--- a/modules/internal/MemConsistency.chpl
+++ b/modules/internal/MemConsistency.chpl
@@ -102,7 +102,7 @@ module MemConsistency {
       when memoryOrder.release do return memory_order_release;
       when memoryOrder.acqRel  do return memory_order_acq_rel;
       when memoryOrder.seqCst  do return memory_order_seq_cst;
-      otherwise do HaltWrappers.exhaustiveSelectHalt("Invalid memoryOrder");
+      otherwise do compilerError("Invalid memoryOrder");
     }
   }
 

--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -256,25 +256,25 @@ module CTypes {
       }
     }
 
+    pragma "always propagate line file info"
+    @chpldoc.nodoc
+    proc boundsCheckThis(i) {
+      if i < 0 || i >= size then
+        HaltWrappers.boundsCheckHalt("c array index out of bounds " + i:string +
+                                     "(indices are 0.." + (size-1):string + ")");
+    }
+
     /* Retrieve the i'th element (zero based) from the array.
        Does the equivalent of arr[i] in C.
        Includes bounds checking when such checks are enabled.
     */
     inline proc ref this(i: integral) ref : eltType {
-      if boundsChecking then
-        if i < 0 || i >= size then
-          HaltWrappers.boundsCheckHalt("c array index out of bounds " + i:string +
-                                       "(indices are 0.." + (size-1):string + ")");
-
+      if boundsChecking then boundsCheckThis(i);
       return __primitive("array_get", this, i);
     }
     @chpldoc.nodoc
     inline proc const ref this(i: integral) const ref : eltType {
-      if boundsChecking then
-        if i < 0 || i >= size then
-          HaltWrappers.boundsCheckHalt("c array index out of bounds " + i:string +
-                                       "(indices are 0.." + (size-1):string + ")");
-
+      if boundsChecking then boundsCheckThis(i);
       return __primitive("array_get", this, i);
     }
 
@@ -803,6 +803,20 @@ module CTypes {
     return x;
   }
 
+  pragma "always propagate line file info"
+  @chpldoc.nodoc
+  proc checksFor_c_ptrTo_arr(l, arr_size, param constVersion=false) {
+    param name = if constVersion then "c_ptrToConst" else "c_ptrTo";
+    if l != here then
+      halt(
+        name + "() can only be applied to an array from the locale on " +
+        "which it lives (array is on locale " + l.id:string +
+        ", call was made on locale " + here.id:string + ")");
+
+    if arr_size == 0 then
+      halt("Can't create a C pointer for an array with 0 elements.");
+  }
+
   /*
     Returns a :type:`c_ptr` to the elements of a non-distributed
     Chapel rectangular array.  Note that the existence of this
@@ -819,16 +833,7 @@ module CTypes {
     if (!chpl__isDROrDRView(arr)) then
       compilerError("Only single-locale rectangular arrays support c_ptrTo() at present");
 
-    if boundsChecking {
-      if (arr._value.locale != here) then
-        halt(
-            "c_ptrTo() can only be applied to an array from the locale on " +
-            "which it lives (array is on locale " + arr._value.locale.id:string +
-            ", call was made on locale " + here.id:string + ")");
-
-      if (arr.size == 0) then
-        halt("Can't create a C pointer for an array with 0 elements.");
-    }
+    if boundsChecking then checksFor_c_ptrTo_arr(arr._value.locale, arr.size);
 
     return c_pointer_return(arr[arr.domain.low]);
   }
@@ -908,16 +913,7 @@ module CTypes {
     if (!chpl__isDROrDRView(arr)) then
       compilerError("Only single-locale rectangular arrays support c_ptrToConst() at present");
 
-    if boundsChecking {
-      if (arr._value.locale != here) then
-        halt(
-            "c_ptrToConst() can only be applied to an array from the locale on " +
-            "which it lives (array is on locale " + arr._value.locale.id:string +
-            ", call was made on locale " + here.id:string + ")");
-
-      if (arr.size == 0) then
-        halt("Can't create a C pointer for an array with 0 elements.");
-    }
+    if boundsChecking then checksFor_c_ptrTo_arr(arr._value.locale, arr.size, true);
 
     return c_pointer_return_const(arr[arr.domain.low]);
   }

--- a/modules/standard/MemMove.chpl
+++ b/modules/standard/MemMove.chpl
@@ -174,48 +174,6 @@ module MemMove {
     }
   }
 
-  // TODO: this function is unused, can it be removed?
-  private inline proc _haltBadIndex(a, idx, indexName: string) {
-    import HaltWrappers.boundsCheckHalt;
-
-    if !a.domain.contains(idx) then
-      boundsCheckHalt('Cannot move-initialize array because its domain ' +
-                      'does not contain: ' + indexName);
-  }
-
-  // TODO: this function is unused, can it be removed?
-  // Call to 'indexOrder' assumes 'idx' is a valid index.
-  private inline proc _haltBadElementRange(a, idx, numElements: int) {
-    import HaltWrappers.boundsCheckHalt;
-
-    if numElements > a.size then
-      boundsCheckHalt('Cannot move-initialize array because number of ' +
-                      'elements to copy exceeds array size');
-
-    if numElements <= 0 then
-      boundsCheckHalt('Cannot move-initialize array because number of ' +
-                      'elements to copy is <= 0');
-
-    const order = a.domain.indexOrder(idx);
-    const hi = order + numElements;
-
-    if hi > a.size then
-      boundsCheckHalt('Cannot move-initialize array because one or ' +
-                      'more indices fall outside its domain');
-  }
-
-  // TODO: this function is unused, can it be removed?
-  private inline proc _haltRangeOverlap(dstIndex, srcIndex, numElements) {
-    import HaltWrappers.boundsCheckHalt;
-
-    const dstRange = dstIndex..#numElements;
-    const srcRange = srcIndex..#numElements;
-
-    if dstRange[srcRange].size != 0 then
-      boundsCheckHalt('Cannot move-initialize array because source and ' +
-                      'destination ranges intersect');
-  }
-
   // TODO: Relax this restriction in the future.
   private inline proc _errorNot1DRectangularArray(a) {
     if !a.isDefaultRectangular() || a.rank > 1 then

--- a/modules/standard/MemMove.chpl
+++ b/modules/standard/MemMove.chpl
@@ -174,6 +174,7 @@ module MemMove {
     }
   }
 
+  // TODO: this function is unused, can it be removed?
   private inline proc _haltBadIndex(a, idx, indexName: string) {
     import HaltWrappers.boundsCheckHalt;
 
@@ -182,6 +183,7 @@ module MemMove {
                       'does not contain: ' + indexName);
   }
 
+  // TODO: this function is unused, can it be removed?
   // Call to 'indexOrder' assumes 'idx' is a valid index.
   private inline proc _haltBadElementRange(a, idx, numElements: int) {
     import HaltWrappers.boundsCheckHalt;
@@ -202,6 +204,7 @@ module MemMove {
                       'more indices fall outside its domain');
   }
 
+  // TODO: this function is unused, can it be removed?
   private inline proc _haltRangeOverlap(dstIndex, srcIndex, numElements) {
     import HaltWrappers.boundsCheckHalt;
 


### PR DESCRIPTION
Changes some internal modules to avoid inlining checks, since that can cause larger compilation times/memory usage. In some cases, this PR factors out the checks into another function so that they will not be duplicated in highly generic inlined functions (which do real work and probably should still be inlined).

Using arkouda as my proxy for a large Chapel application, this change saves 1% execution time.

This PR also removes some unused functions from MemMove.

- [x] paratest with/without gasnet

<details>

<summary>useful scripts I wrote while working on this PR</summary>

Find inline functions with halts/compilerErrors

```python
import chapel
import sys

files = sys.argv[1:]

ctx = chapel.Context()
ctx.set_module_paths([], [])
for file in files:
    asts = ctx.parse(file)

    for (fn, _) in chapel.each_matching(asts, chapel.Function):
        assert isinstance(fn, chapel.Function)
        if not fn.is_inline():
            continue

        # find all any halts
        for (stmt, capture) in chapel.each_matching(fn.body(), [chapel.FnCall, "?name", chapel.rest]):
            if "halt" in str(capture["name"]).lower() or "compilerErrror" in str(capture["name"]).lower():
                print(f"Found a halt in {fn.name()} in {stmt.location()}")

```

Find string literals that are used most often in string concat operations

```python

import sys
import os
import argparse
import re
from collections import defaultdict


chpl_plus_pattern = re.compile(r'chpl___PLUS_\d+\(.*?\n')
str_literal_pattern = re.compile(r'_str_literal_\w+')

def compute(filename):

    # find all chpl___PLUS_\d+\( functions
    # if the line contains any _str_literal_*, log it

    string_literal_counts = defaultdict(int)
    with open(filename, 'r') as f:
        content = f.read()
        for match in chpl_plus_pattern.findall(content):
            for match_str in str_literal_pattern.findall(match):
                string_literal_counts[match_str] += 1

    return string_literal_counts


if __name__ == '__main__':

    parser = argparse.ArgumentParser(description='Count lines in generated C code.')
    parser.add_argument('filename', type=str, help='Path to the generated C file')
    parser.add_argument('--sort', action='store_true', help='Sort the output by size')

    args = parser.parse_args()

    files_to_check = []
    if os.path.isdir(args.filename):
        for root, dirs, files in os.walk(args.filename):
            for file in files:
                if file.endswith('.c'):
                    files_to_check.append(os.path.join(root, file))
    else:
        files_to_check.append(args.filename)


    string_literal_counts = defaultdict(int)
    for file in files_to_check:
        counts = compute(file)
        for key, value in counts.items():
            string_literal_counts[key] += value
    
    if args.sort:
        string_literal_counts = sorted(string_literal_counts.items(), key=lambda x: x[1], reverse=True)
    else:
        string_literal_counts = string_literal_counts.items()

    for key, value in string_literal_counts:
        print(f"{value:6} {key}")

```

</details>

[Reviewed by @e-kayrakli]