### PR TITLE
Fix tests when using `CHPL_RE2=none`

### DIFF
--- a/modules/packages/UnitTest.chpl
+++ b/modules/packages/UnitTest.chpl
@@ -1202,8 +1202,16 @@ module UnitTest {
     proc type create(p: string) throws {
       if noRegex then
         return new Filter(p);
-      else
+      else {
+        import ChplConfig;
+        if ChplConfig.CHPL_RE2 == "none" then
+          compilerError(
+            "Regular expressions are not supported in this Chapel build. " +
+            "Recompile with --noRegex or build Chapel with CHPL_RE2=bundled.",
+            errorDepth=2
+          );
         return new Filter(p, new regex(p));
+      }
     }
     proc matches(s: string): bool throws {
       if rawPattern == "" then

--- a/modules/packages/UnitTest.chpl
+++ b/modules/packages/UnitTest.chpl
@@ -1207,7 +1207,7 @@ module UnitTest {
         if ChplConfig.CHPL_RE2 == "none" then
           compilerError(
             "Regular expressions are not supported in this Chapel build. " +
-            "Recompile with --noRegex or build Chapel with CHPL_RE2=bundled.",
+            "Recompile with -snoRegex or build Chapel with CHPL_RE2=bundled.",
             errorDepth=2
           );
         return new Filter(p, new regex(p));

--- a/test/library/packages/ArgumentParser/ArgumentParserTests.compopts
+++ b/test/library/packages/ArgumentParser/ArgumentParserTests.compopts
@@ -1,1 +1,1 @@
---noRegex
+-snoRegex

--- a/test/library/packages/ArgumentParser/ArgumentParserTests.compopts
+++ b/test/library/packages/ArgumentParser/ArgumentParserTests.compopts
@@ -1,0 +1,1 @@
+--noRegex

--- a/test/library/packages/UnitTest/AssertEqual/test_string_equality.compopts
+++ b/test/library/packages/UnitTest/AssertEqual/test_string_equality.compopts
@@ -1,1 +1,1 @@
---noRegex
+-snoRegex

--- a/test/library/packages/UnitTest/AssertEqual/test_string_equality.compopts
+++ b/test/library/packages/UnitTest/AssertEqual/test_string_equality.compopts
@@ -1,0 +1,1 @@
+--noRegex

--- a/test/library/packages/UnitTest/doc-examples/Runner.compopts
+++ b/test/library/packages/UnitTest/doc-examples/Runner.compopts
@@ -1,1 +1,2 @@
--M ../../../../../tools/mason --noRegex
+-M ../../../../../tools/mason -snoRegex
+

--- a/test/library/packages/UnitTest/doc-examples/Runner.compopts
+++ b/test/library/packages/UnitTest/doc-examples/Runner.compopts
@@ -1,2 +1,2 @@
--M ../../../../../tools/mason -snoRegex
+-M ../../../../../tools/mason
 

--- a/test/library/packages/UnitTest/doc-examples/Runner.compopts
+++ b/test/library/packages/UnitTest/doc-examples/Runner.compopts
@@ -1,1 +1,1 @@
--M ../../../../../tools/mason
+-M ../../../../../tools/mason --noRegex

--- a/test/library/packages/UnitTest/doc-examples/Runner.skipif
+++ b/test/library/packages/UnitTest/doc-examples/Runner.skipif
@@ -1,0 +1,2 @@
+# uses mason, which requires regex
+CHPL_RE2==none

--- a/test/library/packages/canCompileNoLink/testSockets.compopts
+++ b/test/library/packages/canCompileNoLink/testSockets.compopts
@@ -1,1 +1,1 @@
---noRegex
+-snoRegex

--- a/test/library/packages/canCompileNoLink/testSockets.compopts
+++ b/test/library/packages/canCompileNoLink/testSockets.compopts
@@ -1,0 +1,1 @@
+--noRegex


### PR DESCRIPTION
Fixes some tests when using `CHPL_RE2=none`, and tells the user how to fix it in the error message

Tested failing tests `start_test test/library/packages/UnitTest/doc-examples/Runner.chpl test/library/packages/UnitTest/AssertEqual/test_string_equality.chpl test/library/packages/canCompileNoLink/testSockets.chpl test/library/packages/ArgumentParser/ArgumentParserTests.chpl`

[Reviewed by @benharsh]