### PR TITLE
Add pretty printing for tuples on hover in chpl-language-server

### DIFF
--- a/tools/chpl-language-server/src/symbol_signature.py
+++ b/tools/chpl-language-server/src/symbol_signature.py
@@ -234,6 +234,8 @@ def _node_to_string(node: chapel.AstNode, sep="") -> List[Component]:
         return _list_to_string(node.stmts(), sep)
     elif isinstance(node, chapel.New):
         return _new_to_string(node)
+    elif isinstance(node, chapel.Tuple):
+        return _list_to_string(node.actuals(), ", ", "(", ")")
 
     return [Component(ComponentTag.PLACEHOLDER, None)]
 

--- a/tools/chpl-language-server/test/basic.py
+++ b/tools/chpl-language-server/test/basic.py
@@ -458,6 +458,9 @@ async def test_hover(client: LanguageClient):
               proc myRec.secondary(myFormal) { }
               proc getType() type { return myRec; }
               proc (getType()).secondary2(myFormal) { }
+
+              proc takesTuples(myTup: (int, real) = (1, 2.0)) { }
+              proc takesTuples2(myTup: 2 * int) { }
             }
            """
 
@@ -518,6 +521,10 @@ async def test_hover(client: LanguageClient):
         ("proc getType() type", rng(pos((22, 7)), pos((22, 14))), pos((23, 9))),
         # (getType()) is just an expression, so it just shows the text
         ("(getType())", rng(pos((23, 7)), pos((23, 18))), pos((23, 7))),
+        ("takesTuples(myTup: (int, real) = (1, 2.0))", rng(pos((25, 7)), pos((25, 18))), pos((25, 9))),
+        ("myTup: (int, real) = (1, 2.0)", rng(pos((25, 19)), pos((25, 24))), pos((25, 24))),
+        ("takesTuples2(myTup: 2 * int)", rng(pos((26, 7)), pos((26, 19))), pos((26, 9))),
+        ("myTup: 2 * int", rng(pos((26, 20)), pos((26, 25))), pos((26, 25))),
     ]
 
     async with source_file(client, file) as doc:

--- a/tools/chpl-language-server/test/document_symbols.py
+++ b/tools/chpl-language-server/test/document_symbols.py
@@ -185,6 +185,8 @@ async def test_document_symbols_exprs(client: LanguageClient):
         "const v = new (func())();",
         "const w = new unmanaged (func(int, int))(1);",
         "const x = (new shared (func())()): borrowed C?;",
+        "const y: 2 * int = (1, 3);",
+        "const z: (int, real) = (1, 3.0);",
     ]
     file = "\n".join(exprs)
 


### PR DESCRIPTION
Adds the missing pretty printing for tuples on hover in chpl-language-server, and a few test cases of printing the tuples

- [ ] `make test-cls`

[Reviewed by @]