### PR TITLE
Fix the DEPENDS for generated files in compiler build

### DIFF
--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -61,7 +61,7 @@ add_custom_command(
           ${SRC_DIR}/../util/config/generate-license
           ${SRC_DIR}/../
           ${SRC_DIR}/main
-  DEPENDS ${SRC_DIR}/../LICENSE
+  DEPENDS ${SRC_DIR}/../LICENSE ${SRC_DIR}/../util/config/generate-license
   COMMENT "writing LICENSE file updates..."
   VERBATIM)
 
@@ -73,7 +73,7 @@ add_custom_command(
           ${SRC_DIR}/../util/config/generate-copyright
           ${SRC_DIR}/../
           ${SRC_DIR}/main
-  DEPENDS ${SRC_DIR}/../COPYRIGHT
+  DEPENDS ${SRC_DIR}/../COPYRIGHT ${SRC_DIR}/../util/config/generate-copyright
   COMMENT "writing COPYRIGHT file updates..."
   VERBATIM)
 
@@ -84,7 +84,7 @@ add_custom_command(
   COMMAND ${CHPL_CMAKE_PYTHON}
           ${SRC_DIR}/../util/config/generate-reservedSymbolNames
           ${SRC_DIR}/codegen
-  DEPENDS ${SRC_DIR}/codegen/reservedSymbolNames
+  DEPENDS ${SRC_DIR}/codegen/reservedSymbolNames ${SRC_DIR}/../util/config/generate-reservedSymbolNames
   COMMENT "writing reservedSymbolNames.h file updates..."
   VERBATIM)
 


### PR DESCRIPTION
Fixes the DEPENDS for generated files in the compiler build to also depend on the script that creates the generated file.

I fixed this in https://github.com/chapel-lang/chapel/pull/28258, but I reverted the PR. This PR re-applies the fix and extends it to other generated files

[Reviewed by @benharsh]