### PR TITLE
Run 'sed' on the relocated Lua modulefile directory

### DIFF
--- a/util/build_configs/cray-internal/chapel.spec.template
+++ b/util/build_configs/cray-internal/chapel.spec.template
@@ -99,7 +99,10 @@ chmod 755 $RPM_INSTALL_PREFIX/%{set_def_subdir}/set_default_%{real_name}_%{pkg_v
 # Set prefix in TCL modulefile
 sed --in-place "s:\[BASE_INSTALL_DIR\]:$RPM_INSTALL_PREFIX:g" $RPM_INSTALL_PREFIX/modulefiles/%{real_name}/%{pkg_version}
 # Set prefix in Lua modulefile(s)
-find %{lmod_prefix} -name "*.lua" -type f -exec sed --in-place "s:\[BASE_INSTALL_DIR\]:$RPM_INSTALL_PREFIX:g" {} \;
+lmod_prefix_abs="%{lmod_prefix}"
+platform_prefix_abs="%{platform_prefix}"
+lmod_prefix_rel="${lmod_prefix_abs#${platform_prefix_abs}/}"
+find $RPM_INSTALL_PREFIX/$lmod_prefix_rel -name "*.lua" -type f -exec sed --in-place "s:\[BASE_INSTALL_DIR\]:$RPM_INSTALL_PREFIX:g" {} \;
 
 %postun
 if [ $1 == 1 ]


### PR DESCRIPTION
The previous `sed` script uses the absolute `lmod_prefix`, which is always something like `/opt/cray/pe/lmod/...`. This is fine during `.rpm` build, because we place it under `$RPM_BUILD_ROOT/$lmod_prefix`. However, we don't prepend anything to `$lmod_prefix` during postinstall, and thus, try to write to a global path with our `sed`.

So, change the `sed` to use `$RPM_INSTALL_DIR`. Due to the [way relocation works](http://ftp.rpm.org/max-rpm/s1-rpm-reloc-prefix-tag.html), the full `opt/cray/pe/lmod/...` path is not present in the install dir; the `platform_prefix` gets stripped. So, run `sed` logically on `$RPM_INSTALL_DIR + (lmod_prefix - platform_prefix)`. 

Reviewed by @arifthpe -- thanks!

## Testing
- [x] EX RPM builds with this and properly replaces the `[BASE_INSTALL_DIR` with the install dir.