### PR TITLE
Make a version of the floatcomplexexceptions test for aarch64

### DIFF
--- a/test/types/file/bradc/scalar/floatcomplexexceptions-aarch64.chpl
+++ b/test/types/file/bradc/scalar/floatcomplexexceptions-aarch64.chpl
@@ -1,0 +1,1 @@
+floatcomplexexceptions.chpl

--- a/test/types/file/bradc/scalar/floatcomplexexceptions-aarch64.compopts
+++ b/test/types/file/bradc/scalar/floatcomplexexceptions-aarch64.compopts
@@ -1,0 +1,2 @@
+--edition=2.0 # floatcomplexexceptions.old.good
+--edition=preview # floatcomplexexceptions-aarch64.good

--- a/test/types/file/bradc/scalar/floatcomplexexceptions-aarch64.good
+++ b/test/types/file/bradc/scalar/floatcomplexexceptions-aarch64.good
@@ -1,0 +1,1 @@
+floatcomplexexceptions.darwin.good

--- a/test/types/file/bradc/scalar/floatcomplexexceptions-aarch64.skipif
+++ b/test/types/file/bradc/scalar/floatcomplexexceptions-aarch64.skipif
@@ -1,0 +1,1 @@
+CHPL_TARGET_ARCH != aarch64

--- a/test/types/file/bradc/scalar/floatcomplexexceptions.skipif
+++ b/test/types/file/bradc/scalar/floatcomplexexceptions.skipif
@@ -1,0 +1,1 @@
+CHPL_TARGET_ARCH == aarch64


### PR DESCRIPTION
[reviewed by @e-kayrakli]

This test failed on our aarch64 system due to system sign differences when computing the square root of -1.  It also has the same behavior on my arm Mac, but that was solvable with a platform-specific .good file and the platform for our aarch64 testing is linux64.  Since the only way to distinguish it is via the CHPL_TARGET_ARCH, skip the original test with `CHPL_TARGET_ARCH=aarch64` and make a soft-link copy of the test that only runs in that setting (using the same expected output as the darwin run).

Verified that the test skipped when expected and that the output matched that of darwin before reusing its .good file