### PR TITLE
Change the default Arkouda nightly branch name

### DIFF
--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -4,7 +4,7 @@
 # Arkouda and runs testing.
 
 ARKOUDA_URL=${ARKOUDA_URL:-https://github.com/Bears-R-Us/arkouda.git}
-ARKOUDA_BRANCH=${ARKOUDA_BRANCH:-master}
+ARKOUDA_BRANCH=${ARKOUDA_BRANCH:-main}
 
 export CHPL_TEST_ARKOUDA_STOP_AFTER_BUILD=${CHPL_TEST_ARKOUDA_STOP_AFTER_BUILD:-"false"}
 


### PR DESCRIPTION
This PR changes the default branch name we use for nightly Arkouda testing to `main`.