### PR TITLE
Make sure existing servers are killed before running Curl test

### DIFF
--- a/test/library/packages/Curl/PREEXEC
+++ b/test/library/packages/Curl/PREEXEC
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# make sure there are no http.server processes running
+ps -ef | grep 'http.server 8000 --bind 127.0.0.1' | grep -v grep | awk '{print $2}' | xargs -r kill -9


### PR DESCRIPTION
Adds a PREXEC to make sure all existing HTTP servers are killed before running Curl tests. This makes sure that these Curl tests can automatically get out of a bad state.

[Reviewed by @arifthpe]