### PR TITLE
Throw '--no-cache-remote' when running new CommDiagnostics test

### DIFF
--- a/test/library/standard/CommDiagnostics/doc-examples/CommDiagnosticsLittleExample1.compopts
+++ b/test/library/standard/CommDiagnostics/doc-examples/CommDiagnosticsLittleExample1.compopts
@@ -1,0 +1,1 @@
+--no-cache-remote

--- a/test/library/standard/CommDiagnostics/doc-examples/CommDiagnosticsLittleExample1.good
+++ b/test/library/standard/CommDiagnostics/doc-examples/CommDiagnosticsLittleExample1.good
@@ -1,5 +1,3 @@
 0: CommDiagnosticsLittleExample1.chpl:11: remote executeOn, node 1
-1: CommDiagnosticsLittleExample1.chpl:12: remote cache-get, node 0, 8 bytes, commid 3
-1: CommDiagnosticsLittleExample1.chpl:12: remote get_nb, node 0, 64 bytes, commid 3
-1: CommDiagnosticsLittleExample1.chpl:12: remote cache-put, node 0, 8 bytes, commid 4
-1: :-1: remote put_nb, node 0, 8 bytes, commid -1
+1: CommDiagnosticsLittleExample1.chpl:12: remote get, node 0, 8 bytes, commid 3
+1: CommDiagnosticsLittleExample1.chpl:12: remote put, node 0, 8 bytes, commid 4


### PR DESCRIPTION
This PR throws the `--no-cache-remote` flag explicitly for a new `CommDiagnostics` test. It is thrown implicitly on certain nightly testing configurations such as for `asan` and that affects comm counts. Trivial and not reviewed.