### PR TITLE
Fix erroneous error message about .DS_Store files

### DIFF
--- a/util/chplenv/printchplenv.py
+++ b/util/chplenv/printchplenv.py
@@ -574,6 +574,8 @@ def diagnose_missing_library(lib_type):
             print("There is no {} for '{}={}'".format(lib_type, varname, var[1]))
             others = os.listdir(current_path)
             options = [o if not shortname else o.removeprefix("{}-".format(shortname)) for o in others]
+            # filter out . files
+            options = [o for o in options if not o.startswith('.')]
             if options:
                 print("Valid options: {}".format(", ".join(options)))
             chplconfig_path = overrides.get_chplconfig_path()


### PR DESCRIPTION
Fixes an erroneous error message like the following

```
error: The runtime has not been built for this configuration.
There is no runtime for 'CHPL_TARGET_COMPILER=gnu'
Valid options: clang, .DS_Store, llvm
```

"Valid options" is populated by doing a crawl of a specific directory structure, so any extra files in that directory structure will show up in the "valid options" list. Nothing should be creating files in there, but on MacOS if you open a directory in finder you may accidentally create .DS_Store files.

The fix is to just ignore all files that start with `.`

[Reviewed by @DanilaFe]