### PR TITLE
dlopen: Add support for LLVM-14 typed pointers

### DIFF
--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -3099,7 +3099,15 @@ static GenRet codegenCallExprInner(GenRet function,
       c = info->irBuilder->CreateCall(func, llArgs);
       trackLLVMValue(c);
     } else {
-      if (!fnType) INT_FATAL("Could not compute called function type");
+    #ifdef HAVE_LLVM_TYPED_POINTERS
+      // If we are using typed pointers, the pointer type must match the
+      // call type or else instruction verification will fail. If using
+      // opaque pointers, it is fine if the call pointer type is 'void*'.
+      auto fnPtrType = llvm::PointerType::getUnqual(fnType);
+      val = info->irBuilder->CreateBitCast(val, fnPtrType);
+    #endif
+
+      if (!fnType) INT_FATAL("Need function type to create indirect call");
       c = info->irBuilder->CreateCall(fnType, val, llArgs);
       trackLLVMValue(c);
     }

--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -3099,6 +3099,8 @@ static GenRet codegenCallExprInner(GenRet function,
       c = info->irBuilder->CreateCall(func, llArgs);
       trackLLVMValue(c);
     } else {
+      INT_ASSERT(fnType != nullptr);
+
     #ifdef HAVE_LLVM_TYPED_POINTERS
       // If we are using typed pointers, the pointer type must match the
       // call type or else instruction verification will fail. If using
@@ -3107,7 +3109,6 @@ static GenRet codegenCallExprInner(GenRet function,
       val = info->irBuilder->CreateBitCast(val, fnPtrType);
     #endif
 
-      if (!fnType) INT_FATAL("Need function type to create indirect call");
       c = info->irBuilder->CreateCall(fnType, val, llArgs);
       trackLLVMValue(c);
     }

--- a/modules/internal/ChapelDynamicLoading.chpl
+++ b/modules/internal/ChapelDynamicLoading.chpl
@@ -26,30 +26,6 @@ module ChapelDynamicLoading {
 
   param chpl_defaultProcBufferSize = 512;
 
-  proc configErrorsForProcedurePointers(param emitErrors: bool) param {
-    use ChplConfig;
-
-    if !useProcedurePointers then return false;
-
-    // LLVM 14 uses typed pointers, which the backend doesn't support yet.
-    param unsupportedLlvmVersion = CHPL_LLVM_VERSION == "14";
-
-    if CHPL_TARGET_COMPILER == "llvm" && unsupportedLlvmVersion {
-      if emitErrors {
-        param v = CHPL_LLVM_VERSION;
-        compilerError('The experimental procedure pointer implementation ' +
-                      'is not currently supported with LLVM-' + v);
-      }
-      return true;
-    }
-    return false;
-  }
-
-  // Publish platform-specific errors once.
-  if useProcedurePointers {
-    configErrorsForProcedurePointers(emitErrors=true);
-  }
-
   // Returns 'true' if compile-time configuration errors exist.
   proc configErrorsForDynamicLoading(param emitErrors: bool) param {
     use ChplConfig;
@@ -67,8 +43,7 @@ module ChapelDynamicLoading {
   }
 
   proc isDynamicLoadingSupported param {
-    return !configErrorsForProcedurePointers(emitErrors=false) &&
-           !configErrorsForDynamicLoading(emitErrors=false);
+    return !configErrorsForDynamicLoading(emitErrors=false);
   }
 
   // This counter is used to assign a unique 'wide index' to each procedure.

--- a/modules/internal/ChapelDynamicLoading.chpl
+++ b/modules/internal/ChapelDynamicLoading.chpl
@@ -38,7 +38,7 @@ module ChapelDynamicLoading {
       if emitErrors {
         param v = CHPL_LLVM_VERSION;
         compilerError('The experimental procedure pointer implementation ' +
-                      'is not currently supported with LLVM-' + v, 2);
+                      'is not currently supported with LLVM-' + v);
       }
       return true;
     }

--- a/test/dynamic-loading/SKIPIF
+++ b/test/dynamic-loading/SKIPIF
@@ -1,1 +1,0 @@
-../functions/fcf/pointers/SKIPIF

--- a/test/functions/fcf/pointers/SKIPIF
+++ b/test/functions/fcf/pointers/SKIPIF
@@ -1,8 +1,0 @@
-#!/usr/bin/env python3
-
-import os
-
-# Skip for LLVM-14 and under.
-skip = os.getenv('CHPL_TARGET_COMPILER') == 'llvm' and \
-       int(os.getenv('CHPL_LLVM_VERSION')) <= 14
-print(skip)


### PR DESCRIPTION
This PR adds support for older versions of LLVM that require typed pointers (currently the only version of LLVM we support that uses typed pointers by default is LLVM-14).

When issuing an indirect call we usually pass in a `void*` storing the address of the local pointer. This PR just adds a bitcast instruction to the function pointer type when the macro `HAVE_LLVM_TYPED_POINTERS` is defined.

We already do a similar thing when calling vtable pointers, so I found inspiration there.

I tested this with `LLVM-14` on `linux64` with `COMM=gasnet` and `COMM=none` and all the procedure pointer tests seem to pass.

Reviewed by @jabraham17. Thanks!