### PR TITLE
Workaround LLVM and libc++ issue

### DIFF
--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -204,7 +204,7 @@ def check_llvm_packages(llvm_config):
                         usr_include_clang_ok = True
                         clang_include_ok = True
 
-    llvm_lib_dir = run_command([llvm_config, '--libdir']).strip()
+    llvm_lib_dir = _get_llvm_config_libdir(llvm_config)
 
     clang_lib_name = None
     if sys.platform == "darwin":
@@ -441,6 +441,19 @@ def _get_llvm_config_bindir(llvm_config):
     found_version, found_config_err = check_llvm_config(llvm_config)
     if llvm_config and found_version and not found_config_err:
         return run_command([llvm_config, '--bindir']).strip()
+    else:
+        return None
+
+@memoize
+def get_llvm_config_libdir():
+    llvm_config = get_llvm_config()
+    return _get_llvm_config_libdir(llvm_config)
+
+@memoize
+def _get_llvm_config_libdir(llvm_config):
+    found_version, found_config_err = check_llvm_config(llvm_config)
+    if llvm_config and found_version and not found_config_err:
+        return run_command([llvm_config, '--libdir']).strip()
     else:
         return None
 
@@ -1413,9 +1426,8 @@ def compute_host_link_settings():
         if shared_mode.strip() == 'static':
             llvm_dynamic = False
 
-        libdir = run_command([llvm_config, '--libdir'])
+        libdir = _get_llvm_config_libdir(llvm_config)
         if libdir:
-            libdir = libdir.strip()
             system.append('-L' + libdir)
             system.append('-Wl,-rpath,' + libdir)
 
@@ -1443,7 +1455,7 @@ def compute_host_link_settings():
         # don't try to run llvm-config if it's not built yet
         if is_included_llvm_built(llvm_val):
 
-            libdir = run_command([llvm_config, '--libdir'])
+            libdir = _get_llvm_config_libdir(llvm_config)
             if libdir:
                 libdir = libdir.strip()
                 bundled.append('-L' + libdir)


### PR DESCRIPTION
Adds a workaround for linking against C++ libraries in Chapel with LLVM 21 (specifically issues with linking re2)

We saw errors like:
```
Undefined symbols for architecture arm64:
  "std::__1::__hash_memory(void const*, unsigned long)", referenced from:
      std::__1::hash<re2::DFA::State*>::operator()[abi:ne210107](re2::DFA::State*) const in libre2.a[6](dfa.o)
ld: symbol(s) not found for architecture arm64
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```
and
```
> Undefined symbols for architecture arm64:
>   "std::__1::__hash_memory(void const*, unsigned long)", referenced from:
>       re2::DFA::BuildAllStates(std::__1::function<void (int const*, bool)> const&) in libre2.a[6](dfa.o)
>       std::__1::pair<std::__1::__hash_iterator<std::__1::__hash_node<std::__1::__hash_value_type<re2::DFA::State*, int>, void*>*>, bool> std::__1::__hash_table<std::__1::__hash_value_type<re2::DFA::State*, int>, std::__1::__unordered_map_hasher<re2::DFA::State*, std::__1::pair<re2::DFA::State* const, int>, std::__1::hash<re2::DFA::State*>, std::__1::equal_to<re2::DFA::State*>, true>, std::__1::__unordered_map_equal<re2::DFA::State*, std::__1::pair<re2::DFA::State* const, int>, std::__1::equal_to<re2::DFA::State*>, std::__1::hash<re2::DFA::State*>, true>, std::__1::allocator<std::__1::pair<re2::DFA::State* const, int>>>::__emplace_unique_key_args<re2::DFA::State*, re2::DFA::State*&, int>(re2::DFA::State* const&, re2::DFA::State*&, int&&) in libre2.a[6](dfa.o)
>       std::__1::pair<std::__1::__hash_iterator<std::__1::__hash_node<std::__1::__hash_value_type<re2::DFA::State*, int>, void*>*>, bool> std::__1::__hash_table<std::__1::__hash_value_type<re2::DFA::State*, int>, std::__1::__unordered_map_hasher<re2::DFA::State*, std::__1::pair<re2::DFA::State* const, int>, std::__1::hash<re2::DFA::State*>, std::__1::equal_to<re2::DFA::State*>, true>, std::__1::__unordered_map_equal<re2::DFA::State*, std::__1::pair<re2::DFA::State* const, int>, std::__1::equal_to<re2::DFA::State*>, std::__1::hash<re2::DFA::State*>, true>, std::__1::allocator<std::__1::pair<re2::DFA::State* const, int>>>::__emplace_unique_key_args<re2::DFA::State*, std::__1::piecewise_construct_t const&, std::__1::tuple<re2::DFA::State* const&>, std::__1::tuple<>>(re2::DFA::State* const&, std::__1::piecewise_construct_t const&, std::__1::tuple<re2::DFA::State* const&>&&, std::__1::tuple<>&&) in libre2.a[6](dfa.o)
> ld: symbol(s) not found for architecture arm64
> clang++: error: linker command failed with exit code 1 (use -v to see invocation)
> error: Make Binary - Linking
```

This was traced to be caused by https://github.com/llvm/llvm-project/issues/77653 and https://github.com/Homebrew/homebrew-core/issues/235411. This is an upstream issue, but its possible to workaround the issue by explicitly linking against the libc++ shipped with LLVM. See https://github.com/Homebrew/homebrew-core/issues/235411#issuecomment-3314664721


We have only seen this problem with a homebrew LLVM and on Macs, so the fix is restricted to MacOS.

[Reviewed by @benharsh]