### PR TITLE
Improve CLS/mason integration

### DIFF
--- a/tools/chpl-language-server/src/lsp_util.py
+++ b/tools/chpl-language-server/src/lsp_util.py
@@ -1402,7 +1402,8 @@ class CLSConfig:
 
     def _mason_setup(self):
         # if this is a mason project, add 'src' as a module-dir
-        self.args["module_dir"] = self.args["module_dir"] + ["src"]
+        if os.path.exists(os.path.join(os.getcwd(), "Mason.toml")):
+            self.args["module_dir"] = self.args["module_dir"] + ["src"]
 
     def parse_args(self):
         self.args = copy.deepcopy(vars(self.parser.parse_args()))


### PR DESCRIPTION
Improves the CLS/mason integration so that a user opening a mason project should just have everything work out of the box.

Resolves https://github.com/chapel-lang/chapel/issues/25120

[Reviewed by @DanilaFe]