### PR TITLE
Use consistent naming for chapel-py Location methods

### DIFF
--- a/tools/chapel-py/src/method-tables/core-methods.h
+++ b/tools/chapel-py/src/method-tables/core-methods.h
@@ -97,7 +97,7 @@ CLASS_BEGIN(Location)
 
          return Location(left->path(), std::max(left->start(), right.start()), left->end());
   )
-  METHOD(Location, adjust_start, "Get a new Location with the same end as this Location but with the start adjusted by the given line and column offsets",
+  METHOD(Location, modify_start, "Get a new Location with the same end as this Location but with the start adjusted by the given line and column offsets",
          chpl::Location(LineColumnPair),
          auto start = std::get<0>(args);
          auto newStart = std::make_tuple(node->firstLine() + std::get<0>(start),

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -519,7 +519,7 @@ def rules(driver: LintDriver):
                     len("try") if not node.is_try_bang() else len("try!")
                 )
                 # adjust the location to be just the keyword
-                try_loc = try_loc - try_loc.adjust_start((0, len_of_keyword))
+                try_loc = try_loc - try_loc.modify_start((0, len_of_keyword))
                 res = check_for_unattached(
                     context, body, try_loc, curly_loc, AdvancedRuleResult
                 )
@@ -541,7 +541,7 @@ def rules(driver: LintDriver):
                     catch_loc = node.location()
                     len_of_keyword = len("catch")
                     # adjust the location to be just the keyword
-                    before_loc = catch_loc - catch_loc.adjust_start(
+                    before_loc = catch_loc - catch_loc.modify_start(
                         (0, len_of_keyword)
                     )
                 if before_loc is None:


### PR DESCRIPTION
Fixes the new methods recently added for chapel-py Location's to use consistent naming

[Reviewed by @DanilaFe]