### PR TITLE
Ignore errors when GASNET_INC_MAKEFILE is missing

### DIFF
--- a/third-party/gasnet/Makefile.setup
+++ b/third-party/gasnet/Makefile.setup
@@ -3,7 +3,7 @@
 # with the Chapel compiler options.
 
 
-include $(GASNET_INC_MAKEFILE)
+-include $(GASNET_INC_MAKEFILE)
 
 # 
 # The following lines try to combine GASNet's favorite C compiler


### PR DESCRIPTION
Ignore errors when GASNET_INC_MAKEFILE is missing. This should only occur when someone explicitly deletes a gasnet include makefile, like in the homebrew formula (see #27626).

#27626 removed the gasnet include makefiles because they hardcode an incorrect compiler path from homebrew. This is fine, because once Chapel is built those makefiles aren't needed. But they are needed to run `make check`, which `brew test chapel` will run

[Reviewed by @arifthpe]