### PR TITLE
Fix build issue with SMP launcher and clang on MacOS

### DIFF
--- a/runtime/src/chpl-launcher-common.c
+++ b/runtime/src/chpl-launcher-common.c
@@ -154,7 +154,7 @@ void chpl_append_to_cmd(char** cmdBufPtr, int* charsWritten,
 int
 chpl_run_utility1K(const char *command, char *const argv[], char *outbuf, int outbuflen) {
   const int buflen = 1024;
-  char buf[buflen];
+  char buf[/*buflen*/1024];
   char *cur;
   int fdo[2], outfd;
   int fde[2], errfd;


### PR DESCRIPTION
Fixes a build issue on MacOS with Apple clang version 17.0.0 (clang-1700.3.19.1), where the compiler would warn (and then error) about a usage of a VLA. This PR removes the VLA

[Reviewed by @]