### PR TITLE
Fix double free in TOML parser

### DIFF
--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -99,10 +99,9 @@ proc parseToml(input: string) : shared Toml {
   var D: domain(string);
   var table: [D] shared Toml?;
   var rootTable = new shared Toml(table);
-  const source = new shared Source(input);
-  const parser = new unmanaged Parser(source, rootTable);
+  const source = new Source(input);
+  const parser = new Parser(source, rootTable);
   const tomlData = parser.parseLoop();
-  delete parser;
   return tomlData;
 }
 
@@ -159,7 +158,7 @@ module TomlParser {
   @chpldoc.nodoc
   class Parser {
 
-    var source: shared Source;
+    var source: borrowed Source;
     var rootTable: shared Toml;
     var curTable: string;
 
@@ -1068,10 +1067,8 @@ module TomlReader {
   proc skipLine(source) {
     var emptyList: list(string);
     var emptyCurrent = new unmanaged Tokens(emptyList);
-    var ptrhold = source.currentLine;
     source.currentLine = emptyCurrent;
     var readNextLine = readLine(source);
-    delete ptrhold;
   }
 
   /* retrieves the next token in currentLine */
@@ -1166,7 +1163,7 @@ module TomlReader {
       }
 
       // If no non-empty-chars => token is a blank line
-      if(nonEmptyChar == false){
+      if !nonEmptyChar {
         linetokens.pushBack("\n");
       }
 
@@ -1225,7 +1222,7 @@ module TomlReader {
       for token in tokenlist {
         delete token;
       }
-     }
+    }
   }
 
 


### PR DESCRIPTION
Fixes a double free in the TOML parser, which was causing all kinds of weird behavior.

The primary issues was that in `skipLine`, we would delete `currentLine` and replace it with another `Tokens` list. However, `currentLine` is in essence a borrow of an element from `tokenlist`. So `skipLine` would delete an element, and then later on the `deinit` for `Source` would be invoked and try to delete the same element again, resulting in a double free

Resolves https://github.com/chapel-lang/chapel/issues/28315

- [x] paratest

Future work: In hunting for this bug, I unfortunately read a fair amount of the TOML parser code. It seems to have suffered from neglect and language changes, where changes made to "just keep it working" may have caused the code to degrade. It also seems more complicated than maybe is actually necessary, and could be refactored for simplicity. It might also be worth it to just use an [existing TOML parser](https://github.com/toml-lang/toml/wiki) that we wrap in Chapel, rather than maintaining our own.

[Reviewed by @DanilaFe]