### PR TITLE
Unset unwanted `CHPL_LAUNCHER` in multilocale test configs

### DIFF
--- a/util/cron/test-gasnet.c-backend.bash
+++ b/util/cron/test-gasnet.c-backend.bash
@@ -7,6 +7,7 @@ UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common-gasnet.bash
 source $UTIL_CRON_DIR/common-c-backend.bash
 source $UTIL_CRON_DIR/common-localnode-paratest.bash
+unset CHPL_LAUNCHER
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gasnet.c-backend"
 

--- a/util/cron/test-gasnet.quickstart.bash
+++ b/util/cron/test-gasnet.quickstart.bash
@@ -7,6 +7,7 @@ source $UTIL_CRON_DIR/common.bash
 source $UTIL_CRON_DIR/common-quickstart.bash
 source $UTIL_CRON_DIR/common-gasnet.bash # must come after quickstart source
 source $UTIL_CRON_DIR/common-localnode-paratest.bash
+unset CHPL_LAUNCHER
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gasnet.quickstart"
 

--- a/util/cron/test-ml-memleaks.bash
+++ b/util/cron/test-ml-memleaks.bash
@@ -6,6 +6,7 @@ UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common-gasnet.bash
 source $UTIL_CRON_DIR/common-memleaks.bash
 source $UTIL_CRON_DIR/common-localnode-paratest.bash
+unset CHPL_LAUNCHER
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="ml-memleaks"
 


### PR DESCRIPTION
Unset `CHPL_LAUNCHER` in multilocale test configs which began failing after `source`ing `common-localnode-paratest.bash`, which sets `CHPL_LAUNCHER=none`.

I referenced `test-gasnet.darwin.bash` doing so as a justification for this.

Follow up to https://github.com/chapel-lang/chapel/pull/28525.

[reviewer info placeholder]