### PR TITLE
Trivial whitespace adjustment in a good file

### DIFF
--- a/test/mason/simple.good
+++ b/test/mason/simple.good
@@ -1,3 +1,4 @@
+
 [root]
 author = "Sam Partee"
 chplVersion = "CHPL_CUR_FULL..CHPL_CUR_FULL"


### PR DESCRIPTION
Due to quite a bit of changes in what Mason outputs, this test seem to print one more empty line. We want to take a closer look into what Mason prints out and what's tested. This is discussed in https://github.com/chapel-lang/chapel/issues/28163.

Until we have a consistent story, this PR adjusts a good file to make sure that testing passes.