### PR TITLE
Dyno: implement built-in `chpl_anyPOD` type class

### DIFF
--- a/frontend/lib/resolution/can-pass.cpp
+++ b/frontend/lib/resolution/can-pass.cpp
@@ -841,8 +841,8 @@ bool CanPassResult::canInstantiateBuiltin(Context* context,
             return true;
 
   if (formalT->isAnyPodType()) {
-    CHPL_UNIMPL("POD types"); // TODO: compute POD-ness
-    return false;
+    auto rc = createDummyRC(context);
+    return Type::isPod(&rc, actualT);
   }
 
   if (formalT->isAnyRealType() && actualT->isRealType())


### PR DESCRIPTION
Closes https://github.com/Cray/chapel-private/issues/7599.

Thanks to work by @dlongnecke-cray, `isPod` is implemented. All I had to do was hook up the type class, and make a version of the tests based on David's original ones.

## Testing
- [x] dyno tests
- [x] paratest
- [x] paratest `--dyno-resolve-only`

Reviewed by @benharsh -- thanks!