### PR TITLE
Add initial LLDB pretty printer for some base Chapel types

### DIFF
--- a/doc/rst/usingchapel/debugging.rst
+++ b/doc/rst/usingchapel/debugging.rst
@@ -138,7 +138,7 @@ debuggability of the generated executable:
   Flag                                 Description
   ===================================  =========================================
   ``-g``                               Generate debug symbols in the executable
-  ``--ccflags -gdwarf-4``               Use DWARF 4 debug information
+  ``--ccflags -gdwarf-4``              Use DWARF 4 debug information
                                        (useful for ``gdb``)
   ``--preserve-inlined-line-numbers``  When code gets inlined (e.g. replacing a
                                        function call with the function body)

--- a/doc/rst/usingchapel/debugging.rst
+++ b/doc/rst/usingchapel/debugging.rst
@@ -66,6 +66,23 @@ Note that it is the user's responsibility to make sure things are set up
 so the terminal emulator run in the target environment can open its
 display window in the launch environment.
 
+Pretty Printing (LLDB only)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The Chapel pretty-printer for LLDB is automatically loaded when using the
+``--lldb`` flag. If you are using LLDB without this flag, you can load the
+pretty-printer manually by running the following command in LLDB:
+
+.. code-block:: bash
+
+    command script import $CHPL_HOME/runtime/etc/debug/chpl_lldb_pretty_print.py
+
+This pretty-printer understands a number of builtin Chapel types. This
+overrides the default printing for many types when using ``p`` (``print``) or
+``v`` (``frame variable``). To circumvent this, you can use ``v -R`` (``frame
+variable -R``) to print the raw value of a variable without the pretty-printer.
+
+
 Using a graphical debugger
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/rst/usingchapel/debugging.rst
+++ b/doc/rst/usingchapel/debugging.rst
@@ -24,6 +24,19 @@ exists to launch the program within a ``lldb`` session. For best results, you
 should read :ref:`this section <readme-debugging-bkc>` to build Chapel and
 build your application.
 
+You can also just run the program with ``gdb`` or ``lldb`` directly. This
+may be useful, for example if you want to use a graphical debugger like VSCode.
+``--gdb`` and ``--lldb`` are just convenience flags that do the following:
+
+* Set a breakpoint on ``debuggerBreakHere``, i.e. ``b debuggerBreakHere``
+* LLDB only: Enable the Chapel pretty-printer for LLDB, i.e.
+  ``command script import $CHPL_HOME/runtime/etc/debug/chpl_lldb_pretty_print.py``
+* If specified, execute additional debugger commands from a file whose path is
+  set in ``CHPL_RT_DEBUGGER_CMD_FILE``
+
+If you are not using ``--gdb`` or ``--lldb``, make sure to replicate the
+above steps in your debugger of choice for the best experience.
+
 Running in gdb/lldb with a launcher
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/rst/usingchapel/debugging.rst
+++ b/doc/rst/usingchapel/debugging.rst
@@ -103,7 +103,7 @@ debuggability of the generated executable:
   Flag                                 Description
   ===================================  =========================================
   ``-g``                               Generate debug symbols in the executable
-  ``--ccflags -gdwarf4``               Use DWARF 4 debug information
+  ``--ccflags -gdwarf-4``               Use DWARF 4 debug information
                                        (useful for ``gdb``)
   ``--preserve-inlined-line-numbers``  When code gets inlined (e.g. replacing a
                                        function call with the function body)

--- a/doc/rst/usingchapel/debugging.rst
+++ b/doc/rst/usingchapel/debugging.rst
@@ -76,9 +76,14 @@ The `Debugger.breakpoint` statement
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The :chpl:mod:`Debugger` module provides a parenless function called
-:chpl:proc:`~Debugger.breakpoint`. When the code is compiled and run with debug
-symbols, i.e. ``-g``, the attached debugger will automatically stop at calls to
-this function as a breakpoint.
+:chpl:proc:`~Debugger.breakpoint`. This will cause an attached debugger to
+automatically stop at calls to this function as a breakpoint.
+
+.. note::
+
+   This requires ``b debuggerBreakHere`` to be set in the debugger, which is
+   done automatically by the ``--gdb`` and ``--lldb`` flags. If you need a true
+   debug trap, see the :chpl:proc:`~Debugger.debugTrap` function.
 
 .. _readme-debugging-bkc:
 

--- a/runtime/etc/debug/chpl_lldb_pretty_print.py
+++ b/runtime/etc/debug/chpl_lldb_pretty_print.py
@@ -1,0 +1,563 @@
+import lldb
+import re
+
+
+def StringSummary(valobj, internal_dict):
+    size = valobj.GetChildMemberWithName("size").GetValueAsUnsigned()
+    buff = valobj.GetNonSyntheticValue().GetChildMemberWithName("buff")
+
+    if size > 0:
+        return buff.GetSummary()
+    else:
+        return '""'
+
+
+class StringProvider:
+    def __init__(self, valobj, internal_dict):
+        self.valobj = valobj
+
+        self.synthetic_children = {
+            "size": self.valobj.GetChildMemberWithName("buffLen"),
+        }
+
+    def has_children(self):
+        return self.num_children() > 0
+
+    def num_children(self):
+        return len(self.synthetic_children)
+
+    def get_child_index(self, name):
+        if name in self.synthetic_children:
+            return list(self.synthetic_children.keys()).index(name)
+        else:
+            return -1
+
+    def get_child_at_index(self, index):
+        if index < 0 or index >= self.num_children():
+            return None
+        key = list(self.synthetic_children.keys())[index]
+        return self.valobj.CreateValueFromExpression(
+            key, self.synthetic_children[key].GetValue()
+        )
+
+
+range_regex_c = re.compile(
+    r"^range_([a-zA-Z0-9_]+)_(both|low|high|neither)_(one|negOne|positive|negative|any)_chpl$"
+)
+range_regex_llvm = re.compile(
+    r"^ChapelRange::range\(([a-zA-Z0-9_()]+),(both|low|high|neither),(one|negOne|positive|negative|any)\)$"
+)
+
+
+def RangeSummary(valobj, internal_dict):
+    low = (
+        valobj.GetNonSyntheticValue()
+        .GetChildMemberWithName("_low")
+        .GetValueAsSigned()
+    )
+    high = (
+        valobj.GetNonSyntheticValue()
+        .GetChildMemberWithName("_high")
+        .GetValueAsSigned()
+    )
+
+    typename = valobj.GetTypeName()
+    match = range_regex_c.match(typename) or range_regex_llvm.match(typename)
+    if not match:
+        print(
+            f"Range_Summary: type name '{typename}' did not match expected pattern"
+        )
+        return None
+
+    def has_low_bound():
+        return match.group(2) in ("low", "both")
+
+    def has_high_bound():
+        return match.group(2) in ("high", "both")
+
+    # TODO: handle strides and alignment
+    res = ""
+    if has_low_bound():
+        res += str(low)
+    res += ".."
+    if has_high_bound():
+        res += str(high)
+
+    return res
+
+
+def RangeRecognizer(sbtype, internal_dict):
+    typename = sbtype.GetName()
+    match = range_regex_c.match(typename) or range_regex_llvm.match(typename)
+    return match is not None
+
+
+class RangeProvider:
+    def __init__(self, valobj, internal_dict):
+        self.valobj = valobj
+
+        self.synthetic_children = {}
+        if self._has_low_bound():
+            self.synthetic_children["low"] = self.valobj.GetChildMemberWithName(
+                "_low"
+            )
+        if self._has_high_bound():
+            self.synthetic_children["high"] = (
+                self.valobj.GetChildMemberWithName("_high")
+            )
+
+    def _has_low_bound(self):
+        typename = self.valobj.GetTypeName()
+        match = range_regex_c.match(typename) or range_regex_llvm.match(
+            typename
+        )
+        if not match:
+            print(
+                f"RangeProvider: type name '{typename}' did not match expected pattern"
+            )
+            return False
+        return match.group(2) in ("low", "both")
+
+    def _has_high_bound(self):
+        typename = self.valobj.GetTypeName()
+        match = range_regex_c.match(typename) or range_regex_llvm.match(
+            typename
+        )
+        if not match:
+            print(
+                f"RangeProvider: type name '{typename}' did not match expected pattern"
+            )
+            return False
+        return match.group(2) in ("high", "both")
+
+    def has_children(self):
+        return self.num_children() > 0
+
+    def num_children(self):
+        return len(self.synthetic_children)
+
+    def get_child_index(self, name):
+        if name in self.synthetic_children:
+            return list(self.synthetic_children.keys()).index(name)
+        else:
+            return -1
+
+    def get_child_at_index(self, index):
+        if index < 0 or index >= self.num_children():
+            return None
+        key = list(self.synthetic_children.keys())[index]
+        return self.valobj.CreateValueFromExpression(
+            key, self.synthetic_children[key].GetValue()
+        )
+
+
+# TODO: only handles DefaultRectangularDom for now
+domain_regex_c = re.compile(
+    r"^_domain_DefaultRectangularDom_([0-9]+)_([a-zA-Z0-9_]+)_(one|negOne|positive|negative|any)_chpl$"
+)
+domain_regex_llvm = re.compile(r"^$")  # TODO
+
+
+def DomainRecognizer(sbtype, internal_dict):
+    typename = sbtype.GetName()
+    match = domain_regex_c.match(typename) or domain_regex_llvm.match(typename)
+    return match is not None
+
+
+def DomainSummary(valobj, internal_dict):
+    typename = valobj.GetTypeName()
+    match = domain_regex_c.match(typename) or domain_regex_llvm.match(typename)
+    if not match:
+        print(
+            f"Domain_Summary: type name '{typename}' did not match expected pattern"
+        )
+        return None
+
+    rank = int(match.group(1))
+    idx_type = match.group(2)
+    stride_kind = match.group(3)
+
+    ranges = (
+        valobj.GetNonSyntheticValue()
+        .GetChildMemberWithName("_instance")
+        .GetNonSyntheticValue()
+        .GetChildMemberWithName("ranges")
+    )
+    return "{" + (ranges.GetSummary()) + "}"
+
+
+class DomainProvider:
+    def __init__(self, valobj, internal_dict):
+        self.valobj = valobj
+
+        self.synthetic_children = {}
+        typename = self.valobj.GetTypeName()
+        match = domain_regex_c.match(typename) or domain_regex_llvm.match(
+            typename
+        )
+        if not match:
+            print(
+                f"DomainProvider: type name '{typename}' did not match expected pattern"
+            )
+            return
+
+        ranges = (
+            self.valobj.GetNonSyntheticValue()
+            .GetChildMemberWithName("_instance")
+            .GetNonSyntheticValue()
+            .GetChildMemberWithName("ranges")
+        )
+        self.synthetic_children["dim"] = ranges
+
+    def has_children(self):
+        return self.num_children() > 0
+
+    def num_children(self):
+        return len(self.synthetic_children)
+
+    def get_child_index(self, name):
+        if name in self.synthetic_children:
+            return list(self.synthetic_children.keys()).index(name)
+        else:
+            return -1
+
+    def get_child_at_index(self, index):
+        if index < 0 or index >= self.num_children():
+            return None
+        key = list(self.synthetic_children.keys())[index]
+        child_obj = self.synthetic_children[key]
+        return self.valobj.CreateValueFromAddress(
+            key, child_obj.GetLoadAddress(), child_obj.GetType()
+        )
+
+
+#
+# homogenous tuples
+#
+homogeneous_tuple_regex_c = re.compile(
+    r"^_tuple_([0-9]+)_star_([a-zA-Z0-9_]+)_chpl$"
+)
+homogeneous_tuple_regex_llvm = re.compile(r"^$")  # TODO
+
+
+def HomogeneousTupleRecognizer(sbtype, internal_dict):
+    typename = sbtype.GetName()
+    match = homogeneous_tuple_regex_c.match(
+        typename
+    ) or homogeneous_tuple_regex_llvm.match(typename)
+    return match is not None
+
+
+def HomogeneousTupleSummary(valobj, internal_dict):
+    typename = valobj.GetTypeName()
+    match = homogeneous_tuple_regex_c.match(
+        typename
+    ) or homogeneous_tuple_regex_llvm.match(typename)
+    if not match:
+        print(
+            f"HomogeneousTuple_Summary: type name '{typename}' did not match expected pattern"
+        )
+        return None
+
+    size = match.group(1)
+    vals = []
+    for i in range(int(size)):
+        child = valobj.GetNonSyntheticValue().GetChildAtIndex(i)
+        vals.append(child.GetSummary() or child.GetValue() or "")
+    return f"{', '.join(vals)}"
+
+
+class HomogeneousTupleProvider:
+    def __init__(self, valobj, internal_dict):
+        self.valobj = valobj
+
+        self.synthetic_children = {}
+        typename = self.valobj.GetTypeName()
+        match = homogeneous_tuple_regex_c.match(
+            typename
+        ) or homogeneous_tuple_regex_llvm.match(typename)
+        if not match:
+            print(
+                f"HomogeneousTupleProvider: type name '{typename}' did not match expected pattern"
+            )
+            return
+
+        size = int(match.group(1))
+        for i in range(size):
+            self.synthetic_children[str(i)] = self.valobj.GetChildAtIndex(i)
+
+    def has_children(self):
+        return self.num_children() > 0
+
+    def num_children(self):
+        return len(self.synthetic_children)
+
+    def get_child_index(self, name):
+        if name in self.synthetic_children:
+            return list(self.synthetic_children.keys()).index(name)
+        else:
+            return -1
+
+    def get_child_at_index(self, index):
+        if index < 0 or index >= self.num_children():
+            return None
+        key = list(self.synthetic_children.keys())[index]
+        return self.valobj.CreateValueFromExpression(
+            f"[{key}]", self.synthetic_children[key].GetValue()
+        )
+
+
+# array
+# _array_DefaultRectangularArr_1_int64_t_one_int64_t_int64_t_chpl
+# rank, idx_type, stride_kind, element_type, idxSignedType
+
+array_regex_c = re.compile(
+    r"^_array_DefaultRectangularArr_([0-9]+)_([a-zA-Z0-9_]+)_(one|negOne|positive|negative|any)_([a-zA-Z0-9_]+)_([a-zA-Z0-9_]+)_chpl$"
+)
+array_regex_llvm = re.compile(r"^$")  # TODO
+
+
+def ArrayRecognizer(sbtype, internal_dict):
+    typename = sbtype.GetName()
+    match = array_regex_c.match(typename) or array_regex_llvm.match(typename)
+    return match is not None
+
+
+def ArraySummary(valobj, internal_dict):
+    typename = valobj.GetTypeName()
+    match = array_regex_c.match(typename) or array_regex_llvm.match(typename)
+    if not match:
+        print(
+            f"Array_Summary: type name '{typename}' did not match expected pattern"
+        )
+        return None
+
+    rank = int(match.group(1))
+    idx_type = match.group(2)
+    stride_kind = match.group(3)
+    element_type = match.group(4)
+    idx_signed_type = match.group(5)
+
+    _instance = valobj.GetNonSyntheticValue().GetChildMemberWithName(
+        "_instance"
+    )
+    domClass = _instance.GetChildMemberWithName("dom")
+    data = _instance.GetChildMemberWithName("data")
+    ranges = domClass.GetNonSyntheticValue().GetChildMemberWithName("ranges")
+    return f"[{ranges.GetSummary() or ranges.GetValue()}] {GetArrayType(_instance)}"
+
+
+def GetArrayType(_instance):
+    ddata = _instance.GetChildMemberWithName("data")
+    # use the element type we can compute from ddata
+    ddata_regex_c = re.compile(r"^_ddata_([a-zA-Z0-9_]+)_chpl$")
+    ddata_regex_llvm = re.compile(r"^$")  # TODO
+    ddata_typename = ddata.GetTypeName()
+    ddata_match = ddata_regex_c.match(ddata_typename) or ddata_regex
+    if not ddata_match:
+        print(
+            f"ArrayProvider: ddata type name '{ddata_typename}' did not match expected pattern"
+        )
+        return "unknown"
+    element_type = ddata_match.group(1)
+    return element_type
+
+
+class ArrayProvider:
+    def __init__(self, valobj, internal_dict):
+        self.valobj = valobj
+
+        self.synthetic_children = {}
+        typename = self.valobj.GetTypeName()
+        match = array_regex_c.match(typename) or array_regex_llvm.match(
+            typename
+        )
+        if not match:
+            print(
+                f"ArrayProvider: type name '{typename}' did not match expected pattern"
+            )
+            return
+
+        self._instance = (
+            self.valobj.GetNonSyntheticValue().GetChildMemberWithName(
+                "_instance"
+            )
+        )
+        self.domClass = self._instance.GetChildMemberWithName("dom")
+        self.data = self._instance.GetChildMemberWithName("data")
+        self.synthetic_children["dom"] = self.domClass
+        self.synthetic_children["data"] = self.data
+
+        self.rank = int(match.group(1))
+        self.element_type = GetArrayType(self._instance)
+
+        self._make_synthetic_array()
+
+    def _make_synthetic_array(self):
+        """Create synthetic children for array elements"""
+
+        data_valobj = self.data.GetNonSyntheticValue().GetData()
+        if not data_valobj.IsValid():
+            print("ArrayProvider: data SBData is not valid")
+            return
+
+        # Get the size of each element based on the element type
+        element_size = self._get_element_size()
+        if element_size == 0:
+            print(
+                f"ArrayProvider: unknown element size for type '{self.element_type}'"
+            )
+            return
+
+        element_type = self.valobj.GetTarget().FindFirstType(self.element_type)
+        if not element_type.IsValid():
+            print(
+                f"ArrayProvider: could not find element type '{self.element_type}'"
+            )
+            return
+
+        # For 1D arrays, get the range to determine array bounds
+        ranges = self.domClass.GetNonSyntheticValue().GetChildMemberWithName(
+            "ranges"
+        )
+        if ranges.GetNumChildren() <= 0:
+            return
+        # Handle N-dimensional arrays
+        if self.rank == 1:
+            # 1D case - simple linear indexing
+            range_0 = ranges.GetChildAtIndex(0)
+            low = range_0.GetChildMemberWithName("_low").GetValueAsSigned()
+            high = range_0.GetChildMemberWithName("_high").GetValueAsSigned()
+
+            data_ptr = self.data.GetValueAsUnsigned()
+            for i in range(0, high - low + 1):
+                element_addr = data_ptr + i * element_size
+                element_name = f"[{i}]"
+                try:
+                    element_val = self.valobj.CreateValueFromAddress(
+                        element_name, element_addr, element_type
+                    )
+                    self.synthetic_children[element_name] = element_val
+                except:
+                    print(
+                        f"ArrayProvider: failed to create element at index {i}"
+                    )
+        else:
+            # N-D case - multi-dimensional indexing
+            bounds = []
+            for dim in range(self.rank):
+                range_dim = ranges.GetChildAtIndex(dim)
+                low = range_dim.GetChildMemberWithName(
+                    "_low"
+                ).GetValueAsSigned()
+                high = range_dim.GetChildMemberWithName(
+                    "_high"
+                ).GetValueAsSigned()
+                bounds.append((low, high))
+
+            data_ptr = self.data.GetValueAsUnsigned()
+
+            def generate_indices(dims, bounds):
+                if dims == 0:
+                    yield []
+                else:
+                    low, high = bounds[dims - 1]
+                    for i in range(low, high + 1):
+                        for rest in generate_indices(dims - 1, bounds):
+                            yield [i] + rest
+
+            # Calculate strides for row-major ordering
+            strides = [1]
+            for i in range(self.rank - 1, 0, -1):
+                low, high = bounds[i]
+                size = high - low + 1
+                strides.insert(0, strides[0] * size)
+
+            for indices in generate_indices(self.rank, bounds):
+                # Calculate linear offset
+                offset = 0
+                for i, idx in enumerate(indices):
+                    low, _ = bounds[i]
+                    offset += (idx - low) * strides[i]
+
+                element_addr = data_ptr + offset * element_size
+                element_name = f"[{','.join(map(str, indices))}]"
+                try:
+                    element_type = self.valobj.GetTarget().FindFirstType(
+                        self.element_type
+                    )
+                    if element_type.IsValid():
+                        element_val = self.valobj.CreateValueFromAddress(
+                            element_name, element_addr, element_type
+                        )
+                        self.synthetic_children[element_name] = element_val
+                except:
+                    print(
+                        f"ArrayProvider: failed to create element at indices {indices}"
+                    )
+
+    def _get_element_size(self):
+        """Get the size in bytes of the element type"""
+        target = self.valobj.GetTarget()
+        element_type = target.FindFirstType(self.element_type)
+        if element_type.IsValid():
+            return element_type.GetByteSize()
+        return 0
+
+    def has_children(self):
+        return self.num_children() > 0
+
+    def num_children(self):
+        return len(self.synthetic_children)
+
+    def get_child_index(self, name):
+        if name in self.synthetic_children:
+            return list(self.synthetic_children.keys()).index(name)
+        else:
+            return -1
+
+    def get_child_at_index(self, index):
+        if index < 0 or index >= self.num_children():
+            return None
+        key = list(self.synthetic_children.keys())[index]
+        child_obj = self.synthetic_children[key]
+        return self.valobj.CreateValueFromAddress(
+            key, child_obj.GetLoadAddress(), child_obj.GetType()
+        )
+
+
+def __lldb_init_module(debugger, internal_dict):
+    debugger.HandleCommand(
+        "type summary add --expand --python-function chpl_lldb_pretty_print.StringSummary  -x '^string_chpl|String::string$'"
+    )
+    debugger.HandleCommand(
+        "type synth add --python-class chpl_lldb_pretty_print.StringProvider -x '^string_chpl|String::string$'"
+    )
+
+    debugger.HandleCommand(
+        f"type summary add --expand --python-function chpl_lldb_pretty_print.RangeSummary --recognizer-function chpl_lldb_pretty_print.RangeRecognizer"
+    )
+    debugger.HandleCommand(
+        f"type synth add --python-class chpl_lldb_pretty_print.RangeProvider --recognizer-function chpl_lldb_pretty_print.RangeRecognizer"
+    )
+
+    debugger.HandleCommand(
+        f"type summary add --expand --python-function chpl_lldb_pretty_print.DomainSummary --recognizer-function chpl_lldb_pretty_print.DomainRecognizer"
+    )
+    debugger.HandleCommand(
+        f"type synth add --python-class chpl_lldb_pretty_print.DomainProvider --recognizer-function chpl_lldb_pretty_print.DomainRecognizer"
+    )
+
+    debugger.HandleCommand(
+        f"type summary add --expand --python-function chpl_lldb_pretty_print.HomogeneousTupleSummary --recognizer-function chpl_lldb_pretty_print.HomogeneousTupleRecognizer"
+    )
+    debugger.HandleCommand(
+        f"type synth add --python-class chpl_lldb_pretty_print.HomogeneousTupleProvider --recognizer-function chpl_lldb_pretty_print.HomogeneousTupleRecognizer"
+    )
+
+    debugger.HandleCommand(
+        f"type summary add --expand --python-function chpl_lldb_pretty_print.ArraySummary --recognizer-function chpl_lldb_pretty_print.ArrayRecognizer"
+    )
+    debugger.HandleCommand(
+        f"type synth add --python-class chpl_lldb_pretty_print.ArrayProvider --recognizer-function chpl_lldb_pretty_print.ArrayRecognizer"
+    )

--- a/runtime/etc/debug/chpl_lldb_pretty_print.py
+++ b/runtime/etc/debug/chpl_lldb_pretty_print.py
@@ -307,6 +307,7 @@ class HomogeneousTupleProvider:
         )
 
 
+# TODO: for now we only handle DefaultRectangular arrays
 # array
 # _array_DefaultRectangularArr_1_int64_t_one_int64_t_int64_t_chpl
 # rank, idx_type, stride_kind, element_type, idxSignedType

--- a/runtime/src/comm/none/comm-none.c
+++ b/runtime/src/comm/none/comm-none.c
@@ -171,11 +171,6 @@ int chpl_comm_run_in_lldb(int argc, char* argv[], int lldbArgnum, int* status) {
 
   char* command = (char*)"lldb -o 'b debuggerBreakHere'";
 
-  const char* debuggerCmdFile = chpl_get_debugger_cmd_file();
-  if (debuggerCmdFile != NULL) {
-    command = chpl_glom_strings(4, command, " --source \"", debuggerCmdFile, "\"");
-  }
-
   const char* pretty_printer = chpl_glom_strings(2, CHPL_HOME, "/runtime/etc/debug/chpl_lldb_pretty_print.py");
   if (access(pretty_printer, R_OK) == 0) {
     command = chpl_glom_strings(4, command,
@@ -183,6 +178,11 @@ int chpl_comm_run_in_lldb(int argc, char* argv[], int lldbArgnum, int* status) {
   } else {
     chpl_warning("Could not find lldb pretty-printer, it will be ignored",
                   0, CHPL_FILE_IDX_COMMAND_LINE);
+  }
+
+  const char* debuggerCmdFile = chpl_get_debugger_cmd_file();
+  if (debuggerCmdFile != NULL) {
+    command = chpl_glom_strings(4, command, " --source \"", debuggerCmdFile, "\"");
   }
 
   command = chpl_glom_strings(3, command, " -- ", argv[0]);

--- a/runtime/src/comm/none/comm-none.c
+++ b/runtime/src/comm/none/comm-none.c
@@ -169,19 +169,24 @@ int chpl_comm_run_in_gdb(int argc, char* argv[], int gdbArgnum, int* status) {
 
 int chpl_comm_run_in_lldb(int argc, char* argv[], int lldbArgnum, int* status) {
 
+  char* command = (char*)"lldb -o 'b debuggerBreakHere'";
+
   const char* debuggerCmdFile = chpl_get_debugger_cmd_file();
-  char* command;
   if (debuggerCmdFile != NULL) {
-    command = chpl_glom_strings(4,
-      "lldb -o 'b debuggerBreakHere' --source ",
-      debuggerCmdFile,
-      " -- ",
-      argv[0]);
-  } else {
-    command = chpl_glom_strings(2,
-      "lldb -o 'b debuggerBreakHere' -- ",
-      argv[0]);
+    command = chpl_glom_strings(4, command, " --source \"", debuggerCmdFile, "\"");
   }
+
+  const char* pretty_printer = chpl_glom_strings(2, CHPL_HOME, "/runtime/etc/debug/chpl_lldb_pretty_print.py");
+  if (access(pretty_printer, R_OK) == 0) {
+    command = chpl_glom_strings(4, command,
+      " -o 'command script import \"", pretty_printer, "\"'");
+  } else {
+    chpl_warning("Could not find lldb pretty-printer, it will be ignored",
+                  0, CHPL_FILE_IDX_COMMAND_LINE);
+  }
+
+  command = chpl_glom_strings(3, command, " -- ", argv[0]);
+
 
   for (int i=1; i<argc; i++) {
     if (i != lldbArgnum) {


### PR DESCRIPTION
Adds some initial pretty printing logic to ``--lldb`` for COMM=none programs. This pretty print works entirely for the C backend and partially for the LLVM backend (for now). 

This PR adds printers for the following types
- strings
- ranges
- homogeneous tuples
- local default rectangular domains
- local default rectangular arrays

<img width="1176" height="658" alt="Screenshot 2025-08-05 at 8 51 04 AM" src="https://github.com/user-attachments/assets/f4ac3bb4-141a-4d0a-98e2-be02a8a40688" />

Resolves https://github.com/chapel-lang/chapel/issues/27197

Note that this does NOT add tests of the pretty printer, as our primary linux64 nightly test machine has an LLDB without Python support. Its possible we can adjust this install or add testing on other machines.

Future work
- figure out why class types are resolved as `std::nullptr_t` with LLVM (see https://github.com/chapel-lang/chapel/issues/27603)
- figure out how to get these tested.

[Reviewed by @lydia-duncan]