### PR TITLE
Dyno: fix some failures in `test/types/bytes`

### DIFF
--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -526,6 +526,22 @@ CanPassResult CanPassResult::canPassSubtypeNonBorrowing(Context* context,
                          /*conversion*/ SUBTYPE);
   }
 
+  // implement conversions to and from chpl_c_string and c_ptr(c_char)
+  auto charType = typeForSysCType(context, USTR("c_char"));
+  auto checkCStringCPtr = [&charType](const Type* maybeCString, const Type* maybeCPtr) {
+    if (auto cptr = maybeCPtr->toCPtrType()) {
+      return cptr->isConst() && cptr->eltType() == charType.type() &&
+             maybeCString->isCStringType();
+    }
+    return false;
+  };
+  if (checkCStringCPtr(actualT, formalT) || checkCStringCPtr(formalT, actualT)) {
+    return CanPassResult(/* no fail reason */ {},
+                         /* instantiates */ false,
+                         /*promotes*/ false,
+                         /*conversion*/ SUBTYPE);
+  }
+
   // class types
   if (auto actualCt = actualT->toClassType()) {
     if (auto formalCt = formalT->toClassType()) {

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -1592,7 +1592,8 @@ CallResolutionResult resolvePrimCall(ResolutionContext* rc,
           auto lstr = lhs.param()->toStringParam()->value();
           auto rstr = rhs.param()->toStringParam()->value();
           auto concat = UniqueString::getConcat(context, lstr.c_str(), rstr.c_str());
-          type = QualifiedType::makeParamString(context, concat);
+          type = QualifiedType(QualifiedType::PARAM, lhs.type(),
+                               StringParam::get(context, concat));
         }
       }
       break;


### PR DESCRIPTION
@arezaii -- could you sanity-check what I've done here with the auto-conversion between the internal `CString` and `CPtrConst(CChar)`? The conversion exists in production but I am somewhat uneasy about adding it because https://github.com/chapel-lang/chapel/pull/22622 is supposed to have removed `chpl_c_string`. Perhaps I've ran into a TODO from that PR?

This PR makes some fixes for failing tests in `test/types/bytes`. Specifically it:
1. Ensures that `c_ptrConst(char).size` works (by calling `chpl_c_string.size` and implicitly converting)
2. Fixes chained additions of byte-strings by ensuring that `bytes + bytes = bytes` (on main: `bytes + bytes = string`). This was caused by the `string_concat` primitive always returning a `string` `param` instead of preserving the arguments' types.

## Testing
- [ ] dyno tests
- [x] previously failing tests now pass:
  - `types/bytes/basic`
  - `types/bytes/param/param`
  - `types/bytes/literal`
 - [ ] paratest
 - [ ] paratest --dyno-resolve-only