### PR TITLE
Add chpl-parallel-dbg to gen_release

### DIFF
--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -107,6 +107,7 @@ complete_dirs = [
     "tools/chapel-py",
     "tools/chplcheck",
     "tools/chpl-language-server",
+    "tools/chpl-parallel-dbg",
 ]
 
 


### PR DESCRIPTION
Adds `chpl-parallel-dbg` to gen_release.

this was left out of https://github.com/chapel-lang/chapel/pull/27644.

Note this intentionally does not add `chpl-parallel-dbg` to `install.sh` yet, that is future work

[Not reviewed - trivial]