### PR TITLE
Switch https://example.com to http://example.com

### DIFF
--- a/test/library/packages/Curl/doc-examples/CurlExamples.chpl
+++ b/test/library/packages/Curl/doc-examples/CurlExamples.chpl
@@ -39,7 +39,7 @@ writeln('~@OK1');
 // This example changes the Curl options before connecting
 use URL, Curl;
 
-var reader = openUrlReader("https://example.com");
+var reader = openUrlReader("http://example.com");
 var str: bytes;
 // Set verbose output from curl
 extern const CURLOPT_VERBOSE: CURLoption;


### PR DESCRIPTION
The https is causing a failure on one of our test systems and doesn't seem important to the test being done here.  All other example.com URLs in our test suite use http://..., making me think this is acceptable.
