### PR TITLE
Add python3 shebang to `update-release-and-version-info`

### DIFF
--- a/util/config/update-release-and-version-info
+++ b/util/config/update-release-and-version-info
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import argparse
 from enum import Enum
 


### PR DESCRIPTION
Add missing shebang to the Python script `util/config/update-release-and-version-info`.

Though it worked previously, for some reason my machine just started trying to interpret it as a Bash script, causing compilation to fail.

[trivial, not reviewed]