### PR TITLE
Prediff out the `--memLeaks` flag from test output

### DIFF
--- a/test/technotes/doc-examples/MainProcExample1.prediff
+++ b/test/technotes/doc-examples/MainProcExample1.prediff
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# remove FILE: --memLeaks
+sed '/--memLeaks/d' $2 > $2.tmp
+mv $2.tmp $2


### PR DESCRIPTION
Prediffs out the `--memLeaks` flag from a new test where the output depends on the flags passed. This allows `--memLeaks` testing to pass.

[Reviewed by @]