### PR TITLE
Fix unused variable warning in llvmDebug.cpp

### DIFF
--- a/compiler/llvm/llvmDebug.cpp
+++ b/compiler/llvm/llvmDebug.cpp
@@ -199,7 +199,7 @@ void DebugData::finalize() {
       // then remove the same number of pointers from newDI
       auto [baseOldDI, numPtrs] =
         removePointersAndQualifiers(llvm::cast<llvm::DIType>(oldDI));
-      auto [baseNewDI, _] = removePointersAndQualifiers(newDI, numPtrs);
+      auto baseNewDI = std::get<0>(removePointersAndQualifiers(newDI, numPtrs));
 
       auto dibuilder = ts->getModule()->llvmDIBuilder;
       dibuilder->replaceTemporary(llvm::TempDIType(baseOldDI), baseNewDI);
@@ -415,7 +415,7 @@ llvm::DIType* DebugData::constructTypeForAggregate(llvm::StructType* ty,
       // remove any pointers we added to the fwd
       // then remove the same number of pointers from N
       auto [baseFwd, numPtrs] = removePointersAndQualifiers(fwd);
-      auto [baseN, _] = removePointersAndQualifiers(N, numPtrs);
+      auto baseN = std::get<0>(removePointersAndQualifiers(N, numPtrs));
 
       dibuilder->replaceTemporary(llvm::TempDIType(baseFwd), baseN);
       type->symbol->llvmDIForwardType = nullptr;


### PR DESCRIPTION
Probably introduced in https://github.com/chapel-lang/chapel/pull/27841.

C++ doesn't support `_` in unpacking declarations in the way we are used to, from, say, Python. So, here, the code treats `_` as a normal variable that is unused. Use `std::get` instead of unpacking to not have to provide a dummy name for the relevant variable.

We didn't notice this until earlier because this issue only comes up with `CHPL_DEVELOPER=1`.

Reviewed by @dlongnecke-cray -- thanks!

## Testing
- [x] code now compiles on our GCC 7.5 machine