### PR TITLE
Add skipif for settings where this test doesn't behave the same

### DIFF
--- a/test/technotes/doc-examples/AttributeExamples.skipif
+++ b/test/technotes/doc-examples/AttributeExamples.skipif
@@ -1,0 +1,2 @@
+COMPOPTS <= --fast
+CHPL_LLVM == none


### PR DESCRIPTION
The vectorization output doesn't always get generated, so we don't want to run the test when it would generate different output.  Since it gets output in the default settings, I think it's okay to just skipif this test instead of splitting the LLVM portion into its own test (but that's probably the more principled solution).

Checked a fresh checkout with our default linux64 settings (and `-respect-skipifs`) and with `--fast`.  Checked behavior with `CHPL_LLVM=none` locally but not on the fresh checkout