### PR TITLE
Use `pkg-config` for ubuntu22 linux package

### DIFF
--- a/util/packaging/apt/ubuntu22/Dockerfile.template
+++ b/util/packaging/apt/ubuntu22/Dockerfile.template
@@ -11,7 +11,7 @@ RUN apt-get update && \
       python3 python3-dev python3-venv bash make mawk git pkg-config cmake \
       llvm-dev llvm clang libclang-dev libclang-cpp-dev libedit-dev \
       libpmi2-0-dev libslurm-dev \
-      pkgconf libgmp-dev libhwloc-dev
+      pkg-config libgmp-dev libhwloc-dev
 
 @@{USER_CREATION}
 

--- a/util/packaging/apt/ubuntu22/control.template
+++ b/util/packaging/apt/ubuntu22/control.template
@@ -3,4 +3,4 @@ Version: @@{CHAPEL_VERSION}
 Maintainer: chapel-lang
 Architecture: @@{TARGETARCH}
 Description: Chapel Programming Language
-Depends: git,gcc,llvm-dev,llvm,clang,libclang-dev,libclang-cpp-dev,python3,python3-dev,python3-venv,make,libpmi2-0-dev,libslurm-dev,pkgconf,libgmp-dev,libhwloc-dev
+Depends: git,gcc,llvm-dev,llvm,clang,libclang-dev,libclang-cpp-dev,python3,python3-dev,python3-venv,make,libpmi2-0-dev,libslurm-dev,pkg-config,libgmp-dev,libhwloc-dev


### PR DESCRIPTION
Switch usage of `pkgconf` to `pkg-config` for ubuntu22 linux package due to `pkgconf` causing incompatibilities with other packages.

[Not reviewed - trivial]