### PR TITLE
Store arkouda HTML output alongside .dat files

### DIFF
--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -162,7 +162,7 @@ if [ ${CHPL_TEST_ARKOUDA_STOP_AFTER_BUILD} = "false" ]; then
 
   # Run benchmarks
   if [ "${CHPL_TEST_ARKOUDA_PERF}" = "true" ] ; then
-    benchmark_opts="--save-data --dat-dir $CHPL_TEST_PERF_DIR --gen-graphs --graph-dir $CHPL_TEST_PERF_DIR/html"
+    benchmark_opts="--save-data --dat-dir $CHPL_TEST_PERF_DIR --gen-graphs --graph-dir $CHPL_TEST_PERF_DIR/$CHPL_TEST_PERF_DESCRIPTION/html"
     if [ "${CHPL_TEST_GEN_ARKOUDA_GRAPHS}" = "false" ] ; then
         # Where should perf logs go?
         export ARKOUDA_TEST_PERF_DIR="${WORKSPACE}/perfData"
@@ -209,7 +209,7 @@ if [ ${CHPL_TEST_ARKOUDA_STOP_AFTER_BUILD} = "false" ]; then
 
   # Run benchmarks_v2
   if [ "${CHPL_TEST_ARKOUDA_PERF_V2}" = "true" ] ; then
-    reformat_benchmark_opts=" --dat-dir $CHPL_TEST_PERF_DIR --graph-dir $CHPL_TEST_PERF_DIR/html"
+    reformat_benchmark_opts=" --dat-dir $CHPL_TEST_PERF_DIR --graph-dir $CHPL_TEST_PERF_DIR/$CHPL_TEST_PERF_DESCRIPTION/html"
     if [ "${CHPL_TEST_GEN_ARKOUDA_GRAPHS}" = "false" ] ; then
       # v2 benchmarks do not support not generating graphs
       log_fatal_error "CHPL_TEST_GEN_ARKOUDA_GRAPHS must be true for benchmarks_v2"

--- a/util/cron/common-arkouda.bash
+++ b/util/cron/common-arkouda.bash
@@ -112,8 +112,8 @@ function test_nightly() {
 
 function sync_graphs() {
   if [[ -n $CHPL_TEST_PERF_SYNC_DIR_SUFFIX ]]; then
-    $CHPL_HOME/util/cron/syncPerfGraphs.py $CHPL_TEST_PERF_DIR/html/ arkouda/$CHPL_TEST_PERF_CONFIG_NAME/$CHPL_TEST_PERF_SYNC_DIR_SUFFIX
+    $CHPL_HOME/util/cron/syncPerfGraphs.py $CHPL_TEST_PERF_DIR/$CHPL_TEST_PERF_DESCRIPTION/html/ arkouda/$CHPL_TEST_PERF_CONFIG_NAME/$CHPL_TEST_PERF_SYNC_DIR_SUFFIX
   else
-    $CHPL_HOME/util/cron/syncPerfGraphs.py $CHPL_TEST_PERF_DIR/html/ arkouda/$CHPL_TEST_PERF_CONFIG_NAME
+    $CHPL_HOME/util/cron/syncPerfGraphs.py $CHPL_TEST_PERF_DIR/$CHPL_TEST_PERF_DESCRIPTION/html/ arkouda/$CHPL_TEST_PERF_CONFIG_NAME
   fi
 }


### PR DESCRIPTION
This commit uses ``$CHPL_TEST_PERF_DESCRIPTION`` to unique-ify the
output HTML directories instead of using the same common directory
that happens to serve as a parent of the already unique .dat file
directories.

This manually mimics some behavior in arkouda's run_benchmarks script,
which already appends the description to the .dat file directory path.

The arkouda sub_test is updated with the new path for ``--graph-dir``,
and the common arkouda cron script is updated to rsync from those
directories.