### PR TITLE
Have `mason run` default to using -nl1

### DIFF
--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -81,7 +81,8 @@ proc masonBuild(args: [] string) throws {
     var extraCompopts = new list(passArgs.values());
     runExamples(show=show, run=false, build=true, release=release,
                 skipUpdate=skipUpdate, force=force,
-                examplesRequested=examples, extraCompopts=extraCompopts);
+                examplesRequested=examples,
+                extraCompopts=extraCompopts, nLocales=1);
   } else {
     if passArgs.hasValue() {
       for val in passArgs.values() do compopts.pushBack(val);

--- a/tools/mason/MasonExample.chpl
+++ b/tools/mason/MasonExample.chpl
@@ -40,7 +40,8 @@ proc runExamples(show: bool, run: bool, build: bool, release: bool,
                  skipUpdate: bool, force: bool,
                  examplesRequested: list(string),
                  extraCompopts = new list(string),
-                 extraExecopts = new list(string)) throws {
+                 extraExecopts = new list(string),
+                 nLocales: int) throws {
   updateLock(skipUpdate);
 
   const cwd = here.cwd();
@@ -106,7 +107,7 @@ proc runExamples(show: bool, run: bool, build: bool, release: bool,
               writeln("compiled ", example, " successfully");
             if run then
               runExampleBinary(projectHome, exampleName,
-                                release, show, exampleExecopts);
+                                release, show, exampleExecopts, nLocales);
           }
         } else {
           // build is skipped but examples still need to be run
@@ -114,12 +115,12 @@ proc runExamples(show: bool, run: bool, build: bool, release: bool,
                   ": no changes made to project or example");
           if run then
             runExampleBinary(projectHome, exampleName,
-                              release, show, exampleExecopts);
+                              release, show, exampleExecopts, nLocales);
         }
       } else {
         // just running the example
         runExampleBinary(projectHome, exampleName,
-                          release, show, exampleExecopts);
+                          release, show, exampleExecopts, nLocales);
       }
     }
   } else {
@@ -283,10 +284,11 @@ private proc determineExamples(exampleNames: list(string),
 
 private proc runExampleBinary(projectHome: string, exampleName: string,
                               release: bool, show: bool,
-                              execopts: list(string)) throws {
+                              execopts: list(string), nLocales: int) throws {
   const executable = joinPath(projectHome, "target", "example", exampleName);
   var command: list(string);
   command.pushBack(executable);
+  command.pushBack("-nl" + nLocales:string);
   command.pushBack(execopts);
   if show then
     writef("Executing [%s] target: %s\n",

--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -107,25 +107,23 @@ proc masonTest(args: [] string) throws {
   if otherArgs.hasValue() {
     var flagInArgs = false;
     for arg in otherArgs.values() {
-      try! {
-        // try to get option values meant for compilation
-        if flagInArgs && !arg.startsWith('-') {
-          compopts.pushBack(arg);
-          flagInArgs=false;
-        } else if isFile(arg) && arg.endsWith(".chpl") {
-          // assume this is an individual test file
+      // try to get option values meant for compilation
+      if flagInArgs && !arg.startsWith('-') {
+        compopts.pushBack(arg);
+        flagInArgs=false;
+      } else if isFile(arg) && arg.endsWith(".chpl") {
+        // assume this is an individual test file
 
-          files.pushBack(arg);
-        } else if isDir(arg) {
-          // assume this is a test directory
-          dirs.pushBack(arg);
-        } else if arg.startsWith('-') {
-          // assume a flag for compiler
-          compopts.pushBack(arg);
-          flagInArgs=true;
-        } else {
-          searchSubStrings.pushBack(arg);
-        }
+        files.pushBack(arg);
+      } else if isDir(arg) {
+        // assume this is a test directory
+        dirs.pushBack(arg);
+      } else if arg.startsWith('-') {
+        // assume a flag for compiler
+        compopts.pushBack(arg);
+        flagInArgs=true;
+      } else {
+        searchSubStrings.pushBack(arg);
       }
     }
   }
@@ -513,12 +511,14 @@ proc getRuntimeComm() throws {
     if comm != "none" {
       comm = setComm;
     } else {
-      if setComm == "none" then comm = setComm;
+      if setComm == "none" then
+        comm = setComm;
       else {
-        writeln("Trying to execute in a multiLocale environment when ",
-        "communication mechanism is `none`.");
-        writeln("Try changing the communication mechanism");
-        exit(2);
+        throw new MasonError(
+          "Trying to execute in a multiLocale environment when " +
+          "communication mechanism is `none`.\n"+
+          "Try changing the communication mechanism"
+        );
       }
     }
   }


### PR DESCRIPTION
Switches mason to always run Chapel programs with `-nl1`. This means `mason run` can be used on CHPL_COMM!=none executables with no extra flags. Users who want to run with more than 1 locale can still use `mason run -- -nl NUMLOCALES`

[Reviewed by @benharsh]