### PR TITLE
Switch quotes searched for in version update script

### DIFF
--- a/util/config/update-release-and-version-info
+++ b/util/config/update-release-and-version-info
@@ -95,20 +95,20 @@ class FileUpdater:
 class ConfPyUpdater(FileUpdater):
     def update(self):
         lines = self.read_file()
-        version_string = "chplversion = '{}'\n".format(self.short_maybe_long_version())
-        release_string = "release = '{} {}".format(
+        version_string = 'chplversion = "{}"\n'.format(self.short_maybe_long_version())
+        release_string = 'release = "{} {}'.format(
             self.long_version(), "" if self.release else "(pre-release)"
         ).strip()
         any_changed = False
         for i, line in enumerate(lines):
             if (
-                line.startswith("chplversion = '")
+                line.startswith('chplversion = "')
                 and not line.strip() == version_string
             ):
                 lines[i] = version_string
                 any_changed = True
-            elif line.startswith("release = '") and not line.strip() == release_string:
-                lines[i] = release_string + "'\n"
+            elif line.startswith('release = "') and not line.strip() == release_string:
+                lines[i] = release_string + '"\n'
                 any_changed = True
         if any_changed:
             self.write_file(lines)


### PR DESCRIPTION
Switch from expecting single quotes to expecting double quotes in version strings searched for by `util/config/update-release-and-version-info`.

This is a consequence of the formatting pass run in https://github.com/chapel-lang/chapel/pull/28437. This only affected Python files, and the only Python file the version script touches is `doc/rst/conf.py`, so that is the only one needing adjustment to its handling. I caught this when manually checking https://github.com/chapel-lang/chapel/pull/28494.

[trivial, not reviewed]

Testing:
- [x] after fix, version update script generates the expected results (https://github.com/chapel-lang/chapel/pull/28494)