### PR TITLE
Adjust macOS homebrew test job to workaround homebrew change

### DIFF
--- a/util/cron/test-homebrew.bash
+++ b/util/cron/test-homebrew.bash
@@ -62,7 +62,7 @@ brew upgrade
 brew uninstall --force chapel
 # Remove the cached chapel tar file before running brew install --build-from-source chapel.rb
 rm $HOME/Library/Caches/Homebrew/downloads/*--chapel-${short_version}.tar.gz
-HOMEBREW_NO_INSTALL_FROM_API=1 brew install -v --build-from-source chapel.rb
+HOMEBREW_DEVELOPER=1 HOMEBREW_NO_INSTALL_FROM_API=1 brew install -v --build-from-source ./chapel.rb
 INSTALL_STATUS=$?
     if [ $INSTALL_STATUS -ne 0 ]
     then


### PR DESCRIPTION
A recent homebrew PR broke out CI by disallowing install a formula from a local path. This PR adjusts the CI to avoid this by opting into the behavior with `HOMEBREW_DEVELOPER=1`

The homebrew PR that broke things was  https://github.com/Homebrew/brew/pull/20414


[Reviewed by @arifthpe]