### PR TITLE
Adjust a new test to avoid bug revealed with asan

### DIFF
--- a/test/parallel/taskPar/taskIntents/type-methods.chpl
+++ b/test/parallel/taskPar/taskIntents/type-methods.chpl
@@ -34,9 +34,13 @@ record R {
   }
 
   proc type useBegin(dom) {
+    // synchronization to work around https://github.com/chapel-lang/chapel/issues/27769
+    var x: atomic int = 1;
     begin {
       writeln(bar(dom));
+      x.add(-1);
     }
+    x.waitFor(0);
   }
   proc type useCobegin(dom) {
     cobegin {


### PR DESCRIPTION
Adjusts a new test I added to avoid tripping asan/vagrind checks

See https://github.com/chapel-lang/chapel/issues/27769

[Not reviewed - trivial]