### PR TITLE
Restore substitution of `BASE_INSTALL_DIR` in EX RPM TCL module

### DIFF
--- a/util/build_configs/cray-internal/chapel.modulefile.tcl.template
+++ b/util/build_configs/cray-internal/chapel.modulefile.tcl.template
@@ -131,7 +131,7 @@ if { [string match hpe-cray-ex $CHPL_HOST_PLATFORM] } {
     }
 }
 
-set BASE_INSTALL_DIR    @@{platform_prefix}
+set BASE_INSTALL_DIR    [BASE_INSTALL_DIR]
 set CHPL_LEVEL          @@{pkg_version}
 set CHPL_LOC            $BASE_INSTALL_DIR/chapel/$CHPL_LEVEL/$CHPL_HOST_PLATFORM
 set is_module_rm        [module-info mode remove]

--- a/util/build_configs/cray-internal/chapel_package-cray.bash
+++ b/util/build_configs/cray-internal/chapel_package-cray.bash
@@ -189,7 +189,6 @@ fi
 
 log_debug "Generate modulefile-$pkg_version ..."
 $cwd/process-template.py pkg_version="$pkg_version" \
-                         platform_prefix="$platform_prefix" \
 			 --template $cwd/chapel.modulefile.tcl.template \
 			 --output $rpmbuild_dir/modulefile-$pkg_version
 chmod 644 "$rpmbuild_dir/modulefile-$pkg_version"


### PR DESCRIPTION
Go back to leaving the `[BASE_INSTALL_DIR]` string in the TCL modulefile at build time, to later be substituted by `rpm` at install time as defined in `chapel.spec.template`.

This is necessary because after https://github.com/chapel-lang/chapel/pull/28369 (+ additional fix https://github.com/chapel-lang/chapel/pull/28399), the prefix value is substituted at build time and is always a system-wide install in `/opt/cray` rather than the `--prefix` arg the user gives to `rpm`.

Future work:
- Also fix the Lua module, which is currently subject to the same build-time substitution as the TCL module is before this PR.

Reverts https://github.com/chapel-lang/chapel/pull/28399.
Follow up to https://github.com/chapel-lang/chapel/pull/28369.

[reviewer info placeholder]