### PR TITLE
Fix subtle format string bug in start_test

### DIFF
--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -1902,13 +1902,13 @@ def main():
                     result = DiffBinaryFiles(goodfile, complog)
                 else:
                     result = DiffFiles(goodfile, complog)
-                msg = f"{futuretest}{{}}matching compiler output for {localdir}/{test_filename}"
+                msg = f"matching compiler output for {localdir}/{test_filename}"
                 if result==0:
                     os.unlink(complog)
-                    msg = msg.format("[Success ")
+                    msg = f"[Success {msg}"
                 else:
-                    msg = msg.format("[Error ")
-                sys.stdout.write(msg)
+                    msg = f"[Error {msg}"
+                sys.stdout.write(f'{futuretest}{msg}')
                 printTestVariation(compoptsnum, compoptslist)
                 sys.stdout.write(']\n')
 


### PR DESCRIPTION
Fixes an issue where a future test could accidentally create an invalid format string. If the future test line contained `{}`, then Python would try and treat it as a format string. This was only detectable when `-futures` was used

For example, `Future (bug: compiler crashes compiling "proc param int.foo() {...}")` would cause a format string error

Fixes an issue introduced by https://github.com/chapel-lang/chapel/pull/27881

- [x] `st test/functions/bradc/paramThis -futures`

[Reviewed by @]