### PR TITLE
Make the nightly Arkouda venv persist after nightly finishes

### DIFF
--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -135,7 +135,7 @@ if [ ${CHPL_TEST_ARKOUDA_STOP_AFTER_BUILD} = "false" ]; then
   if ! python3 -m pip install --force-reinstall --timeout 60 $AK_PIP_CONTRAINTS -e .[dev] ; then
     log_fatal_error "installing arkouda"
   else
-    log "Use 'source $ARKOUDA_TEST_VENV/bin/activate' to activate the venv"
+    log "Use 'source $(pwd)/$ARKOUDA_TEST_VENV/bin/activate' to activate the venv"
   fi
 
   # Check installation


### PR DESCRIPTION
This PR makes the Python venv created by the nightly run persist instead of removing it after run finishes.

I want to be able to use the nightly venv (alongside the server itself, which persists) for manual testing and debugging afterwards. This PR should hopefully enable that.