### PR TITLE
Deprecate Cray XC/ugni support

### DIFF
--- a/util/chplenv/chpl_comm.py
+++ b/util/chplenv/chpl_comm.py
@@ -4,7 +4,7 @@ import os
 import re
 
 import overrides
-from utils import memoize, check_valid_var, which
+from utils import memoize, check_valid_var, which, warning
 
 
 @memoize
@@ -38,6 +38,10 @@ def get():
                 comm_val = 'none'
 
     check_valid_var("CHPL_COMM", comm_val, ("none", "gasnet", "ofi", "ugni"))
+
+    if comm_val == 'ugni':
+        warning("The 'ugni' communication layer is deprecated and will be removed in a future release")
+
     return comm_val
 
 

--- a/util/chplenv/chpl_platform.py
+++ b/util/chplenv/chpl_platform.py
@@ -6,7 +6,7 @@ import re
 import sys
 
 import overrides, utils
-from utils import error, memoize, try_run_command
+from utils import error, memoize, try_run_command, warning
 
 
 @memoize
@@ -64,6 +64,9 @@ def get(flag='host'):
                 platform_val = 'netbsd64'
             else:
                 platform_val = 'netbsd32'
+
+    if platform_val == 'cray-xc' and flag == 'target':
+        warning("Cray XC support is deprecated and will be removed in a future release")
 
     return platform_val
 


### PR DESCRIPTION
Deprecates Cray XC/ugni support

Per discussion in https://github.com/chapel-lang/chapel/issues/27823

Note, users will get two deprecation warnings, one for the platform being `PLATFORM=cray-xc` and the other for `COMM=ugni`

Resolves #27823

[Reviewed by @DanilaFe]