### PR TITLE
Fix parsing of string values in TOML files

### DIFF
--- a/test/library/packages/TOML/test/stringEscapes.chpl
+++ b/test/library/packages/TOML/test/stringEscapes.chpl
@@ -1,0 +1,44 @@
+
+use TOML, IO;
+
+const str1 = '[table]\nkey = %sFoo, Bar%s';
+const str2 = '[table]\nkey = %sFoo \t\\ Bar%s';
+const str3 = """
+[table]
+key = %sFoo \ Bar%s
+""";
+const str4 = """
+[table]
+key = %sFoo \'\"\\ Bar%s
+""";
+const str5 = '[table]\nkey = "Foo, \' Bar"';
+const str6 = "[table]\nkey = 'Foo, \" Bar'";
+
+proc test(s, quoteType="") {
+  var str:string;
+  if quoteType == ""
+    then str = s;
+    else str = s.format(quoteType, quoteType);
+  var TomlData = parseToml(str);
+  var value = TomlData["table"]!["key"];
+  writeln(value!.toString());
+}
+
+proc main() {
+  writeln("Test with single quotes:");
+  test(str1, "'");
+  test(str2, "'");
+  test(str3, "'");
+  test(str4, "'");
+
+  writeln("Test with double quotes:");
+  test(str1, '"');
+  test(str2, '"');
+  test(str3, '"');
+  test(str4, '"');
+
+  writeln("Test with escaped quotes:");
+  test(str5);
+  test(str6);
+}
+

--- a/test/library/packages/TOML/test/stringEscapes.good
+++ b/test/library/packages/TOML/test/stringEscapes.good
@@ -1,0 +1,13 @@
+Test with single quotes:
+"Foo, Bar"
+"Foo 	\ Bar"
+"Foo \ Bar"
+"Foo \'\"\\ Bar"
+Test with double quotes:
+"Foo, Bar"
+"Foo 	\ Bar"
+"Foo \ Bar"
+"Foo \'\"\\ Bar"
+Test with escaped quotes:
+"Foo, ' Bar"
+"Foo, " Bar"


### PR DESCRIPTION
Fixes an issue I came across where the TOML library does not correctly parse some strings, particularly ones with commas or escaped quotes (`\"`/`\'`).

This PR fixes the regex (which needed to be updated in two places) and refactors the code to remove some duplication.

- [x] paratest with/without gasnet

[Reviewed by @benharsh]