### PR TITLE
dyno: Make the compiler crash if early-resolved AST is mutated

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -2971,7 +2971,14 @@ void AggregateType::addClassToHierarchy(std::set<AggregateType*>& localSeen) {
       auto istmt = ImplementsStmt::build(isym, ifcActuals, nullptr);
       getEnclosingBlockForImplements(this->symbol)->insertAtTail(istmt);
 
-      expr->remove();
+      // TODO: The typed converter need to add code supporting interfaces.
+      //       For at least a little while it will need to defer to the
+      //       production compiler for some things, because interfaces are
+      //       not fully implemented in dyno.
+      EARLY_RESOLVED_AST_MUTATION([=](){
+        expr->remove();
+      });
+
       continue;
     }
 

--- a/compiler/AST/baseAST.cpp
+++ b/compiler/AST/baseAST.cpp
@@ -52,6 +52,8 @@
 #include <sstream>
 #include <string>
 
+bool BaseAST::canMutateEarlyResolvedSymbols = true;
+
 //
 // declare global vectors gSymExprs, gCallExprs, gFnSymbols, ...
 //

--- a/compiler/AST/baseAST.cpp
+++ b/compiler/AST/baseAST.cpp
@@ -431,6 +431,25 @@ bool BaseAST::wasResolvedEarly() {
   return false;
 }
 
+bool BaseAST::canMutateEarly() {
+  // OK, we are at a point where everything can be mutated.
+  if (canMutateEarlyResolvedSymbols) return true;
+
+  // OK, this was not created by the typed converter.
+  if (!wasResolvedEarly()) return true;
+
+  // OK, this is a module, so we can mutate its contents.
+  if (isModuleSymbol(this)) return true;
+
+  // OK, it's an expression contained in a module.
+  if (auto e = toExpr(this)) {
+    if (isModuleSymbol(e->parentSymbol)) return true;
+  }
+
+  // NO, cannot mutate.
+  return false;
+}
+
 bool BaseAST::isRef() {
   return this->qualType().isRef();
 }

--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -51,7 +51,7 @@ class FnSymbol;
 
 // Macro to crash if the AST being mutated was resolved by the frontend.
 #define BASE_AST_CRASH_IF_RESOLVED_EARLY(ast__) do { \
-  if (!BaseAST::canMutateEarlyResolvedSymbols && ast__->wasResolvedEarly()) { \
+  if (!ast__->canMutateEarly()) { \
     INT_FATAL(ast__, "Cannot mutate AST that is or is contained in an " \
                      "early resolved symbol!"); \
   } \

--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -49,6 +49,14 @@
 
 class FnSymbol;
 
+// Macro to crash if the AST being mutated was resolved by the frontend.
+#define BASE_AST_CRASH_IF_RESOLVED_EARLY(ast__) do { \
+  if (!BaseAST::canMutateEarlyResolvedSymbols && ast__->wasResolvedEarly()) { \
+    INT_FATAL(ast__, "Cannot mutate AST that is or is contained in an " \
+                     "early resolved symbol!"); \
+  } \
+} while (0)
+
 // some prototypes
 
 /************************************ | *************************************
@@ -309,6 +317,8 @@ void Expr::prettyPrint(std::ostream *o) {
 }
 
 Expr* Expr::remove() {
+  BASE_AST_CRASH_IF_RESOLVED_EARLY(this);
+
   if (list) {
     if (next)
       next->prev = prev;
@@ -340,6 +350,9 @@ Expr* Expr::remove() {
 
 
 void Expr::replace(Expr* new_ast) {
+  BASE_AST_CRASH_IF_RESOLVED_EARLY(this);
+  BASE_AST_CRASH_IF_RESOLVED_EARLY(new_ast);
+
   if (new_ast->parentSymbol || new_ast->parentExpr)
     INT_FATAL(new_ast, "Argument is already in AST in Expr::replace");
   if (new_ast->list)
@@ -378,6 +391,9 @@ void Expr::replace(Expr* new_ast) {
 
 
 void Expr::insertBefore(Expr* new_ast) {
+  BASE_AST_CRASH_IF_RESOLVED_EARLY(this);
+  BASE_AST_CRASH_IF_RESOLVED_EARLY(new_ast);
+
   if (new_ast->parentSymbol || new_ast->parentExpr)
     INT_FATAL(new_ast, "Argument is already in AST in Expr::insertBefore");
   if (!list)
@@ -398,6 +414,9 @@ void Expr::insertBefore(Expr* new_ast) {
 }
 
 void Expr::insertAfter(Expr* new_ast) {
+  BASE_AST_CRASH_IF_RESOLVED_EARLY(this);
+  BASE_AST_CRASH_IF_RESOLVED_EARLY(new_ast);
+
   if (new_ast->parentSymbol || new_ast->parentExpr)
     INT_FATAL(new_ast, "Argument is already in AST in Expr::insertAfter");
   if (!list)

--- a/compiler/include/baseAST.h
+++ b/compiler/include/baseAST.h
@@ -307,6 +307,18 @@ private:
   Type*             getWideRefType();
 };
 
+// This function lets you deliberately perform some mutation on AST that
+// was resolved early. You pass it a function/closure that does the
+// mutation. Note that if you decide to make an exception you should note
+// it (write a TODO), and make a work item describing what needs to be
+// implemented in the typed converter.
+template <typename F>
+void EARLY_RESOLVED_AST_MUTATION(F function) {
+  BaseAST::canMutateEarlyResolvedSymbols = true;
+  function();
+  BaseAST::canMutateEarlyResolvedSymbols = false;
+}
+
 GenRet baseASTCodegen(BaseAST* ast);
 GenRet baseASTCodegenInt(int x);
 GenRet baseASTCodegenString(const char* str);

--- a/compiler/include/baseAST.h
+++ b/compiler/include/baseAST.h
@@ -270,6 +270,10 @@ public:
   // symbols inserted into it that the old compiler generated).
   bool              wasResolvedEarly();
 
+  // Set to 'true' after a specific point in the 'callDestructors' pass to
+  // indicate that AST marked with 'FLAG_RESOLVED_EARLY' can be mutated.
+  static bool       canMutateEarlyResolvedSymbols;
+
   bool              isRef();
   bool              isWideRef();
   bool              isRefOrWideRef();

--- a/compiler/include/baseAST.h
+++ b/compiler/include/baseAST.h
@@ -282,6 +282,8 @@ public:
   bool              isRef();
   bool              isWideRef();
   bool              isRefOrWideRef();
+  Symbol*           getParentSymbol();
+  Symbol*           getSymbol();
   FnSymbol*         getFunction();
   ModuleSymbol*     getModule();
   Type*             getValType();

--- a/compiler/include/baseAST.h
+++ b/compiler/include/baseAST.h
@@ -270,6 +270,11 @@ public:
   // symbols inserted into it that the old compiler generated).
   bool              wasResolvedEarly();
 
+  // This AST was created by the typed converter but it is allowed to be
+  // mutated (e.g., it is a 'ModuleSymbol', which can contain a mix of
+  // early-resolved and late-resolved symbols).
+  bool              canMutateEarly();
+
   // Set to 'true' after a specific point in the 'callDestructors' pass to
   // indicate that AST marked with 'FLAG_RESOLVED_EARLY' can be mutated.
   static bool       canMutateEarlyResolvedSymbols;

--- a/compiler/include/clangUtil.h
+++ b/compiler/include/clangUtil.h
@@ -111,6 +111,7 @@ void initializeGenInfo(void);
 // appends clang arguments to be used to the provided vector
 void computeClangArgs(std::vector<std::string>& clangCCArgs);
 void runClang(const char* just_parse_filename);
+void saveExternBlock(ModuleSymbol* module, const char* externCode);
 
 bool lookupInExternBlock(ModuleSymbol* module, const char* name,
                          clang::TypeDecl** cTypeOut,

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -3323,9 +3323,7 @@ void runClang(const char* just_parse_filename) {
   }
 }
 
-static
-void saveExternBlock(ModuleSymbol* module, const char* extern_code)
-{
+void saveExternBlock(ModuleSymbol* module, const char* externCode) {
   if( ! gAllExternCode.filename ) {
     openCFile(&gAllExternCode, "extern-code", "c");
     INT_ASSERT(gAllExternCode.fptr);
@@ -3341,7 +3339,7 @@ void saveExternBlock(ModuleSymbol* module, const char* extern_code)
   FILE* f = module->extern_info->file.fptr;
   INT_ASSERT(f);
   // Append the C code to that file.
-  fputs(extern_code, f);
+  fputs(externCode, f);
   // Always make sure it ends in a close semi (solves errors)
   fputs("\n;\n", f);
   // Add this module to the set of modules needing extern compilation.

--- a/compiler/passes/convert-typed-uast.cpp
+++ b/compiler/passes/convert-typed-uast.cpp
@@ -1693,7 +1693,7 @@ FnSymbol* TConverter::findOrConvertTupleInit(const types::TupleType* tt) {
   INT_ASSERT(at);
 
   // Otherwise, construct it.
-  FnSymbol* ret = new FnSymbol("chpl__tuple_init");
+  FnSymbol* ret = new FnSymbol("init");
 
   auto _this = new ArgSymbol(INTENT_REF, "this", newType);
   _this->addFlag(FLAG_ARG_THIS);
@@ -1734,22 +1734,30 @@ FnSymbol* TConverter::findOrConvertTupleInit(const types::TupleType* tt) {
                                    new SymExpr(arg)));
   }
 
+  // End with an empty return to keep 'verify' happy.
+  ret->insertAtTail(new CallExpr(PRIM_RETURN));
+
   ret->addFlag(FLAG_RESOLVED);
   ret->addFlag(FLAG_RESOLVED_EARLY);
-  ret->addFlag(FLAG_ALLOW_REF);
   ret->addFlag(FLAG_COMPILER_GENERATED);
+
   ret->addFlag(FLAG_LAST_RESORT);
   ret->addFlag(FLAG_INLINE);
   ret->addFlag(FLAG_INVISIBLE_FN);
+  ret->addFlag(FLAG_ALLOW_REF);
+
   ret->addFlag(FLAG_INIT_TUPLE);
   ret->addFlag(FLAG_SUPPRESS_LVALUE_ERRORS);
+
+  // TODO: What the heck does this flag do? I see only one use of it in the
+  //       entire compiler, can we/should we remove it once the TC goes live?
   ret->addFlag(FLAG_PARTIAL_TUPLE);
+
+  // Set the intializer to return 'void'.
   ret->retTag = RET_VALUE;
-  ret->retType = newType;
+  ret->retType = dtVoid;
 
   ret->substitutions.copy(newType->substitutions);
-  CallExpr* primReturn = new CallExpr(PRIM_RETURN, _this);
-  ret->insertAtTail(primReturn);
 
   // TODO: Do we need to set this?
   BlockStmt* instantiationPoint = nullptr;

--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -4037,6 +4037,7 @@ Converter::convertToplevelModule(const chpl::uast::Module* mod,
 
   topLevelModTag = modTag;
   ModuleSymbol* ret = convertModule(mod);
+
   return ret;
 }
 

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -1761,6 +1761,9 @@ bool AddEndOfStatementMarkers::enterCallExpr(CallExpr* node) {
 bool AddEndOfStatementMarkers::enterDefExpr(DefExpr* node) {
   VarSymbol* var = toVarSymbol(node->sym);
 
+  // Do not descend into symbols we cannot mutate.
+  if (!node->sym->canMutateEarly()) return false;
+
   if (var != NULL && !var->hasFlag(FLAG_TEMP)) {
     // Scroll forward to find a PRIM_END_OF_STATEMENT
     // (these are added in the parser along with DefExprs)
@@ -1795,6 +1798,9 @@ static void addEndOfStatementMarkers(BaseAST* base) {
 // non-normalized expression is also non-normalizable. Locate the root of
 // the non-normalized expression.
 Expr* partOfNonNormalizableExpr(Expr* expr) {
+
+  // The expression cannot be mutated early, so do not.
+  if (!expr->canMutateEarly()) return expr;
 
   // Anything contained in a non-normalizable expr is non-normalizable.
   for (Expr* node = expr; node; node = node->parentExpr) {

--- a/compiler/passes/parseAndConvert.cpp
+++ b/compiler/passes/parseAndConvert.cpp
@@ -1204,4 +1204,7 @@ void parseAndConvertUast() {
     }
   }
   parsed = true;
+
+  // Allow no mutation of AST generated as a result of this pass (globally).
+  BaseAST::canMutateEarlyResolvedSymbols = false;
 }

--- a/compiler/passes/parseAndConvert.cpp
+++ b/compiler/passes/parseAndConvert.cpp
@@ -1175,8 +1175,6 @@ void parseAndConvertUast() {
   reorderInternalModules();
   gatherWellKnown();
 
-  // add the default uses for all modules
-  // TODO: why do we need to do this?
   forv_Vec(ModuleSymbol, mod, allModules) {
     mod->addDefaultUses();
   }

--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -2195,11 +2195,6 @@ void callDestructors() {
   pm.runPass(AutoDestroyLoopExprTemps(), gCallExprs);
   pm.runPass(InsertDestructorCalls(), gCallExprs);
   pm.runPass(LowerAutoDestroyRuntimeType(), gCallExprs);
-
-  // TODO: Move this to a different pass and don't consider this to be
-  // part of 'callDestructors', as it seems like an optimization.
-  ReturnByRef::apply();
-
   pm.runPass(InsertCopiesForYields(), gCallExprs);
 
   lateConstCheck(NULL);
@@ -2213,7 +2208,15 @@ void callDestructors() {
   checkForErroneousInitCopies();
 
   // Allow mutation of frontend-generation symbols now!
+  //
+  // After this point all transformations can be applied to any AST regardless
+  // of when it was generated. This is considered to be the "end" of the
+  // 'callDestructors' pass as far as the typed converter is concerned.
+  //
   BaseAST::canMutateEarlyResolvedSymbols = true;
+
+  // Make certain functions return via a ref formal. TODO: Can remove?
+  ReturnByRef::apply();
 
   // This always needs to run since the frontend doesn't do lifetime checking.
   checkLifetimesAndNilDereferences();

--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -2212,11 +2212,13 @@ void callDestructors() {
 
   checkForErroneousInitCopies();
 
+  // Allow mutation of frontend-generation symbols now!
+  BaseAST::canMutateEarlyResolvedSymbols = true;
+
+  // This always needs to run since the frontend doesn't do lifetime checking.
   checkLifetimesAndNilDereferences();
 
-  // TODO: Interprocedural, mutates all Vars/Args/ShadowVars of a given type.
-  // TODO: Break out "removeUselessCasts()" into its own pass?
-  // TODO: I think 'dyno' can handle all of this elegantly.
+  // TODO: This pass can be removed when the typed converter comes online.
   convertClassTypesToCanonical();
 
   pm.runPass(CallDestructorsCallCleanup(), gCallExprs);

--- a/compiler/resolution/cleanups.cpp
+++ b/compiler/resolution/cleanups.cpp
@@ -715,7 +715,7 @@ static void removeWhereClausesAndReturnTypeBlocks() {
   }
 }
 
-static void removeMootFields() {
+static void removeTypeAndParamFields() {
   // Remove type fields and parameter fields
   for_alive_in_Vec(TypeSymbol, ts, gTypeSymbols) {
     if (AggregateType* at = toAggregateType(ts->type)) {
@@ -1070,7 +1070,12 @@ void pruneResolvedTree() {
 
   removeWhereClausesAndReturnTypeBlocks();
 
-  removeMootFields();
+  // TODO: This removes type and param fields which are required for the
+  //       old resolver to function properly when considering early-resolved
+  //       instantiations (so we cannot just remove them early on in the
+  //       typed converter). However, later passes expect these fields to be
+  //       removed. It can be removed when we stop using the old resolver.
+  EARLY_RESOLVED_AST_MUTATION(removeTypeAndParamFields);
 
   removeSymbolsWithRemovedTypes();
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -13024,8 +13024,10 @@ static void insertReturnTemps() {
   // because we do not support sync/singles for minimal modules.
   //
   for_alive_in_expanding_Vec(CallExpr, call, gCallExprs) {
-      if (call->list == NULL && isForallRecIterHelper(call))
-        continue;
+      if (!call->canMutateEarly()) continue;
+
+      if (call->list == NULL && isForallRecIterHelper(call)) continue;
+
       if (FnSymbol* fn = call->resolvedOrVirtualFunction()) {
         if (fn->retType != dtVoid && fn->retType != dtUnknown &&
             fn->retTag != RET_TYPE) {


### PR DESCRIPTION
This PR adds a mechanism which makes the old compiler crash when it tries to mutate any AST contained in a `Symbol*` marked with the flag `FLAG_RESOLVED_EARLY`. This will greatly help development of the new typed converter because it allows developers to:

- Have more confidence that it is the typed converter producing correct AST, rather than the old normalizer/resolver
- More easily determine what old code must be preserved when a crash is triggered

Along the way, it adds two new methods to `BaseAST` called `getSymbol` and `getParentSymbol`, which fetch the containing symbol and the parent symbol of the current AST, respectively.