### PR TITLE
Avoid compression libraries with CHPL_UNWIND=bundled

### DIFF
--- a/third-party/libunwind/Makefile
+++ b/third-party/libunwind/Makefile
@@ -5,7 +5,12 @@ endif
 CHPL_MAKE_HOST_TARGET = --target
 include $(CHPL_MAKE_HOME)/make/Makefile.base
 
-CHPL_LIBUNWIND_CFG_OPTIONS = --prefix=$(LIBUNWIND_INSTALL_DIR) --disable-shared --disable-coredump --disable-cxx-exceptions
+CHPL_LIBUNWIND_CFG_OPTIONS = --prefix=$(LIBUNWIND_INSTALL_DIR) \
+                             --disable-shared \
+                             --disable-coredump \
+                             --disable-cxx-exceptions \
+                             --disable-minidebuginfo \
+                             --disable-zlibdebuginfo
 
 ifeq ($(CHPL_MAKE_LIB_PIC),pic)
 CFLAGS += $(SHARED_LIB_CFLAGS)


### PR DESCRIPTION
Avoid building/depending on compression libraries with CHPL_UNWIND=bundled, since we aren't using compression.

I came across this issue while looking at related issues with CHPL_UNWIND=system, and it seemed like a simple fix

Resolves https://github.com/chapel-lang/chapel/issues/11269

[Reviewed by @arifthpe]