### PR TITLE
Move nested record in `chpl_lockGuard` to module scope

### DIFF
--- a/modules/internal/ChapelLocks.chpl
+++ b/modules/internal/ChapelLocks.chpl
@@ -145,8 +145,8 @@ module ChapelLocks {
       as 'read()', 'write()', or 'lock()'. */
   // TODO: This was originally nested inside `chpl_lockGuard`, but that
   //       causes a bizarre problem with `--verify` in programs that
-  //       emit compiler errors during the `resolve()` pass. An issue
-  //       is forthcoming.
+  //       emit compiler errors during the `resolve()` pass. See the
+  //       pull request #27795 for a detailed explanation.
   record chpl_lockGuardAccessManager {
     type dataType;
     type lockType;


### PR DESCRIPTION
This PR fixes nightly test failures when running with `--verify`.

The nested record inside `chpl_lockGuard` is used as a context manager for implementing read or write access. Since it is a context manager, it needs to write an `implements` statement, but that can only be written at module scope right now. Thus I had to write a `type` procedure on `chpl_lockGuard` that could be used to expose the type of the record:

```chapel
type t = chpl_lockGuard._accessManagerType; // A parenless type procedure.
t implements contextManager;
```

This works, except when a specific subset of programs are run with `--verify`. Specifically, any program that emits errors during the `resolve()` compiler pass, and does not throw another flag such as `--ignore-errors-for-pass`.

What goes wrong is that:
- Earlier during resolution the type proc was resolved (for use in the `implements`)
- The resolved type function returns a _generic_ type
- Separate, unrelated errors are emitted during `resolve()` using `USR_FATAL_CONT`
- Because errors occurred, the AST is intentionally malformed and type functions are kept inserted in the tree
- After resolution, cleanup is run on the AST in `pruneResolvedTree()`
- This cleanup opts not to remove the type procedure because errors occurred...
- However, it does remove the nested generic type...?!
- (During cleanup transforms occur that make the type unused, and it is not resolved because it is generic)
- After the pass`--verify` runs and errors because the type procedure's return type is not in the tree

I tried two initial approaches here before turning to an idea suggested by @jabraham17.

First, I tried to massage the contents of `pruneResolvedTree()` in order to find an adjustment that would keep `--verify` happy. This proved to be very error-prone as the slightest mis-adjustment can trigger `--verify` errors about non-normalized AST. I'm sure that I could have eventually figured something out, but either way this approach is fundamentally unproductive. The reason being that eventually we are going to be using the typed converter and delete all the code for passes before `callDestructors`. I expect that this will include most `--verify` code as well.

Next, I naively tried to make it so we only run the "check" pass for a compiler pass if `fVerify` is thrown. It turns out that we can't do this because there are actually _semantic checks_ in some of the "checks" passes. I found this shocking as I always assumed that "checks" were for developers to ensure correct AST shape. I can only assume that at some point "checks" were primarily meant for semantic checks and we transitioned away from that to the current production compiler architecture.

Future work should look into a suggestion from @bradcray about only toggling `fVerify` to `false` in the case that `fatalErrorsOccurred()`, as a workaround for the above. I still think that `--verify` should not be done for a compiler pass that throws fatal errors, specifically because (IMO) it is a bit nonsensical to waste time doing, and because the AST may be intentionally malformed as in this case.

Reviewed by @jabraham17. Thanks!