### PR TITLE
Avoid platform portability issues with unsigned char

### DIFF
--- a/test/types/string/assignToChar/PREDIFF
+++ b/test/types/string/assignToChar/PREDIFF
@@ -5,7 +5,7 @@ compopts=$4
 
 # if -st=1|2|3|4 in compopts, then prediff uint(8) to int(8)
 # these tests use char, but on some systems char is unsigned
-if [[ $compopts =~ -st=(1|2|3|4) ]]; then
+if [[ $compopts =~ -st=(1|2|3|4)[[:space:]] ]]; then
   sed 's/uint(8)/int(8)/g' $output > $output.prediff.tmp
   mv $output.prediff.tmp $output
 fi


### PR DESCRIPTION
Avoids platform portability issues in a test that prints out the type of char, which on some systems may be `uint(8)` instead of `int(8)`

[Not reviewed - trivial]