### PR TITLE
Dyno: resolution fixes variety pack 5

### DIFF
--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1486,6 +1486,20 @@ void Resolver::resolveTypeQueries(const AstNode* formalTypeExpr,
                            isNonStarVarArg, /* isTopLevel */ false);
       }
     }
+  } else if (auto tup = formalTypeExpr->toTuple()) {
+    if (!actualType.isUnknownOrErroneous()) {
+      if (auto tupT = actualType.type()->toTupleType();
+          tupT && tupT->numElements() == tup->numActuals()) {
+        // only do this for well-sized tuples. Otherwise, errors should've
+        // been emitted elsewhere.
+        for (int i = 0; i < tup->numActuals(); i++) {
+          auto actual = tup->actual(i);
+          auto elementType = QualifiedType(QualifiedType::TYPE, tupT->elementType(i).type());
+          resolveTypeQueries(actual, elementType,
+                             isNonStarVarArg, /* isTopLevel */ false);
+        }
+      }
+    }
   }
 }
 

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1471,6 +1471,21 @@ void Resolver::resolveTypeQueries(const AstNode* formalTypeExpr,
                            isNonStarVarArg, /* isTopLevel */ false);
       }
     }
+  } else if (auto op = formalTypeExpr->toOpCall()) {
+    if (op->op() == USTR("*") && !actualType.isUnknownOrErroneous()) {
+      CHPL_ASSERT(op->numActuals() == 2);
+      if (auto tup = actualType.type()->toTupleType();
+          tup && tup->isStarTuple()) {
+        auto size = QualifiedType(QualifiedType::PARAM,
+                                  IntType::get(context, 0),
+                                  IntParam::get(context, tup->numElements()));
+        auto starType = QualifiedType(QualifiedType::TYPE, tup->starType().type());
+        resolveTypeQueries(op->actual(0), size,
+                           isNonStarVarArg, /* isTopLevel */ false);
+        resolveTypeQueries(op->actual(1), starType,
+                           isNonStarVarArg, /* isTopLevel */ false);
+      }
+    }
   }
 }
 

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -6076,7 +6076,7 @@ CallResolutionResult resolveTupleExpr(Context* context,
     const Type* t = q.type();
     if (t == nullptr || t->isUnknownType())
       anyUnknown = true;
-    else if (q.kind() == QualifiedType::TYPE)
+    else if (q.kind() == QualifiedType::TYPE || q.kind() == QualifiedType::TYPE_QUERY)
       allValue = false;
     else
       allType = false;

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -106,6 +106,8 @@ getUntypedFnSignatureForFn(Context* context, const uast::Function* fn, ID const*
       if (auto formal = decl->toFormal()) {
         name = formal->name();
         hasDefault = formal->initExpression() != nullptr;
+      } else if (auto formal = decl->toTupleDecl()) {
+        hasDefault = formal->initExpression() != nullptr;
       } else if (auto varargs = decl->toVarArgFormal()) {
         name = varargs->name();
 

--- a/frontend/test/resolution/testResolve.cpp
+++ b/frontend/test/resolution/testResolve.cpp
@@ -2335,6 +2335,20 @@ static void testAnyPod() {
   // { {"sync int"}, Test::FALSE },
 }
 
+static void testTupleFormalWithDefault() {
+  auto context = buildStdContext();
+  ErrorGuard guard(context);
+  auto qt = resolveTypeOfXInit(context,
+    R"""(
+       proc foo((x, y) = (1, 2)) {
+         return x + y;
+       }
+       var x = foo((3,4));
+    )""");
+  assert(!qt.isUnknownOrErroneous());
+  assert(qt.type()->isIntType());
+}
+
 int main() {
   test1();
   test2();
@@ -2396,6 +2410,7 @@ int main() {
   testUseOfUninitializedVar();
 
   testAnyPod();
+  testTupleFormalWithDefault();
 
   return 0;
 }

--- a/frontend/test/resolution/testTuples.cpp
+++ b/frontend/test/resolution/testTuples.cpp
@@ -739,6 +739,31 @@ static void test18() {
   assert(rr.byAst(z).type().type()->isRealType());
 }
 
+// same as test18, but with unsigned.
+static void test18b() {
+  printf("%s\n", __FUNCTION__);
+  auto context = buildStdContext();
+
+  auto program = R""""(
+                  var t = (1, "hello", 3.0);
+                  var x = t(0 : uint);
+                  var y = t(1 : uint);
+                  var z = t(2 : uint);
+                )"""";
+
+  auto m = parseModule(context, std::move(program));
+
+  auto x = findVariable(m, "x");
+  auto y = findVariable(m ,"y");
+  auto z = findVariable(m ,"z");
+
+  const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
+
+  assert(rr.byAst(x).type().type()->isIntType());
+  assert(rr.byAst(y).type().type()->isStringType());
+  assert(rr.byAst(z).type().type()->isRealType());
+}
+
 // Test "get svec member[ value]" primitives
 static void test19() {
   printf("%s\n", __FUNCTION__);
@@ -1349,6 +1374,7 @@ int main() {
   test16();
   test17();
   test18();
+  test18b();
   test19();
   testTupleGeneric();
 


### PR DESCRIPTION
This is a tuple-themed one.

Closes https://github.com/Cray/chapel-private/issues/7553.
Closes https://github.com/Cray/chapel-private/issues/7554.
Closes https://github.com/Cray/chapel-private/issues/7556.
Closes https://github.com/Cray/chapel-private/issues/7555.
Would've closed an issue for resolving star-tuple queries too, but I didn't see one.

## Testing
- [x] dyno tests
- [x] paratest
- [x] paratest `--dyno-resolve-only`

Reviewed by @arifthpe -- thanks!