### PR TITLE
Expand testing of CHPL_COMM_SUBSTRATE=smp

### DIFF
--- a/util/cron/test-gasnet-smp.bash
+++ b/util/cron/test-gasnet-smp.bash
@@ -4,6 +4,7 @@
 
 UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common.bash
+source $UTIL_CRON_DIR/common-localnode-paratest.bash
 
 # setup for smp
 export CHPL_COMM=gasnet
@@ -11,4 +12,4 @@ export CHPL_COMM_SUBSTRATE=smp
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gasnet-smp"
 
-$UTIL_CRON_DIR/nightly -cron -hellos ${nightly_args}
+$UTIL_CRON_DIR/nightly -cron -multilocale $(get_nightly_paratest_args 8)


### PR DESCRIPTION
Expands testing of CHPL_COMM_SUBSTRATE=smp to match other gasnet substrates

- [ ] `paratest gasnet -multilocale-only`

[Reviewed by @]