### PR TITLE
Dyno: fix incorrectly mangling RHS type when assinging to type alias

### DIFF
--- a/frontend/test/resolution/testCustomInfer.cpp
+++ b/frontend/test/resolution/testCustomInfer.cpp
@@ -88,8 +88,52 @@ module M {
   assert(foundAction);
 }
 
+static void testTypeAlias() {
+  Context ctx;
+  Context* context = &ctx;
+  ErrorGuard guard(context);
+
+  std::string program =
+R"""(
+module M {
+  pragma "infer custom type"
+  record R {
+    var val : int;
+  }
+
+  proc R.chpl__inferCopyType() type {
+    return int;
+  }
+
+  operator =(ref lhs: int, const rhs: int) {}
+  operator =(ref lhs: int, const rhs: R) {
+    lhs = rhs.val;
+  }
+
+  type MyAlias = R;
+  var x : MyAlias;
+}
+)""";
+
+  auto path = UniqueString::get(context, "input.chpl");
+  setFileText(context, path, std::move(program));
+
+  const ModuleVec& vec = parseToplevel(context, path);
+  const Module* m = vec[0];
+
+  const ResolutionResultByPostorderID& rr = resolveModule(context, m->id());
+
+  QualifiedType myAlias = findVarType(m, rr, "MyAlias");
+  assert(myAlias.type()->isRecordType() && myAlias.type()->toRecordType()->name() == "R");
+
+  QualifiedType x = findVarType(m, rr, "x");
+  // x should also be of type R
+  assert(x.type() == myAlias.type());
+}
+
 int main() {
   testRecordInt();
+  testTypeAlias();
 
   return 0;
 }


### PR DESCRIPTION
In cases like `var x = e`,  the language sometimes determines the type of `x` to be different than `e.type`. This is in particular the case for materializing iterators to arrays, and for sync types via implicit reads. Dyno incorrectly applied this logic at the type level, which meant that `type x = sync int` turned into `x = int`. This is wrong. This PR fixes the issue by limiting custom LHS type inference to the value level.

Reviewed by @benharsh -- thanks!

## Testing
- [x] dyno tests
- [x] paratest
- [x] paratest --dyno-resolve-only