### PR TITLE
Revert #28258 due to compiler perf regression

### DIFF
--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -84,7 +84,7 @@ add_custom_command(
   COMMAND ${CHPL_CMAKE_PYTHON}
           ${SRC_DIR}/../util/config/generate-reservedSymbolNames
           ${SRC_DIR}/codegen
-  DEPENDS ${SRC_DIR}/codegen/reservedSymbolNames ${SRC_DIR}/../util/config/generate-reservedSymbolNames
+  DEPENDS ${SRC_DIR}/codegen/reservedSymbolNames
   COMMENT "writing reservedSymbolNames.h file updates..."
   VERBATIM)
 

--- a/compiler/optimizations/removeEmptyRecords.cpp
+++ b/compiler/optimizations/removeEmptyRecords.cpp
@@ -98,7 +98,6 @@ removeEmptyRecords() {
     if (emptyRecordTypeSet.count(fn->retType) != 0) {
       CallExpr* ret = toCallExpr(fn->body->body.last());
       INT_ASSERT(ret && ret->isPrimitive(PRIM_RETURN));
-      SET_LINENO(ret);
       ret->get(1)->replace(new SymExpr(gVoid));
       fn->retType = dtVoid;
       forv_Vec(CallExpr, call, *fn->calledBy) {

--- a/test/users/vass/uniquify/u1-local-user-extern.bad
+++ b/test/users/vass/uniquify/u1-local-user-extern.bad
@@ -1,0 +1,7 @@
+u1-local-user-extern.chpl:12: internal error: COD-COD-GEN-1030 chpl version 1.19.0 pre-release (cfeb6592b3)
+
+Internal errors indicate a bug in the Chapel compiler,
+and we're sorry for the hassle.  We would appreciate your reporting this bug --
+please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/users/vass/uniquify/u1-local-user-extern.future
+++ b/test/users/vass/uniquify/u1-local-user-extern.future
@@ -1,0 +1,3 @@
+unimplemented feature: uniquifyName in presence of extern symbols
+
+Issue #9299

--- a/test/users/vass/uniquify/u2-local-extern-extern.bad
+++ b/test/users/vass/uniquify/u2-local-extern-extern.bad
@@ -1,0 +1,7 @@
+u2-local-extern-extern.chpl:8: internal error: COD-COD-GEN-1030 chpl version 1.19.0 pre-release (cfeb6592b3)
+
+Internal errors indicate a bug in the Chapel compiler,
+and we're sorry for the hassle.  We would appreciate your reporting this bug --
+please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/users/vass/uniquify/u2-local-extern-extern.future
+++ b/test/users/vass/uniquify/u2-local-extern-extern.future
@@ -1,0 +1,3 @@
+feature request: uniquifyName in presence of extern symbols
+
+Issue #9299

--- a/test/users/vass/uniquify/u2-local-extern-extern.good
+++ b/test/users/vass/uniquify/u2-local-extern-extern.good
@@ -1,3 +1,2 @@
-u2-local-extern-extern.chpl:8: error: type conflict for extern variable 'sublocid_local'
-./ux-externs.h:1: note: the C type is 'int64_t'
-u2-local-extern-extern.chpl:8: note: the Chapel type is 'real(64)'
+u2-local-extern-extern.chpl:8: error: the type of extern sublocid_local does not match the previous declaration
+u2-local-extern-extern.chpl:4: note: the previous declaration is here

--- a/util/config/generate-reservedSymbolNames
+++ b/util/config/generate-reservedSymbolNames
@@ -23,5 +23,5 @@ with open(os.path.join(args.location, 'reservedSymbolNames.h'), 'w') as f:
         continue
       line = line.strip("\n")
       parts = line.partition('//')
-      line = '  reserved.insert(astr("{}")); {}{}'.format(parts[0].strip(),parts[1], parts[2])
-      f.write(line.strip() + '\n')
+      line = '  cnames.insert(astr("{}")); {}{}\n'.format(parts[0].strip(),parts[1], parts[2])
+      f.write(line)


### PR DESCRIPTION
Reverts https://github.com/chapel-lang/chapel/pull/28258 due to a compiler performance regression

This fix is not critical, so for now reverting this PR to avoid regressing other aspects of the compiler and avoid impact to other developers

[Reviewed by @DanilaFe]