### PR TITLE
Pin LLVM version to 21 for homebrew

### DIFF
--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -20,7 +20,7 @@ class Chapel < Formula
   depends_on "gmp"
   depends_on "hwloc"
   depends_on "jemalloc"
-  depends_on "llvm"
+  depends_on "llvm@21"
   depends_on "pkgconf"
   depends_on "python@3.14"
 


### PR DESCRIPTION
Pin the LLVM version for homebrew to 21, since homebrew updated `llvm` to `21`

[Not reviewed]