### PR TITLE
Remove old compiler workaround for deprecated 'kind' field

### DIFF
--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -3248,18 +3248,6 @@ static Symbol* determineQueriedField(CallExpr* call) {
     Vec<Symbol*> args;
     int position = var->immediate->int_value();
 
-    // A couple of variables to help us deal with the deprecated 'kind' field
-    // in fileReader and fileWriter.
-    bool isReaderWriter = false;
-    bool specifiesKind = false;
-
-    {
-      AggregateType* root = at->getRootInstantiation();
-      isReaderWriter = root->getModule() == ioModule &&
-          (strcmp(root->symbol->name, "fileReader") == 0 ||
-           strcmp(root->symbol->name, "fileWriter") == 0);
-    }
-
     if (at->symbol->hasFlag(FLAG_TUPLE)) {
       return at->getField(position);
     }
@@ -3295,23 +3283,12 @@ static Symbol* determineQueriedField(CallExpr* call) {
 
       INT_ASSERT(var->immediate->const_kind == CONST_KIND_STRING);
 
-      if (isReaderWriter &&
-          strcmp("kind", var->immediate->v_string.c_str()) == 0) {
-        specifiesKind = true;
-      }
-
       for (int j = 0; j < args.n; j++) {
         if (args.v[j] != NULL &&
             strcmp(args.v[j]->name, var->immediate->v_string.c_str()) == 0) {
           args.v[j] = NULL;
         }
       }
-    }
-
-    // Need to increment by one so that expressions like 'fileWriter(false)'
-    // match up correctly.
-    if (isReaderWriter && !specifiesKind) {
-      position += 1;
     }
 
     forv_Vec(Symbol, arg, args) {


### PR DESCRIPTION
Removes some old compiler code originally added to support a deprecated 'kind' field in IO's fileReader and fileWriter. The field itself has been gone for some time now, so we can remove the compiler workaround.

Testing:
- [x] full paratest