### PR TITLE
Ignore stringop-overread warnings on gcc 11

### DIFF
--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -224,9 +224,9 @@ endif
 # haven't seen problems in practice and run testing with asan, I'm
 # squashing as in the previous case.
 #
-# Also skip this warning for GCC 12 since we saw the issue there in
+# Also skip this warning for GCC 11/12 since we saw the issue there in
 # some configurations.
-ifeq ($(shell test $(GNU_GCC_MAJOR_VERSION) -ge 12; echo "$$?"),0)
+ifeq ($(shell test $(GNU_GCC_MAJOR_VERSION) -ge 11; echo "$$?"),0)
 SQUASH_WARN_GEN_CFLAGS += -Wno-stringop-overread
 endif
 


### PR DESCRIPTION
Add an ignore for stringop-overread warnings on gcc 11

[Not reviewed - trivial]