### PR TITLE
Dyno: fix branch-sensitive parts of try-catch analysis

### DIFF
--- a/frontend/lib/resolution/try-catch-analysis.cpp
+++ b/frontend/lib/resolution/try-catch-analysis.cpp
@@ -290,6 +290,7 @@ namespace resolution {
           }
         }
       }
+      if (r.causedFatalError()) markFatalError();
     }
     return true;
   }

--- a/frontend/test/resolution/testCatch.cpp
+++ b/frontend/test/resolution/testCatch.cpp
@@ -458,7 +458,7 @@ static void test12c(Parser* parser) {
 
                             // this is a regression test; in the past,
                             // trying to branch-sensitively traverse this
-                            // loop (which wasn't resolved, since we
+                            // conditional (which wasn't resolved, since we
                             // produced a compiler error) caused a hard crash
                             // of the compiler.
                             if true {


### PR DESCRIPTION
Closes https://github.com/Cray/chapel-private/issues/7624.

Follows up on https://github.com/chapel-lang/chapel/pull/27591, which introduced branch-sensitivity to try-catch analysis. What was missing was a call to `markFatalError`, which is required when traversing calls to `compilerError`, to tell the branch-sensitive visitor to stop visiting subsequent code. Thus, in some cases, we'd try to access code past the end of available resolution information, and crash. This should fix that.

Notably, the error message / error handling for broken iterators (that have `compilerError` in them) is not addressed by this PR. It's a limitation of the compiler's handling of erroneous code, so it is taking a bit of a back seat. See https://github.com/Cray/chapel-private/issues/7620 (the specific error seen here) and https://github.com/Cray/chapel-private/issues/7622, which I am now realizing is probably the root cause.

## Testing
- [x] dyno tests
- [x] paratest
- [x] paratest `--dyno-resolve-only`

Reviewed by @benharsh -- thanks!