### PR TITLE
Further cleanup for apptainer temp directories

### DIFF
--- a/util/devel/test/portability/provision-scripts/yum-deps-amazonlinux-2.sh
+++ b/util/devel/test/portability/provision-scripts/yum-deps-amazonlinux-2.sh
@@ -20,3 +20,5 @@ unsudo make
 make install
 
 update-alternatives --install /usr/bin/cmake cmake /usr/local/bin/cmake 1
+
+hide rm -rf $MYTMP

--- a/util/devel/test/portability/provision-scripts/yum-deps-centos-7.sh
+++ b/util/devel/test/portability/provision-scripts/yum-deps-centos-7.sh
@@ -26,3 +26,5 @@ unsudo make
 make install
 
 update-alternatives --install /usr/bin/cmake cmake /usr/local/bin/cmake 1
+
+hide rm -rf $MYTMP


### PR DESCRIPTION
This PR removes temp dirs after building cmake in the centos and amazonlinux builds.