### PR TITLE
Mason: avoid using POI unnecessarily

### DIFF
--- a/tools/mason/MasonModules.chpl
+++ b/tools/mason/MasonModules.chpl
@@ -28,6 +28,7 @@ use MasonHelp;
 use MasonEnv;
 use MasonBuild;
 use Subprocess;
+use MasonUpdate;
 use TOML;
 import Path.joinPath;
 


### PR DESCRIPTION
Today, the `masonModules` procedure only resolves because it's generic (due to its array formal). It calls a function `updateLock`, but does not bring it into its scope. The reason this works is that, when called from `main`, the POI scope contains `updateLock`. However, this needlessly obfuscates the code, possibly gets in the way of generic caching, and generally seems accidental. Add the missing use/import.

Reviewed by @jabraham17 -- thanks!