### PR TITLE
Add epel-release to CentOS Stream dependencies

### DIFF
--- a/doc/rst/usingchapel/prereqs-commands.rst
+++ b/doc/rst/usingchapel/prereqs-commands.rst
@@ -57,6 +57,7 @@
   * CentOS Stream 10, 9::
 
       sudo dnf upgrade
+      sudo dnf install epel-release
       sudo dnf install gcc gcc-c++ m4 perl python3 python3-devel bash make gawk git cmake libunwind-devel
       sudo dnf install which diffutils
       sudo dnf install llvm-devel clang clang-devel

--- a/util/devel/test/portability/apptainer/current/centos-stream-10-nollvm/image.def
+++ b/util/devel/test/portability/apptainer/current/centos-stream-10-nollvm/image.def
@@ -6,6 +6,7 @@ From: quay.io/centos/centos:stream10
 
 %post
     /provision-scripts/dnf-upgrade.sh
+    /provision-scripts/dnf-epel.sh
     /provision-scripts/dnf-deps.sh
 
 %runscript

--- a/util/devel/test/portability/apptainer/current/centos-stream-10/image.def
+++ b/util/devel/test/portability/apptainer/current/centos-stream-10/image.def
@@ -6,6 +6,7 @@ From: quay.io/centos/centos:stream10
 
 %post
     /provision-scripts/dnf-upgrade.sh
+    /provision-scripts/dnf-epel.sh
     /provision-scripts/dnf-deps.sh
     # installing llvm-devel installs LLVM 19
     /provision-scripts/dnf-llvm.sh

--- a/util/devel/test/portability/apptainer/current/centos-stream-9-nollvm/image.def
+++ b/util/devel/test/portability/apptainer/current/centos-stream-9-nollvm/image.def
@@ -6,6 +6,7 @@ From: quay.io/centos/centos:stream9
 
 %post
     /provision-scripts/dnf-upgrade.sh
+    /provision-scripts/dnf-epel.sh
     /provision-scripts/dnf-deps.sh
 
 %runscript

--- a/util/devel/test/portability/apptainer/current/centos-stream-9/image.def
+++ b/util/devel/test/portability/apptainer/current/centos-stream-9/image.def
@@ -6,6 +6,7 @@ From: quay.io/centos/centos:stream9
 
 %post
     /provision-scripts/dnf-upgrade.sh
+    /provision-scripts/dnf-epel.sh
     /provision-scripts/dnf-deps.sh
     # installing llvm-devel installs LLVM 18
     /provision-scripts/dnf-llvm.sh


### PR DESCRIPTION
Adds epel-release to CentOS Stream dependencies, similar to other RHEL-based linux distributions

[Reviewed by @arifthpe]