### PR TITLE
Avoid expensive step in `mason run --example`

### DIFF
--- a/tools/mason/MasonExample.chpl
+++ b/tools/mason/MasonExample.chpl
@@ -42,7 +42,8 @@ proc runExamples(show: bool, run: bool, build: bool, release: bool,
                  extraCompopts = new list(string),
                  extraExecopts = new list(string),
                  nLocales: int) throws {
-  updateLock(skipUpdate);
+  if build then
+    updateLock(skipUpdate);
 
   const cwd = here.cwd();
   const projectHome = getProjectHome(cwd);


### PR DESCRIPTION
Avoids an expensive check when doing `mason run --example`, that only needs to be done when building examples, not running them.

`mason run` should basically just invoke the compiled binary, but with `--example` I was finding it introduce unnecessary overhead.

This does not completely remove the unneeded work, since `getBuildInfo` does more work than it should. But its better than before.

[Reviewed by @e-kayrakli]