### PR TITLE
Un-futurize passing test

### DIFF
--- a/test/classes/generic/nonGenericSubclassGenericSuperclass.bad
+++ b/test/classes/generic/nonGenericSubclassGenericSuperclass.bad
@@ -1,7 +1,0 @@
-nonGenericSubclassGenericSuperclass.chpl:13: warning: please use '?' when declaring a variable with generic type
-nonGenericSubclassGenericSuperclass.chpl:13: note: for example with 'Parent(?)'
-nonGenericSubclassGenericSuperclass.chpl:13: In initializer:
-nonGenericSubclassGenericSuperclass.chpl:13: error: cannot default-initialize a variable with generic type
-nonGenericSubclassGenericSuperclass.chpl:13: note: '<temporary>' has generic type 'borrowed Parent'
-nonGenericSubclassGenericSuperclass.chpl:13: note: cannot find initialization point to split-init this variable
-  nonGenericSubclassGenericSuperclass.chpl:19: called as Child.init(x: borrowed Generic(1))

--- a/test/classes/generic/nonGenericSubclassGenericSuperclass.future
+++ b/test/classes/generic/nonGenericSubclassGenericSuperclass.future
@@ -1,2 +1,0 @@
-bug: inheriting from a generic class in a non-generic subclass
-#26579


### PR DESCRIPTION
A test (`classes/generic/nonGenericSubclassGenericSuperclass`) has been passing as of #28362

Reviewed by @arifthpe -- thanks!

## Testing
- [x] test now passes