### PR TITLE
Add more developer flags when building mason

### DIFF
--- a/tools/mason/buildMason
+++ b/tools/mason/buildMason
@@ -36,8 +36,7 @@ COMPOPTS=""
 PRE_COMPOPTS="--launcher=none"
 POST_COMPOPTS="--checks"
 if [ "$DEBUG" == "1" ]; then
-  # TODO add --debug-safe-optimizations-only once https://github.com/chapel-lang/chapel/issues/28165 is resolved
-  COMPOPTS="$COMPOPTS -g --no-devel"
+  COMPOPTS="$COMPOPTS -g --debug-safe-optimizations-only --no-devel --verify --print-passes-memory"
 else
   # avoid specialization to prevent micro-architectural optimizations that
   # could break mason in cross platform scenarios


### PR DESCRIPTION
Adds more build flags to mason to build mason with the following in debug mode

* build mason with `--debug-safe-optimizations-only`: easier to debug mason errors
* build mason with `--verify`: mostly a validation check for debug info since `--no-devel` is explicitly turned off
* build mason with `--print-passes-memory`: validation check to make sure the compiler is making progress

- [ ] `make mason DEBUG=1`

[Reviewed by @]