### PR TITLE
Dyno: support for partial type instantiations

### DIFF
--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -650,6 +650,13 @@ class CallInfo {
       with the ID of the scope that should be searched for candidates.
       That is, if the call expression is 'M.f(...)' for a module 'M', then
       'moduleScopeId' will be set to the ID of the module 'M'.
+
+      This method detects calls to type constructors where the type
+      being constructed is not yet known. if 'outIncompleteTypeConstructor' is
+      provided and not 'nullptr', sets '*outIncompleteTypeConstructor' to 'true'
+      when detecting such a call. In that case, the returned CallInfo
+      should not be resolved.
+
    */
   static CallInfo create(Context* context,
                          const uast::Call* call,
@@ -657,7 +664,8 @@ class CallInfo {
                          bool raiseErrors = true,
                          std::vector<const uast::AstNode*>* actualAsts=nullptr,
                          ID* moduleScopeId=nullptr,
-                         UniqueString rename = UniqueString());
+                         UniqueString rename = UniqueString(),
+                         bool* outIncompleteTypeConstructor = nullptr);
 
   /** Construct a CallInfo by adding a method receiver argument to
       the passed CallInfo. */

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -5294,11 +5294,7 @@ types::QualifiedType Resolver::typeForBooleanOp(const uast::OpCall* op) {
 }
 
 bool Resolver::enter(const Call* call) {
-  // At this time, we don't allow method calls in inheritance expressions,
-  // so we assume that there can't be overloading etc.
-  if (call != curInheritanceExpr) {
-    callNodeStack.push_back(call);
-  }
+  callNodeStack.push_back(call);
   auto op = call->toOpCall();
 
   if (op && initResolver) {
@@ -5706,9 +5702,7 @@ void Resolver::exit(const Call* call) {
 
   // Always remove the call from the stack if we pushed it there,
   // to make sure it's properly set.
-  if (call != curInheritanceExpr) {
-    callNodeStack.pop_back();
-  }
+  callNodeStack.pop_back();
 }
 
 bool Resolver::enter(const Dot* dot) {

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -228,7 +228,7 @@ setupCallForCopyOrMove(Resolver& resolver,
                         std::move(actuals));
   } else {
     // For other types, use `init=`.
-    auto varArg = QualifiedType(QualifiedType::VAR, lhsType.type(), lhsType.param());
+    auto varArg = QualifiedType(QualifiedType::INIT_RECEIVER, lhsType.type(), lhsType.param());
     actuals.push_back(CallInfoActual(varArg, USTR("this")));
     outAsts.push_back(ast);
     actuals.push_back(CallInfoActual(rhsType, UniqueString()));

--- a/frontend/lib/resolution/maybe-const.cpp
+++ b/frontend/lib/resolution/maybe-const.cpp
@@ -292,6 +292,13 @@ bool AdjustMaybeRefs::enter(const Call* ast, RV& rv) {
         // it was inferred, so we need to offset by one.
         const AstNode* actualAst = inferredReceiver ? actualAsts[actualIdx-1] :
                                                       actualAsts[actualIdx];
+
+        // we could've inserted synthetic actuals when making a second
+        // call to a partially instantiated type.
+        if (!actualAst) {
+          continue;
+        }
+
         Access access = accessForQualifier(fa->formalType().kind());
 
         exprStack.push_back(ExprStackEntry(actualAst, access,

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -6706,6 +6706,10 @@ bool addExistingSubstitutionsAsActuals(Context* context,
       auto fieldAst = parsing::idToAst(context, id)->toVarLikeDecl();
       if (fieldAst->storageKind() == QualifiedType::TYPE ||
           fieldAst->storageKind() == QualifiedType::PARAM) {
+        if (qt.isParam() && !qt.hasParamPtr()) {
+          // don't add param substitutions that are not known
+          continue;
+        }
         addedSubs = true;
         outActuals.emplace_back(qt, fieldAst->name());
         outActualAsts.push_back(nullptr);

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -428,6 +428,68 @@ static QualifiedType convertToInitReceiverType(const QualifiedType original) {
   return original;
 }
 
+static void prependActualFromSubstitutions(Context* context,
+                                           const QualifiedType& calledType,
+                                           std::vector<CallInfoActual>& actuals,
+                                           std::vector<const uast::AstNode*>* actualAsts) {
+  if (!calledType.type()) {
+    return;
+  }
+
+  std::vector<CallInfoActual> generatedActuals;
+  std::vector<const uast::AstNode*> generatedActualAsts;
+  if (!addExistingSubstitutionsAsActuals(context, calledType.type(),
+                                         generatedActuals, generatedActualAsts)) {
+    // didn't do anything; just return.
+    return;
+  }
+
+  // if the user is explicitly overriding a substitution, don't include the
+  // previous value, since that would double up the named actuals.
+  // Unnamed actuals are assumed to be sequentially mapped to the remaining
+  // (non-substituted) formals.
+
+  // find the user-mentioned actuals
+  std::set<UniqueString> existingNames;
+  for (const auto& actual : actuals) {
+    existingNames.insert(actual.byName());
+  }
+
+  // remove any generated actuals that the user has overridden
+  //   idx points to current element
+  //   firstToRemove points to the next available index to keep elements
+  // two-list implementation of: https://en.cppreference.com/w/cpp/algorithm/remove.html
+  size_t firstToRemove = 0;
+  for(; firstToRemove < generatedActuals.size(); firstToRemove++) {
+    if (existingNames.count(generatedActuals[firstToRemove].byName()) != 0) {
+      break;
+    }
+  }
+  for (size_t idx = firstToRemove; idx < generatedActuals.size(); idx++) {
+    if (existingNames.count(generatedActuals[idx].byName()) == 0) {
+      generatedActuals[firstToRemove] = std::move(generatedActuals[idx]);
+      generatedActualAsts[firstToRemove] = generatedActualAsts[idx];
+      firstToRemove++;
+    }
+  }
+  generatedActuals.erase(generatedActuals.begin() + firstToRemove,generatedActuals.end());
+  generatedActualAsts.erase(generatedActualAsts.begin() + firstToRemove,generatedActualAsts.end());
+
+  // move the user-provided actuals into the generated lists, then swap
+  generatedActuals.insert(generatedActuals.end(),
+                          std::make_move_iterator(actuals.begin()),
+                          std::make_move_iterator(actuals.end()));
+  actuals.swap(generatedActuals);
+  if (actualAsts != nullptr) {
+    generatedActualAsts.insert(generatedActualAsts.end(),
+                               std::make_move_iterator(actualAsts->begin()),
+                               std::make_move_iterator(actualAsts->end()));
+    actualAsts->swap(generatedActualAsts);
+  }
+}
+
+
+
 CallInfo CallInfo::create(Context* context,
                           const Call* call,
                           const ResolutionResultByPostorderID& byPostorder,
@@ -497,6 +559,7 @@ CallInfo CallInfo::create(Context* context,
         makeCallToDotThis();
       } else {
         calledType = *calledExprType;
+        prependActualFromSubstitutions(context, calledType, actuals, actualAsts);
       }
     } else if (!call->isOpCall() && dotReceiverType &&
                isKindForMethodReceiver(dotReceiverType->kind())) {

--- a/frontend/lib/resolution/signature-checks.cpp
+++ b/frontend/lib/resolution/signature-checks.cpp
@@ -66,7 +66,8 @@ static const bool& checkSignatureQuery(Context* context,
       context->error(errId, "Bad 'this' intent for init=");
     }
     bool rhsIntentGenericOrRef = isGenericQualifier(rhsIntent) ||
-                                 isRefQualifier(rhsIntent);
+                                 isRefQualifier(rhsIntent) ||
+                                 rhsIntent == Qualifier::PARAM;
     // check the intent of the rhs argument
     if (sig->formalType(0).type() == sig->formalType(1).type()) {
       // same-type case: only const/default/ref/const ref RHS is allowed

--- a/frontend/lib/resolution/signature-checks.cpp
+++ b/frontend/lib/resolution/signature-checks.cpp
@@ -65,19 +65,19 @@ static const bool& checkSignatureQuery(Context* context,
           (isInQualifier(thisIntent) && sig->formalType(0).type()->isClassType()))) {
       context->error(errId, "Bad 'this' intent for init=");
     }
-    bool rhsIntentGenericOrRef = isGenericQualifier(rhsIntent) ||
-                                 isRefQualifier(rhsIntent) ||
-                                 rhsIntent == Qualifier::PARAM;
+    bool rhsIntentGenericOrRefOrParam = isGenericQualifier(rhsIntent) ||
+                                        isRefQualifier(rhsIntent) ||
+                                        rhsIntent == Qualifier::PARAM;
     // check the intent of the rhs argument
     if (sig->formalType(0).type() == sig->formalType(1).type()) {
       // same-type case: only const/default/ref/const ref RHS is allowed
       // allow 'in' for borrowed RHS, such as when defining init= for a class.
-      if (!rhsIntentGenericOrRef && !sig->formalType(0).type()->isClassType()) {
+      if (!rhsIntentGenericOrRefOrParam && !sig->formalType(0).type()->isClassType()) {
         context->error(errId, "Bad intent for same-type init= other argument");
       }
     } else {
       // different-type case: RHS can be 'in' intent in addition
-      if (!(rhsIntentGenericOrRef || isInQualifier(rhsIntent))) {
+      if (!(rhsIntentGenericOrRefOrParam || isInQualifier(rhsIntent))) {
         context->error(errId, "Bad intent for cross-type init= other argument");
       }
     }

--- a/frontend/lib/types/CompositeType.cpp
+++ b/frontend/lib/types/CompositeType.cpp
@@ -59,6 +59,13 @@ static void stringifySortedSubstitutions(std::ostream& ss,
                                          const std::vector<SubstitutionPair>& sorted,
                                          bool& emittedField) {
   for (const auto& sub : sorted) {
+    if (sub.second.isParam() && sub.second.param() == nullptr &&
+        stringKind == StringifyKind::CHPL_SYNTAX) {
+      // we know the type of the param value, but not the value. Production
+      // doesn't print it.
+      continue;
+    }
+
     if (emittedField) ss << ", ";
 
     if (stringKind != StringifyKind::CHPL_SYNTAX) {
@@ -66,7 +73,7 @@ static void stringifySortedSubstitutions(std::ostream& ss,
       ss << ":";
       sub.second.stringify(ss, stringKind);
     } else {
-      if (sub.second.isType() || (sub.second.isParam() && sub.second.param() == nullptr)) {
+      if (sub.second.isType()) {
         sub.second.type()->stringify(ss, stringKind);
       } else if (sub.second.isParam()) {
         sub.second.param()->stringify(ss, stringKind);

--- a/frontend/test/resolution/testTypeConstruction.cpp
+++ b/frontend/test/resolution/testTypeConstruction.cpp
@@ -1503,6 +1503,169 @@ static void test44() {
   assert(pf.begin()->second.param()->toEnumParam()->value().str == "red");
 }
 
+static void testSubs(Context* context,
+                     const CompositeType* ct,
+                     const std::map<std::string, QualifiedType>& expected) {
+  assert(ct);
+  auto rc = createDummyRC(context);
+  auto fields =
+    fieldsForTypeDecl(&rc, ct, DefaultsPolicy::IGNORE_DEFAULTS);
+
+  for (int i = 0; i < fields.numFields(); i++) {
+    auto name = fields.fieldName(i);
+    auto fieldId = fields.fieldDeclId(i);
+
+    if (auto it = expected.find(name.str()); it != expected.end()) {
+      auto subit = ct->substitutions().find(fieldId);
+      assert(subit != ct->substitutions().end());
+      assert(subit->second == it->second);
+    } else {
+      assert(ct->substitutions().find(fieldId) == ct->substitutions().end());
+    }
+  }
+}
+
+static void ensureMatchingClassOrRecord(const QualifiedType& root, const QualifiedType& inst) {
+  assert(!root.isUnknownOrErroneous() && !inst.isUnknownOrErroneous());
+  assert((root.type()->isClassType() && inst.type()->isClassType()) ||
+         (root.type()->isRecordType() && inst.type()->isRecordType()));
+
+  if (auto rCt = root.type()->toClassType()) {
+    auto iCt = inst.type()->toClassType();
+    assert(rCt->manager() == iCt->manager());
+    assert(rCt->decorator() == iCt->decorator());
+  }
+  assert(root.type()->getCompositeType() ==
+         inst.type()->getCompositeType()->instantiatedFromCompositeType());
+}
+
+static void testPartialInstantiation() {
+  std::pair<const char*, const char*> cases[] = {
+    {"record", ""},
+    {"class", ""},
+    {"class", "shared "},
+    {"class", "owned "},
+    {"class", "unmanaged "}
+  };
+
+  size_t numCases = sizeof(cases) / sizeof(cases[0]);
+  for (size_t i = 0; i < numCases; i++) {
+    auto [aggregate, management] = cases[i];
+
+    std::string program = std::string(R"""(
+      )""") + aggregate + " triple { type fst; type snd; type thd; }" + R"""(
+
+      type root = )""" + management + R"""(triple(?);
+
+      type R__ = root(real, ?);
+      type R_B = R__(thd=bool, ?);
+      type RIB = R_B(snd=int, ?);
+
+      type r__ = root(real, ?);
+      type ri_ = r__(int, ?);
+      type rib = ri_(bool, ?);
+    )""";
+
+    printf("testPartialInstantiation basic: %s %s\n", aggregate, management);
+    printf("%s\n", program.c_str());
+
+    auto context = buildStdContext();
+    ErrorGuard guard(context);
+    auto vars = resolveTypesOfVariables(context, program.c_str(), {"root", "R__", "R_B", "RIB", "r__", "ri_", "rib"});
+
+    auto& rootInst = vars["root"];
+    assert(rootInst.type());
+    assert(rootInst.type()->getCompositeType());
+    assert(rootInst.type()->getCompositeType()->name() == "triple");
+    assert(rootInst.type()->getCompositeType()->instantiatedFromCompositeType() == nullptr);
+
+    auto I = QualifiedType(QualifiedType::TYPE, IntType::get(context, 0));
+    auto R = QualifiedType(QualifiedType::TYPE, RealType::get(context, 0));
+    auto B = QualifiedType(QualifiedType::TYPE, BoolType::get(context));
+
+    auto& R__ = vars["R__"];
+    testSubs(context, R__.type()->getCompositeType(), {{"fst", R}});
+    ensureMatchingClassOrRecord(rootInst, R__);
+    auto& R_B = vars["R_B"];
+    testSubs(context, R_B.type()->getCompositeType(), {{"fst", R}, {"thd", B}});
+    ensureMatchingClassOrRecord(rootInst, R_B);
+    auto& RIB = vars["RIB"];
+    testSubs(context, RIB.type()->getCompositeType(), {{"fst", R}, {"snd", I}, {"thd", B}});
+    ensureMatchingClassOrRecord(rootInst, RIB);
+
+    auto& r__ = vars["r__"];
+    testSubs(context, r__.type()->getCompositeType(), {{"fst", R}});
+    ensureMatchingClassOrRecord(rootInst, r__);
+    auto& ri_ = vars["ri_"];
+    testSubs(context, ri_.type()->getCompositeType(), {{"fst", R}, {"snd", I}});
+    ensureMatchingClassOrRecord(rootInst, ri_);
+    auto& rib = vars["rib"];
+    testSubs(context, rib.type()->getCompositeType(), {{"fst", R}, {"snd", I}, {"thd", B}});
+    ensureMatchingClassOrRecord(rootInst, rib);
+  }
+
+  for (size_t i = 0; i < numCases; i++) {
+    auto [aggregate, management] = cases[i];
+
+    std::string program = std::string(R"""(
+      )""") + aggregate + " triple { type fst; type snd; type thd; }" + R"""(
+
+      proc checkApply(type Constructor, type Arg, type Dummy: Constructor(Arg)) type {
+          return Constructor(Arg);
+      }
+      type root = )""" + management + R"""(triple(?);
+
+      type r__ = checkApply(root, real, root(real, int, bool));
+      type ri_ = checkApply(r__, int, root(real, int, bool));
+      type rib = checkApply(ri_, bool, root(real, int, bool));
+
+      type bad1 = checkApply(root, real, root(int, int, bool));
+      type bad2 = checkApply(r__, int, root(real, real, bool));
+      type bad3 = checkApply(ri_, bool, root(real, int, int));
+    )""";
+
+    printf("testPartialInstantiation formals: %s %s\n", aggregate, management);
+    printf("%s\n", program.c_str());
+
+    auto context = buildStdContext();
+    ErrorGuard guard(context);
+    auto vars = resolveTypesOfVariables(context, program.c_str(), {"root", "r__", "ri_", "rib", "bad1", "bad2", "bad3"});
+
+    auto& rootInst = vars["root"];
+    assert(rootInst.type());
+    assert(rootInst.type()->getCompositeType());
+    assert(rootInst.type()->getCompositeType()->name() == "triple");
+    assert(rootInst.type()->getCompositeType()->instantiatedFromCompositeType() == nullptr);
+
+    auto I = QualifiedType(QualifiedType::TYPE, IntType::get(context, 0));
+    auto R = QualifiedType(QualifiedType::TYPE, RealType::get(context, 0));
+    auto B = QualifiedType(QualifiedType::TYPE, BoolType::get(context));
+
+    auto& r__ = vars["r__"];
+    testSubs(context, r__.type()->getCompositeType(), {{"fst", R}});
+    ensureMatchingClassOrRecord(rootInst, r__);
+    auto& ri_ = vars["ri_"];
+    testSubs(context, ri_.type()->getCompositeType(), {{"fst", R}, {"snd", I}});
+    ensureMatchingClassOrRecord(rootInst, ri_);
+    auto& rib = vars["rib"];
+    testSubs(context, rib.type()->getCompositeType(), {{"fst", R}, {"snd", I}, {"thd", B}});
+    ensureMatchingClassOrRecord(rootInst, rib);
+
+    assert(vars["bad1"].isUnknownOrErroneous());
+    assert(vars["bad2"].isUnknownOrErroneous());
+    assert(vars["bad3"].isUnknownOrErroneous());
+
+    auto numNoMatchingCandidates = 0;
+    for (auto& err : guard.errors()) {
+      if (err->type() == ErrorType::NoMatchingCandidates) {
+        numNoMatchingCandidates++;
+      }
+    };
+    assert(numNoMatchingCandidates == 3);
+    guard.realizeErrors();
+  }
+}
+
 int main() {
   test1();
   test2();
@@ -1555,6 +1718,8 @@ int main() {
   testRecursiveTypeConstructorMutual();
   test43();
   test44();
+
+  testPartialInstantiation();
 
   return 0;
 }

--- a/frontend/test/resolution/testTypeConstruction.cpp
+++ b/frontend/test/resolution/testTypeConstruction.cpp
@@ -1503,28 +1503,6 @@ static void test44() {
   assert(pf.begin()->second.param()->toEnumParam()->value().str == "red");
 }
 
-static void testSubs(Context* context,
-                     const CompositeType* ct,
-                     const std::map<std::string, QualifiedType>& expected) {
-  assert(ct);
-  auto rc = createDummyRC(context);
-  auto fields =
-    fieldsForTypeDecl(&rc, ct, DefaultsPolicy::IGNORE_DEFAULTS);
-
-  for (int i = 0; i < fields.numFields(); i++) {
-    auto name = fields.fieldName(i);
-    auto fieldId = fields.fieldDeclId(i);
-
-    if (auto it = expected.find(name.str()); it != expected.end()) {
-      auto subit = ct->substitutions().find(fieldId);
-      assert(subit != ct->substitutions().end());
-      assert(subit->second == it->second);
-    } else {
-      assert(ct->substitutions().find(fieldId) == ct->substitutions().end());
-    }
-  }
-}
-
 static void ensureMatchingClassOrRecord(const QualifiedType& root, const QualifiedType& inst) {
   assert(!root.isUnknownOrErroneous() && !inst.isUnknownOrErroneous());
   assert((root.type()->isClassType() && inst.type()->isClassType()) ||
@@ -1584,23 +1562,23 @@ static void testPartialInstantiation() {
     auto B = QualifiedType(QualifiedType::TYPE, BoolType::get(context));
 
     auto& R__ = vars["R__"];
-    testSubs(context, R__.type()->getCompositeType(), {{"fst", R}});
+    ensureSubs(context, R__.type()->getCompositeType(), {{"fst", R}});
     ensureMatchingClassOrRecord(rootInst, R__);
     auto& R_B = vars["R_B"];
-    testSubs(context, R_B.type()->getCompositeType(), {{"fst", R}, {"thd", B}});
+    ensureSubs(context, R_B.type()->getCompositeType(), {{"fst", R}, {"thd", B}});
     ensureMatchingClassOrRecord(rootInst, R_B);
     auto& RIB = vars["RIB"];
-    testSubs(context, RIB.type()->getCompositeType(), {{"fst", R}, {"snd", I}, {"thd", B}});
+    ensureSubs(context, RIB.type()->getCompositeType(), {{"fst", R}, {"snd", I}, {"thd", B}});
     ensureMatchingClassOrRecord(rootInst, RIB);
 
     auto& r__ = vars["r__"];
-    testSubs(context, r__.type()->getCompositeType(), {{"fst", R}});
+    ensureSubs(context, r__.type()->getCompositeType(), {{"fst", R}});
     ensureMatchingClassOrRecord(rootInst, r__);
     auto& ri_ = vars["ri_"];
-    testSubs(context, ri_.type()->getCompositeType(), {{"fst", R}, {"snd", I}});
+    ensureSubs(context, ri_.type()->getCompositeType(), {{"fst", R}, {"snd", I}});
     ensureMatchingClassOrRecord(rootInst, ri_);
     auto& rib = vars["rib"];
-    testSubs(context, rib.type()->getCompositeType(), {{"fst", R}, {"snd", I}, {"thd", B}});
+    ensureSubs(context, rib.type()->getCompositeType(), {{"fst", R}, {"snd", I}, {"thd", B}});
     ensureMatchingClassOrRecord(rootInst, rib);
   }
 
@@ -1642,13 +1620,13 @@ static void testPartialInstantiation() {
     auto B = QualifiedType(QualifiedType::TYPE, BoolType::get(context));
 
     auto& r__ = vars["r__"];
-    testSubs(context, r__.type()->getCompositeType(), {{"fst", R}});
+    ensureSubs(context, r__.type()->getCompositeType(), {{"fst", R}});
     ensureMatchingClassOrRecord(rootInst, r__);
     auto& ri_ = vars["ri_"];
-    testSubs(context, ri_.type()->getCompositeType(), {{"fst", R}, {"snd", I}});
+    ensureSubs(context, ri_.type()->getCompositeType(), {{"fst", R}, {"snd", I}});
     ensureMatchingClassOrRecord(rootInst, ri_);
     auto& rib = vars["rib"];
-    testSubs(context, rib.type()->getCompositeType(), {{"fst", R}, {"snd", I}, {"thd", B}});
+    ensureSubs(context, rib.type()->getCompositeType(), {{"fst", R}, {"snd", I}, {"thd", B}});
     ensureMatchingClassOrRecord(rootInst, rib);
 
     assert(vars["bad1"].isUnknownOrErroneous());

--- a/frontend/test/test-resolution.cpp
+++ b/frontend/test/test-resolution.cpp
@@ -343,6 +343,28 @@ void ensureParamReal(const QualifiedType& type, double expectedValue) {
   }
 }
 
+void ensureSubs(Context* context,
+              const CompositeType* ct,
+              const std::map<std::string, QualifiedType>& expected) {
+  assert(ct);
+  auto rc = createDummyRC(context);
+  auto fields =
+    fieldsForTypeDecl(&rc, ct, DefaultsPolicy::IGNORE_DEFAULTS);
+
+  for (int i = 0; i < fields.numFields(); i++) {
+    auto name = fields.fieldName(i);
+    auto fieldId = fields.fieldDeclId(i);
+
+    if (auto it = expected.find(name.str()); it != expected.end()) {
+      auto subit = ct->substitutions().find(fieldId);
+      assert(subit != ct->substitutions().end());
+      assert(subit->second == it->second);
+    } else {
+      assert(ct->substitutions().find(fieldId) == ct->substitutions().end());
+    }
+  }
+}
+
 void ensureErroneousType(const QualifiedType& type) {
   assert(type.type() != nullptr);
   assert(type.type()->isErroneousType());

--- a/frontend/test/test-resolution.h
+++ b/frontend/test/test-resolution.h
@@ -95,6 +95,10 @@ QualifiedType getTypeForFirstStmt(Context* context, const std::string& program);
 
 Context::Configuration getConfigWithHome();
 
+void ensureSubs(Context* context,
+              const CompositeType* ct,
+              const std::map<std::string, QualifiedType>& expected);
+
 /**
   Returns the ResolvedFunction called by a particular
   ResolvedExpression, if there was exactly one candidate.


### PR DESCRIPTION
This PR resolves most of the issues in `test/types/partial`, __except__ `test/types/partial/formals`, which is caused by https://github.com/Cray/chapel-private/issues/7669. 

We simply didn't have code written to support partial instantiations. Previously, invoking any type constructor reset any previously applied substitutions. Thus:

```Chapel
record triple { type fst; type snd; type thd; }

type a = triple(int, ?);
type b = a(bool, ?);
type c = b(real, ?);
```

Produced `a = triple(int, ?)`, `b = triple(bool, ?)` and `c = triple(real, ?)`. This is not correct.

This PR makes the following adjustments.

* When a type constructor is invoked, inserts the existing substitutions of the type into the call. This mirrors the logic for invoking `new` on a partial instantiation. The calling code already knows when defaults should or should not be included.
* The exception to the above is that in inheritance expressions, we for some reason computed the type of `A` in `A(?)` as `A(A's defaults)`. This was not needed or relied on anywhere, so I removed it.
* Detects cases in which are are invoking a type constructor, but don't know the type. This can happen in initial signatures, where the type-to-be-constructed its given by a preceding formal. In this case, we know the intent to be `TYPE`, but the `Type*` is `UnknownType`. Signal this case from `CallInfo::create`, and defer resolution to instantiation where necessary.
* Allowed `init=`'s lhs to be partially generic. We clearly allow this (in, e.g., `var r: R(t1, ?) = ...`).
* Allow the RHS of `init=` to be a `param`. We clearly allow this (see `test/types/partial/initeq.chpl`). 

## Testing
- [x] dyno tests
- [ ] paratest
- [x] paratest --dyno-resolve-only (down to 54 failures to resolve working programs)