### PR TITLE
Increase time between debugger commands to reduce sporadics

### DIFF
--- a/test/llvm/debugInfo/chpl-parallel-dbg/sub_test
+++ b/test/llvm/debugInfo/chpl-parallel-dbg/sub_test
@@ -200,7 +200,7 @@ class Test:
                 debugger_fp.flush()
                 dbg_process.stdin.write(line + "\n")
                 dbg_process.stdin.flush()
-                time.sleep(0.5)
+                time.sleep(1)
         dbg_process.wait(timeout=timeout())
         exec_process_group_pid = os.getpgid(executable_process.pid)
         try:

--- a/test/llvm/debugInfo/chpl-parallel-dbg/twoLocales.dbg.cmds
+++ b/test/llvm/debugInfo/chpl-parallel-dbg/twoLocales.dbg.cmds
@@ -1,13 +1,8 @@
-#f
-#target list
-
 on 0
-#target list
-#process status
-
 c
 on 1
 c
+f
 p myArr
 p localArr
 q


### PR DESCRIPTION
Increases the time between debugger commands in chpl-parallel-dbg tests to reduce the chance of sporadics.

A sporadic issue could occur if `p myArr` executed before the debugger actually hit the breakpoint, so this PR increases the sleep time and adds a command to execute inbetween `c` and `p myArr`. This is not the most robust solution (a proper solution would only execute the next instruction when the debugger hits the breakpoint), but thats a problem for another day

[Reviewed by @benharsh]