### PR TITLE
Fail homebrew release comparison on clone failure

### DIFF
--- a/util/cron/test-compare-homebrew-release.bash
+++ b/util/cron/test-compare-homebrew-release.bash
@@ -22,7 +22,7 @@ cd $CHPL_HOME
 # Clone a fresh copy of homebrew-core to compare against
 CHECKOUT_DIR=./homebrew-core
 rm -rf $CHECKOUT_DIR
-git clone --branch master --depth 1 https://github.com/Homebrew/homebrew-core.git $CHECKOUT_DIR
+git clone --depth 1 https://github.com/Homebrew/homebrew-core.git $CHECKOUT_DIR
 
 # compare the chapel.rb in homebrew-core with the one in our repository (chapel-release.rb)
 # to catch any changes homebrew makes to the formula without telling us (might happen when they update deps, etc)


### PR DESCRIPTION
Ensure the homebrew-core formula comparison fails if we fail to clone homebrew.

Changes:
- add `set -e` and `set -x`
- clone from HTTPS url instead of SSH
- get a completely fresh clone of the repo each run

[reviewer info placeholder]

Testing:
- [x] fresh (shallow) clone isn't too large -- 10mb
- [x] local run succeeds
- [x] local run exits with error if formula differs