### PR TITLE
Dyno: fix enumToOrder for enums declared in internal modules

### DIFF
--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -1450,8 +1450,20 @@ const BuilderResult& buildEnumToOrder(Context* context, ID typeID) {
   auto visClause = VisibilityClause::build(builder, dummyLoc,
                                            std::move(typeIdent));
   useList.push_back(std::move(visClause));
+
+  // In production, the new function gets inserted into the ChapelBase module.
+  // In dyno, we can't do this, since generated code has to be in a particular
+  // location (at this time, logically "inside" the type declaration it's generated
+  // for). To ensure we have the necessary code, `use` ChapelBase` in the body.
+  auto baseIdent = Identifier::build(builder, dummyLoc,
+                                     UniqueString::get(context, "ChapelBase"));
+  auto baseVisClause = VisibilityClause::build(builder, dummyLoc,
+                                               std::move(baseIdent));
+  useList.push_back(std::move(baseVisClause));
+
   auto use = Use::build(builder, dummyLoc, Decl::Visibility::DEFAULT_VISIBILITY, std::move(useList));
   stmts.push_back(std::move(use));
+
 
   // build up when-stmts
 


### PR DESCRIPTION
Closes https://github.com/Cray/chapel-private/issues/7402.

The following code now resolves fine in `--dyno-resolve-only`:

```Chapel
proc main() {
  var m = memoryOrder.seqCst;
  writeln(chpl__enumToOrder(m));
}
```

The issue was that internal modules don't auto-use `ChapelBase`. 

https://github.com/chapel-lang/chapel/blob/4ac1978a54a367e368369b177d97d7ef1014cea2/frontend/lib/resolution/scope-queries.cpp#L523-L528

As a result, they don't have access to `==`. In production this doesn't come up because `chpl__enumToOrder` gets placed into `ChapelBase` (?!). In Dyno, we can't do this. Instead, this PR inserts a `use` statement into `chpl__enumToOrder` to simulate having access to the necessary methods etc.

# Testing
- [x] dyno tests
- [x] code in this PR's OP / issue 7402 now resolves
- [x] paratest `--dyno-resolve-only`
- [x] paratest

Reviewed by @benharsh -- thanks!