### PR TITLE
Explicitly set CHPL_TARGET_CPU=none in Dockerfile's

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,8 @@ RUN git config --global user.email "noreply@example.com" && \
 # set up Chapel environment variables
 ENV CHPL_HOME=/opt/chapel \
     CHPL_GMP=system \
-    CHPL_LLVM=system
+    CHPL_LLVM=system \
+    CHPL_TARGET_CPU=none
 
 WORKDIR $CHPL_HOME
 


### PR DESCRIPTION
Explicitly set CHPL_TARGET_CPU=none in the Chapel Dockerfiles

This does a few things
- fixes https://github.com/chapel-lang/chapel/issues/27748, where erroneous warnings would show up
- fixes a potential issue where we specialize for the wrong uarch (as noted in https://github.com/chapel-lang/chapel/issues/27748#issuecomment-3267407081)

Resolves https://github.com/chapel-lang/chapel/issues/27748

- [x] ~test `docker build $CHPL_HOME`~ going to let nightly test it, can't easily test locally
- [x] ~test `docker build $CHPL_HOME/util/packaging/docker/gasnet/Dockerfile`~ going to let nightly test it, can't easily test locally

[Reviewed by @arifthpe]