### PR TITLE
CLS: inlays for `enum` elements' values

### DIFF
--- a/tools/chapel-py/src/method-tables/param-methods.h
+++ b/tools/chapel-py/src/method-tables/param-methods.h
@@ -46,6 +46,11 @@ CLASS_BEGIN(IntParam)
                int, return node->value())
 CLASS_END(IntParam)
 
+CLASS_BEGIN(UintParam)
+  PLAIN_GETTER(UintParam, value, "Get the value of this unsigned integer Param",
+               unsigned int, return node->value())
+CLASS_END(UintParam)
+
 CLASS_BEGIN(StringParam)
   PLAIN_GETTER(StringParam, value, "Get the value of this string Param",
                chpl::UniqueString, return node->value())

--- a/tools/chapel-py/src/method-tables/uast-methods.h
+++ b/tools/chapel-py/src/method-tables/uast-methods.h
@@ -571,6 +571,18 @@ CLASS_END(NamedDecl)
 CLASS_BEGIN(EnumElement)
   PLAIN_GETTER(EnumElement, init_expression, "Get the init expression of this EnumElement node",
                Nilable<const chpl::uast::AstNode*>, return node->initExpression())
+  PLAIN_GETTER(EnumElement, assigned_value, "Get the 'param' value assigned to this EnumElement node, either directly or via sequence increment",
+               Nilable<const chpl::types::Param*>,
+               auto parentId = node->id().parentSymbolId(context);
+               auto& numericValues = chpl::resolution::computeNumericValuesOfEnumElements(context, parentId);
+
+               auto it = numericValues.find(node->id());
+               if (it != numericValues.end()) {
+                 return it->second.param();
+               }
+
+               return nullptr;
+               )
 CLASS_END(EnumElement)
 
 CLASS_BEGIN(Function)

--- a/tools/chapel-py/src/python-types.h
+++ b/tools/chapel-py/src/python-types.h
@@ -238,6 +238,7 @@ std::string nilableTypeString() {
 
 DEFINE_INOUT_TYPE(bool, "bool", PyBool_FromLong(TO_WRAP), PyLong_AsLong(TO_UNWRAP));
 DEFINE_INOUT_TYPE(int, "int", Py_BuildValue("i", TO_WRAP), PyLong_AsLong(TO_UNWRAP));
+DEFINE_INOUT_TYPE(unsigned int, "int", Py_BuildValue("I", TO_WRAP), PyLong_AsUnsignedLong(TO_UNWRAP));
 DEFINE_INOUT_TYPE(const char*, "str", Py_BuildValue("s", TO_WRAP), getCStringFromPyObjString(TO_UNWRAP));
 DEFINE_INOUT_TYPE(chpl::UniqueString, "str", Py_BuildValue("s", TO_WRAP.c_str()), chpl::UniqueString::get(&CONTEXT->value_, getCStringFromPyObjString(TO_UNWRAP)));
 DEFINE_INOUT_TYPE(std::string, "str", Py_BuildValue("s", TO_WRAP.c_str()), std::string(getCStringFromPyObjString(TO_UNWRAP)));

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -389,7 +389,7 @@ class ChapelLanguageServer(LanguageServer):
         return [
             InlayHint(
                 position=position,
-                label=[InlayHintLabelPart(value)],
+                label=value,
                 text_edits=edits,
             )
         ]

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -139,6 +139,7 @@ class ChapelLanguageServer(LanguageServer):
         self.type_inlays: bool = config.get("type_inlays")
         self.literal_arg_inlays: bool = config.get("literal_arg_inlays")
         self.param_inlays: bool = config.get("param_inlays")
+        self.enum_inlays: bool = config.get("enum_inlays")
         self.dead_code: bool = config.get("dead_code")
         self.eval_expressions: bool = config.get("eval_expressions")
         self.show_instantiations: bool = config.get("show_instantiations")
@@ -355,6 +356,44 @@ class ChapelLanguageServer(LanguageServer):
         if uri in self.configurations:
             del self.configurations[uri]
 
+    def _get_enum_inlays(self, decl: NodeAndRange) -> List[InlayHint]:
+        if not self.enum_inlays:
+            return []
+
+        node = decl.node
+        if not isinstance(node, chapel.EnumElement):
+            return []
+
+        enum_value = node.assigned_value()
+        inlay_value: str | None = None
+        if isinstance(enum_value, chapel.IntParam):
+            inlay_value = str(enum_value.value())
+        elif isinstance(enum_value, chapel.UintParam):
+            inlay_value = str(enum_value.value())
+
+        if not inlay_value:
+            return []
+
+        node_init = node.init_expression()
+        edits = []
+        if isinstance(node_init, chapel.Literal):
+            return []
+        elif isinstance(node_init, chapel.AstNode):
+            position = location_to_range(node_init.location()).end
+            value = " /* " + inlay_value + " */"
+        else:
+            position = location_to_range(node.location()).end
+            value = " = " + inlay_value
+            edits = [TextEdit(Range(position, position), value)]
+
+        return [
+            InlayHint(
+                position=position,
+                label=[InlayHintLabelPart(value)],
+                text_edits=edits,
+            )
+        ]
+
     def _get_param_inlays(
         self, decl: NodeAndRange, qt: chapel.QualifiedType
     ) -> List[InlayHint]:
@@ -428,15 +467,17 @@ class ChapelLanguageServer(LanguageServer):
         if not self.use_resolver:
             return []
 
+        inlays = []
+        inlays.extend(self._get_enum_inlays(decl))
+
         rr = decl.node.resolve_via(via) if via else decl.node.resolve()
         if not rr:
-            return []
+            return inlays
 
         qt = rr.type()
         if qt is None:
-            return []
+            return inlays
 
-        inlays = []
         inlays.extend(self._get_param_inlays(decl, qt))
         inlays.extend(self._get_type_inlays(decl, qt))
         return inlays

--- a/tools/chpl-language-server/src/lsp_util.py
+++ b/tools/chpl-language-server/src/lsp_util.py
@@ -1351,6 +1351,9 @@ class CLSConfig:
             self.parser, "param-inlays", "param_inlays", True
         )
         chplcheck().config.add_bool_flag(
+            self.parser, "enum-inlays", "enum_inlays", True
+        )
+        chplcheck().config.add_bool_flag(
             self.parser, "literal-arg-inlays", "literal_arg_inlays", True
         )
         chplcheck().config.add_bool_flag(

--- a/tools/chpl-language-server/test/enum_inlays.py
+++ b/tools/chpl-language-server/test/enum_inlays.py
@@ -1,0 +1,72 @@
+"""
+Test that enum value inlays show up properly, Requires `--resolver`.
+"""
+
+import sys
+
+from lsprotocol.types import ClientCapabilities
+from lsprotocol.types import InitializeParams
+import pytest
+import pytest_lsp
+from pytest_lsp import ClientServerConfig, LanguageClient
+
+from util.utils import *
+from util.config import CLS_PATH
+
+
+@pytest_lsp.fixture(
+    config=ClientServerConfig(
+        server_command=[
+            sys.executable,
+            CLS_PATH(),
+            "--resolver",
+            "--enum-inlays",
+        ],
+        client_factory=get_base_client,
+    )
+)
+async def client(lsp_client: LanguageClient):
+    # Setup
+    params = InitializeParams(capabilities=ClientCapabilities())
+    await lsp_client.initialize_session(params)
+
+    yield
+
+    # Teardown
+    await lsp_client.shutdown_session()
+
+
+@pytest.mark.asyncio
+async def test_enum_inlays(client: LanguageClient):
+    """
+    Ensure that type inlays are shown for primitive types.
+    """
+
+    file = """
+            enum color {
+              red = 1,
+              green,
+              blue,
+              cyan = green : int + 10,
+              magenta,
+              yellow
+            }
+           """
+
+    inlays = [
+        (pos((2, 7)), " = 2"),
+        (pos((3, 6)), " = 3"),
+        (pos((4, 25)), " /* 12 */"),
+        (pos((5, 9)), " = 13"),
+        (pos((6, 8)), " = 14"),
+    ]
+
+    async with source_file(client, file) as doc:
+        await check_enum_inlay_hints(
+            client, doc, rng((0, 0), endpos(file)), inlays
+        )
+
+        # check that specifying a range works
+        await check_enum_inlay_hints(
+            client, doc, rng((0, 0), (4, 0)), inlays[:2]
+        )

--- a/tools/chpl-language-server/test/util/utils.py
+++ b/tools/chpl-language-server/test/util/utils.py
@@ -351,7 +351,7 @@ async def check_goto_decl_def(
             typing.Union[
                 Location, typing.List[Location], typing.List[LocationLink]
             ]
-        ]
+        ],
     ):
         if dst is None:
             assert results is None or (
@@ -396,7 +396,7 @@ async def check_goto_type_def(
             typing.Union[
                 Location, typing.List[Location], typing.List[LocationLink]
             ]
-        ]
+        ],
     ):
         if dst is None:
             assert results is None or (
@@ -536,12 +536,12 @@ async def check_enum_inlay_hints(
     client: LanguageClient,
     doc: TextDocumentIdentifier,
     rng: Range,
-    expected_inlays: Sequence[
-        typing.Tuple[Position, str]
-    ],
+    expected_inlays: Sequence[typing.Tuple[Position, str]],
 ) -> typing.List[InlayHint]:
     standardized_inlays = [(i[0], i[1], None) for i in expected_inlays]
-    actual_inlays = await check_inlay_hints(client, doc, rng, standardized_inlays)
+    actual_inlays = await check_inlay_hints(
+        client, doc, rng, standardized_inlays
+    )
 
     # Check that the '= bla' inlays are insertable
     for inlay in actual_inlays:

--- a/tools/chpl-language-server/test/util/utils.py
+++ b/tools/chpl-language-server/test/util/utils.py
@@ -532,6 +532,34 @@ async def check_inlay_hints(
     return results
 
 
+async def check_enum_inlay_hints(
+    client: LanguageClient,
+    doc: TextDocumentIdentifier,
+    rng: Range,
+    expected_inlays: Sequence[
+        typing.Tuple[Position, str]
+    ],
+) -> typing.List[InlayHint]:
+    standardized_inlays = [(i[0], i[1], None) for i in expected_inlays]
+    actual_inlays = await check_inlay_hints(client, doc, rng, standardized_inlays)
+
+    # Check that the '= bla' inlays are insertable
+    for inlay in actual_inlays:
+        label = inlay.label
+        if isinstance(label, list):
+            label = "".join([part.value for part in label])
+
+        if label.startswith(" = "):
+            # the list of inlay text edits should have one element and have the
+            # same text/range as the inlay
+            assert inlay.text_edits is not None
+            assert len(inlay.text_edits) == 1
+            assert inlay.text_edits[0].range.start == inlay.position
+            assert inlay.text_edits[0].new_text == label
+
+    return actual_inlays
+
+
 async def check_type_inlay_hints(
     client: LanguageClient,
     doc: TextDocumentIdentifier,


### PR DESCRIPTION
This PR adds inlays for computed values of `enum` elements, showing them as `= bla` when there's no init expression, and as `/* bla */` if there is a nontrivial init expression. The net result is as follows:

<img width="435" height="207" alt="Screenshot 2025-09-18 at 11 09 12 AM" src="https://github.com/user-attachments/assets/a26a84a0-8da5-4f51-8157-96b28568c581" />

This is implemented by exposing the already-existing `computeNumericValuesOfEnumElements` function through the `EnumElement` AST node.

## Testing
- [x] `make test-cls`