### PR TITLE
Prevent C backend errors about duplicate structs for extern wide refs

### DIFF
--- a/compiler/passes/convert-typed-uast.cpp
+++ b/compiler/passes/convert-typed-uast.cpp
@@ -41,6 +41,7 @@
 #include "metadata.h"
 #include "optimizations.h"
 #include "parser.h"
+#include "passes.h"
 #include "resolution.h"
 #include "stmt.h"
 #include "view.h"
@@ -2914,21 +2915,22 @@ Type* TConverter::convertType(const types::Type* t) {
 
   // If we need to generate a 'ref' wrapper for the type, do so now.
   if (!ret->refType) {
-    SET_LINENO(ret->symbol);
+    // SET_LINENO(ret->symbol);
 
-    // TODO: This is "AGGREGATE_RECORD" in "getOrMakeRefTypeDuringCodegen"?
-    // But making these early 'ref' wrappers records interferes with a lot
-    // of optimization passes that are looking for records, so my guess is
-    // that the codegen generated ones should probably be 'CLASS' as well.
-    AggregateType* ref = new AggregateType(AGGREGATE_CLASS);
-    TypeSymbol* refTs = new TypeSymbol(astr("_ref_", ret->symbol->cname), ref);
-    refTs->addFlag(FLAG_REF);
-    refTs->addFlag(FLAG_NO_DEFAULT_FUNCTIONS);
-    refTs->addFlag(FLAG_NO_OBJECT);
-    refTs->addFlag(FLAG_RESOLVED_EARLY);
-    globalInsertionPoint->insertAtTail(new DefExpr(refTs));
-    ref->fields.insertAtTail(new DefExpr(new VarSymbol("_val", ret)));
-    ret->refType = ref;
+    // // TODO: This is "AGGREGATE_RECORD" in "getOrMakeRefTypeDuringCodegen"?
+    // // But making these early 'ref' wrappers records interferes with a lot
+    // // of optimization passes that are looking for records, so my guess is
+    // // that the codegen generated ones should probably be 'CLASS' as well.
+    // AggregateType* ref = new AggregateType(AGGREGATE_CLASS);
+    // TypeSymbol* refTs = new TypeSymbol(astr("_ref_", ret->symbol->cname), ref);
+    // refTs->addFlag(FLAG_REF);
+    // refTs->addFlag(FLAG_NO_DEFAULT_FUNCTIONS);
+    // refTs->addFlag(FLAG_NO_OBJECT);
+    // refTs->addFlag(FLAG_RESOLVED_EARLY);
+    // globalInsertionPoint->insertAtTail(new DefExpr(refTs));
+    // ref->fields.insertAtTail(new DefExpr(new VarSymbol("_val", ret)));
+    // ret->refType = ref;
+    getOrMakeRefTypeDuringCodegen(ret);
   }
 
   return ret;


### PR DESCRIPTION
Fixes a bug with the C backend (gnu) and `--no-local`, where the compiler would generate wide references to extern types, but then fail to deduplicate them. This results in the backend complaining about duplicate structs named the same thing. This would occur because the wide references were created on the fly in `getOrMakeWideTypeDuringCodegen` during codegen, after `uniquify_names` was run.

This PR does not add a test for this case, as I was unable to replicate the issue outside of a much larger application. But essentially the problem would arise from the following pattern

```
extern "myType" type t1;
extern "myType" type t2;
```

During codegen, the compiler would determine it needs wide references to both `t1` and `t2`, and create those wide references. But it would name them both `myType`, and then `makeBinary` would fail.

This PR solves the problem by adjusting `getOrMakeRefTypeDuringCodegen` to reuse ref types for distinct types with the same cname. This then fixes `getOrMakeWideTypeDuringCodegen` because the name for the wide type is based on the ref type. I solved it this way because technically, there is also an issue with duplicate ref types being generated, they just don't cause an issue because the C compiler silently swallows duplicated `typedefs`


- [ ] paratest with/without gasnet

