### PR TITLE
Suppress numba test with python 3.14

### DIFF
--- a/test/library/packages/Python/examples/numba/apply.suppressif
+++ b/test/library/packages/Python/examples/numba/apply.suppressif
@@ -7,6 +7,7 @@ else
   chpl_python=$($CHPL_HOME/util/config/find-python.sh)
 fi
 
+# numba doesn't support python 3.14 yet
 if $chpl_python -c 'import sys; sys.exit(int(sys.version_info[:2] != (3, 14)))' ; then
   echo "True"
 else


### PR DESCRIPTION
Suppresses an interop test with python 3.14, since we interop with numba but numba doesn't yet support python 3.14

[Not reviewed - trivial]