### PR TITLE
Fix CHAMPS perf graphs not being generated

### DIFF
--- a/test/studies/champs/functions.bash
+++ b/test/studies/champs/functions.bash
@@ -88,10 +88,10 @@ function test_compile() {
 
   test_start "make $kind"
   make $version $make_vars 2> $kind.comp.out.tmp
-  local status=$?
+  export test_compile_status=$?
   cat $kind.comp.out.tmp
 
-  if [[ $status -ne 0 ]] ; then
+  if [[ $test_compile_status -ne 0 ]] ; then
     log_error "compiling ${kind}"
   else
     log_success "make output"
@@ -104,8 +104,8 @@ function test_compile() {
   fi
 
   # early return if compilation failed, to prevent spurious perf stats errors
-  if [[ $status -ne 0 ]] ; then
-    return $status
+  if [[ $test_compile_status -ne 0 ]] ; then
+    return
   fi
 
   if [ -z "$CHAMPS_QUICKSTART" ]; then
@@ -119,8 +119,6 @@ function test_compile() {
       log_error "computing emitted code size stats for ${kind}"
     fi
   fi
-
-  return $status
 }
 
 function test_run() {
@@ -132,12 +130,12 @@ function test_run() {
   # Why?
   eval $CHPL_TEST_LAUNCHCMD --walltime=2:00:00 ./bin/champs_${CHAMPS_VERSION}_$kind -nl $nl -f $kind.in 2>&1 >$kind.exec.out.tmp
 
-  local status=$?
+  export test_run_status=$?
   cat $kind.exec.out.tmp
 
-  if [[ $status -ne 0 ]] ; then
+  if [[ $test_run_status -ne 0 ]] ; then
     log_fatal_error "running ${kind}"
-  else 
+  else
     log_success "$kind output"
   fi
   test_end

--- a/test/studies/champs/sub_test
+++ b/test/studies/champs/sub_test
@@ -88,7 +88,8 @@ FLOW_SUCCESS=0
 
 if [ -z "$CHAMPS_QUICKSTART" ] || [ ! -z "$CHAMPS_COMPILE_ALL_EXECS" ] ; then
   test_compile prep
-  FLOW_SUCCESS=$(test_compile flow)
+  test_compile flow
+  FLOW_SUCCESS=$test_compile_status
   test_compile drop
   # broken!
   # test_compile potential


### PR DESCRIPTION
Fixes the CHAMPS perf graphs, which where not being generated due to an issue with the bash script.

The `return $status` was not working since other code was doing `echo` before it, causing the bash return value to not be correct.

[Reviewed by @benharsh]