### PR TITLE
Improve portability of `make check` when `which` is not installed

### DIFF
--- a/util/test/checkChplDoc
+++ b/util/test/checkChplDoc
@@ -54,7 +54,12 @@ function log_error()
 # Test chpldoc with the chpldoc primer, instead of the chpl.
 bin_name=chpldoc
 
-CHPL_BIN=$(which ${bin_name} 2> /dev/null)
+which which >/dev/null 2>/dev/null
+if [ $? -ne 0 ] ; then
+  CHPL_BIN="$(command -v ${bin_name} 2> /dev/null)"
+else
+  CHPL_BIN="$(which ${bin_name} 2> /dev/null)"
+fi
 
 # Verify chpl binary exists and is executable.
 if [ -z "${CHPL_BIN}" ] ; then

--- a/util/test/checkChplInstall
+++ b/util/test/checkChplInstall
@@ -62,7 +62,12 @@ log_info "Running minimal test script: \$CHPL_HOME/util/test/checkChplInstall"
 
 BIN_NAME=chpl
 
-CHPL_BIN="$(which ${BIN_NAME} 2> /dev/null)"
+which which >/dev/null 2>/dev/null
+if [ $? -ne 0 ] ; then
+  CHPL_BIN="$(command -v ${BIN_NAME} 2> /dev/null)"
+else
+  CHPL_BIN="$(which ${BIN_NAME} 2> /dev/null)"
+fi
 
 # Verify chpl is in $PATH
 if [ -z "${CHPL_BIN}" ] ; then


### PR DESCRIPTION
On some linux systems `which` may not be installed, which causes `make check` to fail.

This PR fixes that by falling back to `command -v` if `which` is unavailable.

[Reviewed by @]