### PR TITLE
 Use the clang sibling dsymutil instead of the generic system one

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -5273,7 +5273,7 @@ void makeBinaryLLVM(void) {
           !fLibraryCompile;
 
     if (generateDarwinSymArchive) {
-      const char* bin = "dsymutil";
+      auto bin = findSiblingClangToolPath("dsymutil");
       const char* sfx = ".dSYM";
       const char* tmp = astr(tmpbinname, sfx);
       const char* out = astr(executableFilename.c_str(), sfx);


### PR DESCRIPTION
Switches the debug info generation to use dsymutil from the same place as `clang`, instead of the generic system one. This ensures a more consistent version of dsymutil which matches the version of clang.

- [x] `start_test test/llvm/debugInfo/dwarfdump/` on MacOS

[Reviewed by @DanilaFe]