### PR TITLE
Unload newly-loaded `libsci` module in EX build configs

### DIFF
--- a/util/cron/common-hpe-cray-ex.bash
+++ b/util/cron/common-hpe-cray-ex.bash
@@ -11,6 +11,9 @@ module swap gcc gcc/12.2.0
 # Our test machine actually calls it 'gcc-native'
 module swap gcc-native gcc-native/12.3
 
+# Newest cray-libsci doesn't work with gnu/12.2.0, and we don't need it anyway
+module unload cray-libsci
+
 module load cray-pmi
 
 export CHPL_HOST_PLATFORM=hpe-cray-ex


### PR DESCRIPTION
These modules started getting loaded recently, and they don't work with the GCC version we specify. Since they previously weren't loaded at all, and are now a part of the sysem config, just unload it.

Since this module wasn't present in builds prior to last week, I think unloading it is safe.

Reviewed by @benharsh -- thanks!