### PR TITLE
Add an anchor for the new-ish chpldoc '-M' flag

### DIFF
--- a/man/chpldoc.rst
+++ b/man/chpldoc.rst
@@ -46,6 +46,8 @@ reStructuredText as an intermediate format.
     documentation comment from a normal one (defaults to '/\*' if
     unspecified).
 
+.. _man-module-dir:
+
 **-M, \--module-dir <**\ *directory*\ **>**
 
     Add the specified *directory* to the module search path. The module


### PR DESCRIPTION
Unfortunately, I didn't notice it was lacking one until attempting to link to it in the CHANGES.md file late last week.
