### PR TITLE
Dyno: allow casting param string to num

### DIFF
--- a/frontend/include/chpl/types/Param.h
+++ b/frontend/include/chpl/types/Param.h
@@ -185,6 +185,10 @@ class Param {
 
   static bool isParamOpFoldable(chpl::uast::PrimitiveTag op);
 
+  static bool castAllowed(Context* context,
+                          const QualifiedType& a,
+                          const QualifiedType& b);
+
   static QualifiedType fold(Context* context,
                             const chpl::uast::AstNode* astForErr,
                             chpl::uast::PrimitiveTag op,

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -4428,9 +4428,14 @@ static bool resolveFnCallSpecial(Context* context,
           return true;
         }
 
-        exprTypeOut = Param::fold(context, astForErr,
-                                  uast::PrimitiveTag::PRIM_CAST, srcQt, dstQt);
-        return true;
+        if (Param::castAllowed(context, srcQt, dstQt)) {
+          exprTypeOut = Param::fold(context, astForErr,
+                                    uast::PrimitiveTag::PRIM_CAST, srcQt, dstQt);
+          return true;
+        }
+
+        // fall through, param cast isn't possible but maybe there's a runtime
+        // cast that normal function resolution can handle.
     } else if (srcQt.isType() && dstQt.hasTypePtr() && dstTy->isStringType()) {
       // handle casting a type name to a string
       std::ostringstream oss;

--- a/frontend/lib/types/Param.cpp
+++ b/frontend/lib/types/Param.cpp
@@ -503,9 +503,9 @@ static QualifiedType enumParamFromNumericValue(Context* context,
   return numericValue;
 }
 
-static bool paramCastAllowed(Context* context,
-                             const QualifiedType& a,
-                             const QualifiedType& b) {
+bool Param::castAllowed(Context* context,
+                        const QualifiedType& a,
+                        const QualifiedType& b) {
   auto at = a.type();
   auto bt = b.type();
 
@@ -552,7 +552,7 @@ static QualifiedType handleParamCast(Context* context,
                                      const AstNode* astForErr,
                                      QualifiedType a,
                                      QualifiedType b) {
-  if (!paramCastAllowed(context, a, b)) {
+  if (!Param::castAllowed(context, a, b)) {
     CHPL_REPORT(context, InvalidParamCast, astForErr, a, b);
     return QualifiedType(QualifiedType::UNKNOWN, ErroneousType::get(context));
   }

--- a/frontend/test/resolution/testCast.cpp
+++ b/frontend/test/resolution/testCast.cpp
@@ -650,6 +650,23 @@ static void test48() {
   }
 }
 
+// string -> int cast should work, but at runtime.
+static void test49() {
+  {
+    // the cast works at runtime...
+    auto context = buildStdContext();
+    ErrorGuard guard(context);
+    auto vars = resolveTypesOfVariables(context, "var x = \"1\" : int;", {"x"});
+    assert(vars.at("x").type() == IntType::get(context, 0));
+  }
+  {
+    // ... but it's not a param cast.
+    auto context = buildStdContext();
+    testHelper(context, "param x = \"hello\" : int;",
+                        ErroneousType::get(context), nullptr);
+  }
+}
+
 int main() {
   test1();
   test2();
@@ -699,6 +716,7 @@ int main() {
   test46();
   test47();
   test48();
+  test49();
 
   return 0;
 }

--- a/frontend/test/resolution/testCast.cpp
+++ b/frontend/test/resolution/testCast.cpp
@@ -455,8 +455,7 @@ static void test43() {
 // param bytes to string (formely throwing assertions)
 static void test44() {
   printf("test44\n");
-  Context ctx;
-  Context* context = &ctx;
+  auto context = buildStdContext();
   testHelper(context, "param x = b\"hello\" : string;",
                       ErroneousType::get(context), nullptr);
 }


### PR DESCRIPTION
Closes https://github.com/Cray/chapel-private/issues/7604.

Dyno didn't allow casting `param` strings to numbers, even at runtime. This was because, if we detected a pair of primitive types in a `param` casts, we either performed the cast at compile time, or failed. However, the proper approach is to fall through to "regular" casts, so that the following two forms can be equivalent:

```Chapel
//form 1
var myVar = "1";
var res = myVar : int;

// form 2
var res = "1" : int;
```

This PR does that.

## Testing
- [x] dyno tests
- [x] paratest
- [x] paratest `--dyno-resolve-only`

Reviewed by @benharsh -- thanks!