### PR TITLE
Document `transmute`

### DIFF
--- a/doc/rst/language/spec/conversions.rst
+++ b/doc/rst/language/spec/conversions.rst
@@ -733,8 +733,8 @@ Bitwise Numeric Conversions
 '''''''''''''''''''''''''''
 
 Some numeric types can also be explicitly converted to other numeric types using
-``transmute``. ``transmute`` changes the type of the value without affecting
-the underlying bit representation.
+``transmute``. ``transmute`` returns a new value of the specified type, whose
+bit pattern is identical to that of the original value.
 
 .. function:: proc real(?w).transmute(type t: uint(w)) : t
 


### PR DESCRIPTION
Documents the `transmute` method on reals and uints, which was added awhile ago but never documented

This PR adds the documentation for transmute to the spec in the conversions section, since `transmute` is closely related to other type conversions. When we actually stabilize `transmute`, https://github.com/chapel-lang/chapel/issues/28239, it may be moved somewhere else and the docs should move accordingly.

Resolves https://github.com/chapel-lang/chapel/issues/28240

- [x] `make spectests` and `start_test test/release/examples/spec/Conversions/transmute.chpl`
- [x] built docs locally

[Reviewed by @bradcray]