### PR TITLE
Add note about using unofficial FreeBSD Vagrant boxes

### DIFF
--- a/util/devel/test/portability/vagrant/README.md
+++ b/util/devel/test/portability/vagrant/README.md
@@ -29,6 +29,14 @@ supported / most recommended and the boxes (such as bento and ubuntu
 images that the Vagrantfiles specify to download) usually start with
 VirtualBox support.
 
+### Note on FreeBSD boxes
+
+[Official FreeBSD
+boxes](https://portal.cloud.hashicorp.com/vagrant/discover/freebsd) have not
+been published since version 13.4, so we've switched to using the [Bento
+project boxes](https://portal.cloud.hashicorp.com/vagrant/discover/bento) for
+FreeBSD.
+
 ## About the scripts in this directory
 
 The scripts in this directory automate common tasks that amount to doing


### PR DESCRIPTION
Add a note to the Vagrant testing README to note that we don't use official FreeBSD boxes, because they haven't been updated for several releases.

[trivial, not reviewed]