### PR TITLE
Fix templating error and architecture detection in Tcl modulefile for EX RPM build

### DIFF
--- a/util/build_configs/cray-internal/chapel.modulefile.tcl.template
+++ b/util/build_configs/cray-internal/chapel.modulefile.tcl.template
@@ -3,8 +3,9 @@
 # Chapel module
 #
 
-if { [info exists env(CPU)] } {
-    set CHPL_HOST_ARCH $env(CPU)
+set cpu "[uname machine]"
+if { [string length cpu] } {
+    set CHPL_HOST_ARCH $cpu
 } else {
     set CHPL_HOST_ARCH "UNSET"
 }
@@ -101,7 +102,7 @@ if { [string match aarch64 $CHPL_HOST_ARCH] } {
         }
     }
 } else {
-    puts stderr "Error: CPU=$cpu"
+    puts stderr "Error: CPU=$CHPL_HOST_ARCH"
     exit 1
 }
 
@@ -130,7 +131,7 @@ if { [string match hpe-cray-ex $CHPL_HOST_PLATFORM] } {
     }
 }
 
-set BASE_INSTALL_DIR    [BASE_INSTALL_DIR]
+set BASE_INSTALL_DIR    @@{platform_prefix}
 set CHPL_LEVEL          @@{pkg_version}
 set CHPL_LOC            $BASE_INSTALL_DIR/chapel/$CHPL_LEVEL/$CHPL_HOST_PLATFORM
 set is_module_rm        [module-info mode remove]

--- a/util/build_configs/cray-internal/chapel_package-cray.bash
+++ b/util/build_configs/cray-internal/chapel_package-cray.bash
@@ -189,6 +189,7 @@ fi
 
 log_debug "Generate modulefile-$pkg_version ..."
 $cwd/process-template.py pkg_version="$pkg_version" \
+                         platform_prefix="$platform_prefix" \
 			 --template $cwd/chapel.modulefile.tcl.template \
 			 --output $rpmbuild_dir/modulefile-$pkg_version
 chmod 644 "$rpmbuild_dir/modulefile-$pkg_version"


### PR DESCRIPTION
I found some issues in the RPM build scripts for EX systems which cause errors in the Environment Modules (Tcl) modulefile:

- The architecture is currently detected via the `$CPU` environment variable. I found that this value is set in `/etc/profile` on SUSE-based distros. On RHEL the environment variable is not set, which causes `CHPL_HOST_ARCH` to be set to `UNKNOWN`. I implemented an alternative detection method which uses the [uname command from Environment Modules](https://modules.readthedocs.io/en/latest/modulefile.html#mfcmd-uname). This should work on all distros.
- If `CHPL_HOST_ARCH` is not set to a known value an error is printed. Unfortunately, the error message prints the `$cpu` variable which is not defined anywhere in the modulefile. This leads to an unspecific error from the Tcl interpreter
- The `BASE_INSTALL_DIR` variable was not correctly propagated by the `process-template.py` script

It would probably be a good idea to change the architecture detection in the Lua modulefile too, however I didn't find a method which doesn't involve launching a subprocess with `uname -m`.