### PR TITLE
Translate testRelease from perl to bash

### DIFF
--- a/util/buildRelease/testRelease
+++ b/util/buildRelease/testRelease
@@ -46,7 +46,7 @@ cp $chplhome/tar/chapel-test.tar.gz $tmpdir
 cd $tmpdir && tar xf chapel-test.tar.gz
 
 # Run testReleaseHelp (capture chpl_make output first for clarity)
-chpl_make_cmd_output="$("$chplhome"/util/chplenv/chpl_make.py)"
+chpl_make_cmd_output=$("$chplhome"/util/chplenv/chpl_make.py)
 cd $tmpdir/chapel-test && $chplhome/util/buildRelease/testReleaseHelp $chpl_make_cmd_output
 
 # Cleanup if everything succeeded


### PR DESCRIPTION
Translates the ``testRelease`` script to bash so that we can ``set -e`` and ``set -x`` to try and help diagnose failures in ``gen_release``.