### PR TITLE
Apply Homebrew macOS Tahoe ld warning fix

### DIFF
--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -188,6 +188,9 @@ class Chapel < Formula
   end
 
   test do
+    # Hide ld warning until formula uses LLVM 21+ or if we apply backports to `llvm@20`
+    ENV["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version.to_s if OS.mac? && MacOS.version >= :tahoe
+
     ENV["CHPL_HOME"] = libexec
     ENV["CHPL_INCLUDE_PATH"] = HOMEBREW_PREFIX/"include"
     ENV["CHPL_LIB_PATH"] = HOMEBREW_PREFIX/"lib"


### PR DESCRIPTION
Applies change from downstream PR https://github.com/Homebrew/homebrew-core/pull/245118.

[trivial, not reviewed]