### PR TITLE
Add prediff for CHPL_GPU=amd and halt

### DIFF
--- a/test/release/examples/benchmarks/lulesh/lulesh.prediff
+++ b/test/release/examples/benchmarks/lulesh/lulesh.prediff
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if [[ "$CHPL_GPU" == "amd" ]]; then
+  # asserts in a GPU kernel may segfault on exit
+  grep -v 'Segmentation fault' $2 >$2.tmp
+  mv $2.tmp $2
+fi

--- a/test/release/examples/benchmarks/lulesh/test3DLulesh.prediff
+++ b/test/release/examples/benchmarks/lulesh/test3DLulesh.prediff
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if [[ "$CHPL_GPU" == "amd" ]]; then
+  # asserts in a GPU kernel may segfault on exit
+  grep -v 'Segmentation fault' $2 >$2.tmp
+  mv $2.tmp $2
+fi


### PR DESCRIPTION
Adds more prediff's for halts with CHPL_GPU=amd, which segfaults with ROCm 6.3+

See https://github.com/chapel-lang/chapel/pull/28220 and https://github.com/chapel-lang/chapel/issues/28415

[Not reviewed - trivial]