### PR TITLE
Fix error code being divided by 256 in `testRelease` script

### DIFF
--- a/util/buildRelease/testRelease
+++ b/util/buildRelease/testRelease
@@ -93,7 +93,6 @@ sub mysystem {
     $status = system($command);
     if ($status != 0) {
         $somethingfailed = 1;
-        $status = $status % 256;
         print "Error $_[1]: $status\n";
         if ($fatal != 0) {
           exit 1;


### PR DESCRIPTION
Remove an instance of a command status code being divided by 256 in `util/buildRelease/testRelease`.

I think this was likely intended to be modded to ensure the status code returned is in the typical 0-255 range. But even that may not be necessary since we just shouldn't be returning an out of range error code from whatever other script of ours this invokes anyways.

[reviewer info placeholder]