### PR TITLE
Close memory leaks caused by not freeing unmanaged class objects

### DIFF
--- a/test/classes/forwarding/not-a-cycle.chpl
+++ b/test/classes/forwarding/not-a-cycle.chpl
@@ -21,6 +21,11 @@ record A {
   proc init() {
     this.impl = new typename();
   }
+
+  proc deinit() {
+    if test == testCase.UNMANAGED then
+      delete this.impl;
+  }
 }
 
 proc main() {

--- a/test/classes/forwarding/not-a-cycle2.chpl
+++ b/test/classes/forwarding/not-a-cycle2.chpl
@@ -10,6 +10,10 @@ class B {
   proc init() {
     this.impl = new unmanaged C();
   }
+
+  proc deinit() {
+    delete this.impl;
+  }
 }
 
 class A {
@@ -17,9 +21,14 @@ class A {
   proc init() {
     this.impl = new unmanaged B();
   }
+
+  proc deinit() {
+    delete this.impl;
+  }
 }
 
 proc main() {
   var a = new unmanaged A();
   a.foo();
+  delete a;
 }


### PR DESCRIPTION
This closes a pair of memory leaks in tests that were added yesterday in #27557 due to allocating unmanaged class objects but failing to free them.