### PR TITLE
Dyno: .good file updates for `test/classes/initializers`.

### DIFF
--- a/util/misc/dyno-ignore-good-files.patch
+++ b/util/misc/dyno-ignore-good-files.patch
@@ -805,6 +805,35 @@ index 94073f3a4f8..8fa89dc71b4 100644
 +where-clause4.chpl:11: error: unable to resolve call to 'init': no matching candidates
 +where-clause4.chpl:5: note: the following candidate didn't match because the 'where' clause evaluated to 'false'
 +where-clause4.chpl:11: note: omitting 22 more candidates that didn't match
+diff --git a/test/classes/initializers/siblingCall/endsInitBad.good b/test/classes/initializers/siblingCall/endsInitBad.good
+index 2fe65bf69a4..abdbe2af7b5 100644
+--- a/test/classes/initializers/siblingCall/endsInitBad.good
++++ b/test/classes/initializers/siblingCall/endsInitBad.good
+@@ -1,2 +1,3 @@
+ endsInitBad.chpl:5: In initializer:
+-endsInitBad.chpl:6: error: field initialization not allowed before super.init() or this.init()
++endsInitBad.chpl:7: error: field initialization not allowed before 'super.init()' or 'this.init()'
++endsInitBad.chpl:6: note: field 'f2' is initialized before the 'init' call here
+diff --git a/test/classes/initializers/siblingCall/middleBad.good b/test/classes/initializers/siblingCall/middleBad.good
+index 1fe81fdc1ca..b4850381fb6 100644
+--- a/test/classes/initializers/siblingCall/middleBad.good
++++ b/test/classes/initializers/siblingCall/middleBad.good
+@@ -1,2 +1,3 @@
+ middleBad.chpl:5: In initializer:
+-middleBad.chpl:6: error: field initialization not allowed before super.init() or this.init()
++middleBad.chpl:7: error: field initialization not allowed before 'super.init()' or 'this.init()'
++middleBad.chpl:6: note: field 'f2' is initialized before the 'init' call here
+diff --git a/test/classes/initializers/where-clause4.good b/test/classes/initializers/where-clause4.good
+index bcd82c29397..2b989de8c28 100644
+--- a/test/classes/initializers/where-clause4.good
++++ b/test/classes/initializers/where-clause4.good
+@@ -1,3 +1,3 @@
+-where-clause4.chpl:12: error: unresolved call 'Foo.init(3.4)'
+-where-clause4.chpl:5: note: this candidate did not match: Foo.init(xVal)
+-where-clause4.chpl:5: note: because where clause evaluated to false
++where-clause4.chpl:12: error: unable to resolve call to 'init': no matching candidates
++where-clause4.chpl:5: note: the following candidate didn't match because the 'where' clause evaluated to 'false'
++where-clause4.chpl:12: note: omitting 22 more candidates that didn't match
 diff --git a/test/types/POD/elliot/varNotPOD.good b/test/types/POD/elliot/varNotPOD.good
 index 66db8242dd1..1a9cf52c977 100644
 --- a/test/types/POD/elliot/varNotPOD.good


### PR DESCRIPTION
This is another PR in the flavor of https://github.com/chapel-lang/chapel/pull/28004.

We find it more important to focus on programs that Dyno is supposed to be able to resolve, but doesn't. However, a lot of tests (the majority of them, in fact), seem to lock down errors rather than additional features. To cut through testing noise and focus on missing features, we typically silence tests that only differ in the precise way that Dyno rejects an invalid program.

I have manually reviewed each of the .good file changes here. I have accepted:
* Differences in capitalization and wording
* Error messages that are formulated differently but are about the same issue

However, I left out tests that fail in strange ways (e.g., one error is expected, but a completely unrelated error is emitted, internal errors, etc). The idea is that they should continue to fail so that we know about them, because they represent "true" failures of the resolver.

Real bugs I've observed:

* `test/classes/initializers/compilerGenerated/shadow_with_different_type.good`  (internal error)
* `test/classes/initializers/errors/fieldBeforeSuper.good` (no error for call to super after field init)
  * This, and many other tests, I've left unchanged because they are masked by Dyno's inability to resolver `super.init` for top-level classes. Presumably in production this is either a low-priority error, or `super.init` refers to the root object type.
* `test/classes/initializers/constInHeader.good` (Dyno fails to detect use-before-def in initializer argument list)
* `test/classes/initializers/errors/iteratorHashMethodCalled.good` (producing `compilerError` in initializer before initializing fields leads to errors about said fields, even if they are later initialized).
* `test/classes/initializers/generics/phase1/accessThisBad.good` (too-early references to `this` are not checked in `init`)
* `test/classes/initializers/super-in-phase2.good` (internal error)

Reviewed by @benharsh -- thanks!