### PR TITLE
Dyno: implement removed cast copy behavior

### DIFF
--- a/frontend/lib/resolution/VarScopeVisitor.cpp
+++ b/frontend/lib/resolution/VarScopeVisitor.cpp
@@ -403,7 +403,8 @@ bool VarScopeVisitor::resolvedCallHelper(const Call* callAst, RV& rv) {
         CHPL_ASSERT(op->numActuals() == 2);
         auto lhs = op->actual(0);
         auto lhsRr = rv.byPostorder().byAst(lhs);
-        if (rr->type().type() == lhsRr.type().type()) {
+        if (!rr->type().isUnknownOrErroneous() &&
+            rr->type().type() == lhsRr.type().type()) {
           handleInFormal(callAst, lhs, rr->type(), nullptr, rv);
           return false;
         }

--- a/frontend/lib/resolution/VarScopeVisitor.cpp
+++ b/frontend/lib/resolution/VarScopeVisitor.cpp
@@ -398,6 +398,12 @@ bool VarScopeVisitor::resolvedCallHelper(const Call* callAst, RV& rv) {
 
     // detect elided unnecessary casts (where the lhs was cast to its own type)
     // in this case we perform a copy of the original value.
+    //
+    // TODO: we could consider a more general way to signal how a particular
+    // call was resolved (like, "hey, this was resolved by a compiler-generated
+    // elided cast!") so that we don't have to pattern match. However, there
+    // aren't a lot of different casses like this, so for now I'm leaving
+    // the special case. - D.F.
     if (auto op = callAst->toOpCall()) {
       if (op->op() == USTR(":")) {
         CHPL_ASSERT(op->numActuals() == 2);

--- a/frontend/lib/resolution/VarScopeVisitor.cpp
+++ b/frontend/lib/resolution/VarScopeVisitor.cpp
@@ -368,8 +368,10 @@ bool VarScopeVisitor::resolvedCallHelper(const Call* callAst, RV& rv) {
   const MostSpecificCandidates& candidates = rr->mostSpecific();
   bool anyInOutInout = false;
   bool isMethod = false;
+  bool foundCandidate = false;
   for (const MostSpecificCandidate& candidate : candidates) {
     if (candidate) {
+      foundCandidate = true;
       auto fn = candidate.fn();
       if (fn->untyped()->isMethod()) isMethod = true;
 
@@ -386,6 +388,25 @@ bool VarScopeVisitor::resolvedCallHelper(const Call* callAst, RV& rv) {
       }
       if (anyInOutInout) {
         break;
+      }
+    }
+  }
+
+  if (!foundCandidate) {
+    // this indicates some special handling took place to resolve this call.
+    // We can handle special logic for such special handling here.
+
+    // detect elided unnecessary casts (where the lhs was cast to its own type)
+    // in this case we perform a copy of the original value.
+    if (auto op = callAst->toOpCall()) {
+      if (op->op() == USTR(":")) {
+        CHPL_ASSERT(op->numActuals() == 2);
+        auto lhs = op->actual(0);
+        auto lhsRr = rv.byPostorder().byAst(lhs);
+        if (rr->type().type() == lhsRr.type().type()) {
+          handleInFormal(callAst, lhs, rr->type(), nullptr, rv);
+          return false;
+        }
       }
     }
   }

--- a/frontend/test/resolution/testCallInitDeinit.cpp
+++ b/frontend/test/resolution/testCallInitDeinit.cpp
@@ -1461,6 +1461,31 @@ static void test16h() {
       {AssociatedAction::DEINIT,       "M.test@4",   "x"},
     });
 }
+// performing a redundant cast to the same type (treated as 'in' intent) without copy elision
+static void test16i() {
+  testActions("test16i",
+    R""""(
+      module M {
+        record R { }
+        proc R.init() { }
+        proc R.init=(other: R) { }
+        operator R.=(ref lhs: R, rhs: R) { }
+        proc R.deinit() { }
+
+        proc test() {
+          var x: R;
+          var tmp = x : R;
+          x;
+        }
+      }
+    )"""",
+    {
+      {AssociatedAction::DEFAULT_INIT, "x",          ""},
+      {AssociatedAction::COPY_INIT,    "M.test@2",   ""},
+      {AssociatedAction::DEINIT,       "M.test@7",   "tmp"},
+      {AssociatedAction::DEINIT,       "M.test@7",   "x"},
+    });
+}
 
 // 'out' intent: formal not deinitialized (deinited at call site)
 static void test17a() {
@@ -2060,6 +2085,7 @@ int main() {
   test16f();
   test16g();
   test16h();
+  test16i();
 
   test17a();
   test17b();


### PR DESCRIPTION
Closes https://github.com/Cray/chapel-private/issues/7329.

This causes the following program to cause a copy initialization of `a`:

```Chapel
record R {
}
proc consume(ref x) {}

proc test() {
  var a : R;
  var ret = a:R;
  consume(a);
  return ret;
}
var x = test();
```

The error in the original issue was resolved by @benharsh as of https://github.com/chapel-lang/chapel/pull/27486; the program in the example works under `--dyno-resolve-only`. The key contribution of this PR is the invocation of the copy initializer, which production introduces via a call to `_removed_cast`, which has an `in` intent.

In the spirit of dyno -- where we try to avoid odd calls to unexpected internal functions -- this PR does not replicate the call to `_removed_cast`. Instead, it simply detects the auto-implemented redundant cast (added in #27486) and invokes the `in`-intent handling logic.

Generally speaking, once call resolution is completed, there's no way for the `Resolver`, or any other code, to detect _how_ the resolution was performed. I was faced with a choice between implementing a general signaling mechanism (e.g., storing an enumeration for "how was this resolved" in `CallResolutionResult` or detecting the auto-cast as a special case. For now, lacking enough examples of how a general mechanism would be useful, and given how easy special-case detection is, I went with the special-casing. As a result, the `VarScopeVisitor` -- which performs the call to the `in`-intent handler -- has to do some sleuthing, detecting calls to `:` where no function candidate was detected.

## Testing
- [x] dyno tests
- [x] motivator now produces a copy
- [x] paratest
- [x] paratest `--dyno-resolve-only`

Reviewed by @benharsh -- thanks!