### PR TITLE
Un-futurize now-working test

### DIFF
--- a/test/types/tuple/tupleTypeAccessClassesField.bad
+++ b/test/types/tuple/tupleTypeAccessClassesField.bad
@@ -1,4 +1,0 @@
-tupleTypeAccessClassesField.chpl:13: In method 'accept':
-tupleTypeAccessClassesField.chpl:15: error: unresolved call '(borrowed GoodStudent,borrowed ExcellentStudent)(0)'
-tupleTypeAccessClassesField.chpl:15: note: because no functions named (borrowed GoodStudent,borrowed ExcellentStudent) found in scope
-  tupleTypeAccessClassesField.chpl:24: called as (AdvancedBasketWeaving((borrowed GoodStudent,borrowed ExcellentStudent))).accept(student: borrowed Student)

--- a/test/types/tuple/tupleTypeAccessClassesField.future
+++ b/test/types/tuple/tupleTypeAccessClassesField.future
@@ -1,2 +1,0 @@
-bug: weird error for accessing tuple type field
-#22633


### PR DESCRIPTION
Closes https://github.com/chapel-lang/chapel/issues/22633.

This was fixed by https://github.com/chapel-lang/chapel/pull/27922. It now works on `main`.

Trivial, will not be reviewed.

## Testing
- [x] unfuturized test passes