### PR TITLE
Add '--no-checks' to ASAN-specific test to ensure ASAN trips

### DIFF
--- a/test/types/type_variables/aliases/record-type-field-alias-array.compopts
+++ b/test/types/type_variables/aliases/record-type-field-alias-array.compopts
@@ -1,0 +1,1 @@
+--no-checks

--- a/test/types/type_variables/aliases/record-type-fields-alias-array-types-conditional.compopts
+++ b/test/types/type_variables/aliases/record-type-fields-alias-array-types-conditional.compopts
@@ -1,0 +1,1 @@
+--no-checks


### PR DESCRIPTION
The test here expects undefined behavior on ASAN's front. However, with `--checks` (default), Chapel itself performs nil checking, and produces output that is not expected by the prediff. Here, add `--no-checks` to the compopts, so that ASAN is always the one to find the error, and thus, the prediff gets its expected output.

Reviewed by @benharsh -- thanks!