### PR TITLE
Adjust pre-edition error tests for `--no-compiler-driver`

### DIFF
--- a/test/edition/basics/attributeCheck.compopts
+++ b/test/edition/basics/attributeCheck.compopts
@@ -3,3 +3,4 @@
 --edition=2.0 # attributeCheck.good
 --edition=preview # attributeCheck.new.good
 --edition=pre-edition # attributeCheck.pre-edition.good
+--edition=pre-edition --no-compiler-driver # attributeCheck.pre-edition.shorter.good

--- a/test/edition/basics/attributeCheck.pre-edition.shorter.good
+++ b/test/edition/basics/attributeCheck.pre-edition.shorter.good
@@ -1,0 +1,4 @@
+warning: 'pre-edition' has been renamed to 'preview'.  This option will still be available for a few releases, but we recommend updating to the new name.
+in new edition foo with arg x=17
+always relevant
+in new baz

--- a/test/edition/basics/attributeCheck.skipif
+++ b/test/edition/basics/attributeCheck.skipif
@@ -1,0 +1,2 @@
+# explicitly checks this in the compopts file.  Remove when pre-edition is removed
+COMPOPTS <= --no-compiler-driver

--- a/test/edition/basics/flagCheck.compopts
+++ b/test/edition/basics/flagCheck.compopts
@@ -3,4 +3,5 @@
 --edition=2.0
 --edition=preview
 --edition=pre-edition # flagCheck.pre-edition.good
+--edition=pre-edition --no-compiler-driver # flagCheck.pre-edition.shorter.good
 --edition=thisHadBetterNeverBeAnActualEditionNameYall # flagCheck.badEdition.good

--- a/test/edition/basics/flagCheck.pre-edition.shorter.good
+++ b/test/edition/basics/flagCheck.pre-edition.shorter.good
@@ -1,0 +1,1 @@
+warning: 'pre-edition' has been renamed to 'preview'.  This option will still be available for a few releases, but we recommend updating to the new name.

--- a/test/edition/basics/flagCheck.skipif
+++ b/test/edition/basics/flagCheck.skipif
@@ -1,0 +1,2 @@
+# explicitly checks this in the compopts file.  Remove when pre-edition is removed
+COMPOPTS <= --no-compiler-driver


### PR DESCRIPTION
The `pre-edition` warning message is sensitive to the use of the compiler driver, so include a compopt to test with that flag and otherwise skip the test with `--no-compiler-driver`, since we're already testing it.

When we remove support for `pre-edition`, we should remove the skipif files as well

Checked the behavior of a fresh checkout of the tests, both with and without `--no-compiler-driver`