### PR TITLE
Detect RISC-V 64-bit Linux

### DIFF
--- a/util/chplenv/chpl_platform.py
+++ b/util/chplenv/chpl_platform.py
@@ -50,7 +50,7 @@ def get(flag='host'):
                     platform_val = "linux64_32"
                 else:
                     platform_val = "linux64"
-            elif machine == 'aarch64' or machine == 'arm64':
+            elif machine in ['aarch64', 'arm64', 'riscv64']:
                 platform_val = "linux64"
             else:
                 platform_val = "linux32"


### PR DESCRIPTION
The current version of the platform detection script falls back to 32-bit linux for unrecognized architectures. This patch allows it to properly detect 64-bit risc-v.