### PR TITLE
Refactor stack unwinding logic to share implementation

### DIFF
--- a/runtime/src/error.c
+++ b/runtime/src/error.c
@@ -50,11 +50,13 @@
 #define UNW_LOCAL_ONLY
 #include <libunwind.h>
 
+
+// TODO: can we do this on other platforms? Whats platform-specific about it?
 #ifdef __linux__
 #include <dlfcn.h> // for dladdr
 // We create a pipe with addr2line and try to get a line number
 // Currently the precise line number works only on linux64
-static int chpl_unwind_getLineNum(void *addr){
+static int chpl_unwind_dladdrGetLineNum(void *addr) {
 
   int rc;
   Dl_info info;
@@ -158,60 +160,23 @@ static int chpl_unwind_getLineNum(void *addr){
 }
 #endif
 
-void chpl_stack_unwind(FILE* out, char sep) {
-  // This is just a prototype using libunwind
-  unw_cursor_t cursor;
-  unw_context_t uc;
-  unw_word_t wordValue;
-  char buffer[256];
-  unsigned int line;
+static unsigned int chpl_unwind_getLineNum(unw_cursor_t* cursor,
+                                           unw_word_t wordValue,
+                                           int tableIdx) {
+  // use the procedure line number
+  unsigned int line = chpl_filenumSymTable[tableIdx + 1];
 
-  // Check if we need to print the stack trace (default = yes)
-  if(! chpl_env_rt_get_bool("UNWIND", true)) {
-    return;
-  }
-
-  line = 0;
-  unw_getcontext(&uc);
-  unw_init_local(&cursor, &uc);
-
-  if(chpl_sizeSymTable > 0)
-    fprintf(out,"Stacktrace%c%c", sep, sep);
-
-  // This loop does the effective stack unwind, see libunwind documentation
-  while (unw_step(&cursor) > 0) {
-    unw_get_proc_name(&cursor, buffer, sizeof(buffer), &wordValue);
-    // Since this stack trace is printed out a program exit, we do not believe
-    // it is performance sensitive. Additionally, this initial implementation
-    // favors simplicity over performance.
-    //
-    // If it becomes necessary to improve performance, this code could use be
-    // faster using one of these two strategies:
-    // 1) Use a hashtable or map to find entries in chpl_funSymTable, or
-    // 2) Emit chpl_funSymTable in sorted order and use binary search on it
-    for(int t = 0; t < chpl_sizeSymTable; t+=2 ){
-      if (!strcmp(chpl_funSymTable[t], buffer)){
 #ifdef __linux__
-        unw_proc_info_t info;
-        // Maybe we can get a more precise line number
-        unw_get_proc_info(&cursor, &info);
-        line = chpl_unwind_getLineNum((void *)(info.start_ip + wordValue));
-        // We wasn't able to obtain the line number, let's use the procedure
-        // line number
-        if(line == 0)
-          line = chpl_filenumSymTable[t+1];
-#else
-        line = chpl_filenumSymTable[t+1];
+  // try and use dladdr to get a more precise line number
+  unw_proc_info_t info;
+  // Maybe we can get a more precise line number
+  unw_get_proc_info(cursor, &info);
+  unsigned int lineTmp = chpl_unwind_dladdrGetLineNum((void *)(info.start_ip + wordValue));
+  if (lineTmp != 0)
+    line = lineTmp;
 #endif
-        fprintf(out,"%s() at %s:%d%c",
-                  chpl_funSymTable[t+1],
-                  chpl_lookupFilename(chpl_filenumSymTable[t]),
-                  line,
-                  sep);
-        break;
-      }
-    }
-  }
+
+  return line;
 }
 
 // bufsz is the allocate size of the buffer
@@ -242,30 +207,44 @@ static void append_to_string(size_t* bufszArg, size_t* strszArg, char** strArg,
   *strArg = str;
 }
 
+enum chpl_stack_unwind_mode {
+  CHPL_STACK_UNWIND_MODE_FILE,
+  CHPL_STACK_UNWIND_MODE_STRING
+};
 
-char* chpl_stack_unwind_to_string(char sep) {
+
+// Helper function for chpl_stack_unwind and chpl_stack_unwind_to_string
+// mode indicates whether we are writing to a FILE* or to a string
+// out is FILE* or char**, depending on the mode
+static void chpl_stack_unwind_helper(enum chpl_stack_unwind_mode mode, char sep, void* out) {
+
   // This is just a prototype using libunwind
   unw_cursor_t cursor;
   unw_context_t uc;
   unw_word_t wordValue;
   char buffer[256];
-  int buffersz = 0;
-  unsigned int line;
 
-  char sepstr[2] = {sep, '\0'};
-
-  char* str = NULL;
-  size_t bufsz = 0;
-  size_t strsz= 0;
-
-  line = 0;
   unw_getcontext(&uc);
   unw_init_local(&cursor, &uc);
 
-  if(chpl_sizeSymTable > 0) {
-    append_to_string(&bufsz, &strsz, &str, "Stacktrace");
-    append_to_string(&bufsz, &strsz, &str, sepstr);
-    append_to_string(&bufsz, &strsz, &str, sepstr);
+  // only used with CHPL_STACK_UNWIND_MODE_STRING
+  size_t bufsz = 0;
+  size_t strsz = 0;
+  char** strPtr = (char**)out;
+  char sepstr[2] = {sep, '\0'};
+
+  if (chpl_sizeSymTable > 0) {
+    switch (mode) {
+      case CHPL_STACK_UNWIND_MODE_FILE:
+        fprintf((FILE*)out,"Stacktrace%c%c", sep, sep);
+      break;
+      case CHPL_STACK_UNWIND_MODE_STRING: {
+        append_to_string(&bufsz, &strsz, strPtr, "Stacktrace");
+        append_to_string(&bufsz, &strsz, strPtr, sepstr);
+        append_to_string(&bufsz, &strsz, strPtr, sepstr);
+      }
+      break;
+    }
   }
 
   // This loop does the effective stack unwind, see libunwind documentation
@@ -279,43 +258,56 @@ char* chpl_stack_unwind_to_string(char sep) {
     // faster using one of these two strategies:
     // 1) Use a hashtable or map to find entries in chpl_funSymTable, or
     // 2) Emit chpl_funSymTable in sorted order and use binary search on it
-    for(int t = 0; t < chpl_sizeSymTable; t+=2 ){
-      if (!strcmp(chpl_funSymTable[t], buffer)){
-#ifdef __linux__
-        unw_proc_info_t info;
-        // Maybe we can get a more precise line number
-        unw_get_proc_info(&cursor, &info);
-        line = chpl_unwind_getLineNum((void *)(info.start_ip + wordValue));
-        // We wasn't able to obtain the line number, let's use the procedure
-        // line number
-        if(line == 0)
-          line = chpl_filenumSymTable[t+1];
-#else
-        line = chpl_filenumSymTable[t+1];
-#endif
+    for (int t = 0; t < chpl_sizeSymTable; t+=2 ) {
+      if (!strcmp(chpl_funSymTable[t], buffer)) {
+        unsigned int line = chpl_unwind_getLineNum(&cursor, wordValue, t);
+        switch (mode) {
+          case CHPL_STACK_UNWIND_MODE_FILE:
+            fprintf((FILE*)out, "%s() at %s:%d%c",
+                     chpl_funSymTable[t+1],
+                     chpl_lookupFilename(chpl_filenumSymTable[t]),
+                     line,
+                     sep);
+          break;
+          case CHPL_STACK_UNWIND_MODE_STRING: {
+            int buffersz = snprintf(buffer, sizeof(buffer), "%d", line);
+            if (buffersz < 0)
+              buffer[0] = '\0';
 
-        buffersz = snprintf(buffer, sizeof(buffer), "%d", line);
-        if (buffersz < 0)
-          buffer[0] = '\0';
-
-        append_to_string(&bufsz, &strsz, &str, chpl_funSymTable[t+1]);
-        append_to_string(&bufsz, &strsz, &str, "() at ");
-        append_to_string(&bufsz, &strsz, &str,
-                         chpl_lookupFilename(chpl_filenumSymTable[t]));
-        append_to_string(&bufsz, &strsz, &str, ":");
-        append_to_string(&bufsz, &strsz, &str, buffer); // line number
-        append_to_string(&bufsz, &strsz, &str, sepstr);
-
-        break;
+            append_to_string(&bufsz, &strsz, strPtr, chpl_funSymTable[t+1]);
+            append_to_string(&bufsz, &strsz, strPtr, "() at ");
+            append_to_string(&bufsz, &strsz, strPtr,
+                            chpl_lookupFilename(chpl_filenumSymTable[t]));
+            append_to_string(&bufsz, &strsz, strPtr, ":");
+            append_to_string(&bufsz, &strsz, strPtr, buffer); // line number
+            append_to_string(&bufsz, &strsz, strPtr, sepstr);
+          }
+          break;
+        }
       }
     }
   }
 
-  // add null terminator
-  if (str != NULL) {
-    str[strsz] = '\0';
+  if (mode == CHPL_STACK_UNWIND_MODE_STRING) {
+    // add null terminator
+    if (*strPtr != NULL) {
+      (*strPtr)[strsz] = '\0';
+    }
   }
+}
 
+
+void chpl_stack_unwind(FILE* out, char sep) {
+  // Check if we need to print the stack trace (default = yes)
+  if (!chpl_env_rt_get_bool("UNWIND", true)) {
+    return;
+  }
+  chpl_stack_unwind_helper(CHPL_STACK_UNWIND_MODE_FILE, sep, out);
+}
+
+char* chpl_stack_unwind_to_string(char sep) {
+  char* str = NULL;
+  chpl_stack_unwind_helper(CHPL_STACK_UNWIND_MODE_STRING, sep, (void*)&str);
   return str;
 }
 


### PR DESCRIPTION
Refactors two different pieces of stack unwinding logic to be shared

- [x] paratest with/without gasnet with `CHPL_UNWIND=bundled`

[Reviewed by @DanilaFe]