### PR TITLE
Dyno: promote methods

### DIFF
--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -3394,7 +3394,7 @@ struct ReceiverScopeTypedHelper final : public ReceiverScopeHelper {
   }
 
   const TypedMethodLookupHelper*
-  methodLookupForType(Context* context, types::QualifiedType type) const;
+  methodLookupForType(Context* context, types::QualifiedType type, bool checkScalarTypes = false) const;
 
   const TypedMethodLookupHelper*
   methodLookupForMethodId(Context* context, const ID& methodId) const override;

--- a/frontend/test/resolution/testPromotion.cpp
+++ b/frontend/test/resolution/testPromotion.cpp
@@ -458,6 +458,8 @@ static void test21() {
 // into the current scope, because the type's definition scope is considered.
 // However, in production, this rule doesn't apply to promoted methods.
 // Test that in Dyno, it does (which is more consistent).
+//
+// Tracking issue in prod: https://github.com/chapel-lang/chapel/issues/27578
 static void testPromotedMethodNotImported() {
   auto prog = R"""(
     module M1 {


### PR DESCRIPTION
Closes https://github.com/Cray/chapel-private/issues/7401.

Specifically, this PR properly handles calls to methods that are the scalar type" of another type. E.g., this makes it possible to invoke a method on each element of an array or records/classes. Sample code from #7401: 

```Chapel
record R {
  proc helper() {
    return 5;
  }
}

proc main() {
  var A : [1..10] R;
  var B = A.helper();
}
```

## Testing
- [x] dyno tests
- [x] code in cray/chapel-private#7401 works
- [x] `types/atomic/sungeun/atomic_vars` compiles with `--dyno-resolve-only -comp-only`
- [x] paratest `--dyno-resolve-only`
- [x] paratest

Reviewed by @benharsh -- thanks!