### PR TITLE
Performance graph updates for release 2.8

### DIFF
--- a/util/pastPerformance/testReleasesPerformance
+++ b/util/pastPerformance/testReleasesPerformance
@@ -230,6 +230,10 @@ testReleasePerformance
 export CHPL_TEST_PERF_DATE="12/12/25"
 export CHPL_HOME=$chpl_release_home/chapel-2.7.0
 testReleasePerformance
+
+export CHPL_TEST_PERF_DATE="03/06/26"
+export CHPL_HOME=$chpl_release_home/chapel-2.8.0
+testReleasePerformance
 #
 # ADD NEW RELEASES HERE AS THEY ARE CREATED.
 #

--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -195,6 +195,10 @@ var branchInfo = [
                     "releaseDate": "2025-12-18",
                     "branchDate" : "2025-12-12",
                     "revision": -1},
+                  { "release": "2.8.0",
+                    "releaseDate": "2026-03-12",
+                    "branchDate" : "2026-03-06",
+                    "revision": -1},
                   ];
 
 var indexMap = {};


### PR DESCRIPTION
This adds performance graph data for the 2.8 release.

Corresponding previous update for 2.7: https://github.com/chapel-lang/chapel/pull/28225

To be merged on 2.8 release day, March 12.

[reviewer info placeholder]

Testing:
- [x] perf graphs viewed locally has line for release
- [x] used branch date (not release date) in `util/pastPerformance/testReleasesPerformance`