### PR TITLE
Don't generate debug info for temps

### DIFF
--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -966,7 +966,7 @@ void VarSymbol::codegenGlobalDef(bool isHeader) {
       gVar->setDSOLocal(true);
       setValueAlignment(gVar, type, this);
 
-      if(debug_info){
+      if (debug_info && debug_info->should_add_DI_for(this)) {
         auto di = debug_info->get_global_variable(this);
         if (di) {
           gVar->addDebugInfo(di);
@@ -1054,7 +1054,7 @@ void VarSymbol::codegenDef() {
         }
       }
     }
-    if(debug_info){
+    if (debug_info && debug_info->should_add_DI_for(this)) {
       debug_info->get_variable(this);
     }
 #endif
@@ -3121,7 +3121,7 @@ void FnSymbol::codegenDef() {
                             tempVar.isLVPtr, tempVar.isUnsigned);
 
         // debug info for formal arguments
-        if(debug_info){
+        if (debug_info && debug_info->should_add_DI_for(arg)) {
           debug_info->get_formal_arg(arg, clangArgNum+1);
         }
       }

--- a/compiler/include/llvmDebug.h
+++ b/compiler/include/llvmDebug.h
@@ -53,6 +53,8 @@ class debug_data
   void finalize();
   void create_compile_unit(ModuleSymbol* modSym, const char *file, const char *directory, bool is_optimized, const char *flags);
 
+  bool should_add_DI_for(Symbol* sym);
+
   llvm::DIType* construct_type(Type *type);
   llvm::DIType* get_type(Type *type);
 

--- a/compiler/llvm/llvmDebug.cpp
+++ b/compiler/llvm/llvmDebug.cpp
@@ -123,6 +123,18 @@ void debug_data::create_compile_unit(
 }
 
 
+bool debug_data::should_add_DI_for(Symbol* sym) {
+  // in developer mode, add debug info for everything
+  if (developer) return true;
+
+  // skip temps
+  if (sym->hasFlag(FLAG_TEMP)) return false;
+
+  // default to adding debug info
+  return true;
+}
+
+
 llvm::DIType* debug_data::construct_type_for_aggregate(
   llvm::StructType* ty, AggregateType* type
 ) {


### PR DESCRIPTION
Only generate debug info for user-level variables.

Prior to this PR, we would generate debug information for all variables, which would mean users would see many compiler generated variables called `call_tmp`. This isn't very useful information to a user debugging their code, so this PR removes the debug information for those extra temps except when `--devel` is used

- [ ] paratest

[Reviewed by @]