### PR TITLE
Update the recommended DCO fix

### DIFF
--- a/doc/rst/developer/bestPractices/DCO.rst
+++ b/doc/rst/developer/bestPractices/DCO.rst
@@ -155,6 +155,5 @@ DCO mistake. In more detail:
 
 * Their dates will be updated.
 
-If someone else, for example your reviewer, had checked off your branch before
-you rebase, they may have to do a rebase on their end. It is a good practice to
-inform your reviewer of your rebase and force-push.
+It is a good practice to inform your reviewer of your rebase and force-push.
+Particularly if they had started reviewing already.


### PR DESCRIPTION
This PR updates the recommended rebase method for fixing DCO:

- it avoids interactivity,
- relies on `merge-base` instead of the developer checking the number of commits they have,
- uses `--force-with-lease` for safer force-push