### PR TITLE
Fix printing of symbol in CLS when hovering

### DIFF
--- a/third-party/chpl-venv/Makefile
+++ b/third-party/chpl-venv/Makefile
@@ -128,7 +128,7 @@ cls-test-venv: chapel-py-venv
 	export VIRTUAL_ENV=$(CHPL_VENV_VIRTUALENV_DIR) && \
 	CHPL_HOME=$(CHPL_MAKE_HOME) $(PIP) install \
 	  $(CHPL_PIP_INSTALL_PARAMS) $(LOCAL_PIP_FLAGS) \
-	  --target $(CHPL_VENV_CHPLDEPS) \
+	  --target $(CHPL_VENV_CHPL_FRONTEND_PY_DEPS) \
 	  $(CHPL_MAKE_HOME)/tools/chapel-py \
 	  -r $(CHPL_VENV_CLS_TEST_REQUIREMENTS_FILE)
 	@# Using --upgrade above breaks the test venv, because there's a bug

--- a/tools/chapel-py/src/core-types.cpp
+++ b/tools/chapel-py/src/core-types.cpp
@@ -205,8 +205,8 @@ PyObject* AstNodeObject::richcompare(AstNodeObject *self, PyObject *other, int o
     Py_RETURN_NOTIMPLEMENTED;
   }
   auto otherCast = (AstNodeObject*) other;
-  auto selfId = self->value_->id();
-  auto otherId = otherCast->value_->id();
+  auto& selfId = self->value_->id();
+  auto& otherId = otherCast->value_->id();
 
   Py_RETURN_RICHCOMPARE(selfId, otherId, op);
 }

--- a/tools/chapel-py/src/core-types.cpp
+++ b/tools/chapel-py/src/core-types.cpp
@@ -196,6 +196,22 @@ PyObject* AstNodeObject::repr(AstNodeObject *self) {
   return Py_BuildValue("s", typeString.c_str());
 }
 
+Py_hash_t AstNodeObject::hash(AstNodeObject *self) {
+  return self->value_->id().hash();
+}
+
+PyObject* AstNodeObject::richcompare(AstNodeObject *self, PyObject *other, int op) {
+  if (!PyObject_TypeCheck(other, AstNodeObject::PythonType)) {
+    Py_RETURN_NOTIMPLEMENTED;
+  }
+  auto otherCast = (AstNodeObject*) other;
+  auto selfId = self->value_->id();
+  auto otherId = otherCast->value_->id();
+
+  Py_RETURN_RICHCOMPARE(selfId, otherId, op);
+}
+
+
 void ChapelTypeObject_dealloc(ChapelTypeObject* self) {
   Py_XDECREF(self->contextObject);
   callPyTypeSlot_tp_free(ChapelTypeObject::PythonType, (PyObject*) self);

--- a/tools/chapel-py/src/core-types.h
+++ b/tools/chapel-py/src/core-types.h
@@ -142,12 +142,16 @@ struct AstNodeObject : public PythonClassWithContext<AstNodeObject, const chpl::
   static PyObject* iter(AstNodeObject *self);
   static PyObject* str(AstNodeObject *self);
   static PyObject* repr(AstNodeObject *self);
+  static Py_hash_t hash(AstNodeObject *self);
+  static PyObject* richcompare(AstNodeObject *self, PyObject *other, int op);
 
   static PyTypeObject* configurePythonType() {
-    std::array<PyType_Slot, 3> extraSlots = {
+    std::array<PyType_Slot, 5> extraSlots = {
       PyType_Slot{Py_tp_str, (void*) AstNodeObject::str},
       PyType_Slot{Py_tp_repr, (void*) AstNodeObject::repr},
       PyType_Slot{Py_tp_iter, (void*) AstNodeObject::iter},
+      PyType_Slot{Py_tp_hash, (void*) AstNodeObject::hash},
+      PyType_Slot{Py_tp_richcompare, (void*) AstNodeObject::richcompare},
     };
     PyTypeObject* configuring = PythonClassWithContext<AstNodeObject, const chpl::uast::AstNode*>::configurePythonType(Py_TPFLAGS_BASETYPE, extraSlots);
     return configuring;

--- a/tools/chapel-py/src/method-tables/uast-methods.h
+++ b/tools/chapel-py/src/method-tables/uast-methods.h
@@ -642,12 +642,7 @@ CLASS_END(VarLikeDecl)
 
 CLASS_BEGIN(Formal)
   PLAIN_GETTER(Formal, is_this, "Check if this Formal node is a 'this' formal",
-               bool,
-                auto parent = chpl::parsing::parentAst(context, node);
-                return parent && parent->isFunction() &&
-                       parent->toFunction()->thisFormal() &&
-                       parent->toFunction()->thisFormal()->id() == node->id();
-              )
+               bool, return node->name() == USTR("this"))
 CLASS_END(Formal)
 
 CLASS_BEGIN(VarArgFormal)

--- a/tools/chapel-py/src/method-tables/uast-methods.h
+++ b/tools/chapel-py/src/method-tables/uast-methods.h
@@ -640,6 +640,16 @@ CLASS_BEGIN(VarLikeDecl)
                const char*, return intentToString(node->storageKind()))
 CLASS_END(VarLikeDecl)
 
+CLASS_BEGIN(Formal)
+  PLAIN_GETTER(Formal, is_this, "Check if this Formal node is a 'this' formal",
+               bool,
+                auto parent = chpl::parsing::parentAst(context, node);
+                return parent && parent->isFunction() &&
+                       parent->toFunction()->thisFormal() &&
+                       parent->toFunction()->thisFormal()->id() == node->id();
+              )
+CLASS_END(Formal)
+
 CLASS_BEGIN(VarArgFormal)
   PLAIN_GETTER(VarArgFormal, count, "Get the count expression of this VarArgFormal node",
                Nilable<const chpl::uast::AstNode*>, return node->count())

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -906,7 +906,8 @@ class FileInfo:
 
     @enter
     def _enter_Formal(self, node: chapel.Formal):
-        # do not enter the this formal, unless it has an explicit type (secondary method)
+        # do not enter the `this` formal, unless it has an explicit type
+        # i.e. (it is a secondary method)
         if not (node.is_this() and node.type_expression() is None):
             self.def_segments.append(NodeAndRange(node))
             self._note_scope(node)

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -907,13 +907,7 @@ class FileInfo:
     @enter
     def _enter_Formal(self, node: chapel.Formal):
         # do not enter the this formal, unless it has an explicit type (secondary method)
-        p = node.parent_symbol()
-        assert p is not None
-        if not (
-            isinstance(p, chapel.Function)
-            and p.this_formal() == node
-            and node.type_expression() is None
-        ):
+        if not (node.is_this() and node.type_expression() is None):
             self.def_segments.append(NodeAndRange(node))
             self._note_scope(node)
 
@@ -1752,11 +1746,7 @@ class ChapelLanguageServer(LanguageServer):
         ):
             return []
         # skip implicit this formals
-        if (
-            isinstance(decl.node, chapel.Formal)
-            and isinstance(decl.node.parent(), chapel.Function)
-            and decl.node.parent().this_formal() == decl.node
-        ):
+        if isinstance(decl.node, chapel.Formal) and decl.node.is_this():
             return []
 
         name_rng = location_to_range(decl.node.name_location())

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -909,7 +909,11 @@ class FileInfo:
         # do not enter the this formal, unless it has an explicit type (secondary method)
         p = node.parent_symbol()
         assert p is not None
-        if not (p.this_formal() == node and node.type_expression() is None):
+        if not (
+            isinstance(p, chapel.Function)
+            and p.this_formal() == node
+            and node.type_expression() is None
+        ):
             self.def_segments.append(NodeAndRange(node))
             self._note_scope(node)
 

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -903,6 +903,15 @@ class FileInfo:
         self._note_scope(node)
 
     @enter
+    def _enter_Formal(self, node: chapel.Formal):
+        # do not enter the this formal, unless it has an explicit type (secondary method)
+        p = node.parent_symbol()
+        assert p is not None
+        if not (p.this_formal() == node and node.type_expression() is None):
+            self.def_segments.append(NodeAndRange(node))
+            self._note_scope(node)
+
+    @enter
     def _enter_NamedDecl(self, node: chapel.NamedDecl):
         self.def_segments.append(NodeAndRange(node))
         self._note_scope(node)

--- a/tools/chpl-language-server/src/symbol_signature.py
+++ b/tools/chpl-language-server/src/symbol_signature.py
@@ -85,13 +85,12 @@ class SymbolSignature:
         Note: this is a temporary method that will go away when the resolver is fully online
         """
         remove = []
-        for i in range(len(self._signature)):
-            tag = self._signature[i].tag
-            node = self._signature[i].node
-            value = self._signature[i].value
-            prefix = self._signature[i].prefix or ""
-            postfix = self._signature[i].postfix or ""
-            if tag == ComponentTag.TYPE and node is not None:
+        for (i, part) in enumerate(self._signature):
+            node = part.node
+            value = part.value
+            prefix = part.prefix or ""
+            postfix = part.postfix or ""
+            if part.tag == ComponentTag.TYPE and node is not None:
                 type_str = _resolve_type_str(node, via)
                 if type_str:
                     self._signature[i] = _wrap_str(
@@ -110,13 +109,12 @@ class SymbolSignature:
     def compute_value(self, via: Optional[chapel.TypedSignature] = None):
         """evaluate expressions"""
         remove = []
-        for i in range(len(self._signature)):
-            tag = self._signature[i].tag
-            node = self._signature[i].node
-            value = self._signature[i].value
-            prefix = self._signature[i].prefix or ""
-            postfix = self._signature[i].postfix or ""
-            if tag == ComponentTag.PARAM_VALUE and node is not None:
+        for i, part in enumerate(self._signature):
+            node = part.node
+            value = part.value
+            prefix = part.prefix or ""
+            postfix = part.postfix or ""
+            if part.tag == ComponentTag.PARAM_VALUE and node is not None:
                 param_str = _resolve_param_str(node, via)
                 if param_str:
                     self._signature[i] = _wrap_str(

--- a/tools/chpl-language-server/src/symbol_signature.py
+++ b/tools/chpl-language-server/src/symbol_signature.py
@@ -60,7 +60,9 @@ class Component:
         return s
 
 
-def _wrap_str(s: str, prefix: Optional[str] = None, postfix: Optional[str] = None) -> Component:
+def _wrap_str(
+    s: str, prefix: Optional[str] = None, postfix: Optional[str] = None
+) -> Component:
     return Component(ComponentTag.STRING, s, prefix=prefix, postfix=postfix)
 
 
@@ -92,16 +94,18 @@ class SymbolSignature:
             if tag == ComponentTag.TYPE and node is not None:
                 type_str = _resolve_type_str(node, via)
                 if type_str:
-                    self._signature[i] = _wrap_str(type_str, prefix=prefix, postfix=postfix)
+                    self._signature[i] = _wrap_str(
+                        type_str, prefix=prefix, postfix=postfix
+                    )
                 elif value:
                     # if we can't resolve the type, we just keep the original value
-                    self._signature[i] = _wrap_str(value, prefix=prefix, postfix=postfix)
+                    self._signature[i] = _wrap_str(
+                        value, prefix=prefix, postfix=postfix
+                    )
                 else:
                     remove.append(i)
         for i in reversed(remove):
             del self._signature[i]
-
-
 
     def compute_value(self, via: Optional[chapel.TypedSignature] = None):
         """evaluate expressions"""
@@ -115,16 +119,19 @@ class SymbolSignature:
             if tag == ComponentTag.PARAM_VALUE and node is not None:
                 param_str = _resolve_param_str(node, via)
                 if param_str:
-                    self._signature[i] = _wrap_str(param_str, prefix=prefix, postfix=postfix)
+                    self._signature[i] = _wrap_str(
+                        param_str, prefix=prefix, postfix=postfix
+                    )
                 elif value:
                     # if we can't resolve the param, we just keep the original value
-                    self._signature[i] = _wrap_str(value, prefix=prefix, postfix=postfix)
+                    self._signature[i] = _wrap_str(
+                        value, prefix=prefix, postfix=postfix
+                    )
                 else:
                     remove.append(i)
 
         for i in reversed(remove):
             del self._signature[i]
-
 
     def __str__(self) -> str:
         return Component.to_string(self._signature)
@@ -234,7 +241,7 @@ def _node_to_string(node: chapel.AstNode, sep="") -> List[Component]:
 
 
 def _record_class_to_string(
-    node: Union[chapel.Record, chapel.Class]
+    node: Union[chapel.Record, chapel.Class],
 ) -> List[Component]:
     """
     Convert a Record or a Class to a string
@@ -293,7 +300,9 @@ def _var_to_string(node: chapel.VarLikeDecl) -> List[Component]:
     init = node.init_expression()
     if init:
         init_str = Component.to_string(_node_to_string(init))
-    comps.append(Component(ComponentTag.PARAM_VALUE, init_str, node, prefix=" = "))
+    comps.append(
+        Component(ComponentTag.PARAM_VALUE, init_str, node, prefix=" = ")
+    )
 
     return comps
 
@@ -322,9 +331,7 @@ def _proc_to_string(node: chapel.Function) -> List[Component]:
         assert isinstance(this_formal, chapel.Formal)
         intent = _intent_to_string(this_formal.intent())
         if intent:
-            comps.append(
-                _wrap_str(f"{intent} ")
-            )
+            comps.append(_wrap_str(f"{intent} "))
         # if the this-formal has a type, add it
         type_expr = this_formal.type_expression()
         if type_expr:
@@ -332,7 +339,9 @@ def _proc_to_string(node: chapel.Function) -> List[Component]:
             comps.append(_wrap_str("."))
         else:
             # if it doesn't have a type_expression, we can try and get it from resolution
-            comps.append(Component(ComponentTag.TYPE, None, this_formal, postfix="."))
+            comps.append(
+                Component(ComponentTag.TYPE, None, this_formal, postfix=".")
+            )
 
     comps.append(_wrap_str(node.name()))
 

--- a/tools/chpl-language-server/src/symbol_signature.py
+++ b/tools/chpl-language-server/src/symbol_signature.py
@@ -288,13 +288,23 @@ def _var_to_string(node: chapel.VarLikeDecl) -> List[Component]:
     if intent:
         comps.append(_wrap_str(f"{intent} "))
 
-    comps.append(_wrap_str(node.name()))
+    # dont show the name if this is this_formal and it has a type_expression
+    is_this_formal = isinstance(node, chapel.Formal) and node.is_this()
+    if not (is_this_formal and node.type_expression()):
+        comps.append(_wrap_str(node.name()))
 
     type_str = None
     type_ = node.type_expression()
     if type_:
         type_str = Component.to_string(_node_to_string(type_))
-    comps.append(Component(ComponentTag.TYPE, type_str, node, prefix=": "))
+    comps.append(
+        Component(
+            ComponentTag.TYPE,
+            type_str,
+            node,
+            prefix=": " if not is_this_formal else None,
+        )
+    )
 
     init_str = None
     init = node.init_expression()

--- a/tools/chpl-language-server/src/symbol_signature.py
+++ b/tools/chpl-language-server/src/symbol_signature.py
@@ -85,7 +85,7 @@ class SymbolSignature:
         Note: this is a temporary method that will go away when the resolver is fully online
         """
         remove = []
-        for (i, part) in enumerate(self._signature):
+        for i, part in enumerate(self._signature):
             node = part.node
             value = part.value
             prefix = part.prefix or ""

--- a/tools/chpl-language-server/test/document_symbols.py
+++ b/tools/chpl-language-server/test/document_symbols.py
@@ -83,7 +83,7 @@ async def test_document_symbols(client: LanguageClient):
             "operator +(a: myRecord, b: myRecord): myRecord",
             SymbolKind.Operator,
         ),
-        (rng((16, 2), (16, 25)), "proc bar()", SymbolKind.Method),
+        (rng((16, 2), (16, 25)), "proc myRecord.bar()", SymbolKind.Method),
         (rng((17, 2), (17, 19)), "class MyClass", SymbolKind.Class),
         (rng((19, 2), (22, 3)), "enum myEnum", SymbolKind.Enum),
         (rng((20, 4), (20, 5)), "a", SymbolKind.EnumMember),


### PR DESCRIPTION
Fixes an issue where hovering over a primary method would just show `this`. Now it will show the method name properly. Along the way, I also added the type name for secondary methods (and primary methods when resolution is enabled)

In this PR:

* added `hash` and rich comparison to AstNode in chapel-py
* added `is_this` to Formal in chapel-py
* used the new comparison ops for AstNode to improve code quaility
* fixed hovering over a primary method
* improved printing of a secondary method by adding the type name
* improved printing of a primary method by adding the type name (only when resolution is enabled). This only works well when the type/method is fully concrete, because there is no way to compute an instantiation from a hover. In the future, it would be nice to be able to show the generic-ness of the type.
* fixes an issue with the venv install for `test-cls`

Before
<img width="665" height="134" alt="Screenshot 2025-08-01 at 9 10 26 AM" src="https://github.com/user-attachments/assets/4086fc95-3bca-428c-ac41-54ff01b2227a" />
<img width="401" height="95" alt="Screenshot 2025-08-01 at 9 10 17 AM" src="https://github.com/user-attachments/assets/bbc655d8-6384-4ccc-aea0-3ab1ca14c199" />
<img width="332" height="128" alt="Screenshot 2025-08-01 at 9 10 12 AM" src="https://github.com/user-attachments/assets/7dc9034a-1a8a-44b7-9c01-830451234dca" />


After
<img width="518" height="125" alt="Screenshot 2025-08-01 at 9 10 52 AM" src="https://github.com/user-attachments/assets/80e5c6f3-8fcc-451c-bdda-ddbb48f5cc05" />
<img width="523" height="82" alt="Screenshot 2025-08-01 at 9 10 45 AM" src="https://github.com/user-attachments/assets/96311227-2691-4fbc-a765-385fabed435d" />
<img width="429" height="136" alt="Screenshot 2025-08-01 at 9 10 40 AM" src="https://github.com/user-attachments/assets/2d683830-b430-4837-a10f-c895c4244dd3" />


 - [x] `make test-cls`

[Reviewed by @DanilaFe]