### PR TITLE
Remove internal `checkProj` flag for mason

### DIFF
--- a/test/library/packages/UnitTest/Launcher_Test.chpl
+++ b/test/library/packages/UnitTest/Launcher_Test.chpl
@@ -2,6 +2,6 @@ private use List;
 use MasonTest;
 
 proc main(args: [] string) {
-  var masonArgs = ["mason", "--recursive", args[1]];
-  masonTest(masonArgs, checkProj=false);
+  var masonArgs = ["test", "--recursive", args[1]];
+  masonTest(masonArgs);
 }

--- a/test/mason/build/_noDeps/Mason.toml
+++ b/test/mason/build/_noDeps/Mason.toml
@@ -3,4 +3,4 @@ name = "noDeps"
 version = "0.1.0"
 chplVersion = "1.24.0"
 license = "None"
-
+type = "application"

--- a/test/mason/build/noDeps.chpl
+++ b/test/mason/build/noDeps.chpl
@@ -7,5 +7,5 @@ proc main() {
   const package = '_noDeps';
   here.chdir(package);
   const args = ["build"];
-  masonBuild(args, checkProj=false);
+  masonBuild(args);
 }

--- a/test/mason/mason-example-with-opts/Mason.toml
+++ b/test/mason/mason-example-with-opts/Mason.toml
@@ -3,6 +3,7 @@
 name = "sampleModule"
 version = "0.1.0"
 chplVersion = "1.17.0"
+type = "library"
 
 [dependencies]
 _MasonTest1 = "0.2.0"

--- a/test/mason/mason-example-with-opts/mason-example.chpl
+++ b/test/mason/mason-example-with-opts/mason-example.chpl
@@ -4,11 +4,11 @@ use MasonRun;
 proc main() {
 
   // build the examples
-  masonBuild(["build", "--example", "--force"], checkProj=false);
+  masonBuild(["build", "--example", "--force"]);
 
   // run each example
   // over 3 arguments runs all examples
   var runArgs = ["run", "--example", "--force"];
-  masonRun(runArgs, checkProj=false);
+  masonRun(runArgs);
 
 }

--- a/test/mason/mason-example/Mason.toml
+++ b/test/mason/mason-example/Mason.toml
@@ -3,6 +3,7 @@
 name = "sampleModule"
 version = "0.1.0"
 chplVersion = "1.17.0"
+type = "library"
 
 [dependencies]
 _MasonTest1 = "0.2.0"

--- a/test/mason/mason-example/mason-example.chpl
+++ b/test/mason/mason-example/mason-example.chpl
@@ -4,10 +4,10 @@ use MasonRun;
 proc main() {
 
   // build the examples
-  masonBuild(["build", "--example", "--force"], checkProj=false);
+  masonBuild(["build", "--example", "--force"]);
 
   // run each example
   // over 3 arguments runs all examples
-  masonRun(["run", "--example", "--force", "--no-update"], checkProj=false);
+  masonRun(["run", "--example", "--force", "--no-update"]);
 
 }

--- a/test/mason/mason-external/libtomlc99/mason-external.chpl
+++ b/test/mason/mason-external/libtomlc99/mason-external.chpl
@@ -25,7 +25,7 @@ proc main() {
 
   // build library that uses libtomlc99
   var buildArgs = ["build", "--force"];
-  masonBuild(buildArgs, checkProj=false);
+  masonBuild(buildArgs);
 
 }
 

--- a/test/mason/mason-external/masonExternalRanges/Mason.toml
+++ b/test/mason/mason-external/masonExternalRanges/Mason.toml
@@ -4,6 +4,7 @@ name = "masonExternalRanges"
 version = "0.1.0"
 chplVersion = "1.23.0"
 license = "None"
+type = "application"
 
 [dependencies]
 

--- a/test/mason/mason-external/masonExternalRanges/mason-external-range.chpl
+++ b/test/mason/mason-external/masonExternalRanges/mason-external-range.chpl
@@ -14,5 +14,5 @@ proc main() {
   installSpkg(installArgs);
   // Build library that uses libtomlc99
   var buildArgs = ["build", "--force"];
-  masonBuild(buildArgs, checkProj=false);
+  masonBuild(buildArgs);
 }

--- a/test/mason/mason-test/Mason.toml
+++ b/test/mason/mason-test/Mason.toml
@@ -12,6 +12,7 @@ tests = ["sampletest.chpl",
          "shallnotpass.chpl",
          "docs/exampletest.chpl",
          "compileerror.chpl"]
+type = "library"
 
 [dependencies]
 _MasonTest1 = "0.2.0"

--- a/test/mason/mason-test/mason-test.chpl
+++ b/test/mason/mason-test/mason-test.chpl
@@ -2,5 +2,5 @@ use MasonTest;
 
 proc main() {
   const args = ["test"];
-  masonTest(args, checkProj=false);
+  masonTest(args);
 }

--- a/test/mason/masonTestSome/Mason.toml
+++ b/test/mason/masonTestSome/Mason.toml
@@ -2,6 +2,7 @@
 name = "masonTestSome"
 version = "0.1.0"
 chplVersion = "1.20.0"
+type = "application"
 
 tests = ["compilererror.chpl"]
 

--- a/test/mason/masonTestSome/mason-test-noShow.chpl
+++ b/test/mason/masonTestSome/mason-test-noShow.chpl
@@ -3,5 +3,5 @@ use MasonTest;
 proc main() {
 
   const args = ["test", "test/compilererror.chpl"];
-  masonTest(args, checkProj=false);
+  masonTest(args);
 }

--- a/test/mason/masonTestSome/mason-test-show.chpl
+++ b/test/mason/masonTestSome/mason-test-show.chpl
@@ -3,5 +3,5 @@ use MasonTest;
 proc main() {
 
   const args = ["test", "--show"];
-  masonTest(args, checkProj=false);
+  masonTest(args);
 }

--- a/test/mason/masonTestSome/mason-test-some.chpl
+++ b/test/mason/masonTestSome/mason-test-some.chpl
@@ -3,5 +3,5 @@ use MasonTest;
 
 proc main() {
   const args = ["test" , "test/test1.chpl", "test/testDir"];
-  masonTest(args, checkProj=false);
+  masonTest(args);
 }

--- a/test/mason/masonTestSubString/Mason.toml
+++ b/test/mason/masonTestSubString/Mason.toml
@@ -2,5 +2,6 @@
 name = "masonTestSubString"
 version = "0.1.0"
 chplVersion = "1.20.0"
+type = "application"
 
 [dependencies]

--- a/test/mason/masonTestSubString/mason-test-sub-string.chpl
+++ b/test/mason/masonTestSubString/mason-test-sub-string.chpl
@@ -2,5 +2,5 @@ use MasonTest;
 
 proc main() {
   const args = ["test" , "1", "3", "--no-update"];
-  masonTest(args, checkProj=false);
+  masonTest(args);
 }

--- a/test/mason/run/Mason.toml
+++ b/test/mason/run/Mason.toml
@@ -3,5 +3,6 @@
 name = "FizzBuzz"
 version = "0.1.0"
 chplVersion = "1.17.0"
+type = "application"
 
 [dependencies]

--- a/test/mason/run/mason-run.chpl
+++ b/test/mason/run/mason-run.chpl
@@ -2,5 +2,5 @@ use MasonRun;
 
 proc main() {
   const args: [0..2] string = ["run", "--build", "--force"];
-  masonRun(args, checkProj=false);
+  masonRun(args);
 }

--- a/test/mason/subdir-commands/Mason.toml
+++ b/test/mason/subdir-commands/Mason.toml
@@ -3,5 +3,6 @@
 name = "FizzBuzz"
 version = "0.1.0"
 chplVersion = "1.17.0"
+type = "application"
 
 [dependencies]

--- a/test/mason/subdir-commands/mason-run.chpl
+++ b/test/mason/subdir-commands/mason-run.chpl
@@ -2,5 +2,5 @@ use MasonRun;
 
 proc main() {
   const args: [0..2] string = ["run", "--build", "--force"];
-  masonRun(args, checkProj=false);
+  masonRun(args);
 }

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -33,7 +33,7 @@ use MasonExample;
 use Subprocess;
 use TOML;
 
-proc masonBuild(args: [] string, checkProj=true) throws {
+proc masonBuild(args: [] string) throws {
 
   var parser = new argumentParser(helpHandler=new MasonBuildHelpHandler());
 
@@ -51,11 +51,9 @@ proc masonBuild(args: [] string, checkProj=true) throws {
     throw new owned MasonError("Examples do not support `--` syntax");
   }
 
-  if checkProj {
-    const projectType = getProjectType();
-    if projectType == "light" then
-      throw new owned MasonError("Mason light projects do not currently support 'mason build'");
-  }
+  const projectType = getProjectType();
+  if projectType == "light" then
+    throw new owned MasonError("Mason light projects do not currently support 'mason build'");
 
   var show = showFlag.valueAsBool();
   var release = releaseFlag.valueAsBool();
@@ -83,7 +81,7 @@ proc masonBuild(args: [] string, checkProj=true) throws {
     if force then compopts.pushBack("--force");
     // add expected arguments for masonExample
     compopts.insert(0,["example", "--example"]);
-    masonExample(compopts.toArray(), checkProj=checkProj);
+    masonExample(compopts.toArray());
   }
   else {
     if passArgs.hasValue() {

--- a/tools/mason/MasonExample.chpl
+++ b/tools/mason/MasonExample.chpl
@@ -34,7 +34,7 @@ use TOML;
 
 
 /* Runs the .chpl files found within the /example directory */
-proc masonExample(args: [] string, checkProj=true) throws {
+proc masonExample(args: [] string) throws {
 
   var parser = new argumentParser();
 
@@ -51,11 +51,9 @@ proc masonExample(args: [] string, checkProj=true) throws {
   var updateFlag = parser.addFlag(name="update", flagInversion=true);
   var exampleOpts = parser.addOption(name="example", numArgs=0..);
 
-  if checkProj {
-    const projectType = getProjectType();
-    if projectType == "light" then
-      throw new owned MasonError("Mason light projects do not currently support 'mason example'");
-  }
+  const projectType = getProjectType();
+  if projectType == "light" then
+    throw new owned MasonError("Mason light projects do not currently support 'mason example'");
 
   try! {
     parser.parseArgs(args);

--- a/tools/mason/MasonRun.chpl
+++ b/tools/mason/MasonRun.chpl
@@ -28,7 +28,7 @@ use MasonUtils;
 use TOML;
 
 
-proc masonRun(args: [] string, checkProj=true) throws {
+proc masonRun(args: [] string) throws {
 
   var parser = new argumentParser(helpHandler=new MasonRunHelpHandler());
 
@@ -47,11 +47,9 @@ proc masonRun(args: [] string, checkProj=true) throws {
 
   parser.parseArgs(args);
 
-  if checkProj {
-    const projectType = getProjectType();
-    if projectType != "application" then
-      throw new owned MasonError("Only mason applications can be run, but this is a Mason " + projectType);
-  }
+  const projectType = getProjectType();
+  if projectType != "application" then
+    throw new owned MasonError("Only mason applications can be run, but this is a Mason " + projectType);
 
   var show = showFlag.valueAsBool();
   var release = releaseFlag.valueAsBool();
@@ -65,7 +63,7 @@ proc masonRun(args: [] string, checkProj=true) throws {
     exit(0);
   } else if exampleOpts._present || buildFlag.valueAsBool() {
     // --example with value or build flag
-    masonBuildRun(args, checkProj);
+    masonBuildRun(args);
     exit(0);
   }
   runProjectBinary(show, release, execopts);
@@ -135,7 +133,7 @@ proc runProjectBinary(show: bool, release: bool, execopts: list(string)) throws 
 
 
 /* Builds program before running. */
-private proc masonBuildRun(args: [?d] string, checkProj=true) {
+private proc masonBuildRun(args: [?d] string) {
 
   var parser = new argumentParser(helpHandler=new MasonRunHelpHandler());
 
@@ -184,7 +182,7 @@ private proc masonBuildRun(args: [?d] string, checkProj=true) {
       if release then execopts.pushBack("--release");
       if force then execopts.pushBack("--force");
       if show then execopts.pushBack("--show");
-      masonExample(execopts.toArray(), checkProj);
+      masonExample(execopts.toArray());
     }
     else {
       var buildArgs: list(string);
@@ -194,7 +192,7 @@ private proc masonBuildRun(args: [?d] string, checkProj=true) {
       if release then buildArgs.pushBack("--release");
       if force then buildArgs.pushBack("--force");
       if show then buildArgs.pushBack("--show");
-      masonBuild(buildArgs.toArray(), checkProj);
+      masonBuild(buildArgs.toArray());
       for val in passArgs.values() do execopts.pushBack(val);
       runProjectBinary(show, release, execopts);
     }

--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -46,7 +46,7 @@ var files: list(string);
 /* Runs the .chpl files found within the /tests directory of Mason packages
    or files which in the path provided.
 */
-proc masonTest(args: [] string, checkProj=true) throws {
+proc masonTest(args: [] string) throws {
 
   var parser = new argumentParser(helpHandler=new MasonTestHelpHandler());
 
@@ -85,7 +85,7 @@ proc masonTest(args: [] string, checkProj=true) throws {
     isMasonProject = false;
   }
 
-  if checkProj && isMasonProject {
+  if isMasonProject {
     const projectType = getProjectType();
     if projectType == "light" then
       throw new owned MasonError("Mason light projects do not currently support 'mason test'");


### PR DESCRIPTION
Fully removes the internal `checkProj` flag added in https://github.com/chapel-lang/chapel/pull/20297 to mason. This flag seems to have been added as a way to avoid checks that were now firing, but this is not representative of a user experience. This PR removes that internal flag, and just fixes the check (which is to add `type` to `Mason.toml`).

- [x] paratest

[Reviewed by @benharsh]