### PR TITLE
Fix memory leak caused by ignored loop index

### DIFF
--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -224,7 +224,9 @@ proc compileSrc(lockFile: borrowed Toml, binLoc: string, show: bool,
 
     log.debugf("Base command: %?\n", cmd);
 
-    for (_, name, version) in srcSource.iterList(sourceList) {
+    // can't use _ since it will leak
+    // see https://github.com/chapel-lang/chapel/issues/25926
+    for (_x, name, version) in srcSource.iterList(sourceList) {
       const nameVer = "%s-%s".format(name, version);
       // version of -1 specifies a git dep
       if version != "-1" {
@@ -242,7 +244,9 @@ proc compileSrc(lockFile: borrowed Toml, binLoc: string, show: bool,
       }
     }
 
-    for (_, name, branch, _) in gitSource.iterList(gitList) {
+    // can't use _ since it will leak
+    // see https://github.com/chapel-lang/chapel/issues/25926
+    for (_x, name, branch, _y) in gitSource.iterList(gitList) {
       var gitDepSrc = ' ' + gitDepPath + name + "-" + branch + '/src/' + name + ".chpl";
       cmd.pushBack(gitDepSrc);
     }

--- a/tools/mason/MasonModules.chpl
+++ b/tools/mason/MasonModules.chpl
@@ -73,12 +73,16 @@ proc masonModules(args: [] string) throws {
   const depPath = MASON_HOME + '/src/';
   const gitDepPath = MASON_HOME + '/git/';
   var modules: string;
-  for (_, name, version) in srcSource.iterList(sourceList) {
+  // can't use _ since it will leak
+  // see https://github.com/chapel-lang/chapel/issues/25926
+  for (_x, name, version) in srcSource.iterList(sourceList) {
     var depM = ' ' + depPath + name + "-" + version + '/src/' + name + ".chpl";;
     modules += depM;
   }
 
-  for (_, name, branch, _) in gitSource.iterList(gitList) {
+  // can't use _ since it will leak
+  // see https://github.com/chapel-lang/chapel/issues/25926
+  for (_x, name, branch, _y) in gitSource.iterList(gitList) {
     var gitDepSrc = ' ' + gitDepPath + name + "-" + branch + '/src/' + name + ".chpl";
     modules += gitDepSrc;
   }

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -579,7 +579,9 @@ proc getMasonDependencies(sourceList: list(srcSource),
     const depPath = joinPath(MASON_HOME, "src");
 
     // Add dependencies to project
-    for (_, name, version) in srcSource.iterList(sourceList) {
+    // can't use _ since it will leak
+    // see https://github.com/chapel-lang/chapel/issues/25926
+    for (_x, name, version) in srcSource.iterList(sourceList) {
       const depSrc = joinPath(depPath, "%s-%s".format(name, version),
                               "src", "%s.chpl".format(name));
       masonCompopts.pushBack(depSrc);
@@ -589,7 +591,9 @@ proc getMasonDependencies(sourceList: list(srcSource),
     const gitDepPath = joinPath(MASON_HOME, "git");
 
     // Add git dependencies
-    for (_, name, branch, _) in gitSource.iterList(gitList) {
+    // can't use _ since it will leak
+    // see https://github.com/chapel-lang/chapel/issues/25926
+    for (_x, name, branch, _y) in gitSource.iterList(gitList) {
       const gitDepSrc = joinPath(gitDepPath, "%s-%s".format(name, branch),
                                  "src", "%s.chpl".format(name));
       masonCompopts.pushBack(gitDepSrc);


### PR DESCRIPTION
Fixes memory leaks introduced into mason, caused by an [existing bug](https://github.com/chapel-lang/chapel/issues/25926) with custom iterators


[Not reviewed - trivial]