### PR TITLE
Change the runtime to always compile with the C gnu11 standard

### DIFF
--- a/make/compiler/Makefile.clang
+++ b/make/compiler/Makefile.clang
@@ -144,7 +144,10 @@ SQUASH_WARN_GEN_CFLAGS += -Wno-tautological-compare
 #
 # warn for unwanted GNU extension usages
 #
-RUNTIME_GNU_WARNINGS = -Wgnu -Wno-gnu-folding-constant -Wno-zero-length-array -Wno-variadic-macro-arguments-omitted
+RUNTIME_GNU_WARNINGS = -Wgnu -Wno-gnu-folding-constant -Wno-zero-length-array
+ifeq ($(shell test $(CLANG_MAJOR_VERSION) -ge 20; echo "$$?"),0)
+RUNTIME_GNU_WARNINGS += -Wno-variadic-macro-arguments-omitted
+endif
 
 #
 # compiler warnings settings

--- a/make/compiler/Makefile.clang
+++ b/make/compiler/Makefile.clang
@@ -54,9 +54,9 @@ GEN_CFLAGS += $(SANITIZER_CFLAGS)
 GEN_LFLAGS += $(SANITIZER_LDFLAGS)
 
 #
-# We always use gnu17 and gnu++17 for the runtime
+# We always use gnu99 and gnu++11 for the runtime
 #
-C_STD := -std=gnu17
+C_STD := -std=gnu99
 CXX_STD := -std=gnu++11
 CXX11_STD := -std=gnu++11
 

--- a/make/compiler/Makefile.clang
+++ b/make/compiler/Makefile.clang
@@ -54,9 +54,9 @@ GEN_CFLAGS += $(SANITIZER_CFLAGS)
 GEN_LFLAGS += $(SANITIZER_LDFLAGS)
 
 #
-# We always use gnu99 and gnu++11 for the runtime
+# We always use gnu11 and gnu++11 for the runtime
 #
-C_STD := -std=gnu99
+C_STD := -std=gnu11
 CXX_STD := -std=gnu++11
 CXX11_STD := -std=gnu++11
 

--- a/make/compiler/Makefile.clang
+++ b/make/compiler/Makefile.clang
@@ -54,24 +54,11 @@ GEN_CFLAGS += $(SANITIZER_CFLAGS)
 GEN_LFLAGS += $(SANITIZER_LDFLAGS)
 
 #
-# If the compiler's default C version is less than C99, force C99 mode.
+# We always use gnu17 and gnu++17 for the runtime
 #
-# If the default C version is at least C11, force the C++ version to
-# be at least C++11 to match.
-#
-ifneq ($(CHPL_MAKE_COMPILER), llvm)
-DEF_C_VER := $(shell echo __STDC_VERSION__ | $(CC) -E -x c - | sed -e '/^\#/d' -e 's/L$$//' -e 's/__STDC_VERSION__/0/')
-DEF_CXX_VER := $(shell echo __cplusplus | $(CXX) -E -x c++ - | sed -e '/^\#/d' -e 's/L$$//' -e 's/__cplusplus/0/')
-C_STD := $(shell test $(DEF_C_VER) -lt 199901 && echo -std=gnu99)
-CXX_STD := $(shell test $(DEF_C_VER) -ge 201112 -a $(DEF_CXX_VER) -lt 201103 && echo -std=gnu++11)
-CXX11_STD := $(shell test $(DEF_CXX_VER) -lt 201103 && echo -std=gnu++11)
-else
-# when CHPL_MAKE_COMPILER=llvm, we are using at least LLVM/clang 11,
-# which defaults to supporting C17 and C++14.
-C_STD :=
-CXX_STD :=
-CXX11_STD :=
-endif
+C_STD := -std=gnu17
+CXX_STD := -std=gnu++11
+CXX11_STD := -std=gnu++11
 
 ifndef CLANG_MAJOR_VERSION
 export CLANG_MAJOR_VERSION := $(shell $(CC) -dumpversion | awk '{split($$1,a,"."); printf("%s", a[1]);}')
@@ -155,13 +142,18 @@ SQUASH_WARN_GEN_CFLAGS += -Wno-incompatible-pointer-types
 SQUASH_WARN_GEN_CFLAGS += -Wno-tautological-compare
 
 #
+# warn for unwanted GNU extension usages
+#
+RUNTIME_GNU_WARNINGS = -Wgnu -Wno-gnu-folding-constant -Wno-zero-length-array -Wno-variadic-macro-arguments-omitted
+
+#
 # compiler warnings settings
 #
 ifeq ($(WARNINGS), 1)
 COMP_CFLAGS += $(WARN_CFLAGS)
 COMP_CXXFLAGS += $(WARN_CXXFLAGS)
-RUNTIME_CFLAGS += $(WARN_CFLAGS) -Wno-char-subscripts
-RUNTIME_CXXFLAGS += $(WARN_CXXFLAGS)
+RUNTIME_CFLAGS += $(WARN_CFLAGS) -Wno-char-subscripts $(RUNTIME_GNU_WARNINGS)
+RUNTIME_CXXFLAGS += $(WARN_CXXFLAGS) $(RUNTIME_GNU_WARNINGS)
 #WARN_GEN_CFLAGS += -Wunreachable-code
 # GEN_CFLAGS gets warnings added via WARN_GEN_CFLAGS in comp-generated Makefile
 

--- a/make/compiler/Makefile.clang
+++ b/make/compiler/Makefile.clang
@@ -144,7 +144,7 @@ SQUASH_WARN_GEN_CFLAGS += -Wno-tautological-compare
 #
 # warn for unwanted GNU extension usages
 #
-RUNTIME_GNU_WARNINGS = -Wgnu -Wno-gnu-folding-constant -Wno-zero-length-array
+RUNTIME_GNU_WARNINGS = -Wgnu -Wno-gnu-folding-constant -Wno-zero-length-array -Wno-gnu-zero-variadic-macro-arguments
 ifeq ($(shell test $(CLANG_MAJOR_VERSION) -ge 20; echo "$$?"),0)
 RUNTIME_GNU_WARNINGS += -Wno-variadic-macro-arguments-omitted
 endif

--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -385,7 +385,7 @@ SQUASH_WARN_GEN_CFLAGS += -Wno-strict-overflow
 #  can change the programs runtime behavior (when -O2 or greater is tossed).
 endif
 
-RUNTIME_GNU_WARNINGS = -Wgnu -Wno-gnu-folding-constant -Wno-zero-length-array -Wno-gnu-zero-variadic-macro-arguments
+RUNTIME_GNU_WARNINGS = -Wno-vla
 
 #
 # compiler warnings settings

--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -146,19 +146,10 @@ export GNU_GCC_SUPPORTS_STRICT_OVERFLOW := $(shell test $(GNU_GCC_MAJOR_VERSION)
 endif
 
 #
-# If the compiler's default C version is less than C99, force C99 mode.
+# We always use gnu17 and gnu++17 for the runtime
 #
-# If the default C version is at least C11, force the C++ version to
-# be at least C++11 to match.
-#
-DEF_C_VER := $(shell echo __STDC_VERSION__ | $(CC) -E -x c - | sed -e '/^\#/d' -e 's/L$$//' -e 's/__STDC_VERSION__/0/')
-ifneq ($(MAKE_LAUNCHER),1)
-DEF_CXX_VER := $(shell  echo __cplusplus | $(CXX) -E -x c++ - | sed -e '/^\#/d' -e 's/L$$//' -e 's/__cplusplus/0/';)
-else
-DEF_CXX_VER := 2017
-endif
-C_STD := $(shell test $(DEF_C_VER) -lt 199901 && echo -std=gnu99)
-CXX_STD := $(shell test $(DEF_C_VER) -ge 201112 -a $(DEF_CXX_VER) -lt 201103 && echo -std=gnu++11)
+C_STD := -std=gnu17
+CXX_STD := -std=gnu11
 
 # CXX11_STD is the flag to select C++11, blank for compilers that
 # don't know how to do that

--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -146,9 +146,9 @@ export GNU_GCC_SUPPORTS_STRICT_OVERFLOW := $(shell test $(GNU_GCC_MAJOR_VERSION)
 endif
 
 #
-# We always use gnu17 and gnu++17 for the runtime
+# We always use gnu99 and gnu++11 for the runtime
 #
-C_STD := -std=gnu17
+C_STD := -std=gnu99
 CXX_STD := -std=gnu11
 CXX11_STD := -std=gnu++11
 

--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -385,14 +385,16 @@ SQUASH_WARN_GEN_CFLAGS += -Wno-strict-overflow
 #  can change the programs runtime behavior (when -O2 or greater is tossed).
 endif
 
+RUNTIME_GNU_WARNINGS = -Wgnu -Wno-gnu-folding-constant -Wno-zero-length-array -Wno-gnu-zero-variadic-macro-arguments
+
 #
 # compiler warnings settings
 #
 ifeq ($(WARNINGS), 1)
 COMP_CFLAGS += $(WARN_CFLAGS)
 COMP_CXXFLAGS += $(WARN_CXXFLAGS)
-RUNTIME_CFLAGS += $(WARN_CFLAGS) -Wno-char-subscripts
-RUNTIME_CXXFLAGS += $(WARN_CXXFLAGS)
+RUNTIME_CFLAGS += $(WARN_CFLAGS) -Wno-char-subscripts $(RUNTIME_GNU_WARNINGS)
+RUNTIME_CXXFLAGS += $(WARN_CXXFLAGS) $(RUNTIME_GNU_WARNINGS)
 #WARN_GEN_CFLAGS += -Wunreachable-code
 # GEN_CFLAGS gets warnings added via WARN_GEN_CFLAGS in comp-generated Makefile
 

--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -150,11 +150,7 @@ endif
 #
 C_STD := -std=gnu17
 CXX_STD := -std=gnu11
-
-# CXX11_STD is the flag to select C++11, blank for compilers that
-# don't know how to do that
-# Also, if a compiler uses C++11 or newer by default, CXX11_STD will be blank.
-CXX11_STD := $(shell test $(DEF_CXX_VER) -lt 201103 && echo -std=gnu++11)
+CXX11_STD := -std=gnu++11
 
 COMP_CFLAGS += $(C_STD)
 RUNTIME_CFLAGS += $(C_STD)

--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -149,7 +149,7 @@ endif
 # We always use gnu11 and gnu++11 for the runtime
 #
 C_STD := -std=gnu11
-CXX_STD := -std=gnu11
+CXX_STD := -std=gnu++11
 CXX11_STD := -std=gnu++11
 
 COMP_CFLAGS += $(C_STD)

--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -146,9 +146,9 @@ export GNU_GCC_SUPPORTS_STRICT_OVERFLOW := $(shell test $(GNU_GCC_MAJOR_VERSION)
 endif
 
 #
-# We always use gnu99 and gnu++11 for the runtime
+# We always use gnu11 and gnu++11 for the runtime
 #
-C_STD := -std=gnu99
+C_STD := -std=gnu11
 CXX_STD := -std=gnu11
 CXX11_STD := -std=gnu++11
 

--- a/make/compiler/Makefile.intel
+++ b/make/compiler/Makefile.intel
@@ -47,9 +47,9 @@ PROFILE_LFLAGS = -pg
 
 
 #
-# We always use gnu17 and gnu++17 for the runtime
+# We always use gnu99 and gnu++11 for the runtime
 #
-C_STD := -std=gnu17
+C_STD := -std=gnu99
 CXX_STD := -std=gnu++11
 CXX11_STD := -std=gnu++11
 

--- a/make/compiler/Makefile.intel
+++ b/make/compiler/Makefile.intel
@@ -47,16 +47,11 @@ PROFILE_LFLAGS = -pg
 
 
 #
-# If the compiler's default C version is less than C99, force C99 mode.
+# We always use gnu17 and gnu++17 for the runtime
 #
-# If the default C version is at least C11, force the C++ version to
-# be at least C++11 to match.
-#
-DEF_C_VER := $(shell echo __STDC_VERSION__ | $(CC) -E -x c - | sed -e '/^\#/d' -e 's/L$$//' -e 's/__STDC_VERSION__/0/')
-DEF_CXX_VER := $(shell echo __cplusplus | $(CXX) -E -x c++ - | sed -e '/^\#/d' -e 's/L$$//' -e 's/__cplusplus/0/')
-C_STD := $(shell test $(DEF_C_VER) -lt 199901 && echo -std=gnu99)
-CXX_STD := $(shell test $(DEF_C_VER) -ge 201112 -a $(DEF_CXX_VER) -lt 201103 && echo -std=gnu++11)
-CXX11_STD := $(shell test $(DEF_CXX_VER) -lt 201103 && echo -std=gnu++11)
+C_STD := -std=gnu17
+CXX_STD := -std=gnu++11
+CXX11_STD := -std=gnu++11
 
 #
 # Flags for compiler, runtime, and generated code

--- a/make/compiler/Makefile.intel
+++ b/make/compiler/Makefile.intel
@@ -47,9 +47,9 @@ PROFILE_LFLAGS = -pg
 
 
 #
-# We always use gnu99 and gnu++11 for the runtime
+# We always use gnu11 and gnu++11 for the runtime
 #
-C_STD := -std=gnu99
+C_STD := -std=gnu11
 CXX_STD := -std=gnu++11
 CXX11_STD := -std=gnu++11
 


### PR DESCRIPTION
Changes the runtime to always compile with the C gnu11 standard, regardless of the minimum version of the C standard supported by that compiler. This change only affects clang, gnu, and intel compilers

- [x] `CHPL_DEVELOPER=1 make` with clang on mac
- [x] `CHPL_DEVELOPER=1 make` with gcc on linux64
- [x] `CHPL_DEVELOPER=1 make` with clang on mac with gasnet
- [x] `CHPL_DEVELOPER=1 make` with gcc on linux64 with gasnet


[Reviewed by @benharsh]

resolves https://github.com/chapel-lang/chapel/issues/27826
resolves https://github.com/Cray/chapel-private/issues/7654