### PR TITLE
Adjust new dead code optimization to not remove module deinit

### DIFF
--- a/compiler/optimizations/deadCodeElimination.cpp
+++ b/compiler/optimizations/deadCodeElimination.cpp
@@ -433,7 +433,8 @@ static bool removeVoidFunction(FnSymbol* fn) {
   // do not remove 'main', even if its empty
   if (fn == chplUserMain) return false;
   // various functions that should not be removed
-  if (fn->hasFlag(FLAG_EXPORT) || fn->hasFlag(FLAG_MODULE_INIT) ||
+  if (fn->hasFlag(FLAG_EXPORT) ||
+      fn->hasFlag(FLAG_MODULE_INIT) ||  fn->hasFlag(FLAG_MODULE_DEINIT) ||
       fn->hasFlag(FLAG_NO_FN_BODY) || fn->hasFlag(FLAG_DESTRUCTOR) ||
       fn->hasFlag(FLAG_VIRTUAL) ||
       fn->hasFlag(FLAG_FIRST_CLASS_FUNCTION_INVOCATION))

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -559,6 +559,7 @@ static void handleModuleDeinitFn(ModuleSymbol* mod) {
 
     deinitFn->name = astr("chpl__deinit_", mod->name);
     deinitFn->removeFlag(FLAG_DESTRUCTOR);
+    deinitFn->addFlag(FLAG_MODULE_DEINIT);
   }
 }
 

--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -1010,6 +1010,7 @@ void ensureModuleDeinitFnAnchor(ModuleSymbol* mod, Expr*& anchor) {
 
   if (!deinitFn) {
     deinitFn = new FnSymbol(astr("chpl__deinit_", mod->name));
+    deinitFn->addFlag(FLAG_MODULE_DEINIT);
 
     mod->block->insertAtTail(new DefExpr(deinitFn));
 

--- a/frontend/include/chpl/uast/PragmaList.h
+++ b/frontend/include/chpl/uast/PragmaList.h
@@ -414,6 +414,7 @@ PRAGMA(MODIFIES_CONST_FIELDS, npr, "modifies const fields", "... of 'this' argum
 PRAGMA(MODULE_FROM_COMMAND_LINE_FILE, npr, "module from command line file", "This is a module that came from a file named on the compiler command line")
 
 PRAGMA(MODULE_INIT, npr, "module init", "a module init function")
+PRAGMA(MODULE_DEINIT, npr, "module deinit", "a module deinit function")
 
 PRAGMA(MODULE_INCLUDED_BY_DEFAULT, ypr, "module included by default", "module is included by default")
 


### PR DESCRIPTION
Adjusts the new dead code optimization added in https://github.com/chapel-lang/chapel/pull/27562 to avoid removing module deinit's.

The pass was avoiding removing regular deinit's, but module deinit's get unmarked as destructors and so weren't handled.

[Reviewed by @e-kayrakli]