### PR TITLE
Adjust `chapel.spec.template` to prevent RPM shebang mangling

### DIFF
--- a/util/build_configs/cray-internal/chapel.spec.template
+++ b/util/build_configs/cray-internal/chapel.spec.template
@@ -28,6 +28,9 @@ Requires:   make
 Requires:   perl
 Requires:   python
 
+# Disable shebang mangling, due to errors encountered with shebangs in included
+# third-party code.
+# Anna, 2026-03-10
 %define __brp_mangle_shebangs %{nil}
 
 %if %{!?buildroot:1}%{?buildroot:0}


### PR DESCRIPTION
Disable the RPM `brp-mangle-shebangs` policy, which was breaking an RHEL build of the EX RPM due to hitting ambiguously-versioned Python shebangs in `third-party/` code.

Used this directive to disable it per https://stackoverflow.com/questions/69915828/shebang-changed-to-usr-libexec-platform-python-when-building-python-rpm-package#comment133388549_73266752.

[trivial, not reviewed]

Testing:
- [x] RPM build succeeds