### PR TITLE
Add EPEL before dep install on almalinux-10-nollvm

### DIFF
--- a/util/devel/test/portability/apptainer/current/almalinux-10-nollvm/image.def
+++ b/util/devel/test/portability/apptainer/current/almalinux-10-nollvm/image.def
@@ -6,8 +6,8 @@ From: almalinux:10
 
 %post
     /provision-scripts/dnf-upgrade.sh
-    /provision-scripts/dnf-deps.sh
     /provision-scripts/dnf-epel.sh
+    /provision-scripts/dnf-deps.sh
 
 %runscript
     ../../provision-scripts/run.sh "$@"


### PR DESCRIPTION
Adjust order of `almalinux-10-nollvm` Apptainer image def so EPEL is added before trying to install other dependencies.

Follow up to https://github.com/chapel-lang/chapel/pull/28053.

[trivial, not reviewed]