### PR TITLE
Fix broken skipif for chplcheck test

### DIFF
--- a/test/chplcheck/rule-settings/SKIPIF
+++ b/test/chplcheck/rule-settings/SKIPIF
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 python=$($CHPL_HOME/util/config/find-python.sh)
-if $CHPL_HOME/util/config/run-in-venv-with-python-bindings.bash $python python3 -c "import chapel" 2> /dev/null; then
+if $CHPL_HOME/util/config/run-in-venv-with-python-bindings.bash $python -c "import chapel" 2> /dev/null; then
     echo "False"
 else
     echo "True"


### PR DESCRIPTION
Fixes a skipif that was always returning `True`.

[Not reviewed - trivial]