### PR TITLE
Remove old "planned work" entry in attributes technote

### DIFF
--- a/doc/rst/technotes/attributes.rst
+++ b/doc/rst/technotes/attributes.rst
@@ -181,9 +181,6 @@ Future Work and Design Discussions
 
 Planned work for attributes includes:
 
-* deprecate and replace the use of ``pragma "no doc"`` with ``@chpldoc.nodoc``
-  as the primary means to omit documentation for a symbol
-
 * convert ``pragma "always RVF"`` into an attribute, possibly ``@chpl.alwaysRvf``
 
 * allow any order of pragmas and attributes


### PR DESCRIPTION
`pragma "no doc"` has been removed from the compiler for a while, so the note to remove it is no longer necessary

Double checked built docs