### PR TITLE
Use CHPL_UNWIND=none on linuxbrew installs

### DIFF
--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -78,7 +78,11 @@ class Chapel < Formula
     EOS
 
     on_linux do
-    # we get strange build erros with the bundled lobunwind onc
+      # we get strange build errors when trying to build with libunwind on linux
+      # the bundled build gets weird linking errors. this seems to be the fault
+      # of the homebrew build environment. we also cant use the system libunwind
+      # due to it being keg-only and not found by default.
+      # for now, disable stack unwinding with linuxbrew
       (libexec/"chplconfig").append_lines <<~EOS
         CHPL_UNWIND=none
       EOS


### PR DESCRIPTION
Adjusts the homebrew/linuxbrew formula to use CHPL_UNWIND=none on linux. This resolves a build error we recently started seeing in nightly tests 


## Details

we started get strange linker errors when trying to build mason from the bundled libunwind on linux. this seems to be the fault of the homebrew build environment (I tested Chapel 2.7 and main, neither workd). using a `chpl` built through linuxbrew works fine with libunwind, but inside of the linuxbrew build (when building mason) it doesn't work. the system libunwind could be used (add a depends_on "libunwind" and set CHPL_UNWIND=system), but because thats keg-only, it won't be found by default and will require special handling. the simplest solution is to just not use libunwind on linux, which is what we do in this PR. this means that backtraces won't work in linuxbrew installs, but it should be a rare enough use case that it's worth it to avoid the build issues.

[Reviewed by @arifthpe]