### PR TITLE
Reduce problem sizes of two tests which sporadically sig-9 in nightly

### DIFF
--- a/test/library/draft/DistributedMap/use-distributed-map.chpl
+++ b/test/library/draft/DistributedMap/use-distributed-map.chpl
@@ -3,7 +3,7 @@ use Map, DistributedMap, Aggregator, BlockDist, Random;
 /////////////////////////////////
 // randomStrings parameters and reference
 config const defaultSeed = 3141592;
-config const numStrings  = 200_000;
+config const numStrings  = 2**16;
 
 // int(8) means the maps will have only 256 keys with large histogram counts
 // use bigger-sized types to have more keys with smaller counts

--- a/test/library/packages/Curl/doc-examples/CurlExamples.prediff
+++ b/test/library/packages/Curl/doc-examples/CurlExamples.prediff
@@ -1,4 +1,6 @@
 #!/bin/bash
+# save a copy of the original output
+cat $2 > $2.orig.tmp
 # replace carriage returns
 cat $2 | sed 's/\r$//' > $2.tmp
 # keep only lines containing special symbol

--- a/test/library/standard/Sort/correctness/SortTypes.chpl
+++ b/test/library/standard/Sort/correctness/SortTypes.chpl
@@ -1,4 +1,4 @@
-config const size = 100000;
+config const size = 2**16;
 config const verbose = false;
 
 use Sort, Math;


### PR DESCRIPTION
Adjust two tests that sporadically die with a signal 9 in `correctness-test-c-backend`. While here, adjust `.prediff` for another sporadic failure to have it keep the original output around.

Reviewed by @benharsh. Thanks!