### PR TITLE
Avoid `lzma` with a system install of libunwind

### DIFF
--- a/util/chplenv/chpl_unwind.py
+++ b/util/chplenv/chpl_unwind.py
@@ -56,7 +56,7 @@ def get_compile_args():
 
     if unwind_val == 'bundled':
         return third_party_utils.get_bundled_compile_args('libunwind')
-    elif unwind_val == 'system' :
+    elif unwind_val == 'system':
         args = third_party_utils.pkgconfig_get_system_compile_args('libunwind')
     return args
 
@@ -80,6 +80,9 @@ def get_link_args():
         args = third_party_utils.pkgconfig_get_bundled_link_args('libunwind')
     elif unwind_val == 'system':
         args = third_party_utils.pkgconfig_get_system_link_args('libunwind', static=True)
+        # remove `-llzma` from the system link args if present
+        if '-llzma' in args[1]:
+            args[1].remove('-llzma')
     return args
 
 


### PR DESCRIPTION
Avoids linking against lzma with a system install of libunwind

This fixes an issue we saw in portability testing with opensuse and alpine linux where linking against libunwind statically tries to also link against lzma, which is not actually listed as a dependency of the system libunwind in the package managers. This results in link failures.

Since we aren't using compression features anyways, it seems to be sufficient to just avoid lzma.

- [x] `make check` on opensuse
- [x] `start_test test/runtime/stacktrace/stacktrace.chpl` on opensuse 

[Reviewed by @arifthpe]