### PR TITLE
Fix two issues with `mason init`/`mason new`

### DIFF
--- a/tools/mason/MasonInit.chpl
+++ b/tools/mason/MasonInit.chpl
@@ -91,6 +91,11 @@ proc masonInit(args: [] string) throws {
     const path = if dirName == '' then '.' else dirName;
     if packageName.size > 0 then name = packageName;
 
+    if !isLightweight {
+      validatePackageName(dirName=name);
+    }
+
+
     if dirName != '' then
       if !isDir(path) then
         throw new owned MasonError("Directory does not exist: " + path +

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -513,10 +513,8 @@ proc isIdentifier(name:string) {
   if name == "" then
     return false;
 
-  // Identifiers can't start with a digit or a $
+  // Identifiers can't start with a digit
   if name[0].isDigit() then
-    return false;
-  if name[0] == "$" then
     return false;
 
   // Check all characters are legal identifier characters
@@ -524,10 +522,9 @@ proc isIdentifier(name:string) {
   // - upper case alphabetic
   // - digits
   // - _
-  // - $
   var ok = true;
   for ch in name {
-    if !(ch == "$" || ch == "_" || ch.isAlnum()) then
+    if !(ch == "_" || ch.isAlnum()) then
       ok = false;
   }
   return ok;


### PR DESCRIPTION
Fixes two issues with `mason init` and `mason new`.

* `mason new` had checking to prevent invalid project names, `mason init` did not. This PR rectifies that
* `mason new` and `mason init` would both allow new projects with `$` in the name, `$` in an identifier has been deprecated for awhile now

- [ ] paratest

[Reviewed by @]