### PR TITLE
Update the Python 3.9 job to match our Python 3.7 job

### DIFF
--- a/util/cron/test-linux64-python39.bash
+++ b/util/cron/test-linux64-python39.bash
@@ -12,4 +12,4 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-python39"
 
 set_and_check_python_version "3.9.13"
 
-$UTIL_CRON_DIR/nightly -cron -hellos ${nightly_args}
+$UTIL_CRON_DIR/nightly -cron -pythonDep ${nightly_args}


### PR DESCRIPTION
[reviewed by @arifthpe]

Now that we're dropping support for Python 3.9 in chpldoc, start_test, etc, this job needed to be adjusted to test that scenario.  We want to make sure the compiler works and other things that support it, only.