### PR TITLE
Remove duplicate memcpy in chpl_createStringWithLiteral

### DIFF
--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -444,7 +444,6 @@ module String {
     buf = buf + offset;
     import OS.POSIX.memcpy;
     memcpy(buf:c_ptr(void), x:c_ptr(void), length.safeCast(c_size_t));
-    memcpy(buf:c_ptr(void), x:c_ptr(void), length.safeCast(c_size_t));
     // add null byte
     buf[length] = 0;
 


### PR DESCRIPTION
Remove one of a pair of identical, consecutive `memcpy`s of the same string literal in `chpl_createStringWithLiteral`.

Caught by @e-kayrakli.

[reviewer info placeholder]