### PR TITLE
Accept changes to .good file for 'dwarfdump/classes.chpl' test

### DIFF
--- a/test/llvm/debugInfo/dwarfdump/classes.good
+++ b/test/llvm/debugInfo/dwarfdump/classes.good
@@ -240,9 +240,6 @@ DW_TAG_structure_type
   NULL
 ================================================================================
 ====================================MyClass=====================================
-DW_TAG_pointer_type
-              DW_AT_type	("classes::MyClass")
-              DW_AT_name	("MyClass")
 DW_TAG_structure_type
               DW_AT_name	("MyClass")
               DW_AT_byte_size	(0x10)
@@ -271,8 +268,14 @@ DW_TAG_structure_type
 DW_TAG_pointer_type
               DW_AT_type	("classes::MyClass")
               DW_AT_name	("MyClass")
+DW_TAG_pointer_type
+              DW_AT_type	("classes::MyClass")
+              DW_AT_name	("MyClass")
 ================================================================================
 ==================================MyChildClass==================================
+DW_TAG_pointer_type
+              DW_AT_type	("classes::MyChildClass")
+              DW_AT_name	("MyChildClass")
 DW_TAG_structure_type
               DW_AT_name	("MyChildClass")
               DW_AT_byte_size	(0x18)
@@ -298,9 +301,6 @@ DW_TAG_structure_type
               DW_AT_name	("MyChildClass")
               DW_AT_declaration	(true)
               DW_AT_alignment	(8)
-DW_TAG_pointer_type
-              DW_AT_type	("classes::MyChildClass")
-              DW_AT_name	("MyChildClass")
 DW_TAG_pointer_type
               DW_AT_type	("classes::MyChildClass")
               DW_AT_name	("MyChildClass")


### PR DESCRIPTION
Try to fix nightly test failures related to differing output-order for dwarfdump tests.