### PR TITLE
Dyno: Fix passing of string to c_ptr

### DIFF
--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -829,6 +829,10 @@ void CallInitDeinit::resolveMoveInit(const AstNode* ast,
       // resolve a copy init and a deinit to deinit the temporary
       if (lhsGenUnk || rhsGenUnk) {
         CHPL_ASSERT(false && "should not be reached");
+      } else if (lhsType.type()->isCPtrType() &&
+                 rhsType.type()->isStringLikeType()) {
+        // Passing string to c_ptr should just coerce
+        // TODO: Should we generate a call to c_str()?
       } else {
         resolveCopyInit(ast, rhsAst, lhsType, rhsType,
                         /* forMoveInit */ true,


### PR DESCRIPTION
We should not resolve an assignment operator, and instead allow the coercion.

Resolves most of the cascade of failures from last night's testing.

Trivial, not reviewed.