### PR TITLE
Add a PREDIFF to remove most of the variance in Python memleaks tests

### DIFF
--- a/test/library/packages/Python/memleaks/PREDIFF
+++ b/test/library/packages/Python/memleaks/PREDIFF
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+TESTNAME=$1
+OUTFILE=$2
+
+# Only process the first two lines, which report leak stats.
+cat $OUTFILE | head -n 2 > $OUTFILE.tmphead
+cat $OUTFILE | tail -n +3 > $OUTFILE.tmptail
+
+# If the number is preceded by a '+', remove it.
+cat $OUTFILE.tmphead | sed 's/+[0-9]\{1,\}//g' > $OUTFILE.scratch
+mv $OUTFILE.scratch $OUTFILE.tmphead
+
+# Remove trailing whitespace as a result of above.
+cat $OUTFILE.tmphead | sed -e 's/[[:space:]]*$//g' > $OUTFILE.scratch
+mv $OUTFILE.scratch $OUTFILE.tmphead
+
+# Next, replace all but the first digit of every number with 'x'. Using
+# 'perl' here saved me a crazy headache trying to do this with 'sed'.
+# TODO: If the variance in leaks is such that the first digit changes, then
+#       just replace the whole line with 'x' (also easier to write...).
+cat $OUTFILE.tmphead | perl -pe 's/([0-9])([0-9]+)/$1 . "x" x length($2)/ge' > $OUTFILE.scratch
+mv $OUTFILE.scratch $OUTFILE.tmphead
+
+# Stitch the files back together.
+cat $OUTFILE.tmptail >> $OUTFILE.tmphead
+mv $OUTFILE.tmphead $OUTFILE
+
+# Make sure all the temp files that were used are cleaned up.
+rm -f $OUTFILE.tmphead $OUTFILE.tmptail $OUTFILE.scratch

--- a/test/library/packages/Python/memleaks/basicTypes.good
+++ b/test/library/packages/Python/memleaks/basicTypes.good
@@ -1,2 +1,2 @@
-list      646        +6
-dict     2123        +2
+list      6xx
+dict     2xxx

--- a/test/library/packages/Python/memleaks/iterate.good
+++ b/test/library/packages/Python/memleaks/iterate.good
@@ -1,5 +1,5 @@
-dict     2123        +2
-list      642        +2
+dict     2xxx
+list      6xx
 yielding Values from tuple
 1
 2

--- a/test/library/packages/Python/memleaks/lambdas.good
+++ b/test/library/packages/Python/memleaks/lambdas.good
@@ -1,5 +1,5 @@
-list      657       +17
-dict     2129        +8
+list      6xx
+dict     2xxx
 [1, 1]
 [hi, hi]
 [[1, 2, 3], [1, 2, 3]]

--- a/test/library/packages/Python/memleaks/maps.good
+++ b/test/library/packages/Python/memleaks/maps.good
@@ -1,5 +1,5 @@
-list      645        +5
-dict     2125        +4
+list      6xx
+dict     2xxx
 d size 3
 d size after deleting second 2
 d size after swap 3


### PR DESCRIPTION
This PR attempts to fix some nightly test failures caused by variance in the amount of memory reported by some memleak tests for the `Python` interpreter package module.

Reviewed by @DanilaFe. Thanks much!