### PR TITLE
Include a GASNet fix needed for Omni-Path support

### DIFF
--- a/third-party/gasnet/README
+++ b/third-party/gasnet/README
@@ -51,3 +51,5 @@ The modifications that we have made to the GASNet source are as follows:
      gasneti_console_message("WARNING",
 
 ```
+
+* Cherry-picked 5da3b2f592 - ofi: fix EVERYTHING support, broken by PR#663

--- a/third-party/gasnet/gasnet-src/ofi-conduit/gasnet_ofi.c
+++ b/third-party/gasnet/gasnet-src/ofi-conduit/gasnet_ofi.c
@@ -2094,7 +2094,7 @@ int gasnetc_ep_bindsegment(gasneti_EP_t i_ep, gasneti_Segment_t segment)
     }
 #endif
 
-    gasneti_assert_zeroret( gasneti_mk_segment_context_push(segment) );
+    gasneti_assert_zeroret( segment && gasneti_mk_segment_context_push(segment) );
 #if GASNETC_HAVE_FI_MR_REG_ATTR
     const char *reg_fn = "fi_mr_regattr";
     int ret = fi_mr_regattr(gasnetc_ofi_domainfd, &attr, flags, mrfd_p);
@@ -2105,7 +2105,7 @@ int gasnetc_ep_bindsegment(gasneti_EP_t i_ep, gasneti_Segment_t segment)
                         attr.access, attr.offset, attr.requested_key,
                         flags, mrfd_p, attr.context);
 #endif
-    gasneti_assert_zeroret( gasneti_mk_segment_context_pop(segment) );
+    gasneti_assert_zeroret( segment && gasneti_mk_segment_context_pop(segment) );
 
     if (ret) {
         if (gasneti_VerboseErrors) {


### PR DESCRIPTION
I am afraid that the new GASNet-EX 2025.8.0 release included a regression for the infrequently tested case of ofi-conduit with "everything" segment mode.  Unfortunately, that is the configuration Chapel recommends for Omni-Path.

This Pull Request cherry-picks the fix for that regression (already present in GASNet's `develop` branch).  

I have directly confirmed that this resolves the observed issue when running Chapel tests on an Omni-Path cluster I have access to.

CC: @bonachea @jabraham17 