### PR TITLE
Fix -Wgnu warnings on linux64 aarch64

### DIFF
--- a/make/compiler/Makefile.clang
+++ b/make/compiler/Makefile.clang
@@ -144,7 +144,11 @@ SQUASH_WARN_GEN_CFLAGS += -Wno-tautological-compare
 #
 # warn for unwanted GNU extension usages
 #
-RUNTIME_GNU_WARNINGS = -Wgnu -Wno-gnu-folding-constant -Wno-zero-length-array -Wno-gnu-zero-variadic-macro-arguments
+RUNTIME_GNU_WARNINGS = -Wgnu -Wno-gnu-folding-constant \
+  	                         -Wno-zero-length-array \
+  		                       -Wno-gnu-zero-variadic-macro-arguments \
+  		                       -Wno-gnu-empty-struct \
+                             -Wno-gnu-statement-expression-from-macro-expansion
 
 #
 # compiler warnings settings


### PR DESCRIPTION
Fixes new -Wgnu warnings on linux64 aarch64 on arm due to new usage of libunwind

[Not reviewed - trivial]