### PR TITLE
Make Debugger.breakpoint not rely in `inline`

### DIFF
--- a/modules/standard/Debugger.chpl
+++ b/modules/standard/Debugger.chpl
@@ -38,10 +38,7 @@ module Debugger {
     with ``b debuggerBreakHere``. If using ``--gdb`` or ``--lldb``, this
     is done automatically.
   */
-  inline proc breakpoint {
-    extern proc debuggerBreakHere();
-    debuggerBreakHere();
-  }
+  extern "debuggerBreakHere" proc breakpoint;
 
   /*
     If ``disableDebugTraps`` is set to ``true``, then the


### PR DESCRIPTION
Adjust `Debugger.breakpoint` to directly be an extern function, rather than an inline function that calls an extern function.

The result of this is that if a user throws `--no-inline`, they don't have an extra stack frame to deal with.

- [x] paratest

[Reviewed by @DanilaFe]