### PR TITLE
Add 'module list' to EX testing configs

### DIFF
--- a/util/cron/test-gpu-ex-cpu.bash
+++ b/util/cron/test-gpu-ex-cpu.bash
@@ -12,5 +12,7 @@ export CHPL_GPU=cpu
 export CHPL_COMM=none
 export CHPL_GPU_NO_CPU_MODE_WARNING=y
 
+module list
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-ex-cpu"
 $UTIL_CRON_DIR/nightly -cron ${nightly_args}

--- a/util/cron/test-gpu-ex-cuda-11.bash
+++ b/util/cron/test-gpu-ex-cuda-11.bash
@@ -13,5 +13,7 @@ export CHPL_CUDA_PATH=$(dirname $(dirname $(which nvcc)))
 export CHPL_COMM=none
 export CHPL_GPU=nvidia  # amd is also detected automatically
 
+module list
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-ex-cuda-11"
 $UTIL_CRON_DIR/nightly -cron ${nightly_args}

--- a/util/cron/test-gpu-ex-cuda-12.bash
+++ b/util/cron/test-gpu-ex-cuda-12.bash
@@ -11,5 +11,7 @@ source $UTIL_CRON_DIR/common-gpu-nvidia-hpe-cray-ex-cuda-12.bash
 export CHPL_COMM=none
 export CHPL_GPU=nvidia  # amd is also detected automatically
 
+module list
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-ex-cuda-12"
 $UTIL_CRON_DIR/nightly -cron ${nightly_args}

--- a/util/cron/test-gpu-ex-cuda-12.colocales.bash
+++ b/util/cron/test-gpu-ex-cuda-12.colocales.bash
@@ -15,5 +15,7 @@ export CHPL_RT_LOCALES_PER_NODE=2
 export CHPL_NIGHTLY_TEST_DIRS="gpu/native/multiLocale"
 export CHPL_GPU=nvidia
 
+module list
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-ex-cuda-12.colocales"
 $UTIL_CRON_DIR/nightly -cron ${nightly_args}

--- a/util/cron/test-gpu-ex-cuda-12.interop.bash
+++ b/util/cron/test-gpu-ex-cuda-12.interop.bash
@@ -11,5 +11,7 @@ source $UTIL_CRON_DIR/common-gpu-nvidia-hpe-cray-ex-cuda-12.bash
 export CHPL_TEST_GPU=true
 export CHPL_NIGHTLY_TEST_DIRS="gpu/interop/"
 
+module list
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-ex-cuda-12.interop"
 $UTIL_CRON_DIR/nightly -cron ${nightly_args}

--- a/util/cron/test-gpu-ex-cuda-12.ofi.bash
+++ b/util/cron/test-gpu-ex-cuda-12.ofi.bash
@@ -11,5 +11,7 @@ source $UTIL_CRON_DIR/common-gpu-nvidia-hpe-cray-ex-cuda-12.bash
 export CHPL_COMM=ofi
 export CHPL_GPU=nvidia  # amd is also detected automatically
 
+module list
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-ex-cuda-12.ofi"
 $UTIL_CRON_DIR/nightly -cron ${nightly_args}

--- a/util/cron/test-gpu-ex-cuda-12.specialization.bash
+++ b/util/cron/test-gpu-ex-cuda-12.specialization.bash
@@ -14,5 +14,7 @@ export CHPL_GPU=nvidia  # amd is also detected automatically
 
 export CHPL_GPU_SPECIALIZATION=y
 
+module list
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-ex-cuda-12.specialization"
 $UTIL_CRON_DIR/nightly -cron ${nightly_args}

--- a/util/cron/test-gpu-ex-rocm-62.bash
+++ b/util/cron/test-gpu-ex-rocm-62.bash
@@ -15,5 +15,7 @@ export CHPL_LAUNCHER_PARTITION=bardpeak  # bardpeak is the default queue
 export CHPL_GPU=amd  # also detected by default
 export CHPL_GPU_ARCH=gfx90a
 
+module list
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-ex-rocm-62"
 $UTIL_CRON_DIR/nightly -cron ${nightly_args}

--- a/util/cron/test-gpu-ex-rocm-62.ofi.bash
+++ b/util/cron/test-gpu-ex-rocm-62.ofi.bash
@@ -15,5 +15,7 @@ export CHPL_LAUNCHER_PARTITION=bardpeak  # bardpeak is the default queue
 export CHPL_GPU=amd  # also detected by default
 export CHPL_GPU_ARCH=gfx90a
 
+module list
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-ex-rocm-62.ofi"
 $UTIL_CRON_DIR/nightly -cron ${nightly_args}

--- a/util/cron/test-hpe-cray-ex-ofi.bash
+++ b/util/cron/test-hpe-cray-ex-ofi.bash
@@ -17,4 +17,6 @@ export CHPL_LAUNCHER_PARTITION=bardpeak
 # ideally, we should run the whole suite
 export CHPL_NIGHTLY_TEST_DIRS="release/examples/ runtime/configMatters/ multilocale/"
 
+module list
+
 $UTIL_CRON_DIR/nightly -cron -blog ${nightly_args}

--- a/util/cron/test-perf.gpu-ex-cuda-12.bash
+++ b/util/cron/test-perf.gpu-ex-cuda-12.bash
@@ -19,6 +19,8 @@ source $UTIL_CRON_DIR/common-native-gpu-perf.bash
 # CONFIG_NAME
 source $UTIL_CRON_DIR/common-perf.bash
 
+module list
+
 nightly_args="${nightly_args} -startdate 04/04/24"
 
 $UTIL_CRON_DIR/nightly -cron ${nightly_args}

--- a/util/cron/test-perf.gpu-ex-cuda-12.um.bash
+++ b/util/cron/test-perf.gpu-ex-cuda-12.um.bash
@@ -20,6 +20,8 @@ source $UTIL_CRON_DIR/common-native-gpu-perf.bash
 # CONFIG_NAME
 source $UTIL_CRON_DIR/common-perf.bash
 
+module list
+
 SHORT_NAME=um
 nightly_args="${nightly_args} -performance-description $SHORT_NAME -performance-configs default:v,$SHORT_NAME:v -sync-dir-suffix $SHORT_NAME"
 nightly_args="${nightly_args} -startdate 10/10/24"

--- a/util/cron/test-perf.gpu-ex-rocm.bash
+++ b/util/cron/test-perf.gpu-ex-rocm.bash
@@ -25,6 +25,8 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.gpu-ex-rocm"
 
 export CHPL_TEST_PERF_CONFIG_NAME="1-node-mi250x"
 
+module list
+
 nightly_args="${nightly_args} -startdate 04/04/24"
 
 $UTIL_CRON_DIR/nightly -cron ${nightly_args}

--- a/util/cron/test-perf.hpe-cray-ex.ofi.1node.bash
+++ b/util/cron/test-perf.hpe-cray-ex.ofi.1node.bash
@@ -20,6 +20,8 @@ export CHPL_RT_COMM_OFI_EXPECTED_PROVIDER="cxi"
 export CHPL_RT_MAX_HEAP_SIZE=16g
 export CHPL_LAUNCHER_PARTITION=bardpeak
 
+module list
+
 nightly_args="${nightly_args} -no-buildcheck"
 perf_args="-performance -perflabel perf -numtrials 1"
 perf_hpe_cray_ex_args="-startdate 06/25/24"

--- a/util/cron/test-perf.hpe-cray-ex.ofi.bash
+++ b/util/cron/test-perf.hpe-cray-ex.ofi.bash
@@ -19,6 +19,8 @@ export CHPL_RT_COMM_OFI_EXPECTED_PROVIDER="cxi"
 export CHPL_RT_MAX_HEAP_SIZE="50%"
 export CHPL_LAUNCHER_PARTITION=bardpeak
 
+module list
+
 nightly_args="${nightly_args} -no-buildcheck"
 perf_args="-performance -perflabel ml- -numtrials 1"
 perf_hpe_cray_ex_args="-startdate 09/10/24"


### PR DESCRIPTION
Adds `module list` to the end of EX test configs to see the currently loaded modules just before running. This will help with debugging nightly issues.

[Not reviewed - trivial]