### PR TITLE
Move meetings bot an hour earlier

### DIFF
--- a/.github/workflows/meetings.yml
+++ b/.github/workflows/meetings.yml
@@ -3,7 +3,7 @@ name: Weekly Meeting Topics
 on:
   workflow_dispatch: # Allows manual triggering of the workflow
   schedule:
-    - cron: '0 17 * * 2' # Runs every week on Tuesday at 10 PT
+    - cron: '0 16 * * 2' # Runs every week on Tuesday at 10 PT
 
 jobs:
   create-discussion:


### PR DESCRIPTION
With daylight savings time now in effect, our meeting bot posts an hour later than my ideal.  Here, I'm moving it an hour earlier, and thinking it could stay in this mode year-round, since there's no real downside to having it up a bit early.
