### PR TITLE
Do not use the bundled LLVM on XC+ugni

### DIFF
--- a/util/cron/test-gpu-xc-cuda.ugni.bash
+++ b/util/cron/test-gpu-xc-cuda.ugni.bash
@@ -9,7 +9,6 @@ source $UTIL_CRON_DIR/common-native-gpu.bash
 # Setup for GPU:
 module load cudatoolkit
 export CHPL_TARGET_COMPILER=llvm
-export CHPL_LLVM=bundled
 export CHPL_TARGET_CPU=native
 export CHPL_LAUNCHER_CONSTRAINT=BW18
 export CHPL_LAUNCHER="slurm-srun"


### PR DESCRIPTION
Avoid using the bundled LLVM on this test machine to save machine time. This will fall back to the LLVM 14 from spack installed on the system

[Reviewed by @vasslitvinov]