### PR TITLE
Temporarily skip array_transfer benchmark with v2

### DIFF
--- a/test/studies/arkouda/sub_test
+++ b/test/studies/arkouda/sub_test
@@ -234,9 +234,13 @@ if [ ${CHPL_TEST_ARKOUDA_STOP_AFTER_BUILD} = "false" ]; then
       reformat_benchmark_opts="${reformat_benchmark_opts} $CHPL_TEST_ARKOUDA_REFORMAT_BENCHMARKS_V2"
     fi
 
-    # TODO: the full problem size causes array_transfer to crash
-    # benchmark_size=$((10**8))
-    benchmark_size=$((10**5))
+    # TODO: the full problem size causes the following to crash
+    # * array_transfer
+    # skip them for now
+    # small size of 10**5 works for everything
+    sed '/array_transfer_benchmark.py/d' benchmark.ini > benchmark.ini.tmp && mv benchmark.ini.tmp benchmark.ini
+    benchmark_size=$((10**8))
+
     benchmark_data=benchmark_v2/data/benchmark_stats_$(date +%Y%m%d_%H%M%S).json
     mkdir -p benchmark_v2/data
     benchmark_opts="--benchmark-autosave --benchmark-storage=file://benchmark_v2/.benchmarks --size=$benchmark_size --benchmark-json=$benchmark_data"


### PR DESCRIPTION
Temporarily skip arkouda array_transfer benchmark with v2

[Not reviewed - trivial]