### PR TITLE
Ensure User-Specified Make is Used When Building mimalloc

### DIFF
--- a/third-party/mimalloc/Makefile
+++ b/third-party/mimalloc/Makefile
@@ -74,10 +74,10 @@ configure-mimalloc: FORCE
 	  $(CHPL_MIMALLOC_CFG_OPTIONS)
 
 build-mimalloc: FORCE
-	$(CMAKE) --build $(MIMALLOC_BUILD_DIR)
+	if [ -f $(MIMALLOC_BUILD_DIR)/Makefile ]; then cd $(MIMALLOC_BUILD_DIR) && $(MAKE); else $(CMAKE) --build $(MIMALLOC_BUILD_DIR); fi
 
 install-mimalloc: FORCE
-	$(CMAKE) --install $(MIMALLOC_BUILD_DIR)
+	if [ -f $(MIMALLOC_BUILD_DIR)/Makefile ]; then cd $(MIMALLOC_BUILD_DIR) && $(MAKE) install; else $(CMAKE) --install $(MIMALLOC_BUILD_DIR); fi
 
 FORCE:
 


### PR DESCRIPTION
This fixes a build error I ran into while testing with mimalloc in one of my development environments where there are multiple versions of make present (and make and gmake aren't necessarily the same).

The idiom I'm using to fix this is the same as the one already used when building qthreads.