### PR TITLE
Add missing $ for varibles in Makefile

### DIFF
--- a/modules/Makefile
+++ b/modules/Makefile
@@ -218,8 +218,8 @@ documentation: $(SYS_CTYPES_MODULE_DOC)
 	@./internal/fixInternalDocs.sh ${MODULE_SPHINX}
 	@./dists/fixDistDocs.perl      ${MODULE_SPHINX}
 	@echo "Copying generated module documentation to ${DOC_BUILD}"
-	@rm -rf {DOC_BUILD}/modules
-	@rm -rf {DOC_BUILD}/builtins
+	@rm -rf ${DOC_BUILD}/modules
+	@rm -rf ${DOC_BUILD}/builtins
 	@mkdir -p ${DOC_BUILD}/modules
 	@mkdir -p ${DOC_BUILD}/builtins
 	@cp -rf ${MODULE_SPHINX}/source/modules/standard   ${DOC_BUILD}/modules


### PR DESCRIPTION
In https://github.com/chapel-lang/chapel/issues/17387#issuecomment-3005908809, Ben noticed that we were missing the dollar signs for these variables, which prevented the generated rst files to be removed as intended. This makes that update.
