### PR TITLE
Add make-install-test script, reduce concurrency

### DIFF
--- a/util/cron/test-make-install-check.bash
+++ b/util/cron/test-make-install-check.bash
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# Test make install and make check, to a prefix and to CHPL_HOME.
+
+set -exo pipefail
+
+UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+source $UTIL_CRON_DIR/common.bash
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="make-install-check"
+
+# Limit build jobs to avoid OOM, as this does a build of bundled LLVM.
+export CHPL_MAKE_MAX_CPU_COUNT=2
+
+source $CHPL_HOME/util/setchplenv.sh
+$UTIL_CRON_DIR/../buildRelease/test_install.bash


### PR DESCRIPTION
Extract the test steps for `make-install-check` (currently defined right in our CI config) into a standalone test script, and within that script cap build jobs to 2.

https://github.com/chapel-lang/chapel/pull/28525 made `util/buildRelease/test_install.bash` (the core of this test) use a number of jobs equal to the number of cores, which exhausted memory on a test machine due to demands of the bundled LLVM build. This reduces the number of jobs from 4 (number of cores on the machine currently responsible for this test) to 2, which is hopefully safe. Since it would be strange to hardcode this somewhat arbitrary limit into `test_install.bash`, create a test script which does it for the CI to call into.

Follow up to https://github.com/chapel-lang/chapel/pull/28525.

[reviewer info placeholder]