### PR TITLE
Limit the amount of parallelism used when running our RHEL job

### DIFF
--- a/util/cron/test-rhel.linux64.bash
+++ b/util/cron/test-rhel.linux64.bash
@@ -7,4 +7,8 @@ source $UTIL_CRON_DIR/common.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="rhel.linux64"
 
+# limit the amount of parallelism used, we were running out of memory on the
+# testing machine.
+export CHPL_MAKE_MAX_CPU_COUNT=2
+
 $UTIL_CRON_DIR/nightly -cron -examples


### PR DESCRIPTION
[reviewed by @arifthpe]

This job has started sporadically running out of memory when making the compiler in parallel, likely due to running docker on the machine as well.  Reduce the amount of parallelism used when making the compiler to alleviate this issue.

Note: Of the jobs running on that machine, this seems to be the one most likely to run out of memory.  If the other ones start regularly exhibiting this behavior and this works to alleviate this job, I'll update them similarly