### PR TITLE
Improve startup performance of `chplcheck`

### DIFF
--- a/tools/chplcheck/src/chplcheck.py
+++ b/tools/chplcheck/src/chplcheck.py
@@ -25,14 +25,12 @@ import sys
 import glob
 import itertools
 import functools
-from typing import List, Tuple, Optional
+from typing import List, Optional
 
 import chapel
-import chapel.replace
 from driver import LintDriver
-from lsp import run_lsp
 from rules import rules
-from fixits import Fixit, Edit
+from fixits import Edit
 from rule_types import CheckResult, RuleLocation
 from config import Config
 
@@ -287,6 +285,7 @@ def main():
         return 2
 
     if args.lsp:
+        from lsp import run_lsp
         run_lsp(driver)
         return 0
 

--- a/tools/chplcheck/src/chplcheck.py
+++ b/tools/chplcheck/src/chplcheck.py
@@ -286,6 +286,7 @@ def main():
 
     if args.lsp:
         from lsp import run_lsp
+
         run_lsp(driver)
         return 0
 

--- a/util/config/run-in-venv-with-python-bindings.bash
+++ b/util/config/run-in-venv-with-python-bindings.bash
@@ -6,9 +6,6 @@ CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 # Perform checks and set up environment variables for virtual env.
 source $CWD/run-in-venv-common.bash
 
-CC=$("$CHPL_HOME/util/printchplenv" --value --only CHPL_HOST_CC)
-PLATFORM=$("$CHPL_HOME/util/printchplenv" --value --only CHPL_HOST_PLATFORM)
-
 chpl_frontend_py_deps=$("$python" "$CHPL_HOME/util/chplenv/chpl_home_utils.py" --chpldeps-chapel-py)
 export PYTHONPATH="$chpl_frontend_py_deps":$PYTHONPATH
 
@@ -19,6 +16,8 @@ if [ ! -d "$chpl_frontend_py_deps/chapel" ]; then
 fi
 
 if [ $("$python" "$CHPL_HOME/util/chplenv/chpl_sanitizers.py") == "address" ]; then
+  CC=$("$CHPL_HOME/util/printchplenv" --value --only CHPL_HOST_CC)
+  PLATFORM=$("$CHPL_HOME/util/printchplenv" --value --only CHPL_HOST_PLATFORM)
   if [ "$PLATFORM" == "darwin" ]; then
     echo "Cannot use chapel-py on Mac OS when address sanitization is enabled; please unset 'CHPL_SANITIZE', then rebuild Chapel and chapel-py"
     exit 1


### PR DESCRIPTION
Improves the startup performance of `chplcheck` by being lazier about loading dependencies

- moves calls to `printchplenv` to be only when needed, as these can be slow on some systems
    - this will also affect CLS
- only import the lsp when we actually are running the lsp
   - this gave me a 1-2s improvement of startup for the CLI
   - I also cleaned up some unused imports  

- [x] `start_test test/chplcheck`

[Reviewed by @DanilaFe]