### PR TITLE
Remove local from bash script

### DIFF
--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -227,8 +227,8 @@ if [ ${CHPL_TEST_ARKOUDA_STOP_AFTER_BUILD} = "false" ]; then
       reformat_benchmark_opts="${reformat_benchmark_opts} $CHPL_TEST_ARKOUDA_REFORMAT_BENCHMARKS_V2"
     fi
 
-    local benchmark_size=$((10**8))
-    local benchmark_data=benchmark_v2/data/benchmark_stats_$(date +%Y%m%d_%H%M%S).json
+    benchmark_size=$((10**8))
+    benchmark_data=benchmark_v2/data/benchmark_stats_$(date +%Y%m%d_%H%M%S).json
     mkdir -p benchmark_v2/data
     benchmark_opts="--benchmark-autosave --benchmark-storage=file://benchmark_v2/.benchmarks --size=$benchmark_size --benchmark-json=$benchmark_data"
     if [[ -n $CHPL_TEST_NUM_TRIALS ]]; then


### PR DESCRIPTION
Removes `local` from a bash script, since its not allowed outside a function.

[Trivial - not reviewed]