### PR TITLE
Install llvm@20 specifically in linuxbrew provision script

### DIFF
--- a/util/devel/test/portability/provision-scripts/apt-get-and-linuxbrew.sh
+++ b/util/devel/test/portability/provision-scripts/apt-get-and-linuxbrew.sh
@@ -27,7 +27,8 @@ brew install gcc #hide
 # install some dependencies in homebrew
 brew install cmake python gmp llvm #unsudo
 
-# install LLVM version 20 as we don't support 21 yet
+# install LLVM version 20 as we don't support 21 yet, along with whatever
+# default latest version was installed above so we use the latest we support
 brew install llvm@20 #unsudo
 
 # we could use Homebrew's gcc if that becomes important in the future:


### PR DESCRIPTION
Install `llvm@20` in the Linuxbrew provision script for Vagrant, since the latest version available is now 21 and we don't yet support it.

Installation of default latest version of `llvm` is also left intact, in the hopes that even if we forget to remove this pinned version, `chplenv` will continue picking the latest supported version in future.

[reviewer info placeholder]