### PR TITLE
Fix small nit typo in CHANGES.md

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@ released March 12, 2026
 Highlights (see the sections that follow for details)
 -----------------------------------------------------
 * significant capability improvements when debugging Chapel programs
-* many improvements to `chpl-language-sever`, `chplcheck`, `chpldoc`, `chapel-py` tools
+* many improvements to CLS, `chplcheck`, `chpldoc`, `chapel-py` tools
 * significant robustness and feature improvements to Mason
 * improved loop-invariant code motion optimizations in support of vectorization
 * support for using LLVM 21 as the compiler's back-end


### PR DESCRIPTION
Fixes a small nit typo, "the CLS" vs "CLS".

The tool is called `chpl-language-server` (CLS for short), it does not need to be called "the". If it is referred to as "Chapel Language Server", then it makes sense to be called "The Chapel Language Server"

[Reviewed by @]