### PR TITLE
Remove `j` and `h` from the FormattedIO docs `[optional base flag]` section

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -10239,10 +10239,6 @@ Going through each section for text conversions:
     means octal
    ``b``
     means binary
-   ``j``
-    means JSON-style strings, numbers, and structures
-   ``h``
-    means Chapel-style strings, numbers, and structures
    ``'``
     means single-quoted string (with \\ and \')
    ``"``


### PR DESCRIPTION
I could have sworn we'd removed these format specifiers twice already, but I guess there was more to miss.

