### PR TITLE
Add GASNet+SMP to linux packages + other improvements

### DIFF
--- a/util/packaging/apt/debian12/control.template
+++ b/util/packaging/apt/debian12/control.template
@@ -4,3 +4,4 @@ Maintainer: chapel-lang
 Architecture: @@{TARGETARCH}
 Description: Chapel Programming Language
 Depends: git,gcc,llvm-dev,llvm,clang,libclang-dev,libclang-cpp-dev,python3,python3-dev,python3-venv,make
+Depends: libgmp-dev,libhwloc-dev

--- a/util/packaging/apt/debian13/control.template
+++ b/util/packaging/apt/debian13/control.template
@@ -4,3 +4,4 @@ Maintainer: chapel-lang
 Architecture: @@{TARGETARCH}
 Description: Chapel Programming Language
 Depends: git,gcc,llvm-dev,llvm,clang,libclang-dev,libclang-cpp-dev,python3,python3-dev,python3-venv,make
+Depends: libgmp-dev,libhwloc-dev

--- a/util/packaging/apt/ubuntu22/Dockerfile.template
+++ b/util/packaging/apt/ubuntu22/Dockerfile.template
@@ -10,7 +10,8 @@ RUN apt-get update && \
       curl wget vim sudo gcc g++ m4 perl chrpath \
       python3 python3-dev python3-venv bash make mawk git pkg-config cmake \
       llvm-dev llvm clang libclang-dev libclang-cpp-dev libedit-dev \
-      libpmi2-0-dev libslurm-dev
+      libpmi2-0-dev libslurm-dev \
+      libgmp-dev libhwloc-dev
 
 @@{USER_CREATION}
 

--- a/util/packaging/apt/ubuntu22/control.template
+++ b/util/packaging/apt/ubuntu22/control.template
@@ -4,3 +4,4 @@ Maintainer: chapel-lang
 Architecture: @@{TARGETARCH}
 Description: Chapel Programming Language
 Depends: git,gcc,llvm-dev,llvm,clang,libclang-dev,libclang-cpp-dev,python3,python3-dev,python3-venv,make,libpmi2-0-dev,libslurm-dev
+Depends: libgmp-dev,libhwloc-dev

--- a/util/packaging/apt/ubuntu24/Dockerfile.template
+++ b/util/packaging/apt/ubuntu24/Dockerfile.template
@@ -10,7 +10,8 @@ RUN apt-get update && \
       curl wget vim sudo gcc g++ m4 perl chrpath \
       python3 python3-dev python3-venv bash make mawk git pkg-config cmake \
       llvm-dev llvm clang libclang-dev libclang-cpp-dev libedit-dev \
-      libpmi2-0-dev libslurm-dev
+      libpmi2-0-dev libslurm-dev \
+      libgmp-dev libhwloc-dev
 
 @@{USER_CREATION}
 

--- a/util/packaging/apt/ubuntu24/control.template
+++ b/util/packaging/apt/ubuntu24/control.template
@@ -4,3 +4,4 @@ Maintainer: chapel-lang
 Architecture: @@{TARGETARCH}
 Description: Chapel Programming Language
 Depends: git,gcc,llvm-dev,llvm,clang,libclang-dev,libclang-cpp-dev,python3,python3-dev,python3-venv,make,libpmi2-0-dev,libslurm-dev
+Depends: libgmp-dev,libhwloc-dev

--- a/util/packaging/rpm/amzn2023/Dockerfile.template
+++ b/util/packaging/rpm/amzn2023/Dockerfile.template
@@ -9,7 +9,7 @@ RUN dnf upgrade -y && \
       gcc gcc-c++ m4 perl python3 python3-devel bash make gawk git cmake \
       which diffutils wget vim sudo \
       llvm-devel clang clang-devel \
-      pmix-devel \
+      pmix-devel gmp-devel hwloc-devel \
       rpm-build rpm-devel rpmlint coreutils patch rpmdevtools chrpath
 
 @@{USER_CREATION}

--- a/util/packaging/rpm/amzn2023/spec.template
+++ b/util/packaging/rpm/amzn2023/spec.template
@@ -8,6 +8,7 @@ License: Apache-2.0
 Source0: chapel-%{version}.tar.gz
 
 Requires: bash perl git llvm-devel clang clang-devel python3 python3-devel make
+Requires: gmp-devel hwloc-devel
 Requires: pmix-devel
 
 %description

--- a/util/packaging/rpm/el10/Dockerfile.template
+++ b/util/packaging/rpm/el10/Dockerfile.template
@@ -10,7 +10,7 @@ RUN dnf upgrade -y && \
       gcc gcc-c++ m4 perl python3 python3-devel bash make gawk git cmake \
       which diffutils wget vim sudo \
       llvm-devel clang clang-devel \
-      pmix-devel \
+      pmix-devel gmp-devel hwloc-devel \
       rpm-build rpm-devel rpmlint coreutils patch rpmdevtools chrpath
 
 @@{USER_CREATION}

--- a/util/packaging/rpm/el10/spec.template
+++ b/util/packaging/rpm/el10/spec.template
@@ -8,6 +8,7 @@ License: Apache-2.0
 Source0: chapel-%{version}.tar.gz
 
 Requires: bash perl git llvm-devel clang clang-devel python3 python3-devel make
+Requires: gmp-devel hwloc-devel
 Requires: pmix-devel
 
 %description

--- a/util/packaging/rpm/fc41/spec.template
+++ b/util/packaging/rpm/fc41/spec.template
@@ -8,6 +8,7 @@ License: Apache-2.0
 Source0: chapel-%{version}.tar.gz
 
 Requires: bash perl git llvm-devel clang clang-devel python3 python3-devel make
+Requires: gmp-devel hwloc-devel
 Requires: pmix-devel
 
 %description

--- a/util/packaging/rpm/fc42/spec.template
+++ b/util/packaging/rpm/fc42/spec.template
@@ -8,6 +8,7 @@ License: Apache-2.0
 Source0: chapel-%{version}.tar.gz
 
 Requires: bash perl git llvm-devel clang clang-devel python3 python3-devel make
+Requires: gmp-devel hwloc-devel
 Requires: pmix-devel
 
 %description


### PR DESCRIPTION
Adds GASNet+SMP as an option to the linux packages

Other improvements
  - use system gmp for smaller/better packages
  - use system hwloc for smaller/better packages
  - improve the configuration of CHPL_SANITIZE_EXE since it can now be used with LLVM and qthreads

Testing
- [ ] build fc42 package locally
- [ ] build debian13 package locally
- [ ] build ubuntu24 package locally
- [ ] build el10 package locally
- [ ] build amzn2023 package locally
