### PR TITLE
Dyno: vararg iterator fix

### DIFF
--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -7356,7 +7356,17 @@ findTaggedIteratorForType(ResolutionContext* rc,
   auto name = fnIter->iteratorFn()->untyped()->name();
   std::vector<QualifiedType> argTypes;
   for (int i = 0; i < fn->numFormals(); i++) {
-    argTypes.push_back(fn->formalType(i));
+    if (fn->untyped()->formalIsVarArgs(i)) {
+      auto varArgs = fn->formalType(i);
+      CHPL_ASSERT(!varArgs.isUnknownOrErroneous());
+      auto tup = varArgs.type()->toTupleType();
+      CHPL_ASSERT(tup);
+      for (int j = 0; j < tup->numElements(); j++) {
+        argTypes.push_back(tup->elementType(j));
+      }
+    } else {
+      argTypes.push_back(fn->formalType(i));
+    }
   }
   auto inScopes = callScopeInfoForIterator(rc->context(), fnIter, overrideScope);
 


### PR DESCRIPTION
Closes https://github.com/Cray/chapel-private/issues/7558.

The bug was caused by iterator varargs being wrapped in an extra layer of tuples. This happened because vararg formals are instantiated with the tuple of arguments passed to them, and subsequent re-runs just passed that tuple directly instead of expanding it.

## Testing
- [x] dyno tests
- [x] paratest
- [x] paratest `--dyno-resolve-only`

Reviewed by @benharsh -- thanks!