### PR TITLE
Fix binding of colocales on non-homogeneous architectures

### DIFF
--- a/runtime/src/topo/hwloc/topo-hwloc.c
+++ b/runtime/src/topo/hwloc/topo-hwloc.c
@@ -562,7 +562,7 @@ static void partitionResources(void) {
         // but maybe it should look for other types of caches? For example,
         // an we may want to bind to an L2 cache in a hybrid core system
         // because there is only one L3 cache per socket.
-        // Its a fairly trivial change (just only select the cache type
+        // It's a fairly trivial change (just only select the cache type
         // that has more than numLocalesOnNode objects)
         // but that changes the meaning of 1x2llc (because we might bind
         // to L2 caches instead of L3 caches) so we should think about it.

--- a/runtime/src/topo/hwloc/topo-hwloc.c
+++ b/runtime/src/topo/hwloc/topo-hwloc.c
@@ -672,12 +672,15 @@ static void partitionResources(void) {
           logAccSets[i] = s;
         }
 
-        // logAccSets has the cores each parition can use. If any of those are
-        // empty, we should not use this parititioning scheme.
+        // logAccSets has the cores each parition can use. If they don't have
+        // the same number of cores, then we can't proceed with this
+        // partitioning scheme.
+        int firstSetSize = hwloc_bitmap_weight(logAccSets[0]);
         chpl_bool badPartitioning = false;
-        for (int i = 0; i < numPartitions; i++) {
-          if (hwloc_bitmap_iszero(logAccSets[i])) {
-            _DBG_P("logAccSets[%d] is empty", i);
+        for (int i = 1; i < numPartitions; i++) {
+          if (hwloc_bitmap_weight(logAccSets[i]) != firstSetSize) {
+            _DBG_P("logAccSets[%d] has %d cores, logAccSets[0] has %d",
+                   i, hwloc_bitmap_weight(logAccSets[i]), firstSetSize);
             badPartitioning = true;
             break;
           }

--- a/runtime/src/topo/hwloc/topo-hwloc.c
+++ b/runtime/src/topo/hwloc/topo-hwloc.c
@@ -686,6 +686,7 @@ static void partitionResources(void) {
         // partitioning scheme.
         // we also want to avoid the situation where all the paritions
         // end up having 0 cores.
+        assert(numPartitions > 0);
         int firstSetSize = hwloc_bitmap_weight(logAccSets[0]);
         chpl_bool badPartitioning = false;
         for (int i = 0; i < numPartitions; i++) {

--- a/test/runtime/jhh/colocales/Makefile
+++ b/test/runtime/jhh/colocales/Makefile
@@ -13,7 +13,7 @@ colocales: lib/libcolocales.a colocales.c
 	$(COMPILE) -g colocales.c -Llib -l$@ $(LIBS) -o $@
 
 lib/libcolocales.a: colocales.chpl
-	$(CHPL_COMPILER) colocales.chpl --library
+	$(CHPL_COMPILER) colocales.chpl -o colocales --library
 
 clean::
 	rm -rf colocales lib colocales.dSYM

--- a/test/runtime/jhh/colocales/colocales.py
+++ b/test/runtime/jhh/colocales/colocales.py
@@ -25,6 +25,19 @@ import printchplenv
 verbose = False
 skipReason = None
 
+class Socket(object):
+    def __init__(self, config, index, totalCores):
+        self.cores = []
+        self.threads = []
+        if config.coresPerSocket > 0:
+            offset = index * config.coresPerSocket
+            self.cores = range(offset, offset + config.coresPerSocket)
+            for t in range(0, config.threadsPerCore):
+                self.threads += [self.cores[i] + (t * totalCores)
+                                 for i in range(0, len(self.cores))]
+            self.threads.sort()
+
+
 def runCmd(cmd, env=None, check=True):
     if type(cmd) is str:
         cmd = cmd.split()
@@ -85,51 +98,37 @@ class TestFramework(unittest.TestCase):
         return output
 
     # Returns a list of cores in the specified partition
-    def getCores(self,  index, partitions):
-        if index == "all":
-            return sorted([x for lst in [self.getCores(i, partitions)
-                          for i in range(0,partitions)] for x in lst])
-        else:
-            coresPerPartition = int((self.cores * self.sockets) /
-                                    partitions)
-            return [i + (index * coresPerPartition)
-                            for i in range(0,coresPerPartition)]
-
-    # Returns a list of cores in the specified socket.
-    def getSocketCores(self, socket):
-        return self.getCores(socket, self.sockets)
+    def getCores(self,  index, numPartitions):
+        coresPerPartition = int(len(self.cores) / numPartitions)
+        offset = index * coresPerPartition
+        return self.cores[offset:offset + coresPerPartition]
 
     # Returns a list of cores in the specified NUMA domain
     def getNumaCores(self, numa):
-        return self.getCores(numa, self.sockets * self.numas)
+        return self.getCores(numa, len(self.sockets) * self.numas)
 
     # Returns a list of cores in the specified L3 cache
     def getCacheCores(self, cache):
-        return self.getCores(cache, self.sockets * self.caches)
+        return self.getCores(cache, len(self.sockets) * self.caches)
 
     # Returns a list of threads (PUs) in the specified partition
     def getThreads(self, index, partitions):
-        if index == "all":
-            return sorted([x for lst in [self.getThreads(i, partitions)
-                        for i in range(0,partitions)] for x in lst])
         cores = self.getCores(index, partitions)
         threads = []
-        for t in range(0, self.threads):
-            threads += [cores[i] + (t * self.sockets * self.cores)
+        for t in range(0, self.threadsPerCore):
+            threads += [cores[i] + (t * len(self.cores))
                         for i in range(0, len(cores))]
         return threads
 
     # Returns a list of threads in the specified socket
-    def getSocketThreads(self, socket):
-        return self.getThreads(socket, self.sockets)
 
     # Returns a list of threads in the specified NUMA domain
     def getNumaThreads(self, numa):
-        return self.getThreads(numa, self.sockets * self.numas)
+        return self.getThreads(numa, len(self.sockets) * self.numas)
 
     # Returns a list of threads in the specified L3 cache
     def getCacheThreads(self, cache):
-        return self.getThreads(cache, self.sockets * self.caches)
+        return self.getThreads(cache, len(self.sockets) * self.caches)
 
     def in_socket_test(self, socket, nic):
         """
@@ -137,10 +136,10 @@ class TestFramework(unittest.TestCase):
         the closest NIC, no matter which NIC is suggested.
         """
         output = self.runCmd("./colocales -r %d -n %d -N %s" %
-                         (socket, self.sockets, nic))
-        cpus = stringify(self.getSocketCores(socket))
+                         (socket, len(self.sockets), nic))
+        cpus = stringify(self.sockets[socket].cores)
         self.assertIn("Physical CPUs: %s\n" % cpus, output)
-        cpus = stringify(self.getSocketThreads(socket))
+        cpus = stringify(self.sockets[socket].threads)
         self.assertIn("Logical CPUs: %s\n" % cpus, output)
         found = False
         for s in self.nicsForSocket[socket]:
@@ -154,7 +153,7 @@ class TestFramework(unittest.TestCase):
         Locale in NUMA should use cores and threads in that NUMA and
         the closest NIC, no matter which NIC is suggested.
         """
-        numas = self.numas * self.sockets
+        numas = self.numas * len(self.sockets)
         output = self.runCmd("./colocales -r %d -n %d -N %s" %
                          (numa, numas, nic))
         cpus = stringify(self.getNumaCores(numa))
@@ -169,7 +168,7 @@ class TestFramework(unittest.TestCase):
         Locale in L3 cache should use cores and threads in that cache and
         the closest NIC, no matter which NIC is suggested.
         """
-        caches = self.caches * self.sockets
+        caches = self.caches * len(self.sockets)
         output = self.runCmd("./colocales -r %d -n %d -N %s" %
                          (cache, caches, nic))
         cpus = stringify(self.getCacheCores(cache))
@@ -183,12 +182,12 @@ class TestFramework(unittest.TestCase):
         Locale in a core should use only that core and its threads and
         the closest NIC, no matter which NIC is suggested.
         """
-        cores = self.cores * self.sockets
+        numCores = len(self.cores)
         output = self.runCmd("./colocales -r %d -n %d -N %s" %
-                         (core, cores, nic))
-        cpus = stringify(self.getCores(core, cores))
+                         (core, numCores, nic))
+        cpus = stringify(self.getCores(core, numCores))
         self.assertIn("Physical CPUs: %s\n" % cpus, output)
-        cpus = stringify(self.getThreads(core, cores))
+        cpus = stringify(self.getThreads(core, numCores))
         self.assertIn("Logical CPUs: %s\n" % cpus, output)
         self.assertIn("NIC: " + self.nicForCore[core], output)
 
@@ -203,20 +202,23 @@ class TestCases(object):
             One locale, should have access to all cores and threads and use
             the suggested NIC.
             """
-            output = self.runCmd("./colocales -N %s" % self.nics[0])
-            cpus = stringify(self.getSocketCores("all"))
+            if len(self.nics) > 0:
+                output = self.runCmd("./colocales -N %s" % self.nics[0])
+                self.assertIn("NIC: " + self.nics[0], output)
+            else:
+                output = self.runCmd("./colocales")
+            cpus = stringify(self.cores)
             self.assertIn("Physical CPUs: %s\n" % cpus, output)
-            cpus = stringify(self.getSocketThreads("all"))
+            cpus = stringify(self.threads)
             self.assertIn("Logical CPUs: %s\n" % cpus, output)
-            self.assertIn("NIC: " + self.nics[0], output)
 
         def test_01_use_another_NIC(self):
             """
             One locale, should have access to all cores and threads and use
             another NIC when it is suggested.
             """
-            if (len(self.nics) == 1):
-                self.skipTest("only one NIC")
+            if (len(self.nics) < 2):
+                self.skipTest("fewer than two NICs")
             output = self.runCmd("./colocales -N %s" % self.nics[1])
             self.assertIn("NIC: " + self.nics[1], output)
 
@@ -226,7 +228,7 @@ class TestCases(object):
             """
             if not hasattr(self, 'nicsForSocket'):
                 self.skipTest("NICs are not in sockets")
-            for i in range(0, self.sockets):
+            for i in range(0, len(self.sockets)):
                 for n in self.nicsForSocket[i]:
                     with self.subTest(i=i, n=n):
                         self.in_socket_test(i, n)
@@ -239,8 +241,8 @@ class TestCases(object):
                 self.skipTest("NICs are not in sockets")
             if (len(self.nics) == 1):
                 self.skipTest("only one NIC")
-            for i in range(0, self.sockets):
-                for n in self.nicsForSocket[(i+1)%self.sockets]:
+            for i in range(0, len(self.sockets)):
+                for n in self.nicsForSocket[(i+1)%len(self.sockets)]:
                     with self.subTest(i=i, n=n):
                         self.in_socket_test(i, n)
 
@@ -250,7 +252,7 @@ class TestCases(object):
             """
             if not hasattr(self, 'nicForNuma'):
                 self.skipTest("NICs are not in NUMAs")
-            for i in range(0, self.numas * self.sockets):
+            for i in range(0, self.numas * len(self.sockets)):
                 with self.subTest(i=i):
                     self.in_numa_test(i, self.nicForNuma[i])
 
@@ -262,10 +264,15 @@ class TestCases(object):
                 self.skipTest("NICs are not in NUMAs")
             if (len(self.nics) == 1):
                 self.skipTest("only one NIC")
-            numas = self.numas * self.sockets
+            numas = self.numas * len(self.sockets)
             for i in range(0, numas):
                 with self.subTest(i=i):
                     self.in_numa_test(i, self.nicForNuma[(i+1)%numas])
+
+def setXML(obj, xml):
+    if not os.path.exists(xml):
+        raise Exception("Missing XML file: %s" % xml)
+    obj.env['HWLOC_XMLFILE'] = xml
 
 """
 These classes represent different machine topologies based on real machines.
@@ -275,21 +282,24 @@ information because there are only a few configurations.
 """
 
 def setupEx2(obj):
-        obj.env['HWLOC_XMLFILE'] = 'ex2.xml'
-        obj.sockets = 2
-        obj.numas = 4
-        obj.caches = 8
-        obj.cores = 64
-        obj.threads = 2
-        obj.nics= ['0000:21:00.0', '0000:a1:00.0']
-        obj.nicsForSocket = [['0000:21:00.0'], ['0000:a1:00.0']]
-        obj.nicForNuma = ['0000:21:00.0', '0000:21:00.0', '0000:21:00.0',
-                           '0000:21:00.0', '0000:a1:00.0', '0000:a1:00.0',
-                           '0000:a1:00.0', '0000:a1:00.0']
-        obj.nicForCache = [obj.nics[int(i/obj.caches)]
-                            for i in range(0, obj.sockets * obj.caches)]
-        obj.nicForCore = [obj.nics[int(i/obj.cores)]
-                            for i in range(0, obj.sockets * obj.cores)]
+    setXML(obj, 'ex2.xml')
+    obj.coresPerSocket = 64
+    obj.threadsPerCore = 2
+    obj.sockets = [Socket(obj, i, 128) for i in range(0,2)]
+    obj.cores = sorted([core for s in obj.sockets for core in s.cores])
+    obj.threads = sorted([thread for s in obj.sockets
+                          for thread in s.threads])
+    obj.numas = 4
+    obj.caches = 8
+    obj.nics = ['0000:21:00.0', '0000:a1:00.0']
+    obj.nicsForSocket = [['0000:21:00.0'], ['0000:a1:00.0']]
+    obj.nicForNuma = ['0000:21:00.0', '0000:21:00.0', '0000:21:00.0',
+                      '0000:21:00.0', '0000:a1:00.0', '0000:a1:00.0',
+                      '0000:a1:00.0', '0000:a1:00.0']
+    obj.nicForCache = [obj.nics[int(i/obj.caches)]
+                        for i in range(0, len(obj.sockets) * obj.caches)]
+    obj.nicForCore = [obj.nics[int(i/obj.coresPerSocket)]
+                        for i in range(0, len(obj.cores))]
 
 class Ex2Tests(TestCases.TestCase):
     """
@@ -346,9 +356,9 @@ class Ex2Tests(TestCases.TestCase):
             with self.subTest(i=i):
                 output = self.runCmd("./colocales -r %d -a 4 -N %s" %
                                      (i, self.nics[0]))
-                cpus = stringify(self.getSocketCores("all"))
+                cpus = stringify(self.cores)
                 self.assertIn("Physical CPUs: %s\n" % cpus, output)
-                cpus = stringify(self.getSocketThreads("all"))
+                cpus = stringify(self.threads)
                 self.assertIn("Logical CPUs: %s\n" % cpus, output)
 
 
@@ -360,20 +370,24 @@ class Ex3Tests(TestCases.TestCase):
     """
     def setUp(self):
         super().setUp()
-        self.env['HWLOC_XMLFILE'] = 'ex3.xml'
-        self.sockets = 1
+        setXML(self, 'ex3.xml')
+        self.coresPerSocket = 64
+        self.threadsPerCore = 2
+        self.sockets = [Socket(self, 0, 64)]
+        self.cores = sorted([core for s in self.sockets for core in s.cores])
+        self.threads = sorted([thread for s in self.sockets
+                               for thread in s.threads])
         self.numas = 4
         self.caches = 8
-        self.cores = 64
-        self.threads = 2
-        self.nics= ['0000:c2:00.0', '0000:81:00.0', '0000:42:00.0',
-                   '0000:01:00.0']
+        self.nics = ['0000:c2:00.0', '0000:81:00.0', '0000:42:00.0',
+                     '0000:01:00.0']
         self.nicsForSocket = [self.nics]
         self.nicForNuma = self.nics
         self.nicForCache = [self.nics[int(i/self.caches)]
-                            for i in range(0, self.sockets * self.caches)]
-        self.nicForCore = [self.nics[int(i/self.cores)]
-                            for i in range(0, self.sockets * self.cores)]
+                            for i in range(0,
+                                           len(self.sockets) * self.caches)]
+        self.nicForCore = [self.nics[int(i/self.coresPerSocket)]
+                           for i in range(0, len(self.cores))]
 
         self.gpus = ['0000:c1:00.0', '0000:82:00.0', '0000:41:00.0',
                      '0000:03:00.0']
@@ -416,39 +430,22 @@ class Ex3Tests(TestCases.TestCase):
                 self.assertIn("GPUS: " + ' '.join(self.gpus), output)
 
 
-
 class Hpc6aTests(TestCases.TestCase):
     """
     AWS hpc6a.48xlarge instance. Two sockets, two NUMA domains per socket, 48
     cores per socket, one thread per core, and one NIC not in a socket.
-    domains.
     """
     def setUp(self):
         super().setUp()
-        self.env['HWLOC_XMLFILE'] = 'hpc6a.48xlarge.xml'
-        self.sockets = 2
+        setXML(self, 'hpc6a.48xlarge.xml')
+        self.coresPerSocket = 48
+        self.threadsPerCore = 1
+        self.sockets = [Socket(self, i, 96) for i in range(0,2)]
+        self.cores = sorted([core for s in self.sockets for core in s.cores])
+        self.threads = sorted([thread for s in self.sockets
+                               for thread in s.threads])
         self.numas = 2
-        self.cores = 48
-        self.threads = 1
-        self.nics= ['0000:00:06.0']
-        self.nicsForSocket = [['0000:00:06.0'], ['0000:00:06.0']]
-        self.nicForNuma = ['0000:00:06.0', '0000:00:06.0', '0000:00:06.0',
-                           '0000:00:06.0']
-
-class Hpc6aTests(TestCases.TestCase):
-    """
-    AWS hpc6a.48xlarge instance. Two sockets, two NUMA domains per socket, 48
-    cores per socket, one thread per core, and one NIC not in a socket.
-    domains.
-    """
-    def setUp(self):
-        super().setUp()
-        self.env['HWLOC_XMLFILE'] = 'hpc6a.48xlarge.xml'
-        self.sockets = 2
-        self.numas = 2
-        self.cores = 48
-        self.threads = 1
-        self.nics= ['0000:00:06.0']
+        self.nics = ['0000:00:06.0']
         self.nicsForSocket = [['0000:00:06.0'], ['0000:00:06.0']]
         self.nicForNuma = ['0000:00:06.0', '0000:00:06.0', '0000:00:06.0',
                            '0000:00:06.0']
@@ -457,16 +454,19 @@ class Hpc6aTests(TestCases.TestCase):
 class M6inTests(TestCases.TestCase):
     """
     AWS m6in-dy-m6in32xlarge instance. Two sockets, one NUMA domain per
-    socket, 32 cores per socket, one thread per core, and two NICs not in
+    socket, 32 cores per socket, two threads per core, and two NICs not in
     sockets.
     """
     def setUp(self):
         super().setUp()
-        self.env['HWLOC_XMLFILE'] = 'm6in-dy-m6in32xlarge.xml'
-        self.sockets = 2
+        setXML(self, 'm6in-dy-m6in32xlarge.xml')
+        self.coresPerSocket = 32
+        self.threadsPerCore = 2
+        self.sockets = [Socket(self, i, 64) for i in range(0,2)]
+        self.cores = sorted([core for s in self.sockets for core in s.cores])
+        self.threads = sorted([thread for s in self.sockets
+                               for thread in s.threads])
         self.numas = 1
-        self.cores = 32
-        self.threads = 2
         self.nics= ['0000:00:06.0', '0000:00:08.0']
 
     def test_10_socket_unique_nics(self):
@@ -475,10 +475,10 @@ class M6inTests(TestCases.TestCase):
         gets a unique NIC.
         """
         nics = []
-        for i in range(0, self.sockets):
+        for i in range(0, len(self.sockets)):
             with self.subTest(i=i):
                 output = self.runCmd("./colocales -r %d -n %d -N %s" %
-                                     (i, self.sockets, self.nics[0]))
+                                     (i, len(self.sockets), self.nics[0]))
                 for line in output.split('\n'):
                     if line.startswith("NIC:"):
                         nic = line.split()[1]
@@ -492,7 +492,7 @@ class M6inTests(TestCases.TestCase):
         In this topology the NICs are not in NUMAs. Test that each locale
         gets a unique NIC.
         """
-        numas = self.numas * self.sockets
+        numas = self.numas * len(self.sockets)
         nics = []
         for i in range(0, numas):
             output = self.runCmd("./colocales -r %d -n %d -N %s" %
@@ -505,6 +505,278 @@ class M6inTests(TestCases.TestCase):
                     nics.append(nic)
                     break
 
+class M1TestCases(object):
+    """
+    This outer class prevents the unittest framework from running the
+    test cases in TestCase.
+    """
+    class M1Tests(TestCases.TestCase):
+        """
+        M1Pro/Max. One socket, one NUMA domain, three L2 caches. The first L2
+        cache has two efficiency cores, the other two have four performance
+        cores.
+        """
+        def setUp(self):
+            super().setUp()
+            self.coresPerSocket = 0
+            self.threadsPerCore = 1
+            s = Socket(self, 0, 0)
+            s.cores = range(2, 2+8)
+            s.threads = s.cores
+            self.sockets = [s]
+            self.cores = sorted([core for s in self.sockets for core in s.cores])
+            self.threads = sorted([thread for s in self.sockets
+                                for thread in s.threads])
+            self.numas = 1
+            self.nics= []
+
+        def test_10_L2_binding(self):
+            """
+            Two co-locales should be bound to the two L2 caches that have performance
+            cores.
+            """
+            for r in range(0, 1):
+                output = self.runCmd("./colocales -r %d -n 2" % (r))
+                start = 2 + r * 4
+                cpus = stringify([start + j for j in range(0, 4)])
+                self.assertIn("Physical CPUs: %s\n" % cpus, output)
+
+        def test_11_no_binding(self):
+            """
+            Three, five, seven, and eight co-locales should be unbound
+            """
+            for (n, cores_per_locale, unused) in [(3, 2, 2), (5, 1, 3), (7, 1, 1), (8, 1, 0)]:
+                for r in range(0, n-1):
+                    output = self.runCmd("./colocales -r {} -n {}".format(r, n))
+                    start = 2 + r * cores_per_locale
+                    cpus = stringify([start + j for j in range(0, cores_per_locale)])
+                    self.assertIn("Physical CPUs: %s\n" % cpus, output)
+                    if unused > 0:
+                        self.assertIn("warning: %d cores are unused\n" % unused, output)
+
+        def test_12_all_cores(self):
+            """
+            test various amounts of colocales with CHPL_RT_USE_PU_KIND=all
+            """
+            self.env['CHPL_RT_USE_PU_KIND'] = 'all'
+
+            for (n, cores_per_locale, unused) in [(2, 5, 0), (3, 3, 1), (4, 2, 2), (5, 2, 0), (7, 1, 3), (8, 1, 2)]:
+                for r in range(0, n-1):
+                    output = self.runCmd("./colocales -r {} -n {}".format(r, n))
+                    start = r * cores_per_locale
+                    cpus = stringify([start + j for j in range(0, cores_per_locale)])
+                    self.assertIn("Physical CPUs: %s\n" % cpus, output)
+                    if unused > 0:
+                        self.assertIn("warning: %d cores are unused\n" % unused, output)
+
+            self.env['CHPL_RT_USE_PU_KIND'] = 'none'
+
+        def test_13_bind_to_llc(self):
+            """
+            Bind to the LLC with 3 colocales, should warn
+            """
+            self.env["CHPL_RT_COLOCALE_OBJ_TYPE"] = "cache"
+
+            output = self.runCmd("./colocales -r 0 -n 3")
+            self.assertIn("warning: 2 cores are unused\n", output)
+            self.assertIn("warning: Cannot bind to the architectural feature 'cache' with 3 co-locales. Falling back to no binding.\n", output)
+
+            self.env['CHPL_RT_COLOCALE_OBJ_TYPE'] = 'none'
+
+
+class M1ProTests(M1TestCases.M1Tests):
+    """
+    M1Pro. One socket, one NUMA domain, three L2 caches. The first L2
+    cache has two efficiency cores, the other two have four performance
+    cores.
+    """
+    def setUp(self):
+        super().setUp()
+        setXML(self, 'm1pro.xml')
+
+class M1MaxTests(M1TestCases.M1Tests):
+    """
+    M1Max. One socket, one NUMA domain, three L2 caches. The first L2
+    cache has two efficiency cores, the other two have four performance
+    cores.
+    """
+    def setUp(self):
+        super().setUp()
+        setXML(self, 'm1max.xml')
+
+
+class M3ProTests(TestCases.TestCase):
+    """
+    M1Pro/Max. One socket, one NUMA domain, three L2 caches. The first L2
+    cache has two efficiency cores, the other two have four performance
+    cores.
+    """
+    def setUp(self):
+        super().setUp()
+        setXML(self, 'm3pro.xml')
+        self.coresPerSocket = 0
+        self.threadsPerCore = 1
+        s = Socket(self, 0, 0)
+        s.cores = range(6, 6+6)
+        s.threads = s.cores
+        self.sockets = [s]
+        self.cores = sorted([core for s in self.sockets for core in s.cores])
+        self.threads = sorted([thread for s in self.sockets
+                            for thread in s.threads])
+        self.numas = 1
+        self.nics= []
+
+    def test_10_no_binding(self):
+        """
+        Two, Three, five, and size co-locales should be unbound
+        """
+        for (n, cores_per_locale, unused) in [(2, 3, 0), (3, 2, 0), (5, 1, 1), (6, 1, 0)]:
+            for r in range(0, n-1):
+                output = self.runCmd("./colocales -r {} -n {}".format(r, n))
+                start = 6 + r * cores_per_locale
+                cpus = stringify([start + j for j in range(0, cores_per_locale)])
+                self.assertIn("Physical CPUs: %s\n" % cpus, output)
+                if unused > 0:
+                    self.assertIn("warning: %d cores are unused\n" % unused, output)
+
+    def test_11_all_cores(self):
+        """
+        test various amounts of colocales with CHPL_RT_USE_PU_KIND=all
+        """
+        self.env['CHPL_RT_USE_PU_KIND'] = 'all'
+
+        for (n, cores_per_locale, unused) in [(2, 6, 0), (3, 4, 0), (4, 3, 0), (5, 2, 2), (6, 2, 0), (7, 1, 5), (12, 1, 0)]:
+            for r in range(0, n-1):
+                output = self.runCmd("./colocales -r {} -n {}".format(r, n))
+                start = r * cores_per_locale
+                cpus = stringify([start + j for j in range(0, cores_per_locale)])
+                self.assertIn("Physical CPUs: %s\n" % cpus, output)
+                if unused > 0:
+                    self.assertIn("warning: %d cores are unused\n" % unused, output)
+
+        self.env['CHPL_RT_USE_PU_KIND'] = 'none'
+
+    def test_12_bind_to_core(self):
+        """
+        Bind to the core with 3 colocales, should warn and fall back
+
+        on M3Pro the with CHPL_RT_USE_PU_KIND=performance (the default),
+        any kind of binding will always fail
+        """
+        self.env["CHPL_RT_COLOCALE_OBJ_TYPE"] = "core"
+
+        output = self.runCmd("./colocales -r 0 -n 3")
+        self.assertIn("warning: Cannot bind to the architectural feature 'core' with 3 co-locales. Falling back to no binding.\n", output)
+
+        self.env['CHPL_RT_COLOCALE_OBJ_TYPE'] = 'none'
+
+class AlderLakeTests(TestCases.TestCase):
+    """
+    This alderlake config has 8 performance cores (2 hyperthreads) and 8 efficiency cores.
+    """
+
+    def setUp(self):
+        super().setUp()
+        setXML(self, '../cpuKinds/alderLake.xml')
+        self.coresPerSocket = 0
+        self.threadsPerCore = 2
+        s = Socket(self, 0, 0)
+        s.cores = range(0, 16, 2)
+        s.threads = range(0, 16)
+        self.sockets = [s]
+        self.cores = sorted([core for s in self.sockets for core in s.cores])
+        self.threads = sorted([thread for s in self.sockets
+                            for thread in s.threads])
+        self.numas = 1
+        self.nics = []
+
+    def test_10_no_binding(self):
+        for n, cores_per_locale, unused in [
+            (2, 4, 0),
+            (3, 2, 2),
+            (4, 2, 0),
+            (5, 1, 3),
+            (6, 1, 2),
+            (7, 1, 1),
+            (8, 1, 0)
+        ]:
+            for r in range(0, n-1):
+                output = self.runCmd("./colocales -r {} -n {}".format(r, n))
+                start = r * cores_per_locale*2
+                cpus = stringify([start + j for j in range(0, cores_per_locale*2, 2)])
+                self.assertIn("Physical CPUs: %s\n" % cpus, output)
+                if unused > 0:
+                    self.assertIn("warning: %d cores are unused\n" % unused, output)
+
+    def test_11_all_cores(self):
+        """
+        test various amounts of colocales with CHPL_RT_USE_PU_KIND=all
+        """
+        self.env['CHPL_RT_USE_PU_KIND'] = 'all'
+
+        all_cores = self.cores + [len(self.cores)*self.threadsPerCore+i for i in range(0, 8)]
+
+        for n, cores_per_locale, unused in [
+            (2, 8, 0),
+            (3, 5, 1),
+            (4, 4, 0),
+            (5, 3, 1),
+            (6, 2, 4),
+            (7, 2, 2),
+            (8, 2, 0),
+            (9, 1, 7),
+            (10, 1, 6),
+            (11, 1, 5),
+            (12, 1, 4),
+            (13, 1, 3),
+            (14, 1, 2),
+            (15, 1, 1),
+            (16, 1, 0)
+        ]:
+            for r in range(0, n-1):
+                output = self.runCmd("./colocales -r {} -n {}".format(r, n))
+                start = r * cores_per_locale
+                cpus = stringify(all_cores[start:start + cores_per_locale])
+                self.assertIn("Physical CPUs: %s\n" % cpus, output)
+                if unused > 0:
+                    self.assertIn("warning: %d cores are unused\n" % unused, output)
+
+        self.env['CHPL_RT_USE_PU_KIND'] = 'none'
+
+    def test_12_bind_to_core(self):
+        """
+        Bind to the core with 3 colocales, only use 3 cores, one per locale
+        """
+        self.env["CHPL_RT_COLOCALE_OBJ_TYPE"] = "core"
+
+        output = self.runCmd("./colocales -r 0 -n 3")
+        # this is technically wrong, since we really only see 8 cores
+        # but its good enough for now
+        self.assertIn("warning: 13 cores are unused\n", output)
+        self.assertIn("Physical CPUs: 0\n", output)
+
+        output = self.runCmd("./colocales -r 1 -n 3")
+        self.assertIn("warning: 13 cores are unused\n", output)
+        self.assertIn("Physical CPUs: 2\n", output)
+
+        output = self.runCmd("./colocales -r 2 -n 3")
+        self.assertIn("warning: 13 cores are unused\n", output)
+        self.assertIn("Physical CPUs: 4\n", output)
+
+        self.env['CHPL_RT_COLOCALE_OBJ_TYPE'] = 'none'
+
+    def test_13_bind_to_cache(self):
+        """
+        Bind to the cache with 3 colocales
+        """
+        self.env["CHPL_RT_COLOCALE_OBJ_TYPE"] = "cache"
+
+        output = self.runCmd("./colocales -r 0 -n 3")
+        # TODO: what if I want to pin to the L2 cache?
+        self.assertIn("error: Node only has 1 L3 cache(s)\n", output)
+
+        self.env['CHPL_RT_COLOCALE_OBJ_TYPE'] = 'none'
+
 class SuffixTests(TestFramework):
     """
     Tests functionality of "-nl" type suffix
@@ -515,80 +787,81 @@ class SuffixTests(TestFramework):
 
     def test_00_socket_basic(self):
         self.env["CHPL_RT_COLOCALE_OBJ_TYPE"] = "socket"
-        for i in range(0, self.sockets):
+        for i in range(0, len(self.sockets)):
             for n in self.nicsForSocket[i]:
                 with self.subTest(i=i, n=n):
                     self.in_socket_test(i, n)
 
     def test_01_socket_too_many_colocales(self):
         self.env["CHPL_RT_COLOCALE_OBJ_TYPE"] = "socket"
-        output = self.runCmd("./colocales -r 0 -n %d" % (self.sockets+1))
-        self.assertIn("error: Node only has %d socket(s)\n" % self.sockets,
-                      output)
+        output = self.runCmd("./colocales -r 0 -n %d" % (len(self.sockets)+1))
+        self.assertIn("error: Node only has %d socket(s)\n" %
+                      len(self.sockets), output)
 
     def test_02_numa_basic(self):
         self.env["CHPL_RT_COLOCALE_OBJ_TYPE"] = "numa"
-        for i in range(0, self.sockets * self.numas):
+        for i in range(0, len(self.sockets) * self.numas):
             with self.subTest(i=i):
                 self.in_numa_test(i, self.nicForNuma[i])
 
     def test_03_numa_too_many_colocales(self):
         self.env["CHPL_RT_COLOCALE_OBJ_TYPE"] = "numa"
         output = self.runCmd("./colocales -r 0 -n %d" %
-                             (self.sockets*self.numas+1))
+                             (len(self.sockets)*self.numas+1))
         self.assertIn("error: Node only has %d NUMA domain(s)\n" %
-                      (self.sockets * self.numas), output)
+                      (len(self.sockets) * self.numas), output)
 
     def test_04_cache_basic(self):
         self.env["CHPL_RT_COLOCALE_OBJ_TYPE"] = "cache"
-        for i in range(0, self.sockets * self.caches):
+        for i in range(0, len(self.sockets) * self.caches):
             with self.subTest(i=i):
                 self.in_cache_test(i, self.nicForCache[i])
 
     def test_05_cache_too_many_colocales(self):
         self.env["CHPL_RT_COLOCALE_OBJ_TYPE"] = "cache"
         output = self.runCmd("./colocales -r 0 -n %d" %
-                             (self.sockets*self.caches+1))
+                             (len(self.sockets)*self.caches+1))
         self.assertIn("error: Node only has %d L3 cache(s)\n" %
-                      (self.sockets * self.caches), output)
+                      (len(self.sockets) * self.caches), output)
 
     def test_06_core_basic(self):
         self.env["CHPL_RT_COLOCALE_OBJ_TYPE"] = "core"
-        for i in range(0, self.sockets * self.cores):
+        for i in self.cores:
             with self.subTest(i=i):
                 self.in_core_test(i, self.nicForCore[i])
 
     def test_07_core_too_many_colocales(self):
         self.env["CHPL_RT_COLOCALE_OBJ_TYPE"] = "core"
         output = self.runCmd("./colocales -r 0 -n %d" %
-                             (self.sockets*self.cores+1))
+                             (len(self.cores) + 1))
         self.assertIn("error: Node only has %d core(s)\n" %
-                      (self.sockets * self.cores), output)
+                      (len(self.cores)), output)
 
     def test_08_socket_unused_cores(self):
         self.env["CHPL_RT_COLOCALE_OBJ_TYPE"] = "socket"
         output = self.runCmd("./colocales -r 0 -n 1")
-        self.assertIn("warning: %d cores are unused" % self.cores, output)
+        self.assertIn("warning: %d cores are unused" % self.coresPerSocket,
+                      output)
 
     def test_09_numa_unused_cores(self):
         self.env["CHPL_RT_COLOCALE_OBJ_TYPE"] = "numa"
         output = self.runCmd("./colocales -r 0 -n 1")
         self.assertIn("warning: %d cores are unused" %
-                      ((self.cores/self.numas * (self.numas - 1)) +
-                       self.cores), output)
+                      ((self.coresPerSocket/self.numas * (self.numas - 1)) +
+                       self.coresPerSocket), output)
 
     def test_10_cache_unused_cores(self):
         self.env["CHPL_RT_COLOCALE_OBJ_TYPE"] = "cache"
         output = self.runCmd("./colocales -r 0 -n 1")
         self.assertIn("warning: %d cores are unused" %
-                      ((self.cores/self.caches * (self.caches - 1)) +
-                       self.cores), output)
+                      ((self.coresPerSocket/self.caches * (self.caches - 1)) +
+                       self.coresPerSocket), output)
 
     def test_11_core_unused_cores(self):
         self.env["CHPL_RT_COLOCALE_OBJ_TYPE"] = "core"
         output = self.runCmd("./colocales -r 0 -n 1")
-        self.assertIn("warning: %d cores are unused" %
-                      (self.cores * self.sockets - 1), output)
+        self.assertIn("warning: %d cores are unused" % (len(self.cores) - 1),
+                      output)
 
 def main(argv):
     global verbose
@@ -661,4 +934,3 @@ def main(argv):
 
 if __name__ == '__main__':
     main(sys.argv)
-

--- a/test/runtime/jhh/colocales/m1max.xml
+++ b/test/runtime/jhh/colocales/m1max.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc2.dtd">
+<topology version="2.0">
+  <object type="Machine" os_index="0" cpuset="0x000003ff" complete_cpuset="0x000003ff" allowed_cpuset="0x000003ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" gp_index="1">
+    <info name="Backend" value="Darwin"/>
+    <info name="OSName" value="Darwin"/>
+    <info name="OSRelease" value="24.6.0"/>
+    <info name="OSVersion" value="Darwin Kernel Version 24.6.0: Mon Jul 14 11:30:29 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6000"/>
+    <info name="HostName" value=""/>
+    <info name="Architecture" value="arm64"/>
+    <info name="hwlocVersion" value="2.11.2"/>
+    <info name="ProcessName" value="lstopo-no-graphics"/>
+    <object type="Package" os_index="0" cpuset="0x000003ff" complete_cpuset="0x000003ff" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="2">
+      <info name="CPUModel" value="Apple M1 Max"/>
+      <object type="NUMANode" os_index="0" cpuset="0x000003ff" complete_cpuset="0x000003ff" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="36" local_memory="3373105152">
+        <page_type size="16384" count="0"/>
+      </object>
+      <object type="L2Cache" cpuset="0x00000003" complete_cpuset="0x00000003" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="17" cache_size="4194304" depth="2" cache_linesize="128" cache_associativity="0" cache_type="0">
+        <object type="L1Cache" cpuset="0x00000001" complete_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="15" cache_size="65536" depth="1" cache_linesize="128" cache_associativity="0" cache_type="1">
+          <object type="L1iCache" cpuset="0x00000001" complete_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="13" cache_size="131072" depth="1" cache_linesize="128" cache_associativity="0" cache_type="2">
+            <object type="Core" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="3">
+              <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="37"/>
+            </object>
+          </object>
+        </object>
+        <object type="L1Cache" cpuset="0x00000002" complete_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="16" cache_size="65536" depth="1" cache_linesize="128" cache_associativity="0" cache_type="1">
+          <object type="L1iCache" cpuset="0x00000002" complete_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="14" cache_size="131072" depth="1" cache_linesize="128" cache_associativity="0" cache_type="2">
+            <object type="Core" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="4">
+              <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="38"/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="L2Cache" cpuset="0x0000003c" complete_cpuset="0x0000003c" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="34" cache_size="12582912" depth="2" cache_linesize="128" cache_associativity="0" cache_type="0">
+        <object type="L1Cache" cpuset="0x00000004" complete_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="26" cache_size="131072" depth="1" cache_linesize="128" cache_associativity="0" cache_type="1">
+          <object type="L1iCache" cpuset="0x00000004" complete_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="18" cache_size="196608" depth="1" cache_linesize="128" cache_associativity="0" cache_type="2">
+            <object type="Core" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="5">
+              <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="39"/>
+            </object>
+          </object>
+        </object>
+        <object type="L1Cache" cpuset="0x00000008" complete_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="27" cache_size="131072" depth="1" cache_linesize="128" cache_associativity="0" cache_type="1">
+          <object type="L1iCache" cpuset="0x00000008" complete_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="19" cache_size="196608" depth="1" cache_linesize="128" cache_associativity="0" cache_type="2">
+            <object type="Core" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="6">
+              <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="40"/>
+            </object>
+          </object>
+        </object>
+        <object type="L1Cache" cpuset="0x00000010" complete_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="28" cache_size="131072" depth="1" cache_linesize="128" cache_associativity="0" cache_type="1">
+          <object type="L1iCache" cpuset="0x00000010" complete_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="20" cache_size="196608" depth="1" cache_linesize="128" cache_associativity="0" cache_type="2">
+            <object type="Core" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="7">
+              <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="41"/>
+            </object>
+          </object>
+        </object>
+        <object type="L1Cache" cpuset="0x00000020" complete_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="29" cache_size="131072" depth="1" cache_linesize="128" cache_associativity="0" cache_type="1">
+          <object type="L1iCache" cpuset="0x00000020" complete_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="21" cache_size="196608" depth="1" cache_linesize="128" cache_associativity="0" cache_type="2">
+            <object type="Core" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="8">
+              <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="42"/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="L2Cache" cpuset="0x000003c0" complete_cpuset="0x000003c0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="35" cache_size="12582912" depth="2" cache_linesize="128" cache_associativity="0" cache_type="0">
+        <object type="L1Cache" cpuset="0x00000040" complete_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="30" cache_size="131072" depth="1" cache_linesize="128" cache_associativity="0" cache_type="1">
+          <object type="L1iCache" cpuset="0x00000040" complete_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="22" cache_size="196608" depth="1" cache_linesize="128" cache_associativity="0" cache_type="2">
+            <object type="Core" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="9">
+              <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="43"/>
+            </object>
+          </object>
+        </object>
+        <object type="L1Cache" cpuset="0x00000080" complete_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="31" cache_size="131072" depth="1" cache_linesize="128" cache_associativity="0" cache_type="1">
+          <object type="L1iCache" cpuset="0x00000080" complete_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="23" cache_size="196608" depth="1" cache_linesize="128" cache_associativity="0" cache_type="2">
+            <object type="Core" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="10">
+              <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="44"/>
+            </object>
+          </object>
+        </object>
+        <object type="L1Cache" cpuset="0x00000100" complete_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="32" cache_size="131072" depth="1" cache_linesize="128" cache_associativity="0" cache_type="1">
+          <object type="L1iCache" cpuset="0x00000100" complete_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="24" cache_size="196608" depth="1" cache_linesize="128" cache_associativity="0" cache_type="2">
+            <object type="Core" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="11">
+              <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="45"/>
+            </object>
+          </object>
+        </object>
+        <object type="L1Cache" cpuset="0x00000200" complete_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="33" cache_size="131072" depth="1" cache_linesize="128" cache_associativity="0" cache_type="1">
+          <object type="L1iCache" cpuset="0x00000200" complete_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="25" cache_size="196608" depth="1" cache_linesize="128" cache_associativity="0" cache_type="2">
+            <object type="Core" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="12">
+              <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="46"/>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+  </object>
+  <support name="discovery.pu"/>
+  <support name="discovery.numa"/>
+  <support name="discovery.cpukind_efficiency"/>
+  <support name="custom.exported_support"/>
+  <cpukind cpuset="0x00000003" forced_efficiency="0">
+    <info name="DarwinCompatible" value="apple,icestorm;ARM,v8"/>
+  </cpukind>
+  <cpukind cpuset="0x000003fc" forced_efficiency="1">
+    <info name="DarwinCompatible" value="apple,firestorm;ARM,v8"/>
+  </cpukind>
+</topology>

--- a/test/runtime/jhh/colocales/m1pro.xml
+++ b/test/runtime/jhh/colocales/m1pro.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc2.dtd">
+<topology version="2.0">
+  <object type="Machine" os_index="0" cpuset="0x000003ff" complete_cpuset="0x000003ff" allowed_cpuset="0x000003ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" gp_index="1">
+    <info name="Backend" value="Darwin"/>
+    <info name="OSName" value="Darwin"/>
+    <info name="OSRelease" value="24.4.0"/>
+    <info name="OSVersion" value="Darwin Kernel Version 24.4.0: Fri Apr 11 18:33:47 PDT 2025; root:xnu-11417.101.15~117/RELEASE_ARM64_T6000"/>
+    <info name="HostName" value=""/>
+    <info name="Architecture" value="arm64"/>
+    <info name="hwlocVersion" value="2.12.0"/>
+    <info name="ProcessName" value="lstopo"/>
+    <object type="Package" os_index="0" cpuset="0x000003ff" complete_cpuset="0x000003ff" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="2">
+      <info name="CPUModel" value="Apple M1 Pro"/>
+      <object type="NUMANode" os_index="0" cpuset="0x000003ff" complete_cpuset="0x000003ff" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="36" local_memory="3624288256">
+        <page_type size="16384" count="0"/>
+      </object>
+      <object type="L2Cache" cpuset="0x00000003" complete_cpuset="0x00000003" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="17" cache_size="4194304" depth="2" cache_linesize="128" cache_associativity="0" cache_type="0">
+        <object type="L1Cache" cpuset="0x00000001" complete_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="15" cache_size="65536" depth="1" cache_linesize="128" cache_associativity="0" cache_type="1">
+          <object type="L1iCache" cpuset="0x00000001" complete_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="13" cache_size="131072" depth="1" cache_linesize="128" cache_associativity="0" cache_type="2">
+            <object type="Core" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="3">
+              <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="37"/>
+            </object>
+          </object>
+        </object>
+        <object type="L1Cache" cpuset="0x00000002" complete_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="16" cache_size="65536" depth="1" cache_linesize="128" cache_associativity="0" cache_type="1">
+          <object type="L1iCache" cpuset="0x00000002" complete_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="14" cache_size="131072" depth="1" cache_linesize="128" cache_associativity="0" cache_type="2">
+            <object type="Core" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="4">
+              <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="38"/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="L2Cache" cpuset="0x0000003c" complete_cpuset="0x0000003c" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="34" cache_size="12582912" depth="2" cache_linesize="128" cache_associativity="0" cache_type="0">
+        <object type="L1Cache" cpuset="0x00000004" complete_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="26" cache_size="131072" depth="1" cache_linesize="128" cache_associativity="0" cache_type="1">
+          <object type="L1iCache" cpuset="0x00000004" complete_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="18" cache_size="196608" depth="1" cache_linesize="128" cache_associativity="0" cache_type="2">
+            <object type="Core" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="5">
+              <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="39"/>
+            </object>
+          </object>
+        </object>
+        <object type="L1Cache" cpuset="0x00000008" complete_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="27" cache_size="131072" depth="1" cache_linesize="128" cache_associativity="0" cache_type="1">
+          <object type="L1iCache" cpuset="0x00000008" complete_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="19" cache_size="196608" depth="1" cache_linesize="128" cache_associativity="0" cache_type="2">
+            <object type="Core" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="6">
+              <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="40"/>
+            </object>
+          </object>
+        </object>
+        <object type="L1Cache" cpuset="0x00000010" complete_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="28" cache_size="131072" depth="1" cache_linesize="128" cache_associativity="0" cache_type="1">
+          <object type="L1iCache" cpuset="0x00000010" complete_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="20" cache_size="196608" depth="1" cache_linesize="128" cache_associativity="0" cache_type="2">
+            <object type="Core" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="7">
+              <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="41"/>
+            </object>
+          </object>
+        </object>
+        <object type="L1Cache" cpuset="0x00000020" complete_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="29" cache_size="131072" depth="1" cache_linesize="128" cache_associativity="0" cache_type="1">
+          <object type="L1iCache" cpuset="0x00000020" complete_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="21" cache_size="196608" depth="1" cache_linesize="128" cache_associativity="0" cache_type="2">
+            <object type="Core" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="8">
+              <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="42"/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="L2Cache" cpuset="0x000003c0" complete_cpuset="0x000003c0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="35" cache_size="12582912" depth="2" cache_linesize="128" cache_associativity="0" cache_type="0">
+        <object type="L1Cache" cpuset="0x00000040" complete_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="30" cache_size="131072" depth="1" cache_linesize="128" cache_associativity="0" cache_type="1">
+          <object type="L1iCache" cpuset="0x00000040" complete_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="22" cache_size="196608" depth="1" cache_linesize="128" cache_associativity="0" cache_type="2">
+            <object type="Core" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="9">
+              <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="43"/>
+            </object>
+          </object>
+        </object>
+        <object type="L1Cache" cpuset="0x00000080" complete_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="31" cache_size="131072" depth="1" cache_linesize="128" cache_associativity="0" cache_type="1">
+          <object type="L1iCache" cpuset="0x00000080" complete_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="23" cache_size="196608" depth="1" cache_linesize="128" cache_associativity="0" cache_type="2">
+            <object type="Core" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="10">
+              <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="44"/>
+            </object>
+          </object>
+        </object>
+        <object type="L1Cache" cpuset="0x00000100" complete_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="32" cache_size="131072" depth="1" cache_linesize="128" cache_associativity="0" cache_type="1">
+          <object type="L1iCache" cpuset="0x00000100" complete_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="24" cache_size="196608" depth="1" cache_linesize="128" cache_associativity="0" cache_type="2">
+            <object type="Core" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="11">
+              <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="45"/>
+            </object>
+          </object>
+        </object>
+        <object type="L1Cache" cpuset="0x00000200" complete_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="33" cache_size="131072" depth="1" cache_linesize="128" cache_associativity="0" cache_type="1">
+          <object type="L1iCache" cpuset="0x00000200" complete_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="25" cache_size="196608" depth="1" cache_linesize="128" cache_associativity="0" cache_type="2">
+            <object type="Core" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="12">
+              <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="46"/>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+    <object type="OSDev" gp_index="47" name="opencl0d0" subtype="OpenCL" osdev_type="5">
+      <info name="Backend" value="OpenCL"/>
+      <info name="OpenCLDeviceType" value="GPU"/>
+      <info name="GPUVendor" value="Apple"/>
+      <info name="GPUModel" value="Apple M1 Pro"/>
+      <info name="OpenCLPlatformIndex" value="0"/>
+      <info name="OpenCLPlatformName" value="Apple"/>
+      <info name="OpenCLPlatformDeviceIndex" value="0"/>
+      <info name="OpenCLComputeUnits" value="16"/>
+      <info name="OpenCLGlobalMemorySize" value="11184816"/>
+    </object>
+  </object>
+  <support name="discovery.pu"/>
+  <support name="discovery.numa"/>
+  <support name="discovery.cpukind_efficiency"/>
+  <support name="custom.exported_support"/>
+  <cpukind cpuset="0x00000003" forced_efficiency="0">
+    <info name="DarwinCompatible" value="apple,icestorm;ARM,v8"/>
+  </cpukind>
+  <cpukind cpuset="0x000003fc" forced_efficiency="1">
+    <info name="DarwinCompatible" value="apple,firestorm;ARM,v8"/>
+  </cpukind>
+</topology>

--- a/test/runtime/jhh/colocales/m3pro.xml
+++ b/test/runtime/jhh/colocales/m3pro.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc2.dtd">
+<topology version="2.0">
+  <object type="Machine" os_index="0" cpuset="0x00000fff" complete_cpuset="0x00000fff" allowed_cpuset="0x00000fff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" gp_index="1">
+    <info name="Backend" value="Darwin"/>
+    <info name="OSName" value="Darwin"/>
+    <info name="OSRelease" value="23.6.0"/>
+    <info name="OSVersion" value="Darwin Kernel Version 23.6.0: Wed May 14 13:52:29 PDT 2025; root:xnu-10063.141.1.705.2~2/RELEASE_ARM64_T6030"/>
+    <info name="HostName" value=""/>
+    <info name="Architecture" value="arm64"/>
+    <info name="hwlocVersion" value="2.11.2"/>
+    <info name="ProcessName" value="lstopo-no-graphics"/>
+    <object type="Package" os_index="0" cpuset="0x00000fff" complete_cpuset="0x00000fff" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="2">
+      <info name="CPUModel" value="Apple M3 Pro"/>
+      <object type="NUMANode" os_index="0" cpuset="0x00000fff" complete_cpuset="0x00000fff" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="41" local_memory="1473363968">
+        <page_type size="16384" count="0"/>
+      </object>
+      <object type="L2Cache" cpuset="0x0000003f" complete_cpuset="0x0000003f" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="27" cache_size="4194304" depth="2" cache_linesize="128" cache_associativity="0" cache_type="0">
+        <object type="L1Cache" cpuset="0x00000001" complete_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="21" cache_size="65536" depth="1" cache_linesize="128" cache_associativity="0" cache_type="1">
+          <object type="L1iCache" cpuset="0x00000001" complete_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="15" cache_size="131072" depth="1" cache_linesize="128" cache_associativity="0" cache_type="2">
+            <object type="Core" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="3">
+              <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="42"/>
+            </object>
+          </object>
+        </object>
+        <object type="L1Cache" cpuset="0x00000002" complete_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="22" cache_size="65536" depth="1" cache_linesize="128" cache_associativity="0" cache_type="1">
+          <object type="L1iCache" cpuset="0x00000002" complete_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="16" cache_size="131072" depth="1" cache_linesize="128" cache_associativity="0" cache_type="2">
+            <object type="Core" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="4">
+              <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="43"/>
+            </object>
+          </object>
+        </object>
+        <object type="L1Cache" cpuset="0x00000004" complete_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="23" cache_size="65536" depth="1" cache_linesize="128" cache_associativity="0" cache_type="1">
+          <object type="L1iCache" cpuset="0x00000004" complete_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="17" cache_size="131072" depth="1" cache_linesize="128" cache_associativity="0" cache_type="2">
+            <object type="Core" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="5">
+              <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="44"/>
+            </object>
+          </object>
+        </object>
+        <object type="L1Cache" cpuset="0x00000008" complete_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="24" cache_size="65536" depth="1" cache_linesize="128" cache_associativity="0" cache_type="1">
+          <object type="L1iCache" cpuset="0x00000008" complete_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="18" cache_size="131072" depth="1" cache_linesize="128" cache_associativity="0" cache_type="2">
+            <object type="Core" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="6">
+              <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="45"/>
+            </object>
+          </object>
+        </object>
+        <object type="L1Cache" cpuset="0x00000010" complete_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="25" cache_size="65536" depth="1" cache_linesize="128" cache_associativity="0" cache_type="1">
+          <object type="L1iCache" cpuset="0x00000010" complete_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="19" cache_size="131072" depth="1" cache_linesize="128" cache_associativity="0" cache_type="2">
+            <object type="Core" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="7">
+              <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="46"/>
+            </object>
+          </object>
+        </object>
+        <object type="L1Cache" cpuset="0x00000020" complete_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="26" cache_size="65536" depth="1" cache_linesize="128" cache_associativity="0" cache_type="1">
+          <object type="L1iCache" cpuset="0x00000020" complete_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="20" cache_size="131072" depth="1" cache_linesize="128" cache_associativity="0" cache_type="2">
+            <object type="Core" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="8">
+              <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="47"/>
+            </object>
+          </object>
+        </object>
+      </object>
+      <object type="L2Cache" cpuset="0x00000fc0" complete_cpuset="0x00000fc0" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="40" cache_size="16777216" depth="2" cache_linesize="128" cache_associativity="0" cache_type="0">
+        <object type="L1Cache" cpuset="0x00000040" complete_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="34" cache_size="131072" depth="1" cache_linesize="128" cache_associativity="0" cache_type="1">
+          <object type="L1iCache" cpuset="0x00000040" complete_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="28" cache_size="196608" depth="1" cache_linesize="128" cache_associativity="0" cache_type="2">
+            <object type="Core" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="9">
+              <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="48"/>
+            </object>
+          </object>
+        </object>
+        <object type="L1Cache" cpuset="0x00000080" complete_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="35" cache_size="131072" depth="1" cache_linesize="128" cache_associativity="0" cache_type="1">
+          <object type="L1iCache" cpuset="0x00000080" complete_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="29" cache_size="196608" depth="1" cache_linesize="128" cache_associativity="0" cache_type="2">
+            <object type="Core" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="10">
+              <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="49"/>
+            </object>
+          </object>
+        </object>
+        <object type="L1Cache" cpuset="0x00000100" complete_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="36" cache_size="131072" depth="1" cache_linesize="128" cache_associativity="0" cache_type="1">
+          <object type="L1iCache" cpuset="0x00000100" complete_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="30" cache_size="196608" depth="1" cache_linesize="128" cache_associativity="0" cache_type="2">
+            <object type="Core" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="11">
+              <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="50"/>
+            </object>
+          </object>
+        </object>
+        <object type="L1Cache" cpuset="0x00000200" complete_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="37" cache_size="131072" depth="1" cache_linesize="128" cache_associativity="0" cache_type="1">
+          <object type="L1iCache" cpuset="0x00000200" complete_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="31" cache_size="196608" depth="1" cache_linesize="128" cache_associativity="0" cache_type="2">
+            <object type="Core" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="12">
+              <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="51"/>
+            </object>
+          </object>
+        </object>
+        <object type="L1Cache" cpuset="0x00000400" complete_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="38" cache_size="131072" depth="1" cache_linesize="128" cache_associativity="0" cache_type="1">
+          <object type="L1iCache" cpuset="0x00000400" complete_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="32" cache_size="196608" depth="1" cache_linesize="128" cache_associativity="0" cache_type="2">
+            <object type="Core" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="13">
+              <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="52"/>
+            </object>
+          </object>
+        </object>
+        <object type="L1Cache" cpuset="0x00000800" complete_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="39" cache_size="131072" depth="1" cache_linesize="128" cache_associativity="0" cache_type="1">
+          <object type="L1iCache" cpuset="0x00000800" complete_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="33" cache_size="196608" depth="1" cache_linesize="128" cache_associativity="0" cache_type="2">
+            <object type="Core" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="14">
+              <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="53"/>
+            </object>
+          </object>
+        </object>
+      </object>
+    </object>
+  </object>
+  <support name="discovery.pu"/>
+  <support name="discovery.numa"/>
+  <support name="discovery.cpukind_efficiency"/>
+  <support name="custom.exported_support"/>
+  <cpukind cpuset="0x0000003f" forced_efficiency="0">
+    <info name="DarwinCompatible" value="apple,sawtooth;ARM,v8"/>
+  </cpukind>
+  <cpukind cpuset="0x00000fc0" forced_efficiency="1">
+    <info name="DarwinCompatible" value="apple,everest;ARM,v8"/>
+  </cpukind>
+</topology>


### PR DESCRIPTION
This PR fixes some issues with our co-locale binding support. Prior to this PR, some architectures like Arm macs would run into internal runtime errors when trying to use colocales (for example with the smp substrate). This was due to the assumption that when trying to bind to an architectural feature, each partition had the same number of cores.

This PR takes the simple approach of just bailing out when it detects it cannot bind colocales to an architectural feature. [Other work](https://github.com/chapel-lang/chapel/pull/27243) had tried to be smart about this and keep looking for other architectural features to bind to, but this approach is simpler and less error-prone. Ideally, if a user requests an odd (as in unexpected) number of colocales, they should get that number of colocales (perhaps with warnings) and not an internal error.

Resolves https://github.com/chapel-lang/chapel/issues/27220

Future work/TODOs captured in https://github.com/chapel-lang/chapel/issues/27704

- [x] paratest

[Reviewed by @DanilaFe]