### PR TITLE
chapel-py: Adjust chapel-py parent_symbol to not assert on toplevel AST

### DIFF
--- a/tools/chapel-py/src/method-tables/uast-methods.h
+++ b/tools/chapel-py/src/method-tables/uast-methods.h
@@ -45,6 +45,7 @@ CLASS_BEGIN(AstNode)
 
                auto id = node->id();
                auto parentId = id.parentSymbolId(context);
+               if (parentId.isEmpty()) return nullptr;
                return parsing::idToAst(context, parentId))
   PLAIN_GETTER(AstNode, pragmas, "Get the pragmas of this AST node",
                std::set<std::string>,


### PR DESCRIPTION
`parentSymbolId` can potentially return an empty ID, which is not a valid argument to `idToAst`. This code previously didn't check for this possibility, and ended up asserting in some cases.

Reviewed by @jabraham17 -- thanks!

## Testing
- [x] it no longer asserts in manual testing and dependent scripts