### PR TITLE
More fixes to OOM sub_test

### DIFF
--- a/test/compflags/oom/sub_test
+++ b/test/compflags/oom/sub_test
@@ -35,6 +35,8 @@ ps_base_command = "ps -o pid,ppid,cmd"
 subtest_start_time = None
 subtest_test_name = '"compflags/oom"'
 
+errored = False
+
 def subtest_start():
     global subtest_start_time
     subtest_start_time = datetime.now()
@@ -50,8 +52,11 @@ def subtest_end():
     print(f"[Finished subtest {subtest_test_name} - {elapsed_time} seconds]")
 
 def subtest_error(msg):
-    print(f"[Error running sub_test {subtest_test_name} - {msg}]")
-    sys.exit(1)
+    global errored
+    # Only print first error
+    if not errored:
+        errored = True
+        print(f"[Error running sub_test {subtest_test_name} - {msg}]")
 
 ### END sub_test output helper functions ###
 


### PR DESCRIPTION
Additional fixes to `test/compflags/oom/sub_test`:
- As this test is racy, add a `time.sleep` to allow time for the child process to be spawned before searching for it. I chose 2 seconds as a value that I think is plenty of time for the child to spawn, but not so long that it could complete.
- Always print `Finished subtest` line expected by test infrastructure at the end, even if an error is encountered.
- Avoid exiting with non-zero status even in the case of an error, as the `Error` line being printed already gets picked up as a failure.
- Comment purposes of constants.

Follow up to https://github.com/chapel-lang/chapel/pull/28364 and https://github.com/chapel-lang/chapel/pull/28400.

[trivial fix, not reviewed]