### PR TITLE
Support CHPL_SANITIZE_EXE=address with LLVM

### DIFF
--- a/doc/rst/developer/bestPractices/Sanitizers.rst
+++ b/doc/rst/developer/bestPractices/Sanitizers.rst
@@ -20,7 +20,6 @@ To use AddressSanitizer with Chapel-generated executables only:
 .. code-block:: bash
 
      export CHPL_TARGET_MEM=cstdlib
-     export CHPL_TARGET_COMPILER=gnu # or CHPL_TARGET_COMPILER=clang
      export CHPL_SANITIZE_EXE=address
      export ASAN_OPTIONS="use_sigaltstack=0,detect_leaks=0"
 
@@ -34,7 +33,6 @@ To use it with both the Chapel compiler and its generated executables:
 .. code-block:: bash
 
      export CHPL_TARGET_MEM=cstdlib
-     export CHPL_TARGET_COMPILER=gnu # or CHPL_TARGET_COMPILER=clang
      export CHPL_HOST_MEM=cstdlib
      export CHPL_SANITIZE=address
      export ASAN_OPTIONS="use_sigaltstack=0,detect_leaks=0"

--- a/doc/rst/usingchapel/debugging/sanitizers.rst
+++ b/doc/rst/usingchapel/debugging/sanitizers.rst
@@ -22,7 +22,6 @@ with sanitizers enabled:
 .. code-block:: bash
 
    export CHPL_TARGET_MEM=cstdlib
-   export CHPL_TARGET_COMPILER=gnu # or CHPL_TARGET_COMPILER=clang
    export CHPL_SANITIZE_EXE=address
 
 Running the Compiled Program
@@ -76,8 +75,6 @@ Configuration Limitations
 The above options are needed because not all third-party libraries support
 sanitizers. In particular:
 
-- Sanitizer instrumentation is added by the C compiler, so LLVM
-  compilations don't currently work
 - Sanitizers hook into the system allocator, so using ``jemalloc`` is not
   supported
 - By default the gcc address sanitizer will enable leak checking, but

--- a/test/deprecated/cpSplittingError.good
+++ b/test/deprecated/cpSplittingError.good
@@ -1,1 +1,0 @@
-cpSplittingError.chpl:1: warning: CodepointSplittingError is deprecated; please use CodepointSplitError instead

--- a/util/chplenv/chpl_sanitizers.py
+++ b/util/chplenv/chpl_sanitizers.py
@@ -18,8 +18,15 @@ def get(flag=''):
     if sanitizers_val != 'none':
         if flag == 'exe' and chpl_mem.get('target') != 'cstdlib':
             error("CHPL_TARGET_MEM=cstdlib is required for sanitizers")
-        if flag == 'exe' and chpl_compiler.get() == 'llvm':
-            error("CHPL_TARGET_COMPILER=llvm is not supported with sanitizers")
+        if flag == 'exe' and chpl_compiler.get(flag='target') == 'llvm':
+            # sanitizers are only supported with the new pass manager (LLVM 16+)
+            # and we only support 'address' for now
+            import chpl_llvm
+            llvm_vers = chpl_llvm.get_llvm_version()
+            if llvm_vers in ('14', '15'):
+                error("This version of LLVM is not supported with sanitizers")
+            if sanitizers_val != 'address':
+                error("CHPL_SANITIZE_EXE={0} is not supported with CHPL_TARGET_COMPILER=llvm".format(sanitizers_val))
         if flag == '' and chpl_mem.get('host') != 'cstdlib':
             error("CHPL_HOST_MEM=cstdlib is required for sanitizers")
     return sanitizers_val

--- a/util/chplenv/chpl_sanitizers.py
+++ b/util/chplenv/chpl_sanitizers.py
@@ -24,7 +24,7 @@ def get(flag=''):
             import chpl_llvm
             llvm_vers = chpl_llvm.get_llvm_version()
             if llvm_vers in ('14', '15'):
-                error("This version of LLVM is not supported with sanitizers")
+                error("LLVM {0} is not supported with sanitizers".format(llvm_vers))
             if sanitizers_val != 'address':
                 error("CHPL_SANITIZE_EXE={0} is not supported with CHPL_TARGET_COMPILER=llvm".format(sanitizers_val))
         if flag == '' and chpl_mem.get('host') != 'cstdlib':


### PR DESCRIPTION
Adds support for CHPL_SANITIZE_EXE=address with LLVM.

Previously, this was only supported when using the C backend with either clang/gcc. This change will allow users to use asan in a config closer to the default.

Also removes an unused .good file and cleans up some `chpl_llvm.py` logic related to LLVM versions.

- [x] paratest with asan enabled

- resolves https://github.com/chapel-lang/chapel/issues/27113 since asan will now be supported with LLVM
- resolves https://github.com/Cray/chapel-private/issues/1984

[Reviewed by @arifthpe]