### PR TITLE
Add unstable warning for forwarding declarations

### DIFF
--- a/doc/rst/technotes/forwarding.rst
+++ b/doc/rst/technotes/forwarding.rst
@@ -9,6 +9,11 @@ This feature allows a ``record`` or ``class`` to specify that certain
 method calls will be forwarded to a particular expression. The most
 typical use case is to forward methods to a particular field.
 
+.. warning::
+
+   Forwarding as described in this technical note is an unstable feature
+   and may change in future Chapel releases.
+
 Why Forwarding?
 ---------------
 

--- a/frontend/lib/uast/post-parse-checks.cpp
+++ b/frontend/lib/uast/post-parse-checks.cpp
@@ -188,6 +188,7 @@ struct Visitor {
   // Warnings.
   void warnUnstableUnions(const Union* node);
   void warnUnstableForeachLoops(const Foreach* node);
+  void warnUnstableForwardingDecls(const ForwardingDecl* node);
   void warnUnstableSymbolNames(const NamedDecl* node);
 
   // Visitors.
@@ -1561,6 +1562,12 @@ void Visitor::warnUnstableForeachLoops(const Foreach* node) {
              "in ways that may break some of their current uses.");
 }
 
+void Visitor::warnUnstableForwardingDecls(const ForwardingDecl* node) {
+  if (!shouldEmitUnstableWarning(node)) return;
+  warn(node, "forwarding is currently unstable and may change "
+             "in ways that will break some of its current uses.");
+}
+
 void Visitor::warnUnstableSymbolNames(const NamedDecl* node) {
   if (!shouldEmitUnstableWarning(node)) return;
   if (!isUserCode()) return;
@@ -1797,6 +1804,7 @@ void Visitor::visit(const Foreach* node) {
 }
 
 void Visitor::visit(const ForwardingDecl* node) {
+  warnUnstableForwardingDecls(node);
   checkForwardingInNonRecordOrClass(node);
 }
 

--- a/test/unstable/forwarding.chpl
+++ b/test/unstable/forwarding.chpl
@@ -1,0 +1,25 @@
+record impl {
+  proc doThing() {
+    writeln("impl doing thing");
+  }
+}
+
+record r1 {
+  forwarding var implField: impl;
+}
+
+record r2 {
+  var implField: impl;
+
+  proc ref getImplField() ref {
+    return implField;
+  }
+
+  forwarding getImplField();
+}
+
+var x1: r1;
+x1.doThing();
+
+var x2: r2;
+x2.doThing();

--- a/test/unstable/forwarding.good
+++ b/test/unstable/forwarding.good
@@ -1,0 +1,4 @@
+forwarding.chpl:8: warning: forwarding is currently unstable and may change in ways that will break some of its current uses
+forwarding.chpl:18: warning: forwarding is currently unstable and may change in ways that will break some of its current uses
+impl doing thing
+impl doing thing


### PR DESCRIPTION
These are from a technical note and not part of the spec. Mark them as such. Also, clarify that the technical note is unstable. 

Reviewed by @jabraham17 -- thanks!

## Testing
- [x] dyno tests
- [x] docs build
- [x] paratest