### PR TITLE
Fix bug with slicing strided ranges of idxType <32

### DIFF
--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -2575,8 +2575,7 @@ private proc isBCPindex(type t) param do
       if st1 == st2 {
         gcd = st1;
       } else {
-        // do we need casts to  something about the types of st1, st2?
-        (gcd, x) = chpl__extendedEuclid(st1, st2);
+        (gcd, x) = chpl__extendedEuclid(st1, st2):(2*strType);
         newStride = st1 / gcd * st2;  // divide first to avoid overflow
         newAbsStride = newStride;
       }
@@ -3823,8 +3822,7 @@ private proc isBCPindex(type t) param do
   //
   // source: Knuth Volume 2 --- Section 4.5.2
   //
-  proc chpl__extendedEuclidHelper(u, v)
-  {
+  proc chpl__extendedEuclid(u: int(?w), v: int(w)) where w == 32 || w == 64 {
     var zero: u.type = 0;
     var one: u.type = 1;
 
@@ -3843,12 +3841,6 @@ private proc isBCPindex(type t) param do
 
     return (U(2), U(0));
   }
-
-  inline proc chpl__extendedEuclid(u:int(32), v:int(32))
-  { return chpl__extendedEuclidHelper(u,v); }
-
-  inline proc chpl__extendedEuclid(u:int(64), v:int(64))
-  { return chpl__extendedEuclidHelper(u,v); }
 
   private proc chpl__rangeIdxTypeError(type idxType) {
     compilerError("ranges don't support '", idxType:string, "' as their idxType");

--- a/test/distributions/cyclic/int16Domain.chpl
+++ b/test/distributions/cyclic/int16Domain.chpl
@@ -1,0 +1,4 @@
+use CyclicDist;
+
+var x = cyclicDist.createDomain(0:int(16)..15:int(16));
+writeln(x, " ", x.type:string);

--- a/test/distributions/cyclic/int16Domain.good
+++ b/test/distributions/cyclic/int16Domain.good
@@ -1,0 +1,1 @@
+{0..15} CyclicDom(1,int(16),one)

--- a/test/types/range/bradc/rangeSliceTy.chpl
+++ b/test/types/range/bradc/rangeSliceTy.chpl
@@ -1,0 +1,16 @@
+
+proc testRange(type t) {
+  var x = 1:t..10:t by 2;
+
+  var y = x(2:t..4:t);
+  writeln(y);
+}
+
+testRange(int(8));
+testRange(int(16));
+testRange(int(32));
+testRange(int(64));
+testRange(uint(8));
+testRange(uint(16));
+testRange(uint(32));
+testRange(uint(64));

--- a/test/types/range/bradc/rangeSliceTy.good
+++ b/test/types/range/bradc/rangeSliceTy.good
@@ -1,0 +1,8 @@
+2..4 by 2 align 1
+2..4 by 2 align 1
+2..4 by 2 align 1
+2..4 by 2 align 1
+2..4 by 2 align 1
+2..4 by 2 align 1
+2..4 by 2 align 1
+2..4 by 2 align 1


### PR DESCRIPTION
Fixes an issue where attempting to slice a strided range with an index type of bitwidth less than 32 would result in a compilation error.

I uncovered this bug while working with cyclicDist, so this PR includes a test of the original reproducer

- [x] paratest with/without gasnet

[Reviewed by @benharsh]