### PR TITLE
Properly quote args in chpl-parallel-dbg

### DIFF
--- a/tools/chpl-parallel-dbg/chpl-parallel-dbg
+++ b/tools/chpl-parallel-dbg/chpl-parallel-dbg
@@ -47,4 +47,4 @@ commands_file="$CHPL_HOME/runtime/etc/debug/chpl_parallel_dbg_commands.py"
 lldb \
   -o "command script import '$commands_file'" \
   -o "connect $real_name $numLocales" \
-  $@
+  "$@"


### PR DESCRIPTION
Properly quotes the extra args passed to `chpl-parallel-dbg`

[Not reviewed - trivial]