### PR TITLE
dlopen: Adjust module `deinit()` to avoid doing unnecessary work

### DIFF
--- a/modules/internal/ChapelDynamicLoading.chpl
+++ b/modules/internal/ChapelDynamicLoading.chpl
@@ -122,7 +122,7 @@ module ChapelDynamicLoading {
   proc deinit() {
     on Locales[0] do delete chpl_localPtrCache;
 
-    if isDynamicLoadingSupported {
+    if isDynamicLoadingSupported && numLocales > 1 {
       coforall loc in Locales[1..] do on loc {
         delete chpl_localPtrCache;
       }


### PR DESCRIPTION
The branch in the module deinit for `ChapelDynamicLoading` tries to fan out and do cleanup on all locales, but currently the branch doesn't check if `numLocales > 1`. By checking to see if there are multiple locales we can avoid an allocation for an array view.

Reviewed by @jabraham17. Thanks!