### PR TITLE
Homebrew accept upstream arm64 build fix

### DIFF
--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -141,7 +141,7 @@ class Chapel < Formula
 
     # Install chpl and other binaries (e.g. chpldoc) into bin/ as exec scripts.
     platform = if OS.linux? && Hardware::CPU.is_64_bit?
-      "linux64-#{Hardware::CPU.arch}"
+      "linux64-#{Hardware::CPU.arm? ? "aarch64" : Hardware::CPU.arch}"
     else
       "#{OS.kernel_name.downcase}-#{Hardware::CPU.arch}"
     end


### PR DESCRIPTION
Incorporate the fix from https://github.com/Homebrew/homebrew-core/pull/218983 into our `chapel-main.rb` formula copy.

I noticed this while diffing `chapel-main.rb` against the formula copy in https://github.com/Homebrew/homebrew-core/pull/244962 to make sure I had included everything, and realized we never incorporated this downstream change. I think we ought to so we don't unintentionally make changes that conflict with or break it.

[reviewer info placeholder]