### PR TITLE
Attempt to fix the whiteboxes, again

### DIFF
--- a/util/cron/common-whitebox.bash
+++ b/util/cron/common-whitebox.bash
@@ -33,8 +33,7 @@ elif [ -z "$(type module 2> /dev/null)" ] ; then
 fi
 
 # Ensure we're using the expected Python version
-source $UTIL_CRON_DIR/load-base-deps.bash
-module unload llvm
+source /lus/scratch/chapelu/chpl-deps/horizon/load_chpl_deps_wb.bash
 
 # Variable set by Jenkins to indicate type of whitebox. If it is not set, assume cray-xc.
 platform=${CRAY_PLATFORM_FROM_JENKINS:-cray-xc}


### PR DESCRIPTION
[reviewed by @arifthpe]

Instead of loading the normal base dependencies and unloading llvm, load a new base dependencies script I've created specially for the whiteboxes that doesn't include llvm from the start.  I'm doing this in case something about trying to load that llvm version is what is throwing off the CC computation for whitebox testing