### PR TITLE
Clean up after apptainer dependency setup

### DIFF
--- a/util/devel/test/portability/provision-scripts/apt-get-deps-and-cmake.sh
+++ b/util/devel/test/portability/provision-scripts/apt-get-deps-and-cmake.sh
@@ -17,4 +17,4 @@ make install
 
 update-alternatives --install /usr/bin/cmake cmake /usr/local/bin/cmake 1
 
-rm -rf $MYTMP
+hide rm -rf $MYTMP


### PR DESCRIPTION
These leftover directories are taking up space in ``/tmp/``, sometimes to the point of causing "no space left on device" errors in nightly testing. This PR just cleans up the leftover cmake build directory, which I believe should be irrelevant after the ``make install``.