### PR TITLE
Dyno: allow casting qualified `param` strings to enums

### DIFF
--- a/frontend/include/chpl/framework/ID.h
+++ b/frontend/include/chpl/framework/ID.h
@@ -28,6 +28,9 @@ class Context;
 
 #define ID_GEN_START -3
 
+/* find the last '.' but don't count \. returns -1 if none was found */
+ssize_t findLastDot(const char* path);
+
 /**
   This class represents an ID for an AST node.
   AST element IDs can be helpful for creating maps with AST

--- a/frontend/lib/framework/ID.cpp
+++ b/frontend/lib/framework/ID.cpp
@@ -45,7 +45,7 @@ UniqueString ID::symbolPathWithoutRepeats(Context* context) const {
 
 // find the last '.' but don't count \.
 // returns -1 if none was found
-static ssize_t findLastDot(const char* path) {
+ssize_t findLastDot(const char* path) {
   ssize_t lastDot = -1;
   for (ssize_t i = 1; path[i]; i++) {
     if (path[i] == '.' && path[i-1] != '\\')

--- a/frontend/test/resolution/testEnums.cpp
+++ b/frontend/test/resolution/testEnums.cpp
@@ -953,6 +953,40 @@ static void test26() {
   ensureParamEnumStr(vars.at("y"), "red");
 }
 
+static void test27() {
+  auto context = buildStdContext();
+  ErrorGuard guard(context);
+
+  auto vars = resolveTypesOfVariables(context,
+      R"""(
+      enum color {
+        red = 0,
+        green = 0,
+      }
+      enum colorOther {
+        red = 0,
+        green = 0,
+      }
+      param a = "color.red" : color;
+      param b = "color.green" : color;
+      param c = "colorOther.red" : color;
+      param d = "colorOther.green" : color;
+      )""", {"a", "b", "c", "d"});
+
+  auto param0 = vars.at("a").param();
+  assert(param0 && param0->isEnumParam());
+  assert(param0->toEnumParam()->value().str == "red");
+
+  auto param1 = vars.at("b").param();
+  assert(param1 && param1->isEnumParam());
+  assert(param1->toEnumParam()->value().str == "green");
+
+  vars.at("c").isErroneousType();
+  vars.at("d").isErroneousType();
+
+  assert(guard.realizeErrors() == 2);
+}
+
 int main() {
   test1();
   test2();
@@ -981,6 +1015,7 @@ int main() {
   test24();
   test25();
   test26();
+  test27();
 
   return 0;
 }


### PR DESCRIPTION
Closes https://github.com/chapel-lang/chapel/issues/27624.

This PR implements casting a qualified string to the type (reporting errors if the qualifier is mismatched). The destination type is encoded in the `rhs` of the cat anyway, so the qualifier only serves for validation.

## Testing
- [x] dyno tests
- [x] paratest
- [x] paratest `--dyno-resolve-only`

Reviewed by @benharsh -- thanks!