### PR TITLE
Fix gen_release invoking chpl-make-cpu_count from fresh clone

### DIFF
--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -35,12 +35,11 @@ make_threads = 1
 
 pjoin = os.path.join
 
-def set_make_threads(home_dir):
+def set_make_threads():
     global make_threads
-    with cd(home_dir):
-        result = run("util/buildRelease/chpl-make-cpu_count", stdout=subprocess.PIPE)
-        make_threads = int(result.stdout.decode().strip())
-        return make_threads
+    cpu_count = run("util/buildRelease/chpl-make-cpu_count", stdout=subprocess.PIPE)
+    make_threads = int(cpu_count.stdout.decode().strip())
+    return make_threads
 
 
 def make(*args, **kwargs):
@@ -135,8 +134,6 @@ def main():
         "CHPL_HOME", os.path.abspath(os.path.join(__file__, "..", "..", ".."))
     )
 
-    set_make_threads(chplhome)
-
     # pointers to temporary directory where chapel will be built
     basetmpdir = os.getenv("CHPL_GEN_RELEASE_TMPDIR", tempfile.gettempdir())
     user = getpass.getuser()
@@ -230,6 +227,7 @@ def main():
             resultdir = basetmpdir
 
     with cd(archive_dir):
+        set_make_threads()
 
         log("Creating the spec tests...")
         make("spectests")


### PR DESCRIPTION
Adjust invocation of `util/buildRelease/chpl-make-cpu_count` in `util/buildRelease/gen_release` to work whether an existing or fresh clone of Chapel is used.

Previously this only worked if `gen_release` was being invoked from within an existing Chapel checkout (containing `chpl-make-cpu_count`), but some of our tests rely on being able to use it standalone. Adjusted to call out to that script only after the copy of Chapel has been acquired, whether from copying an existing clone or via a fresh clone.

Follow up to https://github.com/chapel-lang/chapel/pull/28395.

[reviewer info placeholder]

Testing:
- [x] `util/cron/create_tarball.bash`
- [x] `util/cron/test-release.bash`