### PR TITLE
chplcheck fix: Don't warn for an EmptyStmt that is the only thing in a file

### DIFF
--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -490,7 +490,11 @@ def rules(driver: LintDriver):
             if isinstance(p, SimpleBlockLike) and len(list(p.stmts())) == 1:
                 # dont warn if the EmptyStmt is the only statement in a block
                 return True
-            if isinstance(p, Module) and p.kind() == "implicit" and len(list(p)) == 1:
+            if (
+                isinstance(p, Module)
+                and p.kind() == "implicit"
+                and len(list(p)) == 1
+            ):
                 # dont warn if the EmptyStmt is the only statement in an implicit module
                 return True
 


### PR DESCRIPTION
Fixes an issue where chplcheck would warn for an EmptyStmt that was the only thing in a file.

This lint is wrong, because if the EmptyStmt is removed the file will no longer compile (it will be an empty file). This is a fairly common pattern (mostly in Chapel's test system)

[Reviewed by @DanilaFe]