### PR TITLE
Fix a relative path in vagrant `re2-supported.py`

### DIFF
--- a/util/devel/test/portability/vagrant/re2-supported.py
+++ b/util/devel/test/portability/vagrant/re2-supported.py
@@ -3,7 +3,7 @@
 import os
 import sys
 
-chplenv_dir = os.path.join(os.path.dirname(__file__), '..', '..', '..', 'chplenv')
+chplenv_dir = os.path.join(os.path.dirname(__file__), '..', '..', '..', '..', 'chplenv')
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
 import chpl_compiler


### PR DESCRIPTION
Follow up to https://github.com/chapel-lang/chapel/pull/27398, which moved this file a level deeper in the Chapel source tree.

Fixes this non-fatal error message I noticed in portability testing build logs:
```
Traceback (most recent call last):
  File "/home/vagrant/chapel/./util/devel/test/portability/vagrant/re2-supported.py", line 9, in <module>
    import chpl_compiler
ModuleNotFoundError: No module named 'chpl_compiler'
```

[trivial fix, not reviewed]