### PR TITLE
Fix a comparison between a signed and unsigned int

### DIFF
--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -1151,7 +1151,7 @@ handleRejectedCandidates(Resolver::CallResultWrapper& result,
       // this formal and place it in `actualDecls`, but it will be a decent
       // amount of work and lead to few error message benefits. - Daniel F.
     } else {
-      CHPL_ASSERT(0 <= actualIdx && (unsigned int) actualIdx < actualAsts.size());
+      CHPL_ASSERT(0 <= actualIdx && (size_t) actualIdx < actualAsts.size());
       actualExpr = actualAsts[actualIdx];
     }
 


### PR DESCRIPTION
Add cast to fix an int/uint comparison which failed to compile on a test machine with GCC 7.5.

Follow up to https://github.com/chapel-lang/chapel/pull/28482 which added the comparison.

[reviewer info placeholder]

Testing:
- [x] now compiles on test machine