### PR TITLE
Fix a few issues with chplcheck linting

### DIFF
--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -1370,6 +1370,8 @@ def rules(driver: LintDriver):
         def find_anchor(node: Optional[AstNode]) -> Optional[AstNode]:
             # only loops and NamedDecls can be anchors for indentation
             anchor = node if isinstance(node, (Loop, NamedDecl)) else None
+            if isinstance(node, Module) and node.kind() == "implicit":
+                anchor = None
             return anchor
 
         # If root is something else (e.g., function call), do not


### PR DESCRIPTION
Fixes a few issues I found with chplcheck

* chplcheck would warn about serializer methods having UnusedFormals. Its reasonable for those formals to be unused in a proper method and seems unreasonable to force users to silence those errors with `@chplcheck.ignore`
* IncorrectIndentation warning on variables at implicit module scope would suggest invalid fixits, attempting to attach an attribute to the implicit module
* chplcheck would warn about `this` being an UnusedTaskIntent. This was incorrect, but because `this` may be used implicitly this is overzealous. In theory, we can use resolution to check for implicit uses and warn if its truly unused, but for now this just does the simple thing of hiding the lint (since its not guaranteed to be accurate)

[Reviewed by @DanilaFe]