### PR TITLE
Mark the entire 'functions/fcf/pointers' directory as 'NOTEST'

### DIFF
--- a/test/functions/fcf/pointers/NOTEST
+++ b/test/functions/fcf/pointers/NOTEST
@@ -1,0 +1,3 @@
+This directory is marked 'NOTEST' until #27961 is merged, as it will
+fix a lot of issues which were revealed by some of the tests in this
+directory failing with the C backend.


### PR DESCRIPTION
This is a temporary measure until #27961 is merged in order to clear up nightly testing.

Three out of the five tests in this directory fail in various configurations, and I have identified some issues with the compiler code that need to be addressed. The fix is seeming to be more involved than I had initially thought. If you're interested, go check out #27961.

I think it's fine to squelch this entire directory as this is for an experimental feature (procedure pointers) regardless.