### PR TITLE
Inline the non-param nudge upper/lower bound routines

### DIFF
--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -432,13 +432,13 @@ module ChapelRange {
       compilerError("Ranges defined using bounds of type '" + low.type:string + ".." + high.type:string + "' are not currently supported");
   }
 
-  proc chpl__nudgeLowBound(low) {
+  inline proc chpl__nudgeLowBound(low) {
     return chpl__intToIdx(low.type, chpl__idxToInt(low) + 1);
   }
   proc chpl__nudgeLowBound(param low) param {
     return chpl__intToIdx(low.type, chpl__idxToInt(low) + 1);
   }
-  proc chpl__nudgeHighBound(high) {
+  inline proc chpl__nudgeHighBound(high) {
     return chpl__intToIdx(high.type, chpl__idxToInt(high) - 1);
   }
   proc chpl__nudgeHighBound(param high) param {


### PR DESCRIPTION
While looking at some generated code that used lo..<hi ranges today, I was surprised to find a function call to compute the `hi-1` implied by `<hi`, which seems like overkill in the generated C code.  This changes the non-param versions of the routine to be inlined which seems like it can only help, and likely not hurt, the ability of the back-end compiler to optimize the code.