### PR TITLE
Dyno: resolution fixes variety pack 6

### DIFF
--- a/frontend/include/chpl/parsing/parsing-queries.h
+++ b/frontend/include/chpl/parsing/parsing-queries.h
@@ -647,6 +647,13 @@ bool findFieldIdInDeclaration(const uast::AstNode* varDecl,
                               ID& outFieldId);
 
 /**
+  Given an expression (e.g., a formal's type expression), finds
+  all the type queries.
+ */
+std::vector<const uast::AstNode*> const&
+typeQueriesInExpression(Context* context, const uast::AstNode* expr);
+
+/**
   Given an ID for a Record/Union/Class Decl,
   and a field name, returns the ID for the Variable declaring that field.
   Does so by looking recursively for either:

--- a/frontend/include/chpl/resolution/resolution-queries.h
+++ b/frontend/include/chpl/resolution/resolution-queries.h
@@ -317,11 +317,6 @@ types::Type::Genericity getTypeGenericity(Context* context,
 types::Type::Genericity getTypeGenericity(Context* context,
                                           types::QualifiedType qt);
 
-bool isFieldSyntacticallyGenericIgnoring(Context* context,
-                                         const ID& fieldId,
-                                         types::QualifiedType* formalType,
-                                         std::set<const types::Type*>& typeGenericities);
-
 bool isFieldSyntacticallyGeneric(Context* context,
                                  const ID& field,
                                  types::QualifiedType* formalType = nullptr);

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -1398,6 +1398,8 @@ enum PassingFailureReason {
   FAIL_GENERIC_TO_NONTYPE,
   /* A type was expected to be the exact match of the formal, but wasn't. */
   FAIL_NOT_EXACT_MATCH,
+  /* A vararg type query is present in a non-star vararg. */
+  FAIL_VARARG_TQ_MISMATCH,
   /* Some other, generic reason. */
   FAIL_FORMAL_OTHER,
 };

--- a/frontend/lib/parsing/parsing-queries.cpp
+++ b/frontend/lib/parsing/parsing-queries.cpp
@@ -1754,6 +1754,35 @@ bool findFieldIdInDeclaration(const AstNode* ast,
   return false;
 }
 
+struct TypeQueryCollector {
+  std::vector<const AstNode*> typeQueries;
+
+  bool enter(const TypeQuery* tq) {
+    typeQueries.push_back(tq);
+    return false; // shouldn't have children anyway
+  }
+  void exit(const TypeQuery* tq) {}
+
+  bool enter(const AstNode* node) { return true; }
+  void exit(const AstNode* node) {}
+
+  bool enter(const Module* module) { return false; }
+  void exit(const Module* module) {}
+
+  bool enter(const Function* function) { return false; }
+  void exit(const Function* function) {}
+};
+
+std::vector<const uast::AstNode*> const&
+typeQueriesInExpression(Context* context, const uast::AstNode* expr) {
+  QUERY_BEGIN(typeQueriesInExpression, context, expr);
+
+  TypeQueryCollector collector;
+  expr->traverse(collector);
+
+  return QUERY_END(collector.typeQueries);
+}
+
 static const ID&
 fieldIdWithNameQuery(Context* context, ID typeDeclId, UniqueString fieldName) {
   QUERY_BEGIN(fieldIdWithNameQuery, context, typeDeclId, fieldName);

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -4508,7 +4508,8 @@ void Resolver::resolveIdentifier(const Identifier* ident) {
       return;
     } else if (id.isEmpty()) {
       setToBuiltin(result, ident->name());
-      result.setType(computeDefaultsIfNecessary(*this, result.type(), id, ident));
+      if (!scopeResolveOnly)
+        result.setType(computeDefaultsIfNecessary(*this, result.type(), id, ident));
       return;
     }
 

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1221,22 +1221,6 @@ static void varArgTypeQueryError(Context* context,
   result.setType(errType);
 }
 
-static std::vector<const TypeQuery*>
-collectTypeQueriesIn(const AstNode* ast, bool recurse=true) {
-  std::vector<const TypeQuery*> ret;
-
-  auto func = [&](const AstNode* ast, auto& self) -> void {
-    for (auto child : ast->children()) {
-      if (auto tq = child->toTypeQuery()) ret.push_back(tq);
-      if (recurse) self(child, self);
-    }
-  };
-
-  func(ast, func);
-
-  return ret;
-}
-
 static const TypeQuery* getDomainTypeQuery(const BracketLoop* arrayTypeExpr) {
   auto tq = arrayTypeExpr->iterand()->toTypeQuery();
   if (tq) return tq;
@@ -1334,7 +1318,7 @@ void Resolver::resolveTypeQueries(const AstNode* formalTypeExpr,
                          isNonStarVarArg,
                          /* isTopLevel */ false);
     } else {
-      auto typeQueries = collectTypeQueriesIn(call);
+      auto typeQueries = parsing::typeQueriesInExpression(context, call);
 
       // There are no type queries in the call, so there is nothing to do.
       if (typeQueries.empty()) return;

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -2791,6 +2791,11 @@ void Resolver::resolveTupleDecl(const TupleDecl* td, QualifiedType useType) {
   resolveTupleUnpackDecl(td, std::move(useType));
 }
 
+static SkipCallResolutionReason
+shouldSkipCallResolution(Resolver* rv, const uast::AstNode* callLike,
+                         std::vector<const uast::AstNode*> actualAsts,
+                         const CallInfo& ci);
+
 bool Resolver::resolveSpecialNewCall(const Call* call) {
   if (!call->calledExpression() ||
       !call->calledExpression()->isNew()) {
@@ -2863,6 +2868,10 @@ bool Resolver::resolveSpecialNewCall(const Call* call) {
   auto inScope = currentScope();
   auto inPoiScope = poiScope;
   auto inScopes = CallScopeInfo::forNormalCall(inScope, inPoiScope);
+
+  if (shouldSkipCallResolution(this, call, actualAsts, ci)) {
+    return true;
+  }
 
   // note: the resolution machinery will get compiler generated candidates
   auto c = resolveGeneratedCall(call, &ci, &inScopes);

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -2436,25 +2436,6 @@ static owned<Function> typeConstructorFnForComposite(Context* context,
                                               defaultsPolicy,
                                               /* syntaxOnly */ true);
 
-  // this could be considered a hack. Consider the following snippet:
-  //
-  // class C {
-  //   var next: C?;
-  // }
-  //
-  // Here, we can obviously tell that field `next` has generic management,
-  // and is therefore generic. However, there's no way to build a type
-  // constructor for `C` that would enable instantiating `next`, since to
-  // specify the ownership of `next`, you'd need to provide e.g. an `owned C`,
-  // but to provide ownership for the inner `C`, you'd need to provide
-  // `owned C(owned C)`, and you can keep expanding this. Resolving the type
-  // constructor would require resolving the type constructor, ad infinitum.
-  //
-  // So, for mutually recursive groups of types, ignore even ownership genericity
-  // in fields.
-  std::set<const Type*> ignoreTypes;
-  ignoreTypes.insert(ct->instantiatedFromCompositeType() ? ct->instantiatedFromCompositeType() : ct);
-
   // find the generic fields from the type and add
   // these as type constructor arguments.
   int nFields = f.numFields();
@@ -2465,7 +2446,7 @@ static owned<Function> typeConstructorFnForComposite(Context* context,
     auto fieldDecl = declAst->toVariable();
     CHPL_ASSERT(fieldDecl);
     QualifiedType formalType;
-    if (isFieldSyntacticallyGenericIgnoring(context, declId, nullptr, ignoreTypes)) {
+    if (isFieldSyntacticallyGeneric(context, declId, nullptr)) {
 
       auto typeExpr = fieldDecl->typeExpression();
       auto initExpr = fieldDecl->initExpression();

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2818,6 +2818,19 @@ instantiateSignatureImpl(ResolutionContext* rc,
         return ApplicabilityResult::failure(sig, passResult.reason(), entry.formalIdx());
       }
 
+      // be strict about instantiation type to ensure type query values
+      // are unambiguous. See also the previous justComputedVarArgType
+      // condition and comment above.
+      if (entry.isVarArgEntry() && !justComputedVarArgType &&
+          qFormalType.type() != useType.type()) {
+        auto vfml = formal->toVarArgFormal();
+        CHPL_ASSERT(vfml != nullptr);
+        if (vfml->typeExpression() &&
+            !parsing::typeQueriesInExpression(context, vfml->typeExpression()).empty()) {
+          return ApplicabilityResult::failure(sig, FAIL_VARARG_TQ_MISMATCH, entry.formalIdx());
+        }
+      }
+
       if (fn != nullptr && fn->isMethod() && fn->thisFormal() == formal) {
         // Set the visitor's 'inCompositeType' property to the final
         // instantiation of 'this' so that we can correctly resolve methods.

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -2822,7 +2822,7 @@ instantiateSignatureImpl(ResolutionContext* rc,
       // are unambiguous. See also the previous justComputedVarArgType
       // condition and comment above.
       if (entry.isVarArgEntry() && !justComputedVarArgType &&
-          qFormalType.type() != useType.type()) {
+          passResult.converts()) {
         auto vfml = formal->toVarArgFormal();
         CHPL_ASSERT(vfml != nullptr);
         if (vfml->typeExpression() &&

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -901,7 +901,7 @@ void ResolvedFields::finalizeFields(Context* context, bool syntaxOnly) {
     Type::Genericity g;
 
     if (syntaxOnly) {
-      if (!isFieldSyntacticallyGenericIgnoring(context, field.declId, nullptr, ignore)) {
+      if (!isFieldSyntacticallyGeneric(context, field.declId, nullptr)) {
         g = Type::CONCRETE;
       } else {
         // In syntaxOnly mode, the field type is only set from substitutions;


### PR DESCRIPTION
This variety pack is on the smaller side. It mostly addresses not-yet-categorized issues in `test/type_variables`.

First, I noted that my changes to `isFieldSyntacticallyGeneric` -- which started leaning more heavily on `getTypeGenericity` -- broke some test case. The reason was that, although I used an `ignore` set to prevent recursion, at some point the recursion, we invoke a query without the set, and end up not really tracking recursion at all. Instead, I adjust the logic to _first_ find all the types reachable from the type constructor, and then avoid recursing into them. The reason I think this is valid is in a comment in the diff: these types _better_ be concrete, or we wouldn't be able to build a type constructor.

I also noticed in `test/type_variables` that we don't properly enforce type query constraints in vararg formals. Specifically, we allowed `x: R(?t)...` to be instantiated with both `R(int)` and `R(real`), even though this is disallowed in production. The fix was quite simple: do not re-compute type queries (thereby enforcing the previous type queries) after the first vararg actual has been considered. 

The above still allows for conversions: if the first actual is a `real` and the second is an `int`, the type query gets set to `real`, and the `int` can be converted. This is disallowed in production, and in Dyno as well: when the type query is set during function resolution, we report an error. However, this error is disconnected from call resolution (in fact, the candidate is accepted by the time the error is emitted), and its line number is reported to be the type query formal's line, instead of the offending call that required the conversion. To improve this, I added a new `TQ_MISMATCH` failure reason, and added early failure logic. This logic preempts the regular error during function instantiation, rejects the candidate, and prints a specific error message.

Whether conversions should be allowed, both in production and in Dyno, is an open design issue. https://github.com/chapel-lang/chapel/issues/27700

## Testing
- [x] dyno tests
- [x] paratest
- [x] paratest `--dyno-resolve-only`

Reviewed by @benharsh -- thanks!