### PR TITLE
Dyno: Iterate over param enum ranges

### DIFF
--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -6656,9 +6656,9 @@ static owned<BaseParamRangeInfo> paramRangeInfoFromBound(Context* context, Resol
       optional<int64_t> lowV = empty, hiV = empty;
       auto findElementInList = [&info](auto& into, const EnumParam* p) {
         if (!p) return;
-        for (int64_t i = 0; i < info->elements.size(); i++) {
+        for (size_t i = 0; i < info->elements.size(); i++) {
           if (info->elements[i]->id() == p->value().id) {
-            into = i;
+            into = static_cast<int64_t>(i);
             return;
           }
         }

--- a/frontend/test/resolution/testLoopIndexVars.cpp
+++ b/frontend/test/resolution/testLoopIndexVars.cpp
@@ -400,6 +400,11 @@ struct EnumParamLoopTester {
     resolvedVals.emplace("n", e);
   }
 
+  template <typename ...Ts>
+  void noteExpectedIterations(Ts&&...es) {
+    (noteExpectedIteration(std::forward<Ts>(es)), ...);
+  }
+
   void assertMatch() {
     for (auto& kv : resolvedIdents) {
       assert(pc.resolvedIdents.at(kv.first) == kv.second);
@@ -538,213 +543,145 @@ static void testIntParamFor() {
 static void testEnumParamFor() {
   {
     auto test = helpTestEnumParam("red..blue");
-    test.noteExpectedIteration("red");
-    test.noteExpectedIteration("green");
-    test.noteExpectedIteration("blue");
+    test.noteExpectedIterations("red", "green", "blue");
     test.assertMatch();
   }
 
   {
     auto test = helpTestEnumParam("red..#3");
-    test.noteExpectedIteration("red");
-    test.noteExpectedIteration("green");
-    test.noteExpectedIteration("blue");
+    test.noteExpectedIterations("red", "green", "blue");
     test.assertMatch();
   }
 
   {
     auto test = helpTestEnumParam("red..#6");
-    test.noteExpectedIteration("red");
-    test.noteExpectedIteration("green");
-    test.noteExpectedIteration("blue");
-    test.noteExpectedIteration("cyan");
-    test.noteExpectedIteration("yellow");
-    test.noteExpectedIteration("magenta");
+    test.noteExpectedIterations("red", "green", "blue", "cyan", "yellow", "magenta");
     test.assertMatch();
   }
 
   {
     auto test = helpTestEnumParam("red..#100");
-    test.noteExpectedIteration("red");
-    test.noteExpectedIteration("green");
-    test.noteExpectedIteration("blue");
-    test.noteExpectedIteration("cyan");
-    test.noteExpectedIteration("yellow");
-    test.noteExpectedIteration("magenta");
+    test.noteExpectedIterations("red", "green", "blue", "cyan", "yellow", "magenta");
     test.assertMatch();
   }
 
   {
     auto test = helpTestEnumParam("..cyan#3");
-    test.noteExpectedIteration("green");
-    test.noteExpectedIteration("blue");
-    test.noteExpectedIteration("cyan");
+    test.noteExpectedIterations("green", "blue", "cyan");
     test.assertMatch();
   }
 
   {
     auto test = helpTestEnumParam("..magenta#3");
-    test.noteExpectedIteration("cyan");
-    test.noteExpectedIteration("yellow");
-    test.noteExpectedIteration("magenta");
+    test.noteExpectedIterations("cyan", "yellow", "magenta");
     test.assertMatch();
   }
 
   {
     auto test = helpTestEnumParam("..magenta#6");
-    test.noteExpectedIteration("red");
-    test.noteExpectedIteration("green");
-    test.noteExpectedIteration("blue");
-    test.noteExpectedIteration("cyan");
-    test.noteExpectedIteration("yellow");
-    test.noteExpectedIteration("magenta");
+    test.noteExpectedIterations("red", "green", "blue", "cyan", "yellow", "magenta");
     test.assertMatch();
   }
 
   {
     auto test = helpTestEnumParam("..magenta#100");
-    test.noteExpectedIteration("red");
-    test.noteExpectedIteration("green");
-    test.noteExpectedIteration("blue");
-    test.noteExpectedIteration("cyan");
-    test.noteExpectedIteration("yellow");
-    test.noteExpectedIteration("magenta");
+    test.noteExpectedIterations("red", "green", "blue", "cyan", "yellow", "magenta");
     test.assertMatch();
   }
 
   {
     auto test = helpTestEnumParam("red..blue by -1");
-    test.noteExpectedIteration("blue");
-    test.noteExpectedIteration("green");
-    test.noteExpectedIteration("red");
+    test.noteExpectedIterations("blue", "green", "red");
     test.assertMatch();
   }
 
   {
     auto test = helpTestEnumParam("red..#3 by -1");
-    test.noteExpectedIteration("blue");
-    test.noteExpectedIteration("green");
-    test.noteExpectedIteration("red");
+    test.noteExpectedIterations("blue", "green", "red");
     test.assertMatch();
   }
 
   {
     auto test = helpTestEnumParam("red..#6 by -1");
-    test.noteExpectedIteration("magenta");
-    test.noteExpectedIteration("yellow");
-    test.noteExpectedIteration("cyan");
-    test.noteExpectedIteration("blue");
-    test.noteExpectedIteration("green");
-    test.noteExpectedIteration("red");
+    test.noteExpectedIterations("magenta", "yellow", "cyan", "blue", "green", "red");
     test.assertMatch();
   }
 
   {
     auto test = helpTestEnumParam("red..#100 by -1");
-    test.noteExpectedIteration("magenta");
-    test.noteExpectedIteration("yellow");
-    test.noteExpectedIteration("cyan");
-    test.noteExpectedIteration("blue");
-    test.noteExpectedIteration("green");
-    test.noteExpectedIteration("red");
+    test.noteExpectedIterations("magenta", "yellow", "cyan", "blue", "green", "red");
     test.assertMatch();
   }
 
   {
     auto test = helpTestEnumParam("..cyan#3 by -1");
-    test.noteExpectedIteration("cyan");
-    test.noteExpectedIteration("blue");
-    test.noteExpectedIteration("green");
+    test.noteExpectedIterations("cyan", "blue", "green");
     test.assertMatch();
   }
 
   {
     auto test = helpTestEnumParam("..magenta#3 by -1");
-    test.noteExpectedIteration("magenta");
-    test.noteExpectedIteration("yellow");
-    test.noteExpectedIteration("cyan");
+    test.noteExpectedIterations("magenta", "yellow", "cyan");
     test.assertMatch();
   }
 
   {
     auto test = helpTestEnumParam("..magenta#6 by -1");
-    test.noteExpectedIteration("magenta");
-    test.noteExpectedIteration("yellow");
-    test.noteExpectedIteration("cyan");
-    test.noteExpectedIteration("blue");
-    test.noteExpectedIteration("green");
-    test.noteExpectedIteration("red");
+    test.noteExpectedIterations("magenta", "yellow", "cyan", "blue", "green", "red");
     test.assertMatch();
   }
 
   {
     auto test = helpTestEnumParam("..magenta#100 by -1");
-    test.noteExpectedIteration("magenta");
-    test.noteExpectedIteration("yellow");
-    test.noteExpectedIteration("cyan");
-    test.noteExpectedIteration("blue");
-    test.noteExpectedIteration("green");
-    test.noteExpectedIteration("red");
+    test.noteExpectedIterations("magenta", "yellow", "cyan", "blue", "green", "red");
     test.assertMatch();
   }
 
   {
     auto test = helpTestEnumParam("red..blue by 2");
-    test.noteExpectedIteration("red");
-    test.noteExpectedIteration("blue");
+    test.noteExpectedIterations("red", "blue");
     test.assertMatch();
   }
 
   {
     auto test = helpTestEnumParam("red..#3 by 2");
-    test.noteExpectedIteration("red");
-    test.noteExpectedIteration("blue");
+    test.noteExpectedIterations("red", "blue");
     test.assertMatch();
   }
 
   {
     auto test = helpTestEnumParam("red..#6 by 2");
-    test.noteExpectedIteration("red");
-    test.noteExpectedIteration("blue");
-    test.noteExpectedIteration("yellow");
+    test.noteExpectedIterations("red", "blue", "yellow");
     test.assertMatch();
   }
 
   {
     auto test = helpTestEnumParam("red..#100 by 2");
-    test.noteExpectedIteration("red");
-    test.noteExpectedIteration("blue");
-    test.noteExpectedIteration("yellow");
+    test.noteExpectedIterations("red", "blue", "yellow");
     test.assertMatch();
   }
 
   {
     auto test = helpTestEnumParam("..cyan#3 by 2");
-    test.noteExpectedIteration("green");
-    test.noteExpectedIteration("cyan");
+    test.noteExpectedIterations("green", "cyan");
     test.assertMatch();
   }
 
   {
     auto test = helpTestEnumParam("..magenta#3 by 2");
-    test.noteExpectedIteration("cyan");
-    test.noteExpectedIteration("magenta");
+    test.noteExpectedIterations("cyan", "magenta");
     test.assertMatch();
   }
 
   {
     auto test = helpTestEnumParam("..magenta#6 by 2");
-    test.noteExpectedIteration("red");
-    test.noteExpectedIteration("blue");
-    test.noteExpectedIteration("yellow");
+    test.noteExpectedIterations("red", "blue", "yellow");
     test.assertMatch();
   }
 
   {
     auto test = helpTestEnumParam("..magenta#100 by 2");
-    test.noteExpectedIteration("red");
-    test.noteExpectedIteration("blue");
-    test.noteExpectedIteration("yellow");
+    test.noteExpectedIterations("red", "blue", "yellow");
     test.assertMatch();
   }
 }


### PR DESCRIPTION
Closes https://github.com/Cray/chapel-private/issues/7404.

This PR enables `param` iteration over ranges of enums. For instance, the following program produces one warning for every element in `letters`:

```chapel
enum letters {a, b, c, d, e, f}

for param c in letters.a..letters.f {
  compilerWarning(c:string);
}
```

Curiously the original reproducer in https://github.com/Cray/chapel-private/issues/7404 does not work as expected, because warnings are not emitted from inside `main`. Not sure why that's the case, but it seems to be independent of `param` iteration.

While there, this PR resolves signedness concerns (preventing overflow etc.).

The high-level outline of the change is to think of iteration over enums as iteration over the indices of their elements. This is similar to, but not the same as, the enum's `int` values (not the same because users can change the values of enums by assigning them different integers, like `red = 42`).

## Testing
- [x] dyno tests
- [x] motivator passes
- [x] paratest
- [x] paratest `--dyno-resolve-only`

Reviewed by @benharsh -- thanks!