### PR TITLE
Quiet some LLVM debug info tests

### DIFF
--- a/test/llvm/debugInfo/lldb/basicTypes.skipif
+++ b/test/llvm/debugInfo/lldb/basicTypes.skipif
@@ -1,3 +1,7 @@
+CHPL_LLVM_VERSION==14
+CHPL_LLVM_VERSION==15
+CHPL_LLVM_VERSION==16
+CHPL_LLVM_VERSION==17
 # this can remove too much of the debug info
 COMPOPTS <= --fast
 # baseline testing has extra call_temps left behind that mess up the good file


### PR DESCRIPTION
Quiets some LLVM debug info tests that have been causing configs to fail due to slight variances in string printing on various platforms