### PR TITLE
Dyno: various fixes for `test/types`

### DIFF
--- a/frontend/lib/resolution/Resolver.h
+++ b/frontend/lib/resolution/Resolver.h
@@ -429,7 +429,7 @@ struct Resolver : BranchSensitiveVisitor<DefaultFrame> {
      This function resolves the types of all TypeQuery nodes
      contained in the passed Formal (by updating 'byPostorder').
    */
-  void resolveTypeQueriesFromFormalType(const uast::VarLikeDecl* formal,
+  void resolveTypeQueriesFromFormalType(const uast::Decl* formal,
                                         types::QualifiedType formalType);
 
   // helper for getTypeForDecl -- checks the Kinds are compatible

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -361,10 +361,16 @@ void CallInfo::prepareActual(Context* context,
           auto tupleType = actualType.type()->toTupleType();
           int n = tupleType->numElements();
           for (int i = 0; i < n; i++) {
-            tupleType->elementType(i);
+            auto qt = tupleType->elementType(i);
+            // the type expression (int, string) is that of a value tuple,
+            // so it has 'var' intents for the elements. But if we're splatting
+            // the type expression, we want to insert type actuals.
+            if (actualType.isType()) {
+              qt = QualifiedType(QualifiedType::TYPE, qt.type());
+            }
             // intentionally use the empty name (to ignore it if it was
             // set and we issued an error above)
-            actuals.push_back(CallInfoActual(tupleType->elementType(i),
+            actuals.push_back(CallInfoActual(qt,
                   UniqueString()));
             if (actualAsts != nullptr) {
               actualAsts->push_back(op);

--- a/frontend/test/resolution/testResolve.cpp
+++ b/frontend/test/resolution/testResolve.cpp
@@ -2374,6 +2374,30 @@ static void testSkipUnknownInNew() {
   assert(qt.type()->isRecordType());
 }
 
+// regression test. Allow for patterns in which a type formal etc. is
+// instantiated with a generic type, and we invke a type method on it,
+// which (according to production tests) is allowed.
+static void testTypeProcOnGenericReceiver() {
+  auto context = buildStdContext();
+  ErrorGuard guard(context);
+
+  auto qt = resolveTypeOfXInit(context,
+    R"""(
+    record R {
+      type t;
+      proc type tt type do return int;
+    }
+
+    proc foo(type arg1, type arg2 = arg1.tt) {
+      var tmp: arg2;
+      return tmp;
+    }
+    var x = foo(R(?));
+  )""");
+  assert(!qt.isUnknownOrErroneous());
+  assert(qt.type()->isIntType());
+}
+
 int main() {
   test1();
   test2();
@@ -2438,6 +2462,8 @@ int main() {
   testTupleFormalWithDefault();
 
   testSkipUnknownInNew();
+
+  testTypeProcOnGenericReceiver();
 
   return 0;
 }

--- a/frontend/test/resolution/testTuples.cpp
+++ b/frontend/test/resolution/testTuples.cpp
@@ -653,6 +653,21 @@ static void test16() {
   assert(qt.type()->isRealType());
 }
 
+static void test16b() {
+  printf("%s\n", __FUNCTION__);
+  auto context = buildStdContext();
+
+  auto qt = resolveQualifiedTypeOfX(context,
+                R""""(
+                  proc helper(type a, type b) type { return b; }
+                  type tup = (int, real);
+                  type x = helper( (... tup) );
+                )"""");
+
+  assert(qt.kind() == QualifiedType::TYPE);
+  assert(qt.type()->isRealType());
+}
+
 static void test17() {
   printf("%s\n", __FUNCTION__);
   auto context = buildStdContext();
@@ -1372,6 +1387,7 @@ int main() {
   test14();
   test15();
   test16();
+  test16b();
   test17();
   test18();
   test18b();

--- a/frontend/test/resolution/testTypeQueries.cpp
+++ b/frontend/test/resolution/testTypeQueries.cpp
@@ -958,6 +958,23 @@ static void test27() {
   }
 }
 
+static void test28() {
+  printf("%s\n", __FUNCTION__);
+  auto context = buildStdContext();
+  ErrorGuard guard(context);
+
+  auto vars = resolveTypesOfVariables(context,
+                R""""(
+                proc foo((t,): (int(?w),)) param {
+                  return w;
+                }
+                param x = foo((3, ));
+                )"""", {"x"});
+
+
+  ensureParamInt(vars.at("x"), 64);
+}
+
 int main() {
   test1();
   test2();
@@ -993,6 +1010,7 @@ int main() {
   test25b();
   test26();
   test27();
+  test28();
 
   return 0;
 }


### PR DESCRIPTION
Resolves all valid-program failures in `types/typdefs`, `types/typeFunctions`. Also resolves `types/tuple/BitWidthQueryInReturnTypeComponent`.

Each fix is its own change.

* Fixes tuple unpacking for tuple _types_. Prior to this change, `(...(1, 1.0))` and `(...(int, real))` had the exact same effect. After this change, the latter case passes `type` actuals (rather than `var` actuals), which is to be expected, since the whole thing is a tuple type, of which there aren't even necessarily values.
* Makes an adjustment to the handling for `x.foo` to trigger resolution of the field / parnless proc in more cases. This is necessary because some of our tests invoke `genericType.parenlessProc`, which is apparently fine and allowed. Prior, all generic types were skipped when resolving the dot, and thus, the `parenlessProc` call was skipped.
* Makes type queries work in tuple formals. Previously, type query expressions were only extracted for regular and vararg formals. This is in part due to the fact that tuple formals are not "var-like declarations" (since they can contain nested declarations). They do, however, still have type expressions that can be handled in the same way. This PR implements that.

## Testing
- [x] dyno tests
- [x] paratest
- [x] paratest `--dyno-resolve-only`

Reviewed by @benharsh -- thanks!