### PR TITLE
dlopen: Fix a bug in `loadSymbol`, add test with cross-locale contention

### DIFF
--- a/modules/internal/ChapelDynamicLoading.chpl
+++ b/modules/internal/ChapelDynamicLoading.chpl
@@ -389,6 +389,66 @@ module ChapelDynamicLoading {
       _refCount.sub(1);
     }
 
+    // This private method emplaces a new index into the local procedure
+    // pointer cache on each locale, and then it returns the index. It
+    // may lock on local caches but it does not ensure global consistency.
+    // The caller should do that by holding 'this._lock'.
+    //
+    // Note that the passed in pointer only has meaning on 'this.locale'.
+    inline proc _emplaceNewIndexUnlocked(sym: string, ptrOnThis: c_ptr(void),
+                                         out err: owned DynLoadError?) {
+      var errBuf = new chpl_localBuffer(owned DynLoadError?, numLocales);
+      var numErrs: atomic int;
+
+      // Get the wide index to use by interning on 'this.locale'. By passing
+      // in '0' we tell the routine to assign us a unique index to use.
+      var ret = chpl_insertExternLocalPtrNoSync(ptrOnThis, this.locale.id);
+      assert(ret != 0);
+
+      if numLocales > 1 {
+        coforall loc in Locales {
+          if loc != this.locale then on loc {
+            const n = here.id : int;
+            var handle: c_ptr(void);
+            on Locales[0] do handle = _systemPtrs[here.id];
+
+            var err: owned DynLoadError?;
+            const ptr = localDynLoadSymbolLookup(sym, handle, err);
+
+            if err {
+              on Locales[0] do errBuf[n] = err;
+              numErrs.add(1);
+
+            } else if ptr {
+              const got = chpl_insertExternLocalPtrNoSync(ptr, ret);
+              assert(got == ret);
+
+            } else {
+              // TODO: Construct an error instead.
+              halt('Failed to fetch symbol!');
+            }
+          }
+        }
+      }
+
+      if numErrs.read() > 0 {
+        // If there were errors, then report the first error.
+        // TODO: Evict any pointers stored in the cache.
+        // TODO: Consolidate the reported errors.
+        for i in 0..<errBuf.size {
+          if errBuf[i] {
+            err = errBuf[i];
+            break;
+          }
+        }
+
+        // Clear the index since there was an error.
+        ret = 0;
+      }
+
+      return ret;
+    }
+
     // TODO: 'T' must be a procedure type, but we cannot restrict it yet,
     // e.g., we cannot write "type t: proc". As a short-term workaround
     // we could add a primitive "any procedure type" to use instead.
@@ -411,80 +471,43 @@ module ChapelDynamicLoading {
         return __primitive("cast", P, 0);
       }
 
-      // On the fast path, we check to see if the symbol exists on LOCALE-0.
-      // If it does, then it should be in the procedure pointer cache, and
-      // we can immediately translate it into a wide index.
       on Locales[0] {
-        var errBuf = new chpl_localBuffer(owned DynLoadError?, numLocales);
-        var numErrs: atomic int = 0;
-        var shouldInternPointer = false;
+        const handle = _systemPtrs[here.id];
+        assert(handle != nil);
 
-        // No need to grab the lock, this should not be modified (or nil).
-        const handle0 = _systemPtrs[0];
-        assert(handle0 != nil);
+        // Call the system lookup routine, e.g., 'dlsym'.
+        var errOnThis;
+        const ptrOnThis = localDynLoadSymbolLookup(sym, handle, errOnThis);
 
-        var err0;
-        const ptr0 = localDynLoadSymbolLookup(sym, handle0, err0);
+        if errOnThis != nil {
+          err = errOnThis;
 
-        if err0 != nil {
-          err = err0;
-
-        } else if ptr0 == nil {
+        } else if ptrOnThis == nil {
+          // There was an error while calling the system lookup routine.
           err = new DynLoadError('Failed to locate symbol: ' + sym);
 
         } else manage this._lock {
+          // The following section must all happen while holding the lock.
+          // Check to see if the wide index is already stored stored here.
           var data;
-          const found = _procPtrToDataLocale0.get(ptr0, data);
-          shouldInternPointer = !found;
+          const found = _procPtrToDataLocale0.get(ptrOnThis, data);
+
           if found {
+            // In the fast path there was already an entry for the symbol.
             const (got, sym) = data;
             assert(got != 0);
             idx = got;
-          }
-        }
 
-        if shouldInternPointer {
-          // Get the wide index to use by interning on LOCALE-0. By passing
-          // in '0' we tell the routine to assign us a unique index to use.
-          idx = chpl_insertExternLocalPtrNoSync(ptr0, 0);
-          assert(idx != 0);
+          } else {
+            // Otherwise there was no entry, so add pointers to all caches.
+            idx = _emplaceNewIndexUnlocked(sym, ptrOnThis, err);
 
-          if numLocales > 1 {
-            // Loop over all locales and fetch the symbol's local pointer.
-            coforall loc in Locales[1..] do on loc {
-              const n = (here.id: int);
-
-              // Fetch the system handle that is stored on LOCALE-0.
-              var handle: c_ptr(void);
-              on Locales[0] do handle = _systemPtrs[n];
-
-              var err: owned DynLoadError?;
-              const ptr = localDynLoadSymbolLookup(sym, handle, err);
-              if err {
-                on Locales[0] do errBuf[n] = err;
-                numErrs.add(1);
-              } else if ptr {
-                var got = chpl_insertExternLocalPtrNoSync(ptr, idx);
-                assert(got == idx);
-              } else {
-                // TODO: Construct an error instead.
-                halt('Failed to fetch symbol!');
-              }
+            if idx != 0 {
+              // A non-nil index was returned, so we add a new entry.
+              const data = (idx, sym);
+              const added = _procPtrToDataLocale0.add(ptrOnThis, data);
+              assert(added);
             }
-          }
-
-          if numErrs.read() > 0 {
-            // If there were errors, then report the first error.
-            // TODO: Evict any pointers stored in the cache.
-            // TODO: Consolidate the reported errors.
-            for i in 0..<errBuf.size {
-              if errBuf[i] {
-                err = errBuf[i];
-                break;
-              }
-            }
-            // Clear the index since there was an error.
-            idx = 0;
           }
         }
       }

--- a/test/dynamic-loading/LoadForeignLibrary.chpl
+++ b/test/dynamic-loading/LoadForeignLibrary.chpl
@@ -218,7 +218,8 @@ proc test4() {
   assert(wideProc0 != nil);
 
   // OK to take 'bin' here by 'ref' intent, it should be parallel-safe.
-  forall i in 1..<hi with (ref bin) {
+  const maxIters = hi;
+  forall i in 1..<maxIters with (ref bin) {
     const loc = Locales[i % numLocales];
     on loc {
       const wideProc = try! bin.load("addTwoReturn", P1);

--- a/test/dynamic-loading/LoadForeignLibrary.comm-none.good
+++ b/test/dynamic-loading/LoadForeignLibrary.comm-none.good
@@ -17,3 +17,4 @@ test2
 Caught error!
 test3
 Caught error!
+test4

--- a/test/dynamic-loading/LoadForeignLibrary.good
+++ b/test/dynamic-loading/LoadForeignLibrary.good
@@ -38,3 +38,4 @@ test2
 Caught error!
 test3
 Caught error!
+test4


### PR DESCRIPTION
This PR fixes a rather embarassing bug with `loadSymbol`. When the same symbol was loaded twice the program would crash, because I forgot to emplace appropriate entries into the symbol table maintained by a `chpl_binaryInfo`. It also adds a test with heavy cross-locale contention which (more than) adequately covers the bug.

Reviewed by @jabraham17. Thanks!