### PR TITLE
Fix bundle of nightly errors

### DIFF
--- a/test/execflags/lldbddash/declint.prediff
+++ b/test/execflags/lldbddash/declint.prediff
@@ -13,7 +13,8 @@ grep -v "Breakpoint 1: where" $tmpfile | \
   grep -v "Current executable set to" | \
   grep -v "b debuggerBreakHere" | \
   grep -v 'breakpoint set -n debuggerBreakHere -N debuggerBreakHere' | \
-  grep -v 'breakpoint command add -o up debuggerBreakHere' \
+  grep -v 'breakpoint command add -o up debuggerBreakHere' | \
+  grep -v 'runtime/etc/debug/lldb.commands' \
   > $outfile
 # Also filter out line about memleaks arguments to executable
 mv $outfile $tmpfile

--- a/test/execflags/lldbddash/declint.prediff
+++ b/test/execflags/lldbddash/declint.prediff
@@ -11,8 +11,8 @@ mv $outfile $tmpfile
 grep -v "Breakpoint 1: where" $tmpfile | \
   grep -v "target create" | \
   grep -v "Current executable set to" | \
-  grep -v "b debuggerBreakHere" |
-  grep -v 'breakpoint set -n debuggerBreakHere -N debuggerBreakHere' |\
+  grep -v "b debuggerBreakHere" | \
+  grep -v 'breakpoint set -n debuggerBreakHere -N debuggerBreakHere' | \
   grep -v 'breakpoint command add -o up debuggerBreakHere' \
   > $outfile
 # Also filter out line about memleaks arguments to executable

--- a/test/library/packages/DistributedBag/insertArrayInBag1.bad
+++ b/test/library/packages/DistributedBag/insertArrayInBag1.bad
@@ -1,1 +1,0 @@
-insertArrayInBag1.chpl:4: error: Out of memory allocating "array elements"

--- a/test/types/tuple/errors/tuple-init.bad
+++ b/test/types/tuple/errors/tuple-init.bad
@@ -1,4 +1,4 @@
-$CHPL_HOME/modules/internal/ChapelBase.chpl:1347: internal error: UTI-MIS-0939 chpl version 1.27.0 pre-release (b832268935)
+$CHPL_HOME/modules/standard/Regex.chpl:681: internal error: UTI-MIS-1049 chpl version 2.6.0 pre-release (e69472a1958)
 Note: This source location is a guess.
 
 Internal errors indicate a bug in the Chapel compiler,


### PR DESCRIPTION
Fixes three nightly errors

- Removes a bad file from a PR I merged for @Guillaume-Helbecque, which has non-deterministic crashes
- Updates a bad file for a compiler error that I may or may not have caused
- Fixes a lldb test that only fails with some versions of lldb

[Not reviewed - trivial]