### PR TITLE
Adjust the committer for monitor-homebrew.yml

### DIFF
--- a/.github/workflows/monitor-homebrew.yml
+++ b/.github/workflows/monitor-homebrew.yml
@@ -60,8 +60,8 @@ jobs:
     - name: Create a new branch if file has changed
       if: ${{ (env.file_changed == 'true') && (env.branch_exists == 'false') }}
       run: |
-        git config --global user.email "github-action-bot@email.com"
-        git config --global user.name "github action"
+        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config --global user.name "github-actions[bot]"
         git checkout -b update-chapel-homebrew-release-${{ env.HASH_SUBSTRING }}
         mv hb_master_chapel.rb util/packaging/homebrew/chapel-release.rb
         git add util/packaging/homebrew/chapel-release.rb


### PR DESCRIPTION
Adjusts the committer for `monitor-homebrew.yml` to match best practices

[Reviewed by @DanilaFe]