### PR TITLE
Also limit the parallelism used for the python interop jobs

### DIFF
--- a/util/cron/test-python-modules.bash
+++ b/util/cron/test-python-modules.bash
@@ -11,4 +11,8 @@ export CHPL_LIB_PIC=pic
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="python-modules"
 export CHPL_NIGHTLY_TEST_DIRS="interop/python"
 
+# limit the amount of parallelism used, we were running out of memory on the
+# testing machine.
+export CHPL_MAKE_MAX_CPU_COUNT=2
+
 $UTIL_CRON_DIR/nightly -cron -futures

--- a/util/cron/test-python-modules.gasnet.bash
+++ b/util/cron/test-python-modules.gasnet.bash
@@ -34,4 +34,8 @@ echo "Setting Nightly variables"
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="python-modules.gasnet"
 export CHPL_NIGHTLY_TEST_DIRS="interop/python/multilocale"
 
+# limit the amount of parallelism used, we were running out of memory on the
+# testing machine.
+export CHPL_MAKE_MAX_CPU_COUNT=2
+
 $UTIL_CRON_DIR/nightly -cron -futures


### PR DESCRIPTION
While it happened less frequently than our general RHEL job, these ones that also run on the same system were also occasionally encountering memory limitations.  Reduce the parallelism used when making the compiler to hopefully lower the load