### PR TITLE
Fix usage of unknown flag with older LLVM

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2926,12 +2926,14 @@ static void helpComputeClangArgs(std::string& clangCC,
     clangCCArgs.push_back(clangRequiredWarningFlags[i]);
   }
 
+#if HAVE_LLVM_VER >= 150
   if (usingGpuLocaleModel() &&
       getGpuCodegenType() == GpuCodegenType::GPU_CG_NVIDIA_CUDA) {
     // this is necessary for CUB 11. Once we drop CUDA 11 support, we can
     // probably remove this
     clangCCArgs.push_back("-Wno-deprecated-builtins");
   }
+#endif
 
   // Add debug flags
   if (debugCCode) {


### PR DESCRIPTION
Fixes usage of `-Wno-deprecated-builtins` with clang 14, because the warning wasn't added until clang 15.

[Reviewed by @]