### PR TITLE
Fix homebrew test failure

### DIFF
--- a/util/cron/test-homebrew.bash
+++ b/util/cron/test-homebrew.bash
@@ -65,7 +65,7 @@ cat chapel.rb
 brew upgrade
 brew uninstall --force chapel
 # Remove the cached chapel tar file before running brew install --build-from-source chapel.rb
-rm $HOME/Library/Caches/Homebrew/downloads/*--chapel-${short_version}.tar.gz
+rm -f $HOME/Library/Caches/Homebrew/downloads/*--chapel-${short_version}.tar.gz
 HOMEBREW_DEVELOPER=1 HOMEBREW_NO_INSTALL_FROM_API=1 brew install -v --build-from-source ./chapel.rb
 chpl --version
 


### PR DESCRIPTION
Fixes a homebrew test failure, where the test fails to use `rm -f`