### PR TITLE
Use `on_macos` instead of `OS.mac?` in homebrew formula

### DIFF
--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -26,7 +26,10 @@ class Chapel < Formula
 
   # determine the C backend to use based on the system
   def cbackend
-    OS.mac? ? "clang" : "gnu"
+    on_macos do
+      return "clang"
+    end
+    return "gnu"
   end
 
   def install


### PR DESCRIPTION
Use `on_macos` instead of `OS.mac?` in homebrew formula, since the homebrew style check fails if you use the if statement form.

[Reviewed by @]