### PR TITLE
Remove revision from `chapel-main.rb`

### DIFF
--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -6,7 +6,6 @@ class Chapel < Formula
   url "<url-placeholder-value-injected-during-testing>"
   sha256 "<sha256-placeholder-value-injected-during-testing>"
   license "Apache-2.0"
-  revision 1
   head "https://github.com/chapel-lang/chapel.git", branch: "main"
 
   no_autobump! because: :bumped_by_upstream


### PR DESCRIPTION
Removes revision from `chapel-main.rb` since its not needed for correctness testing and it interferes with the homebrew CI in nightly tests

[Not reviewed - trivial]