### PR TITLE
Fix `--verify` assertion failures when capturing non-existent variable in task intent

### DIFF
--- a/compiler/passes/convert-uast.cpp
+++ b/compiler/passes/convert-uast.cpp
@@ -1147,7 +1147,7 @@ struct Converter final : UastConverter {
           auto r = symStack.back().resolved;
           if (r != nullptr) {
             if (auto rr = r->byAstOrNull(expr)) {
-              if (!rr->toId().isEmpty()) {
+              if (!rr->toId().isEmpty() || rr->isBuiltin()) {
                 noteConvertedSym(expr, findConvertedSym(rr->toId()));
               } else {
                 // we need to note this symbol as having been converted, but


### PR DESCRIPTION
Follow-up to https://github.com/chapel-lang/chapel/pull/27919.

My fix was sound, but it turns out that there's a bug in `convert-uast.cpp` that is also triggered by the test I introduced. Specifically, `convert-uast.cpp` doesn't create a new symbol for `with (ref someVar)`, but rather aliases the inner `someVar` to the outer symbol. The outer symbol is constructed from `findConvertedSym` with the `someVar`'s to-id. The bug is that we don't check if `someVar` has an empty `toId` (indicating the outer variable doesn't exist); this results in creating a `TemporaryConversionSymbol(EmptyId)`, which never gets fixed up and fails `--verify`. 

The solution is to eagerly emit an error message in this case. If we have no symbol to speak of, we have no valid production AST to construct. Thus, this PR introduces an additional (third, I believe) "no outer variable" error (one for foralls; one in `normalize.cpp`, which can be hit if we are using `--no-dyno-scope-resolve`, and one new one in `convert-uast.cpp). 

__Except__ we sometimes emit more specific errors when the tries to capture `bool` with a task intent. In this case, the `toId` is empty, but the `--verify` bug doesn't happen because the scope resolver doesn't allow shadowing global definitions (so, in the body of a loop, `bool` still refers to the global bool, and not to the task variable bool). To keep the more specific error messages here, this PR does not raise the error if the ID is empty but the task var refers to a builtin (in Dyno, to-IDs can be valid and empty if they refer to a builtin that doesn't have a corresponding AST). The resolution information already has support for signaling references to builtins, but it wasn't wired up properly in task intent resolution. So, this PR wires it up, and silences the error (in favor of downstream errors) for builtins.

Reviewed by @benharsh -- thanks!

## Testing
- [x] paratest