### PR TITLE
Fix usage of C++17 for AMD GPUs

### DIFF
--- a/runtime/src/gpu/amd/Makefile.share
+++ b/runtime/src/gpu/amd/Makefile.share
@@ -28,4 +28,4 @@ RUNTIME_CFLAGS += -Wno-strict-prototypes
 
 $(RUNTIME_OBJ_DIR)/gpu-amd-cub.o: gpu-amd-cub.cc \
                                          $(RUNTIME_OBJ_DIR_STAMP)
-	PATH=$(PATH):$(CHPL_MAKE_ROCM_LLVM_PATH)/bin $(CXX) -c -std=c++17 $(RUNTIME_CXXFLAGS) $(RUNTIME_INCLS) -o $@ $<
+	PATH=$(PATH):$(CHPL_MAKE_ROCM_LLVM_PATH)/bin $(CXX) -c $(RUNTIME_CXXFLAGS) $(RUNTIME_INCLS) -std=c++17 -o $@ $<


### PR DESCRIPTION
Fixes an issue introduced by https://github.com/chapel-lang/chapel/pull/27849 where `-std=c++17` was being overridden by `-std=gnu++11`

[Reviewed by @benharsh]