### PR TITLE
Drop EX config's memory to see if it addresses issues in the nightly …

### DIFF
--- a/util/cron/test-perf.hpe-cray-ex.ofi.bash
+++ b/util/cron/test-perf.hpe-cray-ex.ofi.bash
@@ -16,7 +16,7 @@ source $UTIL_CRON_DIR/common-ofi.bash || \
 source $UTIL_CRON_DIR/common-hpe-cray-ex.bash
 
 export CHPL_RT_COMM_OFI_EXPECTED_PROVIDER="cxi"
-export CHPL_RT_MAX_HEAP_SIZE="80%"
+export CHPL_RT_MAX_HEAP_SIZE="50%"
 export CHPL_LAUNCHER_PARTITION=bardpeak
 
 nightly_args="${nightly_args} -no-buildcheck"


### PR DESCRIPTION
…runs

This config has been failing with OFI errors, which are likely to be resolved by reducing the registered heap's size.