### PR TITLE
Don't use `local` outside a bash function

### DIFF
--- a/test/studies/champs/sub_test
+++ b/test/studies/champs/sub_test
@@ -84,11 +84,11 @@ fi
 # Compile CHAMPS executables
 test_compile icing
 
-local flow_success=0
+FLOW_SUCCESS=0
 
 if [ -z "$CHAMPS_QUICKSTART" ] || [ ! -z "$CHAMPS_COMPILE_ALL_EXECS" ] ; then
   test_compile prep
-  flow_success=$(test_compile flow)
+  FLOW_SUCCESS=$(test_compile flow)
   test_compile drop
   # broken!
   # test_compile potential
@@ -109,7 +109,7 @@ if [ -z "$CHAMPS_QUICKSTART" ] || [ ! -z "$CHAMPS_COMPILE_ALL_EXECS" ] ; then
 fi
 
 
-if [ -z "$CHAMPS_QUICKSTART" ] && [[ $flow_success -eq 0 ]] ; then
+if [ -z "$CHAMPS_QUICKSTART" ] && [[ $FLOW_SUCCESS -eq 0 ]] ; then
   # copy the input data to the filesystem we're running on
   # I can't tell whether prep is running too slow or just freezing, for now don't run it
   # cp $CHAMPS_DATA_PATH/CRMHL_coarse.cgns $CHAMPS_HOME/


### PR DESCRIPTION
Fixes a bash issue due to `local` not being valid outside a bash function

[Not reviewed - trivial]