### PR TITLE
Fix parsing of chplcheck rules for documention

### DIFF
--- a/doc/util/chplcheck-docs.py
+++ b/doc/util/chplcheck-docs.py
@@ -79,19 +79,17 @@ def find_rules(file: str):
             if isinstance(i, (ast.Attribute, ast.Call))
         ]
 
+        RULE_DECORATORS = ("basic_rule", "advanced_rule", "location_rule")
+
         # keep only the decorators that are rules
         decorators = [
             d
             for d in decorators
-            if (
-                isinstance(d, ast.Attribute)
-                and d.attr in ["basic_rule", "advanced_rule", "location_rule"]
-            )
+            if (isinstance(d, ast.Attribute) and d.attr in RULE_DECORATORS)
             or (
                 isinstance(d, ast.Call)
                 and isinstance(d.func, ast.Attribute)
-                and d.func.attr
-                in ["basic_rule", "advanced_rule", "location_rule"]
+                and d.func.attr in RULE_DECORATORS
             )
         ]
         # if there are no decorators, this is not a rule


### PR DESCRIPTION
Fixes the parsing of chplcheck rules to generate documentation. The rules were incorrectly being parsed and making all rules have the documentation "Is enabled by default? Yes", which is not true.

[Reviewed by @DanilaFe]