### PR TITLE
Instead of using a hand-installed Python 3.11, use a `dnf` installed one

### DIFF
--- a/util/cron/load-base-deps.bash
+++ b/util/cron/load-base-deps.bash
@@ -22,7 +22,7 @@ elif [[ "$(hostname -s)" == "horizon" ]]; then
   fi
 elif [[ "$(hostname -s)" == "chapel-rocky-9" ]]; then
   # TODO: set up spack for this machine instead of manual installs
-  PATH="$HOME/Python-3.11.13-install/bin:$PATH"
+  PATH="$HOME/bin:$PATH"
 else
   # For systems not using a Spack install
 


### PR DESCRIPTION
[reviewed by @jabraham17]

The hand installed version was having trouble with SSL.  I could solve that, or I could use the version I installed yesterday when I thought things were broken in a different way than they turned out to be.  That version can pip install on its own, so I think it's the better choice.

Location credit goes to Jade, I would have made a lot more drastic of a choice

The commands run were:
``` 
sudo dnf install python3.11 python3.11-devel
/usr/bin/python3.11 -m ensurepip
/usr/bin/python3.11 -m pip install cython
/usr/bin/python3.11 -m pip install numpy
ln -s /usr/bin/python3.11 python3
```