### PR TITLE
Pass `CC` and `CXX` as absolute paths to chapel-py build

### DIFF
--- a/third-party/chpl-venv/Makefile
+++ b/third-party/chpl-venv/Makefile
@@ -111,7 +111,8 @@ chapel-py-venv: FORCE $(CHPL_VENV_VIRTUALENV_DIR_OK)
 	@# note that CC/CXX are explicitly set to avoid scikit-build/scikit-build-core#1114
 	export PATH="$(CHPL_VENV_VIRTUALENV_BIN):$$PATH" && \
 	export VIRTUAL_ENV=$(CHPL_VENV_VIRTUALENV_DIR) && \
-	CC=$(CHPL_MAKE_HOST_CC) CXX=$(CHPL_MAKE_HOST_CXX) \
+	CC=$(shell which $(CHPL_MAKE_HOST_CC)) \
+	CXX=$(shell which $(CHPL_MAKE_HOST_CXX)) \
 	CHPL_HOME=$(CHPL_MAKE_HOME) $(PIP) install --upgrade \
 	  $(CHPL_PIP_INSTALL_PARAMS) $(LOCAL_PIP_FLAGS) \
 	  --target $(CHPL_VENV_CHPL_FRONTEND_PY_DEPS) \


### PR DESCRIPTION
Fixes an issue with homebrew builds of chapel-py

This issue was caused by homebrew passing flags to cmake (i.e. `CMAKE_PREFIX_PATH`) which was causing `cmake` to resolve the `clang` and `clang++` paths to the homebrew install of LLVM/clang, instead of the system clang

[Reviewed by @]