### PR TITLE
Fix paths and env vars for Vagrant 'full' test config

### DIFF
--- a/util/devel/test/portability/vagrant/chapelfullcheck.sh
+++ b/util/devel/test/portability/vagrant/chapelfullcheck.sh
@@ -3,4 +3,4 @@
 # Check if full (util/setchplenv + GMP/RE2) Chapel build passes make check
 # Prints summary at the end
 
-./tryit.sh 'bash -c '\''cd chapel && source util/setchplenv.bash && export CHPL_GMP=gmp && export CHPL_RE2=`./util/devel/test/portability/vagrant/re2-supported.py` && export GMAKE=`which gmake` && export MAKE=${GMAKE:-make} && $MAKE && $MAKE check'\'
+./tryit.sh 'bash -c '\''cd chapel && source util/setchplenv.bash && export CHPL_GMP=bundled && export CHPL_RE2=`./util/devel/test/portability/vagrant/re2-supported.py` && export GMAKE=`which gmake` && export MAKE=${GMAKE:-make} && $MAKE && $MAKE check'\'


### PR DESCRIPTION
Fix these issues:
- Incorrect path to script `re2-supported.py` in vagrant dir, after move in https://github.com/chapel-lang/chapel/pull/27398
- Invalid value `CHPL_GMP=gmp`, set to `CHPL_GMP=bundled`

[trivial, not reviewed]