### PR TITLE
Add annotations for the many-to-one perf tests to reflect last week's change

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -1935,6 +1935,12 @@ remote-amos.ml-perf:
   08/25/25:
     - text: Suspected machine changes
       config: 16-node-hpe-cray-ex
+  02/07/26:
+    - Switch this test's throttling to use recursive doubling (#28375)
+
+remote-fastOns.ml-perf:
+  02/07/26:
+    - Switch this test's throttling to use recursive doubling (#28375)
 
 remote-unordered-amos.ml-perf:
   04/17/25:
@@ -1943,20 +1949,32 @@ remote-unordered-amos.ml-perf:
   08/25/25:
     - text: Suspected machine changes
       config: 16-node-hpe-cray-ex
+  02/07/26:
+    - Switch this test's throttling to use recursive doubling (#28375)
+
+remote-gets.ml-perf:
+  02/07/26:
+    - Switch this test's throttling to use recursive doubling (#28375)
 
 remote-puts.ml-perf:
   11/03/20:
     - Do fewer GETs to force PUTs into a visible state, and do them later (#16634)
+  02/07/26:
+    - Switch this test's throttling to use recursive doubling (#28375)
 
 remote-fetchAmos.ml-perf:
   11/03/20:
     - Do fewer GETs to force PUTs into a visible state, and do them later (#16634)
+  02/07/26:
+    - Switch this test's throttling to use recursive doubling (#28375)
 
 remote-ons.ml-perf:
   05/17/19:
     - Avoid comm/compute overlap for short-lived tasks (#12964)
   05/13/20:
     - Reorganize arg bundles in the runtime (#15660)
+  02/07/26:
+    - Switch this test's throttling to use recursive doubling (#28375)
 
 remote-record-read-copy:
   11/15/18:
@@ -1967,6 +1985,8 @@ remote-record-read-copy:
 remote-unordered-gets.ml-perf:
   02/04/20:
     - Add unordered GET/PUT support in comm=ofi. (#14810)
+  02/07/26:
+    - Switch this test's throttling to use recursive doubling (#28375)
 
 return-array-8: &return-array-base
   03/04/17:


### PR DESCRIPTION
I annotated all 8 benchmarks even though  not all showed a difference in the graphs I was looking at, just in case there were differences on ones I wasn't.

I also haven't written annotations in awhile, so would really appreciate someone giving this a careful review rather than rubber stamping.