### PR TITLE
Patch libunwind to avoid GCC 15 issues

### DIFF
--- a/third-party/libunwind/README
+++ b/third-party/libunwind/README
@@ -10,6 +10,30 @@ convenience and was obtained from:
 Any Chapel issues that seem to be related to libunwind should be
 directed to the Chapel team at https://chapel-lang.org/bugs.html.
 
+Chapel modifications to libunwind
+=================================
+
+Avoid issue with GCC 15. This is a simple patch, the full PR is
+https://github.com/libunwind/libunwind/pull/831. When that is included in a
+release this patch will no longer be needed.
+
+```
+--- a/libunwind-src/tests/Gtest-nomalloc.c
++++ b/libunwind-src/tests/Gtest-nomalloc.c
+@@ -37,10 +37,10 @@ int in_unwind;
+ void *
+ malloc(size_t s)
+ {
+-  static void * (*func)();
++  static void * (*func)(size_t);
+ 
+   if(!func)
+-    func = (void *(*)()) dlsym(RTLD_NEXT, "malloc");
++    func = (void *(*)(size_t)) dlsym(RTLD_NEXT, "malloc");
+ 
+   if (in_unwind) {
+     num_errors++;
+```
 
 Upgrading libunwind versions
 ========================
@@ -21,6 +45,7 @@ follows, assuming the CWD is $CHPL_HOME/third-party/libunwind/:
 1. `wget https://github.com/libunwind/libunwind/releases/download/v1.8.3/libunwind-1.8.3.tar.gz && tar xf libunwind-1.8.3.tar.gz`
 2. `rm -rf libunwind-src`
 3. `mv libunwind-1.8.3 libunwind-src`
+4. Validate and apply any patches listed above
 4. `git add --force libunwind-src` (--force to ignore our .gitignore)
 5. update the version number mentioned above
 6. make sure these instructions are up to date :)

--- a/third-party/libunwind/libunwind-src/tests/Gtest-nomalloc.c
+++ b/third-party/libunwind/libunwind-src/tests/Gtest-nomalloc.c
@@ -37,10 +37,10 @@ int in_unwind;
 void *
 malloc(size_t s)
 {
-  static void * (*func)();
+  static void * (*func)(size_t);
 
   if(!func)
-    func = (void *(*)()) dlsym(RTLD_NEXT, "malloc");
+    func = (void *(*)(size_t)) dlsym(RTLD_NEXT, "malloc");
 
   if (in_unwind) {
     num_errors++;


### PR DESCRIPTION
Patch a libunwind test to avoid GCC 15 issues

The actual upstream patch is quite large, so this PR makes minimal changes as suggested by @PHHargrove 

Confirmed that `CHPL_TARGET_COMPILER=gnu make` works with GCC 15

[Reviewed by @benharsh]