### PR TITLE
Expand Homebrew formula to include multi-locale and gpu support

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1439,6 +1439,7 @@ static ArgumentDescription arg_desc[] = {
  {"comm-substrate", ' ', "<conduit>", "Specify communication conduit", "S", NULL, "_CHPL_COMM_SUBSTRATE", setChplEnv},
  {"gasnet-segment", ' ', "<segment>", "Specify GASNet memory segment", "S", NULL, "_CHPL_GASNET_SEGMENT", setChplEnv},
  {"gmp", ' ', "<gmp-version>", "Specify GMP library", "S", NULL, "_CHPL_GMP", setChplEnv},
+ {"gpu", ' ', "<gpu>", "Specify the GPU vendor", "S", NULL, "_CHPL_GPU", setChplEnv},
  {"hwloc", ' ', "<hwloc-impl>", "Specify whether to use hwloc", "S", NULL, "_CHPL_HWLOC", setChplEnv},
  {"launcher", ' ', "<launcher-system>", "Specify how to launch programs", "S", NULL, "_CHPL_LAUNCHER", setChplEnv},
  {"lib-pic", ' ', "<pic>", "Specify whether to use position-dependent or position-independent code", "S", NULL, "_CHPL_LIB_PIC", setChplEnv},

--- a/doc/rst/platforms/macosx.rst
+++ b/doc/rst/platforms/macosx.rst
@@ -20,34 +20,31 @@ There are two main approaches for using Chapel on Mac OS X:
 Homebrew
 --------
 
-A minimal installation of Chapel can be obtained through Homebrew_ with the
-following commands::
+Chapel can be installed through Homebrew_ with the following commands:
 
-    brew update
-    brew install chapel
+.. code-block:: bash
+
+   brew update
+   brew install chapel
 
 These commands install the latest release of Chapel.  When using a
 Homebrew installation of Chapel, the ``CHPL_HOME`` directory can be found by
-running the following command::
+running the following command:
 
-    chpl --print-chpl-home
+.. code-block:: bash
 
-Compile and run a test program::
+   chpl --print-chpl-home
 
-    chpl `chpl --print-chpl-home`/examples/hello.chpl
-    ./hello
+Compile and run a test program:
+
+.. code-block:: bash
+
+   chpl `chpl --print-chpl-home`/examples/hello.chpl
+   ./hello
 
 If you're new to Chapel, refer to the `What's Next?
 <https://chapel-lang.org/docs/usingchapel/QUICKSTART.html#what-s-next>`_
 section of :ref:`chapelhome-quickstart` for next steps.
-
-.. note::
-
-   The Homebrew installation provides a minimal installation of Chapel
-   for users to explore and test the language.  Of the omitted
-   features, :ref:`multilocale <readme-multilocale>` support is most
-   notable.  Users interested in utilizing Chapel's complete set of
-   features should build Chapel from source (option 2 above).
 
 .. note::
 
@@ -57,6 +54,69 @@ section of :ref:`chapelhome-quickstart` for next steps.
 
     brew install chapel --HEAD
 
+Multi-locale Execution
+~~~~~~~~~~~~~~~~~~~~~~
+
+The Homebrew installation of Chapel supports 2 different ways of
+:ref:`running multi-locale programs <readme-multilocale>` on your
+shared memory machine:
+
+* Using the :ref:`GASNet SMP conduit <readme-gasnet-smp>` allows you to run
+  multi-locale programs by partitioning the machine's resources into multiple
+  locales.
+
+  Compile and run a test program:
+
+  .. code-block:: bash
+
+     chpl --comm=gasnet --comm-substrate=smp \\
+       `chpl --print-chpl-home`/examples/hello6-taskpar-dist.chpl
+     ./hello6-taskpar-dist -nl 4
+
+* Using the :ref:`GASNNet UDP conduit <readme-gasnet-emulating-multilocale>`
+  allows you to run multi-locale programs by oversubscribing the machine's
+  resources.
+
+  Compile and run a test program:
+
+  .. code-block:: bash
+
+     chpl --comm=gasnet --comm-substrate=udp \\
+       `chpl --print-chpl-home`/examples/hello6-taskpar-dist.chpl
+     chplrun-udp ./hello6-taskpar-dist -nl 4
+
+  .. note::
+
+     Note the usage of the ``chplrun-udp`` command to run the program. This is a
+     necessary to setup the environment for the UDP conduit to properly launch
+     the program locally through the network stack. You can also forgo the
+     ``chplrun-udp`` command and run the program directly, making sure to properly
+     setup the environment. This will also allow you to launch jobs on
+     multiple nodes across the network. See :ref:`using-udp` for details.
+
+For more information on the differences between these two modes,
+see :ref:`readme-udp-vs-smp`.
+
+GPU Execution
+~~~~~~~~~~~~~
+
+The Homebrew installation of Chapel comes with a mode for emulating GPU
+execution. This allows you to test Chapel programs designed for a GPU, but
+it does not provide actual GPU support. If you are interested in compiling
+Chapel code for NVIDIA or AMD GPUs, see the
+:ref:`GPU documentation <readme-gpu>`.
+
+Compile and run a test program:
+
+.. code-block:: bash
+
+   chpl --locale-mode=gpu --gpu=cpu `chpl --print-chpl-home`/examples/gpu/hello-gpu.chpl
+   ./hello-gpu
+
+.. warning::
+
+   Chapel does not yet support GPU commutation with Apple GPUs. The above code
+   will emulate GPU execution by treating the CPU as a GPU.
 
 .. _Homebrew: https://brew.sh/
 

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -209,11 +209,17 @@ def _reportMissingGpuReq(msg, allowExempt=True, suggestNone=True):
 def determine_gpu_type():
     typesFound = [val for (val, gpu_type) in GPU_TYPES.items() if which(gpu_type.compiler)]
     if len(typesFound) == 1:
-      return typesFound[0]
+        return typesFound[0]
 
-    error("Unable to determine GPU type%s, assign 'CHPL_GPU' to one of: [%s]" %
-      ("" if len(typesFound) == 0 else " (detected: [%s])" %  ", ".join(typesFound),
-       ", ".join(GPU_TYPES.keys())))
+    detected_str = (
+        " (detected: [{}])".format(", ".join(typesFound)) if typesFound else ""
+    )
+    options_str = ", ".join(t for t in GPU_TYPES.keys() if t != "none")
+    error(
+        "Unable to determine GPU type{}, assign 'CHPL_GPU' to one of: [{}]".format(
+            detected_str, options_str
+        )
+    )
     return None
 
 @memoize

--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -76,7 +76,7 @@ class Chapel < Formula
         system "make"
       end
       with_env(CHPL_COMM: "gasnet", CHPL_COMM_SUBSTRATE: "udp",
-        CHPL_GASNET_CFG_OPTIONS: "--disable-ibv"
+        CHPL_GASNET_CFG_OPTIONS: "--disable-auto-conduit-detect --enable-udp --enable-smp"
       ) do
         system "make"
         with_env(CHPL_TARGET_COMPILER: cbackend) do
@@ -84,7 +84,7 @@ class Chapel < Formula
         end
       end
       with_env(CHPL_COMM: "gasnet", CHPL_COMM_SUBSTRATE: "smp",
-        CHPL_GASNET_CFG_OPTIONS: "--disable-ibv"
+        CHPL_GASNET_CFG_OPTIONS: "--disable-auto-conduit-detect --enable-udp --enable-smp"
       ) do
         system "make"
         with_env(CHPL_TARGET_COMPILER: cbackend) do

--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -1,3 +1,6 @@
+# typed: strict
+# frozen_string_literal: true
+
 class Chapel < Formula
   include Language::Python::Shebang
 
@@ -75,16 +78,20 @@ class Chapel < Formula
       with_env(CHPL_TARGET_COMPILER: cbackend) do
         system "make"
       end
-      with_env(CHPL_COMM: "gasnet", CHPL_COMM_SUBSTRATE: "udp",
-        CHPL_GASNET_CFG_OPTIONS: "--disable-auto-conduit-detect --enable-udp --enable-smp"
+      with_env(
+        CHPL_COMM:               "gasnet",
+        CHPL_COMM_SUBSTRATE:     "udp",
+        CHPL_GASNET_CFG_OPTIONS: "--disable-auto-conduit-detect --enable-udp --enable-smp",
       ) do
         system "make"
         with_env(CHPL_TARGET_COMPILER: cbackend) do
           system "make"
         end
       end
-      with_env(CHPL_COMM: "gasnet", CHPL_COMM_SUBSTRATE: "smp",
-        CHPL_GASNET_CFG_OPTIONS: "--disable-auto-conduit-detect --enable-udp --enable-smp"
+      with_env(
+        CHPL_COMM:               "gasnet",
+        CHPL_COMM_SUBSTRATE:     "smp",
+        CHPL_GASNET_CFG_OPTIONS: "--disable-auto-conduit-detect --enable-udp --enable-smp",
       ) do
         system "make"
         with_env(CHPL_TARGET_COMPILER: cbackend) do
@@ -136,7 +143,27 @@ class Chapel < Formula
     EOS
     chplrun_udp.chmod 0755
     bin.install_symlink chplrun_udp => "chplrun-udp"
+  end
 
+  def post_install
+    ohai "Chapel has been installed successfully!"
+    puts <<~EOS
+      By default, compiled Chapel programs will be single-locale only. There are
+      two ways to compile and run multi-locale Chapel programs locally:
+
+      Compile your program with:
+        `chpl --comm=gasnet --comm-substrate=smp`
+
+      OR
+
+      Compile your program with:
+        `chpl --comm=gasnet --comm-substrate=udp`
+      And then run it with:
+        `chplrun-udp ./your_program_name`
+
+      To simulate GPU execution, you can compile your program with:
+        `chpl --locale-model=gpu --gpu=cpu`
+    EOS
   end
 
   test do
@@ -150,9 +177,13 @@ class Chapel < Formula
         system "util/test/checkChplInstall"
       end
       with_env(CHPL_COMM: "gasnet", CHPL_COMM_SUBSTRATE: "udp") do
-        with_env(GASNET_SPAWNFN: "L", GASNET_ROUTE_OUTPUT: "0",
-          GASNET_QUIET: "Y", GASNET_MASTERIP: "127.0.0.1",
-          GASNET_WORKERIP: "127.0.0.0", CHPL_RT_OVERSUBSCRIBED: "yes"
+        with_env(
+          GASNET_SPAWNFN:         "L",
+          GASNET_ROUTE_OUTPUT:    "0",
+          GASNET_QUIET:           "Y",
+          GASNET_MASTERIP:        "127.0.0.1",
+          GASNET_WORKERIP:        "127.0.0.0",
+          CHPL_RT_OVERSUBSCRIBED: "yes",
         ) do
           system "util/test/checkChplInstall"
           with_env(CHPL_TARGET_COMPILER: cbackend) do
@@ -180,26 +211,5 @@ class Chapel < Formula
     # chpl-language-server will hang indefinitely waiting for a LSP client
     system bin/"chplcheck", "--list-rules"
     system bin/"chplcheck", libexec/"examples/hello.chpl"
-  end
-
-  def post_install
-    ohai "Chapel has been installed successfully!"
-    puts <<~EOS
-      By default, compiled Chapel programs will be single-locale only. There are
-      two ways to compile and run multi-locale Chapel programs locally:
-
-      Compile your program with:
-        `chpl --comm=gasnet --comm-substrate=smp`
-
-      OR
-
-      Compile your program with:
-        `chpl --comm=gasnet --comm-substrate=udp`
-      And then run it with:
-        `chplrun-udp ./your_program_name`
-
-      To simulate GPU execution, you can compile your program with:
-        `chpl --locale-model=gpu --gpu=cpu`
-    EOS
   end
 end


### PR DESCRIPTION
Expands the Homebrew forumla to include multi-locale and gpu support. This PR adds runtime builds for Chapel with multilocale support over udp and smp, as well as CHPL_GPU=cpu.

Resolves https://github.com/chapel-lang/chapel/issues/27333
Resolves https://github.com/chapel-lang/chapel/issues/12433

Other changes:
- adds the missing `--gpu` flag to the compiler to set the CHPL_GPU env as a compiler flag
- improves the error message for not setting `CHPL_GPU` to not suggest `none`, which is not a valid value


Testing:
- [x] build chapel from new formula
- [ ] `brew test chapel`
  - TODO: failures occurring with C Backend + GASNet
- [x] `brew style chapel`