### PR TITLE
Add chpl-shim entry to %files in spec for RPM builds

### DIFF
--- a/util/packaging/rpm/amzn2023/spec.template
+++ b/util/packaging/rpm/amzn2023/spec.template
@@ -47,6 +47,7 @@ cp -r %{_prefix}/share/chapel %{buildroot}/%{_prefix}/share/chapel
 %{_prefix}/bin/mason
 %{_prefix}/bin/chplcheck
 %{_prefix}/bin/chpl-language-server
+%{_prefix}/bin/chpl-shim
 %{_prefix}/lib/chapel/*
 %{_prefix}/share/chapel/*
 %{_prefix}/lib/cmake/chpl/*

--- a/util/packaging/rpm/el10/spec.template
+++ b/util/packaging/rpm/el10/spec.template
@@ -47,6 +47,7 @@ cp -r %{_prefix}/share/chapel %{buildroot}/%{_prefix}/share/chapel
 %{_prefix}/bin/mason
 %{_prefix}/bin/chplcheck
 %{_prefix}/bin/chpl-language-server
+%{_prefix}/bin/chpl-shim
 %{_prefix}/lib/chapel/*
 %{_prefix}/share/chapel/*
 %{_prefix}/lib/cmake/chpl/*

--- a/util/packaging/rpm/el9/spec.template
+++ b/util/packaging/rpm/el9/spec.template
@@ -47,6 +47,7 @@ cp -r %{_prefix}/share/chapel %{buildroot}/%{_prefix}/share/chapel
 %{_prefix}/bin/mason
 %{_prefix}/bin/chplcheck
 %{_prefix}/bin/chpl-language-server
+%{_prefix}/bin/chpl-shim
 %{_prefix}/lib/chapel/*
 %{_prefix}/share/chapel/*
 %{_prefix}/lib/cmake/chpl/*

--- a/util/packaging/rpm/fc41/spec.template
+++ b/util/packaging/rpm/fc41/spec.template
@@ -47,6 +47,7 @@ cp -r %{_prefix}/share/chapel %{buildroot}/%{_prefix}/share/chapel
 %{_prefix}/bin/mason
 %{_prefix}/bin/chplcheck
 %{_prefix}/bin/chpl-language-server
+%{_prefix}/bin/chpl-shim
 %{_prefix}/lib/chapel/*
 %{_prefix}/share/chapel/*
 %{_prefix}/lib/cmake/chpl/*

--- a/util/packaging/rpm/fc42/spec.template
+++ b/util/packaging/rpm/fc42/spec.template
@@ -47,6 +47,7 @@ cp -r %{_prefix}/share/chapel %{buildroot}/%{_prefix}/share/chapel
 %{_prefix}/bin/mason
 %{_prefix}/bin/chplcheck
 %{_prefix}/bin/chpl-language-server
+%{_prefix}/bin/chpl-shim
 %{_prefix}/lib/chapel/*
 %{_prefix}/share/chapel/*
 %{_prefix}/lib/cmake/chpl/*


### PR DESCRIPTION
Adds a chpl-shim entry to `%files` in the spec file for RPM builds. This was missed in https://github.com/chapel-lang/chapel/pull/27528

- [x] `__build_native_package el10 chapel 2.6.0 1 5`

[Reviewed by @arifthpe]