### PR TITLE
Skip test with old LLVM

### DIFF
--- a/test/llvm/licm/SKIPIF
+++ b/test/llvm/licm/SKIPIF
@@ -2,3 +2,4 @@ COMPOPTS <= --baseline
 COMPOPTS <= --fast
 COMPOPTS <= --no-local
 CHPL_COMM!=none
+CHPL_LLVM_VERSION==14


### PR DESCRIPTION
Skips test with old LLVM version

[trivial - not reviewed]