### PR TITLE
Allow '=' in executable names with PBS

### DIFF
--- a/util/test/chpl_launchcmd.py
+++ b/util/test/chpl_launchcmd.py
@@ -202,6 +202,7 @@ class AbstractJob(object):
         logging.debug('Test command basename: {0}'.format(cmd_basename))
 
         job_name = '{0}-{1}'.format(prefix, cmd_basename)
+        job_name = job_name.replace('=','-')
         logging.debug('Job name is: {0}'.format(job_name))
         return job_name
 


### PR DESCRIPTION
`chpl_launchcmd.py` uses the name  of the executable to be run in the name for the PBS job, passed to qsub with the `-N` argument. An equal sign causes `qsub -N` to complain `illegal -N value`.

This PR sanitizes the job name by replacing its `=`, if any, with `-`.

Tested on an Apollo with PBS.