### PR TITLE
Print error at end of oom sub_test only

### DIFF
--- a/test/compflags/oom/sub_test
+++ b/test/compflags/oom/sub_test
@@ -35,7 +35,7 @@ ps_base_command = "ps -o pid,ppid,cmd"
 subtest_start_time = None
 subtest_test_name = '"compflags/oom"'
 
-errored = False
+error_msg = ""
 
 def subtest_start():
     global subtest_start_time
@@ -50,13 +50,14 @@ def subtest_end():
 
     print(f"[Elapsed time to compile and execute all versions of {subtest_test_name} - {elapsed_time} seconds]")
     print(f"[Finished subtest {subtest_test_name} - {elapsed_time} seconds]")
+    if error_msg:
+        print(f"[Error running sub_test {subtest_test_name} - {error_msg}]")
 
 def subtest_error(msg):
-    global errored
+    global error_msg
     # Only print first error
-    if not errored:
-        errored = True
-        print(f"[Error running sub_test {subtest_test_name} - {msg}]")
+    if not error_msg:
+        error_msg = msg
 
 ### END sub_test output helper functions ###
 


### PR DESCRIPTION
Wait to print errors until after normal sub_test output has completed, to hopefully fix parse errors from `convert_start_test_log_to_junit_xml.py`.

Follow up to https://github.com/chapel-lang/chapel/pull/28409.

[trivial fix, not reviewed]

Testing:
- [x] `convert_start_test_log_to_junit_xml.py` succeeds locally