### PR TITLE
Fix path detection of sibiling clang tools

### DIFF
--- a/compiler/include/files.h
+++ b/compiler/include/files.h
@@ -147,8 +147,8 @@ bool readArgsFromFile(std::string path, std::vector<std::string>& cmds,
 void expandInstallationPaths(std::string& arg);
 void expandInstallationPaths(std::vector<std::string>& args);
 
-bool isDirectory(const char* path);
-bool pathExists(const char* path);
+bool isDirectory(std::string_view path);
+bool pathExists(std::string_view path);
 
 char*       chplRealPath(const char* path);
 char*       dirHasFile(const char* dir, const char* file);

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -61,6 +61,9 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
+#include "llvm/Support/Path.h"
+#include "llvm/Support/FileSystem.h"
+
 
 std::string executableFilename;
 std::string libmodeHeadername;
@@ -1103,22 +1106,12 @@ void expandInstallationPaths(std::vector<std::string>& args) {
   }
 }
 
-bool isDirectory(const char* path)
-{
-  struct stat stats;
-  if (stat(path, &stats) == 0 && (stats.st_mode & S_IFMT) == S_IFDIR)
-    return true;
-
-  return false;
+bool isDirectory(std::string_view path) {
+  return llvm::sys::fs::is_directory(path);
 }
 
-bool pathExists(const char* path)
-{
-  struct stat stats;
-  if (stat(path, &stats) == 0)
-    return true;
-
-  return false;
+bool pathExists(std::string_view path) {
+  return llvm::sys::fs::exists(path);
 }
 
 // would just use realpath, but it is not supported on all platforms.

--- a/compiler/util/stringutil.cpp
+++ b/compiler/util/stringutil.cpp
@@ -54,12 +54,12 @@ const char* astr(const char* s1)
 
 const char* astr(const std::string& s)
 {
-  return astr(s.c_str());
+  return astr(std::string_view(s));
 }
 const char* astr(std::string_view s)
 {
   // Make a std::string copy of the string_view to guarantee null termination.
-  return astr(std::string(s));
+  return gContext->uniqueCString(s.data(), s.size());
 }
 const char* astr(UniqueString s)
 {


### PR DESCRIPTION
Fixes the path detection of sibling clang tools, which was fragile to filenames like `clang-20`. To support this, I also modernized some string handling to prefer `std::string_view`

- [ ] paratest

[Reviewed by @]