### PR TITLE
dlopen: Make the dynamic loading internals largely locale-agnostic

### DIFF
--- a/test/dynamic-loading/LoadForeignLibrary.comm-none.good
+++ b/test/dynamic-loading/LoadForeignLibrary.comm-none.good
@@ -18,3 +18,4 @@ Caught error!
 test3
 Caught error!
 test4
+test5

--- a/test/dynamic-loading/LoadForeignLibrary.good
+++ b/test/dynamic-loading/LoadForeignLibrary.good
@@ -39,3 +39,4 @@ Caught error!
 test3
 Caught error!
 test4
+test5


### PR DESCRIPTION
This PR improves the dynamic loading internals by making the code locale-agnostic instead of explicitly synchronizing on e.g., `Locales[0]`.

It also adjusts loaded binaries so that they live on the locale where `create` is first called rather than always being allocated on `Locales[0]`. It's unclear to me what benefit this might have (other than reducing contention on arguably the most contested locale in a program), but it also didn't feel right to have an explicit `Locales[0]` either. I go back and forth on whether or not binaries should be privatized, but ultimately it doesn't seem worth the cost (unlike a procedure pointer cache, which is accessed much more frequently).

While here, I've tweaked and removed some comments, opting to remove some that I found to be redundant. I've also added some more TODOs.