### PR TITLE
Fix brew style issue

### DIFF
--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -77,7 +77,7 @@ class Chapel < Formula
       CHPL_TARGET_CPU=native
     EOS
 
-    on_linux do
+    if OS.linux?
       # we get strange build errors when trying to build with libunwind on linux
       # the bundled build gets weird linking errors. this seems to be the fault
       # of the homebrew build environment. we also cant use the system libunwind


### PR DESCRIPTION
Fixes a style issue with the homebrew formula

```
Taps/homebrew/homebrew-core/Formula/c/chapel.rb:84:5: C: [Correctable] FormulaAudit/OnSystemConditionals: Instead of using on_linux in def install, use if OS.linux?.
    on_linux do
    ^^^^^^^^

1 file inspected, 1 offenses detected, 1 offenses autocorrectable
```

This PR takes the suggested action

[Reviewed by @arifthpe]