### PR TITLE
Mason docs tweaks for consistency

### DIFF
--- a/doc/rst/tools/mason/guide/buildingandrunning.rst
+++ b/doc/rst/tools/mason/guide/buildingandrunning.rst
@@ -1,7 +1,7 @@
 :title: Mason Guide: *Building and Running*
 
 .. _building-and-running:
-        
+
 Building and Running
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -51,9 +51,9 @@ being produced, the ``--release`` flag can be thrown as follows:
 .. code-block:: sh
 
    mason build --release --force
-   
+
    OR
-   
+
    mason run --build --release --force
 
 The ``--release`` option adds the ``--fast`` argument to the compilation step.

--- a/doc/rst/tools/mason/guide/testing.rst
+++ b/doc/rst/tools/mason/guide/testing.rst
@@ -67,7 +67,7 @@ After adding our test, the package structure will be as follows::
    │   └── myPackage.chpl
    ├── target/
    │   ├── debug/
-   │   │   └── myPackage/
+   │   │   └── myPackage
    │   ├── example/
    │   ├── release/
    │   │   └── myPackage

--- a/doc/rst/tools/mason/mason.rst
+++ b/doc/rst/tools/mason/mason.rst
@@ -35,10 +35,10 @@ be better suited.
 
 1. Complex Compilation Needs Beyond `chpl`: For Chapel programs requiring
    compilation steps beyond what the Chapel compiler offers, Mason might not
-   be the most suitable choice. Consider alternatives like `Make` for greater
-   flexibility in crafting intricate build commands. As an example, the
-   Arkouda project, a prominent open-source Chapel application, uses
-   `Make` to run preparatory Python scripts before the final binary compilation.
+   be the most suitable choice. Consider alternatives like `Make` or `CMake`
+   for greater flexibility in crafting intricate build commands. As an example,
+   the Arkouda project, a prominent open-source Chapel application, uses `Make`
+   to run preparatory Python scripts before the final binary compilation.
 
 **Combining Mason with Make:**
 


### PR DESCRIPTION
Makes two minor tweaks to the mason docs.

- Add cmake to the list of alternative build systems
- remove a trailing slash that should not be there

[Not reviewed - trivial]