### PR TITLE
Adjust prediff used by hashtable test

### DIFF
--- a/test/types/chplhashtable/recordOfNonHashRecord.good
+++ b/test/types/chplhashtable/recordOfNonHashRecord.good
@@ -6,6 +6,6 @@ recordOfNonHashRecord.chpl:22: note: is passed to formal 'this: WrapR'
 $CHPL_HOME/modules/standard/Set.chpl:nnnn: note: other candidates are:
 $CHPL_HOME/modules/internal/ChapelHashing.chpl:nnnn: note:   bool.hash()
 $CHPL_HOME/modules/internal/ChapelHashing.chpl:nnnn: note:   int.hash()
-note: and 38 other candidates, use --print-all-candidates to see them
+note: and XXX candidates, use --print-all-candidates to see them
   $CHPL_HOME/modules/standard/Set.chpl:nnnn: called as (set(WrapR,false))._addElem(elem: WrapR) from method 'add'
   recordOfNonHashRecord.chpl:32: called as (set(WrapR,false)).add(element: WrapR)

--- a/test/types/chplhashtable/recordOfNonHashRecord.prediff
+++ b/test/types/chplhashtable/recordOfNonHashRecord.prediff
@@ -2,4 +2,5 @@
 # Ignore line numbers in modules.
 
 sed '\|CHPL_HOME/modules|s/:[0-9]*:/:nnnn:/' $2 > $2.tmp
-mv $2.tmp $2
+sed -E 's/and [0-9]+ other candidates/and XXX candidates/g' $2.tmp > $2
+touch $2.tmp && rm $2.tmp


### PR DESCRIPTION
A hashtable test is failing because a recent PR of mine introduced 3 more types which add their `.hash()` method to the set of visible candidates. Adjust the prediff for this test to replace e.g., "and 41 other candidates" with "and XXX candidates". Hopefully lowering the number of times the `.good` file for this test needs to be touched in the future.