### PR TITLE
Adjust cls-test-venv to be actually correct

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,6 @@ comprt: FORCE
 	@$(MAKE) always-build-test-venv
 	@$(MAKE) always-build-chpldoc
 	@$(MAKE) always-build-chapel-py
-	@$(MAKE) always-build-cls-test
 	@$(MAKE) always-build-chplcheck
 	@$(MAKE) always-build-cls
 	@$(MAKE) runtime

--- a/Makefile
+++ b/Makefile
@@ -140,9 +140,6 @@ test-venv: third-party-test-venv
 chapel-py-venv: frontend-shared
 	$(MAKE) third-party-chapel-py-venv
 
-cls-test-venv: FORCE chapel-py-venv
-	cd third-party && $(MAKE) cls-test-venv
-
 chpldoc: third-party-chpldoc-venv
 	@cd third-party && $(MAKE) llvm
 	cd compiler && $(MAKE) chpldoc
@@ -162,11 +159,6 @@ always-build-chpldoc: FORCE
 always-build-chapel-py: FORCE
 	-@if [ -n "$$CHPL_ALWAYS_BUILD_CHAPEL_PY" ]; then \
 	$(MAKE) chapel-py-venv; \
-	fi
-
-always-build-cls-test: FORCE
-	-@if [ -n "$$CHPL_ALWAYS_BUILD_CHAPEL_PY_TEST" ]; then \
-	$(MAKE) cls-test-venv; \
 	fi
 
 always-build-chplcheck: FORCE

--- a/Makefile.devel
+++ b/Makefile.devel
@@ -21,6 +21,7 @@ export CHPL_MAKE_PYTHON := $(shell $(CHPL_MAKE_HOME)/util/config/find-python.sh)
 develall:
 	@$(MAKE) always-build-man
 	@$(MAKE) always-build-chplspell-venv
+	@$(MAKE) always-build-cls-test
 
 docs: chpldoc man-chpl man-chpldoc
 	cd doc && $(MAKE) docs

--- a/Makefile.devel
+++ b/Makefile.devel
@@ -75,6 +75,17 @@ frontend-tests:
 
 test-dyno: FORCE test-frontend
 
+always-build-cls-test: FORCE
+	-@if [ -n "$$CHPL_ALWAYS_BUILD_CHAPEL_PY_TEST" ]; then \
+	$(MAKE) cls-test-venv; \
+	fi
+
+third-party-test-cls-venv: FORCE
+	cd third-party && $(MAKE) cls-test-venv;
+
+cls-test-venv: frontend-shared
+	$(MAKE) third-party-test-cls-venv
+
 test-cls test-chpl-language-server: FORCE
 	@$(MAKE) chpl-language-server
 	@cd tools/chpl-language-server && $(MAKE) test-chpl-language-server

--- a/third-party/chpl-venv/Makefile
+++ b/third-party/chpl-venv/Makefile
@@ -138,7 +138,6 @@ cls-test-venv: chapel-py-venv
 	CHPL_HOME=$(CHPL_MAKE_HOME) $(PIP) install \
 	  $(CHPL_PIP_INSTALL_PARAMS) $(LOCAL_PIP_FLAGS) \
 	  --target $(CHPL_VENV_CHPL_FRONTEND_PY_DEPS) \
-	  $(CHPL_MAKE_HOME)/tools/chapel-py \
 	  -r $(CHPL_VENV_CLS_TEST_REQUIREMENTS_FILE)
 	@# Using --upgrade above breaks the test venv, because there's a bug
 	@# in its interaction with --target. As a result, this command does


### PR DESCRIPTION
Adjusts the cls-test-venv Makefile target to properly create the cls test venv. 

Reapplies https://github.com/chapel-lang/chapel/pull/27800, plus some fixes now that `cls-test-venv` is only in `Makefile.devel`

- [x] `make test-cls-venv`
- [x] `make` from a tarball is not broken

[Reviewed by @DanilaFe]