### PR TITLE
Dyno: update .good file with new test output

### DIFF
--- a/util/misc/dyno-ignore-good-files.patch
+++ b/util/misc/dyno-ignore-good-files.patch
@@ -1472,14 +1472,20 @@ index 9b2d9720d02..071dcfab346 100644
 +init-new-changes-type.chpl:20: error: final result of initialization does not match the initial type
 +init-new-changes-type.chpl:16: note: field 't' started with type 'int(64)', but had incompatible type 'real(64)' after initialization
 diff --git a/test/types/records/bad-change-type/init-uses-default.good b/test/types/records/bad-change-type/init-uses-default.good
-index 66d88624433..d2cc17f6a5e 100644
+index 66d88624433..656035472dd 100644
 --- a/test/types/records/bad-change-type/init-uses-default.good
 +++ b/test/types/records/bad-change-type/init-uses-default.good
-@@ -1,4 +1 @@
+@@ -1,4 +1,7 @@
 -init-uses-default.chpl:11: error: cannot default-initialize a variable with generic type
 -init-uses-default.chpl:11: note: 'xx' has generic type 'R'
 -init-uses-default.chpl:11: note: cannot find initialization point to split-init this variable
 -init-uses-default.chpl:12: note: 'xx' is used here before it is initialized
++init-uses-default.chpl:12: error: unable to resolve call to 'writeln': no matching candidates
++$CHPL_HOME/modules/standard/ChapelIO.chpl:409: note: the following candidate didn't match because it does not initialize an actual which expects to be initialized
++init-uses-default.chpl:11: note: The actual 'xx' expects to be split-initialized because it is declared with a generic type and no initialization expression here
++init-uses-default.chpl:12: note: The call to 'writeln' occurs before any valid initialization points
++$CHPL_HOME/modules/standard/ChapelIO.chpl:403: note: the following candidate didn't match because it does not initialize an actual which expects to be initialized
++init-uses-default.chpl:12: note: omitting 1 more candidates that didn't match
 +init-uses-default.chpl:11: error: cannot default initialize variable using generic or unknown type
 diff --git a/test/types/records/bad-change-type/range-init1.good b/test/types/records/bad-change-type/range-init1.good
 index 17f6c7aa48d..d30584ffcf1 100644


### PR DESCRIPTION
Not sure why this didn't come up in paratests before, but the change seems benign. We are going to need to fine-tune the errors from non-`out`-initializing calls a bit, but this isn't a priority right now.

Trivial, will not be reviewed.