### PR TITLE
Prevent 1 CHAMPS failure from running other CHAMPS tests

### DIFF
--- a/test/studies/champs/functions.bash
+++ b/test/studies/champs/functions.bash
@@ -92,7 +92,7 @@ function test_compile() {
   cat $kind.comp.out.tmp
 
   if [[ $status -ne 0 ]] ; then
-    log_fatal_error "compiling ${kind}"
+    log_error "compiling ${kind}"
   else
     log_success "make output"
   fi
@@ -103,17 +103,24 @@ function test_compile() {
     unset CHPL_STOP_AFTER_PASS
   fi
 
+  # early return if compilation failed, to prevent spurious perf stats errors
+  if [[ $status -ne 0 ]] ; then
+    return $status
+  fi
+
   if [ -z "$CHAMPS_QUICKSTART" ]; then
     $CHPL_HOME/util/test/computePerfStats comp-time-$kind $CHPL_TEST_PERF_DIR/$CHPL_TEST_PERF_DESCRIPTION $CHAMPS_GRAPH_PATH/comp-time.perfkeys $kind.comp.out.tmp
     if [[ $? -ne 0 ]] ; then
-      log_fatal_error "computing compile time stats for ${kind}"
+      log_error "computing compile time stats for ${kind}"
     fi
 
     $CHPL_HOME/util/test/computePerfStats emitted-code-size-$kind $CHPL_TEST_PERF_DIR/$CHPL_TEST_PERF_DESCRIPTION $CHAMPS_GRAPH_PATH/emitted-code-size.perfkeys $kind.comp.out.tmp
     if [[ $? -ne 0 ]] ; then
-      log_fatal_error "computing emitted code size stats for ${kind}"
+      log_error "computing emitted code size stats for ${kind}"
     fi
   fi
+
+  return $status
 }
 
 function test_run() {

--- a/test/studies/champs/sub_test
+++ b/test/studies/champs/sub_test
@@ -86,7 +86,7 @@ test_compile icing
 
 local flow_success=0
 
-if [ -z "$CHAMPS_QUICKSTART" ] ; then
+if [ -z "$CHAMPS_QUICKSTART" ] || [ ! -z "$CHAMPS_COMPILE_ALL_EXECS" ] ; then
   test_compile prep
   flow_success=$(test_compile flow)
   test_compile drop

--- a/test/studies/champs/sub_test
+++ b/test/studies/champs/sub_test
@@ -84,9 +84,11 @@ fi
 # Compile CHAMPS executables
 test_compile icing
 
-if [ -z "$CHAMPS_QUICKSTART" ] || [ ! -z "$CHAMPS_COMPILE_ALL_EXECS" ] ; then
+local flow_success=0
+
+if [ -z "$CHAMPS_QUICKSTART" ] ; then
   test_compile prep
-  test_compile flow
+  flow_success=$(test_compile flow)
   test_compile drop
   test_compile potential
   test_compile potentialPrep
@@ -105,7 +107,7 @@ if [ -z "$CHAMPS_QUICKSTART" ] || [ ! -z "$CHAMPS_COMPILE_ALL_EXECS" ] ; then
 fi
 
 
-if [ -z "$CHAMPS_QUICKSTART" ] ; then
+if [ -z "$CHAMPS_QUICKSTART" ] && [[ $flow_success -eq 0 ]] ; then
   # copy the input data to the filesystem we're running on
   # I can't tell whether prep is running too slow or just freezing, for now don't run it
   # cp $CHAMPS_DATA_PATH/CRMHL_coarse.cgns $CHAMPS_HOME/


### PR DESCRIPTION
Changes how our CHAMPS testing works to run all compiles, instead of stopping when one CHAMPS executable fails to compile.

This means that even if one fails to compile, other executables will still be built/tested.

[Reviewed by @e-kayrakli]