### PR TITLE
Add variant of 'STEP CANCELLED' prediff for slurm

### DIFF
--- a/util/test/prediff-for-slurm
+++ b/util/test/prediff-for-slurm
@@ -19,7 +19,7 @@ b"""srun: Job step aborted: Waiting up to [0-9]+ seconds for job step .*
 """,
 rb"""slurmstepd: error: \*\*\* STEP [0-9.]+ ON .+ CANCELLED AT [-0-9T.:]+ \*\*\*
 """,
-rb"""\[[-0-9T.:]+\] error: \*\*\* STEP [0-9.]+ ON .+ CANCELLED AT [-0-9T.:]+ DUE TO TASK FAILURE \*\*\*
+rb"""\[[-0-9T.:]+] error: \*\*\* STEP [0-9.]+ ON .+ CANCELLED AT [-0-9T.:]+ DUE TO TASK FAILURE \*\*\*
 """,
 rb"""slurmstepd: error: .+ \[[0-9]+] .*
 """,


### PR DESCRIPTION
This appears to be a variant of the similar message above, which we can encounter when a program has a non-zero exit code. More specifically, the message comes from the root locale when exiting from any other locale.