### PR TITLE
Use CHPL_MAKE_LIB_PIC instead of CHPL_LIB_PIC in Makefiles

### DIFF
--- a/third-party/gasnet/Makefile
+++ b/third-party/gasnet/Makefile
@@ -90,7 +90,7 @@ ifeq (, $(MPI_CC))
 MPI_CC=mpicc
 endif
 
-ifeq ($(CHPL_LIB_PIC),pic)
+ifeq ($(CHPL_MAKE_LIB_PIC),pic)
 GASNET_CFLAGS += $(SHARED_LIB_CFLAGS)
 # MPI_CFLAGS overides autodetection, which we don't want so add to MPI_CC
 MPI_CC += $(SHARED_LIB_CFLAGS)

--- a/third-party/gmp/Makefile
+++ b/third-party/gmp/Makefile
@@ -40,7 +40,7 @@ ifneq (, $(filter %32,$(CHPL_MAKE_TARGET_PLATFORM)))
 CHPL_GMP_ABI_ARG = ABI=32
 endif
 
-ifeq ($(CHPL_LIB_PIC),pic)
+ifeq ($(CHPL_MAKE_LIB_PIC),pic)
 CFLAGS += $(SHARED_LIB_CFLAGS)
 CXXFLAGS += $(SHARED_LIB_CFLAGS)
 endif

--- a/third-party/hwloc/Makefile
+++ b/third-party/hwloc/Makefile
@@ -34,7 +34,7 @@ ifdef CHPL_HWLOC_PREFIX
    CHPL_HWLOC_CFG_OPTIONS += --with-hwloc-symbol-prefix=$(CHPL_HWLOC_PREFIX)
 endif
 
-ifeq ($(CHPL_LIB_PIC),pic)
+ifeq ($(CHPL_MAKE_LIB_PIC),pic)
 CFLAGS += $(SHARED_LIB_CFLAGS)
 endif
 

--- a/third-party/jemalloc/Makefile
+++ b/third-party/jemalloc/Makefile
@@ -39,7 +39,7 @@ CHPL_JEMALLOC_CFG_OPTIONS += --with-malloc-conf=purge:decay
 # from git history & out-of-tree builds, explicitly set the version
 CHPL_JEMALLOC_CFG_OPTIONS += --with-version=`cat $(JEMALLOC_SUBDIR)/VERSION`
 
-ifeq ($(CHPL_LIB_PIC),pic)
+ifeq ($(CHPL_MAKE_LIB_PIC),pic)
 CFLAGS += $(SHARED_LIB_CFLAGS)
 endif
 

--- a/third-party/libfabric/Makefile
+++ b/third-party/libfabric/Makefile
@@ -25,7 +25,7 @@ CHPL_LIBFABRIC_CFG_OPTIONS += --enable-debug
 CFLAGS += -g
 endif
 
-ifeq ($(CHPL_LIB_PIC),pic)
+ifeq ($(CHPL_MAKE_LIB_PIC),pic)
 CFLAGS += $(SHARED_LIB_CFLAGS)
 endif
 

--- a/third-party/libunwind/Makefile
+++ b/third-party/libunwind/Makefile
@@ -7,7 +7,7 @@ include $(CHPL_MAKE_HOME)/make/Makefile.base
 
 CHPL_LIBUNWIND_CFG_OPTIONS = --prefix=$(LIBUNWIND_INSTALL_DIR) --disable-shared --disable-coredump --disable-cxx-exceptions
 
-ifeq ($(CHPL_LIB_PIC),pic)
+ifeq ($(CHPL_MAKE_LIB_PIC),pic)
 CFLAGS += $(SHARED_LIB_CFLAGS)
 endif
 

--- a/third-party/mimalloc/Makefile
+++ b/third-party/mimalloc/Makefile
@@ -41,7 +41,7 @@ CHPL_MIMALLOC_CFG_OPTIONS += -DCMAKE_C_COMPILER='$(shell $(CHPL_MAKE_PYTHON) $(C
 	                           -DCMAKE_CXX_FLAGS='$(shell $(CHPL_MAKE_PYTHON) $(CHPL_MAKE_HOME)/util/chplenv/chpl_compiler.py --cxx --target --additional) $(CXXFLAGS)'
 endif
 
-ifeq ($(CHPL_LIB_PIC),pic)
+ifeq ($(CHPL_MAKE_LIB_PIC),pic)
 CFLAGS += $(SHARED_LIB_CFLAGS)
 endif
 

--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -147,7 +147,7 @@ endif
 # reduce performance penalty in cases where numChapelTasks < numQthreadWorkers
 CHPL_QTHREAD_CFG_OPTIONS += -DQTHREADS_CONDWAIT_QUEUE=ON
 
-ifeq ($(CHPL_LIB_PIC),pic)
+ifeq ($(CHPL_MAKE_LIB_PIC),pic)
 CFLAGS += $(SHARED_LIB_CFLAGS)
 endif
 

--- a/third-party/re2/Makefile
+++ b/third-party/re2/Makefile
@@ -31,7 +31,7 @@ ifneq (, $(CHPL_RE2_VALGRIND_SUPPORT))
 CHPL_RE2_CXXFLAGS += -DRE2_ON_VALGRIND
 endif
 
-ifeq ($(CHPL_LIB_PIC),pic)
+ifeq ($(CHPL_MAKE_LIB_PIC),pic)
 CXXFLAGS += $(SHARED_LIB_CFLAGS)
 endif
 


### PR DESCRIPTION
Without this change, if CHPL_LIB_PIC is set in `chplconfig` (rather than as an environment variable) then third-party libraries would be built without -fPIC.

Reviewed by @jabraham17 - thanks!

- [x] full comm=none testing