### PR TITLE
Skip the module deinit order test in --baseline testing

### DIFF
--- a/test/modules/vass/deinit-order-modules.skipif
+++ b/test/modules/vass/deinit-order-modules.skipif
@@ -1,3 +1,4 @@
 # And in any case no point running this in too many configs.
 CHPL_COMM!=none
 COMPOPTS <= --no-local
+COMPOPTS <= --baseline


### PR DESCRIPTION
This test started failing in our `--baseline` configurations recently due to the deinit order of two modules being swapped (`Time` and (`CompressedSparseLayout`).  I'm imagining that this is due to #28329 in which I removed deprecated dmap and distribution features including 'LayoutCS', but am not confident.

I also don't think it's worth worrying about the reason for the swap given that it's `--baseline` testing.  I think of the main point of this test as to be sure that module deinitialization is working, and less about the specifics of locking in the module deinit order for every configuration (and the pre-existing skipifs suggest this as well).  So this PR just adds a new skip for baseline testing.
