### PR TITLE
Revert "Adjust cls-test-venv to be correct (#27800)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,9 @@ test-venv: third-party-test-venv
 chapel-py-venv: frontend-shared
 	$(MAKE) third-party-chapel-py-venv
 
+cls-test-venv: FORCE chapel-py-venv
+	cd third-party && $(MAKE) cls-test-venv
+
 chpldoc: third-party-chpldoc-venv
 	@cd third-party && $(MAKE) llvm
 	cd compiler && $(MAKE) chpldoc
@@ -159,6 +162,11 @@ always-build-chpldoc: FORCE
 always-build-chapel-py: FORCE
 	-@if [ -n "$$CHPL_ALWAYS_BUILD_CHAPEL_PY" ]; then \
 	$(MAKE) chapel-py-venv; \
+	fi
+
+always-build-cls-test: FORCE
+	-@if [ -n "$$CHPL_ALWAYS_BUILD_CHAPEL_PY_TEST" ]; then \
+	$(MAKE) cls-test-venv; \
 	fi
 
 always-build-chplcheck: FORCE

--- a/Makefile.devel
+++ b/Makefile.devel
@@ -75,17 +75,6 @@ frontend-tests:
 
 test-dyno: FORCE test-frontend
 
-always-build-cls-test: FORCE
-	-@if [ -n "$$CHPL_ALWAYS_BUILD_CHAPEL_PY_TEST" ]; then \
-	$(MAKE) cls-test-venv; \
-	fi
-
-third-party-test-cls-venv: FORCE
-	cd third-party && $(MAKE) cls-test-venv;
-
-cls-test-venv: frontend-shared
-	$(MAKE) third-party-test-cls-venv
-
 test-cls test-chpl-language-server: FORCE
 	@$(MAKE) chpl-language-server
 	@cd tools/chpl-language-server && $(MAKE) test-chpl-language-server

--- a/third-party/chpl-venv/Makefile
+++ b/third-party/chpl-venv/Makefile
@@ -138,6 +138,7 @@ cls-test-venv: chapel-py-venv
 	CHPL_HOME=$(CHPL_MAKE_HOME) $(PIP) install \
 	  $(CHPL_PIP_INSTALL_PARAMS) $(LOCAL_PIP_FLAGS) \
 	  --target $(CHPL_VENV_CHPL_FRONTEND_PY_DEPS) \
+	  $(CHPL_MAKE_HOME)/tools/chapel-py \
 	  -r $(CHPL_VENV_CLS_TEST_REQUIREMENTS_FILE)
 	@# Using --upgrade above breaks the test venv, because there's a bug
 	@# in its interaction with --target. As a result, this command does


### PR DESCRIPTION
Backing this out due to smoke test failures, being on triage, and being busy, so being conservative imagining that if this wasn't worth breaking the 2.6 freeze over, it's probably something we can live without for another day..

This reverts commit 601b6e5021a3871f1357994b16ac8a65520ebff6, reversing changes made to f6980da77bdb68eccbd12ea384702aaac012b7f1.
