### PR TITLE
Make sure python3 is in PATH on darwin tests

### DIFF
--- a/util/cron/common-darwin.bash
+++ b/util/cron/common-darwin.bash
@@ -8,3 +8,9 @@ export CHPL_RT_WORKERIP=127.0.0.0
 # We run darwin testing heavily oversubscribed, so limit the number of Chapel
 # executables that run concurrently to avoid timeouts.
 export CHPL_TEST_LIMIT_RUNNING_EXECUTABLES=yes
+
+
+# 2025-10-14: needed on chapelmac since brew updated and no longer puts python3
+#             in the PATH by default. this is specific to the version of macos
+#             installed, and upgrading the OS may make this unnecessary.
+export PATH="$(brew --prefix python3)/libexec/bin:"$PATH


### PR DESCRIPTION
Makes sure python3 is in PATH on darwin testing, since homebrew changed.

[Not reviewed]