### PR TITLE
Attempt to fix EX dependencies

### DIFF
--- a/util/cron/common-hpe-cray-ex.bash
+++ b/util/cron/common-hpe-cray-ex.bash
@@ -21,3 +21,6 @@ export CHPL_LAUNCHER_MEM=unset
 
 # both partitions we use have 128 cores
 export CHPL_NIGHTLY_MAKE="srun --partition=\$CHPL_LAUNCHER_PARTITION --export=ALL --cpus-per-task=128 make"
+
+# our EX platform is finicky, reload the base deps after fiddling with the modules
+source $UTIL_CRON_DIR/load-base-deps.bash


### PR DESCRIPTION
Attempts to fix issues we started having after an EX system upgrade where the order in which the modules are loaded could cause the built clang to segfault.


In our nightly testing, we have several configs run on an EX. All but one of the tests was broken after an upgrade. After inspecting the loaded modules on the working configs and broken configs, I found slight differences. This was due to the working configs loading the deps, fiddling with the modules, and then reloading the deps. The broken configs skipped that last step. I think that the reload of the deps is unintentional, the proper behavior IMO is to fiddle with the modules, then load the deps. But, its complicated to dedup that, its clearly wrong to load the deps and then fiddle with the modules, and its harmless to reload the modules. This led me to just reload the deps in all cases on EX.

[Reviewed by @DanilaFe]