### PR TITLE
Fix runtime type bug with c_ptr.eltType

### DIFF
--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -282,6 +282,7 @@ extern bool fReportGpuTransformTime;
 extern bool fPermitUnhandledModuleErrors;
 
 extern bool fDebugSymbols;
+extern bool fDebugSafeOptOnly;
 extern bool optimizeCCode;
 extern bool specializeCCode;
 

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -611,8 +611,14 @@ static void setDebugSymbols(const ArgumentDescription* desc, const char* arg_unu
 static void setDebugSafeOptOnly(const ArgumentDescription* desc, const char* arg_unused) {
   // --no-copy-propagation
   fNoCopyPropagation = true;
+  // Dead code elimination (DCE) is made up of many different parts
+  // (dead var, dead expr, dead func, etc). DCE is needed by other parts of
+  // the compiler for proper compilation, so we can't fully disable it here.
+  // However, when debugging, we want to minimize the amount of code that
+  // is removed, so we disable as much of it as possible, controlled
+  // via fDebugSafeOptOnly directly
   // --no-dead-code-elimination
-  fNoDeadCodeElimination = true;
+  // fNoDeadCodeElimination = true;
   // --no-loop-invariant-code-motion
   fNoLoopInvariantCodeMotion = true;
   // --no-inline

--- a/compiler/optimizations/deadCodeElimination.cpp
+++ b/compiler/optimizations/deadCodeElimination.cpp
@@ -107,6 +107,10 @@ void deadVariableElimination(FnSymbol* fn) {
     if (!isVarSymbol(sym))
       continue;
 
+    // when debugging, we're only interested in compiler temps
+    if (fDebugSafeOptOnly && !sym->hasFlag(FLAG_TEMP))
+      continue;
+
     // A method must have a _this symbol, even if it is not used.
     if (sym == fn->_this)
       continue;
@@ -151,6 +155,9 @@ void deadVariableElimination(FnSymbol* fn) {
 // Removes expression statements that have no effect.
 //
 void deadExpressionElimination(FnSymbol* fn) {
+  // when debugging, skip this
+  if (fDebugSafeOptOnly) return;
+
   std::vector<BaseAST*> asts;
 
   collect_asts(fn, asts);
@@ -404,6 +411,9 @@ static bool isDeadModule(ModuleSymbol* mod) {
 
 // Eliminates all dead modules
 static void deadModuleElimination() {
+  // when debugging, skip this
+  if (fDebugSafeOptOnly) return;
+
   deadModuleCount = 0;
 
   forv_Vec(ModuleSymbol, mod, allModules) {
@@ -465,6 +475,8 @@ static bool removeVoidFunction(FnSymbol* fn) {
 }
 
 static void deadFunctionElimination() {
+  // when debugging, skip this
+  if (fDebugSafeOptOnly) return;
   // skip minimal modules, since many key functions are stubbed out and then get
   // removed, which breaks later passes
   if (fMinimalModules) return;

--- a/compiler/optimizations/inlineFunctions.cpp
+++ b/compiler/optimizations/inlineFunctions.cpp
@@ -150,13 +150,13 @@ static void simplifyBody(FnSymbol* fn) {
   removeUnnecessaryGotos(fn);
 
 #if DEBUG_CP < 2    // That is, disabled if DEBUG_CP >= 2
-  if (fNoCopyPropagation == false) {
+  if (!fNoCopyPropagation) {
     singleAssignmentRefPropagation(fn);
     localCopyPropagation(fn);
   }
 #endif
 
-  if (fNoDeadCodeElimination == false) {
+  if (!fNoDeadCodeElimination) {
     deadVariableElimination(fn);
     deadExpressionElimination(fn);
   }


### PR DESCRIPTION
Fixes an issue where runtime types where not properly removed when compiling code with `--debug`.

The bug is really that the compiler doesn't know how to codegen types (which it shouldn't) and earlier phases of the compiler don't remove some type calls properly. This makes `--dead-code-elimination` an essential pass to run. However, DCE, can remove important information when debugging. To workaround this, this PR partially re-enables DCE with `--debug`, keeping enough to make the compiler not crash.

Resolves 

- [ ] paratest with/without gasnet
- [x] confirmed that the reproducers from https://github.com/chapel-lang/chapel/issues/28285 work with `--debug`
- [ ] confirmed that Arkouda can build with this PR