### PR TITLE
Fix pattern matching mistake in `build_helpers.sh`

### DIFF
--- a/util/packaging/common/build_helpers.sh
+++ b/util/packaging/common/build_helpers.sh
@@ -13,10 +13,10 @@ __get_docker_tag() {
 __package_type_from_os() {
   local pkg_type
   case $1 in
-    "amzn*" | "fc*" | "el*")
+    amzn* | fc* | el*)
     pkg_type="rpm"
     ;;
-    "debian*" | "ubuntu*")
+    debian* | ubuntu*)
     pkg_type="apt"
     ;;
     *)


### PR DESCRIPTION
Fix a bash mistake in `case` pattern matching in `util/packaging/common/build_helpers.sh`.

Follow up to https://github.com/chapel-lang/chapel/pull/27758.

[trivial fix, not reviewed]

Testing:
- [x] locally tested that string correctly matched after change