### PR TITLE
Remove unneeded prediff

### DIFF
--- a/test/types/type_variables/numeric-return-type-internal-error.prediff
+++ b/test/types/type_variables/numeric-return-type-internal-error.prediff
@@ -1,1 +1,0 @@
-../../../util/test/prediff-obscure-module-linenos


### PR DESCRIPTION
Follow-up to https://github.com/chapel-lang/chapel/pull/27979.

.bad files are always diffed ignoring line numbers and internal error codes. So, the prediff is totally wasted.

Trivial, will not be reviewed.

## Testing
- [x] `test/types/type_variables/numeric-return-type-internal-error.chpl` still passes without prediff.

