### PR TITLE
Add support for preferring .dyno.good files in testing

### DIFF
--- a/test/types/scalar/bradc/bitNegateBool.dyno.good
+++ b/test/types/scalar/bradc/bitNegateBool.dyno.good
@@ -1,0 +1,2 @@
+bitNegateBool.chpl:4: error: ~ is not supported on operands of boolean type
+bitNegateBool.chpl:5: error: ~ is not supported on operands of boolean type

--- a/test/types/scalar/bradc/bitNegateBoolParam.dyno.good
+++ b/test/types/scalar/bradc/bitNegateBoolParam.dyno.good
@@ -1,0 +1,2 @@
+bitNegateBoolParam.chpl:4: error: ~ is not supported on operands of boolean type
+bitNegateBoolParam.chpl:5: error: ~ is not supported on operands of boolean type

--- a/test/types/scalar/bradc/valAsType.dyno.good
+++ b/test/types/scalar/bradc/valAsType.dyno.good
@@ -1,0 +1,2 @@
+valAsType.chpl:1: error: type specifier is a param of type 'int(64)', but it was expected to be a type
+valAsType.chpl:2: error: type specifier is a param of type 'string', but it was expected to be a type

--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -594,6 +594,14 @@ def FindGoodFile(basename, commExecNums=['']):
         if not os.path.isfile(goodfile):
             goodfile=basename+commExecNum+'.good'
 
+        # look for a .dyno good file, and prefer it over the regular .good file
+        if '--dyno-resolve-only' in envCompopts:
+            if os.path.isfile(goodfile):
+                prefix = goodfile.removesuffix('.good')
+                dynogood=prefix+'.dyno.good'
+                if os.path.isfile(dynogood):
+                    goodfile = dynogood
+
     return goodfile
 
 def get_exec_log_name(execname, comp_opts_count=None, exec_opts_count=None):


### PR DESCRIPTION
Updates sub_test to prefer files ending with .dyno.good when testing with the ``--dyno-resolve-only`` compopts. This allows us to silence some error-message-related failures in dyno testing while we work through actual bugs.

Testing:
- [x] full local paratest