### PR TITLE
Pin the c2chapel version back for fake headers

### DIFF
--- a/tools/c2chapel/Makefile
+++ b/tools/c2chapel/Makefile
@@ -35,7 +35,12 @@ link=$(bdir)/c2chapel
 
 # Note, this version is used only for the fake headers,
 # but it should probably match third-party/chpl-venv/c2chapel-requirements.txt
-VERSION=2.23
+# TODO: this should be 2.23 to match the requirements, but that actually breaks
+# the fake headers (which have new fake headers for dirent, socket, and
+# stdatomic.h)
+# leave this as 2.20 for now until we can update c2chapel to handle the new
+# fake headers
+VERSION=2.20
 TAR=release_v$(VERSION).tar.gz
 
 RELEASE=https://github.com/eliben/pycparser/archive/$(TAR)


### PR DESCRIPTION
Pins the c2chapel version back to what it was for the fake headers, since bumping it actually breaks header generation. The fake headers changed in a way that broke c2chapel

[Not reviewed]