### PR TITLE
mason: refactor error propagation from masonInit and masonNew 

### DIFF
--- a/test/mason/masonInit/masonInitTest3.chpl
+++ b/test/mason/masonInit/masonInitTest3.chpl
@@ -1,13 +1,18 @@
 use MasonInit;
 use CTypes;
+use MasonUtils;
 
 proc removePath() {
   extern proc setenv(name: c_ptrConst(c_char), envval: c_ptrConst(c_char), overwrite: c_int): c_int;
   setenv("PATH", "", 1);
 }
 
-proc main(){
+proc main() throws {
   removePath(); // clobber path so error occurs
   const args = ['init'];
-  masonInit(args);
+  try {
+    masonInit(args);
+  } catch e: MasonError {
+    writeln(e.message());
+  }
 }

--- a/test/mason/masonNewBadName.chpl
+++ b/test/mason/masonNewBadName.chpl
@@ -1,8 +1,13 @@
 use MasonNew;
+use MasonUtils;
 
 config const name="";
 
-proc main() {
+proc main() throws {
   const args = ['new', name];
-  masonNew(args);
+  try {
+    masonNew(args);
+  } catch e: MasonError {
+    writeln(e.message());
+  }
 }

--- a/tools/mason/MasonInit.chpl
+++ b/tools/mason/MasonInit.chpl
@@ -70,65 +70,57 @@ proc masonInit(args: [] string) throws {
   // Default created mason project is a package (has a main func)
   var packageType = 'application';
 
-  try! {
-    var show = showFlag.valueAsBool();
-    if nameOpt.hasValue() then packageName = nameOpt.value();
-    if dirArg.hasValue() then dirName = dirArg.value();
-    if nameOpt.hasValue() {
-      packageName = nameOpt.value();
-    } else {
-      packageName = dirName;
-    }
-    if isApplication then
-      packageType = "application";
-    else if isLibrary then
-      packageType = "library";
-    else if isLightweight then
-      packageType = "light";
-
-    const cwd = here.cwd();
-    var name = if dirName == '' then basename(cwd) else basename(dirName);
-    const path = if dirName == '' then '.' else dirName;
-    if packageName.size > 0 then name = packageName;
-
-    if !isLightweight {
-      validatePackageName(dirName=name);
-    }
-
-
-    if dirName != '' then
-      if !isDir(path) then
-        throw new owned MasonError("Directory does not exist: " + path +
-                                   " Did you mean 'mason new' to create a " +
-                                   "new project from scratch?");
-
-    // If TOML file exists, send message that package is already
-    // initialized and give some info on what they might want to
-    // do instead.
-    if isFile(path + '/Mason.toml') {
-      throw new owned MasonError("Mason.toml already exists for current project. " +
-                                 "Remove or rename the existing manifest file and rerun " +
-                                 "`mason init` to initialize a new project.");
-    } else if isDir(path + '/src/') {
-      throw new owned MasonError("/src/ directory already exists for current project. " +
-                                 "Remove or rename the /src/ directory and rerun " +
-                                 "`mason init` to initialize a new project. " +
-                                 "Alternatively, run `mason new --light` to add only a " +
-                                 "manifest file.");
-    } else {
-      // We can create the /src/ dir and Mason.toml
-      if dirName == '' then
-        InitProject(cwd, name, vcs, show, version, chplVersion, license, packageType);
-      else
-        InitProject(path, name, vcs, show, version, chplVersion, license, packageType);
-    }
-    writeln("Tip: To convert existing code to a mason project, " +
-            "move the driver application to the `src/" + name + ".chpl`" +
-            " file. For adding other source code, using submodules is the " +
-            "recommended approach to avoid namespace collisions.");
+  if nameOpt.hasValue() then packageName = nameOpt.value();
+  if dirArg.hasValue() then dirName = dirArg.value();
+  if nameOpt.hasValue() {
+    packageName = nameOpt.value();
+  } else {
+    packageName = dirName;
   }
-  catch e: MasonError {
-    writeln(e.message());
-    exit(1);
+  if isApplication then
+    packageType = "application";
+  else if isLibrary then
+    packageType = "library";
+  else if isLightweight then
+    packageType = "light";
+
+  const cwd = here.cwd();
+  var name = if dirName == '' then basename(cwd) else basename(dirName);
+  const path = if dirName == '' then '.' else dirName;
+  if packageName.size > 0 then name = packageName;
+
+  if !isLightweight {
+    validatePackageName(dirName=name);
   }
+
+  if dirName != '' then
+    if !isDir(path) then
+      throw new owned MasonError("Directory does not exist: " + path +
+                                 " Did you mean 'mason new' to create a " +
+                                 "new project from scratch?");
+
+  // If TOML file exists, send message that package is already
+  // initialized and give some info on what they might want to
+  // do instead.
+  if isFile(path + '/Mason.toml') {
+    throw new owned MasonError("Mason.toml already exists for current project. " +
+                               "Remove or rename the existing manifest file and rerun " +
+                               "`mason init` to initialize a new project.");
+  } else if isDir(path + '/src/') {
+    throw new owned MasonError("/src/ directory already exists for current project. " +
+                               "Remove or rename the /src/ directory and rerun " +
+                               "`mason init` to initialize a new project. " +
+                               "Alternatively, run `mason new --light` to add only a " +
+                               "manifest file.");
+  } else {
+    // We can create the /src/ dir and Mason.toml
+    if dirName == '' then
+      InitProject(cwd, name, vcs, show, version, chplVersion, license, packageType);
+    else
+      InitProject(path, name, vcs, show, version, chplVersion, license, packageType);
+  }
+  writeln("Tip: To convert existing code to a mason project, " +
+          "move the driver application to the `src/" + name + ".chpl`" +
+          " file. For adding other source code, using submodules is the " +
+          "recommended approach to avoid namespace collisions.");
 }

--- a/tools/mason/MasonNew.chpl
+++ b/tools/mason/MasonNew.chpl
@@ -70,33 +70,27 @@ proc masonNew(args: [] string) throws {
   // Default created mason project is a package (has a main func)
   var packageType = 'application';
 
-  try! {
-    if dirArg.hasValue() then dirName = dirArg.value();
-    else if !isLightweight then
-      throw new owned MasonError("A package name must be specified");
-    if nameOpt.hasValue() {
-      packageName = nameOpt.value();
-    } else {
-      packageName = dirName;
-    }
-    if isApplication then
-      packageType = "application";
-    else if isLibrary then
-      packageType = "library";
-    else if isLightweight then
-      packageType = "light";
+  if dirArg.hasValue() then dirName = dirArg.value();
+  else if !isLightweight then
+    throw new owned MasonError("A package name must be specified");
+  if nameOpt.hasValue() {
+    packageName = nameOpt.value();
+  } else {
+    packageName = dirName;
+  }
+  if isApplication then
+    packageType = "application";
+  else if isLibrary then
+    packageType = "library";
+  else if isLightweight then
+    packageType = "light";
 
-    if !isLightweight && validatePackageName(dirName=packageName) {
-      if isDir(dirName) {
-        throw new owned MasonError("A directory named '" + dirName + "' already exists");
-      }
+  if !isLightweight && validatePackageName(dirName=packageName) {
+    if isDir(dirName) {
+      throw new owned MasonError("A directory named '" + dirName + "' already exists");
     }
-    InitProject(dirName, packageName, vcs, show, version, chplVersion, license, packageType);
   }
-  catch e: MasonError {
-    writeln(e.message());
-    exit(1);
-  }
+  InitProject(dirName, packageName, vcs, show, version, chplVersion, license, packageType);
 }
 
 /* Exit terminal when CTRL + D is pressed */


### PR DESCRIPTION
## Overview
This PR refactors error handling in the Mason package manager so internal functions (`masonInit`, `masonNew`) propagate `MasonError` to the top-level CLI handler instead of catching and calling `exit(1)` locally. This centralizes error-to-exit behavior, improves testability, and preserves user-visible behavior.

## Changes
- `tools/mason/MasonInit.chpl`: remove local `try! { ... } catch e: MasonError { ... exit(1); }` wrapper; let `MasonError` propagate
- `tools/mason/MasonNew.chpl`: remove local try/catch wrapper so `MasonError` propagates (applied earlier)
- `test/mason/masonInit/masonInitTest3.chpl`: updated to catch `MasonError` and print `e.message()`; added `use MasonUtils;` and `proc main() throws`
- `test/mason/masonNewBadName.chpl`: updated to catch `MasonError` and print `e.message()` (applied earlier)

## Rationale
Centralizing error handling at the top-level CLI (`tools/mason/mason.chpl`) provides:
- Unit testing: internal functions can be tested without process exit.
- Consistent error reporting and a single exit-to-user mapping.
- Separation of concerns: internal code handles logic; CLI handles user-facing exit behavior.

## Local testing
$ ./util/start_test test/mason
Test Summary: #Successes = 112 | #Failures = 0 | #Futures = 0 | #Warnings = 0

Branch: mason/issue-28120-fix-mason-error-handling
Commit: 229e4c88fb
Environment: macOS, CHPL_HOME=/Users/tausiffhussainum/workspace/open-source/chapel


## Notes
- Commits include DCO sign-off: `Signed-off-by: Tausif Mujawar <tausiff-hussain-umarsab.mujawar@hpe.com>`
- This PR partially addresses #28120

## Request for reviewers
Please review the above files and the respective test cases . The change is intended to be behavior-preserving for end users (error messages + exit codes continue to be handled by the top-level CLI).  Please provide any feedback that can improve the fix. I have made changes in 2 files and based on the feedback i would incrementally make changes to other files as well to use the same pattern to handle errors. @jabraham17  Can you please review the PR. 