### PR TITLE
Remove deprecated Python.importModule method

### DIFF
--- a/modules/packages/Python.chpl
+++ b/modules/packages/Python.chpl
@@ -642,12 +642,6 @@ module Python {
       return new Module(this, modName);
     }
 
-    @deprecated("'importModule' with a 'moduleContents' argument is deprecated. Use :proc:`createModule` instead.")
-    proc importModule(modName: string, moduleContents): owned Module throws
-      where moduleContents.type == string || moduleContents.type == bytes {
-      return new Module(this, modName, moduleContents);
-    }
-
     /*
       Create a Python module, using the provided ``moduleContents``. This is
       equivalent to putting the code in a file, and then importing the file

--- a/test/deprecated/Python/.gitignore
+++ b/test/deprecated/Python/.gitignore
@@ -1,4 +1,0 @@
-__pycache__
-python_libs
-*.pkl
-

--- a/test/deprecated/Python/CLEANFILES
+++ b/test/deprecated/Python/CLEANFILES
@@ -1,1 +1,0 @@
-../../library/packages/Python/CLEANFILES

--- a/test/deprecated/Python/COMPOPTS
+++ b/test/deprecated/Python/COMPOPTS
@@ -1,1 +1,0 @@
-../../library/packages/Python/COMPOPTS

--- a/test/deprecated/Python/EXECOPTS
+++ b/test/deprecated/Python/EXECOPTS
@@ -1,1 +1,0 @@
-../../library/packages/Python/EXECOPTS

--- a/test/deprecated/Python/importModule.chpl
+++ b/test/deprecated/Python/importModule.chpl
@@ -1,6 +1,0 @@
-use Python;
-var interp = new Interpreter();
-
-var mod = interp.importModule("mymod", "print('hello from Python')");
-interp.flush();
-writeln("module: ", mod.modName);

--- a/test/deprecated/Python/importModule.good
+++ b/test/deprecated/Python/importModule.good
@@ -1,3 +1,0 @@
-importModule.chpl:4: warning: 'importModule' with a 'moduleContents' argument is deprecated. Use createModule instead.
-hello from Python
-module: mymod


### PR DESCRIPTION
Removes a deprecated Python.importModule method that was deprecated in https://github.com/chapel-lang/chapel/pull/26982.

- [x] paratest

[Reviewed by @DanilaFe]