### PR TITLE
Improve debuggability of compiler by avoiding fork/join/exec

### DIFF
--- a/compiler/backend/beautify.cpp
+++ b/compiler/backend/beautify.cpp
@@ -58,7 +58,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "files.h"
 #include "misc.h"
 #include "stringutil.h"
-#include "mysystem.h"
+#include "chpl/util/filesystem.h"
 
 #define ZLINEFORMAT "#line %d \"%s\"\n"
 #define ZLINEINPUT "/* ZLINE: "
@@ -182,7 +182,6 @@ void beautify(fileinfo* origfile) {
   char *cp;
   FILE *inputfile;
   FILE *outputfile;
-  const char* command;
   int i;
   int new_line, indent;
   int zline;
@@ -262,8 +261,12 @@ void beautify(fileinfo* origfile) {
   closefile(tmpfile);
   closefile(origfile);
 
-  command = astr("mv ", tmpfile->pathname, " ", origfile->pathname);
-  mysystem(command, "moving beautified file", false, true);
+  auto err = chpl::moveFile(tmpfile->pathname, origfile->pathname);
+  if (err) {
+    INT_FATAL("Unable to rename %s to %s: %s",
+              tmpfile->pathname, origfile->pathname,
+              err.message().c_str());
+  }
 
   if (justification.size() != 0) {
     INT_FATAL( "Parentheses or curly braces are not balanced "

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -130,6 +130,7 @@ using LlvmOptimizationLevel = llvm::OptimizationLevel;
 
 #include "../../frontend/lib/immediates/prim_data.h"
 #include "chpl/util/clang-integration.h"
+#include "chpl/util/filesystem.h"
 
 #include "global-ast-vecs.h"
 
@@ -5704,48 +5705,12 @@ static void moveResultFromTmp(const char* resultName, const char* tmpbinname) {
   // mv tmp/hello.tmp hello
   if( printSystemCommands )
     printf("mv %s %s\n", tmpbinname, resultName);
-
-  err = llvm::sys::fs::rename(tmpbinname, resultName);
+  err = chpl::moveFile(tmpbinname, resultName);
   if (err) {
-    // But that might fail if /tmp is on a different filesystem.
-
-    std::string mv("mv ");
-    mv += tmpbinname;
-    mv += " ";
-    mv += resultName;
-
-    mysystem(mv.c_str(), mv.c_str());
-
-    /* For future LLVM,
-       err = llvm::sys::fs::copy_file(tmpbinname, resultName);
-       if (err) {
-         USR_FATAL("copying file %s to %s failed: %s\n",
-                   tmpbinname,
-                   resultName,
-                   err.message().c_str());
-       }
-
-       // and then set permissions, like mv
-       auto maybePerms = llvm::sys::fs::getPermissions(tmpbinname);
-       if (maybePerms.getError()) {
-         USR_FATAL("reading permissions on %s failed: %s\n",
-                   tmpbinname,
-                   err.message().c_str());
-       }
-       err = llvm::sys::fs::setPermissions(resultName, *maybePerms);
-       if (err) {
-         USR_FATAL("setting permissions on %s failed: %s\n",
-                   resultName,
-                   err.message().c_str());
-       }
-
-       // and then remove the file, so it's like mv
-       err = llvm::sys::fs::remove(tmpbinname);
-       if (err) {
-         USR_FATAL("removing file %s failed: %s\n",
-                   tmpbinname,
-                   err.message().c_str());
-       }*/
+    USR_FATAL("Moving temporary binary '%s' to '%s' failed: %s\n",
+              tmpbinname,
+              resultName,
+              err.message().c_str());
   }
 }
 

--- a/frontend/include/chpl/util/filesystem.h
+++ b/frontend/include/chpl/util/filesystem.h
@@ -182,6 +182,8 @@ HashFileResult hashString(llvm::StringRef data);
 std::error_code copyModificationTime(const llvm::Twine& srcPath,
                                      const llvm::Twine& dstPath);
 
+std::error_code moveFile(const llvm::Twine& srcPath,
+                         const llvm::Twine& dstPath);
 
 } // end namespace chpl
 


### PR DESCRIPTION
Switches some code that uses the pattern `fork/join + exec (mv, ...)` to rename files, since that can mess up a debug session during codegen (specifically codegenPartTwo).

Resolves https://github.com/chapel-lang/chapel/issues/25672

- [x] paratest

[Reviewed by @DanilaFe]