### PR TITLE
Don't dead code eliminate extern functions we know nothing about

### DIFF
--- a/compiler/optimizations/deadCodeElimination.cpp
+++ b/compiler/optimizations/deadCodeElimination.cpp
@@ -433,7 +433,7 @@ static bool removeVoidFunction(FnSymbol* fn) {
   // do not remove 'main', even if its empty
   if (fn == chplUserMain) return false;
   // various functions that should not be removed
-  if (fn->hasFlag(FLAG_EXPORT) ||
+  if (fn->hasEitherFlag(FLAG_EXPORT, FLAG_EXTERN) ||
       fn->hasFlag(FLAG_MODULE_INIT) ||  fn->hasFlag(FLAG_MODULE_DEINIT) ||
       fn->hasFlag(FLAG_NO_FN_BODY) || fn->hasFlag(FLAG_DESTRUCTOR) ||
       fn->hasFlag(FLAG_VIRTUAL) ||


### PR DESCRIPTION
Don't dead code eliminate extern functions that look like dead code, since we don't know what side effects that code may have.

This optimization was relying on `FLAG_NO_FN_BODY` to determine if a function was extern, but that does not seem to true for all extern functions (especially compiler generated ones like `chpl_mli_smain`)

This PR fixes an issue with multilocale Python interop. I verified this fix fixes the tests failing (they were hung because `chpl_mli_smain` was never called to setup a socket)

[Reviewed by @lydia-duncan]