### PR TITLE
Remove code explicitly unloading cray-libsci

### DIFF
--- a/util/cron/common-hpe-cray-ex.bash
+++ b/util/cron/common-hpe-cray-ex.bash
@@ -11,9 +11,6 @@ module swap gcc gcc/12.2.0
 # Our test machine actually calls it 'gcc-native'
 module swap gcc-native gcc-native/12.3
 
-# Newest cray-libsci doesn't work with gnu/12.2.0, and we don't need it anyway
-module unload cray-libsci
-
 module load cray-pmi
 
 export CHPL_HOST_PLATFORM=hpe-cray-ex


### PR DESCRIPTION
Previously, we had errors loading this module with our other GCC dependencies:

```
chapelu:~> module load gcc
chapelu:~> cc --cray-print-opts=cflags
Error:  Unable to find cray-libsci/25.09.0 libraries compatible with gcc/12.2.0 targeting ....
```

This led me to [disable loading this module](https://github.com/chapel-lang/chapel/pull/28101). However, I have just logged onto the machine, and verified that this error does not appear. Furthermore, we need `cray-libsci` for one of the performance tests. So, I'm putting it back.

Reviewed by @benharsh -- thanks!

## Testing
- [x] cray-libsci is now compatible with required GCC on our machines.