### PR TITLE
Fix link to LICENSE file in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ License
 -------
 Chapel is developed and released under the terms of the Apache 2.0
 license, though it also makes use of third-party packages under their
-own licensing terms.  See the `LICENSE`_ file in this directory for
+own licensing terms.  See the `<LICENSE>`_ file in this directory for
 details.
 
 Resources


### PR DESCRIPTION
Currently, the "See the [LICENSE](https://github.com/chapel-lang/chapel#license) file" link in our README.rst actually just links to the `License` section of the README file itself. Fix that link to point to the separate `LICENSE` file.

Noticed by Brad in https://github.com/chapel-lang/chapel-www/issues/89#issuecomment-3969712521.

[trivial, not reviewed]

Testing:
- [x] RST render preview has correct link generated