### PR TITLE
Install only llvm@20 in Linuxbrew provision script

### DIFF
--- a/util/devel/test/portability/provision-scripts/apt-get-and-linuxbrew.sh
+++ b/util/devel/test/portability/provision-scripts/apt-get-and-linuxbrew.sh
@@ -25,11 +25,8 @@ eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" #hide
 brew install gcc #hide
 
 # install some dependencies in homebrew
-brew install cmake python gmp llvm #unsudo
-
-# install LLVM version 20 as we don't support 21 yet, along with whatever
-# default latest version was installed above so we use the latest we support
-brew install llvm@20 #unsudo
+# install LLVM version 20 as we don't support 21 yet
+brew install cmake python gmp llvm@20 #unsudo
 
 # we could use Homebrew's gcc if that becomes important in the future:
 # # link the homebrew-installed gcc-* to gcc


### PR DESCRIPTION
This Vagrant configuration is still picking up LLVM 21, so I think the strategy of providing both 21 and 20 isn't working, at least not without PATH modifications. So, switch to installing just 20.

Follow up to https://github.com/chapel-lang/chapel/pull/27739.

[trivial, not reviewed]