### PR TITLE
Fix nightly failures caused by debug changes

### DIFF
--- a/test/execflags/bradc/gdbddash/SUPPRESSIF
+++ b/test/execflags/bradc/gdbddash/SUPPRESSIF
@@ -1,0 +1,1 @@
+COMPOPTS <= --verify

--- a/test/execflags/lldbddash/SUPPRESSIF
+++ b/test/execflags/lldbddash/SUPPRESSIF
@@ -1,0 +1,1 @@
+COMPOPTS <= --verify

--- a/test/library/standard/Debugger/breakpoint/useBreakpoint-gdb.suppressif
+++ b/test/library/standard/Debugger/breakpoint/useBreakpoint-gdb.suppressif
@@ -1,3 +1,4 @@
 # running lldb on multi-locale code is not yet well supported
 CHPL_COMM!=none
 COMPOPTS <= --no-local
+COMPOPTS <= --verify

--- a/test/library/standard/Debugger/breakpoint/useBreakpoint-lldb.suppressif
+++ b/test/library/standard/Debugger/breakpoint/useBreakpoint-lldb.suppressif
@@ -1,3 +1,4 @@
 # running lldb on multi-locale code is not yet well supported
 CHPL_COMM!=none
 COMPOPTS <= --no-local
+COMPOPTS <= --verify

--- a/test/llvm/dbg-intrinsics/SUPPRESSIF
+++ b/test/llvm/dbg-intrinsics/SUPPRESSIF
@@ -1,0 +1,1 @@
+COMPOPTS <= --verify

--- a/test/llvm/dbg-records/SUPPRESSIF
+++ b/test/llvm/dbg-records/SUPPRESSIF
@@ -1,0 +1,1 @@
+COMPOPTS <= --verify

--- a/test/llvm/debugInfo/SUPPRESSIF
+++ b/test/llvm/debugInfo/SUPPRESSIF
@@ -1,0 +1,1 @@
+COMPOPTS <= --verify

--- a/test/llvm/debugInfo/dwarfdump/SUPPRESSIF
+++ b/test/llvm/debugInfo/dwarfdump/SUPPRESSIF
@@ -1,2 +1,3 @@
 CHPL_COMM!=none
 COMPOPTS <= --no-local
+COMPOPTS <= --verify

--- a/test/llvm/debugInfo/gdb/basicTypes.suppressif
+++ b/test/llvm/debugInfo/gdb/basicTypes.suppressif
@@ -1,3 +1,4 @@
 # running gdb on multi-locale code is not yet well supported
 CHPL_COMM!=none
 COMPOPTS <= --no-local
+COMPOPTS <= --verify

--- a/test/llvm/debugInfo/gdb/targetVar.suppressif
+++ b/test/llvm/debugInfo/gdb/targetVar.suppressif
@@ -1,3 +1,4 @@
 # running gdb on multi-locale code is not yet well supported
 CHPL_COMM!=none
 COMPOPTS <= --no-local
+COMPOPTS <= --verify

--- a/test/llvm/debugInfo/lldb/PREDIFF
+++ b/test/llvm/debugInfo/lldb/PREDIFF
@@ -20,6 +20,10 @@ mv $file.tmp $file
 grep -v 'command script import' $file > $file.tmp
 mv $file.tmp $file
 
+# remove breakpoint command add
+grep -v 'breakpoint command add' $file > $file.tmp
+mv $file.tmp $file
+
 # remove the OpenCL warnings
 sed -E -e '/OpenCL/d' $file > $file.tmp
 mv $file.tmp $file

--- a/test/llvm/debugInfo/lldb/basicTypes.good
+++ b/test/llvm/debugInfo/lldb/basicTypes.good
@@ -4,7 +4,6 @@ Current executable set to EXECUTABLE
 Executing commands in FILE.txt
 (lldb) breakpoint set -n debuggerBreakHere -N debuggerBreakHere
 Breakpoint
-(lldb) breakpoint command add -o up debuggerBreakHere
 (lldb) command source -s 0 'basicTypesCommands.txt'
 Executing commands in FILE.txt
 (lldb) r
@@ -20,13 +19,6 @@ Executing commands in FILE.txt
 41 42 43 44 45
 46 47 48 49 50
 true | 42 | 3.14 | e2 | e2 | (1, two, 3.0, e1)
-(lldb)  up
-frame #1: 0xXXXX basicTypes`chpl_user_main at basicTypes.chpl:74
-   71  	  writeln(myDom, myArr, myArr2d, sep=" | ");
-   72  	  writeln(myBool, myInt, myReal, myEnumVal, myEnumRef, myTuple, sep=" | ");
-   73
--> 74  	  use Debugger; breakpoint;
-   75  	}
 Process XXXX stopped
 * Thread #X, stop reason = breakpoint 1.1
     frame #1: 0xXXXX basicTypes`chpl_user_main at basicTypes.chpl:74

--- a/test/llvm/debugInfo/lldb/basicTypes.suppressif
+++ b/test/llvm/debugInfo/lldb/basicTypes.suppressif
@@ -1,3 +1,4 @@
 # running lldb on multi-locale code is not yet well supported
 CHPL_COMM!=none
 COMPOPTS <= --no-local
+COMPOPTS <= --verify

--- a/test/llvm/debugInfo/lldb/targetVar.good
+++ b/test/llvm/debugInfo/lldb/targetVar.good
@@ -4,7 +4,6 @@ Current executable set to EXECUTABLE
 Executing commands in FILE.txt
 (lldb) breakpoint set -n debuggerBreakHere -N debuggerBreakHere
 Breakpoint
-(lldb) breakpoint command add -o up debuggerBreakHere
 (lldb) command source -s 0 'targetVarCommands.txt'
 Executing commands in FILE.txt
 (lldb) b targetVar.chpl:5

--- a/test/llvm/debugInfo/lldb/targetVar.suppressif
+++ b/test/llvm/debugInfo/lldb/targetVar.suppressif
@@ -1,3 +1,4 @@
 # running lldb on multi-locale code is not yet well supported
 CHPL_COMM!=none
 COMPOPTS <= --no-local
+COMPOPTS <= --verify


### PR DESCRIPTION
Fixes some nightly failures caused by debug changes. Namely

- LLVM debug info will fail with --verify for now, so suppress
- output changed with LLDB, so remove the offending output