### PR TITLE
Dyno: Add Dyno version of .good file for newish param rangebound test

### DIFF
--- a/util/misc/dyno-ignore-good-files.patch
+++ b/util/misc/dyno-ignore-good-files.patch
@@ -1195,6 +1195,15 @@ index 3a401b6b18c..6c6b88c4edd 100644
  range-generic-default2.chpl:7: error: initializing a range with strideKind.one from a range with strideKind.positive
 -  range-generic-default2.chpl:16: called as (MyRecord(1)).init(param p = 1, r: range(int(64),both,positive))
 +range-generic-default2.chpl:7: error: initializing a range with strideKind.one from a range with strideKind.positive
+diff --git a/test/types/range/lydia/badRange-real-lower.good b/test/types/range/lydia/badRange-real-lower.good
+index d356b0bfbeb..27551395a1b 100644
+--- a/test/types/range/lydia/badRange-real-lower.good
++++ b/test/types/range/lydia/badRange-real-lower.good
+@@ -1,2 +1,3 @@
+ badRange-real-lower.chpl:1: In function 'main':
+-badRange-real-lower.chpl:2: error: param for-loops defined using bounds of type 'real(64)..int(64)' are not currently supported
++badRange-real-lower.chpl:2: error: Ranges defined using bounds of type 'real(64)..int(64)' are not currently supported
++badRange-real-lower.chpl:2: error: incompatible range bounds in 'param' loop
 diff --git a/test/types/range/lydia/badRange-string-lower.good b/test/types/range/lydia/badRange-string-lower.good
 index 32fab7aaf1f..b196306f719 100644
 --- a/test/types/range/lydia/badRange-string-lower.good


### PR DESCRIPTION
While closing some stale issues in https://github.com/chapel-lang/chapel/pull/27984, I added some regression tests for error messages. However, the error messages differ for Dyno, and I didn't update those. This PR does that.

Trivial; will not be reviewed.