### PR TITLE
Fix --help-settings for new 'X' support

### DIFF
--- a/compiler/main/arg.cpp
+++ b/compiler/main/arg.cpp
@@ -237,6 +237,13 @@ void usage(const ArgumentState* state,
 
             break;
 
+          case 'X':
+            if (desc[i].location != 0)
+              printf("0x%lx", *(unsigned long*) desc[i].location);
+            else
+              printf("''");
+            break;
+
           default:
             arg_fatalError("Unexpected case in usage()");
             break;

--- a/test/compflags/bradc/help/helpsettings.chpl
+++ b/test/compflags/bradc/help/helpsettings.chpl
@@ -1,0 +1,2 @@
+// testing is done in the prediff
+var x = 10;

--- a/test/compflags/bradc/help/helpsettings.compopts
+++ b/test/compflags/bradc/help/helpsettings.compopts
@@ -1,0 +1,4 @@
+--help-settings
+--devel --help-settings
+--help-env
+--help-settings --help-env

--- a/test/compflags/bradc/help/helpsettings.good
+++ b/test/compflags/bradc/help/helpsettings.good
@@ -1,0 +1,1 @@
+Success

--- a/test/compflags/bradc/help/helpsettings.prediff
+++ b/test/compflags/bradc/help/helpsettings.prediff
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# for this test, all we really care about is that it did not crash
+# try to match the actual output to something reasonable is really hard
+file=$2
+compopts=$5
+
+# find the last line in file with --
+lastline=$(grep '\--' $file | tail -n 1)
+
+# if devel is in the compopts, the last flag must be --print-chpl-loc
+if [[ $compopts == *--devel* ]]; then
+  if [[ $lastline != *--print-chpl-loc* ]]; then
+    echo "Expected --print-chpl-loc to be the last flag when --devel is used, last line is '$lastline'" >>$file
+    exit 0
+  fi
+else
+  # otherwise, the last flag must be --version
+  if [[ $lastline != *--version* ]]; then
+    echo "Expected --version to be the last flag, last line is '$lastline'" >>$file
+    exit 0
+  fi
+fi
+# overwrite the output on success
+echo "Success" >$file

--- a/test/compflags/bradc/help/sub_test
+++ b/test/compflags/bradc/help/sub_test
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-export -n CHPL_UNOPTIMIZED
-
-../../../../util/test/sub_test $1

--- a/test/compflags/bradc/help/userhelp.noexec
+++ b/test/compflags/bradc/help/userhelp.noexec
@@ -1,1 +1,0 @@
-help doesn't result in an executable.


### PR DESCRIPTION
Fixes `--help-settings --devel`, which was broken by https://github.com/chapel-lang/chapel/pull/19956. #19956 added a new 'X' type for the argument parser, which meant that `--help-settings` was running into an "unexpected case", because #19956 did not add support for `--help-settings`

Also adds testing for `--help-settings` to help catch such regression in the future. The new test is NOT exhaustive, and just makes sure the compiler doesn't crash, not that the output looks right (since that is hard to test in a portable manner)

[Reviewed by @DanilaFe]