### PR TITLE
Switch ASAN testing to use qthreads

### DIFF
--- a/util/cron/common-asan.bash
+++ b/util/cron/common-asan.bash
@@ -6,7 +6,6 @@ UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 
 export CHPL_TARGET_MEM=cstdlib
 export CHPL_HOST_MEM=cstdlib
-export CHPL_TASKS=fifo
 export CHPL_LLVM=none
 export CHPL_SANITIZE=address
 export ASAN_OPTIONS="use_sigaltstack=0,detect_leaks=0"

--- a/util/cron/test-asan-fifo.bash
+++ b/util/cron/test-asan-fifo.bash
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# Test ASAN-compatible configuration on full suite with ASAN on linux64.
+
+UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+source $UTIL_CRON_DIR/common.bash
+source $UTIL_CRON_DIR/common-asan.bash
+source $UTIL_CRON_DIR/common-localnode-paratest.bash
+
+export CHPL_TASKS=fifo
+# don't asan the compiler
+export CHPL_SANITIZE=none
+export CHPL_SANITIZE_EXE=address
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="asan-fifo"
+
+$UTIL_CRON_DIR/nightly -cron ${nightly_args} $(get_nightly_paratest_args 8)


### PR DESCRIPTION
Switches the nightly asan testing to use qthreads instead of fifo. This also maintains a separate fifo config for asan to continue testing it.

TODO: requires CI changes

[Reviewed by @]