### PR TITLE
Print number of threads used for make in nightly script

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -544,6 +544,7 @@ if ($python2 == 0) {
 
 
 if ($build == 1) {
+  print "Using $num_procs processes for make\n";
   print "Making $make_vars_opt compiler\n";
   $makestat = mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_opt compiler", "making chapel compiler", $exitOnError);
 


### PR DESCRIPTION
Print number of threads to be used for `-j` argument to `make` invocations from `util/cron/nightly`.

Similar to https://github.com/chapel-lang/chapel/pull/28512.

[trivial, not reviewed]