### PR TITLE
Test some runtime changes on the performance playground

### DIFF
--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -28,13 +28,16 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground"
 # 4) Update START_DATE to be today, using the format mm/dd/yy
 #
 
-# Test what happens to performance if we disable the
-# --interprocedural-alias-analysis pass by default
+# Test what happens to performance if all references to compiler-generated
+# symbols in the Chapel runtime are replaced with indirect references to
+# the same data that are accessed via struct field reads.
+#
+# E.g., 'CHPL_COMM' is replaced with 'program->data.CHPL_COMM'.
 
-GITHUB_USER=bradcray
-GITHUB_BRANCH=no-noAliasSets2
-SHORT_NAME=noAliasAnalysis
-START_DATE=2/19/26
+GITHUB_USER=dlongnecke-cray
+GITHUB_BRANCH=dynamic-loading-runtime-explore
+SHORT_NAME=runtimeIndirectlyReferencesProgramData
+START_DATE=3/16/26
 
 set -e
 checkout_branch $GITHUB_USER $GITHUB_BRANCH


### PR DESCRIPTION
This PR sets the performance playground to test a branch which would change all direct references to compiler-generated symbols to be struct field reads instead.

Reviewed by @benharsh. Thanks!