### PR TITLE
Add skipifs for tests that require more locales than we have available

### DIFF
--- a/test/release/examples/primers/chplvis/SKIPIF
+++ b/test/release/examples/primers/chplvis/SKIPIF
@@ -1,0 +1,4 @@
+# these tests are not that interesting for GPU locale model and some require
+# more locales than available on the test system. Without that limitation, we
+# could remove this skipif
+CHPL_LOCALE_MODEL==gpu

--- a/test/release/examples/primers/distributions.skipif
+++ b/test/release/examples/primers/distributions.skipif
@@ -1,0 +1,4 @@
+# this test is not that interesting for GPU locale model and some require
+# more locales than available on the test system. Without that limitation, we
+# could remove this skipif
+CHPL_LOCALE_MODEL==gpu

--- a/test/release/examples/primers/replicated.skipif
+++ b/test/release/examples/primers/replicated.skipif
@@ -1,0 +1,4 @@
+# this test is not that interesting for GPU locale model and some require
+# more locales than available on the test system. Without that limitation, we
+# could remove this skipif
+CHPL_LOCALE_MODEL==gpu


### PR DESCRIPTION
There are some tests in `release/examples/primers` that require more than 4 locales. However, after recent changes in our datacenter, a GPU config has been moved to a partition with 4 locales. This PR skips those tests in GPU configs.

Alternatively, we could skip those tests if the `CHPL_LAUNCHER_PARTITION` variable is set to a specific value. That sounded more principled, but would have made the skipif more niche and harder to find. With this PR, we skip those tests based on `CHPL_LOCALE_MODEL` instead.

Test:
- [x] locally tested with `--respect-skipifs`