### PR TITLE
Several improvements to sparse domain implementations

### DIFF
--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -183,7 +183,17 @@ class SparseBlockDom: BaseSparseDomImpl(?) {
                                           sparseLayoutType=sparseLayoutType,
                                           dist=dist);
 
-    if !dataSorted then sort(inds, comparator=comp);
+    // NOTE: at this point, we have to ignore `dataSorted`. The sorting we do
+    // here uses a custom comparator. The rest of the logic here depends on that
+    // custom comparator. Things get a bit tricky here because if the user has
+    // used the `addOn` argument, then we would expect a lexicographical sorting
+    // rather than the custom one here. Right now, I am choosing to silently
+    // ignore the flag in this setting. We could consider issuing warnings, but
+    // it is hard to imagine how to achieve that with today's interface, where
+    // the main problem is two bool flags to the `dsiBulkAdd`. It is hard to
+    // tell whether `Dom.bulkAdd(Inds, true);` uses the dataSorted flag at
+    // compile time
+    sort(inds, comparator=comp);
 
     var localeRanges: [dist.targetLocDom] range;
     on inds {

--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -212,7 +212,7 @@ class SparseBlockDom: BaseSparseDomImpl(?) {
     var _totalAdded: atomic int;
     coforall l in dist.targetLocDom do on dist.targetLocales[l] {
       const _retval = locDoms[l]!.mySparseBlock.bulkAdd(inds[localeRanges[l]],
-          dataSorted=true, isUnique=false);
+          dataSorted=true, isUnique=isUnique);
       _totalAdded.add(_retval);
     }
     const _retval = _totalAdded.read();
@@ -222,8 +222,9 @@ class SparseBlockDom: BaseSparseDomImpl(?) {
   proc _bulkAddHere_help(inds: [] index(rank,idxType),
       dataSorted=false, isUnique=false) {
 
-    const _retval = myLocDom!.mySparseBlock.bulkAdd(inds, dataSorted=true,
-        isUnique=false);
+    const _retval = myLocDom!.mySparseBlock.bulkAdd(inds,
+                                                    dataSorted=dataSorted,
+                                                    isUnique=isUnique);
     return _retval;
   }
 

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -780,7 +780,7 @@ module ChapelDistribution {
 
     proc ref commit() {
       if cur >= 1 then
-        obj.dsiBulkAdd(buf[..cur-1]);
+        obj.dsiBulkAddNoPreserveInds(buf[..cur-1]);
       cur = 0;
     }
   }


### PR DESCRIPTION
This PR:

- Wires in `isUnique` and `dataSorted` flags correctly in the block-distributed sparse domain implementation.
- Uses `dsiBulkAddNoPreserveInds` instead of `dsiBulkAdd` in the sparse index buffer implementation. This avoids an extra array copy during bulk addition at the cost of reordering the index array. That array refers to the index buffer which is by default disposable. So no need to preserve indices.
- Resolves https://github.com/chapel-lang/chapel/issues/27547 by silently ignoring the `dataSorted` flag. (I'll comment more under that issue)