### PR TITLE
Workaround system issues by building on a compute node

### DIFF
--- a/util/cron/common-hpe-cray-ex.bash
+++ b/util/cron/common-hpe-cray-ex.bash
@@ -18,3 +18,6 @@ export CHPL_HOST_PLATFORM=hpe-cray-ex
 # Work around cxi provider bugs that limit memory registration
 export CHPL_RT_MAX_HEAP_SIZE="50%"
 export CHPL_LAUNCHER_MEM=unset
+
+# both partitions we use have 128 cores
+export CHPL_NIGHTLY_MAKE="srun --partition=\$CHPL_LAUNCHER_PARTITION --cpus-per-task=128 make"

--- a/util/cron/test-hpe-cray-ex-ofi.bash
+++ b/util/cron/test-hpe-cray-ex-ofi.bash
@@ -10,7 +10,7 @@ source $UTIL_CRON_DIR/common-hpe-cray-ex.bash
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="hpe-cray-ex-ofi"
 export CHPL_RT_COMM_OFI_EXPECTED_PROVIDER="cxi"
 export CHPL_RT_MAX_HEAP_SIZE=16g
-export SLURM_PARTITION=bardpeak
+export CHPL_LAUNCHER_PARTITION=bardpeak
 
 
 # test a small subset of all tests due to limited resources


### PR DESCRIPTION
Attempts to fix some nightly test failures caused system issues by building on a compute node

Tested with the following to emulate what `nightly` does
```bash
export CHPL_NIGHTLY_DO_NOTHING=1
source util/cron/test-gpu-ex-rocm-62.ofi.bash
perl test.pl
```

```perl
# test.pl
$make = "";
if (exists($ENV{'CHPL_NIGHTLY_MAKE'})) {
    $make = $ENV{'CHPL_NIGHTLY_MAKE'};
} elsif (exists($ENV{'MAKE'})) {
    $make = $ENV{'MAKE'};
} else {
    $make = `$utildir/chplenv/chpl_make.py`;
    chomp($make);
}
print "Using make: $make\n";
system("set -x && $make -j128");
```

[Reviewed by @e-kayrakli]