### PR TITLE
Replace mentions of "generated C code" with "generated code"

### DIFF
--- a/doc/rst/usingchapel/compiling.rst
+++ b/doc/rst/usingchapel/compiling.rst
@@ -55,16 +55,16 @@ Flags                   Description
                         module is used (minus its ``.chpl`` extension).
 ``--no-checks``         turns off runtime semantic checks like bounds
                         checking and nil class instance dereferencing
-``-O``                  turns on optimization of the generated C code
+``-O``                  turns on backend optimization of the generated code
 ``--fast``              turns on ``--no-checks``, ``-O``, and enables
                         many other optimizations
 ``-s <name[=expr]>``    set a config declaration with the given expression
                         as its default value (config params must be set
                         to values that are known at compile time)
 ``-M <dir>``            add the specified directory to the module search path
-``--savec <dir>``       saves the generated C code in the specified
+``--savec <dir>``       saves the generated code in the specified
                         directory
-``-g``                  support debugging of the generated C code
+``-g``                  support debugging of the generated code
 ``--ccflags <flags>``   specify flags that should be used when invoking
                         the back-end C compiler
 ``--ldflags <flags>``   specify flags that should be used when invoking


### PR DESCRIPTION
Replace mentions of "generated C code" with "generated code" since it could be generated LLVM or C code

[Not reviewed - trivial]