### PR TITLE
Fix segfault caused by creating a generic c_array

### DIFF
--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -362,7 +362,10 @@ returnInfoArrayIndexValue(CallExpr* call) {
 static QualifiedType
 returnInfoArrayIndex(CallExpr* call) {
   QualifiedType tmp = returnInfoArrayIndexValue(call);
-  return QualifiedType(tmp.type()->refType, QUAL_REF);
+  auto refType = tmp.type()->refType;
+  if (!refType)
+    INT_FATAL(call, "invalid attempt to get reference type");
+  return QualifiedType(refType, QUAL_REF);
 }
 
 static QualifiedType

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -360,11 +360,11 @@ const char* qualifierToStr(Qualifier q) {
 }
 
 bool QualifiedType::isRefType() const {
-  return _type->symbol->hasFlag(FLAG_REF);
+  return _type && _type->symbol->hasFlag(FLAG_REF);
 }
 
 bool QualifiedType::isWideRefType() const {
-  return _type->symbol->hasFlag(FLAG_WIDE_REF);
+  return _type && _type->symbol->hasFlag(FLAG_WIDE_REF);
 }
 
 const char* QualifiedType::qualStr() const {

--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -228,6 +228,8 @@ module CTypes {
         compilerError("c_array element type cannot be 'void'");
       if eltType == nothing then
         compilerError("c_array element type cannot be 'nothing'");
+      if isGeneric(eltType) then
+        compilerError("c_array element type cannot be generic");
       this.eltType = eltType;
       this.size = size;
       init this;

--- a/modules/standard/CTypes.chpl
+++ b/modules/standard/CTypes.chpl
@@ -185,6 +185,13 @@ module CTypes {
     }
   }
 
+
+  private proc isAnyManagedClass(type t) param {
+    return isGeneric(t) && isClassType(t) &&
+           !(isUnmanagedClass(t) || isBorrowedClass(t) ||
+             isSharedClass(t) || isOwnedClass(t));
+  }
+
   /*
   This type represents a C array with fixed size.  A variable of type
   ``c_array`` can coerce to a ``c_ptr`` with the same element type.  In that
@@ -228,8 +235,15 @@ module CTypes {
         compilerError("c_array element type cannot be 'void'");
       if eltType == nothing then
         compilerError("c_array element type cannot be 'nothing'");
-      if isGeneric(eltType) then
-        compilerError("c_array element type cannot be generic");
+      if isGeneric(eltType) {
+        param msg = "c_array element type cannot be generic";
+        if isAnyManagedClass(eltType) {
+          compilerError(msg + "\n" + eltType:string +
+                        " may be generic due to generic management");
+        } else {
+          compilerError(msg);
+        }
+      }
       this.eltType = eltType;
       this.size = size;
       init this;

--- a/test/extern/ferguson/c-array/c_array-anymanaged-and-generic.chpl
+++ b/test/extern/ferguson/c-array/c_array-anymanaged-and-generic.chpl
@@ -1,0 +1,5 @@
+use CTypes;
+
+class A { type t; }
+
+var a = new c_array(A?, 10);

--- a/test/extern/ferguson/c-array/c_array-anymanaged-and-generic.good
+++ b/test/extern/ferguson/c-array/c_array-anymanaged-and-generic.good
@@ -1,0 +1,2 @@
+c_array-anymanaged-and-generic.chpl:5: error: c_array element type cannot be generic
+A? may be generic due to generic management

--- a/test/extern/ferguson/c-array/c_array-anymanaged.chpl
+++ b/test/extern/ferguson/c-array/c_array-anymanaged.chpl
@@ -1,0 +1,5 @@
+use CTypes;
+
+class A {}
+
+var a = new c_array(A, 10);

--- a/test/extern/ferguson/c-array/c_array-anymanaged.good
+++ b/test/extern/ferguson/c-array/c_array-anymanaged.good
@@ -1,1 +1,2 @@
 c_array-anymanaged.chpl:5: error: c_array element type cannot be generic
+A may be generic due to generic management

--- a/test/extern/ferguson/c-array/c_array-anymanaged.good
+++ b/test/extern/ferguson/c-array/c_array-anymanaged.good
@@ -1,0 +1,1 @@
+c_array-anymanaged.chpl:5: error: c_array element type cannot be generic

--- a/test/extern/ferguson/c-array/c_array-generic.chpl
+++ b/test/extern/ferguson/c-array/c_array-generic.chpl
@@ -1,0 +1,5 @@
+use CTypes;
+
+record R {type t;}
+
+var a = new c_array(R(?), 10);

--- a/test/extern/ferguson/c-array/c_array-generic.good
+++ b/test/extern/ferguson/c-array/c_array-generic.good
@@ -1,0 +1,1 @@
+c_array-generic.chpl:5: error: c_array element type cannot be generic

--- a/test/extern/ferguson/c-array/c_array-unmanaged-and-generic.chpl
+++ b/test/extern/ferguson/c-array/c_array-unmanaged-and-generic.chpl
@@ -1,0 +1,5 @@
+use CTypes;
+
+class A { type t; }
+
+var a = new c_array(unmanaged A?, 10);

--- a/test/extern/ferguson/c-array/c_array-unmanaged-and-generic.good
+++ b/test/extern/ferguson/c-array/c_array-unmanaged-and-generic.good
@@ -1,0 +1,1 @@
+c_array-unmanaged-and-generic.chpl:5: error: c_array element type cannot be generic


### PR DESCRIPTION
Fixes an issue where attempting to `new c_array` with a generic type would segfault. 

This was caused when determine the return type of the primitive `array_get`. I fixed that in this PR (it now gives an internal error) and then to give a better user error I added a check for generic types in the `CTypes` initializer.

Without the check for generics
```
CTypes.chpl:242: internal error: invalid attempt to get reference type [AST/primitive.cpp:367]
```

With the check for generics
```
error: c_array element type cannot be generic
```

Resolves https://github.com/chapel-lang/chapel/issues/22301

- [x] paratest with/without gasnet

[Reviewed by @lydia-duncan]