### PR TITLE
Adjust future to stop using chained '==' as that is deprecated

### DIFF
--- a/test/technotes/doc-examples/FirstClassProceduresCastOffFormalName.chpl
+++ b/test/technotes/doc-examples/FirstClassProceduresCastOffFormalName.chpl
@@ -17,4 +17,9 @@ x = bar;                    // OK!
 /* STOP_EXAMPLE_0 */
 
 assert(x(2, 2) == 4);
-assert(x(4, 4) == foo(4, 4) == bar(4, 4));
+
+// They should all produce the same result.
+const a = x(4, 4);
+const b = foo(4, 4);
+const c = bar(4, 4);
+assert(a == b && b == c);


### PR DESCRIPTION
Stop doing `a == b == c` as that's deprecated. Fixes incorrect output for future file. Trivial and not reviewed.