### PR TITLE
Fix clang resource-dir detection on some OSes

### DIFF
--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -495,7 +495,7 @@ def is_system_clang_version_ok(clang_command):
 # are arguments to use.
 # Returns None if no override was present.
 @memoize
-def get_overriden_llvm_clang(lang):
+def get_overridden_llvm_clang(lang):
     lang_upper = lang.upper()
     if lang_upper == 'C++':
         lang_upper = 'CXX'
@@ -555,7 +555,7 @@ def get_overriden_llvm_clang(lang):
 # use. Returns '' if no acceptable system clang was found.
 @memoize
 def get_system_llvm_clang(lang):
-    provided = get_overriden_llvm_clang(lang)
+    provided = get_overridden_llvm_clang(lang)
     if provided:
         return provided[0]
 
@@ -601,7 +601,7 @@ def get_system_llvm_clang(lang):
 def get_llvm_clang_noargs(lang):
 
     # if it was provided by a user setting, just use that
-    provided = get_overriden_llvm_clang(lang)
+    provided = get_overridden_llvm_clang(lang)
     if provided:
         return provided[0]
 
@@ -623,7 +623,7 @@ def get_llvm_clang_noargs(lang):
 def get_llvm_clang(lang):
 
     # if it was provided by a user setting, just use that
-    provided = get_overriden_llvm_clang(lang)
+    provided = get_overridden_llvm_clang(lang)
     if provided:
         return provided
 

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -591,6 +591,8 @@ def get_system_llvm_clang(lang):
             if '/' not in clang_path:
                 clang_path = which(clang_path)
             if is_system_clang_version_ok(clang_path):
+                # get the real path to the clang executable
+                clang_path = os.path.realpath(clang_path)
                 return clang_path
     return ''
 
@@ -898,11 +900,6 @@ def get_sysroot_linux_args():
                 args.append('--start-no-unused-arguments')
                 args.append('-Wl,-dynamic-linker,' + dyn_linker)
                 args.append('--end-no-unused-arguments')
-
-    # workaround for fedora
-    if chpl_platform.is_fedora():
-        clang = get_llvm_clang_noargs('c')
-        args.extend(_clang_get_resourcedir(clang))
 
     return args
 


### PR DESCRIPTION
Fixes the detection of `resource-dir` on some platforms. The PR removes the [workaround](https://github.com/chapel-lang/chapel/pull/27443) that was fedora specific and uses a more general and principled fix.

The exact problem was as follows:
- LLVM/the clang driver determines the resource dir based on the path of the `clang` executable.
  - basically it tries two different heuristics based on the absolute path of `clang` and some configured variables at build time 
  - See `std::string Driver::GetResourcesPath(StringRef BinaryPath)`.
- Some of the build time variables changed in recent updates to the LLVM packages in Fedora and CentOS, which is why we only see this issue with the latest version's of LLVM on very specific OSes.
  - See https://gitlab.com/redhat/centos-stream/rpms/llvm/-/commit/5826a876b063f4b5041be2eaac07473b78f956ed for an example, where the `llvm.spec` has new logic related to the libdir and does things like set `CLANG_RESOURCE_DIR` where it didn't before.
- We determine the path to clang based on `llvm-config` and sometimes the inferred clang path is a symlink (which we don't resolve).
  - e.g., on fedora we were inferring clang to be  `/usr/lib64/llvm20/bin/clang`, but that is just a symlink to `/usr/bin/clang-20`
- Because we were passing a symlink to the `clang::Driver` constructor in `clangUtil.cpp` (which was not being resolved to a real path), it was throwing off the resource-dir detection logic.

So the solution is to just make sure the `clang` we are using is an absolute path.

- [x] tested that we can build Chapel and compile `hello.chpl` on fedora 42

[Reviewed by @]