### PR TITLE
Update old URL in README.rst to avoid need for redirect

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ For more information about Chapel, please refer to the following resources:
 Project homepage:      https://chapel-lang.org
 Installing Chapel:     https://chapel-lang.org/download/
 Building from source:  https://chapel-lang.org/docs/usingchapel/QUICKSTART.html
-Sample computations:   https://chapel-lang.org/hellos.html
+Sample computations:   https://chapel-lang.org/docs/examples/
 Learning Chapel:       https://chapel-lang.org/learn/
 Reporting bugs:        https://chapel-lang.org/bugs.html
 Chapel documentation:  https://chapel-lang.org/docs/


### PR DESCRIPTION
Found this outdated URL while debugging Google search console messages while snapshotting release docs today.  It hasn't been broken due to our server-side redirects, but it seems preferable to avoid the need for the redirect.