### PR TITLE
Dyno: Add converter support for globals declared in internal/standard modules

### DIFF
--- a/compiler/include/convert-uast.h
+++ b/compiler/include/convert-uast.h
@@ -53,6 +53,7 @@ class UastConverter {
   setFunctionsToConvertWithTypes(const chpl::resolution::CalledFnsSet& calledFns) = 0;
 
   virtual void setSymbolsToIgnore(std::unordered_set<chpl::ID> ignore) = 0;
+  virtual void eraseSymbolToIgnore(chpl::ID ignore) = 0;
 
   // Indicate which module is the main module
   virtual void setMainModule(chpl::ID mainModule) = 0;

--- a/compiler/passes/cleanup.cpp
+++ b/compiler/passes/cleanup.cpp
@@ -91,15 +91,19 @@ static void handleNonTypedAndNonInitedVar(DefExpr* def) {
     if (needsInit) {
       if ((def->init && def->init->isNoInitExpr()) ||
           def->sym->hasFlag(FLAG_CONFIG)) {
-        USR_FATAL_CONT(def->sym,
-                       "Variable '%s' is not initialized and has no type",
-                       def->sym->name);
+        if (!def->sym->hasFlag(FLAG_RESOLVED_EARLY)) {
+          USR_FATAL_CONT(def->sym,
+                         "Variable '%s' is not initialized and has no type",
+                         def->sym->name);
+        }
       } else {
         bool skip = false;
         if (FnSymbol* inFn = toFnSymbol(def->parentSymbol)) {
           if (inFn->isNormalized()) {
             skip = true;
           }
+        } else if (def->sym->hasFlag(FLAG_RESOLVED_EARLY)) {
+          skip = true;
         }
 
         if (!skip) {

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -168,6 +168,9 @@ struct Converter final : UastConverter {
   void setSymbolsToIgnore(std::unordered_set<chpl::ID> ignore) override {
     symbolsToIgnore.swap(ignore);
   }
+  void eraseSymbolToIgnore(chpl::ID ignore) override {
+    symbolsToIgnore.erase(ignore);
+  }
 
   void useModuleWhenConverting(const chpl::ID& modId, ModuleSymbol* modSym) override {
     modSyms[modId] = modSym;
@@ -3583,6 +3586,7 @@ struct Converter final : UastConverter {
   Expr* visit(const uast::Variable* node) {
     auto isTypeVar = node->kind() == uast::Variable::TYPE;
     auto stmts = new BlockStmt(BLOCK_SCOPELESS);
+    if (symbolsToIgnore.count(node->id()) != 0) return nullptr;
 
     auto info = convertVariable(node, true);
     INT_ASSERT(info.entireExpr && info.variableDef);

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -826,6 +826,7 @@ static void normalizeBase(BaseAST* base, bool addEndOfStatements) {
   for_vector(Symbol, symbol, symbols) {
     if (VarSymbol* var = toVarSymbol(symbol)) {
       DefExpr* defExpr = var->defPoint;
+      if (var->hasFlag(FLAG_RESOLVED_EARLY)) continue;
 
       if (FnSymbol* fn = toFnSymbol(defExpr->parentSymbol)) {
         if (fn == stringLiteralModule->initFn) {


### PR DESCRIPTION
In the typed converter we will increasingly encounter situations where we need to resolve some global variable in an internal or standard module, but are unable to resolve the entirety of that module. This commit adds support for resolving just the variables that are used, by making a copy of that variable for the typed converter's usage. The original production AST is still generated.

The motivating use-case here was originally the usage of ``c_sublocid_none`` that we encounter frequently in various modules. I expanded support to include non-extern variables in anticipation of future needs.

Testing:
- [x] test/frontend/