### PR TITLE
Fix dependency path for llvm21

### DIFF
--- a/util/cron/test-linux64-llvm21.bash
+++ b/util/cron/test-linux64-llvm21.bash
@@ -5,7 +5,7 @@
 UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common.bash
 
-source /hpcdc/project/chapel/setup_llvm.bash 21
+source /hpcdc/project/chapel/chpl-deps/chapcs11/setup_llvm.bash 21
 
 # Check LLVM version via llvm-config from CHPL_LLVM_CONFIG
 llvm_version=$($CHPL_LLVM_CONFIG --version)


### PR DESCRIPTION
Fixes the dependency path for llvm21 tests

[Not reviewed - trivial]