### PR TITLE
Remove lcals from Makefile

### DIFF
--- a/test/release/examples/benchmarks/Makefile
+++ b/test/release/examples/benchmarks/Makefile
@@ -10,7 +10,6 @@ all: $(TARGETS)
 clean: FORCE
 	cd hpcc && $(MAKE) clean
 	cd isx && $(MAKE) clean
-	cd lcals && $(MAKE) clean
 	cd lulesh && $(MAKE) clean
 	cd miniMD && $(MAKE) clean
 	cd shootout && $(MAKE) clean
@@ -20,9 +19,6 @@ hpcc: FORCE
 
 isx: FORCE
 	cd isx && $(MAKE)
-
-lcals: FORCE
-	cd lcals && $(MAKE)
 
 lulesh: FORCE
 	cd lulesh && $(MAKE)


### PR DESCRIPTION
Removes `lcals` from a Makefile. `lcals` was removed from the benchmarks directory in https://github.com/chapel-lang/chapel/pull/23527, but this was left behind.

Resolves https://github.com/chapel-lang/chapel/issues/27710

[Reviewed by @lydia-duncan]