### PR TITLE
Add a gpu test config for arkouda on hpe apollo

### DIFF
--- a/util/cron/test-hpe-apollo-gpu.arkouda.bash
+++ b/util/cron/test-hpe-apollo-gpu.arkouda.bash
@@ -12,7 +12,7 @@ export ARKOUDA_PARQUET_TEST_DATA_DIR=/nas/store/khandeka/parquet-testing/data  #
 export CHPL_TEST_ARKOUDA_PERF=false
 export ARKOUDA_DEVELOPER=true
 
-export CHPL_NIGHTLY_TEST_CONFIG_NAME="hpe-apollo-hdr-gpu.arkouda"
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="hpe-apollo-gpu.arkouda"
 
 module list
 


### PR DESCRIPTION
Adds a gpu test config for arkouda on hpe apollo

This is just a clone of regular hpe apollo correctness tests we run, but using CHPL_GPU=cpu and CHPL_COMM=none

[Reviewed by @e-kayrakli]