### PR TITLE
Set version to 2.9 pre-release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,17 +36,17 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 # These values will be written to <build_dir>/frontend/include/chpl/config/config.h
 
 set(CHPL_MAJOR_VERSION 2)
-set(CHPL_MINOR_VERSION 8)
+set(CHPL_MINOR_VERSION 9)
 set(CHPL_PATCH_VERSION 0)
 set(CHPL_BUILD_VERSION 0)
 
 set(CHPL_PREV_MAJOR_VERSION 2)
-set(CHPL_PREV_MINOR_VERSION 7)
+set(CHPL_PREV_MINOR_VERSION 8)
 set(CHPL_PREV_PATCH_VERSION 0)
 
 # Flip this to 'true' when we're ready to roll out a release; then back
 # after branching
-set(CHPL_OFFICIAL_RELEASE true)
+set(CHPL_OFFICIAL_RELEASE false)
 
 ### END config.h version value setting - configured_prefix set below ###
 

--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -142,14 +142,14 @@ master_doc = "index"
 # 'version' adds a redundant version number onto the top of the sidebar
 # automatically (rtd-theme). We also don't use |version| anywhere in rst
 
-chplversion = "2.8"
+chplversion = "2.9"
 shortversion = chplversion.replace(
     "-", "&#8209"
 )  # prevent line-break at hyphen, if any
 html_context = {"chplversion": chplversion}
 
 # The full version, including alpha/beta/rc tags.
-release = "2.8.0"
+release = "2.9.0 (pre-release)"
 
 # General information about the project.
 project = "Chapel Documentation"

--- a/man/confchpl.rst
+++ b/man/confchpl.rst
@@ -1,5 +1,5 @@
 
-:Version: 2.8
+:Version: 2.9 pre-release
 :Manual section: 1
 :Title: \\fBchpl\\fP
 :Subtitle: Compiler for the Chapel Programming Language

--- a/man/confchpldoc.rst
+++ b/man/confchpldoc.rst
@@ -1,5 +1,5 @@
 
-:Version: 2.8
+:Version: 2.9 pre-release
 :Manual section: 1
 :Title: \\fBchpldoc\\fP
 :Subtitle: the Chapel Documentation Tool

--- a/test/chpldoc/compflags/combinations/versionhelp-chpldoc.sh
+++ b/test/chpldoc/compflags/combinations/versionhelp-chpldoc.sh
@@ -5,10 +5,10 @@ compiler=$3
 echo -n `basename $compiler`
 cat $CWD/../../../compflags/bradc/printstuff/version.goodstart
 # During pre-release mode
-# diff $CWD/../../../../compiler/main/BUILD_VERSION $CWD/zero.txt > /dev/null 2>&1 && echo "" || \
-#   { echo -n " pre-release (" && cat $CWD/../../../../compiler/main/BUILD_VERSION | tr -d \"\\n && echo ")" ; }
+diff $CWD/../../../../compiler/main/BUILD_VERSION $CWD/zero.txt > /dev/null 2>&1 && echo "" || \
+  { echo -n " pre-release (" && cat $CWD/../../../../compiler/main/BUILD_VERSION | tr -d \"\\n && echo ")" ; }
 # During release mode:
-echo ""
+# echo ""
 
 # print Sphinx and chapeldomain versions
 python=$($CWD/../../../../util/config/find-python.sh)

--- a/test/compflags/bradc/printstuff/version.goodstart
+++ b/test/compflags/bradc/printstuff/version.goodstart
@@ -1,1 +1,1 @@
- version 2.8.0
+ version 2.9.0

--- a/test/compflags/bradc/printstuff/versionhelp.sh
+++ b/test/compflags/bradc/printstuff/versionhelp.sh
@@ -5,10 +5,10 @@ compiler=$3
 echo -n `basename $compiler`
 cat $CWD/version.goodstart
 # During pre-release mode
-# diff $CWD/../../../../compiler/main/BUILD_VERSION $CWD/zero.txt > /dev/null 2>&1 && echo "" || \
-#   { echo -n " pre-release (" && cat $CWD/../../../../compiler/main/BUILD_VERSION | tr -d \"\\n && echo ")" ; }
+diff $CWD/../../../../compiler/main/BUILD_VERSION $CWD/zero.txt > /dev/null 2>&1 && echo "" || \
+  { echo -n " pre-release (" && cat $CWD/../../../../compiler/main/BUILD_VERSION | tr -d \"\\n && echo ")" ; }
 # During release mode:
-echo ""
+# echo ""
 
 if [ "$CHPL_LLVM" != "none" ]
 then


### PR DESCRIPTION
Update version to reflect the tree's 2.9 pre-release status.

Corresponding PR marking the tree as 2.8 release: https://github.com/chapel-lang/chapel/pull/28494
Corresponding PR from 2.8 pre-release: https://github.com/chapel-lang/chapel/pull/28177

To be merged after the 2.8 tarball is created and we're ready to unfreeze `main`, expected March 10.

[reviewer info placeholder]

Testing:
- [x] manual check against corresponding PR last release
- [x] `test/compflags/bradc`
- [x] `test/chpldoc/compflags`