### PR TITLE
Swap order of sourcing common-arkouda and common-arkouda-hpe-apollo-hdr

### DIFF
--- a/util/cron/test-hpe-apollo-hdr.arkouda.bash
+++ b/util/cron/test-hpe-apollo-hdr.arkouda.bash
@@ -18,10 +18,10 @@ module list
 
 source $UTIL_CRON_DIR/common.bash
 source $UTIL_CRON_DIR/common-hpe-apollo.bash
-#
+
 # setup arkouda
-source $UTIL_CRON_DIR/common-arkouda.bash
 source $UTIL_CRON_DIR/common-arkouda-hpe-apollo-hdr.bash
+source $UTIL_CRON_DIR/common-arkouda.bash
 
 export ARKOUDA_NUMLOCALES=16
 

--- a/util/cron/test-hpe-apollo-hdr.arkouda.release.bash
+++ b/util/cron/test-hpe-apollo-hdr.arkouda.release.bash
@@ -18,10 +18,10 @@ module list
 
 source $UTIL_CRON_DIR/common.bash
 source $UTIL_CRON_DIR/common-hpe-apollo.bash
-#
+
 # setup arkouda
-source $UTIL_CRON_DIR/common-arkouda.bash
 source $UTIL_CRON_DIR/common-arkouda-hpe-apollo-hdr.bash
+source $UTIL_CRON_DIR/common-arkouda.bash
 
 export ARKOUDA_NUMLOCALES=16
 


### PR DESCRIPTION
This fixes the dependency issues caused by not having ARKOUDA_DEP_DIR set before common-arkouda is sourced.


Testing: make check passes on the apollo test machine.

