### PR TITLE
dlopen: Add a new locking abstraction and use it in dlopen code

### DIFF
--- a/modules/internal/ChapelDynamicLoading.chpl
+++ b/modules/internal/ChapelDynamicLoading.chpl
@@ -55,42 +55,37 @@ module ChapelDynamicLoading {
   // We start with '1' since the '0th' index is reserved to represent 'nil'.
   var chpl_dynamicProcIdxCounter: atomic int = 1;
 
-  // Wrapper to use the 'manage' statement to create a critical section.
-  record chpl_lockWrapper {
-    var _lock: chpl_LocalSpinlock;
-    inline proc useSpinlock param do return true;
-    inline proc const withLock() ref do return withWriteLock();
-    inline proc const withReadLock() ref where useSpinlock do return _lock;
-    inline proc const withWriteLock() ref where useSpinlock do return _lock;
-  }
-
   // This class is a local bidirectional map from 'pointer' <-> 'int'.
-  class chpl_LocalPtrCache {
-    forwarding var _lockWrapper = new chpl_lockWrapper();
-    var _procPtrToIdx = new chpl_localMap(c_ptr(void), int);
-    var _idxToProcPtr = new chpl_localMap(int, c_ptr(void));
+  record chpl_localBidirectionalMap {
+    type K, V;
+    var _keyToVal = new chpl_localMap(K, V);
+    var _valToKey = new chpl_localMap(V, K);
 
-    inline proc setUnlocked(ptr: c_ptr(void), idx: int) {
+    inline proc ref set(in key: K, in val: V) {
       var ret = false;
       on this do {
-        var add1 = _procPtrToIdx.set(ptr, idx);
-        var add2 = _idxToProcPtr.set(idx, ptr);
+        const add1 = _keyToVal.set(key, val);
+        const add2 = _valToKey.set(val, key);
         ret = add1;
       }
       return ret;
     }
 
-    inline proc getUnlocked(ptr: c_ptr(void), out idx: int) {
+    inline proc get(key: K, out val: V) {
       var ret = false;
-      on this do ret = _procPtrToIdx.get(ptr, idx);
+      on this do ret = _keyToVal.get(key, val);
       return ret;
     }
 
-    inline proc getUnlocked(idx: int, out ptr: c_ptr(void)) {
+    inline proc get(val: V, out key: K) {
       var ret = false;
-      on this do ret = _idxToProcPtr.get(idx, ptr);
+      on this do ret = _valToKey.get(val, key);
       return ret;
     }
+  }
+
+  class chpl_LocalPtrCache {
+    var guard: chpl_lockGuard(chpl_localBidirectionalMap(c_ptr(void), int));
   }
 
   // One cache of pointers guarded by a lock defined per locale. We use a
@@ -107,23 +102,13 @@ module ChapelDynamicLoading {
   // remaining locales manually, since the module initializer is only
   // running on LOCALE-0.
   if isDynamicLoadingSupported && numLocales > 1 {
-    coforall loc in Locales[1..] {
-      on loc do local do {
-        assert(chpl_localPtrCache == nil);
-        chpl_localPtrCache = new unmanaged chpl_LocalPtrCache();
-      }
+    coforall loc in Locales[1..] do on loc do local {
+      // The local value will be nil despite a non-nilable type. This is OK.
+      assert(chpl_localPtrCache == nil);
+      chpl_localPtrCache = new unmanaged chpl_LocalPtrCache();
     }
   }
 
-  // NOTE: Stale TODO (I think), but I'm keeping it here in case it pops up.
-  //
-  // TODO: The moment I try to delete these pointers some locales will crash
-  // with (what I assume is) a double-free or some other memory corruption
-  // on program shutdown. You don't really see it single-locale unless
-  // jemalloc allocates a large enough chunk, so set the flag
-  // 'chpl_defaultProcBufferSize=512' to see. The crash seems to happen in
-  // the qthreads layer, perhaps while cleaning up TLS.
-  //
   proc deinit() {
     on Locales[0] do delete chpl_localPtrCache;
 
@@ -169,13 +154,13 @@ module ChapelDynamicLoading {
   // lock (per locale) because they all need to access the same error
   // routine, and we need to guarantee that access to it is not racey.
   pragma "locale private"
-  private var localDynLoadGuard: chpl_lockWrapper;
+  private var localDynLoadLock: chpl_LocalSpinlock;
 
   private inline
   proc localDynLoadClose(ptr: c_ptr(void), out err: owned DynLoadError?) {
     extern proc chpl_dlclose(handle: c_ptr(void)): c_int;
 
-    manage localDynLoadGuard.withLock() {
+    manage localDynLoadLock {
       localDynLoadClearErrorUnlocked();
 
       const code = chpl_dlclose(ptr);
@@ -194,7 +179,7 @@ module ChapelDynamicLoading {
 
     var ret: c_ptr(void) = nil;
 
-    manage localDynLoadGuard.withLock() {
+    manage localDynLoadLock {
       localDynLoadClearErrorUnlocked();
 
       ret = chpl_dlopen(path.c_str(), CHPL_RTLD_LAZY);
@@ -215,7 +200,7 @@ module ChapelDynamicLoading {
 
     var ret: c_ptr(void) = nil;
 
-    manage localDynLoadGuard.withLock() {
+    manage localDynLoadLock {
       localDynLoadClearErrorUnlocked();
 
       ret = chpl_dlsym(handle, sym.c_str());
@@ -244,22 +229,17 @@ module ChapelDynamicLoading {
   // binary is loaded an entry will be made in the store. The interface to the
   // stored info is the system pointer retrieved by 'dlopen'.
   class chpl_BinaryInfoStore {
-    forwarding var _lockWrapper = new chpl_lockWrapper();
 
     // The key is the 'dlopen' pointer returned on LOCALE-0. You are able to
     // 'dlopen' a symbol multiple times, so you can get the key as needed.
-    var _handleToInfo: chpl_localMap(c_ptr(void), unmanaged chpl_BinaryInfo?);
-
-    inline proc set(ptr: c_ptr(void), bin: unmanaged chpl_BinaryInfo?) {
-      return _handleToInfo.set(ptr, bin);
-    }
-
-    inline proc get(ptr: c_ptr(void), out bin: unmanaged chpl_BinaryInfo?) {
-      return _handleToInfo.get(ptr, bin);
-    }
+    // TODO: After doing so, do we need to call close to drop the internal
+    //       refcount that is maintained by the OS?
+    var handleToInfo: chpl_lockGuard(chpl_localMap(c_ptr(void),
+                                     unmanaged chpl_BinaryInfo?));
 
     proc deinit() {
-      for slot in _handleToInfo.slots() do {
+      ref m = handleToInfo.unsafeAccess();
+      for slot in m.slots() do {
         if slot.val != nil then delete slot.val;
       }
     }
@@ -271,13 +251,13 @@ module ChapelDynamicLoading {
   // This class represents a "wide" binary. It contains the state necessary
   // to load a symbol from the binary on each locale.
   class chpl_BinaryInfo {
-    forwarding var lockWrapper = new chpl_lockWrapper();
+    var _lock: chpl_LocalSpinlock;
 
     // This refcount is bumped and dropped by the user-facing wrapper.
     var _refCount: atomic int = 0;
 
     // This is the path that was used to load the binary.
-    var _path: string;
+    const _path: string;
 
     // This is the set of loaded binary pointers, indexed by locale. It lives
     // on LOCALE-0. Since it is a local buffer it can only be accessed there!
@@ -289,7 +269,7 @@ module ChapelDynamicLoading {
     var _procPtrToDataLocale0: chpl_localMap(c_ptr(void), (int, string));
 
     // A pointer to the parent store is used to coordinate load/unload.
-    var _store: borrowed chpl_BinaryInfoStore;
+    const _store: borrowed chpl_BinaryInfoStore;
 
     // Set only when '_close()' is called for the first time.
     var _closed = false;
@@ -332,8 +312,8 @@ module ChapelDynamicLoading {
 
         // Check the LOCALE-0 store for an existing entry.
         if shouldCreateNewEntry {
-          manage store.withReadLock() {
-            shouldCreateNewEntry = !store.get(ptr0, ret);
+          manage store.handleToInfo.read() as m {
+            shouldCreateNewEntry = !m.get(ptr0, ret);
           }
         }
 
@@ -393,11 +373,11 @@ module ChapelDynamicLoading {
               assert(bin._systemPtrs[i] != nil);
             }
 
-            manage store.withWriteLock() {
-              var found = store.get(bin._systemPtrs[0], ret);
+            manage store.handleToInfo.write() as m {
+              var found = m.get(bin._systemPtrs[0], ret);
               if !found {
                 ret = owned.release(bin);
-                var ok = store.set(ret!._systemPtrs[0], ret);
+                const ok = m.set(ret!._systemPtrs[0], ret);
                 assert(ok);
               }
             }
@@ -413,15 +393,17 @@ module ChapelDynamicLoading {
       assert(_refCount.read() == 0);
       if _closed then return;
 
-      on Locales[0] do manage this.withWriteLock() {
+      on Locales[0] do manage this._lock {
         if !_closed {
           _closed = true;
+
           for i in 0..<_systemPtrs.size {
-            const loc = Locales[i];
             const ptr = _systemPtrs[i];
-            if ptr != nil then on loc {
+
+            if ptr != nil then on Locales[i] {
               var err: owned DynLoadError?;
               localDynLoadClose(ptr, err);
+
               // TODO: Figure out how to propagate this instead of halting?
               if err != nil then halt(err!.message());
             }
@@ -479,7 +461,7 @@ module ChapelDynamicLoading {
         } else if ptr0 == nil {
           err = new DynLoadError('Failed to locate symbol: ' + sym);
 
-        } else manage this.withReadLock() {
+        } else manage this._lock {
           var data;
           const found = _procPtrToDataLocale0.get(ptr0, data);
           shouldInternPointer = !found;
@@ -800,8 +782,8 @@ module ChapelDynamicLoading {
     // cache because the local roots are emplaced when a function value is
     // created. So just halt if this is not the case.
     if idx != 0 {
-      local do manage chpl_localPtrCache.withReadLock() {
-        var found = chpl_localPtrCache.getUnlocked(idx, ret);
+      local do manage chpl_localPtrCache.guard.read() as m {
+        const found = m.get(idx, ret);
         assert(found);
         assert(ret != nil);
       }
@@ -814,34 +796,34 @@ module ChapelDynamicLoading {
     var ret: int = 0;
 
     // Return the local pointer for this locale if it's already set.
-    local do manage chpl_localPtrCache.withReadLock() {
-      var ptr = lookupPtrFromLocalFtable(idx);
-      if chpl_localPtrCache.getUnlocked(ptr, ret) then return ret;
+    local do manage chpl_localPtrCache.guard.read() as m {
+      const ptr = lookupPtrFromLocalFtable(idx);
+      if m.get(ptr, ret) then return ret;
     }
 
     // Otherwise, synchronize on LOCALE-0...
     on Locales[0] {
-      manage chpl_localPtrCache.withWriteLock() {
+      manage chpl_localPtrCache.guard.write() as m {
         var requestedUniqueIdx = false;
 
         // Use the value of the pointer on LOCALE-0 as the map key.
-        var ptr = lookupPtrFromLocalFtable(idx);
+        const ptr = lookupPtrFromLocalFtable(idx);
 
-        if !chpl_localPtrCache.getUnlocked(ptr, ret) {
+        if !m.get(ptr, ret) {
           // If we did not look up an existing entry, then we are the task
           // that will set the map entries for this pointer. Set the index
           // on LOCALE-0 to claim the job.
           ret = chpl_dynamicProcIdxCounter.fetchAdd(1);
-          chpl_localPtrCache.setUnlocked(ptr, ret);
+          m.set(ptr, ret);
           requestedUniqueIdx = true;
         }
 
         // While holding the LOCALE-0 lock, set on all other locales.
         if requestedUniqueIdx && numLocales > 1 {
           coforall loc in Locales[1..] do on loc {
-            local do manage chpl_localPtrCache.withWriteLock() {
-              var ptr = lookupPtrFromLocalFtable(idx);
-              chpl_localPtrCache.setUnlocked(ptr, ret);
+            local do manage chpl_localPtrCache.guard.write() as m {
+              const ptr = lookupPtrFromLocalFtable(idx);
+              m.set(ptr, ret);
             }
           }
         }
@@ -867,11 +849,11 @@ module ChapelDynamicLoading {
       then chpl_dynamicProcIdxCounter.fetchAdd(1)
       else idx;
 
-    local do manage chpl_localPtrCache.withWriteLock() {
-      // If 'set()' returns 'false' then the index was already in it!
-      // We just overwrote it, but it shouldn't have been set in the
-      // first place so the only thing to do is halt.
-      if !chpl_localPtrCache.setUnlocked(ptr, ret) {
+    local do manage chpl_localPtrCache.guard.write() as m {
+      // If 'set()' returns 'false' then the index was already in the map!
+      // We just overwrote it, but it shouldn't have been set in the first
+      // place so the only thing to do is halt.
+      if !m.set(ptr, ret) {
         halt('Procedure pointer duplicately mapped!');
       }
     }

--- a/modules/internal/ChapelLocks.chpl
+++ b/modules/internal/ChapelLocks.chpl
@@ -24,7 +24,7 @@
 module ChapelLocks {
   private use Atomics, ChapelBase;
   private use MemConsistency;
-  import CTypes.{c_ptr, c_ptrTo};
+  import CTypes.{c_ptr, c_ptrTo, c_ptrToConst};
 
   /*
    * Local processor atomic spinlock. Intended for situations with minimal
@@ -59,9 +59,149 @@ module ChapelLocks {
     inline proc ref enterContext() do lock();
     inline proc ref exitContext(in e: owned Error?) {
       defer unlock();
-      if e then halt();
+      // TODO: We shouldn't halt here, but 'throws' is currently awkward,
+      //       because if your 'exitContext()' throws then it requires
+      //       your 'manage' to be wrapped in a 'try' in non-prototype
+      //       contexts. To fix this, we can make the 'contextManager'
+      //       interface context-sensitive by providing a version of this
+      //       method signature that doesn't throw.
+      if e then halt(e!.message());
+    }
+  }
+
+  // TODO: Transform this into an interface.
+  record chpl_readWriteLockWrapper {
+    type lockType;
+    var _lock: lockType;
+
+    // Corresponds to some locking interface's "acquire write lock" method.
+    inline proc ref acquireWriteLock() where lockType == chpl_LocalSpinlock {
+      _lock.lock();
+    }
+
+    // Corresponds to some locking interface's "acquire read lock" method.
+    inline proc ref acquireReadLock() where lockType == chpl_LocalSpinlock {
+      _lock.lock();
+    }
+
+    // Corresponds to some locking interface's "release write lock" method.
+    inline proc ref releaseWriteLock() where lockType == chpl_LocalSpinlock {
+      _lock.unlock();
+    }
+
+    // Corresponds to some locking interface's "release read lock" method.
+    inline proc ref releaseReadLock() where lockType == chpl_LocalSpinlock {
+      _lock.unlock();
+    }
+  }
+
+  // The default lock type is a spinlock since that is what we use most often.
+  type chpl_defaultLockGuardLockType = chpl_LocalSpinlock;
+
+  /** A lock guard is a useful abstraction which allows you to bundle both
+      a lock and a data type together in the same variable. Access to the
+      data is controlled via use of the guard as a context manager.
+
+      E.g., given a guard 'g', one must write 'manage g as x' to get access
+      to the data. Getting access requires taking the lock. */
+  record chpl_lockGuard {
+    type dataType;
+    type lockType = chpl_defaultLockGuardLockType;
+    var _data: dataType;
+    var _lock: chpl_readWriteLockWrapper(lockType);
+
+    proc init(type dataType, type lockType=chpl_defaultLockGuardLockType) {
+      this.dataType = dataType;
+      this.lockType = lockType;
+    }
+
+    proc init(in x: ?t, type lockType=chpl_defaultLockGuardLockType) {
+      this.dataType = t;
+      this.lockType = lockType;
+      this._data = x;
+    }
+
+    /** An access manager is a context manager meant for use with a 'manage'
+        statement and is created by a call to one of the guard methods such
+        as 'read()', 'write()', or 'lock()'. */
+    record accessManager {
+      type dataType;
+      type lockType;
+      param isWriteAccess: bool;
+      var _guardPtr: c_ptr(chpl_lockGuard(dataType, lockType));
+
+      proc isReading param do return !isWriteAccess;
+      proc isWriting param do return isWriteAccess;
+      proc _guard ref do return _guardPtr.deref();
+
+      pragma "fn returns infinite lifetime"
+      proc ref enterContext() ref where isWriting {
+        _guard._lock.acquireWriteLock();
+        return _guardPtr.deref().unsafeAccess();
+      }
+
+      pragma "fn returns infinite lifetime"
+      proc ref enterContext() const ref where isReading {
+        _guard._lock.acquireReadLock();
+        return _guardPtr.deref().unsafeAccess();
+      }
+
+      proc ref exitContext(in e: owned Error?) where isWriting {
+        defer _guard._lock.releaseWriteLock();
+        // TODO: We shouldn't halt here, but 'throws' is currently awkward.
+        if e then halt(e!.message());
+      }
+
+      proc ref exitContext(in e: owned Error?) where isReading {
+        defer _guard._lock.releaseReadLock();
+        // TODO: We shouldn't halt here, but 'throws' is currently awkward.
+        if e then halt(e!.message());
+      }
+    }
+
+    // Returns the type of the access context manager.
+    proc type _accessManagerType type do return accessManager;
+
+    // Get a ref pointer to 'this' even with const ref receiver intent.
+    inline proc const ref _thisAsMutablePtr {
+      const ptr = c_ptrToConst(this) : c_ptr(void);
+      return ptr : c_ptr(this.type);
+    }
+
+    // Wrapper to create a new context manager instance.
+    inline proc const ref _createAccessManager(param isWriteAccess: bool) {
+      type t = this.type._accessManagerType;
+      return new t(dataType, lockType, isWriteAccess, _thisAsMutablePtr);
+    }
+
+    /** Return a new context manager that provides read access. */
+    inline proc const ref read() do
+      return _createAccessManager(isWriteAccess=false);
+
+    /** Return a new context manager that provides write access. */
+    inline proc const ref write() do
+      return _createAccessManager(isWriteAccess=true);
+
+    /** Allows unlocked access to the data. */
+    proc ref unsafeAccess() ref do return _data;
+
+    /** Use the guard directly as a context manager for write access. */
+    proc const ref enterContext() ref {
+      var manager = write();
+      return manager.enterContext();
+    }
+
+    /** Use the guard directly as a context manager for write access. */
+    proc const ref exitContext(in e: owned Error?) {
+      var manager = write();
+      manager.exitContext(e);
     }
   }
 
   chpl_LocalSpinlock implements contextManager;
+  chpl_lockGuard implements contextManager;
+
+  // TODO: Workaround for 'implements' not supporting dot expressions yet.
+  type chpl_lockGuardAccessManager = chpl_lockGuard._accessManagerType;
+  chpl_lockGuardAccessManager implements contextManager;
 }

--- a/test/dynamic-loading/LockGuard.chpl
+++ b/test/dynamic-loading/LockGuard.chpl
@@ -1,0 +1,56 @@
+use ChapelLocks;
+use CTypes;
+use Map;
+
+config const hi: int = 2**16;
+
+proc test0() {
+  var g = new chpl_lockGuard(int);
+
+  // Confirm that default initialization occurs and 'x' is '0'.
+  manage g.read() as x do assert(x == 0);
+  manage g.write() as x do assert(x == 0);
+  manage g as x do assert(x == 0);
+  assert(g.unsafeAccess() == 0);
+
+  // Add one.
+  manage g as x do x += 1;
+  assert(g.unsafeAccess() == 1);
+
+  // Add one.
+  manage g.write() as x do x += 1;
+  assert(g.unsafeAccess() == 2);
+}
+
+proc test1() {
+  var g1 = new chpl_lockGuard(int);
+  var g2: atomic int;
+
+  assert(g1.unsafeAccess() == 0);
+  assert(g2.read() == 0);
+
+  forall i in 1..<hi {
+    manage g1 as x do x += i;
+    g2.add(i);
+  }
+
+  manage g1 as x do assert(x == g2.read());
+}
+
+proc test2() {
+  var g = new chpl_lockGuard(map(int, int));
+
+  forall i in 1..<hi do
+    manage g as m do m.add(i, 0);
+
+  // Fine because 'm' is 'const ref' due to 'read()', so it can
+  // be used within the forall loop after applying task intents.
+  manage g.read() as m do
+    forall i in 1..<hi do assert(m.contains(i));
+}
+
+proc main() {
+  test0();
+  test1();
+  test2();
+}

--- a/test/dynamic-loading/LockGuard.chpl
+++ b/test/dynamic-loading/LockGuard.chpl
@@ -10,11 +10,10 @@ proc test0() {
   // Confirm that default initialization occurs and 'x' is '0'.
   manage g.read() as x do assert(x == 0);
   manage g.write() as x do assert(x == 0);
-  manage g as x do assert(x == 0);
   assert(g.unsafeAccess() == 0);
 
   // Add one.
-  manage g as x do x += 1;
+  manage g.write() as x do x += 1;
   assert(g.unsafeAccess() == 1);
 
   // Add one.
@@ -30,21 +29,28 @@ proc test1() {
   assert(g2.read() == 0);
 
   forall i in 1..<hi {
-    manage g1 as x do x += i;
+    manage g1.write() as x do x += i;
     g2.add(i);
   }
 
-  manage g1 as x do assert(x == g2.read());
+  manage g1.write() as x do
+    assert(x == g2.read());
 }
 
 proc test2() {
   var g = new chpl_lockGuard(map(int, int));
 
+  // The guard can be used straight up in a 'forall' because its default
+  // task intent is 'ref', making it safe to use in a parallel context.
   forall i in 1..<hi do
-    manage g as m do m.add(i, 0);
+    manage g.write() as m do m.add(i, 0);
 
-  // Fine because 'm' is 'const ref' due to 'read()', so it can
-  // be used within the forall loop after applying task intents.
+  // Fine because 'm' is 'const ref' due to 'read()', so it can be used
+  // within the forall loop after applying task intents. If we were to
+  // call 'g.write()', then 'm' would still be 'const ref' in the loop body
+  // due to the default task intent. If we were to then try and call methods
+  // like 'map.add(...)' the compiler would complain about 'm' being 'const',
+  // see 'LockGuardBadTaskIntent.chpl'.
   manage g.read() as m do
     forall i in 1..<hi do assert(m.contains(i));
 }

--- a/test/dynamic-loading/LockGuardBadTaskIntent.chpl
+++ b/test/dynamic-loading/LockGuardBadTaskIntent.chpl
@@ -1,0 +1,19 @@
+use ChapelLocks;
+use CTypes;
+use Map;
+
+config const hi = 2**16;
+
+proc test0() {
+  var g = new chpl_lockGuard(map(int, int));
+
+  // This should not work because 'm' is 'ref', and its default task intent
+  // will be 'const ref', meaning the user has to opt into task-unsafety
+  // by writing 'with (ref m)'.
+  manage g.write() as m do
+    forall i in 1..<hi do m.add(i, 0);
+}
+
+proc main() {
+  test0();
+}

--- a/test/dynamic-loading/LockGuardBadTaskIntent.good
+++ b/test/dynamic-loading/LockGuardBadTaskIntent.good
@@ -1,0 +1,4 @@
+LockGuardBadTaskIntent.chpl:7: In function 'test0':
+LockGuardBadTaskIntent.chpl:14: error: const actual is passed to 'ref' formal 'this' of add()
+note: to formal of type map(int(64),int(64),false)
+LockGuardBadTaskIntent.chpl:14: note: The shadow variable 'm' is constant due to task intents in this loop

--- a/test/dynamic-loading/PointerCacheInternals.chpl
+++ b/test/dynamic-loading/PointerCacheInternals.chpl
@@ -52,7 +52,7 @@ proc test2() {
   assert(m.size == 0);
 
   // Any key with a bitwise value of zero should not be added.
-  const addedZeroKey = m.set(0, 128);
+  const addedZeroKey = m.add(0, 128);
   assert(!addedZeroKey);
 
   // Size should not have changed yet.
@@ -60,13 +60,13 @@ proc test2() {
 
   for i in 1..<hi {
     // Any key with a bitwise value of zero should not be added.
-    const addedZeroKey = m.set(0, i);
+    const addedZeroKey = m.add(0, i);
     assert(!addedZeroKey);
 
     // Size should not have changed yet.
     assert(m.size == (i - 1));
 
-    const addedIdx1 = m.set(i, 0);
+    const addedIdx1 = m.add(i, 0);
     assert(addedIdx1);
 
     // Size should have increased by 1.
@@ -82,7 +82,7 @@ proc test2() {
     assert(m.size == i);
 
     // We should not have added an entry.
-    const addedIdx2 = m.set(i, (i*2));
+    const addedIdx2 = m.add(i, (i*2));
     assert(!addedIdx2);
 
     // Size should be the same.
@@ -99,8 +99,43 @@ proc test2() {
   }
 }
 
+proc test3() {
+  var m: mod.chpl_localBidirectionalMap(int, real);
+
+  assert(m.size == 0);
+
+  for i in 1..<hi {
+    const inKey = i;
+    const inVal = i:real + 0.123456789;
+
+    const added = m.add(inKey, inVal);
+    assert(added);
+    assert(m.size == i);
+
+    var outKey, outVal;
+    const got1 = m.get(inKey, outVal);
+    const got2 = m.get(inVal, outKey);
+    assert(inKey == outKey);
+    assert(inVal == outVal);
+  }
+}
+
+proc test4() {
+  var m: mod.chpl_localMap(int, bool);
+
+  for i in 1..<hi do m.add(i, false);
+  for i in 1..<hi do m.add(i, true, addOnlyIfAbsent=true);
+  for i in 1..<hi {
+    var outVal;
+    const got = m.get(i, outVal);
+    assert(got && !outVal);
+  }
+}
+
 proc main() {
   test0();
   test1();
   test2();
+  test3();
+  test4();
 }


### PR DESCRIPTION
This PR introduces a first attempt at a new locking abstraction. I've added it to the `modules/internal/ChapelLocks.chpl` module and named it `chpl_lockGuard` for now as I don't want to go through the process of making it user-facing.

Often times when writing code with critical sections I find that there are a few major irritations:

- The data and the lock are separate: one must remember to associate a specific lock variable with a data variable
- Critical sections are not lexically obvious, e.g., for every `lock` call there must be a matching `unlock` call
- Most irritating: accessing the data does not guarantee that the lock was taken

The first bullet point can't always be entirely avoided (sometimes you have one lock to N pieces of data). The second can be addressed by utilizing the `manage` statement with the lock as the context manager. The third can also be handled with `manage`, using a bit of cleverness.
 
A guard is an abstraction which bundles a piece of data and a lock together into a single type. Gaining access to the data requires taking the lock, and can be easily done using a `manage` statement. You'll no longer forget to take a lock before you mutate some data!

```chapel
use ChapelLocks;
use Map;

proc main() {
  var g: chpl_lockGuard(map(int, nothing));

  forall i in 1..(2**16) do
    manage g.write() as m do
      m.add(i, none);

  forall i in 1..(2**16) do
    manage g.read() as m do
      assert(m.contains(i));
}
```

The guard can be supplied a lock to use, and in the future when interfaces work we can make it so the guard can use any lock that satisfies a "readWriteLock" interface.

I find this pattern very useful as the dlopen code is a bit long (for a Chapel code) and locks have to be taken in a few different situations.

Reviewed by @jabraham17. Thanks!