### PR TITLE
OOM sub_test fix 'ps' line splitting to find child process

### DIFF
--- a/test/compflags/oom/sub_test
+++ b/test/compflags/oom/sub_test
@@ -73,8 +73,8 @@ def kill_subphase(ppid):
     print(ps_output)
 
     for line in ps_output.splitlines():
-        split_line = line.split(" ")
-        if str(ppid) in split_line[1]:
+        split_line = line.split()
+        if str(ppid) in split_line:
             child_pid = int(split_line[0])
             print(f"Killing subphase with PID {child_pid}...", end="")
             os.kill(child_pid, signal.SIGKILL)


### PR DESCRIPTION
I noticed in some failed runs that the output from `ps` puts two spaces between PID and PPID, but Python `split` is invoked with just a single space a separator, so the field indices are thrown off. Fixed by removing that separator arg to use the default of splitting on any length chunk of whitespace.

[trivial fix, not reviewed]