### PR TITLE
Change one more mason output to use writeln

### DIFF
--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -311,7 +311,7 @@ proc getSrcCode(sourceListArg: list(3*string), skipUpdate, show) throws {
       if !depExists(nameVers) {
         if skipUpdate then
           throw new owned MasonError("Dependency cannot be installed when MASON_OFFLINE is set.");
-        log.infoln("Downloading dependency: " + nameVers);
+        writeln("Downloading dependency: " + nameVers);
         var getDependency = "git clone -qn "+ srcURL + ' ' + destination +'/';
         var checkout = "git checkout -q v" + version;
         if show {
@@ -347,7 +347,7 @@ proc getGitCode(gitListArg: list(4*string), show) {
     const nameVers = name + "-" + branch;
     const destination = baseDir + nameVers;
     if !depExists(nameVers, '/git/') {
-      log.infoln("Downloading dependency: " + nameVers);
+      writeln("Downloading dependency: " + nameVers);
       var getDependency = "git clone -qn "+ srcURL + ' ' + destination +'/';
       var checkout = "git checkout -q " + revision;
       if show {

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -533,7 +533,7 @@ private proc pullGitDeps(gitDeps, show=false) {
     const nameVers = val + "-" + branch;
     const destination = baseDir + nameVers;
     if !depExists(nameVers, '/git/') {
-      log.infof("Downloading dependency: %s\n", nameVers);
+      writeln("Downloading dependency: %s\n", nameVers);
       var getDependency = "git clone -q "+ srcURL + ' ' + destination +'/';
       runCommand(getDependency);
 


### PR DESCRIPTION
Changes one more logger usage to writeln as it broke testing.

More principled solution on this is being discussed under https://github.com/chapel-lang/chapel/issues/28163

