### PR TITLE
Generalize ASAN prediff

### DIFF
--- a/test/types/type_variables/aliases/record-type-field-alias-array.prediff
+++ b/test/types/type_variables/aliases/record-type-field-alias-array.prediff
@@ -2,6 +2,6 @@
 
 # Sample output:
 # SUMMARY: AddressSanitizer: global-buffer-overflow (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x3dbc0) in __asan_memcpy+0x1a4
-if (grep 'SUMMARY' $2 | sed -e 's/SUMMARY: AddressSanitizer:..*/Found ASAN error/' > $2.tmp); then
+if (grep 'SUMMARY\|Tracer caught signal 11' $2 | sed -e 's/\(SUMMARY: AddressSanitizer:\|Tracer caught signal 11:\)..*/Found ASAN error/' > $2.tmp); then
   mv $2.tmp $2
 fi


### PR DESCRIPTION
Because this test effectively exercises UB, it can fail in different ways. Switching from GCC to Clang causes one such difference. This PR adjusts the prediff to expect the clang version of the error.

Reviewed by @jabraham17 -- thanks!