### PR TITLE
Remove the unused `doc` field in the compiler

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -56,7 +56,6 @@ AggregateType::AggregateType(AggregateTag initTag) :
   initializerResolved = false;
   iteratorInfo        = NULL;
   thunkInvoke         = NULL;
-  doc                 = NULL;
 
   instantiatedFrom    = NULL;
 

--- a/compiler/AST/FnSymbol.cpp
+++ b/compiler/AST/FnSymbol.cpp
@@ -69,7 +69,6 @@ FnSymbol::FnSymbol(const char* initName)
   userString         = NULL;
   valueFunction      = NULL;
   codegenUniqueNum   = 1;
-  doc                = NULL;
   retSymbol          = NULL;
   llvmDISubprogram   = NULL;
   mIsNormalized      = false;

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -536,8 +536,7 @@ bool isConstrainedTypeSymbol(Symbol* s, ConstrainedTypeUse use) {
 
 EnumType::EnumType() :
   Type(E_EnumType, NULL),
-  constants(), integerType(NULL),
-  doc(NULL)
+  constants(), integerType(NULL)
 {
   gEnumTypes.add(this);
   constants.parent = this;

--- a/compiler/include/AggregateType.h
+++ b/compiler/include/AggregateType.h
@@ -215,8 +215,6 @@ public:
   // What to delegate to with 'forwarding'
   AList                       forwardingTo;
 
-  const char*                 doc;
-
   // Used during code generation for subclass checking,
   // isa checking. This is the value we store in chpl__cid_XYZ.
   int                         classId;

--- a/compiler/include/FnSymbol.h
+++ b/compiler/include/FnSymbol.h
@@ -142,7 +142,6 @@ public:
   FnSymbol*                  valueFunction;
 
   int                        codegenUniqueNum;
-  const char*                doc;
 
   // Used to store the return symbol during partial copying.
   Symbol*                    retSymbol;

--- a/compiler/include/ModuleSymbol.h
+++ b/compiler/include/ModuleSymbol.h
@@ -98,7 +98,6 @@ public:
   std::vector<ModuleSymbol*> modUseList;
 
   const char*             filename;
-  const char*             doc;
 
 #ifdef HAVE_LLVM
   ExternBlockInfo*        extern_info;

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -527,8 +527,6 @@ class TypeSymbol final : public Symbol {
   // TBAA metadata for aggregates
   void codegenAggMetadata();
 
-  const char* doc;
-
   BlockStmt* instantiationPoint;
   astlocT userInstantiationPointLoc;
 };

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -338,8 +338,6 @@ class EnumType final : public Type {
   PrimitiveType* integerType;
 
  public:
-  const char* doc;
-
   EnumType();
  ~EnumType() override = default;
 


### PR DESCRIPTION
Removes the unused `doc` field, which is leftover from when `chpldoc` was a compiler pass instead of a standalone tool.

- [x] paratest

[Reviewed by @DanilaFe]