### PR TITLE
Unload the llvm module after loading the other dependencies for wb testing

### DIFF
--- a/util/cron/common-whitebox.bash
+++ b/util/cron/common-whitebox.bash
@@ -34,6 +34,7 @@ fi
 
 # Ensure we're using the expected Python version
 source $UTIL_CRON_DIR/load-base-deps.bash
+module unload llvm
 
 # Variable set by Jenkins to indicate type of whitebox. If it is not set, assume cray-xc.
 platform=${CRAY_PLATFORM_FROM_JENKINS:-cray-xc}


### PR DESCRIPTION
I may need to make a special dependencies script just for our whiteboxes, but at a glance the only thing we didn't want was LLVM, since it was confusing our CC setting, so try just unloading it.

