### PR TITLE
Print number of 'make' threads in gen_release

### DIFF
--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -228,6 +228,7 @@ def main():
 
     with cd(archive_dir):
         set_make_threads()
+        log(f"Will invoke 'make' with {make_threads} threads")
 
         log("Creating the spec tests...")
         make("spectests")


### PR DESCRIPTION
Add a log message to `util/buildRelease/gen_release` stating how many threads will be used in its invocations of `make`.

Follow up to https://github.com/chapel-lang/chapel/pull/28395.

[trivial, not reviewed]