### PR TITLE
Improve Chapel homebrew formula to allow extern C blocks

### DIFF
--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -113,6 +113,7 @@ class Chapel < Formula
       end
     end
     system bin/"chpl", "--print-passes", "--print-commands", libexec/"examples/hello.chpl"
+    system bin/"chpl", "--target-compiler", cbackend, "--print-passes", "--print-commands", libexec/"examples/hello.chpl"
     system bin/"chpldoc", "--version"
     system bin/"mason", "--version"
 


### PR DESCRIPTION
Improves the Chapel homebrew formula to build the C backend by setting CHPL_TARGET_COMPILER, rather than by setting `CHPL_LLVM=none`.

This allows users who make use of the C backend with homebrew to still use code with extern C blocks, which requires the LLVM backend

This should result in faster build times for the formula itself as well.

Users should see no change if they are using the C backend (by toggling CHPL_LLVM) and not making use of extern blocks.

- [x] Tested homebrew build from source on my Macbook

The formula will get propagated to homebrew through the normal Chapel release procedures

[Reviewed by @arifthpe]