### PR TITLE
Adjust cls-test-venv to be correct

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,9 +140,6 @@ test-venv: third-party-test-venv
 chapel-py-venv: frontend-shared
 	$(MAKE) third-party-chapel-py-venv
 
-cls-test-venv: FORCE chapel-py-venv
-	cd third-party && $(MAKE) cls-test-venv
-
 chpldoc: third-party-chpldoc-venv
 	@cd third-party && $(MAKE) llvm
 	cd compiler && $(MAKE) chpldoc
@@ -162,11 +159,6 @@ always-build-chpldoc: FORCE
 always-build-chapel-py: FORCE
 	-@if [ -n "$$CHPL_ALWAYS_BUILD_CHAPEL_PY" ]; then \
 	$(MAKE) chapel-py-venv; \
-	fi
-
-always-build-cls-test: FORCE
-	-@if [ -n "$$CHPL_ALWAYS_BUILD_CHAPEL_PY_TEST" ]; then \
-	$(MAKE) cls-test-venv; \
 	fi
 
 always-build-chplcheck: FORCE

--- a/Makefile.devel
+++ b/Makefile.devel
@@ -75,6 +75,17 @@ frontend-tests:
 
 test-dyno: FORCE test-frontend
 
+always-build-cls-test: FORCE
+	-@if [ -n "$$CHPL_ALWAYS_BUILD_CHAPEL_PY_TEST" ]; then \
+	$(MAKE) cls-test-venv; \
+	fi
+
+third-party-test-cls-venv: FORCE
+	cd third-party && $(MAKE) cls-test-venv;
+
+cls-test-venv: frontend-shared
+	$(MAKE) third-party-test-cls-venv
+
 test-cls test-chpl-language-server: FORCE
 	@$(MAKE) chpl-language-server
 	@cd tools/chpl-language-server && $(MAKE) test-chpl-language-server

--- a/third-party/chpl-venv/Makefile
+++ b/third-party/chpl-venv/Makefile
@@ -132,9 +132,12 @@ chapel-py-venv: FORCE $(CHPL_VENV_VIRTUALENV_DIR_OK)
 		>$(CHPL_MAKE_HOME)/tools/chapel-py/src/chapel/core/__init__.pyi && \
 		cp $(CHPL_MAKE_HOME)/tools/chapel-py/src/chapel/core/__init__.pyi $(CHPL_VENV_CHPL_FRONTEND_PY_DEPS)/chapel/core.pyi
 
-cls-test-venv: chapel-py-venv
+cls-test-venv: FORCE $(CHPL_VENV_VIRTUALENV_DIR_OK)
+	@# note that CC/CXX are explicitly set to avoid scikit-build/scikit-build-core#1114
 	export PATH="$(CHPL_VENV_VIRTUALENV_BIN):$$PATH" && \
 	export VIRTUAL_ENV=$(CHPL_VENV_VIRTUALENV_DIR) && \
+	CC=$(shell which $(CHPL_MAKE_HOST_CC)) \
+	CXX=$(shell which $(CHPL_MAKE_HOST_CXX)) \
 	CHPL_HOME=$(CHPL_MAKE_HOME) $(PIP) install \
 	  $(CHPL_PIP_INSTALL_PARAMS) $(LOCAL_PIP_FLAGS) \
 	  --target $(CHPL_VENV_CHPL_FRONTEND_PY_DEPS) \

--- a/third-party/chpl-venv/Makefile
+++ b/third-party/chpl-venv/Makefile
@@ -132,16 +132,12 @@ chapel-py-venv: FORCE $(CHPL_VENV_VIRTUALENV_DIR_OK)
 		>$(CHPL_MAKE_HOME)/tools/chapel-py/src/chapel/core/__init__.pyi && \
 		cp $(CHPL_MAKE_HOME)/tools/chapel-py/src/chapel/core/__init__.pyi $(CHPL_VENV_CHPL_FRONTEND_PY_DEPS)/chapel/core.pyi
 
-cls-test-venv: FORCE $(CHPL_VENV_VIRTUALENV_DIR_OK)
-	@# note that CC/CXX are explicitly set to avoid scikit-build/scikit-build-core#1114
+cls-test-venv: chapel-py-venv
 	export PATH="$(CHPL_VENV_VIRTUALENV_BIN):$$PATH" && \
 	export VIRTUAL_ENV=$(CHPL_VENV_VIRTUALENV_DIR) && \
-	CC=$(shell which $(CHPL_MAKE_HOST_CC)) \
-	CXX=$(shell which $(CHPL_MAKE_HOST_CXX)) \
 	CHPL_HOME=$(CHPL_MAKE_HOME) $(PIP) install \
 	  $(CHPL_PIP_INSTALL_PARAMS) $(LOCAL_PIP_FLAGS) \
 	  --target $(CHPL_VENV_CHPL_FRONTEND_PY_DEPS) \
-	  $(CHPL_MAKE_HOME)/tools/chapel-py \
 	  -r $(CHPL_VENV_CLS_TEST_REQUIREMENTS_FILE)
 	@# Using --upgrade above breaks the test venv, because there's a bug
 	@# in its interaction with --target. As a result, this command does


### PR DESCRIPTION
Adjusts the makefile targets for `cls-test-venv` to be correct

[Reviewed by @DanilaFe]