### PR TITLE
Fix memory disappearing in new test

### DIFF
--- a/test/classes/delete-free/borrow-bug-27827.chpl
+++ b/test/classes/delete-free/borrow-bug-27827.chpl
@@ -18,7 +18,8 @@ proc main() {
   writeln(r1, r2, r3, r4, sep =" | ");
 
   var newUnmanagedClass = new unmanaged MyClass(20);
-  delete r1.x;
+  var oldR1X = r1.x;
+  defer { delete oldR1X; }
   r1.x = newUnmanagedClass;
   r2.x = newUnmanagedClass:borrowed;
 


### PR DESCRIPTION
Fixes the fixes added in https://github.com/chapel-lang/chapel/pull/27856 by making sure to delete the memory at the end of the test (since it is still being used by other variables)

[Reviewed by @]