### PR TITLE
Fixes `mason test --setComm` always defaulting to `none`

### DIFF
--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -59,7 +59,7 @@ proc masonTest(args: [] string) throws {
   var recursFlag = parser.addFlag(name="recursive", defaultValue=false);
   var parFlag = parser.addFlag(name="parallel", defaultValue=false);
   var updateFlag = parser.addFlag(name="update", flagInversion=true);
-  var setCommOpt = parser.addOption(name="setComm", defaultValue="none");
+  var setCommOpt = parser.addOption(name="setComm");
   var filterFlag = parser.addOption(name="filter", defaultValue="");
 
   // TODO: Why doesn't masonTest support a passthrough for values that should


### PR DESCRIPTION
Fixes an issue where `mason test` was always defaulting to testing with `CHPL_COMM=none`, instead of inferring the right comm layer from the environment. This was because `--setComm` erroneously had a default value of `none`.

- [x] paratest

[Reviewed by @benharsh] 