### PR TITLE
Build mason with optimization

### DIFF
--- a/tools/mason/buildMason
+++ b/tools/mason/buildMason
@@ -26,7 +26,7 @@ if command -v module > /dev/null 2>&1 ; then
   fi
 fi
 
-if ! $chplBinDir/chpl --launcher=none mason.chpl -o $chplBinDir/mason; then
+if ! $chplBinDir/chpl --launcher=none --fast --checks --no-specialize mason.chpl -o $chplBinDir/mason; then
   cat<<EOF
   Error building mason.
 EOF


### PR DESCRIPTION
Builds `mason` with optimizations, which should improve the user experience with mason and make it run faster.

Out of an abundance of caution, this PR use `--fast --checks --no-specialize` to enable optimizations
* `--checks` to re-enable checks so if `mason` has a bug/halts, its a nicer error than just a segfault
* `--no-specialize` out of an abundance of caution to avoid issues when `CHPL_TARGET_CPU!=none`

- [x] paratest

[Reviewed by @benharsh]