### PR TITLE
Switch tests to use the new partition names

### DIFF
--- a/util/cron/common-gpu-nvidia-hpe-cray-ex.bash
+++ b/util/cron/common-gpu-nvidia-hpe-cray-ex.bash
@@ -1,4 +1,4 @@
 # common settings for running GPU nightly testing on the HPE Cray EX system
 
-export CHPL_LAUNCHER_PARTITION=griz512
+export CHPL_LAUNCHER_PARTITION=rhgriz512
 export CHPL_LLVM=system

--- a/util/cron/test-hpe-cray-ex-ofi.bash
+++ b/util/cron/test-hpe-cray-ex-ofi.bash
@@ -10,7 +10,7 @@ source $UTIL_CRON_DIR/common-hpe-cray-ex.bash
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="hpe-cray-ex-ofi"
 export CHPL_RT_COMM_OFI_EXPECTED_PROVIDER="cxi"
 export CHPL_RT_MAX_HEAP_SIZE=16g
-export SLURM_PARTITION=allnodes 
+export SLURM_PARTITION=bardpeak
 
 
 # test a small subset of all tests due to limited resources


### PR DESCRIPTION
Switch some test configs to use the new partition names for the test system

[Not reviewed - trivial]