### PR TITLE
Unpin llvm for homebrew

### DIFF
--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -18,7 +18,7 @@ class Chapel < Formula
   depends_on "gmp"
   depends_on "hwloc"
   depends_on "jemalloc"
-  depends_on "llvm@21"
+  depends_on "llvm"
   depends_on "pkgconf"
   depends_on "python@3.14"
 


### PR DESCRIPTION
Unpins the LLVM for homebrew since homebrew style disallows the pin

[Not reviewed - trivial]