### PR TITLE
Accept changes to .good file for 'printFinalMemStat.chpl'

### DIFF
--- a/test/memory/shannon/printFinalMemStat.good
+++ b/test/memory/shannon/printFinalMemStat.good
@@ -2,4 +2,4 @@
 memStats: Allocated Now:              256
 memStats: Allocation High Water Mark: 2nn
 memStats: Sum of Allocations:         2nn
-memStats: Sum of Frees:               mm
+memStats: Sum of Frees:                 mm


### PR DESCRIPTION
Revert changes made in #27237 after #27600 changed the output once again. A `param` branch was evaluating to `true`, and an array-view was allocated in a module's `deinit()` code. This accounted for the extra 192 bytes. Now that code does not run (for the moment).