### PR TITLE
Enable unstable warnings when requesting a non-default edition

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -357,6 +357,7 @@ char compileVersion[64];
 
 std::array<std::string, 2> editions ({{"2.0", "preview"}});
 std::string fEdition = "2.0";
+std::string defaultEdition = fEdition;
 bool fUserSetPreEdition = false;
 
 static bool fPrintCopyright = false;
@@ -961,6 +962,10 @@ static void setEdition(const ArgumentDescription* desc, const char* arg) {
     clean_exit(1);
   } else {
     fEdition = val;
+  }
+  // when using a non-default edition (and not preview), warn about unstable features
+  if (defaultEdition != fEdition && fEdition != "preview") {
+    fWarnUnstable = true;
   }
 }
 


### PR DESCRIPTION
Automatically turns on unstable warnings when a user requests a non-default edition (not including the preview edition)

Per discussion and consensus from https://github.com/chapel-lang/chapel/issues/27096#issuecomment-2877532757

Note that since we only have 1 edition and its the default, this change is effectively a no-op. But I wanted to make sure the feature was not forgotten about

- [x] paratest

[Reviewed by @benharsh]