### PR TITLE
Adds a `--keep` flag to start_test

### DIFF
--- a/util/test/start_test.py
+++ b/util/test/start_test.py
@@ -757,6 +757,9 @@ def set_up_environment():
     if args.comp_only:
         os.environ["CHPL_COMPONLY"] = "true"
 
+    if args.keep_executable:
+        os.environ["CHPL_TEST_KEEP_EXECUTABLE"] = "true"
+
     # stdin redirection
     if args.no_stdin_redirect or args.stdin_redirect:
         os.environ["CHPL_NO_STDIN_REDIRECT"] = "true"
@@ -1403,6 +1406,8 @@ def parser_setup():
     # only compile
     parser.add_argument("-comp-only", "--comp-only", action="store_true",
             dest="comp_only", help="only compile the tests, don't run")
+    # keep executables
+    parser.add_argument("-keep-executable", "--keep-executable", "--keep", action="store_true", dest="keep_executable", help="don't clean the generated executable after running")
     # num locales
     parser.add_argument("-numlocales", "--numlocales", action="store",
             dest="num_locales", default="0",

--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -406,6 +406,8 @@ def KillProc(p, timeout):
 
 # clean up after the test has been built
 def cleanup(execname, test_ran_and_more_compopts=False):
+    if os.getenv("CHPL_TEST_KEEP_EXECUTABLE"):
+        return
     try:
         if execname is not None:
             if os.path.isfile(execname):


### PR DESCRIPTION
Adds a `--keep` flag to `start_test` to avoid deleting the compiled executable. This is useful when debugging a failure, I may want to rerun the executable rapidly with different execution flags without needing to recompile. Rather than parsing the exact CLI flags `start_test` passed to `chpl`, its easier to just reuse the built executable

[Reviewed by @DanilaFe]