### PR TITLE
Dyno: do not show unimplemented warnings in release mode

### DIFF
--- a/frontend/include/chpl/util/assertions.h
+++ b/frontend/include/chpl/util/assertions.h
@@ -49,6 +49,8 @@ void chpl_unimpl(const char* filename, const char* func, int lineno,
     } \
   } while (0)
 
+#define CHPL_UNIMPL(msg__) do {} while (0)
+
 #else
 // debug mode
 #define CHPL_ASSERT(expr__) \
@@ -56,16 +58,14 @@ void chpl_unimpl(const char* filename, const char* func, int lineno,
     chpl::assertion(expr__, __FILE__, __FUNCTION__, __LINE__, #expr__); \
   } while (0)
 
-#endif
-
 /// \cond DO_NOT_DOCUMENT
-
 #define CHPL_UNIMPL(msg__) \
   do { \
     chpl::chpl_unimpl(__FILE__, __FUNCTION__, __LINE__, msg__); \
   } while (0)
-
 /// \endcond DO_NOT_DOCUMENT
+
+#endif
 
 /*
   Set whether or not assertions in dyno are enabled


### PR DESCRIPTION
this should fix some tests that only differ by unimplemented warnings. It should also make our testing (some of which used to include .good files with `Unimplemented:` messages) more resilient to line number changes.

Reviewed by @benharsh -- thanks!

## Testing
- [x] paratest