### PR TITLE
Adjust MNIST tests to do less work under memleaks

### DIFF
--- a/test/studies/ml/correctness/mnist_classification.compopts
+++ b/test/studies/ml/correctness/mnist_classification.compopts
@@ -1,4 +1,13 @@
--snetworkNum=1 # mnist_classification.1.good
--snetworkNum=2 # mnist_classification.2.good
--snetworkNum=3 # mnist_classification.3.good
--snetworkNum=4 # mnist_classification.4.good
+#!/usr/bin/env python3
+
+import os
+
+for i in range(1, 5):
+    # The fourth model is a big'un, for memory leaks it can
+    # time out. Skip it. Fortunately, for the purposes of
+    # memory leaks, we've tested the model loading path
+    # in configs 1-3.
+    if os.getenv('CHPL_MEM_LEAK_TESTING') == 'true' and i == 4:
+        continue
+
+    print(f"-snetworkNum={i} # mnist_classification.{i}.good")

--- a/test/studies/ml/performance/mnist_cnn_big_everything.execopts
+++ b/test/studies/ml/performance/mnist_cnn_big_everything.execopts
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+import os
+# Training on a lot of data is too slow under memleaks; lower the load.
+if os.getenv('CHPL_MEM_LEAK_TESTING') == 'true':
+    print('--numTrainImages=1 --numTestImages=1')
+else:
+    print('')

--- a/test/studies/ml/performance/mnist_cnn_stride.execopts
+++ b/test/studies/ml/performance/mnist_cnn_stride.execopts
@@ -1,0 +1,1 @@
+mnist_cnn_big_everything.execopts

--- a/test/studies/ml/performance/mnist_cnn_with_dense.execopts
+++ b/test/studies/ml/performance/mnist_cnn_with_dense.execopts
@@ -1,0 +1,1 @@
+mnist_cnn_big_everything.execopts


### PR DESCRIPTION
The idea is to still test all the code paths (still training a model etc.), but to do much less work so that the configuration doesn't time out.

Do so by:
* Adjusting the performance test to train on one image and test on one image.
* Adjusting the correctness test to skip loading and running the biggest model. I took this approach because we already check whether memory is leaked from loading a model by loading the preceding 3 models; the rest is numerical accuracy, which is not the subject of memleaks testing and is tested by normal configurations.

Reviewed by @jabraham17 -- thanks!