### PR TITLE
Dyno: Relax unknown-formal rule to enable more initial signature patterns

### DIFF
--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -1024,7 +1024,7 @@ CanPassResult CanPassResult::canPassScalar(Context* context,
   //   proc f(a: int(?w), b: int(2*w))
   // when computing an initial candidate, 'b' is unknown
   // but we should allow passing an argument to it.
-  if (formalT->isUnknownType() && !actualQT.isType()) {
+  if (formalT->isUnknownType()) {
     return instantiate();
   }
 


### PR DESCRIPTION
Closes https://github.com/Cray/chapel-private/issues/7398.

Chapel's function resolution proceeds in two phases:

1. A simple "zippering" of formals and actuals, in which each pair is independently checked for compatibility
2. A dependency-aware sequential traversal in which type information (e.g., type queries) from all preceding formal/actual pairs is carried forward into subsequent ones.

For the initial phase, it's entirely possible for some formal type expressions to be missing information (e.g., if we have `formal2: f(formal1.type)`. In this case, the existing call resolution logic marks `f(...)` as having unknown type, and allows actuals to be passed to it. More strict checking is deferred until phase 2. However, prior to this PR, this allowing-unknown-formals was not done for `type` formals. It's unclear to me why that is the case. As a result, formals like `type formal2: f(formal1.type)` did not work. This PR relaxes the `canPass` condition to allow passing to `unknown` type formals as well. This doesn't break any tests, but enables generic cast operators:

```Chapel
operator :(x, type t: Wrapper(x.type)) {
  var w: Wrapper(x.type) = x;
  return w;
}
```

## Testing
- [x] dyno tests (including test inspired by https://github.com/Cray/chapel-private/issues/7398)
- [x] `copyInitGeneric` now passes with `--dyno-resolve-only`
- [x] paratest
- [x] paratest `--dyno-resolve-only`

Reviewed by @benharsh -- thanks!