### PR TITLE
Fix portability of `-Wno-gnu-*` warnings

### DIFF
--- a/make/compiler/Makefile.clang
+++ b/make/compiler/Makefile.clang
@@ -145,10 +145,10 @@ SQUASH_WARN_GEN_CFLAGS += -Wno-tautological-compare
 # warn for unwanted GNU extension usages
 #
 RUNTIME_GNU_WARNINGS = -Wgnu -Wno-gnu-folding-constant \
-  	                         -Wno-zero-length-array \
-  		                       -Wno-gnu-zero-variadic-macro-arguments \
-  		                       -Wno-gnu-empty-struct \
-                             -Wno-gnu-statement-expression-from-macro-expansion
+                             -Wno-zero-length-array \
+                             -Wno-gnu-zero-variadic-macro-arguments \
+                             -Wno-gnu-empty-struct \
+                             -Wno-gnu-statement-expression
 
 #
 # compiler warnings settings


### PR DESCRIPTION
Fixes a portability issue with `-Wno-gnu-statement-expression-from-macro-expansion`, which was not added until clang 15.

`-Wno-gnu-statement-expression` exists in prior versions of clang and controls `-Wno-gnu-statement-expression-from-macro-expansion` in later versions of clang

[Not reviewed - trivial]