### PR TITLE
Fix error reporting in `sub_test` to not confuse JUnit parsing script

### DIFF
--- a/test/compflags/oom/sub_test
+++ b/test/compflags/oom/sub_test
@@ -56,7 +56,7 @@ def subtest_error(msg):
     # Only print first error
     if not errored:
         errored = True
-        print(f"[Error running sub_test {subtest_test_name} - {msg}]")
+        print(f"[Error running out-of-memory test {subtest_test_name} - {msg}]")
 
 ### END sub_test output helper functions ###
 


### PR DESCRIPTION
(re) closes https://github.com/Cray/chapel-private/issues/3597.
Reverts https://github.com/chapel-lang/chapel/pull/28420.

'Error matching sub_test' is a specific line that is expected when a `sub_test` script itself fails. In this instance, it's printed from a `sub_test` script to indicate that the the test itself failed (as opposed to the script). This is a distinct failure mode, and is handled better by regular logic that looks for `Error *`. So, change the error to not count as a sub_test failure.

Reviewed by @arifthpe -- thanks!

## Testing
- [x] parsed modified version of originally failing test log with new output.