### PR TITLE
Fix memory leak in dwarfdump test

### DIFF
--- a/test/llvm/debugInfo/dwarfdump/nothingTypes.chpl
+++ b/test/llvm/debugInfo/dwarfdump/nothingTypes.chpl
@@ -25,20 +25,25 @@ proc test(type t) {
   // DWARFDUMP: myVar1
   // DWARFDUMP: myRecord(int(64),real(64))
   // DWARFDUMP: MyClass(int(64),real(64))
+  // DWARFDUMP: shared MyClass(int(64),real(64))?
   var myVar1 = new t(int, real);
   // DWARFDUMP: myVar2
   // DWARFDUMP: myRecord(nothing,nothing)
   // DWARFDUMP: MyClass(nothing,nothing)
+  // DWARFDUMP: shared MyClass(nothing,nothing)?
   var myVar2 = new t(nothing, nothing);
   // DWARFDUMP: myVar3
   // DWARFDUMP: myRecord(int(64),nothing)
   // DWARFDUMP: MyClass(int(64),nothing)
+  // DWARFDUMP: shared MyClass(int(64),nothing)?
   var myVar3 = new t(int, nothing);
   // DWARFDUMP: myVar4
   // DWARFDUMP: myRecord(nothing,real(64))
   // DWARFDUMP: myRecord(myRecord(nothing,real(64)),int(64))
   // DWARFDUMP: MyClass(nothing,real(64))
   // DWARFDUMP: MyClass(unmanaged MyClass(nothing,real(64))?,int(64))
+  // DWARFDUMP: shared MyClass(shared MyClass(nothing,real(64))?,int(64))?
+  // DWARFDUMP: shared MyClass(nothing,real(64))?
   var myVar4 = new t(t(nothing, real), int);
 
   writeln(myVar1, myVar2, myVar3, myVar4, sep=" | ");
@@ -54,6 +59,5 @@ proc test(type t) {
 proc main() {
   test(myRecord(?));
   test(unmanaged MyClass(?)?);
-  // doesn't work due to bug with generic nilable managed class types
-  // test(shared MyClass(?)?);
+  test(shared MyClass(?)?);
 }

--- a/test/llvm/debugInfo/dwarfdump/nothingTypes.good
+++ b/test/llvm/debugInfo/dwarfdump/nothingTypes.good
@@ -1,5 +1,6 @@
 (x = 0, y = 0.0) | () | (x = 0) | (x = (y = 0.0), y = 0)
 {x = 0, y = 0.0} | {} | {x = 0} | {x = nil, y = 0}
+{x = 0, y = 0.0} | {} | {x = 0} | {x = nil, y = 0}
 Running DWARF verification...
 Success!!
 Running DWARF dump checks...
@@ -7,13 +8,18 @@ Running DWARF dump checks...
 DW_TAG_variable
               DW_AT_name	("myVar1")
               DW_AT_decl_file	("./nothingTypes.chpl")
-              DW_AT_decl_line	(28)
+              DW_AT_decl_line	(29)
               DW_AT_type	("nothingTypes::MyClass(int(64),real(64)) *")
 DW_TAG_variable
               DW_AT_name	("myVar1")
               DW_AT_decl_file	("./nothingTypes.chpl")
-              DW_AT_decl_line	(28)
+              DW_AT_decl_line	(29)
               DW_AT_type	("nothingTypes::myRecord(int(64),real(64))")
+DW_TAG_variable
+              DW_AT_name	("myVar1")
+              DW_AT_decl_file	("./nothingTypes.chpl")
+              DW_AT_decl_line	(29)
+              DW_AT_type	("shared MyClass(int(64),real(64))?")
 ================================================================================
 ===========================myRecord(int(64),real(64))===========================
 DW_TAG_structure_type
@@ -71,17 +77,43 @@ DW_TAG_structure_type
                 DW_AT_data_member_location	(0x10)
   NULL
 ================================================================================
+=======================shared MyClass(int(64),real(64))?========================
+DW_TAG_structure_type
+              DW_AT_name	("shared MyClass(int(64),real(64))?")
+              DW_AT_byte_size	(0x10)
+              DW_AT_alignment	(8)
+  DW_TAG_member
+                DW_AT_name	("chpl_p")
+                DW_AT_type	("nothingTypes::MyClass(int(64),real(64)) *")
+                DW_AT_decl_file	("$CHPL_HOME/modules/internal/SharedObject.chpl")
+                DW_AT_decl_line	(125)
+                DW_AT_alignment	(8)
+                DW_AT_data_member_location	(0x00)
+  DW_TAG_member
+                DW_AT_name	("chpl_pn")
+                DW_AT_type	("ReferenceCount *")
+                DW_AT_decl_file	("$CHPL_HOME/modules/internal/SharedObject.chpl")
+                DW_AT_decl_line	(131)
+                DW_AT_alignment	(8)
+                DW_AT_data_member_location	(0x08)
+  NULL
+================================================================================
 =====================================myVar2=====================================
 DW_TAG_variable
               DW_AT_name	("myVar2")
               DW_AT_decl_file	("./nothingTypes.chpl")
-              DW_AT_decl_line	(32)
+              DW_AT_decl_line	(34)
               DW_AT_type	("nothingTypes::MyClass(nothing,nothing) *")
 DW_TAG_variable
               DW_AT_name	("myVar2")
               DW_AT_decl_file	("./nothingTypes.chpl")
-              DW_AT_decl_line	(32)
+              DW_AT_decl_line	(34)
               DW_AT_type	("nothingTypes::myRecord(nothing,nothing)")
+DW_TAG_variable
+              DW_AT_name	("myVar2")
+              DW_AT_decl_file	("./nothingTypes.chpl")
+              DW_AT_decl_line	(34)
+              DW_AT_type	("shared MyClass(nothing,nothing)?")
 ================================================================================
 ===========================myRecord(nothing,nothing)============================
 DW_TAG_structure_type
@@ -110,17 +142,43 @@ DW_TAG_structure_type
                 DW_AT_data_member_location	(0x00)
   NULL
 ================================================================================
+========================shared MyClass(nothing,nothing)?========================
+DW_TAG_structure_type
+              DW_AT_name	("shared MyClass(nothing,nothing)?")
+              DW_AT_byte_size	(0x10)
+              DW_AT_alignment	(8)
+  DW_TAG_member
+                DW_AT_name	("chpl_p")
+                DW_AT_type	("nothingTypes::MyClass(nothing,nothing) *")
+                DW_AT_decl_file	("$CHPL_HOME/modules/internal/SharedObject.chpl")
+                DW_AT_decl_line	(125)
+                DW_AT_alignment	(8)
+                DW_AT_data_member_location	(0x00)
+  DW_TAG_member
+                DW_AT_name	("chpl_pn")
+                DW_AT_type	("ReferenceCount *")
+                DW_AT_decl_file	("$CHPL_HOME/modules/internal/SharedObject.chpl")
+                DW_AT_decl_line	(131)
+                DW_AT_alignment	(8)
+                DW_AT_data_member_location	(0x08)
+  NULL
+================================================================================
 =====================================myVar3=====================================
 DW_TAG_variable
               DW_AT_name	("myVar3")
               DW_AT_decl_file	("./nothingTypes.chpl")
-              DW_AT_decl_line	(36)
+              DW_AT_decl_line	(39)
               DW_AT_type	("nothingTypes::MyClass(int(64),nothing) *")
 DW_TAG_variable
               DW_AT_name	("myVar3")
               DW_AT_decl_file	("./nothingTypes.chpl")
-              DW_AT_decl_line	(36)
+              DW_AT_decl_line	(39)
               DW_AT_type	("nothingTypes::myRecord(int(64),nothing)")
+DW_TAG_variable
+              DW_AT_name	("myVar3")
+              DW_AT_decl_file	("./nothingTypes.chpl")
+              DW_AT_decl_line	(39)
+              DW_AT_type	("shared MyClass(int(64),nothing)?")
 ================================================================================
 ===========================myRecord(int(64),nothing)============================
 DW_TAG_structure_type
@@ -164,17 +222,43 @@ DW_TAG_structure_type
                 DW_AT_data_member_location	(0x08)
   NULL
 ================================================================================
+========================shared MyClass(int(64),nothing)?========================
+DW_TAG_structure_type
+              DW_AT_name	("shared MyClass(int(64),nothing)?")
+              DW_AT_byte_size	(0x10)
+              DW_AT_alignment	(8)
+  DW_TAG_member
+                DW_AT_name	("chpl_p")
+                DW_AT_type	("nothingTypes::MyClass(int(64),nothing) *")
+                DW_AT_decl_file	("$CHPL_HOME/modules/internal/SharedObject.chpl")
+                DW_AT_decl_line	(125)
+                DW_AT_alignment	(8)
+                DW_AT_data_member_location	(0x00)
+  DW_TAG_member
+                DW_AT_name	("chpl_pn")
+                DW_AT_type	("ReferenceCount *")
+                DW_AT_decl_file	("$CHPL_HOME/modules/internal/SharedObject.chpl")
+                DW_AT_decl_line	(131)
+                DW_AT_alignment	(8)
+                DW_AT_data_member_location	(0x08)
+  NULL
+================================================================================
 =====================================myVar4=====================================
 DW_TAG_variable
               DW_AT_name	("myVar4")
               DW_AT_decl_file	("./nothingTypes.chpl")
-              DW_AT_decl_line	(42)
+              DW_AT_decl_line	(47)
               DW_AT_type	("nothingTypes::MyClass(unmanaged MyClass(nothing,real(64))?,int(64)) *")
 DW_TAG_variable
               DW_AT_name	("myVar4")
               DW_AT_decl_file	("./nothingTypes.chpl")
-              DW_AT_decl_line	(42)
+              DW_AT_decl_line	(47)
               DW_AT_type	("nothingTypes::myRecord(myRecord(nothing,real(64)),int(64))")
+DW_TAG_variable
+              DW_AT_name	("myVar4")
+              DW_AT_decl_file	("./nothingTypes.chpl")
+              DW_AT_decl_line	(47)
+              DW_AT_type	("shared MyClass(shared MyClass(nothing,real(64))?,int(64))?")
 ================================================================================
 ===========================myRecord(nothing,real(64))===========================
 DW_TAG_structure_type
@@ -272,6 +356,48 @@ DW_TAG_structure_type
                 DW_AT_decl_line	(17)
                 DW_AT_alignment	(8)
                 DW_AT_data_member_location	(0x10)
+  NULL
+================================================================================
+===========shared MyClass(shared MyClass(nothing,real(64))?,int(64))?===========
+DW_TAG_structure_type
+              DW_AT_name	("shared MyClass(shared MyClass(nothing,real(64))?,int(64))?")
+              DW_AT_byte_size	(0x10)
+              DW_AT_alignment	(8)
+  DW_TAG_member
+                DW_AT_name	("chpl_p")
+                DW_AT_type	("nothingTypes::MyClass(shared MyClass(nothing,real(64))?,int(64)) *")
+                DW_AT_decl_file	("$CHPL_HOME/modules/internal/SharedObject.chpl")
+                DW_AT_decl_line	(125)
+                DW_AT_alignment	(8)
+                DW_AT_data_member_location	(0x00)
+  DW_TAG_member
+                DW_AT_name	("chpl_pn")
+                DW_AT_type	("ReferenceCount *")
+                DW_AT_decl_file	("$CHPL_HOME/modules/internal/SharedObject.chpl")
+                DW_AT_decl_line	(131)
+                DW_AT_alignment	(8)
+                DW_AT_data_member_location	(0x08)
+  NULL
+================================================================================
+=======================shared MyClass(nothing,real(64))?========================
+DW_TAG_structure_type
+              DW_AT_name	("shared MyClass(nothing,real(64))?")
+              DW_AT_byte_size	(0x10)
+              DW_AT_alignment	(8)
+  DW_TAG_member
+                DW_AT_name	("chpl_p")
+                DW_AT_type	("nothingTypes::MyClass(nothing,real(64)) *")
+                DW_AT_decl_file	("$CHPL_HOME/modules/internal/SharedObject.chpl")
+                DW_AT_decl_line	(125)
+                DW_AT_alignment	(8)
+                DW_AT_data_member_location	(0x00)
+  DW_TAG_member
+                DW_AT_name	("chpl_pn")
+                DW_AT_type	("ReferenceCount *")
+                DW_AT_decl_file	("$CHPL_HOME/modules/internal/SharedObject.chpl")
+                DW_AT_decl_line	(131)
+                DW_AT_alignment	(8)
+                DW_AT_data_member_location	(0x08)
   NULL
 ================================================================================
 Success!!


### PR DESCRIPTION
Fixes a memory leak in a dwarfdump test

Additionally, resolves a TODO for a bug which is fixed on main

- [x] `start_test test/llvm/debugInfo/dwarfdump/nothingTypes.chpl --memLeaks`

[Reviewed by @dlongnecke-cray]