### PR TITLE
Dyno: Implement resolving linkage names for procedures

### DIFF
--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -2829,6 +2829,9 @@ class ResolvedFunction {
   // the set of point-of-instantiation scopes used by the instantiation
   PoiInfo poiInfo_;
 
+  // the linkage name computed for this function
+  UniqueString linkageName_;
+
   // the return type computed for this function
   types::QualifiedType returnType_;
 
@@ -2848,6 +2851,7 @@ class ResolvedFunction {
                    uast::Function::ReturnIntent returnIntent,
                    ResolutionResultByPostorderID resolutionById,
                    PoiInfo poiInfo,
+                   UniqueString linkageName,
                    types::QualifiedType returnType,
                    std::vector<CompilerDiagnostic> diagnostics,
                    PoiTraceToChildMap poiTraceToChild,
@@ -2856,6 +2860,7 @@ class ResolvedFunction {
         returnIntent_(returnIntent),
         resolutionById_(std::move(resolutionById)),
         poiInfo_(std::move(poiInfo)),
+        linkageName_(linkageName),
         returnType_(std::move(returnType)),
         diagnostics_(std::move(diagnostics)),
         poiTraceToChild_(std::move(poiTraceToChild)),
@@ -2869,6 +2874,9 @@ class ResolvedFunction {
 
   /** the return intent */
   uast::Function::ReturnIntent returnIntent() const { return returnIntent_; }
+
+  /** the linkage name */
+  UniqueString linkageName() const { return linkageName_; }
 
   /** the return type */
   const types::QualifiedType& returnType() const {
@@ -2904,6 +2912,7 @@ class ResolvedFunction {
            returnIntent_ == other.returnIntent_ &&
            resolutionById_ == other.resolutionById_ &&
            PoiInfo::updateEquals(poiInfo_, other.poiInfo_) &&
+           linkageName_ == other.linkageName_ &&
            returnType_ == other.returnType_ &&
            diagnostics_ == other.diagnostics_ &&
            poiTraceToChild_ == other.poiTraceToChild_ &&
@@ -2918,6 +2927,7 @@ class ResolvedFunction {
     std::swap(returnIntent_, other.returnIntent_);
     resolutionById_.swap(other.resolutionById_);
     poiInfo_.swap(other.poiInfo_);
+    linkageName_.swap(other.linkageName_);
     returnType_.swap(other.returnType_);
     std::swap(diagnostics_, other.diagnostics_);
     std::swap(poiTraceToChild_, other.poiTraceToChild_);
@@ -2931,6 +2941,7 @@ class ResolvedFunction {
     context->markPointer(signature_);
     resolutionById_.mark(context);
     poiInfo_.mark(context);
+    linkageName_.mark(context);
     returnType_.mark(context);
     chpl::mark<decltype(diagnostics_)>{}(context, diagnostics_);
     for (auto& p : poiTraceToChild_) {
@@ -2945,7 +2956,7 @@ class ResolvedFunction {
   size_t hash() const {
     // Skip 'resolutionById_' since it can be quite large.
     std::ignore = resolutionById_;
-    size_t ret = chpl::hash(signature_, returnIntent_, poiInfo_, returnType_, diagnostics_);
+    size_t ret = chpl::hash(signature_, returnIntent_, poiInfo_, linkageName_, returnType_, diagnostics_);
     for (auto& p : poiTraceToChild_) {
       ret = hash_combine(ret, chpl::hash(p.first));
       ret = hash_combine(ret, chpl::hash(p.second));

--- a/frontend/test/resolution/testNestedFunctions.cpp
+++ b/frontend/test/resolution/testNestedFunctions.cpp
@@ -560,6 +560,19 @@ static void test9(Context* ctx) {
   assert(!guard.realizeErrors());
   assert(qt.kind() == QualifiedType::VAR);
   assert(qt.type() && qt.type()->isIntType());
+
+  auto m = parseModule(ctx, std::move(program));
+  CalledFnsSet called;
+  std::ignore = gatherTransitiveFnsCalledByModInit(ctx, m->id(), called);
+
+  bool found = false;
+  for (auto [fn, order] : called) {
+    if (fn->signature()->untyped()->name() != "foobar") continue;
+
+    assert(fn->linkageName() == "bool_hello");
+    found = true;
+  }
+  assert(found);
 }
 
 // This is private issue #6123.


### PR DESCRIPTION
Closes https://github.com/Cray/chapel-private/issues/6021.

After @dlongnecke-cray's work w/ nested functions, this was pretty trivial. 

## Testing
- [x] dyno tests
- [x] paratest
- [x] paratest `--dyno-resolve-only`

Reviewed by @dlongnecke-cray -- thanks!