### PR TITLE
Add pretty printer for Chapel's list type

### DIFF
--- a/runtime/etc/debug/chpl_lldb_pretty_print.py
+++ b/runtime/etc/debug/chpl_lldb_pretty_print.py
@@ -619,7 +619,6 @@ class WidePointerProvider:
         )
 
 
-# needs method calls implemented
 list_regex_llvm = re.compile(r"^(List::list\((?P<eltType>[a-zA-Z0-9_()]+)(,(?P<parSafe>(true|false)))?\))$")
 
 def ListRecognizer(sbtype, internal_dict):
@@ -637,7 +636,6 @@ class ListProvider:
 
         self.synthetic_children = {}
         size = self.valobj.GetNonSyntheticValue().GetChildMemberWithName("_size").GetValueAsUnsigned()
-        # call the _getRef(idx, 0, 0) method on valobj to get each element
         for i in range(size):
             element_name = f"[{i}]"
             element = self.valobj.CreateValueFromExpression(element_name, f"({self.valobj.GetName()})._getRef({i})")


### PR DESCRIPTION
Adds a pretty printer for Chapel's list type

Relies on features implemented in https://github.com/chapel-lang/chapel/pull/28318, without it printing lists will not work
Tests added in https://github.com/chapel-lang/chapel/pull/28318 and https://github.com/chapel-lang/chapel/pull/28344

[Reviewed by @dlongnecke-cray]