### PR TITLE
Set `platform_prefix` var passed in to TCL modulefile template

### DIFF
--- a/util/build_configs/cray-internal/chapel_package-cray.bash
+++ b/util/build_configs/cray-internal/chapel_package-cray.bash
@@ -185,25 +185,24 @@ else
     chmod 644 "$rpmbuild_dir/release_info"
 fi
 
-# Generate modulefile, w versions
-
-log_debug "Generate modulefile-$pkg_version ..."
-$cwd/process-template.py pkg_version="$pkg_version" \
-                         platform_prefix="$platform_prefix" \
-			 --template $cwd/chapel.modulefile.tcl.template \
-			 --output $rpmbuild_dir/modulefile-$pkg_version
-chmod 644 "$rpmbuild_dir/modulefile-$pkg_version"
-
-# Generate Lua modulefile for PE Lmod Hierarchy.
-
-log_debug "Generate Lua modulefile ..."
-
+# Generate modulefiles
 (
     if [ "$chpl_platform" = hpe-cray-ex ]; then
         platform_prefix=/opt/cray
     else
         platform_prefix=/opt
     fi
+
+    # Generate modulefile, w versions
+    log_debug "Generate modulefile-$pkg_version ..."
+    $cwd/process-template.py pkg_version="$pkg_version" \
+                             platform_prefix="$platform_prefix" \
+                 --template $cwd/chapel.modulefile.tcl.template \
+                 --output $rpmbuild_dir/modulefile-$pkg_version
+    chmod 644 "$rpmbuild_dir/modulefile-$pkg_version"
+
+    # Generate Lua modulefile for PE Lmod Hierarchy.
+    log_debug "Generate Lua modulefile ..."
     $cwd/process-template.py pkg_version="$pkg_version" \
                              platform_prefix="$platform_prefix" \
         --template $cwd/chapel.modulefile.lua.template \


### PR DESCRIPTION
Set the `platform_prefix` variable in `util/build_configs/cray-internal/chapel_package-cray.bash` before trying to pass it in to fill out the TCL modulefile, where it is expected as of https://github.com/chapel-lang/chapel/pull/28369.

[reviewer info placeholder]