### PR TITLE
Fix GPU tests after new dead code pass

### DIFF
--- a/test/gpu/native/assertOnFailToGpuizeAttr.chpl
+++ b/test/gpu/native/assertOnFailToGpuizeAttr.chpl
@@ -17,7 +17,7 @@ proc funcMarkedNotGpuizableThatTriesToGpuize() {
 }
 
 pragma "no gpu codegen"
-proc funcMarkedNotGpuizable() { }
+proc funcMarkedNotGpuizable() { return 1; }
 
 on here.gpus[0] {
   if failureMode == 1 {

--- a/test/gpu/native/assertOnNotGpuEligible.chpl
+++ b/test/gpu/native/assertOnNotGpuEligible.chpl
@@ -20,7 +20,7 @@ proc funcMarkedNotGpuizableThatTriesToGpuize() {
 }
 
 pragma "no gpu codegen"
-proc funcMarkedNotGpuizable() { }
+proc funcMarkedNotGpuizable() { return 1; }
 
 on here.gpus[0] {
   if failureMode == 1 {

--- a/test/gpu/native/errors/std/MyMod.chpl
+++ b/test/gpu/native/errors/std/MyMod.chpl
@@ -3,7 +3,7 @@ module MyMod {
   config param usePoi = true;
 
   pragma "no gpu codegen"
-  proc doSomethingElse(x) {}
+  proc doSomethingElse(x) { return 1; }
 
   proc doSomething(x) {
     doSomethingElse(x);

--- a/test/gpu/native/reportGpu.chpl
+++ b/test/gpu/native/reportGpu.chpl
@@ -24,7 +24,7 @@ proc funcMarkedNotGpuizableThatTriesToGpuize() {
 }
 
 pragma "no gpu codegen"
-proc funcMarkedNotGpuizable() { }
+proc funcMarkedNotGpuizable() { return 1; }
 
 on here.gpus[0] {
   funcMarkedNotGpuizableThatTriesToGpuize();


### PR DESCRIPTION
Fixes a few GPU tests after adding a new dead code pass in https://github.com/chapel-lang/chapel/pull/27562.

These tests use empty functions to trigger certain conditions in the compiler, but the empty functions are now being removed. This is a test only fix to make those functions not be empty.


- [x] Tested that all failing tests now pass with CHPL_GPU=nvidia
```
test/gpu/native/assertOnFailToGpuizeAttr.chpl
test/gpu/native/assertOnNotGpuEligible.chpl
test/gpu/native/errors/gpuTrace.chpl
test/gpu/native/errors/gpuTraceStd.chpl
test/gpu/native/errors/gpuTraceViaCall.chpl
test/gpu/native/reportGpu.chpl
```

[Reviewed by @e-kayrakli]