### PR TITLE
Add CHPL_CHECK_MAX_LOCALES to support limited environments

### DIFF
--- a/test/release/examples/hello6-taskpar-dist.nl-1.good
+++ b/test/release/examples/hello6-taskpar-dist.nl-1.good
@@ -1,0 +1,1 @@
+Hello, world! (from locale 0 of 1)

--- a/test/release/examples/hello6-taskpar-dist.nl-2.good
+++ b/test/release/examples/hello6-taskpar-dist.nl-2.good
@@ -1,0 +1,2 @@
+Hello, world! (from locale 0 of 2)
+Hello, world! (from locale 1 of 2)

--- a/util/test/checkChplInstall
+++ b/util/test/checkChplInstall
@@ -235,6 +235,7 @@ fi
 # if CHPL_CHECK_MAX_LOCALES is set, use it to cap NUMLOCALES
 if [ -n "${CHPL_CHECK_MAX_LOCALES}" ] ; then
     if [ ${NUMLOCALES} -gt ${CHPL_CHECK_MAX_LOCALES} ] ; then
+        NUMLOCALES=${CHPL_CHECK_MAX_LOCALES}
     fi
 fi
 

--- a/util/test/checkChplInstall
+++ b/util/test/checkChplInstall
@@ -235,8 +235,6 @@ fi
 # if CHPL_CHECK_MAX_LOCALES is set, use it to cap NUMLOCALES
 if [ -n "${CHPL_CHECK_MAX_LOCALES}" ] ; then
     if [ ${NUMLOCALES} -gt ${CHPL_CHECK_MAX_LOCALES} ] ; then
-        log_info "Capping NUMLOCALES=${NUMLOCALES} to ${CHPL_CHECK_MAX_LOCALES}, because \$CHPL_CHECK_MAX_LOCALES is set"
-        NUMLOCALES=${CHPL_CHECK_MAX_LOCALES}
     fi
 fi
 
@@ -268,6 +266,7 @@ TEST_EXEC_OUT=${TEST_JOB}.exec.out
     fi
 
     log_info "Running test job."
+    log_debug "Using ${NUMLOCALES} locales and execution options: ${EXEC_OPTS}"
     env $(echo ${EXEC_ENV} | xargs) \
       ./${TEST_JOB} -nl${NUMLOCALES} ${EXEC_OPTS} 2>&1 | sort > ${TEST_EXEC_OUT}
     log_info "Test job complete."

--- a/util/test/checkChplInstall
+++ b/util/test/checkChplInstall
@@ -232,6 +232,14 @@ else
     fi
 fi
 
+# if CHPL_CHECK_MAX_LOCALES is set, use it to cap NUMLOCALES
+if [ -n "${CHPL_CHECK_MAX_LOCALES}" ] ; then
+    if [ ${NUMLOCALES} -gt ${CHPL_CHECK_MAX_LOCALES} ] ; then
+        log_info "Capping NUMLOCALES=${NUMLOCALES} to ${CHPL_CHECK_MAX_LOCALES}, because \$CHPL_CHECK_MAX_LOCALES is set"
+        NUMLOCALES=${CHPL_CHECK_MAX_LOCALES}
+    fi
+fi
+
 # Check for valid launchers
 if [ ${chpl_launcher} == "slurm-srun" -o ${chpl_launcher} == "amudprun" -o ${chpl_launcher} == "smp" -o ${chpl_launcher} == "none" ]; then
     log_info "\$CHPL_LAUNCHER=${chpl_launcher} is compatible with test script."

--- a/util/test/checkChplInstall
+++ b/util/test/checkChplInstall
@@ -236,6 +236,10 @@ fi
 if [ -n "${CHPL_CHECK_MAX_LOCALES}" ] ; then
     if [ ${NUMLOCALES} -gt ${CHPL_CHECK_MAX_LOCALES} ] ; then
         NUMLOCALES=${CHPL_CHECK_MAX_LOCALES}
+        # if this is set, we probably need a locale specific good file
+        if [ -f ${TEST_DIR}/${TEST_JOB}.nl-${NUMLOCALES}.good ]; then
+            GOOD=${TEST_DIR}/${TEST_JOB}.nl-${NUMLOCALES}.good
+        fi
     fi
 fi
 


### PR DESCRIPTION
In some environments, like github actions, we may need to run `make check` with less than the number of locales requested by `hello6`. This PR allows that with the new internal env flag CHPL_CHECK_MAX_LOCALES

[Reviewed by @arifthpe]