### PR TITLE
Use the python 3.10 stable ABI for chapel-py

### DIFF
--- a/tools/chapel-py/pyproject.toml
+++ b/tools/chapel-py/pyproject.toml
@@ -9,14 +9,13 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
 ]
 keywords = ["chapel", "compiler", "frontend", "dyno"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
   "attrs==25.3.0",
   "cattrs==25.1.1",
@@ -41,7 +40,7 @@ requires = ["scikit-build-core>=0.11.5"]
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]
-wheel.py-api = "cp39" # limited API for 3.9
+wheel.py-api = "cp310" # limited API for 3.10
 wheel.expand-macos-universal-tags = true
 minimum-version = "build-system.requires"
 build-dir = "./build/{wheel_tag}"


### PR DESCRIPTION
Switches to using the Python 3.10 stable ABI for chapel-py, since that is the minimum version of python we support for chapel-py anyways

[Reviewed by @DanilaFe]