### PR TITLE
Add --version to chplcheck and cls

### DIFF
--- a/tools/chpl-language-server/src/lsp_util.py
+++ b/tools/chpl-language-server/src/lsp_util.py
@@ -1358,6 +1358,11 @@ class CLSConfig:
             ),
             args_for_setting_config_path=["--config", "-c"],
         )
+        self.parser.add_argument(
+            "--version",
+            action="version",
+            version=f"chpl-language-server {chapel.Context().get_compiler_version()}",
+        )
 
         chplcheck().config.add_bool_flag(
             self.parser, "resolver", "resolver", False

--- a/tools/chplcheck/src/chplcheck.py
+++ b/tools/chplcheck/src/chplcheck.py
@@ -211,6 +211,11 @@ def main():
         ),
         args_for_setting_config_path=["--config", "-c"],
     )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"chplcheck {chapel.Context().get_compiler_version()}",
+    )
     parser.add_argument("filenames", nargs="*")
     parser.add_argument(
         "--file",


### PR DESCRIPTION
Adds a `--version` flag to both `chplcheck` and CLS. This flag will report the same version as the compiler being used, since these flags are very tied to a compiler version

[Reviewed by @DanilaFe]