### PR TITLE
Halve memory used by scanPerf performance test

### DIFF
--- a/test/scan/scanPerf.chpl
+++ b/test/scan/scanPerf.chpl
@@ -5,8 +5,8 @@ config const memFraction = 0;
 const totMem = here.physicalMemory(unit = MemUnits.Bytes);
 const defaultN = if memFraction == 0
                    then 30
-                   else numLocales * ((totMem / numBytes(int)) / memFraction /
-                   here.numColocales);
+                   else numLocales * ((totMem / numBytes(int)) /
+                                     (2*memFraction) / here.numColocales);
 
 config const n = defaultN,
              printTiming = false,


### PR DESCRIPTION
By default, this test uses a problem size that consumes ~1/2 of the physical memory by using '4' as the default memFraction and allocating two arrays of that size.  This PR divides the problem size by 1/2 again to support portability to platforms that only support registering 50% of the heap memory.
