### PR TITLE
Remove some remaining references to `single` type in doc

### DIFF
--- a/frontend/include/chpl/types/Type.h
+++ b/frontend/include/chpl/types/Type.h
@@ -314,8 +314,8 @@ class Type {
       always considered to be POD, and no further evaluation takes
       place.
 
-      If 't' is the sync type, the single type, an atomic type, the
-      array type, or the domain type, then 't' is not POD.
+      If 't' is the sync type, an atomic type, the array type, or
+      the domain type, then 't' is not POD.
 
       If 't' is a class with 'owned' or 'shared' management, then 't'
       is not POD.

--- a/modules/standard/Types.chpl
+++ b/modules/standard/Types.chpl
@@ -616,8 +616,6 @@ proc isArray(e)     param do  return isArrayValue(e);
 proc isDmap(e)      param do  return isDmapValue(e);
 /* Returns ``true`` if the argument is a ``sync`` type or a ``sync`` variable. */
 proc isSync(e)      param do  return isSyncValue(e);
-/* Returns ``true`` if the argument is a ``single`` type or a ``single`` variable. */
-proc isSingle(e)    param do  return isSingleValue(e);
 /*Returns ``true`` if the argument is an ``atomic`` type or an ``atomic`` variable.*/
 proc isAtomic(e)    param do  return isAtomicValue(e);
 


### PR DESCRIPTION
Remove some remaining references to `single` type in doc. `single` has been deprecated in 1.32 and removed in 2.2.