### PR TITLE
Dyno: Fix copy elision misfiring for copy-then-call-method

### DIFF
--- a/frontend/lib/resolution/VarScopeVisitor.cpp
+++ b/frontend/lib/resolution/VarScopeVisitor.cpp
@@ -419,7 +419,10 @@ bool VarScopeVisitor::resolvedCallHelper(const Call* callAst, RV& rv) {
   }
 
   if (!anyInOutInout) {
-    // visit the actuals to gather mentions
+    // visit the actuals (and receiver, if any) to gather mentions
+    if (auto fnCall = callAst->toFnCall()) {
+      fnCall->calledExpression()->traverse(rv);
+    }
     for (auto actualAst : callAst->actuals()) {
       actualAst->traverse(rv);
     }

--- a/frontend/test/resolution/testCopyElision.cpp
+++ b/frontend/test/resolution/testCopyElision.cpp
@@ -1364,6 +1364,19 @@ static void test47() {
   //test("forall i in stuff(x) with (var copy = helper(x))", {});
 }
 
+static void test48() {
+  testCopyElision("test5a",
+    R""""(
+        record R { proc foo(){} }
+        proc test(cond: bool) {
+          var x: R;
+          var z = x;
+          return x.foo();
+        }
+    )"""",
+    {}); // x is mentioned in receiver of method call, so no elision
+}
+
 int main() {
   test1();
   test2();
@@ -1412,5 +1425,6 @@ int main() {
   test45();
   test46();
   test47();
+  test48();
   return 0;
 }


### PR DESCRIPTION
Closes https://github.com/Cray/chapel-private/issues/7557.

Receivers of function calls were not considered mentions, which meant that `foo(x)` counted as a "mention" of `x` but 
`x.foo()` did not. This fixes that.

## Testing
- [x] dyno tests
- [x] paratest
- [x] paratest `--dyno-resolve-only`

Reviewed by @benharsh -- thanks!