### PR TITLE
Improve `gen_release` performance

### DIFF
--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -142,12 +142,12 @@ def main():
     # Just use whatever is found in $CHPL_HOME
     if "CHPL_GEN_RELEASE_NO_CLONE" in os.environ:
         # copy the current CHPL_HOME into the directory where chapel will be built
-        log("CHPL_GEN_RELEASE_NO_CLONE: Creating build workspace with tar...")
-        with cd(chplhome):
-            p = run(tar_executable, "-cf", "-", ".", stdout=subprocess.PIPE)
-            with cd(archive_dir):
-                run(tar_executable, "-xf", "-", input=p.stdout)
-            del p  # free all the memory used by the tar file
+        log("CHPL_GEN_RELEASE_NO_CLONE: Creating build workspace in", archive_dir)
+        shutil.copytree(chplhome, archive_dir,
+                        dirs_exist_ok=True,
+                        ignore_dangling_symlinks=True, symlinks=True,
+                        copy_function=shutil.copy2)
+
         resultdir = pjoin(chplhome, "tar")
     else:
         # check out a clean copy of the sources into the directory where chapel will be built


### PR DESCRIPTION
Improves the performance `gen_release`

We have recently seen an uptick in failures due to out-of-memory issues involving this script, motivating this fix. The script was using `tar` and pipes to copy files, this PR just switches it to use a native python function.

I tested this with `CHPL_GEN_RELEASE_SKIP_DOCS=1 CHPL_GEN_RELEASE_NO_CLONE=1 gtime -f '%es and %M KB' ./util/buildRelease/gen_release 2.7.0`

Before this PR: 211.80s and 2,012,368 KB
After this PR:   166.31s and      30,240 KB


[Reviewed by @benharsh]