### PR TITLE
Make sure `--debug` actually turns off return-by-ref

### DIFF
--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -282,6 +282,8 @@ extern bool fReportGpuTransformTime;
 extern bool fPermitUnhandledModuleErrors;
 
 extern bool fDebugSymbols;
+extern bool fDebugSafeOptOnly;
+
 extern bool optimizeCCode;
 extern bool specializeCCode;
 

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -624,7 +624,10 @@ static void setDebugSafeOptOnly(const ArgumentDescription* desc, const char* arg
   // --no-tuple-copy-opt
   fNoTupleCopyOpt = true;
   // --no-denormalize
-  fDenormalize = false;
+  // we want denormalize off for the most part, but need parts of it
+  // (e.g., need denormalize to undo return-by-ref), so this is controlled in
+  // the denormalize pass with fDebugSafeOptOnly
+  // fDenormalize = false;
   // --no-return-by-ref
   fReturnByRef = false;
   // --no-replace-array-accesses-with-ref-temps
@@ -640,6 +643,7 @@ static void setDebug(const ArgumentDescription* desc, const char* arg_unused) {
   printCppLineno = true;
 
   // --debug-safe-optimizations-only
+  fDebugSafeOptOnly = true;
   setDebugSafeOptOnly(nullptr, nullptr); // nullptr since args unused
 }
 

--- a/compiler/passes/denormalize.cpp
+++ b/compiler/passes/denormalize.cpp
@@ -88,12 +88,18 @@ void denormalize(void) {
   std::set<Symbol*> deferredSyms;
   SafeExprAnalysis analysisData;
 
-  if(fDenormalize) {
+  if (fDenormalize) {
     forv_Vec(FnSymbol, fn, gFnSymbols) {
       // remove unused epilogue labels
       removeUnnecessaryGotos(fn, true);
       if (!fReturnByRef && fn->hasFlag(FLAG_FN_RETARG))
         undoReturnByRef(fn);
+
+      // skip the rest of denormalization if we are only doing
+      // debug safe optimizations
+      if (fDebugSafeOptOnly)
+        continue;
+
 
       bool isFirstRound = true;
       do {
@@ -117,8 +123,8 @@ void denormalize(void) {
         isFirstRound = false;
       } while(deferredSyms.size() > 0);
     }
-
-    collapseTrivialMoves();
+    if (!fDebugSafeOptOnly)
+      collapseTrivialMoves();
   }
 }
 


### PR DESCRIPTION
Fixes the `--debug`/`--debug-safe-optimization-only` flags to actually turn off return-by-ref.

This fix is messy, because of how `--no-return-by-ref` is implemented. `--no-return-by-ref` doesn't actually turn off of the return-by-ref pass, it just enables a step in denormalization to undo return-by-ref. This seems to be due to quirks in our compiler where some passes may rely on `return-by-ref` (speculation by @dlongnecke-cray). So because `--debug-safe-optimization-only` turns off denormalization, `return-by-ref` is never undone occurs.

To fix it, we re-enable denormalization with debug opts, and then turn off only the parts of denormalization that are needed for debugging (letting the `no-return-nby-ref` logic run)

- [x] `paratest`
- [x] `start_test --compopts --no-local test/llvm/debugInfo`

[Reviewed by @dlongnecke-cray]