### PR TITLE
Pin LLVM for Centos 10

### DIFF
--- a/util/devel/test/portability/apptainer/current/centos-stream-10/image.def
+++ b/util/devel/test/portability/apptainer/current/centos-stream-10/image.def
@@ -8,7 +8,9 @@ From: quay.io/centos/centos:stream10
     /provision-scripts/dnf-upgrade.sh
     /provision-scripts/dnf-epel.sh
     /provision-scripts/dnf-deps.sh
-    /provision-scripts/dnf-llvm.sh
+    # installing llvm-devel installs LLVM 21
+    # this relies on epel being enabled
+    /provision-scripts/dnf-llvm19.sh
 
 %runscript
     ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/portability/provision-scripts/dnf-llvm19.sh
+++ b/util/devel/test/portability/provision-scripts/dnf-llvm19.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+dnf -y install llvm19-devel clang19 clang19-devel


### PR DESCRIPTION
Pins the LLVM version for centos, since it now defaults to LLVM 21

[Reviewed by @arifthpe]