### PR TITLE
Fix chpldoc to allow `-o my/nested/dir`

### DIFF
--- a/tools/chpldoc/chpldoc.cpp
+++ b/tools/chpldoc/chpldoc.cpp
@@ -2413,13 +2413,13 @@ int main(int argc, char** argv) {
   }
 
   // Make the intermediate dir and output dir.
-  if (auto err = makeDir(docsSphinxDir)) {
+  if (auto err = makeDir(docsSphinxDir, true)) {
     std::cerr << "error: Failed to create directory: "
               << docsSphinxDir << " due to: "
               << err.message() << std::endl;
     return 1;
   }
-  if (auto err = makeDir(docsOutputDir)) {
+  if (auto err = makeDir(docsOutputDir, true)) {
     std::cerr << "error: Failed to create directory: "
               << docsOutputDir << " due to: "
               << err.message() << std::endl;


### PR DESCRIPTION
Fixes an issue where chpldoc would fail when passed a nested output directory that didn't exist, like `-o my/nested/dir`

[Reviewed by @arifthpe]