### PR TITLE
Dyno: Improve genericity checks and allow `_owned(C)` -> `owned C` conversion

### DIFF
--- a/frontend/include/chpl/framework/all-global-strings.h
+++ b/frontend/include/chpl/framework/all-global-strings.h
@@ -196,6 +196,8 @@ X(deprecated          , "deprecated")
 X(edition             , "edition")
 X(unstable            , "unstable")
 
+X(ownedRecId          , "OwnedObject._owned")
+X(sharedRecId         , "SharedObject._shared")
 X(stringId            , "String._string")
 X(bytesId             , "Bytes._bytes")
 X(localeId            , "ChapelLocale._locale")

--- a/frontend/include/chpl/resolution/can-pass.h
+++ b/frontend/include/chpl/resolution/can-pass.h
@@ -198,8 +198,13 @@ class CanPassResult {
  */
 bool
 tryConvertClassTypeIntoManagerRecordIfNeeded(Context* context,
-                                             const types::Type* const & mightBeManagerRecord,
+                                             const types::Type* const& mightBeManagerRecord,
                                              const types::Type*& mightBeClass);
+
+bool
+tryConvertClassTypeOutOfManagerRecordIfNeeded(Context* context,
+                                              const types::Type*& mightBeManagerRecord,
+                                              const types::Type* const& mightBeClass);
 
 /**
   Given an argument with QualifiedType actualType,

--- a/frontend/include/chpl/resolution/resolution-queries.h
+++ b/frontend/include/chpl/resolution/resolution-queries.h
@@ -317,6 +317,10 @@ types::Type::Genericity getTypeGenericity(Context* context,
 types::Type::Genericity getTypeGenericity(Context* context,
                                           types::QualifiedType qt);
 
+bool isFieldSyntacticallyGenericIgnoring(Context* context,
+                                         const ID& fieldId,
+                                         types::QualifiedType* formalType,
+                                         std::set<const types::Type*>& typeGenericities);
 
 bool isFieldSyntacticallyGeneric(Context* context,
                                  const ID& field,

--- a/frontend/include/chpl/types/CompositeType.h
+++ b/frontend/include/chpl/types/CompositeType.h
@@ -27,6 +27,7 @@
 namespace chpl {
 namespace types {
 
+class ClassTypeDecorator;
 
 /**
 
@@ -241,10 +242,12 @@ class CompositeType : public Type {
   static const RecordType* getDistributionType(Context* context);
 
   /** Get the record _owned implementing owned */
-  static const RecordType* getOwnedRecordType(Context* context, const BasicClassType* bct);
+  static const RecordType* getOwnedRecordType(Context* context, const BasicClassType* bct,
+                                              const ClassTypeDecorator& copyNilabilityFrom);
 
   /** Get the record _shared implementing shared */
-  static const RecordType* getSharedRecordType(Context* context, const BasicClassType* bct);
+  static const RecordType* getSharedRecordType(Context* context, const BasicClassType* bct,
+                                               const ClassTypeDecorator& copyNilabilityFrom);
 
   /** Get the sync type (_syncvar record) */
   static const RecordType* getSyncType(Context* context);

--- a/frontend/include/chpl/types/Type.h
+++ b/frontend/include/chpl/types/Type.h
@@ -217,6 +217,12 @@ class Type {
       outEltType and outSize to the element type and size of the c_array. */
   bool isCArrayType(Context* context, const Type*& outEltType, const IntParam*& outSize) const;
 
+  /** returns true if this represents the _owned builtin record */
+  bool isOwnedRecordType() const;
+
+  /** returns true if this represents the _shared builtin record */
+  bool isSharedRecordType() const;
+
   /** returns true if this represents the string type */
   bool isStringType() const;
 

--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -908,10 +908,11 @@ tryConvertClassTypeIntoManagerRecordIfNeeded(Context* context,
   // Override the class type to the manager record type
   // mightBeClass used to be `owned` of type ClassType,
   // now it's `_owned` of type RecordType
+  static const auto genericDec = ClassTypeDecorator(ClassTypeDecorator::GENERIC);
   if (aot) {
-    mightBeClass = CompositeType::getOwnedRecordType(context, /*bct*/ nullptr);
+    mightBeClass = CompositeType::getOwnedRecordType(context, /*bct*/ nullptr, genericDec);
   } else if (ast) {
-    mightBeClass = CompositeType::getSharedRecordType(context, /*bct*/ nullptr);
+    mightBeClass = CompositeType::getSharedRecordType(context, /*bct*/ nullptr, genericDec);
   } else {
     mightBeClass = ct->managerRecordType(context);
   }

--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -920,14 +920,85 @@ tryConvertClassTypeIntoManagerRecordIfNeeded(Context* context,
   return true;
 }
 
-static optional<std::pair<const RecordType*, const RecordType*>>
-shouldConvertClassTypeIntoManagerRecord(Context* context,
-                                        const Type* actualT,
-                                        const Type* formalT) {
+bool
+tryConvertClassTypeOutOfManagerRecordIfNeeded(Context* context,
+                                              const types::Type*& mightBeManagerRecord,
+                                              const types::Type* const& mightBeClass) {
+  if (!mightBeManagerRecord || !mightBeClass) return false;
+
+  auto mr = mightBeManagerRecord->toRecordType();
+  bool otherClassLike =
+    mightBeClass->isClassType() ||
+    mightBeClass->isAnyOwnedType() ||
+    mightBeClass->isAnySharedType() ||
+    mightBeClass->isAnyClassType();
+
+  if (!mr || !otherClassLike) return false;
+
+  const Type* targetManager = nullptr;
+  if (mr->isOwnedRecordType()) {
+    targetManager = AnyOwnedType::get(context);
+  } else if (mr->isSharedRecordType()) {
+    targetManager = AnySharedType::get(context);
+  } else {
+    // not a manager record type
+    return false;
+  }
+
+  // well, the other class is a class-ish thing, and we're _owned or
+  // _shared. So, find the chpl_t field, use that to get the BasicClassType
+  // and nilability, and create the target class type.
+
+  auto rc = createDummyRC(context);
+  auto fields =
+    fieldsForTypeDecl(&rc, mr,
+                      DefaultsPolicy::IGNORE_DEFAULTS);
+
+  for (int i = 0; i < fields.numFields(); i++) {
+    if (fields.fieldName(i) != "chpl_t") continue;
+    auto fieldType = fields.fieldType(i);
+
+    // it's possible that fieldType is unknown (we are the generic _owned).
+    // Otherwise, it better be a class type.
+    if (fieldType.isUnknown()) {
+      mightBeManagerRecord =
+        ClassType::get(context, AnyClassType::get(context), targetManager,
+                       ClassTypeDecorator(ClassTypeDecorator::MANAGED));
+      return true;
+    } else if (!fieldType.isUnknownOrErroneous() &&
+               fieldType.type()->isClassType()) {
+      // we have a class type, so we can use it to create the target class type
+      auto ct = fieldType.type()->toClassType();
+      // _owned(borrowed C) -> owned C
+      // _shared(borrowed C?) -> shared C?
+      auto targetDec =
+        ClassTypeDecorator(ClassTypeDecorator::MANAGED)
+        .copyNilabilityFrom(ct->decorator());
+      mightBeManagerRecord =
+        ClassType::get(context, ct->basicClassType(), targetManager, targetDec);
+      return true;
+    } else {
+      // not a class type, so we can't convert
+      return false;
+    }
+  }
+  CHPL_ASSERT(false && "should not be reachable");
+  return false;
+}
+
+static optional<std::pair<const Type*, const Type*>>
+shouldHandleManagerRecordConversion(Context* context,
+                                    const Type* actualT,
+                                    const Type* formalT) {
   if (tryConvertClassTypeIntoManagerRecordIfNeeded(context, formalT, actualT) ||
       tryConvertClassTypeIntoManagerRecordIfNeeded(context, actualT, formalT)) {
     CHPL_ASSERT(formalT->isRecordType() && actualT->isRecordType());
     return std::make_pair(actualT->toRecordType(), formalT->toRecordType());
+  }
+  if (tryConvertClassTypeOutOfManagerRecordIfNeeded(context, formalT, actualT) ||
+      tryConvertClassTypeOutOfManagerRecordIfNeeded(context, actualT, formalT)) {
+    CHPL_ASSERT(formalT->isClassType() && actualT->isClassType());
+    return std::make_pair(actualT->toClassType(), formalT->toClassType());
   }
 
   return empty;
@@ -1050,7 +1121,7 @@ CanPassResult CanPassResult::canPassScalar(Context* context,
   const Type* formalT = formalQT.type();
   CHPL_ASSERT(actualT && formalT);
   if (auto managerRecordPair =
-           shouldConvertClassTypeIntoManagerRecord(context, actualT, formalT)) {
+           shouldHandleManagerRecordConversion(context, actualT, formalT)) {
     actualT = managerRecordPair->first;
     formalT = managerRecordPair->second;
     actualQT = QualifiedType(actualQT.kind(), actualT, actualQT.param());

--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -993,12 +993,12 @@ shouldHandleManagerRecordConversion(Context* context,
   if (tryConvertClassTypeIntoManagerRecordIfNeeded(context, formalT, actualT) ||
       tryConvertClassTypeIntoManagerRecordIfNeeded(context, actualT, formalT)) {
     CHPL_ASSERT(formalT->isRecordType() && actualT->isRecordType());
-    return std::make_pair(actualT->toRecordType(), formalT->toRecordType());
+    return std::make_pair(actualT, formalT);
   }
   if (tryConvertClassTypeOutOfManagerRecordIfNeeded(context, formalT, actualT) ||
       tryConvertClassTypeOutOfManagerRecordIfNeeded(context, actualT, formalT)) {
     CHPL_ASSERT(formalT->isClassType() && actualT->isClassType());
-    return std::make_pair(actualT->toClassType(), formalT->toClassType());
+    return std::make_pair(actualT, formalT);
   }
 
   return empty;

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -2436,6 +2436,9 @@ static owned<Function> typeConstructorFnForComposite(Context* context,
                                               defaultsPolicy,
                                               /* syntaxOnly */ true);
 
+  std::set<const Type*> ignoreTypes;
+  ignoreTypes.insert(ct->instantiatedFromCompositeType() ? ct->instantiatedFromCompositeType() : ct);
+
   // find the generic fields from the type and add
   // these as type constructor arguments.
   int nFields = f.numFields();
@@ -2446,7 +2449,7 @@ static owned<Function> typeConstructorFnForComposite(Context* context,
     auto fieldDecl = declAst->toVariable();
     CHPL_ASSERT(fieldDecl);
     QualifiedType formalType;
-    if (isFieldSyntacticallyGeneric(context, declId, nullptr)) {
+    if (isFieldSyntacticallyGenericIgnoring(context, declId, nullptr, ignoreTypes)) {
 
       auto typeExpr = fieldDecl->typeExpression();
       auto initExpr = fieldDecl->initExpression();

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -2436,6 +2436,22 @@ static owned<Function> typeConstructorFnForComposite(Context* context,
                                               defaultsPolicy,
                                               /* syntaxOnly */ true);
 
+  // this could be considered a hack. Consider the following snippet:
+  //
+  // class C {
+  //   var next: C?;
+  // }
+  //
+  // Here, we can obviously tell that field `next` has generic management,
+  // and is therefore generic. However, there's no way to build a type
+  // constructor for `C` that would enable instantiating `next`, since to
+  // specify the ownership of `next`, you'd need to provide e.g. an `owned C`,
+  // but to provide ownership for the inner `C`, you'd need to provide
+  // `owned C(owned C)`, and you can keep expanding this. Resolving the type
+  // constructor would require resolving the type constructor, ad infinitum.
+  //
+  // So, for mutually recursive groups of types, ignore even ownership genericity
+  // in fields.
   std::set<const Type*> ignoreTypes;
   ignoreTypes.insert(ct->instantiatedFromCompositeType() ? ct->instantiatedFromCompositeType() : ct);
 

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -1513,7 +1513,7 @@ static bool isScopeResolvedExprGeneric(Context* context,
                                        ResolutionResultByPostorderID& rr,
                                        const AstNode* expr,
                                        std::set<const Type*>& ignore) {
-  bool isConcreteManagement;
+  bool isConcreteManagement = false;
   if (auto call = expr->toCall()) {
     expr = unwrapClassCall(call, isConcreteManagement);
   }

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -1632,6 +1632,8 @@ static bool isVariableDeclWithClearGenericity(Context* context,
   auto aggregateDecl = parsing::idToAst(context, aggregateDeclId)->toAggregateDecl();
   CHPL_ASSERT(aggregateDecl);
 
+  // Performance: this scope resolution could be put behind a query if it
+  //              impacts performance too much.
   ResolutionResultByPostorderID rr;
   auto visitor =
     Resolver::createForScopeResolvingField(context, aggregateDecl,
@@ -1696,6 +1698,7 @@ bool isFieldSyntacticallyGenericIgnoring(Context* context,
 bool isFieldSyntacticallyGeneric(Context* context,
                                  const ID& fieldId,
                                  types::QualifiedType* formalType) {
+  // Performance: this might be made into a query, why not?
   std::set<const Type*> typeGenericities;
   return isFieldSyntacticallyGenericIgnoring(context, fieldId, formalType, typeGenericities);
 }

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -899,7 +899,7 @@ void ResolvedFields::finalizeFields(Context* context, bool syntaxOnly) {
     Type::Genericity g;
 
     if (syntaxOnly) {
-      if (!isFieldSyntacticallyGeneric(context, field.declId, nullptr)) {
+      if (!isFieldSyntacticallyGenericIgnoring(context, field.declId, nullptr, ignore)) {
         g = Type::CONCRETE;
       } else {
         // In syntaxOnly mode, the field type is only set from substitutions;

--- a/frontend/lib/types/ClassType.cpp
+++ b/frontend/lib/types/ClassType.cpp
@@ -121,9 +121,9 @@ const RecordType* ClassType::managerRecordType(Context* context) const {
   //      for `shared C`, produce `_shared(C)`
   if (auto myManager = manager()) {
     if (myManager->isAnyOwnedType()) {
-      return CompositeType::getOwnedRecordType(context, basicClassType());
+      return CompositeType::getOwnedRecordType(context, basicClassType(), decorator());
     } else if (myManager->isAnySharedType()) {
-      return CompositeType::getSharedRecordType(context, basicClassType());
+      return CompositeType::getSharedRecordType(context, basicClassType(), decorator());
     } else if (auto mgr = myManager->toRecordType()) {
       return mgr;
     }

--- a/frontend/lib/types/Type.cpp
+++ b/frontend/lib/types/Type.cpp
@@ -197,6 +197,22 @@ bool Type::isCArrayType(Context* context, const Type*& outEltType, const IntPara
   return true;
 }
 
+bool Type::isOwnedRecordType() const {
+  if (auto rec = toRecordType()) {
+    if (rec->id().symbolPath() == USTR("OwnedObject._owned"))
+      return true;
+  }
+  return false;
+}
+
+bool Type::isSharedRecordType() const {
+  if (auto rec = toRecordType()) {
+    if (rec->id().symbolPath() == USTR("SharedObject._shared"))
+      return true;
+  }
+  return false;
+}
+
 bool Type::isStringType() const {
   if (auto rec = toRecordType()) {
     if (rec->id().symbolPath() == USTR("String._string"))

--- a/frontend/test/resolution/testClasses.cpp
+++ b/frontend/test/resolution/testClasses.cpp
@@ -439,6 +439,87 @@ static void testInstantiateManagerRecord() {
   checkChplT(vars.at("y"));
 }
 
+// same as testInstantiateManagerRecord, but in the other direction.
+static void testInstantiateOutOfManagerRecord() {
+  printf("testInstantiateOutOfManagerRecord\n");
+
+  std::string program = R"""(
+    class C {}
+
+    proc (owned).foo() type {
+      return this.type;
+    }
+
+    proc (shared).foo() type {
+      return this.type;
+    }
+
+
+    type x = (new _owned(new unmanaged C())).foo();
+    type y = (new _shared(new unmanaged C())).foo();
+    type z = (new _owned(new unmanaged C?())).foo();
+    type w = (new _shared(new unmanaged C?())).foo();
+  )""";
+  auto context = buildStdContext();
+  ErrorGuard guard(context);
+
+  auto vars = resolveTypesOfVariables(context, program, {"x", "y", "z", "w"});
+
+  auto checkChplT = [](const QualifiedType qt, const Type* expectManager, bool expectNil) {
+    assert(!qt.isUnknownOrErroneous());
+    assert(qt.type()->isClassType());
+
+    auto ct = qt.type()->toClassType();
+    assert(ct->decorator().isManaged());
+    assert(expectNil ? ct->decorator().isNilable() : ct->decorator().isNonNilable());
+    assert(ct->manager() == expectManager);
+    assert(ct->basicClassType());
+    assert(ct->basicClassType()->name() == "C");
+  };
+
+  auto owned = AnyOwnedType::get(context);
+  auto shared = AnySharedType::get(context);
+  checkChplT(vars.at("x"), owned, false);
+  checkChplT(vars.at("y"), shared, false);
+  checkChplT(vars.at("z"), owned, true);
+  checkChplT(vars.at("w"), shared, true);
+}
+
+// a trickier case is a 'borrowed' formal and an '_owned' actual. So, the
+// actual needs to become 'owned', and then get borrowed.
+static void testBorrowManagerRecord() {
+  printf("testBorrowManagerRecord\n");
+
+  std::string program = R"""(
+    class C {}
+
+    proc (borrowed).foo() type {
+      return this.type;
+    }
+
+    type x = (new _owned(new unmanaged C())).foo();
+    type y = (new _shared(new unmanaged C())).foo();
+  )""";
+  auto context = buildStdContext();
+  ErrorGuard guard(context);
+
+  auto vars = resolveTypesOfVariables(context, program, {"x", "y"});
+
+  auto checkChplT = [](const QualifiedType qt) {
+    assert(!qt.isUnknownOrErroneous());
+    assert(qt.type()->isClassType());
+
+    auto ct = qt.type()->toClassType();
+    assert(ct->decorator().isBorrowed());
+    assert(ct->basicClassType());
+    assert(ct->basicClassType()->name() == "C");
+  };
+
+  checkChplT(vars.at("x"));
+  checkChplT(vars.at("y"));
+
+}
+
 static void testInstantiateParentClass() {
   printf("testInstantiateParentClass\n");
 
@@ -506,6 +587,8 @@ int main() {
   test8();
 
   testInstantiateManagerRecord();
+  testInstantiateOutOfManagerRecord();
+  testBorrowManagerRecord();
   testInstantiateParentClass();
 
   return 0;

--- a/frontend/test/resolution/testClasses.cpp
+++ b/frontend/test/resolution/testClasses.cpp
@@ -400,17 +400,17 @@ static void testInstantiateManagerRecord() {
   std::string program = R"""(
     class C {}
 
-    proc _owned.foo() {
-      return this;
+    proc _owned.foo() type {
+      return this.type;
     }
 
-    proc _shared.foo() {
-      return this;
+    proc _shared.foo() type {
+      return this.type;
     }
 
 
-    var x = (new owned C()).foo();
-    var y = (new shared C()).foo();
+    type x = (new owned C()).foo();
+    type y = (new shared C()).foo();
   )""";
   auto context = buildStdContext();
   ErrorGuard guard(context);

--- a/frontend/test/resolution/testMethodCalls.cpp
+++ b/frontend/test/resolution/testMethodCalls.cpp
@@ -856,6 +856,31 @@ static void test18() {
   assert(guard.numErrors() == 0);
 }
 
+static void test19() {
+  // classes without management, with nested generic fields, or both,
+  // are considered generic and this should not "surprise" the
+  // syntactic genericity checker.
+  auto context = buildStdContext();
+  ErrorGuard guard(context);
+
+  std::string program = R"""(
+    class ClearlyOwnershipGeneric {}
+    record wrapper { type wraps; }
+
+    record r {
+      var x: wrapper(wrapper(?));
+      var y: ClearlyOwnershipGeneric;
+      var z: wrapper(ClearlyOwnershipGeneric);
+    }
+
+    var myR: r(wrapper(wrapper(int)), owned ClearlyOwnershipGeneric, wrapper(owned ClearlyOwnershipGeneric));
+    var tmp = (myR.x, myR.y, myR.z);
+    )""";
+
+  // should resolve without issue
+  std::ignore = resolveTypesOfVariables(context, program, { "tmp" });
+}
+
 int main() {
   test1();
   test2();
@@ -875,6 +900,7 @@ int main() {
   test16();
   test17();
   test18();
+  test19();
 
   return 0;
 }


### PR DESCRIPTION
Closes https://github.com/Cray/chapel-private/issues/7559.
Closes https://github.com/Cray/chapel-private/issues/7560.

Also, improves the "equivalent treatment" of the implementation-detail manager record `_owned` and the builtin `owned` type in Dyno.

Both of the issues addressed by this PR were due to insufficiently advanced "syntactic genericity" checks. This is a step in the resolution of Chapel types in which the genericity of fields (and thus, whether they need to go into a type constructor) is determined. In production, a field is generic if (1) it refers to a generic type (2) somewhere in its type expression, the question mark `?` occurs. There is a comment there saying "Dyno should be more principled".

This PR improves Dyno's syntactic genericity checks to be more principled. Specifically:
1. Referring to generic types, like `var field: myGenericType`, makes the field generic.
2. Referring to a class type without an ownership specifier makes the field generic (`var field: myClass`).
3. Calling a type constructor with `(?)` makes the field generic.
4. Any of the above, occurring as an argument to another type constructor, makes the field generic (e.g., `wrapper(myClass)` or `wrapper(wrapper(?))`).

Rules 2 and 4 are what close the issues addressed by the PR.

To make the example code from https://github.com/Cray/chapel-private/issues/7560 resolve completely, a few other changes were needed, and I made them here just to get the test passing. 

```Chapel
class MyClass { }

record B {
  var myfield: MyClass?;
}

{
  var bb: B(owned MyClass?) = new B(nil: owned MyClass?);
  writeln(bb, " : ", bb.type:string);
}
```

The first change was to improve Dyno's automatic conversion between `_owned(C)` and the builtin `owned C` type, which was incorrect. The "implementation" manager record `_owned(C)` encodes nilability in the nilability of its type argument. Thus, `_owned(borrowed C)` corresponds to `owned C`, while `_owned(borrowed C?)` corresponds to `owned C?`. Prior to this PR, we always produced the non-nilable form.

The second change was to implement the conversion back from `_owned` into `owned` (only the reverse direction existed before). Some background is that the code in `can-pass.cpp`, when given mixed arguments like an `owned C` formal and an `_owned(C)` actual, converts them both into `_owned`, and piggy-backs off the standard record-passing checks. However, this turns out not to be sufficient, since since `<anymanaged> C` has no record-based implementation, and such a conversion is not possible. Instead, we can convert `_owned(C)` into `owned C`, and perform the checks on builtin types, bypassing record logic. I've kept both directions in `can-pass.cpp`, since I view the conversion into a record preferred for using the default record passing rules, while the other conversion is necessary to cover other cases. Also, the extra conversion was necessary (and marked "unimplemented") in resolution code. Adding it made things like instantiating `owned` with `_owned` work, and even other, more tricky cases like `borrow`ing `_owned`.

## Testing
- [x] dyno tests
- [x] paratest
- [x] paratest `--dyno-resolve-only`

Reviewed by @benharsh -- thanks!