### PR TITLE
Extend developer sanitizer docs for ubsan

### DIFF
--- a/doc/rst/developer/bestPractices/Sanitizers.rst
+++ b/doc/rst/developer/bestPractices/Sanitizers.rst
@@ -66,7 +66,7 @@ debugging the Chapel compiler itself.
 UBSan
 -----
 
-We have also find utility in using an undefined behavior sanitizer (UBSan) to
+We have also found utility in using an undefined behavior sanitizer (UBSan) to
 help catch certain classes of bugs in the runtime resulting from undefined
 behavior in C/C++. This works best with the C backend.
 


### PR DESCRIPTION
Extends the developer docs for using sanitizers to include instructions about ubsan

[Reviewed by @DanilaFe]