### PR TITLE
Switch all three playgrounds to measure the performance of disabling alias analysis

### DIFF
--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -28,10 +28,13 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground"
 # 4) Update START_DATE to be today, using the format mm/dd/yy
 #
 
-GITHUB_USER=insertinterestingnamehere
-GITHUB_BRANCH=qthreads-1.23
-SHORT_NAME=qthreads123
-START_DATE=2/5/26
+# Test what happens to performance if we disable the
+# --interprocedural-alias-analysis pass by default
+
+GITHUB_USER=bradcray
+GITHUB_BRANCH=no-noAliasSets2
+SHORT_NAME=noAliasAnalysis
+START_DATE=2/19/26
 
 set -e
 checkout_branch $GITHUB_USER $GITHUB_BRANCH

--- a/util/cron/test-perf.hpe-apollo-hdr.arkouda.playground.bash
+++ b/util/cron/test-perf.hpe-apollo-hdr.arkouda.playground.bash
@@ -40,6 +40,9 @@ source $UTIL_CRON_DIR/common-perf-hpe-apollo-hdr.bash
 # When the multi-local playground is not used, set `SKIP_ARKOUDA_PLAYGROUND=1
 #
 
+# Test what happens to performance if we disable the
+# --interprocedural-alias-analysis pass by default
+
 SKIP_ARKOUDA_PLAYGROUND=0
 if [[ "$SKIP_ARKOUDA_PLAYGROUND" == "1" ]]; then
   log_info "Skipping testing of the arkouda playground"
@@ -48,14 +51,14 @@ fi
 
 TEST_NIGHTLY=1
 
-GITHUB_USER=chapel-lang
-GITHUB_BRANCH=main
+GITHUB_USER=bradcray
+GITHUB_BRANCH=no-noAliasSets2
 
-SHORT_NAME=negative-bigint-better-fix
-START_DATE=12/16/25
+SHORT_NAME=noAliasAnalysis
+START_DATE=2/19/26
 
-export ARKOUDA_URL=https://github.com/1RyanK/arkouda.git
-export ARKOUDA_BRANCH=5150-Try_to_fix_bigint_performance_again
+export ARKOUDA_URL=https://github.com/Bears-R-Us/arkouda.git
+export ARKOUDA_BRANCH=main
 
 if [[ "$TEST_NIGHTLY" == "1" ]]; then
   set -e

--- a/util/cron/test-perf.hpe-apollo-hdr.gasnet-ibv.playground.bash
+++ b/util/cron/test-perf.hpe-apollo-hdr.gasnet-ibv.playground.bash
@@ -33,10 +33,13 @@ if [[ "$SKIP_ML_PLAYGROUND" == "1" ]]; then
   exit
 fi
 
-GITHUB_USER=insertinterestingnamehere
-GITHUB_BRANCH=qthreads-1.23
-SHORT_NAME=qthreads123
-START_DATE=2/5/26
+# Test what happens to performance if we disable the
+# --interprocedural-alias-analysis pass by default
+
+GITHUB_USER=bradcray
+GITHUB_BRANCH=no-noAliasSets2
+SHORT_NAME=noAliasAnalysis
+START_DATE=2/19/26
 
 set -e
 checkout_branch $GITHUB_USER $GITHUB_BRANCH


### PR DESCRIPTION
This switches all three playgrounds (chapcs, Apollo w/ gasnet-ibv, Arkouda) to use a branch in which I disable our alias analysis by default to understand the impact on performance.  This is equivalent to testing with --no-interprocedural-alias-analysis, which tries to find cases in which Chapel has special information about non-aliasing data structures that it passes along to LLVM in hopes of reaping benefits.
