### PR TITLE
Dyno: fix bool type queries

### DIFF
--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -4180,7 +4180,7 @@ static const Type* getNumericType(Context* context,
         return AnyImagType::get(context);
       } else if (name == USTR("complex")) {
         return AnyComplexType::get(context);
-      } else if (name == USTR("bool")) {
+      } else if (name == USTR("bool") || ci.calledType().type()->isBoolType()) {
         // bool used to support custom widths, but now it doesn't.
         //
         // handle it here anyway, since it used to be much like "int" and "real",
@@ -4195,7 +4195,7 @@ static const Type* getNumericType(Context* context,
       }
     }
 
-    if (name == USTR("bool")) {
+    if (name == USTR("bool") || ci.calledType().type()->isBoolType()) {
       if (ci.numActuals() > 0) {
         // bool used to support custom widths, but now it doesn't. Now,
         // there's no bool(..) type constructor.

--- a/frontend/test/resolution/testTypeQueries.cpp
+++ b/frontend/test/resolution/testTypeQueries.cpp
@@ -237,6 +237,46 @@ static void test8b() {
   assert(guard.realizeErrors() == 2);
 }
 
+// same as test7b, but uses a type alias for bool.
+static void test7c() {
+  printf("test7c\n");
+  auto context = buildStdContext();
+  ErrorGuard guard(context);
+
+  auto t = resolveTypeOfXInit(context,
+                R""""(
+                  type mybool = bool;
+                  proc f(arg: mybool(?)) { return arg; }
+                  var a: mybool;
+                  var x = f(a);
+                )"""", /* requireTypeKnown */ false);
+
+  assert(t.isErroneousType());
+
+  // one for type constructor, one for no matching call
+  assert(guard.realizeErrors() == 2);
+}
+
+// same as test8b, but uses a type alias for bool.
+static void test8c() {
+  printf("test8c\n");
+  auto context = buildStdContext();
+  ErrorGuard guard(context);
+
+  auto t = resolveTypeOfXInit(context,
+                R""""(
+                  type mybool = bool;
+                  proc f(arg: mybool(?w)) { return arg; }
+                  var a: mybool;
+                  var x = f(a);
+                )"""", /* requireTypeKnown */ false);
+
+  assert(t.isErroneousType());
+
+  // one for type constructor, one for no matching call
+  assert(guard.realizeErrors() == 2);
+}
+
 static void test9() {
   printf("test9\n");
   auto context = buildStdContext();
@@ -781,6 +821,23 @@ static void test25() {
   assert(guard.realizeErrors() == 2);
 }
 
+// same as test23 but using type aliases for bool
+static void test25b() {
+  printf("%s\n", __FUNCTION__);
+  auto context = buildStdContext();
+  ErrorGuard guard(context);
+
+  auto vars = resolveTypesOfVariables(context,
+                R""""(
+                  type mybool = bool;
+                  var x: mybool(?) = true;
+                  var y: mybool(?w) = false;
+                )"""", {"x", "y"});
+  assert(vars.at("x").isUnknown());
+  assert(vars.at("y").isUnknown());
+  assert(guard.realizeErrors() == 2);
+}
+
 int main() {
   test1();
   test2();
@@ -792,6 +849,8 @@ int main() {
   test8();
   test7b();
   test8b();
+  test7c();
+  test8c();
   test9();
   test10();
   test11();
@@ -811,6 +870,7 @@ int main() {
   test23();
   test24();
   test25();
+  test25b();
 
   return 0;
 }


### PR DESCRIPTION
Closes https://github.com/Cray/chapel-private/issues/7586.

Per @bradcray's recommendation (which I agree with), disables all type queries on `bool`, and prints errors.

```Chapel
var x : bool(?) = true;
var y : bool(?w) = true;

proc foo(a: bool(?)) do return a;
proc bar(a: bool(?w)) do return a;
foo(true);
bar(true);
```

<img width="813" height="138" alt="Screenshot 2025-08-22 at 1 03 00 PM" src="https://github.com/user-attachments/assets/098622dc-a4f9-4e4c-8e68-7d199906ffa3" />


## Testing
- [x] dyno tests
- [x] paratest
- [x] paratest `--dyno-resolve-only`

Reviewed by @arifthpe -- thanks!