### PR TITLE
Remove incorrect compiler option for clang20

### DIFF
--- a/make/compiler/Makefile.clang
+++ b/make/compiler/Makefile.clang
@@ -145,9 +145,6 @@ SQUASH_WARN_GEN_CFLAGS += -Wno-tautological-compare
 # warn for unwanted GNU extension usages
 #
 RUNTIME_GNU_WARNINGS = -Wgnu -Wno-gnu-folding-constant -Wno-zero-length-array -Wno-gnu-zero-variadic-macro-arguments
-ifeq ($(shell test $(CLANG_MAJOR_VERSION) -ge 20; echo "$$?"),0)
-RUNTIME_GNU_WARNINGS += -Wno-variadic-macro-arguments-omitted
-endif
 
 #
 # compiler warnings settings


### PR DESCRIPTION
Removes an incorrect compiler option which is considered unknown for `-std=gnu11`

[Reviewed by @benharsh]